### PR TITLE
DAOS-2498 vos: set iteration type earlier

### DIFF
--- a/src/vos/vos_container.c
+++ b/src/vos/vos_container.c
@@ -660,6 +660,7 @@ cont_iter_prep(vos_iter_type_t type, vos_iter_param_t *param,
 
 	vos_pool_addref(vpool);
 	co_iter->cot_pool = vpool;
+	co_iter->cot_iter.it_type = type;
 
 	rc = dbtree_iter_prepare(vpool->vp_cont_th, 0, &co_iter->cot_hdl);
 	if (rc)

--- a/src/vos/vos_dtx_iter.c
+++ b/src/vos/vos_dtx_iter.c
@@ -88,6 +88,7 @@ dtx_iter_prep(vos_iter_type_t type, vos_iter_param_t *param,
 	if (oiter == NULL)
 		return -DER_NOMEM;
 
+	oiter->oit_iter.it_type = type;
 	oiter->oit_cont = cont;
 	vos_cont_addref(cont);
 

--- a/src/vos/vos_iterator.c
+++ b/src/vos/vos_iterator.c
@@ -216,7 +216,8 @@ vos_iter_prepare(vos_iter_type_t type, vos_iter_param_t *param,
 		return rc;
 	}
 
-	iter->it_type		= type;
+	D_ASSERT(iter->it_type == type);
+
 	iter->it_ops		= dict->id_ops;
 	iter->it_state		= VOS_ITS_NONE;
 	iter->it_ref_cnt	= 1;

--- a/src/vos/vos_obj.c
+++ b/src/vos/vos_obj.c
@@ -929,6 +929,7 @@ vos_obj_iter_prep(vos_iter_type_t type, vos_iter_param_t *param,
 	if (oiter == NULL)
 		return -DER_NOMEM;
 
+	oiter->it_iter.it_type = type;
 	oiter->it_epr = param->ip_epr;
 	oiter->it_epc_expr = param->ip_epc_expr;
 	oiter->it_flags = param->ip_flags;

--- a/src/vos/vos_obj_index.c
+++ b/src/vos/vos_obj_index.c
@@ -476,6 +476,7 @@ oi_iter_prep(vos_iter_type_t type, vos_iter_param_t *param,
 	if (oiter == NULL)
 		return -DER_NOMEM;
 
+	oiter->oit_iter.it_type = type;
 	oiter->oit_epr  = param->ip_epr;
 	oiter->oit_cont = cont;
 	vos_cont_addref(cont);


### PR DESCRIPTION
The dtx_iter_fini() will be called by the dtx_iter_prep() before
set the iteration type for error handling. That will trigger the
dtx_iter_fini() ASSERT for the type check. So the dtx_iter_prep()
needs to set the iteration type some earlier before calling the
dtx_iter_fini() for error handling.

Similar issues for other iterations (such as cont, io) in VOS.

Signed-off-by: Fan Yong <fan.yong@intel.com>