### PR TITLE
DAOS-1441 vos: DTX interfaces for VOS internal usage

### DIFF
--- a/src/common/btree.c
+++ b/src/common/btree.c
@@ -225,6 +225,14 @@ btr_hdl2tcx(daos_handle_t toh)
 	return (struct btr_context *)toh.cookie;
 }
 
+struct umem_instance *
+btr_hdl2umm(daos_handle_t toh)
+{
+	struct btr_context *tcx = btr_hdl2tcx(toh);
+
+	return tcx != NULL ? &tcx->tc_tins.ti_umm : NULL;
+}
+
 void
 btr_context_addref(struct btr_context *tcx)
 {

--- a/src/include/daos/btree.h
+++ b/src/include/daos/btree.h
@@ -566,6 +566,7 @@ int  dbtree_delete(daos_handle_t toh, daos_iov_t *key, void *args);
 int  dbtree_query(daos_handle_t toh, struct btr_attr *attr,
 		  struct btr_stat *stat);
 int  dbtree_is_empty(daos_handle_t toh);
+struct umem_instance *btr_hdl2umm(daos_handle_t toh);
 
 /******* iterator API ******************************************************/
 

--- a/src/vos/vos_common.c
+++ b/src/vos/vos_common.c
@@ -180,6 +180,8 @@ vos_tls_init(const struct dss_thread_local_storage *dtls,
 		return NULL;
 	}
 
+	tls->vtl_dth = NULL;
+
 	return tls;
 }
 
@@ -338,12 +340,13 @@ vos_init(void)
 		return rc;
 	}
 
+	vsa_dth = NULL;
 	vsa_xsctxt_inst = NULL;
 	vsa_nvme_init = false;
 
 	D_ALLOC_PTR(vsa_imems_inst);
 	if (vsa_imems_inst == NULL)
-		D_GOTO(exit, rc);
+		D_GOTO(exit, rc = -DER_NOMEM);
 
 	rc = vos_imem_strts_create(vsa_imems_inst);
 	if (rc)

--- a/src/vos/vos_dtx.c
+++ b/src/vos/vos_dtx.c
@@ -34,6 +34,19 @@
 #define DTX_UMMID_ABORTED	((umem_id_t){ .pool_uuid_lo = -1, .off = -1, })
 #define DTX_UMMID_UNKNOWN	((umem_id_t){ .pool_uuid_lo = -1, .off = -2, })
 
+static inline int
+dtx_inprogress(struct vos_dtx_entry_df *dtx, int pos)
+{
+	if (dtx != NULL)
+		D_DEBUG(DB_TRACE, "Hit uncommitted DTX "DF_DTI
+			" with state %u, time %lu at %d\n",
+			DP_DTI(&dtx->te_xid), dtx->te_state, dtx->te_sec, pos);
+	else
+		D_DEBUG(DB_TRACE, "Hit uncommitted (unknown) DTX at %d\n", pos);
+
+	return -DER_INPROGRESS;
+}
+
 struct dtx_rec_bundle {
 	umem_id_t	trb_ummid;
 };
