### PR TITLE
DAOS-2664 mgmt: Decouple pool create/destroy from RPC handlers

### DIFF
--- a/src/mgmt/srv_internal.h
+++ b/src/mgmt/srv_internal.h
@@ -63,6 +63,11 @@ struct mgmt_join_out {
 int ds_mgmt_join_handler(struct mgmt_join_in *in, struct mgmt_join_out *out);
 
 /** srv_pool.c */
+int ds_mgmt_create_pool(uuid_t pool_uuid, const char *group, char *tgt_dev,
+			d_rank_list_t *targets, size_t scm_size,
+			size_t nvme_size, daos_prop_t *prop, uint32_t svc_nr,
+			d_rank_list_t **svcp);
+int ds_mgmt_destroy_pool(uuid_t pool_uuid, const char *group, uint32_t force);
 void ds_mgmt_hdlr_pool_create(crt_rpc_t *rpc_req);
 void ds_mgmt_hdlr_pool_destroy(crt_rpc_t *rpc_req);
 

--- a/src/mgmt/srv_pool.c
+++ b/src/mgmt/srv_pool.c
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2016-2018 Intel Corporation.
+ * (C) Copyright 2016-2019 Intel Corporation.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -94,12 +94,11 @@ ds_mgmt_pool_svc_create(uuid_t pool_uuid,
 	return rc;
 }
 
-#define TMP_RANKS_ARRAY_SIZE	32
-void
-ds_mgmt_hdlr_pool_create(crt_rpc_t *rpc_req)
+int
+ds_mgmt_create_pool(uuid_t pool_uuid, const char *group, char *tgt_dev,
+		    d_rank_list_t *targets, size_t scm_size, size_t nvme_size,
+		    daos_prop_t *prop, uint32_t svc_nr, d_rank_list_t **svcp)
 {
-	struct mgmt_pool_create_in	*pc_in;
-	struct mgmt_pool_create_out	*pc_out;
 	crt_rpc_t			*tc_req;
 	crt_opcode_t			opc;
 	struct mgmt_tgt_create_in	*tc_in;
@@ -110,46 +109,34 @@ ds_mgmt_hdlr_pool_create(crt_rpc_t *rpc_req)
 	char				id[DAOS_UUID_STR_SIZE];
 	d_rank_list_t			*rank_list;
 	d_rank_list_t			tmp_rank_list = {0};
-	d_rank_t			ranks_array[TMP_RANKS_ARRAY_SIZE];
-	unsigned int			ranks_size;
+	d_rank_t			ranks_array[32];
 	uuid_t				*tgt_uuids = NULL;
 	unsigned int			i;
 	int				topo;
 	int				rc;
 
-	pc_in = crt_req_get(rpc_req);
-	D_ASSERT(pc_in != NULL);
-	pc_out = crt_reply_get(rpc_req);
-	D_ASSERT(pc_out != NULL);
-
-	if (pc_in->pc_tgts) {
-		daos_rank_list_sort(pc_in->pc_tgts);
-		rank_list = pc_in->pc_tgts;
-		ranks_size = pc_in->pc_tgts->rl_nr;
+	if (targets) {
+		daos_rank_list_sort(targets);
+		rank_list = targets;
 	} else {
-		rc = crt_group_size(NULL, &ranks_size);
+		rank_list = &tmp_rank_list;
+		rc = crt_group_size(NULL, &rank_list->rl_nr);
 		D_ASSERT(rc == 0);
 
-		tmp_rank_list.rl_nr = ranks_size;
-		if (ranks_size > TMP_RANKS_ARRAY_SIZE) {
-			d_rank_t *ranks;
-
-			D_ALLOC_ARRAY(ranks, ranks_size);
-			if (ranks == NULL)
+		if (rank_list->rl_nr > ARRAY_SIZE(ranks_array)) {
+			D_ALLOC_ARRAY(rank_list->rl_ranks, rank_list->rl_nr);
+			if (rank_list->rl_ranks == NULL)
 				D_GOTO(free, rc = -DER_NOMEM);
-			tmp_rank_list.rl_ranks = ranks;
 		} else {
-			tmp_rank_list.rl_ranks = ranks_array;
+			rank_list->rl_ranks = ranks_array;
 		}
 
-		for (i = 0; i < ranks_size; i++)
-			tmp_rank_list.rl_ranks[i] = i;
-
-		rank_list = &tmp_rank_list;
+		for (i = 0; i < rank_list->rl_nr; i++)
+			rank_list->rl_ranks[i] = i;
 	}
 
 	/* Collective RPC to all of targets of the pool */
-	uuid_unparse_lower(pc_in->pc_pool_uuid, id);
+	uuid_unparse_lower(pool_uuid, id);
 	rc = dss_group_create(id, rank_list, &grp);
 	if (rc != 0)
 		D_GOTO(free, rc);
@@ -164,15 +151,10 @@ ds_mgmt_hdlr_pool_create(crt_rpc_t *rpc_req)
 
 	tc_in = crt_req_get(tc_req);
 	D_ASSERT(tc_in != NULL);
-	uuid_copy(tc_in->tc_pool_uuid, pc_in->pc_pool_uuid);
-
-	/* the pc_in->pc_tgt_dev will be freed when the MGMT_POOL_CREATE
-	 * finishes, it is after TGT_CREATE RPC handling so it is safe
-	 * to directly use it here.
-	 */
-	tc_in->tc_tgt_dev = pc_in->pc_tgt_dev;
-	tc_in->tc_scm_size = pc_in->pc_scm_size;
-	tc_in->tc_nvme_size = pc_in->pc_nvme_size;
+	uuid_copy(tc_in->tc_pool_uuid, pool_uuid);
+	tc_in->tc_tgt_dev = tgt_dev;
+	tc_in->tc_scm_size = scm_size;
+	tc_in->tc_nvme_size = nvme_size;
 	rc = dss_rpc_send(tc_req);
 	if (rc != 0) {
 		crt_req_decref(tc_req);
@@ -185,14 +167,14 @@ ds_mgmt_hdlr_pool_create(crt_rpc_t *rpc_req)
 		D_ERROR(DF_UUID": failed to update pool map on %d targets\n",
 			DP_UUID(tc_in->tc_pool_uuid), rc);
 		crt_req_decref(tc_req);
-		D_GOTO(tgt_pool_create_fail, rc);
+		D_GOTO(tgt_fail, rc);
 	}
 
 	D_DEBUG(DB_MGMT, DF_UUID" create %zu tgts pool\n",
-		DP_UUID(pc_in->pc_pool_uuid), tc_out->tc_tgt_uuids.ca_count);
+		DP_UUID(pool_uuid), tc_out->tc_tgt_uuids.ca_count);
 
 	/** Gather target uuids ranks from collective RPC to start pool svc. */
-	D_ALLOC_ARRAY(tgt_uuids, ranks_size);
+	D_ALLOC_ARRAY(tgt_uuids, rank_list->rl_nr);
 	if (tgt_uuids == NULL)
 		D_GOTO(free, rc = -DER_NOMEM);
 	tc_out_ranks = tc_out->tc_ranks.ca_arrays;
@@ -212,33 +194,23 @@ ds_mgmt_hdlr_pool_create(crt_rpc_t *rpc_req)
 	}
 
 	crt_req_decref(tc_req);
-	/* Since the pool_svc will create another group,
-	 * let's destroy this group
-	 **/
+	/* Since pool_svc will create another group, let's destroy this group */
 	dss_group_destroy(grp);
 	grp = NULL;
 
 	/** allocate service rank list */
-	D_ALLOC_PTR(pc_out->pc_svc);
-	if (pc_out->pc_svc == NULL)
-		D_GOTO(tgt_pool_create_fail, rc = -DER_NOMEM);
+	*svcp = d_rank_list_alloc(svc_nr);
+	if (*svcp == NULL)
+		D_GOTO(tgt_fail, rc = -DER_NOMEM);
 
-	D_ALLOC_ARRAY(pc_out->pc_svc->rl_ranks,
-		pc_in->pc_svc_nr);
-	if (pc_out->pc_svc->rl_ranks == NULL)
-		D_GOTO(tgt_pool_create_fail, rc = -DER_NOMEM);
-	pc_out->pc_svc->rl_nr = pc_in->pc_svc_nr;
-
-	rc = ds_mgmt_pool_svc_create(pc_in->pc_pool_uuid,
-				     ranks_size, tgt_uuids, pc_in->pc_grp,
-				     rank_list, pc_in->pc_prop, pc_out->pc_svc);
+	rc = ds_mgmt_pool_svc_create(pool_uuid, rank_list->rl_nr, tgt_uuids,
+				     group, rank_list, prop, *svcp);
 	if (rc)
 		D_ERROR("create pool "DF_UUID" svc failed: rc %d\n",
-			DP_UUID(pc_in->pc_pool_uuid), rc);
-
-tgt_pool_create_fail:
+			DP_UUID(pool_uuid), rc);
+tgt_fail:
 	if (rc)
-		ds_mgmt_tgt_pool_destroy(pc_in->pc_pool_uuid, grp);
+		ds_mgmt_tgt_pool_destroy(pool_uuid, grp);
 free:
 	if (tmp_rank_list.rl_ranks != NULL &&
 	    tmp_rank_list.rl_ranks != ranks_array)
@@ -249,12 +221,61 @@ free:
 
 	if (grp != NULL)
 		dss_group_destroy(grp);
+	return rc;
+}
 
