### PR TITLE
DAOS-656 security: Enforce pool access with ACL

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -153,6 +153,7 @@ pipeline {
                                                  build/src/iosrv/tests/drpc_handler_tests,
                                                  build/src/iosrv/tests/drpc_listener_tests,
                                                  build/src/security/tests/cli_security_tests,
+                                                 build/src/security/tests/srv_acl_tests,
                                                  build/src/vos/vea/tests/vea_ut,
                                                  scons_local/build_info/**,
                                                  src/common/tests/btree.sh,

--- a/src/include/daos_srv/security.h
+++ b/src/include/daos_srv/security.h
@@ -29,25 +29,30 @@
 #define __DAOS_SRV_SECURITY_H__
 
 #include <daos_types.h>
-#include <daos_srv/daos_server.h>
+#include <daos_security.h>
 #include <daos_srv/pool.h>
 
 /**
  * Determine whether the provided credentials can access a pool.
  *
- * \param[in]	ugm		Pool properties uid/gid/mode
- * \param[in]	cred		Opaque Credential Data
- * \param[in]	access		Requested pool access
+ * \param[in]	acl		Access Control List for pool
+ * \param[in]	ugm		Pool ownership uid/gid
+ * \param[in]	cred		Credentials of user attempting access
+ * \param[in]	capas		Requested access capabilities (DAOS_PC_* flags
+ *				from include/daos_types.h)
  *
- * \return	0		Success. The access is allowed.
+ * \return	0		Requested access is allowed
+ *		-DER_NO_PERM	Requested access is forbidden
  *		-DER_INVAL	Invalid parameter
- *		-DER_BADPATH	Can't connect to the daos_server socket at
+ *		-DER_BADPATH	Can't connect to the control plane socket at
  *				the expected path
  *		-DER_NOMEM	Out of memory
- *		-DER_NOREPLY	No response from daos_server
- *		-DER_MISC	Invalid response from daos_server
- *		-DER_NO_PERM	Credential does not have access
+ *		-DER_NOREPLY	No response from control plane
+ *		-DER_MISC	Error in control plane communications
+ *		-DER_PROTO	Unexpected or corrupt payload from control plane
  */
-int ds_sec_check_pool_access(const struct pool_prop_ugm *ugm, d_iov_t *cred,
-				uint64_t access);
+int
+ds_sec_check_pool_access(struct daos_acl *acl, struct pool_prop_ugm *ugm,
+			 d_iov_t *cred, uint64_t capas);
+
 #endif /* __DAOS_SRV_SECURITY_H__ */

--- a/src/pool/srv_pool.c
+++ b/src/pool/srv_pool.c
@@ -1733,6 +1733,8 @@ ds_pool_connect_handler(crt_rpc_t *rpc)
 	uint32_t			nhandles;
 	int				skip_update = 0;
 	int				rc;
+	daos_prop_t		       *prop;
+	struct daos_prop_entry	       *acl_entry;
 
 	D_DEBUG(DF_DSMS, DF_UUID": processing rpc %p: hdl="DF_UUID"\n",
 		DP_UUID(in->pci_op.pi_uuid), rpc, DP_UUID(in->pci_op.pi_hdl));
@@ -1793,12 +1795,26 @@ ds_pool_connect_handler(crt_rpc_t *rpc)
 	if (rc != 0)
 		D_GOTO(out_map_version, rc);
 
-	rc = ds_sec_check_pool_access(&ugm, &in->pci_cred, in->pci_capas);
+	/* Fetch ACL for access check */
+	rc = pool_prop_read(&tx, svc, DAOS_PO_QUERY_PROP_ACL, &prop);
+	if (rc != 0) {
+		D_ERROR(DF_UUID": cannot get ACL for pool, rc=%d\n",
+			DP_UUID(in->pci_op.pi_uuid), rc);
+		D_GOTO(out_map_version, rc);
+	}
+	D_ASSERT(prop != NULL);
+
+	acl_entry = daos_prop_entry_get(prop, DAOS_PROP_PO_ACL);
+	D_ASSERT(acl_entry != NULL);
+	D_ASSERT(acl_entry->dpe_val_ptr != NULL);
+
+	rc = ds_sec_check_pool_access(acl_entry->dpe_val_ptr, &ugm,
+			&in->pci_cred, in->pci_capas);
 	if (rc != 0) {
 		D_ERROR(DF_UUID": refusing connect attempt for "
 			DF_X64" error: %d\n", DP_UUID(in->pci_op.pi_uuid),
 			in->pci_capas, rc);
-		D_GOTO(out_map_version, rc = -DER_NO_PERM);
+		D_GOTO(out_pool_prop, rc = -DER_NO_PERM);
 	}
 
 	out->pco_uid = ugm.pp_uid;
@@ -1816,22 +1832,22 @@ ds_pool_connect_handler(crt_rpc_t *rpc)
 	rc = transfer_map_buf(&tx, svc, rpc, in->pci_map_bulk,
 			      &out->pco_map_buf_size, &map_buf_bulk);
 	if (rc != 0)
-		D_GOTO(out_map_version, rc);
+		D_GOTO(out_pool_prop, rc);
 
 	if (skip_update)
-		D_GOTO(out_map_version, rc = 0);
+		D_GOTO(out_pool_prop, rc = 0);
 
 	daos_iov_set(&value, &nhandles, sizeof(nhandles));
 	rc = rdb_tx_lookup(&tx, &svc->ps_root, &ds_pool_prop_nhandles, &value);
 	if (rc != 0)
-		D_GOTO(out_map_version, rc);
+		D_GOTO(out_pool_prop, rc);
 
 	/* Take care of exclusive handles. */
 	if (nhandles != 0) {
 		if (in->pci_capas & DAOS_PC_EX) {
 			D_DEBUG(DF_DSMS, DF_UUID": others already connected\n",
 				DP_UUID(in->pci_op.pi_uuid));
-			D_GOTO(out_map_version, rc = -DER_BUSY);
+			D_GOTO(out_pool_prop, rc = -DER_BUSY);
 		} else {
 			/*
 			 * If there is a non-exclusive handle, then all handles
@@ -1842,9 +1858,9 @@ ds_pool_connect_handler(crt_rpc_t *rpc)
 					  RDB_PROBE_FIRST, NULL /* key_in */,
 					  NULL /* key_out */, &value);
 			if (rc != 0)
-				D_GOTO(out_map_version, rc);
+				D_GOTO(out_pool_prop, rc);
 			if (hdl.ph_capas & DAOS_PC_EX)
-				D_GOTO(out_map_version, rc = -DER_BUSY);
+				D_GOTO(out_pool_prop, rc = -DER_BUSY);
 		}
 	}
 
@@ -1854,7 +1870,7 @@ ds_pool_connect_handler(crt_rpc_t *rpc)
 	if (rc != 0) {
 		D_ERROR(DF_UUID": failed to connect to targets: %d\n",
 			DP_UUID(in->pci_op.pi_uuid), rc);
-		D_GOTO(out_map_version, rc);
+		D_GOTO(out_pool_prop, rc);
 	}
 
 	hdl.ph_capas = in->pci_capas;
@@ -1863,15 +1879,18 @@ ds_pool_connect_handler(crt_rpc_t *rpc)
 	daos_iov_set(&value, &nhandles, sizeof(nhandles));
 	rc = rdb_tx_update(&tx, &svc->ps_root, &ds_pool_prop_nhandles, &value);
 	if (rc != 0)
