### PR TITLE
DAOS-1893: Create test utility to generate the new control plane config file.

### DIFF
--- a/src/tests/ftest/container/Attribute.py
+++ b/src/tests/ftest/container/Attribute.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python
 '''
-  (C) Copyright 2018 Intel Corporation.
+  (C) Copyright 2018-2019 Intel Corporation.
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
@@ -91,16 +91,14 @@ class ContainerAttributeTest(Test):
 
         with open('../../../.build_vars.json') as f:
             build_paths = json.load(f)
-        basepath = os.path.normpath(build_paths['PREFIX']  + "/../")
-        server_group = self.params.get("server_group",
-                                       '/server/',
-                                       'daos_server')
+        self.basepath = os.path.normpath(build_paths['PREFIX']  + "/../")
+        server_group = self.params.get("name", '/server/', 'daos_server')
         self.Context = DaosContext(build_paths['PREFIX'] + '/lib/')
 
         self.hostlist = self.params.get("test_machines", '/run/hosts/*')
         self.hostfile = WriteHostFile.WriteHostFile(self.hostlist, self.workdir)
 
-        ServerUtils.runServer(self.hostfile, server_group, basepath)
+        ServerUtils.runServer(self, server_group)
 
         self.pool = DaosPool(self.Context)
         self.pool.create(self.params.get("mode", '/run/attrtests/createmode/*'),

--- a/src/tests/ftest/container/Attribute.yaml
+++ b/src/tests/ftest/container/Attribute.yaml
@@ -6,7 +6,7 @@ hosts: !mux
         - boro-A
 timeout: 50
 server:
-  server_group: daos_server
+  name: daos_server
 attrtests:
   createmode:
     mode: 511

--- a/src/tests/ftest/container/BasicTxTest.py
+++ b/src/tests/ftest/container/BasicTxTest.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python
 '''
-  (C) Copyright 2018 Intel Corporation.
+  (C) Copyright 2018-2019 Intel Corporation.
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
@@ -53,8 +53,7 @@ class BasicTxTest(Test):
             build_paths = json.load(f)
         self.basepath = os.path.normpath(build_paths['PREFIX']  + "/../")
 
-        self.server_group = self.params.get("server_group",'/server/',
-                                           'daos_server')
+        self.server_group = self.params.get("name", '/server/', 'daos_server')
 
         # setup the DAOS python API
         self.context = DaosContext(build_paths['PREFIX'] + '/lib/')
@@ -62,7 +61,7 @@ class BasicTxTest(Test):
         self.hostlist = self.params.get("test_machines",'/run/hosts/*')
         self.hostfile = WriteHostFile.WriteHostFile(self.hostlist, self.workdir)
 
-        ServerUtils.runServer(self.hostfile, self.server_group, self.basepath)
+        ServerUtils.runServer(self, self.server_group)
 
         # give it time to start
         time.sleep(2)

--- a/src/tests/ftest/container/BasicTxTest.yaml
+++ b/src/tests/ftest/container/BasicTxTest.yaml
@@ -7,7 +7,7 @@ hosts:
         - boro-B
 timeout: 100
 server:
-   server_group: daos_server
+   name: daos_server
 conttests:
    createmode:
      mode: 511

--- a/src/tests/ftest/container/ContainerAsync.py
+++ b/src/tests/ftest/container/ContainerAsync.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python
 '''
-    (C) Copyright 2018 Intel Corporation.
+    (C) Copyright 2018-2019 Intel Corporation.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -69,7 +69,7 @@ class ContainerAsync(Test):
             build_paths = json.load(f)
         self.basepath = os.path.normpath(build_paths['PREFIX']  + "/../")
 
-        self.server_group = self.params.get("server_group",'/server/','daos_server')
+        self.server_group = self.params.get("name",'/server/','daos_server')
 
         # setup the DAOS python API
         self.context = DaosContext(build_paths['PREFIX'] + '/lib/')
@@ -79,7 +79,7 @@ class ContainerAsync(Test):
         self.hostfile = WriteHostFile.WriteHostFile(self.hostlist, self.workdir)
         print("Host file is: {}".format(self.hostfile))
 
-        ServerUtils.runServer(self.hostfile, self.server_group, self.basepath)
+        ServerUtils.runServer(self, self.server_group)
         time.sleep(10)
 
     def tearDown(self):

--- a/src/tests/ftest/container/ContainerAsync.yaml
+++ b/src/tests/ftest/container/ContainerAsync.yaml
@@ -6,7 +6,7 @@ hosts:
             - boro-C
 timeout: 80
 server:
-    server_group: daos_server
+    name: daos_server
 createtests:
     createmode:
         mode_RO:

--- a/src/tests/ftest/container/Create.py
+++ b/src/tests/ftest/container/Create.py
@@ -52,15 +52,15 @@ class CreateContainerTest(Test):
        with open('../../../.build_vars.json') as f:
            build_paths = json.load(f)
        self.basepath = os.path.normpath(build_paths['PREFIX']  + "/../")
-       self.server_group = self.params.get("server_group",'/server/')
+       self.server_group = self.params.get("name",'/server/')
 
        # setup the DAOS python API
        self.context = DaosContext(build_paths['PREFIX'] + '/lib/')
 
        self.hostlist = self.params.get("test_machines",'/run/hosts/*')
-       hostfile = WriteHostFile.WriteHostFile(self.hostlist, self.workdir)
+       self.hostfile = WriteHostFile.WriteHostFile(self.hostlist, self.workdir)
 
-       ServerUtils.runServer(hostfile, self.server_group, self.basepath)
+       ServerUtils.runServer(self, self.server_group)
 
     def tearDown(self):
         ServerUtils.stopServer(None, self.hostlist)

--- a/src/tests/ftest/container/Create.yaml
+++ b/src/tests/ftest/container/Create.yaml
@@ -5,7 +5,7 @@ hosts:
      - boro-A
 timeout: 100
 server:
-   server_group: daos_server
+   name: daos_server
 poolparams:
    mode: 511
    setname: daos_server

--- a/src/tests/ftest/container/Delete.py
+++ b/src/tests/ftest/container/Delete.py
@@ -51,8 +51,7 @@ class DeleteContainerTest(Test):
         with open('../../../.build_vars.json') as f:
             build_paths = json.load(f)
         self.basepath = os.path.normpath(build_paths['PREFIX']  + "/../")
-        self.server_group = self.params.get("server_group",'/server/',
-                                           'daos_server')
+        self.server_group = self.params.get("name", '/server/', 'daos_server')
 
         # parameters used in pool create
         self.createmode = self.params.get("mode",'/run/createtests/createmode/')
@@ -70,7 +69,7 @@ class DeleteContainerTest(Test):
         self.d_log = DaosLog(self.context)
         self.hostlist = self.params.get("test_machines",'/run/hosts/*')
         self.hostfile = WriteHostFile.WriteHostFile(self.hostlist, self.workdir)
-        ServerUtils.runServer(self.hostfile, self.server_group, self.basepath)
+        ServerUtils.runServer(self, self.server_group)
 
     def tearDown(self):
         ServerUtils.stopServer(hosts=self.hostlist)

--- a/src/tests/ftest/container/Delete.yaml
+++ b/src/tests/ftest/container/Delete.yaml
@@ -6,7 +6,7 @@ hosts:
       - boro-A
 timeout: 50
 server:
-  server_group: daos_server
+  name: daos_server
 createtests:
   createmode:
     mode: 511

--- a/src/tests/ftest/container/FullPoolContainerCreate.py
+++ b/src/tests/ftest/container/FullPoolContainerCreate.py
@@ -1,5 +1,5 @@
 """
-  (C) Copyright 2018 Intel Corporation.
+  (C) Copyright 2018-2019 Intel Corporation.
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
@@ -53,8 +53,7 @@ class FullPoolContainerCreate(Test):
                                 "../../../../.build_vars.json")) as f:
             build_paths = json.load(f)
         self.basepath = os.path.normpath(build_paths['PREFIX'] + "/../")
-        self.server_group = self.params.get("server_group", '/server/',
-                                            'daos_default_oops')
+        self.server_group = self.params.get("name", '/server/', 'daos_default_oops')
 
         self.context = DaosContext(build_paths['PREFIX'] + '/lib/')
 
@@ -62,7 +61,7 @@ class FullPoolContainerCreate(Test):
         self.d_log = DaosLog(self.context)
         self.hostlist = self.params.get("test_machines1", '/hosts/')
         self.hostfile = WriteHostFile.WriteHostFile(self.hostlist, self.workdir)
-        ServerUtils.runServer(self.hostfile, self.server_group, self.basepath)
+        ServerUtils.runServer(self, self.server_group)
 
     def tearDown(self):
         # shut 'er down

--- a/src/tests/ftest/container/FullPoolContainerCreate.yaml
+++ b/src/tests/ftest/container/FullPoolContainerCreate.yaml
@@ -4,7 +4,7 @@ hosts:
     test_machines1:
       - boro-A
 server:
-   server_group: daos_server
+   name: daos_server
 conttests:
    createmode:
      mode: 511

--- a/src/tests/ftest/container/GlobalHandle.py
+++ b/src/tests/ftest/container/GlobalHandle.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python
 '''
-  (C) Copyright 2018 Intel Corporation.
+  (C) Copyright 2018-2019 Intel Corporation.
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
@@ -115,24 +115,18 @@ class GlobalHandle(Test):
         # setup the DAOS python API
         self.Context = DaosContext(self.build_paths['PREFIX'] + '/lib/')
 
-        server_group = self.params.get("server_group",'/server/',
-                                           'daos_server')
+        server_group = self.params.get("name", '/server/', 'daos_server')
 
-        basepath = os.path.normpath(self.build_paths['PREFIX']  + "/../")
-        tmp = self.build_paths['PREFIX'] + '/tmp'
+        self.basepath = os.path.normpath(self.build_paths['PREFIX']  + "/../")
 
         self.hostlist = self.params.get("test_machines",'/run/hosts/')
-        self.hostfile = WriteHostFile.WriteHostFile(self.hostlist, tmp)
+        self.hostfile = WriteHostFile.WriteHostFile(self.hostlist, self.workdir)
 
-        ServerUtils.runServer(self.hostfile, server_group, basepath)
+        ServerUtils.runServer(self, server_group)
         time.sleep(2)
 
     def tearDown(self):
-        try:
-            os.remove(self.hostfile)
-        finally:
-            ServerUtils.stopServer(hosts=self.hostlist)
-
+        ServerUtils.stopServer(hosts=self.hostlist)
         # really make sure everything is gone
         CheckForPool.CleanupPools(self.hostlist)
 

--- a/src/tests/ftest/container/GlobalHandle.yaml
+++ b/src/tests/ftest/container/GlobalHandle.yaml
@@ -5,7 +5,7 @@ hosts:
     - boro-A
 timeout: 50
 server:
