### PR TITLE
CORCI-522 Provide a link to artifacts at the bottom of logs  …

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -136,7 +136,8 @@ pipeline {
                         }
                     }
                     steps {
-                        sconsBuild clean: "_build.external${arch}"
+                        sconsBuild clean: "_build.external${arch}",
+                                   failure_artifacts: 'config.log-centos7-gcc'
                         stash name: 'CentOS-install', includes: 'install/**'
                         stash name: 'CentOS-build-vars', includes: ".build_vars${arch}.*"
                         stash name: 'CentOS-tests',
@@ -221,7 +222,8 @@ pipeline {
                         }
                     }
                     steps {
-                        sconsBuild clean: "_build.external${arch}", COMPILER: "clang"
+                        sconsBuild clean: "_build.external${arch}", COMPILER: "clang",
+                                   failure_artifacts: 'config.log-centos7-clang'
                     }
                     post {
                         always {
@@ -282,7 +284,8 @@ pipeline {
                         }
                     }
                     steps {
-                        sconsBuild clean: "_build.external${arch}"
+                        sconsBuild clean: "_build.external${arch}",
+                                   failure_artifacts: 'config.log-ubuntu18.04-gcc'
                     }
                     post {
                         always {
@@ -342,7 +345,8 @@ pipeline {
                         }
                     }
                     steps {
-                        sconsBuild clean: "_build.external${arch}", COMPILER: "clang"
+                        sconsBuild clean: "_build.external${arch}", COMPILER: "clang",
+                                   failure_artifacts: 'config.log-ubuntu18.04-clag'
                     }
                     post {
                         always {
@@ -403,7 +407,8 @@ pipeline {
                         }
                     }
                     steps {
-                        sconsBuild clean: "_build.external${arch}"
+                        sconsBuild clean: "_build.external${arch}",
+                                   failure_artifacts: 'config.log-leap15-gcc'
                     }
                     post {
                         always {
@@ -464,7 +469,8 @@ pipeline {
                         }
                     }
                     steps {
-                        sconsBuild clean: "_build.external${arch}", COMPILER: "clang"
+                        sconsBuild clean: "_build.external${arch}", COMPILER: "clang",
+                                   failure_artifacts: 'config.log-leap15-clang'
                     }
                     post {
                         always {
@@ -525,7 +531,8 @@ pipeline {
                         }
                     }
                     steps {
-                        sconsBuild clean: "_build.external${arch}", COMPILER: "icc"
+                        sconsBuild clean: "_build.external${arch}", COMPILER: "icc",
+                                   failure_artifacts: 'config.log-leap15-icc'
                     }
                     post {
                         always {
@@ -676,7 +683,8 @@ pipeline {
                                                test_tag=regression,vm
                                            fi
                                            ./ftest.sh "$test_tag" ''' + env.NODELIST,
-                                junit_files: "src/tests/ftest/avocado/job-results/*/*.xml"
+                                junit_files: "src/tests/ftest/avocado/job-results/*/*.xml",
+                                failure_artifacts: 'Functional'
                     }
                     post {
                         always {


### PR DESCRIPTION
For stages where there are relevant artifacts, provide a pointer to
them at the end of the console log.  For failed builds, this is the
config.log.  For Functional testing this is the Functional/ directory
in the artifacts.

Signed-off-by: Brian J. Murrell <brian.murrell@intel.com>