### PR TITLE
Test PR only - do not submit

### DIFF
--- a/src/include/daos/object.h
+++ b/src/include/daos/object.h
@@ -51,9 +51,14 @@ struct daos_obj_shard_md {
 /**
  * object layout information.
  **/
+struct daos_target_id {
+	uint32_t	ti_tgt;
+	uint32_t	ti_rank;
+};
+
 struct daos_obj_shard {
 	uint32_t	os_replica_nr;
-	uint32_t	os_ranks[0];
+	struct daos_target_id	os_ids[0];
 };
 
 struct daos_obj_layout {

--- a/src/object/cli_obj.c
+++ b/src/object/cli_obj.c
@@ -810,6 +810,10 @@ dc_obj_layout_get(daos_handle_t oh, struct daos_obj_layout **p_layout)
 
 			shard->os_ids[j].ti_rank = tgt->ta_comp.co_rank;
 			shard->os_ids[j].ti_tgt = tgt->ta_comp.co_id;
+			fprintf(stdout, "shard->os_ids[%d].ti_rank = %u\n", j,
+				shard->os_ids[j].ti_rank);
+			fprintf(stdout, "shard->os_ids[%d].ti_tgt = %u\n", j,
+				shard->os_ids[j].ti_rank);
 		}
 	}
 	*p_layout = layout;

--- a/src/object/cli_obj.c
+++ b/src/object/cli_obj.c
@@ -751,7 +751,7 @@ daos_obj_layout_alloc(struct daos_obj_layout **layout, uint32_t grp_nr,
 	for (i = 0; i < grp_nr; i++) {
 		D_ALLOC((*layout)->ol_shards[i],
 			sizeof(struct daos_obj_shard) +
-			grp_size * sizeof(uint32_t));
+			grp_size * sizeof(struct daos_target_id));
 		if ((*layout)->ol_shards[i] == NULL)
 			D_GOTO(free, rc = -DER_NOMEM);
 
@@ -796,13 +796,11 @@ dc_obj_layout_get(daos_handle_t oh, struct daos_obj_layout **p_layout)
 
 		shard = layout->ol_shards[i];
 		shard->os_replica_nr = grp_size;
-		for (j = 0; j < grp_size; j++) {
+		for (j = 0; j < grp_size; j++, k++) {
 			struct pool_target *tgt;
 
-			if (obj->cob_shards[k].do_target_id == -1) {
-				k++;
+			if (obj->cob_shards[k].do_target_id == -1)
 				continue;
-			}
 
 			rc = dc_cont_tgt_idx2ptr(obj->cob_coh,
 					obj->cob_shards[k].do_target_id,
@@ -810,7 +808,8 @@ dc_obj_layout_get(daos_handle_t oh, struct daos_obj_layout **p_layout)
 			if (rc != 0)
 				D_GOTO(out, rc);
 
-			shard->os_ranks[j] = tgt->ta_comp.co_rank;
+			shard->os_ids[j].ti_rank = tgt->ta_comp.co_rank;
+			shard->os_ids[j].ti_tgt = tgt->ta_comp.co_id;
 		}
 	}
 	*p_layout = layout;

--- a/src/pool/srv_pool.c
+++ b/src/pool/srv_pool.c
@@ -499,6 +499,7 @@ init_pool_metadata(struct rdb_tx *tx, const rdb_path_t *kvs, uint32_t uid,
 			map_comp.co_index = j;
 			map_comp.co_id = i * dss_tgt_nr + j;
 			map_comp.co_rank = target_addrs->rl_ranks[i];
+			printf("target_addrs->rl_ranks[%d]=%d\n", i, map_comp.co_rank);
 			map_comp.co_ver = map_version;
 			map_comp.co_fseq = 1;
 			map_comp.co_nr = 1;

--- a/src/tests/suite/daos_obj.c
+++ b/src/tests/suite/daos_obj.c
@@ -2707,7 +2707,7 @@ tgt_idx_change_retry(void **state)
 		assert_int_equal(layout->ol_shards[0]->os_replica_nr, 3);
 		/* FIXME disable rank compare until we fix the layout_get */
 		/* assert_int_equal(layout->ol_shards[0]->os_ranks[0], 2); */
-		rank = layout->ol_shards[0]->os_ranks[replica];
+		rank = layout->ol_shards[0]->os_ids[replica].ti_rank;
 		rc = daos_obj_layout_free(layout);
 		assert_int_equal(rc, 0);
 
@@ -2733,7 +2733,7 @@ tgt_idx_change_retry(void **state)
 		 *		     rank);
 		*/
 		print_message("target of shard %d changed from %d to %d\n",
-			      replica, rank, layout->ol_shards[0]->os_ranks[0]);
+			      replica, rank, layout->ol_shards[0]->os_ids[0].ti_rank);
 		rc = daos_obj_layout_free(layout);
 		assert_int_equal(rc, 0);
 	}

