### PR TITLE
DAOS-2139 daos_perf: Fix array offset to not overlap with other recxs

### DIFF
--- a/src/tests/daos_perf.c
+++ b/src/tests/daos_perf.c
@@ -223,7 +223,7 @@ update_or_fetch_internal(char *dkey, char *akey, daos_epoch_t *epoch,
 		iod->iod_type = DAOS_IOD_ARRAY;
 		iod->iod_size = 1;
 		recx->rx_nr  = vsize;
-		recx->rx_idx = ts_overwrite ? 0 : indices[idx];
+		recx->rx_idx = ts_overwrite ? 0 : indices[idx] * vsize;
 	}
 
 	iod->iod_nr    = 1;


### PR DESCRIPTION
Change-Id: I73c25e95b9aef2189f8d3e426d14e314b3f7867c
Signed-off-by: Mohamad Chaarawi <mohamad.chaarawi@intel.com>