### PR TITLE
DAOS-2444 dtx: don's use uuid_generate for dti_uuid

### DIFF
--- a/src/common/misc.c
+++ b/src/common/misc.c
@@ -27,6 +27,7 @@
 #define D_LOGFAC	DD_FAC(common)
 
 #include <daos/common.h>
+#include <daos/dtx.h>
 #include <daos_security.h>
 
 /**
@@ -1070,4 +1071,20 @@ out:
 		}
 	}
 	return rc;
+}
+
+void
+daos_dti_gen(struct dtx_id *dti, bool zero)
+{
+	static __thread uuid_t uuid;
+
+	if (zero) {
+		memset(dti, 0, sizeof(*dti));
+	} else {
+		if (uuid_is_null(uuid))
+			uuid_generate(uuid);
+
+		uuid_copy(dti->dti_uuid, uuid);
+		dti->dti_hlc = crt_hlc_get();
+	}
 }

--- a/src/dtx/dtx_common.c
+++ b/src/dtx/dtx_common.c
@@ -663,7 +663,8 @@ dtx_handle_resend(daos_handle_t coh, daos_unit_oid_t *oid,
 	case DTX_ST_COMMITTED:
 		return -DER_ALREADY;
 	case -DER_NONEXIST:
-		if (time(NULL) - dti->dti_sec > DTX_AGG_THRESHOLD_AGE_LOWER) {
+		if (dtx_hlc_age2sec(dti->dti_hlc) >
+		    DTX_AGG_THRESHOLD_AGE_LOWER) {
 			D_DEBUG(DB_IO, "Not sure about whether the old RPC "
 				DF_DTI" is resent or not.\n", DP_DTI(dti));
 			return -DER_TIMEDOUT;

--- a/src/dtx/dtx_rpc.c
+++ b/src/dtx/dtx_rpc.c
@@ -46,7 +46,7 @@ crt_proc_struct_dtx_id(crt_proc_t proc, struct dtx_id *dti)
 	if (rc != 0)
 		return -DER_HG;
 
-	rc = crt_proc_uint64_t(proc, &dti->dti_sec);
+	rc = crt_proc_uint64_t(proc, &dti->dti_hlc);
 	if (rc != 0)
 		return -DER_HG;
 

--- a/src/include/daos/dtx.h
+++ b/src/include/daos/dtx.h
@@ -34,8 +34,8 @@
 struct dtx_id {
 	/** The uuid of the transaction */
 	uuid_t			dti_uuid;
-	/** The timestamp in second for the transaction */
-	uint64_t		dti_sec;
+	/** The HLC timestamp for the transaction */
+	uint64_t		dti_hlc;
 };
 
 struct dtx_conflict_entry {
@@ -43,17 +43,7 @@ struct dtx_conflict_entry {
 	uint64_t		dce_dkey;
 };
 
-static inline void
-daos_dti_gen(struct dtx_id *dti, bool zero)
-{
-	if (zero) {
-		memset(dti, 0, sizeof(*dti));
-	} else {
-		/* It will be replaced by HLC when it is ready. */
-		uuid_generate(dti->dti_uuid);
-		dti->dti_sec = time(NULL);
-	}
-}
+void daos_dti_gen(struct dtx_id *dti, bool zero);
 
 static inline void
 daos_dti_copy(struct dtx_id *des, struct dtx_id *src)
@@ -67,7 +57,7 @@ daos_dti_copy(struct dtx_id *des, struct dtx_id *src)
 static inline bool
 daos_is_zero_dti(struct dtx_id *dti)
 {
-	return dti->dti_sec == 0;
+	return dti->dti_hlc == 0;
 }
 
 static inline bool
@@ -76,8 +66,8 @@ daos_dti_equal(struct dtx_id *dti0, struct dtx_id *dti1)
 	return memcmp(dti0, dti1, sizeof(*dti0)) == 0;
 }
 
-#define DF_DTI		DF_UUID
-#define DP_DTI(dti)	DP_UUID((dti)->dti_uuid)
+#define DF_DTI		DF_UUID"."DF_X64
+#define DP_DTI(dti)	DP_UUID((dti)->dti_uuid), (dti)->dti_hlc
 
 enum daos_ops_intent {
 	DAOS_INTENT_DEFAULT	= 0,	/* fetch/enumerate/query */

--- a/src/object/obj_rpc.c
+++ b/src/object/obj_rpc.c
@@ -40,7 +40,7 @@ crt_proc_struct_dtx_id(crt_proc_t proc, struct dtx_id *dti)
 	if (rc != 0)
 		return -DER_HG;
 
-	rc = crt_proc_uint64_t(proc, &dti->dti_sec);
+	rc = crt_proc_uint64_t(proc, &dti->dti_hlc);
 	if (rc != 0)
 		return -DER_HG;
 


### PR DESCRIPTION
1) only call uuid_generate once for each thread
2) replace dti_sec as HLC.

Signed-off-by: Xuezhao Liu <xuezhao.liu@intel.com>