### PR TITLE
DAOS-2482 dtx: initialize io mode on server side.

### DIFF
--- a/src/object/srv_mod.c
+++ b/src/object/srv_mod.c
@@ -40,8 +40,8 @@ bool srv_enable_dtx = true;
 static int
 obj_mod_init(void)
 {
-	uint32_t	mode;
-	int rc;
+	uint32_t	mode = DIM_DTX_FULL_ENABLED;
+	int		rc;
 
 	d_getenv_int("DAOS_IO_MODE", &mode);
 	if (mode != DIM_DTX_FULL_ENABLED) {


### PR DESCRIPTION
Currently it's not initialized to 0 to indicate to use full DTX by
default so it's acts compiler specific.

Signed-off-by: Mohamad Chaarawi <mohamad.chaarawi@intel.com>