### PR TITLE
DAOS-2050 evtree: Implement evt_iter_delete/empty

### DIFF
--- a/src/common/debug.c
+++ b/src/common/debug.c
@@ -58,6 +58,7 @@ DECLARE_FAC(bio);
 DECLARE_FAC(tests);
 DECLARE_FAC(dfs);
 DECLARE_FAC(drpc);
+DECLARE_FAC(security);
 
 uint64_t DB_MD; /* metadata operation */
 uint64_t DB_PL; /* placement */
@@ -65,8 +66,9 @@ uint64_t DB_MGMT; /* pool management */
 uint64_t DB_EPC; /* epoch system */
 uint64_t DB_DF; /* durable format */
 uint64_t DB_REBUILD; /* rebuild process */
+uint64_t DB_SEC; /* Security checks */
 /* debug bit groups */
-#define DB_GRP1 (DB_IO | DB_MD | DB_PL | DB_REBUILD)
+#define DB_GRP1 (DB_IO | DB_MD | DB_PL | DB_REBUILD | DB_SEC)
 
 #define DBG_DICT_ENTRY(bit, name, lname)			\
 {								\
@@ -85,6 +87,7 @@ static struct d_debug_bit daos_bit_dict[] = {
 	DBG_DICT_ENTRY(&DB_EPC,		"epc",		"epoch"),
 	DBG_DICT_ENTRY(&DB_DF,		"df",		"durable_format"),
 	DBG_DICT_ENTRY(&DB_REBUILD,	"rebuild",	"rebuild"),
+	DBG_DICT_ENTRY(&DB_SEC,		"sec",		"security")
 };
 
 #define NUM_DBG_BIT_ENTRIES	ARRAY_SIZE(daos_bit_dict)
@@ -110,7 +113,8 @@ static struct d_debug_bit daos_bit_dict[] = {
 	ACTION("tests", d_tests_logfac)			\
 	ACTION("bio", d_bio_logfac)			\
 	ACTION("dfs", d_dfs_logfac)			\
-	ACTION("drpc", d_drpc_logfac)
+	ACTION("drpc", d_drpc_logfac)			\
+	ACTION("security", d_security_logfac)
 
 #define DAOS_SETUP_FAC(name, idp)			\
 	DAOS_INIT_LOG_FAC(name, &idp)

--- a/src/include/daos/debug.h
+++ b/src/include/daos/debug.h
@@ -48,6 +48,7 @@ extern int d_bio_logfac;
 extern int d_tests_logfac;
 extern int d_dfs_logfac;
 extern int d_drpc_logfac;
+extern int d_security_logfac;
 
 #include <gurt/debug.h>
 
@@ -57,6 +58,7 @@ extern uint64_t DB_MGMT; /* pool management */
 extern uint64_t DB_EPC; /* epoch system */
 extern uint64_t DB_DF; /* durable format */
 extern uint64_t DB_REBUILD; /* rebuild process */
+extern uint64_t DB_SEC; /* Security checks */
 
 #define DB_DEFAULT	DLOG_DBG
 #define DB_NULL		0

--- a/src/include/daos/rpc.h
+++ b/src/include/daos/rpc.h
@@ -64,6 +64,7 @@ enum daos_module_id {
 	DAOS_RSVC_MODULE	= 6, /** replicated service server */
 	DAOS_RDB_MODULE		= 7, /** rdb */
 	DAOS_RDBT_MODULE	= 8, /** rdb test */
+	DAOS_SEC_MODULE		= 9, /** security framework */
 	DAOS_MAX_MODULE		= (1 << MOD_ID_BITS) - 1,
 };
 

--- a/src/iosrv/init.c
+++ b/src/iosrv/init.c
@@ -40,7 +40,7 @@
 #include <daos.h> /* for daos_init() */
 
 #define MAX_MODULE_OPTIONS	64
-#define MODULE_LIST		"vos,rdb,rsvc,mgmt,pool,cont,obj,rebuild"
+#define MODULE_LIST		"vos,rdb,rsvc,security,mgmt,pool,cont,obj,rebuild"
 
 /** List of modules to load */
 static char		modules[MAX_MODULE_OPTIONS + 1];

--- a/src/security/SConscript
+++ b/src/security/SConscript
@@ -1,4 +1,5 @@
 """Build security library"""
+import daos_build
 
 def scons():
     """Execute build"""
@@ -11,6 +12,9 @@ def scons():
 
     # Shared src between server and client
     common_src = denv.SharedObject(['security.pb-c.c'])
+
+    ds_sec = daos_build.library(denv, 'security', ['srv.c'])
+    denv.Install('$PREFIX/lib/daos_srv', ds_sec)
 
     # dc_security: Security Client
     dc_security_tgts = denv.SharedObject(['cli_security.c']) + common_src

--- a/src/security/srv.c
+++ b/src/security/srv.c
@@ -1,0 +1,60 @@
+/*
+ * (C) Copyright 2019 Intel Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * GOVERNMENT LICENSE RIGHTS-OPEN SOURCE SOFTWARE
+ * The Government's rights to use, modify, reproduce, release, perform, display,
+ * or disclose this software are subject to the terms of the Apache License as
+ * provided in Contract No. 8F-30005.
+ * Any reproduction of computer software, computer software documentation, or
+ * portions thereof marked with this legend must also reproduce the markings.
+ */
+
+/**
+ * ds_sec: Security Framework Server
+ *
+ * This is part of daos_server. It exports the security RPC handlers and
+ * implements Security Framework Server API.
+ */
+#define D_LOGFAC	DD_FAC(security)
+
+#include <daos/rpc.h>
+#include <daos_srv/daos_server.h>
+#include "srv_internal.h"
+
+static int
+init(void)
+{
+	return 0;
+}
+
+static int
+fini(void)
+{
+	return 0;
+}
+
+struct dss_module security_module =  {
+	.sm_name	= "security",
+	.sm_mod_id	= DAOS_SEC_MODULE,
+	.sm_ver		= DAOS_SEC_VERSION,
+	.sm_init	= init,
+	.sm_fini	= fini,
+	.sm_setup	= NULL,
+	.sm_cleanup	= NULL,
+	.sm_proto_fmt	= NULL,
+	.sm_cli_count	= 0,
+	.sm_handlers	= NULL,
+	.sm_key		= NULL,
+};

--- a/src/security/srv_internal.h
+++ b/src/security/srv_internal.h
@@ -1,0 +1,35 @@
+/*
+ * (C) Copyright 2019 Intel Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * GOVERNMENT LICENSE RIGHTS-OPEN SOURCE SOFTWARE
+ * The Government's rights to use, modify, reproduce, release, perform, display,
+ * or disclose this software are subject to the terms of the Apache License as
+ * provided in Contract No. 8F-30005.
+ * Any reproduction of computer software, computer software documentation, or
+ * portions thereof marked with this legend must also reproduce the markings.
+ */
+
+/**
+ * ds_sec: Security Framework Server Internal Declarations
+ */
+
+#ifndef __SECURITY_SRV_INTERNAL_H__
+#define __SECURITY_SRV_INTERNAL_H__
+
+#include <daos_srv/daos_server.h>
+
+#define DAOS_SEC_VERSION 1
+
+#endif /* __SECURITY_SRV_INTERNAL_H__ */

--- a/src/vos/tests/evt_ctl.sh
+++ b/src/vos/tests/evt_ctl.sh
@@ -158,7 +158,7 @@ EOF
 cmd+=" -b -2 -D"
 echo "$cmd"
 
-$cmd
+$cmd -t
 
 result=$?
 echo Test returned $result

--- a/src/vos/vos_obj.c
+++ b/src/vos/vos_obj.c
@@ -1286,7 +1286,7 @@ vos_obj_iter_delete(struct vos_iterator *iter, void *args)
 		return obj_iter_delete(oiter, args);
 
 	case VOS_ITER_RECX:
-		return -DER_NOSYS;
+		return evt_iter_delete(oiter->it_hdl, args);
 	}
 }
 
@@ -1307,7 +1307,7 @@ vos_obj_iter_empty(struct vos_iterator *iter)
 	case VOS_ITER_SINGLE:
 		return dbtree_iter_empty(oiter->it_hdl);
 	case VOS_ITER_RECX:
-		return -DER_NOSYS;
+		return evt_iter_empty(oiter->it_hdl);
 	}
 }
 


### PR DESCRIPTION
For delete, it only is supported for non-sorted iterator.
The function will keep trace intact though reprobe would
be needed if the user yields between calls deleting the
returned payload, for example.  But by default, the trace
will be set to the next entry.

Add some unit test infrastructure and a test for this
feature.  Will continue to add some additional tests.

Bug fix
1. The filter can't filter must not filter intermediate
   nodes on the low epoch because the in-tree rectangle
   only contains the lowest epoch of all rectangles.
2. Call evt_desc_free to free payload if user passes
   NULL to evt_delete or evt_iter_delete
3. Fix a few persistance issues caught by valgrind

Change-Id: Iff45b596e2649eabf4e86a5b2aad9962679d9e07
Signed-off-by: Jeff Olivier <jeffrey.v.olivier@intel.com>