-  server_group: daos_server
+  name: daos_server
 testparams:
   createmode:
     mode: 511

--- a/src/tests/ftest/container/Open.py
+++ b/src/tests/ftest/container/Open.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python
 '''
-  (C) Copyright 2018 Intel Corporation.
+  (C) Copyright 2018-2019 Intel Corporation.
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
@@ -56,10 +56,8 @@ class OpenContainerTest(Test):
         with open('../../../.build_vars.json') as f:
             build_paths = json.load(f)
         self.basepath = os.path.normpath(build_paths['PREFIX']  + "/../")
-        self.tmp = build_paths['PREFIX'] + '/tmp'
 
-        self.server_group = self.params.get("server_group",'/server/',
-                                           'daos_server')
+        self.server_group = self.params.get("name", '/server/', 'daos_server')
 
         # setup the DAOS python API
         self.Context = DaosContext(build_paths['PREFIX'] + '/lib/')
@@ -70,7 +68,7 @@ class OpenContainerTest(Test):
 
         self.hostfile = None
         self.hostlist = self.params.get("test_machines",'/run/hosts/*')
-        self.hostfile = WriteHostFile.WriteHostFile(self.hostlist, self.tmp)
+        self.hostfile = WriteHostFile.WriteHostFile(self.hostlist, self.workdir)
 
         # common parameters used in pool create
         self.createmode = self.params.get("mode",'/run/createtests/createmode/')
@@ -85,7 +83,7 @@ class OpenContainerTest(Test):
         self.createuid2  = self.params.get("uid",'/run/createtests/createuid2/')
         self.creategid2  = self.params.get("gid",'/run/createtests/creategid2/')
 
-        ServerUtils.runServer(self.hostfile, self.server_group, self.basepath)
+        ServerUtils.runServer(self, self.server_group)
 
         # give it time to start
         time.sleep(2)
@@ -185,9 +183,6 @@ class OpenContainerTest(Test):
             print(traceback.format_exc())
             if expected_result == 'PASS':
                 self.fail("Test was expected to pass but it failed.\n")
-        finally:
-            if self.hostfile is not None:
-                os.remove(self.hostfile)
 
 if __name__ == "__main__":
     main()

--- a/src/tests/ftest/container/Open.yaml
+++ b/src/tests/ftest/container/Open.yaml
@@ -5,7 +5,7 @@ hosts: !mux
       test_machines:
         - boro-A
 server:
-  server_group: daos_server
+  name: daos_server
 createtests:
   createmode:
     mode: 511

--- a/src/tests/ftest/container/OpenClose.py
+++ b/src/tests/ftest/container/OpenClose.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python
 '''
-    (C) Copyright 2018 Intel Corporation.
+    (C) Copyright 2018-2019 Intel Corporation.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -54,14 +54,14 @@ class OpenClose(Test):
                                        '../../../../.build_vars.json')) as f:
             build_paths = json.load(f)
         self.basepath = os.path.normpath(build_paths['PREFIX']  + "/../")
-        self.server_group = self.params.get("server_group",'/server/','daos_server')
+        self.server_group = self.params.get("name", '/server/', 'daos_server')
 
         # setup the DAOS python API
         self.Context = DaosContext(build_paths['PREFIX'] + '/lib/')
 
         self.hostfile = WriteHostFile.WriteHostFile(self.hostlist, self.workdir)
 
-        ServerUtils.runServer(self.hostfile, self.server_group, self.basepath)
+        ServerUtils.runServer(self, self.server_group)
 
         time.sleep(5)
 

--- a/src/tests/ftest/container/OpenClose.yaml
+++ b/src/tests/ftest/container/OpenClose.yaml
@@ -3,7 +3,7 @@ hosts:
         - boro-A
 timeout: 40
 server:
-    server_group: daos_server
+    name: daos_server
 pool:
     createmode:
         mode: 146

--- a/src/tests/ftest/container/SimpleCreateDeleteTest.py
+++ b/src/tests/ftest/container/SimpleCreateDeleteTest.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python
 '''
-  (C) Copyright 2017 Intel Corporation.
+  (C) Copyright 2017-2019 Intel Corporation.
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
@@ -51,8 +51,7 @@ class SimpleCreateDeleteTest(Test):
             build_paths = json.load(f)
         self.basepath = os.path.normpath(build_paths['PREFIX']  + "/../")
 
-        self.server_group = self.params.get("server_group",'/server/',
-                                           'daos_server')
+        self.server_group = self.params.get("name", '/server/', 'daos_server')
 
         # setup the DAOS python API
         self.Context = DaosContext(build_paths['PREFIX'] + '/lib/')
@@ -73,9 +72,9 @@ class SimpleCreateDeleteTest(Test):
 
         try:
             hostlist = self.params.get("test_machines",'/run/hosts/*')
-            hostfile = WriteHostFile.WriteHostFile(hostlist, self.workdir)
+            self.hostfile = WriteHostFile.WriteHostFile(hostlist, self.workdir)
 
-            ServerUtils.runServer(hostfile, self.server_group, self.basepath)
+            ServerUtils.runServer(self, self.server_group)
 
             # give it time to start
             time.sleep(2)

--- a/src/tests/ftest/container/SimpleCreateDeleteTest.yaml
+++ b/src/tests/ftest/container/SimpleCreateDeleteTest.yaml
@@ -13,7 +13,7 @@ hosts: !mux
         - boro-E
         - boro-F
 server:
-   server_group: daos_server
+   name: daos_server
 conttests:
    createmode:
      mode: 511

--- a/src/tests/ftest/daos_test/DaosCoreTest.yaml
+++ b/src/tests/ftest/daos_test/DaosCoreTest.yaml
@@ -13,7 +13,7 @@ hosts:
 # rebuild alone takes about 2hrs
 timeout: 9000
 server:
-  server_group: daos_server
+  name: daos_server
 daos_tests:
   num_clients:
     num_clients: 1

--- a/src/tests/ftest/io/EightServers.py
+++ b/src/tests/ftest/io/EightServers.py
@@ -53,7 +53,7 @@ class EightServers(Test):
         self.pool = None
         self.slots = None
         self.hostlist_servers = None
-        self.hostfile_servers = None
+        self.hostfile = None
         hostlist_clients = None
         self.hostfile_clients = None
 
@@ -63,21 +63,21 @@ class EightServers(Test):
             build_paths = json.load(f)
         self.basepath = os.path.normpath(build_paths['PREFIX']  + "/../")
 
-        self.server_group = self.params.get("server_group", '/server/', 'daos_server')
+        self.server_group = self.params.get("name", '/server/', 'daos_server')
 
         # setup the DAOS python API
         self.Context = DaosContext(build_paths['PREFIX'] + '/lib/')
 
         self.hostlist_servers = self.params.get("test_servers", '/run/hosts/test_machines/*')
-        self.hostfile_servers = WriteHostFile.WriteHostFile(self.hostlist_servers, self.workdir)
-        print("Host file servers is: {}".format(self.hostfile_servers))
+        self.hostfile = WriteHostFile.WriteHostFile(self.hostlist_servers, self.workdir)
+        print("Host file servers is: {}".format(self.hostfile))
 
         hostlist_clients = self.params.get("test_clients", '/run/hosts/test_machines/*')
         self.slots = self.params.get("slots", '/run/ior/clientslots/*')
         self.hostfile_clients = WriteHostFile.WriteHostFile(hostlist_clients, self.workdir, self.slots)
         print("Host file clients is: {}".format(self.hostfile_clients))
 
-        ServerUtils.runServer(self.hostfile_servers, self.server_group, self.basepath)
+        ServerUtils.runServer(self, self.server_group)
 
         if not distutils.spawn.find_executable("ior") and \
            int(str(self.name).split("-")[0]) == 1:

--- a/src/tests/ftest/io/EightServers.yaml
+++ b/src/tests/ftest/io/EightServers.yaml
@@ -14,7 +14,7 @@ hosts:
             - boro-J
 timeout: 2000
 server:
-    server_group: daos_server
+    name: daos_server
 pool:
     createmode:
         mode_RW:

--- a/src/tests/ftest/io/IorSingleServer.py
+++ b/src/tests/ftest/io/IorSingleServer.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python
 '''
-    (C) Copyright 2018 Intel Corporation.
+    (C) Copyright 2018-2019 Intel Corporation.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -48,7 +48,7 @@ class IorSingleServer(Test):
             build_paths = json.load(f)
         self.basepath = os.path.normpath(build_paths['PREFIX']  + "/../")
 
-        self.server_group = self.params.get("server_group", '/server/', 'daos_server')
+        self.server_group = self.params.get("name", '/server/', 'daos_server')
         self.daosctl = self.basepath + '/install/bin/daosctl'
 
         # setup the DAOS python API
@@ -56,24 +56,20 @@ class IorSingleServer(Test):
         self.POOL = None
 
         self.hostlist_servers = self.params.get("test_servers", '/run/hosts/test_machines/*')
-        self.hostfile_servers = WriteHostFile.WriteHostFile(self.hostlist_servers, self.workdir)
-        print("Host file servers is: {}".format(self.hostfile_servers))
+        self.hostfile = WriteHostFile.WriteHostFile(self.hostlist_servers, self.workdir)
+        print("Host file servers is: {}".format(self.hostfile))
 
         self.hostlist_clients = self.params.get("clients", '/run/hosts/test_machines/diff_clients/*')
         self.hostfile_clients = WriteHostFile.WriteHostFile(self.hostlist_clients, self.workdir)
         print("Host file clientsis: {}".format(self.hostfile_clients))
 
-        ServerUtils.runServer(self.hostfile_servers, self.server_group, self.basepath)
+        ServerUtils.runServer(self, self.server_group)
 
         if int(str(self.name).split("-")[0]) == 1:
             IorUtils.build_ior(self.basepath)
 
     def tearDown(self):
         try:
-            if self.hostfile_clients is not None:
-                os.remove(self.hostfile_clients)
-            if self.hostfile_servers is not None:
-                os.remove(self.hostfile_servers)
             if self.POOL is not None and self.POOL.attached:
                 self.POOL.destroy(1)
         finally:

--- a/src/tests/ftest/io/IorSingleServer.yaml
+++ b/src/tests/ftest/io/IorSingleServer.yaml
@@ -18,7 +18,7 @@ hosts:
                     - boro-E
 timeout: 540
 server:
-    server_group: daos_server
+    name: daos_server
 createtests:
     createmode:
         mode_RW:

