### PR TITLE
DAOS-655 daos_server: Create security dRPC Module for daos_server

### DIFF
--- a/src/common/debug.c
+++ b/src/common/debug.c
@@ -58,6 +58,7 @@ DECLARE_FAC(bio);
 DECLARE_FAC(tests);
 DECLARE_FAC(dfs);
 DECLARE_FAC(drpc);
+DECLARE_FAC(security);
 
 uint64_t DB_MD; /* metadata operation */
 uint64_t DB_PL; /* placement */
@@ -65,8 +66,9 @@ uint64_t DB_MGMT; /* pool management */
 uint64_t DB_EPC; /* epoch system */
 uint64_t DB_DF; /* durable format */
 uint64_t DB_REBUILD; /* rebuild process */
+uint64_t DB_SEC; /* Security checks */
 /* debug bit groups */
-#define DB_GRP1 (DB_IO | DB_MD | DB_PL | DB_REBUILD)
+#define DB_GRP1 (DB_IO | DB_MD | DB_PL | DB_REBUILD | DB_SEC)
 
 #define DBG_DICT_ENTRY(bit, name, lname)			\
 {								\
@@ -85,6 +87,7 @@ static struct d_debug_bit daos_bit_dict[] = {
 	DBG_DICT_ENTRY(&DB_EPC,		"epc",		"epoch"),
 	DBG_DICT_ENTRY(&DB_DF,		"df",		"durable_format"),
 	DBG_DICT_ENTRY(&DB_REBUILD,	"rebuild",	"rebuild"),
+	DBG_DICT_ENTRY(&DB_SEC,		"sec",		"security")
 };
 
 #define NUM_DBG_BIT_ENTRIES	ARRAY_SIZE(daos_bit_dict)
@@ -110,7 +113,8 @@ static struct d_debug_bit daos_bit_dict[] = {
 	ACTION("tests", d_tests_logfac)			\
 	ACTION("bio", d_bio_logfac)			\
 	ACTION("dfs", d_dfs_logfac)			\
-	ACTION("drpc", d_drpc_logfac)
+	ACTION("drpc", d_drpc_logfac)			\
+	ACTION("security", d_security_logfac)
 
 #define DAOS_SETUP_FAC(name, idp)			\
 	DAOS_INIT_LOG_FAC(name, &idp)

--- a/src/control/security/auth_sys.go
+++ b/src/control/security/auth_sys.go
@@ -1,5 +1,5 @@
 //
-// (C) Copyright 2018 Intel Corporation.
+// (C) Copyright 2018-2019 Intel Corporation.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -36,7 +36,8 @@ import (
 	"github.com/golang/protobuf/proto"
 )
 
-func hashFromToken(token *pb.AuthToken) ([]byte, error) {
+// HashFromToken will return a SHA512 hash of the token data
+func HashFromToken(token *pb.AuthToken) ([]byte, error) {
 	// Generate our hash (not signed yet just a hash)
 	hash := sha512.New()
 
@@ -99,7 +100,7 @@ func AuthSysRequestFromCreds(creds *DomainInfo) (*pb.SecurityCredential, error) 
 		Flavor: pb.AuthFlavor_AUTH_SYS,
 		Data:   tokenBytes}
 
-	verifier, err := hashFromToken(&token)
+	verifier, err := HashFromToken(&token)
 	if err != nil {
 		fmt.Errorf("Unable to generate verifier (%s)", err.Error())
 		return nil, err

--- a/src/control/server/drpc.go
+++ b/src/control/server/drpc.go
@@ -1,5 +1,5 @@
 //
-// (C) Copyright 2018 Intel Corporation.
+// (C) Copyright 2018-2019 Intel Corporation.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -51,6 +51,10 @@ func drpcSetup(sockDir string) {
 	if err != nil {
 		log.Fatalf("Unable to create socket server: %v", err)
 	}
+
+	// Create and add our modules
+	secmodule := &SecurityModule{}
+	drpcServer.RegisterRPCModule(secmodule)
 
 	err = drpcServer.Start()
 	if err != nil {

--- a/src/include/daos/debug.h
+++ b/src/include/daos/debug.h
@@ -48,6 +48,7 @@ extern int d_bio_logfac;
 extern int d_tests_logfac;
 extern int d_dfs_logfac;
 extern int d_drpc_logfac;
+extern int d_security_logfac;
 
 #include <gurt/debug.h>
 
@@ -57,6 +58,7 @@ extern uint64_t DB_MGMT; /* pool management */
 extern uint64_t DB_EPC; /* epoch system */
 extern uint64_t DB_DF; /* durable format */
 extern uint64_t DB_REBUILD; /* rebuild process */
+extern uint64_t DB_SEC; /* Security checks */
 
 #define DB_DEFAULT	DLOG_DBG
 #define DB_NULL		0

--- a/src/include/daos/rpc.h
+++ b/src/include/daos/rpc.h
@@ -64,6 +64,7 @@ enum daos_module_id {
 	DAOS_RSVC_MODULE	= 6, /** replicated service server */
 	DAOS_RDB_MODULE		= 7, /** rdb */
 	DAOS_RDBT_MODULE	= 8, /** rdb test */
+	DAOS_SEC_MODULE		= 9, /** security framework */
 	DAOS_MAX_MODULE		= (1 << MOD_ID_BITS) - 1,
 };
 

--- a/src/iosrv/init.c
+++ b/src/iosrv/init.c
@@ -40,7 +40,7 @@
 #include <daos.h> /* for daos_init() */
 
 #define MAX_MODULE_OPTIONS	64
-#define MODULE_LIST		"vos,rdb,rsvc,mgmt,pool,cont,obj,rebuild"
+#define MODULE_LIST		"vos,rdb,rsvc,security,mgmt,pool,cont,obj,rebuild"
 
 /** List of modules to load */
 static char		modules[MAX_MODULE_OPTIONS + 1];

--- a/src/security/SConscript
+++ b/src/security/SConscript
@@ -1,4 +1,5 @@
 """Build security library"""
+import daos_build
 
 def scons():
     """Execute build"""
@@ -11,6 +12,9 @@ def scons():
 
     # Shared src between server and client
     common_src = denv.SharedObject(['security.pb-c.c'])
+
+    ds_sec = daos_build.library(denv, 'security', ['srv.c'])
+    denv.Install('$PREFIX/lib/daos_srv', ds_sec)
 
     # dc_security: Security Client
     dc_security_tgts = denv.SharedObject(['cli_security.c']) + common_src

--- a/src/security/srv.c
+++ b/src/security/srv.c
@@ -1,0 +1,60 @@
+/*
+ * (C) Copyright 2019 Intel Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * GOVERNMENT LICENSE RIGHTS-OPEN SOURCE SOFTWARE
+ * The Government's rights to use, modify, reproduce, release, perform, display,
+ * or disclose this software are subject to the terms of the Apache License as
+ * provided in Contract No. 8F-30005.
+ * Any reproduction of computer software, computer software documentation, or
+ * portions thereof marked with this legend must also reproduce the markings.
+ */
+
+/**
+ * ds_sec: Security Framework Server
+ *
+ * This is part of daos_server. It exports the security RPC handlers and
+ * implements Security Framework Server API.
+ */
+#define D_LOGFAC	DD_FAC(security)
+
+#include <daos/rpc.h>
+#include <daos_srv/daos_server.h>
+#include "srv_internal.h"
+
+static int
+init(void)
+{
+	return 0;
+}
+
+static int
+fini(void)
+{
+	return 0;
+}
+
+struct dss_module security_module =  {
+	.sm_name	= "security",
+	.sm_mod_id	= DAOS_SEC_MODULE,
+	.sm_ver		= DAOS_SEC_VERSION,
+	.sm_init	= init,
+	.sm_fini	= fini,
+	.sm_setup	= NULL,
+	.sm_cleanup	= NULL,
+	.sm_proto_fmt	= NULL,
+	.sm_cli_count	= 0,
+	.sm_handlers	= NULL,
+	.sm_key		= NULL,
+};

--- a/src/security/srv_internal.h
+++ b/src/security/srv_internal.h
@@ -1,0 +1,35 @@
+/*
+ * (C) Copyright 2019 Intel Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * GOVERNMENT LICENSE RIGHTS-OPEN SOURCE SOFTWARE
+ * The Government's rights to use, modify, reproduce, release, perform, display,
+ * or disclose this software are subject to the terms of the Apache License as
+ * provided in Contract No. 8F-30005.
+ * Any reproduction of computer software, computer software documentation, or
+ * portions thereof marked with this legend must also reproduce the markings.
+ */
+
+/**
+ * ds_sec: Security Framework Server Internal Declarations
+ */
+
+#ifndef __SECURITY_SRV_INTERNAL_H__
+#define __SECURITY_SRV_INTERNAL_H__
+
+#include <daos_srv/daos_server.h>
+
+#define DAOS_SEC_VERSION 1
+
+#endif /* __SECURITY_SRV_INTERNAL_H__ */

--- a/utils/certs/agent.cnf
+++ b/utils/certs/agent.cnf
@@ -1,0 +1,15 @@
+[ req ]
+prompt=no
+distinguished_name = distinguished_name
+basicConstraints = CA:FALSE
+#uncomment if you want to use per agent certificates
+#req_extensions = extensions
+
+[ distinguished_name ]
+organizationName = DAOS
+# Required value for commonName, do not change.
+commonName = agent
+
+[ extensions ]
+#uncomment if you want to use per agent certificates
+#subjectAltName = DNS:<node-hostname>,DNS:<node-domain>,IP:<IP Address>

--- a/utils/certs/ca.cnf
+++ b/utils/certs/ca.cnf
@@ -1,0 +1,46 @@
+ [ ca ]
+default_ca		= CA_daos
+
+[ CA_daos ]
+dir			= ./daosCA
+certs			= $dir/certs
+database		= $dir/index.txt
+serial			= $dir/serial.txt
+
+# Key and Certificate for the root
+certificate		= $dir/daosCA.crt
+private_key		= $dir/private/daosCA.key
+
+default_md		= sha512	# SAFE Crypto Requires SHA-512
+default_days		= 365		# how long to certify for
+copy_extensions		= copy
+unique_subject		= no
+
+[ req ]
+prompt = no
+distinguished_name = ca_dn
+x509_extensions = ca_ext
+
+[ ca_dn ]
+organizationName 	= DAOS
+commonName		= DAOS CA
+
+[ ca_ext ]
+keyUsage = critical,digitalSignature,nonRepudiation,keyEncipherment,keyCertSign
+basicConstraints = critical,CA:true,pathlen:1
+
+[ signing_policy ]
+organizationName	= supplied
+commonName		= supplied
+
+[ signing_agent ]
+keyUsage = critical,digitalSignature,keyEncipherment
+extendedKeyUsage = clientAuth
+
+[ signing_server ]
+keyUsage = critical,digitalSignature,keyEncipherment
+extendedKeyUsage = serverAuth
+
+[ signing_shell ]
+keyUsage = critical,digitalSignature,keyEncipherment
+extendedKeyUsage = clientAuth

--- a/utils/certs/gen_certificates.sh
+++ b/utils/certs/gen_certificates.sh
@@ -1,0 +1,146 @@
+#!/bin/bash
+# Copyright (C) 201999999999orporation
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted for any purpose (including commercial purposes)
+# provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice,
+#    this list of conditions, and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+#    this list of conditions, and the following disclaimer in the
+#    documentation and/or materials provided with the distribution.
+#
+# 3. In addition, redistributions of modified forms of the source or binary
+#    code must carry prominent notices stating that the original code was
+#    changed and the date of the change.
+#
+#  4. All publications or advertising materials mentioning features or use of
+#     this software are asked, but not required, to acknowledge that it was
+#     developed by Intel Corporation and credit the contributors.
+#
+# 5. Neither the name of Intel Corporation, nor the name of any Contributor
+#    may be used to endorse or promote products derived from this software
+#    without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER BE LIABLE FOR ANY
+# DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+# (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+# ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+# THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+
+__usage="
+Usage: gen_certificates.sh [OPTIONS]
+Generate certificates for DAOS deployment in the ./daosCA.
+Certificates will be named in the format daos_Component
+"
+
+function print_usage () {
+	>&2 echo "$__usage"
+}
+
+PRIVATE="./daosCA/private"
+CERTS="./daosCA/certs"
+
+function setup_directories () {
+	mkdir -p ./daosCA/{certs,private}
+}
+
+function generate_ca_cert () {
+	# Generate Private key and set permissions
+	openssl genrsa -out $PRIVATE/daosCA.key 4096
+	chmod 400 $PRIVATE/daosCA.key
+	# Generate CA Certificate
+	openssl req -new -x509 -config ca.cnf -key $PRIVATE/daosCA.key \
+		-out $CERTS/daosCA.crt -batch
+	# Reset the the CA index
+	rm -f ./daosCA/index.txt ./daosCA/serial.txt
+	touch ./daosCA/index.txt
+	echo '01' > ./daosCA/serial.txt
+}
+
+function generate_agent_cert () {
+	echo "Generating Agent Certificate"
+	# Generate Private key and set its permissions
+	openssl genrsa -out $CERTS/agent.key 4096
+	chmod 400 $CERTS/agent.key
+	# Generate a Certificate Signing Request (CRS)
+	openssl req -new -config agent.cnf -key $CERTS/agent.key \
+		-out agent.csr -batch
+	# Create Certificate from request
+	openssl ca -config ca.cnf -keyfile $PRIVATE/daosCA.key \
+		-cert $CERTS/daosCA.crt -policy signing_policy \
+		-extensions signing_agent -out $CERTS/agent.crt \
+		-outdir $CERTS -in agent.csr -batch
+
+	echo "Required Agent Certificate Files:
+	$CERTS/daosCA.crt
+	$CERTS/agent.key
+	$CERTS/agent.crt"
+}
+
+function generate_shell_cert () {
+	echo "Generating Shell Certificate"
+	# Generate Private key and set its permissions
+	openssl genrsa -out $CERTS/shell.key 4096
+	chmod 400 $CERTS/shell.key
+	# Generate a Certificate Signing Request (CRS)
+	openssl req -new -config shell.cnf -key $CERTS/shell.key \
+		-out shell.csr -batch
+	# Create Certificate from request
+	openssl ca -config ca.cnf -keyfile $PRIVATE/daosCA.key \
+		-cert $CERTS/daosCA.crt -policy signing_policy \
+		-extensions signing_shell -out $CERTS/shell.crt \
+		-outdir $CERTS -in shell.csr -batch
+
+	echo "Required Shell Certificate Files:
+	$CERTS/daosCA.crt
+	$CERTS/shell.key
+	$CERTS/shell.crt"
+}
+
+function generate_server_cert () {
+	echo "Generating Server Certificate"
+	# Generate Private key and set its permissions
+	openssl genrsa -out $CERTS/server.key 4096
+	chmod 400 $CERTS/server.key
+	# Generate a Certificate Signing Request (CRS)
+	openssl req -new -config server.cnf -key $CERTS/server.key \
+		-out server.csr -batch
+	# Create Certificate from request
+	openssl ca -config ca.cnf -keyfile $PRIVATE/daosCA.key \
+		-cert $CERTS/daosCA.crt -policy signing_policy \
+		-extensions signing_server -out $CERTS/server.crt \
+		-outdir $CERTS -in server.csr -batch
+
+	echo "Required Shell Certificate Files:
+	$CERTS/daosCA.crt
+	$CERTS/server.key
+	$CERTS/server.crt"
+}
+
+function cleanup () {
+	rm -f $CERTS/*pem
+	rm -f agent.csr
+	rm -f shell.csr
+	rm -f server.csr
+}
+
+function main () {
+	setup_directories
+	generate_ca_cert
+	generate_agent_cert
+	generate_shell_cert
+	generate_server_cert
+	cleanup
+}
+
+main

--- a/utils/certs/server.cnf
+++ b/utils/certs/server.cnf
@@ -1,0 +1,15 @@
+[ req ]
+prompt=no
+distinguished_name = distinguished_name
+basicConstraints = CA:FALSE
+#uncomment if you want to use per agent certificates
+#req_extensions = extensions
+
+[ distinguished_name ]
+organizationName = DAOS
+# Required value for commonName, do not change.
+commonName = server
+
+[ extensions ]
+#uncomment if you want to use per agent certificates
+#subjectAltName = DNS:<node-hostname>,DNS:<node-domain>,IP:<IP Address>

--- a/utils/certs/shell.cnf
+++ b/utils/certs/shell.cnf
@@ -1,0 +1,12 @@
+# OpenSSL client configuration file
+[ req ]
+prompt=no
+distinguished_name = distinguished_name
+basicConstraints = CA:FALSE
+
+[ distinguished_name ]
+organizationName = DAOS
+commonName = shell
+
+#In the future we can do username based certs for login
+#commonName = <username>


### PR DESCRIPTION
This patch provides the go drpc security module for daos_server to
handle incoming drpc messages for the security framework.

Change-Id: I1b0b4ebb3b21a74eb92fa35a45704fd934a95787
Signed-off-by: David Quigley <david.quigley@intel.com>