### PR TITLE
DAOS-1822 control: Fix incorrect package comments

### DIFF
--- a/src/control/drpc/drpc_client_test.go
+++ b/src/control/drpc/drpc_client_test.go
@@ -20,6 +20,7 @@
 // Any reproduction of computer software, computer software documentation, or
 // portions thereof marked with this legend must also reproduce the markings.
 //
+
 package drpc
 
 import (

--- a/src/control/server/config_bdev_test.go
+++ b/src/control/server/config_bdev_test.go
@@ -20,6 +20,7 @@
 // Any reproduction of computer software, computer software documentation, or
 // portions thereof marked with this legend must also reproduce the markings.
 //
+
 package main
 
 import (

--- a/src/control/server/config_test.go
+++ b/src/control/server/config_test.go
@@ -20,6 +20,7 @@
 // Any reproduction of computer software, computer software documentation, or
 // portions thereof marked with this legend must also reproduce the markings.
 //
+
 package main
 
 import (

--- a/src/control/server/main.go
+++ b/src/control/server/main.go
@@ -20,6 +20,7 @@
 // Any reproduction of computer software, computer software documentation, or
 // portions thereof marked with this legend must also reproduce the markings.
 //
+
 package main
 
 import (


### PR DESCRIPTION
The copyright comment shouldn't be a package comment, which shows up in
GoDoc describing what the package does.

Change-Id: I489ef3f479d79b85828ff2dc532511e6a0fd9687
Signed-off-by: Li Wei <wei.g.li@intel.com>