### PR TITLE
DAOS-1742 rdbt: Add membership change tests to RDBT

### DIFF
--- a/src/include/daos/common.h
+++ b/src/include/daos/common.h
@@ -321,7 +321,9 @@ daos_crt_network_error(int err)
 
 #define daos_rank_list_dup		d_rank_list_dup
 #define daos_rank_list_dup_sort_uniq	d_rank_list_dup_sort_uniq
+#define daos_rank_list_filter		d_rank_list_filter
 #define daos_rank_list_alloc		d_rank_list_alloc
+#define daos_rank_list_free		d_rank_list_free
 #define daos_rank_list_copy		d_rank_list_copy
 #define daos_rank_list_sort		d_rank_list_sort
 #define daos_rank_list_find		d_rank_list_find

--- a/src/include/daos_srv/rsvc.h
+++ b/src/include/daos_srv/rsvc.h
@@ -40,6 +40,7 @@
 enum ds_rsvc_class_id {
 	DS_RSVC_CLASS_MGMT,
 	DS_RSVC_CLASS_POOL,
+	DS_RSVC_CLASS_TEST,
 	DS_RSVC_CLASS_COUNT
 };
 

--- a/src/include/daos_srv/rsvc.h
+++ b/src/include/daos_srv/rsvc.h
@@ -142,6 +142,11 @@ int ds_rsvc_dist_start(enum ds_rsvc_class_id class, d_iov_t *id,
 		       bool create, bool bootstrap, size_t size);
 int ds_rsvc_dist_stop(enum ds_rsvc_class_id class, d_iov_t *id,
 		      const d_rank_list_t *ranks, bool destroy);
