### PR TITLE
DAOS-657 security: Implement ACL gRPC hooks

### DIFF
--- a/src/control/SConscript
+++ b/src/control/SConscript
@@ -77,7 +77,7 @@ def scons():
         denv.subst("-L$SPDK_PREFIX/lib -L$PREFIX/lib $_RPATH"))
     denv.AppendENVPath(
         "CGO_CFLAGS",
-        denv.subst("-I$SPDK_PREFIX/include"))
+        denv.subst("-I$SPDK_PREFIX/include -I%s/../include" % gosrc))
 
     # copy server init files to be used at runtime, explicitly
     # remove first because recursive Delete() on dir fails.

--- a/src/control/security/proto/acl.pb.go
+++ b/src/control/security/proto/acl.pb.go
@@ -7,6 +7,11 @@ import proto "github.com/golang/protobuf/proto"
 import fmt "fmt"
 import math "math"
 
+import (
+	context "golang.org/x/net/context"
+	grpc "google.golang.org/grpc"
+)
+
 // Reference imports to suppress errors if they are not otherwise used.
 var _ = proto.Marshal
 var _ = fmt.Errorf
@@ -304,6 +309,150 @@ func init() {
 	proto.RegisterEnum("proto.AclPermissions", AclPermissions_name, AclPermissions_value)
 	proto.RegisterEnum("proto.AclEntryType", AclEntryType_name, AclEntryType_value)
 	proto.RegisterEnum("proto.AclFlags", AclFlags_name, AclFlags_value)
+}
+
+// Reference imports to suppress errors if they are not otherwise used.
+var _ context.Context
+var _ grpc.ClientConn
+
+// This is a compile-time assertion to ensure that this generated file
+// is compatible with the grpc package it is being compiled against.
+const _ = grpc.SupportPackageIsVersion4
+
+// AccessControlClient is the client API for AccessControl service.
+//
+// For semantics around ctx use and closing/ending streaming RPCs, please refer to https://godoc.org/google.golang.org/grpc#ClientConn.NewStream.
+type AccessControlClient interface {
+	// Set the permissions on a given ACE or create it if it doesn't exist
+	SetPermissions(ctx context.Context, in *AclEntryPermissions, opts ...grpc.CallOption) (*AclResponse, error)
+	// Fetch the permissions on a given ACE
+	GetPermissions(ctx context.Context, in *AclEntry, opts ...grpc.CallOption) (*AclResponse, error)
+	// Remove the given ACE completely from the ACL
+	DestroyAclEntry(ctx context.Context, in *AclEntry, opts ...grpc.CallOption) (*AclResponse, error)
+}
+
+type accessControlClient struct {
+	cc *grpc.ClientConn
+}
+
+func NewAccessControlClient(cc *grpc.ClientConn) AccessControlClient {
+	return &accessControlClient{cc}
+}
+
+func (c *accessControlClient) SetPermissions(ctx context.Context, in *AclEntryPermissions, opts ...grpc.CallOption) (*AclResponse, error) {
+	out := new(AclResponse)
+	err := c.cc.Invoke(ctx, "/proto.AccessControl/SetPermissions", in, out, opts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *accessControlClient) GetPermissions(ctx context.Context, in *AclEntry, opts ...grpc.CallOption) (*AclResponse, error) {
+	out := new(AclResponse)
+	err := c.cc.Invoke(ctx, "/proto.AccessControl/GetPermissions", in, out, opts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *accessControlClient) DestroyAclEntry(ctx context.Context, in *AclEntry, opts ...grpc.CallOption) (*AclResponse, error) {
+	out := new(AclResponse)
+	err := c.cc.Invoke(ctx, "/proto.AccessControl/DestroyAclEntry", in, out, opts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+// AccessControlServer is the server API for AccessControl service.
+type AccessControlServer interface {
+	// Set the permissions on a given ACE or create it if it doesn't exist
+	SetPermissions(context.Context, *AclEntryPermissions) (*AclResponse, error)
+	// Fetch the permissions on a given ACE
+	GetPermissions(context.Context, *AclEntry) (*AclResponse, error)
+	// Remove the given ACE completely from the ACL
+	DestroyAclEntry(context.Context, *AclEntry) (*AclResponse, error)
+}
+
+func RegisterAccessControlServer(s *grpc.Server, srv AccessControlServer) {
+	s.RegisterService(&_AccessControl_serviceDesc, srv)
+}
+
+func _AccessControl_SetPermissions_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(AclEntryPermissions)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(AccessControlServer).SetPermissions(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: "/proto.AccessControl/SetPermissions",
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(AccessControlServer).SetPermissions(ctx, req.(*AclEntryPermissions))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _AccessControl_GetPermissions_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(AclEntry)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(AccessControlServer).GetPermissions(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: "/proto.AccessControl/GetPermissions",
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(AccessControlServer).GetPermissions(ctx, req.(*AclEntry))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _AccessControl_DestroyAclEntry_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(AclEntry)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(AccessControlServer).DestroyAclEntry(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: "/proto.AccessControl/DestroyAclEntry",
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(AccessControlServer).DestroyAclEntry(ctx, req.(*AclEntry))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+var _AccessControl_serviceDesc = grpc.ServiceDesc{
+	ServiceName: "proto.AccessControl",
+	HandlerType: (*AccessControlServer)(nil),
+	Methods: []grpc.MethodDesc{
+		{
+			MethodName: "SetPermissions",
+			Handler:    _AccessControl_SetPermissions_Handler,
+		},
+		{
+			MethodName: "GetPermissions",
+			Handler:    _AccessControl_GetPermissions_Handler,
+		},
+		{
+			MethodName: "DestroyAclEntry",
+			Handler:    _AccessControl_DestroyAclEntry_Handler,
+		},
+	},
+	Streams:  []grpc.StreamDesc{},
+	Metadata: "acl.proto",
 }
 
 func init() { proto.RegisterFile("acl.proto", fileDescriptor_acl_08c19ec25d13204d) }

--- a/src/control/server/main.go
+++ b/src/control/server/main.go
@@ -36,6 +36,7 @@ import (
 
 	"github.com/daos-stack/daos/src/control/common"
 	mgmtpb "github.com/daos-stack/daos/src/control/common/proto/mgmt"
+	secpb "github.com/daos-stack/daos/src/control/security/proto"
 	"github.com/daos-stack/daos/src/control/log"
 )
 
@@ -152,6 +153,11 @@ func main() {
 	grpcServer := grpc.NewServer(sOpts...)
 
 	mgmtpb.RegisterMgmtControlServer(grpcServer, mgmtControlServer)
+
+	// Set up security-related gRPC servers
+	secServer := newSecurityService(getDrpcClientConnection(config.SocketDir))
+	secpb.RegisterAccessControlServer(grpcServer, secServer)
+
 	go grpcServer.Serve(lis)
 	defer grpcServer.GracefulStop()
 

--- a/src/control/server/mgmt_drpc.go
+++ b/src/control/server/mgmt_drpc.go
@@ -33,6 +33,15 @@ import (
 
 var sockFileName = "daos_server.sock"
 
+func getDrpcClientSocket(sockDir string) string {
+	return filepath.Join(sockDir, "daos_io_server.sock")
+}
+
+func getDrpcClientConnection(sockDir string) *drpc.ClientConnection {
+	clientSock := getDrpcClientSocket(sockDir)
+	return drpc.NewClientConnection(clientSock)
+}
+
 // drpcSetup creates socket directory, specifies socket path and then
 // starts drpc server.
 func drpcSetup(sockDir string) error {

--- a/src/control/server/security.go
+++ b/src/control/server/security.go
@@ -1,0 +1,146 @@
+//
+// (C) Copyright 2019 Intel Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// GOVERNMENT LICENSE RIGHTS-OPEN SOURCE SOFTWARE
+// The Government's rights to use, modify, reproduce, release, perform, display,
+// or disclose this software are subject to the terms of the Apache License as
+// provided in Contract No. 8F-30005.
+// Any reproduction of computer software, computer software documentation, or
+// portions thereof marked with this legend must also reproduce the markings.
+//
+
+package main
+
+// #cgo CFLAGS: -I${SRCDIR}/../../include
+// #include <daos/drpc_modules.h>
+import "C"
+import (
+	"context"
+	"fmt"
+
+	"github.com/daos-stack/daos/src/control/drpc"
+	pb "github.com/daos-stack/daos/src/control/security/proto"
+	"github.com/golang/protobuf/proto"
+)
+
+const moduleID int32 = C.DRPC_MODULE_SECURITY_AGENT
+
+// TODO: Get Method IDs from the IO server header file, when it exists
+const (
+	methodSetAcl     int32 = 104
+	methodGetAcl     int32 = 105
+	methodDestroyAcl int32 = 106
+)
+
+// SecurityService contains the data for the service that performs tasks related to
+// security and access control
+type SecurityService struct {
+	drpc drpc.DomainSocketClient
+}
+
+// processDrpcReponse extracts the AclResponse from the drpc Response, and
+// checks for some basic formatting errors
+func (s *SecurityService) processDrpcResponse(drpcResp *drpc.Response) (*pb.AclResponse, error) {
+	if drpcResp == nil {
+		return nil, fmt.Errorf("dRPC returned no response")
+	}
+
+	if drpcResp.Status != drpc.Status_SUCCESS {
+		return nil, fmt.Errorf("bad dRPC response status: %v",
+			drpcResp.Status.String())
+	}
+
+	resp := &pb.AclResponse{}
+	err := proto.Unmarshal(drpcResp.Body, resp)
+	if err != nil {
+		return nil, fmt.Errorf("invalid dRPC response body: %v", err)
+	}
+
+	return resp, nil
+}
+
+// newDrpcCall creates a new drpc Call instance for the security module, with
+// the protobuf message marshalled in the body
+func (s *SecurityService) newDrpcCall(method int32, bodyMessage proto.Message) (*drpc.Call, error) {
+	bodyBytes, err := proto.Marshal(bodyMessage)
+	if err != nil {
+		return nil, err
+	}
+
+	return &drpc.Call{
+		Module: moduleID,
+		Method: method,
+		Body:   bodyBytes,
+	}, nil
+}
+
+// callDrpcMethodWithMessage opens a drpc connection, sends a message with the
+// protobuf message marshalled in the body, and closes the connection.
+func (s *SecurityService) callDrpcMethodWithMessage(method int32, body proto.Message) (*pb.AclResponse, error) {
+	drpcCall, err := s.newDrpcCall(method, body)
+	if err != nil {
+		return nil, err
+	}
+
+	// Forward the request to the I/O server via dRPC
+	err = s.drpc.Connect()
+	if err != nil {
+		return nil, err
+	}
+	defer s.drpc.Close()
+
+	drpcResp, err := s.drpc.SendMsg(drpcCall)
+	if err != nil {
+		return nil, err
+	}
+
+	return s.processDrpcResponse(drpcResp)
+}
+
+// SetPermissions sets the permissions for a given Access Control Entry, and creates
+// it if it doesn't already exist.
+func (s *SecurityService) SetPermissions(ctx context.Context, perms *pb.AclEntryPermissions) (*pb.AclResponse, error) {
+	if perms == nil {
+		return nil, fmt.Errorf("requested permissions were nil")
+	}
+
+	return s.callDrpcMethodWithMessage(methodSetAcl, perms)
+}
+
+// GetPermissions fetches the current permissions for a given Access Control Entry.
+func (s *SecurityService) GetPermissions(ctx context.Context, entry *pb.AclEntry) (*pb.AclResponse, error) {
+	if entry == nil {
+		return nil, fmt.Errorf("requested entry was nil")
+	}
+
+	return s.callDrpcMethodWithMessage(methodGetAcl, entry)
+}
+
+// DestroyAclEntry destroys the given Access Control Entry. The permissions for the
+// principal on that object will be inferred from the remaining entries.
+func (s *SecurityService) DestroyAclEntry(ctx context.Context, entry *pb.AclEntry) (*pb.AclResponse, error) {
+	if entry == nil {
+		return nil, fmt.Errorf("requested entry was nil")
+	}
+
+	return s.callDrpcMethodWithMessage(methodDestroyAcl, entry)
+}
+
+// newSecurityService creates and initializes a new security SecurityService instance
+func newSecurityService(client drpc.DomainSocketClient) *SecurityService {
+	return &SecurityService{
+		drpc: client,
+	}
+}

--- a/src/control/server/security_test.go
+++ b/src/control/server/security_test.go
@@ -1,0 +1,382 @@
+//
+// (C) Copyright 2019 Intel Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// GOVERNMENT LICENSE RIGHTS-OPEN SOURCE SOFTWARE
+// The Government's rights to use, modify, reproduce, release, perform, display,
+// or disclose this software are subject to the terms of the Apache License as
+// provided in Contract No. 8F-30005.
+// Any reproduction of computer software, computer software documentation, or
+// portions thereof marked with this legend must also reproduce the markings.
+//
+
+package main
+
+import (
+	"fmt"
+	"testing"
+
+	. "github.com/daos-stack/daos/src/control/common"
+	"github.com/daos-stack/daos/src/control/drpc"
+	pb "github.com/daos-stack/daos/src/control/security/proto"
+	"github.com/golang/protobuf/proto"
+)
+
+// mockDrpcClient is a mock of the DomainSocketClient interface
+type mockDrpcClient struct {
+	ConnectOutputError    error
+	CloseOutputError      error
+	CloseCallCount        int
+	SendMsgInputCall      *drpc.Call
+	SendMsgOutputResponse *drpc.Response
+	SendMsgOutputError    error
+}
+
+func (c *mockDrpcClient) IsConnected() bool {
+	return false
+}
+
+func (c *mockDrpcClient) Connect() error {
+	return c.ConnectOutputError
+}
+
+func (c *mockDrpcClient) Close() error {
+	c.CloseCallCount++
+	return c.CloseOutputError
+}
+
+func (c *mockDrpcClient) SendMsg(call *drpc.Call) (*drpc.Response, error) {
+	c.SendMsgInputCall = call
+	return c.SendMsgOutputResponse, c.SendMsgOutputError
+}
+
+func (c *mockDrpcClient) setSendMsgResponse(status drpc.Status, body []byte) {
+	c.SendMsgOutputResponse = &drpc.Response{
+		Status: status,
+		Body:   body,
+	}
+}
+
+func newMockDrpcClient() *mockDrpcClient {
+	return &mockDrpcClient{}
+}
+
+// newTestSecurityService sets up a new service with mocks
+func newTestSecurityService(client *mockDrpcClient) *SecurityService {
+	return &SecurityService{
+		drpc: client,
+	}
+}
+
+// newValidAclEntry sets up a valid-looking ACL Entry for testing
+func newValidAclEntry() *pb.AclEntry {
+	return &pb.AclEntry{
+		Type:     pb.AclEntryType_ALLOW,
+		Flags:    uint32(pb.AclFlags_GROUP),
+		Entity:   "12345678-1234-1234-1234-123456789ABC",
+		Identity: "group1",
+	}
+}
+
+// newValidAclEntryPermissions sets up valid-looking ACL Permissions for testing
+func newValidAclEntryPermissions() *pb.AclEntryPermissions {
+	return &pb.AclEntryPermissions{
+		PermissionBits: uint64(pb.AclPermissions_READ),
+		Entry:          newValidAclEntry(),
+	}
+}
+
+func aclResponseToBytes(resp *pb.AclResponse) []byte {
+	bytes, _ := proto.Marshal(resp)
+	return bytes
+}
+
+func TestNewSecurityService(t *testing.T) {
+	expectedClient := newMockDrpcClient()
+	service := newSecurityService(expectedClient)
+
+	AssertTrue(t, service != nil, "NewSecurityService returned nil")
+	AssertEqual(t, service.drpc, expectedClient, "Wrong dRPC client")
+}
+
+func TestSetPermissions_NilPermissions(t *testing.T) {
+	service := newTestSecurityService(newMockDrpcClient())
+
+	result, err := service.SetPermissions(nil, nil)
+
+	AssertEqual(t, result, (*pb.AclResponse)(nil), "Expected no response")
+	ExpectError(t, err, "requested permissions were nil",
+		"Should report bad input")
+}
+
+func expectAclResponse(t *testing.T, result *pb.AclResponse, err error,
+	expectedResp *pb.AclResponse) {
+	expectedPerms := expectedResp.Permissions
+
+	AssertTrue(t, err == nil, "Expected no error")
+	AssertTrue(t, result != nil, "Expected a response")
+	AssertEqual(t, result.Status, expectedResp.Status,
+		"Reponse status was wrong")
+	if expectedPerms == nil {
+		AssertEqual(t, result.Permissions,
+			(*pb.AclEntryPermissions)(nil),
+			"Permissions should be nil")
+	} else {
+		AssertEqual(t, result.Permissions.PermissionBits,
+			expectedPerms.PermissionBits,
+			"Permission bits were wrong")
+		AssertEqual(t, result.Permissions.Entry.Entity,
+			expectedPerms.Entry.Entity,
+			"UUID was wrong")
+		AssertEqual(t, result.Permissions.Entry.Type,
+			expectedPerms.Entry.Type, "Entry type was wrong")
+		AssertEqual(t, result.Permissions.Entry.Flags,
+			expectedPerms.Entry.Flags, "Entry flags were wrong")
+		AssertEqual(t, result.Permissions.Entry.Identity,
+			expectedPerms.Entry.Identity,
+			"Principal identity was wrong")
+	}
+
+}
+
+func expectDrpcCall(t *testing.T, client *mockDrpcClient,
+	expectedModuleId int32, expectedMethodId int32,
+	expectedCallBody []byte) {
+	AssertTrue(t, client.SendMsgInputCall != nil, "SendMsg called with nil")
+	AssertEqual(t, client.SendMsgInputCall.Module, expectedModuleId,
+		"Wrong dRPC module")
+	AssertEqual(t, client.SendMsgInputCall.Method, expectedMethodId,
+		"Wrong dRPC method")
+	AssertEqual(t, client.SendMsgInputCall.Body, expectedCallBody,
+		"dRPC call should have permissions request in body")
+}
+
+func TestSetPermissions_Success(t *testing.T) {
+	client := newMockDrpcClient()
+	service := newTestSecurityService(client)
+	perms := newValidAclEntryPermissions()
+	expectedResp := &pb.AclResponse{
+		Status:      pb.AclRequestStatus_SUCCESS,
+		Permissions: perms,
+	}
+	client.setSendMsgResponse(drpc.Status_SUCCESS,
+		aclResponseToBytes(expectedResp))
+
+	result, err := service.SetPermissions(nil, perms)
+
+	// Check the results
+	expectAclResponse(t, result, err, expectedResp)
+
+	// Check that the dRPC call was correct
+	expectedCallBody, _ := proto.Marshal(perms)
+	expectDrpcCall(t, client, moduleID, methodSetAcl, expectedCallBody)
+}
+
+func TestSetPermissions_SendMsgFailed(t *testing.T) {
+	client := newMockDrpcClient()
+	expectedError := "mock dRPC call failed"
+	client.SendMsgOutputError = fmt.Errorf(expectedError)
+	service := newTestSecurityService(client)
+
+	result, err := service.SetPermissions(nil,
+		newValidAclEntryPermissions())
+
+	AssertEqual(t, result, (*pb.AclResponse)(nil), "Expected no response")
+	ExpectError(t, err, expectedError, "Should pass up the dRPC call error")
+}
+
+func TestSetPermissions_SendMsgResponseStatusFailed(t *testing.T) {
+	client := newMockDrpcClient()
+	service := newTestSecurityService(client)
+	client.setSendMsgResponse(drpc.Status_FAILURE, nil)
+
+	result, err := service.SetPermissions(nil,
+		newValidAclEntryPermissions())
+
+	AssertEqual(t, result, (*pb.AclResponse)(nil), "Expected no response")
+	ExpectError(t, err, "bad dRPC response status: FAILURE",
+		"Should report dRPC call failed")
+}
+
+func TestSetPermissions_SendMsgResponseBodyInvalid(t *testing.T) {
+	client := newMockDrpcClient()
+	service := newTestSecurityService(client)
+	badResp := make([]byte, 256)
+	for i := 0; i < len(badResp); i++ {
+		badResp[i] = 0xFF
+	}
+	client.setSendMsgResponse(drpc.Status_SUCCESS, badResp)
+
+	result, err := service.SetPermissions(nil,
+		newValidAclEntryPermissions())
+
+	AssertEqual(t, result, (*pb.AclResponse)(nil), "Expected no response")
+	ExpectError(t, err, "invalid dRPC response body: unexpected EOF",
+		"Should report failed to unmarshal")
+}
+
+func TestSetPermissions_SendMsgResponseNil(t *testing.T) {
+	client := newMockDrpcClient()
+	service := newTestSecurityService(client)
+
+	result, err := service.SetPermissions(nil,
+		newValidAclEntryPermissions())
+
+	AssertEqual(t, result, (*pb.AclResponse)(nil), "Expected no response")
+	ExpectError(t, err, "dRPC returned no response",
+		"Should report nil response")
+}
+
+func TestSetPermissions_ConnectFailed(t *testing.T) {
+	client := newMockDrpcClient()
+	expectedError := "mock dRPC connect failed"
+	client.ConnectOutputError = fmt.Errorf(expectedError)
+	service := newTestSecurityService(client)
+
+	result, err := service.SetPermissions(nil,
+		newValidAclEntryPermissions())
+
+	AssertEqual(t, result, (*pb.AclResponse)(nil), "Expected no response")
+	ExpectError(t, err, expectedError, "Should pass up the dRPC call error")
+}
+
+func TestSetPermissions_CloseFailed(t *testing.T) {
+	client := newMockDrpcClient()
+	expectedError := "mock dRPC close failed"
+	client.CloseOutputError = fmt.Errorf(expectedError)
+	service := newTestSecurityService(client)
+	client.setSendMsgResponse(drpc.Status_SUCCESS,
+		aclResponseToBytes(&pb.AclResponse{}))
+
+	result, err := service.SetPermissions(nil,
+		newValidAclEntryPermissions())
+
+	// We ignore Close errors - not useful to us if we got a good message
+	AssertEqual(t, err, (error)(nil), "Expected no error")
+	AssertTrue(t, result != nil, "Expected the response")
+
+	// Make sure it was actually called
+	AssertEqual(t, client.CloseCallCount, 1, "Close should have been called")
+}
+
+func TestGetPermissions_NilEntry(t *testing.T) {
+	service := newTestSecurityService(newMockDrpcClient())
+
+	result, err := service.GetPermissions(nil, nil)
+
+	AssertEqual(t, result, (*pb.AclResponse)(nil), "Expected no response")
+	ExpectError(t, err, "requested entry was nil",
+		"Should detect invalid input")
+}
+
+func TestGetPermissions_Success(t *testing.T) {
+	client := newMockDrpcClient()
+	service := newTestSecurityService(client)
+	entry := newValidAclEntry()
+
+	expectedPerms := &pb.AclEntryPermissions{
+		Entry: entry,
+		PermissionBits: uint64(
+			pb.AclPermissions_READ | pb.AclPermissions_WRITE),
+	}
+	expectedResp := &pb.AclResponse{
+		Status:      pb.AclRequestStatus_SUCCESS,
+		Permissions: expectedPerms,
+	}
+	client.setSendMsgResponse(drpc.Status_SUCCESS,
+		aclResponseToBytes(expectedResp))
+
+	result, err := service.GetPermissions(nil, entry)
+
+	// Check the results
+	expectAclResponse(t, result, err, expectedResp)
+
+	// Check that the dRPC call was correct
+	expectedCallBody, _ := proto.Marshal(entry)
+	expectDrpcCall(t, client, moduleID, methodGetAcl, expectedCallBody)
+}
+
+func TestGetPermissions_SendMsgFailed(t *testing.T) {
+	client := newMockDrpcClient()
+	expectedError := "mock dRPC call failed"
+	client.SendMsgOutputError = fmt.Errorf(expectedError)
+	service := newTestSecurityService(client)
+
+	result, err := service.GetPermissions(nil, newValidAclEntry())
+
+	AssertEqual(t, result, (*pb.AclResponse)(nil), "Expected no response")
+	ExpectError(t, err, expectedError, "Should pass up the dRPC call error")
+}
+
+func TestGetPermissions_ConnectFailed(t *testing.T) {
+	client := newMockDrpcClient()
+	expectedError := "mock dRPC connect failed"
+	client.ConnectOutputError = fmt.Errorf(expectedError)
+	service := newTestSecurityService(client)
+
+	result, err := service.GetPermissions(nil, newValidAclEntry())
+
+	AssertEqual(t, result, (*pb.AclResponse)(nil), "Expected no response")
+	ExpectError(t, err, expectedError, "Should pass up the dRPC call error")
+}
+
+func TestGetPermissions_CloseFailed(t *testing.T) {
+	client := newMockDrpcClient()
+	expectedError := "mock dRPC close failed"
+	client.CloseOutputError = fmt.Errorf(expectedError)
+	service := newTestSecurityService(client)
+	client.setSendMsgResponse(drpc.Status_SUCCESS,
+		aclResponseToBytes(&pb.AclResponse{}))
+
+	result, err := service.GetPermissions(nil, newValidAclEntry())
+
+	// We ignore Close errors - not useful to us if we got a good message
+	AssertEqual(t, err, (error)(nil), "Expected no error")
+	AssertTrue(t, result != nil, "Expected the response")
+
+	// Make sure it was actually called
+	AssertEqual(t, client.CloseCallCount, 1, "Close should have been called")
+}
+
+func TestDestroyAclEntry_NilEntry(t *testing.T) {
+	service := newTestSecurityService(newMockDrpcClient())
+
+	result, err := service.DestroyAclEntry(nil, nil)
+
+	AssertEqual(t, result, (*pb.AclResponse)(nil), "Expected no response")
+	ExpectError(t, err, "requested entry was nil",
+		"Should detect invalid input")
+}
+
+func TestDestroyAclEntry_Success(t *testing.T) {
+	client := newMockDrpcClient()
+	service := newTestSecurityService(client)
+	entry := newValidAclEntry()
+
+	expectedResp := &pb.AclResponse{
+		Status:      pb.AclRequestStatus_SUCCESS,
+		Permissions: nil,
+	}
+	client.setSendMsgResponse(drpc.Status_SUCCESS,
+		aclResponseToBytes(expectedResp))
+
+	result, err := service.DestroyAclEntry(nil, entry)
+
+	// Check the results
+	expectAclResponse(t, result, err, expectedResp)
+
+	// Check that the dRPC call was correct
+	expectedCallBody, _ := proto.Marshal(entry)
+	expectDrpcCall(t, client, moduleID, methodDestroyAcl, expectedCallBody)
+}

--- a/src/include/daos/drpc.h
+++ b/src/include/daos/drpc.h
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright 2018 Intel Corporation.
+ * (C) Copyright 2018-2019 Intel Corporation.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -61,22 +61,6 @@ struct drpc {
 
 enum rpcflags {
 	R_SYNC = 1
-};
-
-/**
- * DAOS dRPC Modules
- *
- * dRPC modules are used to multiplex communications over the Unix Domain Socket
- * to appropriate handlers. They are populated in the Drpc__Call structure.
- *
- * dRPC module IDs must be unique. This is a list of all DAOS dRPC modules.
- */
-
-enum drpc_module {
-	DRPC_MODULE_TEST		= 0,	/* Reserved for testing */
-	DRPC_MODULE_SECURITY_AGENT	= 1,
-
-	NUM_DRPC_MODULES			/* Must be last */
 };
 
 int drpc_call(struct drpc *ctx, int flags, Drpc__Call *msg,

--- a/src/include/daos/drpc_modules.h
+++ b/src/include/daos/drpc_modules.h
@@ -1,0 +1,43 @@
+/*
+ * (C) Copyright 2019 Intel Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * GOVERNMENT LICENSE RIGHTS-OPEN SOURCE SOFTWARE
+ * The Government's rights to use, modify, reproduce, release, perform, display,
+ * or disclose this software are subject to the terms of the Apache License as
+ * provided in Contract No. 8F-30005.
+ * Any reproduction of computer software, computer software documentation, or
+ * portions thereof marked with this legend must also reproduce the markings.
+ */
+
+#ifndef __DAOS_DRPC_MODULES_H__
+#define __DAOS_DRPC_MODULES_H__
+
+/**
+ * DAOS dRPC Modules
+ *
+ * dRPC modules are used to multiplex communications over the Unix Domain Socket
+ * to appropriate handlers. They are populated in the Drpc__Call structure.
+ *
+ * dRPC module IDs must be unique. This is a list of all DAOS dRPC modules.
+ */
+
+enum drpc_module {
+	DRPC_MODULE_TEST		= 0,	/* Reserved for testing */
+	DRPC_MODULE_SECURITY_AGENT	= 1,
+
+	NUM_DRPC_MODULES			/* Must be last */
+};
+
+#endif /* __DAOS_DRPC_MODULES_H__ */

--- a/src/iosrv/drpc_handler.c
+++ b/src/iosrv/drpc_handler.c
@@ -22,6 +22,7 @@
  */
 
 #include "drpc_handler.h"
+#include <daos/drpc_modules.h>
 
 static drpc_handler_t *registry_table;
 

--- a/src/iosrv/tests/drpc_handler_tests.c
+++ b/src/iosrv/tests/drpc_handler_tests.c
@@ -31,7 +31,7 @@
 #include <cmocka.h>
 
 #include <daos/drpc.pb-c.h>
-#include <daos/drpc.h>
+#include <daos/drpc_modules.h>
 #include <daos/test_mocks.h>
 #include <daos/test_utils.h>
 #include "../drpc_handler.h"

--- a/src/security/cli_security.c
+++ b/src/security/cli_security.c
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright 2018 Intel Corporation.
+ * (C) Copyright 2018-2019 Intel Corporation.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,6 +26,7 @@
 #include <gurt/common.h>
 #include <daos_errno.h>
 #include <daos/drpc.h>
+#include <daos/drpc_modules.h>
 #include <daos/drpc.pb-c.h>
 #include <daos/agent.h>
 #include <daos/security.h>

--- a/src/security/tests/cli_security_tests.c
+++ b/src/security/tests/cli_security_tests.c
@@ -33,6 +33,7 @@
 #include <daos_errno.h>
 #include <daos/common.h>
 #include <daos/drpc.h>
+#include <daos/drpc_modules.h>
 #include <daos/drpc.pb-c.h>
 #include <daos/agent.h>
 #include <daos/security.h>

--- a/utils/run_test.sh
+++ b/utils/run_test.sh
@@ -82,7 +82,7 @@ if [ -d "/mnt/daos" ]; then
     run_test src/vos/tests/evt_ctl.sh pmem
     run_test build/src/vos/vea/tests/vea_ut
     run_test src/rdb/raft_tests/raft_tests.py
-    # Satisfy CGO Link requirements for go-spdk binding imports
+    # Satisfy CGO requirements for go-spdk binding and internal daos imports
     LD_LIBRARY_PATH="${SL_PREFIX}/lib:${SL_SPDK_PREFIX}/lib:${LD_LIBRARY_PATH}"
     export LD_LIBRARY_PATH
     export CGO_LDFLAGS="-L${SL_SPDK_PREFIX}/lib -L${SL_PREFIX}/lib"


### PR DESCRIPTION
This patch implements the server-side hooks for
gRPC calls to be sent from the shell to the
daos_server when an user wants to fetch or
update Access Control Lists. The methods are a
passthrough to a corresponding dRPC call to the
I/O server, which has access to the pool attributes
where the access control list will be stored.

- Implemented SetPermissions gRPC hook.
- Implemented GetPermissions gRPC hook.
- Implemented DestroyAclEntry gRPC hook.

Change-Id: I95a4f70fbd3a7db920809f40ddd3d73de6ee4ac3
Signed-off-by: Kris Jacque <kristin.jacque@intel.com>