### PR TITLE
DAOS-2312 type: add back daos_sg_list_t/daos_iov_t definition

### DIFF
--- a/src/include/daos_types.h
+++ b/src/include/daos_types.h
@@ -53,6 +53,15 @@ extern "C" {
 typedef uint64_t	daos_size_t;
 typedef uint64_t	daos_off_t;
 
+/**
+ * daos_sg_list_t/daos_iov_t/daos_rank_list_free/daos_iov_set is for keeping
+ * compatibility for upper layer.
+ */
+#define daos_sg_list_t			d_sg_list_t
+#define daos_iov_t			d_iov_t
+#define daos_rank_list_free(r)		d_rank_list_free((r))
+#define daos_iov_set(iov, buf, size)	d_iov_set((iov), (buf), (size))
+
 #define crt_proc_daos_key_t	crt_proc_d_iov_t
 #define crt_proc_daos_size_t	crt_proc_uint64_t
 #define crt_proc_daos_epoch_t	crt_proc_uint64_t


### PR DESCRIPTION
To keep compatibility with upper layer.

Signed-off-by: Xuezhao Liu <xuezhao.liu@intel.com>