### PR TITLE
DAOS-658 security: Redesign ACL protobuf

### DIFF
--- a/src/control/security/proto/acl.pb.go
+++ b/src/control/security/proto/acl.pb.go
@@ -7,11 +7,6 @@ import proto "github.com/golang/protobuf/proto"
 import fmt "fmt"
 import math "math"
 
-import (
-	context "golang.org/x/net/context"
-	grpc "google.golang.org/grpc"
-)
-
 // Reference imports to suppress errors if they are not otherwise used.
 var _ = proto.Marshal
 var _ = fmt.Errorf
@@ -55,61 +50,94 @@ func (x AclRequestStatus) String() string {
 	return proto.EnumName(AclRequestStatus_name, int32(x))
 }
 func (AclRequestStatus) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_acl_5afbfbf77011e98b, []int{0}
+	return fileDescriptor_acl_08c19ec25d13204d, []int{0}
 }
 
 // Bits representing access permissions
 type AclPermissions int32
 
 const (
-	AclPermissions_NONE  AclPermissions = 0
-	AclPermissions_READ  AclPermissions = 1
-	AclPermissions_WRITE AclPermissions = 2
+	AclPermissions_NO_ACCESS AclPermissions = 0
+	AclPermissions_READ      AclPermissions = 1
+	AclPermissions_WRITE     AclPermissions = 2
 )
 
 var AclPermissions_name = map[int32]string{
-	0: "NONE",
+	0: "NO_ACCESS",
 	1: "READ",
 	2: "WRITE",
 }
 var AclPermissions_value = map[string]int32{
-	"NONE":  0,
-	"READ":  1,
-	"WRITE": 2,
+	"NO_ACCESS": 0,
+	"READ":      1,
+	"WRITE":     2,
 }
 
 func (x AclPermissions) String() string {
 	return proto.EnumName(AclPermissions_name, int32(x))
 }
 func (AclPermissions) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_acl_5afbfbf77011e98b, []int{1}
+	return fileDescriptor_acl_08c19ec25d13204d, []int{1}
 }
 
-// Types of principals that can have access
-type AclPrincipalType int32
+// A given user/group may have multiple different types of entries
+type AclEntryType int32
 
 const (
-	AclPrincipalType_USER     AclPrincipalType = 0
-	AclPrincipalType_GROUP    AclPrincipalType = 1
-	AclPrincipalType_EVERYONE AclPrincipalType = 2
+	AclEntryType_ALLOW AclEntryType = 0
+	AclEntryType_AUDIT AclEntryType = 1
+	AclEntryType_ALARM AclEntryType = 2
 )
 
