### PR TITLE
DAOS-2219 server: re-order cleanup process

### DIFF
--- a/src/iosrv/server_iv.c
+++ b/src/iosrv/server_iv.c
@@ -842,15 +842,15 @@ ds_iv_fini(void)
 	struct ds_iv_class	*class;
 	struct ds_iv_class	*class_tmp;
 
+	d_list_for_each_entry_safe(ns, tmp, &ds_iv_ns_list, iv_ns_link) {
+		iv_ns_destroy_internal(ns);
+		D_FREE(ns);
+	}
+
 	d_list_for_each_entry_safe(class, class_tmp, &ds_iv_class_list,
 				   iv_class_list) {
 		d_list_del(&class->iv_class_list);
 		D_FREE(class);
-	}
-
-	d_list_for_each_entry_safe(ns, tmp, &ds_iv_ns_list, iv_ns_link) {
-		iv_ns_destroy_internal(ns);
-		D_FREE(ns);
 	}
 
 	if (crt_iv_class_nr > 0)

--- a/src/iosrv/tls.c
+++ b/src/iosrv/tls.c
@@ -165,7 +165,7 @@ dss_tls_init(int tag)
 void
 dss_tls_fini(struct dss_thread_local_storage *dtls)
 {
-	pthread_setspecific(dss_tls_key, NULL);
 	dss_thread_local_storage_fini(dtls);
 	D_FREE(dtls);
+	pthread_setspecific(dss_tls_key, NULL);
 }


### PR DESCRIPTION
Reorder iv and tls cleanup process to avoid
panic during server shutdown.

Signed-off-by: Wang Di <di.wang@intel.com>