### PR TITLE
DAOS-1969 control: implement cli new dmg command and shell

### DIFF
--- a/src/control/SConscript
+++ b/src/control/SConscript
@@ -91,7 +91,7 @@ def scons():
     denv.InstallAs("$PREFIX/bin/daos_server", serverbin)
 
     shellbin = "%s/bin/dmg" % gopath
-    shellsrc = "%s/dmg/daos_shell.go" % gosrc
+    shellsrc = "%s/dmg/cli.go" % gosrc
     denv.Command(shellbin, shellsrc, "go install %s/src/control/dmg" % repopath)
     denv.InstallAs("$PREFIX/bin/daos_shell", shellbin)
 

--- a/src/control/client/mgmt/nvme.go
+++ b/src/control/client/mgmt/nvme.go
@@ -1,5 +1,5 @@
 //
-// (C) Copyright 2018 Intel Corporation.
+// (C) Copyright 2018-2019 Intel Corporation.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/control/dmg/cli.go
+++ b/src/control/dmg/cli.go
@@ -1,0 +1,104 @@
+//
+// (C) Copyright 2018-2019 Intel Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// GOVERNMENT LICENSE RIGHTS-OPEN SOURCE SOFTWARE
+// The Government's rights to use, modify, reproduce, release, perform, display,
+// or disclose this software are subject to the terms of the Apache License as
+// provided in Contract No. 8F-30005.
+// Any reproduction of computer software, computer software documentation, or
+// portions thereof marked with this legend must also reproduce the markings.
+//
+
+package main
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/daos-stack/daos/src/control/client/mgmt"
+
+	flags "github.com/jessevdk/go-flags"
+	"github.com/pkg/errors"
+)
+
+type ShowStorageCommand struct{}
+
+type cliOptions struct {
+	Hostlist    string             `short:"l" long:"hostlist" default:"localhost:10001" description:"comma separated list of addresses <ipv4addr/hostname:port>"`
+	Hostfile    string             `short:"f" long:"hostfile" description:"path of hostfile specifying list of addresses <ipv4addr/hostname:port>, if specified takes preference over HostList"`
+	ConfigPath  string             `short:"o" long:"config-path" description:"Client config file path"`
+	ShowStorage ShowStorageCommand `command:"show-storage" alias:"ss" description:"List attached SCM and NVMe storage"`
+}
+
+var (
+	opts  = new(cliOptions)
+	conns = mgmtclient.NewConnections()
+)
+
+// Execute is run when ShowStorageCommand activates
+func (s *ShowStorageCommand) Execute(args []string) error {
+	// TODO: implement configuration file parsing
+	if opts.ConfigPath != "" {
+		return errors.New("config-path option not implemented")
+	}
+	if err := connectHosts(); err != nil {
+		return errors.Wrap(err, "unable to connect to hosts")
+	}
+	fmt.Printf(
+		checkAndFormat(conns.ListNvme()),
+		"NVMe SSD controller and constituent namespace")
+	fmt.Printf(checkAndFormat(conns.ListScm()), "SCM module")
+	os.Exit(0)
+	// never reached
+	return nil
+}
+
+func connectHosts() error {
+	if opts.Hostfile != "" {
+		return errors.New("hostfile option not implemented")
+	}
+	hosts := strings.Split(opts.Hostlist, ",")
+	if len(hosts) < 1 {
+		return errors.New("no hosts to connect to")
+	}
+	fmt.Println(sprintConns(conns.ConnectClients(hosts)))
+	return nil
+}
+
+func main() {
+	p := flags.NewParser(opts, flags.Default)
+	// make command optional and drop into shell by default
+	p.SubcommandsOptional = true
+
+	_, err := p.Parse()
+	if err != nil {
+		return
+	}
+
+	// TODO: implement configuration file parsing
+	if opts.ConfigPath != "" {
+		println("config-path option not implemented")
+		return
+	}
+	if err := connectHosts(); err != nil {
+		println(errors.Wrap(err, "unable to connect to hosts").Error())
+	}
+	// by default, interactive shell is started with expected
+	// functionality (tab expansion and utility commands)
+	shell := setupShell()
+	shell.Println("DAOS Management Shell")
+	shell.Run()
+}

--- a/src/control/dmg/pool.go
+++ b/src/control/dmg/pool.go
@@ -1,5 +1,5 @@
 //
