### PR TITLE
DAOS-2114 vos: Reduce code duplication in evtree

### DIFF
--- a/src/include/daos_srv/evtree.h
+++ b/src/include/daos_srv/evtree.h
@@ -330,23 +330,23 @@ struct evt_context;
  */
 struct evt_policy_ops {
 	/**
-	 * Add an entry \a entry to a tree node \a nd_mmid.
+	 * Add an entry \a entry to a tree node \a node.
 	 */
 	int	(*po_insert)(struct evt_context *tcx,
-			     uint64_t nd_off,
+			     struct evt_node *node,
 			     uint64_t in_off,
 			     const struct evt_entry_in *entry);
 	/**
-	 * move half entries of the current node \a src_mmid to the new
-	 * node \a dst_mmid.
+	 * move half entries of the current node \a nd_src to the new
+	 * node \a nd_dst.
 	 */
 	int	(*po_split)(struct evt_context *tcx, bool leaf,
-			    uint64_t src_off, uint64_t dst_off);
+			    struct evt_node *nd_src, struct evt_node *nd_dst);
 	/** Move adjusted \a entry within a node after mbr update.
 	 * Returns the offset from at to where the entry was moved
 	 */
 	int	(*po_adjust)(struct evt_context *tcx,
-			     uint64_t nd_off,
+			     struct evt_node *node,
 			     struct evt_node_entry *ne, int at);
 	/**
 	 * Calculate weight of a rectangle \a rect and return it to \a weight.

--- a/src/vos/evt_iter.c
+++ b/src/vos/evt_iter.c
@@ -231,7 +231,7 @@ evt_iter_move(struct evt_context *tcx, struct evt_iterator *iter)
 
 	while ((found = evt_move_trace(tcx))) {
 		trace = &tcx->tc_trace[tcx->tc_depth - 1];
-		rect  = evt_node_rect_at(tcx, trace->tr_node, trace->tr_at);
+		rect  = evt_nd_off_rect_at(tcx, trace->tr_node, trace->tr_at);
 
 		if (evt_filter_rect(&iter->it_filter, rect, true))
 			continue;
@@ -488,7 +488,7 @@ int evt_iter_delete(daos_handle_t ih, void *value_out)
 	}
 
 	trace = &tcx->tc_trace[tcx->tc_depth - 1];
-	rect  = evt_node_rect_at(tcx, trace->tr_node, trace->tr_at);
+	rect  = evt_nd_off_rect_at(tcx, trace->tr_node, trace->tr_at);
 	if (!evt_filter_rect(&iter->it_filter, rect, true))
 		goto out;
 
@@ -511,6 +511,7 @@ evt_iter_fetch(daos_handle_t ih, unsigned int *inob, struct evt_entry *entry,
 {
 	struct evt_iterator	*iter;
 	struct evt_context	*tcx;
+	struct evt_node		*node;
 	struct evt_rect		*rect;
 	struct evt_trace	*trace;
 	struct evt_rect		 saved;
@@ -535,10 +536,11 @@ evt_iter_fetch(daos_handle_t ih, unsigned int *inob, struct evt_entry *entry,
 		goto set_anchor;
 	}
 	trace = &tcx->tc_trace[tcx->tc_depth - 1];
-	rect  = evt_node_rect_at(tcx, trace->tr_node, trace->tr_at);
+	node = evt_off2node(tcx, trace->tr_node);
+	rect  = evt_node_rect_at(tcx, node, trace->tr_at);
 
 	if (entry)
-		evt_entry_fill(tcx, trace->tr_node, trace->tr_at, NULL, entry);
+		evt_entry_fill(tcx, node, trace->tr_at, NULL, entry);
 set_anchor:
 	*inob = tcx->tc_inob;
 

--- a/src/vos/evt_priv.h
+++ b/src/vos/evt_priv.h
@@ -356,24 +356,42 @@ bool evt_move_trace(struct evt_context *tcx);
 
 /** Get a pointer to the rectangle corresponding to an index in a tree node
  * \param[IN]	tcx	The evtree context
- * \param[IN]	nd_mmid	The tree node
- * \param[IN]	at	The index in the node
+ * \param[IN]	node	The tree node
+ * \param[IN]	at	The index in the node entry
  *
  * Returns the rectangle at the index
  */
 struct evt_rect *evt_node_rect_at(struct evt_context *tcx,
-				  uint64_t nd_off, unsigned int at);
+				  struct evt_node *node, unsigned int at);
+
+/** Get a pointer to the rectangle corresponding to an index in a tree node
+ * \param[IN]	tcx	The evtree context
+ * \param[IN]	nd_off	The offset of the tree node
+ * \param[IN]	at	The index in the node entry
+ *
+ * Returns the rectangle at the index
+ */
+static inline struct evt_rect *evt_nd_off_rect_at(struct evt_context *tcx,
+						  uint64_t nd_off,
+						  unsigned int at)
+{
+	struct evt_node	*node;
+
+	node = evt_off2node(tcx, nd_off);
+
+	return evt_node_rect_at(tcx, node, at);
+}
 
 /** Fill an evt_entry from the record at an index in a tree node
  * \param[IN]	tcx		The evtree context
- * \param[IN]	nd_mmid		The tree node
+ * \param[IN]	node		The tree node
  * \param[IN]	at		The index in the node
  * \param[IN]	rect_srch	The original rectangle used for the search
  * \param[OUT]	entry		The entry to fill
  *
  * The selected extent will be trimmed by the search rectangle used.
  */
-void evt_entry_fill(struct evt_context *tcx, uint64_t nd_off,
+void evt_entry_fill(struct evt_context *tcx, struct evt_node *node,
 		    unsigned int at, const struct evt_rect *rect_srch,
 		    struct evt_entry *entry);
 #endif /* __EVT_PRIV_H__ */


### PR DESCRIPTION
1. Instead of only using the offset, use the direct evt_node
   pointer where possible to avoid continual lookups
2. Disable DB_TRACE entirely

This doesn't solve all of the performance issues but gets
array performance closer to single value performance.  Average
on my box goes from 23us to 15us with these changes.

Change-Id: I6d58d0126cbf66d2a7e7caf33ea569f97f3961c5
Signed-off-by: Jeff Olivier <jeffrey.v.olivier@intel.com>