### PR TITLE
DAOS-2523 vos: land updates to SCM regardless io size

### DIFF
--- a/src/vos/vos_aggregate.c
+++ b/src/vos/vos_aggregate.c
@@ -591,7 +591,8 @@ reserve_segment(struct vos_object *obj, struct agg_io_context *io,
 	int			 rc;
 
 	memset(addr, 0, sizeof(*addr));
-	media = vos_media_select(obj, DAOS_IOD_ARRAY, size);
+	media = vos_media_select(obj, DAOS_IOD_ARRAY, size,
+				 VOS_IOS_AGGREGATION);
 
 	if (media == DAOS_MEDIA_SCM) {
 		struct pobj_action	*scm_ext;

--- a/src/vos/vos_internal.h
+++ b/src/vos/vos_internal.h
@@ -1039,7 +1039,7 @@ key_tree_punch(struct vos_object *obj, daos_handle_t toh, daos_iov_t *key_iov,
 /* vos_io.c */
 uint16_t
 vos_media_select(struct vos_object *obj, daos_iod_type_t type,
-		 daos_size_t size);
+		 daos_size_t size, enum vos_io_stream ios);
 int
 vos_publish_blocks(struct vos_object *obj, d_list_t *blk_list, bool publish,
 		   enum vos_io_stream ios);

--- a/src/vos/vos_io.c
+++ b/src/vos/vos_io.c
@@ -1092,11 +1092,11 @@ done:
  */
 uint16_t
 vos_media_select(struct vos_object *obj, daos_iod_type_t type,
-		 daos_size_t size)
+		 daos_size_t size, enum vos_io_stream ios)
 {
 	struct vea_space_info *vsi = obj->obj_cont->vc_pool->vp_vea_info;
 
-	if (vsi == NULL)
+	if (vsi == NULL || ios == VOS_IOS_GENERIC)
 		return DAOS_MEDIA_SCM;
 	else
 		return (size >= VOS_BLK_SZ) ? DAOS_MEDIA_NVME : DAOS_MEDIA_SCM;
@@ -1120,7 +1120,8 @@ akey_update_begin(struct vos_io_context *ioc)
 		size = (iod->iod_type == DAOS_IOD_SINGLE) ? iod->iod_size :
 				iod->iod_recxs[i].rx_nr * iod->iod_size;
 
-		media = vos_media_select(ioc->ic_obj, iod->iod_type, size);
+		media = vos_media_select(ioc->ic_obj, iod->iod_type, size,
+					 VOS_IOS_GENERIC);
 
 		if (iod->iod_type == DAOS_IOD_SINGLE)
 			rc = vos_reserve_single(ioc, media, size);


### PR DESCRIPTION
To improve update performance when quantity of SSD device on server
isn't enough, we may land all updates to SCM first, and aggregate
large records to SSDs later in background.

Signed-off-by: Niu Yawei <yawei.niu@intel.com>
Change-Id: Ibd9f875bbc510e3a99215e6f4b028b50180d4b85