### PR TITLE
DAOS-2668 vos: free leaf node on evt delete

### DIFF
--- a/src/vos/evtree.c
+++ b/src/vos/evtree.c
@@ -2622,9 +2622,11 @@ evt_node_delete(struct evt_context *tcx, bool remove)
 				width = tcx->tc_inob * evt_rect_width(rect);
 				desc = evt_off2desc(tcx, ne->ne_child);
 				rc = evt_desc_free(tcx, desc, width);
-			} else {
-				rc = umem_free(evt_umm(tcx), ne->ne_child);
+				if (rc != 0)
+					return rc;
 			}
+
+			rc = umem_free(evt_umm(tcx), ne->ne_child);
 			if (rc != 0)
 				return rc;
 		}


### PR DESCRIPTION
evtree delete missed freeing leaf node.

Signed-off-by: Niu Yawei <yawei.niu@intel.com>
Change-Id: I8f5fda8a179bdce2c5eee64757bcb87acff7e90d