### PR TITLE
DAOS-654 pool: Modify pool connect to use security credential

### DIFF
--- a/src/client/api/SConscript
+++ b/src/client/api/SConscript
@@ -11,9 +11,9 @@ def scons():
     dc_tgts = denv.SharedObject(Glob('*.c'))
 
     Import('dc_pool_tgts', 'dc_co_tgts', 'dc_obj_tgts', 'dc_placement_tgts')
-    Import('dc_mgmt_tgts', 'addons_tgts')
+    Import('dc_mgmt_tgts', 'addons_tgts', 'dc_security_tgts')
     dc_tgts += dc_pool_tgts + dc_co_tgts + dc_placement_tgts + dc_obj_tgts
-    dc_tgts += dc_mgmt_tgts + addons_tgts
+    dc_tgts += dc_mgmt_tgts + addons_tgts + dc_security_tgts
     libdaos = daos_build.library(env, 'libdaos', dc_tgts,
                                  SHLIBVERSION=DAOS_VERSION,
                                  LIBS=['daos_common'])

--- a/src/control/security/auth_sys.go
+++ b/src/control/security/auth_sys.go
@@ -1,5 +1,5 @@
 //
-// (C) Copyright 2018 Intel Corporation.
+// (C) Copyright 2018-2019 Intel Corporation.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -36,7 +36,8 @@ import (
 	"github.com/golang/protobuf/proto"
 )
 
