### PR TITLE
DAOS-1899 object: replace epoch on server for fetch/update/punch

### DIFF
--- a/src/container/cli_tx.c
+++ b/src/container/cli_tx.c
@@ -152,10 +152,8 @@ dc_tx_check(daos_handle_t th, bool check_write, daos_epoch_t *epoch)
 {
 	struct dc_tx *tx = NULL;
 
-	if (daos_handle_is_inval(th)) {
-		*epoch = daos_ts2epoch();
-		return 0;
-	}
+	if (daos_handle_is_inval(th))
+		return -DER_INVAL;
 
 	tx = tx_hdl2ptr(th);
 	if (tx == NULL)

--- a/src/object/cli_obj.c
+++ b/src/object/cli_obj.c
@@ -1295,8 +1295,13 @@ dc_obj_fetch(tse_task_t *task)
 		D_GOTO(out_task, rc = -DER_INVAL);
 
 	rc = dc_tx_check(args->th, false, &epoch);
-	if (rc)
-		goto out_task;
+	if (rc) {
+		if (rc != -DER_INVAL)
+			goto out_task;
+		/* FIXME: until distributed transaction. */
+		epoch = DAOS_EPOCH_MAX; /* = daos_ts2epoch();*/
+		D_DEBUG(DB_IO, "set epoch "DF_U64"\n", epoch);
+	}
 	D_ASSERT(epoch);
 
 	obj = obj_hdl2ptr(args->oh);
@@ -1525,8 +1530,13 @@ dc_obj_update(tse_task_t *task)
 		D_GOTO(out_task, rc = -DER_INVAL);
 
 	rc = dc_tx_check(args->th, true, &epoch);
-	if (rc)
-		goto out_task;
+	if (rc) {
+		if (rc != -DER_INVAL)
+			goto out_task;
+		/* FIXME: until distributed transaction. */
+		epoch = DAOS_EPOCH_MAX; /* = daos_ts2epoch();*/
+		D_DEBUG(DB_IO, "set epoch "DF_U64"\n", epoch);
+	}
 	D_ASSERT(epoch);
 
 	obj = obj_hdl2ptr(args->oh);
@@ -1665,8 +1675,13 @@ dc_obj_list_internal(daos_handle_t oh, uint32_t op, daos_handle_t th,
 	}
 
 	rc = dc_tx_check(th, false, &epoch);
-	if (rc)
-		goto out_task;
+	if (rc) {
+		if (rc != -DER_INVAL)
+			goto out_task;
+		/* FIXME: until distributed transaction. */
+		epoch = DAOS_EPOCH_MAX; /* = daos_ts2epoch();*/
+		D_DEBUG(DB_IO, "set epoch "DF_U64"\n", epoch);
+	}
 	D_ASSERT(epoch);
 
 	obj = obj_hdl2ptr(oh);
@@ -1879,8 +1894,13 @@ obj_punch_internal(tse_task_t *api_task, enum obj_rpc_opc opc,
 	int			 rc;
 
 	rc = dc_tx_check(api_args->th, true, &epoch);
-	if (rc)
-		goto out_task;
+	if (rc) {
+		if (rc != -DER_INVAL)
+			goto out_task;
+		/* FIXME: until distributed transaction. */
+		epoch = DAOS_EPOCH_MAX; /* = daos_ts2epoch();*/
+		D_DEBUG(DB_IO, "set epoch "DF_U64"\n", epoch);
+	}
 	D_ASSERT(epoch);
 
 	/** Register retry CB */
@@ -2192,8 +2212,12 @@ dc_obj_query_key(tse_task_t *api_task)
 		  "Task Argument OPC does not match DC OPC\n");
 
 	rc = dc_tx_check(api_args->th, false, &epoch);
-	if (rc)
-		goto out_task;
+	if (rc) {
+		if (rc != -DER_INVAL)
+			goto out_task;
+		epoch = daos_ts2epoch();
+		D_DEBUG(DB_IO, "set epoch "DF_U64"\n", epoch);
+	}
 	D_ASSERT(epoch);
 
 	obj = obj_hdl2ptr(api_args->oh);

--- a/src/object/cli_shard.c
+++ b/src/object/cli_shard.c
@@ -382,7 +382,7 @@ obj_shard_rw(struct dc_obj_shard *shard, enum obj_rpc_opc opc,
 		D_GOTO(out_pool, rc = (int)tgt_ep.ep_rank);
 
 	rc = obj_req_create(daos_task2ctx(task), &tgt_ep, opc, &req);
-	D_DEBUG(DB_TRACE, "rpc %p opc:%d "DF_UOID" %d %s rank:%d tag:%d eph"
+	D_DEBUG(DB_TRACE, "rpc %p opc:%d "DF_UOID" %d %s rank:%d tag:%d eph "
 		DF_U64"\n", req, opc, DP_UOID(shard->do_id), (int)dkey->iov_len,
 		(char *)dkey->iov_buf, tgt_ep.ep_rank, tgt_ep.ep_tag, epoch);
 	if (rc != 0)

--- a/src/object/srv_obj.c
+++ b/src/object/srv_obj.c
@@ -922,6 +922,12 @@ ds_obj_rw_handler(crt_rpc_t *rpc)
 		}
 	}
 
+	/* FIXME: until distributed transaction. */
+	if (orw->orw_epoch == DAOS_EPOCH_MAX) {
+		orw->orw_epoch = daos_ts2epoch();
+		D_DEBUG(DB_IO, "overwrite epoch "DF_U64"\n", orw->orw_epoch);
+	}
+
 	if (srv_enable_dtx && (!resend || dispatch)) {
 		/* XXX: In fact, we do not need to start the DTX for
 		 *	non-replicated object. But consider to handle
@@ -1471,6 +1477,7 @@ ds_obj_punch_handler(crt_rpc_t *rpc)
 	opi = crt_req_get(rpc);
 	D_ASSERT(opi != NULL);
 	dispatch = opi->opi_shard_tgts.ca_arrays != NULL;
+
 	tag = dss_get_module_info()->dmi_tgt_id;
 
 	rc = ds_check_container(opi->opi_co_hdl, opi->opi_co_uuid,
@@ -1535,6 +1542,12 @@ ds_obj_punch_handler(crt_rpc_t *rpc)
 			rc = 0;
 		else
 			D_GOTO(out, rc);
+	}
+
+	/* FIXME: until distributed transaction. */
+	if (opi->opi_epoch == DAOS_EPOCH_MAX) {
+		opi->opi_epoch = daos_ts2epoch();
+		D_DEBUG(DB_IO, "overwrite epoch "DF_U64"\n", opi->opi_epoch);
 	}
 
 	if (srv_enable_dtx && (!resend || dispatch)) {


### PR DESCRIPTION
For fetch/update/punch operations pass DAOS_EPOCH_MAX from client side
and replace it with server HLC until we have distributed transactions.