### PR TITLE
    DAOS-1311 build: Install dep in Dockerfiles

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,5 @@ protobuf-all-3.5.1.tar.gz
 src/utils/py/*.pyc
 *.un~
 *.*~
+/pkg/
+Gopkg.lock

--- a/doc/quickstart.md
+++ b/doc/quickstart.md
@@ -82,6 +82,12 @@ The DAOS control plane infrastructure will be using protobuf as the data seriali
 
 The DAOS codebase uses [dep](https://github.com/golang/dep) to manage dependencies in the Go codebase.
 
+On EL7 and later:
+
+    yum install yum-plugin-copr
+    yum copr enable hnakamur/golang-dep
+    yum install golang-dep
+
 On Fedora 27 and later:
 
     dnf install dep
@@ -90,7 +96,13 @@ On Ubuntu 18.04 and later:
 
     apt-get install go-dep
 
-For OSes that don't supply a package: [Installation instructions on Github](https://github.com/golang/dep)
+For OSes that don't supply a package:
+* Ensure that you have a personal GOPATH (typically $HOME/go) and a GOBIN ($GOPATH/bin) set up and included in your PATH:
+
+    mkdir -p $HOME/go/bin
+    export PATH=$HOME/go/bin:$PATH
+
+* Then follow the [installation instructions on Github](https://github.com/golang/dep).
 
 The utils/fetch_go_packages.sh script is provided to populate and/or update the vendor directory using dep.
 

--- a/doc/quickstart.md
+++ b/doc/quickstart.md
@@ -74,19 +74,25 @@ Moreover, please make sure all the auto tools listed below are at the appropriat
 
 ### Protobuf Compiler
 
-The DAOS control plane infrastrucure will be using protobuf as the data serialization format for its RPC requests. The DAOS proto files use protobuf 3 syntax which is not supported by the platform protobuf compiler in all cases. Not all developers will need to build the proto files into the various source files. However if changes are made to the proto files they will need to be regenerated with a protobuf 3.* or higher compiler. To setup support for compiling protobuf files download the following precompiled package for Linux and install it somewhere accessible by your PATH variable.
+The DAOS control plane infrastructure will be using protobuf as the data serialization format for its RPC requests. The DAOS proto files use protobuf 3 syntax which is not supported by the platform protobuf compiler in all cases. Not all developers will need to build the proto files into the various source files. However if changes are made to the proto files they will need to be regenerated with a protobuf 3.* or higher compiler. To setup support for compiling protobuf files download the following precompiled package for Linux and install it somewhere accessible by your PATH variable.
 
     https://github.com/google/protobuf/releases/download/v3.5.1/protoc-3.5.1-linux-x86_64.zip
 
 ### Golang dependencies
 
-The utilities/fetch_go_packages.sh script is provided to prep a GOPATH location for DAOS development.
+The DAOS codebase uses [dep](https://github.com/golang/dep) to manage dependencies in the Go codebase.
 
-By default scons will look for a GOPATH located under _build.external/go. To setup your build GOPATh execute the command below from the top level directory.
+On Fedora 27 and later:
 
-    utils/fetch_go_packages.sh -i .
+    dnf install dep
 
-Once complete verify the install worked by running the same command with an additional -v flag for verification.
+On Ubuntu 18.04 and later:
+
+    apt-get install go-dep
+
+For OSes that don't supply a package: [Installation instructions on Github](https://github.com/golang/dep)
+
+The utils/fetch_go_packages.sh script is provided to populate and/or update the vendor directory using dep.
 
 ### Building DAOS & Dependencies
 

--- a/src/bio/bio_buffer.c
+++ b/src/bio/bio_buffer.c
@@ -704,7 +704,7 @@ dma_rw(struct bio_desc *biod, bool prep)
 		blob, biod->bd_update, rmw_read);
 }
 
-static void
+void
 bio_memcpy(struct bio_desc *biod, uint16_t media, void *media_addr,
 	   void *addr, ssize_t n)
 {

--- a/src/bio/bio_internal.h
+++ b/src/bio/bio_internal.h
@@ -146,5 +146,7 @@ void xs_poll_completion(struct bio_xs_context *ctxt, unsigned int *inflights);
 /* bio_buffer.c */
 void dma_buffer_destroy(struct bio_dma_buffer *buf);
 struct bio_dma_buffer *dma_buffer_create(unsigned int init_cnt);
+void bio_memcpy(struct bio_desc *biod, uint16_t media, void *media_addr,
+		void *addr, ssize_t n);
 
 #endif /* __BIO_INTERNAL_H__ */

--- a/src/common/proc.c
+++ b/src/common/proc.c
@@ -276,7 +276,7 @@ daos_proc_iod(crt_proc_t proc, daos_iod_t *dvi)
 	if (rc != 0)
 		return -DER_HG;
 
