### PR TITLE
DAOS-2312 type: cleanup daos_sg_list_t/daos_iov_t

### DIFF
--- a/src/bio/bio_context.c
+++ b/src/bio/bio_context.c
@@ -478,7 +478,7 @@ bio_blob_delete(uuid_t uuid, struct bio_xs_context *xs_ctxt)
 
 static int
 bio_rwv(struct bio_io_context *ioctxt, struct bio_sglist *bsgl_in,
-	daos_sg_list_t *sgl, bool update)
+	d_sg_list_t *sgl, bool update)
 {
 	struct bio_sglist	*bsgl;
 	struct bio_desc		*biod;
@@ -529,7 +529,7 @@ out:
 
 int
 bio_readv(struct bio_io_context *ioctxt, struct bio_sglist *bsgl,
-	  daos_sg_list_t *sgl)
+	  d_sg_list_t *sgl)
 {
 	int	rc;
 
@@ -546,7 +546,7 @@ bio_readv(struct bio_io_context *ioctxt, struct bio_sglist *bsgl,
 
 int
 bio_writev(struct bio_io_context *ioctxt, struct bio_sglist *bsgl,
-	   daos_sg_list_t *sgl)
+	   d_sg_list_t *sgl)
 {
 	int	rc;
 
@@ -562,12 +562,12 @@ bio_writev(struct bio_io_context *ioctxt, struct bio_sglist *bsgl,
 }
 
 static int
-bio_rw(struct bio_io_context *ioctxt, bio_addr_t addr, daos_iov_t *iov,
+bio_rw(struct bio_io_context *ioctxt, bio_addr_t addr, d_iov_t *iov,
 	bool update)
 {
 	struct bio_sglist	bsgl;
 	struct bio_iov		biov;
-	daos_sg_list_t		sgl;
+	d_sg_list_t		sgl;
 	int			rc;
 
 	biov.bi_buf = NULL;
@@ -594,14 +594,14 @@ bio_rw(struct bio_io_context *ioctxt, bio_addr_t addr, daos_iov_t *iov,
 }
 
 int
-bio_read(struct bio_io_context *ioctxt, bio_addr_t addr, daos_iov_t *iov)
+bio_read(struct bio_io_context *ioctxt, bio_addr_t addr, d_iov_t *iov)
 {
 	return bio_rw(ioctxt, addr, iov, false);
 }
 
 
 int
-bio_write(struct bio_io_context *ioctxt, bio_addr_t addr, daos_iov_t *iov)
+bio_write(struct bio_io_context *ioctxt, bio_addr_t addr, d_iov_t *iov)
 {
 
 	return bio_rw(ioctxt, addr, iov, true);
@@ -612,7 +612,7 @@ bio_write_blob_hdr(struct bio_io_context *ioctxt, struct bio_blob_hdr *bio_bh)
 {
 	struct smd_nvme_pool_info	smd_pool;
 	struct smd_nvme_stream_bond	smd_xs_mapping;
-	daos_iov_t			iov;
+	d_iov_t			iov;
 	bio_addr_t			addr;
 	uint64_t			off = 0; /* byte offset in SPDK blob */
 	uint16_t			dev_type = DAOS_MEDIA_NVME;
@@ -654,7 +654,7 @@ bio_write_blob_hdr(struct bio_io_context *ioctxt, struct bio_blob_hdr *bio_bh)
 	uuid_copy(bio_bh->bbh_blobstore, smd_xs_mapping.nsm_dev_id);
 
 	/* Create an iov to store blob header structure */
-	daos_iov_set(&iov, (void *)bio_bh, sizeof(*bio_bh));
+	d_iov_set(&iov, (void *)bio_bh, sizeof(*bio_bh));
 
 	rc = bio_write(ioctxt, addr, &iov);
 

--- a/src/bio/smd/smd_device.c
+++ b/src/bio/smd/smd_device.c
@@ -43,7 +43,7 @@ dtab_df_hkey_size(void)
 }
 
 static void
-dtab_df_hkey_gen(struct btr_instance *tins, daos_iov_t *key_iov, void *hkey)
+dtab_df_hkey_gen(struct btr_instance *tins, d_iov_t *key_iov, void *hkey)
 {
 	D_ASSERT(key_iov->iov_len == sizeof(struct d_uuid));
 	memcpy(hkey, key_iov->iov_buf, key_iov->iov_len);
@@ -61,8 +61,8 @@ dtab_df_rec_free(struct btr_instance *tins, struct btr_record *rec, void *args)
 }
 
 static int
-dtab_df_rec_alloc(struct btr_instance *tins, daos_iov_t *key_iov,
-		  daos_iov_t *val_iov, struct btr_record *rec)
+dtab_df_rec_alloc(struct btr_instance *tins, d_iov_t *key_iov,
+		  d_iov_t *val_iov, struct btr_record *rec)
 {
 	umem_off_t			 ndev_off;
 	struct smd_nvme_dev_df		*ndev_df;
@@ -84,7 +84,7 @@ dtab_df_rec_alloc(struct btr_instance *tins, daos_iov_t *key_iov,
 
 static int
 dtab_df_rec_fetch(struct btr_instance *tins, struct btr_record *rec,
-		  daos_iov_t *key_iov, daos_iov_t *val_iov)
+		  d_iov_t *key_iov, d_iov_t *val_iov)
 {
 	struct smd_nvme_dev_df		*ndev_df;
 
@@ -95,7 +95,7 @@ dtab_df_rec_fetch(struct btr_instance *tins, struct btr_record *rec,
 
 static int
 dtab_df_rec_update(struct btr_instance *tins, struct btr_record *rec,
-		   daos_iov_t *key_iov, daos_iov_t *val_iov)
+		   d_iov_t *key_iov, d_iov_t *val_iov)
 {
 	struct smd_nvme_dev_df		*ndev_df;
 	int				 rc;
@@ -164,10 +164,10 @@ static int
 smd_dtab_df_lookup(struct smd_store *nvme_obj, struct d_uuid *ukey,
 		   struct smd_nvme_dev_df *ndev_df)
 {
-	daos_iov_t	key, value;
+	d_iov_t	key, value;
 
-	daos_iov_set(&key, ukey, sizeof(struct d_uuid));
-	daos_iov_set(&value, ndev_df, sizeof(struct smd_nvme_dev_df));
+	d_iov_set(&key, ukey, sizeof(struct d_uuid));
+	d_iov_set(&value, ndev_df, sizeof(struct smd_nvme_dev_df));
 	return dbtree_lookup(nvme_obj->sms_dev_tab, &key, &value);
 }
 
@@ -177,10 +177,10 @@ smd_dtab_df_update(struct smd_store *nvme_obj, struct d_uuid *ukey,
 		   struct smd_nvme_dev_df *ndev_df)
 {
 	int		rc = 0;
-	daos_iov_t	key, value;
+	d_iov_t	key, value;
 
-	daos_iov_set(&key, ukey, sizeof(struct d_uuid));
-	daos_iov_set(&value, ndev_df, sizeof(struct smd_nvme_dev_df));
+	d_iov_set(&key, ukey, sizeof(struct d_uuid));
+	d_iov_set(&value, ndev_df, sizeof(struct smd_nvme_dev_df));
 
 	rc = smd_tx_begin(nvme_obj);
 	if (rc != 0)

--- a/src/bio/smd/smd_pool.c
+++ b/src/bio/smd/smd_pool.c
@@ -50,7 +50,7 @@ ptab_df_hkey_size(void)
 }
 
 static void
-ptab_df_hkey_gen(struct btr_instance *tins, daos_iov_t *key_iov, void *hkey)
+ptab_df_hkey_gen(struct btr_instance *tins, d_iov_t *key_iov, void *hkey)
 {
 	D_ASSERT(key_iov->iov_len == sizeof(struct pool_tab_key));
 	memcpy(hkey, key_iov->iov_buf, key_iov->iov_len);
@@ -92,8 +92,8 @@ ptab_df_rec_free(struct btr_instance *tins, struct btr_record *rec, void *args)
 }
 
 static int
-ptab_df_rec_alloc(struct btr_instance *tins, daos_iov_t *key_iov,
-		  daos_iov_t *val_iov, struct btr_record *rec)
+ptab_df_rec_alloc(struct btr_instance *tins, d_iov_t *key_iov,
+		  d_iov_t *val_iov, struct btr_record *rec)
 {
 	umem_off_t			 npool_off;
 	struct smd_nvme_pool_df		*npool_df;
@@ -116,7 +116,7 @@ ptab_df_rec_alloc(struct btr_instance *tins, daos_iov_t *key_iov,
 
 static int
 ptab_df_rec_fetch(struct btr_instance *tins, struct btr_record *rec,
-		  daos_iov_t *key_iov, daos_iov_t *val_iov)
+		  d_iov_t *key_iov, d_iov_t *val_iov)
 {
 	struct smd_nvme_pool_df		*npool_df;
 
@@ -128,7 +128,7 @@ ptab_df_rec_fetch(struct btr_instance *tins, struct btr_record *rec,
 
 static int
 ptab_df_rec_update(struct btr_instance *tins, struct btr_record *rec,
-		   daos_iov_t *key_iov, daos_iov_t *val_iov)
+		   d_iov_t *key_iov, d_iov_t *val_iov)
 {
 	struct smd_nvme_pool_df		*npool_df;
 	int				 rc;
@@ -208,7 +208,7 @@ smd_nvme_add_pool(struct smd_nvme_pool_info *info)
 	struct pool_tab_key	ptab_key;
 	struct smd_nvme_pool_df	nvme_ptab_args;
 	struct smd_store	*store = get_smd_store();
-	daos_iov_t		key, value;
+	d_iov_t		key, value;
 	int			rc	= 0;
 
 	D_DEBUG(DB_TRACE, "Add a pool id in pool table\n");
@@ -227,8 +227,8 @@ smd_nvme_add_pool(struct smd_nvme_pool_info *info)
 	if (rc != 0)
 		goto failed;
 
-	daos_iov_set(&key, &ptab_key, sizeof(ptab_key));
-	daos_iov_set(&value, &nvme_ptab_args, sizeof(nvme_ptab_args));
+	d_iov_set(&key, &ptab_key, sizeof(ptab_key));
+	d_iov_set(&value, &nvme_ptab_args, sizeof(nvme_ptab_args));
 
 	rc = dbtree_update(store->sms_pool_tab, &key, &value);
 
@@ -254,7 +254,7 @@ smd_nvme_get_pool(uuid_t pool_id, int stream_id,
 {
 	struct smd_nvme_pool_df	nvme_ptab_args;
 	struct smd_store	*store = get_smd_store();
-	daos_iov_t		key, value;
+	d_iov_t		key, value;
 	struct pool_tab_key	ptkey;
 	int			rc	= 0;
 
@@ -267,8 +267,8 @@ smd_nvme_get_pool(uuid_t pool_id, int stream_id,
 
 	uuid_copy(ptkey.ptk_pid, pool_id);
 	ptkey.ptk_sid = stream_id;
-	daos_iov_set(&key, &ptkey, sizeof(struct pool_tab_key));
-	daos_iov_set(&value, &nvme_ptab_args, sizeof(struct smd_nvme_pool_df));
+	d_iov_set(&key, &ptkey, sizeof(struct pool_tab_key));
+	d_iov_set(&value, &nvme_ptab_args, sizeof(struct smd_nvme_pool_df));
 
 	smd_lock(SMD_PTAB_LOCK);
 	rc = dbtree_lookup(store->sms_pool_tab, &key, &value);

--- a/src/bio/smd/smd_stream.c
+++ b/src/bio/smd/smd_stream.c
@@ -45,7 +45,7 @@ stab_df_hkey_size(void)
 }
 
 static void
-stab_df_hkey_gen(struct btr_instance *tins, daos_iov_t *key_iov, void *hkey)
+stab_df_hkey_gen(struct btr_instance *tins, d_iov_t *key_iov, void *hkey)
 {
 	D_ASSERT(key_iov->iov_len == sizeof(int));
 	memcpy(hkey, key_iov->iov_buf, key_iov->iov_len);
@@ -63,8 +63,8 @@ stab_df_rec_free(struct btr_instance *tins, struct btr_record *rec, void *args)
 }
 
 static int
-stab_df_rec_alloc(struct btr_instance *tins, daos_iov_t *key_iov,
-		  daos_iov_t *val_iov, struct btr_record *rec)
+stab_df_rec_alloc(struct btr_instance *tins, d_iov_t *key_iov,
+		  d_iov_t *val_iov, struct btr_record *rec)
 {
 	umem_off_t				 nstream_off;
 	struct smd_nvme_stream_df		*nstream_df;
@@ -88,7 +88,7 @@ stab_df_rec_alloc(struct btr_instance *tins, daos_iov_t *key_iov,
 
 static int
 stab_df_rec_fetch(struct btr_instance *tins, struct btr_record *rec,
-		  daos_iov_t *key_iov, daos_iov_t *val_iov)
+		  d_iov_t *key_iov, d_iov_t *val_iov)
 {
 	struct smd_nvme_stream_df		*nstream_df;
 
@@ -99,7 +99,7 @@ stab_df_rec_fetch(struct btr_instance *tins, struct btr_record *rec,
 
 static int
 stab_df_rec_update(struct btr_instance *tins, struct btr_record *rec,
-		   daos_iov_t *key_iov, daos_iov_t *val_iov)
+		   d_iov_t *key_iov, d_iov_t *val_iov)
 {
 	struct smd_nvme_stream_df		*nstream_df;
 	int					 rc;
@@ -164,7 +164,7 @@ smd_nvme_add_stream_bond(struct smd_nvme_stream_bond *bond)
 	struct smd_nvme_stream_df	nvme_stab_args;
 	struct smd_store		*store = get_smd_store();
 	struct d_uuid			ukey;
-	daos_iov_t			key, value;
+	d_iov_t			key, value;
 	int				rc	 = 0;
 
 	if (bond == NULL) {
@@ -191,8 +191,8 @@ smd_nvme_add_stream_bond(struct smd_nvme_stream_bond *bond)
 	if (rc != 0)
 		goto failed;
 
-	daos_iov_set(&key, &bond->nsm_stream_id, sizeof(bond->nsm_stream_id));
-	daos_iov_set(&value, &nvme_stab_args, sizeof(nvme_stab_args));
+	d_iov_set(&key, &bond->nsm_stream_id, sizeof(bond->nsm_stream_id));
+	d_iov_set(&value, &nvme_stab_args, sizeof(nvme_stab_args));
 
 	rc = dbtree_update(store->sms_stream_tab, &key, &value);
 
@@ -220,7 +220,7 @@ smd_nvme_get_stream_bond(int stream_id,
 {
 	struct smd_nvme_stream_df	nvme_stab_args;
 	struct smd_store		*store = get_smd_store();
-	daos_iov_t			key, value;
+	d_iov_t			key, value;
 	int				rc	 = 0;
 
 	D_DEBUG(DB_TRACE, "looking up device id in stream table\n");
@@ -229,8 +229,8 @@ smd_nvme_get_stream_bond(int stream_id,
 		D_ERROR("Missing input parameters: %d\n", rc);
 		return rc;
 	}
-	daos_iov_set(&key, &stream_id, sizeof(stream_id));
-	daos_iov_set(&value, &nvme_stab_args,
+	d_iov_set(&key, &stream_id, sizeof(stream_id));
+	d_iov_set(&value, &nvme_stab_args,
 		     sizeof(struct smd_nvme_stream_df));
 
 	smd_lock(SMD_STAB_LOCK);
@@ -273,11 +273,11 @@ smd_nvme_list_streams(uint32_t *nr, struct smd_nvme_stream_bond *streams,
 
 	i = 0;
 	while (i < *nr) {
-		daos_iov_t	key, value;
+		d_iov_t	key, value;
 		int		stream_id;
 
-		daos_iov_set(&key, &stream_id, sizeof(stream_id));
-		daos_iov_set(&value, &streams[i],
+		d_iov_set(&key, &stream_id, sizeof(stream_id));
+		d_iov_set(&value, &streams[i],
 			     sizeof(struct smd_nvme_stream_bond));
 		rc = dbtree_iter_fetch(sti_hdl, &key, &value, anchor);
 		if (rc != 0) {

--- a/src/client/addons/dac_array.c
+++ b/src/client/addons/dac_array.c
@@ -62,8 +62,8 @@ struct md_params {
 	uint64_t		dkey_val;
 	char			*akey_str;
 	daos_iod_t		iod;
-	daos_sg_list_t		sgl;
-	daos_iov_t		sg_iov;
+	d_sg_list_t		sgl;
+	d_iov_t		sg_iov;
 	uint64_t		md_vals[3];
 };
 
@@ -72,7 +72,7 @@ struct io_params {
 	uint64_t		dkey_val;
 	char			akey_str;
 	daos_iod_t		iod;
-	daos_sg_list_t		sgl;
+	d_sg_list_t		sgl;
 	bool			user_sgl_used;
 	daos_size_t		cell_size;
 	tse_task_t		*task;
@@ -287,7 +287,7 @@ swap_array_glob(struct dac_array_glob *array_glob)
 }
 
 static int
-dac_array_l2g(daos_handle_t oh, daos_iov_t *glob)
+dac_array_l2g(daos_handle_t oh, d_iov_t *glob)
 {
 	struct dac_array	*array;
 	struct dac_array_glob	*array_glob;
@@ -342,7 +342,7 @@ out:
 }
 
 int
-dac_array_local2global(daos_handle_t oh, daos_iov_t *glob)
+dac_array_local2global(daos_handle_t oh, d_iov_t *glob)
 {
 	int rc = 0;
 
@@ -418,7 +418,7 @@ out:
 }
 
 int
-dac_array_global2local(daos_handle_t coh, daos_iov_t glob, daos_handle_t *oh)
+dac_array_global2local(daos_handle_t coh, d_iov_t glob, daos_handle_t *oh)
 {
 	struct dac_array_glob	*array_glob;
 	int			 rc = 0;
@@ -465,17 +465,17 @@ set_md_params(struct md_params *params)
 {
 	/** write metadata to DKEY 0 */
 	params->dkey_val = 0;
-	daos_iov_set(&params->dkey, &params->dkey_val, sizeof(uint64_t));
+	d_iov_set(&params->dkey, &params->dkey_val, sizeof(uint64_t));
 
 	/** set SGL */
-	daos_iov_set(&params->sg_iov, params->md_vals, sizeof(params->md_vals));
+	d_iov_set(&params->sg_iov, params->md_vals, sizeof(params->md_vals));
 	params->sgl.sg_nr	= 1;
 	params->sgl.sg_nr_out	= 0;
 	params->sgl.sg_iovs	= &params->sg_iov;
 
 	/** set IOD */
 	params->akey_str = ARRAY_MD_KEY;
-	daos_iov_set(&params->iod.iod_name, (void *)params->akey_str,
+	d_iov_set(&params->iod.iod_name, (void *)params->akey_str,
 		     strlen(params->akey_str));
 	daos_csum_set(&params->iod.iod_kcsum, NULL, 0);
 	params->iod.iod_nr	= 1;
@@ -894,7 +894,7 @@ err_ptask:
 }
 
 static bool
-io_extent_same(daos_array_iod_t *iod, daos_sg_list_t *sgl,
+io_extent_same(daos_array_iod_t *iod, d_sg_list_t *sgl,
 	       daos_size_t cell_size)
 {
 	daos_size_t rgs_len;
@@ -957,9 +957,9 @@ compute_dkey(struct dac_array *array, daos_off_t array_idx,
 }
 
 static int
-create_sgl(daos_sg_list_t *user_sgl, daos_size_t cell_size,
+create_sgl(d_sg_list_t *user_sgl, daos_size_t cell_size,
 	   daos_size_t num_records, daos_off_t *sgl_off, daos_size_t *sgl_i,
-	   daos_sg_list_t *sgl)
+	   d_sg_list_t *sgl)
 {
 	daos_size_t	k;
 	daos_size_t	rem_records;
@@ -980,8 +980,8 @@ create_sgl(daos_sg_list_t *user_sgl, daos_size_t cell_size,
 		D_ASSERT(user_sgl->sg_nr > cur_i);
 
 		sgl->sg_nr++;
-		sgl->sg_iovs = (daos_iov_t *)realloc
-			(sgl->sg_iovs, sizeof(daos_iov_t) * sgl->sg_nr);
+		sgl->sg_iovs = (d_iov_t *)realloc
+			(sgl->sg_iovs, sizeof(d_iov_t) * sgl->sg_nr);
 		if (sgl->sg_iovs == NULL) {
 			D_ERROR("Failed memory allocation\n");
 			return -DER_NOMEM;
@@ -1017,7 +1017,7 @@ create_sgl(daos_sg_list_t *user_sgl, daos_size_t cell_size,
 
 static int
 dac_array_io(daos_handle_t array_oh, daos_handle_t th,
-	     daos_array_iod_t *rg_iod, daos_sg_list_t *user_sgl,
+	     daos_array_iod_t *rg_iod, d_sg_list_t *user_sgl,
 	     daos_opc_t op_type, tse_task_t *task)
 {
 	struct dac_array *array = NULL;
@@ -1073,7 +1073,7 @@ dac_array_io(daos_handle_t array_oh, daos_handle_t th,
 	 */
 	while (u < rg_iod->arr_nr) {
 		daos_iod_t	*iod;
-		daos_sg_list_t	*sgl;
+		d_sg_list_t	*sgl;
 		daos_key_t	*dkey;
 		daos_size_t	dkey_records;
 		tse_task_t	*io_task = NULL;
@@ -1130,10 +1130,10 @@ dac_array_io(daos_handle_t array_oh, daos_handle_t th,
 			params->dkey_val);
 		D_DEBUG(DB_IO, "idx = %d\t num_records = %zu\t record_i = %d\n",
 			(int)array_idx, num_records, (int)record_i);
-		daos_iov_set(dkey, &params->dkey_val, sizeof(uint64_t));
+		d_iov_set(dkey, &params->dkey_val, sizeof(uint64_t));
 
 		/* set descriptor for KV object */
-		daos_iov_set(&iod->iod_name, &params->akey_str, 1);
+		d_iov_set(&iod->iod_name, &params->akey_str, 1);
 		iod->iod_kcsum = null_csum;
 		iod->iod_nr = 0;
 		iod->iod_csums = NULL;
@@ -1425,9 +1425,9 @@ dac_array_get_size(tse_task_t *task)
 	*args->size = 0;
 
 	kqp->akey_str	= '0';
-	daos_iov_set(&kqp->akey, &kqp->akey_str, 1);
+	d_iov_set(&kqp->akey, &kqp->akey_str, 1);
 	kqp->dkey_val	= 0;
-	daos_iov_set(&kqp->dkey, &kqp->dkey_val, sizeof(uint64_t));
+	d_iov_set(&kqp->dkey, &kqp->dkey_val, sizeof(uint64_t));
 	kqp->ptask	= task;
 	kqp->size	= args->size;
 	kqp->array	= array;
@@ -1484,8 +1484,8 @@ struct set_size_props {
 	char		buf[ENUM_DESC_BUF];
 	daos_key_desc_t kds[ENUM_DESC_NR];
 	char		*val;
-	daos_iov_t	iov;
-	daos_sg_list_t  sgl;
+	d_iov_t	iov;
+	d_sg_list_t  sgl;
 	uint32_t	nr;
 	daos_anchor_t	anchor;
 	bool		update_dkey;
@@ -1530,7 +1530,7 @@ punch_key(daos_handle_t oh, daos_handle_t th, daos_size_t dkey_val,
 
 	params->dkey_val = dkey_val;
 	dkey = &params->dkey;
-	daos_iov_set(dkey, &params->dkey_val, sizeof(uint64_t));
+	d_iov_set(dkey, &params->dkey_val, sizeof(uint64_t));
 
 	/** Punch this entire dkey */
 	D_DEBUG(DB_IO, "Punching Key %zu\n", dkey_val);
@@ -1560,7 +1560,7 @@ punch_key(daos_handle_t oh, daos_handle_t th, daos_size_t dkey_val,
 
 		akey = &params->iod.iod_name;
 		params->akey_str = '0';
-		daos_iov_set(akey, &params->akey_str, 1);
+		d_iov_set(akey, &params->akey_str, 1);
 		p_args->akey_nr = 1;
 		p_args->akeys = akey;
 	}
@@ -1593,7 +1593,7 @@ punch_extent(daos_handle_t oh, daos_handle_t th, daos_size_t dkey_val,
 {
 	daos_obj_update_t	*io_arg;
 	daos_iod_t		*iod;
-	daos_sg_list_t		*sgl;
+	d_sg_list_t		*sgl;
 	daos_key_t		*dkey;
 	daos_csum_buf_t		null_csum;
 	struct io_params	*params = NULL;
@@ -1617,10 +1617,10 @@ punch_extent(daos_handle_t oh, daos_handle_t th, daos_size_t dkey_val,
 	params->user_sgl_used = false;
 	params->dkey_val = dkey_val;
 	dkey = &params->dkey;
-	daos_iov_set(dkey, &params->dkey_val, sizeof(uint64_t));
+	d_iov_set(dkey, &params->dkey_val, sizeof(uint64_t));
 
 	/* set descriptor for KV object */
-	daos_iov_set(&iod->iod_name, &params->akey_str, 1);
+	d_iov_set(&iod->iod_name, &params->akey_str, 1);
 	iod->iod_kcsum = null_csum;
 	iod->iod_nr = 1;
 	iod->iod_csums = NULL;
@@ -1674,7 +1674,7 @@ check_record_cb(tse_task_t *task, void *data)
 	daos_obj_update_t	*io_arg;
 	tse_task_t		*io_task = NULL;
 	daos_iod_t		*iod;
-	daos_sg_list_t		*sgl;
+	d_sg_list_t		*sgl;
 	daos_key_t		*dkey;
 	char			*val;
 	int			rc = task->dt_result;
@@ -1695,7 +1695,7 @@ check_record_cb(tse_task_t *task, void *data)
 	D_ALLOC(val, params->cell_size);
 	sgl->sg_nr = 1;
 	D_ALLOC_PTR(sgl->sg_iovs);
-	daos_iov_set(&sgl->sg_iovs[0], val, params->cell_size);
+	d_iov_set(&sgl->sg_iovs[0], val, params->cell_size);
 
 	D_DEBUG(DB_IO, "update record (%zu, %zu), iod_size %zu.\n",
 		iod->iod_recxs[0].rx_idx, iod->iod_recxs[0].rx_nr,
@@ -1753,7 +1753,7 @@ check_record(daos_handle_t oh, daos_handle_t th, daos_size_t dkey_val,
 {
 	daos_obj_fetch_t	*io_arg;
 	daos_iod_t		*iod;
-	daos_sg_list_t		*sgl;
+	d_sg_list_t		*sgl;
 	daos_key_t		*dkey;
 	daos_csum_buf_t		null_csum;
 	struct io_params	*params = NULL;
@@ -1774,10 +1774,10 @@ check_record(daos_handle_t oh, daos_handle_t th, daos_size_t dkey_val,
 	params->dkey_val = dkey_val;
 	params->task = task;
 	dkey = &params->dkey;
-	daos_iov_set(dkey, &params->dkey_val, sizeof(uint64_t));
+	d_iov_set(dkey, &params->dkey_val, sizeof(uint64_t));
 
 	/* set descriptor for KV object */
-	daos_iov_set(&iod->iod_name, &params->akey_str, 1);
+	d_iov_set(&iod->iod_name, &params->akey_str, 1);
 	daos_csum_set(&null_csum, NULL, 0);
 	iod->iod_kcsum = null_csum;
 	iod->iod_nr = 1;
@@ -1832,7 +1832,7 @@ add_record(daos_handle_t oh, daos_handle_t th, struct set_size_props *props)
 {
 	daos_obj_update_t	*io_arg;
 	daos_iod_t		*iod;
-	daos_sg_list_t		*sgl;
+	d_sg_list_t		*sgl;
 	daos_key_t		*dkey;
 	daos_csum_buf_t		null_csum;
 	struct io_params	*params = NULL;
@@ -1855,16 +1855,16 @@ add_record(daos_handle_t oh, daos_handle_t th, struct set_size_props *props)
 	params->next = NULL;
 	params->user_sgl_used = false;
 	params->dkey_val = props->dkey_val;
-	daos_iov_set(dkey, &params->dkey_val, sizeof(uint64_t));
+	d_iov_set(dkey, &params->dkey_val, sizeof(uint64_t));
 
 	/** set memory location */
 	D_ALLOC(props->val, props->cell_size);
 	sgl->sg_nr = 1;
 	D_ALLOC_PTR(sgl->sg_iovs);
-	daos_iov_set(&sgl->sg_iovs[0], props->val, props->cell_size);
+	d_iov_set(&sgl->sg_iovs[0], props->val, props->cell_size);
 
 	/* set descriptor for KV object */
-	daos_iov_set(&iod->iod_name, &params->akey_str, 1);
+	d_iov_set(&iod->iod_name, &params->akey_str, 1);
 	iod->iod_kcsum = null_csum;
 	iod->iod_nr = 1;
 	iod->iod_csums = NULL;
@@ -1972,7 +1972,7 @@ adjust_array_size_cb(tse_task_t *task, void *data)
 		props->nr = ENUM_DESC_NR;
 		memset(props->buf, 0, ENUM_DESC_BUF);
 		args->sgl->sg_nr = 1;
-		daos_iov_set(&args->sgl->sg_iovs[0], props->buf, ENUM_DESC_BUF);
+		d_iov_set(&args->sgl->sg_iovs[0], props->buf, ENUM_DESC_BUF);
 
 		rc = tse_task_reinit(task);
 		if (rc) {
@@ -2062,7 +2062,7 @@ dac_array_set_size(tse_task_t *task)
 	memset(&set_size_props->anchor, 0, sizeof(set_size_props->anchor));
 	set_size_props->sgl.sg_nr = 1;
 	set_size_props->sgl.sg_iovs = &set_size_props->iov;
-	daos_iov_set(&set_size_props->sgl.sg_iovs[0], set_size_props->buf,
+	d_iov_set(&set_size_props->sgl.sg_iovs[0], set_size_props->buf,
 		     ENUM_DESC_BUF);
 
 	rc = daos_task_create(DAOS_OPC_OBJ_LIST_DKEY, tse_task2sched(task),

--- a/src/client/addons/dac_hl.c
+++ b/src/client/addons/dac_hl.c
@@ -37,8 +37,8 @@
 struct io_params {
 	daos_key_t		dkey;
 	daos_iod_t		iod;
-	daos_iov_t		iov;
-	daos_sg_list_t		sgl;
+	d_iov_t		iov;
+	d_sg_list_t		sgl;
 };
 
 static int
@@ -77,10 +77,10 @@ dac_kv_put(tse_task_t *task)
 	}
 
 	/** init dkey */
-	daos_iov_set(&params->dkey, (void *)args->key, strlen(args->key));
+	d_iov_set(&params->dkey, (void *)args->key, strlen(args->key));
 
 	/** init iod. For now set akey = dkey */
-	daos_iov_set(&params->iod.iod_name, (void *)args->key,
+	d_iov_set(&params->iod.iod_name, (void *)args->key,
 		     strlen(args->key));
 	params->iod.iod_nr	= 1;
 	params->iod.iod_recxs	= NULL;
@@ -92,7 +92,7 @@ dac_kv_put(tse_task_t *task)
 	/** init sgl */
 	params->sgl.sg_nr = 1;
 	params->sgl.sg_iovs = &params->iov;
-	daos_iov_set(&params->sgl.sg_iovs[0], (void *)args->buf,
+	d_iov_set(&params->sgl.sg_iovs[0], (void *)args->buf,
 		     args->buf_size);
 
 	rc = daos_task_create(DAOS_OPC_OBJ_UPDATE, tse_task2sched(task),
@@ -159,10 +159,10 @@ dac_kv_get(tse_task_t *task)
 	}
 
 	/** init dkey */
-	daos_iov_set(&params->dkey, (void *)args->key, strlen(args->key));
+	d_iov_set(&params->dkey, (void *)args->key, strlen(args->key));
 
 	/** init iod. For now set akey = dkey */
-	daos_iov_set(&params->iod.iod_name, (void *)args->key,
+	d_iov_set(&params->iod.iod_name, (void *)args->key,
 		     strlen(args->key));
 	params->iod.iod_nr	= 1;
 	params->iod.iod_recxs	= NULL;
@@ -173,7 +173,7 @@ dac_kv_get(tse_task_t *task)
 
 	/** init sgl */
 	if (buf && *buf_size) {
-		daos_iov_set(&params->iov, buf, *buf_size);
+		d_iov_set(&params->iov, buf, *buf_size);
 		params->sgl.sg_iovs = &params->iov;
 		params->sgl.sg_nr = 1;
 	}
@@ -241,7 +241,7 @@ dac_kv_remove(tse_task_t *task)
 	}
 
 	/** init dkey */
-	daos_iov_set(&params->dkey, (void *)args->key, strlen(args->key));
+	d_iov_set(&params->dkey, (void *)args->key, strlen(args->key));
 
 	rc = daos_task_create(DAOS_OPC_OBJ_PUNCH_DKEYS, tse_task2sched(task),
 			      0, NULL, &punch_task);

--- a/src/client/addons/daos_array.c
+++ b/src/client/addons/daos_array.c
@@ -85,13 +85,13 @@ daos_array_open(daos_handle_t coh, daos_obj_id_t oid, daos_handle_t th,
 }
 
 int
-daos_array_local2global(daos_handle_t oh, daos_iov_t *glob)
+daos_array_local2global(daos_handle_t oh, d_iov_t *glob)
 {
 	return dac_array_local2global(oh, glob);
 }
 
 int
-daos_array_global2local(daos_handle_t coh, daos_iov_t glob, daos_handle_t *oh)
+daos_array_global2local(daos_handle_t coh, d_iov_t glob, daos_handle_t *oh)
 {
 	return dac_array_global2local(coh, glob, oh);
 }
@@ -133,7 +133,7 @@ daos_array_destroy(daos_handle_t oh, daos_handle_t th, daos_event_t *ev)
 
 int
 daos_array_read(daos_handle_t oh, daos_handle_t th,
-		daos_array_iod_t *iod, daos_sg_list_t *sgl,
+		daos_array_iod_t *iod, d_sg_list_t *sgl,
 		daos_csum_buf_t *csums, daos_event_t *ev)
 {
 	daos_array_io_t	*args;
@@ -156,7 +156,7 @@ daos_array_read(daos_handle_t oh, daos_handle_t th,
 
 int
 daos_array_write(daos_handle_t oh, daos_handle_t th,
-		 daos_array_iod_t *iod, daos_sg_list_t *sgl,
+		 daos_array_iod_t *iod, d_sg_list_t *sgl,
 		 daos_csum_buf_t *csums, daos_event_t *ev)
 {
 	daos_array_io_t	*args;

--- a/src/client/addons/daos_hl.c
+++ b/src/client/addons/daos_hl.c
@@ -98,7 +98,7 @@ daos_kv_remove(daos_handle_t oh, daos_handle_t th, const char *key,
 
 int
 daos_kv_list(daos_handle_t oh, daos_handle_t th, uint32_t *nr,
-	     daos_key_desc_t *kds, daos_sg_list_t *sgl, daos_anchor_t *anchor,
+	     daos_key_desc_t *kds, d_sg_list_t *sgl, daos_anchor_t *anchor,
 	     daos_event_t *ev)
 {
 	daos_kv_list_t	*args;

--- a/src/client/api/container.c
+++ b/src/client/api/container.c
@@ -28,13 +28,13 @@
 #include "task_internal.h"
 
 int
-daos_cont_local2global(daos_handle_t coh, daos_iov_t *glob)
+daos_cont_local2global(daos_handle_t coh, d_iov_t *glob)
 {
 	return dc_cont_local2global(coh, glob);
 }
 
 int
-daos_cont_global2local(daos_handle_t poh, daos_iov_t glob, daos_handle_t *coh)
+daos_cont_global2local(daos_handle_t poh, d_iov_t glob, daos_handle_t *coh)
 {
 	return dc_cont_global2local(poh, glob, coh);
 }

--- a/src/client/api/object.c
+++ b/src/client/api/object.c
@@ -164,7 +164,7 @@ daos_obj_query_key(daos_handle_t oh, daos_handle_t th, uint32_t flags,
 
 int
 daos_obj_fetch(daos_handle_t oh, daos_handle_t th, daos_key_t *dkey,
-	       unsigned int nr, daos_iod_t *iods, daos_sg_list_t *sgls,
+	       unsigned int nr, daos_iod_t *iods, d_sg_list_t *sgls,
 	       daos_iom_t *maps, daos_event_t *ev)
 {
 	tse_task_t	*task;
@@ -180,7 +180,7 @@ daos_obj_fetch(daos_handle_t oh, daos_handle_t th, daos_key_t *dkey,
 
 int
 daos_obj_update(daos_handle_t oh, daos_handle_t th, daos_key_t *dkey,
-		unsigned int nr, daos_iod_t *iods, daos_sg_list_t *sgls,
+		unsigned int nr, daos_iod_t *iods, d_sg_list_t *sgls,
 		daos_event_t *ev)
 {
 	tse_task_t	*task;
@@ -196,7 +196,7 @@ daos_obj_update(daos_handle_t oh, daos_handle_t th, daos_key_t *dkey,
 
 int
 daos_obj_list_dkey(daos_handle_t oh, daos_handle_t th, uint32_t *nr,
-		   daos_key_desc_t *kds, daos_sg_list_t *sgl,
+		   daos_key_desc_t *kds, d_sg_list_t *sgl,
 		   daos_anchor_t *anchor, daos_event_t *ev)
 {
 	tse_task_t	*task;
@@ -212,7 +212,7 @@ daos_obj_list_dkey(daos_handle_t oh, daos_handle_t th, uint32_t *nr,
 
 int
 daos_obj_list_akey(daos_handle_t oh, daos_handle_t th, daos_key_t *dkey,
-		   uint32_t *nr, daos_key_desc_t *kds, daos_sg_list_t *sgl,
+		   uint32_t *nr, daos_key_desc_t *kds, d_sg_list_t *sgl,
 		   daos_anchor_t *anchor, daos_event_t *ev)
 {
 	tse_task_t	*task;

--- a/src/client/api/pool.c
+++ b/src/client/api/pool.c
@@ -72,13 +72,13 @@ daos_pool_disconnect(daos_handle_t poh, daos_event_t *ev)
 }
 
 int
-daos_pool_local2global(daos_handle_t poh, daos_iov_t *glob)
+daos_pool_local2global(daos_handle_t poh, d_iov_t *glob)
 {
 	return dc_pool_local2global(poh, glob);
 }
 
 int
-daos_pool_global2local(daos_iov_t glob, daos_handle_t *poh)
+daos_pool_global2local(d_iov_t glob, daos_handle_t *poh)
 {
 	return dc_pool_global2local(glob, poh);
 }

--- a/src/client/api/tx.c
+++ b/src/client/api/tx.c
@@ -122,13 +122,13 @@ daos_tx_open_snap(daos_handle_t coh, daos_epoch_t epoch, daos_handle_t *th,
 }
 
 int
-daos_tx_local2global(daos_handle_t th, daos_iov_t *glob)
+daos_tx_local2global(daos_handle_t th, d_iov_t *glob)
 {
 	return -DER_NOSYS;
 }
 
 int
-daos_tx_global2local(daos_handle_t coh, daos_iov_t glob, daos_handle_t *th)
+daos_tx_global2local(daos_handle_t coh, d_iov_t glob, daos_handle_t *th)
 {
 	return -DER_NOSYS;
 }

--- a/src/client/dfs/dfs.c
+++ b/src/client/dfs/dfs.c
@@ -257,8 +257,8 @@ static int
 fetch_entry(daos_handle_t oh, daos_handle_t th, const char *name,
 	    bool fetch_sym, bool *exists, struct dfs_entry *entry)
 {
-	daos_sg_list_t	sgls[INODE_AKEYS + 1];
-	daos_iov_t	sg_iovs[INODE_AKEYS + 1];
+	d_sg_list_t	sgls[INODE_AKEYS + 1];
+	d_iov_t	sg_iovs[INODE_AKEYS + 1];
 	daos_iod_t	iods[INODE_AKEYS + 1];
 	char		value[DFS_MAX_PATH];
 	daos_key_t	dkey;
@@ -271,38 +271,38 @@ fetch_entry(daos_handle_t oh, daos_handle_t th, const char *name,
 	if (strcmp(name, ".") == 0)
 		D_ASSERT(0);
 
-	daos_iov_set(&dkey, (void *)name, strlen(name));
+	d_iov_set(&dkey, (void *)name, strlen(name));
 	i = 0;
 
 	/** Set Akey for MODE */
-	daos_iov_set(&sg_iovs[i], &entry->mode, sizeof(mode_t));
-	daos_iov_set(&iods[i].iod_name, MODE_NAME, strlen(MODE_NAME));
+	d_iov_set(&sg_iovs[i], &entry->mode, sizeof(mode_t));
+	d_iov_set(&iods[i].iod_name, MODE_NAME, strlen(MODE_NAME));
 	i++;
 
 	/** Set Akey for OID; if entry is symlink, this value will be bogus */
-	daos_iov_set(&sg_iovs[i], &entry->oid, sizeof(daos_obj_id_t));
-	daos_iov_set(&iods[i].iod_name, OID_NAME, strlen(OID_NAME));
+	d_iov_set(&sg_iovs[i], &entry->oid, sizeof(daos_obj_id_t));
+	d_iov_set(&iods[i].iod_name, OID_NAME, strlen(OID_NAME));
 	i++;
 
 	/** Set Akey for ATIME */
-	daos_iov_set(&sg_iovs[i], &entry->atime, sizeof(time_t));
-	daos_iov_set(&iods[i].iod_name, ATIME_NAME, strlen(ATIME_NAME));
+	d_iov_set(&sg_iovs[i], &entry->atime, sizeof(time_t));
+	d_iov_set(&iods[i].iod_name, ATIME_NAME, strlen(ATIME_NAME));
 	i++;
 
 	/** Set Akey for MTIME */
-	daos_iov_set(&sg_iovs[i], &entry->mtime, sizeof(time_t));
-	daos_iov_set(&iods[i].iod_name, MTIME_NAME, strlen(MTIME_NAME));
+	d_iov_set(&sg_iovs[i], &entry->mtime, sizeof(time_t));
+	d_iov_set(&iods[i].iod_name, MTIME_NAME, strlen(MTIME_NAME));
 	i++;
 
 	/** Set Akey for CTIME */
-	daos_iov_set(&sg_iovs[i], &entry->ctime, sizeof(time_t));
-	daos_iov_set(&iods[i].iod_name, CTIME_NAME, strlen(CTIME_NAME));
+	d_iov_set(&sg_iovs[i], &entry->ctime, sizeof(time_t));
+	d_iov_set(&iods[i].iod_name, CTIME_NAME, strlen(CTIME_NAME));
 	i++;
 
 	if (fetch_sym) {
 		/** Set Akey for Symlink Value, will be empty if no symlink */
-		daos_iov_set(&sg_iovs[i], value, DFS_MAX_PATH);
-		daos_iov_set(&iods[i].iod_name, SYML_NAME, strlen(SYML_NAME));
+		d_iov_set(&sg_iovs[i], value, DFS_MAX_PATH);
+		d_iov_set(&iods[i].iod_name, SYML_NAME, strlen(SYML_NAME));
 		i++;
 	}
 
@@ -371,7 +371,7 @@ remove_entry(dfs_t *dfs, daos_handle_t th, daos_handle_t parent_oh,
 			return rc;
 	}
 
-	daos_iov_set(&dkey, (void *)name, strlen(name));
+	d_iov_set(&dkey, (void *)name, strlen(name));
 	return daos_obj_punch_dkeys(parent_oh, th, 1, &dkey, NULL);
 }
 
@@ -379,50 +379,50 @@ static int
 insert_entry(daos_handle_t oh, daos_handle_t th, const char *name,
 	     struct dfs_entry entry)
 {
-	daos_sg_list_t	sgls[INODE_AKEYS];
-	daos_iov_t	sg_iovs[INODE_AKEYS];
+	d_sg_list_t	sgls[INODE_AKEYS];
+	d_iov_t	sg_iovs[INODE_AKEYS];
 	daos_iod_t	iods[INODE_AKEYS];
 	daos_key_t	dkey;
 	unsigned int	akeys_nr, i;
 	int		rc;
 
-	daos_iov_set(&dkey, (void *)name, strlen(name));
+	d_iov_set(&dkey, (void *)name, strlen(name));
 
 	i = 0;
 
 	/** Add the mode */
-	daos_iov_set(&sg_iovs[i], &entry.mode, sizeof(mode_t));
-	daos_iov_set(&iods[i].iod_name, MODE_NAME, strlen(MODE_NAME));
+	d_iov_set(&sg_iovs[i], &entry.mode, sizeof(mode_t));
+	d_iov_set(&iods[i].iod_name, MODE_NAME, strlen(MODE_NAME));
 	iods[i].iod_size = sizeof(mode_t);
 	i++;
 
 	/** If entry is a symlink add the value, otherwise add the oid */
 	if (S_ISLNK(entry.mode)) {
-		daos_iov_set(&sg_iovs[i], entry.value, strlen(entry.value) + 1);
-		daos_iov_set(&iods[i].iod_name, SYML_NAME, strlen(SYML_NAME));
+		d_iov_set(&sg_iovs[i], entry.value, strlen(entry.value) + 1);
+		d_iov_set(&iods[i].iod_name, SYML_NAME, strlen(SYML_NAME));
 		iods[i].iod_size = strlen(entry.value) + 1;
 	} else {
-		daos_iov_set(&sg_iovs[i], &entry.oid, sizeof(daos_obj_id_t));
-		daos_iov_set(&iods[i].iod_name, OID_NAME, strlen(OID_NAME));
+		d_iov_set(&sg_iovs[i], &entry.oid, sizeof(daos_obj_id_t));
+		d_iov_set(&iods[i].iod_name, OID_NAME, strlen(OID_NAME));
 		iods[i].iod_size = sizeof(daos_obj_id_t);
 	}
 	i++;
 
 	/** Add the access time */
-	daos_iov_set(&sg_iovs[i], &entry.atime, sizeof(time_t));
-	daos_iov_set(&iods[i].iod_name, ATIME_NAME, strlen(ATIME_NAME));
+	d_iov_set(&sg_iovs[i], &entry.atime, sizeof(time_t));
+	d_iov_set(&iods[i].iod_name, ATIME_NAME, strlen(ATIME_NAME));
 	iods[i].iod_size = sizeof(time_t);
 	i++;
 
 	/** Add the modify time */
-	daos_iov_set(&sg_iovs[i], &entry.mtime, sizeof(time_t));
-	daos_iov_set(&iods[i].iod_name, MTIME_NAME, strlen(MTIME_NAME));
+	d_iov_set(&sg_iovs[i], &entry.mtime, sizeof(time_t));
+	d_iov_set(&iods[i].iod_name, MTIME_NAME, strlen(MTIME_NAME));
 	iods[i].iod_size = sizeof(time_t);
 	i++;
 
 	/** Add the change time */
-	daos_iov_set(&sg_iovs[i], &entry.ctime, sizeof(time_t));
-	daos_iov_set(&iods[i].iod_name, CTIME_NAME, strlen(CTIME_NAME));
+	d_iov_set(&sg_iovs[i], &entry.ctime, sizeof(time_t));
+	d_iov_set(&iods[i].iod_name, CTIME_NAME, strlen(CTIME_NAME));
 	iods[i].iod_size = sizeof(time_t);
 	i++;
 
@@ -457,14 +457,14 @@ get_nlinks(daos_handle_t oh, daos_handle_t th, uint32_t *nlinks,
 	daos_key_desc_t	kds[ENUM_DESC_NR];
 	daos_anchor_t	anchor = {0};
 	uint32_t	key_nr = 0;
-	daos_sg_list_t	sgl;
-	daos_iov_t	iov;
+	d_sg_list_t	sgl;
+	d_iov_t	iov;
 	char		enum_buf[ENUM_DESC_BUF] = {0};
 	int		rc;
 
 	sgl.sg_nr = 1;
 	sgl.sg_nr_out = 0;
-	daos_iov_set(&iov, enum_buf, ENUM_DESC_BUF);
+	d_iov_set(&iov, enum_buf, ENUM_DESC_BUF);
 	sgl.sg_iovs = &iov;
 
 	/** TODO - Enum of links is expensive. Need to make this faster */
@@ -891,21 +891,21 @@ open_symlink(dfs_t *dfs, daos_handle_t th, dfs_obj_t *parent, int flags,
 static int
 check_sb(dfs_t *dfs, daos_handle_t th, bool insert, bool *exists)
 {
-	daos_sg_list_t	sgl;
-	daos_iov_t	sg_iov;
+	d_sg_list_t	sgl;
+	d_iov_t	sg_iov;
 	daos_iod_t	iod;
 	daos_key_t	dkey;
 	uint64_t	sb_magic;
 	int		rc;
 
-	daos_iov_set(&dkey, SB_DKEY, strlen(SB_DKEY));
+	d_iov_set(&dkey, SB_DKEY, strlen(SB_DKEY));
 
-	daos_iov_set(&sg_iov, &sb_magic, sizeof(uint64_t));
+	d_iov_set(&sg_iov, &sb_magic, sizeof(uint64_t));
 	sgl.sg_nr = 1;
 	sgl.sg_nr_out = 0;
 	sgl.sg_iovs = &sg_iov;
 
-	daos_iov_set(&iod.iod_name, SB_AKEY, strlen(SB_AKEY));
+	d_iov_set(&iod.iod_name, SB_AKEY, strlen(SB_AKEY));
 	daos_csum_set(&iod.iod_kcsum, NULL, 0);
 	iod.iod_nr	= 1;
 	iod.iod_size	= DAOS_REC_ANY;
@@ -1210,9 +1210,9 @@ remove_dir_contents(dfs_t *dfs, daos_handle_t th, struct dfs_entry entry)
 	daos_handle_t	oh;
 	daos_key_desc_t	kds[ENUM_DESC_NR];
 	daos_anchor_t	anchor = {0};
-	daos_iov_t	iov;
+	d_iov_t	iov;
 	char		enum_buf[ENUM_DESC_BUF] = {0};
-	daos_sg_list_t	sgl;
+	d_sg_list_t	sgl;
 	int		rc;
 
 	D_ASSERT(S_ISDIR(entry.mode));
@@ -1223,7 +1223,7 @@ remove_dir_contents(dfs_t *dfs, daos_handle_t th, struct dfs_entry entry)
 
 	sgl.sg_nr = 1;
 	sgl.sg_nr_out = 0;
-	daos_iov_set(&iov, enum_buf, ENUM_DESC_BUF);
+	d_iov_set(&iov, enum_buf, ENUM_DESC_BUF);
 	sgl.sg_iovs = &iov;
 
 	while (!daos_anchor_is_eof(&anchor)) {
@@ -1536,7 +1536,7 @@ dfs_readdir(dfs_t *dfs, dfs_obj_t *obj, daos_anchor_t *anchor, uint32_t *nr,
 	daos_key_desc_t *kds;
 	char *enum_buf;
 	uint32_t number, key_nr, i;
-	daos_sg_list_t sgl;
+	d_sg_list_t sgl;
 	int rc;
 
 	if (dfs == NULL || !dfs->mounted)
@@ -1567,14 +1567,14 @@ dfs_readdir(dfs_t *dfs, dfs_obj_t *obj, daos_anchor_t *anchor, uint32_t *nr,
 	key_nr = 0;
 	number = *nr;
 	while (!daos_anchor_is_eof(anchor)) {
-		daos_iov_t iov;
+		d_iov_t iov;
 		char *ptr;
 
 		memset(enum_buf, 0, (*nr) * DFS_MAX_PATH);
 
 		sgl.sg_nr = 1;
 		sgl.sg_nr_out = 0;
-		daos_iov_set(&iov, enum_buf, (*nr) * DFS_MAX_PATH);
+		d_iov_set(&iov, enum_buf, (*nr) * DFS_MAX_PATH);
 		sgl.sg_iovs = &iov;
 
 		rc = daos_obj_list_dkey(obj->oh, DAOS_TX_NONE, &number, kds,
@@ -1798,7 +1798,7 @@ dfs_release(dfs_obj_t *obj)
 }
 
 static int
-io_internal(dfs_t *dfs, dfs_obj_t *obj, daos_sg_list_t sgl, daos_off_t off,
+io_internal(dfs_t *dfs, dfs_obj_t *obj, d_sg_list_t sgl, daos_off_t off,
 	    int flag)
 {
 	daos_array_iod_t	iod;
@@ -1838,7 +1838,7 @@ io_internal(dfs_t *dfs, dfs_obj_t *obj, daos_sg_list_t sgl, daos_off_t off,
 }
 
 int
-dfs_read(dfs_t *dfs, dfs_obj_t *obj, daos_sg_list_t sgl, daos_off_t off,
+dfs_read(dfs_t *dfs, dfs_obj_t *obj, d_sg_list_t sgl, daos_off_t off,
 	 daos_size_t *read_size)
 {
 	daos_size_t	array_size, max_read;
@@ -1891,7 +1891,7 @@ dfs_read(dfs_t *dfs, dfs_obj_t *obj, daos_sg_list_t sgl, daos_off_t off,
 }
 
 int
-dfs_write(dfs_t *dfs, dfs_obj_t *obj, daos_sg_list_t sgl, daos_off_t off)
+dfs_write(dfs_t *dfs, dfs_obj_t *obj, d_sg_list_t sgl, daos_off_t off)
 {
 	if (dfs == NULL || !dfs->mounted)
 		return -DER_INVAL;
@@ -2044,8 +2044,8 @@ dfs_chmod(dfs_t *dfs, dfs_obj_t *parent, const char *name, mode_t mode)
 	daos_handle_t		th = DAOS_TX_NONE;
 	bool			exists;
 	struct dfs_entry	entry;
-	daos_sg_list_t		sgl;
-	daos_iov_t		sg_iov;
+	d_sg_list_t		sgl;
+	d_iov_t		sg_iov;
 	daos_iod_t		iod;
 	daos_key_t		dkey;
 	int			rc;
@@ -2117,10 +2117,10 @@ dfs_chmod(dfs_t *dfs, dfs_obj_t *parent, const char *name, mode_t mode)
 	}
 
 	/** set dkey as the entry name */
-	daos_iov_set(&dkey, (void *)name, strlen(name));
+	d_iov_set(&dkey, (void *)name, strlen(name));
 
 	/** set akey as the mode attr name */
-	daos_iov_set(&iod.iod_name, MODE_NAME, strlen(MODE_NAME));
+	d_iov_set(&iod.iod_name, MODE_NAME, strlen(MODE_NAME));
 	daos_csum_set(&iod.iod_kcsum, NULL, 0);
 	iod.iod_nr	= 1;
 	iod.iod_recxs	= NULL;
@@ -2130,7 +2130,7 @@ dfs_chmod(dfs_t *dfs, dfs_obj_t *parent, const char *name, mode_t mode)
 	iod.iod_size	= sizeof(mode_t);
 
 	/** set sgl for update */
-	daos_iov_set(&sg_iov, &mode, sizeof(mode_t));
+	d_iov_set(&sg_iov, &mode, sizeof(mode_t));
 	sgl.sg_nr	= 1;
 	sgl.sg_nr_out	= 0;
 	sgl.sg_iovs	= &sg_iov;
@@ -2404,7 +2404,7 @@ dfs_move(dfs_t *dfs, dfs_obj_t *parent, char *name, dfs_obj_t *new_parent,
 	}
 
 	/** remove the old entry from the old parent (just the dkey) */
-	daos_iov_set(&dkey, (void *)name, strlen(name));
+	d_iov_set(&dkey, (void *)name, strlen(name));
 	rc = daos_obj_punch_dkeys(parent->oh, th, 1, &dkey, NULL);
 	if (rc) {
 		D_ERROR("Punch entry %s failed (%d)\n", name, rc);
@@ -2487,7 +2487,7 @@ dfs_exchange(dfs_t *dfs, dfs_obj_t *parent1, char *name1, dfs_obj_t *parent2,
 		D_GOTO(out, rc = -DER_INVAL);
 
 	/** remove the first entry from parent1 (just the dkey) */
-	daos_iov_set(&dkey, (void *)name1, strlen(name1));
+	d_iov_set(&dkey, (void *)name1, strlen(name1));
 	rc = daos_obj_punch_dkeys(parent1->oh, th, 1, &dkey, NULL);
 	if (rc) {
 		D_ERROR("Punch entry %s failed (%d)\n", name1, rc);
@@ -2495,7 +2495,7 @@ dfs_exchange(dfs_t *dfs, dfs_obj_t *parent1, char *name1, dfs_obj_t *parent2,
 	}
 
 	/** remove the second entry from parent2 (just the dkey) */
-	daos_iov_set(&dkey, (void *)name2, strlen(name2));
+	d_iov_set(&dkey, (void *)name2, strlen(name2));
 	rc = daos_obj_punch_dkeys(parent2->oh, th, 1, &dkey, NULL);
 	if (rc) {
 		D_ERROR("Punch entry %s failed (%d)\n", name2, rc);
@@ -2564,8 +2564,8 @@ dfs_setxattr(dfs_t *dfs, dfs_obj_t *obj, const char *name,
 {
 	char		*xname = NULL;
 	daos_handle_t	th = DAOS_TX_NONE;
-	daos_sg_list_t	sgl;
-	daos_iov_t	sg_iov;
+	d_sg_list_t	sgl;
+	d_iov_t	sg_iov;
 	daos_iod_t	iod;
 	daos_key_t	dkey;
 	daos_handle_t	oh;
@@ -2595,10 +2595,10 @@ dfs_setxattr(dfs_t *dfs, dfs_obj_t *obj, const char *name,
 		D_GOTO(out, rc);
 
 	/** set dkey as the entry name */
-	daos_iov_set(&dkey, (void *)obj->name, strlen(obj->name));
+	d_iov_set(&dkey, (void *)obj->name, strlen(obj->name));
 
 	/** set akey as the xattr name */
-	daos_iov_set(&iod.iod_name, xname, strlen(xname));
+	d_iov_set(&iod.iod_name, xname, strlen(xname));
 	daos_csum_set(&iod.iod_kcsum, NULL, 0);
 	iod.iod_nr	= 1;
 	iod.iod_recxs	= NULL;
@@ -2630,7 +2630,7 @@ dfs_setxattr(dfs_t *dfs, dfs_obj_t *obj, const char *name,
 	}
 
 	/** set sgl for update */
-	daos_iov_set(&sg_iov, (void *)value, size);
+	d_iov_set(&sg_iov, (void *)value, size);
 	sgl.sg_nr	= 1;
 	sgl.sg_nr_out	= 0;
 	sgl.sg_iovs	= &sg_iov;
@@ -2654,8 +2654,8 @@ dfs_getxattr(dfs_t *dfs, dfs_obj_t *obj, const char *name, void *value,
 	     daos_size_t *size)
 {
 	char            *xname = NULL;
-	daos_sg_list_t	sgl;
-	daos_iov_t	sg_iov;
+	d_sg_list_t	sgl;
+	d_iov_t	sg_iov;
 	daos_iod_t	iod;
 	daos_key_t	dkey;
 	daos_handle_t	oh;
@@ -2682,10 +2682,10 @@ dfs_getxattr(dfs_t *dfs, dfs_obj_t *obj, const char *name, void *value,
 		return rc;
 
 	/** set dkey as the entry name */
-	daos_iov_set(&dkey, (void *)obj->name, strlen(obj->name));
+	d_iov_set(&dkey, (void *)obj->name, strlen(obj->name));
 
 	/** set akey as the xattr name */
-	daos_iov_set(&iod.iod_name, xname, strlen(xname));
+	d_iov_set(&iod.iod_name, xname, strlen(xname));
 	daos_csum_set(&iod.iod_kcsum, NULL, 0);
 	iod.iod_nr	= 1;
 	iod.iod_recxs	= NULL;
@@ -2697,7 +2697,7 @@ dfs_getxattr(dfs_t *dfs, dfs_obj_t *obj, const char *name, void *value,
 		iod.iod_size	= *size;
 
 		/** set sgl for fetch */
-		daos_iov_set(&sg_iov, value, *size);
+		d_iov_set(&sg_iov, value, *size);
 		sgl.sg_nr	= 1;
 		sgl.sg_nr_out	= 0;
 		sgl.sg_iovs	= &sg_iov;
@@ -2759,10 +2759,10 @@ dfs_removexattr(dfs_t *dfs, dfs_obj_t *obj, const char *name)
 		D_GOTO(out, rc);
 
 	/** set dkey as the entry name */
-	daos_iov_set(&dkey, (void *)obj->name, strlen(obj->name));
+	d_iov_set(&dkey, (void *)obj->name, strlen(obj->name));
 
 	/** set akey as the xattr name */
-	daos_iov_set(&iod.iod_name, xname, strlen(xname));
+	d_iov_set(&iod.iod_name, xname, strlen(xname));
 	daos_csum_set(&iod.iod_kcsum, NULL, 0);
 	iod.iod_nr	= 1;
 	iod.iod_recxs	= NULL;
@@ -2807,7 +2807,7 @@ dfs_listxattr(dfs_t *dfs, dfs_obj_t *obj, char *list, daos_size_t *size)
 		return rc;
 
 	/** set dkey as the entry name */
-	daos_iov_set(&dkey, (void *)obj->name, strlen(obj->name));
+	d_iov_set(&dkey, (void *)obj->name, strlen(obj->name));
 
 	list_size = *size;
 	ret_size = 0;
@@ -2816,14 +2816,14 @@ dfs_listxattr(dfs_t *dfs, dfs_obj_t *obj, char *list, daos_size_t *size)
 	while (!daos_anchor_is_eof(&anchor)) {
 		uint32_t	number = ENUM_DESC_NR;
 		uint32_t	i;
-		daos_iov_t	iov;
+		d_iov_t	iov;
 		char		enum_buf[ENUM_DESC_BUF] = {0};
-		daos_sg_list_t	sgl;
+		d_sg_list_t	sgl;
 		char		*ptr;
 
 		sgl.sg_nr = 1;
 		sgl.sg_nr_out = 0;
-		daos_iov_set(&iov, enum_buf, ENUM_DESC_BUF);
+		d_iov_set(&iov, enum_buf, ENUM_DESC_BUF);
 		sgl.sg_iovs = &iov;
 
 		rc = daos_obj_list_akey(oh, DAOS_TX_NONE, &dkey, &number, kds,

--- a/src/client/dfs/dfuse_hl.c
+++ b/src/client/dfs/dfuse_hl.c
@@ -521,8 +521,8 @@ dfuse_read(const char *path, char *buf, size_t size, off_t offset,
 {
 	dfs_obj_t *obj;
 	daos_size_t actual;
-	daos_iov_t iov;
-	daos_sg_list_t sgl;
+	d_iov_t iov;
+	d_sg_list_t sgl;
 	int rc;
 
 	FUNC_ENTER("path = %s\n", path);
@@ -533,7 +533,7 @@ dfuse_read(const char *path, char *buf, size_t size, off_t offset,
 	/** set memory location */
 	sgl.sg_nr = 1;
 	sgl.sg_nr_out = 0;
-	daos_iov_set(&iov, buf, size);
+	d_iov_set(&iov, buf, size);
 	sgl.sg_iovs = &iov;
 
 	rc = dfs_read(dfs, obj, sgl, offset, &actual);
@@ -548,8 +548,8 @@ dfuse_write(const char *path, const char *buf, size_t size, off_t offset,
 	    struct fuse_file_info *fi)
 {
 	dfs_obj_t *obj;
-	daos_iov_t iov;
-	daos_sg_list_t sgl;
+	d_iov_t iov;
+	d_sg_list_t sgl;
 	int rc;
 
 	FUNC_ENTER("path = %s\n", path);
@@ -560,7 +560,7 @@ dfuse_write(const char *path, const char *buf, size_t size, off_t offset,
 	/** set memory location */
 	sgl.sg_nr = 1;
 	sgl.sg_nr_out = 0;
-	daos_iov_set(&iov, (void *)buf, size);
+	d_iov_set(&iov, (void *)buf, size);
 	sgl.sg_iovs = &iov;
 
 	rc = dfs_write(dfs, obj, sgl, offset);

--- a/src/client/dfuse/ops/read.c
+++ b/src/client/dfuse/ops/read.c
@@ -32,8 +32,8 @@ dfuse_cb_read(fuse_req_t req, fuse_ino_t ino, size_t len, off_t position,
 	struct dfuse_inode_entry	*inode;
 	d_list_t			*rlink;
 	int				rc;
-	daos_iov_t			iov = {};
-	daos_sg_list_t			sgl = {};
+	d_iov_t			iov = {};
+	d_sg_list_t			sgl = {};
 	daos_size_t read_size;
 	void *buff;
 
@@ -54,7 +54,7 @@ dfuse_cb_read(fuse_req_t req, fuse_ino_t ino, size_t len, off_t position,
 	inode = container_of(rlink, struct dfuse_inode_entry, ie_htl);
 
 	sgl.sg_nr = 1;
-	daos_iov_set(&iov, (void *)buff, len);
+	d_iov_set(&iov, (void *)buff, len);
 	sgl.sg_iovs = &iov;
 
 	rc = dfs_read(inode->ie_dfs->dffs_dfs, inode->ie_obj, sgl, position,

--- a/src/client/dfuse/ops/write.c
+++ b/src/client/dfuse/ops/write.c
@@ -32,8 +32,8 @@ dfuse_cb_write(fuse_req_t req, fuse_ino_t ino, const char *buff, size_t len,
 	struct dfuse_inode_entry	*ie;
 	d_list_t			*rlink;
 	int				rc;
-	daos_iov_t			iov = {};
-	daos_sg_list_t			sgl = {};
+	d_iov_t			iov = {};
+	d_sg_list_t			sgl = {};
 
 	rlink = d_hash_rec_find(&fs_handle->dfpi_iet, &ino, sizeof(ino));
 	if (!rlink) {
@@ -46,7 +46,7 @@ dfuse_cb_write(fuse_req_t req, fuse_ino_t ino, const char *buff, size_t len,
 	ie = container_of(rlink, struct dfuse_inode_entry, ie_htl);
 
 	sgl.sg_nr = 1;
-	daos_iov_set(&iov, (void *)buff, len);
+	d_iov_set(&iov, (void *)buff, len);
 	sgl.sg_iovs = &iov;
 
 	rc = dfs_write(ie->ie_dfs->dffs_dfs, ie->ie_obj, sgl, position);

--- a/src/common/btree.c
+++ b/src/common/btree.c
@@ -414,7 +414,7 @@ btr_hkey_size(struct btr_context *tcx)
 }
 
 static void
-btr_hkey_gen(struct btr_context *tcx, daos_iov_t *key, void *hkey)
+btr_hkey_gen(struct btr_context *tcx, d_iov_t *key, void *hkey)
 {
 	if (btr_is_direct_key(tcx)) {
 		/* We store umem offset to record when bubbling up */
@@ -460,21 +460,21 @@ btr_hkey_cmp(struct btr_context *tcx, struct btr_record *rec, void *hkey)
 }
 
 static void
-btr_key_encode(struct btr_context *tcx, daos_iov_t *key, daos_anchor_t *anchor)
+btr_key_encode(struct btr_context *tcx, d_iov_t *key, daos_anchor_t *anchor)
 {
 	D_ASSERT(btr_ops(tcx)->to_key_encode);
 	btr_ops(tcx)->to_key_encode(&tcx->tc_tins, key, anchor);
 }
 
 static void
-btr_key_decode(struct btr_context *tcx, daos_iov_t *key, daos_anchor_t *anchor)
+btr_key_decode(struct btr_context *tcx, d_iov_t *key, daos_anchor_t *anchor)
 {
 	D_ASSERT(btr_ops(tcx)->to_key_decode);
 	btr_ops(tcx)->to_key_decode(&tcx->tc_tins, key, anchor);
 }
 
 static int
-btr_key_cmp(struct btr_context *tcx, struct btr_record *rec, daos_iov_t *key)
+btr_key_cmp(struct btr_context *tcx, struct btr_record *rec, d_iov_t *key)
 {
 	if (btr_ops(tcx)->to_key_cmp)
 		return btr_ops(tcx)->to_key_cmp(&tcx->tc_tins, rec, key);
@@ -483,7 +483,7 @@ btr_key_cmp(struct btr_context *tcx, struct btr_record *rec, daos_iov_t *key)
 }
 
 static int
-btr_rec_alloc(struct btr_context *tcx, daos_iov_t *key, daos_iov_t *val,
+btr_rec_alloc(struct btr_context *tcx, d_iov_t *key, d_iov_t *val,
 	       struct btr_record *rec)
 {
 	return btr_ops(tcx)->to_rec_alloc(&tcx->tc_tins, key, val, rec);
@@ -502,14 +502,14 @@ btr_rec_free(struct btr_context *tcx, struct btr_record *rec, void *args)
  */
 static int
 btr_rec_fetch(struct btr_context *tcx, struct btr_record *rec,
-	      daos_iov_t *key, daos_iov_t *val)
+	      d_iov_t *key, d_iov_t *val)
 {
 	return btr_ops(tcx)->to_rec_fetch(&tcx->tc_tins, rec, key, val);
 }
 
 static int
 btr_rec_update(struct btr_context *tcx, struct btr_record *rec,
-	       daos_iov_t *key, daos_iov_t *val)
+	       d_iov_t *key, d_iov_t *val)
 {
 	if (!btr_ops(tcx)->to_rec_update)
 		return -DER_NO_PERM;
@@ -1179,7 +1179,7 @@ btr_node_insert_rec(struct btr_context *tcx, struct btr_trace *trace,
 
 static int
 btr_cmp(struct btr_context *tcx, umem_off_t nd_off,
-	int at, char *hkey, daos_iov_t *key)
+	int at, char *hkey, d_iov_t *key)
 {
 	struct btr_record *rec;
 	int		   cmp;
@@ -1235,7 +1235,7 @@ btr_probe_valid(dbtree_probe_opc_t opc)
  */
 static enum btr_probe_rc
 btr_probe(struct btr_context *tcx, dbtree_probe_opc_t probe_opc,
-	  uint32_t intent, daos_iov_t *key, char hkey[DAOS_HKEY_MAX])
+	  uint32_t intent, d_iov_t *key, char hkey[DAOS_HKEY_MAX])
 {
 	int			 start;
 	int			 end;
@@ -1511,7 +1511,7 @@ again:
 
 static enum btr_probe_rc
 btr_probe_key(struct btr_context *tcx, dbtree_probe_opc_t probe_opc,
-	      uint32_t intent, daos_iov_t *key)
+	      uint32_t intent, d_iov_t *key)
 {
 	char hkey[DAOS_HKEY_MAX];
 
@@ -1658,7 +1658,7 @@ btr_probe_prev(struct btr_context *tcx)
  */
 int
 dbtree_fetch(daos_handle_t toh, dbtree_probe_opc_t opc, uint32_t intent,
-	     daos_iov_t *key, daos_iov_t *key_out, daos_iov_t *val_out)
+	     d_iov_t *key, d_iov_t *key_out, d_iov_t *val_out)
 {
 	struct btr_record  *rec;
 	struct btr_context *tcx;
@@ -1697,14 +1697,14 @@ dbtree_fetch(daos_handle_t toh, dbtree_probe_opc_t opc, uint32_t intent,
  *			-ve	error code
  */
 int
-dbtree_lookup(daos_handle_t toh, daos_iov_t *key, daos_iov_t *val_out)
+dbtree_lookup(daos_handle_t toh, d_iov_t *key, d_iov_t *val_out)
 {
 	return dbtree_fetch(toh, BTR_PROBE_EQ, DAOS_INTENT_DEFAULT, key, NULL,
 			    val_out);
 }
 
 static int
-btr_update(struct btr_context *tcx, daos_iov_t *key, daos_iov_t *val)
+btr_update(struct btr_context *tcx, d_iov_t *key, d_iov_t *val)
 {
 	struct btr_record *rec;
 	int		   rc;
@@ -1738,7 +1738,7 @@ btr_update(struct btr_context *tcx, daos_iov_t *key, daos_iov_t *val)
  * create a new record, insert it into tree leaf node.
  */
 static int
-btr_insert(struct btr_context *tcx, daos_iov_t *key, daos_iov_t *val)
+btr_insert(struct btr_context *tcx, d_iov_t *key, d_iov_t *val)
 {
 	struct btr_record *rec;
 	char		  *rec_str;
@@ -1790,7 +1790,7 @@ btr_insert(struct btr_context *tcx, daos_iov_t *key, daos_iov_t *val)
 
 static int
 btr_upsert(struct btr_context *tcx, dbtree_probe_opc_t probe_opc,
-	   uint32_t intent, daos_iov_t *key, daos_iov_t *val)
+	   uint32_t intent, d_iov_t *key, d_iov_t *val)
 {
 	int	rc;
 
@@ -1864,7 +1864,7 @@ btr_tx_end(struct btr_context *tcx, int rc)
  *			-ve	error code
  */
 int
-dbtree_update(daos_handle_t toh, daos_iov_t *key, daos_iov_t *val)
+dbtree_update(daos_handle_t toh, d_iov_t *key, d_iov_t *val)
 {
 	struct btr_context *tcx;
 	int		    rc;
@@ -1898,7 +1898,7 @@ dbtree_update(daos_handle_t toh, daos_iov_t *key, daos_iov_t *val)
  */
 int
 dbtree_upsert(daos_handle_t toh, dbtree_probe_opc_t opc, uint32_t intent,
-	      daos_iov_t *key, daos_iov_t *val)
+	      d_iov_t *key, d_iov_t *val)
 {
 	struct btr_context *tcx;
 	int		    rc = 0;
@@ -2609,7 +2609,7 @@ btr_tx_delete(struct btr_context *tcx, void *args)
  *				args to handle special cases(if any)
  */
 int
-dbtree_delete(daos_handle_t toh, daos_iov_t *key,
+dbtree_delete(daos_handle_t toh, d_iov_t *key,
 	      void *args)
 {
 	struct btr_context *tcx;
@@ -3156,7 +3156,7 @@ dbtree_iter_finish(daos_handle_t ih)
  */
 int
 dbtree_iter_probe(daos_handle_t ih, dbtree_probe_opc_t opc, uint32_t intent,
-		  daos_iov_t *key, daos_anchor_t *anchor)
+		  d_iov_t *key, daos_anchor_t *anchor)
 {
 	struct btr_iterator *itr;
 	struct btr_context  *tcx;
@@ -3179,7 +3179,7 @@ dbtree_iter_probe(daos_handle_t ih, dbtree_probe_opc_t opc, uint32_t intent,
 		if (key)
 			rc = btr_probe(tcx, opc, intent, key, NULL);
 		else {
-			daos_iov_t direct_key;
+			d_iov_t direct_key;
 
 			btr_key_decode(tcx, &direct_key, anchor);
 			rc = btr_probe(tcx, opc, intent, &direct_key, NULL);
@@ -3332,8 +3332,8 @@ dbtree_iter_prev_with_intent(daos_handle_t ih, uint32_t intent)
  * \param anchor [OUT]	Returned iteration anchor.
  */
 int
-dbtree_iter_fetch(daos_handle_t ih, daos_iov_t *key,
-		  daos_iov_t *val, daos_anchor_t *anchor)
+dbtree_iter_fetch(daos_handle_t ih, d_iov_t *key,
+		  d_iov_t *val, daos_anchor_t *anchor)
 {
 	struct btr_context  *tcx;
 	struct btr_record   *rec;
@@ -3462,11 +3462,11 @@ dbtree_iterate(daos_handle_t toh, uint32_t intent, bool backward,
 	}
 
 	for (;;) {
-		daos_iov_t	key;
-		daos_iov_t	val;
+		d_iov_t	key;
+		d_iov_t	val;
 
-		daos_iov_set(&key, NULL /* buf */, 0 /* size */);
-		daos_iov_set(&val, NULL /* buf */, 0 /* size */);
+		d_iov_set(&key, NULL /* buf */, 0 /* size */);
+		d_iov_set(&val, NULL /* buf */, 0 /* size */);
 
 		rc = dbtree_iter_fetch(ih, &key, &val, NULL /* anchor */);
 		if (rc != 0) {

--- a/src/common/btree_class.c
+++ b/src/common/btree_class.c
@@ -50,11 +50,11 @@ btr_check_tx(struct btr_attr *attr)
 }
 
 static int
-lookup_ptr(daos_handle_t tree, daos_iov_t *key, daos_iov_t *val)
+lookup_ptr(daos_handle_t tree, d_iov_t *key, d_iov_t *val)
 {
 	int rc;
 
-	daos_iov_set(val, NULL /* buf */, 0 /* size */);
+	d_iov_set(val, NULL /* buf */, 0 /* size */);
 
 	rc = dbtree_lookup(tree, key, val);
 	if (rc != 0)
@@ -64,12 +64,12 @@ lookup_ptr(daos_handle_t tree, daos_iov_t *key, daos_iov_t *val)
 }
 
 static int
-create_tree(daos_handle_t tree, daos_iov_t *key, unsigned int class,
+create_tree(daos_handle_t tree, d_iov_t *key, unsigned int class,
 	    uint64_t feats, unsigned int order, daos_handle_t *tree_new)
 {
 	struct btr_root		buf;
 	struct btr_attr		attr;
-	daos_iov_t		val;
+	d_iov_t		val;
 	daos_handle_t		h;
 	int			rc;
 
@@ -81,7 +81,7 @@ create_tree(daos_handle_t tree, daos_iov_t *key, unsigned int class,
 		 btr_check_tx(&attr) == BTR_IN_TX);
 
 	memset(&buf, 0, sizeof(buf));
-	daos_iov_set(&val, &buf, sizeof(buf));
+	d_iov_set(&val, &buf, sizeof(buf));
 
 	rc = dbtree_update(tree, key, &val);
 	if (rc != 0)
@@ -105,11 +105,11 @@ create_tree(daos_handle_t tree, daos_iov_t *key, unsigned int class,
 }
 
 static int
-open_tree(daos_handle_t tree, daos_iov_t *key, struct btr_attr *attr,
+open_tree(daos_handle_t tree, d_iov_t *key, struct btr_attr *attr,
 	  daos_handle_t *tree_child)
 {
 	struct btr_attr		bta;
-	daos_iov_t		val;
+	d_iov_t		val;
 	int			rc;
 
 	rc = dbtree_query(tree, &bta, NULL);
@@ -131,7 +131,7 @@ open_tree(daos_handle_t tree, daos_iov_t *key, struct btr_attr *attr,
 }
 
 static int
-destroy_tree(daos_handle_t tree, daos_iov_t *key)
+destroy_tree(daos_handle_t tree, d_iov_t *key)
 {
 	daos_handle_t		hdl;
 	struct btr_attr		attr;
@@ -197,7 +197,7 @@ struct nv_rec {
 };
 
 static void
-nv_hkey_gen(struct btr_instance *tins, daos_iov_t *key_iov, void *hkey)
+nv_hkey_gen(struct btr_instance *tins, d_iov_t *key_iov, void *hkey)
 {
 	const char	*key = key_iov->iov_buf;
 	size_t		key_size = key_iov->iov_len;
@@ -219,7 +219,7 @@ nv_hkey_size(void)
 }
 
 static int
-nv_key_cmp(struct btr_instance *tins, struct btr_record *rec, daos_iov_t *key)
+nv_key_cmp(struct btr_instance *tins, struct btr_record *rec, d_iov_t *key)
 {
 	struct nv_rec  *r = umem_off2ptr(&tins->ti_umm, rec->rec_off);
 
@@ -229,7 +229,7 @@ nv_key_cmp(struct btr_instance *tins, struct btr_record *rec, daos_iov_t *key)
 }
 
 static int
-nv_rec_alloc(struct btr_instance *tins, daos_iov_t *key, daos_iov_t *val,
+nv_rec_alloc(struct btr_instance *tins, d_iov_t *key, d_iov_t *val,
 	       struct btr_record *rec)
 {
 	struct nv_rec  *r;
@@ -285,7 +285,7 @@ nv_rec_free(struct btr_instance *tins, struct btr_record *rec, void *args)
 
 static int
 nv_rec_fetch(struct btr_instance *tins, struct btr_record *rec,
-	     daos_iov_t *key, daos_iov_t *val)
+	     d_iov_t *key, d_iov_t *val)
 {
 	struct nv_rec  *r = umem_off2ptr(&tins->ti_umm, rec->rec_off);
 
@@ -317,7 +317,7 @@ nv_rec_fetch(struct btr_instance *tins, struct btr_record *rec,
 
 static int
 nv_rec_update(struct btr_instance *tins, struct btr_record *rec,
-	      daos_iov_t *key, daos_iov_t *val)
+	      d_iov_t *key, d_iov_t *val)
 {
 	struct nv_rec  *r = umem_off2ptr(&tins->ti_umm, rec->rec_off);
 	void	       *v;
@@ -378,15 +378,15 @@ int
 dbtree_nv_update(daos_handle_t tree, const void *key, size_t key_size,
 		 const void *value, size_t size)
 {
-	daos_iov_t	key_iov;
-	daos_iov_t	val;
+	d_iov_t	key_iov;
+	d_iov_t	val;
 	int		rc;
 
 	D_DEBUG(DB_TRACE, "updating \"%s\":%p+%zu\n", (char *)key, key,
 		key_size);
 
-	daos_iov_set(&key_iov, (void *)key, key_size);
-	daos_iov_set(&val, (void *)value, size);
+	d_iov_set(&key_iov, (void *)key, key_size);
+	d_iov_set(&val, (void *)value, size);
 
 	rc = dbtree_update(tree, &key_iov, &val);
 	if (rc != 0)
@@ -399,14 +399,14 @@ int
 dbtree_nv_lookup(daos_handle_t tree, const void *key, size_t key_size,
 		 void *value, size_t size)
 {
-	daos_iov_t	key_iov;
-	daos_iov_t	val;
+	d_iov_t	key_iov;
+	d_iov_t	val;
 	int		rc;
 
 	D_DEBUG(DB_TRACE, "looking up \"%s\"\n", (char *)key);
 
-	daos_iov_set(&key_iov, (void *)key, key_size);
-	daos_iov_set(&val, value, size);
+	d_iov_set(&key_iov, (void *)key, key_size);
+	d_iov_set(&val, value, size);
 
 	rc = dbtree_lookup(tree, &key_iov, &val);
 	if (rc != 0) {
@@ -429,13 +429,13 @@ int
 dbtree_nv_lookup_ptr(daos_handle_t tree, const void *key, size_t key_size,
 		     void **value, size_t *size)
 {
-	daos_iov_t	key_iov;
-	daos_iov_t	val;
+	d_iov_t	key_iov;
+	d_iov_t	val;
 	int		rc;
 
 	D_DEBUG(DB_TRACE, "looking up \"%s\" ptr\n", (char *)key);
 
-	daos_iov_set(&key_iov, (void *)key, key_size);
+	d_iov_set(&key_iov, (void *)key, key_size);
 
 	rc = lookup_ptr(tree, &key_iov, &val);
 	if (rc != 0) {
@@ -455,12 +455,12 @@ dbtree_nv_lookup_ptr(daos_handle_t tree, const void *key, size_t key_size,
 int
 dbtree_nv_delete(daos_handle_t tree, const void *key, size_t key_size)
 {
-	daos_iov_t	key_iov;
+	d_iov_t	key_iov;
 	int		rc;
 
 	D_DEBUG(DB_TRACE, "deleting \"%s\"\n", (char *)key);
 
-	daos_iov_set(&key_iov, (void *)key, key_size);
+	d_iov_set(&key_iov, (void *)key, key_size);
 
 	rc = dbtree_delete(tree, &key_iov, NULL);
 	if (rc != 0) {
@@ -485,10 +485,10 @@ dbtree_nv_create_tree(daos_handle_t tree, const void *key, size_t key_size,
 		      unsigned int class, uint64_t feats, unsigned int order,
 		      daos_handle_t *tree_new)
 {
-	daos_iov_t	key_iov;
+	d_iov_t	key_iov;
 	int		rc;
 
-	daos_iov_set(&key_iov, (void *)key, key_size);
+	d_iov_set(&key_iov, (void *)key, key_size);
 
 	rc = create_tree(tree, &key_iov, class, feats, order, tree_new);
 	if (rc != 0)
@@ -501,10 +501,10 @@ int
 dbtree_nv_open_tree(daos_handle_t tree, const void *key, size_t key_size,
 		    daos_handle_t *tree_child)
 {
-	daos_iov_t	key_iov;
+	d_iov_t	key_iov;
 	int		rc;
 
-	daos_iov_set(&key_iov, (void *)key, key_size);
+	d_iov_set(&key_iov, (void *)key, key_size);
 
 	rc = open_tree(tree, &key_iov, NULL, tree_child);
 	if (rc != 0) {
@@ -521,10 +521,10 @@ dbtree_nv_open_tree(daos_handle_t tree, const void *key, size_t key_size,
 int
 dbtree_nv_destroy_tree(daos_handle_t tree, const void *key, size_t key_size)
 {
-	daos_iov_t	key_iov;
+	d_iov_t	key_iov;
 	int		rc;
 
-	daos_iov_set(&key_iov, (void *)key, key_size);
+	d_iov_set(&key_iov, (void *)key, key_size);
 
 	rc = destroy_tree(tree, &key_iov);
 	if (rc != 0) {
@@ -552,7 +552,7 @@ struct uv_rec {
 };
 
 static void
-uv_hkey_gen(struct btr_instance *tins, daos_iov_t *key, void *hkey)
+uv_hkey_gen(struct btr_instance *tins, d_iov_t *key, void *hkey)
 {
 	uuid_copy(*(uuid_t *)hkey, *(uuid_t *)key->iov_buf);
 }
@@ -564,7 +564,7 @@ uv_hkey_size(void)
 }
 
 static int
-uv_rec_alloc(struct btr_instance *tins, daos_iov_t *key, daos_iov_t *val,
+uv_rec_alloc(struct btr_instance *tins, d_iov_t *key, d_iov_t *val,
 	       struct btr_record *rec)
 {
 	struct uv_rec  *r;
@@ -612,7 +612,7 @@ uv_rec_free(struct btr_instance *tins, struct btr_record *rec, void *args)
 
 static int
 uv_rec_fetch(struct btr_instance *tins, struct btr_record *rec,
-	     daos_iov_t *key, daos_iov_t *val)
+	     d_iov_t *key, d_iov_t *val)
 {
 	/* TODO: What sanity checks are required for key and val? */
 
@@ -645,7 +645,7 @@ uv_rec_fetch(struct btr_instance *tins, struct btr_record *rec,
 
 static int
 uv_rec_update(struct btr_instance *tins, struct btr_record *rec,
-	      daos_iov_t *key, daos_iov_t *val)
+	      d_iov_t *key, d_iov_t *val)
 {
 	struct uv_rec  *r = umem_off2ptr(&tins->ti_umm, rec->rec_off);
 	void	       *v;
@@ -713,12 +713,12 @@ int
 dbtree_uv_update(daos_handle_t tree, const uuid_t uuid, const void *value,
 		 size_t size)
 {
-	daos_iov_t	key;
-	daos_iov_t	val;
+	d_iov_t	key;
+	d_iov_t	val;
 	int		rc;
 
-	daos_iov_set(&key, (void *)uuid, sizeof(uuid_t));
-	daos_iov_set(&val, (void *)value, size);
+	d_iov_set(&key, (void *)uuid, sizeof(uuid_t));
+	d_iov_set(&val, (void *)value, size);
 
 	rc = dbtree_update(tree, &key, &val);
 	if (rc != 0)
@@ -731,12 +731,12 @@ int
 dbtree_uv_lookup(daos_handle_t tree, const uuid_t uuid, void *value,
 		 size_t size)
 {
-	daos_iov_t	key;
-	daos_iov_t	val;
+	d_iov_t	key;
+	d_iov_t	val;
 	int		rc;
 
-	daos_iov_set(&key, (void *)uuid, sizeof(uuid_t));
-	daos_iov_set(&val, value, size);
+	d_iov_set(&key, (void *)uuid, sizeof(uuid_t));
+	d_iov_set(&val, value, size);
 
 	rc = dbtree_lookup(tree, &key, &val);
 	if (rc != 0) {
@@ -756,14 +756,14 @@ int
 dbtree_uv_fetch(daos_handle_t tree, dbtree_probe_opc_t opc,
 		const uuid_t uuid_in, uuid_t uuid_out, void *value, size_t size)
 {
-	daos_iov_t	key_in;
-	daos_iov_t	key_out;
-	daos_iov_t	val;
+	d_iov_t	key_in;
+	d_iov_t	key_out;
+	d_iov_t	val;
 	int		rc;
 
-	daos_iov_set(&key_in, (void *)uuid_in, sizeof(uuid_t));
-	daos_iov_set(&key_out, uuid_out, sizeof(uuid_t));
-	daos_iov_set(&val, value, size);
+	d_iov_set(&key_in, (void *)uuid_in, sizeof(uuid_t));
+	d_iov_set(&key_out, uuid_out, sizeof(uuid_t));
+	d_iov_set(&val, value, size);
 
 	rc = dbtree_fetch(tree, opc, DAOS_INTENT_DEFAULT, &key_in, &key_out,
 			  &val);
@@ -779,10 +779,10 @@ dbtree_uv_fetch(daos_handle_t tree, dbtree_probe_opc_t opc,
 int
 dbtree_uv_delete(daos_handle_t tree, const uuid_t uuid)
 {
-	daos_iov_t	key;
+	d_iov_t	key;
 	int		rc;
 
-	daos_iov_set(&key, (void *)uuid, sizeof(uuid_t));
+	d_iov_set(&key, (void *)uuid, sizeof(uuid_t));
 
 	rc = dbtree_delete(tree, &key, NULL);
 	if (rc != 0) {
@@ -808,10 +808,10 @@ dbtree_uv_create_tree(daos_handle_t tree, const uuid_t uuid, unsigned int class,
 		      uint64_t feats, unsigned int order,
 		      daos_handle_t *tree_new)
 {
-	daos_iov_t	key;
+	d_iov_t	key;
 	int		rc;
 
-	daos_iov_set(&key, (void *)uuid, sizeof(uuid_t));
+	d_iov_set(&key, (void *)uuid, sizeof(uuid_t));
 
 	rc = create_tree(tree, &key, class, feats, order, tree_new);
 	if (rc != 0)
@@ -824,10 +824,10 @@ int
 dbtree_uv_open_tree(daos_handle_t tree, const uuid_t uuid,
 		    daos_handle_t *tree_child)
 {
-	daos_iov_t	key;
+	d_iov_t	key;
 	int		rc;
 
-	daos_iov_set(&key, (void *)uuid, sizeof(uuid_t));
+	d_iov_set(&key, (void *)uuid, sizeof(uuid_t));
 
 	rc = open_tree(tree, &key, NULL, tree_child);
 	if (rc != 0) {
@@ -846,10 +846,10 @@ dbtree_uv_open_tree(daos_handle_t tree, const uuid_t uuid,
 int
 dbtree_uv_destroy_tree(daos_handle_t tree, const uuid_t uuid)
 {
-	daos_iov_t	key;
+	d_iov_t	key;
 	int		rc;
 
-	daos_iov_set(&key, (void *)uuid, sizeof(uuid_t));
+	d_iov_set(&key, (void *)uuid, sizeof(uuid_t));
 
 	rc = destroy_tree(tree, &key);
 	if (rc != 0) {
@@ -876,7 +876,7 @@ struct ec_rec {
 };
 
 static int
-ec_rec_alloc(struct btr_instance *tins, daos_iov_t *key, daos_iov_t *val,
+ec_rec_alloc(struct btr_instance *tins, d_iov_t *key, d_iov_t *val,
 	       struct btr_record *rec)
 {
 	struct ec_rec  *r;
@@ -908,7 +908,7 @@ ec_rec_free(struct btr_instance *tins, struct btr_record *rec, void *args)
 
 static int
 ec_rec_fetch(struct btr_instance *tins, struct btr_record *rec,
-	     daos_iov_t *key, daos_iov_t *val)
+	     d_iov_t *key, d_iov_t *val)
 {
 	/* TODO: What sanity checks are required for key and val? */
 
@@ -937,7 +937,7 @@ ec_rec_fetch(struct btr_instance *tins, struct btr_record *rec,
 
 static int
 ec_rec_update(struct btr_instance *tins, struct btr_record *rec,
-	      daos_iov_t *key, daos_iov_t *val)
+	      d_iov_t *key, d_iov_t *val)
 {
 	struct ec_rec  *r = umem_off2ptr(&tins->ti_umm, rec->rec_off);
 
@@ -977,14 +977,14 @@ btr_ops_t dbtree_ec_ops = {
 int
 dbtree_ec_update(daos_handle_t tree, uint64_t epoch, const uint64_t *count)
 {
-	daos_iov_t	key;
-	daos_iov_t	val;
+	d_iov_t	key;
+	d_iov_t	val;
 	int		rc;
 
 	D_DEBUG(DB_TRACE, "updating "DF_U64":"DF_U64"\n", epoch, *count);
 
-	daos_iov_set(&key, &epoch, sizeof(epoch));
-	daos_iov_set(&val, (void *)count, sizeof(*count));
+	d_iov_set(&key, &epoch, sizeof(epoch));
+	d_iov_set(&val, (void *)count, sizeof(*count));
 
 	rc = dbtree_update(tree, &key, &val);
 	if (rc != 0)
@@ -996,12 +996,12 @@ dbtree_ec_update(daos_handle_t tree, uint64_t epoch, const uint64_t *count)
 int
 dbtree_ec_lookup(daos_handle_t tree, uint64_t epoch, uint64_t *count)
 {
-	daos_iov_t	key;
-	daos_iov_t	val;
+	d_iov_t	key;
+	d_iov_t	val;
 	int		rc;
 
-	daos_iov_set(&key, &epoch, sizeof(epoch));
-	daos_iov_set(&val, (void *)count, sizeof(*count));
+	d_iov_set(&key, &epoch, sizeof(epoch));
+	d_iov_set(&val, (void *)count, sizeof(*count));
 
 	rc = dbtree_lookup(tree, &key, &val);
 	if (rc == -DER_NONEXIST)
@@ -1016,14 +1016,14 @@ int
 dbtree_ec_fetch(daos_handle_t tree, dbtree_probe_opc_t opc,
 		const uint64_t *epoch_in, uint64_t *epoch_out, uint64_t *count)
 {
-	daos_iov_t	key_in;
-	daos_iov_t	key_out;
-	daos_iov_t	val;
+	d_iov_t	key_in;
+	d_iov_t	key_out;
+	d_iov_t	val;
 	int		rc;
 
-	daos_iov_set(&key_in, (void *)epoch_in, sizeof(*epoch_in));
-	daos_iov_set(&key_out, epoch_out, sizeof(*epoch_out));
-	daos_iov_set(&val, (void *)count, sizeof(*count));
+	d_iov_set(&key_in, (void *)epoch_in, sizeof(*epoch_in));
+	d_iov_set(&key_out, epoch_out, sizeof(*epoch_out));
+	d_iov_set(&val, (void *)count, sizeof(*count));
 
 	rc = dbtree_fetch(tree, opc, DAOS_INTENT_DEFAULT, &key_in, &key_out,
 			  &val);
@@ -1039,12 +1039,12 @@ dbtree_ec_fetch(daos_handle_t tree, dbtree_probe_opc_t opc,
 int
 dbtree_ec_delete(daos_handle_t tree, uint64_t epoch)
 {
-	daos_iov_t	key;
+	d_iov_t	key;
 	int		rc;
 
 	D_DEBUG(DB_TRACE, "deleting "DF_U64"\n", epoch);
 
-	daos_iov_set(&key, &epoch, sizeof(epoch));
+	d_iov_set(&key, &epoch, sizeof(epoch));
 
 	rc = dbtree_delete(tree, &key, NULL);
 	if (rc == -DER_NONEXIST)
@@ -1068,7 +1068,7 @@ struct kv_rec {
 };
 
 static void
-kv_hkey_gen(struct btr_instance *tins, daos_iov_t *key, void *hkey)
+kv_hkey_gen(struct btr_instance *tins, d_iov_t *key, void *hkey)
 {
 	uint64_t *hash = hkey;
 
@@ -1085,7 +1085,7 @@ kv_hkey_size(void)
 }
 
 static int
-kv_key_cmp(struct btr_instance *tins, struct btr_record *rec, daos_iov_t *key)
+kv_key_cmp(struct btr_instance *tins, struct btr_record *rec, d_iov_t *key)
 {
 	struct kv_rec  *r = umem_off2ptr(&tins->ti_umm, rec->rec_off);
 	int		rc;
@@ -1097,7 +1097,7 @@ kv_key_cmp(struct btr_instance *tins, struct btr_record *rec, daos_iov_t *key)
 }
 
 static int
-kv_rec_alloc(struct btr_instance *tins, daos_iov_t *key, daos_iov_t *val,
+kv_rec_alloc(struct btr_instance *tins, d_iov_t *key, d_iov_t *val,
 	     struct btr_record *rec)
 {
 	struct kv_rec  *r;
@@ -1145,8 +1145,8 @@ kv_rec_free(struct btr_instance *tins, struct btr_record *rec, void *args)
 }
 
 static int
-kv_rec_fetch(struct btr_instance *tins, struct btr_record *rec, daos_iov_t *key,
-	     daos_iov_t *val)
+kv_rec_fetch(struct btr_instance *tins, struct btr_record *rec, d_iov_t *key,
+	     d_iov_t *val)
 {
 	struct kv_rec *r = umem_off2ptr(&tins->ti_umm, rec->rec_off);
 
@@ -1171,7 +1171,7 @@ kv_rec_fetch(struct btr_instance *tins, struct btr_record *rec, daos_iov_t *key,
 
 static int
 kv_rec_update(struct btr_instance *tins, struct btr_record *rec,
-	      daos_iov_t *key, daos_iov_t *val)
+	      d_iov_t *key, d_iov_t *val)
 {
 	struct kv_rec  *r = umem_off2ptr(&tins->ti_umm, rec->rec_off);
 	void	       *v;
@@ -1235,7 +1235,7 @@ struct iv_rec {
 };
 
 static int
-iv_rec_alloc(struct btr_instance *tins, daos_iov_t *key, daos_iov_t *val,
+iv_rec_alloc(struct btr_instance *tins, d_iov_t *key, d_iov_t *val,
 	     struct btr_record *rec)
 {
 	struct iv_rec  *r;
@@ -1280,8 +1280,8 @@ iv_rec_free(struct btr_instance *tins, struct btr_record *rec, void *args)
 }
 
 static int
-iv_rec_fetch(struct btr_instance *tins, struct btr_record *rec, daos_iov_t *key,
-	     daos_iov_t *val)
+iv_rec_fetch(struct btr_instance *tins, struct btr_record *rec, d_iov_t *key,
+	     d_iov_t *val)
 {
 	if (key != NULL) {
 		if (key->iov_buf == NULL)
@@ -1305,7 +1305,7 @@ iv_rec_fetch(struct btr_instance *tins, struct btr_record *rec, daos_iov_t *key,
 
 static int
 iv_rec_update(struct btr_instance *tins, struct btr_record *rec,
-	      daos_iov_t *key, daos_iov_t *val)
+	      d_iov_t *key, d_iov_t *val)
 {
 	struct iv_rec  *r = umem_off2ptr(&tins->ti_umm, rec->rec_off);
 	void	       *v;
@@ -1360,7 +1360,7 @@ struct recx_rec {
 };
 
 static int
-recx_key_cmp(struct btr_instance *tins, struct btr_record *rec, daos_iov_t *key)
+recx_key_cmp(struct btr_instance *tins, struct btr_record *rec, d_iov_t *key)
 {
 	struct recx_rec	*r = umem_off2ptr(&tins->ti_umm, rec->rec_off);
 	daos_recx_t	*key_recx = (daos_recx_t *)(key->iov_buf);
@@ -1380,7 +1380,7 @@ recx_key_cmp(struct btr_instance *tins, struct btr_record *rec, daos_iov_t *key)
 }
 
 static int
-recx_rec_alloc(struct btr_instance *tins, daos_iov_t *key, daos_iov_t *val,
+recx_rec_alloc(struct btr_instance *tins, d_iov_t *key, d_iov_t *val,
 	     struct btr_record *rec)
 {
 	struct recx_rec	*r;
@@ -1410,7 +1410,7 @@ recx_rec_free(struct btr_instance *tins, struct btr_record *rec, void *args)
 
 static int
 recx_rec_update(struct btr_instance *tins, struct btr_record *rec,
-		daos_iov_t *key, daos_iov_t *val)
+		d_iov_t *key, d_iov_t *val)
 {
 	D_ASSERTF(0, "recx_rec_update should never be called.\n");
 	return 0;
@@ -1418,21 +1418,21 @@ recx_rec_update(struct btr_instance *tins, struct btr_record *rec,
 
 static int
 recx_rec_fetch(struct btr_instance *tins, struct btr_record *rec,
-	       daos_iov_t *key, daos_iov_t *val)
+	       d_iov_t *key, d_iov_t *val)
 {
 	D_ASSERTF(0, "recx_rec_fetch should never be called.\n");
 	return 0;
 }
 
 static void
-recx_key_encode(struct btr_instance *tins, daos_iov_t *key,
+recx_key_encode(struct btr_instance *tins, d_iov_t *key,
 	daos_anchor_t *anchor)
 {
 	D_ASSERTF(0, "recx_key_encode should never be called.\n");
 }
 
 static void
-recx_key_decode(struct btr_instance *tins, daos_iov_t *key,
+recx_key_decode(struct btr_instance *tins, d_iov_t *key,
 	daos_anchor_t *anchor)
 {
 	D_ASSERTF(0, "recx_key_decode should never be called.\n");

--- a/src/common/checksum.c
+++ b/src/common/checksum.c
@@ -212,7 +212,7 @@ daos_csum_update(daos_csum_t *csum, const void *buf,
 }
 
 int
-daos_csum_compute(daos_csum_t *csum, daos_sg_list_t *sgl)
+daos_csum_compute(daos_csum_t *csum, d_sg_list_t *sgl)
 {
 	int	i;
 	int	rc = 0;

--- a/src/common/misc.c
+++ b/src/common/misc.c
@@ -202,7 +202,7 @@ daos_sgl_buf_size(d_sg_list_t *sgl)
 }
 
 daos_size_t
-daos_sgls_buf_size(daos_sg_list_t *sgls, int nr)
+daos_sgls_buf_size(d_sg_list_t *sgls, int nr)
 {
 	daos_size_t size = 0;
 	int	    i;
@@ -221,7 +221,7 @@ daos_sgls_buf_size(daos_sg_list_t *sgls, int nr)
  * value as buffer size as well.
  */
 daos_size_t
-daos_sgls_packed_size(daos_sg_list_t *sgls, int nr, daos_size_t *buf_size)
+daos_sgls_packed_size(d_sg_list_t *sgls, int nr, daos_size_t *buf_size)
 {
 	daos_size_t size = 0;
 	int i;
@@ -351,7 +351,7 @@ daos_str_trimwhite(char *str)
 }
 
 int
-daos_iov_copy(daos_iov_t *dst, daos_iov_t *src)
+daos_iov_copy(d_iov_t *dst, d_iov_t *src)
 {
 	D_ALLOC(dst->iov_buf, src->iov_buf_len);
 	if (dst->iov_buf == NULL)
@@ -364,7 +364,7 @@ daos_iov_copy(daos_iov_t *dst, daos_iov_t *src)
 }
 
 void
-daos_iov_free(daos_iov_t *iov)
+daos_iov_free(d_iov_t *iov)
 {
 	if (iov->iov_buf == NULL)
 		return;

--- a/src/common/rsvc.c
+++ b/src/common/rsvc.c
@@ -68,7 +68,7 @@ rsvc_client_init(struct rsvc_client *client, const d_rank_list_t *ranks)
 void
 rsvc_client_fini(struct rsvc_client *client)
 {
-	daos_rank_list_free(client->sc_ranks);
+	d_rank_list_free(client->sc_ranks);
 }
 
 /**

--- a/src/common/tests/btree.c
+++ b/src/common/tests/btree.c
@@ -92,7 +92,7 @@ ik_hkey_size(void)
 }
 
 static void
-ik_hkey_gen(struct btr_instance *tins, daos_iov_t *key_iov, void *hkey)
+ik_hkey_gen(struct btr_instance *tins, d_iov_t *key_iov, void *hkey)
 {
 	uint64_t	*ikey;
 
@@ -102,8 +102,8 @@ ik_hkey_gen(struct btr_instance *tins, daos_iov_t *key_iov, void *hkey)
 }
 
 static int
-ik_rec_alloc(struct btr_instance *tins, daos_iov_t *key_iov,
-		  daos_iov_t *val_iov, struct btr_record *rec)
+ik_rec_alloc(struct btr_instance *tins, d_iov_t *key_iov,
+		  d_iov_t *val_iov, struct btr_record *rec)
 {
 	umem_off_t		 irec_off;
 	struct ik_rec		*irec;
@@ -149,7 +149,7 @@ ik_rec_free(struct btr_instance *tins, struct btr_record *rec, void *args)
 
 static int
 ik_rec_fetch(struct btr_instance *tins, struct btr_record *rec,
-		 daos_iov_t *key_iov, daos_iov_t *val_iov)
+		 d_iov_t *key_iov, d_iov_t *val_iov)
 {
 	struct ik_rec	*irec;
 	char		*val;
@@ -213,7 +213,7 @@ ik_rec_string(struct btr_instance *tins, struct btr_record *rec,
 
 static int
 ik_rec_update(struct btr_instance *tins, struct btr_record *rec,
-		   daos_iov_t *key, daos_iov_t *val_iov)
+		   d_iov_t *key, d_iov_t *val_iov)
 {
 	struct umem_instance	*umm = &tins->ti_umm;
 	struct ik_rec		*irec;
@@ -375,7 +375,7 @@ ik_btr_close_destroy(void **state)
 }
 
 static int
-btr_rec_verify_delete(umem_off_t *rec, daos_iov_t *key)
+btr_rec_verify_delete(umem_off_t *rec, d_iov_t *key)
 {
 	struct umem_instance	*umm;
 	struct ik_rec		*irec;
@@ -437,8 +437,8 @@ ik_btr_kv_operate(void **state)
 
 	while (str != NULL && !isspace(*str) && *str != '\0') {
 		char	   *val = NULL;
-		daos_iov_t	key_iov;
-		daos_iov_t	val_iov;
+		d_iov_t	key_iov;
+		d_iov_t	val_iov;
 		uint64_t	key;
 
 		key = strtoul(str, NULL, 0);
@@ -460,12 +460,12 @@ ik_btr_kv_operate(void **state)
 			str++;
 		}
 
-		daos_iov_set(&key_iov, &key, sizeof(key));
+		d_iov_set(&key_iov, &key, sizeof(key));
 		switch (opc) {
 		default:
 			fail_msg("Invalid opcode\n");
 		case BTR_OPC_UPDATE:
-			daos_iov_set(&val_iov, val, strlen(val) + 1);
+			d_iov_set(&val_iov, val, strlen(val) + 1);
 			rc = dbtree_update(ik_toh, &key_iov, &val_iov);
 			if (rc != 0) {
 				sprintf(outbuf,
@@ -511,7 +511,7 @@ ik_btr_kv_operate(void **state)
 		case BTR_OPC_LOOKUP:
 			D_DEBUG(DB_TEST, "Looking for "DF_U64"\n", key);
 
-			daos_iov_set(&val_iov, NULL, 0); /* get address */
+			d_iov_set(&val_iov, NULL, 0); /* get address */
 			rc = dbtree_lookup(ik_toh, &key_iov, &val_iov);
 			if (rc != 0) {
 				sprintf(outbuf,
@@ -591,8 +591,8 @@ ik_btr_iterate(void **state)
 		del = 0;
 
 	for (i = d = 0;; i++) {
-		daos_iov_t	key_iov;
-		daos_iov_t	val_iov;
+		d_iov_t	key_iov;
+		d_iov_t	val_iov;
 		uint64_t	key;
 
 		if (i == 0 || (del != 0 && d <= del)) {
@@ -614,8 +614,8 @@ ik_btr_iterate(void **state)
 			}
 		}
 
-		daos_iov_set(&key_iov, NULL, 0);
-		daos_iov_set(&val_iov, NULL, 0);
+		d_iov_set(&key_iov, NULL, 0);
+		d_iov_set(&val_iov, NULL, 0);
 		rc = dbtree_iter_fetch(ih, &key_iov, &val_iov, NULL);
 		if (rc != 0) {
 			err = "fetch failure\n";

--- a/src/common/tests/btree_direct.c
+++ b/src/common/tests/btree_direct.c
@@ -89,7 +89,7 @@ static daos_handle_t		 sk_toh;
 #define min(x, y) ((x) < (y) ? (x) : (y))
 
 static void sk_key_encode(struct btr_instance *tins,
-			  daos_iov_t *key, daos_anchor_t *anchor)
+			  d_iov_t *key, daos_anchor_t *anchor)
 {
 	size_t copy_size = key->iov_len;
 
@@ -100,7 +100,7 @@ static void sk_key_encode(struct btr_instance *tins,
 }
 
 static void sk_key_decode(struct btr_instance *tins,
-			  daos_iov_t *key, daos_anchor_t *anchor)
+			  d_iov_t *key, daos_anchor_t *anchor)
 {
 	key->iov_buf = &anchor->da_buf[0];
 	key->iov_buf_len = strlen((char *)anchor->da_buf) + 1;
@@ -109,7 +109,7 @@ static void sk_key_decode(struct btr_instance *tins,
 
 static int
 sk_key_cmp(struct btr_instance *tins, struct btr_record *rec,
-	   daos_iov_t *key_iov)
+	   d_iov_t *key_iov)
 {
 	struct sk_rec	*srec;
 	char		*s1;
@@ -135,8 +135,8 @@ sk_key_cmp(struct btr_instance *tins, struct btr_record *rec,
 }
 
 static int
-sk_rec_alloc(struct btr_instance *tins, daos_iov_t *key_iov,
-	      daos_iov_t *val_iov, struct btr_record *rec)
+sk_rec_alloc(struct btr_instance *tins, d_iov_t *key_iov,
+	      d_iov_t *val_iov, struct btr_record *rec)
 {
 	struct sk_rec		*srec;
 	char			*vbuf;
@@ -184,7 +184,7 @@ sk_rec_free(struct btr_instance *tins, struct btr_record *rec, void *args)
 
 static int
 sk_rec_fetch(struct btr_instance *tins, struct btr_record *rec,
-	     daos_iov_t *key_iov, daos_iov_t *val_iov)
+	     d_iov_t *key_iov, d_iov_t *val_iov)
 {
 	struct sk_rec	*srec;
 	char		*val;
@@ -245,7 +245,7 @@ sk_rec_string(struct btr_instance *tins, struct btr_record *rec,
 
 static int
 sk_rec_update(struct btr_instance *tins, struct btr_record *rec,
-	       daos_iov_t *key, daos_iov_t *val_iov)
+	       d_iov_t *key, d_iov_t *val_iov)
 {
 	struct umem_instance	*umm = &tins->ti_umm;
 	struct sk_rec		*srec;
@@ -400,7 +400,7 @@ sk_btr_close_destroy(void **state)
 }
 
 static int
-btr_rec_verify_delete(umem_off_t *rec, daos_iov_t *key)
+btr_rec_verify_delete(umem_off_t *rec, d_iov_t *key)
 {
 	struct umem_instance	*umm;
 	struct sk_rec		*srec;
@@ -461,8 +461,8 @@ sk_btr_kv_operate(void **state)
 	while (str != NULL && !isspace(*str) && *str != '\0') {
 		char	   *val = NULL;
 		char	   *key = str;
-		daos_iov_t  key_iov;
-		daos_iov_t  val_iov;
+		d_iov_t  key_iov;
+		d_iov_t  val_iov;
 
 		if (opc == BTR_OPC_UPDATE) {
 			val = strchr(str, SK_SEP_VAL);
@@ -482,12 +482,12 @@ sk_btr_kv_operate(void **state)
 			str++;
 		}
 
-		daos_iov_set(&key_iov, key, strlen(key) + 1);
+		d_iov_set(&key_iov, key, strlen(key) + 1);
 		switch (opc) {
 		default:
 			fail_msg("Invalid opcode\n");
 		case BTR_OPC_UPDATE:
-			daos_iov_set(&val_iov, val, strlen(val) + 1);
+			d_iov_set(&val_iov, val, strlen(val) + 1);
 			rc = dbtree_update(sk_toh, &key_iov, &val_iov);
 			if (rc != 0) {
 				sprintf(outbuf,
@@ -531,7 +531,7 @@ sk_btr_kv_operate(void **state)
 		case BTR_OPC_LOOKUP:
 			D_DEBUG(DB_TEST, "Looking for %s\n", key);
 
-			daos_iov_set(&val_iov, NULL, 0); /* get address */
+			d_iov_set(&val_iov, NULL, 0); /* get address */
 			rc = dbtree_lookup(sk_toh, &key_iov, &val_iov);
 			if (rc != 0) {
 				sprintf(outbuf, "Failed to lookup %s\n", key);
@@ -628,8 +628,8 @@ sk_btr_iterate(void **state)
 	anchor.da_type = DAOS_ANCHOR_TYPE_KEY;
 	for (i = d = 0;; i++) {
 		char		*key;
-		daos_iov_t	 key_iov;
-		daos_iov_t	 val_iov;
+		d_iov_t	 key_iov;
+		d_iov_t	 val_iov;
 
 		if (i == 0 || (del != 0 && d <= del)) {
 			rc = dbtree_iter_probe(ih, opc, DAOS_INTENT_DEFAULT,
@@ -650,8 +650,8 @@ sk_btr_iterate(void **state)
 			}
 		}
 
-		daos_iov_set(&key_iov, NULL, 0);
-		daos_iov_set(&val_iov, NULL, 0);
+		d_iov_set(&key_iov, NULL, 0);
+		d_iov_set(&val_iov, NULL, 0);
 		rc = dbtree_iter_fetch(ih, &key_iov, &val_iov, &anchor);
 
 		if (rc != 0) {
@@ -698,8 +698,8 @@ pass:
 }
 
 struct kv_node {
-	daos_iov_t key;
-	daos_iov_t val;
+	d_iov_t key;
+	d_iov_t val;
 };
 
 
@@ -725,8 +725,8 @@ sk_btr_mix_keys(struct kv_node *kv, unsigned int key_nr)
 static int
 key_cmp(const void *k1, const void *k2)
 {
-	const daos_iov_t	*key1 = k1;
-	const daos_iov_t	*key2 = k2;
+	const d_iov_t	*key1 = k1;
+	const d_iov_t	*key2 = k2;
 	const char		*s1 = key1->iov_buf;
 	const char		*s2 = key2->iov_buf;
 	uint64_t		 len;
@@ -814,11 +814,11 @@ sk_btr_check_order(struct kv_node *kv, unsigned int key_nr)
 	/* check the order */
 	i = 0;
 	for (;;) {
-		daos_iov_t	key_iov;
-		daos_iov_t	val_iov;
+		d_iov_t	key_iov;
+		d_iov_t	val_iov;
 
-		daos_iov_set(&key_iov, NULL, 0);
-		daos_iov_set(&val_iov, NULL, 0);
+		d_iov_set(&key_iov, NULL, 0);
+		d_iov_set(&val_iov, NULL, 0);
 		rc = dbtree_iter_fetch(ih, &key_iov, &val_iov, NULL);
 		if (rc != 0) {
 			err = "fetch";

--- a/src/common/tests/checksum.c
+++ b/src/common/tests/checksum.c
@@ -31,8 +31,8 @@ int test_checksum_simple(char *cs_name, daos_csum_t *csum,
 			 daos_csum_buf_t *csum_buf)
 {
 	int		rc = 0;
-	daos_iov_t	test_iov;
-	daos_sg_list_t	sgl;
+	d_iov_t	test_iov;
+	d_sg_list_t	sgl;
 	char		test_buf[20];
 
 	rc = daos_csum_init(cs_name, csum);
@@ -45,7 +45,7 @@ int test_checksum_simple(char *cs_name, daos_csum_t *csum,
 
 	sgl.sg_nr = 1;
 	sgl.sg_nr_out = 1;
-	daos_iov_set(&test_iov, test_buf, strlen(cs_name));
+	d_iov_set(&test_iov, test_buf, strlen(cs_name));
 	sgl.sg_iovs = &test_iov;
 
 	rc = daos_csum_compute(csum, &sgl);

--- a/src/container/cli.c
+++ b/src/container/cli.c
@@ -1148,7 +1148,7 @@ swap_co_glob(struct dc_cont_glob *cont_glob)
 }
 
 static int
-dc_cont_l2g(daos_handle_t coh, daos_iov_t *glob)
+dc_cont_l2g(daos_handle_t coh, d_iov_t *glob)
 {
 	struct dc_pool		*pool;
 	struct dc_cont		*cont;
@@ -1198,7 +1198,7 @@ out:
 }
 
 int
-dc_cont_local2global(daos_handle_t coh, daos_iov_t *glob)
+dc_cont_local2global(daos_handle_t coh, d_iov_t *glob)
 {
 	int	rc = 0;
 
@@ -1282,7 +1282,7 @@ out:
 }
 
 int
-dc_cont_global2local(daos_handle_t poh, daos_iov_t glob, daos_handle_t *coh)
+dc_cont_global2local(daos_handle_t poh, d_iov_t glob, daos_handle_t *coh)
 {
 	struct dc_cont_glob	*cont_glob;
 	int			 rc = 0;
@@ -1473,17 +1473,17 @@ dc_cont_list_attr(tse_task_t *task)
 
 	in = crt_req_get(cb_args.cra_rpc);
 	if (*args->size > 0) {
-		daos_iov_t iov = {
+		d_iov_t iov = {
 			.iov_buf     = args->buf,
 			.iov_buf_len = *args->size,
 			.iov_len     = 0
 		};
-		daos_sg_list_t sgl = {
+		d_sg_list_t sgl = {
 			.sg_nr_out = 0,
 			.sg_nr	   = 1,
 			.sg_iovs   = &iov
 		};
-		rc = crt_bulk_create(daos_task2ctx(task), daos2crt_sg(&sgl),
+		rc = crt_bulk_create(daos_task2ctx(task), &sgl,
 				     CRT_BULK_RW, &in->cali_bulk);
 		if (rc != 0) {
 			cont_req_cleanup(CLEANUP_RPC, &cb_args);
@@ -1521,7 +1521,7 @@ attr_bulk_create(int n, char *names[], void *values[], size_t sizes[],
 	int		rc;
 	int		i;
 	int		j;
-	daos_sg_list_t	sgl;
+	d_sg_list_t	sgl;
 
 	/* Buffers = 'n' names + non-null values + 1 sizes */
 	sgl.sg_nr_out	= 0;
@@ -1536,20 +1536,20 @@ attr_bulk_create(int n, char *names[], void *values[], size_t sizes[],
 
 	/* names */
 	for (j = 0, i = 0; j < n; ++j)
-		daos_iov_set(&sgl.sg_iovs[i++], (void *)(names[j]),
+		d_iov_set(&sgl.sg_iovs[i++], (void *)(names[j]),
 			     strlen(names[j]) + 1 /* trailing '\0' */);
 
 	/* TODO: Add packing/unpacking of non-byte-arrays to rpc.[hc] ? */
 	/* sizes */
-	daos_iov_set(&sgl.sg_iovs[i++], (void *)sizes, n * sizeof(*sizes));
+	d_iov_set(&sgl.sg_iovs[i++], (void *)sizes, n * sizeof(*sizes));
 
 	/* values */
 	for (j = 0; j < n; ++j)
 		if (sizes[j] > 0)
-			daos_iov_set(&sgl.sg_iovs[i++],
+			d_iov_set(&sgl.sg_iovs[i++],
 				     values[j], sizes[j]);
 
-	rc = crt_bulk_create(crt_ctx, daos2crt_sg(&sgl), perm, bulk);
+	rc = crt_bulk_create(crt_ctx, &sgl, perm, bulk);
 	D_FREE(sgl.sg_iovs);
 out:
 	return rc;
@@ -1897,17 +1897,17 @@ dc_cont_list_snap(tse_task_t *task)
 
 	in = crt_req_get(cb_args.cra_rpc);
 	if (*args->nr > 0) {
-		daos_iov_t iov = {
+		d_iov_t iov = {
 			.iov_buf     = args->epochs,
 			.iov_buf_len = *args->nr * sizeof(*args->epochs),
 			.iov_len     = 0
 		};
-		daos_sg_list_t sgl = {
+		d_sg_list_t sgl = {
 			.sg_nr_out = 0,
 			.sg_nr	   = 1,
 			.sg_iovs   = &iov
 		};
-		rc = crt_bulk_create(daos_task2ctx(task), daos2crt_sg(&sgl),
+		rc = crt_bulk_create(daos_task2ctx(task), &sgl,
 				     CRT_BULK_RW, &in->sli_bulk);
 		if (rc != 0) {
 			cont_req_cleanup(CLEANUP_RPC, &cb_args);

--- a/src/container/container_iv.c
+++ b/src/container/container_iv.c
@@ -74,7 +74,7 @@ cont_iv_value_alloc_internal(d_sg_list_t *sgl)
 	if (entry == NULL)
 		D_GOTO(out, rc = -DER_NOMEM);
 
-	daos_iov_set(&sgl->sg_iovs[0], entry, entry_size);
+	d_iov_set(&sgl->sg_iovs[0], entry, entry_size);
 out:
 	if (rc)
 		daos_sgl_fini(sgl, true);
@@ -131,8 +131,8 @@ cont_iv_ent_put(struct ds_iv_entry *entry, void **priv)
 }
 
 static int
-delete_iter_cb(daos_handle_t ih, daos_iov_t *key,
-	       daos_iov_t *val, void *arg)
+delete_iter_cb(daos_handle_t ih, d_iov_t *key,
+	       d_iov_t *val, void *arg)
 {
 	int rc;
 
@@ -205,8 +205,8 @@ cont_iv_ent_fetch(struct ds_iv_entry *entry, struct ds_iv_key *key,
 	struct cont_iv_entry	*src_iv;
 	daos_handle_t		root_hdl;
 	struct cont_iv_key	*civ_key = key2priv(key);
-	daos_iov_t		key_iov;
-	daos_iov_t		val_iov;
+	d_iov_t		key_iov;
+	d_iov_t		val_iov;
 	struct cont_iv_entry	*iv_entry = NULL;
 	daos_epoch_t		*snaps = NULL;
 	int			snap_cnt = MAX_SNAP_CNT;
@@ -215,8 +215,8 @@ cont_iv_ent_fetch(struct ds_iv_entry *entry, struct ds_iv_key *key,
 	D_ASSERT(dss_get_module_info()->dmi_xs_id == 0);
 	memcpy(&root_hdl, entry->iv_value.sg_iovs[0].iov_buf, sizeof(root_hdl));
 
-	daos_iov_set(&key_iov, civ_key->cont_uuid, sizeof(uuid_t));
-	daos_iov_set(&val_iov, NULL, 0);
+	d_iov_set(&key_iov, civ_key->cont_uuid, sizeof(uuid_t));
+	d_iov_set(&val_iov, NULL, 0);
 	rc = dbtree_lookup(root_hdl, &key_iov, &val_iov);
 	if (rc < 0) {
 		if (rc == -DER_NONEXIST && is_master(entry)) {
@@ -234,7 +234,7 @@ cont_iv_ent_fetch(struct ds_iv_entry *entry, struct ds_iv_key *key,
 			iv_entry->snap_size = snap_cnt;
 			memcpy(iv_entry->snaps, snaps,
 			       snap_cnt * sizeof(daos_epoch_t));
-			daos_iov_set(&val_iov, iv_entry,
+			d_iov_set(&val_iov, iv_entry,
 				     cont_iv_ent_size(iv_entry->snap_size));
 			rc = dbtree_update(root_hdl, &key_iov, &val_iov);
 			if (rc)
@@ -265,15 +265,15 @@ cont_iv_ent_update(struct ds_iv_entry *entry, struct ds_iv_key *key,
 {
 	daos_handle_t		root_hdl;
 	struct cont_iv_key	*civ_key = key2priv(key);
-	daos_iov_t		key_iov;
-	daos_iov_t		val_iov;
+	d_iov_t		key_iov;
+	d_iov_t		val_iov;
 	int			rc;
 
 	D_ASSERT(dss_get_module_info()->dmi_xs_id == 0);
 	memcpy(&root_hdl, entry->iv_value.sg_iovs[0].iov_buf, sizeof(root_hdl));
 
-	daos_iov_set(&key_iov, civ_key->cont_uuid, sizeof(uuid_t));
-	daos_iov_set(&val_iov, src->sg_iovs[0].iov_buf,
+	d_iov_set(&key_iov, civ_key->cont_uuid, sizeof(uuid_t));
+	d_iov_set(&val_iov, src->sg_iovs[0].iov_buf,
 		     src->sg_iovs[0].iov_len);
 	rc = dbtree_update(root_hdl, &key_iov, &val_iov);
 	if (rc < 0)
@@ -311,7 +311,7 @@ int
 cont_iv_fetch(void *ns, struct cont_iv_entry *cont_iv)
 {
 	d_sg_list_t		sgl;
-	daos_iov_t		iov;
+	d_iov_t		iov;
 	uint32_t		cont_iv_len;
 	struct ds_iv_key	key = { 0 };
 	struct cont_iv_key	*civ_key;
@@ -343,7 +343,7 @@ cont_iv_update(void *ns, struct cont_iv_entry *cont_iv,
 	       unsigned int shortcut, unsigned int sync_mode)
 {
 	d_sg_list_t		sgl;
-	daos_iov_t		iov;
+	d_iov_t		iov;
 	uint32_t		cont_iv_len;
 	struct ds_iv_key	key;
 	struct cont_iv_key	*civ_key;

--- a/src/container/srv_container.c
+++ b/src/container/srv_container.c
@@ -280,7 +280,7 @@ static int
 cont_prop_write(struct rdb_tx *tx, const rdb_path_t *kvs, daos_prop_t *prop)
 {
 	struct daos_prop_entry	*entry;
-	daos_iov_t		 value;
+	d_iov_t		 value;
 	int			 i;
 	int			 rc = 0;
 
@@ -291,7 +291,7 @@ cont_prop_write(struct rdb_tx *tx, const rdb_path_t *kvs, daos_prop_t *prop)
 		entry = &prop->dpp_entries[i];
 		switch (entry->dpe_type) {
 		case DAOS_PROP_CO_LABEL:
-			daos_iov_set(&value, entry->dpe_str,
+			d_iov_set(&value, entry->dpe_str,
 				     strlen(entry->dpe_str));
 			rc = rdb_tx_update(tx, kvs, &ds_cont_prop_label,
 					   &value);
@@ -299,7 +299,7 @@ cont_prop_write(struct rdb_tx *tx, const rdb_path_t *kvs, daos_prop_t *prop)
 				return rc;
 			break;
 		case DAOS_PROP_CO_LAYOUT_TYPE:
-			daos_iov_set(&value, &entry->dpe_val,
+			d_iov_set(&value, &entry->dpe_val,
 				     sizeof(entry->dpe_val));
 			rc = rdb_tx_update(tx, kvs, &ds_cont_prop_layout_type,
 					   &value);
@@ -307,7 +307,7 @@ cont_prop_write(struct rdb_tx *tx, const rdb_path_t *kvs, daos_prop_t *prop)
 				return rc;
 			break;
 		case DAOS_PROP_CO_LAYOUT_VER:
-			daos_iov_set(&value, &entry->dpe_val,
+			d_iov_set(&value, &entry->dpe_val,
 				     sizeof(entry->dpe_val));
 			rc = rdb_tx_update(tx, kvs, &ds_cont_prop_layout_ver,
 					   &value);
@@ -315,14 +315,14 @@ cont_prop_write(struct rdb_tx *tx, const rdb_path_t *kvs, daos_prop_t *prop)
 				return rc;
 			break;
 		case DAOS_PROP_CO_CSUM:
-			daos_iov_set(&value, &entry->dpe_val,
+			d_iov_set(&value, &entry->dpe_val,
 				     sizeof(entry->dpe_val));
 			rc = rdb_tx_update(tx, kvs, &ds_cont_prop_csum, &value);
 			if (rc)
 				return rc;
 			break;
 		case DAOS_PROP_CO_REDUN_FAC:
-			daos_iov_set(&value, &entry->dpe_val,
+			d_iov_set(&value, &entry->dpe_val,
 				     sizeof(entry->dpe_val));
 			rc = rdb_tx_update(tx, kvs, &ds_cont_prop_redun_fac,
 					   &value);
@@ -330,7 +330,7 @@ cont_prop_write(struct rdb_tx *tx, const rdb_path_t *kvs, daos_prop_t *prop)
 				return rc;
 			break;
 		case DAOS_PROP_CO_REDUN_LVL:
-			daos_iov_set(&value, &entry->dpe_val,
+			d_iov_set(&value, &entry->dpe_val,
 				     sizeof(entry->dpe_val));
 			rc = rdb_tx_update(tx, kvs, &ds_cont_prop_redun_lvl,
 					   &value);
@@ -338,7 +338,7 @@ cont_prop_write(struct rdb_tx *tx, const rdb_path_t *kvs, daos_prop_t *prop)
 				return rc;
 			break;
 		case DAOS_PROP_CO_SNAPSHOT_MAX:
-			daos_iov_set(&value, &entry->dpe_val,
+			d_iov_set(&value, &entry->dpe_val,
 				     sizeof(entry->dpe_val));
 			rc = rdb_tx_update(tx, kvs, &ds_cont_prop_snapshot_max,
 					   &value);
@@ -346,7 +346,7 @@ cont_prop_write(struct rdb_tx *tx, const rdb_path_t *kvs, daos_prop_t *prop)
 				return rc;
 			break;
 		case DAOS_PROP_CO_COMPRESS:
-			daos_iov_set(&value, &entry->dpe_val,
+			d_iov_set(&value, &entry->dpe_val,
 				     sizeof(entry->dpe_val));
 			rc = rdb_tx_update(tx, kvs, &ds_cont_prop_compress,
 					   &value);
@@ -354,7 +354,7 @@ cont_prop_write(struct rdb_tx *tx, const rdb_path_t *kvs, daos_prop_t *prop)
 				return rc;
 			break;
 		case DAOS_PROP_CO_ENCRYPT:
-			daos_iov_set(&value, &entry->dpe_val,
+			d_iov_set(&value, &entry->dpe_val,
 				     sizeof(entry->dpe_val));
 			rc = rdb_tx_update(tx, kvs, &ds_cont_prop_encrypt,
 					   &value);
@@ -379,8 +379,8 @@ cont_create(struct rdb_tx *tx, struct ds_pool_hdl *pool_hdl,
 {
 	struct cont_create_in  *in = crt_req_get(rpc);
 	daos_prop_t	       *prop_dup = NULL;
-	daos_iov_t		key;
-	daos_iov_t		value;
+	d_iov_t		key;
+	d_iov_t		value;
 	struct rdb_kvs_attr	attr;
 	rdb_path_t		kvs;
 	uint64_t		ghce = 0;
@@ -397,8 +397,8 @@ cont_create(struct rdb_tx *tx, struct ds_pool_hdl *pool_hdl,
 		D_GOTO(out, rc = -DER_NO_PERM);
 
 	/* Check if a container with this UUID already exists. */
-	daos_iov_set(&key, in->cci_op.ci_uuid, sizeof(uuid_t));
-	daos_iov_set(&value, NULL /* buf */, 0 /* size */);
+	d_iov_set(&key, in->cci_op.ci_uuid, sizeof(uuid_t));
+	d_iov_set(&value, NULL /* buf */, 0 /* size */);
 	rc = rdb_tx_lookup(tx, &svc->cs_conts, &key, &value);
 	if (rc != -DER_NONEXIST) {
 		if (rc == 0)
@@ -415,7 +415,7 @@ cont_create(struct rdb_tx *tx, struct ds_pool_hdl *pool_hdl,
 	 */
 
 	/* Create the container attribute KVS under the container KVS. */
-	daos_iov_set(&key, in->cci_op.ci_uuid, sizeof(uuid_t));
+	d_iov_set(&key, in->cci_op.ci_uuid, sizeof(uuid_t));
 	attr.dsa_class = RDB_KVS_GENERIC;
 	attr.dsa_order = 16;
 	rc = rdb_tx_create_kvs(tx, &svc->cs_conts, &key, &attr);
@@ -434,15 +434,15 @@ cont_create(struct rdb_tx *tx, struct ds_pool_hdl *pool_hdl,
 		D_GOTO(out_kvs, rc);
 
 	/* Create the GHCE and GHPCE properties. */
-	daos_iov_set(&value, &ghce, sizeof(ghce));
+	d_iov_set(&value, &ghce, sizeof(ghce));
 	rc = rdb_tx_update(tx, &kvs, &ds_cont_prop_ghce, &value);
 	if (rc != 0)
 		D_GOTO(out_kvs, rc);
-	daos_iov_set(&value, &ghpce, sizeof(ghpce));
+	d_iov_set(&value, &ghpce, sizeof(ghpce));
 	rc = rdb_tx_update(tx, &kvs, &ds_cont_prop_ghpce, &value);
 	if (rc != 0)
 		D_GOTO(out_kvs, rc);
-	daos_iov_set(&value, &max_oid, sizeof(max_oid));
+	d_iov_set(&value, &max_oid, sizeof(max_oid));
 	rc = rdb_tx_update(tx, &kvs, &ds_cont_prop_max_oid, &value);
 	if (rc != 0)
 		D_GOTO(out_kvs, rc);
@@ -534,8 +534,8 @@ cont_destroy(struct rdb_tx *tx, struct ds_pool_hdl *pool_hdl,
 	     struct cont_svc *svc, crt_rpc_t *rpc)
 {
 	struct cont_destroy_in *in = crt_req_get(rpc);
-	daos_iov_t		key;
-	daos_iov_t		value;
+	d_iov_t		key;
+	d_iov_t		value;
 	rdb_path_t		kvs;
 	int			rc;
 
@@ -549,8 +549,8 @@ cont_destroy(struct rdb_tx *tx, struct ds_pool_hdl *pool_hdl,
 		D_GOTO(out, rc = -DER_NO_PERM);
 
 	/* Check if the container attribute KVS exists. */
-	daos_iov_set(&key, in->cdi_op.ci_uuid, sizeof(uuid_t));
-	daos_iov_set(&value, NULL /* buf */, 0 /* size */);
+	d_iov_set(&key, in->cdi_op.ci_uuid, sizeof(uuid_t));
+	d_iov_set(&value, NULL /* buf */, 0 /* size */);
 	rc = rdb_tx_lookup(tx, &svc->cs_conts, &key, &value);
 	if (rc != 0) {
 		if (rc == -DER_NONEXIST)
@@ -604,12 +604,12 @@ cont_lookup(struct rdb_tx *tx, const struct cont_svc *svc, const uuid_t uuid,
 	    struct cont **cont)
 {
 	struct cont    *p;
-	daos_iov_t	key;
-	daos_iov_t	tmp;
+	d_iov_t	key;
+	d_iov_t	tmp;
 	int		rc;
 
-	daos_iov_set(&key, (void *)uuid, sizeof(uuid_t));
-	daos_iov_set(&tmp, NULL, 0);
+	d_iov_set(&key, (void *)uuid, sizeof(uuid_t));
+	d_iov_set(&tmp, NULL, 0);
 	/* check if the container exists or not */
 	rc = rdb_tx_lookup(tx, &svc->cs_conts, &key, &tmp);
 	if (rc != 0)
@@ -747,8 +747,8 @@ cont_open(struct rdb_tx *tx, struct ds_pool_hdl *pool_hdl, struct cont *cont,
 	  crt_rpc_t *rpc)
 {
 	struct cont_open_in    *in = crt_req_get(rpc);
-	daos_iov_t		key;
-	daos_iov_t		value;
+	d_iov_t		key;
+	d_iov_t		value;
 	struct container_hdl	chdl;
 	int			rc;
 
@@ -764,8 +764,8 @@ cont_open(struct rdb_tx *tx, struct ds_pool_hdl *pool_hdl, struct cont *cont,
 		D_GOTO(out, rc = -DER_NO_PERM);
 
 	/* See if this container handle already exists. */
-	daos_iov_set(&key, in->coi_op.ci_hdl, sizeof(uuid_t));
-	daos_iov_set(&value, &chdl, sizeof(chdl));
+	d_iov_set(&key, in->coi_op.ci_hdl, sizeof(uuid_t));
+	d_iov_set(&value, &chdl, sizeof(chdl));
 	rc = rdb_tx_lookup(tx, &cont->c_svc->cs_hdls, &key, &value);
 	if (rc != -DER_NONEXIST) {
 		if (rc == 0 && chdl.ch_capas != in->coi_capas) {
@@ -849,15 +849,15 @@ static int
 cont_close_one_hdl(struct rdb_tx *tx, struct cont_svc *svc,
 		   crt_context_t ctx, const uuid_t uuid)
 {
-	daos_iov_t		key;
-	daos_iov_t		value;
+	d_iov_t		key;
+	d_iov_t		value;
 	struct container_hdl	chdl;
 	struct cont	       *cont;
 	int			rc;
 
 	/* Look up the handle. */
-	daos_iov_set(&key, (void *)uuid, sizeof(uuid_t));
-	daos_iov_set(&value, &chdl, sizeof(chdl));
+	d_iov_set(&key, (void *)uuid, sizeof(uuid_t));
+	d_iov_set(&value, &chdl, sizeof(chdl));
 	rc = rdb_tx_lookup(tx, &svc->cs_hdls, &key, &value);
 	if (rc != 0)
 		return rc;
@@ -932,8 +932,8 @@ cont_close(struct rdb_tx *tx, struct ds_pool_hdl *pool_hdl, struct cont *cont,
 	   crt_rpc_t *rpc)
 {
 	struct cont_close_in	       *in = crt_req_get(rpc);
-	daos_iov_t			key;
-	daos_iov_t			value;
+	d_iov_t			key;
+	d_iov_t			value;
 	struct container_hdl		chdl;
 	struct cont_tgt_close_rec	rec;
 	int				rc;
@@ -943,8 +943,8 @@ cont_close(struct rdb_tx *tx, struct ds_pool_hdl *pool_hdl, struct cont *cont,
 		DP_UUID(in->cci_op.ci_hdl));
 
 	/* See if this container handle is already closed. */
-	daos_iov_set(&key, in->cci_op.ci_hdl, sizeof(uuid_t));
-	daos_iov_set(&value, &chdl, sizeof(chdl));
+	d_iov_set(&key, in->cci_op.ci_hdl, sizeof(uuid_t));
+	d_iov_set(&value, &chdl, sizeof(chdl));
 	rc = rdb_tx_lookup(tx, &cont->c_svc->cs_hdls, &key, &value);
 	if (rc != 0) {
 		if (rc == -DER_NONEXIST) {
@@ -1024,7 +1024,7 @@ cont_prop_read(struct rdb_tx *tx, struct cont *cont, uint64_t bits,
 	       daos_prop_t **prop_out)
 {
 	daos_prop_t	*prop = NULL;
-	daos_iov_t	 value;
+	d_iov_t	 value;
 	uint64_t	 val, bitmap;
 	uint32_t	 idx = 0, nr = 0;
 	int		 rc;
@@ -1046,7 +1046,7 @@ cont_prop_read(struct rdb_tx *tx, struct cont *cont, uint64_t bits,
 
 	idx = 0;
 	if (bits & DAOS_CO_QUERY_PROP_LABEL) {
-		daos_iov_set(&value, NULL, 0);
+		d_iov_set(&value, NULL, 0);
 		rc = rdb_tx_lookup(tx, &cont->c_prop, &ds_cont_prop_label,
 				   &value);
 		if (rc != 0)
@@ -1065,7 +1065,7 @@ cont_prop_read(struct rdb_tx *tx, struct cont *cont, uint64_t bits,
 		idx++;
 	}
 	if (bits & DAOS_CO_QUERY_PROP_LAYOUT_TYPE) {
-		daos_iov_set(&value, &val, sizeof(val));
+		d_iov_set(&value, &val, sizeof(val));
 		rc = rdb_tx_lookup(tx, &cont->c_prop, &ds_cont_prop_layout_type,
 				   &value);
 		if (rc != 0)
@@ -1076,7 +1076,7 @@ cont_prop_read(struct rdb_tx *tx, struct cont *cont, uint64_t bits,
 		idx++;
 	}
 	if (bits & DAOS_CO_QUERY_PROP_LAYOUT_VER) {
-		daos_iov_set(&value, &val, sizeof(val));
+		d_iov_set(&value, &val, sizeof(val));
 		rc = rdb_tx_lookup(tx, &cont->c_prop, &ds_cont_prop_layout_ver,
 				   &value);
 		if (rc != 0)
@@ -1087,7 +1087,7 @@ cont_prop_read(struct rdb_tx *tx, struct cont *cont, uint64_t bits,
 		idx++;
 	}
 	if (bits & DAOS_CO_QUERY_PROP_CSUM) {
-		daos_iov_set(&value, &val, sizeof(val));
+		d_iov_set(&value, &val, sizeof(val));
 		rc = rdb_tx_lookup(tx, &cont->c_prop, &ds_cont_prop_csum,
 				   &value);
 		if (rc != 0)
@@ -1098,7 +1098,7 @@ cont_prop_read(struct rdb_tx *tx, struct cont *cont, uint64_t bits,
 		idx++;
 	}
 	if (bits & DAOS_CO_QUERY_PROP_REDUN_FAC) {
-		daos_iov_set(&value, &val, sizeof(val));
+		d_iov_set(&value, &val, sizeof(val));
 		rc = rdb_tx_lookup(tx, &cont->c_prop, &ds_cont_prop_redun_fac,
 				   &value);
 		if (rc != 0)
@@ -1109,7 +1109,7 @@ cont_prop_read(struct rdb_tx *tx, struct cont *cont, uint64_t bits,
 		idx++;
 	}
 	if (bits & DAOS_CO_QUERY_PROP_REDUN_LVL) {
-		daos_iov_set(&value, &val, sizeof(val));
+		d_iov_set(&value, &val, sizeof(val));
 		rc = rdb_tx_lookup(tx, &cont->c_prop, &ds_cont_prop_redun_lvl,
 				   &value);
 		if (rc != 0)
@@ -1120,7 +1120,7 @@ cont_prop_read(struct rdb_tx *tx, struct cont *cont, uint64_t bits,
 		idx++;
 	}
 	if (bits & DAOS_CO_QUERY_PROP_SNAPSHOT_MAX) {
-		daos_iov_set(&value, &val, sizeof(val));
+		d_iov_set(&value, &val, sizeof(val));
 		rc = rdb_tx_lookup(tx, &cont->c_prop,
 				   &ds_cont_prop_snapshot_max, &value);
 		if (rc != 0)
@@ -1131,7 +1131,7 @@ cont_prop_read(struct rdb_tx *tx, struct cont *cont, uint64_t bits,
 		idx++;
 	}
 	if (bits & DAOS_CO_QUERY_PROP_COMPRESS) {
-		daos_iov_set(&value, &val, sizeof(val));
+		d_iov_set(&value, &val, sizeof(val));
 		rc = rdb_tx_lookup(tx, &cont->c_prop, &ds_cont_prop_compress,
 				   &value);
 		if (rc != 0)
@@ -1142,7 +1142,7 @@ cont_prop_read(struct rdb_tx *tx, struct cont *cont, uint64_t bits,
 		idx++;
 	}
 	if (bits & DAOS_CO_QUERY_PROP_ENCRYPT) {
-		daos_iov_set(&value, &val, sizeof(val));
+		d_iov_set(&value, &val, sizeof(val));
 		rc = rdb_tx_lookup(tx, &cont->c_prop, &ds_cont_prop_encrypt,
 				   &value);
 		if (rc != 0)
@@ -1249,7 +1249,7 @@ shall_close(const uuid_t pool_hdl, uuid_t *pool_hdls, int n_pool_hdls)
 }
 
 static int
-close_iter_cb(daos_handle_t ih, daos_iov_t *key, daos_iov_t *val, void *varg)
+close_iter_cb(daos_handle_t ih, d_iov_t *key, d_iov_t *val, void *varg)
 {
 	struct close_iter_arg  *arg = varg;
 	struct container_hdl   *hdl;
@@ -1414,8 +1414,8 @@ cont_op_with_cont(struct rdb_tx *tx, struct ds_pool_hdl *pool_hdl,
 		  struct cont *cont, crt_rpc_t *rpc)
 {
 	struct cont_op_in      *in = crt_req_get(rpc);
-	daos_iov_t		key;
-	daos_iov_t		value;
+	d_iov_t		key;
+	d_iov_t		value;
 	struct container_hdl	hdl;
 	int			rc;
 
@@ -1428,8 +1428,8 @@ cont_op_with_cont(struct rdb_tx *tx, struct ds_pool_hdl *pool_hdl,
 		break;
 	default:
 		/* Look up the container handle. */
-		daos_iov_set(&key, in->ci_hdl, sizeof(uuid_t));
-		daos_iov_set(&value, &hdl, sizeof(hdl));
+		d_iov_set(&key, in->ci_hdl, sizeof(uuid_t));
+		d_iov_set(&value, &hdl, sizeof(hdl));
 		rc = rdb_tx_lookup(tx, &cont->c_svc->cs_hdls, &key, &value);
 		if (rc != 0) {
 			if (rc == -DER_NONEXIST) {
@@ -1567,8 +1567,8 @@ ds_cont_oid_fetch_add(uuid_t poh_uuid, uuid_t co_uuid, uuid_t coh_uuid,
 	struct cont_svc		*svc;
 	struct rdb_tx		tx;
 	struct cont		*cont = NULL;
-	daos_iov_t		key;
-	daos_iov_t		value;
+	d_iov_t		key;
+	d_iov_t		value;
 	struct container_hdl	hdl;
 	uint64_t		max_oid;
 	int			rc;
@@ -1597,8 +1597,8 @@ ds_cont_oid_fetch_add(uuid_t poh_uuid, uuid_t co_uuid, uuid_t coh_uuid,
 		D_GOTO(out_lock, rc);
 
 	/* Look up the container handle. */
-	daos_iov_set(&key, coh_uuid, sizeof(uuid_t));
-	daos_iov_set(&value, &hdl, sizeof(hdl));
+	d_iov_set(&key, coh_uuid, sizeof(uuid_t));
+	d_iov_set(&value, &hdl, sizeof(hdl));
 	rc = rdb_tx_lookup(&tx, &cont->c_svc->cs_hdls, &key, &value);
 	if (rc != 0) {
 		if (rc == -DER_NONEXIST)
@@ -1607,7 +1607,7 @@ ds_cont_oid_fetch_add(uuid_t poh_uuid, uuid_t co_uuid, uuid_t coh_uuid,
 	}
 
 	/* Read the max OID from the container metadata */
-	daos_iov_set(&value, &max_oid, sizeof(max_oid));
+	d_iov_set(&value, &max_oid, sizeof(max_oid));
 	rc = rdb_tx_lookup(&tx, &cont->c_prop, &ds_cont_prop_max_oid, &value);
 	if (rc != 0) {
 		D_ERROR(DF_CONT": failed to lookup max_oid: %d\n",

--- a/src/container/srv_epoch.c
+++ b/src/container/srv_epoch.c
@@ -82,14 +82,14 @@ ec_increment(struct rdb_tx *tx, struct cont *cont, enum ec_type type,
 	     uint64_t epoch)
 {
 	rdb_path_t     *kvs = ec_type2kvs(cont, type);
-	daos_iov_t	key;
-	daos_iov_t	value;
+	d_iov_t	key;
+	d_iov_t	value;
 	uint64_t	c = 0;
 	uint64_t	c_new;
 	int		rc;
 
-	daos_iov_set(&key, &epoch, sizeof(epoch));
-	daos_iov_set(&value, &c, sizeof(c));
+	d_iov_set(&key, &epoch, sizeof(epoch));
+	d_iov_set(&value, &c, sizeof(c));
 	rc = rdb_tx_lookup(tx, kvs, &key, &value);
 	if (rc != 0 && rc != -DER_NONEXIST)
 		D_GOTO(out, rc);
@@ -98,7 +98,7 @@ ec_increment(struct rdb_tx *tx, struct cont *cont, enum ec_type type,
 	if (c_new < c)
 		D_GOTO(out, rc = -DER_OVERFLOW);
 
-	daos_iov_set(&value, &c_new, sizeof(c_new));
+	d_iov_set(&value, &c_new, sizeof(c_new));
 	rc = rdb_tx_update(tx, kvs, &key, &value);
 
 out:
@@ -114,14 +114,14 @@ ec_decrement(struct rdb_tx *tx, struct cont *cont, enum ec_type type,
 	     uint64_t epoch)
 {
 	rdb_path_t     *kvs = ec_type2kvs(cont, type);
-	daos_iov_t	key;
-	daos_iov_t	value;
+	d_iov_t	key;
+	d_iov_t	value;
 	uint64_t	c = 0;
 	uint64_t	c_new;
 	int		rc;
 
-	daos_iov_set(&key, &epoch, sizeof(epoch));
-	daos_iov_set(&value, &c, sizeof(c));
+	d_iov_set(&key, &epoch, sizeof(epoch));
+	d_iov_set(&value, &c, sizeof(c));
 	rc = rdb_tx_lookup(tx, kvs, &key, &value);
 	if (rc != 0 && rc != -DER_NONEXIST)
 		D_GOTO(out, rc);
@@ -133,7 +133,7 @@ ec_decrement(struct rdb_tx *tx, struct cont *cont, enum ec_type type,
 	if (c_new == 0) {
 		rc = rdb_tx_delete(tx, kvs, &key);
 	} else {
-		daos_iov_set(&value, &c_new, sizeof(c_new));
+		d_iov_set(&value, &c_new, sizeof(c_new));
 		rc = rdb_tx_update(tx, kvs, &key, &value);
 	}
 
@@ -150,10 +150,10 @@ ec_find_lowest(struct rdb_tx *tx, struct cont *cont, enum ec_type type,
 	       daos_epoch_t *epoch)
 {
 	rdb_path_t     *kvs = ec_type2kvs(cont, type);
-	daos_iov_t	key;
+	d_iov_t	key;
 	int		rc;
 
-	daos_iov_set(&key, epoch, sizeof(*epoch));
+	d_iov_set(&key, epoch, sizeof(*epoch));
 	rc = rdb_tx_fetch(tx, kvs, RDB_PROBE_FIRST, NULL /* key_in */, &key,
 			  NULL /* value */);
 	if (rc == -DER_NONEXIST)
@@ -174,7 +174,7 @@ struct ec_decrement_iter_cb_arg {
 };
 
 static int
-ec_decrement_iter_cb(daos_handle_t ih, daos_iov_t *key, daos_iov_t *val,
+ec_decrement_iter_cb(daos_handle_t ih, d_iov_t *key, d_iov_t *val,
 		     void *varg)
 {
 	struct ec_decrement_iter_cb_arg	       *arg = varg;
@@ -320,7 +320,7 @@ static int
 read_epoch_prop(struct rdb_tx *tx, struct cont *cont,
 			struct epoch_prop *prop)
 {
-	daos_iov_t	value;
+	d_iov_t	value;
 	daos_epoch_t	ghce;
 	daos_epoch_t	ghpce;
 	daos_epoch_t	glre;
@@ -328,7 +328,7 @@ read_epoch_prop(struct rdb_tx *tx, struct cont *cont,
 	int		rc;
 
 	/* GHCE */
-	daos_iov_set(&value, &ghce, sizeof(ghce));
+	d_iov_set(&value, &ghce, sizeof(ghce));
 	rc = rdb_tx_lookup(tx, &cont->c_prop, &ds_cont_prop_ghce, &value);
 	if (rc != 0) {
 		D_ERROR(DF_CONT": failed to lookup GHCE: %d\n",
@@ -337,7 +337,7 @@ read_epoch_prop(struct rdb_tx *tx, struct cont *cont,
 	}
 
 	/* GHPCE */
-	daos_iov_set(&value, &ghpce, sizeof(ghpce));
+	d_iov_set(&value, &ghpce, sizeof(ghpce));
 	rc = rdb_tx_lookup(tx, &cont->c_prop, &ds_cont_prop_ghpce, &value);
 	if (rc != 0) {
 		D_ERROR(DF_CONT": failed to lookup GHPCE: %d\n",
@@ -374,7 +374,7 @@ struct snap_list_iter_args {
 };
 
 static int
-snap_list_iter_cb(daos_handle_t ih, daos_iov_t *key, daos_iov_t *val,
+snap_list_iter_cb(daos_handle_t ih, d_iov_t *key, d_iov_t *val,
 		  void *arg)
 {
 	struct snap_list_iter_args *i_args = arg;
@@ -579,7 +579,7 @@ static int
 update_ghce(struct rdb_tx *tx, struct cont *cont, struct epoch_prop *prop)
 {
 	daos_epoch_t	ghce;
-	daos_iov_t	value;
+	d_iov_t	value;
 	int		rc;
 
 	/*
@@ -600,7 +600,7 @@ update_ghce(struct rdb_tx *tx, struct cont *cont, struct epoch_prop *prop)
 		return 0;
 	}
 
-	daos_iov_set(&value, &ghce, sizeof(ghce));
+	d_iov_set(&value, &ghce, sizeof(ghce));
 	rc = rdb_tx_update(tx, &cont->c_prop, &ds_cont_prop_ghce, &value);
 	if (rc != 0)
 		D_ERROR(DF_CONT": failed to update ghce: %d\n",
@@ -642,13 +642,13 @@ ds_cont_epoch_init_hdl(struct rdb_tx *tx, struct cont *cont, uuid_t c_hdl,
 	 * implemented.
 	 */
 	if (hdl->ch_capas & DAOS_COO_RW) {
-		daos_iov_t	key;
-		daos_iov_t	value;
+		d_iov_t	key;
+		d_iov_t	value;
 
 		hdl->ch_lhe = prop.ep_ghpce + 1;
 
-		daos_iov_set(&key, c_hdl, sizeof(uuid_t));
-		daos_iov_set(&value, hdl, sizeof(*hdl));
+		d_iov_set(&key, c_hdl, sizeof(uuid_t));
+		d_iov_set(&value, hdl, sizeof(*hdl));
 		rc = rdb_tx_update(tx, &cont->c_svc->cs_hdls, &key, &value);
 		if (rc != 0)
 			return rc;
@@ -725,8 +725,8 @@ ds_cont_epoch_hold(struct rdb_tx *tx, struct ds_pool_hdl *pool_hdl,
 	struct cont_epoch_op_in	       *in = crt_req_get(rpc);
 	struct epoch_prop		prop;
 	daos_epoch_t			lhe = hdl->ch_lhe;
-	daos_iov_t			key;
-	daos_iov_t			value;
+	d_iov_t			key;
+	d_iov_t			value;
 	int				rc;
 
 	D_DEBUG(DF_DSMS, DF_CONT": processing rpc %p: epoch="DF_U64"\n",
@@ -765,8 +765,8 @@ ds_cont_epoch_hold(struct rdb_tx *tx, struct ds_pool_hdl *pool_hdl,
 
 	D_DEBUG(DF_DSMS, "lhe="DF_U64" lhe'="DF_U64"\n", lhe, hdl->ch_lhe);
 
-	daos_iov_set(&key, in->cei_op.ci_hdl, sizeof(uuid_t));
-	daos_iov_set(&value, hdl, sizeof(*hdl));
+	d_iov_set(&key, in->cei_op.ci_hdl, sizeof(uuid_t));
+	d_iov_set(&value, hdl, sizeof(*hdl));
 	rc = rdb_tx_update(tx, &cont->c_svc->cs_hdls, &key, &value);
 	if (rc != 0)
 		D_GOTO(out_hdl, rc);
@@ -918,8 +918,8 @@ ds_cont_epoch_commit(struct rdb_tx *tx, struct ds_pool_hdl *pool_hdl,
 	daos_epoch_t			lhe = hdl->ch_lhe;
 	daos_epoch_t			lre = hdl->ch_lre;
 	daos_epoch_t			glre = 0;
-	daos_iov_t			key;
-	daos_iov_t			value;
+	d_iov_t			key;
+	d_iov_t			value;
 	bool				slip_flag;
 	int				rc;
 
@@ -962,8 +962,8 @@ ds_cont_epoch_commit(struct rdb_tx *tx, struct ds_pool_hdl *pool_hdl,
 	if (!(hdl->ch_capas & DAOS_COO_NOSLIP))
 		hdl->ch_lre = hdl->ch_hce;
 
-	daos_iov_set(&key, in->cei_op.ci_hdl, sizeof(uuid_t));
-	daos_iov_set(&value, hdl, sizeof(*hdl));
+	d_iov_set(&key, in->cei_op.ci_hdl, sizeof(uuid_t));
+	d_iov_set(&value, hdl, sizeof(*hdl));
 	rc = rdb_tx_update(tx, &cont->c_svc->cs_hdls, &key, &value);
 	if (rc != 0)
 		D_GOTO(out_hdl, rc);
@@ -985,7 +985,7 @@ ds_cont_epoch_commit(struct rdb_tx *tx, struct ds_pool_hdl *pool_hdl,
 
 	if (hdl->ch_hce > prop.ep_ghpce) {
 		prop.ep_ghpce = hdl->ch_hce;
-		daos_iov_set(&value, &prop.ep_ghpce, sizeof(prop.ep_ghpce));
+		d_iov_set(&value, &prop.ep_ghpce, sizeof(prop.ep_ghpce));
 		rc = rdb_tx_update(tx, &cont->c_prop, &ds_cont_prop_ghpce,
 				   &value);
 		if (rc != 0) {
@@ -1006,8 +1006,8 @@ ds_cont_epoch_commit(struct rdb_tx *tx, struct ds_pool_hdl *pool_hdl,
 	if (snapshot) {
 		char		zero = 0;
 
-		daos_iov_set(&key, &in->cei_epoch, sizeof(in->cei_epoch));
-		daos_iov_set(&value, &zero, sizeof(zero));
+		d_iov_set(&key, &in->cei_epoch, sizeof(in->cei_epoch));
+		d_iov_set(&value, &zero, sizeof(zero));
 		rc = rdb_tx_update(tx, &cont->c_snaps, &key, &value);
 		if (rc != 0) {
 			D_ERROR(DF_CONT": failed to create snapshot: %d\n",
@@ -1047,7 +1047,7 @@ struct snap_destroy_iter_args {
 };
 
 static int
-snap_destroy_iter_cb(daos_handle_t ih, daos_iov_t *key, daos_iov_t *val,
+snap_destroy_iter_cb(daos_handle_t ih, d_iov_t *key, d_iov_t *val,
 		     void *arg)
 {
 	struct snap_destroy_iter_args *i_args = arg;
@@ -1073,7 +1073,7 @@ ds_cont_snap_destroy(struct rdb_tx *tx, struct ds_pool_hdl *pool_hdl,
 {
 	struct cont_epoch_op_in		*in = crt_req_get(rpc);
 	struct snap_destroy_iter_args	 iter_args;
-	daos_iov_t			 key;
+	d_iov_t			 key;
 	struct epoch_prop		 prop;
 	bool				 slip_flag;
 	int				 rc;
@@ -1082,7 +1082,7 @@ ds_cont_snap_destroy(struct rdb_tx *tx, struct ds_pool_hdl *pool_hdl,
 		DP_CONT(pool_hdl->sph_pool->sp_uuid, in->cei_op.ci_uuid),
 		rpc, in->cei_epoch);
 
-	daos_iov_set(&key, &in->cei_epoch, sizeof(daos_epoch_t));
+	d_iov_set(&key, &in->cei_epoch, sizeof(daos_epoch_t));
 	rc = rdb_tx_delete(tx, &cont->c_snaps, &key);
 	if (rc != 0) {
 		rc = 0;
@@ -1167,12 +1167,12 @@ ds_cont_snap_list(struct rdb_tx *tx, struct ds_pool_hdl *pool_hdl,
 	if (xfer_size > 0) {
 		ABT_eventual	 eventual;
 		int		*status;
-		daos_iov_t	 iov = {
+		d_iov_t	 iov = {
 			.iov_buf	= snapshots,
 			.iov_len	= xfer_size,
 			.iov_buf_len	= xfer_size
 		};
-		daos_sg_list_t	 sgl = {
+		d_sg_list_t	 sgl = {
 			.sg_nr_out = 1,
 			.sg_nr	   = 1,
 			.sg_iovs   = &iov
@@ -1192,8 +1192,8 @@ ds_cont_snap_list(struct rdb_tx *tx, struct ds_pool_hdl *pool_hdl,
 			goto out_mem;
 		}
 
-		rc = crt_bulk_create(rpc->cr_ctx, daos2crt_sg(&sgl),
-				     CRT_BULK_RW, &bulk_desc.bd_local_hdl);
+		rc = crt_bulk_create(rpc->cr_ctx, &sgl, CRT_BULK_RW,
+				     &bulk_desc.bd_local_hdl);
 		if (rc != 0)
 			goto out_eventual;
 		rc = crt_bulk_transfer(&bulk_desc, bulk_cb, &eventual, NULL);

--- a/src/container/srv_layout.h
+++ b/src/container/srv_layout.h
@@ -47,8 +47,8 @@
 #include <daos_types.h>
 
 /* Root KVS (RDB_KVS_GENERIC) */
-extern daos_iov_t ds_cont_prop_conts;		/* container KVS */
-extern daos_iov_t ds_cont_prop_cont_handles;	/* container handle KVS */
+extern d_iov_t ds_cont_prop_conts;		/* container KVS */
+extern d_iov_t ds_cont_prop_cont_handles;	/* container handle KVS */
 
 /*
  * Container KVS (RDB_KVS_GENERIC)
@@ -72,22 +72,22 @@ extern daos_iov_t ds_cont_prop_cont_handles;	/* container handle KVS */
  * User-defined attributes (RDB_KVS_GENERIC) -
  * To store container attributes of upper layers.
  */
-extern daos_iov_t ds_cont_prop_ghce;		/* uint64_t */
-extern daos_iov_t ds_cont_prop_ghpce;		/* uint64_t */
-extern daos_iov_t ds_cont_prop_max_oid;		/* uint64_t */
-extern daos_iov_t ds_cont_prop_label;		/* uint64_t */
-extern daos_iov_t ds_cont_prop_layout_type;	/* uint64_t */
-extern daos_iov_t ds_cont_prop_layout_ver;	/* uint64_t */
-extern daos_iov_t ds_cont_prop_csum;		/* uint64_t */
-extern daos_iov_t ds_cont_prop_redun_fac;	/* uint64_t */
-extern daos_iov_t ds_cont_prop_redun_lvl;	/* uint64_t */
-extern daos_iov_t ds_cont_prop_snapshot_max;	/* uint64_t */
-extern daos_iov_t ds_cont_prop_compress;	/* uint64_t */
-extern daos_iov_t ds_cont_prop_encrypt;		/* uint64_t */
-extern daos_iov_t ds_cont_prop_lres;		/* LRE KVS */
-extern daos_iov_t ds_cont_prop_lhes;		/* LHE KVS */
-extern daos_iov_t ds_cont_prop_snapshots;	/* snapshot KVS */
-extern daos_iov_t ds_cont_attr_user;		/* User attributes KVS */
+extern d_iov_t ds_cont_prop_ghce;		/* uint64_t */
+extern d_iov_t ds_cont_prop_ghpce;		/* uint64_t */
+extern d_iov_t ds_cont_prop_max_oid;		/* uint64_t */
+extern d_iov_t ds_cont_prop_label;		/* uint64_t */
+extern d_iov_t ds_cont_prop_layout_type;	/* uint64_t */
+extern d_iov_t ds_cont_prop_layout_ver;	/* uint64_t */
+extern d_iov_t ds_cont_prop_csum;		/* uint64_t */
+extern d_iov_t ds_cont_prop_redun_fac;	/* uint64_t */
+extern d_iov_t ds_cont_prop_redun_lvl;	/* uint64_t */
+extern d_iov_t ds_cont_prop_snapshot_max;	/* uint64_t */
+extern d_iov_t ds_cont_prop_compress;	/* uint64_t */
+extern d_iov_t ds_cont_prop_encrypt;		/* uint64_t */
+extern d_iov_t ds_cont_prop_lres;		/* LRE KVS */
+extern d_iov_t ds_cont_prop_lhes;		/* LHE KVS */
+extern d_iov_t ds_cont_prop_snapshots;	/* snapshot KVS */
+extern d_iov_t ds_cont_attr_user;		/* User attributes KVS */
 
 /*
  * Container handle KVS (RDB_KVS_GENERIC)

--- a/src/container/srv_target.c
+++ b/src/container/srv_target.c
@@ -1352,7 +1352,7 @@ cont_oid_alloc(struct ds_pool_hdl *pool_hdl, crt_rpc_t *rpc)
 	out = crt_reply_get(rpc);
 	D_ASSERT(out != NULL);
 
-	daos_iov_set(&iov, &rg, sizeof(rg));
+	d_iov_set(&iov, &rg, sizeof(rg));
 
 	sgl.sg_nr = 1;
 	sgl.sg_nr_out = 0;

--- a/src/dtx/dtx_rpc.c
+++ b/src/dtx/dtx_rpc.c
@@ -317,8 +317,8 @@ dtx_req_list_send(crt_opcode_t opc, d_list_t *head, int length, uuid_t po_uuid,
 }
 
 static int
-dtx_cf_rec_alloc(struct btr_instance *tins, daos_iov_t *key_iov,
-		 daos_iov_t *val_iov, struct btr_record *rec)
+dtx_cf_rec_alloc(struct btr_instance *tins, d_iov_t *key_iov,
+		 d_iov_t *val_iov, struct btr_record *rec)
 {
 	struct dtx_req_rec		*drr;
 	struct dtx_cf_rec_bundle	*dcrb;
@@ -364,7 +364,7 @@ dtx_cf_rec_free(struct btr_instance *tins, struct btr_record *rec, void *args)
 
 static int
 dtx_cf_rec_fetch(struct btr_instance *tins, struct btr_record *rec,
-		 daos_iov_t *key_iov, daos_iov_t *val_iov)
+		 d_iov_t *key_iov, d_iov_t *val_iov)
 {
 	D_ASSERTF(0, "We should not come here.\n");
 	return 0;
@@ -372,7 +372,7 @@ dtx_cf_rec_fetch(struct btr_instance *tins, struct btr_record *rec,
 
 static int
 dtx_cf_rec_update(struct btr_instance *tins, struct btr_record *rec,
-		  daos_iov_t *key, daos_iov_t *val)
+		  d_iov_t *key, d_iov_t *val)
 {
 	struct dtx_req_rec		*drr;
 	struct dtx_cf_rec_bundle	*dcrb;
@@ -460,8 +460,8 @@ dtx_dti_classify_one(struct ds_pool *pool, struct pl_map *map, uuid_t po_uuid,
 	for (i = start; i < start + replicas && rc >= 0; i++) {
 		struct pl_obj_shard	*shard;
 		struct pool_target	*target;
-		daos_iov_t		 kiov;
-		daos_iov_t		 riov;
+		d_iov_t		 kiov;
+		d_iov_t		 riov;
 
 		/* skip unavailable replica(s). */
 		shard = &layout->ol_shards[i];
@@ -479,8 +479,8 @@ dtx_dti_classify_one(struct ds_pool *pool, struct pl_map *map, uuid_t po_uuid,
 		dcrb.dcrb_rank = target->ta_comp.co_rank;
 		dcrb.dcrb_tag = target->ta_comp.co_index;
 
-		daos_iov_set(&riov, &dcrb, sizeof(dcrb));
-		daos_iov_set(&kiov, &dcrb.dcrb_key, sizeof(dcrb.dcrb_key));
+		d_iov_set(&riov, &dcrb, sizeof(dcrb));
+		d_iov_set(&kiov, &dcrb.dcrb_key, sizeof(dcrb.dcrb_key));
 		rc = dbtree_upsert(tree, BTR_PROBE_EQ, DAOS_INTENT_UPDATE,
 				   &kiov, &riov);
 	}

--- a/src/include/daos/addons.h
+++ b/src/include/daos/addons.h
@@ -37,8 +37,8 @@ int dac_array_write(tse_task_t *task);
 int dac_array_punch(tse_task_t *task);
 int dac_array_get_size(tse_task_t *task);
 int dac_array_set_size(tse_task_t *task);
-int dac_array_local2global(daos_handle_t oh, daos_iov_t *glob);
-int dac_array_global2local(daos_handle_t coh, daos_iov_t glob,
+int dac_array_local2global(daos_handle_t oh, d_iov_t *glob);
+int dac_array_global2local(daos_handle_t coh, d_iov_t glob,
 			   daos_handle_t *oh);
 
 /* task function for HL operations */

--- a/src/include/daos/btree.h
+++ b/src/include/daos/btree.h
@@ -224,7 +224,7 @@ typedef struct {
 	 * \param hkey	[OUT]	hashed key
 	 */
 	void		(*to_hkey_gen)(struct btr_instance *tins,
-				       daos_iov_t *key, void *hkey);
+				       d_iov_t *key, void *hkey);
 	/** Static callback to get size of the hashed key. */
 	int		(*to_hkey_size)(void);
 
@@ -275,7 +275,7 @@ typedef struct {
 	 *		other undefined result.
 	 */
 	int		(*to_key_cmp)(struct btr_instance *tins,
-				      struct btr_record *rec, daos_iov_t *key);
+				      struct btr_record *rec, d_iov_t *key);
 
 	/**
 	 * Required if using direct keys. (Should only be called for direct key)
@@ -288,7 +288,7 @@ typedef struct {
 	 * @param anchor	[OUT]	Anchor for the iteration
 	 */
 	void		(*to_key_encode)(struct btr_instance *tins,
-					 daos_iov_t *key,
+					 d_iov_t *key,
 					 daos_anchor_t *anchor);
 	/**
 	 * Required if using direct keys. (Should only be called for direct key)
@@ -300,7 +300,7 @@ typedef struct {
 	 * @param anchor	[IN]	Anchor of where iteration process is.
 	 */
 	void		(*to_key_decode)(struct btr_instance *tins,
-					 daos_iov_t *key,
+					 d_iov_t *key,
 					 daos_anchor_t *anchor);
 
 	/**
@@ -316,7 +316,7 @@ typedef struct {
 	 *			See \a btr_record for the details.
 	 */
 	int		(*to_rec_alloc)(struct btr_instance *tins,
-					daos_iov_t *key, daos_iov_t *val,
+					d_iov_t *key, d_iov_t *val,
 					struct btr_record *rec);
 	/**
 	 * Free the record body stored in \a rec::rec_off
@@ -344,7 +344,7 @@ typedef struct {
 	 */
 	int		(*to_rec_fetch)(struct btr_instance *tins,
 					struct btr_record *rec,
-					daos_iov_t *key, daos_iov_t *val);
+					d_iov_t *key, d_iov_t *val);
 	/**
 	 * Update value of a record, the new value should be stored in the
 	 * current rec::rec_off.
@@ -362,7 +362,7 @@ typedef struct {
 	 */
 	int		(*to_rec_update)(struct btr_instance *tins,
 					 struct btr_record *rec,
-					 daos_iov_t *key, daos_iov_t *val);
+					 d_iov_t *key, d_iov_t *val);
 	/**
 	 * Optional:
 	 * Return key and value size of the record.
@@ -568,13 +568,13 @@ int  dbtree_open_inplace_ex(struct btr_root *root, struct umem_attr *uma,
 			    daos_handle_t coh, void *info, daos_handle_t *toh);
 int  dbtree_close(daos_handle_t toh);
 int  dbtree_destroy(daos_handle_t toh);
-int  dbtree_lookup(daos_handle_t toh, daos_iov_t *key, daos_iov_t *val_out);
-int  dbtree_update(daos_handle_t toh, daos_iov_t *key, daos_iov_t *val);
+int  dbtree_lookup(daos_handle_t toh, d_iov_t *key, d_iov_t *val_out);
+int  dbtree_update(daos_handle_t toh, d_iov_t *key, d_iov_t *val);
 int  dbtree_fetch(daos_handle_t toh, dbtree_probe_opc_t opc, uint32_t intent,
-		  daos_iov_t *key, daos_iov_t *key_out, daos_iov_t *val_out);
+		  d_iov_t *key, d_iov_t *key_out, d_iov_t *val_out);
 int  dbtree_upsert(daos_handle_t toh, dbtree_probe_opc_t opc, uint32_t intent,
-		   daos_iov_t *key, daos_iov_t *val);
-int  dbtree_delete(daos_handle_t toh, daos_iov_t *key, void *args);
+		   d_iov_t *key, d_iov_t *val);
+int  dbtree_delete(daos_handle_t toh, d_iov_t *key, void *args);
 int  dbtree_query(daos_handle_t toh, struct btr_attr *attr,
 		  struct btr_stat *stat);
 int  dbtree_is_empty(daos_handle_t toh);
@@ -595,13 +595,13 @@ int dbtree_iter_prepare(daos_handle_t toh, unsigned int options,
 			daos_handle_t *ih);
 int dbtree_iter_finish(daos_handle_t ih);
 int dbtree_iter_probe(daos_handle_t ih, dbtree_probe_opc_t opc,
-		      uint32_t intent, daos_iov_t *key, daos_anchor_t *anchor);
+		      uint32_t intent, d_iov_t *key, daos_anchor_t *anchor);
 int dbtree_iter_next(daos_handle_t ih);
 int dbtree_iter_prev(daos_handle_t ih);
 int dbtree_iter_next_with_intent(daos_handle_t ih, uint32_t intent);
 int dbtree_iter_prev_with_intent(daos_handle_t ih, uint32_t intent);
-int dbtree_iter_fetch(daos_handle_t ih, daos_iov_t *key,
-		      daos_iov_t *val, daos_anchor_t *anchor);
+int dbtree_iter_fetch(daos_handle_t ih, d_iov_t *key,
+		      d_iov_t *val, daos_anchor_t *anchor);
 int dbtree_iter_delete(daos_handle_t ih, void *args);
 int dbtree_iter_empty(daos_handle_t ih);
 
@@ -612,8 +612,8 @@ int dbtree_iter_empty(daos_handle_t ih);
  *   - if rc == 1, dbtree_iterate() stops and returns 0;
  *   - otherwise, dbtree_iterate() stops and returns rc.
  */
-typedef int (*dbtree_iterate_cb_t)(daos_handle_t ih, daos_iov_t *key,
-				   daos_iov_t *val, void *arg);
+typedef int (*dbtree_iterate_cb_t)(daos_handle_t ih, d_iov_t *key,
+				   d_iov_t *val, void *arg);
 int dbtree_iterate(daos_handle_t toh, uint32_t intent, bool backward,
 		   dbtree_iterate_cb_t cb, void *arg);
 

--- a/src/include/daos/checksum.h
+++ b/src/include/daos/checksum.h
@@ -55,7 +55,7 @@ typedef struct daos_csum daos_csum_t;
 int		daos_csum_init(const char *cs_name, daos_csum_t *checksum);
 int		daos_csum_free(daos_csum_t *csum);
 int		daos_csum_reset(daos_csum_t *csum);
-int		daos_csum_compute(daos_csum_t *csum, daos_sg_list_t *sgl);
+int		daos_csum_compute(daos_csum_t *csum, d_sg_list_t *sgl);
 daos_size_t	daos_csum_get_size(const daos_csum_t *csum);
 int		daos_csum_get(daos_csum_t *csum, daos_csum_buf_t *csum_buf);
 int		daos_csum_compare(daos_csum_t *csum, daos_csum_t *csum_src);

--- a/src/include/daos/common.h
+++ b/src/include/daos/common.h
@@ -163,15 +163,15 @@ int daos_sgl_alloc_copy_data(d_sg_list_t *dst, d_sg_list_t *src);
 daos_size_t daos_sgl_data_len(d_sg_list_t *sgl);
 daos_size_t daos_sgl_buf_size(d_sg_list_t *sgl);
 daos_size_t daos_sgls_buf_size(d_sg_list_t *sgls, int nr);
-daos_size_t daos_sgls_packed_size(daos_sg_list_t *sgls, int nr,
+daos_size_t daos_sgls_packed_size(d_sg_list_t *sgls, int nr,
 				  daos_size_t *buf_size);
 daos_size_t daos_iods_len(daos_iod_t *iods, int nr);
 int daos_iod_copy(daos_iod_t *dst, daos_iod_t *src);
 void daos_iods_free(daos_iod_t *iods, int nr, bool free);
 
 char *daos_str_trimwhite(char *str);
-int daos_iov_copy(daos_iov_t *dst, daos_iov_t *src);
-void daos_iov_free(daos_iov_t *iov);
+int daos_iov_copy(d_iov_t *dst, d_iov_t *src);
+void daos_iov_free(d_iov_t *iov);
 bool daos_key_match(daos_key_t *key1, daos_key_t *key2);
 
 /* The DAOS BITS is composed by uint32_t[x] */

--- a/src/include/daos/container.h
+++ b/src/include/daos/container.h
@@ -42,8 +42,8 @@ int dc_cont_node_id2ptr(daos_handle_t coh, uint32_t node_id,
 int dc_cont_hdl2uuid(daos_handle_t coh, uuid_t *hdl_uuid, uuid_t *con_uuid);
 daos_handle_t dc_cont_hdl2pool_hdl(daos_handle_t coh);
 
-int dc_cont_local2global(daos_handle_t coh, daos_iov_t *glob);
-int dc_cont_global2local(daos_handle_t poh, daos_iov_t glob,
+int dc_cont_local2global(daos_handle_t coh, d_iov_t *glob);
+int dc_cont_global2local(daos_handle_t poh, d_iov_t glob,
 			 daos_handle_t *coh);
 
 int dc_cont_local_open(uuid_t cont_uuid, uuid_t cont_hdl_uuid,

--- a/src/include/daos/pool.h
+++ b/src/include/daos/pool.h
@@ -67,8 +67,8 @@ struct dc_pool *dc_hdl2pool(daos_handle_t hdl);
 void dc_pool_get(struct dc_pool *pool);
 void dc_pool_put(struct dc_pool *pool);
 
-int dc_pool_local2global(daos_handle_t poh, daos_iov_t *glob);
-int dc_pool_global2local(daos_iov_t glob, daos_handle_t *poh);
+int dc_pool_local2global(daos_handle_t poh, d_iov_t *glob);
+int dc_pool_global2local(d_iov_t glob, daos_handle_t *poh);
 int dc_pool_connect(tse_task_t *task);
 int dc_pool_disconnect(tse_task_t *task);
 int dc_pool_query(tse_task_t *task);

--- a/src/include/daos/rpc.h
+++ b/src/include/daos/rpc.h
@@ -201,25 +201,6 @@ daos_rpc_unregister(struct crt_proto_format *proto_fmt)
 	return 0;
 }
 
-static inline d_sg_list_t *
-daos2crt_sg(daos_sg_list_t *sgl)
-{
-	/** XXX better integration with CaRT required */
-	D_CASSERT(sizeof(daos_sg_list_t) == sizeof(d_sg_list_t));
-	D_CASSERT(offsetof(daos_sg_list_t, sg_nr) ==
-		  offsetof(d_sg_list_t, sg_nr));
-	D_CASSERT(offsetof(daos_sg_list_t, sg_iovs) ==
-		  offsetof(d_sg_list_t, sg_iovs));
-	D_CASSERT(sizeof(daos_iov_t) == sizeof(d_iov_t));
-	D_CASSERT(offsetof(daos_iov_t, iov_buf) ==
-		  offsetof(d_iov_t, iov_buf));
-	D_CASSERT(offsetof(daos_iov_t, iov_buf_len) ==
-		  offsetof(d_iov_t, iov_buf_len));
-	D_CASSERT(offsetof(daos_iov_t, iov_len) ==
-		  offsetof(d_iov_t, iov_len));
-	return (d_sg_list_t *)sgl;
-}
-
 int daos_rpc_send(crt_rpc_t *rpc, tse_task_t *task);
 int daos_rpc_complete(crt_rpc_t *rpc, tse_task_t *task);
 int daos_rpc_send_wait(crt_rpc_t *rpc);

--- a/src/include/daos/security.h
+++ b/src/include/daos/security.h
@@ -48,6 +48,6 @@
  *		-DER_NOREPLY	No response from agent
  *		-DER_MISC	Invalid response from agent
  */
-int dc_sec_request_creds(daos_iov_t *creds);
+int dc_sec_request_creds(d_iov_t *creds);
 
 #endif /* __DAOS_SECURITY_H__ */

--- a/src/include/daos/task.h
+++ b/src/include/daos/task.h
@@ -76,25 +76,25 @@ dc_obj_query_key_task_create(daos_handle_t oh, daos_handle_t th,
 int
 dc_obj_fetch_task_create(daos_handle_t oh, daos_handle_t th,
 			 daos_key_t *dkey, unsigned int nr,
-			 daos_iod_t *iods, daos_sg_list_t *sgls,
+			 daos_iod_t *iods, d_sg_list_t *sgls,
 			 daos_iom_t *maps, daos_event_t *ev,
 			 tse_sched_t *tse, tse_task_t **task);
 int
 dc_obj_update_task_create(daos_handle_t oh, daos_handle_t th,
 			  daos_key_t *dkey, unsigned int nr,
-			  daos_iod_t *iods, daos_sg_list_t *sgls,
+			  daos_iod_t *iods, d_sg_list_t *sgls,
 			  daos_event_t *ev, tse_sched_t *tse,
 			  tse_task_t **task);
 
 int
 dc_obj_list_dkey_task_create(daos_handle_t oh, daos_handle_t th, uint32_t *nr,
-			     daos_key_desc_t *kds, daos_sg_list_t *sgl,
+			     daos_key_desc_t *kds, d_sg_list_t *sgl,
 			     daos_anchor_t *anchor, daos_event_t *ev,
 			     tse_sched_t *tse, tse_task_t **task);
 int
 dc_obj_list_akey_task_create(daos_handle_t oh, daos_handle_t th,
 			     daos_key_t *dkey, uint32_t *nr,
-			     daos_key_desc_t *kds, daos_sg_list_t *sgl,
+			     daos_key_desc_t *kds, d_sg_list_t *sgl,
 			     daos_anchor_t *anchor, daos_event_t *ev,
 			     tse_sched_t *tse, tse_task_t **task);
 int
@@ -110,7 +110,7 @@ dc_obj_list_obj_task_create(daos_handle_t oh, daos_handle_t th,
 			    daos_key_t *dkey, daos_key_t *akey,
 			    daos_size_t *size, uint32_t *nr,
 			    daos_key_desc_t *kds, daos_epoch_range_t *eprs,
-			    daos_sg_list_t *sgl,
+			    d_sg_list_t *sgl,
 			    daos_anchor_t *anchor,
 			    daos_anchor_t *dkeay_anchor,
 			    daos_anchor_t *akey_anchor,

--- a/src/include/daos_addons.h
+++ b/src/include/daos_addons.h
@@ -145,14 +145,14 @@ daos_kv_remove(daos_handle_t oh, daos_handle_t th, const char *key,
  */
 int
 daos_kv_list(daos_handle_t oh, daos_handle_t th, uint32_t *nr,
-	     daos_key_desc_t *kds, daos_sg_list_t *sgl, daos_anchor_t *anchor,
+	     daos_key_desc_t *kds, d_sg_list_t *sgl, daos_anchor_t *anchor,
 	     daos_event_t *ev);
 
 typedef struct {
 	daos_key_t	*ioa_dkey;
 	unsigned int	ioa_nr;
 	daos_iod_t	*ioa_iods;
-	daos_sg_list_t	*ioa_sgls;
+	d_sg_list_t	*ioa_sgls;
 	daos_iom_t	*ioa_maps;
 } daos_dkey_io_t;
 
@@ -321,7 +321,7 @@ daos_array_open(daos_handle_t coh, daos_obj_id_t oid, daos_handle_t th,
  *					glob->iov_buf_len.
  */
 int
-daos_array_local2global(daos_handle_t oh, daos_iov_t *glob);
+daos_array_local2global(daos_handle_t oh, d_iov_t *glob);
 
 /**
  * Create a local array open handle for global representation data. This handle
@@ -339,7 +339,7 @@ daos_array_local2global(daos_handle_t oh, daos_iov_t *glob);
  *			-DER_NO_HDL	Container handle is nonexistent
  */
 int
-daos_array_global2local(daos_handle_t coh, daos_iov_t glob, daos_handle_t *oh);
+daos_array_global2local(daos_handle_t coh, d_iov_t glob, daos_handle_t *oh);
 
 /**
  * Close an opened array object.
@@ -383,7 +383,7 @@ daos_array_close(daos_handle_t oh, daos_event_t *ev);
  */
 int
 daos_array_read(daos_handle_t oh, daos_handle_t th,
-		daos_array_iod_t *iod, daos_sg_list_t *sgl,
+		daos_array_iod_t *iod, d_sg_list_t *sgl,
 		daos_csum_buf_t *csums, daos_event_t *ev);
 
 /**
@@ -412,7 +412,7 @@ daos_array_read(daos_handle_t oh, daos_handle_t th,
  */
 int
 daos_array_write(daos_handle_t oh, daos_handle_t th,
-		 daos_array_iod_t *iod, daos_sg_list_t *sgl,
+		 daos_array_iod_t *iod, d_sg_list_t *sgl,
 		 daos_csum_buf_t *csums, daos_event_t *ev);
 
 /**

--- a/src/include/daos_api.h
+++ b/src/include/daos_api.h
@@ -115,7 +115,7 @@ daos_pool_disconnect(daos_handle_t poh, daos_event_t *ev);
  *					glob->iov_buf_len.
  */
 int
-daos_pool_local2global(daos_handle_t poh, daos_iov_t *glob);
+daos_pool_local2global(daos_handle_t poh, d_iov_t *glob);
 
 /**
  * Create a local pool connection for global representation data.
@@ -130,7 +130,7 @@ daos_pool_local2global(daos_handle_t poh, daos_iov_t *glob);
  *			-DER_INVAL	Invalid parameter
  */
 int
-daos_pool_global2local(daos_iov_t glob, daos_handle_t *poh);
+daos_pool_global2local(d_iov_t glob, daos_handle_t *poh);
 
 /**
  * Convert a local container handle to global representation data which can be
@@ -153,7 +153,7 @@ daos_pool_global2local(daos_iov_t glob, daos_handle_t *poh);
  *					glob->iov_buf_len.
  */
 int
-daos_cont_local2global(daos_handle_t coh, daos_iov_t *glob);
+daos_cont_local2global(daos_handle_t coh, d_iov_t *glob);
 
 /**
  * Create a local container handle for global representation data.
@@ -170,7 +170,7 @@ daos_cont_local2global(daos_handle_t coh, daos_iov_t *glob);
  *			-DER_NO_HDL	Pool handle is nonexistent
  */
 int
-daos_cont_global2local(daos_handle_t poh, daos_iov_t glob, daos_handle_t *coh);
+daos_cont_global2local(daos_handle_t poh, d_iov_t glob, daos_handle_t *coh);
 
 /**
  * Query pool information. User should provide at least one of \a info and
@@ -838,7 +838,7 @@ daos_obj_generate_id(daos_obj_id_t *oid, daos_ofeat_t ofeats,
  *			dmg uses ":" as the separator.
  *
  * \return		allocated rank list that user is responsible to free
- *			with daos_rank_list_free().
+ *			with d_rank_list_free().
  */
 d_rank_list_t *
 daos_rank_list_parse(const char *str, const char *sep);
@@ -1074,7 +1074,7 @@ daos_obj_query(daos_handle_t oh, daos_handle_t th, daos_obj_attr_t *oa,
  */
 int
 daos_obj_fetch(daos_handle_t oh, daos_handle_t th, daos_key_t *dkey,
-	       unsigned int nr, daos_iod_t *iods, daos_sg_list_t *sgls,
+	       unsigned int nr, daos_iod_t *iods, d_sg_list_t *sgls,
 	       daos_iom_t *maps, daos_event_t *ev);
 
 /**
@@ -1125,7 +1125,7 @@ daos_obj_fetch(daos_handle_t oh, daos_handle_t th, daos_key_t *dkey,
  */
 int
 daos_obj_update(daos_handle_t oh, daos_handle_t th, daos_key_t *dkey,
-		unsigned int nr, daos_iod_t *iods, daos_sg_list_t *sgls,
+		unsigned int nr, daos_iod_t *iods, d_sg_list_t *sgls,
 		daos_event_t *ev);
 
 /**
@@ -1175,7 +1175,7 @@ daos_obj_update(daos_handle_t oh, daos_handle_t th, daos_key_t *dkey,
  */
 int
 daos_obj_list_dkey(daos_handle_t oh, daos_handle_t th, uint32_t *nr,
-		   daos_key_desc_t *kds, daos_sg_list_t *sgl,
+		   daos_key_desc_t *kds, d_sg_list_t *sgl,
 		   daos_anchor_t *anchor, daos_event_t *ev);
 
 /**
@@ -1227,7 +1227,7 @@ daos_obj_list_dkey(daos_handle_t oh, daos_handle_t th, uint32_t *nr,
  */
 int
 daos_obj_list_akey(daos_handle_t oh, daos_handle_t th, daos_key_t *dkey,
-		   uint32_t *nr, daos_key_desc_t *kds, daos_sg_list_t *sgl,
+		   uint32_t *nr, daos_key_desc_t *kds, d_sg_list_t *sgl,
 		   daos_anchor_t *anchor, daos_event_t *ev);
 
 /**

--- a/src/include/daos_fs.h
+++ b/src/include/daos_fs.h
@@ -175,7 +175,7 @@ dfs_release(dfs_obj_t *obj);
  * \return		0 on Success. Negative on Failure.
  */
 int
-dfs_read(dfs_t *dfs, dfs_obj_t *obj, daos_sg_list_t sgl, daos_off_t off,
+dfs_read(dfs_t *dfs, dfs_obj_t *obj, d_sg_list_t sgl, daos_off_t off,
 	 daos_size_t *read_size);
 
 /**
@@ -189,7 +189,7 @@ dfs_read(dfs_t *dfs, dfs_obj_t *obj, daos_sg_list_t sgl, daos_off_t off,
  * \return		0 on Success. Negative on Failure.
  */
 int
-dfs_write(dfs_t *dfs, dfs_obj_t *obj, daos_sg_list_t sgl, daos_off_t off);
+dfs_write(dfs_t *dfs, dfs_obj_t *obj, d_sg_list_t sgl, daos_off_t off);
 
 /**
  * Query size of file data.

--- a/src/include/daos_srv/bio.h
+++ b/src/include/daos_srv/bio.h
@@ -132,11 +132,11 @@ bio_sgl_fini(struct bio_sglist *sgl)
 }
 
 /*
- * Convert bio_sglist into daos_sg_list_t, caller is responsible to
+ * Convert bio_sglist into d_sg_list_t, caller is responsible to
  * call daos_sgl_fini(sgl, false) to free iovs.
  */
 static inline int
-bio_sgl_convert(struct bio_sglist *bsgl, daos_sg_list_t *sgl)
+bio_sgl_convert(struct bio_sglist *bsgl, d_sg_list_t *sgl)
 {
 	int i, rc;
 
@@ -151,7 +151,7 @@ bio_sgl_convert(struct bio_sglist *bsgl, daos_sg_list_t *sgl)
 
 	for (i = 0; i < sgl->sg_nr_out; i++) {
 		struct bio_iov	*biov = &bsgl->bs_iovs[i];
-		daos_iov_t	*iov = &sgl->sg_iovs[i];
+		d_iov_t	*iov = &sgl->sg_iovs[i];
 
 		iov->iov_buf = biov->bi_buf;
 		iov->iov_len = biov->bi_data_len;
@@ -272,7 +272,7 @@ int bio_blob_unmap(struct bio_io_context *ctxt, uint64_t off, uint64_t len);
  *
  * \returns		Zero on success, negative value on error
  */
-int bio_write(struct bio_io_context *ctxt, bio_addr_t addr, daos_iov_t *iov);
+int bio_write(struct bio_io_context *ctxt, bio_addr_t addr, d_iov_t *iov);
 
 /**
  * Read from per VOS instance blob.
@@ -283,7 +283,7 @@ int bio_write(struct bio_io_context *ctxt, bio_addr_t addr, daos_iov_t *iov);
  *
  * \returns		Zero on success, negative value on error
  */
-int bio_read(struct bio_io_context *ctxt, bio_addr_t addr, daos_iov_t *iov);
+int bio_read(struct bio_io_context *ctxt, bio_addr_t addr, d_iov_t *iov);
 
 /**
  * Write SGL to per VOS instance blob.
@@ -295,7 +295,7 @@ int bio_read(struct bio_io_context *ctxt, bio_addr_t addr, daos_iov_t *iov);
  * \returns		Zero on success, negative value on error
  */
 int bio_writev(struct bio_io_context *ioctxt, struct bio_sglist *bsgl,
-	       daos_sg_list_t *sgl);
+	       d_sg_list_t *sgl);
 
 /**
  * Read SGL from per VOS instance blob.
@@ -307,7 +307,7 @@ int bio_writev(struct bio_io_context *ioctxt, struct bio_sglist *bsgl,
  * \returns		Zero on success, negative value on error
  */
 int bio_readv(struct bio_io_context *ioctxt, struct bio_sglist *bsgl,
-	      daos_sg_list_t *sgl);
+	      d_sg_list_t *sgl);
 
 /*
  * Finish setting up blob header and write info to blob offset 0.

--- a/src/include/daos_srv/daos_server.h
+++ b/src/include/daos_srv/daos_server.h
@@ -528,12 +528,12 @@ int ds_obj_close(daos_handle_t obj_hl);
 
 int ds_obj_list_akey(daos_handle_t oh, daos_epoch_t epoch,
 		 daos_key_t *dkey, uint32_t *nr,
-		 daos_key_desc_t *kds, daos_sg_list_t *sgl,
+		 daos_key_desc_t *kds, d_sg_list_t *sgl,
 		 daos_anchor_t *anchor);
 
 int ds_obj_fetch(daos_handle_t oh, daos_epoch_t epoch,
 		 daos_key_t *dkey, unsigned int nr,
-		 daos_iod_t *iods, daos_sg_list_t *sgls,
+		 daos_iod_t *iods, d_sg_list_t *sgls,
 		 daos_iom_t *maps);
 int ds_obj_list_obj(daos_handle_t oh, daos_epoch_t epoch, daos_key_t *dkey,
 		daos_key_t *akey, daos_size_t *size, uint32_t *nr,
@@ -555,7 +555,7 @@ struct dss_enum_arg {
 			daos_key_desc_t	       *kds;
 			int			kds_cap;
 			int			kds_len;
-			daos_sg_list_t	       *sgl;
+			d_sg_list_t	       *sgl;
 			int			sgl_idx;
 		};
 		struct {	/* fill_recxs && type == S||R */
@@ -601,7 +601,7 @@ struct dss_enum_unpack_io {
 	int	       *ui_recxs_caps;
 	daos_epoch_t	ui_dkey_eph;
 	daos_epoch_t   *ui_akey_ephs;
-	daos_sg_list_t *ui_sgls;	/**< optional */
+	d_sg_list_t *ui_sgls;	/**< optional */
 	uint32_t	ui_version;
 };
 

--- a/src/include/daos_srv/iv.h
+++ b/src/include/daos_srv/iv.h
@@ -279,11 +279,11 @@ int ds_iv_invalidate(struct ds_iv_ns *ns, struct ds_iv_key *key,
 		     unsigned int sync_flags);
 
 int ds_iv_ns_create(crt_context_t ctx, uuid_t pool_uuid, crt_group_t *grp,
-		    unsigned int *ns_id, daos_iov_t *g_ivns,
+		    unsigned int *ns_id, d_iov_t *g_ivns,
 		    struct ds_iv_ns **p_iv_ns);
 
 int ds_iv_ns_attach(crt_context_t ctx, uuid_t pool_uuid, unsigned int ns_id,
-		    unsigned int master_rank, daos_iov_t *iv_ctxt,
+		    unsigned int master_rank, d_iov_t *iv_ctxt,
 		    struct ds_iv_ns **p_iv_ns);
 int ds_iv_ns_update(uuid_t pool_uuid, unsigned int master_rank,
 		    crt_group_t *grp, d_iov_t *iv_iov, unsigned int iv_ns_id,

--- a/src/include/daos_srv/rdb.h
+++ b/src/include/daos_srv/rdb.h
@@ -169,29 +169,29 @@ int rdb_remove_replicas(struct rdb *db, d_rank_list_t *replicas);
  * A path is a list of keys. An absolute path begins with a special key
  * (rdb_path_root_key) representing the root KVS.
  */
-typedef daos_iov_t rdb_path_t;
+typedef d_iov_t rdb_path_t;
 
 /**
  * Root key (opaque)
  *
  * A special key representing the root KVS in a path.
  */
-extern daos_iov_t rdb_path_root_key;
+extern d_iov_t rdb_path_root_key;
 
 /** Path methods */
 int rdb_path_init(rdb_path_t *path);
 void rdb_path_fini(rdb_path_t *path);
 int rdb_path_clone(const rdb_path_t *path, rdb_path_t *new_path);
-int rdb_path_push(rdb_path_t *path, const daos_iov_t *key);
+int rdb_path_push(rdb_path_t *path, const d_iov_t *key);
 
 /**
- * Define a daos_iov_t object, named \a prefix + \a name, that represents a
+ * Define a d_iov_t object, named \a prefix + \a name, that represents a
  * constant string key. See rdb_layout.[ch] for an example of the usage of this
  * helper macro.
  */
 #define RDB_STRING_KEY(prefix, name)					\
 static char	prefix ## name ## _buf[] = #name;			\
-daos_iov_t	prefix ## name = {					\
+d_iov_t	prefix ## name = {					\
 	.iov_buf	= prefix ## name ## _buf,			\
 	.iov_buf_len	= sizeof(prefix ## name ## _buf),		\
 	.iov_len	= sizeof(prefix ## name ## _buf)		\
@@ -235,13 +235,13 @@ void rdb_tx_end(struct rdb_tx *tx);
 int rdb_tx_create_root(struct rdb_tx *tx, const struct rdb_kvs_attr *attr);
 int rdb_tx_destroy_root(struct rdb_tx *tx);
 int rdb_tx_create_kvs(struct rdb_tx *tx, const rdb_path_t *parent,
-		      const daos_iov_t *key, const struct rdb_kvs_attr *attr);
+		      const d_iov_t *key, const struct rdb_kvs_attr *attr);
 int rdb_tx_destroy_kvs(struct rdb_tx *tx, const rdb_path_t *parent,
-		       const daos_iov_t *key);
+		       const d_iov_t *key);
 int rdb_tx_update(struct rdb_tx *tx, const rdb_path_t *kvs,
-		  const daos_iov_t *key, const daos_iov_t *value);
+		  const d_iov_t *key, const d_iov_t *value);
 int rdb_tx_delete(struct rdb_tx *tx, const rdb_path_t *kvs,
-		  const daos_iov_t *key);
+		  const d_iov_t *key);
 
 /** Probe operation codes */
 enum rdb_probe_opc {
@@ -260,15 +260,15 @@ enum rdb_probe_opc {
  *   - if rc == 1, rdb_tx_iterate() stops and returns 0;
  *   - otherwise, rdb_tx_iterate() stops and returns rc.
  */
-typedef int (*rdb_iterate_cb_t)(daos_handle_t ih, daos_iov_t *key,
-				daos_iov_t *val, void *arg);
+typedef int (*rdb_iterate_cb_t)(daos_handle_t ih, d_iov_t *key,
+				d_iov_t *val, void *arg);
 
 /** TX query methods */
 int rdb_tx_lookup(struct rdb_tx *tx, const rdb_path_t *kvs,
-		  const daos_iov_t *key, daos_iov_t *value);
+		  const d_iov_t *key, d_iov_t *value);
 int rdb_tx_fetch(struct rdb_tx *tx, const rdb_path_t *kvs,
-		 enum rdb_probe_opc opc, const daos_iov_t *key_in,
-		 daos_iov_t *key_out, daos_iov_t *value);
+		 enum rdb_probe_opc opc, const d_iov_t *key_in,
+		 d_iov_t *key_out, d_iov_t *value);
 int rdb_tx_iterate(struct rdb_tx *tx, const rdb_path_t *kvs, bool backward,
 		   rdb_iterate_cb_t cb, void *arg);
 

--- a/src/include/daos_srv/rsvc.h
+++ b/src/include/daos_srv/rsvc.h
@@ -51,25 +51,25 @@ struct ds_rsvc_class {
 	 * Name the service identified by the generic \a id. The returned name
 	 * string will later be passed to D_FREE.
 	 */
-	int (*sc_name)(daos_iov_t *id, char **name);
+	int (*sc_name)(d_iov_t *id, char **name);
 
 	/** Retrieve the stored UUID of the service database. */
-	int (*sc_load_uuid)(daos_iov_t *id, uuid_t db_uuid);
+	int (*sc_load_uuid)(d_iov_t *id, uuid_t db_uuid);
 
 	/** Store the UUID of the service database. */
-	int (*sc_store_uuid)(daos_iov_t *id, uuid_t db_uuid);
+	int (*sc_store_uuid)(d_iov_t *id, uuid_t db_uuid);
 
 	/** Delete the stored UUID of the service database. */
-	int (*sc_delete_uuid)(daos_iov_t *id);
+	int (*sc_delete_uuid)(d_iov_t *id);
 
 	/**
 	 * Locate the DB of the service identified by \a id. The returned DB
 	 * path will later be passed to D_FREE.
 	 */
-	int (*sc_locate)(daos_iov_t *id, char **path);
+	int (*sc_locate)(d_iov_t *id, char **path);
 
 	/** Allocate a ds_rsvc object and initialize its s_id member. */
-	int (*sc_alloc)(daos_iov_t *id, struct ds_rsvc **svc);
+	int (*sc_alloc)(d_iov_t *id, struct ds_rsvc **svc);
 
 	/**
 	 * Free the ds_rsvc object, after finalizing its s_id member (if
@@ -116,7 +116,7 @@ enum ds_rsvc_state {
 struct ds_rsvc {
 	d_list_t		s_entry;	/* in rsvc_hash */
 	enum ds_rsvc_class_id	s_class;
-	daos_iov_t		s_id;		/**< for lookups */
+	d_iov_t		s_id;		/**< for lookups */
 	char		       *s_name;		/**< for printing */
 	struct rdb	       *s_db;		/**< DB handle */
 	char		       *s_db_path;
@@ -131,20 +131,20 @@ struct ds_rsvc {
 	ABT_cond		s_leader_ref_cv;
 };
 
-int ds_rsvc_start(enum ds_rsvc_class_id class, daos_iov_t *id, uuid_t db_uuid,
+int ds_rsvc_start(enum ds_rsvc_class_id class, d_iov_t *id, uuid_t db_uuid,
 		  bool create, size_t size, d_rank_list_t *replicas, void *arg);
-int ds_rsvc_stop(enum ds_rsvc_class_id class, daos_iov_t *id, bool destroy);
+int ds_rsvc_stop(enum ds_rsvc_class_id class, d_iov_t *id, bool destroy);
 int ds_rsvc_stop_all(enum ds_rsvc_class_id class);
-int ds_rsvc_stop_leader(enum ds_rsvc_class_id class, daos_iov_t *id,
+int ds_rsvc_stop_leader(enum ds_rsvc_class_id class, d_iov_t *id,
 			struct rsvc_hint *hint);
-int ds_rsvc_dist_start(enum ds_rsvc_class_id class, daos_iov_t *id,
+int ds_rsvc_dist_start(enum ds_rsvc_class_id class, d_iov_t *id,
 		       const uuid_t dbid, const d_rank_list_t *ranks,
 		       bool create, bool bootstrap, size_t size);
-int ds_rsvc_dist_stop(enum ds_rsvc_class_id class, daos_iov_t *id,
+int ds_rsvc_dist_stop(enum ds_rsvc_class_id class, d_iov_t *id,
 		      const d_rank_list_t *ranks, bool destroy);
-int ds_rsvc_lookup(enum ds_rsvc_class_id class, daos_iov_t *id,
+int ds_rsvc_lookup(enum ds_rsvc_class_id class, d_iov_t *id,
 		   struct ds_rsvc **svc);
-int ds_rsvc_lookup_leader(enum ds_rsvc_class_id class, daos_iov_t *id,
+int ds_rsvc_lookup_leader(enum ds_rsvc_class_id class, d_iov_t *id,
 			  struct ds_rsvc **svcp, struct rsvc_hint *hint);
 void ds_rsvc_put(struct ds_rsvc *svc);
 void ds_rsvc_put_leader(struct ds_rsvc *svc);

--- a/src/include/daos_srv/vos.h
+++ b/src/include/daos_srv/vos.h
@@ -425,7 +425,7 @@ vos_discard(daos_handle_t coh, daos_epoch_range_t *epr);
 int
 vos_obj_fetch(daos_handle_t coh, daos_unit_oid_t oid, daos_epoch_t epoch,
 	      daos_key_t *dkey, unsigned int iod_nr, daos_iod_t *iods,
-	      daos_sg_list_t *sgls);
+	      d_sg_list_t *sgls);
 
 
 /**
@@ -455,7 +455,7 @@ vos_obj_fetch(daos_handle_t coh, daos_unit_oid_t oid, daos_epoch_t epoch,
 int
 vos_obj_update(daos_handle_t coh, daos_unit_oid_t oid, daos_epoch_t epoch,
 	       uint32_t pm_ver, daos_key_t *dkey, unsigned int iod_nr,
-	       daos_iod_t *iods, daos_sg_list_t *sgls);
+	       daos_iod_t *iods, d_sg_list_t *sgls);
 
 /**
  * Punch an object, or punch a dkey, or punch an array of akeys under a akey.
@@ -709,7 +709,7 @@ vos_iter_fetch(daos_handle_t ih, vos_iter_entry_t *entry,
  */
 int
 vos_iter_copy(daos_handle_t ih, vos_iter_entry_t *entry,
-	      daos_iov_t *iov_out);
+	      d_iov_t *iov_out);
 
 /**
  * Delete the current data entry of the iterator

--- a/src/include/daos_task.h
+++ b/src/include/daos_task.h
@@ -422,7 +422,7 @@ typedef struct {
 	daos_key_t		*dkey;
 	unsigned int		nr;
 	daos_iod_t		*iods;
-	daos_sg_list_t		*sgls;
+	d_sg_list_t		*sgls;
 	daos_iom_t		*maps;
 } daos_obj_fetch_t;
 
@@ -432,7 +432,7 @@ typedef struct {
 	daos_key_t		*dkey;
 	unsigned int		nr;
 	daos_iod_t		*iods;
-	daos_sg_list_t		*sgls;
+	d_sg_list_t		*sgls;
 } daos_obj_update_t;
 
 typedef struct {
@@ -440,7 +440,7 @@ typedef struct {
 	daos_handle_t		th;
 	uint32_t		*nr;
 	daos_key_desc_t		*kds;
-	daos_sg_list_t		*sgl;
+	d_sg_list_t		*sgl;
 	daos_anchor_t		*anchor;
 } daos_obj_list_dkey_t;
 
@@ -450,7 +450,7 @@ typedef struct {
 	daos_key_t		*dkey;
 	uint32_t		*nr;
 	daos_key_desc_t		*kds;
-	daos_sg_list_t		*sgl;
+	d_sg_list_t		*sgl;
 	daos_anchor_t		*anchor;
 } daos_obj_list_akey_t;
 
@@ -484,7 +484,7 @@ typedef struct {
 					 */
 	daos_key_desc_t		*kds;
 	daos_epoch_range_t	*eprs;
-	daos_sg_list_t		*sgl;
+	d_sg_list_t		*sgl;
 	daos_anchor_t		*anchor;
 	daos_anchor_t		*dkey_anchor;
 	daos_anchor_t		*akey_anchor;
@@ -519,7 +519,7 @@ typedef struct {
 	daos_handle_t		oh;
 	daos_handle_t		th;
 	daos_array_iod_t	*iod;
-	daos_sg_list_t		*sgl;
+	d_sg_list_t		*sgl;
 	daos_csum_buf_t		*csums;
 } daos_array_io_t;
 
@@ -567,7 +567,7 @@ typedef struct {
 	daos_handle_t		th;
 	uint32_t		*nr;
 	daos_key_desc_t		*kds;
-	daos_sg_list_t		*sgl;
+	d_sg_list_t		*sgl;
 	daos_anchor_t		*anchor;
 } daos_kv_list_t;
 

--- a/src/include/daos_types.h
+++ b/src/include/daos_types.h
@@ -46,12 +46,6 @@ extern "C" {
 /** Maximum length (excluding the '\0') of a DAOS system name */
 #define DAOS_SYS_NAME_MAX 15
 
-/** Scatter/gather list for memory buffers */
-#define daos_sg_list_t d_sg_list_t
-
-/** free function for d_rank_list_t */
-#define daos_rank_list_free d_rank_list_free
-
 /**
  * Generic data type definition
  */
@@ -59,17 +53,9 @@ extern "C" {
 typedef uint64_t	daos_size_t;
 typedef uint64_t	daos_off_t;
 
-#define daos_iov_t		d_iov_t
 #define crt_proc_daos_key_t	crt_proc_d_iov_t
 #define crt_proc_daos_size_t	crt_proc_uint64_t
 #define crt_proc_daos_epoch_t	crt_proc_uint64_t
-
-static inline void
-daos_iov_set(daos_iov_t *iov, void *buf, daos_size_t size)
-{
-	iov->iov_buf = buf;
-	iov->iov_len = iov->iov_buf_len = size;
-}
 
 /** size of SHA-256 */
 #define DAOS_HKEY_MAX	32
@@ -645,7 +631,7 @@ typedef struct {
 } daos_obj_attr_t;
 
 /** key type */
-typedef daos_iov_t daos_key_t;
+typedef d_iov_t daos_key_t;
 
 /**
  * Record

--- a/src/iosrv/obj.c
+++ b/src/iosrv/obj.c
@@ -119,7 +119,7 @@ tx_close_cb(tse_task_t *task, void *data)
 
 int
 ds_obj_list_akey(daos_handle_t oh, daos_epoch_t epoch, daos_key_t *dkey,
-		 uint32_t *nr, daos_key_desc_t *kds, daos_sg_list_t *sgl,
+		 uint32_t *nr, daos_key_desc_t *kds, d_sg_list_t *sgl,
 		 daos_anchor_t *anchor)
 {
 	tse_task_t	*task;
@@ -149,7 +149,7 @@ ds_obj_list_akey(daos_handle_t oh, daos_epoch_t epoch, daos_key_t *dkey,
 int
 ds_obj_fetch(daos_handle_t oh, daos_epoch_t epoch,
 	     daos_key_t *dkey, unsigned int nr,
-	     daos_iod_t *iods, daos_sg_list_t *sgls,
+	     daos_iod_t *iods, d_sg_list_t *sgls,
 	     daos_iom_t *maps)
 {
 	tse_task_t	*task;

--- a/src/iosrv/server_iv.c
+++ b/src/iosrv/server_iv.c
@@ -563,7 +563,7 @@ ivc_on_put(crt_iv_namespace_t ivns, d_sg_list_t *iv_value, void *priv)
 
 	/* Let's deal with iv_value first */
 	if (iv_value != NULL)
-		daos_sgl_fini((daos_sg_list_t *)iv_value, false);
+		daos_sgl_fini((d_sg_list_t *)iv_value, false);
 
 	rc = entry->iv_class->iv_class_ops->ivc_ent_put(entry,
 							priv_entry->priv);
@@ -715,7 +715,7 @@ free:
 
 int
 ds_iv_ns_attach(crt_context_t ctx, uuid_t pool_uuid, unsigned int ns_id,
-		unsigned int master_rank, daos_iov_t *iv_ctxt,
+		unsigned int master_rank, d_iov_t *iv_ctxt,
 		struct ds_iv_ns **p_iv_ns)
 {
 	struct ds_iv_ns	*ns = NULL;

--- a/src/mgmt/srv_layout.h
+++ b/src/mgmt/srv_layout.h
@@ -34,10 +34,10 @@
 #include <daos_types.h>
 
 /* Root KVS (RDB_KVS_GENERIC) */
-extern daos_iov_t ds_mgmt_prop_servers;		/* server KVS */
-extern daos_iov_t ds_mgmt_prop_uuids;		/* UUID KVS */
-extern daos_iov_t ds_mgmt_prop_map_version;	/* uint32_t */
-extern daos_iov_t ds_mgmt_prop_rank_next;	/* uint32_t */
+extern d_iov_t ds_mgmt_prop_servers;		/* server KVS */
+extern d_iov_t ds_mgmt_prop_uuids;		/* UUID KVS */
+extern d_iov_t ds_mgmt_prop_map_version;	/* uint32_t */
+extern d_iov_t ds_mgmt_prop_rank_next;	/* uint32_t */
 
 /*
  * Server KVS (RDB_KVS_INTEGER)

--- a/src/object/cli_obj.c
+++ b/src/object/cli_obj.c
@@ -1015,7 +1015,7 @@ struct shard_update_args {
 	uint64_t		 dkey_hash;
 	unsigned int		 nr;
 	daos_iod_t		*iods;
-	daos_sg_list_t		*sgls;
+	d_sg_list_t		*sgls;
 };
 
 static int
@@ -1180,7 +1180,7 @@ obj_recx_valid(unsigned int nr, daos_recx_t *recxs, bool update)
 {
 	struct umem_attr	uma;
 	daos_handle_t		bth;
-	daos_iov_t		key;
+	d_iov_t		key;
 	int			idx;
 	bool			overlapped;
 	struct btr_root		broot = { 0 };
@@ -1217,7 +1217,7 @@ obj_recx_valid(unsigned int nr, daos_recx_t *recxs, bool update)
 
 		overlapped = false;
 		for (idx = 0; idx < nr; idx++) {
-			daos_iov_set(&key, &recxs[idx], sizeof(daos_recx_t));
+			d_iov_set(&key, &recxs[idx], sizeof(daos_recx_t));
 			rc = dbtree_update(bth, &key, NULL);
 			if (rc != 0) {
 				overlapped = true;
@@ -1654,7 +1654,7 @@ dc_obj_list_internal(daos_handle_t oh, uint32_t op, daos_handle_t th,
 		     daos_key_t *dkey, daos_key_t *akey,
 		     daos_iod_type_t type, daos_size_t *size,
 		     uint32_t *nr, daos_key_desc_t *kds,
-		     daos_sg_list_t *sgl, daos_recx_t *recxs,
+		     d_sg_list_t *sgl, daos_recx_t *recxs,
 		     daos_epoch_range_t *eprs, daos_anchor_t *anchor,
 		     daos_anchor_t *dkey_anchor, daos_anchor_t *akey_anchor,
 		     bool incr_order, tse_task_t *task)

--- a/src/object/cli_shard.c
+++ b/src/object/cli_shard.c
@@ -136,7 +136,7 @@ obj_shard_rw_bulk_fini(crt_rpc_t *rpc)
 struct obj_rw_args {
 	crt_rpc_t		*rpc;
 	daos_handle_t		*hdlp;
-	daos_sg_list_t		*rwaa_sgls;
+	d_sg_list_t		*rwaa_sgls;
 	struct dc_obj_shard	*dobj;
 	unsigned int		*map_ver;
 };
@@ -219,7 +219,7 @@ dc_rw_cb(tse_task_t *task, void *arg)
 						     orwo->orw_sgls.ca_count);
 		} else if (rw_args->rwaa_sgls != NULL) {
 			/* for bulk transfer it needs to update sg_nr_out */
-			daos_sg_list_t	*sgls = rw_args->rwaa_sgls;
+			d_sg_list_t	*sgls = rw_args->rwaa_sgls;
 			d_iov_t		*iov;
 			uint32_t	*nrs;
 			uint32_t	 nrs_count;
@@ -280,7 +280,7 @@ out:
 }
 
 static int
-obj_shard_rw_bulk_prep(crt_rpc_t *rpc, unsigned int nr, daos_sg_list_t *sgls,
+obj_shard_rw_bulk_prep(crt_rpc_t *rpc, unsigned int nr, d_sg_list_t *sgls,
 		       bool forward, tse_task_t *task)
 {
 	struct obj_rw_in	*orw;
@@ -301,8 +301,7 @@ obj_shard_rw_bulk_prep(crt_rpc_t *rpc, unsigned int nr, daos_sg_list_t *sgls,
 	for (i = 0; i < nr; i++) {
 		if (sgls != NULL && sgls[i].sg_iovs != NULL &&
 		    sgls[i].sg_iovs[0].iov_buf != NULL) {
-			rc = crt_bulk_create(daos_task2ctx(task),
-					     daos2crt_sg(&sgls[i]),
+			rc = crt_bulk_create(daos_task2ctx(task), &sgls[i],
 					     bulk_perm, &bulks[i]);
 			if (rc < 0) {
 				int j;
@@ -346,7 +345,7 @@ obj_shard_ptr2pool(struct dc_obj_shard *shard)
 static int
 obj_shard_rw(struct dc_obj_shard *shard, enum obj_rpc_opc opc,
 	     daos_epoch_t epoch, daos_key_t *dkey, unsigned int nr,
-	     daos_iod_t *iods, daos_sg_list_t *sgls, unsigned int *map_ver,
+	     daos_iod_t *iods, d_sg_list_t *sgls, unsigned int *map_ver,
 	     struct daos_obj_shard_tgt *fw_shard_tgts, uint32_t fw_cnt,
 	     tse_task_t *task, struct dtx_id *dti, uint32_t flags)
 {
@@ -618,7 +617,7 @@ out:
 int
 dc_obj_shard_update(struct dc_obj_shard *shard, daos_epoch_t epoch,
 		    daos_key_t *dkey, unsigned int nr, daos_iod_t *iods,
-		    daos_sg_list_t *sgls, unsigned int *map_ver,
+		    d_sg_list_t *sgls, unsigned int *map_ver,
 		    struct daos_obj_shard_tgt *fw_shard_tgts, uint32_t fw_cnt,
 		    tse_task_t *task, struct dtx_id *dti, uint32_t flags)
 {
@@ -630,7 +629,7 @@ dc_obj_shard_update(struct dc_obj_shard *shard, daos_epoch_t epoch,
 int
 dc_obj_shard_fetch(struct dc_obj_shard *shard, daos_epoch_t epoch,
 		   daos_key_t *dkey,  unsigned int nr, daos_iod_t *iods,
-		   daos_sg_list_t *sgls, daos_iom_t *maps,
+		   d_sg_list_t *sgls, daos_iom_t *maps,
 		   unsigned int *map_ver, tse_task_t *task)
 {
 	return obj_shard_rw(shard, DAOS_OBJ_RPC_FETCH, epoch, dkey,
@@ -646,7 +645,7 @@ struct obj_enum_args {
 	daos_anchor_t		*eaa_dkey_anchor;
 	daos_anchor_t		*eaa_akey_anchor;
 	struct dc_obj_shard	*eaa_obj;
-	daos_sg_list_t		*eaa_sgl;
+	d_sg_list_t		*eaa_sgl;
 	daos_recx_t		*eaa_recxs;
 	daos_epoch_range_t	*eaa_eprs;
 	daos_size_t		*eaa_size;
@@ -759,7 +758,7 @@ int
 dc_obj_shard_list(struct dc_obj_shard *obj_shard, unsigned int opc,
 		  daos_epoch_t epoch, daos_key_t *dkey, daos_key_t *akey,
 		  daos_iod_type_t type, daos_size_t *size, uint32_t *nr,
-		  daos_key_desc_t *kds, daos_sg_list_t *sgl,
+		  daos_key_desc_t *kds, d_sg_list_t *sgl,
 		  daos_recx_t *recxs, daos_epoch_range_t *eprs,
 		  daos_anchor_t *anchor, daos_anchor_t *dkey_anchor,
 		  daos_anchor_t *akey_anchor, unsigned int *map_ver,
@@ -828,7 +827,7 @@ dc_obj_shard_list(struct dc_obj_shard *obj_shard, unsigned int opc,
 		if (sgl_size >= OBJ_BULK_LIMIT) {
 			/* Create bulk */
 			rc = crt_bulk_create(daos_task2ctx(task),
-					     daos2crt_sg(sgl), CRT_BULK_RW,
+					     sgl, CRT_BULK_RW,
 					     &oei->oei_bulk);
 			if (rc < 0)
 				D_GOTO(out_req, rc);
@@ -836,7 +835,7 @@ dc_obj_shard_list(struct dc_obj_shard *obj_shard, unsigned int opc,
 	}
 
 	if (*nr > KDS_BULK_LIMIT) {
-		daos_sg_list_t	tmp_sgl = { 0 };
+		d_sg_list_t	tmp_sgl = { 0 };
 		d_iov_t		tmp_iov = { 0 };
 
 		tmp_iov.iov_buf_len = sizeof(*kds) * (*nr);
@@ -846,7 +845,7 @@ dc_obj_shard_list(struct dc_obj_shard *obj_shard, unsigned int opc,
 		tmp_sgl.sg_iovs = &tmp_iov;
 
 		rc = crt_bulk_create(daos_task2ctx(task),
-				     daos2crt_sg(&tmp_sgl), CRT_BULK_RW,
+				     &tmp_sgl, CRT_BULK_RW,
 				     &oei->oei_kds_bulk);
 		if (rc < 0)
 			D_GOTO(out_req, rc);

--- a/src/object/obj_class.c
+++ b/src/object/obj_class.c
@@ -508,7 +508,7 @@ obj_ec_codec_get(daos_oclass_id_t oc_id)
  * p_idx	[IN]		Index into parity p_bufs array.
  */
 int
-obj_encode_full_stripe(daos_obj_id_t oid, daos_sg_list_t *sgl, uint32_t *sg_idx,
+obj_encode_full_stripe(daos_obj_id_t oid, d_sg_list_t *sgl, uint32_t *sg_idx,
 		       size_t *sg_off, struct obj_ec_parity *parity, int p_idx)
 {
 	struct obj_ec_codec		*codec = obj_ec_codec_get(

--- a/src/object/obj_internal.h
+++ b/src/object/obj_internal.h
@@ -168,14 +168,14 @@ void dc_obj_shard_close(struct dc_obj_shard *shard);
 struct daos_obj_shard_tgt;
 int dc_obj_shard_update(struct dc_obj_shard *shard, daos_epoch_t epoch,
 			daos_key_t *dkey, unsigned int nr,
-			daos_iod_t *iods, daos_sg_list_t *sgls,
+			daos_iod_t *iods, d_sg_list_t *sgls,
 			unsigned int *map_ver, struct daos_obj_shard_tgt *tgts,
 			uint32_t fw_cnt, tse_task_t *task,
 			struct dtx_id *dti, uint32_t flags);
 
 int dc_obj_shard_fetch(struct dc_obj_shard *shard, daos_epoch_t epoch,
 		       daos_key_t *dkey, unsigned int nr,
-		       daos_iod_t *iods, daos_sg_list_t *sgls,
+		       daos_iod_t *iods, d_sg_list_t *sgls,
 		       daos_iom_t *maps, unsigned int *map_ver,
 		       tse_task_t *task);
 
@@ -183,7 +183,7 @@ int
 dc_obj_shard_list(struct dc_obj_shard *obj_shard, unsigned int opc,
 		  daos_epoch_t epoch, daos_key_t *dkey, daos_key_t *akey,
 		  daos_iod_type_t type, daos_size_t *size, uint32_t *nr,
-		  daos_key_desc_t *kds, daos_sg_list_t *sgl,
+		  daos_key_desc_t *kds, d_sg_list_t *sgl,
 		  daos_recx_t *recxs, daos_epoch_range_t *eprs,
 		  daos_anchor_t *anchor, daos_anchor_t  *dkey_anchor,
 		  daos_anchor_t  *akey_anchor, unsigned int *map_ver,
@@ -250,7 +250,7 @@ obj_dkey2hash(daos_key_t *dkey)
 int obj_ec_codec_init(void);
 void obj_ec_codec_fini(void);
 struct obj_ec_codec *obj_ec_codec_get(daos_oclass_id_t oc_id);
-int obj_encode_full_stripe(daos_obj_id_t oid, daos_sg_list_t *sgl,
+int obj_encode_full_stripe(daos_obj_id_t oid, d_sg_list_t *sgl,
 			   uint32_t *sg_idx, size_t *sg_off,
 			   struct obj_ec_parity *parity, int p_idx);
 

--- a/src/object/obj_rpc.h
+++ b/src/object/obj_rpc.h
@@ -129,7 +129,7 @@ struct daos_obj_shard_tgt {
 	((daos_key_t)		(orw_dkey)		CRT_VAR) \
 	((struct dtx_id)	(orw_dti_cos)		CRT_ARRAY) \
 	((daos_iod_t)		(orw_iods)		CRT_ARRAY) \
-	((daos_sg_list_t)	(orw_sgls)		CRT_ARRAY) \
+	((d_sg_list_t)	(orw_sgls)		CRT_ARRAY) \
 	((crt_bulk_t)		(orw_bulks)		CRT_ARRAY) \
 	((struct daos_obj_shard_tgt) (orw_shard_tgts)	CRT_ARRAY) \
 	((uint32_t)		(orw_flags)		CRT_VAR)
@@ -142,7 +142,7 @@ struct daos_obj_shard_tgt {
 	((struct dtx_id)	(orw_dti_conflict)	CRT_VAR) \
 	((daos_size_t)		(orw_sizes)		CRT_ARRAY) \
 	((uint32_t)		(orw_nrs)		CRT_ARRAY) \
-	((daos_sg_list_t)	(orw_sgls)		CRT_ARRAY)
+	((d_sg_list_t)	(orw_sgls)		CRT_ARRAY)
 
 CRT_RPC_DECLARE(obj_rw, DAOS_ISEQ_OBJ_RW, DAOS_OSEQ_OBJ_RW)
 CRT_RPC_DECLARE(obj_update, DAOS_ISEQ_OBJ_RW, DAOS_OSEQ_OBJ_RW)
@@ -163,7 +163,7 @@ CRT_RPC_DECLARE(obj_fetch, DAOS_ISEQ_OBJ_RW, DAOS_OSEQ_OBJ_RW)
 	((daos_anchor_t)	(oei_anchor)		CRT_VAR) \
 	((daos_anchor_t)	(oei_dkey_anchor)	CRT_VAR) \
 	((daos_anchor_t)	(oei_akey_anchor)	CRT_VAR) \
-	((daos_sg_list_t)	(oei_sgl)		CRT_VAR) \
+	((d_sg_list_t)	(oei_sgl)		CRT_VAR) \
 	((crt_bulk_t)		(oei_bulk)		CRT_VAR) \
 	((crt_bulk_t)		(oei_kds_bulk)		CRT_VAR)
 
@@ -177,7 +177,7 @@ CRT_RPC_DECLARE(obj_fetch, DAOS_ISEQ_OBJ_RW, DAOS_OSEQ_OBJ_RW)
 	((daos_anchor_t)	(oeo_dkey_anchor)	CRT_VAR) \
 	((daos_anchor_t)	(oeo_akey_anchor)	CRT_VAR) \
 	((daos_key_desc_t)	(oeo_kds)		CRT_ARRAY) \
-	((daos_sg_list_t)	(oeo_sgl)		CRT_VAR) \
+	((d_sg_list_t)	(oeo_sgl)		CRT_VAR) \
 	((daos_recx_t)		(oeo_recxs)		CRT_ARRAY) \
 	((daos_epoch_range_t)	(oeo_eprs)		CRT_ARRAY)
 
@@ -193,8 +193,8 @@ CRT_RPC_DECLARE(obj_key_enum, DAOS_ISEQ_OBJ_KEY_ENUM, DAOS_OSEQ_OBJ_KEY_ENUM)
 	((uint32_t)		(opi_map_ver)		CRT_VAR) \
 	((uint32_t)		(opi_flags)		CRT_VAR) \
 	((struct dtx_id)	(opi_dti_cos)		CRT_ARRAY) \
-	((daos_iov_t)		(opi_dkeys)		CRT_ARRAY) \
-	((daos_iov_t)		(opi_akeys)		CRT_ARRAY) \
+	((d_iov_t)		(opi_dkeys)		CRT_ARRAY) \
+	((d_iov_t)		(opi_akeys)		CRT_ARRAY) \
 	((struct daos_obj_shard_tgt) (opi_shard_tgts)	CRT_ARRAY)
 
 #define DAOS_OSEQ_OBJ_PUNCH	/* output fields */		 \

--- a/src/object/obj_task.c
+++ b/src/object/obj_task.c
@@ -169,7 +169,7 @@ dc_obj_query_key_task_create(daos_handle_t oh, daos_handle_t th,
 int
 dc_obj_fetch_task_create(daos_handle_t oh, daos_handle_t th,
 			 daos_key_t *dkey, unsigned int nr,
-			 daos_iod_t *iods, daos_sg_list_t *sgls,
+			 daos_iod_t *iods, d_sg_list_t *sgls,
 			 daos_iom_t *maps, daos_event_t *ev,
 			 tse_sched_t *tse, tse_task_t **task)
 {
@@ -196,7 +196,7 @@ dc_obj_fetch_task_create(daos_handle_t oh, daos_handle_t th,
 int
 dc_obj_update_task_create(daos_handle_t oh, daos_handle_t th,
 			  daos_key_t *dkey, unsigned int nr,
-			  daos_iod_t *iods, daos_sg_list_t *sgls,
+			  daos_iod_t *iods, d_sg_list_t *sgls,
 			  daos_event_t *ev, tse_sched_t *tse,
 			  tse_task_t **task)
 {
@@ -221,7 +221,7 @@ dc_obj_update_task_create(daos_handle_t oh, daos_handle_t th,
 
 int
 dc_obj_list_dkey_task_create(daos_handle_t oh, daos_handle_t th, uint32_t *nr,
-			     daos_key_desc_t *kds, daos_sg_list_t *sgl,
+			     daos_key_desc_t *kds, d_sg_list_t *sgl,
 			     daos_anchor_t *anchor, daos_event_t *ev,
 			     tse_sched_t *tse, tse_task_t **task)
 {
@@ -247,7 +247,7 @@ dc_obj_list_dkey_task_create(daos_handle_t oh, daos_handle_t th, uint32_t *nr,
 int
 dc_obj_list_akey_task_create(daos_handle_t oh, daos_handle_t th,
 			     daos_key_t *dkey, uint32_t *nr,
-			     daos_key_desc_t *kds, daos_sg_list_t *sgl,
+			     daos_key_desc_t *kds, d_sg_list_t *sgl,
 			     daos_anchor_t *anchor, daos_event_t *ev,
 			     tse_sched_t *tse, tse_task_t **task)
 {
@@ -310,7 +310,7 @@ dc_obj_list_obj_task_create(daos_handle_t oh, daos_handle_t th,
 			    daos_key_t *dkey, daos_key_t *akey,
 			    daos_size_t *size, uint32_t *nr,
 			    daos_key_desc_t *kds, daos_epoch_range_t *eprs,
-			    daos_sg_list_t *sgl, daos_anchor_t *anchor,
+			    d_sg_list_t *sgl, daos_anchor_t *anchor,
 			    daos_anchor_t *dkey_anchor,
 			    daos_anchor_t *akey_anchor,
 			    bool incr_order, daos_event_t *ev, tse_sched_t *tse,

--- a/src/object/srv_obj.c
+++ b/src/object/srv_obj.c
@@ -174,7 +174,7 @@ bulk_complete_cb(const struct crt_bulk_cb_info *cb_info)
  * Simulate bulk transfer by memcpy, all data are actually dropped.
  */
 static void
-bulk_bypass(daos_sg_list_t *sgl, crt_bulk_op_t bulk_op)
+bulk_bypass(d_sg_list_t *sgl, crt_bulk_op_t bulk_op)
 {
 	static const int  dummy_buf_len = 4096;
 	static char	 *dummy_buf;
@@ -212,7 +212,7 @@ bulk_bypass(daos_sg_list_t *sgl, crt_bulk_op_t bulk_op)
 static int
 ds_bulk_transfer(crt_rpc_t *rpc, crt_bulk_op_t bulk_op, bool bulk_bind,
 		 crt_bulk_t *remote_bulks, daos_handle_t ioh,
-		 daos_sg_list_t **sgls, int sgl_nr)
+		 d_sg_list_t **sgls, int sgl_nr)
 {
 	struct ds_bulk_async_args arg = { 0 };
 	crt_bulk_opid_t		bulk_opid;
@@ -227,7 +227,7 @@ ds_bulk_transfer(crt_rpc_t *rpc, crt_bulk_op_t bulk_op, bool bulk_bind,
 	D_DEBUG(DB_IO, "bulk_op:%d sgl_nr%d\n", bulk_op, sgl_nr);
 
 	for (i = 0; i < sgl_nr; i++) {
-		daos_sg_list_t		*sgl, tmp_sgl;
+		d_sg_list_t		*sgl, tmp_sgl;
 		struct crt_bulk_desc	 bulk_desc;
 		crt_bulk_t		 local_bulk_hdl;
 		daos_size_t		 offset = 0;
@@ -267,7 +267,7 @@ ds_bulk_transfer(crt_rpc_t *rpc, crt_bulk_op_t bulk_op, bool bulk_bind,
 		 * transfer to avoid touching the input buffer.
 		 */
 		while (idx < sgl->sg_nr_out) {
-			daos_sg_list_t	sgl_sent;
+			d_sg_list_t	sgl_sent;
 			daos_size_t	length = 0;
 			unsigned int	start;
 
@@ -296,8 +296,7 @@ ds_bulk_transfer(crt_rpc_t *rpc, crt_bulk_op_t bulk_op, bool bulk_bind,
 			sgl_sent.sg_nr = idx - start;
 			sgl_sent.sg_nr_out = idx - start;
 
-			rc = crt_bulk_create(rpc->cr_ctx,
-					     daos2crt_sg(&sgl_sent),
+			rc = crt_bulk_create(rpc->cr_ctx, &sgl_sent,
 					     bulk_perm, &local_bulk_hdl);
 			if (rc != 0) {
 				D_ERROR("crt_bulk_create %d error (%d).\n",
@@ -351,7 +350,7 @@ next:
 }
 
 static int
-ds_sgls_prep(daos_sg_list_t *dst_sgls, daos_sg_list_t *sgls, int number)
+ds_sgls_prep(d_sg_list_t *dst_sgls, d_sg_list_t *sgls, int number)
 {
 	int i;
 	int j;
@@ -415,7 +414,7 @@ ds_obj_update_sizes_in_reply(crt_rpc_t *rpc)
  */
 static int
 ds_obj_update_nrs_in_reply(crt_rpc_t *rpc, daos_handle_t ioh,
-			   daos_sg_list_t *sgls)
+			   d_sg_list_t *sgls)
 {
 	struct obj_rw_in	*orw = crt_req_get(rpc);
 	struct obj_rw_out	*orwo = crt_reply_get(rpc);
@@ -437,7 +436,7 @@ ds_obj_update_nrs_in_reply(crt_rpc_t *rpc, daos_handle_t ioh,
 	nrs = orwo->orw_nrs.ca_arrays;
 	for (i = 0; i < nrs_count; i++) {
 		struct bio_sglist	*bsgl;
-		daos_sg_list_t		*sgl;
+		d_sg_list_t		*sgl;
 
 		if (sgls != NULL) {
 			sgl = &sgls[i];
@@ -515,7 +514,7 @@ ds_obj_rw_echo_handler(crt_rpc_t *rpc)
 	struct obj_rw_out	*orwo = crt_reply_get(rpc);
 	struct obj_tls		*tls;
 	daos_iod_t		*iod;
-	daos_sg_list_t		*p_sgl;
+	d_sg_list_t		*p_sgl;
 	crt_bulk_op_t		bulk_op;
 	bool			bulk_bind;
 	int			i;
@@ -1197,8 +1196,8 @@ out:
 static int
 obj_enum_reply_bulk(crt_rpc_t *rpc)
 {
-	daos_sg_list_t	*sgls[2] = { 0 };
-	daos_sg_list_t  tmp_sgl;
+	d_sg_list_t	*sgls[2] = { 0 };
+	d_sg_list_t  tmp_sgl;
 	crt_bulk_t	bulks[2] = { 0 };
 	struct obj_key_enum_in	*oei;
 	struct obj_key_enum_out	*oeo;

--- a/src/pool/rpc.h
+++ b/src/pool/rpc.h
@@ -152,7 +152,7 @@ CRT_RPC_DECLARE(pool_create, DAOS_ISEQ_POOL_CREATE, DAOS_OSEQ_POOL_CREATE)
 
 #define DAOS_ISEQ_POOL_CONNECT	/* input fields */		 \
 	((struct pool_op_in)	(pci_op)		CRT_VAR) \
-	((daos_iov_t)		(pci_cred)		CRT_VAR) \
+	((d_iov_t)		(pci_cred)		CRT_VAR) \
 	((uint64_t)		(pci_capas)		CRT_VAR) \
 	((crt_bulk_t)		(pci_map_bulk)		CRT_VAR)
 
@@ -309,7 +309,7 @@ CRT_RPC_DECLARE(pool_svc_stop, DAOS_ISEQ_POOL_SVC_STOP, DAOS_OSEQ_POOL_SVC_STOP)
 	((uint32_t)		(tci_iv_ns_id)		CRT_VAR) \
 	((uint32_t)		(tci_master_rank)	CRT_VAR) \
 	((uint32_t)		(tci_pad)		CRT_VAR) \
-	((daos_iov_t)		(tci_iv_ctxt)		CRT_VAR)
+	((d_iov_t)		(tci_iv_ctxt)		CRT_VAR)
 
 #define DAOS_OSEQ_POOL_TGT_CONNECT /* output fields */		 \
 	((struct daos_pool_space) (tco_space)		CRT_VAR) \

--- a/src/pool/srv_iv.c
+++ b/src/pool/srv_iv.c
@@ -231,7 +231,7 @@ int
 pool_iv_fetch(void *ns, struct pool_iv_entry *pool_iv)
 {
 	d_sg_list_t		sgl = { 0 };
-	daos_iov_t		iov = { 0 };
+	d_iov_t		iov = { 0 };
 	uint32_t		pool_iv_len;
 	struct ds_iv_key	key;
 	int			rc;
@@ -241,7 +241,7 @@ pool_iv_fetch(void *ns, struct pool_iv_entry *pool_iv)
 	 */
 	if (pool_iv != NULL) {
 		pool_iv_len = pool_iv_ent_size(pool_iv->piv_pool_buf.pb_nr);
-		daos_iov_set(&iov, pool_iv, pool_iv_len);
+		d_iov_set(&iov, pool_iv, pool_iv_len);
 		sgl.sg_nr = 1;
 		sgl.sg_nr_out = 0;
 		sgl.sg_iovs = &iov;
@@ -261,7 +261,7 @@ pool_iv_update(void *ns, struct pool_iv_entry *pool_iv,
 	       unsigned int shortcut, unsigned int sync_mode)
 {
 	d_sg_list_t		sgl;
-	daos_iov_t		iov;
+	d_iov_t		iov;
 	uint32_t		pool_iv_len;
 	struct ds_iv_key	key;
 	int			rc;

--- a/src/pool/srv_layout.h
+++ b/src/pool/srv_layout.h
@@ -53,26 +53,26 @@
  *                       v       v     v      v      v
  *   ds_pool_prop_mode:  [padding][user][group][other]
  */
-extern daos_iov_t ds_pool_prop_uid;		/* uint32_t */
-extern daos_iov_t ds_pool_prop_gid;		/* uint32_t */
-extern daos_iov_t ds_pool_prop_mode;		/* uint32_t */
-extern daos_iov_t ds_pool_prop_map_version;	/* uint32_t */
-extern daos_iov_t ds_pool_prop_map_buffer;	/* pool_buf */
-extern daos_iov_t ds_pool_prop_map_uuids;	/* uuid_t[] (unused now) */
-extern daos_iov_t ds_pool_prop_label;		/* string */
-extern daos_iov_t ds_pool_prop_acl;		/* daos_acl */
-extern daos_iov_t ds_pool_prop_space_rb;	/* uint64_t */
-extern daos_iov_t ds_pool_prop_self_heal;	/* uint64_t */
-extern daos_iov_t ds_pool_prop_reclaim;		/*  uint64_t */
-extern daos_iov_t ds_pool_prop_owner;		/* string */
-extern daos_iov_t ds_pool_prop_owner_group;	/* string */
-extern daos_iov_t ds_pool_prop_nhandles;	/* uint32_t */
+extern d_iov_t ds_pool_prop_uid;		/* uint32_t */
+extern d_iov_t ds_pool_prop_gid;		/* uint32_t */
+extern d_iov_t ds_pool_prop_mode;		/* uint32_t */
+extern d_iov_t ds_pool_prop_map_version;	/* uint32_t */
+extern d_iov_t ds_pool_prop_map_buffer;	/* pool_buf */
+extern d_iov_t ds_pool_prop_map_uuids;	/* uuid_t[] (unused now) */
+extern d_iov_t ds_pool_prop_label;		/* string */
+extern d_iov_t ds_pool_prop_acl;		/* daos_acl */
+extern d_iov_t ds_pool_prop_space_rb;	/* uint64_t */
+extern d_iov_t ds_pool_prop_self_heal;	/* uint64_t */
+extern d_iov_t ds_pool_prop_reclaim;		/*  uint64_t */
+extern d_iov_t ds_pool_prop_owner;		/* string */
+extern d_iov_t ds_pool_prop_owner_group;	/* string */
+extern d_iov_t ds_pool_prop_nhandles;	/* uint32_t */
 
 /** pool handle KVS */
-extern daos_iov_t ds_pool_prop_handles;		/* pool handle KVS */
+extern d_iov_t ds_pool_prop_handles;		/* pool handle KVS */
 
 /** user-defined attributes KVS */
-extern daos_iov_t ds_pool_attr_user;		/* pool user attributes KVS */
+extern d_iov_t ds_pool_attr_user;		/* pool user attributes KVS */
 
 /** value of key (handle uuid) in pool handle KVS (RDB_KVS_GENERIC) */
 struct pool_hdl {

--- a/src/pool/srv_pool.c
+++ b/src/pool/srv_pool.c
@@ -73,20 +73,20 @@ static int
 write_map_buf(struct rdb_tx *tx, const rdb_path_t *kvs, struct pool_buf *buf,
 	      uint32_t version)
 {
-	daos_iov_t	value;
+	d_iov_t	value;
 	int		rc;
 
 	D_DEBUG(DF_DSMS, "version=%u ntargets=%u ndomains=%u\n", version,
 		buf->pb_target_nr, buf->pb_domain_nr);
 
 	/* Write the version. */
-	daos_iov_set(&value, &version, sizeof(version));
+	d_iov_set(&value, &version, sizeof(version));
 	rc = rdb_tx_update(tx, kvs, &ds_pool_prop_map_version, &value);
 	if (rc != 0)
 		return rc;
 
 	/* Write the buffer. */
-	daos_iov_set(&value, buf, pool_buf_size(buf->pb_nr));
+	d_iov_set(&value, buf, pool_buf_size(buf->pb_nr));
 	return rdb_tx_update(tx, kvs, &ds_pool_prop_map_buffer, &value);
 }
 
@@ -99,17 +99,17 @@ read_map_buf(struct rdb_tx *tx, const rdb_path_t *kvs, struct pool_buf **buf,
 	     uint32_t *version)
 {
 	uint32_t	ver;
-	daos_iov_t	value;
+	d_iov_t	value;
 	int		rc;
 
 	/* Read the version. */
-	daos_iov_set(&value, &ver, sizeof(ver));
+	d_iov_set(&value, &ver, sizeof(ver));
 	rc = rdb_tx_lookup(tx, kvs, &ds_pool_prop_map_version, &value);
 	if (rc != 0)
 		return rc;
 
 	/* Look up the buffer address. */
-	daos_iov_set(&value, NULL /* buf */, 0 /* size */);
+	d_iov_set(&value, NULL /* buf */, 0 /* size */);
 	rc = rdb_tx_lookup(tx, kvs, &ds_pool_prop_map_buffer, &value);
 	if (rc != 0)
 		return rc;
@@ -359,7 +359,7 @@ static int
 pool_prop_write(struct rdb_tx *tx, const rdb_path_t *kvs, daos_prop_t *prop)
 {
 	struct daos_prop_entry	*entry;
-	daos_iov_t		 value;
+	d_iov_t		 value;
 	int			 i;
 	int			 rc = 0;
 
@@ -370,7 +370,7 @@ pool_prop_write(struct rdb_tx *tx, const rdb_path_t *kvs, daos_prop_t *prop)
 		entry = &prop->dpp_entries[i];
 		switch (entry->dpe_type) {
 		case DAOS_PROP_PO_LABEL:
-			daos_iov_set(&value, entry->dpe_str,
+			d_iov_set(&value, entry->dpe_str,
 				     strlen(entry->dpe_str));
 			rc = rdb_tx_update(tx, kvs, &ds_pool_prop_label,
 					   &value);
@@ -378,7 +378,7 @@ pool_prop_write(struct rdb_tx *tx, const rdb_path_t *kvs, daos_prop_t *prop)
 				return rc;
 			break;
 		case DAOS_PROP_PO_OWNER:
-			daos_iov_set(&value, entry->dpe_str,
+			d_iov_set(&value, entry->dpe_str,
 				     strlen(entry->dpe_str));
 			rc = rdb_tx_update(tx, kvs, &ds_pool_prop_owner,
 					   &value);
@@ -386,7 +386,7 @@ pool_prop_write(struct rdb_tx *tx, const rdb_path_t *kvs, daos_prop_t *prop)
 				return rc;
 			break;
 		case DAOS_PROP_PO_OWNER_GROUP:
-			daos_iov_set(&value, entry->dpe_str,
+			d_iov_set(&value, entry->dpe_str,
 				     strlen(entry->dpe_str));
 			rc = rdb_tx_update(tx, kvs, &ds_pool_prop_owner_group,
 					   &value);
@@ -395,7 +395,7 @@ pool_prop_write(struct rdb_tx *tx, const rdb_path_t *kvs, daos_prop_t *prop)
 			break;
 		case DAOS_PROP_PO_ACL:
 			if (entry->dpe_val_ptr != NULL) {
-				daos_iov_set(&value, entry->dpe_val_ptr,
+				d_iov_set(&value, entry->dpe_val_ptr,
 					     pool_prop_acl_get_length(entry));
 				rc = rdb_tx_update(tx, kvs, &ds_pool_prop_acl,
 						   &value);
@@ -404,7 +404,7 @@ pool_prop_write(struct rdb_tx *tx, const rdb_path_t *kvs, daos_prop_t *prop)
 			}
 			break;
 		case DAOS_PROP_PO_SPACE_RB:
-			daos_iov_set(&value, &entry->dpe_val,
+			d_iov_set(&value, &entry->dpe_val,
 				     sizeof(entry->dpe_val));
 			rc = rdb_tx_update(tx, kvs, &ds_pool_prop_space_rb,
 					   &value);
@@ -412,7 +412,7 @@ pool_prop_write(struct rdb_tx *tx, const rdb_path_t *kvs, daos_prop_t *prop)
 				return rc;
 			break;
 		case DAOS_PROP_PO_SELF_HEAL:
-			daos_iov_set(&value, &entry->dpe_val,
+			d_iov_set(&value, &entry->dpe_val,
 				     sizeof(entry->dpe_val));
 			rc = rdb_tx_update(tx, kvs, &ds_pool_prop_self_heal,
 					   &value);
@@ -420,7 +420,7 @@ pool_prop_write(struct rdb_tx *tx, const rdb_path_t *kvs, daos_prop_t *prop)
 				return rc;
 			break;
 		case DAOS_PROP_PO_RECLAIM:
-			daos_iov_set(&value, &entry->dpe_val,
+			d_iov_set(&value, &entry->dpe_val,
 				     sizeof(entry->dpe_val));
 			rc = rdb_tx_update(tx, kvs, &ds_pool_prop_reclaim,
 					   &value);
@@ -448,7 +448,7 @@ init_pool_metadata(struct rdb_tx *tx, const rdb_path_t *kvs, uint32_t uid,
 	uint32_t		map_version = 1;
 	uint32_t		nhandles = 0;
 	uuid_t		       *uuids;
-	daos_iov_t		value;
+	d_iov_t		value;
 	struct rdb_kvs_attr	attr;
 	int			ntargets = nnodes * dss_tgt_nr;
 	int			rc;
@@ -525,15 +525,15 @@ init_pool_metadata(struct rdb_tx *tx, const rdb_path_t *kvs, uint32_t uid,
 	}
 
 	/* Initialize the UID, GID, and mode properties. */
-	daos_iov_set(&value, &uid, sizeof(uid));
+	d_iov_set(&value, &uid, sizeof(uid));
 	rc = rdb_tx_update(tx, kvs, &ds_pool_prop_uid, &value);
 	if (rc != 0)
 		D_GOTO(out_uuids, rc);
-	daos_iov_set(&value, &gid, sizeof(gid));
+	d_iov_set(&value, &gid, sizeof(gid));
 	rc = rdb_tx_update(tx, kvs, &ds_pool_prop_gid, &value);
 	if (rc != 0)
 		D_GOTO(out_uuids, rc);
-	daos_iov_set(&value, &mode, sizeof(mode));
+	d_iov_set(&value, &mode, sizeof(mode));
 	rc = rdb_tx_update(tx, kvs, &ds_pool_prop_mode, &value);
 	if (rc != 0)
 		D_GOTO(out_uuids, rc);
@@ -542,7 +542,7 @@ init_pool_metadata(struct rdb_tx *tx, const rdb_path_t *kvs, uint32_t uid,
 	rc = write_map_buf(tx, kvs, map_buf, map_version);
 	if (rc != 0)
 		D_GOTO(out_uuids, rc);
-	daos_iov_set(&value, uuids, sizeof(uuid_t) * nnodes);
+	d_iov_set(&value, uuids, sizeof(uuid_t) * nnodes);
 	rc = rdb_tx_update(tx, kvs, &ds_pool_prop_map_uuids, &value);
 	if (rc != 0)
 		D_GOTO(out_uuids, rc);
@@ -553,7 +553,7 @@ init_pool_metadata(struct rdb_tx *tx, const rdb_path_t *kvs, uint32_t uid,
 		D_GOTO(out_uuids, rc);
 
 	/* Write the handle properties. */
-	daos_iov_set(&value, &nhandles, sizeof(nhandles));
+	d_iov_set(&value, &nhandles, sizeof(nhandles));
 	rc = rdb_tx_update(tx, kvs, &ds_pool_prop_nhandles, &value);
 	if (rc != 0)
 		D_GOTO(out_uuids, rc);
@@ -579,7 +579,7 @@ out_map_buf:
  * nreplicas inputs how many replicas are wanted, while ranks->rl_nr
  * outputs how many replicas are actually selected, which may be less than
  * nreplicas. If successful, callers are responsible for calling
- * daos_rank_list_free(*ranksp).
+ * d_rank_list_free(*ranksp).
  */
 static int
 select_svc_ranks(int nreplicas, const d_rank_list_t *target_addrs,
@@ -659,7 +659,7 @@ ds_pool_svc_create(const uuid_t pool_uuid, unsigned int uid, unsigned int gid,
 {
 	d_rank_list_t	       *ranks;
 	uuid_t			rdb_uuid;
-	daos_iov_t		psid;
+	d_iov_t		psid;
 	struct rsvc_client	client;
 	struct dss_module_info *info = dss_get_module_info();
 	crt_endpoint_t		ep;
@@ -677,7 +677,7 @@ ds_pool_svc_create(const uuid_t pool_uuid, unsigned int uid, unsigned int gid,
 		D_GOTO(out, rc);
 
 	uuid_generate(rdb_uuid);
-	daos_iov_set(&psid, (void *)pool_uuid, sizeof(uuid_t));
+	d_iov_set(&psid, (void *)pool_uuid, sizeof(uuid_t));
 	rc = ds_rsvc_dist_start(DS_RSVC_CLASS_POOL, &psid, rdb_uuid, ranks,
 				true /* create */, true /* bootstrap */,
 				ds_rsvc_get_md_cap());
@@ -743,7 +743,7 @@ out_creation:
 		ds_rsvc_dist_stop(DS_RSVC_CLASS_POOL, &psid, ranks,
 				  true /* destroy */);
 out_ranks:
-	daos_rank_list_free(ranks);
+	d_rank_list_free(ranks);
 out:
 	return rc;
 }
@@ -752,12 +752,12 @@ int
 ds_pool_svc_destroy(const uuid_t pool_uuid)
 {
 	char		id[DAOS_UUID_STR_SIZE];
-	daos_iov_t	psid;
+	d_iov_t	psid;
 	crt_group_t    *group;
 	int		rc;
 
 	ds_rebuild_leader_stop(pool_uuid, -1);
-	daos_iov_set(&psid, (void *)pool_uuid, sizeof(uuid_t));
+	d_iov_set(&psid, (void *)pool_uuid, sizeof(uuid_t));
 	rc = ds_rsvc_dist_stop(DS_RSVC_CLASS_POOL, &psid, NULL /* ranks */,
 			       true /* destroy */);
 	if (rc != 0) {
@@ -807,7 +807,7 @@ pool_svc_create_group(struct pool_svc *svc, struct pool_map *map)
 }
 
 static int
-pool_svc_name_cb(daos_iov_t *id, char **name)
+pool_svc_name_cb(d_iov_t *id, char **name)
 {
 	char *s;
 
@@ -823,7 +823,7 @@ pool_svc_name_cb(daos_iov_t *id, char **name)
 }
 
 static int
-pool_svc_load_uuid_cb(daos_iov_t *id, uuid_t db_uuid)
+pool_svc_load_uuid_cb(d_iov_t *id, uuid_t db_uuid)
 {
 	char   *path;
 	int	rc;
@@ -839,7 +839,7 @@ pool_svc_load_uuid_cb(daos_iov_t *id, uuid_t db_uuid)
 }
 
 static int
-pool_svc_store_uuid_cb(daos_iov_t *id, uuid_t db_uuid)
+pool_svc_store_uuid_cb(d_iov_t *id, uuid_t db_uuid)
 {
 	char   *path;
 	int	rc;
@@ -855,7 +855,7 @@ pool_svc_store_uuid_cb(daos_iov_t *id, uuid_t db_uuid)
 }
 
 static int
-pool_svc_delete_uuid_cb(daos_iov_t *id)
+pool_svc_delete_uuid_cb(d_iov_t *id)
 {
 	char   *path;
 	int	rc;
@@ -876,7 +876,7 @@ pool_svc_delete_uuid_cb(daos_iov_t *id)
 }
 
 static int
-pool_svc_locate_cb(daos_iov_t *id, char **path)
+pool_svc_locate_cb(d_iov_t *id, char **path)
 {
 	char *s;
 
@@ -890,7 +890,7 @@ pool_svc_locate_cb(daos_iov_t *id, char **path)
 }
 
 static int
-pool_svc_alloc_cb(daos_iov_t *id, struct ds_rsvc **rsvc)
+pool_svc_alloc_cb(d_iov_t *id, struct ds_rsvc **rsvc)
 {
 	struct pool_svc	       *svc;
 	int			rc;
@@ -906,7 +906,7 @@ pool_svc_alloc_cb(daos_iov_t *id, struct ds_rsvc **rsvc)
 		goto err;
 	}
 
-	daos_iov_set(&svc->ps_rsvc.s_id, svc->ps_uuid, sizeof(uuid_t));
+	d_iov_set(&svc->ps_rsvc.s_id, svc->ps_uuid, sizeof(uuid_t));
 
 	uuid_copy(svc->ps_uuid, id->iov_buf);
 
@@ -1077,7 +1077,7 @@ out:
 	if (map != NULL)
 		pool_map_decref(map);
 	if (replicas)
-		daos_rank_list_free(replicas);
+		d_rank_list_free(replicas);
 	return rc;
 }
 
@@ -1137,10 +1137,10 @@ static int
 pool_svc_lookup(uuid_t uuid, struct pool_svc **svcp)
 {
 	struct ds_rsvc *rsvc;
-	daos_iov_t	id;
+	d_iov_t	id;
 	int		rc;
 
-	daos_iov_set(&id, uuid, sizeof(uuid_t));
+	d_iov_set(&id, uuid, sizeof(uuid_t));
 	rc = ds_rsvc_lookup(DS_RSVC_CLASS_POOL, &id, &rsvc);
 	if (rc != 0)
 		return rc;
@@ -1159,10 +1159,10 @@ pool_svc_lookup_leader(uuid_t uuid, struct pool_svc **svcp,
 		       struct rsvc_hint *hint)
 {
 	struct ds_rsvc *rsvc;
-	daos_iov_t	id;
+	d_iov_t	id;
 	int		rc;
 
-	daos_iov_set(&id, uuid, sizeof(uuid_t));
+	d_iov_set(&id, uuid, sizeof(uuid_t));
 	rc = ds_rsvc_lookup_leader(DS_RSVC_CLASS_POOL, &id, &rsvc, hint);
 	if (rc != 0)
 		return rc;
@@ -1199,7 +1199,7 @@ static int
 start_one(uuid_t uuid, void *arg)
 {
 	char	       *path;
-	daos_iov_t	id;
+	d_iov_t	id;
 	struct stat	st;
 	int		rc;
 
@@ -1221,7 +1221,7 @@ start_one(uuid_t uuid, void *arg)
 		return 0;
 	}
 
-	daos_iov_set(&id, uuid, sizeof(uuid_t));
+	d_iov_set(&id, uuid, sizeof(uuid_t));
 	ds_rsvc_start(DS_RSVC_CLASS_POOL, &id, NULL /* db_uuid */,
 		      false /* create */, 0 /* size */, NULL /* replicas */,
 		      NULL /* arg */);
@@ -1298,20 +1298,20 @@ static int
 pool_ugm_read(struct rdb_tx *tx, const struct pool_svc *svc,
 	      struct pool_prop_ugm *ugm)
 {
-	daos_iov_t	value;
+	d_iov_t	value;
 	int		rc;
 
-	daos_iov_set(&value, &ugm->pp_uid, sizeof(ugm->pp_uid));
+	d_iov_set(&value, &ugm->pp_uid, sizeof(ugm->pp_uid));
 	rc = rdb_tx_lookup(tx, &svc->ps_root, &ds_pool_prop_uid, &value);
 	if (rc != 0)
 		return rc;
 
-	daos_iov_set(&value, &ugm->pp_gid, sizeof(ugm->pp_gid));
+	d_iov_set(&value, &ugm->pp_gid, sizeof(ugm->pp_gid));
 	rc = rdb_tx_lookup(tx, &svc->ps_root, &ds_pool_prop_gid, &value);
 	if (rc != 0)
 		return rc;
 
-	daos_iov_set(&value, &ugm->pp_mode, sizeof(ugm->pp_mode));
+	d_iov_set(&value, &ugm->pp_mode, sizeof(ugm->pp_mode));
 	rc = rdb_tx_lookup(tx, &svc->ps_root, &ds_pool_prop_mode, &value);
 	if (rc != 0)
 		return rc;
@@ -1326,7 +1326,7 @@ pool_prop_read(struct rdb_tx *tx, const struct pool_svc *svc, uint64_t bits,
 	       daos_prop_t **prop_out)
 {
 	daos_prop_t	*prop;
-	daos_iov_t	 value;
+	d_iov_t	 value;
 	uint64_t	 val;
 	uint32_t	 idx = 0, nr = 0;
 	int		 rc;
@@ -1353,7 +1353,7 @@ pool_prop_read(struct rdb_tx *tx, const struct pool_svc *svc, uint64_t bits,
 		return -DER_NOMEM;
 	*prop_out = prop;
 	if (bits & DAOS_PO_QUERY_PROP_LABEL) {
-		daos_iov_set(&value, NULL, 0);
+		d_iov_set(&value, NULL, 0);
 		rc = rdb_tx_lookup(tx, &svc->ps_root, &ds_pool_prop_label,
 				   &value);
 		if (rc != 0)
@@ -1372,7 +1372,7 @@ pool_prop_read(struct rdb_tx *tx, const struct pool_svc *svc, uint64_t bits,
 		idx++;
 	}
 	if (bits & DAOS_PO_QUERY_PROP_SPACE_RB) {
-		daos_iov_set(&value, &val, sizeof(val));
+		d_iov_set(&value, &val, sizeof(val));
 		rc = rdb_tx_lookup(tx, &svc->ps_root, &ds_pool_prop_space_rb,
 				   &value);
 		if (rc != 0)
@@ -1383,7 +1383,7 @@ pool_prop_read(struct rdb_tx *tx, const struct pool_svc *svc, uint64_t bits,
 		idx++;
 	}
 	if (bits & DAOS_PO_QUERY_PROP_SELF_HEAL) {
-		daos_iov_set(&value, &val, sizeof(val));
+		d_iov_set(&value, &val, sizeof(val));
 		rc = rdb_tx_lookup(tx, &svc->ps_root, &ds_pool_prop_self_heal,
 				   &value);
 		if (rc != 0)
@@ -1394,7 +1394,7 @@ pool_prop_read(struct rdb_tx *tx, const struct pool_svc *svc, uint64_t bits,
 		idx++;
 	}
 	if (bits & DAOS_PO_QUERY_PROP_RECLAIM) {
-		daos_iov_set(&value, &val, sizeof(val));
+		d_iov_set(&value, &val, sizeof(val));
 		rc = rdb_tx_lookup(tx, &svc->ps_root, &ds_pool_prop_reclaim,
 				   &value);
 		if (rc != 0)
@@ -1405,7 +1405,7 @@ pool_prop_read(struct rdb_tx *tx, const struct pool_svc *svc, uint64_t bits,
 		idx++;
 	}
 	if (bits & DAOS_PO_QUERY_PROP_ACL) {
-		daos_iov_set(&value, NULL, 0);
+		d_iov_set(&value, NULL, 0);
 		rc = rdb_tx_lookup(tx, &svc->ps_root, &ds_pool_prop_acl,
 				   &value);
 		if (rc != 0)
@@ -1420,7 +1420,7 @@ pool_prop_read(struct rdb_tx *tx, const struct pool_svc *svc, uint64_t bits,
 		idx++;
 	}
 	if (bits & DAOS_PO_QUERY_PROP_OWNER) {
-		daos_iov_set(&value, NULL, 0);
+		d_iov_set(&value, NULL, 0);
 		rc = rdb_tx_lookup(tx, &svc->ps_root, &ds_pool_prop_owner,
 				   &value);
 		if (rc != 0)
@@ -1439,7 +1439,7 @@ pool_prop_read(struct rdb_tx *tx, const struct pool_svc *svc, uint64_t bits,
 		idx++;
 	}
 	if (bits & DAOS_PO_QUERY_PROP_OWNER_GROUP) {
-		daos_iov_set(&value, NULL, 0);
+		d_iov_set(&value, NULL, 0);
 		rc = rdb_tx_lookup(tx, &svc->ps_root, &ds_pool_prop_owner_group,
 				   &value);
 		if (rc != 0)
@@ -1514,7 +1514,7 @@ ds_pool_create_handler(crt_rpc_t *rpc)
 	struct pool_create_out *out = crt_reply_get(rpc);
 	struct pool_svc	       *svc;
 	struct rdb_tx		tx;
-	daos_iov_t		value;
+	d_iov_t		value;
 	struct rdb_kvs_attr	attr;
 	daos_prop_t	       *prop_dup = NULL;
 	int			rc;
@@ -1552,7 +1552,7 @@ ds_pool_create_handler(crt_rpc_t *rpc)
 	ds_cont_wrlock_metadata(svc->ps_cont_svc);
 
 	/* See if the DB has already been initialized. */
-	daos_iov_set(&value, NULL /* buf */, 0 /* size */);
+	d_iov_set(&value, NULL /* buf */, 0 /* size */);
 	rc = rdb_tx_lookup(&tx, &svc->ps_root, &ds_pool_prop_map_buffer,
 			   &value);
 	if (rc != -DER_NONEXIST) {
@@ -1643,7 +1643,7 @@ out:
 static int
 pool_connect_bcast(crt_context_t ctx, struct pool_svc *svc,
 		   const uuid_t pool_hdl, uint64_t capas,
-		   daos_iov_t *global_ns, struct daos_pool_space *ps,
+		   d_iov_t *global_ns, struct daos_pool_space *ps,
 		   crt_bulk_t map_buf_bulk)
 {
 	struct pool_tgt_connect_in     *in;
@@ -1721,8 +1721,8 @@ transfer_map_buf(struct pool_buf *map_buf, uint32_t map_version,
 {
 	size_t			map_buf_size;
 	daos_size_t		remote_bulk_size;
-	daos_iov_t		map_iov;
-	daos_sg_list_t		map_sgl;
+	d_iov_t		map_iov;
+	d_sg_list_t		map_sgl;
 	crt_bulk_t		bulk = CRT_BULK_NULL;
 	struct crt_bulk_desc	map_desc;
 	crt_bulk_opid_t		map_opid;
@@ -1753,13 +1753,12 @@ transfer_map_buf(struct pool_buf *map_buf, uint32_t map_version,
 		D_GOTO(out, rc = -DER_TRUNC);
 	}
 
-	daos_iov_set(&map_iov, map_buf, map_buf_size);
+	d_iov_set(&map_iov, map_buf, map_buf_size);
 	map_sgl.sg_nr = 1;
 	map_sgl.sg_nr_out = 0;
 	map_sgl.sg_iovs = &map_iov;
 
-	rc = crt_bulk_create(rpc->cr_ctx, daos2crt_sg(&map_sgl),
-			     CRT_BULK_RO, &bulk);
+	rc = crt_bulk_create(rpc->cr_ctx, &map_sgl, CRT_BULK_RO, &bulk);
 	if (rc != 0)
 		D_GOTO(out, rc);
 
@@ -1805,11 +1804,11 @@ ds_pool_connect_handler(crt_rpc_t *rpc)
 	struct pool_buf			*map_buf;
 	uint32_t			map_version;
 	struct rdb_tx			tx;
-	daos_iov_t			key;
-	daos_iov_t			value;
+	d_iov_t			key;
+	d_iov_t			value;
 	struct pool_prop_ugm		ugm;
 	struct pool_hdl			hdl;
-	daos_iov_t			iv_iov;
+	d_iov_t			iv_iov;
 	unsigned int			iv_ns_id;
 	uint32_t			nhandles;
 	int				skip_update = 0;
@@ -1852,8 +1851,8 @@ ds_pool_connect_handler(crt_rpc_t *rpc)
 	ABT_rwlock_wrlock(svc->ps_lock);
 
 	/* Check existing pool handles. */
-	daos_iov_set(&key, in->pci_op.pi_hdl, sizeof(uuid_t));
-	daos_iov_set(&value, &hdl, sizeof(hdl));
+	d_iov_set(&key, in->pci_op.pi_hdl, sizeof(uuid_t));
+	d_iov_set(&value, &hdl, sizeof(hdl));
 	rc = rdb_tx_lookup(&tx, &svc->ps_handles, &key, &value);
 	if (rc == 0) {
 		if (hdl.ph_capas == in->pci_capas) {
@@ -1925,7 +1924,7 @@ ds_pool_connect_handler(crt_rpc_t *rpc)
 	if (skip_update)
 		D_GOTO(out_pool_prop, rc = 0);
 
-	daos_iov_set(&value, &nhandles, sizeof(nhandles));
+	d_iov_set(&value, &nhandles, sizeof(nhandles));
 	rc = rdb_tx_lookup(&tx, &svc->ps_root, &ds_pool_prop_nhandles, &value);
 	if (rc != 0)
 		D_GOTO(out_pool_prop, rc);
@@ -1941,7 +1940,7 @@ ds_pool_connect_handler(crt_rpc_t *rpc)
 			 * If there is a non-exclusive handle, then all handles
 			 * are non-exclusive.
 			 */
-			daos_iov_set(&value, &hdl, sizeof(hdl));
+			d_iov_set(&value, &hdl, sizeof(hdl));
 			rc = rdb_tx_fetch(&tx, &svc->ps_handles,
 					  RDB_PROBE_FIRST, NULL /* key_in */,
 					  NULL /* key_out */, &value);
@@ -1964,13 +1963,13 @@ ds_pool_connect_handler(crt_rpc_t *rpc)
 	hdl.ph_capas = in->pci_capas;
 	nhandles++;
 
-	daos_iov_set(&value, &nhandles, sizeof(nhandles));
+	d_iov_set(&value, &nhandles, sizeof(nhandles));
 	rc = rdb_tx_update(&tx, &svc->ps_root, &ds_pool_prop_nhandles, &value);
 	if (rc != 0)
 		D_GOTO(out_pool_prop, rc);
 
-	daos_iov_set(&key, in->pci_op.pi_hdl, sizeof(uuid_t));
-	daos_iov_set(&value, &hdl, sizeof(hdl));
+	d_iov_set(&key, in->pci_op.pi_hdl, sizeof(uuid_t));
+	d_iov_set(&value, &hdl, sizeof(hdl));
 	rc = rdb_tx_update(&tx, &svc->ps_handles, &key, &value);
 	if (rc != 0)
 		D_GOTO(out_pool_prop, rc);
@@ -2041,7 +2040,7 @@ static int
 pool_disconnect_hdls(struct rdb_tx *tx, struct pool_svc *svc, uuid_t *hdl_uuids,
 		     int n_hdl_uuids, crt_context_t ctx)
 {
-	daos_iov_t	value;
+	d_iov_t	value;
 	uint32_t	nhandles;
 	int		i;
 	int		rc;
@@ -2065,7 +2064,7 @@ pool_disconnect_hdls(struct rdb_tx *tx, struct pool_svc *svc, uuid_t *hdl_uuids,
 	if (rc != 0)
 		D_GOTO(out, rc);
 
-	daos_iov_set(&value, &nhandles, sizeof(nhandles));
+	d_iov_set(&value, &nhandles, sizeof(nhandles));
 	rc = rdb_tx_lookup(tx, &svc->ps_root, &ds_pool_prop_nhandles, &value);
 	if (rc != 0)
 		D_GOTO(out, rc);
@@ -2073,15 +2072,15 @@ pool_disconnect_hdls(struct rdb_tx *tx, struct pool_svc *svc, uuid_t *hdl_uuids,
 	nhandles -= n_hdl_uuids;
 
 	for (i = 0; i < n_hdl_uuids; i++) {
-		daos_iov_t key;
+		d_iov_t key;
 
-		daos_iov_set(&key, hdl_uuids[i], sizeof(uuid_t));
+		d_iov_set(&key, hdl_uuids[i], sizeof(uuid_t));
 		rc = rdb_tx_delete(tx, &svc->ps_handles, &key);
 		if (rc != 0)
 			D_GOTO(out, rc);
 	}
 
-	daos_iov_set(&value, &nhandles, sizeof(nhandles));
+	d_iov_set(&value, &nhandles, sizeof(nhandles));
 	rc = rdb_tx_update(tx, &svc->ps_root, &ds_pool_prop_nhandles, &value);
 	if (rc != 0)
 		D_GOTO(out, rc);
@@ -2098,8 +2097,8 @@ ds_pool_disconnect_handler(crt_rpc_t *rpc)
 	struct pool_disconnect_out     *pdo = crt_reply_get(rpc);
 	struct pool_svc		       *svc;
 	struct rdb_tx			tx;
-	daos_iov_t			key;
-	daos_iov_t			value;
+	d_iov_t			key;
+	d_iov_t			value;
 	struct pool_hdl			hdl;
 	int				rc;
 
@@ -2117,8 +2116,8 @@ ds_pool_disconnect_handler(crt_rpc_t *rpc)
 
 	ABT_rwlock_wrlock(svc->ps_lock);
 
-	daos_iov_set(&key, pdi->pdi_op.pi_hdl, sizeof(uuid_t));
-	daos_iov_set(&value, &hdl, sizeof(hdl));
+	d_iov_set(&key, pdi->pdi_op.pi_hdl, sizeof(uuid_t));
+	d_iov_set(&value, &hdl, sizeof(hdl));
 	rc = rdb_tx_lookup(&tx, &svc->ps_handles, &key, &value);
 	if (rc != 0) {
 		if (rc == -DER_NONEXIST)
@@ -2196,8 +2195,8 @@ ds_pool_query_handler(crt_rpc_t *rpc)
 	uint32_t		map_version;
 	struct pool_svc	       *svc;
 	struct rdb_tx		tx;
-	daos_iov_t		key;
-	daos_iov_t		value;
+	d_iov_t		key;
+	d_iov_t		value;
 	struct pool_hdl		hdl;
 	struct pool_prop_ugm	ugm;
 	int			rc;
@@ -2227,8 +2226,8 @@ ds_pool_query_handler(crt_rpc_t *rpc)
 	 * pool.
 	 */
 	if (!is_rebuild_pool(in->pqi_op.pi_uuid, in->pqi_op.pi_hdl)) {
-		daos_iov_set(&key, in->pqi_op.pi_hdl, sizeof(uuid_t));
-		daos_iov_set(&value, &hdl, sizeof(hdl));
+		d_iov_set(&key, in->pqi_op.pi_hdl, sizeof(uuid_t));
+		d_iov_set(&value, &hdl, sizeof(hdl));
 		rc = rdb_tx_lookup(&tx, &svc->ps_handles, &key, &value);
 		if (rc != 0) {
 			if (rc == -DER_NONEXIST)
@@ -2284,7 +2283,7 @@ out:
 	daos_prop_free(prop);
 }
 
-/* Callers are responsible for daos_rank_list_free(*replicasp). */
+/* Callers are responsible for d_rank_list_free(*replicasp). */
 static int
 ds_pool_update_internal(uuid_t pool_uuid, struct pool_target_id_list *tgts,
 			unsigned int opc,
@@ -2356,7 +2355,7 @@ ds_pool_update_internal(uuid_t pool_uuid, struct pool_target_id_list *tgts,
 
 out_replicas:
 	if (rc) {
-		daos_rank_list_free(*replicasp);
+		d_rank_list_free(*replicasp);
 		*replicasp = NULL;
 	}
 out_map_version:
@@ -2543,7 +2542,7 @@ out:
 	pool_target_addr_list_free(&out_list);
 	pool_target_id_list_free(&target_list);
 	if (replicas != NULL)
-		daos_rank_list_free(replicas);
+		d_rank_list_free(replicas);
 }
 
 struct evict_iter_arg {
@@ -2553,7 +2552,7 @@ struct evict_iter_arg {
 };
 
 static int
-evict_iter_cb(daos_handle_t ih, daos_iov_t *key, daos_iov_t *val, void *varg)
+evict_iter_cb(daos_handle_t ih, d_iov_t *key, d_iov_t *val, void *varg)
 {
 	struct evict_iter_arg  *arg = varg;
 
@@ -2678,13 +2677,13 @@ ds_pool_svc_stop_handler(crt_rpc_t *rpc)
 {
 	struct pool_svc_stop_in	       *in = crt_req_get(rpc);
 	struct pool_svc_stop_out       *out = crt_reply_get(rpc);
-	daos_iov_t			id;
+	d_iov_t			id;
 	int				rc;
 
 	D_DEBUG(DF_DSMS, DF_UUID": processing rpc %p\n",
 		DP_UUID(in->psi_op.pi_uuid), rpc);
 
-	daos_iov_set(&id, in->psi_op.pi_uuid, sizeof(uuid_t));
+	d_iov_set(&id, in->psi_op.pi_uuid, sizeof(uuid_t));
 	rc = ds_rsvc_stop_leader(DS_RSVC_CLASS_POOL, &id, &out->pso_op.po_hint);
 
 	out->pso_op.po_rc = rc;
@@ -2881,7 +2880,7 @@ ds_pool_replicas_update_handler(crt_rpc_t *rpc)
 	d_rank_list_t			*ranks;
 	uuid_t				 db_uuid;
 	uuid_t				 pool_uuid;
-	daos_iov_t			 psid;
+	d_iov_t			 psid;
 	int				 rc;
 
 	D_DEBUG(DB_MD, DF_UUID": Replica Rank: %u\n", DP_UUID(in->pmi_uuid),
@@ -2904,7 +2903,7 @@ ds_pool_replicas_update_handler(crt_rpc_t *rpc)
 	rdb_get_uuid(db, db_uuid);
 	uuid_copy(pool_uuid, svc->ps_uuid);
 	pool_svc_put_leader(svc);
-	daos_iov_set(&psid, pool_uuid, sizeof(uuid_t));
+	d_iov_set(&psid, pool_uuid, sizeof(uuid_t));
 
 	switch (opc) {
 	case POOL_REPLICAS_ADD:

--- a/src/pool/srv_target.c
+++ b/src/pool/srv_target.c
@@ -903,14 +903,14 @@ ds_pool_tgt_update_map_handler(crt_rpc_t *rpc)
 	}
 
 	if (rpc->cr_co_bulk_hdl != NULL) {
-		daos_iov_t	iov;
-		daos_sg_list_t	sgl;
+		d_iov_t	iov;
+		d_sg_list_t	sgl;
 
 		memset(&iov, 0, sizeof(iov));
 		sgl.sg_nr = 1;
 		sgl.sg_nr_out = 1;
 		sgl.sg_iovs = &iov;
-		rc = crt_bulk_access(rpc->cr_co_bulk_hdl, daos2crt_sg(&sgl));
+		rc = crt_bulk_access(rpc->cr_co_bulk_hdl, &sgl);
 		if (rc != 0)
 			D_GOTO(out_pool, rc);
 		buf = iov.iov_buf;

--- a/src/rdb/rdb.c
+++ b/src/rdb/rdb.c
@@ -48,7 +48,7 @@ rdb_create(const char *path, const uuid_t uuid, size_t size,
 {
 	daos_handle_t	pool;
 	daos_handle_t	mc;
-	daos_iov_t	value;
+	d_iov_t	value;
 	int		rc;
 
 	D_DEBUG(DB_MD, DF_UUID": creating db %s with %u replicas\n",
@@ -79,7 +79,7 @@ rdb_create(const char *path, const uuid_t uuid, size_t size,
 	 * Mark this replica as fully initialized by storing its UUID.
 	 * rdb_start() checks this attribute when starting a DB.
 	 */
-	daos_iov_set(&value, (void *)uuid, sizeof(uuid_t));
+	d_iov_set(&value, (void *)uuid, sizeof(uuid_t));
 	rc = rdb_mc_update(mc, RDB_MC_ATTRS, 1 /* n */, &rdb_mc_uuid, &value);
 
 out_mc_hdl:
@@ -224,7 +224,7 @@ rdb_start(const char *path, const uuid_t uuid, struct rdb_cbs *cbs, void *arg,
 	  struct rdb **dbp)
 {
 	struct rdb     *db;
-	daos_iov_t	value;
+	d_iov_t	value;
 	uuid_t		uuid_persist;
 	int		rc;
 
@@ -276,7 +276,7 @@ rdb_start(const char *path, const uuid_t uuid, struct rdb_cbs *cbs, void *arg,
 	}
 
 	/* Check if this replica is fully initialized. See rdb_create(). */
-	daos_iov_set(&value, uuid_persist, sizeof(uuid_t));
+	d_iov_set(&value, uuid_persist, sizeof(uuid_t));
 	rc = rdb_mc_lookup(db->d_mc, RDB_MC_ATTRS, &rdb_mc_uuid, &value);
 	if (rc == -DER_NONEXIST) {
 		D_ERROR(DF_DB": not fully initialized\n", DP_DB(db));
@@ -448,7 +448,7 @@ rdb_get_leader(struct rdb *db, uint64_t *term, d_rank_t *rank)
 
 /**
  * Get the list of replica ranks. Callers are responsible for
- * daos_rank_list_free(*ranksp).
+ * d_rank_list_free(*ranksp).
  *
  * \param[in]	db	database
  * \param[out]	ranksp	list of replica ranks

--- a/src/rdb/rdb_internal.h
+++ b/src/rdb/rdb_internal.h
@@ -218,8 +218,8 @@ CRT_RPC_DECLARE(rdb_appendentries, DAOS_ISEQ_RDB_APPENDENTRIES,
 		DAOS_OSEQ_RDB_APPENDENTRIES)
 
 struct rdb_local {
-	daos_iov_t		rl_kds_iov;	/* isi_kds buffer */
-	daos_iov_t		rl_data_iov;	/* isi_data buffer */
+	d_iov_t		rl_kds_iov;	/* isi_kds buffer */
+	d_iov_t		rl_data_iov;	/* isi_data buffer */
 };
 
 #define DAOS_ISEQ_RDB_INSTALLSNAPSHOT /* input fields */	 \
@@ -283,7 +283,7 @@ void rdb_kvs_evict(struct rdb *db, struct rdb_kvs *kvs);
 /* rdb_path.c *****************************************************************/
 
 int rdb_path_clone(const rdb_path_t *path, rdb_path_t *new_path);
-typedef int (*rdb_path_iterate_cb_t)(daos_iov_t *key, void *arg);
+typedef int (*rdb_path_iterate_cb_t)(d_iov_t *key, void *arg);
 int rdb_path_iterate(const rdb_path_t *path, rdb_path_iterate_cb_t cb,
 		     void *arg);
 int rdb_path_pop(rdb_path_t *path);
@@ -294,10 +294,10 @@ int rdb_path_pop(rdb_path_t *path);
 #define DP_IOV(iov)	(iov)->iov_buf, (iov)->iov_len
 
 extern const daos_size_t rdb_iov_max;
-size_t rdb_encode_iov(const daos_iov_t *iov, void *buf);
-ssize_t rdb_decode_iov(const void *buf, size_t len, daos_iov_t *iov);
+size_t rdb_encode_iov(const d_iov_t *iov, void *buf);
+ssize_t rdb_decode_iov(const void *buf, size_t len, d_iov_t *iov);
 ssize_t rdb_decode_iov_backward(const void *buf_end, size_t len,
-				daos_iov_t *iov);
+				d_iov_t *iov);
 
 void rdb_oid_to_uoid(rdb_oid_t oid, daos_unit_oid_t *uoid);
 
@@ -315,18 +315,18 @@ void rdb_anchor_from_hashes(struct rdb_anchor *anchor,
 			    daos_anchor_t *ev_anchor, daos_anchor_t *sv_anchor);
 
 int rdb_vos_fetch(daos_handle_t cont, daos_epoch_t epoch, rdb_oid_t oid,
-		  daos_key_t *akey, daos_iov_t *value);
+		  daos_key_t *akey, d_iov_t *value);
 int rdb_vos_fetch_addr(daos_handle_t cont, daos_epoch_t epoch, rdb_oid_t oid,
-		       daos_key_t *akey, daos_iov_t *value);
+		       daos_key_t *akey, d_iov_t *value);
 int rdb_vos_iter_fetch(daos_handle_t cont, daos_epoch_t epoch, rdb_oid_t oid,
 		       enum rdb_probe_opc opc, daos_key_t *akey_in,
-		       daos_key_t *akey_out, daos_iov_t *value);
+		       daos_key_t *akey_out, d_iov_t *value);
 int rdb_vos_iterate(daos_handle_t cont, daos_epoch_t epoch, rdb_oid_t oid,
 		    bool backward, rdb_iterate_cb_t cb, void *arg);
 int rdb_vos_update(daos_handle_t cont, daos_epoch_t epoch, rdb_oid_t oid, int n,
-		   daos_iov_t akeys[], daos_iov_t values[]);
+		   d_iov_t akeys[], d_iov_t values[]);
 int rdb_vos_punch(daos_handle_t cont, daos_epoch_t epoch, rdb_oid_t oid, int n,
-		  daos_iov_t akeys[]);
+		  d_iov_t akeys[]);
 int rdb_vos_discard(daos_handle_t cont, daos_epoch_t low, daos_epoch_t high);
 int rdb_vos_aggregate(daos_handle_t cont, daos_epoch_t high);
 
@@ -339,8 +339,8 @@ int rdb_vos_aggregate(daos_handle_t cont, daos_epoch_t high);
 
 /* Update n (<= RDB_VOS_BATCH_MAX) a-keys atomically. */
 static inline int
-rdb_mc_update(daos_handle_t mc, rdb_oid_t oid, int n, daos_iov_t akeys[],
-	      daos_iov_t values[])
+rdb_mc_update(daos_handle_t mc, rdb_oid_t oid, int n, d_iov_t akeys[],
+	      d_iov_t values[])
 {
 	D_DEBUG(DB_TRACE, "mc="DF_X64" oid="DF_X64" n=%d akeys[0]=<%p, %zd> "
 		"values[0]=<%p, %zd>\n", mc.cookie, oid, n, akeys[0].iov_buf,
@@ -349,8 +349,8 @@ rdb_mc_update(daos_handle_t mc, rdb_oid_t oid, int n, daos_iov_t akeys[],
 }
 
 static inline int
-rdb_mc_lookup(daos_handle_t mc, rdb_oid_t oid, daos_iov_t *akey,
-	      daos_iov_t *value)
+rdb_mc_lookup(daos_handle_t mc, rdb_oid_t oid, d_iov_t *akey,
+	      d_iov_t *value)
 {
 	D_DEBUG(DB_TRACE, "mc="DF_X64" oid="DF_X64" akey=<%p, %zd> "
 		"value=<%p, %zd, %zd>\n", mc.cookie, oid, akey->iov_buf,
@@ -361,7 +361,7 @@ rdb_mc_lookup(daos_handle_t mc, rdb_oid_t oid, daos_iov_t *akey,
 
 static inline int
 rdb_lc_update(daos_handle_t lc, uint64_t index, rdb_oid_t oid, int n,
-	      daos_iov_t akeys[], daos_iov_t values[])
+	      d_iov_t akeys[], d_iov_t values[])
 {
 	D_DEBUG(DB_TRACE, "lc="DF_X64" index="DF_U64" oid="DF_X64
 		" n=%d akeys[0]=<%p, %zd> values[0]=<%p, %zd>\n", lc.cookie,
@@ -372,7 +372,7 @@ rdb_lc_update(daos_handle_t lc, uint64_t index, rdb_oid_t oid, int n,
 
 static inline int
 rdb_lc_punch(daos_handle_t lc, uint64_t index, rdb_oid_t oid, int n,
-	     daos_iov_t akeys[])
+	     d_iov_t akeys[])
 {
 	if (n > 0)
 		D_DEBUG(DB_TRACE, "lc="DF_X64" index="DF_U64" oid="DF_X64
@@ -403,7 +403,7 @@ rdb_lc_aggregate(daos_handle_t lc, uint64_t high)
 
 static inline int
 rdb_lc_lookup(daos_handle_t lc, uint64_t index, rdb_oid_t oid,
-	      daos_iov_t *akey, daos_iov_t *value)
+	      d_iov_t *akey, d_iov_t *value)
 {
 	D_DEBUG(DB_TRACE, "lc="DF_X64" index="DF_U64" oid="DF_X64
 		" akey=<%p, %zd> value=<%p, %zd, %zd>\n", lc.cookie, index, oid,
@@ -417,8 +417,8 @@ rdb_lc_lookup(daos_handle_t lc, uint64_t index, rdb_oid_t oid,
 
 static inline int
 rdb_lc_iter_fetch(daos_handle_t lc, uint64_t index, rdb_oid_t oid,
-		  enum rdb_probe_opc opc, daos_iov_t *akey_in,
-		  daos_iov_t *akey_out, daos_iov_t *value)
+		  enum rdb_probe_opc opc, d_iov_t *akey_in,
+		  d_iov_t *akey_out, d_iov_t *value)
 {
 	D_DEBUG(DB_TRACE, "lc="DF_X64" index="DF_U64" oid="DF_X64" opc=%d"
 		" akey_in=<%p, %zd> akey_out=<%p, %zd> value=<%p, %zd, %zd>\n",

--- a/src/rdb/rdb_kvs.c
+++ b/src/rdb/rdb_kvs.c
@@ -43,17 +43,17 @@ struct rdb_kvs_open_arg {
 
 /* Open key in arg->deo_parent. */
 static int
-rdb_kvs_open_path_cb(daos_iov_t *key, void *varg)
+rdb_kvs_open_path_cb(d_iov_t *key, void *varg)
 {
 	struct rdb_kvs_open_arg	       *arg = varg;
 	rdb_oid_t			parent = arg->deo_parent;
-	daos_iov_t			value;
+	d_iov_t			value;
 
 	if (key->iov_len == 0) {
 		D_ASSERTF(parent == RDB_LC_ATTRS, DF_X64"\n", parent);
 		key = &rdb_lc_root;
 	}
-	daos_iov_set(&value, &arg->deo_parent, sizeof(arg->deo_parent));
+	d_iov_set(&value, &arg->deo_parent, sizeof(arg->deo_parent));
 	return rdb_lc_lookup(arg->deo_db->d_lc, arg->deo_index, parent, key,
 			     &value);
 }
@@ -133,7 +133,7 @@ rdb_kvs_alloc_ref(void *key, unsigned int ksize, void *varg,
 
 	/* kvs->de_path */
 	memcpy(kvs->de_buf, key, ksize);
-	daos_iov_set(&kvs->de_path, kvs->de_buf, ksize);
+	d_iov_set(&kvs->de_path, kvs->de_buf, ksize);
 
 	/* kvs->de_object */
 	rc = rdb_kvs_open_path(arg->dea_db, arg->dea_index, &kvs->de_path,

--- a/src/rdb/rdb_layout.h
+++ b/src/rdb/rdb_layout.h
@@ -97,7 +97,7 @@ typedef uint64_t rdb_oid_t;
 #define RDB_OID_CLASS_INTEGER	(1ULL << 63)
 
 /* D-key for all a-keys */
-extern daos_iov_t rdb_dkey;
+extern d_iov_t rdb_dkey;
 
 /* pm_ver for all VOS calls taking a pm_ver argument */
 #define RDB_PM_VER 0
@@ -125,11 +125,11 @@ struct rdb_anchor {
  * Flattened together with the Raft attributes. These are defined in
  * rdb_layout.c using RDB_STRING_KEY().
  */
-extern daos_iov_t rdb_mc_uuid;		/* uuid_t */
-extern daos_iov_t rdb_mc_term;		/* int */
-extern daos_iov_t rdb_mc_vote;		/* int */
-extern daos_iov_t rdb_mc_lc;		/* rdb_lc_record */
-extern daos_iov_t rdb_mc_slc;		/* rdb_lc_record */
+extern d_iov_t rdb_mc_uuid;		/* uuid_t */
+extern d_iov_t rdb_mc_term;		/* int */
+extern d_iov_t rdb_mc_vote;		/* int */
+extern d_iov_t rdb_mc_lc;		/* rdb_lc_record */
+extern d_iov_t rdb_mc_slc;		/* rdb_lc_record */
 
 /* Log container record */
 struct rdb_lc_record {
@@ -155,12 +155,12 @@ struct rdb_lc_record {
 #define RDB_LC_OID_NEXT_INIT 2
 
 /* Attribute a-keys under RDB_LC_ATTRS */
-extern daos_iov_t rdb_lc_entry_header;	/* rdb_entry */
-extern daos_iov_t rdb_lc_entry_data;	/* uint8_t[] */
-extern daos_iov_t rdb_lc_nreplicas;	/* uint8_t */
-extern daos_iov_t rdb_lc_replicas;	/* uint32_t[] */
-extern daos_iov_t rdb_lc_oid_next;	/* rdb_oid_t (classless) */
-extern daos_iov_t rdb_lc_root;		/* rdb_oid_t */
+extern d_iov_t rdb_lc_entry_header;	/* rdb_entry */
+extern d_iov_t rdb_lc_entry_data;	/* uint8_t[] */
+extern d_iov_t rdb_lc_nreplicas;	/* uint8_t */
+extern d_iov_t rdb_lc_replicas;	/* uint32_t[] */
+extern d_iov_t rdb_lc_oid_next;	/* rdb_oid_t (classless) */
+extern d_iov_t rdb_lc_root;		/* rdb_oid_t */
 
 /* Log entry */
 struct rdb_entry {

--- a/src/rdb/rdb_path.c
+++ b/src/rdb/rdb_path.c
@@ -31,7 +31,7 @@
 #include "rdb_internal.h"
 
 /* Key for the root KVS */
-daos_iov_t rdb_path_root_key;
+d_iov_t rdb_path_root_key;
 
 static inline void
 rdb_path_assert(const rdb_path_t *path)
@@ -52,7 +52,7 @@ rdb_path_assert(const rdb_path_t *path)
 int
 rdb_path_init(rdb_path_t *path)
 {
-	daos_iov_t p = {};
+	d_iov_t p = {};
 
 	p.iov_buf_len = 128;
 	D_ALLOC(p.iov_buf, p.iov_buf_len);
@@ -110,7 +110,7 @@ rdb_path_clone(const rdb_path_t *path, rdb_path_t *new_path)
  * \retval -DER_OVERFLOW	path would become too large
  */
 int
-rdb_path_push(rdb_path_t *path, const daos_iov_t *key)
+rdb_path_push(rdb_path_t *path, const d_iov_t *key)
 {
 	size_t	len;
 	size_t	n;
@@ -153,7 +153,7 @@ rdb_path_push(rdb_path_t *path, const daos_iov_t *key)
 int
 rdb_path_pop(rdb_path_t *path)
 {
-	daos_iov_t	key;
+	d_iov_t	key;
 	ssize_t		n;
 
 	rdb_path_assert(path);
@@ -175,7 +175,7 @@ rdb_path_iterate(const rdb_path_t *path, rdb_path_iterate_cb_t cb, void *arg)
 	rdb_path_assert(path);
 	while (p < path->iov_buf + path->iov_len) {
 		ssize_t		n;
-		daos_iov_t	key;
+		d_iov_t	key;
 		int		rc;
 
 		n = rdb_decode_iov(p, path->iov_buf + path->iov_len - p, &key);

--- a/src/rdb/rdb_raft.c
+++ b/src/rdb/rdb_raft.c
@@ -50,11 +50,11 @@
 #include "rdb_layout.h"
 
 static int rdb_raft_create_lc(daos_handle_t pool, daos_handle_t mc,
-			      daos_iov_t *key, uint64_t base,
+			      d_iov_t *key, uint64_t base,
 			      uint64_t base_term, uint64_t term,
 			      struct rdb_lc_record *record);
 static int rdb_raft_destroy_lc(daos_handle_t pool, daos_handle_t mc,
-			       daos_iov_t *key, uuid_t uuid,
+			       d_iov_t *key, uuid_t uuid,
 			       struct rdb_lc_record *record);
 static void *rdb_raft_lookup_result(struct rdb *db, uint64_t index);
 static int rdb_raft_add_node(struct rdb *db, d_rank_t rank);
@@ -213,17 +213,17 @@ static int
 rdb_lc_store_replicas(daos_handle_t lc, uint64_t index,
 		      const d_rank_list_t *replicas)
 {
-	daos_iov_t		keys[2];
-	daos_iov_t		vals[2];
+	d_iov_t		keys[2];
+	d_iov_t		vals[2];
 	uint8_t			nreplicas;
 
 	D_ASSERTF(replicas->rl_nr <= UINT8_MAX, "nreplicas = %u",
 		  replicas->rl_nr);
 	nreplicas = replicas->rl_nr;
 	keys[0] = rdb_lc_nreplicas;
-	daos_iov_set(&vals[0], &nreplicas, sizeof(nreplicas));
+	d_iov_set(&vals[0], &nreplicas, sizeof(nreplicas));
 	keys[1] = rdb_lc_replicas;
-	daos_iov_set(&vals[1], replicas->rl_ranks,
+	d_iov_set(&vals[1], replicas->rl_ranks,
 		     sizeof(*replicas->rl_ranks) * nreplicas);
 	return rdb_lc_update(lc, index, RDB_LC_ATTRS, 2 /* n */, keys, vals);
 }
@@ -255,9 +255,9 @@ out:
 static int
 rdb_raft_get_nreplicas(struct rdb *db, uint64_t index, uint8_t *nreplicas)
 {
-	daos_iov_t		value;
+	d_iov_t		value;
 
-	daos_iov_set(&value, nreplicas, sizeof(*nreplicas));
+	d_iov_set(&value, nreplicas, sizeof(*nreplicas));
 	return rdb_lc_lookup(db->d_lc, index, RDB_LC_ATTRS,
 			     &rdb_lc_nreplicas, &value);
 }
@@ -268,7 +268,7 @@ rdb_raft_get_nreplicas(struct rdb *db, uint64_t index, uint8_t *nreplicas)
 static int
 rdb_raft_load_replicas(struct rdb *db, uint64_t index)
 {
-	daos_iov_t	value;
+	d_iov_t	value;
 	uint8_t		nreplicas;
 	int		rc;
 
@@ -282,7 +282,7 @@ rdb_raft_load_replicas(struct rdb *db, uint64_t index)
 		rc = -DER_NOMEM;
 		goto err;
 	}
-	daos_iov_set(&value, db->d_replicas->rl_ranks,
+	d_iov_set(&value, db->d_replicas->rl_ranks,
 		     sizeof(*db->d_replicas->rl_ranks) * nreplicas);
 	rc = rdb_lc_lookup(db->d_lc, index, RDB_LC_ATTRS,
 			   &rdb_lc_replicas, &value);
@@ -293,7 +293,7 @@ rdb_raft_load_replicas(struct rdb *db, uint64_t index)
 	return 0;
 
 err_replicas:
-	daos_rank_list_free(db->d_replicas);
+	d_rank_list_free(db->d_replicas);
 err:
 	return rc;
 }
@@ -318,7 +318,7 @@ rdb_raft_unload_replicas(struct rdb *db)
 		raft_remove_node(db->d_raft, node);
 		D_FREE(rdb_node);
 	}
-	daos_rank_list_free(db->d_replicas);
+	d_rank_list_free(db->d_replicas);
 }
 
 /* Load the LC base. */
@@ -372,10 +372,10 @@ rdb_raft_unload_snapshot(struct rdb *db)
 }
 
 static int
-rdb_raft_pack_chunk(daos_handle_t lc, struct rdb_raft_is *is, daos_iov_t *kds,
-		    daos_iov_t *data, struct rdb_anchor *anchor)
+rdb_raft_pack_chunk(daos_handle_t lc, struct rdb_raft_is *is, d_iov_t *kds,
+		    d_iov_t *data, struct rdb_anchor *anchor)
 {
-	daos_sg_list_t		sgl;
+	d_sg_list_t		sgl;
 	struct dss_enum_arg	arg = { 0 };
 	struct vos_iter_anchors	anchors = { 0 };
 	vos_iter_param_t	param = { 0 };
@@ -435,9 +435,9 @@ rdb_raft_cb_send_installsnapshot(raft_server_t *raft, void *arg,
 	struct rdb_raft_is	       *is = &rdb_node->dn_is;
 	crt_rpc_t		       *rpc;
 	struct rdb_installsnapshot_in  *in;
-	daos_iov_t			kds;
-	daos_iov_t			data;
-	daos_sg_list_t			sgl;
+	d_iov_t			kds;
+	d_iov_t			data;
+	d_sg_list_t			sgl;
 	struct dss_module_info	       *info = dss_get_module_info();
 	int				rc;
 
@@ -494,7 +494,7 @@ rdb_raft_cb_send_installsnapshot(raft_server_t *raft, void *arg,
 	sgl.sg_nr = 1;
 	sgl.sg_nr_out = 0;
 	sgl.sg_iovs = &kds;
-	rc = crt_bulk_create(info->dmi_ctx, daos2crt_sg(&sgl), CRT_BULK_RO,
+	rc = crt_bulk_create(info->dmi_ctx, &sgl, CRT_BULK_RO,
 			     &in->isi_kds);
 	if (rc != 0) {
 		D_ERROR(DF_DB": failed to create key descriptor bulk for rank "
@@ -505,8 +505,7 @@ rdb_raft_cb_send_installsnapshot(raft_server_t *raft, void *arg,
 	sgl.sg_nr = 1;
 	sgl.sg_nr_out = 0;
 	sgl.sg_iovs = &data;
-	rc = crt_bulk_create(info->dmi_ctx, daos2crt_sg(&sgl), CRT_BULK_RO,
-			     &in->isi_data);
+	rc = crt_bulk_create(info->dmi_ctx, &sgl, CRT_BULK_RO, &in->isi_data);
 	if (rc != 0) {
 		D_ERROR(DF_DB": failed to create key bulk for rank %u: %d\n",
 			DP_DB(db), rdb_node->dn_rank, rc);
@@ -575,8 +574,8 @@ rdb_raft_recv_is_bulk_cb(const struct crt_bulk_cb_info *cb_info)
  * TODO: Implement and use a "parallel bulk" helper.
  */
 static int
-rdb_raft_recv_is(struct rdb *db, crt_rpc_t *rpc, daos_iov_t *kds,
-		 daos_iov_t *data)
+rdb_raft_recv_is(struct rdb *db, crt_rpc_t *rpc, d_iov_t *kds,
+		 d_iov_t *data)
 {
 	struct rdb_installsnapshot_in  *in = crt_req_get(rpc);
 	crt_bulk_t			kds_bulk;
@@ -585,7 +584,7 @@ rdb_raft_recv_is(struct rdb *db, crt_rpc_t *rpc, daos_iov_t *kds,
 	crt_bulk_t			data_bulk;
 	struct crt_bulk_desc		data_desc;
 	crt_bulk_opid_t			data_opid;
-	daos_sg_list_t			sgl;
+	d_sg_list_t			sgl;
 	struct rdb_raft_bulk		arg;
 	int				rc;
 
@@ -611,15 +610,13 @@ rdb_raft_recv_is(struct rdb *db, crt_rpc_t *rpc, daos_iov_t *kds,
 	sgl.sg_nr = 1;
 	sgl.sg_nr_out = 0;
 	sgl.sg_iovs = &in->isi_local.rl_kds_iov;
-	rc = crt_bulk_create(rpc->cr_ctx, daos2crt_sg(&sgl), CRT_BULK_RW,
-			     &kds_bulk);
+	rc = crt_bulk_create(rpc->cr_ctx, &sgl, CRT_BULK_RW, &kds_bulk);
 	if (rc != 0)
 		goto out_data;
 	sgl.sg_nr = 1;
 	sgl.sg_nr_out = 0;
 	sgl.sg_iovs = &in->isi_local.rl_data_iov;
-	rc = crt_bulk_create(rpc->cr_ctx, daos2crt_sg(&sgl), CRT_BULK_RW,
-			     &data_bulk);
+	rc = crt_bulk_create(rpc->cr_ctx, &sgl, CRT_BULK_RW, &data_bulk);
 	if (rc != 0)
 		goto out_kds_bulk;
 
@@ -714,10 +711,10 @@ rdb_raft_exec_unpack_io(struct dss_enum_unpack_io *io, void *arg)
 }
 
 static int
-rdb_raft_unpack_chunk(daos_handle_t slc, daos_iov_t *kds, daos_iov_t *data)
+rdb_raft_unpack_chunk(daos_handle_t slc, d_iov_t *kds, d_iov_t *data)
 {
 	struct dss_enum_arg	arg;
-	daos_sg_list_t		sgl;
+	d_sg_list_t		sgl;
 
 	/* Set up the same iteration as rdb_raft_pack_chunk. */
 	memset(&arg, 0, sizeof(arg));
@@ -749,8 +746,8 @@ rdb_raft_cb_recv_installsnapshot(raft_server_t *raft, void *arg,
 	struct rdb_lc_record	       *slc_record = &db->d_slc_record;
 	uint64_t			seq;
 	struct rdb_anchor		anchor;
-	daos_iov_t			keys[2];
-	daos_iov_t			values[2];
+	d_iov_t			keys[2];
+	d_iov_t			values[2];
 	int				rc;
 
 	in = container_of(msg, struct rdb_installsnapshot_in, isi_msg);
@@ -860,9 +857,9 @@ rdb_raft_cb_recv_installsnapshot(raft_server_t *raft, void *arg,
 
 		/* Swap the records. */
 		keys[0] = rdb_mc_lc;
-		daos_iov_set(&values[0], slc_record, sizeof(*slc_record));
+		d_iov_set(&values[0], slc_record, sizeof(*slc_record));
 		keys[1] = rdb_mc_slc;
-		daos_iov_set(&values[1], lc_record, sizeof(*lc_record));
+		d_iov_set(&values[1], lc_record, sizeof(*lc_record));
 		rc = rdb_mc_update(db->d_mc, RDB_MC_ATTRS, 2 /* n */, keys,
 				   values);
 		if (rc != 0) {
@@ -905,7 +902,7 @@ rdb_raft_cb_recv_installsnapshot(raft_server_t *raft, void *arg,
 		D_DEBUG(DB_TRACE, DF_DB": chunk complete: "DF_U64"/"DF_U64"\n",
 			DP_DB(db), slc_record->dlr_base, slc_record->dlr_seq);
 
-		daos_iov_set(&values[0], slc_record, sizeof(*slc_record));
+		d_iov_set(&values[0], slc_record, sizeof(*slc_record));
 		rc = rdb_mc_update(db->d_mc, RDB_MC_ATTRS, 1 /* n */,
 				   &rdb_mc_slc, &values[0]);
 		if (rc != 0) {
@@ -979,10 +976,10 @@ static int
 rdb_raft_cb_persist_vote(raft_server_t *raft, void *arg, int vote)
 {
 	struct rdb     *db = arg;
-	daos_iov_t	value;
+	d_iov_t	value;
 	int		rc;
 
-	daos_iov_set(&value, &vote, sizeof(vote));
+	d_iov_set(&value, &vote, sizeof(vote));
 	rc = rdb_mc_update(db->d_mc, RDB_MC_ATTRS, 1 /* n */, &rdb_mc_vote,
 			   &value);
 	if (rc != 0)
@@ -995,15 +992,15 @@ static int
 rdb_raft_cb_persist_term(raft_server_t *raft, void *arg, int term, int vote)
 {
 	struct rdb     *db = arg;
-	daos_iov_t	keys[2];
-	daos_iov_t	values[2];
+	d_iov_t	keys[2];
+	d_iov_t	values[2];
 	int		rc;
 
 	/* Update rdb_mc_term and rdb_mc_vote atomically. */
 	keys[0] = rdb_mc_term;
-	daos_iov_set(&values[0], &term, sizeof(term));
+	d_iov_set(&values[0], &term, sizeof(term));
 	keys[1] = rdb_mc_vote;
-	daos_iov_set(&values[1], &vote, sizeof(vote));
+	d_iov_set(&values[1], &vote, sizeof(vote));
 	rc = rdb_mc_update(db->d_mc, RDB_MC_ATTRS, 2 /* n */, keys, values);
 	if (rc != 0)
 		D_ERROR(DF_DB": failed to update term %d and vote %d: %d\n",
@@ -1107,8 +1104,8 @@ rdb_raft_log_offer_single(raft_server_t *raft, void *arg,
 			  raft_entry_t *entry, uint64_t index)
 {
 	struct rdb	       *db = arg;
-	daos_iov_t		keys[2];
-	daos_iov_t		values[2];
+	d_iov_t		keys[2];
+	d_iov_t		values[2];
 	struct rdb_entry	header;
 	int			n = 0;
 	int			rc;
@@ -1145,11 +1142,11 @@ rdb_raft_log_offer_single(raft_server_t *raft, void *arg,
 	header.dre_type = entry->type;
 	header.dre_size = entry->data.len;
 	keys[n] = rdb_lc_entry_header;
-	daos_iov_set(&values[n], &header, sizeof(header));
+	d_iov_set(&values[n], &header, sizeof(header));
 	n++;
 	if (entry->data.len > 0) {
 		keys[n] = rdb_lc_entry_data;
-		daos_iov_set(&values[n], entry->data.buf, entry->data.len);
+		d_iov_set(&values[n], entry->data.buf, entry->data.len);
 		n++;
 	}
 	rc = rdb_lc_update(db->d_lc, index, RDB_LC_ATTRS, n, keys, values);
@@ -1161,7 +1158,7 @@ rdb_raft_log_offer_single(raft_server_t *raft, void *arg,
 
 	/* Replace entry->data.buf with the data's persistent memory address. */
 	if (entry->data.len > 0) {
-		daos_iov_set(&values[0], NULL, entry->data.len);
+		d_iov_set(&values[0], NULL, entry->data.len);
 		rc = rdb_lc_lookup(db->d_lc, index, RDB_LC_ATTRS,
 				   &rdb_lc_entry_data, &values[0]);
 		if (rc != 0) {
@@ -1176,7 +1173,7 @@ rdb_raft_log_offer_single(raft_server_t *raft, void *arg,
 
 	/* Update the log tail. See the log tail assertion above. */
 	db->d_lc_record.dlr_tail++;
-	daos_iov_set(&values[0], &db->d_lc_record, sizeof(db->d_lc_record));
+	d_iov_set(&values[0], &db->d_lc_record, sizeof(db->d_lc_record));
 	rc = rdb_mc_update(db->d_mc, RDB_MC_ATTRS, 1 /* n */, &rdb_mc_lc,
 			   &values[0]);
 	if (rc != 0) {
@@ -1223,7 +1220,7 @@ rdb_raft_cb_log_poll(raft_server_t *raft, void *arg, raft_entry_t *entries,
 	struct rdb     *db = arg;
 	uint64_t	base = db->d_lc_record.dlr_base;
 	uint64_t	base_term = db->d_lc_record.dlr_base_term;
-	daos_iov_t	value;
+	d_iov_t	value;
 	int		rc;
 
 	D_DEBUG(DB_TRACE, DF_DB": polling [%d, %d]\n", DP_DB(db), index,
@@ -1234,7 +1231,7 @@ rdb_raft_cb_log_poll(raft_server_t *raft, void *arg, raft_entry_t *entries,
 	/* Update the log base index and term. */
 	db->d_lc_record.dlr_base = index + *n_entries - 1;
 	db->d_lc_record.dlr_base_term = entries[*n_entries - 1].term;
-	daos_iov_set(&value, &db->d_lc_record, sizeof(db->d_lc_record));
+	d_iov_set(&value, &db->d_lc_record, sizeof(db->d_lc_record));
 	rc = rdb_mc_update(db->d_mc, RDB_MC_ATTRS, 1 /* n */, &rdb_mc_lc,
 			   &value);
 	if (rc != 0) {
@@ -1259,7 +1256,7 @@ rdb_raft_cb_log_pop(raft_server_t *raft, void *arg, raft_entry_t *entry,
 	struct rdb     *db = arg;
 	uint64_t	i = index;
 	uint64_t	tail = db->d_lc_record.dlr_tail;
-	daos_iov_t	value;
+	d_iov_t	value;
 	int		rc;
 
 	D_ASSERTF(i > db->d_lc_record.dlr_base, DF_U64" > "DF_U64"\n", i,
@@ -1270,7 +1267,7 @@ rdb_raft_cb_log_pop(raft_server_t *raft, void *arg, raft_entry_t *entry,
 
 	/* Update the log tail. */
 	db->d_lc_record.dlr_tail = i;
-	daos_iov_set(&value, &db->d_lc_record, sizeof(db->d_lc_record));
+	d_iov_set(&value, &db->d_lc_record, sizeof(db->d_lc_record));
 	rc = rdb_mc_update(db->d_mc, RDB_MC_ATTRS, 1 /* n */, &rdb_mc_lc,
 			   &value);
 	if (rc != 0) {
@@ -1279,7 +1276,7 @@ rdb_raft_cb_log_pop(raft_server_t *raft, void *arg, raft_entry_t *entry,
 		db->d_lc_record.dlr_tail = tail;
 		return rc;
 	}
-	daos_rank_list_free(db->d_replicas);
+	d_rank_list_free(db->d_replicas);
 	rc = rdb_raft_load_replicas(db, db->d_lc_record.dlr_tail - 1);
 	if (rc != 0)
 		return rc;
@@ -1396,7 +1393,7 @@ static int
 rdb_raft_compact(struct rdb *db, uint64_t index)
 {
 	uint64_t	aggregated = db->d_lc_record.dlr_aggregated;
-	daos_iov_t	value;
+	d_iov_t	value;
 	int		rc;
 
 	D_DEBUG(DB_TRACE, DF_DB": compacting to "DF_U64"\n", DP_DB(db), index);
@@ -1407,7 +1404,7 @@ rdb_raft_compact(struct rdb *db, uint64_t index)
 
 	/* Update the last aggregated index. */
 	db->d_lc_record.dlr_aggregated = index;
-	daos_iov_set(&value, &db->d_lc_record, sizeof(db->d_lc_record));
+	d_iov_set(&value, &db->d_lc_record, sizeof(db->d_lc_record));
 	rc = rdb_mc_update(db->d_mc, RDB_MC_ATTRS, 1 /* n */, &rdb_mc_lc,
 			   &value);
 	if (rc != 0) {
@@ -1959,7 +1956,7 @@ rdb_timerd(void *arg)
  * container creation fails.
  */
 static int
-rdb_raft_create_lc(daos_handle_t pool, daos_handle_t mc, daos_iov_t *key,
+rdb_raft_create_lc(daos_handle_t pool, daos_handle_t mc, d_iov_t *key,
 		   uint64_t base, uint64_t base_term, uint64_t term,
 		   struct rdb_lc_record *record)
 {
@@ -1970,7 +1967,7 @@ rdb_raft_create_lc(daos_handle_t pool, daos_handle_t mc, daos_iov_t *key,
 		.dlr_aggregated	= base,
 		.dlr_term	= term
 	};
-	daos_iov_t		value;
+	d_iov_t		value;
 	int			rc;
 
 	D_ASSERTF(key == &rdb_mc_lc || key == &rdb_mc_slc, "%p\n", key);
@@ -1987,7 +1984,7 @@ rdb_raft_create_lc(daos_handle_t pool, daos_handle_t mc, daos_iov_t *key,
 
 	/* Create the record before creating the container. */
 	uuid_generate(r.dlr_uuid);
-	daos_iov_set(&value, &r, sizeof(r));
+	d_iov_set(&value, &r, sizeof(r));
 	rc = rdb_mc_update(mc, RDB_MC_ATTRS, 1 /* n */, key, &value);
 	if (rc != 0) {
 		D_ERROR("failed to create %s record: %d\n",
@@ -2010,11 +2007,11 @@ rdb_raft_create_lc(daos_handle_t pool, daos_handle_t mc, daos_iov_t *key,
 }
 
 static int
-rdb_raft_destroy_lc(daos_handle_t pool, daos_handle_t mc, daos_iov_t *key,
+rdb_raft_destroy_lc(daos_handle_t pool, daos_handle_t mc, d_iov_t *key,
 		    uuid_t uuid, struct rdb_lc_record *record)
 {
 	struct rdb_lc_record	r = {};
-	daos_iov_t		value;
+	d_iov_t		value;
 	int			rc;
 
 	D_ASSERTF(key == &rdb_mc_lc || key == &rdb_mc_slc, "%p\n", key);
@@ -2029,7 +2026,7 @@ rdb_raft_destroy_lc(daos_handle_t pool, daos_handle_t mc, daos_iov_t *key,
 
 	/* Clear the record. We cannot rollback the destroy. */
 	uuid_clear(r.dlr_uuid);
-	daos_iov_set(&value, &r, sizeof(r));
+	d_iov_set(&value, &r, sizeof(r));
 	rc = rdb_mc_update(mc, RDB_MC_ATTRS, 1 /* n */, key, &value);
 	if (rc != 0) {
 		D_ERROR("failed to clear %s record: %d\n",
@@ -2081,14 +2078,14 @@ rdb_raft_init(daos_handle_t pool, daos_handle_t mc,
 static int
 rdb_raft_load_entry(struct rdb *db, uint64_t index)
 {
-	daos_iov_t		value;
+	d_iov_t		value;
 	struct rdb_entry	header;
 	raft_entry_t		entry;
 	int			n_entries;
 	int			rc;
 
 	/* Look up the header. */
-	daos_iov_set(&value, &header, sizeof(header));
+	d_iov_set(&value, &header, sizeof(header));
 	rc = rdb_lc_lookup(db->d_lc, index, RDB_LC_ATTRS, &rdb_lc_entry_header,
 			   &value);
 	if (rc != 0) {
@@ -2103,7 +2100,7 @@ rdb_raft_load_entry(struct rdb *db, uint64_t index)
 
 	/* Look up the persistent memory address of the data (if nonempty). */
 	if (entry.data.len > 0) {
-		daos_iov_set(&value, NULL, header.dre_size);
+		d_iov_set(&value, NULL, header.dre_size);
 		rc = rdb_lc_lookup(db->d_lc, index, RDB_LC_ATTRS,
 				   &rdb_lc_entry_data, &value);
 		if (rc != 0) {
@@ -2152,12 +2149,12 @@ rdb_raft_load_entry(struct rdb *db, uint64_t index)
 static int
 rdb_raft_load_lc(struct rdb *db)
 {
-	daos_iov_t	value;
+	d_iov_t	value;
 	uint64_t	i;
 	int		rc;
 
 	/* Look up and open the SLC. */
-	daos_iov_set(&value, &db->d_slc_record, sizeof(db->d_slc_record));
+	d_iov_set(&value, &db->d_slc_record, sizeof(db->d_slc_record));
 	rc = rdb_mc_lookup(db->d_mc, RDB_MC_ATTRS, &rdb_mc_slc, &value);
 	if (rc == -DER_NONEXIST) {
 		D_DEBUG(DB_MD, DF_DB": no SLC record\n", DP_DB(db));
@@ -2180,7 +2177,7 @@ rdb_raft_load_lc(struct rdb *db)
 
 lc:
 	/* Look up and open the LC. */
-	daos_iov_set(&value, &db->d_lc_record, sizeof(db->d_lc_record));
+	d_iov_set(&value, &db->d_lc_record, sizeof(db->d_lc_record));
 	rc = rdb_mc_lookup(db->d_mc, RDB_MC_ATTRS, &rdb_mc_lc, &value);
 	if (rc != 0) {
 		D_ERROR(DF_DB": failed to look up LC: %d\n", DP_DB(db), rc);
@@ -2275,7 +2272,7 @@ rdb_raft_get_compact_thres(void)
 int
 rdb_raft_start(struct rdb *db)
 {
-	daos_iov_t	value;
+	d_iov_t	value;
 	int		term;
 	int		vote;
 	int		election_timeout;
@@ -2336,7 +2333,7 @@ rdb_raft_start(struct rdb *db)
 	 * Read raft persistent state, if any. Done before setting the
 	 * callbacks in order to avoid unnecessary I/Os.
 	 */
-	daos_iov_set(&value, &term, sizeof(term));
+	d_iov_set(&value, &term, sizeof(term));
 	rc = rdb_mc_lookup(db->d_mc, RDB_MC_ATTRS, &rdb_mc_term, &value);
 	if (rc == 0) {
 		rc = raft_set_current_term(db->d_raft, term);
@@ -2344,7 +2341,7 @@ rdb_raft_start(struct rdb *db)
 	} else if (rc != -DER_NONEXIST) {
 		goto err_raft;
 	}
-	daos_iov_set(&value, &vote, sizeof(vote));
+	d_iov_set(&value, &vote, sizeof(vote));
 	rc = rdb_mc_lookup(db->d_mc, RDB_MC_ATTRS, &rdb_mc_vote, &value);
 	if (rc == 0) {
 		rc = raft_vote_for_nodeid(db->d_raft, vote);
@@ -2356,7 +2353,7 @@ rdb_raft_start(struct rdb *db)
 	if (rc != 0)
 		goto err_raft;
 
-	daos_rank_list_free(db->d_replicas);
+	d_rank_list_free(db->d_replicas);
 	rc = rdb_raft_load_replicas(db, db->d_lc_record.dlr_tail - 1);
 	if (rc != 0 && rc != -DER_NONEXIST)
 		goto err_lc;
@@ -2719,16 +2716,16 @@ rdb_raft_process_reply(struct rdb *db, crt_rpc_t *rpc)
 			DP_DB(db), opc, rc);
 }
 
-/* The buffer belonging to bulk must a single daos_iov_t. */
+/* The buffer belonging to bulk must a single d_iov_t. */
 static void
 rdb_raft_free_bulk_and_buffer(crt_bulk_t bulk)
 {
-	daos_iov_t	iov;
-	daos_sg_list_t	sgl;
+	d_iov_t	iov;
+	d_sg_list_t	sgl;
 	int		rc;
 
 	/* Save the buffer address in iov.iov_buf. */
-	daos_iov_set(&iov, NULL /* buf */, 0 /* size */);
+	d_iov_set(&iov, NULL /* buf */, 0 /* size */);
 	sgl.sg_nr = 1;
 	sgl.sg_nr_out = 0;
 	sgl.sg_iovs = &iov;

--- a/src/rdb/rdb_tx.c
+++ b/src/rdb/rdb_tx.c
@@ -176,8 +176,8 @@ rdb_tx_opc_str(enum rdb_tx_opc opc)
 struct rdb_tx_op {
 	enum rdb_tx_opc		dto_opc;
 	rdb_path_t		dto_kvs;
-	daos_iov_t		dto_key;
-	daos_iov_t		dto_value;
+	d_iov_t		dto_key;
+	d_iov_t		dto_value;
 	struct rdb_kvs_attr    *dto_attr;
 };
 
@@ -378,7 +378,7 @@ rdb_tx_destroy_root(struct rdb_tx *tx)
  */
 int
 rdb_tx_create_kvs(struct rdb_tx *tx, const rdb_path_t *parent,
-		  const daos_iov_t *key, const struct rdb_kvs_attr *attr)
+		  const d_iov_t *key, const struct rdb_kvs_attr *attr)
 {
 	struct rdb_tx_op op = {
 		.dto_opc	= RDB_TX_CREATE,
@@ -403,7 +403,7 @@ rdb_tx_create_kvs(struct rdb_tx *tx, const rdb_path_t *parent,
  */
 int
 rdb_tx_destroy_kvs(struct rdb_tx *tx, const rdb_path_t *parent,
-		   const daos_iov_t *key)
+		   const d_iov_t *key)
 {
 	struct rdb_tx_op op = {
 		.dto_opc	= RDB_TX_DESTROY,
@@ -427,8 +427,8 @@ rdb_tx_destroy_kvs(struct rdb_tx *tx, const rdb_path_t *parent,
  * \retval -DER_NOTLEADER	not current leader
  */
 int
-rdb_tx_update(struct rdb_tx *tx, const rdb_path_t *kvs, const daos_iov_t *key,
-	      const daos_iov_t *value)
+rdb_tx_update(struct rdb_tx *tx, const rdb_path_t *kvs, const d_iov_t *key,
+	      const d_iov_t *value)
 {
 	struct rdb_tx_op op = {
 		.dto_opc	= RDB_TX_UPDATE,
@@ -451,7 +451,7 @@ rdb_tx_update(struct rdb_tx *tx, const rdb_path_t *kvs, const daos_iov_t *key,
  * \retval -DER_NOTLEADER	not current leader
  */
 int
-rdb_tx_delete(struct rdb_tx *tx, const rdb_path_t *kvs, const daos_iov_t *key)
+rdb_tx_delete(struct rdb_tx *tx, const rdb_path_t *kvs, const d_iov_t *key)
 {
 	struct rdb_tx_op op = {
 		.dto_opc	= RDB_TX_DELETE,
@@ -481,9 +481,9 @@ rdb_oid_class(enum rdb_kvs_class class, rdb_oid_t *oid_class)
 
 static int
 rdb_tx_apply_create(struct rdb *db, uint64_t index, rdb_oid_t parent,
-		    daos_iov_t *key, enum rdb_kvs_class class)
+		    d_iov_t *key, enum rdb_kvs_class class)
 {
-	daos_iov_t	value;
+	d_iov_t	value;
 	rdb_oid_t	oid_class;
 	rdb_oid_t	oid_number;
 	rdb_oid_t	oid;
@@ -498,7 +498,7 @@ rdb_tx_apply_create(struct rdb *db, uint64_t index, rdb_oid_t parent,
 	}
 
 	/* Does the KVS already exist? */
-	daos_iov_set(&value, NULL, sizeof(rdb_oid_t));
+	d_iov_set(&value, NULL, sizeof(rdb_oid_t));
 	rc = rdb_lc_lookup(db->d_lc, index, parent, key, &value);
 	if (rc == 0) {
 		return -DER_EXIST;
@@ -509,7 +509,7 @@ rdb_tx_apply_create(struct rdb *db, uint64_t index, rdb_oid_t parent,
 	}
 
 	/* Allocate an object for the new KVS. */
-	daos_iov_set(&value, &oid_number, sizeof(oid_number));
+	d_iov_set(&value, &oid_number, sizeof(oid_number));
 	rc = rdb_lc_lookup(db->d_lc, index, RDB_LC_ATTRS, &rdb_lc_oid_next,
 			   &value);
 	if (rc == -DER_NONEXIST) {
@@ -539,7 +539,7 @@ rdb_tx_apply_create(struct rdb *db, uint64_t index, rdb_oid_t parent,
 	}
 
 	/* Update the key in the parent object. */
-	daos_iov_set(&value, &oid, sizeof(oid));
+	d_iov_set(&value, &oid, sizeof(oid));
 	rc = rdb_lc_update(db->d_lc, index, parent, 1 /* n */, key, &value);
 	if (rc != 0) {
 		D_ERROR(DF_DB": failed to update parent KVS: %d\n", DP_DB(db),
@@ -552,14 +552,14 @@ rdb_tx_apply_create(struct rdb *db, uint64_t index, rdb_oid_t parent,
 
 static int
 rdb_tx_apply_destroy(struct rdb *db, uint64_t index, rdb_oid_t parent,
-		     daos_iov_t *key)
+		     d_iov_t *key)
 {
-	daos_iov_t	value;
+	d_iov_t	value;
 	rdb_oid_t	oid;
 	int		rc;
 
 	/* Does the KVS exist? */
-	daos_iov_set(&value, &oid, sizeof(oid));
+	d_iov_set(&value, &oid, sizeof(oid));
 	rc = rdb_lc_lookup(db->d_lc, index, parent, key, &value);
 	if (rc != 0) {
 		if (rc != -DER_NONEXIST)
@@ -589,7 +589,7 @@ rdb_tx_apply_destroy(struct rdb *db, uint64_t index, rdb_oid_t parent,
 
 static int
 rdb_tx_apply_update(struct rdb *db, uint64_t index, rdb_oid_t kvs,
-		    daos_iov_t *key, daos_iov_t *value)
+		    d_iov_t *key, d_iov_t *value)
 {
 	int rc;
 
@@ -602,7 +602,7 @@ rdb_tx_apply_update(struct rdb *db, uint64_t index, rdb_oid_t kvs,
 
 static int
 rdb_tx_apply_delete(struct rdb *db, uint64_t index, rdb_oid_t kvs,
-		    daos_iov_t *key)
+		    d_iov_t *key)
 {
 	int rc;
 
@@ -830,8 +830,8 @@ rdb_tx_query_post(struct rdb_tx *tx, struct rdb_kvs *kvs)
  * \retval -DER_MISMATCH	unexpected value length
  */
 int
-rdb_tx_lookup(struct rdb_tx *tx, const rdb_path_t *kvs, const daos_iov_t *key,
-	      daos_iov_t *value)
+rdb_tx_lookup(struct rdb_tx *tx, const rdb_path_t *kvs, const d_iov_t *key,
+	      d_iov_t *value)
 {
 	struct rdb     *db = tx->dt_db;
 	struct rdb_kvs *s;
@@ -841,7 +841,7 @@ rdb_tx_lookup(struct rdb_tx *tx, const rdb_path_t *kvs, const daos_iov_t *key,
 	if (rc != 0)
 		return rc;
 	rc = rdb_lc_lookup(db->d_lc, db->d_applied, s->de_object,
-			   (daos_iov_t *)key, value);
+			   (d_iov_t *)key, value);
 	rdb_tx_query_post(tx, s);
 	return rc;
 }
@@ -864,7 +864,7 @@ rdb_tx_lookup(struct rdb_tx *tx, const rdb_path_t *kvs, const daos_iov_t *key,
  */
 int
 rdb_tx_fetch(struct rdb_tx *tx, const rdb_path_t *kvs, enum rdb_probe_opc opc,
-	     const daos_iov_t *key_in, daos_iov_t *key_out, daos_iov_t *value)
+	     const d_iov_t *key_in, d_iov_t *key_out, d_iov_t *value)
 {
 	struct rdb     *db = tx->dt_db;
 	struct rdb_kvs *s;
@@ -874,7 +874,7 @@ rdb_tx_fetch(struct rdb_tx *tx, const rdb_path_t *kvs, enum rdb_probe_opc opc,
 	if (rc != 0)
 		return rc;
 	rc = rdb_lc_iter_fetch(db->d_lc, db->d_applied, s->de_object, opc,
-			       (daos_iov_t *)key_in, key_out, value);
+			       (d_iov_t *)key_in, key_out, value);
 	rdb_tx_query_post(tx, s);
 	return rc;
 }

--- a/src/rdb/rdb_util.c
+++ b/src/rdb/rdb_util.c
@@ -35,9 +35,9 @@
 #include "rdb_internal.h"
 
 /*
- * daos_iov_t encoding/decoding utilities
+ * d_iov_t encoding/decoding utilities
  *
- * These functions convert between a daos_iov_t object and a byte stream in a
+ * These functions convert between a d_iov_t object and a byte stream in a
  * buffer. The format of such a byte stream is:
  *
  *   size_head (rdb_iov_size_t)
@@ -45,7 +45,7 @@
  *   size_tail (rdb_iov_size_t)
  *
  * size_head and size_tail are identical, both indicates the size of data,
- * which equals iov_len of the corresponding daos_iov_t object. The two sizes
+ * which equals iov_len of the corresponding d_iov_t object. The two sizes
  * allows decoding from the tail as well as from the head.
  */
 
@@ -56,7 +56,7 @@ const daos_size_t rdb_iov_max = (rdb_iov_size_t)-1LL;
 
 /* If buf is NULL, then just calculate and return the length required. */
 size_t
-rdb_encode_iov(const daos_iov_t *iov, void *buf)
+rdb_encode_iov(const d_iov_t *iov, void *buf)
 {
 	size_t len = sizeof(rdb_iov_size_t) * 2 + iov->iov_len;
 
@@ -82,9 +82,9 @@ rdb_encode_iov(const daos_iov_t *iov, void *buf)
 
 /* Returns the number of bytes processed or -DER_IO if the content is bad. */
 ssize_t
-rdb_decode_iov(const void *buf, size_t len, daos_iov_t *iov)
+rdb_decode_iov(const void *buf, size_t len, d_iov_t *iov)
 {
-	daos_iov_t	v = {};
+	d_iov_t	v = {};
 	const void     *p = buf;
 
 	/* iov_len (head) */
@@ -129,9 +129,9 @@ rdb_decode_iov(const void *buf, size_t len, daos_iov_t *iov)
 
 /* Returns the number of bytes processed or -DER_IO if the content is bad. */
 ssize_t
-rdb_decode_iov_backward(const void *buf_end, size_t len, daos_iov_t *iov)
+rdb_decode_iov_backward(const void *buf_end, size_t len, d_iov_t *iov)
 {
-	daos_iov_t	v = {};
+	d_iov_t	v = {};
 	const void     *p = buf_end;
 
 	/* iov_len (tail) */
@@ -239,8 +239,8 @@ enum rdb_vos_op {
 };
 
 static void
-rdb_vos_set_iods(enum rdb_vos_op op, int n, daos_iov_t akeys[],
-		 daos_iov_t values[], daos_iod_t iods[])
+rdb_vos_set_iods(enum rdb_vos_op op, int n, d_iov_t akeys[],
+		 d_iov_t values[], daos_iod_t iods[])
 {
 	int i;
 
@@ -257,8 +257,8 @@ rdb_vos_set_iods(enum rdb_vos_op op, int n, daos_iov_t akeys[],
 }
 
 static void
-rdb_vos_set_sgls(enum rdb_vos_op op, int n, daos_iov_t values[],
-		 daos_sg_list_t sgls[])
+rdb_vos_set_sgls(enum rdb_vos_op op, int n, d_iov_t values[],
+		 d_sg_list_t sgls[])
 {
 	int i;
 
@@ -272,7 +272,7 @@ rdb_vos_set_sgls(enum rdb_vos_op op, int n, daos_iov_t values[],
 }
 
 static inline int
-rdb_vos_fetch_check(daos_iov_t *value, daos_iov_t *value_orig)
+rdb_vos_fetch_check(d_iov_t *value, d_iov_t *value_orig)
 {
 	/*
 	 * An emtpy value represents nonexistence. Keep the caller value intact
@@ -294,12 +294,12 @@ rdb_vos_fetch_check(daos_iov_t *value, daos_iov_t *value_orig)
 
 int
 rdb_vos_fetch(daos_handle_t cont, daos_epoch_t epoch, rdb_oid_t oid,
-	      daos_key_t *akey, daos_iov_t *value)
+	      daos_key_t *akey, d_iov_t *value)
 {
 	daos_unit_oid_t	uoid;
 	daos_iod_t	iod;
-	daos_sg_list_t	sgl;
-	daos_iov_t	value_orig = *value;
+	d_sg_list_t	sgl;
+	d_iov_t	value_orig = *value;
 	int		rc;
 
 	rdb_oid_to_uoid(oid, &uoid);
@@ -322,13 +322,13 @@ rdb_vos_fetch(daos_handle_t cont, daos_epoch_t epoch, rdb_oid_t oid,
  */
 int
 rdb_vos_fetch_addr(daos_handle_t cont, daos_epoch_t epoch, rdb_oid_t oid,
-		   daos_key_t *akey, daos_iov_t *value)
+		   daos_key_t *akey, d_iov_t *value)
 {
 	daos_unit_oid_t	uoid;
 	daos_iod_t	iod;
 	daos_handle_t	io;
 	struct bio_sglist *bsgl;
-	daos_iov_t	value_orig = *value;
+	d_iov_t	value_orig = *value;
 	int		rc;
 
 	rdb_oid_to_uoid(oid, &uoid);
@@ -378,7 +378,7 @@ out:
 int
 rdb_vos_iter_fetch(daos_handle_t cont, daos_epoch_t epoch, rdb_oid_t oid,
 		   enum rdb_probe_opc opc, daos_key_t *akey_in,
-		   daos_key_t *akey_out, daos_iov_t *value)
+		   daos_key_t *akey_out, d_iov_t *value)
 {
 	vos_iter_param_t	param = {};
 	daos_handle_t		iter;
@@ -465,14 +465,14 @@ rdb_vos_iterate(daos_handle_t cont, daos_epoch_t epoch, rdb_oid_t oid,
 	}
 
 	for (;;) {
-		daos_iov_t		value;
+		d_iov_t		value;
 		vos_iter_entry_t	entry;
 
 		/* Fetch the a-key and the address of its value. */
 		rc = vos_iter_fetch(iter, &entry, NULL /* anchor */);
 		if (rc != 0)
 			break;
-		daos_iov_set(&value, NULL /* buf */, 0 /* size */);
+		d_iov_set(&value, NULL /* buf */, 0 /* size */);
 		rc = rdb_vos_fetch_addr(cont, epoch, oid, &entry.ie_key,
 					&value);
 		if (rc != 0)
@@ -504,11 +504,11 @@ out:
 
 int
 rdb_vos_update(daos_handle_t cont, daos_epoch_t epoch, rdb_oid_t oid, int n,
-	       daos_iov_t akeys[], daos_iov_t values[])
+	       d_iov_t akeys[], d_iov_t values[])
 {
 	daos_unit_oid_t	uoid;
 	daos_iod_t	iods[n];
-	daos_sg_list_t	sgls[n];
+	d_sg_list_t	sgls[n];
 
 	D_ASSERTF(n <= RDB_VOS_BATCH_MAX, "%d <= %d\n", n, RDB_VOS_BATCH_MAX);
 	rdb_oid_to_uoid(oid, &uoid);
@@ -520,7 +520,7 @@ rdb_vos_update(daos_handle_t cont, daos_epoch_t epoch, rdb_oid_t oid, int n,
 
 int
 rdb_vos_punch(daos_handle_t cont, daos_epoch_t epoch, rdb_oid_t oid, int n,
-	      daos_iov_t akeys[])
+	      d_iov_t akeys[])
 {
 	daos_unit_oid_t	uoid;
 

--- a/src/rebuild/initiator.c
+++ b/src/rebuild/initiator.c
@@ -77,8 +77,8 @@ static int
 rebuild_fetch_update_inline(struct rebuild_one *rdone, daos_handle_t oh,
 			    struct ds_cont_child *ds_cont)
 {
-	daos_sg_list_t	sgls[DSS_ENUM_UNPACK_MAX_IODS];
-	daos_iov_t	iov[DSS_ENUM_UNPACK_MAX_IODS];
+	d_sg_list_t	sgls[DSS_ENUM_UNPACK_MAX_IODS];
+	d_iov_t	iov[DSS_ENUM_UNPACK_MAX_IODS];
 	int		iod_cnt = 0;
 	int		start;
 	char		iov_buf[DSS_ENUM_UNPACK_MAX_IODS][MAX_BUF_SIZE];
@@ -96,7 +96,7 @@ rebuild_fetch_update_inline(struct rebuild_one *rdone, daos_handle_t oh,
 		} else {
 			sgls[i].sg_nr = 1;
 			sgls[i].sg_nr_out = 1;
-			daos_iov_set(&iov[i], iov_buf[i], MAX_BUF_SIZE);
+			d_iov_set(&iov[i], iov_buf[i], MAX_BUF_SIZE);
 			sgls[i].sg_iovs = &iov[i];
 			fetch = true;
 		}
@@ -163,7 +163,7 @@ static int
 rebuild_fetch_update_bulk(struct rebuild_one *rdone, daos_handle_t oh,
 			  struct ds_cont_child *ds_cont)
 {
-	daos_sg_list_t	 sgls[DSS_ENUM_UNPACK_MAX_IODS], *sgl;
+	d_sg_list_t	 sgls[DSS_ENUM_UNPACK_MAX_IODS], *sgl;
 	daos_handle_t	 ioh;
 	int		 rc, i, ret, sgl_cnt = 0;
 
@@ -504,7 +504,7 @@ rebuild_one_ult(void *arg)
 }
 
 static int
-rw_iod_pack(struct rebuild_one *rdone, daos_iod_t *iod, daos_sg_list_t *sgls)
+rw_iod_pack(struct rebuild_one *rdone, daos_iod_t *iod, d_sg_list_t *sgls)
 {
 	int idx = rdone->ro_iod_num;
 	int rec_cnt = 0;
@@ -586,7 +586,7 @@ static int
 rebuild_one_queue(struct rebuild_iter_obj_arg *iter_arg, daos_unit_oid_t *oid,
 		  daos_key_t *dkey, daos_epoch_t dkey_eph, daos_iod_t *iods,
 		  daos_epoch_t *akey_ephs, int iod_eph_total,
-		  daos_sg_list_t *sgls, uint32_t version)
+		  d_sg_list_t *sgls, uint32_t version)
 {
 	struct rebuild_puller		*puller;
 	struct rebuild_tgt_pool_tracker *rpt = iter_arg->rpt;
@@ -767,8 +767,8 @@ rebuild_obj_ult(void *data)
 	daos_anchor_t			 dkey_anchor;
 	daos_anchor_t			 akey_anchor;
 	daos_handle_t			 oh;
-	daos_sg_list_t			 sgl = { 0 };
-	daos_iov_t			 iov = { 0 };
+	d_sg_list_t			 sgl = { 0 };
+	d_iov_t			 iov = { 0 };
 	char				 stack_buf[ITER_BUF_SIZE];
 	char				*buf = NULL;
 	daos_size_t			 buf_len;
@@ -921,8 +921,8 @@ rebuild_obj_callback(daos_unit_oid_t oid, daos_epoch_t eph, unsigned int shard,
 
 #define DEFAULT_YIELD_FREQ			128
 static int
-puller_obj_iter_cb(daos_handle_t ih, daos_iov_t *key_iov,
-		   daos_iov_t *val_iov, void *data)
+puller_obj_iter_cb(daos_handle_t ih, d_iov_t *key_iov,
+		   d_iov_t *val_iov, void *data)
 {
 	struct puller_iter_arg		*arg = data;
 	struct rebuild_tgt_pool_tracker *rpt = arg->rpt;
@@ -992,8 +992,8 @@ puller_obj_iter_cb(daos_handle_t ih, daos_iov_t *key_iov,
 }
 
 static int
-puller_cont_iter_cb(daos_handle_t ih, daos_iov_t *key_iov,
-		    daos_iov_t *val_iov, void *data)
+puller_cont_iter_cb(daos_handle_t ih, d_iov_t *key_iov,
+		    d_iov_t *val_iov, void *data)
 {
 	struct rebuild_root		*root = val_iov->iov_buf;
 	struct puller_iter_arg		*arg = data;
@@ -1104,8 +1104,8 @@ rebuild_puller_ult(void *arg)
 }
 
 static int
-rebuilt_btr_destory_cb(daos_handle_t ih, daos_iov_t *key_iov,
-		       daos_iov_t *val_iov, void *data)
+rebuilt_btr_destory_cb(daos_handle_t ih, d_iov_t *key_iov,
+		       d_iov_t *val_iov, void *data)
 {
 	struct rebuild_root		*root = val_iov->iov_buf;
 	int				rc;
@@ -1198,8 +1198,8 @@ rebuild_scheduled_obj_insert_cb(struct rebuild_root *cont_root, uuid_t co_uuid,
 	struct rebuilt_oid	roid_tmp;
 	struct rebuild_obj_key	key = { 0 };
 	uint32_t		req_cnt;
-	daos_iov_t		key_iov;
-	daos_iov_t		val_iov;
+	d_iov_t		key_iov;
+	d_iov_t		val_iov;
 	int			rc;
 
 	/* ignore the DAOS_OBJ_REPL_MAX case for now */
@@ -1218,8 +1218,8 @@ rebuild_scheduled_obj_insert_cb(struct rebuild_root *cont_root, uuid_t co_uuid,
 	key.eph = eph;
 	key.tgt_idx = tgt_idx;
 	/* Finally look up the object under the container tree */
-	daos_iov_set(&key_iov, &key, sizeof(key));
-	daos_iov_set(&val_iov, NULL, 0);
+	d_iov_set(&key_iov, &key, sizeof(key));
+	d_iov_set(&val_iov, NULL, 0);
 	rc = dbtree_lookup(cont_root->root_hdl, &key_iov, &val_iov);
 	D_DEBUG(DB_REBUILD, "lookup "DF_UOID" in cont "DF_UUID" eph "
 		DF_U64" tgt_idx %d rc %d\n", DP_UOID(oid), DP_UUID(co_uuid),
@@ -1270,7 +1270,7 @@ rebuild_scheduled_obj_insert_cb(struct rebuild_root *cont_root, uuid_t co_uuid,
 		roid_tmp.ro_req_expect = req_cnt;
 		roid_tmp.ro_req_recv = 1;
 		roid_tmp.ro_shard = shard;
-		daos_iov_set(&val_iov, &roid_tmp, sizeof(roid_tmp));
+		d_iov_set(&val_iov, &roid_tmp, sizeof(roid_tmp));
 		rc = dbtree_update(cont_root->root_hdl, &key_iov, &val_iov);
 		if (rc < 0) {
 			D_ERROR("failed to insert "DF_UOID": rc %d\n",

--- a/src/rebuild/rebuild_iv.c
+++ b/src/rebuild/rebuild_iv.c
@@ -249,7 +249,7 @@ int
 rebuild_iv_fetch(void *ns, struct rebuild_iv *rebuild_iv)
 {
 	d_sg_list_t		sgl;
-	daos_iov_t		iov;
+	d_iov_t		iov;
 	struct ds_iv_key	key;
 	int			rc;
 
@@ -275,7 +275,7 @@ rebuild_iv_update(void *ns, struct rebuild_iv *iv,
 		  unsigned int shortcut, unsigned int sync_mode)
 {
 	d_sg_list_t		sgl;
-	daos_iov_t		iov;
+	d_iov_t		iov;
 	struct ds_iv_key	key;
 	int			rc;
 

--- a/src/rebuild/rpc.h
+++ b/src/rebuild/rpc.h
@@ -68,7 +68,7 @@ extern struct crt_proto_format rebuild_proto_fmt;
 	((uuid_t)		(rsi_pool_hdl_uuid)	CRT_VAR) \
 	((uuid_t)		(rsi_cont_hdl_uuid)	CRT_VAR) \
 	((d_rank_list_t)	(rsi_svc_list)		CRT_PTR) \
-	((daos_iov_t)		(rsi_ns_iov)		CRT_VAR) \
+	((d_iov_t)		(rsi_ns_iov)		CRT_VAR) \
 	((uint64_t)		(rsi_leader_term)	CRT_VAR) \
 	((uint32_t)		(rsi_tgts_num)		CRT_VAR) \
 	((uint32_t)		(rsi_ns_id)		CRT_VAR) \

--- a/src/rebuild/scan.c
+++ b/src/rebuild/scan.c
@@ -63,8 +63,8 @@ struct rebuild_scan_arg {
 };
 
 static int
-rebuild_obj_fill_buf(daos_handle_t ih, daos_iov_t *key_iov,
-		     daos_iov_t *val_iov, void *data)
+rebuild_obj_fill_buf(daos_handle_t ih, d_iov_t *key_iov,
+		     d_iov_t *val_iov, void *data)
 {
 	struct rebuild_send_arg *arg = data;
 	struct rebuild_root	*root = arg->tgt_root;
@@ -108,8 +108,8 @@ rebuild_obj_fill_buf(daos_handle_t ih, daos_iov_t *key_iov,
 }
 
 static int
-rebuild_cont_iter_cb(daos_handle_t ih, daos_iov_t *key_iov,
-		     daos_iov_t *val_iov, void *data)
+rebuild_cont_iter_cb(daos_handle_t ih, d_iov_t *key_iov,
+		     d_iov_t *val_iov, void *data)
 {
 	struct rebuild_root *root = val_iov->iov_buf;
 	struct rebuild_send_arg *arg = data;
@@ -305,8 +305,8 @@ out:
 }
 
 static int
-rebuild_tgt_fini_obj_send_cb(daos_handle_t ih, daos_iov_t *key_iov,
-			     daos_iov_t *val_iov, void *data)
+rebuild_tgt_fini_obj_send_cb(daos_handle_t ih, d_iov_t *key_iov,
+			     d_iov_t *val_iov, void *data)
 {
 	struct rebuild_root *root;
 	struct rebuild_scan_arg *arg = data;
@@ -353,8 +353,8 @@ rebuild_tree_create(daos_handle_t toh, unsigned int tree_class,
 		    void *key, daos_size_t key_size,
 		    struct rebuild_root **rootp)
 {
-	daos_iov_t key_iov;
-	daos_iov_t val_iov;
+	d_iov_t key_iov;
+	d_iov_t val_iov;
 	struct umem_attr uma;
 	struct rebuild_root root;
 	struct btr_root	*broot;
@@ -377,13 +377,13 @@ rebuild_tree_create(daos_handle_t toh, unsigned int tree_class,
 		D_GOTO(out, rc);
 	}
 
-	daos_iov_set(&key_iov, key, key_size);
-	daos_iov_set(&val_iov, &root, sizeof(root));
+	d_iov_set(&key_iov, key, key_size);
+	d_iov_set(&val_iov, &root, sizeof(root));
 	rc = dbtree_update(toh, &key_iov, &val_iov);
 	if (rc)
 		D_GOTO(out, rc);
 
-	daos_iov_set(&val_iov, NULL, 0);
+	d_iov_set(&val_iov, NULL, 0);
 	rc = dbtree_lookup(toh, &key_iov, &val_iov);
 	if (rc)
 		D_GOTO(out, rc);
@@ -421,8 +421,8 @@ rebuild_obj_insert_cb(struct rebuild_root *cont_root, uuid_t co_uuid,
 		      unsigned int tgt_idx, unsigned int *cnt, int ref)
 {
 	struct rebuild_obj_key	key;
-	daos_iov_t		key_iov;
-	daos_iov_t		val_iov;
+	d_iov_t		key_iov;
+	d_iov_t		val_iov;
 	int			rc;
 
 	oid.id_shard = shard;
@@ -431,8 +431,8 @@ rebuild_obj_insert_cb(struct rebuild_root *cont_root, uuid_t co_uuid,
 	key.tgt_idx = tgt_idx;
 
 	/* look up the object under the container tree */
-	daos_iov_set(&key_iov, &key, sizeof(key));
-	daos_iov_set(&val_iov, &shard, sizeof(shard));
+	d_iov_set(&key_iov, &key, sizeof(key));
+	d_iov_set(&val_iov, &shard, sizeof(shard));
 	rc = dbtree_lookup(cont_root->root_hdl, &key_iov, &val_iov);
 	D_DEBUG(DB_REBUILD, "lookup "DF_UOID" in cont "DF_UUID" eph "
 		DF_U64" rc %d\n", DP_UOID(oid), DP_UUID(co_uuid), eph, rc);
@@ -461,12 +461,12 @@ rebuild_cont_obj_insert(daos_handle_t toh, uuid_t co_uuid, daos_unit_oid_t oid,
 			rebuild_obj_insert_cb_t obj_cb)
 {
 	struct rebuild_root	*cont_root;
-	daos_iov_t		key_iov;
-	daos_iov_t		val_iov;
+	d_iov_t		key_iov;
+	d_iov_t		val_iov;
 	int			rc;
 
-	daos_iov_set(&key_iov, co_uuid, sizeof(uuid_t));
-	daos_iov_set(&val_iov, NULL, 0);
+	d_iov_set(&key_iov, co_uuid, sizeof(uuid_t));
+	d_iov_set(&val_iov, NULL, 0);
 	rc = dbtree_lookup(toh, &key_iov, &val_iov);
 	if (rc < 0) {
 		if (rc != -DER_NONEXIST) {
@@ -499,15 +499,15 @@ rebuild_object_insert(struct rebuild_scan_arg *arg, unsigned int tgt_id,
 		      unsigned int shard, uuid_t pool_uuid, uuid_t co_uuid,
 		      daos_unit_oid_t oid, daos_epoch_t epoch)
 {
-	daos_iov_t		key_iov;
-	daos_iov_t		val_iov;
+	d_iov_t		key_iov;
+	d_iov_t		val_iov;
 	struct rebuild_root	*tgt_root;
 	daos_handle_t		toh = arg->rebuild_tree_hdl;
 	int			rc;
 
 	/* look up the target tree */
-	daos_iov_set(&key_iov, &tgt_id, sizeof(tgt_id));
-	daos_iov_set(&val_iov, NULL, 0);
+	d_iov_set(&key_iov, &tgt_id, sizeof(tgt_id));
+	d_iov_set(&val_iov, NULL, 0);
 	ABT_mutex_lock(arg->scan_lock);
 	rc = dbtree_lookup(toh, &key_iov, &val_iov);
 	if (rc < 0) {

--- a/src/rebuild/srv.c
+++ b/src/rebuild/srv.c
@@ -868,7 +868,7 @@ rebuild_scan_broadcast(struct ds_pool *pool,
 		       struct rebuild_global_pool_tracker *rgt,
 		       struct pool_target_id_list *tgts_failed,
 		       d_rank_list_t *svc_list, uint32_t map_ver,
-		       daos_iov_t *map_buf)
+		       d_iov_t *map_buf)
 {
 	struct rebuild_scan_in	*rsi;
 	struct rebuild_scan_out	*rso;
@@ -879,8 +879,7 @@ rebuild_scan_broadcast(struct ds_pool *pool,
 
 	sgl.sg_nr = 1;
 	sgl.sg_iovs = map_buf;
-	rc = crt_bulk_create(dss_get_module_info()->dmi_ctx,
-			     daos2crt_sg(&sgl), CRT_BULK_RW,
+	rc = crt_bulk_create(dss_get_module_info()->dmi_ctx, &sgl, CRT_BULK_RW,
 			     &bulk_hdl);
 	if (rc != 0) {
 		D_ERROR("Create bulk for map buffer failed: rc %d\n", rc);
@@ -1004,7 +1003,7 @@ rpt_destroy(struct rebuild_tgt_pool_tracker *rpt)
 
 	uuid_clear(rpt->rt_pool_uuid);
 	if (rpt->rt_svc_list)
-		daos_rank_list_free(rpt->rt_svc_list);
+		d_rank_list_free(rpt->rt_svc_list);
 
 	if (rpt->rt_pool != NULL)
 		ds_pool_put(rpt->rt_pool);
@@ -1066,7 +1065,7 @@ rebuild_task_destroy(struct rebuild_task *task)
 
 	d_list_del(&task->dst_list);
 	pool_target_id_list_free(&task->dst_tgts);
-	daos_rank_list_free(task->dst_svc_list);
+	d_rank_list_free(task->dst_svc_list);
 	D_FREE(task);
 }
 
@@ -1081,7 +1080,7 @@ rebuild_leader_start(struct ds_pool *pool, uint32_t rebuild_ver,
 		     struct rebuild_global_pool_tracker **p_rgt)
 {
 	uint32_t	map_ver;
-	daos_iov_t	map_buf_iov = {0};
+	d_iov_t	map_buf_iov = {0};
 	uint64_t	leader_term;
 	int		rc;
 
@@ -1825,8 +1824,8 @@ rebuild_tgt_prepare(crt_rpc_t *rpc, struct rebuild_tgt_pool_tracker **p_rpt)
 	struct ds_pool_create_arg	pc_arg = { 0 };
 	struct rebuild_tgt_pool_tracker	*rpt = NULL;
 	struct rebuild_pool_tls		*pool_tls;
-	daos_iov_t			iov = { 0 };
-	daos_sg_list_t			sgl;
+	d_iov_t			iov = { 0 };
+	d_sg_list_t			sgl;
 	int				rc;
 
 	/* lookup create the ds_pool first */
@@ -1855,7 +1854,7 @@ rebuild_tgt_prepare(crt_rpc_t *rpc, struct rebuild_tgt_pool_tracker **p_rpt)
 	sgl.sg_nr = 1;
 	sgl.sg_nr_out = 1;
 	sgl.sg_iovs = &iov;
-	rc = crt_bulk_access(rpc->cr_co_bulk_hdl, daos2crt_sg(&sgl));
+	rc = crt_bulk_access(rpc->cr_co_bulk_hdl, &sgl);
 	if (rc != 0)
 		D_GOTO(out, rc);
 

--- a/src/rsvc/rpc.h
+++ b/src/rsvc/rpc.h
@@ -65,7 +65,7 @@ extern struct crt_proto_format rsvc_proto_fmt;
 
 #define DAOS_ISEQ_RSVC_START /* input fields */			 \
 	((uint32_t)		(sai_class)		CRT_VAR) \
-	((daos_iov_t)		(sai_svc_id)		CRT_VAR) \
+	((d_iov_t)		(sai_svc_id)		CRT_VAR) \
 	((uuid_t)		(sai_db_uuid)		CRT_VAR) \
 	((uint32_t)		(sai_flags)		CRT_VAR) \
 	((uint64_t)		(sai_size)		CRT_VAR) \
@@ -78,7 +78,7 @@ CRT_RPC_DECLARE(rsvc_start, DAOS_ISEQ_RSVC_START, DAOS_OSEQ_RSVC_START)
 
 #define DAOS_ISEQ_RSVC_STOP /* input fields */			 \
 	((uint32_t)		(soi_class)		CRT_VAR) \
-	((daos_iov_t)		(soi_svc_id)		CRT_VAR) \
+	((d_iov_t)		(soi_svc_id)		CRT_VAR) \
 	((uint32_t)		(soi_flags)		CRT_VAR) \
 	((d_rank_list_t)	(soi_ranks)		CRT_PTR)
 

--- a/src/rsvc/srv.c
+++ b/src/rsvc/srv.c
@@ -77,7 +77,7 @@ state_str(enum ds_rsvc_state state)
 
 /* Allocate and initialize a ds_rsvc object. */
 static int
-alloc_init(enum ds_rsvc_class_id class, daos_iov_t *id, uuid_t db_uuid,
+alloc_init(enum ds_rsvc_class_id class, d_iov_t *id, uuid_t db_uuid,
 	   struct ds_rsvc **svcp)
 {
 	struct ds_rsvc *svc;
@@ -249,7 +249,7 @@ rsvc_hash_fini(void)
  * \param[out]	svc	replicated service
  */
 int
-ds_rsvc_lookup(enum ds_rsvc_class_id class, daos_iov_t *id,
+ds_rsvc_lookup(enum ds_rsvc_class_id class, d_iov_t *id,
 	       struct ds_rsvc **svc)
 {
 	d_list_t       *entry;
@@ -344,7 +344,7 @@ put_leader(struct ds_rsvc *svc)
  * the replicated service is not up, hint is filled.
  */
 int
-ds_rsvc_lookup_leader(enum ds_rsvc_class_id class, daos_iov_t *id,
+ds_rsvc_lookup_leader(enum ds_rsvc_class_id class, d_iov_t *id,
 		      struct ds_rsvc **svcp, struct rsvc_hint *hint)
 {
 	struct ds_rsvc *svc;
@@ -537,7 +537,7 @@ self_only(d_rank_list_t *replicas)
 }
 
 static int
-start(enum ds_rsvc_class_id class, daos_iov_t *id, uuid_t db_uuid, bool create,
+start(enum ds_rsvc_class_id class, d_iov_t *id, uuid_t db_uuid, bool create,
       size_t size, d_rank_list_t *replicas, void *arg, struct ds_rsvc **svcp)
 {
 	struct ds_rsvc *svc;
@@ -598,7 +598,7 @@ err:
  * \retval -DER_CANCELED	replicated service stopping
  */
 int
-ds_rsvc_start(enum ds_rsvc_class_id class, daos_iov_t *id, uuid_t db_uuid,
+ds_rsvc_start(enum ds_rsvc_class_id class, d_iov_t *id, uuid_t db_uuid,
 	      bool create, size_t size, d_rank_list_t *replicas, void *arg)
 {
 	uuid_t			 db_uuid_buf;
@@ -702,7 +702,7 @@ stop(struct ds_rsvc *svc, bool destroy)
  * \retval -DER_CANCELED	replicated service stopping
  */
 int
-ds_rsvc_stop(enum ds_rsvc_class_id class, daos_iov_t *id, bool destroy)
+ds_rsvc_stop(enum ds_rsvc_class_id class, d_iov_t *id, bool destroy)
 {
 	struct ds_rsvc		*svc;
 	struct ds_rsvc_class	*impl;
@@ -800,7 +800,7 @@ ds_rsvc_stop_all(enum ds_rsvc_class_id class)
  * \param[out]	hint	rsvc hint
  */
 int
-ds_rsvc_stop_leader(enum ds_rsvc_class_id class, daos_iov_t *id,
+ds_rsvc_stop_leader(enum ds_rsvc_class_id class, d_iov_t *id,
 		    struct rsvc_hint *hint)
 {
 	struct ds_rsvc *svc;
@@ -856,7 +856,7 @@ bcast_create(crt_opcode_t opc, crt_group_t *group, crt_rpc_t **rpc)
  * \param[in]	size		size of each replica in bytes if \a create
  */
 int
-ds_rsvc_dist_start(enum ds_rsvc_class_id class, daos_iov_t *id,
+ds_rsvc_dist_start(enum ds_rsvc_class_id class, d_iov_t *id,
 		   const uuid_t dbid, const d_rank_list_t *ranks, bool create,
 		   bool bootstrap, size_t size)
 {
@@ -966,7 +966,7 @@ ds_rsvc_start_aggregator(crt_rpc_t *source, crt_rpc_t *result, void *priv)
  * \param[in]	destroy		destroy after close
  */
 int
-ds_rsvc_dist_stop(enum ds_rsvc_class_id class, daos_iov_t *id,
+ds_rsvc_dist_stop(enum ds_rsvc_class_id class, d_iov_t *id,
 		  const d_rank_list_t *ranks, bool destroy)
 {
 	crt_rpc_t		*rpc;

--- a/src/security/cli_security.c
+++ b/src/security/cli_security.c
@@ -35,11 +35,11 @@
 /* Prototypes for static helper functions */
 static int request_credentials_via_drpc(Drpc__Response **response);
 static int process_credential_response(Drpc__Response *response,
-		daos_iov_t *creds);
+		d_iov_t *creds);
 static int sanity_check_credential_response(Drpc__Response *response);
 
 int
-dc_sec_request_creds(daos_iov_t *creds)
+dc_sec_request_creds(d_iov_t *creds)
 {
 	Drpc__Response	*response = NULL;
 	int		rc;
@@ -95,7 +95,7 @@ request_credentials_via_drpc(Drpc__Response **response)
 
 static int
 process_credential_response(Drpc__Response *response,
-		daos_iov_t *creds)
+		d_iov_t *creds)
 {
 	int rc = DER_SUCCESS;
 
@@ -126,7 +126,7 @@ process_credential_response(Drpc__Response *response,
 		}
 
 		memcpy(bytes, response->body.data, response->body.len);
-		daos_iov_set(creds, bytes, response->body.len);
+		d_iov_set(creds, bytes, response->body.len);
 	}
 
 	return rc;

--- a/src/security/srv_acl.c
+++ b/src/security/srv_acl.c
@@ -56,7 +56,7 @@ sanity_check_validation_response(Drpc__Response *response)
 }
 
 static Drpc__Call *
-new_validation_request(struct drpc *ctx, daos_iov_t *creds)
+new_validation_request(struct drpc *ctx, d_iov_t *creds)
 {
 	uint8_t		*body;
 	Drpc__Call	*request;
@@ -84,7 +84,7 @@ new_validation_request(struct drpc *ctx, daos_iov_t *creds)
 }
 
 static int
-validate_credentials_via_drpc(Drpc__Response **response, daos_iov_t *creds)
+validate_credentials_via_drpc(Drpc__Response **response, d_iov_t *creds)
 {
 	struct drpc	*server_socket;
 	Drpc__Call	*request;
@@ -141,7 +141,7 @@ process_validation_response(Drpc__Response *response, Auth__Token **token)
 }
 
 int
-ds_sec_validate_credentials(daos_iov_t *creds, Auth__Token **token)
+ds_sec_validate_credentials(d_iov_t *creds, Auth__Token **token)
 {
 	Drpc__Response	*response = NULL;
 	int		rc;

--- a/src/security/srv_internal.h
+++ b/src/security/srv_internal.h
@@ -56,6 +56,6 @@ extern char *ds_sec_server_socket_path;
  */
 #define DRPC_METHOD_SECURITY_SERVER_VALIDATE_CREDENTIALS	101
 
-int ds_sec_validate_credentials(daos_iov_t *creds, Auth__Token **token);
+int ds_sec_validate_credentials(d_iov_t *creds, Auth__Token **token);
 
 #endif /* __SECURITY_SRV_INTERNAL_H__ */

--- a/src/security/tests/cli_security_tests.c
+++ b/src/security/tests/cli_security_tests.c
@@ -130,9 +130,9 @@ test_request_credentials_fails_with_null_creds(void **state)
 static void
 test_request_credentials_succeeds_with_good_values(void **state)
 {
-	daos_iov_t creds;
+	d_iov_t creds;
 
-	memset(&creds, 0, sizeof(daos_iov_t));
+	memset(&creds, 0, sizeof(d_iov_t));
 
 	assert_int_equal(dc_sec_request_creds(&creds), DER_SUCCESS);
 
@@ -142,9 +142,9 @@ test_request_credentials_succeeds_with_good_values(void **state)
 static void
 test_request_credentials_fails_if_drpc_connect_fails(void **state)
 {
-	daos_iov_t creds;
+	d_iov_t creds;
 
-	memset(&creds, 0, sizeof(daos_iov_t));
+	memset(&creds, 0, sizeof(d_iov_t));
 	free_drpc_connect_return(); /* drpc_connect returns NULL on failure */
 
 	assert_int_equal(dc_sec_request_creds(&creds), -DER_BADPATH);
@@ -155,9 +155,9 @@ test_request_credentials_fails_if_drpc_connect_fails(void **state)
 static void
 test_request_credentials_connects_to_default_socket(void **state)
 {
-	daos_iov_t creds;
+	d_iov_t creds;
 
-	memset(&creds, 0, sizeof(daos_iov_t));
+	memset(&creds, 0, sizeof(d_iov_t));
 
 	dc_sec_request_creds(&creds);
 
@@ -170,9 +170,9 @@ test_request_credentials_connects_to_default_socket(void **state)
 static void
 test_request_credentials_fails_if_drpc_call_fails(void **state)
 {
-	daos_iov_t creds;
+	d_iov_t creds;
 
-	memset(&creds, 0, sizeof(daos_iov_t));
+	memset(&creds, 0, sizeof(d_iov_t));
 	drpc_call_return = -DER_BUSY;
 
 	assert_int_equal(dc_sec_request_creds(&creds),
@@ -184,9 +184,9 @@ test_request_credentials_fails_if_drpc_call_fails(void **state)
 static void
 test_request_credentials_calls_drpc_call(void **state)
 {
-	daos_iov_t creds;
+	d_iov_t creds;
 
-	memset(&creds, 0, sizeof(daos_iov_t));
+	memset(&creds, 0, sizeof(d_iov_t));
 
 	dc_sec_request_creds(&creds);
 
@@ -215,9 +215,9 @@ test_request_credentials_calls_drpc_call(void **state)
 static void
 test_request_credentials_closes_socket_when_call_ok(void **state)
 {
-	daos_iov_t creds;
+	d_iov_t creds;
 
-	memset(&creds, 0, sizeof(daos_iov_t));
+	memset(&creds, 0, sizeof(d_iov_t));
 
 	dc_sec_request_creds(&creds);
 
@@ -229,9 +229,9 @@ test_request_credentials_closes_socket_when_call_ok(void **state)
 static void
 test_request_credentials_closes_socket_when_call_fails(void **state)
 {
-	daos_iov_t creds;
+	d_iov_t creds;
 
-	memset(&creds, 0, sizeof(daos_iov_t));
+	memset(&creds, 0, sizeof(d_iov_t));
 	drpc_call_return = -DER_NOMEM;
 
 	dc_sec_request_creds(&creds);
@@ -244,9 +244,9 @@ test_request_credentials_closes_socket_when_call_fails(void **state)
 static void
 test_request_credentials_fails_if_reply_null(void **state)
 {
-	daos_iov_t creds;
+	d_iov_t creds;
 
-	memset(&creds, 0, sizeof(daos_iov_t));
+	memset(&creds, 0, sizeof(d_iov_t));
 	drpc_call_resp_return_ptr = NULL;
 
 	assert_int_equal(dc_sec_request_creds(&creds), -DER_NOREPLY);
@@ -257,9 +257,9 @@ test_request_credentials_fails_if_reply_null(void **state)
 static void
 test_request_credentials_fails_if_reply_status_failure(void **state)
 {
-	daos_iov_t creds;
+	d_iov_t creds;
 
-	memset(&creds, 0, sizeof(daos_iov_t));
+	memset(&creds, 0, sizeof(d_iov_t));
 	drpc_call_resp_return_content.status = DRPC__STATUS__FAILURE;
 
 	assert_int_equal(dc_sec_request_creds(&creds), -DER_MISC);
@@ -270,9 +270,9 @@ test_request_credentials_fails_if_reply_status_failure(void **state)
 static void
 test_request_credentials_fails_if_reply_body_malformed(void **state)
 {
-	daos_iov_t creds;
+	d_iov_t creds;
 
-	memset(&creds, 0, sizeof(daos_iov_t));
+	memset(&creds, 0, sizeof(d_iov_t));
 	free_drpc_call_resp_body();
 	D_ALLOC(drpc_call_resp_return_content.body.data, 1);
 	drpc_call_resp_return_content.body.len = 1;
@@ -285,9 +285,9 @@ test_request_credentials_fails_if_reply_body_malformed(void **state)
 static void
 test_request_credentials_fails_if_reply_token_missing(void **state)
 {
-	daos_iov_t creds;
+	d_iov_t creds;
 
-	memset(&creds, 0, sizeof(daos_iov_t));
+	memset(&creds, 0, sizeof(d_iov_t));
 	auth__token__free_unpacked(
 			drpc_call_resp_return_auth_credential->token, NULL);
 	drpc_call_resp_return_auth_credential->token = NULL;
@@ -302,11 +302,11 @@ test_request_credentials_fails_if_reply_token_missing(void **state)
 static void
 test_request_credentials_returns_raw_bytes(void **state)
 {
-	daos_iov_t	creds;
+	d_iov_t	creds;
 	size_t		expected_len;
 	uint8_t		*expected_data;
 
-	memset(&creds, 0, sizeof(daos_iov_t));
+	memset(&creds, 0, sizeof(d_iov_t));
 
 	/*
 	 * Credential bytes == raw bytes of the packed Auth__Credential

--- a/src/tests/addons/array_tests.c
+++ b/src/tests/addons/array_tests.c
@@ -50,7 +50,7 @@ static void read_empty_records(void **state);
 static void
 array_oh_share(daos_handle_t coh, int rank, daos_handle_t *oh)
 {
-	daos_iov_t	ghdl = { NULL, 0, 0 };
+	d_iov_t	ghdl = { NULL, 0, 0 };
 	int		rc;
 
 	if (rank == 0) {
@@ -187,9 +187,9 @@ small_io(void **state)
 	daos_obj_id_t	oid;
 	daos_handle_t	oh;
 	daos_array_iod_t iod;
-	daos_sg_list_t	sgl;
+	d_sg_list_t	sgl;
 	daos_range_t	rg;
-	daos_iov_t	iov;
+	d_iov_t	iov;
 	char		buf[BUFLEN], rbuf[BUFLEN];
 	daos_size_t	array_size;
 	int		rc;
@@ -212,7 +212,7 @@ small_io(void **state)
 
 	/** set memory location */
 	sgl.sg_nr = 1;
-	daos_iov_set(&iov, buf, BUFLEN);
+	d_iov_set(&iov, buf, BUFLEN);
 	sgl.sg_iovs = &iov;
 
 	/** Write */
@@ -223,7 +223,7 @@ small_io(void **state)
 	assert_int_equal(rc, 0);
 	assert_int_equal(array_size, BUFLEN);
 
-	daos_iov_set(&iov, rbuf, BUFLEN);
+	d_iov_set(&iov, rbuf, BUFLEN);
 	sgl.sg_iovs = &iov;
 	rc = daos_array_read(oh, DAOS_TX_NONE, &iod, &sgl, NULL, NULL);
 	assert_int_equal(rc, 0);
@@ -315,8 +315,8 @@ contig_mem_contig_arr_io_helper(void **state, daos_size_t cell_size)
 	daos_handle_t	oh;
 	daos_array_iod_t iod;
 	daos_range_t	rg;
-	daos_sg_list_t	sgl;
-	daos_iov_t	iov;
+	d_sg_list_t	sgl;
+	d_iov_t	iov;
 	int		*wbuf = NULL, *rbuf = NULL;
 	daos_size_t	i;
 	daos_event_t	ev, *evp;
@@ -348,7 +348,7 @@ contig_mem_contig_arr_io_helper(void **state, daos_size_t cell_size)
 
 	/** set memory location */
 	sgl.sg_nr = 1;
-	daos_iov_set(&iov, wbuf, NUM_ELEMS * sizeof(int));
+	d_iov_set(&iov, wbuf, NUM_ELEMS * sizeof(int));
 	sgl.sg_iovs = &iov;
 
 	/** Write */
@@ -375,7 +375,7 @@ contig_mem_contig_arr_io_helper(void **state, daos_size_t cell_size)
 		rc = daos_event_init(&ev, arg->eq, NULL);
 		assert_int_equal(rc, 0);
 	}
-	daos_iov_set(&iov, rbuf, NUM_ELEMS * sizeof(int));
+	d_iov_set(&iov, rbuf, NUM_ELEMS * sizeof(int));
 	sgl.sg_iovs = &iov;
 	rc = daos_array_read(oh, DAOS_TX_NONE, &iod, &sgl, NULL,
 			     arg->async ? &ev : NULL);
@@ -469,8 +469,8 @@ contig_mem_str_arr_io_helper(void **state, daos_size_t cell_size)
 	daos_obj_id_t	oid;
 	daos_handle_t	oh;
 	daos_array_iod_t iod;
-	daos_sg_list_t	sgl;
-	daos_iov_t	iov;
+	d_sg_list_t	sgl;
+	d_iov_t	iov;
 	int		*wbuf = NULL, *rbuf = NULL;
 	daos_size_t	len, i;
 	daos_event_t	ev, *evp;
@@ -509,7 +509,7 @@ contig_mem_str_arr_io_helper(void **state, daos_size_t cell_size)
 
 	/** set memory location */
 	sgl.sg_nr = 1;
-	daos_iov_set(&iov, wbuf, NUM_ELEMS * sizeof(int));
+	d_iov_set(&iov, wbuf, NUM_ELEMS * sizeof(int));
 	sgl.sg_iovs = &iov;
 
 	/** Write */
@@ -536,7 +536,7 @@ contig_mem_str_arr_io_helper(void **state, daos_size_t cell_size)
 		rc = daos_event_init(&ev, arg->eq, NULL);
 		assert_int_equal(rc, 0);
 	}
-	daos_iov_set(&iov, rbuf, NUM_ELEMS * sizeof(int));
+	d_iov_set(&iov, rbuf, NUM_ELEMS * sizeof(int));
 	rc = daos_array_read(oh, DAOS_TX_NONE, &iod, &sgl, NULL,
 			     arg->async ? &ev : NULL);
 	assert_int_equal(rc, 0);
@@ -625,7 +625,7 @@ str_mem_str_arr_io_helper(void **state, daos_size_t cell_size)
 	daos_obj_id_t	oid;
 	daos_handle_t	oh;
 	daos_array_iod_t iod;
-	daos_sg_list_t	sgl;
+	d_sg_list_t	sgl;
 	int		*wbuf[NUM_SEGS], *rbuf[NUM_SEGS];
 	daos_size_t	i, j, len;
 	daos_event_t	ev, *evp;
@@ -669,7 +669,7 @@ str_mem_str_arr_io_helper(void **state, daos_size_t cell_size)
 	assert_non_null(sgl.sg_iovs);
 
 	for (i = 0; i < NUM_SEGS; i++) {
-		daos_iov_set(&sgl.sg_iovs[i], wbuf[i],
+		d_iov_set(&sgl.sg_iovs[i], wbuf[i],
 			     (NUM_ELEMS/NUM_SEGS) * sizeof(int));
 	}
 
@@ -694,7 +694,7 @@ str_mem_str_arr_io_helper(void **state, daos_size_t cell_size)
 
 	/** Read */
 	for (i = 0; i < NUM_SEGS; i++) {
-		daos_iov_set(&sgl.sg_iovs[i], rbuf[i],
+		d_iov_set(&sgl.sg_iovs[i], rbuf[i],
 			     (NUM_ELEMS/NUM_SEGS) * sizeof(int));
 	}
 	if (arg->async) {
@@ -777,8 +777,8 @@ read_empty_records(void **state)
 	daos_obj_id_t	oid;
 	daos_handle_t	oh;
 	daos_array_iod_t iod;
-	daos_sg_list_t	sgl;
-	daos_iov_t	iov;
+	d_sg_list_t	sgl;
+	d_iov_t	iov;
 	int		*wbuf = NULL, *rbuf = NULL;
 	daos_size_t	i;
 	daos_event_t	ev;
@@ -809,7 +809,7 @@ read_empty_records(void **state)
 
 	/** set memory location */
 	sgl.sg_nr = 1;
-	daos_iov_set(&iov, wbuf, NUM_ELEMS * sizeof(int));
+	d_iov_set(&iov, wbuf, NUM_ELEMS * sizeof(int));
 	sgl.sg_iovs = &iov;
 
 	/** set array location */
@@ -823,7 +823,7 @@ read_empty_records(void **state)
 		iod.arr_rgs[i].rg_idx = i * arg->rank_size * sizeof(int) +
 			arg->myrank * sizeof(int);
 	}
-	daos_iov_set(&iov, rbuf, NUM_ELEMS * sizeof(int));
+	d_iov_set(&iov, rbuf, NUM_ELEMS * sizeof(int));
 	rc = daos_array_read(oh, DAOS_TX_NONE, &iod, &sgl, NULL, NULL);
 	assert_int_equal(rc, 0);
 
@@ -857,7 +857,7 @@ read_empty_records(void **state)
 		iod.arr_rgs[i].rg_idx = i * sizeof(int) +
 			arg->myrank * sizeof(int);
 	}
-	daos_iov_set(&iov, rbuf, NUM_ELEMS * sizeof(int));
+	d_iov_set(&iov, rbuf, NUM_ELEMS * sizeof(int));
 	rc = daos_array_read(oh, DAOS_TX_NONE, &iod, &sgl, NULL, NULL);
 	assert_int_equal(rc, 0);
 
@@ -889,7 +889,7 @@ strided_array(void **state)
 	daos_obj_id_t	oid;
 	daos_handle_t	oh;
 	daos_array_iod_t iod;
-	daos_sg_list_t	sgl;
+	d_sg_list_t	sgl;
 	int		*buf;
 	daos_size_t	i, j, nerrors = 0;
 	int		rc;
@@ -926,7 +926,7 @@ strided_array(void **state)
 	D_ALLOC_ARRAY(sgl.sg_iovs, NUM);
 	j = 0;
 	for (i = 0 ; i < NUM; i++) {
-		daos_iov_set(&sgl.sg_iovs[i], &buf[j], sizeof(int));
+		d_iov_set(&sgl.sg_iovs[i], &buf[j], sizeof(int));
 		j += 2;
 	}
 

--- a/src/tests/addons/hl_tests.c
+++ b/src/tests/addons/hl_tests.c
@@ -53,11 +53,11 @@ list_keys(daos_handle_t oh, int *num_keys)
 	daos_key_desc_t  kds[ENUM_DESC_NR];
 	daos_anchor_t	 anchor = {0};
 	int		 key_nr = 0;
-	daos_sg_list_t	 sgl;
-	daos_iov_t       sg_iov;
+	d_sg_list_t	 sgl;
+	d_iov_t       sg_iov;
 
 	buf = malloc(ENUM_DESC_BUF);
-	daos_iov_set(&sg_iov, buf, ENUM_DESC_BUF);
+	d_iov_set(&sg_iov, buf, ENUM_DESC_BUF);
 	sgl.sg_nr		= 1;
 	sgl.sg_nr_out		= 0;
 	sgl.sg_iovs		= &sg_iov;
@@ -242,7 +242,7 @@ simple_multi_io(void **state)
 	daos_handle_t	oh;
 	daos_size_t	buf_size = 128;
 	daos_event_t	ev;
-	daos_iov_t	sg_iov[NUM_KEYS];
+	d_iov_t	sg_iov[NUM_KEYS];
 	daos_recx_t	recx;
 	const char      *key_fmt = "key%d";
 	char		*buf[NUM_KEYS];
@@ -268,7 +268,7 @@ simple_multi_io(void **state)
 
 	for (i = 0; i < NUM_KEYS; i++) {
 		D_ALLOC(io_array[i].ioa_iods, sizeof(daos_iod_t));
-		D_ALLOC(io_array[i].ioa_sgls, sizeof(daos_sg_list_t));
+		D_ALLOC(io_array[i].ioa_sgls, sizeof(d_sg_list_t));
 		D_ALLOC(io_array[i].ioa_dkey, sizeof(daos_key_t));
 		io_array[i].ioa_nr = 1;
 
@@ -284,14 +284,14 @@ simple_multi_io(void **state)
 		assert_non_null(keys[i]);
 		assert_int_not_equal(rc, -1);
 
-		daos_iov_set(io_array[i].ioa_dkey, keys[i], strlen(keys[i]));
+		d_iov_set(io_array[i].ioa_dkey, keys[i], strlen(keys[i]));
 		/** init scatter/gather */
-		daos_iov_set(&sg_iov[i], buf[i], buf_size);
+		d_iov_set(&sg_iov[i], buf[i], buf_size);
 		io_array[i].ioa_sgls[0].sg_nr		= 1;
 		io_array[i].ioa_sgls[0].sg_nr_out	= 0;
 		io_array[i].ioa_sgls[0].sg_iovs		= &sg_iov[i];
 		/** init I/O descriptor */
-		daos_iov_set(&io_array[i].ioa_iods[0].iod_name, "akey",
+		d_iov_set(&io_array[i].ioa_iods[0].iod_name, "akey",
 			     strlen("akey"));
 		daos_csum_set(&io_array[i].ioa_iods[0].iod_kcsum, NULL, 0);
 		io_array[i].ioa_iods[0].iod_nr	= 1;
@@ -315,7 +315,7 @@ simple_multi_io(void **state)
 
 	for (i = 0; i < NUM_KEYS; i++) {
 		/** init scatter/gather */
-		daos_iov_set(&sg_iov[i], buf_out[i], buf_size);
+		d_iov_set(&sg_iov[i], buf_out[i], buf_size);
 		io_array[i].ioa_sgls[0].sg_nr		= 1;
 		io_array[i].ioa_sgls[0].sg_nr_out	= 0;
 		io_array[i].ioa_sgls[0].sg_iovs		= &sg_iov[i];

--- a/src/tests/daos_perf.c
+++ b/src/tests/daos_perf.c
@@ -181,7 +181,7 @@ akey_update_or_fetch(daos_handle_t oh, enum ts_op_type op_type,
 {
 	struct dts_io_credit *cred;
 	daos_iod_t	     *iod;
-	daos_sg_list_t	     *sgl;
+	d_sg_list_t	     *sgl;
 	daos_recx_t	     *recx;
 	int		      vsize = ts_ctx.tsc_cred_vsize;
 	int		      rc = 0;
@@ -203,12 +203,12 @@ akey_update_or_fetch(daos_handle_t oh, enum ts_op_type op_type,
 
 	/* setup dkey */
 	memcpy(cred->tc_dbuf, dkey, DTS_KEY_LEN);
-	daos_iov_set(&cred->tc_dkey, cred->tc_dbuf,
+	d_iov_set(&cred->tc_dkey, cred->tc_dbuf,
 			strlen(cred->tc_dbuf));
 
 	/* setup I/O descriptor */
 	memcpy(cred->tc_abuf, akey, DTS_KEY_LEN);
-	daos_iov_set(&iod->iod_name, cred->tc_abuf,
+	d_iov_set(&iod->iod_name, cred->tc_abuf,
 			strlen(cred->tc_abuf));
 	iod->iod_size = vsize;
 	recx->rx_nr  = 1;
@@ -232,7 +232,7 @@ akey_update_or_fetch(daos_handle_t oh, enum ts_op_type op_type,
 		memset(cred->tc_vbuf, 0, vsize);
 	}
 
-	daos_iov_set(&cred->tc_val, cred->tc_vbuf, vsize);
+	d_iov_set(&cred->tc_val, cred->tc_vbuf, vsize);
 	sgl->sg_iovs = &cred->tc_val;
 	sgl->sg_nr = 1;
 

--- a/src/tests/daosbench.c
+++ b/src/tests/daosbench.c
@@ -130,11 +130,11 @@ struct a_ioreq {
 	d_list_t		list;
 	daos_event_t		ev;
 	daos_key_t		dkey;
-	daos_iov_t		val_iov;
+	d_iov_t		val_iov;
 	daos_iod_t		iod;
 	daos_recx_t		rex;
 	daos_epoch_range_t	erange;
-	daos_sg_list_t		sgl;
+	d_sg_list_t		sgl;
 	daos_csum_buf_t		csum;
 	char			csum_buf[UPDATE_CSUM_SIZE];
 	char			*dkey_buf;
@@ -259,20 +259,20 @@ static void
 ioreq_init_dkey(struct a_ioreq *ioreq, void *buf, size_t size)
 {
 	ioreq->dkey_buf = buf;
-	daos_iov_set(&ioreq->dkey, buf, size);
+	d_iov_set(&ioreq->dkey, buf, size);
 }
 
 static void
 ioreq_init_akey(struct a_ioreq *ioreq, void *buf, size_t size)
 {
 	ioreq->akey_buf = buf;
-	daos_iov_set(&ioreq->iod.iod_name, buf, size);
+	d_iov_set(&ioreq->iod.iod_name, buf, size);
 }
 
 static void
 ioreq_init_value(struct a_ioreq *ioreq, void *buf, size_t size)
 {
-	daos_iov_set(&ioreq->val_iov, buf, size);
+	d_iov_set(&ioreq->val_iov, buf, size);
 }
 
 static void
@@ -627,7 +627,7 @@ enumerate(daos_handle_t th, uint32_t *number, daos_key_desc_t *kds,
 {
 	int	rc;
 
-	daos_iov_set(&req->val_iov, buf, len);
+	d_iov_set(&req->val_iov, buf, len);
 
 	/** execute fetch operation */
 	rc = daos_obj_list_dkey(oh, th, number, kds, &req->sgl, anchor, NULL);
@@ -1834,7 +1834,7 @@ test_fini(struct test *test)
 		printf("\n");
 		printf("Ended at %s", ctime(&t));
 	}
-	daos_rank_list_free(svcl);
+	d_rank_list_free(svcl);
 }
 
 int main(int argc, char *argv[])

--- a/src/tests/daosctl/io-cmds.c
+++ b/src/tests/daosctl/io-cmds.c
@@ -102,8 +102,8 @@ struct ioreq {
 	daos_event_t		ev;
 	daos_key_t		dkey;
 	daos_key_t		akey;
-	daos_iov_t		val_iov[IOREQ_SG_IOD_NR][IOREQ_SG_NR];
-	daos_sg_list_t		sgl[IOREQ_SG_IOD_NR];
+	d_iov_t		val_iov[IOREQ_SG_IOD_NR][IOREQ_SG_NR];
+	d_sg_list_t		sgl[IOREQ_SG_IOD_NR];
 	daos_csum_buf_t		csum;
 	char			csum_buf[UPDATE_CSUM_SIZE];
 	daos_recx_t		rex[IOREQ_SG_IOD_NR][IOREQ_IOD_NR];
@@ -214,7 +214,7 @@ ioreq_init(struct ioreq *req, daos_handle_t coh, daos_obj_id_t oid,
 static void
 ioreq_dkey_set(struct ioreq *req, const char *dkey)
 {
-	daos_iov_set(&req->dkey, (void *)dkey, strlen(dkey));
+	d_iov_set(&req->dkey, (void *)dkey, strlen(dkey));
 }
 
 static void
@@ -228,7 +228,7 @@ ioreq_io_akey_set(struct ioreq *req, const char **akey, int nr)
 	}
 	/** akey */
 	for (i = 0; i < nr; i++)
-		daos_iov_set(&req->iod[i].iod_name, (void *)akey[i],
+		d_iov_set(&req->iod[i].iod_name, (void *)akey[i],
 			     strlen(akey[i]));
 }
 
@@ -271,7 +271,7 @@ ioreq_fini(struct ioreq *req)
 
 /* no wait for async insert, for sync insert it still will block */
 static int
-insert_internal_nowait(daos_key_t *dkey, int nr, daos_sg_list_t *sgls,
+insert_internal_nowait(daos_key_t *dkey, int nr, d_sg_list_t *sgls,
 		       daos_iod_t *iods, daos_handle_t th, struct ioreq *req)
 {
 	int rc;
@@ -283,7 +283,7 @@ insert_internal_nowait(daos_key_t *dkey, int nr, daos_sg_list_t *sgls,
 }
 
 static void
-lookup_internal(daos_key_t *dkey, int nr, daos_sg_list_t *sgls,
+lookup_internal(daos_key_t *dkey, int nr, d_sg_list_t *sgls,
 		daos_iod_t *iods, daos_handle_t th, struct ioreq *req,
 		bool empty)
 {
@@ -309,7 +309,7 @@ static void
 ioreq_sgl_simple_set(struct ioreq *req, void **value,
 		     daos_size_t *size, int nr)
 {
-	daos_sg_list_t *sgl = req->sgl;
+	d_sg_list_t *sgl = req->sgl;
 	int i;
 
 	if (nr < 1 || nr > IOREQ_SG_IOD_NR) {
@@ -319,7 +319,7 @@ ioreq_sgl_simple_set(struct ioreq *req, void **value,
 	for (i = 0; i < nr; i++) {
 		sgl[i].sg_nr = 1;
 		sgl[i].sg_nr_out = 1;
-		daos_iov_set(&sgl[i].sg_iovs[0], value[i], size[i]);
+		d_iov_set(&sgl[i].sg_iovs[0], value[i], size[i]);
 	}
 }
 

--- a/src/tests/dts_common.h
+++ b/src/tests/dts_common.h
@@ -35,9 +35,9 @@ struct dts_io_credit {
 	char			 tc_dbuf[DTS_KEY_LEN];	/**< dkey buffer */
 	char			 tc_abuf[DTS_KEY_LEN];	/**< akey buffer */
 	daos_key_t		 tc_dkey;		/**< dkey iov */
-	daos_iov_t		 tc_val;		/**< value iov */
+	d_iov_t		 tc_val;		/**< value iov */
 	/** sgl for the value iov */
-	daos_sg_list_t		 tc_sgl;
+	d_sg_list_t		 tc_sgl;
 	/** I/O descriptor for input akey */
 	daos_iod_t		 tc_iod;
 	/** recx for the I/O, there is only one recx in \a tc_iod */

--- a/src/tests/obj_ctl.c
+++ b/src/tests/obj_ctl.c
@@ -240,7 +240,7 @@ ctl_daos_list(struct dts_io_credit *cred)
 	memset(&anchor, 0, sizeof(anchor));
 	while (!daos_anchor_is_eof(&anchor)) {
 		memset(kbuf, 0, CTL_BUF_LEN);
-		daos_iov_set(&cred->tc_val, kbuf, CTL_BUF_LEN);
+		d_iov_set(&cred->tc_val, kbuf, CTL_BUF_LEN);
 
 		if (!(ctl_abits & CTL_ARG_OID)) {
 			fprintf(stderr, "Cannot list object for now\n");
@@ -372,13 +372,13 @@ ctl_cmd_run(char opc, char *args)
 
 	if (ctl_abits & CTL_ARG_DKEY) {
 		strcpy(cred->tc_dbuf, dkey);
-		daos_iov_set(&cred->tc_dkey, cred->tc_dbuf,
+		d_iov_set(&cred->tc_dkey, cred->tc_dbuf,
 			     strlen(cred->tc_dbuf) + 1);
 	}
 
 	if (ctl_abits & CTL_ARG_AKEY) {
 		strcpy(cred->tc_abuf, akey);
-		daos_iov_set(&cred->tc_iod.iod_name, cred->tc_abuf,
+		d_iov_set(&cred->tc_iod.iod_name, cred->tc_abuf,
 			     strlen(cred->tc_abuf) + 1);
 
 		cred->tc_iod.iod_type	= DAOS_IOD_SINGLE;
@@ -391,11 +391,11 @@ ctl_cmd_run(char opc, char *args)
 	if (ctl_abits & CTL_ARG_VAL) {
 		cred->tc_iod.iod_size = strlen(val) + 1;
 		strcpy(cred->tc_vbuf, val);
-		daos_iov_set(&cred->tc_val, cred->tc_vbuf,
+		d_iov_set(&cred->tc_val, cred->tc_vbuf,
 			     strlen(cred->tc_vbuf) + 1);
 	} else {
 		memset(cred->tc_vbuf, 0, ctl_ctx.tsc_cred_vsize);
-		daos_iov_set(&cred->tc_val, cred->tc_vbuf,
+		d_iov_set(&cred->tc_val, cred->tc_vbuf,
 			     ctl_ctx.tsc_cred_vsize);
 	}
 	cred->tc_sgl.sg_nr = 1;

--- a/src/tests/security/security_test.c
+++ b/src/tests/security/security_test.c
@@ -165,13 +165,13 @@ int
 main(int argc, char **argv)
 {
 	int			ret;
-	daos_iov_t		creds;
+	d_iov_t		creds;
 	Auth__Credential	*response = NULL;
 	Auth__Sys		*credentials = NULL;
 	Auth__Token		*validated_token = NULL;
 	Auth__Sys		*validated_credentials = NULL;
 
-	memset(&creds, 0, sizeof(daos_iov_t));
+	memset(&creds, 0, sizeof(d_iov_t));
 
 	ret = dc_sec_request_creds(&creds);
 

--- a/src/tests/simple_array.c
+++ b/src/tests/simple_array.c
@@ -104,8 +104,8 @@ struct ioreq {
 	daos_recx_t	recx;
 	daos_iod_t	iod;
 
-	daos_iov_t	iov;
-	daos_sg_list_t	sg;
+	d_iov_t	iov;
+	d_sg_list_t	sg;
 
 	daos_event_t	ev;
 };
@@ -202,7 +202,7 @@ ioreqs_init(struct ioreq *reqs) {
 		req->iod.iod_recxs	= &req->recx;
 
 		/** initialize scatter/gather */
-		req->iov = (daos_iov_t) {
+		req->iov = (d_iov_t) {
 			.iov_buf	= &data,
 			.iov_buf_len	= SLICE_SIZE * sizeof(data[0]),
 			.iov_len	= SLICE_SIZE * sizeof(data[0]),

--- a/src/tests/suite/daos_array.c
+++ b/src/tests/suite/daos_array.c
@@ -36,9 +36,9 @@ byte_array_simple_stack(void **state)
 	test_arg_t	*arg = *state;
 	daos_obj_id_t	 oid;
 	daos_handle_t	 oh;
-	daos_iov_t	 dkey;
-	daos_sg_list_t	 sgl;
-	daos_iov_t	 sg_iov;
+	d_iov_t	 dkey;
+	d_sg_list_t	 sgl;
+	d_iov_t	 sg_iov;
 	daos_iod_t	 iod;
 	daos_recx_t	 recx;
 	char		 buf_out[STACK_BUF_LEN];
@@ -53,16 +53,16 @@ byte_array_simple_stack(void **state)
 	assert_int_equal(rc, 0);
 
 	/** init dkey */
-	daos_iov_set(&dkey, "dkey", strlen("dkey"));
+	d_iov_set(&dkey, "dkey", strlen("dkey"));
 
 	/** init scatter/gather */
-	daos_iov_set(&sg_iov, buf, sizeof(buf));
+	d_iov_set(&sg_iov, buf, sizeof(buf));
 	sgl.sg_nr		= 1;
 	sgl.sg_nr_out		= 0;
 	sgl.sg_iovs		= &sg_iov;
 
 	/** init I/O descriptor */
-	daos_iov_set(&iod.iod_name, "akey", strlen("akey"));
+	d_iov_set(&iod.iod_name, "akey", strlen("akey"));
 	daos_csum_set(&iod.iod_kcsum, NULL, 0);
 	iod.iod_nr	= 1;
 	iod.iod_size	= 1;
@@ -88,7 +88,7 @@ byte_array_simple_stack(void **state)
 	/** fetch */
 	print_message("reading data back ...\n");
 	memset(buf_out, 0, sizeof(buf_out));
-	daos_iov_set(&sg_iov, buf_out, sizeof(buf_out));
+	d_iov_set(&sg_iov, buf_out, sizeof(buf_out));
 	rc = daos_obj_fetch(oh, DAOS_TX_NONE, &dkey, 1, &iod, &sgl, NULL, NULL);
 	assert_int_equal(rc, 0);
 	/** Verify data consistency */
@@ -107,9 +107,9 @@ array_simple(void **state)
 	test_arg_t	*arg = *state;
 	daos_obj_id_t	 oid;
 	daos_handle_t	 oh;
-	daos_iov_t	 dkey;
-	daos_sg_list_t	 sgl;
-	daos_iov_t	 sg_iov;
+	d_iov_t	 dkey;
+	d_sg_list_t	 sgl;
+	d_iov_t	 sg_iov;
 	daos_iod_t	 iod;
 	daos_recx_t	 recx;
 	char		*buf;
@@ -127,16 +127,16 @@ array_simple(void **state)
 	assert_int_equal(rc, 0);
 
 	/** init dkey */
-	daos_iov_set(&dkey, "dkey", strlen("dkey"));
+	d_iov_set(&dkey, "dkey", strlen("dkey"));
 
 	/** init scatter/gather */
-	daos_iov_set(&sg_iov, buf, arg->size * arg->nr);
+	d_iov_set(&sg_iov, buf, arg->size * arg->nr);
 	sgl.sg_nr		= 1;
 	sgl.sg_nr_out		= 0;
 	sgl.sg_iovs		= &sg_iov;
 
 	/** init I/O descriptor */
-	daos_iov_set(&iod.iod_name, "akey", strlen("akey"));
+	d_iov_set(&iod.iod_name, "akey", strlen("akey"));
 	daos_csum_set(&iod.iod_kcsum, NULL, 0);
 	iod.iod_nr	= 1;
 	iod.iod_size	= arg->size;
@@ -159,7 +159,7 @@ array_simple(void **state)
 	D_ALLOC(buf_out, arg->size * arg->nr);
 	assert_non_null(buf_out);
 	memset(buf_out, 0, arg->size * arg->nr);
-	daos_iov_set(&sg_iov, buf_out, arg->size * arg->nr);
+	d_iov_set(&sg_iov, buf_out, arg->size * arg->nr);
 	iod.iod_size	= DAOS_REC_ANY;
 	rc = daos_obj_fetch(oh, DAOS_TX_NONE, &dkey, 1, &iod, &sgl, NULL, NULL);
 	assert_int_equal(rc, 0);
@@ -187,9 +187,9 @@ array_partial(void **state)
 	test_arg_t	*arg = *state;
 	daos_obj_id_t	 oid;
 	daos_handle_t	 oh;
-	daos_iov_t	 dkey;
-	daos_sg_list_t	 sgl;
-	daos_iov_t	 sg_iov;
+	d_iov_t	 dkey;
+	d_sg_list_t	 sgl;
+	d_iov_t	 sg_iov;
 	daos_iod_t	 iod;
 	daos_recx_t	 recx;
 	daos_recx_t	 recxs[4];
@@ -210,16 +210,16 @@ array_partial(void **state)
 	assert_int_equal(rc, 0);
 
 	/** init dkey */
-	daos_iov_set(&dkey, "dkey", strlen("dkey"));
+	d_iov_set(&dkey, "dkey", strlen("dkey"));
 
 	/** init scatter/gather */
-	daos_iov_set(&sg_iov, buf, arg->size * NUM_RECORDS);
+	d_iov_set(&sg_iov, buf, arg->size * NUM_RECORDS);
 	sgl.sg_nr		= 1;
 	sgl.sg_nr_out		= 0;
 	sgl.sg_iovs		= &sg_iov;
 
 	/** init I/O descriptor */
-	daos_iov_set(&iod.iod_name, "akey", strlen("akey"));
+	d_iov_set(&iod.iod_name, "akey", strlen("akey"));
 	daos_csum_set(&iod.iod_kcsum, NULL, 0);
 	iod.iod_nr	= 1;
 	iod.iod_size	= arg->size;
@@ -241,7 +241,7 @@ array_partial(void **state)
 	D_ALLOC(buf_out, arg->size * NUM_RECORDS/2);
 	assert_non_null(buf_out);
 	memset(buf_out, 0, arg->size * NUM_RECORDS/2);
-	daos_iov_set(&sg_iov, buf_out, arg->size * NUM_RECORDS/2);
+	d_iov_set(&sg_iov, buf_out, arg->size * NUM_RECORDS/2);
 	iod.iod_size	= arg->size;
 	iod.iod_nr	= 4;
 	for (i = 0; i < 4; i++) {
@@ -347,9 +347,9 @@ replicator(void **state)
 	test_arg_t	*arg = *state;
 	daos_obj_id_t	 oid;
 	daos_handle_t	 oh;
-	daos_iov_t	 dkey;
-	daos_sg_list_t	 sgl;
-	daos_iov_t	 sg_iov;
+	d_iov_t	 dkey;
+	d_sg_list_t	 sgl;
+	d_iov_t	 sg_iov;
 	daos_iod_t	 iod;
 	daos_recx_t	 recx;
 	char		 buf_out[4608];
@@ -364,16 +364,16 @@ replicator(void **state)
 	assert_int_equal(rc, 0);
 
 	/** init dkey */
-	daos_iov_set(&dkey, "dkey", strlen("dkey"));
+	d_iov_set(&dkey, "dkey", strlen("dkey"));
 
 	/** init scatter/gather */
-	daos_iov_set(&sg_iov, buf, sizeof(buf));
+	d_iov_set(&sg_iov, buf, sizeof(buf));
 	sgl.sg_nr		= 1;
 	sgl.sg_nr_out		= 0;
 	sgl.sg_iovs		= &sg_iov;
 
 	/** init I/O descriptor */
-	daos_iov_set(&iod.iod_name, "akey", strlen("akey"));
+	d_iov_set(&iod.iod_name, "akey", strlen("akey"));
 	daos_csum_set(&iod.iod_kcsum, NULL, 0);
 	iod.iod_nr	= 1;
 	iod.iod_size	= 1;
@@ -404,7 +404,7 @@ replicator(void **state)
 	/** fetch */
 	print_message("reading data back ...\n");
 	memset(buf_out, 0, sizeof(buf_out));
-	daos_iov_set(&sg_iov, buf_out, sizeof(buf_out));
+	d_iov_set(&sg_iov, buf_out, sizeof(buf_out));
 	recx.rx_idx     = 27136;
 	recx.rx_nr      = sizeof(buf_out);
 	iod.iod_recxs	= &recx;
@@ -423,9 +423,9 @@ read_empty(void **state)
 	test_arg_t	*arg = *state;
 	daos_obj_id_t	 oid;
 	daos_handle_t	 oh;
-	daos_iov_t	 dkey;
-	daos_sg_list_t	 sgl;
-	daos_iov_t	 sg_iov;
+	d_iov_t	 dkey;
+	d_sg_list_t	 sgl;
+	d_iov_t	 sg_iov;
 	daos_iod_t	 iod;
 	daos_recx_t	 recx;
 	char		 *buf;
@@ -442,16 +442,16 @@ read_empty(void **state)
 	assert_int_equal(rc, 0);
 
 	/** init dkey */
-	daos_iov_set(&dkey, "dkey", strlen("dkey"));
+	d_iov_set(&dkey, "dkey", strlen("dkey"));
 
 	/** init scatter/gather */
-	daos_iov_set(&sg_iov, buf, buf_len);
+	d_iov_set(&sg_iov, buf, buf_len);
 	sgl.sg_nr		= 1;
 	sgl.sg_nr_out		= 0;
 	sgl.sg_iovs		= &sg_iov;
 
 	/** init I/O descriptor */
-	daos_iov_set(&iod.iod_name, "akey", strlen("akey"));
+	d_iov_set(&iod.iod_name, "akey", strlen("akey"));
 	daos_csum_set(&iod.iod_kcsum, NULL, 0);
 	iod.iod_nr	= 1;
 	iod.iod_size	= 1;
@@ -489,14 +489,14 @@ enumerate_key(daos_handle_t oh, int *total_nr, daos_key_t *dkey, int key_type)
 	char		*buf;
 	daos_key_desc_t  kds[ENUM_DESC_NR];
 	daos_anchor_t	 anchor;
-	daos_sg_list_t	 sgl;
-	daos_iov_t       sg_iov;
+	d_sg_list_t	 sgl;
+	d_iov_t       sg_iov;
 	uint32_t	 nr;
 	int		 key_nr;
 	int		 rc;
 
 	buf = malloc(ENUM_DESC_BUF);
-	daos_iov_set(&sg_iov, buf, ENUM_DESC_BUF);
+	d_iov_set(&sg_iov, buf, ENUM_DESC_BUF);
 	sgl.sg_nr		= 1;
 	sgl.sg_nr_out		= 0;
 	sgl.sg_iovs		= &sg_iov;
@@ -529,9 +529,9 @@ array_dkey_punch_enumerate(void **state)
 	test_arg_t	*arg = *state;
 	daos_obj_id_t	 oid;
 	daos_handle_t	 oh;
-	daos_iov_t	 dkey;
-	daos_sg_list_t	 sgl;
-	daos_iov_t	 sg_iov;
+	d_iov_t	 dkey;
+	d_sg_list_t	 sgl;
+	d_iov_t	 sg_iov;
 	daos_iod_t	 iod;
 	daos_recx_t	 recx;
 	char		 buf[SM_BUF_LEN];
@@ -547,13 +547,13 @@ array_dkey_punch_enumerate(void **state)
 	assert_int_equal(rc, 0);
 
 	/** init scatter/gather */
-	daos_iov_set(&sg_iov, buf, sizeof(buf));
+	d_iov_set(&sg_iov, buf, sizeof(buf));
 	sgl.sg_nr		= 1;
 	sgl.sg_nr_out		= 0;
 	sgl.sg_iovs		= &sg_iov;
 
 	/** init I/O descriptor */
-	daos_iov_set(&iod.iod_name, "akey", strlen("akey"));
+	d_iov_set(&iod.iod_name, "akey", strlen("akey"));
 	daos_csum_set(&iod.iod_kcsum, NULL, 0);
 	iod.iod_nr	= 1;
 	iod.iod_size	= 1;
@@ -570,7 +570,7 @@ array_dkey_punch_enumerate(void **state)
 
 		/** init dkey */
 		sprintf(dkey_str, "dkey_%d", i);
-		daos_iov_set(&dkey, dkey_str, strlen(dkey_str));
+		d_iov_set(&dkey, dkey_str, strlen(dkey_str));
 		rc = daos_obj_update(oh, DAOS_TX_NONE, &dkey, 1, &iod, &sgl,
 				     NULL);
 		assert_int_equal(rc, 0);
@@ -589,7 +589,7 @@ array_dkey_punch_enumerate(void **state)
 
 		/** init dkey */
 		sprintf(dkey_str, "dkey_%d", i);
-		daos_iov_set(&dkey, dkey_str, strlen(dkey_str));
+		d_iov_set(&dkey, dkey_str, strlen(dkey_str));
 		rc = daos_obj_punch_dkeys(oh, DAOS_TX_NONE, 1, &dkey, NULL);
 		assert_int_equal(rc, 0);
 	}
@@ -612,9 +612,9 @@ array_akey_punch_enumerate(void **state)
 	test_arg_t	*arg = *state;
 	daos_obj_id_t	 oid;
 	daos_handle_t	 oh;
-	daos_iov_t	 dkey;
-	daos_sg_list_t	 sgl;
-	daos_iov_t	 sg_iov;
+	d_iov_t	 dkey;
+	d_sg_list_t	 sgl;
+	d_iov_t	 sg_iov;
 	daos_iod_t	 iod;
 	daos_recx_t	 recx;
 	char		 buf[SM_BUF_LEN];
@@ -630,13 +630,13 @@ array_akey_punch_enumerate(void **state)
 	assert_int_equal(rc, 0);
 
 	/** init scatter/gather */
-	daos_iov_set(&sg_iov, buf, sizeof(buf));
+	d_iov_set(&sg_iov, buf, sizeof(buf));
 	sgl.sg_nr		= 1;
 	sgl.sg_nr_out		= 0;
 	sgl.sg_iovs		= &sg_iov;
 
 	/** init dkey */
-	daos_iov_set(&dkey, "dkey", strlen("dkey"));
+	d_iov_set(&dkey, "dkey", strlen("dkey"));
 
 	/** init I/O descriptor */
 	daos_csum_set(&iod.iod_kcsum, NULL, 0);
@@ -654,7 +654,7 @@ array_akey_punch_enumerate(void **state)
 		char akey_str[10];
 
 		sprintf(akey_str, "akey_%d", i);
-		daos_iov_set(&iod.iod_name, akey_str, strlen(akey_str));
+		d_iov_set(&iod.iod_name, akey_str, strlen(akey_str));
 		rc = daos_obj_update(oh, DAOS_TX_NONE, &dkey, 1, &iod, &sgl,
 				     NULL);
 		assert_int_equal(rc, 0);
@@ -673,7 +673,7 @@ array_akey_punch_enumerate(void **state)
 		daos_key_t akey;
 
 		sprintf(akey_str, "akey_%d", i);
-		daos_iov_set(&akey, akey_str, strlen(akey_str));
+		d_iov_set(&akey, akey_str, strlen(akey_str));
 		rc = daos_obj_punch_akeys(oh, DAOS_TX_NONE, &dkey, 1, &akey,
 					  NULL);
 		assert_int_equal(rc, 0);
@@ -690,7 +690,7 @@ array_akey_punch_enumerate(void **state)
 		char akey_str[10];
 
 		sprintf(akey_str, "akey_%d", i);
-		daos_iov_set(&iod.iod_name, akey_str, strlen(akey_str));
+		d_iov_set(&iod.iod_name, akey_str, strlen(akey_str));
 
 		iod.iod_size = DAOS_REC_ANY;
 		rc = daos_obj_fetch(oh, DAOS_TX_NONE, &dkey, 1, &iod,
@@ -714,9 +714,9 @@ array_recx_punch_enumerate(void **state)
 	test_arg_t	*arg = *state;
 	daos_obj_id_t	 oid;
 	daos_handle_t	 oh;
-	daos_iov_t	 dkey;
-	daos_sg_list_t	 sgl;
-	daos_iov_t	 sg_iov;
+	d_iov_t	 dkey;
+	d_sg_list_t	 sgl;
+	d_iov_t	 sg_iov;
 	daos_iod_t	 iod;
 	daos_recx_t	 recx;
 	char		 buf[SM_BUF_LEN];
@@ -733,16 +733,16 @@ array_recx_punch_enumerate(void **state)
 	assert_int_equal(rc, 0);
 
 	/** init dkey */
-	daos_iov_set(&dkey, "dkey", strlen("dkey"));
+	d_iov_set(&dkey, "dkey", strlen("dkey"));
 
 	/** init scatter/gather */
-	daos_iov_set(&sg_iov, buf, sizeof(buf));
+	d_iov_set(&sg_iov, buf, sizeof(buf));
 	sgl.sg_nr		= 1;
 	sgl.sg_nr_out		= 0;
 	sgl.sg_iovs		= &sg_iov;
 
 	/** init I/O descriptor */
-	daos_iov_set(&iod.iod_name, "akey", strlen("akey"));
+	d_iov_set(&iod.iod_name, "akey", strlen("akey"));
 	daos_csum_set(&iod.iod_kcsum, NULL, 0);
 	iod.iod_nr	= 1;
 	iod.iod_size	= 1;

--- a/src/tests/suite/daos_capa.c
+++ b/src/tests/suite/daos_capa.c
@@ -31,7 +31,7 @@
 void
 poh_invalidate_local(daos_handle_t *poh)
 {
-	daos_iov_t	ghdl = { NULL, 0, 0 };
+	d_iov_t	ghdl = { NULL, 0, 0 };
 	int		rc;
 
 	/** fetch size of global handle */
@@ -279,9 +279,9 @@ io_invalid_poh(void **state)
 	daos_handle_t		 coh;
 	daos_obj_id_t		 oid;
 	daos_handle_t		 oh;
-	daos_iov_t		 dkey;
-	daos_sg_list_t		 sgl;
-	daos_iov_t		 sg_iov;
+	d_iov_t		 dkey;
+	d_sg_list_t		 sgl;
+	d_iov_t		 sg_iov;
 	daos_iod_t		 iod;
 	daos_recx_t		 recx;
 	char			 buf[STACK_BUF_LEN];
@@ -325,12 +325,12 @@ io_invalid_poh(void **state)
 		assert_int_equal(rc, 0);
 
 		/** init I/O */
-		daos_iov_set(&dkey, "dkey", strlen("dkey"));
-		daos_iov_set(&sg_iov, buf, sizeof(buf));
+		d_iov_set(&dkey, "dkey", strlen("dkey"));
+		d_iov_set(&sg_iov, buf, sizeof(buf));
 		sgl.sg_nr		= 1;
 		sgl.sg_nr_out		= 0;
 		sgl.sg_iovs		= &sg_iov;
-		daos_iov_set(&iod.iod_name, "akey", strlen("akey"));
+		d_iov_set(&iod.iod_name, "akey", strlen("akey"));
 		daos_csum_set(&iod.iod_kcsum, NULL, 0);
 		iod.iod_nr	= 1;
 		iod.iod_size	= 1;
@@ -381,9 +381,9 @@ io_invalid_coh(void **state)
 	daos_handle_t		 coh;
 	daos_obj_id_t		 oid;
 	daos_handle_t		 oh;
-	daos_iov_t		 dkey;
-	daos_sg_list_t		 sgl;
-	daos_iov_t		 sg_iov;
+	d_iov_t		 dkey;
+	d_sg_list_t		 sgl;
+	d_iov_t		 sg_iov;
 	daos_iod_t		 iod;
 	daos_recx_t		 recx;
 	char			 buf[STACK_BUF_LEN];
@@ -416,12 +416,12 @@ io_invalid_coh(void **state)
 		assert_int_equal(rc, 0);
 
 		/** init I/O */
-		daos_iov_set(&dkey, "dkey", strlen("dkey"));
-		daos_iov_set(&sg_iov, buf, sizeof(buf));
+		d_iov_set(&dkey, "dkey", strlen("dkey"));
+		d_iov_set(&sg_iov, buf, sizeof(buf));
 		sgl.sg_nr		= 1;
 		sgl.sg_nr_out		= 0;
 		sgl.sg_iovs		= &sg_iov;
-		daos_iov_set(&iod.iod_name, "akey", strlen("akey"));
+		d_iov_set(&iod.iod_name, "akey", strlen("akey"));
 		daos_csum_set(&iod.iod_kcsum, NULL, 0);
 		iod.iod_nr	= 1;
 		iod.iod_size	= 1;
@@ -469,9 +469,9 @@ update_ro(void **state)
 	daos_handle_t		 coh;
 	daos_obj_id_t		 oid;
 	daos_handle_t		 oh;
-	daos_iov_t		 dkey;
-	daos_sg_list_t		 sgl;
-	daos_iov_t		 sg_iov;
+	d_iov_t		 dkey;
+	d_sg_list_t		 sgl;
+	d_iov_t		 sg_iov;
 	daos_iod_t		 iod;
 	daos_recx_t		 recx;
 	char			 buf[STACK_BUF_LEN];
@@ -495,12 +495,12 @@ update_ro(void **state)
 	assert_int_equal(rc, 0);
 
 	/** init I/O */
-	daos_iov_set(&dkey, "dkey", strlen("dkey"));
-	daos_iov_set(&sg_iov, buf, sizeof(buf));
+	d_iov_set(&dkey, "dkey", strlen("dkey"));
+	d_iov_set(&sg_iov, buf, sizeof(buf));
 	sgl.sg_nr		= 1;
 	sgl.sg_nr_out		= 0;
 	sgl.sg_iovs		= &sg_iov;
-	daos_iov_set(&iod.iod_name, "akey", strlen("akey"));
+	d_iov_set(&iod.iod_name, "akey", strlen("akey"));
 	daos_csum_set(&iod.iod_kcsum, NULL, 0);
 	iod.iod_nr	= 1;
 	iod.iod_size	= 1;

--- a/src/tests/suite/daos_iotest.h
+++ b/src/tests/suite/daos_iotest.h
@@ -46,8 +46,8 @@ struct ioreq {
 	daos_event_t		ev;
 	daos_key_t		dkey;
 	daos_key_t		akey;
-	daos_iov_t		val_iov[IOREQ_SG_IOD_NR][IOREQ_SG_NR];
-	daos_sg_list_t		sgl[IOREQ_SG_IOD_NR];
+	d_iov_t		val_iov[IOREQ_SG_IOD_NR][IOREQ_SG_NR];
+	d_sg_list_t		sgl[IOREQ_SG_IOD_NR];
 	daos_csum_buf_t		csum;
 	char			csum_buf[UPDATE_CSUM_SIZE];
 	daos_recx_t		rex[IOREQ_SG_IOD_NR][IOREQ_IOD_NR];

--- a/src/tests/suite/daos_test.h
+++ b/src/tests/suite/daos_test.h
@@ -297,7 +297,7 @@ static inline void
 handle_share(daos_handle_t *hdl, int type, int rank, daos_handle_t poh,
 	     int verbose)
 {
-	daos_iov_t	ghdl = { NULL, 0, 0 };
+	d_iov_t	ghdl = { NULL, 0, 0 };
 	int		rc;
 
 	if (rank == 0) {

--- a/src/utils/dcont.c
+++ b/src/utils/dcont.c
@@ -138,13 +138,13 @@ cont_op_hdlr(int argc, char *argv[])
 
 	if (svc->rl_nr == 0) {
 		fprintf(stderr, "--svc mustn't be empty\n");
-		daos_rank_list_free(svc);
+		d_rank_list_free(svc);
 		return 2;
 	}
 
 	if (uuid_is_null(cont_uuid)) {
 		fprintf(stderr, "valid cont uuid required\n");
-		daos_rank_list_free(svc);
+		d_rank_list_free(svc);
 		return 2;
 	}
 
@@ -154,7 +154,7 @@ cont_op_hdlr(int argc, char *argv[])
 	 */
 	rc = daos_pool_connect(pool_uuid, group, svc, DAOS_PC_RW, &pool,
 			       NULL /* info */, NULL /* ev */);
-	daos_rank_list_free(svc);
+	d_rank_list_free(svc);
 	if (rc != 0) {
 		fprintf(stderr, "failed to connect to pool: %d\n", rc);
 		return rc;

--- a/src/utils/dmg.c
+++ b/src/utils/dmg.c
@@ -182,14 +182,14 @@ create_hdlr(int argc, char *argv[])
 		fprintf(stderr, "--svcn must be in [1, %lu]\n",
 			ARRAY_SIZE(ranks));
 		if (targets != NULL)
-			daos_rank_list_free(targets);
+			d_rank_list_free(targets);
 		return 2;
 	}
 
 	rc = daos_pool_create(mode, uid, gid, group, targets, "pmem", scm_size,
 			      nvme_size, NULL, &svc, pool_uuid, NULL /* ev */);
 	if (targets != NULL)
-		daos_rank_list_free(targets);
+		d_rank_list_free(targets);
 	if (rc != 0) {
 		fprintf(stderr, "failed to create pool: %d\n", rc);
 		return rc;
@@ -365,7 +365,7 @@ pool_op_hdlr(int argc, char *argv[])
 	if (ranks == NULL &&
 	    (op == POOL_EXCLUDE || op == REPLICA_ADD || op == REPLICA_DEL)) {
 		fprintf(stderr, "valid target ranks required\n");
-		daos_rank_list_free(svc);
+		d_rank_list_free(svc);
 		return 2;
 	}
 
@@ -428,9 +428,9 @@ pool_op_hdlr(int argc, char *argv[])
 			fprintf(stderr, "failed to connect to pool: %d\n", rc);
 		break;
 	}
-	daos_rank_list_free(svc);
-	daos_rank_list_free(ranks);
-	daos_rank_list_free(targets);
+	d_rank_list_free(svc);
+	d_rank_list_free(ranks);
+	d_rank_list_free(targets);
 	if (rc != 0)
 		return rc;
 
@@ -639,13 +639,13 @@ obj_op_hdlr(int argc, char *argv[])
 	}
 	if (svc->rl_nr == 0) {
 		fprintf(stderr, "--svc mustn't be empty\n");
-		daos_rank_list_free(svc);
+		d_rank_list_free(svc);
 		return 2;
 	}
 
 	rc = daos_pool_connect(pool_uuid, group, svc, DAOS_PC_RO,
 			       &poh, NULL /* info */, NULL /* ev */);
-	daos_rank_list_free(svc);
+	d_rank_list_free(svc);
 	if (rc) {
 		fprintf(stderr, "failed to connect to pool: %d\n", rc);
 		return rc;

--- a/src/vos/tests/csum_extent_tests.c
+++ b/src/vos/tests/csum_extent_tests.c
@@ -209,9 +209,9 @@ sgl_init(d_sg_list_t *sgl, uint8_t *buf, uint32_t buf_len)
 {
 	memset(sgl, 0, sizeof((*sgl)));
 	sgl->sg_nr = 1;
-	sgl->sg_iovs = calloc(sgl->sg_nr, sizeof(daos_iov_t));
+	sgl->sg_iovs = calloc(sgl->sg_nr, sizeof(d_iov_t));
 
-	daos_iov_set(&sgl->sg_iovs[0], buf, buf_len);
+	d_iov_set(&sgl->sg_iovs[0], buf, buf_len);
 }
 
 /*
@@ -262,7 +262,7 @@ static int
 update(struct csum_test *test, const uint32_t extent_nr,
 	uint32_t epoch)
 {
-	daos_sg_list_t		sgl;
+	d_sg_list_t		sgl;
 	daos_iod_t		iod;
 
 	iod_init(&iod, extent_nr, test);
@@ -289,7 +289,7 @@ fetch(struct csum_test *test, int extent_nr,
 	uint32_t *csum_count_per_extent, uint32_t *csum_len,
 	uint32_t *csum_count_total, uint32_t epoch)
 {
-	daos_sg_list_t		sgl;
+	d_sg_list_t		sgl;
 	daos_iod_t		iod;
 
 	iod_init(&iod, extent_nr, test);
@@ -443,7 +443,7 @@ void csum_test_csum_buffer_of_0_during_fetch(void **state)
 	update(&test, 1, epoch);
 
 	/* Fetch ... */
-	daos_sg_list_t	 sgl;
+	d_sg_list_t	 sgl;
 	daos_iod_t	 iod;
 	uint32_t	 extent_nr = 1;
 

--- a/src/vos/tests/vts_aggregate.c
+++ b/src/vos/tests/vts_aggregate.c
@@ -44,7 +44,7 @@ update_value(struct io_test_args *arg, daos_unit_oid_t oid, daos_epoch_t epoch,
 	     daos_recx_t *recx, char *buf)
 {
 	daos_iod_t	iod = { 0 };
-	daos_sg_list_t	sgl = { 0 };
+	d_sg_list_t	sgl = { 0 };
 	daos_key_t	dkey_iov, akey_iov;
 	daos_size_t	buf_len;
 	int		rc;
@@ -54,8 +54,8 @@ update_value(struct io_test_args *arg, daos_unit_oid_t oid, daos_epoch_t epoch,
 	assert_true(!(arg->ta_flags & TF_ZERO_COPY));
 
 	arg->oid = oid;
-	daos_iov_set(&dkey_iov, dkey, strlen(dkey));
-	daos_iov_set(&akey_iov, akey, strlen(akey));
+	d_iov_set(&dkey_iov, dkey, strlen(dkey));
+	d_iov_set(&akey_iov, akey, strlen(akey));
 
 	rc = daos_sgl_init(&sgl, 1);
 	assert_int_equal(rc, 0);
@@ -98,7 +98,7 @@ fetch_value(struct io_test_args *arg, daos_unit_oid_t oid, daos_epoch_t epoch,
 	    daos_recx_t *recx, char *buf)
 {
 	daos_iod_t	iod = { 0 };
-	daos_sg_list_t	sgl = { 0 };
+	d_sg_list_t	sgl = { 0 };
 	daos_key_t	dkey_iov, akey_iov;
 	daos_size_t	buf_len;
 	int		rc;
@@ -108,8 +108,8 @@ fetch_value(struct io_test_args *arg, daos_unit_oid_t oid, daos_epoch_t epoch,
 	assert_true(!(arg->ta_flags & TF_ZERO_COPY));
 
 	arg->oid = oid;
-	daos_iov_set(&dkey_iov, dkey, strlen(dkey));
-	daos_iov_set(&akey_iov, akey, strlen(akey));
+	d_iov_set(&dkey_iov, dkey, strlen(dkey));
+	d_iov_set(&akey_iov, akey, strlen(akey));
 
 	rc = daos_sgl_init(&sgl, 1);
 	assert_int_equal(rc, 0);
@@ -174,8 +174,8 @@ phy_recs_nr(struct io_test_args *arg, daos_unit_oid_t oid,
 
 	assert_true(dkey != NULL && akey != NULL);
 	assert_true(strlen(dkey) && strlen(akey));
-	daos_iov_set(&dkey_iov, dkey, strlen(dkey));
-	daos_iov_set(&akey_iov, akey, strlen(akey));
+	d_iov_set(&dkey_iov, dkey, strlen(dkey));
+	d_iov_set(&akey_iov, akey, strlen(akey));
 
 	iter_param.ip_hdl = arg->ctx.tc_co_hdl;
 	iter_param.ip_oid = oid;

--- a/src/vos/tests/vts_io.c
+++ b/src/vos/tests/vts_io.c
@@ -130,7 +130,7 @@ hash_key(d_iov_t *key, int flag)
 }
 
 void
-set_iov(daos_iov_t *iov, char *buf, int int_flag)
+set_iov(d_iov_t *iov, char *buf, int int_flag)
 {
 	if (int_flag)
 		d_iov_set(iov, buf, sizeof(uint64_t));
@@ -243,7 +243,7 @@ io_recx_iterate(struct io_test_args *arg, vos_iter_param_t *param,
 {
 	daos_handle_t	ih = DAOS_HDL_INVAL;
 	char		fetch_buf[8192];
-	daos_iov_t	iov_out;
+	d_iov_t	iov_out;
 	int		itype;
 	int		nr = 0;
 	int		rc;
@@ -270,7 +270,7 @@ io_recx_iterate(struct io_test_args *arg, vos_iter_param_t *param,
 	}
 
 	/* 8k fetch_buf is large enough to hold largest recx */
-	daos_iov_set(&iov_out, fetch_buf, sizeof(fetch_buf));
+	d_iov_set(&iov_out, fetch_buf, sizeof(fetch_buf));
 
 	while (rc == 0) {
 		vos_iter_entry_t  ent;
@@ -483,11 +483,11 @@ io_obj_iter_test(struct io_test_args *arg, daos_epoch_range_t *epr,
 
 int
 io_test_obj_update(struct io_test_args *arg, int epoch, daos_key_t *dkey,
-		   daos_iod_t *iod, daos_sg_list_t *sgl, bool verbose)
+		   daos_iod_t *iod, d_sg_list_t *sgl, bool verbose)
 {
 	struct bio_sglist	*bsgl;
 	struct bio_iov		*biov;
-	daos_iov_t		*srv_iov;
+	d_iov_t		*srv_iov;
 	daos_handle_t		ioh;
 	unsigned int		off;
 	int			i;
@@ -538,11 +538,11 @@ end:
 
 int
 io_test_obj_fetch(struct io_test_args *arg, int epoch, daos_key_t *dkey,
-		  daos_iod_t *iod, daos_sg_list_t *sgl, bool verbose)
+		  daos_iod_t *iod, d_sg_list_t *sgl, bool verbose)
 {
 	struct bio_sglist *bsgl;
 	struct bio_iov	*biov;
-	daos_iov_t	*dst_iov;
+	d_iov_t	*dst_iov;
 	daos_handle_t	 ioh;
 	unsigned int	 off;
 	int		 i;
@@ -597,7 +597,7 @@ io_update_and_fetch_dkey(struct io_test_args *arg, daos_epoch_t update_epoch,
 			 daos_epoch_t fetch_epoch)
 {
 	int			rc = 0;
-	daos_iov_t		val_iov;
+	d_iov_t		val_iov;
 	daos_key_t		dkey;
 	daos_key_t		akey;
 	daos_recx_t		rex;
@@ -610,7 +610,7 @@ io_update_and_fetch_dkey(struct io_test_args *arg, daos_epoch_t update_epoch,
 	char			update_buf[UPDATE_BUF_SIZE];
 	char			fetch_buf[UPDATE_BUF_SIZE];
 	daos_iod_t		iod;
-	daos_sg_list_t		sgl;
+	d_sg_list_t		sgl;
 	unsigned int		recx_size;
 	unsigned int		recx_nr;
 
@@ -666,7 +666,7 @@ io_update_and_fetch_dkey(struct io_test_args *arg, daos_epoch_t update_epoch,
 		set_iov(&akey, &akey_buf[0], arg->ofeat & DAOS_OF_AKEY_UINT64);
 
 		dts_buf_render(update_buf, UPDATE_BUF_SIZE);
-		daos_iov_set(&val_iov, &update_buf[0], UPDATE_BUF_SIZE);
+		d_iov_set(&val_iov, &update_buf[0], UPDATE_BUF_SIZE);
 		iod.iod_size = recx_size;
 		rex.rx_nr    = recx_nr;
 	} else {
@@ -674,7 +674,7 @@ io_update_and_fetch_dkey(struct io_test_args *arg, daos_epoch_t update_epoch,
 		set_iov(&akey, &last_akey[0], arg->ofeat & DAOS_OF_AKEY_UINT64);
 
 		memset(update_buf, 0, UPDATE_BUF_SIZE);
-		daos_iov_set(&val_iov, &update_buf[0], UPDATE_BUF_SIZE);
+		d_iov_set(&val_iov, &update_buf[0], UPDATE_BUF_SIZE);
 		rex.rx_nr    = recx_nr;
 		iod.iod_size = 0;
 	}
@@ -697,7 +697,7 @@ io_update_and_fetch_dkey(struct io_test_args *arg, daos_epoch_t update_epoch,
 	inc_cntr(arg->ta_flags);
 
 	memset(fetch_buf, 0, UPDATE_BUF_SIZE);
-	daos_iov_set(&val_iov, &fetch_buf[0], UPDATE_BUF_SIZE);
+	d_iov_set(&val_iov, &fetch_buf[0], UPDATE_BUF_SIZE);
 
 	iod.iod_size = DAOS_REC_ANY;
 	memset(actual_csum_buf, 0, sizeof(actual_csum_buf));
@@ -1119,7 +1119,7 @@ io_update_and_fetch_incorrect_dkey(struct io_test_args *arg,
 {
 
 	int			rc = 0;
-	daos_iov_t		val_iov;
+	d_iov_t		val_iov;
 	daos_key_t		dkey;
 	daos_key_t		akey;
 	daos_recx_t		rex;
@@ -1128,7 +1128,7 @@ io_update_and_fetch_incorrect_dkey(struct io_test_args *arg,
 	char			update_buf[UPDATE_BUF_SIZE];
 	char			fetch_buf[UPDATE_BUF_SIZE];
 	daos_iod_t		iod;
-	daos_sg_list_t		sgl;
+	d_sg_list_t		sgl;
 
 	memset(&iod, 0, sizeof(iod));
 	memset(&rex, 0, sizeof(rex));
@@ -1142,7 +1142,7 @@ io_update_and_fetch_incorrect_dkey(struct io_test_args *arg,
 	set_iov(&akey, &akey_buf[0], arg->ofeat & DAOS_OF_AKEY_UINT64);
 
 	dts_buf_render(update_buf, UPDATE_BUF_SIZE);
-	daos_iov_set(&val_iov, &update_buf[0], UPDATE_BUF_SIZE);
+	d_iov_set(&val_iov, &update_buf[0], UPDATE_BUF_SIZE);
 	iod.iod_size	= val_iov.iov_len;
 
 	sgl.sg_nr = 1;
@@ -1163,7 +1163,7 @@ io_update_and_fetch_incorrect_dkey(struct io_test_args *arg,
 	inc_cntr(arg->ta_flags);
 
 	memset(fetch_buf, 0, UPDATE_BUF_SIZE);
-	daos_iov_set(&val_iov, &fetch_buf[0], UPDATE_BUF_SIZE);
+	d_iov_set(&val_iov, &fetch_buf[0], UPDATE_BUF_SIZE);
 
 	/* will be set to zero after fetching a nonexistent key */
 	iod.iod_size = -1;
@@ -1184,7 +1184,7 @@ io_fetch_wo_object(void **state)
 {
 	struct io_test_args	*arg = *state;
 	int			rc = 0;
-	daos_iov_t		val_iov;
+	d_iov_t		val_iov;
 	daos_key_t		dkey;
 	daos_key_t		akey;
 	daos_recx_t		rex;
@@ -1192,7 +1192,7 @@ io_fetch_wo_object(void **state)
 	char			akey_buf[UPDATE_AKEY_SIZE];
 	char			fetch_buf[UPDATE_BUF_SIZE];
 	daos_iod_t		iod;
-	daos_sg_list_t		sgl;
+	d_sg_list_t		sgl;
 
 	memset(&iod, 0, sizeof(iod));
 	memset(&rex, 0, sizeof(rex));
@@ -1214,7 +1214,7 @@ io_fetch_wo_object(void **state)
 	iod.iod_type	= DAOS_IOD_ARRAY;
 
 	memset(fetch_buf, 0, UPDATE_BUF_SIZE);
-	daos_iov_set(&val_iov, &fetch_buf[0], UPDATE_BUF_SIZE);
+	d_iov_set(&val_iov, &fetch_buf[0], UPDATE_BUF_SIZE);
 
 	/* should be set to zero after fetching a nonexistent object */
 	iod.iod_size = -1;
@@ -1394,7 +1394,7 @@ pool_cont_same_uuid(void **state)
 	struct io_test_args	*arg = *state;
 	uuid_t			pool_uuid, co_uuid;
 	daos_handle_t		poh, coh;
-	daos_iov_t		val_iov;
+	d_iov_t		val_iov;
 	daos_key_t		dkey;
 	daos_key_t		akey;
 	daos_recx_t		rex;
@@ -1402,7 +1402,7 @@ pool_cont_same_uuid(void **state)
 	char			akey_buf[UPDATE_AKEY_SIZE];
 	char			update_buf[UPDATE_BUF_SIZE];
 	daos_iod_t		iod;
-	daos_sg_list_t		sgl;
+	d_sg_list_t		sgl;
 	daos_unit_oid_t		oid;
 	int			ret = 0;
 
@@ -1437,7 +1437,7 @@ pool_cont_same_uuid(void **state)
 	set_iov(&dkey, &dkey_buf[0], arg->ofeat & DAOS_OF_DKEY_UINT64);
 	set_iov(&akey, &akey_buf[0], arg->ofeat & DAOS_OF_AKEY_UINT64);
 	dts_buf_render(update_buf, UPDATE_BUF_SIZE);
-	daos_iov_set(&val_iov, &update_buf[0], UPDATE_BUF_SIZE);
+	d_iov_set(&val_iov, &update_buf[0], UPDATE_BUF_SIZE);
 	iod.iod_size = UPDATE_BUF_SIZE;
 	rex.rx_nr    = 1;
 
@@ -1538,14 +1538,14 @@ io_simple_one_key_cross_container(void **state)
 {
 	struct io_test_args	*arg = *state;
 	int			rc;
-	daos_iov_t		val_iov;
+	d_iov_t		val_iov;
 	daos_recx_t		rex;
 	char			dkey_buf[UPDATE_DKEY_SIZE];
 	char			akey_buf[UPDATE_DKEY_SIZE];
 	char			update_buf[UPDATE_BUF_SIZE];
 	char			fetch_buf[UPDATE_BUF_SIZE];
 	daos_iod_t		iod;
-	daos_sg_list_t		sgl;
+	d_sg_list_t		sgl;
 	daos_key_t		dkey;
 	daos_key_t		akey;
 	daos_epoch_t		epoch = gen_rand_epoch();
@@ -1579,7 +1579,7 @@ io_simple_one_key_cross_container(void **state)
 	sgl.sg_iovs = &val_iov;
 
 	dts_buf_render(update_buf, UPDATE_BUF_SIZE);
-	daos_iov_set(&val_iov, &update_buf[0], UPDATE_BUF_SIZE);
+	d_iov_set(&val_iov, &update_buf[0], UPDATE_BUF_SIZE);
 
 	if (arg->ta_flags & TF_REC_EXT) {
 		iod.iod_size = UPDATE_REC_SIZE;
@@ -1611,7 +1611,7 @@ io_simple_one_key_cross_container(void **state)
 	}
 
 	memset(fetch_buf, 0, UPDATE_BUF_SIZE);
-	daos_iov_set(&val_iov, &fetch_buf[0], UPDATE_BUF_SIZE);
+	d_iov_set(&val_iov, &fetch_buf[0], UPDATE_BUF_SIZE);
 	iod.iod_size = DAOS_REC_ANY;
 
 	/**
@@ -1623,7 +1623,7 @@ io_simple_one_key_cross_container(void **state)
 	assert_memory_equal(update_buf, fetch_buf, UPDATE_BUF_SIZE);
 
 	memset(fetch_buf, 0, UPDATE_BUF_SIZE);
-	daos_iov_set(&val_iov, &fetch_buf[0], UPDATE_BUF_SIZE);
+	d_iov_set(&val_iov, &fetch_buf[0], UPDATE_BUF_SIZE);
 	iod.iod_size = DAOS_REC_ANY;
 
 	/**
@@ -1695,7 +1695,7 @@ io_sgl_update(void **state)
 	daos_key_t		akey;
 	daos_recx_t		rex;
 	daos_iod_t		iod;
-	daos_sg_list_t		sgl;
+	d_sg_list_t		sgl;
 	char			dkey_buf[UPDATE_DKEY_SIZE];
 	char			akey_buf[UPDATE_AKEY_SIZE];
 	char			*update_buffs[SGL_TEST_BUF_COUNT];
@@ -1736,7 +1736,7 @@ io_sgl_update(void **state)
 		memcpy(&ground_truth[i * SGL_TEST_BUF_SIZE], update_buffs[i],
 			SGL_TEST_BUF_SIZE);
 		/* Attach the buffer to the scatter-gather list */
-		daos_iov_set(&sgl.sg_iovs[i], update_buffs[i],
+		d_iov_set(&sgl.sg_iovs[i], update_buffs[i],
 			SGL_TEST_BUF_SIZE);
 	}
 
@@ -1755,7 +1755,7 @@ io_sgl_update(void **state)
 	memset(fetch_buf, 0, SGL_TEST_BUF_COUNT * SGL_TEST_BUF_SIZE);
 	rc = daos_sgl_init(&sgl, 1);
 	assert_int_equal(rc, 0);
-	daos_iov_set(sgl.sg_iovs, &fetch_buf[0], SGL_TEST_BUF_COUNT *
+	d_iov_set(sgl.sg_iovs, &fetch_buf[0], SGL_TEST_BUF_COUNT *
 		     SGL_TEST_BUF_SIZE);
 	rc = vos_obj_fetch(arg->ctx.tc_co_hdl, arg->oid, 1, &dkey, 1, &iod,
 				&sgl);
@@ -1782,7 +1782,7 @@ io_sgl_fetch(void **state)
 	daos_key_t		akey;
 	daos_recx_t		rex;
 	daos_iod_t		iod;
-	daos_sg_list_t		sgl;
+	d_sg_list_t		sgl;
 	char			dkey_buf[UPDATE_DKEY_SIZE];
 	char			akey_buf[UPDATE_AKEY_SIZE];
 	char			*fetch_buffs[SGL_TEST_BUF_COUNT];
@@ -1816,7 +1816,7 @@ io_sgl_fetch(void **state)
 		SGL_TEST_BUF_SIZE);
 	/* Attach the buffer to the scatter-gather list */
 	daos_sgl_init(&sgl, 1);
-	daos_iov_set(sgl.sg_iovs, &update_buf[0], SGL_TEST_BUF_COUNT *
+	d_iov_set(sgl.sg_iovs, &update_buf[0], SGL_TEST_BUF_COUNT *
 		     SGL_TEST_BUF_SIZE);
 
 	/* Write/Update */
@@ -1836,7 +1836,7 @@ io_sgl_fetch(void **state)
 		assert_non_null(fetch_buffs[i]);
 		memset(fetch_buffs[i], 0, SGL_TEST_BUF_SIZE);
 		/* Attach the buffer to the scatter-gather list */
-		daos_iov_set(&sgl.sg_iovs[i], fetch_buffs[i],
+		d_iov_set(&sgl.sg_iovs[i], fetch_buffs[i],
 			SGL_TEST_BUF_SIZE);
 	}
 	/* Now fetch */
@@ -1859,12 +1859,12 @@ io_fetch_hole(void **state)
 {
 	struct io_test_args	*arg = *state;
 	int			rc = 0;
-	daos_iov_t		val_iov;
+	d_iov_t		val_iov;
 	daos_key_t		dkey;
 	daos_key_t		akey;
 	daos_recx_t		rexs[3];
 	daos_iod_t		iod;
-	daos_sg_list_t		sgl;
+	d_sg_list_t		sgl;
 	char			dkey_buf[UPDATE_DKEY_SIZE];
 	char			akey_buf[UPDATE_AKEY_SIZE];
 	char			update_buf[3 * 1024];
@@ -1901,7 +1901,7 @@ io_fetch_hole(void **state)
 	memcpy(&ground_truth[0], &update_buf[0], 3 * 1024);
 
 	/* Attach buffer to sgl */
-	daos_iov_set(&val_iov, &update_buf[0], 3 * 1024);
+	d_iov_set(&val_iov, &update_buf[0], 3 * 1024);
 	sgl.sg_iovs = &val_iov;
 	sgl.sg_nr = 1;
 
@@ -1912,7 +1912,7 @@ io_fetch_hole(void **state)
 	inc_cntr(arg->ta_flags);
 
 	/* Fetch */
-	daos_iov_set(&val_iov, &fetch_buf[0], 3 * 1024);
+	d_iov_set(&val_iov, &fetch_buf[0], 3 * 1024);
 	rc = vos_obj_fetch(arg->ctx.tc_co_hdl, arg->oid, 1, &dkey, 1, &iod,
 				&sgl);
 	assert_int_equal(rc, 0);
@@ -1932,7 +1932,7 @@ io_fetch_hole(void **state)
 	/* Update the IOD */
 	rexs[1].rx_idx = 2 * 1024;
 	iod.iod_nr = 2;
-	daos_iov_set(&val_iov, &update_buf[0], 2 * 1024);
+	d_iov_set(&val_iov, &update_buf[0], 2 * 1024);
 	sgl.sg_iovs = &val_iov;
 	/* Update using epoch 2 */
 	rc = vos_obj_update(arg->ctx.tc_co_hdl, arg->oid, 2, 0, &dkey, 1, &iod,
@@ -1943,7 +1943,7 @@ io_fetch_hole(void **state)
 	rexs[0].rx_nr = 3 * 1024;
 	iod.iod_nr = 1;
 	memset(fetch_buf, 0, 3 * 1024);
-	daos_iov_set(&val_iov, &fetch_buf[0], 3 * 1024);
+	d_iov_set(&val_iov, &fetch_buf[0], 3 * 1024);
 	/* Fetch using epoch 2 */
 	rc = vos_obj_fetch(arg->ctx.tc_co_hdl, arg->oid, 2, &dkey, 1, &iod,
 				&sgl);
@@ -2032,10 +2032,10 @@ oid_iter_test_with_anchor(void **state)
 static void gen_query_tree(struct io_test_args *arg, daos_unit_oid_t oid)
 {
 	daos_iod_t		iod = {0};
-	daos_sg_list_t		sgl = {0};
+	d_sg_list_t		sgl = {0};
 	daos_key_t		dkey;
 	daos_key_t		akey;
-	daos_iov_t		val_iov;
+	d_iov_t		val_iov;
 	daos_recx_t		recx;
 	daos_epoch_t		epoch = 1;
 	uint64_t		dkey_value;
@@ -2052,7 +2052,7 @@ static void gen_query_tree(struct io_test_args *arg, daos_unit_oid_t oid)
 	iod.iod_nr = 1;
 
 	/* Attach buffer to sgl */
-	daos_iov_set(&val_iov, &update_var, sizeof(update_var));
+	d_iov_set(&val_iov, &update_var, sizeof(update_var));
 	sgl.sg_iovs = &val_iov;
 	sgl.sg_nr = 1;
 

--- a/src/vos/tests/vts_io.h
+++ b/src/vos/tests/vts_io.h
@@ -109,16 +109,16 @@ void			test_args_reset(struct io_test_args *args,
 int			io_test_obj_update(struct io_test_args *arg,
 					   int epoch, daos_key_t *dkey,
 					   daos_iod_t *iod,
-					   daos_sg_list_t *sgl,
+					   d_sg_list_t *sgl,
 					   bool verbose);
 int			io_test_obj_fetch(struct io_test_args *arg,
 					  int epoch, daos_key_t *dkey,
 					  daos_iod_t *iod,
-					  daos_sg_list_t *sgl,
+					  d_sg_list_t *sgl,
 					  bool verbose);
 int			setup_io(void **state);
 int			teardown_io(void **state);
-void			set_iov(daos_iov_t *iov, char *buf, int int_flag);
+void			set_iov(d_iov_t *iov, char *buf, int int_flag);
 
 #endif
 

--- a/src/vos/vea/vea_alloc.c
+++ b/src/vos/vea/vea_alloc.c
@@ -52,7 +52,7 @@ compound_alloc(struct vea_space_info *vsi, struct vea_free_extent *vfe,
 	       struct vea_entry *entry)
 {
 	struct vea_free_extent remain;
-	daos_iov_t key;
+	d_iov_t key;
 	unsigned int flags = VEA_FL_NO_MERGE | VEA_FL_GEN_AGE;
 	int rc;
 
@@ -63,7 +63,7 @@ compound_alloc(struct vea_space_info *vsi, struct vea_free_extent *vfe,
 	/* Remove the found free extent from compound index */
 	free_class_remove(&vsi->vsi_class, entry);
 
-	daos_iov_set(&key, &remain.vfe_blk_off, sizeof(remain.vfe_blk_off));
+	d_iov_set(&key, &remain.vfe_blk_off, sizeof(remain.vfe_blk_off));
 	rc = dbtree_delete(vsi->vsi_free_btr, &key, NULL);
 	if (rc)
 		return rc;
@@ -84,7 +84,7 @@ reserve_hint(struct vea_space_info *vsi, uint32_t blk_cnt,
 {
 	struct vea_free_extent vfe;
 	struct vea_entry *entry;
-	daos_iov_t key, val;
+	d_iov_t key, val;
 	int rc;
 
 	/* No hint offset provided */
@@ -95,8 +95,8 @@ reserve_hint(struct vea_space_info *vsi, uint32_t blk_cnt,
 	vfe.vfe_blk_cnt = blk_cnt;
 
 	/* Fetch & operate on the in-tree record */
-	daos_iov_set(&key, &vfe.vfe_blk_off, sizeof(vfe.vfe_blk_off));
-	daos_iov_set(&val, NULL, 0);
+	d_iov_set(&key, &vfe.vfe_blk_off, sizeof(vfe.vfe_blk_off));
+	d_iov_set(&val, NULL, 0);
 
 	D_ASSERT(!daos_handle_is_inval(vsi->vsi_free_btr));
 	rc = dbtree_fetch(vsi->vsi_free_btr, BTR_PROBE_EQ, DAOS_INTENT_DEFAULT,
@@ -368,7 +368,7 @@ persistent_alloc(struct vea_space_info *vsi, struct vea_free_extent *vfe)
 {
 	struct vea_free_extent found, frag;
 	daos_handle_t btr_hdl;
-	daos_iov_t key_in, key_out, val;
+	d_iov_t key_in, key_out, val;
 	uint64_t blk_off, found_end, vfe_end;
 	int rc, opc = BTR_PROBE_LE;
 
@@ -383,9 +383,9 @@ persistent_alloc(struct vea_space_info *vsi, struct vea_free_extent *vfe)
 		vfe->vfe_blk_off, vfe->vfe_blk_cnt);
 
 	/* Fetch & operate on the copied record */
-	daos_iov_set(&key_in, &vfe->vfe_blk_off, sizeof(vfe->vfe_blk_off));
-	daos_iov_set(&key_out, &blk_off, sizeof(blk_off));
-	daos_iov_set(&val, &found, sizeof(found));
+	d_iov_set(&key_in, &vfe->vfe_blk_off, sizeof(vfe->vfe_blk_off));
+	d_iov_set(&key_out, &blk_off, sizeof(blk_off));
+	d_iov_set(&val, &found, sizeof(found));
 
 	rc = dbtree_fetch(btr_hdl, opc, DAOS_INTENT_PUNCH, &key_in, &key_out,
 			  &val);
@@ -419,9 +419,9 @@ persistent_alloc(struct vea_space_info *vsi, struct vea_free_extent *vfe)
 		frag = found;
 		frag.vfe_blk_cnt = vfe->vfe_blk_off - found.vfe_blk_off;
 
-		daos_iov_set(&key_in, &frag.vfe_blk_off,
+		d_iov_set(&key_in, &frag.vfe_blk_off,
 			     sizeof(frag.vfe_blk_off));
-		daos_iov_set(&val, &frag, sizeof(frag));
+		d_iov_set(&val, &frag, sizeof(frag));
 		rc = dbtree_update(btr_hdl, &key_in, &val);
 		if (rc)
 			return rc;
@@ -435,9 +435,9 @@ persistent_alloc(struct vea_space_info *vsi, struct vea_free_extent *vfe)
 		if (rc)
 			return rc;
 
-		daos_iov_set(&key_in, &frag.vfe_blk_off,
+		d_iov_set(&key_in, &frag.vfe_blk_off,
 			     sizeof(frag.vfe_blk_off));
-		daos_iov_set(&val, &frag, sizeof(frag));
+		d_iov_set(&val, &frag, sizeof(frag));
 		rc = dbtree_update(btr_hdl, &key_in, &val);
 		if (rc)
 			return rc;

--- a/src/vos/vea/vea_api.c
+++ b/src/vos/vea/vea_api.c
@@ -68,7 +68,7 @@ vea_format(struct umem_instance *umem, struct umem_tx_stage_data *txd,
 	struct umem_attr uma;
 	uint64_t tot_blks;
 	daos_handle_t free_btr, vec_btr;
-	daos_iov_t key, val;
+	d_iov_t key, val;
 	int rc;
 
 	D_ASSERT(umem != NULL);
@@ -152,9 +152,9 @@ vea_format(struct umem_instance *umem, struct umem_tx_stage_data *txd,
 	free_ext.vfe_flags = 0;
 	free_ext.vfe_age = VEA_EXT_AGE_MAX;
 
-	daos_iov_set(&key, &free_ext.vfe_blk_off,
+	d_iov_set(&key, &free_ext.vfe_blk_off,
 		     sizeof(free_ext.vfe_blk_off));
-	daos_iov_set(&val, &free_ext, sizeof(free_ext));
+	d_iov_set(&val, &free_ext, sizeof(free_ext));
 
 	rc = dbtree_update(free_btr, &key, &val);
 	if (rc != 0)
@@ -610,7 +610,7 @@ vea_hint_unload(struct vea_hint_context *thc)
 }
 
 static int
-count_free_persistent(daos_handle_t ih, daos_iov_t *key, daos_iov_t *val,
+count_free_persistent(daos_handle_t ih, d_iov_t *key, d_iov_t *val,
 		      void *arg)
 {
 	struct vea_free_extent	*vfe;
@@ -631,7 +631,7 @@ count_free_persistent(daos_handle_t ih, daos_iov_t *key, daos_iov_t *val,
 }
 
 static int
-count_free_transient(daos_handle_t ih, daos_iov_t *key, daos_iov_t *val,
+count_free_transient(daos_handle_t ih, d_iov_t *key, d_iov_t *val,
 		     void *arg)
 {
 	struct vea_entry	*ve;

--- a/src/vos/vea/vea_init.c
+++ b/src/vos/vea/vea_init.c
@@ -143,7 +143,7 @@ unload_space_info(struct vea_space_info *vsi)
 }
 
 static int
-load_free_entry(daos_handle_t ih, daos_iov_t *key, daos_iov_t *val, void *arg)
+load_free_entry(daos_handle_t ih, d_iov_t *key, d_iov_t *val, void *arg)
 {
 	struct vea_free_extent *vfe;
 	struct vea_space_info *vsi;
@@ -162,7 +162,7 @@ load_free_entry(daos_handle_t ih, daos_iov_t *key, daos_iov_t *val, void *arg)
 }
 
 static int
-load_vec_entry(daos_handle_t ih, daos_iov_t *key, daos_iov_t *val, void *arg)
+load_vec_entry(daos_handle_t ih, d_iov_t *key, d_iov_t *val, void *arg)
 {
 	struct vea_ext_vector *vec;
 	struct vea_space_info *vsi;

--- a/src/vos/vea/vea_util.c
+++ b/src/vos/vea/vea_util.c
@@ -132,7 +132,7 @@ vea_dump(struct vea_space_info *vsi, bool transient)
 {
 	struct vea_free_extent *ext;
 	daos_handle_t ih, btr_hdl;
-	daos_iov_t key, val;
+	d_iov_t key, val;
 	uint64_t *off;
 	int rc, print_cnt = 0, opc = BTR_PROBE_FIRST;
 
@@ -149,8 +149,8 @@ vea_dump(struct vea_space_info *vsi, bool transient)
 	rc = dbtree_iter_probe(ih, opc, DAOS_INTENT_DEFAULT, NULL, NULL);
 
 	while (rc == 0) {
-		daos_iov_set(&key, NULL, 0);
-		daos_iov_set(&val, NULL, 0);
+		d_iov_set(&key, NULL, 0);
+		d_iov_set(&val, NULL, 0);
 		rc = dbtree_iter_fetch(ih, &key, &val, NULL);
 		if (rc != 0)
 			break;
@@ -223,7 +223,7 @@ vea_verify_alloc(struct vea_space_info *vsi, bool transient, uint64_t off,
 {
 	struct vea_free_extent vfe, *ext;
 	daos_handle_t btr_hdl;
-	daos_iov_t key, key_out, val;
+	d_iov_t key, key_out, val;
 	uint64_t *key_off;
 	int rc, opc = BTR_PROBE_LE;
 
@@ -240,10 +240,10 @@ vea_verify_alloc(struct vea_space_info *vsi, bool transient, uint64_t off,
 		btr_hdl = vsi->vsi_md_free_btr;
 
 	D_ASSERT(!daos_handle_is_inval(btr_hdl));
-	daos_iov_set(&key, &vfe.vfe_blk_off, sizeof(vfe.vfe_blk_off));
+	d_iov_set(&key, &vfe.vfe_blk_off, sizeof(vfe.vfe_blk_off));
 repeat:
-	daos_iov_set(&key_out, NULL, 0);
-	daos_iov_set(&val, NULL, 0);
+	d_iov_set(&key_out, NULL, 0);
+	d_iov_set(&val, NULL, 0);
 
 	rc = dbtree_fetch(btr_hdl, opc, DAOS_INTENT_DEFAULT, &key, &key_out,
 			  &val);

--- a/src/vos/vos_aggregate.c
+++ b/src/vos/vos_aggregate.c
@@ -660,8 +660,8 @@ fill_one_segment(daos_handle_t ih, struct agg_merge_window *mw,
 	struct agg_phy_ent	*phy_ent;
 	struct bio_io_context	*bio_ctxt;
 	struct bio_sglist	 bsgl;
-	daos_sg_list_t		 sgl;
-	daos_iov_t		 iov;
+	d_sg_list_t		 sgl;
+	d_iov_t		 iov;
 	bio_addr_t		 addr_dst, addr_src;
 	daos_size_t		 seg_size, copy_size, buf_max;
 	struct evt_extent	 ext = { 0 };

--- a/src/vos/vos_common.c
+++ b/src/vos/vos_common.c
@@ -60,7 +60,7 @@ vos_csum_enabled(void)
 }
 
 int
-vos_csum_compute(daos_sg_list_t *sgl, daos_csum_buf_t *csum)
+vos_csum_compute(d_sg_list_t *sgl, daos_csum_buf_t *csum)
 {
 	int	rc;
 #ifdef VOS_STANDALONE

--- a/src/vos/vos_container.c
+++ b/src/vos/vos_container.c
@@ -60,7 +60,7 @@ cont_df_rec_msize(int alloc_overhead)
 
 
 static void
-cont_df_hkey_gen(struct btr_instance *tins, daos_iov_t *key_iov, void *hkey)
+cont_df_hkey_gen(struct btr_instance *tins, d_iov_t *key_iov, void *hkey)
 {
 	D_ASSERT(key_iov->iov_len == sizeof(struct d_uuid));
 	memcpy(hkey, key_iov->iov_buf, key_iov->iov_len);
@@ -79,8 +79,8 @@ cont_df_rec_free(struct btr_instance *tins, struct btr_record *rec, void *args)
 }
 
 static int
-cont_df_rec_alloc(struct btr_instance *tins, daos_iov_t *key_iov,
-	     daos_iov_t *val_iov, struct btr_record *rec)
+cont_df_rec_alloc(struct btr_instance *tins, d_iov_t *key_iov,
+	     d_iov_t *val_iov, struct btr_record *rec)
 {
 	umem_off_t			 offset;
 	struct vos_cont_df		*cont_df;
@@ -127,7 +127,7 @@ exit:
 
 static int
 cont_df_rec_fetch(struct btr_instance *tins, struct btr_record *rec,
-		  daos_iov_t *key_iov, daos_iov_t *val_iov)
+		  d_iov_t *key_iov, d_iov_t *val_iov)
 {
 	struct vos_cont_df		*cont_df;
 	struct cont_df_args		*args = NULL;
@@ -142,7 +142,7 @@ cont_df_rec_fetch(struct btr_instance *tins, struct btr_record *rec,
 
 static int
 cont_df_rec_update(struct btr_instance *tins, struct btr_record *rec,
-		   daos_iov_t *key, daos_iov_t *val)
+		   d_iov_t *key, d_iov_t *val)
 {
 	D_DEBUG(DB_DF, "Record exists already. Nothing to do\n");
 	return 0;
@@ -162,10 +162,10 @@ static int
 cont_df_lookup(struct vos_pool *vpool, struct d_uuid *ukey,
 	       struct cont_df_args *args)
 {
-	daos_iov_t	key, value;
+	d_iov_t	key, value;
 
-	daos_iov_set(&key, ukey, sizeof(struct d_uuid));
-	daos_iov_set(&value, args, sizeof(struct cont_df_args));
+	d_iov_set(&key, ukey, sizeof(struct d_uuid));
+	d_iov_set(&value, args, sizeof(struct cont_df_args));
 	return dbtree_lookup(vpool->vp_cont_th, &key, &value);
 }
 
@@ -280,7 +280,7 @@ vos_cont_create(daos_handle_t poh, uuid_t co_uuid)
 	struct vos_pool		*vpool = NULL;
 	struct cont_df_args	 args;
 	struct d_uuid		 ukey;
-	daos_iov_t		 key, value;
+	d_iov_t		 key, value;
 	int			 rc = 0;
 
 	vpool = vos_hdl2pool(poh);
@@ -304,8 +304,8 @@ vos_cont_create(daos_handle_t poh, uuid_t co_uuid)
 	if (rc != 0)
 		goto exit;
 
-	daos_iov_set(&key, &ukey, sizeof(ukey));
-	daos_iov_set(&value, &args, sizeof(args));
+	d_iov_set(&key, &ukey, sizeof(ukey));
+	d_iov_set(&value, &args, sizeof(args));
 
 	rc = dbtree_update(vpool->vp_cont_th, &key, &value);
 
@@ -491,7 +491,7 @@ vos_cont_destroy(daos_handle_t poh, uuid_t co_uuid)
 	struct cont_df_args		 args;
 	struct d_uuid			 pkey;
 	struct d_uuid			 key;
-	daos_iov_t			 iov;
+	d_iov_t			 iov;
 	int				 rc;
 
 	uuid_copy(key.uuid, co_uuid);
@@ -529,7 +529,7 @@ vos_cont_destroy(daos_handle_t poh, uuid_t co_uuid)
 		goto end;
 	}
 
-	daos_iov_set(&iov, &key, sizeof(struct d_uuid));
+	d_iov_set(&iov, &key, sizeof(struct d_uuid));
 	rc = dbtree_delete(vpool->vp_cont_th, &iov, NULL);
 
 end:
@@ -677,15 +677,15 @@ cont_iter_fetch(struct vos_iterator *iter, vos_iter_entry_t *it_entry,
 		  daos_anchor_t *anchor)
 {
 	struct cont_iterator	*co_iter = vos_iter2co_iter(iter);
-	daos_iov_t		key, value;
+	d_iov_t		key, value;
 	struct d_uuid		ukey;
 	struct cont_df_args	args;
 	int			rc;
 
 	D_ASSERT(iter->it_type == VOS_ITER_COUUID);
 
-	daos_iov_set(&key, &ukey, sizeof(struct d_uuid));
-	daos_iov_set(&value, &args, sizeof(struct cont_df_args));
+	d_iov_set(&key, &ukey, sizeof(struct d_uuid));
+	d_iov_set(&value, &args, sizeof(struct cont_df_args));
 	uuid_clear(it_entry->ie_couuid);
 
 	rc = dbtree_iter_fetch(co_iter->cot_hdl, &key, &value, anchor);

--- a/src/vos/vos_dtx.c
+++ b/src/vos/vos_dtx.c
@@ -94,7 +94,7 @@ dtx_hkey_size(void)
 }
 
 static void
-dtx_hkey_gen(struct btr_instance *tins, daos_iov_t *key_iov, void *hkey)
+dtx_hkey_gen(struct btr_instance *tins, d_iov_t *key_iov, void *hkey)
 {
 	D_ASSERT(key_iov->iov_len == sizeof(struct dtx_id));
 
@@ -114,8 +114,8 @@ dtx_hkey_cmp(struct btr_instance *tins, struct btr_record *rec, void *hkey)
 }
 
 static int
-dtx_rec_alloc(struct btr_instance *tins, daos_iov_t *key_iov,
-	      daos_iov_t *val_iov, struct btr_record *rec)
+dtx_rec_alloc(struct btr_instance *tins, d_iov_t *key_iov,
+	      d_iov_t *val_iov, struct btr_record *rec)
 {
 	struct dtx_rec_bundle	*rbund;
 
@@ -148,20 +148,20 @@ dtx_rec_free(struct btr_instance *tins, struct btr_record *rec, void *args)
 
 static int
 dtx_rec_fetch(struct btr_instance *tins, struct btr_record *rec,
-	      daos_iov_t *key_iov, daos_iov_t *val_iov)
+	      d_iov_t *key_iov, d_iov_t *val_iov)
 {
 	struct vos_dtx_entry_df	*dtx;
 
 	D_ASSERT(val_iov != NULL);
 
 	dtx = umem_off2ptr(&tins->ti_umm, rec->rec_off);
-	daos_iov_set(val_iov, dtx, sizeof(*dtx));
+	d_iov_set(val_iov, dtx, sizeof(*dtx));
 	return 0;
 }
 
 static int
 dtx_rec_update(struct btr_instance *tins, struct btr_record *rec,
-	       daos_iov_t *key, daos_iov_t *val)
+	       d_iov_t *key, d_iov_t *val)
 {
 	D_ASSERTF(0, "Should never been called\n");
 	return 0;
@@ -701,15 +701,15 @@ vos_dtx_commit_one(struct vos_container *cont, struct dtx_id *dti)
 	struct vos_dtx_entry_df		*ent;
 	struct vos_dtx_table_df		*tab;
 	struct dtx_rec_bundle		 rbund;
-	daos_iov_t			 kiov;
-	daos_iov_t			 riov;
+	d_iov_t			 kiov;
+	d_iov_t			 riov;
 	umem_off_t			 umoff;
 	int				 rc = 0;
 
-	daos_iov_set(&kiov, dti, sizeof(*dti));
+	d_iov_set(&kiov, dti, sizeof(*dti));
 	rc = dbtree_delete(cont->vc_dtx_active_hdl, &kiov, &umoff);
 	if (rc == -DER_NONEXIST) {
-		daos_iov_set(&riov, NULL, 0);
+		d_iov_set(&riov, NULL, 0);
 		rc = dbtree_lookup(cont->vc_dtx_committed_hdl, &kiov, &riov);
 		goto out;
 	}
@@ -722,7 +722,7 @@ vos_dtx_commit_one(struct vos_container *cont, struct dtx_id *dti)
 
 	dtx->te_state = DTX_ST_COMMITTED;
 	rbund.trb_umoff = umoff;
-	daos_iov_set(&riov, &rbund, sizeof(rbund));
+	d_iov_set(&riov, &rbund, sizeof(rbund));
 	rc = dbtree_upsert(cont->vc_dtx_committed_hdl, BTR_PROBE_EQ,
 			   DAOS_INTENT_UPDATE, &kiov, &riov);
 	if (rc != 0)
@@ -767,11 +767,11 @@ static int
 vos_dtx_abort_one(struct vos_container *cont, struct dtx_id *dti,
 		  bool force)
 {
-	daos_iov_t	 kiov;
+	d_iov_t	 kiov;
 	umem_off_t	 dtx;
 	int		 rc;
 
-	daos_iov_set(&kiov, dti, sizeof(*dti));
+	d_iov_set(&kiov, dti, sizeof(*dti));
 	rc = dbtree_delete(cont->vc_dtx_active_hdl, &kiov, &dtx);
 	if (rc == 0)
 		dtx_rec_release(&cont->vc_pool->vp_umm, dtx, true, true);
@@ -813,8 +813,8 @@ vos_dtx_alloc(struct umem_instance *umm, struct dtx_handle *dth,
 	struct vos_dtx_entry_df	*dtx;
 	struct vos_container	*cont;
 	umem_off_t		 dtx_umoff;
-	daos_iov_t		 kiov;
-	daos_iov_t		 riov;
+	d_iov_t		 kiov;
+	d_iov_t		 riov;
 	struct dtx_rec_bundle	 rbund;
 	int			 rc;
 
@@ -840,8 +840,8 @@ vos_dtx_alloc(struct umem_instance *umm, struct dtx_handle *dth,
 	dtx->te_prev = UMOFF_NULL;
 
 	rbund.trb_umoff = dtx_umoff;
-	daos_iov_set(&riov, &rbund, sizeof(rbund));
-	daos_iov_set(&kiov, &dth->dth_xid, sizeof(dth->dth_xid));
+	d_iov_set(&riov, &rbund, sizeof(rbund));
+	d_iov_set(&kiov, &dth->dth_xid, sizeof(dth->dth_xid));
 	rc = dbtree_upsert(cont->vc_dtx_active_hdl, BTR_PROBE_EQ,
 			   DAOS_INTENT_UPDATE, &kiov, &riov);
 	if (rc == 0) {
@@ -1483,16 +1483,16 @@ vos_dtx_prepared(struct dtx_handle *dth)
 
 	dtx = umem_off2ptr(&cont->vc_pool->vp_umm, dth->dth_ent);
 	if (dth->dth_intent == DAOS_INTENT_UPDATE) {
-		daos_iov_t	kiov;
-		daos_iov_t	riov;
+		d_iov_t	kiov;
+		d_iov_t	riov;
 
 		/* There is CPU yield during the bulk transfer, then it is
 		 * possible that some others (rebuild) abort this DTX by race.
 		 * So we need to locate (or verify) DTX via its ID instead of
 		 * directly using the dth_ent.
 		 */
-		daos_iov_set(&kiov, &dth->dth_xid, sizeof(struct dtx_id));
-		daos_iov_set(&riov, NULL, 0);
+		d_iov_set(&kiov, &dth->dth_xid, sizeof(struct dtx_id));
+		d_iov_set(&riov, NULL, 0);
 		rc = dbtree_lookup(cont->vc_dtx_active_hdl, &kiov, &riov);
 		if (rc == -DER_NONEXIST)
 			/* The DTX has been aborted by race, notify the RPC
@@ -1544,8 +1544,8 @@ vos_dtx_check_committable(daos_handle_t coh, daos_unit_oid_t *oid,
 			  bool punch)
 {
 	struct vos_container	*cont;
-	daos_iov_t		 kiov;
-	daos_iov_t		 riov;
+	d_iov_t		 kiov;
+	d_iov_t		 riov;
 	int			 rc;
 
 	cont = vos_hdl2cont(coh);
@@ -1557,8 +1557,8 @@ vos_dtx_check_committable(daos_handle_t coh, daos_unit_oid_t *oid,
 			return DTX_ST_COMMITTED;
 	}
 
-	daos_iov_set(&kiov, dti, sizeof(*dti));
-	daos_iov_set(&riov, NULL, 0);
+	d_iov_set(&kiov, dti, sizeof(*dti));
+	d_iov_set(&riov, NULL, 0);
 	rc = dbtree_lookup(cont->vc_dtx_active_hdl, &kiov, &riov);
 	if (rc == 0) {
 		struct vos_dtx_entry_df	*dtx;
@@ -1661,14 +1661,14 @@ vos_dtx_aggregate(daos_handle_t coh, uint64_t max, uint64_t age)
 	for (count = 0, dtx_umoff = tab->tt_entry_head;
 	     count < max && !dtx_is_null(dtx_umoff); count++) {
 		struct vos_dtx_entry_df	*dtx;
-		daos_iov_t		 kiov;
+		d_iov_t		 kiov;
 		umem_off_t		 umoff;
 
 		dtx = umem_off2ptr(umm, dtx_umoff);
 		if (dtx_hlc_age2sec(dtx->te_sec) <= age)
 			break;
 
-		daos_iov_set(&kiov, &dtx->te_xid, sizeof(dtx->te_xid));
+		d_iov_set(&kiov, &dtx->te_xid, sizeof(dtx->te_xid));
 		rc = dbtree_delete(cont->vc_dtx_committed_hdl, &kiov, &umoff);
 		D_ASSERT(rc == 0);
 

--- a/src/vos/vos_dtx_cos.c
+++ b/src/vos/vos_dtx_cos.c
@@ -87,7 +87,7 @@ dtx_cos_hkey_size(void)
 }
 
 static void
-dtx_cos_hkey_gen(struct btr_instance *tins, daos_iov_t *key_iov, void *hkey)
+dtx_cos_hkey_gen(struct btr_instance *tins, d_iov_t *key_iov, void *hkey)
 {
 	D_ASSERT(key_iov->iov_len == sizeof(struct dtx_cos_key));
 
@@ -107,8 +107,8 @@ dtx_cos_hkey_cmp(struct btr_instance *tins, struct btr_record *rec, void *hkey)
 }
 
 static int
-dtx_cos_rec_alloc(struct btr_instance *tins, daos_iov_t *key_iov,
-		  daos_iov_t *val_iov, struct btr_record *rec)
+dtx_cos_rec_alloc(struct btr_instance *tins, d_iov_t *key_iov,
+		  d_iov_t *val_iov, struct btr_record *rec)
 {
 	struct dtx_cos_key		*key;
 	struct dtx_cos_rec_bundle	*rbund;
@@ -186,21 +186,21 @@ dtx_cos_rec_free(struct btr_instance *tins, struct btr_record *rec, void *args)
 
 static int
 dtx_cos_rec_fetch(struct btr_instance *tins, struct btr_record *rec,
-		  daos_iov_t *key_iov, daos_iov_t *val_iov)
+		  d_iov_t *key_iov, d_iov_t *val_iov)
 {
 	struct dtx_cos_rec	*dcr;
 
 	D_ASSERT(val_iov != NULL);
 
 	dcr = (struct dtx_cos_rec *)umem_off2ptr(&tins->ti_umm, rec->rec_off);
-	daos_iov_set(val_iov, dcr, sizeof(struct dtx_cos_rec));
+	d_iov_set(val_iov, dcr, sizeof(struct dtx_cos_rec));
 
 	return 0;
 }
 
 static int
 dtx_cos_rec_update(struct btr_instance *tins, struct btr_record *rec,
-		   daos_iov_t *key, daos_iov_t *val)
+		   d_iov_t *key, d_iov_t *val)
 {
 	struct dtx_cos_rec_bundle	*rbund;
 	struct dtx_cos_rec		*dcr;
@@ -265,8 +265,8 @@ vos_dtx_list_cos(daos_handle_t coh, daos_unit_oid_t *oid, uint64_t dkey_hash,
 {
 	struct vos_container		*cont;
 	struct dtx_cos_key		 key;
-	daos_iov_t			 kiov;
-	daos_iov_t			 riov;
+	d_iov_t			 kiov;
+	d_iov_t			 riov;
 	struct dtx_id			*dti = NULL;
 	struct dtx_cos_rec		*dcr = NULL;
 	struct dtx_cos_rec		*dcr2 = NULL;
@@ -280,8 +280,8 @@ vos_dtx_list_cos(daos_handle_t coh, daos_unit_oid_t *oid, uint64_t dkey_hash,
 
 	key.oid = *oid;
 	key.dkey = dkey_hash;
-	daos_iov_set(&kiov, &key, sizeof(key));
-	daos_iov_set(&riov, NULL, 0);
+	d_iov_set(&kiov, &key, sizeof(key));
+	d_iov_set(&riov, NULL, 0);
 
 	rc = dbtree_lookup(cont->vc_dtx_cos_hdl, &kiov, &riov);
 	if (rc == 0) {
@@ -299,7 +299,7 @@ vos_dtx_list_cos(daos_handle_t coh, daos_unit_oid_t *oid, uint64_t dkey_hash,
 			goto out;
 
 		key.dkey = 0;
-		daos_iov_set(&riov, NULL, 0);
+		d_iov_set(&riov, NULL, 0);
 
 		rc = dbtree_lookup(cont->vc_dtx_cos_hdl, &kiov, &riov);
 		if (rc != 0)
@@ -361,8 +361,8 @@ vos_dtx_add_cos(daos_handle_t coh, daos_unit_oid_t *oid, struct dtx_id *dti,
 	struct vos_container		*cont;
 	struct dtx_cos_key		 key;
 	struct dtx_cos_rec_bundle	 rbund;
-	daos_iov_t			 kiov;
-	daos_iov_t			 riov;
+	d_iov_t			 kiov;
+	d_iov_t			 riov;
 	int				 rc;
 
 	cont = vos_hdl2cont(coh);
@@ -370,13 +370,13 @@ vos_dtx_add_cos(daos_handle_t coh, daos_unit_oid_t *oid, struct dtx_id *dti,
 
 	key.oid = *oid;
 	key.dkey = dkey_hash;
-	daos_iov_set(&kiov, &key, sizeof(key));
+	d_iov_set(&kiov, &key, sizeof(key));
 
 	rbund.cont = cont;
 	rbund.dti = dti;
 	rbund.time = time;
 	rbund.punch = punch;
-	daos_iov_set(&riov, &rbund, sizeof(rbund));
+	d_iov_set(&riov, &rbund, sizeof(rbund));
 
 	rc = dbtree_upsert(cont->vc_dtx_cos_hdl, BTR_PROBE_EQ,
 			   DAOS_INTENT_UPDATE, &kiov, &riov);
@@ -395,8 +395,8 @@ vos_dtx_lookup_cos(daos_handle_t coh, daos_unit_oid_t *oid,
 {
 	struct vos_container		*cont;
 	struct dtx_cos_key		 key;
-	daos_iov_t			 kiov;
-	daos_iov_t			 riov;
+	d_iov_t			 kiov;
+	d_iov_t			 riov;
 	struct dtx_cos_rec		*dcr;
 	struct dtx_cos_rec_child	*dcrc;
 	d_list_t			*head;
@@ -407,8 +407,8 @@ vos_dtx_lookup_cos(daos_handle_t coh, daos_unit_oid_t *oid,
 
 	key.oid = *oid;
 	key.dkey = dkey_hash;
-	daos_iov_set(&kiov, &key, sizeof(key));
-	daos_iov_set(&riov, NULL, 0);
+	d_iov_set(&kiov, &key, sizeof(key));
+	d_iov_set(&riov, NULL, 0);
 
 	rc = dbtree_lookup(cont->vc_dtx_cos_hdl, &kiov, &riov);
 	if (rc != 0)
@@ -472,8 +472,8 @@ vos_dtx_del_cos(struct vos_container *cont, daos_unit_oid_t *oid,
 		struct dtx_id *xid, uint64_t dkey_hash, bool punch)
 {
 	struct dtx_cos_key		 key;
-	daos_iov_t			 kiov;
-	daos_iov_t			 riov;
+	d_iov_t			 kiov;
+	d_iov_t			 riov;
 	struct dtx_cos_rec		*dcr;
 	struct dtx_cos_rec_child	*dcrc;
 	d_list_t			*head;
@@ -481,8 +481,8 @@ vos_dtx_del_cos(struct vos_container *cont, daos_unit_oid_t *oid,
 
 	key.oid = *oid;
 	key.dkey = dkey_hash;
-	daos_iov_set(&kiov, &key, sizeof(key));
-	daos_iov_set(&riov, NULL, 0);
+	d_iov_set(&kiov, &key, sizeof(key));
+	d_iov_set(&riov, NULL, 0);
 
 	rc = dbtree_lookup(cont->vc_dtx_cos_hdl, &kiov, &riov);
 	if (rc != 0)

--- a/src/vos/vos_dtx_iter.c
+++ b/src/vos/vos_dtx_iter.c
@@ -131,12 +131,12 @@ dtx_iter_fetch(struct vos_iterator *iter, vos_iter_entry_t *it_entry,
 {
 	struct vos_dtx_iter	*oiter = iter2oiter(iter);
 	struct vos_dtx_entry_df	*dtx;
-	daos_iov_t		 rec_iov;
+	d_iov_t		 rec_iov;
 	int			 rc;
 
 	D_ASSERT(iter->it_type == VOS_ITER_DTX);
 
-	daos_iov_set(&rec_iov, NULL, 0);
+	d_iov_set(&rec_iov, NULL, 0);
 	rc = dbtree_iter_fetch(oiter->oit_hdl, NULL, &rec_iov, anchor);
 	if (rc != 0) {
 		D_ERROR("Error while fetching DTX info: rc = %d\n", rc);

--- a/src/vos/vos_internal.h
+++ b/src/vos/vos_internal.h
@@ -382,7 +382,7 @@ int vos_csum_enabled(void);
 /**
  * compute checksum for a sgl using CRC64
  */
-int vos_csum_compute(daos_sg_list_t *sgl, daos_csum_buf_t *csum);
+int vos_csum_compute(d_sg_list_t *sgl, daos_csum_buf_t *csum);
 /**
  * Register btree class for container table, it is called within vos_init()
  *
@@ -631,7 +631,7 @@ struct vos_rec_bundle {
 	 *	    TODO also support scatter/gather list input.
 	 * Output : parameter to return value address.
 	 */
-	daos_iov_t		*rb_iov;
+	d_iov_t		*rb_iov;
 	/**
 	 * Single value record IOV.
 	 */
@@ -655,7 +655,7 @@ struct vos_embedded_key {
 	/** The kbund of the current iterator */
 	struct vos_key_bundle	ek_kbund;
 	/** Inlined iov kbund references */
-	daos_iov_t		ek_kiov;
+	d_iov_t		ek_kiov;
 	/** Inlined buffer the kiov references*/
 	unsigned char		ek_key[EMBEDDED_KEY_MAX];
 };
@@ -685,7 +685,7 @@ vos_rec2irec(struct btr_instance *tins, struct btr_record *rec)
 static inline uint64_t
 vos_krec_size(struct vos_rec_bundle *rbund)
 {
-	daos_iov_t	*key;
+	d_iov_t	*key;
 	daos_size_t	 psize;
 
 	key = rbund->rb_iov;
@@ -944,7 +944,7 @@ struct vos_iter_ops {
 			     daos_anchor_t *anchor);
 	/** copy out the record data */
 	int	(*iop_copy)(struct vos_iterator *iter,
-			    vos_iter_entry_t *it_entry, daos_iov_t *iov_out);
+			    vos_iter_entry_t *it_entry, d_iov_t *iov_out);
 	/** Delete the record that the cursor points to */
 	int	(*iop_delete)(struct vos_iterator *iter,
 			      void *args);
@@ -1001,10 +1001,10 @@ vos_hdl2oiter(daos_handle_t hdl)
  * into dbtree operations as a compound key.
  */
 static inline void
-tree_key_bundle2iov(struct vos_key_bundle *kbund, daos_iov_t *iov)
+tree_key_bundle2iov(struct vos_key_bundle *kbund, d_iov_t *iov)
 {
 	memset(kbund, 0, sizeof(*kbund));
-	daos_iov_set(iov, kbund, sizeof(*kbund));
+	d_iov_set(iov, kbund, sizeof(*kbund));
 }
 
 /**
@@ -1013,10 +1013,10 @@ tree_key_bundle2iov(struct vos_key_bundle *kbund, daos_iov_t *iov)
  * buffer umoff, checksum etc).
  */
 static inline void
-tree_rec_bundle2iov(struct vos_rec_bundle *rbund, daos_iov_t *iov)
+tree_rec_bundle2iov(struct vos_rec_bundle *rbund, d_iov_t *iov)
 {
 	memset(rbund, 0, sizeof(*rbund));
-	daos_iov_set(iov, rbund, sizeof(*rbund));
+	d_iov_set(iov, rbund, sizeof(*rbund));
 }
 
 enum {
@@ -1033,8 +1033,8 @@ key_tree_prepare(struct vos_object *obj, daos_epoch_t epoch,
 void
 key_tree_release(daos_handle_t toh, bool is_array);
 int
-key_tree_punch(struct vos_object *obj, daos_handle_t toh, daos_iov_t *key_iov,
-	       daos_iov_t *val_iov, int flags);
+key_tree_punch(struct vos_object *obj, daos_handle_t toh, d_iov_t *key_iov,
+	       d_iov_t *val_iov, int flags);
 
 /* vos_io.c */
 uint16_t

--- a/src/vos/vos_io.c
+++ b/src/vos/vos_io.c
@@ -259,8 +259,8 @@ akey_fetch_single(daos_handle_t toh, daos_epoch_t epoch,
 {
 	struct vos_key_bundle	 kbund;
 	struct vos_rec_bundle	 rbund;
-	daos_iov_t		 kiov; /* iov to carry key bundle */
-	daos_iov_t		 riov; /* iov to carray record bundle */
+	d_iov_t		 kiov; /* iov to carry key bundle */
+	d_iov_t		 riov; /* iov to carray record bundle */
 	struct bio_iov		 biov; /* iov to return data buffer */
 	int			 rc;
 	daos_iod_t		*iod = &ioc->ic_iods[ioc->ic_sgl_at];
@@ -676,7 +676,7 @@ akey_update_single(daos_handle_t toh, daos_epoch_t epoch, uint32_t pm_ver,
 	struct vos_key_bundle	 kbund;
 	struct vos_rec_bundle	 rbund;
 	daos_csum_buf_t		 csum;
-	daos_iov_t		 kiov, riov;
+	d_iov_t		 kiov, riov;
 	struct bio_iov		*biov;
 	umem_off_t		 umoff;
 	daos_iod_t		*iod = &ioc->ic_iods[ioc->ic_sgl_at];
@@ -1390,7 +1390,7 @@ vos_iod_sgl_at(daos_handle_t ioh, unsigned int idx)
  * Caveat: These two functions may yield, please use with caution.
  */
 static int
-vos_obj_copy(struct vos_io_context *ioc, daos_sg_list_t *sgls,
+vos_obj_copy(struct vos_io_context *ioc, d_sg_list_t *sgls,
 	     unsigned int sgl_nr)
 {
 	int rc, err;
@@ -1409,7 +1409,7 @@ vos_obj_copy(struct vos_io_context *ioc, daos_sg_list_t *sgls,
 int
 vos_obj_update(daos_handle_t coh, daos_unit_oid_t oid, daos_epoch_t epoch,
 	       uint32_t pm_ver, daos_key_t *dkey, unsigned int iod_nr,
-	       daos_iod_t *iods, daos_sg_list_t *sgls)
+	       daos_iod_t *iods, d_sg_list_t *sgls)
 {
 	daos_handle_t ioh;
 	int rc;
@@ -1436,7 +1436,7 @@ vos_obj_update(daos_handle_t coh, daos_unit_oid_t oid, daos_epoch_t epoch,
 int
 vos_obj_fetch(daos_handle_t coh, daos_unit_oid_t oid, daos_epoch_t epoch,
 	      daos_key_t *dkey, unsigned int iod_nr, daos_iod_t *iods,
-	      daos_sg_list_t *sgls)
+	      d_sg_list_t *sgls)
 {
 	daos_handle_t ioh;
 	bool size_fetch = (sgls == NULL);
@@ -1458,7 +1458,7 @@ vos_obj_fetch(daos_handle_t coh, daos_unit_oid_t oid, daos_epoch_t epoch,
 
 		for (i = 0; i < iod_nr; i++) {
 			struct bio_sglist *bsgl = bio_iod_sgl(ioc->ic_biod, i);
-			daos_sg_list_t *sgl = &sgls[i];
+			d_sg_list_t *sgl = &sgls[i];
 
 			/* Inform caller the nonexistent of object/key */
 			if (bsgl->bs_nr_out == 0) {

--- a/src/vos/vos_iterator.c
+++ b/src/vos/vos_iterator.c
@@ -336,7 +336,7 @@ vos_iter_fetch(daos_handle_t ih, vos_iter_entry_t *it_entry,
 
 int
 vos_iter_copy(daos_handle_t ih, vos_iter_entry_t *it_entry,
-	      daos_iov_t *iov_out)
+	      d_iov_t *iov_out)
 {
 	struct vos_iterator *iter = vos_hdl2iter(ih);
 	int rc;

--- a/src/vos/vos_obj.c
+++ b/src/vos/vos_obj.c
@@ -52,8 +52,8 @@ key_punch(struct vos_object *obj, daos_epoch_t epoch, uint32_t pm_ver,
 	struct vos_key_bundle	kbund;
 	struct vos_rec_bundle	rbund;
 	daos_csum_buf_t		csum;
-	daos_iov_t		kiov;
-	daos_iov_t		riov;
+	d_iov_t		kiov;
+	d_iov_t		riov;
 	int			rc;
 
 	rc = obj_tree_init(obj);
@@ -192,12 +192,12 @@ reset:
  */
 static int
 key_iter_fetch_helper(struct vos_obj_iter *oiter, struct vos_key_bundle *kbund,
-		      struct vos_rec_bundle *rbund, daos_iov_t *keybuf,
+		      struct vos_rec_bundle *rbund, d_iov_t *keybuf,
 		      daos_anchor_t *anchor)
 {
-	daos_iov_t		kiov;
-	daos_iov_t		kbund_kiov;
-	daos_iov_t		riov;
+	d_iov_t		kiov;
+	d_iov_t		kbund_kiov;
+	d_iov_t		riov;
 	daos_csum_buf_t		csum;
 
 	tree_key_bundle2iov(kbund, &kiov);
@@ -207,7 +207,7 @@ key_iter_fetch_helper(struct vos_obj_iter *oiter, struct vos_key_bundle *kbund,
 	rbund->rb_iov	= keybuf;
 	rbund->rb_csum	= &csum;
 
-	daos_iov_set(rbund->rb_iov, NULL, 0); /* no copy */
+	d_iov_set(rbund->rb_iov, NULL, 0); /* no copy */
 	daos_csum_set(rbund->rb_csum, NULL, 0);
 
 	return dbtree_iter_fetch(oiter->it_hdl, &kiov, &riov, anchor);
@@ -252,7 +252,7 @@ key_iter_fetch_root(struct vos_obj_iter *oiter, vos_iter_type_t type,
 	struct vos_krec_df	*krec;
 	struct vos_key_bundle	 kbund;
 	struct vos_rec_bundle	 rbund;
-	daos_iov_t		 keybuf;
+	d_iov_t		 keybuf;
 	int			 rc;
 
 	rc = key_iter_fetch_helper(oiter, &kbund, &rbund, &keybuf, NULL);
@@ -285,7 +285,7 @@ key_iter_fetch_root(struct vos_obj_iter *oiter, vos_iter_type_t type,
 
 static int
 key_iter_copy(struct vos_obj_iter *oiter, vos_iter_entry_t *ent,
-	      daos_iov_t *iov_out)
+	      d_iov_t *iov_out)
 {
 	if (ent->ie_key.iov_len > iov_out->iov_buf_len)
 		return -DER_OVERFLOW;
@@ -312,8 +312,8 @@ key_iter_match(struct vos_obj_iter *oiter, vos_iter_entry_t *ent, int *probe_p)
 	struct vos_key_bundle	 kbund;
 	struct vos_rec_bundle	 rbund;
 	daos_handle_t		 toh;
-	daos_iov_t		 kiov;
-	daos_iov_t		 riov;
+	d_iov_t		 kiov;
+	d_iov_t		 riov;
 	int			 probe;
 	int			 rc;
 
@@ -392,7 +392,7 @@ key_iter_match_probe(struct vos_obj_iter *oiter)
 	while (1) {
 		vos_iter_entry_t	entry;
 		struct vos_key_bundle	kbund;
-		daos_iov_t		kiov;
+		d_iov_t		kiov;
 		int			opc = 0;
 
 		rc = key_iter_match(oiter, &entry, &opc);
@@ -565,7 +565,7 @@ singv_iter_probe_fetch(struct vos_obj_iter *oiter, dbtree_probe_opc_t opc,
 		       vos_iter_entry_t *entry)
 {
 	struct vos_key_bundle	kbund;
-	daos_iov_t		kiov;
+	d_iov_t		kiov;
 	int			rc;
 
 	tree_key_bundle2iov(&kbund, &kiov);
@@ -698,8 +698,8 @@ singv_iter_fetch(struct vos_obj_iter *oiter, vos_iter_entry_t *it_entry,
 {
 	struct vos_key_bundle	kbund;
 	struct vos_rec_bundle	rbund;
-	daos_iov_t		kiov;
-	daos_iov_t		riov;
+	d_iov_t		kiov;
+	d_iov_t		riov;
 	int			rc;
 
 	tree_key_bundle2iov(&kbund, &kiov);
@@ -875,7 +875,7 @@ recx_iter_fetch(struct vos_obj_iter *oiter, vos_iter_entry_t *it_entry,
 
 static int
 recx_iter_copy(struct vos_obj_iter *oiter, vos_iter_entry_t *it_entry,
-	       daos_iov_t *iov_out)
+	       d_iov_t *iov_out)
 {
 	struct bio_io_context	*bioc;
 	struct bio_iov		*biov = &it_entry->ie_biov;
@@ -1258,7 +1258,7 @@ vos_obj_iter_fetch(struct vos_iterator *iter, vos_iter_entry_t *it_entry,
 
 static int
 vos_obj_iter_copy(struct vos_iterator *iter, vos_iter_entry_t *it_entry,
-		  daos_iov_t *iov_out)
+		  d_iov_t *iov_out)
 {
 	struct vos_obj_iter *oiter = vos_iter2oiter(iter);
 

--- a/src/vos/vos_query.c
+++ b/src/vos/vos_query.c
@@ -54,9 +54,9 @@ find_key(struct open_query *query, daos_handle_t toh, daos_key_t *key,
 	daos_handle_t		 ih;
 	struct vos_key_bundle	 kbund;
 	struct vos_rec_bundle	 rbund;
-	daos_iov_t		 kiov;
-	daos_iov_t		 kbund_kiov;
-	daos_iov_t		 riov;
+	d_iov_t		 kiov;
+	d_iov_t		 kbund_kiov;
+	d_iov_t		 riov;
 	daos_csum_buf_t		 csum;
 	daos_epoch_range_t	 epr;
 	int			 rc = 0;
@@ -90,7 +90,7 @@ find_key(struct open_query *query, daos_handle_t toh, daos_key_t *key,
 	rbund.rb_csum = &csum;
 
 	do {
-		daos_iov_set(rbund.rb_iov, NULL, 0);
+		d_iov_set(rbund.rb_iov, NULL, 0);
 		daos_csum_set(rbund.rb_csum, NULL, 0);
 
 		rc = dbtree_iter_fetch(ih, &kiov, &riov, anchor);
@@ -192,8 +192,8 @@ open_and_query_key(struct open_query *query, daos_key_t *key,
 	daos_csum_buf_t		 csum = {0};
 	struct vos_key_bundle	 kbund;
 	struct vos_rec_bundle	 rbund;
-	daos_iov_t		 kiov;
-	daos_iov_t		 riov;
+	d_iov_t		 kiov;
+	d_iov_t		 riov;
 	enum vos_tree_class	 tclass;
 	int			 rc = 0;
 

--- a/src/vos/vos_tree.c
+++ b/src/vos/vos_tree.c
@@ -52,14 +52,14 @@ struct vos_btr_attr {
 static struct vos_btr_attr *obj_tree_find_attr(unsigned tree_class);
 
 static struct vos_key_bundle *
-iov2key_bundle(daos_iov_t *key_iov)
+iov2key_bundle(d_iov_t *key_iov)
 {
 	D_ASSERT(key_iov->iov_len == sizeof(struct vos_key_bundle));
 	return (struct vos_key_bundle *)key_iov->iov_buf;
 }
 
 static struct vos_rec_bundle *
-iov2rec_bundle(daos_iov_t *val_iov)
+iov2rec_bundle(d_iov_t *val_iov)
 {
 	D_ASSERT(val_iov->iov_len == sizeof(struct vos_rec_bundle));
 	return (struct vos_rec_bundle *)val_iov->iov_buf;
@@ -90,7 +90,7 @@ ktr_rec_store(struct btr_instance *tins, struct btr_record *rec,
 	      struct vos_key_bundle *kbund, struct vos_rec_bundle *rbund)
 {
 	struct vos_krec_df *krec = vos_rec2krec(tins, rec);
-	daos_iov_t	   *iov	 = rbund->rb_iov;
+	d_iov_t	   *iov	 = rbund->rb_iov;
 	daos_csum_buf_t	   *csum = rbund->rb_csum;
 	char		   *kbuf;
 
@@ -122,7 +122,7 @@ ktr_rec_load(struct btr_instance *tins, struct btr_record *rec,
 	     struct vos_key_bundle *kbund, struct vos_rec_bundle *rbund)
 {
 	struct vos_krec_df *krec = vos_rec2krec(tins, rec);
-	daos_iov_t	   *iov	 = rbund->rb_iov;
+	d_iov_t	   *iov	 = rbund->rb_iov;
 	daos_csum_buf_t	   *csum = rbund->rb_csum;
 	char		   *kbuf;
 
@@ -131,7 +131,7 @@ ktr_rec_load(struct btr_instance *tins, struct btr_record *rec,
 
 	if (kbund != NULL) {
 		if (kbund->kb_key != NULL) {
-			daos_iov_set(kbund->kb_key, kbuf, krec->kr_size);
+			d_iov_set(kbund->kb_key, kbuf, krec->kr_size);
 		} else {
 			kbund->kb_key = iov;
 		}
@@ -179,7 +179,7 @@ ktr_rec_msize(int alloc_overhead)
 
 /** generate hkey */
 static void
-ktr_hkey_gen(struct btr_instance *tins, daos_iov_t *key_iov, void *hkey)
+ktr_hkey_gen(struct btr_instance *tins, d_iov_t *key_iov, void *hkey)
 {
 	struct ktr_hkey		*kkey  = (struct ktr_hkey *)hkey;
 	struct vos_key_bundle	*kbund = iov2key_bundle(key_iov);
@@ -220,7 +220,7 @@ ktr_hkey_cmp(struct btr_instance *tins, struct btr_record *rec, void *hkey)
 }
 
 static int
-ktr_key_cmp_lexical(struct vos_krec_df *krec, daos_iov_t *kiov)
+ktr_key_cmp_lexical(struct vos_krec_df *krec, d_iov_t *kiov)
 {
 	int cmp;
 
@@ -240,7 +240,7 @@ ktr_key_cmp_lexical(struct vos_krec_df *krec, daos_iov_t *kiov)
 }
 
 static int
-ktr_key_cmp_uint64(struct vos_krec_df *krec, daos_iov_t *kiov)
+ktr_key_cmp_uint64(struct vos_krec_df *krec, d_iov_t *kiov)
 {
 	uint64_t k1, k2;
 
@@ -258,7 +258,7 @@ ktr_key_cmp_uint64(struct vos_krec_df *krec, daos_iov_t *kiov)
 }
 
 static int
-ktr_key_cmp_default(struct vos_krec_df *krec, daos_iov_t *kiov)
+ktr_key_cmp_default(struct vos_krec_df *krec, d_iov_t *kiov)
 {
 	/* This only gets called if hash comparison matches. */
 	if (krec->kr_size > kiov->iov_len)
@@ -274,9 +274,9 @@ ktr_key_cmp_default(struct vos_krec_df *krec, daos_iov_t *kiov)
 /** compare the real key */
 static int
 ktr_key_cmp(struct btr_instance *tins, struct btr_record *rec,
-	    daos_iov_t *key_iov)
+	    d_iov_t *key_iov)
 {
-	daos_iov_t		*kiov;
+	d_iov_t		*kiov;
 	struct vos_krec_df	*krec;
 	struct vos_key_bundle	*kbund;
 	uint64_t		 feats = tins->ti_root->tr_feats;
@@ -309,7 +309,7 @@ ktr_key_cmp(struct btr_instance *tins, struct btr_record *rec,
 }
 
 static void
-ktr_key_encode(struct btr_instance *tins, daos_iov_t *key,
+ktr_key_encode(struct btr_instance *tins, d_iov_t *key,
 	       daos_anchor_t *anchor)
 {
 	struct vos_key_bundle *kbund = iov2key_bundle(key);
@@ -329,7 +329,7 @@ ktr_key_encode(struct btr_instance *tins, daos_iov_t *key,
 }
 
 static void
-ktr_key_decode(struct btr_instance *tins, daos_iov_t *key,
+ktr_key_decode(struct btr_instance *tins, d_iov_t *key,
 	       daos_anchor_t *anchor)
 {
 	struct vos_embedded_key *embedded =
@@ -344,8 +344,8 @@ ktr_key_decode(struct btr_instance *tins, daos_iov_t *key,
 
 /** create a new key-record, or install an externally allocated key-record */
 static int
-ktr_rec_alloc(struct btr_instance *tins, daos_iov_t *key_iov,
-	      daos_iov_t *val_iov, struct btr_record *rec)
+ktr_rec_alloc(struct btr_instance *tins, d_iov_t *key_iov,
+	      d_iov_t *val_iov, struct btr_record *rec)
 {
 	struct vos_key_bundle	*kbund;
 	struct vos_rec_bundle	*rbund;
@@ -436,7 +436,7 @@ exit:
 
 static int
 ktr_rec_fetch(struct btr_instance *tins, struct btr_record *rec,
-	      daos_iov_t *key_iov, daos_iov_t *val_iov)
+	      d_iov_t *key_iov, d_iov_t *val_iov)
 {
 	struct vos_krec_df	*krec = vos_rec2krec(tins, rec);
 	struct vos_rec_bundle	*rbund = iov2rec_bundle(val_iov);
@@ -461,7 +461,7 @@ ktr_rec_fetch(struct btr_instance *tins, struct btr_record *rec,
 
 static int
 ktr_rec_update(struct btr_instance *tins, struct btr_record *rec,
-	       daos_iov_t *key_iov, daos_iov_t *val_iov)
+	       d_iov_t *key_iov, d_iov_t *val_iov)
 {
 	struct vos_rec_bundle	*rbund = iov2rec_bundle(val_iov);
 
@@ -605,7 +605,7 @@ svt_rec_msize(int alloc_overhead)
 
 /** generate hkey */
 static void
-svt_hkey_gen(struct btr_instance *tins, daos_iov_t *key_iov, void *hkey)
+svt_hkey_gen(struct btr_instance *tins, d_iov_t *key_iov, void *hkey)
 {
 	struct svt_hkey		*skey = (struct svt_hkey *)hkey;
 	struct vos_key_bundle	*kbund;
@@ -632,8 +632,8 @@ svt_hkey_cmp(struct btr_instance *tins, struct btr_record *rec, void *hkey)
 
 /** allocate a new record and fetch data */
 static int
-svt_rec_alloc(struct btr_instance *tins, daos_iov_t *key_iov,
-	       daos_iov_t *val_iov, struct btr_record *rec)
+svt_rec_alloc(struct btr_instance *tins, d_iov_t *key_iov,
+	       d_iov_t *val_iov, struct btr_record *rec)
 {
 	struct vos_rec_bundle	*rbund;
 	struct vos_key_bundle	*kbund;
@@ -706,7 +706,7 @@ svt_rec_free(struct btr_instance *tins, struct btr_record *rec,
 
 static int
 svt_rec_fetch(struct btr_instance *tins, struct btr_record *rec,
-	       daos_iov_t *key_iov, daos_iov_t *val_iov)
+	       d_iov_t *key_iov, d_iov_t *val_iov)
 {
 	struct vos_key_bundle	*kbund = NULL;
 	struct vos_rec_bundle	*rbund;
@@ -721,7 +721,7 @@ svt_rec_fetch(struct btr_instance *tins, struct btr_record *rec,
 
 static int
 svt_rec_update(struct btr_instance *tins, struct btr_record *rec,
-		daos_iov_t *key_iov, daos_iov_t *val_iov)
+		d_iov_t *key_iov, d_iov_t *val_iov)
 {
 	struct svt_hkey		*skey;
 	struct vos_key_bundle	*kbund;
@@ -915,8 +915,8 @@ key_tree_prepare(struct vos_object *obj, daos_epoch_t epoch,
 	daos_csum_buf_t		 csum;
 	struct vos_key_bundle	 kbund;
 	struct vos_rec_bundle	 rbund;
-	daos_iov_t		 kiov;
-	daos_iov_t		 riov;
+	d_iov_t		 kiov;
+	d_iov_t		 riov;
 	int			 rc;
 
 	if (krecp != NULL)
@@ -1004,8 +1004,8 @@ key_tree_release(daos_handle_t toh, bool is_array)
  * Punch a key in its parent tree.
  */
 int
-key_tree_punch(struct vos_object *obj, daos_handle_t toh, daos_iov_t *key_iov,
-	       daos_iov_t *val_iov, int flags)
+key_tree_punch(struct vos_object *obj, daos_handle_t toh, d_iov_t *key_iov,
+	       d_iov_t *val_iov, int flags)
 {
 	struct vos_key_bundle	*kbund;
 	struct vos_rec_bundle	*rbund;
@@ -1059,7 +1059,7 @@ key_tree_punch(struct vos_object *obj, daos_handle_t toh, daos_iov_t *key_iov,
 		struct umem_instance	*umm = vos_obj2umm(obj);
 		struct vos_krec_df	*krec2;
 		struct vos_key_bundle	 kbund2;
-		daos_iov_t	         tmp;
+		d_iov_t	         tmp;
 
 		krec2 = rbund->rb_krec;
 		if (krec->kr_bmap & KREC_BF_BTR) {


### PR DESCRIPTION
1) remove daos_sg_list_t/daos_sg_list_free/daos2crt_sg, directly
   use d_sg_list_t.
2) remove daos_iov_t/daos_iov_set, directly use d_iov_t/d_iov_set

Signed-off-by: Xuezhao Liu <xuezhao.liu@intel.com>