### PR TITLE
DAOS-2268 dRPC: Change dRPC Environment Variable to only take directory

### DIFF
--- a/src/client/api/agent.c
+++ b/src/client/api/agent.c
@@ -29,19 +29,15 @@ char *dc_agent_sockpath;
 int
 dc_agent_init()
 {
-	int	ret;
 	char	*path = NULL;
 	char	*envpath = getenv(DAOS_AGENT_DRPC_DIR_ENV);
 
 	if (envpath == NULL) {
-		path = strndup(DEFAULT_DAOS_AGENT_DRPC_SOCK,
+		D_STRNDUP(path, DEFAULT_DAOS_AGENT_DRPC_SOCK,
 				sizeof(DEFAULT_DAOS_AGENT_DRPC_SOCK));
 	} else {
-		ret = asprintf(&path, "%s/%s", envpath,
+		D_ASPRINTF(path, "%s/%s", envpath,
 				DAOS_AGENT_DRPC_SOCK_NAME);
-		if (ret < 0) {
-			path = NULL;
-		}
 	}
 
 	if (path == NULL) {

--- a/src/client/api/agent.c
+++ b/src/client/api/agent.c
@@ -1,0 +1,64 @@
+/*
+ * (C) Copyright 2019 Intel Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * GOVERNMENT LICENSE RIGHTS-OPEN SOURCE SOFTWARE
+ * The Government's rights to use, modify, reproduce, release, perform, display,
+ * or disclose this software are subject to the terms of the Apache License as
+ * provided in Contract No. 8F-30005.
+ * Any reproduction of computer software, computer software documentation, or
+ * portions thereof marked with this legend must also reproduce the markings.
+ */
+
+#include <stdlib.h>
+#include <daos/agent.h>
+
+char* dc_agent_sockpath;
+
+int
+dc_agent_init()
+{
+	int	ret;
+	char	*path = NULL;
+	char	*envpath = getenv(DAOS_AGENT_DRPC_DIR_ENV);
+
+	if (envpath == NULL) {
+		path = strndup(DEFAULT_DAOS_AGENT_DRPC_SOCK,
+				sizeof(DEFAULT_DAOS_AGENT_DRPC_SOCK));
+		if (path == NULL) {
+			path = NULL;
+		}
+	} else {
+
+		ret = asprintf(&path, "%s/%s", envpath,
+				DAOS_AGENT_DRPC_SOCK_NAME);
+		if ( ret < 0) {
+			path = NULL;
+		}
+	}
+
+	if (path == NULL) {
+		return DER_NOMEM;
+	}
+
+	dc_agent_sockpath = path;
+	return 0;
+}
+
+void
+dc_agent_fini()
+{
+	free(dc_agent_sockpath);
+	dc_agent_sockpath = NULL;
+}

--- a/src/client/api/agent.c
+++ b/src/client/api/agent.c
@@ -36,11 +36,7 @@ dc_agent_init()
 	if (envpath == NULL) {
 		path = strndup(DEFAULT_DAOS_AGENT_DRPC_SOCK,
 				sizeof(DEFAULT_DAOS_AGENT_DRPC_SOCK));
-		if (path == NULL) {
-			path = NULL;
-		}
 	} else {
-
 		ret = asprintf(&path, "%s/%s", envpath,
 				DAOS_AGENT_DRPC_SOCK_NAME);
 		if (ret < 0) {
@@ -49,6 +45,7 @@ dc_agent_init()
 	}
 
 	if (path == NULL) {
+		D_ERROR("Unable to allocate dc_agent_sockpath.");
 		return DER_NOMEM;
 	}
 
@@ -59,6 +56,5 @@ dc_agent_init()
 void
 dc_agent_fini()
 {
-	free(dc_agent_sockpath);
-	dc_agent_sockpath = NULL;
+	D_FREE(dc_agent_sockpath);
 }

--- a/src/client/api/agent.c
+++ b/src/client/api/agent.c
@@ -24,7 +24,7 @@
 #include <stdlib.h>
 #include <daos/agent.h>
 
-char* dc_agent_sockpath;
+char *dc_agent_sockpath;
 
 int
 dc_agent_init()
@@ -43,7 +43,7 @@ dc_agent_init()
 
 		ret = asprintf(&path, "%s/%s", envpath,
 				DAOS_AGENT_DRPC_SOCK_NAME);
-		if ( ret < 0) {
+		if (ret < 0) {
 			path = NULL;
 		}
 	}

--- a/src/client/api/agent.c
+++ b/src/client/api/agent.c
@@ -46,7 +46,7 @@ dc_agent_init()
 
 	if (path == NULL) {
 		D_ERROR("Unable to allocate dc_agent_sockpath.");
-		return DER_NOMEM;
+		return -DER_NOMEM;
 	}
 
 	dc_agent_sockpath = path;

--- a/src/client/api/init.c
+++ b/src/client/api/init.c
@@ -25,6 +25,7 @@
  */
 #define D_LOGFAC	DD_FAC(client)
 
+#include <daos/agent.h>
 #include <daos/common.h>
 #include <daos/event.h>
 #include <daos/mgmt.h>
@@ -165,9 +166,15 @@ daos_init(void)
 	if (rc != 0)
 		D_GOTO(out_co, rc);
 
+	/** set up agent */
+	rc = dc_agent_init();
+	if (rc != 0)
+		D_GOTO(out_obj, rc);
+
 	module_initialized = true;
 	D_GOTO(unlock, rc = 0);
 
+out_obj:
 	dc_obj_fini();
 out_co:
 	dc_cont_fini();
@@ -208,6 +215,7 @@ daos_fini(void)
 	dc_cont_fini();
 	dc_pool_fini();
 	dc_mgmt_fini();
+	dc_agent_fini();
 
 	daos_hhash_fini();
 	daos_debug_fini();

--- a/src/client/api/tests/SConscript
+++ b/src/client/api/tests/SConscript
@@ -8,6 +8,9 @@ def scons():
     daos_build.test(denv, 'eq_tests', Glob('eq_tests.c'),
                     LIBS=['daos', 'daos_common', 'gurt', 'cart',
                           'pthread', 'cmocka'])
+    daos_build.test(denv, 'agent_tests', Glob('agent_tests.c'),
+                    LIBS=['daos', 'daos_common', 'gurt', 'cart',
+                          'pthread', 'cmocka'])
 
 if __name__ == "SCons.Script":
     scons()

--- a/src/client/api/tests/agent_tests.c
+++ b/src/client/api/tests/agent_tests.c
@@ -1,0 +1,123 @@
+/**
+ * (C) Copyright 2018-2019 Intel Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * GOVERNMENT LICENSE RIGHTS-OPEN SOURCE SOFTWARE
+ * The Government's rights to use, modify, reproduce, release, perform, display,
+ * or disclose this software are subject to the terms of the Apache License as
+ * provided in Contract No. B609815.
+ * Any reproduction of computer software, computer software documentation, or
+ * portions thereof marked with this legend must also reproduce the markings.
+ */
+
+/**
+ * Unit tests for the security API for the client lib
+ */
+
+#include <stdarg.h>
+#include <stdlib.h>
+#include <setjmp.h>
+#include <cmocka.h>
+#include <daos_types.h>
+#include <daos_errno.h>
+#include <daos/common.h>
+#include <daos/agent.h>
+#include <string.h>
+
+/*
+ * Mocks
+ */
+
+static char *getenv_return; /* value to be returned */
+static const char *getenv_name; /* saved input */
+char *getenv(const char *name)
+{
+	getenv_name = name;
+	return getenv_return;
+}
+
+/*
+ * Unit test setup and teardown
+ */
+
+static int
+setup_agent_mocks(void **state)
+{
+	/* Initialize mock values to something sane */
+	getenv_return = NULL;
+	getenv_name = NULL;
+
+	return 0;
+}
+
+static int
+teardown_agent_mocks(void **state)
+{
+	return 0;
+}
+
+/*
+ * Client lib agent function tests
+ */
+static void
+test_dc_agent_init_no_env(void **state)
+{
+	dc_agent_init();
+	/* Tried to connect to the path we got back from getenv */
+	assert_string_equal(dc_agent_sockpath, DEFAULT_DAOS_AGENT_DRPC_SOCK);
+
+	/* Make sure we asked for the right env variable */
+	assert_non_null(getenv_name);
+	assert_string_equal(getenv_name, DAOS_AGENT_DRPC_DIR_ENV);
+
+	dc_agent_fini();
+}
+
+static void
+test_dc_agent_init_with_env(void **state)
+{
+	char *sockaddr = "/nice/good/agent.sock";
+	getenv_return = "/nice/good";
+
+	dc_agent_init();
+	/* Tried to connect to the path we got back from getenv */
+	assert_string_equal(dc_agent_sockpath, sockaddr);
+
+	/* Make sure we asked for the right env variable */
+	assert_non_null(getenv_name);
+	assert_string_equal(getenv_name, DAOS_AGENT_DRPC_DIR_ENV);
+
+	dc_agent_fini();
+}
+
+
+/* Convenience macro for declaring unit tests in this suite */
+#define AGENT_UTEST(X) \
+	cmocka_unit_test_setup_teardown(X, setup_agent_mocks, \
+			teardown_agent_mocks)
+
+int
+main(void)
+{
+	const struct CMUnitTest tests[] = {
+		AGENT_UTEST(
+			test_dc_agent_init_no_env),
+		AGENT_UTEST(
+			test_dc_agent_init_with_env),
+	};
+
+	return cmocka_run_group_tests(tests, NULL, NULL);
+}
+
+#undef AGENT_UTEST

--- a/src/client/api/tests/agent_tests.c
+++ b/src/client/api/tests/agent_tests.c
@@ -22,7 +22,7 @@
  */
 
 /**
- * Unit tests for the security API for the client lib
+ * Unit tests for the agent API for the client lib
  */
 
 #include <stdarg.h>
@@ -87,13 +87,13 @@ test_dc_agent_init_no_env(void **state)
 static void
 test_dc_agent_init_with_env(void **state)
 {
-	char *sockaddr = "/nice/good/agent.sock";
+	char *expected_sockaddr = "/nice/good/agent.sock";
 
 	getenv_return = "/nice/good";
 
 	dc_agent_init();
 	/* Tried to connect to the path we got back from getenv */
-	assert_string_equal(dc_agent_sockpath, sockaddr);
+	assert_string_equal(dc_agent_sockpath, expected_sockaddr);
 
 	/* Make sure we asked for the right env variable */
 	assert_non_null(getenv_name);

--- a/src/client/api/tests/agent_tests.c
+++ b/src/client/api/tests/agent_tests.c
@@ -88,6 +88,7 @@ static void
 test_dc_agent_init_with_env(void **state)
 {
 	char *sockaddr = "/nice/good/agent.sock";
+
 	getenv_return = "/nice/good";
 
 	dc_agent_init();

--- a/src/include/daos/agent.h
+++ b/src/include/daos/agent.h
@@ -34,7 +34,7 @@
 /**
  * Environment variable for specifying an alternate dRPC socket path
  */
-#define DAOS_AGENT_DRPC_SOCK_ENV "DAOS_AGENT_DRPC_SOCK"
+#define DAOS_AGENT_DRPC_DIR_ENV "DAOS_AGENT_DRPC_DIR"
 
 /**
  * dRPC definitions for DAOS agent.

--- a/src/include/daos/agent.h
+++ b/src/include/daos/agent.h
@@ -26,15 +26,30 @@
 
 #include <daos/drpc.h>
 
-/**
- * Default Unix Domain Socket path for the DAOS agent dRPC connection
- */
-#define DEFAULT_DAOS_AGENT_DRPC_SOCK "/var/run/daos_agent/agent.sock"
+int dc_agent_init(void);
+void dc_agent_fini(void);
 
+extern char *dc_agent_sockpath;
+
+/**
+ * Default runtime directory for daos_agent
+ */
+#define DAOS_AGENT_DRPC_DIR "/var/run/daos_agent/"
 /**
  * Environment variable for specifying an alternate dRPC socket path
  */
 #define DAOS_AGENT_DRPC_DIR_ENV "DAOS_AGENT_DRPC_DIR"
+
+/**
+ * Socket name used to craft path from environment variable
+ */
+#define DAOS_AGENT_DRPC_SOCK_NAME "agent.sock"
+
+/**
+ * Default Unix Domain Socket path for the DAOS agent dRPC connection
+ */
+#define DEFAULT_DAOS_AGENT_DRPC_SOCK 	DAOS_AGENT_DRPC_DIR \
+					DAOS_AGENT_DRPC_SOCK_NAME
 
 /**
  * dRPC definitions for DAOS agent.

--- a/src/include/daos/agent.h
+++ b/src/include/daos/agent.h
@@ -26,15 +26,26 @@
 
 #include <daos/drpc.h>
 
+/**
+ *  Called during libray initialization to craft socket path for agent.
+ */
 int dc_agent_init(void);
+
+/**
+ *  Called during library finalization to free allocated agent resources
+ */
 void dc_agent_fini(void);
 
+/**
+ * Path to be used to communicate with the DAOS Agent set at library init.
+ */
 extern char *dc_agent_sockpath;
 
 /**
  * Default runtime directory for daos_agent
  */
 #define DAOS_AGENT_DRPC_DIR "/var/run/daos_agent/"
+
 /**
  * Environment variable for specifying an alternate dRPC socket path
  */

--- a/src/include/daos/agent.h
+++ b/src/include/daos/agent.h
@@ -48,8 +48,8 @@ extern char *dc_agent_sockpath;
 /**
  * Default Unix Domain Socket path for the DAOS agent dRPC connection
  */
-#define DEFAULT_DAOS_AGENT_DRPC_SOCK 	DAOS_AGENT_DRPC_DIR \
-					DAOS_AGENT_DRPC_SOCK_NAME
+#define DEFAULT_DAOS_AGENT_DRPC_SOCK	(DAOS_AGENT_DRPC_DIR \
+					DAOS_AGENT_DRPC_SOCK_NAME)
 
 /**
  * dRPC definitions for DAOS agent.

--- a/src/security/cli_security.c
+++ b/src/security/cli_security.c
@@ -66,10 +66,18 @@ request_credentials_via_drpc(Drpc__Response **response)
 	Drpc__Call	*request;
 	struct drpc	*agent_socket;
 	int		rc;
+	char		*sock_path;
 
-	agent_socket = drpc_connect(get_agent_socket_path());
+	sock_path = get_agent_socket_path();
+	if (sock_path == NULL) {
+		D_ERROR("Unable to craft DRPC socket path\n");
+		return -DER_BADPATH;
+	}
+
+	agent_socket = drpc_connect(sock_path);
 	if (agent_socket == NULL) {
 		D_ERROR("Can't connect to agent socket\n");
+		free(sock_path);
 		return -DER_BADPATH;
 	}
 
@@ -79,6 +87,7 @@ request_credentials_via_drpc(Drpc__Response **response)
 	if (request == NULL) {
 		D_ERROR("Couldn't allocate dRPC call\n");
 		drpc_close(agent_socket);
+		free(sock_path);
 		return -DER_NOMEM;
 	}
 
@@ -86,19 +95,28 @@ request_credentials_via_drpc(Drpc__Response **response)
 
 	drpc_close(agent_socket);
 	drpc_call_free(request);
+	free(sock_path);
 	return rc;
 }
 
 static char *
 get_agent_socket_path(void)
 {
+	char *path = NULL;
 	/*
 	 * UDS path may be set in an environment variable.
 	 */
-	char *path = getenv(DAOS_AGENT_DRPC_SOCK_ENV);
+	char *envpath = getenv(DAOS_AGENT_DRPC_DIR_ENV);
 
-	if (path == NULL) {
+	if (envpath == NULL) {
 		path = DEFAULT_DAOS_AGENT_DRPC_SOCK;
+	}
+
+	/*
+	 * Craft our socket path from the directory.
+	 */
+	if (asprintf(&path, "%s/agent.sock", envpath) < 0) {
+		path = NULL;
 	}
 
 	return path;

--- a/src/security/cli_security.c
+++ b/src/security/cli_security.c
@@ -67,8 +67,8 @@ request_credentials_via_drpc(Drpc__Response **response)
 	int		rc;
 
 	if (dc_agent_sockpath == NULL) {
-		D_ERROR("Unable to craft DRPC socket path\n");
-		return -DER_BADPATH;
+		D_ERROR("DAOS Socket Path is Unitialized\n");
+		return -DER_UNINIT;
 	}
 
 	agent_socket = drpc_connect(dc_agent_sockpath);

--- a/src/security/tests/cli_security_tests.c
+++ b/src/security/tests/cli_security_tests.c
@@ -77,6 +77,8 @@ static Drpc__Response *drpc_call_resp_return_ptr;
 static Drpc__Response drpc_call_resp_return_content;
 /* unpacked content of response body */
 static SecurityCredential *drpc_call_resp_return_security_credential;
+char *dc_agent_sockpath;
+
 int
 drpc_call(struct drpc *ctx, int flags, Drpc__Call *msg,
 		Drpc__Response **resp)
@@ -205,6 +207,7 @@ setup_security_mocks(void **state)
 	/* Initialize mock values to something sane */
 	getenv_return = NULL;
 	getenv_name = NULL;
+	dc_agent_sockpath = DEFAULT_DAOS_AGENT_DRPC_SOCK;
 
 	D_ALLOC_PTR(drpc_connect_return);
 	memset(drpc_connect_sockaddr, 0, sizeof(drpc_connect_sockaddr));
@@ -282,26 +285,6 @@ test_request_credentials_connects_to_default_socket(void **state)
 
 	assert_string_equal(drpc_connect_sockaddr,
 			DEFAULT_DAOS_AGENT_DRPC_SOCK);
-
-	daos_iov_free(&creds);
-}
-
-static void
-test_request_credentials_connects_to_env_socket(void **state)
-{
-	daos_iov_t creds;
-
-	memset(&creds, 0, sizeof(daos_iov_t));
-	getenv_return = "/nice/good/wonderful.sock";
-
-	dc_sec_request_creds(&creds);
-
-	/* Tried to connect to the path we got back from getenv */
-	assert_string_equal(drpc_connect_sockaddr, getenv_return);
-
-	/* Make sure we asked for the right env variable */
-	assert_non_null(getenv_name);
-	assert_string_equal(getenv_name, DAOS_AGENT_DRPC_DIR_ENV);
 
 	daos_iov_free(&creds);
 }
@@ -482,8 +465,6 @@ main(void)
 			test_request_credentials_fails_if_drpc_connect_fails),
 		SECURITY_UTEST(
 			test_request_credentials_connects_to_default_socket),
-		SECURITY_UTEST(
-			test_request_credentials_connects_to_env_socket),
 		SECURITY_UTEST(
 			test_request_credentials_fails_if_drpc_call_fails),
 		SECURITY_UTEST(

--- a/src/security/tests/cli_security_tests.c
+++ b/src/security/tests/cli_security_tests.c
@@ -301,7 +301,7 @@ test_request_credentials_connects_to_env_socket(void **state)
 
 	/* Make sure we asked for the right env variable */
 	assert_non_null(getenv_name);
-	assert_string_equal(getenv_name, DAOS_AGENT_DRPC_SOCK_ENV);
+	assert_string_equal(getenv_name, DAOS_AGENT_DRPC_DIR_ENV);
 
 	daos_iov_free(&creds);
 }

--- a/src/tests/security/SConscript
+++ b/src/tests/security/SConscript
@@ -4,9 +4,9 @@ def scons():
     """Execute build"""
     Import('env', 'prereqs', 'dc_sectest_tgts', 'dc_security_tgts')
 
-    libs = ['gurt', 'daos_common', 'protobuf-c']
+    libs = ['gurt', 'daos', 'daos_common', 'protobuf-c']
     sec_sources = ['security_test.c', dc_sectest_tgts]
-    acl_sources = ['acl_dump_test.c', dc_security_tgts]
+    acl_sources = ['acl_dump_test.c']
 
     denv = env.Clone()
     denv.AppendUnique(CFLAGS=['-std=gnu99'])


### PR DESCRIPTION
The environment variable for daos client library to specify the
alternate DRPC location include the socket name as well. The socket
name isn't configurable so make it so it only takes the directory
and crafts the name.

Signed-off-by: David Quigley <david.quigley@intel.com>