### PR TITLE
DAOS-2216 dfs & duns: expose Chunks size as configurable parameter

### DIFF
--- a/src/client/dfs/dfuse.c
+++ b/src/client/dfs/dfuse.c
@@ -459,7 +459,8 @@ dfuse_create(const char *path, mode_t mode, struct fuse_file_info *fi)
 	}
 
 	mode = S_IFREG | mode;
-	rc = dfs_open(dfs, parent, name, mode, fi->flags, DAOS_OC_LARGE_RW,
+	/** TODO - set the oclass and array chunk size using the UNS */
+	rc = dfs_open(dfs, parent, name, mode, fi->flags, DAOS_OC_LARGE_RW, 0,
 		      NULL, &obj);
 	if (rc)
 		D_GOTO(out, rc);
@@ -505,7 +506,9 @@ dfuse_open(const char *path, struct fuse_file_info *fi)
 		D_GOTO(out, rc = -DER_INVAL);
 	}
 
-	rc = dfs_open(dfs, parent, name, S_IFREG, fi->flags, 0, NULL, &obj);
+	/** TODO - set the oclass and array chunk size using the UNS */
+	rc = dfs_open(dfs, parent, name, S_IFREG, fi->flags, DAOS_OC_LARGE_RW,
+		      0, NULL, &obj);
 	if (rc)
 		D_GOTO(out, rc);
 
@@ -553,7 +556,8 @@ dfuse_opendir(const char *path, struct fuse_file_info *fi)
 		fi->fh = (uint64_t)parent;
 		free_parent = false;
 	} else {
-		rc = dfs_open(dfs, parent, name, S_IFDIR, O_RDONLY, 0, NULL,
+		/** TODO - set the oclass and array chunk size using the UNS */
+		rc = dfs_open(dfs, parent, name, S_IFDIR, O_RDONLY, 0, 0, NULL,
 			      &obj);
 		if (rc)
 			D_GOTO(out, rc);
@@ -696,7 +700,8 @@ dfuse_symlink(const char *from, const char *to)
 		D_GOTO(out, rc = -DER_INVAL);
 	}
 
-	rc = dfs_open(dfs, parent, name, S_IFLNK, O_CREAT, 0, from, &sym);
+	/** TODO - set the object class and array chunk size using the UNS */
+	rc = dfs_open(dfs, parent, name, S_IFLNK, O_CREAT, 0, 0, from, &sym);
 	if (rc)
 		D_GOTO(out, rc);
 

--- a/src/client/dfs/duns.c
+++ b/src/client/dfs/duns.c
@@ -38,8 +38,8 @@
 #include "daos_uns.h"
 
 #define DUNS_XATTR_NAME		"user.daos"
-#define DUNS_MAX_XATTR_LEN	150
-#define DUNS_XATTR_FMT		"DAOS.%s://%36s/%36s/%s/"
+#define DUNS_MAX_XATTR_LEN	170
+#define DUNS_XATTR_FMT		"DAOS.%s://%36s/%36s/%s/%zu"
 
 int
 duns_resolve_path(const char *path, struct duns_attr_t *attr)
@@ -95,6 +95,9 @@ duns_resolve_path(const char *path, struct duns_attr_t *attr)
 
 	t = strtok_r(NULL, "/", &saveptr);
 	daos_parse_oclass(t, &attr->da_oclass);
+
+	t = strtok_r(NULL, "/", &saveptr);
+	attr->da_chunk_size = strtoull(t, NULL, 10);
 
 	return 0;
 }
@@ -184,7 +187,8 @@ duns_link_path(const char *path, struct duns_attr_t attr)
 		uuid_unparse(attr.da_cuuid, cont);
 
 		/** store the daos attributes in the path xattr */
