### PR TITLE
DAOS-1441 object: update/punch RPC protocol changes

### DIFF
--- a/src/common/mem.c
+++ b/src/common/mem.c
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2016-2018 Intel Corporation.
+ * (C) Copyright 2016-2019 Intel Corporation.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -44,6 +44,12 @@ struct umem_tx_stage_item {
 };
 
 /** persistent memory operations (depends on pmdk) */
+
+static umem_id_t
+pmem_id(struct umem_instance *umm, void *addr)
+{
+	return pmemobj_oid(addr);
+}
 
 static void *
 pmem_addr(struct umem_instance *umm, umem_id_t ummid)
@@ -290,6 +296,7 @@ pmem_tx_add_callback(struct umem_instance *umm, struct umem_tx_stage_data *txd,
 }
 
 static umem_ops_t	pmem_ops = {
+	.mo_id			= pmem_id,
 	.mo_addr		= pmem_addr,
 	.mo_equal		= pmem_equal,
 	.mo_tx_free		= pmem_tx_free,
@@ -330,6 +337,15 @@ umem_tx_errno(int err)
 }
 
 /* volatile memroy operations */
+
+static umem_id_t
+vmem_id(struct umem_instance *umm, void *addr)
+{
+	umem_id_t	ummid = UMMID_NULL;
+
+	ummid.off = (uint64_t)addr;
+	return ummid;
+}
 
 static void *
 vmem_addr(struct umem_instance *umm, umem_id_t ummid)
@@ -384,6 +400,7 @@ vmem_tx_add_callback(struct umem_instance *umm, struct umem_tx_stage_data *txd,
 }
 
 static umem_ops_t	vmem_ops = {
+	.mo_id		= vmem_id,
 	.mo_addr	= vmem_addr,
 	.mo_equal	= vmem_equal,
 	.mo_tx_free	= vmem_free,

--- a/src/include/daos/mem.h
+++ b/src/include/daos/mem.h
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2016-2018 Intel Corporation.
+ * (C) Copyright 2016-2019 Intel Corporation.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -110,6 +110,8 @@ int  umem_init_txd(struct umem_tx_stage_data *txd);
 void umem_fini_txd(struct umem_tx_stage_data *txd);
 
 typedef struct {
+	/** convert directly accessible address to ummid */
+	umem_id_t	 (*mo_id)(struct umem_instance *umm, void *addr);
 	/** convert ummid to directly accessible address */
 	void		*(*mo_addr)(struct umem_instance *umm,
 				    umem_id_t ummid);
@@ -358,6 +360,12 @@ static inline void *
 umem_id2ptr(struct umem_instance *umm, umem_id_t ummid)
 {
 	return umm->umm_ops->mo_addr(umm, ummid);
+}
+
+static inline umem_id_t
+umem_ptr2id(struct umem_instance *umm, void *ptr)
+{
+	return umm->umm_ops->mo_id(umm, ptr);
 }
 
 #define umem_id2ptr_typed(umm, tmmid)					\

--- a/src/include/daos/placement.h
+++ b/src/include/daos/placement.h
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2016 Intel Corporation.
+ * (C) Copyright 2016-2019 Intel Corporation.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -52,8 +52,6 @@ struct pl_map_init_attr {
 	};
 };
 
-struct pl_map;
-
 struct pl_target {
 	uint32_t		pt_pos;
 };
@@ -71,6 +69,7 @@ struct pl_target_grp {
 struct pl_obj_shard {
 	uint32_t	po_shard;	/* shard index */
 	uint32_t	po_target;	/* target id */
+	uint32_t	po_fseq;	/* The latest failure sequence */
 	uint32_t	po_rebuilding:1; /* rebuilding status */
 };
 
@@ -80,8 +79,31 @@ struct pl_obj_layout {
 	struct pl_obj_shard	*ol_shards;
 };
 
+/** common header of all placement map */
+struct pl_map {
+	/** correpsonding pool uuid */
+	uuid_t			 pl_uuid;
+	/** link chain on hash */
+	d_list_t		 pl_link;
+	/** protect refcount */
+	pthread_spinlock_t	 pl_lock;
+	/** refcount */
+	int			 pl_ref;
+	/** pool connections, protected by pl_rwlock */
+	int			 pl_connects;
+	/** type of placement map */
+	pl_map_type_t		 pl_type;
+	/** reference to pool map */
+	struct pool_map		*pl_poolmap;
+	/** placement map operations */
+	struct pl_map_ops       *pl_ops;
+};
+
+void pl_map_attr_init(struct pool_map *po_map, pl_map_type_t type,
+		      struct pl_map_init_attr *mia);
+
 int  pl_map_create(struct pool_map *poolmap, struct pl_map_init_attr *mia,
-		   struct pl_map **mapp);
+		   struct pl_map **mapp, bool hash);
 void pl_map_destroy(struct pl_map *map);
 void pl_map_print(struct pl_map *map);
 

--- a/src/include/daos_srv/dtx_srv.h
+++ b/src/include/daos_srv/dtx_srv.h
@@ -45,6 +45,11 @@ enum daos_tx_flags {
 	DTX_F_AOC		= 1,
 };
 
+enum dtx_cos_list_types {
+	DCLT_UPDATE		= (1 << 0),
+	DCLT_PUNCH		= (1 << 1),
+};
+
 /**
  * DAOS two-phase commit transaction handle in DRAM.
  */

--- a/src/include/daos_srv/pool.h
+++ b/src/include/daos_srv/pool.h
@@ -34,6 +34,7 @@
 #include <daos/lru.h>
 #include <daos/pool_map.h>
 #include <daos/rpc.h>
+#include <daos/placement.h>
 
 /*
  * Pool object
@@ -45,6 +46,7 @@ struct ds_pool {
 	uuid_t			sp_uuid;
 	ABT_rwlock		sp_lock;
 	struct pool_map	       *sp_map;
+	struct pl_map	       *sp_pl_map;
 	uint32_t		sp_map_version;	/* temporary */
 	crt_group_t	       *sp_group;
 	struct ds_iv_ns		*sp_iv_ns;
@@ -165,5 +167,8 @@ int ds_pool_iv_ns_update(struct ds_pool *pool, unsigned int master_rank,
 			 d_iov_t *iv_iov, unsigned int iv_ns_id);
 
 int ds_pool_svc_term_get(uuid_t uuid, uint64_t *term);
+
+int ds_pool_check_leader(uuid_t pool_uuid, daos_unit_oid_t *oid,
+			 uint32_t version, struct pl_obj_layout **plo);
 
 #endif /* __DAOS_SRV_POOL_H__ */

--- a/src/include/daos_srv/vos.h
+++ b/src/include/daos_srv/vos.h
@@ -37,6 +37,24 @@
 #include <daos_srv/vos_types.h>
 
 /**
+ * Check whether the given @dti belongs to a resent RPC or not.
+ *
+ * \param coh	[IN]	Container open handle.
+ * \param dti	[IN]	The DTX identifier.
+ *
+ * \return		Zero if related DTX is there ('prepared'),
+ *			but not committed yet.
+ * \return		-DER_ALREADY if related DTX has been committed.
+ * \return		-DER_NONEXIST if no modification has been done before.
+ * \return		-DER_INPROGRESS if some new DTX ('init') is there.
+ * \return		-DER_TIMEDOUT if the DTX is too old as to we are not
+ *			sure about whether it has ever been processed or not.
+ * \return		Other negative value if error.
+ */
+int
+vos_dtx_handle_resend(daos_handle_t coh, struct daos_tx_id *dti);
+
+/**
  * Prepare the DTX handle in DRAM.
  *
  * XXX: Currently, we only support to prepare the DTX against single DAOS

--- a/src/include/daos_srv/vos.h
+++ b/src/include/daos_srv/vos.h
@@ -33,7 +33,53 @@
 
 #include <daos/common.h>
 #include <daos_types.h>
+#include <daos_srv/dtx_srv.h>
 #include <daos_srv/vos_types.h>
+
+/**
+ * Search the specified DTX is in the CoS cache or not.
+ *
+ * \param coh	[IN]	Container open handle.
+ * \param oid	[IN]	Pointer to the object ID.
+ * \param xid	[IN]	Pointer to the DTX identifier.
+ * \param dkey	[IN]	The hashed dkey.
+ * \param punch	[IN]	For punch DTX or not.
+ *
+ * \return	0 if the DTX exists in the CoS cache.
+ * \return	-DER_NONEXIST if not in the CoS cache.
+ * \return	Other negative values on error.
+ */
+int
+vos_dtx_lookup_cos(daos_handle_t coh, daos_unit_oid_t *oid,
+		   struct daos_tx_id *xid, uint64_t dkey, bool punch);
+
+/**
+ * Fetch the list of the DTXs to be committed because of (potential) share.
+ *
+ * \param coh		[IN]	Container open handle.
+ * \param oid		[IN]	The target object (shard) ID.
+ * \param dkey		[IN]	The target dkey to be modified.
+ * \param types		[IN]	The DTX types to be listed.
+ * \param dtis		[OUT]	The DTX IDs array to be committed for share.
+ *
+ * \return			The count of DTXs to be committed for share
+ *				on success, negative value if error.
+ */
+int
+vos_dtx_list_cos(daos_handle_t coh, daos_unit_oid_t *oid,
+		 daos_key_t *dkey, uint32_t types, struct daos_tx_id **dtis);
+
+/**
+ * Fetch the list of the DTXs that can be committed.
+ *
+ * \param coh	[IN]	Container open handle.
+ * \param dtes	[OUT]	The array for DTX entries can be committed.
+ *
+ * \return		The count of DTXs can be committed on success,
+ *			negative value if error.
+ */
+int
+vos_dtx_list_committable(daos_handle_t coh, struct daos_tx_entry **dtes);
 
 /**
  * Initialize the environment for a VOS instance

--- a/src/include/daos_types.h
+++ b/src/include/daos_types.h
@@ -87,6 +87,10 @@ daos_csum_set(daos_csum_buf_t *csum, void *buf, uint16_t size)
 	csum->cs_len = csum->cs_buf_len = size;
 }
 
+enum daos_anchor_flags {
+	/* The RPC will be sent to leader replica. */
+	DAOS_ANCHOR_FLAGS_TO_LEADER	= 1,
+};
 
 typedef enum {
 	DAOS_ANCHOR_TYPE_ZERO	= 0,
@@ -100,10 +104,21 @@ typedef enum {
 typedef struct {
 	uint16_t	da_type; /** daos_anchor_type_t */
 	uint16_t	da_shard;
-	uint32_t	da_padding;
+	uint32_t	da_flags;
 	uint8_t		da_buf[DAOS_ANCHOR_BUF_MAX];
 } daos_anchor_t;
 
+static inline void
+daos_anchor_set_flags(daos_anchor_t *anchor, uint32_t flags)
+{
+	anchor->da_flags |= flags;
+}
+
+static inline uint32_t
+daos_anchor_get_flags(daos_anchor_t *anchor)
+{
+	return anchor->da_flags;
+}
 
 static inline void
 daos_anchor_set_zero(daos_anchor_t *anchor)

--- a/src/object/cli_obj.c
+++ b/src/object/cli_obj.c
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2016-2018 Intel Corporation.
+ * (C) Copyright 2016-2019 Intel Corporation.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -260,6 +260,7 @@ obj_layout_create(struct dc_object *obj)
 		obj_shard = &obj->cob_shards[i];
 		obj_shard->do_shard = i;
 		obj_shard->do_target_id = layout->ol_shards[i].po_target;
+		obj_shard->do_fseq = layout->ol_shards[i].po_fseq;
 		obj_shard->do_rebuilding = layout->ol_shards[i].po_rebuilding;
 	}
 out:
@@ -378,28 +379,125 @@ obj_grp_valid_shard_get(struct dc_object *obj, int idx,
 }
 
 static int
-obj_grp_shard_get(struct dc_object *obj, uint32_t grp_idx,
-		  uint64_t hash, unsigned int map_ver, uint32_t op)
+obj_select_leader_shard(struct dc_object *obj, uint32_t idx,
+			uint32_t *shard_idx)
 {
-	int	grp_size;
-	int	idx;
+	struct dc_obj_shard		*shard;
+	struct daos_oclass_attr		*oc_attr;
+	uint32_t			 replicas;
+	int				 preferred;
+	int				 rdg_idx;
+	int				 start;
+	int				 pos;
+	int				 off;
+	int				 i;
 
-	grp_size = obj_get_grp_size(obj);
-	idx = hash % grp_size + grp_idx * grp_size;
-	return obj_grp_valid_shard_get(obj, idx, map_ver, op);
+	if (obj->cob_shards_nr <= idx)
+		return -DER_INVAL;
+
+	oc_attr = daos_oclass_attr_find(obj->cob_md.omd_id);
+
+	/* For non-replicated object, elect current shard as leader. */
+	if (oc_attr->ca_resil != DAOS_RES_REPL) {
+		*shard_idx = idx;
+		return 0;
+	}
+
+	replicas = oc_attr->u.repl.r_num;
+	if (replicas == DAOS_OBJ_REPL_MAX)
+		replicas = obj->cob_shards_nr;
+
+	if (replicas < 1)
+		return -DER_INVAL;
+
+	if (replicas == 1) {
+		D_ASSERT(idx == 0);
+
+		shard = &obj->cob_shards[idx];
+		if (shard->do_target_id == -1)
+			return -DER_NONEXIST;
+
+		/* Single replicated object will not rebuild. */
+		D_ASSERT(!shard->do_rebuilding);
+		D_ASSERT(shard->do_shard == idx);
+
+		*shard_idx = shard->do_shard;
+		return 0;
+	}
+
+	/* XXX: The shards within [start, start + oc_attr->u.repl.r_num) will
+	 *	search from the same @preferred position, then they will have
+	 *	the same leader. The shards (belonging to the same object) in
+	 *	other redundancy group may get different leader node.
+	 *
+	 *	The one with the lowest f_seq will be elected as the leader to
+	 *	avoid leader switch.
+	 */
+	rdg_idx = idx / replicas;
+	start = rdg_idx * replicas;
+	preferred = start + (obj->cob_md.omd_id.lo + rdg_idx) % replicas;
+	for (i = 0, off = preferred, pos = -1; i < replicas;
+	     i++, off = (off + 1) % replicas + start) {
+		shard = &obj->cob_shards[off];
+		if (shard->do_target_id == -1 || shard->do_rebuilding)
+			continue;
+
+		if (pos == -1 ||
+		    obj->cob_shards[pos].do_fseq > shard->do_fseq)
+			pos = off;
+	}
+
+	if (pos != -1) {
+		D_ASSERT(obj->cob_shards[pos].do_shard == pos);
+
+		*shard_idx = pos;
+		return 0;
+	}
+
+	/* If all the replicas are failed or in-rebuilding, then NONEXIST. */
+	return -DER_NONEXIST;
+}
+
+static int
+obj_grp_leader_get(struct dc_object *obj, int idx, unsigned int map_ver)
+{
+	uint32_t	shard;
+	int		rc;
+
+	D_RWLOCK_RDLOCK(&obj->cob_lock);
+	if (obj->cob_version != map_ver) {
+		/* Sigh, someone else changed the pool map */
+		D_RWLOCK_UNLOCK(&obj->cob_lock);
+		return -DER_STALE;
+	}
+
+	rc = obj_select_leader_shard(obj, idx, &shard);
+	if (rc == 0)
+		rc = shard;
+	D_RWLOCK_UNLOCK(&obj->cob_lock);
+
+	return rc;
 }
 
 static int
 obj_dkeyhash2shard(struct dc_object *obj, uint64_t hash, unsigned int map_ver,
-		   uint32_t op)
+		   uint32_t op, bool to_leader)
 {
-	int	 grp_idx;
+	int	grp_idx;
+	int	grp_size;
+	int	idx;
 
 	grp_idx = obj_dkey2grp(obj, hash, map_ver);
 	if (grp_idx < 0)
 		return grp_idx;
 
-	return obj_grp_shard_get(obj, grp_idx, hash, map_ver, op);
+	grp_size = obj_get_grp_size(obj);
+	idx = hash % grp_size + grp_idx * grp_size;
+
+	if (to_leader)
+		return obj_grp_leader_get(obj, idx, map_ver);
+
+	return obj_grp_valid_shard_get(obj, idx, map_ver, op);
 }
 
 static int
