### PR TITLE
DAOS-1939 mgmt: drpc module and handler registration

### DIFF
--- a/src/include/daos/drpc_modules.h
+++ b/src/include/daos/drpc_modules.h
@@ -36,6 +36,7 @@
 enum drpc_module {
 	DRPC_MODULE_TEST		= 0,	/* Reserved for testing */
 	DRPC_MODULE_SECURITY_AGENT	= 1,
+	DRPC_MODULE_MGMT_SERVER		= 2,
 
 	NUM_DRPC_MODULES			/* Must be last */
 };

--- a/src/iosrv/tests/drpc_handler_tests.c
+++ b/src/iosrv/tests/drpc_handler_tests.c
@@ -49,9 +49,15 @@ dummy_drpc_handler2(Drpc__Call *request, Drpc__Response **response)
 {
 }
 
+static void
+dummy_drpc_handler3(Drpc__Call *request, Drpc__Response **response)
+{
+}
+
 static drpc_handler_t handler_funcs[] = {
 		dummy_drpc_handler1,
-		dummy_drpc_handler2
+		dummy_drpc_handler2,
+		dummy_drpc_handler3
 };
 
 /*
@@ -176,11 +182,15 @@ drpc_hdlr_register_multiple(void **state)
 			dummy_drpc_handler1), DER_SUCCESS);
 	assert_int_equal(drpc_hdlr_register(DRPC_MODULE_SECURITY_AGENT,
 			dummy_drpc_handler2), DER_SUCCESS);
+	assert_int_equal(drpc_hdlr_register(DRPC_MODULE_MGMT_SERVER,
+			dummy_drpc_handler3), DER_SUCCESS);
 
 	assert_ptr_equal(drpc_hdlr_get_handler(DRPC_MODULE_TEST),
 			dummy_drpc_handler1);
 	assert_ptr_equal(drpc_hdlr_get_handler(DRPC_MODULE_SECURITY_AGENT),
 			dummy_drpc_handler2);
+	assert_ptr_equal(drpc_hdlr_get_handler(DRPC_MODULE_MGMT_SERVER),
+			dummy_drpc_handler3);
 }
 
 static void

--- a/src/mgmt/srv.c
+++ b/src/mgmt/srv.c
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2016 Intel Corporation.
+ * (C) Copyright 2016-2019 Intel Corporation.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -35,6 +35,9 @@
 #include "srv_internal.h"
 #include <signal.h>
 
+/** Fully qualified path to daos_server socket */
+char *ds_mgmt_server_socket_path;
+
 static struct crt_corpc_ops ds_mgmt_hdlr_tgt_create_co_ops = {
 	.co_aggregate	= ds_mgmt_tgt_create_aggregator,
 	.co_pre_forward	= NULL,
@@ -56,6 +59,23 @@ static struct daos_rpc_handler mgmt_handlers[] = {
 };
 
 #undef X
+
+static void
+mgmt_drpc_handler(Drpc__Call *request, Drpc__Response **response)
+{
+	D_DEBUG(DB_MGMT, "call received by mgmt drpc handler\n");
+}
+
+static struct dss_drpc_handler mgmt_drpc_handlers[] = {
+	{
+		.module_id = DRPC_MODULE_MGMT_SERVER,
+		.handler = mgmt_drpc_handler
+	},
+	{
+		.module_id = 0,
+		.handler = NULL
+	}
+};
 
 /**
  * Set parameter on a single target.
@@ -189,6 +209,12 @@ ds_mgmt_init()
 	if (rc)
 		return rc;
 
+	rc = asprintf(&ds_mgmt_server_socket_path, "%s/%s",
+			dss_socket_dir, "daos_server.sock");
+	if (rc < 0) {
+		return rc;
+	}
+
 	D_DEBUG(DB_MGMT, "successfull init call\n");
 	return 0;
 }
@@ -197,17 +223,20 @@ static int
 ds_mgmt_fini()
 {
 	ds_mgmt_tgt_fini();
+	free(ds_mgmt_server_socket_path);
+	ds_mgmt_server_socket_path = NULL;
 	D_DEBUG(DB_MGMT, "successfull fini call\n");
 	return 0;
 }
 
 struct dss_module mgmt_module = {
-	.sm_name	= "mgmt",
-	.sm_mod_id	= DAOS_MGMT_MODULE,
-	.sm_ver		= DAOS_MGMT_VERSION,
-	.sm_init	= ds_mgmt_init,
-	.sm_fini	= ds_mgmt_fini,
-	.sm_proto_fmt	= &mgmt_proto_fmt,
-	.sm_cli_count	= MGMT_PROTO_CLI_COUNT,
-	.sm_handlers	= mgmt_handlers,
+	.sm_name		= "mgmt",
+	.sm_mod_id		= DAOS_MGMT_MODULE,
+	.sm_ver			= DAOS_MGMT_VERSION,
+	.sm_init		= ds_mgmt_init,
+	.sm_fini		= ds_mgmt_fini,
+	.sm_proto_fmt		= &mgmt_proto_fmt,
+	.sm_cli_count		= MGMT_PROTO_CLI_COUNT,
+	.sm_handlers		= mgmt_handlers,
+	.sm_drpc_handlers	= mgmt_drpc_handlers,
 };

--- a/src/mgmt/srv_internal.h
+++ b/src/mgmt/srv_internal.h
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2016 Intel Corporation.
+ * (C) Copyright 2016-2019 Intel Corporation.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -37,6 +37,7 @@
 #include "rpc.h"
 
 /** srv.c */
+extern char *ds_mgmt_server_socket_path;
 void ds_mgmt_hdlr_svc_rip(crt_rpc_t *rpc);
 void ds_mgmt_params_set_hdlr(crt_rpc_t *rpc);
 void ds_mgmt_tgt_params_set_hdlr(crt_rpc_t *rpc);
@@ -52,4 +53,25 @@ void ds_mgmt_hdlr_tgt_create(crt_rpc_t *rpc_req);
 void ds_mgmt_hdlr_tgt_destroy(crt_rpc_t *rpc_req);
 int ds_mgmt_tgt_create_aggregator(crt_rpc_t *source, crt_rpc_t *result,
 				  void *priv);
+
+/**
+ * Definitions for DAOS server dRPC modules and their methods.
+ * These numeric designations are used in dRPC communications in the Drpc__Call
+ * structure.
+ */
+
+/**
+ *  Module: Mgmt Server
+ *
+ *  The server module that deals with client mgmt requests.
+ */
+#define DRPC_MODULE_MGMT_SERVER				2
+
+/**
+ * Method: Kill Rank
+ *
+ * Kill server of given rank.
+ */
+#define DRPC_METHOD_MGMT_SERVER_KILL_RANK	201
+
 #endif /* __SRV_MGMT_INTERNAL_H__ */


### PR DESCRIPTION
Register mgmt drpc module to communicate with control plane and
create a simple handler to verify functionality.