### PR TITLE
DAOS-2317 placement: set po_fseq properly

### DIFF
--- a/src/placement/ring_map.c
+++ b/src/placement/ring_map.c
@@ -1191,7 +1191,24 @@ next_fail:
 		if (spare_avail) {
 			/* The selected spare target is up and ready */
 			l_shard->po_target = spare_tgt->ta_comp.co_id;
-			l_shard->po_fseq = spare_tgt->ta_comp.co_fseq;
+
+			/* XXX: Use pl_obj_shard::po_fseq to record the latest
+			 *	failure sequence of the targets on the remap
+			 *	chain for the given shard (@l_shard).
+			 *
+			 *	The f_shard->rfs_fseq is the snapshot of the
+			 *	pool map version (that is incremental only)
+			 *	when related spare (or the original target)
+			 *	became down.
+			 *
+			 *	Currently, DAOS does not support the target
+			 *	re-integration. So the failure sequence for
+			 *	available spares will be the initial value
+			 *	(the oldest one). So here, we only need to
+			 *	consider those unavailable spares's failure
+			 *	sequences to find out the latest (largest).
+			 */
+			l_shard->po_fseq = f_shard->rfs_fseq;
 
 			/*
 			 * Mark the shard as 'rebuilding' so that read will


### PR DESCRIPTION
pl_obj_shard::po_fseq records the latest failure sequence of the
whole remap chain for the given (failed) shard. On the other hand,
the target (spare_tgt) failure sequence (co_fseq) is the snapshot
of the pool map version (that is incremental only) when the target
becomes down, so the latest failure sequence is also the larget one
for the targets on the whole remap chain.

The pl_obj_shard::po_fseq affects the DTX leader election decision:
currently, we elect the non-rebuilding shard with the lowest failure
sequence as the DTX leader.

Signed-off-by: Fan Yong <fan.yong@intel.com>