### PR TITLE
DAOS-2226 rebuild: refine error handling in ds_obj_retry_cb

### DIFF
--- a/src/iosrv/obj.c
+++ b/src/iosrv/obj.c
@@ -54,11 +54,17 @@ ds_obj_retry_cb(tse_task_t *task, void *arg)
 	 * automatically, so let's just keep refreshing the
 	 * layout.
 	 */
-	D_DEBUG(DB_TRACE, "retry task %p\n", task);
 
 	/* let's check if the pool_map has been changed */
-	dc_obj_layout_refresh(*oh);
+	rc = dc_obj_layout_refresh(*oh);
+	if (rc) {
+		D_ERROR("task %p, dc_obj_layout_refresh failed rc %d\n",
+			task, rc);
+		task->dt_result = rc;
+		return rc;
+	}
 
+	D_DEBUG(DB_TRACE, "retry task %p\n", task);
 	rc = dc_task_resched(task);
 	if (rc != 0) {
 		D_ERROR("Failed to re-init task (%p)\n", task);

--- a/src/object/cli_obj.c
+++ b/src/object/cli_obj.c
@@ -867,7 +867,8 @@ dc_obj_query(tse_task_t *task)
 int
 dc_obj_layout_refresh(daos_handle_t oh)
 {
-	struct dc_object *obj;
+	struct dc_object	*obj;
+	int			 rc;
 
 	obj = obj_hdl2ptr(oh);
 	if (obj == NULL) {
@@ -875,11 +876,11 @@ dc_obj_layout_refresh(daos_handle_t oh)
 		return -DER_NO_HDL;
 	}
 
-	obj_layout_refresh(obj);
+	rc = obj_layout_refresh(obj);
 
 	obj_decref(obj);
 
-	return 0;
+	return rc;
 }
 
 static int


### PR DESCRIPTION
Add layout refresh's err handling.
Met an error that dc_obj_layout_refresh failed because layout freed and
then the obj_layout_create failed due to pl_map_find() failed. And then
cause the following retried dc_obj_list_obj task segfault in
obj_grp_valid_shard_get as the NULL obj->cob_shards.
This patch fails the dc_obj_list_obj task at that case for now.

Signed-off-by: Xuezhao Liu <xuezhao.liu@intel.com>