### PR TITLE
DAOS-2031 metadata: add Pool/Container Properties API definitions

### DIFF
--- a/src/client/api/container.c
+++ b/src/client/api/container.c
@@ -40,7 +40,8 @@ daos_cont_global2local(daos_handle_t poh, daos_iov_t glob, daos_handle_t *coh)
 }
 
 int
-daos_cont_create(daos_handle_t poh, const uuid_t uuid, daos_event_t *ev)
+daos_cont_create(daos_handle_t poh, const uuid_t uuid, daos_prop_t *cont_prop,
+		 daos_event_t *ev)
 {
 	daos_cont_create_t	*args;
 	tse_task_t		*task;
@@ -126,7 +127,7 @@ daos_cont_destroy(daos_handle_t poh, const uuid_t uuid, int force,
 
 int
 daos_cont_query(daos_handle_t coh, daos_cont_info_t *info,
-		daos_event_t *ev)
+		daos_prop_t *cont_prop, daos_event_t *ev)
 {
 	daos_cont_query_t	*args;
 	tse_task_t		*task;

--- a/src/client/api/mgmt.c
+++ b/src/client/api/mgmt.c
@@ -95,7 +95,8 @@ int
 daos_pool_create(uint32_t mode, uid_t uid, gid_t gid, const char *grp,
 		 const d_rank_list_t *tgts, const char *dev,
 		 daos_size_t scm_size, daos_size_t nvme_size,
-		 d_rank_list_t *svc, uuid_t uuid, daos_event_t *ev)
+		 daos_prop_t *pool_prop, d_rank_list_t *svc,
+		 uuid_t uuid, daos_event_t *ev)
 {
 	daos_pool_create_t	*args;
 	tse_task_t		*task;

--- a/src/client/api/pool.c
+++ b/src/client/api/pool.c
@@ -84,8 +84,8 @@ daos_pool_global2local(daos_iov_t glob, daos_handle_t *poh)
 }
 
 int
-daos_pool_query(daos_handle_t poh, d_rank_list_t *tgts,
-		daos_pool_info_t *info, daos_event_t *ev)
+daos_pool_query(daos_handle_t poh, d_rank_list_t *tgts, daos_pool_info_t *info,
+		daos_prop_t *pool_prop, daos_event_t *ev)
 {
 	daos_pool_query_t	*args;
 	tse_task_t		*task;

--- a/src/client/dfs/dfs.c
+++ b/src/client/dfs/dfs.c
@@ -986,7 +986,7 @@ dfs_mount(daos_handle_t poh, daos_handle_t coh, int flags, dfs_t **_dfs)
 	if (rc != 0)
 		return rc;
 
-	rc = daos_pool_query(poh, NULL, &pool_info, NULL);
+	rc = daos_pool_query(poh, NULL, &pool_info, NULL, NULL);
 	if (rc) {
 		D_ERROR("daos_pool_query() Failed (%d)\n", rc);
 		D_GOTO(err_dfs, rc);

--- a/src/client/dfs/dfuse.c
+++ b/src/client/dfs/dfuse.c
@@ -1401,7 +1401,7 @@ int main(int argc, char *argv[])
 	if (rc == -DER_NONEXIST) {
 		if (dfuse_fs.debug)
 			fprintf(stderr, "Cont does not exist, creating..\n");
-		rc = daos_cont_create(poh, co_uuid, NULL);
+		rc = daos_cont_create(poh, co_uuid, NULL, NULL);
 		if (rc == 0) {
 			cont_created = true;
 			rc = daos_cont_open(poh, co_uuid, DAOS_COO_RW, &coh,

--- a/src/include/daos_api.h
+++ b/src/include/daos_api.h
@@ -179,6 +179,20 @@ daos_cont_global2local(daos_handle_t poh, daos_iov_t glob, daos_handle_t *coh);
  * \param[in]	poh	Pool connection handle.
  * \param[out]	tgts	Optional, returned storage targets in this pool.
  * \param[out]	info	Optional, returned pool information.
+ * \param[out]	pool_prop
+ *			Optional, returned pool properties.
+ *			If it is NULL, then needs not query the properties.
+ *			If pool_prop is non-NULL but its dpp_entries is NULL,
+ *			will query all pool properties, DAOS internally
+ *			allocates the needed buffers and assign pointer to
+ *			dpp_entries.
+ *			If pool_prop's dpp_nr > 0 and dpp_entries is non-NULL,
+ *			will query the properties for specific dpe_type(s), DAOS
+ *			internally allocates the needed buffer for dpe_str or
+ *			dpe_val_ptr, if the dpe_type with immediate value then
+ *			will directly assign it to dpe_val.
+ *			User can free the associated buffer by calling
+ *			daos_prop_free().
  * \param[in]	ev	Completion event, it is optional and can be NULL.
  *			The function will run in blocking mode if \a ev is NULL.
  *
@@ -190,8 +204,8 @@ daos_cont_global2local(daos_handle_t poh, daos_iov_t glob, daos_handle_t *coh);
  *			-DER_NO_HDL	Invalid pool handle
  */
 int
-daos_pool_query(daos_handle_t poh, d_rank_list_t *tgts,
-		daos_pool_info_t *info, daos_event_t *ev);
+daos_pool_query(daos_handle_t poh, d_rank_list_t *tgts, daos_pool_info_t *info,
+		daos_prop_t *pool_prop, daos_event_t *ev);
 
 /**
  * Query information of storage targets within a DAOS pool.
@@ -288,6 +302,8 @@ daos_pool_set_attr(daos_handle_t poh, int n, char const *const names[],
  *
  * \param[in]	poh	Pool connection handle.
  * \param[in]	uuid	UUID of the new Container.
+ * \param[in]	cont_prop
+ *			Optional, container properties pointer
  * \param[in]	ev	Completion event, it is optional and can be NULL.
  *			The function will run in blocking mode if \a ev is NULL.
  *
@@ -300,7 +316,8 @@ daos_pool_set_attr(daos_handle_t poh, int n, char const *const names[],
  *			-DER_UNREACH	network is unreachable
  */
 int
-daos_cont_create(daos_handle_t poh, const uuid_t uuid, daos_event_t *ev);
+daos_cont_create(daos_handle_t poh, const uuid_t uuid, daos_prop_t *cont_prop,
+		 daos_event_t *ev);
 
 /**
  * Open an existing container identified by UUID \a uuid. Upon successful
@@ -384,6 +401,20 @@ daos_cont_destroy(daos_handle_t poh, const uuid_t uuid, int force,
  *			snapshots will be stored in it.
  *			If \a info::ci_snapshots is NULL, number of snapshots
  *			will be returned by \a info::ci_nsnapshots.
+ * \param[out]	cont_prop
+ *			Optional, returned container properties
+ *			If it is NULL, then needs not query the properties.
+ *			If cont_prop is non-NULL but its dpp_entries is NULL,
+ *			will query all pool properties, DAOS internally
+ *			allocates the needed buffers and assign pointer to
+ *			dpp_entries.
+ *			If cont_prop's dpp_nr > 0 and dpp_entries is non-NULL,
+ *			will query the properties for specific dpe_type(s), DAOS
+ *			internally allocates the needed buffer for dpe_str or
+ *			dpe_val_ptr, if the dpe_type with immediate value then
+ *			will directly assign it to dpe_val.
+ *			User can free the associated buffer by calling
+ *			daos_prop_free().
  * \param[in]	ev	Completion event, it is optional and can be NULL.
  *			The function will run in blocking mode if \a ev is NULL.
  *
@@ -396,7 +427,7 @@ daos_cont_destroy(daos_handle_t poh, const uuid_t uuid, int force,
  */
 int
 daos_cont_query(daos_handle_t container, daos_cont_info_t *info,
-		daos_event_t *ev);
+		daos_prop_t *cont_prop, daos_event_t *ev);
 
 /**
  * List the names of all user-defined container attributes.

--- a/src/include/daos_mgmt.h
+++ b/src/include/daos_mgmt.h
@@ -59,6 +59,7 @@ extern "C" {
  *			consume) in bytes. Passing 0 will use the minimal
  *			supported target size.
  * \param nvme_size[IN]	Target NVMe (Non-Volatile Memory express) size in bytes.
+ * \param pool_prop[IN]	Optional, pool properties.
  * \param svc	[IN]	Number of desired pool service replicas. Callers must
  *			speicfy svc->rl_nr and allocate a matching
  *			svc->rl_ranks; svc->rl_nr and svc->rl_ranks
@@ -76,7 +77,8 @@ int
 daos_pool_create(uint32_t mode, uid_t uid, gid_t gid, const char *grp,
 		 const d_rank_list_t *tgts, const char *dev,
 		 daos_size_t scm_size, daos_size_t nvme_size,
-		 d_rank_list_t *svc, uuid_t uuid, daos_event_t *ev);
+		 daos_prop_t *pool_prop, d_rank_list_t *svc, uuid_t uuid,
+		 daos_event_t *ev);
 
 /**
  * Destroy a pool with \a uuid. If there is at least one connection to this

--- a/src/include/daos_types.h
+++ b/src/include/daos_types.h
@@ -779,7 +779,198 @@ typedef enum {
 	DAOS_EVS_ABORTED,
 } daos_ev_status_t;
 
-struct daos_eq;
+/**
+ * DAOS pool property types
+ * valid in range (DAOS_PROP_PO_MIN, DAOS_PROP_PO_MAX)
+ */
+enum daos_pool_prop_type {
+	DAOS_PROP_PO_MIN = 0,
+	/**
+	 * Label - a string that a user can associated with a pool.
+	 * default = ""
+	 */
+	DAOS_PROP_PO_LABEL,
+	/**
+	 * ACL: access control list for pool
+	 * A list of uid/gid that can access the pool RO
+	 * A list of uid/gid that can access the pool RW
+	 * default RW gid = gid of pool create invoker
+	 */
+	DAOS_PROP_PO_ACL,
+	/**
+	 * Reserve space ratio: amount of space to be reserved on each target
+	 * for rebuild purpose. default = 0%.
+	 */
+	DAOS_PROP_PO_SPACE_RB,
+	/**
+	 * Automatic/manual self-healing. default = auto
+	 * auto/manual exclusion
+	 * auto/manual rebuild
+	 */
+	DAOS_PROP_PO_SELF_HEAL,
+	/**
+	 * Space reclaim strategy = time|batched|snapshot. default = snapshot
+	 * time interval
+	 * batched commits
+	 * snapshot creation
+	 */
+	DAOS_PROP_PO_RECLAIM,
+	DAOS_PROP_PO_MAX,
+};
+
+/** DAOS space reclaim strategy */
+enum {
+	DAOS_RECLAIM_SNAPSHOT,
+	DAOS_RECLAIM_BATCH,
+	DAOS_RECLAIM_TIME,
+};
+
+/** bits of ae_tag entry in struct daos_acl_entry */
+/** access rights for the pool/container/obj's owner */
+#define DAOS_ACL_USER_OBJ	(1U << 0)
+/** access rights for user identified by the entry's ae_id */
+#define DAOS_ACL_USER		(1U << 1)
+/** access rights for the pool/container/obj's group */
+#define DAOS_ACL_GROUP_OBJ	(1U << 2)
+/** access rights for group identified by the entry's ae_id */
+#define DAOS_ACL_GROUP		(1U << 3)
+/**
+ * the maximum access rights that can be granted by entries of ae_tag
+ * DAOS_ACL_USER, DAOS_ACL_GROUP_OBJ, or DAOS_ACL_GROUP.
+ */
+#define DAOS_ACL_MASK		(1U << 4)
+/** access rights for processes that do not match any other entry in the ACL */
+#define DAOS_ACL_OTHER		(1U << 5)
+
+struct daos_acl_entry {
+	/** DAOS_ACL_USER/GROUP/MASK/OTHER */
+	uint16_t	ae_tag;
+	/** permissions DAOS_PC_RO/RW */
+	uint16_t	ae_perm;
+	/** uid or gid, meaningful only when ae_tag is DAOS_ACL_USER/GROUP */
+	uint32_t	ae_id;
+};
+
+struct daos_acl {
+	/** number of acl entries */
+	uint32_t		 da_nr;
+	/** reserved for future usage (for 64 bits alignment now) */
+	uint32_t		 da_rsv;
+	/** acl entries array */
+	struct daos_acl_entry	*da_entries;
+};
+
+/**
+ * DAOS container property types
+ * valid in rage (DAOS_PROP_CO_MIN, DAOS_PROP_CO_MAX).
+ */
+enum daos_cont_prop_type {
+	DAOS_PROP_CO_MIN = 0x1000,
+	/**
+	 * Label - a string that a user can associated with a container.
+	 * default = ""
+	 */
+	DAOS_PROP_CO_LABEL,
+	/**
+	 * Layout type: unknown, POSIX, MPI-IO, HDF5, Apache Arrow, ...
+	 * default value = DAOS_PROP_CO_LAYOUT_UNKOWN
+	 */
+	DAOS_PROP_CO_LAYOUT_TYPE,
+	/**
+	 * Layout version: specific to middleware for interop.
+	 * default = 1
+	 */
+	DAOS_PROP_CO_LAYOUT_VER,
+	/**
+	 * Checksum on/off + checksum type (CRC16, CRC32, SHA-1 & SHA-2).
+	 * default = DAOS_PROP_CO_CSUM_OFF
+	 */
+	DAOS_PROP_CO_CHECKSUM,
+	/**
+	 * Redundancy factor:
+	 * RF1: no data protection. scratched data.
+	 * RF3: 3-way replication, EC 4+2, 8+2, 16+2
+	 * default = RF1 (DAOS_PROP_CO_REDUN_RF1)
+	 */
+	DAOS_PROP_CO_REDUN_FAC,
+	/**
+	 * Redundancy level: default fault domain level for placement.
+	 * default = rack (DAOS_PROP_CO_REDUN_RACK)
+	 */
+	DAOS_PROP_CO_REDUN_LVL,
+	/**
+	 * Maximum number of snapshots to retain.
+	 */
+	DAOS_PROP_CO_SNAPSHOT_MAX,
+	/** ACL: access control list for container */
+	DAOS_PROP_CO_ACL,
+	/** Compression on/off + compression type */
+	DAOS_PROP_CO_COMPRESS,
+	/** Encryption on/off + encryption type */
+	DAOS_PROP_CO_ENCRYP,
+	DAOS_PROP_CO_MAX,
+};
+
+/** container layout type */
+enum {
+	DAOS_PROP_CO_LAYOUT_UNKOWN,
+	DAOS_PROP_CO_LAYOUT_POSIX,
+	DAOS_PROP_CO_LAYOUT_MPIIO,
+	DAOS_PROP_CO_LAYOUT_HDF5,
+	DAOS_PROP_CO_LAYOUT_ARROW,
+};
+
+/** container checksum type */
+enum {
+	DAOS_PROP_CO_CSUM_OFF,
+	DAOS_PROP_CO_CSUM_CRC16,
+	DAOS_PROP_CO_CSUM_CRC32,
+	DAOS_PROP_CO_CSUM_SHA1,
+	DAOS_PROP_CO_CSUM_SHA2,
+};
+
+/** container compress type */
+enum {
+	DAOS_PROP_CO_COMPRESS_OFF,
+};
+
+/** container encryption type */
+enum {
+	DAOS_PROP_CO_ENCRYP_OFF,
+};
+
+/** container redundancy factor */
+enum {
+	DAOS_PROP_CO_REDUN_RF1,
+	DAOS_PROP_CO_REDUN_RF3,
+};
+
+enum {
+	DAOS_PROP_CO_REDUN_RACK,
+	DAOS_PROP_CO_REDUN_NODE,
+};
+
+struct daos_prop_entry {
+	/** property type, see enum daos_pool_prop_type/daos_cont_prop_type */
+	uint32_t		 dpe_type;
+	/** reserved for future usage (for 64 bits alignment now) */
+	uint32_t		 dpe_rsv;
+	/**
+	 * value can be either a uint64_t, or a string, or any other type
+	 * data such as the struct daos_acl pointer.
+	 */
+	union {
+		uint64_t	 dpe_val;
+		d_string_t	 dpe_str;
+		void		*dpe_val_ptr;
+	};
+};
+
+/** daos properties, for pool or container */
+typedef struct {
+	uint32_t		 dpp_nr;
+	struct daos_prop_entry	*dpp_entries;
+} daos_prop_t;
 
 #if defined(__cplusplus)
 }

--- a/src/tests/daos_perf.c
+++ b/src/tests/daos_perf.c
@@ -657,7 +657,7 @@ ts_rebuild_wait()
 
 	while (1) {
 		memset(&pinfo, 0, sizeof(pinfo));
-		rc = daos_pool_query(ts_ctx.tsc_poh, NULL, &pinfo, NULL);
+		rc = daos_pool_query(ts_ctx.tsc_poh, NULL, &pinfo, NULL, NULL);
 		if (rst->rs_done || rc != 0) {
 			fprintf(stderr, "Rebuild (ver=%d) is done %d/%d\n",
 				rst->rs_version, rc, rst->rs_errno);

--- a/src/tests/daosbench.c
+++ b/src/tests/daosbench.c
@@ -317,7 +317,7 @@ kill_daos_server(const char *grp)
 	d_rank_list_t		targets;
 	int				rc;
 
-	rc = daos_pool_query(poh, NULL, &info, NULL);
+	rc = daos_pool_query(poh, NULL, &info, NULL, NULL);
 	DBENCH_CHECK(rc, "Error in querying pool\n");
 
 	if (info.pi_ntargets - info.pi_ndisabled <= 1)
@@ -339,7 +339,7 @@ kill_daos_server(const char *grp)
 	DBENCH_CHECK(rc, "Error in excluding pool from poolmap\n");
 
 	memset(&info, 0, sizeof(daos_pool_info_t));
-	rc = daos_pool_query(poh, NULL, &info, NULL);
+	rc = daos_pool_query(poh, NULL, &info, NULL, NULL);
 	DBENCH_CHECK(rc, "Error in query pool\n");
 
 	printf("Target Rank: %d Killed successfully, (%d targets disabled)\n\n",
@@ -704,7 +704,7 @@ container_open(int rank, char *uuid_str, int create)
 		}
 
 		if (create) {
-			rc = daos_cont_create(poh, cont_uuid, NULL);
+			rc = daos_cont_create(poh, cont_uuid, NULL, NULL);
 			DBENCH_CHECK(rc, "Container create failed\n");
 		}
 

--- a/src/tests/daosctl/cont-cmds.c
+++ b/src/tests/daosctl/cont-cmds.c
@@ -163,7 +163,7 @@ cmd_create_container(int argc, const char **argv, void *ctx)
 			goto done;
 	}
 
-	rc = daos_cont_create(poh, cont_uuid, NULL);
+	rc = daos_cont_create(poh, cont_uuid, NULL, NULL);
 
 	if (rc) {
 		printf("Container create fail, result: %d\n", rc);
@@ -324,7 +324,7 @@ cmd_query_container(int argc, const char **argv, void *ctx)
 		goto done2;
 	}
 
-	rc = daos_cont_query(coh, &cont_info, NULL);
+	rc = daos_cont_query(coh, &cont_info, NULL, NULL);
 
 	if (rc) {
 		printf("Container query failed, result: %d\n", rc);

--- a/src/tests/daosctl/pool-cmds.c
+++ b/src/tests/daosctl/pool-cmds.c
@@ -181,7 +181,7 @@ cmd_create_pool(int argc, const char **argv, void *ctx)
 
 	rc = daos_pool_create(cp_options.mode, cp_options.uid,
 			      cp_options.gid, cp_options.server_group,
-			      NULL, "rubbish", cp_options.size, 0, &svc,
+			      NULL, "rubbish", cp_options.size, 0, NULL, &svc,
 			      uuid, NULL);
 
 	if (rc) {

--- a/src/tests/daosctl/test-pool.c
+++ b/src/tests/daosctl/test-pool.c
@@ -194,7 +194,7 @@ cmd_connect_pool(int argc, const char **argv, void *ctx)
 
 	daos_pool_info_t pool_info;
 
-	rc = daos_pool_query(poh, NULL, &pool_info, NULL);
+	rc = daos_pool_query(poh, NULL, &pool_info, NULL, NULL);
 
 	/* TODO not ready for this test yet */
 	/* the info returned by connect should match query */
@@ -284,9 +284,9 @@ cmd_test_connect_pool(int argc, const char **argv, void *ctx)
 		/* TODO do a better job with failure return */
 		return rc;
 
-	rc = daos_pool_create(cp_options.mode,
-			cp_options.uid, cp_options.gid, cp_options.server_group,
-			      NULL, "rubbish", cp_options.size, 0,
+	rc = daos_pool_create(cp_options.mode, cp_options.uid, cp_options.gid,
+			      cp_options.server_group, NULL, "rubbish",
+			      cp_options.size, 0, NULL,
 			      &pool_service_list, uuid, NULL);
 	if (rc) {
 		printf("<<<daosctl>>> Pool create fail, result: %d\n", rc);
@@ -317,7 +317,7 @@ cmd_test_connect_pool(int argc, const char **argv, void *ctx)
 	} else {
 		daos_pool_info_t pool_info;
 
-		rc = daos_pool_query(poh, NULL, &pool_info, NULL);
+		rc = daos_pool_query(poh, NULL, &pool_info, NULL, NULL);
 
 		/* TODO not ready for this test yet */
 		/* the info returned by connect should match query */
@@ -419,8 +419,8 @@ cmd_test_create_pool(int argc, const char **argv, void *ctx)
 
 	rc = daos_pool_create(cp_options.mode, cp_options.uid, cp_options.gid,
 			      cp_options.server_group, NULL, "rubbish",
-			      cp_options.size, 0, &pool_service_list, uuid,
-			      NULL);
+			      cp_options.size, 0, NULL, &pool_service_list,
+			      uuid, NULL);
 	if (rc) {
 		printf("<<<daosctl>>> Pool create fail, result: %d\n", rc);
 	} else {
@@ -499,9 +499,9 @@ cmd_test_evict_pool(int argc, const char **argv, void *ctx)
 			     &pool_service_list);
 
 	rc = daos_pool_create(ep_options.mode, ep_options.uid, ep_options.gid,
-			      ep_options.server_group,
-			      NULL, "rubbish", ep_options.size, 0,
-			      &pool_service_list, uuid, NULL);
+			      ep_options.server_group, NULL, "rubbish",
+			      ep_options.size, 0, NULL, &pool_service_list,
+			      uuid, NULL);
 	if (rc) {
 		printf("<<<daosctl>>> Pool create fail, result: %d\n", rc);
 	} else {
@@ -532,7 +532,7 @@ cmd_test_evict_pool(int argc, const char **argv, void *ctx)
 	} else {
 		daos_pool_info_t pool_info;
 
-		rc = daos_pool_query(poh, NULL, &pool_info, NULL);
+		rc = daos_pool_query(poh, NULL, &pool_info, NULL, NULL);
 
 		/* TODO not ready for this test yet */
 		/* the info returned by connect should match query */
@@ -556,7 +556,7 @@ cmd_test_evict_pool(int argc, const char **argv, void *ctx)
 		/* connection should be invalid, test by running
 		 * a query
 		 */
-		rc = daos_pool_query(poh, NULL, &pool_info, NULL);
+		rc = daos_pool_query(poh, NULL, &pool_info, NULL, NULL);
 		if (!rc) {
 			printf("npool connection used successfully, "
 			       "but it should be invalid.\n");
@@ -609,7 +609,7 @@ cmd_test_query_pool(int argc, const char **argv, void *ctx)
 	 */
 	poh.cookie = strtoull(qp_options.handle, NULL, 10);
 
-	rc = daos_pool_query(poh, NULL, &pool_info, NULL);
+	rc = daos_pool_query(poh, NULL, &pool_info, NULL, NULL);
 
 	return rc;
 }

--- a/src/tests/dts_common.c
+++ b/src/tests/dts_common.c
@@ -229,7 +229,7 @@ pool_init(struct dts_context *tsc)
 		rc = daos_pool_create(0731, geteuid(), getegid(),
 				      NULL, NULL, "pmem",
 				      tsc->tsc_scm_size, tsc->tsc_nvme_size,
-				      svc, tsc->tsc_pool_uuid, NULL);
+				      NULL, svc, tsc->tsc_pool_uuid, NULL);
 		if (rc)
 			goto bcast;
 
@@ -291,7 +291,8 @@ cont_init(struct dts_context *tsc)
 			goto out;
 
 	} else if (tsc->tsc_mpi_rank == 0) { /* DAOS mode and rank zero */
-		rc = daos_cont_create(tsc->tsc_poh, tsc->tsc_cont_uuid, NULL);
+		rc = daos_cont_create(tsc->tsc_poh, tsc->tsc_cont_uuid, NULL,
+				      NULL);
 		if (rc != 0)
 			goto bcast;
 

--- a/src/tests/simple_array.c
+++ b/src/tests/simple_array.c
@@ -151,6 +151,7 @@ pool_create(void)
 			      NULL /* storage type to use, use default */,
 			      10ULL << 30 /* target SCM size, 10G */,
 			      40ULL << 30 /* target NVMe size, 40G */,
+			      NULL, /* pool properties */
 			      &svcl /* pool service nodes, used for connect */,
 			      pool_uuid, /* the uuid of the pool created */
 			      NULL /* event, use blocking call for now */);
@@ -504,7 +505,8 @@ main(int argc, char **argv)
 		uuid_generate(co_uuid);
 
 		/** create container */
-		rc = daos_cont_create(poh, co_uuid, NULL /* event */);
+		rc = daos_cont_create(poh, co_uuid, NULL /* properties */,
+				      NULL /* event */);
 		ASSERT(rc == 0, "container create failed with %d", rc);
 
 		/** open container */

--- a/src/tests/suite/daos_capa.c
+++ b/src/tests/suite/daos_capa.c
@@ -76,7 +76,7 @@ query(void **state)
 
 	/** query pool info with valid handle */
 	print_message("querying pool with valid handle ...\n");
-	rc = daos_pool_query(poh, NULL, &info, NULL);
+	rc = daos_pool_query(poh, NULL, &info, NULL, NULL);
 	assert_int_equal(rc, 0);
 
 	/** invalidate local pool handle */
@@ -84,7 +84,7 @@ query(void **state)
 
 	/** query pool info with invalid handle */
 	print_message("querying pool with invalid handle ...\n");
-	rc = daos_pool_query(poh, NULL, &info, NULL);
+	rc = daos_pool_query(poh, NULL, &info, NULL, NULL);
 	assert_int_equal(rc, -DER_NO_HDL);
 
 	/** close local handle */
@@ -114,7 +114,7 @@ create(void **state)
 	/** create container with read-only handle */
 	print_message("creating container with read-only pool handle ...\n");
 	uuid_generate(uuid);
-	rc = daos_cont_create(poh, uuid, NULL);
+	rc = daos_cont_create(poh, uuid, NULL, NULL);
 	assert_int_equal(rc, -DER_NO_PERM);
 
 	/** close local RO handle */
@@ -134,7 +134,7 @@ create(void **state)
 	/** create container with invalid handle */
 	print_message("creating container with stale pool handle ...\n");
 	uuid_generate(uuid);
-	rc = daos_cont_create(poh, uuid, NULL);
+	rc = daos_cont_create(poh, uuid, NULL, NULL);
 	assert_int_equal(rc, -DER_NO_HDL);
 
 	/** close local handle */
@@ -163,7 +163,7 @@ destroy(void **state)
 
 	/** create container */
 	uuid_generate(uuid);
-	rc = daos_cont_create(poh, uuid, NULL);
+	rc = daos_cont_create(poh, uuid, NULL, NULL);
 	assert_int_equal(rc, 0);
 
 	/** invalidate local pool handle */

--- a/src/tests/suite/daos_container.c
+++ b/src/tests/suite/daos_container.c
@@ -54,7 +54,7 @@ co_create(void **state)
 	if (arg->myrank == 0) {
 		print_message("creating container %ssynchronously ...\n",
 			      arg->async ? "a" : "");
-		rc = daos_cont_create(arg->pool.poh, uuid,
+		rc = daos_cont_create(arg->pool.poh, uuid, NULL,
 				      arg->async ? &ev : NULL);
 		assert_int_equal(rc, 0);
 		WAIT_ON_ASYNC(arg, ev);

--- a/src/tests/suite/daos_degraded.c
+++ b/src/tests/suite/daos_degraded.c
@@ -89,7 +89,7 @@ insert_lookup_enum_with_ops(test_arg_t *arg, int op_kill)
 	}
 
 	MPI_Barrier(MPI_COMM_WORLD);
-	rc = daos_pool_query(arg->pool.poh, NULL, &info, NULL);
+	rc = daos_pool_query(arg->pool.poh, NULL, &info, NULL, NULL);
 	assert_int_equal(rc, 0);
 	if (info.pi_ntargets - info.pi_ndisabled < 2) {
 		if (rank == 0)

--- a/src/tests/suite/daos_epoch.c
+++ b/src/tests/suite/daos_epoch.c
@@ -116,7 +116,7 @@ cont_create(test_arg_t *arg, uuid_t uuid)
 {
 	uuid_generate(uuid);
 	print_message("creating container "DF_UUIDF"\n", DP_UUID(uuid));
-	return daos_cont_create(arg->pool.poh, uuid, NULL);
+	return daos_cont_create(arg->pool.poh, uuid, NULL, NULL);
 }
 
 static int
@@ -147,7 +147,7 @@ static int
 cont_query(test_arg_t *arg, daos_handle_t coh, daos_cont_info_t *info)
 {
 	print_message(".");
-	return daos_cont_query(coh, info, NULL);
+	return daos_cont_query(coh, info, NULL, NULL);
 }
 
 static void

--- a/src/tests/suite/daos_epoch_io.c
+++ b/src/tests/suite/daos_epoch_io.c
@@ -345,7 +345,7 @@ daos_test_cb_query(test_arg_t *arg, struct test_op_record *op,
 	daos_pool_info_t pinfo = { 0 };
 	int rc;
 
-	rc = daos_pool_query(arg->pool.poh, NULL, &pinfo, NULL);
+	rc = daos_pool_query(arg->pool.poh, NULL, &pinfo, NULL, NULL);
 	if (rc != 0)
 		print_message("pool query failed %d\n", rc);
 

--- a/src/tests/suite/daos_epoch_recovery.c
+++ b/src/tests/suite/daos_epoch_recovery.c
@@ -120,7 +120,8 @@ epoch_recovery(test_arg_t *arg, enum epoch_recovery_op op)
 	uuid_generate(uuid);
 	print_message("creating and opening container "DF_UUIDF"\n",
 		      DP_UUID(uuid));
-	rc = daos_cont_create(arg->pool.poh, uuid, NULL /* ev */);
+	rc = daos_cont_create(arg->pool.poh, uuid, NULL /* properties */,
+			      NULL /* ev */);
 	assert_int_equal(rc, 0);
 	rc = daos_cont_open(arg->pool.poh, uuid, DAOS_COO_RW, &coh,
 			    NULL /* info */, NULL /* ev */);

--- a/src/tests/suite/daos_md_replication.c
+++ b/src/tests/suite/daos_md_replication.c
@@ -42,7 +42,7 @@ mdr_stop_pool_svc(void **argv)
 	if (arg->myrank == 0) {
 		print_message("creating pool\n");
 		rc = daos_pool_create(0731, geteuid(), getegid(), arg->group,
-				      NULL, "pmem", 128*1024*1024, 0,
+				      NULL, "pmem", 128*1024*1024, 0, NULL,
 				      &arg->pool.svc, uuid, NULL);
 	}
 	MPI_Bcast(&rc, 1, MPI_INT, 0, MPI_COMM_WORLD);
@@ -85,6 +85,7 @@ mdr_stop_pool_svc(void **argv)
 		print_message("querying pool info\n");
 		memset(&info, 'D', sizeof(info));
 		rc = daos_pool_query(poh, NULL /* tgts */, &info,
+				     NULL /* properties */,
 				     NULL /* ev */);
 		assert_int_equal(rc, 0);
 	} else {
@@ -96,6 +97,7 @@ mdr_stop_pool_svc(void **argv)
 		for (i = 0; i < n; i++) {
 			memset(&info, 'D', sizeof(info));
 			rc = daos_pool_query(poh, NULL /* tgts */, &info,
+					     NULL /* properties */,
 					     NULL /* ev */);
 			assert_int_equal(rc, 0);
 		}
@@ -133,7 +135,7 @@ mdr_stop_cont_svc(void **argv)
 
 	print_message("creating pool\n");
 	rc = daos_pool_create(0731, geteuid(), getegid(), arg->group, NULL,
-			      "pmem", 128*1024*1024, 0, &arg->pool.svc,
+			      "pmem", 128*1024*1024, 0, NULL, &arg->pool.svc,
 			      pool_uuid, NULL);
 	assert_int_equal(rc, 0);
 
@@ -150,7 +152,7 @@ mdr_stop_cont_svc(void **argv)
 	assert_int_equal(rc, 0);
 	print_message("creating container\n");
 	uuid_generate(uuid);
-	rc = daos_cont_create(poh, uuid, NULL);
+	rc = daos_cont_create(poh, uuid, NULL, NULL);
 	assert_int_equal(rc, 0);
 	print_message("opening container\n");
 	rc = daos_cont_open(poh, uuid, DAOS_COO_RW, &coh, NULL, NULL);

--- a/src/tests/suite/daos_mgmt.c
+++ b/src/tests/suite/daos_mgmt.c
@@ -58,8 +58,8 @@ pool_create_all(void **state)
 	rc = daos_pool_create(0700 /* mode */, 0 /* uid */, 0 /* gid */,
 			      arg->group, NULL /* tgts */, "pmem" /* dev */,
 			      0 /* minimal size */, 0 /* nvme size */,
-			      &arg->pool.svc /* svc */, uuid,
-			      arg->async ? &ev : NULL);
+			      NULL /* properties */, &arg->pool.svc /* svc */,
+			      uuid, arg->async ? &ev : NULL);
 	assert_int_equal(rc, 0);
 
 	if (arg->async) {

--- a/src/tests/suite/daos_obj.c
+++ b/src/tests/suite/daos_obj.c
@@ -2796,7 +2796,7 @@ fetch_replica_unavail(void **state)
 
 	if (arg->myrank == 0) {
 		/** disable rebuild */
-		rc = daos_pool_query(arg->pool.poh, NULL, &info, NULL);
+		rc = daos_pool_query(arg->pool.poh, NULL, &info, NULL, NULL);
 		assert_int_equal(rc, 0);
 		rc = daos_mgmt_set_params(arg->group, info.pi_leader,
 			DSS_KEY_FAIL_LOC,

--- a/src/tests/suite/daos_oid_alloc.c
+++ b/src/tests/suite/daos_oid_alloc.c
@@ -113,7 +113,7 @@ multi_cont_oid_allocator(void **state)
 
 		uuid_clear(co_uuid);
 		uuid_generate(co_uuid);
-		rc = daos_cont_create(arg->pool.poh, co_uuid, NULL);
+		rc = daos_cont_create(arg->pool.poh, co_uuid, NULL, NULL);
 		if (rc) {
 			print_message("Cont create failed\n");
 			goto verify_rc;
@@ -247,7 +247,8 @@ oid_allocator_checker(void **state)
 			daos_pool_info_t info;
 
 			MPI_Barrier(MPI_COMM_WORLD);
-			rc = daos_pool_query(arg->pool.poh, NULL, &info, NULL);
+			rc = daos_pool_query(arg->pool.poh, NULL, &info, NULL,
+					     NULL);
 			assert_int_equal(rc, 0);
 			if (info.pi_ntargets - info.pi_ndisabled >= 2) {
 				if (arg->myrank == 0)

--- a/src/tests/suite/daos_pool.c
+++ b/src/tests/suite/daos_pool.c
@@ -85,7 +85,7 @@ pool_connect(void **state)
 
 		print_message("rank 0 querying pool info... ");
 		memset(&info, 'D', sizeof(info));
-		rc = daos_pool_query(poh, NULL /* tgts */, &info,
+		rc = daos_pool_query(poh, NULL /* tgts */, &info, NULL,
 				     arg->async ? &ev : NULL /* ev */);
 		assert_int_equal(rc, 0);
 		WAIT_ON_ASYNC(arg, ev);
@@ -216,7 +216,7 @@ pool_exclude(void **state)
 
 	print_message("rank 0 querying pool info... ");
 	memset(&info, 'D', sizeof(info));
-	rc = daos_pool_query(poh, NULL /* tgts */, &info,
+	rc = daos_pool_query(poh, NULL /* tgts */, &info, NULL,
 			     arg->async ? &ev : NULL /* ev */);
 	assert_int_equal(rc, 0);
 	WAIT_ON_ASYNC(arg, ev);

--- a/src/tests/suite/daos_test_common.c
+++ b/src/tests/suite/daos_test_common.c
@@ -85,7 +85,7 @@ test_setup_pool_create(void **state, struct test_pool *pool)
 			      (arg->pool.pool_size >> 30), nvme_size >> 30);
 		rc = daos_pool_create(arg->mode, arg->uid, arg->gid, arg->group,
 				      NULL, "pmem", arg->pool.pool_size,
-				      nvme_size, &arg->pool.svc,
+				      nvme_size, NULL, &arg->pool.svc,
 				      arg->pool.pool_uuid, NULL);
 		if (rc)
 			print_message("daos_pool_create failed, rc: %d\n", rc);
@@ -144,7 +144,8 @@ test_setup_pool_connect(void **state, struct test_pool *pool)
 				      arg->pool.pool_info.pi_ntargets);
 
 		if (rc == 0) {
-			rc = daos_pool_query(arg->pool.poh, NULL, &info, NULL);
+			rc = daos_pool_query(arg->pool.poh, NULL, &info, NULL,
+					     NULL);
 
 			if (rc == 0) {
 				arg->srv_ntgts = info.pi_ntargets;
@@ -180,7 +181,7 @@ test_setup_cont_create(void **state)
 		uuid_generate(arg->co_uuid);
 		print_message("setup: creating container "DF_UUIDF"\n",
 			      DP_UUID(arg->co_uuid));
-		rc = daos_cont_create(arg->pool.poh, arg->co_uuid, NULL);
+		rc = daos_cont_create(arg->pool.poh, arg->co_uuid, NULL, NULL);
 		if (rc)
 			print_message("daos_cont_create failed, rc: %d\n", rc);
 	}
@@ -325,7 +326,7 @@ pool_destroy_safe(test_arg_t *arg)
 		struct daos_rebuild_status *rstat = &pinfo.pi_rebuild_st;
 
 		memset(&pinfo, 0, sizeof(pinfo));
-		rc = daos_pool_query(poh, NULL, &pinfo, NULL);
+		rc = daos_pool_query(poh, NULL, &pinfo, NULL, NULL);
 		if (rc != 0) {
 			fprintf(stderr, "pool query failed: %d\n", rc);
 			return rc;
@@ -523,7 +524,7 @@ test_pool_get_info(test_arg_t *arg, daos_pool_info_t *pinfo)
 		connect_pool = true;
 	}
 
-	rc = daos_pool_query(arg->pool.poh, NULL, pinfo, NULL);
+	rc = daos_pool_query(arg->pool.poh, NULL, pinfo, NULL, NULL);
 	if (rc != 0)
 		print_message("pool query failed %d\n", rc);
 

--- a/src/utils/dcont.c
+++ b/src/utils/dcont.c
@@ -147,7 +147,7 @@ cont_op_hdlr(int argc, char *argv[])
 	}
 
 	if (op == CONT_CREATE) {
-		rc = daos_cont_create(pool, cont_uuid, NULL);
+		rc = daos_cont_create(pool, cont_uuid, NULL, NULL);
 		if (rc != 0) {
 			fprintf(stderr, "failed to create container: %d\n", rc);
 			return rc;

--- a/src/utils/dmg.c
+++ b/src/utils/dmg.c
@@ -187,7 +187,7 @@ create_hdlr(int argc, char *argv[])
 	}
 
 	rc = daos_pool_create(mode, uid, gid, group, targets, "pmem", scm_size,
-			      nvme_size, &svc, pool_uuid, NULL /* ev */);
+			      nvme_size, NULL, &svc, pool_uuid, NULL /* ev */);
 	if (targets != NULL)
 		daos_rank_list_free(targets);
 	if (rc != 0) {
@@ -419,7 +419,7 @@ pool_op_hdlr(int argc, char *argv[])
 		struct daos_rebuild_status	*rstat = &pinfo.pi_rebuild_st;
 		int				 i;
 
-		rc = daos_pool_query(pool, NULL, &pinfo, NULL);
+		rc = daos_pool_query(pool, NULL, &pinfo, NULL, NULL);
 		if (rc != 0) {
 			fprintf(stderr, "pool query failed: %d\n", rc);
 			return rc;


### PR DESCRIPTION
Add "struct daos_properties *" parameter to below API definitions:
daos_pool_create/_query(), daos_cont_create/_query().
And pool/container properties and related data structure definitions.

Change-Id: I563898fd77caaca94bf96bda0fafcacfba455280
Signed-off-by: Xuezhao Liu <xuezhao.liu@intel.com>