-		D_GOTO(out_map_version, rc);
+		D_GOTO(out_pool_prop, rc);
 
 	daos_iov_set(&key, in->pci_op.pi_hdl, sizeof(uuid_t));
 	daos_iov_set(&value, &hdl, sizeof(hdl));
 	rc = rdb_tx_update(&tx, &svc->ps_handles, &key, &value);
 	if (rc != 0)
-		D_GOTO(out_map_version, rc);
+		D_GOTO(out_pool_prop, rc);
 
 	rc = rdb_tx_commit(&tx);
+
+out_pool_prop:
+	daos_prop_free(prop);
 out_map_version:
 	out->pco_op.po_map_version = pool_map_get_version(svc->ps_pool->sp_map);
 out_lock:

--- a/src/security/srv_acl.c
+++ b/src/security/srv_acl.c
@@ -183,19 +183,28 @@ get_auth_sys_payload(AuthToken *token, AuthSys **payload)
 }
 
 static bool
+ace_allowed(struct daos_ace *ace, enum daos_acl_perm perm)
+{
+	if (ace->dae_allow_perms & perm)
+		return true;
+
+	return false;
+}
+
+static bool
 ace_has_access(struct daos_ace *ace, uint64_t capas)
 {
 	D_DEBUG(DB_MGMT, "Allow Perms: 0x%lx\n", ace->dae_allow_perms);
 
 	if ((capas & DAOS_PC_RO) &&
-	    (ace->dae_allow_perms & DAOS_ACL_PERM_READ)) {
+	    ace_allowed(ace, DAOS_ACL_PERM_READ)) {
 		D_DEBUG(DB_MGMT, "Allowing read-only access\n");
 		return true;
 	}
 
 	if ((capas & (DAOS_PC_RW | DAOS_PC_EX)) &&
-	    (ace->dae_allow_perms & DAOS_ACL_PERM_READ) &&
-	    (ace->dae_allow_perms & DAOS_ACL_PERM_WRITE)) {
+	    ace_allowed(ace, DAOS_ACL_PERM_READ) &&
+	    ace_allowed(ace, DAOS_ACL_PERM_WRITE)) {
 		D_DEBUG(DB_MGMT, "Allowing RW access\n");
 		return true;
 	}

--- a/src/security/srv_acl.c
+++ b/src/security/srv_acl.c
@@ -42,12 +42,12 @@ sanity_check_validation_response(Drpc__Response *response)
 			response->body.len, response->body.data);
 	if (pb_auth == NULL) {
 		D_ERROR("Response body was not an AuthToken\n");
-		return -DER_MISC;
+		return -DER_PROTO;
 	}
 
 	if (!pb_auth->has_data) {
 		D_ERROR("AuthToken did not include data\n");
-		rc = -DER_MISC;
+		rc = -DER_PROTO;
 	}
 
 	auth_token__free_unpacked(pb_auth, NULL);
@@ -133,7 +133,7 @@ process_validation_response(Drpc__Response *response,
 					response->body.data);
 	if (auth == NULL) {
 		D_ERROR("Failed to unpack response body\n");
-		return -DER_MISC;
+		return -DER_PROTO;
 	}
 	*token = auth;
 
@@ -146,7 +146,11 @@ ds_sec_validate_credentials(daos_iov_t *creds, AuthToken **token)
 	Drpc__Response	*response = NULL;
 	int		rc;
 
-	if (creds == NULL) {
+	if (creds == NULL ||
+	    token == NULL ||
+	    creds->iov_buf_len == 0 ||
+	    creds->iov_buf == NULL) {
+		D_ERROR("Credential iov invalid\n");
 		return -DER_INVAL;
 	}
 
@@ -161,46 +165,164 @@ ds_sec_validate_credentials(daos_iov_t *creds, AuthToken **token)
 	return rc;
 }
 
