### PR TITLE
DAOS-1534 daos_test: Update IO3&4 to test non-aligned I/O

### DIFF
--- a/src/tests/suite/daos_obj.c
+++ b/src/tests/suite/daos_obj.c
@@ -867,7 +867,10 @@ io_var_dkey_size(void **state)
 	ioreq_fini(&req);
 }
 
-/** i/o to variable aligned record size */
+/**
+ * Test I/O and data verification with variable unaligned record sizes for both
+ * NVMe and SCM.
+ */
 static void
 io_var_rec_size(void **state)
 {
@@ -896,6 +899,11 @@ io_var_rec_size(void **state)
 	for (size = 1; size <= max_size; size <<= 1, dkey_num++) {
 		char dkey[30];
 
+		/**
+		 * Adjust size to be unaligned, always include 1 byte test
+		 * (minimal supported size).
+		 */
+		size += (size == 1) ? 0 : (rand() % 10);
 		print_message("Record size: %lu val: \'%c\' dkey: %lu\n",
 			      size, update_buf[0], dkey_num);
 


### PR DESCRIPTION
Update test complexity of io_var_rec_size() to test non-aligned record sizes
with ~50K increments. IO3 and IO4 tests both use io_var_rec_size(), IO4 is
async iteration of test.

Change-Id: I4cc25b7b4387fec11c36673946de9b487fd021ab
Signed-off-by: Sydney Vanda <sydney.m.vanda@intel.com>