--- a/src/tests/ftest/io/MultipleClients.py
+++ b/src/tests/ftest/io/MultipleClients.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python
 '''
-    (C) Copyright 2018 Intel Corporation.
+    (C) Copyright 2018-2019 Intel Corporation.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -47,7 +47,7 @@ class MultipleClients(Test):
             build_paths = json.load(f)
         self.basepath = os.path.normpath(build_paths['PREFIX']  + "/../")
 
-        self.server_group = self.params.get("server_group", '/server/','daos_server')
+        self.server_group = self.params.get("name", '/server/','daos_server')
         self.daosctl = self.basepath + '/install/bin/daosctl'
 
         # setup the DAOS python API
@@ -55,24 +55,20 @@ class MultipleClients(Test):
         self.pool = None
 
         self.hostlist_servers = self.params.get("test_servers", '/run/hosts/test_machines/*')
-        self.hostfile_servers = WriteHostFile.WriteHostFile(self.hostlist_servers, self.workdir)
-        print("Host file servers is: {}".format(self.hostfile_servers))
+        self.hostfile = WriteHostFile.WriteHostFile(self.hostlist_servers, self.workdir)
+        print("Host file servers is: {}".format(self.hostfile))
 
         self.hostlist_clients = self.params.get("clients", '/run/hosts/test_machines/test_clients/*')
         self.hostfile_clients = WriteHostFile.WriteHostFile(self.hostlist_clients, self.workdir)
         print("Host file clientsis: {}".format(self.hostfile_clients))
 
-        ServerUtils.runServer(self.hostfile_servers, self.server_group, self.basepath)
+        ServerUtils.runServer(self, self.server_group)
 
         if int(str(self.name).split("-")[0]) == 1:
             IorUtils.build_ior(self.basepath)
 
     def tearDown(self):
         try:
-            if self.hostfile_clients is not None:
-                os.remove(self.hostfile_clients)
-            if self.hostfile_servers is not None:
-                os.remove(self.hostfile_servers)
             if self.pool is not None and self.pool.attached:
                 self.pool.destroy(1)
         finally:

--- a/src/tests/ftest/io/MultipleClients.yaml
+++ b/src/tests/ftest/io/MultipleClients.yaml
@@ -9,7 +9,7 @@ hosts:
                     - boro-C
                     - boro-D
 server:
-    server_group: daos_server
+    name: daos_server
 pool:
     createmode:
         mode_RW:

--- a/src/tests/ftest/io/SegCount.py
+++ b/src/tests/ftest/io/SegCount.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python
 '''
-    (C) Copyright 2018 Intel Corporation.
+    (C) Copyright 2018-2019 Intel Corporation.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -59,21 +59,21 @@ class SegCount(Test):
             build_paths = json.load(f)
         self.basepath = os.path.normpath(build_paths['PREFIX']  + "/../")
 
-        self.server_group = self.params.get("server_group", '/server/', 'daos_server')
+        self.server_group = self.params.get("name", '/server/', 'daos_server')
 
         # setup the DAOS python API
         self.Context = DaosContext(build_paths['PREFIX'] + '/lib/')
 
         self.hostlist_servers = self.params.get("test_servers", '/run/hosts/*')
-        hostfile_servers = WriteHostFile.WriteHostFile(self.hostlist_servers, self.workdir)
-        print("Host file servers is: {}".format(hostfile_servers))
+        self.hostfile = WriteHostFile.WriteHostFile(self.hostlist_servers, self.workdir)
+        print("Host file servers is: {}".format(self.hostfile))
 
         hostlist_clients = self.params.get("test_clients", '/run/hosts/*')
         self.slots = self.params.get("slots", '/run/ior/clientslots/*')
         self.hostfile_clients = WriteHostFile.WriteHostFile(hostlist_clients, self.workdir, self.slots)
         print("Host file clients is: {}".format(self.hostfile_clients))
 
-        ServerUtils.runServer(hostfile_servers, self.server_group, self.basepath)
+        ServerUtils.runServer(self, self.server_group)
 
         if int(str(self.name).split("-")[0]) == 1:
             IorUtils.build_ior(self.basepath)

--- a/src/tests/ftest/io/SegCount.yaml
+++ b/src/tests/ftest/io/SegCount.yaml
@@ -13,7 +13,7 @@ hosts:
         - boro-J
 timeout: 2000
 server:
-    server_group: daos_server
+    name: daos_server
 pool:
     createmode:
         mode_RW:

--- a/src/tests/ftest/io/romio.py
+++ b/src/tests/ftest/io/romio.py
@@ -49,7 +49,7 @@ class Romio(Test):
         self.server_group = None
         self.Context = None
         self.hostlist_servers = None
-        self.hostfile_servers = None
+        self.hostfile = None
         self.hostlist_clients = None
         self.hostfile_clients = None
 
@@ -59,21 +59,21 @@ class Romio(Test):
             build_paths = json.load(f)
         self.basepath = os.path.normpath(build_paths['PREFIX']  + "/../")
 
-        self.server_group = self.params.get("server_group", '/server/', 'daos_server')
+        self.server_group = self.params.get("name", '/server/', 'daos_server')
 
         # setup the DAOS python API
         self.Context = DaosContext(build_paths['PREFIX'] + '/lib/')
 
         self.hostlist_servers = self.params.get("test_servers", '/run/hosts/')
-        self.hostfile_servers = WriteHostFile.WriteHostFile(self.hostlist_servers, self.workdir)
-        print("Host file servers is: {}".format(self.hostfile_servers))
+        self.hostfile = WriteHostFile.WriteHostFile(self.hostlist_servers, self.workdir)
+        print("Host file servers is: {}".format(self.hostfile))
 
         self.hostlist_clients = self.params.get("test_clients", '/run/hosts/')
         self.hostfile_clients = WriteHostFile.WriteHostFile(self.hostlist_clients, self.workdir)
         print("Host file clients is: {}".format(self.hostfile_clients))
 
         # start servers
-        ServerUtils.runServer(self.hostfile_servers, self.server_group, self.basepath)
+        ServerUtils.runServer(self, self.server_group)
 
     def tearDown(self):
         ServerUtils.stopServer(hosts=self.hostlist_servers)

--- a/src/tests/ftest/io/romio.yaml
+++ b/src/tests/ftest/io/romio.yaml
@@ -5,6 +5,6 @@ hosts:
         - boro-B
 timeout: 240
 server:
-    server_group: daos_server
+    name: daos_server
 romio:
     romio_repo: "/home/standan/mpiotest/build/src/mpi/romio/test/"

--- a/src/tests/ftest/network/CartSelfTest.py
+++ b/src/tests/ftest/network/CartSelfTest.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python
 """
-  (C) Copyright 2018 Intel Corporation.
+  (C) Copyright 2018-2019 Intel Corporation.
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
@@ -50,10 +50,9 @@ class CartSelfTest(Test):
                                "../../../../.build_vars.json")) as f:
             build_paths = json.load(f)
         self.basepath = os.path.normpath(build_paths['PREFIX']  + "/../")
-        tmp = build_paths['PREFIX'] + '/tmp'
 
         self.hostlist = self.params.get("test_machines", '/run/hosts/')
-        self.hostfile = WriteHostFile.WriteHostFile(self.hostlist, tmp)
+        self.hostfile = WriteHostFile.WriteHostFile(self.hostlist, self.workdir)
 
         context = DaosContext(build_paths['PREFIX'] + '/lib/')
         self.d_log = DaosLog(context)
@@ -81,15 +80,13 @@ class CartSelfTest(Test):
             self.env_list.append("{0}={1}".format(k, v))
 
         # daos server params
-        self.server_group = self.params.get("server", 'server_group',
-                                            'daos_server')
+        self.server_group = self.params.get("name", 'server_group', 'daos_server')
         self.uri_file = os.path.join(self.basepath, "install", "tmp", "uri.txt")
-        ServerUtils.runServer(self.hostfile, self.server_group, self.basepath,
+        ServerUtils.runServer(self, self.server_group,
                               uri_path=self.uri_file, env_dict=self.env_dict)
 
     def tearDown(self):
         try:
-            os.remove(self.hostfile)
             os.remove(self.uri_file)
         finally:
             ServerUtils.stopServer(hosts=self.hostlist)

--- a/src/tests/ftest/network/CartSelfTest.yaml
+++ b/src/tests/ftest/network/CartSelfTest.yaml
@@ -4,7 +4,7 @@ hosts:
   test_machines:
     - boro-A
 server:
-  server_group: daos_server
+  name: daos_server
 testparams:
   repetitions: 1000
   endpoint: 0:0

--- a/src/tests/ftest/object/ArrayObjTest.py
+++ b/src/tests/ftest/object/ArrayObjTest.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python
 '''
-  (C) Copyright 2017 Intel Corporation.
+  (C) Copyright 2017-2019 Intel Corporation.
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
@@ -53,8 +53,7 @@ class ArrayObjTest(Test):
             build_paths = json.load(f)
         self.basepath = os.path.normpath(build_paths['PREFIX']  + "/../")
 
-        self.server_group = self.params.get("server_group",'/run/server/',
-                                           'daos_server')
+        self.server_group = self.params.get("name",'/run/server/', 'daos_server')
 
         # setup the DAOS python API
         self.Context = DaosContext(build_paths['PREFIX'] + '/lib/')
@@ -62,7 +61,7 @@ class ArrayObjTest(Test):
         self.hostlist = self.params.get("test_machines",'/run/hosts/')
         self.hostfile = WriteHostFile.WriteHostFile(self.hostlist, self.workdir)
 
-        ServerUtils.runServer(self.hostfile, self.server_group, self.basepath)
+        ServerUtils.runServer(self, self.server_group)
         time.sleep(5)
 
     def tearDown(self):

--- a/src/tests/ftest/object/ArrayObjTest.yaml
+++ b/src/tests/ftest/object/ArrayObjTest.yaml
@@ -5,7 +5,7 @@ hosts:
         - boro-A
 timeout: 100
 server:
-   server_group: daos_server
+   name: daos_server
 pool_params:
    createmode:
         mode: 511

--- a/src/tests/ftest/object/CreateManyDkeys.py
+++ b/src/tests/ftest/object/CreateManyDkeys.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python
 '''
-  (C) Copyright 2018 Intel Corporation.
+  (C) Copyright 2018-2019 Intel Corporation.
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
@@ -50,17 +50,16 @@ class CreateManyDkeys(Test):
     def setUp(self):
         with open('../../../.build_vars.json') as json_f:
             build_paths = json.load(json_f)
-        basepath = os.path.normpath(build_paths['PREFIX']  + "/../")
-        tmp = build_paths['PREFIX'] + '/tmp'
-        server_group = self.params.get("server_group",
+        self.basepath = os.path.normpath(build_paths['PREFIX']  + "/../")
+        server_group = self.params.get("name",
                                        '/server/',
                                        'daos_server')
         self.context = DaosContext(build_paths['PREFIX'] + '/lib/')
 
         self.hostlist = self.params.get("test_machines", '/run/hosts/*')
-        self.hostfile = WriteHostFile.WriteHostFile(self.hostlist, tmp)
+        self.hostfile = WriteHostFile.WriteHostFile(self.hostlist, self.workdir)
 
-        ServerUtils.runServer(self.hostfile, server_group, basepath)
+        ServerUtils.runServer(self, server_group)
 
         self.pool = DaosPool(self.context)
         self.pool.create(self.params.get("mode", '/run/pool/createmode/*'),
@@ -73,8 +72,6 @@ class CreateManyDkeys(Test):
 
     def tearDown(self):
         try:
-            if self.hostfile is not None:
-                os.remove(self.hostfile)
             if self.pool:
                 self.pool.destroy(1)
         finally:

--- a/src/tests/ftest/object/CreateManyDkeys.yaml
+++ b/src/tests/ftest/object/CreateManyDkeys.yaml
@@ -6,7 +6,7 @@ hosts:
     - boro-B
 timeout: 8000
 server:
-  server_group: daos_server
+  name: daos_server
 pool:
   createmode:
     mode: 511

--- a/src/tests/ftest/object/ObjFetchBadParam.py
+++ b/src/tests/ftest/object/ObjFetchBadParam.py
@@ -56,8 +56,7 @@ class ObjFetchBadParam(Test):
             build_paths = json.load(f)
         self.basepath = os.path.normpath(build_paths['PREFIX']  + "/../")
 
-        self.server_group = self.params.get("server_group",'/server/',
-                                           'daos_server')
+        self.server_group = self.params.get("name",'/server/', 'daos_server')
 
         # setup the DAOS python API
         self.context = DaosContext(build_paths['PREFIX'] + '/lib/')
@@ -65,7 +64,7 @@ class ObjFetchBadParam(Test):
         self.hostlist = self.params.get("test_machines",'/run/hosts/*')
         self.hostfile = WriteHostFile.WriteHostFile(self.hostlist, self.workdir)
 
-        ServerUtils.runServer(self.hostfile, self.server_group, self.basepath)
+        ServerUtils.runServer(self, self.server_group)
         time.sleep(5)
 
         try:

--- a/src/tests/ftest/object/ObjFetchBadParam.yaml
+++ b/src/tests/ftest/object/ObjFetchBadParam.yaml
@@ -6,7 +6,7 @@ hosts:
         - boro-A
         - boro-B
 server:
-   server_group: daos_server
+   name: daos_server
 pool:
    createmode:
      mode: 511

--- a/src/tests/ftest/object/ObjOpenBadParam.py
+++ b/src/tests/ftest/object/ObjOpenBadParam.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python
 """
