### PR TITLE
DAOS-2189 vos: Direct Key Hash when Checksum Enabled

### DIFF
--- a/src/common/btree.c
+++ b/src/common/btree.c
@@ -400,11 +400,11 @@ btr_hkey_size_const(btr_ops_t *ops, uint64_t feats)
 {
 	int size;
 
-	if (BTR_IS_DIRECT_KEY(feats) && BTR_IS_CSUM_ENABLED(feats))
-		return sizeof(umem_off_t) + ops->to_hkey_size();
-
-	if (BTR_IS_DIRECT_KEY(feats))
+	if (BTR_IS_DIRECT_KEY(feats)) {
+		if (BTR_IS_CSUM_ENABLED(feats))
+			return sizeof(umem_off_t) + ops->to_hkey_size();
 		return sizeof(umem_off_t);
+	}
 
 	if (BTR_IS_UINT_KEY(feats))
 		return sizeof(uint64_t);

--- a/src/include/daos/btree.h
+++ b/src/include/daos/btree.h
@@ -37,7 +37,7 @@
  * With Checksum enabled, direct key should still have a hash
  */
 struct btr_hash_direct {
-	umem_off_t		rec_node; /* direct key */
+	umem_off_t	rec_node;    /* direct key */
 	char		rec_hkey[0]; /* hashed key */
 };
 

--- a/src/include/daos/btree.h
+++ b/src/include/daos/btree.h
@@ -34,6 +34,14 @@
 #include <daos/mem.h>
 
 /**
+ * With Checksum enabled, direct key should still have a hash
+ */
+struct btr_hash_direct {
+	umem_off_t		rec_node; /* direct key */
+	char		rec_hkey[0]; /* hashed key */
+};
+
+/**
  * KV record of the btree.
  *
  * NB: could be PM data structure.
@@ -63,6 +71,7 @@ struct btr_record {
 		char			rec_hkey[0]; /* hashed key */
 		uint64_t		rec_ukey[0]; /* uint key */
 		umem_off_t		rec_node[0]; /* direct key */
+		struct btr_hash_direct	rec_hnode[0]; /* direct key with hash */
 	};
 };
 
@@ -531,6 +540,7 @@ enum btr_feats {
 	 * to_key_cmp callback
 	 */
 	BTR_FEAT_DIRECT_KEY		= (1 << 1),
+	BTR_FEAT_CSUM			= (1 << 2),
 };
 
 /**


### PR DESCRIPTION
Because the key hash function will be used for keys,
keys direct keys need to store the hash as well in
addition to the node

Signed-off-by: Ryon Jensen <ryon.jensen@intel.com>