### PR TITLE
DAOS-1441 dtx: DTX RPC logic

### DIFF
--- a/src/SConscript
+++ b/src/SConscript
@@ -40,6 +40,7 @@ def scons():
     SConscript('pool/SConscript')
     SConscript('container/SConscript')
     SConscript('placement/SConscript')
+    SConscript('dtx/SConscript')
     SConscript('object/SConscript')
     SConscript('rebuild/SConscript')
     SConscript('security/SConscript')

--- a/src/container/srv_target.c
+++ b/src/container/srv_target.c
@@ -567,7 +567,7 @@ ds_cont_tgt_open_handler(crt_rpc_t *rpc)
 		DP_CONT(in->toi_pool_uuid, in->toi_uuid), rpc,
 		DP_UUID(in->toi_hdl));
 
-	rc = dss_task_collective(cont_open_one, in, 0);
+	rc = dss_thread_collective(cont_open_one, in, 0);
 	D_ASSERTF(rc == 0, "%d\n", rc);
 
 	out->too_rc = (rc == 0 ? 0 : 1);

--- a/src/dtx/SConscript
+++ b/src/dtx/SConscript
@@ -1,0 +1,17 @@
+"""Build dtx library"""
+import daos_build
+
+def scons():
+    """Execute build"""
+    Import('env')
+
+    env.AppendUnique(LIBPATH=[Dir('.')])
+    denv = env.Clone()
+
+    # dtx
+    dtx = daos_build.library(denv, 'dtx',
+                             ['dtx_srv.c', 'dtx_rpc.c'])
+    denv.Install('$PREFIX/lib/daos_srv', dtx)
+
+if __name__ == "SCons.Script":
+    scons()

--- a/src/dtx/dtx_internal.h
+++ b/src/dtx/dtx_internal.h
@@ -1,0 +1,76 @@
+/**
+ * (C) Copyright 2019 Intel Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * GOVERNMENT LICENSE RIGHTS-OPEN SOURCE SOFTWARE
+ * The Government's rights to use, modify, reproduce, release, perform, display,
+ * or disclose this software are subject to the terms of the Apache License as
+ * provided in Contract No. B609815.
+ * Any reproduction of computer software, computer software documentation, or
+ * portions thereof marked with this legend must also reproduce the markings.
+ */
+/**
+ * dtx: dtx internal.h
+ *
+ */
+#ifndef __DTX_INTERNAL_H__
+#define __DTX_INTERNAL_H__
+
+#include <uuid/uuid.h>
+#include <daos/rpc.h>
+#include <daos/btree.h>
+
+/*
+ * RPC operation codes
+ *
+ * These are for daos_rpc::dr_opc and DAOS_RPC_OPCODE(opc, ...) rather than
+ * crt_req_create(..., opc, ...). See src/include/daos/rpc.h.
+ */
+#define DAOS_DTX_VERSION	1
+
+/* LIST of internal RPCS in form of:
+ * OPCODE, flags, FMT, handler, corpc_hdlr,
+ */
+#define DTX_PROTO_SRV_RPC_LIST						\
+	X(DTX_COMMIT, 0, &CQF_dtx, dtx_handler, NULL),			\
+	X(DTX_ABORT, 0, &CQF_dtx, dtx_handler, NULL),			\
+	X(DTX_CHECK, 0, &CQF_dtx, dtx_handler, NULL)
+
+#define X(a, b, c, d, e) a
+
+enum dtx_operation {
+	DTX_PROTO_SRV_RPC_LIST,
+};
+
+#undef X
+
+/* DTX RPC input fields */
+#define DAOS_ISEQ_DTX							\
+	((uuid_t)		(di_po_uuid)		CRT_VAR)	\
+	((uuid_t)		(di_co_uuid)		CRT_VAR)	\
+	((struct daos_tx_id)	(di_dtx_array)		CRT_ARRAY)
+
+/* DTX RPC output fields */
+#define DAOS_OSEQ_DTX							\
+	((int32_t)		(do_status)		CRT_VAR)
+
+CRT_RPC_DECLARE(dtx, DAOS_ISEQ_DTX, DAOS_OSEQ_DTX);
+
+extern struct crt_proto_format dtx_proto_fmt;
+extern btr_ops_t dbtree_dtx_cf_ops;
+
+int dtx_check(uuid_t po_uuid, uuid_t co_uuid,
+	      struct daos_tx_entry *dte, struct pl_obj_layout *layout);
+
+#endif /* __DTX_INTERNAL_H__ */

