### PR TITLE
DAOS-1939 mgmt: drpc module and handler registration

### DIFF
--- a/src/include/daos/drpc_modules.h
+++ b/src/include/daos/drpc_modules.h
@@ -36,8 +36,15 @@
 enum drpc_module {
 	DRPC_MODULE_TEST		= 0,	/* Reserved for testing */
 	DRPC_MODULE_SECURITY_AGENT	= 1,
+	DRPC_MODULE_MGMT_SERVER		= 2,
 
 	NUM_DRPC_MODULES			/* Must be last */
+};
+
+enum drpc_mgmt_server_method {
+	DRPC_METHOD_MGMT_SERVER_KILL_RANK	= 201,
+
+	NUM_DRPC_MGMT_SERVER_METHODS			/* Must be last */
 };
 
 #endif /* __DAOS_DRPC_MODULES_H__ */

--- a/src/include/daos/drpc_modules.h
+++ b/src/include/daos/drpc_modules.h
@@ -41,10 +41,10 @@ enum drpc_module {
 	NUM_DRPC_MODULES			/* Must be last */
 };
 
-enum drpc_mgmt_server_method {
-	DRPC_METHOD_MGMT_SERVER_KILL_RANK	= 201,
+enum drpc_mgmt_method {
+	DRPC_METHOD_MGMT_KILL_RANK	= 201,
 
-	NUM_DRPC_MGMT_SERVER_METHODS			/* Must be last */
+	NUM_DRPC_MGMT_METHODS			/* Must be last */
 };
 
 #endif /* __DAOS_DRPC_MODULES_H__ */

--- a/src/iosrv/tests/drpc_handler_tests.c
+++ b/src/iosrv/tests/drpc_handler_tests.c
@@ -49,9 +49,15 @@ dummy_drpc_handler2(Drpc__Call *request, Drpc__Response **response)
 {
 }
 
+static void
+dummy_drpc_handler3(Drpc__Call *request, Drpc__Response **response)
+{
+}
+
 static drpc_handler_t handler_funcs[] = {
 		dummy_drpc_handler1,
-		dummy_drpc_handler2
+		dummy_drpc_handler2,
+		dummy_drpc_handler3
 };
 
 /*
@@ -176,11 +182,15 @@ drpc_hdlr_register_multiple(void **state)
 			dummy_drpc_handler1), DER_SUCCESS);
 	assert_int_equal(drpc_hdlr_register(DRPC_MODULE_SECURITY_AGENT,
 			dummy_drpc_handler2), DER_SUCCESS);
+	assert_int_equal(drpc_hdlr_register(DRPC_MODULE_MGMT_SERVER,
+			dummy_drpc_handler3), DER_SUCCESS);
 
 	assert_ptr_equal(drpc_hdlr_get_handler(DRPC_MODULE_TEST),
 			dummy_drpc_handler1);
 	assert_ptr_equal(drpc_hdlr_get_handler(DRPC_MODULE_SECURITY_AGENT),
 			dummy_drpc_handler2);
+	assert_ptr_equal(drpc_hdlr_get_handler(DRPC_MODULE_MGMT_SERVER),
+			dummy_drpc_handler3);
 }
 
 static void

--- a/src/mgmt/srv.c
+++ b/src/mgmt/srv.c
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2016 Intel Corporation.
+ * (C) Copyright 2016-2019 Intel Corporation.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -32,8 +32,10 @@
  */
 #define D_LOGFAC	DD_FAC(mgmt)
 
-#include "srv_internal.h"
 #include <signal.h>
+#include <daos/drpc_modules.h>
+
+#include "srv_internal.h"
 
 static struct crt_corpc_ops ds_mgmt_hdlr_tgt_create_co_ops = {
 	.co_aggregate	= ds_mgmt_tgt_create_aggregator,
@@ -56,6 +58,23 @@ static struct daos_rpc_handler mgmt_handlers[] = {
 };
 
 #undef X
+
+static void
+mgmt_drpc_handler(Drpc__Call *request, Drpc__Response **response)
+{
+	D_DEBUG(DB_MGMT, "call received by mgmt drpc handler\n");
+}
+
+static struct dss_drpc_handler mgmt_drpc_handlers[] = {
+	{
+		.module_id = DRPC_MODULE_MGMT_SERVER,
+		.handler = mgmt_drpc_handler
+	},
+	{
+		.module_id = 0,
+		.handler = NULL
+	}
+};
 
 /**
  * Set parameter on a single target.
@@ -202,12 +221,13 @@ ds_mgmt_fini()
 }
 
 struct dss_module mgmt_module = {
-	.sm_name	= "mgmt",
-	.sm_mod_id	= DAOS_MGMT_MODULE,
-	.sm_ver		= DAOS_MGMT_VERSION,
-	.sm_init	= ds_mgmt_init,
-	.sm_fini	= ds_mgmt_fini,
-	.sm_proto_fmt	= &mgmt_proto_fmt,
-	.sm_cli_count	= MGMT_PROTO_CLI_COUNT,
-	.sm_handlers	= mgmt_handlers,
+	.sm_name		= "mgmt",
+	.sm_mod_id		= DAOS_MGMT_MODULE,
+	.sm_ver			= DAOS_MGMT_VERSION,
+	.sm_init		= ds_mgmt_init,
+	.sm_fini		= ds_mgmt_fini,
+	.sm_proto_fmt		= &mgmt_proto_fmt,
+	.sm_cli_count		= MGMT_PROTO_CLI_COUNT,
+	.sm_handlers		= mgmt_handlers,
+	.sm_drpc_handlers	= mgmt_drpc_handlers,
 };

--- a/src/mgmt/srv_internal.h
+++ b/src/mgmt/srv_internal.h
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2016 Intel Corporation.
+ * (C) Copyright 2016-2019 Intel Corporation.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -34,6 +34,7 @@
 #include <daos/rpc.h>
 #include <daos/common.h>
 #include <daos_srv/daos_server.h>
+
 #include "rpc.h"
 
 /** srv.c */
@@ -52,4 +53,5 @@ void ds_mgmt_hdlr_tgt_create(crt_rpc_t *rpc_req);
 void ds_mgmt_hdlr_tgt_destroy(crt_rpc_t *rpc_req);
 int ds_mgmt_tgt_create_aggregator(crt_rpc_t *source, crt_rpc_t *result,
 				  void *priv);
+
 #endif /* __SRV_MGMT_INTERNAL_H__ */


### PR DESCRIPTION
Register mgmt drpc module to communicate with control plane and
create a simple handler to verify functionality.