### PR TITLE
DAOS-1822 control: Fix newDrpcCall for nil body

### DIFF
--- a/src/control/server/drpc.go
+++ b/src/control/server/drpc.go
@@ -98,9 +98,13 @@ func checkDrpcResponse(drpcResp *drpc.Response) error {
 // newDrpcCall creates a new drpc Call instance for specified module, with
 // the protobuf message marshalled in the body
 func newDrpcCall(module int32, method int32, bodyMessage proto.Message) (*drpc.Call, error) {
-	bodyBytes, err := proto.Marshal(bodyMessage)
-	if err != nil {
-		return nil, err
+	var bodyBytes []byte
+	if bodyMessage != nil {
+		var err error
+		bodyBytes, err = proto.Marshal(bodyMessage)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	return &drpc.Call{


### PR DESCRIPTION
For dRPC requests that doesn't need to pass any info, newDrpcCall
returns an error, originated from proto.Marshal, complaining that the
body of the request is nil. This patch changes newDrpcCall to ignore nil
body fields.

Signed-off-by: Li Wei <wei.g.li@intel.com>