### PR TITLE
DAOS-2525 control: fix daos_shell subcommands not connecting

### DIFF
--- a/src/control/client/config.go
+++ b/src/control/client/config.go
@@ -24,13 +24,15 @@
 package client
 
 import (
-	"github.com/daos-stack/daos/src/control/common"
-	"github.com/daos-stack/daos/src/control/log"
-	"gopkg.in/yaml.v2"
 	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
+
+	"github.com/daos-stack/daos/src/control/common"
+	"github.com/daos-stack/daos/src/control/log"
+	"github.com/pkg/errors"
+	"gopkg.in/yaml.v2"
 )
 
 const (
@@ -105,15 +107,17 @@ func ProcessConfigFile(ConfigPath string) (Configuration, error) {
 	if !filepath.IsAbs(config.Path) {
 		newPath, err := common.GetAbsInstallPath(config.Path)
 		if err != nil {
-			return config, err
+			return config, errors.WithMessage(
+				err, "resolving install path")
 		}
+
 		config.Path = newPath
 	}
 
 	err := config.LoadConfig()
 	if err != nil {
-		log.Debugf("\nUnable to read the configuration file from: '%s'\nUsing default configuration.", config.Path)
-		return config, nil
+		return config, errors.WithMessagef(
+			err, "parsing config file %s", config.Path)
 	}
 	log.Debugf("DAOS Client config read from %s", config.Path)
 

--- a/src/control/dmg/service.go
+++ b/src/control/dmg/service.go
@@ -26,8 +26,6 @@ package main
 import (
 	"fmt"
 	"os"
-
-	"github.com/pkg/errors"
 )
 
 // SvcCmd is the struct representing the top-level service subcommand.
@@ -51,8 +49,8 @@ func killRankSvc(uuid string, rank uint32) {
 
 // Execute is run when KillRankSvcCmd activates
 func (k *KillRankSvcCmd) Execute(args []string) error {
-	if err := connectHosts(); err != nil {
-		return errors.WithMessage(err, "unable to connect to hosts")
+	if err := appSetup(); err != nil {
+		return err
 	}
 
 	killRankSvc(k.PoolUUID, k.Rank)

--- a/src/control/dmg/storage.go
+++ b/src/control/dmg/storage.go
@@ -26,8 +26,6 @@ package main
 import (
 	"fmt"
 	"os"
-
-	"github.com/pkg/errors"
 )
 
 // StorCmd is the struct representing the top-level storage subcommand.
@@ -52,8 +50,8 @@ func scanStor() {
 
 // Execute is run when ScanStorCmd activates
 func (s *ScanStorCmd) Execute(args []string) error {
-	if err := connectHosts(); err != nil {
-		return errors.Wrap(err, "unable to connect to hosts")
+	if err := appSetup(); err != nil {
+		return err
 	}
 
 	scanStor()
@@ -85,8 +83,8 @@ func formatStor() {
 
 // Execute is run when FormatStorCmd activates
 func (s *FormatStorCmd) Execute(args []string) error {
-	if err := connectHosts(); err != nil {
-		return errors.Wrap(err, "unable to connect to hosts")
+	if err := appSetup(); err != nil {
+		return err
 	}
 
 	formatStor()

--- a/src/control/dmg/utils.go
+++ b/src/control/dmg/utils.go
@@ -32,16 +32,16 @@ import (
 	pb "github.com/daos-stack/daos/src/control/common/proto/mgmt"
 )
 
-func hasConns(results client.ResultMap) (out string) {
-	out = sprintConns(results)
+func hasConns(results client.ResultMap) (bool, string) {
+	out := sprintConns(results)
 	for _, res := range results {
 		if res.Err == nil {
-			return
+			return true, out
 		}
 	}
 
 	// notify if there have been no successful connections
-	return fmt.Sprintf("%sNo active connections!", out)
+	return false, fmt.Sprintf("%sNo active connections!", out)
 }
 
 func sprintConns(results client.ResultMap) (out string) {

--- a/src/control/dmg/utils_test.go
+++ b/src/control/dmg/utils_test.go
@@ -82,7 +82,8 @@ func TestHasConnection(t *testing.T) {
 	}
 
 	for _, tt := range shelltests {
-		AssertEqual(t, hasConns(tt.results), tt.out, "bad output")
+		_, out := hasConns(tt.results)
+		AssertEqual(t, out, tt.out, "bad output")
 	}
 }
 


### PR DESCRIPTION
Fix regression introduced in
(02f8b5b1799d00357d89681ce41d9f71a52293a2) where daos_shell
subcommands don't connect to the hosts specified on the
commandline hostlist.

Signed-off-by: Tom Nabarro <tom.nabarro@intel.com>