### PR TITLE
DAOS-2225 addons: Add API for listing Keys

### DIFF
--- a/src/client/addons/README.md
+++ b/src/client/addons/README.md
@@ -70,26 +70,15 @@ The API is currently tested with daos_addons_test.
 ## DAOS High Level (HL) API
 
 The HL API simplifies the DAOS Object API and exposes a simple API to manipulate
-a Key-Value object with simple put/get/remove operations. The API exposes only a
-single Key (no multi-level keys) and a value associated with that key which is
-overwritten entirely anytime the key is updated. So internally the mapping of a
-the HL KV object looks like:
+a Key-Value object with simple put/get/remove/list operations. The API exposes
+only a single Key (no multi-level keys) and a value associated with that key
+which is overwritten entirely anytime the key is updated. So internally the
+mapping of a the HL KV object looks like:
 
 ~~~~~~
 Key -> DKey
 NULL AKEY
 Value -> Single Value
-~~~~~~
-
-The API provides three functions to access the DAOS object:
-
-~~~~~~
-int daos_kv_put(daos_handle_t oh, daos_handle_t th, const char *key,
-    	        daos_size_t size, const void *buf, daos_event_t *ev);
-int daos_kv_get(daos_handle_t oh, daos_handle_t th, const char *key,
-  	        daos_size_t *size, void *buf, daos_event_t *ev);
-int daos_kv_remove(daos_handle_t oh, daos_handle_t th, const char *key,
-	           daos_event_t *ev);
 ~~~~~~
 
 The API is currently tested with daos_addons_test.

--- a/src/client/addons/dac_hl.c
+++ b/src/client/addons/dac_hl.c
@@ -129,7 +129,7 @@ err_task:
 	if (params)
 		D_FREE(params);
 	if (update_task)
-		D_FREE(update_task);
+		tse_task_complete(update_task, rc);
 	tse_task_complete(task, rc);
 	return rc;
 }
@@ -220,7 +220,7 @@ err_task:
 	if (params)
 		D_FREE(params);
 	if (fetch_task)
-		D_FREE(fetch_task);
+		tse_task_complete(fetch_task, rc);
 	tse_task_complete(task, rc);
 	return rc;
 }
@@ -228,7 +228,97 @@ err_task:
 int
 dac_kv_remove(tse_task_t *task)
 {
-	return -DER_NOSYS;
+	daos_kv_remove_t	*args = daos_task_get_args(task);
+	daos_obj_punch_t	*punch_args;
+	tse_task_t		*punch_task = NULL;
+	struct io_params	*params;
+	int			rc;
+
+	D_ALLOC_PTR(params);
+	if (params == NULL) {
+		D_ERROR("Failed memory allocation\n");
+		return -DER_NOMEM;
+	}
+
+	/** init dkey */
+	daos_iov_set(&params->dkey, (void *)args->key, strlen(args->key));
+
+	rc = daos_task_create(DAOS_OPC_OBJ_PUNCH_DKEYS, tse_task2sched(task),
+			      0, NULL, &punch_task);
+	if (rc != 0)
+		D_GOTO(err_task, rc);
+
+	punch_args = daos_task_get_args(punch_task);
+	punch_args->oh		= args->oh;
+	punch_args->th		= args->th;
+	punch_args->dkey	= &params->dkey;
+	punch_args->akeys	= NULL;
+	punch_args->akey_nr	= 0;
+
+	rc = tse_task_register_comp_cb(task, free_io_params_cb, &params,
+				       sizeof(params));
+	if (rc != 0)
+		D_GOTO(err_task, rc);
+
+	rc = tse_task_register_deps(task, 1, &punch_task);
+	if (rc != 0)
+		D_GOTO(err_task, rc);
+
+	rc = tse_task_schedule(punch_task, false);
+	if (rc != 0)
+		D_GOTO(err_task, rc);
+
+	tse_sched_progress(tse_task2sched(task));
+
+	return 0;
+
+err_task:
+	if (params)
+		D_FREE(params);
+	if (punch_task)
+		tse_task_complete(punch_task, rc);
+	tse_task_complete(task, rc);
+	return rc;
+}
+
+int
+dac_kv_list(tse_task_t *task)
+{
+	daos_kv_list_t		*args = daos_task_get_args(task);
+	daos_obj_list_dkey_t	*list_args;
+	tse_task_t		*list_task = NULL;
+	int			rc;
+
+	rc = daos_task_create(DAOS_OPC_OBJ_LIST_DKEY, tse_task2sched(task),
+			      0, NULL, &list_task);
+	if (rc != 0)
+		D_GOTO(err_task, rc);
+
+	list_args = daos_task_get_args(list_task);
+	list_args->oh		= args->oh;
+	list_args->th		= args->th;
+	list_args->nr		= args->nr;
+	list_args->sgl		= args->sgl;
+	list_args->kds		= args->kds;
+	list_args->anchor	= args->anchor;
+
+	rc = tse_task_register_deps(task, 1, &list_task);
+	if (rc != 0)
+		D_GOTO(err_task, rc);
+
+	rc = tse_task_schedule(list_task, false);
+	if (rc != 0)
+		D_GOTO(err_task, rc);
+
+	tse_sched_progress(tse_task2sched(task));
+
+	return 0;
+
+err_task:
+	if (list_task)
+		tse_task_complete(list_task, rc);
+	tse_task_complete(task, rc);
+	return rc;
 }
 
 static int