--- a/src/dtx/dtx_rpc.c
+++ b/src/dtx/dtx_rpc.c
@@ -1,0 +1,734 @@
+/**
+ * (C) Copyright 2019 Intel Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * GOVERNMENT LICENSE RIGHTS-OPEN SOURCE SOFTWARE
+ * The Government's rights to use, modify, reproduce, release, perform, display,
+ * or disclose this software are subject to the terms of the Apache License as
+ * provided in Contract No. B609815.
+ * Any reproduction of computer software, computer software documentation, or
+ * portions thereof marked with this legend must also reproduce the markings.
+ */
+/**
+ * dtx: DTX RPC
+ */
+#define D_LOGFAC	DD_FAC(dtx)
+
+#include <abt.h>
+#include <daos/rpc.h>
+#include <daos/btree.h>
+#include <daos/pool_map.h>
+#include <daos/placement.h>
+#include <daos/btree_class.h>
+#include <daos_srv/vos.h>
+#include <daos_srv/dtx_srv.h>
+#include <daos_srv/container.h>
+#include <daos_srv/daos_server.h>
+#include "dtx_internal.h"
+
+static int
+crt_proc_struct_daos_tx_id(crt_proc_t proc, struct daos_tx_id *dti)
+{
+	int rc;
+
+	rc = crt_proc_uuid_t(proc, &dti->dti_uuid);
+	if (rc != 0)
+		return -DER_HG;
+
+	rc = crt_proc_uint64_t(proc, &dti->dti_sec);
+	if (rc != 0)
+		return -DER_HG;
+
+	return 0;
+}
+
+CRT_RPC_DEFINE(dtx, DAOS_ISEQ_DTX, DAOS_OSEQ_DTX);
+
+#define X(a, b, c, d, e)	\
+{				\
+	.prf_flags   = b,	\
+	.prf_req_fmt = c,	\
+	.prf_hdlr    = NULL,	\
+	.prf_co_ops  = NULL,	\
+}
+
+static struct crt_proto_rpc_format dtx_proto_rpc_fmt[] = {
+	DTX_PROTO_SRV_RPC_LIST,
+};
+
+#undef X
+
+struct crt_proto_format dtx_proto_fmt = {
+	.cpf_name  = "dtx-proto",
+	.cpf_ver   = DAOS_DTX_VERSION,
+	.cpf_count = ARRAY_SIZE(dtx_proto_rpc_fmt),
+	.cpf_prf   = dtx_proto_rpc_fmt,
+	.cpf_base  = DAOS_RPC_OPCODE(0, DAOS_DTX_MODULE, 0)
+};
+
+static int
+dtx_req_create(crt_context_t crt_ctx, crt_endpoint_t *tgt_ep,
+	       crt_opcode_t opc, crt_rpc_t **req)
+{
+	crt_opcode_t	opcode;
+
+	opcode = DAOS_RPC_OPCODE(opc, DAOS_DTX_MODULE, DAOS_DTX_VERSION);
+	/* call daos_rpc_tag to get the target tag/context idx */
+	tgt_ep->ep_tag = daos_rpc_tag(DAOS_REQ_DTX, tgt_ep->ep_tag);
+
+	return crt_req_create(crt_ctx, tgt_ep, opcode, req);
+}
+
+/* Top level DTX RPC args */
+struct dtx_req_args {
+	ABT_future			 dra_future;
+	/* The RPC code */
+	crt_opcode_t			 dra_opc;
+	/* pool UUID */
+	uuid_t				 dra_po_uuid;
+	/* container UUID */
+	uuid_t				 dra_co_uuid;
+	/* Pointer to the global list head for all the dtx_req_rec. */
+	d_list_t			*dra_list;
+	/* The length of aobve global list. */
+	int				 dra_length;
+	/* The collective RPC result. */
+	int				 dra_result;
+};
+
+/* The record for the DTX classify-tree in DRAM.
+ * Also used as the sub-request (to related rank/tag) args.
+ */
+struct dtx_req_rec {
+	/* All the records are linked into one global list,
+	 * used for travelling the classify-tree efficiently.
+	 */
+	d_list_t			 drr_link;
+	struct dtx_req_args		*drr_parent; /* The top level args */
+	d_rank_t			 drr_rank; /* The server ID */
+	uint32_t			 drr_tag; /* The VOS ID */
+	int				 drr_count; /* DTX count */
+	int				 drr_result; /* The sub-req result */
+	struct daos_tx_id		*drr_dti; /* The DTX array */
+};
+
+struct dtx_cf_rec_bundle {
+	union {
+		struct {
+			d_rank_t	 dcrb_rank;
+			uint32_t	 dcrb_tag;
+		};
+		uint64_t		 dcrb_key;
+	};
+	/* Pointer to the global list head for all the dtx_req_rec. */
+	d_list_t			*dcrb_head;
+	/* Pointer to the length of above global list. */
+	int				*dcrb_length;
+	/* Current DTX to be classified. */
+	struct daos_tx_id		*dcrb_dti;
+	/* The number of DTXs to be classified that will be used as
+	 * the dtx_req_rec::drr_dti array size when allocating it.
+	 */
+	int				 dcrb_count;
+};
+
+static void
+dtx_sub_req_cb(const struct crt_cb_info *cb_info)
+{
+	crt_rpc_t		*req = cb_info->cci_rpc;
+	struct dtx_req_rec	*drr = cb_info->cci_arg;
+	struct dtx_req_args	*dra = drr->drr_parent;
+	struct dtx_out		*dout;
+	int			 rc = cb_info->cci_rc;
+
+	if (rc == 0) {
+		dout = crt_reply_get(req);
+		rc = dout->do_status;
+	}
+
+	drr->drr_result = rc;
+	rc = ABT_future_set(dra->dra_future, drr);
+	D_ASSERTF(rc == ABT_SUCCESS,
+		  "ABT_future_set failed for opc %x to %d/%d: rc = %d.\n",
+		  dra->dra_opc, drr->drr_rank, drr->drr_tag, rc);
+
+	D_DEBUG(DB_TRACE,
+		"DTX req for opc %x got reply from %d/%d: rc = %d.\n",
+		dra->dra_opc, drr->drr_rank, drr->drr_tag, rc);
+}
+
+static int
+dtx_sub_req_send(struct dtx_req_rec *drr)
+{
+	struct dtx_req_args	*dra = drr->drr_parent;
+	crt_rpc_t		*req;
+	crt_endpoint_t		 tgt_ep;
+	int			 rc;
+
+	tgt_ep.ep_grp = NULL;
+	tgt_ep.ep_rank = drr->drr_rank;
+	tgt_ep.ep_tag = drr->drr_tag;
+
+	rc = dtx_req_create(dss_get_module_info()->dmi_ctx, &tgt_ep,
+			    dra->dra_opc, &req);
+	if (rc == 0) {
+		struct dtx_in	*din;
+
+		din = crt_req_get(req);
+		uuid_copy(din->di_po_uuid, dra->dra_po_uuid);
+		uuid_copy(din->di_co_uuid, dra->dra_co_uuid);
+		din->di_dtx_array.ca_count = drr->drr_count;
+		din->di_dtx_array.ca_arrays = drr->drr_dti;
+
+		rc = crt_req_send(req, dtx_sub_req_cb, drr);
+		if (rc != 0)
+			crt_req_decref(req);
+	}
+
+	D_DEBUG(DB_TRACE, "DTX req for opc %x sent: rc = %d.\n",
+		dra->dra_opc, rc);
+
+	if (rc != 0) {
+		drr->drr_result = rc;
+		ABT_future_set(dra->dra_future, drr);
+	}
+
+	return rc;
+}
+
+static void
+dtx_req_cb(void **args)
+{
+	struct dtx_req_rec	*drr = args[0];
+	struct dtx_req_args	*dra = drr->drr_parent;
+	int			 i;
+
+	if (dra->dra_opc == DTX_CHECK) {
+		for (i = 0; i < dra->dra_length; i++) {
+			drr = args[i];
+			switch (drr->drr_result) {
+			case DTX_ST_INIT:
+				dra->dra_result = DTX_ST_INIT;
+				break;
+			case DTX_ST_COMMITTED:
+				dra->dra_result = DTX_ST_COMMITTED;
+				/* As long as one replica has committed the DTX,
+				 * then the DTX is committable on all replicas.
+				 */
+				D_DEBUG(DB_TRACE,
+					"The DTX "DF_DTI" has been committed "
+					"on %d/%d.\n", DP_DTI(drr->drr_dti),
+					drr->drr_rank, drr->drr_tag);
+				return;
+			case DTX_ST_PREPARED:
+				if (dra->dra_result == 0)
+					dra->dra_result = DTX_ST_PREPARED;
+				break;
+			default:
+				if (dra->dra_result != DTX_ST_INIT)
+					dra->dra_result = drr->drr_result >= 0 ?
+						-DER_IO : drr->drr_result;
+				break;
+			}
+
+			D_DEBUG(DB_TRACE, "The DTX "DF_DTI" RPC req result %d, "
+				"status is %d.\n", DP_DTI(drr->drr_dti),
+				drr->drr_result, dra->dra_result);
+		}
+	} else {
+		for (i = 0; i < dra->dra_length; i++) {
+			drr = args[i];
+			if (dra->dra_result == 0)
+				dra->dra_result = drr->drr_result;
+
+			if (dra->dra_result != 0) {
+				D_ERROR("DTX req for opc %x failed: rc = %d.\n",
+					dra->dra_opc, dra->dra_result);
+				return;
+			}
+		}
+
+		D_DEBUG(DB_TRACE, "DTX req for opc %x succeed.\n",
+			dra->dra_opc);
+	}
+}
+
+static int
+dtx_req_send(crt_opcode_t opc, d_list_t *head, int length, uuid_t po_uuid,
+	     uuid_t co_uuid)
+{
+	ABT_future		 future;
+	struct dtx_req_args	 dra;
+	struct dtx_req_rec	*drr;
+	int			 rc;
+
+	dra.dra_opc = opc;
+	uuid_copy(dra.dra_po_uuid, po_uuid);
+	uuid_copy(dra.dra_co_uuid, co_uuid);
+	dra.dra_list = head;
+	dra.dra_length = length;
+	dra.dra_result = 0;
+
+	rc = ABT_future_create(length, dtx_req_cb, &future);
+	if (rc != ABT_SUCCESS) {
+		D_ERROR("ABT_future_create failed for opc %x, length = %d: "
+			"rc = %d.\n", opc, length, rc);
+		return dss_abterr2der(rc);
+	}
+
+	dra.dra_future = future;
+	d_list_for_each_entry(drr, head, drr_link) {
+		drr->drr_parent = &dra;
+		drr->drr_result = 0;
+		rc = dtx_sub_req_send(drr);
+		if (rc != 0)
+			break;
+	}
+
+	if (rc != 0) {
+		while (drr->drr_link.next != head) {
+			drr = d_list_entry(drr->drr_link.next,
+					   struct dtx_req_rec, drr_link);
+			drr->drr_parent = &dra;
+			drr->drr_result = rc;
+			ABT_future_set(future, drr);
+		}
+	}
+
+	rc = ABT_future_wait(future);
+	D_ASSERTF(rc == ABT_SUCCESS,
+		  "ABT_future_wait failed for opc %x, length = %d: rc = %d.\n",
+		  opc, length, rc);
+
+	ABT_future_free(&future);
+	rc = dra.dra_result;
+
+	D_DEBUG(DB_TRACE, "DTX req for opc %x: rc = %d\n", opc, rc);
+
+	return rc;
+}
+
+static int
+dtx_cf_rec_alloc(struct btr_instance *tins, daos_iov_t *key_iov,
+		 daos_iov_t *val_iov, struct btr_record *rec)
+{
+	struct dtx_req_rec		*drr;
+	struct dtx_cf_rec_bundle	*dcrb;
+
+	D_ASSERT(tins->ti_umm.umm_id == UMEM_CLASS_VMEM);
+
+	D_ALLOC_PTR(drr);
+	if (drr == NULL)
+		return -DER_NOMEM;
+
+	dcrb = (struct dtx_cf_rec_bundle *)val_iov->iov_buf;
+	D_ALLOC_ARRAY(drr->drr_dti, dcrb->dcrb_count);
+	if (drr->drr_dti == NULL) {
+		D_FREE_PTR(drr);
+		return -DER_NOMEM;
+	}
+
+	drr->drr_rank = dcrb->dcrb_rank;
+	drr->drr_tag = dcrb->dcrb_tag;
+	drr->drr_count = 1;
+	drr->drr_dti[0] = *dcrb->dcrb_dti;
+	d_list_add_tail(&drr->drr_link, dcrb->dcrb_head);
+	++(*dcrb->dcrb_length);
+
+	rec->rec_mmid = umem_ptr2id(&tins->ti_umm, drr);
+	return 0;
+}
+
+static int
+dtx_cf_rec_free(struct btr_instance *tins, struct btr_record *rec, void *args)
+{
+	struct dtx_req_rec	*drr;
+
+	D_ASSERT(tins->ti_umm.umm_id == UMEM_CLASS_VMEM);
+
+	drr = (struct dtx_req_rec *)umem_id2ptr(&tins->ti_umm, rec->rec_mmid);
+	d_list_del(&drr->drr_link);
+	D_FREE(drr->drr_dti);
+	D_FREE_PTR(drr);
+
+	return 0;
+}
+
+static int
+dtx_cf_rec_fetch(struct btr_instance *tins, struct btr_record *rec,
+		 daos_iov_t *key_iov, daos_iov_t *val_iov)
+{
+	D_ASSERTF(0, "We should not come here.\n");
+	return 0;
+}
+
+static int
+dtx_cf_rec_update(struct btr_instance *tins, struct btr_record *rec,
+		  daos_iov_t *key, daos_iov_t *val)
+{
+	struct dtx_req_rec		*drr;
+	struct dtx_cf_rec_bundle	*dcrb;
+
+	drr = (struct dtx_req_rec *)umem_id2ptr(&tins->ti_umm, rec->rec_mmid);
+	dcrb = (struct dtx_cf_rec_bundle *)val->iov_buf;
+	drr->drr_dti[drr->drr_count++] = *dcrb->dcrb_dti;
+
+	return 0;
+}
+
+btr_ops_t dbtree_dtx_cf_ops = {
+	.to_rec_alloc	= dtx_cf_rec_alloc,
+	.to_rec_free	= dtx_cf_rec_free,
+	.to_rec_fetch	= dtx_cf_rec_fetch,
+	.to_rec_update	= dtx_cf_rec_update,
+};
+
+#define DTX_CF_BTREE_ORDER	20
+
+static int
+dtx_dti_classify_one(struct ds_pool *pool, uuid_t po_uuid, uuid_t co_uuid,
+		     daos_handle_t tree, d_list_t *head, int *length,
+		     daos_unit_oid_t *oid, struct daos_tx_id *dti,
+		     int count, uint32_t version)
+{
+	struct daos_oclass_attr		*oc_attr;
+	struct pl_obj_layout		*layout = NULL;
+	struct daos_obj_md		 md = { 0 };
+	struct dtx_cf_rec_bundle	 dcrb;
+	d_rank_t			 myrank;
+	uint32_t			 replicas;
+	int				 start;
+	int				 rc;
+	int				 i;
+
+	oc_attr = daos_oclass_attr_find(oid->id_pub);
+	if (oc_attr->ca_resil != DAOS_RES_REPL)
+		return -DER_NOTAPPLICABLE;
+
+	md.omd_id = oid->id_pub;
+	md.omd_ver = version;
+
+	ABT_rwlock_rdlock(pool->sp_lock);
+	D_ASSERT(pool->sp_map != NULL);
+	D_ASSERT(pool->sp_pl_map != NULL);
+
+	rc = pl_obj_place(pool->sp_pl_map, &md, NULL, &layout);
+	ABT_rwlock_unlock(pool->sp_lock);
+	if (rc != 0)
+		return rc;
+
+	if (layout->ol_nr <= oid->id_shard)
+		D_GOTO(out, rc = -DER_INVAL);
+
+	replicas = oc_attr->u.repl.r_num;
+	if (replicas == DAOS_OBJ_REPL_MAX)
+		replicas = layout->ol_nr;
+
+	if (replicas < 1)
+		D_GOTO(out, rc = -DER_INVAL);
+
+	/* Skip single replicated object. */
+	if (replicas == 1)
+		D_GOTO(out, rc = 0);
+
+	dcrb.dcrb_count = count;
+	dcrb.dcrb_dti = dti;
+	dcrb.dcrb_head = head;
+	dcrb.dcrb_length = length;
+
+	crt_group_rank(pool->sp_group, &myrank);
+	start = (oid->id_shard / replicas) * replicas;
+	for (i = start; i < start + replicas && rc == 0; i++) {
+		struct pl_obj_shard	*shard;
+		struct pool_target	*target;
+		daos_iov_t		 kiov;
+		daos_iov_t		 riov;
+
+		/* skip unavailable replica(s). */
+		shard = &layout->ol_shards[i];
+		if (shard->po_target == -1 || shard->po_rebuilding)
+			continue;
+
+		rc = pool_map_find_target(pool->sp_map, shard->po_target,
+					  &target);
+		if (rc < 0)
+			goto out;
+
+		if (rc != 1)
+			D_GOTO(out, rc = -DER_INVAL);
+
+		/* skip myself. */
+		if (myrank == target->ta_comp.co_rank)
+			continue;
+
+		dcrb.dcrb_rank = target->ta_comp.co_rank;
+		dcrb.dcrb_tag = target->ta_comp.co_index;
+
+		daos_iov_set(&riov, &dcrb, sizeof(dcrb));
+		daos_iov_set(&kiov, &dcrb.dcrb_key, sizeof(dcrb.dcrb_key));
+		rc = dbtree_upsert(tree, BTR_PROBE_EQ, DAOS_INTENT_UPDATE,
+				   &kiov, &riov);
+	}
+
+out:
+	if (layout != NULL)
+		pl_obj_layout_free(layout);
+	return rc;
+}
+
+static int
+dtx_dti_classify(uuid_t po_uuid, uuid_t co_uuid, daos_handle_t tree,
+		 struct daos_tx_entry *dtes, int count, uint32_t version,
+		 d_list_t *head, struct daos_tx_id **dtis)
+{
+	struct daos_tx_id	*dti = NULL;
+	struct ds_pool		*pool;
+	int			 length = 0;
+	int			 rc = 0;
+
+	pool = ds_pool_lookup(po_uuid);
+	if (pool == NULL)
+		return -DER_INVAL;
+
+	D_ALLOC_ARRAY(dti, count);
+	if (dti == NULL) {
+		rc = -DER_NOMEM;
+	} else {
+		int	i;
+
+		for (i = 0; i < count; i++) {
+			rc = dtx_dti_classify_one(pool, po_uuid, co_uuid,
+					tree, head, &length, &dtes[i].dte_oid,
+					&dtes[i].dte_xid, count, version);
+			if (rc < 0)
+				break;
+
+			dti[i] = dtes[i].dte_xid;
+		}
+	}
+
+	if (rc >= 0)
+		*dtis = dti;
+	else if (dti != NULL)
+		D_FREE(dti);
+
+	ds_pool_put(pool);
+	return rc < 0 ? rc : length;
+}
+
+int
+dtx_commit(uuid_t po_uuid, uuid_t co_uuid, struct daos_tx_entry *dtes,
+	   int count, uint32_t version)
+{
+	struct ds_cont		*cont = NULL;
+	struct daos_tx_id	*dti = NULL;
+	struct umem_attr	 uma;
+	struct btr_root		 tree_root = { 0 };
+	daos_handle_t		 tree_hdl = DAOS_HDL_INVAL;
+	d_list_t		 head;
+	int			 length;
+	int			 rc;
+	int			 rc1 = 0;
+
+	rc = ds_cont_lookup(po_uuid, co_uuid, &cont);
+	if (rc != 0)
+		return rc;
+
+	D_INIT_LIST_HEAD(&head);
+	memset(&uma, 0, sizeof(uma));
+	uma.uma_id = UMEM_CLASS_VMEM;
+	rc = dbtree_create_inplace(DBTREE_CLASS_DTX_CF, 0, DTX_CF_BTREE_ORDER,
+				   &uma, &tree_root, &tree_hdl);
+	if (rc != 0)
+		goto out;
+
+	length = dtx_dti_classify(po_uuid, co_uuid, tree_hdl, dtes, count,
+				  version, &head, &dti);
+	if (length < 0)
+		D_GOTO(out, rc = length);
+
+	if (!d_list_empty(&head))
+		rc = dtx_req_send(DTX_COMMIT, &head, length, po_uuid, co_uuid);
+
+	if (dti != NULL)
+		/* We cannot rollback the commit, so commit locally anyway. */
+		rc1 = vos_dtx_commit(cont->sc_hdl, dti, count);
+
+out:
+	if (dti != NULL)
+		D_FREE(dti);
+
+	if (!daos_handle_is_inval(tree_hdl))
+		dbtree_destroy(tree_hdl);
+
+	D_ASSERT(d_list_empty(&head));
+
+	if (cont != NULL)
+		ds_cont_put(cont);
+
+	return rc >= 0 ? rc1 : rc;
+}
+
+int
+dtx_abort(uuid_t po_uuid, uuid_t co_uuid, struct daos_tx_entry *dtes,
+	  int count, uint32_t version)
+{
+	struct ds_cont		*cont = NULL;
+	struct daos_tx_id	*dti = NULL;
+	struct umem_attr	 uma;
+	struct btr_root		 tree_root = { 0 };
+	daos_handle_t		 tree_hdl = DAOS_HDL_INVAL;
+	d_list_t		 head;
+	int			 length;
+	int			 rc;
+
+	/* Currently we only support to abort DTXs one by one. */
+	D_ASSERT(count == 1);
+
+	rc = ds_cont_lookup(po_uuid, co_uuid, &cont);
+	if (rc != 0)
+		return rc;
+
+	D_INIT_LIST_HEAD(&head);
+	memset(&uma, 0, sizeof(uma));
+	uma.uma_id = UMEM_CLASS_VMEM;
+	rc = dbtree_create_inplace(DBTREE_CLASS_DTX_CF, 0, DTX_CF_BTREE_ORDER,
+				   &uma, &tree_root, &tree_hdl);
+	if (rc != 0)
+		goto out;
+
+	length = dtx_dti_classify(po_uuid, co_uuid, tree_hdl, dtes, count,
+				  version, &head, &dti);
+	if (length < 0)
+		D_GOTO(out, rc = length);
+
+	D_ASSERT(dti != NULL);
+
+	/* Local abort firstly. */
+	rc = vos_dtx_abort(cont->sc_hdl, dti, count, false);
+	if (rc != 0)
+		D_GOTO(out, rc);
+
+	if (!d_list_empty(&head))
+		rc = dtx_req_send(DTX_ABORT, &head, length, po_uuid, co_uuid);
+
+out:
+	if (dti != NULL)
+		D_FREE(dti);
+
+	if (!daos_handle_is_inval(tree_hdl))
+		dbtree_destroy(tree_hdl);
+
+	D_ASSERT(d_list_empty(&head));
+
+	if (cont != NULL)
+		ds_cont_put(cont);
+
+	return rc == -DER_NONEXIST ? 0 : rc;
+}
+
+int
+dtx_check(uuid_t po_uuid, uuid_t co_uuid, struct daos_tx_entry *dte,
+	  struct pl_obj_layout *layout)
+{
+	struct ds_pool		*pool;
+	struct daos_oclass_attr *oc_attr;
+	daos_unit_oid_t		*oid = &dte->dte_oid;
+	struct dtx_req_rec	*drr;
+	struct dtx_req_rec	*next;
+	d_list_t		 head;
+	d_rank_t		 myrank;
+	uint32_t		 replicas;
+	int			 length = 0;
+	int			 start;
+	int			 rc = 0;
+	int			 i;
+
+	if (layout->ol_nr <= oid->id_shard)
+		return -DER_INVAL;
+
+	oc_attr = daos_oclass_attr_find(oid->id_pub);
+	if (oc_attr->ca_resil != DAOS_RES_REPL)
+		return -DER_NOTAPPLICABLE;
+
+	replicas = oc_attr->u.repl.r_num;
+	if (replicas == DAOS_OBJ_REPL_MAX)
+		replicas = layout->ol_nr;
+
+	if (replicas < 1)
+		return -DER_INVAL;
+
+	/* If no other replica, then currnet replica is the unique
+	 * one that can be committed if it is 'prepared'.
+	 */
+	if (replicas == 1)
+		return DTX_ST_PREPARED;
+
+	pool = ds_pool_lookup(po_uuid);
+	if (pool == NULL)
+		return -DER_INVAL;
+
+	D_INIT_LIST_HEAD(&head);
+	crt_group_rank(pool->sp_group, &myrank);
+	start = (oid->id_shard / replicas) * replicas;
+	for (i = start; i < start + replicas; i++) {
+		struct pl_obj_shard	*shard;
+		struct pool_target	*target;
+
+		/* skip unavailable replica(s). */
+		shard = &layout->ol_shards[i];
+		if (shard->po_target == -1 || shard->po_rebuilding)
+			continue;
+
+		rc = pool_map_find_target(pool->sp_map, shard->po_target,
+					  &target);
+		if (rc < 0)
+			goto out;
+
+		if (rc != 1)
+			D_GOTO(out, rc = -DER_INVAL);
+
+		/* skip myself. */
+		if (myrank == target->ta_comp.co_rank)
+			continue;
+
+		D_ALLOC_PTR(drr);
+		if (drr == NULL)
+			D_GOTO(out, rc = -DER_NOMEM);
+
+		drr->drr_rank = target->ta_comp.co_rank;
+		drr->drr_tag = target->ta_comp.co_index;
+		drr->drr_count = 1;
+		drr->drr_dti = &dte->dte_xid;
+		d_list_add_tail(&drr->drr_link, &head);
+		length++;
+	}
+
+	/* If no other available replicas, then currnet replica is the
+	 * unique valid one, it can be committed if it is also 'prepared'.
+	 */
+	if (d_list_empty(&head))
+		rc = DTX_ST_PREPARED;
+	else
+		rc = dtx_req_send(DTX_CHECK, &head, length, po_uuid, co_uuid);
+
+out:
+	d_list_for_each_entry_safe(drr, next, &head, drr_link) {
+		d_list_del(&drr->drr_link);
+		D_FREE_PTR(drr);
+	}
+
+	ds_pool_put(pool);
+	return rc;
+}

