### PR TITLE
Fix typo to reinstate btree tests.

### DIFF
--- a/src/common/tests/btree.sh
+++ b/src/common/tests/btree.sh
@@ -66,6 +66,7 @@ while [ $# -gt 0 ]; do
 done
 
 set -x
+set -e
 
 run_test()
 {
@@ -75,7 +76,6 @@ run_test()
         echo "B+tree functional test..."
         DAOS_DEBUG="$DDEBUG"                        \
         "${VCMD[@]}" "$BTR" "${PMEM}" -C "${UINT}${IPL}o:$ORDER" \
-
         -c                                          \
         -o                                          \
         -u "$RECORDS"                               \


### PR DESCRIPTION
An extra newline appears to have been inserted into the options list
meaning that options were not being passed to DAOS but were instead
being dropped.

Enable -e so that any failure of the test is propagated to a failure
of the test script so that errors don't get missed.

Signed-off-by: Ashley Pittman <ashley.m.pittman@intel.com>