### PR TITLE
DAOS-2153 build: Fix build issue

### DIFF
--- a/src/include/daos/common.h
+++ b/src/include/daos/common.h
@@ -41,10 +41,10 @@
 #include <pthread.h>
 #include <byteswap.h>
 
+#include <daos/debug.h>
 #include <gurt/hash.h>
 #include <gurt/common.h>
 #include <cart/api.h>
-#include <daos/debug.h>
 #include <daos_types.h>
 #include <daos/checksum.h>
 


### PR DESCRIPTION
Someone added a patch while my patch was inflight that didn't cause
a git conflict but caused the build to fail.

daos/debug.h needs to be included before gurt/debug_setup.h

Change-Id: Ie47f46d787d508e8e1b9187c75ec73dc38d2ed84
Signed-off-by: Jeff Olivier <jeffrey.v.olivier@intel.com>