### PR TITLE
DAOS-2560 control: Use errors package

### DIFF
--- a/src/control/agent/security_rpc.go
+++ b/src/control/agent/security_rpc.go
@@ -100,12 +100,12 @@ func (m *SecurityModule) HandleCall(client *drpc.Client, method int32, body []by
 
 	info, err := security.DomainInfoFromUnixConn(client.Conn)
 	if err != nil {
-		return nil, errors.Wrap(err, "Unable to get credentials for client socket")
+		return nil, errors.WithMessage(err, "Unable to get credentials for client socket")
 	}
 
 	response, err := security.AuthSysRequestFromCreds(m.ext, info)
 	if err != nil {
-		return nil, errors.Wrap(err, "Failed to get AuthSys struct")
+		return nil, errors.WithMessage(err, "Failed to get AuthSys struct")
 	}
 
 	responseBytes, err := proto.Marshal(response)

--- a/src/control/agent/security_rpc.go
+++ b/src/control/agent/security_rpc.go
@@ -100,17 +100,17 @@ func (m *SecurityModule) HandleCall(client *drpc.Client, method int32, body []by
 
 	info, err := security.DomainInfoFromUnixConn(client.Conn)
 	if err != nil {
-		return nil, errors.Errorf("Unable to get credentials for client socket")
+		return nil, errors.Wrap(err, "Unable to get credentials for client socket")
 	}
 
 	response, err := security.AuthSysRequestFromCreds(m.ext, info)
 	if err != nil {
-		return nil, err
+		return nil, errors.Wrap(err, "Failed to get AuthSys struct")
 	}
 
 	responseBytes, err := proto.Marshal(response)
 	if err != nil {
-		return nil, err
+		return nil, errors.Wrap(err, "Failed to marshal response")
 	}
 	return responseBytes, nil
 }

--- a/src/control/drpc/domain_socket_server.go
+++ b/src/control/drpc/domain_socket_server.go
@@ -23,11 +23,11 @@
 package drpc
 
 import (
-	"errors"
-	"fmt"
 	"net"
 	"os"
 	"syscall"
+
+	"github.com/pkg/errors"
 )
 
 // MAXMSGSIZE is the maximum drpc message size that may be sent.
@@ -113,7 +113,7 @@ func ConnReceiver(d *DomainSocketServer) error {
 				}
 				return nil
 			default:
-				return fmt.Errorf("Unable to accept connection on unix socket %s: %s", d.sockFile, err)
+				return errors.Wrapf(err, "Unable to accept connection on unix socket %s", d.sockFile)
 			}
 		}
 