-		len = sprintf(str, DUNS_XATTR_FMT, type, pool, cont, oclass);
+		len = sprintf(str, DUNS_XATTR_FMT, type, pool, cont, oclass,
+			      attr.da_chunk_size);
 		if (len < 90) {
 			D_ERROR("Failed to create xattr value\n");
 			D_GOTO(err_pool, rc = -DER_INVAL);

--- a/src/client/dfs/duns_tool.c
+++ b/src/client/dfs/duns_tool.c
@@ -44,6 +44,7 @@ link_hdlr(int argc, char *argv[])
 		{"pool",	required_argument,	NULL,	'p'},
 		{"type",	required_argument,	NULL,	't'},
 		{"oclass",	required_argument,	NULL,	'o'},
+		{"chunk_size",	required_argument,	NULL,	'c'},
 		{NULL,		0,			NULL,	0}
 	};
 	const char		*path = NULL;
@@ -67,6 +68,9 @@ link_hdlr(int argc, char *argv[])
 			break;
 		case 'o':
 			daos_parse_oclass(optarg, &attr.da_oclass);
+			break;
+		case 'c':
+			attr.da_chunk_size = strtoull(optarg, NULL, 10);
 			break;
 		default:
 			return 2;
@@ -155,7 +159,7 @@ resolve_hdlr(int argc, char *argv[])
 	printf("Container UUID:\t"DF_UUIDF"\n", DP_UUID(attr.da_cuuid));
 	printf("Object Class:\t");
 	print_oclass(attr.da_oclass);
-
+	printf("Chunk Size:\t%zu\n", attr.da_chunk_size);
 	return rc;
 }
 
@@ -174,6 +178,7 @@ link_path options:\n\
 	--path=STR	path name\n\
 	--pool=UUID	pool UUID to connect to\n\
 	--oclass=STR	object class (tiny, small, large, R2S, R2, repl_max)\n\
+	--chunk_size=STR Chunk size of files created\n\
 	--type=STR	container type to create (POSIX, HDF5)\n");
 	printf("\
 resolve_path options:\n\

--- a/src/include/daos_fs.h
+++ b/src/include/daos_fs.h
@@ -103,6 +103,10 @@ dfs_lookup(dfs_t *dfs, const char *path, int flags, dfs_obj_t **obj,
  * \param[in]	flags	Access flags (O_RDONLY, O_RDWR, O_EXCL, O_CREAT).
  * \param[in]	cid	DAOS object class id (pass 0 for default MAX_RW).
  *			Valid on create only; ignored otherwise.
+ * \param[in]	chunk_size
+ *			Chunk size of the array object to be created.
+ *			(pass 0 for default 1 MiB chunk size).
+ *			Valid on file create only; ignored otherwise.
  * \param[in]	value	Symlink value (NULL if not syml).
  * \param[out]	obj	Pointer to object opened.
  *
@@ -110,7 +114,8 @@ dfs_lookup(dfs_t *dfs, const char *path, int flags, dfs_obj_t **obj,
  */
 int
 dfs_open(dfs_t *dfs, dfs_obj_t *parent, const char *name, mode_t mode,
-	 int flags, daos_oclass_id_t cid, const char *value, dfs_obj_t **obj);
+	 int flags, daos_oclass_id_t cid, daos_size_t chunk_size,
+	 const char *value, dfs_obj_t **obj);
 
 /*
  * Close/release open object.

--- a/src/include/daos_uns.h
+++ b/src/include/daos_uns.h
@@ -46,6 +46,8 @@ struct duns_attr_t {
 	daos_cont_layout_t	da_type;
 	/** Default Object Class for all objects in the container */
 	daos_oclass_id_t	da_oclass;
+	/** Default Chunks size for all files in container */
+	daos_size_t		da_chunk_size;
 };
 
 /**


### PR DESCRIPTION
- Add chunk size setting to dfs_open()
- Allow setting of chunk size through DUNS tool and set in extended attribute

Signed-off-by: Mohamad Chaarawi <mohamad.chaarawi@intel.com>