### PR TITLE
Jbrosenz daos 1673

### DIFF
--- a/src/control/server/netdetect.go
+++ b/src/control/server/netdetect.go
@@ -27,8 +27,8 @@ import (
 	"github.com/daos-stack/daos/src/control/common"
 	"github.com/daos-stack/daos/src/control/log"
 	"github.com/pkg/errors"
-	"net"
 	"os/exec"
+	"net"
 	"strings"
 )
 
@@ -47,20 +47,21 @@ func detectTopology(path string) (string, error) {
 	args := []string{"--ignore", "core", "--ignore", "cache", "--ignore", "pu"}
 	out, err := exec.Command(cmd, args...).Output()
 
-	// If execution fails from the given path,
+	// If execution fails from the given path, 
 	// look for the lstopo application and try again
 	if err != nil {
-		out, err = exec.Command("which", "lstopo").Output()
+		out, err = exec.Command("which","lstopo").Output()
 		if err != nil {
-			log.Debugf("Unable to find lstopo.  Cannot detect topology.  Error: %v", err)
+			log.Debugf("Unable to find lstopo.  Cannot detect topology." +
+				"Error: %v", err)
 			return "", err
 		}
 
 		path := strings.SplitAfter(string(out), "lstopo")
 		out, err = exec.Command(path[0], args...).Output()
 		if err != nil {
-			log.Debugf("Uable to detect device topology.  Error: %v", err)
-			return "", err
+				log.Debugf("Uable to detect device topology.  Error: %v", err)
+				return "", err
 		}
 	}
 
@@ -71,7 +72,7 @@ func detectTopology(path string) (string, error) {
 // by the input string in the system topology obtained by detectTopology()
 // The input string has the form "device0,device1,...deviceN"
 // where 'device' specifies a network device such as "eth0", "eth1", or "ib0"
-// The return string has the form:
+// The return string has the form: 
 // "dev0:logical:physical,dev1:logical:physical,...devN:logical:physical"
 // where dev is the name of the network device, logical is the NUMA Node logical ID
 // and physical is the NUMA Node physical ID
@@ -97,7 +98,7 @@ func DetectNUMANodeForDevices(netNames string) (string, error) {
 
 	devices := strings.Split(netNames, ",")
 	deviceFound := make([]bool, len(devices))
-
+	
 	for i := 0; i < numNUMANodes; i++ {
 		if !strings.Contains(fields[i], "L#") {
 			return "", errors.New("invalid topology data: L# not found")
@@ -112,11 +113,13 @@ func DetectNUMANodeForDevices(netNames string) (string, error) {
 		physicalNodeStr = strings.Split(physicalNodeStr[1], " ")
 
 		for j := 0; j < len(devices); j++ {
-			if len(devices[j]) > 0 && !deviceFound[j] {
+			if len(devices[j]) > 0  && !deviceFound[j] {
 				srchStr := "\"" + devices[j] + "\""
 				if strings.Contains(fields[i], srchStr) {
-					numaDeviceStr += devices[j] + ":" + logicalNodeStr[0] + ":" + physicalNodeStr[0] + ","
-					// Mark the device as found so we don't look for it again in the remaining NUMANodes
+					numaDeviceStr += devices[j] + ":" + logicalNodeStr[0] + ":" +
+						physicalNodeStr[0] + ","
+					// Mark the device as found so we don't look for it
+					// again in the remaining NUMANodes
 					deviceFound[j] = true
 				}
 			}

--- a/src/control/server/netdetect.go
+++ b/src/control/server/netdetect.go
@@ -27,8 +27,8 @@ import (
 	"github.com/daos-stack/daos/src/control/common"
 	"github.com/daos-stack/daos/src/control/log"
 	"github.com/pkg/errors"
-	"os/exec"
 	"net"
+	"os/exec"
 	"strings"
 )
 
@@ -47,12 +47,12 @@ func detectTopology(path string) (string, error) {
 	args := []string{"--ignore", "core", "--ignore", "cache", "--ignore", "pu"}
 	out, err := exec.Command(cmd, args...).Output()
 
-	// If execution fails from the given path, 
+	// If execution fails from the given path,
 	// look for the lstopo application and try again
 	if err != nil {
-		out, err = exec.Command("which","lstopo").Output()
+		out, err = exec.Command("which", "lstopo").Output()
 		if err != nil {
-			log.Debugf("Unable to find lstopo.  Cannot detect topology." +
+			log.Debugf("Unable to find lstopo.  Cannot detect topology."+
 				"Error: %v", err)
 			return "", err
 		}
@@ -60,8 +60,8 @@ func detectTopology(path string) (string, error) {
 		path := strings.SplitAfter(string(out), "lstopo")
 		out, err = exec.Command(path[0], args...).Output()
 		if err != nil {
-				log.Debugf("Uable to detect device topology.  Error: %v", err)
-				return "", err
+			log.Debugf("Uable to detect device topology.  Error: %v", err)
+			return "", err
 		}
 	}
 
@@ -72,10 +72,10 @@ func detectTopology(path string) (string, error) {
 // by the input string in the system topology obtained by detectTopology()
 // The input string has the form "device0,device1,...deviceN"
 // where 'device' specifies a network device such as "eth0", "eth1", or "ib0"
-// The return string has the form: 
+// The return string has the form:
 // "dev0:logical:physical,dev1:logical:physical,...devN:logical:physical"
-// where dev is the name of the network device, logical is the NUMA Node logical ID
-// and physical is the NUMA Node physical ID
+// where dev is the name of the network device, logical is the NUMA Node
+// logical ID and physical is the NUMA Node physical ID
 // network device names that are not found in the topology are ignored.
 func DetectNUMANodeForDevices(netNames string) (string, error) {
 	var numaDeviceStr string
@@ -98,7 +98,7 @@ func DetectNUMANodeForDevices(netNames string) (string, error) {
 
 	devices := strings.Split(netNames, ",")
 	deviceFound := make([]bool, len(devices))
-	
+
 	for i := 0; i < numNUMANodes; i++ {
 		if !strings.Contains(fields[i], "L#") {
 			return "", errors.New("invalid topology data: L# not found")
@@ -113,11 +113,11 @@ func DetectNUMANodeForDevices(netNames string) (string, error) {
 		physicalNodeStr = strings.Split(physicalNodeStr[1], " ")
 
 		for j := 0; j < len(devices); j++ {
-			if len(devices[j]) > 0  && !deviceFound[j] {
+			if len(devices[j]) > 0 && !deviceFound[j] {
 				srchStr := "\"" + devices[j] + "\""
 				if strings.Contains(fields[i], srchStr) {
-					numaDeviceStr += devices[j] + ":" + logicalNodeStr[0] + ":" +
-						physicalNodeStr[0] + ","
+					numaDeviceStr += devices[j] + ":" + logicalNodeStr[0] +
+						":" + physicalNodeStr[0] + ","
 					// Mark the device as found so we don't look for it
 					// again in the remaining NUMANodes
 					deviceFound[j] = true

--- a/src/control/server/netdetect.go
+++ b/src/control/server/netdetect.go
@@ -1,0 +1,146 @@
+//
+// (C) Copyright 2019 Intel Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// GOVERNMENT LICENSE RIGHTS-OPEN SOURCE SOFTWARE
+// The Government's rights to use, modify, reproduce, release, perform, display,
+// or disclose this software are subject to the terms of the Apache License as
+// provided in Contract No. 8F-30005.
+// Any reproduction of computer software, computer software documentation, or
+// portions thereof marked with this legend must also reproduce the markings.
+//
+
+package main
+
+import (
+	"github.com/daos-stack/daos/src/control/common"
+	"github.com/daos-stack/daos/src/control/log"
+	"github.com/pkg/errors"
+	"net"
+	"os/exec"
+	"strings"
+)
+
+const applicationPath = "/bin/lstopo"
+
+// detectTopology uses lstopo application to retrieve the network device
+// topology for all NUMA Nodes found on this system.
+// Returns a string containing a hierarchical list of NUMA Nodes and any
+// network devices connected to them.  If the lstopo application cannot be
+// found at the given location, detectTopology() will search for it and
+// try again.
+
+// TODO -- pass in external interface for exec so this can be mocked
+func detectTopology(path string) (string, error) {
+	cmd, err := common.GetAbsInstallPath(path)
+	args := []string{"--ignore", "core", "--ignore", "cache", "--ignore", "pu"}
+	out, err := exec.Command(cmd, args...).Output()
+
+	// If execution fails from the given path,
+	// look for the lstopo application and try again
+	if err != nil {
+		out, err = exec.Command("which", "lstopo").Output()
+		if err != nil {
+			log.Debugf("Unable to find lstopo.  Cannot detect topology.  Error: %v", err)
+			return "", err
+		}
+
+		path := strings.SplitAfter(string(out), "lstopo")
+		out, err = exec.Command(path[0], args...).Output()
+		if err != nil {
+			log.Debugf("Uable to detect device topology.  Error: %v", err)
+			return "", err
+		}
+	}
+
+	return string(out), nil
+}
+
+// DetectNUMANodeForDevices will lookup each network device specified
+// by the input string in the system topology obtained by detectTopology()
+// The input string has the form "device0,device1,...deviceN"
+// where 'device' specifies a network device such as "eth0", "eth1", or "ib0"
+// The return string has the form:
+// "dev0:logical:physical,dev1:logical:physical,...devN:logical:physical"
+// where dev is the name of the network device, logical is the NUMA Node logical ID
+// and physical is the NUMA Node physical ID
+// network device names that are not found in the topology are ignored.
+func DetectNUMANodeForDevices(netNames string) (string, error) {
+	var numaDeviceStr string
+
+	hwlocStr, err := detectTopology(applicationPath)
+	if err != nil {
+		return "", err
+	}
+
+	if !strings.Contains(hwlocStr, "NUMANode") {
+		return numaDeviceStr, errors.New("the NUMA Node information not found")
+	}
+
+	numNUMANodes := strings.Count(hwlocStr, "NUMANode")
+
+	// Separate the string into fields representing each NUMA Node
+	fields := strings.Split(hwlocStr, "NUMANode")
+	// Skip past the header information
+	fields = fields[1:]
+
+	devices := strings.Split(netNames, ",")
+	deviceFound := make([]bool, len(devices))
+
+	for i := 0; i < numNUMANodes; i++ {
+		if !strings.Contains(fields[i], "L#") {
+			return "", errors.New("invalid topology data: L# not found")
+		}
+		logicalNodeStr := strings.SplitAfter(fields[i], "L#")
+		logicalNodeStr = strings.Split(logicalNodeStr[1], " ")
+
+		if !strings.Contains(fields[i], "P#") {
+			return "", errors.New("invalid topology:  P# not found")
+		}
+		physicalNodeStr := strings.SplitAfter(fields[i], "P#")
+		physicalNodeStr = strings.Split(physicalNodeStr[1], " ")
+
+		for j := 0; j < len(devices); j++ {
+			if len(devices[j]) > 0 && !deviceFound[j] {
+				srchStr := "\"" + devices[j] + "\""
+				if strings.Contains(fields[i], srchStr) {
+					numaDeviceStr += devices[j] + ":" + logicalNodeStr[0] + ":" + physicalNodeStr[0] + ","
+					// Mark the device as found so we don't look for it again in the remaining NUMANodes
+					deviceFound[j] = true
+				}
+			}
+		}
+	}
+
+	return strings.TrimSuffix(numaDeviceStr, ","), nil
+}
+
+// DetectNetworkDevices examines the network interfaces
+// and returns a string identifying them by name and has the form:
+// "device0,device1,...deviceN"
+func DetectNetworkDevices() (string, error) {
+	var netNames string
+	networkInterfaces, err := net.Interfaces()
+
+	if err != nil {
+		log.Debugf("Error while detecting network interfaces: %s", err)
+		return netNames, err
+	}
+
+	for _, i := range networkInterfaces {
+		netNames += i.Name + ","
+	}
+
+	return strings.TrimSuffix(netNames, ","), nil
+}

--- a/src/control/server/netdetect_test.go
+++ b/src/control/server/netdetect_test.go
@@ -268,6 +268,7 @@ func TestParseTopology(t *testing.T) {
 		if err != nil {
 			log.Debugf("error was not nil... %v", err)
 		}
-		AssertEqual(t, netAdapterAffinity, tt.expected, "unexected device found")
+		AssertEqual(t, netAdapterAffinity, tt.expected,
+			"unexpected mismatch with device and topology")
 	}
 }

--- a/src/control/server/netdetect_test.go
+++ b/src/control/server/netdetect_test.go
@@ -48,7 +48,7 @@ func TestParseTopology(t *testing.T) {
 			"\"hfi1_0\" HostBridge L#5 PCIBridge PCIBridge PCIBridge " +
 			"PCI 8086:37d2 Net L#5 \"eth0\" OpenFabrics L#6 \"i40iw1\"" +
 			"PCI 8086:37d2 Net L#7 \"eth1\" OpenFabrics L#8 \"i40iw0\"" +
-			"NUMANode L#1 (P#1 96GB) + Package L#1", 
+			"NUMANode L#1 (P#1 96GB) + Package L#1",
 			"ib0:0:0"},
 		// looks for one specific adapter in a good topology
 		{"eth0",
@@ -72,7 +72,7 @@ func TestParseTopology(t *testing.T) {
 			"\"hfi1_0\" HostBridge L#5 PCIBridge PCIBridge PCIBridge " +
 			"PCI 8086:37d2 Net L#5 \"eth0\" OpenFabrics L#6 \"i40iw1\"" +
 			"PCI 8086:37d2 Net L#7 \"eth1\" OpenFabrics L#8 \"i40iw0\"" +
-			"NUMANode L#1 (P#1 96GB) + Package L#1", 
+			"NUMANode L#1 (P#1 96GB) + Package L#1",
 			"eth1:0:0"},
 		// looks for three adapters in a good topology
 		{"eth0,eth1,ib0",
@@ -84,7 +84,7 @@ func TestParseTopology(t *testing.T) {
 			"\"hfi1_0\" HostBridge L#5 PCIBridge PCIBridge PCIBridge " +
 			"PCI 8086:37d2 Net L#5 \"eth0\" OpenFabrics L#6 \"i40iw1\"" +
 			"PCI 8086:37d2 Net L#7 \"eth1\" OpenFabrics L#8 \"i40iw0\"" +
-			"NUMANode L#1 (P#1 96GB) + Package L#1", 
+			"NUMANode L#1 (P#1 96GB) + Package L#1",
 			"eth0:0:0,eth1:0:0,ib0:0:0"},
 		// looks for three adaptors, where "ib1" isn't in the topology
 			{"eth0,eth1,ib1",
@@ -96,7 +96,7 @@ func TestParseTopology(t *testing.T) {
 			"\"hfi1_0\" HostBridge L#5 PCIBridge PCIBridge PCIBridge " +
 			"PCI 8086:37d2 Net L#5 \"eth0\" OpenFabrics L#6 \"i40iw1\"" +
 			"PCI 8086:37d2 Net L#7 \"eth1\" OpenFabrics L#8 \"i40iw0\"" +
-			"NUMANode L#1 (P#1 96GB) + Package L#1", 
+			"NUMANode L#1 (P#1 96GB) + Package L#1",
 			"eth0:0:0,eth1:0:0"},
 		// Test malformed adapter list
 		{"eth0:eth1:ib0",
@@ -108,7 +108,7 @@ func TestParseTopology(t *testing.T) {
 			"\"hfi1_0\" HostBridge L#5 PCIBridge PCIBridge PCIBridge " +
 			"PCI 8086:37d2 Net L#5 \"eth0\" OpenFabrics L#6 \"i40iw1\"" +
 			"PCI 8086:37d2 Net L#7 \"eth1\" OpenFabrics L#8 \"i40iw0\"" +
-			"NUMANode L#1 (P#1 96GB) + Package L#1", 
+			"NUMANode L#1 (P#1 96GB) + Package L#1",
 			""},
 		// Test malformed adapter list
 		{"eth0 eth1 ib0",
@@ -120,7 +120,7 @@ func TestParseTopology(t *testing.T) {
 			"\"hfi1_0\" HostBridge L#5 PCIBridge PCIBridge PCIBridge " +
 			"PCI 8086:37d2 Net L#5 \"eth0\" OpenFabrics L#6 \"i40iw1\"" +
 			"PCI 8086:37d2 Net L#7 \"eth1\" OpenFabrics L#8 \"i40iw0\"" +
-			"NUMANode L#1 (P#1 96GB) + Package L#1", 
+			"NUMANode L#1 (P#1 96GB) + Package L#1",
 			""},
 		// look for adaptor that doesn't show up in topology
 		{"lo",
@@ -132,7 +132,7 @@ func TestParseTopology(t *testing.T) {
 			"\"hfi1_0\" HostBridge L#5 PCIBridge PCIBridge PCIBridge " +
 			"PCI 8086:37d2 Net L#5 \"eth0\" OpenFabrics L#6 \"i40iw1\"" +
 			"PCI 8086:37d2 Net L#7 \"eth1\" OpenFabrics L#8 \"i40iw0\"" +
-			"NUMANode L#1 (P#1 96GB) + Package L#1", 
+			"NUMANode L#1 (P#1 96GB) + Package L#1",
 			""},
 		// Verifies that device is found on the correct NUMA node
 		{"eth0",
@@ -144,7 +144,7 @@ func TestParseTopology(t *testing.T) {
 			"\"hfi1_0\" HostBridge L#5 PCIBridge PCIBridge PCIBridge " +
 			"PCI 8086:37d2 Net L#5 \"eth0\" OpenFabrics L#6 \"i40iw1\"" +
 			"PCI 8086:37d2 Net L#7 \"eth1\" OpenFabrics L#8 \"i40iw0\"" +
-			"NUMANode L#1 (P#1 96GB) + Package L#1", 
+			"NUMANode L#1 (P#1 96GB) + Package L#1",
 			"eth0:1:0"},
 		// Verifies that device is found on correct NUMA node
 		{"eth0",
@@ -156,7 +156,7 @@ func TestParseTopology(t *testing.T) {
 			"\"hfi1_0\" HostBridge L#5 PCIBridge PCIBridge PCIBridge " +
 			"PCI 8086:37d2 Net L#5 \"eth0\" OpenFabrics L#6 \"i40iw1\"" +
 			"PCI 8086:37d2 Net L#7 \"eth1\" OpenFabrics L#8 \"i40iw0\"" +
-			"NUMANode L#2 (P#1 96GB) + Package L#1", 
+			"NUMANode L#2 (P#1 96GB) + Package L#1",
 			"eth0:1:1"},
 		// Verifies devices are found on correct NUMA nodes
 		{"eth0,eth1,ib0",
@@ -264,7 +264,6 @@ func TestParseTopology(t *testing.T) {
 		}
 
 	for _, tt := range tests {
-	
 		netAdapterAffinity, err := DetectNUMANodeForDevices(tt.netDevsList, tt.topology)
 		if err != nil {
 			log.Debugf("error was not nil... %v", err)
@@ -272,42 +271,3 @@ func TestParseTopology(t *testing.T) {
 		AssertEqual(t, netAdapterAffinity, tt.expected, "unexected device found")
 	}
 }
-
-/*
-func TestParseEnvVars(t *testing.T) {
-	// Obtain the default client configuration
-	config := NewConfiguration()
-
-	// Save the environment variable before we blow it away
-	original := config.ext.getenv(daosAgentDrpcSockEnv)
-
-	// Clear the environment variable.  Process them.
-	// Make sure there were none found and the default config value was preserved.
-	os.Setenv(daosAgentDrpcSockEnv, "")
-	res1 := config.ProcessEnvOverrides()
-	// Restore the environment to what it was before the test started
-	os.Setenv(daosAgentDrpcSockEnv, original)
-	AssertEqual(
-		t, res1, 0,
-		"clearing environment variable returned unexpected number of results")
-
-	AssertEqual(
-		t, config.RuntimeDir, defaultRuntimeDir,
-		"an empty environment variable failed to preserve default runtime socket path")
-
-	// Set the environment variable.  Process them.
-	// Make sure there was one found and that config value matches what we set it to.
-	os.Setenv(daosAgentDrpcSockEnv, testRuntimeDir)
-	res2 := config.ProcessEnvOverrides()
-	// Restore the environment to what it was before the test started
-	os.Setenv(daosAgentDrpcSockEnv, original)
-	AssertEqual(
-		t, res2, 1,
-		"setting environment variable returned unexpected number of results")
-
-	AssertEqual(
-		t, config.RuntimeDir, testRuntimeDir,
-		"setting environment variable failed to override default runtime socket path")
-
-}
-*/

--- a/src/control/server/netdetect_test.go
+++ b/src/control/server/netdetect_test.go
@@ -60,7 +60,7 @@ func TestParseTopology(t *testing.T) {
 			"\"hfi1_0\" HostBridge L#5 PCIBridge PCIBridge PCIBridge " +
 			"PCI 8086:37d2 Net L#5 \"eth0\" OpenFabrics L#6 \"i40iw1\"" +
 			"PCI 8086:37d2 Net L#7 \"eth1\" OpenFabrics L#8 \"i40iw0\"" +
-			"NUMANode L#1 (P#1 96GB) + Package L#1", 
+			"NUMANode L#1 (P#1 96GB) + Package L#1",
 			"eth0:0:0"},
 		// looks for one specific adapter in a good topology
 		{"eth1",

--- a/src/control/server/netdetect_test.go
+++ b/src/control/server/netdetect_test.go
@@ -1,0 +1,313 @@
+//
+// (C) Copyright 2019 Intel Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// GOVERNMENT LICENSE RIGHTS-OPEN SOURCE SOFTWARE
+// The Government's rights to use, modify, reproduce, release, perform, display,
+// or disclose this software are subject to the terms of the Apache License as
+// provided in Contract No. 8F-30005.
+// Any reproduction of computer software, computer software documentation, or
+// portions thereof marked with this legend must also reproduce the markings.
+//
+
+package main
+
+import (
+	"testing"
+	. "github.com/daos-stack/daos/src/control/common"
+	"github.com/daos-stack/daos/src/control/log"
+)
+
+func TestParseTopology(t *testing.T) {
+	tests := []struct {
+		netDevsList	string
+		topology	string
+		expected	string
+	}{
+		{"", "", ""},
+		// looks for one specific adatper in a bad topology
+		{"eth0", "", ""},
+		// looks for one specific adapter in a good topology
+		{"ib0",
+			"Machine (191GB total) NUMANode L#0 (P#0 95GB) " +
+			"Package L#0 HostBridge L#0 PCI 8086:a1d2 Block(Disk) L#0 " +
+			"\"sda\" PCI 8086:a182 PCIBridge PCIBridge PCI 1a03:2000 " +
+			"GPU L#1 \"card0\" GPU L#2 \"controlD64\" HostBridge L#3 " +
+			" PCIBridge PCI 8086:24f0 Net L#3 \"ib0\" OpenFabrics L#4 " +
+			"\"hfi1_0\" HostBridge L#5 PCIBridge PCIBridge PCIBridge " +
+			"PCI 8086:37d2 Net L#5 \"eth0\" OpenFabrics L#6 \"i40iw1\"" +
+			"PCI 8086:37d2 Net L#7 \"eth1\" OpenFabrics L#8 \"i40iw0\"" +
+			"NUMANode L#1 (P#1 96GB) + Package L#1", 
+			"ib0:0:0"},
+		// looks for one specific adapter in a good topology
+		{"eth0",
+			"Machine (191GB total) NUMANode L#0 (P#0 95GB) " +
+			"Package L#0 HostBridge L#0 PCI 8086:a1d2 Block(Disk) L#0 " +
+			"\"sda\" PCI 8086:a182 PCIBridge PCIBridge PCI 1a03:2000 " +
+			"GPU L#1 \"card0\" GPU L#2 \"controlD64\" HostBridge L#3 " +
+			" PCIBridge PCI 8086:24f0 Net L#3 \"ib0\" OpenFabrics L#4 " +
+			"\"hfi1_0\" HostBridge L#5 PCIBridge PCIBridge PCIBridge " +
+			"PCI 8086:37d2 Net L#5 \"eth0\" OpenFabrics L#6 \"i40iw1\"" +
+			"PCI 8086:37d2 Net L#7 \"eth1\" OpenFabrics L#8 \"i40iw0\"" +
+			"NUMANode L#1 (P#1 96GB) + Package L#1", 
+			"eth0:0:0"},
+		// looks for one specific adapter in a good topology
+		{"eth1",
+			"Machine (191GB total) NUMANode L#0 (P#0 95GB) " +
+			"Package L#0 HostBridge L#0 PCI 8086:a1d2 Block(Disk) L#0 " +
+			"\"sda\" PCI 8086:a182 PCIBridge PCIBridge PCI 1a03:2000 " +
+			"GPU L#1 \"card0\" GPU L#2 \"controlD64\" HostBridge L#3 " +
+			" PCIBridge PCI 8086:24f0 Net L#3 \"ib0\" OpenFabrics L#4 " +
+			"\"hfi1_0\" HostBridge L#5 PCIBridge PCIBridge PCIBridge " +
+			"PCI 8086:37d2 Net L#5 \"eth0\" OpenFabrics L#6 \"i40iw1\"" +
+			"PCI 8086:37d2 Net L#7 \"eth1\" OpenFabrics L#8 \"i40iw0\"" +
+			"NUMANode L#1 (P#1 96GB) + Package L#1", 
+			"eth1:0:0"},
+		// looks for three adapters in a good topology
+		{"eth0,eth1,ib0",
+			"Machine (191GB total) NUMANode L#0 (P#0 95GB) " +
+			"Package L#0 HostBridge L#0 PCI 8086:a1d2 Block(Disk) L#0 " +
+			"\"sda\" PCI 8086:a182 PCIBridge PCIBridge PCI 1a03:2000 " +
+			"GPU L#1 \"card0\" GPU L#2 \"controlD64\" HostBridge L#3 " +
+			" PCIBridge PCI 8086:24f0 Net L#3 \"ib0\" OpenFabrics L#4 " +
+			"\"hfi1_0\" HostBridge L#5 PCIBridge PCIBridge PCIBridge " +
+			"PCI 8086:37d2 Net L#5 \"eth0\" OpenFabrics L#6 \"i40iw1\"" +
+			"PCI 8086:37d2 Net L#7 \"eth1\" OpenFabrics L#8 \"i40iw0\"" +
+			"NUMANode L#1 (P#1 96GB) + Package L#1", 
+			"eth0:0:0,eth1:0:0,ib0:0:0"},
+		// looks for three adaptors, where "ib1" isn't in the topology
+			{"eth0,eth1,ib1",
+			"Machine (191GB total) NUMANode L#0 (P#0 95GB) " +
+			"Package L#0 HostBridge L#0 PCI 8086:a1d2 Block(Disk) L#0 " +
+			"\"sda\" PCI 8086:a182 PCIBridge PCIBridge PCI 1a03:2000 " +
+			"GPU L#1 \"card0\" GPU L#2 \"controlD64\" HostBridge L#3 " +
+			" PCIBridge PCI 8086:24f0 Net L#3 \"ib0\" OpenFabrics L#4 " +
+			"\"hfi1_0\" HostBridge L#5 PCIBridge PCIBridge PCIBridge " +
+			"PCI 8086:37d2 Net L#5 \"eth0\" OpenFabrics L#6 \"i40iw1\"" +
+			"PCI 8086:37d2 Net L#7 \"eth1\" OpenFabrics L#8 \"i40iw0\"" +
+			"NUMANode L#1 (P#1 96GB) + Package L#1", 
+			"eth0:0:0,eth1:0:0"},
+		// Test malformed adapter list
+		{"eth0:eth1:ib0",
+			"Machine (191GB total) NUMANode L#0 (P#0 95GB) " +
+			"Package L#0 HostBridge L#0 PCI 8086:a1d2 Block(Disk) L#0 " +
+			"\"sda\" PCI 8086:a182 PCIBridge PCIBridge PCI 1a03:2000 " +
+			"GPU L#1 \"card0\" GPU L#2 \"controlD64\" HostBridge L#3 " +
+			" PCIBridge PCI 8086:24f0 Net L#3 \"ib0\" OpenFabrics L#4 " +
+			"\"hfi1_0\" HostBridge L#5 PCIBridge PCIBridge PCIBridge " +
+			"PCI 8086:37d2 Net L#5 \"eth0\" OpenFabrics L#6 \"i40iw1\"" +
+			"PCI 8086:37d2 Net L#7 \"eth1\" OpenFabrics L#8 \"i40iw0\"" +
+			"NUMANode L#1 (P#1 96GB) + Package L#1", 
+			""},
+		// Test malformed adapter list
+		{"eth0 eth1 ib0",
+			"Machine (191GB total) NUMANode L#0 (P#0 95GB) " +
+			"Package L#0 HostBridge L#0 PCI 8086:a1d2 Block(Disk) L#0 " +
+			"\"sda\" PCI 8086:a182 PCIBridge PCIBridge PCI 1a03:2000 " +
+			"GPU L#1 \"card0\" GPU L#2 \"controlD64\" HostBridge L#3 " +
+			" PCIBridge PCI 8086:24f0 Net L#3 \"ib0\" OpenFabrics L#4 " +
+			"\"hfi1_0\" HostBridge L#5 PCIBridge PCIBridge PCIBridge " +
+			"PCI 8086:37d2 Net L#5 \"eth0\" OpenFabrics L#6 \"i40iw1\"" +
+			"PCI 8086:37d2 Net L#7 \"eth1\" OpenFabrics L#8 \"i40iw0\"" +
+			"NUMANode L#1 (P#1 96GB) + Package L#1", 
+			""},
+		// look for adaptor that doesn't show up in topology
+		{"lo",
+			"Machine (191GB total) NUMANode L#0 (P#0 95GB) " +
+			"Package L#0 HostBridge L#0 PCI 8086:a1d2 Block(Disk) L#0 " +
+			"\"sda\" PCI 8086:a182 PCIBridge PCIBridge PCI 1a03:2000 " +
+			"GPU L#1 \"card0\" GPU L#2 \"controlD64\" HostBridge L#3 " +
+			" PCIBridge PCI 8086:24f0 Net L#3 \"ib0\" OpenFabrics L#4 " +
+			"\"hfi1_0\" HostBridge L#5 PCIBridge PCIBridge PCIBridge " +
+			"PCI 8086:37d2 Net L#5 \"eth0\" OpenFabrics L#6 \"i40iw1\"" +
+			"PCI 8086:37d2 Net L#7 \"eth1\" OpenFabrics L#8 \"i40iw0\"" +
+			"NUMANode L#1 (P#1 96GB) + Package L#1", 
+			""},
+		// Verifies that device is found on the correct NUMA node
+		{"eth0",
+			"Machine (191GB total) NUMANode L#1 (P#0 95GB) " +
+			"Package L#0 HostBridge L#0 PCI 8086:a1d2 Block(Disk) L#0 " +
+			"\"sda\" PCI 8086:a182 PCIBridge PCIBridge PCI 1a03:2000 " +
+			"GPU L#1 \"card0\" GPU L#2 \"controlD64\" HostBridge L#3 " +
+			" PCIBridge PCI 8086:24f0 Net L#3 \"ib0\" OpenFabrics L#4 " +
+			"\"hfi1_0\" HostBridge L#5 PCIBridge PCIBridge PCIBridge " +
+			"PCI 8086:37d2 Net L#5 \"eth0\" OpenFabrics L#6 \"i40iw1\"" +
+			"PCI 8086:37d2 Net L#7 \"eth1\" OpenFabrics L#8 \"i40iw0\"" +
+			"NUMANode L#1 (P#1 96GB) + Package L#1", 
+			"eth0:1:0"},
+		// Verifies that device is found on correct NUMA node
+		{"eth0",
+			"Machine (191GB total) NUMANode L#1 (P#1 95GB) " +
+			"Package L#0 HostBridge L#0 PCI 8086:a1d2 Block(Disk) L#0 " +
+			"\"sda\" PCI 8086:a182 PCIBridge PCIBridge PCI 1a03:2000 " +
+			"GPU L#1 \"card0\" GPU L#2 \"controlD64\" HostBridge L#3 " +
+			" PCIBridge PCI 8086:24f0 Net L#3 \"ib0\" OpenFabrics L#4 " +
+			"\"hfi1_0\" HostBridge L#5 PCIBridge PCIBridge PCIBridge " +
+			"PCI 8086:37d2 Net L#5 \"eth0\" OpenFabrics L#6 \"i40iw1\"" +
+			"PCI 8086:37d2 Net L#7 \"eth1\" OpenFabrics L#8 \"i40iw0\"" +
+			"NUMANode L#2 (P#1 96GB) + Package L#1", 
+			"eth0:1:1"},
+		// Verifies devices are found on correct NUMA nodes
+		{"eth0,eth1,ib0",
+			"Machine (191GB total) NUMANode L#0 (P#0 95GB) " +
+			"NUMANode L#1 (P#1 96GB) + Package L#1" +
+			"Package L#0 HostBridge L#0 PCI 8086:a1d2 Block(Disk) L#0 " +
+			"\"sda\" PCI 8086:a182 PCIBridge PCIBridge PCI 1a03:2000 " +
+			"GPU L#1 \"card0\" GPU L#2 \"controlD64\" HostBridge L#3 " +
+			" PCIBridge PCI 8086:24f0 Net L#3 \"ib0\" OpenFabrics L#4 " +
+			"\"hfi1_0\" HostBridge L#5 PCIBridge PCIBridge PCIBridge " +
+			"PCI 8086:37d2 Net L#5 \"eth0\" OpenFabrics L#6 \"i40iw1\"" +
+			"PCI 8086:37d2 Net L#7 \"eth1\" OpenFabrics L#8 \"i40iw0\"" +
+			"NUMANode L#2 (P#2 96GB) + Package L#2",
+			"eth0:1:1,eth1:1:1,ib0:1:1"},
+		// Verifies devices are found on correct NUMA nodes
+		{"eth0,eth1,ib0",
+			"Machine (191GB total) NUMANode L#0 (P#0 95GB) " +
+			"NUMANode L#0 (P#0 96GB) + Package L#0" +
+			"Package L#0 HostBridge L#0 PCI 8086:a1d2 Block(Disk) L#0 " +
+			"\"sda\" PCI 8086:a182 PCIBridge PCIBridge PCI 1a03:2000 " +
+			"GPU L#1 \"card0\" GPU L#2 \"controlD64\" HostBridge L#3 " +
+			" PCIBridge PCI 8086:24f0 Net L#3 \"ib0\" OpenFabrics L#4 " +
+			"\"hfi1_0\" HostBridge L#5 PCIBridge PCIBridge PCIBridge " +
+			"PCI 8086:37d2 Net L#5 \"eth0\" OpenFabrics L#6 \"i40iw1\"" +
+			"NUMANode L#1 (P#1 96GB) + Package L#1" +
+			"PCI 8086:37d2 Net L#7 \"eth1\" OpenFabrics L#8 \"i40iw0\"",
+			"eth0:0:0,ib0:0:0,eth1:1:1"},
+		// Verifies devices are found on correct NUMA nodes
+		{"eth0,eth1,ib0",
+			"Machine (191GB total) NUMANode L#0 (P#0 95GB) " +
+			"NUMANode L#0 (P#1 96GB) + Package L#0" +
+			"Package L#0 HostBridge L#0 PCI 8086:a1d2 Block(Disk) L#0 " +
+			"\"sda\" PCI 8086:a182 PCIBridge PCIBridge PCI 1a03:2000 " +
+			"GPU L#1 \"card0\" GPU L#2 \"controlD64\" HostBridge L#3 " +
+			" PCIBridge PCI 8086:24f0 Net L#3 \"ib0\" OpenFabrics L#4 " +
+			"\"hfi1_0\" HostBridge L#5 PCIBridge PCIBridge PCIBridge " +
+			"PCI 8086:37d2 Net L#5 \"eth0\" OpenFabrics L#6 \"i40iw1\"" +
+			"NUMANode L#1 (P#2 96GB) + Package L#1" +
+			"PCI 8086:37d2 Net L#7 \"eth1\" OpenFabrics L#8 \"i40iw0\"",
+			"eth0:0:1,ib0:0:1,eth1:1:2"},
+		// Verifies devices are found on correct NUMA nodes
+		{"eth0,eth1,ib0",
+			"Machine (191GB total) NUMANode L#0 (P#0 95GB) " +
+			"NUMANode L#23 (P#16 96GB) + Package L#0" +
+			"Package L#0 HostBridge L#0 PCI 8086:a1d2 Block(Disk) L#0 " +
+			"\"sda\" PCI 8086:a182 PCIBridge PCIBridge PCI 1a03:2000 " +
+			"GPU L#1 \"card0\" GPU L#2 \"controlD64\" HostBridge L#3 " +
+			" PCIBridge PCI 8086:24f0 Net L#3 \"ib0\" OpenFabrics L#4 " +
+			"\"hfi1_0\" HostBridge L#5 PCIBridge PCIBridge PCIBridge " +
+			"PCI 8086:37d2 Net L#5 \"eth0\" OpenFabrics L#6 \"i40iw1\"" +
+			"NUMANode L#24 (P#5 96GB) + Package L#1" +
+			"PCI 8086:37d2 Net L#7 \"eth1\" OpenFabrics L#8 \"i40iw0\"",
+			"eth0:23:16,ib0:23:16,eth1:24:5"},
+		// Verifies that devices are found on the correct NUMA node
+		// with a topology of 3 nodes
+		{"eth0,eth1,ib0",
+			"Machine (191GB total) NUMANode L#0 (P#0 95GB) " +
+			"NUMANode L#23 (P#16 96GB) + Package L#0" +
+			"Package L#0 HostBridge L#0 PCI 8086:a1d2 Block(Disk) L#0 " +
+			"\"sda\" PCI 8086:a182 PCIBridge PCIBridge PCI 1a03:2000 " +
+			"GPU L#1 \"card0\" GPU L#2 \"controlD64\" HostBridge L#3 " +
+			" PCIBridge PCI 8086:24f0 Net L#3 \"ib0\" OpenFabrics L#4 " +
+			"NUMANode L#24 (P#5 96GB) + Package L#1" +
+			"\"hfi1_0\" HostBridge L#5 PCIBridge PCIBridge PCIBridge " +
+			"PCI 8086:37d2 Net L#5 \"eth0\" OpenFabrics L#6 \"i40iw1\"" +
+			"NUMANode L#25 (P#7 96GB) + Package L#1" +
+			"PCI 8086:37d2 Net L#7 \"eth1\" OpenFabrics L#8 \"i40iw0\"",
+			"ib0:23:16,eth0:24:5,eth1:25:7"},
+		// Verifies that devices are found on the correct NUMA node
+		// with a topology of 5 nodes (more nodes than devices)
+		{"eth0,eth1,ib0",
+			"Machine (191GB total) NUMANode L#0 (P#0 95GB) " +
+			"NUMANode L#23 (P#16 96GB) + Package L#0" +
+			"Package L#0 HostBridge L#0 PCI 8086:a1d2 Block(Disk) L#0 " +
+			"\"sda\" PCI 8086:a182 PCIBridge PCIBridge PCI 1a03:2000 " +
+			"GPU L#1 \"card0\" GPU L#2 \"controlD64\" HostBridge L#3 " +
+			" PCIBridge PCI 8086:24f0 Net L#3 \"ib0\" OpenFabrics L#4 " +
+			"NUMANode L#24 (P#5 96GB) + Package L#1" +
+			"NUMANode L#28 (P#8 96GB) + Package L#1" +
+			"\"hfi1_0\" HostBridge L#5 PCIBridge PCIBridge PCIBridge " +
+			"PCI 8086:37d2 Net L#5 \"eth0\" OpenFabrics L#6 \"i40iw1\"" +
+			"NUMANode L#30 (P#7 96GB) + Package L#1" +
+			"NUMANode L#32 (P#5 96GB) + Package L#1" +
+			"PCI 8086:37d2 Net L#7 \"eth1\" OpenFabrics L#8 \"i40iw0\"",
+			"ib0:23:16,eth0:28:8,eth1:32:5"},
+		// Verifies that 5 devices are found on the correct NUMA node
+		// with a topology of 5 nodes (equal number of nodes and devices)
+		{"eth0,eth1,ib0,ib1,eth2",
+			"Machine (191GB total) NUMANode L#0 (P#0 95GB) " +
+			"NUMANode L#23 (P#16 96GB) + Package L#0" +
+			"Package L#0 HostBridge L#0 PCI 8086:a1d2 Block(Disk) L#0 " +
+			"\"sda\" PCI 8086:a182 PCIBridge PCIBridge PCI 1a03:2000 " +
+			"GPU L#1 \"card0\" GPU L#2 \"controlD64\" HostBridge L#3 " +
+			" PCIBridge PCI 8086:24f0 Net L#3 \"ib0\" OpenFabrics L#4 " +
+			"NUMANode L#24 (P#5 96GB) + Package L#1" +
+			"PCI 8086:37d2 Net L#7 \"eth1\" OpenFabrics L#8 \"i40iw0\"" +
+			"NUMANode L#28 (P#8 96GB) + Package L#1" +
+			"\"hfi1_0\" HostBridge L#5 PCIBridge PCIBridge PCIBridge " +
+			"PCI 8086:37d2 Net L#5 \"eth0\" OpenFabrics L#6 \"i40iw1\"" +
+			"NUMANode L#30 (P#7 96GB) + Package L#1" +
+			" PCIBridge PCI 8086:24f0 Net L#3 \"ib1\" OpenFabrics L#4 " +
+			"NUMANode L#32 (P#5 96GB) + Package L#1" +
+			"PCI 8086:37d2 Net L#7 \"eth2\" OpenFabrics L#8 \"i40iw0\"",
+			"ib0:23:16,eth1:24:5,eth0:28:8,ib1:30:7,eth2:32:5"},
+		}
+
+	for _, tt := range tests {
+	
+		netAdapterAffinity, err := DetectNUMANodeForDevices(tt.netDevsList, tt.topology)
+		if err != nil {
+			log.Debugf("error was not nil... %v", err)
+		}
+		AssertEqual(t, netAdapterAffinity, tt.expected, "unexected device found")
+	}
+}
+
+/*
+func TestParseEnvVars(t *testing.T) {
+	// Obtain the default client configuration
+	config := NewConfiguration()
+
+	// Save the environment variable before we blow it away
+	original := config.ext.getenv(daosAgentDrpcSockEnv)
+
+	// Clear the environment variable.  Process them.
+	// Make sure there were none found and the default config value was preserved.
+	os.Setenv(daosAgentDrpcSockEnv, "")
+	res1 := config.ProcessEnvOverrides()
+	// Restore the environment to what it was before the test started
+	os.Setenv(daosAgentDrpcSockEnv, original)
+	AssertEqual(
+		t, res1, 0,
+		"clearing environment variable returned unexpected number of results")
+
+	AssertEqual(
+		t, config.RuntimeDir, defaultRuntimeDir,
+		"an empty environment variable failed to preserve default runtime socket path")
+
+	// Set the environment variable.  Process them.
+	// Make sure there was one found and that config value matches what we set it to.
+	os.Setenv(daosAgentDrpcSockEnv, testRuntimeDir)
+	res2 := config.ProcessEnvOverrides()
+	// Restore the environment to what it was before the test started
+	os.Setenv(daosAgentDrpcSockEnv, original)
+	AssertEqual(
+		t, res2, 1,
+		"setting environment variable returned unexpected number of results")
+
+	AssertEqual(
+		t, config.RuntimeDir, testRuntimeDir,
+		"setting environment variable failed to override default runtime socket path")
+
+}
+*/


### PR DESCRIPTION
The functions get called like this:
netDevsList, err := DetectNetworkDevices()
// handle errors
netAdapterAffinity, err := DetectNUMANodeForDevices(netDevsList)
// handle errors
// Do something with the netAdapterAffinity string

Calling this from server main.go gives sample output from my machine:
2019/05/20 15:25:50 main.go:78: debug: netDevsList: lo,eth0,eth1,ib0
2019/05/20 15:25:50 main.go:84: debug: netAdapterAffinity: eth0:0:0,eth1:0:0,ib0:0:0

The output shows that there are 4 network devices, lo, eth0, eth1 and ib0
"lo" isn't part of the topology.  The remaining devices are part of the topology, and are each part of logical and physical NUMA node 0 (of two on the machine).