### PR TITLE
DAOS-1441 dtx: data record visibility with DTX state

### DIFF
--- a/src/common/btree.c
+++ b/src/common/btree.c
@@ -48,6 +48,8 @@ enum btr_probe_rc {
 	PROBE_RC_NONE,
 	PROBE_RC_OK,
 	PROBE_RC_ERR,
+	PROBE_RC_INPROGRESS,
+	PROBE_RC_UNAVAILABLE	= PROBE_RC_UNKNOWN,
 };
 
 /**
@@ -916,6 +918,63 @@ btr_root_grow(struct btr_context *tcx, TMMID(struct btr_node) mmid_left,
 	return 0;
 }
 
+struct btr_check_alb {
+	TMMID(struct btr_node)	nd_mmid;
+	int			at;
+	uint32_t		intent;
+};
+
+static int
+btr_check_availability(struct btr_context *tcx, struct btr_check_alb *alb)
+{
+	struct btr_record	*rec;
+	int			 rc;
+
+	if (btr_ops(tcx)->to_check_availability == NULL)
+		return PROBE_RC_OK;
+
+	if (TMMID_IS_NULL(alb->nd_mmid)) { /* compare the leaf trace */
+		struct btr_trace *trace = &tcx->tc_traces[BTR_TRACE_MAX - 1];
+
+		alb->nd_mmid = trace->tr_node;
+		alb->at = trace->tr_at;
+	}
+
+	if (!btr_node_is_leaf(tcx, alb->nd_mmid))
+		return PROBE_RC_OK;
+
+	rec = btr_node_rec_at(tcx, alb->nd_mmid, alb->at);
+	rc = btr_ops(tcx)->to_check_availability(&tcx->tc_tins, rec,
+						 alb->intent);
+	if (rc == -DER_INPROGRESS) /* Unceration */
+		return PROBE_RC_INPROGRESS;
+
+	if (rc < 0) /* Failure */
+		return PROBE_RC_ERR;
+
+	switch (rc) {
+	case ALB_AVAILABLE_DIRTY:
+		/* XXX: This case is mainly used for purge operation.
+		 *	There are some uncommitted modifications that
+		 *	may belong to some old crashed operations. We
+		 *	hope that the caller can make further check
+		 *	about whether can remove them from the system
+		 *	or not.
+		 *
+		 *	Currently, the main caller with purge intent
+		 *	is the aggregation. We need more handling
+		 *	for the case in the new aggregation logic.
+		 *	But before that, just make it fall through.
+		 */
+	case ALB_AVAILABLE_CLEAN:
+		return PROBE_RC_OK;
+	case ALB_UNAVAILABLE:
+	default:
+		/* Invisibile */
+		return PROBE_RC_UNAVAILABLE;
+	}
+}
+
 static void
 btr_node_insert_rec_only(struct btr_context *tcx, struct btr_trace *trace,
 			 struct btr_record *rec)
