### PR TITLE
DAOS-2336 mgmt: Split ds_mgmt_hldr_pool_create

### DIFF
--- a/src/mgmt/srv_internal.h
+++ b/src/mgmt/srv_internal.h
@@ -63,6 +63,9 @@ struct mgmt_join_out {
 int ds_mgmt_join_handler(struct mgmt_join_in *in, struct mgmt_join_out *out);
 
 /** srv_pool.c */
+int ds_mgmt_pool_create(uuid_t uuid, d_rank_list_t *tgts, char *dev,
+			daos_size_t scm_size, daos_size_t nvme_size,
+			daos_prop_t *prop, d_rank_list_t *svc);
 void ds_mgmt_hdlr_pool_create(crt_rpc_t *rpc_req);
 void ds_mgmt_hdlr_pool_destroy(crt_rpc_t *rpc_req);
 


### PR DESCRIPTION
Split ds_mgmt_hdlr_pool_create into a ds_mgmt_pool_create that is
independent of RPCs and a ds_mgmt_hdlr_pool_create that interface with
CaRT RPCs. This paves the way for the transition to dRPCs.

This patch also fixes the leaking of pc_out->pc_svc memory.

Signed-off-by: Li Wei <wei.g.li@intel.com>