### PR TITLE
DAOS-2157 object: unify I/O tunables

### DIFF
--- a/src/bio/bio_buffer.c
+++ b/src/bio/bio_buffer.c
@@ -669,7 +669,7 @@ dma_rw(struct bio_desc *biod, bool prep)
 	D_ASSERT(blob != NULL && channel != NULL);
 
 	/* Bypass NVMe I/O, used by daos_perf for performance evaluation */
-	if (nvme_io_bypass)
+	if (daos_io_bypass & IOBP_NVME)
 		return;
 
 	D_DEBUG(DB_IO, "DMA start, blob:%p, update:%d, rmw:%d\n",

--- a/src/bio/bio_internal.h
+++ b/src/bio/bio_internal.h
@@ -141,7 +141,6 @@ struct bio_desc {
 };
 
 /* bio_xstream.c */
-extern bool		nvme_io_bypass;
 extern unsigned int	bio_chk_sz;
 extern unsigned int	bio_chk_cnt_max;
 void xs_poll_completion(struct bio_xs_context *ctxt, unsigned int *inflights);

--- a/src/bio/bio_xstream.c
+++ b/src/bio/bio_xstream.c
@@ -54,8 +54,6 @@ enum {
 	BDEV_CLASS_UNKNOWN
 };
 
-/* Bypass NVMe I/O, used by daos_perf for performance evaluation */
-bool nvme_io_bypass;
 /* Chunk size of DMA buffer in pages */
 unsigned int bio_chk_sz;
 /* Per-xstream maximum DMA buffer size (in chunk count) */
@@ -197,15 +195,6 @@ bio_nvme_init(const char *storage_path, const char *nvme_conf, int shm_id)
 	io_stat_period *= (NSEC_PER_SEC / NSEC_PER_USEC);
 
 	nvme_glb.bd_shm_id = shm_id;
-
-	env = getenv("IO_BYPASS_ENV");
-	if (env && !strcasecmp(env, "nvme_io")) {
-		D_WARN("All NVMe I/O will be bypassed!\n");
-		nvme_io_bypass = true;
-	} else {
-		nvme_io_bypass = false;
-	}
-
 	return 0;
 
 free_cond:

--- a/src/common/mem.c
+++ b/src/common/mem.c
@@ -410,6 +410,36 @@ static umem_ops_t	vmem_ops = {
 	.mo_tx_add_callback = vmem_tx_add_callback,
 };
 
+static int
+pmem_no_tx_add(struct umem_instance *umm, umem_id_t ummid,
+	    uint64_t offset, size_t size)
+{
+	return 0;
+}
+
+static int
+pmem_no_tx_add_ptr(struct umem_instance *umm, void *ptr, size_t size)
+{
+	return 0;
+}
+
+static umem_ops_t	pmem_no_snap_ops = {
+	.mo_id			= pmem_id,
+	.mo_addr		= pmem_addr,
+	.mo_equal		= pmem_equal,
+	.mo_tx_free		= pmem_tx_free,
+	.mo_tx_alloc		= pmem_tx_alloc,
+	.mo_tx_add		= pmem_no_tx_add,
+	.mo_tx_add_ptr		= pmem_no_tx_add_ptr,
+	.mo_tx_abort		= pmem_tx_abort,
+	.mo_tx_begin		= pmem_tx_begin,
+	.mo_tx_commit		= pmem_tx_commit,
+	.mo_reserve		= pmem_reserve,
+	.mo_cancel		= pmem_cancel,
+	.mo_tx_publish		= pmem_tx_publish,
+	.mo_tx_add_callback	= pmem_tx_add_callback,
+};
+
 /** Unified memory class definition */
 struct umem_class {
 	umem_class_id_t           umc_id;
@@ -428,6 +458,11 @@ static struct umem_class umem_class_defined[] = {
 		.umc_id		= UMEM_CLASS_PMEM,
 		.umc_ops	= &pmem_ops,
 		.umc_name	= "pmem",
+	},
+	{
+		.umc_id		= UMEM_CLASS_PMEM_NO_SNAP,
+		.umc_ops	= &pmem_no_snap_ops,
+		.umc_name	= "pmem_no_snap",
 	},
 	{
 		.umc_id		= UMEM_CLASS_UNKNOWN,

--- a/src/include/daos/debug.h
+++ b/src/include/daos/debug.h
@@ -93,4 +93,36 @@ int  daos_debug_init(char *logfile);
 /** finalize the debug system */
 void daos_debug_fini(void);
 
+/** I/O bypass tunables for performance debugging */
+enum {
+	IOBP_OFF		= 0,
+	/** client RPC is not sent */
+	IOBP_CLI_RPC		= (1 << 0),
+	/** server ignores bulk transfer (garbage data is stored) */
+	IOBP_SRV_BULK		= (1 << 1),
+	/** bypass target I/O, no VOS and BIO at all */
+	IOBP_TARGET		= (1 << 2),
+	/** server does not store bulk data in NVMe (drop it) */
+	IOBP_NVME		= (1 << 3),
+	/** metadata and small I/O are stored in DRAM */
+	IOBP_PM			= (1 << 4),
+	/** no PMDK snapshot (PMDK transaction will be broken) */
+	IOBP_PM_SNAP		= (1 << 5),
+};
+
+/**
+ * This environment is mostly for performance debugging, it can be set to
+ * combination of strings below, invalid combination will be ignored.
+ */
+#define DENV_IO_BYPASS		"DAOS_IO_BYPASS"
+
+#define IOBP_ENV_CLI_RPC	"cli_rpc"
+#define IOBP_ENV_SRV_BULK	"srv_bulk"
+#define IOBP_ENV_TARGET		"target"
+#define IOBP_ENV_NVME		"nvme"
+#define IOBP_ENV_PM		"pm"
+#define IOBP_ENV_PM_SNAP	"pm_snap"
+
+extern unsigned int daos_io_bypass;
+
 #endif /* __DAOS_DEBUG_H__ */

--- a/src/include/daos/mem.h
+++ b/src/include/daos/mem.h
@@ -73,6 +73,8 @@ typedef enum {
 	UMEM_CLASS_VMEM,
 	/** persistent memory */
 	UMEM_CLASS_PMEM,
+	/** persistent memory but ignore PMDK snapshot */
+	UMEM_CLASS_PMEM_NO_SNAP,
 	/** unknown */
 	UMEM_CLASS_UNKNOWN,
 } umem_class_id_t;

--- a/src/object/cli_mod.c
+++ b/src/object/cli_mod.c
@@ -32,7 +32,6 @@
 #include "obj_rpc.h"
 #include "obj_internal.h"
 
-bool	cli_bypass_rpc;
 bool	srv_io_dispatch = true;
 
 /**
@@ -41,14 +40,7 @@ bool	srv_io_dispatch = true;
 int
 dc_obj_init(void)
 {
-	char	*env;
 	int	 rc;
-
-	env = getenv(IO_BYPASS_ENV);
-	if (env && !strcasecmp(env, "cli_rpc")) {
-		D_DEBUG(DB_IO, "All client I/O RPCs will be dropped\n");
-		cli_bypass_rpc = true;
-	}
 
 	d_getenv_bool("DAOS_IO_SRV_DISPATCH", &srv_io_dispatch);
 	if (srv_io_dispatch)

--- a/src/object/cli_shard.c
+++ b/src/object/cli_shard.c
@@ -447,7 +447,7 @@ obj_shard_rw(struct dc_obj_shard *shard, enum obj_rpc_opc opc,
 	if (rc != 0)
 		D_GOTO(out_args, rc);
 
-	if (cli_bypass_rpc) {
+	if (daos_io_bypass & IOBP_CLI_RPC) {
 		rc = daos_rpc_complete(req, task);
 	} else {
 		rc = daos_rpc_send(req, task);

--- a/src/object/obj_internal.h
+++ b/src/object/obj_internal.h
@@ -52,13 +52,6 @@ extern bool	cli_bypass_rpc;
 /** Switch of server-side IO dispatch */
 extern bool	srv_io_dispatch;
 
-/**
- * Bypass bulk transfer on server side, instead data will be copy from/to
- * dummy buffer.
- * this mode is for performance evaluation on low bandwidth network.
- */
-extern bool	srv_bypass_bulk;
-
 /** client object shard */
 struct dc_obj_shard {
 	/* Metadata for this shard */

--- a/src/object/srv_mod.c
+++ b/src/object/srv_mod.c
@@ -30,19 +30,9 @@
 #include "obj_rpc.h"
 #include "obj_internal.h"
 
-bool srv_bypass_bulk;
-
 static int
 obj_mod_init(void)
 {
-	char	*env;
-
-	env = getenv(IO_BYPASS_ENV);
-	if (env && !strcasecmp(env, "srv_bulk")) {
-		D_DEBUG(DB_IO, "All bulk data will be dropped\n");
-		srv_bypass_bulk = true;
-	}
-
 	dss_abt_pool_choose_cb_register(DAOS_OBJ_MODULE,
 					ds_obj_abt_pool_choose_cb);
 	return 0;

--- a/src/object/srv_obj.c
+++ b/src/object/srv_obj.c
@@ -230,7 +230,7 @@ ds_bulk_transfer(crt_rpc_t *rpc, crt_bulk_op_t bulk_op, bool bulk_bind,
 				break;
 		}
 
-		if (srv_bypass_bulk) {
+		if (daos_io_bypass & IOBP_SRV_BULK) {
 			/* this mode will bypass network bulk transfer and
 			 * only copy data from/to dummy buffer. This is for
 			 * performance evaluation on low bandwidth network.
@@ -629,7 +629,8 @@ ds_obj_rw_local_hdlr(crt_rpc_t *rpc, uint32_t tag, struct ds_cont_hdl *cont_hdl,
 	bool			 bulk_bind;
 	int			 rc, err;
 
-	if (daos_oc_echo_type(daos_obj_id2class(orw->orw_oid.id_pub))) {
+	if (daos_oc_echo_type(daos_obj_id2class(orw->orw_oid.id_pub)) ||
+	    (daos_io_bypass & IOBP_TARGET)) {
 		ds_obj_rw_echo_handler(rpc);
 		return 0;
 	}

--- a/src/tests/daos_perf.c
+++ b/src/tests/daos_perf.c
@@ -44,22 +44,20 @@
 /* unused object class to identify VOS (storage only) test mode */
 #define DAOS_OC_RAW	(0xBEEF)
 #define RANK_ZERO	(0)
-#define WITHOUT_FETCH	(false)
-#define WITH_FETCH	(true)
 #define TEST_VAL_SIZE	(3)
 
-enum ts_op_type_t {
+enum ts_op_type {
 	TS_DO_UPDATE = 0,
 	TS_DO_FETCH
 };
 
-enum ts_level_t {
-	TS_LVL_VOS,  /* pure storage */
-	TS_LVL_ECHO, /* pure network */
-	TS_LVL_DAOS, /* full stack */
+enum {
+	TS_MODE_VOS,  /* pure storage */
+	TS_MODE_ECHO, /* pure network */
+	TS_MODE_DAOS, /* full stack */
 };
 
-int			 ts_level = TS_LVL_VOS;
+int			 ts_mode = TS_MODE_VOS;
 int			 ts_class = DAOS_OC_RAW;
 
 char			 ts_pmem_file[PATH_MAX];
@@ -77,7 +75,7 @@ bool			 ts_zero_copy;
 /* verify the output of fetch */
 bool			 ts_verify_fetch;
 
-daos_handle_t		 ts_oh;			/* object open handle */
+daos_handle_t		*ts_ohs;		/* all opened objects */
 daos_obj_id_t		 ts_oid;		/* object ID */
 daos_unit_oid_t		 ts_uoid;		/* object shard ID (for VOS) */
 
@@ -90,13 +88,13 @@ bool			ts_rebuild_only_iteration = false;
 bool			ts_rebuild_no_update = false;
 
 static int
-ts_vos_update_or_fetch(struct dts_io_credit *cred, daos_epoch_t epoch,
-		       enum ts_op_type_t update_or_fetch)
+vos_update_or_fetch(enum ts_op_type op_type, struct dts_io_credit *cred,
+		    daos_epoch_t epoch)
 {
 	int	rc = 0;
 
 	if (!ts_zero_copy) {
-		if (update_or_fetch == TS_DO_UPDATE)
+		if (op_type == TS_DO_UPDATE)
 			rc = vos_obj_update(ts_ctx.tsc_coh, ts_uoid, epoch,
 				0, &cred->tc_dkey, 1, &cred->tc_iod,
 				&cred->tc_sgl);
@@ -108,7 +106,7 @@ ts_vos_update_or_fetch(struct dts_io_credit *cred, daos_epoch_t epoch,
 		struct bio_sglist	*bsgl;
 		daos_handle_t		 ioh;
 
-		if (update_or_fetch == TS_DO_UPDATE)
+		if (op_type == TS_DO_UPDATE)
 			rc = vos_update_begin(ts_ctx.tsc_coh, ts_uoid, epoch,
 					      &cred->tc_dkey, 1, &cred->tc_iod,
 					      &ioh);
@@ -128,7 +126,7 @@ ts_vos_update_or_fetch(struct dts_io_credit *cred, daos_epoch_t epoch,
 		D_ASSERT(bsgl->bs_nr_out == 1);
 		D_ASSERT(cred->tc_sgl.sg_nr == 1);
 
-		if (update_or_fetch == TS_DO_FETCH) {
+		if (op_type == TS_DO_FETCH) {
 			memcpy(cred->tc_sgl.sg_iovs[0].iov_buf,
 			       bsgl->bs_iovs[0].bi_buf,
 			       bsgl->bs_iovs[0].bi_data_len);
@@ -140,7 +138,7 @@ ts_vos_update_or_fetch(struct dts_io_credit *cred, daos_epoch_t epoch,
 
 		rc = bio_iod_post(vos_ioh2desc(ioh));
 end:
-		if (update_or_fetch == TS_DO_UPDATE)
+		if (op_type == TS_DO_UPDATE)
 			rc = vos_update_end(ioh, 0, &cred->tc_dkey, rc);
 		else
 			rc = vos_fetch_end(ioh, rc);
@@ -150,28 +148,25 @@ end:
 }
 
 static int
-ts_daos_update(struct dts_io_credit *cred, daos_epoch_t epoch)
+daos_update_or_fetch(daos_handle_t oh, enum ts_op_type op_type,
+		     struct dts_io_credit *cred, daos_epoch_t epoch)
 {
 	int	rc;
 
-	rc = daos_obj_update(ts_oh, DAOS_TX_NONE, &cred->tc_dkey, 1,
-			     &cred->tc_iod, &cred->tc_sgl, cred->tc_evp);
-	return rc;
-}
-
-static int
-ts_daos_fetch(struct dts_io_credit *cred, daos_epoch_t epoch)
-{
-	int	rc;
-
-	rc = daos_obj_fetch(ts_oh, DAOS_TX_NONE, &cred->tc_dkey, 1,
-			    &cred->tc_iod, &cred->tc_sgl, NULL, cred->tc_evp);
-
+	if (op_type == TS_DO_UPDATE) {
+		rc = daos_obj_update(oh, DAOS_TX_NONE, &cred->tc_dkey, 1,
+				     &cred->tc_iod, &cred->tc_sgl,
+				     cred->tc_evp);
+	} else {
+		rc = daos_obj_fetch(oh, DAOS_TX_NONE, &cred->tc_dkey, 1,
+				    &cred->tc_iod, &cred->tc_sgl, NULL,
+				    cred->tc_evp);
+	}
 	return rc;
 }
 
 static void
-ts_set_value_buffer(char *buffer, int idx)
+set_value_buffer(char *buffer, int idx)
 {
 	/* Sets a pattern of Aa, Bb, ..., Yy, Zz, Aa, ... */
 	buffer[0] = 'A' + idx % 26;
@@ -180,9 +175,9 @@ ts_set_value_buffer(char *buffer, int idx)
 }
 
 static int
-update_or_fetch_internal(char *dkey, char *akey, daos_epoch_t *epoch,
-			 int *indices, int idx, char *verify_buff,
-			 enum ts_op_type_t update_or_fetch, bool with_fetch)
+akey_update_or_fetch(daos_handle_t oh, enum ts_op_type op_type,
+		     char *dkey, char *akey, daos_epoch_t *epoch,
+		     int *indices, int idx, char *verify_buff)
 {
 	struct dts_io_credit *cred;
 	daos_iod_t	     *iod;
@@ -229,9 +224,9 @@ update_or_fetch_internal(char *dkey, char *akey, daos_epoch_t *epoch,
 	iod->iod_nr    = 1;
 	iod->iod_recxs = recx;
 
-	if (update_or_fetch == TS_DO_UPDATE) {
+	if (op_type == TS_DO_UPDATE) {
 		/* initialize value buffer and setup sgl */
-		ts_set_value_buffer(cred->tc_vbuf, idx);
+		set_value_buffer(cred->tc_vbuf, idx);
 	} else {
 		/* Clear the buffer for fetch */
 		memset(cred->tc_vbuf, 0, vsize);
@@ -241,18 +236,15 @@ update_or_fetch_internal(char *dkey, char *akey, daos_epoch_t *epoch,
 	sgl->sg_iovs = &cred->tc_val;
 	sgl->sg_nr = 1;
 
-	if (ts_class == DAOS_OC_RAW) {
-		rc = ts_vos_update_or_fetch(cred, *epoch, update_or_fetch);
-	} else {
-		if (update_or_fetch == TS_DO_UPDATE)
-			rc = ts_daos_update(cred, *epoch);
-		else
-			rc = ts_daos_fetch(cred, *epoch);
-	}
+	if (ts_mode == TS_MODE_VOS)
+		rc = vos_update_or_fetch(op_type, cred, *epoch);
+	else
+		rc = daos_update_or_fetch(oh, op_type, cred, *epoch);
 
 	if (rc != 0) {
 		fprintf(stderr, "%s failed. rc=%d, epoch=%"PRIu64"\n",
-			update_or_fetch ? "Fetch" : "Update", rc, *epoch);
+			op_type == TS_DO_FETCH ? "Fetch" : "Update",
+			rc, *epoch);
 		return rc;
 	}
 
@@ -269,12 +261,11 @@ update_or_fetch_internal(char *dkey, char *akey, daos_epoch_t *epoch,
 }
 
 static int
-ts_key_update_or_fetch(enum ts_op_type_t update_or_fetch, daos_epoch_t *epoch,
-		       bool with_fetch)
+dkey_update_or_fetch(daos_handle_t oh, enum ts_op_type op_type, char *dkey,
+		     daos_epoch_t *epoch)
 {
 	int		*indices;
-	char		 dkey_buf[DTS_KEY_LEN];
-	char		 akey_buf[DTS_KEY_LEN];
+	char		 akey[DTS_KEY_LEN];
 	int		 i;
 	int		 j;
 	int		 rc = 0;
@@ -282,13 +273,11 @@ ts_key_update_or_fetch(enum ts_op_type_t update_or_fetch, daos_epoch_t *epoch,
 	indices = dts_rand_iarr_alloc(ts_recx_p_akey, 0);
 	D_ASSERT(indices != NULL);
 
-	dts_key_gen(dkey_buf, DTS_KEY_LEN, "blade");
-
 	for (i = 0; i < ts_akey_p_dkey; i++) {
-		dts_key_gen(akey_buf, DTS_KEY_LEN, "walker");
+		dts_key_gen(akey, DTS_KEY_LEN, "walker");
 		for (j = 0; j < ts_recx_p_akey; j++) {
-			rc = update_or_fetch_internal(dkey_buf, akey_buf, epoch,
-				indices, j, NULL, update_or_fetch, with_fetch);
+			rc = akey_update_or_fetch(oh, op_type, dkey, akey,
+						  epoch, indices, j, NULL);
 			if (rc)
 				goto failed;
 		}
@@ -300,7 +289,7 @@ failed:
 }
 
 static int
-ts_write_records_internal(d_rank_t rank, bool with_fetch)
+objects_update(d_rank_t rank)
 {
 	int		i;
 	int		j;
@@ -316,9 +305,10 @@ ts_write_records_internal(d_rank_t rank, bool with_fetch)
 		ts_oid = dts_oid_gen(ts_class, 0, ts_ctx.tsc_mpi_rank);
 		if (ts_class == DAOS_OC_R2S_SPEC_RANK)
 			ts_oid = dts_oid_set_rank(ts_oid, rank);
-		if (ts_class != DAOS_OC_RAW) {
+
+		if (ts_mode == TS_MODE_DAOS) {
 			rc = daos_obj_open(ts_ctx.tsc_coh, ts_oid,
-					   DAOS_OO_RW, &ts_oh, NULL);
+					   DAOS_OO_RW, &ts_ohs[i], NULL);
 			if (rc) {
 				fprintf(stderr, "object open failed\n");
 				return -1;
@@ -329,27 +319,22 @@ ts_write_records_internal(d_rank_t rank, bool with_fetch)
 		}
 
 		for (j = 0; j < ts_dkey_p_obj; j++) {
-			rc = ts_key_update_or_fetch(TS_DO_UPDATE, &epoch,
-						    with_fetch);
-			if (rc)
-				return rc;
-		}
+			char	 dkey[DTS_KEY_LEN];
 
-		if (ts_class != DAOS_OC_RAW &&
-			with_fetch == WITHOUT_FETCH) {
-			rc = daos_obj_close(ts_oh, NULL);
+			dts_key_gen(dkey, DTS_KEY_LEN, "blade");
+			rc = dkey_update_or_fetch(ts_ohs[i], TS_DO_UPDATE, dkey,
+						  &epoch);
 			if (rc)
 				return rc;
 		}
 	}
-
 	rc = dts_credit_drain(&ts_ctx);
 
 	return rc;
 }
 
 static int
-ts_verify_recx_p_akey(char *dkey, daos_epoch_t *epoch)
+dkey_verify(daos_handle_t oh, char *dkey, daos_epoch_t *epoch)
 {
 	int	 i;
 	int	*indices;
@@ -363,9 +348,9 @@ ts_verify_recx_p_akey(char *dkey, daos_epoch_t *epoch)
 	dts_key_gen(akey, DTS_KEY_LEN, "walker");
 
 	for (i = 0; i < ts_recx_p_akey; i++) {
-		ts_set_value_buffer(ground_truth, i);
-		rc = update_or_fetch_internal(dkey, akey, epoch, indices, i,
-			test_string, TS_DO_FETCH, WITH_FETCH);
+		set_value_buffer(ground_truth, i);
+		rc = akey_update_or_fetch(oh, TS_DO_FETCH, dkey, akey, epoch,
+					  indices, i, test_string);
 		if (rc)
 			goto failed;
 		if (memcmp(test_string, ground_truth, TEST_VAL_SIZE) != 0) {
@@ -381,7 +366,7 @@ failed:
 }
 
 static int
-ts_verify_all_fetches(void)
+objects_verify(void)
 {
 	int		i;
 	int		j;
@@ -397,7 +382,7 @@ ts_verify_all_fetches(void)
 		for (j = 0; j < ts_dkey_p_obj; j++) {
 			dts_key_gen(dkey, DTS_KEY_LEN, "blade");
 			for (k = 0; k < ts_akey_p_dkey; k++) {
-				rc = ts_verify_recx_p_akey(dkey, &epoch);
+				rc = dkey_verify(ts_ohs[i], dkey, &epoch);
 				if (rc != 0)
 					return rc;
 			}
@@ -406,22 +391,27 @@ ts_verify_all_fetches(void)
 	return rc;
 }
 
-static int do_verification(void)
+static int
+objects_verify_close(void)
 {
+	int i;
 	int rc = 0;
 
 	if (ts_verify_fetch) {
-		rc = ts_verify_all_fetches();
+		rc = objects_verify();
 		fprintf(stdout, "Fetch verification: %s\n", rc ? "Failed" :
 			"Success");
-		if (ts_class != DAOS_OC_RAW)
-			daos_obj_close(ts_oh, NULL);
 	}
-	return rc;
+
+	for (i = 0; ts_mode == TS_MODE_DAOS && i < ts_obj_p_cont; i++) {
+		rc = daos_obj_close(ts_ohs[i], NULL);
+		D_ASSERT(rc == 0);
+	}
+	return 0;
 }
 
 static int
-ts_read_records_internal(d_rank_t rank)
+objects_fetch(d_rank_t rank)
 {
 	int		i;
 	int		j;
@@ -431,17 +421,18 @@ ts_read_records_internal(d_rank_t rank)
 	dts_reset_key();
 	if (!ts_overwrite)
 		++epoch;
+
 	for (i = 0; i < ts_obj_p_cont; i++) {
 		for (j = 0; j < ts_dkey_p_obj; j++) {
-			rc = ts_key_update_or_fetch(TS_DO_FETCH, &epoch,
-						    WITH_FETCH);
+			char	 dkey[DTS_KEY_LEN];
+
+			dts_key_gen(dkey, DTS_KEY_LEN, "blade");
+			rc = dkey_update_or_fetch(ts_ohs[i], TS_DO_FETCH, dkey,
+						  &epoch);
 			if (rc != 0)
 				return rc;
 		}
 	}
-	if (ts_class != DAOS_OC_RAW && !ts_verify_fetch)
-		rc = daos_obj_close(ts_oh, NULL);
-
 	return rc;
 }
 
@@ -558,12 +549,12 @@ ts_write_perf(double *start_time, double *end_time)
 	int	rc;
 
 	*start_time = dts_time_now();
-	rc = ts_write_records_internal(RANK_ZERO, WITHOUT_FETCH);
+	rc = objects_update(RANK_ZERO);
 	*end_time = dts_time_now();
 	if (rc)
 		return rc;
 
-	rc = do_verification();
+	rc = objects_verify_close();
 	return rc;
 }
 
@@ -572,16 +563,16 @@ ts_fetch_perf(double *start_time, double *end_time)
 {
 	int	rc;
 
-	rc = ts_write_records_internal(RANK_ZERO, WITH_FETCH);
+	rc = objects_update(RANK_ZERO);
 	if (rc)
 		return rc;
 	*start_time = dts_time_now();
-	rc = ts_read_records_internal(RANK_ZERO);
+	rc = objects_fetch(RANK_ZERO);
 	*end_time = dts_time_now();
 	if (rc)
 		return rc;
 
-	rc = do_verification();
+	rc = objects_verify_close();
 	return rc;
 }
 
@@ -590,7 +581,7 @@ ts_iterate_perf(double *start_time, double *end_time)
 {
 	int	rc;
 
-	rc = ts_write_records_internal(RANK_ZERO, WITH_FETCH);
+	rc = objects_update(RANK_ZERO);
 	if (rc)
 		return rc;
 	*start_time = dts_time_now();
@@ -605,15 +596,15 @@ ts_update_fetch_perf(double *start_time, double *end_time)
 	int	rc;
 
 	*start_time = dts_time_now();
-	rc = ts_write_records_internal(RANK_ZERO, WITH_FETCH);
+	rc = objects_update(RANK_ZERO);
 	if (rc)
 		return rc;
-	rc = ts_read_records_internal(RANK_ZERO);
+	rc = objects_fetch(RANK_ZERO);
 	*end_time = dts_time_now();
 	if (rc)
 		return rc;
 
-	rc = do_verification();
+	rc = objects_verify_close();
 	return rc;
 }
 
@@ -676,7 +667,7 @@ ts_rebuild_perf(double *start_time, double *end_time)
 
 	/* prepare the record */
 	ts_class = DAOS_OC_R2S_SPEC_RANK;
-	rc = ts_write_records_internal(RANK_ZERO, WITHOUT_FETCH);
+	rc = objects_update(RANK_ZERO);
 	if (rc)
 		return rc;
 
@@ -790,7 +781,7 @@ The options are as follows:\n\
 	Pool NVMe partition size.\n\
 \n\
 -T vos|echo|daos\n\
-	Tyes of test, it can be 'vos', 'echo' and 'daos'.\n\
+	Tyes of test, it can be 'vos' and 'daos'.\n\
 	vos  : run directly on top of Versioning Object Store (VOS).\n\
 	echo : I/O traffic generated by the utility only goes through the\n\
 	       network stack and never lands to storage.\n\
@@ -1001,17 +992,28 @@ main(int argc, char **argv)
 		case 'T':
 			if (!strcasecmp(optarg, "echo")) {
 				/* just network, no storage */
-				ts_level = TS_LVL_ECHO;
+				ts_mode = TS_MODE_ECHO;
+
 			} else if (!strcasecmp(optarg, "daos")) {
 				/* full stack: network + storage */
-				ts_level = TS_LVL_DAOS;
+				ts_mode = TS_MODE_DAOS;
+
 			} else if (!strcasecmp(optarg, "vos")) {
 				/* pure storage */
-				ts_level = TS_LVL_VOS;
+				ts_mode = TS_MODE_VOS;
+
 			} else {
 				if (ts_ctx.tsc_mpi_rank == 0)
 					ts_print_usage();
 				return -1;
+			}
+
+			if (ts_mode == TS_MODE_VOS) { /* RAW only for VOS */
+				if (ts_class != DAOS_OC_RAW)
+					ts_class = DAOS_OC_RAW;
+			} else { /* no RAW for other modes */
+				if (ts_class == DAOS_OC_RAW)
+					ts_class = DAOS_OC_TINY_RW;
 			}
 			break;
 		case 'C':
@@ -1110,7 +1112,11 @@ main(int argc, char **argv)
 		}
 	}
 
-	if (ts_level == TS_LVL_ECHO) {
+	/* Convert object classes for echo mode.
+	 * NB: we can also run in echo mode for arbitrary object class by
+	 * setting DAOS_IO_BYPASS="target" while starting server.
+	 */
+	if (ts_mode == TS_MODE_ECHO) {
 		if (ts_class == DAOS_OC_R4S_RW)
 			ts_class = DAOS_OC_ECHO_R4S_RW;
 		else if (ts_class == DAOS_OC_R3S_RW)
@@ -1119,10 +1125,6 @@ main(int argc, char **argv)
 			ts_class = DAOS_OC_ECHO_R2S_RW;
 		else
 			ts_class = DAOS_OC_ECHO_TINY_RW;
-	} else if (ts_level == TS_LVL_VOS) {
-		if (ts_class != DAOS_OC_RAW)
-			fprintf(stderr, "-c option ignored for VOS test.\n");
-		ts_class = DAOS_OC_RAW;
 	}
 
 	/* It will run write tests by default */
@@ -1167,12 +1169,12 @@ main(int argc, char **argv)
 	if (vsize <= sizeof(int))
 		vsize = sizeof(int);
 
-	if (ts_ctx.tsc_mpi_rank == 0 || ts_class == DAOS_OC_RAW) {
+	if (ts_ctx.tsc_mpi_rank == 0 || ts_mode == TS_MODE_VOS) {
 		uuid_generate(ts_ctx.tsc_pool_uuid);
 		uuid_generate(ts_ctx.tsc_cont_uuid);
 	}
 
-	if (ts_class == DAOS_OC_RAW) {
+	if (ts_mode == TS_MODE_VOS) {
 		ts_ctx.tsc_cred_nr = -1; /* VOS can only support sync mode */
 		if (strlen(ts_pmem_file) == 0)
 			strcpy(ts_pmem_file, "/mnt/daos/vos_perf.pmem");
@@ -1217,7 +1219,14 @@ main(int argc, char **argv)
 			ts_yes_or_no(ts_zero_copy),
 			ts_yes_or_no(ts_overwrite),
 			ts_yes_or_no(ts_verify_fetch),
-			ts_class == DAOS_OC_RAW ? ts_pmem_file : "<NULL>");
+			ts_mode == TS_MODE_VOS ? ts_pmem_file : "<NULL>");
+	}
+
+	ts_ohs = calloc(ts_obj_p_cont, sizeof(*ts_ohs));
+	if (!ts_ohs) {
+		fprintf(stderr, "failed to allocate %u open handles\n",
+			ts_obj_p_cont);
+		return -1;
 	}
 
 	rc = dts_ctx_init(&ts_ctx);
@@ -1259,6 +1268,7 @@ main(int argc, char **argv)
 
 	dts_ctx_fini(&ts_ctx);
 	MPI_Finalize();
+	free(ts_ohs);
 
 	return 0;
 }

--- a/src/vos/vos_common.c
+++ b/src/vos/vos_common.c
@@ -204,17 +204,7 @@ struct dss_module_key vos_module_key = {
 static int
 vos_mod_init(void)
 {
-	char	*env;
 	int	 rc = 0;
-
-	/* This is for performance evaluation only, all data will be stored
-	 * in DRAM by setting this.
-	 */
-	env = getenv("VOS_MEM_CLASS");
-	if (env && strcasecmp(env, "DRAM") == 0) {
-		D_WARN("Running in DRAM mode, all data are volatile.\n");
-		vos_mem_class = UMEM_CLASS_VMEM;
-	}
 
 	rc = vos_cont_tab_register();
 	if (rc) {

--- a/src/vos/vos_internal.h
+++ b/src/vos/vos_internal.h
@@ -44,7 +44,6 @@
 #define DAOS_VOS_VERSION 1
 
 extern struct dss_module_key vos_module_key;
-extern umem_class_id_t vos_mem_class;
 
 #define VOS_POOL_HHASH_BITS 10 /* Upto 1024 pools */
 #define VOS_CONT_HHASH_BITS 20 /* Upto 1048576 containers */

--- a/src/vos/vos_pool.c
+++ b/src/vos/vos_pool.c
@@ -44,11 +44,23 @@
 #include <fcntl.h>
 
 pthread_mutex_t vos_pmemobj_lock = PTHREAD_MUTEX_INITIALIZER;
-/**
- * Memory class is PMEM by default, user can set it to VMEM (volatile memory)
- * for testing.
- */
-umem_class_id_t	vos_mem_class	 = UMEM_CLASS_PMEM;
+
+static int
+umem_get_type(void)
+{
+	/* NB: BYPASS_PM and BYPASS_PM_SNAP can't coexist */
+	if (daos_io_bypass & IOBP_PM) {
+		D_PRINT("Running in DRAM mode, all data are volatile.\n");
+		return UMEM_CLASS_VMEM;
+
+	} else if (daos_io_bypass & IOBP_PM_SNAP) {
+		D_PRINT("Ignore PMDK snapshot, data can be lost on failure.\n");
+		return UMEM_CLASS_PMEM_NO_SNAP;
+
+	} else {
+		return UMEM_CLASS_PMEM;
+	}
+}
 
 static struct vos_pool *
 pool_hlink2ptr(struct d_ulink *hlink)
@@ -254,7 +266,7 @@ vos_pool_create(const char *path, uuid_t uuid, daos_size_t scm_sz,
 		memset(pool_df, 0, sizeof(*pool_df));
 
 		memset(&uma, 0, sizeof(uma));
-		uma.uma_id = vos_mem_class;
+		uma.uma_id = umem_get_type();
 		uma.uma_pool = ph;
 
 		rc = vos_cont_tab_create(&uma, &pool_df->pd_ctab_df);
@@ -451,7 +463,7 @@ vos_pool_open(const char *path, uuid_t uuid, daos_handle_t *poh)
 	}
 
 	uma = &pool->vp_uma;
-	uma->uma_id = vos_mem_class;
+	uma->uma_id = umem_get_type();
 	uma->uma_pool = vos_pmemobj_open(path,
 				   POBJ_LAYOUT_NAME(vos_pool_layout));
 	if (uma->uma_pool == NULL) {


### PR DESCRIPTION
merge functionality of VOS_MEM_CLASS into DAOS_IO_BYPASS
 - set DAOS_IO_BYPASS="pm" on server to run in DRAM mode
 - set DAOS_IO_BYPASS="pm_snap" on server to run in SCM mode but
   ignore tx_add of PMDK
 - set DAOS_IO_BYPASS="target" on server to run in ECHO mode,
   which bypasses all storage operations (VOS, BIO...)
 - set DAOS_IO_BYPASS="srv_bulk" on server to bypass bulk transfer
   and storage trash data
 - set DAOS_IO_BYPASS="cli_rpc" on client to drop all client RPCs

daos_perf improvements
 - Fix a few bugs in daos_perf
 - code cleanup

Signed-off-by: Liang Zhen <liang.zhen@intel.com>