### PR TITLE
CORCI-413 Tag docker images with the $JOB_NAME

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -43,7 +43,7 @@
 def arch=""
 
 pipeline {
-    agent any
+    agent { label 'lightweight' }
 
     triggers {
         cron(env.BRANCH_NAME == 'master' ? '0 0 * * *' : '')
@@ -153,18 +153,20 @@ pipeline {
                     }
                     post {
                         always {
-                            recordIssues enabledForFailure: true,
-                                         aggregatingResults: true,
-                                         id: "analysis-centos7",
-                                         tools: [ gcc4(), cppCheck() ],
-                                         filters: [excludeFile('.*\\/_build\\.external\\/.*'),
-                                                   excludeFile('_build\\.external\\/.*')]
-                        /* when JENKINS-39203 is resolved, can probably use stepResult
-                           here and remove the remaining post conditions
+                            node('lightweight') {
+                                recordIssues enabledForFailure: true,
+                                             aggregatingResults: true,
+                                             id: "analysis-centos7",
+                                             tools: [ gcc4(), cppCheck() ],
+                                             filters: [excludeFile('.*\\/_build\\.external\\/.*'),
+                                                       excludeFile('_build\\.external\\/.*')]
+                            }
+                            /* when JENKINS-39203 is resolved, can probably use stepResult
+                               here and remove the remaining post conditions
                                stepResult name: env.STAGE_NAME,
                                           context: 'build/' + env.STAGE_NAME,
                                           result: ${currentBuild.currentResult}
-                        */
+                            */
                         }
                         success {
                             sh '''rm -rf daos-devel/
@@ -210,18 +212,20 @@ pipeline {
                     }
                     post {
                         always {
-                            recordIssues enabledForFailure: true,
-                                         aggregatingResults: true,
-                                         id: "analysis-centos7-clang",
-                                         tools: [ clang(), cppCheck() ],
-                                         filters: [excludeFile('.*\\/_build\\.external\\/.*'),
-                                                   excludeFile('_build\\.external\\/.*')]
-                        /* when JENKINS-39203 is resolved, can probably use stepResult
-                           here and remove the remaining post conditions
+                            node('lightweight') {
+                                recordIssues enabledForFailure: true,
+                                             aggregatingResults: true,
+                                             id: "analysis-centos7-clang",
+                                             tools: [ clang(), cppCheck() ],
+                                             filters: [excludeFile('.*\\/_build\\.external\\/.*'),
+                                                       excludeFile('_build\\.external\\/.*')]
+                            }
+                            /* when JENKINS-39203 is resolved, can probably use stepResult
+                               here and remove the remaining post conditions
                                stepResult name: env.STAGE_NAME,
                                           context: 'build/' + env.STAGE_NAME,
                                           result: ${currentBuild.currentResult}
-                        */
+                            */
                         }
                         success {
                             /* temporarily moved into stepResult due to JENKINS-39203
@@ -263,18 +267,20 @@ pipeline {
                     }
                     post {
                         always {
-                            recordIssues enabledForFailure: true,
-                                         aggregatingResults: true,
-                                         id: "analysis-ubuntu18",
-                                         tools: [ gcc4(), cppCheck() ],
-                                         filters: [excludeFile('.*\\/_build\\.external\\/.*'),
-                                                   excludeFile('_build\\.external\\/.*')]
-                        /* when JENKINS-39203 is resolved, can probably use stepResult
-                           here and remove the remaining post conditions
+                            node('lightweight') {
+                                recordIssues enabledForFailure: true,
+                                             aggregatingResults: true,
+                                             id: "analysis-ubuntu18",
+                                             tools: [ gcc4(), cppCheck() ],
+                                             filters: [excludeFile('.*\\/_build\\.external\\/.*'),
+                                                       excludeFile('_build\\.external\\/.*')]
+                            }
+                            /* when JENKINS-39203 is resolved, can probably use stepResult
+                               here and remove the remaining post conditions
                                stepResult name: env.STAGE_NAME,
                                           context: 'build/' + env.STAGE_NAME,
                                           result: ${currentBuild.currentResult}
-                        */
+                            */
                         }
                         success {
                             /* temporarily moved into stepResult due to JENKINS-39203
@@ -315,18 +321,20 @@ pipeline {
                     }
                     post {
                         always {
-                            recordIssues enabledForFailure: true,
-                                         aggregatingResults: true,
-                                         id: "analysis-ubuntu18-clang",
-                                         tools: [ clang(), cppCheck() ],
-                                         filters: [excludeFile('.*\\/_build\\.external\\/.*'),
-                                                   excludeFile('_build\\.external\\/.*')]
-                        /* when JENKINS-39203 is resolved, can probably use stepResult
-                           here and remove the remaining post conditions
+                            node('lightweight') {
+                                recordIssues enabledForFailure: true,
+                                             aggregatingResults: true,
+                                             id: "analysis-ubuntu18-clang",
+                                             tools: [ clang(), cppCheck() ],
+                                             filters: [excludeFile('.*\\/_build\\.external\\/.*'),
+                                                       excludeFile('_build\\.external\\/.*')]
+                            }
+                            /* when JENKINS-39203 is resolved, can probably use stepResult
+                               here and remove the remaining post conditions
                                stepResult name: env.STAGE_NAME,
                                           context: 'build/' + env.STAGE_NAME,
                                           result: ${currentBuild.currentResult}
-                        */
+                            */
                         }
                         success {
                             /* temporarily moved into stepResult due to JENKINS-39203
@@ -368,18 +376,20 @@ pipeline {
                     }
                     post {
                         always {
-                            recordIssues enabledForFailure: true,
-                                         aggregatingResults: true,
-                                         id: "analysis-leap15",
-                                         tools: [ gcc4(), cppCheck() ],
-                                         filters: [excludeFile('.*\\/_build\\.external\\/.*'),
-                                                   excludeFile('_build\\.external\\/.*')]
-                        /* when JENKINS-39203 is resolved, can probably use stepResult
-                           here and remove the remaining post conditions
+                            node('lightweight') {
+                                recordIssues enabledForFailure: true,
+                                             aggregatingResults: true,
+                                             id: "analysis-leap15",
+                                             tools: [ gcc4(), cppCheck() ],
+                                             filters: [excludeFile('.*\\/_build\\.external\\/.*'),
+                                                       excludeFile('_build\\.external\\/.*')]
+                            }
+                            /* when JENKINS-39203 is resolved, can probably use stepResult
+                               here and remove the remaining post conditions
                                stepResult name: env.STAGE_NAME,
                                           context: 'build/' + env.STAGE_NAME,
                                           result: ${currentBuild.currentResult}
-                        */
+                            */
                         }
                         success {
                             /* temporarily moved into stepResult due to JENKINS-39203
@@ -421,18 +431,20 @@ pipeline {
                     }
                     post {
                         always {
-                            recordIssues enabledForFailure: true,
-                                         aggregatingResults: true,
-                                         id: "analysis-leap15-clang",
-                                         tools: [ clang(), cppCheck() ],
-                                         filters: [excludeFile('.*\\/_build\\.external\\/.*'),
-                                                   excludeFile('_build\\.external\\/.*')]
-                        /* when JENKINS-39203 is resolved, can probably use stepResult
-                           here and remove the remaining post conditions
+                            node('lightweight') {
+                                recordIssues enabledForFailure: true,
+                                             aggregatingResults: true,
+                                             id: "analysis-leap15-clang",
+                                             tools: [ clang(), cppCheck() ],
+                                             filters: [excludeFile('.*\\/_build\\.external\\/.*'),
+                                                       excludeFile('_build\\.external\\/.*')]
+                            }
+                            /* when JENKINS-39203 is resolved, can probably use stepResult
+                               here and remove the remaining post conditions
                                stepResult name: env.STAGE_NAME,
                                           context: 'build/' + env.STAGE_NAME,
                                           result: ${currentBuild.currentResult}
-                        */
+                            */
                         }
                         success {
                             /* temporarily moved into stepResult due to JENKINS-39203
@@ -474,18 +486,20 @@ pipeline {
                     }
                     post {
                         always {
-                            recordIssues enabledForFailure: true,
-                                         aggregatingResults: true,
-                                         id: "analysis-leap15-intelc",
-                                         tools: [ intel(), cppCheck() ],
-                                         filters: [excludeFile('.*\\/_build\\.external\\/.*'),
-                                                   excludeFile('_build\\.external\\/.*')]
-                        /* when JENKINS-39203 is resolved, can probably use stepResult
-                           here and remove the remaining post conditions
+                            node('lightweight') {
+                                recordIssues enabledForFailure: true,
+                                             aggregatingResults: true,
+                                             id: "analysis-leap15-intelc",
+                                             tools: [ intel(), cppCheck() ],
+                                             filters: [excludeFile('.*\\/_build\\.external\\/.*'),
+                                                       excludeFile('_build\\.external\\/.*')]
+                            }
+                            /* when JENKINS-39203 is resolved, can probably use stepResult
+                               here and remove the remaining post conditions
                                stepResult name: env.STAGE_NAME,
                                           context: 'build/' + env.STAGE_NAME,
                                           result: ${currentBuild.currentResult}
-                        */
+                            */
                         }
                         success {
                             /* temporarily moved into stepResult due to JENKINS-39203
@@ -561,7 +575,8 @@ pipeline {
                                                [ -f /tmp/daos.log ] && mv /tmp/daos.log run_test.sh/
                                                # servers can sometimes take a while to stop when the test is done
                                                x=0
-                                               while [ \"\\\$x\" -lt \"10\" ] && pgrep '(daos_server|daos_io_server)'; do
+                                               while [ \"\\\$x\" -lt \"10\" ] && 
+                                                     pgrep '(orterun|daos_server|daos_io_server)'; do
                                                    sleep 1
                                                    let x=\\\$x+1
                                                done"''',

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -41,6 +41,7 @@
 //@Library(value="pipeline-lib@your_branch") _
 
 def arch=""
+def sanitized_JOB_NAME = JOB_NAME.replaceAll('/', '-').toLowerCase()
 
 pipeline {
     agent { label 'lightweight' }
@@ -72,7 +73,7 @@ pipeline {
                             filename 'Dockerfile.centos:7'
                             dir 'utils/docker'
                             label 'docker_runner'
-                            additionalBuildArgs '$BUILDARGS'
+                            additionalBuildArgs "-t ${sanitized_JOB_NAME}-centos7 " + '$BUILDARGS'
                         }
                     }
                     steps {
@@ -125,7 +126,7 @@ pipeline {
                             filename 'Dockerfile.centos:7'
                             dir 'utils/docker'
                             label 'docker_runner'
-                            additionalBuildArgs '$BUILDARGS'
+                            additionalBuildArgs "-t ${sanitized_JOB_NAME}-centos7 " + '$BUILDARGS'
                         }
                     }
                     steps {
@@ -204,7 +205,7 @@ pipeline {
                             filename 'Dockerfile.centos:7'
                             dir 'utils/docker'
                             label 'docker_runner'
-                            additionalBuildArgs '$BUILDARGS'
+                            additionalBuildArgs "-t ${sanitized_JOB_NAME}-centos7 " + '$BUILDARGS'
                         }
                     }
                     steps {
@@ -259,7 +260,7 @@ pipeline {
                             filename 'Dockerfile.ubuntu:18.04'
                             dir 'utils/docker'
                             label 'docker_runner'
-                            additionalBuildArgs '$BUILDARGS'
+                            additionalBuildArgs "-t ${sanitized_JOB_NAME}-ubuntu18.04 " + '$BUILDARGS'
                         }
                     }
                     steps {
@@ -313,7 +314,7 @@ pipeline {
                             filename 'Dockerfile.ubuntu:18.04'
                             dir 'utils/docker'
                             label 'docker_runner'
-                            additionalBuildArgs '$BUILDARGS'
+                            additionalBuildArgs "-t ${sanitized_JOB_NAME}-ubuntu18.04 " + '$BUILDARGS'
                         }
                     }
                     steps {
@@ -368,7 +369,7 @@ pipeline {
                             filename 'Dockerfile.leap:15'
                             dir 'utils/docker'
                             label 'docker_runner'
-                            additionalBuildArgs '$BUILDARGS'
+                            additionalBuildArgs "-t ${sanitized_JOB_NAME}-leap15 " + '$BUILDARGS'
                         }
                     }
                     steps {
@@ -423,7 +424,7 @@ pipeline {
                             filename 'Dockerfile.leap:15'
                             dir 'utils/docker'
                             label 'docker_runner'
-                            additionalBuildArgs '$BUILDARGS'
+                            additionalBuildArgs "-t ${sanitized_JOB_NAME}-leap15 " + '$BUILDARGS'
                         }
                     }
                     steps {
@@ -477,7 +478,7 @@ pipeline {
                             filename 'Dockerfile.leap:15'
                             dir 'utils/docker'
                             label 'docker_runner'
-                            additionalBuildArgs '$BUILDARGS'
+                            additionalBuildArgs "-t ${sanitized_JOB_NAME}-leap15 " + '$BUILDARGS'
                             args '-v /opt/intel:/opt/intel'
                         }
                     }


### PR DESCRIPTION
For garbage collection purposes.

This should allow us to delete old docker images without having to
resort to simply deleting the oldest images.

Change-Id: Ia93265566d7fc45afa50a1ea0c16690afd811fec
Signed-off-by: Brian J. Murrell <brian.murrell@intel.com>