+void
+ds_mgmt_hdlr_pool_create(crt_rpc_t *rpc_req)
+{
+	struct mgmt_pool_create_in	*pc_in;
+	struct mgmt_pool_create_out	*pc_out;
+	int				 rc;
+
+	pc_in = crt_req_get(rpc_req);
+	D_ASSERT(pc_in != NULL);
+	pc_out = crt_reply_get(rpc_req);
+	D_ASSERT(pc_out != NULL);
+
+	rc = ds_mgmt_create_pool(pc_in->pc_pool_uuid, pc_in->pc_grp,
+				 pc_in->pc_tgt_dev, pc_in->pc_tgts,
+				 pc_in->pc_scm_size, pc_in->pc_nvme_size,
+				 pc_in->pc_prop, pc_in->pc_svc_nr,
+				 &pc_out->pc_svc);
 	pc_out->pc_rc = rc;
 	rc = crt_reply_send(rpc_req);
 	if (rc != 0)
-		D_ERROR("crt_reply_send failed, rc: %d "
-			"(pc_tgt_dev: %s).\n", rc, pc_in->pc_tgt_dev);
+		D_ERROR("crt_reply_send failed, rc: %d (pc_tgt_dev: %s).\n",
+			rc, pc_in->pc_tgt_dev);
+	if (pc_out->pc_svc != NULL)
+		d_rank_list_free(pc_out->pc_svc);
+}
+
+int
+ds_mgmt_destroy_pool(uuid_t pool_uuid, const char *group, uint32_t force)
+{
+	int				rc;
+
+	/* TODO check metadata about the pool's existence?
+	 *      and check active pool connection for "force"
+	 */
+	D_DEBUG(DB_MGMT, "Destroying pool "DF_UUID"\n", DP_UUID(pool_uuid));
+
+	rc = ds_pool_svc_destroy(pool_uuid);
+	if (rc != 0) {
+		D_ERROR("Failed to destroy pool service "DF_UUID": %d\n",
+			DP_UUID(pool_uuid), rc);
+		D_GOTO(out, rc);
+	}
+
+	rc = ds_mgmt_tgt_pool_destroy(pool_uuid, NULL);
+	if (rc == 0)
+		D_DEBUG(DB_MGMT, "Destroying pool "DF_UUID" succeed.\n",
+			DP_UUID(pool_uuid));
+	else
+		D_ERROR("Destroying pool "DF_UUID" failed, rc: %d.\n",
+			DP_UUID(pool_uuid), rc);
+out:
+	return rc;
 }
 
 void
