### PR TITLE
DAOS-2269 iosrv: add DSS_POOL_FIRST ABT pool

### DIFF
--- a/src/container/srv_target.c
+++ b/src/container/srv_target.c
@@ -583,8 +583,8 @@ ds_cont_local_open(uuid_t pool_uuid, uuid_t cont_hdl_uuid, uuid_t cont_uuid,
 
 		ddra->pool = ds_pool_child_get(hdl->sch_pool);
 		uuid_copy(ddra->co_uuid, cont_uuid);
-		rc = dss_ult_create(ds_dtx_resync, ddra, DSS_ULT_SELF,
-				    dss_get_module_info()->dmi_tgt_id, 0, NULL);
+		rc = dss_ult_create(ds_dtx_resync, ddra, DSS_ULT_DTX_RESYNC,
+				    DSS_TGT_SELF, 0, NULL);
 		if (rc != 0) {
 			ds_pool_child_put(hdl->sch_pool);
 			D_FREE(ddra);

--- a/src/include/daos_srv/daos_server.h
+++ b/src/include/daos_srv/daos_server.h
@@ -226,10 +226,16 @@ struct dss_module {
 	struct dss_drpc_handler	 *sm_drpc_handlers;
 };
 
+/**
+ * DSS_TGT_SELF can be passed to dss_ult_xs to indicate scheduling ULT on
+ * caller's self XS.
+ */
+#define DSS_TGT_SELF	(-1)
+
 /** ULT types to determine on which XS to schedule the ULT */
 enum dss_ult_type {
-	/** To schedule ULT on caller's self XS */
-	DSS_ULT_SELF = 100,
+	/** for dtx_resync */
+	DSS_ULT_DTX_RESYNC = 100,
 	/** forward/dispatch IO request for TX coordinator */
 	DSS_ULT_IOFW,
 	/** EC/checksum/compress computing offload */
@@ -238,12 +244,16 @@ enum dss_ult_type {
 	DSS_ULT_COMPRESS,
 	/** pool service ULT */
 	DSS_ULT_POOL_SRV,
+	/** RDB ULT */
+	DSS_ULT_RDB,
 	/** rebuild ULT such as scanner/puller, status checker etc. */
 	DSS_ULT_REBUILD,
 	/** aggregation ULT */
 	DSS_ULT_AGGREGATE,
 	/** drpc listener ULT */
 	DSS_ULT_DRPC,
+	/** miscellaneous ULT */
+	DSS_ULT_MISC,
 };
 
 int dss_parameters_set(unsigned int key_id, uint64_t value);
@@ -254,8 +264,6 @@ void dss_abt_pool_choose_cb_register(unsigned int mod_id,
 				     dss_abt_pool_choose_cb_t cb);
 int dss_ult_create(void (*func)(void *), void *arg, int ult_type, int tgt_id,
 		   size_t stack_size, ABT_thread *ult);
-int dss_rebuild_ult_create(void (*func)(void *), void *arg, int ult_type,
-			   int tgt_id, size_t stack_size, ABT_thread *ult);
 int dss_ult_create_all(void (*func)(void *), void *arg);
 int dss_ult_create_execute(int (*func)(void *), void *arg,
 			   void (*user_cb)(void *), void *cb_args,
@@ -404,14 +412,18 @@ struct dss_acc_task {
  */
 int dss_acc_offload(struct dss_acc_task *at_args);
 
-/** Different type of ES pools, there are 3 pools for now
+/**
+ * Different type of ES pools, there are 4 pools for now
  *
- *  DSS_POOL_PRIV     Private pool: I/O requests will be added to this pool.
- *  DSS_POOL_SHARE    Shared pool: Other requests and ULT created during
- *                    processing rpc.
- *  DSS_POOL_REBUILD  rebuild pool: pools specially for rebuild tasks.
+ *  DSS_POOL_URGENT	The highest priority pool. ULTs in this pool will be
+ *			scheduled firstly.
+ *  DSS_POOL_PRIV	Private pool: I/O requests will be added to this pool.
+ *  DSS_POOL_SHARE	Shared pool: Other requests and ULT created during
+ *			processing rpc.
+ *  DSS_POOL_REBUILD	rebuild pool: pools specially for rebuild tasks.
  */
 enum {
+	DSS_POOL_URGENT,
 	DSS_POOL_PRIV,
 	DSS_POOL_SHARE,
 	DSS_POOL_REBUILD,

--- a/src/iosrv/server_iv.c
+++ b/src/iosrv/server_iv.c
@@ -472,7 +472,8 @@ ivc_pre_cb(crt_iv_namespace_t ivns, crt_iv_key_t *iv_key,
 {
 	int rc;
 
-	rc = dss_ult_create(cb_func, cb_arg, DSS_ULT_SELF, 0, 0, NULL);
+	rc = dss_ult_create(cb_func, cb_arg, DSS_ULT_MISC, DSS_TGT_SELF,
+			    0, NULL);
 	if (rc)
 		D_ERROR("dss_ult_create failed, rc %d.\n", rc);
 }

--- a/src/iosrv/srv.c
+++ b/src/iosrv/srv.c
@@ -80,7 +80,7 @@
  * Two helper functions:
  * 1) daos_rpc_tag() to query the target tag (context ID) of specific RPC
  *    request,
- * 2) dss_tgt2xs() to query the XS id of the xstream for specific ULT task.
+ * 2) dss_ult_xs() to query the XS id of the xstream for specific ULT task.
  */
 
 /** Number of offload XS per target [0, 2] */
@@ -90,8 +90,10 @@ unsigned int	dss_tgt_nr;
 /** number of system XS */
 unsigned int	dss_sys_xs_nr = DAOS_TGT0_OFFSET;
 
-#define REBUILD_DEFAULT_SCHEDULE_RATIO 30
+#define FIRST_DEFAULT_SCHEDULE_RATIO	80
+#define REBUILD_DEFAULT_SCHEDULE_RATIO	30
 unsigned int	dss_rebuild_res_percentage = REBUILD_DEFAULT_SCHEDULE_RATIO;
+unsigned int	dss_first_res_percentage = FIRST_DEFAULT_SCHEDULE_RATIO;
 
 #define DSS_XS_NAME_LEN		(64)
 #define DSS_SYS_XS_NAME_FMT	"daos_sys_%d"
@@ -161,63 +163,65 @@ dss_sched_init(ABT_sched sched, ABT_sched_config config)
 }
 
 static ABT_unit
+unit_pop(ABT_pool *pools, int pool_idx, ABT_pool *pool)
+{
+	ABT_unit unit;
+
+	ABT_pool_pop(pools[pool_idx], &unit);
+	if (unit != ABT_UNIT_NULL) {
+		*pool = pools[pool_idx];
+		return unit;
+	}
+
+	return ABT_UNIT_NULL;
+}
+
+static ABT_unit
 normal_unit_pop(ABT_pool *pools, ABT_pool *pool)
 {
 	ABT_unit unit;
 
 	/* Let's pop I/O request ULT first */
-	ABT_pool_pop(pools[DSS_POOL_PRIV], &unit);
-	if (unit != ABT_UNIT_NULL) {
-		*pool = pools[DSS_POOL_PRIV];
+	unit = unit_pop(pools, DSS_POOL_PRIV, pool);
+	if (unit != ABT_UNIT_NULL)
 		return unit;
-	}
 
-	/* Other request and ollective ULT or created ULT */
-	ABT_pool_pop(pools[DSS_POOL_SHARE], &unit);
-	if (unit != ABT_UNIT_NULL) {
-		*pool = pools[DSS_POOL_SHARE];
+	/* Other request and collective ULT or created ULT */
+	unit = unit_pop(pools, DSS_POOL_SHARE, pool);
+	if (unit != ABT_UNIT_NULL)
 		return unit;
-	}
-
-	return ABT_UNIT_NULL;
-}
-
-static ABT_unit
-rebuild_unit_pop(ABT_pool *pools, ABT_pool *pool)
-{
-	ABT_unit unit;
-
-	ABT_pool_pop(pools[DSS_POOL_REBUILD], &unit);
-	if (unit != ABT_UNIT_NULL) {
-		*pool = pools[DSS_POOL_REBUILD];
-		return unit;
-	}
 
 	return ABT_UNIT_NULL;
 }
 
 /**
- * Choose ULT from the pool. Note: the rebuild ULT will be
- * be choosen by dss_rebuild_res_percentage.
- *
- * XXX we may change the sequence later once we have more cases.
+ * Choose ULT from the pool.
+ * Firstly with dss_first_res_percentage to schedule the task in
+ * DSS_POOL_URGENT, then with dss_rebuild_res_percentage (of left) to
+ * schedule rebuild task.
  */
 static ABT_unit
 dss_sched_unit_pop(ABT_pool *pools, ABT_pool *pool)
 {
-	size_t	 rebuild_cnt;
-	int	 rc;
+	size_t		cnt;
+	int		rc;
 
-	rc = ABT_pool_get_total_size(pools[DSS_POOL_REBUILD],
-				     &rebuild_cnt);
+	/* pop highest priority pool first */
+	rc = ABT_pool_get_total_size(pools[DSS_POOL_URGENT], &cnt);
+	if (rc != ABT_SUCCESS)
+		return ABT_UNIT_NULL;
+	if (cnt != 0 && rand() % 100 <= dss_first_res_percentage)
+		return unit_pop(pools, DSS_POOL_URGENT, pool);
+
+	/* then pop other pools */
+	rc = ABT_pool_get_total_size(pools[DSS_POOL_REBUILD], &cnt);
 	if (rc != ABT_SUCCESS)
 		return ABT_UNIT_NULL;
 
-	if (rebuild_cnt == 0 ||
-	    rand() % 100 >= dss_rebuild_res_percentage)
+	if (cnt == 0 || rand() % 100 >= dss_rebuild_res_percentage)
 		return normal_unit_pop(pools, pool);
 	else
-		return rebuild_unit_pop(pools, pool);
+		return unit_pop(pools, DSS_POOL_REBUILD, pool);
 
 	return ABT_UNIT_NULL;
 }
@@ -292,7 +296,7 @@ dss_sched_create(ABT_pool *pools, int pool_num, ABT_sched *new_sched)
 	};
 
 	/* Create a scheduler config */
-	ret = ABT_sched_config_create(&config, cv_event_freq, 10,
+	ret = ABT_sched_config_create(&config, cv_event_freq, 512,
 				      ABT_sched_config_var_end);
 	if (ret != ABT_SUCCESS)
 		return dss_abterr2der(ret);
@@ -604,6 +608,10 @@ dss_start_one_xstream(hwloc_cpuset_t cpus, int xs_id)
 	for (i = 0; i < DSS_POOL_CNT; i++) {
 		ABT_pool_access access;
 
+		/* for DSS_POOL_URGENT, now the only usage is for dtx_resync,
+		 * that creates ULT in DSS_XS_SELF. So ABT_POOL_ACCESS_PRIV
+		 * is fine.
+		 */
 		access = (i == DSS_POOL_SHARE || i == DSS_POOL_REBUILD) ?
 			 ABT_POOL_ACCESS_MPSC : ABT_POOL_ACCESS_PRIV;
 
@@ -955,22 +963,16 @@ free:
 	return dss_abterr2der(rc);
 }
 
-/* Create the pool in the normal share pool */
+/**
+ * Create the ult, will internally select the pool and XS based on ult_type
+ * and tgt_idx.
+ */
 int
 dss_ult_create(void (*func)(void *), void *arg, int ult_type, int tgt_idx,
 	       size_t stack_size, ABT_thread *ult)
 {
-	return dss_ult_pool_create(func, arg, dss_tgt2xs(ult_type, tgt_idx),
-				   stack_size, ult, DSS_POOL_SHARE);
-}
-
-/* Create the pool in the rebuild pool */
-int
-dss_rebuild_ult_create(void (*func)(void *), void *arg, int ult_type,
-		       int tgt_id, size_t stack_size, ABT_thread *ult)
-{
-	return dss_ult_pool_create(func, arg, dss_tgt2xs(ult_type, tgt_id),
-				   stack_size, ult, DSS_POOL_REBUILD);
+	return dss_ult_pool_create(func, arg, dss_ult_xs(ult_type, tgt_idx),
+				   stack_size, ult, dss_ult_pool(ult_type));
 }
 
 /**
@@ -1049,13 +1051,13 @@ dss_ult_create_execute_cb(void *data)
  * Note: This is
  * normally used when it needs to create an ULT on other xstream.
  *
- * \param[in]	func	function to execute
- * \param[in]	arg	argument for \a func
- * \param[in]	user_cb	user call back (mandatory for async mode)
- * \param[in]	arg	argument for \a user callback
- * \param[in]	ult_type type of ULT
- * \param[in]	tgt_id	target index
- * \param[out]		error code.
+ * \param[in]	func		function to execute
+ * \param[in]	arg		argument for \a func
+ * \param[in]	user_cb		user call back (mandatory for async mode)
+ * \param[in]	arg		argument for \a user callback
+ * \param[in]	ult_type	type of ULT
+ * \param[in]	tgt_id		target index
+ * \param[out]			error code.
  *
  */
 int

--- a/src/rdb/rdb_raft.c
+++ b/src/rdb/rdb_raft.c
@@ -2369,17 +2369,19 @@ rdb_raft_start(struct rdb *db)
 	raft_set_election_timeout(db->d_raft, election_timeout);
 	raft_set_request_timeout(db->d_raft, request_timeout);
 
-	rc = dss_ult_create(rdb_recvd, db, DSS_ULT_SELF, 0, 0, &db->d_recvd);
+	rc = dss_ult_create(rdb_recvd, db, DSS_ULT_RDB, DSS_TGT_SELF, 0,
+			    &db->d_recvd);
 	if (rc != 0)
 		goto err_lc;
-	rc = dss_ult_create(rdb_timerd, db, DSS_ULT_SELF, 0, 0, &db->d_timerd);
+	rc = dss_ult_create(rdb_timerd, db, DSS_ULT_RDB, DSS_TGT_SELF, 0,
+			    &db->d_timerd);
 	if (rc != 0)
 		goto err_recvd;
-	rc = dss_ult_create(rdb_callbackd, db, DSS_ULT_SELF, 0, 0,
+	rc = dss_ult_create(rdb_callbackd, db, DSS_ULT_RDB, DSS_TGT_SELF, 0,
 			    &db->d_callbackd);
 	if (rc != 0)
 		goto err_timerd;
-	rc = dss_ult_create(rdb_compactd, db, DSS_ULT_SELF, 0, 0,
+	rc = dss_ult_create(rdb_compactd, db, DSS_ULT_RDB, DSS_TGT_SELF, 0,
 			    &db->d_compactd);
 	if (rc != 0)
 		goto err_callbackd;

--- a/src/rebuild/initiator.c
+++ b/src/rebuild/initiator.c
@@ -681,9 +681,9 @@ rebuild_one_queue(struct rebuild_iter_obj_arg *iter_arg, daos_unit_oid_t *oid,
 		D_DEBUG(DB_REBUILD, "create rebuild dkey ult %d\n",
 			iter_arg->tgt_idx);
 		rpt_get(rpt);
-		rc = dss_rebuild_ult_create(rebuild_one_ult, rpt,
-			DSS_ULT_REBUILD, iter_arg->tgt_idx,
-			PULLER_STACK_SIZE, &puller->rp_ult);
+		rc = dss_ult_create(rebuild_one_ult, rpt, DSS_ULT_REBUILD,
+				    iter_arg->tgt_idx, PULLER_STACK_SIZE,
+				    &puller->rp_ult);
 		if (rc) {
 			rpt_put(rpt);
 			D_GOTO(free, rc);
@@ -906,9 +906,9 @@ rebuild_obj_callback(daos_unit_oid_t oid, daos_epoch_t eph, unsigned int shard,
 		obj_arg->rpt->rt_toberb_objs++;
 
 	/* Let's iterate the object on different xstream */
-	rc = dss_rebuild_ult_create(rebuild_obj_ult, obj_arg, DSS_ULT_REBUILD,
-				    oid.id_pub.lo % dss_tgt_nr,
-				    PULLER_STACK_SIZE, NULL);
+	rc = dss_ult_create(rebuild_obj_ult, obj_arg, DSS_ULT_REBUILD,
+			    oid.id_pub.lo % dss_tgt_nr,
+			    PULLER_STACK_SIZE, NULL);
 	if (rc) {
 		rpt_put(iter_arg->rpt);
 		D_FREE(obj_arg);
@@ -1413,8 +1413,8 @@ rebuild_obj_handler(crt_rpc_t *rpc)
 
 		rpt->rt_lead_puller_running = 1;
 		D_ASSERT(rpt->rt_pullers != NULL);
-		rc = dss_rebuild_ult_create(rebuild_puller_ult, arg,
-					    DSS_ULT_SELF, 0, 0, NULL);
+		rc = dss_ult_create(rebuild_puller_ult, arg, DSS_ULT_REBUILD,
+				    DSS_TGT_SELF, 0, NULL);
 		if (rc) {
 			rpt_put(rpt);
 			D_FREE(arg);

--- a/src/rebuild/scan.c
+++ b/src/rebuild/scan.c
@@ -820,8 +820,8 @@ rebuild_tgt_scan_handler(crt_rpc_t *rpc)
 		D_GOTO(out, rc);
 
 	rpt_get(rpt);
-	rc = dss_rebuild_ult_create(rebuild_tgt_status_check, rpt,
-				    DSS_ULT_SELF, 0, 0, NULL);
+	rc = dss_ult_create(rebuild_tgt_status_check, rpt, DSS_ULT_REBUILD,
+			    DSS_TGT_SELF, 0, NULL);
 	if (rc) {
 		rpt_put(rpt);
 		D_GOTO(out, rc);
@@ -852,8 +852,8 @@ rebuild_tgt_scan_handler(crt_rpc_t *rpc)
 	rpt_get(rpt);
 	scan_arg->rpt = rpt;
 	/* step-3: start scann leader */
-	rc = dss_ult_create(rebuild_scan_leader, scan_arg, DSS_ULT_SELF, 0, 0,
-			    NULL);
+	rc = dss_ult_create(rebuild_scan_leader, scan_arg, DSS_ULT_REBUILD,
+			    DSS_TGT_SELF, 0, NULL);
 	if (rc != 0) {
 		rpt_put(rpt);
 		D_GOTO(out_tree, rc);

--- a/src/rebuild/srv.c
+++ b/src/rebuild/srv.c
@@ -1253,8 +1253,9 @@ rebuild_ults(void *arg)
 			if (pool_is_rebuilding(task->dst_pool_uuid))
 				continue;
 
-			rc = dss_rebuild_ult_create(rebuild_task_ult, task,
-						    DSS_ULT_SELF, 0, 0, NULL);
+			rc = dss_ult_create(rebuild_task_ult, task,
+					    DSS_ULT_REBUILD, DSS_TGT_SELF,
+					    0, NULL);
 			if (rc == 0) {
 				rebuild_gst.rg_inflight++;
 				d_list_move(&task->dst_list,
@@ -1407,8 +1408,8 @@ ds_rebuild_schedule(const uuid_t uuid, uint32_t map_ver,
 			D_GOTO(free, rc = dss_abterr2der(rc));
 
 		rebuild_gst.rg_rebuild_running = 1;
-		rc = dss_rebuild_ult_create(rebuild_ults, NULL,
-					    DSS_ULT_SELF, 0, 0, NULL);
+		rc = dss_ult_create(rebuild_ults, NULL, DSS_ULT_REBUILD,
+				    DSS_TGT_SELF, 0, NULL);
 		if (rc) {
 			ABT_cond_free(&rebuild_gst.rg_stop_cond);
 			rebuild_gst.rg_rebuild_running = 0;

--- a/src/rsvc/srv.c
+++ b/src/rsvc/srv.c
@@ -483,7 +483,8 @@ rsvc_stop_cb(struct rdb *db, int err, void *arg)
 	int		rc;
 
 	ds_rsvc_get(svc);
-	rc = dss_ult_create(rsvc_stopper, svc, DSS_ULT_SELF, 0, 0, NULL);
+	rc = dss_ult_create(rsvc_stopper, svc, DSS_ULT_MISC, DSS_TGT_SELF,
+			    0, NULL);
 	if (rc != 0) {
 		D_ERROR("%s: failed to create service stopper: %d\n",
 			svc->s_name, rc);


### PR DESCRIPTION
DSS_POOL_FIRST with highest priority to schedule tasks, to support the
usage of highest priority for example dtx_resync.

Signed-off-by: Xuezhao Liu <xuezhao.liu@intel.com>