### PR TITLE
DAOS-2185 container: add iv to container

### DIFF
--- a/src/container/SConscript
+++ b/src/container/SConscript
@@ -13,7 +13,7 @@ def scons():
     ds_cont = daos_build.library(denv, 'cont',
                                  ['srv.c', 'srv_container.c', 'srv_epoch.c',
                                   'srv_target.c', 'srv_layout.c', 'oid_iv.c',
-                                  common])
+                                  'container_iv.c', common])
     denv.Install('$PREFIX/lib/daos_srv', ds_cont)
 
     # dc_cont: Container Client

--- a/src/container/container_iv.c
+++ b/src/container/container_iv.c
@@ -1,0 +1,418 @@
+/**
+ * (C) Copyright 2019 Intel Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * GOVERNMENT LICENSE RIGHTS-OPEN SOURCE SOFTWARE
+ * The Government's rights to use, modify, reproduce, release, perform, display,
+ * or disclose this software are subject to the terms of the Apache License as
+ * provided in Contract No. B609815.
+ * Any reproduction of computer software, computer software documentation, or
+ * portions thereof marked with this legend must also reproduce the markings.
+ */
+/**
+ * container IV cache
+ */
+#define D_LOGFAC	DD_FAC(container)
+
+#include <daos_srv/container.h>
+#include "srv_internal.h"
+#include <daos_srv/iv.h>
+#include <daos/btree_class.h>
+#include <daos/btree.h>
+#include <daos/dtx.h>
+
+/* XXX Temporary limit for IV */
+#define MAX_SNAP_CNT	20
+/* Container IV structure */
+struct cont_iv_entry {
+	uuid_t	cont_uuid;
+	int	snap_size;
+	uint64_t snaps[0];
+};
+
+struct cont_iv_key {
+	uuid_t	cont_uuid;
+};
+
+static struct cont_iv_key *
+key2priv(struct ds_iv_key *iv_key)
+{
+	return (struct cont_iv_key *)iv_key->key_buf;
+}
+
+static uint32_t
+cont_iv_ent_size(int nr)
+{
+	return sizeof(struct cont_iv_entry) + nr * sizeof(uint64_t);
+}
+
+static int
+cont_iv_value_alloc_internal(d_sg_list_t *sgl)
+{
+	struct cont_iv_entry	*entry;
+	int			entry_size;
+	int			rc;
+
+	rc = daos_sgl_init(sgl, 1);
+	if (rc)
+		return rc;
+
+	/* FIXME: allocate entry by the real size */
+	entry_size = cont_iv_ent_size(MAX_SNAP_CNT);
+	D_ALLOC(entry, entry_size);
+	if (entry == NULL)
+		D_GOTO(out, rc = -DER_NOMEM);
+
+	daos_iov_set(&sgl->sg_iovs[0], entry, entry_size);
+out:
+	if (rc)
+		daos_sgl_fini(sgl, true);
+
+	return rc;
+}
+
+static int
+cont_iv_ent_init(struct ds_iv_key *iv_key, void *data,
+		 struct ds_iv_entry *entry)
+{
+	struct umem_attr uma = { 0 };
+	daos_handle_t	 root_hdl;
+	int		 rc;
+
+	uma.uma_id = UMEM_CLASS_VMEM;
+	rc = dbtree_create(DBTREE_CLASS_NV, 0, 4, &uma, NULL, &root_hdl);
+	if (rc != 0) {
+		D_ERROR("failed to create tree: %d\n", rc);
+		return rc;
+	}
+
+	entry->iv_key.class_id = iv_key->class_id;
+	entry->iv_key.rank = iv_key->rank;
+
+	rc = daos_sgl_init(&entry->iv_value, 1);
+	if (rc)
+		D_GOTO(out, rc = -DER_NOMEM);
+
+	D_ALLOC(entry->iv_value.sg_iovs[0].iov_buf, sizeof(root_hdl));
+	if (entry->iv_value.sg_iovs[0].iov_buf == NULL)
+		D_GOTO(out, rc = -DER_NOMEM);
+
+	memcpy(entry->iv_value.sg_iovs[0].iov_buf, &root_hdl, sizeof(root_hdl));
+out:
+	if (rc != 0) {
+		dbtree_destroy(root_hdl);
+		daos_sgl_fini(&entry->iv_value, true);
+	}
+
+	return rc;
+}
+
+static int
+cont_iv_ent_get(struct ds_iv_entry *entry, void **priv)
+{
+	return 0;
+}
+
+static int
+cont_iv_ent_put(struct ds_iv_entry *entry, void **priv)
+{
+	return 0;
+}
+
+static int
+delete_iter_cb(daos_handle_t ih, daos_iov_t *key,
+	       daos_iov_t *val, void *arg)
+{
+	int rc;
+
+	/* Delete the current container tree */
+	rc = dbtree_iter_delete(ih, NULL);
+	if (rc != 0)
+		return rc;
+
+	/* re-probe the dbtree after delete */
+	rc = dbtree_iter_probe(ih, BTR_PROBE_FIRST, DAOS_INTENT_PUNCH,
+			       NULL, NULL);
+	if (rc == -DER_NONEXIST)
+		return 1;
+
+	return rc;
+}
+
+static int
+cont_iv_ent_destroy(d_sg_list_t *sgl)
+{
+	if (!sgl)
+		return 0;
+
+	if (sgl->sg_iovs && sgl->sg_iovs[0].iov_buf) {
+		daos_handle_t *root_hdl = sgl->sg_iovs[0].iov_buf;
+		int rc;
+
+		while (!dbtree_is_empty(*root_hdl)) {
+			rc = dbtree_iterate(*root_hdl, DAOS_INTENT_PUNCH, false,
+					    delete_iter_cb, NULL);
+			if (rc < 0) {
+				D_ERROR("dbtree iterate fails %d\n", rc);
+				return rc;
+			}
+		}
+		dbtree_destroy(*root_hdl);
+	}
+
+	daos_sgl_fini(sgl, true);
+
+	return 0;
+}
+
+static int
+cont_iv_ent_copy(struct cont_iv_entry *dst, struct cont_iv_entry *src)
+{
+	D_ASSERT(src->snap_size < MAX_SNAP_CNT);
+
+	uuid_copy(dst->cont_uuid, src->cont_uuid);
+	dst->snap_size = src->snap_size;
+
+	memcpy(dst->snaps, src->snaps, src->snap_size * sizeof(src->snaps[0]));
+	return 0;
+}
+
+static bool
+is_master(struct ds_iv_entry *entry)
+{
+	d_rank_t myrank;
+
+	crt_group_rank(NULL, &myrank);
+
+	return entry->ns->iv_master_rank == myrank;
+}
+
+static int
+cont_iv_ent_fetch(struct ds_iv_entry *entry, struct ds_iv_key *key,
+		  d_sg_list_t *dst, d_sg_list_t *src, void **priv)
+{
+	struct cont_iv_entry	*src_iv;
+	daos_handle_t		root_hdl;
+	struct cont_iv_key	*civ_key = key2priv(key);
+	daos_iov_t		key_iov;
+	daos_iov_t		val_iov;
+	struct cont_iv_entry	*iv_entry = NULL;
+	daos_epoch_t		*snaps = NULL;
+	int			snap_cnt = MAX_SNAP_CNT;
+	int			rc;
+
+	D_ASSERT(dss_get_module_info()->dmi_xs_id == 0);
+	memcpy(&root_hdl, entry->iv_value.sg_iovs[0].iov_buf, sizeof(root_hdl));
+
+	daos_iov_set(&key_iov, civ_key->cont_uuid, sizeof(uuid_t));
+	daos_iov_set(&val_iov, NULL, 0);
+	rc = dbtree_lookup(root_hdl, &key_iov, &val_iov);
+	if (rc < 0) {
+		if (rc == -DER_NONEXIST && is_master(entry)) {
+			rc = ds_cont_get_snapshots(entry->ns->iv_pool_uuid,
+						  civ_key->cont_uuid, &snaps,
+						  &snap_cnt);
+			if (rc)
+				D_GOTO(out, rc);
+
+			D_ALLOC(iv_entry, cont_iv_ent_size(snap_cnt));
+			if (iv_entry == NULL)
+				D_GOTO(out, rc = -DER_NOMEM);
+
+			uuid_copy(iv_entry->cont_uuid, civ_key->cont_uuid);
+			iv_entry->snap_size = snap_cnt;
+			memcpy(iv_entry->snaps, snaps,
+			       snap_cnt * sizeof(daos_epoch_t));
+			daos_iov_set(&val_iov, iv_entry,
+				     cont_iv_ent_size(iv_entry->snap_size));
+			rc = dbtree_update(root_hdl, &key_iov, &val_iov);
+			if (rc)
+				D_GOTO(out, rc);
+		} else {
+			D_DEBUG(DB_MGMT, "lookup cont: rc %d\n", rc);
+			D_GOTO(out, rc);
+		}
+	}
+
+	src_iv = val_iov.iov_buf;
+
+	rc = cont_iv_ent_copy((struct cont_iv_entry *)dst->sg_iovs[0].iov_buf,
+				src_iv);
+
+out:
+	if (iv_entry != NULL)
+		D_FREE(iv_entry);
+	if (snaps != NULL)
+		D_FREE(snaps);
+
+	return rc;
+}
+
+static int
+cont_iv_ent_update(struct ds_iv_entry *entry, struct ds_iv_key *key,
+		   d_sg_list_t *src, void **priv)
+{
+	daos_handle_t		root_hdl;
+	struct cont_iv_key	*civ_key = key2priv(key);
+	daos_iov_t		key_iov;
+	daos_iov_t		val_iov;
+	int			rc;
+
+	D_ASSERT(dss_get_module_info()->dmi_xs_id == 0);
+	memcpy(&root_hdl, entry->iv_value.sg_iovs[0].iov_buf, sizeof(root_hdl));
+
+	daos_iov_set(&key_iov, civ_key->cont_uuid, sizeof(uuid_t));
+	daos_iov_set(&val_iov, src->sg_iovs[0].iov_buf,
+		     src->sg_iovs[0].iov_len);
+	rc = dbtree_update(root_hdl, &key_iov, &val_iov);
+	if (rc < 0)
+		D_ERROR("failed to insert: rc %d\n", rc);
+
+	return rc;
+}
+
+static int
+cont_iv_ent_refresh(struct ds_iv_entry *entry, struct ds_iv_key *key,
+		    d_sg_list_t *src, int ref_rc, void **priv)
+{
+	D_ASSERT(dss_get_module_info()->dmi_xs_id == 0);
+	return cont_iv_ent_update(entry, key, src, priv);
+}
+
+static int
+cont_iv_value_alloc(struct ds_iv_entry *entry, d_sg_list_t *sgl)
+{
+	return cont_iv_value_alloc_internal(sgl);
+}
+
+struct ds_iv_class_ops cont_iv_ops = {
+	.ivc_ent_init	= cont_iv_ent_init,
+	.ivc_ent_get	= cont_iv_ent_get,
+	.ivc_ent_put	= cont_iv_ent_put,
+	.ivc_ent_destroy = cont_iv_ent_destroy,
+	.ivc_ent_fetch	= cont_iv_ent_fetch,
+	.ivc_ent_update	= cont_iv_ent_update,
+	.ivc_ent_refresh = cont_iv_ent_refresh,
+	.ivc_value_alloc = cont_iv_value_alloc,
+};
+
+int
+cont_iv_fetch(void *ns, struct cont_iv_entry *cont_iv)
+{
+	d_sg_list_t		sgl;
+	daos_iov_t		iov;
+	uint32_t		cont_iv_len;
+	struct ds_iv_key	key = { 0 };
+	struct cont_iv_key	*civ_key;
+	int			rc;
+
+	cont_iv_len = cont_iv_ent_size(cont_iv->snap_size);
+	iov.iov_buf = cont_iv;
+	iov.iov_len = cont_iv_len;
+	iov.iov_buf_len = cont_iv_len;
+	sgl.sg_nr = 1;
+	sgl.sg_nr_out = 0;
+	sgl.sg_iovs = &iov;
+
+	memset(&key, 0, sizeof(key));
+	key.class_id = IV_CONT_SNAP;
+	civ_key = key2priv(&key);
+	uuid_copy(civ_key->cont_uuid, cont_iv->cont_uuid);
+	rc = ds_iv_fetch(ns, &key, &sgl);
+	if (rc)
+		D_ERROR(DF_UUID" iv fetch failed %d\n",
+			DP_UUID(cont_iv->cont_uuid), rc);
+
+	D_DEBUG(DB_TRACE, "snap_size is %d\n", cont_iv->snap_size);
+	return rc;
+}
+
+int
+cont_iv_update(void *ns, struct cont_iv_entry *cont_iv,
+	       unsigned int shortcut, unsigned int sync_mode)
+{
+	d_sg_list_t		sgl;
+	daos_iov_t		iov;
+	uint32_t		cont_iv_len;
+	struct ds_iv_key	key;
+	struct cont_iv_key	*civ_key;
+	int			rc;
+
+	cont_iv_len = cont_iv_ent_size(cont_iv->snap_size);
+	iov.iov_buf = cont_iv;
+	iov.iov_len = cont_iv_len;
+	iov.iov_buf_len = cont_iv_len;
+	sgl.sg_nr = 1;
+	sgl.sg_nr_out = 0;
+	sgl.sg_iovs = &iov;
+
+	memset(&key, 0, sizeof(key));
+	key.class_id = IV_CONT_SNAP;
+	civ_key = key2priv(&key);
+	uuid_copy(civ_key->cont_uuid, cont_iv->cont_uuid);
+	rc = ds_iv_update(ns, &key, &sgl, shortcut, sync_mode, 0);
+	if (rc)
+		D_ERROR("iv update failed %d\n", rc);
+
+	return rc;
+}
+
+int
+cont_iv_snapshots_fetch(void *ns, uuid_t cont_uuid, uint64_t **snapshots,
+			int *snap_count)
+{
+	struct cont_iv_entry	*iv_entry;
+	int			rc;
+
+	D_ALLOC(iv_entry, cont_iv_ent_size(MAX_SNAP_CNT));
+	if (iv_entry == NULL)
+		return -DER_NOMEM;
+
+	uuid_copy(iv_entry->cont_uuid, cont_uuid);
+	iv_entry->snap_size = MAX_SNAP_CNT;
+	rc = cont_iv_fetch(ns, iv_entry);
+	if (rc)
+		D_GOTO(free, rc);
+
+	D_ASSERT(iv_entry->snap_size <= MAX_SNAP_CNT);
+	if (iv_entry->snap_size == 0) {
+		*snap_count = 0;
+		D_GOTO(free, rc = 0);
+	}
+
+	D_ALLOC(*snapshots, sizeof(iv_entry->snaps[0]) * iv_entry->snap_size);
+	if (*snapshots == NULL)
+		D_GOTO(free, rc = -DER_NOMEM);
+
+	memcpy(*snapshots, iv_entry->snaps,
+	       sizeof(iv_entry->snaps[0]) * iv_entry->snap_size);
+	*snap_count = iv_entry->snap_size;
+free:
+	D_FREE(iv_entry);
+	return rc;
+}
+
+
+int
+ds_cont_iv_init(void)
+{
+	return ds_iv_class_register(IV_CONT_SNAP, &iv_cache_ops,
+				    &cont_iv_ops);
+}
+
+int
+ds_cont_iv_fini(void)
+{
+	return ds_iv_class_unregister(IV_CONT_SNAP);
+}

