### PR TITLE
DAOS-2065 control: Defer os.Exit in server/agent's main

### DIFF
--- a/src/control/README.md
+++ b/src/control/README.md
@@ -154,3 +154,9 @@ TODO: include details of `daos_agent` interaction
 ### Testing the app
 
 * Run the tests `go test` within each directory containing tests
+
+## Coding Guidelines
+
+### daos_server and daos_agent
+
+* Avoid calling `os.Exit` (or `log.Fatal`, `log.Fatalf`, etc.), except for assertion purposes. Fatal errors shall be returned back to `main`, who determines the exit status based on its `err` and calls `os.Exit`, in its last deferred function call.

--- a/src/control/agent/daos_agent.go
+++ b/src/control/agent/daos_agent.go
@@ -1,5 +1,5 @@
 //
-// (C) Copyright 2018 Intel Corporation.
+// (C) Copyright 2018-2019 Intel Corporation.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -39,6 +39,15 @@ var (
 )
 
 func main() {
+	var err error
+	defer func() {
+		status := 0
+		if err != nil {
+			status = 1
+		}
+		os.Exit(status)
+	}()
+
 	flag.Parse()
 
 	// Setup signal handlers so we can block till we get SIGINT or SIGTERM

--- a/src/control/server/daos_server.go
+++ b/src/control/server/daos_server.go
@@ -54,12 +54,21 @@ type cliOptions struct {
 }
 
 func main() {
+	var err error
+	defer func() {
+		status := 0
+		if err != nil {
+			status = 1
+		}
+		os.Exit(status)
+	}()
+
 	runtime.GOMAXPROCS(1)
 
 	var opts cliOptions
 
 	// Parse commandline flags which override options loaded from config.
-	if _, err := flags.Parse(&opts); err != nil {
+	if _, err = flags.Parse(&opts); err != nil {
 		// don't log failure just return usage info
 		println(err.Error())
 		return


### PR DESCRIPTION
os.Exit and therefore log.Fatalf not only exit without returning to the
caller but also drop deferred function calls. This may defeat
daos_server and daos_server's cleanup efforts. This patch defers an
os.Exit call at the beginning of each of their main functions; the
removal of incorrect os.Exit and therefore log.Fatalf calls are left for
future patches.

Change-Id: If72ff23379c8d400d5c109e614b109464eee2149
Signed-off-by: Li Wei <wei.g.li@intel.com>