### PR TITLE
DAOS-2341 test: Fix an issue with go unit test

### DIFF
--- a/src/control/server/storage_nvme_test.go
+++ b/src/control/server/storage_nvme_test.go
@@ -99,7 +99,7 @@ func defaultMockSpdkNvme() NVME {
 // mock external interface implementations for spdk setup script
 type mockSpdkSetup struct{}
 
-func (m *mockSpdkSetup) prep(int, string) error { return nil }
+func (m *mockSpdkSetup) prep(int, string, string) error { return nil }
 func (m *mockSpdkSetup) reset() error           { return nil }
 
 // mockNvmeStorage factory


### PR DESCRIPTION
The SpdkSetup added another parameter but the Mock API
wasn't updated accordingly causing tests to fail