-// (C) Copyright 2018-2019 Intel Corporation.
+// (C) Copyright 2019 Intel Corporation.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -23,18 +23,4 @@
 
 package main
 
-import pb "github.com/daos-stack/daos/src/control/proto/mgmt"
-
-// ListScmModules lists all Storage Class Memory modules installed.
-func (c *controlService) ListScmModules(
-	empty *pb.EmptyParams, stream pb.MgmtControl_ListScmModulesServer) error {
-	if err := c.scm.Discover(); err != nil {
-		return err
-	}
-	for _, module := range c.scm.modules {
-		if err := stream.Send(module); err != nil {
-			return err
-		}
-	}
-	return nil
-}
+// TODO: provide implementation to this placeholder

--- a/src/control/dmg/shell.go
+++ b/src/control/dmg/shell.go
@@ -1,0 +1,153 @@
+//
+// (C) Copyright 2019 Intel Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// GOVERNMENT LICENSE RIGHTS-OPEN SOURCE SOFTWARE
+// The Government's rights to use, modify, reproduce, release, perform, display,
+// or disclose this software are subject to the terms of the Apache License as
+// provided in Contract No. 8F-30005.
+// Any reproduction of computer software, computer software documentation, or
+// portions thereof marked with this legend must also reproduce the markings.
+//
+
+package main
+
+import (
+	"github.com/daos-stack/ishell"
+)
+
+func setupShell() *ishell.Shell {
+	shell := ishell.New()
+
+	shell.AddCmd(&ishell.Cmd{
+		Name: "addconns",
+		Help: "Command to create connections to servers by supplying a space separated list of addresses <ipv4addr/hostname:port>",
+		Func: func(c *ishell.Context) {
+			if len(c.Args) < 1 {
+				c.Println(c.HelpText())
+				return
+			}
+			c.Println(sprintConns(conns.ConnectClients(c.Args)))
+		},
+	})
+
+	shell.AddCmd(&ishell.Cmd{
+		Name: "clearconns",
+		Help: "Command to clear stored server connections",
+		Func: func(c *ishell.Context) {
+			conns.ClearConns()
+			c.Println(sprintConns(conns.GetActiveConns(nil)))
+		},
+	})
+
+	shell.AddCmd(&ishell.Cmd{
+		Name: "getconns",
+		Help: "Command to list active server connections",
+		Func: func(c *ishell.Context) {
+			c.Println(sprintConns(conns.GetActiveConns(nil)))
+		},
+	})
+
+	shell.AddCmd(&ishell.Cmd{
+		Name: "listmgmtfeatures",
+		Help: "Command to retrieve all supported management features from any client connections",
+		Func: func(c *ishell.Context) {
+			c.Println(hasConnections(conns.GetActiveConns(nil)))
+			c.Printf(checkAndFormat(conns.ListFeatures()), "management feature")
+		},
+	})
+
+	shell.AddCmd(&ishell.Cmd{
+		Name: "listnvmecontrollers",
+		Help: "Command to list NVMe SSD controllers",
+		Func: func(c *ishell.Context) {
+			c.Println(hasConnections(conns.GetActiveConns(nil)))
+			c.Printf(
+				checkAndFormat(conns.ListNvme()),
+				"NVMe SSD controller and constituent namespace")
+		},
+	})
+
+	shell.AddCmd(&ishell.Cmd{
+		Name: "listscmmodules",
+		Help: "Command to list installed SCM modules",
+		Func: func(c *ishell.Context) {
+			c.Println(hasConnections(conns.GetActiveConns(nil)))
+			c.Printf(checkAndFormat(conns.ListScm()), "SCM module")
+		},
+	})
+
+	// todo: implement shell commands for features other than discovery on
+	// multiple nodes
+
+	//			// record strings that make up the option list
+	//			cStrs := make([]string, len(cs))
+	//			for i, v := range cs {
+	//				cStrs[i] = fmt.Sprintf("[%d] %+v", i, v)
+	//			}
+	//
+	//			ctrlrIdxs := c.Checklist(
+	//				cStrs,
+	//				"Select the controllers you want to run tasks on.",
+	//				nil)
+	//			if len(ctrlrIdxs) == 0 {
+	//				c.Println("No controllers selected!")
+	//				return
+	//			}
+	//
+	//			// filter list of selected controllers to act on
+	//			var ctrlrs []*pb.NvmeController
+	//			for i, ctrlr := range cs {
+	//				for j := range ctrlrIdxs {
+	//					if i == j {
+	//						ctrlrs = append(ctrlrs, ctrlr)
+	//					}
+	//				}
+	//			}
+	//
+	//			featureMap, err := mgmtClient.ListFeatures("nvme")
+	//			if err != nil {
+	//				c.Println("Unable to retrieve nvme features", err.Error())
+	//				return
+	//			}
+	//
+	//			taskStrs := make([]string, len(featureMap))
+	//			taskHandlers := make([]string, len(featureMap))
+	//			i := 0
+	//			for k, v := range featureMap {
+	//				taskStrs[i] = fmt.Sprintf("[%d] %s - %s", i, k, v)
+	//				taskHandlers[i] = k
+	//				i++
+	//			}
+	//
+	//			taskIdx := c.MultiChoice(
+	//				taskStrs,
+	//				"Select the task you would like to run on the selected controllers.")
+	//
+	//			c.Printf(
+	//				"\nRunning task %s on the following controllers:\n",
+	//				taskHandlers[taskIdx])
+	//			for _, ctrlr := range ctrlrs {
+	//				c.Printf("\t- %+v\n", ctrlr)
+	//			}
+	//			c.Println("")
+	//
+	//			if err := nvmeTaskLookup(c, ctrlrs, taskHandlers[taskIdx]); err != nil {
+	//				c.Println("Problem running task: ", err.Error())
+	//			}
+	//		},
+	//	})
+
+	return shell
+}

