### PR TITLE
DAOS-1822 control: Simplify configuration.populateEnv

### DIFF
--- a/src/control/drpc/drpc_client_test.go
+++ b/src/control/drpc/drpc_client_test.go
@@ -20,6 +20,7 @@
 // Any reproduction of computer software, computer software documentation, or
 // portions thereof marked with this legend must also reproduce the markings.
 //
+
 package drpc
 
 import (

--- a/src/control/server/config.go
+++ b/src/control/server/config.go
@@ -349,7 +349,7 @@ func (c *configuration) getIOParams(cliOpts *cliOptions) error {
 }
 
 // PopulateEnv adds envs from config options
-func (c *configuration) populateEnv(ioIdx int, envs *[]string) error {
+func (c *configuration) populateEnv(ioIdx int, envs *[]string) {
 	for _, env := range c.Servers[ioIdx].EnvVars {
 		kv := strings.Split(env, "=")
 		if kv[1] == "" {
@@ -357,5 +357,4 @@ func (c *configuration) populateEnv(ioIdx int, envs *[]string) error {
 		}
 		*envs = append(*envs, env)
 	}
-	return nil
 }

--- a/src/control/server/config_bdev_test.go
+++ b/src/control/server/config_bdev_test.go
@@ -20,6 +20,7 @@
 // Any reproduction of computer software, computer software documentation, or
 // portions thereof marked with this legend must also reproduce the markings.
 //
+
 package main
 
 import (

--- a/src/control/server/config_test.go
+++ b/src/control/server/config_test.go
@@ -719,7 +719,6 @@ func TestPopulateEnv(t *testing.T) {
 		outEnvs   []string
 		getParams bool
 		desc      string
-		errMsg    string
 	}{
 		{
 			newDefaultMockConfig(),
@@ -728,7 +727,6 @@ func TestPopulateEnv(t *testing.T) {
 			[]string{},
 			false,
 			"empty config (no envs) and getenv returns empty",
-			"",
 		},
 		{
 			newDefaultMockConfig(),
@@ -737,7 +735,6 @@ func TestPopulateEnv(t *testing.T) {
 			[]string{"FOO=bar"},
 			false,
 			"empty config (no envs) and getenv returns empty",
-			"",
 		},
 		{
 			populateMockConfig(t, newDefaultMockConfig(), socketsExample),
@@ -760,7 +757,6 @@ func TestPopulateEnv(t *testing.T) {
 			},
 			true,
 			"sockets populated config (with envs) and getenv returns empty",
-			"",
 		},
 		{
 			populateMockConfig(t, envExistsConfig(), socketsExample),
@@ -795,7 +791,6 @@ func TestPopulateEnv(t *testing.T) {
 			},
 			true,
 			"sockets populated config (with envs) and getenv returns with 'somevalue'",
-			"",
 		},
 		{
 			populateMockConfig(t, newDefaultMockConfig(), psm2Example),
@@ -817,7 +812,6 @@ func TestPopulateEnv(t *testing.T) {
 			},
 			true,
 			"psm2 populated config (with envs) and getenv returns empty",
-			"",
 		},
 		{
 			populateMockConfig(t, envExistsConfig(), psm2Example),
@@ -853,7 +847,6 @@ func TestPopulateEnv(t *testing.T) {
 			},
 			true,
 			"psm2 populated config (with envs) and getenv returns with 'somevalue'",
-			"",
 		},
 	}
 
@@ -873,14 +866,7 @@ func TestPopulateEnv(t *testing.T) {
 			}
 		}
 		// pass in env and verify output envs is as expected
-		err := config.populateEnv(tt.ioIdx, &inEnvs)
-		if tt.errMsg != "" {
-			ExpectError(t, err, tt.errMsg, tt.desc)
-			continue
-		}
-		if err != nil {
-			t.Fatalf("Envs could not be populated (%s: %s)", tt.desc, err)
-		}
+		config.populateEnv(tt.ioIdx, &inEnvs)
 		AssertEqual(t, inEnvs, tt.outEnvs, tt.desc)
 	}
 }

--- a/src/control/server/config_test.go
+++ b/src/control/server/config_test.go
@@ -20,6 +20,7 @@
 // Any reproduction of computer software, computer software documentation, or
 // portions thereof marked with this legend must also reproduce the markings.
 //
+
 package main
 
 import (

--- a/src/control/server/iosrv.go
+++ b/src/control/server/iosrv.go
@@ -1,0 +1,151 @@
+//
+// (C) Copyright 2019 Intel Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// GOVERNMENT LICENSE RIGHTS-OPEN SOURCE SOFTWARE
+// The Government's rights to use, modify, reproduce, release, perform, display,
+// or disclose this software are subject to the terms of the Apache License as
+// provided in Contract No. 8F-30005.
+// Any reproduction of computer software, computer software documentation, or
+// portions thereof marked with this legend must also reproduce the markings.
+//
+
+package main
+
+import (
+	"fmt"
+	"io/ioutil"
+	"net"
+	"os"
+	"path/filepath"
+
+	"github.com/pkg/errors"
+	"github.com/satori/go.uuid"
+	"gopkg.in/yaml.v2"
+
+	"github.com/daos-stack/daos/src/control/common"
+	"github.com/daos-stack/daos/src/control/log"
+)
+
+func formatIosrvs(config *configuration, reformat bool) error {
+	// Determine if an I/O server needs to createMs or bootstrapMs.
+	addr, err := net.ResolveTCPAddr("tcp", fmt.Sprintf("0.0.0.0:%d", config.Port))
+	if err != nil {
+		return errors.WithStack(err)
+	}
+	createMs, bootstrapMs, err := checkMgmtSvcReplica(addr, config.AccessPoints)
+	if err != nil {
+		return err
+	}
+
+	for i := range config.Servers {
+		// Only the first I/O server can be an MS replica.
+		if i == 0 {
+			err = formatIosrv(config, i, reformat, createMs, bootstrapMs)
+		} else {
+			err = formatIosrv(config, i, reformat, false, false)
+		}
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func formatIosrv(config *configuration, i int, reformat, createMs, bootstrapMs bool) error {
+	op := "format"
+	if reformat {
+		op = "reformat"
+	}
+	op += " server " + config.Servers[i].ScmMount
+
+	if _, err := os.Stat(iosrvSuperPath(config.Servers[i].ScmMount)); err == nil {
+		if reformat {
+			return errors.New(op + ": reformat not implemented yet")
+		} else {
+			return nil
+		}
+	} else if !os.IsNotExist(err) {
+		return errors.Wrap(err, op)
+	}
+
+	log.Debugf(op+" (createMs=%t bootstrapMs=%t)", createMs, bootstrapMs)
+
+	if err := createIosrvSuper(config, i, reformat, createMs, bootstrapMs); err != nil {
+		return errors.WithMessage(err, op)
+	}
+
+	return nil
+}
+
+// iosrvSuper is the per-I/O-server "superblock".
+type iosrvSuper struct {
+	Uuid        string
+	System      string
+	Rank        *rank
+	CreateMs    bool
+	BootstrapMs bool
+}
+
+// iosrvSuperPath returns the path to the I/O server superblock file.
+func iosrvSuperPath(root string) string {
+	return filepath.Join(root, "superblock")
+}
+
+// createIosrvSuper creates the superblock file for config.Servers[i]. Called
+// when formatting an I/O server.
+func createIosrvSuper(config *configuration, i int, reformat, createMs, bootstrapMs bool) error {
+	// Initialize the superblock object.
+	u, err := uuid.NewV4()
+	if err != nil {
+		return errors.Wrap(err, "generate server UUID")
+	}
+	super := &iosrvSuper{
+		Uuid:        u.String(),
+		System:      config.SystemName,
+		CreateMs:    createMs,
+		BootstrapMs: bootstrapMs,
+	}
+	if config.Servers[i].Rank != nil {
+		super.Rank = new(rank)
+		*super.Rank = *config.Servers[i].Rank
+	}
+
+	// Write the superblock.
+	return writeIosrvSuper(iosrvSuperPath(config.Servers[i].ScmMount), super)
+}
+
+func readIosrvSuper(path string) (*iosrvSuper, error) {
+	b, err := ioutil.ReadFile(path)
+	if err != nil {
+		return nil, errors.WithStack(err)
+	}
+
+	var s iosrvSuper
+	if err = yaml.Unmarshal(b, &s); err != nil {
+		return nil, errors.Wrapf(err, "unmarshal %s", path)
+	}
+
+	return &s, nil
+}
+
+func writeIosrvSuper(path string, super *iosrvSuper) error {
+	data, err := yaml.Marshal(super)
+	if err != nil {
+		return errors.Wrapf(err, "marshal %s", path)
+	}
+
+	return common.WriteFileAtomic(path, data, 0600)
+}

--- a/src/control/server/main.go
+++ b/src/control/server/main.go
@@ -162,6 +162,12 @@ func main() {
 	go grpcServer.Serve(lis)
 	defer grpcServer.GracefulStop()
 
+	// Format the unformatted servers.
+	if err = formatIosrvs(&config, false); err != nil {
+		log.Errorf("Failed to format servers: %s", err)
+		return
+	}
+
 	// Init socket and start drpc server to communicate with DAOS I/O servers.
 	if err = drpcSetup(config.SocketDir); err != nil {
 		log.Errorf("Failed to set up dRPC: %s", err)

--- a/src/control/server/main.go
+++ b/src/control/server/main.go
@@ -37,8 +37,8 @@ import (
 
 	"github.com/daos-stack/daos/src/control/common"
 	mgmtpb "github.com/daos-stack/daos/src/control/common/proto/mgmt"
-	secpb "github.com/daos-stack/daos/src/control/security/proto"
 	"github.com/daos-stack/daos/src/control/log"
+	secpb "github.com/daos-stack/daos/src/control/security/proto"
 )
 
 // ShowStorageCommand is the struct representing the command to list storage.
@@ -199,10 +199,7 @@ func main() {
 	srv.Env = os.Environ()
 
 	// Populate I/O server environment with values from config before starting.
-	if err = config.populateEnv(ioIdx, &srv.Env); err != nil {
-		log.Errorf("DAOS I/O env vars could not be populated: %s", err)
-		return
-	}
+	config.populateEnv(ioIdx, &srv.Env)
 
 	// I/O server should get a SIGKILL if this process dies.
 	srv.SysProcAttr = &syscall.SysProcAttr{

--- a/src/control/server/main.go
+++ b/src/control/server/main.go
@@ -20,6 +20,7 @@
 // Any reproduction of computer software, computer software documentation, or
 // portions thereof marked with this legend must also reproduce the markings.
 //
+
 package main
 
 import (


### PR DESCRIPTION
Remove the unnecessary error return value from
configuration.populateEnv.

Change-Id: Ie4589f23725ba936e7328680e729024b49462383
Signed-off-by: Li Wei <wei.g.li@intel.com>