### PR TITLE
CORCI-413 Fix daos_test log collection

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -632,11 +632,11 @@ pipeline {
                     }
                     post {
                         always {
-                            sh '''rm -rf src/tests/ftest/avocado/job-results/*/html/ "Functional"/
-                                  mkdir "Functional"/
-                                  ls daos.log* >/dev/null && mv daos.log* "Functional"/
+                            sh '''rm -rf src/tests/ftest/avocado/job-results/*/html/ Functional/
+                                  mkdir Functional/
+                                  ls *daos.log* >/dev/null && mv *daos.log* Functional/
                                   mv src/tests/ftest/avocado/job-results/* \
-                                     $(ls src/tests/ftest/*.stacktrace || true) "Functional"/'''
+                                     $(ls src/tests/ftest/*.stacktrace || true) Functional/'''
                             junit 'Functional/*/results.xml'
                             archiveArtifacts artifacts: 'Functional/**'
                         }

--- a/src/tests/ftest/util/ServerUtils.py
+++ b/src/tests/ftest/util/ServerUtils.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python
 '''
-  (C) Copyright 2018 Intel Corporation.
+  (C) Copyright 2018-2019 Intel Corporation.
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
@@ -59,6 +59,12 @@ def runServer(hostfile, setname, basepath, uri_path=None, env_dict=None):
 
         # first make sure there are no existing servers running
         killServer(servers)
+
+        # clean the tmpfs on the servers
+        for server in servers:
+            subprocess.check_call(['ssh', server,
+                "find /mnt/daos -mindepth 1 -maxdepth 1 -print0 | "
+                "xargs -0r rm -rf"])
 
         # pile of build time variables
         with open(os.path.join(basepath, ".build_vars.json")) as json_vars:


### PR DESCRIPTION
The daos.log collection was not accounting for the logs that
have the subtest name prefixed to it.

Change-Id: I56f98112917e4c3f5ceda41482421e8fc8f4ebed
Signed-off-by: Brian J. Murrell <brian.murrell@intel.com>