### PR TITLE
DAOS-2115 build: Add a preprocess feature to DAOS

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,15 @@
+# clang-format script for daos
+---
+BasedOnStyle: LLVM
+IndentWidth: 8
+UseTab: ForContinuationAndIndentation
+BreakBeforeBraces: Linux
+AllowShortIfStatementsOnASingleLine: false
+IndentCaseLabels: false
+ForEachMacros: ['d_list_for_each_entry', 'd_list_for_each_entry_safe',
+                'evt_ent_array_for_each']
+PointerAlignment: Right
+AlignConsecutiveAssignments: true
+AlignConsecutiveDeclarations: true
+AlignTrailingComments: true
+...

--- a/src/SConscript
+++ b/src/SConscript
@@ -31,11 +31,7 @@ def scons():
     SConscript('common/SConscript')
     SConscript('bio/SConscript')
 
-    # VOS comes with two flavors
-    # A standalone library mostly used for testing
     SConscript('vos/SConscript')
-    VariantDir('vos_srv', 'vos', duplicate=0)
-    SConscript('vos_srv/SConscript')
 
     # Build each DAOS component
     SConscript('rdb/SConscript')

--- a/src/control/SConscript
+++ b/src/control/SConscript
@@ -5,6 +5,21 @@ import os
 from SCons.Script import Literal
 from os.path import join, isdir
 
+def do_build(env, path, gosrc, cmd):
+    """execute a build command"""
+    # Link the version-controlled DAOS Go source directory src/control into
+    # GOPATH/src/REPOPATH/src/control in the build directory.
+    if isdir(path) is False:
+        os.makedirs(path)
+    path += "/control"
+    if isdir(path) is False:
+        os.symlink(gosrc, path)
+    return env.Execute(cmd)
+
+def cmd_build(gopath, repopath, cmd):
+    """create a command that ensure paths exist before execution"""
+    return lambda target, source, env: do_build(env, gopath, repopath, cmd)
+
 def scons():
     """Execute build"""
     Import('env', 'prereqs')
@@ -33,23 +48,17 @@ def scons():
     # Repository path shared by DAOS Go package import paths
     repopath = "github.com/daos-stack/daos"
 
-    # Link the version-controlled DAOS Go source directory src/control into
-    # GOPATH/src/REPOPATH/src/control in the build directory.
-    path = "%s/src/%s/src" % (gopath, repopath)
-    if isdir(path) is False:
-        os.makedirs(path)
-    path += "/control"
-    if isdir(path) is False:
-        os.symlink(gosrc, path)
-
     denv.Append(GOPATH=[gopath])
     denv.AppendENVPath('GOPATH', denv['GOPATH'])
     denv['ENV']['GOBIN'] = "%s/bin" % gopath
 
+    path = "%s/src/%s/src" % (gopath, repopath)
+
     agentbin = "%s/bin/agent" % gopath
     agentsrc = "%s/agent/main.go" % gosrc
     denv.Command(agentbin, agentsrc,
-                 "go install %s/src/control/agent" % repopath)
+                 cmd_build(path, gosrc,
+                           "go install %s/src/control/agent" % repopath))
     denv.InstallAs("$PREFIX/bin/daos_agent", agentbin)
 
     gospdkpath = "%s/vendor/github.com/daos-stack/go-spdk/spdk" % gosrc
@@ -92,18 +101,22 @@ def scons():
     serverbin = "%s/bin/server" % gopath
     serversrc = "%s/server/main.go" % gosrc
     denv.Command(serverbin, [serversrc, nc_installed],
-                 "go install %s/src/control/server" % repopath)
+                 cmd_build(path, gosrc,
+                           "go install %s/src/control/server" % repopath))
     denv.InstallAs("$PREFIX/bin/daos_server", serverbin)
 
     shellbin = "%s/bin/dmg" % gopath
     shellsrc = "%s/dmg/main.go" % gosrc
-    denv.Command(shellbin, shellsrc, "go install %s/src/control/dmg" % repopath)
+    denv.Command(shellbin, shellsrc,
+                 cmd_build(path, gosrc,
+                           "go install %s/src/control/dmg" % repopath))
     denv.InstallAs("$PREFIX/bin/daos_shell", shellbin)
 
     drpcbin = "%s/bin/drpc_test" % gopath
     drpcsrc = "%s/drpc_test/main.go" % gosrc
     denv.Command(drpcbin, drpcsrc,
-                 "go install %s/src/control/drpc_test" % repopath)
+                 cmd_build(path, gosrc,
+                           "go install %s/src/control/drpc_test" % repopath))
     denv.InstallAs("$PREFIX/bin/hello_drpc", drpcbin)
 
     AlwaysBuild([agentbin, serverbin, shellbin, drpcbin])

--- a/src/security/SConscript
+++ b/src/security/SConscript
@@ -13,15 +13,15 @@ def scons():
     # Shared src between server and client
     common_src = denv.SharedObject(['security.pb-c.c'])
 
