### PR TITLE
DAOS-1955 test: reduce VOS aggregate test time

### DIFF
--- a/src/vos/tests/vos_tests.c
+++ b/src/vos/tests/vos_tests.c
@@ -65,7 +65,7 @@ run_all_tests(int keys, bool nest_iterators)
 	for (i = 0; i != DAOS_OF_MASK; i++)
 		failed += run_io_test(i, keys, nest_iterators);
 	failed += run_discard_tests();
-	failed += run_aggregate_tests();
+	failed += run_aggregate_tests(false);
 	return failed;
 }
 
@@ -125,7 +125,7 @@ main(int argc, char **argv)
 							 nest_iterators);
 				break;
 			case 'a':
-				nr_failed += run_aggregate_tests();
+				nr_failed += run_aggregate_tests(true);
 				break;
 			case 'd':
 				nr_failed += run_discard_tests();
@@ -156,5 +156,3 @@ exit_0:
 	daos_debug_fini();
 	return nr_failed;
 }
-
-

--- a/src/vos/tests/vts_common.h
+++ b/src/vos/tests/vts_common.h
@@ -112,7 +112,7 @@ int
 run_discard_tests(void);
 
 int
-run_aggregate_tests(void);
+run_aggregate_tests(bool slow);
 
 int run_io_test(daos_ofeat_t feats, int keys, bool nest_iterators);
 


### PR DESCRIPTION
Use smaller dataset and repeat count to reduce VOS aggregate
test time when the tests are issued by 'vos_test -A'.

The default repeat count is shrunk from 10 to 5 as well.

Signed-off-by: Niu Yawei <yawei.niu@intel.com>
Change-Id: Iee20c9b1b57bfbfd481f2e8f06cda4217a189039