### PR TITLE
DAOS-1678 control: perform nvme device format through spdk

### DIFF
--- a/src/control/Gopkg.toml
+++ b/src/control/Gopkg.toml
@@ -66,4 +66,4 @@
 # pin with commit hash rather than just tip of master until tags exist.
 [[constraint]]
   name = "github.com/daos-stack/go-spdk"
-  revision = "8f6a8431ccb58245640a3c443d1863c2363ac5fa"
+  revision = "a7a7a864ea47192de3ce3d55d21e07bb502c40d8"

--- a/src/control/Gopkg.toml
+++ b/src/control/Gopkg.toml
@@ -66,4 +66,4 @@
 # pin with commit hash rather than just tip of master until tags exist.
 [[constraint]]
   name = "github.com/daos-stack/go-spdk"
-  revision = "32e5aa799715ce8743a796daaf91a2f396254054"
+  revision = "8f6a8431ccb58245640a3c443d1863c2363ac5fa"

--- a/src/control/README.md
+++ b/src/control/README.md
@@ -100,4 +100,4 @@ go test -v
 
 ### daos_server and daos_agent
 
-- Avoid calling `os.Exit` (or function with equivalent effects), except for assertion purposes. Fatal errors shall be returned back to `main`, who calls `os.Exit` accordingly.
+Avoid calling `os.Exit` (or function with equivalent effects), except for assertion purposes. Fatal errors shall be returned back to `main`, who calls `os.Exit` accordingly.

--- a/src/control/README.md
+++ b/src/control/README.md
@@ -1,4 +1,4 @@
-# DAOS Control Plane (aka daos_server) (TO BE UPDATED)
+# DAOS Control Plane (aka daos_server)
 
 DAOS operates over two, closely integrated planes, Control and Data. The Data plane handles the heavy lifting transport operations while the Control plane orchestrates process and storage management, facilitating the operation of the Data plane.
 
@@ -14,15 +14,15 @@ The [management tool](dmg) is an example client application which can connect to
 
 ## Documentation
 