--- a/src/dtx/dtx_srv.c
+++ b/src/dtx/dtx_srv.c
@@ -1,0 +1,126 @@
+/**
+ * (C) Copyright 2019 Intel Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * GOVERNMENT LICENSE RIGHTS-OPEN SOURCE SOFTWARE
+ * The Government's rights to use, modify, reproduce, release, perform, display,
+ * or disclose this software are subject to the terms of the Apache License as
+ * provided in Contract No. B609815.
+ * Any reproduction of computer software, computer software documentation, or
+ * portions thereof marked with this legend must also reproduce the markings.
+ */
+/**
+ * dtx: DTX rpc service
+ */
+#define D_LOGFAC	DD_FAC(dtx)
+
+#include <daos/rpc.h>
+#include <daos/btree_class.h>
+#include <daos_srv/daos_server.h>
+#include <daos_srv/container.h>
+#include <daos_srv/vos.h>
+#include <daos_srv/dtx_srv.h>
+#include "dtx_internal.h"
+
+static void
+dtx_handler(crt_rpc_t *rpc)
+{
+	struct dtx_in		*din = crt_req_get(rpc);
+	struct dtx_out		*dout = crt_reply_get(rpc);
+	struct ds_cont		*cont = NULL;
+	uint32_t		 opc = opc_get(rpc->cr_opc);
+	int			 rc;
+
+	rc = ds_cont_lookup(din->di_po_uuid, din->di_co_uuid, &cont);
+	if (rc != 0) {
+		D_ERROR("Failed to locate pool="DF_UUID" cont="DF_UUID
+			" for DTX rpc %u: rc = %d\n", DP_UUID(din->di_po_uuid),
+			DP_UUID(din->di_co_uuid), opc, rc);
+		goto out;
+	}
+
+	switch (opc) {
+	case DTX_COMMIT:
+		rc = vos_dtx_commit(cont->sc_hdl, din->di_dtx_array.ca_arrays,
+				    din->di_dtx_array.ca_count);
+		break;
+	case DTX_ABORT:
+		rc = vos_dtx_abort(cont->sc_hdl, din->di_dtx_array.ca_arrays,
+				   din->di_dtx_array.ca_count, true);
+		break;
+	case DTX_CHECK:
+		/* Currently, only support to check single DTX state. */
+		if (din->di_dtx_array.ca_count != 1)
+			rc = -DER_PROTO;
+		else
+			rc = vos_dtx_check_committable(cont->sc_hdl,
+						din->di_dtx_array.ca_arrays);
+		break;
+	default:
+		rc = -DER_INVAL;
+		break;
+	}
+
+	if (rc < 0)
+		D_ERROR("Failed to handle DTX rpc %u: rc = %d\n", opc, rc);
+
+out:
+	dout->do_status = rc;
+	rc = crt_reply_send(rpc);
+	if (rc != 0)
+		D_ERROR("send reply failed for DTX rpc %u: rc = %d\n", opc, rc);
+
+	if (cont != NULL)
+		ds_cont_put(cont);
+}
+
+static int
+dtx_init(void)
+{
+	int	rc;
+
+	rc = dbtree_class_register(DBTREE_CLASS_DTX_CF, BTR_FEAT_UINT_KEY,
+				   &dbtree_dtx_cf_ops);
+	return rc;
+}
+
+static int
+dtx_fini(void)
+{
+	return 0;
+}
+
+#define X(a, b, c, d, e)	\
+{				\
+	.dr_opc       = a,	\
+	.dr_hdlr      = d,	\
+	.dr_corpc_ops = e,	\
+}
+
+static struct daos_rpc_handler dtx_handlers[] = {
+	DTX_PROTO_SRV_RPC_LIST,
+};
+
+#undef X
+
+struct dss_module dtx_module =  {
+	.sm_name	= "dtx",
+	.sm_mod_id	= DAOS_DTX_MODULE,
+	.sm_ver		= DAOS_DTX_VERSION,
+	.sm_init	= dtx_init,
+	.sm_fini	= dtx_fini,
+	.sm_proto_fmt	= &dtx_proto_fmt,
+	.sm_cli_count	= 0,
+	.sm_handlers	= dtx_handlers,
+};

