### PR TITLE
DAOS-2279 dfuse: Check for existing pool/cont connections on lookup.

### DIFF
--- a/src/client/dfuse/dfuse.h
+++ b/src/client/dfuse/dfuse.h
@@ -317,18 +317,6 @@ struct fuse_lowlevel_ops *dfuse_get_fuse_ops();
 					__rc, strerror(-__rc));		\
 	} while (0)
 
-#define DFUSE_FUSE_REPLY_STATFS(dfuse_req, stat)			\
-	do {								\
-		int __rc;						\
-		DFUSE_TRA_DEBUG(dfuse_req, "Returning statfs");	\
-		__rc = fuse_reply_statfs((dfuse_req)->req, stat);	\
-		if (__rc != 0)						\
-			DFUSE_TRA_ERROR(dfuse_req,			\
-					"fuse_reply_statfs returned %d:%s", \
-					__rc, strerror(-__rc));		\
-		DFUSE_TRA_DOWN(dfuse_req);				\
-	} while (0)
-
 #define DFUSE_REPLY_IOCTL(handle, req, gah_info)			\
 	do {								\
 		int __rc;						\
@@ -550,6 +538,11 @@ dfuse_lookup_inode(struct dfuse_projection_info *fs_handle,
 		   struct dfuse_dfs *dfs,
 		   daos_obj_id_t *oid,
 		   ino_t *_ino);
+
+int
+dfuse_check_for_inode(struct dfuse_projection_info *fs_handle,
+		      struct dfuse_dfs *dfs,
+		      struct dfuse_inode_entry **_entry);
 
 int
 find_inode(struct dfuse_request *);

--- a/src/client/dfuse/dfuse_cont.c
+++ b/src/client/dfuse/dfuse_cont.c
@@ -62,6 +62,7 @@ dfuse_cont_open(fuse_req_t req, struct dfuse_inode_entry *parent,
 		D_GOTO(err, rc = ENOMEM);
 	}
 	strncpy(dfs->dffs_cont, name, NAME_MAX);
+	strncpy(dfs->dffs_pool, parent->ie_dfs->dffs_pool, NAME_MAX);
 
 	if (create) {
 		rc = daos_cont_create(parent->ie_dfs->dffs_poh, co_uuid,
@@ -71,16 +72,39 @@ dfuse_cont_open(fuse_req_t req, struct dfuse_inode_entry *parent,
 					rc);
 			D_GOTO(err, 0);
 		}
+	} else {
+		rc = dfuse_check_for_inode(fs_handle, dfs, &ie);
+		if (rc == -DER_SUCCESS) {
+			struct fuse_entry_param	entry = {0};
+
+			DFUSE_TRA_INFO(ie,
+				       "Reusing existing container entry without reconnect");
+
+			D_FREE(dfs);
+
+			/* Update the stat information, but copy in the
+			 * inode value afterwards.
+			 */
+			rc = dfs_ostat(ie->ie_dfs->dffs_dfs,
+				       ie->ie_obj, &entry.attr);
+			if (rc != -DER_SUCCESS) {
+				DFUSE_TRA_ERROR(ie, "dfs_ostat() failed: (%d)",
+						rc);
+				D_GOTO(err, 0);
+			}
+
+			entry.attr.st_ino = ie->ie_stat.st_ino;
+			entry.generation = 1;
+			entry.ino = entry.attr.st_ino;
+			DFUSE_REPLY_ENTRY(req, entry);
+			return true;
+		}
 	}
 
 	rc = daos_cont_open(parent->ie_dfs->dffs_poh, co_uuid,
 			    DAOS_COO_RW, &dfs->dffs_coh, &dfs->dffs_co_info,
 			    NULL);
-	if (rc == -DER_NONEXIST) {
-		DFUSE_LOG_INFO("daos_cont_open() failed: (%d)",
-			       rc);
-		D_GOTO(err, rc = ENOENT);
-	} else if (rc != -DER_SUCCESS) {
+	if (rc != -DER_SUCCESS) {
 		DFUSE_LOG_ERROR("daos_cont_open() failed: (%d)",
 				rc);
 		D_GOTO(err, 0);

--- a/src/client/dfuse/dfuse_pool.c
+++ b/src/client/dfuse/dfuse_pool.c
@@ -63,6 +63,25 @@ dfuse_pool_lookup(fuse_req_t req, struct dfuse_inode_entry *parent,
 	}
 	strncpy(dfs->dffs_pool, name, NAME_MAX);
 
+	{
+		struct fuse_entry_param	entry = {0};
+
+		rc = dfuse_check_for_inode(fs_handle, dfs, &ie);
+		if (rc == -DER_SUCCESS) {
+
+			DFUSE_TRA_INFO(ie,
+				       "Reusing existing pool entry without reconnect");
+
+			D_FREE(dfs);
+
+			entry.attr = ie->ie_stat;
+			entry.generation = 1;
+			entry.ino = entry.attr.st_ino;
+			DFUSE_REPLY_ENTRY(req, entry);
+			return true;
+		}
+	}
+
 	rc = daos_pool_connect(pool_uuid, dfuse_info->dfi_dfd.group,
 			       dfuse_info->dfi_dfd.svcl, DAOS_PC_RW,
 			       &dfs->dffs_poh, &dfs->dffs_pool_info,

--- a/src/client/dfuse/ops/lookup.c
+++ b/src/client/dfuse/ops/lookup.c
@@ -113,11 +113,7 @@ dfuse_cb_lookup(fuse_req_t req, struct dfuse_inode_entry *parent,
 	if (rc != -DER_SUCCESS) {
 		DFUSE_TRA_INFO(fs_handle, "dfs_lookup() failed: %d",
 			       rc);
-		if (rc == -DER_NONEXIST) {
-			D_GOTO(err, rc = ENOENT);
-		} else {
-			D_GOTO(err, rc = EIO);
-		}
+		D_GOTO(err, 0);
 	}
 
 	strncpy(ie->ie_name, name, NAME_MAX);


### PR DESCRIPTION
When connecting to pools or opening containers check for existing entries
before, rather than after after extablishing new links.

For lookups of existing entries this is avoids opening, then closing
entries for every lookup.