### PR TITLE
DAOS-2379 iosrv: cleanup IO stack for EC

### DIFF
--- a/src/include/daos/object.h
+++ b/src/include/daos/object.h
@@ -69,6 +69,15 @@ struct daos_obj_layout {
 	struct daos_obj_shard	*ol_shards[0];
 };
 
+#define TGTS_IGNORE		((d_rank_t)-1)
+/** to identify each obj shard's target */
+struct daos_shard_tgt {
+	uint32_t		st_rank;	/* rank of the shard */
+	uint32_t		st_shard;	/* shard index */
+	uint32_t		st_tgt_idx;	/* target xstream index */
+	uint32_t		st_tgt_id;	/* target id */
+};
+
 static inline bool
 daos_obj_id_equal(daos_obj_id_t oid1, daos_obj_id_t oid2)
 {

--- a/src/object/SConscript
+++ b/src/object/SConscript
@@ -14,12 +14,13 @@ def scons():
 
     # generate server module
     srv = daos_build.library(denv, 'obj',
-                             common_tgts + ['srv_obj.c', 'srv_mod.c'])
+                             common_tgts + ['srv_obj.c', 'srv_mod.c',
+                                            'srv_obj_remote.c'])
     denv.Install('$PREFIX/lib/daos_srv', srv)
 
     # Object client library
     dc_obj_tgts = denv.SharedObject(['cli_obj.c', 'cli_shard.c', 'cli_mod.c',
-				     'cli_ec.c'])
+                                     'cli_ec.c'])
     dc_obj_tgts += common_tgts
     Export('dc_obj_tgts')
 

