### PR TITLE
DAOS-1441 dtx: resync non-committed DTX status

### DIFF
--- a/src/dtx/SConscript
+++ b/src/dtx/SConscript
@@ -10,7 +10,7 @@ def scons():
 
     # dtx
     dtx = daos_build.library(denv, 'dtx',
-                             ['dtx_srv.c', 'dtx_rpc.c'])
+                             ['dtx_srv.c', 'dtx_rpc.c', 'dtx_resync.c'])
     denv.Install('$PREFIX/lib/daos_srv', dtx)
 
 if __name__ == "SCons.Script":

--- a/src/dtx/dtx_resync.c
+++ b/src/dtx/dtx_resync.c
@@ -1,0 +1,387 @@
+/**
+ * (C) Copyright 2019 Intel Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * GOVERNMENT LICENSE RIGHTS-OPEN SOURCE SOFTWARE
+ * The Government's rights to use, modify, reproduce, release, perform, display,
+ * or disclose this software are subject to the terms of the Apache License as
+ * provided in Contract No. B609815.
+ * Any reproduction of computer software, computer software documentation, or
+ * portions thereof marked with this legend must also reproduce the markings.
+ */
+/**
+ * dtx: resync DTX status
+ */
+#define D_LOGFAC	DD_FAC(dtx)
+
+#include <daos/placement.h>
+#include <daos/pool_map.h>
+#include <daos_srv/vos.h>
+#include <daos_srv/pool.h>
+#include <daos_srv/dtx_srv.h>
+#include <daos_srv/daos_server.h>
+#include <daos_srv/container.h>
+#include <abt.h>
+#include "dtx_internal.h"
+
+struct dtx_resync_entry {
+	d_list_t		dre_link;
+	struct daos_tx_entry	dre_dte;
+	uint64_t		dre_hash;
+	uint32_t		dre_intent;
+};
+
+#define dre_oid		dre_dte.dte_oid
+#define dre_xid		dre_dte.dte_xid
+
+struct dtx_resync_head {
+	d_list_t		drh_list;
+	int			drh_count;
+};
+
+struct dtx_resync_args {
+	struct ds_cont		*cont;
+	uuid_t			 po_uuid;
+	struct dtx_resync_head	 tables;
+	uint32_t		 version;
+};
+
+static inline void
+dtx_dre_release(struct dtx_resync_head *drh, struct dtx_resync_entry *dre)
+{
+	drh->drh_count--;
+	d_list_del(&dre->dre_link);
+	D_FREE_PTR(dre);
+}
+
+static int
+dtx_resync_commit(uuid_t po_uuid, struct ds_cont *cont,
+		  struct dtx_resync_head *drh, int count, uint32_t version,
+		  bool block)
+{
+	struct dtx_resync_entry		*dre;
+	int				 rc = 0;
+	int				 i = 0;
+
+	D_ASSERT(drh->drh_count >= count);
+
+	/* If we are in block mode, then we need to commit the DTXs as fast as
+	 * possible, so just add them into the CoS cache, then the general DTX
+	 * commit mechanism will commit them some time later.
+	 */
+	if (block) {
+		int	err;
+
+		do {
+			dre = d_list_entry(drh->drh_list.next,
+					   struct dtx_resync_entry, dre_link);
+			if (dre->dre_hash == 0)
+				/* For punch object or the case that the dkey
+				 * hash is just zero, commit them immediately
+				 * without caching.
+				 */
+				err = dtx_commit(po_uuid, cont->sc_uuid,
+						 &dre->dre_dte, 1, version);
+			else
+				err = vos_dtx_add_cos(cont->sc_hdl,
+					&dre->dre_oid, &dre->dre_xid,
+					dre->dre_hash, dre->dre_intent ==
+					DAOS_INTENT_PUNCH ? true : false);
+			if (err != 0) {
+				D_ERROR("Failed to %s the DTX " DF_UOID"/"DF_DTI
+					": rc = %d\n",
+					dre->dre_hash == 0 ? "commit" : "cache",
+					DP_UOID(dre->dre_oid),
+					DP_DTI(&dre->dre_xid), err);
+				rc = err;
+			}
+			dtx_dre_release(drh, dre);
+		} while (++i < count);
+	} else {
+		struct daos_tx_entry	*dte = NULL;
+
+		D_ALLOC_ARRAY(dte, count);
+		if (dte == NULL)
+			return -DER_NOMEM;
+
+		do {
+			dre = d_list_entry(drh->drh_list.next,
+					   struct dtx_resync_entry, dre_link);
+			dte[i].dte_xid = dre->dre_xid;
+			dte[i].dte_oid = dre->dre_oid;
+			dtx_dre_release(drh, dre);
+		} while (++i < count);
+
+		rc = dtx_commit(po_uuid, cont->sc_uuid, dte, count, version);
+		if (rc < 0)
+			D_ERROR("Failed to commit the DTX: rc = %d\n", rc);
+		D_FREE(dte);
+	}
+
+	return rc > 0 ? 0 : rc;
+}
+
+static int
+dtx_status_handle(struct dtx_resync_args *dra, bool block)
+{
+	struct ds_cont			*cont = dra->cont;
+	struct pl_obj_layout		*layout = NULL;
+	struct dtx_resync_head		*drh = &dra->tables;
+	struct dtx_resync_entry		*dre;
+	struct dtx_resync_entry		*next;
+	int				 count = 0;
+	int				 err = 0;
+	int				 rc;
+
+	if (drh->drh_count == 0)
+		return 0;
+
+	d_list_for_each_entry_safe(dre, next, &drh->drh_list, dre_link) {
+		int	local_rc;
+
+		if (layout != NULL) {
+			pl_obj_layout_free(layout);
+			layout = NULL;
+		}
+
+		rc = ds_pool_check_leader(dra->po_uuid, &dre->dre_oid,
+					  dra->version, &layout);
+		if (rc <= 0) {
+			if (rc < 0)
+				D_WARN("Not sure about the leader for the DTX "
+				       DF_UOID"/"DF_DTI" (ver = %u): rc = %d, "
+				       "skip it.\n",
+				       DP_UOID(dre->dre_oid),
+				       DP_DTI(&dre->dre_xid), dra->version, rc);
+			else
+				D_DEBUG(DB_TRACE, "Not the leader for the DTX "
+					DF_UOID"/"DF_DTI" (ver = %u) skip it\n",
+					DP_UOID(dre->dre_oid),
+					DP_DTI(&dre->dre_xid), dra->version);
+			dtx_dre_release(drh, dre);
+			continue;
+		}
+
+		rc = dtx_check(dra->po_uuid, cont->sc_uuid,
+			       &dre->dre_dte, layout);
+		if (rc != DTX_ST_COMMITTED && rc != DTX_ST_PREPARED &&
+		    rc != DTX_ST_INIT) {
+			/* We are not sure about whether the DTX can be
+			 * committed or not, then we have to skip it.
+			 */
+			D_WARN("Not sure about whether the DTX "DF_UOID
+			       "/"DF_DTI" can be committed or not: %d (1)\n",
+			       DP_UOID(dre->dre_oid),
+			       DP_DTI(&dre->dre_xid), rc);
+			dtx_dre_release(drh, dre);
+			continue;
+		}
+
+		/* There is CPU yield during DTX operation (check/commit/abort)
+		 * remotely. Then the other DTXs may become committable by race.
+		 * So re-check the remaining DTXs status.
+		 */
+		local_rc = vos_dtx_lookup_cos(cont->sc_hdl, &dre->dre_oid,
+			&dre->dre_xid, dre->dre_hash,
+			dre->dre_intent == DAOS_INTENT_PUNCH ? true : false);
+		if (local_rc == 0) {
+			/* The DTX is in CoS cache (committable), do nothing. */
+			dtx_dre_release(drh, dre);
+			continue;
+		}
+
+		/* The DTX is not in CoS cache, but it has been committed on
+		 * some remote replica(s), then let's commit the it globally.
+		 */
+		if (rc == DTX_ST_COMMITTED)
+			goto commit;
+
+		if (local_rc != -DER_NONEXIST) {
+			D_WARN("Not sure about whether the DTX "DF_UOID
+			       "/"DF_DTI" can be committed or not: %d (2)\n",
+			       DP_UOID(dre->dre_oid),
+			       DP_DTI(&dre->dre_xid), rc);
+			dtx_dre_release(drh, dre);
+			continue;
+		}
+
+		/* It is possible that other ULT has committed the DTX during
+		 * we handle other DTXs, then such DTX will not be in the CoS
+		 * cache. Let's re-check the on-disk DTX table.
+		 *
+		 * Set the @dkey_hash parameter as zero, then it will skip CoS
+		 * cache since we just did that in above check.
+		 */
+		local_rc = vos_dtx_check_committable(cont->sc_hdl,
+					&dre->dre_oid, &dre->dre_xid, 0, false);
+		switch (local_rc) {
+		case DTX_ST_COMMITTED:
+			/* The DTX has been committed by other, do nothing. */
+			dtx_dre_release(drh, dre);
+			continue;
+		case DTX_ST_PREPARED:
+			/* Both local and remote replicas are 'prepared', then
+			 * it is committable.
+			 */
+			if (rc == DTX_ST_PREPARED)
+				goto commit;
+
+			/* Fall through. */
+		case DTX_ST_INIT:
+			/* If we abort multiple non-ready DTXs together, then
+			 * there is race that one DTX may become committable
+			 * when we abort some other DTX(s). To avoid complex
+			 * rollback logic, let's abort the DTXs one by one.
+			 */
+			rc = dtx_abort(dra->po_uuid, cont->sc_uuid,
+				       &dre->dre_dte, 1, dra->version);
+			dtx_dre_release(drh, dre);
+			if (rc < 0)
+				err = rc;
+			continue;
+		default:
+			D_WARN("Not sure about whether the DTX "DF_UOID
+			       "/"DF_DTI" can be committed or not: %d (3)\n",
+			       DP_UOID(dre->dre_oid),
+			       DP_DTI(&dre->dre_xid), rc);
+			dtx_dre_release(drh, dre);
+			continue;
+		}
+
+commit:
+		if (++count >= DTX_THRESHOLD_COUNT) {
+			rc = dtx_resync_commit(dra->po_uuid, cont,
+					       drh, count, dra->version, block);
+			if (rc < 0)
+				err = rc;
+			count = 0;
+		}
+	}
+
+	if (count > 0) {
+		rc = dtx_resync_commit(dra->po_uuid, cont, drh, count,
+				       dra->version, block);
+		if (rc < 0)
+			err = rc;
+	}
+
+	if (layout != NULL)
+		pl_obj_layout_free(layout);
+
+	return err;
+}
+
+static int
+dtx_iter_cb(uuid_t co_uuid, vos_iter_entry_t *ent, void *args)
+{
+	struct dtx_resync_args		*dra = args;
+	struct dtx_resync_entry		*dre;
+
+	/* Ignore new DTX after the rebuild/recovery start.
+	 *
+	 * XXX: The time(NULL) based checking may be untrusted because of
+	 *	potential clock drift. We may consider to replace it with
+	 *	hybrid-clock based mechanism in future when it is ready.
+	 */
+	if (ent->ie_dtx_sec > dra->cont->sc_dtx_resync_time)
+		return 0;
+
+	/* We commit the DTXs periodically, there will be not too many DTXs
+	 * to be checked when resync. So we can load all those uncommitted
+	 * DTXs in RAM firstly, then check the state one by one. That avoid
+	 * the race trouble between iteration of active-DTX tree and commit
+	 * (or abort) the DTXs (that will change the active-DTX tree).
+	 */
+
+	D_ALLOC_PTR(dre);
+	if (dre == NULL)
+		return -DER_NOMEM;
+
+	dre->dre_xid = ent->ie_xid;
+	dre->dre_oid = ent->ie_oid;
+	dre->dre_intent = ent->ie_dtx_intent;
+	dre->dre_hash = ent->ie_dtx_hash;
+	d_list_add_tail(&dre->dre_link, &dra->tables.drh_list);
+	dra->tables.drh_count++;
+
+	return 0;
+}
+
+int
+dtx_resync(daos_handle_t po_hdl, uuid_t po_uuid, uuid_t co_uuid, uint32_t ver,
+	   bool block)
+{
+	struct ds_cont			*cont = NULL;
+	struct dtx_resync_args		 dra = { 0 };
+	struct dtx_resync_entry		*dre;
+	struct dtx_resync_entry		*next;
+	int				 rc = 0;
+	int				 rc1 = 0;
+	bool				 shared = false;
+
+	rc = ds_cont_lookup(po_uuid, co_uuid, &cont);
+	if (rc != 0) {
+		D_ERROR("Failed to open container for resync DTX "
+			DF_UUID"/"DF_UUID": rc = %d\n",
+			DP_UUID(po_uuid), DP_UUID(co_uuid), rc);
+		return rc;
+	}
+
+	while (cont->sc_dtx_resyncing) {
+		if (!block)
+			goto out;
+
+		shared = true;
+		/* Someone is resyncing the DTXs, let's wait and retry. */
+		ABT_thread_yield();
+	}
+
+	/* Some others just did the DTX resync, needs not to repeat. */
+	if (shared)
+		goto out;
+
+	cont->sc_dtx_resyncing = 1;
+	cont->sc_dtx_resync_time = time(NULL);
+
+	dra.cont = cont;
+	uuid_copy(dra.po_uuid, po_uuid);
+	dra.version = ver;
+	D_INIT_LIST_HEAD(&dra.tables.drh_list);
+	dra.tables.drh_count = 0;
+
+	D_DEBUG(DB_TRACE, "resync DTX scan "DF_UUID"/"DF_UUID" start.\n",
+		DP_UUID(po_uuid), DP_UUID(co_uuid));
+
+	rc = ds_cont_iter(po_hdl, co_uuid, dtx_iter_cb, &dra, VOS_ITER_DTX);
+
+	/* Handle the DTXs that have been scanned even if some failure happend
+	 * in above ds_cont_iter() step.
+	 */
+	rc1 = dtx_status_handle(&dra, block);
+
+	d_list_for_each_entry_safe(dre, next, &dra.tables.drh_list, dre_link)
+		dtx_dre_release(&dra.tables, dre);
+
+	if (rc >= 0)
+		rc = rc1;
+
+	D_DEBUG(DB_TRACE, "resync DTX scan "DF_UUID"/"DF_UUID" stop: rc = %d\n",
+		DP_UUID(po_uuid), DP_UUID(co_uuid), rc);
+
+	cont->sc_dtx_resyncing = 0;
+
+out:
+	ds_cont_put(cont);
+	return rc;
+}

