### PR TITLE
DAOS-1967 server: refine threading model

### DIFF
--- a/src/control/server/config.go
+++ b/src/control/server/config.go
@@ -205,6 +205,10 @@ func (c *configuration) populateCliOpts(i int) error {
 	if c.Attach != "" {
 		server.CliOpts = append(server.CliOpts, "-a", c.Attach)
 	}
+	server.CliOpts = append(server.CliOpts, "-x", strconv.Itoa(c.XShelpernr))
+	if c.Firstcore > 0 {
+		server.CliOpts = append(server.CliOpts, "-f", strconv.Itoa(c.Firstcore))
+	}
 	if c.SystemMap != "" {
 		server.CliOpts = append(server.CliOpts, "-y", c.SystemMap)
 	}
@@ -255,6 +259,16 @@ func (c *configuration) cmdlineOverride(opts *cliOptions) {
 			// to reply to more than one server)
 			c.Servers[0].Rank = opts.Rank
 		}
+	}
+	if opts.XShelpernr > 2 {
+		log.Errorf("invalid XShelpernr %d exceed [0, 2], use default value of 1",
+			   opts.XShelpernr)
+		c.XShelpernr = 1
+	} else {
+		c.XShelpernr = opts.XShelpernr
+	}
+	if opts.Firstcore > 0 {
+		c.Firstcore = opts.Firstcore
 	}
 	if opts.Group != "" {
 		c.SystemName = opts.Group

--- a/src/control/server/config_types.go
+++ b/src/control/server/config_types.go
@@ -240,6 +240,8 @@ type configuration struct {
 	// development (subject to change) config fields
 	Modules   string
 	Attach    string
+	XShelpernr int
+	Firstcore int
 	SystemMap string
 	Path      string
 	ext       External

--- a/src/control/server/main.go
+++ b/src/control/server/main.go
@@ -47,6 +47,8 @@ type cliOptions struct {
 	ConfigPath  string             `short:"o" long:"config_path" description:"Server config file path"`
 	Modules     *string            `short:"m" long:"modules" description:"List of server modules to load"`
 	Cores       uint16             `short:"c" long:"cores" default:"0" description:"number of cores to use (default all)"`
+	XShelpernr  int                `short:"x" long:"xshelpernr" default:"1" description:"number of helper XS per VOS target (default 1)"`
+	Firstcore   int                `short:"f" long:"firstcore" default:"0" description:"index of first core for service thread (default 0)"`
 	Group       string             `short:"g" long:"group" description:"Server group name"`
 	Attach      *string            `short:"a" long:"attach_info" description:"Attach info patch (to support non-PMIx client, default /tmp)"`
 	Map         *string            `short:"y" long:"map" description:"[Temporary] System map file"`

--- a/src/include/daos/rpc.h
+++ b/src/include/daos/rpc.h
@@ -106,11 +106,8 @@ enum daos_rpc_type {
 
 /** DAOS_TGT0_OFFSET is target 0's cart context offset */
 #define DAOS_TGT0_OFFSET		(1)
-/** Number of cart context created for each target */
-#define DAOS_CTX_NR_PER_TGT		(2)
 /** The cart context index of target index */
-#define DAOS_IO_CTX_ID(tgt_idx)				\
-	((tgt_idx) * DAOS_CTX_NR_PER_TGT + DAOS_TGT0_OFFSET)
+#define DAOS_IO_CTX_ID(tgt_idx)		((tgt_idx) + DAOS_TGT0_OFFSET)
 
 /**
  * Get the target tag (context ID) for specific request type and target index.

--- a/src/iosrv/srv.c
+++ b/src/iosrv/srv.c
@@ -57,7 +57,7 @@
  *		container open/close.
  *
  * And a set of "offload XS" (dss_tgt_offload_xs_nr)
- * Now dss_tgt_offload_xs_nr can be 1 or 2.
+ * Now dss_tgt_offload_xs_nr can be [0, 2].
  * 1.2) The tasks for offload XS:
  *	ULT server for:
  *		IO request dispatch (TX coordinator, on 1st offload XS),
@@ -83,8 +83,8 @@
  * 2) dss_tgt2xs() to query the XS id of the xstream for specific ULT task.
  */
 
-/** Number of offload XS per target (1 or 2)*/
-unsigned int	dss_tgt_offload_xs_nr = 2;
+/** Number of offload XS per target [0, 2] */
+unsigned int	dss_tgt_offload_xs_nr = 1;
 /** number of target (XS set) per server */
 unsigned int	dss_tgt_nr;
 /** number of system XS */
@@ -107,9 +107,7 @@ struct dss_xstream {
 	 * For offload XS it is same value as its main XS.
 	 */
 	int		dx_tgt_id;
-	/* CART context id, [0, DSS_CTX_NR_TOTAL - 1].
-	 * Invalid (-1) for the offload XS w/o CART context created.
-	 */
+	/* CART context id, invalid (-1) for the offload XS w/o CART context */
 	int		dx_ctx_id;
 	bool		dx_main_xs;	/* true for main XS */
 	bool		dx_comm;	/* true with cart context */
@@ -406,12 +404,21 @@ dss_srv_handler(void *arg)
 		}
 		dx->dx_ctx_id = dmi->dmi_ctx_id;
 		/** verify CART assigned the ctx_id ascendantly start from 0 */
-		if (dx->dx_xs_id == 0)
-			D_ASSERT(dx->dx_ctx_id == 0);
-		else
-			D_ASSERT(dx->dx_ctx_id ==
-				 (dx->dx_tgt_id * DSS_CTX_NR_PER_TGT +
-				  dss_sys_xs_nr + !dx->dx_main_xs));
+		if (dx->dx_xs_id < dss_sys_xs_nr) {
+			D_ASSERT(dx->dx_ctx_id == dx->dx_xs_id);
+		} else {
+			if (dx->dx_main_xs)
+				D_ASSERTF(dx->dx_ctx_id ==
+					  dx->dx_tgt_id + dss_sys_xs_nr,
+					  "incorrect ctx_id %d for xs_id %d\n",
+					  dx->dx_ctx_id, dx->dx_xs_id);
+			else
+				D_ASSERTF(dx->dx_ctx_id ==
+					  (dss_sys_xs_nr + dss_tgt_nr +
+					   dx->dx_tgt_id),
+					  "incorrect ctx_id %d for xs_id %d\n",
+					  dx->dx_ctx_id, dx->dx_xs_id);
+		}
 	}
 
 	/* Prepare the scheduler */
@@ -660,7 +667,7 @@ dss_start_one_xstream(hwloc_cpuset_t cpus, int xs_id)
 		ABT_mutex_unlock(xstream_data.xd_mutex);
 		goto out_xstream;
 	}
-	xstream_data.xd_xs_ptrs[xstream_data.xd_xs_nr++] = dx;
+	xstream_data.xd_xs_ptrs[xs_id] = dx;
 	ABT_mutex_unlock(xstream_data.xd_mutex);
 	ABT_thread_attr_free(&attr);
 
@@ -700,10 +707,14 @@ dss_xstreams_fini(bool force)
 	/** Stop & free progress ULTs */
 	for (i = 0; i < xstream_data.xd_xs_nr; i++) {
 		dx = xstream_data.xd_xs_ptrs[i];
+		if (dx == NULL)
+			continue;
 		ABT_future_set(dx->dx_shutdown, dx);
 	}
 	for (i = 0; i < xstream_data.xd_xs_nr; i++) {
 		dx = xstream_data.xd_xs_ptrs[i];
+		if (dx == NULL)
+			continue;
 		ABT_thread_join(dx->dx_progress);
 		ABT_thread_free(&dx->dx_progress);
 		ABT_future_free(&dx->dx_shutdown);
@@ -712,6 +723,8 @@ dss_xstreams_fini(bool force)
 	/** Wait for each execution stream to complete */
 	for (i = 0; i < xstream_data.xd_xs_nr; i++) {
 		dx = xstream_data.xd_xs_ptrs[i];
+		if (dx == NULL)
+			continue;
 		ABT_xstream_join(dx->dx_xstream);
 		ABT_xstream_free(&dx->dx_xstream);
 	}
@@ -719,6 +732,8 @@ dss_xstreams_fini(bool force)
 	/** housekeeping ... */
 	for (i = 0; i < xstream_data.xd_xs_nr; i++) {
 		dx = xstream_data.xd_xs_ptrs[i];
+		if (dx == NULL)
+			continue;
 		ABT_sched_free(&dx->dx_sched);
 		dss_xstream_free(dx);
 		xstream_data.xd_xs_ptrs[i] = NULL;
@@ -751,13 +766,34 @@ dss_xstreams_empty(void)
 }
 
 static int
+dss_start_xs_id(int xs_id)
+{
+	hwloc_obj_t	obj;
+	int		rc;
+
+	obj = hwloc_get_obj_by_depth(dss_topo, dss_core_depth,
+				     (xs_id + dss_core_offset) % dss_core_nr);
+	if (obj == NULL) {
+		D_ERROR("Null core returned by hwloc\n");
+		return -DER_INVAL;
+	}
+
+	rc = dss_start_one_xstream(obj->allowed_cpuset, xs_id);
+	if (rc)
+		return rc;
+	
+	return 0;
+}
+
+static int
 dss_xstreams_init()
 {
 	int	rc;
-	int	i;
+	int	i, xs_id;
 
 	D_ASSERT(dss_tgt_nr >= 1);
-	D_ASSERT(dss_tgt_offload_xs_nr == 1 || dss_tgt_offload_xs_nr == 2);
+	D_ASSERT(dss_tgt_offload_xs_nr == 0 || dss_tgt_offload_xs_nr == 1 ||
+		 dss_tgt_offload_xs_nr == 2);
 
 	/* initialize xstream-local storage */
 	rc = pthread_key_create(&dss_tls_key, NULL);
@@ -770,23 +806,42 @@ dss_xstreams_init()
 	D_DEBUG(DB_TRACE, "%d cores detected, starting %d main xstreams\n",
 		dss_core_nr, dss_tgt_nr);
 
-	for (i = 0; i < DSS_XS_NR_TOTAL; i++) {
-		hwloc_obj_t	obj;
-
-		obj = hwloc_get_obj_by_depth(dss_topo, dss_core_depth,
-					     i % dss_core_nr);
-		if (obj == NULL) {
-			D_ERROR("Null core returned by hwloc\n");
-			D_GOTO(failed, rc = -DER_INVAL);
-		}
-
-		rc = dss_start_one_xstream(obj->allowed_cpuset, i);
+	xstream_data.xd_xs_nr = DSS_XS_NR_TOTAL;
+	/* start system service XS */
+	for (i = 0; i < dss_sys_xs_nr; i++) {
+		xs_id = i;
+		rc = dss_start_xs_id(xs_id);
 		if (rc)
-			D_GOTO(failed, rc);
+			D_GOTO(out, rc);
 	}
-	D_DEBUG(DB_TRACE, "%d execution streams successfully started\n",
-		dss_tgt_nr);
-failed:
+
+	/* start main IO service XS */
+	for (i = 0; i< dss_tgt_nr; i++) {
+		xs_id = DSS_MAIN_XS_ID(i);
+		rc = dss_start_xs_id(xs_id);
+		if (rc)
+			D_GOTO(out, rc);
+	}
+
+	/* start offload XS if any */
+	if (dss_tgt_offload_xs_nr == 0)
+		D_GOTO(out, rc);
+	for (i = 0; i < dss_tgt_nr; i++) {
+		xs_id = DSS_MAIN_XS_ID(i) + 1;
+		rc = dss_start_xs_id(xs_id);
+		if (rc)
+			D_GOTO(out, rc);
+		if (dss_tgt_offload_xs_nr == 1)
+			continue;
+		xs_id++;
+		rc = dss_start_xs_id(xs_id);
+		if (rc)
+			D_GOTO(out, rc);
+	}
+
+	D_DEBUG(DB_TRACE, "%d execution streams successfully started "
+		"(first core %d)\n", dss_tgt_nr, dss_core_offset);
+out:
 	dss_xstreams_open_barrier();
 	if (dss_xstreams_empty()) /* started nothing */
 		pthread_key_delete(dss_tls_key);

--- a/src/iosrv/srv_internal.h
+++ b/src/iosrv/srv_internal.h
@@ -31,6 +31,8 @@ extern hwloc_topology_t	dss_topo;
 extern int		dss_core_depth;
 /** number of physical cores, w/o hyper-threading */
 extern int		dss_core_nr;
+/** start offset index of the first core for service XS */
+extern int		dss_core_offset;
 
 /** Number of offload XS per target (1 or 2)*/
 extern unsigned int	dss_tgt_offload_xs_nr;
@@ -70,11 +72,6 @@ int dss_sys_map_load(const char *path, crt_group_id_t grpid, d_rank_t self_rank,
 /** Total number of XS */
 #define DSS_XS_NR_TOTAL						\
 	(dss_tgt_nr * DSS_XS_NR_PER_TGT + dss_sys_xs_nr)
-/** Number of cart contexts for each VOS target */
-#define DSS_CTX_NR_PER_TGT	DAOS_CTX_NR_PER_TGT
-/** Total number of cart contexts created */
-#define DSS_CTX_NR_TOTAL					\
-	(dss_tgt_nr * DSS_CTX_NR_PER_TGT + dss_sys_xs_nr)
 /** main XS id of (vos) tgt_id */
 #define DSS_MAIN_XS_ID(tgt_id)					\
 	(((tgt_id) * DSS_XS_NR_PER_TGT) + dss_sys_xs_nr)
@@ -103,7 +100,7 @@ dss_tgt2xs(int ult_type, int tgt_id)
 	case DSS_ULT_SELF:
 		return DSS_XS_SELF;
 	case DSS_ULT_IOFW:
-		return DSS_MAIN_XS_ID(tgt_id) + 1;
+		return (DSS_MAIN_XS_ID(tgt_id) + 1) % DSS_XS_NR_TOTAL;
 	case DSS_ULT_EC:
 	case DSS_ULT_CHECKSUM:
 	case DSS_ULT_COMPRESS:

--- a/src/vos/vos_layout.h
+++ b/src/vos/vos_layout.h
@@ -254,8 +254,8 @@ enum vos_krec_bf {
 };
 
 /**
- * Persisted VOS (d)key record, it is referenced by btr_record::rec_mmid
- * of btree VOS_BTR_KEY.
+ * Persisted VOS (d/a)key record, it is referenced by btr_record::rec_mmid
+ * of btree VOS_BTR_DKEY/VOS_BTR_AKEY.
  */
 struct vos_krec_df {
 	/** record bitmap, e.g. has evtree, see vos_krec_bf */
@@ -274,7 +274,7 @@ struct vos_krec_df {
 	daos_epoch_t			kr_earliest;
 	/** The DTX entry in SCM. */
 	umem_id_t			kr_dtx;
-	/** The count of uncommitted DTXs that share the object. */
+	/** The count of uncommitted DTXs that share the key. */
 	uint32_t			kr_dtx_shares;
 	/** For 64-bits alignment. */
 	uint32_t			kr_padding;
@@ -293,8 +293,8 @@ D_CASSERT(offsetof(struct vos_krec_df, kr_earliest) ==
 	  sizeof(((struct vos_krec_df *)0)->kr_latest));
 
 /**
- * Persisted VOS index & epoch record, it is referenced by btr_record::rec_mmid
- * of btree VOS_BTR_IDX.
+ * Persisted VOS single value & epoch record, it is referenced by
+ * btr_record::rec_mmid of btree VOS_BTR_SINGV.
  */
 struct vos_irec_df {
 	/** key checksum size (in bytes) */


### PR DESCRIPTION
1) add "-x" (--xshelpernr) option to set the number of helper XS per VOS
   target, default value is 1, valid value is [0, 2].
2) add "-f" (--firstcore) option to set the index of first core used for
   service XS, default value is 0, valid value is [0, num_cores - 1]
3) change XS creation order to be - create system XS, then main IO XS,
   then helper XS. The benefit is client can use the same tag for vos
   target despite of different server-side "-x" config.

And refined a few comments.

Signed-off-by: Xuezhao Liu <xuezhao.liu@intel.com>