### PR TITLE
DAOS-2185 rebuild: rebuild by snapshot & stable view

### DIFF
--- a/src/include/daos/task.h
+++ b/src/include/daos/task.h
@@ -119,8 +119,8 @@ dc_obj_list_recx_task_create(daos_handle_t oh, daos_handle_t th,
 			     tse_sched_t *tse, tse_task_t **task);
 int
 dc_obj_list_obj_task_create(daos_handle_t oh, daos_handle_t th,
-			    daos_key_t *dkey, daos_key_t *akey,
-			    daos_size_t *size, uint32_t *nr,
+			    daos_epoch_range_t *epr, daos_key_t *dkey,
+			    daos_key_t *akey, daos_size_t *size, uint32_t *nr,
 			    daos_key_desc_t *kds, d_sg_list_t *sgl,
 			    daos_anchor_t *anchor,
 			    daos_anchor_t *dkeay_anchor,

--- a/src/include/daos_srv/container.h
+++ b/src/include/daos_srv/container.h
@@ -59,6 +59,7 @@ struct ds_cont_child {
 	uuid_t			 sc_uuid;	/* container UUID */
 	struct ds_pool_child	*sc_pool;
 	d_list_t		 sc_link;	/* link to spc_cont_list */
+
 	ABT_mutex		 sc_mutex;
 	ABT_cond		 sc_dtx_resync_cond;
 	void			*sc_dtx_flush_cbdata;
@@ -74,15 +75,20 @@ struct ds_cont_child {
 
 	/* Aggregate ULT */
 	struct dss_sleep_ult	 *sc_agg_ult;
+
 	/*
-	 * Lower bound of aggregation epoch, it can be:
-	 *
-	 * < DAOS_EOPCH_MAX	: Some snapshot was deleted since last
-	 *			  round of aggregation
-	 * DAOS_EPOCH_MAX	: No snapshot deletion since last round of
-	 *			  aggregation
+	 * Snapshot delete HLC (0 means no change), which is used
+	 * to compare with the aggregation HLC, so it knows whether the
+	 * aggregation needs to be restart from 0.
 	 */
-	uint64_t		 sc_aggregation_min;
+	uint64_t		sc_snapshot_delete_hlc;
+
+	/* HLC when the full scan aggregation start, if it is smaller than
+	 * snapshot_delete_hlc(or rebuild), then aggregation needs to restart
+	 * from 0.
+	 */
+	uint64_t		sc_aggregation_full_scan_hlc;
+
 	/* Upper bound of aggregation epoch, it can be:
 	 *
 	 * 0			: When snapshot list isn't retrieved yet

--- a/src/include/daos_srv/daos_server.h
+++ b/src/include/daos_srv/daos_server.h
@@ -519,10 +519,11 @@ int dsc_obj_fetch(daos_handle_t oh, daos_epoch_t epoch,
 		daos_key_t *dkey, unsigned int nr,
 		daos_iod_t *iods, d_sg_list_t *sgls,
 		daos_iom_t *maps);
-int dsc_obj_list_obj(daos_handle_t oh, daos_epoch_t epoch, daos_key_t *dkey,
-		daos_key_t *akey, daos_size_t *size, uint32_t *nr,
-		daos_key_desc_t *kds, d_sg_list_t *sgl, daos_anchor_t *anchor,
-		daos_anchor_t *dkey_anchor, daos_anchor_t *akey_anchor);
+int dsc_obj_list_obj(daos_handle_t oh, daos_epoch_range_t *epr,
+		daos_key_t *dkey, daos_key_t *akey, daos_size_t *size,
+		uint32_t *nr, daos_key_desc_t *kds, d_sg_list_t *sgl,
+		daos_anchor_t *anchor, daos_anchor_t *dkey_anchor,
+		daos_anchor_t *akey_anchor);
 int dsc_pool_tgt_exclude(const uuid_t uuid, const char *grp,
 			 const d_rank_list_t *svc, struct d_tgt_list *tgts);
 

--- a/src/include/daos_srv/pool.h
+++ b/src/include/daos_srv/pool.h
@@ -88,6 +88,17 @@ struct ds_pool_child {
 	struct ds_pool	*spc_pool;
 	uuid_t		spc_uuid;	/* pool UUID */
 	d_list_t	spc_cont_list;
+
+	/* The current maxim rebuild epoch, (0 if there is no rebuild), so
+	 * vos aggregation can not cross this epoch during rebuild to avoid
+	 * interferring rebuild process.
+	 */
+	uint64_t	spc_rebuild_fence;
+
+	/* The HLC when current rebuild ends, which will be used to compare
+	 * with the aggregation full scan start HLC to know whether the 
+	 * aggregation needs to be restarted from 0. */
+	uint64_t	spc_rebuild_end_hlc;
 	uint32_t	spc_map_version;
 	int		spc_ref;
 };

--- a/src/iosrv/srv_cli.c
+++ b/src/iosrv/srv_cli.c
@@ -284,7 +284,7 @@ dsc_obj_fetch(daos_handle_t oh, daos_epoch_t epoch, daos_key_t *dkey,
 }
 
 int
-dsc_obj_list_obj(daos_handle_t oh, daos_epoch_t epoch, daos_key_t *dkey,
+dsc_obj_list_obj(daos_handle_t oh, daos_epoch_range_t *epr, daos_key_t *dkey,
 		 daos_key_t *akey, daos_size_t *size, uint32_t *nr,
 		 daos_key_desc_t *kds, d_sg_list_t *sgl, daos_anchor_t *anchor,
 		 daos_anchor_t *dkey_anchor, daos_anchor_t *akey_anchor)
@@ -294,12 +294,12 @@ dsc_obj_list_obj(daos_handle_t oh, daos_epoch_t epoch, daos_key_t *dkey,
 	int		rc;
 
 	coh = dc_obj_hdl2cont_hdl(oh);
-	rc = dc_tx_local_open(coh, epoch, &th);
+	rc = dc_tx_local_open(coh, epr->epr_hi, &th);
 	if (rc)
 		return rc;
 
-	rc = dc_obj_list_obj_task_create(oh, th, dkey, akey, size, nr, kds,
-					 sgl, anchor, dkey_anchor,
+	rc = dc_obj_list_obj_task_create(oh, th, epr, dkey, akey, size, nr,
+					 kds, sgl, anchor, dkey_anchor,
 					 akey_anchor, true, NULL,
 					 dsc_scheduler(), &task);
 	if (rc)

--- a/src/iosrv/vos.c
+++ b/src/iosrv/vos.c
@@ -95,8 +95,8 @@ is_sgl_full(struct dss_enum_arg *arg, daos_size_t size)
 
 	/* Check if the sgl is full */
 	if (arg->sgl_idx >= sgl->sg_nr) {
-		D_DEBUG(DB_IO, "sgl is full sgl %d/%d size "DF_U64"\n",
-			arg->sgl_idx, sgl->sg_nr, size);
+		D_DEBUG(DB_IO, "full sgl %d/%d size " DF_U64"\n", arg->sgl_idx,
+			sgl->sg_nr, size);
 		return 1;
 	}
 
@@ -119,7 +119,6 @@ fill_obj(daos_handle_t ih, vos_iter_entry_t *entry, struct dss_enum_arg *arg,
 
 	type = vos_iter_type_2pack_type(vos_type);
 	/* Append a new descriptor to kds. */
-	D_ASSERT(arg->kds_len < arg->kds_cap);
 	memset(&arg->kds[arg->kds_len], 0, sizeof(arg->kds[arg->kds_len]));
 	arg->kds[arg->kds_len].kd_key_len = sizeof(entry->ie_oid);
 	arg->kds[arg->kds_len].kd_val_type = type;

--- a/src/object/cli_shard.c
+++ b/src/object/cli_shard.c
@@ -768,7 +768,13 @@ dc_obj_shard_list(struct dc_obj_shard *obj_shard, enum obj_rpc_opc opc,
 		oei->oei_akey = *obj_args->akey;
 	oei->oei_oid		= obj_shard->do_id;
 	oei->oei_map_ver	= args->la_auxi.map_ver;
-	oei->oei_epoch		= args->la_auxi.epoch;
+	if (obj_args->eprs != NULL && opc == DAOS_OBJ_RPC_ENUMERATE) {
+		oei->oei_epr = *obj_args->eprs;
+	} else {
+		oei->oei_epr.epr_lo = 0;
+		oei->oei_epr.epr_hi = args->la_auxi.epoch;
+	}
+
 	oei->oei_nr		= *obj_args->nr;
 	oei->oei_rec_type	= obj_args->type;
 	uuid_copy(oei->oei_pool_uuid, pool->dp_pool);

--- a/src/object/obj_rpc.h
+++ b/src/object/obj_rpc.h
@@ -179,7 +179,7 @@ CRT_RPC_DECLARE(obj_fetch,	DAOS_ISEQ_OBJ_RW, DAOS_OSEQ_OBJ_RW)
 	((uuid_t)		(oei_pool_uuid)		CRT_VAR) \
 	((uuid_t)		(oei_co_hdl)		CRT_VAR) \
 	((uuid_t)		(oei_co_uuid)		CRT_VAR) \
-	((uint64_t)		(oei_epoch)		CRT_VAR) \
+	((daos_epoch_range_t)	(oei_epr)		CRT_VAR) \
 	((uint32_t)		(oei_map_ver)		CRT_VAR) \
 	((uint32_t)		(oei_nr)		CRT_VAR) \
 	((uint32_t)		(oei_rec_type)		CRT_VAR) \

--- a/src/object/obj_task.c
+++ b/src/object/obj_task.c
@@ -368,6 +368,7 @@ dc_obj_list_recx_task_create(daos_handle_t oh, daos_handle_t th,
 
 int
 dc_obj_list_obj_task_create(daos_handle_t oh, daos_handle_t th,
+			    daos_epoch_range_t *epr,
 			    daos_key_t *dkey, daos_key_t *akey,
 			    daos_size_t *size, uint32_t *nr,
 			    daos_key_desc_t *kds,
@@ -393,6 +394,7 @@ dc_obj_list_obj_task_create(daos_handle_t oh, daos_handle_t th,
 	args->nr	= nr;
 	args->kds	= kds;
 	args->sgl	= sgl;
+	args->eprs	= epr;
 	args->anchor	= anchor;
 	args->dkey_anchor = dkey_anchor;
 	args->akey_anchor = akey_anchor;

--- a/src/object/obj_verify.c
+++ b/src/object/obj_verify.c
@@ -64,7 +64,7 @@ again:
 	dova->list_iov.iov_buf = dova->list_buf;
 	dova->list_iov.iov_buf_len = dova->list_buf_len;
 
-	rc = dc_obj_list_obj_task_create(dova->oh, dova->th, NULL, NULL,
+	rc = dc_obj_list_obj_task_create(dova->oh, dova->th, NULL, NULL, NULL,
 					 &dova->size, &dova->num, dova->kds,
 					 &dova->list_sgl, &dova->anchor,
 					 &dova->dkey_anchor,

--- a/src/object/srv_obj.c
+++ b/src/object/srv_obj.c
@@ -1413,8 +1413,9 @@ obj_iter_vos(crt_rpc_t *rpc, struct vos_iter_anchors *anchors,
 		param.ip_dkey = oei->oei_dkey;
 	if (oei->oei_akey.iov_len > 0)
 		param.ip_akey = oei->oei_akey;
-	param.ip_epr.epr_lo = oei->oei_epoch;
-	param.ip_epr.epr_hi = oei->oei_epoch;
+
+	param.ip_epr.epr_lo = oei->oei_epr.epr_lo;
+	param.ip_epr.epr_hi = oei->oei_epr.epr_hi;
 	param.ip_epc_expr = VOS_IT_EPC_LE;
 
 	if (opc == DAOS_OBJ_RECX_RPC_ENUMERATE) {
@@ -1422,15 +1423,10 @@ obj_iter_vos(crt_rpc_t *rpc, struct vos_iter_anchors *anchors,
 		    oei->oei_akey.iov_len == 0)
 			D_GOTO(out_cont_hdl, rc = -DER_PROTO);
 
-		if (oei->oei_rec_type == DAOS_IOD_ARRAY) {
+		if (oei->oei_rec_type == DAOS_IOD_ARRAY)
 			type = VOS_ITER_RECX;
-			/* To capture everything visible, we must search from
-			 * 0 to our epoch
-			 */
-			param.ip_epr.epr_lo = 0;
-		} else {
+		else
 			type = VOS_ITER_SINGLE;
-		}
 
 		param.ip_epc_expr = VOS_IT_EPC_RE;
 		/** Only show visible records and skip punches */
@@ -1447,12 +1443,11 @@ obj_iter_vos(crt_rpc_t *rpc, struct vos_iter_anchors *anchors,
 		if (daos_anchor_get_flags(&anchors->ia_dkey) &
 		      DIOF_WITH_SPEC_EPOCH) {
 			/* For obj verification case. */
-			param.ip_flags = VOS_IT_RECX_VISIBLE;
+			param.ip_flags |= VOS_IT_RECX_VISIBLE;
 			param.ip_epc_expr = VOS_IT_EPC_RR;
 		} else {
 			param.ip_epc_expr = VOS_IT_EPC_RE;
 		}
-		param.ip_epr.epr_lo = 0;
 		recursive = true;
 		enum_arg->chk_key2big = true;
 		enum_arg->need_punch = true;
@@ -1478,8 +1473,9 @@ obj_iter_vos(crt_rpc_t *rpc, struct vos_iter_anchors *anchors,
 	if (type == VOS_ITER_SINGLE)
 		anchors->ia_ev = anchors->ia_sv;
 
-	D_DEBUG(DB_IO, ""DF_UOID" iterate type %d tag %d rc %d\n",
-		DP_UOID(oei->oei_oid), type, dss_get_module_info()->dmi_tgt_id,
+	D_DEBUG(DB_IO, ""DF_UOID" iterate "DF_U64"-"DF_U64" type %d tag %d"
+		" rc %d\n", DP_UOID(oei->oei_oid), param.ip_epr.epr_lo,
+		param.ip_epr.epr_hi, type, dss_get_module_info()->dmi_tgt_id,
 		rc);
 out_cont_hdl:
 	if (cont_hdl)
@@ -1567,12 +1563,6 @@ ds_obj_enum_handler(crt_rpc_t *rpc)
 	anchors.ia_dkey = oei->oei_dkey_anchor;
 	anchors.ia_akey = oei->oei_akey_anchor;
 	anchors.ia_ev = oei->oei_anchor;
-
-	/* FIXME: until distributed transaction. */
-	if (oei->oei_epoch == DAOS_EPOCH_MAX) {
-		oei->oei_epoch = crt_hlc_get();
-		D_DEBUG(DB_IO, "overwrite epoch "DF_U64"\n", oei->oei_epoch);
-	}
 
 	/* TODO: Transfer the inline_thres from enumerate RPC */
 	enum_arg.inline_thres = 32;

--- a/src/rebuild/initiator.c
+++ b/src/rebuild/initiator.c
@@ -55,8 +55,9 @@ struct puller_iter_arg {
 	struct rebuild_root		*cont_root;
 	unsigned int			yield_freq;
 	unsigned int			obj_cnt;
-	bool				yielded;
 	bool				re_iter;
+	uint64_t			*snaps;
+	uint32_t			snap_cnt;
 };
 
 /* Argument for dkey/akey/record iteration */
@@ -68,6 +69,8 @@ struct rebuild_iter_obj_arg {
 	unsigned int	shard;
 	unsigned int	tgt_idx;
 	struct rebuild_tgt_pool_tracker *rpt;
+	uint64_t	*snaps;
+	uint32_t	snap_cnt;
 };
 
 #define PULLER_STACK_SIZE	131072
@@ -229,8 +232,8 @@ end:
  * Punch dkeys/akeys before rebuild.
  */
 static int
-rebuild_one_punch_keys(struct rebuild_tgt_pool_tracker *rpt,
-		       struct rebuild_one *rdone, struct ds_cont_child *cont)
+rebuild_one_punch(struct rebuild_tgt_pool_tracker *rpt,
+		  struct rebuild_one *rdone, struct ds_cont_child *cont)
 {
 	int	i;
 	int	rc = 0;
@@ -279,13 +282,27 @@ rebuild_one_punch_keys(struct rebuild_tgt_pool_tracker *rpt,
 
 	/* punch records */
 	if (rdone->ro_punch_iod_num > 0) {
-		rc = vos_obj_update(cont->sc_hdl, rdone->ro_oid,
-				    rdone->ro_epoch, rdone->ro_version,
-				    &rdone->ro_dkey, rdone->ro_punch_iod_num,
+		daos_epoch_t punch_eph = 0;
+		int j;
+
+		for (i = 0; i < rdone->ro_punch_iod_num; i++) {
+			daos_iod_t *iod;
+
+			iod = &rdone->ro_punch_iods[i];
+			for (j = 0; j < iod->iod_nr; j++) {
+				if (punch_eph == 0 ||
+				    punch_eph < iod->iod_eprs[i].epr_lo)
+					punch_eph = iod->iod_eprs[i].epr_lo;
+			}
+		}
+
+		rc = vos_obj_update(cont->sc_hdl, rdone->ro_oid, punch_eph,
+				    rdone->ro_version, &rdone->ro_dkey,
+				    rdone->ro_punch_iod_num,
 				    rdone->ro_punch_iods, NULL);
-		D_DEBUG(DB_REBUILD, DF_UOID" rdone %p punch %d records: %d\n",
-			DP_UOID(rdone->ro_oid), rdone, rdone->ro_punch_iod_num,
-			rc);
+		D_DEBUG(DB_REBUILD, DF_UOID" rdone %p punch %d eph "DF_U64
+			" records: %d\n", DP_UOID(rdone->ro_oid), rdone,
+			rdone->ro_punch_iod_num, punch_eph, rc);
 	}
 
 	return rc;
@@ -336,7 +353,7 @@ rebuild_dkey(struct rebuild_tgt_pool_tracker *rpt,
 	if (rc)
 		D_GOTO(obj_close, rc);
 
-	rc = rebuild_one_punch_keys(rpt, rdone, rebuild_cont);
+	rc = rebuild_one_punch(rpt, rdone, rebuild_cont);
 	if (rc)
 		D_GOTO(cont_put, rc);
 
@@ -518,9 +535,6 @@ rw_iod_pack(struct rebuild_one *rdone, daos_iod_t *iod, d_sg_list_t *sgls)
 	for (i = 0; i < iod->iod_nr; i++) {
 		rec_cnt += iod->iod_recxs[i].rx_nr;
 		total_size += iod->iod_recxs[i].rx_nr * iod->iod_size;
-		if (rdone->ro_epoch == 0 ||
-		    iod->iod_eprs[i].epr_lo > rdone->ro_epoch)
-			rdone->ro_epoch = iod->iod_eprs[i].epr_lo;
 	}
 
 	D_DEBUG(DB_REBUILD,
@@ -572,6 +586,12 @@ punch_iod_pack(struct rebuild_one *rdone, daos_iod_t *iod)
 	if (rc)
 		return rc;
 
+	D_DEBUG(DB_REBUILD,
+		"idx %d akey "DF_KEY" nr %d size "DF_U64" type %d eph "
+		DF_U64"/"DF_U64"\n", idx, DP_KEY(&iod->iod_name),
+		iod->iod_nr, iod->iod_size, iod->iod_type,
+		iod->iod_eprs->epr_lo, iod->iod_eprs->epr_hi);
+
 	rdone->ro_punch_iod_num++;
 	iod->iod_recxs = NULL;
 	iod->iod_csums = NULL;
@@ -584,8 +604,8 @@ punch_iod_pack(struct rebuild_one *rdone, daos_iod_t *iod)
  * steals the memory of the recx, csum, and epr arrays from iods.
  */
 static int
-rebuild_one_queue(struct rebuild_iter_obj_arg *iter_arg, daos_unit_oid_t *oid,
-		  daos_key_t *dkey, daos_epoch_t dkey_eph,
+rebuild_one_queue(struct rebuild_iter_obj_arg *iter_arg, daos_epoch_t epoch,
+		  daos_unit_oid_t *oid, daos_key_t *dkey, daos_epoch_t dkey_eph,
 		  daos_iod_t *iods, daos_epoch_t *akey_ephs,
 		  int iod_eph_total, d_sg_list_t *sgls, uint32_t version)
 {
@@ -613,6 +633,7 @@ rebuild_one_queue(struct rebuild_iter_obj_arg *iter_arg, daos_unit_oid_t *oid,
 	if (rdone->ro_iods == NULL)
 		D_GOTO(free, rc = -DER_NOMEM);
 
+	rdone->ro_epoch = epoch;
 	rdone->ro_dkey_punch_eph = dkey_eph;
 	D_ALLOC_ARRAY(rdone->ro_akey_punch_ephs, iod_eph_total);
 	if (rdone->ro_akey_punch_ephs == NULL)
@@ -701,13 +722,21 @@ free:
 	return rc;
 }
 
+struct rebuild_enum_unpack_arg {
+	struct rebuild_iter_obj_arg	*arg;
+	daos_epoch_range_t		epr;
+};
+
 static int
-rebuild_one_queue_cb(struct dss_enum_unpack_io *io, void *arg)
+rebuild_enum_unpack_cb(struct dss_enum_unpack_io *io, void *data)
 {
-	return rebuild_one_queue(arg, &io->ui_oid, &io->ui_dkey,
-				 io->ui_dkey_punch_eph, io->ui_iods,
-				 io->ui_akey_punch_ephs, io->ui_iods_top + 1,
-				 io->ui_sgls, io->ui_version);
+	struct rebuild_enum_unpack_arg *arg = data;
+
+	return rebuild_one_queue(arg->arg, arg->epr.epr_hi, &io->ui_oid,
+				 &io->ui_dkey, io->ui_dkey_punch_eph,
+				 io->ui_iods, io->ui_akey_punch_ephs,
+				 io->ui_iods_top + 1, io->ui_sgls,
+				 io->ui_version);
 }
 
 static int
@@ -733,69 +762,47 @@ rebuild_obj_punch_one(void *data)
 	return rc;
 }
 
-static int
-rebuild_obj_punch(struct rebuild_iter_obj_arg *arg)
-{
-	return dss_task_collective(rebuild_obj_punch_one, arg, 0);
-}
-
 #define KDS_NUM		16
 #define ITER_BUF_SIZE   2048
 
 /**
  * Iterate akeys/dkeys of the object
  */
-static void
-rebuild_obj_ult(void *data)
+static int
+rebuild_one_epoch_object(daos_handle_t oh, daos_epoch_range_t *epr,
+			 struct rebuild_iter_obj_arg *arg)
 {
-	struct rebuild_iter_obj_arg	*arg = data;
-	struct rebuild_pool_tls		*tls;
-	daos_anchor_t			 anchor;
-	daos_anchor_t			 dkey_anchor;
-	daos_anchor_t			 akey_anchor;
-	daos_handle_t			 oh;
-	d_sg_list_t			 sgl = { 0 };
-	d_iov_t			 iov = { 0 };
-	char				 stack_buf[ITER_BUF_SIZE];
-	char				*buf = NULL;
-	daos_size_t			 buf_len;
-	struct dss_enum_arg		 enum_arg;
-	int				 rc;
+	daos_anchor_t	anchor;
+	daos_anchor_t	dkey_anchor;
+	daos_anchor_t	akey_anchor;
+	char		stack_buf[ITER_BUF_SIZE];
+	char		*buf = NULL;
+	daos_size_t	buf_len;
+	daos_key_desc_t		kds[KDS_NUM] = { 0 };
+	struct dss_enum_arg	enum_arg = { 0 };
+	struct rebuild_enum_unpack_arg unpack_arg = { 0 };
+	d_iov_t		iov = { 0 };
+	d_sg_list_t	sgl = { 0 };
+	uint32_t	num;
+	daos_size_t	size;
+	int		rc = 0;
 
-	tls = rebuild_pool_tls_lookup(arg->rpt->rt_pool_uuid,
-				      arg->rpt->rt_rebuild_ver);
-	D_ASSERT(tls != NULL);
+	D_DEBUG(DB_REBUILD, "rebuild obj "DF_UOID" for shard %u eph "
+		DF_U64"-"DF_U64"\n", DP_UOID(arg->oid), arg->shard, epr->epr_lo,
+		epr->epr_hi);
 
-	if (arg->epoch != DAOS_EPOCH_MAX) {
-		rc = rebuild_obj_punch(arg);
-		if (rc)
-			D_GOTO(free, rc);
-	}
-
-	rc = dsc_obj_open(arg->cont_hdl, arg->oid.id_pub, DAOS_OO_RW, &oh);
-	if (rc)
-		D_GOTO(free, rc);
-
-	D_DEBUG(DB_REBUILD, "start rebuild obj "DF_UOID" for shard %u\n",
-		DP_UOID(arg->oid), arg->shard);
 	memset(&anchor, 0, sizeof(anchor));
 	memset(&dkey_anchor, 0, sizeof(dkey_anchor));
 	memset(&akey_anchor, 0, sizeof(akey_anchor));
 	dc_obj_shard2anchor(&dkey_anchor, arg->shard);
-	daos_anchor_set_flags(&dkey_anchor, DIOF_TO_LEADER);
+	daos_anchor_set_flags(&dkey_anchor,
+			      DIOF_TO_LEADER | DIOF_WITH_SPEC_EPOCH);
 
-	/* Initialize enum_arg for VOS_ITER_DKEY. */
-	memset(&enum_arg, 0, sizeof(enum_arg));
-	enum_arg.oid = arg->oid;
-	enum_arg.chk_key2big = true;
-
+	unpack_arg.arg = arg;
+	unpack_arg.epr = *epr;
 	buf = stack_buf;
 	buf_len = ITER_BUF_SIZE;
 	while (1) {
-		daos_key_desc_t	kds[KDS_NUM] = { 0 };
-		uint32_t	num = KDS_NUM;
-		daos_size_t	size;
-
 		memset(buf, 0, buf_len);
 		iov.iov_len = 0;
 		iov.iov_buf = buf;
@@ -805,10 +812,10 @@ rebuild_obj_ult(void *data)
 		sgl.sg_nr_out = 1;
 		sgl.sg_iovs = &iov;
 
-		rc = dsc_obj_list_obj(oh, arg->epoch, NULL, NULL, &size, &num,
-				      kds, &sgl, &anchor, &dkey_anchor,
-				      &akey_anchor);
-
+		num = KDS_NUM;
+		rc = dsc_obj_list_obj(oh, epr, NULL, NULL, &size,
+				     &num, kds, &sgl, &anchor,
+				     &dkey_anchor, &akey_anchor);
 		if (rc == -DER_KEY2BIG) {
 			D_DEBUG(DB_REBUILD, "rebuild obj "DF_UOID" got "
 				"-DER_KEY2BIG, key_len "DF_U64"\n",
@@ -835,13 +842,15 @@ rebuild_obj_ult(void *data)
 
 		iov.iov_len = size;
 
+		enum_arg.oid = arg->oid;
 		enum_arg.kds = kds;
 		enum_arg.kds_cap = KDS_NUM;
 		enum_arg.kds_len = num;
 		enum_arg.sgl = &sgl;
 		enum_arg.sgl_idx = 1;
+		enum_arg.chk_key2big = true;
 		rc = dss_enum_unpack(VOS_ITER_DKEY, &enum_arg,
-				     rebuild_one_queue_cb, arg);
+				     rebuild_enum_unpack_cb, &unpack_arg);
 		if (rc) {
 			D_ERROR("rebuild "DF_UOID" failed: %d\n",
 				DP_UOID(arg->oid), rc);
@@ -852,10 +861,68 @@ rebuild_obj_ult(void *data)
 			break;
 	}
 
-	dsc_obj_close(oh);
-free:
 	if (buf != NULL && buf != stack_buf)
 		D_FREE(buf);
+
+	D_DEBUG(DB_REBUILD, "obj "DF_UOID" for shard %u eph "
+		DF_U64"-"DF_U64": rc %d\n", DP_UOID(arg->oid), arg->shard,
+		epr->epr_lo, epr->epr_hi, rc);
+
+	return rc;
+}
+
+static int
+rebuild_obj_punch(struct rebuild_iter_obj_arg *arg)
+{
+	return dss_task_collective(rebuild_obj_punch_one, arg, 0);
+}
+
+/**
+ * Iterate akeys/dkeys of the object
+ */
+static void
+rebuild_obj_ult(void *data)
+{
+	struct rebuild_iter_obj_arg	*arg = data;
+	struct rebuild_pool_tls		*tls;
+	daos_handle_t			oh;
+	daos_epoch_range_t		epr;
+	int				rc;
+
+	tls = rebuild_pool_tls_lookup(arg->rpt->rt_pool_uuid,
+				      arg->rpt->rt_rebuild_ver);
+	D_ASSERT(tls != NULL);
+
+	if (arg->epoch != DAOS_EPOCH_MAX) {
+		rc = rebuild_obj_punch(arg);
+		if (rc)
+			D_GOTO(free, rc);
+	}
+
+	rc = dsc_obj_open(arg->cont_hdl, arg->oid.id_pub, DAOS_OO_RW, &oh);
+	if (rc)
+		D_GOTO(free, rc);
+
+	if (arg->snaps) {
+		int	i;
+
+		for (i = 0; i < arg->snap_cnt; i++) {
+			epr.epr_lo = i > 0 ? arg->snaps[i-1] + 1 : 0;
+			epr.epr_hi = arg->snaps[i];
+			rc = rebuild_one_epoch_object(oh, &epr, arg);
+			if (rc)
+				D_GOTO(close, rc);
+		}
+	}
+
+	D_ASSERT(arg->rpt->rt_stable_epoch != 0);
+	epr.epr_lo = arg->snaps ? arg->snaps[arg->snap_cnt - 1] + 1 : 0;
+	epr.epr_hi = arg->rpt->rt_stable_epoch;
+	rc = rebuild_one_epoch_object(oh, &epr, arg);
+
+close:
+	dsc_obj_close(oh);
+free:
 	if (arg->epoch == DAOS_EPOCH_MAX)
 		tls->rebuild_pool_obj_count++;
 	if (tls->rebuild_pool_status == 0 && rc < 0)
@@ -863,6 +930,8 @@ free:
 	D_DEBUG(DB_REBUILD, "stop rebuild obj "DF_UOID" for shard %u rc %d\n",
 		DP_UOID(arg->oid), arg->shard, rc);
 	rpt_put(arg->rpt);
+	if (arg->snaps)
+		D_FREE(arg->snaps);
 	D_FREE(arg);
 }
 
@@ -889,13 +958,27 @@ rebuild_obj_callback(daos_unit_oid_t oid, daos_epoch_t eph, unsigned int shard,
 	if (eph == DAOS_EPOCH_MAX)
 		obj_arg->rpt->rt_toberb_objs++;
 
+	if (iter_arg->snaps) {
+		D_ALLOC(obj_arg->snaps,
+			sizeof(*obj_arg->snaps) * iter_arg->snap_cnt);
+		if (obj_arg->snaps == NULL)
+			D_GOTO(free, rc = -DER_NOMEM);
+
+		obj_arg->snap_cnt = iter_arg->snap_cnt;
+		memcpy(obj_arg->snaps, iter_arg->snaps,
+		       sizeof(*obj_arg->snaps) * iter_arg->snap_cnt);
+	}
+
 	/* Let's iterate the object on different xstream */
 	rc = dss_ult_create(rebuild_obj_ult, obj_arg, DSS_ULT_REBUILD,
 			    oid.id_pub.lo % dss_tgt_nr,
 			    PULLER_STACK_SIZE, NULL);
+free:
 	if (rc) {
-		rpt_put(iter_arg->rpt);
+		if (obj_arg->snaps)
+			D_FREE(obj_arg->snaps);
 		D_FREE(obj_arg);
+		rpt_put(iter_arg->rpt);
 	}
 
 	return rc;
@@ -941,7 +1024,6 @@ puller_obj_iter_cb(daos_handle_t ih, d_iov_t *key_iov,
 		if (arg->yield_freq == 0) {
 			arg->yield_freq = DEFAULT_YIELD_FREQ;
 			ABT_thread_yield();
-			arg->yielded = true;
 			if (arg->cont_root->count > arg->obj_cnt) {
 				arg->obj_cnt = arg->cont_root->count;
 				/* re-iterate after new oid inserted */
@@ -981,7 +1063,10 @@ puller_cont_iter_cb(daos_handle_t ih, d_iov_t *key_iov,
 	struct rebuild_tgt_pool_tracker	*rpt = arg->rpt;
 	struct rebuild_pool_tls		*tls;
 	daos_handle_t			coh = DAOS_HDL_INVAL;
+	uint64_t			*snapshots = NULL;
+	int				snap_cnt;
 	int				rc;
+	int				rc1;
 
 	uuid_copy(arg->cont_uuid, *(uuid_t *)key_iov->iov_buf);
 	D_DEBUG(DB_REBUILD, "iter cont "DF_UUID"/%"PRIx64" %"PRIx64" start\n",
@@ -1003,16 +1088,30 @@ puller_cont_iter_cb(daos_handle_t ih, d_iov_t *key_iov,
 		tls->rebuild_pool_hdl = ph;
 	}
 
-	rc = dc_cont_local_open(arg->cont_uuid, rpt->rt_coh_uuid,
-				0, tls->rebuild_pool_hdl, &coh);
+	rc = cont_iv_snapshots_fetch(rpt->rt_pool->sp_iv_ns, arg->cont_uuid,
+				     &snapshots, &snap_cnt);
 	if (rc)
 		return rc;
+
+	rc = dc_cont_local_open(arg->cont_uuid, rpt->rt_coh_uuid,
+				0, tls->rebuild_pool_hdl, &coh);
+	if (rc) {
+		if (snapshots)
+			D_FREE(snapshots);
+		return rc;
+	}
 
 	arg->cont_hdl	= coh;
 	arg->yield_freq	= DEFAULT_YIELD_FREQ;
 	arg->obj_cnt	= root->count;
 	arg->cont_root	= root;
-	arg->yielded	= false;
+	if (snap_cnt > 0) {
+		arg->snaps = snapshots;
+		arg->snap_cnt = snap_cnt;
+	} else {
+		arg->snaps = NULL;
+		arg->snap_cnt = 0;
+	}
 
 	do {
 		arg->re_iter = false;
@@ -1027,21 +1126,24 @@ puller_cont_iter_cb(daos_handle_t ih, d_iov_t *key_iov,
 		}
 	} while (arg->re_iter);
 
-	rc = dc_cont_local_close(tls->rebuild_pool_hdl, coh);
-	if (rc)
-		return rc;
+	if (arg->snaps) {
+		D_FREE(arg->snaps);
+		arg->snap_cnt = 0;
+	}
+
+	rc1 = dc_cont_local_close(tls->rebuild_pool_hdl, coh);
+	if (rc1 != 0 || rc != 0)
+		return rc ? rc : rc1;
 
 	D_DEBUG(DB_REBUILD, "iter cont "DF_UUID"/%"PRIx64" finish.\n",
 		DP_UUID(arg->cont_uuid), ih.cookie);
 
-	if (arg->yielded) {
-		/* Some one might insert new record to the tree let's reprobe */
-		rc = dbtree_iter_probe(ih, BTR_PROBE_EQ, DAOS_INTENT_REBUILD,
-				       key_iov, NULL);
-		if (rc) {
-			D_ASSERT(rc != -DER_NONEXIST);
-			return rc;
-		}
+	/* Snapshot fetch will yield the ULT, let's reprobe before delete  */
+	rc = dbtree_iter_probe(ih, BTR_PROBE_EQ, DAOS_INTENT_REBUILD,
+			       key_iov, NULL);
+	if (rc) {
+		D_ASSERT(rc != -DER_NONEXIST);
+		return rc;
 	}
 
 	rc = dbtree_iter_delete(ih, NULL);
@@ -1319,7 +1421,7 @@ rebuild_obj_handler(crt_rpc_t *rpc)
 	 */
 	rpt = rpt_lookup(rebuild_in->roi_pool_uuid,
 			 rebuild_in->roi_rebuild_ver);
-	if (rpt == NULL || rpt->rt_pool == NULL)
+	if (rpt == NULL || rpt->rt_pool == NULL || rpt->rt_stable_epoch == 0)
 		D_GOTO(out, rc = -DER_AGAIN);
 
 	/* Initialize the local rebuild tree */

--- a/src/rebuild/rebuild_iv.c
+++ b/src/rebuild/rebuild_iv.c
@@ -175,8 +175,10 @@ rebuild_iv_ent_refresh(struct ds_iv_entry *entry, struct ds_iv_key *key,
 	dst_iv->riv_master_rank = src_iv->riv_master_rank;
 	dst_iv->riv_global_done = src_iv->riv_global_done;
 	dst_iv->riv_global_scan_done = src_iv->riv_global_scan_done;
+	dst_iv->riv_stable_epoch = src_iv->riv_stable_epoch;
 
-	if (dst_iv->riv_global_done || dst_iv->riv_global_scan_done) {
+	if (dst_iv->riv_global_done || dst_iv->riv_global_scan_done ||
+	    dst_iv->riv_stable_epoch) {
 		struct rebuild_tgt_pool_tracker *rpt;
 		d_rank_t	rank;
 		int		rc;
@@ -190,11 +192,18 @@ rebuild_iv_ent_refresh(struct ds_iv_entry *entry, struct ds_iv_key *key,
 			return 0;
 		}
 
-		D_DEBUG(DB_REBUILD, DF_UUID" rebuild finished"
-			" sgl/gl %d/%d\n",
+		D_DEBUG(DB_REBUILD, DF_UUID" rebuild status gsd/gd %d/%d"
+			" stable eph "DF_U64"\n",
 			 DP_UUID(src_iv->riv_pool_uuid),
 			 dst_iv->riv_global_scan_done,
-			 dst_iv->riv_global_done);
+			 dst_iv->riv_global_done, dst_iv->riv_stable_epoch);
+
+		if (rpt->rt_stable_epoch == 0)
+			rpt->rt_stable_epoch = dst_iv->riv_stable_epoch;
+		else if (rpt->rt_stable_epoch != dst_iv->riv_stable_epoch)
+			D_WARN("leader change stable epoch from "DF_U64" to "
+			       DF_U64 "\n", rpt->rt_stable_epoch,
+			       dst_iv->riv_stable_epoch);
 
 		/* on svc nodes update the rebuild status completed list
 		 * to serve rebuild status querying in case of master

--- a/src/rebuild/rpc.h
+++ b/src/rebuild/rpc.h
@@ -78,6 +78,7 @@ extern struct crt_proto_format rebuild_proto_fmt;
 
 #define DAOS_OSEQ_REBUILD_SCAN	/* output fields */		 \
 	((d_rank_list_t)	(rso_ranks_list)	CRT_PTR) \
+	((uint64_t)		(rso_stable_epoch)	CRT_VAR) \
 	((int32_t)		(rso_status)		CRT_VAR)
 
 CRT_RPC_DECLARE(rebuild_scan, DAOS_ISEQ_REBUILD_SCAN, DAOS_OSEQ_REBUILD_SCAN)

--- a/src/rebuild/scan.c
+++ b/src/rebuild/scan.c
@@ -940,7 +940,7 @@ rebuild_tgt_scan_handler(crt_rpc_t *rpc)
 	scan_arg->rebuild_tgt_nr = rsi->rsi_tgts_num;
 	rpt_get(rpt);
 	scan_arg->rpt = rpt;
-	/* step-3: start scann leader */
+	/* step-3: start scan leader */
 	rc = dss_ult_create(rebuild_scan_leader, scan_arg, DSS_ULT_REBUILD,
 			    DSS_TGT_SELF, 0, NULL);
 	if (rc != 0) {
@@ -960,6 +960,7 @@ out:
 		rpt_put(rpt);
 	ro = crt_reply_get(rpc);
 	ro->rso_status = rc;
+	ro->rso_stable_epoch = crt_hlc_get();
 	if (rc) {
 		/* If it failed, tell the master the target can not
 		 * start the rebuild, so master will put the target
@@ -982,10 +983,7 @@ out:
 	}
 
 	dss_rpc_reply(rpc, DAOS_REBUILD_DROP_SCAN);
-	/* will fix cart to call co_post_reply() for this case, freeing
-	 * it immediately at here is potentially unsafe.
-	 */
-	/* d_rank_list_free(fail_list); */
+	d_rank_list_free(fail_list);
 }
 
 int
@@ -998,6 +996,10 @@ rebuild_tgt_scan_aggregator(crt_rpc_t *source, crt_rpc_t *result,
 
 	if (dst->rso_status == 0)
 		dst->rso_status = src->rso_status;
+
+	if (src->rso_status == 0 &&
+	    dst->rso_stable_epoch < src->rso_stable_epoch)
+		dst->rso_stable_epoch = src->rso_stable_epoch;
 
 	if (src->rso_ranks_list == NULL ||
 	    src->rso_ranks_list->rl_nr == 0)
@@ -1061,13 +1063,3 @@ out:
 	return rc;
 }
 
-int
-rebuild_tgt_scan_post_reply(crt_rpc_t *rpc, void *arg)
-{
-	struct rebuild_scan_out *out = crt_reply_get(rpc);
-
-	if (out->rso_ranks_list != NULL)
-		d_rank_list_free(out->rso_ranks_list);
-
-	return 0;
-}

--- a/src/rebuild/srv.c
+++ b/src/rebuild/srv.c
@@ -569,14 +569,18 @@ rebuild_leader_status_check(struct ds_pool *pool, uint32_t map_ver,
 			D_FREE(targets);
 		}
 
-		if (!is_rebuild_global_pull_done(rgt) &&
-		    is_rebuild_global_scan_done(rgt)) {
+		if ((!is_rebuild_global_pull_done(rgt) &&
+		     is_rebuild_global_scan_done(rgt)) ||
+		     !rgt->rgt_notify_stable_epoch) {
 			struct rebuild_iv iv;
 
+			D_ASSERT(rgt->rgt_stable_epoch != 0);
 			memset(&iv, 0, sizeof(iv));
 			uuid_copy(iv.riv_pool_uuid, rgt->rgt_pool_uuid);
 			iv.riv_master_rank = pool->sp_iv_ns->iv_master_rank;
-			iv.riv_global_scan_done = 1;
+			iv.riv_global_scan_done =
+					is_rebuild_global_scan_done(rgt);
+			iv.riv_stable_epoch = rgt->rgt_stable_epoch;
 			iv.riv_ver = rgt->rgt_rebuild_ver;
 			iv.riv_leader_term = rgt->rgt_leader_term;
 
@@ -586,9 +590,17 @@ rebuild_leader_status_check(struct ds_pool *pool, uint32_t map_ver,
 			rc = rebuild_iv_update(pool->sp_iv_ns,
 					       &iv, CRT_IV_SHORTCUT_NONE,
 					       CRT_IV_SYNC_LAZY);
-			if (rc)
+			if (rc) {
 				D_WARN("rebuild master iv update failed: %d\n",
 				       rc);
+			} else {
+				/* Each server uses IV to notify the leader
+				 * its rebuild stable epoch, then the leader
+				 * will choose the largest epoch as the global
+				 * stable epoch to rebuild.
+				 */
+				rgt->rgt_notify_stable_epoch = 1;
+			}
 		}
 
 		/* query the current rebuild status */
@@ -608,8 +620,8 @@ rebuild_leader_status_check(struct ds_pool *pool, uint32_t map_ver,
 			(d_timeus_secdiff(0) - rgt->rgt_time_start) / 1e6;
 		snprintf(sbuf, RBLD_SBUF_LEN,
 			"Rebuild [%s] (pool "DF_UUID" ver=%u, toberb_obj="
-			DF_U64", rb_obj="DF_U64", rec= "DF_U64", size= "DF_U64
-			"done %d status %d/%d duration=%d secs)\n",
+			DF_U64", rb_obj="DF_U64", rec="DF_U64", size="DF_U64
+			" done %d status %d/%d duration=%d secs)\n",
 			str, DP_UUID(pool->sp_uuid), map_ver,
 			rs->rs_toberb_obj_nr, rs->rs_obj_nr, rs->rs_rec_nr,
 			rs->rs_size, rs->rs_done, rs->rs_errno,
@@ -627,6 +639,7 @@ rebuild_leader_status_check(struct ds_pool *pool, uint32_t map_ver,
 			last_print = now;
 			D_PRINT("%s", sbuf);
 		}
+
 		dss_ult_sleep(rgt->rgt_ult, RBLD_BCAST_INTV);
 	}
 
@@ -868,6 +881,7 @@ retry:
 		}
 	}
 
+	rgt->rgt_stable_epoch = rso->rso_stable_epoch;
 	rc = rso->rso_status;
 	if (rc != 0) {
 		D_ERROR(DF_UUID": failed to start pool rebuild: %d\n",
@@ -1442,6 +1456,7 @@ rebuild_fini_one(void *arg)
 {
 	struct rebuild_tgt_pool_tracker	*rpt = arg;
 	struct rebuild_pool_tls		*pool_tls;
+	struct ds_pool_child		*dpc;
 
 	pool_tls = rebuild_pool_tls_lookup(rpt->rt_pool_uuid,
 					   rpt->rt_rebuild_ver);
@@ -1461,6 +1476,26 @@ rebuild_fini_one(void *arg)
 	/* close the opened local ds_cont on main XS */
 	D_ASSERT(dss_get_module_info()->dmi_xs_id != 0);
 	ds_cont_local_close(rpt->rt_coh_uuid);
+
+	dpc = ds_pool_child_lookup(rpt->rt_pool_uuid);
+	D_ASSERT(dpc != NULL);
+
+	/* Reset rebuild epoch, then reset the aggregation epoch, so
+	 * it can aggregate the rebuild epoch.
+	 */
+	D_ASSERT(rpt->rt_rebuild_fence != 0);
+	if (rpt->rt_rebuild_fence == dpc->spc_rebuild_fence) {
+		dpc->spc_rebuild_fence = 0;
+		dpc->spc_rebuild_end_hlc = crt_hlc_get();
+		D_DEBUG(DB_REBUILD, DF_UUID": Reset aggregation end hlc "
+			DF_U64"\n", DP_UUID(rpt->rt_pool_uuid),
+			dpc->spc_rebuild_end_hlc);
+	} else {
+		D_DEBUG(DB_REBUILD, DF_UUID": pool is still being rebuilt"
+			" rt_rebuild_fence "DF_U64" spc_rebuild_fence "
+			DF_U64"\n", DP_UUID(rpt->rt_pool_uuid),
+			rpt->rt_rebuild_fence, dpc->spc_rebuild_fence);
+	}
 
 	return 0;
 }
@@ -1685,6 +1720,7 @@ rebuild_prepare_one(void *data)
 {
 	struct rebuild_tgt_pool_tracker	*rpt = data;
 	struct rebuild_pool_tls		*pool_tls;
+	struct ds_pool_child		*dpc;
 	int				 rc = 0;
 
 	pool_tls = rebuild_pool_tls_create(rpt->rt_pool_uuid, rpt->rt_poh_uuid,
@@ -1693,6 +1729,9 @@ rebuild_prepare_one(void *data)
 	if (pool_tls == NULL)
 		return -DER_NOMEM;
 
+	dpc = ds_pool_child_lookup(rpt->rt_pool_uuid);
+	D_ASSERT(dpc != NULL);
+
 	D_ASSERT(dss_get_module_info()->dmi_xs_id != 0);
 	/* Create ds_container locally on main XS */
 	rc = ds_cont_local_open(rpt->rt_pool_uuid, rpt->rt_coh_uuid,
@@ -1700,8 +1739,14 @@ rebuild_prepare_one(void *data)
 	if (rc)
 		pool_tls->rebuild_pool_status = rc;
 
-	D_DEBUG(DB_REBUILD, "open local container "DF_UUID"/"DF_UUID" rc %d\n",
-		DP_UUID(rpt->rt_pool_uuid), DP_UUID(rpt->rt_coh_uuid), rc);
+	/* Set the rebuild epoch per VOS container, so VOS aggregation will not
+	 * cross the epoch to cause problem.
+	 */
+	D_ASSERT(rpt->rt_rebuild_fence != 0);
+	dpc->spc_rebuild_fence = rpt->rt_rebuild_fence;
+	D_DEBUG(DB_REBUILD, "open local container "DF_UUID"/"DF_UUID
+		" rebuild eph "DF_U64" rc %d\n", DP_UUID(rpt->rt_pool_uuid),
+		DP_UUID(rpt->rt_coh_uuid), rpt->rt_rebuild_fence, rc);
 	return rc;
 }
 
@@ -1823,6 +1868,22 @@ rebuild_tgt_prepare(crt_rpc_t *rpc, struct rebuild_tgt_pool_tracker **p_rpt)
 		}
 	}
 
+	if (pool->sp_iv_ns) {
+		uuid_t	cont_uuid;
+
+		uuid_clear(cont_uuid);
+		/* Let's invalidate local snapshot cache before
+		 * rebuild, so to make sure rebuild will use the updated
+		 * snapshot during rebuild fetch, otherwise it may cause
+		 * corruption.
+		 */
+		rc = cont_iv_snapshot_invalidate(pool->sp_iv_ns, cont_uuid,
+						 CRT_IV_SHORTCUT_NONE,
+						 CRT_IV_SYNC_NONE);
+		if (rc)
+			D_GOTO(out, rc);
+	}
+
 	/* Create rpt for the target */
 	rc = rpt_create(pool, rsi->rsi_svc_list, rsi->rsi_rebuild_ver,
 			rsi->rsi_leader_term, &rpt);
@@ -1842,8 +1903,11 @@ rebuild_tgt_prepare(crt_rpc_t *rpc, struct rebuild_tgt_pool_tracker **p_rpt)
 					   rpt->rt_rebuild_ver);
 	if (pool_tls == NULL)
 		D_GOTO(out, rc = -DER_NOMEM);
+
+	rpt->rt_rebuild_fence = crt_hlc_get();
 	rc = dss_task_collective(rebuild_prepare_one, rpt, 0);
 	if (rc) {
+		rpt->rt_rebuild_fence = 0;
 		rebuild_pool_tls_destroy(pool_tls);
 		D_GOTO(out, rc);
 	}
@@ -1869,7 +1933,6 @@ out:
 static struct crt_corpc_ops rebuild_tgt_scan_co_ops = {
 	.co_aggregate	= rebuild_tgt_scan_aggregator,
 	.co_pre_forward	= rebuild_tgt_scan_pre_forward,
-	.co_post_reply	= rebuild_tgt_scan_post_reply,
 };
 
 /* Define for cont_rpcs[] array population below.

--- a/src/tests/ftest/daos_test/daos_core_test-rebuild.yaml
+++ b/src/tests/ftest/daos_test/daos_core_test-rebuild.yaml
@@ -19,16 +19,40 @@ daos_tests:
   num_replicas:
     num_replicas: 1
   Tests: !mux
-    test_r_0-16:
+    test_r_0-10:
       daos_test: r
-      test_name: rebuild tests 0-16
-      args: -s3 -u subtests="0-16"
+      test_name: rebuild tests 0-10
+      args: -s3 -u subtests="0-10"
       test_timeout: 1500
-    test_r_18-24:
+    test_r_12-18:
       daos_test: r
-      test_name: rebuild tests 18-24
-      args: -s3 -u subtests="18-24"
+      test_name: rebuild tests 12-18
+      args: -s3 -u subtests="12-18"
       test_timeout: 1500
+    test_r_19:
+      daos_test: r
+      test_name: rebuild tests 19
+      args: -s3 -u subtests="19"
+    test_r_20:
+      daos_test: r
+      test_name: rebuild tests 20
+      args: -s3 -u subtests="27"
+    test_r_21:
+      daos_test: r
+      test_name: rebuild tests 21
+      args: -s3 -u subtests="21"
+    test_r_22:
+      daos_test: r
+      test_name: rebuild tests 22
+      args: -s3 -u subtests="22"
+    test_r_23:
+      daos_test: r
+      test_name: rebuild tests 23
+      args: -s3 -u subtests="23"
+    test_r_24:
+      daos_test: r
+      test_name: rebuild tests 24
+      args: -s3 -u subtests="24"
     test_r_25:
       daos_test: r
       test_name: rebuild tests 25
@@ -41,12 +65,4 @@ daos_tests:
       daos_test: r
       test_name: rebuild tests 27
       args: -s3 -u subtests="27"
-    test_r_28:
-      daos_test: r
-      test_name: rebuild tests 28
-      args: -s3 -u subtests="28"
-    test_r_31:
-      daos_test: r
-      test_name: rebuild tests 31
-      args: -s3 -u subtests="31"
       test_timeout: 1500

--- a/src/tests/ftest/daos_test/daos_core_test.yaml
+++ b/src/tests/ftest/daos_test/daos_core_test.yaml
@@ -69,6 +69,10 @@ daos_tests:
     test_R:
       daos_test: R
       test_name: DAOS MD replication tests
+    test_v:
+      daos_test: v
+      test_name: DAOS rebuild simple tests
+      test_timeout: 1500
     test_O:
       daos_test: O
       test_name: OID Allocator tests

--- a/src/tests/suite/daos_iotest.h
+++ b/src/tests/suite/daos_iotest.h
@@ -104,7 +104,10 @@ int
 enumerate_dkey(daos_handle_t th, uint32_t *number, daos_key_desc_t *kds,
 	       daos_anchor_t *anchor, void *buf, daos_size_t len,
 	       struct ioreq *req);
-
+int
+enumerate_akey(daos_handle_t th, char *dkey, uint32_t *number,
+	       daos_key_desc_t *kds, daos_anchor_t *anchor, void *buf,
+	       daos_size_t len, struct ioreq *req);
 void
 insert(const char *dkey, int nr, const char **akey, daos_size_t *iod_size,
 	int *rx_nr, uint64_t *idx, void **val, daos_handle_t th,

--- a/src/tests/suite/daos_obj.c
+++ b/src/tests/suite/daos_obj.c
@@ -1048,7 +1048,7 @@ enumerate_dkey(daos_handle_t th, uint32_t *number, daos_key_desc_t *kds,
 	return rc;
 }
 
-static int
+int
 enumerate_akey(daos_handle_t th, char *dkey, uint32_t *number,
 	       daos_key_desc_t *kds, daos_anchor_t *anchor, void *buf,
 	       daos_size_t len, struct ioreq *req)

--- a/src/tests/suite/daos_rebuild_simple.c
+++ b/src/tests/suite/daos_rebuild_simple.c
@@ -1,0 +1,616 @@
+/**
+ * (C) Copyright 2016-2019 Intel Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * GOVERNMENT LICENSE RIGHTS-OPEN SOURCE SOFTWARE
+ * The Government's rights to use, modify, reproduce, release, perform, display,
+ * or disclose this software are subject to the terms of the Apache License as
+ * provided in Contract No. B609815.
+ * Any reproduction of computer software, computer software documentation, or
+ * portions thereof marked with this legend must also reproduce the markings.
+ */
+/**
+ * This file is for simple tests of rebuild, which does not need to kill the
+ * rank, and only used to verify the consistency after different data model
+ * rebuild.
+ *
+ * tests/suite/daos_rebuild_simple.c
+ *
+ *
+ */
+#define D_LOGFAC	DD_FAC(tests)
+
+#include "daos_iotest.h"
+#include <daos/pool.h>
+#include <daos/mgmt.h>
+#include <daos/container.h>
+
+#define KEY_NR		100
+#define OBJ_NR		10
+#define OBJ_CLS		OC_RP_3G1
+#define OBJ_REPLICAS	3
+#define DEFAULT_FAIL_TGT 0
+#define REBUILD_POOL_SIZE	(4ULL << 30)
+#define REBUILD_SUBTEST_POOL_SIZE (1ULL << 30)
+#define REBUILD_SMALL_POOL_SIZE (1ULL << 28)
+
+static void
+rebuild_dkeys(void **state)
+{
+	test_arg_t		*arg = *state;
+	daos_obj_id_t		oid;
+	struct ioreq		req;
+	int			tgt = DEFAULT_FAIL_TGT;
+	int			i;
+
+	if (!test_runable(arg, 4))
+		return;
+
+	oid = dts_oid_gen(DAOS_OC_R3S_SPEC_RANK, 0, arg->myrank);
+	oid = dts_oid_set_rank(oid, ranks_to_kill[0]);
+	oid = dts_oid_set_tgt(oid, tgt);
+	ioreq_init(&req, arg->coh, oid, DAOS_IOD_ARRAY, arg);
+
+	/** Insert 1000 records */
+	print_message("Insert %d kv record in object "DF_OID"\n",
+		      KEY_NR, DP_OID(oid));
+	for (i = 0; i < KEY_NR; i++) {
+		char	key[16];
+
+		sprintf(key, "dkey_0_%d", i);
+		insert_single(key, "a_key", 0, "data", strlen("data") + 1,
+			      DAOS_TX_NONE, &req);
+	}
+	ioreq_fini(&req);
+
+	rebuild_single_pool_target(arg, ranks_to_kill[0], tgt);
+
+	rebuild_add_back_tgts(arg, ranks_to_kill[0], &tgt, 1);
+}
+
+static void
+rebuild_akeys(void **state)
+{
+	test_arg_t		*arg = *state;
+	daos_obj_id_t		oid;
+	struct ioreq		req;
+	int			tgt = DEFAULT_FAIL_TGT;
+	int			i;
+
+	if (!test_runable(arg, 4))
+		return;
+
+	oid = dts_oid_gen(DAOS_OC_R3S_SPEC_RANK, 0, arg->myrank);
+	oid = dts_oid_set_rank(oid, ranks_to_kill[0]);
+	oid = dts_oid_set_tgt(oid, tgt);
+	ioreq_init(&req, arg->coh, oid, DAOS_IOD_ARRAY, arg);
+
+	/** Insert 1000 records */
+	print_message("Insert %d kv record in object "DF_OID"\n",
+		      KEY_NR, DP_OID(oid));
+	for (i = 0; i < KEY_NR; i++) {
+		char	akey[16];
+
+		sprintf(akey, "%d", i);
+		insert_single("dkey_1_0", akey, 0, "data", strlen("data") + 1,
+			      DAOS_TX_NONE, &req);
+	}
+	ioreq_fini(&req);
+
+	rebuild_single_pool_target(arg, ranks_to_kill[0], tgt);
+
+	rebuild_add_back_tgts(arg, ranks_to_kill[0], &tgt, 1);
+}
+
+static void
+rebuild_indexes(void **state)
+{
+	test_arg_t		*arg = *state;
+	daos_obj_id_t		oid;
+	struct ioreq		req;
+	int			tgt = DEFAULT_FAIL_TGT;
+	int			i;
+	int			j;
+
+	if (!test_runable(arg, 4))
+		return;
+
+	oid = dts_oid_gen(DAOS_OC_R3S_SPEC_RANK, 0, arg->myrank);
+	oid = dts_oid_set_rank(oid, ranks_to_kill[0]);
+	oid = dts_oid_set_tgt(oid, tgt);
+	ioreq_init(&req, arg->coh, oid, DAOS_IOD_ARRAY, arg);
+
+	/** Insert 2000 records */
+	print_message("Insert %d kv record in object "DF_OID"\n",
+		      2000, DP_OID(oid));
+	for (i = 0; i < KEY_NR; i++) {
+		char	key[16];
+
+		sprintf(key, "dkey_2_%d", i);
+		for (j = 0; j < 20; j++)
+			insert_single(key, "a_key", j, "data",
+				      strlen("data") + 1, DAOS_TX_NONE, &req);
+	}
+	ioreq_fini(&req);
+
+	/* Rebuild rank 1 */
+	rebuild_single_pool_target(arg, ranks_to_kill[0], tgt);
+
+	rebuild_add_back_tgts(arg, ranks_to_kill[0], &tgt, 1);
+}
+
+static void
+rebuild_snap_update_recs(void **state)
+{
+	test_arg_t	*arg = *state;
+	daos_obj_id_t	oid;
+	struct ioreq	req;
+	daos_recx_t	recx;
+	int		tgt = DEFAULT_FAIL_TGT;
+	char		string[100] = { 0 };
+	daos_epoch_t	snap_epoch[5];
+	int		i;
+
+	if (!test_runable(arg, 4))
+		return;
+
+	oid = dts_oid_gen(DAOS_OC_R3S_SPEC_RANK, 0, arg->myrank);
+	oid = dts_oid_set_rank(oid, ranks_to_kill[0]);
+	oid = dts_oid_set_tgt(oid, tgt);
+	ioreq_init(&req, arg->coh, oid, DAOS_IOD_ARRAY, arg);
+	for (i = 0; i < 5; i++)
+		sprintf(string + strlen(string), "old-snap%d", i);
+
+	recx.rx_idx = 0;
+	recx.rx_nr = strlen(string);
+	insert_recxs("d_key", "a_key", 1, DAOS_TX_NONE, &recx, 1, string,
+		     strlen(string) + 1, &req);
+
+	for (i = 0; i < 5; i++) {
+		char data[20] = { 0 };
+
+		/* Update string for each snapshot */
+		daos_cont_create_snap(arg->coh, &snap_epoch[i], NULL, NULL);
+		sprintf(data, "new-snap%d", i);
+		recx.rx_idx = i * strlen(data);
+		recx.rx_nr = strlen(data);
+		insert_recxs("d_key", "a_key", 1, DAOS_TX_NONE, &recx, 1, data,
+			      strlen(data) + 1, &req);
+	}
+
+	rebuild_single_pool_target(arg, ranks_to_kill[0], tgt);
+
+	daos_fail_loc_set(DAOS_OBJ_SPECIAL_SHARD);
+	for (i = 0; i < OBJ_REPLICAS; i++) {
+		daos_handle_t th_open;
+		char verify_data[100];
+		char data[100] = { 0 };
+		int j;
+
+		strcpy(verify_data, string);
+		daos_fail_value_set(i);
+		for (j = 0; j < 5; j++) {
+			char tmp[20];
+
+			recx.rx_idx = 0;
+			recx.rx_nr = strlen(verify_data);
+			daos_tx_open_snap(arg->coh, snap_epoch[j], &th_open,
+					  NULL);
+			lookup_recxs("d_key", "a_key", 1, th_open, &recx, 1,
+				      data, strlen(verify_data), &req);
+			assert_memory_equal(data, verify_data,
+					    strlen(verify_data));
+			daos_tx_close(th_open, NULL);
+
+			sprintf(tmp, "new-snap%d", j);
+			memcpy(verify_data + j * 9, tmp, strlen(tmp));
+		}
+
+		recx.rx_idx = 0;
+		recx.rx_nr = strlen(verify_data);
+		lookup_recxs("d_key", "a_key", 1, DAOS_TX_NONE, &recx, 1,
+			     data, strlen(verify_data), &req);
+		assert_memory_equal(data, verify_data, strlen(verify_data));
+	}
+	ioreq_fini(&req);
+
+	rebuild_add_back_tgts(arg, ranks_to_kill[0], &tgt, 1);
+}
+
+static void
+rebuild_snap_punch_recs(void **state)
+{
+	test_arg_t	*arg = *state;
+	daos_obj_id_t	oid;
+	struct ioreq	req;
+	daos_recx_t	recx;
+	int		tgt = DEFAULT_FAIL_TGT;
+	char		string[100];
+	daos_epoch_t	snap_epoch[5];
+	int		i;
+
+	if (!test_runable(arg, 4))
+		return;
+
+	oid = dts_oid_gen(DAOS_OC_R3S_SPEC_RANK, 0, arg->myrank);
+	oid = dts_oid_set_rank(oid, ranks_to_kill[0]);
+	oid = dts_oid_set_tgt(oid, tgt);
+	ioreq_init(&req, arg->coh, oid, DAOS_IOD_ARRAY, arg);
+	for (i = 0; i < 5; i++)
+		sprintf(string + strlen(string), "old-snap%d", i);
+
+	recx.rx_idx = 0;
+	recx.rx_nr = strlen(string);
+	insert_recxs("d_key", "a_key", 1, DAOS_TX_NONE, &recx, 1, string,
+		     strlen(string) + 1, &req);
+
+	for (i = 0; i < 5; i++) {
+		/* punch string */
+		daos_cont_create_snap(arg->coh, &snap_epoch[i], NULL, NULL);
+		recx.rx_idx = i * 9; /* strlen("old-snap%d") */
+		recx.rx_nr = 9;
+		punch_recxs("d_key", "a_key", &recx, 1, DAOS_TX_NONE, &req);
+	}
+
+	rebuild_single_pool_target(arg, ranks_to_kill[0], tgt);
+
+	daos_fail_loc_set(DAOS_OBJ_SPECIAL_SHARD);
+	for (i = 0; i < OBJ_REPLICAS; i++) {
+		char verify_data[100];
+		char data[100] = { 0 };
+		int j;
+
+		strcpy(verify_data, string);
+		daos_fail_value_set(i);
+		for (j = 0; j < 5; j++) {
+			daos_handle_t th_open;
+			char tmp[] = "aaaaaaaaa";
+
+			recx.rx_idx = 0;
+			recx.rx_nr = strlen(verify_data);
+			daos_tx_open_snap(arg->coh, snap_epoch[j], &th_open,
+					  NULL);
+			lookup_recxs("d_key", "a_key", 1, th_open, &recx, 1,
+				      data, strlen(verify_data), &req);
+			assert_memory_equal(data, verify_data,
+					    strlen(verify_data));
+			daos_tx_close(th_open, NULL);
+			memcpy(verify_data, tmp, strlen(tmp));
+			memcpy(data, tmp, strlen(tmp));
+		}
+
+		lookup_recxs("d_key", "a_key", 1, DAOS_TX_NONE, &recx, 1,
+			      data, strlen(verify_data), &req);
+		assert_memory_equal(data, verify_data, strlen(verify_data));
+	}
+	ioreq_fini(&req);
+
+	rebuild_add_back_tgts(arg, ranks_to_kill[0], &tgt, 1);
+}
+
+static void
+rebuild_snap_update_keys(void **state)
+{
+	test_arg_t	*arg = *state;
+	daos_obj_id_t	oid;
+	struct ioreq	req;
+	int		tgt = DEFAULT_FAIL_TGT;
+	daos_epoch_t	snap_epoch[5];
+	int		i;
+
+	if (!test_runable(arg, 4))
+		return;
+
+	oid = dts_oid_gen(DAOS_OC_R3S_SPEC_RANK, 0, arg->myrank);
+	oid = dts_oid_set_rank(oid, ranks_to_kill[0]);
+	oid = dts_oid_set_tgt(oid, tgt);
+	ioreq_init(&req, arg->coh, oid, DAOS_IOD_ARRAY, arg);
+	/* Insert dkey/akey by different snapshot */
+	for (i = 0; i < 5; i++) {
+		char dkey[20] = { 0 };
+		char akey[20] = { 0 };
+
+		/* Update string for each snapshot */
+		daos_cont_create_snap(arg->coh, &snap_epoch[i], NULL, NULL);
+		sprintf(dkey, "dkey_%d", i);
+		sprintf(akey, "akey_%d", i);
+		insert_single(dkey, "a_key", 0, "data", 1, DAOS_TX_NONE, &req);
+		insert_single("dkey", akey, 0, "data", 1, DAOS_TX_NONE, &req);
+	}
+
+	rebuild_single_pool_target(arg, ranks_to_kill[0], tgt);
+
+	daos_fail_loc_set(DAOS_OBJ_SPECIAL_SHARD);
+	for (i = 0; i < OBJ_REPLICAS; i++) {
+		uint32_t	number;
+		daos_key_desc_t kds[10];
+		daos_anchor_t	anchor = { 0 };
+		char		buf[256];
+		int		buf_len = 256;
+		int		j;
+
+		daos_fail_value_set(i);
+		for (j = 0; j < 5; j++) {
+			daos_handle_t	th_open;
+
+			memset(&anchor, 0, sizeof(anchor));
+			daos_tx_open_snap(arg->coh, snap_epoch[j], &th_open,
+					  NULL);
+			number = 10;
+			enumerate_dkey(th_open, &number, kds, &anchor, buf,
+				       buf_len, &req);
+
+			assert_int_equal(number, j > 0 ? j+1 : 0);
+
+			number = 10;
+			memset(&anchor, 0, sizeof(anchor));
+			enumerate_akey(th_open, "dkey", &number, kds, &anchor,
+				       buf, buf_len, &req);
+
+			assert_int_equal(number, j);
+			daos_tx_close(th_open, NULL);
+		}
+		number = 10;
+		memset(&anchor, 0, sizeof(anchor));
+		enumerate_dkey(DAOS_TX_NONE, &number, kds, &anchor, buf,
+			       buf_len, &req);
+		assert_int_equal(number, 6);
+
+		number = 10;
+		memset(&anchor, 0, sizeof(anchor));
+		enumerate_akey(DAOS_TX_NONE, "dkey", &number, kds, &anchor,
+			       buf, buf_len, &req);
+		assert_int_equal(number, 5);
+	}
+
+	ioreq_fini(&req);
+	rebuild_add_back_tgts(arg, ranks_to_kill[0], &tgt, 1);
+}
+
+static void
+rebuild_snap_punch_keys(void **state)
+{
+	test_arg_t	*arg = *state;
+	daos_obj_id_t	oid;
+	struct ioreq	req;
+	int		tgt = DEFAULT_FAIL_TGT;
+	daos_epoch_t	snap_epoch[5];
+	int		i;
+
+	if (!test_runable(arg, 4))
+		return;
+
+	oid = dts_oid_gen(DAOS_OC_R3S_SPEC_RANK, 0, arg->myrank);
+	oid = dts_oid_set_rank(oid, ranks_to_kill[0]);
+	oid = dts_oid_set_tgt(oid, tgt);
+	ioreq_init(&req, arg->coh, oid, DAOS_IOD_ARRAY, arg);
+	/* Insert dkey/akey */
+	for (i = 0; i < 5; i++) {
+		char dkey[20] = { 0 };
+		char akey[20] = { 0 };
+
+		/* Update string for each snapshot */
+		sprintf(dkey, "dkey_%d", i);
+		sprintf(akey, "akey_%d", i);
+		insert_single(dkey, "a_key", 0, "data", 1, DAOS_TX_NONE, &req);
+		insert_single("dkey", akey, 0, "data", 1, DAOS_TX_NONE, &req);
+	}
+
+	/* Insert dkey/akey by different epoch */
+	for (i = 0; i < 5; i++) {
+		char dkey[20] = { 0 };
+		char akey[20] = { 0 };
+
+		daos_cont_create_snap(arg->coh, &snap_epoch[i], NULL, NULL);
+
+		sprintf(dkey, "dkey_%d", i);
+		sprintf(akey, "akey_%d", i);
+		punch_dkey(dkey, DAOS_TX_NONE, &req);
+		punch_akey("dkey", akey, DAOS_TX_NONE, &req);
+	}
+
+	rebuild_single_pool_target(arg, ranks_to_kill[0], tgt);
+
+	daos_fail_loc_set(DAOS_OBJ_SPECIAL_SHARD);
+	for (i = 0; i < OBJ_REPLICAS; i++) {
+		daos_key_desc_t  kds[10];
+		daos_anchor_t	 anchor;
+		char		 buf[256];
+		int		 buf_len = 256;
+		uint32_t	 number;
+		int		 j;
+
+		daos_fail_value_set(i);
+		for (j = 0; j < 5; j++) {
+			daos_handle_t th_open;
+
+			daos_tx_open_snap(arg->coh, snap_epoch[j], &th_open,
+					  NULL);
+			number = 10;
+			memset(&anchor, 0, sizeof(anchor));
+			enumerate_dkey(th_open, &number, kds, &anchor, buf,
+				       buf_len, &req);
+			assert_int_equal(number, 6 - j);
+
+			number = 10;
+			memset(&anchor, 0, sizeof(anchor));
+			enumerate_akey(th_open, "dkey", &number, kds,
+				       &anchor, buf, buf_len, &req);
+			assert_int_equal(number, 5 - j);
+
+			daos_tx_close(th_open, NULL);
+		}
+
+		number = 10;
+		memset(&anchor, 0, sizeof(anchor));
+		enumerate_dkey(DAOS_TX_NONE, &number, kds, &anchor, buf,
+			       buf_len, &req);
+		assert_int_equal(number, 1);
+
+		number = 10;
+		memset(&anchor, 0, sizeof(anchor));
+		enumerate_akey(DAOS_TX_NONE, "dkey", &number, kds, &anchor,
+			       buf, buf_len, &req);
+		assert_int_equal(number, 0);
+	}
+
+	ioreq_fini(&req);
+	rebuild_add_back_tgts(arg, ranks_to_kill[0], &tgt, 1);
+}
+
+static void
+rebuild_multiple(void **state)
+{
+	test_arg_t	*arg = *state;
+	daos_obj_id_t	oid;
+	struct ioreq	req;
+	int		tgt = DEFAULT_FAIL_TGT;
+	int		i;
+	int		j;
+	int		k;
+
+	if (!test_runable(arg, 4))
+		return;
+
+	oid = dts_oid_gen(DAOS_OC_R3S_SPEC_RANK, 0, arg->myrank);
+	oid = dts_oid_set_rank(oid, ranks_to_kill[0]);
+	oid = dts_oid_set_tgt(oid, tgt);
+	ioreq_init(&req, arg->coh, oid, DAOS_IOD_ARRAY, arg);
+
+	/** Insert 1000 records */
+	print_message("Insert %d kv record in object "DF_OID"\n",
+		      1000, DP_OID(oid));
+	for (i = 0; i < 10; i++) {
+		char	dkey[16];
+
+		sprintf(dkey, "dkey_3_%d", i);
+		for (j = 0; j < 10; j++) {
+			char	akey[16];
+
+			sprintf(akey, "akey_%d", j);
+			for (k = 0; k < 10; k++)
+				insert_single(dkey, akey, k, "data",
+					      strlen("data") + 1,
+					      DAOS_TX_NONE, &req);
+		}
+	}
+	ioreq_fini(&req);
+
+	rebuild_single_pool_target(arg, ranks_to_kill[0], tgt);
+	rebuild_add_back_tgts(arg, ranks_to_kill[0], &tgt, 1);
+}
+
+static void
+rebuild_large_rec(void **state)
+{
+	test_arg_t		*arg = *state;
+	daos_obj_id_t		oid;
+	struct ioreq		req;
+	int			tgt = DEFAULT_FAIL_TGT;
+	int			i;
+	char			buffer[5000];
+
+	if (!test_runable(arg, 4))
+		return;
+
+	oid = dts_oid_gen(DAOS_OC_R3S_SPEC_RANK, 0, arg->myrank);
+	oid = dts_oid_set_rank(oid, ranks_to_kill[0]);
+	oid = dts_oid_set_tgt(oid, tgt);
+	ioreq_init(&req, arg->coh, oid, DAOS_IOD_ARRAY, arg);
+
+	/** Insert 1000 records */
+	print_message("Insert %d kv record in object "DF_OID"\n",
+		      KEY_NR, DP_OID(oid));
+	memset(buffer, 'a', 5000);
+	for (i = 0; i < KEY_NR; i++) {
+		char	key[16];
+
+		sprintf(key, "dkey_4_%d", i);
+		insert_single(key, "a_key", 0, buffer, 5000, DAOS_TX_NONE,
+			      &req);
+	}
+	ioreq_fini(&req);
+
+	rebuild_single_pool_target(arg, ranks_to_kill[0], tgt);
+	rebuild_add_back_tgts(arg, ranks_to_kill[0], &tgt, 1);
+}
+
+static void
+rebuild_objects(void **state)
+{
+	test_arg_t	*arg = *state;
+	daos_obj_id_t	oids[OBJ_NR];
+	int		tgt = DEFAULT_FAIL_TGT;
+	int		i;
+
+	if (!test_runable(arg, 4))
+		return;
+
+	for (i = 0; i < OBJ_NR; i++) {
+		oids[i] = dts_oid_gen(DAOS_OC_R3S_SPEC_RANK, 0, arg->myrank);
+		oids[i] = dts_oid_set_rank(oids[i], ranks_to_kill[0]);
+		oids[i] = dts_oid_set_tgt(oids[i], DEFAULT_FAIL_TGT);
+	}
+
+	rebuild_io(arg, oids, OBJ_NR);
+
+	rebuild_single_pool_target(arg, ranks_to_kill[0], tgt);
+
+	rebuild_add_back_tgts(arg, ranks_to_kill[0], &tgt, 1);
+}
+
+/** create a new pool/container for each test */
+static const struct CMUnitTest rebuild_tests[] = {
+	{"REBUILD1: rebuild small rec mulitple dkeys",
+	 rebuild_dkeys, rebuild_small_sub_setup, test_teardown},
+	{"REBUILD2: rebuild small rec multiple akeys",
+	 rebuild_akeys, rebuild_small_sub_setup, test_teardown},
+	{"REBUILD3: rebuild small rec multiple indexes",
+	 rebuild_indexes, rebuild_small_sub_setup, test_teardown},
+	{"REBUILD4: rebuild small rec multiple keys/indexes",
+	 rebuild_multiple, rebuild_small_sub_setup, test_teardown},
+	{"REBUILD5: rebuild large rec single index",
+	 rebuild_large_rec, rebuild_small_sub_setup, test_teardown},
+	{"REBUILD6: rebuild records with multiple snapshots",
+	 rebuild_snap_update_recs, rebuild_small_sub_setup, test_teardown},
+	{"REBUILD7: rebuild punch/records with multiple snapshots",
+	 rebuild_snap_punch_recs, rebuild_small_sub_setup, test_teardown},
+	{"REBUILD8: rebuild keys with multiple snapshots",
+	 rebuild_snap_update_keys, rebuild_small_sub_setup, test_teardown},
+	{"REBUILD9: rebuild keys/punch with multiple snapshots",
+	 rebuild_snap_punch_keys, rebuild_small_sub_setup, test_teardown},
+	{"REBUILD10: rebuild multiple objects",
+	 rebuild_objects, rebuild_sub_setup, test_teardown},
+};
+
+int
+run_daos_rebuild_simple_test(int rank, int size, int *sub_tests,
+			     int sub_tests_size)
+{
+	int rc = 0;
+
+	MPI_Barrier(MPI_COMM_WORLD);
+	if (sub_tests_size == 0) {
+		sub_tests_size = ARRAY_SIZE(rebuild_tests);
+		sub_tests = NULL;
+	}
+
+	rc = run_daos_sub_tests(rebuild_tests, ARRAY_SIZE(rebuild_tests),
+				REBUILD_POOL_SIZE, sub_tests, sub_tests_size,
+				NULL, NULL);
+
+	MPI_Barrier(MPI_COMM_WORLD);
+
+	return rc;
+}

--- a/src/tests/suite/daos_test.c
+++ b/src/tests/suite/daos_test.c
@@ -34,7 +34,7 @@
  * all will be run if no test is specified. Tests will be run in order
  * so tests that kill nodes must be last.
  */
-#define TESTS "mpceXVizADKCoROdrFN"
+#define TESTS "mpceXVizADKCoROdrFNv"
 /**
  * These tests will only be run if explicity specified. They don't get
  * run if no test is specified.
@@ -75,6 +75,7 @@ print_usage(int rank)
 	print_message("daos_test -R|--MD_replication_tests\n");
 	print_message("daos_test -O|--oid_alloc\n");
 	print_message("daos_test -r|--rebuild\n");
+	print_message("daos_test -v|--rebuild_simple\n");
 	print_message("daos_test -N|--nvme_recovery\n");
 	print_message("daos_test -a|--daos_all_tests\n");
 	print_message("Default <daos_tests> runs all tests\n=============\n");
@@ -231,6 +232,14 @@ run_specified_tests(const char *tests, int rank, int size,
 			nr_failed += run_daos_nvme_recov_test(rank, size,
 						sub_tests, sub_tests_size);
 			break;
+		case 'v':
+			daos_test_print(rank, "\n\n=================");
+			daos_test_print(rank, "DAOS rebuild simple tests..");
+			daos_test_print(rank, "=================");
+			nr_failed += run_daos_rebuild_simple_test(rank, size,
+						sub_tests, sub_tests_size);
+			break;
+
 		default:
 			D_ASSERT(0);
 		}
@@ -286,6 +295,7 @@ main(int argc, char **argv)
 		{"oid_alloc",	no_argument,		NULL,	'O'},
 		{"degraded",	no_argument,		NULL,	'd'},
 		{"rebuild",	no_argument,		NULL,	'r'},
+		{"rebuild_simple",	no_argument,	NULL,	's'},
 		{"nvme_recovery",	no_argument,	NULL,	'N'},
 		{"group",	required_argument,	NULL,	'g'},
 		{"csum_type",	required_argument,	NULL,
@@ -314,7 +324,7 @@ main(int argc, char **argv)
 	memset(tests, 0, sizeof(tests));
 
 	while ((opt = getopt_long(argc, argv,
-				  "ampcCdXVizxADKeoROg:s:u:E:f:Fw:W:hrN",
+				  "ampcCdXVizxADKeoROg:s:u:E:f:Fw:W:hrNv",
 				  long_options, &index)) != -1) {
 		if (strchr(all_tests_defined, opt) != NULL) {
 			tests[ntests] = opt;

--- a/src/tests/suite/daos_test.h
+++ b/src/tests/suite/daos_test.h
@@ -287,6 +287,7 @@ int run_daos_checksum_test(int rank, int size);
 int run_daos_fs_test(int rank, int size, int *tests, int test_size);
 int run_daos_nvme_recov_test(int rank, int size, int *sub_tests,
 			     int sub_tests_size);
+int run_daos_rebuild_simple_test(int rank, int size, int *tests, int test_size);
 
 void daos_kill_server(test_arg_t *arg, const uuid_t pool_uuid, const char *grp,
 		      d_rank_list_t *svc, d_rank_t rank);
@@ -314,6 +315,17 @@ int run_daos_sub_tests(const struct CMUnitTest *tests, int tests_size,
 		       daos_size_t pool_size, int *sub_tests,
 		       int sub_tests_size, test_setup_cb_t setup_cb,
 		       test_teardown_cb_t teardown_cb);
+
+void rebuild_io(test_arg_t *arg, daos_obj_id_t *oids, int oids_nr);
+void rebuild_io_validate(test_arg_t *arg, daos_obj_id_t *oids, int oids_nr,
+			 bool discard);
+void rebuild_single_pool_target(test_arg_t *arg, d_rank_t failed_rank,
+				int failed_tgt);
+void rebuild_add_back_tgts(test_arg_t *arg, d_rank_t failed_rank,
+			   int *failed_tgts, int nr);
+
+int rebuild_sub_setup(void **state);
+int rebuild_small_sub_setup(void **state);
 
 static inline void
 daos_test_print(int rank, char *message)


### PR DESCRIPTION
Rebuild will iterate the snapshot epochs, then
iterate/fetch/update rebuild object by snapshot
epoch.

Create a global stable rebuild epoch, so rebuild will
use this stable epoch to rebuild the data on the spare
target. And also treat this rebuild epoch as snapshot,
so the aggregation will not cross the snapshot epoch.

Some minor fixes and cleanup for sgl and kds full check.

Revert PR-1331 for the moment, since it will cause rebuild-18
fails.

Add a few snapshot rebuild test cases.

Move some of the rebuild tests to simple test case(daos_rebuild_simple.c)

Signed-off-by: Di Wang <di.wang@intel.com>