-func hashFromToken(token *pb.AuthToken) ([]byte, error) {
+// HashFromToken will return a SHA512 hash of the token data
+func HashFromToken(token *pb.AuthToken) ([]byte, error) {
 	// Generate our hash (not signed yet just a hash)
 	hash := sha512.New()
 
@@ -99,7 +100,7 @@ func AuthSysRequestFromCreds(creds *DomainInfo) (*pb.SecurityCredential, error) 
 		Flavor: pb.AuthFlavor_AUTH_SYS,
 		Data:   tokenBytes}
 
-	verifier, err := hashFromToken(&token)
+	verifier, err := HashFromToken(&token)
 	if err != nil {
 		fmt.Errorf("Unable to generate verifier (%s)", err.Error())
 		return nil, err

--- a/src/control/server/drpc.go
+++ b/src/control/server/drpc.go
@@ -1,5 +1,5 @@
 //
-// (C) Copyright 2018 Intel Corporation.
+// (C) Copyright 2018-2019 Intel Corporation.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -51,6 +51,10 @@ func drpcSetup(sockDir string) {
 	if err != nil {
 		log.Fatalf("Unable to create socket server: %v", err)
 	}
+
+	// Create and add our modules
+	secmodule := &SecurityModule{}
+	drpcServer.RegisterRPCModule(secmodule)
 
 	err = drpcServer.Start()
 	if err != nil {

--- a/src/include/daos_srv/pool.h
+++ b/src/include/daos_srv/pool.h
@@ -93,6 +93,20 @@ struct ds_pool_child {
 	int		spc_ref;
 };
 
+/*
+ * Pool attributes
+ *
+ * Stores per-pool access control information
+ *
+ * This is only being exposed until the access control attributes are
+ * proper encapsulated in the security module.
+ */
+struct pool_attr {
+	uint32_t	pa_uid;
+	uint32_t	pa_gid;
+	uint32_t	pa_mode;
+};
+
 struct ds_pool_child *ds_pool_child_lookup(const uuid_t uuid);
 void ds_pool_child_put(struct ds_pool_child *child);
 

--- a/src/include/daos_srv/security.h
+++ b/src/include/daos_srv/security.h
@@ -25,37 +25,28 @@
  * ds_sec: Security Framework Server Internal Declarations
  */
 
-#ifndef __SECURITY_SRV_INTERNAL_H__
-#define __SECURITY_SRV_INTERNAL_H__
+#ifndef __DAOS_SRV_SECURITY_H__
+#define __DAOS_SRV_SECURITY_H__
 
 #include <daos_types.h>
-#include "security.pb-c.h"
 #include <daos_srv/daos_server.h>
-
-#define DAOS_SEC_VERSION 1
-
-extern char *ds_sec_server_socket_path;
+#include <daos_srv/pool.h>
 
 /**
- * Definitions for DAOS server dRPC modules and their methods.
- * These numeric designations are used in dRPC communications in the Drpc__Call
- * structure.
- */
-
-/**
- *  Module: Security Server
+ * Determine whether the provided credentials can access a pool.
  *
- *  The server module that deals with client security requests.
- */
-#define DRPC_MODULE_SECURITY_SERVER				1
-
-/**
- * Method: Validate Security Credential
+ * \param[in]	attr		Pool attributes
+ * \param[in]	cred		Opaque Credential Data
+ * \param[in]	access		Requested pool access
  *
- * Requests validation of the security credential.
+ * \return	0		Success. The access is allowed.
+ *		-DER_INVAL	Invalid parameter
+ *		-DER_BADPATH	Can't connect to the agent socket at
+ *				the expected path
+ *		-DER_NOMEM	Out of memory
+ *		-DER_NOREPLY	No response from agent
+ *		-DER_MISC	Invalid response from agent
  */
-#define DRPC_METHOD_SECURITY_SERVER_VALIDATE_CREDENTIALS	101
-
-int ds_sec_validate_credentials(daos_iov_t *creds, AuthToken **token);
-
-#endif /* __SECURITY_SRV_INTERNAL_H__ */
+int ds_sec_can_pool_connect(const struct pool_attr *attr, d_iov_t *cred,
+				uint64_t access);
+#endif /* __DAOS_SRV_SECURITY_H__ */

--- a/src/pool/cli.c
+++ b/src/pool/cli.c
@@ -32,6 +32,7 @@
 #include <daos/event.h>
 #include <daos/placement.h>
 #include <daos/pool.h>
+#include <daos/security.h>
 #include <daos_types.h>
 #include "cli_internal.h"
 #include "rpc.h"
@@ -423,6 +424,7 @@ pool_connect_cp(tse_task_t *task, void *data)
 		DP_UUID(pool->dp_pool_hdl));
 
 out:
+	daos_iov_free(&pci->pci_cred);
 	crt_req_decref(arg->rpc);
 	map_bulk_destroy(pci->pci_map_bulk, map_buf);
 	if (put_pool)
@@ -571,22 +573,27 @@ dc_pool_connect(tse_task_t *task)
 		D_ERROR("failed to create rpc: %d\n", rc);
 		D_GOTO(out_pool, rc);
 	}
-
 	/** for con_argss */
 	crt_req_addref(rpc);
 
 	/** fill in request buffer */
 	pci = crt_req_get(rpc);
+
+	/** request credentials */
+	rc = dc_sec_request_creds(&pci->pci_cred);
+	if (rc != 0) {
+		D_ERROR("failed to obtain security credential: %d\n", rc);
+		D_GOTO(out_req, rc);
+	}
+
 	uuid_copy(pci->pci_op.pi_uuid, args->uuid);
 	uuid_copy(pci->pci_op.pi_hdl, pool->dp_pool_hdl);
-	pci->pci_uid = geteuid();
-	pci->pci_gid = getegid();
 	pci->pci_capas = args->flags;
 
 	rc = map_bulk_create(daos_task2ctx(task), &pci->pci_map_bulk, &map_buf,
 			     pool_buf_nr(pool->dp_map_sz));
 	if (rc != 0)
-		D_GOTO(out_req, rc);
+		D_GOTO(out_cred, rc);
 
 	/** Prepare "con_args" for pool_connect_cp(). */
 	con_args.pca_info = args->info;
@@ -608,6 +615,8 @@ dc_pool_connect(tse_task_t *task)
 
 out_bulk:
 	map_bulk_destroy(pci->pci_map_bulk, map_buf);
+out_cred:
+	daos_iov_free(&pci->pci_cred);
 out_req:
 	crt_req_decref(rpc);
 	crt_req_decref(rpc); /* free req */

--- a/src/pool/rpc.h
+++ b/src/pool/rpc.h
@@ -159,8 +159,7 @@ CRT_RPC_DECLARE(pool_create, DAOS_ISEQ_POOL_CREATE, DAOS_OSEQ_POOL_CREATE)
 
 #define DAOS_ISEQ_POOL_CONNECT	/* input fields */		 \
 	((struct pool_op_in)	(pci_op)		CRT_VAR) \
-	((uint32_t)		(pci_uid)		CRT_VAR) \
-	((uint32_t)		(pci_gid)		CRT_VAR) \
+	((daos_iov_t)		(pci_cred)		CRT_VAR) \
 	((uint64_t)		(pci_capas)		CRT_VAR) \
 	((crt_bulk_t)		(pci_map_bulk)		CRT_VAR)
 

--- a/src/pool/srv_pool.c
+++ b/src/pool/srv_pool.c
@@ -1149,11 +1149,22 @@ bcast_create(crt_context_t ctx, struct pool_svc *svc, crt_opcode_t opcode,
 				    rpc, NULL, NULL);
 }
 
