### PR TITLE
(WIP) DIO-9 NVMe resilience demo with AIO devs on Xeon

### DIFF
--- a/src/control/server/config.go
+++ b/src/control/server/config.go
@@ -114,6 +114,10 @@ func loadConfigOpts(cliOpts *cliOptions, host string) (
 		return config, errors.New("missing I/O server params")
 	}
 
+	for idx := range config.Servers {
+		config.Servers[idx].Hostname = host
+	}
+
 	return config, nil
 }
 
@@ -428,7 +432,8 @@ func (c *configuration) setLogging(name string) (*os.File, error) {
 
 	// if no logfile specified, output from multiple hosts
 	// may get aggregated, prefix entries with hostname
-	log.NewDefaultLogger(log.Debug, name+" ", os.Stderr)
+	log.NewDefaultLogger(
+		log.Debug, c.Servers[0].Hostname+" ", os.Stderr)
 
 	return nil, nil
 }

--- a/src/control/server/config_bdev.go
+++ b/src/control/server/config_bdev.go
@@ -43,10 +43,10 @@ const (
 `
 	// device block size hardcoded to 4096
 	fileTempl = `[AIO]
-{{ range $i, $e := .BdevList }}    AIO {{$e}} AIO{{$i}} 4096
+{{ $host := .Hostname }}{{ range $i, $e := .BdevList }}    AIO {{$e}} AIO_{{$host}}_{{$i}} 4096
 {{ end }} `
 	kdevTempl = `[AIO]
-{{ range $i, $e := .BdevList }}    AIO {{$e}} AIO{{$i}}
+{{ $host := .Hostname }}{{ range $i, $e := .BdevList }}    AIO {{$e}} AIO_{{$host}}_{{$i}}
 {{ end }}`
 	mallocTempl = `[Malloc]
 	NumberOfLuns {{.BdevNumber}}

--- a/src/control/server/config_types.go
+++ b/src/control/server/config_types.go
@@ -24,6 +24,7 @@
 package main
 
 import (
+	"os"
 	"fmt"
 	"math"
 	"path/filepath"
@@ -179,17 +180,22 @@ type server struct {
 	BdevSize        int      `yaml:"bdev_size"`
 	// ioParams represents commandline options and environment variables
 	// to be passed on I/O server invocation.
-	CliOpts []string // tuples (short option, value) e.g. ["-p", "10000"...]
 	// Condition variable to announce formatting of storage
 	FormatCond *sync.Cond
+	CliOpts  []string // tuples (short option, value) e.g. ["-p", "10000"...]
+	Hostname string   // used when generating templates
 }
 
 // newDefaultServer creates a new instance of server struct with default values.
 func newDefaultServer() server {
+	// TODO: fix by only ever creating server in one place
+	host, _ := os.Hostname()
+
 	return server{
 		ScmClass:    scmDCPM,
 		BdevClass:   bdNVMe,
 		NrXsHelpers: 2,
+		Hostname:    host,
 	}
 }
 

--- a/src/include/daos/object.h
+++ b/src/include/daos/object.h
@@ -51,9 +51,14 @@ struct daos_obj_shard_md {
 /**
  * object layout information.
  **/
+struct daos_target_id {
+	uint32_t	ti_tgt;
+	uint32_t	ti_rank;
+};
+
 struct daos_obj_shard {
 	uint32_t	os_replica_nr;
-	uint32_t	os_ranks[0];
+	struct daos_target_id	os_ids[0];
 };
 
 struct daos_obj_layout {

--- a/src/iosrv/init.c
+++ b/src/iosrv/init.c
@@ -328,6 +328,8 @@ server_init(int argc, char *argv[])
 	uint32_t	flags = CRT_FLAG_BIT_SERVER | CRT_FLAG_BIT_LM_DISABLE;
 	d_rank_t	rank = -1;
 	uint32_t	size = -1;
+	char		*hostname;
+	size_t		hostlen = 30;
 
 	rc = daos_debug_init(NULL);
 	if (rc != 0)
@@ -451,11 +453,24 @@ server_init(int argc, char *argv[])
 		goto exit_drpc_fini;
 	D_INFO("Modules successfully set up\n");
 
-	D_PRINT("DAOS I/O server (v%s) process %u started on rank %u "
+	D_ALLOC(hostname, hostlen);
+	if (hostname == NULL) {
+		D_ERROR("Failed to alloc hostname\n");
+		goto exit_drpc_fini;
+	}
+	memset(hostname, 0, hostlen);
+
+	rc = gethostname(hostname, hostlen);
+	if (rc != 0)
+		D_ERROR("Failed to get hostname\n");
+
+	D_PRINT("DAOS I/O server (v%s) process %u started on rank %u [%s] "
 		"(out of %u) with %u target xstream set(s), %d helper XS "
 		"per target, firstcore %d.\n",
-		DAOS_VERSION, getpid(), rank, size, dss_tgt_nr,
+		DAOS_VERSION, getpid(), rank, hostname, size, dss_tgt_nr,
 		dss_tgt_offload_xs_nr, dss_core_offset);
+
+	D_FREE(hostname);
 
 	return 0;
 

--- a/src/object/cli_obj.c
+++ b/src/object/cli_obj.c
@@ -787,7 +787,7 @@ daos_obj_layout_alloc(struct daos_obj_layout **layout, uint32_t grp_nr,
 	for (i = 0; i < grp_nr; i++) {
 		D_ALLOC((*layout)->ol_shards[i],
 			sizeof(struct daos_obj_shard) +
-			grp_size * sizeof(uint32_t));
+			grp_size * sizeof(struct daos_target_id));
 		if ((*layout)->ol_shards[i] == NULL)
 			D_GOTO(free, rc = -DER_NOMEM);
 
@@ -832,13 +832,11 @@ dc_obj_layout_get(daos_handle_t oh, struct daos_obj_layout **p_layout)
 
 		shard = layout->ol_shards[i];
 		shard->os_replica_nr = grp_size;
-		for (j = 0; j < grp_size; j++) {
+		for (j = 0; j < grp_size; j++, k++) {
 			struct pool_target *tgt;
 
-			if (obj->cob_shards[k].do_target_id == -1) {
-				k++;
+			if (obj->cob_shards[k].do_target_id == -1)
 				continue;
-			}
 
 			rc = dc_cont_tgt_idx2ptr(obj->cob_coh,
 					obj->cob_shards[k].do_target_id,
@@ -846,7 +844,8 @@ dc_obj_layout_get(daos_handle_t oh, struct daos_obj_layout **p_layout)
 			if (rc != 0)
 				D_GOTO(out, rc);
 
-			shard->os_ranks[j] = tgt->ta_comp.co_rank;
+			shard->os_ids[j].ti_rank = tgt->ta_comp.co_rank;
+			shard->os_ids[j].ti_tgt = tgt->ta_comp.co_id;
 		}
 	}
 	*p_layout = layout;

--- a/src/tests/suite/daos_obj.c
+++ b/src/tests/suite/daos_obj.c
@@ -2707,7 +2707,7 @@ tgt_idx_change_retry(void **state)
 		assert_int_equal(layout->ol_shards[0]->os_replica_nr, 3);
 		/* FIXME disable rank compare until we fix the layout_get */
 		/* assert_int_equal(layout->ol_shards[0]->os_ranks[0], 2); */
-		rank = layout->ol_shards[0]->os_ranks[replica];
+		rank = layout->ol_shards[0]->os_ids[replica].ti_rank;
 		rc = daos_obj_layout_free(layout);
 		assert_int_equal(rc, 0);
 
@@ -2733,7 +2733,7 @@ tgt_idx_change_retry(void **state)
 		 *		     rank);
 		*/
 		print_message("target of shard %d changed from %d to %d\n",
-			      replica, rank, layout->ol_shards[0]->os_ranks[0]);
+			      replica, rank, layout->ol_shards[0]->os_ids[0].ti_rank);
 		rc = daos_obj_layout_free(layout);
 		assert_int_equal(rc, 0);
 	}

--- a/src/tests/suite/daos_rebuild.c
+++ b/src/tests/suite/daos_rebuild.c
@@ -1429,7 +1429,7 @@ rebuild_multiple_tgts(void **state)
 		/* kill 2 ranks at the same time */
 		D_ASSERT(layout->ol_shards[0]->os_replica_nr > 2);
 		for (i = 0; i < 3; i++) {
-			d_rank_t rank = layout->ol_shards[0]->os_ranks[i];
+			d_rank_t rank = layout->ol_shards[0]->os_ids[i].ti_rank;
 
 			if (rank != leader) {
 				exclude_ranks[fail_cnt] = rank;
@@ -1604,9 +1604,9 @@ rebuild_fail_all_replicas_before_rebuild(void **state)
 	/* Kill one replica and start rebuild */
 	shard = layout->ol_shards[0];
 	daos_kill_server(arg, arg->pool.pool_uuid, arg->group, &arg->pool.svc,
-			 shard->os_ranks[0]);
+			 shard->os_ids[0].ti_rank);
 	daos_exclude_server(arg->pool.pool_uuid, arg->group, &arg->pool.svc,
-			    shard->os_ranks[0]);
+			    shard->os_ids[0].ti_rank);
 
 	/* Sleep 10 seconds after it scan finish and hang before rebuild */
 	print_message("sleep 10 seconds to wait scan to be finished \n");
@@ -1614,9 +1614,9 @@ rebuild_fail_all_replicas_before_rebuild(void **state)
 
 	/* Then kill rank 1 */
 	daos_kill_server(arg, arg->pool.pool_uuid, arg->group, &arg->pool.svc,
-			 shard->os_ranks[1]);
+			 shard->os_ids[1].ti_rank);
 	daos_exclude_server(arg->pool.pool_uuid, arg->group, &arg->pool.svc,
-			    shard->os_ranks[1]);
+			    shard->os_ids[1].ti_rank);
 
 	/* Continue rebuild */
 	daos_mgmt_set_params(arg->group, -1, DSS_KEY_FAIL_LOC, 0, 0, NULL);
@@ -1657,14 +1657,14 @@ rebuild_fail_all_replicas(void **state)
 		int j;
 
 		for (j = 0; j < layout->ol_shards[i]->os_replica_nr; j++) {
-			d_rank_t rank = layout->ol_shards[i]->os_ranks[j];
+			d_rank_t rank = layout->ol_shards[i]->os_ids[j].ti_rank;
 
 			daos_kill_server(arg, arg->pool.pool_uuid,
 					 arg->group, &arg->pool.svc, rank);
 		}
 
 		for (j = 0; j < layout->ol_shards[i]->os_replica_nr; j++) {
-			d_rank_t rank = layout->ol_shards[i]->os_ranks[j];
+			d_rank_t rank = layout->ol_shards[i]->os_ids[j].ti_rank;
 
 			daos_exclude_server(arg->pool.pool_uuid, arg->group,
 					    &arg->pool.svc, rank);

--- a/src/tests/suite/daos_rebuild_demo.c
+++ b/src/tests/suite/daos_rebuild_demo.c
@@ -1,0 +1,557 @@
+/**
+ * (C) Copyright 2019 Intel Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * GOVERNMENT LICENSE RIGHTS-OPEN SOURCE SOFTWARE
+ * The Government's rights to use, modify, reproduce, release, perform, display,
+ * or disclose this software are subject to the terms of the Apache License as
+ * provided in Contract No. B609815.
+ * Any reproduction of computer software, computer software documentation, or
+ * portions thereof marked with this legend must also reproduce the markings.
+ */
+/**
+ * This file is part of daos
+ *
+ * tests/suite/daos_demo_rebuild.c
+ *
+ *
+ */
+#define D_LOGFAC	DD_FAC(tests)
+
+#include "daos_iotest.h"
+#include <daos/pool.h>
+#include <daos/mgmt.h>
+#include <daos/container.h>
+
+#define KEY_NR		1000
+#define OBJ_NR		4
+#define OBJ_REPLICAS	2
+#define DEFAULT_FAIL_TGT 0
+#define REBUILD_POOL_SIZE	(4ULL << 30)
+static void
+rebuild_exclude_tgt(test_arg_t **args, int arg_cnt, d_rank_t rank,
+		    int tgt_idx, bool kill)
+{
+	int i;
+
+	if (kill) {
+		daos_kill_server(args[0], args[0]->pool.pool_uuid,
+				 args[0]->group, &args[0]->pool.svc,
+				 rank);
+		sleep(5);
+		/* If one rank is killed, then it has to exclude all
+		 * targets on this rank.
+		 **/
+		D_ASSERT(tgt_idx == -1);
+	}
+
+	for (i = 0; i < arg_cnt; i++) {
+		daos_exclude_target(args[i]->pool.pool_uuid,
+				    args[i]->group, &args[i]->pool.svc,
+				    rank, tgt_idx);
+		sleep(2);
+	}
+}
+
+static void
+rebuild_targets(test_arg_t **args, int args_cnt, d_rank_t *failed_ranks,
+		int *failed_tgts, int rank_nr, bool kill)
+{
+	int	i;
+
+	for (i = 0; i < args_cnt; i++) {
+		if (args[i]->rebuild_pre_cb)
+			args[i]->rebuild_pre_cb(args[i]);
+	}
+
+	MPI_Barrier(MPI_COMM_WORLD);
+	/** exclude the target from the pool */
+	if (args[0]->myrank == 0) {
+		for (i = 0; i < rank_nr; i++) {
+			rebuild_exclude_tgt(args, args_cnt, failed_ranks[i],
+					    failed_tgts ? failed_tgts[i] : -1,
+					    kill);
+			/* Sleep 5 seconds to make sure the rebuild start */
+			sleep(5);
+		}
+	}
+	MPI_Barrier(MPI_COMM_WORLD);
+
+	for (i = 0; i < args_cnt; i++)
+		if (args[i]->rebuild_cb)
+			args[i]->rebuild_cb(args[i]);
+
+	if (args[0]->myrank == 0) {
+		test_rebuild_wait(args, args_cnt);
+	}
+
+	MPI_Barrier(MPI_COMM_WORLD);
+	for (i = 0; i < args_cnt; i++) {
+		if (args[i]->rebuild_post_cb)
+			args[i]->rebuild_post_cb(args[i]);
+	}
+}
+
+static int
+rebuild_io_obj_internal(struct ioreq *req, bool validate, daos_epoch_t eph,
+			daos_epoch_t validate_eph)
+{
+#define BULK_SIZE	5000
+#define REC_SIZE	64
+#define LARGE_KEY_SIZE	(512 * 1024)
+#define DKEY_LOOP	3
+#define AKEY_LOOP	3
+#define REC_LOOP	10
+	char	dkey[32];
+	char	akey[32];
+	char	data[REC_SIZE];
+	char	data_verify[REC_SIZE];
+	char	*large_key;
+	int	akey_punch_idx = 1;
+	int	dkey_punch_idx = 1;
+	int	rec_punch_idx = 2;
+	int	j;
+	int	k;
+	int	l;
+
+	D_ALLOC(large_key, LARGE_KEY_SIZE);
+	if (large_key == NULL)
+		return -DER_NOMEM;
+	memset(large_key, 'L', LARGE_KEY_SIZE - 1);
+
+	for (j = 0; j < DKEY_LOOP; j++) {
+		req->iod_type = DAOS_IOD_ARRAY;
+		/* small records */
+		sprintf(dkey, "dkey_%d", j);
+		sprintf(data, "%s_"DF_U64, "data", eph);
+		sprintf(data_verify, "%s_"DF_U64, "data", validate_eph);
+		for (k = 0; k < AKEY_LOOP; k++) {
+			sprintf(akey, "akey_%d", k);
+			for (l = 0; l < REC_LOOP; l++) {
+				if (validate) {
+					/* How to verify punch? XXX */
+					if (k == akey_punch_idx ||
+					    j == dkey_punch_idx ||
+					    l == rec_punch_idx)
+						continue;
+					memset(data, 0, REC_SIZE);
+					if (l == 7)
+						lookup_single(large_key, akey,
+							      l, data, REC_SIZE,
+							      DAOS_TX_NONE,
+							      req);
+					else
+						lookup_single(dkey, akey, l,
+							      data, REC_SIZE,
+							      DAOS_TX_NONE,
+							      req);
+					assert_memory_equal(data, data_verify,
+						    strlen(data_verify));
+				} else {
+					if (l == 7)
+						insert_single(large_key, akey,
+							l, data,
+							strlen(data) + 1,
+							DAOS_TX_NONE, req);
+					else if (l == rec_punch_idx)
+						punch_single(dkey, akey, l,
+							     DAOS_TX_NONE,
+							     req);
+					else
+						insert_single(dkey, akey, l,
+							data, strlen(data) + 1,
+							DAOS_TX_NONE, req);
+				}
+			}
+
+			/* Punch akey */
+			if (k == akey_punch_idx && !validate)
+				punch_akey(dkey, akey, DAOS_TX_NONE, req);
+		}
+
+		/* large records */
+		for (k = 0; k < 2; k++) {
+			char bulk[BULK_SIZE+10];
+			char compare[BULK_SIZE];
+
+			sprintf(akey, "akey_bulk_%d", k);
+			memset(compare, 'a', BULK_SIZE);
+			for (l = 0; l < 5; l++) {
+				if (validate) {
+					/* How to verify punch? XXX */
+					if (k == akey_punch_idx ||
+					    j == dkey_punch_idx)
+						continue;
+					memset(bulk, 0, BULK_SIZE);
+					lookup_single(dkey, akey, l,
+						      bulk, BULK_SIZE + 10,
+						      DAOS_TX_NONE, req);
+					assert_memory_equal(bulk, compare,
+							    BULK_SIZE);
+				} else {
+					memset(bulk, 'a', BULK_SIZE);
+					insert_single(dkey, akey, l,
+						      bulk, BULK_SIZE,
+						      DAOS_TX_NONE, req);
+				}
+			}
+
+			/* Punch akey */
+			if (k == akey_punch_idx && !validate)
+				punch_akey(dkey, akey, DAOS_TX_NONE, req);
+		}
+
+		/* Punch dkey */
+		if (j == dkey_punch_idx && !validate)
+			punch_dkey(dkey, DAOS_TX_NONE, req);
+
+		/* single record */
+		sprintf(data, "%s_"DF_U64, "single_data", eph);
+		sprintf(data_verify, "%s_"DF_U64, "single_data",
+			validate_eph);
+		req->iod_type = DAOS_IOD_SINGLE;
+		sprintf(dkey, "dkey_single_%d", j);
+		if (validate) {
+			memset(data, 0, REC_SIZE);
+			lookup_single(dkey, "akey_single", 0, data, REC_SIZE,
+				      DAOS_TX_NONE, req);
+			assert_memory_equal(data, data_verify,
+					    strlen(data_verify));
+		} else {
+			insert_single(dkey, "akey_single", 0, data,
+				      strlen(data) + 1, DAOS_TX_NONE, req);
+		}
+	}
+
+	D_FREE(large_key);
+	return 0;
+}
+
+static void
+rebuild_io(test_arg_t *arg, daos_obj_id_t *oids, int oids_nr)
+{
+	struct ioreq	req;
+	daos_epoch_t	eph = arg->hce + arg->index * 2 + 1;
+	int		i;
+	int		punch_idx = 1;
+
+	for (i = 0; i < oids_nr; i++) {
+		ioreq_init(&req, arg->coh, oids[i], DAOS_IOD_ARRAY, arg);
+		if (i == punch_idx) {
+			print_message("punching object "DF_U64"\n", oids[i].lo);
+			punch_obj(DAOS_TX_NONE, &req);
+		} else {
+			print_message("creating records on object "DF_U64"\n",
+					oids[i].lo);
+			rebuild_io_obj_internal((&req), false, eph, -1);
+		}
+		ioreq_fini(&req);
+	}
+}
+
+static void
+rebuild_io_validate(test_arg_t *arg, daos_obj_id_t *oids, int oids_nr,
+		    bool discard)
+{
+	struct ioreq	req;
+	daos_epoch_t	eph = arg->hce + arg->index * 2 + 1;
+	int		i;
+	int		punch_idx = 1;
+
+	arg->fail_loc = DAOS_OBJ_SPECIAL_SHARD;
+	/* Validate data for each shard */
+	for (i = 0; i < OBJ_REPLICAS; i++) {
+		int j;
+
+		arg->fail_value = i;
+		for (j = 0; j < oids_nr; j++) {
+			ioreq_init(&req, arg->coh, oids[j], DAOS_IOD_ARRAY,
+				   arg);
+
+			/* how to validate punch object XXX */
+			if (j != punch_idx)
+				/* Validate eph data */
+				rebuild_io_obj_internal((&req), true, eph, eph);
+
+			ioreq_fini(&req);
+		}
+	}
+
+	arg->fail_loc = 0;
+	arg->fail_value = 0;
+}
+
+
+static int
+rebuild_pool_disconnect_internal(void *data)
+{
+	test_arg_t	*arg = data;
+	int		rc = 0;
+	int		rc_reduce = 0;
+
+	/* Close cont and disconnect pool */
+	rc = daos_cont_close(arg->coh, NULL);
+	if (arg->multi_rank) {
+		MPI_Allreduce(&rc, &rc_reduce, 1, MPI_INT, MPI_MIN,
+			      MPI_COMM_WORLD);
+		rc = rc_reduce;
+	}
+	print_message("container close "DF_UUIDF"\n",
+		      DP_UUID(arg->co_uuid));
+	if (rc) {
+		print_message("failed to close container "DF_UUIDF
+			      ": %d\n", DP_UUID(arg->co_uuid), rc);
+		return rc;
+	}
+
+	arg->coh = DAOS_HDL_INVAL;
+	rc = daos_pool_disconnect(arg->pool.poh, NULL /* ev */);
+	if (rc)
+		print_message("failed to disconnect pool "DF_UUIDF
+			      ": %d\n", DP_UUID(arg->pool.pool_uuid), rc);
+
+	print_message("pool disconnect "DF_UUIDF"\n",
+		      DP_UUID(arg->pool.pool_uuid));
+
+	arg->pool.poh = DAOS_HDL_INVAL;
+	MPI_Barrier(MPI_COMM_WORLD);
+	return rc;
+}
+
+
+static int
+rebuild_pool_connect_internal(void *data)
+{
+	test_arg_t	*arg = data;
+	int		rc;
+
+	MPI_Barrier(MPI_COMM_WORLD);
+	if (arg->myrank == 0) {
+		rc = daos_pool_connect(arg->pool.pool_uuid, arg->group,
+				       &arg->pool.svc, DAOS_PC_RW,
+				       &arg->pool.poh, &arg->pool.pool_info,
+				       NULL /* ev */);
+		if (rc)
+			print_message("daos_pool_connect failed, rc: %d\n", rc);
+
+		print_message("pool connect "DF_UUIDF"\n",
+			       DP_UUID(arg->pool.pool_uuid));
+	}
+	MPI_Barrier(MPI_COMM_WORLD);
+	if (arg->multi_rank)
+		MPI_Bcast(&rc, 1, MPI_INT, 0, MPI_COMM_WORLD);
+	if (rc)
+		return rc;
+
+	/** broadcast pool info */
+	if (arg->multi_rank) {
+		MPI_Bcast(&arg->pool.pool_info, sizeof(arg->pool.pool_info),
+			  MPI_CHAR, 0, MPI_COMM_WORLD);
+		handle_share(&arg->pool.poh, HANDLE_POOL, arg->myrank,
+			     arg->pool.poh, 0);
+	}
+
+	/** open container */
+	MPI_Barrier(MPI_COMM_WORLD);
+	if (arg->myrank == 0) {
+		rc = daos_cont_open(arg->pool.poh, arg->co_uuid, DAOS_COO_RW,
+				    &arg->coh, &arg->co_info, NULL);
+		if (rc)
+			print_message("daos_cont_open failed, rc: %d\n", rc);
+
+		print_message("container open "DF_UUIDF"\n",
+			       DP_UUID(arg->co_uuid));
+	}
+	MPI_Barrier(MPI_COMM_WORLD);
+	if (arg->multi_rank)
+		MPI_Bcast(&rc, 1, MPI_INT, 0, MPI_COMM_WORLD);
+	if (rc)
+		return rc;
+
+	/** broadcast container info */
+	if (arg->multi_rank) {
+		MPI_Bcast(&rc, 1, MPI_INT, 0, MPI_COMM_WORLD);
+		handle_share(&arg->coh, HANDLE_CO, arg->myrank, arg->pool.poh,
+			     0);
+	}
+
+	return 0;
+}
+
+static void
+rebuild_get_obj_layout(test_arg_t *arg, daos_obj_id_t oid)
+{
+	struct daos_obj_layout	*layout;
+	int			rc;
+	int			i;
+	int			j;
+
+
+	rc = daos_obj_layout_get(arg->coh, oid, &layout);
+	if (rc) {
+		print_message("daos_obj_layout_get failed, rc: %d\n", rc);
+		return;
+	}
+
+	/* Print the object layout */
+	for (i = 0; i < layout->ol_nr; i++) {
+		struct daos_obj_shard *shard;
+
+		shard = layout->ol_shards[i];
+		for (j = 0; j < shard->os_replica_nr; j++)
+			print_message("i:%d rank: %d tgt_id: %d\n",
+				      j, shard->os_ids[j].ti_rank,
+				      shard->os_ids[j].ti_tgt);
+	}
+
+	daos_obj_layout_free(layout);
+}
+
+static void
+rebuild_full_node(void **state)
+{
+	test_arg_t	*arg = *state;
+	daos_obj_id_t	oids[OBJ_NR];
+	unsigned int	required_nodes = 3;
+	int		failed_tgt = 0;
+	int		i;
+
+	if (!test_runable(arg, required_nodes))
+		return;
+
+	print_message("%u server nodes, 2-way object replica, %d objects\n",
+		      required_nodes, OBJ_NR);
+
+	for (i = 0; i < OBJ_NR; i++) {
+		/* Alternate targets for object creation */
+		if (i % 2 == 0)
+			failed_tgt = 0;
+		else
+			failed_tgt = 1;
+		oids[i] = dts_oid_gen(DAOS_OC_R2S_SPEC_RANK, 0, arg->myrank);
+		oids[i] = dts_oid_set_rank(oids[i], ranks_to_kill[0]);
+		oids[i] = dts_oid_set_tgt(oids[i], failed_tgt);
+		print_message("Object %d created\n", i);
+		print_message("oid:"DF_U64"."DF_U64", rank:%d, tgt:%d\n",
+			      oids[i].hi, oids[i].lo, ranks_to_kill[0],
+			      failed_tgt);
+		/* Get object layout */
+		rebuild_get_obj_layout(arg, oids[i]);
+	}
+	rebuild_io(arg, oids, OBJ_NR);
+
+	arg->rebuild_pre_cb = rebuild_pool_disconnect_internal;
+	arg->rebuild_post_cb = rebuild_pool_connect_internal;
+
+	rebuild_targets(&arg, 1, ranks_to_kill, NULL, 1, true);
+
+	arg->rebuild_pre_cb = NULL;
+	arg->rebuild_post_cb = NULL;
+
+	rebuild_io_validate(arg, oids, OBJ_NR, false);
+
+	/* Get final object layout */
+	for (i = 0; i < OBJ_NR; i++) {
+		print_message("oid:"DF_U64"."DF_U64" layout:\n",
+			      oids[i].hi, oids[i].lo);
+		rebuild_get_obj_layout(arg, oids[i]);
+	}
+}
+
+static void
+rebuild_partial_node(void **state)
+{
+	test_arg_t	*arg = *state;
+	daos_obj_id_t	oids[OBJ_NR];
+	unsigned int	required_nodes = 3;
+	int		failed_tgt = 0;
+	int		i;
+
+	if (!test_runable(arg, required_nodes))
+		return;
+
+	print_message("%u server nodes, 2-way object replica, %d objects\n",
+		      required_nodes, OBJ_NR);
+
+	for (i = 0; i < OBJ_NR; i++) {
+		/* Alternate targets for object creation */
+		if (i % 2 == 0)
+			failed_tgt = 0;
+		else
+			failed_tgt = 1;
+		oids[i] = dts_oid_gen(DAOS_OC_R2S_SPEC_RANK, 0, arg->myrank);
+		oids[i] = dts_oid_set_rank(oids[i], ranks_to_kill[0]);
+		oids[i] = dts_oid_set_tgt(oids[i], failed_tgt);
+		print_message("Object %d created\n", i);
+		print_message("oid:"DF_U64"."DF_U64", rank:%d, tgt:%d\n",
+			      oids[i].hi, oids[i].lo, ranks_to_kill[0],
+			      failed_tgt);
+		/* Get object layout */
+		rebuild_get_obj_layout(arg, oids[i]);
+	}
+	rebuild_io(arg, oids, OBJ_NR);
+
+	arg->rebuild_pre_cb = rebuild_pool_disconnect_internal;
+	arg->rebuild_post_cb = rebuild_pool_connect_internal;
+
+	rebuild_targets(&arg, 1, ranks_to_kill, &failed_tgt, 1, false);
+
+	arg->rebuild_pre_cb = NULL;
+	arg->rebuild_post_cb = NULL;
+
+	rebuild_io_validate(arg, oids, OBJ_NR, false);
+
+	/* Get final object layout */
+	for (i = 0; i < OBJ_NR; i++) {
+		print_message("oid:"DF_U64"."DF_U64" layout:\n",
+			      oids[i].hi, oids[i].lo);
+		rebuild_get_obj_layout(arg, oids[i]);
+	}
+}
+
+/** create a new pool/container for each test */
+static const struct CMUnitTest demo_rebuild_tests[] = {
+	{"REBUILD_DEMO1: single storage target failure rebuild",
+	rebuild_partial_node, NULL, test_case_teardown},
+	{"REBUILD_DEMO2: full server node failure rebuild",
+	rebuild_full_node, NULL, test_case_teardown},
+
+};
+
+int
+demo_rebuild_setup(void **state)
+{
+	return test_setup(state, SETUP_CONT_CONNECT, true, REBUILD_POOL_SIZE,
+			  NULL);
+}
+
+int
+run_daos_demo_rebuild_test(int rank, int size, int *sub_tests, int sub_tests_size)
+{
+	int rc = 0;
+
+	MPI_Barrier(MPI_COMM_WORLD);
+	if (sub_tests_size == 0) {
+		sub_tests_size = ARRAY_SIZE(demo_rebuild_tests);
+		sub_tests = NULL;
+	}
+
+	rc = run_daos_sub_tests(demo_rebuild_tests, ARRAY_SIZE(demo_rebuild_tests),
+				REBUILD_POOL_SIZE, sub_tests, sub_tests_size,
+				NULL, NULL);
+
+	MPI_Barrier(MPI_COMM_WORLD);
+
+	return rc;
+}

--- a/src/tests/suite/daos_test.c
+++ b/src/tests/suite/daos_test.c
@@ -30,8 +30,8 @@
 #include "daos_test.h"
 
 /** All tests in default order (tests that kill nodes must be last) */
-static const char *all_tests = "mpceiACoROdr";
-static const char *all_tests_defined = "mpceixACoROdr";
+static const char *all_tests = "mpceiACoROdrD";
+static const char *all_tests_defined = "mpceixACoROdrD";
 
 static void
 print_usage(int rank)
@@ -41,6 +41,7 @@ print_usage(int rank)
 
 	print_message("\n\nDAOS TESTS\n=============================\n");
 	print_message("Use one of these options(s) for specific test\n");
+	print_message("daos_test -D| --demo (for DIO-9 demo rebuild tests)\n");
 	print_message("daos_test -m|--mgmt\n");
 	print_message("daos_test -p|--daos_pool_tests\n");
 	print_message("daos_test -c|--daos_container_tests\n");
@@ -154,6 +155,14 @@ run_specified_tests(const char *tests, int rank, int size,
 							   sub_tests,
 							   sub_tests_size);
 			break;
+		case 'D':
+			daos_test_print(rank, "\n\n=================");
+			daos_test_print(rank, "DAOS DIO-9 demo rebuild tests..");
+			daos_test_print(rank, "=================");
+			nr_failed += run_daos_demo_rebuild_test(rank, size,
+								sub_tests,
+								sub_tests_size);
+			break;
 		default:
 			D_ASSERT(0);
 		}
@@ -189,6 +198,7 @@ main(int argc, char **argv)
 
 	static struct option long_options[] = {
 		{"all",		no_argument,		NULL,	'a'},
+		{"demo",	no_argument,		NULL,	'D'},
 		{"mgmt",	no_argument,		NULL,	'm'},
 		{"pool",	no_argument,		NULL,	'p'},
 		{"cont",	no_argument,		NULL,	'c'},
@@ -219,7 +229,7 @@ main(int argc, char **argv)
 
 	memset(tests, 0, sizeof(tests));
 
-	while ((opt = getopt_long(argc, argv, "ampcCdixAeoROg:s:u:E:w:W:hr",
+	while ((opt = getopt_long(argc, argv, "aDmpcCdixAeoROg:s:u:E:w:W:hr",
 				  long_options, &index)) != -1) {
 		if (strchr(all_tests_defined, opt) != NULL) {
 			tests[ntests] = opt;

--- a/src/tests/suite/daos_test.h
+++ b/src/tests/suite/daos_test.h
@@ -258,6 +258,7 @@ int run_daos_md_replication_test(int rank, int size);
 int run_daos_oid_alloc_test(int rank, int size);
 int run_daos_degraded_test(int rank, int size);
 int run_daos_rebuild_test(int rank, int size, int *tests, int test_size);
+int run_daos_demo_rebuild_test(int rank, int size, int *tests, int test_size);
 
 void daos_kill_server(test_arg_t *arg, const uuid_t pool_uuid, const char *grp,
 		      d_rank_list_t *svc, d_rank_t rank);
@@ -383,7 +384,7 @@ daos_sync_ranks(MPI_Comm comm)
 	}
 }
 
-#define MAX_KILLS	3
+#define MAX_KILLS	1
 extern d_rank_t ranks_to_kill[MAX_KILLS];
 d_rank_t test_get_last_svr_rank(test_arg_t *arg);
 

--- a/src/utils/dmg.c
+++ b/src/utils/dmg.c
@@ -670,10 +670,12 @@ obj_op_hdlr(int argc, char *argv[])
 		struct daos_obj_shard *shard;
 
 		shard = layout->ol_shards[i];
-		fprintf(stdout, "grp: %d\n", i);
+		fprintf(stdout, "grp: %d replica %d\n", i,
+			shard->os_replica_nr);
 		for (j = 0; j < shard->os_replica_nr; j++)
-			fprintf(stdout, "replica %d %d\n", j,
-				shard->os_ranks[j]);
+			fprintf(stdout, "i:%d rank: %d tgt_id: %d\n",
+				j, shard->os_ids[j].ti_rank,
+				shard->os_ids[j].ti_tgt);
 	}
 
 	daos_obj_layout_free(layout);


### PR DESCRIPTION
3 servers, 2 AIO devs per server

# Rebuild Demo Test 1: Partial storage failure test
A single AIO device failure and automatic rebuild. Objects
created on rank 2 w/ 2-way replica on another server (4 objects
created - 2 per target); Single AIO device/target goes down and
only objects on that single target will get rebuilt on additional server.

# Rebuild Demo Test 2: Full node failure test
A single server node goes offline and automatic rebuild. Objects
created on rank 2 w/ 2-way replica on another server (4 objects
created - 2 per target); Rank 2 gets killed and all objects on all
targets on that rank get rebuilt on additional server.

***Each test creates a new pool/container

Option to run DIO-9 demo rebuild tests is now daos_test -D or --demo
This avoids having to make changes/comment out most of the tests
in daos_rebuild.c

Before Test Setup:
----------------------
- Create 2 AIO devices backed by files
	$mkdir /mnt/daos/smvanda
	$dd if=/dev/zero of=/mnt/daos/smvanda/aio_file1 bs=1G count=20
	$dd if=/dev/zero of=/mnt/daos/smvanda/aio_file2 bs=1G count=30
- Disable ASLR - Address Space Layout Randomization
	(as root) $echo 0 | tee /proc/sys/kernel/randomize_va_space
- Update configuration yml for control plane (generates nvme.conf)
	If emulating NVMe SSD with backend file:
	bdev_class: file # map to VOS_BDEV_CLASS=AIO
	bdev_size: 20 # file size in GB. Create file if does not exist.
	bdev_list: [/mnt/daos/smvanda/aio_file1,/mnt/daos/smvanda/aio_file2]

Run Test:
-------------
- Start DAOS servers:
	$orterun -np 3 --hostfile $hostfile --enable-recovery
		--report-uri uri.txt daos_server -t 2 -d /tmp/
		-o $config_yml_file
- Run DAOS demo rebuild tests
	$daos_agent -runtime_dir /tmp/ &
		$orterun -np 1 -x DAOS_AGENT_DRPC_DIR=/tmp/
		--ompi-server file:uri.txt daos_test --demo

Additional updates to daos_test output:
------------------------------------------
- DAOS servers now print the hostname associated with each rank when started
	"DAOS I/O server (v0.4.0) process 5640 started on rank 0
	[boro-51.boro.hpdd.intel.com] (out of 3) with 2 target xstream set(s)..."
- Object layout printed during tests (both before and after)
	Similar to "$dmg layout" output
- SPDK IO Stats will not print the device hostname with device name
	"SPDK IO STAT: xs_id[1] dev[AIO_boro-51.boro.hpdd.intel.com_1]"
	"SPDK IO STAT: xs_id[4] dev[AIO_boro-51.boro.hpdd.intel.com_0]"
	(previously):
	"SPDK IO STAT: xs_id[1] dev[AIO0]"
	"SPDK IO STAT: xs_id[1] dev[AIO1]"
	*** PR: #265

Signed-off-by: Sydney Vanda <sydney.m.vanda@intel.com>