### PR TITLE
DAOS-2299: Fix bug in daos_agent shutdown

### DIFF
--- a/src/tests/ftest/container/simple_create_delete_test.py
+++ b/src/tests/ftest/container/simple_create_delete_test.py
@@ -118,7 +118,7 @@ class SimpleCreateDeleteTest(TestWithoutServers):
                 pool.disconnect()
                 pool.destroy(1)
             if self.agent_sessions:
-                agent_utils.stop_agent(hostlist, self.agent_sessions)
+                agent_utils.stop_agent(self.agent_sessions)
             server_utils.stop_server(hosts=hostlist)
 
 if __name__ == "__main__":

--- a/src/tests/ftest/io/eight_servers.py
+++ b/src/tests/ftest/io/eight_servers.py
@@ -97,8 +97,8 @@ class EightServers(Test):
                 self.pool.destroy(1)
         finally:
             if self.agent_sessions:
-                agent_utils.stop_agent(self.hostlist_clients,
-                                       self.agent_sessions)
+                agent_utils.stop_agent(self.agent_sessions,
+                                       self.hostlist_clients)
             server_utils.stop_server(hosts=self.hostlist_servers)
 
     def executable(self, iorflags=None):
@@ -137,8 +137,8 @@ class EightServers(Test):
 
             pool_uuid = self.pool.get_uuid_str()
             svc_list = ""
-            for i in range(createsvc):
-                svc_list += str(int(self.pool.svc.rl_ranks[i])) + ":"
+            for item in range(createsvc):
+                svc_list += str(int(self.pool.svc.rl_ranks[item])) + ":"
             svc_list = svc_list[:-1]
 
             print ("svc_list: {}".format(svc_list))

--- a/src/tests/ftest/io/ior_single_server.py
+++ b/src/tests/ftest/io/ior_single_server.py
@@ -68,8 +68,8 @@ class IorSingleServer(Test):
         print("Host file clientsis: {}".format(self.hostfile_clients))
 
         self.agent_sessions = agent_utils.run_agent(self.basepath,
-                                                   self.hostlist_servers,
-                                                   self.hostlist_clients)
+                                                    self.hostlist_servers,
+                                                    self.hostlist_clients)
         server_utils.run_server(self.hostfile_servers, self.server_group,
                                 self.basepath)
 
@@ -86,8 +86,8 @@ class IorSingleServer(Test):
                 self.pool.destroy(1)
         finally:
             if self.agent_sessions:
-                agent_utils.stop_agent(self.hostlist_clients,
-                                      self.agent_sessions)
+                agent_utils.stop_agent(self.agent_sessions,
+                                       self.hostlist_clients)
             server_utils.stop_server(hosts=self.hostlist_servers)
 
     def test_singleserver(self):
@@ -124,9 +124,9 @@ class IorSingleServer(Test):
             print ("pool_uuid: {}".format(pool_uuid))
             tmp_rank_list = []
             svc_list = ""
-            for i in range(createsvc):
-                tmp_rank_list.append(int(self.pool.svc.rl_ranks[i]))
-                svc_list += str(tmp_rank_list[i]) + ":"
+            for item in range(createsvc):
+                tmp_rank_list.append(int(self.pool.svc.rl_ranks[item]))
+                svc_list += str(tmp_rank_list[item]) + ":"
             svc_list = svc_list[:-1]
 
             ior_utils.run_ior_daos(self.hostfile_clients, ior_flags, iteration,

--- a/src/tests/ftest/io/multiple_clients.py
+++ b/src/tests/ftest/io/multiple_clients.py
@@ -71,8 +71,8 @@ class MultipleClients(Test):
         print("Host file clientsis: {}".format(self.hostfile_clients))
 
         self.agent_sessions = agent_utils.run_agent(self.basepath,
-                                                   self.hostlist_servers,
-                                                   self.hostlist_clients)
+                                                    self.hostlist_servers,
+                                                    self.hostlist_clients)
         server_utils.run_server(self.hostfile_servers, self.server_group,
                                 self.basepath)
 
@@ -89,8 +89,8 @@ class MultipleClients(Test):
                 self.pool.destroy(1)
         finally:
             if self.agent_sessions:
-                agent_utils.stop_agent(self.hostlist_clients,
-                                      self.agent_sessions)
+                agent_utils.stop_agent(self.agent_sessions,
+                                       self.hostlist_clients)
             server_utils.stop_server(hosts=self.hostlist_servers)
 
     def test_multipleclients(self):
