### PR TITLE
DAOS-644 and DAOS-1587:  Configuration file for daos_agent

### DIFF
--- a/src/control/client/config.go
+++ b/src/control/client/config.go
@@ -1,0 +1,82 @@
+//
+// (C) Copyright 2018-2019 Intel Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// GOVERNMENT LICENSE RIGHTS-OPEN SOURCE SOFTWARE
+// The Government's rights to use, modify, reproduce, release, perform, display,
+// or disclose this software are subject to the terms of the Apache License as
+// provided in Contract No. 8F-30005.
+// Any reproduction of computer software, computer software documentation, or
+// portions thereof marked with this legend must also reproduce the markings.
+//
+
+package client
+
+import (
+	"io/ioutil"
+	"strconv"
+	"github.com/daos-stack/daos/src/control/log"
+)
+
+const (
+	providerEnvKey = "CRT_PHY_ADDR_STR"
+	ofi_interface_env = "OFI_INTERFACE"
+	ofi_port_env = "OFI_PORT"
+	daos_agent_drpc_sock_env = "DAOS_AGENT_DRPC_SOCK"
+)
+
+func (c *ClientConfiguration) LoadConfig() error {
+	bytes, err := ioutil.ReadFile(c.Path)
+	if err != nil {
+		return err
+	}
+	if err = c.parse(bytes); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func ProcessEnvOverrides(c *ClientConfiguration) int {
+	var env_vars_found = 0
+	if c.ext.getenv(providerEnvKey) != "" {
+		log.Debugf("Provider key found .. reading environment vars")
+		ofi_interface := c.ext.getenv(ofi_interface_env)
+		if ofi_interface != "" {
+			log.Debugf("OFI_INTERFACE found: %s", ofi_interface)
+			c.FabricIface = ofi_interface
+			env_vars_found ++
+		}
+		ofi_port := c.ext.getenv(ofi_port_env)
+		if ofi_port != "" {
+			log.Debugf("OFI_PORT found: %s", ofi_port)
+			port, err := strconv.Atoi(ofi_port)
+			if err != nil {
+				log.Debugf("Error while converting OFI_PORT to integer.  Not using OFI_PORT")
+			}
+			if err == nil {
+				c.FabricIfacePort = port
+				env_vars_found ++
+			}
+		}
+		daos_agent_drpc_sock := c.ext.getenv(daos_agent_drpc_sock_env)
+		if daos_agent_drpc_sock != "" {
+			log.Debugf("DAOS_AGENT_DRPC_SOCK found: %s", daos_agent_drpc_sock)
+			c.DAOS_AGENT_DRPC_SOCK = daos_agent_drpc_sock
+			env_vars_found ++
+		}
+	}
+	return env_vars_found
+}
+

--- a/src/control/client/config_types.go
+++ b/src/control/client/config_types.go
@@ -1,0 +1,95 @@
+// (C) Copyright 2018-2019 Intel Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// GOVERNMENT LICENSE RIGHTS-OPEN SOURCE SOFTWARE
+// The Government's rights to use, modify, reproduce, release, perform, display,
+// or disclose this software are subject to the terms of the Apache License as
+// provided in Contract No. 8F-30005.
+// Any reproduction of computer software, computer software documentation, or
+// portions thereof marked with this legend must also reproduce the markings.
+//
+
+package client
+
+import (
+	"os"
+	"os/exec"
+
+	"gopkg.in/yaml.v2"
+)
+
+// External interface provides methods to support various os operations.
+type External interface {
+	getenv(string) string
+}
+
+type ext struct{}
+
+// runCommand executes command in subshell (to allow redirection) and returns
+// error result.
+func (e *ext) runCommand(cmd string) error {
+	return exec.Command("sh", "-c", cmd).Run()
+}
+
+// getEnv wraps around os.GetEnv and implements External.getEnv().
+func (e *ext) getenv(key string) string {
+	return os.Getenv(key)
+}
+
+type ClientConfiguration struct {
+	SystemName      string          `yaml:"name"`
+	SocketDir       string          `yaml:"socket_dir"`
+	AccessPoints    []string        `yaml:"access_points"`
+	Port            int             `yaml:"port"`
+	CaCert          string          `yaml:"ca_cert"`
+	Cert            string          `yaml:"cert"`
+	Key             string          `yaml:"key"`
+	Provider        string          `yaml:"provider"`
+	FabricIface     string          `yaml:"fabric_iface"`
+	FabricIfacePort int             `yaml:"fabric_iface_port"`
+	DAOS_AGENT_DRPC_SOCK string
+	Path            string
+	ext             External
+}
+
+// parse decodes YAML representation of configure struct and checks for Group
+func (c *ClientConfiguration) parse(data []byte) error {
+	return yaml.Unmarshal(data, c)
+}
+
+// newDefaultConfiguration creates a new instance of configuration struct
+// populated with defaults.
+func newDefaultConfiguration(ext External) ClientConfiguration {
+	return ClientConfiguration{
+		SystemName:     "daos",
+		SocketDir:      "/var/run/daos_agent",
+		AccessPoints:   []string{"localhost"},
+		Port:           10000,
+	        CaCert:         "./.daos/ca.crt",
+	        Cert:           "./.daos/daos.crt",
+		Key:            "./.daos/daos.key",
+		Provider:	"ofi+socket",
+		FabricIface:	"qib0",
+		FabricIfacePort: 20000,
+		Path:           "etc/daos.yml",
+		DAOS_AGENT_DRPC_SOCK: "",
+		ext:            ext,
+	}
+}
+
+// newConfiguration creates a new instance of configuration struct
+// populated with defaults and default external interface.
+func NewConfiguration() ClientConfiguration {
+	return newDefaultConfiguration(&ext{})
+}

--- a/utils/config/daos.yml
+++ b/utils/config/daos.yml
@@ -1,8 +1,8 @@
 # DAOS agent configuration file.
 #
 # Location of this configuration file is determined by first checking for the
-# path specified through the -f option of the daos_agent command line.
-# Otherwise, /etc/daos.conf is used.
+# path specified through the -o option of the daos_agent command line.
+# Otherwise, /etc/daos.yml is used.
 #
 # Section describing the client configuration
 #
@@ -10,33 +10,72 @@
 # DAOS installations from the same node in the future.
 #
 # Specify the associated DAOS systems.
-# Name must match name specifed in the daos_server.conf file on the server.
+# Name must match name specifed in the daos_server.yml file on the server.
 #
-systems:
--
-  name: daos
+# # default: daos
+name: daos
+
+#
+#  TODO: Rework this description
 #
 #  # Access points
 #  # To operate, DAOS will need a quorum of access point nodes to be available.
 #  # Hosts can be specified with or without port, default port below.
 #  #
-#  # access_pts: ['hostname1:10001','hostname2:10001','hostname3:10001']
+#  # default: ??? TBD
 #  # access_pts: [hostname1,hostname2,hostname3]
+access_points: ['hostname1:10001','hostname2:10001','hostname3:10001']
+
 #
-#  # Force default port number to connect to on daos_server, this will also
+# TODO: Rework this description
+#
+#  # Force default port number to connect to daos_server, this will also
 #  # be used when connecting to access points if no port is specified.
 #  #
 #  # default: 10000
-#  # port: 10001
+port: 10000
+
 #
 #  # Path to CA certificate
 #  # Not required if the DAOS server is configured in an insecured way
 #  #
-#  # ca_cert: ./.daos/ca.crt
+# # default: ./.daos/ca.crt
+ca_cert: ./.daos/ca.crt
+
 #
 #  # Path to client certificate and key file.
 #  # Discarded if no CA certificate is passed.
 #  #
 #  # default: ./.daos/daos.{crt,key}
-#  # cert: ./.daos/daos.crt
-#  # key: ./.daos/daos.key
+cert: ./.daos/daos.crt
+key: ./.daos/daos.key
+
+#
+## Use specific OFI interface and port
+#
+## Specify the single fabric interface used by the client to connect with the DAOS server.
+# # default: The fabric interface is autodetected.  Specify a value to override.
+fabric_iface: qib0
+## Specify the fabric interface port to use with the fabric_iface chosen above
+fabric_iface_port: 20000
+
+#
+## Use specific OFI provider
+#
+## Specify the provider that matches the DAOS server.
+## ofi+psm2 for Omni-Path, ofi+verbs;ofi_rxm for Infiniband/RoCE and finally
+## ofi+socket for non-RDMA-capable Ethernet.
+#
+# # default: ??? TBD
+provider: ofi+socket
+
+#
+## Use the given directory for creating unix domain sockets
+#
+## DAOS Agent and DAOS Server both use unix domain sockets for communication
+## with other system components. This setting is the base location to place
+## the sockets in.
+#
+# TODO: validate this default value
+## default: /var/run/daos_agent
+socket_dir: /var/run/daos_agent


### PR DESCRIPTION
Add configuration file support to DAOS client.  Parse the configuration
for the agent and dmg applications.

Added entries to existing daos.yml to match expected configuration needs.
Client now supports reading the yml and populating the related configuration
structure.  The application command line arguments override config file
attributes where applicable.

Signed-off-by: Joel Rosenzweig <joel.b.rosenzweig@intel.com>