### PR TITLE
DAOS-1955 test: misused srand()

### DIFF
--- a/src/common/sort.c
+++ b/src/common/sort.c
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2016 Intel Corporation.
+ * (C) Copyright 2016-2019 Intel Corporation.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -119,12 +119,8 @@ daos_array_find(void *array, unsigned int len, uint64_t key,
 void
 daos_array_shuffle(void *array, unsigned int len, daos_sort_ops_t *ops)
 {
-	struct timeval	tv;
 	int		n;
 	int		i;
-
-	gettimeofday(&tv, NULL);
-	srand(tv.tv_usec);
 
 	for (n = len; n > 0; n--) {
 		i = rand() % n;

--- a/src/common/tests/btree.c
+++ b/src/common/tests/btree.c
@@ -645,12 +645,8 @@ ik_btr_iterate(char *args)
 void
 ik_btr_gen_keys(unsigned int *arr, unsigned int key_nr)
 {
-	struct timeval	tv;
 	int		nr;
 	int		i;
-
-	gettimeofday(&tv, NULL);
-	srand(tv.tv_usec);
 
 	for (i = 0; i < key_nr; i++)
 		arr[i] = i + 1;
@@ -834,8 +830,12 @@ static struct option btr_ops[] = {
 int
 main(int argc, char **argv)
 {
-	int	rc = 0;
-	int	opt;
+	struct timeval	tv;
+	int		rc = 0;
+	int		opt;
+
+	gettimeofday(&tv, NULL);
+	srand(tv.tv_usec);
 
 	ik_toh = DAOS_HDL_INVAL;
 	ik_root_mmid = TMMID_NULL(struct btr_root);

--- a/src/common/tests/btree_direct.c
+++ b/src/common/tests/btree_direct.c
@@ -694,11 +694,7 @@ struct kv_node {
 static void
 sk_btr_mix_keys(struct kv_node *kv, unsigned int key_nr)
 {
-	struct timeval	tv;
-	int		nr;
-
-	gettimeofday(&tv, NULL);
-	srand(tv.tv_usec);
+	int	nr;
 
 	for (nr = key_nr; nr > 0; nr--) {
 		struct kv_node	tmp;
@@ -749,13 +745,9 @@ sk_btr_gen_keys(struct kv_node *kv, unsigned int key_nr)
 {
 	char		*key;
 	char		*value;
-	struct timeval	tv;
 	int		len;
 	int		i;
 	int		j;
-
-	gettimeofday(&tv, NULL);
-	srand(tv.tv_usec);
 
 	for (i = 0; i < key_nr; i++) {
 		len = rand() % SK_MAX_KEY_LEN;
@@ -1055,8 +1047,12 @@ static struct option btr_ops[] = {
 int
 main(int argc, char **argv)
 {
-	int	opt;
-	int	rc;
+	struct timeval	tv;
+	int		opt;
+	int		rc;
+
+	gettimeofday(&tv, NULL);
+	srand(tv.tv_usec);
 
 	sk_toh = DAOS_HDL_INVAL;
 	sk_root_mmid = TMMID_NULL(struct btr_root);

--- a/src/common/tests_lib.c
+++ b/src/common/tests_lib.c
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2015-2018 Intel Corporation.
+ * (C) Copyright 2015-2019 Intel Corporation.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -41,8 +41,6 @@ dts_oid_gen(uint16_t oclass, uint8_t ofeats, unsigned seed)
 {
 	daos_obj_id_t	oid;
 	uint64_t	hdr;
-
-	srand(time(NULL));
 
 	if (oclass == 0)
 		oclass = DTS_OCLASS_DEF;
@@ -88,7 +86,6 @@ dts_buf_render(char *buf, unsigned int buf_len)
 	int	nr = 'z' - 'a' + 1;
 	int	i;
 
-	srand(time(NULL));
 	for (i = 0; i < buf_len - 1; i++) {
 		int randv = rand() % (2 * nr);
 
@@ -106,7 +103,6 @@ dts_buf_render_uppercase(char *buf, unsigned int buf_len)
 	int	nr = 'z' - 'a' + 1;
 	int	i;
 
-	srand(time(NULL));
 	for (i = 0; i < buf_len - 1; i++) {
 		int randv = rand() % (2 * nr);
 

--- a/src/tests/daos_perf.c
+++ b/src/tests/daos_perf.c
@@ -966,6 +966,7 @@ char	*perf_tests_name[] = {
 int
 main(int argc, char **argv)
 {
+	struct timeval	tv;
 	daos_size_t	scm_size = (2ULL << 30); /* default pool SCM size */
 	daos_size_t	nvme_size = (8ULL << 30); /* default pool NVMe size */
 	int		credits   = -1;	/* sync mode */
@@ -980,6 +981,9 @@ main(int argc, char **argv)
 	MPI_Init(&argc, &argv);
 	MPI_Comm_rank(MPI_COMM_WORLD, &ts_ctx.tsc_mpi_rank);
 	MPI_Comm_size(MPI_COMM_WORLD, &ts_ctx.tsc_mpi_size);
+
+	gettimeofday(&tv, NULL);
+	srand(tv.tv_usec);
 
 	memset(ts_pmem_file, 0, sizeof(ts_pmem_file));
 	while ((rc = getopt_long(argc, argv,

--- a/src/vos/tests/evt_ctl.c
+++ b/src/vos/tests/evt_ctl.c
@@ -1084,7 +1084,11 @@ ts_cmd_run(char opc, char *args)
 int
 main(int argc, char **argv)
 {
-	int	rc;
+	struct timeval	tv;
+	int		rc;
+
+	gettimeofday(&tv, NULL);
+	srand(tv.tv_usec);
 
 	ts_toh = DAOS_HDL_INVAL;
 

--- a/src/vos/tests/vts_io.c
+++ b/src/vos/tests/vts_io.c
@@ -32,7 +32,6 @@
 #include "vts_io.h"
 #include <daos_api.h>
 
-#define SETUP_RANDOM_SEED  (10)
 #define NO_FLAGS	    (0)
 
 /* key generator */
@@ -187,7 +186,7 @@ static struct io_test_args	test_args;
 int
 setup_io(void **state)
 {
-	srand(SETUP_RANDOM_SEED);
+	srand(time(NULL));
 	test_args_init(&test_args, VPOOL_SIZE);
 
 	*state = &test_args;


### PR DESCRIPTION
The pseudo random sequences returned by rand() are repeatable by
calling srand() with same seed value, so srand(seed) shouldn't be
called in each lib function where the rand() is called, otherwise,
the same random sequence will be generated unexpectedly. (since
seed is usually set as time(NULL), when the lib function is called
multiple times within same second, same sequence will be used).

Signed-off-by: Niu Yawei <yawei.niu@intel.com>
Change-Id: Ie5e6defa6ede8515480ff7df93ba3d36c7153bb5