### PR TITLE
DAOS-1918 rebuild: add target rebuild test

### DIFF
--- a/src/client/api/mgmt.c
+++ b/src/client/api/mgmt.c
@@ -170,7 +170,7 @@ daos_pool_evict(const uuid_t uuid, const char *grp, const d_rank_list_t *svc,
 
 int
 daos_pool_add_tgt(const uuid_t uuid, const char *grp,
-		  const d_rank_list_t *svc, d_rank_list_t *tgts,
+		  const d_rank_list_t *svc, struct d_tgt_list *tgts,
 		  daos_event_t *ev)
 {
 	daos_pool_update_t	*args;
@@ -191,9 +191,9 @@ daos_pool_add_tgt(const uuid_t uuid, const char *grp,
 }
 
 int
-daos_pool_exclude_out(const uuid_t uuid, const char *grp,
-		      const d_rank_list_t *svc, d_rank_list_t *tgts,
-		      daos_event_t *ev)
+daos_pool_tgt_exclude_out(const uuid_t uuid, const char *grp,
+			  const d_rank_list_t *svc, struct d_tgt_list *tgts,
+			  daos_event_t *ev)
 {
 	daos_pool_update_t	*args;
 	tse_task_t		*task;
@@ -213,9 +213,9 @@ daos_pool_exclude_out(const uuid_t uuid, const char *grp,
 }
 
 int
-daos_pool_exclude(const uuid_t uuid, const char *grp,
-		  const d_rank_list_t *svc, d_rank_list_t *tgts,
-		  daos_event_t *ev)
+daos_pool_tgt_exclude(const uuid_t uuid, const char *grp,
+		      const d_rank_list_t *svc, struct d_tgt_list *tgts,
+		      daos_event_t *ev)
 {
 	daos_pool_update_t	*args;
 	tse_task_t		*task;

--- a/src/include/daos/object.h
+++ b/src/include/daos/object.h
@@ -84,6 +84,21 @@ unsigned int daos_oclass_grp_nr(struct daos_oclass_attr *oc_attr,
 				struct daos_obj_md *md);
 int daos_oclass_name2id(const char *name);
 
+/** bits for the specified rank */
+#define DAOS_OC_SR_SHIFT	24
+#define DAOS_OC_SR_BITS		8
+#define DAOS_OC_SR_MASK		\
+	(((1ULL << DAOS_OC_SR_BITS) - 1) << DAOS_OC_SR_SHIFT)
+
+/** bits for the specified target, Note: the target here means the target
+ * index inside the rank, and it only reserve 4 bits, so only specify 16th
+ * target maximum.
+ */
+#define DAOS_OC_ST_SHIFT	20
+#define DAOS_OC_ST_BITS		4
+#define DAOS_OC_ST_MASK		\
+	(((1ULL << DAOS_OC_ST_BITS) - 1) << DAOS_OC_ST_SHIFT)
+
 static inline d_rank_t
 daos_oclass_sr_get_rank(daos_obj_id_t oid)
 {
@@ -104,6 +119,29 @@ daos_oclass_sr_set_rank(daos_obj_id_t oid, d_rank_t rank)
 	D_ASSERT((oid.hi & DAOS_OC_SR_MASK) == 0);
 
 	oid.hi |= (uint64_t)rank << DAOS_OC_SR_SHIFT;
+	return oid;
+}
+
+static inline int
+daos_oclass_st_get_tgt(daos_obj_id_t oid)
+{
+	D_ASSERT(daos_obj_id2class(oid) == DAOS_OC_R3S_SPEC_RANK ||
+		 daos_obj_id2class(oid) == DAOS_OC_R1S_SPEC_RANK ||
+		 daos_obj_id2class(oid) == DAOS_OC_R2S_SPEC_RANK);
+
+	return ((oid.hi & DAOS_OC_ST_MASK) >> DAOS_OC_ST_SHIFT);
+}
+
+static inline daos_obj_id_t
+daos_oclass_st_set_tgt(daos_obj_id_t oid, int tgt)
+{
+	D_ASSERT(daos_obj_id2class(oid) == DAOS_OC_R3S_SPEC_RANK ||
+		 daos_obj_id2class(oid) == DAOS_OC_R1S_SPEC_RANK ||
+		 daos_obj_id2class(oid) == DAOS_OC_R2S_SPEC_RANK);
+	D_ASSERT(tgt < (1 << DAOS_OC_ST_SHIFT));
+	D_ASSERT((oid.hi & DAOS_OC_ST_MASK) == 0);
+
+	oid.hi |= (uint64_t)tgt << DAOS_OC_ST_SHIFT;
 	return oid;
 }
 

--- a/src/include/daos/tests_lib.h
+++ b/src/include/daos/tests_lib.h
@@ -63,6 +63,8 @@ daos_unit_oid_t dts_unit_oid_gen(uint16_t oclass, uint8_t ofeats,
 
 /** Set rank into the oid */
 #define dts_oid_set_rank(oid, rank)	daos_oclass_sr_set_rank(oid, rank)
+/** Set target offset into oid */
+#define dts_oid_set_tgt(oid, tgt)	daos_oclass_st_set_tgt(oid, tgt)
 
 /**
  * Create a random ordered integer array with \a nr elements, value of this

--- a/src/include/daos_mgmt.h
+++ b/src/include/daos_mgmt.h
@@ -116,8 +116,10 @@ daos_mgmt_svc_rip(const char *grp, d_rank_t rank, bool force,
  * \param uuid	[IN]	UUID of the pool
  * \param grp	[IN]	process set name of the DAOS servers managing the pool
  * \param svc	[IN]	list of pool service ranks
- * \param tgts	[IN]	Target rank array to be excluded from the pool.
- *			Now can-only exclude one target per API calling.
+ * \param tgts	[IN]	Target to be excluded from the pool.
+ *			Now can-only exclude one target per API calling. If
+ *			tl_tgts = -1, it means it will exclude all targets
+ *			on the rank.
  * \param ev	[IN]	Completion event, it is optional and can be NULL.
  *			The function will run in blocking mode if \a ev is NULL.
  *
@@ -129,9 +131,9 @@ daos_mgmt_svc_rip(const char *grp, d_rank_t rank, bool force,
  *			-DER_NONEXIST	Pool is nonexistent
  */
 int
-daos_pool_exclude(const uuid_t uuid, const char *grp,
-		  const d_rank_list_t *svc, d_rank_list_t *tgts,
-		  daos_event_t *ev);
+daos_pool_tgt_exclude(const uuid_t uuid, const char *grp,
+		      const d_rank_list_t *svc, struct d_tgt_list *tgts,
+		      daos_event_t *ev);
 
 /**
  * Extend the pool to more targets. If \a tgts is NULL, this function
@@ -186,7 +188,9 @@ daos_pool_evict(const uuid_t uuid, const char *grp, const d_rank_list_t *svc,
  * \param uuid	[IN]	UUID of the pool
  * \param grp	[IN]	process set name of the DAOS servers managing the pool
  * \param svc	[IN]	list of pool service ranks
- * \param tgts	[IN]	Target rank array to be added from the pool.
+ * \param tgts	[IN]	Target array to be added from the pool.  If
+ *			tl_tgts = -1, it means it will add all targets
+ *			on the rank.
  * \param ev	[IN]	Completion event, it is optional and can be NULL.
  *			The function will run in blocking mode if \a ev is NULL.
  *
@@ -199,7 +203,7 @@ daos_pool_evict(const uuid_t uuid, const char *grp, const d_rank_list_t *svc,
  */
 int
 daos_pool_add_tgt(const uuid_t uuid, const char *grp,
-		  const d_rank_list_t *svc, d_rank_list_t *tgts,
+		  const d_rank_list_t *svc, struct d_tgt_list *tgts,
 		  daos_event_t *ev);
 
 /**
@@ -221,15 +225,17 @@ daos_mgmt_set_params(const char *grp, d_rank_t rank, unsigned int key_id,
 
 /**
  * Exclude completely a set of storage targets from a pool. Compared with
- * daos_pool_exclude(), this API will mark the targets to be DOWNOUT, i.e.
- * the rebuilding for this target is done, while daos_pool_exclude() only
+ * daos_pool_tgt_exclude(), this API will mark the targets to be DOWNOUT, i.e.
+ * the rebuilding for this target is done, while daos_pool_tgt_exclude() only
  * mark the target to be DOWN, i.e. the rebuilding might not finished yet.
  *
  * \param uuid	[IN]	UUID of the pool
  * \param grp	[IN]	process set name of the DAOS servers managing the pool
  * \param svc	[IN]	list of pool service ranks
- * \param tgts	[IN]	Target rank array to be excluded from the pool.
- *			Now can-only exclude one target per API calling.
+ * \param tgts	[IN]	Target array to be excluded from the pool.
+ *			Now can-only exclude out one target per API calling. If
+ *			tl_tgts = -1, it means it will exclude out all targets
+ *			on the rank.
  * \param ev	[IN]	Completion event, it is optional and can be NULL.
  *			The function will run in blocking mode if \a ev is NULL.
  *
@@ -241,9 +247,9 @@ daos_mgmt_set_params(const char *grp, d_rank_t rank, unsigned int key_id,
  *			-DER_NO_PERM	Permission denied
  */
 int
-daos_pool_exclude_out(const uuid_t uuid, const char *grp,
-		      const d_rank_list_t *svc, d_rank_list_t *tgts,
-		      daos_event_t *ev);
+daos_pool_tgt_exclude_out(const uuid_t uuid, const char *grp,
+			  const d_rank_list_t *svc, struct d_tgt_list *tgts,
+			  daos_event_t *ev);
 
 /**
  * Stop the current pool service leader.

--- a/src/include/daos_task.h
+++ b/src/include/daos_task.h
@@ -188,7 +188,7 @@ typedef struct {
 	const uuid_t		uuid;
 	const char		*grp;
 	d_rank_list_t		*svc;
-	d_rank_list_t		*tgts;
+	struct d_tgt_list	*tgts;
 } daos_pool_update_t;
 
 typedef struct {

--- a/src/include/daos_types.h
+++ b/src/include/daos_types.h
@@ -488,12 +488,6 @@ enum {
 				 */
 };
 
-/** bits for the specified rank */
-#define DAOS_OC_SR_SHIFT	24
-#define DAOS_OC_SR_BITS		8
-#define DAOS_OC_SR_MASK		\
-	(((1ULL << DAOS_OC_SR_BITS) - 1) << DAOS_OC_SR_SHIFT)
-
 /** Object class attributes */
 typedef struct daos_oclass_attr {
 	/** Object placement schema */
@@ -778,6 +772,14 @@ typedef enum {
 	DAOS_EVS_COMPLETED,
 	DAOS_EVS_ABORTED,
 } daos_ev_status_t;
+
+/* rank/target list for target */
+struct d_tgt_list {
+	d_rank_t	*tl_ranks;
+	int32_t		*tl_tgts;
+	/** number of ranks & tgts */
+	uint32_t	tl_nr;
+};
 
 struct daos_eq;
 

--- a/src/placement/ring_map.c
+++ b/src/placement/ring_map.c
@@ -785,6 +785,7 @@ ring_obj_spec_place_begin(struct pl_ring_map *rimap, daos_obj_id_t oid,
 	unsigned int		tgts_nr;
 	struct pl_target	*plts;
 	d_rank_t		rank;
+	int			tgt;
 	unsigned int		pos;
 	unsigned int		i;
 
@@ -797,8 +798,10 @@ ring_obj_spec_place_begin(struct pl_ring_map *rimap, daos_obj_id_t oid,
 	tgts_nr = pool_map_target_nr(rimap->rmp_map.pl_poolmap);
 	/* locate rank in the pool map targets */
 	rank = daos_oclass_sr_get_rank(oid);
+	tgt = daos_oclass_st_get_tgt(oid);
 	for (pos = 0; pos < tgts_nr; pos++) {
-		if (rank == tgts[pos].ta_comp.co_rank)
+		if (rank == tgts[pos].ta_comp.co_rank &&
+		    (tgt == tgts[pos].ta_comp.co_index))
 			break;
 	}
 	if (pos == tgts_nr)
@@ -814,7 +817,8 @@ ring_obj_spec_place_begin(struct pl_ring_map *rimap, daos_obj_id_t oid,
 		return -DER_INVAL;
 
 
-	D_DEBUG(DB_PL, "create obj with rank %d pl pos %d\n", rank, i);
+	D_DEBUG(DB_PL, "create obj with rank/tgt %d/%d pl pos %d\n",
+		rank, tgt, i);
 	*begin = i;
 
 	return 0;

--- a/src/pool/cli.c
+++ b/src/pool/cli.c
@@ -1097,19 +1097,20 @@ dc_pool_update_internal(tse_task_t *task, daos_pool_update_t *args,
 	int				rc;
 
 	if (state == NULL) {
-		if (args->tgts == NULL || args->tgts->rl_nr == 0) {
-			D_ERROR("NULL tgts or tgts->rl_nr is zero\n");
+		if (args->tgts == NULL || args->tgts->tl_nr == 0) {
+			D_ERROR("NULL tgts or tgts->tl_nr is zero\n");
 			return -DER_INVAL;
 		} else if ((opc == POOL_EXCLUDE || opc == POOL_EXCLUDE_OUT) &&
-			   args->tgts->rl_nr > 1) {
+			   args->tgts->tl_nr > 1) {
 			D_ERROR("pool exclude can only work with "
-				"(tgts->rl_nr == 1) for now.\n");
+				"(tgts->tl_nr == 1) for now.\n");
 			return -DER_INVAL;
 		}
 
-		D_DEBUG(DF_DSMC, DF_UUID": excluding %u targets: tgts[0]=%u\n",
-			DP_UUID(args->uuid), args->tgts->rl_nr,
-			args->tgts->rl_ranks[0]);
+		D_DEBUG(DF_DSMC, DF_UUID": excluding %u targets:"
+			" tgts[0]=%u/%d\n", DP_UUID(args->uuid),
+			args->tgts->tl_nr, args->tgts->tl_ranks[0],
+			args->tgts->tl_tgts[0]);
 
 		D_ALLOC_PTR(state);
 		if (state == NULL) {
@@ -1139,16 +1140,16 @@ dc_pool_update_internal(tse_task_t *task, daos_pool_update_t *args,
 	in = crt_req_get(rpc);
 	uuid_copy(in->pti_op.pi_uuid, args->uuid);
 
-	rc = pool_target_addr_list_alloc(args->tgts->rl_nr, &list);
+	rc = pool_target_addr_list_alloc(args->tgts->tl_nr, &list);
 	if (rc) {
 		crt_req_decref(rpc);
 		D_GOTO(out_client, rc);
 	}
 
 	/* XXX Let's update all targets on the node */
-	for (i = 0; i < args->tgts->rl_nr; i++) {
-		list.pta_addrs[i].pta_rank = args->tgts->rl_ranks[i];
-		list.pta_addrs[i].pta_target = -1;
+	for (i = 0; i < args->tgts->tl_nr; i++) {
+		list.pta_addrs[i].pta_rank = args->tgts->tl_ranks[i];
+		list.pta_addrs[i].pta_target = args->tgts->tl_tgts[i];
 	}
 	in->pti_addr_list.ca_arrays = list.pta_addrs;
 	in->pti_addr_list.ca_count = (size_t)list.pta_number;

--- a/src/pool/srv_pool.c
+++ b/src/pool/srv_pool.c
@@ -2129,6 +2129,9 @@ pool_find_all_targets_by_addr(uuid_t pool_uuid,
 			/* Can not locate the target in pool map, let's
 			 * add it to the output list
 			 */
+			D_WARN("Can not find %u/%d , add to out_list\n",
+				list->pta_addrs[i].pta_rank,
+				(int)list->pta_addrs[i].pta_target);
 			ret = pool_target_addr_list_append(out_list,
 						&list->pta_addrs[i]);
 			if (ret) {

--- a/src/pool/srv_util.c
+++ b/src/pool/srv_util.c
@@ -302,21 +302,25 @@ ds_pool_map_tgts_update(struct pool_map *map, struct pool_target_id_list *tgts,
 		if (opc == POOL_EXCLUDE &&
 		    target->ta_comp.co_status != PO_COMP_ST_DOWN &&
 		    target->ta_comp.co_status != PO_COMP_ST_DOWNOUT) {
-			D_DEBUG(DF_DSMS, "change rank %u to DOWN %p\n",
-				target->ta_comp.co_rank, map);
+			D_DEBUG(DF_DSMS, "change target %u/%u to DOWN %p\n",
+				target->ta_comp.co_rank,
+				target->ta_comp.co_index, map);
 			target->ta_comp.co_status = PO_COMP_ST_DOWN;
 			target->ta_comp.co_fseq = version;
 			nchanges++;
 			if (pool_map_node_status_match(dom,
 				PO_COMP_ST_DOWN | PO_COMP_ST_DOWNOUT)) {
+				D_DEBUG(DF_DSMS, "change rank %u to DOWN\n",
+					dom->do_comp.co_rank);
 				dom->do_comp.co_status = PO_COMP_ST_DOWN;
 				dom->do_comp.co_fseq = version;
 			}
 		} else if (opc == POOL_ADD &&
 			 target->ta_comp.co_status != PO_COMP_ST_UP &&
 			 target->ta_comp.co_status != PO_COMP_ST_UPIN) {
-			D_DEBUG(DF_DSMS, "change rank %u to UP %p\n",
-				target->ta_comp.co_rank, map);
+			D_DEBUG(DF_DSMS, "change target %u/%u to UP %p\n",
+				target->ta_comp.co_rank,
+				target->ta_comp.co_index, map);
 			target->ta_comp.co_status = PO_COMP_ST_UP;
 			target->ta_comp.co_ver = version;
 			target->ta_comp.co_fseq = 0;
@@ -325,13 +329,17 @@ ds_pool_map_tgts_update(struct pool_map *map, struct pool_target_id_list *tgts,
 			dom->do_comp.co_ver = version;
 		} else if (opc == POOL_EXCLUDE_OUT &&
 			 target->ta_comp.co_status == PO_COMP_ST_DOWN) {
-			D_DEBUG(DF_DSMS, "change rank %u DOWNOUT %p\n",
-				target->ta_comp.co_rank, map);
+			D_DEBUG(DF_DSMS, "change target %u/%u to DOWNOUT %p\n",
+				target->ta_comp.co_rank,
+				target->ta_comp.co_index, map);
 			target->ta_comp.co_status = PO_COMP_ST_DOWNOUT;
 			nchanges++;
 			if (pool_map_node_status_match(dom,
-						PO_COMP_ST_DOWNOUT))
+						PO_COMP_ST_DOWNOUT)) {
+				D_DEBUG(DF_DSMS, "change rank %u to DOWNOUT\n",
+					dom->do_comp.co_rank);
 				dom->do_comp.co_status = PO_COMP_ST_DOWNOUT;
+			}
 		}
 	}
 

--- a/src/rebuild/initiator.c
+++ b/src/rebuild/initiator.c
@@ -294,8 +294,8 @@ rebuild_one_punch_keys(struct rebuild_tgt_pool_tracker *rpt,
 }
 
 static int
-rebuild_rdone(struct rebuild_tgt_pool_tracker *rpt,
-	      struct rebuild_one *rdone)
+rebuild_dkey(struct rebuild_tgt_pool_tracker *rpt,
+	     struct rebuild_one *rdone)
 {
 	struct rebuild_pool_tls	*tls;
 	struct ds_cont		*rebuild_cont;
@@ -432,7 +432,7 @@ rebuild_one_ult(void *arg)
 		d_list_for_each_entry_safe(rdone, tmp, &rebuild_list, ro_list) {
 			d_list_del_init(&rdone->ro_list);
 			if (!rpt->rt_abort) {
-				rc = rebuild_rdone(rpt, rdone);
+				rc = rebuild_dkey(rpt, rdone);
 				D_DEBUG(DB_REBUILD, DF_UOID" rebuild dkey %d %s"
 					" rc %d tag %d rpt %p\n",
 					DP_UOID(rdone->ro_oid),

--- a/src/tests/daos_perf.c
+++ b/src/tests/daos_perf.c
@@ -622,14 +622,16 @@ ts_update_fetch_perf(double *start_time, double *end_time)
 static int
 ts_exclude_server(d_rank_t rank)
 {
-	d_rank_list_t	targets;
-	int		rc;
+	struct d_tgt_list	targets;
+	int			tgt = -1;
+	int			rc;
 
 	/** exclude from the pool */
-	targets.rl_nr = 1;
-	targets.rl_ranks = &rank;
-	rc = daos_pool_exclude(ts_ctx.tsc_pool_uuid, NULL, &ts_ctx.tsc_svc,
-			       &targets, NULL);
+	targets.tl_nr = 1;
+	targets.tl_ranks = &rank;
+	targets.tl_tgts = &tgt;
+	rc = daos_pool_tgt_exclude(ts_ctx.tsc_pool_uuid, NULL, &ts_ctx.tsc_svc,
+				   &targets, NULL);
 
 	return rc;
 }
@@ -637,12 +639,14 @@ ts_exclude_server(d_rank_t rank)
 static int
 ts_add_server(d_rank_t rank)
 {
-	d_rank_list_t	targets;
-	int		rc;
+	struct d_tgt_list	targets;
+	int			tgt = -1;
+	int			rc;
 
 	/** exclude from the pool */
-	targets.rl_nr = 1;
-	targets.rl_ranks = &rank;
+	targets.tl_nr = 1;
+	targets.tl_ranks = &rank;
+	targets.tl_tgts = &tgt;
 	rc = daos_pool_add_tgt(ts_ctx.tsc_pool_uuid, NULL, &ts_ctx.tsc_svc,
 			       &targets, NULL);
 	return rc;

--- a/src/tests/daosbench.c
+++ b/src/tests/daosbench.c
@@ -312,10 +312,11 @@ free_buffers()
 static void
 kill_daos_server(const char *grp)
 {
-	daos_pool_info_t		info;
-	d_rank_t			rank;
-	d_rank_list_t		targets;
-	int				rc;
+	daos_pool_info_t	info;
+	d_rank_t		rank;
+	int			tgt = -1;
+	struct d_tgt_list	targets;
+	int			rc;
 
 	rc = daos_pool_query(poh, NULL, &info, NULL);
 	DBENCH_CHECK(rc, "Error in querying pool\n");
@@ -332,10 +333,11 @@ kill_daos_server(const char *grp)
 	rc  = daos_mgmt_svc_rip(grp, rank, true, NULL);
 	DBENCH_CHECK(rc, "Error in killing server\n");
 
-	targets.rl_nr		= 1;
-	targets.rl_ranks	= &rank;
+	targets.tl_nr		= 1;
+	targets.tl_ranks	= &rank;
+	targets.tl_tgts		= &tgt;
 
-	rc = daos_pool_exclude(pool_uuid, grp, svcl, &targets, NULL);
+	rc = daos_pool_tgt_exclude(pool_uuid, grp, svcl, &targets, NULL);
 	DBENCH_CHECK(rc, "Error in excluding pool from poolmap\n");
 
 	memset(&info, 0, sizeof(daos_pool_info_t));

--- a/src/tests/daosctl/pool-cmds.c
+++ b/src/tests/daosctl/pool-cmds.c
@@ -265,7 +265,9 @@ cmd_exclude_target(int argc, const char **argv, void *ctx)
 	uuid_t uuid;
 	int    rc;
 	d_rank_list_t pool_service_list = {NULL, 0};
-	d_rank_list_t pool_target_list = {NULL, 0};
+	d_rank_list_t pool_rank_list = {NULL, 0};
+	struct d_tgt_list pool_target_list = {NULL, 0};
+	int	i;
 
 	struct argp_option options[] = {
 		{"server-group",   's',   "SERVER-GROUP",     0,
@@ -303,12 +305,22 @@ cmd_exclude_target(int argc, const char **argv, void *ctx)
 
 	/* put the ascii list of target ranks into the right format */
 	rc = parse_rank_list(et_options.target_list,
-			     &pool_target_list);
+			     &pool_rank_list);
 	if (rc < 0)
 		/* TODO do a better job with failure return */
 		return rc;
 
-	rc = daos_pool_exclude(uuid, et_options.server_group,
+	pool_target_list.tl_nr = pool_rank_list.rl_nr;
+	pool_target_list.tl_ranks = pool_rank_list.rl_ranks;
+	pool_target_list.tl_tgts = calloc(pool_target_list.tl_nr,
+					  sizeof(int32_t));
+	if (pool_target_list.tl_tgts == NULL)
+		return -1;
+
+	for (i = 0; i < pool_target_list.tl_nr; i++)
+		pool_target_list.tl_tgts[i] = -1;
+
+	rc = daos_pool_tgt_exclude(uuid, et_options.server_group,
 			       &pool_service_list,
 			       &pool_target_list, NULL);
 
@@ -317,6 +329,8 @@ cmd_exclude_target(int argc, const char **argv, void *ctx)
 	else
 		printf("Target excluded.\n");
 	fflush(stdout);
+
+	free(pool_target_list.tl_tgts);
 
 	return rc;
 }

--- a/src/tests/suite/daos_pool.c
+++ b/src/tests/suite/daos_pool.c
@@ -169,8 +169,9 @@ pool_exclude(void **state)
 	daos_handle_t	 poh;
 	daos_event_t	 ev;
 	daos_pool_info_t info;
-	d_rank_list_t ranks;
+	struct d_tgt_list tgts;
 	d_rank_t	 rank;
+	int		 tgt = -1;
 	int		 rc;
 
 	if (1) {
@@ -199,17 +200,19 @@ pool_exclude(void **state)
 	print_message("success\n");
 
 	/** exclude last non-svc rank */
-	if (info.pi_ntargets - 1 /* rank 0 */ <= arg->pool.svc.rl_nr) {
+	if (info.pi_nnodes - 1 /* rank 0 */ <= arg->pool.svc.rl_nr) {
 		print_message("not enough non-svc targets; skipping\n");
 		goto disconnect;
 	}
-	rank = info.pi_ntargets - 1;
-	ranks.rl_nr = 1;
-	ranks.rl_ranks = &rank;
+	rank = info.pi_nnodes - 1;
+	tgts.tl_nr = 1;
+	tgts.tl_ranks = &rank;
+	tgts.tl_tgts = &tgt;
 
 	print_message("rank 0 excluding rank %u... ", rank);
-	rc = daos_pool_exclude(arg->pool.pool_uuid, arg->group, &arg->pool.svc,
-			       &ranks, arg->async ? &ev : NULL /* ev */);
+	rc = daos_pool_tgt_exclude(arg->pool.pool_uuid, arg->group,
+				   &arg->pool.svc, &tgts,
+				   arg->async ? &ev : NULL /* ev */);
 	assert_int_equal(rc, 0);
 	WAIT_ON_ASYNC(arg, ev);
 	print_message("success\n");

--- a/src/tests/suite/daos_test.h
+++ b/src/tests/suite/daos_test.h
@@ -256,12 +256,8 @@ int run_daos_rebuild_test(int rank, int size, int *tests, int test_size);
 
 void daos_kill_server(test_arg_t *arg, const uuid_t pool_uuid, const char *grp,
 		      d_rank_list_t *svc, d_rank_t rank);
-void daos_exclude_server(const uuid_t pool_uuid, const char *grp,
-			 const d_rank_list_t *svc, d_rank_t rank);
 void daos_kill_exclude_server(test_arg_t *arg, const uuid_t pool_uuid,
 			      const char *grp, d_rank_list_t *svc);
-void daos_add_server(const uuid_t pool_uuid, const char *grp,
-		     const d_rank_list_t *svc, d_rank_t rank);
 typedef int (*test_setup_cb_t)(void **state);
 typedef int (*test_teardown_cb_t)(void **state);
 
@@ -270,10 +266,16 @@ int test_pool_get_info(test_arg_t *arg, daos_pool_info_t *pinfo);
 int test_get_leader(test_arg_t *arg, d_rank_t *rank);
 bool test_rebuild_query(test_arg_t **args, int args_cnt);
 void test_rebuild_wait(test_arg_t **args, int args_cnt);
+void daos_exclude_target(const uuid_t pool_uuid, const char *grp,
+			 const d_rank_list_t *svc, d_rank_t rank, int tgt);
+void daos_add_target(const uuid_t pool_uuid, const char *grp,
+		     const d_rank_list_t *svc, d_rank_t rank, int tgt);
+
 void daos_exclude_server(const uuid_t pool_uuid, const char *grp,
 			 const d_rank_list_t *svc, d_rank_t rank);
 void daos_add_server(const uuid_t pool_uuid, const char *grp,
 		     const d_rank_list_t *svc, d_rank_t rank);
+
 int run_daos_sub_tests(const struct CMUnitTest *tests, int tests_size,
 		       daos_size_t pool_size, int *sub_tests,
 		       int sub_tests_size, test_setup_cb_t setup_cb,

--- a/src/tests/suite/daos_test_common.c
+++ b/src/tests/suite/daos_test_common.c
@@ -675,35 +675,52 @@ run_daos_sub_tests(const struct CMUnitTest *tests, int tests_size,
 }
 
 void
-daos_exclude_server(const uuid_t pool_uuid, const char *grp,
-		    const d_rank_list_t *svc, d_rank_t rank)
+daos_exclude_target(const uuid_t pool_uuid, const char *grp,
+		    const d_rank_list_t *svc, d_rank_t rank,
+		    int tgt_idx)
 {
-	int		rc;
-	d_rank_list_t	targets;
+	struct d_tgt_list	targets;
+	int			rc;
 
 	/** exclude from the pool */
-	targets.rl_nr = 1;
-	targets.rl_ranks = &rank;
-	rc = daos_pool_exclude(pool_uuid, grp, svc, &targets, NULL);
+	targets.tl_nr = 1;
+	targets.tl_ranks = &rank;
+	targets.tl_tgts = &tgt_idx;
+	rc = daos_pool_tgt_exclude(pool_uuid, grp, svc, &targets, NULL);
 	if (rc)
 		print_message("exclude pool failed rc %d\n", rc);
 	assert_int_equal(rc, 0);
 }
 
 void
-daos_add_server(const uuid_t pool_uuid, const char *grp,
-		const d_rank_list_t *svc, d_rank_t rank)
+daos_add_target(const uuid_t pool_uuid, const char *grp,
+		const d_rank_list_t *svc, d_rank_t rank, int tgt_idx)
 {
-	int		rc;
-	d_rank_list_t	targets;
+	struct d_tgt_list	targets;
+	int			rc;
 
 	/** add tgt to the pool */
-	targets.rl_nr = 1;
-	targets.rl_ranks = &rank;
+	targets.tl_nr = 1;
+	targets.tl_ranks = &rank;
+	targets.tl_tgts = &tgt_idx;
 	rc = daos_pool_add_tgt(pool_uuid, grp, svc, &targets, NULL);
 	if (rc)
 		print_message("add pool failed rc %d\n", rc);
 	assert_int_equal(rc, 0);
+}
+
+void
+daos_exclude_server(const uuid_t pool_uuid, const char *grp,
+		    const d_rank_list_t *svc, d_rank_t rank)
+{
+	daos_exclude_target(pool_uuid, grp, svc, rank, -1);
+}
+
+void
+daos_add_server(const uuid_t pool_uuid, const char *grp,
+		const d_rank_list_t *svc, d_rank_t rank)
+{
+	daos_add_target(pool_uuid, grp, svc, rank, -1);
 }
 
 void

--- a/src/utils/dmg.c
+++ b/src/utils/dmg.c
@@ -300,6 +300,8 @@ pool_op_hdlr(int argc, char *argv[])
 	const char	       *tgt_str = NULL;
 	d_rank_list_t	       *targets;
 	enum pool_op		op = pool_op_parse(argv[1]);
+	struct d_tgt_list	tgt_list = { 0 };
+	int			tgt = -1;
 	int			rc;
 
 	uuid_clear(pool_uuid);
@@ -375,8 +377,12 @@ pool_op_hdlr(int argc, char *argv[])
 		break;
 
 	case POOL_EXCLUDE:
-		targets->rl_nr = 1;
-		rc = daos_pool_exclude(pool_uuid, group, svc, targets,
+		/* Only support exclude single target XXX */
+		D_ASSERT(targets->rl_nr == 1);
+		tgt_list.tl_nr = 1;
+		tgt_list.tl_ranks = targets->rl_ranks;
+		tgt_list.tl_tgts = &tgt;
+		rc = daos_pool_tgt_exclude(pool_uuid, group, svc, &tgt_list,
 				       NULL /* ev */);
 		if (rc != 0)
 			fprintf(stderr, "failed to exclude target: "
@@ -411,7 +417,6 @@ pool_op_hdlr(int argc, char *argv[])
 	daos_rank_list_free(targets);
 	if (rc != 0)
 		return rc;
-
 
 	if (op == POOL_QUERY) {
 		daos_pool_info_t		 pinfo;


### PR DESCRIPTION
1 replace d_rank_list_t with d_tgt_list_t for pool
add/exclude to single target failure.

2. Add single target failure to the rebuild test.

3. A few cleanup and fixes for single target failure.

Change-Id: I2c5c25f8ce5d03720f0469f7d6c1806e8c81531f
Signed-off-by: Wang Di <di.wang@intel.com>