@@ -136,9 +136,9 @@ class MultipleClients(Test):
             pool_uuid = self.pool.get_uuid_str()
             tmp_rank_list = []
             svc_list = ""
-            for i in range(createsvc):
-                tmp_rank_list.append(int(self.pool.svc.rl_ranks[i]))
-                svc_list += str(tmp_rank_list[i]) + ":"
+            for item in range(createsvc):
+                tmp_rank_list.append(int(self.pool.svc.rl_ranks[item]))
+                svc_list += str(tmp_rank_list[item]) + ":"
             svc_list = svc_list[:-1]
 
             if slots == 8:

--- a/src/tests/ftest/io/romio.py
+++ b/src/tests/ftest/io/romio.py
@@ -83,8 +83,8 @@ class Romio(Test):
 
         # start servers
         self.agent_sessions = agent_utils.run_agent(self.basepath,
-                                                   self.hostlist_servers,
-                                                   self.hostlist_clients)
+                                                    self.hostlist_servers,
+                                                    self.hostlist_clients)
         server_utils.run_server(self.hostfile_servers, self.server_group,
                                 self.basepath)
 
@@ -92,7 +92,7 @@ class Romio(Test):
 
     def tearDown(self):
         if self.agent_sessions:
-            agent_utils.stop_agent(self.hostlist_clients, self.agent_sessions)
+            agent_utils.stop_agent(self.agent_sessions, self.hostlist_clients)
         server_utils.stop_server(hosts=self.hostlist_servers)
 
     def test_romio(self):

--- a/src/tests/ftest/io/seg_count.py
+++ b/src/tests/ftest/io/seg_count.py
@@ -91,8 +91,8 @@ class SegCount(Test):
                 self.pool.destroy(1)
         finally:
             if self.agent_sessions:
-                agent_utils.stop_agent(self.hostlist_clients,
-                                       self.agent_sessions)
+                agent_utils.stop_agent(self.agent_sessions,
+                                       self.hostlist_clients)
             server_utils.stop_server(hosts=self.hostlist_servers)
 
     def test_segcount(self):
@@ -158,8 +158,8 @@ class SegCount(Test):
 
             pool_uuid = self.pool.get_uuid_str()
             svc_list = ""
