### PR TITLE
DAOS-2076 Only run rebuild subtests 0-1

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -576,7 +576,7 @@ pipeline {
                                                [ -f /tmp/daos.log ] && mv /tmp/daos.log run_test.sh/
                                                # servers can sometimes take a while to stop when the test is done
                                                x=0
-                                               while [ \"\\\$x\" -lt \"10\" ] && 
+                                               while [ \"\\\$x\" -lt \"10\" ] &&
                                                      pgrep '(orterun|daos_server|daos_io_server)'; do
                                                    sleep 1
                                                    let x=\\\$x+1

--- a/src/tests/ftest/daos_test/DaosCoreTest.yaml
+++ b/src/tests/ftest/daos_test/DaosCoreTest.yaml
@@ -23,7 +23,7 @@ daos_tests:
     test_r:
       daos_test: r
       test_name: rebuild tests
-      args: -u subtests="0-13"
+      args: -u subtests="0-1"
     test_d:
       daos_test: d
       test_name: DAOS degraded-mode tests


### PR DESCRIPTION
Just as was landed for old CI in b226d0f75715d18570f26433bb62a1bd1ed71a9b.

Change-Id: I6dbcbf89c3b0350a114449e9bc55576491e59103