### PR TITLE
DAOS-2320 ctrl: Implement reformat config option for SCM format

### DIFF
--- a/src/control/server/config_types.go
+++ b/src/control/server/config_types.go
@@ -226,6 +226,7 @@ type configuration struct {
 	FaultCb        string          `yaml:"fault_cb"`
 	FabricIfaces   []string        `yaml:"fabric_ifaces"`
 	FormatOverride bool            `yaml:"format_override"`
+	Reformat       bool            `yaml:"reformat"`
 	ScmMountPath   string          `yaml:"scm_mount_path"`
 	BdevInclude    []string        `yaml:"bdev_include"`
 	BdevExclude    []string        `yaml:"bdev_exclude"`
@@ -277,6 +278,7 @@ func newDefaultConfiguration(ext External) configuration {
 		Cert:           "./.daos/daos_server.crt",
 		Key:            "./.daos/daos_server.key",
 		FormatOverride: true,
+		Reformat:	true,
 		ScmMountPath:   "/mnt/daos",
 		Hyperthreads:   false,
 		NrHugepages:    1024,

--- a/src/control/server/iosrv.go
+++ b/src/control/server/iosrv.go
@@ -93,10 +93,10 @@ func formatIosrv(
 	if _, err := os.Stat(iosrvSuperPath(srv.ScmMount)); err == nil {
 		log.Debugf("server %d has already been formatted\n", i)
 
-		if reformat {
-			return errors.New(op + ": reformat not implemented yet")
+		if !reformat {
+			log.Debugf("Reformatting server %d\n", i)
+			return nil
 		}
-		return nil
 	} else if !os.IsNotExist(err) {
 		return errors.Wrap(err, op)
 	}

--- a/src/control/server/main.go
+++ b/src/control/server/main.go
@@ -124,10 +124,19 @@ func serverMain() error {
 	go grpcServer.Serve(lis)
 	defer grpcServer.GracefulStop()
 
-	// Format the unformatted servers and related hardware.
-	if err = formatIosrvs(&config, false); err != nil {
-		log.Errorf("Failed to format servers: %s", err)
-		return err
+	if !config.Reformat {
+		// Format the unformatted servers and related hardware.
+		if err = formatIosrvs(&config, false); err != nil {
+			log.Errorf("Failed to format servers: %s", err)
+			return err
+		}
+	} else {
+		// Reformat servers (re-run daos_server with existing superblock
+		// and environment.
+		if err = formatIosrvs(&config, true); err != nil {
+			log.Errorf("Failed to format servers: %s", err)
+			return err
+		}
 	}
 
 	// Only start single io_server for now.


### PR DESCRIPTION
This allows daos_server to be re-run without first having to remove
the superblock.
"reformat" is by default set to true, can be turned off in config yaml

Signed-off-by: Sydney Vanda <sydney.m.vanda@intel.com>