### PR TITLE
DAOS-2222 Common: Update .gitignore to cover certificates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,4 @@ Gopkg.lock
 /src/control/vendor/**/*.os
 *.xml
 utils/certs/daosCA/**
+vos_size.yaml

--- a/.gitignore
+++ b/.gitignore
@@ -9,9 +9,10 @@ daos_m.conf
 config.log
 /install/
 utils/daos_build.pyc
-hwloc-1.11.5.tar.gz
-mpi4py-2.0.0.tar.gz
-protobuf-all-3.5.1.tar.gz
+hwloc-*.tar.gz
+mpi4py-*.tar.gz
+protobuf-all-*.tar.gz
+protobuf-c-*.tar.gz
 *.pyc
 src/tests/ftest/*/*.yaml.dist
 *.un~
@@ -24,3 +25,4 @@ Gopkg.lock
 *.o
 /src/control/vendor/**/*.os
 *.xml
+utils/certs/daosCA/**

--- a/.gitignore
+++ b/.gitignore
@@ -9,10 +9,8 @@ daos_m.conf
 config.log
 /install/
 utils/daos_build.pyc
-hwloc-*.tar.gz
-mpi4py-*.tar.gz
-protobuf-all-*.tar.gz
-protobuf-c-*.tar.gz
+*.tar.gz
+*.tgz
 *.pyc
 src/tests/ftest/*/*.yaml.dist
 *.un~


### PR DESCRIPTION
The generated certificate directory was not covered by .gitignore. Also the two zip
files downloaded for protobuf support compilation were missing from .gitignore. In order
to make updating to future versionf of zips downloaded with the web downloaded easier
all zip files in .gitignore have been updated to make their version be a wildcard.

Signed-off-by: David Quigley <david.quigley@intel.com>