### PR TITLE
CORCI-413 Reduce timeout of Functional daos_test to 700

### DIFF
--- a/src/tests/ftest/daos_test/DaosCoreTest.yaml
+++ b/src/tests/ftest/daos_test/DaosCoreTest.yaml
@@ -11,7 +11,7 @@ hosts:
     - boro-G
     - boro-H
 # rebuild alone takes about 2hrs
-timeout: 9000
+timeout: 700
 server:
   server_group: daos_server
 daos_tests:


### PR DESCRIPTION
The current time out for the daos_test subtess is 9000 seconds.  That is much much
more than is necessary.  Reduce it to 700 seconds.