### PR TITLE
DAOS-2321 control: nvme.conf not written if superblock exists

### DIFF
--- a/src/control/server/config_bdev.go
+++ b/src/control/server/config_bdev.go
@@ -66,7 +66,8 @@ const (
 	msgBdevNone = "in config, no nvme.conf generated for server"
 )
 
-type Bdev struct {
+// bdev describes parameters and behaviours for a particular bdev class.
+type bdev struct {
 	templ   string
 	vosEnv  string
 	isEmpty func(*server) string            // check no elements
@@ -131,11 +132,12 @@ func prepBdevFile(i int, c *configuration) error {
 	return nil
 }
 
-var bdevMap = map[BdClass]Bdev{
-	bdNVMe:   Bdev{nvmeTempl, "", isEmptyList, isValidList, nilPrep},
-	bdMalloc: Bdev{mallocTempl, "MALLOC", isEmptyNumber, nilValidate, nilPrep},
-	bdKdev:   Bdev{kdevTempl, "AIO", isEmptyList, isValidList, nilPrep},
-	bdFile:   Bdev{fileTempl, "AIO", isEmptyList, isValidSize, prepBdevFile},
+// bdevMap provides lookup of params and behaviour for each bdev class.
+var bdevMap = map[BdClass]bdev{
+	bdNVMe:   {nvmeTempl, "", isEmptyList, isValidList, nilPrep},
+	bdMalloc: {mallocTempl, "MALLOC", isEmptyNumber, nilValidate, nilPrep},
+	bdKdev:   {kdevTempl, "AIO", isEmptyList, isValidList, nilPrep},
+	bdFile:   {fileTempl, "AIO", isEmptyList, isValidSize, prepBdevFile},
 }
 
 // rank represents a rank of an I/O server or a nil rank.

--- a/src/control/server/config_bdev.go
+++ b/src/control/server/config_bdev.go
@@ -175,11 +175,10 @@ func (c *configuration) createConf(srv *server, templ string, path string) (
 	return
 }
 
-// parseNvme reads server config file, calls createConf when "create" == true
-// and performs necessary file creation and sets environment variable for SPDK
-// emulation if needed. Direct io_server to use generated NVMe conf by setting
-//"-n" cli opt.
-func (c *configuration) parseNvme(i int, create bool) (err error) {
+// parseNvme reads server config file, calls createConf and performs necessary
+// file creation and sets environment variable for SPDK emulation if needed.
+// Direct io_server to use generated NVMe conf by setting "-n" cli opt.
+func (c *configuration) parseNvme(i int) (err error) {
 	srv := &c.Servers[i]
 	confPath := filepath.Join(srv.ScmMount, confOut)
 	bdev := bdevMap[srv.BdevClass]
@@ -189,14 +188,12 @@ func (c *configuration) parseNvme(i int, create bool) (err error) {
 		return
 	}
 
-	if create {
-		if err = bdev.prep(i, c); err != nil {
-			return
-		}
+	if err = bdev.prep(i, c); err != nil {
+		return
+	}
 
-		if err = c.createConf(srv, bdev.templ, confPath); err != nil {
-			return
-		}
+	if err = c.createConf(srv, bdev.templ, confPath); err != nil {
+		return
 	}
 
 	if bdev.vosEnv != "" {

--- a/src/control/server/config_bdev.go
+++ b/src/control/server/config_bdev.go
@@ -26,8 +26,11 @@ package main
 import (
 	"bytes"
 	"errors"
+	"fmt"
 	"path/filepath"
 	"text/template"
+
+	"github.com/daos-stack/daos/src/control/log"
 )
 
 const (
@@ -54,84 +57,156 @@ const (
 `
 	gbyte   = 1000000000
 	blkSize = 4096
+
+	bdNVMe   BdClass = "nvme"
+	bdMalloc BdClass = "malloc"
+	bdKdev   BdClass = "kdev"
+	bdFile   BdClass = "file"
+
+	msgBdevNone = "in config, no nvme.conf generated for server"
 )
 
+type Bdev struct {
+	templ   string
+	vosEnv  string
+	isEmpty func(*server) string            // check no elements
+	isValid func(*server) string            // check valid elements
+	prep    func(int, *configuration) error // prerequisite actions
+}
+
+func nilValidate(srv *server) string { return "" }
+
+func nilPrep(i int, c *configuration) error { return nil }
+
+func isEmptyList(srv *server) string {
+	if len(srv.BdevList) == 0 {
+		return "bdev_list empty " + msgBdevNone
+	}
+
+	return ""
+}
+
+func isEmptyNumber(srv *server) string {
+	if srv.BdevNumber == 0 {
+		return "bdev_number == 0 " + msgBdevNone
+	}
+
+	return ""
+}
+
+func isValidList(srv *server) string {
+	for i, elem := range srv.BdevList {
+		if elem == "" {
+			return fmt.Sprintf(
+				"element %d in bdev_list is empty", i)
+		}
+	}
+
+	return ""
+}
+
+func isValidSize(srv *server) string {
+	if srv.BdevSize < 1 {
+		return "bdev_size should be greater than 0"
+	}
+
+	return ""
+}
+
+func prepBdevFile(i int, c *configuration) error {
+	srv := c.Servers[i]
+
+	// truncate or create files for SPDK AIO emulation,
+	// requested size aligned with block size
+	size := (int64(srv.BdevSize*gbyte) / int64(blkSize)) *
+		int64(blkSize)
+
+	for _, path := range srv.BdevList {
+		err := c.ext.createEmpty(path, size)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+var bdevMap = map[BdClass]Bdev{
+	bdNVMe:   Bdev{nvmeTempl, "", isEmptyList, isValidList, nilPrep},
+	bdMalloc: Bdev{mallocTempl, "MALLOC", isEmptyNumber, nilValidate, nilPrep},
+	bdKdev:   Bdev{kdevTempl, "AIO", isEmptyList, isValidList, nilPrep},
+	bdFile:   Bdev{fileTempl, "AIO", isEmptyNumber, isValidSize, prepBdevFile},
+}
+
+// rank represents a rank of an I/O server or a nil rank.
 // genFromNvme takes NVMe device PCI addresses and generates config content
 // (output as string) from template.
-func genFromTempl(server *server, templ string) (string, error) {
+func genFromTempl(server *server, templ string) (out bytes.Buffer, err error) {
 	t := template.Must(
 		template.New(confOut).Parse(templ))
-	var out bytes.Buffer
-	if err := t.Execute(&out, server); err != nil {
-		return "", err
-	}
-	return out.String(), nil
+
+	err = t.Execute(&out, server)
+
+	return
 }
 
-func createConf(ext External, server *server, templ string) error {
-	out, err := genFromTempl(server, templ)
+// createConf writes NVMe conf to persistent SCM mount at location "path"
+// generated from io_server config at given index populating template "templ".
+// Generated file is written to SCM mount specific to an io_server instance
+// to be consumed by SPDK in that process.
+func (c *configuration) createConf(srv *server, templ string, path string) (
+	err error) {
+
+	confBytes, err := genFromTempl(srv, templ)
 	if err != nil {
-		return err
+		return
 	}
-	if out == "" {
-		return errors.New("generated NVMe config unexpectedly empty")
+
+	confStr := confBytes.String()
+	if confStr == "" {
+		return errors.New(
+			"spdk: generated NVMe config unexpectedly empty")
 	}
-	confPath := filepath.Join(server.ScmMount, confOut)
-	// write NVMe config file for this I/O Server located in
-	// server-local SCM mount dir
-	if err := ext.writeToFile(out, confPath); err != nil {
-		return err
+
+	if err = c.ext.writeToFile(confStr, path); err != nil {
+		return
 	}
-	// set location of daos_nvme.conf to pass to I/O Server
-	server.CliOpts = append(server.CliOpts, "-n", confPath)
-	return nil
+
+	return
 }
 
-func (c *configuration) parseNvme(i int) error {
+// parseNvme reads server config file, calls createConf when "create" == true
+// and performs necessary file creation and sets environment variable for SPDK
+// emulation if needed. Direct io_server to use generated NVMe conf by setting
+//"-n" cli opt.
+func (c *configuration) parseNvme(i int, create bool) (err error) {
 	srv := &c.Servers[i]
+	confPath := filepath.Join(srv.ScmMount, confOut)
+	bdev := bdevMap[srv.BdevClass]
 
-	switch srv.BdevClass {
-	case bdNVMe:
-		if len(srv.BdevList) == 0 {
-			break
-		}
-		// standard daos_nvme.conf, don't need to set VOS_BDEV_CLASS
-		if err := createConf(c.ext, srv, nvmeTempl); err != nil {
-			return err
-		}
-	case bdMalloc:
-		if srv.BdevNumber == 0 {
-			break
-		}
-		if err := createConf(c.ext, srv, mallocTempl); err != nil {
-			return err
-		}
-		srv.EnvVars = append(srv.EnvVars, "VOS_BDEV_CLASS=MALLOC")
-	case bdKdev:
-		if len(srv.BdevList) == 0 {
-			break
-		}
-		if err := createConf(c.ext, srv, kdevTempl); err != nil {
-			return err
-		}
-		srv.EnvVars = append(srv.EnvVars, "VOS_BDEV_CLASS=AIO")
-	case bdFile:
-		if len(srv.BdevList) == 0 {
-			break
-		}
-		// requested size aligned with block size
-		size := (int64(srv.BdevSize*gbyte) / int64(blkSize)) * int64(blkSize)
-		for _, path := range srv.BdevList {
-			err := c.ext.createEmpty(path, size)
-			if err != nil {
-				return err
-			}
-		}
-		if err := createConf(c.ext, srv, fileTempl); err != nil {
-			return err
-		}
-		srv.EnvVars = append(srv.EnvVars, "VOS_BDEV_CLASS=AIO")
+	if msg := bdev.isEmpty(srv); msg != "" {
+		log.Debugf("spdk %s: %s (server %d)\n", srv.BdevClass, msg, i)
+		return
 	}
 
-	return nil
+	if create {
+		if err = bdev.prep(i, c); err != nil {
+			return
+		}
+
+		if err = c.createConf(srv, bdev.templ, confPath); err != nil {
+			return
+		}
+	}
+
+	if bdev.vosEnv != "" {
+		srv.EnvVars = append(srv.EnvVars, "VOS_BDEV_CLASS="+bdev.vosEnv)
+	}
+
+	// if we get here we can assume we have SPDK conf in SCM mount, set
+	// location in io_server cli opts (assuming config hasn't changed
+	// between restarts)
+	srv.CliOpts = append(srv.CliOpts, "-n", confPath)
+
+	return
 }

--- a/src/control/server/config_bdev.go
+++ b/src/control/server/config_bdev.go
@@ -135,7 +135,7 @@ var bdevMap = map[BdClass]Bdev{
 	bdNVMe:   Bdev{nvmeTempl, "", isEmptyList, isValidList, nilPrep},
 	bdMalloc: Bdev{mallocTempl, "MALLOC", isEmptyNumber, nilValidate, nilPrep},
 	bdKdev:   Bdev{kdevTempl, "AIO", isEmptyList, isValidList, nilPrep},
-	bdFile:   Bdev{fileTempl, "AIO", isEmptyNumber, isValidSize, prepBdevFile},
+	bdFile:   Bdev{fileTempl, "AIO", isEmptyList, isValidSize, prepBdevFile},
 }
 
 // rank represents a rank of an I/O server or a nil rank.

--- a/src/control/server/config_bdev_test.go
+++ b/src/control/server/config_bdev_test.go
@@ -161,7 +161,9 @@ func TestParseBdev(t *testing.T) {
 			srv.BdevNumber = tt.bdevNumber
 		}
 
-		err := config.parseNvme(srvIdx)
+		// TODO: add test to verify parseNvme works with create == false and adds
+		// expected env + cli opts
+		err := config.parseNvme(srvIdx, true)
 		if tt.errMsg != "" {
 			ExpectError(t, err, tt.errMsg, "")
 			continue

--- a/src/control/server/config_bdev_test.go
+++ b/src/control/server/config_bdev_test.go
@@ -168,8 +168,6 @@ func TestParseBdev(t *testing.T) {
 			srv.BdevNumber = tt.bdevNumber
 		}
 
-		// TODO: add test to verify parseNvme works with create == false and adds
-		// expected env + cli opts
 		err := config.parseNvme(srvIdx)
 		if tt.errMsg != "" {
 			ExpectError(t, err, tt.errMsg, tt.desc)

--- a/src/control/server/config_bdev_test.go
+++ b/src/control/server/config_bdev_test.go
@@ -42,7 +42,6 @@ func TestParseBdev(t *testing.T) {
 		fileExists bool // mock return value for file exists check
 		extraEnv   string
 		expFiles   [][]string
-		dontCreate bool // default is to create conf and AIO files
 		errMsg     string
 		desc       string
 	}{
@@ -171,7 +170,7 @@ func TestParseBdev(t *testing.T) {
 
 		// TODO: add test to verify parseNvme works with create == false and adds
 		// expected env + cli opts
-		err := config.parseNvme(srvIdx, !tt.dontCreate)
+		err := config.parseNvme(srvIdx)
 		if tt.errMsg != "" {
 			ExpectError(t, err, tt.errMsg, tt.desc)
 			continue

--- a/src/control/server/config_types.go
+++ b/src/control/server/config_types.go
@@ -45,16 +45,10 @@ const (
 	scmDCPM ScmClass = "dcpm"
 	scmRAM  ScmClass = "ram"
 
-	bdNVMe   BdClass = "nvme"
-	bdMalloc BdClass = "malloc"
-	bdKdev   BdClass = "kdev"
-	bdFile   BdClass = "file"
-
 	// TODO: implement Provider discriminated union
 	// TODO: implement LogMask discriminated union
 )
 
-// rank represents a rank of an I/O server or a nil rank.
 type rank uint32
 
 func (r rank) String() string {

--- a/src/control/server/iosrv.go
+++ b/src/control/server/iosrv.go
@@ -97,12 +97,6 @@ func formatIosrv(
 			return errors.New(op + ": reformat not implemented yet")
 		}
 
-		// process config parameters for nvme and persist nvme.conf in scm
-		// but don't create files as they should already exist
-		if err := config.parseNvme(i, false); err != nil {
-			return errors.Wrap(err, "nvme config could not be processed")
-		}
-
 		return nil
 	} else if !os.IsNotExist(err) {
 		return errors.Wrap(err, op)
@@ -126,11 +120,6 @@ func formatIosrv(
 			fmt.Sprintf(
 				"server%d scm mount path (%s) not mounted",
 				i, srv.ScmMount))
-	}
-
-	// process config parameters for nvme and persist nvme.conf in scm
-	if err := config.parseNvme(i, true); err != nil {
-		return errors.Wrap(err, "nvme config could not be processed")
 	}
 
 	log.Debugf(op+" (createMS=%t bootstrapMS=%t)", createMS, bootstrapMS)
@@ -237,6 +226,14 @@ func (srv *iosrv) start() (err error) {
 	defer func() {
 		err = errors.WithMessagef(err, "start server %s", srv.config.Servers[srv.index].ScmMount)
 	}()
+
+	// Process bdev config parameters and write nvme.conf to SCM to be
+	// consumed by SPDK in I/O server process. Populates env & cli opts.
+	if err = srv.config.parseNvme(srv.index); err != nil {
+		err = errors.WithMessage(
+			err, "nvme config could not be processed")
+		return
+	}
 
 	if err = srv.startCmd(); err != nil {
 		return

--- a/src/control/server/iosrv.go
+++ b/src/control/server/iosrv.go
@@ -96,6 +96,13 @@ func formatIosrv(
 		if reformat {
 			return errors.New(op + ": reformat not implemented yet")
 		}
+
+		// process config parameters for nvme and persist nvme.conf in scm
+		// but don't create files as they should already exist
+		if err := config.parseNvme(i, false); err != nil {
+			return errors.Wrap(err, "nvme config could not be processed")
+		}
+
 		return nil
 	} else if !os.IsNotExist(err) {
 		return errors.Wrap(err, op)
@@ -122,7 +129,7 @@ func formatIosrv(
 	}
 
 	// process config parameters for nvme and persist nvme.conf in scm
-	if err := config.parseNvme(i); err != nil {
+	if err := config.parseNvme(i, true); err != nil {
 		return errors.Wrap(err, "nvme config could not be processed")
 	}
 


### PR DESCRIPTION
Bug with control plane format, skips part where -n gets added to
io_server cli opts so on rerun daos_server cant find nvme.conf in SCM
mount dir.

Signed-off-by: Tom Nabarro <tom.nabarro@intel.com>