### PR TITLE
DAOS-2111 tests: shrink rebuild test object

### DIFF
--- a/src/tests/suite/daos_test_common.c
+++ b/src/tests/suite/daos_test_common.c
@@ -306,7 +306,6 @@ pool_destroy_safe(test_arg_t *arg)
 {
 	daos_pool_info_t		 pinfo;
 	daos_handle_t			 poh = arg->pool.poh;
-	bool				 connected = false;
 	int				 rc;
 
 	if (daos_handle_is_inval(poh)) {
@@ -317,8 +316,6 @@ pool_destroy_safe(test_arg_t *arg)
 		if (rc != 0) { /* destory straightaway */
 			print_message("failed to connect pool: %d\n", rc);
 			poh = DAOS_HDL_INVAL;
-		} else {
-			connected = true;
 		}
 	}
 
@@ -339,10 +336,10 @@ pool_destroy_safe(test_arg_t *arg)
 		}
 
 		/* no rebuild */
-		if (connected)
-			daos_pool_disconnect(poh, NULL);
 		break;
 	}
+
+	daos_pool_disconnect(poh, NULL);
 
 	rc = daos_pool_destroy(arg->pool.pool_uuid, arg->group, 1, NULL);
 	if (rc && rc != -DER_TIMEDOUT)
@@ -397,22 +394,6 @@ test_teardown(void **state)
 		if (rc) {
 			print_message("failed to destroy container "DF_UUIDF
 				      ": %d\n", DP_UUID(arg->co_uuid), rc);
-			return rc;
-		}
-	}
-
-	if (!daos_handle_is_inval(arg->pool.poh) && !arg->pool.slave) {
-		rc = daos_pool_disconnect(arg->pool.poh, NULL /* ev */);
-		arg->pool.poh = DAOS_HDL_INVAL;
-		if (arg->multi_rank) {
-			MPI_Allreduce(&rc, &rc_reduce, 1, MPI_INT, MPI_MIN,
-				      MPI_COMM_WORLD);
-			rc = rc_reduce;
-		}
-		if (rc) {
-			print_message("failed to disconnect pool "DF_UUIDF
-				      ": %d\n", DP_UUID(arg->pool.pool_uuid),
-				      rc);
 			return rc;
 		}
 	}

--- a/utils/bvtest/scripts/DaosRebuild.yml
+++ b/utils/bvtest/scripts/DaosRebuild.yml
@@ -31,7 +31,7 @@ use_daemon:
     name: "DaosServer"
 
 passToConfig:
-    DAOS_TEST_FLAGS: "--rebuild -u subtests=\"0-1\""
+    DAOS_TEST_FLAGS: "--rebuild -u subtests=\"0-5\""
 
 execStrategy:
     - name: "DaosTest"


### PR DESCRIPTION
Shrink rebuild test objects to shrink the rebuild time
for CI VM test.

Change-Id: I4fa00f4ed6e63d2a82b79d0a71703d2c5b7c2dd7
Signed-off-by: Wang Di <di.wang@intel.com>