-var AclPrincipalType_name = map[int32]string{
-	0: "USER",
-	1: "GROUP",
-	2: "EVERYONE",
+var AclEntryType_name = map[int32]string{
+	0: "ALLOW",
+	1: "AUDIT",
+	2: "ALARM",
 }
-var AclPrincipalType_value = map[string]int32{
-	"USER":     0,
-	"GROUP":    1,
-	"EVERYONE": 2,
+var AclEntryType_value = map[string]int32{
+	"ALLOW": 0,
+	"AUDIT": 1,
+	"ALARM": 2,
 }
 
-func (x AclPrincipalType) String() string {
-	return proto.EnumName(AclPrincipalType_name, int32(x))
+func (x AclEntryType) String() string {
+	return proto.EnumName(AclEntryType_name, int32(x))
 }
-func (AclPrincipalType) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_acl_5afbfbf77011e98b, []int{2}
+func (AclEntryType) EnumDescriptor() ([]byte, []int) {
+	return fileDescriptor_acl_08c19ec25d13204d, []int{2}
+}
+
+// Bits representing flags on a given ACL entry
+type AclFlags int32
+
+const (
+	AclFlags_NO_FLAGS       AclFlags = 0
+	AclFlags_GROUP          AclFlags = 1
+	AclFlags_ACCESS_SUCCESS AclFlags = 2
+	AclFlags_ACCESS_FAILURE AclFlags = 4
+	AclFlags_POOL_INHERIT   AclFlags = 8
+)
+
+var AclFlags_name = map[int32]string{
+	0: "NO_FLAGS",
+	1: "GROUP",
+	2: "ACCESS_SUCCESS",
+	4: "ACCESS_FAILURE",
+	8: "POOL_INHERIT",
+}
+var AclFlags_value = map[string]int32{
+	"NO_FLAGS":       0,
+	"GROUP":          1,
+	"ACCESS_SUCCESS": 2,
+	"ACCESS_FAILURE": 4,
+	"POOL_INHERIT":   8,
+}
+
+func (x AclFlags) String() string {
+	return proto.EnumName(AclFlags_name, int32(x))
+}
+func (AclFlags) EnumDescriptor() ([]byte, []int) {
+	return fileDescriptor_acl_08c19ec25d13204d, []int{3}
 }
 
 type AclResponse struct {
@@ -124,7 +152,7 @@ func (m *AclResponse) Reset()         { *m = AclResponse{} }
 func (m *AclResponse) String() string { return proto.CompactTextString(m) }
 func (*AclResponse) ProtoMessage()    {}
 func (*AclResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_acl_5afbfbf77011e98b, []int{0}
+	return fileDescriptor_acl_08c19ec25d13204d, []int{0}
 }
 func (m *AclResponse) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_AclResponse.Unmarshal(m, b)
@@ -158,166 +186,22 @@ func (m *AclResponse) GetPermissions() *AclEntryPermissions {
 	return nil
 }
 
-// Represents a user or group who could access an entity.
-// If it is "everyone" we can ignore the identifying information.
-type AclPrincipal struct {
-	Type AclPrincipalType `protobuf:"varint,1,opt,name=type,proto3,enum=proto.AclPrincipalType" json:"type,omitempty"`
-	// Types that are valid to be assigned to Identifier:
-	//	*AclPrincipal_Id
-	//	*AclPrincipal_Name
-	Identifier           isAclPrincipal_Identifier `protobuf_oneof:"identifier"`
-	XXX_NoUnkeyedLiteral struct{}                  `json:"-"`
-	XXX_unrecognized     []byte                    `json:"-"`
-	XXX_sizecache        int32                     `json:"-"`
-}
-
-func (m *AclPrincipal) Reset()         { *m = AclPrincipal{} }
-func (m *AclPrincipal) String() string { return proto.CompactTextString(m) }
-func (*AclPrincipal) ProtoMessage()    {}
-func (*AclPrincipal) Descriptor() ([]byte, []int) {
-	return fileDescriptor_acl_5afbfbf77011e98b, []int{1}
-}
-func (m *AclPrincipal) XXX_Unmarshal(b []byte) error {
-	return xxx_messageInfo_AclPrincipal.Unmarshal(m, b)
-}
-func (m *AclPrincipal) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
-	return xxx_messageInfo_AclPrincipal.Marshal(b, m, deterministic)
-}
-func (dst *AclPrincipal) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_AclPrincipal.Merge(dst, src)
-}
-func (m *AclPrincipal) XXX_Size() int {
-	return xxx_messageInfo_AclPrincipal.Size(m)
-}
-func (m *AclPrincipal) XXX_DiscardUnknown() {
-	xxx_messageInfo_AclPrincipal.DiscardUnknown(m)
-}
-
-var xxx_messageInfo_AclPrincipal proto.InternalMessageInfo
-
-func (m *AclPrincipal) GetType() AclPrincipalType {
-	if m != nil {
-		return m.Type
-	}
-	return AclPrincipalType_USER
-}
-
-type isAclPrincipal_Identifier interface {
-	isAclPrincipal_Identifier()
-}
-
-type AclPrincipal_Id struct {
-	Id uint32 `protobuf:"varint,2,opt,name=id,proto3,oneof"`
-}
-
-type AclPrincipal_Name struct {
-	Name string `protobuf:"bytes,3,opt,name=name,proto3,oneof"`
-}
-
-func (*AclPrincipal_Id) isAclPrincipal_Identifier() {}
-
-func (*AclPrincipal_Name) isAclPrincipal_Identifier() {}
-
-func (m *AclPrincipal) GetIdentifier() isAclPrincipal_Identifier {
-	if m != nil {
-		return m.Identifier
-	}
-	return nil
-}
-
-func (m *AclPrincipal) GetId() uint32 {
-	if x, ok := m.GetIdentifier().(*AclPrincipal_Id); ok {
-		return x.Id
-	}
-	return 0
-}
-
-func (m *AclPrincipal) GetName() string {
-	if x, ok := m.GetIdentifier().(*AclPrincipal_Name); ok {
-		return x.Name
-	}
-	return ""
-}
-
-// XXX_OneofFuncs is for the internal use of the proto package.
-func (*AclPrincipal) XXX_OneofFuncs() (func(msg proto.Message, b *proto.Buffer) error, func(msg proto.Message, tag, wire int, b *proto.Buffer) (bool, error), func(msg proto.Message) (n int), []interface{}) {
-	return _AclPrincipal_OneofMarshaler, _AclPrincipal_OneofUnmarshaler, _AclPrincipal_OneofSizer, []interface{}{
-		(*AclPrincipal_Id)(nil),
-		(*AclPrincipal_Name)(nil),
-	}
-}
-
-func _AclPrincipal_OneofMarshaler(msg proto.Message, b *proto.Buffer) error {
-	m := msg.(*AclPrincipal)
-	// identifier
-	switch x := m.Identifier.(type) {
-	case *AclPrincipal_Id:
-		b.EncodeVarint(2<<3 | proto.WireVarint)
-		b.EncodeVarint(uint64(x.Id))
-	case *AclPrincipal_Name:
-		b.EncodeVarint(3<<3 | proto.WireBytes)
-		b.EncodeStringBytes(x.Name)
-	case nil:
-	default:
-		return fmt.Errorf("AclPrincipal.Identifier has unexpected type %T", x)
-	}
-	return nil
-}
-
-func _AclPrincipal_OneofUnmarshaler(msg proto.Message, tag, wire int, b *proto.Buffer) (bool, error) {
-	m := msg.(*AclPrincipal)
-	switch tag {
-	case 2: // identifier.id
-		if wire != proto.WireVarint {
-			return true, proto.ErrInternalBadWireType
-		}
-		x, err := b.DecodeVarint()
-		m.Identifier = &AclPrincipal_Id{uint32(x)}
-		return true, err
-	case 3: // identifier.name
-		if wire != proto.WireBytes {
-			return true, proto.ErrInternalBadWireType
-		}
-		x, err := b.DecodeStringBytes()
-		m.Identifier = &AclPrincipal_Name{x}
-		return true, err
-	default:
-		return false, nil
-	}
-}
-
-func _AclPrincipal_OneofSizer(msg proto.Message) (n int) {
-	m := msg.(*AclPrincipal)
-	// identifier
-	switch x := m.Identifier.(type) {
-	case *AclPrincipal_Id:
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(x.Id))
-	case *AclPrincipal_Name:
-		n += 1 // tag and wire
-		n += proto.SizeVarint(uint64(len(x.Name)))
-		n += len(x.Name)
-	case nil:
-	default:
-		panic(fmt.Sprintf("proto: unexpected type %T in oneof", x))
-	}
-	return n
-}
-
-// Identifier for an Access Control Entry
+// Identifier for a specific Access Control Entry
 type AclEntry struct {
-	Uuid                 string        `protobuf:"bytes,1,opt,name=uuid,proto3" json:"uuid,omitempty"`
-	Principal            *AclPrincipal `protobuf:"bytes,2,opt,name=principal,proto3" json:"principal,omitempty"`
-	XXX_NoUnkeyedLiteral struct{}      `json:"-"`
-	XXX_unrecognized     []byte        `json:"-"`
-	XXX_sizecache        int32         `json:"-"`
+	Type                 AclEntryType `protobuf:"varint,1,opt,name=type,proto3,enum=proto.AclEntryType" json:"type,omitempty"`
+	Flags                uint32       `protobuf:"varint,2,opt,name=flags,proto3" json:"flags,omitempty"`
+	Entity               string       `protobuf:"bytes,3,opt,name=entity,proto3" json:"entity,omitempty"`
+	Identity             string       `protobuf:"bytes,4,opt,name=identity,proto3" json:"identity,omitempty"`
+	XXX_NoUnkeyedLiteral struct{}     `json:"-"`
+	XXX_unrecognized     []byte       `json:"-"`
+	XXX_sizecache        int32        `json:"-"`
 }
 
 func (m *AclEntry) Reset()         { *m = AclEntry{} }
 func (m *AclEntry) String() string { return proto.CompactTextString(m) }
 func (*AclEntry) ProtoMessage()    {}
 func (*AclEntry) Descriptor() ([]byte, []int) {
-	return fileDescriptor_acl_5afbfbf77011e98b, []int{2}
+	return fileDescriptor_acl_08c19ec25d13204d, []int{1}
 }
 func (m *AclEntry) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_AclEntry.Unmarshal(m, b)
@@ -337,24 +221,38 @@ func (m *AclEntry) XXX_DiscardUnknown() {
 
 var xxx_messageInfo_AclEntry proto.InternalMessageInfo
 
-func (m *AclEntry) GetUuid() string {
+func (m *AclEntry) GetType() AclEntryType {
 	if m != nil {
-		return m.Uuid
+		return m.Type
+	}
+	return AclEntryType_ALLOW
+}
+
+func (m *AclEntry) GetFlags() uint32 {
+	if m != nil {
+		return m.Flags
+	}
+	return 0
+}
+
+func (m *AclEntry) GetEntity() string {
+	if m != nil {
+		return m.Entity
 	}
 	return ""
 }
 
-func (m *AclEntry) GetPrincipal() *AclPrincipal {
+func (m *AclEntry) GetIdentity() string {
 	if m != nil {
-		return m.Principal
+		return m.Identity
 	}
-	return nil
+	return ""
 }
 
 // Permissions for the given entry
 type AclEntryPermissions struct {
 	Entry                *AclEntry `protobuf:"bytes,1,opt,name=entry,proto3" json:"entry,omitempty"`
-	PermissionBits       uint32    `protobuf:"varint,2,opt,name=permission_bits,json=permissionBits,proto3" json:"permission_bits,omitempty"`
+	PermissionBits       uint64    `protobuf:"varint,2,opt,name=permission_bits,json=permissionBits,proto3" json:"permission_bits,omitempty"`
 	XXX_NoUnkeyedLiteral struct{}  `json:"-"`
 	XXX_unrecognized     []byte    `json:"-"`
 	XXX_sizecache        int32     `json:"-"`
@@ -364,7 +262,7 @@ func (m *AclEntryPermissions) Reset()         { *m = AclEntryPermissions{} }
 func (m *AclEntryPermissions) String() string { return proto.CompactTextString(m) }
 func (*AclEntryPermissions) ProtoMessage()    {}
 func (*AclEntryPermissions) Descriptor() ([]byte, []int) {
-	return fileDescriptor_acl_5afbfbf77011e98b, []int{3}
+	return fileDescriptor_acl_08c19ec25d13204d, []int{2}
 }
 func (m *AclEntryPermissions) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_AclEntryPermissions.Unmarshal(m, b)
@@ -391,7 +289,7 @@ func (m *AclEntryPermissions) GetEntry() *AclEntry {
 	return nil
 }
 
-func (m *AclEntryPermissions) GetPermissionBits() uint32 {
+func (m *AclEntryPermissions) GetPermissionBits() uint64 {
 	if m != nil {
 		return m.PermissionBits
 	}
@@ -400,192 +298,49 @@ func (m *AclEntryPermissions) GetPermissionBits() uint32 {
 
 func init() {
 	proto.RegisterType((*AclResponse)(nil), "proto.AclResponse")
-	proto.RegisterType((*AclPrincipal)(nil), "proto.AclPrincipal")
 	proto.RegisterType((*AclEntry)(nil), "proto.AclEntry")
 	proto.RegisterType((*AclEntryPermissions)(nil), "proto.AclEntryPermissions")
 	proto.RegisterEnum("proto.AclRequestStatus", AclRequestStatus_name, AclRequestStatus_value)
 	proto.RegisterEnum("proto.AclPermissions", AclPermissions_name, AclPermissions_value)
-	proto.RegisterEnum("proto.AclPrincipalType", AclPrincipalType_name, AclPrincipalType_value)
+	proto.RegisterEnum("proto.AclEntryType", AclEntryType_name, AclEntryType_value)
+	proto.RegisterEnum("proto.AclFlags", AclFlags_name, AclFlags_value)
 }
 
-// Reference imports to suppress errors if they are not otherwise used.
-var _ context.Context
-var _ grpc.ClientConn
+func init() { proto.RegisterFile("acl.proto", fileDescriptor_acl_08c19ec25d13204d) }
 
-// This is a compile-time assertion to ensure that this generated file
-// is compatible with the grpc package it is being compiled against.
-const _ = grpc.SupportPackageIsVersion4
-
-// AccessControlClient is the client API for AccessControl service.
-//
-// For semantics around ctx use and closing/ending streaming RPCs, please refer to https://godoc.org/google.golang.org/grpc#ClientConn.NewStream.
-type AccessControlClient interface {
-	// Set the permissions on a given ACE or create it if it doesn't exist
-	SetPermissions(ctx context.Context, in *AclEntryPermissions, opts ...grpc.CallOption) (*AclResponse, error)
-	// Fetch the permissions on a given ACE
-	GetPermissions(ctx context.Context, in *AclEntry, opts ...grpc.CallOption) (*AclResponse, error)
-	// Remove the given ACE completely from the ACL
-	DestroyAclEntry(ctx context.Context, in *AclEntry, opts ...grpc.CallOption) (*AclResponse, error)
-}
-
-type accessControlClient struct {
-	cc *grpc.ClientConn
-}
-
-func NewAccessControlClient(cc *grpc.ClientConn) AccessControlClient {
-	return &accessControlClient{cc}
-}
-
-func (c *accessControlClient) SetPermissions(ctx context.Context, in *AclEntryPermissions, opts ...grpc.CallOption) (*AclResponse, error) {
-	out := new(AclResponse)
-	err := c.cc.Invoke(ctx, "/proto.AccessControl/SetPermissions", in, out, opts...)
-	if err != nil {
-		return nil, err
-	}
-	return out, nil
-}
-
-func (c *accessControlClient) GetPermissions(ctx context.Context, in *AclEntry, opts ...grpc.CallOption) (*AclResponse, error) {
-	out := new(AclResponse)
-	err := c.cc.Invoke(ctx, "/proto.AccessControl/GetPermissions", in, out, opts...)
-	if err != nil {
-		return nil, err
-	}
-	return out, nil
-}
-
-func (c *accessControlClient) DestroyAclEntry(ctx context.Context, in *AclEntry, opts ...grpc.CallOption) (*AclResponse, error) {
-	out := new(AclResponse)
-	err := c.cc.Invoke(ctx, "/proto.AccessControl/DestroyAclEntry", in, out, opts...)
-	if err != nil {
-		return nil, err
-	}
-	return out, nil
-}
-
-// AccessControlServer is the server API for AccessControl service.
-type AccessControlServer interface {
-	// Set the permissions on a given ACE or create it if it doesn't exist
-	SetPermissions(context.Context, *AclEntryPermissions) (*AclResponse, error)
-	// Fetch the permissions on a given ACE
-	GetPermissions(context.Context, *AclEntry) (*AclResponse, error)
-	// Remove the given ACE completely from the ACL
-	DestroyAclEntry(context.Context, *AclEntry) (*AclResponse, error)
-}
-
-func RegisterAccessControlServer(s *grpc.Server, srv AccessControlServer) {
-	s.RegisterService(&_AccessControl_serviceDesc, srv)
-}
-
-func _AccessControl_SetPermissions_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
-	in := new(AclEntryPermissions)
-	if err := dec(in); err != nil {
-		return nil, err
-	}
-	if interceptor == nil {
-		return srv.(AccessControlServer).SetPermissions(ctx, in)
-	}
-	info := &grpc.UnaryServerInfo{
-		Server:     srv,
-		FullMethod: "/proto.AccessControl/SetPermissions",
-	}
-	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
-		return srv.(AccessControlServer).SetPermissions(ctx, req.(*AclEntryPermissions))
-	}
-	return interceptor(ctx, in, info, handler)
-}
-
-func _AccessControl_GetPermissions_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
-	in := new(AclEntry)
-	if err := dec(in); err != nil {
-		return nil, err
-	}
-	if interceptor == nil {
-		return srv.(AccessControlServer).GetPermissions(ctx, in)
-	}
-	info := &grpc.UnaryServerInfo{
-		Server:     srv,
-		FullMethod: "/proto.AccessControl/GetPermissions",
-	}
-	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
-		return srv.(AccessControlServer).GetPermissions(ctx, req.(*AclEntry))
-	}
-	return interceptor(ctx, in, info, handler)
-}
-
-func _AccessControl_DestroyAclEntry_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
-	in := new(AclEntry)
-	if err := dec(in); err != nil {
-		return nil, err
-	}
-	if interceptor == nil {
-		return srv.(AccessControlServer).DestroyAclEntry(ctx, in)
-	}
-	info := &grpc.UnaryServerInfo{
-		Server:     srv,
-		FullMethod: "/proto.AccessControl/DestroyAclEntry",
-	}
-	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
-		return srv.(AccessControlServer).DestroyAclEntry(ctx, req.(*AclEntry))
-	}
-	return interceptor(ctx, in, info, handler)
-}
-
-var _AccessControl_serviceDesc = grpc.ServiceDesc{
-	ServiceName: "proto.AccessControl",
-	HandlerType: (*AccessControlServer)(nil),
-	Methods: []grpc.MethodDesc{
-		{
-			MethodName: "SetPermissions",
-			Handler:    _AccessControl_SetPermissions_Handler,
-		},
-		{
-			MethodName: "GetPermissions",
-			Handler:    _AccessControl_GetPermissions_Handler,
-		},
-		{
-			MethodName: "DestroyAclEntry",
-			Handler:    _AccessControl_DestroyAclEntry_Handler,
-		},
-	},
-	Streams:  []grpc.StreamDesc{},
-	Metadata: "acl.proto",
-}
-
-func init() { proto.RegisterFile("acl.proto", fileDescriptor_acl_5afbfbf77011e98b) }
-
-var fileDescriptor_acl_5afbfbf77011e98b = []byte{
-	// 507 bytes of a gzipped FileDescriptorProto
-	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0x8c, 0x93, 0xdd, 0x6e, 0xd3, 0x30,
-	0x14, 0xc7, 0x93, 0xd2, 0x8e, 0xf6, 0xa4, 0x1f, 0xc6, 0x03, 0x51, 0x4d, 0x80, 0xaa, 0x48, 0x88,
-	0xaa, 0x48, 0x9b, 0x28, 0x42, 0x70, 0xc1, 0x4d, 0xda, 0x58, 0x5b, 0xc4, 0x48, 0x83, 0xb3, 0x6c,
-	0xe2, 0xaa, 0xea, 0x52, 0x23, 0x59, 0xca, 0x92, 0x2c, 0x76, 0x2f, 0x2a, 0xf1, 0x64, 0x3c, 0x00,
-	0x2f, 0xc5, 0xa7, 0xe2, 0xae, 0x4d, 0x5a, 0x06, 0x22, 0x37, 0x71, 0xce, 0xff, 0x77, 0xce, 0xf1,
-	0xf9, 0x08, 0x34, 0x66, 0x61, 0x74, 0x98, 0x66, 0x89, 0x4c, 0x70, 0x4d, 0xbd, 0xcc, 0xcf, 0x60,
-	0x58, 0x61, 0x44, 0x99, 0x48, 0x93, 0x58, 0x30, 0x7c, 0x04, 0x7b, 0x42, 0xce, 0xe4, 0x42, 0x74,
-	0xf5, 0x9e, 0xde, 0x6f, 0x0f, 0x1f, 0xae, 0xe8, 0x43, 0xc5, 0x5c, 0x2f, 0x98, 0x90, 0xbe, 0x92,
-	0xe9, 0x0d, 0x86, 0xdf, 0x82, 0x91, 0xb2, 0xec, 0x8a, 0x0b, 0xc1, 0x93, 0x58, 0x74, 0x2b, 0x3d,
-	0xbd, 0x6f, 0x0c, 0x0f, 0x0a, 0x2f, 0x12, 0xcb, 0x6c, 0xe9, 0x15, 0x04, 0x2d, 0xe3, 0xe6, 0x35,
-	0x34, 0xad, 0x30, 0xf2, 0x32, 0x1e, 0x87, 0x3c, 0x9d, 0x45, 0xf8, 0x39, 0x54, 0xe5, 0x32, 0x65,
-	0x7f, 0x26, 0xdf, 0x20, 0x67, 0xcb, 0x94, 0x51, 0x05, 0x61, 0x04, 0x15, 0x3e, 0x57, 0x19, 0x5b,
-	0x27, 0x1a, 0xad, 0xf0, 0x39, 0xbe, 0x0f, 0xd5, 0x78, 0x76, 0xc5, 0xba, 0x77, 0x7a, 0x7a, 0xbf,
-	0x71, 0xa2, 0x51, 0xf5, 0x35, 0x6a, 0x02, 0xf0, 0x39, 0x8b, 0x25, 0xff, 0xc4, 0x59, 0x66, 0x7e,
-	0x80, 0xfa, 0xfa, 0x5a, 0x18, 0x43, 0x75, 0xb1, 0xe0, 0x73, 0x95, 0xae, 0x41, 0xd5, 0x19, 0xbf,
-	0x80, 0x46, 0xba, 0x4e, 0x76, 0x53, 0xce, 0xfe, 0x2d, 0xf7, 0xa0, 0x05, 0x65, 0x32, 0xd8, 0xbf,
-	0xa5, 0x52, 0xfc, 0x14, 0x6a, 0x2c, 0xb7, 0xa9, 0xf0, 0xc6, 0xb0, 0xb3, 0xd3, 0x14, 0xba, 0x52,
-	0xf1, 0x33, 0xe8, 0x14, 0x2d, 0x99, 0x5e, 0x72, 0xb9, 0xea, 0x62, 0x8b, 0xb6, 0x0b, 0xf3, 0x88,
-	0x4b, 0x31, 0xf8, 0xa2, 0x03, 0xda, 0x9d, 0x03, 0x36, 0xe0, 0xae, 0x1f, 0x8c, 0xc7, 0xc4, 0xf7,
-	0x91, 0x86, 0xbb, 0x60, 0x10, 0x4a, 0xa7, 0x81, 0xfb, 0xce, 0x9d, 0x5c, 0xb8, 0xe8, 0xd7, 0xfa,
-	0xd1, 0xf1, 0x23, 0xe8, 0xe4, 0x8a, 0x47, 0xe8, 0xfb, 0xa9, 0x4d, 0x5c, 0x87, 0xd8, 0xe8, 0x67,
-	0xa1, 0x3e, 0x81, 0x7b, 0xb9, 0xea, 0xb8, 0xe7, 0xd6, 0xa9, 0x63, 0x2b, 0xca, 0x47, 0x3f, 0x0a,
-	0xdd, 0x84, 0x07, 0x5b, 0x3a, 0x75, 0xdc, 0xb1, 0xe3, 0x59, 0xa7, 0xe8, 0x7b, 0xc1, 0x3c, 0x06,
-	0x54, 0x66, 0x82, 0xc0, 0xb1, 0xd1, 0xb7, 0x8d, 0x3c, 0x38, 0x82, 0x76, 0xde, 0xbe, 0x52, 0x7b,
-	0xea, 0x50, 0x75, 0x27, 0x2e, 0x41, 0x5a, 0x7e, 0xa2, 0xc4, 0xb2, 0x91, 0x8e, 0x1b, 0x50, 0xbb,
-	0xa0, 0xce, 0x19, 0x41, 0x95, 0xc1, 0x2b, 0x55, 0xec, 0xd6, 0xdc, 0x73, 0x30, 0xf0, 0x09, 0x45,
-	0x5a, 0x0e, 0x1e, 0xd3, 0x49, 0xe0, 0x21, 0x1d, 0x37, 0xa1, 0x4e, 0xce, 0x09, 0xfd, 0x98, 0xc7,
-	0xaa, 0x0c, 0xbf, 0xea, 0xd0, 0xb2, 0xc2, 0x90, 0x09, 0x31, 0x4e, 0x62, 0x99, 0x25, 0x11, 0x1e,
-	0x41, 0xdb, 0x67, 0xb2, 0x9c, 0xf9, 0x1f, 0xeb, 0x79, 0x80, 0xcb, 0x0b, 0xbf, 0xfa, 0x29, 0x4c,
-	0x0d, 0xbf, 0x86, 0xf6, 0xf1, 0x76, 0x8c, 0xdd, 0x69, 0xfe, 0xc5, 0xf1, 0x0d, 0x74, 0x6c, 0x26,
-	0x64, 0x96, 0x2c, 0x37, 0x4b, 0xf7, 0x7f, 0x9e, 0x97, 0x7b, 0xca, 0xf8, 0xf2, 0x77, 0x00, 0x00,
-	0x00, 0xff, 0xff, 0x37, 0xb0, 0xbb, 0x7f, 0xb3, 0x03, 0x00, 0x00,
+var fileDescriptor_acl_08c19ec25d13204d = []byte{
+	// 522 bytes of a gzipped FileDescriptorProto
+	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0x8c, 0x93, 0x5d, 0x8f, 0xd2, 0x4c,
+	0x14, 0xc7, 0x29, 0x0f, 0xf0, 0xc0, 0x29, 0x94, 0x71, 0xd6, 0x17, 0x42, 0xd4, 0x10, 0x12, 0xb3,
+	0x84, 0x8b, 0xdd, 0x04, 0x4d, 0xf4, 0xc2, 0x9b, 0x59, 0x3a, 0xe0, 0xc4, 0x6e, 0x4b, 0xa6, 0x54,
+	0xae, 0x4c, 0xc3, 0xe2, 0x68, 0x9a, 0x20, 0x45, 0x66, 0xf6, 0xa2, 0x89, 0x7e, 0x31, 0x3f, 0x80,
+	0x5f, 0xca, 0xd7, 0x30, 0x05, 0xda, 0x25, 0x6a, 0xec, 0x4d, 0xe7, 0x9c, 0xff, 0xef, 0xcc, 0x39,
+	0x73, 0xe6, 0x0c, 0xd4, 0xe6, 0x8b, 0xe5, 0xd9, 0x7a, 0x13, 0xab, 0x18, 0x97, 0xf5, 0xaf, 0xfb,
+	0x11, 0x4c, 0xb2, 0x58, 0x72, 0x21, 0xd7, 0xf1, 0x4a, 0x0a, 0x7c, 0x0e, 0x15, 0xa9, 0xe6, 0xea,
+	0x5a, 0xb6, 0x8c, 0x8e, 0xd1, 0xb3, 0x06, 0xf7, 0x52, 0xfa, 0x4c, 0x33, 0x1f, 0xae, 0x85, 0x54,
+	0xbe, 0x96, 0xf9, 0x0e, 0xc3, 0xcf, 0xc1, 0x5c, 0x8b, 0xcd, 0xfb, 0x48, 0xca, 0x28, 0x5e, 0xc9,
+	0x56, 0xb1, 0x63, 0xf4, 0xcc, 0x41, 0x3b, 0x8b, 0xa2, 0x2b, 0xb5, 0x49, 0x26, 0x19, 0xc1, 0xf3,
+	0x78, 0xf7, 0x13, 0x54, 0xf7, 0x0c, 0x3e, 0x85, 0x92, 0x4a, 0xd6, 0x62, 0x97, 0xf8, 0xe4, 0x68,
+	0x8b, 0x69, 0xb2, 0x16, 0x5c, 0x03, 0xf8, 0x36, 0x94, 0xdf, 0x2e, 0xe7, 0xef, 0xd2, 0x64, 0x0d,
+	0x9e, 0x1a, 0xf8, 0x2e, 0x54, 0xc4, 0x4a, 0x45, 0x2a, 0x69, 0xfd, 0xd7, 0x31, 0x7a, 0x35, 0xbe,
+	0xb3, 0x70, 0x1b, 0xaa, 0xd1, 0x9b, 0x9d, 0x52, 0xd2, 0xca, 0xc1, 0xee, 0x0a, 0x38, 0xf9, 0x4d,
+	0x89, 0xf8, 0x11, 0x94, 0xc5, 0xd6, 0xa7, 0x4b, 0x31, 0x07, 0xcd, 0xa3, 0x52, 0x78, 0xaa, 0xe2,
+	0x53, 0x68, 0x66, 0x67, 0x09, 0xaf, 0x22, 0x95, 0x56, 0x54, 0xe2, 0x56, 0xe6, 0xbe, 0x88, 0x94,
+	0xec, 0x7f, 0x36, 0x00, 0x1d, 0x37, 0x10, 0x9b, 0xf0, 0xbf, 0x1f, 0x0c, 0x87, 0xd4, 0xf7, 0x51,
+	0x01, 0xb7, 0xc0, 0xa4, 0x9c, 0x87, 0x81, 0xfb, 0xd2, 0xf5, 0x66, 0x2e, 0xfa, 0xb9, 0xff, 0x0c,
+	0x7c, 0x1f, 0x9a, 0x5b, 0x65, 0x42, 0xf9, 0x65, 0x68, 0x53, 0x97, 0x51, 0x1b, 0xfd, 0xc8, 0xd4,
+	0x87, 0x70, 0x6b, 0xab, 0x32, 0xf7, 0x15, 0x71, 0x98, 0xad, 0x29, 0x1f, 0x7d, 0xcf, 0xf4, 0x2e,
+	0xdc, 0xb9, 0xa1, 0x73, 0xe6, 0x0e, 0xd9, 0x84, 0x38, 0xe8, 0x5b, 0xc6, 0x3c, 0x00, 0x94, 0x67,
+	0x82, 0x80, 0xd9, 0xe8, 0xeb, 0x41, 0xee, 0x3f, 0x01, 0x8b, 0x2c, 0x96, 0xf9, 0xf6, 0x34, 0xa0,
+	0xe6, 0x7a, 0x21, 0xd9, 0xd7, 0x5e, 0x85, 0x12, 0xa7, 0xc4, 0x46, 0x06, 0xae, 0x41, 0x79, 0xc6,
+	0xd9, 0x94, 0xa2, 0x62, 0xff, 0x1c, 0xea, 0xf9, 0x9b, 0xdb, 0x4a, 0xc4, 0x71, 0xbc, 0x19, 0x2a,
+	0xe8, 0x65, 0x60, 0xb3, 0x69, 0x1a, 0x40, 0x1c, 0xc2, 0x2f, 0x51, 0xb1, 0xff, 0x5a, 0x4f, 0xc2,
+	0x48, 0x5f, 0x65, 0x1d, 0xaa, 0xae, 0x17, 0x8e, 0x1c, 0x32, 0xf6, 0x53, 0x7e, 0xcc, 0xbd, 0x60,
+	0x82, 0x0c, 0x8c, 0xc1, 0x4a, 0xd3, 0x86, 0xfb, 0xd6, 0x15, 0x73, 0xbe, 0x11, 0x61, 0x4e, 0xc0,
+	0x29, 0x2a, 0x61, 0x04, 0xf5, 0x89, 0xe7, 0x39, 0x21, 0x73, 0x5f, 0x50, 0xce, 0xa6, 0xa8, 0x3a,
+	0xf8, 0x62, 0x40, 0x83, 0x2c, 0x16, 0x42, 0xca, 0x61, 0xbc, 0x52, 0x9b, 0x78, 0x89, 0x2f, 0xc0,
+	0xf2, 0x85, 0xca, 0x9f, 0xeb, 0x2f, 0x53, 0xdb, 0xc6, 0xf9, 0x77, 0x90, 0xbe, 0x95, 0x6e, 0x01,
+	0x3f, 0x05, 0x6b, 0x7c, 0x73, 0x8f, 0xe3, 0x59, 0xf9, 0x43, 0xe0, 0x33, 0x68, 0xda, 0x42, 0xaa,
+	0x4d, 0x9c, 0x1c, 0xc6, 0xff, 0xdf, 0x22, 0xaf, 0x2a, 0xda, 0xf9, 0xf8, 0x57, 0x00, 0x00, 0x00,
+	0xff, 0xff, 0xf5, 0x62, 0xab, 0xeb, 0xca, 0x03, 0x00, 0x00,
 }

--- a/src/proto/security/acl.proto
+++ b/src/proto/security/acl.proto
@@ -44,38 +44,39 @@ message AclResponse {
 
 // Bits representing access permissions
 enum AclPermissions {
-	NONE = 0;
+	NO_ACCESS = 0;
 	READ = 1;
 	WRITE = 2;
 }
 
-// Types of principals that can have access
-enum AclPrincipalType {
-	USER = 0;
-	GROUP = 1;
-	EVERYONE = 2;
+// A given user/group may have multiple different types of entries
+enum AclEntryType {
+	ALLOW = 0;
+	AUDIT = 1;
+	ALARM = 2;
 }
 
-// Represents a user or group who could access an entity.
-// If it is "everyone" we can ignore the identifying information.
-message AclPrincipal {
-	AclPrincipalType type = 1;
-	oneof identifier {
-		uint32 id = 2;	// uid or gid
-		string name = 3;
-	}
+// Bits representing flags on a given ACL entry
+enum AclFlags {
+	NO_FLAGS = 0;
+	GROUP = 1;		// This entry is for a group not a user
+	ACCESS_SUCCESS = 2;	// audit/alarm on successful access
+	ACCESS_FAILURE = 4;	// audit/alarm on failed access
+	POOL_INHERIT = 8;	// entry should be inherited by pool's containers
 }
 
-// Identifier for an Access Control Entry
+// Identifier for a specific Access Control Entry
 message AclEntry {
-	string uuid = 1;		// UUID of the entity (such as a pool)
-	AclPrincipal principal = 2;	// User/group who accesses the entity
+	AclEntryType type = 1;
+	uint32 flags = 2;	// bitmask of AclFlags
+	string entity = 3;	// UUID of the entity (such as a pool)
+	string identity = 4;	// User/group who accesses the entity
 }
 
 // Permissions for the given entry
 message AclEntryPermissions {
 	AclEntry entry = 1;
-	uint32 permission_bits = 2;	// Bitmask of AclPermissions
+	uint64 permission_bits = 2;	// Bitmask of AclPermissions
 }
 
 // gRPC API for ACL service

--- a/src/security/acl.pb-c.c
+++ b/src/security/acl.pb-c.c
@@ -52,51 +52,6 @@ void   proto__acl_response__free_unpacked
   assert(message->base.descriptor == &proto__acl_response__descriptor);
   protobuf_c_message_free_unpacked ((ProtobufCMessage*)message, allocator);
 }
-void   proto__acl_principal__init
-                     (Proto__AclPrincipal         *message)
-{
-  static const Proto__AclPrincipal init_value = PROTO__ACL_PRINCIPAL__INIT;
-  *message = init_value;
-}
-size_t proto__acl_principal__get_packed_size
-                     (const Proto__AclPrincipal *message)
-{
-  assert(message->base.descriptor == &proto__acl_principal__descriptor);
-  return protobuf_c_message_get_packed_size ((const ProtobufCMessage*)(message));
-}
-size_t proto__acl_principal__pack
-                     (const Proto__AclPrincipal *message,
-                      uint8_t       *out)
-{
-  assert(message->base.descriptor == &proto__acl_principal__descriptor);
-  return protobuf_c_message_pack ((const ProtobufCMessage*)message, out);
-}
-size_t proto__acl_principal__pack_to_buffer
-                     (const Proto__AclPrincipal *message,
-                      ProtobufCBuffer *buffer)
-{
-  assert(message->base.descriptor == &proto__acl_principal__descriptor);
-  return protobuf_c_message_pack_to_buffer ((const ProtobufCMessage*)message, buffer);
-}
-Proto__AclPrincipal *
-       proto__acl_principal__unpack
-                     (ProtobufCAllocator  *allocator,
-                      size_t               len,
-                      const uint8_t       *data)
-{
-  return (Proto__AclPrincipal *)
-     protobuf_c_message_unpack (&proto__acl_principal__descriptor,
-                                allocator, len, data);
-}
-void   proto__acl_principal__free_unpacked
-                     (Proto__AclPrincipal *message,
-                      ProtobufCAllocator *allocator)
-{
-  if(!message)
-    return;
-  assert(message->base.descriptor == &proto__acl_principal__descriptor);
-  protobuf_c_message_free_unpacked ((ProtobufCMessage*)message, allocator);
-}
 void   proto__acl_entry__init
                      (Proto__AclEntry         *message)
 {
@@ -238,7 +193,7 @@ const ProtobufCMessageDescriptor proto__acl_response__descriptor =
   (ProtobufCMessageInit) proto__acl_response__init,
   NULL,NULL,NULL    /* reserved[123] */
 };
-static const ProtobufCFieldDescriptor proto__acl_principal__field_descriptors[3] =
+static const ProtobufCFieldDescriptor proto__acl_entry__field_descriptors[4] =
 {
   {
     "type",
@@ -246,97 +201,59 @@ static const ProtobufCFieldDescriptor proto__acl_principal__field_descriptors[3]
     PROTOBUF_C_LABEL_NONE,
     PROTOBUF_C_TYPE_ENUM,
     0,   /* quantifier_offset */
-    offsetof(Proto__AclPrincipal, type),
-    &proto__acl_principal_type__descriptor,
+    offsetof(Proto__AclEntry, type),
+    &proto__acl_entry_type__descriptor,
     NULL,
     0,             /* flags */
     0,NULL,NULL    /* reserved1,reserved2, etc */
   },
   {
-    "id",
+    "flags",
     2,
     PROTOBUF_C_LABEL_NONE,
     PROTOBUF_C_TYPE_UINT32,
-    offsetof(Proto__AclPrincipal, identifier_case),
-    offsetof(Proto__AclPrincipal, id),
+    0,   /* quantifier_offset */
+    offsetof(Proto__AclEntry, flags),
     NULL,
     NULL,
-    0 | PROTOBUF_C_FIELD_FLAG_ONEOF,             /* flags */
+    0,             /* flags */
     0,NULL,NULL    /* reserved1,reserved2, etc */
   },
   {
-    "name",
+    "entity",
     3,
     PROTOBUF_C_LABEL_NONE,
     PROTOBUF_C_TYPE_STRING,
-    offsetof(Proto__AclPrincipal, identifier_case),
-    offsetof(Proto__AclPrincipal, name),
-    NULL,
-    &protobuf_c_empty_string,
-    0 | PROTOBUF_C_FIELD_FLAG_ONEOF,             /* flags */
-    0,NULL,NULL    /* reserved1,reserved2, etc */
-  },
-};
-static const unsigned proto__acl_principal__field_indices_by_name[] = {
-  1,   /* field[1] = id */
-  2,   /* field[2] = name */
-  0,   /* field[0] = type */
-};
-static const ProtobufCIntRange proto__acl_principal__number_ranges[1 + 1] =
-{
-  { 1, 0 },
-  { 0, 3 }
-};
-const ProtobufCMessageDescriptor proto__acl_principal__descriptor =
-{
-  PROTOBUF_C__MESSAGE_DESCRIPTOR_MAGIC,
-  "proto.AclPrincipal",
-  "AclPrincipal",
-  "Proto__AclPrincipal",
-  "proto",
-  sizeof(Proto__AclPrincipal),
-  3,
-  proto__acl_principal__field_descriptors,
-  proto__acl_principal__field_indices_by_name,
-  1,  proto__acl_principal__number_ranges,
-  (ProtobufCMessageInit) proto__acl_principal__init,
-  NULL,NULL,NULL    /* reserved[123] */
-};
-static const ProtobufCFieldDescriptor proto__acl_entry__field_descriptors[2] =
-{
-  {
-    "uuid",
-    1,
-    PROTOBUF_C_LABEL_NONE,
-    PROTOBUF_C_TYPE_STRING,
     0,   /* quantifier_offset */
-    offsetof(Proto__AclEntry, uuid),
+    offsetof(Proto__AclEntry, entity),
     NULL,
     &protobuf_c_empty_string,
     0,             /* flags */
     0,NULL,NULL    /* reserved1,reserved2, etc */
   },
   {
-    "principal",
-    2,
+    "identity",
+    4,
     PROTOBUF_C_LABEL_NONE,
-    PROTOBUF_C_TYPE_MESSAGE,
+    PROTOBUF_C_TYPE_STRING,
     0,   /* quantifier_offset */
-    offsetof(Proto__AclEntry, principal),
-    &proto__acl_principal__descriptor,
+    offsetof(Proto__AclEntry, identity),
     NULL,
+    &protobuf_c_empty_string,
     0,             /* flags */
     0,NULL,NULL    /* reserved1,reserved2, etc */
   },
 };
 static const unsigned proto__acl_entry__field_indices_by_name[] = {
-  1,   /* field[1] = principal */
-  0,   /* field[0] = uuid */
+  2,   /* field[2] = entity */
+  1,   /* field[1] = flags */
+  3,   /* field[3] = identity */
+  0,   /* field[0] = type */
 };
 static const ProtobufCIntRange proto__acl_entry__number_ranges[1 + 1] =
 {
   { 1, 0 },
-  { 0, 2 }
+  { 0, 4 }
 };
 const ProtobufCMessageDescriptor proto__acl_entry__descriptor =
 {
@@ -346,7 +263,7 @@ const ProtobufCMessageDescriptor proto__acl_entry__descriptor =
   "Proto__AclEntry",
   "proto",
   sizeof(Proto__AclEntry),
-  2,
+  4,
   proto__acl_entry__field_descriptors,
   proto__acl_entry__field_indices_by_name,
   1,  proto__acl_entry__number_ranges,
@@ -371,7 +288,7 @@ static const ProtobufCFieldDescriptor proto__acl_entry_permissions__field_descri
     "permission_bits",
     2,
     PROTOBUF_C_LABEL_NONE,
-    PROTOBUF_C_TYPE_UINT32,
+    PROTOBUF_C_TYPE_UINT64,
     0,   /* quantifier_offset */
     offsetof(Proto__AclEntryPermissions, permission_bits),
     NULL,
@@ -442,7 +359,7 @@ const ProtobufCEnumDescriptor proto__acl_request_status__descriptor =
 };
 static const ProtobufCEnumValue proto__acl_permissions__enum_values_by_number[3] =
 {
-  { "NONE", "PROTO__ACL_PERMISSIONS__NONE", 0 },
+  { "NO_ACCESS", "PROTO__ACL_PERMISSIONS__NO_ACCESS", 0 },
   { "READ", "PROTO__ACL_PERMISSIONS__READ", 1 },
   { "WRITE", "PROTO__ACL_PERMISSIONS__WRITE", 2 },
 };
@@ -451,7 +368,7 @@ static const ProtobufCIntRange proto__acl_permissions__value_ranges[] = {
 };
 static const ProtobufCEnumValueIndex proto__acl_permissions__enum_values_by_name[3] =
 {
-  { "NONE", 0 },
+  { "NO_ACCESS", 0 },
   { "READ", 1 },
   { "WRITE", 2 },
 };
@@ -470,34 +387,68 @@ const ProtobufCEnumDescriptor proto__acl_permissions__descriptor =
   proto__acl_permissions__value_ranges,
   NULL,NULL,NULL,NULL   /* reserved[1234] */
 };
-static const ProtobufCEnumValue proto__acl_principal_type__enum_values_by_number[3] =
+static const ProtobufCEnumValue proto__acl_entry_type__enum_values_by_number[3] =
 {
-  { "USER", "PROTO__ACL_PRINCIPAL_TYPE__USER", 0 },
-  { "GROUP", "PROTO__ACL_PRINCIPAL_TYPE__GROUP", 1 },
-  { "EVERYONE", "PROTO__ACL_PRINCIPAL_TYPE__EVERYONE", 2 },
+  { "ALLOW", "PROTO__ACL_ENTRY_TYPE__ALLOW", 0 },
+  { "AUDIT", "PROTO__ACL_ENTRY_TYPE__AUDIT", 1 },
+  { "ALARM", "PROTO__ACL_ENTRY_TYPE__ALARM", 2 },
 };
-static const ProtobufCIntRange proto__acl_principal_type__value_ranges[] = {
+static const ProtobufCIntRange proto__acl_entry_type__value_ranges[] = {
 {0, 0},{0, 3}
 };
-static const ProtobufCEnumValueIndex proto__acl_principal_type__enum_values_by_name[3] =
+static const ProtobufCEnumValueIndex proto__acl_entry_type__enum_values_by_name[3] =
 {
-  { "EVERYONE", 2 },
-  { "GROUP", 1 },
-  { "USER", 0 },
+  { "ALARM", 2 },
+  { "ALLOW", 0 },
+  { "AUDIT", 1 },
 };
-const ProtobufCEnumDescriptor proto__acl_principal_type__descriptor =
+const ProtobufCEnumDescriptor proto__acl_entry_type__descriptor =
 {
   PROTOBUF_C__ENUM_DESCRIPTOR_MAGIC,
-  "proto.AclPrincipalType",
-  "AclPrincipalType",
-  "Proto__AclPrincipalType",
+  "proto.AclEntryType",
+  "AclEntryType",
+  "Proto__AclEntryType",
   "proto",
   3,
-  proto__acl_principal_type__enum_values_by_number,
+  proto__acl_entry_type__enum_values_by_number,
   3,
-  proto__acl_principal_type__enum_values_by_name,
+  proto__acl_entry_type__enum_values_by_name,
   1,
-  proto__acl_principal_type__value_ranges,
+  proto__acl_entry_type__value_ranges,
+  NULL,NULL,NULL,NULL   /* reserved[1234] */
+};
+static const ProtobufCEnumValue proto__acl_flags__enum_values_by_number[5] =
+{
+  { "NO_FLAGS", "PROTO__ACL_FLAGS__NO_FLAGS", 0 },
+  { "GROUP", "PROTO__ACL_FLAGS__GROUP", 1 },
+  { "ACCESS_SUCCESS", "PROTO__ACL_FLAGS__ACCESS_SUCCESS", 2 },
+  { "ACCESS_FAILURE", "PROTO__ACL_FLAGS__ACCESS_FAILURE", 4 },
+  { "POOL_INHERIT", "PROTO__ACL_FLAGS__POOL_INHERIT", 8 },
+};
+static const ProtobufCIntRange proto__acl_flags__value_ranges[] = {
+{0, 0},{4, 3},{8, 4},{0, 5}
+};
+static const ProtobufCEnumValueIndex proto__acl_flags__enum_values_by_name[5] =
+{
+  { "ACCESS_FAILURE", 3 },
+  { "ACCESS_SUCCESS", 2 },
+  { "GROUP", 1 },
+  { "NO_FLAGS", 0 },
+  { "POOL_INHERIT", 4 },
+};
+const ProtobufCEnumDescriptor proto__acl_flags__descriptor =
+{
+  PROTOBUF_C__ENUM_DESCRIPTOR_MAGIC,
+  "proto.AclFlags",
+  "AclFlags",
+  "Proto__AclFlags",
+  "proto",
+  5,
+  proto__acl_flags__enum_values_by_number,
+  5,
+  proto__acl_flags__enum_values_by_name,
+  3,
+  proto__acl_flags__value_ranges,
   NULL,NULL,NULL,NULL   /* reserved[1234] */
 };
 static const ProtobufCMethodDescriptor proto__access_control__method_descriptors[3] =


### PR DESCRIPTION
Redesigned the Access Control protobuf definitions based
on changes in design, and regenerated the source code.

Change-Id: I8935aaa68023e267d71bbb219fd69cc53deea965
Signed-off-by: Kris Jacque <kristin.jacque@intel.com>