### PR TITLE
DAOS-1822 rsvc: Fix bootstrap_self hangs

### DIFF
--- a/src/pool/srv_pool.c
+++ b/src/pool/srv_pool.c
@@ -1535,6 +1535,7 @@ out_tx:
 			D_GOTO(out_svc, rc);
 		}
 		svc->ps_rsvc.s_state = DS_RSVC_UP;
+		ABT_cond_broadcast(svc->ps_rsvc.s_state_cv);
 	}
 
 out_mutex:


### PR DESCRIPTION
After changing svc->s_state, rsvc_step_up_cb forgets to signal
svc->s_state_cv. The bug causes bootstrap_self to hang indefinitely.
This patch adds a helper function, change_state, to avoid similar bugs.

Once Pool Service moves to the new bootstrap method, it shall not access
ds_rsvc states anymore. Hence, change_state is not exported to pool.

Signed-off-by: Li Wei <wei.g.li@intel.com>