-int
-ds_sec_check_pool_access(const struct pool_prop_ugm *ugm, d_iov_t *cred,
-				uint64_t access)
+static int
+get_auth_sys_payload(AuthToken *token, AuthSys **payload)
 {
-	int		rc;
-	int		shift;
-	uint32_t	access_permitted;
-	AuthToken	*sec_token = NULL;
-	AuthSys		*sys_creds = NULL;
+	if (token->flavor != AUTH_FLAVOR__AUTH_SYS) {
+		D_ERROR("Credential auth flavor not supported\n");
+		return -DER_PROTO;
+	}
 
-	if (ugm == NULL || cred == NULL) {
+	*payload = auth_sys__unpack(NULL, token->data.len, token->data.data);
+	if (*payload == NULL) {
+		D_ERROR("Invalid auth_sys payload\n");
+		return -DER_PROTO;
+	}
+
+	return 0;
+}
+
+static bool
+ace_has_access(struct daos_ace *ace, uint64_t capas)
+{
+	D_DEBUG(DB_MGMT, "Allow Perms: 0x%lx\n", ace->dae_allow_perms);
+
+	if ((capas & DAOS_PC_RO) &&
+	    (ace->dae_allow_perms & DAOS_ACL_PERM_READ)) {
+		D_DEBUG(DB_MGMT, "Allowing read-only access\n");
+		return true;
+	}
+
+	if ((capas & (DAOS_PC_RW | DAOS_PC_EX)) &&
+	    (ace->dae_allow_perms & DAOS_ACL_PERM_READ) &&
+	    (ace->dae_allow_perms & DAOS_ACL_PERM_WRITE)) {
+		D_DEBUG(DB_MGMT, "Allowing RW access\n");
+		return true;
+	}
+
+	return false;
+}
+
+static int
+check_access_for_principal(struct daos_acl *acl,
+			   enum daos_acl_principal_type type,
+			   uint64_t capas)
+{
+	struct daos_ace *ace;
+	int		rc;
+
+	D_DEBUG(DB_MGMT, "Checking ACE for principal type %d\n", type);
+
+	rc = daos_acl_get_ace_for_principal(acl, type, NULL, &ace);
+	if (rc == 0 && ace_has_access(ace, capas))
+		return 0;
+
+	/* ACE not found */
+	if (rc == -DER_NONEXIST)
+		return rc;
+
+	return -DER_NO_PERM;
+}
+
+static int
+check_owner_group_access_for_gid(struct daos_acl *acl,
+				 struct pool_prop_ugm *ugm,
+				 uint64_t capas,
+				 uint32_t gid)
+{
+	int rc = -DER_NO_PERM;
+
+	if (gid == ugm->pp_gid) {
+		rc = check_access_for_principal(acl, DAOS_ACL_OWNER_GROUP,
+						capas);
+	}
+
+	return rc;
+}
+
+static int
+check_authsys_permissions(struct daos_acl *acl, struct pool_prop_ugm *ugm,
+			  AuthSys *authsys, uint64_t capas)
+{
+	int rc = -DER_NO_PERM;
+	int i;
+
+	/* If this is the owner, and there's an owner entry... */
+	if (authsys->has_uid && authsys->uid == ugm->pp_uid) {
+		rc = check_access_for_principal(acl, DAOS_ACL_OWNER,
+						capas);
+		if (rc != -DER_NONEXIST)
+			return rc;
+	}
+
+	/* Check all the user's groups for owner group... */
+	if (authsys->has_gid) {
+		rc = check_owner_group_access_for_gid(acl, ugm, capas,
+						      authsys->gid);
+		if (rc == 0)
+			return 0;
+	}
+
+	for (i = 0; i < authsys->n_gids; i++) {
+		rc = check_owner_group_access_for_gid(acl, ugm, capas,
+						      authsys->gids[i]);
+		if (rc == 0)
+			return 0;
+	}
+
+	return rc;
+}
+
+int
+ds_sec_check_pool_access(struct daos_acl *acl, struct pool_prop_ugm *ugm,
+			 d_iov_t *cred, uint64_t capas)
+{
+	int		rc = 0;
+	AuthToken	*token = NULL;
+	AuthSys		*authsys = NULL;
+
+	if (acl == NULL || ugm == NULL || cred == NULL) {
+		D_ERROR("An input was NULL, acl=0x%p, ugm=0x%p, cred=0x%p\n",
+			acl, ugm, cred);
 		return -DER_INVAL;
 	}
 
-	rc = ds_sec_validate_credentials(cred, &sec_token);
-	if (rc != DER_SUCCESS) {
+	if (daos_acl_validate(acl) != 0) {
+		D_ERROR("ACL content not valid\n");
+		return -DER_INVAL;
+	}
+
+	rc = ds_sec_validate_credentials(cred, &token);
+	if (rc != 0) {
+		D_ERROR("Failed to validate credentials, rc=%d\n", rc);
 		return rc;
 	}
 
-	sys_creds = auth_sys__unpack(NULL, sec_token->data.len,
-					sec_token->data.data);
+	rc = get_auth_sys_payload(token, &authsys);
+	auth_token__free_unpacked(token, NULL);
+	if (rc != 0)
+		return rc;
 
 	/*
-	 * Determine which set of capability bits applies. See also the
-	 * comment/diagram for ds_pool_attr_mode in src/pool/srv_layout.h.
+	 * Check ACL for permission via AUTH_SYS credentials
 	 */
-	if (sys_creds->uid == ugm->pp_uid)
-		shift = DAOS_PC_NBITS * 2;	/* user */
-	else if (sys_creds->gid == ugm->pp_gid)
-		shift = DAOS_PC_NBITS;		/* group */
-	else
-		shift = 0;			/* other */
+	rc = check_authsys_permissions(acl, ugm, authsys, capas);
+	if (rc == 0)
+		goto access_allowed;
 
-	/* Extract the applicable set of capability bits. */
-	access_permitted = (ugm->pp_mode >> shift) & DAOS_PC_MASK;
+	/*
+	 * Last resort - if we don't have access via credentials
+	 */
+	rc = check_access_for_principal(acl, DAOS_ACL_EVERYONE, capas);
+	if (rc == 0)
+		goto access_allowed;
 
-	/* Only if all requested capability bits are permitted... */
-	if ((access & access_permitted) == access) {
-		return 0;
-	}
-
+	D_INFO("Access denied\n");
+	auth_sys__free_unpacked(authsys, NULL);
 	return -DER_NO_PERM;
+
+access_allowed:
+	D_INFO("Access allowed\n");
+	auth_sys__free_unpacked(authsys, NULL);
+	return 0;
 }

--- a/src/security/tests/SConscript
+++ b/src/security/tests/SConscript
@@ -7,7 +7,13 @@ def scons():
 
     # Isolated unit tests
     daos_build.test(denv, 'cli_security_tests',
-                    source=['cli_security_tests.c', dc_security_tgts],
+                    source=['cli_security_tests.c', dc_security_tgts,
+                            'drpc_mocks.c'],
+                    LIBS=['cmocka', 'protobuf-c', 'daos_common', 'gurt'])
+
+    daos_build.test(denv, 'srv_acl_tests',
+                    source=['srv_acl_tests.c', '../srv_acl.c',
+                            '../security.pb-c.c', 'drpc_mocks.c'],
                     LIBS=['cmocka', 'protobuf-c', 'daos_common', 'gurt'])
 
 if __name__ == "SCons.Script":

--- a/src/security/tests/drpc_mocks.c
+++ b/src/security/tests/drpc_mocks.c
@@ -1,0 +1,195 @@
+/*
+ * (C) Copyright 2019 Intel Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * GOVERNMENT LICENSE RIGHTS-OPEN SOURCE SOFTWARE
+ * The Government's rights to use, modify, reproduce, release, perform, display,
+ * or disclose this software are subject to the terms of the Apache License as
+ * provided in Contract No. 8F-30005.
+ * Any reproduction of computer software, computer software documentation, or
+ * portions thereof marked with this legend must also reproduce the markings.
+ */
+
+/**
+ * Mocks of dRPC framework functions
+ */
+
+#include "drpc_mocks.h"
+
+struct drpc *drpc_connect_return; /* value to be returned */
+char drpc_connect_sockaddr[PATH_MAX + 1]; /* saved copy of input */
+struct drpc *
+drpc_connect(char *sockaddr)
+{
+	strncpy(drpc_connect_sockaddr, sockaddr, PATH_MAX);
+	return drpc_connect_return;
+}
+
+void
+mock_drpc_connect_setup(void)
+{
+	D_ALLOC_PTR(drpc_connect_return);
+	memset(drpc_connect_sockaddr, 0, sizeof(drpc_connect_sockaddr));
+}
+
+void mock_drpc_connect_teardown(void)
+{
+	free_drpc_connect_return();
+}
+
+int drpc_call_return; /* value to be returned */
+struct drpc *drpc_call_ctx; /* saved input */
+int drpc_call_flags; /* saved input */
+Drpc__Call drpc_call_msg_content; /* saved copy of input */
+/* saved input ptr address (for checking non-NULL) */
+Drpc__Call *drpc_call_msg_ptr;
+/* saved input ptr address (for checking non-NULL) */
+Drpc__Response **drpc_call_resp_ptr;
+/* ptr to content to allocate in response (can be NULL) */
+Drpc__Response *drpc_call_resp_return_ptr;
+/* actual content to allocate in response */
+Drpc__Response drpc_call_resp_return_content;
+int
+drpc_call(struct drpc *ctx, int flags, Drpc__Call *msg,
+		Drpc__Response **resp)
+{
+	/* Save off the params passed in */
+	drpc_call_ctx = ctx;
+	drpc_call_flags = flags;
+	drpc_call_msg_ptr = msg;
+	if (msg != NULL) {
+		memcpy(&drpc_call_msg_content, msg, sizeof(Drpc__Call));
+
+		/* Need a copy of the body data, it's separately allocated */
+		D_ALLOC(drpc_call_msg_content.body.data, msg->body.len);
+		memcpy(drpc_call_msg_content.body.data, msg->body.data,
+				msg->body.len);
+	}
+	drpc_call_resp_ptr = resp;
+
+	if (resp == NULL) {
+		return drpc_call_return;
+	}
+
+	/* Fill out the mocked response */
+	if (drpc_call_resp_return_ptr == NULL) {
+		*resp = NULL;
+	} else {
+		size_t data_len = drpc_call_resp_return_content.body.len;
+
+		/**
+		 * Need to allocate a new copy to return - the
+		 * production code will free the returned memory.
+		 */
+		D_ALLOC_PTR(*resp);
+		memcpy(*resp, &drpc_call_resp_return_content,
+				sizeof(Drpc__Response));
+
+		D_ALLOC((*resp)->body.data, data_len);
+		memcpy((*resp)->body.data,
+				drpc_call_resp_return_content.body.data,
+				data_len);
+	}
+
+	return drpc_call_return;
+}
+
+static void
+init_drpc_call_resp()
+{
+	/* By default, return non-null response */
+	drpc_call_resp_return_ptr = &drpc_call_resp_return_content;
+
+	drpc__response__init(&drpc_call_resp_return_content);
+	drpc_call_resp_return_content.status = DRPC__STATUS__SUCCESS;
+}
+
+void
+mock_drpc_call_setup(void)
+{
+	drpc_call_return = 0;
+	drpc_call_ctx = NULL;
+	drpc_call_flags = 0;
+	drpc_call_msg_ptr = NULL;
+	memset(&drpc_call_msg_content, 0, sizeof(drpc_call_msg_content));
+	drpc_call_resp_ptr = NULL;
+	init_drpc_call_resp();
+}
+
+void
+mock_drpc_call_teardown(void)
+{
+	free_drpc_call_msg_body();
+	free_drpc_call_resp_body();
+}
+
+int drpc_close_return; /* value to be returned */
+struct drpc *drpc_close_ctx; /* saved input ptr */
+int
+drpc_close(struct drpc *ctx)
+{
+	drpc_close_ctx = ctx;
+	return drpc_close_return;
+}
+
+void
+mock_drpc_close_setup(void)
+{
+	drpc_close_return = 0;
+	drpc_close_ctx = NULL;
+}
+
+void
+free_drpc_connect_return()
+{
+	D_FREE(drpc_connect_return);
+}
+
+void
+free_drpc_call_msg_body()
+{
+	D_FREE(drpc_call_msg_content.body.data);
+	drpc_call_msg_content.body.len = 0;
+}
+
+void
+free_drpc_call_resp_body()
+{
+	D_FREE(drpc_call_resp_return_content.body.data);
+	drpc_call_resp_return_content.body.len = 0;
+}
+
+void
+pack_cred_in_drpc_call_resp_body(SecurityCredential *cred)
+{
+	size_t len = security_credential__get_packed_size(cred);
+
+	D_FREE(drpc_call_resp_return_content.body.data);
+
+	drpc_call_resp_return_content.body.len = len;
+	D_ALLOC(drpc_call_resp_return_content.body.data, len);
+	security_credential__pack(cred,
+			drpc_call_resp_return_content.body.data);
+}
+
+void pack_token_in_drpc_call_resp_body(AuthToken *token)
+{
+	size_t len = auth_token__get_packed_size(token);
+
+	D_FREE(drpc_call_resp_return_content.body.data);
+
+	drpc_call_resp_return_content.body.len = len;
+	D_ALLOC(drpc_call_resp_return_content.body.data, len);
+	auth_token__pack(token, drpc_call_resp_return_content.body.data);
+}

--- a/src/security/tests/drpc_mocks.c
+++ b/src/security/tests/drpc_mocks.c
@@ -106,7 +106,7 @@ drpc_call(struct drpc *ctx, int flags, Drpc__Call *msg,
 }
 
 static void
-init_drpc_call_resp()
+init_drpc_call_resp(void)
 {
 	/* By default, return non-null response */
 	drpc_call_resp_return_ptr = &drpc_call_resp_return_content;
@@ -151,20 +151,20 @@ mock_drpc_close_setup(void)
 }
 
 void
-free_drpc_connect_return()
+free_drpc_connect_return(void)
 {
 	D_FREE(drpc_connect_return);
 }
 
 void
-free_drpc_call_msg_body()
+free_drpc_call_msg_body(void)
 {
 	D_FREE(drpc_call_msg_content.body.data);
 	drpc_call_msg_content.body.len = 0;
 }
 
 void
-free_drpc_call_resp_body()
+free_drpc_call_resp_body(void)
 {
 	D_FREE(drpc_call_resp_return_content.body.data);
 	drpc_call_resp_return_content.body.len = 0;

--- a/src/security/tests/drpc_mocks.h
+++ b/src/security/tests/drpc_mocks.h
@@ -41,7 +41,7 @@ void mock_drpc_connect_setup(void);
 void mock_drpc_connect_teardown(void);
 
 /* Convenience method to free mocks */
-void free_drpc_connect_return();
+void free_drpc_connect_return(void);
 
 /**
  * drpc_call mock values
@@ -67,8 +67,8 @@ void pack_cred_in_drpc_call_resp_body(SecurityCredential *cred);
 void pack_token_in_drpc_call_resp_body(AuthToken *token);
 
 /* Convenience methods to free mocks */
-void free_drpc_call_msg_body();
-void free_drpc_call_resp_body();
+void free_drpc_call_msg_body(void);
+void free_drpc_call_resp_body(void);
 
 /**
  * drpc_close mock values

--- a/src/security/tests/drpc_mocks.h
+++ b/src/security/tests/drpc_mocks.h
@@ -1,0 +1,81 @@
+/*
+ * (C) Copyright 2019 Intel Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * GOVERNMENT LICENSE RIGHTS-OPEN SOURCE SOFTWARE
+ * The Government's rights to use, modify, reproduce, release, perform, display,
+ * or disclose this software are subject to the terms of the Apache License as
+ * provided in Contract No. 8F-30005.
+ * Any reproduction of computer software, computer software documentation, or
+ * portions thereof marked with this legend must also reproduce the markings.
+ */
+
+/**
+ * Mocks of dRPC framework functions
+ */
+
+#ifndef __DAOS_DRPC_MOCKS_H__
+#define __DAOS_DRPC_MOCKS_H__
+
+#include <daos/drpc.h>
+#include "../security.pb-c.h"
+
+/**
+ * drpc_connect mock values
+ */
+extern struct drpc *drpc_connect_return; /* value to be returned */
+extern char drpc_connect_sockaddr[PATH_MAX + 1]; /* saved copy of input */
+
+void mock_drpc_connect_setup(void);
+void mock_drpc_connect_teardown(void);
+
+/* Convenience method to free mocks */
+void free_drpc_connect_return();
+
+/**
+ * drpc_call mock values
+ */
+extern int drpc_call_return; /* value to be returned */
+extern struct drpc *drpc_call_ctx; /* saved input */
+extern int drpc_call_flags; /* saved input */
+extern Drpc__Call drpc_call_msg_content; /* saved copy of input */
+/* saved input ptr address (for checking non-NULL) */
+extern Drpc__Call *drpc_call_msg_ptr;
+/* saved input ptr address (for checking non-NULL) */
+extern Drpc__Response **drpc_call_resp_ptr;
+/* ptr to content to allocate in response (can be NULL) */
+extern Drpc__Response *drpc_call_resp_return_ptr;
+/* actual content to allocate in response */
+extern Drpc__Response drpc_call_resp_return_content;
+
+void mock_drpc_call_setup(void);
+void mock_drpc_call_teardown(void);
+
+/* Convenience methods to initialize mocks */
+void pack_cred_in_drpc_call_resp_body(SecurityCredential *cred);
+void pack_token_in_drpc_call_resp_body(AuthToken *token);
+
+/* Convenience methods to free mocks */
+void free_drpc_call_msg_body();
+void free_drpc_call_resp_body();
+
+/**
+ * drpc_close mock values
+ */
+extern int drpc_close_return; /* value to be returned */
+extern struct drpc *drpc_close_ctx; /* saved input ptr */
+
+void mock_drpc_close_setup(void);
+
+#endif /* __DAOS_DRPC_MOCKS_H__ */

--- a/src/security/tests/srv_acl_tests.c
+++ b/src/security/tests/srv_acl_tests.c
@@ -1,0 +1,809 @@
+/*
+ * (C) Copyright 2019 Intel Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * GOVERNMENT LICENSE RIGHTS-OPEN SOURCE SOFTWARE
+ * The Government's rights to use, modify, reproduce, release, perform, display,
+ * or disclose this software are subject to the terms of the Apache License as
+ * provided in Contract No. 8F-30005.
+ * Any reproduction of computer software, computer software documentation, or
+ * portions thereof marked with this legend must also reproduce the markings.
+ */
+
+/**
+ * Unit tests for server ACL functions
+ */
+
+#include <stdarg.h>
+#include <stdlib.h>
+#include <setjmp.h>
+#include <cmocka.h>
+
+#include "drpc_mocks.h"
+#include <daos_types.h>
+#include <daos_srv/security.h>
+#include "../srv_internal.h"
+
+/*
+ * Mocks
+ */
+char *ds_sec_server_socket_path = "/fake/socket/path";
+
+/*
+ * Test constants and defaults
+ */
+static const uint32_t TEST_UID = 4;
+static const uint32_t TEST_GID = 100;
+
+/*
+ * Test helper functions
+ */
+static AuthToken *
+create_valid_auth_token(uint32_t uid, uint32_t gid, uint32_t *gid_list,
+			size_t num_gids)
+{
+	AuthToken	*token;
+	AuthSys		*authsys;
+	size_t		gid_list_size;
+
+	D_ALLOC_PTR(token);
+	auth_token__init(token);
+	token->flavor = AUTH_FLAVOR__AUTH_SYS;
+	token->has_flavor = true;
+
+	D_ALLOC_PTR(authsys);
+	auth_sys__init(authsys);
+	authsys->uid = uid;
+	authsys->has_uid = true;
+	authsys->gid = gid;
+	authsys->has_gid = true;
+
+	if (num_gids > 0) {
+		authsys->n_gids = num_gids;
+		gid_list_size = sizeof(uint32_t) * num_gids;
+
+		D_ALLOC(authsys->gids, gid_list_size);
+		memcpy(authsys->gids, gid_list, gid_list_size);
+	}
+
+	token->data.len = auth_sys__get_packed_size(authsys);
+	D_ALLOC(token->data.data, token->data.len);
+	auth_sys__pack(authsys, token->data.data);
+	token->has_data = true;
+
+	auth_sys__free_unpacked(authsys, NULL);
+
+	return token;
+}
+
+static void
+init_valid_cred(d_iov_t *cred, uint32_t uid, uint32_t gid, uint32_t *gid_list,
+		size_t num_gids)
+{
+	SecurityCredential	new_cred = SECURITY_CREDENTIAL__INIT;
+	AuthToken		*token;
+	uint8_t			*buf;
+	size_t			buf_len;
+
+	token = create_valid_auth_token(uid, gid, gid_list, num_gids);
+
+	/* Initialize the cred with token */
+	new_cred.token = token;
+	buf_len = security_credential__get_packed_size(&new_cred);
+	D_ALLOC(buf, buf_len);
+	security_credential__pack(&new_cred, buf);
+	d_iov_set(cred, buf, buf_len);
+
+	/* Return the cred token from the drpc mock, too */
+	pack_token_in_drpc_call_resp_body(token);
+
+	auth_token__free_unpacked(token, NULL);
+}
+
+static void
+init_default_cred(d_iov_t *cred)
+{
+	init_valid_cred(cred, TEST_UID, TEST_GID, NULL, 0);
+}
+
+static void
+init_default_ugm(struct pool_prop_ugm *ugm)
+{
+	ugm->pp_uid = TEST_UID;
+	ugm->pp_gid = TEST_GID;
+	ugm->pp_mode = 777;
+}
+
+/*
+ * Setup and teardown
+ */
+static int
+srv_acl_setup(void **state)
+{
+	mock_drpc_connect_setup();
+	mock_drpc_call_setup();
+	mock_drpc_close_setup();
+
+	return 0;
+}
+
+static int
+srv_acl_teardown(void **state)
+{
+	mock_drpc_connect_teardown();
+	mock_drpc_call_teardown();
+
+	return 0;
+}
+
+/*
+ * Unit tests
+ */
+
+static void
+test_validate_creds_null_cred(void **state)
+{
+	AuthToken *result = NULL;
+
+	assert_int_equal(ds_sec_validate_credentials(NULL, &result),
+			 -DER_INVAL);
+}
+
+static void
+test_validate_creds_null_token_ptr(void **state)
+{
+	d_iov_t cred;
+
+	init_default_cred(&cred);
+
+	assert_int_equal(ds_sec_validate_credentials(&cred, NULL),
+			 -DER_INVAL);
+
+	daos_iov_free(&cred);
+}
+
+static void
+test_validate_creds_empty_cred(void **state)
+{
+	AuthToken	*result = NULL;
+	d_iov_t		cred;
+
+	d_iov_set(&cred, NULL, 0);
+
+	assert_int_equal(ds_sec_validate_credentials(&cred, &result),
+			 -DER_INVAL);
+}
+
+static void
+test_check_pool_access_null_acl(void **state)
+{
+	d_iov_t			cred;
+	struct pool_prop_ugm	ugm;
+
+	init_default_cred(&cred);
+	init_default_ugm(&ugm);
+
+	assert_int_equal(ds_sec_check_pool_access(NULL, &ugm, &cred,
+						      DAOS_PC_RO),
+			 -DER_INVAL);
+
+	daos_iov_free(&cred);
+}
+
+static void
+test_check_pool_access_null_ugm(void **state)
+{
+	struct daos_acl		*acl;
+	d_iov_t			cred;
+
+	init_default_cred(&cred);
+	acl = daos_acl_create(NULL, 0);
+
+	assert_int_equal(ds_sec_check_pool_access(acl, NULL, &cred,
+						      DAOS_PC_RO),
+			 -DER_INVAL);
+
+	daos_acl_free(acl);
+}
+
+static void
+test_check_pool_access_null_cred(void **state)
+{
+	struct daos_acl		*acl;
+	struct pool_prop_ugm	ugm;
+
+	acl = daos_acl_create(NULL, 0);
+	init_default_ugm(&ugm);
+
+	assert_int_equal(ds_sec_check_pool_access(acl, &ugm, NULL,
+						      DAOS_PC_RO),
+			 -DER_INVAL);
+
+	daos_acl_free(acl);
+}
+
+static void
+test_check_pool_access_bad_acl(void **state)
+{
+	struct daos_acl		*bad_acl;
+	d_iov_t			cred;
+	struct pool_prop_ugm	ugm;
+
+	init_default_cred(&cred);
+	init_default_ugm(&ugm);
+
+	/* zeroed out - not a valid ACL */
+	D_ALLOC(bad_acl, sizeof(struct daos_acl));
+	assert_non_null(bad_acl);
+
+	assert_int_equal(ds_sec_check_pool_access(bad_acl, &ugm, &cred,
+						      DAOS_PC_RO),
+			 -DER_INVAL);
+
+	D_FREE(bad_acl);
+	daos_iov_free(&cred);
+}
+
+static void
+test_check_pool_access_validate_cred_failed(void **state)
+{
+	struct daos_acl		*acl;
+	d_iov_t			cred;
+	struct pool_prop_ugm	ugm;
+
+	init_default_cred(&cred);
+	init_default_ugm(&ugm);
+	acl = daos_acl_create(NULL, 0);
+
+	/* drpc call failure will fail validation */
+	drpc_call_return = -DER_UNKNOWN;
+
+	assert_int_equal(ds_sec_check_pool_access(acl, &ugm, &cred,
+						      DAOS_PC_RO),
+			 drpc_call_return);
+
+	daos_acl_free(acl);
+	daos_iov_free(&cred);
+}
+
+static void
+expect_no_access_bad_authsys_payload(int auth_flavor)
+{
+	struct daos_acl		*acl;
+	d_iov_t			cred;
+	size_t			data_len = 8;
+	AuthToken		token = AUTH_TOKEN__INIT;
+	struct pool_prop_ugm	ugm;
+
+	init_default_cred(&cred);
+	init_default_ugm(&ugm);
+	acl = daos_acl_create(NULL, 0);
+
+	token.flavor = auth_flavor;
+	token.has_flavor = true;
+
+	/* Put some junk in there */
+	D_ALLOC(token.data.data, data_len);
+	memset(token.data.data, 0xFF, data_len);
+	token.data.len = data_len;
+	token.has_data = true;
+
+	pack_token_in_drpc_call_resp_body(&token);
+
+	assert_int_equal(ds_sec_check_pool_access(acl, &ugm, &cred,
+						      DAOS_PC_RO),
+			 -DER_PROTO);
+
+	daos_acl_free(acl);
+	daos_iov_free(&cred);
+	D_FREE(token.data.data);
+}
+
+static void
+test_check_pool_access_not_authsys(void **state)
+{
+	expect_no_access_bad_authsys_payload(AUTH_FLAVOR__AUTH_NONE);
+	expect_no_access_bad_authsys_payload(AUTH_FLAVOR__AUTH_SYS);
+}
+
+static void
+test_check_pool_access_empty_acl(void **state)
+{
+	struct daos_acl		*acl;
+	d_iov_t			cred;
+	struct pool_prop_ugm	ugm;
+
+	init_default_cred(&cred);
+	init_default_ugm(&ugm);
+	acl = daos_acl_create(NULL, 0);
+
+	assert_int_equal(ds_sec_check_pool_access(acl, &ugm, &cred,
+						      DAOS_PC_RO),
+			 -DER_NO_PERM);
+
+	daos_acl_free(acl);
+	daos_iov_free(&cred);
+}
+
+static struct daos_acl *
+get_acl_with_perms(uint64_t owner_perms, uint64_t group_perms)
+{
+	struct daos_acl *acl;
+	size_t		num_aces = 2;
+	struct daos_ace *aces[num_aces];
+	size_t		i;
+
+	aces[0] = daos_ace_create(DAOS_ACL_OWNER, NULL);
+	aces[0]->dae_access_types = DAOS_ACL_ACCESS_ALLOW;
+	aces[0]->dae_allow_perms = owner_perms;
+
+	aces[1] = daos_ace_create(DAOS_ACL_OWNER_GROUP, NULL);
+	aces[1]->dae_access_types = DAOS_ACL_ACCESS_ALLOW;
+	aces[1]->dae_allow_perms = group_perms;
+
+	acl = daos_acl_create(aces, num_aces);
+
+	for (i = 0; i < num_aces; i++) {
+		daos_ace_free(aces[i]);
+	}
+
+	return acl;
+}
+
+static void
+expect_access_with_acl(struct daos_acl *acl, d_iov_t *cred,
+		       uint64_t requested_capas)
+{
+	struct pool_prop_ugm	ugm;
+
+	init_default_ugm(&ugm);
+
+	assert_int_equal(ds_sec_check_pool_access(acl, &ugm, cred,
+						      requested_capas),
+			 0);
+}
+
+static void
+expect_owner_access_with_perms(uint64_t acl_perms, uint64_t requested_capas)
+{
+	struct daos_acl	*acl;
+	d_iov_t		cred;
+
+	/* Only matches owner */
+	init_valid_cred(&cred, TEST_UID, TEST_GID + 1, NULL, 0);
+	acl = get_acl_with_perms(acl_perms, 0);
+
+	expect_access_with_acl(acl, &cred, requested_capas);
+
+	daos_acl_free(acl);
+	daos_iov_free(&cred);
+}
+
+static void
+test_check_pool_access_owner_success(void **state)
+{
+	expect_owner_access_with_perms(DAOS_ACL_PERM_READ, DAOS_PC_RO);
+	expect_owner_access_with_perms(DAOS_ACL_PERM_READ | DAOS_ACL_PERM_WRITE,
+				       DAOS_PC_RO);
+	expect_owner_access_with_perms(DAOS_ACL_PERM_READ | DAOS_ACL_PERM_WRITE,
+				       DAOS_PC_RW);
+	expect_owner_access_with_perms(DAOS_ACL_PERM_READ | DAOS_ACL_PERM_WRITE,
+				       DAOS_PC_EX);
+}
+
+static void
+expect_group_access_with_perms(uint64_t acl_perms, uint64_t requested_capas)
+{
+	struct daos_acl	*acl;
+	d_iov_t		cred;
+
+	/* Only matches group */
+	init_valid_cred(&cred, TEST_UID + 1, TEST_GID, NULL, 0);
+	acl = get_acl_with_perms(0, acl_perms);
+
+	expect_access_with_acl(acl, &cred, requested_capas);
+
+	daos_acl_free(acl);
+	daos_iov_free(&cred);
+}
+
+static void
+test_check_pool_access_group_success(void **state)
+{
+	expect_group_access_with_perms(DAOS_ACL_PERM_READ, DAOS_PC_RO);
+	expect_group_access_with_perms(DAOS_ACL_PERM_READ | DAOS_ACL_PERM_WRITE,
+				       DAOS_PC_RO);
+	expect_group_access_with_perms(DAOS_ACL_PERM_READ | DAOS_ACL_PERM_WRITE,
+				       DAOS_PC_RW);
+	expect_group_access_with_perms(DAOS_ACL_PERM_READ | DAOS_ACL_PERM_WRITE,
+				       DAOS_PC_EX);
+}
+
+static void
+expect_list_access_with_perms(uint64_t acl_perms,
+			      uint64_t requested_capas)
+{
+	struct daos_acl	*acl;
+	d_iov_t		cred;
+	uint32_t	gids[] = { TEST_GID - 1, TEST_GID, TEST_GID + 1 };
+
+	/* Only matches group */
+	init_valid_cred(&cred, TEST_UID + 1, TEST_GID + 1, gids,
+			sizeof(gids) / sizeof(uint32_t));
+	acl = get_acl_with_perms(0, acl_perms);
+
+	expect_access_with_acl(acl, &cred, requested_capas);
+
+	daos_acl_free(acl);
+	daos_iov_free(&cred);
+}
+
+static void
+test_check_pool_access_group_list_success(void **state)
+{
+	expect_list_access_with_perms(DAOS_ACL_PERM_READ, DAOS_PC_RO);
+	expect_list_access_with_perms(DAOS_ACL_PERM_READ | DAOS_ACL_PERM_WRITE,
+				      DAOS_PC_RO);
+	expect_list_access_with_perms(DAOS_ACL_PERM_READ | DAOS_ACL_PERM_WRITE,
+				      DAOS_PC_RW);
+	expect_list_access_with_perms(DAOS_ACL_PERM_READ | DAOS_ACL_PERM_WRITE,
+				      DAOS_PC_EX);
+}
+
+static void
+test_check_pool_access_owner_overrides_group(void **state)
+{
+	struct daos_acl		*acl;
+	d_iov_t			cred;
+	struct pool_prop_ugm	ugm;
+
+	init_default_ugm(&ugm);
+	init_default_cred(&cred);
+	acl = get_acl_with_perms(DAOS_ACL_PERM_READ,
+				 DAOS_ACL_PERM_READ | DAOS_ACL_PERM_WRITE);
+
+	/* Owner-specific entry overrides group permissions */
+	assert_int_equal(ds_sec_check_pool_access(acl, &ugm, &cred,
+						      DAOS_PC_RW),
+			 -DER_NO_PERM);
+
+	daos_acl_free(acl);
+	daos_iov_free(&cred);
+}
+
+static void
+test_check_pool_access_no_match(void **state)
+{
+	struct daos_acl		*acl;
+	d_iov_t			cred;
+	struct pool_prop_ugm	ugm;
+
+	init_default_ugm(&ugm);
+
+	/* Cred is neither owner user nor owner group */
+	init_valid_cred(&cred, TEST_UID + 1, TEST_GID + 1, NULL, 0);
+	acl = get_acl_with_perms(DAOS_ACL_PERM_READ, DAOS_ACL_PERM_READ);
+
+	assert_int_equal(ds_sec_check_pool_access(acl, &ugm, &cred,
+						      DAOS_PC_RO),
+			 -DER_NO_PERM);
+
+	daos_acl_free(acl);
+	daos_iov_free(&cred);
+}
+
+static void
+expect_no_owner_access_with_perms(uint64_t acl_perms, uint64_t requested_capas)
+{
+	struct daos_acl		*acl;
+	d_iov_t			cred;
+	struct pool_prop_ugm	ugm;
+
+	init_default_ugm(&ugm);
+	init_default_cred(&cred);
+	acl = get_acl_with_perms(acl_perms,
+				 DAOS_ACL_PERM_READ | DAOS_ACL_PERM_WRITE);
+
+	assert_int_equal(ds_sec_check_pool_access(acl, &ugm, &cred,
+						      requested_capas),
+			 -DER_NO_PERM);
+
+	daos_acl_free(acl);
+	daos_iov_free(&cred);
+}
+
+static void
+test_check_pool_access_owner_forbidden(void **state)
+{
+	expect_no_owner_access_with_perms(0, DAOS_PC_RO);
+	expect_no_owner_access_with_perms(DAOS_ACL_PERM_READ, DAOS_PC_RW);
+	expect_no_owner_access_with_perms(DAOS_ACL_PERM_READ, DAOS_PC_EX);
+	expect_no_owner_access_with_perms(DAOS_ACL_PERM_WRITE, DAOS_PC_RW);
+	expect_no_owner_access_with_perms(DAOS_ACL_PERM_WRITE, DAOS_PC_EX);
+}
+
+static void
+expect_no_group_access_with_perms(uint64_t acl_perms, uint64_t requested_capas)
+{
+	struct daos_acl		*acl;
+	d_iov_t			cred;
+	struct pool_prop_ugm	ugm;
+
+	init_default_ugm(&ugm);
+	init_valid_cred(&cred, TEST_UID + 1, TEST_GID, NULL, 0);
+	acl = get_acl_with_perms(0, acl_perms);
+
+	assert_int_equal(ds_sec_check_pool_access(acl, &ugm, &cred,
+						      requested_capas),
+			 -DER_NO_PERM);
+
+	daos_acl_free(acl);
+	daos_iov_free(&cred);
+}
+
+static void
+test_check_pool_access_group_forbidden(void **state)
+{
+	expect_no_group_access_with_perms(0, DAOS_PC_RO);
+	expect_no_group_access_with_perms(DAOS_ACL_PERM_READ, DAOS_PC_RW);
+	expect_no_group_access_with_perms(DAOS_ACL_PERM_READ, DAOS_PC_EX);
+	expect_no_group_access_with_perms(DAOS_ACL_PERM_WRITE, DAOS_PC_RW);
+	expect_no_group_access_with_perms(DAOS_ACL_PERM_WRITE, DAOS_PC_EX);
+}
+
+static void
+expect_no_list_access_with_perms(uint64_t acl_perms, uint64_t requested_capas)
+{
+	struct daos_acl		*acl;
+	d_iov_t			cred;
+	struct pool_prop_ugm	ugm;
+	uint32_t		gids[] = { TEST_GID - 1, TEST_GID };
+
+	/* owner group is in gid list only */
+	init_valid_cred(&cred, TEST_UID + 1, TEST_GID + 1, gids,
+			sizeof(gids) / sizeof(uint32_t));
+
+	init_default_ugm(&ugm);
+	acl = get_acl_with_perms(DAOS_ACL_PERM_READ | DAOS_ACL_PERM_WRITE,
+				 acl_perms);
+
+	assert_int_equal(ds_sec_check_pool_access(acl, &ugm, &cred,
+						      requested_capas),
+			 -DER_NO_PERM);
+
+	daos_acl_free(acl);
+	daos_iov_free(&cred);
+}
+
+static void
+test_check_pool_access_list_forbidden(void **state)
+{
+	expect_no_list_access_with_perms(0, DAOS_PC_RO);
+	expect_no_list_access_with_perms(DAOS_ACL_PERM_READ, DAOS_PC_RW);
+	expect_no_list_access_with_perms(DAOS_ACL_PERM_READ, DAOS_PC_EX);
+	expect_no_list_access_with_perms(DAOS_ACL_PERM_WRITE, DAOS_PC_RW);
+	expect_no_list_access_with_perms(DAOS_ACL_PERM_WRITE, DAOS_PC_EX);
+}
+
+static void
+test_check_pool_access_no_owner_entry(void **state)
+{
+	struct daos_acl		*acl;
+	d_iov_t			cred;
+	struct pool_prop_ugm	ugm;
+
+	init_default_ugm(&ugm);
+	init_default_cred(&cred);
+	acl = get_acl_with_perms(0, DAOS_ACL_PERM_READ);
+	assert_int_equal(daos_acl_remove_ace(&acl, DAOS_ACL_OWNER, NULL), 0);
+
+	/*
+	 * Cred is owner and in owner group, but there's no entry for owner,
+	 * just owner group. Should still get access.
+	 */
+	assert_int_equal(ds_sec_check_pool_access(acl, &ugm, &cred,
+						      DAOS_PC_RO),
+			 0);
+
+	daos_acl_free(acl);
+	daos_iov_free(&cred);
+}
+
+static void
+test_check_pool_access_no_owner_group_entry(void **state)
+{
+	struct daos_acl		*acl;
+	d_iov_t			cred;
+	struct pool_prop_ugm	ugm;
+
+	init_default_ugm(&ugm);
+	init_valid_cred(&cred, TEST_UID + 1, TEST_GID, NULL, 0);
+	acl = get_acl_with_perms(DAOS_ACL_PERM_READ, DAOS_ACL_PERM_READ);
+	assert_int_equal(daos_acl_remove_ace(&acl, DAOS_ACL_OWNER_GROUP, NULL),
+			 0);
+
+	/*
+	 * Cred is in owner group, but there's no entry for owner group.
+	 */
+	assert_int_equal(ds_sec_check_pool_access(acl, &ugm, &cred,
+						      DAOS_PC_RO),
+			 -DER_NO_PERM);
+
+	daos_acl_free(acl);
+	daos_iov_free(&cred);
+}
+
+static void
+test_check_pool_access_no_owner_group_entry_list(void **state)
+{
+	struct daos_acl		*acl;
+	d_iov_t			cred;
+	struct pool_prop_ugm	ugm;
+	uint32_t		gids[] = { TEST_GID };
+
+	init_default_ugm(&ugm);
+	init_valid_cred(&cred, TEST_UID + 1, TEST_GID + 1, gids, 1);
+	acl = get_acl_with_perms(DAOS_ACL_PERM_READ, DAOS_ACL_PERM_READ);
+	assert_int_equal(daos_acl_remove_ace(&acl, DAOS_ACL_OWNER_GROUP, NULL),
+			 0);
+
+	/*
+	 * Cred is in owner group, but there's no entry for owner group.
+	 */
+	assert_int_equal(ds_sec_check_pool_access(acl, &ugm, &cred,
+						      DAOS_PC_RO),
+			 -DER_NO_PERM);
+
+	daos_acl_free(acl);
+	daos_iov_free(&cred);
+}
+
+static void
+expect_everyone_gets_result_with_perms(uint64_t acl_perms,
+				       uint64_t requested_capas,
+				       int expected_result)
+{
+	struct daos_acl		*acl;
+	struct daos_ace		*ace;
+	d_iov_t			cred;
+	struct pool_prop_ugm	ugm;
+
+	init_default_ugm(&ugm);
+	init_valid_cred(&cred, TEST_UID, TEST_GID, NULL, 0);
+	ace = daos_ace_create(DAOS_ACL_EVERYONE, NULL);
+	ace->dae_access_types = DAOS_ACL_ACCESS_ALLOW;
+	ace->dae_allow_perms = acl_perms;
+	acl = daos_acl_create(&ace, 1);
+
+	/*
+	 * In owner and owner group... but no entries for them.
+	 * "Everyone" permissions should apply.
+	 */
+	assert_int_equal(ds_sec_check_pool_access(acl, &ugm, &cred,
+						  requested_capas),
+			 expected_result);
+
+	daos_acl_free(acl);
+	daos_ace_free(ace);
+	daos_iov_free(&cred);
+}
+
+static void
+expect_everyone_access_with_perms(uint64_t acl_perms, uint64_t requested_capas)
+{
+	expect_everyone_gets_result_with_perms(acl_perms, requested_capas, 0);
+}
+
+static void
+test_check_pool_access_everyone_success(void **state)
+{
+	expect_everyone_access_with_perms(DAOS_ACL_PERM_READ, DAOS_PC_RO);
+	expect_everyone_access_with_perms(DAOS_ACL_PERM_READ |
+					  DAOS_ACL_PERM_WRITE,
+					  DAOS_PC_RO);
+	expect_everyone_access_with_perms(DAOS_ACL_PERM_READ |
+					  DAOS_ACL_PERM_WRITE,
+					  DAOS_PC_RW);
+	expect_everyone_access_with_perms(DAOS_ACL_PERM_READ |
+					  DAOS_ACL_PERM_WRITE,
+					  DAOS_PC_EX);
+}
+
+static void
+expect_everyone_no_access_with_perms(uint64_t acl_perms,
+				     uint64_t requested_capas)
+{
+	expect_everyone_gets_result_with_perms(acl_perms, requested_capas,
+					       -DER_NO_PERM);
+}
+
+static void
+test_check_pool_access_everyone_forbidden(void **state)
+{
+	expect_everyone_no_access_with_perms(0, DAOS_PC_RO);
+	expect_everyone_no_access_with_perms(0, DAOS_PC_RW);
+	expect_everyone_no_access_with_perms(0, DAOS_PC_EX);
+	expect_everyone_no_access_with_perms(DAOS_ACL_PERM_READ, DAOS_PC_RW);
+	expect_everyone_no_access_with_perms(DAOS_ACL_PERM_READ, DAOS_PC_EX);
+}
+
+static void
+test_check_pool_access_fall_thru_everyone(void **state)
+{
+	struct daos_acl		*acl;
+	struct daos_ace		*ace;
+	d_iov_t			cred;
+	struct pool_prop_ugm	ugm;
+	uint32_t		gids[] = { TEST_GID - 1 };
+
+	init_default_ugm(&ugm);
+	/* Cred doesn't match owner or group */
+	init_valid_cred(&cred, TEST_UID + 1, TEST_GID + 1, gids, 1);
+	/* Owner/group entries exist with no perms */
+	acl = get_acl_with_perms(0, 0);
+
+	/* Everyone entry allowing RW access */
+	ace = daos_ace_create(DAOS_ACL_EVERYONE, NULL);
+	ace->dae_access_types = DAOS_ACL_ACCESS_ALLOW;
+	ace->dae_allow_perms = DAOS_ACL_PERM_READ | DAOS_ACL_PERM_WRITE;
+	assert_int_equal(daos_acl_add_ace(&acl, ace), 0);
+
+	/*
+	 * Cred doesn't match owner/group, falls thru to everyone
+	 */
+	assert_int_equal(ds_sec_check_pool_access(acl, &ugm, &cred, DAOS_PC_RW),
+			 0);
+
+	daos_acl_free(acl);
+	daos_ace_free(ace);
+	daos_iov_free(&cred);
+}
+
+/* Convenience macro for unit tests */
+#define ACL_UTEST(X)	cmocka_unit_test_setup_teardown(X, srv_acl_setup, \
+							srv_acl_teardown)
+int
+main(void)
+{
+	const struct CMUnitTest tests[] = {
+		ACL_UTEST(test_validate_creds_null_cred),
+		ACL_UTEST(test_validate_creds_null_token_ptr),
+		ACL_UTEST(test_validate_creds_empty_cred),
+		ACL_UTEST(test_check_pool_access_null_acl),
+		ACL_UTEST(test_check_pool_access_null_ugm),
+		ACL_UTEST(test_check_pool_access_null_cred),
+		ACL_UTEST(test_check_pool_access_bad_acl),
+		ACL_UTEST(test_check_pool_access_validate_cred_failed),
+		ACL_UTEST(test_check_pool_access_not_authsys),
+		ACL_UTEST(test_check_pool_access_empty_acl),
+		ACL_UTEST(test_check_pool_access_owner_success),
+		ACL_UTEST(test_check_pool_access_group_success),
+		ACL_UTEST(test_check_pool_access_group_list_success),
+		ACL_UTEST(test_check_pool_access_owner_overrides_group),
+		ACL_UTEST(test_check_pool_access_no_match),
+		ACL_UTEST(test_check_pool_access_owner_forbidden),
+		ACL_UTEST(test_check_pool_access_group_forbidden),
+		ACL_UTEST(test_check_pool_access_list_forbidden),
+		ACL_UTEST(test_check_pool_access_no_owner_entry),
+		ACL_UTEST(test_check_pool_access_no_owner_group_entry),
+		ACL_UTEST(test_check_pool_access_no_owner_group_entry_list),
+		ACL_UTEST(test_check_pool_access_everyone_success),
+		ACL_UTEST(test_check_pool_access_everyone_forbidden),
+		ACL_UTEST(test_check_pool_access_fall_thru_everyone),
+	};
+
+	return cmocka_run_group_tests(tests, NULL, NULL);
+}
+
+#undef ACL_UTEST

--- a/utils/run_test.sh
+++ b/utils/run_test.sh
@@ -95,6 +95,7 @@ if [ -d "/mnt/daos" ]; then
     export OFI_INTERFACE=lo
     run_test src/rdb/tests/rdb_test_runner.py "${SL_OMPI_PREFIX}"
     run_test build/src/security/tests/cli_security_tests
+    run_test build/src/security/tests/srv_acl_tests
     run_test build/src/common/tests/acl_api_tests
     run_test build/src/iosrv/tests/drpc_progress_tests
     run_test build/src/iosrv/tests/drpc_handler_tests


### PR DESCRIPTION
Enforce access with the pool's default owner/group ACL
entries instead of mode bits. Uid/gid are still used
to determine ownership.