--- a/src/control/dmg/storage.go
+++ b/src/control/dmg/storage.go
@@ -1,5 +1,5 @@
 //
-// (C) Copyright 2018 Intel Corporation.
+// (C) Copyright 2019 Intel Corporation.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -22,14 +22,6 @@
 //
 
 package main
-
-import (
-	"github.com/daos-stack/daos/src/control/client/mgmt"
-
-	"github.com/daos-stack/ishell"
-)
-
-var conns mgmtclient.Connections
 
 // todo: implement shell commands for features other than discovery on
 // multiple nodes
@@ -155,139 +147,4 @@ var conns mgmtclient.Connections
 //	}
 //
 //	return nil
-//
-
-func setupShell() *ishell.Shell {
-	shell := ishell.New()
-
-	shell.AddCmd(&ishell.Cmd{
-		Name: "addconns",
-		Help: "Command to create connections to servers by supplying a space separated list of addresses <ipv4addr/hostname:port>",
-		Func: func(c *ishell.Context) {
-			if len(c.Args) < 1 {
-				c.Println(c.HelpText())
-				return
-			}
-			c.Println(sprintConns(conns.ConnectClients(c.Args)))
-		},
-	})
-
-	shell.AddCmd(&ishell.Cmd{
-		Name: "clearconns",
-		Help: "Command to clear stored server connections",
-		Func: func(c *ishell.Context) {
-			conns.ClearConns()
-			c.Println(sprintConns(conns.GetActiveConns(nil)))
-		},
-	})
-
-	shell.AddCmd(&ishell.Cmd{
-		Name: "getconns",
-		Help: "Command to list active server connections",
-		Func: func(c *ishell.Context) {
-			c.Println(sprintConns(conns.GetActiveConns(nil)))
-		},
-	})
-
-	shell.AddCmd(&ishell.Cmd{
-		Name: "listmgmtfeatures",
-		Help: "Command to retrieve all supported management features from any client connections",
-		Func: func(c *ishell.Context) {
-			c.Println(hasConnections(conns.GetActiveConns(nil)))
-			c.Printf(checkAndFormat(conns.ListFeatures()), "management feature")
-		},
-	})
-
-	shell.AddCmd(&ishell.Cmd{
-		Name: "listnvmecontrollers",
-		Help: "Command to list NVMe SSD controllers",
-		Func: func(c *ishell.Context) {
-			c.Println(hasConnections(conns.GetActiveConns(nil)))
-			c.Printf(
-				checkAndFormat(conns.ListNvme()),
-				"NVMe SSD controller and constituent namespace")
-		},
-	})
-
-	shell.AddCmd(&ishell.Cmd{
-		Name: "listscmmodules",
-		Help: "Command to list installed SCM modules",
-		Func: func(c *ishell.Context) {
-			c.Println(hasConnections(conns.GetActiveConns(nil)))
-			c.Printf(checkAndFormat(conns.ListScm()), "SCM module")
-		},
-	})
-
-	// todo: implement shell commands for features other than discovery on
-	// multiple nodes
-
-	//			// record strings that make up the option list
-	//			cStrs := make([]string, len(cs))
-	//			for i, v := range cs {
-	//				cStrs[i] = fmt.Sprintf("[%d] %+v", i, v)
-	//			}
-	//
-	//			ctrlrIdxs := c.Checklist(
-	//				cStrs,
-	//				"Select the controllers you want to run tasks on.",
-	//				nil)
-	//			if len(ctrlrIdxs) == 0 {
-	//				c.Println("No controllers selected!")
-	//				return
-	//			}
-	//
-	//			// filter list of selected controllers to act on
-	//			var ctrlrs []*pb.NvmeController
-	//			for i, ctrlr := range cs {
-	//				for j := range ctrlrIdxs {
-	//					if i == j {
-	//						ctrlrs = append(ctrlrs, ctrlr)
-	//					}
-	//				}
-	//			}
-	//
-	//			featureMap, err := mgmtClient.ListFeatures("nvme")
-	//			if err != nil {
-	//				c.Println("Unable to retrieve nvme features", err.Error())
-	//				return
-	//			}
-	//
-	//			taskStrs := make([]string, len(featureMap))
-	//			taskHandlers := make([]string, len(featureMap))
-	//			i := 0
-	//			for k, v := range featureMap {
-	//				taskStrs[i] = fmt.Sprintf("[%d] %s - %s", i, k, v)
-	//				taskHandlers[i] = k
-	//				i++
-	//			}
-	//
-	//			taskIdx := c.MultiChoice(
-	//				taskStrs,
-	//				"Select the task you would like to run on the selected controllers.")
-	//
-	//			c.Printf(
-	//				"\nRunning task %s on the following controllers:\n",
-	//				taskHandlers[taskIdx])
-	//			for _, ctrlr := range ctrlrs {
-	//				c.Printf("\t- %+v\n", ctrlr)
-	//			}
-	//			c.Println("")
-	//
-	//			if err := nvmeTaskLookup(c, ctrlrs, taskHandlers[taskIdx]); err != nil {
-	//				c.Println("Problem running task: ", err.Error())
-	//			}
-	//		},
-	//	})
-
-	return shell
-}
-
-func main() {
-	// by default, shell includes 'exit', 'help' and 'clear' commands.
-	conns = mgmtclient.NewConnections()
-	shell := setupShell()
-
-	shell.Println("DAOS Management Shell")
-
-	shell.Run()
-}
+//}

