### PR TITLE
Provide better error message for scons

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -42,8 +42,10 @@ def scons():
             sys.path.insert(0, os.path.join(Dir('#').abspath, 'scons_local'))
             from prereq_tools import PreReqComponent
             print ('Using scons_local build')
-        except ImportError:
-            print ('Using traditional build')
+        except ImportError as e:
+            print ('Failed to import prereq_tools: {0}'.format(e))
+            print ('Please run `git submodule update --init`')
+            sys.exit(1)
 
     env = Environment(TOOLS=['default'])
 


### PR DESCRIPTION
Provide a better error message when the needed git submodules are not available.

```
[harms@localhost daos]$ scons --config=force --build-deps=yes USE_INSTALLED=all install
scons: Reading SConscript files ...
Failed to import prereq_tools: No module named prereq_tools
Please run `git submodule update --init`
```