### PR TITLE
DAOS-1441 object: update/punch RPC protocol changes

### DIFF
--- a/src/include/daos/dtx.h
+++ b/src/include/daos/dtx.h
@@ -39,14 +39,19 @@ struct daos_tx_id {
 };
 
 static inline void
-daos_generate_dti(struct daos_tx_id *dti)
+daos_dti_gen(struct daos_tx_id *dti, bool zero)
 {
-	uuid_generate(dti->dti_uuid);
-	dti->dti_sec = time(NULL);
+	if (zero) {
+		memset(dti, 0, sizeof(*dti));
+	} else {
+		/* It will be replaced by HLC when it is ready. */
+		uuid_generate(dti->dti_uuid);
+		dti->dti_sec = time(NULL);
+	}
 }
 
 static inline void
-daos_copy_dti(struct daos_tx_id *des, struct daos_tx_id *src)
+daos_dti_copy(struct daos_tx_id *des, struct daos_tx_id *src)
 {
 	if (src != NULL)
 		*des = *src;

--- a/src/include/daos/placement.h
+++ b/src/include/daos/placement.h
@@ -91,6 +91,7 @@ struct pl_map {
 	int			 pl_ref;
 	/** pool connections, protected by pl_rwlock */
 	int			 pl_connects;
+	unsigned int		 pl_ignore_connects:1;
 	/** type of placement map */
 	pl_map_type_t		 pl_type;
 	/** reference to pool map */
@@ -99,15 +100,14 @@ struct pl_map {
 	struct pl_map_ops       *pl_ops;
 };
 
-int pl_map_create_v2(struct pool_map *pool_map, struct pl_map **pl_mapp);
-void pl_map_destroy_v2(struct pl_map **pl_mapp);
 int pl_map_create(struct pool_map *pool_map, struct pl_map_init_attr *mia,
 		  struct pl_map **pl_mapp);
 void pl_map_destroy(struct pl_map *map);
 void pl_map_print(struct pl_map *map);
 
 struct pl_map *pl_map_find(uuid_t uuid, daos_obj_id_t oid);
-int  pl_map_update(uuid_t uuid, struct pool_map *new_map, bool connect);
+int  pl_map_update(uuid_t uuid, struct pool_map *new_map, bool connect,
+		   bool ignore_connects);
 void pl_map_disconnect(uuid_t uuid);
 void pl_map_addref(struct pl_map *map);
 void pl_map_decref(struct pl_map *map);
@@ -136,7 +136,7 @@ int pl_obj_find_reint(struct pl_map *map,
 
 typedef struct pl_obj_shard *(*pl_get_shard_t)(void *data, int idx);
 
-int pl_select_leader(daos_unit_oid_t *oid, int nr, bool for_tgt_id,
-		     pl_get_shard_t pl_get_shard, void *data, uint32_t *leader);
+int pl_select_leader(daos_obj_id_t oid, uint32_t shard_idx, int shards_nr,
+		     bool for_tgt_id, pl_get_shard_t pl_get_shard, void *data);
 
 #endif /* __DAOS_PLACEMENT_H__ */

--- a/src/include/daos_srv/pool.h
+++ b/src/include/daos_srv/pool.h
@@ -46,7 +46,6 @@ struct ds_pool {
 	uuid_t			sp_uuid;
 	ABT_rwlock		sp_lock;
 	struct pool_map	       *sp_map;
-	struct pl_map	       *sp_pl_map;
 	uint32_t		sp_map_version;	/* temporary */
 	crt_group_t	       *sp_group;
 	struct ds_iv_ns		*sp_iv_ns;

--- a/src/include/daos_types.h
+++ b/src/include/daos_types.h
@@ -127,6 +127,11 @@ daos_csum_from_offset(daos_csum_buf_t *csum, uint32_t offset_bytes)
 				  daos_csum_idx_from_off(csum, offset_bytes));
 }
 
+enum daos_anchor_flags {
+	/* The RPC will be sent to leader replica. */
+	DAOS_ANCHOR_FLAGS_TO_LEADER	= 1,
+};
+
 typedef enum {
 	DAOS_ANCHOR_TYPE_ZERO	= 0,
 	DAOS_ANCHOR_TYPE_HKEY	= 1,
@@ -139,10 +144,21 @@ typedef enum {
 typedef struct {
 	uint16_t	da_type; /** daos_anchor_type_t */
 	uint16_t	da_shard;
-	uint32_t	da_padding;
+	uint32_t	da_flags; /** see enum daos_anchor_flags */
 	uint8_t		da_buf[DAOS_ANCHOR_BUF_MAX];
 } daos_anchor_t;
 
+static inline void
+daos_anchor_set_flags(daos_anchor_t *anchor, uint32_t flags)
+{
+	anchor->da_flags |= flags;
+}
+
+static inline uint32_t
+daos_anchor_get_flags(daos_anchor_t *anchor)
+{
+	return anchor->da_flags;
+}
 
 static inline void
 daos_anchor_set_zero(daos_anchor_t *anchor)

--- a/src/object/cli_obj.c
+++ b/src/object/cli_obj.c
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2016-2018 Intel Corporation.
+ * (C) Copyright 2016-2019 Intel Corporation.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -260,6 +260,7 @@ obj_layout_create(struct dc_object *obj)
 		obj_shard = &obj->cob_shards[i];
 		obj_shard->do_shard = i;
 		obj_shard->do_target_id = layout->ol_shards[i].po_target;
+		obj_shard->do_fseq = layout->ol_shards[i].po_fseq;
 		obj_shard->do_rebuilding = layout->ol_shards[i].po_rebuilding;
 	}
 out:
@@ -279,6 +280,23 @@ obj_layout_refresh(struct dc_object *obj)
 	D_RWLOCK_UNLOCK(&obj->cob_lock);
 
 	return rc;
+}
+
+static int
+obj_get_replicas(struct dc_object *obj)
+{
+	struct daos_oclass_attr *oc_attr;
+
+	oc_attr = daos_oclass_attr_find(obj->cob_md.omd_id);
+	D_ASSERT(oc_attr != NULL);
+
+	if (oc_attr->ca_resil != DAOS_RES_REPL)
+		return 1;
+
+	if (oc_attr->u.repl.r_num == DAOS_OBJ_REPL_MAX)
+		return obj->cob_shards_nr;
+
+	return oc_attr->u.repl.r_num;
 }
 
 int
@@ -377,29 +395,48 @@ obj_grp_valid_shard_get(struct dc_object *obj, int idx,
 	return idx;
 }
 
-static int
-obj_grp_shard_get(struct dc_object *obj, uint32_t grp_idx,
-		  uint64_t hash, unsigned int map_ver, uint32_t op)
+static inline struct pl_obj_shard*
+obj_get_shard(void *data, int idx)
 {
-	int	grp_size;
-	int	idx;
+	struct dc_object	*obj = data;
 
-	grp_size = obj_get_grp_size(obj);
-	idx = hash % grp_size + grp_idx * grp_size;
-	return obj_grp_valid_shard_get(obj, idx, map_ver, op);
+	return &obj->cob_shards[idx].do_pl_shard;
+}
+
+static int
+obj_grp_leader_get(struct dc_object *obj, int idx, unsigned int map_ver)
+{
+	int	rc = -DER_STALE;
+
+	D_RWLOCK_RDLOCK(&obj->cob_lock);
+	if (obj->cob_version == map_ver)
+		rc = pl_select_leader(obj->cob_md.omd_id, idx,
+				      obj->cob_shards_nr, false,
+				      obj_get_shard, obj);
+	D_RWLOCK_UNLOCK(&obj->cob_lock);
+
+	return rc;
 }
 
 static int
 obj_dkeyhash2shard(struct dc_object *obj, uint64_t hash, unsigned int map_ver,
-		   uint32_t op)
+		   uint32_t op, bool to_leader)
 {
-	int	 grp_idx;
+	int	grp_idx;
+	int	grp_size;
+	int	idx;
 
 	grp_idx = obj_dkey2grp(obj, hash, map_ver);
 	if (grp_idx < 0)
 		return grp_idx;
 
-	return obj_grp_shard_get(obj, grp_idx, hash, map_ver, op);
+	grp_size = obj_get_grp_size(obj);
+	idx = hash % grp_size + grp_idx * grp_size;
+
+	if (to_leader)
+		return obj_grp_leader_get(obj, idx, map_ver);
+
+	return obj_grp_valid_shard_get(obj, idx, map_ver, op);
 }
 
 static int
@@ -468,8 +505,7 @@ obj_shards_2_fwtgts(struct dc_object *obj, uint32_t map_ver,
 		return 0;
 
 	/* select one leader shard and generate the fw_shard_tgts array */
-	rc = obj_grp_valid_shard_get(obj, *start_shard, map_ver,
-				     DAOS_OBJ_RPC_UPDATE);
+	rc = obj_grp_leader_get(obj, *start_shard, map_ver);
 	if (rc < 0) {
 		D_ERROR(DF_OID" no valid shard, rc %d.\n",
 			DP_OID(obj->cob_md.omd_id), rc);
@@ -847,7 +883,8 @@ dc_obj_layout_refresh(daos_handle_t oh)
 }
 
 static int
-obj_retry_cb(tse_task_t *task, struct dc_object *obj, bool io_retry)
+obj_retry_cb(tse_task_t *task, struct dc_object *obj, bool io_retry,
+	     bool retry_with_leader)
 {
 	tse_sched_t	 *sched = tse_task2sched(task);
 	tse_task_t	 *pool_task = NULL;
@@ -858,10 +895,14 @@ obj_retry_cb(tse_task_t *task, struct dc_object *obj, bool io_retry)
 	if (!obj_retry_error(result) && !io_retry)
 		return result;
 
-	/* Add pool map update task */
-	rc = obj_pool_query_task(sched, obj, &pool_task);
-	if (rc != 0)
-		D_GOTO(err, rc);
+	if (!retry_with_leader) {
+		/* Add pool map update task if NOT ask retry with leader. */
+		rc = obj_pool_query_task(sched, obj, &pool_task);
+		if (rc != 0)
+			D_GOTO(err, rc);
+	} else {
+		D_ASSERT(io_retry);
+	}
 
 	if (io_retry) {
 		/* Let's reset task result before retry */
@@ -871,18 +912,20 @@ obj_retry_cb(tse_task_t *task, struct dc_object *obj, bool io_retry)
 			D_GOTO(err, rc);
 		}
 
-		rc = dc_task_depend(task, 1, &pool_task);
-		if (rc != 0) {
-			D_ERROR("Failed to add dependency on pool "
-				 "query task (%p)\n", pool_task);
-			D_GOTO(err, rc);
+		if (pool_task != NULL) {
+			rc = dc_task_depend(task, 1, &pool_task);
+			if (rc != 0) {
+				D_ERROR("Failed to add dependency on pool "
+					 "query task (%p)\n", pool_task);
+				D_GOTO(err, rc);
+			}
 		}
 	}
 
 	D_DEBUG(DB_IO, "Retrying task=%p for err=%d, io_retry=%d\n",
 		 task, result, io_retry);
 	/* ignore returned value, error is reported by comp_cb */
-	dc_task_schedule(pool_task, io_retry);
+	dc_task_schedule(pool_task != NULL ? pool_task : task, io_retry);
 
 	return 0;
 err:
@@ -901,7 +944,9 @@ struct obj_auxi_args {
 	uint32_t			 map_ver_req;
 	uint32_t			 map_ver_reply;
 	uint32_t			 io_retry:1,
-					 shard_task_scheded:1;
+					 shard_task_scheded:1,
+					 retry_with_leader:1;
+	uint32_t			 flags;
 	int				 result;
 	d_list_t			 shard_task_head;
 	tse_task_t			*obj_task;
@@ -930,6 +975,7 @@ struct obj_list_arg {
 struct shard_update_args {
 	struct shard_auxi_args	 auxi;
 	daos_epoch_t		 epoch;
+	struct daos_tx_id	 dti;
 	daos_key_t		*dkey;
 	uint64_t		 dkey_hash;
 	unsigned int		 nr;
@@ -957,6 +1003,8 @@ shard_result_process(tse_task_t *task, void *arg)
 	} else if (obj_retry_error(ret)) {
 		D_DEBUG(DB_IO, "shard %d ret %d.\n", shard_auxi->shard, ret);
 		obj_auxi->io_retry = 1;
+		if (task->dt_result == -DER_INPROGRESS)
+			obj_auxi->retry_with_leader = 1;
 	} else {
 		/* for un-retryable failure, set the err to whole obj IO */
 		D_DEBUG(DB_IO, "shard %d ret %d.\n", shard_auxi->shard, ret);
@@ -1053,6 +1101,7 @@ obj_comp_cb(tse_task_t *task, void *data)
 		D_ASSERT(!d_list_empty(head));
 		obj_auxi->result = 0;
 		obj_auxi->io_retry = 0;
+		obj_auxi->retry_with_leader = 0;
 		tse_task_list_traverse(head, shard_result_process, obj_auxi);
 		/* for stale pm version, retry the obj IO at there will check
 		 * if need to retry shard IO.
@@ -1075,7 +1124,7 @@ obj_comp_cb(tse_task_t *task, void *data)
 		io_retry = true;
 
 	if (pm_stale || io_retry)
-		obj_retry_cb(task, obj, io_retry);
+		obj_retry_cb(task, obj, io_retry, obj_auxi->retry_with_leader);
 	else if (task->dt_result == 0)
 		task->dt_result = obj_auxi->result;
 
@@ -1236,7 +1285,8 @@ dc_obj_fetch(tse_task_t *task)
 
 	dkey_hash = obj_dkey2hash(args->dkey);
 	shard = obj_dkeyhash2shard(obj, dkey_hash, map_ver,
-				   DAOS_OPC_OBJ_UPDATE);
+				   DAOS_OPC_OBJ_UPDATE,
+				   obj_auxi->retry_with_leader);
 	if (shard < 0)
 		D_GOTO(out_task, rc = shard);
 
@@ -1310,7 +1360,8 @@ shard_update_task(tse_task_t *task)
 	rc = dc_obj_shard_update(obj_shard, args->epoch, args->dkey, args->nr,
 				 args->iods, args->sgls, &args->auxi.map_ver,
 				 args->auxi.obj_auxi->fw_shard_tgts,
-				 args->auxi.obj_auxi->fw_cnt, task);
+				 args->auxi.obj_auxi->fw_cnt, task,
+				 &args->dti, args->auxi.obj_auxi->flags);
 
 	obj_shard_close(obj_shard);
 	return rc;
@@ -1405,6 +1456,19 @@ obj_shard_task_sched(struct obj_auxi_args *obj_auxi)
 		tse_task_complete(obj_auxi->obj_task, 0);
 }
 
+static int
+shard_task_reset_target(tse_task_t *shard_task, void *arg)
+{
+	struct shard_auxi_args	*shard_arg;
+	uint32_t		 shard = *(uint32_t *)arg;
+
+	shard_arg = tse_task_buf_embedded(shard_task, sizeof(*shard_arg));
+	shard_arg->shard = shard;
+	shard_arg->target = obj_shard2tgtid(shard_arg->obj, shard_arg->shard);
+
+	return 0;
+}
+
 int
 dc_obj_update(tse_task_t *task)
 {
@@ -1473,8 +1537,26 @@ dc_obj_update(tse_task_t *task)
 
 	head = &obj_auxi->shard_task_head;
 	/* for retried obj IO, reuse the previous shard tasks and resched it */
-	if (obj_auxi->io_retry)
+	if (obj_auxi->io_retry) {
+		/* We mark the RPC as RESEND although @io_retry does not
+		 * guarantee that the RPC has ever been sent. It may cause
+		 * some overhead on server side, but no correctness issues.
+		 *
+		 * On the other hand, the client may resend the RPC to new
+		 * shard if leader switched. That is why the resend logic
+		 * is handled at object layer rather than shard layer.
+		 */
+		obj_auxi->flags = ORF_RESEND;
+
+		/* The RPC may need to be resent to new leader. */
+		if (srv_io_dispatch)
+			tse_task_list_traverse(head, shard_task_reset_target,
+					       &shard);
+
 		goto task_sched;
+	}
+
+	obj_auxi->flags = 0;
 	for (i = 0; i < shards_cnt; i++, shard++) {
 		tse_task_t			*shard_task;
 		struct shard_update_args	*shard_arg;
@@ -1487,6 +1569,7 @@ dc_obj_update(tse_task_t *task)
 		shard_arg = tse_task_buf_embedded(shard_task,
 						  sizeof(*shard_arg));
 		shard_arg->epoch		= epoch;
+		daos_dti_gen(&shard_arg->dti, !srv_io_dispatch);
 		shard_arg->dkey			= args->dkey;
 		shard_arg->dkey_hash		= dkey_hash;
 		shard_arg->nr			= args->nr;
@@ -1574,21 +1657,34 @@ dc_obj_list_internal(daos_handle_t oh, uint32_t op, daos_handle_t th,
 		D_GOTO(out_task, rc);
 
 	if (dkey == NULL) {
+		bool	to_leader = false;
+
 		if (op != DAOS_OBJ_DKEY_RPC_ENUMERATE &&
 		    op != DAOS_OBJ_RPC_ENUMERATE) {
 			D_ERROR("No dkey for opc %x\n", op);
 			D_GOTO(out_task, rc = -DER_INVAL);
 		}
 
+		if (obj_auxi->retry_with_leader)
+			to_leader = true;
+		else if (daos_anchor_get_flags(dkey_anchor) &
+			 DAOS_ANCHOR_FLAGS_TO_LEADER)
+			to_leader = true;
+
 		shard = dc_obj_anchor2shard(dkey_anchor);
-		shard = obj_grp_valid_shard_get(obj, shard, map_ver, op);
+		if (to_leader)
+			shard = obj_grp_leader_get(obj, shard, map_ver);
+		else
+			shard = obj_grp_valid_shard_get(obj, shard,
+							map_ver, op);
 		if (shard < 0)
 			D_GOTO(out_task, rc = shard);
 
 		dc_obj_shard2anchor(dkey_anchor, shard);
 	} else {
 		dkey_hash = obj_dkey2hash(dkey);
-		shard = obj_dkeyhash2shard(obj, dkey_hash, map_ver, op);
+		shard = obj_dkeyhash2shard(obj, dkey_hash, map_ver, op,
+					   obj_auxi->retry_with_leader);
 		if (shard < 0)
 			D_GOTO(out_task, rc = shard);
 	}
@@ -1685,6 +1781,7 @@ struct shard_punch_args {
 	daos_obj_punch_t	*pa_api_args;
 	uint64_t		 pa_dkey_hash;
 	daos_epoch_t		 pa_epoch;
+	struct daos_tx_id	 pa_dti;
 	uint32_t		 pa_opc;
 };
 
@@ -1719,7 +1816,8 @@ shard_punch_task(tse_task_t *task)
 				api_args->akey_nr, args->pa_coh_uuid,
 				args->pa_cont_uuid, &args->pa_auxi.map_ver,
 				args->pa_auxi.obj_auxi->fw_shard_tgts,
-				args->pa_auxi.obj_auxi->fw_cnt, task);
+				args->pa_auxi.obj_auxi->fw_cnt, task,
+				&args->pa_dti, args->pa_auxi.obj_auxi->flags);
 
 	obj_shard_close(obj_shard);
 	return rc;
@@ -1806,8 +1904,18 @@ obj_punch_internal(tse_task_t *api_task, enum obj_rpc_opc opc,
 	obj_auxi->obj_task = api_task;
 	head = &obj_auxi->shard_task_head;
 	/* for retried obj IO, reuse the previous shard tasks and resched it */
-	if (obj_auxi->io_retry)
+	if (obj_auxi->io_retry) {
+		obj_auxi->flags = ORF_RESEND;
+
+		/* The RPC may need to be resent to new leader. */
+		if (srv_io_dispatch)
+			tse_task_list_traverse(head, shard_task_reset_target,
+					       &shard_first);
+
 		goto task_sched;
+	}
+
+	obj_auxi->flags = 0;
 	for (i = 0; i < shard_nr; i++) {
 		tse_task_t		*task;
 		struct shard_punch_args	*args;
@@ -1821,6 +1929,7 @@ obj_punch_internal(tse_task_t *api_task, enum obj_rpc_opc opc,
 		shard			= shard_first + i;
 		args->pa_api_args	= api_args;
 		args->pa_epoch		= epoch;
+		daos_dti_gen(&args->pa_dti, !srv_io_dispatch);
 		args->pa_auxi.shard	= shard;
 		args->pa_auxi.target	= obj_shard2tgtid(obj, shard);
 		args->pa_auxi.map_ver	= map_ver;
@@ -1996,6 +2105,31 @@ shard_query_key_task(tse_task_t *task)
 	return rc;
 }
 
+struct shard_task_reset_query_target_args {
+	uint32_t	shard;
+	uint32_t	replicas;
+	uint32_t	version;
+	uint32_t	flags;
+};
+
+static int
+shard_task_reset_query_target(tse_task_t *shard_task, void *arg)
+{
+	struct shard_task_reset_query_target_args	*reset_arg = arg;
+	struct shard_auxi_args				*auxi_arg;
+
+	auxi_arg = tse_task_buf_embedded(shard_task, sizeof(*auxi_arg));
+	if (reset_arg->flags & DAOS_GET_DKEY)
+		auxi_arg->shard = obj_grp_leader_get(auxi_arg->obj,
+					reset_arg->shard, reset_arg->version);
+	else
+		auxi_arg->shard = reset_arg->shard;
+	auxi_arg->target = obj_shard2tgtid(auxi_arg->obj, auxi_arg->shard);
+	reset_arg->shard += reset_arg->replicas;
+
+	return 0;
+}
+
 int
 dc_obj_query_key(tse_task_t *api_task)
 {
@@ -2007,8 +2141,8 @@ dc_obj_query_key(tse_task_t *api_task)
 	daos_handle_t		coh;
 	uuid_t			coh_uuid;
 	uuid_t			cont_uuid;
-	unsigned int		shard_first;
-	unsigned int		shard_nr;
+	int			shard_first;
+	unsigned int		replicas;
 	unsigned int		map_ver;
 	uint64_t		dkey_hash;
 	daos_epoch_t            epoch;
@@ -2060,34 +2194,61 @@ dc_obj_query_key(tse_task_t *api_task)
 	D_ASSERTF(api_args->dkey != NULL, "dkey should not be NULL\n");
 	dkey_hash = obj_dkey2hash(api_args->dkey);
 	if (api_args->flags & DAOS_GET_DKEY) {
-		obj_ptr2shards(obj, &shard_first, &shard_nr);
+		replicas = obj_get_replicas(obj);
+		shard_first = 0;
 		/** set data len to 0 before retrieving dkey. */
 		api_args->dkey->iov_len = 0;
 	} else {
-		rc = obj_dkeyhash2update_grp(obj, dkey_hash, map_ver,
-					     &shard_first, &shard_nr);
-		if (rc != 0)
-			D_GOTO(out_task, rc);
+		replicas = obj->cob_shards_nr;
+		/* For the specified dkey, only need to query one replica. */
+		shard_first = obj_dkeyhash2shard(obj, dkey_hash, map_ver,
+						 DAOS_OPC_OBJ_QUERY,
+						 obj_auxi->retry_with_leader);
+		if (shard_first < 0)
+			D_GOTO(out_task, rc = shard_first);
 	}
 
 	obj_auxi->map_ver_req = map_ver;
 	obj_auxi->obj_task = api_task;
 
-	D_DEBUG(DB_IO, "Object Key Query "DF_OID" start %u cnt %u\n",
-		DP_OID(obj->cob_md.omd_id), shard_first, shard_nr);
+	D_DEBUG(DB_IO, "Object Key Query "DF_OID" start %u\n",
+		DP_OID(obj->cob_md.omd_id), shard_first);
 
 	head = &obj_auxi->shard_task_head;
 
 	/* for retried obj IO, reuse the previous shard tasks and resched it */
-	if (obj_auxi->io_retry)
-		goto task_sched;
+	if (obj_auxi->io_retry) {
+		/* The RPC may need to be resent to (new) leader. */
+		if (srv_io_dispatch) {
+			struct shard_task_reset_query_target_args	arg;
 
-	for (i = 0; i < shard_nr; i++) {
+			arg.shard = shard_first;
+			arg.replicas = replicas;
+			arg.version = map_ver;
+			arg.flags = api_args->flags;
+			tse_task_list_traverse(head,
+					shard_task_reset_query_target, &arg);
+		}
+
+		goto task_sched;
+	}
+
+	/* In each redundancy group, the QUERY RPC only needs to be sent
+	 * to one replica: i += replicas
+	 */
+	for (i = 0; i < obj->cob_shards_nr; i += replicas) {
 		tse_task_t			*task;
 		struct shard_query_key_args	*args;
 		unsigned int			 shard;
 
-		shard = shard_first + i;
+		if (api_args->flags & DAOS_GET_DKEY)
+			/* Send to leader replica directly for reducing
+			 * retry because some potential 'prepared' DTX.
+			 */
+			shard = obj_grp_leader_get(obj, i, map_ver);
+		else
+			shard = shard_first + i;
+
 		rc = tse_task_create(shard_query_key_task, sched, NULL, &task);
 		if (rc != 0)
 			D_GOTO(out_task, rc);

--- a/src/object/cli_shard.c
+++ b/src/object/cli_shard.c
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2016-2018 Intel Corporation.
+ * (C) Copyright 2016-2019 Intel Corporation.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -294,7 +294,7 @@ obj_shard_rw_bulk_prep(crt_rpc_t *rpc, unsigned int nr, daos_sg_list_t *sgls,
 				D_ERROR("crt_bulk_bind failed, rc: %d.\n", rc);
 				D_GOTO(out, rc);
 			}
-			orw->orw_flags	= ORW_FLAG_BULK_BIND;
+			orw->orw_flags |= ORF_BULK_BIND;
 		}
 	}
 	orw->orw_bulks.ca_count = nr;
@@ -323,7 +323,7 @@ obj_shard_rw(struct dc_obj_shard *shard, enum obj_rpc_opc opc,
 	     daos_epoch_t epoch, daos_key_t *dkey, unsigned int nr,
 	     daos_iod_t *iods, daos_sg_list_t *sgls, unsigned int *map_ver,
 	     struct daos_obj_shard_tgt *fw_shard_tgts, uint32_t fw_cnt,
-	     tse_task_t *task)
+	     tse_task_t *task, struct daos_tx_id *dti, uint32_t flags)
 {
 	struct dc_pool	       *pool;
 	crt_rpc_t	       *req = NULL;
@@ -380,6 +380,10 @@ obj_shard_rw(struct dc_obj_shard *shard, enum obj_rpc_opc opc,
 	orw->orw_oid = shard->do_id;
 	uuid_copy(orw->orw_co_hdl, cont_hdl_uuid);
 	uuid_copy(orw->orw_co_uuid, cont_uuid);
+	daos_dti_copy(&orw->orw_dti, dti);
+	orw->orw_flags = flags;
+	orw->orw_dti_cos.ca_count = 0;
+	orw->orw_dti_cos.ca_arrays = NULL;
 
 	orw->orw_epoch = epoch;
 	orw->orw_nr = nr;
@@ -406,9 +410,10 @@ obj_shard_rw(struct dc_obj_shard *shard, enum obj_rpc_opc opc,
 	data_size = sgls_size;
 
 	D_DEBUG(DB_TRACE, "opc %d "DF_UOID" %d %s rank %d tag %d eph "
-		DF_U64" data_size "DF_U64"\n", opc, DP_UOID(shard->do_id),
-		(int)dkey->iov_len, (char *)dkey->iov_buf, tgt_ep.ep_rank,
-		tgt_ep.ep_tag, epoch, data_size);
+		DF_U64" data_size "DF_U64", DTI = "DF_DTI"\n",
+		opc, DP_UOID(shard->do_id), (int)dkey->iov_len,
+		(char *)dkey->iov_buf, tgt_ep.ep_rank,
+		tgt_ep.ep_tag, epoch, data_size, DP_DTI(&orw->orw_dti));
 
 	do_bulk = data_size >= OBJ_BULK_LIMIT;
 	if (do_bulk) {
@@ -500,7 +505,7 @@ dc_obj_shard_punch(struct dc_obj_shard *shard, uint32_t opc, daos_epoch_t epoch,
 		   const uuid_t coh_uuid, const uuid_t cont_uuid,
 		   unsigned int *map_ver,
 		   struct daos_obj_shard_tgt *fw_shard_tgts, uint32_t fw_cnt,
-		   tse_task_t *task)
+		   tse_task_t *task, struct daos_tx_id *dti, uint32_t flags)
 {
 	struct dc_pool			*pool;
 	struct obj_punch_in		*opi;
@@ -561,6 +566,10 @@ dc_obj_shard_punch(struct dc_obj_shard *shard, uint32_t opc, daos_epoch_t epoch,
 	}
 	uuid_copy(opi->opi_co_hdl, coh_uuid);
 	uuid_copy(opi->opi_co_uuid, cont_uuid);
+	daos_dti_copy(&opi->opi_dti, dti);
+	opi->opi_flags = flags;
+	opi->opi_dti_cos.ca_count = 0;
+	opi->opi_dti_cos.ca_arrays = NULL;
 
 	rc = daos_rpc_send(req, task);
 	if (rc != 0) {
@@ -581,11 +590,11 @@ dc_obj_shard_update(struct dc_obj_shard *shard, daos_epoch_t epoch,
 		    daos_key_t *dkey, unsigned int nr, daos_iod_t *iods,
 		    daos_sg_list_t *sgls, unsigned int *map_ver,
 		    struct daos_obj_shard_tgt *fw_shard_tgts, uint32_t fw_cnt,
-		    tse_task_t *task)
+		    tse_task_t *task, struct daos_tx_id *dti, uint32_t flags)
 {
 	return obj_shard_rw(shard, DAOS_OBJ_RPC_UPDATE, epoch, dkey,
 			    nr, iods, sgls, map_ver, fw_shard_tgts, fw_cnt,
-			    task);
+			    task, dti, flags);
 }
 
 int
@@ -595,7 +604,7 @@ dc_obj_shard_fetch(struct dc_obj_shard *shard, daos_epoch_t epoch,
 		   unsigned int *map_ver, tse_task_t *task)
 {
 	return obj_shard_rw(shard, DAOS_OBJ_RPC_FETCH, epoch, dkey,
-			    nr, iods, sgls, map_ver, NULL, 0, task);
+			    nr, iods, sgls, map_ver, NULL, 0, task, NULL, 0);
 }
 
 struct obj_enum_args {

--- a/src/object/obj_internal.h
+++ b/src/object/obj_internal.h
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2016-2018 Intel Corporation.
+ * (C) Copyright 2016-2019 Intel Corporation.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -35,6 +35,7 @@
 #include <daos/placement.h>
 #include <daos/btree.h>
 #include <daos/btree_class.h>
+#include <daos/dtx.h>
 #include <daos_srv/daos_server.h>
 #include <daos_types.h>
 
@@ -67,14 +68,17 @@ struct dc_obj_shard {
 	daos_handle_t		do_co_hdl;
 	/** list to the container */
 	d_list_t		do_co_list;
-	uint32_t		do_shard;	/* shard index */
-	uint32_t		do_target_id;	/* target id (unique in pool) */
 	uint32_t		do_target_idx;	/* target VOS index in node */
 	uint32_t		do_target_rank;
-	uint32_t		do_rebuilding:1;
+	struct pl_obj_shard	do_pl_shard;
 	/** point back to object */
 	struct dc_object	*do_obj;
 };
+
+#define do_shard	do_pl_shard.po_shard
+#define do_target_id	do_pl_shard.po_target
+#define do_fseq		do_pl_shard.po_fseq
+#define do_rebuilding	do_pl_shard.po_rebuilding
 
 /** Client stack object */
 struct dc_object {
@@ -122,7 +126,9 @@ int dc_obj_shard_update(struct dc_obj_shard *shard, daos_epoch_t epoch,
 			daos_key_t *dkey, unsigned int nr,
 			daos_iod_t *iods, daos_sg_list_t *sgls,
 			unsigned int *map_ver, struct daos_obj_shard_tgt *tgts,
-			uint32_t fw_cnt, tse_task_t *task);
+			uint32_t fw_cnt, tse_task_t *task,
+			struct daos_tx_id *dti, uint32_t flags);
+
 int dc_obj_shard_fetch(struct dc_obj_shard *shard, daos_epoch_t epoch,
 		       daos_key_t *dkey, unsigned int nr,
 		       daos_iod_t *iods, daos_sg_list_t *sgls,
@@ -144,7 +150,8 @@ int dc_obj_shard_punch(struct dc_obj_shard *shard, uint32_t opc,
 		       daos_key_t *akeys, unsigned int akey_nr,
 		       const uuid_t coh_uuid, const uuid_t cont_uuid,
 		       unsigned int *map_ver, struct daos_obj_shard_tgt *tgts,
-		       uint32_t fw_cnt, tse_task_t *task);
+		       uint32_t fw_cnt, tse_task_t *task,
+		       struct daos_tx_id *dti, uint32_t flags);
 
 int dc_obj_shard_query_key(struct dc_obj_shard *shard, daos_epoch_t epoch,
 			   uint32_t flags, daos_key_t *dkey, daos_key_t *akey,
@@ -156,7 +163,7 @@ static inline bool
 obj_retry_error(int err)
 {
 	return err == -DER_TIMEDOUT || err == -DER_STALE ||
-	       daos_crt_network_error(err);
+	       err == -DER_INPROGRESS || daos_crt_network_error(err);
 }
 
 void obj_shard_decref(struct dc_obj_shard *shard);

--- a/src/object/obj_rpc.c
+++ b/src/object/obj_rpc.c
@@ -31,6 +31,22 @@
 #include "obj_rpc.h"
 
 static int
+crt_proc_struct_daos_tx_id(crt_proc_t proc, struct daos_tx_id *dti)
+{
+	int rc;
+
+	rc = crt_proc_uuid_t(proc, &dti->dti_uuid);
+	if (rc != 0)
+		return -DER_HG;
+
+	rc = crt_proc_uint64_t(proc, &dti->dti_sec);
+	if (rc != 0)
+		return -DER_HG;
+
+	return 0;
+}
+
+static int
 crt_proc_daos_key_desc_t(crt_proc_t proc, daos_key_desc_t *key)
 {
 	int rc;
@@ -304,7 +320,7 @@ crt_proc_daos_anchor_t(crt_proc_t proc, daos_anchor_t *anchor)
 	if (crt_proc_uint16_t(proc, &anchor->da_shard) != 0)
 		return -DER_HG;
 
-	if (crt_proc_uint32_t(proc, &anchor->da_padding) != 0)
+	if (crt_proc_uint32_t(proc, &anchor->da_flags) != 0)
 		return -DER_HG;
 
 	if (crt_proc_raw(proc, anchor->da_buf, sizeof(anchor->da_buf)) != 0)

--- a/src/object/srv_obj.c
+++ b/src/object/srv_obj.c
@@ -574,7 +574,7 @@ ds_obj_rw_echo_handler(crt_rpc_t *rpc)
 		bulk_op = CRT_BULK_GET;
 	}
 
-	bulk_bind = orw->orw_flags & ORW_FLAG_BULK_BIND;
+	bulk_bind = orw->orw_flags & ORF_BULK_BIND;
 	rc = ds_bulk_transfer(rpc, bulk_op, bulk_bind, orw->orw_bulks.ca_arrays,
 			      DAOS_HDL_INVAL, &p_sgl, orw->orw_nr);
 
@@ -612,7 +612,7 @@ obj_update_prefw(crt_rpc_t *req, uint32_t shard, void *arg)
 	uuid_copy(orw->orw_co_uuid, orw_parent->orw_co_uuid);
 	orw->orw_shard_tgts.ca_count	= 0;
 	orw->orw_shard_tgts.ca_arrays	= NULL;
-	orw->orw_flags			= ORW_FLAG_BULK_BIND;
+	orw->orw_flags			= ORF_BULK_BIND;
 
 	return 0;
 }
@@ -693,7 +693,7 @@ ds_obj_rw_local_hdlr(crt_rpc_t *rpc, uint32_t tag, struct ds_cont_hdl *cont_hdl,
 	}
 
 	if (rma) {
-		bulk_bind = orw->orw_flags & ORW_FLAG_BULK_BIND;
+		bulk_bind = orw->orw_flags & ORF_BULK_BIND;
 		rc = ds_bulk_transfer(rpc, bulk_op, bulk_bind,
 			orw->orw_bulks.ca_arrays, *ioh, NULL, orw->orw_nr);
 	} else if (orw->orw_sgls.ca_arrays != NULL) {

--- a/src/placement/tests/place_obj.c
+++ b/src/placement/tests/place_obj.c
@@ -146,7 +146,7 @@ plt_spare_tgts_get(uuid_t pl_uuid, daos_obj_id_t oid, uint32_t *failed_tgts,
 	for (i = 0; i < failed_cnt; i++)
 		plt_fail_tgt(failed_tgts[i]);
 
-	rc = pl_map_update(pl_uuid, po_map, false);
+	rc = pl_map_update(pl_uuid, po_map, false, false);
 	D_ASSERT(rc == 0);
 	pl_map = pl_map_find(pl_uuid, oid);
 	D_ASSERT(pl_map != NULL);

--- a/src/pool/cli.c
+++ b/src/pool/cli.c
@@ -222,7 +222,7 @@ pool_map_update(struct dc_pool *pool, struct pool_map *map,
 
 	D_ASSERT(map != NULL);
 	if (pool->dp_map == NULL) {
-		rc = pl_map_update(pool->dp_pool, map, connect);
+		rc = pl_map_update(pool->dp_pool, map, connect, false);
 		if (rc != 0)
 			D_GOTO(out, rc);
 
@@ -243,7 +243,7 @@ pool_map_update(struct dc_pool *pool, struct pool_map *map,
 		pool->dp_map == NULL ?
 		0 : pool_map_get_version(pool->dp_map), map_version);
 
-	rc = pl_map_update(pool->dp_pool, map, connect);
+	rc = pl_map_update(pool->dp_pool, map, connect, false);
 	if (rc != 0) {
 		D_ERROR("Failed to refresh placement map: %d\n", rc);
 		D_GOTO(out, rc);
@@ -972,7 +972,7 @@ dc_pool_g2l(struct dc_pool_glob *pool_glob, size_t len, daos_handle_t *poh)
 		D_GOTO(out, rc);
 	}
 
-	rc = pl_map_update(pool->dp_pool, pool->dp_map, true);
+	rc = pl_map_update(pool->dp_pool, pool->dp_map, true, false);
 	if (rc != 0)
 		D_GOTO(out, rc);
 

--- a/src/rdb/rdb_rpc.c
+++ b/src/rdb/rdb_rpc.c
@@ -231,7 +231,7 @@ crt_proc_daos_anchor_t(crt_proc_t proc, daos_anchor_t *p)
 	rc = crt_proc_uint16_t(proc, &p->da_shard);
 	if (rc != 0)
 		return -DER_HG;
-	rc = crt_proc_uint32_t(proc, &p->da_padding);
+	rc = crt_proc_uint32_t(proc, &p->da_flags);
 	if (rc != 0)
 		return -DER_HG;
 	rc = crt_proc_memcpy(proc, &p->da_buf, sizeof(p->da_buf));


### PR DESCRIPTION
The client will generate the DTX identifier and send it to
the leader replica via the update/punch RPC. On the leader
side, it will dispatch the update/punch RPC to other replicas
with the DTXs array that need to be committed because of share
or conflict.

For the client, it uses the same algorithm to elect leader.
Because the difference between client side and server side
data structure, to avoid format conversion, they implement
each own function for the leader election. They may share
the same one in the future.

For modification RPC, the client sends it to leader only.
For other read only RPC, it can be sent to any replica as
without the DTX case. But if the non-leader replica does
not sure about related target data record visibility, it
will reply "-DER_INPROGRESS" to the client, and then the
client needs to retry the RPC with leader. Related logic
will be implemented in subsequent patches.

Signed-off-by: Fan Yong <fan.yong@intel.com>
Change-Id: I7c0ad29e79c62a65c4db7b1d38911db6cd168c0c