### PR TITLE
DAOS-2190 rsvc: Move get/set/list attributes into RSVC module

### DIFF
--- a/src/include/daos_srv/rsvc.h
+++ b/src/include/daos_srv/rsvc.h
@@ -135,4 +135,13 @@ void ds_rsvc_put(struct ds_rsvc *svc);
 void ds_rsvc_put_leader(struct ds_rsvc *svc);
 void ds_rsvc_set_hint(struct ds_rsvc *svc, struct rsvc_hint *hint);
 
+int ds_rsvc_set_attr(struct ds_rsvc *svc, struct rdb_tx *tx, rdb_path_t *path,
+		     crt_bulk_t remote_bulk, crt_rpc_t *rpc, uint64_t count);
+int ds_rsvc_get_attr(struct ds_rsvc *svc, struct rdb_tx *tx, rdb_path_t *path,
+		     crt_bulk_t remote_bulk, crt_rpc_t *rpc, uint64_t count,
+		     uint64_t key_length);
+int ds_rsvc_list_attr(struct ds_rsvc *svc, struct rdb_tx *tx, rdb_path_t *path,
+		      crt_bulk_t remote_bulk, crt_rpc_t *rpc, uint64_t *size);
+
+
 #endif /* DAOS_SRV_RSVC_H */

--- a/src/pool/srv_pool.c
+++ b/src/pool/srv_pool.c
@@ -2747,44 +2747,6 @@ ds_pool_svc_term_get(uuid_t uuid, uint64_t *term)
 	return 0;
 }
 
