### PR TITLE
DAOS-657 drpc: Move drpc modules to their own file

### DIFF
--- a/src/include/daos/drpc.h
+++ b/src/include/daos/drpc.h
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright 2018 Intel Corporation.
+ * (C) Copyright 2018-2019 Intel Corporation.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -61,22 +61,6 @@ struct drpc {
 
 enum rpcflags {
 	R_SYNC = 1
-};
-
-/**
- * DAOS dRPC Modules
- *
- * dRPC modules are used to multiplex communications over the Unix Domain Socket
- * to appropriate handlers. They are populated in the Drpc__Call structure.
- *
- * dRPC module IDs must be unique. This is a list of all DAOS dRPC modules.
- */
-
-enum drpc_module {
-	DRPC_MODULE_TEST		= 0,	/* Reserved for testing */
-	DRPC_MODULE_SECURITY_AGENT	= 1,
-
-	NUM_DRPC_MODULES			/* Must be last */
 };
 
 int drpc_call(struct drpc *ctx, int flags, Drpc__Call *msg,

--- a/src/include/daos/drpc_modules.h
+++ b/src/include/daos/drpc_modules.h
@@ -1,0 +1,43 @@
+/*
+ * (C) Copyright 2019 Intel Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * GOVERNMENT LICENSE RIGHTS-OPEN SOURCE SOFTWARE
+ * The Government's rights to use, modify, reproduce, release, perform, display,
+ * or disclose this software are subject to the terms of the Apache License as
+ * provided in Contract No. 8F-30005.
+ * Any reproduction of computer software, computer software documentation, or
+ * portions thereof marked with this legend must also reproduce the markings.
+ */
+
+#ifndef __DAOS_DRPC_MODULES_H__
+#define __DAOS_DRPC_MODULES_H__
+
+/**
+ * DAOS dRPC Modules
+ *
+ * dRPC modules are used to multiplex communications over the Unix Domain Socket
+ * to appropriate handlers. They are populated in the Drpc__Call structure.
+ *
+ * dRPC module IDs must be unique. This is a list of all DAOS dRPC modules.
+ */
+
+enum drpc_module {
+	DRPC_MODULE_TEST		= 0,	/* Reserved for testing */
+	DRPC_MODULE_SECURITY_AGENT	= 1,
+
+	NUM_DRPC_MODULES			/* Must be last */
+};
+
+#endif /* __DAOS_DRPC_MODULES_H__ */

--- a/src/iosrv/drpc_handler.c
+++ b/src/iosrv/drpc_handler.c
@@ -22,6 +22,7 @@
  */
 
 #include "drpc_handler.h"
+#include <daos/drpc_modules.h>
 
 static drpc_handler_t *registry_table;
 

--- a/src/iosrv/tests/drpc_handler_tests.c
+++ b/src/iosrv/tests/drpc_handler_tests.c
@@ -31,7 +31,7 @@
 #include <cmocka.h>
 
 #include <daos/drpc.pb-c.h>
-#include <daos/drpc.h>
+#include <daos/drpc_modules.h>
 #include <daos/test_mocks.h>
 #include <daos/test_utils.h>
 #include "../drpc_handler.h"

--- a/src/security/cli_security.c
+++ b/src/security/cli_security.c
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright 2018 Intel Corporation.
+ * (C) Copyright 2018-2019 Intel Corporation.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,6 +26,7 @@
 #include <gurt/common.h>
 #include <daos_errno.h>
 #include <daos/drpc.h>
+#include <daos/drpc_modules.h>
 #include <daos/drpc.pb-c.h>
 #include <daos/agent.h>
 #include <daos/security.h>

--- a/src/security/tests/cli_security_tests.c
+++ b/src/security/tests/cli_security_tests.c
@@ -33,6 +33,7 @@
 #include <daos_errno.h>
 #include <daos/common.h>
 #include <daos/drpc.h>
+#include <daos/drpc_modules.h>
 #include <daos/drpc.pb-c.h>
 #include <daos/agent.h>
 #include <daos/security.h>


### PR DESCRIPTION
The dRPC module list will be shared with Go code. To
avoid cascades of unneeded includes on the Go side,
modules are defined in their own header.

Change-Id: I50be78191f10ff369c4cceedda424d4b01a007d4
Signed-off-by: Kris Jacque <kristin.jacque@intel.com>