--- a/src/control/dmg/utils.go
+++ b/src/control/dmg/utils.go
@@ -1,5 +1,5 @@
 //
-// (C) Copyright 2018 Intel Corporation.
+// (C) Copyright 2018-2019 Intel Corporation.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -26,8 +26,9 @@ package main
 import (
 	"fmt"
 	"sort"
-	"github.com/daos-stack/daos/src/control/utils/handlers"
+
 	"github.com/daos-stack/daos/src/control/client/mgmt"
+	"github.com/daos-stack/daos/src/control/utils/handlers"
 )
 
 func hasConnections(addrs mgmtclient.Addresses, eMap mgmtclient.ErrorMap) (

--- a/src/control/server/daos_server.go
+++ b/src/control/server/daos_server.go
@@ -61,7 +61,7 @@ func main() {
 	// Parse commandline flags which override options loaded from config.
 	if _, err := flags.Parse(&opts); err != nil {
 		// don't log failure just return usage info
-		println(err)
+		println(err.Error())
 		return
 	}
 

--- a/src/control/server/nvme.go
+++ b/src/control/server/nvme.go
@@ -42,7 +42,7 @@ func (c *controlService) ListNvmeCtrlrs(
 	if err := c.nvme.Discover(); err != nil {
 		return err
 	}
-	for _, ctrlr := range c.nvme.Controllers {
+	for _, ctrlr := range c.nvme.controllers {
 		if err := stream.Send(ctrlr); err != nil {
 			return err
 		}
@@ -60,7 +60,7 @@ func (c *controlService) UpdateNvmeCtrlr(
 	if err := c.nvme.Update(id, params.Path, params.Slot); err != nil {
 		return nil, err
 	}
-	for _, ctrlr := range c.nvme.Controllers {
+	for _, ctrlr := range c.nvme.controllers {
 		if ctrlr.Id == id {
 			if ctrlr.Fwrev == params.Ctrlr.Fwrev {
 				return nil, fmt.Errorf("update failed, firmware revision unchanged")
@@ -96,7 +96,7 @@ func (c *controlService) BurnInNvme(
 	params *pb.BurnInNvmeParams, stream pb.MgmtControl_BurnInNvmeServer) error {
 	// retrieve command components
 	cmdName, args, env, err := c.nvme.BurnIn(
-		c.nvme.Controllers[params.Ctrlrid].Pciaddr,
+		c.nvme.controllers[params.Ctrlrid].Pciaddr,
 		// hardcode first Namespace on controller for the moment
 		1,
 		params.Path.Path)

--- a/src/control/server/nvme_test.go
+++ b/src/control/server/nvme_test.go
@@ -48,7 +48,7 @@ func TestUpdateNvmeCtrlr(t *testing.T) {
 	}
 
 	cExpect := MockControllerPB("1.0.1")
-	c := s.nvme.Controllers[0]
+	c := s.nvme.controllers[0]
 
 	// after fetching controller details, simulate updated firmware
 	// version being reported
@@ -60,7 +60,7 @@ func TestUpdateNvmeCtrlr(t *testing.T) {
 		t.Fatal(err.Error())
 	}
 
-	AssertEqual(t, s.nvme.Controllers[0], cExpect, "unexpected Controller populated")
+	AssertEqual(t, s.nvme.controllers[0], cExpect, "unexpected Controller populated")
 	AssertEqual(t, newC, cExpect, "unexpected Controller returned")
 }
 
@@ -71,7 +71,7 @@ func TestUpdateNvmeCtrlrFail(t *testing.T) {
 		t.Fatal(err.Error())
 	}
 
-	c := s.nvme.Controllers[0]
+	c := s.nvme.controllers[0]
 
 	// after fetching controller details, simulate the same firmware
 	// version being reported

--- a/src/control/server/scm_test.go
+++ b/src/control/server/scm_test.go
@@ -56,8 +56,8 @@ func TestListScmModules(t *testing.T) {
 	mock := &mockListScmModulesServer{}
 	s.ListScmModules(nil, mock)
 
-	AssertEqual(t, len(s.scm.Modules), 1, "unexpected number of modules")
-	AssertEqual(t, s.scm.Modules, ScmmMap{0: m}, "unexpected list of modules")
+	AssertEqual(t, len(s.scm.modules), 1, "unexpected number of modules")
+	AssertEqual(t, s.scm.modules, ScmmMap{0: m}, "unexpected list of modules")
 	AssertEqual(t, len(mock.Results), 1, "unexpected number of modules sent")
 	AssertEqual(t, mock.Results, []*pb.ScmModule{m}, "unexpected list of modules sent")
 }

--- a/src/control/server/server.go
+++ b/src/control/server/server.go
@@ -91,29 +91,19 @@ func loadInitData(relPath string) (m FeatureMap, err error) {
 	return
 }
 
-func dumpLocalStorage(name string, i interface{}) {
-	println(name + ":")
-	s, err := handlers.StructsToString(i)
-	if err != nil {
-		println("Unable to YAML encode response: " + err.Error())
-		return
-	}
-	println(s)
-}
-
-// ShowLocalStorage retrieves and prints details of locally attached SCM and
+// showLocalStorage retrieves and prints details of locally attached SCM and
 // NVMe storage to daos_server stdout.
 func (c *controlService) showLocalStorage() {
 	println("Listing attached storage...")
 	if err := c.nvme.Discover(); err != nil {
-		println("Failure retrieving NVMe details: " + err.Error())
+		println("Failure retrieving NVMe details: ", err.Error())
 	} else {
-		dumpLocalStorage("NVMe", c.nvme.Controllers)
+		handlers.PrintStructs("NVMe", c.nvme.controllers)
 	}
 	if err := c.scm.Discover(); err != nil {
-		println("Failure retrieving SCM details: " + err.Error())
+		println("Failure retrieving SCM details: ", err.Error())
 	} else {
-		dumpLocalStorage("SCM", c.scm.Modules)
+		handlers.PrintStructs("SCM", c.scm.modules)
 	}
 }
 

--- a/src/control/server/storage_nvme_test.go
+++ b/src/control/server/storage_nvme_test.go
@@ -55,9 +55,10 @@ func (m *mockSpdkNvme) Update(ctrlrID int32, path string, slot int32) (
 }
 func (m *mockSpdkNvme) Cleanup() { return }
 
+// mock external interface implementations for spdk setup script
 type mockSpdkSetup struct{}
 
-func (m *mockSpdkSetup) start() error { return nil }
+func (m *mockSpdkSetup) prep() error  { return nil }
 func (m *mockSpdkSetup) reset() error { return nil }
 
 // mockNvmeStorage factory
@@ -67,7 +68,7 @@ func newMockNvmeStorage(
 		logger:      log.NewLogger(),
 		env:         &mockSpdkEnv{},
 		nvme:        &mockSpdkNvme{fwRevBefore, fwRevAfter},
-		setup:       &mockSpdkSetup{},
+		spdk:        &mockSpdkSetup{},
 		initialized: inited,
 	}
 }
@@ -95,13 +96,13 @@ func TestDiscoveryNvme(t *testing.T) {
 
 		if tt.inited {
 			AssertEqual(
-				t, sn.Controllers, []*pb.NvmeController(nil),
+				t, sn.controllers, []*pb.NvmeController(nil),
 				"unexpected list of protobuf format controllers")
 			continue
 		}
 
 		AssertEqual(
-			t, sn.Controllers, []*pb.NvmeController{c},
+			t, sn.controllers, []*pb.NvmeController{c},
 			"unexpected list of protobuf format controllers")
 	}
 }
@@ -140,7 +141,7 @@ func TestUpdateNvme(t *testing.T) {
 		}
 
 		AssertEqual(
-			t, sn.Controllers, []*pb.NvmeController{c},
+			t, sn.controllers, []*pb.NvmeController{c},
 			"unexpected list of protobuf format controllers")
 	}
 }

--- a/src/control/server/storage_scm.go
+++ b/src/control/server/storage_scm.go
@@ -44,7 +44,7 @@ type ScmmMap map[int32]*pb.ScmModule
 type scmStorage struct {
 	logger      *log.Logger
 	ipmCtl      ipmctl.IpmCtl // ipmctl NVM API interface
-	Modules     ScmmMap
+	modules     ScmmMap
 	initialized bool
 }
 
@@ -77,7 +77,7 @@ func (s *scmStorage) Discover() error {
 		if err != nil {
 			return err
 		}
-		s.Modules = pbMms
+		s.modules = pbMms
 		return nil
 	}
 	return fmt.Errorf("scm storage not initialized")

--- a/src/control/server/storage_scm_test.go
+++ b/src/control/server/storage_scm_test.go
@@ -77,6 +77,6 @@ func TestDiscoveryScm(t *testing.T) {
 			t.Fatal(err.Error())
 		}
 
-		AssertEqual(t, ss.Modules, ScmmMap{0: m}, "unexpected list of modules")
+		AssertEqual(t, ss.modules, ScmmMap{0: m}, "unexpected list of modules")
 	}
 }

--- a/src/control/utils/handlers/file.go
+++ b/src/control/utils/handlers/file.go
@@ -1,5 +1,5 @@
 //
-// (C) Copyright 2018 Intel Corporation.
+// (C) Copyright 2018-2019 Intel Corporation.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -131,8 +131,20 @@ func StructsToString(i interface{}) (lines string, err error) {
 	}
 	for _, l := range strings.Split(string(s), "\n") {
 		if !strings.Contains(l, "xxx_") {
-			lines = lines+l+"\n"
+			lines = lines + l + "\n"
 		}
 	}
 	return
+}
+
+// PrintStructs dumps friendly YAML representation of structs to stdout
+// proceeded with "name" identifier.
+func PrintStructs(name string, i interface{}) {
+	println(name + ":")
+	s, err := StructsToString(i)
+	if err != nil {
+		println("Unable to YAML encode response: ", err.Error())
+		return
+	}
+	println(s)
 }


### PR DESCRIPTION
Control plane management tool runs as shell if given no args or
performs specific tasks otherwise. Implement initial structure
including hostlist connection processing and listing of storage
attached to hosts.

Change-Id: I6e372a5e98ba7b62e108fc60af9a921ba5f9c5da
Signed-off-by: Tom Nabarro <tom.nabarro@intel.com>