--  [Management API](https://godoc.org/github.com/daos-stack/daos/src/control/client)
--  [Management internals](https://godoc.org/github.com/daos-stack/daos/src/control/server)
--  [Agent API](https://godoc.org/github.com/daos-stack/daos/src/control/client/agent)
--  [Agent internals](https://godoc.org/github.com/daos-stack/daos/src/control/security)
--  [dRPC](https://godoc.org/github.com/daos-stack/daos/src/control/drpc)
--  [server package](server/README.md)
--  [management tool package](dmg/README.md)
--  [client package](client/README.md)
--  [common package](common/README.md)
+- [Management API](https://godoc.org/github.com/daos-stack/daos/src/control/client)
+- [Management internals](https://godoc.org/github.com/daos-stack/daos/src/control/server)
+- [Agent API](https://godoc.org/github.com/daos-stack/daos/src/control/client/agent)
+- [Agent internals](https://godoc.org/github.com/daos-stack/daos/src/control/security)
+- [dRPC](https://godoc.org/github.com/daos-stack/daos/src/control/drpc)
+- [server package](server/README.md)
+- [management tool package](dmg/README.md)
+- [client package](client/README.md)
+- [common package](common/README.md)
 
 ## Architecture
 
@@ -32,74 +32,72 @@ First a view of software component architecture:
 
 ## Development Requirements
 
-* [Golang](https://golang.org/) 1.9 or higher
-* [gRPC](https://grpc.io/)
-* [Protocol Buffers](https://developers.google.com/protocol-buffers/)
-* [Dep](https://github.com/golang/dep/) for managing dependencies in vendor directory.
+- [Golang](https://golang.org/) 1.9 or higher
+- [gRPC](https://grpc.io/)
+- [Protocol Buffers](https://developers.google.com/protocol-buffers/)
+- [Dep](https://github.com/golang/dep/) for managing dependencies in vendor directory.
 
 ## Development setup
 
-* If changing vendor package versions, edit `src/control/Gopkg.toml` and then run `dep ensure` from src/control.
-* (Optional) protoc protocol buffer compiler
+- If changing vendor package versions, edit `src/control/Gopkg.toml` and then run `dep ensure` from src/control.
+- (Optional) protoc protocol buffer compiler
 
 ### Building the app
 
 For instructions on building and running DAOS see the [Quickstart guide](../../doc/quickstart.md).
 
-#### Local
-
-* `scons` (binaries should be produced in `install/bin` directory)
+Build with `scons` and binaries should be produced in `install/bin` directory.
 
 ### Testing the app
 
-* Run the tests `go test` within each directory containing tests
+Run the tests `go test` within each directory containing tests
 
 ### Run unit tests locally
 
 Checkout the DAOS source code:
 
-'git clone <https://github.com/daos-stack/daos.git>'
+`git clone <https://github.com/daos-stack/daos.git>`
 
 Checkout the SPDK source code on branch v18.07.x:
 
-'git clone --single-branch --branch v18.07.x git@github.com:spdk/spdk.git'
+`git clone --single-branch --branch v18.07.x git@github.com:spdk/spdk.git`
 
 Continue installing SPDK with the procedure in the repository on branch v18.07.x: [SPDK-v18.07.x](https://github.com/spdk/spdk/tree/v18.07.x)
 
 Setup environment variables:
 
-'DAOS_REPO="/path/to/daos_repo"'
-
-'SPDK_REPO="/path/to/spdk_repo"'
-
-'export CGO_LDFLAGS="-L${SPDK_REPO}/build/lib"'
-
-'export CGO_CFLAGS=-I${SPDK_REPO}/include/'
-
-'export LD_LIBRARY_PATH="${SPDK_REPO}/build/lib:${DAOS_REPO}/src/control/vendor/github.com/daos-stack/go-spdk/spdk"'
+```bash
+DAOS_REPO="/path/to/daos_repo"
+SPDK_REPO="/path/to/spdk_repo"
+export CGO_LDFLAGS="-L${SPDK_REPO}/build/lib"
+export CGO_CFLAGS=-I${SPDK_REPO}/include
+export LD_LIBRARY_PATH="${SPDK_REPO}/build/lib:${DAOS_REPO}/src/control/vendor/github.com/daos-stack/go-spdk/spdk"
+```
 
 Build NVME libs:
 
-'cd ${DAOS_REPO}/src/control/vendor/github.com/daos-stack/go-spdk/spdk'
-
-'gcc ${CGO_LDFLAGS} ${CGO_CFLAGS} -Werror -g -Wshadow -Wall -Wno-missing-braces -c -fpic -Iinclude src/*.c -lspdk'
-
-'gcc ${CGO_LDFLAGS} ${CGO_CFLAGS} -shared -o libnvme_control.so *.o'
+```bash
+cd ${DAOS_REPO}/src/control/vendor/github.com/daos-stack/go-spdk/spdk
+gcc ${CGO_LDFLAGS} ${CGO_CFLAGS} -Werror -g -Wshadow -Wall -Wno-missing-braces -c -fpic -Iinclude src/*.c -lspdk
+gcc ${CGO_LDFLAGS} ${CGO_CFLAGS} -shared -o libnvme_control.so *.o
+```
 
 To run suite of control plane unit tests:
 
-'cd ${DAOS_REPO}/src/control'
-
-'./run_go_tests.sh'
+```bash
+cd ${DAOS_REPO}/src/control
+./run_go_tests.sh
+```
 
 To run go-spdk tests:
 
-'cd ${DAOS_REPO}/src/control/vendor/github.com/daos-stack/go-spdk/spdk'
-
-'go test -v'
+```base
+cd ${DAOS_REPO}/src/control/vendor/github.com/daos-stack/go-spdk/spdk
+go test -v
+```
 
 ## Coding Guidelines
 
 ### daos_server and daos_agent
 
-* Avoid calling `os.Exit` (or function with equivalent effects), except for assertion purposes. Fatal errors shall be returned back to `main`, who calls `os.Exit` accordingly.
+- Avoid calling `os.Exit` (or function with equivalent effects), except for assertion purposes. Fatal errors shall be returned back to `main`, who calls `os.Exit` accordingly.

--- a/src/control/client/storage.go
+++ b/src/control/client/storage.go
@@ -154,7 +154,8 @@ func (c *connList) ListStorage() (ClientNvmeMap, ClientScmMap) {
 }
 
 func (c *control) formatStorage() error {
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	// Maximum time limit for format is 2hrs
+	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Minute)
 	defer cancel()
 
 	_, err := c.client.FormatStorage(ctx, &pb.FormatStorageParams{})

--- a/src/control/common/test_mocks.go
+++ b/src/control/common/test_mocks.go
@@ -50,7 +50,6 @@ func MockNamespacePB() *pb.NvmeNamespace {
 // multiple packages (message contains repeated namespace field).
 func MockControllerPB(fwRev string) *pb.NvmeController {
 	return &pb.NvmeController{
-		Id:        int32(12345),
 		Model:     "ABC",
 		Serial:    "123ABC",
 		Pciaddr:   "1:2:3.0",

--- a/src/control/dmg/README.md
+++ b/src/control/dmg/README.md
@@ -79,6 +79,8 @@ Help Options:
 </p>
 </details>
 
+## Subcommands
+
 <details>
 <summary>Example output from invoking "storage list" subcommand</summary>
 <p>
@@ -115,6 +117,26 @@ boro-45:10001: []
 
 </p>
 </details>
+
+<details>
+<summary>Example output from invoking "storage format" subcommand</summary>
+<p>
+
+```
+[tanabarr@ssh-1 ~]$ projects/daos_m/install/bin/daos_shell -l boro-45:10001 storage format
+Active connections: [boro-45:10001]
+
+This is a destructive operation and storage devices specified in the server
+config file will be erased. Are you sure you want to continue? (yes/no)
+yes
+Listing Format Storage command results on connected storage servers:
+boro-45:10001: 'Success!'
+```
+
+</p>
+</details>
+
+## Interactive shell
 
 <details>
 <summary>Example output when listing storage in interactive mode</summary>

--- a/src/control/dmg/README.md
+++ b/src/control/dmg/README.md
@@ -10,7 +10,7 @@ The management tool has no storage library dependencies and as such is suitable 
 <summary>Usage info from app help</summary>
 <p>
 
-```
+```bash
 [tanabarr@ssh-1 ~]$ projects/daos_m/install/bin/daos_shell --help
 Usage:
   daos_shell [OPTIONS] [command]
@@ -82,12 +82,80 @@ Help Options:
 ## Subcommands
 
 <details>
-<summary>Example output from invoking "storage list" subcommand</summary>
+<summary>Example output from invoking "storage list" subcommand on a single host</summary>
 <p>
 
+```bash
+[root@wolf-72 ~]# /root/daos_m/install/bin/daos_shell storage list
+Active connections: [localhost:10001]
+
+Listing NVMe SSD controller and constituent namespaces on connected storage servers:
+localhost:10001:
+- id: 0
+  model: 'INTEL SSDPED1K375GA '
+  serial: 'PHKS7335008X375AGN  '
+  pciaddr: 0000:87:00.0
+  fwrev: E2010324
+  namespace:
+  - id: 1
+    capacity: 375
+- id: 0
+  model: 'INTEL SSDPEDMD016T4 '
+  serial: 'CVFT6010002F1P6DGN  '
+  pciaddr: 0000:81:00.0
+  fwrev: 8DV10171
+  namespace:
+  - id: 1
+    capacity: 1600
+- id: 0
+  model: 'INTEL SSDPEDMD016T4 '
+  serial: 'CVFT5392000G1P6DGN  '
+  pciaddr: 0000:da:00.0
+  fwrev: 8DV10171
+  namespace:
+  - id: 1
+    capacity: 1600
+
+
+Listing SCM modules on connected storage servers:
+localhost:10001:
+- physicalid: 28
+  channel: 0
+  channelpos: 1
+  memctrlr: 0
+  socket: 0
+  capacity: 539661172736
+- physicalid: 40
+  channel: 0
+  channelpos: 1
+  memctrlr: 1
+  socket: 0
+  capacity: 539661172736
+- physicalid: 50
+  channel: 0
+  channelpos: 1
+  memctrlr: 0
+  socket: 1
+  capacity: 539661172736
+- physicalid: 62
+  channel: 0
+  channelpos: 1
+  memctrlr: 1
+  socket: 1
+  capacity: 539661172736
 ```
+
+</p>
+</details>
+
+<details>
+<summary>Example output from invoking "storage list" subcommand on multiple hosts</summary>
+<p>
+
+```bash
 [tanabarr@ssh-1 ~]$ projects/daos_m/install/bin/daos_shell -l boro-44:10001,boro-45:10001 storage list
 Active connections: [boro-45:10001 boro-44:10001]
+
 
 Listing NVMe SSD controller and constituent namespaces on connected storage servers:
 boro-44:10001:
@@ -122,7 +190,7 @@ boro-45:10001: []
 <summary>Example output from invoking "storage format" subcommand</summary>
 <p>
 
-```
+```bash
 [tanabarr@ssh-1 ~]$ projects/daos_m/install/bin/daos_shell -l boro-45:10001 storage format
 Active connections: [boro-45:10001]
 

--- a/src/control/dmg/storage.go
+++ b/src/control/dmg/storage.go
@@ -71,13 +71,14 @@ type FormatStorCmd struct{}
 func formatStor() {
 	fmt.Println(
 		"This is a destructive operation and storage devices " +
-			"specified in the server config file will be erased. " +
+			"specified in the server config file will be erased.\n" +
+			"Please be patient as it may take several minutes.\n" +
 			"Are you sure you want to continue? (yes/no)")
 
 	if getConsent() {
 		fmt.Printf(
 			unpackFormat(conns.FormatStorage()),
-			"Format Storage command result")
+			"storage format result")
 	}
 }
 

--- a/src/control/dmg/utils_test.go
+++ b/src/control/dmg/utils_test.go
@@ -102,7 +102,7 @@ func TestCheckSprint(t *testing.T) {
 		},
 		{
 			NewClientNvme(ctrlrs, addresses),
-			"Listing %[1]ss on connected storage servers:\n1.2.3.4:10000:\n- id: 12345\n  model: ABC\n  serial: 123ABC\n  pciaddr: \"1:2:3.0\"\n  fwrev: \"\"\n  namespace:\n  - id: 12345\n    capacity: 99999\n1.2.3.5:10001:\n- id: 12345\n  model: ABC\n  serial: 123ABC\n  pciaddr: \"1:2:3.0\"\n  fwrev: \"\"\n  namespace:\n  - id: 12345\n    capacity: 99999\n\n\n",
+			"Listing %[1]ss on connected storage servers:\n1.2.3.4:10000:\n- id: 0\n  model: ABC\n  serial: 123ABC\n  pciaddr: \"1:2:3.0\"\n  fwrev: \"\"\n  namespace:\n  - id: 12345\n    capacity: 99999\n1.2.3.5:10001:\n- id: 0\n  model: ABC\n  serial: 123ABC\n  pciaddr: \"1:2:3.0\"\n  fwrev: \"\"\n  namespace:\n  - id: 12345\n    capacity: 99999\n\n\n",
 		},
 		{
 			NewClientScm(modules, addresses),

--- a/src/control/server/README.md
+++ b/src/control/server/README.md
@@ -185,7 +185,7 @@ Formatting SCM involves creating an ext4 filesystem on the nvdimm device.
 
 Mounting SCM results in an active mount using the DAX extension enabling direct access without restrictions imposed by legacy HDD hardware.
 
-The DAOS control plane willa also provide SCM storage management capabilities enabling the discovery, initial burn-in testing, firmware update and allocation of devices to data plane instances.
+The DAOS control plane wil provide SCM storage management capabilities enabling the discovery, initial burn-in testing, firmware update and allocation of devices to data plane instances.
 
 #### SCM module discovery
 

--- a/src/control/server/README.md
+++ b/src/control/server/README.md
@@ -187,6 +187,21 @@ TODO: return details of AppDirect memory regions
 
 Format can be triggered through the management tool at DAOS system installation time, formatting and mounting of SCM device namespace is will be performed as specified in config file parameters prefixed with `scm_`.
 
+##### `format_override` == true
+
+If `format_override` IS SET to `true` in config file, control plane will attempt to use whatever is mounted at `scm_mount` location specified in config file and start data plane instances regardless of whether the server has been formatted.
+If `scm_mount` IS NOT mounted, control plane will fail to start data plane.
+If `scm_mount` IS mounted but no superblock exists, control plane will attempt to create superblock and start data plane.
+
+##### `format_override` == false
+
+If `format_override` IS SET to `false` in config file, control plane will attempt to start the data plane instances ONLY if the DAOS superblock exists within the specified `scm_mount`.
+Otherwise, the control plane will wait until an administrator calls FormatStorage over the client API from the management tool.
+If FormatStorage call is successful, control plane will continue to start data plane instances when SCM and NVMe have been formatted, SCM mounted and superblock and nvme.conf successfully written to SCM mount.
+If a superblock exists in `scm_mount`, but the location is not actively mounted, the control plane will fail (so as to not inadvertently wipe a useful SCM location).
+whatever is mounted at `scm_mount` location specified in config file and start data plane instances.
+and the location is an active mountpoint.
+
 #### SCM Firmware Update
 
 #### SCM Burn-in Validation
@@ -214,6 +229,8 @@ In the context of what is required from the control plane to prepare NVMe device
 Formatting will be performed on devices identified by PCI addresses specified in config file parameter `bdev_list` when `bdev_class` is equal to `nvme`.
 
 The SPDK "[blobcli](https://github.com/spdk/spdk/tree/master/examples/blob/cli)" can be used to initiate and manipulate blobstores for testing and verification purposes.
+
+In order to designate NVMe devices to be used by DAOS data plane instances, the control plane will generate an `nvme.conf` file to be consumed by SPDK which will be written to the `scm_mount` (persistent) mounted location as a final stage of formatting before the superblock is written, signifying the server has been formatted.
 
 #### NVMe Controller Firmware Update
 

--- a/src/control/server/README.md
+++ b/src/control/server/README.md
@@ -164,8 +164,8 @@ Implemented as a gRPC client application it connects and interacts with multiple
 
 In order to run the tool to perform administrative tasks from non-storage nodes (e.g. login nodes) over an out-of-band management network;
 
-1. build and run the `daos_server` as per the [quickstart guide](https://github.com/daos-stack/daos/blob/master/doc/quickstart.md) on the storage nodes
-2. run `daos_shell` from a login node
+ 1. build and run the `daos_server` as per the [quickstart guide](https://github.com/daos-stack/daos/blob/master/doc/quickstart.md) on the storage nodes
+ 2. run `daos_shell` from a login node
 
 See `daos_shell --help` for usage and [here](../dmg) for package details.
 
@@ -400,4 +400,3 @@ The following animation illustrates starting the control server and using the ma
 #### NVMe Controller Burn-in Validation
 
 Burn-in validation is performed using the [fio tool](https://github.com/axboe/fio) which executes workloads over the SPDK framework using the [fio plugin](https://github.com/spdk/spdk/tree/v18.04.1/examples/nvme/fio_plugin).
-

--- a/src/control/server/README.md
+++ b/src/control/server/README.md
@@ -205,12 +205,151 @@ If `format_override` IS SET to `true` in config file, control plane will attempt
 If `scm_mount` IS NOT mounted, control plane will fail to start data plane.
 If `scm_mount` IS mounted but no superblock exists, control plane will attempt to create superblock and start data plane.
 
+<details>
+<summary>Example output from invoking `daos_server` on single host with `format_override` TRUE when `scm_mount` IS NOT mounted</summary>
+<p>
+
+```bash
+[root@wolf-72 daos_m]# install/bin/orterun -np 1 --hostfile hostfile --enable-recovery --allow-run-as-root install/bin/daos_server -t 1 -o /root/daos_m/utils/config/examples/daos_server_sockets.yml
+[root@wolf-72 daos_m]# install/bin/orterun -np 1 --hostfile hostfile --enable-recovery --allow-run-as-root install/bin/daos_server -t 1 -o /root/daos_m/utils/config/examples/daos_server_sockets.yml
+2019/04/10 04:04:05 config.go:103: debug: DAOS config read from /root/daos_m/utils/config/examples/daos_server_sockets.yml
+2019/04/10 04:04:05 config.go:135: debug: Active config saved to /root/daos_m/utils/config/examples/.daos_server.active.yml (read-only)
+2019/04/10 04:04:05 config.go:405: debug: Switching control log level to DEBUG
+Starting SPDK v18.07-pre / DPDK 18.02.0 initialization...
+[ DPDK EAL parameters: spdk -c 0x1 --file-prefix=spdk1319116020 --base-virtaddr=0x200000000000 --proc-type=auto ]
+EAL: Detected 96 lcore(s)
+EAL: Auto-detected process type: PRIMARY
+EAL: No free hugepages reported in hugepages-1048576kB
+EAL: Multi-process socket /var/run/.spdk1319116020_unix
+EAL: Probing VFIO support...
+EAL: PCI device 0000:81:00.0 on NUMA socket 1
+EAL:   probe driver: 8086:953 spdk_nvme
+EAL: PCI device 0000:87:00.0 on NUMA socket 1
+EAL:   probe driver: 8086:2701 spdk_nvme
+EAL: PCI device 0000:da:00.0 on NUMA socket 1
+EAL:   probe driver: 8086:953 spdk_nvme
+wolf-72.wolf.hpdd.intel.com 2019/04/10 04:04:09 iosrv.go:104: debug: continuing without storage format on server 0 (format_override set in config)
+wolf-72.wolf.hpdd.intel.com 2019/04/10 04:04:09 external.go:54: debug: exec 'mount | grep ' /mnt/daos ''
+wolf-72.wolf.hpdd.intel.com 2019/04/10 04:04:09 external.go:54: debug: exec 'mount | grep ' /mnt ''
+wolf-72.wolf.hpdd.intel.com 2019/04/10 04:04:09 main.go:129: error: Failed to format servers: server0 scm mount path (/mnt/daos) not mounted: Error running mount | grep ' /mnt ': : exit status 1
+```
+
+</details>
+</p>
+
+<details>
+<summary>Example output from invoking `daos_server` on single host with `format_override` TRUE when `scm_mount` IS mounted</summary>
+<p>
+
+```bash
+[root@wolf-72 daos_m]# mkdir /mnt/daos
+[root@wolf-72 daos_m]# mount -t tmpfs -o size=68719476736 tmpfs /mnt/daos
+[root@wolf-72 daos_m]# install/bin/orterun -np 1 --hostfile hostfile --enable-recovery --allow-run-as-root install/bin/daos_server -t 1 -o /root/daos_m/utils/config/examples/daos_server_sockets.yml
+2019/04/10 04:04:50 config.go:103: debug: DAOS config read from /root/daos_m/utils/config/examples/daos_server_sockets.yml
+2019/04/10 04:04:50 config.go:135: debug: Active config saved to /root/daos_m/utils/config/examples/.daos_server.active.yml (read-only)
+2019/04/10 04:04:50 config.go:405: debug: Switching control log level to DEBUG
+Starting SPDK v18.07-pre / DPDK 18.02.0 initialization...
+[ DPDK EAL parameters: spdk -c 0x1 --file-prefix=spdk1234882151 --base-virtaddr=0x200000000000 --proc-type=auto ]
+EAL: Detected 96 lcore(s)
+EAL: Auto-detected process type: PRIMARY
+EAL: No free hugepages reported in hugepages-1048576kB
+EAL: Multi-process socket /var/run/.spdk1234882151_unix
+EAL: Probing VFIO support...
+EAL: PCI device 0000:81:00.0 on NUMA socket 1
+EAL:   probe driver: 8086:953 spdk_nvme
+EAL: PCI device 0000:87:00.0 on NUMA socket 1
+EAL:   probe driver: 8086:2701 spdk_nvme
+EAL: PCI device 0000:da:00.0 on NUMA socket 1
+EAL:   probe driver: 8086:953 spdk_nvme
+wolf-72.wolf.hpdd.intel.com 2019/04/10 04:04:54 iosrv.go:104: debug: continuing without storage format on server 0 (format_override set in config)
+wolf-72.wolf.hpdd.intel.com 2019/04/10 04:04:54 external.go:54: debug: exec 'mount | grep ' /mnt/daos ''
+wolf-72.wolf.hpdd.intel.com 2019/04/10 04:04:54 iosrv.go:128: debug: format server /mnt/daos (createMS=false bootstrapMS=false)
+wolf-72.wolf.hpdd.intel.com 2019/04/10 04:04:54 main.go:156: debug: DAOS server listening on 0.0.0.0:10001
+DAOS I/O server (v0.4.0) process 135939 started on rank 0 (out of 1) with 1 target xstream set(s), 2 helper XS per target, firstcore 0.
+```
+
+</details>
+</p>
+
 ##### `format_override` == false
 
 If `format_override` IS SET to `false` in config file, control plane will attempt to start the data plane instances ONLY if the DAOS superblock exists within the specified `scm_mount`.
 Otherwise, the control plane will wait until an administrator calls "[storage format](../dmg/README.md#subcommands)" over the client API from the management tool.
 If `storage format` call is successful, control plane will continue to start data plane instances when SCM and NVMe have been formatted, SCM mounted and superblock and nvme.conf successfully written to SCM mount.
 If a superblock exists in `scm_mount`, and the location is mounted, the control plane will fail (so as to not inadvertently wipe a useful SCM location).
+
+<details>
+<summary>Example output from invoking `daos_server` on single host with `format_override` FALSE when superblock already exists</summary>
+<p>
+
+```bash
+[root@wolf-72 daos_m]# install/bin/orterun -np 1 --hostfile hostfile --enable-recovery --allow-run-as-root install/bin/daos_server -t 1 -o /root/daos_m/utils/config/examples/daos_server_sockets.yml
+2019/04/10 03:34:22 config.go:103: debug: DAOS config read from /root/daos_m/utils/config/examples/daos_server_sockets.yml
+2019/04/10 03:34:22 config.go:135: debug: Active config saved to /root/daos_m/utils/config/examples/.daos_server.active.yml (read-only)
+2019/04/10 03:34:22 config.go:405: debug: Switching control log level to DEBUG
+Starting SPDK v18.07-pre / DPDK 18.02.0 initialization...
+[ DPDK EAL parameters: spdk -c 0x1 --file-prefix=spdk850287469 --base-virtaddr=0x200000000000 --proc-type=auto ]
+EAL: Detected 96 lcore(s)
+EAL: Auto-detected process type: PRIMARY
+EAL: No free hugepages reported in hugepages-1048576kB
+EAL: Multi-process socket /var/run/.spdk850287469_unix
+EAL: Probing VFIO support...
+EAL: PCI device 0000:81:00.0 on NUMA socket 1
+EAL:   probe driver: 8086:953 spdk_nvme
+EAL: PCI device 0000:87:00.0 on NUMA socket 1
+EAL:   probe driver: 8086:2701 spdk_nvme
+EAL: PCI device 0000:da:00.0 on NUMA socket 1
+EAL:   probe driver: 8086:953 spdk_nvme
+wolf-72.wolf.hpdd.intel.com 2019/04/10 03:34:25 iosrv.go:93: debug: server 0 has already been formatted
+wolf-72.wolf.hpdd.intel.com 2019/04/10 03:34:26 main.go:156: debug: DAOS server listening on 0.0.0.0:10001
+DAOS I/O server (v0.4.0) process 135671 started on rank 0 (out of 1) with 1 target xstream set(s), 2 helper XS per target, firstcore 0.
+```
+
+</p>
+</details>
+
+<details>
+<summary>Example output from invoking `daos_server` on single host with `format_override` FALSE when `scm_mount` location is not mounted</summary>
+<p>
+
+```bash
+[root@wolf-72 daos_m]# install/bin/orterun -np 1 --hostfile hostfile --enable-recovery --allow-run-as-root install/bin/daos_server -t 1 -o /root/daos_m/utils/config/examples/daos_server_sockets.yml
+2019/04/10 03:34:22 config.go:103: debug: DAOS config read from /root/daos_m/utils/config/examples/daos_server_sockets.yml
+2019/04/10 03:34:22 config.go:135: debug: Active config saved to /root/daos_m/utils/config/examples/.daos_server.active.yml (read-only)
+2019/04/10 03:34:22 config.go:405: debug: Switching control log level to DEBUG
+Starting SPDK v18.07-pre / DPDK 18.02.0 initialization...
+[ DPDK EAL parameters: spdk -c 0x1 --file-prefix=spdk850287469 --base-virtaddr=0x200000000000 --proc-type=auto ]
+EAL: Detected 96 lcore(s)
+EAL: Auto-detected process type: PRIMARY
+EAL: No free hugepages reported in hugepages-1048576kB
+EAL: Multi-process socket /var/run/.spdk850287469_unix
+EAL: Probing VFIO support...
+EAL: PCI device 0000:81:00.0 on NUMA socket 1
+EAL:   probe driver: 8086:953 spdk_nvme
+EAL: PCI device 0000:87:00.0 on NUMA socket 1
+EAL:   probe driver: 8086:2701 spdk_nvme
+EAL: PCI device 0000:da:00.0 on NUMA socket 1
+EAL:   probe driver: 8086:953 spdk_nvme
+wolf-72.wolf.hpdd.intel.com 2019/04/10 03:49:19 iosrv.go:108: debug: waiting for storage format on server 0
+```
+...after [`storage format`](../dmg/README.md#subcommands) gets called, data plane is started...
+```bash
+wolf-72.wolf.hpdd.intel.com 2019/04/10 04:00:21 mgmt.go:108: debug: performing nvme format, may take several minutes!
+wolf-72.wolf.hpdd.intel.com 2019/04/10 04:00:21 mgmt.go:114: debug: performing scm format, should be quick!
+wolf-72.wolf.hpdd.intel.com 2019/04/10 04:00:21 external.go:111: debug: calling unmount with /mnt/daos, MNT_DETACH
+wolf-72.wolf.hpdd.intel.com 2019/04/10 04:00:21 storage_scm.go:140: debug: wiping all fs identifiers on device /dev/pmem4
+wolf-72.wolf.hpdd.intel.com 2019/04/10 04:00:21 external.go:54: debug: exec 'wipefs -a /dev/pmem4'
+wolf-72.wolf.hpdd.intel.com 2019/04/10 04:00:21 external.go:54: debug: exec 'mkfs.ext4 /dev/pmem4'
+wolf-72.wolf.hpdd.intel.com 2019/04/10 04:00:22 external.go:98: debug: calling mount with /dev/pmem4, /mnt/daos, ext4, 33806, dax
+wolf-72.wolf.hpdd.intel.com 2019/04/10 04:00:22 external.go:54: debug: exec 'mount | grep ' /mnt/daos ''
+wolf-72.wolf.hpdd.intel.com 2019/04/10 04:00:22 mgmt.go:153: debug: FormatStorage: storage format successful on server 0
+wolf-72.wolf.hpdd.intel.com 2019/04/10 04:00:22 iosrv.go:128: debug: format server /mnt/daos (createMS=false bootstrapMS=false)
+wolf-72.wolf.hpdd.intel.com 2019/04/10 04:00:23 main.go:156: debug: DAOS server listening on 0.0.0.0:10001
+DAOS I/O server (v0.4.0) process 135863 started on rank 0 (out of 1) with 1 target xstream set(s), 2 helper XS per target, firstcore 0.
+```
+
+</p>
+</details>
 
 #### SCM Firmware Update
 

--- a/src/control/server/config_bdev.go
+++ b/src/control/server/config_bdev.go
@@ -87,51 +87,51 @@ func createConf(ext External, server *server, templ string) error {
 	return nil
 }
 
-func (c *configuration) parseNvme() error {
-	for i := range c.Servers {
-		s := &c.Servers[i]
-		switch s.BdevClass {
-		case bdNVMe:
-			if len(s.BdevList) == 0 {
-				continue
-			}
-			// standard daos_nvme.conf, don't need to set VOS_BDEV_CLASS
-			if err := createConf(c.ext, s, nvmeTempl); err != nil {
-				return err
-			}
-		case bdMalloc:
-			if s.BdevNumber == 0 {
-				continue
-			}
-			if err := createConf(c.ext, s, mallocTempl); err != nil {
-				return err
-			}
-			s.EnvVars = append(s.EnvVars, "VOS_BDEV_CLASS=MALLOC")
-		case bdKdev:
-			if len(s.BdevList) == 0 {
-				continue
-			}
-			if err := createConf(c.ext, s, kdevTempl); err != nil {
-				return err
-			}
-			s.EnvVars = append(s.EnvVars, "VOS_BDEV_CLASS=AIO")
-		case bdFile:
-			if len(s.BdevList) == 0 {
-				continue
-			}
-			// requested size aligned with block size
-			size := (int64(s.BdevSize*gbyte) / int64(blkSize)) * int64(blkSize)
-			for _, path := range s.BdevList {
-				err := c.ext.createEmpty(path, size)
-				if err != nil {
-					return err
-				}
-			}
-			if err := createConf(c.ext, s, fileTempl); err != nil {
-				return err
-			}
-			s.EnvVars = append(s.EnvVars, "VOS_BDEV_CLASS=AIO")
+func (c *configuration) parseNvme(i int) error {
+	srv := &c.Servers[i]
+
+	switch srv.BdevClass {
+	case bdNVMe:
+		if len(srv.BdevList) == 0 {
+			break
 		}
+		// standard daos_nvme.conf, don't need to set VOS_BDEV_CLASS
+		if err := createConf(c.ext, srv, nvmeTempl); err != nil {
+			return err
+		}
+	case bdMalloc:
+		if srv.BdevNumber == 0 {
+			break
+		}
+		if err := createConf(c.ext, srv, mallocTempl); err != nil {
+			return err
+		}
+		srv.EnvVars = append(srv.EnvVars, "VOS_BDEV_CLASS=MALLOC")
+	case bdKdev:
+		if len(srv.BdevList) == 0 {
+			break
+		}
+		if err := createConf(c.ext, srv, kdevTempl); err != nil {
+			return err
+		}
+		srv.EnvVars = append(srv.EnvVars, "VOS_BDEV_CLASS=AIO")
+	case bdFile:
+		if len(srv.BdevList) == 0 {
+			break
+		}
+		// requested size aligned with block size
+		size := (int64(srv.BdevSize*gbyte) / int64(blkSize)) * int64(blkSize)
+		for _, path := range srv.BdevList {
+			err := c.ext.createEmpty(path, size)
+			if err != nil {
+				return err
+			}
+		}
+		if err := createConf(c.ext, srv, fileTempl); err != nil {
+			return err
+		}
+		srv.EnvVars = append(srv.EnvVars, "VOS_BDEV_CLASS=AIO")
 	}
+
 	return nil
 }

--- a/src/control/server/config_bdev_test.go
+++ b/src/control/server/config_bdev_test.go
@@ -40,17 +40,24 @@ func TestParseBdev(t *testing.T) {
 		bdevSize   int  // relevant for MALLOC/FILE
 		bdevNumber int  // relevant for MALLOC
 		fileExists bool // mock return value for file exists check
-		expEnvs    []string
+		extraEnv   string
 		expFiles   [][]string
 		errMsg     string
 	}{
 		{
-			bdevClass: "",
-			bdevList:  []string{"0000:81:00.1"},
-		},
-		{},
-		{
-			bdevClass: bdNVMe,
+			expFiles: [][]string{
+				{
+					`/mnt/daos/daos_nvme.conf:[Nvme]`,
+					`TransportID "trtype:PCIe traddr:0000:81:00.0" Nvme0`,
+					`RetryCount 4`,
+					`TimeoutUsec 0`,
+					`ActionOnTimeout None`,
+					`AdminPollRate 100000`,
+					`HotplugEnable No`,
+					`HotplugPollRate 0`,
+					``,
+				},
+			},
 		},
 		{
 			bdevClass: bdNVMe,
@@ -84,7 +91,7 @@ func TestParseBdev(t *testing.T) {
 					"",
 				},
 			},
-			expEnvs: []string{"VOS_BDEV_CLASS=AIO"},
+			extraEnv: "VOS_BDEV_CLASS=AIO",
 		},
 		{
 			bdevClass: bdFile,
@@ -98,7 +105,7 @@ func TestParseBdev(t *testing.T) {
 					"",
 				},
 			},
-			expEnvs:    []string{"VOS_BDEV_CLASS=AIO"},
+			extraEnv:   "VOS_BDEV_CLASS=AIO",
 			fileExists: true,
 		},
 		{
@@ -112,7 +119,7 @@ func TestParseBdev(t *testing.T) {
 					"",
 				},
 			},
-			expEnvs: []string{"VOS_BDEV_CLASS=AIO"},
+			extraEnv: "VOS_BDEV_CLASS=AIO",
 		},
 		{
 			bdevClass:  bdMalloc,
@@ -126,7 +133,7 @@ func TestParseBdev(t *testing.T) {
 					"",
 				},
 			},
-			expEnvs: []string{"VOS_BDEV_CLASS=MALLOC"},
+			extraEnv: "VOS_BDEV_CLASS=MALLOC",
 		},
 	}
 
@@ -134,16 +141,27 @@ func TestParseBdev(t *testing.T) {
 		// files is a mock store of written file contents
 		files = []string{}
 
-		// create default config and add server populated with test values
-		server := newDefaultServer()
-		server.ScmMount = "/mnt/daos"
-		server.BdevClass = tt.bdevClass
-		server.BdevList = tt.bdevList
-		server.BdevSize = tt.bdevSize
-		server.BdevNumber = tt.bdevNumber
-		config := newMockConfig(nil, "", tt.fileExists, nil, nil, nil, nil)
-		config.Servers = append(config.Servers, server)
-		err := config.parseNvme()
+		ext := newMockExt(nil, "", tt.fileExists, nil, nil, nil, nil)
+		config := mockConfigFromFile(t, ext, socketsExample)
+
+		srvIdx := 0 // we know that socketsExample only specifies one srv
+		srv := &config.Servers[srvIdx]
+
+		// populate bdev server config parameters
+		if tt.bdevClass != "" {
+			srv.BdevClass = tt.bdevClass
+		}
+		if len(tt.bdevList) != 0 {
+			srv.BdevList = tt.bdevList
+		}
+		if tt.bdevSize != 0 {
+			srv.BdevSize = tt.bdevSize
+		}
+		if tt.bdevNumber != 0 {
+			srv.BdevNumber = tt.bdevNumber
+		}
+
+		err := config.parseNvme(srvIdx)
 		if tt.errMsg != "" {
 			ExpectError(t, err, tt.errMsg, "")
 			continue
@@ -169,6 +187,10 @@ func TestParseBdev(t *testing.T) {
 			}
 		}
 		// verify VOS_BDEV_CLASS env gets set as expected
-		AssertEqual(t, config.Servers[0].EnvVars, tt.expEnvs, string(tt.bdevClass))
+		if tt.extraEnv != "" {
+			if !Include(srv.EnvVars, tt.extraEnv) {
+				t.Fatal("env variable missing: " + tt.extraEnv)
+			}
+		}
 	}
 }

--- a/src/control/server/config_test.go
+++ b/src/control/server/config_test.go
@@ -47,8 +47,9 @@ const (
 	tmpOut           = "testdata/.tmp_out.yml"
 )
 
+// init gets called once per package, don't call in other test files
 func init() {
-	log.NewDefaultLogger(log.Error, "config_test: ", os.Stderr)
+	log.NewDefaultLogger(log.Error, "server_tests: ", os.Stderr)
 
 	// load uncommented version of canonical config file daos_server.yml
 	uncommentServerConfig()
@@ -82,16 +83,6 @@ func uncommentServerConfig() {
 	if err := cmd.Wait(); err != nil {
 		fail(err)
 	}
-}
-
-func newMockConfig(
-	cmdRet error, getenvRet string, existsRet bool, mountRet error,
-	unmountRet error, mkdirRet error, removeRet error) configuration {
-
-	return newDefaultConfiguration(
-		newMockExt(
-			cmdRet, getenvRet, existsRet, mountRet, unmountRet,
-			mkdirRet, removeRet))
 }
 
 // defaultMoc2kConfig returns configuration populated from blank config file

--- a/src/control/server/external.go
+++ b/src/control/server/external.go
@@ -114,6 +114,12 @@ func (e *ext) unmount(mntPoint string) error {
 	if err := syscall.Unmount(
 		mntPoint, syscall.MNT_DETACH); err != nil && !os.IsNotExist(err) {
 
+		// when mntpoint exists but is unmounted, get EINVAL
+		e, ok := err.(syscall.Errno)
+		if ok && e == syscall.EINVAL {
+			return nil
+		}
+
 		return os.NewSyscallError("umount", err)
 	}
 	return nil

--- a/src/control/server/iosrv.go
+++ b/src/control/server/iosrv.go
@@ -120,6 +120,12 @@ func formatIosrv(
 		}
 	}
 
+	// after mounting scm, process config parameters for nvme and store
+	// nvme.conf in persistent scm location
+	if err := config.parseNvme(i); err != nil {
+		return errors.Wrap(err, "nvme config could not be processed")
+	}
+
 	log.Debugf(op+" (createMS=%t bootstrapMS=%t)", createMS, bootstrapMS)
 
 	if err := createIosrvSuper(config, i, reformat, createMS, bootstrapMS); err != nil {

--- a/src/control/server/main.go
+++ b/src/control/server/main.go
@@ -130,12 +130,6 @@ func serverMain() error {
 		return err
 	}
 
-	// Process configurations parameters for Nvme.
-	if err = config.parseNvme(); err != nil {
-		log.Errorf("NVMe config could not be processed: %s", err)
-		return err
-	}
-
 	// Only start single io_server for now.
 	// TODO: Extend to start two io_servers per host.
 	iosrv, err := newIosrv(&config, 0)

--- a/src/control/server/mgmt.go
+++ b/src/control/server/mgmt.go
@@ -104,12 +104,16 @@ func (c *controlService) doFormat(i int) error {
 	cond.L.Lock()
 	defer cond.L.Unlock()
 
+	msg := "nvme format"
+	log.Debugf("performing %s, may take several minutes!\n", msg)
 	if err := c.nvme.Format(i); err != nil {
-		return errAnnotate(err, "nvme format")
+		return errAnnotate(err, msg)
 	}
 
+	msg = "scm format"
+	log.Debugf("performing %s, should be quick!\n", msg)
 	if err := c.scm.Format(i); err != nil {
-		return errAnnotate(err, "scm format")
+		return errAnnotate(err, msg)
 	}
 
 	// storage subsystem format successful, signal to alert main.

--- a/src/control/server/mgmt_test.go
+++ b/src/control/server/mgmt_test.go
@@ -25,16 +25,10 @@ package main
 
 import (
 	"fmt"
-	"os"
 	"testing"
 
 	. "github.com/daos-stack/daos/src/control/common"
-	"github.com/daos-stack/daos/src/control/log"
 )
-
-func init() {
-	log.NewDefaultLogger(log.Debug, "mgmt_test: ", os.Stdout)
-}
 
 func defaultMockControlService(t *testing.T) *controlService {
 	c := defaultMockConfig(t)

--- a/src/control/server/mgmt_test.go
+++ b/src/control/server/mgmt_test.go
@@ -51,7 +51,7 @@ func mockControlService(config *configuration) *controlService {
 	return &cs
 }
 
-func TestFormatStorage(t *testing.T) {
+func TestFormatScmStorage(t *testing.T) {
 	tests := []struct {
 		mountRet   error
 		unmountRet error
@@ -104,10 +104,12 @@ func TestFormatStorage(t *testing.T) {
 			}
 		}()
 
+		AssertEqual(t, cs.nvme.formatted, false, tt.desc)
 		AssertEqual(t, cs.scm.formatted, false, tt.desc)
 
 		c.Wait()
 
+		AssertEqual(t, cs.nvme.formatted, true, tt.desc)
 		AssertEqual(t, cs.scm.formatted, true, tt.desc)
 	}
 }

--- a/src/control/server/storage_nvme.go
+++ b/src/control/server/storage_nvme.go
@@ -152,13 +152,6 @@ func (n *nvmeStorage) Teardown() (err error) {
 	return
 }
 
-// Format attempts to format (forcefully) NVMe devices on a given server
-// as specified in config file.
-func (n *nvmeStorage) Format(idx int) error {
-	// TODO: add implementation
-	return nil
-}
-
 // Discover method implementation for nvmeStorage.
 //
 // Initialise SPDK environment before probing controllers then retrieve
@@ -189,55 +182,98 @@ func (n *nvmeStorage) Discover() error {
 	return nil
 }
 
+// Format attempts to format (forcefully) NVMe devices on a given server
+// as specified in config file.
+func (n *nvmeStorage) Format(idx int) error {
+	if !n.initialized {
+		return errors.New("nvme storage not initialized")
+	}
+	if n.formatted {
+		return errors.New(
+			"nvme storage has already been formatted and reformat " +
+				"not implemented")
+	}
+
+	srv := n.config.Servers[idx]
+
+	switch srv.BdevClass {
+	case bdNVMe:
+		for _, pciAddr := range srv.BdevList {
+			if pciAddr == "" {
+				return errors.New("bdev nvme device list entry empty")
+			}
+
+			cs, ns, err := n.nvme.Format(pciAddr)
+			if err != nil {
+				return errors.Wrap(err, "nvme format")
+			}
+			n.controllers = loadControllers(cs, ns)
+		}
+	default:
+		return errors.Errorf(
+			"format unsupported on BdevClass %v", srv.BdevClass)
+	}
+
+	n.formatted = true
+	return nil
+}
+
 // Update method implementation for nvmeStorage
 func (n *nvmeStorage) Update(pciAddr string, path string, slot int32) error {
-	if n.initialized {
-		cs, ns, err := n.nvme.Update(pciAddr, path, slot)
-		if err != nil {
-			return err
-		}
-		n.controllers = loadControllers(cs, ns)
-		return nil
+	if !n.initialized {
+		return errors.New("nvme storage not initialized")
 	}
-	return errors.New("nvme storage not initialized")
+
+	cs, ns, err := n.nvme.Update(pciAddr, path, slot)
+	if err != nil {
+		return err
+	}
+
+	n.controllers = loadControllers(cs, ns)
+	return nil
 }
 
 // BurnIn method implementation for nvmeStorage
 // Doesn't call through go-spdk, returns cmds to be issued over shell
 func (n *nvmeStorage) BurnIn(pciAddr string, nsID int32, configPath string) (
 	fioPath string, cmds []string, env string, err error) {
-	if n.initialized {
-		pluginDir := ""
-		pluginDir, err = common.GetAbsInstallPath(spdkFioPluginDir)
-		if err != nil {
-			return
-		}
-		fioPath, err = common.GetAbsInstallPath(fioExecPath)
-		if err != nil {
-			return
-		}
-		// run fio with spdk plugin specified in LD_PRELOAD env
-		env = fmt.Sprintf("LD_PRELOAD=%s/fio_plugin", pluginDir)
-		// limitation of fio_plugin for spdk is that traddr needs
-		// to not contain colon chars, convert to full-stops
-		// https://github.com/spdk/spdk/tree/master/examples/nvme/fio_plugin .
-		// shm_id specified within fio configs to enable spdk multiprocess
-		// mode required to perform burn-in from Go process.
-		// eta options provided to trigger periodic client responses.
-		cmds = []string{
-			fmt.Sprintf(
-				"--filename=\"trtype=PCIe traddr=%s ns=%d\"",
-				strings.Replace(pciAddr, ":", ".", -1), nsID),
-			"--ioengine=spdk",
-			"--eta=always",
-			"--eta-newline=10",
-			configPath,
-		}
-		log.Debugf(
-			"BurnIn command string: %s %s %v", env, fioPath, cmds)
+
+	if !n.initialized {
+		err = errors.New("nvme storage not initialized")
 		return
 	}
-	err = errors.New("nvme storage not initialized")
+
+	pluginDir := ""
+	pluginDir, err = common.GetAbsInstallPath(spdkFioPluginDir)
+	if err != nil {
+		return
+	}
+
+	fioPath, err = common.GetAbsInstallPath(fioExecPath)
+	if err != nil {
+		return
+	}
+
+	// run fio with spdk plugin specified in LD_PRELOAD env
+	env = fmt.Sprintf("LD_PRELOAD=%s/fio_plugin", pluginDir)
+	// limitation of fio_plugin for spdk is that traddr needs
+	// to not contain colon chars, convert to full-stops
+	// https://github.com/spdk/spdk/tree/master/examples/nvme/fio_plugin .
+	// shm_id specified within fio configs to enable spdk multiprocess
+	// mode required to perform burn-in from Go process.
+	// eta options provided to trigger periodic client responses.
+	cmds = []string{
+		fmt.Sprintf(
+			"--filename=\"trtype=PCIe traddr=%s ns=%d\"",
+			strings.Replace(pciAddr, ":", ".", -1), nsID),
+		"--ioengine=spdk",
+		"--eta=always",
+		"--eta-newline=10",
+		configPath,
+	}
+	log.Debugf(
+		"BurnIn command string: %s %s %v", env, fioPath, cmds)
+
 	return
 }
 
@@ -249,7 +285,6 @@ func loadControllers(ctrlrs []spdk.Controller, nss []spdk.Namespace) (
 		pbCtrlrs = append(
 			pbCtrlrs,
 			&pb.NvmeController{
-				Id:      c.ID,
 				Model:   c.Model,
 				Serial:  c.Serial,
 				Pciaddr: c.PCIAddr,

--- a/src/control/server/storage_nvme_test.go
+++ b/src/control/server/storage_nvme_test.go
@@ -25,21 +25,15 @@ package main
 
 import (
 	"fmt"
-	"os"
 	"strings"
 	"testing"
 
 	. "github.com/daos-stack/daos/src/control/common"
 	pb "github.com/daos-stack/daos/src/control/common/proto/mgmt"
-	"github.com/daos-stack/daos/src/control/log"
 	. "github.com/daos-stack/go-spdk/spdk"
 )
 
 var nvmeFormatCalls []string
-
-func init() {
-	log.NewDefaultLogger(log.Error, "storage_nvme_test: ", os.Stderr)
-}
 
 // MockController is a mock NVMe SSD controller of type exported from go-spdk.
 func MockController(fwrev string) Controller {

--- a/src/control/server/storage_nvme_test.go
+++ b/src/control/server/storage_nvme_test.go
@@ -35,6 +35,8 @@ import (
 	. "github.com/daos-stack/go-spdk/spdk"
 )
 
+var nvmeFormatCalls []string
+
 func init() {
 	log.NewDefaultLogger(log.Error, "storage_nvme_test: ", os.Stderr)
 }
@@ -43,7 +45,6 @@ func init() {
 func MockController(fwrev string) Controller {
 	c := MockControllerPB(fwrev)
 	return Controller{
-		ID:      c.Id,
 		Model:   c.Model,
 		Serial:  c.Serial,
 		PCIAddr: c.Pciaddr,
@@ -74,6 +75,10 @@ type mockSpdkNvme struct {
 }
 
 func (m *mockSpdkNvme) Discover() ([]Controller, []Namespace, error) {
+	return m.initCtrlrs, m.initNss, nil
+}
+func (m *mockSpdkNvme) Format(pciAddr string) ([]Controller, []Namespace, error) {
+	nvmeFormatCalls = append(nvmeFormatCalls, pciAddr)
 	return m.initCtrlrs, m.initNss, nil
 }
 func (m *mockSpdkNvme) Update(pciAddr string, path string, slot int32) (
@@ -167,8 +172,8 @@ func TestDiscoveryNvmeMulti(t *testing.T) {
 	}{
 		{
 			[]Controller{
-				{0, "", "", "1.2.3.4.5", "1.0.0"},
-				{0, "", "", "1.2.3.4.6", "1.0.0"},
+				{"", "", "1.2.3.4.5", "1.0.0"},
+				{"", "", "1.2.3.4.6", "1.0.0"},
 			},
 			[]Namespace{
 				{0, 100, "1.2.3.4.5"},
@@ -177,15 +182,15 @@ func TestDiscoveryNvmeMulti(t *testing.T) {
 		},
 		{
 			[]Controller{
-				{0, "", "", "1.2.3.4.5", "1.0.0"},
-				{0, "", "", "1.2.3.4.6", "1.0.0"},
+				{"", "", "1.2.3.4.5", "1.0.0"},
+				{"", "", "1.2.3.4.6", "1.0.0"},
 			},
 			[]Namespace{},
 		},
 		{
 			[]Controller{
-				{0, "", "", "1.2.3.4.5", "1.0.0"},
-				{0, "", "", "1.2.3.4.6", "1.0.0"},
+				{"", "", "1.2.3.4.5", "1.0.0"},
+				{"", "", "1.2.3.4.6", "1.0.0"},
 			},
 			[]Namespace{
 				{0, 100, "1.2.3.4.5"},
@@ -241,6 +246,74 @@ func TestDiscoveryNvmeMulti(t *testing.T) {
 				t.Fatalf("namespace not found: %v", n)
 			}
 		}
+	}
+}
+
+func TestFormatNvme(t *testing.T) {
+	tests := []struct {
+		inited    bool
+		formatted bool
+		pciAddrs  []string
+		errMsg    string
+	}{
+		{
+			true,
+			false,
+			[]string{},
+			"",
+		},
+		{
+			false,
+			true,
+			[]string{},
+			"nvme storage not initialized",
+		},
+		{
+			true,
+			true,
+			[]string{},
+			"nvme storage has already been formatted and reformat " +
+				"not implemented",
+		},
+		{
+			true,
+			false,
+			[]string{"0000:81:00.0", "0000:83:00.0"},
+			"",
+		},
+	}
+
+	c := MockControllerPB("1.0.0")
+	srvIdx := 0 // assume just a single io_server (index 0)
+
+	for _, tt := range tests {
+		nvmeFormatCalls = []string{}
+
+		config := defaultMockConfig(t)
+		config.Servers[srvIdx].BdevList = tt.pciAddrs
+		sn := defaultMockNvmeStorage(&config)
+
+		if tt.inited {
+			if err := sn.Discover(); err != nil {
+				t.Fatal(err)
+			}
+		}
+
+		if err := sn.Format(srvIdx); err != nil {
+			if tt.errMsg != "" {
+				ExpectError(t, err, tt.errMsg, "")
+				continue
+			}
+			t.Fatal(err)
+		}
+
+		AssertEqual(
+			t, nvmeFormatCalls, tt.pciAddrs,
+			"unexpected list of pci addresses in format calls")
+		AssertEqual(t, sn.formatted, true, "expect formatted state")
+		AssertEqual(
+			t, sn.controllers, []*pb.NvmeController{c},
+			"unexpected list of protobuf format controllers")
 	}
 }
 

--- a/src/control/server/storage_scm.go
+++ b/src/control/server/storage_scm.go
@@ -103,6 +103,8 @@ func (s *scmStorage) Discover() error {
 	if s.initialized {
 		mms, err := s.ipmCtl.Discover()
 		if err != nil {
+			// TODO: check and handle permissions and no module errs
+			//       to give caller useful message.
 			return err
 		}
 		pbMms, err := loadModules(mms)
@@ -180,6 +182,12 @@ func (s *scmStorage) makeMount(
 func (s *scmStorage) Format(idx int) error {
 	var devType, devPath, mntOpts string
 
+	if s.formatted {
+		return errors.New(
+			"scm storage has already been formatted and reformat " +
+				"not implemented")
+	}
+
 	srv := s.config.Servers[idx]
 	mntPoint := srv.ScmMount
 
@@ -194,7 +202,8 @@ func (s *scmStorage) Format(idx int) error {
 	case scmDCPM:
 		if len(srv.ScmList) != 1 {
 			return errors.New(
-				"expecting one scm dcpm pmem device per-server in config")
+				"expecting one scm dcpm pmem device per-server " +
+					"in config")
 		}
 		devPath = srv.ScmList[0]
 		if devPath == "" {

--- a/src/control/server/storage_scm_test.go
+++ b/src/control/server/storage_scm_test.go
@@ -25,17 +25,11 @@ package main
 
 import (
 	"fmt"
-	"os"
 	"testing"
 
 	. "github.com/daos-stack/daos/src/control/common"
-	"github.com/daos-stack/daos/src/control/log"
 	. "github.com/daos-stack/go-ipmctl/ipmctl"
 )
-
-func init() {
-	log.NewDefaultLogger(log.Error, "storage_scm_test: ", os.Stderr)
-}
 
 // MockModule returns a mock SCM module of type exported from go-ipmctl.
 func MockModule() DeviceDiscovery {

--- a/src/control/vendor/github.com/daos-stack/go-spdk/Taskfile.yml
+++ b/src/control/vendor/github.com/daos-stack/go-spdk/Taskfile.yml
@@ -17,7 +17,7 @@ tasks:
   unit-tests:
     dir: spdk
     cmds:
-      - go test
+      - LD_LIBRARY_PATH=. go test
 
   build-spdk:
     dir: spdk

--- a/src/control/vendor/github.com/daos-stack/go-spdk/spdk/include/nvme_control.h
+++ b/src/control/vendor/github.com/daos-stack/go-spdk/spdk/include/nvme_control.h
@@ -29,13 +29,29 @@
 #define NVMECONTROL_GBYTE_BYTES 1000000000
 
 /**
+ * @brief NVMECONTROL return codes
+ */
+typedef enum _NvmeControlStatusCode {
+	NVMEC_SUCCESS			= 0,
+	NVMEC_ERR_CHK_SIZE		= 1,
+	NVMEC_ERR_GET_PCI_DEV		= 2,
+	NVMEC_ERR_PCI_ADDR_FMT		= 3,
+	NVMEC_ERR_PCI_ADDR_PARSE	= 4,
+	NVMEC_ERR_CTRLR_NOT_FOUND	= 5,
+	NVMEC_ERR_NS_NOT_FOUND		= 6,
+	NVMEC_ERR_NOT_SUPPORTED		= 7,
+	NVMEC_ERR_BAD_LBA		= 8,
+	NVMEC_LAST_STATUS_VALUE
+} NvmeControlStatusCode;
+
+
+/**
  * \brief NVMe controller details
  */
 struct ctrlr_t {
-	int		id;
 	char		model[1024];
 	char		serial[1024];
-	char		tr_addr[SPDK_NVMF_TRADDR_MAX_LEN + 1];
+	char		pci_addr[1024];
 	char		fw_rev[1024];
 	struct ctrlr_t	*next;
 };
@@ -78,6 +94,15 @@ struct ret_t *nvme_discover(void);
  * \return a pointer to a return struct (ret_t).
  */
 struct ret_t *nvme_fwupdate(char *ctrlr_pci_addr, char *path, unsigned int slot);
+
+/**
+ * Format NVMe controller namespace.
+ *
+ * \param ctrlr_pci_addr PCI address of NVMe controller.
+ *
+ * \return a pointer to a return struct (ret_t).
+ */
+struct ret_t *nvme_format(char *ctrlr_pci_addr);
 
 /**
  * Cleanup structs held in memory.

--- a/src/control/vendor/github.com/daos-stack/go-spdk/spdk/spdk.go
+++ b/src/control/vendor/github.com/daos-stack/go-spdk/spdk/spdk.go
@@ -59,7 +59,7 @@ func Rc2err(label string, rc C.int) error {
 			rc = -rc
 		}
 		// e := errors.Error(rc)
-		return fmt.Errorf("%s: %s", label, rc) // e
+		return fmt.Errorf("%s: %d", label, rc) // e
 	}
 	return nil
 }

--- a/src/control/vendor/github.com/daos-stack/go-spdk/spdk/src/nvme_control.c
+++ b/src/control/vendor/github.com/daos-stack/go-spdk/spdk/src/nvme_control.c
@@ -510,13 +510,6 @@ nvme_format(char *ctrlr_pci_addr)
 		return ret;
 	}
 
-	// TODO: move this consent to caller
-	printf("Warning: use this utility at your own risk.\n"
-	       "This command will format your namespace and all data will be lost.\n"
-	       "This command may take several minutes to complete,\n"
-	       "so do not interrupt the utility until it completes.\n");
-	//      "Press 'Y' to continue with the format operation.\n");
-
 	format.lbaf	= 0; // LBA format defaulted to 0
 	format.ms	= 0; // metadata transferred as part of a separate buffer
 	format.pi	= 0; // protection information is not enabled

--- a/utils/config/examples/daos_server_psm2.yml
+++ b/utils/config/examples/daos_server_psm2.yml
@@ -12,7 +12,7 @@ format_override: true       # don't require manual storage format over client AP
 # single server instance per config file for now
 servers:
 -
-  targets: [0-7]            # map to -c 8, just count number of #cpus in the range for now
+  targets: [0-7]            # map to -t 8, just count number of cpus in the range for now
   fabric_iface: ib0         # map to OFI_INTERFACE=ib0
   fabric_iface_port: 31416  # map to OFI_PORT=31416
   log_mask: ERR             # map to D_LOG_MASK=ERR

--- a/utils/config/examples/daos_server_sockets.yml
+++ b/utils/config/examples/daos_server_sockets.yml
@@ -12,7 +12,7 @@ format_override: true       # don't require manual storage format over client AP
 # single server instance per config file for now
 servers:
 -
-  targets: [0-7]            # map to -c 8, just count number of #cpus in the range for now
+  targets: [0-7]            # map to -t 8, just count number of cpus in the range for now
   fabric_iface: eth0        # map to OFI_INTERFACE=eth0
   fabric_iface_port: 31416  # map to OFI_PORT=31416
   log_mask: ERR             # map to D_LOG_MASK=ERR


### PR DESCRIPTION
Force format SSDs identified by PCI addresses listed in bdev_list
parameter in server config file. No attention will be paid to whether
the device has an existing blob store, if this is required it can be
added in a future iteration.

Update go-spdk bindings to provide format capability using PCI
address to identify a controller. Perform format during FormatStorage
client API call alongside SCM subsystem format. Add details to server
README.md and unit tests.

Signed-off-by: Tom Nabarro <tom.nabarro@intel.com>