### PR TITLE
DAOS-1441 vos: handle resent RPC

### DIFF
--- a/src/common/mem.c
+++ b/src/common/mem.c
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2016-2018 Intel Corporation.
+ * (C) Copyright 2016-2019 Intel Corporation.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -44,6 +44,12 @@ struct umem_tx_stage_item {
 };
 
 /** persistent memory operations (depends on pmdk) */
+
+static umem_id_t
+pmem_id(struct umem_instance *umm, void *addr)
+{
+	return pmemobj_oid(addr);
+}
 
 static void *
 pmem_addr(struct umem_instance *umm, umem_id_t ummid)
@@ -290,6 +296,7 @@ pmem_tx_add_callback(struct umem_instance *umm, struct umem_tx_stage_data *txd,
 }
 
 static umem_ops_t	pmem_ops = {
+	.mo_id			= pmem_id,
 	.mo_addr		= pmem_addr,
 	.mo_equal		= pmem_equal,
 	.mo_tx_free		= pmem_tx_free,
@@ -330,6 +337,15 @@ umem_tx_errno(int err)
 }
 
 /* volatile memroy operations */
+
+static umem_id_t
+vmem_id(struct umem_instance *umm, void *addr)
+{
+	umem_id_t	ummid = UMMID_NULL;
+
+	ummid.off = (uint64_t)addr;
+	return ummid;
+}
 
 static void *
 vmem_addr(struct umem_instance *umm, umem_id_t ummid)
