### PR TITLE
DAOS-2619 DFS: fix warnings with strncpy and name length in DFS and DFUSE

### DIFF
--- a/src/client/addons/dac_array.c
+++ b/src/client/addons/dac_array.c
@@ -1030,7 +1030,7 @@ dac_array_io(daos_handle_t array_oh, daos_handle_t th,
 	daos_size_t	num_records;
 	daos_off_t	record_i;
 	daos_csum_buf_t	null_csum;
-	struct io_params *head, *current;
+	struct io_params *head, *current = NULL;
 	daos_size_t	num_ios;
 	int		rc;
 
@@ -1107,6 +1107,7 @@ dac_array_io(daos_handle_t array_oh, daos_handle_t th,
 			tse_task_register_comp_cb(task, free_io_params_cb,
 						  &head, sizeof(head));
 		} else {
+			D_ASSERT(current);
 			current->next = params;
 			current = params;
 		}

--- a/src/client/dfs/dfs.c
+++ b/src/client/dfs/dfs.c
@@ -260,7 +260,7 @@ fetch_entry(daos_handle_t oh, daos_handle_t th, const char *name,
 	d_sg_list_t	sgls[INODE_AKEYS + 1];
 	d_iov_t	sg_iovs[INODE_AKEYS + 1];
 	daos_iod_t	iods[INODE_AKEYS + 1];
-	char		*value;
+	char		*value = NULL;
 	daos_key_t	dkey;
 	unsigned int	akeys_nr, i;
 	int		rc;
@@ -335,6 +335,7 @@ fetch_entry(daos_handle_t oh, daos_handle_t th, const char *name,
 		size_t sym_len = iods[INODE_AKEYS].iod_size;
 
 		if (sym_len != 0) {
+			D_ASSERT(value);
 			entry->value = strdup(value);
 			if (entry->value == NULL)
 				D_GOTO(out, rc = -DER_NOMEM);

--- a/src/client/dfuse/dfuse.h
+++ b/src/client/dfuse/dfuse.h
@@ -108,8 +108,8 @@ extern struct dfuse_inode_ops dfuse_pool_ops;
 struct dfuse_dfs {
 	struct dfuse_inode_ops	*dffs_ops;
 	dfs_t			*dffs_dfs;
-	char			dffs_pool[NAME_MAX];
-	char			dffs_cont[NAME_MAX];
+	char			dffs_pool[NAME_MAX + 1];
+	char			dffs_cont[NAME_MAX + 1];
 	daos_handle_t		dffs_poh;
 	daos_handle_t		dffs_coh;
 	daos_pool_info_t	dffs_pool_info;
@@ -463,7 +463,7 @@ struct dfuse_inode_entry {
 	 * even match the local kernels view of the projection as it is
 	 * not updated on local rename requests.
 	 */
-	char			ie_name[NAME_MAX];
+	char			ie_name[NAME_MAX + 1];
 
 	/** The parent inode of this entry.
 	 *

--- a/src/client/dfuse/dfuse_cont.c
+++ b/src/client/dfuse/dfuse_cont.c
@@ -62,7 +62,9 @@ dfuse_cont_open(fuse_req_t req, struct dfuse_inode_entry *parent,
 		D_GOTO(err, rc = ENOMEM);
 	}
 	strncpy(dfs->dffs_cont, name, NAME_MAX);
-	strncpy(dfs->dffs_pool, parent->ie_dfs->dffs_pool, NAME_MAX);
+	dfs->dffs_cont[NAME_MAX] = '\0';
+	strncpy(dfs->dffs_pool, parent->ie_dfs->dffs_pool, NAME_MAX - 1);
+	dfs->dffs_pool[NAME_MAX] = '\0';
 
 	if (create) {
 		rc = daos_cont_create(parent->ie_dfs->dffs_poh, co_uuid,
@@ -132,6 +134,7 @@ dfuse_cont_open(fuse_req_t req, struct dfuse_inode_entry *parent,
 
 	ie->ie_parent = parent->ie_stat.st_ino;
 	strncpy(ie->ie_name, name, NAME_MAX);
+	ie->ie_name[NAME_MAX] = '\0';
 
 	rc = dfs_ostat(dfs->dffs_dfs, ie->ie_obj, &ie->ie_stat);
 	if (rc != -DER_SUCCESS) {

--- a/src/client/dfuse/dfuse_pool.c
+++ b/src/client/dfuse/dfuse_pool.c
@@ -62,6 +62,7 @@ dfuse_pool_lookup(fuse_req_t req, struct dfuse_inode_entry *parent,
 		D_GOTO(err, rc = ENOMEM);
 	}
 	strncpy(dfs->dffs_pool, name, NAME_MAX);
+	dfs->dffs_pool[NAME_MAX] = '\0';
 
 	{
 		struct fuse_entry_param	entry = {0};
@@ -99,6 +100,7 @@ dfuse_pool_lookup(fuse_req_t req, struct dfuse_inode_entry *parent,
 
 	ie->ie_parent = parent->ie_stat.st_ino;
 	strncpy(ie->ie_name, name, NAME_MAX);
+	ie->ie_name[NAME_MAX] = '\0';
 
 	atomic_fetch_add(&ie->ie_ref, 1);
 	ie->ie_dfs = dfs;

--- a/src/client/dfuse/ops/create.c
+++ b/src/client/dfuse/ops/create.c
@@ -78,6 +78,7 @@ dfuse_cb_create(fuse_req_t req, struct dfuse_inode_entry *parent,
 	 * as the inode.
 	 */
 	strncpy(ie->ie_name, name, NAME_MAX);
+	ie->ie_name[NAME_MAX] = '\0';
 	ie->ie_parent = parent->ie_stat.st_ino;
 	ie->ie_dfs = parent->ie_dfs;
 	atomic_fetch_add(&ie->ie_ref, 1);

--- a/src/client/dfuse/ops/lookup.c
+++ b/src/client/dfuse/ops/lookup.c
@@ -117,6 +117,7 @@ dfuse_cb_lookup(fuse_req_t req, struct dfuse_inode_entry *parent,
 	}
 
 	strncpy(ie->ie_name, name, NAME_MAX);
+	ie->ie_name[NAME_MAX] = '\0';
 	atomic_fetch_add(&ie->ie_ref, 1);
 
 	rc = dfs_ostat(parent->ie_dfs->dffs_dfs, ie->ie_obj, &ie->ie_stat);

--- a/src/client/dfuse/ops/mkdir.c
+++ b/src/client/dfuse/ops/mkdir.c
@@ -49,6 +49,7 @@ dfuse_cb_mkdir(fuse_req_t req, struct dfuse_inode_entry *parent,
 	}
 
 	strncpy(ie->ie_name, name, NAME_MAX);
+	ie->ie_name[NAME_MAX] = '\0';
 	ie->ie_parent = parent->ie_stat.st_ino;
 	ie->ie_dfs = parent->ie_dfs;
 	atomic_fetch_add(&ie->ie_ref, 1);

--- a/src/client/dfuse/ops/readdir.c
+++ b/src/client/dfuse/ops/readdir.c
@@ -137,6 +137,7 @@ dfuse_cb_readdir(fuse_req_t req, struct dfuse_inode_entry *inode,
 			ie->ie_dfs = inode->ie_dfs;
 
 			strncpy(ie->ie_name, dirents[i].d_name, NAME_MAX);
+			ie->ie_name[NAME_MAX] = '\0';
 			atomic_fetch_add(&ie->ie_ref, 1);
 
 			/* As this code needs to know the stat struct, including

--- a/src/client/dfuse/ops/symlink.c
+++ b/src/client/dfuse/ops/symlink.c
@@ -50,6 +50,7 @@ dfuse_cb_symlink(fuse_req_t req, const char *link, fuse_ino_t parent,
 
 	desc->da = fs_handle->symlink_da;
 	strncpy(desc->ie->ie_name, name, NAME_MAX);
+	desc->ie->ie_name[NAME_MAX] = '\0';
 	desc->ie->ie_parent = parent;
 
 	desc->request.ir_inode_num = parent;

--- a/src/include/daos/rpc.h
+++ b/src/include/daos/rpc.h
@@ -210,9 +210,9 @@ int daos_rpc_send_wait(crt_rpc_t *rpc);
 static inline int
 daos_group_attach(const char *group_id, crt_group_t **group)
 {
-	D_DEBUG(DB_NET, "attaching to group '%s'\n", group_id);
 	if (group_id == NULL)
 		group_id = DAOS_DEFAULT_GROUP_ID;
+	D_DEBUG(DB_NET, "attaching to group '%s'\n", group_id);
 	return crt_group_attach((char *)group_id, group);
 }
 

--- a/src/include/daos_fs.h
+++ b/src/include/daos_fs.h
@@ -39,7 +39,7 @@ extern "C" {
 
 #include <dirent.h>
 
-#define DFS_MAX_PATH 128
+#define DFS_MAX_PATH NAME_MAX
 #define DFS_MAX_FSIZE (~0ULL)
 
 typedef struct dfs_obj dfs_obj_t;


### PR DESCRIPTION
Those warnings are spit out by newer versions of gcc.

Signed-off-by: Mohamad Chaarawi <mohamad.chaarawi@intel.com>