--- a/src/object/cli_shard.c
+++ b/src/object/cli_shard.c
@@ -269,7 +269,7 @@ obj_shard_ptr2pool(struct dc_obj_shard *shard)
 
 int
 dc_obj_shard_rw(struct dc_obj_shard *shard, enum obj_rpc_opc opc,
-		void *shard_args, struct daos_obj_shard_tgt *fw_shard_tgts,
+		void *shard_args, struct daos_shard_tgt *fw_shard_tgts,
 		uint32_t fw_cnt, tse_task_t *task)
 {
 	struct shard_rw_args	*args = shard_args;
@@ -447,7 +447,7 @@ obj_shard_punch_cb(tse_task_t *task, void *data)
 
 int
 dc_obj_shard_punch(struct dc_obj_shard *shard, enum obj_rpc_opc opc,
-		   void *shard_args, struct daos_obj_shard_tgt *fw_shard_tgts,
+		   void *shard_args, struct daos_shard_tgt *fw_shard_tgts,
 		   uint32_t fw_cnt, tse_task_t *task)
 {
 	struct shard_punch_args		*args = shard_args;

--- a/src/object/obj_internal.h
+++ b/src/object/obj_internal.h
@@ -37,6 +37,7 @@
 #include <daos/btree_class.h>
 #include <daos/dtx.h>
 #include <daos_srv/daos_server.h>
+#include <daos_srv/dtx_srv.h>
 #include <daos_types.h>
 
 #include "obj_rpc.h"
@@ -143,7 +144,7 @@ enum obj_profile_op {
 	OBJ_PF_UPDATE_END,
 	OBJ_PF_UPDATE_WAIT,
 	OBJ_PF_UPDATE_REPLY,
-	OBJ_PF_UPDATE
+	OBJ_PF_UPDATE,
 };
 
 struct obj_tls {
@@ -164,7 +165,7 @@ obj_tls_get()
 
 typedef int (*shard_io_cb_t)(struct dc_obj_shard *shard, enum obj_rpc_opc opc,
 			     void *shard_args,
-			     struct daos_obj_shard_tgt *fw_shard_tgts,
+			     struct daos_shard_tgt *fw_shard_tgts,
 			     uint32_t fw_cnt, tse_task_t *task);
 
 /* shard update/punch auxiliary args, must be the first field of
@@ -213,7 +214,7 @@ int dc_obj_shard_open(struct dc_object *obj, daos_unit_oid_t id,
 void dc_obj_shard_close(struct dc_obj_shard *shard);
 
 int dc_obj_shard_rw(struct dc_obj_shard *shard, enum obj_rpc_opc opc,
-		    void *shard_args, struct daos_obj_shard_tgt *fw_shard_tgts,
+		    void *shard_args, struct daos_shard_tgt *fw_shard_tgts,
 		    uint32_t fw_cnt, tse_task_t *task);
 
 int
@@ -222,7 +223,7 @@ ec_obj_update_encode(tse_task_t *task, daos_obj_id_t oid,
 
 int dc_obj_shard_punch(struct dc_obj_shard *shard, enum obj_rpc_opc opc,
 		       void *shard_args,
-		       struct daos_obj_shard_tgt *fw_shard_tgts,
+		       struct daos_shard_tgt *fw_shard_tgts,
 		       uint32_t fw_cnt, tse_task_t *task);
 
 int
@@ -254,24 +255,29 @@ void obj_addref(struct dc_object *obj);
 void obj_decref(struct dc_object *obj);
 int obj_get_grp_size(struct dc_object *obj);
 
+struct ds_obj_exec_arg {
+	crt_rpc_t		*rpc;
+	struct ds_cont_hdl	*cont_hdl;
+	struct ds_cont_child	*cont;
+	uint32_t		flags;
+};
+
+int
+ds_obj_remote_update(struct dtx_handle *dth, void *arg, int idx,
+		     dtx_exec_shard_comp_cb_t comp_cb, void *cb_arg);
+int
+ds_obj_remote_punch(struct dtx_handle *dth, void *arg, int idx,
+		    dtx_exec_shard_comp_cb_t comp_cb, void *cb_arg);
 /* srv_obj.c */
 void ds_obj_rw_handler(crt_rpc_t *rpc);
+void ds_obj_tgt_update_handler(crt_rpc_t *rpc);
 void ds_obj_enum_handler(crt_rpc_t *rpc);
 void ds_obj_punch_handler(crt_rpc_t *rpc);
+void ds_obj_tgt_punch_handler(crt_rpc_t *rpc);
 void ds_obj_query_key_handler(crt_rpc_t *rpc);
-#define OBJ_TGTS_IGNORE		((d_rank_t)-1)
 ABT_pool
 ds_obj_abt_pool_choose_cb(crt_rpc_t *rpc, ABT_pool *pools);
 typedef int (*ds_iofw_cb_t)(crt_rpc_t *req, void *arg);
-struct obj_req_disp_arg;
-int ds_obj_req_disp_prepare(crt_opcode_t opc,
-			struct daos_obj_shard_tgt *fw_shard_tgts,
-			uint32_t fw_cnt, ds_iofw_cb_t prefw_cb,
-			ds_iofw_cb_t postfw_cb, void *cb_data,
-			uint32_t flags, int dti_cos_count,
-			struct dtx_id *dti_cos, struct obj_req_disp_arg **arg);
-void ds_obj_req_dispatch(void *arg);
-void ds_obj_req_disp_arg_free(struct obj_req_disp_arg *obj_arg);
 
 static inline uint64_t
 obj_dkey2hash(daos_key_t *dkey)

--- a/src/object/obj_rpc.h
+++ b/src/object/obj_rpc.h
@@ -83,7 +83,19 @@
 		ds_obj_punch_handler, NULL),				\
 	X(DAOS_OBJ_RPC_QUERY_KEY,					\
 		0, &CQF_obj_query_key,					\
-		ds_obj_query_key_handler, NULL)
+		ds_obj_query_key_handler, NULL),			\
+	X(DAOS_OBJ_RPC_TGT_UPDATE,					\
+		0, &CQF_obj_update,					\
+		ds_obj_tgt_update_handler, NULL),			\
+	X(DAOS_OBJ_RPC_TGT_PUNCH,					\
+		0, &CQF_obj_punch,					\
+		ds_obj_tgt_punch_handler, NULL),			\
+	X(DAOS_OBJ_RPC_TGT_PUNCH_DKEYS,					\
+		0, &CQF_obj_punch,					\
+		ds_obj_tgt_punch_handler, NULL),			\
+	X(DAOS_OBJ_RPC_TGT_PUNCH_AKEYS,					\
+		0, &CQF_obj_punch,					\
+		ds_obj_tgt_punch_handler, NULL)
 
 /* Define for RPC enum population below */
 #define X(a, b, c, d, e) a
@@ -102,18 +114,8 @@ enum obj_rpc_flags {
 	ORF_BULK_BIND		= (1 << 0),
 	/** It is a resent RPC. */
 	ORF_RESEND		= (1 << 1),
-	/** The request is from leader server (replica). */
-	ORF_FROM_LEADER		= (1 << 2),
 	/** Disable DTX or not. */
 	ORF_DTX_DISABLED	= (1 << 3),
-};
-
-/** to identify each obj shard's target */
-struct daos_obj_shard_tgt {
-	uint32_t		st_rank;	/* rank of the shard */
-	uint32_t		st_shard;	/* shard index */
-	uint32_t		st_tgt_idx;	/* target xstream index */
-	uint32_t		st_tgt_id;	/* target id */
 };
 
 /* common for update/fetch */
@@ -134,7 +136,7 @@ struct daos_obj_shard_tgt {
 	((daos_iod_t)		(orw_iods)		CRT_ARRAY) \
 	((d_sg_list_t)	(orw_sgls)		CRT_ARRAY) \
 	((crt_bulk_t)		(orw_bulks)		CRT_ARRAY) \
-	((struct daos_obj_shard_tgt) (orw_shard_tgts)	CRT_ARRAY)
+	((struct daos_shard_tgt) (orw_shard_tgts)	CRT_ARRAY)
 
 #define DAOS_OSEQ_OBJ_RW	/* output fields */		 \
 	((int32_t)		(orw_ret)		CRT_VAR) \
@@ -199,7 +201,7 @@ CRT_RPC_DECLARE(obj_key_enum, DAOS_ISEQ_OBJ_KEY_ENUM, DAOS_OSEQ_OBJ_KEY_ENUM)
 	((struct dtx_id)	(opi_dti_cos)		CRT_ARRAY) \
 	((d_iov_t)		(opi_dkeys)		CRT_ARRAY) \
 	((d_iov_t)		(opi_akeys)		CRT_ARRAY) \
-	((struct daos_obj_shard_tgt) (opi_shard_tgts)	CRT_ARRAY)
+	((struct daos_shard_tgt) (opi_shard_tgts)	CRT_ARRAY)
 
 #define DAOS_OSEQ_OBJ_PUNCH	/* output fields */		 \
 	((int32_t)		(opo_ret)		CRT_VAR) \
@@ -253,5 +255,25 @@ int obj_reply_get_status(crt_rpc_t *rpc);
 void obj_reply_map_version_set(crt_rpc_t *rpc, uint32_t map_version);
 uint32_t obj_reply_map_version_get(crt_rpc_t *rpc);
 void obj_reply_dtx_conflict_set(crt_rpc_t *rpc, struct dtx_conflict_entry *dce);
+
+static inline bool
+obj_is_modification_opc(uint32_t opc)
+{
+	return opc == DAOS_OBJ_RPC_UPDATE || opc == DAOS_OBJ_RPC_TGT_UPDATE ||
+		opc == DAOS_OBJ_RPC_PUNCH || opc == DAOS_OBJ_RPC_TGT_PUNCH ||
+		opc == DAOS_OBJ_RPC_PUNCH_DKEYS ||
+		opc == DAOS_OBJ_RPC_TGT_PUNCH_DKEYS ||
+		opc == DAOS_OBJ_RPC_PUNCH_AKEYS ||
+		opc == DAOS_OBJ_RPC_TGT_PUNCH_AKEYS;
+}
+
+static inline bool
+obj_is_tgt_modification_opc(uint32_t opc)
+{
+	return opc == DAOS_OBJ_RPC_TGT_UPDATE ||
+	       opc == DAOS_OBJ_RPC_TGT_PUNCH ||
+	       opc == DAOS_OBJ_RPC_TGT_PUNCH_DKEYS ||
+	       opc == DAOS_OBJ_RPC_TGT_PUNCH_AKEYS;
+}
 
 #endif /* __DAOS_OBJ_RPC_H__ */

--- a/src/object/srv_mod.c
+++ b/src/object/srv_mod.c
@@ -108,8 +108,10 @@ obj_tls_fini(const struct dss_thread_local_storage *dtls,
 
 char *profile_op_names[] = {
 	[OBJ_PF_UPDATE_PREP] = "update_prep",
+	[OBJ_PF_UPDATE_DISPATCH] = "update_dispatch",
 	[OBJ_PF_UPDATE_LOCAL] = "update_local",
 	[OBJ_PF_UPDATE_END] = "update_end",
+	[OBJ_PF_UPDATE_WAIT] = "update_end",
 	[OBJ_PF_UPDATE_REPLY] = "update_repl",
 	[OBJ_PF_UPDATE] = "update",
 };

--- a/src/object/srv_obj.c
+++ b/src/object/srv_obj.c
@@ -42,16 +42,12 @@
 #include "obj_rpc.h"
 #include "obj_internal.h"
 
-int ds_obj_req_disp_wait(struct obj_req_disp_arg *obj_arg,
-			 struct dtx_conflict_entry **dces);
-
 /**
  * After bulk finish, let's send reply, then release the resource.
  */
 static int
 ds_obj_rw_complete(crt_rpc_t *rpc, struct ds_cont_hdl *cont_hdl,
-		   daos_handle_t ioh, int status, uint32_t map_version,
-		   struct dtx_handle *dth)
+		   daos_handle_t ioh, int status, struct dtx_handle *dth)
 {
 	struct obj_tls		*tls = obj_tls_get();
 	struct obj_rw_in	*orwi = crt_req_get(rpc);
@@ -60,7 +56,9 @@ ds_obj_rw_complete(crt_rpc_t *rpc, struct ds_cont_hdl *cont_hdl,
 	D_TIME_START(tls->ot_sp, OBJ_PF_UPDATE_END);
 
 	if (!daos_handle_is_inval(ioh)) {
-		bool update = (opc_get(rpc->cr_opc) == DAOS_OBJ_RPC_UPDATE);
+		uint32_t map_version = cont_hdl->sch_pool->spc_map_version;
+		bool update = (opc_get(rpc->cr_opc) == DAOS_OBJ_RPC_UPDATE ||
+			       opc_get(rpc->cr_opc) == DAOS_OBJ_RPC_TGT_UPDATE);
 
 		rc = update ? vos_update_end(ioh, map_version, &orwi->orw_dkey,
 					     status, dth) :
@@ -104,7 +102,8 @@ ds_obj_rw_reply(crt_rpc_t *rpc, int status, uint32_t map_version,
 
 	obj_reply_set_status(rpc, status);
 	obj_reply_map_version_set(rpc, map_version);
-	if (opc_get(rpc->cr_opc) == DAOS_OBJ_RPC_UPDATE)
+	if (opc_get(rpc->cr_opc) == DAOS_OBJ_RPC_UPDATE ||
+	    opc_get(rpc->cr_opc) == DAOS_OBJ_RPC_TGT_UPDATE)
 		obj_reply_dtx_conflict_set(rpc, dce);
 
 	D_DEBUG(DB_TRACE, "rpc %p opc %d send reply, ver %d, status %d.\n",
@@ -459,7 +458,8 @@ ds_obj_update_nrs_in_reply(crt_rpc_t *rpc, daos_handle_t ioh,
  */
 static int
 ds_check_container(uuid_t pool_uuid, uuid_t cont_hdl_uuid, uuid_t cont_uuid,
-		   struct ds_cont_hdl **hdlp, struct ds_cont_child **contp)
+		   int opc, struct ds_cont_hdl **hdlp,
+		   struct ds_cont_child **contp)
 {
 	struct ds_cont_hdl	*cont_hdl;
 	int			 rc;
@@ -470,7 +470,16 @@ ds_check_container(uuid_t pool_uuid, uuid_t cont_hdl_uuid, uuid_t cont_uuid,
 		D_GOTO(out, rc);
 	}
 
+	if (obj_is_modification_opc(opc) &&
+	    !(cont_hdl->sch_capas & DAOS_COO_RW)) {
+		D_ERROR("cont "DF_UUID" hdl "DF_UUID" sch_capas "DF_U64", "
+			"NO_PERM to update.\n", DP_UUID(cont_uuid),
+			DP_UUID(cont_hdl_uuid), cont_hdl->sch_capas);
+		D_GOTO(out, rc = -DER_NO_PERM);
+	}
+
 	if (cont_hdl->sch_cont != NULL) { /* a regular container */
+		ds_cont_child_get(cont_hdl->sch_cont);
 		*contp = cont_hdl->sch_cont;
 		D_GOTO(out, rc = 0);
 	}
@@ -603,87 +612,19 @@ out:
 	orwo->orw_map_version = orw->orw_map_ver;
 }
 
-struct obj_req_disp_arg {
-	ds_iofw_cb_t			 prefw_cb;
-	ds_iofw_cb_t			 postfw_cb;
-	void				*cb_data;
-	ABT_future			 fw_future;
-	crt_opcode_t			 fw_opc;
-	uint32_t			 fw_cnt;
-	int				 fw_result;
-	uint32_t			 flags;
-	int				 dti_cos_count;
-	struct dtx_id			*dti_cos;
-};
-
-struct shard_req_fw_arg {
-	struct daos_obj_shard_tgt	*fw_shard_tgt;
-	struct obj_req_disp_arg		*fw_obj_arg;
-	struct dtx_conflict_entry	 fw_dce;
-	int				 fw_shard_rc;
-};
-
 static int
-obj_update_postfw(crt_rpc_t *req, void *arg)
-{
-	struct shard_req_fw_arg		*shard_arg = arg;
-	struct obj_req_disp_arg		*obj_arg = shard_arg->fw_obj_arg;
-	struct obj_rw_in		*orw_parent = obj_arg->cb_data;
-	struct obj_rw_out		*orw = crt_reply_get(req);
-	int				 rc;
-
-	if (orw_parent->orw_map_ver < orw->orw_map_version) {
-		D_DEBUG(DB_IO, DF_UOID": map_ver stale (%d < %d).\n",
-			DP_UOID(orw_parent->orw_oid), orw_parent->orw_map_ver,
-			orw->orw_map_version);
-		rc = -DER_STALE;
-	} else {
-		rc = orw->orw_ret;
-		if (rc == -DER_INPROGRESS) {
-			daos_dti_copy(&shard_arg->fw_dce.dce_xid,
-				      &orw->orw_dti_conflict);
-			shard_arg->fw_dce.dce_dkey = orw->orw_dkey_conflict;
-		}
-	}
-
-	return rc > 0 ? 0 : rc;
-}
-
-static int
-obj_update_prefw(crt_rpc_t *req, void *arg)
-{
-	struct shard_req_fw_arg		*shard_arg = arg;
-	struct obj_req_disp_arg		*obj_arg = shard_arg->fw_obj_arg;
-	struct obj_rw_in		*orw_parent = obj_arg->cb_data;
-	struct obj_rw_in		*orw = crt_req_get(req);
-
-	*orw = *orw_parent;
-	orw->orw_oid.id_shard = shard_arg->fw_shard_tgt->st_shard;
-	uuid_copy(orw->orw_co_hdl, orw_parent->orw_co_hdl);
-	uuid_copy(orw->orw_co_uuid, orw_parent->orw_co_uuid);
-	orw->orw_shard_tgts.ca_count	= 0;
-	orw->orw_shard_tgts.ca_arrays	= NULL;
-	orw->orw_flags			|= ORF_BULK_BIND | obj_arg->flags;
-	if (!srv_enable_dtx)
-		orw->orw_flags |= ORF_DTX_DISABLED;
-	orw->orw_dti_cos.ca_count	= obj_arg->dti_cos_count;
-	orw->orw_dti_cos.ca_arrays	= obj_arg->dti_cos;
-
-	return 0;
-}
-
-static int
-ds_obj_rw_local_hdlr(crt_rpc_t *rpc, uint32_t tag, struct ds_cont_hdl *cont_hdl,
-		     struct ds_cont_child *cont, daos_handle_t *ioh,
-		     bool update, uint32_t map_version, struct dtx_handle *dth)
+obj_local_rw(crt_rpc_t *rpc, struct ds_cont_hdl *cont_hdl,
+	     struct ds_cont_child *cont, struct dtx_handle *dth)
 {
 	struct obj_rw_in	*orw = crt_req_get(rpc);
 	struct obj_rw_out	*orwo = crt_reply_get(rpc);
+	uint32_t		tag = dss_get_module_info()->dmi_tgt_id;
+	daos_handle_t		ioh = DAOS_HDL_INVAL;
 	struct bio_desc		*biod;
-	crt_bulk_op_t		 bulk_op;
-	bool			 rma;
-	bool			 bulk_bind;
-	int			 rc, err;
+	crt_bulk_op_t		bulk_op;
+	bool			rma;
+	bool			bulk_bind;
+	int			rc, err;
 
 	if (daos_oc_echo_type(daos_obj_id2class(orw->orw_oid.id_pub)) ||
 	    (daos_io_bypass & IOBP_TARGET)) {
@@ -699,12 +640,13 @@ ds_obj_rw_local_hdlr(crt_rpc_t *rpc, uint32_t tag, struct ds_cont_hdl *cont_hdl,
 	       orw->orw_bulks.ca_count != 0);
 
 	/* Prepare IO descriptor */
-	if (update) {
+	if (opc_get(rpc->cr_opc) == DAOS_OBJ_RPC_UPDATE ||
+	    opc_get(rpc->cr_opc) == DAOS_OBJ_RPC_TGT_UPDATE) {
 		bulk_op = CRT_BULK_GET;
 		rc = vos_update_begin(cont->sc_hdl, orw->orw_oid,
 				      orw->orw_epoch, &orw->orw_dkey,
 				      orw->orw_nr, orw->orw_iods.ca_arrays,
-				      ioh, dth);
+				      &ioh, dth);
 		if (rc) {
 			D_ERROR(DF_UOID" Update begin failed: %d\n",
 				DP_UOID(orw->orw_oid), rc);
@@ -714,10 +656,9 @@ ds_obj_rw_local_hdlr(crt_rpc_t *rpc, uint32_t tag, struct ds_cont_hdl *cont_hdl,
 		bool size_fetch = (!rma && orw->orw_sgls.ca_arrays == NULL);
 
 		bulk_op = CRT_BULK_PUT;
-		rc = vos_fetch_begin(cont->sc_hdl, orw->orw_oid,
-				     orw->orw_epoch, &orw->orw_dkey,
-				     orw->orw_nr, orw->orw_iods.ca_arrays,
-				     size_fetch, ioh);
+		rc = vos_fetch_begin(cont->sc_hdl, orw->orw_oid, orw->orw_epoch,
+				     &orw->orw_dkey, orw->orw_nr,
+				     orw->orw_iods.ca_arrays, size_fetch, &ioh);
 		if (rc) {
 			D_ERROR(DF_UOID" Fetch begin failed: %d\n",
 				DP_UOID(orw->orw_oid), rc);
@@ -732,7 +673,7 @@ ds_obj_rw_local_hdlr(crt_rpc_t *rpc, uint32_t tag, struct ds_cont_hdl *cont_hdl,
 			orwo->orw_sgls.ca_count = 0;
 			orwo->orw_sgls.ca_arrays = NULL;
 
-			rc = ds_obj_update_nrs_in_reply(rpc, *ioh, NULL);
+			rc = ds_obj_update_nrs_in_reply(rpc, ioh, NULL);
 			if (rc != 0)
 				goto out;
 		} else {
@@ -741,7 +682,7 @@ ds_obj_rw_local_hdlr(crt_rpc_t *rpc, uint32_t tag, struct ds_cont_hdl *cont_hdl,
 		}
 	}
 
-	biod = vos_ioh2desc(*ioh);
+	biod = vos_ioh2desc(ioh);
 	rc = bio_iod_prep(biod);
 	if (rc) {
 		D_ERROR(DF_UOID" bio_iod_prep failed: %d.\n",
@@ -752,7 +693,7 @@ ds_obj_rw_local_hdlr(crt_rpc_t *rpc, uint32_t tag, struct ds_cont_hdl *cont_hdl,
 	if (rma) {
 		bulk_bind = orw->orw_flags & ORF_BULK_BIND;
 		rc = ds_bulk_transfer(rpc, bulk_op, bulk_bind,
-			orw->orw_bulks.ca_arrays, *ioh, NULL, orw->orw_nr);
+			orw->orw_bulks.ca_arrays, ioh, NULL, orw->orw_nr);
 	} else if (orw->orw_sgls.ca_arrays != NULL) {
 		rc = bio_iod_copy(biod, orw->orw_sgls.ca_arrays, orw->orw_nr);
 	}
@@ -766,14 +707,14 @@ ds_obj_rw_local_hdlr(crt_rpc_t *rpc, uint32_t tag, struct ds_cont_hdl *cont_hdl,
 	err = bio_iod_post(biod);
 	rc = rc ? : err;
 out:
-	rc = ds_obj_rw_complete(rpc, cont_hdl, *ioh, rc, map_version, dth);
+	rc = ds_obj_rw_complete(rpc, cont_hdl, ioh, rc, dth);
 	return rc;
 }
 
 static int
-ds_obj_check_dtx_config(uint32_t flags, struct dtx_id *dti)
+ds_obj_check_dtx_config(uint32_t opc, uint32_t flags, struct dtx_id *dti)
 {
-	if (flags & ORF_FROM_LEADER) {
+	if (obj_is_tgt_modification_opc(opc)) {
 		if (((flags & ORF_DTX_DISABLED) == 0) != srv_enable_dtx) {
 			D_ERROR("Inconsistent DTX configuration among "
 				"servers.\n");
@@ -790,78 +731,28 @@ ds_obj_check_dtx_config(uint32_t flags, struct dtx_id *dti)
 	return 0;
 }
 
-void
-ds_obj_rw_handler(crt_rpc_t *rpc)
+/* Various check before access VOS */
+static int
+ds_pre_check(daos_unit_oid_t oid, uint32_t rpc_map_ver, uuid_t pool_uuid,
+	     uuid_t hdl_uuid, uuid_t co_uuid, uint32_t opc, uint32_t flags,
+	     struct dtx_id *dti, struct ds_cont_hdl **hdlp,
+	     struct ds_cont_child **contp)
 {
-	struct obj_req_disp_arg		*obj_arg = NULL;
-	struct obj_rw_in		*orw = crt_req_get(rpc);
-	struct obj_rw_out		*orwo = crt_reply_get(rpc);
-	struct ds_cont_hdl		*cont_hdl = NULL;
-	struct ds_cont_child		*cont = NULL;
-	struct dtx_handle		*dth = NULL;
-	struct dtx_id			*dti_cos = NULL;
-	struct dtx_conflict_entry	 conflict = { 0 };
-	struct obj_tls			*tls = obj_tls_get();
-	daos_handle_t			 ioh = DAOS_HDL_INVAL;
-	uint32_t			 map_ver = 0;
-	uint32_t			 flags = 0;
-	int				 tag;
-	bool				 update;
-	bool				 dispatch;
-	bool				 resend = false;
-	int				 dti_cos_count = 0;
-	int				 rc;
-	int				 rc1;
+	uint32_t	map_ver;
+	int		rc;
 
-	D_ASSERT(orw != NULL);
-	D_ASSERT(orwo != NULL);
-	update = (opc_get(rpc->cr_opc) == DAOS_OBJ_RPC_UPDATE);
-	dispatch = update && orw->orw_shard_tgts.ca_arrays != NULL;
-	tag = dss_get_module_info()->dmi_tgt_id;
-
-	D_TIME_START(tls->ot_sp, OBJ_PF_UPDATE);
-	D_TIME_START(tls->ot_sp, OBJ_PF_UPDATE_PREP);
-
-	rc = ds_check_container(orw->orw_pool_uuid, orw->orw_co_hdl,
-				orw->orw_co_uuid, &cont_hdl, &cont);
+	*hdlp = NULL;
+	*contp = NULL;
+	rc = ds_check_container(pool_uuid, hdl_uuid, co_uuid, opc, hdlp, contp);
 	if (rc)
-		goto out;
+		return rc;
 
-	if (update && !(cont_hdl->sch_capas & DAOS_COO_RW)) {
-		D_ERROR("cont "DF_UUID" sch_capas "DF_U64", "
-			"NO_PERM to update.\n",
-			DP_UUID(orw->orw_co_uuid), cont_hdl->sch_capas);
-		D_GOTO(out, rc = -DER_NO_PERM);
-	}
+	D_ASSERT((*hdlp)->sch_pool != NULL);
+	map_ver = (*hdlp)->sch_pool->spc_map_version;
 
-	D_ASSERT(cont_hdl->sch_pool != NULL);
-	map_ver = cont_hdl->sch_pool->spc_map_version;
-
-	D_DEBUG(DB_TRACE, "rpc %p opc %d "DF_UOID" dkey %d %s tag/xs %d/%d eph "
-		DF_U64", pool ver %u/%u with "DF_DTI".\n",
-		rpc, opc_get(rpc->cr_opc), DP_UOID(orw->orw_oid),
-		(int)orw->orw_dkey.iov_len, (char *)orw->orw_dkey.iov_buf,
-		tag, dss_get_module_info()->dmi_xs_id, orw->orw_epoch,
-		orw->orw_map_ver, map_ver, DP_DTI(&orw->orw_dti));
-	if (map_ver < orw->orw_map_ver ||
-	    cont_hdl->sch_pool->spc_pool->sp_map == NULL ||
-	    DAOS_FAIL_CHECK(DAOS_FORCE_REFRESH_POOL_MAP)) {
-		D_DEBUG(DB_IO, "stale server map_version %d req %d\n",
-			map_ver, orw->orw_map_ver);
-		rc = ds_pool_child_map_refresh_async(cont_hdl->sch_pool);
-		if (rc)
-			D_GOTO(out, rc);
-		D_GOTO(out, rc = -DER_STALE);
-	}
-
-	if (orw->orw_map_ver < map_ver) {
-		D_DEBUG(DB_IO, "stale version req %d map_version %d\n",
-			orw->orw_map_ver, map_ver);
-		if (update)
-			D_GOTO(out, rc = -DER_STALE);
-
-		/* It is harmless if fetch with old pool map version. */
-	} else if (orw->orw_map_ver > map_ver) {
+	if (rpc_map_ver > map_ver ||
+	   (*hdlp)->sch_pool->spc_pool->sp_map == NULL ||
+	   DAOS_FAIL_CHECK(DAOS_FORCE_REFRESH_POOL_MAP)) {
 		/* XXX: Client (or leader replica) has newer pool map than
 		 *	current replica. Two possibile cases:
 		 *
@@ -883,185 +774,290 @@ ds_obj_rw_handler(crt_rpc_t *rpc)
 		 *	   this server during the client retry. It is
 		 *	   inefficient, but harmless.
 		 */
+		/*
+		 * Though maybe harmless for now, but let's refresh the server
+		 * pool map to avoid any possible issue
+		 */
+		D_DEBUG(DB_IO, "stale server map_version %d req %d\n",
+			map_ver, rpc_map_ver);
+		rc = ds_pool_child_map_refresh_async((*hdlp)->sch_pool);
+		D_GOTO(out_put, rc = rc ? : -DER_STALE);
+	} else if (rpc_map_ver < map_ver) {
+		D_DEBUG(DB_IO, "stale version req %d map_version %d\n",
+			rpc_map_ver, map_ver);
+		if (obj_is_modification_opc(opc))
+			D_GOTO(out_put, rc = -DER_STALE);
+		/* It is harmless if fetch with old pool map version. */
 	}
 
-	if (!update) {
-		D_TIME_END(tls->ot_sp, OBJ_PF_UPDATE_PREP);
-		D_TIME_START(tls->ot_sp, OBJ_PF_UPDATE_LOCAL);
-
-		rc = ds_obj_rw_local_hdlr(rpc, tag, cont_hdl, cont,
-					  &ioh, false, map_ver, dth);
+	/* Check DTX configuration. */
+	if (obj_is_modification_opc(opc) &&
+	    !daos_oc_echo_type(daos_obj_id2class(oid.id_pub))) {
+		rc = ds_obj_check_dtx_config(opc, flags, dti);
 		if (rc != 0)
-			D_ERROR(DF_UOID": rw_local_hdlr (fetch) failed %d.\n",
-				DP_UOID(orw->orw_oid), rc);
-
-		D_TIME_END(tls->ot_sp, OBJ_PF_UPDATE_LOCAL);
-
-		D_GOTO(out, rc);
+			D_GOTO(out_put, rc);
 	}
 
-	if (!daos_oc_echo_type(daos_obj_id2class(orw->orw_oid.id_pub))) {
-		/* Check DTX configuration. */
-		rc = ds_obj_check_dtx_config(orw->orw_flags, &orw->orw_dti);
-		if (rc != 0)
-			D_GOTO(out, rc);
-
-		/* Handle resend. */
-		if (srv_enable_dtx && orw->orw_flags & ORF_RESEND) {
-			rc = dtx_handle_resend(cont->sc_hdl, &orw->orw_oid,
-					       &orw->orw_dti,
-					       orw->orw_dkey_hash, false);
-			if (rc == -DER_ALREADY)
-				D_GOTO(out, rc = 0);
-			if (rc == 0)
-				resend = true;
-			else if (rc == -DER_NONEXIST)
-				rc = 0;
-			else
-				D_GOTO(out, rc);
+out_put:
+	if (rc) {
+		if (*contp != NULL) {
+			ds_cont_child_put(*contp);
+			*contp = NULL;
+		}
+		if (*hdlp != NULL) {
+			ds_cont_hdl_put(*hdlp);
+			*hdlp = NULL;
 		}
 	}
 
+	return rc;
+}
+
+void
+ds_obj_tgt_update_handler(crt_rpc_t *rpc)
+{
+	struct obj_rw_in		*orw = crt_req_get(rpc);
+	struct obj_rw_out		*orwo = crt_reply_get(rpc);
+	struct ds_cont_hdl		*cont_hdl = NULL;
+	struct ds_cont_child		*cont = NULL;
+	struct dtx_handle		*dth = NULL;
+	struct dtx_conflict_entry	 conflict = { 0 };
+	uint32_t			 map_ver = 0;
+	int				 rc;
+
+	D_ASSERT(orw != NULL);
+	D_ASSERT(orwo != NULL);
+
+	rc = ds_pre_check(orw->orw_oid, orw->orw_map_ver, orw->orw_pool_uuid,
+			  orw->orw_co_hdl, orw->orw_co_uuid,
+			  opc_get(rpc->cr_opc), orw->orw_flags, &orw->orw_dti,
+			  &cont_hdl, &cont);
+	if (rc)
+		goto out;
+
+	D_ASSERT(cont_hdl->sch_pool != NULL);
+	map_ver = cont_hdl->sch_pool->spc_map_version;
+
+	D_DEBUG(DB_TRACE, "rpc %p opc %d "DF_UOID" dkey %d %s tag/xs %d/%d eph "
+		DF_U64", pool ver %u/%u with "DF_DTI".\n",
+		rpc, opc_get(rpc->cr_opc), DP_UOID(orw->orw_oid),
+		(int)orw->orw_dkey.iov_len, (char *)orw->orw_dkey.iov_buf,
+		dss_get_module_info()->dmi_tgt_id,
+		dss_get_module_info()->dmi_xs_id, orw->orw_epoch,
+		orw->orw_map_ver, map_ver, DP_DTI(&orw->orw_dti));
+
+	/* Handle resend. */
+	if (orw->orw_flags & ORF_RESEND) {
+		rc = dtx_handle_resend(cont->sc_hdl, &orw->orw_oid,
+				       &orw->orw_dti,
+				       orw->orw_dkey_hash, false);
+		if (rc == -DER_ALREADY)
+			D_GOTO(out, rc = 0);
+	}
+
+	/**
+	 * XXX we should use different api for local dtx, will fix in the
+	 * following patch.
+	 **/
+	rc = dtx_begin(&orw->orw_dti, &orw->orw_oid, cont->sc_hdl,
+		       orw->orw_epoch, orw->orw_dkey_hash,
+		       &conflict, orw->orw_dti_cos.ca_arrays,
+		       orw->orw_dti_cos.ca_count, orw->orw_map_ver,
+		       DAOS_INTENT_UPDATE, false, &dth);
+	if (rc != 0) {
+		D_ERROR(DF_UOID": Failed to start DTX for update %d.\n",
+			DP_UOID(orw->orw_oid), rc);
+		D_GOTO(out, rc);
+	}
+
+	rc = obj_local_rw(rpc, cont_hdl, cont, dth);
+	if (rc != 0) {
+		D_ERROR(DF_UOID": rw_local (update) failed %d.\n",
+			DP_UOID(orw->orw_oid), rc);
+		D_GOTO(out, rc);
+	}
+
+	/**
+	 * XXX layer violation, it should be moved to DTX module, will
+	 * handle in following patches.
+	 */
+	if (orw->orw_dti_cos.ca_count > 0) {
+		/* XXX: For non-leader replica, even if we fail to
+		 *	make related modification for some reason,
+		 *	we still need to commit the DTXs for CoS.
+		 *	Because other replica may have already
+		 *	committed them. For leader case, it is
+		 *	not important even if we miss to commit
+		 *	the CoS DTXs, because they are still in
+		 *	CoS cache, and can be committed next time.
+		 */
+		rc = vos_dtx_commit(cont->sc_hdl,
+				    orw->orw_dti_cos.ca_arrays,
+				    orw->orw_dti_cos.ca_count);
+		if (rc != 0)
+			D_ERROR(DF_UUID": Fail to DTX CoS commit: %d\n",
+				DP_UUID(cont->sc_uuid), rc);
+	}
+
+out:
+	rc = dtx_end(dth, cont_hdl, cont, rc);
+	ds_obj_rw_reply(rpc, rc, map_ver, &conflict);
+
+	if (cont_hdl)
+		ds_cont_hdl_put(cont_hdl);
+	if (cont)
+		ds_cont_child_put(cont);
+}
+
+static int
+ds_obj_tgt_update(struct dtx_handle *dth, void *arg, int idx,
+		  dtx_exec_shard_comp_cb_t comp_cb,
+		  struct dtx_exec_shard_arg *comp_arg)
+{
+	struct ds_obj_exec_arg *exec_arg = arg;
+
+	/* handle local operaion */
+	if (idx == -1) {
+		int rc = 0;
+
+		/* No need re-exec local update */
+		if (!(exec_arg->flags & ORF_RESEND)) {
+			rc = obj_local_rw(exec_arg->rpc, exec_arg->cont_hdl,
+					  exec_arg->cont, dth);
+		}
+		if (comp_cb != NULL)
+			comp_cb(comp_arg, rc);
+
+		return rc;
+	}
+
+	/* Handle the object remotely */
+	return ds_obj_remote_update(dth, arg, idx, comp_cb, comp_arg);
+}
+
+void
+ds_obj_rw_handler(crt_rpc_t *rpc)
+{
+	struct obj_rw_in		*orw = crt_req_get(rpc);
+	struct obj_rw_out		*orwo = crt_reply_get(rpc);
+	struct ds_cont_hdl		*cont_hdl = NULL;
+	struct ds_cont_child		*cont = NULL;
+	struct dtx_handle		*dth = NULL;
+	struct dtx_conflict_entry	 conflict = { 0 };
+	struct obj_tls			*tls = obj_tls_get();
+	struct ds_obj_exec_arg		exec_arg = { 0 };
+	uint32_t			 map_ver = 0;
+	uint32_t			 flags = 0;
+	int				 rc;
+
+	D_ASSERT(orw != NULL);
+	D_ASSERT(orwo != NULL);
+
+	D_TIME_START(tls->ot_sp, OBJ_PF_UPDATE);
+
+	rc = ds_pre_check(orw->orw_oid, orw->orw_map_ver, orw->orw_pool_uuid,
+			  orw->orw_co_hdl, orw->orw_co_uuid,
+			  opc_get(rpc->cr_opc), orw->orw_flags, &orw->orw_dti,
+			  &cont_hdl, &cont);
+	if (rc)
+		goto out;
+
+	D_ASSERT(cont_hdl->sch_pool != NULL);
+	map_ver = cont_hdl->sch_pool->spc_map_version;
+
+	D_DEBUG(DB_TRACE, "rpc %p opc %d "DF_UOID" dkey %d %s tag/xs %d/%d eph "
+		DF_U64", pool ver %u/%u with "DF_DTI".\n",
+		rpc, opc_get(rpc->cr_opc), DP_UOID(orw->orw_oid),
+		(int)orw->orw_dkey.iov_len, (char *)orw->orw_dkey.iov_buf,
+		dss_get_module_info()->dmi_tgt_id,
+		dss_get_module_info()->dmi_xs_id, orw->orw_epoch,
+		orw->orw_map_ver, map_ver, DP_DTI(&orw->orw_dti));
 	/* FIXME: until distributed transaction. */
 	if (orw->orw_epoch == DAOS_EPOCH_MAX) {
 		orw->orw_epoch = daos_ts2epoch();
 		D_DEBUG(DB_IO, "overwrite epoch "DF_U64"\n", orw->orw_epoch);
 	}
 
-	if (srv_enable_dtx && (!resend || dispatch)) {
-		/* XXX: In fact, we do not need to start the DTX for
-		 *	non-replicated object. But consider to handle
-		 *	resend case, we need the DTX record. So start
-		 *	the DTX unconditionally. It may be changed in
-		 *	the future when we introduce more suitable
-		 *	mechanism for handling resent modification.
-		 *
-		 *	For new leader, even though the local replica
-		 *	has ever been modified before, but it doesn't
-		 *	know whether other replicas have also done the
-		 *	modification or not, so still need to dispatch
-		 *	the RPC to other replicas.
-		 */
-
-		rc = dtx_begin(&orw->orw_dti, &orw->orw_oid, cont->sc_hdl,
-			       orw->orw_epoch, orw->orw_dkey_hash,
-			       &conflict, orw->orw_dti_cos.ca_arrays,
-			       orw->orw_dti_cos.ca_count, orw->orw_map_ver,
-			       DAOS_INTENT_UPDATE,
-			       !(orw->orw_flags & ORF_FROM_LEADER), &dth);
-		if (rc != 0) {
-			D_ERROR(DF_UOID": Failed to start DTX for update %d.\n",
-				DP_UOID(orw->orw_oid), rc);
-			D_GOTO(out, rc);
-		}
-
-		dti_cos = dth->dth_dti_cos;
-		dti_cos_count = dth->dth_dti_cos_count;
-		if (!(orw->orw_flags & ORF_FROM_LEADER) && !dispatch)
-			dth->dth_non_rep = 1;
-	}
-
-	D_TIME_END(tls->ot_sp, OBJ_PF_UPDATE_PREP);
-
-dispatch:
-	if (dispatch) {
-		D_TIME_START(tls->ot_sp, OBJ_PF_UPDATE_DISPATCH);
-
-		rc = ds_obj_req_disp_prepare(rpc->cr_opc,
-				orw->orw_shard_tgts.ca_arrays,
-				orw->orw_shard_tgts.ca_count,
-				obj_update_prefw, obj_update_postfw, orw, flags,
-				dti_cos_count, dti_cos, &obj_arg);
-		if (rc != 0) {
-			D_ERROR(DF_UOID": ds_obj_req_disp_prepare failed %d.\n",
-				DP_UOID(orw->orw_oid), rc);
-			D_GOTO(out, rc);
-		}
-		D_ASSERT(obj_arg != NULL);
-
-		rc = dss_ult_create(ds_obj_req_dispatch, obj_arg,
-				    DSS_ULT_IOFW, tag, 0, NULL);
-		if (rc != 0) {
-			D_ERROR(DF_UOID": ds_obj_req_dispatch failed %d.\n",
-				DP_UOID(orw->orw_oid), rc);
-			ds_obj_req_disp_arg_free(obj_arg);
-			D_GOTO(out, rc);
-		}
-
-		D_TIME_END(tls->ot_sp, OBJ_PF_UPDATE_DISPATCH);
-	}
-
-	if (!resend) {
+	/* Single replica update or fetch. */
+	if (orw->orw_shard_tgts.ca_arrays == NULL) {
+		/* No resend case for single replica yet XXX */
 		D_TIME_START(tls->ot_sp, OBJ_PF_UPDATE_LOCAL);
-
-		/* local RPC handler */
-		rc = ds_obj_rw_local_hdlr(rpc, tag, cont_hdl, cont,
-					  &ioh, true, map_ver, dth);
-		if (rc != 0)
-			D_ERROR(DF_UOID": rw_local_hdlr (update) failed %d.\n",
+		rc = obj_local_rw(rpc, cont_hdl, cont, dth);
+		if (rc != 0) {
+			D_ERROR(DF_UOID": rw_local (update) failed %d.\n",
 				DP_UOID(orw->orw_oid), rc);
+			D_GOTO(out, rc);
+		}
 
 		D_TIME_END(tls->ot_sp, OBJ_PF_UPDATE_LOCAL);
+		D_GOTO(out, rc);
 	}
 
-	/* wait dispatched IO's completion when needed */
-	if (dispatch) {
-		struct dtx_conflict_entry	*dces = NULL;
-
-		D_TIME_START(tls->ot_sp, OBJ_PF_UPDATE_WAIT);
-
-		rc1 = ds_obj_req_disp_wait(obj_arg, rc >= 0 ? &dces : NULL);
-		if (dces != NULL) {
-			/* XXX: The local modification has been done, but remote
-			 *	replica failed because of some uncommitted DTX,
-			 *	it may be caused by some garbage DTXs on remote
-			 *	replicas or leader has more information because
-			 *	of CoS cache. So handle (abort or commit) them
-			 *	firstly then retry.
-			 */
-
-			D_ASSERT(dth != NULL);
-
-			D_DEBUG(DB_TRACE, "Hit conflict DTX (%d)"DF_DTI" for "
-				DF_DTI", handle them and retry update.\n",
-				rc1, DP_DTI(&dces[0].dce_xid),
-				DP_DTI(&orw->orw_dti));
-
-			rc = dtx_conflict(cont->sc_hdl, dth,
-					  cont_hdl->sch_pool->spc_uuid,
-					  cont->sc_uuid, dces, rc1,
-					  cont_hdl->sch_pool->spc_map_version);
-			D_FREE(dces);
-			if (rc >= 0) {
-				resend = true;
-				flags |= ORF_RESEND;
-				dti_cos = dth->dth_dti_cos;
-				dti_cos_count = dth->dth_dti_cos_count;
-
-				D_TIME_END(tls->ot_sp, OBJ_PF_UPDATE_WAIT);
-
-				goto dispatch;
-			}
-		} else if (rc >= 0) {
-			rc = rc1;
+	/* Handle resend. */
+	if (orw->orw_flags & ORF_RESEND) {
+		rc = dtx_handle_resend(cont->sc_hdl, &orw->orw_oid,
+				       &orw->orw_dti,
+				       orw->orw_dkey_hash, false);
+		if (rc == -DER_ALREADY)
+			D_GOTO(out, rc = 0);
+		if (rc == 0) {
+			flags |= ORF_RESEND;
+		} else if (rc == -DER_NONEXIST) {
+			rc = 0;
+		} else {
+			D_GOTO(out, rc);
 		}
-
-		D_TIME_END(tls->ot_sp, OBJ_PF_UPDATE_WAIT);
 	}
 
+	D_TIME_START(tls->ot_sp, OBJ_PF_UPDATE_PREP);
+	/*
+	 * Since we do not know if other replicas execute the
+	 * operation, so even the operation has been execute
+	 * locally, we will start dtx and forward reqests to
+	 * all replicas.
+	 *
+	 * For new leader, even though the local replica
+	 * has ever been modified before, but it doesn't
+	 * know whether other replicas have also done the
+	 * modification or not, so still need to dispatch
+	 * the RPC to other replicas.
+	 */
+	rc = dtx_begin(&orw->orw_dti, &orw->orw_oid, cont->sc_hdl,
+		       orw->orw_epoch, orw->orw_dkey_hash,
+		       &conflict, orw->orw_dti_cos.ca_arrays,
+		       orw->orw_dti_cos.ca_count, orw->orw_map_ver,
+		       DAOS_INTENT_UPDATE, true, &dth);
+	if (rc != 0) {
+		D_ERROR(DF_UOID": Failed to start DTX for update %d.\n",
+			DP_UOID(orw->orw_oid), rc);
+		D_GOTO(out, rc);
+	}
+	D_TIME_END(tls->ot_sp, OBJ_PF_UPDATE_PREP);
+
+	exec_arg.rpc = rpc;
+	exec_arg.cont_hdl = cont_hdl;
+	exec_arg.cont = cont;
+again:
+	exec_arg.flags = flags;
+	/* Execute the operation on all targets */
+	rc = dtx_exec_ops(orw->orw_shard_tgts.ca_arrays,
+			  orw->orw_shard_tgts.ca_count, dth,
+			  ds_obj_tgt_update, &exec_arg);
 out:
-	if (dth != NULL)
-		rc = dtx_end(dth, cont_hdl, cont, rc);
+	/* Stop the distribute transaction */
+	rc = dtx_end(dth, cont_hdl, cont, rc);
+	if (rc == -DER_AGAIN) {
+		flags |= ORF_RESEND;
+		D_GOTO(again, rc);
+	}
 
 	ds_obj_rw_reply(rpc, rc, map_ver, &conflict);
-
 	D_TIME_END(tls->ot_sp, OBJ_PF_UPDATE);
 
-	if (cont_hdl) {
-		if (!cont_hdl->sch_cont)
-			ds_cont_child_put(cont); /* -1 for rebuild container */
+	if (cont_hdl)
 		ds_cont_hdl_put(cont_hdl);
-	}
+	if (cont)
+		ds_cont_child_put(cont);
 }
 
 static void
@@ -1108,16 +1104,14 @@ ds_iter_vos(crt_rpc_t *rpc, struct vos_iter_anchors *anchors,
 	int			rc;
 	bool			recursive = false;
 
-	rc = ds_check_container(oei->oei_pool_uuid, oei->oei_co_hdl,
-				oei->oei_co_uuid, &cont_hdl, &cont);
+	rc = ds_pre_check(oei->oei_oid, oei->oei_map_ver, oei->oei_pool_uuid,
+			  oei->oei_co_hdl, oei->oei_co_uuid, opc, 0, NULL,
+			  &cont_hdl, &cont);
 	if (rc)
 		D_GOTO(out, rc);
 
 	D_ASSERT(cont_hdl->sch_pool != NULL);
 	*map_version = cont_hdl->sch_pool->spc_map_version;
-	if (oei->oei_map_ver < *map_version)
-		D_DEBUG(DB_IO, "stale version req %d map_version %d\n",
-			oei->oei_map_ver, *map_version);
 
 	/* prepare enumeration parameters */
 	param.ip_hdl = cont->sc_hdl;
@@ -1184,10 +1178,10 @@ ds_iter_vos(crt_rpc_t *rpc, struct vos_iter_anchors *anchors,
 		DP_UOID(oei->oei_oid), type, dss_get_module_info()->dmi_tgt_id,
 		rc);
 out_cont_hdl:
-
-	if (!cont_hdl->sch_cont)
-		ds_cont_child_put(cont); /* -1 for rebuild container */
-	ds_cont_hdl_put(cont_hdl);
+	if (cont_hdl)
+		ds_cont_hdl_put(cont_hdl);
+	if (cont)
+		ds_cont_child_put(cont);
 out:
 	return rc;
 }
@@ -1360,55 +1354,6 @@ out:
 	ds_eu_complete(rpc, rc, map_version);
 }
 
-static int
-obj_punch_postfw(crt_rpc_t *req, void *arg)
-{
-	struct shard_req_fw_arg	*shard_arg = arg;
-	struct obj_req_disp_arg	*obj_arg = shard_arg->fw_obj_arg;
-	struct obj_punch_in	*opi_parent = obj_arg->cb_data;
-	struct obj_punch_out	*opo = crt_reply_get(req);
-	int			 rc;
-
-	if (opi_parent->opi_map_ver < opo->opo_map_version) {
-		D_DEBUG(DB_IO, DF_UOID": map_ver stale (%d < %d).\n",
-			DP_UOID(opi_parent->opi_oid), opi_parent->opi_map_ver,
-			opo->opo_map_version);
-		rc = -DER_STALE;
-	} else {
-		rc = opo->opo_ret;
-		if (rc == -DER_INPROGRESS) {
-			daos_dti_copy(&shard_arg->fw_dce.dce_xid,
-				      &opo->opo_dti_conflict);
-			shard_arg->fw_dce.dce_dkey = opo->opo_dkey_conflict;
-		}
-	}
-
-	return rc > 0 ? 0 : rc;
-}
-
-static int
-obj_punch_prefw(crt_rpc_t *req, void *arg)
-{
-	struct shard_req_fw_arg	*shard_arg = arg;
-	struct obj_req_disp_arg	*obj_arg = shard_arg->fw_obj_arg;
-	struct obj_punch_in	*opi_parent = obj_arg->cb_data;
-	struct obj_punch_in	*opi = crt_req_get(req);
-
-	*opi = *opi_parent;
-	opi->opi_oid.id_shard = shard_arg->fw_shard_tgt->st_shard;
-	uuid_copy(opi->opi_co_hdl, opi_parent->opi_co_hdl);
-	uuid_copy(opi->opi_co_uuid, opi_parent->opi_co_uuid);
-	opi->opi_shard_tgts.ca_count = 0;
-	opi->opi_shard_tgts.ca_arrays = NULL;
-	opi->opi_flags |= obj_arg->flags;
-	if (!srv_enable_dtx)
-		opi->opi_flags |= ORF_DTX_DISABLED;
-	opi->opi_dti_cos.ca_count = obj_arg->dti_cos_count;
-	opi->opi_dti_cos.ca_arrays = obj_arg->dti_cos;
-
-	return 0;
-}
-
 static void
 obj_punch_complete(crt_rpc_t *rpc, int status, uint32_t map_version,
 		   struct dtx_conflict_entry *dce)
@@ -1425,25 +1370,23 @@ obj_punch_complete(crt_rpc_t *rpc, int status, uint32_t map_version,
 }
 
 static int
-ds_obj_punch_local_hdlr(struct obj_punch_in *opi, crt_opcode_t opc,
-			struct ds_cont_hdl *cont_hdl,
-			struct ds_cont_child *cont,
-			struct dtx_handle *dth)
+obj_local_punch(struct obj_punch_in *opi, crt_opcode_t opc,
+		struct ds_cont_hdl *cont_hdl, struct ds_cont_child *cont,
+		struct dtx_handle *dth)
 {
 	int	rc = 0;
 
 	switch (opc) {
-	default:
-		D_ERROR("opc %#x not supported\n", opc);
-		D_GOTO(out, rc = -DER_NOSYS);
-
 	case DAOS_OBJ_RPC_PUNCH:
+	case DAOS_OBJ_RPC_TGT_PUNCH:
 		rc = vos_obj_punch(cont->sc_hdl, opi->opi_oid,
 				   opi->opi_epoch, opi->opi_map_ver, 0,
 				   NULL, 0, NULL, dth);
 		break;
 	case DAOS_OBJ_RPC_PUNCH_DKEYS:
-	case DAOS_OBJ_RPC_PUNCH_AKEYS: {
+	case DAOS_OBJ_RPC_PUNCH_AKEYS:
+	case DAOS_OBJ_RPC_TGT_PUNCH_DKEYS:
+	case DAOS_OBJ_RPC_TGT_PUNCH_AKEYS: {
 		daos_key_t *dkey;
 
 		D_ASSERTF(opi->opi_dkeys.ca_count == 1,
@@ -1457,99 +1400,146 @@ ds_obj_punch_local_hdlr(struct obj_punch_in *opi, crt_opcode_t opc,
 				   opi->opi_akeys.ca_arrays, dth);
 		break;
 	}
+	default:
+		D_ERROR("opc %#x not supported\n", opc);
+		D_GOTO(out, rc = -DER_NOSYS);
 	}
-
 out:
 	return rc;
 }
 
+/* Handle the punch requests on non-leader */
 void
-ds_obj_punch_handler(crt_rpc_t *rpc)
+ds_obj_tgt_punch_handler(crt_rpc_t *rpc)
 {
-	struct obj_req_disp_arg		*obj_arg = NULL;
 	struct ds_cont_hdl		*cont_hdl = NULL;
 	struct ds_cont_child		*cont = NULL;
 	struct dtx_handle		*dth = NULL;
-	struct dtx_id			*dti_cos = NULL;
 	struct dtx_conflict_entry	 conflict = { 0 };
 	struct obj_punch_in		*opi;
 	uint32_t			 map_version = 0;
-	uint32_t			 flags = 0;
-	int				 tag;
-	int				 dti_cos_count = 0;
-	bool				 dispatch;
-	bool				 resend = false;
 	int				 rc;
 
 	opi = crt_req_get(rpc);
 	D_ASSERT(opi != NULL);
-	dispatch = opi->opi_shard_tgts.ca_arrays != NULL;
-
-	tag = dss_get_module_info()->dmi_tgt_id;
-
-	rc = ds_check_container(opi->opi_pool_uuid, opi->opi_co_hdl,
-				opi->opi_co_uuid, &cont_hdl, &cont);
+	rc = ds_pre_check(opi->opi_oid, opi->opi_map_ver, opi->opi_pool_uuid,
+			  opi->opi_co_hdl, opi->opi_co_uuid,
+			  opc_get(rpc->cr_opc), opi->opi_flags, &opi->opi_dti,
+			  &cont_hdl, &cont);
 	if (rc)
-		D_GOTO(out, rc);
-
-	if (!(cont_hdl->sch_capas & DAOS_COO_RW))
-		D_GOTO(out, rc = -DER_NO_PERM);
-
-	D_ASSERT(cont_hdl->sch_pool != NULL);
-	map_version = cont_hdl->sch_pool->spc_map_version;
-
-	D_DEBUG(DB_TRACE, "rpc %p opc %d "DF_UOID" tag/xs %d/%d eph "
-		DF_U64", pool ver %u/%u with "DF_DTI".\n",
-		rpc, opc_get(rpc->cr_opc), DP_UOID(opi->opi_oid),
-		tag, dss_get_module_info()->dmi_xs_id, opi->opi_epoch,
-		opi->opi_map_ver, map_version, DP_DTI(&opi->opi_dti));
-
-	if (opi->opi_map_ver < map_version) {
-		D_DEBUG(DB_IO, "stale version req %d map_version %d\n",
-			 opi->opi_map_ver, map_version);
-		D_GOTO(out, rc = -DER_STALE);
-	} else if (opi->opi_map_ver > map_version) {
-		/* XXX: Client (or leader replica) has newer pool map than
-		 *	current replica. Two possibile cases:
-		 *
-		 *	1. The current replica was the old leader if with
-		 *	   the old pool map version. According to current
-		 *	   leader election algorithm, it is still the new
-		 *	   leader with the new pool map version. Since no
-		 *	   leader switch, the unmatched pool version will
-		 *	   not affect DTX related availability check.
-		 *
-		 *	2. The current replica was NOT the old leader if
-		 *	   with the old pool map version. But it becomes
-		 *	   the new leader with the new pool map version.
-		 *	   In the subsequent modificaiton, it may hit
-		 *	   some 'prepared' DTX when make availability
-		 *	   check, it will return -DER_INPROGRESS that
-		 *	   will cause client to retry. It is possible
-		 *	   that the pool map version event arrives at
-		 *	   this server during the client retry. It is
-		 *	   inefficient, but harmless.
-		 */
-	}
-
-	/* Check DTX configuration. */
-	rc = ds_obj_check_dtx_config(opi->opi_flags, &opi->opi_dti);
-	if (rc != 0)
-		D_GOTO(out, rc);
+		goto out;
 
 	/* Handle resend. */
-	if (srv_enable_dtx && opi->opi_flags & ORF_RESEND) {
+	if (opi->opi_flags & ORF_RESEND) {
 		rc = dtx_handle_resend(cont->sc_hdl, &opi->opi_oid,
 				       &opi->opi_dti, opi->opi_dkey_hash, true);
 		if (rc == -DER_ALREADY)
 			D_GOTO(out, rc = 0);
-		if (rc == 0)
-			resend = true;
-		else if (rc == -DER_NONEXIST)
-			rc = 0;
-		else
-			D_GOTO(out, rc);
 	}
+
+	/* Start the local transaction */
+	rc = dtx_begin(&opi->opi_dti, &opi->opi_oid, cont->sc_hdl,
+		       opi->opi_epoch, opi->opi_dkey_hash,
+		       &conflict, opi->opi_dti_cos.ca_arrays,
+		       opi->opi_dti_cos.ca_count, opi->opi_map_ver,
+		       DAOS_INTENT_PUNCH, false, &dth);
+	if (rc != 0) {
+		D_ERROR(DF_UOID": Failed to start DTX for punch %d.\n",
+			DP_UOID(opi->opi_oid), rc);
+		D_GOTO(out, rc);
+	}
+
+	/* local RPC handler */
+	rc = obj_local_punch(opi, opc_get(rpc->cr_opc), cont_hdl, cont, dth);
+	if (rc != 0) {
+		D_ERROR(DF_UOID": obj_local_punch failed %d.\n",
+			DP_UOID(opi->opi_oid), rc);
+		D_GOTO(out, rc);
+	}
+
+	/**
+	 * XXX layer violation, it should be moved to DTX module, will
+	 * handle in following patches.
+	 */
+	if (opi->opi_dti_cos.ca_count > 0) {
+		/* XXX: For non-leader replica, even if we fail to
+		 *	make related modification for some reason,
+		 *	we still need to commit the DTXs for CoS.
+		 *	Because other replica may have already
+		 *	committed them. For leader case, it is
+		 *	not important even if we miss to commit
+		 *	the CoS DTXs, because they are still in
+		 *	CoS cache, and can be committed next time.
+		 */
+		rc = vos_dtx_commit(cont->sc_hdl,
+				    opi->opi_dti_cos.ca_arrays,
+				    opi->opi_dti_cos.ca_count);
+		if (rc != 0) {
+			D_ERROR(DF_UUID": Fail to DTX CoS commit: %d\n",
+				DP_UUID(cont->sc_uuid), rc);
+			D_GOTO(out, rc);
+		}
+	}
+out:
+	/* Stop the local transaction */
+	rc = dtx_end(dth, cont_hdl, cont, rc);
+	obj_punch_complete(rpc, rc, map_version, &conflict);
+	if (cont_hdl)
+		ds_cont_hdl_put(cont_hdl);
+	if (cont)
+		ds_cont_child_put(cont); /* -1 for rebuild container */
+}
+
+static int
+ds_obj_tgt_punch(struct dtx_handle *dth, void *arg, int idx,
+		 dtx_exec_shard_comp_cb_t comp_cb,
+		 struct dtx_exec_shard_arg *comp_arg)
+{
+	struct ds_obj_exec_arg	*exec_arg = arg;
+
+	/* handle local operaion */
+	if (idx == -1) {
+		crt_rpc_t		*rpc = exec_arg->rpc;
+		struct obj_punch_in	*opi = crt_req_get(rpc);
+		int			rc = 0;
+
+		if (!(exec_arg->flags & ORF_RESEND)) {
+			rc = obj_local_punch(opi, opc_get(rpc->cr_opc),
+					     exec_arg->cont_hdl,
+					     exec_arg->cont, dth);
+		}
+		if (comp_cb != NULL)
+			comp_cb(comp_arg, rc);
+
+		return rc;
+	}
+
+	/* Handle the object remotely */
+	return ds_obj_remote_punch(dth, arg, idx, comp_cb, comp_arg);
+}
+
+/* Handle the punch requests on the leader */
+void
+ds_obj_punch_handler(crt_rpc_t *rpc)
+{
+	struct ds_cont_hdl		*cont_hdl = NULL;
+	struct ds_cont_child		*cont = NULL;
+	struct dtx_handle		*dth = NULL;
+	struct dtx_conflict_entry	 conflict = { 0 };
+	struct obj_punch_in		*opi;
+	struct ds_obj_exec_arg		exec_arg = { 0 };
+	uint32_t			 map_version = 0;
+	uint32_t			 flags = 0;
+	int				 rc;
+
+	opi = crt_req_get(rpc);
+	D_ASSERT(opi != NULL);
+	rc = ds_pre_check(opi->opi_oid, opi->opi_map_ver, opi->opi_pool_uuid,
+			  opi->opi_co_hdl, opi->opi_co_uuid,
+			  opc_get(rpc->cr_opc), opi->opi_flags, &opi->opi_dti,
+			  &cont_hdl, &cont);
+	if (rc)
+		goto out;
 
 	/* FIXME: until distributed transaction. */
 	if (opi->opi_epoch == DAOS_EPOCH_MAX) {
@@ -1557,120 +1547,78 @@ ds_obj_punch_handler(crt_rpc_t *rpc)
 		D_DEBUG(DB_IO, "overwrite epoch "DF_U64"\n", opi->opi_epoch);
 	}
 
-	if (srv_enable_dtx && (!resend || dispatch)) {
-		/* XXX: In fact, we do not need to start the DTX for
-		 *	non-replicated object. But consider to handle
-		 *	resend case, we need the DTX record. So start
-		 *	the DTX unconditionally. It may be changed in
-		 *	the future when we introduce more suitable
-		 *	mechanism for handling resent modification.
-		 *
-		 *	For new leader, even though the local replica
-		 *	has ever been modified before, but it doesn't
-		 *	know whether other replicas have also done the
-		 *	modification or not, so still need to dispatch
-		 *	the RPC to other replicas.
-		 */
-
-		rc = dtx_begin(&opi->opi_dti, &opi->opi_oid, cont->sc_hdl,
-			       opi->opi_epoch, opi->opi_dkey_hash,
-			       &conflict, opi->opi_dti_cos.ca_arrays,
-			       opi->opi_dti_cos.ca_count, opi->opi_map_ver,
-			       DAOS_INTENT_PUNCH,
-			       !(opi->opi_flags & ORF_FROM_LEADER), &dth);
-		if (rc != 0) {
-			D_ERROR(DF_UOID": Failed to start DTX for punch %d.\n",
-				DP_UOID(opi->opi_oid), rc);
-			D_GOTO(out, rc);
-		}
-
-		dti_cos = dth->dth_dti_cos;
-		dti_cos_count = dth->dth_dti_cos_count;
-		if (!(opi->opi_flags & ORF_FROM_LEADER) && !dispatch)
-			dth->dth_non_rep = 1;
-	}
-
-dispatch:
-	if (dispatch) {
-		rc = ds_obj_req_disp_prepare(rpc->cr_opc,
-				opi->opi_shard_tgts.ca_arrays,
-				opi->opi_shard_tgts.ca_count,
-				obj_punch_prefw, obj_punch_postfw, opi, flags,
-				dti_cos_count, dti_cos, &obj_arg);
-		if (rc != 0) {
-			D_ERROR(DF_UOID": ds_obj_req_disp_prepare failed %d.\n",
-				DP_UOID(opi->opi_oid), rc);
-			D_GOTO(out, rc);
-		}
-		D_ASSERT(obj_arg != NULL);
-
-		rc = dss_ult_create(ds_obj_req_dispatch, obj_arg,
-				    DSS_ULT_IOFW, tag, 0, NULL);
-		if (rc != 0) {
-			D_ERROR(DF_UOID": ds_obj_req_dispatch failed %d.\n",
-				DP_UOID(opi->opi_oid), rc);
-			ds_obj_req_disp_arg_free(obj_arg);
-			D_GOTO(out, rc);
-		}
-	}
-
-	if (!resend) {
+	if (opi->opi_shard_tgts.ca_arrays == NULL) {
 		/* local RPC handler */
-		rc = ds_obj_punch_local_hdlr(opi, opc_get(rpc->cr_opc),
-					     cont_hdl, cont, dth);
-		if (rc != 0)
-			D_ERROR(DF_UOID": obj_punch_local_hdlr failed %d.\n",
+		rc = obj_local_punch(opi, opc_get(rpc->cr_opc), cont_hdl, cont,
+				     dth);
+		if (rc != 0) {
+			D_ERROR(DF_UOID": obj_local_punch failed %d.\n",
 				DP_UOID(opi->opi_oid), rc);
-	}
-
-	if (dispatch) {
-		struct dtx_conflict_entry	*dces = NULL;
-		int				 rc1 = 0;
-
-		rc1 = ds_obj_req_disp_wait(obj_arg, rc >= 0 ? &dces : NULL);
-		if (dces != NULL) {
-			/* XXX: The local modification has been done, but remote
-			 *	replica failed because of some uncommitted DTX,
-			 *	it may be caused by some garbage DTXs on remote
-			 *	replicas or leader has more information because
-			 *	of CoS cache. So handle (abort or commit) them
-			 *	firstly then retry.
-			 */
-
-			D_ASSERT(dth != NULL);
-
-			D_DEBUG(DB_TRACE, "Hit conflict DTX (%d)"DF_DTI" for "
-				DF_DTI", handle them then retry punch.\n",
-				rc1, DP_DTI(&dces[0].dce_xid),
-				DP_DTI(&opi->opi_dti));
-
-			rc = dtx_conflict(cont->sc_hdl, dth,
-					  cont_hdl->sch_pool->spc_uuid,
-					  cont->sc_uuid, dces, rc1,
-					  cont_hdl->sch_pool->spc_map_version);
-			D_FREE(dces);
-			if (rc >= 0) {
-				resend = true;
-				flags |= ORF_RESEND;
-				dti_cos = dth->dth_dti_cos;
-				dti_cos_count = dth->dth_dti_cos_count;
-				goto dispatch;
-			}
-		} else if (rc >= 0) {
-			rc = rc1;
+			D_GOTO(out, rc);
 		}
+
+		D_GOTO(out, rc);
 	}
 
+	/* Handle resend. */
+	if (opi->opi_flags & ORF_RESEND) {
+		rc = dtx_handle_resend(cont->sc_hdl, &opi->opi_oid,
+				       &opi->opi_dti, opi->opi_dkey_hash, true);
+		if (rc == -DER_ALREADY)
+			D_GOTO(out, rc = 0);
+		if (rc == 0)
+			flags |= ORF_RESEND;
+		else if (rc == -DER_NONEXIST)
+			rc = 0;
+		else
+			D_GOTO(out, rc);
+	}
+
+	/*
+	 * Since we do not know if other replicas execute the
+	 * operation, so even the operation has been execute
+	 * locally, we will start dtx and forward reqests to
+	 * all replicas.
+	 *
+	 * For new leader, even though the local replica
+	 * has ever been modified before, but it doesn't
+	 * know whether other replicas have also done the
+	 * modification or not, so still need to dispatch
+	 * the RPC to other replicas.
+	 */
+	rc = dtx_begin(&opi->opi_dti, &opi->opi_oid, cont->sc_hdl,
+		       opi->opi_epoch, opi->opi_dkey_hash,
+		       &conflict, opi->opi_dti_cos.ca_arrays,
+		       opi->opi_dti_cos.ca_count, opi->opi_map_ver,
+		       DAOS_INTENT_PUNCH, true, &dth);
+	if (rc != 0) {
+		D_ERROR(DF_UOID": Failed to start DTX for punch %d.\n",
+			DP_UOID(opi->opi_oid), rc);
+		D_GOTO(out, rc);
+	}
+
+	exec_arg.rpc = rpc;
+	exec_arg.cont_hdl = cont_hdl;
+	exec_arg.cont = cont;
+again:
+	exec_arg.flags = flags;
+	/* Execute the operation on all shards */
+	rc = dtx_exec_ops(opi->opi_shard_tgts.ca_arrays,
+			  opi->opi_shard_tgts.ca_count, dth, ds_obj_tgt_punch,
+			  &exec_arg);
 out:
-	if (dth != NULL)
-		rc = dtx_end(dth, cont_hdl, cont, rc);
+	/* Stop the distribute transaction */
+	rc = dtx_end(dth, cont_hdl, cont, rc);
+	if (rc == -DER_AGAIN) {
+		flags |= ORF_RESEND;
+		D_GOTO(again, rc);
+	}
 
 	obj_punch_complete(rpc, rc, map_version, &conflict);
-	if (cont_hdl) {
-		if (!cont_hdl->sch_cont)
-			ds_cont_child_put(cont); /* -1 for rebuild container */
+	if (cont_hdl)
 		ds_cont_hdl_put(cont_hdl);
-	}
+	if (cont)
+		ds_cont_child_put(cont); /* -1 for rebuild container */
 }
 
 void
@@ -1700,7 +1648,8 @@ ds_obj_query_key_handler(crt_rpc_t *rpc)
 	}
 
 	rc = ds_check_container(okqi->okqi_pool_uuid, okqi->okqi_co_hdl,
-				okqi->okqi_co_uuid, &cont_hdl, &cont);
+				okqi->okqi_co_uuid, opc_get(rpc->cr_opc),
+				&cont_hdl, &cont);
 	if (rc)
 		D_GOTO(out, rc);
 
@@ -1719,11 +1668,10 @@ ds_obj_query_key_handler(crt_rpc_t *rpc)
 	rc = vos_obj_query_key(cont->sc_hdl, okqi->okqi_oid, okqi->okqi_flags,
 			       okqi->okqi_epoch, dkey, akey, &okqo->okqo_recx);
 out:
-	if (cont_hdl) {
-		if (!cont_hdl->sch_cont)
-			ds_cont_child_put(cont); /* -1 for rebuild container */
+	if (cont_hdl)
 		ds_cont_hdl_put(cont_hdl);
-	}
+	if (cont)
+		ds_cont_child_put(cont); /* -1 for rebuild container */
 
 	obj_reply_set_status(rpc, rc);
 	obj_reply_map_version_set(rpc, map_version);
@@ -1750,6 +1698,7 @@ ds_obj_abt_pool_choose_cb(crt_rpc_t *rpc, ABT_pool *pools)
 	case DAOS_OBJ_RPC_PUNCH_DKEYS:
 	case DAOS_OBJ_RPC_PUNCH_AKEYS:
 	case DAOS_OBJ_RPC_UPDATE:
+	case DAOS_OBJ_RPC_TGT_UPDATE:
 	case DAOS_OBJ_RPC_FETCH:
 		pool = pools[DSS_POOL_SHARE];
 		break;
@@ -1760,235 +1709,3 @@ ds_obj_abt_pool_choose_cb(crt_rpc_t *rpc, ABT_pool *pools)
 
 	return pool;
 }
-
-static void
-obj_req_dispatch_cb(void **arg)
-{
-	struct shard_req_fw_arg		*shard_arg;
-	struct obj_req_disp_arg		*obj_arg;
-	uint32_t			 i, fw_cnt;
-
-	shard_arg = arg[0];
-	obj_arg = shard_arg->fw_obj_arg;
-	fw_cnt = obj_arg->fw_cnt;
-	D_ASSERT(fw_cnt >= 1);
-	for (i = 0; i < fw_cnt; i++) {
-		shard_arg = arg[i];
-		D_ASSERT(shard_arg->fw_obj_arg == obj_arg);
-		if (obj_arg->fw_result == 0)
-			obj_arg->fw_result = shard_arg->fw_shard_rc;
-	}
-}
-
-static void
-shard_req_fw_cb(const struct crt_cb_info *cb_info)
-{
-	crt_rpc_t		*req = cb_info->cci_rpc;
-	struct shard_req_fw_arg	*shard_arg = cb_info->cci_arg;
-	int			 rc = cb_info->cci_rc;
-
-	if (rc == 0)
-		rc = shard_arg->fw_obj_arg->postfw_cb(req, shard_arg);
-
-	shard_arg->fw_shard_rc = rc;
-	rc = ABT_future_set(shard_arg->fw_obj_arg->fw_future, shard_arg);
-	D_ASSERTF(rc == ABT_SUCCESS, "ABT_future_set failed %d.\n", rc);
-
-	D_DEBUG(DB_TRACE, "forward req got reply from rank %d tag %d, rc %d.\n",
-		shard_arg->fw_shard_tgt->st_rank,
-		shard_arg->fw_shard_tgt->st_tgt_idx, shard_arg->fw_shard_rc);
-}
-
-static int
-shard_req_forward(struct shard_req_fw_arg *fw_arg)
-{
-	struct daos_obj_shard_tgt	*shard_tgt = fw_arg->fw_shard_tgt;
-	crt_rpc_t			*req;
-	ABT_future			 future = fw_arg->fw_obj_arg->fw_future;
-	crt_opcode_t			 opc = fw_arg->fw_obj_arg->fw_opc;
-	crt_endpoint_t			 tgt_ep;
-	int				 rc = 0;
-
-	if (opc_get(opc) == DAOS_OBJ_RPC_UPDATE &&
-	    DAOS_FAIL_CHECK(DAOS_OBJ_TGT_IDX_CHANGE)) {
-		/* to trigger retry on all other shards */
-		if (shard_tgt->st_shard != daos_fail_value_get()) {
-			D_DEBUG(DB_TRACE, "complete shard %d update as "
-				"-DER_TIMEDOUT.\n", shard_tgt->st_shard);
-			rc = -DER_TIMEDOUT;
-		}
-	}
-
-	if (rc != 0 || shard_tgt->st_rank == OBJ_TGTS_IGNORE) {
-		D_DEBUG(DB_TRACE, "opc:%#x, ignore the forward tgt rank %d.\n",
-			opc, shard_tgt->st_rank);
-		fw_arg->fw_shard_rc = rc;
-		rc = ABT_future_set(future, fw_arg);
-		rc = dss_abterr2der(rc);
-		return rc;
-	}
-
-	tgt_ep.ep_grp = NULL;
-	tgt_ep.ep_rank = shard_tgt->st_rank;
-	tgt_ep.ep_tag = daos_rpc_tag(DAOS_REQ_IO, shard_tgt->st_tgt_idx);
-	D_DEBUG(DB_TRACE, "opc:%#x, forwarding to rank:%d tag:%d.\n",
-		opc, tgt_ep.ep_rank, tgt_ep.ep_tag);
-	rc = crt_req_create(dss_get_module_info()->dmi_ctx, &tgt_ep, opc, &req);
-	if (rc != 0) {
-		D_ERROR("opc:%#x, crt_req_create failed, rc %d.\n", opc, rc);
-		D_GOTO(out, rc);
-	}
-
-	rc = fw_arg->fw_obj_arg->prefw_cb(req, fw_arg);
-	if (rc != 0) {
-		D_DEBUG(DB_TRACE, "opc:%#x, prefw_cb failed, rc %d.\n",
-			opc, rc);
-		crt_req_decref(req);
-		D_GOTO(out, rc);
-	}
-
-	rc = crt_req_send(req, shard_req_fw_cb, fw_arg);
-	if (rc != 0) {
-		D_ERROR("opc:%#x, crt_req_send failed, rc %d.\n", opc, rc);
-		crt_req_decref(req);
-		D_GOTO(out, rc);
-	}
-
-out:
-	if (rc) {
-		fw_arg->fw_shard_rc = rc;
-		rc = ABT_future_set(future, fw_arg);
-		rc = dss_abterr2der(rc);
-	}
-	return rc;
-}
-
-int
-ds_obj_req_disp_prepare(crt_opcode_t opc,
-			struct daos_obj_shard_tgt *fw_shard_tgts,
-			uint32_t fw_cnt, ds_iofw_cb_t prefw_cb,
-			ds_iofw_cb_t postfw_cb, void *cb_data,
-			uint32_t flags, int dti_cos_count,
-			struct dtx_id *dti_cos, struct obj_req_disp_arg **arg)
-{
-	struct obj_req_disp_arg		*obj_arg;
-	struct shard_req_fw_arg		*shard_arg;
-	ABT_future			 future;
-	int				 i, rc;
-
-	D_ASSERT(fw_cnt >= 1);
-	D_ALLOC(obj_arg, sizeof(struct obj_req_disp_arg) +
-		fw_cnt * sizeof(struct shard_req_fw_arg));
-	if (obj_arg == NULL)
-		return -DER_NOMEM;
-
-	rc = ABT_future_create(fw_cnt, obj_req_dispatch_cb, &future);
-	if (rc != ABT_SUCCESS) {
-		D_ERROR("ABT_future_create failed %d.\n", rc);
-		D_FREE(obj_arg);
-		return dss_abterr2der(rc);
-	}
-
-	obj_arg->prefw_cb	= prefw_cb;
-	obj_arg->postfw_cb	= postfw_cb;
-	obj_arg->cb_data	= cb_data;
-	obj_arg->fw_future	= future;
-	obj_arg->fw_opc		= opc;
-	obj_arg->fw_cnt		= fw_cnt;
-	obj_arg->flags		= flags | ORF_FROM_LEADER;
-	obj_arg->dti_cos_count	= dti_cos_count;
-	obj_arg->dti_cos	= dti_cos;
-
-	shard_arg = (struct shard_req_fw_arg *)(obj_arg + 1);
-	for (i = 0; i < fw_cnt; i++, shard_arg++) {
-		shard_arg->fw_shard_tgt	= fw_shard_tgts + i;
-		shard_arg->fw_obj_arg	= obj_arg;
-	}
-
-	*arg = obj_arg;
-	return 0;
-}
-
-void
-ds_obj_req_dispatch(void *arg)
-{
-	struct obj_req_disp_arg		*obj_arg = arg;
-	ABT_future			 future = obj_arg->fw_future;
-	struct shard_req_fw_arg		*shard_arg;
-	uint32_t			 i, fw_cnt;
-	int				 rc = 0;
-
-	fw_cnt = obj_arg->fw_cnt;
-	D_ASSERT(fw_cnt >= 1);
-	D_ASSERT(future != ABT_FUTURE_NULL);
-	shard_arg = (struct shard_req_fw_arg *)(obj_arg + 1);
-	for (i = 0; i < fw_cnt; i++, shard_arg++) {
-		rc = shard_req_forward(shard_arg);
-		if (rc != 0)
-			break;
-	}
-
-	if (rc != 0) {
-		D_ASSERT(i < fw_cnt);
-		for (i++; i < fw_cnt; i++) {
-			shard_arg++;
-			shard_arg->fw_shard_rc = rc;
-			rc = ABT_future_set(future, shard_arg);
-			D_ASSERTF(rc == ABT_SUCCESS,
-				  "ABT_future_set failed %d.\n", rc);
-		}
-	}
-}
-
-void
-ds_obj_req_disp_arg_free(struct obj_req_disp_arg *obj_arg)
-{
-	ABT_future_free(&obj_arg->fw_future);
-	D_FREE(obj_arg);
-}
-
-int
-ds_obj_req_disp_wait(struct obj_req_disp_arg *obj_arg,
-		     struct dtx_conflict_entry **dces)
-{
-	ABT_future	future = obj_arg->fw_future;
-	int		rc;
-
-	D_ASSERT(future != ABT_FUTURE_NULL);
-	rc = ABT_future_wait(future);
-	D_ASSERTF(rc == ABT_SUCCESS, "ABT_future_wait failed %d.\n", rc);
-	rc = obj_arg->fw_result;
-	if (rc == -DER_INPROGRESS && dces != NULL) {
-		struct shard_req_fw_arg		*shard_arg;
-		struct dtx_conflict_entry	*conflict;
-		int				 fw_cnt = obj_arg->fw_cnt;
-		int				 i;
-		int				 j;
-
-		D_ALLOC_ARRAY(conflict, fw_cnt);
-		if (conflict == NULL) {
-			rc = -DER_NOMEM;
-			goto out;
-		}
-
-		shard_arg = (struct shard_req_fw_arg *)(obj_arg + 1);
-		for (i = 0, j = 0; i < fw_cnt; i++, shard_arg++) {
-			if (!daos_is_zero_dti(&shard_arg->fw_dce.dce_xid)) {
-				daos_dti_copy(&conflict[j].dce_xid,
-					      &shard_arg->fw_dce.dce_xid);
-				conflict[j++].dce_dkey =
-						shard_arg->fw_dce.dce_dkey;
-			}
-		}
-
-		D_ASSERT(j > 0);
-
-		*dces = conflict;
-		rc = j;
-	}
-
-out:
-	ds_obj_req_disp_arg_free(obj_arg);
-
-	return rc;
-};

--- a/src/object/srv_obj_remote.c
+++ b/src/object/srv_obj_remote.c
@@ -1,0 +1,295 @@
+/**
+ * (C) Copyright 2019 Intel Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * GOVERNMENT LICENSE RIGHTS-OPEN SOURCE SOFTWARE
+ * The Government's rights to use, modify, reproduce, release, perform, display,
+ * or disclose this software are subject to the terms of the Apache License as
+ * provided in Contract No. B609815.
+ * Any reproduction of computer software, computer software documentation, or
+ * portions thereof marked with this legend must also reproduce the markings.
+ */
+/**
+ * object server operations
+ *
+ * This file contains the object server remote object api.
+ */
+#define D_LOGFAC	DD_FAC(object)
+
+#include <uuid/uuid.h>
+
+#include <abt.h>
+#include <daos/rpc.h>
+#include <daos_srv/pool.h>
+#include <daos_srv/rebuild.h>
+#include <daos_srv/container.h>
+#include <daos_srv/vos.h>
+#include <daos_srv/bio.h>
+#include <daos_srv/daos_server.h>
+#include <daos_srv/dtx_srv.h>
+#include "obj_rpc.h"
+#include "obj_internal.h"
+
+struct obj_remote_cb_arg {
+	dtx_exec_shard_comp_cb_t	comp_cb;
+	void				*cb_arg;
+	crt_rpc_t			*parent_req;
+	struct dtx_exec_shard_arg	*shard_arg;
+};
+
+static void
+shard_update_req_cb(const struct crt_cb_info *cb_info)
+{
+	crt_rpc_t			*req = cb_info->cci_rpc;
+	struct obj_remote_cb_arg	*arg = cb_info->cci_arg;
+	struct dtx_exec_shard_arg	*shard_arg = arg->shard_arg;
+	crt_rpc_t			*parent_req = arg->parent_req;
+	struct obj_rw_out		*orwo = crt_reply_get(req);
+	struct obj_rw_in		*orw_parent = crt_req_get(parent_req);
+	int				rc = cb_info->cci_rc;
+	int				rc1 = 0;
+
+	if (orw_parent->orw_map_ver < orwo->orw_map_version) {
+		D_DEBUG(DB_IO, DF_UOID": map_ver stale (%d < %d).\n",
+			DP_UOID(orw_parent->orw_oid), orw_parent->orw_map_ver,
+			orwo->orw_map_version);
+		rc1 = -DER_STALE;
+	} else {
+		rc1 = orwo->orw_ret;
+		if (rc1 == -DER_INPROGRESS) {
+			daos_dti_copy(&shard_arg->exec_dce.dce_xid,
+				      &orwo->orw_dti_conflict);
+			shard_arg->exec_dce.dce_dkey = orwo->orw_dkey_conflict;
+		}
+	}
+
+	if (rc >= 0)
+		rc = rc1;
+
+	if (arg->comp_cb)
+		arg->comp_cb(arg->cb_arg, rc);
+
+	crt_req_decref(parent_req);
+	D_FREE_PTR(arg);
+}
+
+/* Execute update on the remote target */
+int
+ds_obj_remote_update(struct dtx_handle *dth, void *data, int idx,
+		     dtx_exec_shard_comp_cb_t comp_cb, void *cb_arg)
+{
+	struct ds_obj_exec_arg		*obj_exec_arg = data;
+	struct dtx_exec_arg		*arg = dth->dth_exec_arg;
+	struct daos_shard_tgt		*shard_tgt;
+	struct dtx_exec_shard_arg	*shard_arg;
+	crt_endpoint_t			 tgt_ep;
+	crt_rpc_t			*parent_req = obj_exec_arg->rpc;
+	crt_rpc_t			*req;
+	struct obj_remote_cb_arg	*remote_arg = NULL;
+	struct obj_rw_in		*orw;
+	struct obj_rw_in		*orw_parent;
+	int				 rc = 0;
+
+	D_ASSERT(arg != NULL);
+	D_ASSERT(idx < arg->shard_cnt);
+	shard_arg = &arg->exec_shards_args[idx];
+	shard_tgt = shard_arg->exec_shard_tgt;
+	if (DAOS_FAIL_CHECK(DAOS_OBJ_TGT_IDX_CHANGE)) {
+		/* to trigger retry on all other shards */
+		if (shard_tgt->st_shard != daos_fail_value_get()) {
+			D_DEBUG(DB_TRACE, "complete shard %d update as "
+				"-DER_TIMEDOUT.\n", shard_tgt->st_shard);
+			D_GOTO(out, rc = -DER_TIMEDOUT);
+		}
+	}
+
+	D_ALLOC_PTR(remote_arg);
+	if (remote_arg == NULL)
+		D_GOTO(out, rc = -DER_NOMEM);
+
+	tgt_ep.ep_grp = NULL;
+	tgt_ep.ep_rank = shard_tgt->st_rank;
+	tgt_ep.ep_tag = shard_tgt->st_tgt_idx;
+
+	remote_arg->comp_cb = comp_cb;
+	remote_arg->cb_arg = cb_arg;
+	remote_arg->shard_arg = shard_arg;
+	crt_req_addref(parent_req);
+	remote_arg->parent_req = parent_req;
+	rc = obj_req_create(dss_get_module_info()->dmi_ctx, &tgt_ep,
+			    DAOS_OBJ_RPC_TGT_UPDATE, &req);
+	if (rc != 0) {
+		D_ERROR("crt_req_create failed, rc %d.\n", rc);
+		D_GOTO(out, rc);
+	}
+
+	orw_parent = crt_req_get(parent_req);
+	orw = crt_req_get(req);
+	*orw = *orw_parent;
+	orw->orw_oid.id_shard = shard_arg->exec_shard_tgt->st_shard;
+	uuid_copy(orw->orw_co_hdl, orw_parent->orw_co_hdl);
+	uuid_copy(orw->orw_co_uuid, orw_parent->orw_co_uuid);
+	orw->orw_shard_tgts.ca_count	= 0;
+	orw->orw_shard_tgts.ca_arrays	= NULL;
+	orw->orw_flags |= ORF_BULK_BIND | obj_exec_arg->flags;
+	if (!srv_enable_dtx)
+		orw->orw_flags |= ORF_DTX_DISABLED;
+	orw->orw_dti_cos.ca_count	= dth->dth_dti_cos_count;
+	orw->orw_dti_cos.ca_arrays	= dth->dth_dti_cos;
+
+	D_DEBUG(DB_TRACE, DF_UOID" forwarding to rank:%d tag:%d.\n",
+		DP_UOID(orw->orw_oid), tgt_ep.ep_rank, tgt_ep.ep_tag);
+	rc = crt_req_send(req, shard_update_req_cb, remote_arg);
+	if (rc != 0) {
+		D_ERROR("crt_req_send failed, rc %d.\n", rc);
+		crt_req_decref(req);
+		D_GOTO(out, rc);
+	}
+
+out:
+	if (rc) {
+		shard_arg->exec_shard_rc = rc;
+		if (comp_cb != NULL)
+			comp_cb(cb_arg, rc);
+		if (remote_arg) {
+			if (remote_arg->parent_req)
+				crt_req_decref(remote_arg->parent_req);
+			D_FREE_PTR(remote_arg);
+		}
+	}
+	return rc;
+}
+
+static void
+shard_punch_req_cb(const struct crt_cb_info *cb_info)
+{
+	crt_rpc_t			*req = cb_info->cci_rpc;
+	struct obj_remote_cb_arg	*arg = cb_info->cci_arg;
+	crt_rpc_t			*parent_req = arg->parent_req;
+	struct dtx_exec_shard_arg	*shard_arg = arg->shard_arg;
+	struct obj_punch_out		*opo = crt_reply_get(req);
+	struct obj_punch_in		*opi_parent = crt_req_get(req);
+	int				rc = cb_info->cci_rc;
+	int				rc1 = 0;
+
+	if (opi_parent->opi_map_ver < opo->opo_map_version) {
+		D_DEBUG(DB_IO, DF_UOID": map_ver stale (%d < %d).\n",
+			DP_UOID(opi_parent->opi_oid), opi_parent->opi_map_ver,
+			opo->opo_map_version);
+		rc1 = -DER_STALE;
+	} else {
+		rc1 = opo->opo_ret;
+		if (rc1 == -DER_INPROGRESS) {
+			daos_dti_copy(&shard_arg->exec_dce.dce_xid,
+				      &opo->opo_dti_conflict);
+			shard_arg->exec_dce.dce_dkey = opo->opo_dkey_conflict;
+		}
+	}
+
+	if (rc >= 0)
+		rc = rc1;
+
+	if (arg->comp_cb)
+		arg->comp_cb(arg->cb_arg, rc);
+
+	crt_req_decref(parent_req);
+	D_FREE_PTR(arg);
+}
+
+/* Execute punch on the remote target */
+int
+ds_obj_remote_punch(struct dtx_handle *dth, void *data, int idx,
+		    dtx_exec_shard_comp_cb_t comp_cb, void *cb_arg)
+{
+	struct ds_obj_exec_arg		*obj_exec_arg = data;
+	struct dtx_exec_arg		*arg = dth->dth_exec_arg;
+	struct daos_shard_tgt		*shard_tgt;
+	struct dtx_exec_shard_arg	*shard_arg;
+	struct obj_remote_cb_arg	*remote_arg;
+	crt_endpoint_t			 tgt_ep;
+	crt_rpc_t			*parent_req = obj_exec_arg->rpc;
+	crt_rpc_t			*req;
+	struct obj_punch_in		*opi;
+	struct obj_punch_in		*opi_parent;
+	crt_opcode_t			opc;
+	int				rc = 0;
+
+	D_ASSERT(arg != NULL);
+	D_ASSERT(idx < arg->shard_cnt);
+	shard_arg = &arg->exec_shards_args[idx];
+	shard_tgt = shard_arg->exec_shard_tgt;
+	D_ALLOC_PTR(remote_arg);
+	if (remote_arg == NULL)
+		D_GOTO(out, rc = -DER_NOMEM);
+
+	tgt_ep.ep_grp = NULL;
+	tgt_ep.ep_rank = shard_tgt->st_rank;
+	tgt_ep.ep_tag = shard_tgt->st_tgt_idx;
+
+	remote_arg->comp_cb = comp_cb;
+	remote_arg->cb_arg = cb_arg;
+	remote_arg->shard_arg = shard_arg;
+	crt_req_addref(parent_req);
+	remote_arg->parent_req = parent_req;
+	if (opc_get(parent_req->cr_opc) == DAOS_OBJ_RPC_PUNCH)
+		opc = DAOS_OBJ_RPC_TGT_PUNCH;
+	else if (opc_get(parent_req->cr_opc) == DAOS_OBJ_RPC_TGT_PUNCH_DKEYS)
+		opc = DAOS_OBJ_RPC_TGT_PUNCH_DKEYS;
+	else
+		opc = DAOS_OBJ_RPC_TGT_PUNCH_AKEYS;
+
+	rc = obj_req_create(dss_get_module_info()->dmi_ctx, &tgt_ep, opc, &req);
+	if (rc != 0) {
+		D_ERROR("crt_req_create failed, rc %d.\n", rc);
+		D_GOTO(out, rc);
+	}
+
+	opi_parent = crt_req_get(parent_req);
+	opi = crt_req_get(req);
+	*opi = *opi_parent;
+	opi->opi_oid.id_shard = shard_arg->exec_shard_tgt->st_shard;
+	uuid_copy(opi->opi_co_hdl, opi_parent->opi_co_hdl);
+	uuid_copy(opi->opi_co_uuid, opi_parent->opi_co_uuid);
+	opi->opi_shard_tgts.ca_count = 0;
+	opi->opi_shard_tgts.ca_arrays = NULL;
+	opi->opi_flags |= obj_exec_arg->flags;
+	if (!srv_enable_dtx)
+		opi->opi_flags |= ORF_DTX_DISABLED;
+	opi->opi_dti_cos.ca_count = dth->dth_dti_cos_count;
+	opi->opi_dti_cos.ca_arrays = dth->dth_dti_cos;
+
+	D_DEBUG(DB_TRACE, DF_UOID" forwarding to rank:%d tag:%d.\n",
+		DP_UOID(opi->opi_oid), tgt_ep.ep_rank, tgt_ep.ep_tag);
+
+	rc = crt_req_send(req, shard_punch_req_cb, remote_arg);
+	if (rc != 0) {
+		D_ERROR("crt_req_send failed, rc %d.\n", rc);
+		crt_req_decref(req);
+		D_GOTO(out, rc);
+	}
+
+out:
+	if (rc) {
+		shard_arg->exec_shard_rc = rc;
+		rc = dss_abterr2der(rc);
+		if (comp_cb != NULL)
+			comp_cb(cb_arg, rc);
+		if (remote_arg) {
+			if (remote_arg->parent_req)
+				crt_req_decref(remote_arg->parent_req);
+			D_FREE_PTR(remote_arg);
+		}
+	}
+	return rc;
+}

--- a/src/rebuild/initiator.c
+++ b/src/rebuild/initiator.c
@@ -737,7 +737,8 @@ rebuild_obj_punch_one(void *data)
 	D_ASSERT(rc == 0);
 
 	rc = vos_obj_punch(cont->sc_hdl, arg->oid, arg->epoch,
-			   arg->rpt->rt_rebuild_ver, 0, NULL, 0, NULL, NULL);
+			   arg->rpt->rt_rebuild_ver, VOS_OF_REPLAY_PC,
+			   NULL, 0, NULL, NULL);
 	ds_cont_child_put(cont);
 	if (rc)
 		D_ERROR(DF_UOID" rebuild punch failed rc %d\n",


### PR DESCRIPTION
Cleanup the IO stack to EC

1. Move some distribute transaction stuff to
dtx to make IO processing clearer.

2. Some code cleanup for IO RPC processing.

Signed-off-by: Wang Di <di.wang@intel.com>