### PR TITLE
DAOS-1742 API: revert change making daos_rank_list_free private.

### DIFF
--- a/src/include/daos/common.h
+++ b/src/include/daos/common.h
@@ -334,7 +334,6 @@ daos_crt_network_error(int err)
 #define daos_rank_list_dup_sort_uniq	d_rank_list_dup_sort_uniq
 #define daos_rank_list_filter		d_rank_list_filter
 #define daos_rank_list_alloc		d_rank_list_alloc
-#define daos_rank_list_free		d_rank_list_free
 #define daos_rank_list_copy		d_rank_list_copy
 #define daos_rank_list_sort		d_rank_list_sort
 #define daos_rank_list_find		d_rank_list_find

--- a/src/include/daos_types.h
+++ b/src/include/daos_types.h
@@ -60,6 +60,7 @@ typedef uint64_t	daos_off_t;
 #define daos_sg_list_t			d_sg_list_t
 #define daos_iov_t			d_iov_t
 #define daos_iov_set(iov, buf, size)	d_iov_set((iov), (buf), (size))
+#define daos_rank_list_free(r)		d_rank_list_free((r))
 
 #define crt_proc_daos_key_t	crt_proc_d_iov_t
 #define crt_proc_daos_size_t	crt_proc_uint64_t


### PR DESCRIPTION
This should be public since it's used by other libraries.

Signed-off-by: Mohamad Chaarawi <mohamad.chaarawi@intel.com>