### PR TITLE
DAOS-2656 dtx: Remove DTX_ST_INIT state from DTX

### DIFF
--- a/src/dtx/dtx_common.c
+++ b/src/dtx/dtx_common.c
@@ -636,20 +636,6 @@ dtx_handle_resend(daos_handle_t coh, daos_unit_oid_t *oid,
 	switch (rc) {
 	case DTX_ST_PREPARED:
 		return 0;
-	case DTX_ST_INIT:
-		/* XXX: The INIT DTX in SCM must be for an in-updating
-		 *	object/key that was waiting for the bulk transfer.
-		 *
-		 *	Currently, we do NOT support server re-integration,
-		 *	then we will ignore the case of client resending
-		 *	RPC to the restarted server. So we can handle the
-		 *	DTX_ST_INIT case the same as DTX_ST_PREPARED.
-		 *
-		 *	We need to check whether the RPC's time-stamp is
-		 *	older than the server re-integration time or not
-		 *	in the furture.
-		 */
-		return 0;
 	case DTX_ST_COMMITTED:
 		return -DER_ALREADY;
 	case -DER_NONEXIST:

--- a/src/dtx/dtx_resync.c
+++ b/src/dtx/dtx_resync.c
@@ -148,8 +148,7 @@ dtx_status_handle(struct dtx_resync_args *dra)
 
 		rc = dtx_check(dra->po_uuid, cont->sc_uuid,
 			       &dre->dre_dte, layout);
-		if (rc != DTX_ST_COMMITTED && rc != DTX_ST_PREPARED &&
-		    rc != DTX_ST_INIT) {
+		if (rc != DTX_ST_COMMITTED && rc != DTX_ST_PREPARED) {
 			/* We are not sure about whether the DTX can be
 			 * committed or not, then we have to skip it.
 			 */
@@ -189,8 +188,6 @@ dtx_status_handle(struct dtx_resync_args *dra)
 			if (rc == DTX_ST_PREPARED)
 				goto commit;
 
-			/* Fall through. */
-		case DTX_ST_INIT:
 			/* If we abort multiple non-ready DTXs together, then
 			 * there is race that one DTX may become committable
 			 * when we abort some other DTX(s). To avoid complex

--- a/src/dtx/dtx_rpc.c
+++ b/src/dtx/dtx_rpc.c
@@ -219,23 +219,13 @@ dtx_req_list_cb(void **args)
 					"on %d/%d.\n", DP_DTI(drr->drr_dti),
 					drr->drr_rank, drr->drr_tag);
 				return;
-			case DTX_ST_INIT:
-				if (dra->dra_result != DTX_ST_COMMITTED)
-					dra->dra_result = DTX_ST_INIT;
-				break;
 			case DTX_ST_PREPARED:
 				if (dra->dra_result == 0)
 					dra->dra_result = DTX_ST_PREPARED;
 				break;
 			default:
-				if (drr->drr_result == -DER_NONEXIST) {
-					if (dra->dra_result <= 0 ||
-					    dra->dra_result == DTX_ST_PREPARED)
-						dra->dra_result = DTX_ST_INIT;
-				} else if (dra->dra_result != DTX_ST_INIT) {
-					dra->dra_result = drr->drr_result >= 0 ?
-						-DER_IO : drr->drr_result;
-				}
+				dra->dra_result = drr->drr_result >= 0 ?
+					-DER_IO : drr->drr_result;
 				break;
 			}
 

--- a/src/include/daos_srv/dtx_srv.h
+++ b/src/include/daos_srv/dtx_srv.h
@@ -100,12 +100,10 @@ struct dtx_stat {
  * DAOS two-phase commit transaction status.
  */
 enum dtx_status {
-	/**  Initialized, but local modification has not completed. */
-	DTX_ST_INIT		= 1,
 	/** Local participant has done the modification. */
-	DTX_ST_PREPARED		= 2,
+	DTX_ST_PREPARED		= 1,
 	/** The DTX has been committed. */
-	DTX_ST_COMMITTED	= 3,
+	DTX_ST_COMMITTED	= 2,
 };
 
 int dtx_resync(daos_handle_t po_hdl, uuid_t po_uuid, uuid_t co_uuid,

--- a/src/include/daos_srv/vos.h
+++ b/src/include/daos_srv/vos.h
@@ -110,9 +110,7 @@ vos_dtx_fetch_committable(daos_handle_t coh, int max, struct dtx_entry **dtes);
  * \param dkey_hash	[IN]	The hashed dkey.
  * \param punch		[IN]	For punch operation or not.
  *
- * \return		DTX_ST_INIT	Related DTX has been initialized, but
- *					the modification has not completed yet.
- *			DTX_ST_PREPARED	means that the DTX has been 'prepared',
+ * \return		DTX_ST_PREPARED	means that the DTX has been 'prepared',
  *					so the local modification has been done
  *					on related replica(s). If all replicas
  *					have 'prepared', then the whole DTX is

--- a/src/vos/tests/vts_io.c
+++ b/src/vos/tests/vts_io.c
@@ -724,8 +724,8 @@ hold_objects(struct vos_object **objs, struct daos_lru_cache *occ,
 	int i = 0, rc = 0;
 
 	for (i = start; i < end; i++) {
-		rc = vos_obj_hold(occ, *coh, *oid, 1, true, DAOS_INTENT_DEFAULT,
-				  &objs[i]);
+		rc = vos_obj_hold(occ, vos_hdl2cont(*coh), *oid, 1, true,
+				  DAOS_INTENT_DEFAULT, &objs[i]);
 		assert_int_equal(rc, 0);
 	}
 
@@ -794,8 +794,8 @@ io_obj_cache_test(void **state)
 	rc = hold_objects(objs, occ, &ctx->tc_co_hdl, &oids[1], 10, 15);
 	assert_int_equal(rc, 0);
 
-	rc = vos_obj_hold(occ, l_coh, oids[1], 1, true, DAOS_INTENT_DEFAULT,
-			  &objs[16]);
+	rc = vos_obj_hold(occ, vos_hdl2cont(l_coh), oids[1], 1, true,
+			  DAOS_INTENT_DEFAULT, &objs[16]);
 	assert_int_equal(rc, 0);
 	vos_obj_release(occ, objs[16]);
 

--- a/src/vos/vos_aggregate.c
+++ b/src/vos/vos_aggregate.c
@@ -950,7 +950,7 @@ insert_segments(daos_handle_t ih, struct agg_merge_window *mw,
 	}
 
 	/* Publish NVMe reservations */
-	rc = vos_publish_blocks(obj, &io->ic_nvme_exts, true,
+	rc = vos_publish_blocks(obj->obj_cont, &io->ic_nvme_exts, true,
 				VOS_IOS_AGGREGATION);
 	if (rc) {
 		D_ERROR("Publish NVMe extents error: %d\n", rc);
@@ -980,8 +980,8 @@ cleanup_segments(daos_handle_t ih, struct agg_merge_window *mw, int rc)
 			io->ic_scm_cnt = 0;
 		}
 		if (!d_list_empty(&io->ic_nvme_exts))
-			vos_publish_blocks(obj, &io->ic_nvme_exts, false,
-					   VOS_IOS_AGGREGATION);
+			vos_publish_blocks(obj->obj_cont, &io->ic_nvme_exts,
+					   false, VOS_IOS_AGGREGATION);
 	}
 
 	/* Reset io context */

--- a/src/vos/vos_internal.h
+++ b/src/vos/vos_internal.h
@@ -794,12 +794,6 @@ vos_cont2pool(struct vos_container *cont)
 	return cont->vc_pool;
 }
 
-static inline struct umem_instance *
-vos_cont2umm(struct vos_container *cont)
-{
-	return &cont->vc_pool->vp_umm;
-}
-
 static inline struct vos_pool *
 vos_obj2pool(struct vos_object *obj)
 {
@@ -1047,7 +1041,7 @@ uint16_t
 vos_media_select(struct vos_container *cont, daos_iod_type_t type,
 		 daos_size_t size);
 int
-vos_publish_blocks(struct vos_object *obj, d_list_t *blk_list, bool publish,
+vos_publish_blocks(struct vos_container *cont, d_list_t *blk_list, bool publish,
 		   enum vos_io_stream ios);
 
 /* Update the timestamp in a key or object.  The latest and earliest must be

--- a/src/vos/vos_obj.c
+++ b/src/vos/vos_obj.c
@@ -156,8 +156,8 @@ vos_obj_punch(daos_handle_t coh, daos_unit_oid_t oid, daos_epoch_t epoch,
 	}
 
 	/* NB: punch always generate a new incarnation of the object */
-	rc = vos_obj_hold(vos_obj_cache_current(), coh, oid, epoch,
-			  false, DAOS_INTENT_PUNCH, &obj);
+	rc = vos_obj_hold(vos_obj_cache_current(), vos_hdl2cont(coh), oid,
+			  epoch, false, DAOS_INTENT_PUNCH, &obj);
 	if (rc == 0) {
 		if (dkey) /* key punch */
 			rc = key_punch(obj, epoch, pm_ver, dkey,
@@ -941,7 +941,7 @@ vos_obj_iter_prep(vos_iter_type_t type, vos_iter_param_t *param,
 	 * the object/key if it's punched more than once. However, rebuild
 	 * system should guarantee this will never happen.
 	 */
-	rc = vos_obj_hold(vos_obj_cache_current(), param->ip_hdl,
+	rc = vos_obj_hold(vos_obj_cache_current(), vos_hdl2cont(param->ip_hdl),
 			  param->ip_oid, param->ip_epr.epr_hi, true,
 			  vos_iter_intent(&oiter->it_iter), &oiter->it_obj);
 	if (rc != 0)
@@ -1042,7 +1042,7 @@ nested_dkey_iter_init(struct vos_obj_iter *oiter, struct vos_iter_info *info)
 	 * the object/key if it's punched more than once. However, rebuild
 	 * system should guarantee this will never happen.
 	 */
-	rc = vos_obj_hold(vos_obj_cache_current(), info->ii_hdl,
+	rc = vos_obj_hold(vos_obj_cache_current(), vos_hdl2cont(info->ii_hdl),
 			  info->ii_oid, info->ii_epr.epr_hi, true,
 			  vos_iter_intent(&oiter->it_iter), &oiter->it_obj);
 	if (rc != 0)
@@ -1370,8 +1370,8 @@ vos_oi_set_attr_helper(daos_handle_t coh, daos_unit_oid_t oid,
 	if (rc != 0)
 		goto exit;
 
-	rc = vos_obj_hold(vos_obj_cache_current(), coh, oid, epoch, false,
-			  DAOS_INTENT_UPDATE, &obj);
+	rc = vos_obj_hold(vos_obj_cache_current(), vos_hdl2cont(coh), oid,
+			  epoch, false, DAOS_INTENT_UPDATE, &obj);
 	if (rc != 0)
 		goto end;
 
@@ -1456,8 +1456,8 @@ vos_oi_get_attr(daos_handle_t coh, daos_unit_oid_t oid, daos_epoch_t epoch,
 	}
 
 	vos_dth_set(dth);
-	rc = vos_obj_hold(vos_obj_cache_current(), coh, oid, epoch, true,
-			  DAOS_INTENT_DEFAULT, &obj);
+	rc = vos_obj_hold(vos_obj_cache_current(), vos_hdl2cont(coh), oid,
+			  epoch, true, DAOS_INTENT_DEFAULT, &obj);
 	vos_dth_set(NULL);
 	if (rc != 0)
 		return rc;

--- a/src/vos/vos_obj.h
+++ b/src/vos/vos_obj.h
@@ -54,7 +54,7 @@ struct vos_container;
  * add it to the cache.
  *
  * \param occ	[IN]	Object cache, it could be a percpu data structure.
- * \param coh	[IN]	Container open handle.
+ * \param cont	[IN]	Open container.
  * \param oid	[IN]	VOS object ID.
  * \param no_create [IN]
  *			Do not allocate object if it's not there yet.
@@ -62,7 +62,7 @@ struct vos_container;
  * \param obj_p [OUT]	Returned object cache reference.
  */
 int
-vos_obj_hold(struct daos_lru_cache *occ, daos_handle_t coh,
+vos_obj_hold(struct daos_lru_cache *occ, struct vos_container *cont,
 	     daos_unit_oid_t oid, daos_epoch_t epoch,
 	     bool no_create, uint32_t intent, struct vos_object **obj_p);
 
@@ -140,7 +140,7 @@ vos_oi_update_metadata(daos_handle_t coh, daos_unit_oid_t oid);
  * If the object is not found, create a new object for the @oid and return
  * the direct pointer of the new allocated object.
  *
- * \param coh	[IN]	Container handle
+ * \param cont	[IN]	Open container
  * \param oid	[IN]	DAOS object ID
  * \param intent [IN]	The request intent
  * \param obj	[OUT]	Direct pointer to VOS object
@@ -158,7 +158,7 @@ vos_oi_find_alloc(struct vos_container *cont, daos_unit_oid_t oid,
  * Created to us in tests for checking sanity of obj index
  * after deletion
  *
- * \param coh	[IN]	Container handle
+ * \param cont	[IN]	Open container
  * \param oid	[IN]	DAOS object ID
  * \param intent [IN]	The operation intent
  * \param obj	[OUT]	Direct pointer to VOS object

--- a/src/vos/vos_obj_cache.c
+++ b/src/vos/vos_obj_cache.c
@@ -194,17 +194,15 @@ vos_obj_release(struct daos_lru_cache *occ, struct vos_object *obj)
 
 
 int
-vos_obj_hold(struct daos_lru_cache *occ, daos_handle_t coh,
+vos_obj_hold(struct daos_lru_cache *occ, struct vos_container *cont,
 	     daos_unit_oid_t oid, daos_epoch_t epoch,
 	     bool no_create, uint32_t intent, struct vos_object **obj_p)
 {
 
 	struct vos_object	*obj;
-	struct vos_container	*cont;
 	struct obj_lru_key	 lkey;
 	int			 rc;
 
-	cont = vos_hdl2cont(coh);
 	D_ASSERT(cont != NULL);
 
 	D_DEBUG(DB_TRACE, "Try to hold cont="DF_UUID", obj="DF_UOID"\n",
@@ -234,7 +232,7 @@ vos_obj_hold(struct daos_lru_cache *occ, daos_handle_t coh,
 		    (obj->obj_epoch <= epoch || obj->obj_incarnation == 0)) {
 			struct umem_instance	*umm = &cont->vc_pool->vp_umm;
 
-			rc = vos_dtx_check_availability(umm, coh,
+			rc = vos_dtx_check_availability(umm, vos_cont2hdl(cont),
 						obj->obj_df->vo_dtx,
 						umem_ptr2off(umm, obj->obj_df),
 						intent, DTX_RT_OBJ);
@@ -325,7 +323,7 @@ vos_obj_revalidate(struct daos_lru_cache *occ, daos_epoch_t epoch,
 	if (!vos_obj_evicted(obj))
 		return 0;
 
-	rc = vos_obj_hold(occ, vos_cont2hdl(obj->obj_cont), obj->obj_id,
+	rc = vos_obj_hold(occ, obj->obj_cont, obj->obj_id,
 			  epoch, !obj->obj_df, DAOS_INTENT_UPDATE, obj_p);
 	if (rc == 0) {
 		D_ASSERT(*obj_p != obj);

--- a/src/vos/vos_query.c
+++ b/src/vos/vos_query.c
@@ -304,8 +304,8 @@ vos_obj_query_key(daos_handle_t coh, daos_unit_oid_t oid, uint32_t flags,
 		return -DER_INVAL;
 	}
 
-	rc = vos_obj_hold(vos_obj_cache_current(), coh, oid, epoch, true,
-			  DAOS_INTENT_DEFAULT, &obj);
+	rc = vos_obj_hold(vos_obj_cache_current(), vos_hdl2cont(coh), oid,
+			  epoch, true, DAOS_INTENT_DEFAULT, &obj);
 	if (rc != 0) {
 		LOG_RC(rc, "Could not hold object: %s\n", d_errstr(rc));
 		return rc;


### PR DESCRIPTION
Now that object creation is deferred to vos_update_end,
there is no need for the DTX_ST_INIT state.   Transactions
will either be DTX_ST_PREPARED or the pmdk transaction will
rollback the state so the update doesn't exist.