-struct pool_attr {
-	uint32_t	pa_uid;
-	uint32_t	pa_gid;
-	uint32_t	pa_mode;
-};
+/**
+ * Retrieve the latest leader hint from \a db and fill it into \a hint.
+ *
+ * \param[in]	db	database
+ * \param[out]	hint	rsvc hint
+ */
+void
+ds_pool_set_hint(struct rdb *db, struct rsvc_hint *hint)
+{
+	int rc;
+
+	rc = rdb_get_leader(db, &hint->sh_term, &hint->sh_rank);
+	if (rc != 0)
+		return;
+	hint->sh_flags |= RSVC_HINT_VALID;
+}
 
 static int
 pool_attr_read(struct rdb_tx *tx, const struct pool_svc *svc,

--- a/src/security/SConscript
+++ b/src/security/SConscript
@@ -13,12 +13,16 @@ def scons():
     # Shared src between server and client
     common_src = denv.SharedObject(['security.pb-c.c'])
 
-    ds_sec = daos_build.library(denv, 'security', ['srv.c'])
+    ds_sec = daos_build.library(denv, 'security', ['srv.c','srv_acl.c'])
     denv.Install('$PREFIX/lib/daos_srv', ds_sec)
 
     # dc_security: Security Client
     dc_security_tgts = denv.SharedObject(['cli_security.c']) + common_src
     Export('dc_security_tgts')
+
+    dc_sectest_tgts = denv.SharedObject(['cli_security.c',
+    						'srv_acl.c']) + common_src
+    Export('dc_sectest_tgts')
 
     SConscript('tests/SConscript', exports='denv')
 

--- a/src/security/srv.c
+++ b/src/security/srv.c
@@ -33,15 +33,27 @@
 #include <daos_srv/daos_server.h>
 #include "srv_internal.h"
 
+/** Fully qualified path to daos_server socket */
+char *ds_sec_server_socket_path;
+
 static int
 init(void)
 {
+	int rc;
+
+	rc = asprintf(&ds_sec_server_socket_path, "%s/%s",
+			dss_socket_dir, "daos_server.sock");
+	if (rc < 0) {
+		return rc;
+	}
 	return 0;
 }
 
 static int
 fini(void)
 {
+	free(ds_sec_server_socket_path);
+	ds_sec_server_socket_path = NULL;
 	return 0;
 }
 

--- a/src/security/srv_acl.c
+++ b/src/security/srv_acl.c
@@ -1,0 +1,214 @@
+/*
+ * (C) Copyright 2019 Intel Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * GOVERNMENT LICENSE RIGHTS-OPEN SOURCE SOFTWARE
+ * The Government's rights to use, modify, reproduce, release, perform, display,
+ * or disclose this software are subject to the terms of the Apache License as
+ * provided in Contract No. 8F-30005.
+ * Any reproduction of computer software, computer software documentation, or
+ * portions thereof marked with this legend must also reproduce the markings.
+ */
+
+#include <unistd.h>
+#include <string.h>
+#include <gurt/common.h>
+#include <daos_errno.h>
+#include <daos/drpc.h>
+#include <daos/drpc.pb-c.h>
+
+#include <daos_srv/pool.h>
+#include <daos_srv/security.h>
+
+#include "srv_internal.h"
+#include "security.pb-c.h"
+
+static int
+sanity_check_validation_response(Drpc__Response *response)
+{
+	int rc = DER_SUCCESS;
+
+	/* Unpack the response body for a basic sanity check */
+	AuthToken *pb_auth = auth_token__unpack(NULL,
+			response->body.len, response->body.data);
+	if (pb_auth == NULL) {
+		/* Malformed body */
+		return -DER_MISC;
+	}
+
+	/* Not super useful if we didn't get token data*/
+	if (!pb_auth->has_data) {
+		rc = -DER_MISC;
+	}
+
+	auth_token__free_unpacked(pb_auth, NULL);
+	return rc;
+}
+
+static Drpc__Call *
+new_validation_request(daos_iov_t *creds)
+{
+	uint8_t		*body;
+	Drpc__Call	*request;
+
+	D_ALLOC_PTR(request);
+
+	if (request == NULL) {
+		return NULL;
+	}
+
+	D_ALLOC(body, creds->iov_len);
+	if (body == NULL) {
+		return NULL;
+	}
+
+	memcpy(body, creds->iov_buf, creds->iov_len);
+	drpc__call__init(request);
+
+	request->module = DRPC_MODULE_SECURITY_SERVER;
+	request->method =
+		DRPC_METHOD_SECURITY_SERVER_VALIDATE_CREDENTIALS;
+	request->body.len = creds->iov_len;
+	request->body.data = body;
+
+	return request;
+}
+
+static int
+send_drpc_message(Drpc__Call *message, Drpc__Response **response)
+{
+	struct drpc	*server_socket;
+	int		rc;
+
+	server_socket = drpc_connect(ds_sec_server_socket_path);
+	if (server_socket == NULL) {
+		/* can't connect to agent socket */
+		return -DER_BADPATH;
+	}
+
+	rc = drpc_call(server_socket, R_SYNC, message, response);
+	drpc_close(server_socket);
+
+	return rc;
+}
+
+static int
+validate_credentials_via_drpc(Drpc__Response **response, daos_iov_t *creds)
+{
+	Drpc__Call	*request;
+	int		rc;
+
+	request = new_validation_request(creds);
+
+	if (request == NULL) {
+		return -DER_NOMEM;
+	}
+
+	rc = send_drpc_message(request, response);
+
+	drpc__call__free_unpacked(request, NULL);
+	return rc;
+}
+
+static int
+process_validation_response(Drpc__Response *response,
+		AuthToken **token)
+{
+	int		rc = DER_SUCCESS;
+	AuthToken	*auth;
+
+	if (response == NULL) {
+		return -DER_NOREPLY;
+	}
+
+	if (response->status != DRPC__STATUS__SUCCESS) {
+		/* Recipient could not parse our message */
+		return -DER_MISC;
+	}
+
+	rc = sanity_check_validation_response(response);
+	if (rc != DER_SUCCESS) {
+		return rc;
+	}
+
+	auth = auth_token__unpack(NULL, response->body.len,
+					response->body.data);
+	if (auth == NULL) {
+		return -DER_MISC;
+	}
+	*token = auth;
+
+	return rc;
+}
+
+int
+ds_sec_validate_credentials(daos_iov_t *creds, AuthToken **token)
+{
+	Drpc__Response	*response = NULL;
+	int		rc;
+
+	if (creds == NULL) {
+		return -DER_INVAL;
+	}
+
+	rc = validate_credentials_via_drpc(&response, creds);
+	if (rc != DER_SUCCESS) {
+		return rc;
+	}
+
+	rc = process_validation_response(response, token);
+
+	drpc__response__free_unpacked(response, NULL);
+	return rc;
+}
+
+int
+ds_sec_can_pool_connect(const struct pool_attr *attr, d_iov_t *cred,
+				uint64_t access)
+{
+	int		rc;
+	int		shift;
+	uint32_t	access_permitted;
+	AuthToken	*sec_token = NULL;
+	AuthSys		*sys_creds = NULL;
+
+	if (attr == NULL || cred == NULL) {
+		return -DER_INVAL;
+	}
+
+	rc = ds_sec_validate_credentials(cred, &sec_token);
+	if (rc != DER_SUCCESS) {
+		return rc;
+	}
+
+	sys_creds = auth_sys__unpack(NULL, sec_token->data.len,
+					sec_token->data.data);
+
+	/*
+	 * Determine which set of capability bits applies. See also the
+	 * comment/diagram for ds_pool_attr_mode in src/pool/srv_layout.h.
+	 */
+	if (sys_creds->uid == attr->pa_uid)
+		shift = DAOS_PC_NBITS * 2;	/* user */
+	else if (sys_creds->gid == attr->pa_gid)
+		shift = DAOS_PC_NBITS;		/* group */
+	else
+		shift = 0;			/* other */
+
+	/* Extract the applicable set of capability bits. */
+	access_permitted = (attr->pa_mode >> shift) & DAOS_PC_MASK;
+
+	/* Only if all requested capability bits are permitted... */
+	return (access & access_permitted) == access;
+}

--- a/src/tests/security/SConscript
+++ b/src/tests/security/SConscript
@@ -2,10 +2,10 @@
 
 def scons():
     """Execute build"""
-    Import('env', 'prereqs', 'dc_security_tgts')
+    Import('env', 'prereqs', 'dc_security_tgts', 'dc_sectest_tgts')
 
     libs = ['gurt', 'daos_common', 'protobuf-c']
-    sources = ['security_test.c', dc_security_tgts]
+    sources = ['security_test.c', dc_sectest_tgts]
 
 
     denv = env.Clone()

--- a/src/tests/security/security_test.c
+++ b/src/tests/security/security_test.c
@@ -23,12 +23,112 @@
 #include <stdio.h>
 #include <unistd.h>
 #include <stdlib.h>
+#include <string.h>
 #include <daos/security.h>
 #include <daos_types.h>
 #include <daos_errno.h>
 #include <daos/common.h>
+#include "../../security/srv_internal.h"
 #include "../../security/security.pb-c.h"
 
+/**
+ * This is a bit of a hack to deal with the fact that the security module
+ * initializes this variable normally and without the module code we need
+ * to set it ourselves
+ */
+char *ds_sec_server_socket_path = "/var/run/daos_server/daos_server.sock";
+
+static int
+check_valid_pointers(void *p1, void *p2)
+{
+	if (p1 == NULL && p2 != NULL) {
+		return -1;
+	}
+	if (p1 != NULL && p2 == NULL) {
+		return -1;
+	}
+	return 0;
+}
+
+int
+compare_auth_sys(AuthSys *auth1, AuthSys *auth2)
+{
+	if (!auth1 || !auth2) {
+		printf("compare_auth_sys needs two valid pointers\n");
+		return -1;
+	}
+
+	if (auth1->has_uid != auth2->has_uid) {
+		printf("An AuthSys is missing a uid\n");
+		return -1;
+	}
+	if (auth1->has_uid && (auth1->uid != auth2->uid)) {
+		printf("Tokens do not have a matching uid\n");
+		return -1;
+	}
+
+	if (auth1->has_gid != auth2->has_gid) {
+		printf("An AuthSys is missing a gid\n");
+		return -1;
+	}
+	if (auth1->has_gid && (auth1->gid != auth2->gid)) {
+		printf("Tokens do not have a matching gid\n");
+		return -1;
+	}
+
+	/* Check to make sure that both or neither are set */
+	if (check_valid_pointers(auth1->gids, auth2->gids)) {
+		printf("An AuthSys is missing a gids list\n");
+		return  -1;
+	}
+
+	if (auth1->n_gids != auth2->n_gids) {
+		printf("Gids lists are not of equal length\n");
+		return -1;
+	}
+
+	for (int i = 0; i < auth1->n_gids; i++) {
+		if (auth1->gids[i] != auth2->gids[i]) {
+			printf("Gid lists do not match\n");
+			return -1;
+		}
+	}
+
+	if (check_valid_pointers(auth1->secctx, auth2->secctx)) {
+		printf("An AuthSys is missing a secctx\n");
+		return -1;
+	}
+
+	if (auth1->secctx) {
+		if (strcmp(auth1->secctx, auth2->secctx)) {
+			printf("Secctx entries do not match\n");
+			return -1;
+		}
+	}
+
+	if (check_valid_pointers(auth1->machinename, auth2->machinename)) {
+		printf("An AuthSys is missing a machinename\n");
+		return -1;
+	}
+
+	if (auth1->machinename) {
+		if (strcmp(auth1->machinename, auth2->machinename)) {
+			printf("machinename entries do not match\n");
+			return -1;
+		}
+	}
+
+	if (auth1->has_stamp != auth2->has_stamp) {
+		printf("An AuthSys is missing a stamp\n");
+		return -1;
+	}
+	if (auth1->has_stamp && (auth1->stamp != auth2->stamp)) {
+		printf("Tokens do not have a matching stamps\n");
+		return -1;
+	}
+
+	return 0;
+}
 void
 print_auth_sys(AuthSys *auth)
 {
@@ -83,13 +183,15 @@ main(int argc, char **argv)
 	daos_iov_t		creds;
 	SecurityCredential	*response = NULL;
 	AuthSys			*credentials = NULL;
+	AuthToken		*validated_token = NULL;
+	AuthSys			*validated_credentials = NULL;
 
 	memset(&creds, 0, sizeof(daos_iov_t));
 
 	ret = dc_sec_request_creds(&creds);
 
 	if (ret != DER_SUCCESS) {
-		printf("We failed with ret: %d\n", ret);
+		printf("Failed to obtain credentials with ret: %d\n", ret);
 		exit(ret);
 	}
 
@@ -101,9 +203,35 @@ main(int argc, char **argv)
 					response->token->data.len,
 					response->token->data.data);
 
+	printf("Credentials as obtained from Agent:\n");
 	print_auth_sys(credentials);
 	print_auth_verifier(response->verifier);
 
+	ret = ds_sec_validate_credentials(&creds, &validated_token);
+	if (ret != DER_SUCCESS) {
+		printf("Failed to validate credential with ret: %d\n", ret);
+		exit(1);
+	}
+
+	validated_credentials = auth_sys__unpack(NULL,
+					validated_token->data.len,
+					validated_token->data.data);
+
+	printf("AuthToken as obtained from Server:\n");
+	print_auth_sys(validated_credentials);
+
+	printf("Comparing tokens:\n");
+	if (compare_auth_sys(credentials, validated_credentials) != 0) {
+		printf("The credentials do not match.\n");
+		exit(1);
+	} else {
+		printf("The credentials match.\n");
+	}
+
+	security_credential__free_unpacked(response, NULL);
+	auth_sys__free_unpacked(credentials, NULL);
+	auth_sys__free_unpacked(validated_credentials, NULL);
+	auth_token__free_unpacked(validated_token, NULL);
 	daos_iov_free(&creds);
 
 	return 0;

--- a/utils/certs/agent.cnf
+++ b/utils/certs/agent.cnf
@@ -1,0 +1,15 @@
+[ req ]
+prompt=no
+distinguished_name = distinguished_name
+basicConstraints = CA:FALSE
+#uncomment if you want to use per agent certificates
+#req_extensions = extensions
+
+[ distinguished_name ]
+organizationName = DAOS
+# Required value for commonName, do not change.
+commonName = agent
+
+[ extensions ]
+#uncomment if you want to use per agent certificates
+#subjectAltName = DNS:<node-hostname>,DNS:<node-domain>,IP:<IP Address>

--- a/utils/certs/ca.cnf
+++ b/utils/certs/ca.cnf
@@ -1,0 +1,46 @@
+ [ ca ]
+default_ca		= CA_daos
+
+[ CA_daos ]
+dir			= ./daosCA
+certs			= $dir/certs
+database		= $dir/index.txt
+serial			= $dir/serial.txt
+
+# Key and Certificate for the root
+certificate		= $dir/daosCA.crt
+private_key		= $dir/private/daosCA.key
+
+default_md		= sha512	# SAFE Crypto Requires SHA-512
+default_days		= 365		# how long to certify for
+copy_extensions		= copy
+unique_subject		= no
+
+[ req ]
+prompt = no
+distinguished_name = ca_dn
+x509_extensions = ca_ext
+
+[ ca_dn ]
+organizationName 	= DAOS
+commonName		= DAOS CA
+
+[ ca_ext ]
+keyUsage = critical,digitalSignature,nonRepudiation,keyEncipherment,keyCertSign
+basicConstraints = critical,CA:true,pathlen:1
+
+[ signing_policy ]
+organizationName	= supplied
+commonName		= supplied
+
+[ signing_agent ]
+keyUsage = critical,digitalSignature,keyEncipherment
+extendedKeyUsage = clientAuth
+
+[ signing_server ]
+keyUsage = critical,digitalSignature,keyEncipherment
+extendedKeyUsage = serverAuth
+
+[ signing_shell ]
+keyUsage = critical,digitalSignature,keyEncipherment
+extendedKeyUsage = clientAuth

--- a/utils/certs/gen_certificates.sh
+++ b/utils/certs/gen_certificates.sh
@@ -1,0 +1,146 @@
+#!/bin/bash
+# Copyright (C) 2019 Intel Corporation.
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted for any purpose (including commercial purposes)
+# provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice,
+#    this list of conditions, and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+#    this list of conditions, and the following disclaimer in the
+#    documentation and/or materials provided with the distribution.
+#
+# 3. In addition, redistributions of modified forms of the source or binary
+#    code must carry prominent notices stating that the original code was
+#    changed and the date of the change.
+#
+#  4. All publications or advertising materials mentioning features or use of
+#     this software are asked, but not required, to acknowledge that it was
+#     developed by Intel Corporation and credit the contributors.
+#
+# 5. Neither the name of Intel Corporation, nor the name of any Contributor
+#    may be used to endorse or promote products derived from this software
+#    without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER BE LIABLE FOR ANY
+# DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+# (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+# ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+# THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+
+__usage="
+Usage: gen_certificates.sh [OPTIONS]
+Generate certificates for DAOS deployment in the ./daosCA.
+Certificates will be named in the format daos_Component
+"
+
+function print_usage () {
+	>&2 echo "$__usage"
+}
+
+PRIVATE="./daosCA/private"
+CERTS="./daosCA/certs"
+
+function setup_directories () {
+	mkdir -p ./daosCA/{certs,private}
+}
+
+function generate_ca_cert () {
+	# Generate Private key and set permissions
+	openssl genrsa -out $PRIVATE/daosCA.key 4096
+	chmod 400 $PRIVATE/daosCA.key
+	# Generate CA Certificate
+	openssl req -new -x509 -config ca.cnf -key $PRIVATE/daosCA.key \
+		-out $CERTS/daosCA.crt -batch
+	# Reset the the CA index
+	rm -f ./daosCA/index.txt ./daosCA/serial.txt
+	touch ./daosCA/index.txt
+	echo '01' > ./daosCA/serial.txt
+}
+
+function generate_agent_cert () {
+	echo "Generating Agent Certificate"
+	# Generate Private key and set its permissions
+	openssl genrsa -out $CERTS/agent.key 4096
+	chmod 400 $CERTS/agent.key
+	# Generate a Certificate Signing Request (CRS)
+	openssl req -new -config agent.cnf -key $CERTS/agent.key \
+		-out agent.csr -batch
+	# Create Certificate from request
+	openssl ca -config ca.cnf -keyfile $PRIVATE/daosCA.key \
+		-cert $CERTS/daosCA.crt -policy signing_policy \
+		-extensions signing_agent -out $CERTS/agent.crt \
+		-outdir $CERTS -in agent.csr -batch
+
+	echo "Required Agent Certificate Files:
+	$CERTS/daosCA.crt
+	$CERTS/agent.key
+	$CERTS/agent.crt"
+}
+
+function generate_shell_cert () {
+	echo "Generating Shell Certificate"
+	# Generate Private key and set its permissions
+	openssl genrsa -out $CERTS/shell.key 4096
+	chmod 400 $CERTS/shell.key
+	# Generate a Certificate Signing Request (CRS)
+	openssl req -new -config shell.cnf -key $CERTS/shell.key \
+		-out shell.csr -batch
+	# Create Certificate from request
+	openssl ca -config ca.cnf -keyfile $PRIVATE/daosCA.key \
+		-cert $CERTS/daosCA.crt -policy signing_policy \
+		-extensions signing_shell -out $CERTS/shell.crt \
+		-outdir $CERTS -in shell.csr -batch
+
+	echo "Required Shell Certificate Files:
+	$CERTS/daosCA.crt
+	$CERTS/shell.key
+	$CERTS/shell.crt"
+}
+
+function generate_server_cert () {
+	echo "Generating Server Certificate"
+	# Generate Private key and set its permissions
+	openssl genrsa -out $CERTS/server.key 4096
+	chmod 400 $CERTS/server.key
+	# Generate a Certificate Signing Request (CRS)
+	openssl req -new -config server.cnf -key $CERTS/server.key \
+		-out server.csr -batch
+	# Create Certificate from request
+	openssl ca -config ca.cnf -keyfile $PRIVATE/daosCA.key \
+		-cert $CERTS/daosCA.crt -policy signing_policy \
+		-extensions signing_server -out $CERTS/server.crt \
+		-outdir $CERTS -in server.csr -batch
+
+	echo "Required Shell Certificate Files:
+	$CERTS/daosCA.crt
+	$CERTS/server.key
+	$CERTS/server.crt"
+}
+
+function cleanup () {
+	rm -f $CERTS/*pem
+	rm -f agent.csr
+	rm -f shell.csr
+	rm -f server.csr
+}
+
+function main () {
+	setup_directories
+	generate_ca_cert
+	generate_agent_cert
+	generate_shell_cert
+	generate_server_cert
+	cleanup
+}
+
+main

--- a/utils/certs/server.cnf
+++ b/utils/certs/server.cnf
@@ -1,0 +1,15 @@
+[ req ]
+prompt=no
+distinguished_name = distinguished_name
+basicConstraints = CA:FALSE
+#uncomment if you want to use per agent certificates
+#req_extensions = extensions
+
+[ distinguished_name ]
+organizationName = DAOS
+# Required value for commonName, do not change.
+commonName = server
+
+[ extensions ]
+#uncomment if you want to use per agent certificates
+#subjectAltName = DNS:<node-hostname>,DNS:<node-domain>,IP:<IP Address>

--- a/utils/certs/shell.cnf
+++ b/utils/certs/shell.cnf
@@ -1,0 +1,12 @@
+# OpenSSL client configuration file
+[ req ]
+prompt=no
+distinguished_name = distinguished_name
+basicConstraints = CA:FALSE
+
+[ distinguished_name ]
+organizationName = DAOS
+commonName = shell
+
+#In the future we can do username based certs for login
+#commonName = <username>


### PR DESCRIPTION
This patch modifies the pool connect RPC to pass the opaque security credential
instead of uid and gid of the calling process. It also modifies the daos client
library call for pool connect to request the opaque credential from the agent
and packs it into the connect RPC. on the server end the pool connect handler
has been modified to pass the credential and the pool attributes which contain
the pool ownership information to a new can_pool_connect api call in the
security module.

Change-Id: I0bd88e93a472dcbed627618a37b3ef9e2398a4bd
Signed-off-by: David Quigley <david.quigley@intel.com>