### PR TITLE
DAOS-2028 vos: ignore invalid eprs

### DIFF
--- a/src/pool/cli.c
+++ b/src/pool/cli.c
@@ -1104,12 +1104,12 @@ dc_pool_update_internal(tse_task_t *task, daos_pool_update_t *args,
 	if (state == NULL) {
 		if (args->tgts == NULL || args->tgts->tl_nr == 0) {
 			D_ERROR("NULL tgts or tgts->tl_nr is zero\n");
-			return -DER_INVAL;
+			D_GOTO(out_task, rc = -DER_INVAL);
 		} else if ((opc == POOL_EXCLUDE || opc == POOL_EXCLUDE_OUT) &&
 			   args->tgts->tl_nr > 1) {
 			D_ERROR("pool exclude can only work with "
 				"(tgts->tl_nr == 1) for now.\n");
-			return -DER_INVAL;
+			D_GOTO(out_task, rc = -DER_INVAL);
 		}
 
 		D_DEBUG(DF_DSMC, DF_UUID": excluding %u targets:"

--- a/src/tests/suite/daos_obj.c
+++ b/src/tests/suite/daos_obj.c
@@ -194,7 +194,8 @@ ioreq_iod_simple_set(struct ioreq *req, daos_size_t *iod_size, bool lookup,
 			iod[i].iod_recxs[0].rx_idx = idx[i] + i * SEGMENT_SIZE;
 			iod[i].iod_recxs[0].rx_nr = rx_nr[i];
 		}
-		iod[i].iod_eprs = NULL;
+		/** Try I/O with invalid epoch, which then suould be ignored */
+		iod[i].iod_eprs = &req->erange[i][0]; /* [ 0 - MAX_EPOCH ] */
 		iod[i].iod_nr = 1;
 	}
 }
@@ -965,6 +966,7 @@ io_simple_internal(void **state, daos_obj_id_t oid, unsigned int size,
 		assert_int_equal(req.iod[0].iod_size, size);
 		assert_memory_equal(update_buf, fetch_buf, size);
 	}
+	punch_dkey(dkey, DAOS_TX_NONE, &req);
 	D_FREE(update_buf);
 	D_FREE(fetch_buf);
 	ioreq_fini(&req);

--- a/src/vos/vos_io.c
+++ b/src/vos/vos_io.c
@@ -437,7 +437,7 @@ akey_fetch(struct vos_io_context *ioc, daos_handle_t ak_toh)
 		flags |= SUBTR_EVT;
 
 	if (iod->iod_type == DAOS_IOD_SINGLE) {
-		if (iod->iod_eprs)
+		if (iod->iod_eprs && iod->iod_eprs[0].epr_lo != 0)
 			epoch = iod->iod_eprs[0].epr_lo;
 
 		rc = key_tree_prepare(ioc->ic_obj, epoch, ak_toh, VOS_BTR_AKEY,
@@ -491,7 +491,7 @@ akey_fetch(struct vos_io_context *ioc, daos_handle_t ak_toh)
 	iod->iod_size = 0;
 	for (i = 0; i < iod->iod_nr; i++) {
 		daos_size_t rsize;
-		if (iod->iod_eprs)
+		if (iod->iod_eprs && iod->iod_eprs[i].epr_lo)
 			epoch = iod->iod_eprs[i].epr_lo;
 
 		/* If epoch on each iod_eprs are out of boundary, then it needs
@@ -778,11 +778,11 @@ akey_update(struct vos_io_context *ioc, uint32_t pm_ver, daos_handle_t ak_toh,
 	if (is_array)
 		flags |= SUBTR_EVT;
 
-	if (iod->iod_eprs == NULL)
+	if (iod->iod_eprs == NULL || iod->iod_eprs[0].epr_lo == 0)
 		akey_epr.epr_hi = akey_epr.epr_lo = epoch;
 
 	if (iod->iod_type == DAOS_IOD_SINGLE) {
-		if (iod->iod_eprs) {
+		if (iod->iod_eprs && iod->iod_eprs[0].epr_lo != 0) {
 			epoch = iod->iod_eprs[0].epr_lo;
 			update_bounds(&akey_epr, &iod->iod_eprs[0]);
 		}
@@ -800,7 +800,7 @@ akey_update(struct vos_io_context *ioc, uint32_t pm_ver, daos_handle_t ak_toh,
 	} /* else: array */
 
 	for (i = 0; i < iod->iod_nr; i++) {
-		if (iod->iod_eprs) {
+		if (iod->iod_eprs && iod->iod_eprs[i].epr_lo != 0) {
 			update_bounds(&akey_epr, &iod->iod_eprs[i]);
 			epoch = iod->iod_eprs[i].epr_lo;
 		}


### PR DESCRIPTION
Igore invalid eprs inside IOD for akey
fetch and update.

Add test to verify it.

Minor fixes in dc_pool_update_internal to
complete task for failure cases.

Signed-off-by: Wang Di <di.wang@intel.com>
Change-Id: I1b4e7cd2ed2835121dd8636d10cc7d39e594c15d