-            for i in range(createsvc):
-                svc_list += str(int(self.pool.svc.rl_ranks[i])) + ":"
+            for item in range(createsvc):
+                svc_list += str(int(self.pool.svc.rl_ranks[item])) + ":"
             svc_list = svc_list[:-1]
 
             ior_utils.run_ior(self.hostfile_clients, ior_flags, iteration,

--- a/src/tests/ftest/network/cart_self_test.py
+++ b/src/tests/ftest/network/cart_self_test.py
@@ -98,8 +98,7 @@ class CartSelfTest(TestWithoutServers):
             os.remove(self.uri_file)
         finally:
             if self.agent_sessions:
-                agent_utils.stop_agent(self.hostlist_servers,
-                                       self.agent_sessions)
+                agent_utils.stop_agent(self.agent_sessions)
             server_utils.stop_server(hosts=self.hostlist_servers)
             super(CartSelfTest, self).tearDown()
 

--- a/src/tests/ftest/object/object_integrity.py
+++ b/src/tests/ftest/object/object_integrity.py
@@ -111,7 +111,7 @@ class ObjectDataValidation(avocado.Test):
                 self.pool.destroy(1)
         finally:
             if self.agent_sessions:
-                agent_utils.stop_agent(self.hostlist, self.agent_sessions)
+                agent_utils.stop_agent(self.agent_sessions)
             server_utils.stop_server(hosts=self.hostlist)
 
     def reconnect(self):

--- a/src/tests/ftest/pool/bad_connect.py
+++ b/src/tests/ftest/pool/bad_connect.py
@@ -74,7 +74,7 @@ class BadConnectTest(Test):
 
     def tearDown(self):
         if self.agent_sessions:
-            agent_utils.stop_agent(self.hostlist_servers, self.agent_sessions)
+            agent_utils.stop_agent(self.agent_sessions)
         server_utils.stop_server(hosts=self.hostlist_servers)
 
     def test_connect(self):

--- a/src/tests/ftest/pool/bad_create.py
+++ b/src/tests/ftest/pool/bad_create.py
@@ -68,7 +68,7 @@ class BadCreateTest(Test):
 
     def tearDown(self):
         if self.agent_sessions:
-            agent_utils.stop_agent(self.hostlist_servers, self.agent_sessions)
+            agent_utils.stop_agent(self.agent_sessions)
         server_utils.stop_server(hosts=self.hostlist_servers)
 
     def test_create(self):

--- a/src/tests/ftest/pool/bad_evict.py
+++ b/src/tests/ftest/pool/bad_evict.py
@@ -69,7 +69,7 @@ class BadEvictTest(Test):
 
     def tearDown(self):
         if self.agent_sessions:
-            agent_utils.stop_agent(self.hostlist_servers, self.agent_sessions)
+            agent_utils.stop_agent(self.agent_sessions)
         server_utils.stop_server(hosts=self.hostlist_servers)
 
     def test_evict(self):
@@ -145,13 +145,13 @@ class BadEvictTest(Test):
             # trash the UUID value in various ways
             if excludeuuid is None:
                 saveduuid = (ctypes.c_ubyte * 16)(0)
-                for i in range(0, len(saveduuid)):
-                    saveduuid[i] = pool.uuid[i]
-                pool.uuid[0:] = [0 for i in range(0, len(pool.uuid))]
+                for item in range(0, len(saveduuid)):
+                    saveduuid[item] = pool.uuid[item]
+                pool.uuid[0:] = [0 for item in range(0, len(pool.uuid))]
             if excludeuuid == 'JUNK':
                 saveduuid = (ctypes.c_ubyte * 16)(0)
-                for i in range(0, len(saveduuid)):
-                    saveduuid[i] = pool.uuid[i]
+                for item in range(0, len(saveduuid)):
+                    saveduuid[item] = pool.uuid[item]
                 pool.uuid[4] = 244
 
             pool.evict()
@@ -171,8 +171,8 @@ class BadEvictTest(Test):
                 if savedgroup is not None:
                     pool.group = savedgroup
                 if saveduuid is not None:
-                    for i in range(0, len(saveduuid)):
-                        pool.uuid[i] = saveduuid[i]
+                    for item in range(0, len(saveduuid)):
+                        pool.uuid[item] = saveduuid[item]
                 if savedsvc is not None:
                     pool.svc = savedsvc
                 pool.destroy(1)

--- a/src/tests/ftest/pool/bad_exclude.py
+++ b/src/tests/ftest/pool/bad_exclude.py
@@ -68,7 +68,7 @@ class BadExcludeTest(Test):
 
     def tearDown(self):
         if self.agent_sessions:
-            agent_utils.stop_agent(self.hostlist_servers, self.agent_sessions)
+            agent_utils.stop_agent(self.agent_sessions)
         server_utils.stop_server(hosts=self.hostlist_servers)
 
     def test_exclude(self):

--- a/src/tests/ftest/pool/bad_query.py
+++ b/src/tests/ftest/pool/bad_query.py
@@ -66,7 +66,7 @@ class BadQueryTest(Test):
 
     def tearDown(self):
         if self.agent_sessions:
-            agent_utils.stop_agent(self.hostlist_servers, self.agent_sessions)
+            agent_utils.stop_agent(self.agent_sessions)
         server_utils.stop_server(hosts=self.hostlist_servers)
 
     def test_query(self):

--- a/src/tests/ftest/pool/destroy_rebuild.py
+++ b/src/tests/ftest/pool/destroy_rebuild.py
@@ -93,8 +93,7 @@ class DestroyRebuild(Test):
                 self.pool.destroy(1)
         finally:
             if self.agent_sessions:
-                agent_utils.stop_agent(self.hostlist_servers,
-                                       self.agent_sessions)
+                agent_utils.stop_agent(self.agent_sessions)
             server_utils.stop_server(hosts=self.hostlist_servers)
 
 

--- a/src/tests/ftest/pool/destroy_tests.py
+++ b/src/tests/ftest/pool/destroy_tests.py
@@ -139,8 +139,7 @@ class DestroyTests(Test):
                 os.remove(hostfile_servers)
             finally:
                 if self.agent_sessions:
-                    agent_utils.stop_agent(self.hostlist_servers,
-                                           self.agent_sessions)
+                    agent_utils.stop_agent(self.agent_sessions)
                 server_utils.stop_server(hosts=self.hostlist_servers)
 
     def test_delete_doesnt_exist(self):
@@ -186,8 +185,7 @@ class DestroyTests(Test):
         # no matter what happens shutdown the server
         finally:
             if self.agent_sessions:
-                agent_utils.stop_agent(self.hostlist_servers,
-                                       self.agent_sessions)
+                agent_utils.stop_agent(self.agent_sessions)
             server_utils.stop_server(hosts=self.hostlist_servers)
             os.remove(hostfile_servers)
 
@@ -257,8 +255,7 @@ class DestroyTests(Test):
         # no matter what happens shutdown the server
         finally:
             if self.agent_sessions:
-                agent_utils.stop_agent(self.hostlist_servers,
-                                       self.agent_sessions)
+                agent_utils.stop_agent(self.agent_sessions)
             server_utils.stop_server(hosts=self.hostlist_servers)
             os.remove(hostfile_servers)
 
@@ -334,8 +331,7 @@ class DestroyTests(Test):
         # no matter what happens shutdown the server
         finally:
             if self.agent_sessions:
-                agent_utils.stop_agent(self.hostlist_servers,
-                                       self.agent_sessions)
+                agent_utils.stop_agent(self.agent_sessions)
             server_utils.stop_server(hosts=self.hostlist_servers)
             os.remove(hostfile_servers)
 
@@ -420,11 +416,9 @@ class DestroyTests(Test):
         # no matter what happens shutdown the server
         finally:
             if self.agent_sessions:
-                agent_utils.stop_agent(self.hostlist_servers1,
-                                       self.agent_sessions)
+                agent_utils.stop_agent(self.agent_sessions)
             if self.agent_sessions2:
-                agent_utils.stop_agent(self.hostlist_servers2,
-                                       self.agent_sessions2)
+                agent_utils.stop_agent(self.agent_sessions2)
             server_utils.stop_server(hosts=self.hostlist_servers)
             os.remove(hostfile_servers1)
             os.remove(hostfile_servers2)
@@ -485,8 +479,7 @@ class DestroyTests(Test):
         # no matter what happens cleanup
         finally:
             if self.agent_sessions:
-                agent_utils.stop_agent(self.hostlist_servers,
-                                       self.agent_sessions)
+                agent_utils.stop_agent(self.agent_sessions)
             server_utils.stop_server(hosts=self.hostlist_servers)
             os.remove(hostfile_servers)
 
@@ -552,8 +545,7 @@ class DestroyTests(Test):
         # no matter what happens cleanup
         finally:
             if self.agent_sessions:
-                agent_utils.stop_agent(self.hostlist_servers,
-                                       self.agent_sessions)
+                agent_utils.stop_agent(self.agent_sessions)
             server_utils.stop_server(hosts=self.hostlist_servers)
             os.remove(hostfile_servers)
 
@@ -605,8 +597,7 @@ class DestroyTests(Test):
         # no matter what happens cleanup
         finally:
             if self.agent_sessions:
-                agent_utils.stop_agent(self.hostlist_servers,
-                                       self.agent_sessions)
+                agent_utils.stop_agent(self.agent_sessions)
             server_utils.stop_server(hosts=self.hostlist_servers)
             os.remove(hostfile_servers)
 
@@ -674,8 +665,7 @@ class DestroyTests(Test):
         # no matter what happens cleanup
         finally:
             if self.agent_sessions:
-                agent_utils.stop_agent(self.hostlist_servers,
-                                       self.agent_sessions)
+                agent_utils.stop_agent(self.agent_sessions)
             server_utils.stop_server(hosts=self.hostlist_servers)
             os.remove(hostfile_servers)
 
@@ -751,7 +741,6 @@ class DestroyTests(Test):
         # no matter what happens cleanup
         finally:
             if self.agent_sessions:
-                agent_utils.stop_agent(self.hostlist_servers,
-                                       self.agent_sessions)
+                agent_utils.stop_agent(self.agent_sessions)
             server_utils.stop_server(hosts=self.hostlist_servers)
             os.remove(hostfile_servers)

--- a/src/tests/ftest/pool/info_tests.py
+++ b/src/tests/ftest/pool/info_tests.py
@@ -68,8 +68,7 @@ class InfoTests(Test):
             os.remove(self.hostfile_servers)
         finally:
             if self.agent_sessions:
-                agent_utils.stop_agent(self.hostlist_servers,
-                                       self.agent_sessions)
+                agent_utils.stop_agent(self.agent_sessions)
             server_utils.stop_server(hosts=self.hostlist_servers)
 
     def test_simple_query(self):

--- a/src/tests/ftest/pool/multi_server_create_delete_test.py
+++ b/src/tests/ftest/pool/multi_server_create_delete_test.py
@@ -64,7 +64,7 @@ class MultiServerCreateDeleteTest(Test):
 
     def tearDown(self):
         if self.agent_sessions:
-            agent_utils.stop_agent(self.hostlist_servers, self.agent_sessions)
+            agent_utils.stop_agent(self.agent_sessions)
         server_utils.stop_server(hosts=self.hostlist_servers)
 
     def test_create(self):

--- a/src/tests/ftest/pool/multiple_creates_test.py
+++ b/src/tests/ftest/pool/multiple_creates_test.py
@@ -70,8 +70,7 @@ class MultipleCreatesTest(Test):
             os.remove(self.hostfile_servers)
         finally:
             if self.agent_sessions:
-                agent_utils.stop_agent(self.hostlist_servers,
-                                       self.agent_sessions)
+                agent_utils.stop_agent(self.agent_sessions)
             server_utils.stop_server(hosts=self.hostlist_servers)
 
     def test_create_one(self):

--- a/src/tests/ftest/pool/permission.py
+++ b/src/tests/ftest/pool/permission.py
@@ -77,8 +77,7 @@ class Permission(Test):
         finally:
             # stop servers
             if self.agent_sessions:
-                agent_utils.stop_agent(self.hostlist_servers,
-                                       self.agent_sessions)
+                agent_utils.stop_agent(self.agent_sessions)
             server_utils.stop_server(hosts=self.hostlist_servers)
 
     def test_connectpermission(self):

--- a/src/tests/ftest/pool/rebuild_with_io.py
+++ b/src/tests/ftest/pool/rebuild_with_io.py
@@ -158,6 +158,5 @@ class RebuildWithIO(TestWithoutServers):
                 check_for_pool.cleanup_pools(self.hostlist_servers)
             finally:
                 if self.agent_sessions:
-                    agent_utils.stop_agent(self.hostlist_servers,
-                                           self.agent_sessions)
+                    agent_utils.stop_agent(self.agent_sessions)
                 server_utils.kill_server(self.hostlist_servers)

--- a/src/tests/ftest/server/metadata.py
+++ b/src/tests/ftest/server/metadata.py
@@ -146,8 +146,8 @@ class ObjectMetadata(Test):
                 self.pool.destroy(1)
         finally:
             if self.agent_sessions:
-                agent_utils.stop_agent(self.hostlist_clients,
-                                       self.agent_sessions)
+                agent_utils.stop_agent(self.agent_sessions,
+                                       self.hostlist_clients)
             server_utils.stop_server(hosts=self.hostlist_servers)
 
     @skipForTicket("DAOS-1936/DAOS-1946")
@@ -269,7 +269,7 @@ class ObjectMetadata(Test):
 
         #Server Restart
         if self.agent_sessions:
-            agent_utils.stop_agent(self.hostlist_clients, self.agent_sessions)
+            agent_utils.stop_agent(self.agent_sessions, self.hostlist_clients)
         server_utils.stop_server(hosts=self.hostlist_servers)
         self.agent_sessions = agent_utils.run_agent(self.basepath,
                                                     self.hostlist_clients,

--- a/src/tests/ftest/util/agent_utils.py
+++ b/src/tests/ftest/util/agent_utils.py
@@ -159,7 +159,7 @@ def run_agent(basepath, server_list, client_list=None):
 # pylint: enable=too-many-locals
 
 
-def stop_agent(client_list, sessions):
+def stop_agent(sessions, client_list=None):
     """
     This should kill ssh and the agent.  This is temporary; presuming the
     agent will deamonize at somepoint and can be started killed more

--- a/src/tests/ftest/util/apricot/apricot/test.py
+++ b/src/tests/ftest/util/apricot/apricot/test.py
@@ -213,8 +213,8 @@ class TestWithServers(TestWithoutServers):
         try:
             if self.agent_sessions:
                 self.d_log.info("Stopping agents")
-                agent_utils.stop_agent(
-                    self.hostlist_clients, self.agent_sessions)
+                agent_utils.stop_agent(self.agent_sessions,
+                                       self.hostlist_clients)
         finally:
             self.d_log.info("Stopping servers")
             try:


### PR DESCRIPTION
Where there are no specific clients, the serverlist was being passed
to stop_agent() preventing it from using the local host as the client
to stop, such as it used when it started the client.