### PR TITLE
DAOS-2620 vos: Update metadata tool for dynamic tree order

### DIFF
--- a/src/include/daos/btree.h
+++ b/src/include/daos/btree.h
@@ -102,12 +102,10 @@ struct btr_root {
 	 * entries than the order
 	 */
 	uint8_t				tr_node_size;
-	/** Internal index to select the node size */
-	uint8_t				tr_node_size_idx;
 	/** configured btree order */
 	uint8_t				tr_order;
 	/** depth of the tree */
-	uint8_t				tr_depth;
+	uint16_t			tr_depth;
 	/**
 	 * ID to find a registered tree class, which provides customized
 	 * funtions etc.

--- a/src/include/daos/common.h
+++ b/src/include/daos/common.h
@@ -54,16 +54,27 @@
 #define DF_UOID		DF_OID".%u"
 #define DP_UOID(uo)	DP_OID((uo).id_pub), (uo).id_shard
 
+#define MAX_TREE_ORDER_INC	7
+
+struct daos_node_overhead {
+	/** Node size in bytes for tree with only */
+	int	no_size;
+	/** Order of node */
+	int	no_order;
+};
+
 /** Overheads for a tree */
 struct daos_tree_overhead {
-	/** Static size of an allocated tree node */
-	int			to_node_size;
+	/** Overhead for full size tree node */
+	struct daos_node_overhead	to_node_overhead;
+	/** Overhead for dynamic tree nodes */
+	struct daos_node_overhead	to_dyn_overhead[MAX_TREE_ORDER_INC];
+	/** Number of dynamic tree node sizes */
+	int				to_dyn_count;
+	/** Inline metadata size for each record */
+	int				to_node_rec_msize;
 	/** Dynamic metadata size of an allocated record. */
-	int			to_record_msize;
-	/** Size of first insertion.  Full node allocated on second key */
-	int			to_single_size;
-	/** Tree order */
-	int			to_order;
+	int				to_record_msize;
 };
 
 /*

--- a/src/vos/evtree.c
+++ b/src/vos/evtree.c
@@ -2845,11 +2845,13 @@ int evt_overhead_get(int alloc_overhead, int tree_order,
 		return -DER_INVAL;
 	}
 
+	ovhd->to_dyn_count = 0;
 	ovhd->to_record_msize = alloc_overhead + sizeof(struct evt_desc);
-	ovhd->to_single_size = alloc_overhead + sizeof(struct evt_desc) +
-		sizeof(struct evt_node_entry);
-	ovhd->to_node_size = alloc_overhead + sizeof(struct evt_node) +
+	ovhd->to_node_rec_msize = sizeof(struct evt_node_entry);
+	ovhd->to_node_overhead.no_size = alloc_overhead +
+		sizeof(struct evt_node) +
 		(tree_order * sizeof(struct evt_node_entry));
-	ovhd->to_order = tree_order;
+	ovhd->to_node_overhead.no_order = tree_order;
+
 	return 0;
 }

--- a/src/vos/vos_obj_index.c
+++ b/src/vos/vos_obj_index.c
@@ -685,8 +685,7 @@ vos_obj_tab_register()
 	D_DEBUG(DB_DF, "Registering class for OI table Class: %d\n",
 		VOS_BTR_OBJ_TABLE);
 
-	rc = dbtree_class_register(VOS_BTR_OBJ_TABLE, BTR_FEAT_DYNAMIC_ROOT,
-				   &oi_btr_ops);
+	rc = dbtree_class_register(VOS_BTR_OBJ_TABLE, 0, &oi_btr_ops);
 	if (rc)
 		D_ERROR("dbtree create failed\n");
 	return rc;


### PR DESCRIPTION
Removes single entry handling and replaces it with generalized
dynamic tree ordering based on what vos tool reports.
Remove order_idx and remove dynamic ordering from object tree
based on comments on a previous patch