@@ -924,6 +983,7 @@ btr_node_insert_rec_only(struct btr_context *tcx, struct btr_trace *trace,
 	struct btr_record *rec_b;
 	struct btr_node   *nd;
 	bool		   leaf;
+	bool		   reuse = false;
 	char		   sbuf[BTR_PRINT_BUF];
 
 	/* NB: assume trace->tr_node has been added to TX */
@@ -938,11 +998,28 @@ btr_node_insert_rec_only(struct btr_context *tcx, struct btr_trace *trace,
 	rec_b = btr_node_rec_at(tcx, trace->tr_node, trace->tr_at + 1);
 
 	nd = btr_mmid2ptr(tcx, trace->tr_node);
-	if (trace->tr_at != nd->tn_keyn)
-		btr_rec_move(tcx, rec_b, rec_a, nd->tn_keyn - trace->tr_at);
+	if (trace->tr_at != nd->tn_keyn) {
+		struct btr_check_alb	alb;
+		int			rc;
+
+		alb.nd_mmid = trace->tr_node;
+		alb.at = trace->tr_at;
+		alb.intent = DAOS_INTENT_CHECK;
+		rc = btr_check_availability(tcx, &alb);
+		if (rc == PROBE_RC_UNAVAILABLE)
+			reuse = true;
+	}
+
+	if (reuse) {
+		btr_rec_free(tcx, rec_a, NULL);
+	} else {
+		if (trace->tr_at != nd->tn_keyn)
+			btr_rec_move(tcx, rec_b, rec_a,
+				     nd->tn_keyn - trace->tr_at);
+		nd->tn_keyn++;
+	}
 
 	btr_rec_copy(tcx, rec_a, rec, 1);
-	nd->tn_keyn++;
 }
 
 /**
@@ -1168,7 +1245,9 @@ btr_probe(struct btr_context *tcx, dbtree_probe_opc_t probe_opc,
 	int			 rc;
 	int			 cmp;
 	int			 level;
+	int			 saved = -1;
 	bool			 next_level;
+	struct btr_check_alb	 alb;
 	struct btr_trace	 traces[BTR_TRACE_MAX];
 	struct btr_trace	*trace = NULL;
 	TMMID(struct btr_node)	 nd_mmid;
@@ -1268,60 +1347,123 @@ btr_probe(struct btr_context *tcx, dbtree_probe_opc_t probe_opc,
 		D_ASSERTF(cmp == BTR_CMP_EQ, "Hash collision is unsupported\n");
 	}
 
+	alb.nd_mmid = nd_mmid;
+	alb.at = at;
+	alb.intent = intent;
+
+again:
 	switch (probe_opc & ~BTR_PROBE_MATCHED) {
 	default:
 		D_ASSERT(0);
 	case BTR_PROBE_FIRST:
+		do {
+			alb.nd_mmid = tcx->tc_trace[level].tr_node;
+			alb.at = tcx->tc_trace[level].tr_at;
+			rc = btr_check_availability(tcx, &alb);
+		} while (rc == PROBE_RC_UNAVAILABLE && btr_probe_next(tcx));
+
+		if (rc == PROBE_RC_UNAVAILABLE)
+			rc = PROBE_RC_NONE;
+		goto out;
+
 	case BTR_PROBE_LAST:
-		rc = PROBE_RC_OK;
+		do {
+			alb.nd_mmid = tcx->tc_trace[level].tr_node;
+			alb.at = tcx->tc_trace[level].tr_at;
+			rc = btr_check_availability(tcx, &alb);
+		} while (rc == PROBE_RC_UNAVAILABLE && btr_probe_prev(tcx));
+
+		if (rc == PROBE_RC_UNAVAILABLE)
+			rc = PROBE_RC_NONE;
 		goto out;
 
 	case BTR_PROBE_EQ:
 		if (cmp == BTR_CMP_EQ) {
-			rc = PROBE_RC_OK;
-			goto out;
+			rc = btr_check_availability(tcx, &alb);
+			if (rc != PROBE_RC_UNAVAILABLE)
+				goto out;
+
+			/* Current pos is unavailable, it can be used for the
+			 * follow-on insert if applicable.
+			 */
+		} else {
+			/* Point at the first key which is larger than the
+			 * probed one, this if for the follow-on insert if
+			 * applicable.
+			 */
+			btr_trace_set(tcx, level, nd_mmid,
+				      at + !(cmp & BTR_CMP_GT));
 		}
-		/* point at the first key which is larger than the probed one,
-		 * this if for follow-on insert if applicable.
-		 */
-		btr_trace_set(tcx, level, nd_mmid, at + !(cmp & BTR_CMP_GT));
+
 		rc = PROBE_RC_NONE;
 		goto out;
 
 	case BTR_PROBE_GE:
 		if (cmp == BTR_CMP_EQ) {
-			rc = PROBE_RC_OK;
-			goto out;
+			rc = btr_check_availability(tcx, &alb);
+			if (rc != PROBE_RC_UNAVAILABLE)
+				goto out;
+
+			/* Current pos is unavailable, it can be used for the
+			 * follow-on insert if applicable.
+			 */
+			if (saved == -1)
+				saved = at;
 		}
 		/* fall through */
 	case BTR_PROBE_GT:
-		if (cmp & BTR_CMP_GT)
-			break;
+		if (cmp & BTR_CMP_GT) {
+			rc = btr_check_availability(tcx, &alb);
+			if (rc != PROBE_RC_UNAVAILABLE) {
+				if (rc == PROBE_RC_OK)
+					break;
 
-		/* point at the next position in the current leaf node, this is
-		 * for follow-on insert if applicable.
-		 */
-		at += 1;
+				goto out;
+			}
+
+			/* Current pos is unavailable, it can be used for the
+			 * follow-on insert if applicable.
+			 */
+			if (saved == -1)
+				saved = at;
+		} else {
+			/* Point at the next position in the current leaf node,
+			 * this is for the follow-on insert if applicable.
+			 */
+			if (saved == -1)
+				saved = at + 1;
+		}
+
 		/* backup the probe trace because probe_next will change it */
