### PR TITLE
DAOS-2651 rebuild: abort rebuild once scan fails

### DIFF
--- a/src/container/container_iv.c
+++ b/src/container/container_iv.c
@@ -265,7 +265,7 @@ again:
 			} else if (entry->iv_class->iv_class_id ==
 							IV_CONT_CAPA) {
 				/* Can not find the handle on leader */
-				rc = -DER_NO_PERM;
+				rc = -DER_NONEXIST;
 			}
 		}
 		D_DEBUG(DB_MGMT, "lookup cont: rc %d\n", rc);

--- a/src/object/cli_obj.c
+++ b/src/object/cli_obj.c
@@ -2008,8 +2008,8 @@ dc_obj_update(tse_task_t *task)
 	if (rc)
 		goto out_task;
 
-	D_DEBUG(DB_IO, "update "DF_OID" dkey %llu\n",
-		DP_OID(obj->cob_md.omd_id), (unsigned long long)dkey_hash);
+	D_DEBUG(DB_IO, "update "DF_OID" dkey_hash "DF_U64"\n",
+		DP_OID(obj->cob_md.omd_id), dkey_hash);
 
 	if (!obj_auxi->io_retry) {
 		rc = obj_rw_bulk_prep(obj, args->iods, args->sgls, args->nr,

--- a/src/object/srv_obj.c
+++ b/src/object/srv_obj.c
@@ -465,8 +465,9 @@ ds_check_container(uuid_t pool_uuid, uuid_t cont_hdl_uuid, uuid_t cont_uuid,
 	int			 rc;
 
 	rc = cont_iv_capa_fetch(pool_uuid, cont_hdl_uuid, cont_uuid, &cont_hdl);
-	if (rc == -DER_NONEXIST) {
-		rc = -DER_NO_PERM;
+	if (rc) {
+		if (rc == -DER_NONEXIST)
+			rc = -DER_NO_HDL;
 		D_GOTO(out, rc);
 	}
 

--- a/src/rebuild/scan.c
+++ b/src/rebuild/scan.c
@@ -906,6 +906,9 @@ rebuild_tgt_scan_aggregator(crt_rpc_t *source, crt_rpc_t *result,
 	struct rebuild_scan_out *dst = crt_reply_get(result);
 	int i;
 
+	if (dst->rso_status == 0)
+		dst->rso_status = src->rso_status;
+
 	if (src->rso_ranks_list == NULL ||
 	    src->rso_ranks_list->rl_nr == 0)
 		return 0;

--- a/src/rebuild/srv.c
+++ b/src/rebuild/srv.c
@@ -1177,6 +1177,11 @@ rebuild_task_ult(void *arg)
 		" as DOWNOUT: %d\n", task->dst_tgts.pti_ids[0].pti_id,
 		DP_UUID(task->dst_pool_uuid), rc);
 
+out:
+	/* NB: even if there are some failures, the leader should
+	 * still notify all other servers to stop their local
+	 * rebuild.
+	 */
 	memset(&iv, 0, sizeof(iv));
 	uuid_copy(iv.riv_pool_uuid, task->dst_pool_uuid);
 	iv.riv_master_rank	= pool->sp_iv_ns->iv_master_rank;
@@ -1191,7 +1196,6 @@ rebuild_task_ult(void *arg)
 	rc = rebuild_iv_update(pool->sp_iv_ns,
 			       &iv, CRT_IV_SHORTCUT_NONE,
 			       CRT_IV_SYNC_LAZY);
-out:
 	ds_pool_put(pool);
 	if (rgt) {
 		rgt->rgt_status.rs_version = rgt->rgt_rebuild_ver;

--- a/src/tests/ftest/daos_test/daos_core_test.yaml
+++ b/src/tests/ftest/daos_test/daos_core_test.yaml
@@ -23,7 +23,7 @@ daos_tests:
     test_r:
       daos_test: r
       test_name: rebuild tests
-      args: -u subtests="0-19"
+      args: -s3 -u subtests="0-23"
     test_d:
       daos_test: d
       test_name: DAOS degraded-mode tests

--- a/src/tests/suite/daos_rebuild.c
+++ b/src/tests/suite/daos_rebuild.c
@@ -34,12 +34,13 @@
 #include <daos/mgmt.h>
 #include <daos/container.h>
 
-#define KEY_NR		1000
+#define KEY_NR		100
 #define OBJ_NR		10
 #define OBJ_CLS		DAOS_OC_R3S_RW
 #define OBJ_REPLICAS	3
 #define DEFAULT_FAIL_TGT 0
 #define REBUILD_POOL_SIZE	(4ULL << 30)
+#define REBUILD_SUBTEST_POOL_SIZE (1ULL << 30)
 static void
 rebuild_exclude_tgt(test_arg_t **args, int arg_cnt, d_rank_t rank,
 		    int tgt_idx, bool kill)
@@ -62,21 +63,6 @@ rebuild_exclude_tgt(test_arg_t **args, int arg_cnt, d_rank_t rank,
 				    args[i]->group, &args[i]->pool.svc,
 				    rank, tgt_idx);
 		sleep(2);
-	}
-}
-
-static void
-rebuild_add_tgt(test_arg_t **args, int args_cnt, d_rank_t rank,
-		int tgt_idx)
-{
-	int i;
-
-	for (i = 0; i < args_cnt; i++) {
-		if (!args[i]->pool.destroyed)
-			daos_add_target(args[i]->pool.pool_uuid,
-					args[i]->group,
-					&args[i]->pool.svc,
-					rank, tgt_idx);
 	}
 }
 
@@ -137,16 +123,17 @@ rebuild_single_pool_target(test_arg_t *arg, d_rank_t failed_rank,
 }
 
 static void
-rebuild_add_back_tgts(test_arg_t **args, int args_nr, d_rank_t *failed_ranks,
-		      int *failed_tgts, int nr)
+rebuild_add_back_tgts(test_arg_t *arg, d_rank_t failed_rank, int *failed_tgts,
+		      int nr)
 {
 	MPI_Barrier(MPI_COMM_WORLD);
 	/* Add back the target if it is not being killed */
-	if (args[0]->myrank == 0) {
+	if (arg->myrank == 0 && !arg->pool.destroyed) {
 		int i;
 
 		for (i = 0; i < nr; i++)
-			rebuild_add_tgt(args, args_nr, failed_ranks[i],
+			daos_add_target(arg->pool.pool_uuid, arg->group,
+					&arg->pool.svc, failed_rank,
 					failed_tgts ? failed_tgts[i] : -1);
 	}
 	MPI_Barrier(MPI_COMM_WORLD);
@@ -154,7 +141,7 @@ rebuild_add_back_tgts(test_arg_t **args, int args_nr, d_rank_t *failed_ranks,
 
 static int
 rebuild_io_obj_internal(struct ioreq *req, bool validate, daos_epoch_t eph,
-			daos_epoch_t validate_eph)
+			daos_epoch_t validate_eph, int index)
 {
 #define BULK_SIZE	5000
 #define REC_SIZE	64
@@ -182,11 +169,11 @@ rebuild_io_obj_internal(struct ioreq *req, bool validate, daos_epoch_t eph,
 	for (j = 0; j < DKEY_LOOP; j++) {
 		req->iod_type = DAOS_IOD_ARRAY;
 		/* small records */
-		sprintf(dkey, "dkey_%d", j);
+		sprintf(dkey, "dkey_%d_%d", index, j);
 		sprintf(data, "%s_"DF_U64, "data", eph);
 		sprintf(data_verify, "%s_"DF_U64, "data", validate_eph);
 		for (k = 0; k < AKEY_LOOP; k++) {
-			sprintf(akey, "akey_%d", k);
+			sprintf(akey, "akey_%d_%d", index, k);
 			for (l = 0; l < REC_LOOP; l++) {
 				if (validate) {
 					/* How to verify punch? XXX */
@@ -234,7 +221,7 @@ rebuild_io_obj_internal(struct ioreq *req, bool validate, daos_epoch_t eph,
 			char bulk[BULK_SIZE+10];
 			char compare[BULK_SIZE];
 
-			sprintf(akey, "akey_bulk_%d", k);
+			sprintf(akey, "akey_bulk_%d_%d", index, k);
 			memset(compare, 'a', BULK_SIZE);
 			for (l = 0; l < 5; l++) {
 				if (validate) {
@@ -270,7 +257,7 @@ rebuild_io_obj_internal(struct ioreq *req, bool validate, daos_epoch_t eph,
 		sprintf(data_verify, "%s_"DF_U64, "single_data",
 			validate_eph);
 		req->iod_type = DAOS_IOD_SINGLE;
-		sprintf(dkey, "dkey_single_%d", j);
+		sprintf(dkey, "dkey_single_%d_%d", index, j);
 		if (validate) {
 			memset(data, 0, REC_SIZE);
 			lookup_single(dkey, "akey_single", 0, data, REC_SIZE,
@@ -303,7 +290,8 @@ rebuild_io(test_arg_t *arg, daos_obj_id_t *oids, int oids_nr)
 		if (i == punch_idx) {
 			punch_obj(DAOS_TX_NONE, &req);
 		} else {
-			rebuild_io_obj_internal((&req), false, eph, -1);
+			rebuild_io_obj_internal((&req), false, eph, -1,
+						 arg->index);
 		}
 		ioreq_fini(&req);
 	}
@@ -331,7 +319,8 @@ rebuild_io_validate(test_arg_t *arg, daos_obj_id_t *oids, int oids_nr,
 			/* how to validate punch object XXX */
 			if (j != punch_idx)
 				/* Validate eph data */
-				rebuild_io_obj_internal((&req), true, eph, eph);
+				rebuild_io_obj_internal((&req), true, eph, eph,
+							arg->index);
 
 			ioreq_fini(&req);
 		}
@@ -339,6 +328,32 @@ rebuild_io_validate(test_arg_t *arg, daos_obj_id_t *oids, int oids_nr,
 
 	arg->fail_loc = 0;
 	arg->fail_value = 0;
+}
+
+/* Create a new pool for the sub_test */
+static int
+rebuild_pool_create(test_arg_t **new_arg, test_arg_t *old_arg, int flag,
+		    struct test_pool *pool)
+{
+	int rc;
+
+	/* create/connect another pool */
+	rc = test_setup((void **)new_arg, flag, old_arg->multi_rank,
+			REBUILD_SUBTEST_POOL_SIZE, pool);
+	if (rc) {
+		print_message("open/connect another pool failed: rc %d\n", rc);
+		return rc;
+	}
+
+	(*new_arg)->index = old_arg->index;
+	return 0;
+}
+
+/* Destroy the pool for the sub test */
+static void
+rebuild_pool_destroy(test_arg_t *arg)
+{
+	test_teardown((void **)&arg);
 }
 
 static void
@@ -364,7 +379,7 @@ rebuild_dkeys(void **state)
 	for (i = 0; i < KEY_NR; i++) {
 		char	key[16];
 
-		sprintf(key, "%d", i);
+		sprintf(key, "dkey_0_%d", i);
 		insert_single(key, "a_key", 0, "data", strlen("data") + 1,
 			      DAOS_TX_NONE, &req);
 	}
@@ -372,7 +387,7 @@ rebuild_dkeys(void **state)
 
 	rebuild_single_pool_target(arg, ranks_to_kill[0], tgt);
 
-	rebuild_add_back_tgts(&arg, 1, ranks_to_kill, &tgt, 1);
+	rebuild_add_back_tgts(arg, ranks_to_kill[0], &tgt, 1);
 }
 
 static void
@@ -399,41 +414,48 @@ rebuild_akeys(void **state)
 		char	akey[16];
 
 		sprintf(akey, "%d", i);
-		insert_single("d_key", akey, 0, "data", strlen("data") + 1,
+		insert_single("dkey_1_0", akey, 0, "data", strlen("data") + 1,
 			      DAOS_TX_NONE, &req);
 	}
 	ioreq_fini(&req);
 
 	rebuild_single_pool_target(arg, ranks_to_kill[0], tgt);
 
-	rebuild_add_back_tgts(&arg, 1, ranks_to_kill, &tgt, 1);
+	rebuild_add_back_tgts(arg, ranks_to_kill[0], &tgt, 1);
 }
 
 static void
 rebuild_indexes(void **state)
 {
 	test_arg_t		*arg = *state;
+	test_arg_t		*new_arg = NULL;
 	daos_obj_id_t		oid;
 	struct ioreq		req;
 	int			tgt = DEFAULT_FAIL_TGT;
 	int			i;
 	int			j;
+	int			rc;
 
 	if (!test_runable(arg, 6))
 		return;
 
-	oid = dts_oid_gen(DAOS_OC_R3S_SPEC_RANK, 0, arg->myrank);
+	/* create/connect another pool */
+	rc = rebuild_pool_create(&new_arg, arg, SETUP_CONT_CONNECT, NULL);
+	if (rc)
+		return;
+
+	oid = dts_oid_gen(DAOS_OC_R3S_SPEC_RANK, 0, new_arg->myrank);
 	oid = dts_oid_set_rank(oid, ranks_to_kill[0]);
 	oid = dts_oid_set_tgt(oid, tgt);
-	ioreq_init(&req, arg->coh, oid, DAOS_IOD_ARRAY, arg);
+	ioreq_init(&req, new_arg->coh, oid, DAOS_IOD_ARRAY, new_arg);
 
 	/** Insert 2000 records */
 	print_message("Insert %d kv record in object "DF_OID"\n",
 		      2000, DP_OID(oid));
-	for (i = 0; i < 100; i++) {
+	for (i = 0; i < KEY_NR; i++) {
 		char	key[16];
 
-		sprintf(key, "%d", i);
+		sprintf(key, "dkey_2_%d", i);
 		for (j = 0; j < 20; j++)
 			insert_single(key, "a_key", j, "data",
 				      strlen("data") + 1, DAOS_TX_NONE, &req);
@@ -441,8 +463,9 @@ rebuild_indexes(void **state)
 	ioreq_fini(&req);
 
 	/* Rebuild rank 1 */
-	rebuild_single_pool_target(arg, ranks_to_kill[0], tgt);
-	rebuild_add_back_tgts(&arg, 1, ranks_to_kill, &tgt, 1);
+	rebuild_single_pool_target(new_arg, ranks_to_kill[0], tgt);
+
+	rebuild_pool_destroy(new_arg);
 }
 
 static void
@@ -470,7 +493,7 @@ rebuild_multiple(void **state)
 	for (i = 0; i < 10; i++) {
 		char	dkey[16];
 
-		sprintf(dkey, "dkey_%d", i);
+		sprintf(dkey, "dkey_3_%d", i);
 		for (j = 0; j < 10; j++) {
 			char	akey[16];
 
@@ -484,7 +507,7 @@ rebuild_multiple(void **state)
 	ioreq_fini(&req);
 
 	rebuild_single_pool_target(arg, ranks_to_kill[0], tgt);
-	rebuild_add_back_tgts(&arg, 1, ranks_to_kill, &tgt, 1);
+	rebuild_add_back_tgts(arg, ranks_to_kill[0], &tgt, 1);
 }
 
 static void
@@ -512,14 +535,14 @@ rebuild_large_rec(void **state)
 	for (i = 0; i < KEY_NR; i++) {
 		char	key[16];
 
-		sprintf(key, "%d", i);
+		sprintf(key, "dkey_4_%d", i);
 		insert_single(key, "a_key", 0, buffer, 5000, DAOS_TX_NONE,
 			      &req);
 	}
 	ioreq_fini(&req);
 
 	rebuild_single_pool_target(arg, ranks_to_kill[0], tgt);
-	rebuild_add_back_tgts(&arg, 1, ranks_to_kill, &tgt, 1);
+	rebuild_add_back_tgts(arg, ranks_to_kill[0], &tgt, 1);
 }
 
 static void
@@ -545,7 +568,7 @@ rebuild_objects(void **state)
 
 	rebuild_io_validate(arg, oids, OBJ_NR, false);
 
-	rebuild_add_back_tgts(&arg, 1, ranks_to_kill, &tgt, 1);
+	rebuild_add_back_tgts(arg, ranks_to_kill[0], &tgt, 1);
 }
 
 static void
@@ -577,7 +600,7 @@ rebuild_drop_scan(void **state)
 	rebuild_single_pool_target(arg, ranks_to_kill[0], tgt);
 
 	rebuild_io_validate(arg, oids, OBJ_NR, true);
-	rebuild_add_back_tgts(&arg, 1, ranks_to_kill, &tgt, 1);
+	rebuild_add_back_tgts(arg, ranks_to_kill[0], &tgt, 1);
 }
 
 static void
@@ -608,7 +631,7 @@ rebuild_retry_rebuild(void **state)
 	rebuild_single_pool_target(arg, ranks_to_kill[0], tgt);
 
 	rebuild_io_validate(arg, oids, OBJ_NR, true);
-	rebuild_add_back_tgts(&arg, 1, ranks_to_kill, &tgt, 1);
+	rebuild_add_back_tgts(arg, ranks_to_kill[0], &tgt, 1);
 }
 
 static void
@@ -637,7 +660,7 @@ rebuild_retry_for_stale_pool(void **state)
 	rebuild_single_pool_rank(arg, ranks_to_kill[0]);
 
 	rebuild_io_validate(arg, oids, OBJ_NR, true);
-	rebuild_add_back_tgts(&arg, 1, ranks_to_kill, NULL, 1);
+	rebuild_add_back_tgts(arg, ranks_to_kill[0], NULL, 1);
 }
 
 static void
@@ -666,7 +689,7 @@ rebuild_drop_obj(void **state)
 	rebuild_single_pool_rank(arg, ranks_to_kill[0]);
 
 	rebuild_io_validate(arg, oids, OBJ_NR, true);
-	rebuild_add_back_tgts(&arg, 1, ranks_to_kill, NULL, 1);
+	rebuild_add_back_tgts(arg, ranks_to_kill[0], NULL, 1);
 }
 
 static void
@@ -695,7 +718,7 @@ rebuild_update_failed(void **state)
 				     0, NULL);
 	MPI_Barrier(MPI_COMM_WORLD);
 	rebuild_single_pool_target(arg, ranks_to_kill[0], tgt);
-	rebuild_add_back_tgts(&arg, 1, ranks_to_kill, &tgt, 1);
+	rebuild_add_back_tgts(arg, ranks_to_kill[0], &tgt, 1);
 }
 
 static void
@@ -712,12 +735,9 @@ rebuild_multiple_pools(void **state)
 
 	args[0] = arg;
 	/* create/connect another pool */
-	rc = test_setup((void **)&args[1], SETUP_CONT_CONNECT, arg->multi_rank,
-			REBUILD_POOL_SIZE, NULL);
-	if (rc) {
-		print_message("open/connect another pool failed: rc %d\n", rc);
+	rc = rebuild_pool_create(&args[1], arg, SETUP_CONT_CONNECT, NULL);
+	if (rc)
 		return;
-	}
 
 	for (i = 0; i < OBJ_NR; i++) {
 		oids[i] = dts_oid_gen(DAOS_OC_R3S_SPEC_RANK, 0, arg->myrank);
@@ -732,8 +752,8 @@ rebuild_multiple_pools(void **state)
 	rebuild_io_validate(args[0], oids, OBJ_NR, true);
 	rebuild_io_validate(args[1], oids, OBJ_NR, true);
 
-	test_teardown((void **)&args[1]);
-	rebuild_add_back_tgts(&arg, 1, ranks_to_kill, NULL, 1);
+	rebuild_pool_destroy(args[1]);
+	rebuild_add_back_tgts(arg, ranks_to_kill[0], NULL, 1);
 }
 
 static int
@@ -802,7 +822,7 @@ static void
 rebuild_destroy_container(void **state)
 {
 	test_arg_t	*arg = *state;
-	test_arg_t	*args[2] = { 0 };
+	test_arg_t	*new_arg = NULL;
 	daos_obj_id_t	oids[OBJ_NR];
 	int		i;
 	int		rc;
@@ -810,36 +830,30 @@ rebuild_destroy_container(void **state)
 	if (!test_runable(arg, 6))
 		return;
 
-	args[0] = arg;
 	/* create/connect another pool */
-	rc = test_setup((void **)&args[1], SETUP_CONT_CONNECT, arg->multi_rank,
-			REBUILD_POOL_SIZE, NULL);
-	if (rc) {
-		print_message("open/connect another pool failed: rc %d\n", rc);
+	rc = rebuild_pool_create(&new_arg, arg, SETUP_CONT_CONNECT, NULL);
+	if (rc)
 		return;
-	}
 
 	for (i = 0; i < OBJ_NR; i++) {
 		oids[i] = dts_oid_gen(DAOS_OC_R3S_SPEC_RANK, 0, arg->myrank);
 		oids[i] = dts_oid_set_rank(oids[i], ranks_to_kill[0]);
 	}
 
-	rebuild_io(args[1], oids, OBJ_NR);
+	rebuild_io(new_arg, oids, OBJ_NR);
 
-	args[1]->rebuild_cb = rebuild_destroy_container_cb;
+	new_arg->rebuild_cb = rebuild_destroy_container_cb;
 
-	rebuild_pools_ranks(args, 2, ranks_to_kill, 1);
+	rebuild_single_pool_rank(new_arg, ranks_to_kill[0]);
 
-	test_teardown((void **)&args[1]);
-
-	rebuild_add_back_tgts(&arg, 1, ranks_to_kill, NULL, 1);
+	rebuild_pool_destroy(new_arg);
 }
 
 static void
 rebuild_close_container(void **state)
 {
 	test_arg_t	*arg = *state;
-	test_arg_t	*args[2] = { 0 };
+	test_arg_t	*new_arg = NULL;
 	daos_obj_id_t	oids[OBJ_NR];
 	int		i;
 	int		rc;
@@ -847,29 +861,23 @@ rebuild_close_container(void **state)
 	if (!test_runable(arg, 6))
 		return;
 
-	args[0] = arg;
 	/* create/connect another pool */
-	rc = test_setup((void **)&args[1], SETUP_CONT_CONNECT, arg->multi_rank,
-			REBUILD_POOL_SIZE, NULL);
-	if (rc) {
-		print_message("open/connect another pool failed: rc %d\n", rc);
+	rc = rebuild_pool_create(&new_arg, arg, SETUP_CONT_CONNECT, NULL);
+	if (rc)
 		return;
-	}
 
 	for (i = 0; i < OBJ_NR; i++) {
 		oids[i] = dts_oid_gen(DAOS_OC_R3S_SPEC_RANK, 0, arg->myrank);
 		oids[i] = dts_oid_set_rank(oids[i], ranks_to_kill[0]);
 	}
 
-	rebuild_io(args[1], oids, OBJ_NR);
+	rebuild_io(new_arg, oids, OBJ_NR);
 
-	args[1]->rebuild_pre_cb = rebuild_close_container_cb;
+	new_arg->rebuild_pre_cb = rebuild_close_container_cb;
 
-	rebuild_pools_ranks(args, 2, ranks_to_kill, 1);
+	rebuild_single_pool_rank(new_arg, ranks_to_kill[0]);
 
-	test_teardown((void **)&args[1]);
-
-	rebuild_add_back_tgts(&arg, 1, ranks_to_kill, NULL, 1);
+	rebuild_pool_destroy(new_arg);
 }
 
 static int
@@ -940,7 +948,7 @@ static void
 rebuild_destroy_pool_internal(void **state, uint64_t fail_loc)
 {
 	test_arg_t	*arg = *state;
-	test_arg_t	*args[2] = { 0 };
+	test_arg_t	*new_arg = NULL;
 	daos_obj_id_t	oids[OBJ_NR];
 	int		i;
 	int		rc;
@@ -948,32 +956,25 @@ rebuild_destroy_pool_internal(void **state, uint64_t fail_loc)
 	if (!test_runable(arg, 6))
 		return;
 
-	args[0] = arg;
-	/* create/connect another pool */
-	rc = test_setup((void **)&args[1], SETUP_CONT_CONNECT, arg->multi_rank,
-			REBUILD_POOL_SIZE, NULL);
-	if (rc) {
-		print_message("open/connect another pool failed: rc %d\n", rc);
+	rc = rebuild_pool_create(&new_arg, arg, SETUP_CONT_CONNECT, NULL);
+	if (rc)
 		return;
-	}
 
 	for (i = 0; i < OBJ_NR; i++) {
 		oids[i] = dts_oid_gen(DAOS_OC_R3S_SPEC_RANK, 0, arg->myrank);
 		oids[i] = dts_oid_set_rank(oids[i], ranks_to_kill[0]);
 	}
 
-	rebuild_io(args[1], oids, OBJ_NR);
+	rebuild_io(new_arg, oids, OBJ_NR);
 
 	/* hang the rebuild */
 	if (arg->myrank == 0)
 		daos_mgmt_set_params(arg->group, -1, DSS_KEY_FAIL_LOC, fail_loc,
 				     0, NULL);
 
-	args[1]->rebuild_cb = rebuild_destroy_pool_cb;
+	new_arg->rebuild_cb = rebuild_destroy_pool_cb;
 
-	rebuild_pools_ranks(args, 2, ranks_to_kill, 1);
-
-	rebuild_add_back_tgts(&arg, 1, ranks_to_kill, NULL, 1);
+	rebuild_single_pool_rank(new_arg, ranks_to_kill[0]);
 }
 
 static void
@@ -1016,7 +1017,7 @@ rebuild_iv_tgt_fail(void **state)
 
 	rebuild_io_validate(arg, oids, OBJ_NR, true);
 
-	rebuild_add_back_tgts(&arg, 1, ranks_to_kill, NULL, 1);
+	rebuild_add_back_tgts(arg, ranks_to_kill[0], NULL, 1);
 }
 
 static void
@@ -1024,6 +1025,7 @@ rebuild_tgt_start_fail(void **state)
 {
 	test_arg_t	*arg = *state;
 	daos_obj_id_t	oids[OBJ_NR];
+	d_rank_t	exclude_rank = 0;
 	int		i;
 
 	if (!test_runable(arg, 6))
@@ -1038,7 +1040,7 @@ rebuild_tgt_start_fail(void **state)
 
 	/* failed to start rebuild on rank 0 */
 	if (arg->myrank == 0)
-		daos_mgmt_set_params(arg->group, 0, DSS_KEY_FAIL_LOC,
+		daos_mgmt_set_params(arg->group, exclude_rank, DSS_KEY_FAIL_LOC,
 				  DAOS_REBUILD_TGT_START_FAIL | DAOS_FAIL_ONCE,
 				  0, NULL);
 	MPI_Barrier(MPI_COMM_WORLD);
@@ -1046,7 +1048,8 @@ rebuild_tgt_start_fail(void **state)
 
 	rebuild_io_validate(arg, oids, OBJ_NR, true);
 
-	rebuild_add_back_tgts(&arg, 1, ranks_to_kill, NULL, 1);
+	rebuild_add_back_tgts(arg, ranks_to_kill[0], NULL, 1);
+	rebuild_add_back_tgts(arg, exclude_rank, NULL, 1);
 }
 
 static void
@@ -1082,7 +1085,7 @@ rebuild_send_objects_fail(void **state)
 				     0, NULL);
 	MPI_Barrier(MPI_COMM_WORLD);
 
-	rebuild_add_back_tgts(&arg, 1, ranks_to_kill, NULL, 1);
+	rebuild_add_back_tgts(arg, ranks_to_kill[0], NULL, 1);
 }
 
 static int
@@ -1169,7 +1172,7 @@ rebuild_add_tgt_pool_connect_internal(void *data)
 	 * add targets before pool connect to make sure container is opened
 	 * on all servers.
 	 */
-	rebuild_add_back_tgts(&arg, 1, ranks_to_kill, NULL, 1);
+	rebuild_add_back_tgts(arg, ranks_to_kill[0], NULL, 1);
 
 	return rebuild_pool_connect_internal(data);
 }
@@ -1322,24 +1325,19 @@ static void
 rebuild_offline_empty(void **state)
 {
 	test_arg_t	*arg = *state;
-	test_arg_t	*args[2] = { 0 };
+	test_arg_t	*new_arg = NULL;
 	int		rc;
 
 	if (!test_runable(arg, 6))
 		return;
 
-	args[0] = arg;
-	/* create/connect another pool */
-	rc = test_setup((void **)&args[1], SETUP_CONT_CONNECT, arg->multi_rank,
-			REBUILD_POOL_SIZE, NULL);
-	if (rc) {
-		print_message("open/connect another pool failed: rc %d\n", rc);
+	rc = rebuild_pool_create(&new_arg, arg, SETUP_POOL_CREATE, NULL);
+	if (rc)
 		return;
-	}
 
-	rebuild_pools_ranks(args, 2, ranks_to_kill, 1);
-	test_teardown((void **)&args[1]);
-	rebuild_add_back_tgts(&arg, 1, ranks_to_kill, NULL, 1);
+	rebuild_single_pool_rank(new_arg, ranks_to_kill[0]);
+	rebuild_pool_destroy(new_arg);
+
 }
 
 static int
@@ -1391,12 +1389,8 @@ rebuild_master_change_during_scan(void **state)
 
 	rebuild_single_pool_rank(arg, ranks_to_kill[0]);
 
-	arg->rebuild_cb = NULL;
-
 	/* Verify the data */
 	rebuild_io_validate(arg, oids, OBJ_NR, true);
-
-	rebuild_add_back_tgts(&arg, 1, ranks_to_kill, NULL, 1);
 }
 
 static void
@@ -1417,19 +1411,16 @@ rebuild_master_change_during_rebuild(void **state)
 	rebuild_io(arg, oids, OBJ_NR);
 
 	/* All ranks should wait before rebuild */
-	daos_mgmt_set_params(arg->group, -1, DSS_KEY_FAIL_LOC,
-			     DAOS_REBUILD_TGT_REBUILD_HANG, 0, NULL);
-
+	if (arg->myrank == 0)
+		daos_mgmt_set_params(arg->group, -1, DSS_KEY_FAIL_LOC,
+				     DAOS_REBUILD_TGT_REBUILD_HANG, 0, NULL);
+	MPI_Barrier(MPI_COMM_WORLD);
 	arg->rebuild_cb = rebuild_change_leader_cb;
 
 	rebuild_single_pool_rank(arg, ranks_to_kill[0]);
 
-	arg->rebuild_cb = NULL;
-
 	/* Verify the data */
 	rebuild_io_validate(arg, oids, OBJ_NR, true);
-
-	rebuild_add_back_tgts(&arg, 1, ranks_to_kill, NULL, 1);
 }
 
 static int
@@ -1486,7 +1477,7 @@ rebuild_nospace(void **state)
 	arg->rebuild_cb = NULL;
 	rebuild_io_validate(arg, oids, OBJ_NR, true);
 
-	rebuild_add_back_tgts(&arg, 1, ranks_to_kill, NULL, 1);
+	rebuild_add_back_tgts(arg, ranks_to_kill[0], NULL, 1);
 }
 
 static void
@@ -1789,13 +1780,10 @@ multi_pools_rebuild_concurrently(void **state)
 	for (i = 0; i < POOL_NUM * CONT_PER_POOL; i++) {
 		pool = (i % CONT_PER_POOL == 0) ? NULL :
 				&args[(i/CONT_PER_POOL) * CONT_PER_POOL]->pool;
-		rc = test_setup((void **)&args[i], SETUP_CONT_CONNECT,
-				arg->multi_rank, REBUILD_POOL_SIZE, pool);
-		if (rc) {
-			print_message("open/connect another pool failed: "
-				      "rc %d\n", rc);
+		rc = rebuild_pool_create(&args[i], arg, SETUP_CONT_CONNECT,
+					 pool);
+		if (rc)
 			return;
-		}
 		if (i % CONT_PER_POOL == 0)
 			assert_int_equal(args[i]->pool.slave, 0);
 		else
@@ -1814,9 +1802,15 @@ multi_pools_rebuild_concurrently(void **state)
 
 	for (i = POOL_NUM * CONT_PER_POOL - 1; i >= 0; i--) {
 		rebuild_io_validate(args[i], oids, OBJ_PER_CONT, true);
-		test_teardown((void **)&args[i]);
+		rebuild_pool_destroy(args[i]);
 	}
-	rebuild_add_back_tgts(&arg, 1, &ranks_to_kill[0], NULL, 1);
+}
+
+static int
+rebuild_sub_setup(void **state)
+{
+	return test_setup(state, SETUP_CONT_CONNECT, true,
+			  REBUILD_SUBTEST_POOL_SIZE, NULL);
 }
 
 /** create a new pool/container for each test */
@@ -1861,42 +1855,38 @@ static const struct CMUnitTest rebuild_tests[] = {
 	 rebuild_send_objects_fail, NULL, test_case_teardown},
 	{"REBUILD20: rebuild empty pool offline",
 	rebuild_offline_empty, NULL, test_case_teardown},
-	{"REBUILD21: rebuild with master change during scan",
-	rebuild_master_change_during_scan, NULL, test_case_teardown},
-	{"REBUILD22: rebuild with master change during rebuild",
-	rebuild_master_change_during_rebuild, NULL, test_case_teardown},
-	{"REBUILD23: rebuild no space failure",
+	{"REBUILD21: rebuild no space failure",
 	rebuild_nospace, NULL, test_case_teardown},
-	{"REBUILD24: rebuild multiple tgts",
+	{"REBUILD22: rebuild multiple tgts",
 	rebuild_multiple_tgts, NULL, test_case_teardown},
-	{"REBUILD25: disconnect pool during scan",
+	{"REBUILD23: disconnect pool during scan",
 	 rebuild_tgt_pool_disconnect_in_scan, NULL, test_case_teardown},
-	{"REBUILD26: disconnect pool during rebuild",
-	 rebuild_tgt_pool_disconnect_in_rebuild, NULL, test_case_teardown},
-	{"REBUILD27: multi-pools rebuild concurrently",
-	 multi_pools_rebuild_concurrently, NULL, test_case_teardown},
+	{"REBUILD24: disconnect pool during rebuild",
+	 rebuild_tgt_pool_disconnect_in_rebuild, NULL, test_teardown},
+	{"REBUILD25: multi-pools rebuild concurrently",
+	 multi_pools_rebuild_concurrently, rebuild_sub_setup, test_teardown},
+	{"REBUILD26: rebuild with master change during scan",
+	rebuild_master_change_during_scan, rebuild_sub_setup, test_teardown},
+	{"REBUILD27: rebuild with master change during rebuild",
+	rebuild_master_change_during_rebuild, rebuild_sub_setup, test_teardown},
 	{"REBUILD28: rebuild with master failure",
-	 rebuild_master_failure, NULL, test_case_teardown},
+	 rebuild_master_failure, rebuild_sub_setup, test_teardown},
 	{"REBUILD29: connect pool during scan for offline rebuild",
-	 rebuild_offline_pool_connect_in_scan, NULL, test_case_teardown},
+	 rebuild_offline_pool_connect_in_scan, rebuild_sub_setup,
+	 test_teardown},
 	{"REBUILD30: connect pool during rebuild for offline rebuild",
-	 rebuild_offline_pool_connect_in_rebuild, NULL, test_case_teardown},
+	 rebuild_offline_pool_connect_in_rebuild, rebuild_sub_setup,
+	 test_teardown},
 	{"REBUILD31: offline rebuild",
-	rebuild_offline, NULL, test_case_teardown},
+	rebuild_offline, rebuild_sub_setup, test_teardown},
 	{"REBUILD32: rebuild with two failures",
-	 rebuild_multiple_failures, NULL, test_case_teardown},
+	 rebuild_multiple_failures, rebuild_sub_setup, test_teardown},
 	{"REBUILD33: rebuild fail all replicas before rebuild",
-	 rebuild_fail_all_replicas_before_rebuild, NULL, test_case_teardown},
+	 rebuild_fail_all_replicas_before_rebuild, rebuild_sub_setup,
+	 test_teardown},
 	{"REBUILD34: rebuild fail all replicas",
-	 rebuild_fail_all_replicas, NULL, test_case_teardown},
+	 rebuild_fail_all_replicas, rebuild_sub_setup, test_case_teardown},
 };
-
-int
-rebuild_setup(void **state)
-{
-	return test_setup(state, SETUP_CONT_CONNECT, true, REBUILD_POOL_SIZE,
-			  NULL);
-}
 
 int
 run_daos_rebuild_test(int rank, int size, int *sub_tests, int sub_tests_size)


### PR DESCRIPTION
Let's return the status of scan bcast, and abort
current rebuild immediately, and rebuild all targets
in the next rebuild.

Signed-off-by: Wang Di <di.wang@intel.com>