### PR TITLE
DAOS-623 build: Fix duplicate specification in scons build

### DIFF
--- a/src/security/tests/SConscript
+++ b/src/security/tests/SConscript
@@ -5,15 +5,16 @@ def scons():
     """Execute build"""
     Import('denv', 'dc_security_tgts')
 
+    mocks = denv.Object('drpc_mocks.c')
     # Isolated unit tests
     daos_build.test(denv, 'cli_security_tests',
                     source=['cli_security_tests.c', dc_security_tgts,
-                            'drpc_mocks.c'],
+                            mocks],
                     LIBS=['cmocka', 'protobuf-c', 'daos_common', 'gurt'])
 
     daos_build.test(denv, 'srv_acl_tests',
                     source=['srv_acl_tests.c', '../srv_acl.c',
-                            '../security.pb-c.c', 'drpc_mocks.c'],
+                            '../security.pb-c.c', mocks],
                     LIBS=['cmocka', 'protobuf-c', 'daos_common', 'gurt'])
 
 if __name__ == "SCons.Script":


### PR DESCRIPTION
drpc_mocks.c is configured to be built twice in current build
producing a scons warning.