### PR TITLE
DAOS-2411 control: fix shell getconns panic

### DIFF
--- a/src/control/client/connect.go
+++ b/src/control/client/connect.go
@@ -25,6 +25,7 @@ package client
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/daos-stack/daos/src/control/common"
 )
@@ -119,6 +120,7 @@ func (c *connList) ConnectClients(addresses Addresses) ResultMap {
 		c.controllers = append(c.controllers, controller)
 	}
 
+	time.Sleep(1000 * time.Millisecond)
 	return c.GetActiveConns(results)
 }
 
@@ -126,6 +128,9 @@ func (c *connList) ConnectClients(addresses Addresses) ResultMap {
 //
 // TODO: resolve hostname and compare destination IPs for duplicates.
 func (c *connList) GetActiveConns(results ResultMap) ResultMap {
+	if results == nil {
+		results = make(ResultMap)
+	}
 	addresses := []string{}
 
 	controllers := c.controllers[:0]


### PR DESCRIPTION
daos_shell interactive getconns cmd which retrieves active
connections panics trying to dereference null pointer to
uninitialised map.

Introduce 0.1s delay to register conn state.

Signed-off-by: Tom Nabarro <tom.nabarro@intel.com>