### PR TITLE
DAOS-2406 vos: not unhash container until zero-referenced

### DIFF
--- a/src/vos/tests/vts_io.c
+++ b/src/vos/tests/vts_io.c
@@ -482,8 +482,9 @@ io_obj_iter_test(struct io_test_args *arg, daos_epoch_range_t *epr,
 }
 
 int
-io_test_obj_update(struct io_test_args *arg, int epoch, daos_key_t *dkey,
-		   daos_iod_t *iod, daos_sg_list_t *sgl, bool verbose)
+io_test_obj_update(struct io_test_args *arg, daos_epoch_t epoch,
+		   daos_key_t *dkey, daos_iod_t *iod, daos_sg_list_t *sgl,
+		   bool verbose)
 {
 	struct bio_sglist	*bsgl;
 	struct bio_iov		*biov;
@@ -537,8 +538,9 @@ end:
 }
 
 int
-io_test_obj_fetch(struct io_test_args *arg, int epoch, daos_key_t *dkey,
-		  daos_iod_t *iod, daos_sg_list_t *sgl, bool verbose)
+io_test_obj_fetch(struct io_test_args *arg, daos_epoch_t epoch,
+		  daos_key_t *dkey, daos_iod_t *iod, daos_sg_list_t *sgl,
+		  bool verbose)
 {
 	struct bio_sglist *bsgl;
 	struct bio_iov	*biov;

--- a/src/vos/tests/vts_io.h
+++ b/src/vos/tests/vts_io.h
@@ -107,12 +107,12 @@ void			inc_cntr(unsigned long op_flags);
 void			test_args_reset(struct io_test_args *args,
 					uint64_t pool_size);
 int			io_test_obj_update(struct io_test_args *arg,
-					   int epoch, daos_key_t *dkey,
+					   daos_epoch_t epoch, daos_key_t *dkey,
 					   daos_iod_t *iod,
 					   daos_sg_list_t *sgl,
 					   bool verbose);
 int			io_test_obj_fetch(struct io_test_args *arg,
-					  int epoch, daos_key_t *dkey,
+					  daos_epoch_t epoch, daos_key_t *dkey,
 					  daos_iod_t *iod,
 					  daos_sg_list_t *sgl,
 					  bool verbose);

--- a/src/vos/vos_common.c
+++ b/src/vos/vos_common.c
@@ -132,7 +132,7 @@ vos_imem_strts_create(struct vos_imem_strts *imem_inst)
 		goto failed;
 	}
 
