### PR TITLE
DAOS-2169 vos: Add single entry estimate to overhead tool

### DIFF
--- a/src/common/btree.c
+++ b/src/common/btree.c
@@ -3631,6 +3631,7 @@ dbtree_overhead_get(int alloc_overhead, unsigned int tclass, uint64_t ofeat,
 {
 	btr_ops_t	*ops;
 	size_t		 hkey_size;
+	size_t		 btr_size;
 
 	if (ovhd == NULL) {
 		D_ERROR("Invalid ovhd argument\n");
@@ -3651,12 +3652,14 @@ dbtree_overhead_get(int alloc_overhead, unsigned int tclass, uint64_t ofeat,
 	}
 
 	hkey_size = btr_hkey_size_const(ops, ofeat);
+	btr_size = sizeof(struct btr_record) + hkey_size;
 
 	ovhd->to_record_msize = ops->to_rec_msize(alloc_overhead);
+	ovhd->to_single_size = ovhd->to_record_msize + btr_size;
 
 	ovhd->to_order = tree_order;
 	ovhd->to_node_size = alloc_overhead + sizeof(struct btr_node) +
-		(sizeof(struct btr_record) + hkey_size) * tree_order;
+		btr_size * tree_order;
 
 	return 0;
 }

--- a/src/include/daos/common.h
+++ b/src/include/daos/common.h
@@ -60,6 +60,8 @@ struct daos_tree_overhead {
 	int			to_node_size;
 	/** Dynamic metadata size of an allocated record. */
 	int			to_record_msize;
+	/** Size of first insertion.  Full node allocated on second key */
+	int			to_single_size;
 	/** Tree order */
 	int			to_order;
 };

--- a/src/include/daos_srv/vos.h
+++ b/src/include/daos_srv/vos.h
@@ -911,4 +911,9 @@ int vos_tree_get_overhead(int alloc_overhead, enum VOS_TREE_CLASS tclass,
 /** Return the size of the pool metadata in persistent memory on-disk format */
 int vos_pool_get_msize(void);
 
+/** Return the cutoff size for SCM allocation.  Larger blocks are allocated to
+ *  NVME.
+ */
+int vos_pool_get_scm_cutoff(void);
+
 #endif /* __VOS_API_H */

--- a/src/vos/evtree.c
+++ b/src/vos/evtree.c
@@ -2928,6 +2928,8 @@ int evt_overhead_get(int alloc_overhead, int tree_order,
 	}
 
 	ovhd->to_record_msize = alloc_overhead + sizeof(struct evt_desc);
+	ovhd->to_single_size = alloc_overhead + sizeof(struct evt_desc) +
+		sizeof(struct evt_node_entry);
 	ovhd->to_node_size = alloc_overhead + sizeof(struct evt_node) +
 		(tree_order * sizeof(struct evt_node_entry));
 	ovhd->to_order = tree_order;

--- a/src/vos/tests/parse_csv.py
+++ b/src/vos/tests/parse_csv.py
@@ -1,0 +1,261 @@
+#!/usr/bin/env python
+'''
+  (C) Copyright 2019 Intel Corporation.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+  GOVERNMENT LICENSE RIGHTS-OPEN SOURCE SOFTWARE
+  The Government's rights to use, modify, reproduce, release, perform, display,
+  or disclose this software are subject to the terms of the Apache License as
+  provided in Contract No. B609815.
+  Any reproduction of computer software, computer software documentation, or
+  portions thereof marked with this legend must also reproduce the markings.
+
+  Takes customer csv data and parses it.  Mostly checking in for backup purpose
+'''
+import sys
+
+FILE_SIZES = ['4k', '64k', '128k', '256k', '512k', '768k', '1m', '8m', '64m',
+              '128m', '1g', '10g', '100g', '250g', '500g', '1t', '10t', '100t']
+
+def split(array, indent):
+    """Split an array into a pretty string"""
+    last = array[-1]
+    full_str = ""
+    mystr = ""
+    while array:
+        if array[0] == last:
+            thisstr = array[0]
+        else:
+            thisstr = "%s, " % array[0]
+        if (len(mystr) + len(thisstr)) > (80 - indent):
+            full_str = full_str + "%*s" % (indent, " ") + mystr.strip() + "\n"
+            mystr = ""
+            continue
+        mystr = mystr + thisstr
+        array = array[1:]
+    return full_str + "%*s" % (indent, " ") + mystr.strip()
+
+def produce_results(args, file_histo, dir_histo):
+    """Produce yaml file"""
+    with open(args.output, "w") as yaml_file:
+        yaml_file.write("---\n# Generated file data\n")
+        yaml_file.write("""# Assumptions:
+# Average file name size: {0}
+# Average link size:      {1}
+# Chunk size:             {2}
+# I/O size:               {3}
+num_pools: {4}
+# File timestamps
+time_key: &time
+  count: 3
+  size: 5
+  overhead: meta
+  value_type: single_value
+  values: [{{"overhead": "meta", "count": 3, "size": 8}}]
+
+# Object ID key
+oid_key: &oid
+  size: 3
+  overhead: meta
+  value_type: single_value
+  values: [{{"overhead": "meta", "size": 16}}]
+
+# File mode
+mode_key: &mode
+  size: 4
+  overhead: meta
+  value_type: single_value
+  values: [{{"overhead": "meta", "size": 4}}]
+
+# symlink.  Hard coded to average length of {1} bytes
+link_key: &link
+  size: 4
+  overhead: meta
+  value_type: single_value
+  values: [{{"size": {1}}}]
+
+# File directory entry.  Hard coded filename length {0} bytes
+file_dirent_key: &file_dirent
+  count: {5}
+  size: {0}
+  akeys: [*time, *oid, *mode]
+
+# File directory entry.  Hard coded filename length {0} bytes
+link_dirent_key: &link_dirent
+  count: {6}
+  size: {0}
+  akeys: [*time, *mode, *link]
+
+# Directory
+dir_obj: &dir
+  count: {7}
+  dkeys: [*file_dirent, *link_dirent]
+
+# Array metadata for file data
+array_meta: &file_meta
+  size: 19
+  overhead: meta
+  value_type: single_value
+  values: [{{"overhead": "meta", "size": 24}}]
+
+""".format(args.name, args.link, args.chunk_size, args.io_size, args.num_pools,
+           dir_histo["avgfiles"], dir_histo["avglink"], dir_histo["count"]))
+        obj = ["*dir"]
+        full_chunk_writes = args.chunk_size / args.io_size
+        for size in file_histo.keys():
+            num_chunks = file_histo[size]["avgsize"] / args.chunk_size
+            remainder = file_histo[size]["avgsize"] % args.chunk_size
+            yaml_file.write("# Files in %s bucket\n" % size)
+            num_full = 0
+            num_partial = 0
+            if num_chunks:
+                num_full = num_chunks - 1
+                yaml_file.write("""{0}_array_akey: &{0}_file_data
+  size: 1
+  overhead: meta
+  value_type: array
+  values: [{{"count": {1}, "size": {2}}}]
+
+""".format(size, full_chunk_writes, args.io_size))
+                dkey0_akey = "*%s_file_data" % size
+            if remainder:
+                if num_chunks:
+                    num_partial = 1
+                else:
+                    dkey0_akey = "*%s_file_tail" % size
+                last_count = remainder / args.io_size
+                last_partial = remainder % args.io_size
+                lst_val = []
+                if last_count:
+                    lst_val.append('{"count": %d, "size": %d}' % (last_count,
+                                                                  args.io_size))
+                if last_partial:
+                    lst_val.append('{"count": 1, "size": %d}' % (last_partial))
+                yaml_file.write("""{0}_array_akey_tail: &{0}_file_tail
+  size: 1
+  overhead: meta
+  value_type: array
+  values: [
+{1}
+  ]
+
+""".format(size, split(lst_val, 4)))
+            yaml_file.write("""{0}_dkey_0: &{0}_dkey0
+  count: 1
+  type: integer
+  akeys: [{1}, *file_meta]
+
+""".format(size, dkey0_akey))
+            dkeys = ["*%s_dkey0" % size]
+            if num_full:
+                dkeys.append("*%s_dkeyfull" % size)
+                yaml_file.write("""{0}_dkey_full: &{0}_dkeyfull
+  count: {1}
+  type: integer
+  akeys: [*{0}_file_data]
+
+""".format(size, num_full))
+
+            if num_partial:
+                dkeys.append("*%s_dkeytail" % size)
+                yaml_file.write("""{0}_dkey_tail: &{0}_dkeytail
+  count: 1
+  type: integer
+  akeys: [*{0}_file_tail]
+
+""".format(size))
+            yaml_file.write("""{0}_file_key: &{0}_file
+  count: {1}
+  dkeys: [
+{2}
+  ]
+
+""".format(size, file_histo[size]["count"], split(dkeys, 4)))
+            obj.append("*%s_file" % size)
+        yaml_file.write("""posix_key: &posix
+  objects: [
+{0}
+  ]
+
+containers: [*posix]
+""".format(split(obj, 4)))
+
+
+def ingest(fname, args):
+    """Parse csv and produce yaml input to vos_size.py"""
+    value_dict = {}
+    with open(fname, "r") as csv_file:
+        idx = 0
+        fields = csv_file.readline().strip().split(',')
+        values = csv_file.readline().strip().split(',')
+        if len(fields) != len(values):
+            print "CSV must provide one row of values that matches fields"
+            print "Number of fields is %d" % len(fields)
+            print "Number of values is %d" % len(values)
+            sys.exit(-1)
+        for name in fields:
+            value_dict[name] = values[idx]
+            idx += 1
+        file_histo = {}
+        for size in FILE_SIZES:
+            num_files = int(value_dict["%s_count" % size])
+            total_size = int(value_dict["%s_size" % size])
+            if num_files != 0:
+                file_histo[size] = {"count": num_files,
+                                    "avgsize": total_size / num_files}
+        dir_count = int(value_dict["dir_count"])
+        link_count = int(value_dict["link_count"])
+        if link_count < dir_count:
+            link_count = dir_count # assume at least one link per dir
+        obj_count = int(value_dict["total_objects"])
+        dir_histo = {"count": dir_count,
+                     "avgfiles": obj_count / dir_count,
+                     "avglink": link_count / dir_count}
+        produce_results(args, file_histo, dir_histo)
+
+def run_main():
+    """Run the program"""
+    import argparse
+
+    parser = argparse.ArgumentParser(description="Estimate VOS Overhead")
+    parser.add_argument('csv', metavar='CSV', type=str, nargs=1,
+                        help='Input CSV (assumes Argonne format)')
+    parser.add_argument('--name-len', type=int, dest="name",
+                        help='Average file name length', default=32)
+    parser.add_argument('--link-len', type=int, dest="link",
+                        help='Average link length', default=32)
+    parser.add_argument('--chunk-size', dest="chunk_size", type=int,
+                        help='Array chunk size.  Must be multiple of I/O size',
+                        default=1048576)
+    parser.add_argument('--num-pools', dest="num_pools", type=int,
+                        help='Number of vos pools', default=1000)
+    parser.add_argument('--io-size', dest="io_size", type=int,
+                        help='I/O size', default=1048576)
+    parser.add_argument('--output', dest="output", type=str,
+                        help='Output file name', default="output.yaml")
+    args = parser.parse_args()
+
+    if args.io_size > args.chunk_size:
+        print "Assuming --io-size set to --chunk-size %d\n" % args.chunk_size
+        args.io_size = args.chunk_size
+
+    if args.chunk_size % args.io_size != 0:
+        print "--chunk-size must be evenly divisble by --io-size"
+        parser.print_help()
+        sys.exit(-1)
+
+    ingest(args.csv[0], args)
+
+if __name__ == "__main__":
+    run_main()

--- a/src/vos/tests/vos_dfs_sample.yaml
+++ b/src/vos/tests/vos_dfs_sample.yaml
@@ -4,19 +4,23 @@ num_pools: 1000
 time_key: &time
   count: 3
   size: 5
+  overhead: meta
   value_type: single_value
   values: [{"count": 3, "size": 8}]
 
 oid_key: &oid
   size: 3
+  overhead: meta
   value_type: single_value
   values: [{"size": 16}]
 
 mode_key: &mode
   size: 4
+  overhead: meta
   value_type: single_value
   values: [{"size": 4}]
 
+# Assumes 16 bytes for file name
 dirent_key: &dirent
   count: 1000000
   size: 16
@@ -27,21 +31,29 @@ dir_obj: &dir
 
 array_akey: &file_data
   size: 1
+  overhead: meta
   value_type: array
-  values: [{"size": 32756}]
+  values: [{"count": 1, "size": 4096}]
 
 array_meta: &file_meta
   size: 19
+  overhead: meta
   value_type: single_value
   values: [{"size": 24}]
 
-file_dkey_key: &file_dkey
+file_dkey_key0: &file_dkey0
+  count: 1
   type: integer
   akeys: [*file_data, *file_meta]
 
+file_dkey_key: &file_dkey
+  count: 1
+  type: integer
+  akeys: [*file_data]
+
 file_key: &file
   count: 1000000
-  dkeys: [*file_dkey]
+  dkeys: [*file_dkey0, *file_dkey]
 
 posix_key: &posix
   objects: [*file, *dir]

--- a/src/vos/tests/vos_size.c
+++ b/src/vos/tests/vos_size.c
@@ -56,12 +56,14 @@
 
 #define TREE_FMT(name, type, feats)		\
 "  " #name ":\n"				\
-"    node_size: %d\n"			\
+"    node_size: %d\n"				\
 "    record_msize: %d\n"			\
+"    single_size: %d\n"				\
 "    order: %d\n"
 
-#define TREE_PRINT(name, type, feats)		\
-	name.to_node_size, name.to_record_msize, name.to_order,
+#define TREE_PRINT(name, type, feats)			\
+	name.to_node_size, name.to_record_msize,	\
+	name.to_single_size, name.to_order,
 
 char *
 alloc_fname(const char *requested)
@@ -166,8 +168,9 @@ main(int argc, char **argv)
 		goto exit_1;
 
 	fprintf(fp, "---\n# VOS tree overheads\ntrees:\n"
-		FOREACH_TYPE(TREE_FMT) "root: %d\n",
-		FOREACH_TYPE(TREE_PRINT) vos_pool_get_msize());
+		FOREACH_TYPE(TREE_FMT) "root: %d\nscm_cutoff: %d\n",
+		FOREACH_TYPE(TREE_PRINT) vos_pool_get_msize(),
+		vos_pool_get_scm_cutoff());
 
 	fclose(fp);
 exit_1:

--- a/src/vos/tests/vos_size_input.yaml
+++ b/src/vos/tests/vos_size_input.yaml
@@ -27,6 +27,7 @@ s1: &sv_example
 # count     No                  Number of identical akeys       1
 # type      No                  Either hashed or integer        hashed
 # size      if type == hashed   Size in bytes of key            N/A
+# overhead  No                  Assign overhead to meta or user user
 # val_type  Yes                 Array or single value           N/A
 # values    Yes                 List of values                  N/A
 a1: &akey1
@@ -46,6 +47,7 @@ a2: &akey2
 # count     No                  Number of identical dkeys       1
 # type      No                  Either hashed or integer        hashed
 # size      if type == hashed   Size in bytes of key            N/A
+# overhead  No                  Assign overhead to meta or user user
 # akeys     Yes                 List of akeys                   N/A
 d1: &dkey_example
   count: 200

--- a/src/vos/vos_overhead.c
+++ b/src/vos/vos_overhead.c
@@ -12,6 +12,12 @@ vos_pool_get_msize(void)
 }
 
 int
+vos_pool_get_scm_cutoff(void)
+{
+	return VOS_BLK_SZ;
+}
+
+int
 vos_tree_get_overhead(int alloc_overhead, enum VOS_TREE_CLASS tclass,
 		      uint64_t ofeat, struct daos_tree_overhead *ovhd)
 {

--- a/utils/run_test.sh
+++ b/utils/run_test.sh
@@ -102,6 +102,8 @@ if [ -d "/mnt/daos" ]; then
     run_test "${SL_PREFIX}/bin/vos_size"
     run_test "${SL_PREFIX}/bin/vos_size.py" \
              "${SL_PREFIX}/etc/vos_size_input.yaml"
+    run_test "${SL_PREFIX}/bin/vos_size.py" \
+             "${SL_PREFIX}/etc/vos_dfs_sample.yaml"
 
     if [ $failed -eq 0 ]; then
         # spit out the magic string that the post build script looks for


### PR DESCRIPTION
To get an idea of what tree optimization will do, add single
entry size to estimator.  Also, add ability to specify that
a key is metadata rather than user data for such things
as array and posix file metadata keys.  Adds SCM size
and fixes a couple of bugs with calculations