--- a/src/include/daos/placement.h
+++ b/src/include/daos/placement.h
@@ -91,7 +91,6 @@ struct pl_map {
 	int			 pl_ref;
 	/** pool connections, protected by pl_rwlock */
 	int			 pl_connects;
-	unsigned int		 pl_ignore_connects:1;
 	/** type of placement map */
 	pl_map_type_t		 pl_type;
 	/** reference to pool map */
@@ -106,8 +105,7 @@ void pl_map_destroy(struct pl_map *map);
 void pl_map_print(struct pl_map *map);
 
 struct pl_map *pl_map_find(uuid_t uuid, daos_obj_id_t oid);
-int  pl_map_update(uuid_t uuid, struct pool_map *new_map, bool connect,
-		   bool ignore_connects);
+int  pl_map_update(uuid_t uuid, struct pool_map *new_map, bool connect);
 void pl_map_disconnect(uuid_t uuid);
 void pl_map_addref(struct pl_map *map);
 void pl_map_decref(struct pl_map *map);
@@ -126,7 +124,8 @@ int pl_obj_find_rebuild(struct pl_map *map,
 			struct daos_obj_md *md,
 			struct daos_obj_shard_md *shard_md,
 			uint32_t rebuild_ver, uint32_t *tgt_rank,
-			uint32_t *shard_id, unsigned int array_size);
+			uint32_t *shard_id, unsigned int array_size,
+			int myrank);
 
 int pl_obj_find_reint(struct pl_map *map,
 		      struct daos_obj_md *md,
@@ -135,6 +134,14 @@ int pl_obj_find_reint(struct pl_map *map,
 		      uint32_t *tgt_reint);
 
 typedef struct pl_obj_shard *(*pl_get_shard_t)(void *data, int idx);
+
+static inline struct pl_obj_shard *
+pl_obj_get_shard(void *data, int idx)
+{
+	struct pl_obj_layout	*layout = data;
+
+	return &layout->ol_shards[idx];
+}
 
 int pl_select_leader(daos_obj_id_t oid, uint32_t shard_idx, int shards_nr,
 		     bool for_tgt_id, pl_get_shard_t pl_get_shard, void *data);

--- a/src/include/daos_srv/container.h
+++ b/src/include/daos_srv/container.h
@@ -33,6 +33,7 @@
 #include <daos_types.h>
 #include <daos_srv/pool.h>
 #include <daos_srv/rsvc.h>
+#include <daos_srv/vos_types.h>
 
 void ds_cont_wrlock_metadata(struct cont_svc *svc);
 void ds_cont_rdlock_metadata(struct cont_svc *svc);
@@ -55,6 +56,9 @@ struct ds_cont {
 	struct daos_llink	sc_list;
 	daos_handle_t		sc_hdl;
 	uuid_t			sc_uuid;
+	/* The time for the latest DTX resync operation. */
+	uint64_t		sc_dtx_resync_time;
+	uint32_t		sc_dtx_resyncing:1;
 };
 
 /*
@@ -90,10 +94,7 @@ ds_cont_lookup(uuid_t pool_uuid, uuid_t cont_uuid, struct ds_cont **ds_cont);
 
 void ds_cont_put(struct ds_cont *cont);
 
-typedef int (*cont_iter_cb_t)(uuid_t co_uuid, daos_unit_oid_t,
-			      daos_epoch_t eph, void *arg);
-
 int
-ds_cont_obj_iter(daos_handle_t ph, uuid_t co_uuid, cont_iter_cb_t callback,
-		 void *arg);
+ds_cont_iter(daos_handle_t ph, uuid_t co_uuid, ds_iter_cb_t callback,
+	     void *arg, uint32_t type);
 #endif /* ___DAOS_SRV_CONTAINER_H_ */

--- a/src/include/daos_srv/dtx_srv.h
+++ b/src/include/daos_srv/dtx_srv.h
@@ -112,5 +112,7 @@ int dtx_commit(uuid_t po_uuid, uuid_t co_uuid,
 	       struct daos_tx_entry *dtes, int count, uint32_t version);
 int dtx_abort(uuid_t po_uuid, uuid_t co_uuid,
 	      struct daos_tx_entry *dtes, int count, uint32_t version);
+int dtx_resync(daos_handle_t po_hdl, uuid_t po_uuid, uuid_t co_uuid,
+	       uint32_t ver, bool block);
 
 #endif /* __DAOS_DTX_SRV_H__ */

--- a/src/include/daos_srv/pool.h
+++ b/src/include/daos_srv/pool.h
@@ -35,6 +35,7 @@
 #include <daos/pool_map.h>
 #include <daos/rpc.h>
 #include <daos/placement.h>
+#include <daos_srv/vos_types.h>
 
 /*
  * Pool object
@@ -109,6 +110,7 @@ struct pool_prop_ugm {
 };
 
 struct ds_pool_child *ds_pool_child_lookup(const uuid_t uuid);
+struct ds_pool_child *ds_pool_child_get(struct ds_pool_child *child);
 void ds_pool_child_put(struct ds_pool_child *child);
 
 int ds_pool_bcast_create(crt_context_t ctx, struct ds_pool *pool,
@@ -154,9 +156,10 @@ int ds_pool_hdl_list(const uuid_t pool_uuid, uuid_t buf, size_t *size);
  */
 int ds_pool_hdl_evict(const uuid_t pool_uuid, const uuid_t handle_uuid);
 
-typedef int (*obj_iter_cb_t)(uuid_t cont_uuid, daos_unit_oid_t oid,
-			     daos_epoch_t eph, void *arg);
-int ds_pool_obj_iter(uuid_t pool_uuid, obj_iter_cb_t callback, void *arg);
+typedef int (*ds_iter_cb_t)(uuid_t cont_uuid, vos_iter_entry_t *ent,
+			     void *arg);
+int ds_pool_iter(uuid_t pool_uuid, ds_iter_cb_t callback, void *arg,
+		 uint32_t version, uint32_t intent);
 
 struct cont_svc;
 struct rsvc_hint;

--- a/src/include/daos_srv/vos.h
+++ b/src/include/daos_srv/vos.h
@@ -79,6 +79,22 @@ int
 vos_dtx_end(struct daos_tx_handle *dth, int result, bool leader);
 
 /**
+ * Add the given DTX to the Commit-on-Share (CoS) cache (in DRAM).
+ *
+ * \param coh	[IN]	Container open handle.
+ * \param oid	[IN]	The target object (shard) ID.
+ * \param dti	[IN]	The DTX identifier.
+ * \param dkey	[IN]	The hashed dkey.
+ * \param punch	[IN]	For punch DTX or not.
+ *
+ * \return		Zero on success and need not additional actions.
+ * \return		Negative value if error.
+ */
+int
+vos_dtx_add_cos(daos_handle_t coh, daos_unit_oid_t *oid,
+		struct daos_tx_id *dti, uint64_t dkey, bool punch);
+
+/**
  * Search the specified DTX is in the CoS cache or not.
  *
  * \param coh	[IN]	Container open handle.

--- a/src/include/daos_srv/vos_types.h
+++ b/src/include/daos_srv/vos_types.h
@@ -26,6 +26,7 @@
 
 #include <daos_types.h>
 #include <daos_srv/bio.h>
+#include <daos_srv/dtx_srv.h>
 
 enum vos_oi_attr {
 	/** Marks object as failed */
@@ -92,6 +93,8 @@ typedef enum {
 	VOS_ITER_SINGLE,
 	/** iterate record extents and epoch validities of these extents */
 	VOS_ITER_RECX,
+	/** iterate VOS active-DTX table */
+	VOS_ITER_DTX,
 } vos_iter_type_t;
 
 /** epoch logic expression for the single value iterator */
@@ -173,17 +176,31 @@ enum {
  * Returned entry of a VOS iterator
  */
 typedef struct {
-	/** Returned epoch. It is ignored for container iteration. */
-	daos_epoch_t		ie_epoch;
-	/** Returned earliest update epoch for a key */
-	daos_epoch_t		ie_earliest;
+	union {
+		/** Returned epoch. It is ignored for container iteration. */
+		daos_epoch_t			ie_epoch;
+		/** Return the DTX identifier. */
+		struct daos_tx_id		ie_xid;
+	};
+	union {
+		/** Returned earliest update epoch for a key */
+		daos_epoch_t			ie_earliest;
+		/** Return the DTX handled time for DTX iteration. */
+		uint64_t			ie_dtx_sec;
+	};
 	union {
 		/** Returned entry for container UUID iterator */
 		uuid_t				ie_couuid;
 		/** dkey or akey */
 		daos_key_t			ie_key;
-		/** oid */
-		daos_unit_oid_t			ie_oid;
+		struct {
+			/** oid */
+			daos_unit_oid_t		ie_oid;
+			/* The DTX dkey hash for DTX iteration. */
+			uint64_t		ie_dtx_hash;
+			/* The DTX intent for DTX iteration. */
+			uint32_t		ie_dtx_intent;
+		};
 		struct {
 			/** record size */
 			daos_size_t		ie_rsize;

--- a/src/placement/pl_map.h
+++ b/src/placement/pl_map.h
@@ -59,7 +59,7 @@ struct pl_map_ops {
 				      uint32_t rebuild_ver,
 				      uint32_t *tgt_rank,
 				      uint32_t *shard_id,
-				      unsigned int array_size);
+				      unsigned int array_size, int myrank);
 	int	(*o_obj_find_reint)(struct pl_map *map,
 				    struct daos_obj_md *md,
 				    struct daos_obj_shard_md *shard_md,

--- a/src/placement/tests/place_obj.c
+++ b/src/placement/tests/place_obj.c
@@ -146,7 +146,7 @@ plt_spare_tgts_get(uuid_t pl_uuid, daos_obj_id_t oid, uint32_t *failed_tgts,
 	for (i = 0; i < failed_cnt; i++)
 		plt_fail_tgt(failed_tgts[i]);
 
-	rc = pl_map_update(pl_uuid, po_map, false, false);
+	rc = pl_map_update(pl_uuid, po_map, false);
 	D_ASSERT(rc == 0);
 	pl_map = pl_map_find(pl_uuid, oid);
 	D_ASSERT(pl_map != NULL);
@@ -154,7 +154,7 @@ plt_spare_tgts_get(uuid_t pl_uuid, daos_obj_id_t oid, uint32_t *failed_tgts,
 	md.omd_ver = po_ver;
 	*spare_cnt = pl_obj_find_rebuild(pl_map, &md, NULL, po_ver,
 					 spare_tgt_ranks, shard_ids,
-					 SPARE_MAX_NUM);
+					 SPARE_MAX_NUM, -1);
 	D_PRINT("spare_cnt %d for version %d -\n", *spare_cnt, po_ver);
 	for (i = 0; i < *spare_cnt; i++)
 		D_PRINT("shard %d, spare target rank %d\n",

--- a/src/pool/cli.c
+++ b/src/pool/cli.c
@@ -222,7 +222,7 @@ pool_map_update(struct dc_pool *pool, struct pool_map *map,
 
 	D_ASSERT(map != NULL);
 	if (pool->dp_map == NULL) {
-		rc = pl_map_update(pool->dp_pool, map, connect, false);
+		rc = pl_map_update(pool->dp_pool, map, connect);
 		if (rc != 0)
 			D_GOTO(out, rc);
 
@@ -243,7 +243,7 @@ pool_map_update(struct dc_pool *pool, struct pool_map *map,
 		pool->dp_map == NULL ?
 		0 : pool_map_get_version(pool->dp_map), map_version);
 
-	rc = pl_map_update(pool->dp_pool, map, connect, false);
+	rc = pl_map_update(pool->dp_pool, map, connect);
 	if (rc != 0) {
 		D_ERROR("Failed to refresh placement map: %d\n", rc);
 		D_GOTO(out, rc);
@@ -972,7 +972,7 @@ dc_pool_g2l(struct dc_pool_glob *pool_glob, size_t len, daos_handle_t *poh)
 		D_GOTO(out, rc);
 	}
 
-	rc = pl_map_update(pool->dp_pool, pool->dp_map, true, false);
+	rc = pl_map_update(pool->dp_pool, pool->dp_map, true);
 	if (rc != 0)
 		D_GOTO(out, rc);
 

--- a/src/rebuild/initiator.c
+++ b/src/rebuild/initiator.c
@@ -792,7 +792,9 @@ rebuild_obj_ult(void *data)
 	memset(&anchor, 0, sizeof(anchor));
 	memset(&dkey_anchor, 0, sizeof(dkey_anchor));
 	memset(&akey_anchor, 0, sizeof(akey_anchor));
-	dc_obj_shard2anchor(&anchor, arg->shard);
+	dc_obj_shard2anchor(&dkey_anchor, arg->shard);
+	daos_anchor_set_flags(&dkey_anchor,
+			      DAOS_ANCHOR_FLAGS_TO_LEADER);
 
 	/* Initialize enum_arg for VOS_ITER_DKEY. */
 	memset(&enum_arg, 0, sizeof(enum_arg));

--- a/src/rebuild/scan.c
+++ b/src/rebuild/scan.c
@@ -548,14 +548,13 @@ out:
 
 #define LOCAL_ARRAY_SIZE	128
 static int
-placement_check(uuid_t co_uuid, daos_unit_oid_t oid,
-		daos_epoch_t epoch, void *data)
+placement_check(uuid_t co_uuid, vos_iter_entry_t *ent, void *data)
 {
 	struct rebuild_scan_arg	*arg = data;
 	struct rebuild_tgt_pool_tracker *rpt = arg->rpt;
-	struct pl_obj_layout	*layout = NULL;
 	struct pl_map		*map = NULL;
 	struct daos_obj_md	md;
+	daos_unit_oid_t		oid = ent->ie_oid;
 	unsigned int		tgt_array[LOCAL_ARRAY_SIZE];
 	unsigned int		shard_array[LOCAL_ARRAY_SIZE];
 	unsigned int		*tgts = NULL;
@@ -590,7 +589,8 @@ placement_check(uuid_t co_uuid, daos_unit_oid_t oid,
 	}
 
 	rebuild_nr = pl_obj_find_rebuild(map, &md, NULL, rpt->rt_rebuild_ver,
-					 tgts, shards, arg->rebuild_tgt_nr);
+					 tgts, shards, arg->rebuild_tgt_nr,
+					 myrank);
 	if (rebuild_nr <= 0) /* No need rebuild */
 		D_GOTO(out, rc = rebuild_nr);
 
@@ -610,7 +610,7 @@ placement_check(uuid_t co_uuid, daos_unit_oid_t oid,
 		if (myrank != tgts[i]) {
 			rc = rebuild_object_insert(arg, tgts[i], shards[i],
 						   rpt->rt_pool_uuid, co_uuid,
-						   oid, epoch);
+						   oid, ent->ie_epoch);
 			if (rc)
 				D_GOTO(out, rc);
 		} else {
@@ -619,9 +619,6 @@ placement_check(uuid_t co_uuid, daos_unit_oid_t oid,
 		}
 	}
 out:
-	if (layout != NULL)
-		pl_obj_layout_free(layout);
-
 	if (tgts != tgt_array && tgts != NULL)
 		D_FREE(tgts);
 
@@ -635,7 +632,7 @@ out:
 }
 
 struct rebuild_iter_arg {
-	cont_iter_cb_t	callback;
+	ds_iter_cb_t	callback;
 	void		*arg;
 };
 
@@ -652,8 +649,8 @@ rebuild_scanner(void *data)
 	while (daos_fail_check(DAOS_REBUILD_TGT_SCAN_HANG))
 		ABT_thread_yield();
 
-	return ds_pool_obj_iter(rpt->rt_pool_uuid, arg->callback,
-				arg->arg);
+	return ds_pool_iter(rpt->rt_pool_uuid, arg->callback, arg->arg,
+			    rpt->rt_rebuild_ver, DAOS_INTENT_REBUILD);
 }
 
 static int
@@ -692,7 +689,7 @@ rebuild_scan_leader(void *data)
 	ABT_mutex_lock(rpt->rt_lock);
 	map = rebuild_pool_map_get(rpt->rt_pool);
 	D_ASSERT(map != NULL);
-	rc = pl_map_update(rpt->rt_pool_uuid, map, false, true);
+	rc = pl_map_update(rpt->rt_pool_uuid, map, true);
 	if (rc != 0) {
 		ABT_mutex_unlock(rpt->rt_lock);
 		D_GOTO(out_map, rc = -DER_NOMEM);
@@ -704,7 +701,7 @@ rebuild_scan_leader(void *data)
 
 	rc = dss_thread_collective(rebuild_scanner, &iter_arg, 0);
 	if (rc)
-		D_GOTO(out_map, rc);
+		D_GOTO(put_plmap, rc);
 
 	D_DEBUG(DB_REBUILD, "rebuild scan collective "DF_UUID" done.\n",
 		DP_UUID(rpt->rt_pool_uuid));
@@ -717,7 +714,7 @@ rebuild_scan_leader(void *data)
 		rc = dbtree_iterate(arg->rebuild_tree_hdl, DAOS_INTENT_REBUILD,
 				    false, rebuild_tgt_fini_obj_send_cb, arg);
 		if (rc)
-			D_GOTO(out_map, rc);
+			D_GOTO(put_plmap, rc);
 	}
 
 	ABT_mutex_lock(rpt->rt_lock);
@@ -726,12 +723,14 @@ rebuild_scan_leader(void *data)
 	if (rc) {
 		D_ERROR(DF_UUID" send rebuild object list failed:%d\n",
 			DP_UUID(rpt->rt_pool_uuid), rc);
-		D_GOTO(out_map, rc);
+		D_GOTO(put_plmap, rc);
 	}
 
 	D_DEBUG(DB_REBUILD, DF_UUID" sent objects to initiator %d\n",
 		DP_UUID(rpt->rt_pool_uuid), rc);
 
+put_plmap:
+	pl_map_disconnect(rpt->rt_pool_uuid);
 out_map:
 	rebuild_pool_map_put(map);
 	dbtree_destroy(arg->rebuild_tree_hdl);

--- a/src/tests/suite/daos_obj.c
+++ b/src/tests/suite/daos_obj.c
@@ -2830,13 +2830,17 @@ fetch_replica_unavail(void **state)
 	lookup_single(dkey, akey, 0, buf, size, DAOS_TX_NONE, &req);
 
 	if (arg->myrank == 0) {
+		/* re-enable rebuild */
+		rc = daos_mgmt_set_params(arg->group, info.pi_leader,
+					  DSS_KEY_FAIL_LOC, 0, 0, NULL);
+
+		/* wait until rebuild done */
+		test_rebuild_wait(&arg, 1);
+
 		/* add back the excluded targets */
 		daos_add_server(arg->pool.pool_uuid, arg->group, &arg->pool.svc,
 				rank);
 
-		/* re-enable rebuild */
-		rc = daos_mgmt_set_params(arg->group, info.pi_leader,
-			DSS_KEY_FAIL_LOC, 0, 0, NULL);
 		assert_int_equal(rc, 0);
 	}
 	D_FREE(buf);

--- a/src/vos/SConscript
+++ b/src/vos/SConscript
@@ -5,7 +5,8 @@ import daos_build
 FILES = ["evt_iter.c", "vos_common.c", "vos_iterator.c", "vos_obj.c",
          "vos_pool.c", "vos_aggregate.c", "vos_container.c", "vos_io.c",
          "vos_obj_cache.c", "vos_obj_index.c", "vos_tree.c", "evtree.c",
-         "vos_dtx.c", "vos_dtx_cos.c", "vos_query.c", "vos_overhead.c"]
+         "vos_dtx.c", "vos_dtx_cos.c", "vos_query.c", "vos_overhead.c",
+         "vos_dtx_iter.c"]
 
 def build_vos(env, standalone):
     """build vos"""

--- a/src/vos/vos_dtx_cos.c
+++ b/src/vos/vos_dtx_cos.c
@@ -28,6 +28,7 @@
 #define D_LOGFAC	DD_FAC(vos)
 
 #include <daos/btree.h>
+#include <daos_srv/vos.h>
 #include "vos_layout.h"
 #include "vos_internal.h"
 
@@ -254,9 +255,10 @@ vos_dtx_cos_register(void)
 }
 
 int
-vos_dtx_list_cos(struct vos_container *cont, daos_unit_oid_t *oid,
+vos_dtx_list_cos(daos_handle_t coh, daos_unit_oid_t *oid,
 		 daos_key_t *dkey, uint32_t types, struct daos_tx_id **dtis)
 {
+	struct vos_container		*cont;
 	struct dtx_cos_key		 key;
 	daos_iov_t			 kiov;
 	daos_iov_t			 riov;
@@ -269,6 +271,9 @@ vos_dtx_list_cos(struct vos_container *cont, daos_unit_oid_t *oid,
 
 	if (dkey == NULL)
 		return 0;
+
+	cont = vos_hdl2cont(coh);
+	D_ASSERT(cont != NULL);
 
 	D_ASSERT(dkey->iov_buf != NULL);
 	D_ASSERT(dkey->iov_len != 0);
@@ -326,9 +331,10 @@ vos_dtx_list_cos(struct vos_container *cont, daos_unit_oid_t *oid,
 }
 
 int
-vos_dtx_add_cos(struct vos_container *cont, daos_unit_oid_t *oid,
+vos_dtx_add_cos(daos_handle_t coh, daos_unit_oid_t *oid,
 		struct daos_tx_id *dti, uint64_t dkey, bool punch)
 {
+	struct vos_container		*cont;
 	struct dtx_cos_key		 key;
 	struct dtx_cos_rec_bundle	 rbund;
 	daos_iov_t			 kiov;
@@ -336,6 +342,9 @@ vos_dtx_add_cos(struct vos_container *cont, daos_unit_oid_t *oid,
 	int				 rc;
 
 	D_ASSERT(dkey != 0);
+
+	cont = vos_hdl2cont(coh);
+	D_ASSERT(cont != NULL);
 
 	key.oid = *oid;
 	key.dkey = dkey;

--- a/src/vos/vos_dtx_iter.c
+++ b/src/vos/vos_dtx_iter.c
@@ -1,0 +1,193 @@
+/**
+ * (C) Copyright 2019 Intel Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * GOVERNMENT LICENSE RIGHTS-OPEN SOURCE SOFTWARE
+ * The Government's rights to use, modify, reproduce, release, perform, display,
+ * or disclose this software are subject to the terms of the Apache License as
+ * provided in Contract No. B609815.
+ * Any reproduction of computer software, computer software documentation, or
+ * portions thereof marked with this legend must also reproduce the markings.
+ */
+/**
+ * This file is part of daos two-phase commit transaction.
+ *
+ * vos/vos_dtx_iter.c
+ */
+#define D_LOGFAC	DD_FAC(vos)
+
+#include "vos_layout.h"
+#include "vos_internal.h"
+
+/** Iterator for active-DTX table. */
+struct vos_dtx_iter {
+	/** embedded VOS common iterator */
+	struct vos_iterator	 oit_iter;
+	/** Handle of iterator */
+	daos_handle_t		 oit_hdl;
+	/** Reference to the container */
+	struct vos_container	*oit_cont;
+};
+
+static struct vos_dtx_iter *
+iter2oiter(struct vos_iterator *iter)
+{
+	return container_of(iter, struct vos_dtx_iter, oit_iter);
+}
+
+static int
+dtx_iter_fini(struct vos_iterator *iter)
+{
+	struct vos_dtx_iter	*oiter = iter2oiter(iter);
+	int			 rc = 0;
+
+	D_ASSERT(iter->it_type == VOS_ITER_DTX);
+
+	if (!daos_handle_is_inval(oiter->oit_hdl)) {
+		rc = dbtree_iter_finish(oiter->oit_hdl);
+		if (rc != 0)
+			D_ERROR("oid_iter_fini failed: rc = %d\n", rc);
+	}
+
+	if (oiter->oit_cont != NULL)
+		vos_cont_decref(oiter->oit_cont);
+
+	D_FREE_PTR(oiter);
+	return rc;
+}
+
+static int
+dtx_iter_prep(vos_iter_type_t type, vos_iter_param_t *param,
+	      struct vos_iterator **iter_pp)
+{
+	struct vos_dtx_iter	*oiter;
+	struct vos_container	*cont;
+	int			 rc;
+
+	if (type != VOS_ITER_DTX) {
+		D_ERROR("Expected Type: %d, got %d\n", VOS_ITER_DTX, type);
+		return -DER_INVAL;
+	}
+
+	cont = vos_hdl2cont(param->ip_hdl);
+	if (cont == NULL)
+		return -DER_INVAL;
+
+	D_ALLOC_PTR(oiter);
+	if (oiter == NULL)
+		return -DER_NOMEM;
+
+	oiter->oit_cont = cont;
+	vos_cont_addref(cont);
+
+	rc = dbtree_iter_prepare(cont->vc_dtx_active_hdl, 0, &oiter->oit_hdl);
+	if (rc != 0) {
+		D_ERROR("Failed to prepare DTX iteration: rc = %d\n", rc);
+		dtx_iter_fini(&oiter->oit_iter);
+	} else {
+		*iter_pp = &oiter->oit_iter;
+	}
+
+	return rc;
+}
+
+static int
+dtx_iter_probe(struct vos_iterator *iter, daos_anchor_t *anchor)
+{
+	struct vos_dtx_iter	*oiter = iter2oiter(iter);
+	dbtree_probe_opc_t	 opc;
+
+	D_ASSERT(iter->it_type == VOS_ITER_DTX);
+
+	opc = anchor == NULL ? BTR_PROBE_FIRST : BTR_PROBE_GE;
+	return dbtree_iter_probe(oiter->oit_hdl, opc, vos_iter_intent(iter),
+				 NULL, anchor);
+}
+
+static int
+dtx_iter_next(struct vos_iterator *iter)
+{
+	struct vos_dtx_iter	*oiter = iter2oiter(iter);
+
+	D_ASSERT(iter->it_type == VOS_ITER_DTX);
+
+	return dbtree_iter_next(oiter->oit_hdl);
+}
+
+static int
+dtx_iter_fetch(struct vos_iterator *iter, vos_iter_entry_t *it_entry,
+	       daos_anchor_t *anchor)
+{
+	struct vos_dtx_iter	*oiter = iter2oiter(iter);
+	struct vos_dtx_entry_df	*dtx;
+	daos_iov_t		 rec_iov;
+	int			 rc;
+
+	D_ASSERT(iter->it_type == VOS_ITER_DTX);
+
+	daos_iov_set(&rec_iov, NULL, 0);
+	rc = dbtree_iter_fetch(oiter->oit_hdl, NULL, &rec_iov, anchor);
+	if (rc != 0) {
+		D_ERROR("Error while fetching DTX info: rc = %d\n", rc);
+		return rc;
+	}
+
+	D_ASSERT(rec_iov.iov_len == sizeof(struct vos_dtx_entry_df));
+	dtx = (struct vos_dtx_entry_df *)rec_iov.iov_buf;
+
+	it_entry->ie_xid = dtx->te_xid;
+	it_entry->ie_oid = dtx->te_oid;
+	it_entry->ie_dtx_sec = dtx->te_sec;
+	it_entry->ie_dtx_intent = dtx->te_intent;
+	it_entry->ie_dtx_hash = dtx->te_dkey_hash[0];
+
+	D_DEBUG(DB_TRACE, "DTX iterator fetch the one "DF_DTI"\n",
+		DP_DTI(&dtx->te_xid));
+
+	return 0;
+}
+
+static int
+dtx_iter_delete(struct vos_iterator *iter, void *args)
+{
+	struct vos_dtx_iter	*oiter = iter2oiter(iter);
+	struct umem_instance	*umm;
+	int			 rc;
+
+	D_ASSERT(iter->it_type == VOS_ITER_DTX);
+
+	umm = &oiter->oit_cont->vc_pool->vp_umm;
+	rc = umem_tx_begin(umm, vos_txd_get());
+	if (rc != 0)
+		return rc;
+
+	rc = dbtree_iter_delete(oiter->oit_hdl, args);
+	if (rc != 0) {
+		umem_tx_abort(umm, rc);
+		D_ERROR("Failed to delete DTX entry: rc = %d\n", rc);
+	} else {
+		umem_tx_commit(umm);
+	}
+
+	return rc;
+}
+
+struct vos_iter_ops vos_dtx_iter_ops = {
+	.iop_prepare =	dtx_iter_prep,
+	.iop_finish  =  dtx_iter_fini,
+	.iop_probe   =	dtx_iter_probe,
+	.iop_next    =  dtx_iter_next,
+	.iop_fetch   =  dtx_iter_fetch,
+	.iop_delete  =	dtx_iter_delete,
+};

--- a/src/vos/vos_internal.h
+++ b/src/vos/vos_internal.h
@@ -212,6 +212,7 @@ struct vos_object {
 extern struct vos_iter_ops vos_oi_iter_ops;
 extern struct vos_iter_ops vos_obj_iter_ops;
 extern struct vos_iter_ops vos_cont_iter_ops;
+extern struct vos_iter_ops vos_dtx_iter_ops;
 
 /** VOS thread local storage structure */
 struct vos_tls {
@@ -447,22 +448,6 @@ vos_dtx_table_register(void);
  */
 int
 vos_dtx_cos_register(void);
-
-/**
- * Add the given DTX to the Commit-on-Share (CoS) cache (in DRAM).
- *
- * \param cont	[IN]	Pointer to the container.
- * \param oid	[IN]	The target object (shard) ID.
- * \param dti	[IN]	The DTX identifier.
- * \param dkey	[IN]	The hashed dkey.
- * \param punch	[IN]	For punch DTX or not.
- *
- * \return		Zero on success and need not additional actions.
- * \return		Negative value if error.
- */
-int
-vos_dtx_add_cos(struct vos_container *cont, daos_unit_oid_t *oid,
-		struct daos_tx_id *dti, uint64_t dkey, bool punch);
 
 /**
  * Remove the DTX from the CoS cache.

--- a/src/vos/vos_iterator.c
+++ b/src/vos/vos_iterator.c
@@ -70,6 +70,11 @@ static struct vos_iter_dict vos_iterators[] = {
 		.id_ops		= &vos_obj_iter_ops,
 	},
 	{
+		.id_type	= VOS_ITER_DTX,
+		.id_name	= "dtx",
+		.id_ops		= &vos_dtx_iter_ops,
+	},
+	{
 		.id_type	= VOS_ITER_NONE,
 		.id_name	= "unknown",
 		.id_ops		= NULL,


### PR DESCRIPTION
For performance consideration, the leader caches the committable
DTXs (in DRAM) and commits them asychronously. If leader failed,
there may be some committable DTXs that are not committed. Because
DTX status affects the visibility of related data record that is
modified via the DTX, we need to resync former cached DTXs state,
otherwise, accessing related data records will get wrong results,
including the rebuilding objects process.

This patch introduces the logic to resync DTX status when the
container is opened or before scanning the objects for rebuild.
Each replica scans its local active-DTX table, for the leader,
it check with other replicas about the DTX state. As long as one
replica reports 'committed' or all the replicas as 'prepared',
then such DTX can be committed, otherwise, the DTX will be aborted.

The patch also enhance the rebuilding object logic as following:

1. For each server, it will not start the object scan until the
   local DTX resync is done.

2. If the server is the leader for some object's shard, then it
   can send such shard to the in-rebuilding target.

3. The in-rebuilding target only can fetch data from leaders to
   avoid missing any data record.

Signed-off-by: Fan Yong <fan.yong@intel.com>
Change-Id: I3a1916590d8e13027fb9c48a7575650e23a06f30