### PR TITLE
DAOS-1955 evtree: return actual rsize on iter_fetch

### DIFF
--- a/src/vos/vos_io.c
+++ b/src/vos/vos_io.c
@@ -364,15 +364,9 @@ akey_fetch_recx(daos_handle_t toh, daos_epoch_t epoch, daos_recx_t *recx,
 			holes = 0;
 		}
 
-		/**
-		 * XXX Let's set iod_size = 0 for non-existent
-		 * records, since client still need this for
-		 * some cases, see check_record_cb().
-		 */
 		if (rsize == 0)
 			rsize = ent_array.ea_inob;
-		else
-			D_ASSERT(rsize == ent_array.ea_inob);
+		D_ASSERT(rsize == ent_array.ea_inob);
 
 		biov.bi_data_len = nr * ent_array.ea_inob;
 		biov.bi_addr = ent->en_addr;
@@ -536,7 +530,11 @@ akey_fetch(struct vos_io_context *ioc, daos_handle_t ak_toh)
 			goto out;
 		}
 
-		if (rsize == 0) /* empty tree */
+		/*
+		 * Empty tree or all holes, DAOS array API relies on zero
+		 * iod_size to see if an array cell is empty.
+		 */
+		if (rsize == 0)
 			continue;
 
 		if (iod->iod_size == 0)

--- a/src/vos/vos_obj.c
+++ b/src/vos/vos_obj.c
@@ -860,7 +860,7 @@ recx_iter_fetch(struct vos_obj_iter *oiter, vos_iter_entry_t *it_entry,
 	it_entry->ie_orig_recx.rx_idx = ext->ex_lo;
 	it_entry->ie_orig_recx.rx_nr	 = evt_extent_width(ext);
 	it_entry->ie_recx_flags = entry.en_visibility;
-	it_entry->ie_rsize	 = bio_addr_is_hole(&entry.en_addr) ? 0 : inob;
+	it_entry->ie_rsize	= inob;
 	it_entry->ie_ver	= entry.en_ver;
 	it_entry->ie_biov.bi_buf = NULL;
 	it_entry->ie_biov.bi_data_len = it_entry->ie_recx.rx_nr *


### PR DESCRIPTION
Evtree iter_fetch should return actual rsize for punched record
instead of zero, so that caller can tell the size of the hole.
(This is helpful for evtree aggregation)

Adjusted enumeration pack code accordingly, and revised ambiguous
comment about rsize on evtree recx fetch.

Signed-off-by: Niu Yawei <yawei.niu@intel.com>
Change-Id: I89ffc5e6a277693ca455e1bdd58eb12cd452198b