### PR TITLE
DAOS-2455 client: add daos_cont_aggregate()

### DIFF
--- a/src/client/api/container.c
+++ b/src/client/api/container.c
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2015, 2016 Intel Corporation.
+ * (C) Copyright 2015-2019 Intel Corporation.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -152,6 +152,25 @@ daos_cont_query(daos_handle_t coh, daos_cont_info_t *info,
 	args->coh	= coh;
 	args->info	= info;
 	args->prop	= cont_prop;
+
+	return dc_task_schedule(task, true);
+}
+
+int
+daos_cont_aggregate(daos_handle_t coh, daos_epoch_t epoch, daos_event_t *ev)
+{
+	daos_cont_aggregate_t	*args;
+	tse_task_t		*task;
+	int			 rc;
+
+	DAOS_API_ARG_ASSERT(*args, CONT_AGGREGATE);
+	rc = dc_task_create(dc_cont_aggregate, NULL, ev, &task);
+	if (rc)
+		return rc;
+
+	args = dc_task_get_args(task);
+	args->coh	= coh;
+	args->epoch	= epoch;
 
 	return dc_task_schedule(task, true);
 }

--- a/src/client/api/init.c
+++ b/src/client/api/init.c
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2016-2018 Intel Corporation.
+ * (C) Copyright 2016-2019 Intel Corporation.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -67,6 +67,7 @@ const struct daos_task_api dc_funcs[] = {
 	{dc_cont_close, sizeof(daos_cont_close_t)},
 	{dc_cont_destroy, sizeof(daos_cont_destroy_t)},
 	{dc_cont_query, sizeof(daos_cont_query_t)},
+	{dc_cont_aggregate, sizeof(daos_cont_aggregate_t)},
 	{dc_cont_rollback, sizeof(daos_cont_rollback_t)},
 	{dc_cont_subscribe, sizeof(daos_cont_subscribe_t)},
 	{dc_cont_list_attr, sizeof(daos_cont_list_attr_t)},

--- a/src/client/api/task_internal.h
+++ b/src/client/api/task_internal.h
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2017 Intel Corporation.
+ * (C) Copyright 2017-2019 Intel Corporation.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -54,6 +54,7 @@ struct daos_task_args {
 		daos_cont_close_t	cont_close;
 		daos_cont_destroy_t	cont_destory;
 		daos_cont_query_t	cont_query;
+		daos_cont_aggregate_t	cont_aggregate;
 		daos_cont_rollback_t	cont_rollback;
 		daos_cont_subscribe_t	cont_subscribe;
 		daos_cont_list_attr_t	cont_list_attr;

--- a/src/container/cli.c
+++ b/src/container/cli.c
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2016-2018 Intel Corporation.
+ * (C) Copyright 2016-2019 Intel Corporation.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -1769,6 +1769,23 @@ out:
 	D_DEBUG(DF_DSMC, "epoch op %u("DF_U64") failed: %d\n", opc,
 		epoch == NULL ? 0 : *epoch, rc);
 	return rc;
+}
+
+int
+dc_cont_aggregate(tse_task_t *task)
+{
+	daos_cont_aggregate_t	*args;
+
+	args = dc_task_get_args(task);
+	D_ASSERTF(args != NULL, "Task Argument OPC does not match DC OPC\n");
+
+	if (args->epoch == DAOS_EPOCH_MAX) {
+		D_ERROR("Invalid epoch: "DF_U64"\n", args->epoch);
+		tse_task_complete(task, -DER_INVAL);
+		return -DER_INVAL;
+	}
+
+	return dc_epoch_op(args->coh, CONT_EPOCH_AGGREGATE, &args->epoch, task);
 }
 
 int

--- a/src/container/rpc.h
+++ b/src/container/rpc.h
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2016-2018 Intel Corporation.
+ * (C) Copyright 2016-2019 Intel Corporation.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -77,6 +77,9 @@
 		0, &CQF_cont_epoch_op,					\
 		ds_cont_op_handler, NULL),				\
 	X(CONT_EPOCH_COMMIT,						\
+		0, &CQF_cont_epoch_op,					\
+		ds_cont_op_handler, NULL),				\
+	X(CONT_EPOCH_AGGREGATE,						\
 		0, &CQF_cont_epoch_op,					\
 		ds_cont_op_handler, NULL),				\
 	X(CONT_SNAP_LIST,						\

--- a/src/container/srv_container.c
+++ b/src/container/srv_container.c
@@ -1389,6 +1389,8 @@ cont_op_with_hdl(struct rdb_tx *tx, struct ds_pool_hdl *pool_hdl,
 	case CONT_EPOCH_COMMIT:
 		return ds_cont_epoch_commit(tx, pool_hdl, cont, hdl, rpc,
 					    false);
+	case CONT_EPOCH_AGGREGATE:
+		return ds_cont_epoch_aggregate(tx, pool_hdl, cont, hdl, rpc);
 	case CONT_SNAP_LIST:
 		return ds_cont_snap_list(tx, pool_hdl, cont, hdl, rpc);
 	case CONT_SNAP_CREATE:

--- a/src/container/srv_internal.h
+++ b/src/container/srv_internal.h
@@ -119,6 +119,9 @@ int ds_cont_epoch_discard(struct rdb_tx *tx, struct ds_pool_hdl *pool_hdl,
 int ds_cont_epoch_commit(struct rdb_tx *tx, struct ds_pool_hdl *pool_hdl,
 			 struct cont *cont, struct container_hdl *hdl,
 			 crt_rpc_t *rpc, bool snapshot);
+int ds_cont_epoch_aggregate(struct rdb_tx *tx, struct ds_pool_hdl *pool_hdl,
+			    struct cont *cont, struct container_hdl *hdl,
+			    crt_rpc_t *rpc);
 int ds_cont_snap_list(struct rdb_tx *tx, struct ds_pool_hdl *pool_hdl,
 		      struct cont *cont, struct container_hdl *hdl,
 		      crt_rpc_t *rpc);

--- a/src/include/daos/container.h
+++ b/src/include/daos/container.h
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2016 Intel Corporation.
+ * (C) Copyright 2016-2019 Intel Corporation.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -58,6 +58,7 @@ int dc_cont_open(tse_task_t *task);
 int dc_cont_close(tse_task_t *task);
 int dc_cont_destroy(tse_task_t *task);
 int dc_cont_query(tse_task_t *task);
+int dc_cont_aggregate(tse_task_t *task);
 int dc_cont_rollback(tse_task_t *task);
 int dc_cont_subscribe(tse_task_t *task);
 int dc_cont_list_attr(tse_task_t *task);

--- a/src/include/daos_api.h
+++ b/src/include/daos_api.h
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright 2015-2018 Intel Corporation.
+ * (C) Copyright 2015-2019 Intel Corporation.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -531,6 +531,18 @@ daos_cont_set_attr(daos_handle_t coh, int n, char const *const names[],
 int
 daos_cont_alloc_oids(daos_handle_t coh, daos_size_t num_oids, uint64_t *oid,
 		     daos_event_t *ev);
+
+/**
+ * Trigger aggregation to specified epoch
+ *
+ * \param[in]	coh	Container handle
+ * \param[in]	epoch	Epoch to be aggregated to. Current time will be used
+ *			when 0 is specified.
+ * \param[in]	ev	Completion event, it is optional and can be NULL.
+ *			The function will run in blocking mode if \a ev is NULL.
+ */
+int
+daos_cont_aggregate(daos_handle_t coh, daos_epoch_t epoch, daos_event_t *ev);
 
 /**
  * Rollback to a specific persistent snapshot.

--- a/src/include/daos_task.h
+++ b/src/include/daos_task.h
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2017-2018 Intel Corporation.
+ * (C) Copyright 2017-2019 Intel Corporation.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -69,6 +69,7 @@ typedef enum {
 	DAOS_OPC_CONT_CLOSE,
 	DAOS_OPC_CONT_DESTROY,
 	DAOS_OPC_CONT_QUERY,
+	DAOS_OPC_CONT_AGGREGATE,
 	DAOS_OPC_CONT_ROLLBACK,
 	DAOS_OPC_CONT_SUBSCRIBE,
 	DAOS_OPC_CONT_LIST_ATTR,
@@ -270,6 +271,11 @@ typedef struct {
 	daos_cont_info_t	*info;
 	daos_prop_t		*prop;
 } daos_cont_query_t;
+
+typedef struct {
+	daos_handle_t		coh;
+	daos_epoch_t		epoch;
+} daos_cont_aggregate_t;
 
 typedef struct {
 	daos_handle_t		coh;

--- a/src/utils/dcont.c
+++ b/src/utils/dcont.c
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2016 Intel Corporation.
+ * (C) Copyright 2016-2019 Intel Corporation.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -34,7 +34,8 @@ typedef int (*command_hdlr_t)(int, char *[]);
 enum cont_op {
 	CONT_CREATE,
 	CONT_DESTROY,
-	CONT_QUERY
+	CONT_QUERY,
+	CONT_AGGREGATE
 };
 
 static enum cont_op
@@ -46,6 +47,8 @@ cont_op_parse(const char *str)
 		return CONT_DESTROY;
 	else if (strcmp(str, "query") == 0)
 		return CONT_QUERY;
+	else if (strcmp(str, "aggregate") == 0)
+		return CONT_AGGREGATE;
 	assert(0);
 	return -1;
 }
@@ -59,6 +62,7 @@ cont_op_hdlr(int argc, char *argv[])
 		{"pool",	required_argument,	NULL, 'p'},
 		{"svc",		required_argument,	NULL, 'v'},
 		{"cont",	required_argument,	NULL, 'c'},
+		{"epoch",	required_argument,	NULL, 'e'},
 		{NULL,		0,			NULL,  0}
 	};
 	const char		*group = default_group;
@@ -70,6 +74,8 @@ cont_op_hdlr(int argc, char *argv[])
 	d_rank_list_t	*svc;
 	daos_cont_info_t	cont_info;
 	enum cont_op		op = cont_op_parse(argv[1]);
+	daos_epoch_t		epoch = 0;
+	char			*end;
 	int			rc;
 
 	uuid_clear(pool_uuid);
@@ -95,6 +101,14 @@ cont_op_hdlr(int argc, char *argv[])
 			if (uuid_parse(optarg, cont_uuid) != 0) {
 				fprintf(stderr,
 					"failed to parse cont UUID: %s\n",
+					optarg);
+				return 2;
+			}
+			break;
+		case 'e':
+			epoch = strtoul(optarg, &end, 10);
+			if (end == optarg || epoch == DAOS_EPOCH_MAX) {
+				fprintf(stderr, "invalid epoch: %s\n",
 					optarg);
 				return 2;
 			}
@@ -165,6 +179,13 @@ cont_op_hdlr(int argc, char *argv[])
 		}
 	}
 
+	if (op == CONT_AGGREGATE) {
+		rc = daos_cont_aggregate(coh, epoch, NULL);
+		if (rc != 0) {
+			fprintf(stderr, "cont aggregate failed: %d\n", rc);
+			return rc;
+		}
+	}
 
 	if (op != CONT_DESTROY) {
 		rc = daos_cont_close(coh, NULL);
@@ -203,6 +224,7 @@ commands:\n\
 	create        create a container\n\
 	destroy       destroy a conainer\n\
 	query         query a container\n\
+	aggregate     trigger aggregation for a container\n\
 	help          print this message and exit\n");
 
 	printf("\
@@ -226,6 +248,15 @@ query options:\n\
 	--group=STR   pool server process group (\"%s\")\n\
 	--svc=RANKS   pool service replicas like 1:2:3\n\
 	--cont=UUID   cont UUID\n", default_group);
+
+	printf("\
+aggregate options:\n\
+	--pool=UUID   pool UUID\n\
+	--group=STR   pool server process group (\"%s\")\n\
+	--svc=RANKS   pool service replicas like 1:2:3\n\
+	--epoch=EPC   the highest epoch to be aggregated to,\n\
+		      current time by default\n\
+	--cont=UUID   cont UUID\n", default_group);
 	return 0;
 }
 
@@ -242,6 +273,8 @@ main(int argc, char *argv[])
 	else if (strcmp(argv[1], "destroy") == 0)
 		hdlr = cont_op_hdlr;
 	else if (strcmp(argv[1], "query") == 0)
+		hdlr = cont_op_hdlr;
+	else if (strcmp(argv[1], "aggregate") == 0)
 		hdlr = cont_op_hdlr;
 
 	if (hdlr == NULL || hdlr == help_hdlr) {

--- a/src/vos/vos_aggregate.c
+++ b/src/vos/vos_aggregate.c
@@ -1461,6 +1461,11 @@ vos_aggregate_cb(daos_handle_t ih, vos_iter_entry_t *entry,
 	struct vos_container	*cont;
 	int			 rc;
 
+	cont = vos_hdl2cont(param->ip_hdl);
+	D_DEBUG(DB_EPC, DF_CONT": Aggregate, type:%d, is_discard:%d\n",
+		DP_CONT(cont->vc_pool->vp_id, cont->vc_id), type,
+		agg_param->ap_discard);
+
 	switch (type) {
 	case VOS_ITER_OBJ:
 		rc = vos_agg_obj(ih, entry, agg_param, acts);
@@ -1488,7 +1493,6 @@ vos_aggregate_cb(daos_handle_t ih, vos_iter_entry_t *entry,
 		return rc;
 	}
 
-	cont = vos_hdl2cont(param->ip_hdl);
 	if (cont->vc_abort_aggregation) {
 		D_DEBUG(DB_EPC, "VOS aggregation aborted\n");
 		cont->vc_abort_aggregation = 0;


### PR DESCRIPTION
Add daos_cont_aggregate() to trigger aggregation to specified epoch,
'dcont aggregate' is added to trigger aggregation manually.

Signed-off-by: Niu Yawei <yawei.niu@intel.com>
Change-Id: I430f8a69726bf8be000a3083875f458e46df0c3b