### PR TITLE
DAOS-654 pool: Modify pool connect to use security credential

### DIFF
--- a/src/client/api/SConscript
+++ b/src/client/api/SConscript
@@ -11,9 +11,9 @@ def scons():
     dc_tgts = denv.SharedObject(Glob('*.c'))
 
     Import('dc_pool_tgts', 'dc_co_tgts', 'dc_obj_tgts', 'dc_placement_tgts')
-    Import('dc_mgmt_tgts', 'addons_tgts')
+    Import('dc_mgmt_tgts', 'addons_tgts', 'dc_security_tgts')
     dc_tgts += dc_pool_tgts + dc_co_tgts + dc_placement_tgts + dc_obj_tgts
-    dc_tgts += dc_mgmt_tgts + addons_tgts
+    dc_tgts += dc_mgmt_tgts + addons_tgts + dc_security_tgts
     libdaos = daos_build.library(env, 'libdaos', dc_tgts,
                                  SHLIBVERSION=DAOS_VERSION,
                                  LIBS=['daos_common'])

--- a/src/control/security/domain_info.go
+++ b/src/control/security/domain_info.go
@@ -27,6 +27,7 @@ import (
 	"net"
 	"syscall"
 
+	"github.com/daos-stack/daos/src/control/log"
 	"golang.org/x/sys/unix"
 )
 
@@ -49,14 +50,21 @@ func DomainInfoFromUnixConn(sock *net.UnixConn) (*DomainInfo, error) {
 	}
 	defer f.Close()
 
+	log.Debugf("Client Socket Credentials:\n")
 	fd := int(f.Fd())
 	creds, err := syscall.GetsockoptUcred(fd, syscall.SOL_SOCKET, syscall.SO_PEERCRED)
 	if err != nil {
 		return nil, err
 	}
+	log.Debugf("Pid: %d\n", creds.Pid)
+	log.Debugf("Uid: %d\n", creds.Uid)
+	log.Debugf("Gid: %d", creds.Gid)
+
 	ctx, err := unix.GetsockoptString(fd, syscall.SOL_SOCKET, syscall.SO_PEERSEC)
 	if err != nil {
-		return nil, err
+		log.Debugf("Unable to obtain peer context: %s\n", err)
+		ctx = ""
 	}
+	log.Debugf("Context: %s", ctx)
 	return InitDomainInfo(creds, ctx), nil
 }

--- a/src/include/daos_srv/security.h
+++ b/src/include/daos_srv/security.h
@@ -48,6 +48,6 @@
  *		-DER_MISC	Invalid response from daos_server
  *		-DER_NO_PERM	Credential does not have access
  */
