### PR TITLE
DAOS-2405 test: fix a bug in daos_perf echo mode

### DIFF
--- a/src/tests/daos_perf.c
+++ b/src/tests/daos_perf.c
@@ -306,7 +306,7 @@ objects_update(d_rank_t rank)
 		if (ts_class == DAOS_OC_R2S_SPEC_RANK)
 			ts_oid = dts_oid_set_rank(ts_oid, rank);
 
-		if (ts_mode == TS_MODE_DAOS) {
+		if (ts_mode == TS_MODE_DAOS || ts_mode == TS_MODE_ECHO) {
 			rc = daos_obj_open(ts_ctx.tsc_coh, ts_oid,
 					   DAOS_OO_RW, &ts_ohs[i], NULL);
 			if (rc) {


### PR DESCRIPTION
need to open obj for echo mode, or will get such error:
ERR  src/gurt/hash.c:1080 d_hhash_link_lookup() invalid PTR type key
being lookup in a non ptr-based htable.

Signed-off-by: Xuezhao Liu <xuezhao.liu@intel.com>