-  (C) Copyright 2018 Intel Corporation.
+  (C) Copyright 2018-2019 Intel Corporation.
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
@@ -61,8 +61,7 @@ class ObjOpenBadParam(Test):
             build_paths = json.load(f)
         self.basepath = os.path.normpath(build_paths['PREFIX']  + "/../")
 
-        self.server_group = self.params.get("server_group",'/server/',
-                                            'daos_server')
+        self.server_group = self.params.get("name", '/server/', 'daos_server')
 
         # setup the DAOS python API
         self.context = DaosContext(build_paths['PREFIX'] + '/lib/')
@@ -71,7 +70,7 @@ class ObjOpenBadParam(Test):
         self.hostlist = self.params.get("test_machines",'/run/hosts/*')
         self.hostfile = WriteHostFile.WriteHostFile(self.hostlist, self.workdir)
 
-        ServerUtils.runServer(self.hostfile, self.server_group, self.basepath)
+        ServerUtils.runServer(self, self.server_group)
         try:
             # parameters used in pool create
             createmode = self.params.get("mode",'/run/pool/createmode/')

--- a/src/tests/ftest/object/ObjOpenBadParam.yaml
+++ b/src/tests/ftest/object/ObjOpenBadParam.yaml
@@ -4,7 +4,7 @@ hosts:
    test_machines:
      - boro-A
 server:
-   server_group: daos_server
+   name: daos_server
 pool:
    createmode:
      mode: 511

--- a/src/tests/ftest/object/ObjUpdateBadParam.py
+++ b/src/tests/ftest/object/ObjUpdateBadParam.py
@@ -53,8 +53,7 @@ class ObjUpdateBadParam(Test):
             build_paths = json.load(f)
         self.basepath = os.path.normpath(build_paths['PREFIX']  + "/../")
 
-        self.server_group = self.params.get("server_group",'/server/',
-                                           'daos_server')
+        self.server_group = self.params.get("name", '/server/', 'daos_server')
 
         # setup the DAOS python API
         self.Context = DaosContext(build_paths['PREFIX'] + '/lib/')
@@ -62,7 +61,7 @@ class ObjUpdateBadParam(Test):
         self.hostlist = self.params.get("test_machines",'/run/hosts/*')
         self.hostfile = WriteHostFile.WriteHostFile(self.hostlist, self.workdir)
 
-        ServerUtils.runServer(self.hostfile, self.server_group, self.basepath)
+        ServerUtils.runServer(self, self.server_group)
         time.sleep(5)
 
     def tearDown(self):

--- a/src/tests/ftest/object/ObjUpdateBadParam.yaml
+++ b/src/tests/ftest/object/ObjUpdateBadParam.yaml
@@ -6,7 +6,7 @@ hosts:
         - boro-A
         - boro-B
 server:
-   server_group: daos_server
+   name: daos_server
 conttests:
    createmode:
      mode: 511

--- a/src/tests/ftest/object/ObjectIntegrity.py
+++ b/src/tests/ftest/object/ObjectIntegrity.py
@@ -60,8 +60,8 @@ class ObjectDataValidation(avocado.Test):
 
         with open('../../../.build_vars.json') as json_f:
             build_paths = json.load(json_f)
