### PR TITLE
DAOS-1979 rebuild: optimze the rebuild unpack process

### DIFF
--- a/src/iosrv/vos.c
+++ b/src/iosrv/vos.c
@@ -393,6 +393,11 @@ grow_array(void **arrayp, size_t elem_size, int old_len, int new_len)
 	return 0;
 }
 
+enum {
+	UNPACK_COMPLETE_IO = 1,	/* Only finish current I/O */
+	UNPACK_COMPLETE_IOD = 2,	/* Only finish current IOD */
+};
+
 /* Parse recxs in <*data, len> and append them to iod and sgl. */
 static int
 unpack_recxs(daos_iod_t *iod, int *recxs_cap, daos_sg_list_t *sgl,
@@ -433,17 +438,15 @@ unpack_recxs(daos_iod_t *iod, int *recxs_cap, daos_sg_list_t *sgl,
 		} else if (*version != rec->rec_version) {
 			D_DEBUG(DB_REBUILD, "different version %u != %u\n",
 				*version, rec->rec_version);
-			rc = 1;
+			rc = UNPACK_COMPLETE_IO;
 			break;
 		}
 
-		/* Note: there can only be one IOD type per IOD, so
-		 * either it would be single or array, and once it
-		 * is changed, it has to return 1 to finish this IOD.
-		 */
 		if (iod->iod_nr > 0 &&
-		    (iod->iod_type != type || rec->rec_size == 0)) {
-			rc = 1;
+		    (iod->iod_type == DAOS_IOD_SINGLE ||
+		     iod->iod_type != type || rec->rec_size == 0 ||
+		     iod->iod_size == 0)) {
+			rc = UNPACK_COMPLETE_IOD;
 			break;
 		}
 
@@ -495,38 +498,29 @@ unpack_recxs(daos_iod_t *iod, int *recxs_cap, daos_sg_list_t *sgl,
 		len -= sizeof(*rec);
 
 		/* Append the data, if inline. */
-		if (sgl != NULL) {
+		if (sgl != NULL && rec->rec_size > 0) {
 			daos_iov_t *iov = &sgl->sg_iovs[sgl->sg_nr];
 
 			if (rec->rec_flags & RECX_INLINE) {
-				daos_iov_set(iov, *data,
-					     rec->rec_size *
-					     rec->rec_recx.rx_nr);
-				D_DEBUG(DB_TRACE, "set data iov %p len %d\n",
-					iov, (int)iov->iov_len);
+				daos_iov_set(iov, *data, rec->rec_size *
+							 rec->rec_recx.rx_nr);
 			} else {
 				daos_iov_set(iov, NULL, 0);
 			}
+
 			sgl->sg_nr++;
-			D_ASSERTF(sgl->sg_nr == iod->iod_nr, "%u == %u\n",
+			D_ASSERTF(sgl->sg_nr <= iod->iod_nr, "%u == %u\n",
 				  sgl->sg_nr, iod->iod_nr);
 			*data += iov->iov_len;
 			len -= iov->iov_len;
 		}
 
 		D_DEBUG(DB_REBUILD, "unpack %p idx/nr "DF_U64"/"DF_U64 "ver %u"
-			" epr lo/hi "DF_U64"/"DF_U64" size %zd inline %zu\n",
+			" epr lo/hi "DF_U64"/"DF_U64" size %zd\n",
 			*data, iod->iod_recxs[iod->iod_nr - 1].rx_idx,
 			iod->iod_recxs[iod->iod_nr - 1].rx_nr, rec->rec_version,
 			iod->iod_eprs[iod->iod_nr - 1].epr_lo,
-			iod->iod_eprs[iod->iod_nr - 1].epr_hi, iod->iod_size,
-			sgl != NULL ? sgl->sg_iovs[sgl->sg_nr - 1].iov_len : 0);
-
-		/* Only allow one SINGLE record per IOD, let's close this one */
-		if (iod->iod_type == DAOS_IOD_SINGLE || iod->iod_size == 0) {
-			rc = 1;
-			break;
-		}
+			iod->iod_eprs[iod->iod_nr - 1].epr_hi, iod->iod_size);
 	}
 
 	D_DEBUG(DB_REBUILD, "pack nr %d version/type /%u/%d rc %d\n",
@@ -860,10 +854,13 @@ dss_enum_unpack(vos_iter_type_t type, struct dss_enum_arg *arg,
 				if (rc == 0)
 					break;
 
-				/* Otherwise let's complete current io, and go
-				 * next round.
-				 */
+				D_ASSERT(rc == UNPACK_COMPLETE_IOD ||
+					 rc == UNPACK_COMPLETE_IO);
+				/* Close current IOD or even current I/O.*/
 				close_iod(&io);
+				if (rc == UNPACK_COMPLETE_IOD)
+					continue;
+
 				rc = complete_io(&io, cb, cb_arg);
 				if (rc < 0)
 					goto out;

--- a/src/object/srv_obj.c
+++ b/src/object/srv_obj.c
@@ -499,10 +499,12 @@ ds_obj_rw_echo_handler(crt_rpc_t *rpc)
 	int			i;
 	int			rc = 0;
 
-	D_DEBUG(DB_TRACE, "opc %d "DF_UOID" dkey %d %s tag %d eph "DF_U64".\n",
-		opc_get(rpc->cr_opc), DP_UOID(orw->orw_oid),
+	D_DEBUG(DB_TRACE, "opc %d "DF_UOID" dkey %d %s tgt/xs %d/%d eph "
+		DF_U64".\n", opc_get(rpc->cr_opc), DP_UOID(orw->orw_oid),
 		(int)orw->orw_dkey.iov_len, (char *)orw->orw_dkey.iov_buf,
-		dss_get_module_info()->dmi_tgt_id, orw->orw_epoch);
+		dss_get_module_info()->dmi_tgt_id,
+		dss_get_module_info()->dmi_xs_id,
+		orw->orw_epoch);
 
 	if (opc_get(rpc->cr_opc) == DAOS_OBJ_RPC_FETCH) {
 		rc = ds_obj_update_sizes_in_reply(rpc);
@@ -731,10 +733,10 @@ ds_obj_rw_handler(crt_rpc_t *rpc)
 	dispatch = update && orw->orw_shard_tgts.ca_arrays != NULL;
 	tag = dss_get_module_info()->dmi_tgt_id;
 
-	D_DEBUG(DB_TRACE, "rpc %p opc %d "DF_UOID" dkey %d %s tag %d eph "
+	D_DEBUG(DB_TRACE, "rpc %p opc %d "DF_UOID" dkey %d %s tag/xs %d/%d eph "
 		DF_U64".\n", rpc, opc_get(rpc->cr_opc), DP_UOID(orw->orw_oid),
 		(int)orw->orw_dkey.iov_len, (char *)orw->orw_dkey.iov_buf,
-		tag, orw->orw_epoch);
+		tag, dss_get_module_info()->dmi_xs_id, orw->orw_epoch);
 	rc = ds_check_container(orw->orw_co_hdl, orw->orw_co_uuid,
 				&cont_hdl, &cont);
 	if (rc)


### PR DESCRIPTION
Optimize rebuild unpack process, so single/array/punch
record can be packed in one VOS call.

Change-Id: I931ccc530683e11edc91aca32c05d34eb57c393c
Signed-off-by: Wang Di <di.wang@intel.com>