@@ -468,8 +566,7 @@ obj_shards_2_fwtgts(struct dc_object *obj, uint32_t map_ver,
 		return 0;
 
 	/* select one leader shard and generate the fw_shard_tgts array */
-	rc = obj_grp_valid_shard_get(obj, *start_shard, map_ver,
-				     DAOS_OBJ_RPC_UPDATE);
+	rc = obj_grp_leader_get(obj, *start_shard, map_ver);
 	if (rc < 0) {
 		D_ERROR(DF_OID" no valid shard, rc %d.\n",
 			DP_OID(obj->cob_md.omd_id), rc);
@@ -901,7 +998,9 @@ struct obj_auxi_args {
 	uint32_t			 map_ver_req;
 	uint32_t			 map_ver_reply;
 	uint32_t			 io_retry:1,
-					 shard_task_scheded:1;
+					 shard_task_scheded:1,
+					 retry_with_leader:1;
+	uint32_t			 flags;
 	int				 result;
 	d_list_t			 shard_task_head;
 	tse_task_t			*obj_task;
@@ -930,6 +1029,7 @@ struct obj_list_arg {
 struct shard_update_args {
 	struct shard_auxi_args	 auxi;
 	daos_epoch_t		 epoch;
+	struct daos_tx_id	 dti;
 	daos_key_t		*dkey;
 	uint64_t		 dkey_hash;
 	unsigned int		 nr;
@@ -957,6 +1057,8 @@ shard_result_process(tse_task_t *task, void *arg)
 	} else if (obj_retry_error(ret)) {
 		D_DEBUG(DB_IO, "shard %d ret %d.\n", shard_auxi->shard, ret);
 		obj_auxi->io_retry = 1;
+		if (task->dt_result == -DER_INPROGRESS)
+			obj_auxi->retry_with_leader = 1;
 	} else {
 		/* for un-retryable failure, set the err to whole obj IO */
 		D_DEBUG(DB_IO, "shard %d ret %d.\n", shard_auxi->shard, ret);
@@ -1073,6 +1175,9 @@ obj_comp_cb(tse_task_t *task, void *data)
 		pm_stale = true;
 	if (obj_retry_error(task->dt_result) || obj_auxi->io_retry)
 		io_retry = true;
+
+	if (io_retry && task->dt_result == -DER_INPROGRESS)
+		obj_auxi->retry_with_leader = 1;
 
 	if (pm_stale || io_retry)
 		obj_retry_cb(task, obj, io_retry);
@@ -1236,7 +1341,8 @@ dc_obj_fetch(tse_task_t *task)
 
 	dkey_hash = obj_dkey2hash(args->dkey);
 	shard = obj_dkeyhash2shard(obj, dkey_hash, map_ver,
-				   DAOS_OPC_OBJ_UPDATE);
+				   DAOS_OPC_OBJ_UPDATE,
+				   obj_auxi->retry_with_leader);
 	if (shard < 0)
 		D_GOTO(out_task, rc = shard);
 
@@ -1310,7 +1416,8 @@ shard_update_task(tse_task_t *task)
 	rc = dc_obj_shard_update(obj_shard, args->epoch, args->dkey, args->nr,
 				 args->iods, args->sgls, &args->auxi.map_ver,
 				 args->auxi.obj_auxi->fw_shard_tgts,
-				 args->auxi.obj_auxi->fw_cnt, task);
+				 args->auxi.obj_auxi->fw_cnt, task,
+				 &args->dti, args->auxi.obj_auxi->flags);
 
 	obj_shard_close(obj_shard);
 	return rc;
@@ -1473,8 +1580,20 @@ dc_obj_update(tse_task_t *task)
 
 	head = &obj_auxi->shard_task_head;
 	/* for retried obj IO, reuse the previous shard tasks and resched it */
-	if (obj_auxi->io_retry)
+	if (obj_auxi->io_retry) {
+		/* We mark the RPC as RESEND although @io_retry does not
+		 * guarantee that the RPC has ever been sent. It may cause
+		 * some overhead on server side, but no correctness issues.
+		 *
+		 * On the other hand, the client may resend the RPC to new
+		 * shard if leader switched. That is why the resend logic
+		 * is handled at object layer rather than shard layer.
+		 */
+		obj_auxi->flags = ORF_RESEND;
 		goto task_sched;
+	}
+
+	obj_auxi->flags = 0;
 	for (i = 0; i < shards_cnt; i++, shard++) {
 		tse_task_t			*shard_task;
 		struct shard_update_args	*shard_arg;
@@ -1487,6 +1606,7 @@ dc_obj_update(tse_task_t *task)
 		shard_arg = tse_task_buf_embedded(shard_task,
 						  sizeof(*shard_arg));
 		shard_arg->epoch		= epoch;
+		daos_generate_dti(&shard_arg->dti);
 		shard_arg->dkey			= args->dkey;
 		shard_arg->dkey_hash		= dkey_hash;
 		shard_arg->nr			= args->nr;
@@ -1574,21 +1694,34 @@ dc_obj_list_internal(daos_handle_t oh, uint32_t op, daos_handle_t th,
 		D_GOTO(out_task, rc);
 
 	if (dkey == NULL) {
+		bool	to_leader = false;
+
 		if (op != DAOS_OBJ_DKEY_RPC_ENUMERATE &&
 		    op != DAOS_OBJ_RPC_ENUMERATE) {
 			D_ERROR("No dkey for opc %x\n", op);
 			D_GOTO(out_task, rc = -DER_INVAL);
 		}
 
+		if (obj_auxi->retry_with_leader)
+			to_leader = true;
+		else if (daos_anchor_get_flags(dkey_anchor) &
+			 DAOS_ANCHOR_FLAGS_TO_LEADER)
+			to_leader = true;
+
 		shard = dc_obj_anchor2shard(dkey_anchor);
-		shard = obj_grp_valid_shard_get(obj, shard, map_ver, op);
+		if (to_leader)
+			shard = obj_grp_leader_get(obj, shard, map_ver);
+		else
+			shard = obj_grp_valid_shard_get(obj, shard,
+							map_ver, op);
 		if (shard < 0)
 			D_GOTO(out_task, rc = shard);
 
 		dc_obj_shard2anchor(dkey_anchor, shard);
 	} else {
 		dkey_hash = obj_dkey2hash(dkey);
-		shard = obj_dkeyhash2shard(obj, dkey_hash, map_ver, op);
+		shard = obj_dkeyhash2shard(obj, dkey_hash, map_ver, op,
+					   obj_auxi->retry_with_leader);
 		if (shard < 0)
 			D_GOTO(out_task, rc = shard);
 	}
@@ -1685,6 +1818,7 @@ struct shard_punch_args {
 	daos_obj_punch_t	*pa_api_args;
 	uint64_t		 pa_dkey_hash;
 	daos_epoch_t		 pa_epoch;
+	struct daos_tx_id	 pa_dti;
 	uint32_t		 pa_opc;
 };
 
@@ -1719,7 +1853,8 @@ shard_punch_task(tse_task_t *task)
 				api_args->akey_nr, args->pa_coh_uuid,
 				args->pa_cont_uuid, &args->pa_auxi.map_ver,
 				args->pa_auxi.obj_auxi->fw_shard_tgts,
-				args->pa_auxi.obj_auxi->fw_cnt, task);
+				args->pa_auxi.obj_auxi->fw_cnt, task,
+				&args->pa_dti, args->pa_auxi.obj_auxi->flags);
 
 	obj_shard_close(obj_shard);
 	return rc;
@@ -1806,8 +1941,12 @@ obj_punch_internal(tse_task_t *api_task, enum obj_rpc_opc opc,
 	obj_auxi->obj_task = api_task;
 	head = &obj_auxi->shard_task_head;
 	/* for retried obj IO, reuse the previous shard tasks and resched it */
-	if (obj_auxi->io_retry)
+	if (obj_auxi->io_retry) {
+		obj_auxi->flags = ORF_RESEND;
 		goto task_sched;
+	}
+
+	obj_auxi->flags = 0;
 	for (i = 0; i < shard_nr; i++) {
 		tse_task_t		*task;
 		struct shard_punch_args	*args;
@@ -1821,6 +1960,7 @@ obj_punch_internal(tse_task_t *api_task, enum obj_rpc_opc opc,
 		shard			= shard_first + i;
 		args->pa_api_args	= api_args;
 		args->pa_epoch		= epoch;
+		daos_generate_dti(&args->pa_dti);
 		args->pa_auxi.shard	= shard;
 		args->pa_auxi.target	= obj_shard2tgtid(obj, shard);
 		args->pa_auxi.map_ver	= map_ver;

--- a/src/object/obj_internal.h
+++ b/src/object/obj_internal.h
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2016-2018 Intel Corporation.
+ * (C) Copyright 2016-2019 Intel Corporation.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -35,6 +35,7 @@
 #include <daos/placement.h>
 #include <daos/btree.h>
 #include <daos/btree_class.h>
+#include <daos/dtx.h>
 #include <daos_srv/daos_server.h>
 #include <daos_types.h>
 
@@ -78,6 +79,7 @@ struct dc_obj_shard {
 	uint32_t		do_target_id;	/* target id (unique in pool) */
 	uint32_t		do_target_idx;	/* target VOS index in node */
 	uint32_t		do_target_rank;
+	uint32_t		do_fseq;	/* failure sequence */
 	uint32_t		do_rebuilding:1;
 	/** point back to object */
 	struct dc_object	*do_obj;
@@ -129,7 +131,9 @@ int dc_obj_shard_update(struct dc_obj_shard *shard, daos_epoch_t epoch,
 			daos_key_t *dkey, unsigned int nr,
 			daos_iod_t *iods, daos_sg_list_t *sgls,
 			unsigned int *map_ver, struct daos_obj_shard_tgt *tgts,
-			uint32_t fw_cnt, tse_task_t *task);
+			uint32_t fw_cnt, tse_task_t *task,
+			struct daos_tx_id *dti, uint32_t flags);
+
 int dc_obj_shard_fetch(struct dc_obj_shard *shard, daos_epoch_t epoch,
 		       daos_key_t *dkey, unsigned int nr,
 		       daos_iod_t *iods, daos_sg_list_t *sgls,
@@ -151,7 +155,8 @@ int dc_obj_shard_punch(struct dc_obj_shard *shard, uint32_t opc,
 		       daos_key_t *akeys, unsigned int akey_nr,
 		       const uuid_t coh_uuid, const uuid_t cont_uuid,
 		       unsigned int *map_ver, struct daos_obj_shard_tgt *tgts,
-		       uint32_t fw_cnt, tse_task_t *task);
+		       uint32_t fw_cnt, tse_task_t *task,
+		       struct daos_tx_id *dti, uint32_t flags);
 
 int dc_obj_shard_query_key(struct dc_obj_shard *shard, daos_epoch_t epoch,
 			   uint32_t flags, daos_key_t *dkey, daos_key_t *akey,
@@ -163,7 +168,7 @@ static inline bool
 obj_retry_error(int err)
 {
 	return err == -DER_TIMEDOUT || err == -DER_STALE ||
-	       daos_crt_network_error(err);
+	       err == -DER_INPROGRESS || daos_crt_network_error(err);
 }
 
 void obj_shard_decref(struct dc_obj_shard *shard);

--- a/src/object/obj_rpc.c
+++ b/src/object/obj_rpc.c
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2016-2018 Intel Corporation.
+ * (C) Copyright 2016-2019 Intel Corporation.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -29,6 +29,22 @@
 #include <daos/event.h>
 #include <daos/rpc.h>
 #include "obj_rpc.h"
+
+static int
+crt_proc_struct_daos_tx_id(crt_proc_t proc, struct daos_tx_id *dti)
+{
+	int rc;
+
+	rc = crt_proc_uuid_t(proc, &dti->dti_uuid);
+	if (rc != 0)
+		return -DER_HG;
+
+	rc = crt_proc_uint64_t(proc, &dti->dti_sec);
+	if (rc != 0)
+		return -DER_HG;
+
+	return 0;
+}
 
 static int
 crt_proc_daos_key_desc_t(crt_proc_t proc, daos_key_desc_t *key)
@@ -304,7 +320,7 @@ crt_proc_daos_anchor_t(crt_proc_t proc, daos_anchor_t *anchor)
 	if (crt_proc_uint16_t(proc, &anchor->da_shard) != 0)
 		return -DER_HG;
 
-	if (crt_proc_uint32_t(proc, &anchor->da_padding) != 0)
+	if (crt_proc_uint32_t(proc, &anchor->da_flags) != 0)
 		return -DER_HG;
 
 	if (crt_proc_raw(proc, anchor->da_buf, sizeof(anchor->da_buf)) != 0)

--- a/src/object/srv_obj.c
+++ b/src/object/srv_obj.c
@@ -574,7 +574,7 @@ ds_obj_rw_echo_handler(crt_rpc_t *rpc)
 		bulk_op = CRT_BULK_GET;
 	}
 
-	bulk_bind = orw->orw_flags & ORW_FLAG_BULK_BIND;
+	bulk_bind = orw->orw_flags & ORF_BULK_BIND;
 	rc = ds_bulk_transfer(rpc, bulk_op, bulk_bind, orw->orw_bulks.ca_arrays,
 			      DAOS_HDL_INVAL, &p_sgl, orw->orw_nr);
 
@@ -612,7 +612,7 @@ obj_update_prefw(crt_rpc_t *req, uint32_t shard, void *arg)
 	uuid_copy(orw->orw_co_uuid, orw_parent->orw_co_uuid);
 	orw->orw_shard_tgts.ca_count	= 0;
 	orw->orw_shard_tgts.ca_arrays	= NULL;
-	orw->orw_flags			= ORW_FLAG_BULK_BIND;
+	orw->orw_flags			= ORF_BULK_BIND;
 
 	return 0;
 }
@@ -692,7 +692,7 @@ ds_obj_rw_local_hdlr(crt_rpc_t *rpc, uint32_t tag, struct ds_cont_hdl *cont_hdl,
 	}
 
 	if (rma) {
-		bulk_bind = orw->orw_flags & ORW_FLAG_BULK_BIND;
+		bulk_bind = orw->orw_flags & ORF_BULK_BIND;
 		rc = ds_bulk_transfer(rpc, bulk_op, bulk_bind,
 			orw->orw_bulks.ca_arrays, *ioh, NULL, orw->orw_nr);
 	} else if (orw->orw_sgls.ca_arrays != NULL) {

--- a/src/placement/pl_map.c
+++ b/src/placement/pl_map.c
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2016 Intel Corporation.
+ * (C) Copyright 2016-2019 Intel Corporation.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -275,7 +275,7 @@ struct d_hash_table	pl_htable = {
 
 #define DSR_RING_DOMAIN		PO_COMP_TP_RACK
 
-static void
+void
 pl_map_attr_init(struct pool_map *po_map, pl_map_type_t type,
 		 struct pl_map_init_attr *mia)
 {
@@ -380,18 +380,20 @@ pl_htable_init()
  */
 int
 pl_map_create(struct pool_map *pool_map, struct pl_map_init_attr *mia,
-	      struct pl_map **pl_mapp)
+	      struct pl_map **pl_mapp, bool hash)
 {
-	int rc = 0;
+	if (hash) {
+		int rc = 0;
 
-	D_RWLOCK_WRLOCK(&pl_rwlock);
-	if (!pl_htable.ht_ops)
-		rc = pl_htable_init();
-	D_RWLOCK_UNLOCK(&pl_rwlock);
+		D_RWLOCK_WRLOCK(&pl_rwlock);
+		if (!pl_htable.ht_ops)
+			rc = pl_htable_init();
+		D_RWLOCK_UNLOCK(&pl_rwlock);
 
-	if (rc) {
-		D_ERROR("pl_htable_init failed, rc %d.\n", rc);
-		return rc;
+		if (rc != 0) {
+			D_ERROR("pl_htable_init failed, rc %d.\n", rc);
+			return rc;
+		}
 	}
 
 	return pl_map_create_inited(pool_map, mia, pl_mapp);

--- a/src/placement/pl_map.h
+++ b/src/placement/pl_map.h
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2016 Intel Corporation.
+ * (C) Copyright 2016-2019 Intel Corporation.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -32,26 +32,6 @@
 #include <daos/placement.h>
 
 struct pl_map_ops;
-
-/** common header of all placement map */
-struct pl_map {
-	/** correpsonding pool uuid */
-	uuid_t			 pl_uuid;
-	/** link chain on hash */
-	d_list_t		 pl_link;
-	/** protect refcount */
-	pthread_spinlock_t	 pl_lock;
-	/** refcount */
-	int			 pl_ref;
-	/** pool connections, protected by pl_rwlock */
-	int			 pl_connects;
-	/** type of placement map */
-	pl_map_type_t		 pl_type;
-	/** reference to pool map */
-	struct pool_map		*pl_poolmap;
-	/** placement map operations */
-	struct pl_map_ops       *pl_ops;
-};
 
 /**
  * Function table for placement map.

--- a/src/placement/ring_map.c
+++ b/src/placement/ring_map.c
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2016-2018 Intel Corporation.
+ * (C) Copyright 2016-2019 Intel Corporation.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -1191,6 +1191,7 @@ next_fail:
 		if (spare_avail) {
 			/* The selected spare target is up and ready */
 			l_shard->po_target = spare_tgt->ta_comp.co_id;
+			l_shard->po_fseq = spare_tgt->ta_comp.co_fseq;
 
 			/*
 			 * Mark the shard as 'rebuilding' so that read will
@@ -1262,6 +1263,7 @@ ring_obj_layout_fill(struct pl_map *map, struct daos_obj_md *md,
 			tgt = &tgts[pos];
 			layout->ol_shards[k].po_shard  = rop->rop_shard_id + k;
 			layout->ol_shards[k].po_target = tgt->ta_comp.co_id;
+			layout->ol_shards[k].po_fseq   = tgt->ta_comp.co_fseq;
 
 			if (pool_target_unavail(tgt)) {
 				rc = ring_remap_alloc_one(remap_list, k, tgt);
@@ -1319,7 +1321,7 @@ ring_obj_place(struct pl_map *map, struct daos_obj_md *md,
 	return 0;
 }
 
-#define SHARDS_ON_STACK_COUNT	256
+#define SHARDS_ON_STACK_COUNT	128
 int
 ring_obj_find_rebuild(struct pl_map *map, struct daos_obj_md *md,
 		      struct daos_obj_shard_md *shard_md,

--- a/src/placement/tests/place_obj.c
+++ b/src/placement/tests/place_obj.c
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2016-2018 Intel Corporation.
+ * (C) Copyright 2016-2019 Intel Corporation.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -231,7 +231,7 @@ main(int argc, char **argv)
 	mia.ia_ring.ring_nr = 1;
 	mia.ia_ring.domain  = PO_COMP_TP_RACK;
 
-	rc = pl_map_create(po_map, &mia, &pl_map);
+	rc = pl_map_create(po_map, &mia, &pl_map, true);
 	D_ASSERT(rc == 0);
 
 	pl_map_print(pl_map);

--- a/src/pool/srv_internal.h
+++ b/src/pool/srv_internal.h
@@ -61,6 +61,8 @@ struct pool_iv_entry {
 /*
  * srv_pool.c
  */
+void ds_pool_destroy_pl_map(struct ds_pool *pool);
+int ds_pool_create_pl_map(struct ds_pool *pool, struct pool_map *map);
 void ds_pool_rsvc_class_register(void);
 void ds_pool_rsvc_class_unregister(void);
 int ds_pool_svc_start(uuid_t uuid, bool create, uuid_t db_uuid, size_t size,

--- a/src/pool/srv_pool.c
+++ b/src/pool/srv_pool.c
@@ -290,6 +290,36 @@ pool_svc_rdb_uuid_remove(const uuid_t pool_uuid)
 	return rc;
 }
 
+void
+ds_pool_destroy_pl_map(struct ds_pool *pool)
+{
+	if (pool->sp_pl_map != NULL) {
+		struct pl_map	*map = pool->sp_pl_map;
+
+		pool->sp_pl_map = NULL;
+		/* Drop the reference when create */
+		map->pl_ref--;
+		pl_map_destroy(map);
+	}
+}
+
+int
+ds_pool_create_pl_map(struct ds_pool *pool, struct pool_map *map)
+{
+	struct pl_map		*pl_map = NULL;
+	struct pl_map_init_attr	 mia;
+	int			 rc;
+
+	pl_map_attr_init(map, PL_TYPE_RING, &mia);
+	rc = pl_map_create(map, &mia, &pl_map, false);
+	if (rc == 0) {
+		ds_pool_destroy_pl_map(pool);
+		pool->sp_pl_map = pl_map;
+	}
+
+	return rc;
+}
+
 /*
  * Called by mgmt module on every storage node belonging to this pool.
  * "path" is the directory under which the VOS and metadata files shall be.
@@ -882,6 +912,14 @@ pool_svc_step_up_cb(struct ds_rsvc *rsvc)
 
 			/* Need to update pool->sp_map. Swap with map. */
 			pool->sp_map_version = map_version;
+			rc = ds_pool_create_pl_map(pool, map);
+			if (rc != 0) {
+				svc->ps_pool = NULL;
+				ABT_rwlock_unlock(pool->sp_lock);
+				ds_pool_put(pool);
+				goto out;
+			}
+
 			tmp = pool->sp_map;
 			pool->sp_map = map;
 			map = tmp;
@@ -1143,10 +1181,10 @@ ds_pool_svc_stop_all(void)
 
 static int
 bcast_create(crt_context_t ctx, struct pool_svc *svc, crt_opcode_t opcode,
-	     crt_rpc_t **rpc)
+	     crt_bulk_t bulk_hdl, crt_rpc_t **rpc)
 {
 	return ds_pool_bcast_create(ctx, svc->ps_pool, DAOS_POOL_MODULE, opcode,
-				    rpc, NULL, NULL);
+				    rpc, bulk_hdl, NULL);
 }
 
 /**
@@ -1341,7 +1379,8 @@ permitted(const struct pool_attr *attr, uint32_t uid, uint32_t gid,
 static int
 pool_connect_bcast(crt_context_t ctx, struct pool_svc *svc,
 		   const uuid_t pool_hdl, uint64_t capas,
-		   daos_iov_t *global_ns, struct daos_pool_space *ps)
+		   daos_iov_t *global_ns, struct daos_pool_space *ps,
+		   crt_bulk_t map_buf_bulk)
 {
 	struct pool_tgt_connect_in     *in;
 	struct pool_tgt_connect_out    *out;
@@ -1355,7 +1394,7 @@ pool_connect_bcast(crt_context_t ctx, struct pool_svc *svc,
 	if (rc != 0)
 		D_GOTO(out, rc);
 
-	rc = bcast_create(ctx, svc, POOL_TGT_CONNECT, &rpc);
+	rc = bcast_create(ctx, svc, POOL_TGT_CONNECT, map_buf_bulk, &rpc);
 	if (rc != 0)
 		D_GOTO(out, rc);
 
@@ -1406,10 +1445,15 @@ bulk_cb(const struct crt_bulk_cb_info *cb_info)
  * Transfer the pool map to "remote_bulk". If the remote bulk buffer is too
  * small, then return -DER_TRUNC and set "required_buf_size" to the local pool
  * map buffer size.
+ * If the map_buf_bulk is non-NULL, then the created local bulk handle for
+ * pool_buf will be returned and caller needs to do crt_bulk_free later.
+ * If the map_buf_bulk is NULL then the internally created local bulk handle
+ * will be freed within this function.
  */
 static int
 transfer_map_buf(struct rdb_tx *tx, struct pool_svc *svc, crt_rpc_t *rpc,
-		 crt_bulk_t remote_bulk, uint32_t *required_buf_size)
+		 crt_bulk_t remote_bulk, uint32_t *required_buf_size,
+		 crt_bulk_t *map_buf_bulk)
 {
 	struct pool_buf	       *map_buf;
 	size_t			map_buf_size;
@@ -1417,7 +1461,7 @@ transfer_map_buf(struct rdb_tx *tx, struct pool_svc *svc, crt_rpc_t *rpc,
 	daos_size_t		remote_bulk_size;
 	daos_iov_t		map_iov;
 	daos_sg_list_t		map_sgl;
-	crt_bulk_t		bulk;
+	crt_bulk_t		bulk = CRT_BULK_NULL;
 	struct crt_bulk_desc	map_desc;
 	crt_bulk_opid_t		map_opid;
 	ABT_eventual		eventual;
@@ -1491,7 +1535,10 @@ transfer_map_buf(struct rdb_tx *tx, struct pool_svc *svc, crt_rpc_t *rpc,
 out_eventual:
 	ABT_eventual_free(&eventual);
 out_bulk:
-	crt_bulk_free(bulk);
+	if (map_buf_bulk != NULL)
+		*map_buf_bulk = bulk;
+	else
+		crt_bulk_free(bulk);
 out:
 	return rc;
 }
@@ -1502,6 +1549,7 @@ ds_pool_connect_handler(crt_rpc_t *rpc)
 	struct pool_connect_in	       *in = crt_req_get(rpc);
 	struct pool_connect_out	       *out = crt_reply_get(rpc);
 	struct pool_svc		       *svc;
+	crt_bulk_t			map_buf_bulk = CRT_BULK_NULL;
 	struct rdb_tx			tx;
 	daos_iov_t			key;
 	daos_iov_t			value;
@@ -1592,7 +1640,7 @@ ds_pool_connect_handler(crt_rpc_t *rpc)
 	 * its pool_buf away.
 	 */
 	rc = transfer_map_buf(&tx, svc, rpc, in->pci_map_bulk,
-			      &out->pco_map_buf_size);
+			      &out->pco_map_buf_size, &map_buf_bulk);
 	if (rc != 0)
 		D_GOTO(out_map_version, rc);
 
@@ -1627,7 +1675,8 @@ ds_pool_connect_handler(crt_rpc_t *rpc)
 	}
 
 	rc = pool_connect_bcast(rpc->cr_ctx, svc, in->pci_op.pi_hdl,
-				in->pci_capas, &iv_iov, &out->pco_space);
+				in->pci_capas, &iv_iov, &out->pco_space,
+				map_buf_bulk);
 	if (rc != 0) {
 		D_ERROR(DF_UUID": failed to connect to targets: %d\n",
 			DP_UUID(in->pci_op.pi_uuid), rc);
@@ -1658,6 +1707,7 @@ out_svc:
 	ds_rsvc_set_hint(&svc->ps_rsvc, &out->pco_op.po_hint);
 	pool_svc_put_leader(svc);
 out:
+	crt_bulk_free(map_buf_bulk);
 	out->pco_op.po_rc = rc;
 	D_DEBUG(DF_DSMS, DF_UUID": replying rpc %p: %d\n",
 		DP_UUID(in->pci_op.pi_uuid), rpc, rc);
@@ -1675,7 +1725,7 @@ pool_disconnect_bcast(crt_context_t ctx, struct pool_svc *svc,
 
 	D_DEBUG(DF_DSMS, DF_UUID": bcasting\n", DP_UUID(svc->ps_uuid));
 
-	rc = bcast_create(ctx, svc, POOL_TGT_DISCONNECT, &rpc);
+	rc = bcast_create(ctx, svc, POOL_TGT_DISCONNECT, NULL, &rpc);
 	if (rc != 0)
 		D_GOTO(out, rc);
 
@@ -1822,7 +1872,7 @@ pool_query_bcast(crt_context_t ctx, struct pool_svc *svc, uuid_t pool_hdl,
 
 	D_DEBUG(DB_MD, DF_UUID": bcasting\n", DP_UUID(svc->ps_uuid));
 
-	rc = bcast_create(ctx, svc, POOL_TGT_QUERY, &rpc);
+	rc = bcast_create(ctx, svc, POOL_TGT_QUERY, NULL, &rpc);
 	if (rc != 0)
 		goto out;
 
@@ -1906,7 +1956,7 @@ ds_pool_query_handler(crt_rpc_t *rpc)
 	out->pqo_mode = attr.pa_mode;
 
 	rc = transfer_map_buf(&tx, svc, rpc, in->pqi_map_bulk,
-			      &out->pqo_map_buf_size);
+			      &out->pqo_map_buf_size, NULL);
 	if (rc != 0)
 		D_GOTO(out_map_version, rc);
 
@@ -2040,13 +2090,14 @@ ds_pool_update_internal(uuid_t pool_uuid, struct pool_target_id_list *tgts,
 		D_GOTO(out_map, rc);
 	}
 
-	updated = true;
-
 	/*
 	 * The new pool map is now committed and can be publicized. Swap the
 	 * new pool map with the old one in the cache.
 	 */
 	ABT_rwlock_wrlock(svc->ps_pool->sp_lock);
+	rc = ds_pool_create_pl_map(svc->ps_pool, map);
+	if (rc == 0)
+		updated = true;
 	map_tmp = svc->ps_pool->sp_map;
 	svc->ps_pool->sp_map = map;
 	map = map_tmp;
@@ -2959,4 +3010,129 @@ out:
 	out->pmo_failed = ranks;
 	out->pmo_rc = rc;
 	crt_reply_send(rpc);
+}
+
+static int
+ds_pool_select_leader_target(struct pl_obj_layout *layout, daos_unit_oid_t *oid,
+			     uint32_t *leader)
+{
+	struct pl_obj_shard		*shard;
+	struct daos_oclass_attr		*oc_attr;
+	uint32_t			 replicas;
+	int				 preferred;
+	int				 rdg_idx;
+	int				 start;
+	int				 pos;
+	int				 off;
+	int				 i;
+
+	if (layout->ol_nr <= oid->id_shard)
+		return -DER_INVAL;
+
+	oc_attr = daos_oclass_attr_find(oid->id_pub);
+
+	/* For non-replicated object, elect current shard as leader. */
+	if (oc_attr->ca_resil != DAOS_RES_REPL) {
+		*leader = layout->ol_shards[oid->id_shard].po_target;
+		return 0;
+	}
+
+	replicas = oc_attr->u.repl.r_num;
+	if (replicas == DAOS_OBJ_REPL_MAX)
+		replicas = layout->ol_nr;
+
+	if (replicas < 1)
+		return -DER_INVAL;
+
+	if (replicas == 1) {
+		shard = &layout->ol_shards[oid->id_shard];
+
+		if (shard->po_target == -1)
+			return -DER_NONEXIST;
+
+		/* Single replicated object will not rebuild. */
+		D_ASSERT(!shard->po_rebuilding);
+		D_ASSERT(shard->po_shard == oid->id_shard);
+
+		*leader = shard->po_target;
+		return 0;
+	}
+
+	/* XXX: The shards within [start, start + oc_attr->u.repl.r_num) will
+	 *	search from the same @preferred position, then they will have
+	 *	the same leader. The shards (belonging to the same object) in
+	 *	other redundancy group may get different leader node.
+	 *
+	 *	The one with the lowest f_seq will be elected as the leader to
+	 *	avoid leader switch.
+	 */
+	rdg_idx = oid->id_shard / replicas;
+	start = rdg_idx * replicas;
+	preferred = start + (oid->id_pub.lo + rdg_idx) % replicas;
+	for (i = 0, off = preferred, pos = -1; i < replicas;
+	     i++, off = (off + 1) % replicas + start) {
+		shard = &layout->ol_shards[off];
+		if (shard->po_target == -1 || shard->po_rebuilding)
+			continue;
+
+		if (pos == -1 ||
+		    layout->ol_shards[pos].po_fseq > shard->po_fseq)
+			pos = off;
+	}
+
+	if (pos != -1) {
+		D_ASSERT(layout->ol_shards[pos].po_shard == pos);
+
+		*leader = layout->ol_shards[pos].po_target;
+		return 0;
+	}
+
+	/* If all the replicas are failed or in-rebuilding, then NONEXIST. */
+	return -DER_NONEXIST;
+}
+
+int
+ds_pool_check_leader(uuid_t pool_uuid, daos_unit_oid_t *oid,
+		     uint32_t version, struct pl_obj_layout **plo)
+{
+	struct ds_pool		*pool;
+	struct pl_obj_layout	*layout = NULL;
+	struct pool_target	*target;
+	struct daos_obj_md	 md = { 0 };
+	d_rank_t		 leader;
+	d_rank_t		 myrank;
+	int			 rc = 0;
+
+	pool = ds_pool_lookup(pool_uuid);
+	if (pool == NULL)
+		return -DER_INVAL;
+
+	md.omd_id = oid->id_pub;
+	md.omd_ver = version;
+	rc = pl_obj_place(pool->sp_pl_map, &md, NULL, &layout);
+	if (rc != 0)
+		goto out;
+
+	rc = ds_pool_select_leader_target(layout, oid, &leader);
+	if (rc != 0)
+		goto out;
+
+	rc = pool_map_find_target(pool->sp_map, leader, &target);
+	if (rc != 1)
+		D_GOTO(out, rc = -DER_INVAL);
+
+	crt_group_rank(NULL, &myrank);
+	if (myrank != target->ta_comp.co_rank) {
+		rc = 0;
+	} else {
+		if (plo != NULL)
+			*plo = layout;
+		rc = 1;
+	}
+
+out:
+	if (rc <= 0 && layout != NULL)
+		pl_obj_layout_free(layout);
+	ds_pool_put(pool);
+	return rc;
 }

--- a/src/pool/srv_target.c
+++ b/src/pool/srv_target.c
@@ -220,8 +220,16 @@ pool_alloc_ref(void *key, unsigned int ksize, void *varg,
 	uuid_copy(pool->sp_uuid, key);
 	pool->sp_map_version = arg->pca_map_version;
 
-	if (arg->pca_map != NULL)
+	if (arg->pca_map != NULL) {
+		rc = ds_pool_create_pl_map(pool, arg->pca_map);
+		if (rc != 0) {
+			D_ERROR(DF_UUID": failed to create pl_map: %d\n",
+				DP_UUID(key), rc);
+			D_GOTO(err_lock, rc);
+		}
+
 		pool->sp_map = arg->pca_map;
+	}
 
 	collective_arg.pla_uuid = key;
 	collective_arg.pla_map_version = arg->pca_map_version;
@@ -254,6 +262,7 @@ err_collective:
 err_lock:
 	ABT_rwlock_free(&pool->sp_lock);
 err_pool:
+	ds_pool_destroy_pl_map(pool);
 	D_FREE(pool);
 err:
 	return rc;
@@ -289,8 +298,10 @@ pool_free_ref(struct daos_llink *llink)
 		D_ERROR(DF_UUID": failed to delete ES pool caches: %d\n",
 			DP_UUID(pool->sp_uuid), rc);
 
-	if (pool->sp_map != NULL)
+	if (pool->sp_map != NULL) {
+		ds_pool_destroy_pl_map(pool);
 		pool_map_decref(pool->sp_map);
+	}
 
 	ABT_rwlock_free(&pool->sp_lock);
 	D_FREE(pool);
@@ -638,12 +649,13 @@ pool_tgt_query(struct ds_pool *pool, struct daos_pool_space *ps)
 void
 ds_pool_tgt_connect_handler(crt_rpc_t *rpc)
 {
-	struct pool_tgt_connect_in     *in = crt_req_get(rpc);
-	struct pool_tgt_connect_out    *out = crt_reply_get(rpc);
-	struct ds_pool		       *pool;
-	struct ds_pool_hdl	       *hdl;
-	struct ds_pool_create_arg	arg;
-	int				rc;
+	struct pool_tgt_connect_in	*in = crt_req_get(rpc);
+	struct pool_tgt_connect_out	*out = crt_reply_get(rpc);
+	struct pool_map			*map = NULL;
+	struct ds_pool			*pool;
+	struct ds_pool_hdl		*hdl;
+	struct ds_pool_create_arg	 arg;
+	int				 rc;
 
 	D_DEBUG(DF_DSMS, DF_UUID": handling rpc %p: hdl="DF_UUID"\n",
 		DP_UUID(in->tci_uuid), rpc, DP_UUID(in->tci_hdl));
@@ -671,7 +683,33 @@ ds_pool_tgt_connect_handler(crt_rpc_t *rpc)
 	if (hdl == NULL)
 		D_GOTO(out, rc = -DER_NOMEM);
 
-	arg.pca_map = NULL;
+	/* Init the pool map */
+	if (rpc->cr_co_bulk_hdl != NULL) {
+		struct pool_buf		*buf;
+		daos_iov_t		 iov = { 0 };
+		daos_sg_list_t		 sgl;
+
+		sgl.sg_nr = 1;
+		sgl.sg_nr_out = 1;
+		sgl.sg_iovs = &iov;
+		rc = crt_bulk_access(rpc->cr_co_bulk_hdl, daos2crt_sg(&sgl));
+		if (rc != 0) {
+			D_ERROR(DF_UUID": crt_bulk_access failed, rc %d.\n",
+				DP_UUID(in->tci_uuid), rc);
+			D_GOTO(out, rc);
+		}
+
+		buf = iov.iov_buf;
+		D_ASSERT(buf != NULL);
+		rc = pool_map_create(buf, in->tci_map_version, &map);
+		if (rc != 0) {
+			D_ERROR(DF_UUID" failed to create pool map: %d\n",
+				DP_UUID(in->tci_uuid), rc);
+			D_GOTO(out, rc);
+		}
+	}
+
+	arg.pca_map = map;
 	arg.pca_map_version = in->tci_map_version;
 	arg.pca_need_group = 0;
 
@@ -703,6 +741,9 @@ ds_pool_tgt_connect_handler(crt_rpc_t *rpc)
 
 	rc = pool_tgt_query(pool, &out->tco_space);
 out:
+	if (rc != 0 && map != NULL)
+		pool_map_decref(map);
+
 	out->tco_rc = (rc == 0 ? 0 : 1);
 	D_DEBUG(DF_DSMS, DF_UUID": replying rpc %p: %d (%d)\n",
 		DP_UUID(in->tci_uuid), rpc, out->tco_rc, rc);
@@ -819,6 +860,14 @@ ds_pool_tgt_map_update(struct ds_pool *pool, struct pool_buf *buf,
 		if (map != NULL) {
 			struct pool_map *tmp = pool->sp_map;
 
+			rc = ds_pool_create_pl_map(pool, map);
+			if (rc != 0) {
+				D_ERROR(DF_UUID
+					": failed to create pl_map: %d\n",
+					DP_UUID(pool->sp_uuid), rc);
+				D_GOTO(out, rc);
+			}
+
 			pool->sp_map = map;
 			map = tmp;
 		}
@@ -835,6 +884,13 @@ ds_pool_tgt_map_update(struct ds_pool *pool, struct pool_buf *buf,
 		   pool_map_get_version(pool->sp_map) < map_version &&
 		   map != NULL) {
 		struct pool_map *tmp = pool->sp_map;
+
+		rc = ds_pool_create_pl_map(pool, map);
+		if (rc != 0) {
+			D_ERROR(DF_UUID": failed to create pl_map: %d\n",
+				DP_UUID(pool->sp_uuid), rc);
+			D_GOTO(out, rc);
+		}
 
 		/* drop the stale map */
 		pool->sp_map = map;

--- a/src/rdb/rdb_rpc.c
+++ b/src/rdb/rdb_rpc.c
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2017-2018 Intel Corporation.
+ * (C) Copyright 2017-2019 Intel Corporation.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -231,7 +231,7 @@ crt_proc_daos_anchor_t(crt_proc_t proc, daos_anchor_t *p)
 	rc = crt_proc_uint16_t(proc, &p->da_shard);
 	if (rc != 0)
 		return -DER_HG;
-	rc = crt_proc_uint32_t(proc, &p->da_padding);
+	rc = crt_proc_uint32_t(proc, &p->da_flags);
 	if (rc != 0)
 		return -DER_HG;
 	rc = crt_proc_memcpy(proc, &p->da_buf, sizeof(p->da_buf));

--- a/src/vos/SConscript
+++ b/src/vos/SConscript
@@ -5,7 +5,7 @@ import daos_build
 FILES = ["evt_iter.c", "vos_common.c", "vos_iterator.c", "vos_obj.c",
          "vos_pool.c", "vos_aggregate.c", "vos_container.c", "vos_io.c",
          "vos_obj_cache.c", "vos_obj_index.c", "vos_tree.c", "evtree.c",
-         "vos_dtx.c", "vos_query.c"]
+         "vos_dtx.c", "vos_dtx_cos.c", "vos_query.c"]
 
 def build_vos(env, standalone):
     """build vos"""

--- a/src/vos/vos_common.c
+++ b/src/vos/vos_common.c
@@ -35,6 +35,13 @@
 #include <daos/lru.h>
 #include <daos/btree_class.h>
 
+/**
+ * The vos_start_time records the timestamp when server starts the serive.
+ * Via comparing with the DTX entry's timestamp, we can know whether
+ * the DTX happened before the server restarting its service or not.
+ */
+double vos_start_time;
+
 static pthread_mutex_t	mutex = PTHREAD_MUTEX_INITIALIZER;
 /**
  * Object cache based on mode of instantiation
@@ -367,6 +374,7 @@ vos_init(void)
 	if (rc)
 		D_GOTO(exit, rc);
 
+	vos_start_time = ABT_get_wtime();
 	is_init = 1;
 exit:
 	D_MUTEX_UNLOCK(&mutex);

--- a/src/vos/vos_common.c
+++ b/src/vos/vos_common.c
@@ -228,6 +228,12 @@ vos_mod_init(void)
 		return rc;
 	}
 
+	rc = vos_dtx_cos_register();
+	if (rc != 0) {
+		D_ERROR("DTX CoS btree initialization error\n");
+		return rc;
+	}
+
 	/**
 	 * Registering the class for OI btree
 	 * and KV btree

--- a/src/vos/vos_container.c
+++ b/src/vos/vos_container.c
@@ -362,6 +362,7 @@ vos_cont_open(daos_handle_t poh, uuid_t co_uuid, daos_handle_t *coh)
 	cont->vc_dtx_cos_hdl = DAOS_HDL_INVAL;
 	D_INIT_LIST_HEAD(&cont->vc_dtx_committable);
 	cont->vc_dtx_committable_count = 0;
+	cont->vc_dtx_time_last_commit = ABT_get_wtime();
 
 	/* Cache this btr object ID in container handle */
 	rc = dbtree_open_inplace_ex(&cont->vc_otab_df->obt_btr,

--- a/src/vos/vos_dtx.c
+++ b/src/vos/vos_dtx.c
@@ -31,6 +31,19 @@
 #include "vos_layout.h"
 #include "vos_internal.h"
 
+#define DTX_RETURN_INPROGRESS(dtx, pos)					 \
+do {									 \
+	if ((dtx) != NULL)						 \
+		D_DEBUG(DB_TRACE, "Hit uncommitted DTX "DF_DTI		 \
+			" with state %u, time %lu at %d\n",		 \
+			DP_DTI(&(dtx)->te_xid), (dtx)->te_state,	 \
+			(dtx)->te_sec, (pos));				 \
+	else								 \
+		D_DEBUG(DB_TRACE, "Hit uncommitted DTX at %d\n", (pos)); \
+									 \
+	return -DER_INPROGRESS;						 \
+} while (0)
+
 struct dtx_rec_bundle {
 	umem_id_t	trb_ummid;
 };
@@ -589,6 +602,66 @@ vos_dtx_abort_one(struct vos_container *cont, struct daos_tx_id *dti,
 		rc = 0;
 
 	return rc;
+}
+
+int
+vos_dtx_handle_resend(daos_handle_t coh, struct daos_tx_id *dti)
+{
+	struct vos_container	*cont;
+	struct vos_dtx_entry_df	*dtx;
+	daos_iov_t		 kiov;
+	daos_iov_t		 riov;
+	int			 rc;
+
+	cont = vos_hdl2cont(coh);
+	D_ASSERT(cont != NULL);
+
+	daos_iov_set(&kiov, dti, sizeof(*dti));
+	daos_iov_set(&riov, NULL, 0);
+	rc = dbtree_lookup(cont->vc_dtx_active_hdl, &kiov, &riov);
+	if (rc == -DER_NONEXIST)
+		rc = dbtree_lookup(cont->vc_dtx_committed_hdl, &kiov, &riov);
+
+	if (rc == -DER_NONEXIST) {
+		/* If the resent RPC is too old, then we cannot know whether
+		 * the RPC has ever been executed before or not. Then return
+		 * -DER_TIMEDOUT to the RPC sponsor. Means that modification
+		 * for such RPC may have been executed, but nobody guarantee
+		 * that. It is the caller's duty to check related record(s).
+		 */
+		if ((uint64_t)ABT_get_wtime() - dti->dti_sec >
+		    DTX_AGGREGATION_THRESHOLD_TIME) {
+			D_DEBUG(DB_IO, "Not sure about whether the RPC "
+				DF_DTI" is resend or not.\n", DP_DTI(dti));
+			return -DER_TIMEDOUT;
+		}
+	}
+
+	if (rc != 0)
+		return rc;
+
+	dtx = (struct vos_dtx_entry_df *)riov.iov_buf;
+	switch (dtx->te_state) {
+	case DTX_ST_INIT:
+		/* New DTX after the leader (re)start that is not
+		 * completed yet, retry related RPC some time later.
+		 */
+		if (dtx->te_sec >= (uint64_t)vos_start_time)
+			DTX_RETURN_INPROGRESS(dtx, 1);
+
+		/* The INIT DTX in PRAM must be for an in-update object/key
+		 * that was waiting for the bulk transfer (or remote abort)
+		 * before the VOS restart. So here, it should be the case
+		 * that client resends RPC after server restart.
+		 */
+		return 0;
+	case DTX_ST_PREPARED:
+		return 0;
+	case DTX_ST_COMMITTED:
+		return -DER_ALREADY;
+	default:
+		return -DER_INVAL;
+	}
 }
 
 int

--- a/src/vos/vos_dtx.c
+++ b/src/vos/vos_dtx.c
@@ -219,3 +219,603 @@ vos_dtx_table_destroy(struct vos_pool *pool, struct vos_dtx_table_df *dtab_df)
 
 	return rc;
 }
+
+static int
+dtx_rec_release(struct umem_instance *umm, umem_id_t ummid,
+		bool abort, bool destroy)
+{
+	struct vos_dtx_entry_df		*dtx;
+
+	dtx = umem_id2ptr(umm, ummid);
+	/* The caller has started the PMDK transaction. */
+	umem_tx_add_ptr(umm, dtx, sizeof(*dtx));
+
+	while (!UMMID_IS_NULL(dtx->te_records)) {
+		umem_id_t			 rec_mmid = dtx->te_records;
+		struct vos_dtx_record_df	*rec;
+
+		rec = umem_id2ptr(umm, rec_mmid);
+		switch (rec->tr_type) {
+		case DTX_RT_OBJ: {
+			struct vos_obj_df	*obj;
+
+			obj = umem_id2ptr(umm, rec->tr_record);
+			umem_tx_add_ptr(umm, obj, sizeof(*obj));
+			obj->vo_dtx_shares--;
+
+			/* Other DTX that shares the object has committed. */
+			if (UMMID_IS_NULL(obj->vo_dtx)) {
+				if (dtx->te_epoch > obj->vo_latest)
+					obj->vo_latest = dtx->te_epoch;
+				if (dtx->te_epoch < obj->vo_earliest)
+					obj->vo_earliest = dtx->te_epoch;
+
+				break;
+			}
+
+			/* commit case */
+			if (!abort) {
+				obj->vo_dtx = UMMID_NULL;
+				obj->vo_latest = dtx->te_epoch;
+				obj->vo_earliest = dtx->te_epoch;
+				break;
+			}
+
+			/* The last shared DTX is aborted. */
+			if (obj->vo_dtx_shares == 0) {
+				obj->vo_dtx = DTX_UMMID_ABORTED;
+				break;
+			}
+
+			/* I am not the original DTX that create the object. */
+			if (!umem_id_equal(umm, obj->vo_dtx, ummid))
+				break;
+
+			/* I am the original DTX that create the object that
+			 * is still shared by others. Now, I will be aborted,
+			 * set the reference as UNKNOWN for other left shares.
+			 */
+			obj->vo_dtx = DTX_UMMID_UNKNOWN;
+			break;
+		}
+		case DTX_RT_KEY: {
+			struct vos_krec_df	*key;
+
+			key = umem_id2ptr(umm, rec->tr_record);
+			umem_tx_add_ptr(umm, key, sizeof(*key));
+			key->kr_dtx_shares--;
+
+			if (UMMID_IS_NULL(key->kr_dtx)) {
+				/* The exchange_src has been committed.
+				 * I am the exchange_tgt, do nothing.
+				 */
+				if (rec->tr_flags == DTX_RF_EXCHANGE_TGT)
+					break;
+
+				/* Other DTX that shares the key has
+				 * committed, must be for sharing of
+				 * update cases.
+				 */
+				if (dtx->te_epoch > key->kr_latest)
+					key->kr_latest = dtx->te_epoch;
+				if (dtx->te_epoch < key->kr_earliest)
+					key->kr_earliest = dtx->te_epoch;
+
+				break;
+			}
+
+			/* commit case */
+			if (!abort) {
+				key->kr_dtx = UMMID_NULL;
+				key->kr_latest = dtx->te_epoch;
+				if (rec->tr_flags != DTX_RF_EXCHANGE_SRC &&
+				    rec->tr_flags != DTX_RF_EXCHANGE_TGT)
+					key->kr_earliest = dtx->te_epoch;
+
+				goto exchange;
+			}
+
+			/* The last shared DTX is aborted. */
+			if (key->kr_dtx_shares == 0) {
+				key->kr_dtx = DTX_UMMID_ABORTED;
+				goto exchange;
+			}
+
+			/* I am not the original DTX that create the key. */
+			if (!umem_id_equal(umm, key->kr_dtx, ummid))
+				goto exchange;
+
+			/* I am the original DTX that create the key that
+			 * is still shared by others. Now, I will be aborted,
+			 * set the reference as UNKNOWN for other left shares.
+			 */
+			key->kr_dtx = DTX_UMMID_UNKNOWN;
+
+exchange:
+			if (rec->tr_flags != DTX_RF_EXCHANGE_SRC)
+				break;
+
+			D_ASSERT(key->kr_flags & VKF_DELETED);
+
+			if (!abort) { /* commit case */
+				struct vos_dtx_record_df	*tgt_rec;
+				struct vos_krec_df		*tgt_key;
+				struct btr_root			 tmp_btr;
+				daos_epoch_t			 tmp_epoch;
+
+				/*
+				 * XXX: If the exchange target still exist,
+				 *	it will be the next record. If it does
+				 *	not exist, then either it is crashed
+				 *	or it has already degistered from the
+				 *	DTX records list. We cannot commit the
+				 *	DTX under any the two cases. Failing
+				 *	the DTX commit is meaningless, then we
+				 *	have to give some warning message.
+				 */
+				if (UMMID_IS_NULL(rec->tr_next)) {
+					D_ERROR(DF_UOID" miss the DTX ("DF_DTI
+						") exchange pairs (1)\n",
+						DP_UOID(dtx->te_oid),
+						DP_DTI(&dtx->te_xid));
+					break;
+				}
+
+				tgt_rec = umem_id2ptr(umm, rec->tr_next);
+				if (tgt_rec->tr_flags != DTX_RF_EXCHANGE_TGT) {
+					D_ERROR(DF_UOID" miss the DTX ("DF_DTI
+						") exchange pairs (2)\n",
+						DP_UOID(dtx->te_oid),
+						DP_DTI(&dtx->te_xid));
+					break;
+				}
+
+				/* Exchange the sub-tree between max epoch
+				 * record and the give epoch record. The
+				 * record with max epoch will be removed
+				 * when aggregation.
+				 */
+				tgt_key = umem_id2ptr(umm, tgt_rec->tr_record);
+				umem_tx_add_ptr(umm, tgt_key, sizeof(*tgt_key));
+
+				tmp_btr = key->kr_btr;
+				key->kr_btr = tgt_key->kr_btr;
+				tgt_key->kr_btr = tmp_btr;
+
+				if (key->kr_bmap & KREC_BF_EVT) {
+					struct evt_root		tmp_evt;
+
+					umem_tx_add_ptr(umm, &key->kr_evt[0],
+							sizeof(key->kr_evt[0]));
+					umem_tx_add_ptr(umm,
+						&tgt_key->kr_evt[0],
+						sizeof(tgt_key->kr_evt[0]));
+
+					tmp_evt = key->kr_evt[0];
+					key->kr_evt[0] = tgt_key->kr_evt[0];
+					tgt_key->kr_evt[0] = tmp_evt;
+				}
+
+				tmp_epoch = key->kr_earliest;
+				key->kr_earliest = tgt_key->kr_earliest;
+				tgt_key->kr_earliest = tmp_epoch;
+
+				D_DEBUG(DB_TRACE, "Exchanged DTX records for "
+					DF_DTI"\n", DP_DTI(&dtx->te_xid));
+			} else { /* abort case */
+				/* Recover the visibility of the exchange source
+				 * for the DTX abort case.
+				 */
+				key->kr_flags &= ~VKF_DELETED;
+				key->kr_dtx = UMMID_NULL;
+			}
+			break;
+		}
+		case DTX_RT_SVT: {
+			struct vos_irec_df	*svt;
+
+			svt = umem_id2ptr(umm, rec->tr_record);
+			umem_tx_add_ptr(umm, svt, sizeof(*svt));
+			if (abort)
+				svt->ir_dtx = DTX_UMMID_ABORTED;
+			else
+				svt->ir_dtx = UMMID_NULL;
+			break;
+		}
+		case DTX_RT_EVT: {
+			struct evt_desc		*evt;
+
+			evt = umem_id2ptr(umm, rec->tr_record);
+			umem_tx_add_ptr(umm, evt, sizeof(*evt));
+			if (abort)
+				evt->dc_dtx = DTX_UMMID_ABORTED;
+			else
+				evt->dc_dtx = UMMID_NULL;
+			break;
+		}
+		default:
+			D_ERROR(DF_UOID" unknown DTX "DF_DTI" type %u\n",
+				DP_UOID(dtx->te_oid), DP_DTI(&dtx->te_xid),
+				rec->tr_type);
+			break;
+		}
+
+		dtx->te_records = rec->tr_next;
+		umem_tx_add_ptr(umm, rec, sizeof(*rec));
+		umem_free(umm, rec_mmid);
+	}
+
+	D_DEBUG(DB_TRACE, "dtx_rec_release: %s/%s the DTX "DF_DTI"\n",
+		abort ? "abort" : "commit", destroy ? "destroy" : "keep",
+		DP_DTI(&dtx->te_xid));
+
+	if (destroy)
+		umem_free(umm, ummid);
+	else
+		dtx->te_flags &= ~(DTX_EF_EXCHANGE_PENDING  | DTX_EF_SHARES);
+
+	return 0;
+}
+
+static void
+vos_dtx_unlink_entry(struct umem_instance *umm, struct vos_dtx_table_df *tab,
+		     struct vos_dtx_entry_df *dtx)
+{
+	struct vos_dtx_entry_df	*ent;
+
+	if (UMMID_IS_NULL(dtx->te_next)) { /* The tail of the DTXs list. */
+		if (UMMID_IS_NULL(dtx->te_prev)) { /* The unique one on list. */
+			tab->tt_entry_head = UMMID_NULL;
+			tab->tt_entry_tail = UMMID_NULL;
+		} else {
+			ent = umem_id2ptr(umm, dtx->te_prev);
+			umem_tx_add_ptr(umm, ent, sizeof(*ent));
+
+			ent->te_next = UMMID_NULL;
+			tab->tt_entry_tail = dtx->te_prev;
+			dtx->te_prev = UMMID_NULL;
+		}
+	} else if (UMMID_IS_NULL(dtx->te_prev)) { /* The head of DTXs list */
+		ent = umem_id2ptr(umm, dtx->te_next);
+		umem_tx_add_ptr(umm, ent, sizeof(*ent));
+
+		ent->te_prev = UMMID_NULL;
+		tab->tt_entry_head = dtx->te_next;
+		dtx->te_next = UMMID_NULL;
+	} else {
+		ent = umem_id2ptr(umm, dtx->te_next);
+		umem_tx_add_ptr(umm, ent, sizeof(*ent));
+		ent->te_prev = dtx->te_prev;
+
+		ent = umem_id2ptr(umm, dtx->te_prev);
+		umem_tx_add_ptr(umm, ent, sizeof(*ent));
+		ent->te_next = dtx->te_next;
+
+		dtx->te_prev = UMMID_NULL;
+		dtx->te_next = UMMID_NULL;
+	}
+}
+
+static int
+vos_dtx_commit_one(struct vos_container *cont, struct daos_tx_id *dti)
+{
+	struct umem_instance	*umm;
+	daos_iov_t		 kiov;
+	daos_iov_t		 riov;
+	umem_id_t		 ummid;
+	int			 rc = 0;
+
+	umm = &cont->vc_pool->vp_umm;
+	daos_iov_set(&kiov, dti, sizeof(*dti));
+	rc = dbtree_delete(cont->vc_dtx_active_hdl, &kiov, &ummid);
+	if (rc == 0) {
+		struct vos_dtx_entry_df		*dtx;
+		struct vos_dtx_entry_df		*ent;
+		struct dtx_rec_bundle		 rbund;
+
+		dtx = umem_id2ptr(umm, ummid);
+		umem_tx_add_ptr(umm, dtx, sizeof(*dtx));
+		dtx->te_state = DTX_ST_COMMITTED;
+
+		if (dtx->te_dkey_hash[0] != 0)
+			vos_dtx_del_cos(cont, &dtx->te_oid, dti,
+					dtx->te_dkey_hash[0],
+					dtx->te_intent == DAOS_INTENT_PUNCH ?
+					true : false);
+
+		rbund.trb_ummid = ummid;
+		daos_iov_set(&riov, &rbund, sizeof(rbund));
+		rc = dbtree_upsert(cont->vc_dtx_committed_hdl,
+				BTR_PROBE_EQ, DAOS_INTENT_UPDATE, &kiov, &riov);
+		if (rc == 0) {
+			struct vos_dtx_table_df	*tab;
+
+			tab = &cont->vc_cont_df->cd_dtx_table_df;
+			umem_tx_add_ptr(umm, tab, sizeof(*tab));
+
+			tab->tt_count++;
+			if (UMMID_IS_NULL(tab->tt_entry_tail)) {
+				D_ASSERT(UMMID_IS_NULL(tab->tt_entry_head));
+
+				tab->tt_entry_head = ummid;
+				tab->tt_entry_tail = tab->tt_entry_head;
+			} else {
+				ent = umem_id2ptr(umm, tab->tt_entry_tail);
+				umem_tx_add_ptr(umm, ent, sizeof(*ent));
+
+				ent->te_next = ummid;
+				dtx->te_prev = tab->tt_entry_tail;
+				tab->tt_entry_tail = ent->te_next;
+			}
+
+			/* If there are pending exchange of records, then we
+			 * need some additional work when commit, such as
+			 * exchange the subtree under the source and target
+			 * records, then related subtree can be exported
+			 * correctly. That will be done when release related
+			 * vos_dth_record_df(s) attached to the DTX.
+			 */
+			if (dtx->te_flags &
+			    (DTX_EF_EXCHANGE_PENDING | DTX_EF_SHARES))
+				rc = dtx_rec_release(umm, ummid, false, false);
+		}
+	} else if (rc == -DER_NONEXIST) {
+		daos_iov_set(&riov, NULL, 0);
+		rc = dbtree_lookup(cont->vc_dtx_committed_hdl, &kiov, &riov);
+	}
+
+	D_DEBUG(DB_TRACE, "Commit the DTX "DF_DTI": rc = %d\n",
+		DP_DTI(dti), rc);
+
+	return rc;
+}
+
+static int
+vos_dtx_abort_one(struct vos_container *cont, struct daos_tx_id *dti,
+		  bool force)
+{
+	daos_iov_t	 kiov;
+	umem_id_t	 dtx;
+	int		 rc;
+
+	daos_iov_set(&kiov, dti, sizeof(*dti));
+	rc = dbtree_delete(cont->vc_dtx_active_hdl, &kiov, &dtx);
+	if (rc == 0)
+		rc = dtx_rec_release(&cont->vc_pool->vp_umm, dtx, true, true);
+
+	D_DEBUG(DB_TRACE, "Abort the DTX "DF_DTI": rc = %d\n", DP_DTI(dti), rc);
+
+	if (rc != 0 && force)
+		rc = 0;
+
+	return rc;
+}
+
+int
+vos_dtx_begin(struct daos_tx_id *dti, daos_unit_oid_t *oid, daos_key_t *dkey,
+	      daos_handle_t coh, daos_epoch_t epoch, uint32_t pm_ver,
+	      uint32_t intent, uint32_t flags, struct daos_tx_handle **dtx)
+{
+	struct daos_tx_handle	*th;
+
+	D_ALLOC_PTR(th);
+	if (th == NULL)
+		return -DER_NOMEM;
+
+	th->dth_xid = *dti;
+	th->dth_oid = *oid;
+	th->dth_dkey = dkey;
+	th->dth_coh = coh;
+	th->dth_epoch = epoch;
+	D_INIT_LIST_HEAD(&th->dth_shares);
+	th->dth_ver = pm_ver;
+	th->dth_intent = intent;
+	th->dth_flags = flags;
+	th->dth_sync = 0;
+	th->dth_non_rep = 0;
+	th->dth_ent = UMMID_NULL;
+
+	*dtx = th;
+	D_DEBUG(DB_TRACE, "Start the DTX "DF_DTI"\n", DP_DTI(dti));
+
+	return 0;
+}
+
+int
+vos_dtx_end(struct daos_tx_handle *dth, int result, bool leader)
+{
+	struct vos_container	*cont;
+	struct vos_dtx_table_df	*tab;
+	double			 now = ABT_get_wtime();
+	int			 rc = 0;
+
+	if (result < 0)
+		D_GOTO(out, rc = result);
+
+	cont = vos_hdl2cont(dth->dth_coh);
+	D_ASSERT(cont != NULL);
+
+	if (leader) {
+		if (dth->dth_sync)
+			D_GOTO(out, rc = 3);
+
+		if (cont->vc_dtx_committable_count > DTX_THRESHOLD_COUNT)
+			D_GOTO(out, rc = 2);
+
+		if ((uint64_t)now - cont->vc_dtx_time_last_commit >
+		     DTX_COMMIT_THRESHOLD_TIME)
+			D_GOTO(out, rc = 2);
+	}
+
+	tab = &cont->vc_cont_df->cd_dtx_table_df;
+	if (tab->tt_count > DTX_AGGREGATION_THRESHOLD_COUNT)
+		D_GOTO(out, rc = 1);
+
+	if ((uint64_t)now - tab->tt_time_last_shrink >
+	    DTX_AGGREGATION_THRESHOLD_TIME)
+		D_GOTO(out, rc = 1);
+
+out:
+	D_DEBUG(DB_TRACE,
+		"Stop the DTX "DF_DTI" ver = %u, %s, %s, %s: rc = %d\n",
+		DP_DTI(&dth->dth_xid), dth->dth_ver,
+		dth->dth_sync ? "sync" : "async",
+		dth->dth_non_rep ? "non-replicated" : "replicated",
+		dth->dth_leader ? "leader" : "non-leader", rc);
+	D_FREE_PTR(dth);
+	return rc;
+}
+
+int
+vos_dtx_check_committable(daos_handle_t coh, struct daos_tx_id *dti)
+{
+	struct vos_container	*cont;
+	daos_iov_t		 kiov;
+	daos_iov_t		 riov;
+	int			 rc = 0;
+
+	cont = vos_hdl2cont(coh);
+	D_ASSERT(cont != NULL);
+
+	daos_iov_set(&kiov, dti, sizeof(*dti));
+	daos_iov_set(&riov, NULL, 0);
+	rc = dbtree_lookup(cont->vc_dtx_active_hdl, &kiov, &riov);
+	if (rc == 0) {
+		struct vos_dtx_entry_df	*dtx;
+
+		dtx = (struct vos_dtx_entry_df *)riov.iov_buf;
+		return dtx->te_state;
+	}
+
+	if (rc == -DER_NONEXIST) {
+		rc = dbtree_lookup(cont->vc_dtx_committed_hdl, &kiov, &riov);
+		if (rc == 0)
+			return DTX_ST_COMMITTED;
+	}
+
+	if (rc == -DER_NONEXIST)
+		return DTX_ST_INIT;
+
+	return rc;
+}
+
+int
+vos_dtx_commit(daos_handle_t coh, struct daos_tx_id *dti, int count)
+{
+	struct vos_container	*cont;
+	struct umem_instance	*umm;
+	int			 i;
+	int			 rc = 0;
+
+	cont = vos_hdl2cont(coh);
+	D_ASSERT(cont != NULL);
+
+	umm = &cont->vc_pool->vp_umm;
+	/* Commit multiple DTXs via single PMDK transaction. */
+	rc = umem_tx_begin(umm, vos_txd_get());
+	if (rc == 0) {
+		for (i = 0; i < count; i++)
+			vos_dtx_commit_one(cont, &dti[i]);
+
+		cont->vc_dtx_time_last_commit = ABT_get_wtime();
+		umem_tx_commit(umm);
+	}
+
+	return rc;
+}
+
+int
+vos_dtx_abort(daos_handle_t coh, struct daos_tx_id *dti, int count, bool force)
+{
+	struct vos_container	*cont;
+	struct umem_instance	*umm;
+	int			 rc;
+	int			 i;
+
+	cont = vos_hdl2cont(coh);
+	D_ASSERT(cont != NULL);
+
+	umm = &cont->vc_pool->vp_umm;
+	/* Abort multiple DTXs via single PMDK transaction. */
+	rc = umem_tx_begin(umm, vos_txd_get());
+	for (i = 0; rc == 0 && i < count; i++)
+		rc = vos_dtx_abort_one(cont, &dti[i], force);
+
+	if (rc == 0)
+		umem_tx_commit(umm);
+	else
+		umem_tx_abort(umm, rc);
+
+	return rc;
+}
+
+void
+vos_dtx_aggregate(daos_handle_t coh, uint64_t max, uint64_t age)
+{
+	struct vos_container		*cont;
+	struct umem_instance		*umm;
+	struct vos_dtx_table_df		*tab;
+	umem_id_t			 dtx_mmid;
+	daos_iov_t			 kiov;
+	uint64_t			 count;
+	double				 now;
+	int				 rc = 0;
+	bool				 stop = false;
+
+	if (max == 0)
+		max = DTX_AGGREGATION_THRESHOLD_COUNT;
+
+	now = ABT_get_wtime();
+	if (age == 0)
+		age = now - DTX_AGGREGATION_THRESHOLD_TIME;
+	else if (age != (uint64_t)(-1))
+		age = now - age;
+
+	cont = vos_hdl2cont(coh);
+	D_ASSERT(cont != NULL);
+
+	umm = &cont->vc_pool->vp_umm;
+	tab = &cont->vc_cont_df->cd_dtx_table_df;
+
+	for (count = 0, dtx_mmid = tab->tt_entry_head;
+	     count < max && !UMMID_IS_NULL(dtx_mmid);) {
+		int	i;
+
+		rc = umem_tx_begin(umm, vos_txd_get());
+		if (rc != 0)
+			return;
+
+		umem_tx_add_ptr(umm, tab, sizeof(*tab));
+		for (i = 0; i < DTX_AGGREGATION_YIELD_INTERVAL &&
+		     !UMMID_IS_NULL(dtx_mmid) && count < max; i++, count++) {
+			struct vos_dtx_entry_df	*dtx;
+			umem_id_t		 ummid;
+
+			dtx = umem_id2ptr(umm, dtx_mmid);
+			if (dtx->te_sec > age) {
+				stop = true;
+				break;
+			}
+
+			umem_tx_add_ptr(umm, dtx, sizeof(*dtx));
+			daos_iov_set(&kiov, &dtx->te_xid, sizeof(dtx->te_xid));
+			rc = dbtree_delete(cont->vc_dtx_committed_hdl, &kiov,
+					   &ummid);
+			D_ASSERT(rc == 0);
+
+			tab->tt_count--;
+			dtx_mmid = dtx->te_next;
+			vos_dtx_unlink_entry(umm, tab, dtx);
+			dtx_rec_release(umm, ummid, false, true);
+		}
+
+		tab->tt_time_last_shrink = now;
+		umem_tx_commit(umm);
+
+		if (stop)
+			return;
+
+		/* Yield per DTX_AGGREGATION_YIELD_INTERVAL. */
+		ABT_thread_yield();
+	}
+}

--- a/src/vos/vos_dtx_cos.c
+++ b/src/vos/vos_dtx_cos.c
@@ -1,0 +1,481 @@
+/**
+ * (C) Copyright 2019 Intel Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * GOVERNMENT LICENSE RIGHTS-OPEN SOURCE SOFTWARE
+ * The Government's rights to use, modify, reproduce, release, perform, display,
+ * or disclose this software are subject to the terms of the Apache License as
+ * provided in Contract No. B609815.
+ * Any reproduction of computer software, computer software documentation, or
+ * portions thereof marked with this legend must also reproduce the markings.
+ */
+/**
+ * This file is part of daos two-phase commit transaction.
+ *
+ * vos/vos_dtx_cos.c
+ */
+#define D_LOGFAC	DD_FAC(vos)
+
+#include <daos/btree.h>
+#include "vos_layout.h"
+#include "vos_internal.h"
+
+/* The record for the DTX CoS B+tree in DRAM. Each record contains current
+ * committable DTXs that modify (update or punch) something under the same
+ * object and the same dkey.
+ */
+struct dtx_cos_rec {
+	daos_unit_oid_t		 dcr_oid;
+	/* The list in DRAM for the DTXs that modify the same object/dkey.
+	 * Per-dkey based.
+	 */
+	d_list_t		 dcr_update_list;
+	d_list_t		 dcr_punch_list;
+	/* The number of the UPDATE DTXs in the dcr_update_list. */
+	int			 dcr_update_count;
+	/* The number of the PUNCH DTXs in the dcr_punch_list. */
+	int			 dcr_punch_count;
+	/* Pointer to the container. */
+	struct vos_container	*dcr_cont;
+};
+
+/* Above dtx_cos_rec is consisted of a series of dtx_cos_rec_child uints.
+ * Each dtx_cos_rec_child contains one DTX that modifies something under
+ * related object and dkey (that attached to the dtx_cos_rec).
+ */
+struct dtx_cos_rec_child {
+	/* Link into the container::vc_dtx_committable. */
+	d_list_t		 dcrc_committable;
+	/* Link into related dcr_{update,punch}_list. */
+	d_list_t		 dcrc_link;
+	/* The DTX identifier. */
+	struct daos_tx_id	 dcrc_dti;
+	/* Pointer to the dtx_cos_rec. */
+	struct dtx_cos_rec	*dcrc_ptr;
+};
+
+struct dtx_cos_rec_bundle {
+	struct vos_container	*cont;
+	struct daos_tx_id	*dti;
+	bool			 punch;
+};
+
+struct dtx_cos_key {
+	daos_unit_oid_t		 oid;
+	uint64_t		 dkey;
+};
+
+static int
+dtx_cos_hkey_size(struct btr_instance *tins)
+{
+	return sizeof(struct dtx_cos_key);
+}
+
+static void
+dtx_cos_hkey_gen(struct btr_instance *tins, daos_iov_t *key_iov, void *hkey)
+{
+	D_ASSERT(key_iov->iov_len == sizeof(struct dtx_cos_key));
+
+	memcpy(hkey, key_iov->iov_buf, key_iov->iov_len);
+}
+
+static int
+dtx_cos_hkey_cmp(struct btr_instance *tins, struct btr_record *rec, void *hkey)
+{
+	struct dtx_cos_key *hkey1 = (struct dtx_cos_key *)&rec->rec_hkey[0];
+	struct dtx_cos_key *hkey2 = (struct dtx_cos_key *)hkey;
+	int		    rc;
+
+	rc = memcmp(hkey1, hkey2, sizeof(struct dtx_cos_key));
+
+	return dbtree_key_cmp_rc(rc);
+}
+
+static int
+dtx_cos_rec_alloc(struct btr_instance *tins, daos_iov_t *key_iov,
+		  daos_iov_t *val_iov, struct btr_record *rec)
+{
+	struct dtx_cos_key		*key;
+	struct dtx_cos_rec_bundle	*rbund;
+	struct dtx_cos_rec		*dcr;
+	struct dtx_cos_rec_child	*dcrc;
+
+	D_ASSERT(tins->ti_umm.umm_id == UMEM_CLASS_VMEM);
+
+	key = (struct dtx_cos_key *)key_iov->iov_buf;
+	rbund = (struct dtx_cos_rec_bundle *)val_iov->iov_buf;
+
+	D_ALLOC_PTR(dcr);
+	if (dcr == NULL)
+		return -DER_NOMEM;
+
+	dcr->dcr_oid = key->oid;
+	D_INIT_LIST_HEAD(&dcr->dcr_update_list);
+	D_INIT_LIST_HEAD(&dcr->dcr_punch_list);
+	dcr->dcr_cont = rbund->cont;
+
+	D_ALLOC_PTR(dcrc);
+	if (dcrc == NULL) {
+		D_FREE_PTR(dcr);
+		return -DER_NOMEM;
+	}
+
+	dcrc->dcrc_dti = *rbund->dti;
+	dcrc->dcrc_ptr = dcr;
+
+	d_list_add_tail(&dcrc->dcrc_committable,
+			&rbund->cont->vc_dtx_committable);
+	rbund->cont->vc_dtx_committable_count++;
+
+	if (rbund->punch) {
+		d_list_add_tail(&dcrc->dcrc_link, &dcr->dcr_punch_list);
+		dcr->dcr_punch_count = 1;
+	} else {
+		d_list_add_tail(&dcrc->dcrc_link, &dcr->dcr_update_list);
+		dcr->dcr_update_count = 1;
+	}
+
+	rec->rec_mmid = umem_ptr2id(&tins->ti_umm, dcr);
+	return 0;
+}
+
+static int
+dtx_cos_rec_free(struct btr_instance *tins, struct btr_record *rec, void *args)
+{
+	struct dtx_cos_rec		*dcr;
+	struct dtx_cos_rec_child	*dcrc;
+	struct dtx_cos_rec_child	*next;
+
+	D_ASSERT(tins->ti_umm.umm_id == UMEM_CLASS_VMEM);
+
+	dcr = (struct dtx_cos_rec *)umem_id2ptr(&tins->ti_umm, rec->rec_mmid);
+	d_list_for_each_entry_safe(dcrc, next, &dcr->dcr_update_list,
+				   dcrc_link) {
+		d_list_del(&dcrc->dcrc_link);
+		d_list_del(&dcrc->dcrc_committable);
+		D_FREE_PTR(dcrc);
+		dcr->dcr_cont->vc_dtx_committable_count--;
+	}
+	d_list_for_each_entry_safe(dcrc, next, &dcr->dcr_punch_list,
+				   dcrc_link) {
+		d_list_del(&dcrc->dcrc_link);
+		d_list_del(&dcrc->dcrc_committable);
+		D_FREE_PTR(dcrc);
+		dcr->dcr_cont->vc_dtx_committable_count--;
+	}
+	D_FREE_PTR(dcr);
+
+	return 0;
+}
+
+static int
+dtx_cos_rec_fetch(struct btr_instance *tins, struct btr_record *rec,
+		  daos_iov_t *key_iov, daos_iov_t *val_iov)
+{
+	struct dtx_cos_rec	*dcr;
+
+	D_ASSERT(val_iov != NULL);
+
+	dcr = (struct dtx_cos_rec *)umem_id2ptr(&tins->ti_umm, rec->rec_mmid);
+	daos_iov_set(val_iov, dcr, sizeof(struct dtx_cos_rec));
+
+	return 0;
+}
+
+static int
+dtx_cos_rec_update(struct btr_instance *tins, struct btr_record *rec,
+		   daos_iov_t *key, daos_iov_t *val)
+{
+	struct dtx_cos_rec_bundle	*rbund;
+	struct dtx_cos_rec		*dcr;
+	struct dtx_cos_rec_child	*dcrc;
+
+	D_ASSERT(tins->ti_umm.umm_id == UMEM_CLASS_VMEM);
+
+	dcr = (struct dtx_cos_rec *)umem_id2ptr(&tins->ti_umm, rec->rec_mmid);
+	rbund = (struct dtx_cos_rec_bundle *)val->iov_buf;
+
+	D_ALLOC_PTR(dcrc);
+	if (dcrc == NULL)
+		return -DER_NOMEM;
+
+	dcrc->dcrc_dti = *rbund->dti;
+	dcrc->dcrc_ptr = dcr;
+
+	d_list_add_tail(&dcrc->dcrc_committable,
+			&rbund->cont->vc_dtx_committable);
+	rbund->cont->vc_dtx_committable_count++;
+
+	if (rbund->punch) {
+		d_list_add_tail(&dcrc->dcrc_link, &dcr->dcr_punch_list);
+		dcr->dcr_punch_count++;
+	} else {
+		d_list_add_tail(&dcrc->dcrc_link, &dcr->dcr_update_list);
+		dcr->dcr_update_count++;
+	}
+
+	return 0;
+}
+
+static btr_ops_t dtx_btr_cos_ops = {
+	.to_hkey_size	= dtx_cos_hkey_size,
+	.to_hkey_gen	= dtx_cos_hkey_gen,
+	.to_hkey_cmp	= dtx_cos_hkey_cmp,
+	.to_rec_alloc	= dtx_cos_rec_alloc,
+	.to_rec_free	= dtx_cos_rec_free,
+	.to_rec_fetch	= dtx_cos_rec_fetch,
+	.to_rec_update	= dtx_cos_rec_update,
+};
+
+int
+vos_dtx_cos_register(void)
+{
+	int	rc;
+
+	D_DEBUG(DB_DF, "Registering DTX CoS class: %d\n",
+		VOS_BTR_DTX_COS);
+
+	rc = dbtree_class_register(VOS_BTR_DTX_COS, 0, &dtx_btr_cos_ops);
+	if (rc != 0)
+		D_ERROR("Failed to register DTX CoS dbtree: rc = %d\n", rc);
+
+	return rc;
+}
+
+int
+vos_dtx_list_cos(struct vos_container *cont, daos_unit_oid_t *oid,
+		 daos_key_t *dkey, uint32_t types, struct daos_tx_id **dtis)
+{
+	struct dtx_cos_key		 key;
+	daos_iov_t			 kiov;
+	daos_iov_t			 riov;
+	struct daos_tx_id		*dti = NULL;
+	struct dtx_cos_rec		*dcr;
+	struct dtx_cos_rec_child	*dcrc;
+	int				 count = 0;
+	int				 rc;
+	int				 i = 0;
+
+	if (dkey == NULL)
+		return 0;
+
+	D_ASSERT(dkey->iov_buf != NULL);
+	D_ASSERT(dkey->iov_len != 0);
+
+	key.oid = *oid;
+	key.dkey = d_hash_murmur64(dkey->iov_buf, dkey->iov_len,
+				   VOS_BTR_MUR_SEED);
+	daos_iov_set(&kiov, &key, sizeof(key));
+	daos_iov_set(&riov, NULL, 0);
+
+	rc = dbtree_lookup(cont->vc_dtx_cos_hdl, &kiov, &riov);
+	if (rc != 0)
+		return rc == -DER_NONEXIST ? 0 : rc;
+
+	dcr = (struct dtx_cos_rec *)riov.iov_buf;
+	if (types & DCLT_PUNCH)
+		count += dcr->dcr_punch_count;
+	if (types & DCLT_UPDATE)
+		count += dcr->dcr_update_count;
+
+	if (count == 0)
+		return 0;
+
+	/* There are too many shared DTXs to be committed, as to
+	 * cannot be taken via the normal UPDATE RPC. Return the
+	 * DTXs count directly without filling the DTX array.
+	 */
+	if (count > DTX_THRESHOLD_COUNT) {
+		*dtis = NULL;
+		return count;
+	}
+
+	D_ALLOC_ARRAY(dti, count);
+	if (dti == NULL)
+		return -DER_NOMEM;
+
+	if (types & DCLT_PUNCH) {
+		d_list_for_each_entry(dcrc, &dcr->dcr_punch_list,
+				      dcrc_link) {
+			dti[i++] = dcrc->dcrc_dti;
+		}
+	}
+
+	if (types & DCLT_UPDATE) {
+		d_list_for_each_entry(dcrc, &dcr->dcr_update_list,
+				      dcrc_link) {
+			dti[i++] = dcrc->dcrc_dti;
+		}
+	}
+
+	D_ASSERT(i == count);
+
+	*dtis = dti;
+	return count;
+}
+
+int
+vos_dtx_add_cos(struct vos_container *cont, daos_unit_oid_t *oid,
+		struct daos_tx_id *dti, uint64_t dkey, bool punch)
+{
+	struct dtx_cos_key		 key;
+	struct dtx_cos_rec_bundle	 rbund;
+	daos_iov_t			 kiov;
+	daos_iov_t			 riov;
+	int				 rc;
+
+	D_ASSERT(dkey != 0);
+
+	key.oid = *oid;
+	key.dkey = dkey;
+	daos_iov_set(&kiov, &key, sizeof(key));
+
+	rbund.cont = cont;
+	rbund.dti = dti;
+	rbund.punch = punch;
+	daos_iov_set(&riov, &rbund, sizeof(rbund));
+
+	rc = dbtree_upsert(cont->vc_dtx_cos_hdl, BTR_PROBE_EQ,
+			   DAOS_INTENT_UPDATE, &kiov, &riov);
+
+	return rc;
+}
+
+void
+vos_dtx_del_cos(struct vos_container *cont, daos_unit_oid_t *oid,
+		struct daos_tx_id *xid, uint64_t dkey, bool punch)
+{
+	struct dtx_cos_key		 key;
+	daos_iov_t			 kiov;
+	daos_iov_t			 riov;
+	struct dtx_cos_rec		*dcr;
+	struct dtx_cos_rec_child	*dcrc;
+	d_list_t			*head;
+	int				 rc;
+
+	D_ASSERT(dkey != 0);
+
+	key.oid = *oid;
+	key.dkey = dkey;
+	daos_iov_set(&kiov, &key, sizeof(key));
+	daos_iov_set(&riov, NULL, 0);
+
+	rc = dbtree_lookup(cont->vc_dtx_cos_hdl, &kiov, &riov);
+	if (rc != 0)
+		return;
+
+	dcr = (struct dtx_cos_rec *)riov.iov_buf;
+	if (punch)
+		head = &dcr->dcr_punch_list;
+	else
+		head = &dcr->dcr_update_list;
+
+	d_list_for_each_entry(dcrc, head, dcrc_link) {
+		if (memcmp(&dcrc->dcrc_dti, xid, sizeof(*xid)) != 0)
+			continue;
+
+		d_list_del(&dcrc->dcrc_committable);
+		d_list_del(&dcrc->dcrc_link);
+		D_FREE_PTR(dcrc);
+
+		cont->vc_dtx_committable_count--;
+		if (punch)
+			dcr->dcr_punch_count--;
+		else
+			dcr->dcr_update_count--;
+		if (dcr->dcr_punch_count == 0 && dcr->dcr_update_count == 0)
+			dbtree_delete(cont->vc_dtx_cos_hdl, &kiov, NULL);
+
+		return;
+	}
+}
+
+int
+vos_dtx_lookup_cos(daos_handle_t coh, daos_unit_oid_t *oid,
+		   struct daos_tx_id *xid, uint64_t dkey, bool punch)
+{
+	struct vos_container		*cont;
+	struct dtx_cos_key		 key;
+	daos_iov_t			 kiov;
+	daos_iov_t			 riov;
+	struct dtx_cos_rec		*dcr;
+	struct dtx_cos_rec_child	*dcrc;
+	d_list_t			*head;
+	int				 rc;
+
+	if (dkey == 0)
+		return -DER_NONEXIST;
+
+	cont = vos_hdl2cont(coh);
+	D_ASSERT(cont != NULL);
+
+	key.oid = *oid;
+	key.dkey = dkey;
+	daos_iov_set(&kiov, &key, sizeof(key));
+	daos_iov_set(&riov, NULL, 0);
+
+	rc = dbtree_lookup(cont->vc_dtx_cos_hdl, &kiov, &riov);
+	if (rc != 0)
+		return rc;
+
+	dcr = (struct dtx_cos_rec *)riov.iov_buf;
+	if (punch)
+		head = &dcr->dcr_punch_list;
+	else
+		head = &dcr->dcr_update_list;
+
+	d_list_for_each_entry(dcrc, head, dcrc_link) {
+		if (memcmp(&dcrc->dcrc_dti, xid, sizeof(*xid)) == 0)
+			return 0;
+	}
+
+	return -DER_NONEXIST;
+}
+
+int
+vos_dtx_list_committable(daos_handle_t coh, struct daos_tx_entry **dtes)
+{
+	struct daos_tx_entry		*dte = NULL;
+	struct dtx_cos_rec_child	*dcrc;
+	struct vos_container		*cont;
+	int				 count;
+	int				 i = 0;
+
+	cont = vos_hdl2cont(coh);
+	D_ASSERT(cont != NULL);
+
+	if (cont->vc_dtx_committable_count > DTX_THRESHOLD_COUNT)
+		count = DTX_THRESHOLD_COUNT;
+	else
+		count = cont->vc_dtx_committable_count;
+
+	if (count == 0)
+		return 0;
+
+	D_ALLOC_ARRAY(dte, count);
+	if (dte == NULL)
+		return -DER_NOMEM;
+
+	d_list_for_each_entry(dcrc, &cont->vc_dtx_committable,
+			      dcrc_committable) {
+		dte[i].dte_xid = dcrc->dcrc_dti;
+		dte[i].dte_oid = dcrc->dcrc_ptr->dcr_oid;
+
+		if (++i >= count)
+			break;
+	}
+
+	*dtes = dte;
+	return count;
+}

--- a/src/vos/vos_internal.h
+++ b/src/vos/vos_internal.h
@@ -45,6 +45,7 @@
 
 extern struct dss_module_key vos_module_key;
 extern umem_class_id_t vos_mem_class;
+extern double vos_start_time;
 
 #define VOS_POOL_HHASH_BITS 10 /* Upto 1024 pools */
 #define VOS_CONT_HHASH_BITS 20 /* Upto 1048576 containers */

--- a/src/vos/vos_internal.h
+++ b/src/vos/vos_internal.h
@@ -116,6 +116,8 @@ struct vos_container {
 	d_list_t		vc_dtx_committable;
 	/* The count of commiitable DTXs. */
 	uint32_t		vc_dtx_committable_count;
+	/** The time in second when last commit the DTXs. */
+	double			vc_dtx_time_last_commit;
 	/* Direct pointer to VOS object index
 	 * within container
 	 */
@@ -172,6 +174,18 @@ enum {
 #define VOS_OFEAT_SHIFT		48
 #define VOS_OFEAT_MASK		(0x0ffULL   << VOS_OFEAT_SHIFT)
 #define VOS_OFEAT_BITS		(0x0ffffULL << VOS_OFEAT_SHIFT)
+
+#if DAOS_HAS_PMDK
+static const PMEMoid DTX_UMMID_ABORTED = { .pool_uuid_lo = -1,
+					   .off = -1,
+};
+static const PMEMoid DTX_UMMID_UNKNOWN = { .pool_uuid_lo = -1,
+					   .off = -2,
+};
+#else
+# define DTX_UMMID_ABORTED	((umem_id_t){ .pool_uuid_lo = -1, .off = -1, })
+# define DTX_UMMID_UNKNOWN	((umem_id_t){ .pool_uuid_lo = -1, .off = -2, })
+#endif
 
 /**
  * A cached object (DRAM data structure).

--- a/src/vos/vos_internal.h
+++ b/src/vos/vos_internal.h
@@ -108,6 +108,14 @@ struct vos_container {
 	daos_handle_t		vc_dtx_committed_hdl;
 	/* DAOS handle for object index btree */
 	daos_handle_t		vc_btr_hdl;
+	/* The objects with committable DTXs in DRAM. */
+	daos_handle_t		vc_dtx_cos_hdl;
+	/* The DTX COS-btree. */
+	struct btr_root		vc_dtx_cos_btr;
+	/* The global list for commiitable DTXs. */
+	d_list_t		vc_dtx_committable;
+	/* The count of commiitable DTXs. */
+	uint32_t		vc_dtx_committable_count;
 	/* Direct pointer to VOS object index
 	 * within container
 	 */
@@ -419,6 +427,43 @@ vos_dtx_table_destroy(struct vos_pool *pool, struct vos_dtx_table_df *dtab_df);
 int
 vos_dtx_table_register(void);
 
+/**
+ * Register dbtree class for DTX CoS, it is called within vos_init().
+ *
+ * \return		0 on success and negative on failure.
+ */
+int
+vos_dtx_cos_register(void);
+
+/**
+ * Add the given DTX to the Commit-on-Share (CoS) cache (in DRAM).
+ *
+ * \param cont	[IN]	Pointer to the container.
+ * \param oid	[IN]	The target object (shard) ID.
+ * \param dti	[IN]	The DTX identifier.
+ * \param dkey	[IN]	The hashed dkey.
+ * \param punch	[IN]	For punch DTX or not.
+ *
+ * \return		Zero on success and need not additional actions.
+ * \return		Negative value if error.
+ */
+int
+vos_dtx_add_cos(struct vos_container *cont, daos_unit_oid_t *oid,
+		struct daos_tx_id *dti, uint64_t dkey, bool punch);
+
+/**
+ * Remove the DTX from the CoS cache.
+ *
+ * \param cont	[IN]	Pointer to the container.
+ * \param oid	[IN]	Pointer to the object ID.
+ * \param xid	[IN]	Pointer to the DTX identifier.
+ * \param dkey	[IN]	The hashed dkey.
+ * \param punch	[IN]	For punch DTX or not.
+ */
+void
+vos_dtx_del_cos(struct vos_container *cont, daos_unit_oid_t *oid,
+		struct daos_tx_id *xid, uint64_t dkey, bool punch);
+
 enum vos_tree_class {
 	/** the first reserved tree class */
 	VOS_BTR_BEGIN		= DBTREE_VOS_BEGIN,
@@ -434,6 +479,8 @@ enum vos_tree_class {
 	VOS_BTR_CONT_TABLE	= (VOS_BTR_BEGIN + 4),
 	/** DAOS two-phase commit transation table */
 	VOS_BTR_DTX_TABLE	= (VOS_BTR_BEGIN + 5),
+	/** The objects with committable DTXs in DRAM */
+	VOS_BTR_DTX_COS		= (VOS_BTR_BEGIN + 6),
 	/** the last reserved tree class */
 	VOS_BTR_END,
 };

--- a/src/vos/vos_layout.h
+++ b/src/vos/vos_layout.h
@@ -251,6 +251,11 @@ enum vos_krec_bf {
 	KREC_BF_PUNCHED			= (1 << 1),
 };
 
+enum vos_kerc_flags {
+	/* The record is (or to be) deleted. */
+	VKF_DELETED	= 1,
+};
+
 /**
  * Persisted VOS (d)key record, it is referenced by btr_record::rec_mmid
  * of btree VOS_BTR_KEY.
@@ -262,8 +267,8 @@ struct vos_krec_df {
 	uint8_t				kr_cs_type;
 	/** key checksum size (in bytes) */
 	uint8_t				kr_cs_size;
-	/** padding bytes */
-	uint8_t				kr_pad_8;
+	/** See enum vos_kerc_flags. */
+	uint8_t				kr_flags;
 	/** key length */
 	uint32_t			kr_size;
 	/* Latest known update timestamp or punched timestamp */


### PR DESCRIPTION
The client will generate the DTX identifier and send it to
the leader replica via the update/punch RPC. On the other
hand, the leader replica will dispatch the update/punch RPC
to other non-leader replicas with the DTXs array that need
to be committed because of share or conflict.

For the client, it uses the same algorithm to elect leader.
Because the difference between client side and server side
data structure, to avoid format conversion, they implement
each own function for the leader election. They may share
the same one in the future.

For modification RPC, the client sends it to leader only.
For other read only RPC, it can be sent to any replica as
without the DTX case. But if the non-leader replica does
not sure about related target data record visibility, it
will reply "-DER_INPROGRESS" to the client, and then the
client needs to retry the RPC with leader. Related logic
will be implemented in subsequent patches.

Signed-off-by: Fan Yong <fan.yong@intel.com>
Change-Id: I7c0ad29e79c62a65c4db7b1d38911db6cd168c0c