### PR TITLE
DAOS-2070 vos: Fix some issues with PMDK

### DIFF
--- a/src/common/tests/SConscript
+++ b/src/common/tests/SConscript
@@ -8,9 +8,12 @@ def scons():
     common_test_utils = denv.SharedObject(['test_mocks.c', 'test_utils.c'])
     Export('common_test_utils')
 
-    daos_build.test(denv, 'btree', 'btree.c',
+    utest_utils = denv.SharedObject('utest_common.c')
+    Export('utest_utils')
+
+    daos_build.test(denv, 'btree', ['btree.c', utest_utils],
                     LIBS=['daos_common', 'gurt', 'cart', 'pmemobj'])
-    daos_build.test(denv, 'btree_direct', 'btree_direct.c',
+    daos_build.test(denv, 'btree_direct', ['btree_direct.c', utest_utils],
                     LIBS=['daos_common', 'gurt', 'cart', 'pmemobj'])
     daos_build.test(denv, 'other', 'other.c',
                     LIBS=['daos_common', 'gurt', 'cart'])

--- a/src/common/tests/btree.c
+++ b/src/common/tests/btree.c
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2016-2018 Intel Corporation.
+ * (C) Copyright 2016-2019 Intel Corporation.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -36,12 +36,24 @@
 
 #include <daos/btree.h>
 #include <daos/tests_lib.h>
+#include "utest_common.h"
 
 /**
  * An example for integer key btree.
  */
 
 TMMID_DECLARE(struct ik_rec, 0);
+
+#define IK_ORDER_DEF	16
+
+static int ik_order = IK_ORDER_DEF;
+
+struct utest_context		*ik_utx;
+struct umem_attr		*ik_uma;
+static TMMID(struct btr_root)	ik_root_mmid;
+static struct btr_root		*ik_root;
+static daos_handle_t		ik_toh;
+
 
 /** integer key record */
 struct ik_rec {
@@ -54,8 +66,6 @@ struct ik_rec {
 #define IK_TREE_CLASS	100
 #define POOL_NAME "/mnt/daos/btree-test"
 #define POOL_SIZE ((1024 * 1024  * 1024ULL))
-
-struct umem_attr ik_uma;
 
 /** customized functions for btree */
 static int
@@ -118,8 +128,8 @@ ik_rec_free(struct btr_instance *tins, struct btr_record *rec, void *args)
 		rec->rec_mmid	= UMMID_NULL;
 		return 0;
 	}
-	umem_free(umm, irec->ir_val_mmid);
-	umem_free_typed(umm, irec_mmid);
+	utest_free(ik_utx, irec->ir_val_mmid);
+	utest_free_typed(ik_utx, irec_mmid);
 
 	return 0;
 }
@@ -245,14 +255,6 @@ static btr_ops_t ik_ops = {
 	.to_rec_stat	= ik_rec_stat,
 };
 
-#define IK_ORDER_DEF	16
-
-static int ik_order = IK_ORDER_DEF;
-
-static TMMID(struct btr_root)	ik_root_mmid;
-static struct btr_root		ik_root;
-static daos_handle_t		ik_toh;
-
 #define IK_SEP		','
 #define IK_SEP_VAL	':'
 
@@ -293,7 +295,7 @@ ik_btr_open_create(bool create, char *args)
 			return -1;
 		}
 	} else if (!create) {
-		inplace = (ik_root.tr_class != 0);
+		inplace = (ik_root->tr_class != 0);
 		if (TMMID_IS_NULL(ik_root_mmid) && !inplace) {
 			D_ERROR("Please create tree first\n");
 			return -1;
@@ -305,18 +307,20 @@ ik_btr_open_create(bool create, char *args)
 			ik_order, inplace ? " inplace" : "", feats);
 		if (inplace) {
 			rc = dbtree_create_inplace(IK_TREE_CLASS, feats,
-						   ik_order, &ik_uma, &ik_root,
+						   ik_order, ik_uma, ik_root,
 						   &ik_toh);
 		} else {
 			rc = dbtree_create(IK_TREE_CLASS, feats, ik_order,
-					   &ik_uma, &ik_root_mmid, &ik_toh);
+					   ik_uma, &ik_root_mmid, &ik_toh);
 		}
 	} else {
 		D_PRINT("Open btree%s\n", inplace ? " inplace" : "");
 		if (inplace) {
-			rc = dbtree_open_inplace(&ik_root, &ik_uma, &ik_toh);
+			rc = dbtree_open_inplace(ik_root,
+						 ik_uma,
+						 &ik_toh);
 		} else {
-			rc = dbtree_open(ik_root_mmid, &ik_uma, &ik_toh);
+			rc = dbtree_open(ik_root_mmid, ik_uma, &ik_toh);
 		}
 	}
 	if (rc != 0) {
@@ -357,18 +361,13 @@ static int
 btr_rec_verify_delete(umem_id_t *rec, daos_iov_t *key)
 {
 	TMMID(struct ik_rec)	irec_mmid;
-	struct umem_instance	umm;
+	struct umem_instance	*umm;
 	struct ik_rec		*irec;
-	int			rc;
 
-	rc = umem_class_init(&ik_uma, &umm);
-	if (rc != 0) {
-		D_ERROR("Failed to instantiate umem while vefify: %d\n", rc);
-		return -1;
-	}
+	umm = utest_utx2umm(ik_utx);
 
 	irec_mmid = umem_id_u2t(*rec, struct ik_rec);
-	irec	  = umem_id2ptr_typed(&umm, irec_mmid);
+	irec	  = umem_id2ptr_typed(umm, irec_mmid);
 
 	if ((sizeof(irec->ir_key) != key->iov_len) ||
 	    (irec->ir_key != *((uint64_t *)key->iov_buf))) {
@@ -376,8 +375,8 @@ btr_rec_verify_delete(umem_id_t *rec, daos_iov_t *key)
 		return -1;
 	}
 
-	umem_free(&umm, irec->ir_val_mmid);
-	umem_free_typed(&umm, irec_mmid);
+	utest_free(ik_utx, irec->ir_val_mmid);
+	utest_free_typed(ik_utx, irec_mmid);
 
 	return 0;
 }
@@ -833,11 +832,11 @@ static struct option btr_ops[] = {
 int
 main(int argc, char **argv)
 {
-	int	rc;
+	int	rc = 0;
+	int	opt;
 
 	ik_toh = DAOS_HDL_INVAL;
 	ik_root_mmid = TMMID_NULL(struct btr_root);
-	ik_root.tr_class = 0;
 
 	rc = daos_debug_init(NULL);
 	if (rc != 0)
@@ -847,10 +846,34 @@ main(int argc, char **argv)
 	D_ASSERT(rc == 0);
 
 	optind = 0;
-	ik_uma.uma_id = UMEM_CLASS_VMEM;
-	while ((rc = getopt_long(argc, argv, "mC:Docqu:d:r:f:i:b:p:",
-				 btr_ops, NULL)) != -1) {
-		switch (rc) {
+
+	/* Check for -m option first */
+	while ((opt = getopt_long(argc, argv, "mC:Docqu:d:r:f:i:b:p:", btr_ops,
+				  NULL)) != -1) {
+		if (opt == 'm') {
+			D_PRINT("Using pmem\n");
+			rc = utest_pmem_create(POOL_NAME, POOL_SIZE,
+					       sizeof(*ik_root), &ik_utx);
+			D_ASSERT(rc == 0);
+			break;
+		}
+	}
+
+	if (ik_utx == NULL) {
+		D_PRINT("Using vmem\n");
+		rc = utest_vmem_create(sizeof(*ik_root), &ik_utx);
+		D_ASSERT(rc == 0);
+	}
+
+	ik_root = utest_utx2root(ik_utx);
+	ik_uma = utest_utx2uma(ik_utx);
+
+	/* start over */
+	optind = 0;
+
+	while ((opt = getopt_long(argc, argv, "mC:Docqu:d:r:f:i:b:p:", btr_ops,
+				  NULL)) != -1) {
+		switch (opt) {
 		case 'C':
 			rc = ik_btr_open_create(true, optarg);
 			break;
@@ -888,25 +911,20 @@ main(int argc, char **argv)
 		case 'p':
 			rc = ik_btr_perf(atoi(optarg));
 			break;
-		case 'm':
-			ik_uma.uma_id = UMEM_CLASS_PMEM;
-			ik_uma.uma_pool = pmemobj_create(POOL_NAME,
-						"btree-perf-test", POOL_SIZE,
-						0666);
-			if (ik_uma.uma_pool == NULL) {
-				perror("Btree test pool creation failed");
-				return 1;
-			}
-			break;
 		default:
-			D_PRINT("Unsupported command %c\n", rc);
+			D_PRINT("Unsupported command %c\n", opt);
+		case 'm':
+			/* handled previously */
+			rc = 0;
 			break;
 		}
+		if (rc != 0)
+			break;
 	}
 	daos_debug_fini();
-	if (ik_uma.uma_id == UMEM_CLASS_PMEM) {
-		pmemobj_close(ik_uma.uma_pool);
-		remove(POOL_NAME);
-	}
-	return 0;
+	rc += utest_utx_destroy(ik_utx);
+	if (rc != 0)
+		printf("Error: %d\n", rc);
+
+	return rc;
 }

--- a/src/common/tests/btree.sh
+++ b/src/common/tests/btree.sh
@@ -4,21 +4,15 @@ cwd=$(dirname "$0")
 DAOS_DIR=${DAOS_DIR:-$(cd "$cwd/../../.." && echo "$PWD")}
 BTR=$DAOS_DIR/build/src/common/tests/btree
 
+VCMD=()
+if [ "$USE_VALGRIND" = "yes" ]; then
+    VCMD=("valgrind" "--tool=pmemcheck")
+fi
+
 ORDER=${ORDER:-3}
 DDEBUG=${DDEBUG:-0}
-INPLACE=${INPLACE:-"no"}
-BACKWARD=${BACKWARD:-"no"}
 BAT_NUM=${BAT_NUM:-"200000"}
 
-IPL=""
-if [ "x$INPLACE" == "xyes" ]; then
-    IPL="i,"
-fi
-
-IDIR="f"
-if [ "x$BACKWARD" == "xyes" ]; then
-    IDIR="b"
-fi
 
 KEYS=${KEYS:-"3,6,5,7,2,1,4"}
 RECORDS=${RECORDS:-"7:loaded,3:that,5:dice,2:knows,4:the,6:are,1:Everybody"}
@@ -73,42 +67,49 @@ done
 
 set -x
 
-if [ -z ${PERF} ]; then
+run_test()
+{
+    printf "\nOptions: IPL='%s' IDIR='%s' PMEM='%s'\n" "$IPL" "$IDIR" "$PMEM"
+    if [ -z ${PERF} ]; then
 
-    echo "B+tree functional test..."
-    DAOS_DEBUG="$DDEBUG"              \
-    "$BTR" -C "${UINT}${IPL}o:$ORDER" \
-    -c                                \
-    -o                                \
-    -u "$RECORDS"                     \
-    -i "$IDIR"                        \
-    -q                                \
-    -f "$KEYS"                        \
-    -d "$KEYS"                        \
-    -u "$RECORDS"                     \
-    -f "$KEYS"                        \
-    -r "$KEYS"                        \
-    -q                                \
-    -u "$RECORDS"                     \
-    -q                                \
-    -i "$IDIR:3"                      \
-    -D
+        echo "B+tree functional test..."
+        DAOS_DEBUG="$DDEBUG"                        \
+        "${VCMD[@]}" "$BTR" "${PMEM}" -C "${UINT}${IPL}o:$ORDER" \
 
-    echo "B+tree batch operations test..."
-    "$BTR" -C "${UINT}${IPL}o:$ORDER" \
-    -c                                \
-    -o                                \
-    -b "$BAT_NUM"                     \
-    -D
-else
-    echo "B+tree performance test..."
-    "$BTR" -C "${UINT}${IPL}o:$ORDER" \
-    -p "$BAT_NUM"                     \
-    -D
+        -c                                          \
+        -o                                          \
+        -u "$RECORDS"                               \
+        -i "$IDIR"                                  \
+        -q                                          \
+        -f "$KEYS"                                  \
+        -d "$KEYS"                                  \
+        -u "$RECORDS"                               \
+        -f "$KEYS"                                  \
+        -r "$KEYS"                                  \
+        -q                                          \
+        -u "$RECORDS"                               \
+        -q                                          \
+        -i "$IDIR:3"                                \
+        -D
 
-    echo "B+tree performance test using pmemobj"
-    "$BTR" -m                  \
-    -C "${UINT}${IPL}o:$ORDER" \
-    -p "$BAT_NUM"              \
-    -D
-fi
+        echo "B+tree batch operations test..."
+        "${VCMD[@]}" "$BTR" "${PMEM}" -C "${UINT}${IPL}o:$ORDER" \
+        -c                                          \
+        -o                                          \
+        -b "$BAT_NUM"                               \
+        -D
+    else
+        echo "B+tree performance test..."
+        "${VCMD[@]}" "$BTR" "${PMEM}" -C "${UINT}${IPL}o:$ORDER" \
+        -p "$BAT_NUM"                               \
+        -D
+    fi
+}
+
+for IPL in "i," ""; do
+    for IDIR in "f" "b"; do
+        for PMEM in "-m" ""; do
+            run_test
+        done
+    done
+done

--- a/src/common/tests/utest_common.c
+++ b/src/common/tests/utest_common.c
@@ -1,0 +1,285 @@
+/**
+ * (C) Copyright 2019 Intel Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * GOVERNMENT LICENSE RIGHTS-OPEN SOURCE SOFTWARE
+ * The Government's rights to use, modify, reproduce, release, perform, display,
+ * or disclose this software are subject to the terms of the Apache License as
+ * provided in Contract No. B609815.
+ * Any reproduction of computer software, computer software documentation, or
+ * portions thereof marked with this legend must also reproduce the markings.
+ *
+ * Helper library for low level tests (e.g. btree/evtree)
+ */
+#include "utest_common.h"
+
+struct utest_context {
+	char			uc_pool_name[UTEST_POOL_NAME_MAX + 1];
+	struct umem_instance	uc_umm;
+	struct umem_attr	uc_uma;
+	umem_id_t		uc_root;
+};
+
+struct utest_root {
+	uint32_t	ur_class;
+	uint32_t	ur_ref_cnt;
+	size_t		ur_root_size;
+	uint64_t	ur_root[0];
+};
+
+int
+utest_tx_begin(struct utest_context *utx)
+{
+	if (!umem_has_tx(&utx->uc_umm))
+		return 0;
+
+	return umem_tx_begin(&utx->uc_umm, NULL);
+}
+
+int
+utest_tx_end(struct utest_context *utx, int rc)
+{
+	if (!umem_has_tx(&utx->uc_umm))
+		return rc;
+
+	if (rc != 0)
+		return umem_tx_abort(&utx->uc_umm, rc);
+
+	return umem_tx_commit(&utx->uc_umm);
+}
+
+static int
+utest_tx_add(struct utest_context *utx, void *ptr, size_t size)
+{
+	if (!umem_has_tx(&utx->uc_umm))
+		return 0;
+
+	return umem_tx_add_ptr(&utx->uc_umm, ptr, size);
+}
+
+#define utest_tx_add_ptr(utx, ptr) utest_tx_add(utx, ptr, sizeof(*ptr))
+
+int
+utest_pmem_create(const char *name, size_t pool_size, size_t root_size,
+		  struct utest_context **utx)
+{
+	struct utest_context	*ctx;
+	struct utest_root	*root;
+	int			 rc;
+
+	if (strnlen(name, UTEST_POOL_NAME_MAX + 1) > UTEST_POOL_NAME_MAX)
+		return -DER_INVAL;
+
+	D_ALLOC_PTR(ctx);
+	if (ctx == NULL)
+		return -DER_NOMEM;
+
+	strcpy(ctx->uc_pool_name, name);
+	ctx->uc_uma.uma_id = UMEM_CLASS_PMEM;
+	ctx->uc_uma.uma_pool = pmemobj_create(name, "utest_pool", pool_size,
+					      0666);
+
+	if (ctx->uc_uma.uma_pool == NULL) {
+		perror("Utest pmem pool couldn't be created");
+		rc = -DER_NOMEM;
+		goto free_ctx;
+	}
+
+	umem_class_init(&ctx->uc_uma, &ctx->uc_umm);
+
+	ctx->uc_root = pmemobj_root(ctx->uc_uma.uma_pool,
+				 sizeof(*root) + root_size);
+	if (OID_IS_NULL(ctx->uc_root)) {
+		perror("Could not get pmem root");
+		rc = -DER_MISC;
+		goto destroy;
+	}
+
+	root = umem_id2ptr(&ctx->uc_umm, ctx->uc_root);
+
+	rc = utest_tx_begin(ctx);
+	if (rc != 0)
+		goto destroy;
+
+	rc = utest_tx_add_ptr(ctx, root);
+	if (rc != 0)
+		goto end;
+
+	root->ur_class = UMEM_CLASS_PMEM;
+	root->ur_root_size = root_size;
+	root->ur_ref_cnt = 1;
+end:
+	rc = utest_tx_end(ctx, rc);
+	if (rc != 0)
+		goto destroy;
+
+	*utx = ctx;
+	return 0;
+destroy:
+	pmemobj_close(ctx->uc_uma.uma_pool);
+	remove(ctx->uc_pool_name);
+free_ctx:
+	D_FREE(ctx);
+	return rc;
+}
+
+int
+utest_vmem_create(size_t root_size, struct utest_context **utx)
+{
+	struct utest_context	*ctx;
+	struct utest_root	*root;
+	int			 rc = 0;
+
+	D_ALLOC_PTR(ctx);
+	if (ctx == NULL)
+		return -DER_NOMEM;
+
+	ctx->uc_uma.uma_id = UMEM_CLASS_VMEM;
+
+	umem_class_init(&ctx->uc_uma, &ctx->uc_umm);
+
+	ctx->uc_root = umem_alloc(&ctx->uc_umm, sizeof(*root) + root_size);
+
+	if (UMMID_IS_NULL(ctx->uc_root)) {
+		rc = -DER_NOMEM;
+		goto free_ctx;
+	}
+
+	root = umem_id2ptr(&ctx->uc_umm, ctx->uc_root);
+
+	root->ur_class = UMEM_CLASS_VMEM;
+	root->ur_root_size = root_size;
+	root->ur_ref_cnt = 1;
+
+	*utx = ctx;
+
+	return 0;
+
+free_ctx:
+	D_FREE(ctx);
+	return rc;
+}
+
+int
+utest_utx_destroy(struct utest_context *utx)
+{
+	struct utest_root	*root;
+	int			 refcnt = 0;
+	int			 rc = 0;
+
+	root = umem_id2ptr(&utx->uc_umm, utx->uc_root);
+
+	if (utx->uc_uma.uma_id == UMEM_CLASS_VMEM) {
+		root->ur_ref_cnt--;
+		if (root->ur_ref_cnt == 0) {
+			umem_free(&utx->uc_umm, utx->uc_root);
+			D_FREE(utx);
+		}
+		return 0;
+	}
+
+	/* Ok, PMEM is a bit more complicated */
+	rc = utest_tx_begin(utx);
+	if (rc != 0) {
+		D_ERROR("Problem in tx begin\n");
+		return rc;
+	}
+
+	rc = utest_tx_add_ptr(utx, root);
+	if (rc != 0) {
+		D_ERROR("Problem in tx add\n");
+		goto end;
+	}
+
+	root->ur_ref_cnt--;
+	refcnt = root->ur_ref_cnt;
+end:
+	rc = utest_tx_end(utx, rc);
+	if (rc != 0) {
+		D_ERROR("Problem in tx end\n");
+		return rc;
+	}
+
+	if (refcnt != 0)
+		return 0;
+
+	pmemobj_close(utx->uc_uma.uma_pool);
+	remove(utx->uc_pool_name);
+	D_FREE(utx);
+	return 0;
+}
+
+void *
+utest_utx2root(struct utest_context *utx)
+{
+	struct utest_root	*root;
+
+	root = umem_id2ptr(&utx->uc_umm, utx->uc_root);
+
+	return &root->ur_root[0];
+}
+
+umem_id_t
+utest_utx2rootmmid(struct utest_context *utx)
+{
+	return utx->uc_root;
+}
+
+int
+utest_alloc(struct utest_context *utx, umem_id_t *mmid, size_t size,
+	    utest_init_cb cb, const void *cb_arg)
+{
+	int	rc;
+
+	rc = utest_tx_begin(utx);
+	if (rc != 0)
+		return rc;
+
+	*mmid = umem_alloc(&utx->uc_umm, size);
+	if (UMMID_IS_NULL(*mmid)) {
+		rc = -DER_NOMEM;
+		goto end;
+	}
+
+	if (cb)
+		cb(umem_id2ptr(&utx->uc_umm, *mmid), size, cb_arg);
+end:
+	return utest_tx_end(utx, rc);
+}
+
+int
+utest_free(struct utest_context *utx, umem_id_t mmid)
+{
+	int	rc;
+
+	rc = utest_tx_begin(utx);
+	if (rc != 0)
+		return rc;
+
+	rc = umem_free(&utx->uc_umm, mmid);
+
+	return utest_tx_end(utx, rc);
+}
+
+struct umem_instance *
+utest_utx2umm(struct utest_context *utx)
+{
+	return &utx->uc_umm;
+}
+
+struct umem_attr *
+utest_utx2uma(struct utest_context *utx)
+{
+	return &utx->uc_uma;
+}

--- a/src/common/tests/utest_common.h
+++ b/src/common/tests/utest_common.h
@@ -1,0 +1,168 @@
+/**
+ * (C) Copyright 2019 Intel Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * GOVERNMENT LICENSE RIGHTS-OPEN SOURCE SOFTWARE
+ * The Government's rights to use, modify, reproduce, release, perform, display,
+ * or disclose this software are subject to the terms of the Apache License as
+ * provided in Contract No. B609815.
+ * Any reproduction of computer software, computer software documentation, or
+ * portions thereof marked with this legend must also reproduce the markings.
+ *
+ * Helper library for low level tests (e.g. btree/evtree)
+ */
+#include <daos/mem.h>
+
+#define UTEST_POOL_NAME_MAX	255
+
+struct utest_context;
+
+/** Create pmem context for unit testing.  This creates a pool and a root
+ *  object of specified sizes.  Note that the root object should be
+ *  retrieved with utest_utx2root* rather than pmemobj_root as the real
+ *  root type is internal to the helper library.
+ *
+ *  \param	name[IN]	The path of the pool
+ *  \param	pool_size[IN]	The size of the pool in bytes
+ *  \param	root_size[IN]	The size of the root object
+ *  \param	utx[OUT]
+ *
+ *  \return 0 on success, error otherwise
+ */
+int utest_pmem_create(const char *name, size_t pool_size, size_t root_size,
+		      struct utest_context **utx);
+
+/** Create vmem context for unit testing.  This allocates a context and
+ *  a root object of the specified size.  This isn't wholly necessary but
+ *  ensures that we have a common interface whether we are using vmem or
+ *  pmem.
+ *
+ *  \param	root_size[IN]	The size of the root object
+ *  \param	utx[OUT]
+ *
+ *  \return 0 on success, error otherwise
+ */
+int utest_vmem_create(size_t root_size, struct utest_context **utx);
+
+/** Destroy a context and free any associated resources (e.g. memory,
+ *  pmemobj pool, files)
+ *
+ *  \param	utx[IN]	The context to destroy
+ *
+ *  \return 0 on success, error otherwise
+ */
+int utest_utx_destroy(struct utest_context *utx);
+
+/** Retrieve a pointer to the root object in a context
+ *
+ *  \param	utx[IN]	The context to query
+ *
+ *  \return	Pointer to root
+ */
+void *utest_utx2root(struct utest_context *utx);
+
+/** Retrieve an mmid pointer to the root object in a context
+ *
+ *  \param	utx[IN]	The context to query
+ *
+ *  \return	mmid pointer to root
+ */
+umem_id_t utest_utx2rootmmid(struct utest_context *utx);
+
+/** Initialization callback for object allocation API.  If the context
+ *  is a pmem context, this will be invoked inside a transaction.  The
+ *  pointer will already be added to the transaction but it is up to the
+ *  user to add any additional memory modified.
+ *
+ *  \param	ptr[IN, OUT]	The pointer to initialize
+ *  \param	size[IN]	The size of the allocation
+ *  \param	cb_arg[IN]	Argument passed in by user
+ */
+typedef void (*utest_init_cb)(void *ptr, size_t size, const void *cb_arg);
+
+/** Allocate an object and, optionally, initialize it.  If the context
+ *  is a pmem context, this will be done in a transaction.
+ *
+ *  \param	utx[IN]		The context
+ *  \param	mmid[OUT]	The allocated pointer
+ *  \param	size[IN]	The size to allocate
+ *  \param	cb[IN]		Optional initialization callback
+ *  \param	cb_arg[IN]	Optional argument to pass to initialization
+ *
+ *  \return 0 on success, error otherwise
+ */
+int utest_alloc(struct utest_context *utx, umem_id_t *mmid, size_t size,
+		utest_init_cb cb, const void *cb_arg);
+
+/** Free an object
+ *
+ *  \param	utx[IN]		The context
+ *  \param	mmid[IN]	The allocated pointer to free
+ *
+ *  \return 0 on success, error otherwise
+ */
+int utest_free(struct utest_context *utx, umem_id_t mmid);
+
+/** Free a typed object
+ *
+ *  \param	utx[IN]		The context
+ *  \param	tmmid[IN]	The allocated pointer to free
+ *
+ *  \return 0 on success, error otherwise
+ */
+#define utest_free_typed(utx, tmmid) utest_free(utx, (tmmid).oid)
+
+/** Get the umem_instance for a context
+ *
+ *  \param	utx[IN]		The context
+ *
+ *  \return umem_instance
+ */
+struct umem_instance *utest_utx2umm(struct utest_context *utx);
+
+/** Get the umem_attr for a context
+ *
+ *  \param	utx[IN]		The context
+ *
+ *  \return The umem_attr
+ */
+struct umem_attr *utest_utx2uma(struct utest_context *utx);
+
+/** Helper macro to convert an offset to an mmid
+ *  \param	utx[IN]		The context
+ *  \param	offset[IN]	The offset from start of pool
+ *
+ *  \return The mmid to the memory
+ */
+#define utest_off2mmid(utx, offset)					\
+	(								\
+	{								\
+		umem_id_t	__ummid;				\
+		uint64_t	__pool_uuid;				\
+									\
+		__pool_uuid = umem_get_uuid(utest_utx2umm(utx));	\
+		__ummid.pool_uuid_lo = __pool_uuid;			\
+		__ummid.off = (offset);					\
+		__ummid;						\
+	}								\
+	)
+
+/** Helper macro to convert an offset to an direct pointer
+ *  \param	utx[IN]		The context
+ *  \param	offset[IN]	The offset from start of pool
+ *
+ *  \return The pointer to the memory
+ */
+#define utest_off2ptr(utx, offset)					\
+	umem_id2ptr(utest_utx2umm(utx), utest_off2mmid(utx, offset))

--- a/src/vos/tests/SConscript
+++ b/src/vos/tests/SConscript
@@ -3,7 +3,7 @@ import daos_build
 
 def scons():
     """Execute build"""
-    Import('denv', 'prereqs')
+    Import('denv', 'prereqs', 'utest_utils')
 
     libraries = ['vos', 'bio', 'abt', 'pthread', 'daos_common', 'daos_tests',
                  'gurt', 'cart', 'uuid', 'pthread', 'pmemobj', 'cmocka', 'gomp']
@@ -17,7 +17,9 @@ def scons():
                     denv.Object("vts_common.c"), 'vts_purge.c']
     vos_tests = daos_build.program(denv, 'vos_tests', vos_test_src,
                                    LIBS=libraries)
-    evt_ctl = daos_build.program(denv, 'evt_ctl', 'evt_ctl.c', LIBS=libraries)
+    denv.AppendUnique(CPPPATH=["../../common/tests"])
+    evt_ctl = daos_build.program(denv, 'evt_ctl', ['evt_ctl.c', utest_utils],
+                                 LIBS=libraries)
 
     denv.Install('$PREFIX/bin/', vos_tests)
     denv.Install('$PREFIX/bin/', evt_ctl)

--- a/src/vos/tests/evt_ctl.sh
+++ b/src/vos/tests/evt_ctl.sh
@@ -1,12 +1,16 @@
 #!/bin/bash
 
+if [ "$USE_VALGRIND" = "yes" ]; then
+    VCMD="valgrind --tool=pmemcheck "
+fi
+
 cwd=$(dirname "$0")
 DAOS_DIR=$(cd "${cwd}/../../.." && echo "$PWD")
 #shellcheck disable=SC1090
 source "$DAOS_DIR/.build_vars.sh"
 EVT_CTL="$SL_PREFIX/bin/evt_ctl"
 
-cmd="$EVT_CTL -C o:4"
+cmd="$VCMD $EVT_CTL $* -C o:4"
 
 function word_set {
     ((flag = $1 % 2))
@@ -23,6 +27,7 @@ function word_set {
  -a 20-24@$n:black		\
  -a 90-95@$np2:coffee	\
  -a 50-56@$n:scarlet	\
+ -a 57-61@$n:witch		\
  -a 57-61@$n:witch		\
  -a 96-99@$n:blue		\
  -a 78-82@$np2:hello	\

--- a/src/vos/vea/vea_api.c
+++ b/src/vos/vea/vea_api.c
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2018 Intel Corporation.
+ * (C) Copyright 2018-2019 Intel Corporation.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -425,7 +425,8 @@ process_resrvd_list(struct vea_space_info *vsi, struct vea_hint_context *hint,
 			goto error;
 	}
 
-	rc = publish ? hint_tx_publish(hint, off_p, seq_min, seq_max) :
+	rc = publish ? hint_tx_publish(vsi->vsi_umem, hint, off_p, seq_min,
+				       seq_max) :
 		       hint_cancel(hint, off_c, seq_min, seq_max);
 error:
 	d_list_for_each_entry_safe(resrvd, tmp, resrvd_list, vre_link) {

--- a/src/vos/vea/vea_internal.h
+++ b/src/vos/vea/vea_internal.h
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2018 Intel Corporation.
+ * (C) Copyright 2018-2019 Intel Corporation.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -199,7 +199,7 @@ void hint_get(struct vea_hint_context *hint, uint64_t *off);
 void hint_update(struct vea_hint_context *hint, uint64_t off, uint64_t *seq);
 int hint_cancel(struct vea_hint_context *hint, uint64_t off, uint64_t seq_min,
 		uint64_t seq_max);
-int hint_tx_publish(struct vea_hint_context *hint, uint64_t off,
-		    uint64_t seq_min, uint64_t seq_max);
+int hint_tx_publish(struct umem_instance *umm, struct vea_hint_context *hint,
+		    uint64_t off, uint64_t seq_min, uint64_t seq_max);
 
 #endif /* __VEA_INTERNAL_H__ */

--- a/src/vos/vos_pool.c
+++ b/src/vos/vos_pool.c
@@ -206,6 +206,7 @@ vos_pool_create(const char *path, uuid_t uuid, daos_size_t scm_sz,
 	PMEMobjpool		*ph;
 	struct umem_attr	 uma;
 	struct umem_instance	 umem;
+	struct vos_pool_df	*pool_df;
 	struct bio_xs_context	*xs_ctxt = vos_xsctxt_get();
 	struct bio_blob_hdr	 blob_hdr;
 	int			 rc = 0, enabled = 1;
@@ -247,10 +248,8 @@ vos_pool_create(const char *path, uuid_t uuid, daos_size_t scm_sz,
 		scm_sz = lstat.st_size;
 	}
 
+	pool_df = vos_pool_pop2df(ph);
 	TX_BEGIN(ph) {
-		struct vos_pool_df	*pool_df;
-
-		pool_df = vos_pool_pop2df(ph);
 		pmemobj_tx_add_range_direct(pool_df, sizeof(*pool_df));
 		memset(pool_df, 0, sizeof(*pool_df));
 

--- a/src/vos/vos_tree.c
+++ b/src/vos/vos_tree.c
@@ -653,6 +653,8 @@ svt_rec_alloc(struct btr_instance *tins, daos_iov_t *key_iov,
 		if (UMMID_IS_NULL(rec->rec_mmid))
 			return -DER_NOMEM;
 	} else {
+		umem_tx_add(&tins->ti_umm, rbund->rb_mmid,
+			    vos_irec_msize(rbund));
 		rec->rec_mmid = rbund->rb_mmid;
 		rbund->rb_mmid = UMMID_NULL; /* taken over by btree */
 	}

--- a/utils/run_test.sh
+++ b/utils/run_test.sh
@@ -79,6 +79,7 @@ if [ -d "/mnt/daos" ]; then
     run_test build/src/common/tests/drpc_tests
     run_test build/src/client/api/tests/eq_tests
     run_test src/vos/tests/evt_ctl.sh
+    run_test src/vos/tests/evt_ctl.sh pmem
     run_test build/src/vos/vea/tests/vea_ut
     run_test src/rdb/raft_tests/raft_tests.py
     # Satisfy CGO Link requirements for go-spdk binding imports


### PR DESCRIPTION
There are a few bugs with our usage of PMDK and still some more
to fix.   This change fixes a few in btree and evtree, primarily
with in-transaction stores without adding memory to a transaction.

The other primary change here is to create a simple helper
library to be able to test with pmdk or virtual memory.  It would
probably be good to add nvme to the mix here but I'll defer that
to later.   As I was trying to find some issues with btree, I
noticed that inplace updates didn't work well with PMDK and I had
recently added similar changes to evt_ctl so I thought I'd
commonize those changes.

I plan to also add some more normal unit tests and this
infrastructure should help in that regard.

Change-Id: I23f4946a321ee99aafa6f3758c7c23bb727eb1f6
Signed-off-by: Jeff Olivier <jeffrey.v.olivier@intel.com>