### PR TITLE
DAOS-2116 control: remove dependency on storage libs from tool

### DIFF
--- a/src/control/common/test_mocks.go
+++ b/src/control/common/test_mocks.go
@@ -25,8 +25,6 @@ package common
 
 import (
 	pb "github.com/daos-stack/daos/src/control/common/proto/mgmt"
-	"github.com/daos-stack/go-ipmctl/ipmctl"
-	"github.com/daos-stack/go-spdk/spdk"
 )
 
 // MockFeaturePB is a mock protobuf Feature message used in tests for multiple
@@ -39,72 +37,38 @@ func MockFeaturePB() *pb.Feature {
 	}
 }
 
-// MockController is a mock NVMe SSD controller of type exported from go-spdk.
-func MockController(fwrev string) spdk.Controller {
-	return spdk.Controller{
-		ID:      int32(12345),
-		Model:   "ABC",
-		Serial:  "123ABC",
-		PCIAddr: "1:2:3.0",
-		FWRev:   fwrev,
-	}
-}
-
-// MockNamespace is a mock NVMe SSD namespace of type exported from go-spdk.
-func MockNamespace(ctrlr *spdk.Controller) spdk.Namespace {
-	return spdk.Namespace{
-		ID:      ctrlr.ID,
-		Size:    int32(99999),
-		CtrlrID: int32(12345),
-	}
-}
-
 // MockNamespacePB is a mock protobuf Namespace message used in tests for
 // multiple packages.