-int ds_check_pool_access(const struct pool_prop_ugm *ugm, d_iov_t *cred,
+int ds_sec_check_pool_access(const struct pool_prop_ugm *ugm, d_iov_t *cred,
 				uint64_t access);
 #endif /* __DAOS_SRV_SECURITY_H__ */

--- a/src/include/daos_srv/security.h
+++ b/src/include/daos_srv/security.h
@@ -41,12 +41,13 @@
  *
  * \return	0		Success. The access is allowed.
  *		-DER_INVAL	Invalid parameter
- *		-DER_BADPATH	Can't connect to the agent socket at
+ *		-DER_BADPATH	Can't connect to the daos_server socket at
  *				the expected path
  *		-DER_NOMEM	Out of memory
- *		-DER_NOREPLY	No response from agent
- *		-DER_MISC	Invalid response from agent
+ *		-DER_NOREPLY	No response from daos_server
+ *		-DER_MISC	Invalid response from daos_server
+ *		-DER_NO_PERM	Credential does not have access
  */
-int ds_sec_can_pool_connect(const struct pool_prop_ugm *ugm, d_iov_t *cred,
+int ds_check_pool_access(const struct pool_prop_ugm *ugm, d_iov_t *cred,
 				uint64_t access);
 #endif /* __DAOS_SRV_SECURITY_H__ */

--- a/src/pool/rpc.h
+++ b/src/pool/rpc.h
@@ -160,8 +160,7 @@ CRT_RPC_DECLARE(pool_create, DAOS_ISEQ_POOL_CREATE, DAOS_OSEQ_POOL_CREATE)
 
 #define DAOS_ISEQ_POOL_CONNECT	/* input fields */		 \
 	((struct pool_op_in)	(pci_op)		CRT_VAR) \
-	((uint32_t)		(pci_uid)		CRT_VAR) \
-	((uint32_t)		(pci_gid)		CRT_VAR) \
+	((daos_iov_t)		(pci_cred)		CRT_VAR) \
 	((uint64_t)		(pci_capas)		CRT_VAR) \
 	((crt_bulk_t)		(pci_map_bulk)		CRT_VAR)
 

--- a/src/pool/srv_pool.c
+++ b/src/pool/srv_pool.c
@@ -1788,7 +1788,7 @@ ds_pool_connect_handler(crt_rpc_t *rpc)
 	if (rc != 0)
 		D_GOTO(out_map_version, rc);
 
-	rc = ds_check_pool_access(&ugm, &in->pci_cred, in->pci_capas);
+	rc = ds_sec_check_pool_access(&ugm, &in->pci_cred, in->pci_capas);
 	if (rc != 0) {
 		D_ERROR(DF_UUID": refusing connect attempt for "
 			DF_X64" error: %d\n", DP_UUID(in->pci_op.pi_uuid),

--- a/src/pool/srv_pool.c
+++ b/src/pool/srv_pool.c
@@ -44,6 +44,7 @@
 #include <daos_srv/daos_server.h>
 #include <daos_srv/rdb.h>
 #include <daos_srv/rebuild.h>
+#include <daos_srv/security.h>
 #include <cart/iv.h>
 #include "rpc.h"
 #include "srv_internal.h"
@@ -1544,31 +1545,6 @@ out:
 }
 
 static int
-permitted(const struct pool_prop_ugm *ugm, uint32_t uid, uint32_t gid,
-	  uint64_t capas)
-{
-	int		shift;
-	uint32_t	capas_permitted;
-
-	/*
-	 * Determine which set of capability bits applies. See also the
-	 * comment/diagram for ds_pool_prop_mode in src/pool/srv_layout.h.
-	 */
-	if (uid == ugm->pp_uid)
-		shift = DAOS_PC_NBITS * 2;	/* user */
-	else if (gid == ugm->pp_gid)
-		shift = DAOS_PC_NBITS;		/* group */
-	else
-		shift = 0;			/* other */
-
-	/* Extract the applicable set of capability bits. */
-	capas_permitted = (ugm->pp_mode >> shift) & DAOS_PC_MASK;
-
-	/* Only if all requested capability bits are permitted... */
-	return (capas & capas_permitted) == capas;
-}
-
-static int
 pool_connect_bcast(crt_context_t ctx, struct pool_svc *svc,
 		   const uuid_t pool_hdl, uint64_t capas,
 		   daos_iov_t *global_ns, struct daos_pool_space *ps,
@@ -1812,10 +1788,11 @@ ds_pool_connect_handler(crt_rpc_t *rpc)
 	if (rc != 0)
 		D_GOTO(out_map_version, rc);
 
-	if (!permitted(&ugm, in->pci_uid, in->pci_gid, in->pci_capas)) {
-		D_ERROR(DF_UUID": refusing connect attempt for uid %u gid %u "
-			DF_X64"\n", DP_UUID(in->pci_op.pi_uuid), in->pci_uid,
-			in->pci_gid, in->pci_capas);
+	rc = ds_check_pool_access(&ugm, &in->pci_cred, in->pci_capas);
+	if (rc != 0) {
+		D_ERROR(DF_UUID": refusing connect attempt for "
+			DF_X64" error: %d\n", DP_UUID(in->pci_op.pi_uuid),
+			in->pci_capas, rc);
 		D_GOTO(out_map_version, rc = -DER_NO_PERM);
 	}
 

--- a/src/security/cli_security.c
+++ b/src/security/cli_security.c
@@ -144,6 +144,7 @@ process_credential_response(Drpc__Response *response,
 
 	if (response->status != DRPC__STATUS__SUCCESS) {
 		/* Recipient could not parse our message */
+		D_ERROR("Response status is: %d\n", response->status);
 		return -DER_MISC;
 	}
 
@@ -177,11 +178,14 @@ sanity_check_credential_response(Drpc__Response *response)
 			response->body.len, response->body.data);
 	if (pb_cred == NULL) {
 		/* Malformed body */
+		D_ERROR("Unable to unmarshal credential: body.len: %zu\n",
+			response->body.len);
 		return -DER_MISC;
 	}
 
 	/* Not super useful if we didn't get a token */
 	if (pb_cred->token == NULL) {
+		D_ERROR("Credential has no token\n");
 		rc = -DER_MISC;
 	}
 

--- a/src/security/cli_security.c
+++ b/src/security/cli_security.c
@@ -144,7 +144,8 @@ process_credential_response(Drpc__Response *response,
 
 	if (response->status != DRPC__STATUS__SUCCESS) {
 		/* Recipient could not parse our message */
-		D_ERROR("Agent credential drpc request failed: %d\n", response->status);
+		D_ERROR("Agent credential drpc request failed: %d\n",
+			response->status);
 		return -DER_MISC;
 	}
 

--- a/src/security/cli_security.c
+++ b/src/security/cli_security.c
@@ -144,7 +144,7 @@ process_credential_response(Drpc__Response *response,
 
 	if (response->status != DRPC__STATUS__SUCCESS) {
 		/* Recipient could not parse our message */
-		D_ERROR("Response status is: %d\n", response->status);
+		D_ERROR("Agent credential drpc request failed: %d\n", response->status);
 		return -DER_MISC;
 	}
 

--- a/src/security/srv_acl.c
+++ b/src/security/srv_acl.c
@@ -173,7 +173,7 @@ ds_sec_validate_credentials(daos_iov_t *creds, AuthToken **token)
 }
 
 int
-ds_sec_can_pool_connect(const struct pool_prop_ugm *attr, d_iov_t *cred,
+ds_check_pool_access(const struct pool_prop_ugm *ugm, d_iov_t *cred,
 				uint64_t access)
 {
 	int		rc;
@@ -182,7 +182,7 @@ ds_sec_can_pool_connect(const struct pool_prop_ugm *attr, d_iov_t *cred,
 	AuthToken	*sec_token = NULL;
 	AuthSys		*sys_creds = NULL;
 
-	if (attr == NULL || cred == NULL) {
+	if (ugm == NULL || cred == NULL) {
 		return -DER_INVAL;
 	}
 
@@ -198,16 +198,20 @@ ds_sec_can_pool_connect(const struct pool_prop_ugm *attr, d_iov_t *cred,
 	 * Determine which set of capability bits applies. See also the
 	 * comment/diagram for ds_pool_attr_mode in src/pool/srv_layout.h.
 	 */
-	if (sys_creds->uid == attr->pp_uid)
+	if (sys_creds->uid == ugm->pp_uid)
 		shift = DAOS_PC_NBITS * 2;	/* user */
-	else if (sys_creds->gid == attr->pp_gid)
+	else if (sys_creds->gid == ugm->pp_gid)
 		shift = DAOS_PC_NBITS;		/* group */
 	else
 		shift = 0;			/* other */
 
 	/* Extract the applicable set of capability bits. */
-	access_permitted = (attr->pp_mode >> shift) & DAOS_PC_MASK;
+	access_permitted = (ugm->pp_mode >> shift) & DAOS_PC_MASK;
 
 	/* Only if all requested capability bits are permitted... */
-	return (access & access_permitted) == access;
+	if ((access & access_permitted) == access) {
+		return 0;
+	}
+
+	return -DER_NO_PERM;
 }

--- a/src/security/srv_acl.c
+++ b/src/security/srv_acl.c
@@ -173,7 +173,7 @@ ds_sec_validate_credentials(daos_iov_t *creds, AuthToken **token)
 }
 
 int
-ds_check_pool_access(const struct pool_prop_ugm *ugm, d_iov_t *cred,
+ds_sec_check_pool_access(const struct pool_prop_ugm *ugm, d_iov_t *cred,
 				uint64_t access)
 {
 	int		rc;


### PR DESCRIPTION
Modify pool connect RPC to pass the opaque security credential
instead of uid and gid of the calling process.

Modifies the daos client library call for pool connect to request
the credential from the agent and packs it into the connect RPC.

Modifies the daos_io_server pool connect handler to pass the credential
and the pool attributes new can_pool_connect api call in the
security module.

Implements upcall from daos_io_server to daos_server to validate and
unpack the credential for use in can_pool_connect.

Signed-off-by: David Quigley <david.quigley@intel.com>