### PR TITLE
DAOS-2036 build: check {} stack size < 4k

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -9,8 +9,8 @@ sys.path.insert(0, os.path.join(Dir('#').abspath, 'utils'))
 DESIRED_FLAGS = ['-Wno-gnu-designator',
                  '-Wno-missing-braces',
                  '-Wno-gnu-zero-variadic-macro-arguments',
-                 '-Wno-tautological-constant-out-of-range-compare']
-
+                 '-Wno-tautological-constant-out-of-range-compare',
+                 '-Wframe-larger-than=4096']
 DAOS_VERSION = "0.0.2"
 
 def is_platform_arm():

--- a/src/client/api/tests/eq_tests.c
+++ b/src/client/api/tests/eq_tests.c
@@ -28,6 +28,13 @@
  * Author: Liang Zhen  <liang.zhen@intel.com>
  */
 #define D_LOGFAC	DD_FAC(tests)
+#if !defined(__has_warning)  /* gcc */
+	#pragma GCC diagnostic ignored "-Wframe-larger-than="
+#else
+	#if __has_warning("-Wframe-larger-than=") /* valid clang warning */
+		#pragma GCC diagnostic ignored "-Wframe-larger-than="
+	#endif
+#endif
 
 #include <pthread.h>
 #include <stdarg.h>

--- a/src/common/tests/drpc_tests.c
+++ b/src/common/tests/drpc_tests.c
@@ -25,6 +25,13 @@
  * Unit tests for the drpc module
  */
 
+#if !defined(__has_warning)  /* gcc */
+	#pragma GCC diagnostic ignored "-Wframe-larger-than="
+#else
+	#if __has_warning("-Wframe-larger-than=") /* valid clang warning */
+		#pragma GCC diagnostic ignored "-Wframe-larger-than="
+	#endif
+#endif
 #include <stdarg.h>
 #include <stddef.h>
 #include <setjmp.h>

--- a/src/common/tests/test_mocks.c
+++ b/src/common/tests/test_mocks.c
@@ -20,6 +20,13 @@
  * Any reproduction of computer software, computer software documentation, or
  * portions thereof marked with this legend must also reproduce the markings.
  */
+#if !defined(__has_warning)  /* gcc */
+	#pragma GCC diagnostic ignored "-Wframe-larger-than="
+#else
+	#if __has_warning("-Wframe-larger-than=") /* valid clang warning */
+		#pragma GCC diagnostic ignored "-Wframe-larger-than="
+	#endif
+#endif
 
 #include <daos/test_mocks.h>
 #include <daos/test_utils.h>

--- a/src/rebuild/SConscript
+++ b/src/rebuild/SConscript
@@ -8,6 +8,7 @@ def scons():
     env.AppendUnique(LIBPATH=[Dir('.')])
     denv = env.Clone()
 
+    denv.Append(CCFLAGS=['-Wframe-larger-than=131072'])
     # rebuild
     rebuild = daos_build.library(denv, 'rebuild',
                                  ['scan.c', 'srv.c', 'rpc.c', 'initiator.c',

--- a/src/tests/addons/hl_tests.c
+++ b/src/tests/addons/hl_tests.c
@@ -25,7 +25,13 @@
  *
  * src/tests/addons/
  */
-
+#if !defined(__has_warning)  /* gcc */
+	#pragma GCC diagnostic ignored "-Wframe-larger-than="
+#else
+	#if __has_warning("-Wframe-larger-than=") /* valid clang warning */
+		#pragma GCC diagnostic ignored "-Wframe-larger-than="
+	#endif
+#endif
 #include <daos_types.h>
 #include <daos_addons.h>
 #include "daos_test.h"

--- a/src/tests/suite/daos_test.h
+++ b/src/tests/suite/daos_test.h
@@ -26,6 +26,13 @@
  */
 #ifndef __DAOS_TEST_H
 #define __DAOS_TEST_H
+#if !defined(__has_warning)  /* gcc */
+	#pragma GCC diagnostic ignored "-Wframe-larger-than="
+#else
+	#if __has_warning("-Wframe-larger-than=") /* valid clang warning */
+		#pragma GCC diagnostic ignored "-Wframe-larger-than="
+	#endif
+#endif
 
 #include <unistd.h>
 #include <stdlib.h>

--- a/src/vos/tests/vts_common.h
+++ b/src/vos/tests/vts_common.h
@@ -27,7 +27,13 @@
  */
 #ifndef __VTS_COMMON_H__
 #define __VTS_COMMON_H__
-
+#if !defined(__has_warning)  /* gcc */
+	#pragma GCC diagnostic ignored "-Wframe-larger-than="
+#else
+	#if __has_warning("-Wframe-larger-than=") /* valid clang warning */
+		#pragma GCC diagnostic ignored "-Wframe-larger-than="
+	#endif
+#endif
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>


### PR DESCRIPTION
Add -Wframe-larger-than=4096 check to make sure
each function stack size <=4k to avoid overflow
the regular ULT (16K) stack size.

Ignore the check for some tests.

Enlarge the rebuild ULT stack size to 128K.

Change-Id: I7c2c0e80177023298f952c3fe74c400cc9c0deb8
Signed-off-by: Wang Di <di.wang@intel.com>