### PR TITLE
DAOS-1441 common: operation intent for DTX

### DIFF
--- a/src/bio/smd/smd_stream.c
+++ b/src/bio/smd/smd_stream.c
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2018 Intel Corporation.
+ * (C) Copyright 2018-2019 Intel Corporation.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -31,6 +31,7 @@
 #include <daos/mem.h>
 #include <gurt/hash.h>
 #include <daos/btree.h>
+#include <daos/dtx.h>
 #include <daos_types.h>
 
 #include "smd_internal.h"
@@ -265,7 +266,7 @@ smd_nvme_list_streams(uint32_t *nr, struct smd_nvme_stream_bond *streams,
 		probe_hash = anchor;
 
 	opc = probe_hash == NULL ? BTR_PROBE_FIRST : BTR_PROBE_GT;
-	rc = dbtree_iter_probe(sti_hdl, opc, NULL, anchor);
+	rc = dbtree_iter_probe(sti_hdl, opc, DAOS_INTENT_DEFAULT, NULL, anchor);
 	if (rc != 0)
 		D_GOTO(out_eof, rc);
 

--- a/src/common/btree.c
+++ b/src/common/btree.c
@@ -31,6 +31,7 @@
 
 #include <daos_errno.h>
 #include <daos/btree.h>
+#include <daos/dtx.h>
 
 /**
  * Tree node types.
@@ -1140,7 +1141,7 @@ btr_probe_valid(dbtree_probe_opc_t opc)
  */
 static enum btr_probe_rc
 btr_probe(struct btr_context *tcx, dbtree_probe_opc_t probe_opc,
-	  daos_iov_t *key, char hkey[DAOS_HKEY_MAX])
+	  uint32_t intent, daos_iov_t *key, char hkey[DAOS_HKEY_MAX])
 {
 	int			 start;
 	int			 end;
@@ -1343,12 +1344,12 @@ btr_probe(struct btr_context *tcx, dbtree_probe_opc_t probe_opc,
 
 static enum btr_probe_rc
 btr_probe_key(struct btr_context *tcx, dbtree_probe_opc_t probe_opc,
-	       daos_iov_t *key)
+	      uint32_t intent, daos_iov_t *key)
 {
 	char hkey[DAOS_HKEY_MAX];
 
 	btr_hkey_gen(tcx, key, hkey);
-	return btr_probe(tcx, probe_opc, key, hkey);
+	return btr_probe(tcx, probe_opc, intent, key, hkey);
 }
 
 static bool
@@ -1478,6 +1479,7 @@ btr_probe_prev(struct btr_context *tcx)
  * \param toh	[IN]		Tree open handle.
  * \param opc	[IN]		Probe opcode, see dbtree_probe_opc_t for the
  *				details.
+ * \param intent [IN]		The operation intent.
  * \param key	[IN]		Key to search
  * \param key_out [OUT]		Return the actual matched key if \a opc is
  *				not BTR_PROBE_EQ.
@@ -1488,8 +1490,8 @@ btr_probe_prev(struct btr_context *tcx)
  *			-ve	error code
  */
 int
-dbtree_fetch(daos_handle_t toh, dbtree_probe_opc_t opc, daos_iov_t *key,
-	     daos_iov_t *key_out, daos_iov_t *val_out)
+dbtree_fetch(daos_handle_t toh, dbtree_probe_opc_t opc, uint32_t intent,
+	     daos_iov_t *key, daos_iov_t *key_out, daos_iov_t *val_out)
 {
 	struct btr_record  *rec;
 	struct btr_context *tcx;
@@ -1499,7 +1501,7 @@ dbtree_fetch(daos_handle_t toh, dbtree_probe_opc_t opc, daos_iov_t *key,
 	if (tcx == NULL)
 		return -DER_NO_HDL;
 
-	rc = btr_probe_key(tcx, opc, key);
+	rc = btr_probe_key(tcx, opc, intent, key);
 	if (rc == PROBE_RC_NONE || rc == PROBE_RC_ERR) {
 		D_DEBUG(DB_TRACE, "Cannot find key\n");
 		return -DER_NONEXIST;
@@ -1526,7 +1528,8 @@ dbtree_fetch(daos_handle_t toh, dbtree_probe_opc_t opc, daos_iov_t *key,
 int
 dbtree_lookup(daos_handle_t toh, daos_iov_t *key, daos_iov_t *val_out)
 {
-	return dbtree_fetch(toh, BTR_PROBE_EQ, key, NULL, val_out);
+	return dbtree_fetch(toh, BTR_PROBE_EQ, DAOS_INTENT_DEFAULT, key, NULL,
+			    val_out);
 }
 
 static int
@@ -1615,14 +1618,14 @@ btr_insert(struct btr_context *tcx, daos_iov_t *key, daos_iov_t *val)
 
 static int
 btr_upsert(struct btr_context *tcx, dbtree_probe_opc_t probe_opc,
-	   daos_iov_t *key, daos_iov_t *val)
+	   uint32_t intent, daos_iov_t *key, daos_iov_t *val)
 {
 	int	rc;
 
 	if (probe_opc == BTR_PROBE_BYPASS)
 		rc = tcx->tc_probe_rc; /* trust previous probe... */
 	else
-		rc = btr_probe_key(tcx, probe_opc, key);
+		rc = btr_probe_key(tcx, probe_opc, intent, key);
 
 	switch (rc) {
 	default:
@@ -1699,7 +1702,7 @@ dbtree_update(daos_handle_t toh, daos_iov_t *key, daos_iov_t *val)
 	if (rc != 0)
 		return rc;
 
-	rc = btr_upsert(tcx, BTR_PROBE_EQ, key, val);
+	rc = btr_upsert(tcx, BTR_PROBE_EQ, DAOS_INTENT_UPDATE, key, val);
 
 	return btr_tx_end(tcx, rc);
 }
@@ -1719,7 +1722,7 @@ dbtree_update(daos_handle_t toh, daos_iov_t *key, daos_iov_t *val)
  *			-ve	error code
  */
 int
-dbtree_upsert(daos_handle_t toh, dbtree_probe_opc_t opc,
+dbtree_upsert(daos_handle_t toh, dbtree_probe_opc_t opc, uint32_t intent,
 	      daos_iov_t *key, daos_iov_t *val)
 {
 	struct btr_context *tcx;
@@ -1732,7 +1735,7 @@ dbtree_upsert(daos_handle_t toh, dbtree_probe_opc_t opc,
 	rc = btr_tx_begin(tcx);
 	if (rc != 0)
 		return rc;
-	rc = btr_upsert(tcx, opc, key, val);
+	rc = btr_upsert(tcx, opc, intent, key, val);
 
 	return btr_tx_end(tcx, rc);
 }
@@ -2448,7 +2451,7 @@ dbtree_delete(daos_handle_t toh, daos_iov_t *key,
 	if (tcx == NULL)
 		return -DER_NO_HDL;
 
-	rc = btr_probe_key(tcx, BTR_PROBE_EQ, key);
+	rc = btr_probe_key(tcx, BTR_PROBE_EQ, DAOS_INTENT_PUNCH, key);
 	if (rc != PROBE_RC_OK) {
 		D_DEBUG(DB_TRACE, "Cannot find key\n");
 		return -DER_NONEXIST;
@@ -2968,7 +2971,9 @@ dbtree_iter_finish(daos_handle_t ih)
  * This function must be called after dbtree_iter_prepare, it can be called
  * for arbitrary times for the same iterator.
  *
+ * \param ih	[IN]	The iterator handle.
  * \param opc	[IN]	Probe opcode, see dbtree_probe_opc_t for the details.
+ * \param intent [IN]	The operation intent.
  * \param key	[IN]	The key to probe, it will be ignored if opc is
  *			BTR_PROBE_FIRST or BTR_PROBE_LAST.
  * \param anchor [IN]	the anchor point to probe, it will be ignored if
@@ -2977,7 +2982,7 @@ dbtree_iter_finish(daos_handle_t ih)
  *			key or anchor is required.
  */
 int
-dbtree_iter_probe(daos_handle_t ih, dbtree_probe_opc_t opc,
+dbtree_iter_probe(daos_handle_t ih, dbtree_probe_opc_t opc, uint32_t intent,
 		  daos_iov_t *key, daos_anchor_t *anchor)
 {
 	struct btr_iterator *itr;
@@ -2995,16 +3000,16 @@ dbtree_iter_probe(daos_handle_t ih, dbtree_probe_opc_t opc,
 		return -DER_NO_HDL;
 
 	if (opc == BTR_PROBE_FIRST || opc == BTR_PROBE_LAST)
-		rc = btr_probe(tcx, opc, NULL, NULL);
+		rc = btr_probe(tcx, opc, intent, NULL, NULL);
 	else if (btr_is_direct_key(tcx)) {
 		D_ASSERT(key != NULL || anchor != NULL);
 		if (key)
-			rc = btr_probe(tcx, opc, key, NULL);
+			rc = btr_probe(tcx, opc, intent, key, NULL);
 		else {
 			daos_iov_t direct_key;
 
 			btr_key_decode(tcx, &direct_key, anchor);
-			rc = btr_probe(tcx, opc, &direct_key, NULL);
+			rc = btr_probe(tcx, opc, intent, &direct_key, NULL);
 		}
 	} else {
 		D_ASSERT(key != NULL || anchor != NULL);
@@ -3014,7 +3019,7 @@ dbtree_iter_probe(daos_handle_t ih, dbtree_probe_opc_t opc,
 			btr_hkey_gen(tcx, key, hkey);
 		else
 			btr_hkey_copy(tcx, hkey, (char *)&anchor->da_buf[0]);
-		rc = btr_probe(tcx, opc, key, hkey);
+		rc = btr_probe(tcx, opc, intent, key, hkey);
 	}
 
 	if (rc == PROBE_RC_NONE || rc == PROBE_RC_ERR) {
@@ -3198,13 +3203,14 @@ dbtree_iter_empty(daos_handle_t ih)
  * dbtree_iterate_cb_t.
  *
  * \param toh		[IN]	Tree open handle
+ * \param intent	[IN]	The operation intent
  * \param backward	[IN]	If true, iterate from last to first
  * \param cb		[IN]	Callback function (see dbtree_iterate_cb_t)
  * \param arg		[IN]	Callback argument
  */
 int
-dbtree_iterate(daos_handle_t toh, bool backward, dbtree_iterate_cb_t cb,
-	       void *arg)
+dbtree_iterate(daos_handle_t toh, uint32_t intent, bool backward,
+	       dbtree_iterate_cb_t cb, void *arg)
 {
 	daos_handle_t	ih;
 	int		niterated = 0;
@@ -3217,7 +3223,7 @@ dbtree_iterate(daos_handle_t toh, bool backward, dbtree_iterate_cb_t cb,
 	}
 
 	rc = dbtree_iter_probe(ih, backward ? BTR_PROBE_LAST : BTR_PROBE_FIRST,
-			       NULL /* key */, NULL /* anchor */);
+			       intent, NULL /* key */, NULL /* anchor */);
 	if (rc == -DER_NONEXIST) {
 		D_GOTO(out_iter, rc = 0);
 	} else if (rc != 0) {

--- a/src/common/btree_class.c
+++ b/src/common/btree_class.c
@@ -29,6 +29,7 @@
 
 #include <string.h>
 #include <daos/btree_class.h>
+#include <daos/dtx.h>
 
 enum {
 	BTR_NO_TX,		/**< no transaction support */
@@ -762,7 +763,8 @@ dbtree_uv_fetch(daos_handle_t tree, dbtree_probe_opc_t opc,
 	daos_iov_set(&key_out, uuid_out, sizeof(uuid_t));
 	daos_iov_set(&val, value, size);
 
-	rc = dbtree_fetch(tree, opc, &key_in, &key_out, &val);
+	rc = dbtree_fetch(tree, opc, DAOS_INTENT_DEFAULT, &key_in, &key_out,
+			  &val);
 	if (rc == -DER_NONEXIST)
 		D_DEBUG(DB_TRACE, "cannot find opc=%d in="DF_UUID"\n", opc,
 			DP_UUID(uuid_in));
@@ -1021,7 +1023,8 @@ dbtree_ec_fetch(daos_handle_t tree, dbtree_probe_opc_t opc,
 	daos_iov_set(&key_out, epoch_out, sizeof(*epoch_out));
 	daos_iov_set(&val, (void *)count, sizeof(*count));
 
-	rc = dbtree_fetch(tree, opc, &key_in, &key_out, &val);
+	rc = dbtree_fetch(tree, opc, DAOS_INTENT_DEFAULT, &key_in, &key_out,
+			  &val);
 	if (rc == -DER_NONEXIST)
 		D_DEBUG(DB_TRACE, "cannot find opc=%d in="DF_U64"\n",
 			opc, epoch_in == NULL ? -1 : *epoch_in);

--- a/src/common/tests/btree.c
+++ b/src/common/tests/btree.c
@@ -35,6 +35,7 @@
 #include <getopt.h>
 
 #include <daos/btree.h>
+#include <daos/dtx.h>
 #include <daos/tests_lib.h>
 #include "utest_common.h"
 
@@ -574,7 +575,8 @@ ik_btr_iterate(char *args)
 		uint64_t	key;
 
 		if (i == 0 || (del != 0 && d <= del)) {
-			rc = dbtree_iter_probe(ih, opc, NULL, NULL);
+			rc = dbtree_iter_probe(ih, opc, DAOS_INTENT_DEFAULT,
+					       NULL, NULL);
 			if (rc == -DER_NONEXIST)
 				break;
 

--- a/src/common/tests/btree_direct.c
+++ b/src/common/tests/btree_direct.c
@@ -36,6 +36,7 @@
 #include <getopt.h>
 
 #include <daos/btree.h>
+#include <daos/dtx.h>
 #include <daos/tests_lib.h>
 #include <gurt/common.h>
 #include "utest_common.h"
@@ -619,7 +620,8 @@ sk_btr_iterate(char *args)
 		daos_iov_t	 val_iov;
 
 		if (i == 0 || (del != 0 && d <= del)) {
-			rc = dbtree_iter_probe(ih, opc, NULL, &anchor);
+			rc = dbtree_iter_probe(ih, opc, DAOS_INTENT_DEFAULT,
+					       NULL, &anchor);
 			if (rc == -DER_NONEXIST)
 				break;
 
@@ -796,7 +798,8 @@ sk_btr_check_order(struct kv_node *kv, unsigned int key_nr)
 		goto failed;
 	}
 
-	rc = dbtree_iter_probe(ih, BTR_PROBE_FIRST, NULL, NULL);
+	rc = dbtree_iter_probe(ih, BTR_PROBE_FIRST, DAOS_INTENT_DEFAULT, NULL,
+			       NULL);
 	if (rc == -DER_NONEXIST) {
 		err = "nonexist";
 		goto failed;

--- a/src/container/srv_target.c
+++ b/src/container/srv_target.c
@@ -1056,6 +1056,7 @@ ds_cont_obj_iter(daos_handle_t ph, uuid_t co_uuid,
 	param.ip_hdl = coh;
 	param.ip_epr.epr_lo = 0;
 	param.ip_epr.epr_hi = DAOS_EPOCH_MAX;
+	param.ip_flags = VOS_IT_FOR_REBUILD;
 
 	rc = vos_iter_prepare(VOS_ITER_OBJ, &param, &iter_h);
 	if (rc != 0) {

--- a/src/include/daos/btree.h
+++ b/src/include/daos/btree.h
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2016-2018 Intel Corporation.
+ * (C) Copyright 2016-2019 Intel Corporation.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -557,9 +557,9 @@ int  dbtree_close(daos_handle_t toh);
 int  dbtree_destroy(daos_handle_t toh);
 int  dbtree_lookup(daos_handle_t toh, daos_iov_t *key, daos_iov_t *val_out);
 int  dbtree_update(daos_handle_t toh, daos_iov_t *key, daos_iov_t *val);
-int  dbtree_fetch(daos_handle_t toh, dbtree_probe_opc_t opc,
+int  dbtree_fetch(daos_handle_t toh, dbtree_probe_opc_t opc, uint32_t intent,
 		  daos_iov_t *key, daos_iov_t *key_out, daos_iov_t *val_out);
-int  dbtree_upsert(daos_handle_t toh, dbtree_probe_opc_t opc,
+int  dbtree_upsert(daos_handle_t toh, dbtree_probe_opc_t opc, uint32_t intent,
 		   daos_iov_t *key, daos_iov_t *val);
 int  dbtree_delete(daos_handle_t toh, daos_iov_t *key, void *args);
 int  dbtree_query(daos_handle_t toh, struct btr_attr *attr,
@@ -581,7 +581,7 @@ int dbtree_iter_prepare(daos_handle_t toh, unsigned int options,
 			daos_handle_t *ih);
 int dbtree_iter_finish(daos_handle_t ih);
 int dbtree_iter_probe(daos_handle_t ih, dbtree_probe_opc_t opc,
-		      daos_iov_t *key, daos_anchor_t *anchor);
+		      uint32_t intent, daos_iov_t *key, daos_anchor_t *anchor);
 int dbtree_iter_next(daos_handle_t ih);
 int dbtree_iter_prev(daos_handle_t ih);
 int dbtree_iter_fetch(daos_handle_t ih, daos_iov_t *key,
@@ -598,8 +598,8 @@ int dbtree_iter_empty(daos_handle_t ih);
  */
 typedef int (*dbtree_iterate_cb_t)(daos_handle_t ih, daos_iov_t *key,
 				   daos_iov_t *val, void *arg);
-int dbtree_iterate(daos_handle_t toh, bool backward, dbtree_iterate_cb_t cb,
-		   void *arg);
+int dbtree_iterate(daos_handle_t toh, uint32_t intent, bool backward,
+		   dbtree_iterate_cb_t cb, void *arg);
 
 enum {
 	DBTREE_VOS_BEGIN	= 10,

--- a/src/include/daos/dtx.h
+++ b/src/include/daos/dtx.h
@@ -57,4 +57,13 @@ daos_copy_dti(struct daos_tx_id *des, struct daos_tx_id *src)
 #define DF_DTI		DF_UUID
 #define DP_DTI(dti)	DP_UUID((dti)->dti_uuid)
 
+enum daos_ops_intent {
+	DAOS_INTENT_DEFAULT	= 0,	/* fetch/enumerate/query */
+	DAOS_INTENT_PURGE	= 1,	/* purge/aggregation */
+	DAOS_INTENT_UPDATE	= 2,	/* write/insert */
+	DAOS_INTENT_PUNCH	= 3,	/* punch/delete */
+	DAOS_INTENT_REBUILD	= 4,	/* for rebuild related scan */
+	DAOS_INTENT_PROBE	= 5,	/* check aborted or not */
+};
+
 #endif /* __DAOS_DTX_H__ */

--- a/src/include/daos_srv/evtree.h
+++ b/src/include/daos_srv/evtree.h
@@ -511,6 +511,11 @@ enum {
 	 * If neither flag is set, all rectangles in tree that intersect the
 	 * search rectangle, including punched extents, are returned.
 	 */
+
+	/** The iterator is for purge operation */
+	EVT_ITER_FOR_PURGE	= (1 << 5),
+	/** The iterator is for rebuild scan */
+	EVT_ITER_FOR_REBUILD	= (1 << 6),
 };
 
 /**

--- a/src/include/daos_srv/vos_types.h
+++ b/src/include/daos_srv/vos_types.h
@@ -122,6 +122,10 @@ enum {
 	VOS_IT_RECX_SKIP_HOLES	= (1 << 2),
 	/** When sorted iteration is enabled, iterate in reverse */
 	VOS_IT_RECX_REVERSE	= (1 << 3),
+	/** The iterator is for purge operation */
+	VOS_IT_FOR_PURGE	= (1 << 4),
+	/** The iterator is for rebuild scan */
+	VOS_IT_FOR_REBUILD	= (1 << 5),
 };
 
 /**
@@ -146,8 +150,8 @@ typedef struct {
 	daos_epoch_range_t	ip_epr;
 	/** epoch logic expression for the iterator. */
 	vos_it_epc_expr_t	ip_epc_expr;
-	/** extent visibility flags for for iterator */
-	uint32_t		ip_recx_flags;
+	/** flags for for iterator */
+	uint32_t		ip_flags;
 } vos_iter_param_t;
 
 enum {

--- a/src/object/srv_obj.c
+++ b/src/object/srv_obj.c
@@ -888,8 +888,7 @@ ds_iter_vos(crt_rpc_t *rpc, struct vos_iter_anchors *anchors,
 
 		param.ip_epc_expr = VOS_IT_EPC_RE;
 		/** Only show visible records and skip punches */
-		param.ip_recx_flags = VOS_IT_RECX_VISIBLE |
-			VOS_IT_RECX_SKIP_HOLES;
+		param.ip_flags = VOS_IT_RECX_VISIBLE | VOS_IT_RECX_SKIP_HOLES;
 		enum_arg->fill_recxs = true;
 	} else if (opc == DAOS_OBJ_DKEY_RPC_ENUMERATE) {
 		type = VOS_ITER_DKEY;

--- a/src/pool/srv_target.c
+++ b/src/pool/srv_target.c
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2016-2018 Intel Corporation.
+ * (C) Copyright 2016-2019 Intel Corporation.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -955,6 +955,7 @@ ds_pool_cont_iter(daos_handle_t ph, pool_iter_cb_t callback, void *arg)
 
 	memset(&param, 0, sizeof(param));
 	param.ip_hdl = ph;
+	param.ip_flags = VOS_IT_FOR_REBUILD;
 
 	rc = vos_iter_prepare(VOS_ITER_COUUID, &param, &iter_h);
 	if (rc != 0) {

--- a/src/vos/evt_priv.h
+++ b/src/vos/evt_priv.h
@@ -308,6 +308,7 @@ int evt_ent_array_sort(struct evt_context *tcx,
 /** Scan the tree and select all rectangles that match
  * \param[IN]		tcx		The evtree context
  * \param[IN]		opc		The opcode for the scan
+ * \param[IN]		intent		The operation intent
  *					EVT_FIND_FIRST: First record only
  *					EVT_FIND_SAME:  Same record only
  *					EVT_FIND_ALL:   All records
@@ -319,7 +320,7 @@ int evt_ent_array_sort(struct evt_context *tcx,
  * scanned record.
  */
 int evt_ent_array_fill(struct evt_context *tcx, enum evt_find_opc find_opc,
-		       const struct evt_filter *filter,
+		       uint32_t intent, const struct evt_filter *filter,
 		       const struct evt_rect *rect,
 		       struct evt_entry_array *ent_array);
 
@@ -351,8 +352,9 @@ struct evt_context *evt_hdl2tcx(daos_handle_t toh);
 
 /** Move the trace forward.
  * \param[IN]	tcx	The evtree context
+ * \param IN]	intent	The operation intent
  */
-bool evt_move_trace(struct evt_context *tcx);
+bool evt_move_trace(struct evt_context *tcx, uint32_t intent);
 
 /** Get a pointer to the rectangle corresponding to an index in a tree node
  * \param[IN]	tcx	The evtree context

--- a/src/vos/evtree.c
+++ b/src/vos/evtree.c
@@ -1658,8 +1658,8 @@ evt_insert(daos_handle_t toh, const struct evt_entry_in *entry)
 	filter.fr_epr.epr_lo = entry->ei_rect.rc_epc;
 	filter.fr_epr.epr_hi = entry->ei_rect.rc_epc;
 	/* Phase-1: Check for overwrite */
-	rc = evt_ent_array_fill(tcx, EVT_FIND_OVERWRITE, &filter,
-				&entry->ei_rect, &ent_array);
+	rc = evt_ent_array_fill(tcx, EVT_FIND_OVERWRITE, DAOS_INTENT_UPDATE,
+				&filter, &entry->ei_rect, &ent_array);
 	if (rc != 0)
 		return rc;
 
@@ -1752,19 +1752,12 @@ evt_entry_fill(struct evt_context *tcx, struct evt_node *node,
 }
 
 /**
- * Find all versioned extents which intercept with the input one \a rect.
- * It attaches all found extents and their data pointers on \a ent_array if
- * \a no_overlap is false, otherwise returns error if there is any overlapped
- * extent.
- *
- * \param rect		[IN]	Rectangle to check.
- * \param no_overlap	[IN]	Returns error if \a rect overlap with any
- *				existent extent.
- * \param ent_array	[OUT]	The returned entries for overlapped extents.
+ * See the description in evt_priv.h
  */
 int
 evt_ent_array_fill(struct evt_context *tcx, enum evt_find_opc find_opc,
-		   const struct evt_filter *filter, const struct evt_rect *rect,
+		   uint32_t intent, const struct evt_filter *filter,
+		   const struct evt_rect *rect,
 		   struct evt_entry_array *ent_array)
 {
 	uint64_t	nd_off;
@@ -2161,7 +2154,8 @@ evt_find(daos_handle_t toh, const struct evt_rect *rect,
 	filter.fr_epr.epr_lo = 0;
 	filter.fr_epr.epr_hi = rect->rc_epc;
 
-	rc = evt_ent_array_fill(tcx, EVT_FIND_ALL, &filter, rect, ent_array);
+	rc = evt_ent_array_fill(tcx, EVT_FIND_ALL, DAOS_INTENT_DEFAULT,
+				&filter, rect, ent_array);
 	if (rc == 0)
 		rc = evt_ent_array_sort(tcx, ent_array, EVT_VISIBLE);
 	if (rc != 0)
@@ -2171,7 +2165,7 @@ evt_find(daos_handle_t toh, const struct evt_rect *rect,
 
 /** move the probing trace forward */
 bool
-evt_move_trace(struct evt_context *tcx)
+evt_move_trace(struct evt_context *tcx, uint32_t intent)
 {
 	struct evt_trace	*trace;
 	struct evt_node		*nd;
@@ -2859,7 +2853,8 @@ int evt_delete(daos_handle_t toh, const struct evt_rect *rect,
 	filter.fr_ex = rect->rc_ex;
 	filter.fr_epr.epr_lo = rect->rc_epc;
 	filter.fr_epr.epr_hi = rect->rc_epc;
-	rc = evt_ent_array_fill(tcx, EVT_FIND_SAME, &filter, rect, &ent_array);
+	rc = evt_ent_array_fill(tcx, EVT_FIND_SAME, DAOS_INTENT_PUNCH,
+				&filter, rect, &ent_array);
 	if (rc != 0)
 		return rc;
 

--- a/src/vos/tests/vts_io.c
+++ b/src/vos/tests/vts_io.c
@@ -694,7 +694,8 @@ hold_objects(struct vos_object **objs, struct daos_lru_cache *occ,
 	int i = 0, rc = 0;
 
 	for (i = start; i < end; i++) {
-		rc = vos_obj_hold(occ, *coh, *oid, 1, true, &objs[i]);
+		rc = vos_obj_hold(occ, *coh, *oid, 1, true, DAOS_INTENT_DEFAULT,
+				  &objs[i]);
 		assert_int_equal(rc, 0);
 	}
 
@@ -715,10 +716,10 @@ io_oi_test(void **state)
 	cont = vos_hdl2cont(arg->ctx.tc_co_hdl);
 	assert_ptr_not_equal(cont, NULL);
 
-	rc = vos_oi_find_alloc(cont, oid, 1, &obj[0]);
+	rc = vos_oi_find_alloc(cont, oid, 1, DAOS_INTENT_UPDATE, &obj[0]);
 	assert_int_equal(rc, 0);
 
-	rc = vos_oi_find_alloc(cont, oid, 1, &obj[1]);
+	rc = vos_oi_find_alloc(cont, oid, 1, DAOS_INTENT_UPDATE, &obj[1]);
 	assert_int_equal(rc, 0);
 }
 
@@ -763,7 +764,8 @@ io_obj_cache_test(void **state)
 	rc = hold_objects(objs, occ, &ctx->tc_co_hdl, &oids[1], 10, 15);
 	assert_int_equal(rc, 0);
 
-	rc = vos_obj_hold(occ, l_coh, oids[1], 1, true, &objs[16]);
+	rc = vos_obj_hold(occ, l_coh, oids[1], 1, true, DAOS_INTENT_DEFAULT,
+			  &objs[16]);
 	assert_int_equal(rc, 0);
 	vos_obj_release(occ, objs[16]);
 
@@ -1273,7 +1275,7 @@ io_set_attribute_setup(void **state)
 
 	arg->oid = gen_oid(arg->ofeat);
 
-	rc = vos_oi_find_alloc(cont, arg->oid, 1, &obj_df);
+	rc = vos_oi_find_alloc(cont, arg->oid, 1, DAOS_INTENT_UPDATE, &obj_df);
 	assert_int_equal(rc, 0);
 
 	return 0;
@@ -1954,7 +1956,8 @@ oid_iter_test_setup(void **state)
 	for (i = 0; i < VTS_IO_OIDS; i++) {
 		oids[i] = gen_oid(arg->ofeat);
 
-		rc = vos_oi_find_alloc(cont, oids[i], 1, &obj_df);
+		rc = vos_oi_find_alloc(cont, oids[i], 1, DAOS_INTENT_UPDATE,
+				       &obj_df);
 		assert_int_equal(rc, 0);
 	}
 	return 0;

--- a/src/vos/tests/vts_purge.c
+++ b/src/vos/tests/vts_purge.c
@@ -237,7 +237,7 @@ io_create_object(struct vos_container *cont)
 	struct vos_obj_df	*obj;
 
 	oid = dts_unit_oid_gen(0, 0, 0);
-	rc = vos_oi_find_alloc(cont, oid, 1, &obj);
+	rc = vos_oi_find_alloc(cont, oid, 1, DAOS_INTENT_UPDATE, &obj);
 	return rc;
 }
 
@@ -535,7 +535,7 @@ io_multi_dkey_discard(struct io_test_args *arg, int flags)
 	struct vos_obj_df	*obj_res = NULL;
 
 	rc = vos_oi_find(vos_hdl2cont(arg->ctx.tc_co_hdl), last_oid, 1,
-			 &obj_res);
+			 DAOS_INTENT_DEFAULT, &obj_res);
 	assert_int_equal(rc, -DER_NONEXIST);
 	assert_ptr_equal(obj_res, NULL);
 

--- a/src/vos/vea/vea_alloc.c
+++ b/src/vos/vea/vea_alloc.c
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2018 Intel Corporation.
+ * (C) Copyright 2018-2019 Intel Corporation.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,6 +24,7 @@
 #define D_LOGFAC	DD_FAC(vos)
 
 #include <daos/common.h>
+#include <daos/dtx.h>
 #include "vea_internal.h"
 
 void
@@ -98,7 +99,8 @@ reserve_hint(struct vea_space_info *vsi, uint32_t blk_cnt,
 	daos_iov_set(&val, NULL, 0);
 
 	D_ASSERT(!daos_handle_is_inval(vsi->vsi_free_btr));
-	rc = dbtree_fetch(vsi->vsi_free_btr, BTR_PROBE_EQ, &key, NULL, &val);
+	rc = dbtree_fetch(vsi->vsi_free_btr, BTR_PROBE_EQ, DAOS_INTENT_DEFAULT,
+			  &key, NULL, &val);
 	if (rc)
 		return (rc == -DER_NONEXIST) ? 0 : rc;
 
@@ -385,7 +387,8 @@ persistent_alloc(struct vea_space_info *vsi, struct vea_free_extent *vfe)
 	daos_iov_set(&key_out, &blk_off, sizeof(blk_off));
 	daos_iov_set(&val, &found, sizeof(found));
 
-	rc = dbtree_fetch(btr_hdl, opc, &key_in, &key_out, &val);
+	rc = dbtree_fetch(btr_hdl, opc, DAOS_INTENT_PUNCH, &key_in, &key_out,
+			  &val);
 	if (rc) {
 		D_ERROR("failed to find extent ["DF_U64", %u]\n",
 			vfe->vfe_blk_off, vfe->vfe_blk_cnt);

--- a/src/vos/vea/vea_api.c
+++ b/src/vos/vea/vea_api.c
@@ -24,6 +24,7 @@
 
 #include <daos/common.h>
 #include <daos/btree_class.h>
+#include <daos/dtx.h>
 #include "vea_internal.h"
 
 #define VEA_BLK_SZ	(4 * 1024)	/* 4K */
@@ -671,15 +672,15 @@ vea_query(struct vea_space_info *vsi, struct vea_attr *attr,
 		int			 i, rc;
 
 		stat->vs_free_persistent = 0;
-		rc = dbtree_iterate(vsi->vsi_md_free_btr, false,
-				    count_free_persistent,
+		rc = dbtree_iterate(vsi->vsi_md_free_btr, DAOS_INTENT_DEFAULT,
+				    false, count_free_persistent,
 				    (void *)&stat->vs_free_persistent);
 		if (rc != 0)
 			return rc;
 
 		stat->vs_free_transient = 0;
-		rc = dbtree_iterate(vsi->vsi_free_btr, false,
-				    count_free_transient,
+		rc = dbtree_iterate(vsi->vsi_free_btr, DAOS_INTENT_DEFAULT,
+				    false, count_free_transient,
 				    (void *)&stat->vs_free_transient);
 		if (rc != 0)
 			return rc;

--- a/src/vos/vea/vea_free.c
+++ b/src/vos/vea/vea_free.c
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2018 Intel Corporation.
+ * (C) Copyright 2018-2019 Intel Corporation.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,6 +23,7 @@
 #define D_LOGFAC	DD_FAC(vos)
 
 #include <daos/common.h>
+#include <daos/dtx.h>
 #include "vea_internal.h"
 
 enum vea_free_type {
@@ -63,7 +64,8 @@ merge_free_ext(struct vea_space_info *vsi, struct vea_free_extent *ext_in,
 repeat:
 	daos_iov_set(&val, NULL, 0);
 
-	rc = dbtree_fetch(btr_hdl, opc, &key, &key_out, &val);
+	rc = dbtree_fetch(btr_hdl, opc, DAOS_INTENT_PUNCH, &key, &key_out,
+			  &val);
 	if (rc == -DER_NONEXIST && opc == BTR_PROBE_LE) {
 		opc = BTR_PROBE_GE;
 		goto repeat;
@@ -183,7 +185,8 @@ compound_free(struct vea_space_info *vsi, struct vea_free_extent *vfe,
 		     sizeof(dummy.ve_ext.vfe_blk_off));
 	daos_iov_set(&val, NULL, 0);
 
-	rc = dbtree_fetch(vsi->vsi_free_btr, BTR_PROBE_EQ, &key, NULL, &val);
+	rc = dbtree_fetch(vsi->vsi_free_btr, BTR_PROBE_EQ, DAOS_INTENT_DEFAULT,
+			  &key, NULL, &val);
 	D_ASSERT(rc != -DER_NONEXIST);
 	if (rc)
 		return rc;
@@ -288,7 +291,8 @@ aggregated_free(struct vea_space_info *vsi, struct vea_free_extent *vfe)
 		     sizeof(dummy.ve_ext.vfe_blk_off));
 	daos_iov_set(&val, NULL, 0);
 
-	rc = dbtree_fetch(btr_hdl, BTR_PROBE_EQ, &key, NULL, &val);
+	rc = dbtree_fetch(btr_hdl, BTR_PROBE_EQ, DAOS_INTENT_PURGE, &key, NULL,
+			  &val);
 	D_ASSERT(rc != -DER_NONEXIST);
 	if (rc)
 		return rc;

--- a/src/vos/vea/vea_init.c
+++ b/src/vos/vea/vea_init.c
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2018 Intel Corporation.
+ * (C) Copyright 2018-2019 Intel Corporation.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,6 +23,7 @@
 #define D_LOGFAC	DD_FAC(vos)
 
 #include <daos/common.h>
+#include <daos/dtx.h>
 #include "vea_internal.h"
 
 void
@@ -206,14 +207,14 @@ load_space_info(struct vea_space_info *vsi)
 		goto error;
 
 	/* Build up in-memory compound free extent index */
-	rc = dbtree_iterate(vsi->vsi_md_free_btr, false, load_free_entry,
-			    (void *)vsi);
+	rc = dbtree_iterate(vsi->vsi_md_free_btr, DAOS_INTENT_DEFAULT, false,
+			    load_free_entry, (void *)vsi);
 	if (rc != 0)
 		goto error;
 
 	/* Build up in-memory extent vector tree */
-	rc = dbtree_iterate(vsi->vsi_md_vec_btr, false, load_vec_entry,
-			    (void *)vsi);
+	rc = dbtree_iterate(vsi->vsi_md_vec_btr, DAOS_INTENT_DEFAULT, false,
+			    load_vec_entry, (void *)vsi);
 	if (rc != 0)
 		goto error;
 

--- a/src/vos/vea/vea_util.c
+++ b/src/vos/vea/vea_util.c
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2018 Intel Corporation.
+ * (C) Copyright 2018-2019 Intel Corporation.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,6 +23,7 @@
 #define D_LOGFAC	DD_FAC(vos)
 
 #include <daos/common.h>
+#include <daos/dtx.h>
 #include "vea_internal.h"
 
 int
@@ -145,7 +146,7 @@ vea_dump(struct vea_space_info *vsi, bool transient)
 	if (rc)
 		return rc;
 
-	rc = dbtree_iter_probe(ih, opc, NULL, NULL);
+	rc = dbtree_iter_probe(ih, opc, DAOS_INTENT_DEFAULT, NULL, NULL);
 
 	while (rc == 0) {
 		daos_iov_set(&key, NULL, 0);
@@ -244,7 +245,8 @@ repeat:
 	daos_iov_set(&key_out, NULL, 0);
 	daos_iov_set(&val, NULL, 0);
 
-	rc = dbtree_fetch(btr_hdl, opc, &key, &key_out, &val);
+	rc = dbtree_fetch(btr_hdl, opc, DAOS_INTENT_DEFAULT, &key, &key_out,
+			  &val);
 	if (rc == -DER_NONEXIST && opc == BTR_PROBE_LE) {
 		opc = BTR_PROBE_GE;
 		goto repeat;

--- a/src/vos/vos_aggregate.c
+++ b/src/vos/vos_aggregate.c
@@ -328,6 +328,7 @@ vos_aggregate(daos_handle_t coh, daos_epoch_range_t *epr)
 	agg_param.ap_credits = 0;
 	agg_param.ap_discard = false;
 
+	iter_param.ip_flags |= VOS_IT_FOR_PURGE;
 	rc = vos_iterate(&iter_param, VOS_ITER_OBJ, true, &anchors,
 			 vos_aggregate_cb, &agg_param);
 	if (rc != 0)
@@ -381,6 +382,7 @@ vos_discard(daos_handle_t coh, daos_epoch_range_t *epr)
 	agg_param.ap_credits = 0;
 	agg_param.ap_discard = true;
 
+	iter_param.ip_flags |= VOS_IT_FOR_PURGE;
 	rc = vos_iterate(&iter_param, VOS_ITER_OBJ, true, &anchors,
 			 vos_aggregate_cb, &agg_param);
 

--- a/src/vos/vos_container.c
+++ b/src/vos/vos_container.c
@@ -683,7 +683,11 @@ cont_iter_probe(struct vos_iterator *iter, daos_anchor_t *anchor)
 	D_ASSERT(iter->it_type == VOS_ITER_COUUID);
 
 	opc = anchor == NULL ? BTR_PROBE_FIRST : BTR_PROBE_GE;
-	return dbtree_iter_probe(co_iter->cot_hdl, opc, NULL, anchor);
+	/* The container tree will not be affected by the iterator intent,
+	 * just set it as DAOS_INTENT_DEFAULT.
+	 */
+	return dbtree_iter_probe(co_iter->cot_hdl, opc, DAOS_INTENT_DEFAULT,
+				 NULL, anchor);
 }
 
 static int

--- a/src/vos/vos_internal.h
+++ b/src/vos/vos_internal.h
@@ -713,8 +713,10 @@ struct vos_iterator {
 	struct vos_iterator	*it_parent; /* parent iterator */
 	vos_iter_type_t		 it_type;
 	enum vos_iter_state	 it_state;
-	bool			 it_from_parent;
 	uint32_t		 it_ref_cnt;
+	uint32_t		 it_from_parent:1,
+				 it_for_purge:1,
+				 it_for_rebuild:1;
 };
 
 /* Auxiliary structure for passing information between parent and nested
@@ -741,8 +743,8 @@ struct vos_iter_info {
 	daos_epoch_range_t	 ii_epr;
 	/** epoch logic expression for the iterator. */
 	vos_it_epc_expr_t	 ii_epc_expr;
-	/** recx visibility flags */
-	uint32_t		 ii_recx_flags;
+	/** iterator flags */
+	uint32_t		 ii_flags;
 
 };
 
@@ -833,8 +835,8 @@ enum {
 int
 key_tree_prepare(struct vos_object *obj, daos_epoch_t epoch,
 		 daos_handle_t toh, enum vos_tree_class tclass,
-		 daos_key_t *key, int flags, struct vos_krec_df **krec,
-		 daos_handle_t *sub_toh);
+		 daos_key_t *key, int flags, uint32_t intent,
+		 struct vos_krec_df **krec, daos_handle_t *sub_toh);
 void
 key_tree_release(daos_handle_t toh, bool is_array);
 int
@@ -906,6 +908,16 @@ vos_tx_end(struct vos_pool *vpool, int rc)
 
 	return umem_tx_commit(&vpool->vp_umm);
 
+}
+
+static inline uint32_t
+vos_iter_intent(struct vos_iterator *iter)
+{
+	if (iter->it_for_purge)
+		return DAOS_INTENT_PURGE;
+	if (iter->it_for_rebuild)
+		return DAOS_INTENT_REBUILD;
+	return DAOS_INTENT_DEFAULT;
 }
 
 #endif /* __VOS_INTERNAL_H__ */

--- a/src/vos/vos_iterator.c
+++ b/src/vos/vos_iterator.c
@@ -133,7 +133,7 @@ nested_prepare(vos_iter_type_t type, struct vos_iter_dict *dict,
 	}
 
 	info.ii_epc_expr = param->ip_epc_expr;
-	info.ii_recx_flags = param->ip_recx_flags;
+	info.ii_flags = param->ip_flags;
 	info.ii_akey = &param->ip_akey;
 
 	rc = dict->id_ops->iop_nested_prepare(type, &info, &citer);
@@ -150,7 +150,7 @@ nested_prepare(vos_iter_type_t type, struct vos_iter_dict *dict,
 	citer->it_state		= VOS_ITS_NONE;
 	citer->it_ref_cnt	= 1;
 	citer->it_parent	= iter;
-	citer->it_from_parent	= true;
+	citer->it_from_parent	= 1;
 
 	*cih = vos_iter2hdl(citer);
 	return 0;
@@ -203,7 +203,7 @@ vos_iter_prepare(vos_iter_type_t type, vos_iter_param_t *param,
 	iter->it_state		= VOS_ITS_NONE;
 	iter->it_ref_cnt	= 1;
 	iter->it_parent		= NULL;
-	iter->it_from_parent	= false;
+	iter->it_from_parent	= 0;
 
 	*ih = vos_iter2hdl(iter);
 	return 0;

--- a/src/vos/vos_obj.c
+++ b/src/vos/vos_obj.c
@@ -48,8 +48,8 @@ struct vos_obj_iter {
 	daos_handle_t		 it_hdl;
 	/** condition of the iterator: epoch logic expression */
 	vos_it_epc_expr_t	 it_epc_expr;
-	/** recx visibility flags */
-	uint32_t		 it_recx_flags;
+	/** iterator flags */
+	uint32_t		 it_flags;
 	/** condition of the iterator: epoch range */
 	daos_epoch_range_t	 it_epr;
 	/** condition of the iterator: attribute key */
@@ -113,7 +113,8 @@ key_punch(struct vos_object *obj, daos_epoch_t epoch, uint32_t pm_ver,
 		int		i;
 
 		rc = key_tree_prepare(obj, epoch, obj->obj_toh, VOS_BTR_DKEY,
-				      dkey, SUBTR_CREATE, NULL, &toh);
+				      dkey, SUBTR_CREATE, DAOS_INTENT_PUNCH,
+				      NULL, &toh);
 		if (rc) {
 			/* If the key is punched, then do nothing */
 			if (rc == -DER_NONEXIST)
@@ -171,7 +172,7 @@ vos_obj_punch(daos_handle_t coh, daos_unit_oid_t oid, daos_epoch_t epoch,
 
 	/* NB: punch always generate a new incarnation of the object */
 	rc = vos_obj_hold(vos_obj_cache_current(), coh, oid, epoch,
-			  false, &obj);
+			  false, DAOS_INTENT_PUNCH, &obj);
 	if (rc != 0)
 		return rc;
 
@@ -352,7 +353,8 @@ key_iter_match(struct vos_obj_iter *oiter, vos_iter_entry_t *ent, int *probe_p)
 	}
 
 	rc = key_tree_prepare(obj, ent->ie_epoch, obj->obj_toh, VOS_BTR_DKEY,
-			      &ent->ie_key, 0, NULL, &toh);
+			      &ent->ie_key, 0, vos_iter_intent(&oiter->it_iter),
+			      NULL, &toh);
 	if (rc != 0) {
 		D_DEBUG(DB_IO, "can't load the akey tree: %d\n", rc);
 		return rc;
@@ -364,8 +366,8 @@ key_iter_match(struct vos_obj_iter *oiter, vos_iter_entry_t *ent, int *probe_p)
 	kbund.kb_key = &oiter->it_akey;
 	kbund.kb_epoch = epr->epr_lo;
 
-	rc = dbtree_fetch(toh, BTR_PROBE_GT | BTR_PROBE_MATCHED, &kiov, NULL,
-			  &riov);
+	rc = dbtree_fetch(toh, BTR_PROBE_GT | BTR_PROBE_MATCHED,
+			  vos_iter_intent(&oiter->it_iter), &kiov, NULL, &riov);
 	key_tree_release(toh, false);
 	if (rc == 0)
 		return IT_OPC_NOOP; /* match the condition (akey), done */
@@ -409,7 +411,9 @@ key_iter_match_probe(struct vos_obj_iter *oiter)
 			tree_key_bundle2iov(&kbund, &kiov);
 			kbund.kb_key	= &entry.ie_key;
 			kbund.kb_epoch	= entry.ie_epoch;
-			rc = dbtree_iter_probe(oiter->it_hdl, opc, &kiov, NULL);
+			rc = dbtree_iter_probe(oiter->it_hdl, opc,
+					       vos_iter_intent(&oiter->it_iter),
+					       &kiov, NULL);
 			if (rc)
 				goto out;
 			break;
@@ -433,6 +437,7 @@ key_iter_probe(struct vos_obj_iter *oiter, daos_anchor_t *anchor)
 
 	rc = dbtree_iter_probe(oiter->it_hdl,
 			       anchor ? BTR_PROBE_GE : BTR_PROBE_FIRST,
+			       vos_iter_intent(&oiter->it_iter),
 			       NULL, anchor);
 	if (rc)
 		D_GOTO(out, rc);
@@ -483,7 +488,8 @@ akey_iter_prepare(struct vos_obj_iter *oiter, daos_key_t *dkey)
 	int			 rc;
 
 	rc = key_tree_prepare(obj, oiter->it_epr.epr_lo, obj->obj_toh,
-			      VOS_BTR_DKEY, dkey, 0, NULL, &toh);
+			      VOS_BTR_DKEY, dkey, 0,
+			      vos_iter_intent(&oiter->it_iter), NULL, &toh);
 	if (rc != 0) {
 		D_ERROR("Cannot load the akey tree: %d\n", rc);
 		return rc;
@@ -522,12 +528,14 @@ singv_iter_prepare(struct vos_obj_iter *oiter, daos_key_t *dkey,
 	int			 rc;
 
 	rc = key_tree_prepare(obj, oiter->it_epr.epr_hi, obj->obj_toh,
-			      VOS_BTR_DKEY, dkey, 0, NULL, &dk_toh);
+			      VOS_BTR_DKEY, dkey, 0,
+			      vos_iter_intent(&oiter->it_iter), NULL, &dk_toh);
 	if (rc != 0)
 		D_GOTO(failed_0, rc);
 
 	rc = key_tree_prepare(obj, oiter->it_epr.epr_hi, dk_toh,
-			      VOS_BTR_AKEY, akey, 0, NULL, &ak_toh);
+			      VOS_BTR_AKEY, akey, 0,
+			      vos_iter_intent(&oiter->it_iter), NULL, &ak_toh);
 	if (rc != 0)
 		D_GOTO(failed_1, rc);
 
@@ -560,7 +568,8 @@ singv_iter_probe_fetch(struct vos_obj_iter *oiter, dbtree_probe_opc_t opc,
 	tree_key_bundle2iov(&kbund, &kiov);
 	kbund.kb_epoch = entry->ie_epoch;
 
-	rc = dbtree_iter_probe(oiter->it_hdl, opc, &kiov, NULL);
+	rc = dbtree_iter_probe(oiter->it_hdl, opc,
+			       vos_iter_intent(&oiter->it_iter), &kiov, NULL);
 	if (rc != 0)
 		return rc;
 
@@ -655,7 +664,8 @@ singv_iter_probe(struct vos_obj_iter *oiter, daos_anchor_t *anchor)
 	else
 		opc = anchor == NULL ? BTR_PROBE_FIRST : BTR_PROBE_GE;
 
-	rc = dbtree_iter_probe(oiter->it_hdl, opc, NULL, anchor);
+	rc = dbtree_iter_probe(oiter->it_hdl, opc,
+			       vos_iter_intent(&oiter->it_iter), NULL, anchor);
 	if (rc != 0)
 		return rc;
 
@@ -750,22 +760,25 @@ recx_get_flags(struct vos_obj_iter *oiter)
 {
 	uint32_t options = EVT_ITER_EMBEDDED;
 
-	if (recx_flags_set(oiter->it_recx_flags,
+	if (recx_flags_set(oiter->it_flags,
 			   VOS_IT_RECX_VISIBLE | VOS_IT_RECX_SKIP_HOLES)) {
 		options |= EVT_ITER_VISIBLE | EVT_ITER_SKIP_HOLES;
-		D_ASSERT(!recx_flags_set(oiter->it_recx_flags,
-					 VOS_IT_RECX_COVERED));
+		D_ASSERT(!recx_flags_set(oiter->it_flags, VOS_IT_RECX_COVERED));
 		goto done;
 	}
-	D_ASSERT(!recx_flags_set(oiter->it_recx_flags, VOS_IT_RECX_SKIP_HOLES));
-	if (oiter->it_recx_flags & VOS_IT_RECX_VISIBLE)
+	D_ASSERT(!recx_flags_set(oiter->it_flags, VOS_IT_RECX_SKIP_HOLES));
+	if (oiter->it_flags & VOS_IT_RECX_VISIBLE)
 		options |= EVT_ITER_VISIBLE;
-	if (oiter->it_recx_flags & VOS_IT_RECX_COVERED)
+	if (oiter->it_flags & VOS_IT_RECX_COVERED)
 		options |= EVT_ITER_COVERED;
 
 done:
-	if (oiter->it_recx_flags & VOS_IT_RECX_REVERSE)
+	if (oiter->it_flags & VOS_IT_RECX_REVERSE)
 		options |= EVT_ITER_REVERSE;
+	if (oiter->it_flags & VOS_IT_FOR_PURGE)
+		options |= EVT_ITER_FOR_PURGE;
+	if (oiter->it_flags & VOS_IT_FOR_REBUILD)
+		options |= EVT_ITER_FOR_REBUILD;
 	return options;
 }
 
@@ -784,12 +797,14 @@ recx_iter_prepare(struct vos_obj_iter *oiter, daos_key_t *dkey,
 	uint32_t		 options;
 
 	rc = key_tree_prepare(obj, oiter->it_epr.epr_hi, obj->obj_toh,
-			      VOS_BTR_DKEY, dkey, 0, NULL, &dk_toh);
+			      VOS_BTR_DKEY, dkey, 0,
+			      vos_iter_intent(&oiter->it_iter), NULL, &dk_toh);
 	if (rc != 0)
 		D_GOTO(failed_0, rc);
 
 	rc = key_tree_prepare(obj, oiter->it_epr.epr_hi, dk_toh,
-			      VOS_BTR_AKEY, akey, SUBTR_EVT, NULL, &ak_toh);
+			      VOS_BTR_AKEY, akey, SUBTR_EVT,
+			      vos_iter_intent(&oiter->it_iter), NULL, &ak_toh);
 	if (rc != 0)
 		D_GOTO(failed_1, rc);
 
@@ -913,14 +928,19 @@ vos_obj_iter_prep(vos_iter_type_t type, vos_iter_param_t *param,
 
 	oiter->it_epr = param->ip_epr;
 	oiter->it_epc_expr = param->ip_epc_expr;
-	oiter->it_recx_flags = param->ip_recx_flags;
+	oiter->it_flags = param->ip_flags;
+	if (param->ip_flags & VOS_IT_FOR_PURGE)
+		oiter->it_iter.it_for_purge = 1;
+	if (param->ip_flags & VOS_IT_FOR_REBUILD)
+		oiter->it_iter.it_for_rebuild = 1;
+
 	/* XXX the condition epoch ranges could cover multiple versions of
 	 * the object/key if it's punched more than once. However, rebuild
 	 * system should guarantee this will never happen.
 	 */
 	rc = vos_obj_hold(vos_obj_cache_current(), param->ip_hdl,
 			  param->ip_oid, param->ip_epr.epr_hi, true,
-			  &oiter->it_obj);
+			  vos_iter_intent(&oiter->it_iter), &oiter->it_obj);
 	if (rc != 0)
 		D_GOTO(failed, rc);
 
@@ -1021,7 +1041,7 @@ nested_dkey_iter_init(struct vos_obj_iter *oiter, struct vos_iter_info *info)
 	 */
 	rc = vos_obj_hold(vos_obj_cache_current(), info->ii_hdl,
 			  info->ii_oid, info->ii_epr.epr_hi, true,
-			  &oiter->it_obj);
+			  vos_iter_intent(&oiter->it_iter), &oiter->it_obj);
 	if (rc != 0)
 		return rc;
 
@@ -1063,9 +1083,13 @@ vos_obj_iter_nested_prep(vos_iter_type_t type, struct vos_iter_info *info,
 
 	oiter->it_epr = info->ii_epr;
 	oiter->it_epc_expr = info->ii_epc_expr;
-	oiter->it_recx_flags = info->ii_recx_flags;
+	oiter->it_flags = info->ii_flags;
 	if (type != VOS_ITER_DKEY)
 		oiter->it_obj = info->ii_obj;
+	if (info->ii_flags & VOS_IT_FOR_PURGE)
+		oiter->it_iter.it_for_purge = 1;
+	if (info->ii_flags & VOS_IT_FOR_REBUILD)
+		oiter->it_iter.it_for_rebuild = 1;
 
 	switch (type) {
 	default:
@@ -1334,7 +1358,7 @@ vos_oi_set_attr_helper(daos_handle_t coh, daos_unit_oid_t oid,
 	int			 rc;
 
 	rc = vos_obj_hold(vos_obj_cache_current(), coh, oid, epoch, false,
-			  &obj);
+			  DAOS_INTENT_UPDATE, &obj);
 	if (rc != 0)
 		return rc;
 
@@ -1408,7 +1432,7 @@ vos_oi_get_attr(daos_handle_t coh, daos_unit_oid_t oid, daos_epoch_t epoch,
 	}
 
 	rc = vos_obj_hold(vos_obj_cache_current(), coh, oid, epoch, true,
-			  &obj);
+			  DAOS_INTENT_DEFAULT, &obj);
 	if (rc != 0)
 		return rc;
 

--- a/src/vos/vos_obj.h
+++ b/src/vos/vos_obj.h
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2016 Intel Corporation.
+ * (C) Copyright 2016-2019 Intel Corporation.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -59,12 +59,13 @@ struct vos_container;
  * \param oid	[IN]	VOS object ID.
  * \param no_create [IN]
  *			Do not allocate object if it's not there yet.
+ * \param intent [IN]	The request intent.
  * \param obj_p [OUT]	Returned object cache reference.
  */
 int
 vos_obj_hold(struct daos_lru_cache *occ, daos_handle_t coh,
 	     daos_unit_oid_t oid, daos_epoch_t epoch,
-	     bool no_create, struct vos_object **obj_p);
+	     bool no_create, uint32_t intent, struct vos_object **obj_p);
 
 /**
  * Release the object cache reference.
@@ -142,6 +143,7 @@ vos_oi_update_metadata(daos_handle_t coh, daos_unit_oid_t oid);
  *
  * \param coh	[IN]	Container handle
  * \param oid	[IN]	DAOS object ID
+ * \param intent [IN]	The request intent
  * \param obj	[OUT]	Direct pointer to VOS object
  *
  * \return		0 on success and negative on
@@ -149,7 +151,8 @@ vos_oi_update_metadata(daos_handle_t coh, daos_unit_oid_t oid);
  */
 int
 vos_oi_find_alloc(struct vos_container *cont, daos_unit_oid_t oid,
-		  daos_epoch_t epoch, struct vos_obj_df **obj);
+		  daos_epoch_t epoch, uint32_t intent,
+		  struct vos_obj_df **obj);
 
 /**
  * Find an enty in the obj_index by @oid
@@ -158,6 +161,7 @@ vos_oi_find_alloc(struct vos_container *cont, daos_unit_oid_t oid,
  *
  * \param coh	[IN]	Container handle
  * \param oid	[IN]	DAOS object ID
+ * \param intent [IN]	The operation intent
  * \param obj	[OUT]	Direct pointer to VOS object
  *
  * \return		0 on success and negative on
@@ -165,7 +169,7 @@ vos_oi_find_alloc(struct vos_container *cont, daos_unit_oid_t oid,
  */
 int
 vos_oi_find(struct vos_container *cont, daos_unit_oid_t oid,
-	    daos_epoch_t epoch, struct vos_obj_df **obj);
+	    daos_epoch_t epoch, uint32_t intent, struct vos_obj_df **obj);
 
 /**
  * Punch an object from the OI table

--- a/src/vos/vos_obj_cache.c
+++ b/src/vos/vos_obj_cache.c
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2016-2018 Intel Corporation.
+ * (C) Copyright 2016-2019 Intel Corporation.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -196,7 +196,7 @@ vos_obj_release(struct daos_lru_cache *occ, struct vos_object *obj)
 int
 vos_obj_hold(struct daos_lru_cache *occ, daos_handle_t coh,
 	     daos_unit_oid_t oid, daos_epoch_t epoch,
-	     bool no_create, struct vos_object **obj_p)
+	     bool no_create, uint32_t intent, struct vos_object **obj_p)
 {
 
 	struct vos_object	*obj;
@@ -256,14 +256,14 @@ vos_obj_hold(struct daos_lru_cache *occ, daos_handle_t coh,
 		no_create ? "find" : "find/create", DP_UOID(oid), epoch);
 
 	if (no_create) {
-		rc = vos_oi_find(cont, oid, epoch, &obj->obj_df);
+		rc = vos_oi_find(cont, oid, epoch, intent, &obj->obj_df);
 		if (rc == -DER_NONEXIST) {
 			D_DEBUG(DB_TRACE, "non exist oid "DF_UOID"\n",
 				DP_UOID(oid));
 			rc = 0;
 		}
 	} else {
-		rc = vos_oi_find_alloc(cont, oid, epoch, &obj->obj_df);
+		rc = vos_oi_find_alloc(cont, oid, epoch, intent, &obj->obj_df);
 		D_ASSERT(rc || obj->obj_df);
 	}
 
@@ -315,7 +315,7 @@ vos_obj_revalidate(struct daos_lru_cache *occ, daos_epoch_t epoch,
 		return 0;
 
 	rc = vos_obj_hold(occ, vos_cont2hdl(obj->obj_cont), obj->obj_id,
-			  epoch, !obj->obj_df, obj_p);
+			  epoch, !obj->obj_df, DAOS_INTENT_UPDATE, obj_p);
 	if (rc == 0) {
 		D_ASSERT(*obj_p != obj);
 		vos_obj_release(occ, obj);


### PR DESCRIPTION
The operation intent affects the visibility (that will be
implemented in subsequent patches) of related records that
have ever been touched by DTX (with status of committed,
committable, or aborted).

The intent will be used by the DTX in subsequent patches.

Signed-off-by: Fan Yong <fan.yong@intel.com>
Change-Id: I1568d098306762f5a806f98ea5d77b4cd866937a