### PR TITLE
DAOS-2240 Move some tests out of common to -tests

### DIFF
--- a/utils/docker/Dockerfile-mockbuild.centos.7
+++ b/utils/docker/Dockerfile-mockbuild.centos.7
@@ -1,5 +1,5 @@
 #
-# Copyright 2018, Intel Corporation
+# Copyright 2018-2019, Intel Corporation
 #
 # 'recipe' for Docker to build an RPM
 #
@@ -15,8 +15,8 @@ ARG UID=1000
 #Nothing to do for CentOS
 
 # Install basic tools
-RUN yum install -y epel-release
-RUN yum install -y mock make rpm-build curl createrepo rpmlint git
+RUN yum -y install epel-release
+RUN yum -y install mock make rpm-build curl createrepo rpmlint git
 
 # Add build user (to keep rpmbuild happy)
 ENV USER build
@@ -33,10 +33,10 @@ ARG JENKINS_URL=""
 
 RUN echo -e "config_opts['yum.conf'] += \"\"\"\n" >> /etc/mock/default.cfg;  \
     for repo in openpa libfabric pmix ompi mercury spdk isa-l fio dpdk       \
-                protobuf-c fuse pmdk argobots raft cart:daos_devel; do       \
-        if [[ $repo = *:* ]]; then                                           \
-            branch="${repo#*:}";                                             \
-            repo="${repo%:*}";                                               \
+                protobuf-c fuse pmdk argobots raft cart@daos_devel; do       \
+        if [[ $repo = *@* ]]; then                                           \
+            branch="${repo#*@}";                                             \
+            repo="${repo%@*}";                                               \
         else                                                                 \
             branch="master";                                                 \
         fi;                                                                  \

--- a/utils/rpms/daos.spec
+++ b/utils/rpms/daos.spec
@@ -5,7 +5,7 @@
 
 Name:          daos
 Version:       0.5.0
-Release:       2%{?dist}
+Release:       3%{?dist}
 Summary:       DAOS Storage Engine
 
 License:       Apache
@@ -69,6 +69,7 @@ to optimize performance and cost.
 %package server
 Summary: The DAOS server
 Requires: %{name} = %{version}-%{release}
+Requires: spdk-tools
 Requires(post): /sbin/ldconfig
 Requires(postun): /sbin/ldconfig
 
@@ -150,10 +151,7 @@ echo "%{_libdir}/daos_srv" > %{?buildroot}/%{_sysconfdir}/ld.so.conf.d/daos.conf
 # you might think libdaos_tests.so goes in the tests RPM but
 # the 4 tools following it need it
 %{_libdir}/libdaos_tests.so
-%{_bindir}/obj_ctl
 %{_bindir}/vos_size
-%{_bindir}/daos_gen_io_conf
-%{_bindir}/daos_run_io_conf
 %{_bindir}/io_conf
 %{_bindir}/pl_map
 %{_bindir}/rdbt
@@ -214,6 +212,9 @@ echo "%{_libdir}/daos_srv" > %{?buildroot}/%{_sysconfdir}/ld.so.conf.d/daos.conf
 %{_bindir}/daosbench
 %{_bindir}/daos_perf
 %{_bindir}/evt_ctl
+%{_bindir}/obj_ctl
+%{_bindir}/daos_gen_io_conf
+%{_bindir}/daos_run_io_conf
 
 %files devel
 %{_includedir}/*
@@ -221,6 +222,11 @@ echo "%{_libdir}/daos_srv" > %{?buildroot}/%{_sysconfdir}/ld.so.conf.d/daos.conf
 %{_libdir}/*.a
 
 %changelog
+* Thu Jun 12 2019 Brian J. Murrell <brian.murrell@intel.com>
+- move obj_ctl daos_gen_io_conf daos_run_io_conf to
+  daos-tests sub-package
+- daos-server needs spdk-tools
+
 * Fri May 31 2019 Ken Cain <kenneth.c.cain@intel.com>
 - Add new daos utility binary
 


### PR DESCRIPTION
Based on feedback from Mohamad, some tests are being moved out of
the common package into the -tests package.

Also, daos-server needs spdk-tools for
/usr/share/daos/control/../../spdk/scripts/setup.sh.