-    ds_sec = daos_build.library(denv, 'security', ['srv.c','srv_acl.c'])
+    ds_sec = daos_build.library(denv, 'security', ['srv.c', 'srv_acl.c'])
     denv.Install('$PREFIX/lib/daos_srv', ds_sec)
 
     # dc_security: Security Client
     dc_security_tgts = denv.SharedObject(['cli_security.c']) + common_src
     Export('dc_security_tgts')
 
-    dc_sectest_tgts = denv.SharedObject(['cli_security.c',
-    						'srv_acl.c']) + common_src
+    dc_sectest_tgts = denv.SharedObject(['cli_security.c', 'srv_acl.c'],
+                                        OBJPREFIX="s_") + common_src
     Export('dc_sectest_tgts')
 
     SConscript('tests/SConscript', exports='denv')

--- a/src/vos/SConscript
+++ b/src/vos/SConscript
@@ -2,40 +2,52 @@
 import os
 import daos_build
 
+FILES = ["evt_iter.c", "vos_common.c", "vos_iterator.c", "vos_obj.c",
+         "vos_pool.c", "vos_aggregate.c", "vos_container.c", "vos_io.c",
+         "vos_obj_cache.c", "vos_obj_index.c", "vos_tree.c", "evtree.c"]
+
+def build_vos(env, standalone):
+    """build vos"""
+    denv = env.Clone()
+    install = 'lib/daos_srv'
+    libname = 'vos_srv'
+
+    if standalone:
+        denv.Append(CPPDEFINES={'VOS_STANDALONE' : '1'})
+        denv.Append(OBJPREFIX="s_")
+        install = 'lib'
+        libname = 'vos'
+
+    files = FILES
+    if GetOption("preprocess"):
+        #For profileing performance, it can sometimes be useful to preprocess
+        #the files first.   This uses the new scons_local feature to do this
+        #so profiling tools will point at preprocessed file lines.
+        files = denv.Preprocess(FILES)
+
+    vos = daos_build.library(denv, libname, files, LIBS=['vea'])
+    denv.Install('$PREFIX/' + install, vos)
+
 def scons():
     """Execute build"""
     Import('env', 'prereqs')
 
-    build_dir = Dir('.')
-    lib = os.path.basename(build_dir.abspath)
-    env.AppendUnique(LIBPATH=[build_dir])
+    env.AppendUnique(LIBPATH=[Dir('.')])
 
     prereqs.require(env, 'pmdk')
     denv = env.Clone()
 
     # Compiler options
-    denv.Append(CPPPATH=[Dir('../vos').srcnode()])
-
-    if lib == "vos":
-        # generate standalone library
-        denv.Append(CPPDEFINES={'VOS_STANDALONE' : '1'})
-        install = 'lib'
-    else:
-        # generate DAOS server module
-        install = 'lib/daos_srv'
-
-    Export('install')
+    denv.Append(CPPPATH=[Dir('.').srcnode()])
 
     # VEA
     SConscript('vea/SConscript')
     denv.AppendUnique(LIBPATH=['vea'])
 
-    vos = daos_build.library(denv, lib, Glob('*.c'), LIBS=['vea'])
-    denv.Install('$PREFIX/' + install, vos)
+    build_vos(denv, False)
+    build_vos(denv, True)
 
-    # Tests
-    if lib == "vos":
-        SConscript('tests/SConscript', exports='denv')
+    SConscript('tests/SConscript', exports='denv')
 
 if __name__ == "SCons.Script":
     scons()

--- a/src/vos/vea/SConscript
+++ b/src/vos/vea/SConscript
@@ -2,13 +2,11 @@
 def scons():
     """Execute build"""
     Import('env')
-    Import('install')
 
     denv = env.Clone()
     denv.Library('vea', Glob('*.c'), LIBS=['daos_common', 'gurt'])
 
-    if install == "lib":
-        SConscript('tests/SConscript', exports='denv')
+    SConscript('tests/SConscript', exports='denv')
 
 if __name__ == "SCons.Script":
     scons()


### PR DESCRIPTION
Recently, for rpc handlers, I added a Preprocess builder to
scons_local.   I've also been doing performance analysis on
DAOS and realized we have a lot of macros in our code and
it can be helpful to do profiling on preprocessed code.

1. Updates scons_local to get new feature
2. Simplifies vos build to get rid of multiple SConscript
   reads and rather just build both libraries in one pass
3. Add --preprocess option to daos SConstruct.  Default is
   off as we really only want to use this interactively
4. Enable the option in vos
5. Add a new option to daos_perf to pause before start to
   give opportunity to attach a profiler
6. Add .clang-format file which allows preprocess builder
   to use clang-format to pretty up the file, quasi
   matching our code guidelines.  This file must be in
   daos root for this to work.

This all will be useful for further tuning of vos (and
eventually can be applied elsewhere).

Change-Id: I33d3064c077f35dd9d85e25a7992c2216357d2fd
Signed-off-by: Jeff Olivier <jeffrey.v.olivier@intel.com>