@@ -268,28 +289,8 @@ ds_mgmt_hdlr_pool_destroy(crt_rpc_t *rpc_req)
 	pd_out = crt_reply_get(rpc_req);
 	D_ASSERT(pd_in != NULL && pd_out != NULL);
 
-	/* TODO check metadata about the pool's existence?
-	 *      and check active pool connection for "force"
-	 */
-	D_DEBUG(DB_MGMT, "Destroying pool "DF_UUID"\n",
-		DP_UUID(pd_in->pd_pool_uuid));
-
-	rc = ds_pool_svc_destroy(pd_in->pd_pool_uuid);
-	if (rc != 0) {
-		D_ERROR("Failed to destroy pool service "DF_UUID": %d\n",
-			DP_UUID(pd_in->pd_pool_uuid), rc);
-		D_GOTO(out, rc);
-	}
-
-	rc = ds_mgmt_tgt_pool_destroy(pd_in->pd_pool_uuid, NULL);
-	if (rc == 0)
-		D_DEBUG(DB_MGMT, "Destroying pool "DF_UUID" succeed.\n",
-			DP_UUID(pd_in->pd_pool_uuid));
-	else
-		D_ERROR("Destroying pool "DF_UUID" failed, rc: %d.\n",
-			DP_UUID(pd_in->pd_pool_uuid), rc);
-out:
-	pd_out->pd_rc = rc;
+	pd_out->pd_rc = ds_mgmt_destroy_pool(pd_in->pd_pool_uuid,
+					     pd_in->pd_grp, pd_in->pd_force);
 	rc = crt_reply_send(rpc_req);
 	if (rc != 0)
 		D_ERROR("crt_reply_send failed, rc: %d.\n", rc);


### PR DESCRIPTION
Split the Management Service CaRT RPC handlers for creating and destroying pools to support transition to dRPC.

Signed-off-by: Omkar Kulkarni <omkar.kulkarni@intel.com>