### PR TITLE
DAOS-2561 tests: Modify run_go_tests to detect and setup its environment

### DIFF
--- a/src/control/run_go_tests.sh
+++ b/src/control/run_go_tests.sh
@@ -11,7 +11,8 @@ function find_build_source()
 		if [ "${path}" == "/" ]; then
 			break
 		fi
-		test -e "${path}/.build_vars.sh" && echo "${path}/.build_vars.sh" && return
+		bvp="${path}/.build_vars.sh"
+		test -e "${bvp}" && echo "${bvp}" && return
 		BASE=$(dirname "${path}")
 	done
 	echo ""
@@ -38,7 +39,7 @@ function setup_environment()
 	build_source=$(find_build_source)
 
 	if [ "${build_source}" == "" ]; then
-		echo "Unable to find .build_source.sh" && exit 1
+		echo "Unable to find .build_vars.sh" && exit 1
 	fi
 
 	source "${build_source}"

--- a/src/control/run_go_tests.sh
+++ b/src/control/run_go_tests.sh
@@ -1,6 +1,61 @@
 #!/bin/bash
 ## Run linters across control plane code and execute Go tests
-set -e
+set -x
+
+function find_build_source()
+{
+	BASE=$PWD
+	
+	while true
+	do
+		path=`realpath ${BASE}`
+		if [ "${path}" == "/" ]; then
+			break
+		fi
+		test -e "${path}/.build_vars.sh" && echo "${path}/.build_vars.sh" && return
+		BASE=`dirname "${path}"`
+	done
+	echo ""
+}
+
+function check_environment()
+{
+	if [ -z "$LD_LIBRARY_PATH" ]; then
+		echo "false" && return
+	fi
+
+	if [ -z "$CGO_LDFLAGS" ]; then
+		echo "false" && return
+	fi
+
+	if [ -z "$CGO_CFLAGS" ]; then
+		echo "false" && return
+	fi
+
+	echo "true" && return
+} 
+
+function setup_environment()
+{
+	build_source=$(find_build_source)
+
+	if [ "${build_source}" == "" ]; then
+		echo "Unable to find .build_source.sh" && exit 1
+	fi
+
+	source ${build_source}
+
+	LD_LIBRARY_PATH="${SL_PREFIX}/lib:${SL_SPDK_PREFIX}/lib:${LD_LIBRARY_PATH}"
+	export LD_LIBRARY_PATH
+	export CGO_LDFLAGS="-L${SL_SPDK_PREFIX}/lib -L${SL_PREFIX}/lib"
+	export CGO_CFLAGS="-I${SL_SPDK_PREFIX}/include"
+}
+
+check=$(check_environment)
+
+if [ "$check" == "false" ]; then
+	setup_environment
+fi
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
 

--- a/src/control/run_go_tests.sh
+++ b/src/control/run_go_tests.sh
@@ -1,19 +1,18 @@
 #!/bin/bash
 ## Run linters across control plane code and execute Go tests
-set -x
+set -e
 
 function find_build_source()
 {
 	BASE=$PWD
-	
 	while true
 	do
-		path=`realpath ${BASE}`
+		path=$(realpath "${BASE}")
 		if [ "${path}" == "/" ]; then
 			break
 		fi
 		test -e "${path}/.build_vars.sh" && echo "${path}/.build_vars.sh" && return
-		BASE=`dirname "${path}"`
+		BASE=$(dirname "${path}")
 	done
 	echo ""
 }
@@ -31,9 +30,8 @@ function check_environment()
 	if [ -z "$CGO_CFLAGS" ]; then
 		echo "false" && return
 	fi
-
 	echo "true" && return
-} 
+}
 
 function setup_environment()
 {
@@ -43,7 +41,7 @@ function setup_environment()
 		echo "Unable to find .build_source.sh" && exit 1
 	fi
 
-	source ${build_source}
+	source "${build_source}"
 
 	LD_LIBRARY_PATH="${SL_PREFIX}/lib:${SL_SPDK_PREFIX}/lib:${LD_LIBRARY_PATH}"
 	export LD_LIBRARY_PATH


### PR DESCRIPTION
run_go_tests.sh required the user to either configure its environment or for the environment to be configured with run_tests.sh. This patch modifies run_go_tests.sh to check if it has the necessary environment and if it doesn't it climbs backwards through its directory structure until it finds .build_vars.sh. Upon finding .build_vars.sh it will source the file and setup the environment like it does in run_tests.sh. This will allow run_go_tests.sh to be run on its own but also by running run_tests.sh.

