### PR TITLE
DAOS-2408 build: scons fixes for control component

### DIFF
--- a/src/control/SConscript
+++ b/src/control/SConscript
@@ -106,16 +106,14 @@ def scons():
     # CGO prerequisite libs for go-spdk bindings
     denv.AppendUnique(CPPPATH=[join(gospdkpath, "include")])
     # hack to avoid building this library with cov compiler for the moment
-    if denv.get('COMPILER').lower() == "covc":
-        nvmecontrol = denv.StaticLibrary(
-            "nvme_control",
-            join(gospdkpath, "src", "nvme_control.c"),
-            CC='gcc', LIBS=['spdk'])
-    else:
-        nvmecontrol = denv.StaticLibrary(
-            "nvme_control",
-            join(gospdkpath, "src", "nvme_control.c"),
-            LIBS=['spdk'])
+    compiler = denv.get('COMPILER').lower()
+    if compiler == "covc":
+        compiler = "gcc"
+
+    nvmecontrol = denv.StaticLibrary(
+        "nvme_control",
+        join(gospdkpath, "src", "nvme_control.c"),
+        CC=compiler, LIBS=['spdk'])
 
     denv.Install(join(denv.subst("$PREFIX"), "lib"), nvmecontrol)
 

--- a/src/control/SConscript
+++ b/src/control/SConscript
@@ -103,18 +103,26 @@ def scons():
     gospdkpath = join(gosrc, "vendor", "github.com", "daos-stack", "go-spdk",
                       "spdk")
 
-    # CGO prerequisite libs for nvme
+    # CGO prerequisite libs for go-spdk bindings
     denv.AppendUnique(CPPPATH=[join(gospdkpath, "include")])
-    nvmecontrol = denv.StaticLibrary(
-        "nvme_control",
-        join(gospdkpath, "src", "nvme_control.c"),
-        LIBS=['spdk'])
-    nc_installed = denv.Install(join(denv.subst("$PREFIX"), "lib"), nvmecontrol)
+    # hack to avoid building this library with cov compiler for the moment
+    if denv.get('COMPILER').lower() == "covc":
+        nvmecontrol = denv.StaticLibrary(
+            "nvme_control",
+            join(gospdkpath, "src", "nvme_control.c"),
+            CC='gcc', LIBS=['spdk'])
+    else:
+        nvmecontrol = denv.StaticLibrary(
+            "nvme_control",
+            join(gospdkpath, "src", "nvme_control.c"),
+            LIBS=['spdk'])
+
+    denv.Install(join(denv.subst("$PREFIX"), "lib"), nvmecontrol)
 
     # CGO shell env vars.
     denv.AppendENVPath(
         "CGO_LDFLAGS",
-        denv.subst("-L$SPDK_PREFIX/lib -L%s $_RPATH" % gopath))
+        denv.subst("-L%s -L$SPDK_PREFIX/lib $_RPATH" % gopath))
     denv.AppendENVPath(
         "CGO_CFLAGS",
         denv.subst("-I$SPDK_PREFIX/include"))


### PR DESCRIPTION
Fix to allow coverage build to complete without adding coverage
to libnvme_control.a for the moment (library is built with 'gcc'
rather than coverage specific compiler when coverage is enabled).

Change CGO_LDFLAGS to look in daos install dir before spdk install
dir when looking for libnvme_control.a. This results in finding newer
versions if they exist (when linking to C libs in Go binaries).

Signed-off-by: Tom Nabarro <tom.nabarro@intel.com>