-	rc = d_uhash_create(0 /* no locking */, VOS_CONT_HHASH_BITS,
+	rc = d_uhash_create(D_HASH_FT_EPHEMERAL, VOS_CONT_HHASH_BITS,
 			    &imem_inst->vis_cont_hhash);
 	if (rc) {
 		D_ERROR("Error in creating CONT ref hash: %d\n", rc);

--- a/src/vos/vos_container.c
+++ b/src/vos/vos_container.c
@@ -194,6 +194,8 @@ cont_free(struct d_ulink *ulink)
 	int			 i;
 
 	cont = container_of(ulink, struct vos_container, vc_uhlink);
+	D_ASSERT(cont->vc_open_count == 0);
+
 	if (!daos_handle_is_inval(cont->vc_dtx_cos_hdl))
 		dbtree_destroy(cont->vc_dtx_cos_hdl);
 	D_ASSERT(d_list_empty(&cont->vc_dtx_committable));
@@ -261,13 +263,6 @@ static void
 cont_addref(struct vos_container *cont)
 {
 	d_uhash_link_addref(vos_cont_hhash_get(), &cont->vc_uhlink);
-}
-
-static int
-cont_close(struct vos_container *cont)
-{
-	d_uhash_link_delete(vos_cont_hhash_get(), &cont->vc_uhlink);
-	return 0;
 }
 
 /**
@@ -345,7 +340,10 @@ vos_cont_open(daos_handle_t poh, uuid_t co_uuid, daos_handle_t *coh)
 	 */
 	rc = cont_lookup(&ukey, &pkey, &cont);
 	if (rc == 0) {
-		D_DEBUG(DB_TRACE, "Found handle in DRAM UUID hash\n");
+		cont->vc_open_count++;
+		D_DEBUG(DB_TRACE, "Found handle for cont "DF_UUID
+			" in DRAM hash table, open count: %d\n",
+			DP_UUID(co_uuid), cont->vc_open_count);
 		*coh = vos_cont2hdl(cont);
 		D_GOTO(exit, rc);
 	}
@@ -425,9 +423,14 @@ vos_cont_open(daos_handle_t poh, uuid_t co_uuid, daos_handle_t *coh)
 	}
 
 	rc = cont_insert(cont, &ukey, &pkey, coh);
-	if (rc) {
+	if (rc != 0) {
 		D_ERROR("Error inserting vos container handle to uuid hash\n");
-		D_GOTO(exit, rc);
+	} else {
+		cont->vc_open_count = 1;
+
+		D_DEBUG(DB_TRACE, "Inert cont "DF_UUID" into hash table.\n",
+			DP_UUID(cont->vc_id));
+
 	}
 
 exit:
@@ -451,8 +454,16 @@ vos_cont_close(daos_handle_t coh)
 		return -DER_NO_HDL;
 	}
 
-	vos_obj_cache_evict(vos_obj_cache_current(), cont);
-	cont_close(cont);
+	D_ASSERTF(cont->vc_open_count > 0, "Invalid close, open count %d\n",
+		  cont->vc_open_count);
+
+	cont->vc_open_count--;
+	if (cont->vc_open_count == 0)
+		vos_obj_cache_evict(vos_obj_cache_current(), cont);
+
+	D_DEBUG(DB_TRACE, "Close cont "DF_UUID", open count: %d\n",
+		DP_UUID(cont->vc_id), cont->vc_open_count);
+
 	cont_decref(cont);
 
 	return 0;
@@ -507,9 +518,19 @@ vos_cont_destroy(daos_handle_t poh, uuid_t co_uuid)
 
 	rc = cont_lookup(&key, &pkey, &cont);
 	if (rc != -DER_NONEXIST) {
-		D_ERROR("Open reference exists, cannot destroy\n");
-		cont_decref(cont);
-		D_GOTO(exit, rc = -DER_BUSY);
+		D_ASSERT(rc == 0);
+
+		if (cont->vc_open_count == 0) {
+			d_uhash_link_delete(vos_cont_hhash_get(),
+					    &cont->vc_uhlink);
+			cont_decref(cont);
+		} else {
+			D_ERROR("Open reference exists for cont "DF_UUID
+				", cannot destroy, open count: %d\n",
+				DP_UUID(co_uuid), cont->vc_open_count);
+			cont_decref(cont);
+			D_GOTO(exit, rc = -DER_BUSY);
+		}
 	}
 
 	rc = cont_df_lookup(vpool, &key, &args);

--- a/src/vos/vos_internal.h
+++ b/src/vos/vos_internal.h
@@ -141,6 +141,7 @@ struct vos_container {
 	/* Various flags */
 	unsigned int		vc_in_aggregation:1,
 				vc_abort_aggregation:1;
+	unsigned int		vc_open_count;
 };
 
 struct vos_imem_strts {


### PR DESCRIPTION
The vos_cont_close() should not remove the vos_container
from DRAM hash table. Otherwise, if some others are using
such vos_container, then subsequent vos_cont_open() will
create new vos_container instance in DRAM. That will cause
multiple instances in DRAM for the same container. Because
some DTX relataed stuff, such as the DTX CoS cache and DTX
table handle, are attached to the vos_containder, if there
are multiple vos_container instances, then it will cause
DTX related trouble. For example, the committable DTXs in
CoS cache may be discarded.

So let's keep the vos_container in the DRAM hash table
until nobody references it.

Signed-off-by: Fan Yong <fan.yong@intel.com>