--- a/src/tests/suite/daos_rebuild.c
+++ b/src/tests/suite/daos_rebuild.c
@@ -47,6 +47,7 @@ rebuild_exclude_tgt(test_arg_t **args, int arg_cnt, d_rank_t rank,
 	int i;
 
 	if (kill) {
+		print_message("calling daos_kill_server()\n");
 		daos_kill_server(args[0], args[0]->pool.pool_uuid,
 				 args[0]->group, &args[0]->pool.svc,
 				 rank);
@@ -58,6 +59,7 @@ rebuild_exclude_tgt(test_arg_t **args, int arg_cnt, d_rank_t rank,
 	}
 
 	for (i = 0; i < arg_cnt; i++) {
+		print_message("calling daos_exclude_target()\n");
 		daos_exclude_target(args[i]->pool.pool_uuid,
 				    args[i]->group, &args[i]->pool.svc,
 				    rank, tgt_idx);
@@ -72,11 +74,13 @@ rebuild_add_tgt(test_arg_t **args, int args_cnt, d_rank_t rank,
 	int i;
 
 	for (i = 0; i < args_cnt; i++) {
-		if (!args[i]->pool.destroyed)
+		if (!args[i]->pool.destroyed) {
+			print_message("daos_add_target()\n");
 			daos_add_target(args[i]->pool.pool_uuid,
 					args[i]->group,
 					&args[i]->pool.svc,
 					rank, tgt_idx);
+			}
 	}
 }
 
@@ -86,19 +90,22 @@ rebuild_targets(test_arg_t **args, int args_cnt, d_rank_t *failed_ranks,
 {
 	int	i;
 
-	for (i = 0; i < args_cnt; i++)
+	for (i = 0; i < args_cnt; i++) {
 		if (args[i]->rebuild_pre_cb)
 			args[i]->rebuild_pre_cb(args[i]);
+	}
 
 	MPI_Barrier(MPI_COMM_WORLD);
 	/** exclude the target from the pool */
 	if (args[0]->myrank == 0) {
 		for (i = 0; i < rank_nr; i++) {
+			print_message("calling rebuild_exclude_tgt()\n");
 			rebuild_exclude_tgt(args, args_cnt, failed_ranks[i],
 					    failed_tgts ? failed_tgts[i] : -1,
 					    kill);
 			/* Sleep 5 seconds to make sure the rebuild start */
 			sleep(5);
+			print_message("rebuild should have already started\n");
 		}
 	}
 	MPI_Barrier(MPI_COMM_WORLD);
@@ -107,41 +114,25 @@ rebuild_targets(test_arg_t **args, int args_cnt, d_rank_t *failed_ranks,
 		if (args[i]->rebuild_cb)
 			args[i]->rebuild_cb(args[i]);
 
-	if (args[0]->myrank == 0)
+	if (args[0]->myrank == 0) {
 		test_rebuild_wait(args, args_cnt);
+	}
 
 	MPI_Barrier(MPI_COMM_WORLD);
 	/* Add back the target if it is not being killed */
 	if (!kill && args[0]->myrank == 0) {
-		for (i = 0; i < rank_nr; i++)
+		for (i = 0; i < rank_nr; i++) {
+			print_message("rebuild_add_tgt()\n");
 			rebuild_add_tgt(args, args_cnt, failed_ranks[i],
 					failed_tgts ? failed_tgts[i] : -1);
+		}
 	}
 
 	MPI_Barrier(MPI_COMM_WORLD);
-	for (i = 0; i < args_cnt; i++)
+	for (i = 0; i < args_cnt; i++) {
 		if (args[i]->rebuild_post_cb)
 			args[i]->rebuild_post_cb(args[i]);
-}
-
-static void
-rebuild_single_pool_rank(test_arg_t *arg, d_rank_t failed_rank)
-{
-	rebuild_targets(&arg, 1, &failed_rank, NULL, 1, false);
-}
-
-static void
-rebuild_pools_ranks(test_arg_t **args, int args_cnt, d_rank_t *failed_ranks,
-		    int ranks_nr)
-{
-	rebuild_targets(args, args_cnt, failed_ranks, NULL, ranks_nr, false);
-}
-
-static void
-rebuild_single_pool_target(test_arg_t *arg, d_rank_t failed_rank,
-			   int failed_tgt)
-{
-	rebuild_targets(&arg, 1, &failed_rank, &failed_tgt, 1, false);
+	}
 }
 
 static int
@@ -293,8 +284,11 @@ rebuild_io(test_arg_t *arg, daos_obj_id_t *oids, int oids_nr)
 	for (i = 0; i < oids_nr; i++) {
 		ioreq_init(&req, arg->coh, oids[i], DAOS_IOD_ARRAY, arg);
 		if (i == punch_idx) {
+			print_message("punching obj "DF_U64"\n", oids[i].lo);
 			punch_obj(DAOS_TX_NONE, &req);
 		} else {
+			print_message("create records on obj "DF_U64"\n",
+					oids[i].lo);
 			rebuild_io_obj_internal((&req), false, eph, -1);
 		}
 		ioreq_fini(&req);
@@ -310,6 +304,7 @@ rebuild_io_validate(test_arg_t *arg, daos_obj_id_t *oids, int oids_nr,
 	int		i;
 	int		punch_idx = 1;
 
+	print_message("rebuild_io_validate\n");
 	arg->fail_loc = DAOS_OBJ_SPECIAL_SHARD;
 	/* Validate data for each shard */
 	for (i = 0; i < OBJ_REPLICAS; i++) {
@@ -333,507 +328,6 @@ rebuild_io_validate(test_arg_t *arg, daos_obj_id_t *oids, int oids_nr,
 	arg->fail_value = 0;
 }
 
-static void
-rebuild_dkeys(void **state)
-{
-	test_arg_t		*arg = *state;
-	daos_obj_id_t		oid;
-	struct ioreq		req;
-	int			i;
-
-	if (!test_runable(arg, 6))
-		return;
-
-	oid = dts_oid_gen(DAOS_OC_R3S_SPEC_RANK, 0, arg->myrank);
-	oid = dts_oid_set_rank(oid, ranks_to_kill[0]);
-	oid = dts_oid_set_tgt(oid, DEFAULT_FAIL_TGT);
-	ioreq_init(&req, arg->coh, oid, DAOS_IOD_ARRAY, arg);
-
-	/** Insert 1000 records */
-	print_message("Insert %d kv record in object "DF_OID"\n",
-		      KEY_NR, DP_OID(oid));
-	for (i = 0; i < KEY_NR; i++) {
-		char	key[16];
-
-		sprintf(key, "%d", i);
-		insert_single(key, "a_key", 0, "data", strlen("data") + 1,
-			      DAOS_TX_NONE, &req);
-	}
-	ioreq_fini(&req);
-
-	rebuild_single_pool_target(arg, ranks_to_kill[0], DEFAULT_FAIL_TGT);
-}
-
-static void
-rebuild_akeys(void **state)
-{
-	test_arg_t		*arg = *state;
-	daos_obj_id_t		oid;
-	struct ioreq		req;
-	int			i;
-
-	if (!test_runable(arg, 6))
-		return;
-
-	oid = dts_oid_gen(DAOS_OC_R3S_SPEC_RANK, 0, arg->myrank);
-	oid = dts_oid_set_rank(oid, ranks_to_kill[0]);
-	oid = dts_oid_set_tgt(oid, DEFAULT_FAIL_TGT);
-	ioreq_init(&req, arg->coh, oid, DAOS_IOD_ARRAY, arg);
-
-	/** Insert 1000 records */
-	print_message("Insert %d kv record in object "DF_OID"\n",
-		      KEY_NR, DP_OID(oid));
-	for (i = 0; i < KEY_NR; i++) {
-		char	akey[16];
-
-		sprintf(akey, "%d", i);
-		insert_single("d_key", akey, 0, "data", strlen("data") + 1,
-			      DAOS_TX_NONE, &req);
-	}
-	ioreq_fini(&req);
-
-	rebuild_single_pool_target(arg, ranks_to_kill[0], DEFAULT_FAIL_TGT);
-}
-
-static void
-rebuild_indexes(void **state)
-{
-	test_arg_t		*arg = *state;
-	daos_obj_id_t		oid;
-	struct ioreq		req;
-	int			i;
-	int			j;
-
-	if (!test_runable(arg, 6))
-		return;
-
-	oid = dts_oid_gen(DAOS_OC_R3S_SPEC_RANK, 0, arg->myrank);
-	oid = dts_oid_set_rank(oid, ranks_to_kill[0]);
-	oid = dts_oid_set_tgt(oid, DEFAULT_FAIL_TGT);
-	ioreq_init(&req, arg->coh, oid, DAOS_IOD_ARRAY, arg);
-
-	/** Insert 2000 records */
-	print_message("Insert %d kv record in object "DF_OID"\n",
-		      2000, DP_OID(oid));
-	for (i = 0; i < 100; i++) {
-		char	key[16];
-
-		sprintf(key, "%d", i);
-		for (j = 0; j < 20; j++)
-			insert_single(key, "a_key", j, "data",
-				      strlen("data") + 1, DAOS_TX_NONE, &req);
-	}
-	ioreq_fini(&req);
-
-	/* Rebuild rank 1 */
-	rebuild_single_pool_target(arg, ranks_to_kill[0], DEFAULT_FAIL_TGT);
-}
-
-static void
-rebuild_multiple(void **state)
-{
-	test_arg_t	*arg = *state;
-	daos_obj_id_t	oid;
-	struct ioreq	req;
-	int		i;
-	int		j;
-	int		k;
-
-	if (!test_runable(arg, 6))
-		return;
-
-	oid = dts_oid_gen(DAOS_OC_R3S_SPEC_RANK, 0, arg->myrank);
-	oid = dts_oid_set_rank(oid, ranks_to_kill[0]);
-	oid = dts_oid_set_tgt(oid, DEFAULT_FAIL_TGT);
-	ioreq_init(&req, arg->coh, oid, DAOS_IOD_ARRAY, arg);
-
-	/** Insert 1000 records */
-	print_message("Insert %d kv record in object "DF_OID"\n",
-		      1000, DP_OID(oid));
-	for (i = 0; i < 10; i++) {
-		char	dkey[16];
-
-		sprintf(dkey, "dkey_%d", i);
-		for (j = 0; j < 10; j++) {
-			char	akey[16];
-
-			sprintf(akey, "akey_%d", j);
-			for (k = 0; k < 10; k++)
-				insert_single(dkey, akey, k, "data",
-					      strlen("data") + 1,
-					      DAOS_TX_NONE, &req);
-		}
-	}
-	ioreq_fini(&req);
-
-	rebuild_single_pool_target(arg, ranks_to_kill[0], DEFAULT_FAIL_TGT);
-}
-
-static void
-rebuild_large_rec(void **state)
-{
-	test_arg_t		*arg = *state;
-	daos_obj_id_t		oid;
-	struct ioreq		req;
-	int			i;
-	char			buffer[5000];
-
-	if (!test_runable(arg, 6))
-		return;
-
-	oid = dts_oid_gen(DAOS_OC_R3S_SPEC_RANK, 0, arg->myrank);
-	oid = dts_oid_set_rank(oid, ranks_to_kill[0]);
-	oid = dts_oid_set_tgt(oid, DEFAULT_FAIL_TGT);
-	ioreq_init(&req, arg->coh, oid, DAOS_IOD_ARRAY, arg);
-
-	/** Insert 1000 records */
-	print_message("Insert %d kv record in object "DF_OID"\n",
-		      KEY_NR, DP_OID(oid));
-	memset(buffer, 'a', 5000);
-	for (i = 0; i < KEY_NR; i++) {
-		char	key[16];
-
-		sprintf(key, "%d", i);
-		insert_single(key, "a_key", 0, buffer, 5000, DAOS_TX_NONE,
-			      &req);
-	}
-	ioreq_fini(&req);
-
-	rebuild_single_pool_target(arg, ranks_to_kill[0], DEFAULT_FAIL_TGT);
-}
-
-static void
-rebuild_objects(void **state)
-{
-	test_arg_t	*arg = *state;
-	daos_obj_id_t	oids[OBJ_NR];
-	int		i;
-
-	if (!test_runable(arg, 6))
-		return;
-
-	for (i = 0; i < OBJ_NR; i++) {
-		oids[i] = dts_oid_gen(DAOS_OC_R3S_SPEC_RANK, 0, arg->myrank);
-		oids[i] = dts_oid_set_rank(oids[i], ranks_to_kill[0]);
-		oids[i] = dts_oid_set_tgt(oids[i], DEFAULT_FAIL_TGT);
-	}
-
-	rebuild_io(arg, oids, OBJ_NR);
-
-	rebuild_single_pool_target(arg, ranks_to_kill[0], DEFAULT_FAIL_TGT);
-
-	rebuild_io_validate(arg, oids, OBJ_NR, false);
-}
-
-static void
-rebuild_drop_scan(void **state)
-{
-	test_arg_t	*arg = *state;
-	daos_obj_id_t	oids[OBJ_NR];
-	int		i;
-
-	if (!test_runable(arg, 6))
-		return;
-
-	for (i = 0; i < OBJ_NR; i++) {
-		oids[i] = dts_oid_gen(DAOS_OC_R3S_SPEC_RANK, 0, arg->myrank);
-		oids[i] = dts_oid_set_rank(oids[i], ranks_to_kill[0]);
-		oids[i] = dts_oid_set_tgt(oids[i], DEFAULT_FAIL_TGT);
-	}
-
-	rebuild_io(arg, oids, OBJ_NR);
-
-	/* Set drop scan fail_loc on server 0 */
-	if (arg->myrank == 0)
-		daos_mgmt_set_params(arg->group, 0, DSS_KEY_FAIL_LOC,
-				     DAOS_REBUILD_NO_HDL | DAOS_FAIL_ONCE,
-				     0, NULL);
-	MPI_Barrier(MPI_COMM_WORLD);
-	rebuild_single_pool_target(arg, ranks_to_kill[0], DEFAULT_FAIL_TGT);
-
-	rebuild_io_validate(arg, oids, OBJ_NR, true);
-}
-
-static void
-rebuild_retry_rebuild(void **state)
-{
-	test_arg_t	*arg = *state;
-	daos_obj_id_t	oids[OBJ_NR];
-	int		i;
-
-	if (!test_runable(arg, 6))
-		return;
-
-	for (i = 0; i < OBJ_NR; i++) {
-		oids[i] = dts_oid_gen(DAOS_OC_R3S_SPEC_RANK, 0, arg->myrank);
-		oids[i] = dts_oid_set_rank(oids[i], ranks_to_kill[0]);
-		oids[i] = dts_oid_set_tgt(oids[i], DEFAULT_FAIL_TGT);
-	}
-
-	rebuild_io(arg, oids, OBJ_NR);
-
-	/* Set no hdl fail_loc on all servers */
-	if (arg->myrank == 0)	
-		daos_mgmt_set_params(arg->group, -1, DSS_KEY_FAIL_LOC,
-				     DAOS_REBUILD_NO_HDL | DAOS_FAIL_ONCE,
-				     0, NULL);
-	MPI_Barrier(MPI_COMM_WORLD);
-	rebuild_single_pool_target(arg, ranks_to_kill[0], DEFAULT_FAIL_TGT);
-
-	rebuild_io_validate(arg, oids, OBJ_NR, true);
-}
-
-static void
-rebuild_retry_for_stale_pool(void **state)
-{
-	test_arg_t	*arg = *state;
-	daos_obj_id_t	oids[OBJ_NR];
-	int		i;
-
-	if (!test_runable(arg, 6))
-		return;
-
-	for (i = 0; i < OBJ_NR; i++) {
-		oids[i] = dts_oid_gen(DAOS_OC_R3S_SPEC_RANK, 0, arg->myrank);
-		oids[i] = dts_oid_set_rank(oids[i], ranks_to_kill[0]);
-	}
-
-	rebuild_io(arg, oids, OBJ_NR);
-
-	/* Set no hdl fail_loc on all servers */
-	if (arg->myrank == 0)
-		daos_mgmt_set_params(arg->group, -1, DSS_KEY_FAIL_LOC,
-				     DAOS_REBUILD_STALE_POOL | DAOS_FAIL_ONCE,
-				     0, NULL);
-	MPI_Barrier(MPI_COMM_WORLD);
-	rebuild_single_pool_rank(arg, ranks_to_kill[0]);
-
-	rebuild_io_validate(arg, oids, OBJ_NR, true);
-}
-
-static void
-rebuild_drop_obj(void **state)
-{
-	test_arg_t	*arg = *state;
-	daos_obj_id_t	oids[OBJ_NR];
-	int		i;
-
-	if (!test_runable(arg, 6))
-		return;
-
-	for (i = 0; i < OBJ_NR; i++) {
-		oids[i] = dts_oid_gen(DAOS_OC_R3S_SPEC_RANK, 0, arg->myrank);
-		oids[i] = dts_oid_set_rank(oids[i], ranks_to_kill[0]);
-	}
-
-	rebuild_io(arg, oids, OBJ_NR);
-
-	/* Set drop REBUILD_OBJECTS reply on all servers */
-	if (arg->myrank == 0)
-		daos_mgmt_set_params(arg->group, 0, DSS_KEY_FAIL_LOC,
-				     DAOS_REBUILD_DROP_OBJ | DAOS_FAIL_ONCE,
-				     0, NULL);
-	MPI_Barrier(MPI_COMM_WORLD);
-	rebuild_single_pool_rank(arg, ranks_to_kill[0]);
-
-	rebuild_io_validate(arg, oids, OBJ_NR, true);
-}
-
-static void
-rebuild_update_failed(void **state)
-{
-	test_arg_t	*arg = *state;
-	daos_obj_id_t	oids[OBJ_NR];
-	int		i;
-
-	if (!test_runable(arg, 6))
-		return;
-
-	for (i = 0; i < OBJ_NR; i++) {
-		oids[i] = dts_oid_gen(DAOS_OC_R3S_SPEC_RANK, 0, arg->myrank);
-		oids[i] = dts_oid_set_rank(oids[i], ranks_to_kill[0]);
-		oids[i] = dts_oid_set_tgt(oids[i], DEFAULT_FAIL_TGT);
-	}
-
-	rebuild_io(arg, oids, OBJ_NR);
-
-	/* Set drop scan reply on all servers */
-	if (arg->myrank == 0)
-		daos_mgmt_set_params(arg->group, 0, DSS_KEY_FAIL_LOC,
-				     DAOS_REBUILD_UPDATE_FAIL | DAOS_FAIL_ONCE,
-				     0, NULL);
-	MPI_Barrier(MPI_COMM_WORLD);
-	rebuild_single_pool_target(arg, ranks_to_kill[0], DEFAULT_FAIL_TGT);
-}
-
-static void
-rebuild_multiple_pools(void **state)
-{
-	test_arg_t	*arg = *state;
-	test_arg_t	*args[2] = { 0 };
-	daos_obj_id_t	oids[OBJ_NR];
-	int		i;
-	int		rc;
-
-	if (!test_runable(arg, 6))
-		return;
-
-	args[0] = arg;
-	/* create/connect another pool */
-	rc = test_setup((void **)&args[1], SETUP_CONT_CONNECT, arg->multi_rank,
-			REBUILD_POOL_SIZE, NULL);
-	if (rc) {
-		print_message("open/connect another pool failed: rc %d\n", rc);
-		return;
-	}
-
-	for (i = 0; i < OBJ_NR; i++) {
-		oids[i] = dts_oid_gen(DAOS_OC_R3S_SPEC_RANK, 0, arg->myrank);
-		oids[i] = dts_oid_set_rank(oids[i], ranks_to_kill[0]);
-	}
-
-	rebuild_io(args[0], oids, OBJ_NR);
-	rebuild_io(args[1], oids, OBJ_NR);
-
-	rebuild_pools_ranks(args, 2, ranks_to_kill, 1);
-
-	rebuild_io_validate(args[0], oids, OBJ_NR, true);
-	rebuild_io_validate(args[1], oids, OBJ_NR, true);
-
-	test_teardown((void **)&args[1]);
-}
-
-static int
-rebuild_close_container_cb(void *data)
-{
-	test_arg_t	*arg = data;
-	int		rc = 0;
-	int		rc_reduce = 0;
-
-	if (daos_handle_is_inval(arg->coh))
-		return 0;
-
-	rc = daos_cont_close(arg->coh, NULL);
-	if (arg->multi_rank) {
-		MPI_Allreduce(&rc, &rc_reduce, 1, MPI_INT, MPI_MIN,
-			      MPI_COMM_WORLD);
-		rc = rc_reduce;
-	}
-	print_message("container close "DF_UUIDF"\n",
-		      DP_UUID(arg->co_uuid));
-	if (rc) {
-		print_message("failed to close container "DF_UUIDF
-			      ": %d\n", DP_UUID(arg->co_uuid), rc);
-		return rc;
-	}
-	arg->coh = DAOS_HDL_INVAL;
-
-	return 0;
-}
-
-static int
-rebuild_destroy_container_cb(void *data)
-{
-	test_arg_t	*arg = data;
-	int		rc = 0;
-
-	if (uuid_is_null(arg->co_uuid))
-		return 0;
-
-	rc = rebuild_close_container_cb(data);
-	if (rc)
-		return rc;
-
-	while (arg->myrank == 0) {
-		rc = daos_cont_destroy(arg->pool.poh, arg->co_uuid, 1, NULL);
-		if (rc == -DER_BUSY || rc == -DER_IO) {
-			print_message("Container is busy, wait\n");
-			sleep(1);
-			continue;
-		}
-		break;
-	}
-	print_message("container "DF_UUIDF"/"DF_UUIDF" destroyed\n",
-		      DP_UUID(arg->pool.pool_uuid), DP_UUID(arg->co_uuid));
-	if (arg->multi_rank)
-		MPI_Bcast(&rc, 1, MPI_INT, 0, MPI_COMM_WORLD);
-	if (rc)
-		print_message("failed to destroy container "DF_UUIDF
-			      ": %d\n", DP_UUID(arg->co_uuid), rc);
-	uuid_clear(arg->co_uuid);
-
-	return rc;
-}
-
-static void
-rebuild_destroy_container(void **state)
-{
-	test_arg_t	*arg = *state;
-	test_arg_t	*args[2] = { 0 };
-	daos_obj_id_t	oids[OBJ_NR];
-	int		i;
-	int		rc;
-
-	if (!test_runable(arg, 6))
-		return;
-
-	args[0] = arg;
-	/* create/connect another pool */
-	rc = test_setup((void **)&args[1], SETUP_CONT_CONNECT, arg->multi_rank,
-			REBUILD_POOL_SIZE, NULL);
-	if (rc) {
-		print_message("open/connect another pool failed: rc %d\n", rc);
-		return;
-	}
-
-	for (i = 0; i < OBJ_NR; i++) {
-		oids[i] = dts_oid_gen(DAOS_OC_R3S_SPEC_RANK, 0, arg->myrank);
-		oids[i] = dts_oid_set_rank(oids[i], ranks_to_kill[0]);
-	}
-
-	rebuild_io(args[1], oids, OBJ_NR);
-
-	args[1]->rebuild_cb = rebuild_destroy_container_cb;
-
-	rebuild_pools_ranks(args, 2, ranks_to_kill, 1);
-
-	test_teardown((void **)&args[1]);
-}
-
-static void
-rebuild_close_container(void **state)
-{
-	test_arg_t	*arg = *state;
-	test_arg_t	*args[2] = { 0 };
-	daos_obj_id_t	oids[OBJ_NR];
-	int		i;
-	int		rc;
-
-	if (!test_runable(arg, 6))
-		return;
-
-	args[0] = arg;
-	/* create/connect another pool */
-	rc = test_setup((void **)&args[1], SETUP_CONT_CONNECT, arg->multi_rank,
-			REBUILD_POOL_SIZE, NULL);
-	if (rc) {
-		print_message("open/connect another pool failed: rc %d\n", rc);
-		return;
-	}
-
-	for (i = 0; i < OBJ_NR; i++) {
-		oids[i] = dts_oid_gen(DAOS_OC_R3S_SPEC_RANK, 0, arg->myrank);
-		oids[i] = dts_oid_set_rank(oids[i], ranks_to_kill[0]);
-	}
-
-	rebuild_io(args[1], oids, OBJ_NR);
-
-	args[1]->rebuild_pre_cb = rebuild_close_container_cb;
-
-	rebuild_pools_ranks(args, 2, ranks_to_kill, 1);
-
-	test_teardown((void **)&args[1]);
-}
 
 static int
 rebuild_pool_disconnect_internal(void *data)
@@ -866,179 +360,14 @@ rebuild_pool_disconnect_internal(void *data)
 	print_message("pool disconnect "DF_UUIDF"\n",
 		      DP_UUID(arg->pool.pool_uuid));
 
+	print_message("Pause to check object layout before server eviction\n");
+	sleep(30);
+
 	arg->pool.poh = DAOS_HDL_INVAL;
 	MPI_Barrier(MPI_COMM_WORLD);
 	return rc;
 }
 
-static int
-rebuild_destroy_pool_cb(void *data)
-{
-	test_arg_t	*arg = data;
-	int		rc = 0;
-
-	rebuild_pool_disconnect_internal(data);
-
-	if (arg->myrank == 0) {
-		rc = daos_pool_destroy(arg->pool.pool_uuid, NULL, true, NULL);
-		if (rc)
-			print_message("failed to destroy pool"DF_UUIDF" %d\n",
-				      DP_UUID(arg->pool.pool_uuid), rc);
-	}
-
-	arg->pool.destroyed = true;
-	print_message("pool destroyed "DF_UUIDF"\n",
-		      DP_UUID(arg->pool.pool_uuid));
-	/* Disable fail_loc and start rebuild */
-	if (arg->myrank == 0)
-		daos_mgmt_set_params(arg->group, -1, DSS_KEY_FAIL_LOC,
-				     0, 0, NULL);
-
-	MPI_Barrier(MPI_COMM_WORLD);
-
-	return rc;
-}
-
-static void
-rebuild_destroy_pool_internal(void **state, uint64_t fail_loc)
-{
-	test_arg_t	*arg = *state;
-	test_arg_t	*args[2] = { 0 };
-	daos_obj_id_t	oids[OBJ_NR];
-	int		i;
-	int		rc;
-
-	if (!test_runable(arg, 6))
-		return;
-
-	args[0] = arg;
-	/* create/connect another pool */
-	rc = test_setup((void **)&args[1], SETUP_CONT_CONNECT, arg->multi_rank,
-			REBUILD_POOL_SIZE, NULL);
-	if (rc) {
-		print_message("open/connect another pool failed: rc %d\n", rc);
-		return;
-	}
-
-	for (i = 0; i < OBJ_NR; i++) {
-		oids[i] = dts_oid_gen(DAOS_OC_R3S_SPEC_RANK, 0, arg->myrank);
-		oids[i] = dts_oid_set_rank(oids[i], ranks_to_kill[0]);
-	}
-
-	rebuild_io(args[1], oids, OBJ_NR);
-
-	/* hang the rebuild */
-	if (arg->myrank == 0)
-		daos_mgmt_set_params(arg->group, -1, DSS_KEY_FAIL_LOC, fail_loc,
-				     0, NULL);
-
-	args[1]->rebuild_cb = rebuild_destroy_pool_cb;
-
-	rebuild_pools_ranks(args, 2, ranks_to_kill, 1);
-}
-
-static void
-rebuild_destroy_pool_during_scan(void ** state)
-{
-	return rebuild_destroy_pool_internal(state, DAOS_REBUILD_TGT_SCAN_HANG);
-}
-
-static void
-rebuild_destroy_pool_during_rebuild(void ** state)
-{
-	return rebuild_destroy_pool_internal(state,
-					     DAOS_REBUILD_TGT_REBUILD_HANG);
-}
-
-static void
-rebuild_iv_tgt_fail(void **state)
-{
-	test_arg_t	*arg = *state;
-	daos_obj_id_t	oids[OBJ_NR];
-	int		i;
-
-	if (!test_runable(arg, 6))
-		return;
-
-	for (i = 0; i < OBJ_NR; i++) {
-		oids[i] = dts_oid_gen(DAOS_OC_R3S_SPEC_RANK, 0, arg->myrank);
-		oids[i] = dts_oid_set_rank(oids[i], ranks_to_kill[0]);
-	}
-
-	rebuild_io(arg, oids, OBJ_NR);
-
-	/* Set no hdl fail_loc on all servers */
-	if (arg->myrank == 0)
-		daos_mgmt_set_params(arg->group, -1, DSS_KEY_FAIL_LOC,
-				     DAOS_REBUILD_TGT_IV_UPDATE_FAIL |
-				     DAOS_FAIL_ONCE, 0, NULL);
-	MPI_Barrier(MPI_COMM_WORLD);
-	rebuild_single_pool_rank(arg, ranks_to_kill[0]);
-
-	rebuild_io_validate(arg, oids, OBJ_NR, true);
-}
-
-static void
-rebuild_tgt_start_fail(void **state)
-{
-	test_arg_t	*arg = *state;
-	daos_obj_id_t	oids[OBJ_NR];
-	int		i;
-
-	if (!test_runable(arg, 6))
-		return;
-
-	for (i = 0; i < OBJ_NR; i++) {
-		oids[i] = dts_oid_gen(DAOS_OC_R3S_SPEC_RANK, 0, arg->myrank);
-		oids[i] = dts_oid_set_rank(oids[i], ranks_to_kill[0]);
-	}
-
-	rebuild_io(arg, oids, OBJ_NR);
-
-	/* failed to start rebuild on rank 0 */
-	if (arg->myrank == 0)
-		daos_mgmt_set_params(arg->group, 0, DSS_KEY_FAIL_LOC,
-				  DAOS_REBUILD_TGT_START_FAIL | DAOS_FAIL_ONCE,
-				  0, NULL);
-	MPI_Barrier(MPI_COMM_WORLD);
-	rebuild_single_pool_rank(arg, ranks_to_kill[0]);
-
-	rebuild_io_validate(arg, oids, OBJ_NR, true);
-}
-
-static void
-rebuild_send_objects_fail(void **state)
-{
-	test_arg_t	*arg = *state;
-	daos_obj_id_t	oids[OBJ_NR];
-	int		i;
-
-	if (!test_runable(arg, 6))
-		return;
-
-	for (i = 0; i < OBJ_NR; i++) {
-		oids[i] = dts_oid_gen(DAOS_OC_R3S_SPEC_RANK, 0, arg->myrank);
-		oids[i] = dts_oid_set_rank(oids[i], ranks_to_kill[0]);
-	}
-
-	rebuild_io(arg, oids, OBJ_NR);
-
-	/* Skip object send on all of the targets */
-	if (arg->myrank == 0)
-		daos_mgmt_set_params(arg->group, -1, DSS_KEY_FAIL_LOC,
-				     DAOS_REBUILD_TGT_SEND_OBJS_FAIL, 0, NULL);
-	MPI_Barrier(MPI_COMM_WORLD);
-	/* Even do not sending the objects, the rebuild should still be
-	 * able to finish.
-	 */
-	rebuild_single_pool_rank(arg, ranks_to_kill[0]);
-
-	/* failed to start rebuild on rank 0 */
-	if (arg->myrank == 0)
-		daos_mgmt_set_params(arg->group, -1, DSS_KEY_FAIL_LOC, 0,
-				     0, NULL);
-	MPI_Barrier(MPI_COMM_WORLD);
-}
 
 static int
 rebuild_pool_connect_internal(void *data)
@@ -1075,6 +404,7 @@ rebuild_pool_connect_internal(void *data)
 	/** open container */
 	MPI_Barrier(MPI_COMM_WORLD);
 	if (arg->myrank == 0) {
+		print_message("daos_cont_open()\n");
 		rc = daos_cont_open(arg->pool.poh, arg->co_uuid, DAOS_COO_RW,
 				    &arg->coh, &arg->co_info, NULL);
 		if (rc)
@@ -1099,150 +429,23 @@ rebuild_pool_connect_internal(void *data)
 	return 0;
 }
 
-static int
-rebuild_pool_disconnect_cb(void *data)
-{
-	test_arg_t	*arg = data;
-
-	rebuild_pool_disconnect_internal(data);
-
-	/* Disable fail_loc and start rebuild */
-	if (arg->myrank == 0)
-		daos_mgmt_set_params(arg->group, -1, DSS_KEY_FAIL_LOC,
-				     0, 0, NULL);
-	MPI_Barrier(MPI_COMM_WORLD);
-
-	return 0;
-}
-
-static void
-rebuild_tgt_pool_disconnect_internal(void **state, unsigned int fail_loc)
-{
-	test_arg_t	*arg = *state;
-	daos_obj_id_t	oids[OBJ_NR];
-	int		i;
-
-	if (!test_runable(arg, 6))
-		return;
-
-	for (i = 0; i < OBJ_NR; i++) {
-		oids[i] = dts_oid_gen(DAOS_OC_R3S_SPEC_RANK, 0, arg->myrank);
-		oids[i] = dts_oid_set_rank(oids[i], ranks_to_kill[0]);
-	}
-
-	rebuild_io(arg, oids, OBJ_NR);
-
-	/* hang the rebuild during scan */
-	if (arg->myrank == 0)
-		daos_mgmt_set_params(arg->group, -1, DSS_KEY_FAIL_LOC, fail_loc,
-				     0, NULL);
-	MPI_Barrier(MPI_COMM_WORLD);
-
-	/* NB: During the test, one target will be excluded from the pool map,
-	 * then container/pool will be closed/disconnectd during the rebuild,
-	 * i.e. before the target is added back. so the container hdl cache
-	 * will be left on the excluded target after the target is added back.
-	 * So the container might not be able to destroyed because of the left
-	 * over container hdl. Once the container is able to evict the container
-	 * hdl, then this issue can be fixed. XXX
-	 */
-	arg->rebuild_cb = rebuild_pool_disconnect_cb;
-	arg->rebuild_post_cb = rebuild_pool_connect_internal;
-
-	rebuild_single_pool_rank(arg, ranks_to_kill[0]);
-
-	arg->rebuild_cb = NULL;
-	arg->rebuild_post_cb = NULL;
-}
-
-static void
-rebuild_tgt_pool_disconnect_in_scan(void **state)
-{
-	rebuild_tgt_pool_disconnect_internal(state,
-					     DAOS_REBUILD_TGT_SCAN_HANG);
-}
-
-static void
-rebuild_tgt_pool_disconnect_in_rebuild(void **state)
-{
-	rebuild_tgt_pool_disconnect_internal(state,
-					     DAOS_REBUILD_TGT_REBUILD_HANG);
-}
-
-static int
-rebuild_pool_connect_cb(void *data)
-{
-	test_arg_t	*arg = data;
-
-	rebuild_pool_connect_internal(data);
-	/* Disable fail_loc and start rebuild */
-	if (arg->myrank == 0)
-		daos_mgmt_set_params(arg->group, -1, DSS_KEY_FAIL_LOC,
-				     0, 0, NULL);
-	MPI_Barrier(MPI_COMM_WORLD);
-	return 0;
-}
-
-static void
-rebuild_offline_pool_connect_internal(void **state, unsigned int fail_loc)
-{
-	test_arg_t	*arg = *state;
-	daos_obj_id_t	oids[OBJ_NR];
-	int		i;
-
-	if (!test_runable(arg, 6))
-		return;
-
-	for (i = 0; i < OBJ_NR; i++) {
-		oids[i] = dts_oid_gen(DAOS_OC_R3S_SPEC_RANK, 0, arg->myrank);
-		oids[i] = dts_oid_set_rank(oids[i], ranks_to_kill[0]);
-	}
-
-	rebuild_io(arg, oids, OBJ_NR);
-
-	/* hang the rebuild */
-	if (arg->myrank == 0)
-		daos_mgmt_set_params(arg->group, -1, DSS_KEY_FAIL_LOC, fail_loc,
-				     0, NULL);
-	MPI_Barrier(MPI_COMM_WORLD);
-
-	arg->rebuild_pre_cb = rebuild_pool_disconnect_internal;
-	arg->rebuild_cb = rebuild_pool_connect_cb;
-
-	rebuild_targets(&arg, 1, ranks_to_kill, NULL, 1, true);
-
-	arg->rebuild_pre_cb = NULL;
-	arg->rebuild_cb = NULL;
-
-	rebuild_io_validate(arg, oids, OBJ_NR, false);
-}
-
-static void
-rebuild_offline_pool_connect_in_scan(void **state)
-{
-	rebuild_offline_pool_connect_internal(state,
-					      DAOS_REBUILD_TGT_SCAN_HANG);
-}
-
-static void
-rebuild_offline_pool_connect_in_rebuild(void **state)
-{
-	rebuild_offline_pool_connect_internal(state,
-					      DAOS_REBUILD_TGT_REBUILD_HANG);
-}
-
 static void
 rebuild_offline(void **state)
 {
 	test_arg_t	*arg = *state;
 	daos_obj_id_t	oids[OBJ_NR];
 	int		i;
+	unsigned int	required_nodes = 3;
 
-	if (!test_runable(arg, 6))
+	print_message("rebuild_offline test - %u server nodes, 2-way replica\n",
+			required_nodes);
+	if (!test_runable(arg, required_nodes))
 		return;
 
 	for (i = 0; i < OBJ_NR; i++) {
-		oids[i] = dts_oid_gen(DAOS_OC_R3S_SPEC_RANK, 0, arg->myrank);
+		oids[i] = dts_oid_gen(DAOS_OC_R2S_SPEC_RANK, 0, arg->myrank);
+		print_message("rank %d set for oid:"DF_U64"."DF_U64"\n",
+				ranks_to_kill[0], oids[i].hi, oids[i].lo);
 		oids[i] = dts_oid_set_rank(oids[i], ranks_to_kill[0]);
 	}
 	rebuild_io(arg, oids, OBJ_NR);
@@ -1258,542 +461,75 @@ rebuild_offline(void **state)
 	rebuild_io_validate(arg, oids, OBJ_NR, false);
 }
 
-static int
-rebuild_change_leader_cb(void *arg)
-{
-	test_arg_t	*test_arg = arg;
-	d_rank_t	leader;
-
-	test_get_leader(test_arg, &leader);
-
-	/* Skip appendentry to re-elect the leader */
-	if (test_arg->myrank == 0) {
-		daos_mgmt_set_params(test_arg->group, leader, DSS_KEY_FAIL_LOC,
-				     DAOS_RDB_SKIP_APPENDENTRIES_FAIL, 0, NULL);
-		print_message("sleep 15 seconds for re-election leader\n");
-		/* Sleep 15 seconds to make sure the leader is changed */
-		sleep(15);
-		/* Continue the rebuild */
-		daos_mgmt_set_params(test_arg->group, -1, DSS_KEY_FAIL_LOC,
-				     0, 0, NULL);
-	}
-	MPI_Barrier(MPI_COMM_WORLD);
-	return 0;
-}
-
-static void
-rebuild_master_change_during_scan(void **state)
-{
-	test_arg_t	*arg = *state;
-	daos_obj_id_t	oids[OBJ_NR];
-	int		i;
-
-	if (!test_runable(arg, 6) || arg->pool.svc.rl_nr == 1)
-		return;
-
-	for (i = 0; i < OBJ_NR; i++) {
-		oids[i] = dts_oid_gen(DAOS_OC_R3S_SPEC_RANK, 0, arg->myrank);
-		oids[i] = dts_oid_set_rank(oids[i], ranks_to_kill[0]);
-	}
-
-	rebuild_io(arg, oids, OBJ_NR);
-
-	/* All ranks should wait before rebuild */
-	if (arg->myrank == 0)
-		daos_mgmt_set_params(arg->group, -1, DSS_KEY_FAIL_LOC,
-				     DAOS_REBUILD_TGT_SCAN_HANG, 0, NULL);
-	MPI_Barrier(MPI_COMM_WORLD);
-	arg->rebuild_cb = rebuild_change_leader_cb;
-
-	rebuild_single_pool_rank(arg, ranks_to_kill[0]);
-
-	arg->rebuild_cb = NULL;
-
-	/* Verify the data */
-	rebuild_io_validate(arg, oids, OBJ_NR, true);
-}
-
-static void
-rebuild_master_change_during_rebuild(void **state)
-{
-	test_arg_t	*arg = *state;
-	daos_obj_id_t	oids[OBJ_NR];
-	int		i;
-
-	if (!test_runable(arg, 6) || arg->pool.svc.rl_nr == 1)
-		return;
-
-	for (i = 0; i < OBJ_NR; i++) {
-		oids[i] = dts_oid_gen(DAOS_OC_R3S_SPEC_RANK, 0, arg->myrank);
-		oids[i] = dts_oid_set_rank(oids[i], ranks_to_kill[0]);
-	}
-
-	rebuild_io(arg, oids, OBJ_NR);
-
-	/* All ranks should wait before rebuild */
-	daos_mgmt_set_params(arg->group, -1, DSS_KEY_FAIL_LOC,
-			     DAOS_REBUILD_TGT_REBUILD_HANG, 0, NULL);
-
-	arg->rebuild_cb = rebuild_change_leader_cb;
-
-	rebuild_single_pool_rank(arg, ranks_to_kill[0]);
-
-	arg->rebuild_cb = NULL;
-
-	/* Verify the data */
-	rebuild_io_validate(arg, oids, OBJ_NR, true);
-}
-
-static int
-rebuild_nospace_cb(void *data)
-{
-	test_arg_t	*arg = data;
-
-	/* Wait for space is claimed */
-	sleep(60);
-
-	if (arg->myrank == 0)
-		daos_mgmt_set_params(arg->group, -1, DSS_KEY_FAIL_LOC,
-				     0, 0, NULL);
-
-	print_message("re-enable recovery\n");
-	if (arg->myrank == 0)
-		/* Resume the rebuild. FIXME: fix this once we have better
-		 * way to resume rebuild through mgmt cmd.
-		 */
-		daos_mgmt_set_params(arg->group, -1, DSS_REBUILD_RES_PERCENTAGE,
-				     30, 0, NULL);
-
-	MPI_Barrier(MPI_COMM_WORLD);
-
-	return 0;
-}
-
-static void
-rebuild_nospace(void **state)
-{
-	test_arg_t	*arg = *state;
-	daos_obj_id_t	oids[OBJ_NR];
-	int		i;
-
-	if (!test_runable(arg, 6))
-		skip();
-
-	for (i = 0; i < OBJ_NR; i++) {
-		oids[i] = dts_oid_gen(DAOS_OC_R3S_SPEC_RANK, 0, arg->myrank);
-		oids[i] = dts_oid_set_rank(oids[i], ranks_to_kill[0]);
-	}
-
-	rebuild_io(arg, oids, OBJ_NR);
-
-	if (arg->myrank == 0)
-		daos_mgmt_set_params(arg->group, -1, DSS_KEY_FAIL_LOC,
-				     DAOS_REBUILD_TGT_NOSPACE, 0, NULL);
-
-	MPI_Barrier(MPI_COMM_WORLD);
-
-	arg->rebuild_cb = rebuild_nospace_cb;
-	rebuild_single_pool_rank(arg, ranks_to_kill[0]);
-
-	arg->rebuild_cb = NULL;
-	rebuild_io_validate(arg, oids, OBJ_NR, true);
-}
-
-static void
-rebuild_multiple_tgts(void **state)
-{
-	test_arg_t	*arg = *state;
-	daos_obj_id_t	oid;
-	struct daos_obj_layout *layout;
-	d_rank_t	leader;
-	d_rank_t	exclude_ranks[2];
-	int		i;
-
-	if (!test_runable(arg, 6))
-		return;
-
-	oid = dts_oid_gen(DAOS_OC_R3S_SPEC_RANK, 0, arg->myrank);
-	oid = dts_oid_set_rank(oid, ranks_to_kill[0]);
-
-	rebuild_io(arg, &oid, 1);
-
-	test_get_leader(arg, &leader);
-	daos_obj_layout_get(arg->coh, oid, &layout);
-
-	if (arg->myrank == 0) {
-		int fail_cnt = 0;
-
-		/* All ranks should wait before rebuild */
-		daos_mgmt_set_params(arg->group, -1, DSS_KEY_FAIL_LOC,
-				     DAOS_REBUILD_HANG, 0, NULL);
-		/* kill 2 ranks at the same time */
-		D_ASSERT(layout->ol_shards[0]->os_replica_nr > 2);
-		for (i = 0; i < 3; i++) {
-			d_rank_t rank = layout->ol_shards[0]->os_ids[i].ti_rank;
-
-			if (rank != leader) {
-				exclude_ranks[fail_cnt] = rank;
-				daos_exclude_server(arg->pool.pool_uuid,
-						    arg->group, &arg->pool.svc,
-						    rank);
-				if (++fail_cnt >= 2)
-					break;
-			}
-		}
-
-		daos_mgmt_set_params(arg->group, -1, DSS_KEY_FAIL_LOC, 0,
-				     0, NULL);
-	}
-
-	MPI_Barrier(MPI_COMM_WORLD);
-
-	/* Rebuild 2 ranks at the same time */
-	if (arg->myrank == 0)
-		test_rebuild_wait(&arg, 1);
-
-	/* Verify the data */
-	rebuild_io_validate(arg, &oid, 1, true);
-
-	daos_obj_layout_free(layout);
-
-	/* Add back the target if it is not being killed */
-	if (arg->myrank == 0) {
-		for (i = 0; i < 2; i++)
-			daos_add_server(arg->pool.pool_uuid, arg->group,
-					&arg->pool.svc, exclude_ranks[i]);
-	}
-	MPI_Barrier(MPI_COMM_WORLD);
-}
-
-static int
-rebuild_io_cb(void *arg)
-{
-	test_arg_t	*test_arg = arg;
-	daos_obj_id_t	*oids = test_arg->rebuild_cb_arg;
-
-	if (!daos_handle_is_inval(test_arg->coh))
-		rebuild_io(test_arg, oids, OBJ_NR);
-
-	return 0;
-}
-
-static int
-rebuild_io_post_cb(void *arg)
-{
-	test_arg_t	*test_arg = arg;
-	daos_obj_id_t	*oids = test_arg->rebuild_post_cb_arg;
-
-	if (!daos_handle_is_inval(test_arg->coh))
-		rebuild_io_validate(test_arg, oids, OBJ_NR, true);
-
-	return 0;
-}
-
-static void
-rebuild_master_failure(void **state)
-{
-	test_arg_t		*arg = *state;
-	daos_obj_id_t		oids[OBJ_NR];
-	daos_obj_id_t		cb_arg_oids[OBJ_NR];
-	daos_pool_info_t	pinfo = { 0 };
-	daos_pool_info_t	pinfo_new = { 0 };
-	int			i;
-	int			rc;
-
-	/* need 5 svc replicas, as will kill the leader 2 times */
-	if (!test_runable(arg, 6) || arg->pool.svc.rl_nr < 5) {
-		print_message("testing skipped ...\n");
-		return;
-	}
-
-	test_get_leader(arg, &ranks_to_kill[0]);
-	for (i = 0; i < OBJ_NR; i++) {
-		oids[i] = dts_oid_gen(DAOS_OC_R3S_SPEC_RANK, 0, arg->myrank);
-		oids[i] = dts_oid_set_rank(oids[i], ranks_to_kill[0]);
-		cb_arg_oids[i] = dts_oid_gen(OBJ_CLS, 0, arg->myrank);
-	}
-
-	/* prepare the data */
-	rebuild_io(arg, oids, OBJ_NR);
-
-	arg->rebuild_cb = rebuild_io_cb;
-	arg->rebuild_cb_arg = cb_arg_oids;
-	arg->rebuild_post_cb = rebuild_io_post_cb;
-	arg->rebuild_post_cb_arg = cb_arg_oids;
-
-	rebuild_targets(&arg, 1, ranks_to_kill, NULL, 1, true);
-
-	arg->rebuild_cb = NULL;
-	arg->rebuild_post_cb = NULL;
-
-	/* Verify the data */
-	rebuild_io_validate(arg, oids, OBJ_NR, true);
-
-	/* Verify the POOL_QUERY get same rebuild status after leader change */
-	rc = test_pool_get_info(arg, &pinfo);
-	assert_int_equal(rc, 0);
-	assert_int_equal(pinfo.pi_rebuild_st.rs_done, 1);
-	rc = rebuild_change_leader_cb(arg);
-	assert_int_equal(rc, 0);
-	rc = test_pool_get_info(arg, &pinfo_new);
-	assert_int_equal(rc, 0);
-	assert_int_equal(pinfo_new.pi_rebuild_st.rs_done, 1);
-	rc = memcmp(&pinfo.pi_rebuild_st, &pinfo_new.pi_rebuild_st,
-		    sizeof(pinfo.pi_rebuild_st));
-	print_message("svc leader changed from %d to %d, should get same "
-		      "rebuild status (memcmp result %d).\n", pinfo.pi_leader,
-		      pinfo_new.pi_leader, rc);
-	assert_int_equal(rc, 0);
-}
-
-static void
-rebuild_multiple_failures(void **state)
-{
-	test_arg_t	*arg = *state;
-	daos_obj_id_t	oids[OBJ_NR];
-	daos_obj_id_t	cb_arg_oids[OBJ_NR];
-	int		i;
-
-	if (!test_runable(arg, 6))
-		return;
-
-	for (i = 0; i < OBJ_NR; i++) {
-		oids[i] = dts_oid_gen(DAOS_OC_R3S_SPEC_RANK, 0, arg->myrank);
-		oids[i] = dts_oid_set_rank(oids[i], ranks_to_kill[0]);
-		cb_arg_oids[i] = dts_oid_gen(OBJ_CLS, 0, arg->myrank);
-	}
-
-	/* prepare the data */
-	rebuild_io(arg, oids, OBJ_NR);
-
-	arg->rebuild_cb = rebuild_io_cb;
-	arg->rebuild_cb_arg = cb_arg_oids;
-	arg->rebuild_post_cb = rebuild_io_post_cb;
-	arg->rebuild_post_cb_arg = cb_arg_oids;
-
-	rebuild_targets(&arg, 1, ranks_to_kill, NULL, MAX_KILLS, true);
-
-	arg->rebuild_cb = NULL;
-	arg->rebuild_post_cb = NULL;
-}
-
-static void
-rebuild_fail_all_replicas_before_rebuild(void **state)
-{
-	test_arg_t	*arg = *state;
-	daos_obj_id_t	oid;
-	struct daos_obj_layout *layout;
-	struct daos_obj_shard *shard;
-
-	if (!test_runable(arg, 6))
-		return;
-
-	oid = dts_oid_gen(DAOS_OC_R2S_SPEC_RANK, 0, arg->myrank);
-	oid = dts_oid_set_rank(oid, ranks_to_kill[0]);
-
-	rebuild_io(arg, &oid, 1);
-
-	daos_obj_layout_get(arg->coh, oid, &layout);
-
-	/* HOLD rebuild ULT */
-	daos_mgmt_set_params(arg->group, -1, DSS_KEY_FAIL_LOC,
-			     DAOS_REBUILD_HANG, 0, NULL);
-
-	/* Kill one replica and start rebuild */
-	shard = layout->ol_shards[0];
-	daos_kill_server(arg, arg->pool.pool_uuid, arg->group, &arg->pool.svc,
-			 shard->os_ids[0].ti_rank);
-	daos_exclude_server(arg->pool.pool_uuid, arg->group, &arg->pool.svc,
-			    shard->os_ids[0].ti_rank);
-
-	/* Sleep 10 seconds after it scan finish and hang before rebuild */
-	print_message("sleep 10 seconds to wait scan to be finished \n");
-	sleep(10);
-
-	/* Then kill rank 1 */
-	daos_kill_server(arg, arg->pool.pool_uuid, arg->group, &arg->pool.svc,
-			 shard->os_ids[1].ti_rank);
-	daos_exclude_server(arg->pool.pool_uuid, arg->group, &arg->pool.svc,
-			    shard->os_ids[1].ti_rank);
-
-	/* Continue rebuild */
-	daos_mgmt_set_params(arg->group, -1, DSS_KEY_FAIL_LOC, 0, 0, NULL);
-
-	sleep(5);
-	if (arg->myrank == 0)
-		test_rebuild_wait(&arg, 1);
-
-	MPI_Barrier(MPI_COMM_WORLD);
-	daos_obj_layout_free(layout);
-}
-
-static void
-rebuild_fail_all_replicas(void **state)
-{
-	test_arg_t	*arg = *state;
-	daos_obj_id_t	oid;
-	struct daos_obj_layout *layout;
-	int		i;
-
-	/* This test will kill 3 replicas, which might include the ranks
-	 * in svcs, so make sure there are at least 6 ranks in svc, so
-	 * the new leader can be chosen.
-	 */
-	if (!test_runable(arg, 6) || arg->pool.svc.rl_nr < 6) {
-		print_message("need at least 6 svcs, -s5\n");
-		return;
-	}
-
-	oid = dts_oid_gen(DAOS_OC_R3S_SPEC_RANK, 0, arg->myrank);
-	oid = dts_oid_set_rank(oid, ranks_to_kill[0]);
-
-	rebuild_io(arg, &oid, 1);
-
-	daos_obj_layout_get(arg->coh, oid, &layout);
-
-	for (i = 0; i < layout->ol_nr; i++) {
-		int j;
-
-		for (j = 0; j < layout->ol_shards[i]->os_replica_nr; j++) {
-			d_rank_t rank = layout->ol_shards[i]->os_ids[j].ti_rank;
-
-			daos_kill_server(arg, arg->pool.pool_uuid,
-					 arg->group, &arg->pool.svc, rank);
-		}
-
-		for (j = 0; j < layout->ol_shards[i]->os_replica_nr; j++) {
-			d_rank_t rank = layout->ol_shards[i]->os_ids[j].ti_rank;
-
-			daos_exclude_server(arg->pool.pool_uuid, arg->group,
-					    &arg->pool.svc, rank);
-		}
-	}
-
-	sleep(5);
-	if (arg->myrank == 0)
-		test_rebuild_wait(&arg, 1);
-
-	MPI_Barrier(MPI_COMM_WORLD);
-	daos_obj_layout_free(layout);
-}
-
-static void
-multi_pools_rebuild_concurrently(void **state)
-{
-#define POOL_NUM		6
-#define CONT_PER_POOL		4
-#define OBJ_PER_CONT		256
-	test_arg_t		*arg = *state;
-	test_arg_t		*args[POOL_NUM * CONT_PER_POOL];
-	daos_obj_id_t		oids[OBJ_PER_CONT];
-	struct test_pool	*pool;
-	int			i;
-	int			rc;
-
-	if (!test_runable(arg, 6))
-		return;
-
-	memset(args, 0, sizeof(args[0]) * POOL_NUM * CONT_PER_POOL);
-	for (i = 0; i < POOL_NUM * CONT_PER_POOL; i++) {
-		pool = (i % CONT_PER_POOL == 0) ? NULL :
-				&args[(i/CONT_PER_POOL) * CONT_PER_POOL]->pool;
-		rc = test_setup((void **)&args[i], SETUP_CONT_CONNECT,
-				arg->multi_rank, REBUILD_POOL_SIZE, pool);
-		if (rc) {
-			print_message("open/connect another pool failed: "
-				      "rc %d\n", rc);
-			return;
-		}
-		if (i % CONT_PER_POOL == 0)
-			assert_int_equal(args[i]->pool.slave, 0);
-		else
-			assert_int_equal(args[i]->pool.slave, 1);
-	}
-
-	for (i = 0; i < OBJ_PER_CONT; i++) {
-		oids[i] = dts_oid_gen(DAOS_OC_R3S_SPEC_RANK, 0, arg->myrank);
-		oids[i] = dts_oid_set_rank(oids[i], ranks_to_kill[0]);
-	}
-
-	for (i = 0; i < POOL_NUM * CONT_PER_POOL; i++)
-		rebuild_io(args[i], oids, OBJ_PER_CONT);
-
-	rebuild_pools_ranks(args, POOL_NUM * CONT_PER_POOL, ranks_to_kill, 1);
-
-	for (i = POOL_NUM * CONT_PER_POOL - 1; i >= 0; i--) {
-		rebuild_io_validate(args[i], oids, OBJ_PER_CONT, true);
-		test_teardown((void **)&args[i]);
-	}
-}
 
 /** create a new pool/container for each test */
 static const struct CMUnitTest rebuild_tests[] = {
-	{"REBUILD1: rebuild small rec mulitple dkeys",
-	 rebuild_dkeys, NULL, test_case_teardown},
-	{"REBUILD2: rebuild small rec multiple akeys",
-	 rebuild_akeys, NULL, test_case_teardown},
-	{"REBUILD3: rebuild small rec multiple indexes",
-	 rebuild_indexes, NULL, test_case_teardown},
-	{"REBUILD4: rebuild small rec multiple keys/indexes",
-	 rebuild_multiple, NULL, test_case_teardown},
-	{"REBUILD5: rebuild large rec single index",
-	 rebuild_large_rec, NULL, test_case_teardown},
-	{"REBUILD6: rebuild multiple objects",
-	 rebuild_objects, NULL, test_case_teardown},
-	{"REBUILD7: drop rebuild scan reply",
-	rebuild_drop_scan, NULL, test_case_teardown},
-	{"REBUILD8: retry rebuild for not ready",
-	rebuild_retry_rebuild, NULL, test_case_teardown},
-	{"REBUILD9: drop rebuild obj reply",
-	rebuild_drop_obj, NULL, test_case_teardown},
-	{"REBUILD10: rebuild multiple pools",
-	rebuild_multiple_pools, NULL, test_case_teardown},
-	{"REBUILD11: rebuild update failed",
-	rebuild_update_failed, NULL, test_case_teardown},
-	{"REBUILD12: retry rebuild for pool stale",
-	rebuild_retry_for_stale_pool, NULL, test_case_teardown},
-	{"REBUILD13: rebuild with container destroy",
-	rebuild_destroy_container, NULL, test_case_teardown},
-	{"REBUILD14: rebuild with container close",
-	rebuild_close_container, NULL, test_case_teardown},
-	{"REBUILD15: rebuild with pool destroy during scan",
-	rebuild_destroy_pool_during_scan, NULL, test_case_teardown},
-	{"REBUILD16: rebuild with pool destroy during rebuild",
-	rebuild_destroy_pool_during_rebuild, NULL, test_case_teardown},
-	{"REBUILD17: rebuild iv tgt fail",
-	rebuild_iv_tgt_fail, NULL, test_case_teardown},
-	{"REBUILD18: rebuild tgt start fail",
-	rebuild_tgt_start_fail, NULL, test_case_teardown},
-	{"REBUILD19: rebuild send objects failed",
-	 rebuild_send_objects_fail, NULL, test_case_teardown},
-	{"REBUILD20: rebuild with master change during scan",
-	rebuild_master_change_during_scan, NULL, test_case_teardown},
-	{"REBUILD21: rebuild with master change during rebuild",
-	rebuild_master_change_during_rebuild, NULL, test_case_teardown},
-	{"REBUILD22: rebuild no space failure",
-	rebuild_nospace, NULL, test_case_teardown},
-	{"REBUILD23: rebuild multiple tgts",
-	rebuild_multiple_tgts, NULL, test_case_teardown},
-	{"REBUILD24: disconnect pool during scan",
-	 rebuild_tgt_pool_disconnect_in_scan, NULL, test_case_teardown},
-	{"REBUILD25: disconnect pool during rebuild",
-	 rebuild_tgt_pool_disconnect_in_rebuild, NULL, test_case_teardown},
-	{"REBUILD26: connect pool during scan for offline rebuild",
-	 rebuild_offline_pool_connect_in_scan, NULL, test_case_teardown},
-	{"REBUILD27: connect pool during rebuild for offline rebuild",
-	 rebuild_offline_pool_connect_in_rebuild, NULL, test_case_teardown},
+//	{"REBUILD1: rebuild small rec mulitple dkeys",
+//	 rebuild_dkeys, NULL, test_case_teardown},
+//	{"REBUILD2: rebuild small rec multiple akeys",
+//	 rebuild_akeys, NULL, test_case_teardown},
+//	{"REBUILD3: rebuild small rec multiple indexes",
+//	 rebuild_indexes, NULL, test_case_teardown},
+//	{"REBUILD4: rebuild small rec multiple keys/indexes",
+//	 rebuild_multiple, NULL, test_case_teardown},
+//	{"REBUILD5: rebuild large rec single index",
+//	 rebuild_large_rec, NULL, test_case_teardown},
+//	{"REBUILD6: rebuild multiple objects",
+//	 rebuild_objects, NULL, test_case_teardown},
+//	{"REBUILD7: drop rebuild scan reply",
+//	rebuild_drop_scan, NULL, test_case_teardown},
+//	{"REBUILD8: retry rebuild for not ready",
+//	rebuild_retry_rebuild, NULL, test_case_teardown},
+//	{"REBUILD9: drop rebuild obj reply",
+//	rebuild_drop_obj, NULL, test_case_teardown},
+//	{"REBUILD10: rebuild multiple pools",
+//	rebuild_multiple_pools, NULL, test_case_teardown},
+//	{"REBUILD11: rebuild update failed",
+//	rebuild_update_failed, NULL, test_case_teardown},
+//	{"REBUILD12: retry rebuild for pool stale",
+//	rebuild_retry_for_stale_pool, NULL, test_case_teardown},
+//	{"REBUILD13: rebuild with container destroy",
+//	rebuild_destroy_container, NULL, test_case_teardown},
+//	{"REBUILD14: rebuild with container close",
+//	rebuild_close_container, NULL, test_case_teardown},
+//	{"REBUILD15: rebuild with pool destroy during scan",
+//	rebuild_destroy_pool_during_scan, NULL, test_case_teardown},
+//	{"REBUILD16: rebuild with pool destroy during rebuild",
+//	rebuild_destroy_pool_during_rebuild, NULL, test_case_teardown},
+//	{"REBUILD17: rebuild iv tgt fail",
+//	rebuild_iv_tgt_fail, NULL, test_case_teardown},
+//	{"REBUILD18: rebuild tgt start fail",
+//	rebuild_tgt_start_fail, NULL, test_case_teardown},
+//	{"REBUILD19: rebuild send objects failed",
+//	 rebuild_send_objects_fail, NULL, test_case_teardown},
+//	{"REBUILD20: rebuild with master change during scan",
+//	rebuild_master_change_during_scan, NULL, test_case_teardown},
+//	{"REBUILD21: rebuild with master change during rebuild",
+//	rebuild_master_change_during_rebuild, NULL, test_case_teardown},
+//	{"REBUILD22: rebuild no space failure",
+//	rebuild_nospace, NULL, test_case_teardown},
+//	{"REBUILD23: rebuild multiple tgts",
+//	rebuild_multiple_tgts, NULL, test_case_teardown},
+//	{"REBUILD24: disconnect pool during scan",
+//	 rebuild_tgt_pool_disconnect_in_scan, NULL, test_case_teardown},
+//	{"REBUILD25: disconnect pool during rebuild",
+//	 rebuild_tgt_pool_disconnect_in_rebuild, NULL, test_case_teardown},
+//	{"REBUILD26: connect pool during scan for offline rebuild",
+//	 rebuild_offline_pool_connect_in_scan, NULL, test_case_teardown},
+//	{"REBUILD27: connect pool during rebuild for offline rebuild",
+//	 rebuild_offline_pool_connect_in_rebuild, NULL, test_case_teardown},
 	{"REBUILD28: offline rebuild",
 	rebuild_offline, NULL, test_case_teardown},
-	{"REBUILD29: rebuild with master failure",
-	 rebuild_master_failure, NULL, test_case_teardown},
-	{"REBUILD30: rebuild with two failures",
-	 rebuild_multiple_failures, NULL, test_case_teardown},
-	{"REBUILD31: rebuild fail all replicas before rebuild",
-	 rebuild_fail_all_replicas_before_rebuild, NULL, test_case_teardown},
-	{"REBUILD32: rebuild fail all replicas",
-	 rebuild_fail_all_replicas, NULL, test_case_teardown},
-	{"REBUILD33: multi-pools rebuild concurrently",
-	 multi_pools_rebuild_concurrently, NULL, test_case_teardown},
+//	{"REBUILD29: rebuild with master failure",
+//	 rebuild_master_failure, NULL, test_case_teardown},
+//	{"REBUILD30: rebuild with two failures",
+//	 rebuild_multiple_failures, NULL, test_case_teardown},
+//	{"REBUILD31: rebuild fail all replicas before rebuild",
+//	 rebuild_fail_all_replicas_before_rebuild, NULL, test_case_teardown},
+//	{"REBUILD32: rebuild fail all replicas",
+//	 rebuild_fail_all_replicas, NULL, test_case_teardown},
+//	{"REBUILD33: multi-pools rebuild concurrently",
+//	 multi_pools_rebuild_concurrently, NULL, test_case_teardown},
 };
 
 int

--- a/src/tests/suite/daos_rebuild.c
+++ b/src/tests/suite/daos_rebuild.c
@@ -1429,7 +1429,7 @@ rebuild_multiple_tgts(void **state)
 		/* kill 2 ranks at the same time */
 		D_ASSERT(layout->ol_shards[0]->os_replica_nr > 2);
 		for (i = 0; i < 3; i++) {
-			d_rank_t rank = layout->ol_shards[0]->os_ranks[i];
+			d_rank_t rank = layout->ol_shards[0]->os_ids[i].ti_rank;
 
 			if (rank != leader) {
 				exclude_ranks[fail_cnt] = rank;
@@ -1602,9 +1602,9 @@ rebuild_fail_all_replicas_before_rebuild(void **state)
 	/* Kill one replica and start rebuild */
 	shard = layout->ol_shards[0];
 	daos_kill_server(arg, arg->pool.pool_uuid, arg->group, &arg->pool.svc,
-			 shard->os_ranks[0]);
+			 shard->os_ids[0].ti_rank);
 	daos_exclude_server(arg->pool.pool_uuid, arg->group, &arg->pool.svc,
-			    shard->os_ranks[0]);
+			    shard->os_ids[0].ti_rank);
 
 	/* Sleep 10 seconds after it scan finish and hang before rebuild */
 	print_message("sleep 10 seconds to wait scan to be finished \n");
@@ -1612,9 +1612,9 @@ rebuild_fail_all_replicas_before_rebuild(void **state)
 
 	/* Then kill rank 1 */
 	daos_kill_server(arg, arg->pool.pool_uuid, arg->group, &arg->pool.svc,
-			 shard->os_ranks[1]);
+			 shard->os_ids[1].ti_rank);
 	daos_exclude_server(arg->pool.pool_uuid, arg->group, &arg->pool.svc,
-			    shard->os_ranks[1]);
+			    shard->os_ids[1].ti_rank);
 
 	/* Continue rebuild */
 	daos_mgmt_set_params(arg->group, -1, DSS_KEY_FAIL_LOC, 0, 0, NULL);
@@ -1655,14 +1655,14 @@ rebuild_fail_all_replicas(void **state)
 		int j;
 
 		for (j = 0; j < layout->ol_shards[i]->os_replica_nr; j++) {
-			d_rank_t rank = layout->ol_shards[i]->os_ranks[j];
+			d_rank_t rank = layout->ol_shards[i]->os_ids[j].ti_rank;
 
 			daos_kill_server(arg, arg->pool.pool_uuid,
 					 arg->group, &arg->pool.svc, rank);
 		}
 
 		for (j = 0; j < layout->ol_shards[i]->os_replica_nr; j++) {
-			d_rank_t rank = layout->ol_shards[i]->os_ranks[j];
+			d_rank_t rank = layout->ol_shards[i]->os_ids[j].ti_rank;
 
 			daos_exclude_server(arg->pool.pool_uuid, arg->group,
 					    &arg->pool.svc, rank);

--- a/src/tests/suite/daos_test_common.c
+++ b/src/tests/suite/daos_test_common.c
@@ -342,10 +342,14 @@ pool_destroy_safe(test_arg_t *arg)
 	}
 
 	daos_pool_disconnect(poh, NULL);
+	print_message("pool disconnect "DF_UUIDF"\n", DP_UUID(arg->pool.pool_uuid));
 
-	rc = daos_pool_destroy(arg->pool.pool_uuid, arg->group, 1, NULL);
-	if (rc && rc != -DER_TIMEDOUT)
-		print_message("daos_pool_destroy failed, rc: %d\n", rc);
+//	rc = daos_pool_destroy(arg->pool.pool_uuid, arg->group, 1, NULL);
+//	if (rc && rc != -DER_TIMEDOUT)
+//		print_message("daos_pool_destroy failed, rc: %d\n", rc);
+//	if (rc)
+//		print_message("daos_pool_destroy rc = %d\n", rc);
+//	print_message("pool destroy "DF_UUIDF"\n", DP_UUID(arg->pool.pool_uuid));
 	return rc;
 }
 
@@ -356,6 +360,7 @@ test_teardown(void **state)
 	int		 rc = 0;
 	int              rc_reduce = 0;
 
+	print_message("test_teardown()\n");
 	if (arg == NULL) {
 		print_message("state not set, likely due to group-setup"
 			      " issue\n");
@@ -366,6 +371,7 @@ test_teardown(void **state)
 		MPI_Barrier(MPI_COMM_WORLD);
 
 	if (!daos_handle_is_inval(arg->coh)) {
+		print_message("closing container\n");
 		rc = daos_cont_close(arg->coh, NULL);
 		if (arg->multi_rank) {
 			MPI_Allreduce(&rc, &rc_reduce, 1, MPI_INT, MPI_MIN,
@@ -380,8 +386,9 @@ test_teardown(void **state)
 		}
 	}
 
-	if (!uuid_is_null(arg->co_uuid)) {
+	/*if (!uuid_is_null(arg->co_uuid)) {
 		while (arg->myrank == 0) {
+			print_message("destroying container\n");
 			rc = daos_cont_destroy(arg->pool.poh, arg->co_uuid, 1,
 					       NULL);
 			if (rc == -DER_BUSY) {
@@ -398,7 +405,7 @@ test_teardown(void **state)
 				      ": %d\n", DP_UUID(arg->co_uuid), rc);
 			return rc;
 		}
-	}
+	}*/
 
 	if (!uuid_is_null(arg->pool.pool_uuid) && !arg->pool.slave) {
 		if (arg->myrank == 0)

--- a/src/utils/dmg.c
+++ b/src/utils/dmg.c
@@ -639,6 +639,7 @@ obj_op_hdlr(int argc, char *argv[])
 		D_GOTO(disconnect, rc);
 	}
 
+	fprintf(stdout, "calling daos_obj_layout_get()\n");
 	rc = daos_obj_layout_get(coh, oid, &layout);
 	if (rc) {
 		fprintf(stderr, "daos_cont_open failed, rc: %d\n", rc);

--- a/src/utils/dmg.c
+++ b/src/utils/dmg.c
@@ -653,10 +653,12 @@ obj_op_hdlr(int argc, char *argv[])
 		struct daos_obj_shard *shard;
 
 		shard = layout->ol_shards[i];
-		fprintf(stdout, "grp: %d\n", i);
+		fprintf(stdout, "grp: %d replica %d\n", i,
+			shard->os_replica_nr);
 		for (j = 0; j < shard->os_replica_nr; j++)
-			fprintf(stdout, "replica %d %d\n", j,
-				shard->os_ranks[j]);
+			fprintf(stdout, "i:%d rank: %d tgt_id: %d\n",
+				j, shard->os_ids[j].ti_rank,
+				shard->os_ids[j].ti_tgt);
 	}
 
 	daos_obj_layout_free(layout);


### PR DESCRIPTION
Running $dmg layout to get the object layout before the server eviction and also at the end of the test (after server eviction and rebuild). both outputs give me the same result:

oid: 72057662757404718.1 ver 0 grp_nr: 1
grp: 0 replica 2
i:0 rank: 0 tgt_id: 0
i:1 rank: 1 tgt_id: 3

The object should have been created on rank 2 I would think (since that is specified by dts_oid_set_rank()), but output does not show that. Final output seems like it would be correct, but not sure why it's the same for both stages of the test.
