### PR TITLE
DAOS-2647 control: allow skip confirm through cli flag

### DIFF
--- a/src/control/dmg/shell.go
+++ b/src/control/dmg/shell.go
@@ -160,7 +160,7 @@ func setupShell() *ishell.Shell {
 			_, out := hasConns(conns.GetActiveConns(nil))
 			c.Println(out)
 
-			formatStor()
+			formatStor(false)
 		},
 	})
 
@@ -177,7 +177,7 @@ func setupShell() *ishell.Shell {
 				c.Println(err)
 			}
 
-			updateStor(params)
+			updateStor(params, false)
 		},
 	})
 

--- a/src/control/dmg/storage.go
+++ b/src/control/dmg/storage.go
@@ -104,7 +104,7 @@ func (s *FormatStorCmd) Execute(args []string) error {
 type UpdateStorCmd struct {
 	Force        bool   `short:"f" long:"force" description:"Perform update without prompting for confirmation"`
 	NVMeModel    string `short:"m" long:"nvme-model" description:"Only update firmware on NVMe SSDs with this model name/number." required:"1"`
-	NVMeStartRev string `short:"f" long:"nvme-fw-rev" description:"Only update firmware on NVMe SSDs currently running this firmware revision." required:"1"`
+	NVMeStartRev string `short:"r" long:"nvme-fw-rev" description:"Only update firmware on NVMe SSDs currently running this firmware revision." required:"1"`
 	NVMeFwPath   string `short:"p" long:"nvme-fw-path" description:"Update firmware on NVMe SSDs with image file at this path (path must be accessible on all servers)." required:"1"`
 	NVMeFwSlot   int    `short:"s" default:"0" long:"nvme-fw-slot" description:"Update firmware on NVMe SSDs to this firmware register."`
 }

--- a/src/control/dmg/storage.go
+++ b/src/control/dmg/storage.go
@@ -78,7 +78,7 @@ func formatStor(force bool) {
 			"Please be patient as it may take several minutes.\n" +
 			"Are you sure you want to continue? (yes/no)")
 
-	if getConsent(force) {
+	if getConsent(!force) {
 		fmt.Println("")
 		cCtrlrResults, cMountResults := conns.FormatStorage()
 		fmt.Printf(unpackClientMap(cCtrlrResults), "NVMe storage format result")
@@ -118,7 +118,7 @@ func updateStor(params *pb.UpdateStorageParams, force bool) {
 			"and be patient as it may take several minutes.\n" +
 			"Are you sure you want to continue? (yes/no)")
 
-	if getConsent(force) {
+	if getConsent(!force) {
 		fmt.Println("")
 		cCtrlrResults, cModuleResults := conns.UpdateStorage(params)
 		fmt.Printf(unpackClientMap(cCtrlrResults), "NVMe storage update result")

--- a/src/control/dmg/storage.go
+++ b/src/control/dmg/storage.go
@@ -66,17 +66,19 @@ func (s *ScanStorCmd) Execute(args []string) error {
 }
 
 // FormatStorCmd is the struct representing the format storage subcommand.
-type FormatStorCmd struct{}
+type FormatStorCmd struct {
+	Force bool `short:"f" long:"force" description:"Perform format without prompting for confirmation"`
+}
 
 // run NVMe and SCM storage format on all connected servers
-func formatStor() {
+func formatStor(force bool) {
 	fmt.Println(
 		"This is a destructive operation and storage devices " +
 			"specified in the server config file will be erased.\n" +
 			"Please be patient as it may take several minutes.\n" +
 			"Are you sure you want to continue? (yes/no)")
 
-	if getConsent() {
+	if getConsent(force) {
 		fmt.Println("")
 		cCtrlrResults, cMountResults := conns.FormatStorage()
 		fmt.Printf(unpackClientMap(cCtrlrResults), "NVMe storage format result")
@@ -90,7 +92,7 @@ func (s *FormatStorCmd) Execute(args []string) error {
 		return err
 	}
 
-	formatStor()
+	formatStor(s.Force)
 
 	// exit immediately to avoid continuation of main
 	os.Exit(0)
@@ -100,6 +102,7 @@ func (s *FormatStorCmd) Execute(args []string) error {
 
 // UpdateStorCmd is the struct representing the update storage subcommand.
 type UpdateStorCmd struct {
+	Force        bool   `short:"f" long:"force" description:"Perform update without prompting for confirmation"`
 	NVMeModel    string `short:"m" long:"nvme-model" description:"Only update firmware on NVMe SSDs with this model name/number." required:"1"`
 	NVMeStartRev string `short:"f" long:"nvme-fw-rev" description:"Only update firmware on NVMe SSDs currently running this firmware revision." required:"1"`
 	NVMeFwPath   string `short:"p" long:"nvme-fw-path" description:"Update firmware on NVMe SSDs with image file at this path (path must be accessible on all servers)." required:"1"`
@@ -107,7 +110,7 @@ type UpdateStorCmd struct {
 }
 
 // run NVMe and SCM storage update on all connected servers
-func updateStor(params *pb.UpdateStorageParams) {
+func updateStor(params *pb.UpdateStorageParams, force bool) {
 	fmt.Println(
 		"This could be a destructive operation and storage devices " +
 			"specified in the server config file will have firmware " +
@@ -115,7 +118,7 @@ func updateStor(params *pb.UpdateStorageParams) {
 			"and be patient as it may take several minutes.\n" +
 			"Are you sure you want to continue? (yes/no)")
 
-	if getConsent() {
+	if getConsent(force) {
 		fmt.Println("")
 		cCtrlrResults, cModuleResults := conns.UpdateStorage(params)
 		fmt.Printf(unpackClientMap(cCtrlrResults), "NVMe storage update result")
@@ -137,7 +140,7 @@ func (u *UpdateStorCmd) Execute(args []string) error {
 				Model: u.NVMeModel, Startrev: u.NVMeStartRev,
 				Path: u.NVMeFwPath, Slot: int32(u.NVMeFwSlot),
 			},
-		})
+		}, u.Force)
 
 	// exit immediately to avoid continuation of main
 	os.Exit(0)

--- a/src/control/dmg/storage.go
+++ b/src/control/dmg/storage.go
@@ -78,7 +78,7 @@ func formatStor(force bool) {
 			"Please be patient as it may take several minutes.\n" +
 			"Are you sure you want to continue? (yes/no)")
 
-	if getConsent(!force) {
+	if force || getConsent() {
 		fmt.Println("")
 		cCtrlrResults, cMountResults := conns.FormatStorage()
 		fmt.Printf(unpackClientMap(cCtrlrResults), "NVMe storage format result")
@@ -118,7 +118,7 @@ func updateStor(params *pb.UpdateStorageParams, force bool) {
 			"and be patient as it may take several minutes.\n" +
 			"Are you sure you want to continue? (yes/no)")
 
-	if getConsent(!force) {
+	if force || getConsent() {
 		fmt.Println("")
 		cCtrlrResults, cModuleResults := conns.UpdateStorage(params)
 		fmt.Printf(unpackClientMap(cCtrlrResults), "NVMe storage update result")

--- a/src/control/dmg/utils.go
+++ b/src/control/dmg/utils.go
@@ -154,8 +154,12 @@ func unpackClientMap(i interface{}) string {
 }
 
 // getConsent scans stdin for yes/no
-func getConsent() bool {
+func getConsent(skip bool) bool {
 	var response string
+
+	if skip {
+		return true
+	}
 
 	_, err := fmt.Scanln(&response)
 	if err != nil {
@@ -167,7 +171,7 @@ func getConsent() bool {
 		return false
 	} else if response != "yes" {
 		fmt.Println("Please type yes or no and then press enter:")
-		return getConsent()
+		return getConsent(false)
 	}
 
 	return true

--- a/src/control/dmg/utils.go
+++ b/src/control/dmg/utils.go
@@ -154,10 +154,10 @@ func unpackClientMap(i interface{}) string {
 }
 
 // getConsent scans stdin for yes/no
-func getConsent(skip bool) bool {
+func getConsent(interactive bool) bool {
 	var response string
 
-	if skip {
+	if !interactive {
 		return true
 	}
 
@@ -171,7 +171,7 @@ func getConsent(skip bool) bool {
 		return false
 	} else if response != "yes" {
 		fmt.Println("Please type yes or no and then press enter:")
-		return getConsent(false)
+		return getConsent(true)
 	}
 
 	return true

--- a/src/control/dmg/utils.go
+++ b/src/control/dmg/utils.go
@@ -154,12 +154,8 @@ func unpackClientMap(i interface{}) string {
 }
 
 // getConsent scans stdin for yes/no
-func getConsent(interactive bool) bool {
+func getConsent() bool {
 	var response string
-
-	if !interactive {
-		return true
-	}
 
 	_, err := fmt.Scanln(&response)
 	if err != nil {
@@ -171,7 +167,7 @@ func getConsent(interactive bool) bool {
 		return false
 	} else if response != "yes" {
 		fmt.Println("Please type yes or no and then press enter:")
-		return getConsent(true)
+		return getConsent()
 	}
 
 	return true


### PR DESCRIPTION
Enable skipping of confirmation for `daos_shell storage
format/update` commands by specifying -f/force flag.

Signed-off-by: Tom Nabarro <tom.nabarro@intel.com>