### PR TITLE
DAOS-2146 test: DaosCoreTest broken by cleanup patch

### DIFF
--- a/src/tests/ftest/daos_test/DaosCoreTest.py
+++ b/src/tests/ftest/daos_test/DaosCoreTest.py
@@ -110,7 +110,7 @@ class DaosCoreTest(Test):
                                                 subtest, args)
 
         env = {}
-        env['CMOCKA_XML_FILE'] = self.tmp + "/%g_results.xml"
+        env['CMOCKA_XML_FILE'] = self.workdir + "/%g_results.xml"
         env['CMOCKA_MESSAGE_OUTPUT'] = "xml"
 
         try:
@@ -118,7 +118,7 @@ class DaosCoreTest(Test):
         except process.CmdError as result:
             if result.result.exit_status is not 0:
                 # fake a JUnit failure output
-                with open(self.tmp + "/" + self.subtest_name +
+                with open(self.workdir + "/" + self.subtest_name +
                           "_results.xml", "w") as results_xml:
                     results_xml.write('''<?xml version="1.0" encoding="UTF-8"?>
 <testsuite name="{0}" errors="1" failures="0" skipped="0" tests="1" time="0.0">


### PR DESCRIPTION
DaosCoreTest was broken by cleaning up usage of self.tmp and
switching to using self.workdir. There was one instance in
DaosCoreTest.py that still referenced self.tmp.

Change-Id: I06c01c4b130cfa8e89b81a46eb17c141f5704fc4
Signed-off-by: Stephen Willson <stephen.d.willson@intel.com>