-        basepath = os.path.normpath(build_paths['PREFIX']  + "/../")
-        server_group = self.params.get("server_group",
+        self.basepath = os.path.normpath(build_paths['PREFIX']  + "/../")
+        server_group = self.params.get("name",
                                        '/server/',
                                        'daos_server')
         self.context = DaosContext(build_paths['PREFIX'] + '/lib/')
@@ -73,7 +73,7 @@ class ObjectDataValidation(avocado.Test):
         self.array_size = self.params.get("size", '/array_size/')
         self.record_length = self.params.get("length", '/run/record/*')
 
-        ServerUtils.runServer(self.hostfile, server_group, basepath)
+        ServerUtils.runServer(self, server_group)
 
         self.pool = DaosPool(self.context)
         self.pool.create(self.params.get("mode", '/run/pool/createmode/*'),

--- a/src/tests/ftest/object/ObjectIntegrity.yaml
+++ b/src/tests/ftest/object/ObjectIntegrity.yaml
@@ -7,7 +7,7 @@ hosts:
     - boro-B
 timeout: 2400
 server:
-   server_group: daos_server
+   name: daos_server
 pool:
   createmode:
     mode: 511

--- a/src/tests/ftest/object/PunchTest.py
+++ b/src/tests/ftest/object/PunchTest.py
@@ -50,8 +50,7 @@ class PunchTest(Test):
                 build_paths = json.load(f)
                 self.basepath = os.path.normpath(build_paths['PREFIX'] + "/../")
 
-                self.server_group = self.params.get("server_group",'/server/',
-                                                    'daos_server')
+                self.server_group = self.params.get("name", '/server/', 'daos_server')
 
                 # setup the DAOS python API
                 self.Context = DaosContext(build_paths['PREFIX'] + '/lib/')
@@ -60,8 +59,7 @@ class PunchTest(Test):
                 self.hostfile = WriteHostFile.WriteHostFile(self.hostlist,
                                                             self.workdir)
 
-                ServerUtils.runServer(self.hostfile, self.server_group,
-                                      self.basepath)
+                ServerUtils.runServer(self, self.server_group)
 
                 # parameters used in pool create
                 createmode = self.params.get("mode",'/run/pool/createmode/')
@@ -105,9 +103,6 @@ class PunchTest(Test):
             if self.pool:
                 self.pool.disconnect()
                 self.pool.destroy(1)
-
-            if self.hostfile is not None:
-                os.remove(self.hostfile)
 
         except DaosApiError as e:
             print(e)

--- a/src/tests/ftest/object/PunchTest.yaml
+++ b/src/tests/ftest/object/PunchTest.yaml
@@ -7,7 +7,7 @@ hosts:
         - boro-B
 timeout: 100
 server:
-   server_group: daos_server
+   name: daos_server
 pool:
    createmode:
      mode: 511

--- a/src/tests/ftest/pool/BadConnect.py
+++ b/src/tests/ftest/pool/BadConnect.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python
 '''
-  (C) Copyright 2018 Intel Corporation.
+  (C) Copyright 2018-2019 Intel Corporation.
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
@@ -68,8 +68,8 @@ class BadConnectTest(Test):
 
         # launch the server
         self.hostfile = WriteHostFile.WriteHostFile(self.hostlist, tmp)
-        server_group = self.params.get("server_group",'/server/','daos_server')
-        ServerUtils.runServer(self.hostfile, server_group, self.basepath)
+        server_group = self.params.get("name",'/server/','daos_server')
+        ServerUtils.runServer(self, server_group)
 
         time.sleep(2)
 

--- a/src/tests/ftest/pool/BadConnect.yaml
+++ b/src/tests/ftest/pool/BadConnect.yaml
@@ -1,7 +1,7 @@
 # Note that stuff that is commented out represents tests that presently
 # cause issues and will be uncommented as the daos code is fixed
 server:
-   server_group: scott_server
+   name: scott_server
 hosts:
   test_machines:
     - boro-A

--- a/src/tests/ftest/pool/BadCreate.py
+++ b/src/tests/ftest/pool/BadCreate.py
@@ -60,11 +60,11 @@ class BadCreateTest(Test):
         self.hostlist = self.params.get("test_machines", '/run/hosts/')
         self.hostfile = WriteHostFile.WriteHostFile(self.hostlist, self.workdir)
 
-        server_group = self.params.get("server_group",
+        server_group = self.params.get("name",
                                        '/server/',
                                        'daos_server')
 
-        ServerUtils.runServer(self.hostfile, server_group, self.basepath)
+        ServerUtils.runServer(self, server_group)
 
         time.sleep(2)
 

--- a/src/tests/ftest/pool/BadCreate.yaml
+++ b/src/tests/ftest/pool/BadCreate.yaml
@@ -4,7 +4,7 @@ hosts:
   test_machines:
     - boro-A
 server:
-   server_group: daos_server
+   name: daos_server
 timeout: 50
 createtests:
    modes: !mux

--- a/src/tests/ftest/pool/BadEvict.py
+++ b/src/tests/ftest/pool/BadEvict.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python
 '''
-  (C) Copyright 2018 Intel Corporation.
+  (C) Copyright 2018-2019 Intel Corporation.
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
@@ -57,9 +57,9 @@ class BadEvictTest(Test):
         self.hostlist = self.params.get("test_machines",'/run/hosts/')
         self.hostfile = WriteHostFile.WriteHostFile(self.hostlist, self.workdir)
 
-        server_group = self.params.get("server_group",'/server/','daos_server')
+        server_group = self.params.get("name",'/server/','daos_server')
 
-        ServerUtils.runServer(self.hostfile, server_group, self.basepath)
+        ServerUtils.runServer(self, server_group)
 
         # pause for good luck and let things stabilize
         time.sleep(3)

--- a/src/tests/ftest/pool/BadEvict.yaml
+++ b/src/tests/ftest/pool/BadEvict.yaml
@@ -1,5 +1,5 @@
 server:
-   server_group: scott_server
+   name: scott_server
 hosts:
   test_machines:
     - boro-A

--- a/src/tests/ftest/pool/BadExclude.py
+++ b/src/tests/ftest/pool/BadExclude.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python
 '''
-  (C) Copyright 2018 Intel Corporation.
+  (C) Copyright 2018-2019 Intel Corporation.
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
@@ -59,11 +59,11 @@ class BadExcludeTest(Test):
 
         self.hostfile = WriteHostFile.WriteHostFile(self.hostlist, self.workdir)
 
-        server_group = self.params.get("server_group",
+        server_group = self.params.get("name",
                                        '/server/',
                                        'daos_server')
 
-        ServerUtils.runServer(self.hostfile, server_group, self.basepath)
+        ServerUtils.runServer(self, server_group)
 
         time.sleep(2)
 

--- a/src/tests/ftest/pool/BadExclude.yaml
+++ b/src/tests/ftest/pool/BadExclude.yaml
@@ -1,10 +1,10 @@
 server:
-   server_group: test_server
+   name: test_server
 hosts:
   test_machines:
-    - boro-26
-    - boro-29
-    - boro-30
+    - boro-A
+    - boro-B
+    - boro-C
 timeout: 200
 testparams:
    tgtlist: !mux

--- a/src/tests/ftest/pool/BadQuery.py
+++ b/src/tests/ftest/pool/BadQuery.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python
 '''
-  (C) Copyright 2018 Intel Corporation.
+  (C) Copyright 2018-2019 Intel Corporation.
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
@@ -56,11 +56,11 @@ class BadQueryTest(Test):
         self.hostlist = self.params.get("test_machines", '/run/hosts/')
         self.hostfile = WriteHostFile.WriteHostFile(self.hostlist, tmp)
 
-        server_group = self.params.get("server_group",
+        server_group = self.params.get("name",
                                        '/server/',
                                        'daos_server')
 
-        ServerUtils.runServer(self.hostfile, server_group, self.basepath)
+        ServerUtils.runServer(self, server_group)
 
         time.sleep(2)
 

--- a/src/tests/ftest/pool/BadQuery.yaml
+++ b/src/tests/ftest/pool/BadQuery.yaml
@@ -1,7 +1,7 @@
 # Note that stuff that is commented out represents tests that presently
 # fail and will be uncommented as the daos code is fixed
 server:
-   server_group: scott_server
+   name: scott_server
 hosts:
   test_machines:
     - boro-A

--- a/src/tests/ftest/pool/ConnectTest.py
+++ b/src/tests/ftest/pool/ConnectTest.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python
 '''
-  (C) Copyright 2018 Intel Corporation.
+  (C) Copyright 2018-2019 Intel Corporation.
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
@@ -52,21 +52,19 @@ class ConnectTest(Test):
         with open('../../../.build_vars.json') as f:
             build_paths = json.load(f)
         self.basepath = os.path.normpath(build_paths['PREFIX']  + "/../")
-        tmp = build_paths['PREFIX'] + '/tmp'
 
         self.hostlist = self.params.get("test_machines",'/run/hosts/')
-        self.hostfile = WriteHostFile.WriteHostFile(self.hostlist, tmp)
+        self.hostfile = WriteHostFile.WriteHostFile(self.hostlist, self.workdir)
 
-        server_group = self.params.get("server_group",'/server/','daos_server')
+        server_group = self.params.get("name",'/server/','daos_server')
 
-        ServerUtils.runServer(self.hostfile, server_group, self.basepath)
+        ServerUtils.runServer(self, server_group)
 
         # not sure I need to do this but ... give it time to start
         time.sleep(1)
 
     def tearDown(self):
         ServerUtils.stopServer(hosts=self.hostlist)
-        os.remove(self.hostfile)
 
     def test_connect(self):
         """

--- a/src/tests/ftest/pool/ConnectTest.yaml
+++ b/src/tests/ftest/pool/ConnectTest.yaml
@@ -5,7 +5,7 @@ hosts:
     - boro-A
     - boro-B
 server:
-  server_group: daos_server
+  name: daos_server
 tests:
   setnames: !mux
     validsetname:

--- a/src/tests/ftest/pool/DestroyRebuild.py
+++ b/src/tests/ftest/pool/DestroyRebuild.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python
 '''
-  (C) Copyright 2018 Intel Corporation.
+  (C) Copyright 2018-2019 Intel Corporation.
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
@@ -51,7 +51,6 @@ class DestroyRebuild(Test):
     server_group = ""
     CONTEXT = None
     POOL = None
-    hostfile = ""
 
     def setUp(self):
         """ setup for the test """
@@ -60,17 +59,15 @@ class DestroyRebuild(Test):
         with open('../../../.build_vars.json') as f:
               build_paths = json.load(f)
         self.CONTEXT = DaosContext(build_paths['PREFIX'] + '/lib/')
+        self.basepath = os.path.normpath(build_paths['PREFIX']  + "/../")
 
         # generate a hostfile
         self.hostlist = self.params.get("test_machines",'/run/hosts/')
-        tmp = build_paths['PREFIX'] + '/tmp'
-        self.hostfile = WriteHostFile.WriteHostFile(self.hostlist, tmp)
+        self.hostfile = WriteHostFile.WriteHostFile(self.hostlist, self.workdir)
 
         # fire up the DAOS servers
-        self.server_group = self.params.get("server_group",'/run/server/',
-                                      'daos_server')
-        ServerUtils.runServer(self.hostfile, self.server_group,
-                             build_paths['PREFIX'] + '/../')
+        self.server_group = self.params.get("name", '/run/server/', 'daos_server')
+        ServerUtils.runServer(self, self.server_group)
         time.sleep(3)
 
         # create a pool to test with
@@ -90,7 +87,6 @@ class DestroyRebuild(Test):
         """ cleanup after the test """
 
         try:
-            os.remove(self.hostfile)
             if self.POOL:
                 self.POOL.destroy(1)
         finally:

--- a/src/tests/ftest/pool/DestroyRebuild.yaml
+++ b/src/tests/ftest/pool/DestroyRebuild.yaml
@@ -9,7 +9,7 @@ hosts:
     - boro-E
     - boro-F
 server:
-   server_group: daos_server
+   name: daos_server
 pool:
    createmode:
      mode: 511

--- a/src/tests/ftest/pool/DestroyTests.yaml
+++ b/src/tests/ftest/pool/DestroyTests.yaml
@@ -21,7 +21,7 @@ hosts:
     - boro-E
     - boro-F
 server:
-   server_group: daos_server
+   name: daos_server
 poolparams:
    createmode:
      mode: 511

--- a/src/tests/ftest/pool/EvictTest.py
+++ b/src/tests/ftest/pool/EvictTest.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python
 '''
-  (C) Copyright 2018 Intel Corporation.
+  (C) Copyright 2018-2019 Intel Corporation.
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
@@ -51,23 +51,20 @@ class EvictTest(Test):
         with open('../../../.build_vars.json') as f:
             build_paths = json.load(f)
         self.basepath = os.path.normpath(build_paths['PREFIX']  + "/../")
-        tmp = build_paths['PREFIX'] + '/tmp'
 
         self.hostlist = self.params.get("test_machines",'/run/hosts/')
-        self.hostfile = WriteHostFile.WriteHostFile(self.hostlist, tmp)
+        self.hostfile = WriteHostFile.WriteHostFile(self.hostlist, self.workdir)
 
         self.daosctl = self.basepath + '/install/bin/daosctl'
 
-        server_group = self.params.get("server_group",'/server/',
-                                       'daos_server')
+        server_group = self.params.get("name", '/server/', 'daos_server')
 
-        ServerUtils.runServer(self.hostfile, server_group, self.basepath)
+        ServerUtils.runServer(self, server_group)
         # not sure I need to do this but ... give it time to start
         time.sleep(1)
 
     def tearDown(self):
         ServerUtils.stopServer(hosts=self.hostlist)
-        os.remove(self.hostfile)
 
     def test_evict(self):
         """

--- a/src/tests/ftest/pool/EvictTest.yaml
+++ b/src/tests/ftest/pool/EvictTest.yaml
@@ -5,7 +5,7 @@ hosts:
     - boro-A
     - boro-B
 server:
-   server_group: daos_server
+   name: daos_server
 tests:
    setnames:
       validsetname:

--- a/src/tests/ftest/pool/GlobalHandle.py
+++ b/src/tests/ftest/pool/GlobalHandle.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python
 '''
-  (C) Copyright 2018 Intel Corporation.
+  (C) Copyright 2018-2019 Intel Corporation.
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
@@ -91,23 +91,19 @@ class GlobalHandle(Test):
         # setup the DAOS python API
         self.Context = DaosContext(self.build_paths['PREFIX'] + '/lib/')
 
-        server_group = self.params.get("server_group",'/server/',
-                                           'daos_server')
+        server_group = self.params.get("name", '/server/', 'daos_server')
 
-        basepath = os.path.normpath(self.build_paths['PREFIX']  + "/../")
-        tmp = self.build_paths['PREFIX'] + '/tmp'
+        self.basepath = os.path.normpath(self.build_paths['PREFIX']  + "/../")
 
         self.hostlist = self.params.get("test_machines",'/run/hosts/')
-        self.hostfile = WriteHostFile.WriteHostFile(self.hostlist, tmp)
+        self.hostfile = WriteHostFile.WriteHostFile(self.hostlist, self.workdir)
 
-        ServerUtils.runServer(self.hostfile, server_group, basepath)
+        ServerUtils.runServer(self, server_group)
         time.sleep(2)
 
     def tearDown(self):
         try:
             ServerUtils.stopServer()
-            os.remove(self.hostfile)
-
             # really make sure everything is gone
             CheckForPool.CleanupPools(self.hostlist)
         finally:

--- a/src/tests/ftest/pool/GlobalHandle.yaml
+++ b/src/tests/ftest/pool/GlobalHandle.yaml
@@ -5,7 +5,7 @@ hosts:
     - boro-A
 timeout: 5000
 server:
-  server_group: daos_server
+  name: daos_server
 testparams:
   createmode:
     mode: 511

--- a/src/tests/ftest/pool/InfoTests.py
+++ b/src/tests/ftest/pool/InfoTests.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python
 """
-  (C) Copyright 2018 Intel Corporation.
+  (C) Copyright 2018-2019 Intel Corporation.
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
@@ -48,8 +48,7 @@ class InfoTests(Test):
             build_paths = json.load(f)
         self.basepath = os.path.normpath(build_paths['PREFIX'] + "/../")
         self.tmp = build_paths['PREFIX'] + '/tmp'
-        self.server_group = self.params.get("server_group", '/server/',
-                                            'daos_server')
+        self.server_group = self.params.get("name", '/server/', 'daos_server')
 
         context = DaosContext(build_paths['PREFIX'] + '/lib/')
 
@@ -57,14 +56,13 @@ class InfoTests(Test):
         self.d_log = DaosLog(context)
         self.hostlist = self.params.get("test_machines1", '/run/hosts/')
         self.hostfile = WriteHostFile.WriteHostFile(self.hostlist, self.tmp)
-        ServerUtils.runServer(self.hostfile, self.server_group, self.basepath)
+        ServerUtils.runServer(self, self.server_group)
 
     def tearDown(self):
         # shut 'er down
         try:
             if self.pool:
                 self.pool.destroy(1)
-            os.remove(self.hostfile)
         finally:
             ServerUtils.stopServer(hosts=self.hostlist)
 

--- a/src/tests/ftest/pool/InfoTests.yaml
+++ b/src/tests/ftest/pool/InfoTests.yaml
@@ -2,7 +2,7 @@ hosts:
   test_machines1:
     - boro-A
 server:
-   server_group: daos_server
+   name: daos_server
 testparams:
    setnames:
       validsetname:

--- a/src/tests/ftest/pool/MultiServerCreateDeleteTest.py
+++ b/src/tests/ftest/pool/MultiServerCreateDeleteTest.py
@@ -47,13 +47,13 @@ class MultiServerCreateDeleteTest(Test):
         self.hostlist = None
         with open('../../../.build_vars.json') as f_open:
             build_paths = json.load(f_open)
-        basepath = os.path.normpath(build_paths['PREFIX']  + "/../")
+        self.basepath = os.path.normpath(build_paths['PREFIX']  + "/../")
         self.hostlist = self.params.get("test_machines", '/run/hosts/')
         self.hostfile = WriteHostFile.WriteHostFile(self.hostlist, self.workdir)
-        server_group = self.params.get("server_group", '/server/', 'daos_server')
+        server_group = self.params.get("name", '/server/', 'daos_server')
 
-        ServerUtils.runServer(self.hostfile, server_group, basepath)
-        self.dmg = basepath + '/install/bin/dmg'
+        ServerUtils.runServer(self, server_group)
+        self.dmg = self.basepath + '/install/bin/dmg'
 
     def tearDown(self):
         ServerUtils.stopServer(hosts=self.hostlist)

--- a/src/tests/ftest/pool/MultiServerCreateDeleteTest.yaml
+++ b/src/tests/ftest/pool/MultiServerCreateDeleteTest.yaml
@@ -5,7 +5,7 @@ hosts:
     - boro-A
     - boro-B
 server:
-  server_group: daos_server
+  name: daos_server
 tests:
   modes: !mux
     modeall:

--- a/src/tests/ftest/pool/MultipleCreatesTest.py
+++ b/src/tests/ftest/pool/MultipleCreatesTest.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python
 '''
-  (C) Copyright 2018 Intel Corporation.
+  (C) Copyright 2018-2019 Intel Corporation.
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
@@ -51,26 +51,22 @@ class MultipleCreatesTest(Test):
         # spot in the repo
         with open('../../../.build_vars.json') as f:
             build_paths = json.load(f)
-        basepath = os.path.normpath(build_paths['PREFIX']  + "/../")
-        tmp = build_paths['PREFIX'] + '/tmp'
+        self.basepath = os.path.normpath(build_paths['PREFIX']  + "/../")
 
         self.hostlist = self.params.get("test_machines",'/run/hosts/')
-        self.hostfile = WriteHostFile.WriteHostFile(self.hostlist, tmp)
+        self.hostfile = WriteHostFile.WriteHostFile(self.hostlist, self.workdir)
 
-        server_group = self.params.get("server_group",'/server/','daos_server')
+        server_group = self.params.get("name",'/server/','daos_server')
 
-        ServerUtils.runServer(self.hostfile, server_group, basepath)
+        ServerUtils.runServer(self, server_group)
         # not sure I need to do this but ... give it time to start
         time.sleep(2)
 
-        self.daosctl = basepath + '/install/bin/daosctl'
+        self.daosctl = self.basepath + '/install/bin/daosctl'
 
 
     def tearDown(self):
-        try:
-            os.remove(self.hostfile)
-        finally:
-            ServerUtils.stopServer(hosts=self.hostlist)
+        ServerUtils.stopServer(hosts=self.hostlist)
 
     def test_create_one(self):
         """

--- a/src/tests/ftest/pool/MultipleCreatesTest.yaml
+++ b/src/tests/ftest/pool/MultipleCreatesTest.yaml
@@ -5,7 +5,7 @@ hosts:
     - boro-A
     - boro-B
 server:
-   server_group: daos_server
+   name: daos_server
 tests:
    modes:
       modeall:

--- a/src/tests/ftest/pool/Permission.py
+++ b/src/tests/ftest/pool/Permission.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python
 '''
-	(C) Copyright 2018 Intel Corporation.
+	(C) Copyright 2018-2019 Intel Corporation.
 
 	Licensed under the Apache License, Version 2.0 (the "License");
 	you may not use this file except in compliance with the License.
@@ -48,7 +48,7 @@ class Permission(Test):
         with open('../../../.build_vars.json') as f:
             build_paths = json.load(f)
         self.basepath = os.path.normpath(build_paths['PREFIX']  + "/../")
-        self.server_group = self.params.get("server_group",
+        self.server_group = self.params.get("name",
                                             '/server/',
                                             'daos_server')
 
@@ -64,7 +64,7 @@ class Permission(Test):
         print ("Host file is: {}".format(self.hostfile))
 
         # starting server
-        ServerUtils.runServer(self.hostfile, self.server_group, self.basepath)
+        ServerUtils.runServer(self, self.server_group)
 
     def tearDown(self):
         try:

--- a/src/tests/ftest/pool/Permission.yaml
+++ b/src/tests/ftest/pool/Permission.yaml
@@ -12,7 +12,7 @@ hosts:
         - boro-B
 timeout: 300
 server:
-    server_group: daos_server
+    name: daos_server
 
 createtests:
     createmode: !mux

--- a/src/tests/ftest/pool/PoolSvc.py
+++ b/src/tests/ftest/pool/PoolSvc.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python
 '''
-    (C) Copyright 2018 Intel Corporation.
+    (C) Copyright 2018-2019 Intel Corporation.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -52,7 +52,7 @@ class PoolSvc(Test):
             build_paths = json.load(f)
         self.basepath = os.path.normpath(build_paths['PREFIX']  + "/../")
 
-        self.server_group = self.params.get("server_group",'/server/','daos_server')
+        self.server_group = self.params.get("name", '/server/', 'daos_server')
         self.daosctl = self.basepath + '/install/bin/daosctl'
 
         # setup the DAOS python API
@@ -64,7 +64,7 @@ class PoolSvc(Test):
         self.hostfile = WriteHostFile.WriteHostFile(self.hostlist, self.workdir)
         print("Host file is: {}".format(self.hostfile))
 
-        ServerUtils.runServer(self.hostfile, self.server_group, self.basepath)
+        ServerUtils.runServer(self, self.server_group)
 
     def tearDown(self):
         try:

--- a/src/tests/ftest/pool/PoolSvc.yaml
+++ b/src/tests/ftest/pool/PoolSvc.yaml
@@ -6,7 +6,7 @@ hosts:
             - boro-C
             - boro-D
 server:
-    server_group: daos_server
+    name: daos_server
 createtests:
     createmode:
         mode_RW:

--- a/src/tests/ftest/pool/RebuildNoCap.py
+++ b/src/tests/ftest/pool/RebuildNoCap.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python
 '''
-  (C) Copyright 2018 Intel Corporation.
+  (C) Copyright 2018-2019 Intel Corporation.
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
@@ -52,7 +52,6 @@ class RebuildNoCap(Test):
     server_group = ""
     CONTEXT = None
     POOL = None
-    hostfile = ""
 
     def setUp(self):
         """ setup for the test """
@@ -61,17 +60,16 @@ class RebuildNoCap(Test):
         with open('../../../.build_vars.json') as f:
               build_paths = json.load(f)
         self.CONTEXT = DaosContext(build_paths['PREFIX'] + '/lib/')
+        self.basepath = os.path.normpath(build_paths['PREFIX']  + "/../")
 
         # generate a hostfile
         self.hostlist = self.params.get("test_machines",'/run/hosts/')
-        tmp = build_paths['PREFIX'] + '/tmp'
-        self.hostfile = WriteHostFile.WriteHostFile(self.hostlist, tmp)
+
+        self.hostfile = WriteHostFile.WriteHostFile(self.hostlist, self.workdir)
 
         # fire up the DAOS servers
-        self.server_group = self.params.get("server_group",'/run/server/',
-                                            'daos_server')
-        ServerUtils.runServer(self.hostfile, self.server_group,
-                              build_paths['PREFIX'] + '/../')
+        self.server_group = self.params.get("name", '/run/server/', 'daos_server')
+        ServerUtils.runServer(self, self.server_group)
         time.sleep(3)
 
         # create a pool to test with
@@ -101,7 +99,6 @@ class RebuildNoCap(Test):
         """ cleanup after the test """
 
         try:
-            os.remove(self.hostfile)
             if self.POOL:
                 self.POOL.destroy(1)
         finally:

--- a/src/tests/ftest/pool/RebuildNoCap.yaml
+++ b/src/tests/ftest/pool/RebuildNoCap.yaml
@@ -9,7 +9,7 @@ hosts:
     - boro-E
     - boro-F
 server:
-   server_group: daos_server
+   name: daos_server
 pool:
    createmode:
      mode: 511

--- a/src/tests/ftest/pool/RebuildTests.py
+++ b/src/tests/ftest/pool/RebuildTests.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python
 '''
-  (C) Copyright 2018 Intel Corporation.
+  (C) Copyright 2018-2019 Intel Corporation.
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
@@ -76,18 +76,16 @@ class RebuildTests(Test):
         # the rebuild tests need to redo this stuff each time so not in setup
         # as it usually would be
         setid = self.params.get("setname", '/run/testparams/setnames/')
-        server_group = self.params.get("server_group",
+        server_group = self.params.get("name",
                                        '/server/',
                                        'daos_server')
 
-        basepath = os.path.normpath(self.build_paths['PREFIX']  + "/../")
-        tmp = self.build_paths['PREFIX'] + '/tmp'
-
+        self.basepath = os.path.normpath(self.build_paths['PREFIX']  + "/../")
         self.hostlist = self.params.get("test_machines", '/run/hosts/')
-        hostfile = WriteHostFile.WriteHostFile(self.hostlist, tmp)
+        self.hostfile = WriteHostFile.WriteHostFile(self.hostlist, self.workdir)
 
         try:
-            ServerUtils.runServer(hostfile, server_group, basepath)
+            ServerUtils.runServer(self, server_group)
 
             # use the uid/gid of the user running the test, these should
             # be perfectly valid
@@ -217,7 +215,6 @@ class RebuildTests(Test):
         finally:
             try:
                 ServerUtils.stopServer()
-                os.remove(hostfile)
                 # really make sure everything is gone
                 CheckForPool.CleanupPools(self.hostlist)
             finally:
@@ -239,18 +236,16 @@ class RebuildTests(Test):
         # the rebuild tests need to redo this stuff each time so not in setup
         # as it usually would be
         setid = self.params.get("setname", '/run/testparams/setnames/')
-        server_group = self.params.get("server_group",
+        server_group = self.params.get("name",
                                        '/server/',
                                        'daos_server')
 
-        basepath = os.path.normpath(self.build_paths['PREFIX']  + "/../")
-        tmp = self.build_paths['PREFIX'] + '/tmp'
-
+        self.basepath = os.path.normpath(self.build_paths['PREFIX']  + "/../")
         self.hostlist = self.params.get("test_machines", '/run/hosts/')
-        hostfile = WriteHostFile.WriteHostFile(self.hostlist, tmp)
+        self.hostfile = WriteHostFile.WriteHostFile(self.hostlist, self.workdir)
 
         try:
-            ServerUtils.runServer(hostfile, server_group, basepath)
+            ServerUtils.runServer(self, server_group)
 
             # use the uid/gid of the user running the test, these should
             # be perfectly valid
@@ -420,7 +415,6 @@ class RebuildTests(Test):
 
         finally:
             ServerUtils.stopServer(hosts=self.hostlist)
-            os.remove(hostfile)
             CheckForPool.CleanupPools(self.hostlist)
             ServerUtils.killServer(self.hostlist)
 

--- a/src/tests/ftest/pool/RebuildTests.yaml
+++ b/src/tests/ftest/pool/RebuildTests.yaml
@@ -10,7 +10,7 @@ hosts:
     - boro-F
 timeout: 5000
 server:
-  server_group: daos_server
+  name: daos_server
 testparams:
   ranks: !mux
     rank1:

--- a/src/tests/ftest/pool/RebuildWithIO.py
+++ b/src/tests/ftest/pool/RebuildWithIO.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python
 '''
-  (C) Copyright 2018 Intel Corporation.
+  (C) Copyright 2018-2019 Intel Corporation.
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
@@ -80,19 +80,15 @@ class RebuildWithIO(Test):
         # the rebuild tests need to redo this stuff each time so not in setup
         # as it usually would be
         setid = self.params.get("setname", '/run/testparams/setnames/')
-        server_group = self.params.get("server_group",'/server/',
-                                          'daos_server')
+        server_group = self.params.get("name", '/server/', 'daos_server')
 
-        basepath = os.path.normpath(self.build_paths['PREFIX']  + "/../")
-        tmp = self.build_paths['PREFIX'] + '/tmp'
-
-        self.hostlist = self.params.get("test_machines",'/run/hosts/')
-        hostfile = WriteHostFile.WriteHostFile(self.hostlist, tmp)
+        self.basepath = os.path.normpath(self.build_paths['PREFIX']  + "/../")
+        self.hostfile = WriteHostFile.WriteHostFile(self.hostlist, self.workdir)
 
         io_proc = None
 
         try:
-            ServerUtils.runServer(hostfile, server_group, basepath)
+            ServerUtils.runServer(self, server_group)
 
             # use the uid/gid of the user running the test, these should
             # be perfectly valid
@@ -173,7 +169,6 @@ class RebuildWithIO(Test):
             # wait for the I/O process to finish
             try:
                 ServerUtils.stopServer()
-                os.remove(hostfile)
                 # really make sure everything is gone
                 CheckForPool.CleanupPools(self.hostlist)
             finally:

--- a/src/tests/ftest/pool/RebuildWithIO.yaml
+++ b/src/tests/ftest/pool/RebuildWithIO.yaml
@@ -10,7 +10,7 @@ hosts:
     - boro-F
 timeout: 5000
 server:
-  server_group: daos_server
+  name: daos_server
 testparams:
   ranks:
     rank5:

--- a/src/tests/ftest/pool/SimpleCreateDeleteTest.py
+++ b/src/tests/ftest/pool/SimpleCreateDeleteTest.py
@@ -50,15 +50,15 @@ class SimpleCreateDeleteTest(Test):
 
         with open('../../../.build_vars.json') as filep:
             build_paths = json.load(filep)
-        basepath = os.path.normpath(build_paths['PREFIX']  + "/../")
+        self.basepath = os.path.normpath(build_paths['PREFIX']  + "/../")
 
         self.context = DaosContext(build_paths['PREFIX'] + '/lib/')
         self.hostlist = self.params.get("test_machines", '/run/hosts/')
-        hostfile = WriteHostFile.WriteHostFile(self.hostlist, self.workdir)
+        self.hostfile = WriteHostFile.WriteHostFile(self.hostlist, self.workdir)
 
-        server_group = self.params.get("server_group", '/server/', 'daos_server')
+        server_group = self.params.get("name", '/server/', 'daos_server')
 
-        ServerUtils.runServer(hostfile, server_group, basepath)
+        ServerUtils.runServer(self, server_group)
 
     def tearDown(self):
         try:

--- a/src/tests/ftest/pool/SimpleCreateDeleteTest.yaml
+++ b/src/tests/ftest/pool/SimpleCreateDeleteTest.yaml
@@ -4,7 +4,7 @@ hosts:
  test_machines:
   - boro-A
 server:
- server_group: daos_server
+ name: daos_server
 tests:
  modes: !mux
   modeall:

--- a/src/tests/ftest/server/Metadata.py
+++ b/src/tests/ftest/server/Metadata.py
@@ -112,7 +112,7 @@ class ObjectMetadata(avocado.Test):
             build_paths = json.load(json_f)
 
         self.basepath = os.path.normpath(build_paths['PREFIX']  + "/../")
-        self.server_group = self.params.get("server_group",
+        self.server_group = self.params.get("name",
                                             '/server/',
                                             'daos_server')
         self.context = DaosContext(build_paths['PREFIX'] + '/lib/')
@@ -122,7 +122,7 @@ class ObjectMetadata(avocado.Test):
         hostlist_clients = self.params.get("clients", '/run/hosts/*')
         self.hostfile_clients = WriteHostFile.WriteHostFile(hostlist_clients,
                                                             self.workdir)
-        ServerUtils.runServer(self.hostfile, self.server_group, self.basepath)
+        ServerUtils.runServer(self, self.server_group)
 
         self.pool = DaosPool(self.context)
         self.pool.create(self.params.get("mode", '/run/pool/createmode/*'),
@@ -259,7 +259,7 @@ class ObjectMetadata(avocado.Test):
 
         #Server Restart
         ServerUtils.stopServer(hosts=self.hostlist)
-        ServerUtils.runServer(self.hostfile, self.server_group, self.basepath)
+        ServerUtils.runServer(self, self.server_group)
 
         #Read IOR with verification with same number of threads
         threads = []

--- a/src/tests/ftest/server/Metadata.yaml
+++ b/src/tests/ftest/server/Metadata.yaml
@@ -9,7 +9,7 @@ hosts:
     - boro-C
 timeout: 1800
 server:
-   server_group: daos_server
+   name: daos_server
 pool:
   createmode:
     mode: 511

--- a/src/tests/ftest/util/ServerUtils.py
+++ b/src/tests/ftest/util/ServerUtils.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python
 '''
-  (C) Copyright 2018 Intel Corporation.
+  (C) Copyright 2018-2019 Intel Corporation.
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
@@ -33,10 +33,14 @@ import resource
 import signal
 import fcntl
 import errno
+import yaml
 
 from avocado.utils import genio
 
 sessions = {}
+
+DEFAULT_YAML_FILE = "utils/config/examples/daos_server_sockets.yml"
+AVOCADO_YAML_FILE = "utils/config/daos_avocado_test.yml"
 
 class ServerFailed(Exception):
     """ Server didn't start/stop properly. """
@@ -44,58 +48,160 @@ class ServerFailed(Exception):
 # a callback function used when there is cmd line I/O, not intended
 # to be used outside of this file
 def printFunc(thestring):
-        print("<SERVER>" + thestring)
+    print("<SERVER>" + thestring)
 
-def runServer(hostfile, setname, basepath, uri_path=None, env_dict=None):
+def nvme_yaml_config(default_yaml_value, bdev, enabled=False):
+    """
+    Enable/Disable NVMe Mode.
+    By default it's Enabled in yaml file so disable to run with ofi+sockets.
+    """
+    if 'bdev_class' in default_yaml_value['servers'][0]:
+        if default_yaml_value['servers'][0]['bdev_class'] == bdev and not enabled:
+            del default_yaml_value['servers'][0]['bdev_class']
+    if enabled:
+        default_yaml_value['servers'][0]['bdev_class'] = bdev
+
+def remove_mux_from_yaml(avocado_yaml_file, avocado_yaml_file_tmp):
+    """
+    Function to remove "!mux" from yaml file and create new tmp file
+    Args:
+        avocado_yaml_file: Avocado test yaml file
+        avocado_yaml_file_tmp: Avocado temporary test yaml file
+    """
+    with open(avocado_yaml_file, 'r') as rfile:
+        filedata = rfile.read()
+    filedata = filedata.replace('!mux', '')
+    with open(avocado_yaml_file_tmp, 'w') as wfile:
+        wfile.write(filedata)
+
+def update_server_options(avocado_yaml_value, default_yaml_value):
+    """
+    Update the 'server_options' from avocado_yaml_value dictionary to default_yaml_value dictionary.
+    """
+    default_yaml_env = default_yaml_value["servers"][0]['env_vars']
+
+    if 'server_options' in avocado_yaml_value:
+        avocado_yaml_options = avocado_yaml_value['server_options']
+        #Iterate through the server_options value from test file
+        for key, val in avocado_yaml_options.iteritems():
+            if 'env_vars' in key:
+                for no_of_env in enumerate(val):
+                    for env_k, env_v in no_of_env[1].iteritems():
+                        env_index = [default_yaml_env.index(i)
+                                     for i in  default_yaml_env if env_k in i]
+                        #Update the Existing environment variable
+                        if env_index:
+                            default_yaml_env[env_index[0]] = "{}={}".format(env_k, env_v)
+                        #Add new environment variable
+                        else:
+                            default_yaml_env.append("{}={}".format(env_k, env_v))
+            #Update/Add other non env_vars variable
+            else:
+                default_yaml_value["servers"][0].update({key:val})
+
+def create_server_yaml(test_cls):
+    """
+    This function is to create DAOS server configuration YAML file based on Avocado test Yaml file.
+    Args:
+        - test_cls = Pass Avocado self (Test) class
+    """
+    #Read the default utils/config/examples/daos_server_sockets.yml
+    try:
+        with open('{}/{}'.format(test_cls.basepath, DEFAULT_YAML_FILE), 'r') as read_file:
+            default_yaml_value = yaml.load(read_file)
+    except Exception as excpn:
+        print("<SERVER> Exception occurred: {0}".format(str(excpn)))
+        traceback.print_exception(excpn.__class__, excpn, sys.exc_info()[2])
+        raise ServerFailed("Failed to Read {}/{}".format(test_cls.basepath, DEFAULT_YAML_FILE))
+
+    #Read the values from avocado_testcase.yaml file
+    avocado_yaml_file = str(test_cls.name).split("-")[1].split(":")[0].replace(".py", ".yaml")
+    avocado_yaml_file_tmp = '{}.tmp'.format(avocado_yaml_file)
+
+    # Yaml Python module is not able to read !mux so need to remove !mux before reading.
+    remove_mux_from_yaml(avocado_yaml_file, avocado_yaml_file_tmp)
+
+    # Read avocado avocado_testcase.yaml file.
+    try:
+        with open('{}'.format(avocado_yaml_file_tmp), 'r') as read_file:
+            avocado_yaml_value = yaml.load(read_file)
+    except Exception as excpn:
+        print("<SERVER> Exception occurred: {0}".format(str(excpn)))
+        traceback.print_exception(excpn.__class__, excpn, sys.exc_info()[2])
+        raise ServerFailed("Failed to Read {}".format('{}.tmp'.format(avocado_yaml_file)))
+    #Remove temporary file
+    os.remove(avocado_yaml_file_tmp)
+
+    #Update main values from avocado_testcase.yaml in DAOS yaml variables.
+    if 'server' in avocado_yaml_value:
+        default_yaml_value.update(avocado_yaml_value["server"])
+
+    #Disable NVMe as it's Enabled in utils/config/examples/daos_server_sockets.yml
+    nvme_yaml_config(default_yaml_value, "nvme")
+
+    # Update servers: instance value in DAOS yaml
+    update_server_options(avocado_yaml_value, default_yaml_value)
+
+    #Write default_yaml_value dictionary in to AVOCADO_YAML_FILE, This will be used to start
+    #with daos_server -o option.
+    try:
+        with open('{}/{}'.format(test_cls.basepath, AVOCADO_YAML_FILE), 'w') as write_file:
+            yaml.dump(default_yaml_value, write_file, default_flow_style=False)
+    except Exception as excpn:
+        print("<SERVER> Exception occurred: {0}".format(str(excpn)))
+        traceback.print_exception(excpn.__class__, excpn, sys.exc_info()[2])
+        raise ServerFailed("Failed to Write {}/{}".format(test_cls.basepath, AVOCADO_YAML_FILE))
+
+def runServer(test_cls, setname, uri_path=None, env_dict=None):
     """
     Launches DAOS servers in accordance with the supplied hostfile.
-
+    Args:
+        - test_cls = Avocado self (Test) class
+            - test_cls.basepath
+            - test_cls.hostfile
+          Example ServerUtils.runServer(self, self.server_group)
+        - setname = Server Group name
+        - uri_path = uri path
     """
     global sessions
+
     try:
-        servers = [line.split(' ')[0]
-                   for line in genio.read_all_lines(hostfile)]
+        servers = [line.split(' ')[0] for line in genio.read_all_lines(test_cls.hostfile)]
         server_count = len(servers)
+
+        #Create the DAOS server configuration yaml file to pass with daos_server -o <FILE_NAME>
+        create_server_yaml(test_cls)
 
         # first make sure there are no existing servers running
         killServer(servers)
 
         # pile of build time variables
-        with open(os.path.join(basepath, ".build_vars.json")) as json_vars:
+        with open(os.path.join(test_cls.basepath, ".build_vars.json")) as json_vars:
             build_vars = json.load(json_vars)
         orterun_bin = os.path.join(build_vars["OMPI_PREFIX"], "bin", "orterun")
         daos_srv_bin = os.path.join(build_vars["PREFIX"], "bin", "daos_server")
 
-        # before any set in env are added to env_args, add any user supplied
-        # envirables to environment first
+        env_args = []
+        # Add any user supplied environment
         if env_dict is not None:
             for k, v in env_dict.items():
                 os.environ[k] = v
-
-        env_vars = ['CRT_.*', 'DAOS_.*', 'ABT_.*', 'D_LOG_.*',
-                    'DD_(STDERR|LOG|SUBSYS|MASK)', 'OFI_.*']
-
-        env_args = []
-        for (env_var, env_val) in os.environ.items():
-            for pat in env_vars:
-                if re.match(pat, env_var):
-                    env_args.extend(["-x", "{}={}".format(env_var, env_val)])
+                env_args.extend(["-x", "{}={}".format(k, v)])
 
         server_cmd = [orterun_bin, "--np", str(server_count)]
         if uri_path is not None:
             server_cmd.extend(["--report-uri", uri_path])
-        server_cmd.extend(["--hostfile", hostfile, "--enable-recovery"])
+        server_cmd.extend(["--hostfile", test_cls.hostfile, "--enable-recovery"])
         server_cmd.extend(env_args)
-        server_cmd.extend([daos_srv_bin, "-g", setname, "-c", "1",
-                           "-a", os.path.join(basepath, "install", "tmp"),
-                           "-d", os.path.join(os.sep, "var", "run", "user",
-                           str(os.geteuid()))])
+        server_cmd.extend([daos_srv_bin,
+                           "-a", os.path.join(test_cls.basepath, "install", "tmp"),
+                           "-o", '{}/{}'.format(test_cls.basepath, AVOCADO_YAML_FILE)])
 
         print("Start CMD>>>>{0}".format(' '.join(server_cmd)))
 
-        resource.setrlimit(
-            resource.RLIMIT_CORE,
-            (resource.RLIM_INFINITY, resource.RLIM_INFINITY))
+        resource.setrlimit(resource.RLIMIT_CORE,
+                           (resource.RLIM_INFINITY,
+                            resource.RLIM_INFINITY))
 
         sessions[setname] = subprocess.Popen(server_cmd,
                                              stdout=subprocess.PIPE,
@@ -119,14 +225,12 @@ def runServer(hostfile, setname, basepath, uri_path=None, env_dict=None):
             match = re.findall(pattern, output)
             expected_data += output
             result += len(match)
-            if not output or result == server_count or \
-               time.time() - start_time > timeout:
+            if not output or result == server_count or time.time() - start_time > timeout:
                 print("<SERVER>: {}".format(expected_data))
                 if result != server_count:
                     raise ServerFailed("Server didn't start!")
                 break
-        print("<SERVER> server started and took %s seconds to start" % \
-              (time.time() - start_time))
+        print("<SERVER> server started and took %s seconds to start" %(time.time() - start_time))
     except Exception as excpn:
         print("<SERVER> Exception occurred: {0}".format(str(excpn)))
         traceback.print_exception(excpn.__class__, excpn, sys.exc_info()[2])
@@ -139,8 +243,7 @@ def runServer(hostfile, setname, basepath, uri_path=None, env_dict=None):
             if sessions[setname].poll() is None:
                 sessions[setname].kill()
             retcode = sessions[setname].wait()
-            print("<SERVER> server start return code: {}\n" \
-                  "stderr:\n{}".format(retcode, error))
+            print("<SERVER> server start return code: {}\n stderr:\n{}".format(retcode, error))
         except KeyError:
             pass
         raise ServerFailed("Server didn't start!")
@@ -191,10 +294,8 @@ def stopServer(setname=None, hosts=None):
 
     if found_hosts:
         killServer(found_hosts)
-        raise ServerFailed("daos processes {} found on hosts "
-                           "{} after stopServer() were "
-                           "killed".format(', '.join(stdout.splitlines()),
-                           found_hosts))
+        raise ServerFailed("daos processes {} found on hosts {} after stopServer() were killed"
+                           .format(', '.join(stdout.splitlines()), found_hosts))
 
     # we can also have orphaned ssh processes that started an orted on a
     # remote node but never get cleaned up when that remote node spontaneiously

--- a/utils/config/examples/daos_server_sockets.yml
+++ b/utils/config/examples/daos_server_sockets.yml
@@ -33,7 +33,7 @@ servers:
 
   # Storage definitions
 
-  scm_mount: /mnt/daos	# map to -s /mnt/daos
+  scm_mount: /mnt/daos  # map to -s /mnt/daos
 
   # If using NVMe SSD (will write /mnt/daos/daos_nvme.conf and start I/O
   # service with -n <path>)


### PR DESCRIPTION
- Server start API has been changed. Server will be started with -o .yaml option
  will not pass any extra arguments to the server command line except must require
  which is -a (--attach_info) which required further Python API to work.
- Flow:
  1> New YAML file created to use with daos_server based on examples/daos_server_sockets.yml.
  2> Code will read avocado_test.yaml file options "server", "server_options". Example..
     server:
      server_group: daos_avocado
     server_options:
      cpus: [0-1]
  3> Option will be overwritten in New YAML file. For Example
     name: daos_avocado         # map to -g daos_server
     servers:
     -
      cpus: [0-1]               # map to -c 8
  4> runServer(env_dict) kept as it is to work with some test like CartSelfTest.py.
- Changed "server_group" to "name" in all test yaml file to map with DAOS Control Plane name.
- Removed "/t" from daos_server_sockets.yml, Python yaml module won't work if tab is
  used instead of space.
- Need this Env to setup on Shell to run client side code.
  export CRT_PHY_ADDR_STR="ofi+sockets" or "ofi+psm2"
  export OFI_INTERFACE="eth0" or "ib0"
- Other variable can be set on Shell prior starting tests and those Env will get the
  higher priority by Control Plane Management.
- Verified CartSelfTest.py,SimpleCreateDeleteTest and ObjectIntegrity for sanity.

Change-Id: Id7323ef763cd9c437ccbb056263fc5fddde39e4e
Signed-off-by: Samir <samir.raval@intel.com>