### PR TITLE
DAOS-1822 control: Exit daos_server upon signals

### DIFF
--- a/src/control/server/main.go
+++ b/src/control/server/main.go
@@ -27,9 +27,7 @@ import (
 	"fmt"
 	"net"
 	"os"
-	"os/signal"
 	"runtime"
-	"syscall"
 
 	flags "github.com/jessevdk/go-flags"
 	"google.golang.org/grpc"
@@ -145,14 +143,6 @@ func serverMain() error {
 		log.Errorf("Failed to format servers: %s", err)
 		return err
 	}
-
-	// Create a channel to retrieve signals.
-	sigchan := make(chan os.Signal, 2)
-	signal.Notify(sigchan,
-		syscall.SIGTERM,
-		syscall.SIGINT,
-		syscall.SIGQUIT,
-		syscall.SIGHUP)
 
 	// Process configurations parameters for Nvme.
 	if err = config.parseNvme(); err != nil {


### PR DESCRIPTION
00be4c5e976cbae80fa76adca2729acfad8d7ef0 removes the signal handling in
daos_server, but leaves the signal.Notify call there. This causes
daos_server to ignore to the signals passed to the signal.Notify call.
For example, it's not possible to ctrl-c a daos_server process. This
patch simply removes unblocks these signals as there's no clear cases
that require special signal handling (yet).

Signed-off-by: Li Wei <wei.g.li@intel.com>