-		memcpy(traces, tcx->tc_trace, sizeof(*trace) * tcx->tc_depth);
+		if (trace == NULL)
+			memcpy(traces, tcx->tc_trace,
+			       sizeof(*trace) * tcx->tc_depth);
 		if (btr_probe_next(tcx)) {
 			trace = traces;
 			cmp = BTR_CMP_UNKNOWN;
 			break;
 		}
-		btr_trace_set(tcx, level, nd_mmid, at);
+		btr_trace_set(tcx, level, nd_mmid, saved);
 		rc = PROBE_RC_NONE;
 		goto out;
 
 	case BTR_PROBE_LE:
 		if (cmp == BTR_CMP_EQ) {
-			rc = PROBE_RC_OK;
-			goto out;
+			rc = btr_check_availability(tcx, &alb);
+			if (rc != PROBE_RC_UNAVAILABLE)
+				goto out;
 		}
 		/* fall through */
 	case BTR_PROBE_LT:
-		if (cmp & BTR_CMP_LT)
-			break;
+		if (cmp & BTR_CMP_LT) {
+			rc = btr_check_availability(tcx, &alb);
+			if (rc != PROBE_RC_UNAVAILABLE) {
+				if (rc == PROBE_RC_OK)
+					break;
+
+				goto out;
+			}
+		}
 
 		if (btr_probe_prev(tcx)) {
 			cmp = BTR_CMP_UNKNOWN;
@@ -1331,8 +1473,12 @@ btr_probe(struct btr_context *tcx, dbtree_probe_opc_t probe_opc,
 		goto out;
 	}
 
-	if (cmp == BTR_CMP_UNKNOWN) /* position changed, compare again */
+	if (cmp == BTR_CMP_UNKNOWN) {/* position changed, compare again */
 		cmp = btr_cmp(tcx, BTR_NODE_NULL, -1, hkey, key);
+		alb.nd_mmid = BTR_NODE_NULL;
+		alb.at = -1;
+		goto again;
+	}
 
 	D_ASSERT(cmp != BTR_CMP_EQ);
 	if (cmp & BTR_CMP_MATCHED) {
@@ -1342,9 +1488,11 @@ btr_probe(struct btr_context *tcx, dbtree_probe_opc_t probe_opc,
 			rc = PROBE_RC_NONE;
 			/* restore the probe trace for follow-on insert. */
 			if (trace) {
+				D_ASSERT(saved != -1);
+
 				memcpy(tcx->tc_trace, trace,
 				       tcx->tc_depth * sizeof(*trace));
-				btr_trace_set(tcx, level, nd_mmid, at);
+				btr_trace_set(tcx, level, nd_mmid, saved);
 			}
 		} else {
 			/* GT/GE/LT/LE without MATCHED */
@@ -1521,6 +1669,10 @@ dbtree_fetch(daos_handle_t toh, dbtree_probe_opc_t opc, uint32_t intent,
 		return -DER_NO_HDL;
 
 	rc = btr_probe_key(tcx, opc, intent, key);
+	if (rc == PROBE_RC_INPROGRESS) {
+		D_DEBUG(DB_TRACE, "Target is in some uncommitted DTX.\n");
+		return -DER_INPROGRESS;
+	}
 	if (rc == PROBE_RC_NONE || rc == PROBE_RC_ERR) {
 		D_DEBUG(DB_TRACE, "Cannot find key\n");
 		return -DER_NONEXIST;
@@ -1669,6 +1821,9 @@ btr_upsert(struct btr_context *tcx, dbtree_probe_opc_t probe_opc,
 			"operation.\n");
 		rc = -DER_INVAL;
 		break;
+	case PROBE_RC_INPROGRESS:
+		D_DEBUG(DB_TRACE, "The target is in some uncommitted DTX.");
+		return -DER_INPROGRESS;
 	}
 
 	tcx->tc_probe_rc = PROBE_RC_UNKNOWN; /* path changed */
@@ -2471,6 +2626,11 @@ dbtree_delete(daos_handle_t toh, daos_iov_t *key,
 		return -DER_NO_HDL;
 
 	rc = btr_probe_key(tcx, BTR_PROBE_EQ, DAOS_INTENT_PUNCH, key);
+	if (rc == PROBE_RC_INPROGRESS) {
+		D_DEBUG(DB_TRACE, "Target is in some uncommitted DTX.\n");
+		return -DER_INPROGRESS;
+	}
+
 	if (rc != PROBE_RC_OK) {
 		D_DEBUG(DB_TRACE, "Cannot find key\n");
 		return -DER_NONEXIST;
@@ -3041,6 +3201,11 @@ dbtree_iter_probe(daos_handle_t ih, dbtree_probe_opc_t opc, uint32_t intent,
 		rc = btr_probe(tcx, opc, intent, key, hkey);
 	}
 
+	if (rc == PROBE_RC_INPROGRESS) {
+		itr->it_state = BTR_ITR_FINI;
+		return -DER_INPROGRESS;
+	}
+
 	if (rc == PROBE_RC_NONE || rc == PROBE_RC_ERR) {
 		itr->it_state = BTR_ITR_FINI;
 		return -DER_NONEXIST;
@@ -3105,6 +3270,58 @@ int
 dbtree_iter_prev(daos_handle_t ih)
 {
 	return btr_iter_move(ih, false);
+}
+
+static int
+btr_iter_move_with_intent(daos_handle_t ih, uint32_t intent, bool forward)
+{
+	struct btr_context	*tcx;
+	struct btr_trace	*trace;
+	struct btr_iterator	*itr;
+	struct btr_check_alb	 alb;
+	int			 rc;
+
+	tcx = btr_hdl2tcx(ih);
+	if (tcx == NULL)
+		return -DER_NO_HDL;
+
+	itr = &tcx->tc_itr;
+	alb.intent = intent;
+
+again:
+	rc = btr_iter_move(ih, forward);
+	if (rc != 0)
+		return rc;
+
+	trace = &tcx->tc_trace[tcx->tc_depth - 1];
+	alb.nd_mmid = trace->tr_node;
+	alb.at = trace->tr_at;
+	rc = btr_check_availability(tcx, &alb);
+	switch (rc) {
+	case PROBE_RC_UNAVAILABLE:
+		goto again;
+	case PROBE_RC_INPROGRESS:
+		itr->it_state = BTR_ITR_FINI;
+		return -DER_INPROGRESS;
+	case PROBE_RC_OK:
+		return 0;
+	case PROBE_RC_ERR:
+	default:
+		itr->it_state = BTR_ITR_FINI;
+		return -DER_INVAL;
+	}
+}
+
+int
+dbtree_iter_next_with_intent(daos_handle_t ih, uint32_t intent)
+{
+	return btr_iter_move_with_intent(ih, intent, true);
+}
+
+int
+dbtree_iter_prev_with_intent(daos_handle_t ih, uint32_t intent)
+{
+	return btr_iter_move_with_intent(ih, intent, false);
 }
 
 /**

--- a/src/include/daos/btree.h
+++ b/src/include/daos/btree.h
@@ -481,6 +481,30 @@ typedef struct {
 	 */
 	int		(*to_node_tx_add)(struct btr_instance *tins,
 					  TMMID(struct btr_node) nd_mmid);
+	/**
+	 * Optional:
+	 * Check whether the given record is available to outside or not.
+	 *
+	 * \param tins	[IN]	Tree instance which contains the root mmid
+	 *			and memory class etc.
+	 * \param rec	[IN]	Record to be checked.
+	 * \parem intent [IN]	The intent for why check the record.
+	 *
+	 * \a return	ALB_AVAILABLE_DIRTY	The target is available but with
+	 *					some uncommitted modification
+	 *					or garbage, need cleanup.
+	 *		ALB_AVAILABLE_CLEAN	The target is available,
+	 *					no pending modification.
+	 *		ALB_UNAVAILABLE		The target is unavailable.
+	 *		-DER_INPROGRESS		If the target record is in
+	 *					some uncommitted DTX, the caller
+	 *					needs to retry related operation
+	 *					some time later.
+	 *		Other negative values on error.
+	 */
+	int		(*to_check_availability)(struct btr_instance *tins,
+						 struct btr_record *rec,
+						 uint32_t intent);
 } btr_ops_t;
 
 /**
@@ -586,6 +610,8 @@ int dbtree_iter_probe(daos_handle_t ih, dbtree_probe_opc_t opc,
 		      uint32_t intent, daos_iov_t *key, daos_anchor_t *anchor);
 int dbtree_iter_next(daos_handle_t ih);
 int dbtree_iter_prev(daos_handle_t ih);
+int dbtree_iter_next_with_intent(daos_handle_t ih, uint32_t intent);
+int dbtree_iter_prev_with_intent(daos_handle_t ih, uint32_t intent);
 int dbtree_iter_fetch(daos_handle_t ih, daos_iov_t *key,
 		      daos_iov_t *val, daos_anchor_t *anchor);
 int dbtree_iter_delete(daos_handle_t ih, void *args);

--- a/src/include/daos/dtx.h
+++ b/src/include/daos/dtx.h
@@ -68,7 +68,16 @@ enum daos_ops_intent {
 	DAOS_INTENT_UPDATE	= 2,	/* write/insert */
 	DAOS_INTENT_PUNCH	= 3,	/* punch/delete */
 	DAOS_INTENT_REBUILD	= 4,	/* for rebuild related scan */
-	DAOS_INTENT_PROBE	= 5,	/* check aborted or not */
+	DAOS_INTENT_CHECK	= 5,	/* check aborted or not */
+};
+
+enum daos_dtx_alb {
+	/* unavailable case */
+	ALB_UNAVAILABLE		= 0,
+	/* available, no (or not care) pending modification */
+	ALB_AVAILABLE_CLEAN	= 1,
+	/* available but with dirty modification or garbage */
+	ALB_AVAILABLE_DIRTY	= 2,
 };
 
 #endif /* __DAOS_DTX_H__ */

--- a/src/include/daos_srv/evtree.h
+++ b/src/include/daos_srv/evtree.h
@@ -247,6 +247,8 @@ struct evt_entry {
 	bio_addr_t			en_addr;
 	/** update epoch of extent */
 	daos_epoch_t			en_epoch;
+	/** The DTX entry address */
+	umem_id_t			en_dtx;
 };
 
 struct evt_list_entry {
@@ -258,7 +260,7 @@ struct evt_list_entry {
 	struct evt_entry	 le_ent;
 };
 
-#define EVT_EMBEDDED_NR 32
+#define EVT_EMBEDDED_NR 16
 /**
  * list head of \a evt_entry, it contains a few embedded entries to support
  * lightweight allocation of entries.

--- a/src/include/daos_srv/vos.h
+++ b/src/include/daos_srv/vos.h
@@ -33,8 +33,18 @@
 
 #include <daos/common.h>
 #include <daos_types.h>
+#include <daos/placement.h>
 #include <daos_srv/dtx_srv.h>
 #include <daos_srv/vos_types.h>
+
+/**
+ * Register the function for checking whether the replica is leader or not.
+ *
+ * \param checker	[IN]	The specified function for checking leader.
+ */
+void
+vos_dtx_register_check_leader(int (*checker)(uuid_t, daos_unit_oid_t *,
+			      uint32_t, struct pl_obj_layout **));
 
 /**
  * Prepare the DTX handle in DRAM.

--- a/src/object/srv_mod.c
+++ b/src/object/srv_mod.c
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2016 Intel Corporation.
+ * (C) Copyright 2016-2019 Intel Corporation.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,6 +26,8 @@
 #define D_LOGFAC	DD_FAC(object)
 
 #include <daos_srv/daos_server.h>
+#include <daos_srv/vos.h>
+#include <daos_srv/pool.h>
 #include <daos/rpc.h>
 #include "obj_rpc.h"
 #include "obj_internal.h"
@@ -35,6 +37,7 @@ obj_mod_init(void)
 {
 	dss_abt_pool_choose_cb_register(DAOS_OBJ_MODULE,
 					ds_obj_abt_pool_choose_cb);
+	vos_dtx_register_check_leader(ds_pool_check_leader);
 	return 0;
 }
 

--- a/src/vos/evt_iter.c
+++ b/src/vos/evt_iter.c
@@ -215,15 +215,16 @@ evt_iter_intent(struct evt_iterator *iter)
 static int
 evt_iter_move(struct evt_context *tcx, struct evt_iterator *iter)
 {
-	struct evt_entry	*entry;
-	struct evt_rect		*rect;
-	struct evt_trace	*trace;
 	uint32_t		 intent;
 	int			 rc = 0;
+	int			 rc1;
 	bool			 found;
 
+	intent = evt_iter_intent(iter);
 	if (evt_iter_is_sorted(iter)) {
 		for (;;) {
+			struct evt_entry	*entry;
+
 			iter->it_index +=
 				iter->it_forward ? 1 : -1;
 			if (iter->it_index < 0 ||
@@ -231,22 +232,47 @@ evt_iter_move(struct evt_context *tcx, struct evt_iterator *iter)
 				iter->it_state = EVT_ITER_FINI;
 				D_GOTO(out, rc = -DER_NONEXIST);
 			}
-			if (iter->it_options & EVT_ITER_SKIP_HOLES) {
-				entry = evt_ent_array_get(&iter->it_entries,
-							  iter->it_index);
-				if (bio_addr_is_hole(&entry->en_addr))
-					continue;
-			}
+
+			entry = evt_ent_array_get(&iter->it_entries,
+						  iter->it_index);
+			rc1 = evt_dtx_check_availability(tcx, entry->en_dtx,
+							 intent);
+			if (rc1 < 0)
+				return rc1;
+
+			if (rc1 == ALB_UNAVAILABLE)
+				continue;
+
+			if (iter->it_options & EVT_ITER_SKIP_HOLES &&
+			    bio_addr_is_hole(&entry->en_addr))
+				continue;
+
 			break;
 		}
 		goto ready;
 	}
 
-	intent = evt_iter_intent(iter);
-	while ((found = evt_move_trace(tcx, intent))) {
-		trace = &tcx->tc_trace[tcx->tc_depth - 1];
-		rect  = evt_nd_off_rect_at(tcx, trace->tr_node, trace->tr_at);
+	while ((found = evt_move_trace(tcx))) {
+		struct evt_trace	*trace;
+		struct evt_rect		*rect;
+		struct evt_node		*nd;
 
+		trace = &tcx->tc_trace[tcx->tc_depth - 1];
+		nd = evt_off2node(tcx, trace->tr_node);
+		if (evt_node_is_leaf(tcx, nd)) {
+			struct evt_desc		*desc;
+
+			desc = evt_node_desc_at(tcx, nd, trace->tr_at);
+			rc1 = evt_dtx_check_availability(tcx, desc->dc_dtx,
+							 intent);
+			if (rc1 < 0)
+				return rc1;
+
+			if (rc1 == ALB_UNAVAILABLE)
+				continue;
+		}
+
+		rect  = evt_nd_off_rect_at(tcx, trace->tr_node, trace->tr_at);
 		if (evt_filter_rect(&iter->it_filter, rect, true))
 			continue;
 		break;

--- a/src/vos/evt_priv.h
+++ b/src/vos/evt_priv.h
@@ -385,9 +385,8 @@ struct evt_context *evt_hdl2tcx(daos_handle_t toh);
 
 /** Move the trace forward.
  * \param[IN]	tcx	The evtree context
- * \param IN]	intent	The operation intent
  */
-bool evt_move_trace(struct evt_context *tcx, uint32_t intent);
+bool evt_move_trace(struct evt_context *tcx);
 
 /** Get a pointer to the rectangle corresponding to an index in a tree node
  * \param[IN]	tcx	The evtree context
@@ -429,4 +428,64 @@ static inline struct evt_rect *evt_nd_off_rect_at(struct evt_context *tcx,
 void evt_entry_fill(struct evt_context *tcx, struct evt_node *node,
 		    unsigned int at, const struct evt_rect *rect_srch,
 		    struct evt_entry *entry);
+
+/**
+ * Check whether the EVT record is available or not.
+ * \param[IN]	tcx		The evtree context
+ * \param[IN]	entry		Address of the DTX to be checked.
+ * \param[IN]	intent		The operation intent
+ *
+ * \return	ALB_AVAILABLE_DIRTY	The target is available but with
+ *					some uncommitted modification
+ *					or garbage, need cleanup.
+ *		ALB_AVAILABLE_CLEAN	The target is available,
+ *					no pending modification.
+ *		ALB_UNAVAILABLE		The target is unavailable.
+ *		-DER_INPROGRESS		If the target record is in some
+ *					uncommitted DTX, the caller needs
+ *					to retry related operation some
+ *					time later.
+ *		Other negative values on error.
+ */
+int evt_dtx_check_availability(struct evt_context *tcx, umem_id_t entry,
+			       uint32_t intent);
+
+static inline bool
+evt_node_is_set(struct evt_context *tcx, struct evt_node *node,
+		unsigned int bits)
+{
+	return node->tn_flags & bits;
+}
+
+static inline bool
+evt_node_is_leaf(struct evt_context *tcx, struct evt_node *node)
+{
+	return evt_node_is_set(tcx, node, EVT_NODE_LEAF);
+}
+
+static inline bool
+evt_node_is_root(struct evt_context *tcx, struct evt_node *node)
+{
+	return evt_node_is_set(tcx, node, EVT_NODE_ROOT);
+}
+
+/** Return the rectangle at the offset of @at */
+static inline struct evt_node_entry *
+evt_node_entry_at(struct evt_context *tcx, struct evt_node *node,
+		  unsigned int at)
+{
+	return &node->tn_rec[at];
+}
+
+/** Return the data pointer at the offset of @at */
+static inline struct evt_desc *
+evt_node_desc_at(struct evt_context *tcx, struct evt_node *node,
+		 unsigned int at)
+{
+	struct evt_node_entry	*ne = evt_node_entry_at(tcx, node, at);
+
+	D_ASSERT(evt_node_is_leaf(tcx, node));
+
+	return evt_off2desc(tcx, ne->ne_child);
+}
 #endif /* __EVT_PRIV_H__ */

--- a/src/vos/vos_internal.h
+++ b/src/vos/vos_internal.h
@@ -479,6 +479,30 @@ vos_dtx_table_destroy(struct vos_pool *pool, struct vos_dtx_table_df *dtab_df);
 int
 vos_dtx_table_register(void);
 
+/**
+ * Check whether the record (to be accessible) is available to outside or not.
+ *
+ * \param umm		[IN]	Instance of an unified memory class.
+ * \param coh		[IN]	The container open handle.
+ * \param entry		[IN]	Address of the DTX to be checked.
+ * \param record	[IN]	Address of the record modified via the DTX.
+ * \param intent	[IN]	The request intent.
+ * \param type		[IN]	The record type, see vos_dtx_record_types.
+ *
+ * \return	positive value	If available to outside.
+ *		zero		If unavailable to outside.
+ *		-DER_INPROGRESS If the target record is in some
+ *				uncommitted DTX, the caller
+ *				needs to retry some time later.
+ *				Or the caller is not sure about whether
+ *				related DTX is committable or not, need
+ *				to check with leader replica.
+ *		negative value	For error cases.
+ */
+int
+vos_dtx_check_availability(struct umem_instance *umm, daos_handle_t coh,
+			   umem_id_t entry, umem_id_t record, uint32_t intent,
+			   uint32_t type);
 
 /**
  * Register the record (to be modified) to the DTX entry.

--- a/src/vos/vos_obj.c
+++ b/src/vos/vos_obj.c
@@ -395,7 +395,8 @@ key_iter_match_probe(struct vos_obj_iter *oiter)
 
 		case IT_OPC_NEXT:
 			/* move to the next tree record */
-			rc = dbtree_iter_next(oiter->it_hdl);
+			rc = dbtree_iter_next_with_intent(oiter->it_hdl,
+					vos_iter_intent(&oiter->it_iter));
 			if (rc)
 				goto out;
 			break;
@@ -429,7 +430,8 @@ key_iter_next(struct vos_obj_iter *oiter)
 {
 	int	rc;
 
-	rc = dbtree_iter_next(oiter->it_hdl);
+	rc = dbtree_iter_next_with_intent(oiter->it_hdl,
+					  vos_iter_intent(&oiter->it_iter));
 	if (rc)
 		D_GOTO(out, rc);
 

--- a/src/vos/vos_obj_index.c
+++ b/src/vos/vos_obj_index.c
@@ -215,15 +215,28 @@ oi_rec_update(struct btr_instance *tins, struct btr_record *rec,
 	return 0;
 }
 
+static int
+oi_check_availability(struct btr_instance *tins, struct btr_record *rec,
+		      uint32_t intent)
+{
+	struct vos_obj_df	*obj;
+
+	obj = umem_id2ptr(&tins->ti_umm, rec->rec_mmid);
+	return vos_dtx_check_availability(&tins->ti_umm, tins->ti_coh,
+					  obj->vo_dtx, rec->rec_mmid,
+					  intent, DTX_RT_OBJ);
+}
+
 static btr_ops_t oi_btr_ops = {
-	.to_rec_msize	= oi_rec_msize,
-	.to_hkey_size	= oi_hkey_size,
-	.to_hkey_gen	= oi_hkey_gen,
-	.to_hkey_cmp	= oi_hkey_cmp,
-	.to_rec_alloc	= oi_rec_alloc,
-	.to_rec_free	= oi_rec_free,
-	.to_rec_fetch	= oi_rec_fetch,
-	.to_rec_update	= oi_rec_update,
+	.to_rec_msize		= oi_rec_msize,
+	.to_hkey_size		= oi_hkey_size,
+	.to_hkey_gen		= oi_hkey_gen,
+	.to_hkey_cmp		= oi_hkey_cmp,
+	.to_rec_alloc		= oi_rec_alloc,
+	.to_rec_free		= oi_rec_free,
+	.to_rec_fetch		= oi_rec_fetch,
+	.to_rec_update		= oi_rec_update,
+	.to_check_availability	= oi_check_availability,
 };
 
 /**
@@ -589,7 +602,8 @@ oi_iter_next(struct vos_iterator *iter)
 	int			 rc;
 
 	D_ASSERT(iter->it_type == VOS_ITER_OBJ);
-	rc = dbtree_iter_next(oiter->oit_hdl);
+	rc = dbtree_iter_next_with_intent(oiter->oit_hdl,
+					  vos_iter_intent(iter));
 	if (rc)
 		D_GOTO(out, rc);
 

--- a/src/vos/vos_query.c
+++ b/src/vos/vos_query.c
@@ -108,9 +108,11 @@ find_key(struct open_query *query, daos_handle_t toh, daos_key_t *key,
 			break;
 
 		if (query->qt_flags & DAOS_GET_MAX)
-			rc = dbtree_iter_prev(ih);
+			rc = dbtree_iter_prev_with_intent(ih,
+						DAOS_INTENT_DEFAULT);
 		else
-			rc = dbtree_iter_next(ih);
+			rc = dbtree_iter_next_with_intent(ih,
+						DAOS_INTENT_DEFAULT);
 	} while (rc == 0);
 out:
 	fini_rc = dbtree_iter_finish(ih);
@@ -208,8 +210,8 @@ open_and_query_key(struct open_query *query, daos_key_t *key,
 	if (to_open->tr_class == 0)
 		return -DER_NONEXIST;
 
-	rc = dbtree_open_inplace(to_open, query->qt_uma, toh);
-
+	rc = dbtree_open_inplace_ex(to_open, query->qt_uma,
+				    query->qt_coh, NULL, toh);
 	if (rc != 0)
 		return rc;
 

--- a/src/vos/vos_tree.c
+++ b/src/vos/vos_tree.c
@@ -522,6 +522,18 @@ ktr_rec_update(struct btr_instance *tins, struct btr_record *rec,
 	return 0;
 }
 
+static int
+ktr_check_availability(struct btr_instance *tins, struct btr_record *rec,
+		       uint32_t intent)
+{
+	struct vos_krec_df	*key;
+
+	key = umem_id2ptr(&tins->ti_umm, rec->rec_mmid);
+	return vos_dtx_check_availability(&tins->ti_umm, tins->ti_coh,
+					  key->kr_dtx, rec->rec_mmid,
+					  intent, DTX_RT_KEY);
+}
+
 static btr_ops_t key_btr_ops = {
 	.to_rec_msize		= ktr_rec_msize,
 	.to_hkey_size		= ktr_hkey_size,
@@ -534,6 +546,7 @@ static btr_ops_t key_btr_ops = {
 	.to_rec_free		= ktr_rec_free,
 	.to_rec_fetch		= ktr_rec_fetch,
 	.to_rec_update		= ktr_rec_update,
+	.to_check_availability	= ktr_check_availability,
 };
 
 /**
@@ -786,6 +799,18 @@ svt_rec_update(struct btr_instance *tins, struct btr_record *rec,
 	return svt_rec_store(tins, rec, kbund, rbund);
 }
 
+static int
+svt_check_availability(struct btr_instance *tins, struct btr_record *rec,
+		       uint32_t intent)
+{
+	struct vos_irec_df	*svt;
+
+	svt = umem_id2ptr(&tins->ti_umm, rec->rec_mmid);
+	return vos_dtx_check_availability(&tins->ti_umm, tins->ti_coh,
+					  svt->ir_dtx, UMMID_NULL, intent,
+					  DTX_RT_SVT);
+}
+
 static btr_ops_t singv_btr_ops = {
 	.to_rec_msize		= svt_rec_msize,
 	.to_hkey_size		= svt_hkey_size,
@@ -795,6 +820,7 @@ static btr_ops_t singv_btr_ops = {
 	.to_rec_free		= svt_rec_free,
 	.to_rec_fetch		= svt_rec_fetch,
 	.to_rec_update		= svt_rec_update,
+	.to_check_availability	= svt_check_availability,
 };
 
 /**


### PR DESCRIPTION
The data record visibility is related with both the operation intent
and the state of the last DTX that modified the data record.

When access some data record, we need to check its visibility firstly.
For modification (update/punch) RPC, it will be sent to leader replica
that knows related DTX's state (via checking the DTX tables and/or the
CoS cache). For read only (fetch, enumerate, and so on) RPC, it may be
sent to non-leader replica. If related DTX on non-leader is committed,
then related data record is visible to outside. But if related DTX is
in 'prepared' state, then the non-leader cannot know whether such DTX
is committable or not, then cannot make the decision about the target
data record visibility. Under such case, it will tell the RPC sponsor
to retry the RPC with leader replica via returning "-DER_INPROGRESS".

For the aborted DTX, because the DTX does not has the knowledge about
the tree in which the target data record is stored, then we will keep
related data record in the tree when abort the DTX. To prevent others
accessing (read) such data record, it will be marked as invisible via
referencing aborted DTX or dummy DTX (DTX_UMMID_ABORTED). The garbage
records will be clean up when next system aggregation or be reused by
subsequent modification if it find some former aborted data record.

Signed-off-by: Fan Yong <fan.yong@intel.com>
Change-Id: I85a704209d5d51030df05cc71fe70aa7d5d0ef0d