### PR TITLE
CORCI-413 Fix daos_test log collection

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -632,11 +632,11 @@ pipeline {
                     }
                     post {
                         always {
-                            sh '''rm -rf src/tests/ftest/avocado/job-results/*/html/ "Functional"/
-                                  mkdir "Functional"/
-                                  ls daos.log* >/dev/null && mv daos.log* "Functional"/
+                            sh '''rm -rf src/tests/ftest/avocado/job-results/*/html/ Functional/
+                                  mkdir Functional/
+                                  ls *daos.log* >/dev/null && mv *daos.log* Functional/
                                   mv src/tests/ftest/avocado/job-results/* \
-                                     $(ls src/tests/ftest/*.stacktrace || true) "Functional"/'''
+                                     $(ls src/tests/ftest/*.stacktrace || true) Functional/'''
                             junit 'Functional/*/results.xml'
                             archiveArtifacts artifacts: 'Functional/**'
                         }


### PR DESCRIPTION
The daos.log collection was not accounting for the logs that
have the subtest name prefixed to it.

Change-Id: I56f98112917e4c3f5ceda41482421e8fc8f4ebed