### PR TITLE
DAOS-2636 control: succeed nvme format if no devices specified in config

### DIFF
--- a/src/control/dmg/utils.go
+++ b/src/control/dmg/utils.go
@@ -80,6 +80,7 @@ func annotateState(state *pb.ResponseState) {
 // unpackClientMap takes a map of addresses to result type and prints either
 // decoded struct or provided error.
 func unpackClientMap(i interface{}) string {
+	var answer interface{}
 	decoded := make(map[string]interface{})
 
 	switch v := i.(type) {
@@ -94,42 +95,57 @@ func unpackClientMap(i interface{}) string {
 		}
 	case client.ClientCtrlrMap:
 		for addr, res := range v {
-			if res.Err != nil {
-				decoded[addr] = res.Err.Error()
-			} else if len(res.Ctrlrs) > 0 {
-				decoded[addr] = res.Ctrlrs
-			} else {
-				for i := range res.Responses {
-					annotateState(res.Responses[i].State)
+			if res.Err == nil {
+				if len(res.Ctrlrs) > 0 {
+					answer = res.Ctrlrs
+				} else if len(res.Responses) == 0 {
+					answer = "unexpected error: no responses"
+				} else {
+					for i := range res.Responses {
+						annotateState(res.Responses[i].State)
+					}
+					answer = res.Responses
 				}
-				decoded[addr] = res.Responses
+			} else {
+				answer = res.Err.Error()
 			}
+			decoded[addr] = answer
 		}
 	case client.ClientModuleMap:
 		for addr, res := range v {
-			if res.Err != nil {
-				decoded[addr] = res.Err.Error()
-			} else if len(res.Modules) > 0 {
-				decoded[addr] = res.Modules
-			} else {
-				for i := range res.Responses {
-					annotateState(res.Responses[i].State)
+			if res.Err == nil {
+				if len(res.Modules) > 0 {
+					answer = res.Modules
+				} else if len(res.Responses) == 0 {
+					answer = "unexpected error: no responses"
+				} else {
+					for i := range res.Responses {
+						annotateState(res.Responses[i].State)
+					}
+					answer = res.Responses
 				}
-				decoded[addr] = res.Responses
+			} else {
+				answer = res.Err.Error()
 			}
+			decoded[addr] = answer
 		}
 	case client.ClientMountMap:
 		for addr, res := range v {
-			if res.Err != nil {
-				decoded[addr] = res.Err.Error()
-			} else if len(res.Mounts) > 0 {
-				decoded[addr] = res.Mounts
-			} else {
-				for i := range res.Responses {
-					annotateState(res.Responses[i].State)
+			if res.Err == nil {
+				if len(res.Mounts) > 0 {
+					answer = res.Mounts
+				} else if len(res.Responses) == 0 {
+					answer = "unexpected error: no responses"
+				} else {
+					for i := range res.Responses {
+						annotateState(res.Responses[i].State)
+					}
+					answer = res.Responses
 				}
-				decoded[addr] = res.Responses
+			} else {
+				answer = res.Err.Error()
 			}
+			decoded[addr] = answer
 		}
 	case client.ResultMap:
 		for addr, res := range v {

--- a/src/control/server/storage_nvme.go
+++ b/src/control/server/storage_nvme.go
@@ -51,7 +51,9 @@ const (
 var (
 	msgBdevAlreadyFormatted = "nvme storage has already been formatted and " +
 		"reformat not implemented"
-	msgBdevNotFound           = "controller at pci addr not found"
+	msgBdevNotFound = "controller at pci addr not found, check device exists " +
+		"and can be discovered, you may need to run `sudo daos_server " +
+		"storage prep-nvme` to setup SPDK to access SSDs"
 	msgBdevNotInited          = "nvme storage not initialized"
 	msgBdevClassNotSupported  = "operation unsupported on bdev class"
 	msgSpdkInitFail           = "SPDK env init, has setup been run?"
@@ -267,12 +269,6 @@ func (n *nvmeStorage) Format(i int, results *([]*pb.NvmeControllerResult)) {
 			newCret(
 				"format", pciAddr, status, errMsg,
 				common.UtilLogDepth+1))
-	}
-
-	if !n.initialized {
-		addCretFormat(
-			pb.ResponseStatus_CTRL_ERR_APP, msgBdevNotInited)
-		return
 	}
 
 	if n.formatted {


### PR DESCRIPTION
When executing cmd "daos_shell storage format" with daos_server
running as root, NVMe format should succeed if no devices are
specified in config. This will allow format to complete and IO
servers to start with only SCM storage specified. SCM will need to be
formatted with valid storage to continue. This change only effects
the behaviour of daos_server instances that are run as root, storage
format from control plane management tool (daos_shell) is only
supported when daos_server is started as root.

Previously NVMe/SPDK would require initialisation even if no devices
were specified in server config file.

Signed-off-by: Tom Nabarro <tom.nabarro@intel.com>