@@ -128,22 +128,22 @@ func ConnReceiver(d *DomainSocketServer) error {
 // go routine.
 func (d *DomainSocketServer) Start() error {
 
-	addr := &net.UnixAddr{d.sockFile, "unixpacket"}
+	addr := &net.UnixAddr{Name: d.sockFile, Net: "unixpacket"}
 
 	// Setup our unix domain socket for our socket server to listen on
 	err := syscall.Unlink(d.sockFile)
 	if err != nil && !os.IsNotExist(err) {
-		return fmt.Errorf("Unable to unlink %s: %s", d.sockFile, err)
+		return errors.Wrapf(err, "Unable to unlink %s", d.sockFile)
 	}
 
 	lis, err := net.ListenUnix("unixpacket", addr)
 	if err != nil {
-		return fmt.Errorf("Unable to listen on unix socket %s: %s", d.sockFile, err)
+		return errors.Wrapf(err, "Unable to listen on unix socket %s", d.sockFile)
 	}
 
 	err = os.Chmod(d.sockFile, 0777)
 	if err != nil {
-		return fmt.Errorf("Unable to set permissions on %s: %s", d.sockFile, err)
+		return errors.Wrapf(err, "Unable to set permissions on %s", d.sockFile)
 	}
 
 	d.listener = lis

--- a/src/control/drpc/rpc.go
+++ b/src/control/drpc/rpc.go
@@ -23,9 +23,8 @@
 package drpc
 
 import (
-	"fmt"
-
 	"github.com/golang/protobuf/proto"
+	"github.com/pkg/errors"
 )
 
 // ModuleState is an interface to allow a module to pass in private
@@ -60,7 +59,7 @@ func NewRPCService() *Service {
 func (r *Service) RegisterModule(mod Module) error {
 	_, ok := r.modules[mod.ID()]
 	if ok == true {
-		return fmt.Errorf("module with Id %d already exists", mod.ID())
+		return errors.Errorf("module with Id %d already exists", mod.ID())
 	}
 	r.modules[mod.ID()] = mod
 	return nil
@@ -94,7 +93,7 @@ func marshalResponse(sequence int64, status Status, body []byte) ([]byte, error)
 
 	responseBytes, mErr := proto.Marshal(&response)
 	if mErr != nil {
-		return nil, mErr
+		return nil, errors.Wrap(mErr, "Failed to marshal response")
 	}
 	return responseBytes, nil
 }
@@ -112,7 +111,7 @@ func (r *Service) ProcessMessage(client *Client, callBytes []byte) ([]byte, erro
 	}
 	module, ok := r.modules[rpcMsg.GetModule()]
 	if !ok {
-		err = fmt.Errorf("Attempted to call unregistered module")
+		err = errors.Errorf("Attempted to call unregistered module")
 		return marshalResponse(rpcMsg.GetSequence(), Status_FAILURE, nil)
 	}
 	respBody, err := module.HandleCall(client, rpcMsg.GetMethod(), rpcMsg.GetBody())

--- a/src/control/security/auth_sys.go
+++ b/src/control/security/auth_sys.go
@@ -128,7 +128,7 @@ func AuthSysRequestFromCreds(ext UserExt, creds *DomainInfo) (*auth.Credential, 
 
 	verifier, err := HashFromToken(&token)
 	if err != nil {
-		return nil, errors.Wrap(err, "Unable to generate verifier")
+		return nil, errors.WithMessage(err, "Unable to generate verifier")
 	}
 
 	verifierToken := auth.Token{

--- a/src/control/security/auth_sys.go
+++ b/src/control/security/auth_sys.go
@@ -25,14 +25,13 @@ package security
 
 import (
 	"crypto/sha512"
-	"errors"
-	"fmt"
 	"os"
 	"os/user"
 
 	"github.com/daos-stack/daos/src/control/security/auth"
 
 	"github.com/golang/protobuf/proto"
+	"github.com/pkg/errors"
 )
 
 // User is an interface wrapping a representation of a specific system user
@@ -54,8 +53,7 @@ func HashFromToken(token *auth.Token) ([]byte, error) {
 
 	tokenBytes, err := proto.Marshal(token)
 	if err != nil {
-		fmt.Errorf("Unable to marshal AuthToken (%s)", err)
-		return nil, err
+		return nil, errors.Wrap(err, "Unable to marshal AuthToken")
 	}
 
 	hash.Write(tokenBytes)
@@ -77,20 +75,20 @@ func AuthSysRequestFromCreds(ext UserExt, creds *DomainInfo) (*auth.Credential, 
 
 	userInfo, err := ext.LookupUserID(creds.creds.Uid)
 	if err != nil {
-		return nil, fmt.Errorf("Failed to lookup uid %v: %v",
-			creds.creds.Uid, err)
+		return nil, errors.Wrapf(err, "Failed to lookup uid %v",
+			creds.creds.Uid)
 	}
 
 	groupInfo, err := ext.LookupGroupID(creds.creds.Gid)
 	if err != nil {
-		return nil, fmt.Errorf("Failed to lookup gid %v: %v",
-			creds.creds.Gid, err)
+		return nil, errors.Wrapf(err, "Failed to lookup gid %v",
+			creds.creds.Gid)
 	}
 
 	groups, err := userInfo.GroupIDs()
 	if err != nil {
-		return nil, fmt.Errorf("Failed to get group IDs for user %v: %v",
-			userInfo.Username(), err)
+		return nil, errors.Wrapf(err, "Failed to get group IDs for user %v",
+			userInfo.Username())
 	}
 
 	name, err := os.Hostname()
@@ -122,7 +120,7 @@ func AuthSysRequestFromCreds(ext UserExt, creds *DomainInfo) (*auth.Credential, 
 	// Marshal our AuthSys token into a byte array
 	tokenBytes, err := proto.Marshal(&sys)
 	if err != nil {
-		return nil, fmt.Errorf("Unable to marshal AuthSys token (%s)", err)
+		return nil, errors.Wrap(err, "Unable to marshal AuthSys token")
 	}
 	token := auth.Token{
 		Flavor: auth.Flavor_AUTH_SYS,
@@ -130,7 +128,7 @@ func AuthSysRequestFromCreds(ext UserExt, creds *DomainInfo) (*auth.Credential, 
 
 	verifier, err := HashFromToken(&token)
 	if err != nil {
-		return nil, fmt.Errorf("Unable to generate verifier (%s)", err)
+		return nil, errors.Wrap(err, "Unable to generate verifier")
 	}
 
 	verifierToken := auth.Token{
@@ -154,7 +152,7 @@ func AuthSysFromAuthToken(authToken *auth.Token) (*auth.Sys, error) {
 	sysToken := &auth.Sys{}
 	err := proto.Unmarshal(authToken.GetData(), sysToken)
 	if err != nil {
-		return nil, fmt.Errorf("unmarshaling %s: %v", authToken.GetFlavor(), err)
+		return nil, errors.Wrapf(err, "unmarshaling %s", authToken.GetFlavor())
 	}
 	return sysToken, nil
 }

--- a/src/control/security/context.go
+++ b/src/control/security/context.go
@@ -24,10 +24,8 @@
 package security
 
 import (
-	"errors"
-	"fmt"
-
 	"github.com/daos-stack/daos/src/control/security/auth"
+	"github.com/pkg/errors"
 
 	uuid "github.com/satori/go.uuid"
 )
@@ -77,7 +75,7 @@ func (s *ContextMap) AddToken(requestor string, token *auth.Token) (*uuid.UUID, 
 	key, err := uuid.NewV4()
 
 	if err != nil {
-		return nil, fmt.Errorf("Unable to generate UUIDv4 UUID: %s", err)
+		return nil, errors.Wrap(err, "Unable to generate UUIDv4 UUID")
 	}
 	s.ctxmap[key] = NewContext(requestor, token)
 	return &key, nil

--- a/src/control/security/domain_info.go
+++ b/src/control/security/domain_info.go
@@ -28,6 +28,7 @@ import (
 	"syscall"
 
 	"github.com/daos-stack/daos/src/control/log"
+	"github.com/pkg/errors"
 	"golang.org/x/sys/unix"
 )
 
@@ -46,7 +47,7 @@ func InitDomainInfo(creds *syscall.Ucred, ctx string) *DomainInfo {
 func DomainInfoFromUnixConn(sock *net.UnixConn) (*DomainInfo, error) {
 	f, err := sock.File()
 	if err != nil {
-		return nil, err
+		return nil, errors.Wrap(err, "Failed to get socket file")
 	}
 	defer f.Close()
 
@@ -54,7 +55,7 @@ func DomainInfoFromUnixConn(sock *net.UnixConn) (*DomainInfo, error) {
 	fd := int(f.Fd())
 	creds, err := syscall.GetsockoptUcred(fd, syscall.SOL_SOCKET, syscall.SO_PEERCRED)
 	if err != nil {
-		return nil, err
+		return nil, errors.Wrap(err, "Failed to get sockopt creds")
 	}
 	log.Debugf("Pid: %d\n", creds.Pid)
 	log.Debugf("Uid: %d\n", creds.Uid)


### PR DESCRIPTION
Change security and dRPC Go code to use the errors pkg,
consistent with the mgmt code.

Signed-off-by: Kris Jacque <kristin.jacque@intel.com>