### PR TITLE
DAOS-2586 btree: Dynamic tree order

### DIFF
--- a/src/common/tests/btree.c
+++ b/src/common/tests/btree.c
@@ -830,7 +830,7 @@ static int
 run_btree_open_create_test(void)
 {
 	static const struct CMUnitTest btree_open_create_test[] = {
-		{ "EVT001: btree_open_create test", ik_btr_open_create,
+		{ "BTR001: btree_open_create test", ik_btr_open_create,
 			NULL, NULL},
 		{ NULL, NULL, NULL, NULL }
 	};
@@ -843,7 +843,7 @@ static int
 run_btree_close_destroy_test(void)
 {
 	static const struct CMUnitTest btree_close_destroy_test[] = {
-		{ "EVT002: btree_close_destroy test", ik_btr_close_destroy,
+		{ "BTR002: btree_close_destroy test", ik_btr_close_destroy,
 			NULL, NULL},
 		{ NULL, NULL, NULL, NULL }
 	};
@@ -856,7 +856,7 @@ static int
 run_btree_query_test(void)
 {
 	static const struct CMUnitTest btree_query_test[] = {
-		{ "EVT003: btree_query test", ik_btr_query,
+		{ "BTR003: btree_query test", ik_btr_query,
 			NULL, NULL},
 		{ NULL, NULL, NULL, NULL }
 	};
@@ -869,7 +869,7 @@ static int
 run_btree_iter_test(void)
 {
 	static const struct CMUnitTest btree_iterate_test[] = {
-		{ "EVT004: btree_iterate test", ik_btr_iterate,
+		{ "BTR004: btree_iterate test", ik_btr_iterate,
 			NULL, NULL},
 		{ NULL, NULL, NULL, NULL }
 	};
@@ -882,7 +882,7 @@ static int
 run_btree_batch_oper_test(void)
 {
 	static const struct CMUnitTest btree_batch_oper_test[] = {
-		{ "EVT005: btree_batch_oper test", ik_btr_batch_oper,
+		{ "BTR005: btree_batch_oper test", ik_btr_batch_oper,
 			NULL, NULL},
 		{ NULL, NULL, NULL, NULL }
 	};
@@ -895,7 +895,7 @@ static int
 run_btree_perf_test(void)
 {
 	static const struct CMUnitTest btree_perf_test[] = {
-		{ "EVT006: btree_perf test", ik_btr_perf, NULL, NULL},
+		{ "BTR006: btree_perf test", ik_btr_perf, NULL, NULL},
 		{ NULL, NULL, NULL, NULL }
 	};
 
@@ -907,7 +907,7 @@ static int
 run_btree_kv_operate_test(void)
 {
 	static const struct CMUnitTest btree_kv_operate_test[] = {
-		{ "EVT007: btree_kv_operate test",
+		{ "BTR007: btree_kv_operate test",
 			ik_btr_kv_operate, NULL, NULL},
 		{ NULL, NULL, NULL, NULL }
 	};
@@ -924,6 +924,7 @@ static struct option btr_ops[] = {
 	{ "close",	no_argument,		NULL,	'c'	},
 	{ "update",	required_argument,	NULL,	'u'	},
 	{ "find",	required_argument,	NULL,	'f'	},
+	{ "dyn_tree",	no_argument,		NULL,	't'	},
 	{ "delete",	required_argument,	NULL,	'd'	},
 	{ "del_retain", required_argument,	NULL,	'r'	},
 	{ "query",	no_argument,		NULL,	'q'	},
@@ -939,6 +940,7 @@ main(int argc, char **argv)
 	struct timeval	tv;
 	int		rc = 0;
 	int		opt;
+	int		dynamic_flag = 0;
 
 	gettimeofday(&tv, NULL);
 	srand(tv.tv_usec);
@@ -950,13 +952,10 @@ main(int argc, char **argv)
 	if (rc != 0)
 		return rc;
 
-	rc = dbtree_class_register(IK_TREE_CLASS, BTR_FEAT_UINT_KEY, &ik_ops);
-	D_ASSERT(rc == 0);
-
 	optind = 0;
 
 	/* Check for -m option first */
-	while ((opt = getopt_long(argc, argv, "mC:Docqu:d:r:f:i:b:p:", btr_ops,
+	while ((opt = getopt_long(argc, argv, "tmC:Docqu:d:r:f:i:b:p:", btr_ops,
 				  NULL)) != -1) {
 		if (opt == 'm') {
 			D_PRINT("Using pmem\n");
@@ -965,7 +964,16 @@ main(int argc, char **argv)
 			D_ASSERT(rc == 0);
 			break;
 		}
+		if (opt == 't') {
+			D_PRINT("Using dynamic tree order\n");
+			dynamic_flag = BTR_FEAT_DYNAMIC_ROOT;
+		}
 	}
+
+
+	rc = dbtree_class_register(IK_TREE_CLASS,
+				   dynamic_flag | BTR_FEAT_UINT_KEY, &ik_ops);
+	D_ASSERT(rc == 0);
 
 	if (ik_utx == NULL) {
 		D_PRINT("Using vmem\n");
@@ -979,7 +987,7 @@ main(int argc, char **argv)
 	/* start over */
 	optind = 0;
 
-	while ((opt = getopt_long(argc, argv, "mC:Docqu:d:r:f:i:b:p:", btr_ops,
+	while ((opt = getopt_long(argc, argv, "tmC:Docqu:d:r:f:i:b:p:", btr_ops,
 				  NULL)) != -1) {
 		tst_fn_val.optval = optarg;
 		tst_fn_val.input = true;
@@ -1031,6 +1039,7 @@ main(int argc, char **argv)
 		default:
 			D_PRINT("Unsupported command %c\n", opt);
 		case 'm':
+		case 't':
 			/* handled previously */
 			rc = 0;
 			break;

--- a/src/common/tests/btree.sh
+++ b/src/common/tests/btree.sh
@@ -22,6 +22,7 @@ function print_help()
 Usage: btree.sh [OPTIONS]
     Options:
         -s [num]  Run with num keys
+        dyn       Run with dynamic root
         ukey      Use integer keys
         perf      Run performance tests
         direct    Use direct string key
@@ -40,6 +41,10 @@ while [ $# -gt 0 ]; do
             echo "Bad argument to -s option.  Must be numeric"
             print_help
         fi
+        shift
+        ;;
+    dyn)
+        DYN="-t"
         shift
         ;;
     perf)
@@ -74,7 +79,7 @@ run_test()
 
         echo "B+tree functional test..."
         DAOS_DEBUG="$DDEBUG"                        \
-        "${VCMD[@]}" "$BTR" "${PMEM}" -C "${UINT}${IPL}o:$ORDER" \
+        "${VCMD[@]}" "$BTR" "${DYN}" "${PMEM}" -C "${UINT}${IPL}o:$ORDER" \
         -c                                          \
         -o                                          \
         -u "$RECORDS"                               \
@@ -92,14 +97,14 @@ run_test()
         -D
 
         echo "B+tree batch operations test..."
-        "${VCMD[@]}" "$BTR" "${PMEM}" -C "${UINT}${IPL}o:$ORDER" \
+        "${VCMD[@]}" "$BTR" "${DYN}" "${PMEM}" -C "${UINT}${IPL}o:$ORDER" \
         -c                                          \
         -o                                          \
         -b "$BAT_NUM"                               \
         -D
     else
         echo "B+tree performance test..."
-        "${VCMD[@]}" "$BTR" "${PMEM}" -C "${UINT}${IPL}o:$ORDER" \
+        "${VCMD[@]}" "$BTR" "${DYN}" "${PMEM}" -C "${UINT}${IPL}o:$ORDER" \
         -p "$BAT_NUM"                               \
         -D
     fi

--- a/src/common/tests/btree_direct.c
+++ b/src/common/tests/btree_direct.c
@@ -1037,7 +1037,7 @@ static int
 run_btree_direct_open_create_test(void)
 {
 	static const struct CMUnitTest btree_direct_open_create_test[] = {
-		{ "EVT001: btree_direct_open_create test", sk_btr_open_create,
+		{ "BTD001: btree_direct_open_create test", sk_btr_open_create,
 			NULL, NULL},
 		{ NULL, NULL, NULL, NULL }
 	};
@@ -1050,7 +1050,7 @@ static int
 run_btree_direct_close_destroy_test(void)
 {
 	static const struct CMUnitTest btree_direct_close_destroy_test[] = {
-		{ "EVT002: btree_direct_close_destroy test",
+		{ "BTD002: btree_direct_close_destroy test",
 		sk_btr_close_destroy, NULL, NULL},
 		{ NULL, NULL, NULL, NULL }
 	};
@@ -1063,7 +1063,7 @@ static int
 run_btree_direct_query_test(void)
 {
 	static const struct CMUnitTest btree_direct_query_test[] = {
-		{ "EVT003: btree_direct_query test", sk_btr_query,
+		{ "BTD003: btree_direct_query test", sk_btr_query,
 			NULL, NULL},
 		{ NULL, NULL, NULL, NULL }
 	};
@@ -1076,7 +1076,7 @@ static int
 run_btree_direct_iter_test(void)
 {
 	static const struct CMUnitTest btree_direct_iterate_test[] = {
-		{ "EVT004: btree_direct_iterate test", sk_btr_iterate,
+		{ "BTD004: btree_direct_iterate test", sk_btr_iterate,
 			NULL, NULL},
 		{ NULL, NULL, NULL, NULL }
 	};
@@ -1089,7 +1089,7 @@ static int
 run_btree_direct_batch_oper_test(void)
 {
 	static const struct CMUnitTest btree_direct_batch_oper_test[] = {
-		{ "EVT005: btree_direct_batch_oper test", sk_btr_batch_oper,
+		{ "BTD005: btree_direct_batch_oper test", sk_btr_batch_oper,
 			NULL, NULL},
 		{ NULL, NULL, NULL, NULL }
 	};
@@ -1102,7 +1102,7 @@ static int
 run_btree_direct_perf_test(void)
 {
 	static const struct CMUnitTest btree_direct_perf_test[] = {
-		{ "EVT006: btree_direct_perf test", sk_btr_perf, NULL, NULL},
+		{ "BTD006: btree_direct_perf test", sk_btr_perf, NULL, NULL},
 		{ NULL, NULL, NULL, NULL }
 	};
 
@@ -1114,7 +1114,7 @@ static int
 run_btree_direct_kv_operate_test(void)
 {
 	static const struct CMUnitTest btree_direct_kv_operate_test[] = {
-		{ "EVT007: btree_direct_kv_operate test",
+		{ "BTD007: btree_direct_kv_operate test",
 			sk_btr_kv_operate, NULL, NULL},
 		{ NULL, NULL, NULL, NULL }
 	};

--- a/src/include/daos/btree.h
+++ b/src/include/daos/btree.h
@@ -88,20 +88,26 @@ struct btr_node {
 
 enum {
 	BTR_ORDER_MIN			= 3,
-	BTR_ORDER_MAX			= 4096
+	BTR_ORDER_MAX			= 255
 };
 
 /**
  * Tree root descriptor, it consits of tree attributes and reference to the
  * actual root node.
  *
- * NB: could be PM data structure.
+ * NB: Can be stored in pmem
  */
 struct btr_root {
-	/** btree order */
-	uint16_t			tr_order;
+	/** For dynamic tree ordering, the root node temporarily has less
+	 * entries than the order
+	 */
+	uint8_t				tr_node_size;
+	/** Internal index to select the node size */
+	uint8_t				tr_node_size_idx;
+	/** configured btree order */
+	uint8_t				tr_order;
 	/** depth of the tree */
-	uint16_t			tr_depth;
+	uint8_t				tr_depth;
 	/**
 	 * ID to find a registered tree class, which provides customized
 	 * funtions etc.
@@ -531,6 +537,10 @@ enum btr_feats {
 	 * to_key_cmp callback
 	 */
 	BTR_FEAT_DIRECT_KEY		= (1 << 1),
+	/** Root is dynamically sized up to tree order.  This bit is set for a
+	 *  tree class
+	 */
+	BTR_FEAT_DYNAMIC_ROOT		= (1 << 2),
 };
 
 /**

--- a/src/vos/vos_obj_index.c
+++ b/src/vos/vos_obj_index.c
@@ -685,7 +685,8 @@ vos_obj_tab_register()
 	D_DEBUG(DB_DF, "Registering class for OI table Class: %d\n",
 		VOS_BTR_OBJ_TABLE);
 
-	rc = dbtree_class_register(VOS_BTR_OBJ_TABLE, 0, &oi_btr_ops);
+	rc = dbtree_class_register(VOS_BTR_OBJ_TABLE, BTR_FEAT_DYNAMIC_ROOT,
+				   &oi_btr_ops);
 	if (rc)
 		D_ERROR("dbtree create failed\n");
 	return rc;

--- a/src/vos/vos_tree.c
+++ b/src/vos/vos_tree.c
@@ -781,21 +781,23 @@ static struct vos_btr_attr vos_btr_attrs[] = {
 	{
 		.ta_class	= VOS_BTR_DKEY,
 		.ta_order	= VOS_KTR_ORDER,
-		.ta_feats	= VOS_OFEAT_BITS | BTR_FEAT_DIRECT_KEY,
+		.ta_feats	= VOS_OFEAT_BITS | BTR_FEAT_DIRECT_KEY |
+				  BTR_FEAT_DYNAMIC_ROOT,
 		.ta_name	= "vos_dkey",
 		.ta_ops		= &key_btr_ops,
 	},
 	{
 		.ta_class	= VOS_BTR_AKEY,
 		.ta_order	= VOS_KTR_ORDER,
-		.ta_feats	= VOS_OFEAT_BITS | BTR_FEAT_DIRECT_KEY,
+		.ta_feats	= VOS_OFEAT_BITS | BTR_FEAT_DIRECT_KEY |
+				  BTR_FEAT_DYNAMIC_ROOT,
 		.ta_name	= "vos_akey",
 		.ta_ops		= &key_btr_ops,
 	},
 	{
 		.ta_class	= VOS_BTR_SINGV,
 		.ta_order	= VOS_SVT_ORDER,
-		.ta_feats	= 0,
+		.ta_feats	= BTR_FEAT_DYNAMIC_ROOT,
 		.ta_name	= "singv",
 		.ta_ops		= &singv_btr_ops,
 	},

--- a/utils/run_test.sh
+++ b/utils/run_test.sh
@@ -80,6 +80,10 @@ if [ -d "/mnt/daos" ]; then
     run_test src/common/tests/btree.sh perf -s 20000
     run_test src/common/tests/btree.sh perf direct -s 20000
     run_test src/common/tests/btree.sh perf ukey -s 20000
+    run_test src/common/tests/btree.sh dyn ukey -s 20000
+    run_test src/common/tests/btree.sh dyn -s 20000
+    run_test src/common/tests/btree.sh dyn perf -s 20000
+    run_test src/common/tests/btree.sh dyn perf ukey -s 20000
     run_test build/src/common/tests/umem_test
     run_test build/src/common/tests/sched
     run_test build/src/common/tests/drpc_tests


### PR DESCRIPTION
Dynamically size the root node if BTR_FEAT_DYNAMIC_ROOT is set
to optimize metadata usage for trees with very few entries