### PR TITLE
DAOS-2221 doc: Fix links, typos, and package dependencies

### DIFF
--- a/doc/environ.md
+++ b/doc/environ.md
@@ -143,4 +143,4 @@ generic DEBUG messages. All debug streams will be enabled by default
 ("DD_MASK=all"). Single debug masks can be set ("DD_MASK=trace") or multiple
 masks ("DD_MASK=trace,test,mgmt").
 Note that since these debug streams are strictly related to the debug log
-messages, DD_LOG_MASK must be set to DEBUG.
+messages, D_LOG_MASK must be set to DEBUG.

--- a/doc/quickstart.md
+++ b/doc/quickstart.md
@@ -118,7 +118,7 @@ If all the software dependencies listed previously are already satisfied, type t
     scons --config=force install
 ```
 
-If you are a developer of DAOS, we recommend following the instructions in the [DAOS for Developers](#daos-for-development) section below.
+If you are a developer of DAOS, we recommend following the instructions in [DAOS for Developers](development.md).
 
 Otherwise, the missing dependencies can be built automatically by invoking scons with the following parameters:
 


### PR DESCRIPTION
CentOS 7.x build mpi4py package fails if python-devel not installed.
Update quickstart.md with the dependency. Fix broken link and typo.

Signed-off-by: Ken Cain <kenneth.c.cain@intel.com>