### PR TITLE
DAOS-2279 dfuse: Fix hash table double entries and cleanup.

### DIFF
--- a/src/client/dfuse/dfuse_cont.c
+++ b/src/client/dfuse/dfuse_cont.c
@@ -33,7 +33,7 @@ dfuse_cont_open(fuse_req_t req, struct dfuse_inode_entry *parent,
 {
 	struct dfuse_projection_info	*fs_handle = fuse_req_userdata(req);
 	struct dfuse_inode_entry	*ie = NULL;
-	struct dfuse_dfs		*dfs = NULL;
+	struct dfuse_dfs		*dfs;
 	uuid_t				co_uuid;
 	dfs_t				*ddfs;
 	mode_t				mode;
@@ -45,9 +45,16 @@ dfuse_cont_open(fuse_req_t req, struct dfuse_inode_entry *parent,
 	 */
 	D_ASSERT(parent->ie_stat.st_ino == parent->ie_dfs->dffs_root);
 
+	/* Dentry names where are not valid uuids cannot possibly be added so in
+	 * this case return the negative dentry with a timeout to prevent future
+	 * lookups.
+	 */
 	if (uuid_parse(name, co_uuid) < 0) {
+		struct fuse_entry_param entry = {.entry_timeout = 60};
+
 		DFUSE_LOG_ERROR("Invalid container uuid");
-		D_GOTO(err, rc = ENOENT);
+		DFUSE_REPLY_ENTRY(req, entry);
+		return false;
 	}
 
 	D_ALLOC_PTR(dfs);

--- a/src/client/dfuse/dfuse_core.c
+++ b/src/client/dfuse/dfuse_core.c
@@ -110,10 +110,9 @@ ir_key_cmp(struct d_hash_table *htable, d_list_t *rlink,
 	}
 
 	/* Now check the container name */
-	if (ir->ir_id.irid_dfs->dffs_cont &&
-		(strncmp(ir->ir_id.irid_dfs->dffs_cont,
+	if (strncmp(ir->ir_id.irid_dfs->dffs_cont,
 		    ir_id->irid_dfs->dffs_cont,
-			NAME_MAX) != 0)) {
+			NAME_MAX) != 0) {
 		return false;
 	}
 

--- a/src/client/dfuse/dfuse_inode.c
+++ b/src/client/dfuse/dfuse_inode.c
@@ -23,6 +23,7 @@
 
 #include "dfuse_common.h"
 #include "dfuse.h"
+#include "daos_api.h"
 
 /* Lookup a unique inode for the specific dfs/oid combination */
 int
@@ -112,9 +113,43 @@ ie_close(struct dfuse_projection_info *fs_handle, struct dfuse_inode_entry *ie)
 		drop_ino_ref(fs_handle, ie->ie_parent);
 	}
 
-	rc = dfs_release(ie->ie_obj);
-	if (rc != -DER_SUCCESS) {
-		DFUSE_TRA_ERROR(ie, "dfs_release failed: %d", rc);
+	if (ie->ie_obj) {
+		rc = dfs_release(ie->ie_obj);
+		if (rc != -DER_SUCCESS) {
+			DFUSE_TRA_ERROR(ie, "dfs_release() failed: (%d)", rc);
+		}
 	}
+
+	if (ie->ie_stat.st_ino == ie->ie_dfs->dffs_root) {
+		DFUSE_TRA_INFO(ie, "Closing dfs_root %d %d",
+			       !daos_handle_is_inval(ie->ie_dfs->dffs_poh),
+			       !daos_handle_is_inval(ie->ie_dfs->dffs_coh));
+
+		if (!daos_handle_is_inval(ie->ie_dfs->dffs_coh)) {
+			rc = daos_cont_close(ie->ie_dfs->dffs_coh, NULL);
+			if (rc != -DER_SUCCESS) {
+				DFUSE_TRA_ERROR(ie,
+						"daos_cont_close() failed: (%d)",
+						rc);
+			}
+
+		} else if (!daos_handle_is_inval(ie->ie_dfs->dffs_poh)) {
+			rc = daos_pool_disconnect(ie->ie_dfs->dffs_poh, NULL);
+			if (rc != -DER_SUCCESS) {
+				DFUSE_TRA_ERROR(ie,
+						"daos_pool_disconnect() failed: (%d)",
+						rc);
+			}
+		}
+
+		/* TODO:
+		 * Check if this is correct, there could still be entries in
+		 * the inode record table which are keeping a pointer to this
+		 * value
+		 *
+		 * D_FREE(ie->ie_dfs);
+		 */
+	}
+
 	D_FREE(ie);
 }


### PR DESCRIPTION
Fix a bug where the entire key was being used in the hashing function
meaning that entries which should have matched weren't because of the
irir_dfs pointer.  Provide a hashing function which skips this part
to avoid the issue.  This was leading to multiple inodes being assigned
for containers, with different ones being used based on what pointer
value was allocated which caused lots of forget() calls.

Close containers and detach from pools in inode_close() if appropiate
which means that open handles are now no longer leaked on duplicate
lookups.

Add negative dentry caching of invalid uuids in both the root and
pools, as these entries cannot be valid instead of simply returning
ENOENT pass back an entry struct with a timeout of 60 seconds to
avoid duplicate lookups.