### PR TITLE
DAOS-2633 dtx: Remove check leader from VOS

### DIFF
--- a/src/common/fail_loc.c
+++ b/src/common/fail_loc.c
@@ -35,7 +35,7 @@ uint64_t daos_fail_value;
 uint64_t daos_fail_num;
 
 void
-daos_reset_fail_loc()
+daos_fail_loc_reset()
 {
 	daos_fail_loc_set(0);
 	D_DEBUG(DB_ANY, "*** fail_loc="DF_X64"\n", daos_fail_loc);

--- a/src/dtx/dtx_srv.c
+++ b/src/dtx/dtx_srv.c
@@ -110,7 +110,6 @@ dtx_setup(void)
 {
 	int	rc;
 
-	vos_dtx_register_check_leader(ds_pool_check_leader);
 	rc = dss_ult_create_all(dtx_batched_commit, NULL, true);
 	if (rc != 0)
 		D_ERROR("Failed to create DTX batched commit ULT: %d\n", rc);

--- a/src/include/daos/common.h
+++ b/src/include/daos/common.h
@@ -343,6 +343,8 @@ enum {
 void
 daos_fail_loc_set(uint64_t id);
 void
+daos_fail_loc_reset(void);
+void
 daos_fail_value_set(uint64_t val);
 void
 daos_fail_num_set(uint64_t num);
@@ -417,10 +419,11 @@ enum {
 #define DAOS_REBUILD_TGT_NOSPACE (DAOS_FAIL_UNIT_TEST_GROUP_LOC | 0x18)
 
 #define DAOS_RDB_SKIP_APPENDENTRIES_FAIL (DAOS_FAIL_UNIT_TEST_GROUP_LOC | 0x19)
-#define DAOS_FORCE_REFRESH_POOL_MAP	  (DAOS_FAIL_UNIT_TEST_GROUP_LOC | 0x20)
+#define DAOS_FORCE_REFRESH_POOL_MAP	  (DAOS_FAIL_UNIT_TEST_GROUP_LOC | 0x1a)
 
-#define DAOS_VOS_AGG_RANDOM_YIELD	(DAOS_FAIL_UNIT_TEST_GROUP_LOC | 0x1a)
-#define DAOS_VOS_AGG_MW_THRESH		(DAOS_FAIL_UNIT_TEST_GROUP_LOC | 0x1b)
+#define DAOS_VOS_AGG_RANDOM_YIELD	(DAOS_FAIL_UNIT_TEST_GROUP_LOC | 0x1b)
+#define DAOS_VOS_AGG_MW_THRESH		(DAOS_FAIL_UNIT_TEST_GROUP_LOC | 0x1c)
+#define DAOS_VOS_NON_LEADER		(DAOS_FAIL_UNIT_TEST_GROUP_LOC | 0x1d)
 
 #define DAOS_FAIL_CHECK(id) daos_fail_check(id)
 

--- a/src/include/daos_srv/vos.h
+++ b/src/include/daos_srv/vos.h
@@ -38,15 +38,6 @@
 #include <daos_srv/vos_types.h>
 
 /**
- * Register the function for checking whether the replica is leader or not.
- *
- * \param checker	[IN]	The specified function for checking leader.
- */
-void
-vos_dtx_register_check_leader(int (*checker)(uuid_t, daos_unit_oid_t *,
-			      uint32_t, struct pl_obj_layout **));
-
-/**
  * Add the given DTX to the Commit-on-Share (CoS) cache (in DRAM).
  *
  * \param coh		[IN]	Container open handle.

--- a/src/pool/srv_pool.c
+++ b/src/pool/srv_pool.c
@@ -2957,6 +2957,7 @@ ds_pool_check_leader(uuid_t pool_uuid, daos_unit_oid_t *oid,
 		D_GOTO(out, rc = leader);
 	}
 
+	D_DEBUG(DB_TRACE, "get new leader tgt id %d\n", leader);
 	rc = pool_map_find_target(pool->sp_map, leader, &target);
 	if (rc < 0)
 		goto out;

--- a/src/vos/vos_layout.h
+++ b/src/vos/vos_layout.h
@@ -168,6 +168,8 @@ enum vos_dtx_entry_flags {
 	DTX_EF_EXCHANGE_PENDING		= (1 << 0),
 	/* The DTX shares something with other DTX(s). */
 	DTX_EF_SHARES			= (1 << 1),
+	/* The DTX is the leader */
+	DTX_EF_LEADER			= (1 << 2),
 };
 
 /**


### PR DESCRIPTION
Let's remove check_leader callback from VOS

If the leader has been changed, then the leader
selected in vos_dtx_check_availability() can not
be trusted to decide the visiablity of the uncommited
data, consider the following sequence

 a) the leader(A) and other replicas finish the local
    operation, and the leader get the reply and insert
    it into COS, but other replicas are still in prepared
    status.

 b) Then leader(A) failed, and one of replicas(B) is
    choosen as the new leader.

 c) Then another fetch arrive at the new leader(B), since
    the dtx on B is still in prepared status, and it is
    also the new leader, so it will not fetch any valid
    data. Apperantly, this is not right.

So we should only trust the inital leader as the moderator.
And in this case, if the new leader B is not the initial
leader, let's just return EINPROGRESS and wait until the
new leader commit the transaction. And this also means we
should store the initial leader information in dtx entry.

This also means we can remove vos_dtx_register_check_leader

Signed-off-by: Wang Di <di.wang@intel.com>