### PR TITLE
DAOS-1939 control: refactor client

### DIFF
--- a/src/control/client/connect.go
+++ b/src/control/client/connect.go
@@ -28,19 +28,20 @@ import (
 	"time"
 
 	"github.com/daos-stack/daos/src/control/common"
+	"github.com/pkg/errors"
 )
 
-// ClientFeatureMap is an alias for management features supported on server
+// cFeatureMap is an alias for management features supported on server
 // connected to given client.
-type ClientFeatureMap map[string]FeatureMap
+type cFeatureMap map[string]FeatureMap
 
-// ClientNvmeMap is an alias for NVMe controllers (and any residing namespaces)
+// cNvmeMap is an alias for NVMe controllers (and any residing namespaces)
 // on server node connected to given client.
-type ClientNvmeMap map[string]NvmeControllers
+type cNvmeMap map[string]NvmeControllers
 
-// ClientScmMap is an alias for SCM modules installed on server node
+// cScmMap is an alias for SCM modules installed on server node
 // connected to given client.
-type ClientScmMap map[string]ScmModules
+type cScmMap map[string]ScmModules
 
 // ErrorMap is an alias to return errors keyed on address.
 type ErrorMap map[string]error
@@ -48,58 +49,59 @@ type ErrorMap map[string]error
 // Addresses is an alias for a slice of <ipv4/hostname>:<port> addresses.
 type Addresses []string
 