+int ds_rsvc_add_replicas(enum ds_rsvc_class_id class, d_iov_t *id,
+			 d_rank_list_t *ranks, size_t size,
+			 struct rsvc_hint *hint);
+int ds_rsvc_remove_replicas(enum ds_rsvc_class_id class, d_iov_t *id,
+			    d_rank_list_t *ranks, struct rsvc_hint *hint);
 int ds_rsvc_lookup(enum ds_rsvc_class_id class, d_iov_t *id,
 		   struct ds_rsvc **svc);
 int ds_rsvc_lookup_leader(enum ds_rsvc_class_id class, d_iov_t *id,

--- a/src/include/daos_types.h
+++ b/src/include/daos_types.h
@@ -54,12 +54,11 @@ typedef uint64_t	daos_size_t;
 typedef uint64_t	daos_off_t;
 
 /**
- * daos_sg_list_t/daos_iov_t/daos_rank_list_free/daos_iov_set is for keeping
- * compatibility for upper layer.
+ * daos_sg_list_t/daos_iov_t/daos_iov_set is for keeping compatibility for
+ * upper layer.
  */
 #define daos_sg_list_t			d_sg_list_t
 #define daos_iov_t			d_iov_t
-#define daos_rank_list_free(r)		d_rank_list_free((r))
 #define daos_iov_set(iov, buf, size)	d_iov_set((iov), (buf), (size))
 
 #define crt_proc_daos_key_t	crt_proc_d_iov_t

--- a/src/pool/srv_pool.c
+++ b/src/pool/srv_pool.c
@@ -1093,7 +1093,6 @@ static struct ds_rsvc_class pool_svc_rsvc_class = {
 	.sc_locate	= pool_svc_locate_cb,
 	.sc_alloc	= pool_svc_alloc_cb,
 	.sc_free	= pool_svc_free_cb,
-	.sc_bootstrap	= NULL,
 	.sc_step_up	= pool_svc_step_up_cb,
 	.sc_step_down	= pool_svc_step_down_cb,
 	.sc_drain	= pool_svc_drain_cb
@@ -2842,64 +2841,32 @@ ds_pool_replicas_update_handler(crt_rpc_t *rpc)
 {
 	struct pool_membership_in	*in = crt_req_get(rpc);
 	struct pool_membership_out	*out = crt_reply_get(rpc);
-	crt_opcode_t			 opc = opc_get(rpc->cr_opc);
-	struct pool_svc			*svc;
-	struct rdb			*db;
 	d_rank_list_t			*ranks;
-	uuid_t				 db_uuid;
-	uuid_t				 pool_uuid;
-	d_iov_t			 psid;
+	d_iov_t				 id;
 	int				 rc;
-
-	D_DEBUG(DB_MD, DF_UUID": Replica Rank: %u\n", DP_UUID(in->pmi_uuid),
-				 in->pmi_targets->rl_ranks[0]);
 
 	rc = daos_rank_list_dup(&ranks, in->pmi_targets);
 	if (rc != 0)
-		D_GOTO(out, rc);
+		goto out;
+	d_iov_set(&id, in->pmi_uuid, sizeof(uuid_t));
 
-	/*
-	 * Do this locally and release immediately; otherwise if we try to
-	 * remove the leader replica, the call never returns since the service
-	 * won't stop until all references have been released
-	 */
-	rc = pool_svc_lookup_leader(in->pmi_uuid, &svc, &out->pmo_hint);
-	if (rc != 0)
-		D_GOTO(out, rc);
-	/* TODO: Use rdb_get() to track references? */
-	db = svc->ps_rsvc.s_db;
-	rdb_get_uuid(db, db_uuid);
-	uuid_copy(pool_uuid, svc->ps_uuid);
-	pool_svc_put_leader(svc);
-	d_iov_set(&psid, pool_uuid, sizeof(uuid_t));
-
-	switch (opc) {
+	switch (opc_get(rpc->cr_opc)) {
 	case POOL_REPLICAS_ADD:
-		rc = ds_rsvc_dist_start(DS_RSVC_CLASS_POOL, &psid, db_uuid,
-					in->pmi_targets, true /* create */,
-					false /* bootstrap */,
-					ds_rsvc_get_md_cap());
-		if (rc != 0)
-			break;
-		rc = rdb_add_replicas(db, ranks);
+		rc = ds_rsvc_add_replicas(DS_RSVC_CLASS_POOL, &id, ranks,
+					  ds_rsvc_get_md_cap(), &out->pmo_hint);
 		break;
 
 	case POOL_REPLICAS_REMOVE:
-		rc = rdb_remove_replicas(db, ranks);
-		if (rc != 0)
-			break;
-		/* ignore return code */
-		ds_rsvc_dist_stop(DS_RSVC_CLASS_POOL, &psid, in->pmi_targets,
-				  true /*destroy*/);
+		rc = ds_rsvc_remove_replicas(DS_RSVC_CLASS_POOL, &id, ranks,
+					     &out->pmo_hint);
 		break;
 
 	default:
 		D_ASSERT(0);
 	}
 
-	ds_rsvc_set_hint(&svc->ps_rsvc, &out->pmo_hint);
-out:
 	out->pmo_failed = ranks;
+out:
 	out->pmo_rc = rc;
 	crt_reply_send(rpc);
 }

--- a/src/rdb/tests/rdb_test.c
+++ b/src/rdb/tests/rdb_test.c
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2017-2018 Intel Corporation.
+ * (C) Copyright 2017-2019 Intel Corporation.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,12 +24,17 @@
 
 #include <daos_srv/daos_server.h>	/* for dss_module */
 #include <daos_srv/rdb.h>
+#include <daos_srv/rsvc.h>
 #include "../rdb_internal.h"
 #include "rpc.h"
 
-static char	       *rdb_file_path;
-static uuid_t		rdb_uuid;
-static struct rdb      *rdb_db;
+#define DB_CAP	(1L << 25)
+
+static char		*test_svc_name = "rsvc_test";
+static daos_iov_t	 test_svc_id;
+static uuid_t		 test_db_uuid;
+
+#define ID_OK(id) ioveq((id), &test_svc_id)
 
 #define MUST(call)							\
 do {									\
@@ -53,6 +58,110 @@ ioveq(const d_iov_t *iov1, const d_iov_t *iov2)
 		  iov1->iov_len, iov2->iov_len);
 	D_ASSERT(memcmp(iov1->iov_buf, iov2->iov_buf, iov1->iov_len) == 0);
 }
+
+static int
+test_svc_name_cb(daos_iov_t *id, char **name)
+{
+	ID_OK(id);
+	D_STRNDUP(*name, test_svc_name, strlen(test_svc_name));
+	D_ASSERT(*name != NULL);
+	return 0;
+}
+
+static int
+test_svc_load_uuid_cb(daos_iov_t *id, uuid_t db_uuid)
+{
+	ID_OK(id);
+	uuid_copy(db_uuid, test_db_uuid);
+	return 0;
+}
+
+static int
+test_svc_store_uuid_cb(daos_iov_t *id, uuid_t db_uuid)
+{
+	ID_OK(id);
+	return 0;
+}
+
+static int
+test_svc_delete_uuid_cb(daos_iov_t *id)
+{
+	ID_OK(id);
+	return 0;
+}
+
+static int
+test_svc_locate_cb(daos_iov_t *id, char **path)
+{
+	char	uuid_string[DAOS_UUID_STR_SIZE];
+	int	rc;
+
+	ID_OK(id);
+	uuid_unparse_lower(test_db_uuid, uuid_string);
+	rc = asprintf(path, "%s/rdbt-%s", dss_storage_path, uuid_string);
+	D_ASSERTF(rc > 0, "%d\n", rc);
+	D_ASSERT(*path != NULL);
+	return 0;
+}
+
+static int
+test_svc_alloc_cb(daos_iov_t *id, struct ds_rsvc **svcp)
+{
+	ID_OK(id);
+	D_ALLOC_PTR(*svcp);
+	D_ASSERT(*svcp != NULL);
+	(*svcp)->s_id = test_svc_id;
+	return 0;
+}
+
+static void
+test_svc_free_cb(struct ds_rsvc *svc)
+{
+	D_ASSERT(svc != NULL);
+	D_FREE(svc);
+}
+
+static int
+test_svc_step_up_cb(struct ds_rsvc *svc)
+{
+	d_rank_t rank;
+	int	 rc;
+
+	rc = crt_group_rank(NULL, &rank);
+	D_ASSERTF(rc == 0, "%d\n", rc);
+	D_WARN("rank %u became leader of term "DF_U64"\n", rank, svc->s_term);
+	return 0;
+}
+
+static void
+test_svc_step_down_cb(struct ds_rsvc *svc)
+{
+	d_rank_t rank;
+	int	 rc;
+
+	rc = crt_group_rank(NULL, &rank);
+	D_ASSERTF(rc == 0, "%d\n", rc);
+	D_WARN("rank %u is no longer leader of term "DF_U64"\n", rank,
+	       svc->s_term);
+}
+
+static void
+test_svc_drain_cb(struct ds_rsvc *rsvc)
+{
+}
+
+static struct ds_rsvc_class test_svc_rsvc_class = {
+	.sc_name	= test_svc_name_cb,
+	.sc_load_uuid	= test_svc_load_uuid_cb,
+	.sc_store_uuid	= test_svc_store_uuid_cb,
+	.sc_delete_uuid	= test_svc_delete_uuid_cb,
+	.sc_locate	= test_svc_locate_cb,
+	.sc_alloc	= test_svc_alloc_cb,
+	.sc_free	= test_svc_free_cb,
+	.sc_step_up	= test_svc_step_up_cb,
+	.sc_step_down	= test_svc_step_down_cb,
+	.sc_drain	= test_svc_drain_cb
+};
 
 static void
 rdbt_test_util(void)
@@ -165,19 +274,6 @@ rdbt_test_path(void)
 	rdb_path_fini(&path);
 }
 
-static char *
-rdbt_path(uuid_t uuid)
-{
-	char   *path;
-	char	uuid_string[DAOS_UUID_STR_SIZE];
-	int	rc;
-
-	uuid_unparse_lower(uuid, uuid_string);
-	rc = asprintf(&path, "%s/rdbt-%s", dss_storage_path, uuid_string);
-	D_ASSERT(rc > 0 && path != NULL);
-	return path;
-}
-
 struct iterate_cb_arg {
 	uint64_t       *keys;
 	int		nkeys;
@@ -200,6 +296,8 @@ iterate_cb(daos_handle_t ih, d_iov_t *key, d_iov_t *val, void *varg)
 static void
 rdbt_test_tx(bool update)
 {
+	struct ds_rsvc	       *svc;
+	struct rsvc_hint	hint;
 	rdb_path_t		path;
 	d_iov_t		key;
 	d_iov_t		value;
@@ -214,24 +312,22 @@ rdbt_test_tx(bool update)
 	int			rc;
 
 	D_WARN("commit empty tx\n");
-	rc = rdb_tx_begin(rdb_db, RDB_NIL_TERM, &tx);
+	rc = ds_rsvc_lookup_leader(DS_RSVC_CLASS_TEST, &test_svc_id, &svc,
+				   &hint);
 	if (rc == -DER_NOTLEADER) {
-		uint64_t	term;
-		d_rank_t	rank;
-
-		rc = rdb_get_leader(rdb_db, &term, &rank);
-		if (rc == 0)
-			D_WARN("not leader; try rank %u\n", rank);
+		if (hint.sh_flags & RSVC_HINT_VALID)
+			D_WARN("not leader; try rank %u\n", hint.sh_rank);
 		else
 			D_WARN("not leader\n");
 		return;
 	}
+	MUST(rdb_tx_begin(svc->s_db, RDB_NIL_TERM, &tx));
 	MUST(rdb_tx_commit(&tx));
 	rdb_tx_end(&tx);
 
 	if (update) {
 		D_WARN("create KVSs and regular keys\n");
-		MUST(rdb_tx_begin(rdb_db, RDB_NIL_TERM, &tx));
+		MUST(rdb_tx_begin(svc->s_db, RDB_NIL_TERM, &tx));
 		/* Create the root KVS. */
 		MUST(rdb_path_init(&path));
 		MUST(rdb_path_push(&path, &rdb_path_root_key));
@@ -258,7 +354,7 @@ rdbt_test_tx(bool update)
 	}
 
 	D_WARN("query regular keys\n");
-	MUST(rdb_tx_begin(rdb_db, RDB_NIL_TERM, &tx));
+	MUST(rdb_tx_begin(svc->s_db, RDB_NIL_TERM, &tx));
 	MUST(rdb_path_init(&path));
 	/* Look up keys[0]. */
 	MUST(rdb_path_push(&path, &rdb_path_root_key));
@@ -295,7 +391,7 @@ rdbt_test_tx(bool update)
 
 	if (!update) {
 		D_WARN("destroy KVSs\n");
-		MUST(rdb_tx_begin(rdb_db, RDB_NIL_TERM, &tx));
+		MUST(rdb_tx_begin(svc->s_db, RDB_NIL_TERM, &tx));
 		MUST(rdb_path_init(&path));
 		MUST(rdb_path_push(&path, &rdb_path_root_key));
 		d_iov_set(&key, "kvs1", strlen("kvs1") + 1);
@@ -305,100 +401,66 @@ rdbt_test_tx(bool update)
 		MUST(rdb_tx_commit(&tx));
 		rdb_tx_end(&tx);
 	}
-}
 
-static int
-rdbt_module_init(void)
-{
-	return 0;
-}
-
-static int
-rdbt_module_fini(void)
-{
-	return 0;
-}
-
-static int
-rdbt_step_up(struct rdb *db, uint64_t term, void *arg)
-{
-	d_rank_t rank;
-
-	crt_group_rank(NULL, &rank);
-	D_WARN("rank %u became leader of term "DF_U64"\n", rank, term);
-	return 0;
+	ds_rsvc_put_leader(svc);
 }
 
 static void
-rdbt_step_down(struct rdb *db, uint64_t term, void *arg)
+get_all_ranks(d_rank_list_t **list)
 {
-	d_rank_t rank;
+	crt_group_t	*group;
+	d_rank_list_t	*ranks;
+	int		 i;
 
-	crt_group_rank(NULL, &rank);
-	D_WARN("rank %u is no longer leader of term "DF_U64"\n", rank, term);
+	group = crt_group_lookup(NULL /* grp_id */);
+	D_ASSERT(group != NULL);
+	MUST(crt_group_ranks_get(group, list));
+	if (*list != NULL)
+		return;
+	D_ALLOC_PTR(ranks);
+	D_ASSERT(ranks != NULL);
+	MUST(crt_group_size(group, &ranks->rl_nr));
+	D_ALLOC_ARRAY(ranks->rl_ranks, ranks->rl_nr);
+	D_ASSERT(ranks->rl_ranks != NULL);
+	for (i = 0; i < ranks->rl_nr; ++i)
+		ranks->rl_ranks[i] = i;
+	*list = ranks;
 }
-
-static void
-rdbt_stop(struct rdb *db, int err, void *arg)
-{
-	d_rank_t rank;
-
-	crt_group_rank(NULL, &rank);
-	D_WARN("rank %u should stop\n", rank);
-	D_ASSERT(0);
-}
-
-static struct rdb_cbs rdbt_rdb_cbs = {
-	.dc_step_up	= rdbt_step_up,
-	.dc_step_down	= rdbt_step_down,
-	.dc_stop	= rdbt_stop
-};
 
 static void
 rdbt_init_handler(crt_rpc_t *rpc)
 {
-	struct rdbt_init_in    *in = crt_req_get(rpc);
-	d_rank_t		rank;
-	uint32_t		group_size;
-	d_rank_list_t	ranks;
-	int			i;
-	int			rc;
+	struct rdbt_init_in	*in = crt_req_get(rpc);
+	d_rank_t		 rank;
+	d_rank_list_t		*ranks;
 
-	crt_group_rank(NULL /* grp */, &rank);
-	crt_group_size(NULL /* grp */, &group_size);
+	uuid_copy(test_db_uuid, in->tii_uuid);
+	MUST(crt_group_rank(NULL /* grp */, &rank));
+	get_all_ranks(&ranks);
+	D_ASSERT(ranks != NULL);
+	if (in->tii_nreplicas < ranks->rl_nr)
+		ranks->rl_nr = in->tii_nreplicas;
 
-	/* Build the rank list. */
-	ranks.rl_nr = in->tii_nreplicas;
-	if (ranks.rl_nr > group_size)
-		ranks.rl_nr = group_size;
-	D_ALLOC_ARRAY(ranks.rl_ranks, ranks.rl_nr);
-	if (ranks.rl_ranks == NULL) {
-		D_ERROR("failed to allocate ranks array\n");
-		D_GOTO(out, rc = -DER_NOMEM);
-	}
-	for (i = 0; i < ranks.rl_nr; i++)
-		ranks.rl_ranks[i] = i;
-
-	D_WARN("initializing rank %u: nreplicas=%u\n", rank, in->tii_nreplicas);
-	rdb_file_path = rdbt_path(in->tii_uuid);
-	uuid_copy(rdb_uuid, in->tii_uuid);
-	MUST(rdb_create(rdb_file_path, in->tii_uuid, 1 << 25, &ranks));
-	MUST(rdb_start(rdb_file_path, in->tii_uuid, &rdbt_rdb_cbs,
-		       NULL /* arg */, &rdb_db));
-out:
+	D_WARN("initializing rank %u: nreplicas=%u\n", rank, ranks->rl_nr);
+	MUST(ds_rsvc_dist_start(DS_RSVC_CLASS_TEST, &test_svc_id, test_db_uuid,
+				ranks, true /* create */, true /* bootstrap */,
+				DB_CAP));
 	crt_reply_send(rpc);
 }
 
 static void
 rdbt_fini_handler(crt_rpc_t *rpc)
 {
-	d_rank_t rank;
+	struct ds_rsvc	*svc;
+	d_rank_t	 rank;
+	d_rank_list_t	*ranks;
 
-	crt_group_rank(NULL /* grp */, &rank);
+	MUST(crt_group_rank(NULL /* grp */, &rank));
 	D_WARN("finalizing rank %u\n", rank);
-	rdb_stop(rdb_db);
-	MUST(rdb_destroy(rdb_file_path, rdb_uuid));
-	D_FREE(rdb_file_path);
+	MUST(ds_rsvc_lookup(DS_RSVC_CLASS_TEST, &test_svc_id, &svc));
+	MUST(rdb_get_ranks(svc->s_db, &ranks));
+	ds_rsvc_put(svc);
+	MUST(ds_rsvc_dist_stop(DS_RSVC_CLASS_TEST, &test_svc_id, ranks, true));
 	crt_reply_send(rpc);
 }
 
@@ -407,15 +469,28 @@ rdbt_test_handler(crt_rpc_t *rpc)
 {
 	struct rdbt_test_in    *in = crt_req_get(rpc);
 	d_rank_t		rank;
-	int			rc;
 
-	rc = crt_group_rank(NULL /* grp */, &rank);
-	D_ASSERTF(rc == 0, "%d\n", rc);
+	MUST(crt_group_rank(NULL /* grp */, &rank));
 	D_WARN("testing rank %u: update=%d\n", rank, in->tti_update);
 	rdbt_test_util();
 	rdbt_test_path();
 	rdbt_test_tx(in->tti_update);
 	crt_reply_send(rpc);
+}
+
+static int
+rdbt_module_init(void)
+{
+	daos_iov_set(&test_svc_id, test_svc_name, strlen(test_svc_name) + 1);
+	ds_rsvc_class_register(DS_RSVC_CLASS_TEST, &test_svc_rsvc_class);
+	return 0;
+}
+
+static int
+rdbt_module_fini(void)
+{
+	ds_rsvc_class_unregister(DS_RSVC_CLASS_TEST);
+	return 0;
 }
 
 /* Define for cont_rpcs[] array population below.

--- a/src/rdb/tests/rdb_test_runner.py
+++ b/src/rdb/tests/rdb_test_runner.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python
 
-# Copyright (c) 2018 Intel Corporation
+# Copyright (c) 2018-2019 Intel Corporation
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -32,7 +32,7 @@ This script runs the rdb tests. From the command line the tests are run with:
 server:
 orterun -N 1 --report-uri /tmp/urifile -x LD_LIBRARY_PATH
 daos_server -o <builddir>/utils/config/examples/daos_server_rdb_tests.yml
--d ./ -c 1 -m vos,rdb,rdbt
+-d ./ -t 1 -m vos,rdb,rsvc,rdbt
 
 client:
 orterun --ompi-server file:/tmp/urifile <debug_cmds> -np 1 rdbt init
@@ -105,7 +105,7 @@ def start_server(binfo):
     cmd += "-x LD_LIBRARY_PATH "
     cmd += binfo.get("PREFIX") + "/bin/daos_server "
     cmd += "-o {} ".format(config_file)
-    cmd += "-d ./ -c 1 -m vos,rdb,rdbt "
+    cmd += "-d ./ -t 1 -m vos,rdb,rsvc,rdbt "
     print("Running command:\n{}".format(cmd))
     sys.stdout.flush()
 


### PR DESCRIPTION
This patch make add/remove replica functionality part of the `rsvc` 
module so it may be shared by all replicated services, instead of being
specific to the `pool` module. This will also allow running functional
tests for `rsvc` and `rdb` without having to load the `pool` module.

Also converts `rdbt` module into a replicated service which allows
functional testing of `rsvc` features including membership changes.

Signed-off-by: Omkar Kulkarni <omkar.kulkarni@intel.com>