--- a/src/include/daos/btree_class.h
+++ b/src/include/daos/btree_class.h
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2016 Intel Corporation.
+ * (C) Copyright 2016-2019 Intel Corporation.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -102,5 +102,12 @@ extern btr_ops_t dbtree_iv_ops;
  */
 #define DBTREE_CLASS_RECX (DBTREE_DSM_BEGIN + 5)
 extern btr_ops_t dbtree_recx_ops;
+
+/**
+ * The key is a uint64_t integer: 32-bits rank + 32-bits VOS tag.
+ * The value is the array of DTX IDs.
+ * The dbtree is usually in the volatile memory for classifying DTX IDs.
+ */
+#define DBTREE_CLASS_DTX_CF (DBTREE_DSM_BEGIN + 6)
 
 #endif /* __DAOS_SRV_BTREE_CLASS_H__ */

--- a/src/include/daos/debug.h
+++ b/src/include/daos/debug.h
@@ -57,7 +57,8 @@
 	ACTION(tests,     tests,     arg)	\
 	ACTION(dfs,       dfs,       arg)	\
 	ACTION(drpc,      drpc,      arg)	\
-	ACTION(security,  security,  arg)
+	ACTION(security,  security,  arg)	\
+	ACTION(dtx,       dtx,  arg)
 
 #define DAOS_FOREACH_DB(ACTION, arg)				\
 	/** metadata operation */				\

--- a/src/include/daos/rpc.h
+++ b/src/include/daos/rpc.h
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2016-2018 Intel Corporation.
+ * (C) Copyright 2016-2019 Intel Corporation.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -65,6 +65,7 @@ enum daos_module_id {
 	DAOS_RDB_MODULE		= 7, /** rdb */
 	DAOS_RDBT_MODULE	= 8, /** rdb test */
 	DAOS_SEC_MODULE		= 9, /** security framework */
+	DAOS_DTX_MODULE		= 10, /** DTX */
 	DAOS_MAX_MODULE		= (1 << MOD_ID_BITS) - 1,
 };
 
@@ -100,6 +101,7 @@ enum daos_rpc_type {
 	DAOS_REQ_IV,
 	DAOS_REQ_BCAST,
 	DAOS_REQ_SWIM,
+	DAOS_REQ_DTX,
 };
 
 /** DAOS_TGT0_OFFSET is target 0's cart context offset */