--- a/src/container/oid_iv.c
+++ b/src/container/oid_iv.c
@@ -79,15 +79,16 @@ oid_iv_key_cmp(void *key1, void *key2)
 }
 
 static int
-oid_iv_ent_fetch(struct ds_iv_entry *entry, d_sg_list_t *dst, d_sg_list_t *src,
-		 void **priv)
+oid_iv_ent_fetch(struct ds_iv_entry *entry, struct ds_iv_key *key,
+		 d_sg_list_t *src, d_sg_list_t *dst, void **priv)
 {
 	D_ASSERT(0);
 	return 0;
 }
 
 static int
-oid_iv_ent_refresh(d_sg_list_t *dst, d_sg_list_t *src, int ref_rc, void **_priv)
+oid_iv_ent_refresh(struct ds_iv_entry *iv_entry, struct ds_iv_key *key,
+		   d_sg_list_t *src, int ref_rc, void **_priv)
 {
 	struct oid_iv_priv	*priv = (struct oid_iv_priv *)_priv;
 	daos_size_t		num_oids;
@@ -102,7 +103,7 @@ oid_iv_ent_refresh(d_sg_list_t *dst, d_sg_list_t *src, int ref_rc, void **_priv)
 #endif
 	D_ASSERT(num_oids != 0);
 
-	entry = dst->sg_iovs[0].iov_buf;
+	entry = iv_entry->iv_value.sg_iovs[0].iov_buf;
 	D_ASSERT(entry != NULL);
 
 	/** if iv op failed, just release the entry lock acquired in update */
@@ -129,7 +130,7 @@ out:
 }
 
 static int
