### PR TITLE
CORCI-662 Remove comma from junit_files: runTest command

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -978,7 +978,7 @@ pipeline {
                                            fi
                                            tnodes=$(echo $NODELIST | cut -d ',' -f 1-9)
                                            ./ftest.sh "$test_tag" $tnodes''',
-                                junit_files: "src/tests/ftest/avocado/*/*/*.xml, src/tests/ftest/*_results.xml",
+                                junit_files: "src/tests/ftest/avocado/*/*/*.xml src/tests/ftest/*_results.xml",
                                 failure_artifacts: env.STAGE_NAME
                     }
                     post {
@@ -1041,7 +1041,7 @@ pipeline {
                                            fi
                                            tnodes=$(echo $NODELIST | cut -d ',' -f 1-9)
                                            ./ftest.sh "$test_tag" $tnodes''',
-                                junit_files: "src/tests/ftest/avocado/*/*/*.xml, src/tests/ftest/*_results.xml",
+                                junit_files: "src/tests/ftest/avocado/*/*/*.xml src/tests/ftest/*_results.xml",
                                 failure_artifacts: env.STAGE_NAME
                     }
                     post {


### PR DESCRIPTION
Since this is just a string (of files) given to grep to check, the comma
makes the first one "not found", which has the unfortunate side effect
of turning failing test runs into passing ones given the nature of grep
and how it deals with missing files."