### PR TITLE
DAOS-2020 control: enable multiprocess mode for spdk

### DIFF
--- a/src/control/server/config_types.go
+++ b/src/control/server/config_types.go
@@ -284,7 +284,7 @@ func newDefaultConfiguration(ext External) configuration {
 		Hyperthreads:   false,
 		NrHugepages:    1024,
 		Path:           "etc/daos_server.yml",
-		NvmeShmID:      0, // currently disabled by default
+		NvmeShmID:      0,
 		ControlLogMask: cLogDebug,
 		ext:            ext,
 	}

--- a/src/control/server/main.go
+++ b/src/control/server/main.go
@@ -203,15 +203,6 @@ func main() {
 		return
 	}
 
-	// Catch signals raised by I/O server.
-	go func() {
-		<-sigchan
-		if err := srv.Process.Kill(); err != nil {
-			log.Errorf("Failed to kill DAOS I/O server: %s", err)
-			return
-		}
-	}()
-
 	extraText, err := CheckReplica(lis, config.AccessPoints, srv)
 	if err != nil {
 		log.Errorf(

--- a/src/control/server/storage_nvme.go
+++ b/src/control/server/storage_nvme.go
@@ -127,6 +127,9 @@ func (n *nvmeStorage) Setup() (err error) {
 	if err = n.spdk.prep(); err != nil {
 		return
 	}
+	if err = n.Discover(); err != nil {
+		return
+	}
 	return
 }
 


### PR DESCRIPTION
Start daos_server as primary and daos_io_server as secondary spdk
processes so hugepage memory can be allocated appropriately between
io_servers.

Use hash of hostname+pid to create a unique shm_id for each host so
multiple spdk applications can access the same NVMe controllers and
hugepage allocations.

Change-Id: I51ce562706404868b0ab945ed1e3778564703eb3
Signed-off-by: Tom Nabarro <tom.nabarro@intel.com>