-static int
-attr_bulk_transfer(crt_rpc_t *rpc, crt_bulk_op_t op,
-		   crt_bulk_t local_bulk, crt_bulk_t remote_bulk,
-		   off_t local_off, off_t remote_off, size_t length)
-{
-	ABT_eventual		 eventual;
-	int			*status;
-	int			 rc;
-	struct crt_bulk_desc	 bulk_desc = {
-				.bd_rpc		= rpc,
-				.bd_bulk_op	= op,
-				.bd_local_hdl	= local_bulk,
-				.bd_local_off	= local_off,
-				.bd_remote_hdl	= remote_bulk,
-				.bd_remote_off	= remote_off,
-				.bd_len		= length,
-			};
-
-	rc = ABT_eventual_create(sizeof(*status), &eventual);
-	if (rc != ABT_SUCCESS)
-		D_GOTO(out, rc = dss_abterr2der(rc));
-
-	rc = crt_bulk_transfer(&bulk_desc, bulk_cb, &eventual, NULL);
-	if (rc != 0)
-		D_GOTO(out_eventual, rc);
-
-	rc = ABT_eventual_wait(eventual, (void **)&status);
-	if (rc != ABT_SUCCESS)
-		D_GOTO(out_eventual, rc = dss_abterr2der(rc));
-	if (*status != 0)
-		D_GOTO(out_eventual, rc = *status);
-
-out_eventual:
-	ABT_eventual_free(&eventual);
-out:
-	return rc;
-}
-
 void
 ds_pool_attr_set_handler(crt_rpc_t *rpc)
 {
@@ -2792,16 +2754,7 @@ ds_pool_attr_set_handler(crt_rpc_t *rpc)
 	struct pool_op_out	 *out = crt_reply_get(rpc);
 	struct pool_svc		 *svc;
 	struct rdb_tx		  tx;
-	crt_bulk_t		  local_bulk;
-	daos_size_t		  bulk_size;
-	daos_iov_t		  iov;
-	daos_sg_list_t		  sgl;
-	void			 *data;
-	char			 *names;
-	char			 *values;
-	size_t			 *sizes;
 	int			  rc;
-	int			  i;
 
 	D_DEBUG(DF_DSMS, DF_UUID": processing rpc %p: hdl="DF_UUID"\n",
 		DP_UUID(in->pasi_op.pi_uuid), rpc, DP_UUID(in->pasi_op.pi_hdl));
@@ -2816,64 +2769,10 @@ ds_pool_attr_set_handler(crt_rpc_t *rpc)
 
 	ABT_rwlock_wrlock(svc->ps_lock);
 
-	rc = crt_bulk_get_len(in->pasi_bulk, &bulk_size);
-	if (rc != 0)
-		D_GOTO(out_lock, rc);
-	D_DEBUG(DF_DSMS, DF_UUID": count=%lu, size=%lu\n",
-		DP_UUID(in->pasi_op.pi_uuid), in->pasi_count, bulk_size);
-
-	D_ALLOC(data, bulk_size);
-	if (data == NULL)
-		D_GOTO(out_lock, rc = -DER_NOMEM);
-
-	sgl.sg_nr = 1;
-	sgl.sg_nr_out = sgl.sg_nr;
-	sgl.sg_iovs = &iov;
-	daos_iov_set(&iov, data, bulk_size);
-	rc = crt_bulk_create(rpc->cr_ctx, daos2crt_sg(&sgl),
-			     CRT_BULK_RW, &local_bulk);
-	if (rc != 0)
-		D_GOTO(out_mem, rc);
-
-	rc = attr_bulk_transfer(rpc, CRT_BULK_GET, local_bulk,
-				in->pasi_bulk, 0, 0, bulk_size);
-	if (rc != 0)
-		D_GOTO(out_bulk, rc);
-
-	names = data;
-	/* go to the end of names array */
-	for (values = names, i = 0; i < in->pasi_count; ++values)
-		if (*values == '\0')
-			++i;
-	sizes = (size_t *)values;
-	values = (char *)(sizes + in->pasi_count);
-
-	for (i = 0; i < in->pasi_count; i++) {
-		size_t len;
-		daos_iov_t key;
-		daos_iov_t value;
-
-		len = strlen(names) /* trailing '\0' */ + 1;
-		daos_iov_set(&key, names, len);
-		names += len;
-		daos_iov_set(&value, values, sizes[i]);
-		values += sizes[i];
-
-		rc = rdb_tx_update(&tx, &svc->ps_user, &key, &value);
-		if (rc != 0) {
-			D_ERROR(DF_UUID": failed to update attribute "
-				 "'%s': %d\n", DP_UUID(svc->ps_uuid),
-				 (char *) key.iov_buf, rc);
-			D_GOTO(out_bulk, rc);
-		}
-	}
-	rc = rdb_tx_commit(&tx);
-
-out_bulk:
-	crt_bulk_free(local_bulk);
-out_mem:
-	D_FREE(data);
-out_lock:
+	rc = ds_rsvc_set_attr(&svc->ps_rsvc, &tx, &svc->ps_user,
+			      in->pasi_bulk, rpc, in->pasi_count);
+	if (rc == 0)
+		rc = rdb_tx_commit(&tx);
 	ABT_rwlock_unlock(svc->ps_lock);
 	rdb_tx_end(&tx);
 out_svc:
@@ -2893,17 +2792,7 @@ ds_pool_attr_get_handler(crt_rpc_t *rpc)
 	struct pool_op_out	 *out = crt_reply_get(rpc);
 	struct pool_svc		 *svc;
 	struct rdb_tx		  tx;
-	crt_bulk_t		  local_bulk;
-	daos_size_t		  bulk_size;
-	daos_size_t		  input_size;
-	daos_iov_t		 *iovs;
-	daos_sg_list_t		  sgl;
-	void			 *data;
-	char			 *names;
-	size_t			 *sizes;
 	int			  rc;
-	int			  i;
-	int			  j;
 
 	D_DEBUG(DF_DSMS, DF_UUID": processing rpc %p: hdl="DF_UUID"\n",
 		DP_UUID(in->pagi_op.pi_uuid), rpc, DP_UUID(in->pagi_op.pi_hdl));
@@ -2917,92 +2806,8 @@ ds_pool_attr_get_handler(crt_rpc_t *rpc)
 		D_GOTO(out_svc, rc);
 
 	ABT_rwlock_rdlock(svc->ps_lock);
-
-
-	rc = crt_bulk_get_len(in->pagi_bulk, &bulk_size);
-	if (rc != 0)
-		D_GOTO(out_lock, rc);
-	D_DEBUG(DF_DSMS, DF_UUID": count=%lu, key_length=%lu, size=%lu\n",
-		DP_UUID(in->pagi_op.pi_uuid),
-		in->pagi_count, in->pagi_key_length, bulk_size);
-
-	input_size = in->pagi_key_length + in->pagi_count * sizeof(*sizes);
-	D_ASSERT(input_size <= bulk_size);
-
-	D_ALLOC(data, input_size);
-	if (data == NULL)
-		D_GOTO(out_lock, rc = -DER_NOMEM);
-
-	/* for output sizes */
-	D_ALLOC_ARRAY(iovs, (int)(1 + in->pagi_count));
-	if (iovs == NULL)
-		D_GOTO(out_data, rc = -DER_NOMEM);
-
-	sgl.sg_nr = 1;
-	sgl.sg_nr_out = sgl.sg_nr;
-	sgl.sg_iovs = &iovs[0];
-	daos_iov_set(&iovs[0], data, input_size);
-	rc = crt_bulk_create(rpc->cr_ctx, daos2crt_sg(&sgl),
-			     CRT_BULK_RW, &local_bulk);
-	if (rc != 0)
-		D_GOTO(out_iovs, rc);
-
-	rc = attr_bulk_transfer(rpc, CRT_BULK_GET, local_bulk,
-				in->pagi_bulk, 0, 0, input_size);
-	crt_bulk_free(local_bulk);
-	if (rc != 0)
-		D_GOTO(out_iovs, rc);
-
-	names = data;
-	sizes = (size_t *)(names + in->pagi_key_length);
-	daos_iov_set(&iovs[0], (void *)sizes,
-		     in->pagi_count * sizeof(*sizes));
-
-	for (i = 0, j = 1; i < in->pagi_count; ++i) {
-		size_t len;
-		daos_iov_t key;
-
-		len = strlen(names) + /* trailing '\0' */ 1;
-		daos_iov_set(&key, names, len);
-		names += len;
-		daos_iov_set(&iovs[j], NULL, 0);
-
-		rc = rdb_tx_lookup(&tx, &svc->ps_user, &key, &iovs[j]);
-
-		if (rc != 0) {
-			D_ERROR(DF_UUID": failed to lookup attribute "
-				 "'%s': %d\n", DP_UUID(svc->ps_uuid),
-				 (char *) key.iov_buf, rc);
-			D_GOTO(out_iovs, rc);
-		}
-		iovs[j].iov_buf_len = sizes[i];
-		sizes[i] = iovs[j].iov_len;
-
-		/* If buffer length is zero, send only size */
-		if (iovs[j].iov_buf_len > 0)
-			++j;
-	}
-
-	sgl.sg_nr = j;
-	sgl.sg_nr_out = sgl.sg_nr;
-	sgl.sg_iovs = iovs;
-	rc = crt_bulk_create(rpc->cr_ctx, daos2crt_sg(&sgl),
-			     CRT_BULK_RO, &local_bulk);
-	if (rc != 0)
-		D_GOTO(out_iovs, rc);
-
-	rc = attr_bulk_transfer(rpc, CRT_BULK_PUT, local_bulk,
-				in->pagi_bulk, 0, in->pagi_key_length,
-				bulk_size - in->pagi_key_length);
-	crt_bulk_free(local_bulk);
-	if (rc != 0)
-		D_GOTO(out_iovs, rc);
-
-out_iovs:
-	D_FREE(iovs);
-out_data:
-	D_FREE(data);
-out_lock:
+	rc = ds_rsvc_get_attr(&svc->ps_rsvc, &tx, &svc->ps_user, in->pagi_bulk,
+			      rpc, in->pagi_count, in->pagi_key_length);
 	ABT_rwlock_unlock(svc->ps_lock);
 	rdb_tx_end(&tx);
 out_svc:
@@ -3016,58 +2821,6 @@ out:
 
 }
 
