### PR TITLE
CORCI-610 Run all Functional tests weekly on Saturdays

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -88,7 +88,8 @@ pipeline {
                     steps {
                         sconsBuild clean: "_build.external${arch}",
                                    scm: [url: 'https://github.com/daos-stack/daos.git',
-                                         branch: "master"],
+                                         branch: "master",
+                                         withSubmodules: true],
                                    failure_artifacts: 'config.log-centos7-gcc'
                         stash name: 'CentOS-install', includes: 'install/**'
                         stash name: 'CentOS-build-vars', includes: ".build_vars${arch}.*"


### PR DESCRIPTION
Done as a branch currently.  Once we have the ability to run
tests on the RPMs we build, this could move to a separate job/
repo.

Currently just running all tests.  Once we have an avocado tag
for weekly tests and have tests tagged with that tag we can
switch it.