### PR TITLE
DAOS-2175 rebuild: increase rebuild pool size

### DIFF
--- a/src/tests/suite/daos_rebuild.c
+++ b/src/tests/suite/daos_rebuild.c
@@ -39,7 +39,7 @@
 #define OBJ_CLS		DAOS_OC_R3S_RW
 #define OBJ_REPLICAS	3
 #define DEFAULT_FAIL_TGT 0
-#define REBUILD_POOL_SIZE	(4ULL << 28)
+#define REBUILD_POOL_SIZE	(4ULL << 30)
 static void
 rebuild_exclude_tgt(test_arg_t **args, int arg_cnt, d_rank_t rank,
 		    int tgt_idx, bool kill)


### PR DESCRIPTION
Increase rebuild pool size to avoid out of space
failure.

Signed-off-by: Wang Di <di.wang@intel.com>