-struct attr_list_iter_args {
-	size_t		 alia_available; /* Remaining client buffer space */
-	size_t		 alia_length; /* Aggregate length of attribute names */
-	size_t		 alia_iov_index;
-	size_t		 alia_iov_count;
-	daos_iov_t	*alia_iovs;
-};
-
-static int
-attr_list_iter_cb(daos_handle_t ih,
-		  daos_iov_t *key, daos_iov_t *val, void *arg)
-{
-	struct attr_list_iter_args *i_args = arg;
-
-	i_args->alia_length += key->iov_len;
-
-	if (i_args->alia_available > key->iov_len && key->iov_len > 0) {
-		/*
-		 * Exponentially grow the array of IOVs if insufficient.
-		 * Considering the pathological case where each key is just
-		 * a single character, with one additional trailing '\0',
-		 * if the client buffer is 'N' bytes, it can hold at the most
-		 * N/2 keys, which requires that many IOVs to be allocated.
-		 * Thus, the upper limit on the space required for IOVs is:
-		 * sizeof(daos_iov_t) * N/2 = 24 * N/2 = 12*N bytes.
-		 */
-		if (i_args->alia_iov_index == i_args->alia_iov_count) {
-			void *ptr;
-
-			D_REALLOC(ptr, i_args->alia_iovs,
-				  i_args->alia_iov_count *
-				  2 * sizeof(daos_iov_t));
-			/*
-			 * TODO: Fail or continue transferring
-			 *	 iteratively using available memory?
-			 */
-			if (ptr == NULL)
-				return -DER_NOMEM;
-			i_args->alia_iovs = ptr;
-			i_args->alia_iov_count *= 2;
-		}
-
-		memcpy(&i_args->alia_iovs[i_args->alia_iov_index],
-		       key, sizeof(daos_iov_t));
-		i_args->alia_iovs[i_args->alia_iov_index]
-			.iov_buf_len = key->iov_len;
-		i_args->alia_available -= key->iov_len;
-		++i_args->alia_iov_index;
-	}
-	return 0;
-}
-
 void
 ds_pool_attr_list_handler(crt_rpc_t *rpc)
 {
@@ -3075,10 +2828,7 @@ ds_pool_attr_list_handler(crt_rpc_t *rpc)
 	struct pool_attr_list_out	*out	    = crt_reply_get(rpc);
 	struct pool_svc			*svc;
 	struct rdb_tx			 tx;
-	crt_bulk_t			 local_bulk;
-	daos_size_t			 bulk_size;
 	int				 rc;
-	struct attr_list_iter_args	 iter_args;
 
 	D_DEBUG(DF_DSMS, DF_UUID": processing rpc %p: hdl="DF_UUID"\n",
 		DP_UUID(in->pali_op.pi_uuid), rpc, DP_UUID(in->pali_op.pi_hdl));
@@ -3093,56 +2843,8 @@ ds_pool_attr_list_handler(crt_rpc_t *rpc)
 		D_GOTO(out_svc, rc);
 
 	ABT_rwlock_rdlock(svc->ps_lock);
-
-	/*
-	 * If remote bulk handle does not exist, only aggregate size is sent.
-	 */
-	if (in->pali_bulk) {
-		rc = crt_bulk_get_len(in->pali_bulk, &bulk_size);
-		if (rc != 0)
-			D_GOTO(out_lock, rc);
-		D_DEBUG(DF_DSMS, DF_UUID": bulk_size=%lu\n",
-			DP_UUID(in->pali_op.pi_uuid), bulk_size);
-
-		/* Start with 1 and grow as needed */
-		D_ALLOC_PTR(iter_args.alia_iovs);
-		if (iter_args.alia_iovs == NULL)
-			D_GOTO(out_lock, rc = -DER_NOMEM);
-		iter_args.alia_iov_count = 1;
-	} else {
-		bulk_size = 0;
-		iter_args.alia_iovs = NULL;
-		iter_args.alia_iov_count = 0;
-	}
-	iter_args.alia_iov_index = 0;
-	iter_args.alia_length	 = 0;
-	iter_args.alia_available = bulk_size;
-	rc = rdb_tx_iterate(&tx, &svc->ps_user, false /* !backward */,
-			    attr_list_iter_cb, &iter_args);
-	out->palo_size = iter_args.alia_length;
-	if (rc != 0)
-		D_GOTO(out_mem, rc);
-
-	if (iter_args.alia_iov_index > 0) {
-		daos_sg_list_t	 sgl = {
-			.sg_nr_out = iter_args.alia_iov_index,
-			.sg_nr	   = iter_args.alia_iov_index,
-			.sg_iovs   = iter_args.alia_iovs
-		};
-		rc = crt_bulk_create(rpc->cr_ctx, daos2crt_sg(&sgl),
-				     CRT_BULK_RW, &local_bulk);
-		if (rc != 0)
-			D_GOTO(out_mem, rc);
-
-		rc = attr_bulk_transfer(rpc, CRT_BULK_PUT, local_bulk,
-					in->pali_bulk, 0, 0,
-					bulk_size - iter_args.alia_available);
-		crt_bulk_free(local_bulk);
-	}
-
-out_mem:
-	D_FREE(iter_args.alia_iovs);
-out_lock:
+	rc = ds_rsvc_list_attr(&svc->ps_rsvc, &tx, &svc->ps_user,
+			       in->pali_bulk, rpc, &out->palo_size);
 	ABT_rwlock_unlock(svc->ps_lock);
 	rdb_tx_end(&tx);
 out_svc:

--- a/src/rsvc/SConscript
+++ b/src/rsvc/SConscript
@@ -9,7 +9,7 @@ def scons():
     denv = env.Clone()
 
     # ds_rsvc
-    ds_rsvc = daos_build.library(denv, 'rsvc', ['srv.c'])
+    ds_rsvc = daos_build.library(denv, 'rsvc', ['srv.c', 'srv_common.c'])
     denv.Install('$PREFIX/lib/daos_srv', ds_rsvc)
 
 if __name__ == "SCons.Script":

--- a/src/rsvc/srv_common.c
+++ b/src/rsvc/srv_common.c
@@ -1,0 +1,372 @@
+/*
+ * (C) Copyright 2019 Intel Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * GOVERNMENT LICENSE RIGHTS-OPEN SOURCE SOFTWARE
+ * The Government's rights to use, modify, reproduce, release, perform, display,
+ * or disclose this software are subject to the terms of the Apache License as
+ * provided in Contract No. B609815.
+ * Any reproduction of computer software, computer software documentation, or
+ * portions thereof marked with this legend must also reproduce the markings.
+ */
+/**
+ * Replicated Service Common Functions
+ */
+
+#define D_LOGFAC DD_FAC(rsvc)
+
+#include <sys/stat.h>
+#include <daos_srv/daos_server.h>
+#include <daos_srv/rsvc.h>
+
+struct attr_list_iter_args {
+	size_t		 available; /* Remaining client buffer space */
+	size_t		 length; /* Aggregate length of attribute names */
+	size_t		 iov_index;
+	size_t		 iov_count;
+	daos_iov_t	*iovs;
+};
+
+static int
+attr_list_iter_cb(daos_handle_t ih, daos_iov_t *key, daos_iov_t *val,
+		  void *arg);
+static int
+attr_bulk_transfer(crt_rpc_t *rpc, crt_bulk_op_t op,
+		   crt_bulk_t local_bulk, crt_bulk_t remote_bulk,
+		   off_t local_off, off_t remote_off, size_t length);
+
+int
+ds_rsvc_set_attr(struct ds_rsvc *svc, struct rdb_tx *tx, rdb_path_t *path,
+		 crt_bulk_t remote_bulk, crt_rpc_t *rpc, uint64_t count)
+{
+	crt_bulk_t			 local_bulk;
+	daos_size_t			 bulk_size;
+	daos_iov_t			 iov;
+	daos_sg_list_t			 sgl;
+	void				*data;
+	char				*names;
+	char				*values;
+	size_t				*sizes;
+	int				 rc;
+	int				 i;
+
+	rc = crt_bulk_get_len(remote_bulk, &bulk_size);
+	if (rc != 0)
+		D_GOTO(out, rc);
+	D_DEBUG(DB_MD, "%s: count=%lu, size=%lu\n", svc->s_name, count,
+		bulk_size);
+
+	D_ALLOC(data, bulk_size);
+	if (data == NULL)
+		D_GOTO(out, rc = -DER_NOMEM);
+
+	sgl.sg_nr = 1;
+	sgl.sg_nr_out = sgl.sg_nr;
+	sgl.sg_iovs = &iov;
+	daos_iov_set(&iov, data, bulk_size);
+	rc = crt_bulk_create(rpc->cr_ctx, daos2crt_sg(&sgl),
+			     CRT_BULK_RW, &local_bulk);
+	if (rc != 0)
+		D_GOTO(out_mem, rc);
+
+	rc = attr_bulk_transfer(rpc, CRT_BULK_GET, local_bulk,
+				remote_bulk, 0, 0, bulk_size);
+	if (rc != 0)
+		D_GOTO(out_bulk, rc);
+
+	names = data;
+	/* go to the end of names array */
+	for (values = names, i = 0; i < count; ++values)
+		if (*values == '\0')
+			++i;
+	sizes = (size_t *)values;
+	values = (char *)(sizes + count);
+
+	for (i = 0; i < count; i++) {
+		size_t len;
+		daos_iov_t key;
+		daos_iov_t value;
+
+		len = strlen(names) /* trailing '\0' */ + 1;
+		daos_iov_set(&key, names, len);
+		names += len;
+		daos_iov_set(&value, values, sizes[i]);
+		values += sizes[i];
+
+		rc = rdb_tx_update(tx, path, &key, &value);
+		if (rc != 0) {
+			D_ERROR("%s: failed to update attribute '%s': %d\n",
+				 svc->s_name, (char *) key.iov_buf, rc);
+			D_GOTO(out_bulk, rc);
+		}
+	}
+
+out_bulk:
+	crt_bulk_free(local_bulk);
+out_mem:
+	D_FREE(data);
+out:
+	return rc;
+}
+
+int
+ds_rsvc_get_attr(struct ds_rsvc *svc, struct rdb_tx *tx, rdb_path_t *path,
+		 crt_bulk_t remote_bulk, crt_rpc_t *rpc, uint64_t count,
+		 uint64_t key_length)
+{
+	crt_bulk_t			 local_bulk;
+	daos_size_t			 bulk_size;
+	daos_size_t			 input_size;
+	daos_iov_t			*iovs;
+	daos_sg_list_t			 sgl;
+	void				*data;
+	char				*names;
+	size_t				*sizes;
+	int				 rc;
+	int				 i;
+	int				 j;
+
+	rc = crt_bulk_get_len(remote_bulk, &bulk_size);
+	if (rc != 0)
+		D_GOTO(out, rc);
+	D_DEBUG(DB_MD, "%s: count=%lu, key_length=%lu, size=%lu\n",
+		svc->s_name, count, key_length, bulk_size);
+
+	input_size = key_length + count * sizeof(*sizes);
+	D_ASSERT(input_size <= bulk_size);
+
+	D_ALLOC(data, input_size);
+	if (data == NULL)
+		D_GOTO(out, rc = -DER_NOMEM);
+
+	/* for output sizes */
+	D_ALLOC_ARRAY(iovs, (int)(1 + count));
+	if (iovs == NULL)
+		D_GOTO(out_data, rc = -DER_NOMEM);
+
+	sgl.sg_nr = 1;
+	sgl.sg_nr_out = sgl.sg_nr;
+	sgl.sg_iovs = &iovs[0];
+	daos_iov_set(&iovs[0], data, input_size);
+	rc = crt_bulk_create(rpc->cr_ctx, daos2crt_sg(&sgl),
+			     CRT_BULK_RW, &local_bulk);
+	if (rc != 0)
+		D_GOTO(out_iovs, rc);
+
+	rc = attr_bulk_transfer(rpc, CRT_BULK_GET, local_bulk,
+				remote_bulk, 0, 0, input_size);
+	crt_bulk_free(local_bulk);
+	if (rc != 0)
+		D_GOTO(out_iovs, rc);
+
+	names = data;
+	sizes = (size_t *)(names + key_length);
+	daos_iov_set(&iovs[0], (void *)sizes,
+		     count * sizeof(*sizes));
+
+	for (i = 0, j = 1; i < count; ++i) {
+		size_t len;
+		daos_iov_t key;
+
+		len = strlen(names) + /* trailing '\0' */ 1;
+		daos_iov_set(&key, names, len);
+		names += len;
+		daos_iov_set(&iovs[j], NULL, 0);
+
+		rc = rdb_tx_lookup(tx, path, &key, &iovs[j]);
+
+		if (rc != 0) {
+			D_ERROR("%s: failed to lookup attribute '%s': %d\n",
+				 svc->s_name, (char *) key.iov_buf, rc);
+			D_GOTO(out_iovs, rc);
+		}
+		iovs[j].iov_buf_len = sizes[i];
+		sizes[i] = iovs[j].iov_len;
+
+		/* If buffer length is zero, send only size */
+		if (iovs[j].iov_buf_len > 0)
+			++j;
+	}
+
+	sgl.sg_nr = j;
+	sgl.sg_nr_out = sgl.sg_nr;
+	sgl.sg_iovs = iovs;
+	rc = crt_bulk_create(rpc->cr_ctx, daos2crt_sg(&sgl),
+			     CRT_BULK_RO, &local_bulk);
+	if (rc != 0)
+		D_GOTO(out_iovs, rc);
+
+	rc = attr_bulk_transfer(rpc, CRT_BULK_PUT, local_bulk, remote_bulk,
+				0, key_length, bulk_size - key_length);
+	crt_bulk_free(local_bulk);
+	if (rc != 0)
+		D_GOTO(out_iovs, rc);
+
+out_iovs:
+	D_FREE(iovs);
+out_data:
+	D_FREE(data);
+out:
+	return rc;
+}
+
+int
+ds_rsvc_list_attr(struct ds_rsvc *svc, struct rdb_tx *tx, rdb_path_t *path,
+		  crt_bulk_t remote_bulk, crt_rpc_t *rpc, uint64_t *size)
+{
+	crt_bulk_t			 local_bulk;
+	daos_size_t			 bulk_size;
+	int				 rc;
+	struct attr_list_iter_args	 iter_args;
+
+	/*
+	 * If remote bulk handle does not exist, only aggregate size is sent.
+	 */
+	if (remote_bulk) {
+		rc = crt_bulk_get_len(remote_bulk, &bulk_size);
+		if (rc != 0)
+			D_GOTO(out, rc);
+		D_DEBUG(DB_MD, "%s: bulk_size=%lu\n", svc->s_name, bulk_size);
+
+		/* Start with 1 and grow as needed */
+		D_ALLOC_PTR(iter_args.iovs);
+		if (iter_args.iovs == NULL)
+			D_GOTO(out, rc = -DER_NOMEM);
+		iter_args.iov_count = 1;
+	} else {
+		bulk_size = 0;
+		iter_args.iovs = NULL;
+		iter_args.iov_count = 0;
+	}
+	iter_args.iov_index = 0;
+	iter_args.length	 = 0;
+	iter_args.available = bulk_size;
+	rc = rdb_tx_iterate(tx, path, false /* !backward */,
+			    attr_list_iter_cb, &iter_args);
+	*size = iter_args.length;
+	if (rc != 0)
+		D_GOTO(out_mem, rc);
+
+	if (iter_args.iov_index > 0) {
+		daos_sg_list_t	 sgl = {
+			.sg_nr_out = iter_args.iov_index,
+			.sg_nr	   = iter_args.iov_index,
+			.sg_iovs   = iter_args.iovs
+		};
+		rc = crt_bulk_create(rpc->cr_ctx, daos2crt_sg(&sgl),
+				     CRT_BULK_RW, &local_bulk);
+		if (rc != 0)
+			D_GOTO(out_mem, rc);
+
+		rc = attr_bulk_transfer(rpc, CRT_BULK_PUT, local_bulk,
+					remote_bulk, 0, 0,
+					bulk_size - iter_args.available);
+		crt_bulk_free(local_bulk);
+	}
+
+out_mem:
+	D_FREE(iter_args.iovs);
+out:
+	return rc;
+}
+
+static int
+bulk_cb(const struct crt_bulk_cb_info *cb_info)
+{
+	ABT_eventual *eventual = cb_info->bci_arg;
+
+	ABT_eventual_set(*eventual, (void *)&cb_info->bci_rc,
+			 sizeof(cb_info->bci_rc));
+	return 0;
+}
+
+static int
+attr_bulk_transfer(crt_rpc_t *rpc, crt_bulk_op_t op,
+		   crt_bulk_t local_bulk, crt_bulk_t remote_bulk,
+		   off_t local_off, off_t remote_off, size_t length)
+{
+	ABT_eventual		 eventual;
+	int			*status;
+	int			 rc;
+	struct crt_bulk_desc	 bulk_desc = {
+				.bd_rpc		= rpc,
+				.bd_bulk_op	= op,
+				.bd_local_hdl	= local_bulk,
+				.bd_local_off	= local_off,
+				.bd_remote_hdl	= remote_bulk,
+				.bd_remote_off	= remote_off,
+				.bd_len		= length,
+			};
+
+	rc = ABT_eventual_create(sizeof(*status), &eventual);
+	if (rc != ABT_SUCCESS)
+		D_GOTO(out, rc = dss_abterr2der(rc));
+
+	rc = crt_bulk_transfer(&bulk_desc, bulk_cb, &eventual, NULL);
+	if (rc != 0)
+		D_GOTO(out_eventual, rc);
+
+	rc = ABT_eventual_wait(eventual, (void **)&status);
+	if (rc != ABT_SUCCESS)
+		D_GOTO(out_eventual, rc = dss_abterr2der(rc));
+	if (*status != 0)
+		D_GOTO(out_eventual, rc = *status);
+
+out_eventual:
+	ABT_eventual_free(&eventual);
+out:
+	return rc;
+}
+
+static int
+attr_list_iter_cb(daos_handle_t ih, daos_iov_t *key, daos_iov_t *val, void *arg)
+{
+	struct attr_list_iter_args *i_args = arg;
+
+	i_args->length += key->iov_len;
+
+	if (i_args->available > key->iov_len && key->iov_len > 0) {
+		/*
+		 * Exponentially grow the array of IOVs if insufficient.
+		 * Considering the pathological case where each key is just
+		 * a single character, with one additional trailing '\0',
+		 * if the client buffer is 'N' bytes, it can hold at the most
+		 * N/2 keys, which requires that many IOVs to be allocated.
+		 * Thus, the upper limit on the space required for IOVs is:
+		 * sizeof(daos_iov_t) * N/2 = 24 * N/2 = 12*N bytes.
+		 */
+		if (i_args->iov_index == i_args->iov_count) {
+			void *ptr;
+
+			D_REALLOC(ptr, i_args->iovs,
+				  i_args->iov_count * 2 * sizeof(daos_iov_t));
+			/*
+			 * TODO: Fail or continue transferring
+			 *	 iteratively using available memory?
+			 */
+			if (ptr == NULL)
+				return -DER_NOMEM;
+			i_args->iovs = ptr;
+			i_args->iov_count *= 2;
+		}
+
+		memcpy(&i_args->iovs[i_args->iov_index],
+		       key, sizeof(daos_iov_t));
+		i_args->iovs[i_args->iov_index]
+			.iov_buf_len = key->iov_len;
+		i_args->available -= key->iov_len;
+		++i_args->iov_index;
+	}
+	return 0;
+}


### PR DESCRIPTION
The code for getting, setting and listing attributes is duplicated
in both Pool and Container services. This patch consolidates common
functionality into the recently created Replicated Service module.

Signed-off-by: Omkar Kulkarni <omkar.kulkarni@intel.com>
Change-Id: I47f669ef08f908d9308e4326e5081749c0b6cc13