--- a/src/client/addons/daos_hl.c
+++ b/src/client/addons/daos_hl.c
@@ -80,8 +80,44 @@ int
 daos_kv_remove(daos_handle_t oh, daos_handle_t th, const char *key,
 	       daos_event_t *ev)
 {
-	D_ERROR("Unsupported API\n");
-	return -DER_NOSYS;
+	daos_kv_remove_t	*args;
+	tse_task_t		*task;
+	int			rc;
+
+	rc = dc_task_create(dac_kv_remove, NULL, ev, &task);
+	if (rc)
+		return rc;
+
+	args = dc_task_get_args(task);
+	args->oh	= oh;
+	args->th	= th;
+	args->key	= key;
+
+	return dc_task_schedule(task, true);
+}
+
+int
+daos_kv_list(daos_handle_t oh, daos_handle_t th, uint32_t *nr,
+	     daos_key_desc_t *kds, daos_sg_list_t *sgl, daos_anchor_t *anchor,
+	     daos_event_t *ev)
+{
+	daos_kv_list_t	*args;
+	tse_task_t	*task;
+	int		rc;
+
+	rc = dc_task_create(dac_kv_list, NULL, ev, &task);
+	if (rc)
+		return rc;
+
+	args = dc_task_get_args(task);
+	args->oh	= oh;
+	args->th	= th;
+	args->nr	= nr;
+	args->kds	= kds;
+	args->sgl	= sgl;
+	args->anchor	= anchor;
+
+	return dc_task_schedule(task, true);
 }
 
 int

--- a/src/client/api/init.c
+++ b/src/client/api/init.c
@@ -105,6 +105,7 @@ const struct daos_task_api dc_funcs[] = {
 	{dac_kv_get, sizeof(daos_kv_get_t)},
 	{dac_kv_put, sizeof(daos_kv_put_t)},
 	{dac_kv_remove, sizeof(daos_kv_remove_t)},
+	{dac_kv_list, sizeof(daos_kv_list_t)},
 	{dac_obj_fetch_multi, sizeof(daos_obj_multi_io_t)},
 	{dac_obj_update_multi, sizeof(daos_obj_multi_io_t)},
 };

--- a/src/client/api/task_internal.h
+++ b/src/client/api/task_internal.h
@@ -88,9 +88,10 @@ struct daos_task_args {
 		daos_array_io_t		array_io;
 		daos_array_get_size_t	array_get_size;
 		daos_array_set_size_t	array_set_size;
-		daos_kv_get_t		obj_get;
-		daos_kv_put_t		obj_put;
-		daos_kv_remove_t	obj_remove;
+		daos_kv_get_t		kv_get;
+		daos_kv_put_t		kv_put;
+		daos_kv_remove_t	kv_remove;
+		daos_kv_list_t		kv_list;
 		daos_obj_multi_io_t	obj_fetch_multi;
 		daos_obj_multi_io_t	obj_update_multi;
 	}		 ta_u;

