### PR TITLE
DAOS-1093 tests: use cmocka workaround when needed

### DIFF
--- a/src/tests/suite/SConscript
+++ b/src/tests/suite/SConscript
@@ -18,7 +18,42 @@ def scons():
     daos_test_obj = denv.SharedObject(['daos_obj.c'])
     Export('daos_test_obj')
 
-    test = daos_build.program(denv, 'daos_test', Glob('*.c'), LIBS=libraries)
+    newenv = denv.Clone()
+    try:
+        import os
+        with open('/etc/os-release') as f:
+            for line in f:
+                if 'ID' in line:
+                    line = line.strip()
+                    id, distro = line.strip().split('=')
+                    break
+        if distro in ['"centos"', '"rhel"', '"fedora"']:
+            import rpm
+            ts = rpm.TransactionSet()
+            headers = ts.dbMatch('name', 'libcmocka')
+            if not headers:
+                print "No package libcmocka found."
+            else:
+                from pkg_resources import parse_version
+                for h in headers:
+                    if parse_version(h['version']) < parse_version('1.1.5'):
+                        newenv.AppendUnique(CCFLAGS=['-DOVERRIDE_CMOCKA_SKIP'])
+        elif distro in ('"debian"', '"ubuntu"'):
+            import apt
+            cache = apt.Cache()
+            cache.open()
+            instver = cache["libcmocka"].installed
+            if instver:
+                if parse_version(instver.version) < parse_version('1.1.5'):
+                    newenv.AppendUnique(CCFLAGS=['-DOVERRIDE_CMOCKA_SKIP'])
+            else:
+                print "No package libcmocka found."
+        else:
+            print "Unable to identify distro."
+    except ImportError:
+        pass
+
+    test = daos_build.program(newenv, 'daos_test', Glob('*.c'), LIBS=libraries)
     denv.Install('$PREFIX/bin/', test)
     denv.Install('$PREFIX/bin/io_conf', Glob('io_conf/daos_io_conf_1'))
     denv.Install('$PREFIX/bin/io_conf', Glob('io_conf/daos_io_conf_2'))

--- a/src/tests/suite/daos_test.h
+++ b/src/tests/suite/daos_test.h
@@ -46,6 +46,7 @@
 #include <dirent.h>
 
 #include <cmocka.h>
+#ifdef OVERRIDE_CMOCKA_SKIP
 /* redefine cmocka's skip() so it will no longer abort()
  * if CMOCKA_TEST_ABORT=1
  *
@@ -61,6 +62,7 @@
 			_skip(__FILE__, __LINE__); \
 		return; \
 	} while  (0)
+#endif
 
 #include <mpi.h>
 #include <daos/debug.h>


### PR DESCRIPTION
A workaround to a cmocka bug (in [_]skip()/exit_test() processing
when CMOCKA_TEST_ABORT=1, causing abort() upon any skipped test)
had been introduced in a previous patch
(Gerrit Change, https://review.hpdd.intel.com/32933).
Since a fix for this bug is available starting with
libcmocka-1.1.5, only apply workaround when needed.
As libcmocka do not provide a way/api to dynamicaly query its
version, this has to be implemented staticaly by checking
installed package version.

Signed-off-by: Bruno Faccini <bruno.faccini@intel.com>