### PR TITLE
DAOS-1822 control: Simplify configuration.populateEnv

### DIFF
--- a/src/control/server/config.go
+++ b/src/control/server/config.go
@@ -349,7 +349,7 @@ func (c *configuration) getIOParams(cliOpts *cliOptions) error {
 }
 
 // PopulateEnv adds envs from config options
-func (c *configuration) populateEnv(ioIdx int, envs *[]string) error {
+func (c *configuration) populateEnv(ioIdx int, envs *[]string) {
 	for _, env := range c.Servers[ioIdx].EnvVars {
 		kv := strings.Split(env, "=")
 		if kv[1] == "" {
@@ -357,5 +357,4 @@ func (c *configuration) populateEnv(ioIdx int, envs *[]string) error {
 		}
 		*envs = append(*envs, env)
 	}
-	return nil
 }

--- a/src/control/server/config_test.go
+++ b/src/control/server/config_test.go
@@ -719,7 +719,6 @@ func TestPopulateEnv(t *testing.T) {
 		outEnvs   []string
 		getParams bool
 		desc      string
-		errMsg    string
 	}{
 		{
 			newDefaultMockConfig(),
@@ -728,7 +727,6 @@ func TestPopulateEnv(t *testing.T) {
 			[]string{},
 			false,
 			"empty config (no envs) and getenv returns empty",
-			"",
 		},
 		{
 			newDefaultMockConfig(),
@@ -737,7 +735,6 @@ func TestPopulateEnv(t *testing.T) {
 			[]string{"FOO=bar"},
 			false,
 			"empty config (no envs) and getenv returns empty",
-			"",
 		},
 		{
 			populateMockConfig(t, newDefaultMockConfig(), socketsExample),
@@ -760,7 +757,6 @@ func TestPopulateEnv(t *testing.T) {
 			},
 			true,
 			"sockets populated config (with envs) and getenv returns empty",
-			"",
 		},
 		{
 			populateMockConfig(t, envExistsConfig(), socketsExample),
@@ -795,7 +791,6 @@ func TestPopulateEnv(t *testing.T) {
 			},
 			true,
 			"sockets populated config (with envs) and getenv returns with 'somevalue'",
-			"",
 		},
 		{
 			populateMockConfig(t, newDefaultMockConfig(), psm2Example),
@@ -817,7 +812,6 @@ func TestPopulateEnv(t *testing.T) {
 			},
 			true,
 			"psm2 populated config (with envs) and getenv returns empty",
-			"",
 		},
 		{
 			populateMockConfig(t, envExistsConfig(), psm2Example),
@@ -853,7 +847,6 @@ func TestPopulateEnv(t *testing.T) {
 			},
 			true,
 			"psm2 populated config (with envs) and getenv returns with 'somevalue'",
-			"",
 		},
 	}
 
@@ -873,14 +866,7 @@ func TestPopulateEnv(t *testing.T) {
 			}
 		}
 		// pass in env and verify output envs is as expected
-		err := config.populateEnv(tt.ioIdx, &inEnvs)
-		if tt.errMsg != "" {
-			ExpectError(t, err, tt.errMsg, tt.desc)
-			continue
-		}
-		if err != nil {
-			t.Fatalf("Envs could not be populated (%s: %s)", tt.desc, err)
-		}
+		config.populateEnv(tt.ioIdx, &inEnvs)
 		AssertEqual(t, inEnvs, tt.outEnvs, tt.desc)
 	}
 }

--- a/src/control/server/main.go
+++ b/src/control/server/main.go
@@ -37,8 +37,8 @@ import (
 
 	"github.com/daos-stack/daos/src/control/common"
 	mgmtpb "github.com/daos-stack/daos/src/control/common/proto/mgmt"
-	secpb "github.com/daos-stack/daos/src/control/security/proto"
 	"github.com/daos-stack/daos/src/control/log"
+	secpb "github.com/daos-stack/daos/src/control/security/proto"
 )
 
 // ShowStorageCommand is the struct representing the command to list storage.
@@ -199,10 +199,7 @@ func main() {
 	srv.Env = os.Environ()
 
 	// Populate I/O server environment with values from config before starting.
-	if err = config.populateEnv(ioIdx, &srv.Env); err != nil {
-		log.Errorf("DAOS I/O env vars could not be populated: %s", err)
-		return
-	}
+	config.populateEnv(ioIdx, &srv.Env)
 
 	// I/O server should get a SIGKILL if this process dies.
 	srv.SysProcAttr = &syscall.SysProcAttr{


### PR DESCRIPTION
Remove the unnecessary error return value from
configuration.populateEnv.

Change-Id: Ie4589f23725ba936e7328680e729024b49462383
Signed-off-by: Li Wei <wei.g.li@intel.com>