-oid_iv_ent_update(struct ds_iv_entry *ns_entry, d_sg_list_t *dst,
+oid_iv_ent_update(struct ds_iv_entry *ns_entry, struct ds_iv_key *iv_key,
 		  d_sg_list_t *src, void **_priv)
 {
 	struct oid_iv_priv	*priv = (struct oid_iv_priv *)_priv;
@@ -142,7 +143,7 @@ oid_iv_ent_update(struct ds_iv_entry *ns_entry, d_sg_list_t *dst,
 
 	D_ASSERT(priv != NULL);
 
-	entry = dst->sg_iovs[0].iov_buf;
+	entry = ns_entry->iv_value.sg_iovs[0].iov_buf;
 	ABT_mutex_lock(entry->lock);
 	avail = &entry->rg;
 

--- a/src/container/srv.c
+++ b/src/container/srv.c
@@ -41,8 +41,22 @@ init(void)
 	rc = ds_oid_iv_init();
 	if (rc)
 		D_GOTO(err, rc);
+
+	rc = ds_cont_cache_init();
+	if (rc)
+		D_GOTO(err_oid_iv, rc);
+
+	rc = ds_cont_iv_init();
+	if (rc)
+		D_GOTO(err_cont_cache, rc);
+
 	return 0;
 
+err_cont_cache:
+	ds_cont_iv_fini();
+
+err_oid_iv:
+	ds_oid_iv_fini();
 err:
 	return rc;
 }
@@ -50,6 +64,8 @@ err:
 static int
 fini(void)
 {
+	ds_cont_iv_fini();
+	ds_cont_cache_fini();
 	ds_oid_iv_fini();
 	return 0;
 }
@@ -112,7 +128,7 @@ dsm_tls_init(const struct dss_thread_local_storage *dtls,
 	if (tls == NULL)
 		return NULL;
 
-	rc = ds_cont_cache_create(&tls->dt_cont_cache);
+	rc = ds_cont_child_cache_create(&tls->dt_cont_cache);
 	if (rc != 0) {
 		D_ERROR("failed to create thread-local container cache: %d\n",
 			rc);
@@ -122,9 +138,9 @@ dsm_tls_init(const struct dss_thread_local_storage *dtls,
 
 	rc = ds_cont_hdl_hash_create(&tls->dt_cont_hdl_hash);
 	if (rc != 0) {
-		D_ERROR("failed to create thread-local container handle cache: "
-			"%d\n", rc);
-		ds_cont_cache_destroy(tls->dt_cont_cache);
+		D_ERROR("failed to create thread-local container handle cache:"
+			" %d\n", rc);
+		ds_cont_child_cache_destroy(tls->dt_cont_cache);
 		D_FREE(tls);
 		return NULL;
 	}
@@ -139,7 +155,7 @@ dsm_tls_fini(const struct dss_thread_local_storage *dtls,
 	struct dsm_tls *tls = data;
 
 	ds_cont_hdl_hash_destroy(&tls->dt_cont_hdl_hash);
-	ds_cont_cache_destroy(tls->dt_cont_cache);
+	ds_cont_child_cache_destroy(tls->dt_cont_cache);
 	D_FREE(tls);
 }
 

--- a/src/container/srv_container.c
+++ b/src/container/srv_container.c
@@ -147,7 +147,7 @@ ds_cont_svc_step_down(struct cont_svc *svc)
 	svc->cs_pool = NULL;
 }
 
-static int
+int
 cont_svc_lookup_leader(uuid_t pool_uuid, uint64_t id, struct cont_svc **svcp,
 		       struct rsvc_hint *hint)
 {
@@ -163,7 +163,7 @@ cont_svc_lookup_leader(uuid_t pool_uuid, uint64_t id, struct cont_svc **svcp,
 	return 0;
 }
 
-static void
+void
 cont_svc_put_leader(struct cont_svc *svc)
 {
 	ds_rsvc_put_leader(svc->cs_rsvc);
@@ -599,7 +599,7 @@ out:
 	return rc;
 }
 
-static int
+int
 cont_lookup(struct rdb_tx *tx, const struct cont_svc *svc, const uuid_t uuid,
 	    struct cont **cont)
 {
@@ -1640,3 +1640,4 @@ out_pool_hdl:
 out:
 	return rc;
 }
+

--- a/src/container/srv_target.c
+++ b/src/container/srv_target.c
@@ -43,23 +43,24 @@
 #include <daos/rpc.h>
 #include <daos_srv/pool.h>
 #include <daos_srv/vos.h>
+#include <daos_srv/iv.h>
 #include "rpc.h"
 #include "srv_internal.h"
 
-/* ds_cont ********************************************************************/
+/* ds_cont_child *******************************************************/
 
-static inline struct ds_cont *
-cont_obj(struct daos_llink *llink)
+static inline struct ds_cont_child *
+cont_child_obj(struct daos_llink *llink)
 {
-	return container_of(llink, struct ds_cont, sc_list);
+	return container_of(llink, struct ds_cont_child, sc_list);
 }
 
 static int
-cont_alloc_ref(void *key, unsigned int ksize, void *varg,
+cont_child_alloc_ref(void *key, unsigned int ksize, void *varg,
 	       struct daos_llink **link)
 {
-	struct ds_pool_child   *pool = varg;
-	struct ds_cont	       *cont;
+	struct ds_pool_child	*pool = varg;
+	struct ds_cont_child	*cont;
 	int			rc;
 
 	D_DEBUG(DF_DSMS, DF_CONT": creating\n", DP_CONT(pool->spc_uuid, key));
@@ -82,9 +83,9 @@ cont_alloc_ref(void *key, unsigned int ksize, void *varg,
 }
 
 static void
-cont_free_ref(struct daos_llink *llink)
+cont_child_free_ref(struct daos_llink *llink)
 {
-	struct ds_cont *cont = cont_obj(llink);
+	struct ds_cont_child *cont = cont_child_obj(llink);
 
 	D_DEBUG(DF_DSMS, DF_CONT": freeing\n", DP_CONT(NULL, cont->sc_uuid));
 	vos_cont_close(cont->sc_hdl);
@@ -92,43 +93,44 @@ cont_free_ref(struct daos_llink *llink)
 }
 
 static bool
-cont_cmp_keys(const void *key, unsigned int ksize, struct daos_llink *llink)
+cont_child_cmp_keys(const void *key, unsigned int ksize,
+		    struct daos_llink *llink)
 {
-	struct ds_cont *cont = cont_obj(llink);
+	struct ds_cont_child *cont = cont_child_obj(llink);
 
 	return uuid_compare(key, cont->sc_uuid) == 0;
 }
 
-static struct daos_llink_ops cont_cache_ops = {
-	.lop_alloc_ref	= cont_alloc_ref,
-	.lop_free_ref	= cont_free_ref,
-	.lop_cmp_keys	= cont_cmp_keys
+static struct daos_llink_ops ds_cont_child_cache_ops = {
+	.lop_alloc_ref	= cont_child_alloc_ref,
+	.lop_free_ref	= cont_child_free_ref,
+	.lop_cmp_keys	= cont_child_cmp_keys
 };
 
 int
-ds_cont_cache_create(struct daos_lru_cache **cache)
+ds_cont_child_cache_create(struct daos_lru_cache **cache)
 {
 	/*
 	 * Since there's currently no way to evict an idle object, we don't
 	 * really cache any idle objects.
 	 */
 	return daos_lru_cache_create(-1 /* bits */, D_HASH_FT_NOLOCK /*feats*/,
-				     &cont_cache_ops, cache);
+				     &ds_cont_child_cache_ops, cache);
 }
 
 void
-ds_cont_cache_destroy(struct daos_lru_cache *cache)
+ds_cont_child_cache_destroy(struct daos_lru_cache *cache)
 {
 	daos_lru_cache_destroy(cache);
 }
 
 /*
  * If "pool == NULL", then this is assumed to be a pure lookup. In this case,
- * -DER_NONEXIST is returned if the ds_cont object does not exist.
+ * -DER_NONEXIST is returned if the ds_cont_child object does not exist.
  */
 static int
-cont_lookup(struct daos_lru_cache *cache, const uuid_t uuid,
-	    struct ds_pool_child *pool, struct ds_cont **cont)
+cont_child_lookup(struct daos_lru_cache *cache, const uuid_t uuid,
+		  struct ds_pool_child *pool, struct ds_cont_child **cont)
 {
 	struct daos_llink      *llink;
 	int			rc;
@@ -147,12 +149,12 @@ cont_lookup(struct daos_lru_cache *cache, const uuid_t uuid,
 		return rc;
 	}
 
-	*cont = cont_obj(llink);
+	*cont = cont_child_obj(llink);
 	return 0;
 }
 
 static void
-cont_put(struct daos_lru_cache *cache, struct ds_cont *cont)
+cont_child_put(struct daos_lru_cache *cache, struct ds_cont_child *cont)
 {
 	daos_lru_ref_release(cache, &cont->sc_list);
 }
@@ -203,7 +205,7 @@ cont_hdl_rec_free(struct d_hash_table *htable, d_list_t *rlink)
 		D_DEBUG(DF_DSMS, DF_CONT": freeing\n",
 			DP_CONT(hdl->sch_pool->spc_uuid,
 			hdl->sch_cont->sc_uuid));
-		cont_put(tls->dt_cont_cache, hdl->sch_cont);
+		cont_child_put(tls->dt_cont_cache, hdl->sch_cont);
 	}
 	ds_pool_child_put(hdl->sch_pool);
 	D_FREE(hdl);
@@ -314,28 +316,143 @@ ds_cont_hdl_get(struct ds_cont_hdl *hdl)
 	cont_hdl_get_internal(hash, hdl);
 }
 
+/* ds cont cache */
+static struct daos_lru_cache   *ds_cont_cache;
+static ABT_mutex		cont_cache_lock;
+
+static inline struct ds_cont *
+cont_obj(struct daos_llink *llink)
+{
+	return container_of(llink, struct ds_cont, sc_list);
+}
+
+static int
+cont_alloc_ref(void *key, unsigned int ksize, void *varg,
+	       struct daos_llink **link)
+{
+	struct ds_cont	*cont;
+	uuid_t		*uuid = varg;
+
+	D_ALLOC_PTR(cont);
+	uuid_copy(cont->sc_uuid, *uuid);
+	*link = &cont->sc_list;
+	return 0;
+}
+
+static void
+cont_free_ref(struct daos_llink *llink)
+{
+	struct ds_cont *cont = cont_obj(llink);
+
+	D_FREE(cont);
+}
+
+static bool
+cont_cmp_keys(const void *key, unsigned int ksize, struct daos_llink *llink)
+{
+	struct ds_cont *cont = cont_obj(llink);
+
+	return uuid_compare(key, cont->sc_uuid) == 0;
+}
+
+static struct daos_llink_ops ds_cont_cache_ops = {
+	.lop_alloc_ref	= cont_alloc_ref,
+	.lop_free_ref	= cont_free_ref,
+	.lop_cmp_keys	= cont_cmp_keys
+};
+
+int
+ds_cont_lookup_create(const uuid_t uuid, void *arg, struct ds_cont **cont_p)
+{
+	struct daos_llink	*llink;
+	int			rc;
+
+	ABT_mutex_lock(cont_cache_lock);
+	rc = daos_lru_ref_hold(ds_cont_cache, (void *)uuid, sizeof(uuid_t),
+			       arg, &llink);
+	ABT_mutex_unlock(cont_cache_lock);
+	if (rc != 0) {
+		if (arg == NULL && rc == -DER_NONEXIST)
+			D_DEBUG(DF_DSMS, DF_UUID": pure lookup failed: %d\n",
+				DP_UUID(uuid), rc);
+		else
+			D_ERROR(DF_UUID": failed to lookup%s: %d\n",
+				DP_UUID(uuid), arg == NULL ? "" : "/create",
+				rc);
+		return rc;
+	}
+
+	*cont_p = cont_obj(llink);
+	return 0;
+}
+
+struct ds_cont *
+ds_cont_lookup(const uuid_t uuid)
+{
+	struct ds_cont *cont;
+	int		rc;
+
+	rc = ds_cont_lookup_create(uuid, NULL, &cont);
+	if (rc != 0)
+		cont = NULL;
+
+	return cont;
+}
+
+void
+ds_cont_put(struct ds_cont *cont)
+{
+	ABT_mutex_lock(cont_cache_lock);
+	daos_lru_ref_release(ds_cont_cache, &cont->sc_list);
+	ABT_mutex_unlock(cont_cache_lock);
+}
+
+int
+ds_cont_cache_init(void)
+{
+	int rc;
+
+	rc = ABT_mutex_create(&cont_cache_lock);
+	if (rc != ABT_SUCCESS)
+		return dss_abterr2der(rc);
+	rc = daos_lru_cache_create(-1 /* bits */, D_HASH_FT_NOLOCK /* feats */,
+				   &ds_cont_cache_ops, &ds_cont_cache);
+	if (rc != 0)
+		ABT_mutex_free(&cont_cache_lock);
+	return rc;
+}
+
+void
+ds_cont_cache_fini(void)
+{
+	ABT_mutex_lock(cont_cache_lock);
+	daos_lru_cache_destroy(ds_cont_cache);
+	ABT_mutex_unlock(cont_cache_lock);
+	ABT_mutex_free(&cont_cache_lock);
+}
+
 /*
  * Called via dss_collective() to destroy the ds_cont object as well as the vos
  * container.
  */
 static int
-cont_destroy_one(void *vin)
+cont_child_destroy_one(void *vin)
 {
 	struct cont_tgt_destroy_in     *in = vin;
 	struct dsm_tls		       *tls = dsm_tls_get();
 	struct ds_pool_child	       *pool;
-	struct ds_cont		       *cont;
+	struct ds_cont_child	       *cont;
 	int				rc;
 
 	pool = ds_pool_child_lookup(in->tdi_pool_uuid);
 	if (pool == NULL)
 		D_GOTO(out, rc = -DER_NO_HDL);
 
-	rc = cont_lookup(tls->dt_cont_cache, in->tdi_uuid, NULL /* arg */,
-			 &cont);
+	rc = cont_child_lookup(tls->dt_cont_cache, in->tdi_uuid, NULL,
+			       &cont);
 	if (rc == 0) {
 		/* Should evict if idle, but no such interface at the moment. */
-		cont_put(tls->dt_cont_cache, cont);
+		cont_child_put(tls->dt_cont_cache, cont);
 		D_GOTO(out_pool, rc = -DER_BUSY);
 	} else if (rc != -DER_NONEXIST) {
 		D_GOTO(out_pool, rc);
@@ -367,7 +484,7 @@ ds_cont_tgt_destroy_handler(crt_rpc_t *rpc)
 	D_DEBUG(DF_DSMS, DF_CONT": handling rpc %p\n",
 		DP_CONT(in->tdi_pool_uuid, in->tdi_uuid), rpc);
 
-	rc = dss_thread_collective(cont_destroy_one, in, 0);
+	rc = dss_thread_collective(cont_child_destroy_one, in, 0);
 	out->tdo_rc = (rc == 0 ? 0 : 1);
 	D_DEBUG(DF_DSMS, DF_CONT": replying rpc %p: %d (%d)\n",
 		DP_CONT(in->tdi_pool_uuid, in->tdi_uuid), rpc, out->tdo_rc,
@@ -389,7 +506,8 @@ ds_cont_tgt_destroy_aggregator(crt_rpc_t *source, crt_rpc_t *result, void *priv)
  * sert container lookup by pool/container uuid.
  **/
 int
-ds_cont_lookup(uuid_t pool_uuid, uuid_t cont_uuid, struct ds_cont **ds_cont)
+ds_cont_child_lookup(uuid_t pool_uuid, uuid_t cont_uuid,
+		     struct ds_cont_child **ds_cont)
 {
 	struct dsm_tls		*tls = dsm_tls_get();
 	struct ds_pool_child	*ds_pool;
@@ -399,8 +517,8 @@ ds_cont_lookup(uuid_t pool_uuid, uuid_t cont_uuid, struct ds_cont **ds_cont)
 	if (ds_pool == NULL)
 		return -DER_NO_HDL;
 
-	rc = cont_lookup(tls->dt_cont_cache, cont_uuid, ds_pool,
-			 ds_cont);
+	rc = cont_child_lookup(tls->dt_cont_cache, cont_uuid, ds_pool,
+			       ds_cont);
 	ds_pool_child_put(ds_pool);
 
 	return rc;
@@ -411,14 +529,14 @@ ds_cont_lookup(uuid_t pool_uuid, uuid_t cont_uuid, struct ds_cont **ds_cont)
  * it will return 1, otherwise return 0 or error code.
  **/
 int
-ds_cont_lookup_or_create(struct ds_cont_hdl *hdl, uuid_t cont_uuid)
+ds_cont_child_lookup_or_create(struct ds_cont_hdl *hdl, uuid_t cont_uuid)
 {
 	struct dsm_tls	*tls = dsm_tls_get();
 	int rc;
 
 	D_ASSERT(hdl->sch_cont == NULL);
-	rc = cont_lookup(tls->dt_cont_cache, cont_uuid, hdl->sch_pool,
-			 &hdl->sch_cont);
+	rc = cont_child_lookup(tls->dt_cont_cache, cont_uuid, hdl->sch_pool,
+			       &hdl->sch_cont);
 	if (rc != -DER_NONEXIST)
 		return rc;
 
@@ -429,8 +547,8 @@ ds_cont_lookup_or_create(struct ds_cont_hdl *hdl, uuid_t cont_uuid)
 	if (rc != 0)
 		return rc;
 
-	rc = cont_lookup(tls->dt_cont_cache, cont_uuid,
-			 hdl->sch_pool, &hdl->sch_cont);
+	rc = cont_child_lookup(tls->dt_cont_cache, cont_uuid,
+			       hdl->sch_pool, &hdl->sch_cont);
 	if (rc != 0) {
 		vos_cont_destroy(hdl->sch_pool->spc_hdl, cont_uuid);
 		return rc;
@@ -456,17 +574,17 @@ ds_cont_local_close(uuid_t cont_hdl_uuid)
 }
 
 void
-ds_cont_get(struct ds_cont *cont)
+ds_cont_child_get(struct ds_cont_child *cont)
 {
 	daos_lru_ref_add(&cont->sc_list);
 }
 
 void
-ds_cont_put(struct ds_cont *cont)
+ds_cont_child_put(struct ds_cont_child *cont)
 {
 	struct dsm_tls	*tls = dsm_tls_get();
 
-	cont_put(tls->dt_cont_cache, cont);
+	cont_child_put(tls->dt_cont_cache, cont);
 }
 
 struct ds_dtx_resync_args {
@@ -538,7 +656,7 @@ ds_cont_local_open(uuid_t pool_uuid, uuid_t cont_hdl_uuid, uuid_t cont_uuid,
 		D_GOTO(err_hdl, rc = -DER_NO_HDL);
 
 	if (cont_uuid != NULL) {
-		rc = ds_cont_lookup_or_create(hdl, cont_uuid);
+		rc = ds_cont_child_lookup_or_create(hdl, cont_uuid);
 		if (rc == 1) {
 			vos_co_created = 1;
 			rc = 0;
@@ -615,7 +733,7 @@ ds_cont_local_open(uuid_t pool_uuid, uuid_t cont_hdl_uuid, uuid_t cont_uuid,
 err_cont:
 	dtx_batched_commit_deregister(hdl);
 	if (hdl->sch_cont)
-		cont_put(tls->dt_cont_cache, hdl->sch_cont);
+		cont_child_put(tls->dt_cont_cache, hdl->sch_cont);
 
 	if (vos_co_created) {
 		D_DEBUG(DF_DSMS, DF_CONT": destroying new vos container\n",
@@ -648,6 +766,8 @@ ds_cont_tgt_open_handler(crt_rpc_t *rpc)
 {
 	struct cont_tgt_open_in	       *in = crt_req_get(rpc);
 	struct cont_tgt_open_out       *out = crt_reply_get(rpc);
+	struct ds_cont			*cont;
+	struct ds_pool			*pool = NULL;
 	int				rc;
 
 	D_DEBUG(DF_DSMS, DF_CONT": handling rpc %p: hdl="DF_UUID"\n",
@@ -657,9 +777,21 @@ ds_cont_tgt_open_handler(crt_rpc_t *rpc)
 	rc = dss_thread_collective(cont_open_one, in, 0);
 	D_ASSERTF(rc == 0, "%d\n", rc);
 
+	pool = ds_pool_lookup(in->toi_pool_uuid);
+	D_ASSERT(pool != NULL);
+	rc = ds_cont_lookup_create(in->toi_uuid, &in->toi_uuid, &cont);
+	if (rc)
+		D_GOTO(out, rc);
+
+	cont->sc_iv_ns = pool->sp_iv_ns;
+out:
 	out->too_rc = (rc == 0 ? 0 : 1);
 	D_DEBUG(DF_DSMS, DF_UUID": replying rpc %p: %d (%d)\n",
 		DP_UUID(in->toi_uuid), rpc, out->too_rc, rc);
+	if (pool)
+		ds_pool_put(pool);
+	if (cont)
+		ds_cont_put(cont);
 	crt_reply_send(rpc);
 }
 

--- a/src/dtx/dtx_resync.c
+++ b/src/dtx/dtx_resync.c
@@ -51,7 +51,7 @@ struct dtx_resync_head {
 };
 
 struct dtx_resync_args {
-	struct ds_cont		*cont;
+	struct ds_cont_child	*cont;
 	uuid_t			 po_uuid;
 	struct dtx_resync_head	 tables;
 	uint32_t		 version;
@@ -66,7 +66,7 @@ dtx_dre_release(struct dtx_resync_head *drh, struct dtx_resync_entry *dre)
 }
 
 static int
-dtx_resync_commit(uuid_t po_uuid, struct ds_cont *cont,
+dtx_resync_commit(uuid_t po_uuid, struct ds_cont_child *cont,
 		  struct dtx_resync_head *drh, int count, uint32_t version)
 {
 	struct dtx_resync_entry		*dre;
@@ -108,7 +108,7 @@ dtx_resync_commit(uuid_t po_uuid, struct ds_cont *cont,
 static int
 dtx_status_handle(struct dtx_resync_args *dra)
 {
-	struct ds_cont			*cont = dra->cont;
+	struct ds_cont_child		*cont = dra->cont;
 	struct pl_obj_layout		*layout = NULL;
 	struct dtx_resync_head		*drh = &dra->tables;
 	struct dtx_resync_entry		*dre;
@@ -270,12 +270,12 @@ dtx_resync(daos_handle_t po_hdl, uuid_t po_uuid, uuid_t co_uuid, uint32_t ver,
 	   bool block)
 {
 	ABT_future			 future;
-	struct ds_cont			*cont = NULL;
+	struct ds_cont_child		*cont = NULL;
 	struct dtx_resync_args		 dra = { 0 };
 	int				 rc = 0;
 	int				 rc1 = 0;
 
-	rc = ds_cont_lookup(po_uuid, co_uuid, &cont);
+	rc = ds_cont_child_lookup(po_uuid, co_uuid, &cont);
 	if (rc != 0) {
 		D_ERROR("Failed to open container for resync DTX "
 			DF_UUID"/"DF_UUID": rc = %d\n",
@@ -346,6 +346,6 @@ dtx_resync(daos_handle_t po_hdl, uuid_t po_uuid, uuid_t co_uuid, uint32_t ver,
 	}
 
 out:
-	ds_cont_put(cont);
+	ds_cont_child_put(cont);
 	return rc;
 }

--- a/src/dtx/dtx_srv.c
+++ b/src/dtx/dtx_srv.c
@@ -38,11 +38,11 @@ dtx_handler(crt_rpc_t *rpc)
 {
 	struct dtx_in		*din = crt_req_get(rpc);
 	struct dtx_out		*dout = crt_reply_get(rpc);
-	struct ds_cont		*cont = NULL;
+	struct ds_cont_child	*cont = NULL;
 	uint32_t		 opc = opc_get(rpc->cr_opc);
 	int			 rc;
 
-	rc = ds_cont_lookup(din->di_po_uuid, din->di_co_uuid, &cont);
+	rc = ds_cont_child_lookup(din->di_po_uuid, din->di_co_uuid, &cont);
 	if (rc != 0) {
 		D_ERROR("Failed to locate pool="DF_UUID" cont="DF_UUID
 			" for DTX rpc %u: rc = %d\n", DP_UUID(din->di_po_uuid),
@@ -86,7 +86,7 @@ out:
 		D_ERROR("send reply failed for DTX rpc %u: rc = %d\n", opc, rc);
 
 	if (cont != NULL)
-		ds_cont_put(cont);
+		ds_cont_child_put(cont);
 }
 
 static int

--- a/src/include/daos_srv/container.h
+++ b/src/include/daos_srv/container.h
@@ -52,7 +52,7 @@ void ds_cont_svc_step_down(struct cont_svc *svc);
  * Stores per-thread, per-container information, such as the vos container
  * handle.
  */
-struct ds_cont {
+struct ds_cont_child {
 	struct daos_llink	 sc_list;
 	daos_handle_t		 sc_hdl;
 	uuid_t			 sc_uuid;
@@ -76,8 +76,8 @@ struct ds_cont_hdl {
 	d_list_t		sch_entry;
 	uuid_t			sch_uuid;	/* of the container handle */
 	uint64_t		sch_capas;
-	struct ds_pool_child   *sch_pool;
-	struct ds_cont	       *sch_cont;
+	struct ds_pool_child	*sch_pool;
+	struct ds_cont_child	*sch_cont;
 	int			sch_ref;
 	uint32_t		sch_dtx_registered:1,
 				sch_deleted:1;
@@ -96,14 +96,19 @@ int
 ds_cont_local_close(uuid_t cont_hdl_uuid);
 
 int
-ds_cont_lookup_or_create(struct ds_cont_hdl *hdl, uuid_t cont_uuid);
+ds_cont_child_lookup_or_create(struct ds_cont_hdl *hdl, uuid_t cont_uuid);
 int
-ds_cont_lookup(uuid_t pool_uuid, uuid_t cont_uuid, struct ds_cont **ds_cont);
+ds_cont_child_lookup(uuid_t pool_uuid, uuid_t cont_uuid,
+		     struct ds_cont_child **ds_cont);
 
-void ds_cont_put(struct ds_cont *cont);
-void ds_cont_get(struct ds_cont *cont);
+void ds_cont_child_put(struct ds_cont_child *cont);
+void ds_cont_child_get(struct ds_cont_child *cont);
 
 int
 ds_cont_iter(daos_handle_t ph, uuid_t co_uuid, ds_iter_cb_t callback,
 	     void *arg, uint32_t type);
+
+int
+cont_iv_snapshots_fetch(void *ns, uuid_t cont_uuid, uint64_t **snapshots,
+			int *snap_count);
 #endif /* ___DAOS_SRV_CONTAINER_H_ */

--- a/src/include/daos_srv/dtx_srv.h
+++ b/src/include/daos_srv/dtx_srv.h
@@ -118,7 +118,7 @@ int dtx_begin(struct dtx_id *dti, daos_unit_oid_t *oid, daos_handle_t coh,
 	      struct dtx_handle **dth);
 
 int dtx_end(struct dtx_handle *dth, struct ds_cont_hdl *cont_hdl,
-	    struct ds_cont *cont, int result);
+	    struct ds_cont_child *cont, int result);
 
 int dtx_conflict(daos_handle_t coh, struct dtx_handle *dth, uuid_t po_uuid,
 		 uuid_t co_uuid, struct dtx_conflict_entry *dces, int count,

--- a/src/include/daos_srv/iv.h
+++ b/src/include/daos_srv/iv.h
@@ -46,6 +46,8 @@ struct ds_iv_ns {
 	d_list_t	iv_entry_list;
 	/* Cart IV namespace */
 	crt_iv_namespace_t	iv_ns;
+	/* pool uuid */
+	uuid_t		iv_pool_uuid;
 };
 
 struct ds_iv_class_ops;
@@ -187,37 +189,46 @@ typedef int (*ds_iv_ent_destroy_t)(d_sg_list_t *sgl);
 /**
  * Fetch data from the iv_class entry.
  *
- * \param src [IN]	data attached to the class entry.
- * \param dst [IN]	fetch buffer.
+ * \param entry [IN]	class entry.
+ * \param key [IN]	key to locate the entry.
+ * \param src [IN]	source buffer.
+ * \param dst [OUT]	destination buffer.
  * \param priv [OUT]	private buffer from IV callback.
  *
  * \return		0 if succeeds, error code otherwise.
  */
-typedef int (*ds_iv_ent_fetch_t)(struct ds_iv_entry *entry, d_sg_list_t *src,
-				 d_sg_list_t *dst, void **priv);
+typedef int (*ds_iv_ent_fetch_t)(struct ds_iv_entry *entry,
+				 struct ds_iv_key *key,
+				 d_sg_list_t *dst, d_sg_list_t *src,
+				 void **priv);
 
 /**
  * Update data to the iv_class entry.
  *
- * \param ent [IN]	data attached to the class entry.
+ * \param entry [IN]	class entry.
+ * \param key [IN]	key to locate entry.
  * \param src [IN]	source update buffer.
  * \param priv [IN]	private buffer from IV callback.
  *
  * \return		0 if succeeds, error code otherwise.
  */
-typedef int (*ds_iv_ent_update_t)(struct ds_iv_entry *entry, d_sg_list_t *dst,
+typedef int (*ds_iv_ent_update_t)(struct ds_iv_entry *entry,
+				  struct ds_iv_key *key,
 				  d_sg_list_t *src, void **priv);
 
 /**
  * Refresh the data to the iv_class entry.
  *
- * \param dst [IN]	data attached to the class entry.
+ * \param entry[IN]	class entry
+ * \param key [IN]	key to locate the entry.
  * \param src [IN]	source refresh buffer.
  * \param priv [IN]	private buffer from IV callback.
  *
  * \return		0 if succeeds, error code otherwise.
  */
-typedef int (*ds_iv_ent_refresh_t)(d_sg_list_t *dst, d_sg_list_t *src,
+typedef int (*ds_iv_ent_refresh_t)(struct ds_iv_entry *entry,
+				   struct ds_iv_key *key,
+				   d_sg_list_t *src,
 				   int ref_rc, void **priv);
 
 /**
@@ -256,6 +267,7 @@ enum iv_key {
 	IV_POOL_MAP = 1,
 	IV_REBUILD,
 	IV_OID,
+	IV_CONT_SNAP,
 };
 
 int ds_iv_fetch(struct ds_iv_ns *ns, struct ds_iv_key *key, d_sg_list_t *value);
@@ -266,12 +278,16 @@ int ds_iv_invalidate(struct ds_iv_ns *ns, struct ds_iv_key *key,
 		     unsigned int shortcut, unsigned int sync_mode,
 		     unsigned int sync_flags);
 
-int ds_iv_ns_create(crt_context_t ctx, crt_group_t *grp, unsigned int *ns_id,
-		    daos_iov_t *g_ivns, struct ds_iv_ns **p_iv_ns);
+int ds_iv_ns_create(crt_context_t ctx, uuid_t pool_uuid, crt_group_t *grp,
+		    unsigned int *ns_id, daos_iov_t *g_ivns,
+		    struct ds_iv_ns **p_iv_ns);
 
-int ds_iv_ns_attach(crt_context_t ctx, unsigned int ns_id,
+int ds_iv_ns_attach(crt_context_t ctx, uuid_t pool_uuid, unsigned int ns_id,
 		    unsigned int master_rank, daos_iov_t *iv_ctxt,
 		    struct ds_iv_ns **p_iv_ns);
+int ds_iv_ns_update(uuid_t pool_uuid, unsigned int master_rank,
+		    crt_group_t *grp, d_iov_t *iv_iov, unsigned int iv_ns_id,
+		    struct ds_iv_ns **iv_ns);
 
 void ds_iv_ns_destroy(void *ns);
 

--- a/src/iosrv/server_iv.c
+++ b/src/iosrv/server_iv.c
@@ -246,14 +246,15 @@ iv_entry_free(struct ds_iv_entry *entry)
 }
 
 static int
-fetch_iv_value(struct ds_iv_entry *entry, d_sg_list_t *dst,
-	       d_sg_list_t *src, void *priv)
+fetch_iv_value(struct ds_iv_entry *entry, struct ds_iv_key *key,
+	       d_sg_list_t *dst, d_sg_list_t *src, void *priv)
 {
 	struct ds_iv_class	*class = entry->iv_class;
 	int			rc;
 
 	if (class->iv_class_ops && class->iv_class_ops->ivc_ent_fetch)
-		rc = class->iv_class_ops->ivc_ent_fetch(entry, dst, src, priv);
+		rc = class->iv_class_ops->ivc_ent_fetch(entry, key, dst, src,
+							priv);
 	else
 		rc = daos_sgl_copy_data(dst, src);
 
@@ -261,31 +262,31 @@ fetch_iv_value(struct ds_iv_entry *entry, d_sg_list_t *dst,
 }
 
 static int
-update_iv_value(struct ds_iv_entry *entry, d_sg_list_t *dst,
+update_iv_value(struct ds_iv_entry *entry, struct ds_iv_key *key,
 		d_sg_list_t *src, void **priv)
 {
 	struct ds_iv_class	*class = entry->iv_class;
 	int			rc;
 
 	if (class->iv_class_ops && class->iv_class_ops->ivc_ent_update)
-		rc = class->iv_class_ops->ivc_ent_update(entry, dst, src, priv);
+		rc = class->iv_class_ops->ivc_ent_update(entry, key, src, priv);
 	else
-		rc = daos_sgl_copy_data(dst, src);
+		rc = daos_sgl_copy_data(&entry->iv_value, src);
 	return rc;
 }
 
 static int
-refresh_iv_value(struct ds_iv_entry *entry, d_sg_list_t *dst,
+refresh_iv_value(struct ds_iv_entry *entry, struct ds_iv_key *key,
 		 d_sg_list_t *src, int ref_rc, void *priv)
 {
 	struct ds_iv_class	*class = entry->iv_class;
 	int			rc;
 
 	if (class->iv_class_ops && class->iv_class_ops->ivc_ent_refresh)
-		rc = class->iv_class_ops->ivc_ent_refresh(dst, src, ref_rc,
-							  priv);
+		rc = class->iv_class_ops->ivc_ent_refresh(entry, key, src,
+							  ref_rc, priv);
 	else
-		rc = daos_sgl_copy_data(dst, src);
+		rc = daos_sgl_copy_data(&entry->iv_value, src);
 	return rc;
 }
 
@@ -388,10 +389,16 @@ ivc_on_fetch(crt_iv_namespace_t ivns, crt_iv_key_t *iv_key,
 	D_DEBUG(DB_TRACE, "FETCH: Key [%d:%d] entry %p valid %s\n", key.rank,
 		key.class_id, entry, entry->iv_valid ? "yes" : "no");
 
-	if (!entry->iv_valid)
+	/* Forward the request to its parent if it is not root, and
+	 * let's caller decide how to deal with leader.
+	 */
+	if (!entry->iv_valid && ns->iv_master_rank != dss_self_rank())
 		return -DER_IVCB_FORWARD;
 
-	rc = fetch_iv_value(entry, iv_value, &entry->iv_value, priv);
+	rc = fetch_iv_value(entry, &key, iv_value, &entry->iv_value, priv);
+	if (rc == 0)
+		entry->iv_valid = true;
+
 	return rc;
 }
 
@@ -421,11 +428,10 @@ iv_on_update_internal(crt_iv_namespace_t ivns, crt_iv_key_t *iv_key,
 
 	if (iv_value && iv_value->sg_iovs != NULL) {
 		if (refresh)
-			rc = refresh_iv_value(entry, &entry->iv_value, iv_value,
-				      ref_rc,
+			rc = refresh_iv_value(entry, &key, iv_value, ref_rc,
 				      priv_entry ? priv_entry->priv : NULL);
 		else
-			rc = update_iv_value(entry, &entry->iv_value, iv_value,
+			rc = update_iv_value(entry, &key, iv_value,
 				      priv_entry ? priv_entry->priv : NULL);
 		if (rc != -DER_IVCB_FORWARD && rc != 0) {
 			D_ERROR("key id %d update failed: rc = %d\n",
@@ -626,8 +632,8 @@ ds_iv_ns_lookup(unsigned int ns_id, d_rank_t master_rank)
 }
 
 static int
-iv_ns_create_internal(unsigned int ns_id, d_rank_t master_rank,
-		      struct ds_iv_ns **pns)
+iv_ns_create_internal(unsigned int ns_id, uuid_t pool_uuid,
+		      d_rank_t master_rank, struct ds_iv_ns **pns)
 {
 	struct ds_iv_ns	*ns;
 
@@ -639,6 +645,7 @@ iv_ns_create_internal(unsigned int ns_id, d_rank_t master_rank,
 	if (ns == NULL)
 		return -DER_NOMEM;
 
+	uuid_copy(ns->iv_pool_uuid, pool_uuid);
 	D_INIT_LIST_HEAD(&ns->iv_entry_list);
 	ns->iv_ns_id = ns_id;
 	ns->iv_master_rank = master_rank;
@@ -667,26 +674,33 @@ ds_iv_ns_destroy(void *ns)
  * be called on master node
  */
 int
-ds_iv_ns_create(crt_context_t ctx, crt_group_t *grp,
-		unsigned int *ns_id, daos_iov_t *g_ivns,
+ds_iv_ns_create(crt_context_t ctx, uuid_t pool_uuid,
+		crt_group_t *grp, unsigned int *ns_id, d_iov_t *ivns,
 		struct ds_iv_ns **p_iv_ns)
 {
+	d_iov_t			*g_ivns;
+	d_iov_t			tmp = { 0 };
 	struct ds_iv_ns		*ns = NULL;
 	int			tree_topo;
 	int			rc;
 
 	/* Create namespace on master */
-	rc = iv_ns_create_internal(ds_iv_ns_id++, dss_self_rank(), &ns);
+	rc = iv_ns_create_internal(ds_iv_ns_id++, pool_uuid, dss_self_rank(),
+				   &ns);
 	if (rc)
 		return rc;
+
+	if (ivns == NULL)
+		g_ivns = &tmp;
+	else
+		g_ivns = ivns;
 
 	/* Let's set the topo to 32 to avoid cart IV failover,
 	 * which is not supported yet. XXX
 	 */
 	tree_topo = crt_tree_topo(CRT_TREE_KNOMIAL, 32);
 	rc = crt_iv_namespace_create(ctx, grp, tree_topo, crt_iv_class,
-				     crt_iv_class_nr, &ns->iv_ns,
-				     (d_iov_t *)g_ivns);
+				     crt_iv_class_nr, &ns->iv_ns, g_ivns);
 	if (rc)
 		D_GOTO(free, rc);
 
@@ -700,7 +714,7 @@ free:
 }
 
 int
-ds_iv_ns_attach(crt_context_t ctx, unsigned int ns_id,
+ds_iv_ns_attach(crt_context_t ctx, uuid_t pool_uuid, unsigned int ns_id,
 		unsigned int master_rank, daos_iov_t *iv_ctxt,
 		struct ds_iv_ns **p_iv_ns)
 {
@@ -721,7 +735,7 @@ ds_iv_ns_attach(crt_context_t ctx, unsigned int ns_id,
 		return 0;
 	}
 
-	rc = iv_ns_create_internal(ns_id, master_rank, &ns);
+	rc = iv_ns_create_internal(ns_id, pool_uuid, master_rank, &ns);
 	if (rc)
 		return rc;
 
@@ -738,6 +752,49 @@ free:
 	if (rc)
 		ds_iv_ns_destroy(ns);
 
+	return rc;
+}
+
+/* Update iv namespace */
+int
+ds_iv_ns_update(uuid_t pool_uuid, unsigned int master_rank,
+		crt_group_t *grp, d_iov_t *iv_iov,
+		unsigned int iv_ns_id, struct ds_iv_ns **iv_ns)
+{
+	struct ds_iv_ns	*ns;
+	int		rc;
+
+	D_ASSERT(iv_ns != NULL);
+	if (*iv_ns != NULL &&
+	    (*iv_ns)->iv_master_rank != master_rank) {
+		/* If root has been changed, let's destroy the
+		 * previous IV ns
+		 */
+		ds_iv_ns_destroy(*iv_ns);
+		*iv_ns = NULL;
+	}
+
+	if (*iv_ns != NULL)
+		return 0;
+
+	/* Create new iv_ns */
+	if (iv_iov == NULL) {
+		/* master node */
+		rc = ds_iv_ns_create(dss_get_module_info()->dmi_ctx,
+				     pool_uuid, grp, &iv_ns_id, NULL, &ns);
+	} else {
+		/* other node */
+		rc = ds_iv_ns_attach(dss_get_module_info()->dmi_ctx,
+				     pool_uuid, iv_ns_id, master_rank, iv_iov,
+				     &ns);
+	}
+
+	if (rc) {
+		D_ERROR("pool iv ns create failed %d\n", rc);
+		return rc;
+	}
+
+	*iv_ns = ns;
 	return rc;
 }
 
@@ -813,11 +870,14 @@ ds_iv_done(crt_iv_namespace_t ivns, uint32_t class_id,
 
 	if (cb_info->opc == IV_FETCH && cb_info->value) {
 		struct ds_iv_entry	*entry;
+		struct ds_iv_key	key;
 
 		D_ASSERT(cb_info->ns != NULL);
 		entry = iv_class_entry_lookup(cb_info->ns, cb_info->key);
 		D_ASSERT(entry != NULL);
-		ret = fetch_iv_value(entry, cb_info->value, iv_value, NULL);
+		iv_key_unpack(&key, iv_key);
+		ret = fetch_iv_value(entry, &key, cb_info->value, iv_value,
+				     NULL);
 	}
 
 	ABT_future_set(cb_info->future, &rc);

--- a/src/object/srv_obj.c
+++ b/src/object/srv_obj.c
@@ -460,7 +460,7 @@ ds_obj_update_nrs_in_reply(crt_rpc_t *rpc, daos_handle_t ioh,
  */
 static int
 ds_check_container(uuid_t cont_hdl_uuid, uuid_t cont_uuid,
-		   struct ds_cont_hdl **hdlp, struct ds_cont **contp)
+		   struct ds_cont_hdl **hdlp, struct ds_cont_child **contp)
 {
 	struct ds_cont_hdl	*cont_hdl;
 	int			 rc;
@@ -495,7 +495,8 @@ ds_check_container(uuid_t cont_hdl_uuid, uuid_t cont_uuid,
 		DP_UUID(cont_hdl_uuid), cont_hdl);
 
 	/* load or create VOS container on demand */
-	rc = ds_cont_lookup(cont_hdl->sch_pool->spc_uuid, cont_uuid, contp);
+	rc = ds_cont_child_lookup(cont_hdl->sch_pool->spc_uuid, cont_uuid,
+				  contp);
 	if (rc)
 		D_GOTO(failed, rc);
 out:
@@ -675,8 +676,8 @@ obj_update_prefw(crt_rpc_t *req, void *arg)
 
 static int
 ds_obj_rw_local_hdlr(crt_rpc_t *rpc, uint32_t tag, struct ds_cont_hdl *cont_hdl,
-		     struct ds_cont *cont, daos_handle_t *ioh, bool update,
-		     uint32_t map_version, struct dtx_handle *dth)
+		     struct ds_cont_child *cont, daos_handle_t *ioh,
+		     bool update, uint32_t map_version, struct dtx_handle *dth)
 {
 	struct obj_rw_in	*orw = crt_req_get(rpc);
 	struct obj_rw_out	*orwo = crt_reply_get(rpc);
@@ -715,9 +716,10 @@ ds_obj_rw_local_hdlr(crt_rpc_t *rpc, uint32_t tag, struct ds_cont_hdl *cont_hdl,
 		bool size_fetch = (!rma && orw->orw_sgls.ca_arrays == NULL);
 
 		bulk_op = CRT_BULK_PUT;
-		rc = vos_fetch_begin(cont->sc_hdl, orw->orw_oid, orw->orw_epoch,
-				     &orw->orw_dkey, orw->orw_nr,
-				     orw->orw_iods.ca_arrays, size_fetch, ioh);
+		rc = vos_fetch_begin(cont->sc_hdl, orw->orw_oid,
+				     orw->orw_epoch, &orw->orw_dkey,
+				     orw->orw_nr, orw->orw_iods.ca_arrays,
+				     size_fetch, ioh);
 		if (rc) {
 			D_ERROR(DF_UOID" Fetch begin failed: %d\n",
 				DP_UOID(orw->orw_oid), rc);
@@ -797,7 +799,7 @@ ds_obj_rw_handler(crt_rpc_t *rpc)
 	struct obj_rw_in		*orw = crt_req_get(rpc);
 	struct obj_rw_out		*orwo = crt_reply_get(rpc);
 	struct ds_cont_hdl		*cont_hdl = NULL;
-	struct ds_cont			*cont = NULL;
+	struct ds_cont_child		*cont = NULL;
 	struct dtx_handle		*dth = NULL;
 	struct dtx_id			*dti_cos = NULL;
 	struct dtx_conflict_entry	 conflict = { 0 };
@@ -1059,7 +1061,7 @@ out:
 
 	if (cont_hdl) {
 		if (!cont_hdl->sch_cont)
-			ds_cont_put(cont); /* -1 for rebuild container */
+			ds_cont_child_put(cont); /* -1 for rebuild container */
 		ds_cont_hdl_put(cont_hdl);
 	}
 }
@@ -1103,7 +1105,7 @@ ds_iter_vos(crt_rpc_t *rpc, struct vos_iter_anchors *anchors,
 	struct obj_key_enum_in	*oei = crt_req_get(rpc);
 	int			opc = opc_get(rpc->cr_opc);
 	struct ds_cont_hdl	*cont_hdl;
-	struct ds_cont		*cont;
+	struct ds_cont_child	*cont;
 	int			type;
 	int			rc;
 	bool			recursive = false;
@@ -1186,7 +1188,7 @@ ds_iter_vos(crt_rpc_t *rpc, struct vos_iter_anchors *anchors,
 out_cont_hdl:
 
 	if (!cont_hdl->sch_cont)
-		ds_cont_put(cont); /* -1 for rebuild container */
+		ds_cont_child_put(cont); /* -1 for rebuild container */
 	ds_cont_hdl_put(cont_hdl);
 out:
 	return rc;
@@ -1420,7 +1422,8 @@ obj_punch_complete(crt_rpc_t *rpc, int status, uint32_t map_version,
 
 static int
 ds_obj_punch_local_hdlr(struct obj_punch_in *opi, crt_opcode_t opc,
-			struct ds_cont_hdl *cont_hdl, struct ds_cont *cont,
+			struct ds_cont_hdl *cont_hdl,
+			struct ds_cont_child *cont,
 			struct dtx_handle *dth)
 {
 	int	rc = 0;
@@ -1461,7 +1464,7 @@ ds_obj_punch_handler(crt_rpc_t *rpc)
 {
 	struct obj_req_disp_arg		*obj_arg = NULL;
 	struct ds_cont_hdl		*cont_hdl = NULL;
-	struct ds_cont			*cont = NULL;
+	struct ds_cont_child		*cont = NULL;
 	struct dtx_handle		*dth = NULL;
 	struct dtx_id			*dti_cos = NULL;
 	struct dtx_conflict_entry	 conflict = { 0 };
@@ -1661,7 +1664,7 @@ out:
 	obj_punch_complete(rpc, rc, map_version, &conflict);
 	if (cont_hdl) {
 		if (!cont_hdl->sch_cont)
-			ds_cont_put(cont); /* -1 for rebuild container */
+			ds_cont_child_put(cont); /* -1 for rebuild container */
 		ds_cont_hdl_put(cont_hdl);
 	}
 }
@@ -1672,7 +1675,7 @@ ds_obj_query_key_handler(crt_rpc_t *rpc)
 	struct obj_query_key_in		*okqi;
 	struct obj_query_key_out	*okqo;
 	struct ds_cont_hdl		*cont_hdl = NULL;
-	struct ds_cont			*cont = NULL;
+	struct ds_cont_child		*cont = NULL;
 	daos_key_t			*dkey;
 	daos_key_t			*akey;
 	uint32_t			map_version = 0;
@@ -1708,7 +1711,7 @@ ds_obj_query_key_handler(crt_rpc_t *rpc)
 out:
 	if (cont_hdl) {
 		if (!cont_hdl->sch_cont)
-			ds_cont_put(cont); /* -1 for rebuild container */
+			ds_cont_child_put(cont); /* -1 for rebuild container */
 		ds_cont_hdl_put(cont_hdl);
 	}
 

--- a/src/pool/srv_iv.c
+++ b/src/pool/srv_iv.c
@@ -138,14 +138,14 @@ pool_iv_ent_copy(d_sg_list_t *dst, d_sg_list_t *src)
 }
 
 static int
-pool_iv_ent_fetch(struct ds_iv_entry *entry, d_sg_list_t *dst, d_sg_list_t *src,
-		  void **priv)
+pool_iv_ent_fetch(struct ds_iv_entry *entry, struct ds_iv_key *key,
+		  d_sg_list_t *dst, d_sg_list_t *src, void **priv)
 {
 	return pool_iv_ent_copy(dst, src);
 }
 
 static int
-pool_iv_ent_update(struct ds_iv_entry *entry, d_sg_list_t *dst,
+pool_iv_ent_update(struct ds_iv_entry *entry, struct ds_iv_key *key,
 		   d_sg_list_t *src, void **priv)
 {
 	struct pool_iv_entry	*src_iv = src->sg_iovs[0].iov_buf;
@@ -177,20 +177,21 @@ pool_iv_ent_update(struct ds_iv_entry *entry, d_sg_list_t *dst,
 				    src_iv->piv_pool_map_ver);
 	ds_pool_put(pool);
 
-	return pool_iv_ent_copy(dst, src);
+	return pool_iv_ent_copy(&entry->iv_value, src);
 }
 
 static int
-pool_iv_ent_refresh(d_sg_list_t *dst, d_sg_list_t *src, int ref_rc, void **priv)
+pool_iv_ent_refresh(struct ds_iv_entry *entry, struct ds_iv_key *key,
+		    d_sg_list_t *src, int ref_rc, void **priv)
 {
-	struct pool_iv_entry	*dst_iv = dst->sg_iovs[0].iov_buf;
+	struct pool_iv_entry	*dst_iv = entry->iv_value.sg_iovs[0].iov_buf;
 	struct pool_iv_entry	*src_iv = src->sg_iovs[0].iov_buf;
 	struct ds_pool		*pool;
 	int			rc;
 
 	D_ASSERT(src_iv != NULL);
 	D_ASSERT(dst_iv != NULL);
-	rc = pool_iv_ent_copy(dst, src);
+	rc = pool_iv_ent_copy(&entry->iv_value, src);
 	if (rc)
 		return rc;
 

--- a/src/pool/srv_target.c
+++ b/src/pool/srv_target.c
@@ -704,14 +704,11 @@ ds_pool_tgt_connect_handler(crt_rpc_t *rpc)
 		D_GOTO(out, rc);
 	}
 
-	if (pool->sp_iv_ns == NULL) {
-		rc = ds_pool_iv_ns_update(pool, in->tci_master_rank,
-					  &in->tci_iv_ctxt,
-					  in->tci_iv_ns_id);
-		if (rc) {
-			D_ERROR("attach iv ns failed rc %d\n", rc);
-			D_GOTO(out, rc);
-		}
+	rc = ds_pool_iv_ns_update(pool, in->tci_master_rank, &in->tci_iv_ctxt,
+				  in->tci_iv_ns_id);
+	if (rc) {
+		D_ERROR("attach iv ns failed rc %d\n", rc);
+		D_GOTO(out, rc);
 	}
 
 	rc = pool_tgt_query(pool, &out->tco_space);

--- a/src/rebuild/rebuild_iv.c
+++ b/src/rebuild/rebuild_iv.c
@@ -97,8 +97,8 @@ rebuild_iv_ent_destroy(d_sg_list_t *sgl)
 }
 
 static int
-rebuild_iv_ent_fetch(struct ds_iv_entry *entry, d_sg_list_t *dst,
-		     d_sg_list_t *src, void **priv)
+rebuild_iv_ent_fetch(struct ds_iv_entry *entry, struct ds_iv_key *key,
+		     d_sg_list_t *dst, d_sg_list_t *src, void **priv)
 {
 	D_ASSERT(0);
 	return 0;
@@ -106,11 +106,11 @@ rebuild_iv_ent_fetch(struct ds_iv_entry *entry, d_sg_list_t *dst,
 
 /* Update the rebuild status from leaves to the master */
 static int
-rebuild_iv_ent_update(struct ds_iv_entry *entry, d_sg_list_t *dst,
+rebuild_iv_ent_update(struct ds_iv_entry *entry, struct ds_iv_key *key,
 		      d_sg_list_t *src, void **priv)
 {
 	struct rebuild_iv *src_iv = src->sg_iovs[0].iov_buf;
-	struct rebuild_iv *dst_iv = dst->sg_iovs[0].iov_buf;
+	struct rebuild_iv *dst_iv = entry->iv_value.sg_iovs[0].iov_buf;
 	struct rebuild_global_pool_tracker *rgt;
 	d_rank_t	  rank;
 	int		  rc;
@@ -162,10 +162,10 @@ rebuild_iv_ent_update(struct ds_iv_entry *entry, d_sg_list_t *dst,
 
 /* Distribute the rebuild uuid/master rank from master to leaves */
 static int
-rebuild_iv_ent_refresh(d_sg_list_t *dst, d_sg_list_t *src, int ref_rc,
-		       void **priv)
+rebuild_iv_ent_refresh(struct ds_iv_entry *entry, struct ds_iv_key *key,
+		       d_sg_list_t *src, int ref_rc, void **priv)
 {
-	struct rebuild_iv *dst_iv = dst->sg_iovs[0].iov_buf;
+	struct rebuild_iv *dst_iv = entry->iv_value.sg_iovs[0].iov_buf;
 	struct rebuild_iv *src_iv = src->sg_iovs[0].iov_buf;
 
 	uuid_copy(dst_iv->riv_pool_uuid, src_iv->riv_pool_uuid);


### PR DESCRIPTION
Add iv to container leader, so the snapshot list
can be shared over all servers, and rebuild might need it.

NB: container will share the same iv namespace with
the pool, i.e. all container under the pool will share
the same iv namespace.

Rename origin ds_cont with ds_cont_child to identify
it as a per xstream structure, align with ds_pool_child.

Add ds_cont per node to load iv namespace.

Some cleanup and fixes.

Rebuild the pool by snapshot epoch.

Signed-off-by: Wang Di <di.wang@intel.com>