### PR TITLE
DAOS-2312 object: add a few basic obj classes for EC

### DIFF
--- a/src/include/daos_types.h
+++ b/src/include/daos_types.h
@@ -569,6 +569,12 @@ enum {
 				 * These 3 XX_SPEC are mostly for testing
 				 * purpose.
 				 */
+	DAOS_OC_EC_K2P2_L32K,	/* Erasure code, 2 data cells, 2 parity cell,
+				 * cell size 32KB.
+				 */
+	DAOS_OC_EC_K8P2_L1M,	/* Erasure code, 8 data cells, 2 parity cells,
+				 * cell size 1MB.
+				 */
 };
 
 /** Object class attributes */
@@ -598,14 +604,12 @@ typedef struct daos_oclass_attr {
 
 		/** Erasure coding attributes */
 		struct daos_ec_attr {
-			/** Type of EC */
-			unsigned int	 e_type;
-			/** EC group size */
-			unsigned int	 e_grp_size;
-			/**
-			 * TODO: add members to describe erasure coding
-			 * attributes
-			 */
+			/** number of data cells (k) */
+			unsigned short	 e_k;
+			/** number of parity cells (p) */
+			unsigned short	 e_p;
+			/** length of each block of data (cell) */
+			unsigned int	 e_len;
 		} ec;
 	} u;
 	/** TODO: add more attributes */

--- a/src/object/cli_mod.c
+++ b/src/object/cli_mod.c
@@ -50,9 +50,16 @@ dc_obj_init(void)
 
 	rc = daos_rpc_register(&obj_proto_fmt, OBJ_PROTO_CLI_COUNT,
 				NULL, DAOS_OBJ_MODULE);
-	if (rc != 0)
+	if (rc != 0) {
 		D_ERROR("failed to register daos obj RPCs: %d\n", rc);
+		D_GOTO(out, rc);
+	}
 
+	rc = obj_ec_codec_init();
+	if (rc != 0)
+		D_ERROR("failed to obj_ec_codec_init: %d\n", rc);
+
+out:
 	return rc;
 }
 
@@ -63,4 +70,5 @@ void
 dc_obj_fini(void)
 {
 	daos_rpc_unregister(&obj_proto_fmt);
+	obj_ec_codec_fini();
 }

--- a/src/object/obj_internal.h
+++ b/src/object/obj_internal.h
@@ -108,6 +108,17 @@ struct dc_object {
 	struct dc_obj_layout	*cob_shards;
 };
 
+/** EC codec for object EC encoding/decoding */
+struct obj_ec_codec {
+	/** encode matrix, can be used to generate decode matrix */
+	unsigned char		*ec_en_matrix;
+	/**
+	 * GF (galois field) tables, pointer to array of input tables generated
+	 * from coding coefficients. Needed for both encoding and decoding.
+	 */
+	unsigned char		*ec_gftbls;
+};
+
 static inline void
 enum_anchor_copy(daos_anchor_t *dst, daos_anchor_t *src)
 {
@@ -219,5 +230,10 @@ obj_dkey2hash(daos_key_t *dkey)
 	return d_hash_murmur64((unsigned char *)dkey->iov_buf,
 			       dkey->iov_len, 5731);
 }
+
+/* obj_class.c */
+int obj_ec_codec_init(void);
+void obj_ec_codec_fini(void);
+struct obj_ec_codec *obj_ec_codec_get(daos_oclass_id_t oc_id);
 
 #endif /* __DAOS_OBJ_INTENRAL_H__ */

--- a/src/object/srv_mod.c
+++ b/src/object/srv_mod.c
@@ -35,13 +35,21 @@
 static int
 obj_mod_init(void)
 {
+	int rc;
+
 	vos_dtx_register_check_leader(ds_pool_check_leader);
-	return 0;
+
+	rc = obj_ec_codec_init();
+	if (rc != 0)
+		D_ERROR("failed to obj_ec_codec_init: %d\n", rc);
+
+	return rc;
 }
 
 static int
 obj_mod_fini(void)
 {
+	obj_ec_codec_fini();
 	return 0;
 }
 


### PR DESCRIPTION
1) add two basic EC object classes
2) init/fini the EC object classes' gf tables, so can use it later
3) provide a helper daos_oc_gftbls_get() to query EC gf tables for
   obj class ID.

Signed-off-by: Xuezhao Liu <xuezhao.liu@intel.com>