### PR TITLE
DAOS-2077 test: implement daos agent launch + cleanup in tests

### DIFF
--- a/ftest.sh
+++ b/ftest.sh
@@ -119,6 +119,16 @@ if [ \"\${HOSTNAME%%%%.*}\" != \"${nodes[0]}\" ]; then
             sudo mkdir -p /mnt/daos
         fi
     fi
+
+    # make sure to set up for daos_agent
+    current_username=\$(whoami)
+    sudo mkdir /var/run/daos_agent
+    sudo mkdir /var/run/daos_server
+    sudo chown \${current_username} -R /var/run/daos_agent
+    sudo chown \${current_username} -R /var/run/daos_server
+    sudo chmod u+w /var/run/daos_agent
+    sudo chmod u+w /var/run/daos_server
+
     sudo ed <<EOF /etc/fstab
 \\\$a
 tmpfs /mnt/daos tmpfs rw,relatime,size=16777216k 0 0 # added by ftest.sh

--- a/src/tests/ftest/container/Attribute.py
+++ b/src/tests/ftest/container/Attribute.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python
 '''
-  (C) Copyright 2018 Intel Corporation.
+  (C) Copyright 2018-2019 Intel Corporation.
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
@@ -37,6 +37,7 @@ sys.path.append('../../../utils/py')
 sys.path.append('./../../utils/py')
 import ServerUtils
 import WriteHostFile
+import AgentUtils
 from GeneralUtils import DaosTestError
 
 from daos_api import DaosContext, DaosPool, DaosContainer, DaosApiError
@@ -100,6 +101,7 @@ class ContainerAttributeTest(Test):
         self.hostlist = self.params.get("test_machines", '/run/hosts/*')
         self.hostfile = WriteHostFile.WriteHostFile(self.hostlist, self.workdir)
 
+        AgentUtils.run_agent(basepath, self.hostlist)
         ServerUtils.runServer(self.hostfile, server_group, basepath)
 
         self.pool = DaosPool(self.Context)
@@ -120,6 +122,7 @@ class ContainerAttributeTest(Test):
             if self.container:
                 self.container.close()
         finally:
+            AgentUtils.stop_agent(self.hostlist)
             ServerUtils.stopServer(hosts=self.hostlist)
 
     def create_data_set(self):

--- a/src/tests/ftest/container/BasicTxTest.py
+++ b/src/tests/ftest/container/BasicTxTest.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python
 '''
-  (C) Copyright 2018 Intel Corporation.
+  (C) Copyright 2018-2019 Intel Corporation.
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
@@ -35,6 +35,7 @@ sys.path.append('./../../utils/py')
 
 import ServerUtils
 import WriteHostFile
+import AgentUtils
 from conversion import c_uuid_to_str
 from daos_api import DaosContext, DaosPool, DaosContainer, DaosApiError
 
@@ -62,12 +63,14 @@ class BasicTxTest(Test):
         self.hostlist = self.params.get("test_machines",'/run/hosts/*')
         self.hostfile = WriteHostFile.WriteHostFile(self.hostlist, self.workdir)
 
+        AgentUtils.run_agent(self.basepath, self.hostlist)
         ServerUtils.runServer(self.hostfile, self.server_group, self.basepath)
 
         # give it time to start
         time.sleep(2)
 
     def tearDown(self):
+        AgentUtils.stop_agent(self.hostlist)
         ServerUtils.stopServer(hosts=self.hostlist)
 
     def test_tx_basics(self):

--- a/src/tests/ftest/container/ContainerAsync.py
+++ b/src/tests/ftest/container/ContainerAsync.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python
 '''
-    (C) Copyright 2018 Intel Corporation.
+    (C) Copyright 2018-2019 Intel Corporation.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -38,6 +38,7 @@ sys.path.append('../util')
 sys.path.append('../../../utils/py')
 sys.path.append('./../../utils/py')
 
+import AgentUtils
 import ServerUtils
 import WriteHostFile
 import daos_api
@@ -79,6 +80,7 @@ class ContainerAsync(Test):
         self.hostfile = WriteHostFile.WriteHostFile(self.hostlist, self.workdir)
         print("Host file is: {}".format(self.hostfile))
 
+        AgentUtils.run_agent(self.basepath, self.hostlist)
         ServerUtils.runServer(self.hostfile, self.server_group, self.basepath)
         time.sleep(10)
 
@@ -87,6 +89,7 @@ class ContainerAsync(Test):
             if self.pool is not None and self.pool.attached:
                 self.pool.destroy(1)
         finally:
+            AgentUtils.stop_agent(self.hostlist)
             time.sleep(5)
             ServerUtils.stopServer(hosts=self.hostlist)
 

--- a/src/tests/ftest/container/Create.py
+++ b/src/tests/ftest/container/Create.py
@@ -36,6 +36,7 @@ sys.path.append('./util')
 sys.path.append('../util')
 sys.path.append('../../../utils/py')
 sys.path.append('./../../utils/py')
+import AgentUtils
 import ServerUtils
 import WriteHostFile
 from daos_api import DaosContext, DaosPool, DaosContainer, DaosApiError
@@ -60,9 +61,11 @@ class CreateContainerTest(Test):
        self.hostlist = self.params.get("test_machines",'/run/hosts/*')
        hostfile = WriteHostFile.WriteHostFile(self.hostlist, self.workdir)
 
+       AgentUtils.run_agent(self.basepath, self.hostlist)
        ServerUtils.runServer(hostfile, self.server_group, self.basepath)
 
     def tearDown(self):
+        AgentUtils.stop_agent(self.hostlist)
         ServerUtils.stopServer(None, self.hostlist)
 
     def test_container_create(self):

--- a/src/tests/ftest/container/Delete.py
+++ b/src/tests/ftest/container/Delete.py
@@ -35,6 +35,7 @@ sys.path.append('../../../utils/py')
 sys.path.append('./../../utils/py')
 
 import daos_api
+import AgentUtils
 import ServerUtils
 import WriteHostFile
 from avocado import Test, main
@@ -70,9 +71,12 @@ class DeleteContainerTest(Test):
         self.d_log = DaosLog(self.context)
         self.hostlist = self.params.get("test_machines",'/run/hosts/*')
         self.hostfile = WriteHostFile.WriteHostFile(self.hostlist, self.workdir)
+
+        AgentUtils.run_agent(self.basepath, self.hostlist)
         ServerUtils.runServer(self.hostfile, self.server_group, self.basepath)
 
     def tearDown(self):
+        AgentUtils.stop_agent(self.hostlist)
         ServerUtils.stopServer(hosts=self.hostlist)
 
     def test_container_delete(self):

--- a/src/tests/ftest/container/FullPoolContainerCreate.py
+++ b/src/tests/ftest/container/FullPoolContainerCreate.py
@@ -1,5 +1,5 @@
 """
-  (C) Copyright 2018 Intel Corporation.
+  (C) Copyright 2018-2019 Intel Corporation.
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
@@ -35,6 +35,7 @@ sys.path.append('./util')
 sys.path.append('../util')
 sys.path.append('../../../utils/py')
 sys.path.append('./../../utils/py')
+import AgentUtils
 import ServerUtils
 import CheckForPool
 import WriteHostFile
@@ -62,6 +63,8 @@ class FullPoolContainerCreate(Test):
         self.d_log = DaosLog(self.context)
         self.hostlist = self.params.get("test_machines1", '/hosts/')
         self.hostfile = WriteHostFile.WriteHostFile(self.hostlist, self.workdir)
+
+        AgentUtils.run_agent(self.basepath, self.hostlist)
         ServerUtils.runServer(self.hostfile, self.server_group, self.basepath)
 
     def tearDown(self):
@@ -73,6 +76,7 @@ class FullPoolContainerCreate(Test):
         try:
             self.pool.destroy(1)
         finally:
+            AgentUtils.stop_agent(self.hostlist)
             ServerUtils.stopServer(hosts=self.hostlist)
 
     def test_no_space_cont_create(self):

--- a/src/tests/ftest/container/GlobalHandle.py
+++ b/src/tests/ftest/container/GlobalHandle.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python
 '''
-  (C) Copyright 2018 Intel Corporation.
+  (C) Copyright 2018-2019 Intel Corporation.
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
@@ -36,6 +36,7 @@ sys.path.append('./util')
 sys.path.append('../util')
 sys.path.append('../../../utils/py')
 sys.path.append('./../../utils/py')
+import AgentUtils
 import ServerUtils
 import WriteHostFile
 import CheckForPool
@@ -124,12 +125,14 @@ class GlobalHandle(Test):
         self.hostlist = self.params.get("test_machines",'/run/hosts/')
         self.hostfile = WriteHostFile.WriteHostFile(self.hostlist, tmp)
 
+        AgentUtils.run_agent(basepath, self.hostlist)
         ServerUtils.runServer(self.hostfile, server_group, basepath)
 
     def tearDown(self):
         try:
             os.remove(self.hostfile)
         finally:
+            AgentUtils.stop_agent(self.hostlist)
             ServerUtils.stopServer(hosts=self.hostlist)
 
         # really make sure everything is gone

--- a/src/tests/ftest/container/Open.py
+++ b/src/tests/ftest/container/Open.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python
 '''
-  (C) Copyright 2018 Intel Corporation.
+  (C) Copyright 2018-2019 Intel Corporation.
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
@@ -37,6 +37,7 @@ sys.path.append('./util')
 sys.path.append('../util')
 sys.path.append('../../../utils/py')
 sys.path.append('./../../utils/py')
+import AgentUtils
 import ServerUtils
 import WriteHostFile
 
@@ -85,6 +86,7 @@ class OpenContainerTest(Test):
         self.createuid2  = self.params.get("uid",'/run/createtests/createuid2/')
         self.creategid2  = self.params.get("gid",'/run/createtests/creategid2/')
 
+        AgentUtils.run_agent(self.basepath, self.hostlist)
         ServerUtils.runServer(self.hostfile, self.server_group, self.basepath)
 
     def tearDown(self):
@@ -98,6 +100,7 @@ class OpenContainerTest(Test):
             if self.POOL2 is not None and self.POOL2.attached:
                 self.POOL2.destroy(1)
         finally:
+            AgentUtils.stop_agent(self.hostlist)
             ServerUtils.stopServer(hosts=self.hostlist)
 
     def test_container_open(self):

--- a/src/tests/ftest/container/OpenClose.py
+++ b/src/tests/ftest/container/OpenClose.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python
 '''
-    (C) Copyright 2018 Intel Corporation.
+    (C) Copyright 2018-2019 Intel Corporation.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -34,6 +34,7 @@ sys.path.append('./util')
 sys.path.append('../util')
 sys.path.append('../../../utils/py')
 sys.path.append('./../../utils/py')
+import AgentUtils
 import ServerUtils
 import WriteHostFile
 import daos_api
@@ -61,6 +62,7 @@ class OpenClose(Test):
 
         self.hostfile = WriteHostFile.WriteHostFile(self.hostlist, self.workdir)
 
+        AgentUtils.run_agent(self.basepath, self.hostlist)
         ServerUtils.runServer(self.hostfile, self.server_group, self.basepath)
 
     def tearDown(self):
@@ -69,6 +71,7 @@ class OpenClose(Test):
                 self.pool.destroy(1)
         finally:
             try:
+                AgentUtils.stop_agent(self.hostlist)
                 ServerUtils.stopServer(hosts=self.hostlist)
             except ServerFailed as e:
                 pass

--- a/src/tests/ftest/container/SimpleCreateDeleteTest.py
+++ b/src/tests/ftest/container/SimpleCreateDeleteTest.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python
 '''
-  (C) Copyright 2017 Intel Corporation.
+  (C) Copyright 2017-2019 Intel Corporation.
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
@@ -34,6 +34,7 @@ sys.path.append('../util')
 sys.path.append('../../../utils/py')
 sys.path.append('./../../utils/py')
 
+import AgentUtils
 import ServerUtils
 import WriteHostFile
 from daos_api import DaosContext, DaosPool, DaosContainer, DaosApiError
@@ -72,6 +73,7 @@ class SimpleCreateDeleteTest(Test):
             hostlist = self.params.get("test_machines",'/run/hosts/*')
             hostfile = WriteHostFile.WriteHostFile(hostlist, self.workdir)
 
+            AgentUtils.run_agent(self.basepath, hostlist)
             ServerUtils.runServer(hostfile, self.server_group, self.basepath)
 
             # give it time to start
@@ -126,6 +128,7 @@ class SimpleCreateDeleteTest(Test):
                 pool.disconnect()
                 pool.destroy(1)
 
+            AgentUtils.stop_agent(hostlist)
             ServerUtils.stopServer(hosts=hostlist)
 
 if __name__ == "__main__":

--- a/src/tests/ftest/daos_test/DaosCoreTest.py
+++ b/src/tests/ftest/daos_test/DaosCoreTest.py
@@ -35,6 +35,7 @@ sys.path.append('../util')
 sys.path.append('../../../utils/py')
 sys.path.append('./../../utils/py')
 # pylint: disable=wrong-import-position,import-error
+import AgentUtils
 import ServerUtils
 import WriteHostFile
 # pylint: enable=wrong-import-position,import-error
@@ -60,11 +61,13 @@ class DaosCoreTest(Test):
         self.daos_test = self.basepath + '/install/bin/daos_test'
         self.orterun = self.basepath + '/install/bin/orterun'
         self.hostlist = self.params.get("test_machines", '/run/hosts/*')
-
         self.hostfile = WriteHostFile.WriteHostFile(self.hostlist, self.workdir)
+
+        AgentUtils.run_agent(self.basepath, self.hostlist)
         ServerUtils.runServer(self.hostfile, self.server_group, self.basepath)
 
     def tearDown(self):
+        AgentUtils.stop_agent(self.hostlist)
         ServerUtils.stopServer(hosts=self.hostlist)
 
         # collect up a debug log so that we have a separate one for each

--- a/src/tests/ftest/io/EightServers.py
+++ b/src/tests/ftest/io/EightServers.py
@@ -31,6 +31,7 @@ sys.path.append('./util')
 sys.path.append('../util')
 sys.path.append('../../../utils/py')
 sys.path.append('./../../utils/py')
+import AgentUtils
 import ServerUtils
 import WriteHostFile
 import IorUtils
@@ -54,7 +55,7 @@ class EightServers(Test):
         self.slots = None
         self.hostlist_servers = None
         self.hostfile_servers = None
-        hostlist_clients = None
+        self.hostlist_clients = None
         self.hostfile_clients = None
 
     def setUp(self):
@@ -72,11 +73,12 @@ class EightServers(Test):
         self.hostfile_servers = WriteHostFile.WriteHostFile(self.hostlist_servers, self.workdir)
         print("Host file servers is: {}".format(self.hostfile_servers))
 
-        hostlist_clients = self.params.get("test_clients", '/run/hosts/test_machines/*')
+        self.hostlist_clients = self.params.get("test_clients", '/run/hosts/test_machines/*')
         self.slots = self.params.get("slots", '/run/ior/clientslots/*')
-        self.hostfile_clients = WriteHostFile.WriteHostFile(hostlist_clients, self.workdir, self.slots)
+        self.hostfile_clients = WriteHostFile.WriteHostFile(self.hostlist_clients, self.workdir, self.slots)
         print("Host file clients is: {}".format(self.hostfile_clients))
 
+        AgentUtils.run_agent(self.basepath, self.hostlist_servers, self.hostlist_clients)
         ServerUtils.runServer(self.hostfile_servers, self.server_group, self.basepath)
 
         if not distutils.spawn.find_executable("ior") and \
@@ -88,6 +90,7 @@ class EightServers(Test):
             if self.pool is not None and self.pool.attached:
                 self.pool.destroy(1)
         finally:
+            AgentUtils.stop_agent(self.hostlist_clients)
             ServerUtils.stopServer(hosts=self.hostlist_servers)
 
     def executable(self, iorflags=None):

--- a/src/tests/ftest/io/IorSingleServer.py
+++ b/src/tests/ftest/io/IorSingleServer.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python
 '''
-    (C) Copyright 2018 Intel Corporation.
+    (C) Copyright 2018-2019 Intel Corporation.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -32,6 +32,7 @@ sys.path.append('./util')
 sys.path.append('../util')
 sys.path.append('../../../utils/py')
 sys.path.append('./../../utils/py')
+import AgentUtils
 import ServerUtils
 import WriteHostFile
 import IorUtils
@@ -63,6 +64,7 @@ class IorSingleServer(Test):
         self.hostfile_clients = WriteHostFile.WriteHostFile(self.hostlist_clients, self.workdir)
         print("Host file clientsis: {}".format(self.hostfile_clients))
 
+        AgentUtils.run_agent(self.basepath, self.hostlist_servers, self.hostlist_clients)
         ServerUtils.runServer(self.hostfile_servers, self.server_group, self.basepath)
 
         if int(str(self.name).split("-")[0]) == 1:
@@ -77,6 +79,7 @@ class IorSingleServer(Test):
             if self.POOL is not None and self.POOL.attached:
                 self.POOL.destroy(1)
         finally:
+            AgentUtils.stop_agent(self.hostlist_clients)
             ServerUtils.stopServer(hosts=self.hostlist_servers)
 
     def test_singleserver(self):

--- a/src/tests/ftest/io/MultipleClients.py
+++ b/src/tests/ftest/io/MultipleClients.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python
 '''
-    (C) Copyright 2018 Intel Corporation.
+    (C) Copyright 2018-2019 Intel Corporation.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -31,6 +31,7 @@ sys.path.append('./util')
 sys.path.append('../util')
 sys.path.append('../../../utils/py')
 sys.path.append('./../../utils/py')
+import AgentUtils
 import ServerUtils
 import WriteHostFile
 import IorUtils
@@ -62,6 +63,7 @@ class MultipleClients(Test):
         self.hostfile_clients = WriteHostFile.WriteHostFile(self.hostlist_clients, self.workdir)
         print("Host file clientsis: {}".format(self.hostfile_clients))
 
+        AgentUtils.run_agent(self.basepath, self.hostlist_servers, self.hostlist_clients)
         ServerUtils.runServer(self.hostfile_servers, self.server_group, self.basepath)
 
         if int(str(self.name).split("-")[0]) == 1:
@@ -76,6 +78,7 @@ class MultipleClients(Test):
             if self.pool is not None and self.pool.attached:
                 self.pool.destroy(1)
         finally:
+            AgentUtils.stop_agent(self.hostlist_clients)
             ServerUtils.stopServer(hosts=self.hostlist_servers)
 
     def test_multipleclients(self):

--- a/src/tests/ftest/io/SegCount.py
+++ b/src/tests/ftest/io/SegCount.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python
 '''
-    (C) Copyright 2018 Intel Corporation.
+    (C) Copyright 2018-2019 Intel Corporation.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -31,6 +31,7 @@ sys.path.append('./util')
 sys.path.append('../util')
 sys.path.append('../../../utils/py')
 sys.path.append('./../../utils/py')
+import AgentUtils
 import ServerUtils
 import WriteHostFile
 import IorUtils
@@ -68,11 +69,12 @@ class SegCount(Test):
         hostfile_servers = WriteHostFile.WriteHostFile(self.hostlist_servers, self.workdir)
         print("Host file servers is: {}".format(hostfile_servers))
 
-        hostlist_clients = self.params.get("test_clients", '/run/hosts/*')
+        self.hostlist_clients = self.params.get("test_clients", '/run/hosts/*')
         self.slots = self.params.get("slots", '/run/ior/clientslots/*')
-        self.hostfile_clients = WriteHostFile.WriteHostFile(hostlist_clients, self.workdir, self.slots)
+        self.hostfile_clients = WriteHostFile.WriteHostFile(self.hostlist_clients, self.workdir, self.slots)
         print("Host file clients is: {}".format(self.hostfile_clients))
 
+        AgentUtils.run_agent(self.basepath, self.hostlist_servers, self.hostlist_clients)
         ServerUtils.runServer(hostfile_servers, self.server_group, self.basepath)
 
         if int(str(self.name).split("-")[0]) == 1:
@@ -83,6 +85,7 @@ class SegCount(Test):
             if self.pool is not None and self.pool.attached:
                 self.pool.destroy(1)
         finally:
+            AgentUtils.stop_agent(self.hostlist_clients)
             ServerUtils.stopServer(hosts=self.hostlist_servers)
 
     def test_segcount(self):

--- a/src/tests/ftest/io/romio.py
+++ b/src/tests/ftest/io/romio.py
@@ -31,6 +31,7 @@ sys.path.append('./util')
 sys.path.append('../util')
 sys.path.append('../../../utils/py')
 sys.path.append('./../../utils/py')
+import AgentUtils
 import ServerUtils
 import WriteHostFile
 from MpioUtils import MpioUtils, MpioFailed
@@ -73,9 +74,11 @@ class Romio(Test):
         print("Host file clients is: {}".format(self.hostfile_clients))
 
         # start servers
+        AgentUtils.run_agent(self.basepath, self.hostlist_servers, self.hostlist_clients)
         ServerUtils.runServer(self.hostfile_servers, self.server_group, self.basepath)
 
     def tearDown(self):
+        AgentUtils.stop_agent(self.hostlist_clients)
         ServerUtils.stopServer(hosts=self.hostlist_servers)
 
     def test_romio(self):

--- a/src/tests/ftest/network/CartSelfTest.py
+++ b/src/tests/ftest/network/CartSelfTest.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python
 """
-  (C) Copyright 2018 Intel Corporation.
+  (C) Copyright 2018-2019 Intel Corporation.
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
@@ -33,6 +33,7 @@ sys.path.append('../../../utils/py')
 sys.path.append('./util')
 sys.path.append('./../../utils/py')
 
+import AgentUtils
 import ServerUtils
 import WriteHostFile
 from daos_api import DaosContext, DaosLog
@@ -84,6 +85,8 @@ class CartSelfTest(Test):
         self.server_group = self.params.get("server", 'server_group',
                                             'daos_server')
         self.uri_file = os.path.join(self.basepath, "install", "tmp", "uri.txt")
+
+        AgentUtils.run_agent(self.basepath, self.hostlist)
         ServerUtils.runServer(self.hostfile, self.server_group, self.basepath,
                               uri_path=self.uri_file, env_dict=self.env_dict)
 
@@ -92,6 +95,7 @@ class CartSelfTest(Test):
             os.remove(self.hostfile)
             os.remove(self.uri_file)
         finally:
+            AgentUtils.stop_agent(self.hostlist)
             ServerUtils.stopServer(hosts=self.hostlist)
 
     def test_self_test(self):

--- a/src/tests/ftest/object/ArrayObjTest.py
+++ b/src/tests/ftest/object/ArrayObjTest.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python
 '''
-  (C) Copyright 2017 Intel Corporation.
+  (C) Copyright 2017-2019 Intel Corporation.
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
@@ -34,6 +34,7 @@ sys.path.append('../util')
 sys.path.append('../../../utils/py')
 sys.path.append('./../../utils/py')
 
+import AgentUtils
 import ServerUtils
 import WriteHostFile
 from conversion import c_uuid_to_str
@@ -62,9 +63,11 @@ class ArrayObjTest(Test):
         self.hostlist = self.params.get("test_machines",'/run/hosts/')
         self.hostfile = WriteHostFile.WriteHostFile(self.hostlist, self.workdir)
 
+        AgentUtils.run_agent(self.basepath, self.hostlist)
         ServerUtils.runServer(self.hostfile, self.server_group, self.basepath)
 
     def tearDown(self):
+        AgentUtils.stop_agent(self.hostlist)
         ServerUtils.stopServer(hosts=self.hostlist)
 
     def test_array_obj(self):

--- a/src/tests/ftest/object/CreateManyDkeys.py
+++ b/src/tests/ftest/object/CreateManyDkeys.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python
 '''
-  (C) Copyright 2018 Intel Corporation.
+  (C) Copyright 2018-2019 Intel Corporation.
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
@@ -34,6 +34,7 @@ sys.path.append('./util')
 sys.path.append('../util')
 sys.path.append('../../../utils/py')
 sys.path.append('./../../utils/py')
+import AgentUtils
 import ServerUtils
 import WriteHostFile
 
@@ -60,6 +61,7 @@ class CreateManyDkeys(Test):
         self.hostlist = self.params.get("test_machines", '/run/hosts/*')
         self.hostfile = WriteHostFile.WriteHostFile(self.hostlist, tmp)
 
+        AgentUtils.run_agent(basepath, self.hostlist)
         ServerUtils.runServer(self.hostfile, server_group, basepath)
 
         self.pool = DaosPool(self.context)
@@ -78,6 +80,7 @@ class CreateManyDkeys(Test):
             if self.pool:
                 self.pool.destroy(1)
         finally:
+            AgentUtils.stop_agent(self.hostlist)
             ServerUtils.stopServer(hosts=self.hostlist)
 
     def write_a_bunch_of_values(self, how_many):

--- a/src/tests/ftest/object/ObjFetchBadParam.py
+++ b/src/tests/ftest/object/ObjFetchBadParam.py
@@ -34,6 +34,7 @@ sys.path.append('../util')
 sys.path.append('../../../utils/py')
 sys.path.append('./../../utils/py')
 
+import AgentUtils
 import ServerUtils
 import WriteHostFile
 from daos_api import DaosContext, DaosPool, DaosContainer, DaosApiError
@@ -65,6 +66,7 @@ class ObjFetchBadParam(Test):
         self.hostlist = self.params.get("test_machines",'/run/hosts/*')
         self.hostfile = WriteHostFile.WriteHostFile(self.hostlist, self.workdir)
 
+        AgentUtils.run_agent(self.basepath, self.hostlist)
         ServerUtils.runServer(self.hostfile, self.server_group, self.basepath)
         time.sleep(5)
 
@@ -123,6 +125,7 @@ class ObjFetchBadParam(Test):
                 self.pool.disconnect()
                 self.pool.destroy(1)
         finally:
+            AgentUtils.stop_agent(self.hostlist)
             ServerUtils.stopServer(hosts=self.hostlist)
 
     def test_bad_handle(self):

--- a/src/tests/ftest/object/ObjOpenBadParam.py
+++ b/src/tests/ftest/object/ObjOpenBadParam.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python
 """
-  (C) Copyright 2018 Intel Corporation.
+  (C) Copyright 2018-2019 Intel Corporation.
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
@@ -34,6 +34,7 @@ sys.path.append('../util')
 sys.path.append('../../../utils/py')
 sys.path.append('./../../utils/py')
 
+import AgentUtils
 import ServerUtils
 import WriteHostFile
 from daos_api import DaosContext, DaosPool, DaosContainer, DaosLog, DaosApiError
@@ -72,6 +73,7 @@ class ObjOpenBadParam(Test):
         self.hostlist = self.params.get("test_machines",'/run/hosts/*')
         self.hostfile = WriteHostFile.WriteHostFile(self.hostlist, self.workdir)
 
+        AgentUtils.run_agent(self.basepath, self.hostlist)
         ServerUtils.runServer(self.hostfile, self.server_group, self.basepath)
         try:
             # parameters used in pool create
@@ -134,6 +136,7 @@ class ObjOpenBadParam(Test):
             self.pool.disconnect()
             self.pool.destroy(1)
         finally:
+            AgentUtils.stop_agent(self.hostlist)
             ServerUtils.stopServer(hosts=self.hostlist)
 
     def test_bad_obj_handle(self):

--- a/src/tests/ftest/object/ObjUpdateBadParam.py
+++ b/src/tests/ftest/object/ObjUpdateBadParam.py
@@ -34,6 +34,7 @@ sys.path.append('../util')
 sys.path.append('../../../utils/py')
 sys.path.append('./../../utils/py')
 
+import AgentUtils
 import ServerUtils
 import WriteHostFile
 from conversion import c_uuid_to_str
@@ -62,10 +63,12 @@ class ObjUpdateBadParam(Test):
         self.hostlist = self.params.get("test_machines",'/run/hosts/*')
         self.hostfile = WriteHostFile.WriteHostFile(self.hostlist, self.workdir)
 
+        AgentUtils.run_agent(self.basepath, self.hostlist)
         ServerUtils.runServer(self.hostfile, self.server_group, self.basepath)
         time.sleep(5)
 
     def tearDown(self):
+        AgentUtils.stop_agent(self.hostlist)
         ServerUtils.stopServer(hosts=self.hostlist)
 
     def test_bad_handle(self):

--- a/src/tests/ftest/object/ObjectIntegrity.py
+++ b/src/tests/ftest/object/ObjectIntegrity.py
@@ -33,6 +33,7 @@ sys.path.append('./util')
 sys.path.append('../util')
 sys.path.append('../../../utils/py')
 sys.path.append('./../../utils/py')
+import AgentUtils
 import ServerUtils
 import WriteHostFile
 
@@ -73,6 +74,7 @@ class ObjectDataValidation(avocado.Test):
         self.array_size = self.params.get("size", '/array_size/')
         self.record_length = self.params.get("length", '/run/record/*')
 
+        AgentUtils.run_agent(basepath, self.hostlist)
         ServerUtils.runServer(self.hostfile, server_group, basepath)
 
         self.pool = DaosPool(self.context)
@@ -104,6 +106,7 @@ class ObjectDataValidation(avocado.Test):
                 self.pool.disconnect()
                 self.pool.destroy(1)
         finally:
+            AgentUtils.stop_agent(self.hostlist)
             ServerUtils.stopServer(hosts=self.hostlist)
 
     def reconnect(self):

--- a/src/tests/ftest/object/PunchTest.py
+++ b/src/tests/ftest/object/PunchTest.py
@@ -34,6 +34,7 @@ sys.path.append('../util')
 sys.path.append('../../../utils/py')
 sys.path.append('./../../utils/py')
 
+import AgentUtils
 import ServerUtils
 import WriteHostFile
 from daos_api import DaosContext, DaosPool, DaosContainer, DaosApiError
@@ -60,6 +61,7 @@ class PunchTest(Test):
                 self.hostfile = WriteHostFile.WriteHostFile(self.hostlist,
                                                             self.workdir)
 
+                AgentUtils.run_agent(self.basepath, self.hostlist)
                 ServerUtils.runServer(self.hostfile, self.server_group,
                                       self.basepath)
 
@@ -115,6 +117,7 @@ class PunchTest(Test):
             self.fail("Test failed during teardown.\n")
 
         finally:
+            AgentUtils.stop_agent(self.hostlist)
             ServerUtils.stopServer(hosts=self.hostlist)
 
     def test_dkey_punch(self):

--- a/src/tests/ftest/pool/BadConnect.py
+++ b/src/tests/ftest/pool/BadConnect.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python
 '''
-  (C) Copyright 2018 Intel Corporation.
+  (C) Copyright 2018-2019 Intel Corporation.
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
@@ -35,6 +35,7 @@ sys.path.append('../../../utils/py')
 sys.path.append('./util')
 sys.path.append('./../../utils/py')
 
+import AgentUtils
 import ServerUtils
 import WriteHostFile
 from daos_api import DaosContext, DaosPool, DaosApiError
@@ -69,9 +70,12 @@ class BadConnectTest(Test):
         # launch the server
         self.hostfile = WriteHostFile.WriteHostFile(self.hostlist, tmp)
         server_group = self.params.get("server_group",'/server/','daos_server')
+
+        AgentUtils.run_agent(self.basepath, self.hostlist)
         ServerUtils.runServer(self.hostfile, server_group, self.basepath)
 
     def tearDown(self):
+        AgentUtils.stop_agent(self.hostlist)
         ServerUtils.stopServer(hosts=self.hostlist)
 
     def test_connect(self):

--- a/src/tests/ftest/pool/BadCreate.py
+++ b/src/tests/ftest/pool/BadCreate.py
@@ -34,6 +34,7 @@ sys.path.append('../../../utils/py')
 sys.path.append('./util')
 sys.path.append('./../../utils/py')
 
+import AgentUtils
 import ServerUtils
 import WriteHostFile
 from daos_api import DaosContext, DaosPool, DaosApiError
@@ -64,9 +65,11 @@ class BadCreateTest(Test):
                                        '/server/',
                                        'daos_server')
 
+        AgentUtils.run_agent(self.basepath, self.hostlist)
         ServerUtils.runServer(self.hostfile, server_group, self.basepath)
 
     def tearDown(self):
+        AgentUtils.stop_agent(self.hostlist)
         ServerUtils.stopServer(hosts=self.hostlist)
 
     def test_create(self):

--- a/src/tests/ftest/pool/BadEvict.py
+++ b/src/tests/ftest/pool/BadEvict.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python
 '''
-  (C) Copyright 2018 Intel Corporation.
+  (C) Copyright 2018-2019 Intel Corporation.
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
@@ -35,6 +35,7 @@ sys.path.append('../../../utils/py')
 sys.path.append('./util')
 sys.path.append('./../../utils/py')
 
+import AgentUtils
 import ServerUtils
 import WriteHostFile
 from daos_api import DaosContext, DaosPool, DaosApiError
@@ -61,10 +62,17 @@ class BadEvictTest(Test):
 
         server_group = self.params.get("server_group",'/server/','daos_server')
 
+        AgentUtils.run_agent(self.basepath, self.hostlist)
         ServerUtils.runServer(self.hostfile, server_group, self.basepath)
 
     def tearDown(self):
-        ServerUtils.stopServer(hosts=self.hostlist)
+        # right now the exception logic in stopServer is too aggresive/broken.
+        # remove this catch later on when working better
+        try:
+            AgentUtils.stop_agent(self.hostlist)
+            ServerUtils.stopServer(hosts=self.hostlist)
+        except Exception as e:
+            pass
 
     def test_evict(self):
         """

--- a/src/tests/ftest/pool/BadExclude.py
+++ b/src/tests/ftest/pool/BadExclude.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python
 '''
-  (C) Copyright 2018 Intel Corporation.
+  (C) Copyright 2018-2019 Intel Corporation.
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
@@ -35,6 +35,7 @@ sys.path.append('../../../utils/py')
 sys.path.append('./util')
 sys.path.append('./../../utils/py')
 
+import AgentUtils
 import ServerUtils
 import WriteHostFile
 from daos_api import DaosContext, DaosPool, DaosApiError
@@ -63,10 +64,12 @@ class BadExcludeTest(Test):
                                        '/server/',
                                        'daos_server')
 
+        AgentUtils.run_agent(self.basepath, self.hostlist)
         ServerUtils.runServer(self.hostfile, server_group, self.basepath)
 
     def tearDown(self):
         try:
+            AgentUtils.stop_agent(self.hostlist)
             ServerUtils.stopServer(hosts=self.hostlist)
         except ServerFailed as e:
             pass

--- a/src/tests/ftest/pool/BadExclude.yaml
+++ b/src/tests/ftest/pool/BadExclude.yaml
@@ -2,9 +2,9 @@ server:
    server_group: test_server
 hosts:
   test_machines:
-    - boro-26
-    - boro-29
-    - boro-30
+    - boro-A
+    - boro-B
+    - boro-C
 timeout: 200
 testparams:
    tgtlist: !mux

--- a/src/tests/ftest/pool/BadQuery.py
+++ b/src/tests/ftest/pool/BadQuery.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python
 '''
-  (C) Copyright 2018 Intel Corporation.
+  (C) Copyright 2018-2019 Intel Corporation.
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
@@ -34,6 +34,7 @@ sys.path.append('../../../utils/py')
 sys.path.append('./util')
 sys.path.append('./../../utils/py')
 
+import AgentUtils
 import ServerUtils
 import WriteHostFile
 from daos_api import DaosContext, DaosPool, DaosApiError
@@ -55,14 +56,15 @@ class BadQueryTest(Test):
 
         self.hostlist = self.params.get("test_machines", '/run/hosts/')
         self.hostfile = WriteHostFile.WriteHostFile(self.hostlist, tmp)
-
         server_group = self.params.get("server_group",
                                        '/server/',
                                        'daos_server')
 
+        AgentUtils.run_agent(self.basepath, self.hostlist)
         ServerUtils.runServer(self.hostfile, server_group, self.basepath)
 
     def tearDown(self):
+        AgentUtils.stop_agent(self.hostlist)
         ServerUtils.stopServer(hosts=self.hostlist)
 
     def test_query(self):

--- a/src/tests/ftest/pool/ConnectTest.py
+++ b/src/tests/ftest/pool/ConnectTest.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python
 '''
-  (C) Copyright 2018 Intel Corporation.
+  (C) Copyright 2018-2019 Intel Corporation.
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
@@ -33,6 +33,7 @@ from avocado       import main
 from avocado.utils import process
 
 sys.path.append('./util')
+import AgentUtils
 import ServerUtils
 import CheckForPool
 import GetHostsFromFile
@@ -55,12 +56,13 @@ class ConnectTest(Test):
 
         self.hostlist = self.params.get("test_machines",'/run/hosts/')
         self.hostfile = WriteHostFile.WriteHostFile(self.hostlist, self.workdir)
-
         server_group = self.params.get("server_group",'/server/','daos_server')
 
+        AgentUtils.run_agent(self.basepath, self.hostlist)
         ServerUtils.runServer(self.hostfile, server_group, self.basepath)
 
     def tearDown(self):
+        AgentUtils.stop_agent(self.hostlist)
         ServerUtils.stopServer(hosts=self.hostlist)
 
     def test_connect(self):

--- a/src/tests/ftest/pool/DestroyRebuild.py
+++ b/src/tests/ftest/pool/DestroyRebuild.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python
 '''
-  (C) Copyright 2018 Intel Corporation.
+  (C) Copyright 2018-2019 Intel Corporation.
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
@@ -34,6 +34,7 @@ sys.path.append('../util')
 sys.path.append('./../../utils/py')
 sys.path.append('../../../utils/py')
 
+import AgentUtils
 import ServerUtils
 import WriteHostFile
 from daos_api import DaosContext, DaosPool, DaosServer, DaosApiError
@@ -60,6 +61,7 @@ class DestroyRebuild(Test):
         with open('../../../.build_vars.json') as f:
               build_paths = json.load(f)
         self.CONTEXT = DaosContext(build_paths['PREFIX'] + '/lib/')
+        self.basepath = os.path.normpath(build_paths['PREFIX']  + "/../")
 
         # generate a hostfile
         self.hostlist = self.params.get("test_machines",'/run/hosts/')
@@ -69,8 +71,9 @@ class DestroyRebuild(Test):
         # fire up the DAOS servers
         self.server_group = self.params.get("server_group",'/run/server/',
                                       'daos_server')
-        ServerUtils.runServer(self.hostfile, self.server_group,
-                             build_paths['PREFIX'] + '/../')
+
+        AgentUtils.run_agent(self.basepath, self.hostlist)
+        ServerUtils.runServer(self.hostfile, self.server_group, self.basepath)
 
         # create a pool to test with
         createmode = self.params.get("mode",'/run/pool/createmode/')
@@ -93,6 +96,7 @@ class DestroyRebuild(Test):
             if self.POOL:
                 self.POOL.destroy(1)
         finally:
+            AgentUtils.stop_agent(self.hostlist)
             ServerUtils.stopServer(hosts=self.hostlist)
 
 

--- a/src/tests/ftest/pool/DestroyTests.py
+++ b/src/tests/ftest/pool/DestroyTests.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python2
 '''
-  (C) Copyright 2018 Intel Corporation.
+  (C) Copyright 2018-2019 Intel Corporation.
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
@@ -36,6 +36,7 @@ sys.path.append('../util')
 sys.path.append('./../../utils/py')
 sys.path.append('../../../utils/py')
 
+import AgentUtils
 import ServerUtils
 import CheckForPool
 import WriteHostFile
@@ -85,6 +86,7 @@ class DestroyTests(Test):
         self.hostlist = self.params.get("test_machines1", '/run/hosts/')
         hostfile = WriteHostFile.WriteHostFile(self.hostlist, self.tmp)
 
+        AgentUtils.run_agent(self.basepath, self.hostlist)
         ServerUtils.runServer(hostfile, self.server_group, self.basepath)
 
         setid = self.params.get("setname",
@@ -130,6 +132,7 @@ class DestroyTests(Test):
             try:
                 os.remove(hostfile)
             finally:
+                AgentUtils.stop_agent(self.hostlist)
                 ServerUtils.stopServer(hosts=self.hostlist)
 
     def test_delete_doesnt_exist(self):
@@ -141,6 +144,7 @@ class DestroyTests(Test):
         self.hostlist = self.params.get("test_machines1", '/run/hosts/')
         hostfile = WriteHostFile.WriteHostFile(self.hostlist, self.tmp)
 
+        AgentUtils.run_agent(self.basepath, self.hostlist)
         ServerUtils.runServer(hostfile, self.server_group, self.basepath)
 
         setid = self.params.get("setname",
@@ -170,6 +174,7 @@ class DestroyTests(Test):
 
         # no matter what happens shutdown the server
         finally:
+            AgentUtils.stop_agent(self.hostlist)
             ServerUtils.stopServer(hosts=self.hostlist)
             os.remove(hostfile)
 
@@ -184,6 +189,7 @@ class DestroyTests(Test):
         self.hostlist = self.params.get("test_machines1", '/run/hosts/')
         hostfile = WriteHostFile.WriteHostFile(self.hostlist, self.tmp)
 
+        AgentUtils.run_agent(self.basepath, self.hostlist)
         ServerUtils.runServer(hostfile, self.server_group, self.basepath)
 
         # need both a good and bad set
@@ -234,6 +240,7 @@ class DestroyTests(Test):
 
         # no matter what happens shutdown the server
         finally:
+            AgentUtils.stop_agent(self.hostlist)
             ServerUtils.stopServer(hosts=self.hostlist)
             os.remove(hostfile)
 
@@ -249,6 +256,7 @@ class DestroyTests(Test):
         self.hostlist = self.params.get("test_machines2", '/run/hosts/')
         hostfile = WriteHostFile.WriteHostFile(self.hostlist, self.tmp)
 
+        AgentUtils.run_agent(self.basepath, self.hostlist)
         ServerUtils.runServer(hostfile, self.server_group, self.basepath)
 
         setid = self.params.get("setname",
@@ -297,6 +305,7 @@ class DestroyTests(Test):
 
         # no matter what happens shutdown the server
         finally:
+            AgentUtils.stop_agent(self.hostlist)
             ServerUtils.stopServer(hosts=self.hostlist)
             os.remove(hostfile)
 
@@ -307,7 +316,6 @@ class DestroyTests(Test):
 
         :avocado: tags=pool,pooldestroy
         """
-
         setid2 = self.basepath + self.params.get("setname",
                                                  '/run/setnames/othersetname/')
 
@@ -322,6 +330,8 @@ class DestroyTests(Test):
         daosctl = self.basepath + '/install/bin/daosctl'
 
         # start 2 different sets of servers,
+        AgentUtils.run_agent(self.basepath, self.hostlist1)
+        AgentUtils.run_agent(self.basepath, self.hostlist2)
         ServerUtils.runServer(hostfile1, self.server_group, self.basepath)
         ServerUtils.runServer(hostfile2, setid2, self.basepath)
 
@@ -372,6 +382,8 @@ class DestroyTests(Test):
 
         # no matter what happens shutdown the server
         finally:
+            AgentUtils.stop_agent(self.hostlist1)
+            AgentUtils.stop_agent(self.hostlist2)
             ServerUtils.stopServer(hosts=self.hostlist)
             os.remove(hostfile1)
             os.remove(hostfile2)
@@ -390,6 +402,7 @@ class DestroyTests(Test):
             self.hostlist = self.params.get("test_machines1", '/run/hosts/')
             hostfile = WriteHostFile.WriteHostFile(self.hostlist, self.tmp)
 
+            AgentUtils.run_agent(self.basepath, self.hostlist)
             ServerUtils.runServer(hostfile, self.server_group, self.basepath)
 
             # parameters used in pool create
@@ -426,6 +439,7 @@ class DestroyTests(Test):
 
         # no matter what happens cleanup
         finally:
+            AgentUtils.stop_agent(self.hostlist)
             ServerUtils.stopServer(hosts=self.hostlist)
             os.remove(hostfile)
 
@@ -442,6 +456,7 @@ class DestroyTests(Test):
             self.hostlist = self.params.get("test_machines1", '/run/hosts/')
             hostfile = WriteHostFile.WriteHostFile(self.hostlist, self.tmp)
 
+            AgentUtils.run_agent(self.basepath, self.hostlist)
             ServerUtils.runServer(hostfile, self.server_group, self.basepath)
 
             # parameters used in pool create
@@ -485,6 +500,7 @@ class DestroyTests(Test):
 
         # no matter what happens cleanup
         finally:
+            AgentUtils.stop_agent(self.hostlist)
             ServerUtils.stopServer(hosts=self.hostlist)
             os.remove(hostfile)
 
@@ -499,6 +515,7 @@ class DestroyTests(Test):
             self.hostlist = self.params.get("test_machines6", '/run/hosts/')
             hostfile = WriteHostFile.WriteHostFile(self.hostlist, self.tmp)
 
+            AgentUtils.run_agent(self.basepath, self.hostlist)
             ServerUtils.runServer(hostfile, self.server_group, self.basepath)
 
             # parameters used in pool create
@@ -530,6 +547,7 @@ class DestroyTests(Test):
 
         # no matter what happens cleanup
         finally:
+            AgentUtils.stop_agent(self.hostlist)
             ServerUtils.stopServer(hosts=self.hostlist)
             os.remove(hostfile)
 
@@ -545,6 +563,7 @@ class DestroyTests(Test):
             self.hostlist = self.params.get("test_machines1", '/run/hosts/')
             hostfile = WriteHostFile.WriteHostFile(self.hostlist, self.tmp)
 
+            AgentUtils.run_agent(self.basepath, self.hostlist)
             ServerUtils.runServer(hostfile, self.server_group, self.basepath)
 
             # parameters used in pool create
@@ -591,6 +610,7 @@ class DestroyTests(Test):
 
         # no matter what happens cleanup
         finally:
+            AgentUtils.stop_agent(self.hostlist)
             ServerUtils.stopServer(hosts=self.hostlist)
             os.remove(hostfile)
 
@@ -609,6 +629,7 @@ class DestroyTests(Test):
             self.hostlist = self.params.get("test_machines1", '/run/hosts/')
             hostfile = WriteHostFile.WriteHostFile(self.hostlist, self.tmp)
 
+            AgentUtils.run_agent(self.basepath, self.hostlist)
             ServerUtils.runServer(hostfile, self.server_group, self.basepath)
 
             # parameters used in pool create
@@ -660,5 +681,6 @@ class DestroyTests(Test):
 
         # no matter what happens cleanup
         finally:
+            AgentUtils.stop_agent(self.hostlist)
             ServerUtils.stopServer(hosts=self.hostlist)
             os.remove(hostfile)

--- a/src/tests/ftest/pool/EvictTest.py
+++ b/src/tests/ftest/pool/EvictTest.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python
 '''
-  (C) Copyright 2018 Intel Corporation.
+  (C) Copyright 2018-2019 Intel Corporation.
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
@@ -33,6 +33,7 @@ from avocado       import main
 from avocado.utils import process
 
 sys.path.append('./util')
+import AgentUtils
 import ServerUtils
 import CheckForPool
 import WriteHostFile
@@ -61,9 +62,11 @@ class EvictTest(Test):
         server_group = self.params.get("server_group",'/server/',
                                        'daos_server')
 
+        AgentUtils.run_agent(self.basepath, self.hostlist)
         ServerUtils.runServer(self.hostfile, server_group, self.basepath)
 
     def tearDown(self):
+        AgentUtils.stop_agent(self.hostlist)
         ServerUtils.stopServer(hosts=self.hostlist)
         os.remove(self.hostfile)
 

--- a/src/tests/ftest/pool/GlobalHandle.py
+++ b/src/tests/ftest/pool/GlobalHandle.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python
 '''
-  (C) Copyright 2018 Intel Corporation.
+  (C) Copyright 2018-2019 Intel Corporation.
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
@@ -36,6 +36,7 @@ sys.path.append('./util')
 sys.path.append('../util')
 sys.path.append('../../../utils/py')
 sys.path.append('./../../utils/py')
+import AgentUtils
 import ServerUtils
 import WriteHostFile
 import CheckForPool
@@ -100,6 +101,7 @@ class GlobalHandle(Test):
         self.hostlist = self.params.get("test_machines",'/run/hosts/')
         self.hostfile = WriteHostFile.WriteHostFile(self.hostlist, self.workdir)
 
+        AgentUtils.run_agent(basepath, self.hostlist)
         ServerUtils.runServer(self.hostfile, server_group, basepath)
 
     def tearDown(self):
@@ -107,6 +109,7 @@ class GlobalHandle(Test):
             # really make sure everything is gone
             CheckForPool.CleanupPools(self.hostlist)
         finally:
+            AgentUtils.stop_agent(self.hostlist)
             ServerUtils.stopServer(hosts=self.hostlist)
 
     def test_global_handle(self):

--- a/src/tests/ftest/pool/InfoTests.py
+++ b/src/tests/ftest/pool/InfoTests.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python
 """
-  (C) Copyright 2018 Intel Corporation.
+  (C) Copyright 2018-2019 Intel Corporation.
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
@@ -32,6 +32,7 @@ sys.path.append('../util')
 sys.path.append('./../../utils/py')
 sys.path.append('../../../utils/py')
 
+import AgentUtils
 import ServerUtils
 import WriteHostFile
 from daos_api import DaosContext, DaosPool, DaosLog, DaosApiError
@@ -57,6 +58,8 @@ class InfoTests(Test):
         self.d_log = DaosLog(context)
         self.hostlist = self.params.get("test_machines1", '/run/hosts/')
         self.hostfile = WriteHostFile.WriteHostFile(self.hostlist, self.tmp)
+
+        AgentUtils.run_agent(self.basepath, self.hostlist)
         ServerUtils.runServer(self.hostfile, self.server_group, self.basepath)
 
     def tearDown(self):
@@ -66,6 +69,7 @@ class InfoTests(Test):
                 self.pool.destroy(1)
             os.remove(self.hostfile)
         finally:
+            AgentUtils.stop_agent(self.hostlist)
             ServerUtils.stopServer(hosts=self.hostlist)
 
     def test_simple_query(self):

--- a/src/tests/ftest/pool/MultiServerCreateDeleteTest.py
+++ b/src/tests/ftest/pool/MultiServerCreateDeleteTest.py
@@ -31,6 +31,7 @@ from avocado       import Test
 from avocado.utils import process
 
 sys.path.append('./util')
+import AgentUtils
 import ServerUtils
 import CheckForPool
 import WriteHostFile
@@ -52,10 +53,12 @@ class MultiServerCreateDeleteTest(Test):
         self.hostfile = WriteHostFile.WriteHostFile(self.hostlist, self.workdir)
         server_group = self.params.get("server_group", '/server/', 'daos_server')
 
+        AgentUtils.run_agent(basepath, self.hostlist)
         ServerUtils.runServer(self.hostfile, server_group, basepath)
         self.dmg = basepath + '/install/bin/dmg'
 
     def tearDown(self):
+        AgentUtils.stop_agent(self.hostlist)
         ServerUtils.stopServer(hosts=self.hostlist)
 
     def test_create(self):

--- a/src/tests/ftest/pool/MultipleCreatesTest.py
+++ b/src/tests/ftest/pool/MultipleCreatesTest.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python
 '''
-  (C) Copyright 2018 Intel Corporation.
+  (C) Copyright 2018-2019 Intel Corporation.
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
@@ -33,6 +33,7 @@ from avocado       import main
 from avocado.utils import process
 
 sys.path.append('./util')
+import AgentUtils
 import ServerUtils
 import CheckForPool
 import WriteHostFile
@@ -56,9 +57,9 @@ class MultipleCreatesTest(Test):
 
         self.hostlist = self.params.get("test_machines",'/run/hosts/')
         self.hostfile = WriteHostFile.WriteHostFile(self.hostlist, tmp)
-
         server_group = self.params.get("server_group",'/server/','daos_server')
 
+        AgentUtils.run_agent(basepath, self.hostlist)
         ServerUtils.runServer(self.hostfile, server_group, basepath)
 
         self.daosctl = basepath + '/install/bin/daosctl'
@@ -68,6 +69,7 @@ class MultipleCreatesTest(Test):
         try:
             os.remove(self.hostfile)
         finally:
+            AgentUtils.stop_agent(self.hostlist)
             ServerUtils.stopServer(hosts=self.hostlist)
 
     def test_create_one(self):

--- a/src/tests/ftest/pool/Permission.py
+++ b/src/tests/ftest/pool/Permission.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python
 '''
-	(C) Copyright 2018 Intel Corporation.
+	(C) Copyright 2018-2019 Intel Corporation.
 
 	Licensed under the Apache License, Version 2.0 (the "License");
 	you may not use this file except in compliance with the License.
@@ -32,6 +32,7 @@ sys.path.append('../util')
 sys.path.append('../../../utils/py')
 sys.path.append('./../../utils/py')
 
+import AgentUtils
 import ServerUtils
 import WriteHostFile
 from daos_api import DaosContext, DaosPool, DaosContainer, DaosLog, DaosApiError
@@ -64,6 +65,7 @@ class Permission(Test):
         print ("Host file is: {}".format(self.hostfile))
 
         # starting server
+        AgentUtils.run_agent(self.basepath, self.hostlist)
         ServerUtils.runServer(self.hostfile, self.server_group, self.basepath)
 
     def tearDown(self):
@@ -72,6 +74,7 @@ class Permission(Test):
                 self.pool.destroy(1)
         finally:
             # stop servers
+            AgentUtils.stop_agent(self.hostlist)
             ServerUtils.stopServer(hosts=self.hostlist)
 
     def test_connectpermission(self):

--- a/src/tests/ftest/pool/PoolSvc.py
+++ b/src/tests/ftest/pool/PoolSvc.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python
 '''
-    (C) Copyright 2018 Intel Corporation.
+    (C) Copyright 2018-2019 Intel Corporation.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -37,6 +37,7 @@ sys.path.append('./util')
 sys.path.append('../util')
 sys.path.append('../../../utils/py')
 sys.path.append('./../../utils/py')
+import AgentUtils
 import ServerUtils
 import WriteHostFile
 from daos_api import DaosContext, DaosPool, DaosServer, DaosApiError
@@ -64,6 +65,7 @@ class PoolSvc(Test):
         self.hostfile = WriteHostFile.WriteHostFile(self.hostlist, self.workdir)
         print("Host file is: {}".format(self.hostfile))
 
+        AgentUtils.run_agent(self.basepath, self.hostlist)
         ServerUtils.runServer(self.hostfile, self.server_group, self.basepath)
 
     def tearDown(self):
@@ -71,6 +73,7 @@ class PoolSvc(Test):
             if self.pool is not None and self.pool.attached:
                 self.pool.destroy(1)
         finally:
+            AgentUtils.stop_agent(self.hostlist)
             ServerUtils.stopServer(hosts=self.hostlist)
 
     def test_poolsvc(self):

--- a/src/tests/ftest/pool/RebuildNoCap.py
+++ b/src/tests/ftest/pool/RebuildNoCap.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python
 '''
-  (C) Copyright 2018 Intel Corporation.
+  (C) Copyright 2018-2019 Intel Corporation.
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
@@ -35,6 +35,7 @@ sys.path.append('../util')
 sys.path.append('../../../utils/py')
 sys.path.append('./../../utils/py')
 
+import AgentUtils
 import ServerUtils
 import WriteHostFile
 from daos_api import DaosContext, DaosPool, DaosServer, DaosApiError
@@ -61,6 +62,7 @@ class RebuildNoCap(Test):
         with open('../../../.build_vars.json') as f:
               build_paths = json.load(f)
         self.CONTEXT = DaosContext(build_paths['PREFIX'] + '/lib/')
+        self.basepath = os.path.normpath(build_paths['PREFIX']  + "/../")
 
         # generate a hostfile
         self.hostlist = self.params.get("test_machines",'/run/hosts/')
@@ -70,8 +72,9 @@ class RebuildNoCap(Test):
         # fire up the DAOS servers
         self.server_group = self.params.get("server_group",'/run/server/',
                                             'daos_server')
-        ServerUtils.runServer(self.hostfile, self.server_group,
-                              build_paths['PREFIX'] + '/../')
+
+        AgentUtils.run_agent(self.basepath, self.hostlist)
+        ServerUtils.runServer(self.hostfile, self.server_group, self.basepath)
 
         # create a pool to test with
         createmode = self.params.get("mode",'/run/pool/createmode/')
@@ -104,6 +107,7 @@ class RebuildNoCap(Test):
             if self.POOL:
                 self.POOL.destroy(1)
         finally:
+            AgentUtils.stop_agent(self.hostlist)
             ServerUtils.stopServer(hosts=self.hostlist)
 
 

--- a/src/tests/ftest/pool/RebuildTests.py
+++ b/src/tests/ftest/pool/RebuildTests.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python
 '''
-  (C) Copyright 2018 Intel Corporation.
+  (C) Copyright 2018-2019 Intel Corporation.
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
@@ -36,6 +36,7 @@ sys.path.append('../util')
 sys.path.append('../../../utils/py')
 sys.path.append('./../../utils/py')
 
+import AgentUtils
 import ServerUtils
 import WriteHostFile
 import CheckForPool
@@ -88,6 +89,7 @@ class RebuildTests(Test):
         hostfile = WriteHostFile.WriteHostFile(self.hostlist, tmp)
 
         try:
+            AgentUtils.run_agent(basepath, self.hostlist)
             ServerUtils.runServer(hostfile, server_group, basepath)
 
             # use the uid/gid of the user running the test, these should
@@ -222,6 +224,7 @@ class RebuildTests(Test):
                 # really make sure everything is gone
                 CheckForPool.CleanupPools(self.hostlist)
             finally:
+                AgentUtils.stop_agent(self.hostlist)
                 ServerUtils.killServer(self.hostlist)
 
 
@@ -251,6 +254,7 @@ class RebuildTests(Test):
         hostfile = WriteHostFile.WriteHostFile(self.hostlist, tmp)
 
         try:
+            AgentUtils.run_agent(basepath, self.hostlist)
             ServerUtils.runServer(hostfile, server_group, basepath)
 
             # use the uid/gid of the user running the test, these should
@@ -420,6 +424,7 @@ class RebuildTests(Test):
             self.fail("Expecting to pass but test has failed.\n")
 
         finally:
+            AgentUtils.stop_agent(self.hostlist)
             ServerUtils.stopServer(hosts=self.hostlist)
             os.remove(hostfile)
             CheckForPool.CleanupPools(self.hostlist)

--- a/src/tests/ftest/pool/RebuildWithIO.py
+++ b/src/tests/ftest/pool/RebuildWithIO.py
@@ -40,6 +40,7 @@ sys.path.append('./util')
 sys.path.append('../util')
 sys.path.append('../../../utils/py')
 sys.path.append('./../../utils/py')
+import AgentUtils
 import ServerUtils
 import WriteHostFile
 import CheckForPool
@@ -92,6 +93,7 @@ class RebuildWithIO(Test):
         io_proc = None
 
         try:
+            AgentUtils.run_agent(basepath, self.hostlist)
             ServerUtils.runServer(hostfile, server_group, basepath)
 
             # use the uid/gid of the user running the test, these should
@@ -177,4 +179,5 @@ class RebuildWithIO(Test):
                 # really make sure everything is gone
                 CheckForPool.CleanupPools(self.hostlist)
             finally:
+                AgentUtils.stop_agent(self.hostlist)
                 ServerUtils.killServer(self.hostlist)

--- a/src/tests/ftest/pool/SimpleCreateDeleteTest.py
+++ b/src/tests/ftest/pool/SimpleCreateDeleteTest.py
@@ -33,6 +33,7 @@ sys.path.append('../util')
 sys.path.append('../../../utils/py')
 sys.path.append('./../../utils/py')
 
+import AgentUtils
 import ServerUtils
 import WriteHostFile
 from daos_api import DaosPool, DaosContext, DaosApiError
@@ -58,6 +59,7 @@ class SimpleCreateDeleteTest(Test):
 
         server_group = self.params.get("server_group", '/server/', 'daos_server')
 
+        AgentUtils.run_agent(basepath, self.hostlist)
         ServerUtils.runServer(self.hostfile, server_group, basepath)
 
     def tearDown(self):
@@ -65,6 +67,7 @@ class SimpleCreateDeleteTest(Test):
             if self.pool is not None and self.pool.attached:
                 self.pool.destroy(1)
         finally:
+            AgentUtils.stop_agent(self.hostlist)
             ServerUtils.stopServer(hosts=self.hostlist)
 
     def test_create(self):

--- a/src/tests/ftest/server/Metadata.py
+++ b/src/tests/ftest/server/Metadata.py
@@ -35,6 +35,7 @@ sys.path.append('./util')
 sys.path.append('../util')
 sys.path.append('../../../utils/py')
 sys.path.append('./../../utils/py')
+import AgentUtils
 import ServerUtils
 import WriteHostFile
 import IorUtils
@@ -119,9 +120,10 @@ class ObjectMetadata(avocado.Test):
         self.d_log = DaosLog(self.context)
         self.hostlist = self.params.get("servers", '/run/hosts/*')
         self.hostfile = WriteHostFile.WriteHostFile(self.hostlist, self.workdir)
-        hostlist_clients = self.params.get("clients", '/run/hosts/*')
-        self.hostfile_clients = WriteHostFile.WriteHostFile(hostlist_clients,
+        self.hostlist_clients = self.params.get("clients", '/run/hosts/*')
+        self.hostfile_clients = WriteHostFile.WriteHostFile(self.hostlist_clients,
                                                             self.workdir)
+        AgentUtils.run_agent(self.basepath, self.hostlist, self.hostlist_clients)
         ServerUtils.runServer(self.hostfile, self.server_group, self.basepath)
 
         self.pool = DaosPool(self.context)
@@ -140,6 +142,7 @@ class ObjectMetadata(avocado.Test):
             if self.pool:
                 self.pool.destroy(1)
         finally:
+            AgentUtils.stop_agent(self.hostlist_clients)
             ServerUtils.stopServer(hosts=self.hostlist)
 
     @avocado.skip("Skipping until DAOS-1936/DAOS-1946 is fixed.")
@@ -258,7 +261,9 @@ class ObjectMetadata(avocado.Test):
             self.fail(" IOR write Thread FAIL")
 
         #Server Restart
+        AgentUtils.stop_agent(self.hostlist_clients)
         ServerUtils.stopServer(hosts=self.hostlist)
+        AgentUtils.run_agent(self.basepath, self.hostlist_clients, self.hostlist)
         ServerUtils.runServer(self.hostfile, self.server_group, self.basepath)
 
         #Read IOR with verification with same number of threads

--- a/src/tests/ftest/util/AgentUtils.py
+++ b/src/tests/ftest/util/AgentUtils.py
@@ -27,6 +27,7 @@ import time
 import subprocess
 import json
 import signal
+import getpass
 
 sessions = {}
 
@@ -59,15 +60,17 @@ def node_setup_okay(node_list, node_server_type):
         raise AgentFailed("Unknown node type, exiting")
 
     okay = True
+    failed_node = None
     for node in node_list:
         cmd = "test -d " + socket_dir
         resp = subprocess.call(["ssh", node, cmd])
         if resp != 0:
             okay = False
+            failed_node = node
             break
-    return okay
+    return okay, failed_node, socket_dir
 
-def run_agent(basepath, client_list, server_list):
+def run_agent(basepath, server_list, client_list=None):
     """
     Makes sure the environment is setup for the security agent and then launches
     it on the compute nodes.
@@ -80,11 +83,20 @@ def run_agent(basepath, client_list, server_list):
     server_list --those nodes that are acting as server nodes in the test
 
     """
-    if not node_setup_okay(client_list, NodeListType.CLIENT):
-        raise AgentFailed("A compute node isn't configured properly")
+    user = getpass.getuser()
 
-    if not node_setup_okay(server_list, NodeListType.SERVER):
-        raise AgentFailed("A server node isn't configured properly")
+    rc, node, agent_dir = node_setup_okay(server_list, NodeListType.SERVER)
+    if not rc:
+        raise AgentFailed("Server node " + node + " does not have directory "
+                          + agent_dir + " set up correctly for user "
+                          + user + ".")
+
+    if client_list is not None:
+        rc, node, agent_dir = node_setup_okay(client_list, NodeListType.CLIENT)
+        if not rc:
+            raise AgentFailed("Client node " + node + " does not have directory "
+                            + agent_dir + " set up correctly for user "
+                            + user + ".")
 
     with open(os.path.join(basepath, ".build_vars.json")) as json_vars:
         build_vars = json.load(json_vars)


### PR DESCRIPTION
In each relevant functional test, this patch implements node checks
and agent launch on client nodes.

Patch also includes one minor fix adjusting node names in .yaml file.

Change-Id: Ie6ffba49c391019bdbd2702c0038cef6bb96cdae
Signed-off-by: Stephen Willson <stephen.d.willson@intel.com>