@@ -514,7 +527,8 @@ dtx_rec_release(struct umem_instance *umm, umem_id_t ummid,
 	struct vos_dtx_entry_df		*dtx;
 
 	dtx = umem_id2ptr(umm, ummid);
-	umem_tx_add_ptr(umm, dtx, sizeof(*dtx));
+	if (!destroy)
+		umem_tx_add_ptr(umm, dtx, sizeof(*dtx));
 
 	while (!UMMID_IS_NULL(dtx->te_records)) {
 		umem_id_t			 rec_mmid = dtx->te_records;
@@ -568,7 +582,6 @@ dtx_rec_release(struct umem_instance *umm, umem_id_t ummid,
 		}
 
 		dtx->te_records = rec->tr_next;
-		umem_tx_add_ptr(umm, rec, sizeof(*rec));
 		umem_free(umm, rec_mmid);
 	}
 
@@ -717,6 +730,520 @@ vos_dtx_abort_one(struct vos_container *cont, struct daos_tx_id *dti,
 	return rc;
 }
 
+struct vos_dtx_share {
+	/** Link into the daos_tx_handle::dth_shares */
+	d_list_t		vds_link;
+	/** The DTX record type, see enum vos_dtx_record_types. */
+	uint32_t		vds_type;
+	/** The record in the related tree in SCM. */
+	umem_id_t		vds_record;
+};
+
+static bool
+vos_dtx_is_normal_entry(struct umem_instance *umm, umem_id_t entry)
+{
+	if (UMMID_IS_NULL(entry) ||
+	    umem_id_equal(umm, entry, DTX_UMMID_ABORTED) ||
+	    umem_id_equal(umm, entry, DTX_UMMID_UNKNOWN))
+		return false;
+
+	return true;
+}
+
+static int
+vos_dtx_alloc(struct umem_instance *umm, struct daos_tx_handle *dth,
+	      umem_id_t rec_mmid, struct vos_dtx_entry_df **dtxp)
+{
+	daos_key_t		*dkey = dth->dth_dkey;
+	struct vos_dtx_entry_df	*dtx;
+	struct vos_container	*cont;
+	umem_id_t		 dtx_mmid;
+	daos_iov_t		 kiov;
+	daos_iov_t		 riov;
+	struct dtx_rec_bundle	 rbund;
+	int			 rc;
+
+	cont = vos_hdl2cont(dth->dth_coh);
+	D_ASSERT(cont != NULL);
+
+	dtx_mmid = umem_zalloc(umm, sizeof(struct vos_dtx_entry_df));
+	if (UMMID_IS_NULL(dtx_mmid))
+		return -DER_NOMEM;
+
+	dtx = umem_id2ptr(umm, dtx_mmid);
+	dtx->te_xid = dth->dth_xid;
+	dtx->te_oid = dth->dth_oid;
+	if (dkey != NULL) {
+		dtx->te_dkey_hash[0] = d_hash_murmur64(dkey->iov_buf,
+						       dkey->iov_len,
+						       VOS_BTR_MUR_SEED);
+		dtx->te_dkey_hash[1] = d_hash_string_u32(dkey->iov_buf,
+							 dkey->iov_len);
+	} else {
+		dtx->te_dkey_hash[0] = 0;
+		dtx->te_dkey_hash[1] = 0;
+	}
+	dtx->te_epoch = dth->dth_epoch;
+	dtx->te_ver = dth->dth_ver;
+	dtx->te_state = DTX_ST_INIT;
+	dtx->te_flags = 0;
+	dtx->te_intent = dth->dth_intent;
+	dtx->te_sec = time(NULL);
+	dtx->te_records = rec_mmid;
+	dtx->te_next = UMMID_NULL;
+	dtx->te_prev = UMMID_NULL;
+
+	rbund.trb_ummid = dtx_mmid;
+	daos_iov_set(&riov, &rbund, sizeof(rbund));
+	daos_iov_set(&kiov, &dth->dth_xid, sizeof(dth->dth_xid));
+	rc = dbtree_upsert(cont->vc_dtx_active_hdl, BTR_PROBE_EQ,
+			   DAOS_INTENT_UPDATE, &kiov, &riov);
+	if (rc == 0) {
+		dth->dth_ent = dtx_mmid;
+		*dtxp = dtx;
+	}
+
+	return rc;
+}
+
+static void
+vos_dtx_append(struct umem_instance *umm, struct daos_tx_handle *dth,
+	       umem_id_t rec_mmid, umem_id_t record, uint32_t type,
+	       uint32_t flags, struct vos_dtx_entry_df **dtxp)
+{
+	struct vos_dtx_entry_df		*dtx;
+	struct vos_dtx_record_df	*rec;
+	struct vos_dtx_record_df	*tgt;
+
+	/* The @dtx must be new created via former
+	 * vos_dtx_register_record(), no need umem_tx_add_ptr().
+	 */
+	dtx = umem_id2ptr(umm, dth->dth_ent);
+	dtx->te_sec = time(NULL);
+	rec = umem_id2ptr(umm, rec_mmid);
+	rec->tr_next = dtx->te_records;
+	dtx->te_records = rec_mmid;
+	*dtxp = dtx;
+
+	if (flags == 0)
+		return;
+
+	/*
+	 * XXX: Currently, we only support DTX_RF_EXCHANGE_SRC when register
+	 *	the target for punch {a,d}key. It is implemented as exchange
+	 *	related {a,d}key. The exchange target has registered its record
+	 *	to the DTX just before the exchange source.
+	 */
+	D_ASSERT(flags == DTX_RF_EXCHANGE_SRC);
+	D_ASSERT(type == DTX_RT_OBJ || type == DTX_RT_KEY);
+
+	/* The @tgt must be new created via former
+	 * vos_dtx_register_record(), no need umem_tx_add_ptr().
+	 */
+	tgt = umem_id2ptr(umm, rec->tr_next);
+	D_ASSERT(tgt->tr_flags == 0);
+
+	tgt->tr_flags = DTX_RF_EXCHANGE_TGT;
+	dtx->te_flags |= DTX_EF_EXCHANGE_PENDING;
+
+	if (type == DTX_RT_OBJ) {
+		struct vos_obj_df	*obj;
+
+		obj = umem_id2ptr(umm, record);
+		obj->vo_oi_attr |= VOS_OI_REMOVED;
+	} else {
+		struct vos_krec_df	*key;
+
+		key = umem_id2ptr(umm, record);
+		key->kr_bmap |= KREC_BF_REMOVED;
+	}
+
+	D_DEBUG(DB_TRACE, "Register exchange source for %s DTX "DF_DTI"\n",
+		type == DTX_RT_OBJ ? "OBJ" : "KEY", DP_DTI(&dtx->te_xid));
+}
+
+static int
+vos_dtx_append_share(struct umem_instance *umm, struct vos_dtx_entry_df *dtx,
+		     struct vos_dtx_share *vds)
+{
+	struct vos_dtx_record_df	*rec;
+	umem_id_t			 rec_mmid;
+
+	rec_mmid = umem_zalloc(umm, sizeof(struct vos_dtx_record_df));
+	if (UMMID_IS_NULL(rec_mmid))
+		return -DER_NOMEM;
+
+	rec = umem_id2ptr(umm, rec_mmid);
+	rec->tr_type = vds->vds_type;
+	rec->tr_flags = 0;
+	rec->tr_record = vds->vds_record;
+
+	rec->tr_next = dtx->te_records;
+	dtx->te_records = rec_mmid;
+
+	return 0;
+}
+
+static int
+vos_dtx_share_obj(struct umem_instance *umm, struct daos_tx_handle *dth,
+		  struct vos_dtx_entry_df *dtx, struct vos_dtx_share *vds,
+		  bool *shared)
+{
+	struct vos_obj_df	*obj;
+	struct vos_dtx_entry_df	*sh_dtx;
+	int			 rc;
+
+	obj = umem_id2ptr(umm, vds->vds_record);
+	/* The to be shared obj has been committed. */
+	if (UMMID_IS_NULL(obj->vo_dtx))
+		return 0;
+
+	rc = vos_dtx_append_share(umm, dtx, vds);
+	if (rc != 0)
+		goto out;
+
+	umem_tx_add_ptr(umm, obj, sizeof(*obj));
+
+	/* The to be shared obj has been aborted, reuse it. */
+	if (umem_id_equal(umm, obj->vo_dtx, DTX_UMMID_ABORTED)) {
+		D_ASSERTF(obj->vo_dtx_shares == 0,
+			  "Invalid shared obj DTX shares %d\n",
+			  obj->vo_dtx_shares);
+		obj->vo_dtx_shares = 1;
+		goto out;
+	}
+
+	obj->vo_dtx_shares++;
+	*shared = true;
+
+	/* The original obj DTX has been aborted, but some others
+	 * still share the obj. Then set the vo_dtx to current DTX.
+	 */
+	if (umem_id_equal(umm, obj->vo_dtx, DTX_UMMID_UNKNOWN)) {
+		D_DEBUG(DB_TRACE, "The DTX "DF_DTI" shares obj "
+			"with unknown DTXs, shares count %u.\n",
+			DP_DTI(&dth->dth_xid),
+			obj->vo_dtx_shares);
+		obj->vo_dtx = dth->dth_ent;
+		goto out;
+	}
+
+	sh_dtx = umem_id2ptr(umm, obj->vo_dtx);
+	D_ASSERT(dtx != sh_dtx);
+	D_ASSERTF(sh_dtx->te_state == DTX_ST_PREPARED ||
+		  sh_dtx->te_state == DTX_ST_INIT,
+		  "Invalid shared obj DTX state: %u\n",
+		  sh_dtx->te_state);
+
+	umem_tx_add_ptr(umm, sh_dtx, sizeof(*sh_dtx));
+	sh_dtx->te_flags |= DTX_EF_SHARES;
+
+out:
+	D_DEBUG(DB_TRACE, "The DTX "DF_DTI" try to shares obj with others, "
+		"the shares count %u: rc = %d\n",
+		DP_DTI(&dth->dth_xid), obj->vo_dtx_shares, rc);
+
+	return rc;
+}
+
+static int
+vos_dtx_share_key(struct umem_instance *umm, struct daos_tx_handle *dth,
+		  struct vos_dtx_entry_df *dtx, struct vos_dtx_share *vds,
+		  bool *shared)
+{
+	struct vos_krec_df	*key;
+	struct vos_dtx_entry_df	*sh_dtx;
+	int			 rc;
+
+	key = umem_id2ptr(umm, vds->vds_record);
+	/* The to be shared key has been committed. */
+	if (UMMID_IS_NULL(key->kr_dtx))
+		return 0;
+
+	rc = vos_dtx_append_share(umm, dtx, vds);
+	if (rc != 0)
+		goto out;
+
+	umem_tx_add_ptr(umm, key, sizeof(*key));
+
+	/* The to be shared key has been aborted, reuse it. */
+	if (umem_id_equal(umm, key->kr_dtx, DTX_UMMID_ABORTED)) {
+		D_ASSERTF(key->kr_dtx_shares == 0,
+			  "Invalid shared key DTX shares %d\n",
+			  key->kr_dtx_shares);
+		key->kr_dtx_shares = 1;
+		goto out;
+	}
+
+	key->kr_dtx_shares++;
+	*shared = true;
+
+	/* The original key DTX has been aborted, but some others
+	 * still share the key. Then set the kr_dtx to current DTX.
+	 */
+	if (umem_id_equal(umm, key->kr_dtx, DTX_UMMID_UNKNOWN)) {
+		D_DEBUG(DB_TRACE, "The DTX "DF_DTI" shares key "
+			"with unknown DTXs, shares count %u.\n",
+			DP_DTI(&dth->dth_xid), key->kr_dtx_shares);
+		key->kr_dtx = dth->dth_ent;
+		goto out;
+	}
+
+	sh_dtx = umem_id2ptr(umm, key->kr_dtx);
+	D_ASSERT(dtx != sh_dtx);
+	D_ASSERTF(sh_dtx->te_state == DTX_ST_PREPARED ||
+		  sh_dtx->te_state == DTX_ST_INIT,
+		  "Invalid shared key DTX state: %u\n",
+		  sh_dtx->te_state);
+
+	umem_tx_add_ptr(umm, sh_dtx, sizeof(*sh_dtx));
+	sh_dtx->te_flags |= DTX_EF_SHARES;
+
+out:
+	D_DEBUG(DB_TRACE, "The DTX "DF_DTI" try to shares key with others, "
+		"the shares count %u: rc = %d\n",
+		DP_DTI(&dth->dth_xid), key->kr_dtx_shares, rc);
+
+	return rc;
+}
+
+/* The caller has started PMDK transaction. */
+int
+vos_dtx_register_record(struct umem_instance *umm, umem_id_t record,
+			uint32_t type, uint32_t flags)
+{
+	struct daos_tx_handle		*dth = vos_dth_get();
+	struct vos_dtx_entry_df		*dtx;
+	struct vos_dtx_record_df	*rec;
+	struct vos_dtx_share		*vds;
+	struct vos_dtx_share		*next;
+	umem_id_t			 rec_mmid = UMMID_NULL;
+	umem_id_t			*entry = NULL;
+	uint32_t			*shares = NULL;
+	int				 rc = 0;
+	bool				 shared = false;
+
+	switch (type) {
+	case DTX_RT_OBJ: {
+		struct vos_obj_df	*obj;
+
+		obj = umem_id2ptr(umm, record);
+		entry = &obj->vo_dtx;
+		if (dth == NULL || dth->dth_intent == DAOS_INTENT_UPDATE)
+			shares = &obj->vo_dtx_shares;
+
+		/* "flags == 0" means new created object. It is unnecessary
+		 * to umem_tx_add_ptr() for new created object.
+		 */
+		if (flags != 0)
+			umem_tx_add_ptr(umm, obj, sizeof(*obj));
+		break;
+	}
+	case DTX_RT_KEY: {
+		struct vos_krec_df	*key;
+
+		key = umem_id2ptr(umm, record);
+		entry = &key->kr_dtx;
+		if (dth == NULL || dth->dth_intent == DAOS_INTENT_UPDATE)
+			shares = &key->kr_dtx_shares;
+
+		if (flags != 0)
+			umem_tx_add_ptr(umm, key, sizeof(*key));
+		break;
+	}
+	case DTX_RT_SVT: {
+		struct vos_irec_df	*svt;
+
+		svt = umem_id2ptr(umm, record);
+		entry = &svt->ir_dtx;
+		break;
+	}
+	case DTX_RT_EVT: {
+		struct evt_desc		*evt;
+
+		evt = umem_id2ptr(umm, record);
+		entry = &evt->dc_dtx;
+		break;
+	}
+	default:
+		D_ERROR("Unknown DTX type %u\n", type);
+		return -DER_INVAL;
+	}
+
+	if (dth == NULL) {
+		*entry = UMMID_NULL;
+		if (shares != NULL)
+			*shares = 0;
+
+		return 0;
+	}
+
+	rec_mmid = umem_zalloc(umm, sizeof(struct vos_dtx_record_df));
+	if (UMMID_IS_NULL(rec_mmid))
+		return -DER_NOMEM;
+
+	rec = umem_id2ptr(umm, rec_mmid);
+	rec->tr_type = type;
+	rec->tr_flags = flags;
+	rec->tr_record = record;
+	rec->tr_next = UMMID_NULL;
+
+	if (UMMID_IS_NULL(dth->dth_ent)) {
+		D_ASSERT(flags == 0);
+
+		rc = vos_dtx_alloc(umm, dth, rec_mmid, &dtx);
+		if (rc != 0)
+			return rc;
+	} else {
+		vos_dtx_append(umm, dth, rec_mmid, record, type, flags, &dtx);
+	}
+
+	*entry = dth->dth_ent;
+	if (shares != NULL)
+		*shares = 1;
+
+	if (d_list_empty(&dth->dth_shares))
+		return 0;
+
+	d_list_for_each_entry_safe(vds, next, &dth->dth_shares, vds_link) {
+		if (vds->vds_type == DTX_RT_OBJ)
+			rc = vos_dtx_share_obj(umm, dth, dtx, vds, &shared);
+		else
+			rc = vos_dtx_share_key(umm, dth, dtx, vds, &shared);
+		if (rc != 0)
+			return rc;
+
+		d_list_del(&vds->vds_link);
+		D_FREE_PTR(vds);
+	}
+
+	if (rc == 0 && shared)
+		dtx->te_flags |= DTX_EF_SHARES;
+
+	return rc;
+}
+
+/* The caller has started PMDK transaction. */
+void
+vos_dtx_degister_record(struct umem_instance *umm,
+			umem_id_t entry, umem_id_t record, uint32_t type)
+{
+	struct vos_dtx_entry_df		*dtx;
+	struct vos_dtx_record_df	*rec;
+	struct vos_dtx_record_df	*prev = NULL;
+	umem_id_t			 rec_mmid;
+
+	if (!vos_dtx_is_normal_entry(umm, entry))
+		return;
+
+	dtx = umem_id2ptr(umm, entry);
+	rec_mmid = dtx->te_records;
+	while (!UMMID_IS_NULL(rec_mmid)) {
+		rec = umem_id2ptr(umm, rec_mmid);
+		if (!umem_id_equal(umm, record, rec->tr_record)) {
+			prev = rec;
+			rec_mmid = rec->tr_next;
+			continue;
+		}
+
+		if (prev == NULL) {
+			umem_tx_add_ptr(umm, dtx, sizeof(*dtx));
+			dtx->te_records = rec->tr_next;
+		} else {
+			umem_tx_add_ptr(umm, prev, sizeof(*prev));
+			prev->tr_next = rec->tr_next;
+		}
+
+		umem_free(umm, rec_mmid);
+		break;
+	};
+
+	/* The caller will destroy related OBJ/KEY/SVT/EVT record after
+	 * degistered the DTX record. So not reset DTX reference inside
+	 * related OBJ/KEY/SVT/EVT record unless necessary.
+	 */
+	if (type == DTX_RT_OBJ) {
+		struct vos_obj_df	*obj;
+
+		obj = umem_id2ptr(umm, record);
+		D_ASSERT(umem_id_equal(umm, obj->vo_dtx, entry));
+
+		umem_tx_add_ptr(umm, obj, sizeof(*obj));
+		if (dtx->te_intent == DAOS_INTENT_UPDATE) {
+			obj->vo_dtx_shares--;
+			if (obj->vo_dtx_shares > 0)
+				obj->vo_dtx = DTX_UMMID_UNKNOWN;
+		}
+	} else if (type == DTX_RT_KEY) {
+		struct vos_krec_df	*key;
+
+		key = umem_id2ptr(umm, record);
+		D_ASSERT(umem_id_equal(umm, key->kr_dtx, entry));
+
+		if (dtx->te_intent == DAOS_INTENT_UPDATE) {
+			umem_tx_add_ptr(umm, key, sizeof(*key));
+			key->kr_dtx_shares--;
+			if (key->kr_dtx_shares > 0)
+				key->kr_dtx = DTX_UMMID_UNKNOWN;
+		}
+	}
+}
+
+int
+vos_dtx_prepared(struct daos_tx_handle *dth)
+{
+	struct vos_container	*cont;
+	struct vos_dtx_entry_df	*dtx;
+	int			 rc = 0;
+
+	D_ASSERT(!UMMID_IS_NULL(dth->dth_ent));
+
+	cont = vos_hdl2cont(dth->dth_coh);
+	D_ASSERT(cont != NULL);
+
+	dtx = umem_id2ptr(&cont->vc_pool->vp_umm, dth->dth_ent);
+	if (dth->dth_intent == DAOS_INTENT_UPDATE) {
+		daos_iov_t	kiov;
+		daos_iov_t	riov;
+
+		/* There is CPU yield during the bulk transfer, then it is
+		 * possible that some others (rebuild) abort this DTX by race.
+		 * So we need to locate (or verify) DTX via its ID instead of
+		 * directly using the dth_ent.
+		 */
+		daos_iov_set(&kiov, &dth->dth_xid, sizeof(struct daos_tx_id));
+		daos_iov_set(&riov, NULL, 0);
+		rc = dbtree_lookup(cont->vc_dtx_active_hdl, &kiov, &riov);
+		if (rc == -DER_NONEXIST)
+			/* The DTX has been aborted by race, notify the RPC
+			 * sponsor to retry via returning -DER_INPROGRESS.
+			 */
+			return dtx_inprogress(dtx, 1);
+
+		if (rc != 0)
+			return rc;
+
+		D_ASSERT(dtx == (struct vos_dtx_entry_df *)riov.iov_buf);
+	}
+
+	/* The caller has already started the PMDK transaction
+	 * and add the DTX into the PMDK transaction.
+	 */
+	dtx->te_state = DTX_ST_PREPARED;
+
+	if (dth->dth_non_rep) {
+		dth->dth_sync = 0;
+		rc = vos_dtx_commit_one(cont, &dth->dth_xid);
+		if (rc == 0)
+			dth->dth_ent = UMMID_NULL;
+		else
+			D_ERROR(DF_UOID" fail to commit for "DF_DTI" rc = %d\n",
+				DP_UOID(dtx->te_oid), DP_DTI(&dtx->te_xid), rc);
+	}
+
+	return rc;
+}
+
 int
 vos_dtx_begin(struct daos_tx_id *dti, daos_unit_oid_t *oid, daos_key_t *dkey,
 	      daos_handle_t coh, daos_epoch_t epoch, uint32_t pm_ver,
@@ -762,8 +1289,29 @@ vos_dtx_end(struct daos_tx_handle *dth, int result, bool leader)
 	D_ASSERT(cont != NULL);
 
 	if (leader) {
-		if (dth->dth_sync)
-			D_GOTO(out, result = DTX_ACT_COMMIT_SYNC);
+		if (!UMMID_IS_NULL(dth->dth_ent)) {
+			struct vos_dtx_entry_df *dtx;
+			int			 rc;
+
+			dtx = umem_id2ptr(&cont->vc_pool->vp_umm, dth->dth_ent);
+			if (dtx->te_flags & DTX_EF_SHARES ||
+			    dtx->te_dkey_hash[0] == 0) {
+				/* If some DTXs share something (object/key),
+				 * then synchronously commit the DTX that
+				 * becomes committable to avoid visibility
+				 * trouble.
+				 */
+				dth->dth_sync = 1;
+				D_GOTO(out, result = DTX_ACT_COMMIT_SYNC);
+			}
+
+			rc = vos_dtx_add_cos(vos_cont2hdl(cont), &dth->dth_oid,
+					&dth->dth_xid, dtx->te_dkey_hash[0],
+					dtx->te_intent == DAOS_INTENT_PUNCH ?
+					true : false);
+			if (rc != 0)
+				D_GOTO(out, result = rc);
+		}
 
 		if (cont->vc_dtx_committable_count > DTX_THRESHOLD_COUNT)
 			D_GOTO(out, result = DTX_ACT_COMMIT_ASYNC);
@@ -829,6 +1377,18 @@ vos_dtx_check_committable(daos_handle_t coh, daos_unit_oid_t *oid,
 	return rc;
 }
 
+void
+vos_dtx_commit_internal(struct vos_container *cont, struct daos_tx_id *dtis,
+			int count)
+{
+	int	i;
+
+	for (i = 0; i < count; i++)
+		vos_dtx_commit_one(cont, &dtis[i]);
+
+	cont->vc_dtx_time_last_commit = time(NULL);
+}
+
 int
 vos_dtx_commit(daos_handle_t coh, struct daos_tx_id *dtis, int count)
 {
@@ -843,14 +1403,22 @@ vos_dtx_commit(daos_handle_t coh, struct daos_tx_id *dtis, int count)
 	/* Commit multiple DTXs via single PMDK transaction. */
 	rc = umem_tx_begin(umm, vos_txd_get());
 	if (rc == 0) {
-		int	i;
-
-		for (i = 0; i < count; i++)
-			vos_dtx_commit_one(cont, &dtis[i]);
-
-		cont->vc_dtx_time_last_commit = time(NULL);
+		vos_dtx_commit_internal(cont, dtis, count);
 		umem_tx_commit(umm);
 	}
+
+	return rc;
+}
+
+int
+vos_dtx_abort_internal(struct vos_container *cont, struct daos_tx_id *dtis,
+		       int count, bool force)
+{
+	int	rc = 0;
+	int	i;
+
+	for (i = 0; rc == 0 && i < count; i++)
+		rc = vos_dtx_abort_one(cont, &dtis[i], force);
 
 	return rc;
 }
@@ -861,7 +1429,6 @@ vos_dtx_abort(daos_handle_t coh, struct daos_tx_id *dtis, int count, bool force)
 	struct vos_container	*cont;
 	struct umem_instance	*umm;
 	int			 rc;
-	int			 i;
 
 	cont = vos_hdl2cont(coh);
 	D_ASSERT(cont != NULL);
@@ -869,9 +1436,10 @@ vos_dtx_abort(daos_handle_t coh, struct daos_tx_id *dtis, int count, bool force)
 	umm = &cont->vc_pool->vp_umm;
 	/* Abort multiple DTXs via single PMDK transaction. */
 	rc = umem_tx_begin(umm, vos_txd_get());
-	for (i = 0; rc == 0 && i < count; i++)
-		rc = vos_dtx_abort_one(cont, &dtis[i], force);
+	if (rc != 0)
+		return rc;
 
+	rc = vos_dtx_abort_internal(cont, dtis, count, force);
 	if (rc == 0)
 		umem_tx_commit(umm);
 	else
@@ -917,7 +1485,6 @@ vos_dtx_aggregate(daos_handle_t coh)
 		    now - dtx->te_sec <= DTX_AGGREGATION_THRESHOLD_TIME)
 			break;
 
-		umem_tx_add_ptr(umm, dtx, sizeof(*dtx));
 		daos_iov_set(&kiov, &dtx->te_xid, sizeof(dtx->te_xid));
 		rc = dbtree_delete(cont->vc_dtx_committed_hdl, &kiov, &ummid);
 		D_ASSERT(rc == 0);

--- a/src/vos/vos_internal.h
+++ b/src/vos/vos_internal.h
@@ -162,6 +162,7 @@ struct vos_imem_strts {
 struct vos_imem_strts		*vsa_imems_inst;
 struct bio_xs_context		*vsa_xsctxt_inst;
 struct umem_tx_stage_data	 vsa_txd_inst;
+struct daos_tx_handle		*vsa_dth;
 bool vsa_nvme_init;
 
 static inline struct bio_xs_context *
@@ -217,9 +218,22 @@ extern struct vos_iter_ops vos_dtx_iter_ops;
 /** VOS thread local storage structure */
 struct vos_tls {
 	/* in-memory structures TLS instance */
-	struct vos_imem_strts		vtl_imems_inst;
+	struct vos_imem_strts		 vtl_imems_inst;
 	/* PMDK transaction stage callback data */
-	struct umem_tx_stage_data	vtl_txd;
+	struct umem_tx_stage_data	 vtl_txd;
+	/** XXX: The DTX handle.
+	 *
+	 *	 Transferring DTX handle via TLS can avoid much changing
+	 *	 of existing functions' interfaces, and avoid the corner
+	 *	 cases that someone may miss to set the DTX handle when
+	 *	 operate related tree.
+	 *
+	 *	 But honestly, it is some hack to pass the DTX handle via
+	 *	 the TLS. It requires that there is no CPU yield during the
+	 *	 processing. Otherwise, the vtl_dth may be changed by other
+	 *	 ULTs. The user needs to guarantee that by itself.
+	 */
+	struct daos_tx_handle		*vtl_dth;
 };
 
 static inline struct vos_tls *
@@ -260,6 +274,30 @@ vos_txd_get(void)
 	return &vsa_txd_inst;
 #else
 	return &(vos_tls_get()->vtl_txd);
+#endif
+}
+
+static inline struct daos_tx_handle *
+vos_dth_get(void)
+{
+#ifdef VOS_STANDALONE
+	return vsa_dth;
+#else
+	return vos_tls_get()->vtl_dth;
+#endif
+}
+
+static inline void
+vos_dth_set(struct daos_tx_handle *dth)
+{
+#ifdef VOS_STANDALONE
+	D_ASSERT(dth == NULL || vsa_dth == NULL);
+
+	vsa_dth = dth;
+#else
+	D_ASSERT(dth == NULL || vos_tls_get()->vtl_dth == NULL);
+
+	vos_tls_get()->vtl_dth = dth;
 #endif
 }
 
@@ -440,6 +478,51 @@ vos_dtx_table_destroy(struct vos_pool *pool, struct vos_dtx_table_df *dtab_df);
  */
 int
 vos_dtx_table_register(void);
+
+
+/**
+ * Register the record (to be modified) to the DTX entry.
+ *
+ * \param umm		[IN]	Instance of an unified memory class.
+ * \param record	[IN]	Address of the record (in SCM) to be modified.
+ * \param type		[IN]	The record type, see vos_dtx_record_types.
+ * \param flags		[IN]	The record flags, see vos_dtx_record_flags.
+ *
+ * \return		0 on success and negative on failure.
+ */
+int
+vos_dtx_register_record(struct umem_instance *umm, umem_id_t record,
+			uint32_t type, uint32_t flags);
+
+/**
+ * Degister the record from the DTX entry.
+ *
+ * \param umm		[IN]	Instance of an unified memory class.
+ * \param entry		[IN]	The DTX entry address.
+ * \param record	[IN]	Address of the record to be degistered.
+ * \param type		[IN]	The record type, vos_dtx_record_types.
+ */
+void
+vos_dtx_degister_record(struct umem_instance *umm,
+			umem_id_t entry, umem_id_t record, uint32_t type);
+
+/**
+ * Mark the DTX as prepared locally.
+ *
+ * \param dth	[IN]	Pointer to the DTX handle.
+ *
+ * \return		0 on success and negative on failure.
+ */
+int
+vos_dtx_prepared(struct daos_tx_handle *dth);
+
+void
+vos_dtx_commit_internal(struct vos_container *cont, struct daos_tx_id *dtis,
+			int count);
+
+int
+vos_dtx_abort_internal(struct vos_container *cont, struct daos_tx_id *dtis,
+		       int count, bool force);
 
 /**
  * Register dbtree class for DTX CoS, it is called within vos_init().

--- a/src/vos/vos_tree.c
+++ b/src/vos/vos_tree.c
@@ -28,6 +28,7 @@
 #define D_LOGFAC	DD_FAC(vos)
 
 #include <daos/btree.h>
+#include <daos/mem.h>
 #include <daos_srv/vos.h>
 #include <daos_api.h> /* For ofeat bits */
 #include "vos_internal.h"
@@ -422,8 +423,13 @@ ktr_rec_alloc(struct btr_instance *tins, daos_iov_t *key_iov,
 			D_GOTO(out, rc);
 		}
 	}
-	ktr_rec_store(tins, rec, kbund, rbund);
- out:
+
+	rc = vos_dtx_register_record(&tins->ti_umm, rec->rec_mmid,
+				     DTX_RT_KEY, 0);
+	if (rc == 0)
+		ktr_rec_store(tins, rec, kbund, rbund);
+
+out:
 	if (!daos_handle_is_inval(btr_oh))
 		dbtree_close(btr_oh);
 
@@ -446,6 +452,14 @@ ktr_rec_free(struct btr_instance *tins, struct btr_record *rec, void *args)
 
 	krec = vos_rec2krec(tins, rec);
 	umem_attr_get(&tins->ti_umm, &uma);
+
+	vos_dtx_degister_record(&tins->ti_umm, krec->kr_dtx,
+				rec->rec_mmid, DTX_RT_KEY);
+	if (krec->kr_dtx_shares > 0) {
+		D_ERROR("There are some unknown DTXs (%d) share the key rec\n",
+			krec->kr_dtx_shares);
+		return -DER_BUSY;
+	}
 
 	/* has subtree? */
 	if (krec->kr_btr.tr_order) {
@@ -676,6 +690,14 @@ svt_rec_alloc(struct btr_instance *tins, daos_iov_t *key_iov,
 		rbund->rb_mmid = UMMID_NULL; /* taken over by btree */
 	}
 
+	rc = vos_dtx_register_record(&tins->ti_umm, rec->rec_mmid,
+				     DTX_RT_SVT, 0);
+	if (rc != 0)
+		/* It is unnecessary to free the PMEM that will be dropped
+		 * automatically when the PMDK transaction is aborted.
+		 */
+		return rc;
+
 	rc = svt_rec_store(tins, rec, kbund, rbund);
 	return rc;
 }
@@ -690,6 +712,8 @@ svt_rec_free(struct btr_instance *tins, struct btr_record *rec,
 	if (UMMID_IS_NULL(rec->rec_mmid))
 		return 0;
 
+	vos_dtx_degister_record(&tins->ti_umm, irec->ir_dtx,
+				rec->rec_mmid, DTX_RT_SVT);
 	if (args != NULL) {
 		*(umem_id_t *)args = rec->rec_mmid;
 		rec->rec_mmid = UMMID_NULL; /** taken over by user */
@@ -931,6 +955,7 @@ key_tree_punch(struct vos_object *obj, daos_handle_t toh, daos_iov_t *key_iov,
 	struct vos_key_bundle	*kbund;
 	struct vos_rec_bundle	*rbund;
 	struct vos_krec_df	*krec;
+	umem_id_t		 addr;
 	int			 rc;
 	bool			 replay = (flags & VOS_OF_REPLAY_PC);
 
@@ -954,6 +979,7 @@ key_tree_punch(struct vos_object *obj, daos_handle_t toh, daos_iov_t *key_iov,
 	kbund = iov2key_bundle(key_iov);
 	rbund = iov2rec_bundle(val_iov);
 	krec = rbund->rb_krec;
+	addr = umem_ptr2id(vos_obj2umm(obj), krec);
 
 	if (krec->kr_bmap & KREC_BF_PUNCHED &&
 	    krec->kr_latest == kbund->kb_epoch) {
@@ -971,10 +997,10 @@ key_tree_punch(struct vos_object *obj, daos_handle_t toh, daos_iov_t *key_iov,
 	/* PROBE_EQ == insert in this case */
 	rc = dbtree_upsert(toh, BTR_PROBE_EQ, DAOS_INTENT_PUNCH, key_iov,
 			   val_iov);
-	if (rc)
+	if (rc != 0 || replay)
 		return rc;
 
-	if (!replay) { /* delete the max epoch */
+	if (vos_dth_get() == NULL) { /* delete the max epoch */
 		struct umem_instance	*umm = vos_obj2umm(obj);
 		struct vos_krec_df	*krec2;
 		struct vos_key_bundle	 kbund2;
@@ -1001,6 +1027,9 @@ key_tree_punch(struct vos_object *obj, daos_handle_t toh, daos_iov_t *key_iov,
 		rc = dbtree_delete(toh, &tmp, NULL);
 		if (rc)
 			D_ERROR("Failed to delete: %d\n", rc);
+	} else {
+		rc = vos_dtx_register_record(btr_hdl2umm(toh), addr, DTX_RT_KEY,
+					     DTX_RF_EXCHANGE_SRC);
 	}
 	return rc;
 }


### PR DESCRIPTION
Mainly include the following three interfaces:

1. vos_dtx_register_record()
   Register the data record (to be modified) to the DTX entry.
   The registeration will store new DTX record (any may plus
   the new DTX entry if it is the first DTX record) in the SCM,
   the storing of DTX information will share the same PMDK
   transaction as related data modification, no extra PMDK
   transaction.

2. vos_dtx_degister_record()
   Degister the record from the DTX entry. That is usually
   used when related data record is removed from the tree.

3. vos_dtx_prepared()
   Mark the DTX as prepared locally. The DTX state change
   will cause SCM modification that will share the same
   PMDK transaction as related data modification, no extra
   PMDK transaction.

Signed-off-by: Fan Yong <fan.yong@intel.com>
Change-Id: I505e08802c0e02b1f4dd34475503211b7b46324c