@@ -384,6 +400,7 @@ vmem_tx_add_callback(struct umem_instance *umm, struct umem_tx_stage_data *txd,
 }
 
 static umem_ops_t	vmem_ops = {
+	.mo_id		= vmem_id,
 	.mo_addr	= vmem_addr,
 	.mo_equal	= vmem_equal,
 	.mo_tx_free	= vmem_free,

--- a/src/include/daos/mem.h
+++ b/src/include/daos/mem.h
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2016-2018 Intel Corporation.
+ * (C) Copyright 2016-2019 Intel Corporation.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -110,6 +110,8 @@ int  umem_init_txd(struct umem_tx_stage_data *txd);
 void umem_fini_txd(struct umem_tx_stage_data *txd);
 
 typedef struct {
+	/** convert directly accessible address to ummid */
+	umem_id_t	 (*mo_id)(struct umem_instance *umm, void *addr);
 	/** convert ummid to directly accessible address */
 	void		*(*mo_addr)(struct umem_instance *umm,
 				    umem_id_t ummid);
@@ -358,6 +360,12 @@ static inline void *
 umem_id2ptr(struct umem_instance *umm, umem_id_t ummid)
 {
 	return umm->umm_ops->mo_addr(umm, ummid);
+}
+
+static inline umem_id_t
+umem_ptr2id(struct umem_instance *umm, void *ptr)
+{
+	return umm->umm_ops->mo_id(umm, ptr);
 }
 
 #define umem_id2ptr_typed(umm, tmmid)					\

--- a/src/include/daos_srv/dtx_srv.h
+++ b/src/include/daos_srv/dtx_srv.h
@@ -45,6 +45,11 @@ enum daos_tx_flags {
 	DTX_F_AOC		= 1,
 };
 
+enum dtx_cos_list_types {
+	DCLT_UPDATE		= (1 << 0),
+	DCLT_PUNCH		= (1 << 1),
+};
+
 /**
  * DAOS two-phase commit transaction handle in DRAM.
  */

--- a/src/include/daos_srv/vos.h
+++ b/src/include/daos_srv/vos.h
@@ -37,6 +37,24 @@
 #include <daos_srv/vos_types.h>
 
 /**
+ * Check whether the given @dti belongs to a resent RPC or not.
+ *
+ * \param coh	[IN]	Container open handle.
+ * \param dti	[IN]	The DTX identifier.
+ *
+ * \return		Zero if related DTX is there ('prepared'),
+ *			but not committed yet.
+ * \return		-DER_ALREADY if related DTX has been committed.
+ * \return		-DER_NONEXIST if no modification has been done before.
+ * \return		-DER_INPROGRESS if some new DTX ('init') is there.
+ * \return		-DER_TIMEDOUT if the DTX is too old as to we are not
+ *			sure about whether it has ever been processed or not.
+ * \return		Other negative value if error.
+ */
+int
+vos_dtx_handle_resend(daos_handle_t coh, struct daos_tx_id *dti);
+
+/**
  * Prepare the DTX handle in DRAM.
  *
  * XXX: Currently, we only support to prepare the DTX against single DAOS

--- a/src/include/daos_srv/vos.h
+++ b/src/include/daos_srv/vos.h
@@ -33,7 +33,53 @@
 
 #include <daos/common.h>
 #include <daos_types.h>
+#include <daos_srv/dtx_srv.h>
 #include <daos_srv/vos_types.h>
+
+/**
+ * Search the specified DTX is in the CoS cache or not.
+ *
+ * \param coh	[IN]	Container open handle.
+ * \param oid	[IN]	Pointer to the object ID.
+ * \param xid	[IN]	Pointer to the DTX identifier.
+ * \param dkey	[IN]	The hashed dkey.
+ * \param punch	[IN]	For punch DTX or not.
+ *
+ * \return	0 if the DTX exists in the CoS cache.
+ * \return	-DER_NONEXIST if not in the CoS cache.
+ * \return	Other negative values on error.
+ */
+int
+vos_dtx_lookup_cos(daos_handle_t coh, daos_unit_oid_t *oid,
+		   struct daos_tx_id *xid, uint64_t dkey, bool punch);
+
+/**
+ * Fetch the list of the DTXs to be committed because of (potential) share.
+ *
+ * \param coh		[IN]	Container open handle.
+ * \param oid		[IN]	The target object (shard) ID.
+ * \param dkey		[IN]	The target dkey to be modified.
+ * \param types		[IN]	The DTX types to be listed.
+ * \param dtis		[OUT]	The DTX IDs array to be committed for share.
+ *
+ * \return			The count of DTXs to be committed for share
+ *				on success, negative value if error.
+ */
+int
+vos_dtx_list_cos(daos_handle_t coh, daos_unit_oid_t *oid,
+		 daos_key_t *dkey, uint32_t types, struct daos_tx_id **dtis);
+
+/**
+ * Fetch the list of the DTXs that can be committed.
+ *
+ * \param coh	[IN]	Container open handle.
+ * \param dtes	[OUT]	The array for DTX entries can be committed.
+ *
+ * \return		The count of DTXs can be committed on success,
+ *			negative value if error.
+ */
+int
+vos_dtx_list_committable(daos_handle_t coh, struct daos_tx_entry **dtes);
 
 /**
  * Initialize the environment for a VOS instance

--- a/src/vos/SConscript
+++ b/src/vos/SConscript
@@ -5,7 +5,7 @@ import daos_build
 FILES = ["evt_iter.c", "vos_common.c", "vos_iterator.c", "vos_obj.c",
          "vos_pool.c", "vos_aggregate.c", "vos_container.c", "vos_io.c",
          "vos_obj_cache.c", "vos_obj_index.c", "vos_tree.c", "evtree.c",
-         "vos_dtx.c", "vos_query.c"]
+         "vos_dtx.c", "vos_dtx_cos.c", "vos_query.c"]
 
 def build_vos(env, standalone):
     """build vos"""

--- a/src/vos/vos_common.c
+++ b/src/vos/vos_common.c
@@ -35,6 +35,13 @@
 #include <daos/lru.h>
 #include <daos/btree_class.h>
 
+/**
+ * The vos_start_time records the timestamp when server starts the serive.
+ * Via comparing with the DTX entry's timestamp, we can know whether
+ * the DTX happened before the server restarting its service or not.
+ */
+double vos_start_time;
+
 static pthread_mutex_t	mutex = PTHREAD_MUTEX_INITIALIZER;
 /**
  * Object cache based on mode of instantiation
@@ -367,6 +374,7 @@ vos_init(void)
 	if (rc)
 		D_GOTO(exit, rc);
 
+	vos_start_time = ABT_get_wtime();
 	is_init = 1;
 exit:
 	D_MUTEX_UNLOCK(&mutex);

--- a/src/vos/vos_common.c
+++ b/src/vos/vos_common.c
@@ -228,6 +228,12 @@ vos_mod_init(void)
 		return rc;
 	}
 
+	rc = vos_dtx_cos_register();
+	if (rc != 0) {
+		D_ERROR("DTX CoS btree initialization error\n");
+		return rc;
+	}
+
 	/**
 	 * Registering the class for OI btree
 	 * and KV btree

--- a/src/vos/vos_container.c
+++ b/src/vos/vos_container.c
@@ -362,6 +362,7 @@ vos_cont_open(daos_handle_t poh, uuid_t co_uuid, daos_handle_t *coh)
 	cont->vc_dtx_cos_hdl = DAOS_HDL_INVAL;
 	D_INIT_LIST_HEAD(&cont->vc_dtx_committable);
 	cont->vc_dtx_committable_count = 0;
+	cont->vc_dtx_time_last_commit = ABT_get_wtime();
 
 	/* Cache this btr object ID in container handle */
 	rc = dbtree_open_inplace_ex(&cont->vc_otab_df->obt_btr,

--- a/src/vos/vos_dtx.c
+++ b/src/vos/vos_dtx.c
@@ -31,6 +31,19 @@
 #include "vos_layout.h"
 #include "vos_internal.h"
 
+#define DTX_RETURN_INPROGRESS(dtx, pos)					 \
+do {									 \
+	if ((dtx) != NULL)						 \
+		D_DEBUG(DB_TRACE, "Hit uncommitted DTX "DF_DTI		 \
+			" with state %u, time %lu at %d\n",		 \
+			DP_DTI(&(dtx)->te_xid), (dtx)->te_state,	 \
+			(dtx)->te_sec, (pos));				 \
+	else								 \
+		D_DEBUG(DB_TRACE, "Hit uncommitted DTX at %d\n", (pos)); \
+									 \
+	return -DER_INPROGRESS;						 \
+} while (0)
+
 struct dtx_rec_bundle {
 	umem_id_t	trb_ummid;
 };
@@ -589,6 +602,66 @@ vos_dtx_abort_one(struct vos_container *cont, struct daos_tx_id *dti,
 		rc = 0;
 
 	return rc;
+}
+
+int
+vos_dtx_handle_resend(daos_handle_t coh, struct daos_tx_id *dti)
+{
+	struct vos_container	*cont;
+	struct vos_dtx_entry_df	*dtx;
+	daos_iov_t		 kiov;
+	daos_iov_t		 riov;
+	int			 rc;
+
+	cont = vos_hdl2cont(coh);
+	D_ASSERT(cont != NULL);
+
+	daos_iov_set(&kiov, dti, sizeof(*dti));
+	daos_iov_set(&riov, NULL, 0);
+	rc = dbtree_lookup(cont->vc_dtx_active_hdl, &kiov, &riov);
+	if (rc == -DER_NONEXIST)
+		rc = dbtree_lookup(cont->vc_dtx_committed_hdl, &kiov, &riov);
+
+	if (rc == -DER_NONEXIST) {
+		/* If the resent RPC is too old, then we cannot know whether
+		 * the RPC has ever been executed before or not. Then return
+		 * -DER_TIMEDOUT to the RPC sponsor. Means that modification
+		 * for such RPC may have been executed, but nobody guarantee
+		 * that. It is the caller's duty to check related record(s).
+		 */
+		if ((uint64_t)ABT_get_wtime() - dti->dti_sec >
+		    DTX_AGGREGATION_THRESHOLD_TIME) {
+			D_DEBUG(DB_IO, "Not sure about whether the RPC "
+				DF_DTI" is resend or not.\n", DP_DTI(dti));
+			return -DER_TIMEDOUT;
+		}
+	}
+
+	if (rc != 0)
+		return rc;
+
+	dtx = (struct vos_dtx_entry_df *)riov.iov_buf;
+	switch (dtx->te_state) {
+	case DTX_ST_INIT:
+		/* New DTX after the leader (re)start that is not
+		 * completed yet, retry related RPC some time later.
+		 */
+		if (dtx->te_sec >= (uint64_t)vos_start_time)
+			DTX_RETURN_INPROGRESS(dtx, 1);
+
+		/* The INIT DTX in PRAM must be for an in-update object/key
+		 * that was waiting for the bulk transfer (or remote abort)
+		 * before the VOS restart. So here, it should be the case
+		 * that client resends RPC after server restart.
+		 */
+		return 0;
+	case DTX_ST_PREPARED:
+		return 0;
+	case DTX_ST_COMMITTED:
+		return -DER_ALREADY;
+	default:
+		return -DER_INVAL;
+	}
 }
 
 int

--- a/src/vos/vos_dtx.c
+++ b/src/vos/vos_dtx.c
@@ -219,3 +219,603 @@ vos_dtx_table_destroy(struct vos_pool *pool, struct vos_dtx_table_df *dtab_df)
 
 	return rc;
 }
+
+static int
+dtx_rec_release(struct umem_instance *umm, umem_id_t ummid,
+		bool abort, bool destroy)
+{
+	struct vos_dtx_entry_df		*dtx;
+
+	dtx = umem_id2ptr(umm, ummid);
+	/* The caller has started the PMDK transaction. */
+	umem_tx_add_ptr(umm, dtx, sizeof(*dtx));
+
+	while (!UMMID_IS_NULL(dtx->te_records)) {
+		umem_id_t			 rec_mmid = dtx->te_records;
+		struct vos_dtx_record_df	*rec;
+
+		rec = umem_id2ptr(umm, rec_mmid);
+		switch (rec->tr_type) {
+		case DTX_RT_OBJ: {
+			struct vos_obj_df	*obj;
+
+			obj = umem_id2ptr(umm, rec->tr_record);
+			umem_tx_add_ptr(umm, obj, sizeof(*obj));
+			obj->vo_dtx_shares--;
+
+			/* Other DTX that shares the object has committed. */
+			if (UMMID_IS_NULL(obj->vo_dtx)) {
+				if (dtx->te_epoch > obj->vo_latest)
+					obj->vo_latest = dtx->te_epoch;
+				if (dtx->te_epoch < obj->vo_earliest)
+					obj->vo_earliest = dtx->te_epoch;
+
+				break;
+			}
+
+			/* commit case */
+			if (!abort) {
+				obj->vo_dtx = UMMID_NULL;
+				obj->vo_latest = dtx->te_epoch;
+				obj->vo_earliest = dtx->te_epoch;
+				break;
+			}
+
+			/* The last shared DTX is aborted. */
+			if (obj->vo_dtx_shares == 0) {
+				obj->vo_dtx = DTX_UMMID_ABORTED;
+				break;
+			}
+
+			/* I am not the original DTX that create the object. */
+			if (!umem_id_equal(umm, obj->vo_dtx, ummid))
+				break;
+
+			/* I am the original DTX that create the object that
+			 * is still shared by others. Now, I will be aborted,
+			 * set the reference as UNKNOWN for other left shares.
+			 */
+			obj->vo_dtx = DTX_UMMID_UNKNOWN;
+			break;
+		}
+		case DTX_RT_KEY: {
+			struct vos_krec_df	*key;
+
+			key = umem_id2ptr(umm, rec->tr_record);
+			umem_tx_add_ptr(umm, key, sizeof(*key));
+			key->kr_dtx_shares--;
+
+			if (UMMID_IS_NULL(key->kr_dtx)) {
+				/* The exchange_src has been committed.
+				 * I am the exchange_tgt, do nothing.
+				 */
+				if (rec->tr_flags == DTX_RF_EXCHANGE_TGT)
+					break;
+
+				/* Other DTX that shares the key has
+				 * committed, must be for sharing of
+				 * update cases.
+				 */
+				if (dtx->te_epoch > key->kr_latest)
+					key->kr_latest = dtx->te_epoch;
+				if (dtx->te_epoch < key->kr_earliest)
+					key->kr_earliest = dtx->te_epoch;
+
+				break;
+			}
+
+			/* commit case */
+			if (!abort) {
+				key->kr_dtx = UMMID_NULL;
+				key->kr_latest = dtx->te_epoch;
+				if (rec->tr_flags != DTX_RF_EXCHANGE_SRC &&
+				    rec->tr_flags != DTX_RF_EXCHANGE_TGT)
+					key->kr_earliest = dtx->te_epoch;
+
+				goto exchange;
+			}
+
+			/* The last shared DTX is aborted. */
+			if (key->kr_dtx_shares == 0) {
+				key->kr_dtx = DTX_UMMID_ABORTED;
+				goto exchange;
+			}
+
+			/* I am not the original DTX that create the key. */
+			if (!umem_id_equal(umm, key->kr_dtx, ummid))
+				goto exchange;
+
+			/* I am the original DTX that create the key that
+			 * is still shared by others. Now, I will be aborted,
+			 * set the reference as UNKNOWN for other left shares.
+			 */
+			key->kr_dtx = DTX_UMMID_UNKNOWN;
+
+exchange:
+			if (rec->tr_flags != DTX_RF_EXCHANGE_SRC)
+				break;
+
+			D_ASSERT(key->kr_flags & VKF_DELETED);
+
+			if (!abort) { /* commit case */
+				struct vos_dtx_record_df	*tgt_rec;
+				struct vos_krec_df		*tgt_key;
+				struct btr_root			 tmp_btr;
+				daos_epoch_t			 tmp_epoch;
+
+				/*
+				 * XXX: If the exchange target still exist,
+				 *	it will be the next record. If it does
+				 *	not exist, then either it is crashed
+				 *	or it has already degistered from the
+				 *	DTX records list. We cannot commit the
+				 *	DTX under any the two cases. Failing
+				 *	the DTX commit is meaningless, then we
+				 *	have to give some warning message.
+				 */
+				if (UMMID_IS_NULL(rec->tr_next)) {
+					D_ERROR(DF_UOID" miss the DTX ("DF_DTI
+						") exchange pairs (1)\n",
+						DP_UOID(dtx->te_oid),
+						DP_DTI(&dtx->te_xid));
+					break;
+				}
+
+				tgt_rec = umem_id2ptr(umm, rec->tr_next);
+				if (tgt_rec->tr_flags != DTX_RF_EXCHANGE_TGT) {
+					D_ERROR(DF_UOID" miss the DTX ("DF_DTI
+						") exchange pairs (2)\n",
+						DP_UOID(dtx->te_oid),
+						DP_DTI(&dtx->te_xid));
+					break;
+				}
+
+				/* Exchange the sub-tree between max epoch
+				 * record and the give epoch record. The
+				 * record with max epoch will be removed
+				 * when aggregation.
+				 */
+				tgt_key = umem_id2ptr(umm, tgt_rec->tr_record);
+				umem_tx_add_ptr(umm, tgt_key, sizeof(*tgt_key));
+
+				tmp_btr = key->kr_btr;
+				key->kr_btr = tgt_key->kr_btr;
+				tgt_key->kr_btr = tmp_btr;
+
+				if (key->kr_bmap & KREC_BF_EVT) {
+					struct evt_root		tmp_evt;
+
+					umem_tx_add_ptr(umm, &key->kr_evt[0],
+							sizeof(key->kr_evt[0]));
+					umem_tx_add_ptr(umm,
+						&tgt_key->kr_evt[0],
+						sizeof(tgt_key->kr_evt[0]));
+
+					tmp_evt = key->kr_evt[0];
+					key->kr_evt[0] = tgt_key->kr_evt[0];
+					tgt_key->kr_evt[0] = tmp_evt;
+				}
+
+				tmp_epoch = key->kr_earliest;
+				key->kr_earliest = tgt_key->kr_earliest;
+				tgt_key->kr_earliest = tmp_epoch;
+
+				D_DEBUG(DB_TRACE, "Exchanged DTX records for "
+					DF_DTI"\n", DP_DTI(&dtx->te_xid));
+			} else { /* abort case */
+				/* Recover the visibility of the exchange source
+				 * for the DTX abort case.
+				 */
+				key->kr_flags &= ~VKF_DELETED;
+				key->kr_dtx = UMMID_NULL;
+			}
+			break;
+		}
+		case DTX_RT_SVT: {
+			struct vos_irec_df	*svt;
+
+			svt = umem_id2ptr(umm, rec->tr_record);
+			umem_tx_add_ptr(umm, svt, sizeof(*svt));
+			if (abort)
+				svt->ir_dtx = DTX_UMMID_ABORTED;
+			else
+				svt->ir_dtx = UMMID_NULL;
+			break;
+		}
+		case DTX_RT_EVT: {
+			struct evt_desc		*evt;
+
+			evt = umem_id2ptr(umm, rec->tr_record);
+			umem_tx_add_ptr(umm, evt, sizeof(*evt));
+			if (abort)
+				evt->dc_dtx = DTX_UMMID_ABORTED;
+			else
+				evt->dc_dtx = UMMID_NULL;
+			break;
+		}
+		default:
+			D_ERROR(DF_UOID" unknown DTX "DF_DTI" type %u\n",
+				DP_UOID(dtx->te_oid), DP_DTI(&dtx->te_xid),
+				rec->tr_type);
+			break;
+		}
+
+		dtx->te_records = rec->tr_next;
+		umem_tx_add_ptr(umm, rec, sizeof(*rec));
+		umem_free(umm, rec_mmid);
+	}
+
+	D_DEBUG(DB_TRACE, "dtx_rec_release: %s/%s the DTX "DF_DTI"\n",
+		abort ? "abort" : "commit", destroy ? "destroy" : "keep",
+		DP_DTI(&dtx->te_xid));
+
+	if (destroy)
+		umem_free(umm, ummid);
+	else
+		dtx->te_flags &= ~(DTX_EF_EXCHANGE_PENDING  | DTX_EF_SHARES);
+
+	return 0;
+}
+
+static void
+vos_dtx_unlink_entry(struct umem_instance *umm, struct vos_dtx_table_df *tab,
+		     struct vos_dtx_entry_df *dtx)
+{
+	struct vos_dtx_entry_df	*ent;
+
+	if (UMMID_IS_NULL(dtx->te_next)) { /* The tail of the DTXs list. */
+		if (UMMID_IS_NULL(dtx->te_prev)) { /* The unique one on list. */
+			tab->tt_entry_head = UMMID_NULL;
+			tab->tt_entry_tail = UMMID_NULL;
+		} else {
+			ent = umem_id2ptr(umm, dtx->te_prev);
+			umem_tx_add_ptr(umm, ent, sizeof(*ent));
+
+			ent->te_next = UMMID_NULL;
+			tab->tt_entry_tail = dtx->te_prev;
+			dtx->te_prev = UMMID_NULL;
+		}
+	} else if (UMMID_IS_NULL(dtx->te_prev)) { /* The head of DTXs list */
+		ent = umem_id2ptr(umm, dtx->te_next);
+		umem_tx_add_ptr(umm, ent, sizeof(*ent));
+
+		ent->te_prev = UMMID_NULL;
+		tab->tt_entry_head = dtx->te_next;
+		dtx->te_next = UMMID_NULL;
+	} else {
+		ent = umem_id2ptr(umm, dtx->te_next);
+		umem_tx_add_ptr(umm, ent, sizeof(*ent));
+		ent->te_prev = dtx->te_prev;
+
+		ent = umem_id2ptr(umm, dtx->te_prev);
+		umem_tx_add_ptr(umm, ent, sizeof(*ent));
+		ent->te_next = dtx->te_next;
+
+		dtx->te_prev = UMMID_NULL;
+		dtx->te_next = UMMID_NULL;
+	}
+}
+
+static int
+vos_dtx_commit_one(struct vos_container *cont, struct daos_tx_id *dti)
+{
+	struct umem_instance	*umm;
+	daos_iov_t		 kiov;
+	daos_iov_t		 riov;
+	umem_id_t		 ummid;
+	int			 rc = 0;
+
+	umm = &cont->vc_pool->vp_umm;
+	daos_iov_set(&kiov, dti, sizeof(*dti));
+	rc = dbtree_delete(cont->vc_dtx_active_hdl, &kiov, &ummid);
+	if (rc == 0) {
+		struct vos_dtx_entry_df		*dtx;
+		struct vos_dtx_entry_df		*ent;
+		struct dtx_rec_bundle		 rbund;
+
+		dtx = umem_id2ptr(umm, ummid);
+		umem_tx_add_ptr(umm, dtx, sizeof(*dtx));
+		dtx->te_state = DTX_ST_COMMITTED;
+
+		if (dtx->te_dkey_hash[0] != 0)
+			vos_dtx_del_cos(cont, &dtx->te_oid, dti,
+					dtx->te_dkey_hash[0],
+					dtx->te_intent == DAOS_INTENT_PUNCH ?
+					true : false);
+
+		rbund.trb_ummid = ummid;
+		daos_iov_set(&riov, &rbund, sizeof(rbund));
+		rc = dbtree_upsert(cont->vc_dtx_committed_hdl,
+				BTR_PROBE_EQ, DAOS_INTENT_UPDATE, &kiov, &riov);
+		if (rc == 0) {
+			struct vos_dtx_table_df	*tab;
+
+			tab = &cont->vc_cont_df->cd_dtx_table_df;
+			umem_tx_add_ptr(umm, tab, sizeof(*tab));
+
+			tab->tt_count++;
+			if (UMMID_IS_NULL(tab->tt_entry_tail)) {
+				D_ASSERT(UMMID_IS_NULL(tab->tt_entry_head));
+
+				tab->tt_entry_head = ummid;
+				tab->tt_entry_tail = tab->tt_entry_head;
+			} else {
+				ent = umem_id2ptr(umm, tab->tt_entry_tail);
+				umem_tx_add_ptr(umm, ent, sizeof(*ent));
+
+				ent->te_next = ummid;
+				dtx->te_prev = tab->tt_entry_tail;
+				tab->tt_entry_tail = ent->te_next;
+			}
+
+			/* If there are pending exchange of records, then we
+			 * need some additional work when commit, such as
+			 * exchange the subtree under the source and target
+			 * records, then related subtree can be exported
+			 * correctly. That will be done when release related
+			 * vos_dth_record_df(s) attached to the DTX.
+			 */
+			if (dtx->te_flags &
+			    (DTX_EF_EXCHANGE_PENDING | DTX_EF_SHARES))
+				rc = dtx_rec_release(umm, ummid, false, false);
+		}
+	} else if (rc == -DER_NONEXIST) {
+		daos_iov_set(&riov, NULL, 0);
+		rc = dbtree_lookup(cont->vc_dtx_committed_hdl, &kiov, &riov);
+	}
+
+	D_DEBUG(DB_TRACE, "Commit the DTX "DF_DTI": rc = %d\n",
+		DP_DTI(dti), rc);
+
+	return rc;
+}
+
+static int
+vos_dtx_abort_one(struct vos_container *cont, struct daos_tx_id *dti,
+		  bool force)
+{
+	daos_iov_t	 kiov;
+	umem_id_t	 dtx;
+	int		 rc;
+
+	daos_iov_set(&kiov, dti, sizeof(*dti));
+	rc = dbtree_delete(cont->vc_dtx_active_hdl, &kiov, &dtx);
+	if (rc == 0)
+		rc = dtx_rec_release(&cont->vc_pool->vp_umm, dtx, true, true);
+
+	D_DEBUG(DB_TRACE, "Abort the DTX "DF_DTI": rc = %d\n", DP_DTI(dti), rc);
+
+	if (rc != 0 && force)
+		rc = 0;
+
+	return rc;
+}
+
+int
+vos_dtx_begin(struct daos_tx_id *dti, daos_unit_oid_t *oid, daos_key_t *dkey,
+	      daos_handle_t coh, daos_epoch_t epoch, uint32_t pm_ver,
+	      uint32_t intent, uint32_t flags, struct daos_tx_handle **dtx)
+{
+	struct daos_tx_handle	*th;
+
+	D_ALLOC_PTR(th);
+	if (th == NULL)
+		return -DER_NOMEM;
+
+	th->dth_xid = *dti;
+	th->dth_oid = *oid;
+	th->dth_dkey = dkey;
+	th->dth_coh = coh;
+	th->dth_epoch = epoch;
+	D_INIT_LIST_HEAD(&th->dth_shares);
+	th->dth_ver = pm_ver;
+	th->dth_intent = intent;
+	th->dth_flags = flags;
+	th->dth_sync = 0;
+	th->dth_non_rep = 0;
+	th->dth_ent = UMMID_NULL;
+
+	*dtx = th;
+	D_DEBUG(DB_TRACE, "Start the DTX "DF_DTI"\n", DP_DTI(dti));
+
+	return 0;
+}
+
+int
+vos_dtx_end(struct daos_tx_handle *dth, int result, bool leader)
+{
+	struct vos_container	*cont;
+	struct vos_dtx_table_df	*tab;
+	double			 now = ABT_get_wtime();
+	int			 rc = 0;
+
+	if (result < 0)
+		D_GOTO(out, rc = result);
+
+	cont = vos_hdl2cont(dth->dth_coh);
+	D_ASSERT(cont != NULL);
+
+	if (leader) {
+		if (dth->dth_sync)
+			D_GOTO(out, rc = 3);
+
+		if (cont->vc_dtx_committable_count > DTX_THRESHOLD_COUNT)
+			D_GOTO(out, rc = 2);
+
+		if ((uint64_t)now - cont->vc_dtx_time_last_commit >
+		     DTX_COMMIT_THRESHOLD_TIME)
+			D_GOTO(out, rc = 2);
+	}
+
+	tab = &cont->vc_cont_df->cd_dtx_table_df;
+	if (tab->tt_count > DTX_AGGREGATION_THRESHOLD_COUNT)
+		D_GOTO(out, rc = 1);
+
+	if ((uint64_t)now - tab->tt_time_last_shrink >
+	    DTX_AGGREGATION_THRESHOLD_TIME)
+		D_GOTO(out, rc = 1);
+
+out:
+	D_DEBUG(DB_TRACE,
+		"Stop the DTX "DF_DTI" ver = %u, %s, %s, %s: rc = %d\n",
+		DP_DTI(&dth->dth_xid), dth->dth_ver,
+		dth->dth_sync ? "sync" : "async",
+		dth->dth_non_rep ? "non-replicated" : "replicated",
+		dth->dth_leader ? "leader" : "non-leader", rc);
+	D_FREE_PTR(dth);
+	return rc;
+}
+
+int
+vos_dtx_check_committable(daos_handle_t coh, struct daos_tx_id *dti)
+{
+	struct vos_container	*cont;
+	daos_iov_t		 kiov;
+	daos_iov_t		 riov;
+	int			 rc = 0;
+
+	cont = vos_hdl2cont(coh);
+	D_ASSERT(cont != NULL);
+
+	daos_iov_set(&kiov, dti, sizeof(*dti));
+	daos_iov_set(&riov, NULL, 0);
+	rc = dbtree_lookup(cont->vc_dtx_active_hdl, &kiov, &riov);
+	if (rc == 0) {
+		struct vos_dtx_entry_df	*dtx;
+
+		dtx = (struct vos_dtx_entry_df *)riov.iov_buf;
+		return dtx->te_state;
+	}
+
+	if (rc == -DER_NONEXIST) {
+		rc = dbtree_lookup(cont->vc_dtx_committed_hdl, &kiov, &riov);
+		if (rc == 0)
+			return DTX_ST_COMMITTED;
+	}
+
+	if (rc == -DER_NONEXIST)
+		return DTX_ST_INIT;
+
+	return rc;
+}
+
+int
+vos_dtx_commit(daos_handle_t coh, struct daos_tx_id *dti, int count)
+{
+	struct vos_container	*cont;
+	struct umem_instance	*umm;
+	int			 i;
+	int			 rc = 0;
+
+	cont = vos_hdl2cont(coh);
+	D_ASSERT(cont != NULL);
+
+	umm = &cont->vc_pool->vp_umm;
+	/* Commit multiple DTXs via single PMDK transaction. */
+	rc = umem_tx_begin(umm, vos_txd_get());
+	if (rc == 0) {
+		for (i = 0; i < count; i++)
+			vos_dtx_commit_one(cont, &dti[i]);
+
+		cont->vc_dtx_time_last_commit = ABT_get_wtime();
+		umem_tx_commit(umm);
+	}
+
+	return rc;
+}
+
+int
+vos_dtx_abort(daos_handle_t coh, struct daos_tx_id *dti, int count, bool force)
+{
+	struct vos_container	*cont;
+	struct umem_instance	*umm;
+	int			 rc;
+	int			 i;
+
+	cont = vos_hdl2cont(coh);
+	D_ASSERT(cont != NULL);
+
+	umm = &cont->vc_pool->vp_umm;
+	/* Abort multiple DTXs via single PMDK transaction. */
+	rc = umem_tx_begin(umm, vos_txd_get());
+	for (i = 0; rc == 0 && i < count; i++)
+		rc = vos_dtx_abort_one(cont, &dti[i], force);
+
+	if (rc == 0)
+		umem_tx_commit(umm);
+	else
+		umem_tx_abort(umm, rc);
+
+	return rc;
+}
+
+void
+vos_dtx_aggregate(daos_handle_t coh, uint64_t max, uint64_t age)
+{
+	struct vos_container		*cont;
+	struct umem_instance		*umm;
+	struct vos_dtx_table_df		*tab;
+	umem_id_t			 dtx_mmid;
+	daos_iov_t			 kiov;
+	uint64_t			 count;
+	double				 now;
+	int				 rc = 0;
+	bool				 stop = false;
+
+	if (max == 0)
+		max = DTX_AGGREGATION_THRESHOLD_COUNT;
+
+	now = ABT_get_wtime();
+	if (age == 0)
+		age = now - DTX_AGGREGATION_THRESHOLD_TIME;
+	else if (age != (uint64_t)(-1))
+		age = now - age;
+
+	cont = vos_hdl2cont(coh);
+	D_ASSERT(cont != NULL);
+
+	umm = &cont->vc_pool->vp_umm;
+	tab = &cont->vc_cont_df->cd_dtx_table_df;
+
+	for (count = 0, dtx_mmid = tab->tt_entry_head;
+	     count < max && !UMMID_IS_NULL(dtx_mmid);) {
+		int	i;
+
+		rc = umem_tx_begin(umm, vos_txd_get());
+		if (rc != 0)
+			return;
+
+		umem_tx_add_ptr(umm, tab, sizeof(*tab));
+		for (i = 0; i < DTX_AGGREGATION_YIELD_INTERVAL &&
+		     !UMMID_IS_NULL(dtx_mmid) && count < max; i++, count++) {
+			struct vos_dtx_entry_df	*dtx;
+			umem_id_t		 ummid;
+
+			dtx = umem_id2ptr(umm, dtx_mmid);
+			if (dtx->te_sec > age) {
+				stop = true;
+				break;
+			}
+
+			umem_tx_add_ptr(umm, dtx, sizeof(*dtx));
+			daos_iov_set(&kiov, &dtx->te_xid, sizeof(dtx->te_xid));
+			rc = dbtree_delete(cont->vc_dtx_committed_hdl, &kiov,
+					   &ummid);
+			D_ASSERT(rc == 0);
+
+			tab->tt_count--;
+			dtx_mmid = dtx->te_next;
+			vos_dtx_unlink_entry(umm, tab, dtx);
+			dtx_rec_release(umm, ummid, false, true);
+		}
+
+		tab->tt_time_last_shrink = now;
+		umem_tx_commit(umm);
+
+		if (stop)
+			return;
+
+		/* Yield per DTX_AGGREGATION_YIELD_INTERVAL. */
+		ABT_thread_yield();
+	}
+}

--- a/src/vos/vos_dtx_cos.c
+++ b/src/vos/vos_dtx_cos.c
@@ -1,0 +1,481 @@
+/**
+ * (C) Copyright 2019 Intel Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * GOVERNMENT LICENSE RIGHTS-OPEN SOURCE SOFTWARE
+ * The Government's rights to use, modify, reproduce, release, perform, display,
+ * or disclose this software are subject to the terms of the Apache License as
+ * provided in Contract No. B609815.
+ * Any reproduction of computer software, computer software documentation, or
+ * portions thereof marked with this legend must also reproduce the markings.
+ */
+/**
+ * This file is part of daos two-phase commit transaction.
+ *
+ * vos/vos_dtx_cos.c
+ */
+#define D_LOGFAC	DD_FAC(vos)
+
+#include <daos/btree.h>
+#include "vos_layout.h"
+#include "vos_internal.h"
+
+/* The record for the DTX CoS B+tree in DRAM. Each record contains current
+ * committable DTXs that modify (update or punch) something under the same
+ * object and the same dkey.
+ */
+struct dtx_cos_rec {
+	daos_unit_oid_t		 dcr_oid;
+	/* The list in DRAM for the DTXs that modify the same object/dkey.
+	 * Per-dkey based.
+	 */
+	d_list_t		 dcr_update_list;
+	d_list_t		 dcr_punch_list;
+	/* The number of the UPDATE DTXs in the dcr_update_list. */
+	int			 dcr_update_count;
+	/* The number of the PUNCH DTXs in the dcr_punch_list. */
+	int			 dcr_punch_count;
+	/* Pointer to the container. */
+	struct vos_container	*dcr_cont;
+};
+
+/* Above dtx_cos_rec is consisted of a series of dtx_cos_rec_child uints.
+ * Each dtx_cos_rec_child contains one DTX that modifies something under
+ * related object and dkey (that attached to the dtx_cos_rec).
+ */
+struct dtx_cos_rec_child {
+	/* Link into the container::vc_dtx_committable. */
+	d_list_t		 dcrc_committable;
+	/* Link into related dcr_{update,punch}_list. */
+	d_list_t		 dcrc_link;
+	/* The DTX identifier. */
+	struct daos_tx_id	 dcrc_dti;
+	/* Pointer to the dtx_cos_rec. */
+	struct dtx_cos_rec	*dcrc_ptr;
+};
+
+struct dtx_cos_rec_bundle {
+	struct vos_container	*cont;
+	struct daos_tx_id	*dti;
+	bool			 punch;
+};
+
+struct dtx_cos_key {
+	daos_unit_oid_t		 oid;
+	uint64_t		 dkey;
+};
+
+static int
+dtx_cos_hkey_size(struct btr_instance *tins)
+{
+	return sizeof(struct dtx_cos_key);
+}
+
+static void
+dtx_cos_hkey_gen(struct btr_instance *tins, daos_iov_t *key_iov, void *hkey)
+{
+	D_ASSERT(key_iov->iov_len == sizeof(struct dtx_cos_key));
+
+	memcpy(hkey, key_iov->iov_buf, key_iov->iov_len);
+}
+
+static int
+dtx_cos_hkey_cmp(struct btr_instance *tins, struct btr_record *rec, void *hkey)
+{
+	struct dtx_cos_key *hkey1 = (struct dtx_cos_key *)&rec->rec_hkey[0];
+	struct dtx_cos_key *hkey2 = (struct dtx_cos_key *)hkey;
+	int		    rc;
+
+	rc = memcmp(hkey1, hkey2, sizeof(struct dtx_cos_key));
+
+	return dbtree_key_cmp_rc(rc);
+}
+
+static int
+dtx_cos_rec_alloc(struct btr_instance *tins, daos_iov_t *key_iov,
+		  daos_iov_t *val_iov, struct btr_record *rec)
+{
+	struct dtx_cos_key		*key;
+	struct dtx_cos_rec_bundle	*rbund;
+	struct dtx_cos_rec		*dcr;
+	struct dtx_cos_rec_child	*dcrc;
+
+	D_ASSERT(tins->ti_umm.umm_id == UMEM_CLASS_VMEM);
+
+	key = (struct dtx_cos_key *)key_iov->iov_buf;
+	rbund = (struct dtx_cos_rec_bundle *)val_iov->iov_buf;
+
+	D_ALLOC_PTR(dcr);
+	if (dcr == NULL)
+		return -DER_NOMEM;
+
+	dcr->dcr_oid = key->oid;
+	D_INIT_LIST_HEAD(&dcr->dcr_update_list);
+	D_INIT_LIST_HEAD(&dcr->dcr_punch_list);
+	dcr->dcr_cont = rbund->cont;
+
+	D_ALLOC_PTR(dcrc);
+	if (dcrc == NULL) {
+		D_FREE_PTR(dcr);
+		return -DER_NOMEM;
+	}
+
+	dcrc->dcrc_dti = *rbund->dti;
+	dcrc->dcrc_ptr = dcr;
+
+	d_list_add_tail(&dcrc->dcrc_committable,
+			&rbund->cont->vc_dtx_committable);
+	rbund->cont->vc_dtx_committable_count++;
+
+	if (rbund->punch) {
+		d_list_add_tail(&dcrc->dcrc_link, &dcr->dcr_punch_list);
+		dcr->dcr_punch_count = 1;
+	} else {
+		d_list_add_tail(&dcrc->dcrc_link, &dcr->dcr_update_list);
+		dcr->dcr_update_count = 1;
+	}
+
+	rec->rec_mmid = umem_ptr2id(&tins->ti_umm, dcr);
+	return 0;
+}
+
+static int
+dtx_cos_rec_free(struct btr_instance *tins, struct btr_record *rec, void *args)
+{
+	struct dtx_cos_rec		*dcr;
+	struct dtx_cos_rec_child	*dcrc;
+	struct dtx_cos_rec_child	*next;
+
+	D_ASSERT(tins->ti_umm.umm_id == UMEM_CLASS_VMEM);
+
+	dcr = (struct dtx_cos_rec *)umem_id2ptr(&tins->ti_umm, rec->rec_mmid);
+	d_list_for_each_entry_safe(dcrc, next, &dcr->dcr_update_list,
+				   dcrc_link) {
+		d_list_del(&dcrc->dcrc_link);
+		d_list_del(&dcrc->dcrc_committable);
+		D_FREE_PTR(dcrc);
+		dcr->dcr_cont->vc_dtx_committable_count--;
+	}
+	d_list_for_each_entry_safe(dcrc, next, &dcr->dcr_punch_list,
+				   dcrc_link) {
+		d_list_del(&dcrc->dcrc_link);
+		d_list_del(&dcrc->dcrc_committable);
+		D_FREE_PTR(dcrc);
+		dcr->dcr_cont->vc_dtx_committable_count--;
+	}
+	D_FREE_PTR(dcr);
+
+	return 0;
+}
+
+static int
+dtx_cos_rec_fetch(struct btr_instance *tins, struct btr_record *rec,
+		  daos_iov_t *key_iov, daos_iov_t *val_iov)
+{
+	struct dtx_cos_rec	*dcr;
+
+	D_ASSERT(val_iov != NULL);
+
+	dcr = (struct dtx_cos_rec *)umem_id2ptr(&tins->ti_umm, rec->rec_mmid);
+	daos_iov_set(val_iov, dcr, sizeof(struct dtx_cos_rec));
+
+	return 0;
+}
+
+static int
+dtx_cos_rec_update(struct btr_instance *tins, struct btr_record *rec,
+		   daos_iov_t *key, daos_iov_t *val)
+{
+	struct dtx_cos_rec_bundle	*rbund;
+	struct dtx_cos_rec		*dcr;
+	struct dtx_cos_rec_child	*dcrc;
+
+	D_ASSERT(tins->ti_umm.umm_id == UMEM_CLASS_VMEM);
+
+	dcr = (struct dtx_cos_rec *)umem_id2ptr(&tins->ti_umm, rec->rec_mmid);
+	rbund = (struct dtx_cos_rec_bundle *)val->iov_buf;
+
+	D_ALLOC_PTR(dcrc);
+	if (dcrc == NULL)
+		return -DER_NOMEM;
+
+	dcrc->dcrc_dti = *rbund->dti;
+	dcrc->dcrc_ptr = dcr;
+
+	d_list_add_tail(&dcrc->dcrc_committable,
+			&rbund->cont->vc_dtx_committable);
+	rbund->cont->vc_dtx_committable_count++;
+
+	if (rbund->punch) {
+		d_list_add_tail(&dcrc->dcrc_link, &dcr->dcr_punch_list);
+		dcr->dcr_punch_count++;
+	} else {
+		d_list_add_tail(&dcrc->dcrc_link, &dcr->dcr_update_list);
+		dcr->dcr_update_count++;
+	}
+
+	return 0;
+}
+
+static btr_ops_t dtx_btr_cos_ops = {
+	.to_hkey_size	= dtx_cos_hkey_size,
+	.to_hkey_gen	= dtx_cos_hkey_gen,
+	.to_hkey_cmp	= dtx_cos_hkey_cmp,
+	.to_rec_alloc	= dtx_cos_rec_alloc,
+	.to_rec_free	= dtx_cos_rec_free,
+	.to_rec_fetch	= dtx_cos_rec_fetch,
+	.to_rec_update	= dtx_cos_rec_update,
+};
+
+int
+vos_dtx_cos_register(void)
+{
+	int	rc;
+
+	D_DEBUG(DB_DF, "Registering DTX CoS class: %d\n",
+		VOS_BTR_DTX_COS);
+
+	rc = dbtree_class_register(VOS_BTR_DTX_COS, 0, &dtx_btr_cos_ops);
+	if (rc != 0)
+		D_ERROR("Failed to register DTX CoS dbtree: rc = %d\n", rc);
+
+	return rc;
+}
+
+int
+vos_dtx_list_cos(struct vos_container *cont, daos_unit_oid_t *oid,
+		 daos_key_t *dkey, uint32_t types, struct daos_tx_id **dtis)
+{
+	struct dtx_cos_key		 key;
+	daos_iov_t			 kiov;
+	daos_iov_t			 riov;
+	struct daos_tx_id		*dti = NULL;
+	struct dtx_cos_rec		*dcr;
+	struct dtx_cos_rec_child	*dcrc;
+	int				 count = 0;
+	int				 rc;
+	int				 i = 0;
+
+	if (dkey == NULL)
+		return 0;
+
+	D_ASSERT(dkey->iov_buf != NULL);
+	D_ASSERT(dkey->iov_len != 0);
+
+	key.oid = *oid;
+	key.dkey = d_hash_murmur64(dkey->iov_buf, dkey->iov_len,
+				   VOS_BTR_MUR_SEED);
+	daos_iov_set(&kiov, &key, sizeof(key));
+	daos_iov_set(&riov, NULL, 0);
+
+	rc = dbtree_lookup(cont->vc_dtx_cos_hdl, &kiov, &riov);
+	if (rc != 0)
+		return rc == -DER_NONEXIST ? 0 : rc;
+
+	dcr = (struct dtx_cos_rec *)riov.iov_buf;
+	if (types & DCLT_PUNCH)
+		count += dcr->dcr_punch_count;
+	if (types & DCLT_UPDATE)
+		count += dcr->dcr_update_count;
+
+	if (count == 0)
+		return 0;
+
+	/* There are too many shared DTXs to be committed, as to
+	 * cannot be taken via the normal UPDATE RPC. Return the
+	 * DTXs count directly without filling the DTX array.
+	 */
+	if (count > DTX_THRESHOLD_COUNT) {
+		*dtis = NULL;
+		return count;
+	}
+
+	D_ALLOC_ARRAY(dti, count);
+	if (dti == NULL)
+		return -DER_NOMEM;
+
+	if (types & DCLT_PUNCH) {
+		d_list_for_each_entry(dcrc, &dcr->dcr_punch_list,
+				      dcrc_link) {
+			dti[i++] = dcrc->dcrc_dti;
+		}
+	}
+
+	if (types & DCLT_UPDATE) {
+		d_list_for_each_entry(dcrc, &dcr->dcr_update_list,
+				      dcrc_link) {
+			dti[i++] = dcrc->dcrc_dti;
+		}
+	}
+
+	D_ASSERT(i == count);
+
+	*dtis = dti;
+	return count;
+}
+
+int
+vos_dtx_add_cos(struct vos_container *cont, daos_unit_oid_t *oid,
+		struct daos_tx_id *dti, uint64_t dkey, bool punch)
+{
+	struct dtx_cos_key		 key;
+	struct dtx_cos_rec_bundle	 rbund;
+	daos_iov_t			 kiov;
+	daos_iov_t			 riov;
+	int				 rc;
+
+	D_ASSERT(dkey != 0);
+
+	key.oid = *oid;
+	key.dkey = dkey;
+	daos_iov_set(&kiov, &key, sizeof(key));
+
+	rbund.cont = cont;
+	rbund.dti = dti;
+	rbund.punch = punch;
+	daos_iov_set(&riov, &rbund, sizeof(rbund));
+
+	rc = dbtree_upsert(cont->vc_dtx_cos_hdl, BTR_PROBE_EQ,
+			   DAOS_INTENT_UPDATE, &kiov, &riov);
+
+	return rc;
+}
+
+void
+vos_dtx_del_cos(struct vos_container *cont, daos_unit_oid_t *oid,
+		struct daos_tx_id *xid, uint64_t dkey, bool punch)
+{
+	struct dtx_cos_key		 key;
+	daos_iov_t			 kiov;
+	daos_iov_t			 riov;
+	struct dtx_cos_rec		*dcr;
+	struct dtx_cos_rec_child	*dcrc;
+	d_list_t			*head;
+	int				 rc;
+
+	D_ASSERT(dkey != 0);
+
+	key.oid = *oid;
+	key.dkey = dkey;
+	daos_iov_set(&kiov, &key, sizeof(key));
+	daos_iov_set(&riov, NULL, 0);
+
+	rc = dbtree_lookup(cont->vc_dtx_cos_hdl, &kiov, &riov);
+	if (rc != 0)
+		return;
+
+	dcr = (struct dtx_cos_rec *)riov.iov_buf;
+	if (punch)
+		head = &dcr->dcr_punch_list;
+	else
+		head = &dcr->dcr_update_list;
+
+	d_list_for_each_entry(dcrc, head, dcrc_link) {
+		if (memcmp(&dcrc->dcrc_dti, xid, sizeof(*xid)) != 0)
+			continue;
+
+		d_list_del(&dcrc->dcrc_committable);
+		d_list_del(&dcrc->dcrc_link);
+		D_FREE_PTR(dcrc);
+
+		cont->vc_dtx_committable_count--;
+		if (punch)
+			dcr->dcr_punch_count--;
+		else
+			dcr->dcr_update_count--;
+		if (dcr->dcr_punch_count == 0 && dcr->dcr_update_count == 0)
+			dbtree_delete(cont->vc_dtx_cos_hdl, &kiov, NULL);
+
+		return;
+	}
+}
+
+int
+vos_dtx_lookup_cos(daos_handle_t coh, daos_unit_oid_t *oid,
+		   struct daos_tx_id *xid, uint64_t dkey, bool punch)
+{
+	struct vos_container		*cont;
+	struct dtx_cos_key		 key;
+	daos_iov_t			 kiov;
+	daos_iov_t			 riov;
+	struct dtx_cos_rec		*dcr;
+	struct dtx_cos_rec_child	*dcrc;
+	d_list_t			*head;
+	int				 rc;
+
+	if (dkey == 0)
+		return -DER_NONEXIST;
+
+	cont = vos_hdl2cont(coh);
+	D_ASSERT(cont != NULL);
+
+	key.oid = *oid;
+	key.dkey = dkey;
+	daos_iov_set(&kiov, &key, sizeof(key));
+	daos_iov_set(&riov, NULL, 0);
+
+	rc = dbtree_lookup(cont->vc_dtx_cos_hdl, &kiov, &riov);
+	if (rc != 0)
+		return rc;
+
+	dcr = (struct dtx_cos_rec *)riov.iov_buf;
+	if (punch)
+		head = &dcr->dcr_punch_list;
+	else
+		head = &dcr->dcr_update_list;
+
+	d_list_for_each_entry(dcrc, head, dcrc_link) {
+		if (memcmp(&dcrc->dcrc_dti, xid, sizeof(*xid)) == 0)
+			return 0;
+	}
+
+	return -DER_NONEXIST;
+}
+
+int
+vos_dtx_list_committable(daos_handle_t coh, struct daos_tx_entry **dtes)
+{
+	struct daos_tx_entry		*dte = NULL;
+	struct dtx_cos_rec_child	*dcrc;
+	struct vos_container		*cont;
+	int				 count;
+	int				 i = 0;
+
+	cont = vos_hdl2cont(coh);
+	D_ASSERT(cont != NULL);
+
+	if (cont->vc_dtx_committable_count > DTX_THRESHOLD_COUNT)
+		count = DTX_THRESHOLD_COUNT;
+	else
+		count = cont->vc_dtx_committable_count;
+
+	if (count == 0)
+		return 0;
+
+	D_ALLOC_ARRAY(dte, count);
+	if (dte == NULL)
+		return -DER_NOMEM;
+
+	d_list_for_each_entry(dcrc, &cont->vc_dtx_committable,
+			      dcrc_committable) {
+		dte[i].dte_xid = dcrc->dcrc_dti;
+		dte[i].dte_oid = dcrc->dcrc_ptr->dcr_oid;
+
+		if (++i >= count)
+			break;
+	}
+
+	*dtes = dte;
+	return count;
+}

--- a/src/vos/vos_internal.h
+++ b/src/vos/vos_internal.h
@@ -45,6 +45,7 @@
 
 extern struct dss_module_key vos_module_key;
 extern umem_class_id_t vos_mem_class;
+extern double vos_start_time;
 
 #define VOS_POOL_HHASH_BITS 10 /* Upto 1024 pools */
 #define VOS_CONT_HHASH_BITS 20 /* Upto 1048576 containers */

--- a/src/vos/vos_internal.h
+++ b/src/vos/vos_internal.h
@@ -116,6 +116,8 @@ struct vos_container {
 	d_list_t		vc_dtx_committable;
 	/* The count of commiitable DTXs. */
 	uint32_t		vc_dtx_committable_count;
+	/** The time in second when last commit the DTXs. */
+	double			vc_dtx_time_last_commit;
 	/* Direct pointer to VOS object index
 	 * within container
 	 */
@@ -172,6 +174,18 @@ enum {
 #define VOS_OFEAT_SHIFT		48
 #define VOS_OFEAT_MASK		(0x0ffULL   << VOS_OFEAT_SHIFT)
 #define VOS_OFEAT_BITS		(0x0ffffULL << VOS_OFEAT_SHIFT)
+
+#if DAOS_HAS_PMDK
+static const PMEMoid DTX_UMMID_ABORTED = { .pool_uuid_lo = -1,
+					   .off = -1,
+};
+static const PMEMoid DTX_UMMID_UNKNOWN = { .pool_uuid_lo = -1,
+					   .off = -2,
+};
+#else
+# define DTX_UMMID_ABORTED	((umem_id_t){ .pool_uuid_lo = -1, .off = -1, })
+# define DTX_UMMID_UNKNOWN	((umem_id_t){ .pool_uuid_lo = -1, .off = -2, })
+#endif
 
 /**
  * A cached object (DRAM data structure).

--- a/src/vos/vos_internal.h
+++ b/src/vos/vos_internal.h
@@ -108,6 +108,14 @@ struct vos_container {
 	daos_handle_t		vc_dtx_committed_hdl;
 	/* DAOS handle for object index btree */
 	daos_handle_t		vc_btr_hdl;
+	/* The objects with committable DTXs in DRAM. */
+	daos_handle_t		vc_dtx_cos_hdl;
+	/* The DTX COS-btree. */
+	struct btr_root		vc_dtx_cos_btr;
+	/* The global list for commiitable DTXs. */
+	d_list_t		vc_dtx_committable;
+	/* The count of commiitable DTXs. */
+	uint32_t		vc_dtx_committable_count;
 	/* Direct pointer to VOS object index
 	 * within container
 	 */
@@ -419,6 +427,43 @@ vos_dtx_table_destroy(struct vos_pool *pool, struct vos_dtx_table_df *dtab_df);
 int
 vos_dtx_table_register(void);
 
+/**
+ * Register dbtree class for DTX CoS, it is called within vos_init().
+ *
+ * \return		0 on success and negative on failure.
+ */
+int
+vos_dtx_cos_register(void);
+
+/**
+ * Add the given DTX to the Commit-on-Share (CoS) cache (in DRAM).
+ *
+ * \param cont	[IN]	Pointer to the container.
+ * \param oid	[IN]	The target object (shard) ID.
+ * \param dti	[IN]	The DTX identifier.
+ * \param dkey	[IN]	The hashed dkey.
+ * \param punch	[IN]	For punch DTX or not.
+ *
+ * \return		Zero on success and need not additional actions.
+ * \return		Negative value if error.
+ */
+int
+vos_dtx_add_cos(struct vos_container *cont, daos_unit_oid_t *oid,
+		struct daos_tx_id *dti, uint64_t dkey, bool punch);
+
+/**
+ * Remove the DTX from the CoS cache.
+ *
+ * \param cont	[IN]	Pointer to the container.
+ * \param oid	[IN]	Pointer to the object ID.
+ * \param xid	[IN]	Pointer to the DTX identifier.
+ * \param dkey	[IN]	The hashed dkey.
+ * \param punch	[IN]	For punch DTX or not.
+ */
+void
+vos_dtx_del_cos(struct vos_container *cont, daos_unit_oid_t *oid,
+		struct daos_tx_id *xid, uint64_t dkey, bool punch);
+
 enum vos_tree_class {
 	/** the first reserved tree class */
 	VOS_BTR_BEGIN		= DBTREE_VOS_BEGIN,
@@ -434,6 +479,8 @@ enum vos_tree_class {
 	VOS_BTR_CONT_TABLE	= (VOS_BTR_BEGIN + 4),
 	/** DAOS two-phase commit transation table */
 	VOS_BTR_DTX_TABLE	= (VOS_BTR_BEGIN + 5),
+	/** The objects with committable DTXs in DRAM */
+	VOS_BTR_DTX_COS		= (VOS_BTR_BEGIN + 6),
 	/** the last reserved tree class */
 	VOS_BTR_END,
 };

--- a/src/vos/vos_layout.h
+++ b/src/vos/vos_layout.h
@@ -251,6 +251,11 @@ enum vos_krec_bf {
 	KREC_BF_PUNCHED			= (1 << 1),
 };
 
+enum vos_kerc_flags {
+	/* The record is (or to be) deleted. */
+	VKF_DELETED	= 1,
+};
+
 /**
  * Persisted VOS (d)key record, it is referenced by btr_record::rec_mmid
  * of btree VOS_BTR_KEY.
@@ -262,8 +267,8 @@ struct vos_krec_df {
 	uint8_t				kr_cs_type;
 	/** key checksum size (in bytes) */
 	uint8_t				kr_cs_size;
-	/** padding bytes */
-	uint8_t				kr_pad_8;
+	/** See enum vos_kerc_flags. */
+	uint8_t				kr_flags;
 	/** key length */
 	uint32_t			kr_size;
 	/* Latest known update timestamp or punched timestamp */


### PR DESCRIPTION
In DAOS, we allow the RPC to be resent. For read-only RPC,
it is not important to re-handle the resent RPC as handling
the original one. But for resent modification RPC, we need
to distinguish it from non-resent case, in further, we also
need to know whether the orignal modification has been done
successfully or not. Otherwise, only simply re-execute the
modification may cause unexpected result, such as breaking
POSIX semantics.

Since the committed DTX table stores all the historical
modifications since some time point, then we can re-use
it to detect resent modification RPC. Such functionality
is not required by the DTX model, just the side-effect.
In the future, if we have more suitable solution for the
resent handling, then we can replace the temporary solution.

There is one restriction for the committed DTX table based
resent RPC solution: we only store the historical DTXs from
some time point (since the last vos_dtx_aggregate) because
of the limited SCM/NVM space. If some client resends very
old RPC that has ever been done on the server successfully
but related DTX record has been discarded when aggregation,
then we cannot know whether the RPC has ever been executed
before or not. Under such case, the server will notify the
client via returning -DER_TIMEDOUT. Means that modification
for such RPC may have been executed, but nobody guarantee
that. It is the caller's duty to check related data record.

Signed-off-by: Fan Yong <fan.yong@intel.com>
Change-Id: Ia85563d78c1170af9cd46e1ee92aadd2690132bd