### PR TITLE
DAOS-2522 control: Fix mgmtJoin error checking

### DIFF
--- a/src/control/server/iosrv.go
+++ b/src/control/server/iosrv.go
@@ -449,6 +449,9 @@ func mgmtJoin(ap string, req *mgmtpb.JoinReq) (*mgmtpb.JoinResp, error) {
 	if err != nil {
 		return nil, errors.Wrapf(err, "join %s %v", ap, *req)
 	}
+	if resp.Status != mgmtpb.DaosRequestStatus_SUCCESS {
+		return nil, errors.Errorf("join %s %v: %d\n", ap, *req, resp.Status)
+	}
 
 	return resp, nil
 }


### PR DESCRIPTION
server main.mgmtJoin should check mgmtpb.JoinReq.Status before returning
success.

Signed-off-by: Li Wei <wei.g.li@intel.com>