### PR TITLE
DAOS-1441 dtx: data record visibility with DTX state

### DIFF
--- a/src/SConscript
+++ b/src/SConscript
@@ -40,6 +40,7 @@ def scons():
     SConscript('pool/SConscript')
     SConscript('container/SConscript')
     SConscript('placement/SConscript')
+    SConscript('dtx/SConscript')
     SConscript('object/SConscript')
     SConscript('rebuild/SConscript')
     SConscript('security/SConscript')

--- a/src/common/btree.c
+++ b/src/common/btree.c
@@ -220,6 +220,14 @@ btr_hdl2tcx(daos_handle_t toh)
 	return (struct btr_context *)toh.cookie;
 }
 
+struct umem_instance *
+btr_hdl2umm(daos_handle_t toh)
+{
+	struct btr_context *tcx = btr_hdl2tcx(toh);
+
+	return tcx != NULL ? &tcx->tc_tins.ti_umm : NULL;
+}
+
 void
 btr_context_addref(struct btr_context *tcx)
 {

--- a/src/common/btree.c
+++ b/src/common/btree.c
@@ -47,6 +47,7 @@ enum btr_probe_rc {
 	PROBE_RC_NONE,
 	PROBE_RC_OK,
 	PROBE_RC_ERR,
+	PROBE_RC_INPROGRESS,
 };
 
 /**
@@ -905,6 +906,46 @@ btr_root_grow(struct btr_context *tcx, TMMID(struct btr_node) mmid_left,
 	return 0;
 }
 
+struct btr_check_vbt {
+	TMMID(struct btr_node)	nd_mmid;
+	int			at;
+	uint32_t		intent;
+};
+
+static int
+btr_check_visibility(struct btr_context *tcx, struct btr_check_vbt *vbt)
+{
+	struct btr_record	*rec;
+	int			 rc;
+
+	if (btr_ops(tcx)->to_check_visibility == NULL)
+		return PROBE_RC_OK;
+
+	if (TMMID_IS_NULL(vbt->nd_mmid)) { /* compare the leaf trace */
+		struct btr_trace *trace = &tcx->tc_traces[BTR_TRACE_MAX - 1];
+
+		vbt->nd_mmid = trace->tr_node;
+		vbt->at = trace->tr_at;
+	}
+
+	if (!btr_node_is_leaf(tcx, vbt->nd_mmid))
+		return PROBE_RC_OK;
+
+	rec = btr_node_rec_at(tcx, vbt->nd_mmid, vbt->at);
+	rc = btr_ops(tcx)->to_check_visibility(&tcx->tc_tins, rec, vbt->intent);
+	if (rc > 0) /* Visible */
+		return PROBE_RC_OK;
+
+	if (rc == -DER_INPROGRESS) /* Unceration */
+		return PROBE_RC_INPROGRESS;
+
+	if (rc < 0) /* Failure */
+		return PROBE_RC_ERR;
+
+	/* Invisibile */
+	return 0;
+}
+
 static void
 btr_node_insert_rec_only(struct btr_context *tcx, struct btr_trace *trace,
 			 struct btr_record *rec)
@@ -913,6 +954,7 @@ btr_node_insert_rec_only(struct btr_context *tcx, struct btr_trace *trace,
 	struct btr_record *rec_b;
 	struct btr_node   *nd;
 	bool		   leaf;
+	bool		   reuse = false;
 	char		   sbuf[BTR_PRINT_BUF];
 
 	/* NB: assume trace->tr_node has been added to TX */
@@ -927,11 +969,28 @@ btr_node_insert_rec_only(struct btr_context *tcx, struct btr_trace *trace,
 	rec_b = btr_node_rec_at(tcx, trace->tr_node, trace->tr_at + 1);
 
 	nd = btr_mmid2ptr(tcx, trace->tr_node);
-	if (trace->tr_at != nd->tn_keyn)
-		btr_rec_move(tcx, rec_b, rec_a, nd->tn_keyn - trace->tr_at);
+	if (trace->tr_at != nd->tn_keyn) {
+		struct btr_check_vbt	vbt;
+		int			rc;
+
+		vbt.nd_mmid = trace->tr_node;
+		vbt.at = trace->tr_at;
+		vbt.intent = DAOS_INTENT_PROBE;
+		rc = btr_check_visibility(tcx, &vbt);
+		if (rc == 0)
+			reuse = true;
+	}
+
+	if (reuse) {
+		btr_rec_free(tcx, rec_a, NULL);
+	} else {
+		if (trace->tr_at != nd->tn_keyn)
+			btr_rec_move(tcx, rec_b, rec_a,
+				     nd->tn_keyn - trace->tr_at);
+		nd->tn_keyn++;
+	}
 
 	btr_rec_copy(tcx, rec_a, rec, 1);
-	nd->tn_keyn++;
 }
 
 /**
@@ -1157,7 +1216,9 @@ btr_probe(struct btr_context *tcx, dbtree_probe_opc_t probe_opc,
 	int			 rc;
 	int			 cmp;
 	int			 level;
+	int			 saved = -1;
 	bool			 next_level;
+	struct btr_check_vbt	 vbt;
 	struct btr_trace	 traces[BTR_TRACE_MAX];
 	struct btr_trace	*trace = NULL;
 	TMMID(struct btr_node)	 nd_mmid;
@@ -1257,60 +1318,115 @@ btr_probe(struct btr_context *tcx, dbtree_probe_opc_t probe_opc,
 		D_ASSERTF(cmp == BTR_CMP_EQ, "Hash collision is unsupported\n");
 	}
 
+	vbt.nd_mmid = nd_mmid;
+	vbt.at = at;
+	vbt.intent = intent;
+
+again:
 	switch (probe_opc & ~BTR_PROBE_MATCHED) {
 	default:
 		D_ASSERT(0);
 	case BTR_PROBE_FIRST:
+		do {
+			vbt.nd_mmid = tcx->tc_trace[level].tr_node;
+			vbt.at = tcx->tc_trace[level].tr_at;
+			rc = btr_check_visibility(tcx, &vbt);
+		} while (rc == 0 && btr_probe_next(tcx));
+
+		if (rc <= 0)
+			rc = PROBE_RC_NONE;
+		goto out;
+
 	case BTR_PROBE_LAST:
-		rc = PROBE_RC_OK;
+		do {
+			vbt.nd_mmid = tcx->tc_trace[level].tr_node;
+			vbt.at = tcx->tc_trace[level].tr_at;
+			rc = btr_check_visibility(tcx, &vbt);
+		} while (rc == 0 && btr_probe_prev(tcx));
+
+		if (rc <= 0)
+			rc = PROBE_RC_NONE;
 		goto out;
 
 	case BTR_PROBE_EQ:
 		if (cmp == BTR_CMP_EQ) {
-			rc = PROBE_RC_OK;
-			goto out;
+			rc = btr_check_visibility(tcx, &vbt);
+			if (rc > 0)
+				goto out;
+
+			/* Current pos is invisible, it can be used for the
+			 * follow-on insert if applicable.
+			 */
+		} else {
+			/* Point at the first key which is larger than the
+			 * probed one, this if for the follow-on insert if
+			 * applicable.
+			 */
+			btr_trace_set(tcx, level, nd_mmid,
+				      at + !(cmp & BTR_CMP_GT));
 		}
-		/* point at the first key which is larger than the probed one,
-		 * this if for follow-on insert if applicable.
-		 */
-		btr_trace_set(tcx, level, nd_mmid, at + !(cmp & BTR_CMP_GT));
+
 		rc = PROBE_RC_NONE;
 		goto out;
 
 	case BTR_PROBE_GE:
 		if (cmp == BTR_CMP_EQ) {
-			rc = PROBE_RC_OK;
-			goto out;
+			rc = btr_check_visibility(tcx, &vbt);
+			if (rc > 0)
+				goto out;
+
+			/* Current pos is invisible, it can be used for the
+			 * follow-on insert if applicable.
+			 */
+			if (saved == -1)
+				saved = at;
 		}
 		/* fall through */
 	case BTR_PROBE_GT:
-		if (cmp & BTR_CMP_GT)
-			break;
+		if (cmp & BTR_CMP_GT) {
+			rc = btr_check_visibility(tcx, &vbt);
+			if (rc > 0)
+				break;
 
-		/* point at the next position in the current leaf node, this is
-		 * for follow-on insert if applicable.
-		 */
-		at += 1;
+			/* Current pos is invisible, it can be used for the
+			 * follow-on insert if applicable.
+			 */
+			if (saved == -1)
+				saved = at;
+		} else {
+			/* Point at the next position in the current leaf node,
+			 * this is for the follow-on insert if applicable.
+			 */
+			if (saved == -1)
+				saved = at + 1;
+		}
+
 		/* backup the probe trace because probe_next will change it */
-		memcpy(traces, tcx->tc_trace, sizeof(*trace) * tcx->tc_depth);
+		if (trace == NULL)
+			memcpy(traces, tcx->tc_trace,
+			       sizeof(*trace) * tcx->tc_depth);
 		if (btr_probe_next(tcx)) {
 			trace = traces;
 			cmp = BTR_CMP_UNKNOWN;
 			break;
 		}
-		btr_trace_set(tcx, level, nd_mmid, at);
+		btr_trace_set(tcx, level, nd_mmid, saved);
 		rc = PROBE_RC_NONE;
 		goto out;
 
 	case BTR_PROBE_LE:
 		if (cmp == BTR_CMP_EQ) {
-			rc = PROBE_RC_OK;
-			goto out;
+			rc = btr_check_visibility(tcx, &vbt);
+			if (rc > 0)
+				goto out;
 		}
 		/* fall through */
 	case BTR_PROBE_LT:
-		if (cmp & BTR_CMP_LT)
-			break;
+		if (cmp & BTR_CMP_LT) {
+			rc = btr_check_visibility(tcx, &vbt);
+			if (rc > 0)
+				break;
+		}
 
 		if (btr_probe_prev(tcx)) {
 			cmp = BTR_CMP_UNKNOWN;
@@ -1320,8 +1436,12 @@ btr_probe(struct btr_context *tcx, dbtree_probe_opc_t probe_opc,
 		goto out;
 	}
 
-	if (cmp == BTR_CMP_UNKNOWN) /* position changed, compare again */
+	if (cmp == BTR_CMP_UNKNOWN) {/* position changed, compare again */
 		cmp = btr_cmp(tcx, BTR_NODE_NULL, -1, hkey, key);
+		vbt.nd_mmid = BTR_NODE_NULL;
+		vbt.at = -1;
+		goto again;
+	}
 
 	D_ASSERT(cmp != BTR_CMP_EQ);
 	if (cmp & BTR_CMP_MATCHED) {
@@ -1331,9 +1451,11 @@ btr_probe(struct btr_context *tcx, dbtree_probe_opc_t probe_opc,
 			rc = PROBE_RC_NONE;
 			/* restore the probe trace for follow-on insert. */
 			if (trace) {
+				D_ASSERT(saved != -1);
+
 				memcpy(tcx->tc_trace, trace,
 				       tcx->tc_depth * sizeof(*trace));
-				btr_trace_set(tcx, level, nd_mmid, at);
+				btr_trace_set(tcx, level, nd_mmid, saved);
 			}
 		} else {
 			/* GT/GE/LT/LE without MATCHED */
@@ -1510,6 +1632,10 @@ dbtree_fetch(daos_handle_t toh, dbtree_probe_opc_t opc, uint32_t intent,
 		return -DER_NO_HDL;
 
 	rc = btr_probe_key(tcx, opc, intent, key);
+	if (rc == PROBE_RC_INPROGRESS) {
+		D_DEBUG(DB_TRACE, "Target is in some uncommitted DTX.\n");
+		return -DER_INPROGRESS;
+	}
 	if (rc == PROBE_RC_NONE || rc == PROBE_RC_ERR) {
 		D_DEBUG(DB_TRACE, "Cannot find key\n");
 		return -DER_NONEXIST;
@@ -1658,6 +1784,9 @@ btr_upsert(struct btr_context *tcx, dbtree_probe_opc_t probe_opc,
 			"operation.\n");
 		rc = -DER_INVAL;
 		break;
+	case PROBE_RC_INPROGRESS:
+		D_DEBUG(DB_TRACE, "The target is in some uncommitted DTX.");
+		return -DER_INPROGRESS;
 	}
 
 	tcx->tc_probe_rc = PROBE_RC_UNKNOWN; /* path changed */
@@ -2460,6 +2589,11 @@ dbtree_delete(daos_handle_t toh, daos_iov_t *key,
 		return -DER_NO_HDL;
 
 	rc = btr_probe_key(tcx, BTR_PROBE_EQ, DAOS_INTENT_PUNCH, key);
+	if (rc == PROBE_RC_INPROGRESS) {
+		D_DEBUG(DB_TRACE, "Target is in some uncommitted DTX.\n");
+		return -DER_INPROGRESS;
+	}
+
 	if (rc != PROBE_RC_OK) {
 		D_DEBUG(DB_TRACE, "Cannot find key\n");
 		return -DER_NONEXIST;
@@ -3028,6 +3162,11 @@ dbtree_iter_probe(daos_handle_t ih, dbtree_probe_opc_t opc, uint32_t intent,
 		else
 			btr_hkey_copy(tcx, hkey, (char *)&anchor->da_buf[0]);
 		rc = btr_probe(tcx, opc, intent, key, hkey);
+	}
+
+	if (rc == PROBE_RC_INPROGRESS) {
+		itr->it_state = BTR_ITR_FINI;
+		return -DER_INPROGRESS;
 	}
 
 	if (rc == PROBE_RC_NONE || rc == PROBE_RC_ERR) {

--- a/src/common/debug.c
+++ b/src/common/debug.c
@@ -50,6 +50,7 @@ DECLARE_FAC(rdb);
 DECLARE_FAC(rsvc);
 DECLARE_FAC(pool);
 DECLARE_FAC(container);
+DECLARE_FAC(dtx);
 DECLARE_FAC(object);
 DECLARE_FAC(placement);
 DECLARE_FAC(rebuild);
@@ -106,6 +107,7 @@ static struct d_debug_bit daos_bit_dict[] = {
 	ACTION("rsvc", d_rsvc_logfac)			\
 	ACTION("pool", d_pool_logfac)			\
 	ACTION("container", d_container_logfac)		\
+	ACTION("dtx", d_dtx_logfac)			\
 	ACTION("object", d_object_logfac)		\
 	ACTION("placement", d_placement_logfac)		\
 	ACTION("rebuild", d_rebuild_logfac)		\

--- a/src/common/mem.c
+++ b/src/common/mem.c
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2016-2018 Intel Corporation.
+ * (C) Copyright 2016-2019 Intel Corporation.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -44,6 +44,12 @@ struct umem_tx_stage_item {
 };
 
 /** persistent memory operations (depends on pmdk) */
+
+static umem_id_t
+pmem_id(struct umem_instance *umm, void *addr)
+{
+	return pmemobj_oid(addr);
+}
 
 static void *
 pmem_addr(struct umem_instance *umm, umem_id_t ummid)
@@ -290,6 +296,7 @@ pmem_tx_add_callback(struct umem_instance *umm, struct umem_tx_stage_data *txd,
 }
 
 static umem_ops_t	pmem_ops = {
+	.mo_id			= pmem_id,
 	.mo_addr		= pmem_addr,
 	.mo_equal		= pmem_equal,
 	.mo_tx_free		= pmem_tx_free,
@@ -330,6 +337,15 @@ umem_tx_errno(int err)
 }
 
 /* volatile memroy operations */
+
+static umem_id_t
+vmem_id(struct umem_instance *umm, void *addr)
+{
+	umem_id_t	ummid = UMMID_NULL;
+
+	ummid.off = (uint64_t)addr;
+	return ummid;
+}
 
 static void *
 vmem_addr(struct umem_instance *umm, umem_id_t ummid)
@@ -384,6 +400,7 @@ vmem_tx_add_callback(struct umem_instance *umm, struct umem_tx_stage_data *txd,
 }
 
 static umem_ops_t	vmem_ops = {
+	.mo_id		= vmem_id,
 	.mo_addr	= vmem_addr,
 	.mo_equal	= vmem_equal,
 	.mo_tx_free	= vmem_free,

--- a/src/container/srv_container.c
+++ b/src/container/srv_container.c
@@ -36,6 +36,7 @@
 #include <daos/rpc.h>
 #include <daos_srv/pool.h>
 #include <daos_srv/rdb.h>
+#include <daos_srv/dtx_srv.h>
 #include "rpc.h"
 #include "srv_internal.h"
 #include "srv_layout.h"

--- a/src/container/srv_target.c
+++ b/src/container/srv_target.c
@@ -567,7 +567,7 @@ ds_cont_tgt_open_handler(crt_rpc_t *rpc)
 		DP_CONT(in->toi_pool_uuid, in->toi_uuid), rpc,
 		DP_UUID(in->toi_hdl));
 
-	rc = dss_task_collective(cont_open_one, in, 0);
+	rc = dss_thread_collective(cont_open_one, in, 0);
 	D_ASSERTF(rc == 0, "%d\n", rc);
 
 	out->too_rc = (rc == 0 ? 0 : 1);

--- a/src/dtx/SConscript
+++ b/src/dtx/SConscript
@@ -10,7 +10,7 @@ def scons():
 
     # dtx
     dtx = daos_build.library(denv, 'dtx',
-                             ['dtx_srv.c', 'dtx_rpc.c'])
+                             ['dtx_srv.c', 'dtx_rpc.c', 'dtx_resync.c'])
     denv.Install('$PREFIX/lib/daos_srv', dtx)
 
 if __name__ == "SCons.Script":

--- a/src/dtx/SConscript
+++ b/src/dtx/SConscript
@@ -1,0 +1,17 @@
+"""Build dtx library"""
+import daos_build
+
+def scons():
+    """Execute build"""
+    Import('env')
+
+    env.AppendUnique(LIBPATH=[Dir('.')])
+    denv = env.Clone()
+
+    # dtx
+    dtx = daos_build.library(denv, 'dtx',
+                             ['dtx_srv.c', 'dtx_rpc.c'])
+    denv.Install('$PREFIX/lib/daos_srv', dtx)
+
+if __name__ == "SCons.Script":
+    scons()

--- a/src/dtx/dtx_internal.h
+++ b/src/dtx/dtx_internal.h
@@ -1,0 +1,76 @@
+/**
+ * (C) Copyright 2019 Intel Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * GOVERNMENT LICENSE RIGHTS-OPEN SOURCE SOFTWARE
+ * The Government's rights to use, modify, reproduce, release, perform, display,
+ * or disclose this software are subject to the terms of the Apache License as
+ * provided in Contract No. B609815.
+ * Any reproduction of computer software, computer software documentation, or
+ * portions thereof marked with this legend must also reproduce the markings.
+ */
+/**
+ * dtx: dtx internal.h
+ *
+ */
+#ifndef __DTX_INTERNAL_H__
+#define __DTX_INTERNAL_H__
+
+#include <uuid/uuid.h>
+#include <daos/rpc.h>
+#include <daos/btree.h>
+
+/*
+ * RPC operation codes
+ *
+ * These are for daos_rpc::dr_opc and DAOS_RPC_OPCODE(opc, ...) rather than
+ * crt_req_create(..., opc, ...). See src/include/daos/rpc.h.
+ */
+#define DAOS_DTX_VERSION	1
+
+/* LIST of internal RPCS in form of:
+ * OPCODE, flags, FMT, handler, corpc_hdlr,
+ */
+#define DTX_PROTO_SRV_RPC_LIST						\
+	X(DTX_COMMIT, 0, &CQF_dtx, dtx_handler, NULL),			\
+	X(DTX_ABORT, 0, &CQF_dtx, dtx_handler, NULL),			\
+	X(DTX_CHECK, 0, &CQF_dtx, dtx_handler, NULL)
+
+#define X(a, b, c, d, e) a
+
+enum dtx_operation {
+	DTX_PROTO_SRV_RPC_LIST,
+};
+
+#undef X
+
+/* DTX RPC input fields */
+#define DAOS_ISEQ_DTX							\
+	((uuid_t)		(di_po_uuid)		CRT_VAR)	\
+	((uuid_t)		(di_co_uuid)		CRT_VAR)	\
+	((struct daos_tx_id)	(di_dtx_array)		CRT_ARRAY)
+
+/* DTX RPC output fields */
+#define DAOS_OSEQ_DTX							\
+	((int32_t)		(do_status)		CRT_VAR)
+
+CRT_RPC_DECLARE(dtx, DAOS_ISEQ_DTX, DAOS_OSEQ_DTX);
+
+extern struct crt_proto_format dtx_proto_fmt;
+extern btr_ops_t dbtree_dtx_cf_ops;
+
+int dtx_check(uuid_t po_uuid, uuid_t co_uuid,
+	      struct daos_tx_entry *dte, struct pl_obj_layout *layout);
+
+#endif /* __DTX_INTERNAL_H__ */

--- a/src/dtx/dtx_resync.c
+++ b/src/dtx/dtx_resync.c
@@ -1,0 +1,427 @@
+/**
+ * (C) Copyright 2019 Intel Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * GOVERNMENT LICENSE RIGHTS-OPEN SOURCE SOFTWARE
+ * The Government's rights to use, modify, reproduce, release, perform, display,
+ * or disclose this software are subject to the terms of the Apache License as
+ * provided in Contract No. B609815.
+ * Any reproduction of computer software, computer software documentation, or
+ * portions thereof marked with this legend must also reproduce the markings.
+ */
+/**
+ * dtx: resync DTX status
+ */
+#define D_LOGFAC	DD_FAC(dtx)
+
+#include <daos/placement.h>
+#include <daos/pool_map.h>
+#include <daos_srv/vos.h>
+#include <daos_srv/pool.h>
+#include <daos_srv/dtx_srv.h>
+#include <daos_srv/daos_server.h>
+#include <daos_srv/container.h>
+#include "dtx_internal.h"
+
+struct dtx_resync_entry {
+	d_list_t		dre_link;
+	struct daos_tx_id	dre_xid;
+	daos_unit_oid_t		dre_oid;
+	uint32_t		dre_state;
+	uint32_t		dre_intent;
+	uint64_t		dre_hash;
+};
+
+struct dtx_resync_head {
+	d_list_t		drh_list;
+	int			drh_count;
+};
+
+struct dtx_resync_args {
+	uuid_t			 po_uuid;
+	uint64_t		 start;
+	uint32_t		 version;
+	struct dtx_resync_head	*tables;
+};
+
+struct dtx_iter_args {
+	cont_iter_cb_t	 callback;
+	void		*arg;
+};
+
+static int
+dtx_check_committable(uuid_t po_uuid, uuid_t co_uuid, struct daos_tx_id *dti,
+		      daos_unit_oid_t *oid, struct pl_obj_layout *layout)
+{
+	struct daos_tx_entry	dte;
+
+	dte.dte_xid = *dti;
+	dte.dte_oid = *oid;
+
+	return dtx_check(po_uuid, co_uuid, &dte, layout);
+}
+
+static int
+dtx_resync_commit(uuid_t po_uuid, uuid_t co_uuid,
+		  struct dtx_resync_head *drh, int count, uint32_t version)
+{
+	struct daos_tx_entry		*dte;
+	struct dtx_resync_entry		*dre;
+	int				 rc;
+	int				 i = 0;
+
+	D_ASSERT(drh->drh_count >= count);
+
+	D_ALLOC_ARRAY(dte, count);
+	if (dte == NULL)
+		return -DER_NOMEM;
+
+	do {
+		dre = d_list_entry(drh->drh_list.next,
+				   struct dtx_resync_entry, dre_link);
+		d_list_del(&dre->dre_link);
+		drh->drh_count--;
+
+		dte[i].dte_xid = dre->dre_xid;
+		dte[i].dte_oid = dre->dre_oid;
+		D_FREE_PTR(dre);
+	} while (++i < count);
+
+	rc = dtx_commit(po_uuid, co_uuid, dte, count, version);
+	D_FREE(dte);
+
+	if (rc < 0)
+		D_ERROR("Failed to commit the DTX: rc = %d\n", rc);
+
+	return rc > 0 ? 0 : rc;
+}
+
+static int
+dtx_resync_abort(uuid_t po_uuid, struct ds_cont *cont,
+		 struct dtx_resync_head *drh, struct dtx_resync_entry *dre,
+		 uint32_t version, bool force)
+{
+	struct daos_tx_entry	 dte;
+	int			 rc;
+
+	/* If we abort multiple non-ready DTXs together, then there is race that
+	 * one DTX may become committable when we abort some other DTX. To avoid
+	 * complex rollback logic, let's abort the DTXs one by one.
+	 */
+
+	if (!force) {
+		rc = vos_dtx_lookup_cos(cont->sc_hdl, &dre->dre_oid,
+			&dre->dre_xid, dre->dre_hash,
+			dre->dre_intent == DAOS_INTENT_PUNCH ? true : false);
+		if (rc == 0)
+			/* The DTX become committable, should NOT abort it. */
+			return 1;
+
+		if (rc != -DER_NONEXIST)
+			goto out;
+	}
+
+	dte.dte_xid = dre->dre_xid;
+	dte.dte_oid = dre->dre_oid;
+	rc = dtx_abort(po_uuid, cont->sc_uuid, &dte, 1, version);
+
+out:
+	if (rc < 0)
+		D_ERROR("Failed to abort the DTX "DF_UOID"/"DF_DTI": rc = %d\n",
+			DP_UOID(dre->dre_oid), DP_DTI(&dre->dre_xid), rc);
+
+	d_list_del(&dre->dre_link);
+	drh->drh_count--;
+	D_FREE_PTR(dre);
+
+	return rc > 0 ? 0 : rc;
+}
+
+static int
+dtx_placement_handle(struct dtx_resync_args *dra, uuid_t co_uuid)
+{
+	struct ds_cont			*cont = NULL;
+	struct pl_obj_layout		*layout = NULL;
+	struct daos_oclass_attr		*oc_attr;
+	struct dtx_resync_head		*drh;
+	struct dtx_resync_entry		*dre;
+	struct dtx_resync_entry		*next;
+	int				 count = 0;
+	int				 err = 0;
+	int				 idx;
+	int				 rc = 0;
+
+	idx = dss_get_module_info()->dmi_tgt_id;
+	D_ASSERT(idx >= 0);
+
+	drh = &dra->tables[idx];
+	if (drh->drh_count == 0)
+		return 0;
+
+	rc = ds_cont_lookup(dra->po_uuid, co_uuid, &cont);
+	if (rc != 0)
+		return rc;
+
+	d_list_for_each_entry_safe(dre, next, &drh->drh_list, dre_link) {
+		if (layout != NULL) {
+			pl_obj_layout_free(layout);
+			layout = NULL;
+		}
+
+		rc = ds_pool_check_leader(dra->po_uuid, &dre->dre_oid,
+					  dra->version, &layout);
+		if (rc <= 0) {
+			if (rc < 0)
+				D_WARN("Not sure about the leader for the DTX "
+				       DF_UOID"/"DF_DTI" (ver = %u): rc = %d, "
+				       "skip it.\n",
+				       DP_UOID(dre->dre_oid),
+				       DP_DTI(&dre->dre_xid), dra->version, rc);
+			else
+				D_DEBUG(DB_TRACE, "Not the leader for the DTX "
+					DF_UOID"/"DF_DTI" (ver = %u) skip it\n",
+					DP_UOID(dre->dre_oid),
+					DP_DTI(&dre->dre_xid), dra->version);
+
+			d_list_del(&dre->dre_link);
+			drh->drh_count--;
+			D_FREE_PTR(dre);
+			continue;
+		}
+
+		if (dre->dre_state == DTX_ST_INIT) {
+			/* The INIT DTX may become committable when we
+			 * scan the DTX tables So re-check its status.
+			 */
+			rc = vos_dtx_check_committable(cont->sc_hdl,
+						       &dre->dre_xid);
+			switch (rc) {
+			case DTX_ST_PREPARED:
+				break;
+			case DTX_ST_INIT:
+				/* I am the leader, and if the DTX is in INIT
+				 * state, then it must be non-committable case,
+				 * unnecessary to check with others. Abort it.
+				 */
+				rc = dtx_resync_abort(dra->po_uuid, cont,
+						drh, dre, dra->version, true);
+				if (rc > 0)
+					goto committable;
+				if (rc < 0)
+					err = rc;
+				continue;
+			default:
+				D_WARN("Not sure about the leader for the DTX "
+				       DF_UOID"/"DF_DTI": rc = %d, skip it.\n",
+				       DP_UOID(dre->dre_oid),
+				       DP_DTI(&dre->dre_xid), rc);
+				/* Fall through. */
+			case DTX_ST_COMMITTED:
+				d_list_del(&dre->dre_link);
+				drh->drh_count--;
+				D_FREE_PTR(dre);
+				continue;
+			}
+		}
+
+		oc_attr = daos_oclass_attr_find(dre->dre_oid.id_pub);
+		D_ASSERT(oc_attr->ca_resil == DAOS_RES_REPL);
+
+		rc = dtx_check_committable(dra->po_uuid, co_uuid, &dre->dre_xid,
+					   &dre->dre_oid, layout);
+		if (rc == DTX_ST_INIT) {
+			rc = dtx_resync_abort(dra->po_uuid, cont,
+					      drh, dre, dra->version, false);
+			if (rc > 0)
+				goto committable;
+			if (rc < 0)
+				err = rc;
+			continue;
+		}
+
+		if (rc != DTX_ST_COMMITTED && rc != DTX_ST_PREPARED) {
+			/* We are not sure about whether the DTX can be
+			 * committed or not, then we have to skip it.
+			 */
+			D_WARN("Not sure about whether the DTX "DF_UOID
+			       "/"DF_DTI" can be committed or not: rc = %d\n",
+			       DP_UOID(dre->dre_oid),
+			       DP_DTI(&dre->dre_xid), rc);
+
+			d_list_del(&dre->dre_link);
+			drh->drh_count--;
+			D_FREE_PTR(dre);
+			continue;
+		}
+
+committable:
+		if (++count >= DTX_THRESHOLD_COUNT) {
+			rc = dtx_resync_commit(dra->po_uuid, co_uuid,
+					       drh, count, dra->version);
+			if (rc < 0)
+				err = rc;
+			count = 0;
+		}
+	}
+
+	if (count > 0) {
+		rc = dtx_resync_commit(dra->po_uuid, co_uuid, drh, count,
+				       dra->version);
+		if (rc < 0)
+			err = rc;
+	}
+
+	if (layout != NULL)
+		pl_obj_layout_free(layout);
+
+	if (cont != NULL)
+		ds_cont_put(cont);
+
+	return err;
+}
+
+static int
+dtx_placement_check(uuid_t co_uuid, vos_iter_entry_t *ent, void *args)
+{
+	struct dtx_resync_args		*dra = args;
+	struct dtx_resync_entry		*dre;
+	int				 idx;
+
+	/* The end of the iteration. */
+	if (ent == NULL)
+		return dtx_placement_handle(dra, co_uuid);
+
+	/* Ignore new DTX after the rebuild/recovery start */
+	if (ent->ie_dtx_sec > dra->start)
+		return 0;
+
+	/* We commit the DTXs periodically, there will be not too many DTXs
+	 * to be checked when resync. So we can load all those uncommitted
+	 * DTXs in RAM firstly, then check the state one by one. That avoid
+	 * the race trouble between iteration of active-DTX tree and commit
+	 * (or abort) the DTXs (that will change the active-DTX tree).
+	 */
+
+	idx = dss_get_module_info()->dmi_tgt_id;
+	D_ASSERT(idx >= 0);
+
+	D_ALLOC_PTR(dre);
+	if (dre == NULL)
+		return -DER_NOMEM;
+
+	dre->dre_xid = ent->ie_xid;
+	dre->dre_oid = ent->ie_oid;
+	dre->dre_state = ent->ie_dtx_state;
+	dre->dre_intent = ent->ie_dtx_intent;
+	dre->dre_hash = ent->ie_dtx_hash;
+	d_list_add_tail(&dre->dre_link, &dra->tables[idx].drh_list);
+	dra->tables[idx].drh_count++;
+
+	return 0;
+}
+
+static bool
+dtx_is_tgt_up(uuid_t po_uuid)
+{
+	struct ds_pool		*pool;
+	struct pool_target	*tgt;
+	d_rank_t		 rank;
+	int			 rc;
+
+	pool = ds_pool_lookup(po_uuid);
+	if (pool == NULL)
+		return false;
+
+	D_ASSERT(pool->sp_map != NULL);
+
+	crt_group_rank(NULL, &rank);
+	rc = pool_map_find_target_by_rank_idx(pool->sp_map, rank,
+				dss_get_module_info()->dmi_tgt_id, &tgt);
+	D_ASSERT(rc == 1);
+
+	ds_pool_put(pool);
+
+	return (tgt->ta_comp.co_status == PO_COMP_ST_UP);
+}
+
+static int
+dtx_resync_scanner(void *data)
+{
+	struct dtx_iter_args	*dia = data;
+	struct dtx_resync_args	*dra = dia->arg;
+
+	if (!dtx_is_tgt_up(dra->po_uuid))
+		return 0;
+
+	return ds_pool_rebuild_iter(dra->po_uuid, dia->callback, dra,
+				    VOS_ITER_DTX);
+}
+
+int
+dtx_resync(daos_handle_t po_hdl, uuid_t po_uuid, uuid_t co_uuid,
+	   uint32_t version, bool collective)
+{
+	struct dtx_resync_args		 dra = { 0 };
+	struct dtx_resync_head		*tables;
+	struct dtx_resync_entry		*dre;
+	struct dtx_resync_entry		*next;
+	int				 rc;
+	int				 i;
+
+	D_ALLOC_ARRAY(tables, dss_tgt_nr);
+	if (tables == NULL) {
+		D_ERROR(DF_UUID"/"DF_UUID" not enough DRAM for resync DTX.\n",
+			DP_UUID(po_uuid), DP_UUID(co_uuid));
+		return -DER_NOMEM;
+	}
+
+	for (i = 0; i < dss_tgt_nr; i++) {
+		D_INIT_LIST_HEAD(&tables[i].drh_list);
+		tables[i].drh_count = 0;
+	}
+
+	uuid_copy(dra.po_uuid, po_uuid);
+	dra.start = time(NULL);
+	dra.version = version;
+	dra.tables = tables;
+
+	D_DEBUG(DB_TRACE, "resync DTX scan %s "DF_UUID" start.\n",
+		collective ? "collective" : "non-collective", DP_UUID(po_uuid));
+
+	if (collective) {
+		struct dtx_iter_args	dia = { 0 };
+
+		dia.callback = dtx_placement_check;
+		dia.arg = &dra;
+
+		rc = dss_thread_collective(dtx_resync_scanner, &dia, 0);
+	} else {
+		D_ASSERT(!daos_handle_is_inval(po_hdl));
+
+		rc = ds_cont_rebuild_iter(po_hdl, co_uuid, dtx_placement_check,
+					  &dra, VOS_ITER_DTX);
+	}
+
+	for (i = 0; i < dss_tgt_nr; i++) {
+		d_list_for_each_entry_safe(dre, next,
+					   &tables[i].drh_list, dre_link) {
+			d_list_del(&dre->dre_link);
+			D_FREE_PTR(dre);
+		}
+	}
+
+	D_FREE(tables);
+
+	return rc > 0 ? 0 : rc;
+}

--- a/src/dtx/dtx_rpc.c
+++ b/src/dtx/dtx_rpc.c
@@ -1,0 +1,723 @@
+/**
+ * (C) Copyright 2019 Intel Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * GOVERNMENT LICENSE RIGHTS-OPEN SOURCE SOFTWARE
+ * The Government's rights to use, modify, reproduce, release, perform, display,
+ * or disclose this software are subject to the terms of the Apache License as
+ * provided in Contract No. B609815.
+ * Any reproduction of computer software, computer software documentation, or
+ * portions thereof marked with this legend must also reproduce the markings.
+ */
+/**
+ * dtx: DTX RPC
+ */
+#define D_LOGFAC	DD_FAC(dtx)
+
+#include <abt.h>
+#include <daos/rpc.h>
+#include <daos/btree.h>
+#include <daos/pool_map.h>
+#include <daos/placement.h>
+#include <daos/btree_class.h>
+#include <daos_srv/vos.h>
+#include <daos_srv/dtx_srv.h>
+#include <daos_srv/container.h>
+#include <daos_srv/daos_server.h>
+#include "dtx_internal.h"
+
+static int
+crt_proc_struct_daos_tx_id(crt_proc_t proc, struct daos_tx_id *dti)
+{
+	int rc;
+
+	rc = crt_proc_uuid_t(proc, &dti->dti_uuid);
+	if (rc != 0)
+		return -DER_HG;
+
+	rc = crt_proc_uint64_t(proc, &dti->dti_sec);
+	if (rc != 0)
+		return -DER_HG;
+
+	return 0;
+}
+
+CRT_RPC_DEFINE(dtx, DAOS_ISEQ_DTX, DAOS_OSEQ_DTX);
+
+#define X(a, b, c, d, e)	\
+{				\
+	.prf_flags   = b,	\
+	.prf_req_fmt = c,	\
+	.prf_hdlr    = NULL,	\
+	.prf_co_ops  = NULL,	\
+}
+
+static struct crt_proto_rpc_format dtx_proto_rpc_fmt[] = {
+	DTX_PROTO_SRV_RPC_LIST,
+};
+
+#undef X
+
+struct crt_proto_format dtx_proto_fmt = {
+	.cpf_name  = "dtx-proto",
+	.cpf_ver   = DAOS_DTX_VERSION,
+	.cpf_count = ARRAY_SIZE(dtx_proto_rpc_fmt),
+	.cpf_prf   = dtx_proto_rpc_fmt,
+	.cpf_base  = DAOS_RPC_OPCODE(0, DAOS_DTX_MODULE, 0)
+};
+
+static int
+dtx_req_create(crt_context_t crt_ctx, crt_endpoint_t *tgt_ep,
+	       crt_opcode_t opc, crt_rpc_t **req)
+{
+	crt_opcode_t	opcode;
+
+	opcode = DAOS_RPC_OPCODE(opc, DAOS_DTX_MODULE, DAOS_DTX_VERSION);
+	/* call daos_rpc_tag to get the target tag/context idx */
+	tgt_ep->ep_tag = daos_rpc_tag(DAOS_REQ_DTX, tgt_ep->ep_tag);
+
+	return crt_req_create(crt_ctx, tgt_ep, opcode, req);
+}
+
+/* Top level DTX RPC args */
+struct dtx_req_args {
+	ABT_future			 dra_future;
+	/* The RPC code */
+	crt_opcode_t			 dra_opc;
+	/* pool UUID */
+	uuid_t				 dra_po_uuid;
+	/* container UUID */
+	uuid_t				 dra_co_uuid;
+	/* Pointer to the global list head for all the dtx_req_rec. */
+	d_list_t			*dra_list;
+	/* The length of aobve global list. */
+	int				 dra_length;
+	/* The collective RPC result. */
+	int				 dra_result;
+};
+
+/* The record for the DTX classify-tree in DRAM.
+ * Also used as the sub-request (to related rank/tag) args.
+ */
+struct dtx_req_rec {
+	/* All the records are linked into one global list,
+	 * used for travelling the classify-tree efficiently.
+	 */
+	d_list_t			 drr_link;
+	struct dtx_req_args		*drr_parent; /* The top level args */
+	d_rank_t			 drr_rank; /* The server ID */
+	uint32_t			 drr_tag; /* The VOS ID */
+	int				 drr_count; /* DTX count */
+	int				 drr_result; /* The sub-req result */
+	struct daos_tx_id		*drr_dti; /* The DTX array */
+};
+
+struct dtx_cf_rec_bundle {
+	union {
+		struct {
+			d_rank_t	 dcrb_rank;
+			uint32_t	 dcrb_tag;
+		};
+		uint64_t		 dcrb_key;
+	};
+	/* Pointer to the global list head for all the dtx_req_rec. */
+	d_list_t			*dcrb_head;
+	/* Pointer to the length of above global list. */
+	int				*dcrb_length;
+	/* Current DTX to be classified. */
+	struct daos_tx_id		*dcrb_dti;
+	/* The number of DTXs to be classified that will be used as
+	 * the dtx_req_rec::drr_dti array size when allocating it.
+	 */
+	int				 dcrb_count;
+};
+
+static void
+dtx_sub_req_cb(const struct crt_cb_info *cb_info)
+{
+	crt_rpc_t		*req = cb_info->cci_rpc;
+	struct dtx_req_rec	*drr = cb_info->cci_arg;
+	struct dtx_req_args	*dra = drr->drr_parent;
+	struct dtx_out		*dout;
+	int			 rc = cb_info->cci_rc;
+
+	if (rc == 0) {
+		dout = crt_reply_get(req);
+		rc = dout->do_status;
+	}
+
+	drr->drr_result = rc;
+	rc = ABT_future_set(dra->dra_future, drr);
+	D_ASSERTF(rc == ABT_SUCCESS,
+		  "ABT_future_set failed for opc %x to %d/%d: rc = %d.\n",
+		  dra->dra_opc, drr->drr_rank, drr->drr_tag, rc);
+
+	D_DEBUG(DB_TRACE,
+		"DTX req for opc %x got reply from %d/%d: rc = %d.\n",
+		dra->dra_opc, drr->drr_rank, drr->drr_tag, rc);
+}
+
+static int
+dtx_sub_req_send(struct dtx_req_rec *drr)
+{
+	struct dtx_req_args	*dra = drr->drr_parent;
+	crt_rpc_t		*req;
+	struct dtx_in		*din;
+	crt_endpoint_t		 tgt_ep;
+	int			 rc;
+
+	tgt_ep.ep_grp = NULL;
+	tgt_ep.ep_rank = drr->drr_rank;
+	tgt_ep.ep_tag = drr->drr_tag;
+
+	rc = dtx_req_create(dss_get_module_info()->dmi_ctx, &tgt_ep,
+			    dra->dra_opc, &req);
+	if (rc == 0) {
+		din = crt_req_get(req);
+		uuid_copy(din->di_po_uuid, dra->dra_po_uuid);
+		uuid_copy(din->di_co_uuid, dra->dra_co_uuid);
+		din->di_dtx_array.ca_count = drr->drr_count;
+		din->di_dtx_array.ca_arrays = drr->drr_dti;
+
+		rc = crt_req_send(req, dtx_sub_req_cb, drr);
+		if (rc != 0)
+			crt_req_decref(req);
+	}
+
+	D_DEBUG(DB_TRACE, "DTX req for opc %x sent: rc = %d.\n",
+		dra->dra_opc, rc);
+
+	if (rc != 0) {
+		drr->drr_result = rc;
+		ABT_future_set(dra->dra_future, drr);
+	}
+
+	return rc;
+}
+
+static void
+dtx_req_cb(void **args)
+{
+	struct dtx_req_rec	*drr = args[0];
+	struct dtx_req_args	*dra = drr->drr_parent;
+	int			 i;
+
+	if (dra->dra_opc == DTX_CHECK) {
+		for (i = 0; i < dra->dra_length; i++) {
+			drr = args[i];
+			switch (drr->drr_result) {
+			case DTX_ST_INIT:
+				dra->dra_result = DTX_ST_INIT;
+				break;
+			case DTX_ST_COMMITTED:
+				dra->dra_result = DTX_ST_COMMITTED;
+				/* As long as one replica has committed the DTX,
+				 * then the DTX is committable on all replicas.
+				 */
+				D_DEBUG(DB_TRACE,
+					"The DTX "DF_DTI" has been committed "
+					"on %d/%d.\n", DP_DTI(drr->drr_dti),
+					drr->drr_rank, drr->drr_tag);
+				return;
+			case DTX_ST_PREPARED:
+				if (dra->dra_result == 0)
+					dra->dra_result = DTX_ST_PREPARED;
+				break;
+			default:
+				if (dra->dra_result != DTX_ST_INIT)
+					dra->dra_result = drr->drr_result >= 0 ?
+						-DER_IO : drr->drr_result;
+				break;
+			}
+
+			D_DEBUG(DB_TRACE, "The DTX "DF_DTI" RPC req result %d, "
+				"status is %d.\n", DP_DTI(drr->drr_dti),
+				drr->drr_result, dra->dra_result);
+		}
+	} else {
+		for (i = 0; i < dra->dra_length; i++) {
+			drr = args[i];
+			if (dra->dra_result == 0)
+				dra->dra_result = drr->drr_result;
+
+			if (dra->dra_result != 0) {
+				D_ERROR("DTX req for opc %x failed: rc = %d.\n",
+					dra->dra_opc, dra->dra_result);
+				return;
+			}
+		}
+
+		D_DEBUG(DB_TRACE, "DTX req for opc %x succeed.\n",
+			dra->dra_opc);
+	}
+}
+
+static int
+dtx_req_send(crt_opcode_t opc, d_list_t *head, int length, uuid_t po_uuid,
+	     uuid_t co_uuid)
+{
+	ABT_future		 future;
+	struct dtx_req_args	 dra;
+	struct dtx_req_rec	*drr;
+	int			 rc;
+
+	dra.dra_opc = opc;
+	uuid_copy(dra.dra_po_uuid, po_uuid);
+	uuid_copy(dra.dra_co_uuid, co_uuid);
+	dra.dra_list = head;
+	dra.dra_length = length;
+	dra.dra_result = 0;
+
+	rc = ABT_future_create(length, dtx_req_cb, &future);
+	if (rc != ABT_SUCCESS) {
+		D_ERROR("ABT_future_create failed for opc %x, length = %d: "
+			"rc = %d.\n", opc, length, rc);
+		return dss_abterr2der(rc);
+	}
+
+	dra.dra_future = future;
+	d_list_for_each_entry(drr, head, drr_link) {
+		drr->drr_parent = &dra;
+		drr->drr_result = 0;
+		rc = dtx_sub_req_send(drr);
+		if (rc != 0)
+			break;
+	}
+
+	if (rc != 0) {
+		while (drr->drr_link.next != head) {
+			drr = d_list_entry(drr->drr_link.next,
+					   struct dtx_req_rec, drr_link);
+			drr->drr_parent = &dra;
+			drr->drr_result = rc;
+			ABT_future_set(future, drr);
+		}
+	}
+
+	rc = ABT_future_wait(future);
+	D_ASSERTF(rc == ABT_SUCCESS,
+		  "ABT_future_wait failed for opc %x, length = %d: rc = %d.\n",
+		  opc, length, rc);
+
+	ABT_future_free(&future);
+	rc = dra.dra_result;
+
+	D_DEBUG(DB_TRACE, "DTX req for opc %x: rc = %d\n", opc, rc);
+
+	return rc;
+}
+
+static int
+dtx_cf_rec_alloc(struct btr_instance *tins, daos_iov_t *key_iov,
+		 daos_iov_t *val_iov, struct btr_record *rec)
+{
+	struct dtx_req_rec		*drr;
+	struct dtx_cf_rec_bundle	*dcrb;
+
+	D_ASSERT(tins->ti_umm.umm_id == UMEM_CLASS_VMEM);
+
+	D_ALLOC_PTR(drr);
+	if (drr == NULL)
+		return -DER_NOMEM;
+
+	dcrb = (struct dtx_cf_rec_bundle *)val_iov->iov_buf;
+	D_ALLOC_ARRAY(drr->drr_dti, dcrb->dcrb_count);
+	if (drr->drr_dti == NULL) {
+		D_FREE_PTR(drr);
+		return -DER_NOMEM;
+	}
+
+	drr->drr_rank = dcrb->dcrb_rank;
+	drr->drr_tag = dcrb->dcrb_tag;
+	drr->drr_count = 1;
+	drr->drr_dti[0] = *dcrb->dcrb_dti;
+	d_list_add_tail(&drr->drr_link, dcrb->dcrb_head);
+	++(*dcrb->dcrb_length);
+
+	rec->rec_mmid = umem_ptr2id(&tins->ti_umm, drr);
+	return 0;
+}
+
+static int
+dtx_cf_rec_free(struct btr_instance *tins, struct btr_record *rec, void *args)
+{
+	struct dtx_req_rec	*drr;
+
+	D_ASSERT(tins->ti_umm.umm_id == UMEM_CLASS_VMEM);
+
+	drr = (struct dtx_req_rec *)umem_id2ptr(&tins->ti_umm, rec->rec_mmid);
+	d_list_del(&drr->drr_link);
+	D_FREE(drr->drr_dti);
+	D_FREE_PTR(drr);
+
+	return 0;
+}
+
+static int
+dtx_cf_rec_fetch(struct btr_instance *tins, struct btr_record *rec,
+		 daos_iov_t *key_iov, daos_iov_t *val_iov)
+{
+	D_ASSERTF(0, "We should not come here.\n");
+	return 0;
+}
+
+static int
+dtx_cf_rec_update(struct btr_instance *tins, struct btr_record *rec,
+		  daos_iov_t *key, daos_iov_t *val)
+{
+	struct dtx_req_rec		*drr;
+	struct dtx_cf_rec_bundle	*dcrb;
+
+	drr = (struct dtx_req_rec *)umem_id2ptr(&tins->ti_umm, rec->rec_mmid);
+	dcrb = (struct dtx_cf_rec_bundle *)val->iov_buf;
+	drr->drr_dti[drr->drr_count++] = *dcrb->dcrb_dti;
+
+	return 0;
+}
+
+btr_ops_t dbtree_dtx_cf_ops = {
+	.to_rec_alloc	= dtx_cf_rec_alloc,
+	.to_rec_free	= dtx_cf_rec_free,
+	.to_rec_fetch	= dtx_cf_rec_fetch,
+	.to_rec_update	= dtx_cf_rec_update,
+};
+
+#define DTX_CF_BTREE_ORDER	20
+
+static int
+dtx_dti_classify_one(struct ds_pool *pool, uuid_t po_uuid, uuid_t co_uuid,
+		     daos_handle_t tree, d_list_t *head, int *length,
+		     daos_unit_oid_t *oid, struct daos_tx_id *dti,
+		     int count, uint32_t version)
+{
+	struct daos_oclass_attr		*oc_attr;
+	struct pl_obj_layout		*layout = NULL;
+	struct daos_obj_md		 md = { 0 };
+	struct dtx_cf_rec_bundle	 dcrb;
+	d_rank_t			 myrank;
+	uint32_t			 replicas;
+	int				 start;
+	int				 rc = 0;
+	int				 i;
+
+	oc_attr = daos_oclass_attr_find(oid->id_pub);
+	if (oc_attr->ca_resil != DAOS_RES_REPL)
+		return -DER_NOTAPPLICABLE;
+
+	md.omd_id = oid->id_pub;
+	md.omd_ver = version;
+	rc = pl_obj_place(pool->sp_pl_map, &md, NULL, &layout);
+	if (rc != 0)
+		return rc;
+
+	if (layout->ol_nr <= oid->id_shard)
+		D_GOTO(out, rc = -DER_INVAL);
+
+	replicas = oc_attr->u.repl.r_num;
+	if (replicas == DAOS_OBJ_REPL_MAX)
+		replicas = layout->ol_nr;
+
+	if (replicas < 1)
+		D_GOTO(out, rc = -DER_INVAL);
+
+	/* Skip single replicated object. */
+	if (replicas == 1)
+		D_GOTO(out, rc = 0);
+
+	dcrb.dcrb_count = count;
+	dcrb.dcrb_dti = dti;
+	dcrb.dcrb_head = head;
+	dcrb.dcrb_length = length;
+
+	crt_group_rank(NULL, &myrank);
+	start = (oid->id_shard / replicas) * replicas;
+	for (i = start; i < start + replicas && rc == 0; i++) {
+		struct pl_obj_shard	*shard;
+		struct pool_target	*target;
+		daos_iov_t		 kiov;
+		daos_iov_t		 riov;
+
+		/* skip unavailable replica(s). */
+		shard = &layout->ol_shards[i];
+		if (shard->po_target == -1 || shard->po_rebuilding)
+			continue;
+
+		rc = pool_map_find_target(pool->sp_map, shard->po_target,
+					  &target);
+		if (rc != 1)
+			D_GOTO(out, rc = -DER_INVAL);
+
+		/* skip myself. */
+		if (myrank == target->ta_comp.co_rank)
+			continue;
+
+		dcrb.dcrb_rank = target->ta_comp.co_rank;
+		dcrb.dcrb_tag = target->ta_comp.co_index;
+
+		daos_iov_set(&riov, &dcrb, sizeof(dcrb));
+		daos_iov_set(&kiov, &dcrb.dcrb_key, sizeof(dcrb.dcrb_key));
+		rc = dbtree_upsert(tree, BTR_PROBE_EQ, DAOS_INTENT_UPDATE,
+				   &kiov, &riov);
+	}
+
+out:
+	if (layout != NULL)
+		pl_obj_layout_free(layout);
+	return rc;
+}
+
+static int
+dtx_dti_classify(uuid_t po_uuid, uuid_t co_uuid, daos_handle_t tree,
+		 struct daos_tx_entry *dte, int count, uint32_t version,
+		 d_list_t *head, struct daos_tx_id **dtis)
+{
+	struct daos_tx_id	*dti = NULL;
+	struct ds_pool		*pool;
+	int			 length = 0;
+	int			 rc = 0;
+	int			 i;
+
+	pool = ds_pool_lookup(po_uuid);
+	if (pool == NULL)
+		return -DER_INVAL;
+
+	D_ASSERT(pool->sp_map != NULL);
+	D_ASSERT(pool->sp_pl_map != NULL);
+
+	D_ALLOC_ARRAY(dti, count);
+	if (dti == NULL)
+		D_GOTO(out, rc = -DER_NOMEM);
+
+	for (i = 0; i < count; i++) {
+		rc = dtx_dti_classify_one(pool, po_uuid, co_uuid, tree, head,
+					  &length, &dte[i].dte_oid,
+					  &dte[i].dte_xid, count, version);
+		if (rc < 0)
+			break;
+
+		dti[i] = dte[i].dte_xid;
+	}
+
+out:
+	if (rc >= 0)
+		*dtis = dti;
+	else if (dti != NULL)
+		D_FREE(dti);
+
+	ds_pool_put(pool);
+	return rc < 0 ? rc : length;
+}
+
+int
+dtx_commit(uuid_t po_uuid, uuid_t co_uuid, struct daos_tx_entry *dte,
+	   int count, uint32_t version)
+{
+	struct ds_cont		*cont = NULL;
+	struct daos_tx_id	*dti = NULL;
+	struct umem_attr	 uma;
+	struct btr_root		 tree_root = { 0 };
+	daos_handle_t		 tree_hdl = DAOS_HDL_INVAL;
+	d_list_t		 head;
+	int			 length;
+	int			 rc = 0;
+	int			 rc1 = 0;
+
+	rc = ds_cont_lookup(po_uuid, co_uuid, &cont);
+	if (rc != 0)
+		return rc;
+
+	D_INIT_LIST_HEAD(&head);
+	memset(&uma, 0, sizeof(uma));
+	uma.uma_id = UMEM_CLASS_VMEM;
+	rc = dbtree_create_inplace(DBTREE_CLASS_DTX_CF, 0, DTX_CF_BTREE_ORDER,
+				   &uma, &tree_root, &tree_hdl);
+	if (rc != 0)
+		D_GOTO(out, rc);
+
+	length = dtx_dti_classify(po_uuid, co_uuid, tree_hdl, dte, count,
+				  version, &head, &dti);
+	if (length < 0)
+		D_GOTO(out, rc = length);
+
+	if (!d_list_empty(&head))
+		rc = dtx_req_send(DTX_COMMIT, &head, length, po_uuid, co_uuid);
+
+	if (dti != NULL)
+		/* We cannot rollback the commit, so commit locally anyway. */
+		rc1 = vos_dtx_commit(cont->sc_hdl, dti, count);
+
+out:
+	if (dti != NULL)
+		D_FREE(dti);
+
+	if (!daos_handle_is_inval(tree_hdl))
+		dbtree_destroy(tree_hdl);
+
+	D_ASSERT(d_list_empty(&head));
+
+	if (cont != NULL)
+		ds_cont_put(cont);
+
+	return rc >= 0 ? rc1 : rc;
+}
+
+int
+dtx_abort(uuid_t po_uuid, uuid_t co_uuid, struct daos_tx_entry *dte,
+	  int count, uint32_t version)
+{
+	struct ds_cont		*cont = NULL;
+	struct daos_tx_id	*dti = NULL;
+	struct umem_attr	 uma;
+	struct btr_root		 tree_root = { 0 };
+	daos_handle_t		 tree_hdl = DAOS_HDL_INVAL;
+	d_list_t		 head;
+	int			 length;
+	int			 rc = 0;
+
+	/* Currently we only support to abort DTXs one by one. */
+	D_ASSERT(count == 1);
+
+	rc = ds_cont_lookup(po_uuid, co_uuid, &cont);
+	if (rc != 0)
+		return rc;
+
+	D_INIT_LIST_HEAD(&head);
+	memset(&uma, 0, sizeof(uma));
+	uma.uma_id = UMEM_CLASS_VMEM;
+	rc = dbtree_create_inplace(DBTREE_CLASS_DTX_CF, 0, DTX_CF_BTREE_ORDER,
+				   &uma, &tree_root, &tree_hdl);
+	if (rc != 0)
+		D_GOTO(out, rc);
+
+	length = dtx_dti_classify(po_uuid, co_uuid, tree_hdl, dte, count,
+				  version, &head, &dti);
+	if (length < 0)
+		D_GOTO(out, rc = length);
+
+	D_ASSERT(dti != NULL);
+
+	/* Local abort firstly. */
+	rc = vos_dtx_abort(cont->sc_hdl, dti, count, false);
+	if (rc != 0)
+		D_GOTO(out, rc);
+
+	if (!d_list_empty(&head))
+		rc = dtx_req_send(DTX_ABORT, &head, length, po_uuid, co_uuid);
+
+out:
+	if (dti != NULL)
+		D_FREE(dti);
+
+	if (!daos_handle_is_inval(tree_hdl))
+		dbtree_destroy(tree_hdl);
+
+	D_ASSERT(d_list_empty(&head));
+
+	if (cont != NULL)
+		ds_cont_put(cont);
+
+	return rc == -DER_NONEXIST ? 0 : rc;
+}
+
+int
+dtx_check(uuid_t po_uuid, uuid_t co_uuid, struct daos_tx_entry *dte,
+	  struct pl_obj_layout *layout)
+{
+	struct ds_pool		*pool;
+	struct daos_oclass_attr *oc_attr;
+	daos_unit_oid_t		*oid = &dte->dte_oid;
+	struct dtx_req_rec	*drr;
+	struct dtx_req_rec	*next;
+	d_list_t		 head;
+	d_rank_t		 myrank;
+	uint32_t		 replicas;
+	int			 length = 0;
+	int			 start;
+	int			 rc = 0;
+	int			 i;
+
+	if (layout->ol_nr <= oid->id_shard)
+		return -DER_INVAL;
+
+	oc_attr = daos_oclass_attr_find(oid->id_pub);
+	if (oc_attr->ca_resil != DAOS_RES_REPL)
+		return -DER_NOTAPPLICABLE;
+
+	replicas = oc_attr->u.repl.r_num;
+	if (replicas == DAOS_OBJ_REPL_MAX)
+		replicas = layout->ol_nr;
+
+	if (replicas < 1)
+		return -DER_INVAL;
+
+	/* If no other replica, then currnet replica is the unique
+	 * one that can be committed if it is 'prepared'.
+	 */
+	if (replicas == 1)
+		return DTX_ST_PREPARED;
+
+	pool = ds_pool_lookup(po_uuid);
+	if (pool == NULL)
+		return -DER_INVAL;
+
+	D_INIT_LIST_HEAD(&head);
+	crt_group_rank(NULL, &myrank);
+	start = (oid->id_shard / replicas) * replicas;
+	for (i = start; i < start + replicas; i++) {
+		struct pl_obj_shard	*shard;
+		struct pool_target	*target;
+
+		/* skip unavailable replica(s). */
+		shard = &layout->ol_shards[i];
+		if (shard->po_target == -1 || shard->po_rebuilding)
+			continue;
+
+		rc = pool_map_find_target(pool->sp_map, shard->po_target,
+					  &target);
+		if (rc != 1)
+			D_GOTO(out, rc = -DER_INVAL);
+
+		/* skip myself. */
+		if (myrank == target->ta_comp.co_rank)
+			continue;
+
+		D_ALLOC_PTR(drr);
+		if (drr == NULL)
+			D_GOTO(out, rc = -DER_NOMEM);
+
+		drr->drr_rank = target->ta_comp.co_rank;
+		drr->drr_tag = target->ta_comp.co_index;
+		drr->drr_count = 1;
+		drr->drr_dti = &dte->dte_xid;
+		d_list_add_tail(&drr->drr_link, &head);
+		length++;
+	}
+
+	/* If no other available replicas, then currnet replica is the
+	 * unique valid one, it can be committed if it is also 'prepared'.
+	 */
+	if (d_list_empty(&head))
+		rc = DTX_ST_PREPARED;
+	else
+		rc = dtx_req_send(DTX_CHECK, &head, length, po_uuid, co_uuid);
+
+out:
+	d_list_for_each_entry_safe(drr, next, &head, drr_link) {
+		d_list_del(&drr->drr_link);
+		D_FREE_PTR(drr);
+	}
+
+	ds_pool_put(pool);
+	return rc;
+}

--- a/src/dtx/dtx_srv.c
+++ b/src/dtx/dtx_srv.c
@@ -1,0 +1,127 @@
+/**
+ * (C) Copyright 2019 Intel Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * GOVERNMENT LICENSE RIGHTS-OPEN SOURCE SOFTWARE
+ * The Government's rights to use, modify, reproduce, release, perform, display,
+ * or disclose this software are subject to the terms of the Apache License as
+ * provided in Contract No. B609815.
+ * Any reproduction of computer software, computer software documentation, or
+ * portions thereof marked with this legend must also reproduce the markings.
+ */
+/**
+ * dtx: DTX rpc service
+ */
+#define D_LOGFAC	DD_FAC(dtx)
+
+#include <daos/rpc.h>
+#include <daos/btree_class.h>
+#include <daos_srv/daos_server.h>
+#include <daos_srv/container.h>
+#include <daos_srv/vos.h>
+#include <daos_srv/dtx_srv.h>
+#include "dtx_internal.h"
+
+static void
+dtx_handler(crt_rpc_t *rpc)
+{
+	struct dtx_in		*din = crt_req_get(rpc);
+	struct dtx_out		*dout = crt_reply_get(rpc);
+	struct ds_cont		*cont = NULL;
+	uint32_t		 opc = opc_get(rpc->cr_opc);
+	int			 rc;
+
+	rc = ds_cont_lookup(din->di_po_uuid, din->di_co_uuid, &cont);
+	if (rc != 0) {
+		D_ERROR("Failed to locate pool="DF_UUID" cont="DF_UUID
+			" for DTX rpc %u: rc = %d\n", DP_UUID(din->di_po_uuid),
+			DP_UUID(din->di_co_uuid), opc, rc);
+
+		D_GOTO(out, rc);
+	}
+
+	switch (opc) {
+	case DTX_COMMIT:
+		rc = vos_dtx_commit(cont->sc_hdl, din->di_dtx_array.ca_arrays,
+				    din->di_dtx_array.ca_count);
+		break;
+	case DTX_ABORT:
+		rc = vos_dtx_abort(cont->sc_hdl, din->di_dtx_array.ca_arrays,
+				   din->di_dtx_array.ca_count, true);
+		break;
+	case DTX_CHECK:
+		/* Currently, only support to check single DTX state. */
+		if (din->di_dtx_array.ca_count != 1)
+			rc = -DER_PROTO;
+		else
+			rc = vos_dtx_check_committable(cont->sc_hdl,
+						din->di_dtx_array.ca_arrays);
+		break;
+	default:
+		rc = -DER_INVAL;
+		break;
+	}
+
+	if (rc < 0)
+		D_ERROR("Failed to handle DTX rpc %u: rc = %d\n", opc, rc);
+
+out:
+	dout->do_status = rc;
+	rc = crt_reply_send(rpc);
+	if (rc != 0)
+		D_ERROR("send reply failed for DTX rpc %u: rc = %d\n", opc, rc);
+
+	if (cont != NULL)
+		ds_cont_put(cont);
+}
+
+static int
+dtx_init(void)
+{
+	int	rc;
+
+	rc = dbtree_class_register(DBTREE_CLASS_DTX_CF, BTR_FEAT_UINT_KEY,
+				   &dbtree_dtx_cf_ops);
+	return rc;
+}
+
+static int
+dtx_fini(void)
+{
+	return 0;
+}
+
+#define X(a, b, c, d, e)	\
+{				\
+	.dr_opc       = a,	\
+	.dr_hdlr      = d,	\
+	.dr_corpc_ops = e,	\
+}
+
+static struct daos_rpc_handler dtx_handlers[] = {
+	DTX_PROTO_SRV_RPC_LIST,
+};
+
+#undef X
+
+struct dss_module dtx_module =  {
+	.sm_name	= "dtx",
+	.sm_mod_id	= DAOS_DTX_MODULE,
+	.sm_ver		= DAOS_DTX_VERSION,
+	.sm_init	= dtx_init,
+	.sm_fini	= dtx_fini,
+	.sm_proto_fmt	= &dtx_proto_fmt,
+	.sm_cli_count	= 0,
+	.sm_handlers	= dtx_handlers,
+};

--- a/src/include/daos/btree.h
+++ b/src/include/daos/btree.h
@@ -565,6 +565,7 @@ int  dbtree_delete(daos_handle_t toh, daos_iov_t *key, void *args);
 int  dbtree_query(daos_handle_t toh, struct btr_attr *attr,
 		  struct btr_stat *stat);
 int  dbtree_is_empty(daos_handle_t toh);
+struct umem_instance *btr_hdl2umm(daos_handle_t toh);
 
 /******* iterator API ******************************************************/
 

--- a/src/include/daos/btree.h
+++ b/src/include/daos/btree.h
@@ -221,6 +221,9 @@ enum btr_key_cmp_rc {
 	BTR_CMP_MATCHED	= (1 << 2),
 	BTR_CMP_UNKNOWN	= (1 << 3),	/* unset */
 	BTR_CMP_ERR	= (1 << 4),	/* error */
+
+	/* The target is in some uncommitted DTX */
+	BTR_CMP_INPROGRESS	= (1 << 5),
 };
 
 /**
@@ -480,6 +483,25 @@ typedef struct {
 	 */
 	int		(*to_node_tx_add)(struct btr_instance *tins,
 					  TMMID(struct btr_node) nd_mmid);
+	/**
+	 * Optional:
+	 * Check whether the given record is visible to outside or not.
+	 *
+	 * \param tins	[IN]	Tree instance which contains the root mmid
+	 *			and memory class etc.
+	 * \param rec	[IN]	Record to be checked.
+	 * \parem intent [IN]	The intent for why check the record.
+	 *
+	 * \a return		Positive value for visible case.
+	 *			Zero for invisible case.
+	 *			-DER_INPROGRESS if the target record is in
+	 *			some uncommitted DTX, the caller needs to
+	 *			retry related operation some time later.
+	 *			Other negative values on error.
+	 */
+	int		(*to_check_visibility)(struct btr_instance *tins,
+					       struct btr_record *rec,
+					       uint32_t intent);
 } btr_ops_t;
 
 /**

--- a/src/include/daos/btree_class.h
+++ b/src/include/daos/btree_class.h
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2016 Intel Corporation.
+ * (C) Copyright 2016-2019 Intel Corporation.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -102,5 +102,12 @@ extern btr_ops_t dbtree_iv_ops;
  */
 #define DBTREE_CLASS_RECX (DBTREE_DSM_BEGIN + 5)
 extern btr_ops_t dbtree_recx_ops;
+
+/**
+ * The key is a uint64_t integer: 32-bits rank + 32-bits VOS tag.
+ * The value is the array of DTX IDs.
+ * The dbtree is usually in the volatile memory for classifying DTX IDs.
+ */
+#define DBTREE_CLASS_DTX_CF (DBTREE_DSM_BEGIN + 6)
 
 #endif /* __DAOS_SRV_BTREE_CLASS_H__ */

--- a/src/include/daos/debug.h
+++ b/src/include/daos/debug.h
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2015, 2016 Intel Corporation.
+ * (C) Copyright 2015-2019 Intel Corporation.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -40,6 +40,7 @@ extern int d_rdb_logfac;
 extern int d_rsvc_logfac;
 extern int d_pool_logfac;
 extern int d_container_logfac;
+extern int d_dtx_logfac;
 extern int d_object_logfac;
 extern int d_placement_logfac;
 extern int d_rebuild_logfac;

--- a/src/include/daos/mem.h
+++ b/src/include/daos/mem.h
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2016-2018 Intel Corporation.
+ * (C) Copyright 2016-2019 Intel Corporation.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -110,6 +110,8 @@ int  umem_init_txd(struct umem_tx_stage_data *txd);
 void umem_fini_txd(struct umem_tx_stage_data *txd);
 
 typedef struct {
+	/** convert directly accessible address to ummid */
+	umem_id_t	 (*mo_id)(struct umem_instance *umm, void *addr);
 	/** convert ummid to directly accessible address */
 	void		*(*mo_addr)(struct umem_instance *umm,
 				    umem_id_t ummid);
@@ -358,6 +360,12 @@ static inline void *
 umem_id2ptr(struct umem_instance *umm, umem_id_t ummid)
 {
 	return umm->umm_ops->mo_addr(umm, ummid);
+}
+
+static inline umem_id_t
+umem_ptr2id(struct umem_instance *umm, void *ptr)
+{
+	return umm->umm_ops->mo_id(umm, ptr);
 }
 
 #define umem_id2ptr_typed(umm, tmmid)					\

--- a/src/include/daos/placement.h
+++ b/src/include/daos/placement.h
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2016 Intel Corporation.
+ * (C) Copyright 2016-2019 Intel Corporation.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -52,8 +52,6 @@ struct pl_map_init_attr {
 	};
 };
 
-struct pl_map;
-
 struct pl_target {
 	uint32_t		pt_pos;
 };
@@ -71,6 +69,7 @@ struct pl_target_grp {
 struct pl_obj_shard {
 	uint32_t	po_shard;	/* shard index */
 	uint32_t	po_target;	/* target id */
+	uint32_t	po_fseq;	/* The latest failure sequence */
 	uint32_t	po_rebuilding:1; /* rebuilding status */
 };
 
@@ -80,8 +79,31 @@ struct pl_obj_layout {
 	struct pl_obj_shard	*ol_shards;
 };
 
+/** common header of all placement map */
+struct pl_map {
+	/** correpsonding pool uuid */
+	uuid_t			 pl_uuid;
+	/** link chain on hash */
+	d_list_t		 pl_link;
+	/** protect refcount */
+	pthread_spinlock_t	 pl_lock;
+	/** refcount */
+	int			 pl_ref;
+	/** pool connections, protected by pl_rwlock */
+	int			 pl_connects;
+	/** type of placement map */
+	pl_map_type_t		 pl_type;
+	/** reference to pool map */
+	struct pool_map		*pl_poolmap;
+	/** placement map operations */
+	struct pl_map_ops       *pl_ops;
+};
+
+void pl_map_attr_init(struct pool_map *po_map, pl_map_type_t type,
+		      struct pl_map_init_attr *mia);
+
 int  pl_map_create(struct pool_map *poolmap, struct pl_map_init_attr *mia,
-		   struct pl_map **mapp);
+		   struct pl_map **mapp, bool hash);
 void pl_map_destroy(struct pl_map *map);
 void pl_map_print(struct pl_map *map);
 

--- a/src/include/daos/rpc.h
+++ b/src/include/daos/rpc.h
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2016-2018 Intel Corporation.
+ * (C) Copyright 2016-2019 Intel Corporation.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -65,6 +65,7 @@ enum daos_module_id {
 	DAOS_RDB_MODULE		= 7, /** rdb */
 	DAOS_RDBT_MODULE	= 8, /** rdb test */
 	DAOS_SEC_MODULE		= 9, /** security framework */
+	DAOS_DTX_MODULE		= 10, /** DTX */
 	DAOS_MAX_MODULE		= (1 << MOD_ID_BITS) - 1,
 };
 
@@ -100,6 +101,7 @@ enum daos_rpc_type {
 	DAOS_REQ_IV,
 	DAOS_REQ_BCAST,
 	DAOS_REQ_SWIM,
+	DAOS_REQ_DTX,
 };
 
 /** DAOS_TGT0_OFFSET is target 0's cart context offset */
@@ -124,6 +126,7 @@ daos_rpc_tag(int req_type, int tgt_idx)
 	switch (req_type) {
 	/* for normal IO request, send to the main service thread/context */
 	case DAOS_REQ_IO:
+	case DAOS_REQ_DTX:
 		return DAOS_IO_CTX_ID(tgt_idx);
 	/* target tag 0 is to handle below requests */
 	case DAOS_REQ_MGMT:

--- a/src/include/daos_srv/container.h
+++ b/src/include/daos_srv/container.h
@@ -33,6 +33,7 @@
 #include <daos_types.h>
 #include <daos_srv/pool.h>
 #include <daos_srv/rsvc.h>
+#include <daos_srv/vos_types.h>
 
 void ds_cont_wrlock_metadata(struct cont_svc *svc);
 void ds_cont_rdlock_metadata(struct cont_svc *svc);
@@ -79,7 +80,7 @@ int ds_cont_close_by_pool_hdls(uuid_t pool_uuid, uuid_t *pool_hdls,
 			       int n_pool_hdls, crt_context_t ctx);
 int
 ds_cont_local_open(uuid_t pool_uuid, uuid_t cont_hdl_uuid, uuid_t cont_uuid,
-		   uint64_t capas, struct ds_cont_hdl **cont_hdl);
+		   uint64_t capas, struct ds_cont_hdl **cont_hdl, bool resync);
 int
 ds_cont_local_close(uuid_t cont_hdl_uuid);
 
@@ -90,10 +91,9 @@ ds_cont_lookup(uuid_t pool_uuid, uuid_t cont_uuid, struct ds_cont **ds_cont);
 
 void ds_cont_put(struct ds_cont *cont);
 
-typedef int (*cont_iter_cb_t)(uuid_t co_uuid, daos_unit_oid_t,
-			      daos_epoch_t eph, void *arg);
+typedef int (*cont_iter_cb_t)(uuid_t co_uuid, vos_iter_entry_t *ent, void *arg);
 
 int
-ds_cont_obj_iter(daos_handle_t ph, uuid_t co_uuid, cont_iter_cb_t callback,
-		 void *arg);
+ds_cont_rebuild_iter(daos_handle_t ph, uuid_t co_uuid, cont_iter_cb_t callback,
+		     void *arg, uint32_t type);
 #endif /* ___DAOS_SRV_CONTAINER_H_ */

--- a/src/include/daos_srv/dtx_srv.h
+++ b/src/include/daos_srv/dtx_srv.h
@@ -26,6 +26,7 @@
 
 #include <daos/mem.h>
 #include <daos/dtx.h>
+#include <daos/placement.h>
 
 #define DTX_THRESHOLD_COUNT			512
 #define DTX_COMMIT_THRESHOLD_TIME		60ULL
@@ -94,5 +95,10 @@ enum dtx_status {
 	/** The DTX has been committed. */
 	DTX_ST_COMMITTED	= 3,
 };
+
+int dtx_commit(uuid_t po_uuid, uuid_t co_uuid,
+	       struct daos_tx_entry *dte, int count, uint32_t version);
+int dtx_abort(uuid_t po_uuid, uuid_t co_uuid,
+	      struct daos_tx_entry *dte, int count, uint32_t version);
 
 #endif /* __DAOS_DTX_SRV_H__ */

--- a/src/include/daos_srv/dtx_srv.h
+++ b/src/include/daos_srv/dtx_srv.h
@@ -45,6 +45,11 @@ enum daos_tx_flags {
 	DTX_F_AOC		= 1,
 };
 
+enum dtx_cos_list_types {
+	DCLT_UPDATE		= (1 << 0),
+	DCLT_PUNCH		= (1 << 1),
+};
+
 /**
  * DAOS two-phase commit transaction handle in DRAM.
  */

--- a/src/include/daos_srv/dtx_srv.h
+++ b/src/include/daos_srv/dtx_srv.h
@@ -100,5 +100,7 @@ int dtx_commit(uuid_t po_uuid, uuid_t co_uuid,
 	       struct daos_tx_entry *dte, int count, uint32_t version);
 int dtx_abort(uuid_t po_uuid, uuid_t co_uuid,
 	      struct daos_tx_entry *dte, int count, uint32_t version);
+int dtx_resync(daos_handle_t po_hdl, uuid_t po_uuid, uuid_t co_uuid,
+	       uint32_t version, bool collective);
 
 #endif /* __DAOS_DTX_SRV_H__ */

--- a/src/include/daos_srv/evtree.h
+++ b/src/include/daos_srv/evtree.h
@@ -273,7 +273,8 @@ evt_debug_print_visibility(const struct evt_entry *ent)
 
 	switch (ent->en_visibility & flags) {
 	default:
-		D_ASSERT(0);
+		D_ASSERTF(0, "Unexpected visibility flags %x\n",
+			  ent->en_visibility);
 	case 0:
 		break;
 	case EVT_PARTIAL:

--- a/src/include/daos_srv/pool.h
+++ b/src/include/daos_srv/pool.h
@@ -34,6 +34,7 @@
 #include <daos/lru.h>
 #include <daos/pool_map.h>
 #include <daos/rpc.h>
+#include <daos/placement.h>
 
 /*
  * Pool object
@@ -45,6 +46,7 @@ struct ds_pool {
 	uuid_t			sp_uuid;
 	ABT_rwlock		sp_lock;
 	struct pool_map	       *sp_map;
+	struct pl_map	       *sp_pl_map;
 	uint32_t		sp_map_version;	/* temporary */
 	crt_group_t	       *sp_group;
 	struct ds_iv_ns		*sp_iv_ns;
@@ -165,5 +167,8 @@ int ds_pool_iv_ns_update(struct ds_pool *pool, unsigned int master_rank,
 			 d_iov_t *iv_iov, unsigned int iv_ns_id);
 
 int ds_pool_svc_term_get(uuid_t uuid, uint64_t *term);
+
+int ds_pool_check_leader(uuid_t pool_uuid, daos_unit_oid_t *oid,
+			 uint32_t version, struct pl_obj_layout **plo);
 
 #endif /* __DAOS_SRV_POOL_H__ */

--- a/src/include/daos_srv/pool.h
+++ b/src/include/daos_srv/pool.h
@@ -35,6 +35,7 @@
 #include <daos/pool_map.h>
 #include <daos/rpc.h>
 #include <daos/placement.h>
+#include <daos_srv/vos_types.h>
 
 /*
  * Pool object
@@ -154,9 +155,10 @@ int ds_pool_hdl_list(const uuid_t pool_uuid, uuid_t buf, size_t *size);
  */
 int ds_pool_hdl_evict(const uuid_t pool_uuid, const uuid_t handle_uuid);
 
-typedef int (*obj_iter_cb_t)(uuid_t cont_uuid, daos_unit_oid_t oid,
-			     daos_epoch_t eph, void *arg);
-int ds_pool_obj_iter(uuid_t pool_uuid, obj_iter_cb_t callback, void *arg);
+typedef int (*rebuild_iter_cb_t)(uuid_t cont_uuid, vos_iter_entry_t *ent,
+				 void *arg);
+int ds_pool_rebuild_iter(uuid_t pool_uuid, rebuild_iter_cb_t callback,
+			 void *arg, uint32_t type);
 
 struct cont_svc;
 struct rsvc_hint;

--- a/src/include/daos_srv/vos.h
+++ b/src/include/daos_srv/vos.h
@@ -33,6 +33,7 @@
 
 #include <daos/common.h>
 #include <daos_types.h>
+#include <daos/placement.h>
 #include <daos_srv/dtx_srv.h>
 #include <daos_srv/vos_types.h>
 
@@ -53,6 +54,15 @@
  */
 int
 vos_dtx_handle_resend(daos_handle_t coh, struct daos_tx_id *dti);
+
+/**
+ * Register the function for checking whether the replica is leader or not.
+ *
+ * \param checker	[IN]	The specified function for checking leader.
+ */
+void
+vos_dtx_register_check_leader(int (*checker)(uuid_t, daos_unit_oid_t *,
+			      uint32_t, struct pl_obj_layout **));
 
 /**
  * Prepare the DTX handle in DRAM.

--- a/src/include/daos_srv/vos.h
+++ b/src/include/daos_srv/vos.h
@@ -37,6 +37,24 @@
 #include <daos_srv/vos_types.h>
 
 /**
+ * Check whether the given @dti belongs to a resent RPC or not.
+ *
+ * \param coh	[IN]	Container open handle.
+ * \param dti	[IN]	The DTX identifier.
+ *
+ * \return		Zero if related DTX is there ('prepared'),
+ *			but not committed yet.
+ * \return		-DER_ALREADY if related DTX has been committed.
+ * \return		-DER_NONEXIST if no modification has been done before.
+ * \return		-DER_INPROGRESS if some new DTX ('init') is there.
+ * \return		-DER_TIMEDOUT if the DTX is too old as to we are not
+ *			sure about whether it has ever been processed or not.
+ * \return		Other negative value if error.
+ */
+int
+vos_dtx_handle_resend(daos_handle_t coh, struct daos_tx_id *dti);
+
+/**
  * Prepare the DTX handle in DRAM.
  *
  * XXX: Currently, we only support to prepare the DTX against single DAOS

--- a/src/include/daos_srv/vos.h
+++ b/src/include/daos_srv/vos.h
@@ -33,7 +33,53 @@
 
 #include <daos/common.h>
 #include <daos_types.h>
+#include <daos_srv/dtx_srv.h>
 #include <daos_srv/vos_types.h>
+
+/**
+ * Search the specified DTX is in the CoS cache or not.
+ *
+ * \param coh	[IN]	Container open handle.
+ * \param oid	[IN]	Pointer to the object ID.
+ * \param xid	[IN]	Pointer to the DTX identifier.
+ * \param dkey	[IN]	The hashed dkey.
+ * \param punch	[IN]	For punch DTX or not.
+ *
+ * \return	0 if the DTX exists in the CoS cache.
+ * \return	-DER_NONEXIST if not in the CoS cache.
+ * \return	Other negative values on error.
+ */
+int
+vos_dtx_lookup_cos(daos_handle_t coh, daos_unit_oid_t *oid,
+		   struct daos_tx_id *xid, uint64_t dkey, bool punch);
+
+/**
+ * Fetch the list of the DTXs to be committed because of (potential) share.
+ *
+ * \param coh		[IN]	Container open handle.
+ * \param oid		[IN]	The target object (shard) ID.
+ * \param dkey		[IN]	The target dkey to be modified.
+ * \param types		[IN]	The DTX types to be listed.
+ * \param dtis		[OUT]	The DTX IDs array to be committed for share.
+ *
+ * \return			The count of DTXs to be committed for share
+ *				on success, negative value if error.
+ */
+int
+vos_dtx_list_cos(daos_handle_t coh, daos_unit_oid_t *oid,
+		 daos_key_t *dkey, uint32_t types, struct daos_tx_id **dtis);
+
+/**
+ * Fetch the list of the DTXs that can be committed.
+ *
+ * \param coh	[IN]	Container open handle.
+ * \param dtes	[OUT]	The array for DTX entries can be committed.
+ *
+ * \return		The count of DTXs can be committed on success,
+ *			negative value if error.
+ */
+int
+vos_dtx_list_committable(daos_handle_t coh, struct daos_tx_entry **dtes);
 
 /**
  * Initialize the environment for a VOS instance

--- a/src/include/daos_srv/vos_types.h
+++ b/src/include/daos_srv/vos_types.h
@@ -26,6 +26,7 @@
 
 #include <daos_types.h>
 #include <daos_srv/bio.h>
+#include <daos_srv/dtx_srv.h>
 
 enum vos_oi_attr {
 	/** Marks object as failed */
@@ -90,6 +91,8 @@ typedef enum {
 	VOS_ITER_SINGLE,
 	/** iterate record extents and epoch validities of these extents */
 	VOS_ITER_RECX,
+	/** iterate VOS active-DTX table */
+	VOS_ITER_DTX,
 } vos_iter_type_t;
 
 /** epoch logic expression for the single value iterator */
@@ -171,17 +174,33 @@ enum {
  * Returned entry of a VOS iterator
  */
 typedef struct {
-	/** Returned epoch. It is ignored for container iteration. */
-	daos_epoch_t		ie_epoch;
-	/** Returned earliest update epoch for a key */
-	daos_epoch_t		ie_earliest;
+	union {
+		/** Returned epoch. It is ignored for container iteration. */
+		daos_epoch_t			ie_epoch;
+		/** Return the DTX identifier. */
+		struct daos_tx_id		ie_xid;
+	};
+	union {
+		/** Returned earliest update epoch for a key */
+		daos_epoch_t			ie_earliest;
+		/** Return the DTX handled time for DTX iteration. */
+		uint64_t			ie_dtx_sec;
+	};
 	union {
 		/** Returned entry for container UUID iterator */
 		uuid_t				ie_couuid;
 		/** dkey or akey */
 		daos_key_t			ie_key;
-		/** oid */
-		daos_unit_oid_t			ie_oid;
+		struct {
+			/** oid */
+			daos_unit_oid_t		ie_oid;
+			/* The DTX state for DTX iteration. */
+			uint32_t		ie_dtx_state;
+			/* The DTX intent for DTX iteration. */
+			uint32_t		ie_dtx_intent;
+			/* The DTX dkey hash for DTX iteration. */
+			uint64_t		ie_dtx_hash;
+		};
 		struct {
 			/** record size */
 			daos_size_t		ie_rsize;

--- a/src/include/daos_types.h
+++ b/src/include/daos_types.h
@@ -87,6 +87,10 @@ daos_csum_set(daos_csum_buf_t *csum, void *buf, uint16_t size)
 	csum->cs_len = csum->cs_buf_len = size;
 }
 
+enum daos_anchor_flags {
+	/* The RPC will be sent to leader replica. */
+	DAOS_ANCHOR_FLAGS_TO_LEADER	= 1,
+};
 
 typedef enum {
 	DAOS_ANCHOR_TYPE_ZERO	= 0,
@@ -100,10 +104,21 @@ typedef enum {
 typedef struct {
 	uint16_t	da_type; /** daos_anchor_type_t */
 	uint16_t	da_shard;
-	uint32_t	da_padding;
+	uint32_t	da_flags;
 	uint8_t		da_buf[DAOS_ANCHOR_BUF_MAX];
 } daos_anchor_t;
 
+static inline void
+daos_anchor_set_flags(daos_anchor_t *anchor, uint32_t flags)
+{
+	anchor->da_flags |= flags;
+}
+
+static inline uint32_t
+daos_anchor_get_flags(daos_anchor_t *anchor)
+{
+	return anchor->da_flags;
+}
 
 static inline void
 daos_anchor_set_zero(daos_anchor_t *anchor)

--- a/src/iosrv/init.c
+++ b/src/iosrv/init.c
@@ -40,7 +40,7 @@
 #include <daos.h> /* for daos_init() */
 
 #define MAX_MODULE_OPTIONS	64
-#define MODULE_LIST		"vos,rdb,rsvc,security,mgmt,pool,cont,obj,rebuild"
+#define MODULE_LIST	"vos,rdb,rsvc,security,mgmt,pool,cont,dtx,obj,rebuild"
 
 /** List of modules to load */
 static char		modules[MAX_MODULE_OPTIONS + 1];

--- a/src/object/cli_obj.c
+++ b/src/object/cli_obj.c
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2016-2018 Intel Corporation.
+ * (C) Copyright 2016-2019 Intel Corporation.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -260,6 +260,7 @@ obj_layout_create(struct dc_object *obj)
 		obj_shard = &obj->cob_shards[i];
 		obj_shard->do_shard = i;
 		obj_shard->do_target_id = layout->ol_shards[i].po_target;
+		obj_shard->do_fseq = layout->ol_shards[i].po_fseq;
 		obj_shard->do_rebuilding = layout->ol_shards[i].po_rebuilding;
 	}
 out:
@@ -378,28 +379,125 @@ obj_grp_valid_shard_get(struct dc_object *obj, int idx,
 }
 
 static int
-obj_grp_shard_get(struct dc_object *obj, uint32_t grp_idx,
-		  uint64_t hash, unsigned int map_ver, uint32_t op)
+obj_select_leader_shard(struct dc_object *obj, uint32_t idx,
+			uint32_t *shard_idx)
 {
-	int	grp_size;
-	int	idx;
+	struct dc_obj_shard		*shard;
+	struct daos_oclass_attr		*oc_attr;
+	uint32_t			 replicas;
+	int				 preferred;
+	int				 rdg_idx;
+	int				 start;
+	int				 pos;
+	int				 off;
+	int				 i;
 
-	grp_size = obj_get_grp_size(obj);
-	idx = hash % grp_size + grp_idx * grp_size;
-	return obj_grp_valid_shard_get(obj, idx, map_ver, op);
+	if (obj->cob_shards_nr <= idx)
+		return -DER_INVAL;
+
+	oc_attr = daos_oclass_attr_find(obj->cob_md.omd_id);
+
+	/* For non-replicated object, elect current shard as leader. */
+	if (oc_attr->ca_resil != DAOS_RES_REPL) {
+		*shard_idx = idx;
+		return 0;
+	}
+
+	replicas = oc_attr->u.repl.r_num;
+	if (replicas == DAOS_OBJ_REPL_MAX)
+		replicas = obj->cob_shards_nr;
+
+	if (replicas < 1)
+		return -DER_INVAL;
+
+	if (replicas == 1) {
+		D_ASSERT(idx == 0);
+
+		shard = &obj->cob_shards[idx];
+		if (shard->do_target_id == -1)
+			return -DER_NONEXIST;
+
+		/* Single replicated object will not rebuild. */
+		D_ASSERT(!shard->do_rebuilding);
+		D_ASSERT(shard->do_shard == idx);
+
+		*shard_idx = shard->do_shard;
+		return 0;
+	}
+
+	/* XXX: The shards within [start, start + oc_attr->u.repl.r_num) will
+	 *	search from the same @preferred position, then they will have
+	 *	the same leader. The shards (belonging to the same object) in
+	 *	other redundancy group may get different leader node.
+	 *
+	 *	The one with the lowest f_seq will be elected as the leader to
+	 *	avoid leader switch.
+	 */
+	rdg_idx = idx / replicas;
+	start = rdg_idx * replicas;
+	preferred = start + (obj->cob_md.omd_id.lo + rdg_idx) % replicas;
+	for (i = 0, off = preferred, pos = -1; i < replicas;
+	     i++, off = (off + 1) % replicas + start) {
+		shard = &obj->cob_shards[off];
+		if (shard->do_target_id == -1 || shard->do_rebuilding)
+			continue;
+
+		if (pos == -1 ||
+		    obj->cob_shards[pos].do_fseq > shard->do_fseq)
+			pos = off;
+	}
+
+	if (pos != -1) {
+		D_ASSERT(obj->cob_shards[pos].do_shard == pos);
+
+		*shard_idx = pos;
+		return 0;
+	}
+
+	/* If all the replicas are failed or in-rebuilding, then NONEXIST. */
+	return -DER_NONEXIST;
+}
+
+static int
+obj_grp_leader_get(struct dc_object *obj, int idx, unsigned int map_ver)
+{
+	uint32_t	shard;
+	int		rc;
+
+	D_RWLOCK_RDLOCK(&obj->cob_lock);
+	if (obj->cob_version != map_ver) {
+		/* Sigh, someone else changed the pool map */
+		D_RWLOCK_UNLOCK(&obj->cob_lock);
+		return -DER_STALE;
+	}
+
+	rc = obj_select_leader_shard(obj, idx, &shard);
+	if (rc == 0)
+		rc = shard;
+	D_RWLOCK_UNLOCK(&obj->cob_lock);
+
+	return rc;
 }
 
 static int
 obj_dkeyhash2shard(struct dc_object *obj, uint64_t hash, unsigned int map_ver,
-		   uint32_t op)
+		   uint32_t op, bool to_leader)
 {
-	int	 grp_idx;
+	int	grp_idx;
+	int	grp_size;
+	int	idx;
 
 	grp_idx = obj_dkey2grp(obj, hash, map_ver);
 	if (grp_idx < 0)
 		return grp_idx;
 
-	return obj_grp_shard_get(obj, grp_idx, hash, map_ver, op);
+	grp_size = obj_get_grp_size(obj);
+	idx = hash % grp_size + grp_idx * grp_size;
+
+	if (to_leader)
+		return obj_grp_leader_get(obj, idx, map_ver);
+
+	return obj_grp_valid_shard_get(obj, idx, map_ver, op);
 }
 
 static int
@@ -468,8 +566,7 @@ obj_shards_2_fwtgts(struct dc_object *obj, uint32_t map_ver,
 		return 0;
 
 	/* select one leader shard and generate the fw_shard_tgts array */
-	rc = obj_grp_valid_shard_get(obj, *start_shard, map_ver,
-				     DAOS_OBJ_RPC_UPDATE);
+	rc = obj_grp_leader_get(obj, *start_shard, map_ver);
 	if (rc < 0) {
 		D_ERROR(DF_OID" no valid shard, rc %d.\n",
 			DP_OID(obj->cob_md.omd_id), rc);
@@ -901,7 +998,9 @@ struct obj_auxi_args {
 	uint32_t			 map_ver_req;
 	uint32_t			 map_ver_reply;
 	uint32_t			 io_retry:1,
-					 shard_task_scheded:1;
+					 shard_task_scheded:1,
+					 retry_with_leader:1;
+	uint32_t			 flags;
 	int				 result;
 	d_list_t			 shard_task_head;
 	tse_task_t			*obj_task;
@@ -930,6 +1029,7 @@ struct obj_list_arg {
 struct shard_update_args {
 	struct shard_auxi_args	 auxi;
 	daos_epoch_t		 epoch;
+	struct daos_tx_id	 dti;
 	daos_key_t		*dkey;
 	uint64_t		 dkey_hash;
 	unsigned int		 nr;
@@ -957,6 +1057,8 @@ shard_result_process(tse_task_t *task, void *arg)
 	} else if (obj_retry_error(ret)) {
 		D_DEBUG(DB_IO, "shard %d ret %d.\n", shard_auxi->shard, ret);
 		obj_auxi->io_retry = 1;
+		if (task->dt_result == -DER_INPROGRESS)
+			obj_auxi->retry_with_leader = 1;
 	} else {
 		/* for un-retryable failure, set the err to whole obj IO */
 		D_DEBUG(DB_IO, "shard %d ret %d.\n", shard_auxi->shard, ret);
@@ -1073,6 +1175,9 @@ obj_comp_cb(tse_task_t *task, void *data)
 		pm_stale = true;
 	if (obj_retry_error(task->dt_result) || obj_auxi->io_retry)
 		io_retry = true;
+
+	if (io_retry && task->dt_result == -DER_INPROGRESS)
+		obj_auxi->retry_with_leader = 1;
 
 	if (pm_stale || io_retry)
 		obj_retry_cb(task, obj, io_retry);
@@ -1236,7 +1341,8 @@ dc_obj_fetch(tse_task_t *task)
 
 	dkey_hash = obj_dkey2hash(args->dkey);
 	shard = obj_dkeyhash2shard(obj, dkey_hash, map_ver,
-				   DAOS_OPC_OBJ_UPDATE);
+				   DAOS_OPC_OBJ_UPDATE,
+				   obj_auxi->retry_with_leader);
 	if (shard < 0)
 		D_GOTO(out_task, rc = shard);
 
@@ -1310,7 +1416,8 @@ shard_update_task(tse_task_t *task)
 	rc = dc_obj_shard_update(obj_shard, args->epoch, args->dkey, args->nr,
 				 args->iods, args->sgls, &args->auxi.map_ver,
 				 args->auxi.obj_auxi->fw_shard_tgts,
-				 args->auxi.obj_auxi->fw_cnt, task);
+				 args->auxi.obj_auxi->fw_cnt, task,
+				 &args->dti, args->auxi.obj_auxi->flags);
 
 	obj_shard_close(obj_shard);
 	return rc;
@@ -1473,8 +1580,20 @@ dc_obj_update(tse_task_t *task)
 
 	head = &obj_auxi->shard_task_head;
 	/* for retried obj IO, reuse the previous shard tasks and resched it */
-	if (obj_auxi->io_retry)
+	if (obj_auxi->io_retry) {
+		/* We mark the RPC as RESEND although @io_retry does not
+		 * guarantee that the RPC has ever been sent. It may cause
+		 * some overhead on server side, but no correctness issues.
+		 *
+		 * On the other hand, the client may resend the RPC to new
+		 * shard if leader switched. That is why the resend logic
+		 * is handled at object layer rather than shard layer.
+		 */
+		obj_auxi->flags = ORF_RESEND;
 		goto task_sched;
+	}
+
+	obj_auxi->flags = 0;
 	for (i = 0; i < shards_cnt; i++, shard++) {
 		tse_task_t			*shard_task;
 		struct shard_update_args	*shard_arg;
@@ -1487,6 +1606,7 @@ dc_obj_update(tse_task_t *task)
 		shard_arg = tse_task_buf_embedded(shard_task,
 						  sizeof(*shard_arg));
 		shard_arg->epoch		= epoch;
+		daos_generate_dti(&shard_arg->dti);
 		shard_arg->dkey			= args->dkey;
 		shard_arg->dkey_hash		= dkey_hash;
 		shard_arg->nr			= args->nr;
@@ -1574,21 +1694,34 @@ dc_obj_list_internal(daos_handle_t oh, uint32_t op, daos_handle_t th,
 		D_GOTO(out_task, rc);
 
 	if (dkey == NULL) {
+		bool	to_leader = false;
+
 		if (op != DAOS_OBJ_DKEY_RPC_ENUMERATE &&
 		    op != DAOS_OBJ_RPC_ENUMERATE) {
 			D_ERROR("No dkey for opc %x\n", op);
 			D_GOTO(out_task, rc = -DER_INVAL);
 		}
 
+		if (obj_auxi->retry_with_leader)
+			to_leader = true;
+		else if (daos_anchor_get_flags(dkey_anchor) &
+			 DAOS_ANCHOR_FLAGS_TO_LEADER)
+			to_leader = true;
+
 		shard = dc_obj_anchor2shard(dkey_anchor);
-		shard = obj_grp_valid_shard_get(obj, shard, map_ver, op);
+		if (to_leader)
+			shard = obj_grp_leader_get(obj, shard, map_ver);
+		else
+			shard = obj_grp_valid_shard_get(obj, shard,
+							map_ver, op);
 		if (shard < 0)
 			D_GOTO(out_task, rc = shard);
 
 		dc_obj_shard2anchor(dkey_anchor, shard);
 	} else {
 		dkey_hash = obj_dkey2hash(dkey);
-		shard = obj_dkeyhash2shard(obj, dkey_hash, map_ver, op);
+		shard = obj_dkeyhash2shard(obj, dkey_hash, map_ver, op,
+					   obj_auxi->retry_with_leader);
 		if (shard < 0)
 			D_GOTO(out_task, rc = shard);
 	}
@@ -1685,6 +1818,7 @@ struct shard_punch_args {
 	daos_obj_punch_t	*pa_api_args;
 	uint64_t		 pa_dkey_hash;
 	daos_epoch_t		 pa_epoch;
+	struct daos_tx_id	 pa_dti;
 	uint32_t		 pa_opc;
 };
 
@@ -1719,7 +1853,8 @@ shard_punch_task(tse_task_t *task)
 				api_args->akey_nr, args->pa_coh_uuid,
 				args->pa_cont_uuid, &args->pa_auxi.map_ver,
 				args->pa_auxi.obj_auxi->fw_shard_tgts,
-				args->pa_auxi.obj_auxi->fw_cnt, task);
+				args->pa_auxi.obj_auxi->fw_cnt, task,
+				&args->pa_dti, args->pa_auxi.obj_auxi->flags);
 
 	obj_shard_close(obj_shard);
 	return rc;
@@ -1806,8 +1941,12 @@ obj_punch_internal(tse_task_t *api_task, enum obj_rpc_opc opc,
 	obj_auxi->obj_task = api_task;
 	head = &obj_auxi->shard_task_head;
 	/* for retried obj IO, reuse the previous shard tasks and resched it */
-	if (obj_auxi->io_retry)
+	if (obj_auxi->io_retry) {
+		obj_auxi->flags = ORF_RESEND;
 		goto task_sched;
+	}
+
+	obj_auxi->flags = 0;
 	for (i = 0; i < shard_nr; i++) {
 		tse_task_t		*task;
 		struct shard_punch_args	*args;
@@ -1821,6 +1960,7 @@ obj_punch_internal(tse_task_t *api_task, enum obj_rpc_opc opc,
 		shard			= shard_first + i;
 		args->pa_api_args	= api_args;
 		args->pa_epoch		= epoch;
+		daos_generate_dti(&args->pa_dti);
 		args->pa_auxi.shard	= shard;
 		args->pa_auxi.target	= obj_shard2tgtid(obj, shard);
 		args->pa_auxi.map_ver	= map_ver;

--- a/src/object/obj_internal.h
+++ b/src/object/obj_internal.h
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2016-2018 Intel Corporation.
+ * (C) Copyright 2016-2019 Intel Corporation.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -35,6 +35,7 @@
 #include <daos/placement.h>
 #include <daos/btree.h>
 #include <daos/btree_class.h>
+#include <daos/dtx.h>
 #include <daos_srv/daos_server.h>
 #include <daos_types.h>
 
@@ -78,6 +79,7 @@ struct dc_obj_shard {
 	uint32_t		do_target_id;	/* target id (unique in pool) */
 	uint32_t		do_target_idx;	/* target VOS index in node */
 	uint32_t		do_target_rank;
+	uint32_t		do_fseq;	/* failure sequence */
 	uint32_t		do_rebuilding:1;
 	/** point back to object */
 	struct dc_object	*do_obj;
@@ -129,7 +131,9 @@ int dc_obj_shard_update(struct dc_obj_shard *shard, daos_epoch_t epoch,
 			daos_key_t *dkey, unsigned int nr,
 			daos_iod_t *iods, daos_sg_list_t *sgls,
 			unsigned int *map_ver, struct daos_obj_shard_tgt *tgts,
-			uint32_t fw_cnt, tse_task_t *task);
+			uint32_t fw_cnt, tse_task_t *task,
+			struct daos_tx_id *dti, uint32_t flags);
+
 int dc_obj_shard_fetch(struct dc_obj_shard *shard, daos_epoch_t epoch,
 		       daos_key_t *dkey, unsigned int nr,
 		       daos_iod_t *iods, daos_sg_list_t *sgls,
@@ -151,7 +155,8 @@ int dc_obj_shard_punch(struct dc_obj_shard *shard, uint32_t opc,
 		       daos_key_t *akeys, unsigned int akey_nr,
 		       const uuid_t coh_uuid, const uuid_t cont_uuid,
 		       unsigned int *map_ver, struct daos_obj_shard_tgt *tgts,
-		       uint32_t fw_cnt, tse_task_t *task);
+		       uint32_t fw_cnt, tse_task_t *task,
+		       struct daos_tx_id *dti, uint32_t flags);
 
 int dc_obj_shard_query_key(struct dc_obj_shard *shard, daos_epoch_t epoch,
 			   uint32_t flags, daos_key_t *dkey, daos_key_t *akey,
@@ -163,7 +168,7 @@ static inline bool
 obj_retry_error(int err)
 {
 	return err == -DER_TIMEDOUT || err == -DER_STALE ||
-	       daos_crt_network_error(err);
+	       err == -DER_INPROGRESS || daos_crt_network_error(err);
 }
 
 void obj_shard_decref(struct dc_obj_shard *shard);

--- a/src/object/obj_rpc.c
+++ b/src/object/obj_rpc.c
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2016-2018 Intel Corporation.
+ * (C) Copyright 2016-2019 Intel Corporation.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -29,6 +29,22 @@
 #include <daos/event.h>
 #include <daos/rpc.h>
 #include "obj_rpc.h"
+
+static int
+crt_proc_struct_daos_tx_id(crt_proc_t proc, struct daos_tx_id *dti)
+{
+	int rc;
+
+	rc = crt_proc_uuid_t(proc, &dti->dti_uuid);
+	if (rc != 0)
+		return -DER_HG;
+
+	rc = crt_proc_uint64_t(proc, &dti->dti_sec);
+	if (rc != 0)
+		return -DER_HG;
+
+	return 0;
+}
 
 static int
 crt_proc_daos_key_desc_t(crt_proc_t proc, daos_key_desc_t *key)
@@ -304,7 +320,7 @@ crt_proc_daos_anchor_t(crt_proc_t proc, daos_anchor_t *anchor)
 	if (crt_proc_uint16_t(proc, &anchor->da_shard) != 0)
 		return -DER_HG;
 
-	if (crt_proc_uint32_t(proc, &anchor->da_padding) != 0)
+	if (crt_proc_uint32_t(proc, &anchor->da_flags) != 0)
 		return -DER_HG;
 
 	if (crt_proc_raw(proc, anchor->da_buf, sizeof(anchor->da_buf)) != 0)

--- a/src/object/srv_mod.c
+++ b/src/object/srv_mod.c
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2016 Intel Corporation.
+ * (C) Copyright 2016-2019 Intel Corporation.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,6 +26,8 @@
 #define D_LOGFAC	DD_FAC(object)
 
 #include <daos_srv/daos_server.h>
+#include <daos_srv/vos.h>
+#include <daos_srv/pool.h>
 #include <daos/rpc.h>
 #include "obj_rpc.h"
 #include "obj_internal.h"
@@ -45,6 +47,7 @@ obj_mod_init(void)
 
 	dss_abt_pool_choose_cb_register(DAOS_OBJ_MODULE,
 					ds_obj_abt_pool_choose_cb);
+	vos_dtx_register_check_leader(ds_pool_check_leader);
 	return 0;
 }
 

--- a/src/object/srv_obj.c
+++ b/src/object/srv_obj.c
@@ -574,7 +574,7 @@ ds_obj_rw_echo_handler(crt_rpc_t *rpc)
 		bulk_op = CRT_BULK_GET;
 	}
 
-	bulk_bind = orw->orw_flags & ORW_FLAG_BULK_BIND;
+	bulk_bind = orw->orw_flags & ORF_BULK_BIND;
 	rc = ds_bulk_transfer(rpc, bulk_op, bulk_bind, orw->orw_bulks.ca_arrays,
 			      DAOS_HDL_INVAL, &p_sgl, orw->orw_nr);
 
@@ -612,7 +612,7 @@ obj_update_prefw(crt_rpc_t *req, uint32_t shard, void *arg)
 	uuid_copy(orw->orw_co_uuid, orw_parent->orw_co_uuid);
 	orw->orw_shard_tgts.ca_count	= 0;
 	orw->orw_shard_tgts.ca_arrays	= NULL;
-	orw->orw_flags			= ORW_FLAG_BULK_BIND;
+	orw->orw_flags			= ORF_BULK_BIND;
 
 	return 0;
 }
@@ -692,7 +692,7 @@ ds_obj_rw_local_hdlr(crt_rpc_t *rpc, uint32_t tag, struct ds_cont_hdl *cont_hdl,
 	}
 
 	if (rma) {
-		bulk_bind = orw->orw_flags & ORW_FLAG_BULK_BIND;
+		bulk_bind = orw->orw_flags & ORF_BULK_BIND;
 		rc = ds_bulk_transfer(rpc, bulk_op, bulk_bind,
 			orw->orw_bulks.ca_arrays, *ioh, NULL, orw->orw_nr);
 	} else if (orw->orw_sgls.ca_arrays != NULL) {

--- a/src/placement/pl_map.c
+++ b/src/placement/pl_map.c
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2016 Intel Corporation.
+ * (C) Copyright 2016-2019 Intel Corporation.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -275,7 +275,7 @@ struct d_hash_table	pl_htable = {
 
 #define DSR_RING_DOMAIN		PO_COMP_TP_RACK
 
-static void
+void
 pl_map_attr_init(struct pool_map *po_map, pl_map_type_t type,
 		 struct pl_map_init_attr *mia)
 {
@@ -380,18 +380,20 @@ pl_htable_init()
  */
 int
 pl_map_create(struct pool_map *pool_map, struct pl_map_init_attr *mia,
-	      struct pl_map **pl_mapp)
+	      struct pl_map **pl_mapp, bool hash)
 {
-	int rc = 0;
+	if (hash) {
+		int rc = 0;
 
-	D_RWLOCK_WRLOCK(&pl_rwlock);
-	if (!pl_htable.ht_ops)
-		rc = pl_htable_init();
-	D_RWLOCK_UNLOCK(&pl_rwlock);
+		D_RWLOCK_WRLOCK(&pl_rwlock);
+		if (!pl_htable.ht_ops)
+			rc = pl_htable_init();
+		D_RWLOCK_UNLOCK(&pl_rwlock);
 
-	if (rc) {
-		D_ERROR("pl_htable_init failed, rc %d.\n", rc);
-		return rc;
+		if (rc != 0) {
+			D_ERROR("pl_htable_init failed, rc %d.\n", rc);
+			return rc;
+		}
 	}
 
 	return pl_map_create_inited(pool_map, mia, pl_mapp);

--- a/src/placement/pl_map.h
+++ b/src/placement/pl_map.h
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2016 Intel Corporation.
+ * (C) Copyright 2016-2019 Intel Corporation.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -32,26 +32,6 @@
 #include <daos/placement.h>
 
 struct pl_map_ops;
-
-/** common header of all placement map */
-struct pl_map {
-	/** correpsonding pool uuid */
-	uuid_t			 pl_uuid;
-	/** link chain on hash */
-	d_list_t		 pl_link;
-	/** protect refcount */
-	pthread_spinlock_t	 pl_lock;
-	/** refcount */
-	int			 pl_ref;
-	/** pool connections, protected by pl_rwlock */
-	int			 pl_connects;
-	/** type of placement map */
-	pl_map_type_t		 pl_type;
-	/** reference to pool map */
-	struct pool_map		*pl_poolmap;
-	/** placement map operations */
-	struct pl_map_ops       *pl_ops;
-};
 
 /**
  * Function table for placement map.

--- a/src/placement/ring_map.c
+++ b/src/placement/ring_map.c
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2016-2018 Intel Corporation.
+ * (C) Copyright 2016-2019 Intel Corporation.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -1191,6 +1191,7 @@ next_fail:
 		if (spare_avail) {
 			/* The selected spare target is up and ready */
 			l_shard->po_target = spare_tgt->ta_comp.co_id;
+			l_shard->po_fseq = spare_tgt->ta_comp.co_fseq;
 
 			/*
 			 * Mark the shard as 'rebuilding' so that read will
@@ -1262,6 +1263,7 @@ ring_obj_layout_fill(struct pl_map *map, struct daos_obj_md *md,
 			tgt = &tgts[pos];
 			layout->ol_shards[k].po_shard  = rop->rop_shard_id + k;
 			layout->ol_shards[k].po_target = tgt->ta_comp.co_id;
+			layout->ol_shards[k].po_fseq   = tgt->ta_comp.co_fseq;
 
 			if (pool_target_unavail(tgt)) {
 				rc = ring_remap_alloc_one(remap_list, k, tgt);
@@ -1319,7 +1321,7 @@ ring_obj_place(struct pl_map *map, struct daos_obj_md *md,
 	return 0;
 }
 
-#define SHARDS_ON_STACK_COUNT	256
+#define SHARDS_ON_STACK_COUNT	128
 int
 ring_obj_find_rebuild(struct pl_map *map, struct daos_obj_md *md,
 		      struct daos_obj_shard_md *shard_md,

--- a/src/placement/tests/place_obj.c
+++ b/src/placement/tests/place_obj.c
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2016-2018 Intel Corporation.
+ * (C) Copyright 2016-2019 Intel Corporation.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -231,7 +231,7 @@ main(int argc, char **argv)
 	mia.ia_ring.ring_nr = 1;
 	mia.ia_ring.domain  = PO_COMP_TP_RACK;
 
-	rc = pl_map_create(po_map, &mia, &pl_map);
+	rc = pl_map_create(po_map, &mia, &pl_map, true);
 	D_ASSERT(rc == 0);
 
 	pl_map_print(pl_map);

--- a/src/pool/srv_internal.h
+++ b/src/pool/srv_internal.h
@@ -61,6 +61,8 @@ struct pool_iv_entry {
 /*
  * srv_pool.c
  */
+void ds_pool_destroy_pl_map(struct ds_pool *pool);
+int ds_pool_create_pl_map(struct ds_pool *pool, struct pool_map *map);
 void ds_pool_rsvc_class_register(void);
 void ds_pool_rsvc_class_unregister(void);
 int ds_pool_svc_start(uuid_t uuid, bool create, uuid_t db_uuid, size_t size,

--- a/src/pool/srv_pool.c
+++ b/src/pool/srv_pool.c
@@ -290,6 +290,36 @@ pool_svc_rdb_uuid_remove(const uuid_t pool_uuid)
 	return rc;
 }
 
+void
+ds_pool_destroy_pl_map(struct ds_pool *pool)
+{
+	if (pool->sp_pl_map != NULL) {
+		struct pl_map	*map = pool->sp_pl_map;
+
+		pool->sp_pl_map = NULL;
+		/* Drop the reference when create */
+		map->pl_ref--;
+		pl_map_destroy(map);
+	}
+}
+
+int
+ds_pool_create_pl_map(struct ds_pool *pool, struct pool_map *map)
+{
+	struct pl_map		*pl_map = NULL;
+	struct pl_map_init_attr	 mia;
+	int			 rc;
+
+	pl_map_attr_init(map, PL_TYPE_RING, &mia);
+	rc = pl_map_create(map, &mia, &pl_map, false);
+	if (rc == 0) {
+		ds_pool_destroy_pl_map(pool);
+		pool->sp_pl_map = pl_map;
+	}
+
+	return rc;
+}
+
 /*
  * Called by mgmt module on every storage node belonging to this pool.
  * "path" is the directory under which the VOS and metadata files shall be.
@@ -882,6 +912,14 @@ pool_svc_step_up_cb(struct ds_rsvc *rsvc)
 
 			/* Need to update pool->sp_map. Swap with map. */
 			pool->sp_map_version = map_version;
+			rc = ds_pool_create_pl_map(pool, map);
+			if (rc != 0) {
+				svc->ps_pool = NULL;
+				ABT_rwlock_unlock(pool->sp_lock);
+				ds_pool_put(pool);
+				goto out;
+			}
+
 			tmp = pool->sp_map;
 			pool->sp_map = map;
 			map = tmp;
@@ -1143,10 +1181,10 @@ ds_pool_svc_stop_all(void)
 
 static int
 bcast_create(crt_context_t ctx, struct pool_svc *svc, crt_opcode_t opcode,
-	     crt_rpc_t **rpc)
+	     crt_bulk_t bulk_hdl, crt_rpc_t **rpc)
 {
 	return ds_pool_bcast_create(ctx, svc->ps_pool, DAOS_POOL_MODULE, opcode,
-				    rpc, NULL, NULL);
+				    rpc, bulk_hdl, NULL);
 }
 
 /**
@@ -1341,7 +1379,8 @@ permitted(const struct pool_attr *attr, uint32_t uid, uint32_t gid,
 static int
 pool_connect_bcast(crt_context_t ctx, struct pool_svc *svc,
 		   const uuid_t pool_hdl, uint64_t capas,
-		   daos_iov_t *global_ns, struct daos_pool_space *ps)
+		   daos_iov_t *global_ns, struct daos_pool_space *ps,
+		   crt_bulk_t map_buf_bulk)
 {
 	struct pool_tgt_connect_in     *in;
 	struct pool_tgt_connect_out    *out;
@@ -1355,7 +1394,7 @@ pool_connect_bcast(crt_context_t ctx, struct pool_svc *svc,
 	if (rc != 0)
 		D_GOTO(out, rc);
 
-	rc = bcast_create(ctx, svc, POOL_TGT_CONNECT, &rpc);
+	rc = bcast_create(ctx, svc, POOL_TGT_CONNECT, map_buf_bulk, &rpc);
 	if (rc != 0)
 		D_GOTO(out, rc);
 
@@ -1406,10 +1445,15 @@ bulk_cb(const struct crt_bulk_cb_info *cb_info)
  * Transfer the pool map to "remote_bulk". If the remote bulk buffer is too
  * small, then return -DER_TRUNC and set "required_buf_size" to the local pool
  * map buffer size.
+ * If the map_buf_bulk is non-NULL, then the created local bulk handle for
+ * pool_buf will be returned and caller needs to do crt_bulk_free later.
+ * If the map_buf_bulk is NULL then the internally created local bulk handle
+ * will be freed within this function.
  */
 static int
 transfer_map_buf(struct rdb_tx *tx, struct pool_svc *svc, crt_rpc_t *rpc,
-		 crt_bulk_t remote_bulk, uint32_t *required_buf_size)
+		 crt_bulk_t remote_bulk, uint32_t *required_buf_size,
+		 crt_bulk_t *map_buf_bulk)
 {
 	struct pool_buf	       *map_buf;
 	size_t			map_buf_size;
@@ -1417,7 +1461,7 @@ transfer_map_buf(struct rdb_tx *tx, struct pool_svc *svc, crt_rpc_t *rpc,
 	daos_size_t		remote_bulk_size;
 	daos_iov_t		map_iov;
 	daos_sg_list_t		map_sgl;
-	crt_bulk_t		bulk;
+	crt_bulk_t		bulk = CRT_BULK_NULL;
 	struct crt_bulk_desc	map_desc;
 	crt_bulk_opid_t		map_opid;
 	ABT_eventual		eventual;
@@ -1491,7 +1535,10 @@ transfer_map_buf(struct rdb_tx *tx, struct pool_svc *svc, crt_rpc_t *rpc,
 out_eventual:
 	ABT_eventual_free(&eventual);
 out_bulk:
-	crt_bulk_free(bulk);
+	if (map_buf_bulk != NULL)
+		*map_buf_bulk = bulk;
+	else
+		crt_bulk_free(bulk);
 out:
 	return rc;
 }
@@ -1502,6 +1549,7 @@ ds_pool_connect_handler(crt_rpc_t *rpc)
 	struct pool_connect_in	       *in = crt_req_get(rpc);
 	struct pool_connect_out	       *out = crt_reply_get(rpc);
 	struct pool_svc		       *svc;
+	crt_bulk_t			map_buf_bulk = CRT_BULK_NULL;
 	struct rdb_tx			tx;
 	daos_iov_t			key;
 	daos_iov_t			value;
@@ -1592,7 +1640,7 @@ ds_pool_connect_handler(crt_rpc_t *rpc)
 	 * its pool_buf away.
 	 */
 	rc = transfer_map_buf(&tx, svc, rpc, in->pci_map_bulk,
-			      &out->pco_map_buf_size);
+			      &out->pco_map_buf_size, &map_buf_bulk);
 	if (rc != 0)
 		D_GOTO(out_map_version, rc);
 
@@ -1627,7 +1675,8 @@ ds_pool_connect_handler(crt_rpc_t *rpc)
 	}
 
 	rc = pool_connect_bcast(rpc->cr_ctx, svc, in->pci_op.pi_hdl,
-				in->pci_capas, &iv_iov, &out->pco_space);
+				in->pci_capas, &iv_iov, &out->pco_space,
+				map_buf_bulk);
 	if (rc != 0) {
 		D_ERROR(DF_UUID": failed to connect to targets: %d\n",
 			DP_UUID(in->pci_op.pi_uuid), rc);
@@ -1658,6 +1707,7 @@ out_svc:
 	ds_rsvc_set_hint(&svc->ps_rsvc, &out->pco_op.po_hint);
 	pool_svc_put_leader(svc);
 out:
+	crt_bulk_free(map_buf_bulk);
 	out->pco_op.po_rc = rc;
 	D_DEBUG(DF_DSMS, DF_UUID": replying rpc %p: %d\n",
 		DP_UUID(in->pci_op.pi_uuid), rpc, rc);
@@ -1675,7 +1725,7 @@ pool_disconnect_bcast(crt_context_t ctx, struct pool_svc *svc,
 
 	D_DEBUG(DF_DSMS, DF_UUID": bcasting\n", DP_UUID(svc->ps_uuid));
 
-	rc = bcast_create(ctx, svc, POOL_TGT_DISCONNECT, &rpc);
+	rc = bcast_create(ctx, svc, POOL_TGT_DISCONNECT, NULL, &rpc);
 	if (rc != 0)
 		D_GOTO(out, rc);
 
@@ -1822,7 +1872,7 @@ pool_query_bcast(crt_context_t ctx, struct pool_svc *svc, uuid_t pool_hdl,
 
 	D_DEBUG(DB_MD, DF_UUID": bcasting\n", DP_UUID(svc->ps_uuid));
 
-	rc = bcast_create(ctx, svc, POOL_TGT_QUERY, &rpc);
+	rc = bcast_create(ctx, svc, POOL_TGT_QUERY, NULL, &rpc);
 	if (rc != 0)
 		goto out;
 
@@ -1906,7 +1956,7 @@ ds_pool_query_handler(crt_rpc_t *rpc)
 	out->pqo_mode = attr.pa_mode;
 
 	rc = transfer_map_buf(&tx, svc, rpc, in->pqi_map_bulk,
-			      &out->pqo_map_buf_size);
+			      &out->pqo_map_buf_size, NULL);
 	if (rc != 0)
 		D_GOTO(out_map_version, rc);
 
@@ -2040,13 +2090,14 @@ ds_pool_update_internal(uuid_t pool_uuid, struct pool_target_id_list *tgts,
 		D_GOTO(out_map, rc);
 	}
 
-	updated = true;
-
 	/*
 	 * The new pool map is now committed and can be publicized. Swap the
 	 * new pool map with the old one in the cache.
 	 */
 	ABT_rwlock_wrlock(svc->ps_pool->sp_lock);
+	rc = ds_pool_create_pl_map(svc->ps_pool, map);
+	if (rc == 0)
+		updated = true;
 	map_tmp = svc->ps_pool->sp_map;
 	svc->ps_pool->sp_map = map;
 	map = map_tmp;
@@ -2959,4 +3010,129 @@ out:
 	out->pmo_failed = ranks;
 	out->pmo_rc = rc;
 	crt_reply_send(rpc);
+}
+
+static int
+ds_pool_select_leader_target(struct pl_obj_layout *layout, daos_unit_oid_t *oid,
+			     uint32_t *leader)
+{
+	struct pl_obj_shard		*shard;
+	struct daos_oclass_attr		*oc_attr;
+	uint32_t			 replicas;
+	int				 preferred;
+	int				 rdg_idx;
+	int				 start;
+	int				 pos;
+	int				 off;
+	int				 i;
+
+	if (layout->ol_nr <= oid->id_shard)
+		return -DER_INVAL;
+
+	oc_attr = daos_oclass_attr_find(oid->id_pub);
+
+	/* For non-replicated object, elect current shard as leader. */
+	if (oc_attr->ca_resil != DAOS_RES_REPL) {
+		*leader = layout->ol_shards[oid->id_shard].po_target;
+		return 0;
+	}
+
+	replicas = oc_attr->u.repl.r_num;
+	if (replicas == DAOS_OBJ_REPL_MAX)
+		replicas = layout->ol_nr;
+
+	if (replicas < 1)
+		return -DER_INVAL;
+
+	if (replicas == 1) {
+		shard = &layout->ol_shards[oid->id_shard];
+
+		if (shard->po_target == -1)
+			return -DER_NONEXIST;
+
+		/* Single replicated object will not rebuild. */
+		D_ASSERT(!shard->po_rebuilding);
+		D_ASSERT(shard->po_shard == oid->id_shard);
+
+		*leader = shard->po_target;
+		return 0;
+	}
+
+	/* XXX: The shards within [start, start + oc_attr->u.repl.r_num) will
+	 *	search from the same @preferred position, then they will have
+	 *	the same leader. The shards (belonging to the same object) in
+	 *	other redundancy group may get different leader node.
+	 *
+	 *	The one with the lowest f_seq will be elected as the leader to
+	 *	avoid leader switch.
+	 */
+	rdg_idx = oid->id_shard / replicas;
+	start = rdg_idx * replicas;
+	preferred = start + (oid->id_pub.lo + rdg_idx) % replicas;
+	for (i = 0, off = preferred, pos = -1; i < replicas;
+	     i++, off = (off + 1) % replicas + start) {
+		shard = &layout->ol_shards[off];
+		if (shard->po_target == -1 || shard->po_rebuilding)
+			continue;
+
+		if (pos == -1 ||
+		    layout->ol_shards[pos].po_fseq > shard->po_fseq)
+			pos = off;
+	}
+
+	if (pos != -1) {
+		D_ASSERT(layout->ol_shards[pos].po_shard == pos);
+
+		*leader = layout->ol_shards[pos].po_target;
+		return 0;
+	}
+
+	/* If all the replicas are failed or in-rebuilding, then NONEXIST. */
+	return -DER_NONEXIST;
+}
+
+int
+ds_pool_check_leader(uuid_t pool_uuid, daos_unit_oid_t *oid,
+		     uint32_t version, struct pl_obj_layout **plo)
+{
+	struct ds_pool		*pool;
+	struct pl_obj_layout	*layout = NULL;
+	struct pool_target	*target;
+	struct daos_obj_md	 md = { 0 };
+	d_rank_t		 leader;
+	d_rank_t		 myrank;
+	int			 rc = 0;
+
+	pool = ds_pool_lookup(pool_uuid);
+	if (pool == NULL)
+		return -DER_INVAL;
+
+	md.omd_id = oid->id_pub;
+	md.omd_ver = version;
+	rc = pl_obj_place(pool->sp_pl_map, &md, NULL, &layout);
+	if (rc != 0)
+		goto out;
+
+	rc = ds_pool_select_leader_target(layout, oid, &leader);
+	if (rc != 0)
+		goto out;
+
+	rc = pool_map_find_target(pool->sp_map, leader, &target);
+	if (rc != 1)
+		D_GOTO(out, rc = -DER_INVAL);
+
+	crt_group_rank(NULL, &myrank);
+	if (myrank != target->ta_comp.co_rank) {
+		rc = 0;
+	} else {
+		if (plo != NULL)
+			*plo = layout;
+		rc = 1;
+	}
+
+out:
+	if (rc <= 0 && layout != NULL)
+		pl_obj_layout_free(layout);
+	ds_pool_put(pool);
+	return rc;
 }

--- a/src/pool/srv_target.c
+++ b/src/pool/srv_target.c
@@ -1058,35 +1058,39 @@ iter_fini:
 	return rc;
 }
 
-struct obj_iter_arg {
+struct cont_rebuild_iter_arg {
 	cont_iter_cb_t	callback;
 	void		*arg;
+	uint32_t	 type;
 };
 
 static int
-cont_obj_iter_cb(uuid_t cont_uuid, daos_unit_oid_t oid, daos_epoch_t eph,
-		 void *data)
+cont_rebuild_iter_cb(uuid_t cont_uuid, vos_iter_entry_t *ent, void *data)
 {
-	struct obj_iter_arg *arg = data;
+	struct cont_rebuild_iter_arg *arg = data;
 
-	return arg->callback(cont_uuid, oid, eph, arg->arg);
+	return arg->callback(cont_uuid, ent, arg->arg);
 }
 
 static int
-pool_obj_iter_cb(daos_handle_t ph, uuid_t co_uuid, void *data)
+pool_rebuild_iter_cb(daos_handle_t ph, uuid_t co_uuid, void *data)
 {
-	return ds_cont_obj_iter(ph, co_uuid, cont_obj_iter_cb, data);
+	struct cont_rebuild_iter_arg *arg = data;
+
+	return ds_cont_rebuild_iter(ph, co_uuid, cont_rebuild_iter_cb, data,
+				    arg->type);
 }
 
 /**
- * Iterate all of the objects in the pool.
+ * Iterate all of the objects or DTXs in the pool.
  **/
 int
-ds_pool_obj_iter(uuid_t pool_uuid, obj_iter_cb_t callback, void *data)
+ds_pool_rebuild_iter(uuid_t pool_uuid, rebuild_iter_cb_t callback,
+		     void *data, uint32_t type)
 {
-	struct obj_iter_arg	arg;
-	struct ds_pool_child	*child;
-	int			rc;
+	struct cont_rebuild_iter_arg	 arg;
+	struct ds_pool_child		*child;
+	int				 rc;
 
 	child = ds_pool_child_lookup(pool_uuid);
 	if (child == NULL)
@@ -1094,7 +1098,8 @@ ds_pool_obj_iter(uuid_t pool_uuid, obj_iter_cb_t callback, void *data)
 
 	arg.callback = callback;
 	arg.arg = data;
-	rc = ds_pool_cont_iter(child->spc_hdl, pool_obj_iter_cb, &arg);
+	arg.type = type;
+	rc = ds_pool_cont_iter(child->spc_hdl, pool_rebuild_iter_cb, &arg);
 
 	ds_pool_child_put(child);
 

--- a/src/pool/srv_target.c
+++ b/src/pool/srv_target.c
@@ -220,8 +220,16 @@ pool_alloc_ref(void *key, unsigned int ksize, void *varg,
 	uuid_copy(pool->sp_uuid, key);
 	pool->sp_map_version = arg->pca_map_version;
 
-	if (arg->pca_map != NULL)
+	if (arg->pca_map != NULL) {
+		rc = ds_pool_create_pl_map(pool, arg->pca_map);
+		if (rc != 0) {
+			D_ERROR(DF_UUID": failed to create pl_map: %d\n",
+				DP_UUID(key), rc);
+			D_GOTO(err_lock, rc);
+		}
+
 		pool->sp_map = arg->pca_map;
+	}
 
 	collective_arg.pla_uuid = key;
 	collective_arg.pla_map_version = arg->pca_map_version;
@@ -254,6 +262,7 @@ err_collective:
 err_lock:
 	ABT_rwlock_free(&pool->sp_lock);
 err_pool:
+	ds_pool_destroy_pl_map(pool);
 	D_FREE(pool);
 err:
 	return rc;
@@ -289,8 +298,10 @@ pool_free_ref(struct daos_llink *llink)
 		D_ERROR(DF_UUID": failed to delete ES pool caches: %d\n",
 			DP_UUID(pool->sp_uuid), rc);
 
-	if (pool->sp_map != NULL)
+	if (pool->sp_map != NULL) {
+		ds_pool_destroy_pl_map(pool);
 		pool_map_decref(pool->sp_map);
+	}
 
 	ABT_rwlock_free(&pool->sp_lock);
 	D_FREE(pool);
@@ -638,12 +649,13 @@ pool_tgt_query(struct ds_pool *pool, struct daos_pool_space *ps)
 void
 ds_pool_tgt_connect_handler(crt_rpc_t *rpc)
 {
-	struct pool_tgt_connect_in     *in = crt_req_get(rpc);
-	struct pool_tgt_connect_out    *out = crt_reply_get(rpc);
-	struct ds_pool		       *pool;
-	struct ds_pool_hdl	       *hdl;
-	struct ds_pool_create_arg	arg;
-	int				rc;
+	struct pool_tgt_connect_in	*in = crt_req_get(rpc);
+	struct pool_tgt_connect_out	*out = crt_reply_get(rpc);
+	struct pool_map			*map = NULL;
+	struct ds_pool			*pool;
+	struct ds_pool_hdl		*hdl;
+	struct ds_pool_create_arg	 arg;
+	int				 rc;
 
 	D_DEBUG(DF_DSMS, DF_UUID": handling rpc %p: hdl="DF_UUID"\n",
 		DP_UUID(in->tci_uuid), rpc, DP_UUID(in->tci_hdl));
@@ -671,7 +683,33 @@ ds_pool_tgt_connect_handler(crt_rpc_t *rpc)
 	if (hdl == NULL)
 		D_GOTO(out, rc = -DER_NOMEM);
 
-	arg.pca_map = NULL;
+	/* Init the pool map */
+	if (rpc->cr_co_bulk_hdl != NULL) {
+		struct pool_buf		*buf;
+		daos_iov_t		 iov = { 0 };
+		daos_sg_list_t		 sgl;
+
+		sgl.sg_nr = 1;
+		sgl.sg_nr_out = 1;
+		sgl.sg_iovs = &iov;
+		rc = crt_bulk_access(rpc->cr_co_bulk_hdl, daos2crt_sg(&sgl));
+		if (rc != 0) {
+			D_ERROR(DF_UUID": crt_bulk_access failed, rc %d.\n",
+				DP_UUID(in->tci_uuid), rc);
+			D_GOTO(out, rc);
+		}
+
+		buf = iov.iov_buf;
+		D_ASSERT(buf != NULL);
+		rc = pool_map_create(buf, in->tci_map_version, &map);
+		if (rc != 0) {
+			D_ERROR(DF_UUID" failed to create pool map: %d\n",
+				DP_UUID(in->tci_uuid), rc);
+			D_GOTO(out, rc);
+		}
+	}
+
+	arg.pca_map = map;
 	arg.pca_map_version = in->tci_map_version;
 	arg.pca_need_group = 0;
 
@@ -703,6 +741,9 @@ ds_pool_tgt_connect_handler(crt_rpc_t *rpc)
 
 	rc = pool_tgt_query(pool, &out->tco_space);
 out:
+	if (rc != 0 && map != NULL)
+		pool_map_decref(map);
+
 	out->tco_rc = (rc == 0 ? 0 : 1);
 	D_DEBUG(DF_DSMS, DF_UUID": replying rpc %p: %d (%d)\n",
 		DP_UUID(in->tci_uuid), rpc, out->tco_rc, rc);
@@ -819,6 +860,14 @@ ds_pool_tgt_map_update(struct ds_pool *pool, struct pool_buf *buf,
 		if (map != NULL) {
 			struct pool_map *tmp = pool->sp_map;
 
+			rc = ds_pool_create_pl_map(pool, map);
+			if (rc != 0) {
+				D_ERROR(DF_UUID
+					": failed to create pl_map: %d\n",
+					DP_UUID(pool->sp_uuid), rc);
+				D_GOTO(out, rc);
+			}
+
 			pool->sp_map = map;
 			map = tmp;
 		}
@@ -835,6 +884,13 @@ ds_pool_tgt_map_update(struct ds_pool *pool, struct pool_buf *buf,
 		   pool_map_get_version(pool->sp_map) < map_version &&
 		   map != NULL) {
 		struct pool_map *tmp = pool->sp_map;
+
+		rc = ds_pool_create_pl_map(pool, map);
+		if (rc != 0) {
+			D_ERROR(DF_UUID": failed to create pl_map: %d\n",
+				DP_UUID(pool->sp_uuid), rc);
+			D_GOTO(out, rc);
+		}
 
 		/* drop the stale map */
 		pool->sp_map = map;

--- a/src/rdb/rdb_rpc.c
+++ b/src/rdb/rdb_rpc.c
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2017-2018 Intel Corporation.
+ * (C) Copyright 2017-2019 Intel Corporation.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -231,7 +231,7 @@ crt_proc_daos_anchor_t(crt_proc_t proc, daos_anchor_t *p)
 	rc = crt_proc_uint16_t(proc, &p->da_shard);
 	if (rc != 0)
 		return -DER_HG;
-	rc = crt_proc_uint32_t(proc, &p->da_padding);
+	rc = crt_proc_uint32_t(proc, &p->da_flags);
 	if (rc != 0)
 		return -DER_HG;
 	rc = crt_proc_memcpy(proc, &p->da_buf, sizeof(p->da_buf));

--- a/src/rebuild/initiator.c
+++ b/src/rebuild/initiator.c
@@ -792,7 +792,9 @@ rebuild_obj_ult(void *data)
 	memset(&anchor, 0, sizeof(anchor));
 	memset(&dkey_anchor, 0, sizeof(dkey_anchor));
 	memset(&akey_anchor, 0, sizeof(akey_anchor));
-	dc_obj_shard2anchor(&anchor, arg->shard);
+	dc_obj_shard2anchor(&dkey_anchor, arg->shard);
+	daos_anchor_set_flags(&dkey_anchor,
+			      DAOS_ANCHOR_FLAGS_TO_LEADER);
 
 	/* Initialize enum_arg for VOS_ITER_DKEY. */
 	memset(&enum_arg, 0, sizeof(enum_arg));

--- a/src/rebuild/srv.c
+++ b/src/rebuild/srv.c
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2016-2018 Intel Corporation.
+ * (C) Copyright 2016-2019 Intel Corporation.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -1721,7 +1721,7 @@ rebuild_prepare_one(void *data)
 	D_ASSERT(dss_get_module_info()->dmi_xs_id != 0);
 	/* Create ds_container locally on main XS */
 	rc = ds_cont_local_open(rpt->rt_pool_uuid, rpt->rt_coh_uuid,
-				NULL, 0, NULL);
+				NULL, 0, NULL, false);
 	if (rc)
 		pool_tls->rebuild_pool_status = rc;
 

--- a/src/vos/SConscript
+++ b/src/vos/SConscript
@@ -5,7 +5,7 @@ import daos_build
 FILES = ["evt_iter.c", "vos_common.c", "vos_iterator.c", "vos_obj.c",
          "vos_pool.c", "vos_aggregate.c", "vos_container.c", "vos_io.c",
          "vos_obj_cache.c", "vos_obj_index.c", "vos_tree.c", "evtree.c",
-         "vos_dtx.c", "vos_dtx_cos.c", "vos_query.c"]
+         "vos_dtx.c", "vos_dtx_cos.c", "vos_dtx_iter.c", "vos_query.c"]
 
 def build_vos(env, standalone):
     """build vos"""

--- a/src/vos/SConscript
+++ b/src/vos/SConscript
@@ -5,7 +5,7 @@ import daos_build
 FILES = ["evt_iter.c", "vos_common.c", "vos_iterator.c", "vos_obj.c",
          "vos_pool.c", "vos_aggregate.c", "vos_container.c", "vos_io.c",
          "vos_obj_cache.c", "vos_obj_index.c", "vos_tree.c", "evtree.c",
-         "vos_dtx.c", "vos_query.c"]
+         "vos_dtx.c", "vos_dtx_cos.c", "vos_query.c"]
 
 def build_vos(env, standalone):
     """build vos"""

--- a/src/vos/evtree.c
+++ b/src/vos/evtree.c
@@ -880,6 +880,30 @@ evt_desc_free(struct evt_context *tcx, struct evt_desc *desc, daos_size_t size)
 	return rc;
 }
 
+static int
+evt_desc_free_all(struct evt_context *tcx, struct evt_node_entry *ne)
+{
+	struct evt_desc	*desc;
+	int		 rc;
+
+	if (ne->ne_child == 0)
+		return 0;
+
+	desc = evt_off2desc(tcx, ne->ne_child);
+	rc = vos_dtx_degister_record(evt_umm(tcx), desc->dc_dtx,
+				     umem_ptr2id(evt_umm(tcx), desc),
+				     DTX_RT_EVT);
+	if (rc != 0)
+		return rc;
+
+	rc = evt_desc_free(tcx, desc,
+			   tcx->tc_inob * evt_rect_width(&ne->ne_rect));
+	if (rc == 0)
+		rc = umem_free(evt_umm(tcx), evt_off2mmid(tcx, ne->ne_child));
+
+	return rc;
+}
+
 /** check if a node is full */
 static bool
 evt_node_is_full(struct evt_context *tcx, struct evt_node *nd)
@@ -1047,7 +1071,6 @@ evt_node_destroy(struct evt_context *tcx, uint64_t nd_off, int level)
 {
 	struct evt_node_entry	*ne;
 	struct evt_node		*nd;
-	struct evt_rect		*rect;
 	bool			 leaf;
 	int			 i;
 	int			 rc = 0;
@@ -1060,22 +1083,13 @@ evt_node_destroy(struct evt_context *tcx, uint64_t nd_off, int level)
 
 	for (i = 0; i < nd->tn_nr; i++) {
 		ne = evt_node_entry_at(tcx, nd, i);
-		rect = evt_node_rect_at(tcx, nd, i);
-		if (leaf) {
+		if (leaf)
 			/* NB: This will be replaced with a callback */
-			rc = evt_desc_free(tcx, evt_off2desc(tcx, ne->ne_child),
-					   tcx->tc_inob * evt_rect_width(rect));
-			if (rc != 0)
-				return rc;
-			rc = umem_free(evt_umm(tcx),
-				       evt_off2mmid(tcx, ne->ne_child));
-			if (rc != 0)
-				return rc;
-		} else {
+			rc = evt_desc_free_all(tcx, ne);
+		else
 			rc = evt_node_destroy(tcx, ne->ne_child, level + 1);
-			if (rc != 0)
-				return rc;
-		}
+		if (rc != 0)
+			return rc;
 	}
 	return evt_node_free(tcx, nd_off);
 }
@@ -2524,6 +2538,16 @@ evt_ssof_insert(struct evt_context *tcx, struct evt_node *nd,
 			return -DER_NOMEM;
 		ne->ne_child = desc_mmid.oid.off;
 		desc = evt_tmmid2ptr(tcx, desc_mmid);
+		rc = vos_dtx_register_record(evt_umm(tcx),
+					     umem_ptr2id(evt_umm(tcx), desc),
+					     DTX_RT_EVT, 0);
+		if (rc != 0)
+			/* It is unnecessary to free the PMEM that will be
+			 * dropped automatically when the PMDK transaction
+			 * is aborted.
+			 */
+			return rc;
+
 		desc->dc_magic = EVT_DESC_MAGIC;
 		desc->dc_ex_addr = ent->ei_addr;
 		desc->dc_csum = ent->ei_csum;

--- a/src/vos/vos_common.c
+++ b/src/vos/vos_common.c
@@ -35,6 +35,13 @@
 #include <daos/lru.h>
 #include <daos/btree_class.h>
 
+/**
+ * The vos_start_time records the timestamp when server starts the serive.
+ * Via comparing with the DTX entry's timestamp, we can know whether
+ * the DTX happened before the server restarting its service or not.
+ */
+double vos_start_time;
+
 static pthread_mutex_t	mutex = PTHREAD_MUTEX_INITIALIZER;
 /**
  * Object cache based on mode of instantiation
@@ -367,6 +374,7 @@ vos_init(void)
 	if (rc)
 		D_GOTO(exit, rc);
 
+	vos_start_time = ABT_get_wtime();
 	is_init = 1;
 exit:
 	D_MUTEX_UNLOCK(&mutex);

--- a/src/vos/vos_common.c
+++ b/src/vos/vos_common.c
@@ -187,6 +187,8 @@ vos_tls_init(const struct dss_thread_local_storage *dtls,
 		return NULL;
 	}
 
+	tls->vtl_dth = NULL;
+
 	return tls;
 }
 
@@ -355,12 +357,13 @@ vos_init(void)
 		return rc;
 	}
 
+	vsa_dth = NULL;
 	vsa_xsctxt_inst = NULL;
 	vsa_nvme_init = false;
 
 	D_ALLOC_PTR(vsa_imems_inst);
 	if (vsa_imems_inst == NULL)
-		D_GOTO(exit, rc);
+		D_GOTO(exit, rc = -DER_NOMEM);
 
 	rc = vos_imem_strts_create(vsa_imems_inst);
 	if (rc)

--- a/src/vos/vos_common.c
+++ b/src/vos/vos_common.c
@@ -228,6 +228,12 @@ vos_mod_init(void)
 		return rc;
 	}
 
+	rc = vos_dtx_cos_register();
+	if (rc != 0) {
+		D_ERROR("DTX CoS btree initialization error\n");
+		return rc;
+	}
+
 	/**
 	 * Registering the class for OI btree
 	 * and KV btree

--- a/src/vos/vos_container.c
+++ b/src/vos/vos_container.c
@@ -362,6 +362,7 @@ vos_cont_open(daos_handle_t poh, uuid_t co_uuid, daos_handle_t *coh)
 	cont->vc_dtx_cos_hdl = DAOS_HDL_INVAL;
 	D_INIT_LIST_HEAD(&cont->vc_dtx_committable);
 	cont->vc_dtx_committable_count = 0;
+	cont->vc_dtx_time_last_commit = ABT_get_wtime();
 
 	/* Cache this btr object ID in container handle */
 	rc = dbtree_open_inplace_ex(&cont->vc_otab_df->obt_btr,

--- a/src/vos/vos_dtx.c
+++ b/src/vos/vos_dtx.c
@@ -31,6 +31,19 @@
 #include "vos_layout.h"
 #include "vos_internal.h"
 
+#define DTX_RETURN_INPROGRESS(dtx, pos)					 \
+do {									 \
+	if ((dtx) != NULL)						 \
+		D_DEBUG(DB_TRACE, "Hit uncommitted DTX "DF_DTI		 \
+			" with state %u, time %lu at %d\n",		 \
+			DP_DTI(&(dtx)->te_xid), (dtx)->te_state,	 \
+			(dtx)->te_sec, (pos));				 \
+	else								 \
+		D_DEBUG(DB_TRACE, "Hit uncommitted DTX at %d\n", (pos)); \
+									 \
+	return -DER_INPROGRESS;						 \
+} while (0)
+
 struct dtx_rec_bundle {
 	umem_id_t	trb_ummid;
 };
@@ -589,6 +602,66 @@ vos_dtx_abort_one(struct vos_container *cont, struct daos_tx_id *dti,
 		rc = 0;
 
 	return rc;
+}
+
+int
+vos_dtx_handle_resend(daos_handle_t coh, struct daos_tx_id *dti)
+{
+	struct vos_container	*cont;
+	struct vos_dtx_entry_df	*dtx;
+	daos_iov_t		 kiov;
+	daos_iov_t		 riov;
+	int			 rc;
+
+	cont = vos_hdl2cont(coh);
+	D_ASSERT(cont != NULL);
+
+	daos_iov_set(&kiov, dti, sizeof(*dti));
+	daos_iov_set(&riov, NULL, 0);
+	rc = dbtree_lookup(cont->vc_dtx_active_hdl, &kiov, &riov);
+	if (rc == -DER_NONEXIST)
+		rc = dbtree_lookup(cont->vc_dtx_committed_hdl, &kiov, &riov);
+
+	if (rc == -DER_NONEXIST) {
+		/* If the resent RPC is too old, then we cannot know whether
+		 * the RPC has ever been executed before or not. Then return
+		 * -DER_TIMEDOUT to the RPC sponsor. Means that modification
+		 * for such RPC may have been executed, but nobody guarantee
+		 * that. It is the caller's duty to check related record(s).
+		 */
+		if ((uint64_t)ABT_get_wtime() - dti->dti_sec >
+		    DTX_AGGREGATION_THRESHOLD_TIME) {
+			D_DEBUG(DB_IO, "Not sure about whether the RPC "
+				DF_DTI" is resend or not.\n", DP_DTI(dti));
+			return -DER_TIMEDOUT;
+		}
+	}
+
+	if (rc != 0)
+		return rc;
+
+	dtx = (struct vos_dtx_entry_df *)riov.iov_buf;
+	switch (dtx->te_state) {
+	case DTX_ST_INIT:
+		/* New DTX after the leader (re)start that is not
+		 * completed yet, retry related RPC some time later.
+		 */
+		if (dtx->te_sec >= (uint64_t)vos_start_time)
+			DTX_RETURN_INPROGRESS(dtx, 1);
+
+		/* The INIT DTX in PRAM must be for an in-update object/key
+		 * that was waiting for the bulk transfer (or remote abort)
+		 * before the VOS restart. So here, it should be the case
+		 * that client resends RPC after server restart.
+		 */
+		return 0;
+	case DTX_ST_PREPARED:
+		return 0;
+	case DTX_ST_COMMITTED:
+		return -DER_ALREADY;
+	default:
+		return -DER_INVAL;
+	}
 }
 
 int

--- a/src/vos/vos_dtx.c
+++ b/src/vos/vos_dtx.c
@@ -219,3 +219,603 @@ vos_dtx_table_destroy(struct vos_pool *pool, struct vos_dtx_table_df *dtab_df)
 
 	return rc;
 }
+
+static int
+dtx_rec_release(struct umem_instance *umm, umem_id_t ummid,
+		bool abort, bool destroy)
+{
+	struct vos_dtx_entry_df		*dtx;
+
+	dtx = umem_id2ptr(umm, ummid);
+	/* The caller has started the PMDK transaction. */
+	umem_tx_add_ptr(umm, dtx, sizeof(*dtx));
+
+	while (!UMMID_IS_NULL(dtx->te_records)) {
+		umem_id_t			 rec_mmid = dtx->te_records;
+		struct vos_dtx_record_df	*rec;
+
+		rec = umem_id2ptr(umm, rec_mmid);
+		switch (rec->tr_type) {
+		case DTX_RT_OBJ: {
+			struct vos_obj_df	*obj;
+
+			obj = umem_id2ptr(umm, rec->tr_record);
+			umem_tx_add_ptr(umm, obj, sizeof(*obj));
+			obj->vo_dtx_shares--;
+
+			/* Other DTX that shares the object has committed. */
+			if (UMMID_IS_NULL(obj->vo_dtx)) {
+				if (dtx->te_epoch > obj->vo_latest)
+					obj->vo_latest = dtx->te_epoch;
+				if (dtx->te_epoch < obj->vo_earliest)
+					obj->vo_earliest = dtx->te_epoch;
+
+				break;
+			}
+
+			/* commit case */
+			if (!abort) {
+				obj->vo_dtx = UMMID_NULL;
+				obj->vo_latest = dtx->te_epoch;
+				obj->vo_earliest = dtx->te_epoch;
+				break;
+			}
+
+			/* The last shared DTX is aborted. */
+			if (obj->vo_dtx_shares == 0) {
+				obj->vo_dtx = DTX_UMMID_ABORTED;
+				break;
+			}
+
+			/* I am not the original DTX that create the object. */
+			if (!umem_id_equal(umm, obj->vo_dtx, ummid))
+				break;
+
+			/* I am the original DTX that create the object that
+			 * is still shared by others. Now, I will be aborted,
+			 * set the reference as UNKNOWN for other left shares.
+			 */
+			obj->vo_dtx = DTX_UMMID_UNKNOWN;
+			break;
+		}
+		case DTX_RT_KEY: {
+			struct vos_krec_df	*key;
+
+			key = umem_id2ptr(umm, rec->tr_record);
+			umem_tx_add_ptr(umm, key, sizeof(*key));
+			key->kr_dtx_shares--;
+
+			if (UMMID_IS_NULL(key->kr_dtx)) {
+				/* The exchange_src has been committed.
+				 * I am the exchange_tgt, do nothing.
+				 */
+				if (rec->tr_flags == DTX_RF_EXCHANGE_TGT)
+					break;
+
+				/* Other DTX that shares the key has
+				 * committed, must be for sharing of
+				 * update cases.
+				 */
+				if (dtx->te_epoch > key->kr_latest)
+					key->kr_latest = dtx->te_epoch;
+				if (dtx->te_epoch < key->kr_earliest)
+					key->kr_earliest = dtx->te_epoch;
+
+				break;
+			}
+
+			/* commit case */
+			if (!abort) {
+				key->kr_dtx = UMMID_NULL;
+				key->kr_latest = dtx->te_epoch;
+				if (rec->tr_flags != DTX_RF_EXCHANGE_SRC &&
+				    rec->tr_flags != DTX_RF_EXCHANGE_TGT)
+					key->kr_earliest = dtx->te_epoch;
+
+				goto exchange;
+			}
+
+			/* The last shared DTX is aborted. */
+			if (key->kr_dtx_shares == 0) {
+				key->kr_dtx = DTX_UMMID_ABORTED;
+				goto exchange;
+			}
+
+			/* I am not the original DTX that create the key. */
+			if (!umem_id_equal(umm, key->kr_dtx, ummid))
+				goto exchange;
+
+			/* I am the original DTX that create the key that
+			 * is still shared by others. Now, I will be aborted,
+			 * set the reference as UNKNOWN for other left shares.
+			 */
+			key->kr_dtx = DTX_UMMID_UNKNOWN;
+
+exchange:
+			if (rec->tr_flags != DTX_RF_EXCHANGE_SRC)
+				break;
+
+			D_ASSERT(key->kr_flags & VKF_DELETED);
+
+			if (!abort) { /* commit case */
+				struct vos_dtx_record_df	*tgt_rec;
+				struct vos_krec_df		*tgt_key;
+				struct btr_root			 tmp_btr;
+				daos_epoch_t			 tmp_epoch;
+
+				/*
+				 * XXX: If the exchange target still exist,
+				 *	it will be the next record. If it does
+				 *	not exist, then either it is crashed
+				 *	or it has already degistered from the
+				 *	DTX records list. We cannot commit the
+				 *	DTX under any the two cases. Failing
+				 *	the DTX commit is meaningless, then we
+				 *	have to give some warning message.
+				 */
+				if (UMMID_IS_NULL(rec->tr_next)) {
+					D_ERROR(DF_UOID" miss the DTX ("DF_DTI
+						") exchange pairs (1)\n",
+						DP_UOID(dtx->te_oid),
+						DP_DTI(&dtx->te_xid));
+					break;
+				}
+
+				tgt_rec = umem_id2ptr(umm, rec->tr_next);
+				if (tgt_rec->tr_flags != DTX_RF_EXCHANGE_TGT) {
+					D_ERROR(DF_UOID" miss the DTX ("DF_DTI
+						") exchange pairs (2)\n",
+						DP_UOID(dtx->te_oid),
+						DP_DTI(&dtx->te_xid));
+					break;
+				}
+
+				/* Exchange the sub-tree between max epoch
+				 * record and the give epoch record. The
+				 * record with max epoch will be removed
+				 * when aggregation.
+				 */
+				tgt_key = umem_id2ptr(umm, tgt_rec->tr_record);
+				umem_tx_add_ptr(umm, tgt_key, sizeof(*tgt_key));
+
+				tmp_btr = key->kr_btr;
+				key->kr_btr = tgt_key->kr_btr;
+				tgt_key->kr_btr = tmp_btr;
+
+				if (key->kr_bmap & KREC_BF_EVT) {
+					struct evt_root		tmp_evt;
+
+					umem_tx_add_ptr(umm, &key->kr_evt[0],
+							sizeof(key->kr_evt[0]));
+					umem_tx_add_ptr(umm,
+						&tgt_key->kr_evt[0],
+						sizeof(tgt_key->kr_evt[0]));
+
+					tmp_evt = key->kr_evt[0];
+					key->kr_evt[0] = tgt_key->kr_evt[0];
+					tgt_key->kr_evt[0] = tmp_evt;
+				}
+
+				tmp_epoch = key->kr_earliest;
+				key->kr_earliest = tgt_key->kr_earliest;
+				tgt_key->kr_earliest = tmp_epoch;
+
+				D_DEBUG(DB_TRACE, "Exchanged DTX records for "
+					DF_DTI"\n", DP_DTI(&dtx->te_xid));
+			} else { /* abort case */
+				/* Recover the visibility of the exchange source
+				 * for the DTX abort case.
+				 */
+				key->kr_flags &= ~VKF_DELETED;
+				key->kr_dtx = UMMID_NULL;
+			}
+			break;
+		}
+		case DTX_RT_SVT: {
+			struct vos_irec_df	*svt;
+
+			svt = umem_id2ptr(umm, rec->tr_record);
+			umem_tx_add_ptr(umm, svt, sizeof(*svt));
+			if (abort)
+				svt->ir_dtx = DTX_UMMID_ABORTED;
+			else
+				svt->ir_dtx = UMMID_NULL;
+			break;
+		}
+		case DTX_RT_EVT: {
+			struct evt_desc		*evt;
+
+			evt = umem_id2ptr(umm, rec->tr_record);
+			umem_tx_add_ptr(umm, evt, sizeof(*evt));
+			if (abort)
+				evt->dc_dtx = DTX_UMMID_ABORTED;
+			else
+				evt->dc_dtx = UMMID_NULL;
+			break;
+		}
+		default:
+			D_ERROR(DF_UOID" unknown DTX "DF_DTI" type %u\n",
+				DP_UOID(dtx->te_oid), DP_DTI(&dtx->te_xid),
+				rec->tr_type);
+			break;
+		}
+
+		dtx->te_records = rec->tr_next;
+		umem_tx_add_ptr(umm, rec, sizeof(*rec));
+		umem_free(umm, rec_mmid);
+	}
+
+	D_DEBUG(DB_TRACE, "dtx_rec_release: %s/%s the DTX "DF_DTI"\n",
+		abort ? "abort" : "commit", destroy ? "destroy" : "keep",
+		DP_DTI(&dtx->te_xid));
+
+	if (destroy)
+		umem_free(umm, ummid);
+	else
+		dtx->te_flags &= ~(DTX_EF_EXCHANGE_PENDING  | DTX_EF_SHARES);
+
+	return 0;
+}
+
+static void
+vos_dtx_unlink_entry(struct umem_instance *umm, struct vos_dtx_table_df *tab,
+		     struct vos_dtx_entry_df *dtx)
+{
+	struct vos_dtx_entry_df	*ent;
+
+	if (UMMID_IS_NULL(dtx->te_next)) { /* The tail of the DTXs list. */
+		if (UMMID_IS_NULL(dtx->te_prev)) { /* The unique one on list. */
+			tab->tt_entry_head = UMMID_NULL;
+			tab->tt_entry_tail = UMMID_NULL;
+		} else {
+			ent = umem_id2ptr(umm, dtx->te_prev);
+			umem_tx_add_ptr(umm, ent, sizeof(*ent));
+
+			ent->te_next = UMMID_NULL;
+			tab->tt_entry_tail = dtx->te_prev;
+			dtx->te_prev = UMMID_NULL;
+		}
+	} else if (UMMID_IS_NULL(dtx->te_prev)) { /* The head of DTXs list */
+		ent = umem_id2ptr(umm, dtx->te_next);
+		umem_tx_add_ptr(umm, ent, sizeof(*ent));
+
+		ent->te_prev = UMMID_NULL;
+		tab->tt_entry_head = dtx->te_next;
+		dtx->te_next = UMMID_NULL;
+	} else {
+		ent = umem_id2ptr(umm, dtx->te_next);
+		umem_tx_add_ptr(umm, ent, sizeof(*ent));
+		ent->te_prev = dtx->te_prev;
+
+		ent = umem_id2ptr(umm, dtx->te_prev);
+		umem_tx_add_ptr(umm, ent, sizeof(*ent));
+		ent->te_next = dtx->te_next;
+
+		dtx->te_prev = UMMID_NULL;
+		dtx->te_next = UMMID_NULL;
+	}
+}
+
+static int
+vos_dtx_commit_one(struct vos_container *cont, struct daos_tx_id *dti)
+{
+	struct umem_instance	*umm;
+	daos_iov_t		 kiov;
+	daos_iov_t		 riov;
+	umem_id_t		 ummid;
+	int			 rc = 0;
+
+	umm = &cont->vc_pool->vp_umm;
+	daos_iov_set(&kiov, dti, sizeof(*dti));
+	rc = dbtree_delete(cont->vc_dtx_active_hdl, &kiov, &ummid);
+	if (rc == 0) {
+		struct vos_dtx_entry_df		*dtx;
+		struct vos_dtx_entry_df		*ent;
+		struct dtx_rec_bundle		 rbund;
+
+		dtx = umem_id2ptr(umm, ummid);
+		umem_tx_add_ptr(umm, dtx, sizeof(*dtx));
+		dtx->te_state = DTX_ST_COMMITTED;
+
+		if (dtx->te_dkey_hash[0] != 0)
+			vos_dtx_del_cos(cont, &dtx->te_oid, dti,
+					dtx->te_dkey_hash[0],
+					dtx->te_intent == DAOS_INTENT_PUNCH ?
+					true : false);
+
+		rbund.trb_ummid = ummid;
+		daos_iov_set(&riov, &rbund, sizeof(rbund));
+		rc = dbtree_upsert(cont->vc_dtx_committed_hdl,
+				BTR_PROBE_EQ, DAOS_INTENT_UPDATE, &kiov, &riov);
+		if (rc == 0) {
+			struct vos_dtx_table_df	*tab;
+
+			tab = &cont->vc_cont_df->cd_dtx_table_df;
+			umem_tx_add_ptr(umm, tab, sizeof(*tab));
+
+			tab->tt_count++;
+			if (UMMID_IS_NULL(tab->tt_entry_tail)) {
+				D_ASSERT(UMMID_IS_NULL(tab->tt_entry_head));
+
+				tab->tt_entry_head = ummid;
+				tab->tt_entry_tail = tab->tt_entry_head;
+			} else {
+				ent = umem_id2ptr(umm, tab->tt_entry_tail);
+				umem_tx_add_ptr(umm, ent, sizeof(*ent));
+
+				ent->te_next = ummid;
+				dtx->te_prev = tab->tt_entry_tail;
+				tab->tt_entry_tail = ent->te_next;
+			}
+
+			/* If there are pending exchange of records, then we
+			 * need some additional work when commit, such as
+			 * exchange the subtree under the source and target
+			 * records, then related subtree can be exported
+			 * correctly. That will be done when release related
+			 * vos_dth_record_df(s) attached to the DTX.
+			 */
+			if (dtx->te_flags &
+			    (DTX_EF_EXCHANGE_PENDING | DTX_EF_SHARES))
+				rc = dtx_rec_release(umm, ummid, false, false);
+		}
+	} else if (rc == -DER_NONEXIST) {
+		daos_iov_set(&riov, NULL, 0);
+		rc = dbtree_lookup(cont->vc_dtx_committed_hdl, &kiov, &riov);
+	}
+
+	D_DEBUG(DB_TRACE, "Commit the DTX "DF_DTI": rc = %d\n",
+		DP_DTI(dti), rc);
+
+	return rc;
+}
+
+static int
+vos_dtx_abort_one(struct vos_container *cont, struct daos_tx_id *dti,
+		  bool force)
+{
+	daos_iov_t	 kiov;
+	umem_id_t	 dtx;
+	int		 rc;
+
+	daos_iov_set(&kiov, dti, sizeof(*dti));
+	rc = dbtree_delete(cont->vc_dtx_active_hdl, &kiov, &dtx);
+	if (rc == 0)
+		rc = dtx_rec_release(&cont->vc_pool->vp_umm, dtx, true, true);
+
+	D_DEBUG(DB_TRACE, "Abort the DTX "DF_DTI": rc = %d\n", DP_DTI(dti), rc);
+
+	if (rc != 0 && force)
+		rc = 0;
+
+	return rc;
+}
+
+int
+vos_dtx_begin(struct daos_tx_id *dti, daos_unit_oid_t *oid, daos_key_t *dkey,
+	      daos_handle_t coh, daos_epoch_t epoch, uint32_t pm_ver,
+	      uint32_t intent, uint32_t flags, struct daos_tx_handle **dtx)
+{
+	struct daos_tx_handle	*th;
+
+	D_ALLOC_PTR(th);
+	if (th == NULL)
+		return -DER_NOMEM;
+
+	th->dth_xid = *dti;
+	th->dth_oid = *oid;
+	th->dth_dkey = dkey;
+	th->dth_coh = coh;
+	th->dth_epoch = epoch;
+	D_INIT_LIST_HEAD(&th->dth_shares);
+	th->dth_ver = pm_ver;
+	th->dth_intent = intent;
+	th->dth_flags = flags;
+	th->dth_sync = 0;
+	th->dth_non_rep = 0;
+	th->dth_ent = UMMID_NULL;
+
+	*dtx = th;
+	D_DEBUG(DB_TRACE, "Start the DTX "DF_DTI"\n", DP_DTI(dti));
+
+	return 0;
+}
+
+int
+vos_dtx_end(struct daos_tx_handle *dth, int result, bool leader)
+{
+	struct vos_container	*cont;
+	struct vos_dtx_table_df	*tab;
+	double			 now = ABT_get_wtime();
+	int			 rc = 0;
+
+	if (result < 0)
+		D_GOTO(out, rc = result);
+
+	cont = vos_hdl2cont(dth->dth_coh);
+	D_ASSERT(cont != NULL);
+
+	if (leader) {
+		if (dth->dth_sync)
+			D_GOTO(out, rc = 3);
+
+		if (cont->vc_dtx_committable_count > DTX_THRESHOLD_COUNT)
+			D_GOTO(out, rc = 2);
+
+		if ((uint64_t)now - cont->vc_dtx_time_last_commit >
+		     DTX_COMMIT_THRESHOLD_TIME)
+			D_GOTO(out, rc = 2);
+	}
+
+	tab = &cont->vc_cont_df->cd_dtx_table_df;
+	if (tab->tt_count > DTX_AGGREGATION_THRESHOLD_COUNT)
+		D_GOTO(out, rc = 1);
+
+	if ((uint64_t)now - tab->tt_time_last_shrink >
+	    DTX_AGGREGATION_THRESHOLD_TIME)
+		D_GOTO(out, rc = 1);
+
+out:
+	D_DEBUG(DB_TRACE,
+		"Stop the DTX "DF_DTI" ver = %u, %s, %s, %s: rc = %d\n",
+		DP_DTI(&dth->dth_xid), dth->dth_ver,
+		dth->dth_sync ? "sync" : "async",
+		dth->dth_non_rep ? "non-replicated" : "replicated",
+		dth->dth_leader ? "leader" : "non-leader", rc);
+	D_FREE_PTR(dth);
+	return rc;
+}
+
+int
+vos_dtx_check_committable(daos_handle_t coh, struct daos_tx_id *dti)
+{
+	struct vos_container	*cont;
+	daos_iov_t		 kiov;
+	daos_iov_t		 riov;
+	int			 rc = 0;
+
+	cont = vos_hdl2cont(coh);
+	D_ASSERT(cont != NULL);
+
+	daos_iov_set(&kiov, dti, sizeof(*dti));
+	daos_iov_set(&riov, NULL, 0);
+	rc = dbtree_lookup(cont->vc_dtx_active_hdl, &kiov, &riov);
+	if (rc == 0) {
+		struct vos_dtx_entry_df	*dtx;
+
+		dtx = (struct vos_dtx_entry_df *)riov.iov_buf;
+		return dtx->te_state;
+	}
+
+	if (rc == -DER_NONEXIST) {
+		rc = dbtree_lookup(cont->vc_dtx_committed_hdl, &kiov, &riov);
+		if (rc == 0)
+			return DTX_ST_COMMITTED;
+	}
+
+	if (rc == -DER_NONEXIST)
+		return DTX_ST_INIT;
+
+	return rc;
+}
+
+int
+vos_dtx_commit(daos_handle_t coh, struct daos_tx_id *dti, int count)
+{
+	struct vos_container	*cont;
+	struct umem_instance	*umm;
+	int			 i;
+	int			 rc = 0;
+
+	cont = vos_hdl2cont(coh);
+	D_ASSERT(cont != NULL);
+
+	umm = &cont->vc_pool->vp_umm;
+	/* Commit multiple DTXs via single PMDK transaction. */
+	rc = umem_tx_begin(umm, vos_txd_get());
+	if (rc == 0) {
+		for (i = 0; i < count; i++)
+			vos_dtx_commit_one(cont, &dti[i]);
+
+		cont->vc_dtx_time_last_commit = ABT_get_wtime();
+		umem_tx_commit(umm);
+	}
+
+	return rc;
+}
+
+int
+vos_dtx_abort(daos_handle_t coh, struct daos_tx_id *dti, int count, bool force)
+{
+	struct vos_container	*cont;
+	struct umem_instance	*umm;
+	int			 rc;
+	int			 i;
+
+	cont = vos_hdl2cont(coh);
+	D_ASSERT(cont != NULL);
+
+	umm = &cont->vc_pool->vp_umm;
+	/* Abort multiple DTXs via single PMDK transaction. */
+	rc = umem_tx_begin(umm, vos_txd_get());
+	for (i = 0; rc == 0 && i < count; i++)
+		rc = vos_dtx_abort_one(cont, &dti[i], force);
+
+	if (rc == 0)
+		umem_tx_commit(umm);
+	else
+		umem_tx_abort(umm, rc);
+
+	return rc;
+}
+
+void
+vos_dtx_aggregate(daos_handle_t coh, uint64_t max, uint64_t age)
+{
+	struct vos_container		*cont;
+	struct umem_instance		*umm;
+	struct vos_dtx_table_df		*tab;
+	umem_id_t			 dtx_mmid;
+	daos_iov_t			 kiov;
+	uint64_t			 count;
+	double				 now;
+	int				 rc = 0;
+	bool				 stop = false;
+
+	if (max == 0)
+		max = DTX_AGGREGATION_THRESHOLD_COUNT;
+
+	now = ABT_get_wtime();
+	if (age == 0)
+		age = now - DTX_AGGREGATION_THRESHOLD_TIME;
+	else if (age != (uint64_t)(-1))
+		age = now - age;
+
+	cont = vos_hdl2cont(coh);
+	D_ASSERT(cont != NULL);
+
+	umm = &cont->vc_pool->vp_umm;
+	tab = &cont->vc_cont_df->cd_dtx_table_df;
+
+	for (count = 0, dtx_mmid = tab->tt_entry_head;
+	     count < max && !UMMID_IS_NULL(dtx_mmid);) {
+		int	i;
+
+		rc = umem_tx_begin(umm, vos_txd_get());
+		if (rc != 0)
+			return;
+
+		umem_tx_add_ptr(umm, tab, sizeof(*tab));
+		for (i = 0; i < DTX_AGGREGATION_YIELD_INTERVAL &&
+		     !UMMID_IS_NULL(dtx_mmid) && count < max; i++, count++) {
+			struct vos_dtx_entry_df	*dtx;
+			umem_id_t		 ummid;
+
+			dtx = umem_id2ptr(umm, dtx_mmid);
+			if (dtx->te_sec > age) {
+				stop = true;
+				break;
+			}
+
+			umem_tx_add_ptr(umm, dtx, sizeof(*dtx));
+			daos_iov_set(&kiov, &dtx->te_xid, sizeof(dtx->te_xid));
+			rc = dbtree_delete(cont->vc_dtx_committed_hdl, &kiov,
+					   &ummid);
+			D_ASSERT(rc == 0);
+
+			tab->tt_count--;
+			dtx_mmid = dtx->te_next;
+			vos_dtx_unlink_entry(umm, tab, dtx);
+			dtx_rec_release(umm, ummid, false, true);
+		}
+
+		tab->tt_time_last_shrink = now;
+		umem_tx_commit(umm);
+
+		if (stop)
+			return;
+
+		/* Yield per DTX_AGGREGATION_YIELD_INTERVAL. */
+		ABT_thread_yield();
+	}
+}

--- a/src/vos/vos_dtx_cos.c
+++ b/src/vos/vos_dtx_cos.c
@@ -1,0 +1,481 @@
+/**
+ * (C) Copyright 2019 Intel Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * GOVERNMENT LICENSE RIGHTS-OPEN SOURCE SOFTWARE
+ * The Government's rights to use, modify, reproduce, release, perform, display,
+ * or disclose this software are subject to the terms of the Apache License as
+ * provided in Contract No. B609815.
+ * Any reproduction of computer software, computer software documentation, or
+ * portions thereof marked with this legend must also reproduce the markings.
+ */
+/**
+ * This file is part of daos two-phase commit transaction.
+ *
+ * vos/vos_dtx_cos.c
+ */
+#define D_LOGFAC	DD_FAC(vos)
+
+#include <daos/btree.h>
+#include "vos_layout.h"
+#include "vos_internal.h"
+
+/* The record for the DTX CoS B+tree in DRAM. Each record contains current
+ * committable DTXs that modify (update or punch) something under the same
+ * object and the same dkey.
+ */
+struct dtx_cos_rec {
+	daos_unit_oid_t		 dcr_oid;
+	/* The list in DRAM for the DTXs that modify the same object/dkey.
+	 * Per-dkey based.
+	 */
+	d_list_t		 dcr_update_list;
+	d_list_t		 dcr_punch_list;
+	/* The number of the UPDATE DTXs in the dcr_update_list. */
+	int			 dcr_update_count;
+	/* The number of the PUNCH DTXs in the dcr_punch_list. */
+	int			 dcr_punch_count;
+	/* Pointer to the container. */
+	struct vos_container	*dcr_cont;
+};
+
+/* Above dtx_cos_rec is consisted of a series of dtx_cos_rec_child uints.
+ * Each dtx_cos_rec_child contains one DTX that modifies something under
+ * related object and dkey (that attached to the dtx_cos_rec).
+ */
+struct dtx_cos_rec_child {
+	/* Link into the container::vc_dtx_committable. */
+	d_list_t		 dcrc_committable;
+	/* Link into related dcr_{update,punch}_list. */
+	d_list_t		 dcrc_link;
+	/* The DTX identifier. */
+	struct daos_tx_id	 dcrc_dti;
+	/* Pointer to the dtx_cos_rec. */
+	struct dtx_cos_rec	*dcrc_ptr;
+};
+
+struct dtx_cos_rec_bundle {
+	struct vos_container	*cont;
+	struct daos_tx_id	*dti;
+	bool			 punch;
+};
+
+struct dtx_cos_key {
+	daos_unit_oid_t		 oid;
+	uint64_t		 dkey;
+};
+
+static int
+dtx_cos_hkey_size(struct btr_instance *tins)
+{
+	return sizeof(struct dtx_cos_key);
+}
+
+static void
+dtx_cos_hkey_gen(struct btr_instance *tins, daos_iov_t *key_iov, void *hkey)
+{
+	D_ASSERT(key_iov->iov_len == sizeof(struct dtx_cos_key));
+
+	memcpy(hkey, key_iov->iov_buf, key_iov->iov_len);
+}
+
+static int
+dtx_cos_hkey_cmp(struct btr_instance *tins, struct btr_record *rec, void *hkey)
+{
+	struct dtx_cos_key *hkey1 = (struct dtx_cos_key *)&rec->rec_hkey[0];
+	struct dtx_cos_key *hkey2 = (struct dtx_cos_key *)hkey;
+	int		    rc;
+
+	rc = memcmp(hkey1, hkey2, sizeof(struct dtx_cos_key));
+
+	return dbtree_key_cmp_rc(rc);
+}
+
+static int
+dtx_cos_rec_alloc(struct btr_instance *tins, daos_iov_t *key_iov,
+		  daos_iov_t *val_iov, struct btr_record *rec)
+{
+	struct dtx_cos_key		*key;
+	struct dtx_cos_rec_bundle	*rbund;
+	struct dtx_cos_rec		*dcr;
+	struct dtx_cos_rec_child	*dcrc;
+
+	D_ASSERT(tins->ti_umm.umm_id == UMEM_CLASS_VMEM);
+
+	key = (struct dtx_cos_key *)key_iov->iov_buf;
+	rbund = (struct dtx_cos_rec_bundle *)val_iov->iov_buf;
+
+	D_ALLOC_PTR(dcr);
+	if (dcr == NULL)
+		return -DER_NOMEM;
+
+	dcr->dcr_oid = key->oid;
+	D_INIT_LIST_HEAD(&dcr->dcr_update_list);
+	D_INIT_LIST_HEAD(&dcr->dcr_punch_list);
+	dcr->dcr_cont = rbund->cont;
+
+	D_ALLOC_PTR(dcrc);
+	if (dcrc == NULL) {
+		D_FREE_PTR(dcr);
+		return -DER_NOMEM;
+	}
+
+	dcrc->dcrc_dti = *rbund->dti;
+	dcrc->dcrc_ptr = dcr;
+
+	d_list_add_tail(&dcrc->dcrc_committable,
+			&rbund->cont->vc_dtx_committable);
+	rbund->cont->vc_dtx_committable_count++;
+
+	if (rbund->punch) {
+		d_list_add_tail(&dcrc->dcrc_link, &dcr->dcr_punch_list);
+		dcr->dcr_punch_count = 1;
+	} else {
+		d_list_add_tail(&dcrc->dcrc_link, &dcr->dcr_update_list);
+		dcr->dcr_update_count = 1;
+	}
+
+	rec->rec_mmid = umem_ptr2id(&tins->ti_umm, dcr);
+	return 0;
+}
+
+static int
+dtx_cos_rec_free(struct btr_instance *tins, struct btr_record *rec, void *args)
+{
+	struct dtx_cos_rec		*dcr;
+	struct dtx_cos_rec_child	*dcrc;
+	struct dtx_cos_rec_child	*next;
+
+	D_ASSERT(tins->ti_umm.umm_id == UMEM_CLASS_VMEM);
+
+	dcr = (struct dtx_cos_rec *)umem_id2ptr(&tins->ti_umm, rec->rec_mmid);
+	d_list_for_each_entry_safe(dcrc, next, &dcr->dcr_update_list,
+				   dcrc_link) {
+		d_list_del(&dcrc->dcrc_link);
+		d_list_del(&dcrc->dcrc_committable);
+		D_FREE_PTR(dcrc);
+		dcr->dcr_cont->vc_dtx_committable_count--;
+	}
+	d_list_for_each_entry_safe(dcrc, next, &dcr->dcr_punch_list,
+				   dcrc_link) {
+		d_list_del(&dcrc->dcrc_link);
+		d_list_del(&dcrc->dcrc_committable);
+		D_FREE_PTR(dcrc);
+		dcr->dcr_cont->vc_dtx_committable_count--;
+	}
+	D_FREE_PTR(dcr);
+
+	return 0;
+}
+
+static int
+dtx_cos_rec_fetch(struct btr_instance *tins, struct btr_record *rec,
+		  daos_iov_t *key_iov, daos_iov_t *val_iov)
+{
+	struct dtx_cos_rec	*dcr;
+
+	D_ASSERT(val_iov != NULL);
+
+	dcr = (struct dtx_cos_rec *)umem_id2ptr(&tins->ti_umm, rec->rec_mmid);
+	daos_iov_set(val_iov, dcr, sizeof(struct dtx_cos_rec));
+
+	return 0;
+}
+
+static int
+dtx_cos_rec_update(struct btr_instance *tins, struct btr_record *rec,
+		   daos_iov_t *key, daos_iov_t *val)
+{
+	struct dtx_cos_rec_bundle	*rbund;
+	struct dtx_cos_rec		*dcr;
+	struct dtx_cos_rec_child	*dcrc;
+
+	D_ASSERT(tins->ti_umm.umm_id == UMEM_CLASS_VMEM);
+
+	dcr = (struct dtx_cos_rec *)umem_id2ptr(&tins->ti_umm, rec->rec_mmid);
+	rbund = (struct dtx_cos_rec_bundle *)val->iov_buf;
+
+	D_ALLOC_PTR(dcrc);
+	if (dcrc == NULL)
+		return -DER_NOMEM;
+
+	dcrc->dcrc_dti = *rbund->dti;
+	dcrc->dcrc_ptr = dcr;
+
+	d_list_add_tail(&dcrc->dcrc_committable,
+			&rbund->cont->vc_dtx_committable);
+	rbund->cont->vc_dtx_committable_count++;
+
+	if (rbund->punch) {
+		d_list_add_tail(&dcrc->dcrc_link, &dcr->dcr_punch_list);
+		dcr->dcr_punch_count++;
+	} else {
+		d_list_add_tail(&dcrc->dcrc_link, &dcr->dcr_update_list);
+		dcr->dcr_update_count++;
+	}
+
+	return 0;
+}
+
+static btr_ops_t dtx_btr_cos_ops = {
+	.to_hkey_size	= dtx_cos_hkey_size,
+	.to_hkey_gen	= dtx_cos_hkey_gen,
+	.to_hkey_cmp	= dtx_cos_hkey_cmp,
+	.to_rec_alloc	= dtx_cos_rec_alloc,
+	.to_rec_free	= dtx_cos_rec_free,
+	.to_rec_fetch	= dtx_cos_rec_fetch,
+	.to_rec_update	= dtx_cos_rec_update,
+};
+
+int
+vos_dtx_cos_register(void)
+{
+	int	rc;
+
+	D_DEBUG(DB_DF, "Registering DTX CoS class: %d\n",
+		VOS_BTR_DTX_COS);
+
+	rc = dbtree_class_register(VOS_BTR_DTX_COS, 0, &dtx_btr_cos_ops);
+	if (rc != 0)
+		D_ERROR("Failed to register DTX CoS dbtree: rc = %d\n", rc);
+
+	return rc;
+}
+
+int
+vos_dtx_list_cos(struct vos_container *cont, daos_unit_oid_t *oid,
+		 daos_key_t *dkey, uint32_t types, struct daos_tx_id **dtis)
+{
+	struct dtx_cos_key		 key;
+	daos_iov_t			 kiov;
+	daos_iov_t			 riov;
+	struct daos_tx_id		*dti = NULL;
+	struct dtx_cos_rec		*dcr;
+	struct dtx_cos_rec_child	*dcrc;
+	int				 count = 0;
+	int				 rc;
+	int				 i = 0;
+
+	if (dkey == NULL)
+		return 0;
+
+	D_ASSERT(dkey->iov_buf != NULL);
+	D_ASSERT(dkey->iov_len != 0);
+
+	key.oid = *oid;
+	key.dkey = d_hash_murmur64(dkey->iov_buf, dkey->iov_len,
+				   VOS_BTR_MUR_SEED);
+	daos_iov_set(&kiov, &key, sizeof(key));
+	daos_iov_set(&riov, NULL, 0);
+
+	rc = dbtree_lookup(cont->vc_dtx_cos_hdl, &kiov, &riov);
+	if (rc != 0)
+		return rc == -DER_NONEXIST ? 0 : rc;
+
+	dcr = (struct dtx_cos_rec *)riov.iov_buf;
+	if (types & DCLT_PUNCH)
+		count += dcr->dcr_punch_count;
+	if (types & DCLT_UPDATE)
+		count += dcr->dcr_update_count;
+
+	if (count == 0)
+		return 0;
+
+	/* There are too many shared DTXs to be committed, as to
+	 * cannot be taken via the normal UPDATE RPC. Return the
+	 * DTXs count directly without filling the DTX array.
+	 */
+	if (count > DTX_THRESHOLD_COUNT) {
+		*dtis = NULL;
+		return count;
+	}
+
+	D_ALLOC_ARRAY(dti, count);
+	if (dti == NULL)
+		return -DER_NOMEM;
+
+	if (types & DCLT_PUNCH) {
+		d_list_for_each_entry(dcrc, &dcr->dcr_punch_list,
+				      dcrc_link) {
+			dti[i++] = dcrc->dcrc_dti;
+		}
+	}
+
+	if (types & DCLT_UPDATE) {
+		d_list_for_each_entry(dcrc, &dcr->dcr_update_list,
+				      dcrc_link) {
+			dti[i++] = dcrc->dcrc_dti;
+		}
+	}
+
+	D_ASSERT(i == count);
+
+	*dtis = dti;
+	return count;
+}
+
+int
+vos_dtx_add_cos(struct vos_container *cont, daos_unit_oid_t *oid,
+		struct daos_tx_id *dti, uint64_t dkey, bool punch)
+{
+	struct dtx_cos_key		 key;
+	struct dtx_cos_rec_bundle	 rbund;
+	daos_iov_t			 kiov;
+	daos_iov_t			 riov;
+	int				 rc;
+
+	D_ASSERT(dkey != 0);
+
+	key.oid = *oid;
+	key.dkey = dkey;
+	daos_iov_set(&kiov, &key, sizeof(key));
+
+	rbund.cont = cont;
+	rbund.dti = dti;
+	rbund.punch = punch;
+	daos_iov_set(&riov, &rbund, sizeof(rbund));
+
+	rc = dbtree_upsert(cont->vc_dtx_cos_hdl, BTR_PROBE_EQ,
+			   DAOS_INTENT_UPDATE, &kiov, &riov);
+
+	return rc;
+}
+
+void
+vos_dtx_del_cos(struct vos_container *cont, daos_unit_oid_t *oid,
+		struct daos_tx_id *xid, uint64_t dkey, bool punch)
+{
+	struct dtx_cos_key		 key;
+	daos_iov_t			 kiov;
+	daos_iov_t			 riov;
+	struct dtx_cos_rec		*dcr;
+	struct dtx_cos_rec_child	*dcrc;
+	d_list_t			*head;
+	int				 rc;
+
+	D_ASSERT(dkey != 0);
+
+	key.oid = *oid;
+	key.dkey = dkey;
+	daos_iov_set(&kiov, &key, sizeof(key));
+	daos_iov_set(&riov, NULL, 0);
+
+	rc = dbtree_lookup(cont->vc_dtx_cos_hdl, &kiov, &riov);
+	if (rc != 0)
+		return;
+
+	dcr = (struct dtx_cos_rec *)riov.iov_buf;
+	if (punch)
+		head = &dcr->dcr_punch_list;
+	else
+		head = &dcr->dcr_update_list;
+
+	d_list_for_each_entry(dcrc, head, dcrc_link) {
+		if (memcmp(&dcrc->dcrc_dti, xid, sizeof(*xid)) != 0)
+			continue;
+
+		d_list_del(&dcrc->dcrc_committable);
+		d_list_del(&dcrc->dcrc_link);
+		D_FREE_PTR(dcrc);
+
+		cont->vc_dtx_committable_count--;
+		if (punch)
+			dcr->dcr_punch_count--;
+		else
+			dcr->dcr_update_count--;
+		if (dcr->dcr_punch_count == 0 && dcr->dcr_update_count == 0)
+			dbtree_delete(cont->vc_dtx_cos_hdl, &kiov, NULL);
+
+		return;
+	}
+}
+
+int
+vos_dtx_lookup_cos(daos_handle_t coh, daos_unit_oid_t *oid,
+		   struct daos_tx_id *xid, uint64_t dkey, bool punch)
+{
+	struct vos_container		*cont;
+	struct dtx_cos_key		 key;
+	daos_iov_t			 kiov;
+	daos_iov_t			 riov;
+	struct dtx_cos_rec		*dcr;
+	struct dtx_cos_rec_child	*dcrc;
+	d_list_t			*head;
+	int				 rc;
+
+	if (dkey == 0)
+		return -DER_NONEXIST;
+
+	cont = vos_hdl2cont(coh);
+	D_ASSERT(cont != NULL);
+
+	key.oid = *oid;
+	key.dkey = dkey;
+	daos_iov_set(&kiov, &key, sizeof(key));
+	daos_iov_set(&riov, NULL, 0);
+
+	rc = dbtree_lookup(cont->vc_dtx_cos_hdl, &kiov, &riov);
+	if (rc != 0)
+		return rc;
+
+	dcr = (struct dtx_cos_rec *)riov.iov_buf;
+	if (punch)
+		head = &dcr->dcr_punch_list;
+	else
+		head = &dcr->dcr_update_list;
+
+	d_list_for_each_entry(dcrc, head, dcrc_link) {
+		if (memcmp(&dcrc->dcrc_dti, xid, sizeof(*xid)) == 0)
+			return 0;
+	}
+
+	return -DER_NONEXIST;
+}
+
+int
+vos_dtx_list_committable(daos_handle_t coh, struct daos_tx_entry **dtes)
+{
+	struct daos_tx_entry		*dte = NULL;
+	struct dtx_cos_rec_child	*dcrc;
+	struct vos_container		*cont;
+	int				 count;
+	int				 i = 0;
+
+	cont = vos_hdl2cont(coh);
+	D_ASSERT(cont != NULL);
+
+	if (cont->vc_dtx_committable_count > DTX_THRESHOLD_COUNT)
+		count = DTX_THRESHOLD_COUNT;
+	else
+		count = cont->vc_dtx_committable_count;
+
+	if (count == 0)
+		return 0;
+
+	D_ALLOC_ARRAY(dte, count);
+	if (dte == NULL)
+		return -DER_NOMEM;
+
+	d_list_for_each_entry(dcrc, &cont->vc_dtx_committable,
+			      dcrc_committable) {
+		dte[i].dte_xid = dcrc->dcrc_dti;
+		dte[i].dte_oid = dcrc->dcrc_ptr->dcr_oid;
+
+		if (++i >= count)
+			break;
+	}
+
+	*dtes = dte;
+	return count;
+}

--- a/src/vos/vos_dtx_iter.c
+++ b/src/vos/vos_dtx_iter.c
@@ -1,0 +1,194 @@
+/**
+ * (C) Copyright 2019 Intel Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * GOVERNMENT LICENSE RIGHTS-OPEN SOURCE SOFTWARE
+ * The Government's rights to use, modify, reproduce, release, perform, display,
+ * or disclose this software are subject to the terms of the Apache License as
+ * provided in Contract No. B609815.
+ * Any reproduction of computer software, computer software documentation, or
+ * portions thereof marked with this legend must also reproduce the markings.
+ */
+/**
+ * This file is part of daos two-phase commit transaction.
+ *
+ * vos/vos_dtx_iter.c
+ */
+#define D_LOGFAC	DD_FAC(vos)
+
+#include "vos_layout.h"
+#include "vos_internal.h"
+
+/** Iterator for active-DTX table. */
+struct vos_dtx_iter {
+	/** embedded VOS common iterator */
+	struct vos_iterator	 oit_iter;
+	/** Handle of iterator */
+	daos_handle_t		 oit_hdl;
+	/** Reference to the container */
+	struct vos_container	*oit_cont;
+};
+
+static struct vos_dtx_iter *
+iter2oiter(struct vos_iterator *iter)
+{
+	return container_of(iter, struct vos_dtx_iter, oit_iter);
+}
+
+static int
+dtx_iter_fini(struct vos_iterator *iter)
+{
+	struct vos_dtx_iter	*oiter = iter2oiter(iter);
+	int			 rc = 0;
+
+	D_ASSERT(iter->it_type == VOS_ITER_DTX);
+
+	if (!daos_handle_is_inval(oiter->oit_hdl)) {
+		rc = dbtree_iter_finish(oiter->oit_hdl);
+		if (rc != 0)
+			D_ERROR("oid_iter_fini failed: rc = %d\n", rc);
+	}
+
+	if (oiter->oit_cont != NULL)
+		vos_cont_decref(oiter->oit_cont);
+
+	D_FREE_PTR(oiter);
+	return rc;
+}
+
+static int
+dtx_iter_prep(vos_iter_type_t type, vos_iter_param_t *param,
+	      struct vos_iterator **iter_pp)
+{
+	struct vos_dtx_iter	*oiter;
+	struct vos_container	*cont;
+	int			 rc;
+
+	if (type != VOS_ITER_DTX) {
+		D_ERROR("Expected Type: %d, got %d\n", VOS_ITER_DTX, type);
+		return -DER_INVAL;
+	}
+
+	cont = vos_hdl2cont(param->ip_hdl);
+	if (cont == NULL)
+		return -DER_INVAL;
+
+	D_ALLOC_PTR(oiter);
+	if (oiter == NULL)
+		return -DER_NOMEM;
+
+	oiter->oit_cont = cont;
+	vos_cont_addref(cont);
+
+	rc = dbtree_iter_prepare(cont->vc_dtx_active_hdl, 0, &oiter->oit_hdl);
+	if (rc != 0) {
+		D_ERROR("Failed to prepare DTX iteration: rc = %d\n", rc);
+		dtx_iter_fini(&oiter->oit_iter);
+	} else {
+		*iter_pp = &oiter->oit_iter;
+	}
+
+	return rc;
+}
+
+static int
+dtx_iter_probe(struct vos_iterator *iter, daos_anchor_t *anchor)
+{
+	struct vos_dtx_iter	*oiter = iter2oiter(iter);
+	dbtree_probe_opc_t	 opc;
+
+	D_ASSERT(iter->it_type == VOS_ITER_DTX);
+
+	opc = anchor == NULL ? BTR_PROBE_FIRST : BTR_PROBE_GE;
+	return dbtree_iter_probe(oiter->oit_hdl, opc, vos_iter_intent(iter),
+				 NULL, anchor);
+}
+
+static int
+dtx_iter_next(struct vos_iterator *iter)
+{
+	struct vos_dtx_iter	*oiter = iter2oiter(iter);
+
+	D_ASSERT(iter->it_type == VOS_ITER_DTX);
+
+	return dbtree_iter_next(oiter->oit_hdl);
+}
+
+static int
+dtx_iter_fetch(struct vos_iterator *iter, vos_iter_entry_t *it_entry,
+	       daos_anchor_t *anchor)
+{
+	struct vos_dtx_iter	*oiter = iter2oiter(iter);
+	struct vos_dtx_entry_df	*dtx;
+	daos_iov_t		 rec_iov;
+	int			 rc;
+
+	D_ASSERT(iter->it_type == VOS_ITER_DTX);
+
+	daos_iov_set(&rec_iov, NULL, 0);
+	rc = dbtree_iter_fetch(oiter->oit_hdl, NULL, &rec_iov, anchor);
+	if (rc != 0) {
+		D_ERROR("Error while fetching DTX info: rc = %d\n", rc);
+		return rc;
+	}
+
+	D_ASSERT(rec_iov.iov_len == sizeof(struct vos_dtx_entry_df));
+	dtx = (struct vos_dtx_entry_df *)rec_iov.iov_buf;
+
+	it_entry->ie_xid = dtx->te_xid;
+	it_entry->ie_oid = dtx->te_oid;
+	it_entry->ie_dtx_sec = dtx->te_sec;
+	it_entry->ie_dtx_state = dtx->te_state;
+	it_entry->ie_dtx_intent = dtx->te_intent;
+	it_entry->ie_dtx_hash = dtx->te_dkey_hash[0];
+
+	D_DEBUG(DB_TRACE, "DTX iterator fetch the one "DF_DTI"\n",
+		DP_DTI(&dtx->te_xid));
+
+	return 0;
+}
+
+static int
+dtx_iter_delete(struct vos_iterator *iter, void *args)
+{
+	struct vos_dtx_iter	*oiter = iter2oiter(iter);
+	struct umem_instance	*umm;
+	int			 rc;
+
+	D_ASSERT(iter->it_type == VOS_ITER_DTX);
+
+	umm = &oiter->oit_cont->vc_pool->vp_umm;
+	rc = umem_tx_begin(umm, vos_txd_get());
+	if (rc != 0)
+		return rc;
+
+	rc = dbtree_iter_delete(oiter->oit_hdl, args);
+	if (rc != 0) {
+		umem_tx_abort(umm, rc);
+		D_ERROR("Failed to delete DTX entry: rc = %d\n", rc);
+	} else {
+		umem_tx_commit(umm);
+	}
+
+	return rc;
+}
+
+struct vos_iter_ops vos_dtx_iter_ops = {
+	.iop_prepare =	dtx_iter_prep,
+	.iop_finish  =  dtx_iter_fini,
+	.iop_probe   =	dtx_iter_probe,
+	.iop_next    =  dtx_iter_next,
+	.iop_fetch   =  dtx_iter_fetch,
+	.iop_delete  =	dtx_iter_delete,
+};

--- a/src/vos/vos_internal.h
+++ b/src/vos/vos_internal.h
@@ -45,6 +45,7 @@
 
 extern struct dss_module_key vos_module_key;
 extern umem_class_id_t vos_mem_class;
+extern double vos_start_time;
 
 #define VOS_POOL_HHASH_BITS 10 /* Upto 1024 pools */
 #define VOS_CONT_HHASH_BITS 20 /* Upto 1048576 containers */

--- a/src/vos/vos_internal.h
+++ b/src/vos/vos_internal.h
@@ -152,6 +152,7 @@ struct vos_imem_strts {
 struct vos_imem_strts		*vsa_imems_inst;
 struct bio_xs_context		*vsa_xsctxt_inst;
 struct umem_tx_stage_data	 vsa_txd_inst;
+struct daos_tx_handle		*vsa_dth;
 bool vsa_nvme_init;
 
 static inline struct bio_xs_context *
@@ -219,9 +220,22 @@ extern struct vos_iter_ops vos_dtx_iter_ops;
 /** VOS thread local storage structure */
 struct vos_tls {
 	/* in-memory structures TLS instance */
-	struct vos_imem_strts		vtl_imems_inst;
+	struct vos_imem_strts		 vtl_imems_inst;
 	/* PMDK transaction stage callback data */
-	struct umem_tx_stage_data	vtl_txd;
+	struct umem_tx_stage_data	 vtl_txd;
+	/** XXX: The DTX handle.
+	 *
+	 *	 Transferring DTX handle via TLS can avoid much changing
+	 *	 of existing functions' interfaces, and avoid the corner
+	 *	 cases that someone may miss to set the DTX handle when
+	 *	 operate related tree.
+	 *
+	 *	 But honestly, it is some hack to pass the DTX handle via
+	 *	 the TLS. It requires that there is no CPU yield during the
+	 *	 processing. Otherwise, the vtl_dth may be changed by other
+	 *	 ULTs. The user needs to guarantee that by itself.
+	 */
+	struct daos_tx_handle		*vtl_dth;
 };
 
 static inline struct vos_tls *
@@ -262,6 +276,30 @@ vos_txd_get(void)
 	return &vsa_txd_inst;
 #else
 	return &(vos_tls_get()->vtl_txd);
+#endif
+}
+
+static inline struct daos_tx_handle *
+vos_dth_get(void)
+{
+#ifdef VOS_STANDALONE
+	return vsa_dth;
+#else
+	return vos_tls_get()->vtl_dth;
+#endif
+}
+
+static inline void
+vos_dth_set(struct daos_tx_handle *dth)
+{
+#ifdef VOS_STANDALONE
+	D_ASSERT(dth == NULL || vsa_dth == NULL);
+
+	vsa_dth = dth;
+#else
+	D_ASSERT(dth == NULL || vos_tls_get()->vtl_dth == NULL);
+
+	vos_tls_get()->vtl_dth = dth;
 #endif
 }
 
@@ -442,6 +480,53 @@ vos_dtx_table_destroy(struct vos_pool *pool, struct vos_dtx_table_df *dtab_df);
  */
 int
 vos_dtx_table_register(void);
+
+
+/**
+ * Register the record (to be modified) to the DTX entry.
+ *
+ * \param umm		[IN]	Instance of an unified memory class.
+ * \param record	[IN]	Address of the record (in SCM) to be modified.
+ * \param type		[IN]	The record type, see vos_dtx_record_types.
+ * \param flags		[IN]	The record flags, see vos_dtx_record_flags.
+ *
+ * \return		0 on success and negative on failure.
+ */
+int
+vos_dtx_register_record(struct umem_instance *umm, umem_id_t record,
+			uint32_t type, uint32_t flags);
+
+/**
+ * Degister the record from the DTX entry.
+ *
+ * \param umm		[IN]	Instance of an unified memory class.
+ * \param entry		[IN]	The DTX entry address.
+ * \param record	[IN]	Address of the record to be degistered.
+ * \param type		[IN]	The record type, vos_dtx_record_types.
+ *
+ * \return		0 on success and negative on failure.
+ */
+int
+vos_dtx_degister_record(struct umem_instance *umm,
+			umem_id_t entry, umem_id_t record, uint32_t type);
+
+/**
+ * Mark the DTX as prepared locally.
+ *
+ * \param dth	[IN]	Pointer to the DTX handle.
+ *
+ * \return		0 on success and negative on failure.
+ */
+int
+vos_dtx_prepared(struct daos_tx_handle *dth);
+
+void
+vos_dtx_commit_internal(struct vos_container *cont, struct daos_tx_id *dti,
+			int count);
+
+int
+vos_dtx_abort_internal(struct vos_container *cont, struct daos_tx_id *dti,
+		       int count, bool force);
 
 /**
  * Register dbtree class for DTX CoS, it is called within vos_init().

--- a/src/vos/vos_internal.h
+++ b/src/vos/vos_internal.h
@@ -116,6 +116,8 @@ struct vos_container {
 	d_list_t		vc_dtx_committable;
 	/* The count of commiitable DTXs. */
 	uint32_t		vc_dtx_committable_count;
+	/** The time in second when last commit the DTXs. */
+	double			vc_dtx_time_last_commit;
 	/* Direct pointer to VOS object index
 	 * within container
 	 */
@@ -172,6 +174,18 @@ enum {
 #define VOS_OFEAT_SHIFT		48
 #define VOS_OFEAT_MASK		(0x0ffULL   << VOS_OFEAT_SHIFT)
 #define VOS_OFEAT_BITS		(0x0ffffULL << VOS_OFEAT_SHIFT)
+
+#if DAOS_HAS_PMDK
+static const PMEMoid DTX_UMMID_ABORTED = { .pool_uuid_lo = -1,
+					   .off = -1,
+};
+static const PMEMoid DTX_UMMID_UNKNOWN = { .pool_uuid_lo = -1,
+					   .off = -2,
+};
+#else
+# define DTX_UMMID_ABORTED	((umem_id_t){ .pool_uuid_lo = -1, .off = -1, })
+# define DTX_UMMID_UNKNOWN	((umem_id_t){ .pool_uuid_lo = -1, .off = -2, })
+#endif
 
 /**
  * A cached object (DRAM data structure).

--- a/src/vos/vos_internal.h
+++ b/src/vos/vos_internal.h
@@ -481,6 +481,29 @@ vos_dtx_table_destroy(struct vos_pool *pool, struct vos_dtx_table_df *dtab_df);
 int
 vos_dtx_table_register(void);
 
+/**
+ * Check whether the record (to be accessible) is visible to outside or not.
+ *
+ * \param umm		[IN]	Instance of an unified memory class.
+ * \param coh		[IN]	The container open handle.
+ * \param entry		[IN]	Address of the DTX to be checked.
+ * \param intent	[IN]	The request intent.
+ * \param type		[IN]	The record type, see vos_dtx_record_types.
+ *
+ * \return	positive value	If visible to outside.
+ *		zero		If invisible to outside.
+ *		-DER_INPROGRESS If the target record is in some
+ *				uncommitted DTX, the caller
+ *				needs to retry some time later.
+ *				Or the caller is not sure about whether
+ *				related DTX is committable or not, need
+ *				to check with leader replica.
+ *		negative value	For error cases.
+ */
+int
+vos_dtx_check_visibility(struct umem_instance *umm,
+			 daos_handle_t coh, umem_id_t entry,
+			 uint32_t intent, uint32_t type);
 
 /**
  * Register the record (to be modified) to the DTX entry.

--- a/src/vos/vos_internal.h
+++ b/src/vos/vos_internal.h
@@ -214,6 +214,7 @@ struct vos_object {
 extern struct vos_iter_ops vos_oi_iter_ops;
 extern struct vos_iter_ops vos_obj_iter_ops;
 extern struct vos_iter_ops vos_cont_iter_ops;
+extern struct vos_iter_ops vos_dtx_iter_ops;
 
 /** VOS thread local storage structure */
 struct vos_tls {

--- a/src/vos/vos_internal.h
+++ b/src/vos/vos_internal.h
@@ -108,6 +108,14 @@ struct vos_container {
 	daos_handle_t		vc_dtx_committed_hdl;
 	/* DAOS handle for object index btree */
 	daos_handle_t		vc_btr_hdl;
+	/* The objects with committable DTXs in DRAM. */
+	daos_handle_t		vc_dtx_cos_hdl;
+	/* The DTX COS-btree. */
+	struct btr_root		vc_dtx_cos_btr;
+	/* The global list for commiitable DTXs. */
+	d_list_t		vc_dtx_committable;
+	/* The count of commiitable DTXs. */
+	uint32_t		vc_dtx_committable_count;
 	/* Direct pointer to VOS object index
 	 * within container
 	 */
@@ -419,6 +427,43 @@ vos_dtx_table_destroy(struct vos_pool *pool, struct vos_dtx_table_df *dtab_df);
 int
 vos_dtx_table_register(void);
 
+/**
+ * Register dbtree class for DTX CoS, it is called within vos_init().
+ *
+ * \return		0 on success and negative on failure.
+ */
+int
+vos_dtx_cos_register(void);
+
+/**
+ * Add the given DTX to the Commit-on-Share (CoS) cache (in DRAM).
+ *
+ * \param cont	[IN]	Pointer to the container.
+ * \param oid	[IN]	The target object (shard) ID.
+ * \param dti	[IN]	The DTX identifier.
+ * \param dkey	[IN]	The hashed dkey.
+ * \param punch	[IN]	For punch DTX or not.
+ *
+ * \return		Zero on success and need not additional actions.
+ * \return		Negative value if error.
+ */
+int
+vos_dtx_add_cos(struct vos_container *cont, daos_unit_oid_t *oid,
+		struct daos_tx_id *dti, uint64_t dkey, bool punch);
+
+/**
+ * Remove the DTX from the CoS cache.
+ *
+ * \param cont	[IN]	Pointer to the container.
+ * \param oid	[IN]	Pointer to the object ID.
+ * \param xid	[IN]	Pointer to the DTX identifier.
+ * \param dkey	[IN]	The hashed dkey.
+ * \param punch	[IN]	For punch DTX or not.
+ */
+void
+vos_dtx_del_cos(struct vos_container *cont, daos_unit_oid_t *oid,
+		struct daos_tx_id *xid, uint64_t dkey, bool punch);
+
 enum vos_tree_class {
 	/** the first reserved tree class */
 	VOS_BTR_BEGIN		= DBTREE_VOS_BEGIN,
@@ -434,6 +479,8 @@ enum vos_tree_class {
 	VOS_BTR_CONT_TABLE	= (VOS_BTR_BEGIN + 4),
 	/** DAOS two-phase commit transation table */
 	VOS_BTR_DTX_TABLE	= (VOS_BTR_BEGIN + 5),
+	/** The objects with committable DTXs in DRAM */
+	VOS_BTR_DTX_COS		= (VOS_BTR_BEGIN + 6),
 	/** the last reserved tree class */
 	VOS_BTR_END,
 };

--- a/src/vos/vos_iterator.c
+++ b/src/vos/vos_iterator.c
@@ -70,6 +70,11 @@ static struct vos_iter_dict vos_iterators[] = {
 		.id_ops		= &vos_obj_iter_ops,
 	},
 	{
+		.id_type	= VOS_ITER_DTX,
+		.id_name	= "dtx",
+		.id_ops		= &vos_dtx_iter_ops,
+	},
+	{
 		.id_type	= VOS_ITER_NONE,
 		.id_name	= "unknown",
 		.id_ops		= NULL,

--- a/src/vos/vos_layout.h
+++ b/src/vos/vos_layout.h
@@ -251,6 +251,11 @@ enum vos_krec_bf {
 	KREC_BF_PUNCHED			= (1 << 1),
 };
 
+enum vos_kerc_flags {
+	/* The record is (or to be) deleted. */
+	VKF_DELETED	= 1,
+};
+
 /**
  * Persisted VOS (d)key record, it is referenced by btr_record::rec_mmid
  * of btree VOS_BTR_KEY.
@@ -262,8 +267,8 @@ struct vos_krec_df {
 	uint8_t				kr_cs_type;
 	/** key checksum size (in bytes) */
 	uint8_t				kr_cs_size;
-	/** padding bytes */
-	uint8_t				kr_pad_8;
+	/** See enum vos_kerc_flags. */
+	uint8_t				kr_flags;
 	/** key length */
 	uint32_t			kr_size;
 	/* Latest known update timestamp or punched timestamp */

--- a/src/vos/vos_obj_index.c
+++ b/src/vos/vos_obj_index.c
@@ -213,14 +213,23 @@ oi_rec_update(struct btr_instance *tins, struct btr_record *rec,
 	return 0;
 }
 
+static int
+oi_check_visibility(struct btr_instance *tins, struct btr_record *rec,
+		    uint32_t intent)
+{
+	return vos_dtx_check_visibility(&tins->ti_umm, tins->ti_coh,
+					rec->rec_mmid, intent, DTX_RT_OBJ);
+}
+
 static btr_ops_t oi_btr_ops = {
-	.to_hkey_size	= oi_hkey_size,
-	.to_hkey_gen	= oi_hkey_gen,
-	.to_hkey_cmp	= oi_hkey_cmp,
-	.to_rec_alloc	= oi_rec_alloc,
-	.to_rec_free	= oi_rec_free,
-	.to_rec_fetch	= oi_rec_fetch,
-	.to_rec_update	= oi_rec_update,
+	.to_hkey_size		= oi_hkey_size,
+	.to_hkey_gen		= oi_hkey_gen,
+	.to_hkey_cmp		= oi_hkey_cmp,
+	.to_rec_alloc		= oi_rec_alloc,
+	.to_rec_free		= oi_rec_free,
+	.to_rec_fetch		= oi_rec_fetch,
+	.to_rec_update		= oi_rec_update,
+	.to_check_visibility	= oi_check_visibility,
 };
 
 /**

--- a/src/vos/vos_tree.c
+++ b/src/vos/vos_tree.c
@@ -518,6 +518,14 @@ ktr_rec_update(struct btr_instance *tins, struct btr_record *rec,
 	return 0;
 }
 
+static int
+ktr_check_visibility(struct btr_instance *tins, struct btr_record *rec,
+		     uint32_t intent)
+{
+	return vos_dtx_check_visibility(&tins->ti_umm, tins->ti_coh,
+					rec->rec_mmid, intent, DTX_RT_KEY);
+}
+
 static btr_ops_t key_btr_ops = {
 	.to_hkey_size		= ktr_hkey_size,
 	.to_hkey_gen		= ktr_hkey_gen,
@@ -529,6 +537,7 @@ static btr_ops_t key_btr_ops = {
 	.to_rec_free		= ktr_rec_free,
 	.to_rec_fetch		= ktr_rec_fetch,
 	.to_rec_update		= ktr_rec_update,
+	.to_check_visibility	= ktr_check_visibility,
 };
 
 /**
@@ -783,6 +792,14 @@ svt_rec_update(struct btr_instance *tins, struct btr_record *rec,
 	return svt_rec_store(tins, rec, kbund, rbund);
 }
 
+static int
+svt_check_visibility(struct btr_instance *tins, struct btr_record *rec,
+		     uint32_t intent)
+{
+	return vos_dtx_check_visibility(&tins->ti_umm, tins->ti_coh,
+					rec->rec_mmid, intent, DTX_RT_SVT);
+}
+
 static btr_ops_t singv_btr_ops = {
 	.to_hkey_size		= svt_hkey_size,
 	.to_hkey_gen		= svt_hkey_gen,
@@ -791,6 +808,7 @@ static btr_ops_t singv_btr_ops = {
 	.to_rec_free		= svt_rec_free,
 	.to_rec_fetch		= svt_rec_fetch,
 	.to_rec_update		= svt_rec_update,
+	.to_check_visibility	= svt_check_visibility,
 };
 
 /**


### PR DESCRIPTION
The data record visibility is related with both the operation intent
and the state of the last DTX that modified the data record.

When access some data record, we need to check its visibility firstly.
For modification (update/punch) RPC, it will be sent to leader replica
that knows related DTX's state (via checking the DTX tables and/or the
CoS cache). For read only (fetch, enumerate, and so on) RPC, it may be
sent to non-leader replica. If related DTX on non-leader is committed,
then related data record is visible to outside. But if related DTX is
in 'prepared' state, then the non-leader cannot know whether such DTX
is committable or not, then cannot make the decision about the target
data record visibility. Under such case, it will tell the RPC sponsor
to retry the RPC with leader replica via returning "-DER_INPROGRESS".

For the aborted DTX, because the DTX does not has the knowledge about
the tree in which the target data record is stored, then we will keep
related data record in the tree when abort the DTX. To prevent others
accessing (read) such data record, it will be marked as invisible via
referencing aborted DTX or dummy DTX (DTX_UMMID_ABORTED). The garbage
records will be clean up when next system aggregation or be reused by
subsequent modification if it find some former aborted data record.

Signed-off-by: Fan Yong <fan.yong@intel.com>
Change-Id: I85a704209d5d51030df05cc71fe70aa7d5d0ef0d