### PR TITLE
DAOS-2671 control: reinstate format_override server config parameter

### DIFF
--- a/src/control/server/README.md
+++ b/src/control/server/README.md
@@ -312,7 +312,7 @@ DAOS I/O server (v0.4.0) process 135939 started on rank 0 (out of 1) with 1 targ
 If `format_override` IS SET to `false` in config file, control plane will attempt to start the data plane instances ONLY if the DAOS superblock exists within the specified `scm_mount`.
 Otherwise, the control plane will wait until an administrator calls "[storage format](../dmg/README.md#subcommands)" over the client API from the management tool.
 If `storage format` call is successful, control plane will continue to start data plane instances when SCM and NVMe have been formatted, SCM mounted and superblock and nvme.conf successfully written to SCM mount.
-If a superblock exists in `scm_mount`, and the location is mounted, the control plane will fail (so as to not inadvertently wipe a useful SCM location).
+If a superblock exists in `scm_mount`, and the location is mounted, the control plane will not perform a storage format (so as to not inadvertently wipe an active SCM dir).
 
 <details>
 <summary>Example output from invoking `daos_server` on single host with `format_override` FALSE when superblock already exists</summary>

--- a/src/control/server/config_types.go
+++ b/src/control/server/config_types.go
@@ -24,9 +24,9 @@
 package main
 
 import (
-	"os"
 	"fmt"
 	"math"
+	"os"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -175,7 +175,7 @@ type server struct {
 	// ioParams represents commandline options and environment variables
 	// to be passed on I/O server invocation.
 	CliOpts   []string      // tuples (short option, value) e.g. ["-p", "10000"...]
-	Hostname string   // used when generating templates
+	Hostname  string        // used when generating templates
 	formatted chan struct{} // closed when server is formatted
 }
 
@@ -187,7 +187,7 @@ func newDefaultServer() server {
 	return server{
 		ScmClass:    scmDCPM,
 		BdevClass:   bdNVMe,
-		Hostname:  host,
+		Hostname:    host,
 		NrXsHelpers: 2,
 	}
 }
@@ -227,6 +227,7 @@ type configuration struct {
 	FaultPath      string          `yaml:"fault_path"`
 	FaultCb        string          `yaml:"fault_cb"`
 	FabricIfaces   []string        `yaml:"fabric_ifaces"`
+	FormatOverride bool            `yaml:"format_override"`
 	ScmMountPath   string          `yaml:"scm_mount_path"`
 	BdevInclude    []string        `yaml:"bdev_include"`
 	BdevExclude    []string        `yaml:"bdev_exclude"`

--- a/src/control/server/mgmt.go
+++ b/src/control/server/mgmt.go
@@ -116,7 +116,7 @@ func awaitStorageFormat(config *configuration) error {
 				<-srv.formatted
 			}
 		} else {
-			reason = "format override set in server config"
+			reason = "format override set true in server config"
 		}
 
 		if err := dropPrivileges(config); err != nil {
@@ -130,11 +130,11 @@ func awaitStorageFormat(config *configuration) error {
 
 	if reason != "" {
 		log.Debugf("storage format skipped (%s)\n", reason)
-	}
 
-	// broadcast storage formatting stage completed
-	for _, srv := range config.Servers {
-		close(srv.formatted)
+		// broadcast storage formatting stage completed
+		for _, srv := range config.Servers {
+			close(srv.formatted)
+		}
 	}
 
 	return nil

--- a/src/control/server/testdata/expect_daos_server.yml
+++ b/src/control/server/testdata/expect_daos_server.yml
@@ -11,6 +11,7 @@ key: ./.daos/daos_server.key
 fault_path: ""
 fault_cb: ""
 fabric_ifaces: []
+format_override: false
 scm_mount_path: /mnt/daos
 bdev_include: []
 bdev_exclude: []

--- a/src/control/server/testdata/expect_daos_server_psm2.yml
+++ b/src/control/server/testdata/expect_daos_server_psm2.yml
@@ -35,6 +35,7 @@ key: ./.daos/daos_server.key
 fault_path: ""
 fault_cb: ""
 fabric_ifaces: []
+format_override: false
 scm_mount_path: /mnt/daos
 bdev_include: []
 bdev_exclude: []

--- a/src/control/server/testdata/expect_daos_server_sockets.yml
+++ b/src/control/server/testdata/expect_daos_server_sockets.yml
@@ -36,6 +36,7 @@ key: ./.daos/daos_server.key
 fault_path: ""
 fault_cb: ""
 fabric_ifaces: []
+format_override: false
 scm_mount_path: /mnt/daos
 bdev_include: []
 bdev_exclude: []

--- a/src/control/server/testdata/expect_daos_server_uncomment.yml
+++ b/src/control/server/testdata/expect_daos_server_uncomment.yml
@@ -59,6 +59,7 @@ fault_cb: ./.daos/fd_callback
 fabric_ifaces:
 - qib0
 - qib1
+format_override: true
 scm_mount_path: /mnt/daosa
 bdev_include:
 - 0000:81:00.1

--- a/src/control/server/testdata/output_success.txt
+++ b/src/control/server/testdata/output_success.txt
@@ -11,6 +11,7 @@ key: ./.daos/daos_server.key
 fault_path: ""
 fault_cb: ""
 fabric_ifaces: []
+format_override: false
 scm_mount_path: /mnt/daos
 bdev_include: []
 bdev_exclude: []
@@ -29,6 +30,7 @@ key: ./.daos/daos_server.key
 fault_path: ""
 fault_cb: ""
 fabric_ifaces: []
+format_override: false
 scm_mount_path: /mnt/daos
 bdev_include: []
 bdev_exclude: []
@@ -50,6 +52,7 @@ fault_cb: /tmp/daos_fault_cb.sh
 fabric_ifaces:
 - ib0
 - ib1
+format_override: false
 scm_mount_path: /tmp/daos
 bdev_include:
 - pcie1000.0.0.0.8

--- a/utils/config/daos_server.yml
+++ b/utils/config/daos_server.yml
@@ -167,11 +167,11 @@
 #
 #
 ## Format override when true will continue to format and start data plane
-## without waiting for client API storage format call (which formats
-## NVMe and SCM storage devices.
+## without waiting for client API storage format call (formats NVMe and SCM
+## storage devices). Only relevant when daos_server it started by root.
 #
-## default: true
-#format_override: false
+## default: false
+#format_override: true
 #
 #
 ## Username used to lookup user uid/gid to drop privileges to if started

--- a/utils/config/examples/daos_server_psm2.yml
+++ b/utils/config/examples/daos_server_psm2.yml
@@ -7,6 +7,8 @@ socket_dir: /tmp/daos_psm2
 nr_hugepages: 4096
 control_log_mask: DEBUG
 control_log_file: /tmp/daos_control.log
+## uncomment to start data plane as root without waiting for storage format
+# format_override: true
 ## uncomment to drop privileges before starting data plane
 ## (if started as root to perform hardware provisioning)
 # user_name: daosuser

--- a/utils/config/examples/daos_server_sockets.yml
+++ b/utils/config/examples/daos_server_sockets.yml
@@ -7,6 +7,8 @@ socket_dir: /tmp/daos_sockets
 nr_hugepages: 4096
 control_log_mask: DEBUG
 control_log_file: /tmp/daos_control.log
+## uncomment to start data plane as root without waiting for storage format
+# format_override: true
 ## uncomment to drop privileges before starting data plane
 ## (if started as root to perform hardware provisioning)
 # user_name: daosuser


### PR DESCRIPTION
When set to true (default false), format_override server config file
parameter will allow daos_server to spawn data planes instances
without having to manually perform storage format through the client
API. This can be convenient in non-production situations.

If parameter is set to false (normal operation), and daos_server is
started for the first time by root user, data plane will not be
spawned until storage is formatted by client API call from mgmt tool
e.g. `daos_shell -l <ds_host>:<ds_port> storage format`.

Signed-off-by: Tom Nabarro <tom.nabarro@intel.com>