### PR TITLE
DAOS-2065 control: Fix the handling of panics

### DIFF
--- a/src/control/README.md
+++ b/src/control/README.md
@@ -177,4 +177,4 @@ TODO: include details of `daos_agent` interaction
 
 ### daos_server and daos_agent
 
-* Avoid calling `os.Exit` (or `log.Fatal`, `log.Fatalf`, etc.), except for assertion purposes. Fatal errors shall be returned back to `main`, who determines the exit status based on its `err` and calls `os.Exit`, in its last deferred function call.
+* Avoid calling `os.Exit` (or function with equivalent effects), except for assertion purposes. Fatal errors shall be returned back to `main`, who calls `os.Exit` accordingly.

--- a/src/control/agent/main.go
+++ b/src/control/agent/main.go
@@ -39,15 +39,12 @@ var (
 )
 
 func main() {
-	var err error
-	defer func() {
-		status := 0
-		if err != nil {
-			status = 1
-		}
-		os.Exit(status)
-	}()
+	if agentMain() != nil {
+		os.Exit(1)
+	}
+}
 
+func agentMain() error {
 	// Set default global logger for application.
 	log.NewDefaultLogger(log.Debug, "", os.Stderr)
 
@@ -62,7 +59,7 @@ func main() {
 	drpcServer, err := drpc.NewDomainSocketServer(sockPath)
 	if err != nil {
 		log.Errorf("Unable to create socket server: %v", err)
-		return
+		return err
 	}
 
 	module := &SecurityModule{}
@@ -71,7 +68,7 @@ func main() {
 	err = drpcServer.Start()
 	if err != nil {
 		log.Errorf("Unable to start socket server on %s: %v", sockPath, err)
-		return
+		return err
 	}
 
 	// Anonymous goroutine to wait on the signals channel and tell the
@@ -85,4 +82,6 @@ func main() {
 	}()
 	<-finish
 	drpcServer.Shutdown()
+
+	return nil
 }

--- a/src/control/dmg/main.go
+++ b/src/control/dmg/main.go
@@ -82,15 +82,12 @@ func connectHosts() error {
 }
 
 func main() {
-	var err error
-	defer func() {
-		status := 0
-		if err != nil {
-			status = 1
-		}
-		os.Exit(status)
-	}()
+	if dmgMain() != nil {
+		os.Exit(1)
+	}
+}
 
+func dmgMain() error {
 	// Set default global logger for application.
 	log.NewDefaultLogger(log.Debug, "", os.Stderr)
 
@@ -98,21 +95,21 @@ func main() {
 	// Continue with main if no subcommand is executed.
 	p.SubcommandsOptional = true
 
-	_, err = p.Parse()
+	_, err := p.Parse()
 	if err != nil {
-		return
+		return err
 	}
 
 	// TODO: implement configuration file parsing
 	if opts.ConfigPath != "" {
 		err = errors.New("config-path option not implemented")
 		log.Errorf(err.Error())
-		return
+		return err
 	}
 	err = connectHosts()
 	if err != nil {
 		log.Errorf("unable to connect to hosts: %v", err)
-		return
+		return err
 	}
 
 	// If no subcommand is specified, interactive shell is started
@@ -120,4 +117,6 @@ func main() {
 	shell := setupShell()
 	shell.Println("DAOS Management Shell")
 	shell.Run()
+
+	return nil
 }

--- a/src/control/server/main.go
+++ b/src/control/server/main.go
@@ -57,15 +57,12 @@ type cliOptions struct {
 }
 
 func main() {
-	var err error
-	defer func() {
-		status := 0
-		if err != nil {
-			status = 1
-		}
-		os.Exit(status)
-	}()
+	if serverMain() != nil {
+		os.Exit(1)
+	}
+}
 
+func serverMain() error {
 	runtime.GOMAXPROCS(1)
 
 	// Set default global logger for application.
@@ -77,16 +74,16 @@ func main() {
 	p.SubcommandsOptional = true
 
 	// Parse commandline flags which override options loaded from config.
-	_, err = p.Parse()
+	_, err := p.Parse()
 	if err != nil {
-		return
+		return err
 	}
 
 	// Parse configuration file and load values.
 	config, err := loadConfigOpts(opts)
 	if err != nil {
 		log.Errorf("Failed to load config options: %s", err)
-		return
+		return err
 	}
 
 	// Set log level mask for default logger from config.
@@ -104,7 +101,7 @@ func main() {
 		f, err := common.AppendFile(config.ControlLogFile)
 		if err != nil {
 			log.Errorf("Failure creating log file: %s", err)
-			return
+			return err
 		}
 		defer f.Close()
 
@@ -122,7 +119,7 @@ func main() {
 		&config, getDrpcClientConnection(config.SocketDir))
 	if err != nil {
 		log.Errorf("Failed to init ControlService: %s", err)
-		return
+		return err
 	}
 	mgmtControlServer.Setup()
 	defer mgmtControlServer.Teardown()
@@ -132,7 +129,7 @@ func main() {
 	lis, err := net.Listen("tcp", addr)
 	if err != nil {
 		log.Errorf("Unable to listen on management interface: %s", err)
-		return
+		return err
 	}
 
 	// TODO: This will need to be extended to take certificate information for
@@ -152,7 +149,7 @@ func main() {
 	// Format the unformatted servers.
 	if err = formatIosrvs(&config, false); err != nil {
 		log.Errorf("Failed to format servers: %s", err)
-		return
+		return err
 	}
 
 	// Create a channel to retrieve signals.
@@ -166,7 +163,7 @@ func main() {
 	// Process configurations parameters for Nvme.
 	if err = config.parseNvme(); err != nil {
 		log.Errorf("NVMe config could not be processed: %s", err)
-		return
+		return err
 	}
 
 	// Only start single io_server for now.
@@ -174,15 +171,15 @@ func main() {
 	iosrv, err := newIosrv(&config, 0)
 	if err != nil {
 		log.Errorf("Failed to load server: %s", err)
-		return
+		return err
 	}
 	if err = drpcSetup(config.SocketDir, iosrv); err != nil {
 		log.Errorf("Failed to set up dRPC: %s", err)
-		return
+		return err
 	}
 	if err = iosrv.start(); err != nil {
 		log.Errorf("Failed to start server: %s", err)
-		return
+		return err
 	}
 
 	extraText, err := CheckReplica(lis, config.AccessPoints, iosrv.cmd)
@@ -190,7 +187,7 @@ func main() {
 		log.Errorf(
 			"Unable to determine if management service replica: %s",
 			err)
-		return
+		return err
 	}
 	log.Debugf("DAOS server listening on %s%s", addr, extraText)
 
@@ -199,4 +196,6 @@ func main() {
 	if err != nil {
 		log.Errorf("DAOS I/O server exited with error: %s", err)
 	}
+
+	return err
 }


### PR DESCRIPTION
Unfortunately, d0bfb46a9746ebabddf105a3adb9a7b85fd2a541 introduces a
problem. When daos_server panics, it exits through the os.Exit call,
before printing the runtime error. Often, err is nil, resulting in a
zero exit status. Also, we won't see the valuable stack trace. This
indicates one shall never defer os.Exit. This patch adds an additional
level to main to avoid deferring os.Exit.

Signed-off-by: Li Wei <wei.g.li@intel.com>