### PR TITLE
Adding a .travis.yml file to trigger CI builds.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,10 @@
+language: c
+dist: trusty
+compiler: clang
+before_install:
+- sudo apt-get -qq update
+- sudo apt-get install -y pandoc uuid-dev libcmocka-dev doxygen
+- sudo apt-get install -y libevent-dev libboost-dev
+- sudo apt-get install -y librdmacm-dev libibverbs-dev
+script:
+- scons --build-deps=yes

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Distributed Asynchronous Object Store (DAOS)
 
+[![Build Status](https://travis-ci.org/daos-stack/daos.svg?branch=master)](https://travis-ci.org/daos-stack/daos)
+
 > :warning: **Warning:** DAOS is under heavy development. Use at your own risk.
 
 The Distributed Asynchronous Object Store (DAOS) provides a new storage paradigm for Exascale computing and Big Data. DAOS is an open-source storage stack designed from the ground up to exploit NVRAM and NVMe storage technologies with integrated fabric. It provides ultra-fine grained I/O by using a persistent memory storage model for byte-granular data & metadata combined with NVMe storage for bulk data, all this with end-to-end OS bypass to guarantee ultra-low latency. The DAOS stack aims at increasing data velocity by several orders of magnitude over conventional storage stacks and providing extreme scalability and resilience.


### PR DESCRIPTION
Added a `.travis.yml` file for automatic CI builds in Travis. Currently just kicking off `scons --build-deps=yes`, which fails due to a [CCI build issue](https://github.com/CCI/cci/issues/45). If you guys already have a way to build DAOS working around this issue, we can update the yml to reflect that.

You can see a sample build in my [fork's TravisCI](https://travis-ci.org/rajachan/daos/builds/177732469).
