### PR TITLE
DAOS-2501 tests: a few fixes for rebuild test

### DIFF
--- a/src/object/cli_obj.c
+++ b/src/object/cli_obj.c
@@ -861,11 +861,9 @@ dc_obj_layout_get(daos_handle_t oh, struct daos_obj_layout **p_layout)
 			struct dc_obj_shard *obj_shard;
 			struct pool_target *tgt;
 
-			obj_shard = &obj->cob_shards->do_shards[k];
-			if (obj_shard->do_target_id == -1) {
-				k++;
+			obj_shard = &obj->cob_shards->do_shards[k++];
+			if (obj_shard->do_target_id == -1)
 				continue;
-			}
 
 			rc = dc_cont_tgt_idx2ptr(obj->cob_coh,
 						 obj_shard->do_target_id, &tgt);

--- a/src/tests/suite/daos_rebuild.c
+++ b/src/tests/suite/daos_rebuild.c
@@ -1677,7 +1677,7 @@ rebuild_fail_all_replicas_before_rebuild(void **state)
 	struct daos_obj_layout *layout;
 	struct daos_obj_shard *shard;
 
-	if (!test_runable(arg, 6))
+	if (!test_runable(arg, 6) || arg->pool.svc.rl_nr < 3)
 		return;
 
 	oid = dts_oid_gen(DAOS_OC_R2S_SPEC_RANK, 0, arg->myrank);
@@ -1772,9 +1772,9 @@ rebuild_fail_all_replicas(void **state)
 static void
 multi_pools_rebuild_concurrently(void **state)
 {
-#define POOL_NUM		6
-#define CONT_PER_POOL		4
-#define OBJ_PER_CONT		256
+#define POOL_NUM		4
+#define CONT_PER_POOL		2
+#define OBJ_PER_CONT		8
 	test_arg_t		*arg = *state;
 	test_arg_t		*args[POOL_NUM * CONT_PER_POOL];
 	daos_obj_id_t		oids[OBJ_PER_CONT];


### PR DESCRIPTION
Decrease multiple pool rebuild size to shrink
the run_time.

Fix a typo for get obect layout, so rebuild tests
can kill the right rank by the object layout.

Signed-off-by: Wang Di <di.wang@intel.com>