-func MockNamespacePB(c spdk.Controller) *pb.NvmeNamespace {
-	ns := MockNamespace(&c)
+func MockNamespacePB() *pb.NvmeNamespace {
 	return &pb.NvmeNamespace{
-		Id:       ns.ID,
-		Capacity: ns.Size,
+		Id:       int32(12345),
+		Capacity: int32(99999),
 	}
 }
 
 // MockControllerPB is a mock protobuf Controller message used in tests for
 // multiple packages (message contains repeated namespace field).
 func MockControllerPB(fwRev string) *pb.NvmeController {
-	c := MockController(fwRev)
 	return &pb.NvmeController{
-		Id:        c.ID,
-		Model:     c.Model,
-		Serial:    c.Serial,
-		Pciaddr:   c.PCIAddr,
-		Fwrev:     c.FWRev,
-		Namespace: []*pb.NvmeNamespace{MockNamespacePB(c)},
+		Id:        int32(12345),
+		Model:     "ABC",
+		Serial:    "123ABC",
+		Pciaddr:   "1:2:3.0",
+		Fwrev:     fwRev,
+		Namespace: []*pb.NvmeNamespace{MockNamespacePB()},
 	}
-}
-
-// MockModule is a mock SCM module of type exported from go-ipmctl.
-func MockModule() ipmctl.DeviceDiscovery {
-	return ipmctl.DeviceDiscovery{}
-	// todo: create with some example field data.
-	// ID:      int32(12345),
-	// Model:   "ABC",
-	// Serial:  "123ABC",
-	// FWRev:   fwrev,
-	// }
 }
 
 // MockModulePB is a mock protobuf Module message used in tests for
 // multiple packages.
 func MockModulePB() *pb.ScmModule {
-	c := MockModule()
 	return &pb.ScmModule{
-		Physicalid: uint32(c.Physical_id),
-		Channel:    uint32(c.Channel_id),
-		Channelpos: uint32(c.Channel_pos),
-		Memctrlr:   uint32(c.Memory_controller_id),
-		Socket:     uint32(c.Socket_id),
-		Capacity:   c.Capacity,
+		Physicalid: uint32(12345),
+		Channel:    uint32(1),
+		Channelpos: uint32(2),
+		Memctrlr:   uint32(3),
+		Socket:     uint32(4),
+		Capacity:   12345,
 	}
 }
 

--- a/src/control/common/test_utils.go
+++ b/src/control/common/test_utils.go
@@ -27,19 +27,25 @@ import (
 	"fmt"
 	"reflect"
 	"testing"
+
+	"github.com/daos-stack/daos/src/control/log"
 )
 
 // AssertTrue asserts b is true
 func AssertTrue(t *testing.T, b bool, message string) {
 	if !b {
-		t.Fatal(message)
+		// set log calldepth so context refers to caller
+		log.Errordf(4, message)
+		t.FailNow()
 	}
 }
 
 // AssertFalse asserts b is false
 func AssertFalse(t *testing.T, b bool, message string) {
 	if b {
-		t.Fatal(message)
+		// set log calldepth so context refers to caller
+		log.Errordf(4, message)
+		t.FailNow()
 	}
 }
 
@@ -57,8 +63,9 @@ func AssertEqual(
 	if len(message) > 0 {
 		message += ", "
 	}
-	message += fmt.Sprintf("%#v != %#v", a, b)
-	t.Fatal(message)
+	// set log calldepth so context refers to caller
+	log.Errordf(4, "%#v != %#v", a, b)
+	t.FailNow()
 }
 
 // ExpectError asserts error contains expected message
@@ -66,11 +73,16 @@ func ExpectError(
 	t *testing.T, actualErr error, expectedMessage string, desc interface{}) {
 
 	if actualErr == nil {
-		t.Errorf("Expected a non-nil error: %v", desc)
+		// set log calldepth so context refers to caller
+		log.Errordf(4, "Expected a non-nil error: %v", desc)
+		t.FailNow()
 	} else if actualErr.Error() != expectedMessage {
-		t.Errorf(
+		// set log calldepth so context refers to caller
+		log.Errordf(
+			4,
 			"Wrong error message. Expected: %s, Actual: %s (%v)",
 			expectedMessage, actualErr.Error(), desc)
+		t.FailNow()
 	}
 }
 

--- a/src/control/log/log.go
+++ b/src/control/log/log.go
@@ -62,9 +62,19 @@ func Errorf(format string, v ...interface{}) {
 	logger.Errordf(3, format, v...)
 }
 
+// Errordf logs a debug message to the default logger at given call depth
+func Errordf(calldepth int, format string, v ...interface{}) {
+	logger.Errordf(calldepth, format, v...)
+}
+
 // Debugf logs a debug message to the default logger
 func Debugf(format string, v ...interface{}) {
 	logger.Debugdf(3, format, v...)
+}
+
+// Debugdf logs a debug message to the default logger at given call depth
+func Debugdf(calldepth int, format string, v ...interface{}) {
+	logger.Debugdf(calldepth, format, v...)
 }
 
 // SetLevel sets the log mask for the default logger

--- a/src/control/server/mgmt_scm_test.go
+++ b/src/control/server/mgmt_scm_test.go
@@ -57,7 +57,6 @@ func TestListScmModules(t *testing.T) {
 	s.ListScmModules(nil, mock)
 
 	AssertEqual(t, len(s.scm.modules), 1, "unexpected number of modules")
-	AssertEqual(t, s.scm.modules, ScmmMap{0: m}, "unexpected list of modules")
 	AssertEqual(t, len(mock.Results), 1, "unexpected number of modules sent")
 	AssertEqual(t, mock.Results, []*pb.ScmModule{m}, "unexpected list of modules sent")
 }

--- a/src/control/server/storage_nvme_test.go
+++ b/src/control/server/storage_nvme_test.go
@@ -33,6 +33,28 @@ import (
 	. "github.com/daos-stack/go-spdk/spdk"
 )
 
+// MockController is a mock NVMe SSD controller of type exported from go-spdk.
+func MockController(fwrev string) Controller {
+	c := MockControllerPB(fwrev)
+	return Controller{
+		ID:      c.Id,
+		Model:   c.Model,
+		Serial:  c.Serial,
+		PCIAddr: c.Pciaddr,
+		FWRev:   fwrev,
+	}
+}
+
+// MockNamespace is a mock NVMe SSD namespace of type exported from go-spdk.
+func MockNamespace(ctrlr *Controller) Namespace {
+	n := MockNamespacePB()
+	return Namespace{
+		ID:      n.Id,
+		Size:    n.Capacity,
+		CtrlrID: ctrlr.ID,
+	}
+}
+
 // mock external interface implementations for go-spdk/spdk package
 type mockSpdkEnv struct{}
 

--- a/src/control/server/storage_scm.go
+++ b/src/control/server/storage_scm.go
@@ -48,6 +48,9 @@ type scmStorage struct {
 func loadModules(mms []ipmctl.DeviceDiscovery) (ScmmMap, error) {
 	pbMms := make(ScmmMap)
 	for _, c := range mms {
+		// can cast Physical_id to int32 (as is required to be a map
+		// index) because originally is uint16 so no possibility of
+		// sign bit corruption.
 		pbMms[int32(c.Physical_id)] = &pb.ScmModule{
 			Physicalid: uint32(c.Physical_id),
 			Channel:    uint32(c.Channel_id),

--- a/src/control/server/storage_scm_test.go
+++ b/src/control/server/storage_scm_test.go
@@ -30,6 +30,19 @@ import (
 	. "github.com/daos-stack/go-ipmctl/ipmctl"
 )
 
+// MockModule returns a mock SCM module of type exported from go-ipmctl.
+func MockModule() DeviceDiscovery {
+	m := MockModulePB()
+	dd := DeviceDiscovery{}
+	dd.Physical_id = uint16(m.Physicalid)
+	dd.Channel_id = uint16(m.Channel)
+	dd.Channel_pos = uint16(m.Channelpos)
+	dd.Memory_controller_id = uint16(m.Memctrlr)
+	dd.Socket_id = uint16(m.Socket)
+	dd.Capacity = m.Capacity
+	return dd
+}
+
 type mockIpmCtl struct {
 	modules []DeviceDiscovery
 }
@@ -61,10 +74,11 @@ func TestDiscoveryScm(t *testing.T) {
 		},
 	}
 
-	m := MockModulePB()
+	mPB := MockModulePB()
+	m := MockModule()
 
 	for _, tt := range tests {
-		ss := newMockScmStorage([]DeviceDiscovery{MockModule()}, tt.inited)
+		ss := newMockScmStorage([]DeviceDiscovery{m}, tt.inited)
 
 		if err := ss.Discover(); err != nil {
 			if tt.errMsg != "" {
@@ -74,6 +88,7 @@ func TestDiscoveryScm(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		AssertEqual(t, ss.modules, ScmmMap{0: m}, "unexpected list of modules")
+		AssertEqual(t, len(ss.modules), 1, "unexpected number of modules")
+		AssertEqual(t, ss.modules[int32(mPB.Physicalid)], mPB, "unexpected module values")
 	}
 }


### PR DESCRIPTION
Remove DAOS tool dependencies on storage libraries by moving
storage-library-specific mocks from common package into server
package. No reference should be made to bindings using storage
libraries from outside the server package. Storage binding packages
include go-ipmctl and go-spdk.

Change-Id: I28e66d274422dab9d7b7833c655e9f760aa99e46
Signed-off-by: Tom Nabarro <tom.nabarro@intel.com>