### PR TITLE
DAOS-2472 bio: improper assert

### DIFF
--- a/src/bio/bio_buffer.c
+++ b/src/bio/bio_buffer.c
@@ -368,7 +368,7 @@ iod_last_region(struct bio_desc *biod)
 {
 	unsigned int cnt = biod->bd_rsrvd.brd_rg_cnt;
 
-	D_ASSERT(!cnt || cnt < biod->bd_rsrvd.brd_rg_max);
+	D_ASSERT(!cnt || cnt <= biod->bd_rsrvd.brd_rg_max);
 	return (cnt != 0) ? &biod->bd_rsrvd.brd_regions[cnt - 1] : NULL;
 }
 


### PR DESCRIPTION
Change the 'cnt < max' assert to 'cnt <= max' in iod_last_region().

Signed-off-by: Niu Yawei <yawei.niu@intel.com>
Change-Id: I7f516702aea42ac328c22f5901c88d036303a679