### PR TITLE
DAOS-2185 iv: add iv_entry valid ops

### DIFF
--- a/src/container/container_iv.c
+++ b/src/container/container_iv.c
@@ -365,6 +365,29 @@ cont_iv_value_alloc(struct ds_iv_entry *entry, d_sg_list_t *sgl)
 	return 0;
 }
 
+static bool
+cont_iv_ent_valid(struct ds_iv_entry *entry, struct ds_iv_key *key)
+{
+	daos_handle_t		root_hdl;
+	d_iov_t			key_iov;
+	d_iov_t			val_iov;
+	struct cont_iv_key	*civ_key = key2priv(key);
+	int			rc;
+
+	if (!entry->iv_valid)
+		return false;
+
+	/* Let's check whether the container really exist */
+	memcpy(&root_hdl, entry->iv_value.sg_iovs[0].iov_buf, sizeof(root_hdl));
+	d_iov_set(&key_iov, civ_key->cont_uuid, sizeof(uuid_t));
+	d_iov_set(&val_iov, NULL, 0);
+	rc = dbtree_lookup(root_hdl, &key_iov, &val_iov);
+	if (rc != 0)
+		return false;
+
+	return true;
+}
+
 struct ds_iv_class_ops cont_iv_ops = {
 	.ivc_ent_init	= cont_iv_ent_init,
 	.ivc_ent_get	= cont_iv_ent_get,
@@ -374,6 +397,7 @@ struct ds_iv_class_ops cont_iv_ops = {
 	.ivc_ent_update	= cont_iv_ent_update,
 	.ivc_ent_refresh = cont_iv_ent_refresh,
 	.ivc_value_alloc = cont_iv_value_alloc,
+	.ivc_ent_valid	= cont_iv_ent_valid,
 };
 
 int

--- a/src/include/daos_srv/iv.h
+++ b/src/include/daos_srv/iv.h
@@ -242,6 +242,18 @@ typedef int (*ds_iv_ent_refresh_t)(struct ds_iv_entry *entry,
 typedef int (*ds_iv_value_alloc_t)(struct ds_iv_entry *ent,
 				   d_sg_list_t *sgl);
 
+/**
+ * Check whether the entry is valid
+ *
+ * \param ent [IN]	entry to be check
+ * \param key [IN]	key to help checking
+ *
+ * \return		true if it is valid
+ *                      false if it is not valid
+ */
+typedef bool (*ds_iv_ent_valid_t)(struct ds_iv_entry *ent,
+				 struct ds_iv_key *key);
+
 struct ds_iv_class_ops {
 	ds_iv_key_pack_t	ivc_key_pack;
 	ds_iv_key_unpack_t	ivc_key_unpack;
@@ -254,6 +266,7 @@ struct ds_iv_class_ops {
 	ds_iv_ent_update_t	ivc_ent_update;
 	ds_iv_ent_refresh_t	ivc_ent_refresh;
 	ds_iv_value_alloc_t	ivc_value_alloc;
+	ds_iv_ent_valid_t	ivc_ent_valid;
 };
 
 extern struct crt_iv_ops iv_cache_ops;


### PR DESCRIPTION
Add iv_entry_valid for iv_entry, so the IV user can
decide whether the entry is valid during fetch, i.e.
whether it should send the request to its parent or
root.

Signed-off-by: Wang Di <di.wang@intel.com>