### PR TITLE
DAOS-1441 vos: handle resent RPC

### DIFF
--- a/src/include/daos_srv/vos.h
+++ b/src/include/daos_srv/vos.h
@@ -37,6 +37,24 @@
 #include <daos_srv/vos_types.h>
 
 /**
+ * Check whether the given @dti belongs to a resent RPC or not.
+ *
+ * \param coh	[IN]	Container open handle.
+ * \param dti	[IN]	The DTX identifier.
+ *
+ * \return		Zero if related DTX is there ('prepared'),
+ *			but not committed yet.
+ * \return		-DER_ALREADY if related DTX has been committed.
+ * \return		-DER_NONEXIST if no modification has been done before.
+ * \return		-DER_INPROGRESS if some new DTX ('init') is there.
+ * \return		-DER_TIMEDOUT if the DTX is too old as to we are not
+ *			sure about whether it has ever been processed or not.
+ * \return		Other negative value if error.
+ */
+int
+vos_dtx_handle_resend(daos_handle_t coh, struct daos_tx_id *dti);
+
+/**
  * Prepare the DTX handle in DRAM.
  *
  * XXX: Currently, we only support to prepare the DTX against single DAOS

--- a/src/vos/vos_common.c
+++ b/src/vos/vos_common.c
@@ -35,6 +35,13 @@
 #include <daos/lru.h>
 #include <daos/btree_class.h>
 
+/**
+ * The vos_start_time records the timestamp when server starts the serive.
+ * Via comparing with the DTX entry's timestamp, we can know whether
+ * the DTX happened before the server restarting its service or not.
+ */
+uint64_t vos_start_time;
+
 static pthread_mutex_t	mutex = PTHREAD_MUTEX_INITIALIZER;
 /**
  * Object cache based on mode of instantiation
@@ -357,6 +364,7 @@ vos_init(void)
 	if (rc)
 		D_GOTO(exit, rc);
 
+	vos_start_time = time(NULL);
 	is_init = 1;
 exit:
 	D_MUTEX_UNLOCK(&mutex);

--- a/src/vos/vos_internal.h
+++ b/src/vos/vos_internal.h
@@ -44,6 +44,7 @@
 #define DAOS_VOS_VERSION 1
 
 extern struct dss_module_key vos_module_key;
+extern uint64_t vos_start_time;
 
 #define VOS_POOL_HHASH_BITS 10 /* Upto 1024 pools */
 #define VOS_CONT_HHASH_BITS 20 /* Upto 1048576 containers */


### PR DESCRIPTION
In DAOS, we allow the RPC to be resent. For read-only RPC,
it is not important to re-handle the resent RPC as handling
the original one. But for resent modification RPC, we need
to distinguish it from non-resent case, in further, we also
need to know whether the orignal modification has been done
successfully or not. Otherwise, only simply re-execute the
modification may cause unexpected result, such as breaking
POSIX semantics.

The committed DTX table stores the historical modifications
since some time point, then we can reuse it to detect resent
modification RPC. Such functionality is not required by the
DTX model, just the side-effect. In the future, if we have
more suitable solution for the resent handling, then we can
replace the temporary solution.

There is one restriction for the committed DTX table based
resent RPC solution: we only store the historical DTXs from
some time point (since the last vos_dtx_aggregate) because
of the limited SCM/NVMe space. If some client resends very
old RPC that has ever been done on the server successfully
but related DTX record has been discarded when aggregation,
then we cannot know whether the RPC has ever been executed
before or not. Under such case, the server will notify the
client via returning -DER_TIMEDOUT. Means that modification
for such RPC may have been executed, but nobody guarantee
that. It is the caller's duty to check related data record.

Signed-off-by: Fan Yong <fan.yong@intel.com>
Change-Id: Ia85563d78c1170af9cd46e1ee92aadd2690132bd