--- a/src/include/daos/addons.h
+++ b/src/include/daos/addons.h
@@ -45,6 +45,7 @@ int dac_array_global2local(daos_handle_t coh, daos_iov_t glob,
 int dac_kv_get(tse_task_t *task);
 int dac_kv_put(tse_task_t *task);
 int dac_kv_remove(tse_task_t *task);
+int dac_kv_list(tse_task_t *task);
 int dac_obj_fetch_multi(tse_task_t *task);
 int dac_obj_update_multi(tse_task_t *task);
 #endif /* __DAOS_ADDONSX_H__ */

--- a/src/include/daos_addons.h
+++ b/src/include/daos_addons.h
@@ -113,6 +113,41 @@ int
 daos_kv_remove(daos_handle_t oh, daos_handle_t th, const char *key,
 	       daos_event_t *ev);
 
+/**
+ * List/enumerate all keys in an object.
+ *
+ * \param[in]	oh	Object open handle.
+ * \param[in]	th	Transaction handle.
+ * \param[in,out]
+ *		nr	[in]: number of key descriptors in \a kds. [out]: number
+ *			of returned key descriptors.
+ * \param[in,out]
+ *		kds	[in]: preallocated array of \nr key descriptors. [out]:
+ *			size of each individual key.
+ * \param[in]	sgl	Scatter/gather list to store the dkey list.
+ *			All keys are written contiguously, with actual
+ *			boundaries that can be calculated using \a kds.
+ * \param[in,out]
+ *		anchor	Hash anchor for the next call, it should be set to
+ *			zeroes for the first call, it should not be changed
+ *			by caller between calls.
+ * \param[in]	ev	Completion event, it is optional and can be NULL.
+ *			Function will run in blocking mode if \a ev is NULL.
+ *
+ * \return		These values will be returned by \a ev::ev_error in
+ *			non-blocking mode:
+ *			0		Success
+ *			-DER_NO_HDL	Invalid object open handle
+ *			-DER_INVAL	Invalid parameter
+ *			-DER_NO_PERM	Permission denied
+ *			-DER_UNREACH	Network is unreachable
+ *			-DER_EP_RO	Epoch is read-only
+ */
+int
+daos_kv_list(daos_handle_t oh, daos_handle_t th, uint32_t *nr,
+	     daos_key_desc_t *kds, daos_sg_list_t *sgl, daos_anchor_t *anchor,
+	     daos_event_t *ev);
+
 typedef struct {
 	daos_key_t	*ioa_dkey;
 	unsigned int	ioa_nr;

--- a/src/include/daos_task.h
+++ b/src/include/daos_task.h
@@ -119,6 +119,7 @@ typedef enum {
 	DAOS_OPC_KV_GET,
 	DAOS_OPC_KV_PUT,
 	DAOS_OPC_KV_REMOVE,
+	DAOS_OPC_KV_LIST,
 	DAOS_OPC_OBJ_FETCH_MULTI,
 	DAOS_OPC_OBJ_UPDATE_MULTI,
 
@@ -554,6 +555,15 @@ typedef struct {
 	daos_handle_t		th;
 	const char		*key;
 } daos_kv_remove_t;
+
+typedef struct {
+	daos_handle_t		oh;
+	daos_handle_t		th;
+	uint32_t		*nr;
+	daos_key_desc_t		*kds;
+	daos_sg_list_t		*sgl;
+	daos_anchor_t		*anchor;
+} daos_kv_list_t;
 
 typedef struct {
 	daos_handle_t		oh;

--- a/src/tests/addons/hl_tests.c
+++ b/src/tests/addons/hl_tests.c
@@ -65,6 +65,7 @@ list_keys(daos_handle_t oh, int *num_keys)
 	while (!daos_anchor_is_eof(&anchor)) {
 		uint32_t	nr = ENUM_DESC_NR;
 		int		rc;
+
 		memset(buf, 0, ENUM_DESC_BUF);
 		rc = daos_kv_list(oh, DAOS_TX_NONE, &nr, kds, &sgl, &anchor,
 				  NULL);

--- a/src/tests/addons/hl_tests.c
+++ b/src/tests/addons/hl_tests.c
@@ -55,7 +55,6 @@ list_keys(daos_handle_t oh, int *num_keys)
 	int		 key_nr = 0;
 	daos_sg_list_t	 sgl;
 	daos_iov_t       sg_iov;
-	int		 rc;
 
 	buf = malloc(ENUM_DESC_BUF);
 	daos_iov_set(&sg_iov, buf, ENUM_DESC_BUF);
@@ -65,7 +64,7 @@ list_keys(daos_handle_t oh, int *num_keys)
 
 	while (!daos_anchor_is_eof(&anchor)) {
 		uint32_t	nr = ENUM_DESC_NR;
-
+		int		rc;
 		memset(buf, 0, ENUM_DESC_BUF);
 		rc = daos_kv_list(oh, DAOS_TX_NONE, &nr, kds, &sgl, &anchor,
 				  NULL);


### PR DESCRIPTION
Add a missing KV API to list all keys in a KV object.
Also implement the remove API that was not supported previously.

Signed-off-by: Mohamad Chaarawi <mohamad.chaarawi@intel.com>