### PR TITLE
DAOS-1659 vos: Checksums stored in VOS for Array Types

### DIFF
--- a/src/common/checksum.c
+++ b/src/common/checksum.c
@@ -122,7 +122,7 @@ daos_csum_free(daos_csum_t *cs_obj)
 }
 
 inline daos_size_t
-daos_csum_get_size(daos_csum_t *csum)
+daos_csum_get_size(const daos_csum_t *csum)
 {
 #if defined(__x86_64__)
 	return csum_dict[csum->dc_csum].cs_size;

--- a/src/include/daos/checksum.h
+++ b/src/include/daos/checksum.h
@@ -56,7 +56,7 @@ int		daos_csum_init(const char *cs_name, daos_csum_t *checksum);
 int		daos_csum_free(daos_csum_t *csum);
 int		daos_csum_reset(daos_csum_t *csum);
 int		daos_csum_compute(daos_csum_t *csum, daos_sg_list_t *sgl);
-daos_size_t	daos_csum_get_size(daos_csum_t *csum);
+daos_size_t	daos_csum_get_size(const daos_csum_t *csum);
 int		daos_csum_get(daos_csum_t *csum, daos_csum_buf_t *csum_buf);
 int		daos_csum_compare(daos_csum_t *csum, daos_csum_t *csum_src);
 #endif

--- a/src/object/obj_rpc.c
+++ b/src/object/obj_rpc.c
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2016-2018 Intel Corporation.
+ * (C) Copyright 2016-2019 Intel Corporation.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -132,7 +132,7 @@ crt_proc_daos_csum_buf_t(crt_proc_t proc, daos_csum_buf_t *csum)
 	if (rc != 0)
 		return -DER_HG;
 
-	rc = crt_proc_uint32_t(proc, &csum->cs_type);
+	rc = crt_proc_uint16_t(proc, &csum->cs_type);
 	if (rc != 0)
 		return -DER_HG;
 
@@ -140,12 +140,12 @@ crt_proc_daos_csum_buf_t(crt_proc_t proc, daos_csum_buf_t *csum)
 	if (rc != 0)
 		return -DER_HG;
 
-	rc = crt_proc_uint16_t(proc, &csum->cs_buf_len);
+	rc = crt_proc_uint32_t(proc, &csum->cs_buf_len);
 	if (rc != 0)
 		return -DER_HG;
 
 	if (csum->cs_buf_len < csum->cs_len) {
-		D_ERROR("invalid csum buf len %hu < csum len %hu\n",
+		D_ERROR("invalid csum buf len %iu < csum len %hu\n",
 			csum->cs_buf_len, csum->cs_len);
 		return -DER_HG;
 	}

--- a/src/tests/daosbench.c
+++ b/src/tests/daosbench.c
@@ -231,7 +231,7 @@ ioreq_init_basic(struct a_ioreq *ioreq, daos_iod_type_t iod_type)
 	ioreq->iod.iod_type = iod_type;
 	ioreq->rex.rx_nr = 1;
 
-	ioreq->csum.cs_csum = &ioreq->csum_buf;
+	ioreq->csum.cs_csum = (uint8_t *) &ioreq->csum_buf;
 	ioreq->csum.cs_buf_len = UPDATE_CSUM_SIZE;
 	ioreq->csum.cs_len = UPDATE_CSUM_SIZE;
 

--- a/src/vos/tests/SConscript
+++ b/src/vos/tests/SConscript
@@ -14,7 +14,8 @@ def scons():
     denv.AppendUnique(RPATH=[Literal(r'\$$ORIGIN/../lib/daos_srv')])
 
     vos_test_src = ['vos_tests.c', 'vts_io.c', 'vts_pool.c', 'vts_container.c',
-                    denv.Object("vts_common.c"), 'vts_purge.c']
+                    denv.Object("vts_common.c"), 'vts_purge.c',
+                    'csum_extent_tests.c']
     vos_tests = daos_build.program(denv, 'vos_tests', vos_test_src,
                                    LIBS=libraries)
     denv.AppendUnique(CPPPATH=["../../common/tests"])

--- a/src/vos/tests/csum_extent_tests.c
+++ b/src/vos/tests/csum_extent_tests.c
@@ -1,0 +1,765 @@
+/**
+ * (C) Copyright 2019 Intel Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * GOVERNMENT LICENSE RIGHTS-OPEN SOURCE SOFTWARE
+ * The Government's rights to use, modify, reproduce, release, perform, display,
+ * or disclose this software are subject to the terms of the Apache License as
+ * provided in Contract No. B609815.
+ * Any reproduction of computer software, computer software documentation, or
+ * portions thereof marked with this legend must also reproduce the markings.
+ */
+
+#include <daos_types.h>
+#include <gurt/common.h>
+#include "csum_extent_tests.h"
+#include "vts_io.h"
+
+#define SUCCESS(exp) (0 == (exp))
+
+/*
+ * Structure which uniquely identifies a extent in a key value pair.
+ */
+struct extent_key {
+	daos_handle_t	container_hdl;
+	daos_unit_oid_t	object_id;
+	daos_key_t		dkey;
+	daos_key_t		akey;
+	char		dkey_buf[UPDATE_DKEY_SIZE];
+	char		akey_buf[UPDATE_AKEY_SIZE];
+};
+
+/*
+ * Initialize the extent key from the io_test_args
+ */
+void extent_key_from_test_args(struct extent_key *k,
+			       struct io_test_args *args)
+{
+	/* Set up dkey and akey */
+	dts_key_gen(&k->dkey_buf[0], args->dkey_size, args->dkey);
+	dts_key_gen(&k->akey_buf[0], args->akey_size, args->akey);
+	set_iov(&k->dkey, &k->dkey_buf[0], args->ofeat & DAOS_OF_DKEY_UINT64);
+	set_iov(&k->akey, &k->akey_buf[0], args->ofeat & DAOS_OF_AKEY_UINT64);
+
+	k->container_hdl = args->ctx.tc_co_hdl;
+	k->object_id = args->oid;
+}
+
+/*
+ * Parameters used to setup the test
+ */
+struct csum_test_params {
+	uint32_t csum_bytes;
+	uint32_t total_records;
+	uint32_t record_bytes;
+	uint32_t csum_chunk_records;
+	uint8_t  use_rand_csum;
+};
+
+/*
+ * test properties for extents that expand an entire range of memory
+ */
+struct csum_test {
+	struct  extent_key extent_key;
+	uint32_t csum_bytes;
+	uint32_t total_records;
+	uint32_t record_bytes;
+	uint32_t csum_chunk_records;
+	uint32_t csum_buf_len;
+	uint32_t buf_len;
+	uint8_t *update_csum_buf;
+	uint8_t *fetch_csum_buf;
+	uint8_t *fetch_buf;
+	uint8_t *update_buf;
+	uint8_t  use_rand_csum;
+};
+
+/*
+ * Calculated fields based on number of extents to segment the data
+ */
+static uint64_t
+get_records_per_extent(struct csum_test *test, const uint64_t extents)
+{
+	return test->total_records / extents;
+}
+
+static uint64_t
+get_csums_per_extent(struct csum_test *test, const uint64_t extents)
+{
+	return get_records_per_extent(test, extents) / test->csum_chunk_records;
+}
+
+static uint64_t
+get_csum_buf_len_per_extent(struct csum_test *test, const uint64_t extents)
+{
+	return get_csums_per_extent(test, extents) * test->csum_bytes;
+}
+
+static uint64_t
+get_csum_total(struct csum_test *test, const uint64_t extents)
+{
+	return test->total_records / test->csum_chunk_records;
+}
+
+/*
+ * Setup the tests
+ */
+static void
+csum_test_setup(struct csum_test *test, void **state,
+		struct csum_test_params *params)
+{
+	test->total_records = params->total_records;
+	test->record_bytes = params->record_bytes;
+	test->csum_bytes = params->csum_bytes;
+	test->csum_chunk_records = params->csum_chunk_records;
+	test->use_rand_csum = params->use_rand_csum;
+
+	/* Calculated fields */
+	test->buf_len = test->total_records * test->record_bytes;
+	test->csum_buf_len = (test->total_records /
+			      test->csum_chunk_records) *
+			     test->csum_bytes;
+
+	/* Allocate memory for the csums and buffers used for data */
+	test->fetch_buf = malloc(test->buf_len);
+	test->update_buf = malloc(test->buf_len);
+	test->update_csum_buf = malloc(test->csum_buf_len);
+	test->fetch_csum_buf = malloc(test->csum_buf_len);
+
+	/* Generate some random data */
+	dts_buf_render((char *) test->update_buf, test->buf_len);
+
+	extent_key_from_test_args(&test->extent_key,
+				  (struct io_test_args *) *state);
+}
+
+/*
+ * Cleanup from test
+ */
+static void
+csum_test_teardown(struct csum_test *test_test)
+{
+	free(test_test->update_csum_buf);
+	free(test_test->fetch_csum_buf);
+	free(test_test->fetch_buf);
+	free(test_test->update_buf);
+}
+
+/*
+ * Initialize an I/O Descriptor based on current test and number of extents
+ */
+static void
+iod_init(daos_iod_t *iod, const uint32_t extent_nr,
+	 struct csum_test *test)
+{
+	memset(iod, 0, sizeof(*iod));
+	iod->iod_type = DAOS_IOD_ARRAY;
+	iod->iod_size = 1;
+	iod->iod_name = test->extent_key.akey;
+	iod->iod_recxs = calloc(extent_nr, sizeof(daos_recx_t));
+	iod->iod_csums = calloc(extent_nr, sizeof(daos_csum_buf_t));
+	iod->iod_nr = extent_nr;
+}
+
+/*
+ * Free resources allocated for the I/O Descriptor
+ */
+static void
+iod_free(daos_iod_t *iod)
+{
+	free(iod->iod_recxs);
+	free(iod->iod_csums);
+}
+
+/*
+ * Initialize the record extents based on current test and number of extents
+ */
+static void
+iod_recx_init(daos_iod_t *iod, const uint32_t extent_nr,
+	      struct csum_test *test)
+{
+	uint64_t records_per_extent = get_records_per_extent(test, extent_nr);
+	int i;
+
+	for (i = 0; i < extent_nr; i++) {
+		daos_recx_t *recx = &iod->iod_recxs[i];
+
+		recx->rx_nr = records_per_extent;
+		recx->rx_idx = i * records_per_extent;
+	}
+}
+
+/*
+ * Setup the Scatter/Gather List and allocate resources required
+ */
+static void
+sgl_init(d_sg_list_t *sgl, uint8_t *buf, uint32_t buf_len)
+{
+	memset(sgl, 0, sizeof((*sgl)));
+	sgl->sg_nr = 1;
+	sgl->sg_iovs = calloc(sgl->sg_nr, sizeof(daos_iov_t));
+
+	daos_iov_set(&sgl->sg_iovs[0], buf, buf_len);
+}
+
+/*
+ * Free resources allocated for the Scatter/Gather List
+ */
+static void
+sgl_free(d_sg_list_t *sgl)
+{
+	free(sgl->sg_iovs);
+}
+
+/*
+ * Setup the csum buffer structure and create dummy csums.
+ */
+static void
+iod_csum_calculate(struct csum_test *test, uint32_t extent_nr, daos_iod_t *iod)
+{
+	uint64_t csum_buf_len =
+		get_csum_buf_len_per_extent(test, extent_nr);
+
+	int i;
+
+	for (i = 0; i < extent_nr; i++) {
+		daos_csum_buf_t *csum = &iod->iod_csums[i];
+		/*
+		 * "Calculating" csums for extents (ignoring "chunks" for now)
+		 */
+		uint8_t *buf = &test->update_csum_buf[i * csum_buf_len];
+		char *extent_csum_buf = (char *) buf;
+
+		if (test->use_rand_csum)
+			dts_buf_render(extent_csum_buf, csum_buf_len);
+		else
+			memset(extent_csum_buf, i + 1, csum_buf_len);
+
+		daos_csum_set_multiple(csum, buf, csum_buf_len,
+				       test->csum_bytes,
+				       get_csums_per_extent(test, extent_nr),
+				       test->csum_chunk_records *
+				       test->record_bytes);
+	}
+}
+
+/*
+ * Send the test's update buffer and csum to VOS to update the object.
+ */
+int
+update(struct csum_test *test, const uint32_t extent_nr,
+	uint32_t epoch)
+{
+	daos_sg_list_t		sgl;
+	daos_iod_t		iod;
+
+	iod_init(&iod, extent_nr, test);
+	iod_recx_init(&iod, extent_nr, test);
+	sgl_init(&sgl, test->update_buf, test->buf_len);
+
+	iod_csum_calculate(test, extent_nr, &iod);
+
+	int rc = vos_obj_update(test->extent_key.container_hdl,
+		test->extent_key.object_id, epoch,
+				0, &test->extent_key.dkey,
+				1, &iod, &sgl);
+	iod_free(&iod);
+	sgl_free(&sgl);
+	return rc;
+}
+
+/*
+ * Fetch the extent and csum into the test's fetch buffers. Count the total
+ * number of csums that were fetched and return to be verified.
+ */
+int
+fetch(struct csum_test *test, int extent_nr,
+	uint32_t *csum_count_per_extent, uint32_t *csum_len,
+	uint32_t *csum_count_total, uint32_t epoch)
+{
+	daos_sg_list_t		sgl;
+	daos_iod_t		iod;
+
+	iod_init(&iod, extent_nr, test);
+	iod_recx_init(&iod, extent_nr, test);
+	sgl_init(&sgl, test->update_buf, test->buf_len);
+
+	daos_csum_buf_t *csums = iod.iod_csums;
+
+	int i;
+
+	uint64_t len_per_extent = get_csum_buf_len_per_extent(test, extent_nr);
+
+	for (i = 0; i < extent_nr; i++) {
+		csums[i].cs_buf_len = len_per_extent;
+		csums[i].cs_csum = &test->fetch_csum_buf[i * len_per_extent];
+		csums[i].cs_chunksize = test->csum_chunk_records *
+			test->record_bytes;
+	}
+
+	int rc = vos_obj_fetch(test->extent_key.container_hdl,
+			       test->extent_key.object_id,
+			       epoch, &test->extent_key.dkey,
+			       1, &iod, &sgl);
+
+	*csum_count_total = 0;
+	*csum_count_per_extent = 0;
+	*csum_len = 0;
+	for (i = 0; i < extent_nr; i++) {
+		/*
+		 * Count total checksums fetched
+		 */
+		*csum_count_total += csums[i].cs_nr;
+
+		/*
+		 * Each extent's csum values should be the same ... so just save
+		 * the first
+		 */
+		if (i == 0) {
+			*csum_count_per_extent = csums[i].cs_nr;
+			*csum_len = csums[i].cs_len;
+		} else {
+			assert_int_equal(*csum_count_per_extent,
+					 csums[i].cs_nr);
+			assert_int_equal(*csum_len, csums[i].cs_len);
+		}
+	}
+
+
+	iod_free(&iod);
+	sgl_free(&sgl);
+
+	return rc;
+}
+
+/*
+ * ------------------------------------------------------------------------
+ * Actual Test Functions
+ * - These are called from vts_io and included in csum_extent_tests.h
+ * ------------------------------------------------------------------------
+ */
+
+/*
+ * Using a single data source, this test will repeatedly update and fetch
+ * a key value (vos_object_update/vos_object_fetch) with different number
+ * of extents spanning the data source. It does expect that the updates and
+ * fetched extents are "chunk" aligned.
+ *
+ */
+void
+csum_multiple_extents_tests(void **state)
+{
+	int rc;
+	int i;
+
+	/* Setup Test */
+	struct csum_test_params params;
+
+	params.total_records = 1024 * 1024 * 64;
+	params.record_bytes = 1;
+	params.csum_bytes = 8; /* CRC64? */
+	params.csum_chunk_records = 1024 * 16; /* 16K */
+	params.use_rand_csum = true;
+	struct csum_test test;
+
+	csum_test_setup(&test, state, &params);
+
+	/* extent counts for update and fetch. The extents will span the same
+	 * amount of data, the extents themselves will be of different lengths
+	 */
+	const int END = 0;
+	const int table[][2] = {
+	/*	update, fetch  */
+		{1,	1},
+		{1,	4},
+		{4,	4},
+		{4,	1},
+		{END,	END}
+	};
+
+	for (i = 0; table[i][0] != END; i++) {
+		int update_extents = table[i][0];
+		int fetch_extents = table[i][1];
+
+		printf("Update Extents: %d, Fetch Extents: %d\n",
+		       update_extents, fetch_extents);
+
+		uint32_t csums_count_total, csum_count_per_extent, csum_len;
+
+		rc = update(&test, update_extents, i);
+		if (!SUCCESS(rc))
+			fail_msg("Error updating extent with csum: %s\n",
+				 d_errstr(rc));
+
+		rc = fetch(&test, fetch_extents, &csum_count_per_extent,
+			   &csum_len, &csums_count_total, i);
+		if (!SUCCESS(rc))
+			fail_msg("Error fetching extent with csum: %s\n",
+				 d_errstr(rc));
+
+		/* Verify */
+		assert_int_equal(test.csum_bytes, csum_len);
+		assert_int_equal(get_csums_per_extent(&test, fetch_extents),
+				 csum_count_per_extent);
+		assert_int_equal(get_csum_total(&test, fetch_extents),
+				 csums_count_total);
+		assert_memory_equal(test.update_csum_buf, test.fetch_csum_buf,
+				    test.csum_buf_len);
+	}
+	csum_test_teardown(&test);
+}
+
+/*
+ * This test verifies that csums aren't copied into a zero length buffer.
+ */
+void csum_test_csum_buffer_of_0_during_fetch(void **state)
+{
+	struct csum_test_params params;
+	struct csum_test test;
+
+	params.total_records = 1024 * 1024 * 64;
+	params.record_bytes = 1;
+	params.csum_bytes = 64;
+	params.csum_chunk_records = 1024 * 16;
+	params.use_rand_csum = true;
+
+
+	csum_test_setup(&test, state, &params);
+
+	daos_epoch_t epoch = 0;
+
+	update(&test, 1, epoch);
+
+	/* Fetch ... */
+	daos_sg_list_t	 sgl;
+	daos_iod_t	 iod;
+	uint32_t	 extent_nr = 1;
+
+	iod_init(&iod, extent_nr, &test);
+	iod_recx_init(&iod, extent_nr, &test);
+	sgl_init(&sgl, test.update_buf, test.buf_len);
+
+	iod.iod_csums[0].cs_buf_len = 0;
+	iod.iod_csums[0].cs_csum = NULL;
+	vos_obj_fetch(test.extent_key.container_hdl,
+			       test.extent_key.object_id,
+			       epoch, &test.extent_key.dkey,
+			       1, &iod, &sgl);
+
+	assert_int_equal(0, iod.iod_csums[0].cs_nr);
+
+	iod_free(&iod);
+	sgl_free(&sgl);
+
+
+}
+
+/*******************************************************************************
+ * Tests with estents that don't span the entire block of memory
+ */
+
+uint32_t csum_needed_for_extent(uint32_t chunk_size, daos_recx_t extent,
+				uint32_t record_size)
+{
+	return (uint32_t)(extent.rx_nr * record_size) / chunk_size;
+}
+
+void csum_helper_functions_tests(void **state)
+{
+	daos_csum_buf_t csum;
+
+	csum.cs_len = 2;
+	csum.cs_chunksize = 4;
+	csum.cs_buf_len = 4;
+	csum.cs_nr = 2;
+	csum.cs_csum = calloc(csum.cs_buf_len, 1);
+	csum.cs_csum[0] = 1;
+	csum.cs_csum[1] = 1;
+	csum.cs_csum[2] = 2;
+	csum.cs_csum[3] = 2;
+
+
+	assert_int_equal(0x0101, *(uint16_t *) daos_csum_from_idx(&csum, 0));
+	assert_int_equal(0x0202, *(uint16_t *) daos_csum_from_idx(&csum, 1));
+
+	assert_int_equal(0, daos_csum_idx_from_off(&csum, 0));
+	assert_int_equal(1, daos_csum_idx_from_off(&csum, 4));
+	assert_int_equal(1, daos_csum_idx_from_off(&csum, 5));
+
+	assert_int_equal(0x0101, *(uint16_t *) daos_csum_from_offset(&csum, 0));
+	assert_int_equal(0x0202, *(uint16_t *) daos_csum_from_offset(&csum, 4));
+
+
+	/** try some larger values */
+	csum.cs_chunksize = 1024 * 16; /** 16K */
+	assert_int_equal(0, daos_csum_idx_from_off(&csum, 1024 * 16 - 1));
+	assert_int_equal(1, daos_csum_idx_from_off(&csum, 1024 * 16));
+	assert_int_equal(1024, daos_csum_idx_from_off(&csum, 1024 * 1024 * 16));
+
+
+	free(csum.cs_csum);
+}
+
+
+void write_to_extent(struct extent_key *extent_key, daos_recx_t *extent,
+		     uint8_t *data_buf, const uint64_t buf_len,
+		     daos_csum_buf_t *csum)
+{
+	daos_iod_t	iod;
+	d_iov_t		sgl_iov;
+	d_sg_list_t	sgl;
+
+	memset(&iod, 0, sizeof(iod));
+	iod.iod_name = extent_key->akey;
+	iod.iod_nr = 1;
+	iod.iod_csums = csum;
+	iod.iod_recxs = extent;
+
+	iod.iod_size = 1;
+	iod.iod_type = DAOS_IOD_ARRAY;
+
+	sgl_iov.iov_len = sgl_iov.iov_buf_len = buf_len;
+	sgl_iov.iov_buf = data_buf;
+
+	memset(&sgl, 0, sizeof(sgl));
+	sgl.sg_nr = 1;
+	sgl.sg_iovs = &sgl_iov;
+
+	if (!SUCCESS(vos_obj_update(extent_key->container_hdl,
+				    extent_key->object_id, 1, 0,
+				    &extent_key->dkey, 1, &iod, &sgl)))
+		fail_msg("Failed to update");
+}
+
+uint8_t *
+allocate_random(size_t len)
+{
+	uint8_t *result = (uint8_t *)malloc(len);
+
+	D_ASSERT(result != NULL);
+	dts_buf_render((char *) result, (unsigned int) len);
+	return result;
+}
+
+void
+read_from_extent(struct extent_key *extent_key, daos_recx_t *extent,
+		 uint8_t *buf, uint64_t buf_len, daos_csum_buf_t *csum)
+{
+	daos_iod_t	iod;
+	d_iov_t		sgl_iov;
+	d_sg_list_t	sgl;
+
+	memset(&iod, 0, sizeof(iod));
+
+	iod.iod_name = extent_key->akey;
+	iod.iod_nr = 1;
+	iod.iod_csums = csum;
+	iod.iod_recxs = extent;
+
+	iod.iod_size = 1;
+	iod.iod_type = DAOS_IOD_ARRAY;
+
+
+	sgl_iov.iov_len = sgl_iov.iov_buf_len = buf_len;
+	sgl_iov.iov_buf = buf;
+
+	memset(&sgl, 0, sizeof(sgl));
+	sgl.sg_nr = 1;
+	sgl.sg_iovs = &sgl_iov;
+
+	if (!SUCCESS(vos_obj_fetch(extent_key->container_hdl,
+			extent_key->object_id, 1, &extent_key->dkey,
+				   1, &iod, &sgl)))
+		fail_msg("Failed to fetch");
+}
+
+/*
+ * This test verifies that csums aren't copied for holes
+ */
+void csum_test_holes(void **state)
+{
+	const uint64_t		 data_size = 1024 * 64; /** 64K */
+	const uint64_t		 chunk_size = 1024 * 16; /** 16K */
+	struct extent_key	 extent_key;
+	daos_recx_t		 extent = {0, data_size};
+	daos_csum_buf_t		 csum;
+	daos_csum_buf_t		 read_csum;
+	uint8_t			*data_buf_1;
+	uint8_t			*data_buf_2;
+	uint8_t			*read_data_buf = calloc(data_size * 3, 1);
+	uint8_t			*csum_buf_1;
+	uint8_t			*csum_buf_2;
+	uint8_t			*csum_read_buf;
+
+	extent_key_from_test_args(&extent_key, (struct io_test_args *) *state);
+
+	csum.cs_len = 8; /** CRC64 maybe? */
+	csum.cs_type = 1;
+	csum.cs_chunksize = chunk_size;
+	csum.cs_nr = csum_needed_for_extent(chunk_size, extent, 1);
+	csum.cs_buf_len = csum.cs_len * csum.cs_nr;
+
+	csum_buf_1 = allocate_random(csum.cs_buf_len);
+	data_buf_1 = allocate_random(data_size);
+	sleep(1); /** Sleep so random seed is different */
+	data_buf_2 = allocate_random(data_size);
+	csum_buf_2 = allocate_random(csum.cs_buf_len);
+
+	assert_memory_not_equal(data_buf_1, data_buf_2, data_size);
+	assert_memory_not_equal(csum_buf_1, csum_buf_2, csum.cs_buf_len);
+	csum_read_buf = calloc(csum.cs_buf_len * 3, 1);
+
+	/** Write first 64K */
+	csum.cs_csum = csum_buf_1;
+	write_to_extent(&extent_key, &extent, data_buf_1, data_size, &csum);
+
+	/** Leave a 64K hole and write the following 64K */
+	extent.rx_idx = data_size * 2;
+	csum.cs_csum = csum_buf_2;
+	write_to_extent(&extent_key, &extent, data_buf_2, data_size, &csum);
+
+	/** Read from first to last written */
+	extent.rx_idx = 0;
+	extent.rx_nr *= 3;
+
+	memset(&read_csum, 0, sizeof(read_csum));
+	read_csum.cs_len = csum.cs_len;
+	read_csum.cs_chunksize = chunk_size;
+	read_csum.cs_nr = csum_needed_for_extent(chunk_size, extent, 1);
+	read_csum.cs_buf_len = read_csum.cs_len * read_csum.cs_nr;
+	read_csum.cs_csum = csum_read_buf;
+
+
+	read_from_extent(&extent_key, &extent,
+			 read_data_buf, data_size * 3, &read_csum);
+
+	assert_memory_equal(data_buf_1, read_data_buf, data_size);
+	assert_memory_equal(data_buf_2, read_data_buf + data_size * 2,
+			    data_size);
+
+	assert_memory_equal(csum_buf_1, csum_read_buf, csum.cs_buf_len);
+	assert_memory_equal(csum_buf_2, csum_read_buf + csum.cs_buf_len * 2,
+			    csum.cs_buf_len);
+
+	free(data_buf_1);
+	free(data_buf_2);
+	free(read_data_buf);
+	free(csum_buf_1);
+	free(csum_buf_2);
+	free(csum_read_buf);
+}
+
+/*
+ * Verifies can handle not starting at 0
+ */
+void csum_extent_not_starting_at_0(void **state)
+{
+	const uint64_t		 data_size = 1024 * 64; /** 64K */
+	const uint64_t		 chunk_size = 1024 * 16; /** 16K */
+	struct extent_key	 extent_key;
+	daos_csum_buf_t		 csum;
+	daos_csum_buf_t		 read_csum;
+	uint8_t			*data_buf_1 = allocate_random(data_size);
+	uint8_t			*read_data_buf = calloc(data_size, 1);
+	uint8_t			*csum_buf_1;
+	uint8_t			*csum_read_buf;
+
+	extent_key_from_test_args(&extent_key, (struct io_test_args *) *state);
+
+
+	daos_recx_t extent = {1024 * 64, data_size};
+
+	csum.cs_len = 8; /** CRC64 maybe? */
+	csum.cs_type = 1;
+	csum.cs_chunksize = chunk_size;
+	csum.cs_nr = csum_needed_for_extent(chunk_size, extent, 1);
+	csum.cs_buf_len = csum.cs_len * csum.cs_nr;
+
+	csum_buf_1 = allocate_random(csum.cs_buf_len);
+	csum_read_buf = calloc(csum.cs_buf_len, 1);
+
+	/** Write first 64K at offset 64K */
+	csum.cs_csum = csum_buf_1;
+	write_to_extent(&extent_key, &extent, data_buf_1, data_size, &csum);
+
+	memset(&read_csum, 0, sizeof(read_csum));
+	read_csum.cs_len = csum.cs_len;
+	read_csum.cs_chunksize = chunk_size;
+	read_csum.cs_nr = csum_needed_for_extent(chunk_size, extent, 1);
+	read_csum.cs_buf_len = read_csum.cs_len * read_csum.cs_nr;
+	read_csum.cs_csum = csum_read_buf;
+
+	read_from_extent(&extent_key, &extent, read_data_buf, data_size,
+			 &read_csum);
+
+	assert_memory_equal(data_buf_1, read_data_buf, data_size);
+	assert_memory_equal(csum_buf_1, csum_read_buf, csum.cs_buf_len);
+
+	free(data_buf_1);
+	free(read_data_buf);
+	free(csum_buf_1);
+	free(csum_read_buf);
+}
+
+/*
+ * Verifies can handle non-chunk aligned extents
+ */
+void csum_extent_not_chunk_aligned(void **state)
+{
+	const uint64_t		data_size = 20;
+	const uint64_t		chunk_size = 8;
+
+	struct extent_key	 extent_key;
+	daos_csum_buf_t		 csum;
+	daos_csum_buf_t		 read_csum;
+	uint8_t			*csum_buf_1 = NULL;
+	uint8_t			*csum_read_buf = NULL;
+	uint8_t			*data_buf_1 = allocate_random(data_size);
+	uint8_t			*read_data_buf = calloc(data_size, 1);
+	daos_recx_t		 extent = {10, data_size};
+
+	extent_key_from_test_args(&extent_key, (struct io_test_args *) *state);
+
+
+
+	csum.cs_len = 8; /** CRC64 maybe? */
+	csum.cs_type = 1;
+	csum.cs_chunksize = chunk_size;
+	csum.cs_nr = csum_needed_for_extent(chunk_size, extent, 1);
+	csum.cs_buf_len = csum.cs_len * csum.cs_nr;
+
+	csum_buf_1 = allocate_random(csum.cs_buf_len);
+	csum_read_buf = calloc(csum.cs_buf_len, 1);
+
+	csum.cs_csum = csum_buf_1;
+	write_to_extent(&extent_key, &extent, data_buf_1, data_size, &csum);
+
+
+	memset(&read_csum, 0, sizeof(read_csum));
+	read_csum.cs_len = csum.cs_len;
+	read_csum.cs_chunksize = chunk_size;
+	read_csum.cs_buf_len = csum.cs_buf_len;
+	read_csum.cs_csum = csum_read_buf;
+
+	read_from_extent(&extent_key, &extent, read_data_buf, data_size,
+			 &read_csum);
+
+	assert_memory_equal(data_buf_1, read_data_buf, data_size);
+	assert_memory_equal(csum_buf_1, csum_read_buf, csum.cs_buf_len);
+
+	free(data_buf_1);
+	free(read_data_buf);
+	free(csum_buf_1);
+	free(csum_read_buf);
+}

--- a/src/vos/tests/csum_extent_tests.h
+++ b/src/vos/tests/csum_extent_tests.h
@@ -1,0 +1,46 @@
+/**
+ * (C) Copyright 2019 Intel Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * GOVERNMENT LICENSE RIGHTS-OPEN SOURCE SOFTWARE
+ * The Government's rights to use, modify, reproduce, release, perform, display,
+ * or disclose this software are subject to the terms of the Apache License as
+ * provided in Contract No. B609815.
+ * Any reproduction of computer software, computer software documentation, or
+ * portions thereof marked with this legend must also reproduce the markings.
+ */
+
+
+#ifndef __CSUM_TESTS_H__
+#define __CSUM_TESTS_H__
+
+void
+csum_multiple_extents_tests(void **state);
+
+void
+csum_test_csum_buffer_of_0_during_fetch(void **state);
+
+void
+csum_test_holes(void **state);
+
+void
+csum_helper_functions_tests(void **state);
+
+void
+csum_extent_not_starting_at_0(void **state);
+
+void
+csum_extent_not_chunk_aligned(void **state);
+
+#endif

--- a/src/vos/tests/evt_ctl.c
+++ b/src/vos/tests/evt_ctl.c
@@ -834,7 +834,7 @@ test_evt_iter_delete(void **state)
 			entry.ei_rect.rc_ex.ex_lo = offset;
 			entry.ei_rect.rc_ex.ex_hi = offset;
 			entry.ei_rect.rc_epc = epoch;
-			entry.ei_csum = 0;
+			memset(&entry.ei_csum, 0, sizeof(entry.ei_csum));
 			entry.ei_ver = 0;
 			entry.ei_inob = sizeof(offset);
 			sum = offset - epoch + 1;
@@ -964,7 +964,7 @@ test_evt_iter_delete_internal(void **state)
 			entry.ei_rect.rc_ex.ex_lo = offset;
 			entry.ei_rect.rc_ex.ex_hi = offset;
 			entry.ei_rect.rc_epc = epoch;
-			entry.ei_csum = 0;
+			memset(&entry.ei_csum, 0, sizeof(entry.ei_csum));
 			entry.ei_ver = 0;
 			entry.ei_inob = sizeof(offset);
 			rc = bio_alloc_init(arg->ta_utx, &entry.ei_addr,

--- a/src/vos/tests/vts_io.c
+++ b/src/vos/tests/vts_io.c
@@ -30,6 +30,7 @@
 #define D_LOGFAC	DD_FAC(tests)
 
 #include "vts_io.h"
+#include "csum_extent_tests.h"
 #include <daos_api.h>
 
 #define SETUP_RANDOM_SEED  (10)
@@ -70,8 +71,12 @@ static struct io_test_flag io_test_flags[] = {
 		.tf_bits	= TF_REC_EXT,
 	},
 	{
-		.tf_str		= "CSUM",
+		.tf_str		= "Single Value + CSUM",
 		.tf_bits	= TF_USE_CSUM,
+	},
+	{
+		.tf_str		= "Array Value + CSUM",
+		.tf_bits	= TF_USE_CSUM | TF_REC_EXT,
 	},
 	{
 		.tf_str		= "ZC + extent",
@@ -91,7 +96,7 @@ hash_key(d_iov_t *key, int flag)
 	return d_hash_string_u32((char *)key->iov_buf, key->iov_len);
 }
 
-static void
+void
 set_iov(daos_iov_t *iov, char *buf, int int_flag)
 {
 	if (int_flag)
@@ -572,8 +577,9 @@ io_update_and_fetch_dkey(struct io_test_args *arg, daos_epoch_t update_epoch,
 	daos_key_t		akey;
 	daos_recx_t		rex;
 	daos_csum_buf_t		csum;
-	char			expected_csum_buf[UPDATE_CSUM_SIZE];
-	char			actual_csum_buf[UPDATE_CSUM_SIZE];
+	char			expected_csum_buf[UPDATE_CSUM_BUF_SIZE];
+	char			actual_csum_buf[UPDATE_CSUM_BUF_SIZE];
+	uint16_t		csum_count = 0;
 	char			dkey_buf[UPDATE_DKEY_SIZE];
 	char			akey_buf[UPDATE_AKEY_SIZE];
 	char			update_buf[UPDATE_BUF_SIZE];
@@ -583,27 +589,36 @@ io_update_and_fetch_dkey(struct io_test_args *arg, daos_epoch_t update_epoch,
 	unsigned int		recx_size;
 	unsigned int		recx_nr;
 
+	/* Setup */
 	memset(&iod, 0, sizeof(iod));
 	memset(&rex, 0, sizeof(rex));
 	memset(&sgl, 0, sizeof(sgl));
+	memset(&expected_csum_buf, 0, sizeof(expected_csum_buf));
+	memset(&actual_csum_buf, 0, sizeof(actual_csum_buf));
+	memset(&csum, 0, sizeof(csum));
 
 	if (arg->ta_flags & TF_REC_EXT) {
 		iod.iod_type = DAOS_IOD_ARRAY;
 		recx_size = UPDATE_REC_SIZE;
 		recx_nr   = UPDATE_BUF_SIZE / UPDATE_REC_SIZE;
+		if (arg->ta_flags & TF_USE_CSUM) {
+			csum_count = UPDATE_CSUM_MAX_COUNT;
+			dts_buf_render(expected_csum_buf, UPDATE_CSUM_BUF_SIZE);
+			daos_csum_set_multiple(&csum, expected_csum_buf,
+					       UPDATE_CSUM_BUF_SIZE,
+					       UPDATE_CSUM_SIZE, csum_count,
+					       UPDATE_BUF_SIZE / csum_count);
+
+			iod.iod_csums = &csum;
+		}
 	} else {
 		iod.iod_type = DAOS_IOD_SINGLE;
 		recx_size = UPDATE_BUF_SIZE;
 		recx_nr   = 1;
 
-		/* currently, checksums only supported for single value */
 		if (arg->ta_flags & TF_USE_CSUM) {
-			memset(&csum, 0, sizeof(csum));
-			memset(&expected_csum_buf, 0,
-			       sizeof(expected_csum_buf));
-			memset(&actual_csum_buf, 0, sizeof(actual_csum_buf));
-			dts_buf_render(expected_csum_buf,
-				       sizeof(expected_csum_buf));
+			csum_count = 1;
+			dts_buf_render(expected_csum_buf, UPDATE_CSUM_SIZE);
 			daos_csum_set(&csum, expected_csum_buf,
 				      UPDATE_CSUM_SIZE);
 			iod.iod_csums = &csum;
@@ -659,27 +674,34 @@ io_update_and_fetch_dkey(struct io_test_args *arg, daos_epoch_t update_epoch,
 	iod.iod_recxs	= &rex;
 	iod.iod_nr	= 1;
 
+	/* Act */
 	rc = io_test_obj_update(arg, update_epoch, &dkey, &iod, &sgl, true);
 	if (rc)
 		goto exit;
 
+	/* Changes */
 	inc_cntr(arg->ta_flags);
 
 	memset(fetch_buf, 0, UPDATE_BUF_SIZE);
 	daos_iov_set(&val_iov, &fetch_buf[0], UPDATE_BUF_SIZE);
 
 	iod.iod_size = DAOS_REC_ANY;
+	memset(actual_csum_buf, 0, sizeof(actual_csum_buf));
+	if (arg->ta_flags & TF_USE_CSUM)
+		daos_csum_set_multiple(&csum, actual_csum_buf,
+				       UPDATE_CSUM_BUF_SIZE,
+				       UPDATE_CSUM_SIZE, csum_count,
+				       UPDATE_BUF_SIZE / csum_count);
 
-	if (!(arg->ta_flags & TF_REC_EXT) && arg->ta_flags & TF_USE_CSUM)
-		daos_csum_set(&csum, actual_csum_buf, UPDATE_CSUM_SIZE);
-
+	/* Act again */
 	rc = io_test_obj_fetch(arg, fetch_epoch, &dkey, &iod, &sgl, true);
 	if (rc)
 		goto exit;
 
-	if (!(arg->ta_flags & TF_REC_EXT) && arg->ta_flags & TF_USE_CSUM)
+	/* Verify */
+	if (arg->ta_flags & TF_USE_CSUM)
 		assert_memory_equal(expected_csum_buf, actual_csum_buf,
-				    UPDATE_CSUM_SIZE);
+				    UPDATE_CSUM_SIZE * csum_count);
 
 	assert_memory_equal(update_buf, fetch_buf, UPDATE_BUF_SIZE);
 
@@ -1346,6 +1368,7 @@ io_set_attribute_test(void **state)
 		assert_int_equal(attr, expected);
 	}
 }
+
 static void
 pool_cont_same_uuid(void **state)
 {
@@ -2348,6 +2371,18 @@ static const struct CMUnitTest io_tests[] = {
 		pool_cont_same_uuid, NULL, NULL},
 	{ "VOS299: Space overflow negative error test",
 		io_pool_overflow_test, NULL, io_pool_overflow_teardown},
+	{ "VOS300: Extent checksums with multiple extents requested",
+		csum_multiple_extents_tests, NULL, NULL},
+	{ "VOS301: Extent checksums with zero len csum buffer",
+		csum_test_csum_buffer_of_0_during_fetch, NULL, NULL},
+	{ "VOS302: Extent checksums with holes",
+		csum_test_holes, NULL, NULL},
+	{ "VOS303: Test some checksum helper functions",
+		csum_helper_functions_tests, NULL, NULL},
+	{ "VOS303: Test checksums when extent index doesn't start at 0",
+		csum_extent_not_starting_at_0, NULL, NULL},
+	{ "VOS303: Test checksums with chunk-unaligned extents",
+		csum_extent_not_chunk_aligned, NULL, NULL},
 };
 
 static const struct CMUnitTest int_tests[] = {

--- a/src/vos/tests/vts_io.h
+++ b/src/vos/tests/vts_io.h
@@ -52,6 +52,8 @@
 #define	UPDATE_BUF_SIZE		64
 #define UPDATE_REC_SIZE		16
 #define UPDATE_CSUM_SIZE	32
+#define UPDATE_CSUM_MAX_COUNT	2
+#define UPDATE_CSUM_BUF_SIZE	(UPDATE_CSUM_SIZE * UPDATE_CSUM_MAX_COUNT)
 #define VTS_IO_OIDS		1
 #define VTS_IO_KEYS		100000
 
@@ -138,6 +140,7 @@ int			setup_io_int_dkey(void **state);
 int			setup_io_lex_akey(void **state);
 int			setup_io_lex_dkey(void **state);
 int			teardown_io(void **state);
+void			set_iov(daos_iov_t *iov, char *buf, int int_flag);
 
 #endif
 

--- a/src/vos/vos_io.c
+++ b/src/vos/vos_io.c
@@ -304,7 +304,8 @@ biov_set_hole(struct bio_iov *biov, ssize_t len)
 /** Fetch an extent from an akey */
 static int
 akey_fetch_recx(daos_handle_t toh, daos_epoch_t epoch, daos_recx_t *recx,
-		daos_size_t *rsize_p, struct vos_io_context *ioc)
+		daos_csum_buf_t *csum, daos_size_t *rsize_p,
+		struct vos_io_context *ioc)
 {
 	struct evt_entry	*ent;
 	/* At present, this is not exposed in interface but passing it toggles
@@ -332,6 +333,7 @@ akey_fetch_recx(daos_handle_t toh, daos_epoch_t epoch, daos_recx_t *recx,
 		goto failed;
 
 	holes = 0;
+	uint32_t csum_copied = 0;
 	rsize = 0;
 	evt_ent_array_for_each(ent, &ent_array) {
 		daos_off_t	 lo = ent->en_sel_ext.ex_lo;
@@ -362,6 +364,29 @@ akey_fetch_recx(daos_handle_t toh, daos_epoch_t epoch, daos_recx_t *recx,
 			if (rc != 0)
 				goto failed;
 			holes = 0;
+		}
+
+		if (csum &&
+		    csum_copied < csum->cs_buf_len &&
+		    csum->cs_buf_len - csum_copied >= ent->en_csum.cs_buf_len) {
+			D_ASSERT(csum->cs_chunksize > 0);
+			D_ASSERT(lo >= recx->rx_idx);
+
+			void *csum_ptr = daos_csum_from_offset(csum,
+				(uint32_t) ((lo - recx->rx_idx) * rsize));
+
+			memcpy(csum_ptr, ent->en_csum.cs_csum,
+			       ent->en_csum.cs_buf_len);
+			csum_copied += ent->en_csum.cs_buf_len;
+
+			csum->cs_nr += ent->en_csum.cs_nr;
+
+			/** These should all be the same for each entry,
+			 * so it's okay to copy over previously written
+			 * value
+			 */
+			csum->cs_len = ent->en_csum.cs_len;
+			csum->cs_type = ent->en_csum.cs_type;
 		}
 
 		if (rsize == 0)
@@ -524,7 +549,7 @@ akey_fetch(struct vos_io_context *ioc, daos_handle_t ak_toh)
 
 		D_DEBUG(DB_IO, "fetch %d eph "DF_U64"\n", i, epoch);
 		rc = akey_fetch_recx(toh, epoch, &iod->iod_recxs[i],
-				     &rsize, ioc);
+				     daos_iod_csum(iod, i), &rsize, ioc);
 		if (rc != 0) {
 			D_DEBUG(DB_IO, "Failed to fetch index %d: %d\n", i, rc);
 			goto out;
@@ -717,7 +742,8 @@ akey_update_single(daos_handle_t toh, daos_epoch_t epoch, uint32_t pm_ver,
  */
 static int
 akey_update_recx(daos_handle_t toh, daos_epoch_t epoch, uint32_t pm_ver,
-		 daos_recx_t *recx, daos_size_t rsize,
+		 daos_recx_t *recx, daos_csum_buf_t *iod_csum,
+		 daos_size_t rsize,
 		 struct vos_io_context *ioc)
 {
 	struct evt_entry_in ent;
@@ -725,11 +751,14 @@ akey_update_recx(daos_handle_t toh, daos_epoch_t epoch, uint32_t pm_ver,
 	int rc;
 
 	D_ASSERT(recx->rx_nr > 0);
+	memset(&ent, 0, sizeof(ent));
 	ent.ei_rect.rc_epc = epoch;
 	ent.ei_rect.rc_ex.ex_lo = recx->rx_idx;
 	ent.ei_rect.rc_ex.ex_hi = recx->rx_idx + recx->rx_nr - 1;
 	ent.ei_ver = pm_ver;
 	ent.ei_inob = rsize;
+	if (iod_csum)
+		ent.ei_csum = *iod_csum;
 
 	biov = iod_update_biov(ioc);
 	ent.ei_addr = biov->bi_addr;
@@ -821,8 +850,9 @@ akey_update(struct vos_io_context *ioc, uint32_t pm_ver, daos_handle_t ak_toh,
 		}
 
 		D_DEBUG(DB_IO, "Array update %d eph "DF_U64"\n", i, epoch);
+		daos_csum_buf_t *csum = daos_iod_csum(iod, i);
 		rc = akey_update_recx(toh, epoch, pm_ver, &iod->iod_recxs[i],
-				      iod->iod_size, ioc);
+				      csum, iod->iod_size, ioc);
 		if (rc != 0)
 			goto failed;
 	}

--- a/src/vos/vos_tree.c
+++ b/src/vos/vos_tree.c
@@ -151,7 +151,7 @@ ktr_rec_load(struct btr_instance *tins, struct btr_record *rec,
 	csum->cs_len  = krec->kr_cs_size;
 	csum->cs_type = krec->kr_cs_type;
 	if (csum->cs_csum == NULL)
-		csum->cs_csum = vos_krec2csum(krec);
+		csum->cs_csum = (uint8_t *) vos_krec2csum(krec);
 	else if (csum->cs_buf_len > csum->cs_len)
 		memcpy(csum->cs_csum, vos_krec2csum(krec), csum->cs_len);
 
@@ -589,7 +589,7 @@ svt_rec_load(struct btr_instance *tins, struct btr_record *rec,
 			memcpy(csum->cs_csum,
 			       vos_irec2csum(irec), csum->cs_len);
 		else
-			csum->cs_csum = vos_irec2csum(irec);
+			csum->cs_csum = (uint8_t *) vos_irec2csum(irec);
 	}
 
 	rbund->rb_rsize	= irec->ir_size;


### PR DESCRIPTION
- evt_desc updated to store checksum information
   - changed daos_csum_buf_t to account for multiple checksums
   - added tests specific to checksums stored for extents

Change-Id: I48c638ee956f2f924c30cac3b7898300b9b10ba7
Signed-off-by: Ryon Jensen <ryon.jensen@intel.com>