### PR TITLE
DAOS-2235 Test:daos_test -i test is failing on master intermediately

### DIFF
--- a/src/tests/ftest/daos_test/DaosCoreTest.yaml
+++ b/src/tests/ftest/daos_test/DaosCoreTest.yaml
@@ -11,7 +11,7 @@ hosts:
     - boro-G
     - boro-H
 # rebuild alone takes about 2hrs
-timeout: 700
+timeout: 1400
 server:
   server_group: daos_server
 daos_tests:


### PR DESCRIPTION
Increasing the test timeout 2X, as daos_test -i s taking ~725-750 seconds
on CI HW.

Signed-off-by: Samir <samir.raval@intel.com>