@@ -124,6 +126,7 @@ daos_rpc_tag(int req_type, int tgt_idx)
 	switch (req_type) {
 	/* for normal IO request, send to the main service thread/context */
 	case DAOS_REQ_IO:
+	case DAOS_REQ_DTX:
 		return DAOS_IO_CTX_ID(tgt_idx);
 	/* target tag 0 is to handle below requests */
 	case DAOS_REQ_MGMT:

--- a/src/include/daos_srv/dtx_srv.h
+++ b/src/include/daos_srv/dtx_srv.h
@@ -95,4 +95,16 @@ enum dtx_status {
 	DTX_ST_COMMITTED	= 3,
 };
 
+/**
+ * Some actions to be done for DTX control.
+ */
+enum dtx_actions {
+	/** Need to aggregate some old DTXs. */
+	DTX_ACT_AGGREGATE	= 1,
+	/** Need to commit some old DTXs asychronously. */
+	DTX_ACT_COMMIT_ASYNC	= 2,
+	/** Commit current DTX sychronously. */
+	DTX_ACT_COMMIT_SYNC	= 3,
+};
+
 #endif /* __DAOS_DTX_SRV_H__ */

--- a/src/include/daos_srv/dtx_srv.h
+++ b/src/include/daos_srv/dtx_srv.h
@@ -26,6 +26,7 @@
 
 #include <daos/mem.h>
 #include <daos/dtx.h>
+#include <daos/placement.h>
 
 #define DTX_THRESHOLD_COUNT			512
 #define DTX_COMMIT_THRESHOLD_TIME		60ULL
@@ -106,5 +107,10 @@ enum dtx_actions {
 	/** Commit current DTX sychronously. */
 	DTX_ACT_COMMIT_SYNC	= 3,
 };
+
+int dtx_commit(uuid_t po_uuid, uuid_t co_uuid,
+	       struct daos_tx_entry *dtes, int count, uint32_t version);
+int dtx_abort(uuid_t po_uuid, uuid_t co_uuid,
+	      struct daos_tx_entry *dtes, int count, uint32_t version);
 
 #endif /* __DAOS_DTX_SRV_H__ */

--- a/src/include/daos_srv/pool.h
+++ b/src/include/daos_srv/pool.h
@@ -34,6 +34,7 @@
 #include <daos/lru.h>
 #include <daos/pool_map.h>
 #include <daos/rpc.h>
+#include <daos/placement.h>
 
 /*
  * Pool object
@@ -45,6 +46,7 @@ struct ds_pool {
 	uuid_t			sp_uuid;
 	ABT_rwlock		sp_lock;
 	struct pool_map	       *sp_map;
+	struct pl_map	       *sp_pl_map;
 	uint32_t		sp_map_version;	/* temporary */
 	crt_group_t	       *sp_group;
 	struct ds_iv_ns		*sp_iv_ns;
@@ -166,5 +168,8 @@ int ds_pool_iv_ns_update(struct ds_pool *pool, unsigned int master_rank,
 			 d_iov_t *iv_iov, unsigned int iv_ns_id);
 
 int ds_pool_svc_term_get(uuid_t uuid, uint64_t *term);
+
+int ds_pool_check_leader(uuid_t pool_uuid, daos_unit_oid_t *oid,
+			 uint32_t version, struct pl_obj_layout **plo);
 
 #endif /* __DAOS_SRV_POOL_H__ */

--- a/src/include/daos_srv/vos.h
+++ b/src/include/daos_srv/vos.h
@@ -37,6 +37,24 @@
 #include <daos_srv/vos_types.h>
 
 /**
+ * Check whether the given @dti belongs to a resent RPC or not.
+ *
+ * \param coh	[IN]	Container open handle.
+ * \param dti	[IN]	The DTX identifier.
+ *
+ * \return		Zero if related DTX is there ('prepared'),
+ *			but not committed yet.
+ * \return		-DER_ALREADY if related DTX has been committed.
+ * \return		-DER_NONEXIST if no modification has been done before.
+ * \return		-DER_INPROGRESS if some new DTX ('init') is there.
+ * \return		-DER_TIMEDOUT if the DTX is too old as to we are not
+ *			sure about whether it has ever been processed or not.
+ * \return		Other negative value if error.
+ */
+int
+vos_dtx_handle_resend(daos_handle_t coh, struct daos_tx_id *dti);
+
+/**
  * Prepare the DTX handle in DRAM.
  *
  * XXX: Currently, we only support to prepare the DTX against single DAOS

--- a/src/include/daos_srv/vos.h
+++ b/src/include/daos_srv/vos.h
@@ -37,6 +37,48 @@
 #include <daos_srv/vos_types.h>
 
 /**
+ * Prepare the DTX handle in DRAM.
+ *
+ * XXX: Currently, we only support to prepare the DTX against single DAOS
+ *	object and single dkey.
+ *
+ * \param dti		[IN]	The DTX identifier.
+ * \param oid		[IN]	The target object (shard) ID.
+ * \param dkey		[IN]	The target dkey to be modified.
+ * \param coh		[IN]	Container open handle.
+ * \param epoch		[IN]	Epoch for the DTX.
+ * \param pm_ver	[IN]	Pool map version for the DTX.
+ * \param intent	[IN]	The intent of related modification.
+ * \param flags		[IN]	The flags for the DTX, see daos_tx_flags.
+ * \param dth		[OUT]	Pointer to the DTX handle.
+ *
+ * \return			Zero on success, negative value if error.
+ */
+int
+vos_dtx_begin(struct daos_tx_id *dti, daos_unit_oid_t *oid, daos_key_t *dkey,
+	      daos_handle_t coh, daos_epoch_t epoch, uint32_t pm_ver,
+	      uint32_t intent, uint32_t flags, struct daos_tx_handle **dth);
+
+/**
+ * Release the DTX handle in DRAM.
+ *
+ * \param dth		[IN]	Pointer to the DTX handle.
+ * \param result	[IN]	The modification result.
+ * \param leader	[IN]	Whether is leader for current DTX or not.
+ *
+ * \return		DTX_ACT_COMMIT_SYNC	Ask the caller to commit
+ *						current DTX sychronously.
+ * \return		DTX_ACT_COMMIT_ASYNC	Ask the caller to commit
+ *						some old DTXs asychronously.
+ * \return		DTX_ACT_AGGREGATE	Ask the caller to aggregate
+ *						some old DTXs.
+ * \return		Zero on success (no additional action required).
+ * \return		Negative value if error.
+ */
+int
+vos_dtx_end(struct daos_tx_handle *dth, int result, bool leader);
+
+/**
  * Search the specified DTX is in the CoS cache or not.
  *
  * \param coh	[IN]	Container open handle.
@@ -80,6 +122,70 @@ vos_dtx_list_cos(daos_handle_t coh, daos_unit_oid_t *oid,
  */
 int
 vos_dtx_list_committable(daos_handle_t coh, struct daos_tx_entry **dtes);
+
+/**
+ * Check whether the specified DTX can be committed or not.
+ *
+ * \param coh	[IN]	Container open handle.
+ * \param dti	[IN]	The DTX identifier.
+ *
+ * \return		DTX_ST_INIT	Related DTX does not exist, or it is
+ *					initialized, but the modification has
+ *					not completed yet.
+ *			DTX_ST_PREPARED	means that the DTX has been 'prepared',
+ *					so the local modification has been done
+ *					on related replica(s). If all replicas
+ *					have 'prepared', then the whole DTX is
+ *					committable.
+ *			DTX_ST_COMMITTED means the DTX has been committed.
+ *			Negative value if error.
+ */
+int
+vos_dtx_check_committable(daos_handle_t coh, struct daos_tx_id *dti);
+
+/**
+ * Commit the specified DTXs.
+ *
+ * \param coh	[IN]	Container open handle.
+ * \param dtis	[IN]	The array for DTX identifiers to be committed.
+ * \param count [IN]	The count of DTXs to be committed.
+ *
+ * \return		Positive value to ask the caller to aggregate
+ *			some old DTXs.
+ * \return		Zero on success (no additional action required).
+ * \return		Negative value if error.
+ */
+int
+vos_dtx_commit(daos_handle_t coh, struct daos_tx_id *dtis, int count);
+
+/**
+ * Abort the specified DTXs.
+ *
+ * \param coh	[IN]	Container open handle.
+ * \param dtis	[IN]	The array for DTX identifiers to be aborted.
+ * \param count [IN]	The count of DTXs to be aborted.
+ * \param force [IN]	Force abort even if some replica(s) have not
+ *			'prepared' related DTXs.
+ *
+ * \return		Zero on success, negative value if error.
+ */
+int
+vos_dtx_abort(daos_handle_t coh, struct daos_tx_id *dtis, int count,
+	      bool force);
+
+/**
+ * Aggregate the committed DTXs.
+ *
+ * \param coh	[IN]	Container open handle.
+ * \param max	[IN]	The maximum count of DTXs to be aggregated at most.
+ *			0 is the default: DTX_AGGREGATION_THRESHOLD_COUNT
+ *			(1 << 27), -1ULL is for all if @age is also -1ULL.
+ * \param age	[IN]	Aggregate the DTXs that are older than the give age
+ *			(in second). 0 means DTX_AGGREGATION_THRESHOLD_TIME
+ *			(3600 seconds). -1ULL means ignore the age factor.
+ */
+void
+vos_dtx_aggregate(daos_handle_t coh, uint64_t max, uint64_t age);
 
 /**
  * Initialize the environment for a VOS instance

--- a/src/include/daos_types.h
+++ b/src/include/daos_types.h
@@ -87,6 +87,10 @@ daos_csum_set(daos_csum_buf_t *csum, void *buf, uint16_t size)
 	csum->cs_len = csum->cs_buf_len = size;
 }
 
+enum daos_anchor_flags {
+	/* The RPC will be sent to leader replica. */
+	DAOS_ANCHOR_FLAGS_TO_LEADER	= 1,
+};
 
 typedef enum {
 	DAOS_ANCHOR_TYPE_ZERO	= 0,
@@ -100,10 +104,21 @@ typedef enum {
 typedef struct {
 	uint16_t	da_type; /** daos_anchor_type_t */
 	uint16_t	da_shard;
-	uint32_t	da_padding;
+	uint32_t	da_flags;
 	uint8_t		da_buf[DAOS_ANCHOR_BUF_MAX];
 } daos_anchor_t;
 
+static inline void
+daos_anchor_set_flags(daos_anchor_t *anchor, uint32_t flags)
+{
+	anchor->da_flags |= flags;
+}
+
+static inline uint32_t
+daos_anchor_get_flags(daos_anchor_t *anchor)
+{
+	return anchor->da_flags;
+}
 
 static inline void
 daos_anchor_set_zero(daos_anchor_t *anchor)

--- a/src/iosrv/init.c
+++ b/src/iosrv/init.c
@@ -40,7 +40,7 @@
 #include <daos.h> /* for daos_init() */
 
 #define MAX_MODULE_OPTIONS	64
-#define MODULE_LIST		"vos,rdb,rsvc,security,mgmt,pool,cont,obj,rebuild"
+#define MODULE_LIST	"vos,rdb,rsvc,security,mgmt,pool,cont,dtx,obj,rebuild"
 
 /** List of modules to load */
 static char		modules[MAX_MODULE_OPTIONS + 1];

--- a/src/object/obj_internal.h
+++ b/src/object/obj_internal.h
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2016-2018 Intel Corporation.
+ * (C) Copyright 2016-2019 Intel Corporation.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -35,6 +35,7 @@
 #include <daos/placement.h>
 #include <daos/btree.h>
 #include <daos/btree_class.h>
+#include <daos/dtx.h>
 #include <daos_srv/daos_server.h>
 #include <daos_types.h>
 
@@ -78,6 +79,7 @@ struct dc_obj_shard {
 	uint32_t		do_target_id;	/* target id (unique in pool) */
 	uint32_t		do_target_idx;	/* target VOS index in node */
 	uint32_t		do_target_rank;
+	uint32_t		do_fseq;	/* failure sequence */
 	uint32_t		do_rebuilding:1;
 	/** point back to object */
 	struct dc_object	*do_obj;
@@ -129,7 +131,9 @@ int dc_obj_shard_update(struct dc_obj_shard *shard, daos_epoch_t epoch,
 			daos_key_t *dkey, unsigned int nr,
 			daos_iod_t *iods, daos_sg_list_t *sgls,
 			unsigned int *map_ver, struct daos_obj_shard_tgt *tgts,
-			uint32_t fw_cnt, tse_task_t *task);
+			uint32_t fw_cnt, tse_task_t *task,
+			struct daos_tx_id *dti, uint32_t flags);
+
 int dc_obj_shard_fetch(struct dc_obj_shard *shard, daos_epoch_t epoch,
 		       daos_key_t *dkey, unsigned int nr,
 		       daos_iod_t *iods, daos_sg_list_t *sgls,
@@ -151,7 +155,8 @@ int dc_obj_shard_punch(struct dc_obj_shard *shard, uint32_t opc,
 		       daos_key_t *akeys, unsigned int akey_nr,
 		       const uuid_t coh_uuid, const uuid_t cont_uuid,
 		       unsigned int *map_ver, struct daos_obj_shard_tgt *tgts,
-		       uint32_t fw_cnt, tse_task_t *task);
+		       uint32_t fw_cnt, tse_task_t *task,
+		       struct daos_tx_id *dti, uint32_t flags);
 
 int dc_obj_shard_query_key(struct dc_obj_shard *shard, daos_epoch_t epoch,
 			   uint32_t flags, daos_key_t *dkey, daos_key_t *akey,
@@ -163,7 +168,7 @@ static inline bool
 obj_retry_error(int err)
 {
 	return err == -DER_TIMEDOUT || err == -DER_STALE ||
-	       daos_crt_network_error(err);
+	       err == -DER_INPROGRESS || daos_crt_network_error(err);
 }
 
 void obj_shard_decref(struct dc_obj_shard *shard);

--- a/src/object/obj_rpc.c
+++ b/src/object/obj_rpc.c
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2016-2018 Intel Corporation.
+ * (C) Copyright 2016-2019 Intel Corporation.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -29,6 +29,22 @@
 #include <daos/event.h>
 #include <daos/rpc.h>
 #include "obj_rpc.h"
+
+static int
+crt_proc_struct_daos_tx_id(crt_proc_t proc, struct daos_tx_id *dti)
+{
+	int rc;
+
+	rc = crt_proc_uuid_t(proc, &dti->dti_uuid);
+	if (rc != 0)
+		return -DER_HG;
+
+	rc = crt_proc_uint64_t(proc, &dti->dti_sec);
+	if (rc != 0)
+		return -DER_HG;
+
+	return 0;
+}
 
 static int
 crt_proc_daos_key_desc_t(crt_proc_t proc, daos_key_desc_t *key)
@@ -304,7 +320,7 @@ crt_proc_daos_anchor_t(crt_proc_t proc, daos_anchor_t *anchor)
 	if (crt_proc_uint16_t(proc, &anchor->da_shard) != 0)
 		return -DER_HG;
 
-	if (crt_proc_uint32_t(proc, &anchor->da_padding) != 0)
+	if (crt_proc_uint32_t(proc, &anchor->da_flags) != 0)
 		return -DER_HG;
 
 	if (crt_proc_raw(proc, anchor->da_buf, sizeof(anchor->da_buf)) != 0)

--- a/src/object/srv_obj.c
+++ b/src/object/srv_obj.c
@@ -574,7 +574,7 @@ ds_obj_rw_echo_handler(crt_rpc_t *rpc)
 		bulk_op = CRT_BULK_GET;
 	}
 
-	bulk_bind = orw->orw_flags & ORW_FLAG_BULK_BIND;
+	bulk_bind = orw->orw_flags & ORF_BULK_BIND;
 	rc = ds_bulk_transfer(rpc, bulk_op, bulk_bind, orw->orw_bulks.ca_arrays,
 			      DAOS_HDL_INVAL, &p_sgl, orw->orw_nr);
 
@@ -612,7 +612,7 @@ obj_update_prefw(crt_rpc_t *req, uint32_t shard, void *arg)
 	uuid_copy(orw->orw_co_uuid, orw_parent->orw_co_uuid);
 	orw->orw_shard_tgts.ca_count	= 0;
 	orw->orw_shard_tgts.ca_arrays	= NULL;
-	orw->orw_flags			= ORW_FLAG_BULK_BIND;
+	orw->orw_flags			= ORF_BULK_BIND;
 
 	return 0;
 }
@@ -692,7 +692,7 @@ ds_obj_rw_local_hdlr(crt_rpc_t *rpc, uint32_t tag, struct ds_cont_hdl *cont_hdl,
 	}
 
 	if (rma) {
-		bulk_bind = orw->orw_flags & ORW_FLAG_BULK_BIND;
+		bulk_bind = orw->orw_flags & ORF_BULK_BIND;
 		rc = ds_bulk_transfer(rpc, bulk_op, bulk_bind,
 			orw->orw_bulks.ca_arrays, *ioh, NULL, orw->orw_nr);
 	} else if (orw->orw_sgls.ca_arrays != NULL) {

--- a/src/placement/pl_map.c
+++ b/src/placement/pl_map.c
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2016 Intel Corporation.
+ * (C) Copyright 2016-2019 Intel Corporation.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -57,7 +57,7 @@ static struct pl_map_dict pl_maps[] = {
 };
 
 
-static int
+int
 pl_map_create_inited(struct pool_map *pool_map, struct pl_map_init_attr *mia,
 		    struct pl_map **pl_mapp)
 {
@@ -275,8 +275,8 @@ struct d_hash_table	pl_htable = {
 
 #define DSR_RING_DOMAIN		PO_COMP_TP_RACK
 
-static void
-pl_map_attr_init(struct pool_map *po_map, pl_map_type_t type,
+void
+pl_map_attr_init(const struct pool_map *po_map, pl_map_type_t type,
 		 struct pl_map_init_attr *mia)
 {
 	memset(mia, 0, sizeof(*mia));

--- a/src/placement/pl_map.h
+++ b/src/placement/pl_map.h
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2016 Intel Corporation.
+ * (C) Copyright 2016-2019 Intel Corporation.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -32,26 +32,6 @@
 #include <daos/placement.h>
 
 struct pl_map_ops;
-
-/** common header of all placement map */
-struct pl_map {
-	/** correpsonding pool uuid */
-	uuid_t			 pl_uuid;
-	/** link chain on hash */
-	d_list_t		 pl_link;
-	/** protect refcount */
-	pthread_spinlock_t	 pl_lock;
-	/** refcount */
-	int			 pl_ref;
-	/** pool connections, protected by pl_rwlock */
-	int			 pl_connects;
-	/** type of placement map */
-	pl_map_type_t		 pl_type;
-	/** reference to pool map */
-	struct pool_map		*pl_poolmap;
-	/** placement map operations */
-	struct pl_map_ops       *pl_ops;
-};
 
 /**
  * Function table for placement map.

--- a/src/placement/ring_map.c
+++ b/src/placement/ring_map.c
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2016-2018 Intel Corporation.
+ * (C) Copyright 2016-2019 Intel Corporation.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -1191,6 +1191,7 @@ next_fail:
 		if (spare_avail) {
 			/* The selected spare target is up and ready */
 			l_shard->po_target = spare_tgt->ta_comp.co_id;
+			l_shard->po_fseq = spare_tgt->ta_comp.co_fseq;
 
 			/*
 			 * Mark the shard as 'rebuilding' so that read will
@@ -1262,6 +1263,7 @@ ring_obj_layout_fill(struct pl_map *map, struct daos_obj_md *md,
 			tgt = &tgts[pos];
 			layout->ol_shards[k].po_shard  = rop->rop_shard_id + k;
 			layout->ol_shards[k].po_target = tgt->ta_comp.co_id;
+			layout->ol_shards[k].po_fseq   = tgt->ta_comp.co_fseq;
 
 			if (pool_target_unavail(tgt)) {
 				rc = ring_remap_alloc_one(remap_list, k, tgt);
@@ -1319,7 +1321,7 @@ ring_obj_place(struct pl_map *map, struct daos_obj_md *md,
 	return 0;
 }
 
-#define SHARDS_ON_STACK_COUNT	256
+#define SHARDS_ON_STACK_COUNT	128
 int
 ring_obj_find_rebuild(struct pl_map *map, struct daos_obj_md *md,
 		      struct daos_obj_shard_md *shard_md,

--- a/src/pool/srv_internal.h
+++ b/src/pool/srv_internal.h
@@ -61,6 +61,8 @@ struct pool_iv_entry {
 /*
  * srv_pool.c
  */
+void ds_pool_destroy_pl_map(struct ds_pool *pool);
+int ds_pool_create_pl_map(struct ds_pool *pool, struct pool_map *map);
 void ds_pool_rsvc_class_register(void);
 void ds_pool_rsvc_class_unregister(void);
 int ds_pool_svc_start(uuid_t uuid, bool create, uuid_t db_uuid, size_t size,

--- a/src/rdb/rdb_rpc.c
+++ b/src/rdb/rdb_rpc.c
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2017-2018 Intel Corporation.
+ * (C) Copyright 2017-2019 Intel Corporation.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -231,7 +231,7 @@ crt_proc_daos_anchor_t(crt_proc_t proc, daos_anchor_t *p)
 	rc = crt_proc_uint16_t(proc, &p->da_shard);
 	if (rc != 0)
 		return -DER_HG;
-	rc = crt_proc_uint32_t(proc, &p->da_padding);
+	rc = crt_proc_uint32_t(proc, &p->da_flags);
 	if (rc != 0)
 		return -DER_HG;
 	rc = crt_proc_memcpy(proc, &p->da_buf, sizeof(p->da_buf));

--- a/src/vos/vos_common.c
+++ b/src/vos/vos_common.c
@@ -35,6 +35,13 @@
 #include <daos/lru.h>
 #include <daos/btree_class.h>
 
+/**
+ * The vos_start_time records the timestamp when server starts the serive.
+ * Via comparing with the DTX entry's timestamp, we can know whether
+ * the DTX happened before the server restarting its service or not.
+ */
+double vos_start_time;
+
 static pthread_mutex_t	mutex = PTHREAD_MUTEX_INITIALIZER;
 /**
  * Object cache based on mode of instantiation
@@ -367,6 +374,7 @@ vos_init(void)
 	if (rc)
 		D_GOTO(exit, rc);
 
+	vos_start_time = ABT_get_wtime();
 	is_init = 1;
 exit:
 	D_MUTEX_UNLOCK(&mutex);

--- a/src/vos/vos_container.c
+++ b/src/vos/vos_container.c
@@ -362,6 +362,7 @@ vos_cont_open(daos_handle_t poh, uuid_t co_uuid, daos_handle_t *coh)
 	cont->vc_dtx_cos_hdl = DAOS_HDL_INVAL;
 	D_INIT_LIST_HEAD(&cont->vc_dtx_committable);
 	cont->vc_dtx_committable_count = 0;
+	cont->vc_dtx_time_last_commit = ABT_get_wtime();
 
 	/* Cache this btr object ID in container handle */
 	rc = dbtree_open_inplace_ex(&cont->vc_otab_df->obt_btr,

--- a/src/vos/vos_dtx.c
+++ b/src/vos/vos_dtx.c
@@ -34,6 +34,19 @@
 #define DTX_UMMID_ABORTED	((umem_id_t){ .pool_uuid_lo = -1, .off = -1, })
 #define DTX_UMMID_UNKNOWN	((umem_id_t){ .pool_uuid_lo = -1, .off = -2, })
 
+static inline int
+dtx_inprogress(struct vos_dtx_entry_df *dtx, int pos)
+{
+	if (dtx != NULL)
+		D_DEBUG(DB_TRACE, "Hit uncommitted DTX "DF_DTI
+			" with state %u, time %lu at %d\n",
+			DP_DTI(&dtx->te_xid), dtx->te_state, dtx->te_sec, pos);
+	else
+		D_DEBUG(DB_TRACE, "Hit uncommitted (unknown) DTX at %d\n", pos);
+
+	return -DER_INPROGRESS;
+}
+
 struct dtx_rec_bundle {
 	umem_id_t	trb_ummid;
 };
@@ -621,6 +634,66 @@ vos_dtx_abort_one(struct vos_container *cont, struct daos_tx_id *dti,
 		rc = 0;
 
 	return rc;
+}
+
+int
+vos_dtx_handle_resend(daos_handle_t coh, struct daos_tx_id *dti)
+{
+	struct vos_container	*cont;
+	struct vos_dtx_entry_df	*dtx;
+	daos_iov_t		 kiov;
+	daos_iov_t		 riov;
+	int			 rc;
+
+	cont = vos_hdl2cont(coh);
+	D_ASSERT(cont != NULL);
+
+	daos_iov_set(&kiov, dti, sizeof(*dti));
+	daos_iov_set(&riov, NULL, 0);
+	rc = dbtree_lookup(cont->vc_dtx_active_hdl, &kiov, &riov);
+	if (rc == -DER_NONEXIST)
+		rc = dbtree_lookup(cont->vc_dtx_committed_hdl, &kiov, &riov);
+
+	if (rc == -DER_NONEXIST) {
+		/* If the resent RPC is too old, then we cannot know whether
+		 * the RPC has ever been executed before or not. Then return
+		 * -DER_TIMEDOUT to the RPC sponsor. Means that modification
+		 * for such RPC may have been executed, but nobody guarantee
+		 * that. It is the caller's duty to check related record(s).
+		 */
+		if ((uint64_t)ABT_get_wtime() - dti->dti_sec >
+		    DTX_AGGREGATION_THRESHOLD_TIME) {
+			D_DEBUG(DB_IO, "Not sure about whether the RPC "
+				DF_DTI" is resend or not.\n", DP_DTI(dti));
+			return -DER_TIMEDOUT;
+		}
+	}
+
+	if (rc != 0)
+		return rc;
+
+	dtx = (struct vos_dtx_entry_df *)riov.iov_buf;
+	switch (dtx->te_state) {
+	case DTX_ST_INIT:
+		/* New DTX after the leader (re)start that is not
+		 * completed yet, retry related RPC some time later.
+		 */
+		if (dtx->te_sec >= (uint64_t)vos_start_time)
+			return dtx_inprogress(dtx, 1);
+
+		/* The INIT DTX in PRAM must be for an in-update object/key
+		 * that was waiting for the bulk transfer (or remote abort)
+		 * before the VOS restart. So here, it should be the case
+		 * that client resends RPC after server restart.
+		 */
+		return 0;
+	case DTX_ST_PREPARED:
+		return 0;
+	case DTX_ST_COMMITTED:
+		return -DER_ALREADY;
+	default:
+		return -DER_INVAL;
+	}
 }
 
 int

--- a/src/vos/vos_dtx.c
+++ b/src/vos/vos_dtx.c
@@ -31,6 +31,9 @@
 #include "vos_layout.h"
 #include "vos_internal.h"
 
+#define DTX_UMMID_ABORTED	((umem_id_t){ .pool_uuid_lo = -1, .off = -1, })
+#define DTX_UMMID_UNKNOWN	((umem_id_t){ .pool_uuid_lo = -1, .off = -2, })
+
 struct dtx_rec_bundle {
 	umem_id_t	trb_ummid;
 };
@@ -218,4 +221,634 @@ vos_dtx_table_destroy(struct vos_pool *pool, struct vos_dtx_table_df *dtab_df)
 	}
 
 	return rc;
+}
+
+static void
+dtx_obj_rec_release(struct umem_instance *umm, struct vos_obj_df *obj,
+		    umem_id_t ummid, bool abort)
+{
+	struct vos_dtx_entry_df		*dtx;
+
+	dtx = umem_id2ptr(umm, ummid);
+	obj->vo_dtx_shares--;
+
+	/* Other DTX that shares the object has been committed firstly.
+	 * The subsequent modifications may have seen such modification
+	 * before current DTX commit or abort.
+	 */
+	if (UMMID_IS_NULL(obj->vo_dtx)) {
+		if (!abort) { /* commit case */
+			if (obj->vo_latest < dtx->te_epoch &&
+			    obj->vo_latest != 0)
+				/* "vo_latest == 0" is for punched case. */
+				obj->vo_latest = dtx->te_epoch;
+			if (obj->vo_earliest > dtx->te_epoch &&
+			    obj->vo_earliest != DAOS_EPOCH_MAX)
+				/* "vo_earliest == DAOS_EPOCH_MAX" means
+				 * that the new created object have been
+				 * punched before current DTX committed.
+				 */
+				obj->vo_earliest = dtx->te_epoch;
+		}
+		return;
+	}
+
+	/* I am the DTX that is committed firstly. The current DTX may be not
+	 * the one that create the object. The DTX that create the object may
+	 * be not committed or has been aborted. So vo_latest and vo_earliest
+	 * may be different from current DTX. Set them as current DTX's epoch.
+	 */
+	if (!abort) {
+		obj->vo_dtx = UMMID_NULL;
+		obj->vo_latest = dtx->te_epoch;
+		obj->vo_earliest = dtx->te_epoch;
+		return;
+	}
+
+	/* The last shared DTX is aborted. */
+	if (obj->vo_dtx_shares == 0) {
+		obj->vo_dtx = DTX_UMMID_ABORTED;
+		return;
+	}
+
+	/* I am the original DTX that create the object that
+	 * is still shared by others. Now, I will be aborted,
+	 * set the reference as UNKNOWN for other left shares.
+	 */
+	if (umem_id_equal(umm, obj->vo_dtx, ummid))
+		obj->vo_dtx = DTX_UMMID_UNKNOWN;
+}
+
+static void
+dtx_key_rec_release(struct umem_instance *umm, struct vos_krec_df *key,
+		    struct vos_dtx_record_df *rec, umem_id_t ummid, bool abort)
+{
+	struct vos_dtx_entry_df		*dtx;
+
+	dtx = umem_id2ptr(umm, ummid);
+	key->kr_dtx_shares--;
+
+	/* Other DTX that shares the key has been committed firstly.
+	 * It must be for sharing of update. Subsequent modification
+	 * may have seen the modification before current DTX commit
+	 * or abort.
+	 */
+	if (UMMID_IS_NULL(key->kr_dtx)) {
+		if (!abort) { /* commit case */
+			if (key->kr_latest < dtx->te_epoch &&
+			    key->kr_latest != 0)
+				key->kr_latest = dtx->te_epoch;
+			if (key->kr_earliest > dtx->te_epoch &&
+			    key->kr_earliest != DAOS_EPOCH_MAX)
+				key->kr_earliest = dtx->te_epoch;
+		}
+		return;
+	}
+
+	/* I am the DTX that is committed firstly. The current DTX may be not
+	 * the one that create the key. The DTX that create the key may be not
+	 * committed or has been aborted. So the kr_latest and kr_earliest may
+	 * be different from current DTX. Set them as current DTX's epoch.
+	 */
+	if (!abort) {
+		key->kr_dtx = UMMID_NULL;
+		if (rec->tr_flags != DTX_RF_EXCHANGE_SRC &&
+		    rec->tr_flags != DTX_RF_EXCHANGE_TGT) {
+			key->kr_latest = dtx->te_epoch;
+			key->kr_earliest = dtx->te_epoch;
+			return;
+		}
+		goto exchange;
+	}
+
+	/* The last shared DTX is aborted. */
+	if (key->kr_dtx_shares == 0) {
+		key->kr_dtx = DTX_UMMID_ABORTED;
+		goto exchange;
+	}
+
+	/* I am the original DTX that create the key that
+	 * is still shared by others. Now, I will be aborted,
+	 * set the reference as UNKNOWN for other left shares.
+	 */
+	if (umem_id_equal(umm, key->kr_dtx, ummid))
+		key->kr_dtx = DTX_UMMID_UNKNOWN;
+
+exchange:
+	if (rec->tr_flags != DTX_RF_EXCHANGE_SRC)
+		return;
+
+	D_ASSERT(key->kr_bmap & KREC_BF_REMOVED);
+
+	if (!abort) { /* commit case */
+		struct vos_dtx_record_df	*tgt_rec;
+		struct vos_krec_df		*tgt_key;
+		struct btr_root			 tmp_btr;
+
+		/* XXX: If the exchange target still exist, it will be the next
+		 *	record. If it does not exist, then either it is crashed
+		 *	or it has already degistered from the DTX records list.
+		 *	We cannot commit the DTX under any the two cases. Fail
+		 *	the DTX commit is meaningless, then some warnings.
+		 */
+		if (UMMID_IS_NULL(rec->tr_next)) {
+			D_ERROR(DF_UOID" miss the DTX ("DF_DTI
+				") exchange pairs (1)\n",
+				DP_UOID(dtx->te_oid), DP_DTI(&dtx->te_xid));
+			return;
+		}
+
+		tgt_rec = umem_id2ptr(umm, rec->tr_next);
+		if (tgt_rec->tr_flags != DTX_RF_EXCHANGE_TGT) {
+			D_ERROR(DF_UOID" miss the DTX ("DF_DTI
+				") exchange pairs (2)\n",
+				DP_UOID(dtx->te_oid), DP_DTI(&dtx->te_xid));
+			return;
+		}
+
+		/* Exchange the sub-tree between max epoch record and the given
+		 * epoch record. The record with max epoch will be removed when
+		 * aggregation or some special cleanup.
+		 */
+		tgt_key = umem_id2ptr(umm, tgt_rec->tr_record);
+		umem_tx_add_ptr(umm, tgt_key, sizeof(*tgt_key));
+
+		tmp_btr = key->kr_btr;
+		key->kr_btr = tgt_key->kr_btr;
+		tgt_key->kr_btr = tmp_btr;
+
+		if (key->kr_bmap & KREC_BF_EVT) {
+			struct evt_root		tmp_evt;
+
+			umem_tx_add_ptr(umm, &key->kr_evt[0],
+					sizeof(key->kr_evt[0]));
+			umem_tx_add_ptr(umm, &tgt_key->kr_evt[0],
+					sizeof(tgt_key->kr_evt[0]));
+
+			tmp_evt = key->kr_evt[0];
+			key->kr_evt[0] = tgt_key->kr_evt[0];
+			tgt_key->kr_evt[0] = tmp_evt;
+		}
+
+		/* The @tgt_key which epoch is current DTX's epoch will be
+		 * visibile to outside of VOS. Set its kr_earliest as @key
+		 * kr_earliest.
+		 */
+		tgt_key->kr_earliest = key->kr_earliest;
+		tgt_key->kr_latest = dtx->te_epoch;
+
+		/* The @key which epoch is MAX will be removed later. */
+		key->kr_latest = 0;
+		key->kr_earliest = DAOS_EPOCH_MAX;
+
+		D_DEBUG(DB_TRACE, "Exchanged DTX records for "DF_DTI"\n",
+			DP_DTI(&dtx->te_xid));
+	} else { /* abort case */
+		/* Recover the visibility of the exchange source
+		 * for the DTX abort case.
+		 */
+		key->kr_bmap &= ~KREC_BF_REMOVED;
+		key->kr_dtx = UMMID_NULL;
+	}
+}
+
+static int
+dtx_rec_release(struct umem_instance *umm, umem_id_t ummid,
+		bool abort, bool destroy)
+{
+	struct vos_dtx_entry_df		*dtx;
+
+	dtx = umem_id2ptr(umm, ummid);
+	umem_tx_add_ptr(umm, dtx, sizeof(*dtx));
+
+	while (!UMMID_IS_NULL(dtx->te_records)) {
+		umem_id_t			 rec_mmid = dtx->te_records;
+		struct vos_dtx_record_df	*rec;
+
+		rec = umem_id2ptr(umm, rec_mmid);
+		switch (rec->tr_type) {
+		case DTX_RT_OBJ: {
+			struct vos_obj_df	*obj;
+
+			obj = umem_id2ptr(umm, rec->tr_record);
+			umem_tx_add_ptr(umm, obj, sizeof(*obj));
+			dtx_obj_rec_release(umm, obj, ummid, abort);
+			break;
+		}
+		case DTX_RT_KEY: {
+			struct vos_krec_df	*key;
+
+			key = umem_id2ptr(umm, rec->tr_record);
+			umem_tx_add_ptr(umm, key, sizeof(*key));
+			dtx_key_rec_release(umm, key, rec, ummid, abort);
+			break;
+		}
+		case DTX_RT_SVT: {
+			struct vos_irec_df	*svt;
+
+			svt = umem_id2ptr(umm, rec->tr_record);
+			umem_tx_add_ptr(umm, &svt->ir_dtx, sizeof(svt->ir_dtx));
+			if (abort)
+				svt->ir_dtx = DTX_UMMID_ABORTED;
+			else
+				svt->ir_dtx = UMMID_NULL;
+			break;
+		}
+		case DTX_RT_EVT: {
+			struct evt_desc		*evt;
+
+			evt = umem_id2ptr(umm, rec->tr_record);
+			umem_tx_add_ptr(umm, &evt->dc_dtx, sizeof(evt->dc_dtx));
+			if (abort)
+				evt->dc_dtx = DTX_UMMID_ABORTED;
+			else
+				evt->dc_dtx = UMMID_NULL;
+			break;
+		}
+		default:
+			D_ERROR(DF_UOID" unknown DTX "DF_DTI" type %u\n",
+				DP_UOID(dtx->te_oid), DP_DTI(&dtx->te_xid),
+				rec->tr_type);
+			break;
+		}
+
+		dtx->te_records = rec->tr_next;
+		umem_tx_add_ptr(umm, rec, sizeof(*rec));
+		umem_free(umm, rec_mmid);
+	}
+
+	D_DEBUG(DB_TRACE, "dtx_rec_release: %s/%s the DTX "DF_DTI"\n",
+		abort ? "abort" : "commit", destroy ? "destroy" : "keep",
+		DP_DTI(&dtx->te_xid));
+
+	if (destroy)
+		umem_free(umm, ummid);
+	else
+		dtx->te_flags &= ~(DTX_EF_EXCHANGE_PENDING | DTX_EF_SHARES);
+
+	return 0;
+}
+
+static void
+vos_dtx_unlink_entry(struct umem_instance *umm, struct vos_dtx_table_df *tab,
+		     struct vos_dtx_entry_df *dtx)
+{
+	struct vos_dtx_entry_df	*ent;
+
+	if (UMMID_IS_NULL(dtx->te_next)) { /* The tail of the DTXs list. */
+		if (UMMID_IS_NULL(dtx->te_prev)) { /* The unique one on list. */
+			tab->tt_entry_head = UMMID_NULL;
+			tab->tt_entry_tail = UMMID_NULL;
+		} else {
+			ent = umem_id2ptr(umm, dtx->te_prev);
+			umem_tx_add_ptr(umm, &ent->te_next,
+					sizeof(ent->te_next));
+			ent->te_next = UMMID_NULL;
+			tab->tt_entry_tail = dtx->te_prev;
+			dtx->te_prev = UMMID_NULL;
+		}
+	} else if (UMMID_IS_NULL(dtx->te_prev)) { /* The head of DTXs list */
+		ent = umem_id2ptr(umm, dtx->te_next);
+		umem_tx_add_ptr(umm, &ent->te_prev, sizeof(ent->te_prev));
+		ent->te_prev = UMMID_NULL;
+		tab->tt_entry_head = dtx->te_next;
+		dtx->te_next = UMMID_NULL;
+	} else {
+		ent = umem_id2ptr(umm, dtx->te_next);
+		umem_tx_add_ptr(umm, &ent->te_prev, sizeof(ent->te_prev));
+		ent->te_prev = dtx->te_prev;
+
+		ent = umem_id2ptr(umm, dtx->te_prev);
+		umem_tx_add_ptr(umm, &ent->te_next, sizeof(ent->te_next));
+		ent->te_next = dtx->te_next;
+
+		dtx->te_prev = UMMID_NULL;
+		dtx->te_next = UMMID_NULL;
+	}
+}
+
+static int
+vos_dtx_commit_one(struct vos_container *cont, struct daos_tx_id *dti)
+{
+	struct umem_instance	*umm;
+	daos_iov_t		 kiov;
+	daos_iov_t		 riov;
+	umem_id_t		 ummid;
+	int			 rc = 0;
+
+	umm = &cont->vc_pool->vp_umm;
+	daos_iov_set(&kiov, dti, sizeof(*dti));
+	rc = dbtree_delete(cont->vc_dtx_active_hdl, &kiov, &ummid);
+	if (rc == 0) {
+		struct vos_dtx_entry_df		*dtx;
+		struct vos_dtx_entry_df		*ent;
+		struct dtx_rec_bundle		 rbund;
+
+		dtx = umem_id2ptr(umm, ummid);
+		umem_tx_add_ptr(umm, dtx, sizeof(*dtx));
+		dtx->te_state = DTX_ST_COMMITTED;
+
+		if (dtx->te_dkey_hash[0] != 0)
+			vos_dtx_del_cos(cont, &dtx->te_oid, dti,
+					dtx->te_dkey_hash[0],
+					dtx->te_intent == DAOS_INTENT_PUNCH ?
+					true : false);
+
+		rbund.trb_ummid = ummid;
+		daos_iov_set(&riov, &rbund, sizeof(rbund));
+		rc = dbtree_upsert(cont->vc_dtx_committed_hdl, BTR_PROBE_EQ,
+				   DAOS_INTENT_UPDATE, &kiov, &riov);
+		if (rc == 0) {
+			struct vos_dtx_table_df	*tab;
+
+			tab = &cont->vc_cont_df->cd_dtx_table_df;
+			umem_tx_add_ptr(umm, tab, sizeof(*tab));
+
+			tab->tt_count++;
+			if (UMMID_IS_NULL(tab->tt_entry_tail)) {
+				D_ASSERT(UMMID_IS_NULL(tab->tt_entry_head));
+
+				tab->tt_entry_head = ummid;
+				tab->tt_entry_tail = tab->tt_entry_head;
+			} else {
+				ent = umem_id2ptr(umm, tab->tt_entry_tail);
+				umem_tx_add_ptr(umm, &ent->te_next,
+						sizeof(ent->te_next));
+
+				ent->te_next = ummid;
+				dtx->te_prev = tab->tt_entry_tail;
+				tab->tt_entry_tail = ent->te_next;
+			}
+
+			/* If there are pending exchange of records, then we
+			 * need some additional work when commit, such as
+			 * exchange the subtree under the source and target
+			 * records, then related subtree can be exported
+			 * correctly. That will be done when release related
+			 * vos_dth_record_df(s) attached to the DTX.
+			 */
+			if (dtx->te_flags &
+			    (DTX_EF_EXCHANGE_PENDING | DTX_EF_SHARES))
+				rc = dtx_rec_release(umm, ummid, false, false);
+		}
+	} else if (rc == -DER_NONEXIST) {
+		daos_iov_set(&riov, NULL, 0);
+		rc = dbtree_lookup(cont->vc_dtx_committed_hdl, &kiov, &riov);
+	}
+
+	D_DEBUG(DB_TRACE, "Commit the DTX "DF_DTI": rc = %d\n",
+		DP_DTI(dti), rc);
+
+	return rc;
+}
+
+static int
+vos_dtx_abort_one(struct vos_container *cont, struct daos_tx_id *dti,
+		  bool force)
+{
+	daos_iov_t	 kiov;
+	umem_id_t	 dtx;
+	int		 rc;
+
+	daos_iov_set(&kiov, dti, sizeof(*dti));
+	rc = dbtree_delete(cont->vc_dtx_active_hdl, &kiov, &dtx);
+	if (rc == 0)
+		rc = dtx_rec_release(&cont->vc_pool->vp_umm, dtx, true, true);
+
+	D_DEBUG(DB_TRACE, "Abort the DTX "DF_DTI": rc = %d\n", DP_DTI(dti), rc);
+
+	if (rc != 0 && force)
+		rc = 0;
+
+	return rc;
+}
+
+int
+vos_dtx_begin(struct daos_tx_id *dti, daos_unit_oid_t *oid, daos_key_t *dkey,
+	      daos_handle_t coh, daos_epoch_t epoch, uint32_t pm_ver,
+	      uint32_t intent, uint32_t flags, struct daos_tx_handle **dtx)
+{
+	struct daos_tx_handle	*th;
+
+	D_ALLOC_PTR(th);
+	if (th == NULL)
+		return -DER_NOMEM;
+
+	th->dth_xid = *dti;
+	th->dth_oid = *oid;
+	th->dth_dkey = dkey;
+	th->dth_coh = coh;
+	th->dth_epoch = epoch;
+	D_INIT_LIST_HEAD(&th->dth_shares);
+	th->dth_ver = pm_ver;
+	th->dth_intent = intent;
+	th->dth_flags = flags;
+	th->dth_sync = 0;
+	th->dth_non_rep = 0;
+	th->dth_ent = UMMID_NULL;
+
+	*dtx = th;
+	D_DEBUG(DB_TRACE, "Start the DTX "DF_DTI"\n", DP_DTI(dti));
+
+	return 0;
+}
+
+int
+vos_dtx_end(struct daos_tx_handle *dth, int result, bool leader)
+{
+	struct vos_container	*cont;
+	struct vos_dtx_table_df	*tab;
+	double			 now = ABT_get_wtime();
+
+	if (result < 0)
+		goto out;
+
+	result = 0;
+	cont = vos_hdl2cont(dth->dth_coh);
+	D_ASSERT(cont != NULL);
+
+	if (leader) {
+		if (dth->dth_sync)
+			D_GOTO(out, result = DTX_ACT_COMMIT_SYNC);
+
+		if (cont->vc_dtx_committable_count > DTX_THRESHOLD_COUNT)
+			D_GOTO(out, result = DTX_ACT_COMMIT_ASYNC);
+
+		if ((uint64_t)now - cont->vc_dtx_time_last_commit >
+		     DTX_COMMIT_THRESHOLD_TIME)
+			D_GOTO(out, result = DTX_ACT_COMMIT_ASYNC);
+	}
+
+	tab = &cont->vc_cont_df->cd_dtx_table_df;
+	if (tab->tt_count > DTX_AGGREGATION_THRESHOLD_COUNT)
+		D_GOTO(out, result = DTX_ACT_AGGREGATE);
+
+	if ((uint64_t)now - tab->tt_time_last_shrink >
+	    DTX_AGGREGATION_THRESHOLD_TIME)
+		D_GOTO(out, result = DTX_ACT_AGGREGATE);
+
+out:
+	D_DEBUG(DB_TRACE,
+		"Stop the DTX "DF_DTI" ver = %u, %s, %s, %s: rc = %d\n",
+		DP_DTI(&dth->dth_xid), dth->dth_ver,
+		dth->dth_sync ? "sync" : "async",
+		dth->dth_non_rep ? "non-replicated" : "replicated",
+		dth->dth_leader ? "leader" : "non-leader", result);
+	D_FREE_PTR(dth);
+	return result;
+}
+
+int
+vos_dtx_check_committable(daos_handle_t coh, struct daos_tx_id *dti)
+{
+	struct vos_container	*cont;
+	daos_iov_t		 kiov;
+	daos_iov_t		 riov;
+	int			 rc;
+
+	cont = vos_hdl2cont(coh);
+	D_ASSERT(cont != NULL);
+
+	daos_iov_set(&kiov, dti, sizeof(*dti));
+	daos_iov_set(&riov, NULL, 0);
+	rc = dbtree_lookup(cont->vc_dtx_active_hdl, &kiov, &riov);
+	if (rc == 0) {
+		struct vos_dtx_entry_df	*dtx;
+
+		dtx = (struct vos_dtx_entry_df *)riov.iov_buf;
+		return dtx->te_state;
+	}
+
+	if (rc == -DER_NONEXIST) {
+		rc = dbtree_lookup(cont->vc_dtx_committed_hdl, &kiov, &riov);
+		if (rc == 0)
+			return DTX_ST_COMMITTED;
+	}
+
+	if (rc == -DER_NONEXIST)
+		return DTX_ST_INIT;
+
+	return rc;
+}
+
+int
+vos_dtx_commit(daos_handle_t coh, struct daos_tx_id *dtis, int count)
+{
+	struct vos_container	*cont;
+	struct umem_instance	*umm;
+	int			 rc;
+
+	cont = vos_hdl2cont(coh);
+	D_ASSERT(cont != NULL);
+
+	umm = &cont->vc_pool->vp_umm;
+	/* Commit multiple DTXs via single PMDK transaction. */
+	rc = umem_tx_begin(umm, vos_txd_get());
+	if (rc == 0) {
+		int	i;
+
+		for (i = 0; i < count; i++)
+			vos_dtx_commit_one(cont, &dtis[i]);
+
+		cont->vc_dtx_time_last_commit = ABT_get_wtime();
+		umem_tx_commit(umm);
+	}
+
+	return rc;
+}
+
+int
+vos_dtx_abort(daos_handle_t coh, struct daos_tx_id *dtis, int count, bool force)
+{
+	struct vos_container	*cont;
+	struct umem_instance	*umm;
+	int			 rc;
+	int			 i;
+
+	cont = vos_hdl2cont(coh);
+	D_ASSERT(cont != NULL);
+
+	umm = &cont->vc_pool->vp_umm;
+	/* Abort multiple DTXs via single PMDK transaction. */
+	rc = umem_tx_begin(umm, vos_txd_get());
+	for (i = 0; rc == 0 && i < count; i++)
+		rc = vos_dtx_abort_one(cont, &dtis[i], force);
+
+	if (rc == 0)
+		umem_tx_commit(umm);
+	else
+		umem_tx_abort(umm, rc);
+
+	return rc;
+}
+
+void
+vos_dtx_aggregate(daos_handle_t coh, uint64_t max, uint64_t age)
+{
+	struct vos_container		*cont;
+	struct umem_instance		*umm;
+	struct vos_dtx_table_df		*tab;
+	umem_id_t			 dtx_mmid;
+	daos_iov_t			 kiov;
+	uint64_t			 count;
+	double				 now;
+	bool				 stop = false;
+
+	if (max == 0)
+		max = DTX_AGGREGATION_THRESHOLD_COUNT;
+
+	now = ABT_get_wtime();
+	if (age == 0)
+		age = now - DTX_AGGREGATION_THRESHOLD_TIME;
+	else if (age != (uint64_t)(-1))
+		age = now - age;
+
+	cont = vos_hdl2cont(coh);
+	D_ASSERT(cont != NULL);
+
+	umm = &cont->vc_pool->vp_umm;
+	tab = &cont->vc_cont_df->cd_dtx_table_df;
+
+	for (count = 0, dtx_mmid = tab->tt_entry_head;
+	     count < max && !UMMID_IS_NULL(dtx_mmid);) {
+		int	rc;
+		int	i;
+
+		rc = umem_tx_begin(umm, vos_txd_get());
+		if (rc != 0)
+			return;
+
+		umem_tx_add_ptr(umm, tab, sizeof(*tab));
+		for (i = 0; i < DTX_AGGREGATION_YIELD_INTERVAL &&
+		     !UMMID_IS_NULL(dtx_mmid) && count < max; i++, count++) {
+			struct vos_dtx_entry_df	*dtx;
+			umem_id_t		 ummid;
+
+			dtx = umem_id2ptr(umm, dtx_mmid);
+			if (dtx->te_sec > age) {
+				stop = true;
+				break;
+			}
+
+			umem_tx_add_ptr(umm, dtx, sizeof(*dtx));
+			daos_iov_set(&kiov, &dtx->te_xid, sizeof(dtx->te_xid));
+			rc = dbtree_delete(cont->vc_dtx_committed_hdl, &kiov,
+					   &ummid);
+			D_ASSERT(rc == 0);
+
+			tab->tt_count--;
+			dtx_mmid = dtx->te_next;
+			vos_dtx_unlink_entry(umm, tab, dtx);
+			dtx_rec_release(umm, ummid, false, true);
+		}
+
+		tab->tt_time_last_shrink = now;
+		umem_tx_commit(umm);
+
+		if (stop)
+			return;
+
+		/* Yield per DTX_AGGREGATION_YIELD_INTERVAL. */
+		ABT_thread_yield();
+	}
 }

--- a/src/vos/vos_internal.h
+++ b/src/vos/vos_internal.h
@@ -45,6 +45,7 @@
 
 extern struct dss_module_key vos_module_key;
 extern umem_class_id_t vos_mem_class;
+extern double vos_start_time;
 
 #define VOS_POOL_HHASH_BITS 10 /* Upto 1024 pools */
 #define VOS_CONT_HHASH_BITS 20 /* Upto 1048576 containers */

--- a/src/vos/vos_internal.h
+++ b/src/vos/vos_internal.h
@@ -116,6 +116,8 @@ struct vos_container {
 	d_list_t		vc_dtx_committable;
 	/* The count of commiitable DTXs. */
 	uint32_t		vc_dtx_committable_count;
+	/** The time in second when commit the DTXs for the last time. */
+	double			vc_dtx_time_last_commit;
 	/* Direct pointer to VOS object index
 	 * within container
 	 */

--- a/src/vos/vos_layout.h
+++ b/src/vos/vos_layout.h
@@ -249,6 +249,8 @@ enum vos_krec_bf {
 	KREC_BF_EVT			= (1 << 0),
 	/* The key is punched at time kr_latest */
 	KREC_BF_PUNCHED			= (1 << 1),
+	/* The key has been (or will be) removed */
+	KREC_BF_REMOVED			= (1 << 2),
 };
 
 /**


### PR DESCRIPTION
The DTX RPC is used for the DTX control between leader
and non-leader replicas, including:

1. DTX_COMMIT
   The leader ask the non-leaders to commit a bunch of DTXs.

2. DTX_ABORT
   The leader ask the non-leaders to abort a bunch of DTXs.

3. DTX_CHECK
   The leader ask the non-leaders to return the specified
   DTX state.

Signed-off-by: Fan Yong <fan.yong@intel.com>
Change-Id: I393d75a8b91e4b89af7c7fbf20535f5c070e177e