-	if (dvi->iod_nr == 0) {
+	if (dvi->iod_nr == 0 && dvi->iod_type != DAOS_IOD_ARRAY) {
 		D_ERROR("invalid I/O descriptor, iod_nr = 0\n");
 		return -DER_HG;
 	}

--- a/src/control/Gopkg.toml
+++ b/src/control/Gopkg.toml
@@ -1,0 +1,50 @@
+# This file defines the dependencies for the Go language control plane code.
+# In general we pin to a minor version or release branch, with the assumption
+# that backwards compatibility won't be broken in a patch release.
+
+# Running "dep ensure" will pull the latest versions that satisfy the
+# constraints outlined here, and put them into the vendor directory.
+
+[prune]
+  go-tests = true
+  unused-packages = true
+
+# ishell: MIT License used for the frontend shell interface for Go components.
+# This is our ishell fork - we control the accepted patches.
+[[constraint]]
+  name = "github.com/daos-stack/ishell"
+  branch = "master"
+
+# protobuf: 3 Clause BSD Licensed and provides go GRPC compiler support
+[[constraint]]
+  name = "github.com/golang/protobuf"
+  version = "~1.2.0"
+
+# go-flags: 3 Clause BSD used for command line parsing with ishell.
+[[constraint]]
+  name = "github.com/jessevdk/go-flags"
+  version = "~1.4.0"
+
+# go.uuid: MIT Licensed and used for UUID generation in Go components
+[[constraint]]
+  name = "github.com/satori/go.uuid"
+# API-breaking changes have gone in since v1.2.0.
+# Uncomment with appropriate version number and remove
+# revision hash when the maintainer tags a new version.
+#  version = "~2.0.0"
+  revision = "36e9d2ebbde5e3f13ab2e25625fd453271d6522e"
+
+# net: 3 Clause BSD Licensed
+[[constraint]]
+  branch = "release-branch.go1.10"
+  name = "golang.org/x/net"
+
+# sys: 3 Clause BSD Licensed
+[[constraint]]
+  branch = "release-branch.go1.11"
+  name = "golang.org/x/sys"
+
+# grpc: Apache 2.0 used as communication channel between Go components.
+[[constraint]]
+  name = "google.golang.org/grpc"
+  version = "~1.15.0"

--- a/src/control/README.md
+++ b/src/control/README.md
@@ -144,10 +144,11 @@ TODO: include details of `daos_agent` interaction
 * [Golang](https://golang.org/) 1.9 or higher
 * [gRPC](https://grpc.io/)
 * [Protocol Buffers](https://developers.google.com/protocol-buffers/)
+* [Dep](https://github.com/golang/dep/) for managing dependencies in vendor directory.
 
 ## Development setup
 
-* Install Go dependencies: `utils/fetch_go_packages.sh -i .` from daos checkout root directory.
+* Update vendor directory if needed: `utils/fetch_go_packages.sh -i .` from daos checkout root directory.
 * (Optional) protoc protocol buffer compiler
 
 ### Building the app

--- a/src/control/README.md
+++ b/src/control/README.md
@@ -10,7 +10,15 @@ The [shell](shell/DAOSShell) is an example client application which can connect 
 
 ## Usage
 
-In order to run the shell to perform administrative tasks, build and run the `daos_server` as per the [quickstart guide](https://github.com/daos-stack/daos/blob/master/doc/quickstart.md). Then the shell can be used to connect to and interact with the gRPC server (running on port 10000 by default) as follows:
+In order to run the shell to perform administrative tasks, build and run the `daos_server` as per the [quickstart guide](https://github.com/daos-stack/daos/blob/master/doc/quickstart.md).
+
+`daos_server` is to be run as root in order to perform administrative tasks, to be run through `orterun` as root, the following command can be used (assuming the quickstart_guide instructions have already been performed):
+
+```
+root$ orterun -np 1 -c 1 --hostfile hostfile --enable-recovery --allow-run-as-root --report-uri /tmp/urifile daos_server -c 1
+```
+
+DAOSShell (the client application) is to be run as a standard, unprivileged user.  The shell can be used to connect to and interact with the gRPC server (running on port 10000 by default) as follows:
 
 ```
 $ projects/daos_m/install/bin/DAOSShell
@@ -41,6 +49,7 @@ Category: nvme
 ```
 
 To use a supported management feature, run the relevant top-level command e.g. `nvme` and follow the interactive prompts:
+NOTE: SPDK is used to manage NVMe devices and will unbind them from currently bound drivers while performing management tasks (but won't unbind PCI devices that have active mountpoint), they will be rebound to original drivers when management tasks are complete.
 
 ```
 >>> nvme

--- a/src/control/SConscript
+++ b/src/control/SConscript
@@ -50,7 +50,7 @@ def scons():
         "CGO_CFLAGS",
         denv.subst("-I$SPDK_PREFIX/include"))
 
-    # initialise management server db
+    # install management server db
     modulemgmt = "%s/modules/mgmt" % gosrc
     mgmtinitdb = "mgmtinit_db.json"
     denv.InstallAs(

--- a/src/control/common/agent/client.go
+++ b/src/control/common/agent/client.go
@@ -145,7 +145,5 @@ func (ac *DAOSAgentClient) VerifySecurityHandle(handle string) (*secpb.AuthToken
 // NewDAOSAgentClient returns an initialized instance of the DAOSAgentClient
 // object
 func NewDAOSAgentClient() *DAOSAgentClient {
-	ac := &DAOSAgentClient{}
-	ac.logger = log.NewLogger()
-	return ac
+	return &DAOSAgentClient{logger: log.NewLogger()}
 }

--- a/src/control/modules/mgmt/features.go
+++ b/src/control/modules/mgmt/features.go
@@ -1,0 +1,68 @@
+//
+// (C) Copyright 2018 Intel Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// GOVERNMENT LICENSE RIGHTS-OPEN SOURCE SOFTWARE
+// The Government's rights to use, modify, reproduce, release, perform, display,
+// or disclose this software are subject to the terms of the Apache License as
+// provided in Contract No. 8F-30005.
+// Any reproduction of computer software, computer software documentation, or
+// portions thereof marked with this legend must also reproduce the markings.
+//
+
+package mgmt
+
+import (
+	"fmt"
+
+	"github.com/golang/protobuf/proto"
+	"golang.org/x/net/context"
+
+	pb "modules/mgmt/proto"
+)
+
+// GetFeature returns the feature from feature name.
+func (s *ControlService) GetFeature(
+	ctx context.Context, name *pb.FeatureName) (*pb.Feature, error) {
+	for _, feature := range s.supportedFeatures {
+		if proto.Equal(feature.GetFname(), name) {
+			return feature, nil
+		}
+	}
+	return nil, fmt.Errorf("no feature with name %s", name.Name)
+}
+
+// ListAllFeatures lists all features supported by the management server.
+func (s *ControlService) ListAllFeatures(
+	empty *pb.ListAllFeaturesParams, stream pb.MgmtControl_ListAllFeaturesServer) error {
+	for _, feature := range s.supportedFeatures {
+		if err := stream.Send(feature); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// ListFeatures lists all features supported by the management server.
+func (s *ControlService) ListFeatures(
+	category *pb.Category, stream pb.MgmtControl_ListFeaturesServer) error {
+	for _, feature := range s.supportedFeatures {
+		if proto.Equal(feature.GetCategory(), category) {
+			if err := stream.Send(feature); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}

--- a/src/control/modules/mgmt/features.go
+++ b/src/control/modules/mgmt/features.go
@@ -32,21 +32,23 @@ import (
 	pb "modules/mgmt/proto"
 )
 
+// FeatureMap is a type alias
+type FeatureMap map[string]*pb.Feature
+
 // GetFeature returns the feature from feature name.
 func (s *ControlService) GetFeature(
 	ctx context.Context, name *pb.FeatureName) (*pb.Feature, error) {
-	for _, feature := range s.supportedFeatures {
-		if proto.Equal(feature.GetFname(), name) {
-			return feature, nil
-		}
+	f, exists := s.SupportedFeatures[name.Name]
+	if !exists {
+		return nil, fmt.Errorf("no feature with name %s", name.Name)
 	}
-	return nil, fmt.Errorf("no feature with name %s", name.Name)
+	return f, nil
 }
 
 // ListAllFeatures lists all features supported by the management server.
 func (s *ControlService) ListAllFeatures(
 	empty *pb.ListAllFeaturesParams, stream pb.MgmtControl_ListAllFeaturesServer) error {
-	for _, feature := range s.supportedFeatures {
+	for _, feature := range s.SupportedFeatures {
 		if err := stream.Send(feature); err != nil {
 			return err
 		}
@@ -57,7 +59,7 @@ func (s *ControlService) ListAllFeatures(
 // ListFeatures lists all features supported by the management server.
 func (s *ControlService) ListFeatures(
 	category *pb.Category, stream pb.MgmtControl_ListFeaturesServer) error {
-	for _, feature := range s.supportedFeatures {
+	for _, feature := range s.SupportedFeatures {
 		if proto.Equal(feature.GetCategory(), category) {
 			if err := stream.Send(feature); err != nil {
 				return err

--- a/src/control/modules/mgmt/nvme.go
+++ b/src/control/modules/mgmt/nvme.go
@@ -1,0 +1,223 @@
+//
+// (C) Copyright 2018 Intel Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// GOVERNMENT LICENSE RIGHTS-OPEN SOURCE SOFTWARE
+// The Government's rights to use, modify, reproduce, release, perform, display,
+// or disclose this software are subject to the terms of the Apache License as
+// provided in Contract No. 8F-30005.
+// Any reproduction of computer software, computer software documentation, or
+// portions thereof marked with this legend must also reproduce the markings.
+//
+
+package mgmt
+
+import (
+	"fmt"
+	"os/exec"
+
+	"go-spdk/nvme"
+	"go-spdk/spdk"
+
+	"golang.org/x/net/context"
+
+	pb "modules/mgmt/proto"
+)
+
+var spdkSetupPath = "share/spdk/scripts/setup.sh"
+
+// Init method implementation for NvmeStorage.
+//
+// Setup available NVMe devices to be used by SPDK
+// and initialise SPDK environment before probing controllers.
+func (sn *NvmeStorage) Init() error {
+	absSetupPath, err := getAbsInstallPath(spdkSetupPath)
+	if err != nil {
+		return err
+	}
+	// run setup to allocate hugepages and bind PCI devices
+	// (that don't have active mountpoints) to generic kernel driver
+	//
+	// todo: we need to be sure that we want to do this, it
+	//       will make the controller invisible to other
+	//       consumers.
+	if err := exec.Command(absSetupPath).Run(); err != nil {
+		return err
+	}
+	if err := spdk.InitSPDKEnv(); err != nil {
+		return err
+	}
+	return nil
+}
+
+// Discover method implementation for NvmeStorage
+func (sn *NvmeStorage) Discover() interface{} {
+	cs, ns, err := nvme.Discover()
+	return NVMeReturn{cs, ns, err}
+}
+
+// Update method implementation for NvmeStorage
+func (sn *NvmeStorage) Update(params interface{}) interface{} {
+	switch t := params.(type) {
+	case UpdateParams:
+		cs, ns, err := nvme.Update(t.CtrlrID, t.Path, t.Slot)
+		return NVMeReturn{cs, ns, err}
+	default:
+		return fmt.Errorf("unexpected return type")
+	}
+}
+
+// Teardown method implementation for NvmeStorage.
+//
+// Cleanup references to NVMe devices held by go-spdk
+// bindings, rebind PCI devices back to their original drivers
+// and cleanup any leftover spdk files/resources.
+func (sn *NvmeStorage) Teardown() error {
+	nvme.Cleanup()
+
+	absSetupPath, err := getAbsInstallPath(spdkSetupPath)
+	if err != nil {
+		return err
+	}
+	if err := exec.Command(absSetupPath, "reset").Run(); err != nil {
+		return err
+	}
+	return nil
+}
+
+// loadControllers converts slice of Controller into protobuf equivalent.
+// Implemented as a pure function.
+func loadControllers(ctrlrs []nvme.Controller) []*pb.NVMeController {
+	var pbCtrlrs []*pb.NVMeController
+	for _, c := range ctrlrs {
+		pbCtrlrs = append(
+			pbCtrlrs,
+			&pb.NVMeController{
+				Id:      c.ID,
+				Model:   c.Model,
+				Serial:  c.Serial,
+				Pciaddr: c.PCIAddr,
+				Fwrev:   c.FWRev,
+			})
+	}
+	return pbCtrlrs
+}
+
+// loadNamespaces converts slice of Namespace into protobuf equivalent.
+// Implemented as a pure function.
+func loadNamespaces(
+	pbCtrlrs []*pb.NVMeController, nss []nvme.Namespace) []*pb.NVMeNamespace {
+	var pbNamespaces []*pb.NVMeNamespace
+	for _, ns := range nss {
+		for _, c := range pbCtrlrs {
+			if c.Id == ns.CtrlrID {
+				pbNamespaces = append(
+					pbNamespaces,
+					&pb.NVMeNamespace{
+						Controller: c,
+						Id:         ns.ID,
+						Capacity:   ns.Size,
+					})
+			}
+		}
+	}
+	return pbNamespaces
+}
+
+// populateNVMe unpacks return type and loads protobuf representations.
+func (s *ControlService) populateNVMe(ret interface{}) error {
+	switch ret := ret.(type) {
+	case NVMeReturn:
+		if ret.Err != nil {
+			return ret.Err
+		}
+		s.NvmeControllers = loadControllers(ret.Ctrlrs)
+		s.NvmeNamespaces = loadNamespaces(s.NvmeControllers, ret.Nss)
+		s.storageInitialised = true
+	default:
+		return fmt.Errorf("unexpected return type")
+	}
+
+	return nil
+}
+
+// FetchNVMe populates controllers and namespaces in ControlService
+// as side effect.
+//
+// todo: presumably we want to be able to detect namespaces added
+//       during the lifetime of the daos_server process, in that case
+//       will need to rerun discover here (currently SPDK throws
+//		 exception if you try to probe a second time).
+func (s *ControlService) FetchNVMe() error {
+	if s.storageInitialised != true {
+		if err := s.Storage.Init(); err != nil {
+			return err
+		}
+		ret := s.Storage.Discover()
+		if err := s.populateNVMe(ret); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// ListNVMeCtrlrs lists all NVMe controllers.
+func (s *ControlService) ListNVMeCtrlrs(
+	empty *pb.ListNVMeCtrlrsParams, stream pb.MgmtControl_ListNVMeCtrlrsServer) error {
+	if err := s.FetchNVMe(); err != nil {
+		return err
+	}
+	for _, c := range s.NvmeControllers {
+		if err := stream.Send(c); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// ListNVMeNss lists all namespaces discovered on attached NVMe controllers.
+func (s *ControlService) ListNVMeNss(
+	ctrlr *pb.NVMeController, stream pb.MgmtControl_ListNVMeNssServer) error {
+	if err := s.FetchNVMe(); err != nil {
+		return err
+	}
+	for _, ns := range s.NvmeNamespaces {
+		if ns.Controller.Id == ctrlr.Id {
+			if err := stream.Send(ns); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+// UpdateNVMeCtrlr updates the firmware on a NVMe controller, verifying that the
+// fwrev reported changes after update.
+func (s *ControlService) UpdateNVMeCtrlr(
+	ctx context.Context, params *pb.UpdateNVMeCtrlrParams) (*pb.NVMeController, error) {
+	id := params.Ctrlr.Id
+	ret := s.Storage.Update(UpdateParams{id, params.Path, params.Slot})
+	if err := s.populateNVMe(ret); err != nil {
+		return nil, err
+	}
+	for _, c := range s.NvmeControllers {
+		if c.Id == id {
+			if c.Fwrev == params.Ctrlr.Fwrev {
+				return nil, fmt.Errorf("update failed, firmware revision unchanged")
+			}
+			return c, nil
+		}
+	}
+	return nil, fmt.Errorf("update failed, no matching controller found")
+}

--- a/src/control/modules/mgmt/nvme_test.go
+++ b/src/control/modules/mgmt/nvme_test.go
@@ -1,3 +1,26 @@
+//
+// (C) Copyright 2018 Intel Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// GOVERNMENT LICENSE RIGHTS-OPEN SOURCE SOFTWARE
+// The Government's rights to use, modify, reproduce, release, perform, display,
+// or disclose this software are subject to the terms of the Apache License as
+// provided in Contract No. 8F-30005.
+// Any reproduction of computer software, computer software documentation, or
+// portions thereof marked with this legend must also reproduce the markings.
+//
+
 package mgmt_test
 
 import (
@@ -62,6 +85,7 @@ func (mock *mockStorage) Update(interface{}) interface{} {
 	c := mockController(mock.fwRevAfter)
 	return NVMeReturn{[]Controller{c}, []Namespace{mockNamespace(&c)}, nil}
 }
+func (mock *mockStorage) Teardown() error { return nil }
 
 func NewTestControlServer(storageImpl Storage) *ControlService {
 	return &ControlService{Storage: storageImpl}
@@ -92,8 +116,8 @@ func TestFetchNVMe(t *testing.T) {
 	cExpect := mockControllerPB("1.0.0")
 	nsExpect := mockNamespacePB("1.0.0")
 
-	assertEqual(t, s.NvmeControllers[0], cExpect, "")
-	assertEqual(t, s.NvmeNamespaces[0], nsExpect, "")
+	assertEqual(t, s.NvmeControllers[cExpect.Id], cExpect, "")
+	assertEqual(t, s.NvmeNamespaces[nsExpect.Id], nsExpect, "")
 }
 
 func TestUpdateNVMe(t *testing.T) {
@@ -103,7 +127,8 @@ func TestUpdateNVMe(t *testing.T) {
 		t.Fatal(err.Error())
 	}
 
-	c := s.NvmeControllers[0]
+	cExpect := mockControllerPB("1.0.1")
+	c := s.NvmeControllers[cExpect.Id]
 
 	// after fetching controller details, simulate updated firmware
 	// version being reported
@@ -115,8 +140,28 @@ func TestUpdateNVMe(t *testing.T) {
 		t.Fatal(err.Error())
 	}
 
-	cExpect := mockControllerPB("1.0.1")
-
-	assertEqual(t, s.NvmeControllers[0], cExpect, "")
+	assertEqual(t, s.NvmeControllers[cExpect.Id], cExpect, "")
 	assertEqual(t, newC, cExpect, "")
+}
+
+func TestUpdateNVMeFail(t *testing.T) {
+	s := NewTestControlServer(&mockStorage{"1.0.0", "1.0.0"})
+
+	if err := s.FetchNVMe(); err != nil {
+		t.Fatal(err.Error())
+	}
+
+	cExpect := mockControllerPB("1.0.0")
+	c := s.NvmeControllers[cExpect.Id]
+
+	// after fetching controller details, simulate the same firmware
+	// version being reported
+	params := &pb.UpdateNVMeCtrlrParams{
+		Ctrlr: c, Path: "/foo/bar", Slot: 0}
+
+	_, err := s.UpdateNVMeCtrlr(nil, params)
+	// expect error
+	if err == nil {
+		t.Fatal(err.Error())
+	}
 }

--- a/src/control/modules/mgmt/server.go
+++ b/src/control/modules/mgmt/server.go
@@ -51,21 +51,25 @@ type ControlService struct {
 	Storage
 	logger             *log.Logger
 	storageInitialised bool
-	supportedFeatures  []*pb.Feature
-	NvmeNamespaces     []*pb.NVMeNamespace
-	NvmeControllers    []*pb.NVMeController
+	SupportedFeatures  FeatureMap
+	NvmeNamespaces     NsMap
+	NvmeControllers    CtrlrMap
 }
 
 // loadInitData retrieves initial data from file.
 func (s *ControlService) loadInitData(filePath string) error {
+	s.SupportedFeatures = make(FeatureMap)
 	file, err := ioutil.ReadFile(filePath)
 	if err != nil {
 		return err
 	}
-	if err := json.Unmarshal(file, &s.supportedFeatures); err != nil {
+	var features []*pb.Feature
+	if err := json.Unmarshal(file, &features); err != nil {
 		return err
 	}
-
+	for _, f := range features {
+		s.SupportedFeatures[f.Fname.Name] = f
+	}
 	return nil
 }
 

--- a/src/control/modules/mgmt/server.go
+++ b/src/control/modules/mgmt/server.go
@@ -25,266 +25,35 @@ package mgmt
 
 import (
 	"encoding/json"
-	"fmt"
 	"io/ioutil"
 	"os"
 	"path/filepath"
 
 	"common/log"
-	"go-spdk/nvme"
-	"go-spdk/spdk"
-
-	"github.com/golang/protobuf/proto"
-	"golang.org/x/net/context"
 
 	pb "modules/mgmt/proto"
 )
 
-var (
-	jsonDBRelPath = "share/control/mgmtinit_db.json"
-)
+var jsonDBRelPath = "share/control/mgmtinit_db.json"
 
-// Storage interface represents a persistent storage that can
-// support relevant operations via a library
-type Storage interface {
-	Init() error
-	Discover() interface{}
-	Update(interface{}) interface{}
-}
-
-// NvmeStorage is an implementation of the Storage interface
-type NvmeStorage struct{}
-
-// Init method implementation for NvmeStorage
-func (sn *NvmeStorage) Init() error {
-	if err := spdk.InitSPDKEnv(); err != nil {
-		return err
+// getAbsInstallPath retrieves absolute path of files in daos install dir
+func getAbsInstallPath(relPath string) (string, error) {
+	ex, err := os.Executable()
+	if err != nil {
+		return "", err
 	}
 
-	return nil
-}
-
-// NVMeReturn struct contains return values for NvmeStorage
-// Discover method
-type NVMeReturn struct {
-	Ctrlrs []nvme.Controller
-	Nss    []nvme.Namespace
-	Err    error
-}
-
-// Discover method implementation for NvmeStorage
-func (sn *NvmeStorage) Discover() interface{} {
-	cs, ns, err := nvme.Discover()
-	return NVMeReturn{cs, ns, err}
-}
-
-// UpdateParams struct contains input parameters for NvmeStorage
-// Update implementation
-type UpdateParams struct {
-	CtrlrID int32
-	Path    string
-	Slot    int32
-}
-
-// Update method implementation for NvmeStorage
-func (sn *NvmeStorage) Update(params interface{}) interface{} {
-	switch t := params.(type) {
-	default:
-		return fmt.Errorf("unexpected return type")
-	case UpdateParams:
-		cs, ns, err := nvme.Update(t.CtrlrID, t.Path, t.Slot)
-		return NVMeReturn{cs, ns, err}
-	}
+	return filepath.Join(filepath.Dir(ex), "..", relPath), nil
 }
 
 // ControlService type is the data container for the service.
 type ControlService struct {
-	logger *log.Logger
 	Storage
+	logger             *log.Logger
 	storageInitialised bool
 	supportedFeatures  []*pb.Feature
 	NvmeNamespaces     []*pb.NVMeNamespace
 	NvmeControllers    []*pb.NVMeController
-}
-
-// GetFeature returns the feature from feature name.
-func (s *ControlService) GetFeature(
-	ctx context.Context, name *pb.FeatureName) (*pb.Feature, error) {
-
-	for _, feature := range s.supportedFeatures {
-		if proto.Equal(feature.GetFname(), name) {
-			return feature, nil
-		}
-	}
-	// No feature was found, return an unnamed feature.
-	return &pb.Feature{Fname: &pb.FeatureName{Name: "none"}, Description: "none"}, nil
-}
-
-// ListAllFeatures lists all features supported by the management server.
-func (s *ControlService) ListAllFeatures(
-	empty *pb.ListAllFeaturesParams, stream pb.MgmtControl_ListAllFeaturesServer) error {
-
-	for _, feature := range s.supportedFeatures {
-		if err := stream.Send(feature); err != nil {
-			return err
-		}
-	}
-	return nil
-}
-
-// ListFeatures lists all features supported by the management server.
-func (s *ControlService) ListFeatures(
-	category *pb.Category, stream pb.MgmtControl_ListFeaturesServer) error {
-
-	for _, feature := range s.supportedFeatures {
-		if proto.Equal(feature.GetCategory(), category) {
-			if err := stream.Send(feature); err != nil {
-				return err
-			}
-		}
-	}
-	return nil
-}
-
-// loadControllers converts slice of Controller into protobuf equivalent.
-// Implemented as a pure function.
-func loadControllers(ctrlrs []nvme.Controller) []*pb.NVMeController {
-	var pbCtrlrs []*pb.NVMeController
-	for _, c := range ctrlrs {
-		pbCtrlrs = append(
-			pbCtrlrs,
-			&pb.NVMeController{
-				Id:      c.ID,
-				Model:   c.Model,
-				Serial:  c.Serial,
-				Pciaddr: c.PCIAddr,
-				Fwrev:   c.FWRev,
-			})
-	}
-
-	return pbCtrlrs
-}
-
-// loadNamespaces converts slice of Namespace into protobuf equivalent.
-// Implemented as a pure function.
-func loadNamespaces(
-	pbCtrlrs []*pb.NVMeController, nss []nvme.Namespace) []*pb.NVMeNamespace {
-
-	var pbNamespaces []*pb.NVMeNamespace
-	for _, ns := range nss {
-		for _, c := range pbCtrlrs {
-			if c.Id == ns.CtrlrID {
-				pbNamespaces = append(
-					pbNamespaces,
-					&pb.NVMeNamespace{
-						Controller: c,
-						Id:         ns.ID,
-						Capacity:   ns.Size,
-					})
-			}
-		}
-	}
-
-	return pbNamespaces
-}
-
-// populateNVMe unpacks return type and loads protobuf representations.
-func (s *ControlService) populateNVMe(ret interface{}) error {
-	switch ret := ret.(type) {
-	default:
-		return fmt.Errorf("unexpected return type")
-	case NVMeReturn:
-		if ret.Err != nil {
-			return ret.Err
-		}
-
-		s.NvmeControllers = loadControllers(ret.Ctrlrs)
-		s.NvmeNamespaces = loadNamespaces(s.NvmeControllers, ret.Nss)
-		s.storageInitialised = true
-	}
-
-	return nil
-}
-
-// FetchNVMe populates controllers and namespaces in ControlService
-// as side effect.
-//
-// todo: presumably we want to be able to detect namespaces added
-//       during the lifetime of the daos_server process, in that case
-//       will need to rerun discover here (currently SPDK throws).
-func (s *ControlService) FetchNVMe() error {
-	if s.storageInitialised != true {
-		if err := s.Storage.Init(); err != nil {
-			return err
-		}
-
-		ret := s.Storage.Discover()
-
-		if err := s.populateNVMe(ret); err != nil {
-			return err
-		}
-	}
-
-	return nil
-}
-
-// ListNVMeCtrlrs lists all NVMe controllers.
-func (s *ControlService) ListNVMeCtrlrs(
-	empty *pb.ListNVMeCtrlrsParams, stream pb.MgmtControl_ListNVMeCtrlrsServer) error {
-
-	if err := s.FetchNVMe(); err != nil {
-		return err
-	}
-	for _, c := range s.NvmeControllers {
-		if err := stream.Send(c); err != nil {
-			return err
-		}
-	}
-	return nil
-}
-
-// ListNVMeNss lists all namespaces discovered on attached NVMe controllers.
-func (s *ControlService) ListNVMeNss(
-	ctrlr *pb.NVMeController, stream pb.MgmtControl_ListNVMeNssServer) error {
-
-	if err := s.FetchNVMe(); err != nil {
-		return err
-	}
-	for _, ns := range s.NvmeNamespaces {
-		if ns.Controller.Id == ctrlr.Id {
-			if err := stream.Send(ns); err != nil {
-				return err
-			}
-		}
-	}
-
-	return nil
-}
-
-// UpdateNVMeCtrlr updates the firmware on a NVMe controller, verifying that the
-// fwrev reported changes after update.
-func (s *ControlService) UpdateNVMeCtrlr(
-	ctx context.Context, params *pb.UpdateNVMeCtrlrParams) (*pb.NVMeController, error) {
-
-	id := params.Ctrlr.Id
-
-	ret := s.Storage.Update(UpdateParams{id, params.Path, params.Slot})
-
-	if err := s.populateNVMe(ret); err != nil {
-		return nil, err
-	}
-
-	for _, c := range s.NvmeControllers {
-		if c.Id == id {
-			if c.Fwrev == params.Ctrlr.Fwrev {
-				return nil, fmt.Errorf("update failed, firmware revision unchanged")
-			}
-
-			return c, nil
-		}
-	}
-
-	return nil, fmt.Errorf("update failed, no matching controller found")
 }
 
 // loadInitData retrieves initial data from file.
@@ -302,25 +71,21 @@ func (s *ControlService) loadInitData(filePath string) error {
 
 // NewControlServer creates a new instance of our ControlServer struct.
 func NewControlServer() *ControlService {
-	s := &ControlService{Storage: &NvmeStorage{}, storageInitialised: false}
+	s := &ControlService{
+		Storage:            &NvmeStorage{},
+		storageInitialised: false,
+		logger:             log.NewLogger(),
+	}
 
 	// Retrieve absolute path of init DB file and load data
-	ex, err := os.Executable()
+	dbAbsPath, err := getAbsInstallPath(jsonDBRelPath)
 	if err != nil {
 		panic(err)
 	}
-	dbAbsPath := filepath.Join(filepath.Dir(ex), "..", jsonDBRelPath)
+
 	if err := s.loadInitData(dbAbsPath); err != nil {
 		panic(err)
 	}
-
-	// Discover NVMe controllers, assumes they will not be added
-	// during the lifetime of daos_server process
-	//if err := s.getControllers(); err != nil {
-	//	panic(err)
-	//}
-
-	s.logger = log.NewLogger()
 
 	return s
 }

--- a/src/control/modules/mgmt/server_test.go
+++ b/src/control/modules/mgmt/server_test.go
@@ -11,7 +11,6 @@ import (
 	pb "modules/mgmt/proto"
 )
 
-
 func mockController(fwrev string) Controller {
 	return Controller{
 		ID:      int32(12345),
@@ -43,15 +42,15 @@ func mockNamespacePB(fwRev string) *pb.NVMeNamespace {
 	ns := mockNamespace(&c)
 	return &pb.NVMeNamespace{
 		Controller: mockControllerPB(fwRev),
-		Id: ns.ID,
-		Capacity: ns.Size,
+		Id:         ns.ID,
+		Capacity:   ns.Size,
 	}
 }
 
 // MockStorage struct implements Storage interface
 type mockStorage struct {
 	fwRevBefore string
-	fwRevAfter string
+	fwRevAfter  string
 }
 
 func (mock *mockStorage) Init() error { return nil }

--- a/src/control/modules/mgmt/storage_types.go
+++ b/src/control/modules/mgmt/storage_types.go
@@ -23,7 +23,11 @@
 
 package mgmt
 
-import "go-spdk/nvme"
+import (
+	"go-spdk/nvme"
+
+	pb "modules/mgmt/proto"
+)
 
 // Storage interface represents a persistent storage that can
 // support relevant operations.
@@ -33,6 +37,11 @@ type Storage interface {
 	Update(interface{}) interface{}
 	Teardown() error
 }
+
+// NsMap is a type alias
+type NsMap map[int32]*pb.NVMeNamespace
+// CtrlrMap is a type alias
+type CtrlrMap map[int32]*pb.NVMeController
 
 // NvmeStorage is an implementation of the Storage interface.
 type NvmeStorage struct{}

--- a/src/control/modules/mgmt/storage_types.go
+++ b/src/control/modules/mgmt/storage_types.go
@@ -1,0 +1,54 @@
+//
+// (C) Copyright 2018 Intel Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// GOVERNMENT LICENSE RIGHTS-OPEN SOURCE SOFTWARE
+// The Government's rights to use, modify, reproduce, release, perform, display,
+// or disclose this software are subject to the terms of the Apache License as
+// provided in Contract No. 8F-30005.
+// Any reproduction of computer software, computer software documentation, or
+// portions thereof marked with this legend must also reproduce the markings.
+//
+
+package mgmt
+
+import "go-spdk/nvme"
+
+// Storage interface represents a persistent storage that can
+// support relevant operations.
+type Storage interface {
+	Init() error
+	Discover() interface{}
+	Update(interface{}) interface{}
+	Teardown() error
+}
+
+// NvmeStorage is an implementation of the Storage interface.
+type NvmeStorage struct{}
+
+// NVMeReturn struct contains return values for NvmeStorage
+// Discover and Update methods.
+type NVMeReturn struct {
+	Ctrlrs []nvme.Controller
+	Nss    []nvme.Namespace
+	Err    error
+}
+
+// UpdateParams struct contains input parameters for NvmeStorage
+// Update implementation.
+type UpdateParams struct {
+	CtrlrID int32
+	Path    string
+	Slot    int32
+}

--- a/src/include/daos_srv/bio.h
+++ b/src/include/daos_srv/bio.h
@@ -75,6 +75,19 @@ struct bio_io_context;
 /* Opaque per-xstream context */
 struct bio_xs_context;
 
+/**
+ * Header for SPDK blob per VOS pool
+ */
+struct bio_blob_hdr {
+	uint32_t	bbh_magic;
+	uint32_t	bbh_blk_sz;
+	uint32_t	bbh_hdr_sz; /* blocks reserved for blob header */
+	uint32_t	bbh_vos_id; /* service xstream id */
+	uint64_t	bbh_blob_id;
+	uuid_t		bbh_blobstore;
+	uuid_t		bbh_pool;
+};
+
 static inline void
 bio_addr_set(bio_addr_t *addr, uint16_t type, uint64_t off)
 {
@@ -238,6 +251,38 @@ int bio_ioctxt_open(struct bio_io_context **pctxt,
  * \returns		Zero on success, negative value on error
  */
 int bio_ioctxt_close(struct bio_io_context *ctxt);
+
+/**
+ * Write to per VOS instance blob created.
+ *
+ * \param[IN] ctxt	VOS instance I/O context
+ * \param[IN] addr	SPDK blob addr info including byte offset
+ * \param[IN] iov	IO vector containing buffer to be written
+ *
+ * \returns		Zero on success, negative value on error
+ */
+int bio_writev(struct bio_io_context *ctxt, bio_addr_t addr, daos_iov_t *iov);
+
+/**
+ * Read from per VOS instance blob created.
+ *
+ * \param[IN] ctxt	VOS instance I/O context
+ * \param[IN] addr	SPDK blob addr info including byte offset
+ * \param[IN] iov	IO vector containing buffer from read
+ *
+ * \returns		Zero on success, negative value on error
+ */
+int bio_readv(struct bio_io_context *ctxt, bio_addr_t addr, daos_iov_t *iov);
+
+/*
+ * Finish setting up blob header and write info to blob offset 0.
+ *
+ * \param[IN] ctxt	I/O context
+ * \param[IN] hdr	VOS blob header struct
+ *
+ * \returns		Zero on success, negative value on error
+ */
+int bio_write_blob_hdr(struct bio_io_context *ctxt, struct bio_blob_hdr *hdr);
 
 /**
  * Allocate & initialize an io descriptor

--- a/src/include/daos_srv/evtree.h
+++ b/src/include/daos_srv/evtree.h
@@ -349,18 +349,17 @@ int evt_find(daos_handle_t toh, struct evt_rect *rect,
 	     struct evt_entry_list *ent_list, d_list_t *covered);
 
 /** Scan the tree for the non-punched visible rectangle with the highest
- *  end offset and return the offset.  The returned offset is only valid
- *  if the function returns 0.
+ *  end offset and return the offset + 1 as the size.  Size is set to 0
+ *  if no entries exist.   Size is undefined if an error is returned.
  *
  *  \param toh		[IN]	The tree open handle
  *  \param epoch	[IN]	The epoch at which to scan
- *  \param max_off	[OUT]	The returned max offset, if available
+ *  \param size		[OUT]	The size of the evtree
  *
- *  \return		0		Found the max offset
- *			-DER_ENOENT	Tree is empty at specified epoch
+ *  \return		0		Size is valid
  *			-rc		Other error code
  */
-int evt_get_max(daos_handle_t toh, daos_epoch_t epoch, daos_off_t *max_off);
+int evt_get_size(daos_handle_t toh, daos_epoch_t epoch, daos_size_t *size);
 
 /**
  * Debug function, it outputs status of tree nodes at level \a debug_level,

--- a/src/include/daos_srv/vea.h
+++ b/src/include/daos_srv/vea.h
@@ -126,7 +126,7 @@ struct vea_space_df {
 struct vea_space_info;
 
 /* Callback to initialize block device header */
-typedef int (*vea_format_callback_t)(void *cb_data);
+typedef int (*vea_format_callback_t)(void *cb_data, struct umem_instance *umem);
 
 /**
  * Initialize the space tracking information on SCM and the header of the

--- a/src/include/daos_types.h
+++ b/src/include/daos_types.h
@@ -594,11 +594,11 @@ typedef struct {
 /** Type of the value accessed in an IOD */
 typedef enum {
 	/** is a dkey */
-	DAOS_IOD_NONE	= 0,
+	DAOS_IOD_NONE		= 0,
 	/** one indivisble value udpate atomically */
-	DAOS_IOD_SINGLE = (1 << 0),
+	DAOS_IOD_SINGLE		= (1 << 0),
 	/** an array of records where each record is update atomically */
-	DAOS_IOD_ARRAY	= (1 << 1),
+	DAOS_IOD_ARRAY		= (1 << 1),
 } daos_iod_type_t;
 
 /**
@@ -621,11 +621,15 @@ typedef struct {
 	 * value. The idx is ignored and the rx_nr is also required to be 1.
 	 */
 	daos_iod_type_t		iod_type;
-	/** Size of the single value or the record size of the akey */
+	/* DAOS_IOD_SINGLE:	Size of the value
+	 * DAOS_IOD_ARRAY:	iod_nr > 0:  Record size
+	 *			iod_nr == 0: Array size
+	 */
 	daos_size_t		iod_size;
 	/*
 	 * Number of entries in the \a iod_recxs, \a iod_csums, and \a iod_eprs
-	 * arrays, should be 1 if single value.
+	 * arrays, should be 1 if single value,
+	 * 0 for array size query
 	 */
 	unsigned int		iod_nr;
 	/*

--- a/src/object/cli_obj.c
+++ b/src/object/cli_obj.c
@@ -1012,6 +1012,9 @@ obj_iod_valid(unsigned int nr, daos_iod_t *iods, bool update)
 			return false;
 
 		case DAOS_IOD_ARRAY:
+			if (iods[i].iod_nr == 0) /* size query */
+				continue;
+
 			if (obj_recx_valid(iods[i].iod_nr, iods[i].iod_recxs,
 					   update)) {
 				continue;

--- a/src/tests/ftest/util/ServerUtils.py
+++ b/src/tests/ftest/util/ServerUtils.py
@@ -63,11 +63,10 @@ def runServer(hostfile, setname, basepath):
                     'OFI_.*']
 
         env_args = ""
-        for env_var in os.environ.items():
+        for (env_var, env_val) in os.environ.items():
             for pat in env_vars:
-                if not re.match(pat, env_var[0]):
-                    continue
-                env_args += "-x {0}=\"{1}\" ".format(env_var, os.environ[env_var])
+                if re.match(pat, env_var):
+                    env_args += "-x {}='{}' ".format(env_var, env_val)
 
         initial_cmd = "/bin/sh"
         server_cmd = orterun_bin + " --np {0} ".format(server_count)

--- a/src/vos/tests/evt_ctl.c
+++ b/src/vos/tests/evt_ctl.c
@@ -530,25 +530,25 @@ ts_many_add(char *args)
 }
 
 static int
-ts_get_max(char *args)
+ts_get_size(char *args)
 {
 	char		*tok;
 	daos_epoch_t	 epoch;
-	daos_off_t	 max_off;
-	daos_off_t	 expected_off;
+	daos_size_t	 size;
+	daos_size_t	 expected_size;
 	int		 expected_rc = 0;
 	int		 rc;
-	bool		 check_offset = true;
+	bool		 check_size = true;
 	bool		 check_rc = true;
 
 	epoch = strtoull(args, NULL, 10);
 
 	tok = strchr(args, EVT_SEP);
 	if (tok == NULL) {
-		check_offset = false;
+		check_size = false;
 	} else {
 		tok++;
-		expected_off = strtoull(tok, NULL, 10);
+		expected_size = strtoull(tok, NULL, 10);
 	}
 
 	tok = strchr(args, EVT_SEP_VAL);
@@ -560,19 +560,19 @@ ts_get_max(char *args)
 		D_PRINT("Expecting rc %d\n", expected_rc);
 	}
 
-	rc = evt_get_max(ts_toh, epoch, &max_off);
+	rc = evt_get_size(ts_toh, epoch, &size);
 
-	D_PRINT("evt_get_max returns %s at epoch "DF_U64"\n", d_errstr(rc),
+	D_PRINT("evt_get_size returns %s at epoch "DF_U64"\n", d_errstr(rc),
 		epoch);
 	if (rc == 0)
-		D_PRINT("   max_offset is "DF_U64"\n", max_off);
+		D_PRINT("   size is "DF_U64"\n", size);
 
 	if (check_rc && expected_rc != rc) {
 		D_PRINT("Expected rc == %s\n", d_errstr(expected_rc));
 		return 1;
 	}
-	if (check_offset && expected_off != max_off) {
-		D_PRINT("Expected offset "DF_U64"\n", expected_off);
+	if (check_size && expected_size != size) {
+		D_PRINT("Expected size "DF_U64"\n", expected_size);
 		return 1;
 	}
 
@@ -599,7 +599,7 @@ static struct option ts_ops[] = {
 	{ "find",	required_argument,	NULL,	'f'	},
 	{ "delete",	required_argument,	NULL,	'd'	},
 	{ "list",	no_argument,		NULL,	'l'	},
-	{ "get_max",	required_argument,	NULL,	'g'	},
+	{ "get_size",	required_argument,	NULL,	'g'	},
 	{ "debug",	required_argument,	NULL,	'b'	},
 	{ NULL,		0,			NULL,	0	},
 };
@@ -635,7 +635,7 @@ ts_cmd_run(char opc, char *args)
 		rc = ts_list_rect();
 		break;
 	case 'g':
-		rc = ts_get_max(args);
+		rc = ts_get_size(args);
 		break;
 	case 'd':
 		rc = ts_delete_rect(args);

--- a/src/vos/tests/evt_ctl.sh
+++ b/src/vos/tests/evt_ctl.sh
@@ -66,10 +66,10 @@ EOF
  -a 31-56@$nm3:abcdefghijklmnopqrstuvwxyz	\
  -f 0-100@$np4          \
  -d -0-100@$np4         \
- -g $np4,99             \
- -g $n,99               \
- -g 0:-2003             \
- -g $nm3,99
+ -g $np4,100            \
+ -g $n,100              \
+ -g 0:0                 \
+ -g $nm3,100
 EOF
 )
 }
@@ -88,10 +88,10 @@ function check_max {
     -a 0-0@$fourth              \
     -f 0-355@$first             \
     -f 0-355@$fourth            \
-    -g $first,355               \
-    -g $second,354              \
-    -g $third,0                 \
-    -g $fourth:-2003
+    -g $first,356               \
+    -g $second,355              \
+    -g $third,1                 \
+    -g $fourth:0
 EOF
 )
 }

--- a/src/vos/vea/vea_api.c
+++ b/src/vos/vea/vea_api.c
@@ -106,7 +106,7 @@ vea_format(struct umem_instance *umem, struct umem_tx_stage_data *txd,
 		 */
 		D_ASSERT(pmemobj_tx_stage() == TX_STAGE_NONE);
 
-		rc = cb(cb_data);
+		rc = cb(cb_data, umem);
 		if (rc != 0)
 			return rc;
 	}

--- a/src/vos/vos_internal.h
+++ b/src/vos/vos_internal.h
@@ -54,19 +54,6 @@ extern umem_class_id_t vos_mem_class;
 /** hash seed for murmur hash */
 #define VOS_BTR_MUR_SEED	0xC0FFEE
 
-/**
- * Header for SPDK blob per VOS pool
- */
-struct vos_blob_hdr {
-	uint32_t	vbh_magic;
-	uint32_t	vbh_blk_sz;
-	uint32_t	vbh_hdr_sz; /* blocks reserved for blob header */
-	uint32_t	vbh_vos_id; /* Service xstream id */
-	uuid_t		vbh_blobstore;
-	uint64_t	vbh_blob_id;
-	uuid_t		vbh_pool;
-};
-
 static inline uint32_t vos_byte2blkcnt(uint64_t bytes)
 {
 	D_ASSERT(bytes != 0);

--- a/src/vos/vos_io.c
+++ b/src/vos/vos_io.c
@@ -451,6 +451,14 @@ akey_fetch(struct vos_io_context *ioc, daos_handle_t ak_toh)
 		goto out;
 	} /* else: array */
 
+	if (iod->iod_nr == 0) { /* array size query */
+		D_DEBUG(DB_IO, "fetch array size for eph "DF_U64"\n", epoch);
+		rc = evt_get_size(toh, epoch, &iod->iod_size);
+		if (rc != 0)
+			D_DEBUG(DB_IO, "Array size query failed %d\n", rc);
+		goto out;
+	} /* else: array */
+
 	for (i = 0; i < iod->iod_nr; i++) {
 		daos_size_t rsize;
 

--- a/utils/docker/Dockerfile.centos:7
+++ b/utils/docker/Dockerfile.centos:7
@@ -24,7 +24,9 @@ RUN yum install -y doxygen pandoc flex patch nasm yasm ninja-build meson
 RUN yum install -y CUnit-devel libaio-devel astyle-devel python-pep8 lcov
 RUN yum install -y python clang-analyzer sg3_utils libiscsi-devel
 RUN yum install -y libibverbs-devel numactl-devel doxygen mscgen graphviz
-
+RUN yum -y install yum-plugin-copr
+RUN yum -y copr enable hnakamur/golang-dep
+RUN yum -y install golang-dep
 
 # Dependencies
 # Packages for NVML, PMIx, hwloc and OpenMPI exist in CentOS, but are unfortunately

--- a/utils/docker/Dockerfile.ubuntu:18.04
+++ b/utils/docker/Dockerfile.ubuntu:18.04
@@ -25,7 +25,7 @@ RUN apt-get install -y librdmacm-dev libcmocka0 libcmocka-dev libreadline6-dev
 RUN apt-get install -y curl doxygen pandoc flex patch nasm yasm graphviz doxygen
 RUN apt-get install -y libibverbs-dev librdmacm-dev libcunit1-dev libnuma-dev
 RUN apt-get install -y libaio-dev sg3-utils libiscsi-dev python-dev mscgen
-RUN apt-get install -y ninja-build meson
+RUN apt-get install -y ninja-build meson go-dep
 
 # Dependencies
 

--- a/utils/fetch_go_packages.sh
+++ b/utils/fetch_go_packages.sh
@@ -1,47 +1,17 @@
 #!/bin/bash
 
 function print_usage {
-	echo "fetch_go_packages.sh [-i ipath][-g gopath][-v]" 1>&2
-	echo "-i in-tree path to top level DAOS source tree" 1>&2
-	echo "-g path to a user specified GOPATH" 1>&2
-	echo "-v verify packages at the specified path" 1>&2
-	echo "if no path is specified $HOME/go is the default GOPATH" 1>&2
+	echo "fetch_go_packages.sh [-i <path/to/daos>]" 1>&2
+	echo "	-i: Path to top level DAOS source tree" 1>&2
+	echo "	If no path is specified, current directory is used." 1>&2
 }
 
-#set the default values
-GOPATH="$HOME/go"
-VERIFY=false
+DAOS_ROOT="."
 
-# go.uuid: MIT Licensed and used for UUID generation in Go components
-# protoc-gen-go: 3 Clause BSD Licensed and provides go GRPC compiler support
-# grpc: Apache 2.0 used as communication channel between Go components.
-# sys/unix: 3 Clause BSD Official Golang package for unix os support
-# ishell: MIT License used for the frontend shell interface for Go components.
-# go-flags: 3 Clause BSD used for command line parsing with ishell.
-packages=('github.com/satori/go.uuid'
-'github.com/golang/protobuf/protoc-gen-go'
-'google.golang.org/grpc'
-'golang.org/x/sys/unix'
-'github.com/daos-stack/ishell'
-'github.com/jessevdk/go-flags'
-'github.com/pkg/errors'
-)
-
-
-while getopts ":i:g:vh" opt; do
+while getopts ":i:" opt; do
 	case "${opt}" in
 		i)
-			GOPATH="${OPTARG}/_build.external/go"
-			;;
-		g)
-			GOPATH=${OPTARG}
-			;;
-		v)
-			VERIFY=true
-			;;
-		h)
-			print_usage
-			exit 1
+			DAOS_ROOT=${OPTARG}
 			;;
 		*)
 			print_usage
@@ -50,28 +20,6 @@ while getopts ":i:g:vh" opt; do
         esac
 done
 
-REALGOPATH=$(realpath -ms "$GOPATH")
-GOPATH=$REALGOPATH
-export GOPATH
+GOPATH=$(realpath -ms "$DAOS_ROOT")
 
-echo "Using the GOPATH location of $GOPATH" 1>&2
-if [[ $VERIFY = true ]] ; then
-	for package in "${packages[@]}"; do
-		go list ... | grep ${package} > /dev/null
-		if [[ $? -ne 0 ]]; then
-			echo "Cannot find ${package} in GOPATH=${GOPATH}" 1>&2
-			exit 1
-		fi
-		echo "Found package ${package} in GOPATH" 1>&2
-	done
-	exit 0
-fi
-
-if [[ ! -d $GOPATH ]] ; then
-	mkdir -p "$GOPATH"
-fi
-
-for package in "${packages[@]}"; do
-	echo "Fetching Package: $package" 1>&2
-	go get -u "$package"
-done
+cd "$DAOS_ROOT/src/control" && GOPATH="$GOPATH" dep ensure -v


### PR DESCRIPTION
DAOS-1311 build: Install dep in Dockerfiles

This patch updates the Dockerfiles to install dep. The Docker
build calls utils/fetch_go_packages.sh, so dep is required.

The Quickstart Guide has also been updated with details for
installing dep manually, if the user's OS does not supply a
package.

Change-Id: I2ba71a818ad8a0a920d687387f068a5a4adea935
Signed-off-by: Kris Jacque <kristin.jacque@intel.com>
Signed-off-by: Brian J. Murrell <brian.murrell@intel.com>