-// ConnFactory is an interface providing capability to create clients.
-type ConnFactory interface {
-	createConn(string) Control
+// ControllerFactory is an interface providing capability to connect clients.
+type ControllerFactory interface {
+	create(string) Control
 }
 
-// Connections is an interface providing functionality across multiple
-// connected clients.
-type Connections interface {
+// Connect is an interface providing functionality across multiple
+// connected clients (controllers).
+type Connect interface {
 	// ConnectClients attempts to connect a list of addresses, returns
-	// list of connected clients and map of any errors.
+	// list of connected clients (controllers) and map of any errors.
 	ConnectClients(Addresses) (Addresses, ErrorMap)
-	// GetActiveConns verifies states of stored conns and removes inactive
-	// from stored. Adds failure to failure map and returns active conns.
+	// GetActiveConns verifies states of controllers and removes inactive
+	// from stored. Adds failure to failure map and returns active.
 	GetActiveConns(ErrorMap) (Addresses, ErrorMap)
 	ClearConns() ErrorMap
-	ListFeatures() (ClientFeatureMap, error)
-	ListNvme() (ClientNvmeMap, error)
-	ListScm() (ClientScmMap, error)
+	ListFeatures() (cFeatureMap, error)
+	ListNvme() (cNvmeMap, error)
+	ListScm() (cScmMap, error)
 	KillRank(uuid string, rank uint32) error
 }
 
-// connList is an implementation of Connections, a collection of connected
-// client instances, one per target server.
+// connList is an implementation of Connect and stores controllers
+// (connections to clients, one per target server).
 type connList struct {
-	factory ConnFactory
-	clients []Control
+	factory     ControllerFactory
+	controllers []Control
 }
 
-// connFactory as an implementation of ConnFactory.
-type connFactory struct{}
+// controllerFactory as an implementation of ControllerFactory.
+type controllerFactory struct{}
 
-// createConn instantiates and connects a client to server at given address.
-func (c *connFactory) createConn(address string) Control {
+// create instantiates and connects a client to server at given address.
+func (c *controllerFactory) create(address string) Control {
 	return &control{}
 }
 
-// ConnectClients populates collection of client-server connections.
+// ConnectClients populates collection of client-server controllers.
 //
 // Returns errors if server addresses doesn't resolve but will add
-// clients for any server addresses that are connectable.
+// controllers for any server addresses that are connectable.
 func (c *connList) ConnectClients(addresses Addresses) (
 	Addresses, ErrorMap) {
 
 	failures := make(ErrorMap)
 	for _, address := range addresses {
-		client := c.factory.createConn(address)
-		if err := client.connect(address); err != nil {
+		controller := c.factory.create(address)
+		if err := controller.connect(address); err != nil {
 			failures[address] = err
 			continue
 		}
-		c.clients = append(c.clients, client)
+		c.controllers = append(c.controllers, controller)
 	}
+
 	// small delay to allow correct states to register
 	time.Sleep(100 * time.Millisecond)
 	return c.GetActiveConns(failures)
@@ -107,19 +109,20 @@ func (c *connList) ConnectClients(addresses Addresses) (
 
 // GetActiveConns is an access method to verify active connections.
 //
-// Mutate client slice with only valid unique connected conns, return
+// Mutate controller slice with only valid unique connected conns, return
 // addresses and map of failed connections.
-// todo: resolve hostname and compare destination IPs for duplicates.
+//
+// TODO: resolve hostname and compare destination IPs for duplicates.
 func (c *connList) GetActiveConns(failures ErrorMap) (
 	addresses Addresses, eMap ErrorMap) {
 
-	if failures == nil {
+	eMap = failures
+	if eMap == nil {
 		eMap = make(ErrorMap)
-	} else {
-		eMap = failures
 	}
-	clients := c.clients[:0]
-	for _, mc := range c.clients {
+
+	controllers := c.controllers[:0]
+	for _, mc := range c.controllers {
 		address := mc.getAddress()
 		if common.Include(addresses, address) {
 			eMap[address] = fmt.Errorf("duplicate connection to %s", address)
@@ -128,32 +131,33 @@ func (c *connList) GetActiveConns(failures ErrorMap) (
 		state, ok := mc.connected()
 		if ok {
 			addresses = append(addresses, address)
-			clients = append(clients, mc)
+			controllers = append(controllers, mc)
 			continue
 		}
 		eMap[address] = fmt.Errorf("socket connection is not active (%s)", state)
 	}
-	c.clients = clients
+
+	c.controllers = controllers
 	return
 }
 
 // ClearConns clears all stored connections.
 func (c *connList) ClearConns() ErrorMap {
 	eMap := make(ErrorMap)
-	for _, client := range c.clients {
-		addr := client.getAddress()
-		if err := client.close(); err != nil {
+	for _, controller := range c.controllers {
+		addr := controller.getAddress()
+		if err := controller.disconnect(); err != nil {
 			eMap[addr] = err
 		}
 	}
-	c.clients = nil
+	c.controllers = nil
 	return eMap
 }
 
 // ListFeatures returns supported management features for each server connected.
-func (c *connList) ListFeatures() (ClientFeatureMap, error) {
-	cf := make(ClientFeatureMap)
-	for _, mc := range c.clients {
+func (c *connList) ListFeatures() (cFeatureMap, error) {
+	cf := make(cFeatureMap)
+	for _, mc := range c.controllers {
 		fMap, err := mc.listAllFeatures()
 		if err != nil {
 			return cf, err
@@ -164,9 +168,9 @@ func (c *connList) ListFeatures() (ClientFeatureMap, error) {
 }
 
 // ListNvme returns installed NVMe SSD controllers for each server connected.
-func (c *connList) ListNvme() (ClientNvmeMap, error) {
-	cCtrlrs := make(ClientNvmeMap)
-	for _, mc := range c.clients {
+func (c *connList) ListNvme() (cNvmeMap, error) {
+	cCtrlrs := make(cNvmeMap)
+	for _, mc := range c.controllers {
 		ctrlrs, err := mc.listNvmeCtrlrs()
 		if err != nil {
 			return cCtrlrs, err
@@ -177,9 +181,9 @@ func (c *connList) ListNvme() (ClientNvmeMap, error) {
 }
 
 // ListScm returns installed SCM module details for each server connected.
-func (c *connList) ListScm() (ClientScmMap, error) {
-	cmms := make(ClientScmMap)
-	for _, mc := range c.clients {
+func (c *connList) ListScm() (cScmMap, error) {
+	cmms := make(cScmMap)
+	for _, mc := range c.controllers {
 		mms, err := mc.listScmModules()
 		if err != nil {
 			return cmms, err
@@ -192,18 +196,20 @@ func (c *connList) ListScm() (ClientScmMap, error) {
 // KillRank Will terminate server running at given rank on pool specified by
 // uuid.
 func (c *connList) KillRank(uuid string, rank uint32) error {
-	for _, mc := range c.clients {
+	for _, mc := range c.controllers {
 		err := mc.killRank(uuid, rank)
 		if err != nil {
-			return err
+			return errors.WithMessage(err, mc.getAddress())
 		}
 	}
 	return nil
 }
 
-// NewConnections is a factory for Connections interface to operate over
+// NewConnect is a factory for Connect interface to operate over
 // multiple clients.
-func NewConnections() Connections {
-	var clients []Control
-	return &connList{factory: &connFactory{}, clients: clients}
+func NewConnect() Connect {
+	return &connList{
+		factory:     &controllerFactory{},
+		controllers: []Control{},
+	}
 }

--- a/src/control/client/connect_test.go
+++ b/src/control/client/connect_test.go
@@ -25,10 +25,12 @@ package client
 
 import (
 	"fmt"
+	"os"
 	"testing"
 
 	. "github.com/daos-stack/daos/src/control/common"
 	pb "github.com/daos-stack/daos/src/control/common/proto/mgmt"
+	"github.com/daos-stack/daos/src/control/log"
 
 	"google.golang.org/grpc/connectivity"
 )
@@ -40,22 +42,26 @@ var (
 	modules   = ScmModules{MockModulePB()}
 )
 
-type mockConnFactory struct {
+func init() {
+	log.NewDefaultLogger(log.Error, "connect_test: ", os.Stderr)
+}
+
+type mockControllerFactory struct {
 	state    connectivity.State
 	features []*pb.Feature
 	ctrlrs   NvmeControllers
 	modules  ScmModules
 }
 
-func (m *mockConnFactory) createConn(address string) Control {
+func (m *mockControllerFactory) create(address string) Control {
 	return newMockControl(address, m.state, m.features, m.ctrlrs, m.modules)
 }
 
-func newMockConnections(
+func newMockConnect(
 	state connectivity.State, features []*pb.Feature, ctrlrs NvmeControllers,
-	modules ScmModules) Connections {
+	modules ScmModules) Connect {
 
-	return &connList{factory: &mockConnFactory{state, features, ctrlrs, modules}}
+	return &connList{factory: &mockControllerFactory{state, features, ctrlrs, modules}}
 }
 
 func TestConnectClients(t *testing.T) {
@@ -72,7 +78,7 @@ func TestConnectClients(t *testing.T) {
 		{addresses, Addresses{}, connectivity.Shutdown, false},
 	}
 	for _, tt := range conntests {
-		cc := newMockConnections(tt.state, features, ctrlrs, modules)
+		cc := newMockConnect(tt.state, features, ctrlrs, modules)
 
 		addrs, eMap := cc.ConnectClients(tt.addrsIn)
 
@@ -94,15 +100,15 @@ func TestConnectClients(t *testing.T) {
 
 func clientSetup(
 	t *testing.T, state connectivity.State, features []*pb.Feature,
-	ctrlrs NvmeControllers, modules ScmModules) Connections {
+	ctrlrs NvmeControllers, modules ScmModules) Connect {
 
-	cc := newMockConnections(state, features, ctrlrs, modules)
+	cc := newMockConnect(state, features, ctrlrs, modules)
 	_, _ = cc.ConnectClients(addresses)
 	return cc
 }
 
 func TestDuplicateConns(t *testing.T) {
-	cc := newMockConnections(connectivity.Ready, features, ctrlrs, modules)
+	cc := newMockConnect(connectivity.Ready, features, ctrlrs, modules)
 	addrs, eMap := cc.ConnectClients(append(addresses, addresses...))
 
 	// verify duplicates are removed and failed attempts recorded.

--- a/src/control/client/control.go
+++ b/src/control/client/control.go
@@ -45,10 +45,10 @@ type ScmModules []*pb.ScmModule
 // representing a number of NVMe SSD controllers installed on a storage node.
 type NvmeControllers []*pb.NvmeController
 
-// Control interface specifies gRPC client functionality.
+// Control interface accesses gRPC client functionality.
 type Control interface {
 	connect(string) error
-	close() error
+	disconnect() error
 	connected() (connectivity.State, bool)
 	getAddress() string
 	listAllFeatures() (FeatureMap, error)
@@ -91,15 +91,12 @@ func (c *control) connect(addr string) (err error) {
 	return
 }
 
-// close terminates the underlying channel used by the grpc client service.
-func (c *control) close() error {
-	return c.gconn.Close()
-}
+// disconnect terminates the underlying channel used by the grpc
+// client service.
+func (c *control) disconnect() error { return c.gconn.Close() }
 
 // getAddress returns the target address of the connection.
-func (c *control) getAddress() string {
-	return c.gconn.Target()
-}
+func (c *control) getAddress() string { return c.gconn.Target() }
 
 func checkState(state connectivity.State) bool {
 	return (state == connectivity.Idle || state == connectivity.Ready)

--- a/src/control/client/control_test.go
+++ b/src/control/client/control_test.go
@@ -43,7 +43,7 @@ func (m *mockControl) connect(addr string) error {
 	m.address = addr
 	return nil
 }
-func (m *mockControl) close() error { return nil }
+func (m *mockControl) disconnect() error { return nil }
 func (m *mockControl) connected() (connectivity.State, bool) {
 	return m.connState, checkState(m.connState)
 }

--- a/src/control/client/mocks.go
+++ b/src/control/client/mocks.go
@@ -29,9 +29,9 @@ import (
 	pb "github.com/daos-stack/daos/src/control/common/proto/mgmt"
 )
 
-// NewClientFM provides a mock ClientFeatureMap for testing.
-func NewClientFM(features []*pb.Feature, addrs Addresses) ClientFeatureMap {
-	cf := make(ClientFeatureMap)
+// NewClientFM provides a mock cFeatureMap for testing.
+func NewClientFM(features []*pb.Feature, addrs Addresses) cFeatureMap {
+	cf := make(cFeatureMap)
 	for _, addr := range addrs {
 		fMap := make(FeatureMap)
 		for _, f := range features {
@@ -43,18 +43,18 @@ func NewClientFM(features []*pb.Feature, addrs Addresses) ClientFeatureMap {
 	return cf
 }
 
-// NewClientNvme provides a mock ClientNvmeMap for testing.
-func NewClientNvme(ctrlrs NvmeControllers, addrs Addresses) ClientNvmeMap {
-	cMap := make(ClientNvmeMap)
+// NewClientNvme provides a mock cNvmeMap for testing.
+func NewClientNvme(ctrlrs NvmeControllers, addrs Addresses) cNvmeMap {
+	cMap := make(cNvmeMap)
 	for _, addr := range addrs {
 		cMap[addr] = ctrlrs
 	}
 	return cMap
 }
 
-// NewClientScm provides a mock ClientScmMap for testing.
-func NewClientScm(mms ScmModules, addrs Addresses) ClientScmMap {
-	cMap := make(ClientScmMap)
+// NewClientScm provides a mock cScmMap for testing.
+func NewClientScm(mms ScmModules, addrs Addresses) cScmMap {
+	cMap := make(cScmMap)
 	for _, addr := range addrs {
 		cMap[addr] = mms
 	}

--- a/src/control/dmg/main.go
+++ b/src/control/dmg/main.go
@@ -66,7 +66,7 @@ type cliOptions struct {
 
 var (
 	opts  = new(cliOptions)
-	conns = client.NewConnections()
+	conns = client.NewConnect()
 )
 
 func connectHosts() error {

--- a/src/control/dmg/shell.go
+++ b/src/control/dmg/shell.go
@@ -65,7 +65,7 @@ func setupShell() *ishell.Shell {
 		Name: "listmgmtfeatures",
 		Help: "Command to retrieve all supported management features from any client connections",
 		Func: func(c *ishell.Context) {
-			c.Println(hasConnections(conns.GetActiveConns(nil)))
+			c.Println(hasConns(conns.GetActiveConns(nil)))
 			c.Printf(checkAndFormat(conns.ListFeatures()), "management feature")
 		},
 	})
@@ -74,7 +74,7 @@ func setupShell() *ishell.Shell {
 		Name: "listnvmecontrollers",
 		Help: "Command to list NVMe SSD controllers",
 		Func: func(c *ishell.Context) {
-			c.Println(hasConnections(conns.GetActiveConns(nil)))
+			c.Println(hasConns(conns.GetActiveConns(nil)))
 			c.Printf(
 				checkAndFormat(conns.ListNvme()),
 				"NVMe SSD controller and constituent namespace")
@@ -85,7 +85,7 @@ func setupShell() *ishell.Shell {
 		Name: "listscmmodules",
 		Help: "Command to list installed SCM modules",
 		Func: func(c *ishell.Context) {
-			c.Println(hasConnections(conns.GetActiveConns(nil)))
+			c.Println(hasConns(conns.GetActiveConns(nil)))
 			c.Printf(checkAndFormat(conns.ListScm()), "SCM module")
 		},
 	})
@@ -98,7 +98,7 @@ func setupShell() *ishell.Shell {
 				c.Println(c.HelpText())
 				return
 			}
-			c.Println(hasConnections(conns.GetActiveConns(nil)))
+			c.Println(hasConns(conns.GetActiveConns(nil)))
 			rank, err := strconv.Atoi(c.Args[1])
 			if err != nil {
 				c.Println("bad rank")

--- a/src/control/dmg/utils.go
+++ b/src/control/dmg/utils.go
@@ -31,7 +31,7 @@ import (
 	"github.com/daos-stack/daos/src/control/common"
 )
 
-func hasConnections(addrs client.Addresses, eMap client.ErrorMap) (
+func hasConns(addrs client.Addresses, eMap client.ErrorMap) (
 	out string) {
 
 	out = sprintConns(addrs, eMap)

--- a/src/control/dmg/utils_test.go
+++ b/src/control/dmg/utils_test.go
@@ -63,7 +63,7 @@ func TestHasConnection(t *testing.T) {
 		},
 	}
 	for _, tt := range shelltests {
-		AssertEqual(t, hasConnections(tt.addrs, tt.eMap), tt.out, "bad output")
+		AssertEqual(t, hasConns(tt.addrs, tt.eMap), tt.out, "bad output")
 	}
 }
 

--- a/src/control/drpc/drpc_client.go
+++ b/src/control/drpc/drpc_client.go
@@ -25,9 +25,10 @@ package drpc
 
 import (
 	"fmt"
+	"net"
+
 	"github.com/golang/protobuf/proto"
 	"github.com/pkg/errors"
-	"net"
 )
 
 // DomainSocketClient is the interface to a dRPC client communicating over a

--- a/src/control/drpc/drpc_client_test.go
+++ b/src/control/drpc/drpc_client_test.go
@@ -25,10 +25,11 @@ package drpc
 
 import (
 	"fmt"
-	. "github.com/daos-stack/daos/src/control/common"
-	"github.com/golang/protobuf/proto"
 	"net"
 	"testing"
+
+	. "github.com/daos-stack/daos/src/control/common"
+	"github.com/golang/protobuf/proto"
 )
 
 // testSockPath is an arbitrary path string to use for testing. These tests

--- a/src/control/security/domain_info.go
+++ b/src/control/security/domain_info.go
@@ -24,9 +24,10 @@
 package security
 
 import (
-	"golang.org/x/sys/unix"
 	"net"
 	"syscall"
+
+	"golang.org/x/sys/unix"
 )
 
 // DomainInfo holds our socket credentials to be used by the DomainSocketServer

--- a/src/control/server/commands.go
+++ b/src/control/server/commands.go
@@ -89,7 +89,7 @@ type PrepNvmeCommand struct {
 func (p *PrepNvmeCommand) Execute(args []string) error {
 	ok, usr := common.CheckSudo()
 	if !ok {
-		return errors.New("This subcommand must be run as root or sudo!")
+		return errors.New("subcommand must be run as root or sudo")
 	}
 
 	// falls back to sudoer or root if TargetUser is unspecified


### PR DESCRIPTION
Rename connection/client/control terminology to clarify intent.
Include linter fixes and test utility improvements.

Signed-off-by: Tom Nabarro <tom.nabarro@intel.com>