### PR TITLE
DAOS-2383 control: drop privileges before io_server start-up

### DIFF
--- a/src/control/server/config_types.go
+++ b/src/control/server/config_types.go
@@ -219,7 +219,6 @@ type configuration struct {
 	FaultPath      string          `yaml:"fault_path"`
 	FaultCb        string          `yaml:"fault_cb"`
 	FabricIfaces   []string        `yaml:"fabric_ifaces"`
-	FormatOverride bool            `yaml:"format_override"`
 	ScmMountPath   string          `yaml:"scm_mount_path"`
 	BdevInclude    []string        `yaml:"bdev_include"`
 	BdevExclude    []string        `yaml:"bdev_exclude"`
@@ -227,6 +226,8 @@ type configuration struct {
 	NrHugepages    int             `yaml:"nr_hugepages"`
 	ControlLogMask ControlLogLevel `yaml:"control_log_mask"`
 	ControlLogFile string          `yaml:"control_log_file"`
+	UserName       string          `yaml:"user_name"`
+	GroupName      string          `yaml:"group_name"`
 	// development (subject to change) config fields
 	Modules   string
 	Attach    string
@@ -270,7 +271,6 @@ func newDefaultConfiguration(ext External) configuration {
 		Port:           10000,
 		Cert:           "./.daos/daos_server.crt",
 		Key:            "./.daos/daos_server.key",
-		FormatOverride: true,
 		ScmMountPath:   "/mnt/daos",
 		Hyperthreads:   false,
 		NrHugepages:    1024,

--- a/src/control/server/external_mocks.go
+++ b/src/control/server/external_mocks.go
@@ -25,6 +25,7 @@ package main
 
 import (
 	"fmt"
+	"os/user"
 
 	"github.com/pkg/errors"
 )
@@ -101,6 +102,22 @@ func (m *mockExt) remove(path string) error {
 
 func (m *mockExt) exists(string) (bool, error) {
 	return m.existsRet, nil
+}
+
+func (m *mockExt) lookupUser(name string) (*user.User, error) {
+	return &user.User{}, nil
+}
+
+func (m *mockExt) lookupGroup(name string) (*user.Group, error) {
+	return &user.Group{}, nil
+}
+
+func (m *mockExt) setUid(uid int64) error {
+	return nil
+}
+
+func (m *mockExt) setGid(gid int64) error {
+	return nil
 }
 
 func newMockExt(

--- a/src/control/server/mgmt_storage.go
+++ b/src/control/server/mgmt_storage.go
@@ -106,12 +106,6 @@ func (c *controlService) FormatStorage(
 
 	resp := new(pb.FormatStorageResp)
 
-	if c.config.FormatOverride {
-		return errors.New(
-			"FormatStorage call unsupported when " +
-				"format_override == true in server config file")
-	}
-
 	for i := range c.config.Servers {
 		if err := c.doFormat(i, resp); err != nil {
 			return errors.WithMessage(err, "formatting storage")

--- a/src/control/server/mgmt_storage_test.go
+++ b/src/control/server/mgmt_storage_test.go
@@ -356,8 +356,6 @@ func TestFormatStorage(t *testing.T) {
 			tt.sMount, tt.sClass, tt.sDevs, tt.sSize,
 			tt.bClass, tt.bDevs, tt.superblockExists)
 
-		config.FormatOverride = false
-
 		cs := mockControlService(config)
 		cs.Setup() // init and increment WaitGroup countera
 

--- a/src/control/server/testdata/expect_daos_server.yml
+++ b/src/control/server/testdata/expect_daos_server.yml
@@ -11,7 +11,6 @@ key: ./.daos/daos_server.key
 fault_path: ""
 fault_cb: ""
 fabric_ifaces: []
-format_override: true
 scm_mount_path: /mnt/daos
 bdev_include: []
 bdev_exclude: []
@@ -19,6 +18,8 @@ hyperthreads: false
 nr_hugepages: 1024
 control_log_mask: DEBUG
 control_log_file: ""
+user_name: ""
+group_name: ""
 modules: ""
 attach: ""
 systemmap: ""

--- a/src/control/server/testdata/expect_daos_server_psm2.yml
+++ b/src/control/server/testdata/expect_daos_server_psm2.yml
@@ -35,7 +35,6 @@ key: ./.daos/daos_server.key
 fault_path: ""
 fault_cb: ""
 fabric_ifaces: []
-format_override: true
 scm_mount_path: /mnt/daos
 bdev_include: []
 bdev_exclude: []
@@ -43,6 +42,8 @@ hyperthreads: false
 nr_hugepages: 4096
 control_log_mask: DEBUG
 control_log_file: /tmp/daos_control.log
+user_name: ""
+group_name: ""
 modules: ""
 attach: ""
 systemmap: ""

--- a/src/control/server/testdata/expect_daos_server_sockets.yml
+++ b/src/control/server/testdata/expect_daos_server_sockets.yml
@@ -36,7 +36,6 @@ key: ./.daos/daos_server.key
 fault_path: ""
 fault_cb: ""
 fabric_ifaces: []
-format_override: true
 scm_mount_path: /mnt/daos
 bdev_include: []
 bdev_exclude: []
@@ -44,6 +43,8 @@ hyperthreads: false
 nr_hugepages: 4096
 control_log_mask: DEBUG
 control_log_file: /tmp/daos_control.log
+user_name: ""
+group_name: ""
 modules: ""
 attach: ""
 systemmap: ""

--- a/src/control/server/testdata/expect_daos_server_uncomment.yml
+++ b/src/control/server/testdata/expect_daos_server_uncomment.yml
@@ -59,7 +59,6 @@ fault_cb: ./.daos/fd_callback
 fabric_ifaces:
 - qib0
 - qib1
-format_override: false
 scm_mount_path: /mnt/daosa
 bdev_include:
 - 0000:81:00.1
@@ -71,6 +70,8 @@ hyperthreads: true
 nr_hugepages: 4096
 control_log_mask: ERROR
 control_log_file: /tmp/daos_control.log
+user_name: daosuser
+group_name: daosgroup
 modules: ""
 attach: ""
 systemmap: ""

--- a/src/control/server/testdata/output_success.txt
+++ b/src/control/server/testdata/output_success.txt
@@ -11,7 +11,6 @@ key: ./.daos/daos_server.key
 fault_path: ""
 fault_cb: ""
 fabric_ifaces: []
-format_override: true
 scm_mount_path: /mnt/daos
 bdev_include: []
 bdev_exclude: []
@@ -30,7 +29,6 @@ key: ./.daos/daos_server.key
 fault_path: ""
 fault_cb: ""
 fabric_ifaces: []
-format_override: true
 scm_mount_path: /mnt/daos
 bdev_include: []
 bdev_exclude: []
@@ -52,7 +50,6 @@ fault_cb: /tmp/daos_fault_cb.sh
 fabric_ifaces:
 - ib0
 - ib1
-format_override: true
 scm_mount_path: /tmp/daos
 bdev_include:
 - pcie1000.0.0.0.8

--- a/utils/config/daos_server.yml
+++ b/utils/config/daos_server.yml
@@ -174,6 +174,21 @@
 #format_override: false
 #
 #
+## Username used to lookup user uid/gid to drop privileges to if started
+## as root. After control plane start-up and configuration, before starting
+## data plane, process ownership will be dropped to those of supplied user.
+#
+#user_name: daosuser
+#
+#
+## Group name used to lookup group gid to drop privileges to when user_name
+## is root. If user is a member of group, this group gid is set for the running
+## process. If group look up fails or user is not member, use uid return from
+## user lookup.
+#
+#group_name: daosgroup
+#
+#
 ## When per-server definitions exist, auto-allocation of resources is not
 ## performed. Without per-server definitions, node resources will
 ## automatically be assigned to servers based on NUMA ratings, there will


### PR DESCRIPTION
daos_server requires start-up in root/privileged mode to perform
tasks such as format. After control plane setup and configurations
tasks and before forking io_server, drop privileges by changing
effective uid/gid to that of the user provided in config file.
io_server will then be launched by normal user.

Signed-off-by: Tom Nabarro <tom.nabarro@intel.com>