### PR TITLE
DAOS-2379 dtx: split dtx into leader/local dtx

### DIFF
--- a/src/dtx/dtx_common.c
+++ b/src/dtx/dtx_common.c
@@ -200,7 +200,35 @@ check:
 }
 
 /**
- * Prepare the DTX handle in DRAM.
+ * Init local dth handle.
+ */
+static void
+dtx_handle_init(struct dtx_id *dti, daos_unit_oid_t *oid, daos_handle_t coh,
+		daos_epoch_t epoch, uint64_t dkey_hash, uint32_t pm_ver,
+		uint32_t intent, struct dtx_conflict_entry *conflict,
+		struct dtx_id *dti_cos, int dti_cos_count, bool leader,
+		struct dtx_handle *dth)
+{
+	dth->dth_xid = *dti;
+	dth->dth_oid = *oid;
+	dth->dth_coh = coh;
+	dth->dth_epoch = epoch;
+	D_INIT_LIST_HEAD(&dth->dth_shares);
+	dth->dth_dkey_hash = dkey_hash;
+	dth->dth_ver = pm_ver;
+	dth->dth_intent = intent;
+	dth->dth_sync = 0;
+	dth->dth_leader = leader ? 1 : 0;
+	dth->dth_non_rep = 0;
+	dth->dth_dti_cos = dti_cos;
+	dth->dth_dti_cos_count = dti_cos_count;
+	dth->dth_conflict = conflict;
+	dth->dth_ent = UMOFF_NULL;
+	dth->dth_obj = UMOFF_NULL;
+}
+
+/**
+ * Prepare the leader DTX handle in DRAM.
  *
  * XXX: Currently, we only support to prepare the DTX against single DAOS
  *	object and single dkey.
@@ -210,205 +238,118 @@ check:
  * \param coh		[IN]	Container open handle.
  * \param epoch		[IN]	Epoch for the DTX.
  * \param dkey_hash	[IN]	Hash of the dkey to be modified if applicable.
- * \param conflict	[IN]	Hash of the dkey to be modified if applicable.
- * \param dti_cos	[IN,OUT]The DTX array to be committed because of shared.
- * \param dti_cos_count [IN,OUT]The @dti_cos array size.
+ * \param tgts		[IN]	targets for distribute transaction.
+ * \param tgts_cnt	[IN]	number of targets.
  * \param pm_ver	[IN]	Pool map version for the DTX.
  * \param intent	[IN]	The intent of related modification.
- * \param leader	[IN]	The target (to be modified) is leader or not.
  * \param dth		[OUT]	Pointer to the DTX handle.
  *
  * \return			Zero on success, negative value if error.
  */
 int
-dtx_begin(struct dtx_id *dti, daos_unit_oid_t *oid, daos_handle_t coh,
-	  daos_epoch_t epoch, uint64_t dkey_hash,
-	  struct dtx_conflict_entry *conflict, struct dtx_id *dti_cos,
-	  int dti_cos_count, uint32_t pm_ver, uint32_t intent, bool leader,
-	  struct dtx_handle **dthp)
+dtx_leader_begin(struct dtx_id *dti, daos_unit_oid_t *oid, daos_handle_t coh,
+		 daos_epoch_t epoch, uint64_t dkey_hash, uint32_t pm_ver,
+		 uint32_t intent, struct daos_shard_tgt *tgts, int tgts_cnt,
+		 struct dtx_leader_handle *dlh)
 {
-	struct dtx_handle	*dth;
+	struct dtx_handle	*dth = &dlh->dlh_handle;
+	struct dtx_id		*dti_cos = NULL;
+	int			dti_cos_count = 0;
+	int			i;
 
-	if (leader) {
-		/* XXX: For leader case, we need to find out the potential
-		 *	conflict DTXs in the CoS cache, and append them to
-		 *	the dispatched RPC to non-leaders. Then non-leader
-		 *	replicas can commit them before real modifications
-		 *	to avoid availability trouble.
+	/* XXX: For leader case, we need to find out the potential
+	 *	conflict DTXs in the CoS cache, and append them to
+	 *	the dispatched RPC to non-leaders. Then non-leader
+	 *	replicas can commit them before real modifications
+	 *	to avoid availability trouble.
+	 */
+	dti_cos_count = vos_dtx_list_cos(coh, oid, dkey_hash,
+			intent == DAOS_INTENT_UPDATE ?
+			DCLT_PUNCH : DCLT_PUNCH | DCLT_UPDATE,
+			DTX_THRESHOLD_COUNT, &dti_cos);
+	if (dti_cos_count < 0)
+		return dti_cos_count;
+
+	if (dti_cos_count > 0 && dti_cos == NULL) {
+		/* There are too many conflict DTXs to be committed,
+		 * as to cannot be taken via the normal IO RPC. The
+		 * background dedicated DTXs batched commit ULT has
+		 * not committed them in time. Let's retry later.
 		 */
-		D_ASSERT(dti_cos == NULL);
-		D_ASSERT(dti_cos_count == 0);
-
-		dti_cos_count = vos_dtx_list_cos(coh, oid, dkey_hash,
-				intent == DAOS_INTENT_UPDATE ?
-				DCLT_PUNCH : DCLT_PUNCH | DCLT_UPDATE,
-				DTX_THRESHOLD_COUNT, &dti_cos);
-		if (dti_cos_count < 0)
-			return dti_cos_count;
-
-		if (dti_cos_count > 0 && dti_cos == NULL) {
-			/* There are too many conflict DTXs to be committed,
-			 * as to cannot be taken via the normal IO RPC. The
-			 * background dedicated DTXs batched commit ULT has
-			 * not committed them in time. Let's retry later.
-			 */
-			D_DEBUG(DB_TRACE, "Too many pontential conflict DTXs "
-				"for the given "DF_DTI", let's retry later.\n",
-				DP_DTI(dti));
-			return -DER_INPROGRESS;
-		}
+		D_DEBUG(DB_TRACE, "Too many pontential conflict DTXs "
+			"for the given "DF_DTI", let's retry later.\n",
+			DP_DTI(dti));
+		return -DER_INPROGRESS;
 	}
-
-	D_ALLOC_PTR(dth);
-	if (dth == NULL) {
-		if (leader && dti_cos != NULL)
+	dlh->dlh_handled_time = crt_hlc_get();
+	dlh->dlh_future = ABT_FUTURE_NULL;
+	D_ALLOC(dlh->dlh_subs, tgts_cnt * sizeof(*dlh->dlh_subs));
+	if (dlh->dlh_subs == NULL) {
+		if (dti_cos != NULL)
 			D_FREE(dti_cos);
-
 		return -DER_NOMEM;
 	}
+	for (i = 0; i < tgts_cnt; i++)
+		dlh->dlh_subs[i].dss_tgt = tgts[i];
+	dlh->dlh_sub_cnt = tgts_cnt;
 
-	dth->dth_xid = *dti;
-	dth->dth_oid = *oid;
-	dth->dth_coh = coh;
-	dth->dth_epoch = epoch;
-	D_INIT_LIST_HEAD(&dth->dth_shares);
-	dth->dth_handled_time = crt_hlc_get();
-	dth->dth_dkey_hash = dkey_hash;
-	dth->dth_ver = pm_ver;
-	dth->dth_intent = intent;
-	dth->dth_sync = 0;
-	dth->dth_leader = (leader ? 1 : 0);
-	dth->dth_non_rep = 0;
-	dth->dth_dti_cos = dti_cos;
-	dth->dth_dti_cos_count = dti_cos_count;
-	dth->dth_conflict = conflict;
-	dth->dth_ent = UMOFF_NULL;
-	dth->dth_obj = UMOFF_NULL;
+	dtx_handle_init(dti, oid, coh, epoch, dkey_hash, pm_ver, intent,
+			NULL, dti_cos, dti_cos_count, true, dth);
 
-	*dthp = dth;
-	D_DEBUG(DB_TRACE, "Start the DTX "DF_DTI" for object "DF_OID
-		" ver %u, dkey %llu, dti_cos_count %d, intent %s, %s\n",
+	D_DEBUG(DB_TRACE, "Start DTX "DF_DTI" for object "DF_OID
+		" ver %u, dkey %llu, dti_cos_count %d, intent %s\n",
 		DP_DTI(&dth->dth_xid), DP_OID(oid->id_pub), dth->dth_ver,
 		(unsigned long long)dth->dth_dkey_hash, dti_cos_count,
-		dth->dth_intent == DAOS_INTENT_PUNCH ? "Punch" : "Update",
-		leader ? "leader" : "non-leader");
+		intent == DAOS_INTENT_PUNCH ? "Punch" : "Update");
 
 	return 0;
 }
 
 static int
-dtx_wait(struct dtx_handle *dth, struct dtx_conflict_entry **dces,
-	 int *dces_cnt);
-
-int
-dtx_end(struct dtx_handle *dth, struct ds_cont_hdl *cont_hdl,
-	struct ds_cont_child *cont, int result)
+dtx_leader_wait(struct dtx_leader_handle *dlh, struct dtx_conflict_entry **dces,
+		int *dces_cnt)
 {
-	struct dtx_conflict_entry	*dces = NULL;
-	int				dces_cnt = 0;
-	int				rc = 0;
+	int	rc;
 
-	if (dth == NULL)
-		return result;
+	rc = ABT_future_wait(dlh->dlh_future);
+	D_ASSERTF(rc == ABT_SUCCESS, "ABT_future_wait failed %d.\n", rc);
+	rc = dlh->dlh_result;
+	if (rc == -DER_INPROGRESS) {
+		struct dtx_conflict_entry	*conflict;
+		int				shard_cnt = dlh->dlh_sub_cnt;
+		int				i;
+		int				j;
 
-	if (!dth->dth_leader || dth->dth_non_rep || dtx_is_null(dth->dth_ent) ||
-	    dth->dth_exec_arg == NULL)
-		goto out_free;
-
-	rc = dtx_wait(dth, &dces, &dces_cnt);
-	if (rc == -DER_INPROGRESS && dces != NULL) {
-		/* XXX: The local modification has been done, but remote
-		 *	replica failed because of some uncommitted DTX,
-		 *	it may be caused by some garbage DTXs on remote
-		 *	replicas or leader has more information because
-		 *	of CoS cache. So handle (abort or commit) them
-		 *	firstly then retry.
-		 */
-		D_ASSERT(dth != NULL);
-		D_DEBUG(DB_TRACE, "Hit conflict DTX (%d)"DF_DTI" for "
-			DF_DTI", handle them and retry update.\n",
-			rc, DP_DTI(&dces[0].dce_xid), DP_DTI(&dth->dth_xid));
-
-		rc = dtx_conflict(cont_hdl->sch_cont->sc_hdl, dth,
-				  cont_hdl->sch_pool->spc_uuid,
-				  cont->sc_uuid, dces, dces_cnt,
-				  cont_hdl->sch_pool->spc_map_version);
-		D_FREE(dces);
-		if (rc >= 0) {
-			D_DEBUG(DB_TRACE, "retry DTX "DF_DTI"\n",
-				DP_DTI(&dth->dth_xid));
-			D_GOTO(out, result = -DER_AGAIN);
+		D_ALLOC_ARRAY(conflict, shard_cnt);
+		if (conflict == NULL) {
+			rc = -DER_NOMEM;
+			goto out;
 		}
 
-		if (result == 0)
-			result = rc;
+		for (i = 0, j = 0; i < shard_cnt; i++) {
+			struct dtx_sub_status *dss;
 
-		D_GOTO(fail, rc);
-	} else  if (rc < 0) {
-		if (result == 0)
-			result = rc;
-		D_GOTO(fail, rc);
-	}
-
-	/* If the DTX is started befoe DTX resync operation (for rebuild),
-	 * then it is possbile that the DTX resync ULT may have aborted
-	 * current DTX before remote replica(s) modification by race. So
-	 * let's check DTX status locally before marking as 'committable'.
-	 */
-	if (dth->dth_handled_time <= cont->sc_dtx_resync_time) {
-		rc = vos_dtx_check_committable(cont->sc_hdl, NULL,
-					       &dth->dth_xid, 0, false);
-		if (rc < 0) {
-			result = (rc == -DER_NONEXIST ? -DER_INPROGRESS : rc);
-			D_GOTO(fail, result);
+			dss = &dlh->dlh_subs[i];
+			if (!daos_is_zero_dti(&dss->dss_dce.dce_xid)) {
+				daos_dti_copy(&conflict[j].dce_xid,
+					      &dss->dss_dce.dce_xid);
+				conflict[j++].dce_dkey =
+					      dss->dss_dce.dce_dkey;
+			}
 		}
+
+		D_ASSERT(j > 0);
+
+		*dces = conflict;
+		*dces_cnt = j;
 	}
 
-	rc = vos_dtx_add_cos(dth->dth_coh, &dth->dth_oid, &dth->dth_xid,
-			     dth->dth_dkey_hash, dth->dth_handled_time,
-			     dth->dth_intent == DAOS_INTENT_PUNCH ?
-			     true : false);
-	if (rc != 0) {
-		D_ERROR(DF_UUID": Fail to add DTX "DF_DTI" to CoS cache: %d. "
-			"Try to commit it sychronously.\n",
-			DP_UUID(cont->sc_uuid), DP_DTI(&dth->dth_xid), rc);
-		dth->dth_sync = 1;
-	}
-
-	if (dth->dth_sync) {
-		rc = dtx_commit(cont_hdl->sch_pool->spc_uuid,
-				cont->sc_uuid, &dth->dth_dte, 1,
-				cont_hdl->sch_pool->spc_map_version);
-		if (rc != 0) {
-			D_ERROR(DF_UUID": Fail to sync commit DTX "DF_DTI
-				": rc = %d\n", DP_UUID(cont->sc_uuid),
-				DP_DTI(&dth->dth_xid), rc);
-			D_GOTO(fail, result = rc);
-		}
-	}
-
-fail:
-	if (result < 0)
-		dtx_abort(cont_hdl->sch_pool->spc_uuid, cont->sc_uuid,
-			  &dth->dth_dte, 1,
-			  cont_hdl->sch_pool->spc_map_version);
-out_free:
-	D_DEBUG(DB_TRACE,
-		"Stop the DTX "DF_DTI" ver %u, dkey %llu, intent %s, "
-		"%s, %s, %s: rc = %d\n",
-		DP_DTI(&dth->dth_xid), dth->dth_ver,
-		(unsigned long long)dth->dth_dkey_hash,
-		dth->dth_intent == DAOS_INTENT_PUNCH ? "Punch" : "Update",
-		dth->dth_sync ? "sync" : "async",
-		dth->dth_non_rep ? "non-replicated" : "replicated",
-		dth->dth_leader ? "leader" : "non-leader", result);
-
-	if (dth->dth_leader && dth->dth_dti_cos != NULL)
-		D_FREE(dth->dth_dti_cos);
-	D_FREE_PTR(dth);
 out:
-	return result > 0 ? 0 : result;
-}
+	ABT_future_free(&dlh->dlh_future);
+	D_DEBUG(DB_TRACE, "dth "DF_DTI" rc %d\n",
+		DP_DTI(&dlh->dlh_handle.dth_xid), rc);
+	return rc;
+};
 
 /**
  * Handle the conflict between current DTX and former uncommmitted DTXs.
@@ -431,11 +372,12 @@ out:
  *
  * \return			Zero on success, negative value if error.
  */
-int
-dtx_conflict(daos_handle_t coh, struct dtx_handle *dth, uuid_t po_uuid,
+static int
+dtx_conflict(daos_handle_t coh, struct dtx_leader_handle *dlh, uuid_t po_uuid,
 	     uuid_t co_uuid, struct dtx_conflict_entry *dces, int count,
 	     uint32_t version)
 {
+	struct dtx_handle	*dth = &dlh->dlh_handle;
 	daos_unit_oid_t		*oid = &dth->dth_oid;
 	struct dtx_id		*commit_ids = NULL;
 	struct dtx_entry	*abort_dtes = NULL;
@@ -443,8 +385,6 @@ dtx_conflict(daos_handle_t coh, struct dtx_handle *dth, uuid_t po_uuid,
 	int			 abort_cnt = 0;
 	int			 rc = 0;
 	int			 i;
-
-	D_ASSERT(dth->dth_leader);
 
 	D_ALLOC_ARRAY(commit_ids, count);
 	if (commit_ids == NULL)
@@ -542,6 +482,210 @@ out:
 
 	return rc > 0 ? 0 : rc;
 }
+
+/**
+ * Stop the leader thandle.
+ *
+ * \param dti		[IN]	The DTX identifier.
+ * \param oid		[IN]	The target object (shard) ID.
+ * \param coh		[IN]	Container open handle.
+ * \param epoch		[IN]	Epoch for the DTX.
+ * \param dkey_hash	[IN]	Hash of the dkey to be modified if applicable.
+ * \param pm_ver	[IN]	Pool map version for the DTX.
+ * \param intent	[IN]	The intent of related modification.
+ * \param dth		[OUT]	Pointer to the DTX handle.
+ *
+ * \return			Zero on success, negative value if error.
+ */
+int
+dtx_leader_end(struct dtx_leader_handle *dlh, struct ds_cont_hdl *cont_hdl,
+	       struct ds_cont_child *cont, int result)
+{
+	struct dtx_handle		*dth = &dlh->dlh_handle;
+	struct dtx_conflict_entry	*dces = NULL;
+	int				dces_cnt = 0;
+	int				rc = 0;
+
+	if (dlh == NULL)
+		return result;
+
+	if (dth->dth_non_rep || dlh->dlh_subs == NULL)
+		goto out_free;
+
+	/* NB: even the local request failure, dth_ent == NULL, we
+	 * should still wait for remote object to finish the request.
+	 */
+	rc = dtx_leader_wait(dlh, &dces, &dces_cnt);
+	if (rc == -DER_INPROGRESS && dces != NULL) {
+		/* XXX: The local modification has been done, but remote
+		 *	replica failed because of some uncommitted DTX,
+		 *	it may be caused by some garbage DTXs on remote
+		 *	replicas or leader has more information because
+		 *	of CoS cache. So handle (abort or commit) them
+		 *	firstly then retry.
+		 */
+		D_ASSERT(dth != NULL);
+		D_DEBUG(DB_TRACE, "Hit conflict DTX (%d)"DF_DTI" for "
+			DF_DTI", handle them and retry update.\n",
+			rc, DP_DTI(&dces[0].dce_xid), DP_DTI(&dth->dth_xid));
+
+		rc = dtx_conflict(cont_hdl->sch_cont->sc_hdl, dlh,
+				  cont_hdl->sch_pool->spc_uuid,
+				  cont->sc_uuid, dces, dces_cnt,
+				  cont_hdl->sch_pool->spc_map_version);
+		D_FREE(dces);
+		if (rc >= 0) {
+			D_DEBUG(DB_TRACE, "retry DTX "DF_DTI"\n",
+				DP_DTI(&dth->dth_xid));
+			D_GOTO(out, result = -DER_AGAIN);
+		}
+
+		if (result == 0)
+			result = rc;
+
+		D_GOTO(fail, rc);
+	} else  if (rc < 0) {
+		if (result == 0)
+			result = rc;
+		D_GOTO(fail, rc);
+	}
+
+	/* If the DTX is started befoe DTX resync operation (for rebuild),
+	 * then it is possbile that the DTX resync ULT may have aborted
+	 * current DTX before remote replica(s) modification by race. So
+	 * let's check DTX status locally before marking as 'committable'.
+	 */
+	if (dlh->dlh_handled_time <= cont->sc_dtx_resync_time) {
+		rc = vos_dtx_check_committable(cont->sc_hdl, NULL,
+					       &dth->dth_xid, 0, false);
+		if (rc < 0) {
+			result = (rc == -DER_NONEXIST ? -DER_INPROGRESS : rc);
+			D_GOTO(fail, result);
+		}
+	}
+
+	rc = vos_dtx_add_cos(dth->dth_coh, &dth->dth_oid, &dth->dth_xid,
+			     dth->dth_dkey_hash, dlh->dlh_handled_time,
+			     dth->dth_intent == DAOS_INTENT_PUNCH ?
+			     true : false);
+	if (rc != 0) {
+		D_ERROR(DF_UUID": Fail to add DTX "DF_DTI" to CoS cache: %d. "
+			"Try to commit it sychronously.\n",
+			DP_UUID(cont->sc_uuid), DP_DTI(&dth->dth_xid), rc);
+		dth->dth_sync = 1;
+	}
+
+	if (dth->dth_sync) {
+		rc = dtx_commit(cont_hdl->sch_pool->spc_uuid,
+				cont->sc_uuid, &dth->dth_dte, 1,
+				cont_hdl->sch_pool->spc_map_version);
+		if (rc != 0) {
+			D_ERROR(DF_UUID": Fail to sync commit DTX "DF_DTI
+				": rc = %d\n", DP_UUID(cont->sc_uuid),
+				DP_DTI(&dth->dth_xid), rc);
+			D_GOTO(fail, result = rc);
+		}
+	}
+
+fail:
+	if (result < 0)
+		dtx_abort(cont_hdl->sch_pool->spc_uuid, cont->sc_uuid,
+			  &dth->dth_dte, 1,
+			  cont_hdl->sch_pool->spc_map_version);
+out_free:
+	D_DEBUG(DB_TRACE,
+		"Stop the DTX "DF_DTI" ver %u, dkey %llu, intent %s, "
+		"%s, %s: rc = %d\n",
+		DP_DTI(&dth->dth_xid), dth->dth_ver,
+		(unsigned long long)dth->dth_dkey_hash,
+		dth->dth_intent == DAOS_INTENT_PUNCH ? "Punch" : "Update",
+		dth->dth_sync ? "sync" : "async",
+		dth->dth_non_rep ? "non-replicated" : "replicated", result);
+
+	if (dth->dth_dti_cos != NULL)
+		D_FREE(dth->dth_dti_cos);
+out:
+	return result > 0 ? 0 : result;
+}
+
+/**
+ * Prepare the DTX handle in DRAM.
+ *
+ * XXX: Currently, we only support to prepare the DTX against single DAOS
+ *	object and single dkey.
+ *
+ * \param dti		[IN]	The DTX identifier.
+ * \param oid		[IN]	The target object (shard) ID.
+ * \param coh		[IN]	Container open handle.
+ * \param epoch		[IN]	Epoch for the DTX.
+ * \param dkey_hash	[IN]	Hash of the dkey to be modified if applicable.
+ * \param conflict	[IN]	Hash of the dkey to be modified if applicable.
+ * \param dti_cos	[IN,OUT]The DTX array to be committed because of shared.
+ * \param dti_cos_count [IN,OUT]The @dti_cos array size.
+ * \param pm_ver	[IN]	Pool map version for the DTX.
+ * \param intent	[IN]	The intent of related modification.
+ * \param leader	[IN]	The target (to be modified) is leader or not.
+ * \param dth		[OUT]	Pointer to the DTX handle.
+ *
+ * \return			Zero on success, negative value if error.
+ */
+int
+dtx_begin(struct dtx_id *dti, daos_unit_oid_t *oid, daos_handle_t coh,
+	  daos_epoch_t epoch, uint64_t dkey_hash,
+	  struct dtx_conflict_entry *conflict, struct dtx_id *dti_cos,
+	  int dti_cos_cnt, uint32_t pm_ver, uint32_t intent,
+	  struct dtx_handle *dth)
+{
+	dtx_handle_init(dti, oid, coh, epoch, dkey_hash, pm_ver, intent,
+			conflict, dti_cos, dti_cos_cnt, false, dth);
+
+	D_DEBUG(DB_TRACE, "Start the DTX "DF_DTI" for object "DF_OID
+		" ver %u, dkey %llu, dti_cos_count %d, intent %s\n",
+		DP_DTI(&dth->dth_xid), DP_OID(oid->id_pub), dth->dth_ver,
+		(unsigned long long)dth->dth_dkey_hash, dti_cos_cnt,
+		intent == DAOS_INTENT_PUNCH ? "Punch" : "Update");
+
+	return 0;
+}
+
+int
+dtx_end(struct dtx_handle *dth, struct ds_cont_hdl *cont_hdl,
+	struct ds_cont_child *cont, int result)
+{
+	int rc = 0;
+
+	if (dth == NULL)
+		D_GOTO(out, rc);
+
+	if (result < 0 && dth->dth_dti_cos_count > 0) {
+		/* XXX: For non-leader replica, even if we fail to
+		 *	make related modification for some reason,
+		 *	we still need to commit the DTXs for CoS.
+		 *	Because other replica may have already
+		 *	committed them. For leader case, it is
+		 *	not important even if we miss to commit
+		 *	the CoS DTXs, because they are still in
+		 *	CoS cache, and can be committed next time.
+		 */
+		rc = vos_dtx_commit(cont->sc_hdl, dth->dth_dti_cos,
+				    dth->dth_dti_cos_count);
+		if (rc != 0)
+			D_ERROR(DF_UUID": Fail to DTX CoS commit: %d\n",
+				DP_UUID(cont->sc_uuid), rc);
+	}
+
+	D_DEBUG(DB_TRACE,
+		"Stop the DTX "DF_DTI" ver %u, dkey %llu, intent %s, "
+		"%s, %s: rc = %d\n",
+		DP_DTI(&dth->dth_xid), dth->dth_ver,
+		(unsigned long long)dth->dth_dkey_hash,
+		dth->dth_intent == DAOS_INTENT_PUNCH ? "Punch" : "Update",
+		dth->dth_sync ? "sync" : "async",
+		dth->dth_non_rep ? "non-replicated" : "replicated", result);
+out:
+	return result > 0 ? 0 : result;
+}
+
 
 int
 dtx_batched_commit_register(struct ds_cont_hdl *hdl)
@@ -675,147 +819,84 @@ dtx_handle_resend(daos_handle_t coh, daos_unit_oid_t *oid,
 }
 
 static void
-dtx_exec_ops_comp_cb(void **arg)
+dtx_comp_cb(void **arg)
 {
-	struct dtx_exec_shard_arg	*shard_arg;
-	struct dtx_exec_arg		*exec_arg;
+	struct dtx_leader_handle	*dlh;
 	uint32_t			i;
-	uint32_t			shard_cnt;
 
-	shard_arg = arg[0];
-	exec_arg = shard_arg->exec_arg;
-	shard_cnt = exec_arg->shard_cnt;
-	D_ASSERT(shard_cnt >= 1);
-	for (i = 0; i < shard_cnt; i++) {
-		shard_arg = arg[i];
-		D_ASSERT(shard_arg->exec_arg == exec_arg);
+	dlh = arg[0];
+	for (i = 0; i < dlh->dlh_sub_cnt; i++) {
+		struct dtx_sub_status	*sub = &dlh->dlh_subs[i];
 
-		if (shard_arg->exec_shard_rc == 0)
+		if (sub->dss_result == 0)
 			continue;
 
 		/* Ignore DER_INPROGRESS if there are other failures */
-		if (exec_arg->exec_result == 0 ||
-		    exec_arg->exec_result == -DER_INPROGRESS)
-			exec_arg->exec_result = shard_arg->exec_shard_rc;
+		if (dlh->dlh_result == 0 || dlh->dlh_result == -DER_INPROGRESS)
+			dlh->dlh_result = sub->dss_result;
 	}
 }
 
 static void
-dtx_shard_exec_comp_cb(struct dtx_exec_shard_arg *shard_arg, int rc)
+dtx_sub_comp_cb(struct dtx_leader_handle *dlh, int idx, int rc)
 {
-	shard_arg->exec_shard_rc = rc;
-	rc = ABT_future_set(shard_arg->exec_arg->future, shard_arg);
+	struct dtx_sub_status	*sub = &dlh->dlh_subs[idx];
+	ABT_future		future = dlh->dlh_future;
+
+	sub->dss_result = rc;
+	rc = ABT_future_set(future, dlh);
 	D_ASSERTF(rc == ABT_SUCCESS, "ABT_future_set failed %d.\n", rc);
 
 	D_DEBUG(DB_TRACE, "execute from rank %d tag %d, rc %d.\n",
-		shard_arg->exec_shard_tgt->st_rank,
-		shard_arg->exec_shard_tgt->st_tgt_idx,
-		shard_arg->exec_shard_rc);
+		sub->dss_tgt.st_rank, sub->dss_tgt.st_tgt_idx,
+		sub->dss_result);
 }
 
-static int
-dtx_exec_op(struct dtx_exec_shard_arg *shard_arg, int idx)
-{
-	struct dtx_exec_arg	*exec_arg = shard_arg->exec_arg;
-	struct daos_shard_tgt	*shard_tgt;
-	int			 rc = 0;
-
-	D_ASSERT(idx < exec_arg->shard_cnt);
-	shard_tgt = shard_arg->exec_shard_tgt;
-	if (shard_tgt->st_rank == TGTS_IGNORE) {
-		D_DEBUG(DB_TRACE, "ignore exec on tgt rank %d. idx %d\n",
-			shard_tgt->st_rank, idx);
-		shard_arg->exec_shard_rc = rc;
-		rc = ABT_future_set(exec_arg->future, shard_arg);
-		return rc;
-	}
-
-	rc = exec_arg->exec_func(exec_arg->dth, exec_arg->exec_func_arg, idx,
-				 dtx_shard_exec_comp_cb, shard_arg);
-	return rc;
-}
-
-void
-dtx_exec_arg_free(struct dtx_exec_arg *exec_arg)
-{
-	ABT_future_free(&exec_arg->future);
-	D_FREE(exec_arg);
-}
-
-static int
-dtx_wait(struct dtx_handle *dth, struct dtx_conflict_entry **dces,
-	 int *dces_cnt)
-{
-	struct dtx_exec_arg	*exec_arg = dth->dth_exec_arg;
-	int			rc;
-
-	D_ASSERT(exec_arg != NULL);
-	D_ASSERT(exec_arg->future != ABT_FUTURE_NULL);
-	rc = ABT_future_wait(exec_arg->future);
-	D_ASSERTF(rc == ABT_SUCCESS, "ABT_future_wait failed %d.\n", rc);
-	rc = exec_arg->exec_result;
-	if (rc == -DER_INPROGRESS && dces != NULL) {
-		struct dtx_conflict_entry	*conflict;
-		int				shard_cnt = exec_arg->shard_cnt;
-		int				i;
-		int				j;
-
-		D_ALLOC_ARRAY(conflict, shard_cnt);
-		if (conflict == NULL) {
-			rc = -DER_NOMEM;
-			goto out;
-		}
-
-		for (i = 0, j = 0; i < shard_cnt; i++) {
-			struct dtx_exec_shard_arg *shard_arg;
-
-			shard_arg = &exec_arg->exec_shards_args[i];
-			if (!daos_is_zero_dti(&shard_arg->exec_dce.dce_xid)) {
-				daos_dti_copy(&conflict[j].dce_xid,
-					      &shard_arg->exec_dce.dce_xid);
-				conflict[j++].dce_dkey =
-						shard_arg->exec_dce.dce_dkey;
-			}
-		}
-
-		D_ASSERT(j > 0);
-
-		*dces = conflict;
-		*dces_cnt = j;
-	}
-
-out:
-	D_DEBUG(DB_TRACE, "dth "DF_DTI" rc %d\n", DP_DTI(&dth->dth_xid), rc);
-	dtx_exec_arg_free(exec_arg);
-
-	return rc;
+struct dtx_ult_arg {
+	dtx_sub_func_t			func;
+	void				*func_arg;
+	struct dtx_leader_handle	*dlh;
 };
 
-void
-dtx_exec_ops_ult(void *arg)
+static void
+dtx_leader_exec_ops_ult(void *arg)
 {
-	struct dtx_exec_arg	*exec_arg = arg;
-	ABT_future		future = exec_arg->future;
-	int			shard_cnt = exec_arg->shard_cnt;
-	uint32_t		i;
-	int			rc = 0;
+	struct dtx_ult_arg	  *ult_arg = arg;
+	struct dtx_leader_handle  *dlh = ult_arg->dlh;
+	ABT_future		  future = dlh->dlh_future;
+	uint32_t		  i;
+	int			  rc = 0;
 
-	D_ASSERT(shard_cnt >= 1);
 	D_ASSERT(future != ABT_FUTURE_NULL);
-	for (i = 0; i < shard_cnt; i++) {
-		rc = dtx_exec_op(&exec_arg->exec_shards_args[i], i);
-		if (rc != 0)
+	for (i = 0; i < dlh->dlh_sub_cnt; i++) {
+		struct dtx_sub_status *sub = &dlh->dlh_subs[i];
+
+		if (sub->dss_tgt.st_rank == TGTS_IGNORE) {
+			int ret;
+
+			ret = ABT_future_set(future, dlh);
+			D_ASSERTF(ret == ABT_SUCCESS,
+				  "ABT_future_set failed %d.\n", ret);
+			continue;
+		}
+
+		sub->dss_result = 0;
+		memset(&sub->dss_dce, 0, sizeof(sub->dss_dce));
+		rc = ult_arg->func(dlh, ult_arg->func_arg, i,
+				   dtx_sub_comp_cb);
+		if (rc) {
+			dlh->dlh_subs[i].dss_result = rc;
 			break;
+		}
 	}
 
 	if (rc != 0) {
-		D_ASSERT(i < shard_cnt);
-		for (i++; i < shard_cnt; i++) {
-			exec_arg->exec_shards_args[i].exec_shard_rc = rc;
-			rc = ABT_future_set(future,
-					    &exec_arg->exec_shards_args[i]);
-			D_ASSERTF(rc == ABT_SUCCESS,
-				  "ABT_future_set failed %d.\n", rc);
+		for (i++; i < dlh->dlh_sub_cnt; i++) {
+			int ret;
+
+			ret = ABT_future_set(future, dlh);
+			D_ASSERTF(ret == ABT_SUCCESS,
+				  "ABT_future_set failed %d.\n", ret);
 		}
 	}
 }
@@ -824,54 +905,45 @@ dtx_exec_ops_ult(void *arg)
  * Execute the operations on all targets.
  */
 int
-dtx_exec_ops(struct daos_shard_tgt *shard_tgts, int tgts_cnt,
-	     struct dtx_handle *dth, dtx_exec_shard_func_t exec_func,
-	     void *func_arg)
+dtx_leader_exec_ops(struct dtx_leader_handle *dlh, dtx_sub_func_t func,
+		    void *func_arg)
 {
-	struct dtx_exec_arg		*exec_arg;
-	ABT_future			future;
-	int				i;
-	int				rc;
+	struct dtx_ult_arg	*ult_arg;
+	int			rc;
 
-	D_ALLOC(exec_arg,
-		offsetof(struct dtx_exec_arg, exec_shards_args[tgts_cnt]));
-	if (exec_arg == NULL)
+	D_ALLOC_PTR(ult_arg);
+	if (ult_arg == NULL)
 		return -DER_NOMEM;
+	ult_arg->func	= func;
+	ult_arg->func_arg = func_arg;
+	ult_arg->dlh	= dlh;
 
-	rc = ABT_future_create(tgts_cnt, dtx_exec_ops_comp_cb, &future);
+	/* the future should already be freed */
+	D_ASSERT(dlh->dlh_future == ABT_FUTURE_NULL);
+	rc = ABT_future_create(dlh->dlh_sub_cnt, dtx_comp_cb, &dlh->dlh_future);
 	if (rc != ABT_SUCCESS) {
 		D_ERROR("ABT_future_create failed %d.\n", rc);
-		D_FREE(exec_arg);
+		D_FREE_PTR(ult_arg);
 		return dss_abterr2der(rc);
 	}
 
-	exec_arg->exec_func	= exec_func;
-	exec_arg->exec_func_arg	= func_arg;
-	exec_arg->future	= future;
-	exec_arg->shard_cnt	= tgts_cnt;
-	exec_arg->dth		= dth;
-	for (i = 0; i < tgts_cnt; i++) {
-		exec_arg->exec_shards_args[i].exec_shard_tgt = shard_tgts + i;
-		exec_arg->exec_shards_args[i].exec_arg = exec_arg;
-	}
-
-	dth->dth_exec_arg = exec_arg;
-
 	/*
 	 * XXX ideally, we probably should create ULT for each shard, but
-	 * for performance reasons, let's create one for all remote targets
-	 * for now.
+	 * for performance reasons, let's only create one for all remote
+	 * targets for now.
 	 */
-	rc = dss_ult_create(dtx_exec_ops_ult, exec_arg, DSS_ULT_IOFW,
+	dlh->dlh_result = 0;
+	rc = dss_ult_create(dtx_leader_exec_ops_ult, ult_arg, DSS_ULT_IOFW,
 			    dss_get_module_info()->dmi_tgt_id, 0, NULL);
 	if (rc != 0) {
 		D_ERROR("ult create failed %d.\n", rc);
-		dtx_exec_arg_free(exec_arg);
+		D_FREE_PTR(ult_arg);
+		ABT_future_free(&dlh->dlh_future);
 		D_GOTO(out, rc);
 	}
 
 	/* Then execute the local operation */
-	rc = exec_func(dth, func_arg, -1, NULL, NULL);
+	rc = func(dlh, func_arg, -1, NULL);
 out:
 	return rc;
 }

--- a/src/include/daos_srv/dtx_srv.h
+++ b/src/include/daos_srv/dtx_srv.h
@@ -43,7 +43,6 @@ enum dtx_cos_list_types {
 	DCLT_PUNCH		= (1 << 1),
 };
 
-struct dtx_exec_arg;
 /**
  * DAOS two-phase commit transaction handle in DRAM.
  */
@@ -65,8 +64,6 @@ struct dtx_handle {
 	 * by other DTXs, but not ready for commit yet.
 	 */
 	d_list_t			 dth_shares;
-	/* The time when the DTX is handled on the server. */
-	uint64_t			 dth_handled_time;
 	/* The hash of the dkey to be modified if applicable */
 	uint64_t			 dth_dkey_hash;
 	/** Pool map version. */
@@ -84,12 +81,39 @@ struct dtx_handle {
 	struct dtx_id			*dth_dti_cos;
 	/* The identifier of the DTX that conflict with current one. */
 	struct dtx_conflict_entry	*dth_conflict;
-	/* The data attached to the dth for dispatch */
-	struct dtx_exec_arg		*dth_exec_arg;
 	/** The address of the DTX entry in SCM. */
 	umem_off_t			 dth_ent;
 	/** The address (offset) of the (new) object to be modified. */
 	umem_off_t			 dth_obj;
+};
+
+/* Each sub transaction handle to manage each sub thandle */
+struct dtx_sub_status {
+	struct daos_shard_tgt		dss_tgt;
+	struct dtx_conflict_entry	dss_dce;
+	int				dss_result;
+};
+
+/* Transaction handle on the leader node to manage the transaction */
+struct dtx_leader_handle {
+	/* The dtx handle on the leader node */
+	struct dtx_handle		dlh_handle;
+	/* The time when the DTX is handled on the server. */
+	uint64_t			dlh_handled_time;
+	/* result for the distribute transaction */
+	int				dlh_result;
+
+	/* The array of the DTX COS entries */
+	uint32_t			dlh_dti_cos_count;
+	struct dtx_id			*dlh_dti_cos;
+
+	/* The future to wait for all sub handle to finish */
+	ABT_future			dlh_future;
+
+	/* How many sub leader transaction */
+	uint32_t			dlh_sub_cnt;
+	/* Sub transaction handle to manage the dtx leader */
+	struct dtx_sub_status		*dlh_subs;
 };
 
 struct dtx_stat {
@@ -109,48 +133,34 @@ enum dtx_status {
 	DTX_ST_COMMITTED	= 2,
 };
 
-struct dtx_exec_arg;
+int
+dtx_leader_begin(struct dtx_id *dti, daos_unit_oid_t *oid, daos_handle_t coh,
+		 daos_epoch_t epoch, uint64_t dkey_hash, uint32_t pm_ver,
+		 uint32_t intent, struct daos_shard_tgt *tgts, int tgts_cnt,
+		 struct dtx_leader_handle *dlh);
+int
+dtx_leader_end(struct dtx_leader_handle *dlh, struct ds_cont_hdl *cont_hdl,
+	       struct ds_cont_child *cont, int result);
 
-struct dtx_exec_shard_arg {
-	struct daos_shard_tgt		*exec_shard_tgt;
-	struct dtx_exec_arg		*exec_arg;
-	struct dtx_conflict_entry	 exec_dce;
-	int				 exec_shard_rc;
-};
-
-typedef void (*dtx_exec_shard_comp_cb_t)(struct dtx_exec_shard_arg *arg,
-					 int rc);
-typedef int (*dtx_exec_shard_func_t)(struct dtx_handle *dth, void *arg, int idx,
-				     dtx_exec_shard_comp_cb_t comp_cb,
-				     struct dtx_exec_shard_arg *comp_cb_arg);
-struct dtx_exec_arg {
-	dtx_exec_shard_func_t	exec_func;
-	void			*exec_func_arg;
-	struct dtx_handle	*dth;
-	ABT_future		future;
-	uint32_t		shard_cnt;
-	int			exec_result;
-	struct dtx_exec_shard_arg exec_shards_args[0];
-};
+typedef void (*dtx_sub_comp_cb_t)(struct dtx_leader_handle *dlh, int idx,
+				  int rc);
+typedef int (*dtx_sub_func_t)(struct dtx_leader_handle *dlh, void *arg, int idx,
+			      dtx_sub_comp_cb_t comp_cb);
 
 int dtx_resync(daos_handle_t po_hdl, uuid_t po_uuid, uuid_t co_uuid,
 	       uint32_t ver, bool block);
+int
+dtx_begin(struct dtx_id *dti, daos_unit_oid_t *oid, daos_handle_t coh,
+	  daos_epoch_t epoch, uint64_t dkey_hash,
+	  struct dtx_conflict_entry *conflict, struct dtx_id *dti_cos,
+	  int dti_cos_cnt, uint32_t pm_ver, uint32_t intent,
+	  struct dtx_handle *dth);
+int
+dtx_end(struct dtx_handle *dth, struct ds_cont_hdl *cont_hdl,
+	struct ds_cont_child *cont, int result);
 
-int dtx_begin(struct dtx_id *dti, daos_unit_oid_t *oid, daos_handle_t coh,
-	      daos_epoch_t epoch, uint64_t dkey_hash,
-	      struct dtx_conflict_entry *conflict, struct dtx_id *dti_cos,
-	      int dti_cos_count, uint32_t pm_ver, uint32_t intent, bool leader,
-	      struct dtx_handle **dth);
-
-int dtx_end(struct dtx_handle *dth, struct ds_cont_hdl *cont_hdl,
-	    struct ds_cont_child *cont, int result);
-
-int dtx_conflict(daos_handle_t coh, struct dtx_handle *dth, uuid_t po_uuid,
-		 uuid_t co_uuid, struct dtx_conflict_entry *dces, int count,
-		 uint32_t version);
-int dtx_exec_ops(struct daos_shard_tgt *shard_tgts, int tgts_cnt,
-		 struct dtx_handle *dth, dtx_exec_shard_func_t exec_func,
-		 void *func_arg);
+int dtx_leader_exec_ops(struct dtx_leader_handle *dth, dtx_sub_func_t exec_func,
+			void *func_arg);
 
 int dtx_batched_commit_register(struct ds_cont_hdl *hdl);
 

--- a/src/object/obj_internal.h
+++ b/src/object/obj_internal.h
@@ -258,11 +258,11 @@ struct ds_obj_exec_arg {
 };
 
 int
-ds_obj_remote_update(struct dtx_handle *dth, void *arg, int idx,
-		     dtx_exec_shard_comp_cb_t comp_cb, void *cb_arg);
+ds_obj_remote_update(struct dtx_leader_handle *dth, void *arg, int idx,
+		     dtx_sub_comp_cb_t comp_cb);
 int
-ds_obj_remote_punch(struct dtx_handle *dth, void *arg, int idx,
-		    dtx_exec_shard_comp_cb_t comp_cb, void *cb_arg);
+ds_obj_remote_punch(struct dtx_leader_handle *dth, void *arg, int idx,
+		    dtx_sub_comp_cb_t comp_cb);
 /* srv_obj.c */
 void ds_obj_rw_handler(crt_rpc_t *rpc);
 void ds_obj_tgt_update_handler(crt_rpc_t *rpc);

--- a/src/object/obj_rpc.c
+++ b/src/object/obj_rpc.c
@@ -557,7 +557,6 @@ obj_reply_dtx_conflict_set(crt_rpc_t *rpc, struct dtx_conflict_entry *dce)
 	void *reply = crt_reply_get(rpc);
 
 	switch (opc_get(rpc->cr_opc)) {
-	case DAOS_OBJ_RPC_UPDATE:
 	case DAOS_OBJ_RPC_TGT_UPDATE: {
 		struct obj_rw_out	*orw = reply;
 
@@ -565,9 +564,6 @@ obj_reply_dtx_conflict_set(crt_rpc_t *rpc, struct dtx_conflict_entry *dce)
 		orw->orw_dkey_conflict = dce->dce_dkey;
 		break;
 	}
-	case DAOS_OBJ_RPC_PUNCH:
-	case DAOS_OBJ_RPC_PUNCH_DKEYS:
-	case DAOS_OBJ_RPC_PUNCH_AKEYS:
 	case DAOS_OBJ_RPC_TGT_PUNCH:
 	case DAOS_OBJ_RPC_TGT_PUNCH_DKEYS:
 	case DAOS_OBJ_RPC_TGT_PUNCH_AKEYS: {

--- a/src/object/srv_obj.c
+++ b/src/object/srv_obj.c
@@ -102,8 +102,7 @@ ds_obj_rw_reply(crt_rpc_t *rpc, int status, uint32_t map_version,
 
 	obj_reply_set_status(rpc, status);
 	obj_reply_map_version_set(rpc, map_version);
-	if (opc_get(rpc->cr_opc) == DAOS_OBJ_RPC_UPDATE ||
-	    opc_get(rpc->cr_opc) == DAOS_OBJ_RPC_TGT_UPDATE)
+	if (dce != NULL)
 		obj_reply_dtx_conflict_set(rpc, dce);
 
 	D_DEBUG(DB_TRACE, "rpc %p opc %d send reply, ver %d, status %d.\n",
@@ -821,7 +820,7 @@ ds_obj_tgt_update_handler(crt_rpc_t *rpc)
 	struct obj_rw_out		*orwo = crt_reply_get(rpc);
 	struct ds_cont_hdl		*cont_hdl = NULL;
 	struct ds_cont_child		*cont = NULL;
-	struct dtx_handle		*dth = NULL;
+	struct dtx_handle		dth = { 0 };
 	struct dtx_conflict_entry	 conflict = { 0 };
 	uint32_t			 map_ver = 0;
 	int				 rc;
@@ -864,44 +863,22 @@ ds_obj_tgt_update_handler(crt_rpc_t *rpc)
 		       orw->orw_epoch, orw->orw_dkey_hash,
 		       &conflict, orw->orw_dti_cos.ca_arrays,
 		       orw->orw_dti_cos.ca_count, orw->orw_map_ver,
-		       DAOS_INTENT_UPDATE, false, &dth);
+		       DAOS_INTENT_UPDATE, &dth);
 	if (rc != 0) {
 		D_ERROR(DF_UOID": Failed to start DTX for update %d.\n",
 			DP_UOID(orw->orw_oid), rc);
 		D_GOTO(out, rc);
 	}
 
-	rc = obj_local_rw(rpc, cont_hdl, cont, dth);
+	rc = obj_local_rw(rpc, cont_hdl, cont, &dth);
 	if (rc != 0) {
 		D_ERROR(DF_UOID": rw_local (update) failed %d.\n",
 			DP_UOID(orw->orw_oid), rc);
 		D_GOTO(out, rc);
 	}
 
-	/**
-	 * XXX layer violation, it should be moved to DTX module, will
-	 * handle in following patches.
-	 */
-	if (orw->orw_dti_cos.ca_count > 0) {
-		/* XXX: For non-leader replica, even if we fail to
-		 *	make related modification for some reason,
-		 *	we still need to commit the DTXs for CoS.
-		 *	Because other replica may have already
-		 *	committed them. For leader case, it is
-		 *	not important even if we miss to commit
-		 *	the CoS DTXs, because they are still in
-		 *	CoS cache, and can be committed next time.
-		 */
-		rc = vos_dtx_commit(cont->sc_hdl,
-				    orw->orw_dti_cos.ca_arrays,
-				    orw->orw_dti_cos.ca_count);
-		if (rc != 0)
-			D_ERROR(DF_UUID": Fail to DTX CoS commit: %d\n",
-				DP_UUID(cont->sc_uuid), rc);
-	}
-
 out:
-	rc = dtx_end(dth, cont_hdl, cont, rc);
+	rc = dtx_end(&dth, cont_hdl, cont, rc);
 	ds_obj_rw_reply(rpc, rc, map_ver, &conflict);
 
 	if (cont_hdl)
@@ -911,9 +888,8 @@ out:
 }
 
 static int
-ds_obj_tgt_update(struct dtx_handle *dth, void *arg, int idx,
-		  dtx_exec_shard_comp_cb_t comp_cb,
-		  struct dtx_exec_shard_arg *comp_arg)
+ds_obj_tgt_update(struct dtx_leader_handle *dlh, void *arg, int idx,
+		  dtx_sub_comp_cb_t comp_cb)
 {
 	struct ds_obj_exec_arg *exec_arg = arg;
 
@@ -924,16 +900,16 @@ ds_obj_tgt_update(struct dtx_handle *dth, void *arg, int idx,
 		/* No need re-exec local update */
 		if (!(exec_arg->flags & ORF_RESEND)) {
 			rc = obj_local_rw(exec_arg->rpc, exec_arg->cont_hdl,
-					  exec_arg->cont, dth);
+					  exec_arg->cont, &dlh->dlh_handle);
 		}
 		if (comp_cb != NULL)
-			comp_cb(comp_arg, rc);
+			comp_cb(dlh, idx, rc);
 
 		return rc;
 	}
 
 	/* Handle the object remotely */
-	return ds_obj_remote_update(dth, arg, idx, comp_cb, comp_arg);
+	return ds_obj_remote_update(dlh, arg, idx, comp_cb);
 }
 
 void
@@ -943,13 +919,12 @@ ds_obj_rw_handler(crt_rpc_t *rpc)
 	struct obj_rw_out		*orwo = crt_reply_get(rpc);
 	struct ds_cont_hdl		*cont_hdl = NULL;
 	struct ds_cont_child		*cont = NULL;
-	struct dtx_handle		*dth = NULL;
-	struct dtx_conflict_entry	 conflict = { 0 };
+	struct dtx_leader_handle	dlh = { 0 };
 	struct obj_tls			*tls = obj_tls_get();
 	struct ds_obj_exec_arg		exec_arg = { 0 };
-	uint32_t			 map_ver = 0;
-	uint32_t			 flags = 0;
-	int				 rc;
+	uint32_t			map_ver = 0;
+	uint32_t			flags = 0;
+	int				rc;
 
 	D_ASSERT(orw != NULL);
 	D_ASSERT(orwo != NULL);
@@ -983,7 +958,7 @@ ds_obj_rw_handler(crt_rpc_t *rpc)
 	if (orw->orw_shard_tgts.ca_arrays == NULL) {
 		/* No resend case for single replica yet XXX */
 		D_TIME_START(tls->ot_sp, OBJ_PF_UPDATE_LOCAL);
-		rc = obj_local_rw(rpc, cont_hdl, cont, dth);
+		rc = obj_local_rw(rpc, cont_hdl, cont, NULL);
 		if (rc != 0) {
 			D_ERROR(DF_UOID": rw_local (update) failed %d.\n",
 				DP_UOID(orw->orw_oid), rc);
@@ -1023,11 +998,11 @@ ds_obj_rw_handler(crt_rpc_t *rpc)
 	 * modification or not, so still need to dispatch
 	 * the RPC to other replicas.
 	 */
-	rc = dtx_begin(&orw->orw_dti, &orw->orw_oid, cont->sc_hdl,
-		       orw->orw_epoch, orw->orw_dkey_hash,
-		       &conflict, orw->orw_dti_cos.ca_arrays,
-		       orw->orw_dti_cos.ca_count, orw->orw_map_ver,
-		       DAOS_INTENT_UPDATE, true, &dth);
+	rc = dtx_leader_begin(&orw->orw_dti, &orw->orw_oid, cont->sc_hdl,
+			      orw->orw_epoch, orw->orw_dkey_hash,
+			      orw->orw_map_ver, DAOS_INTENT_UPDATE,
+			      orw->orw_shard_tgts.ca_arrays,
+			      orw->orw_shard_tgts.ca_count, &dlh);
 	if (rc != 0) {
 		D_ERROR(DF_UOID": Failed to start DTX for update %d.\n",
 			DP_UOID(orw->orw_oid), rc);
@@ -1041,18 +1016,16 @@ ds_obj_rw_handler(crt_rpc_t *rpc)
 again:
 	exec_arg.flags = flags;
 	/* Execute the operation on all targets */
-	rc = dtx_exec_ops(orw->orw_shard_tgts.ca_arrays,
-			  orw->orw_shard_tgts.ca_count, dth,
-			  ds_obj_tgt_update, &exec_arg);
+	rc = dtx_leader_exec_ops(&dlh, ds_obj_tgt_update, &exec_arg);
 out:
 	/* Stop the distribute transaction */
-	rc = dtx_end(dth, cont_hdl, cont, rc);
+	rc = dtx_leader_end(&dlh, cont_hdl, cont, rc);
 	if (rc == -DER_AGAIN) {
 		flags |= ORF_RESEND;
 		D_GOTO(again, rc);
 	}
 
-	ds_obj_rw_reply(rpc, rc, map_ver, &conflict);
+	ds_obj_rw_reply(rpc, rc, map_ver, NULL);
 	D_TIME_END(tls->ot_sp, OBJ_PF_UPDATE);
 
 	if (cont_hdl)
@@ -1363,7 +1336,8 @@ obj_punch_complete(crt_rpc_t *rpc, int status, uint32_t map_version,
 
 	obj_reply_set_status(rpc, status);
 	obj_reply_map_version_set(rpc, map_version);
-	obj_reply_dtx_conflict_set(rpc, dce);
+	if (dce != NULL)
+		obj_reply_dtx_conflict_set(rpc, dce);
 
 	rc = crt_reply_send(rpc);
 	if (rc != 0)
@@ -1415,7 +1389,7 @@ ds_obj_tgt_punch_handler(crt_rpc_t *rpc)
 {
 	struct ds_cont_hdl		*cont_hdl = NULL;
 	struct ds_cont_child		*cont = NULL;
-	struct dtx_handle		*dth = NULL;
+	struct dtx_handle		dth = { 0 };
 	struct dtx_conflict_entry	 conflict = { 0 };
 	struct obj_punch_in		*opi;
 	uint32_t			 map_version = 0;
@@ -1443,7 +1417,7 @@ ds_obj_tgt_punch_handler(crt_rpc_t *rpc)
 		       opi->opi_epoch, opi->opi_dkey_hash,
 		       &conflict, opi->opi_dti_cos.ca_arrays,
 		       opi->opi_dti_cos.ca_count, opi->opi_map_ver,
-		       DAOS_INTENT_PUNCH, false, &dth);
+		       DAOS_INTENT_PUNCH, &dth);
 	if (rc != 0) {
 		D_ERROR(DF_UOID": Failed to start DTX for punch %d.\n",
 			DP_UOID(opi->opi_oid), rc);
@@ -1451,39 +1425,15 @@ ds_obj_tgt_punch_handler(crt_rpc_t *rpc)
 	}
 
 	/* local RPC handler */
-	rc = obj_local_punch(opi, opc_get(rpc->cr_opc), cont_hdl, cont, dth);
+	rc = obj_local_punch(opi, opc_get(rpc->cr_opc), cont_hdl, cont, &dth);
 	if (rc != 0) {
 		D_ERROR(DF_UOID": obj_local_punch failed %d.\n",
 			DP_UOID(opi->opi_oid), rc);
 		D_GOTO(out, rc);
 	}
-
-	/**
-	 * XXX layer violation, it should be moved to DTX module, will
-	 * handle in following patches.
-	 */
-	if (opi->opi_dti_cos.ca_count > 0) {
-		/* XXX: For non-leader replica, even if we fail to
-		 *	make related modification for some reason,
-		 *	we still need to commit the DTXs for CoS.
-		 *	Because other replica may have already
-		 *	committed them. For leader case, it is
-		 *	not important even if we miss to commit
-		 *	the CoS DTXs, because they are still in
-		 *	CoS cache, and can be committed next time.
-		 */
-		rc = vos_dtx_commit(cont->sc_hdl,
-				    opi->opi_dti_cos.ca_arrays,
-				    opi->opi_dti_cos.ca_count);
-		if (rc != 0) {
-			D_ERROR(DF_UUID": Fail to DTX CoS commit: %d\n",
-				DP_UUID(cont->sc_uuid), rc);
-			D_GOTO(out, rc);
-		}
-	}
 out:
 	/* Stop the local transaction */
-	rc = dtx_end(dth, cont_hdl, cont, rc);
+	rc = dtx_end(&dth, cont_hdl, cont, rc);
 	obj_punch_complete(rpc, rc, map_version, &conflict);
 	if (cont_hdl)
 		ds_cont_hdl_put(cont_hdl);
@@ -1492,9 +1442,8 @@ out:
 }
 
 static int
-ds_obj_tgt_punch(struct dtx_handle *dth, void *arg, int idx,
-		 dtx_exec_shard_comp_cb_t comp_cb,
-		 struct dtx_exec_shard_arg *comp_arg)
+ds_obj_tgt_punch(struct dtx_leader_handle *dlh, void *arg, int idx,
+		 dtx_sub_comp_cb_t comp_cb)
 {
 	struct ds_obj_exec_arg	*exec_arg = arg;
 
@@ -1507,16 +1456,16 @@ ds_obj_tgt_punch(struct dtx_handle *dth, void *arg, int idx,
 		if (!(exec_arg->flags & ORF_RESEND)) {
 			rc = obj_local_punch(opi, opc_get(rpc->cr_opc),
 					     exec_arg->cont_hdl,
-					     exec_arg->cont, dth);
+					     exec_arg->cont, &dlh->dlh_handle);
 		}
 		if (comp_cb != NULL)
-			comp_cb(comp_arg, rc);
+			comp_cb(dlh, idx, rc);
 
 		return rc;
 	}
 
 	/* Handle the object remotely */
-	return ds_obj_remote_punch(dth, arg, idx, comp_cb, comp_arg);
+	return ds_obj_remote_punch(dlh, arg, idx, comp_cb);
 }
 
 /* Handle the punch requests on the leader */
@@ -1525,13 +1474,12 @@ ds_obj_punch_handler(crt_rpc_t *rpc)
 {
 	struct ds_cont_hdl		*cont_hdl = NULL;
 	struct ds_cont_child		*cont = NULL;
-	struct dtx_handle		*dth = NULL;
-	struct dtx_conflict_entry	 conflict = { 0 };
+	struct dtx_leader_handle	dlh = { 0 };
 	struct obj_punch_in		*opi;
 	struct ds_obj_exec_arg		exec_arg = { 0 };
-	uint32_t			 map_version = 0;
-	uint32_t			 flags = 0;
-	int				 rc;
+	uint32_t			map_version = 0;
+	uint32_t			flags = 0;
+	int				rc;
 
 	opi = crt_req_get(rpc);
 	D_ASSERT(opi != NULL);
@@ -1551,7 +1499,7 @@ ds_obj_punch_handler(crt_rpc_t *rpc)
 	if (opi->opi_shard_tgts.ca_arrays == NULL) {
 		/* local RPC handler */
 		rc = obj_local_punch(opi, opc_get(rpc->cr_opc), cont_hdl, cont,
-				     dth);
+				     NULL);
 		if (rc != 0) {
 			D_ERROR(DF_UOID": obj_local_punch failed %d.\n",
 				DP_UOID(opi->opi_oid), rc);
@@ -1587,11 +1535,11 @@ ds_obj_punch_handler(crt_rpc_t *rpc)
 	 * modification or not, so still need to dispatch
 	 * the RPC to other replicas.
 	 */
-	rc = dtx_begin(&opi->opi_dti, &opi->opi_oid, cont->sc_hdl,
-		       opi->opi_epoch, opi->opi_dkey_hash,
-		       &conflict, opi->opi_dti_cos.ca_arrays,
-		       opi->opi_dti_cos.ca_count, opi->opi_map_ver,
-		       DAOS_INTENT_PUNCH, true, &dth);
+	rc = dtx_leader_begin(&opi->opi_dti, &opi->opi_oid, cont->sc_hdl,
+			      opi->opi_epoch, opi->opi_dkey_hash,
+			      opi->opi_map_ver, DAOS_INTENT_PUNCH,
+			      opi->opi_shard_tgts.ca_arrays,
+			      opi->opi_shard_tgts.ca_count, &dlh);
 	if (rc != 0) {
 		D_ERROR(DF_UOID": Failed to start DTX for punch %d.\n",
 			DP_UOID(opi->opi_oid), rc);
@@ -1604,18 +1552,16 @@ ds_obj_punch_handler(crt_rpc_t *rpc)
 again:
 	exec_arg.flags = flags;
 	/* Execute the operation on all shards */
-	rc = dtx_exec_ops(opi->opi_shard_tgts.ca_arrays,
-			  opi->opi_shard_tgts.ca_count, dth, ds_obj_tgt_punch,
-			  &exec_arg);
+	rc = dtx_leader_exec_ops(&dlh, ds_obj_tgt_punch, &exec_arg);
 out:
 	/* Stop the distribute transaction */
-	rc = dtx_end(dth, cont_hdl, cont, rc);
+	rc = dtx_leader_end(&dlh, cont_hdl, cont, rc);
 	if (rc == -DER_AGAIN) {
 		flags |= ORF_RESEND;
 		D_GOTO(again, rc);
 	}
 
-	obj_punch_complete(rpc, rc, map_version, &conflict);
+	obj_punch_complete(rpc, rc, map_version, NULL);
 	if (cont_hdl)
 		ds_cont_hdl_put(cont_hdl);
 	if (cont)

--- a/src/object/srv_obj_remote.c
+++ b/src/object/srv_obj_remote.c
@@ -42,10 +42,10 @@
 #include "obj_internal.h"
 
 struct obj_remote_cb_arg {
-	dtx_exec_shard_comp_cb_t	comp_cb;
-	void				*cb_arg;
+	dtx_sub_comp_cb_t		comp_cb;
 	crt_rpc_t			*parent_req;
-	struct dtx_exec_shard_arg	*shard_arg;
+	struct dtx_leader_handle	*dlh;
+	int				idx;
 };
 
 static void
@@ -53,10 +53,11 @@ shard_update_req_cb(const struct crt_cb_info *cb_info)
 {
 	crt_rpc_t			*req = cb_info->cci_rpc;
 	struct obj_remote_cb_arg	*arg = cb_info->cci_arg;
-	struct dtx_exec_shard_arg	*shard_arg = arg->shard_arg;
 	crt_rpc_t			*parent_req = arg->parent_req;
 	struct obj_rw_out		*orwo = crt_reply_get(req);
 	struct obj_rw_in		*orw_parent = crt_req_get(parent_req);
+	struct dtx_leader_handle	*dlh = arg->dlh;
+	struct dtx_sub_status		*sub = &dlh->dlh_subs[arg->idx];
 	int				rc = cb_info->cci_rc;
 	int				rc1 = 0;
 
@@ -68,9 +69,9 @@ shard_update_req_cb(const struct crt_cb_info *cb_info)
 	} else {
 		rc1 = orwo->orw_ret;
 		if (rc1 == -DER_INPROGRESS) {
-			daos_dti_copy(&shard_arg->exec_dce.dce_xid,
+			daos_dti_copy(&sub->dss_dce.dce_xid,
 				      &orwo->orw_dti_conflict);
-			shard_arg->exec_dce.dce_dkey = orwo->orw_dkey_conflict;
+			sub->dss_dce.dce_dkey = orwo->orw_dkey_conflict;
 		}
 	}
 
@@ -78,7 +79,7 @@ shard_update_req_cb(const struct crt_cb_info *cb_info)
 		rc = rc1;
 
 	if (arg->comp_cb)
-		arg->comp_cb(arg->cb_arg, rc);
+		arg->comp_cb(dlh, arg->idx, rc);
 
 	crt_req_decref(parent_req);
 	D_FREE_PTR(arg);
@@ -86,25 +87,24 @@ shard_update_req_cb(const struct crt_cb_info *cb_info)
 
 /* Execute update on the remote target */
 int
-ds_obj_remote_update(struct dtx_handle *dth, void *data, int idx,
-		     dtx_exec_shard_comp_cb_t comp_cb, void *cb_arg)
+ds_obj_remote_update(struct dtx_leader_handle *dlh, void *data, int idx,
+		     dtx_sub_comp_cb_t comp_cb)
 {
 	struct ds_obj_exec_arg		*obj_exec_arg = data;
-	struct dtx_exec_arg		*arg = dth->dth_exec_arg;
 	struct daos_shard_tgt		*shard_tgt;
-	struct dtx_exec_shard_arg	*shard_arg;
 	crt_endpoint_t			 tgt_ep;
 	crt_rpc_t			*parent_req = obj_exec_arg->rpc;
 	crt_rpc_t			*req;
+	struct dtx_sub_status		*sub;
+	struct dtx_handle		*dth = &dlh->dlh_handle;
 	struct obj_remote_cb_arg	*remote_arg = NULL;
 	struct obj_rw_in		*orw;
 	struct obj_rw_in		*orw_parent;
 	int				 rc = 0;
 
-	D_ASSERT(arg != NULL);
-	D_ASSERT(idx < arg->shard_cnt);
-	shard_arg = &arg->exec_shards_args[idx];
-	shard_tgt = shard_arg->exec_shard_tgt;
+	D_ASSERT(idx < dlh->dlh_sub_cnt);
+	sub = &dlh->dlh_subs[idx];
+	shard_tgt = &sub->dss_tgt;
 	if (DAOS_FAIL_CHECK(DAOS_OBJ_TGT_IDX_CHANGE)) {
 		/* to trigger retry on all other shards */
 		if (shard_tgt->st_shard != daos_fail_value_get()) {
@@ -122,11 +122,12 @@ ds_obj_remote_update(struct dtx_handle *dth, void *data, int idx,
 	tgt_ep.ep_rank = shard_tgt->st_rank;
 	tgt_ep.ep_tag = shard_tgt->st_tgt_idx;
 
+	remote_arg->dlh = dlh;
 	remote_arg->comp_cb = comp_cb;
-	remote_arg->cb_arg = cb_arg;
-	remote_arg->shard_arg = shard_arg;
+	remote_arg->idx = idx;
 	crt_req_addref(parent_req);
 	remote_arg->parent_req = parent_req;
+
 	rc = obj_req_create(dss_get_module_info()->dmi_ctx, &tgt_ep,
 			    DAOS_OBJ_RPC_TGT_UPDATE, &req);
 	if (rc != 0) {
@@ -137,7 +138,7 @@ ds_obj_remote_update(struct dtx_handle *dth, void *data, int idx,
 	orw_parent = crt_req_get(parent_req);
 	orw = crt_req_get(req);
 	*orw = *orw_parent;
-	orw->orw_oid.id_shard = shard_arg->exec_shard_tgt->st_shard;
+	orw->orw_oid.id_shard = shard_tgt->st_shard;
 	uuid_copy(orw->orw_co_hdl, orw_parent->orw_co_hdl);
 	uuid_copy(orw->orw_co_uuid, orw_parent->orw_co_uuid);
 	orw->orw_shard_tgts.ca_count	= 0;
@@ -159,9 +160,9 @@ ds_obj_remote_update(struct dtx_handle *dth, void *data, int idx,
 
 out:
 	if (rc) {
-		shard_arg->exec_shard_rc = rc;
-		if (comp_cb != NULL)
-			comp_cb(cb_arg, rc);
+		sub->dss_result = rc;
+		if (comp_cb)
+			comp_cb(dlh, idx, rc);
 		if (remote_arg) {
 			if (remote_arg->parent_req)
 				crt_req_decref(remote_arg->parent_req);
@@ -177,9 +178,10 @@ shard_punch_req_cb(const struct crt_cb_info *cb_info)
 	crt_rpc_t			*req = cb_info->cci_rpc;
 	struct obj_remote_cb_arg	*arg = cb_info->cci_arg;
 	crt_rpc_t			*parent_req = arg->parent_req;
-	struct dtx_exec_shard_arg	*shard_arg = arg->shard_arg;
 	struct obj_punch_out		*opo = crt_reply_get(req);
 	struct obj_punch_in		*opi_parent = crt_req_get(req);
+	struct dtx_leader_handle	*dlh = arg->dlh;
+	struct dtx_sub_status		*sub = &dlh->dlh_subs[arg->idx];
 	int				rc = cb_info->cci_rc;
 	int				rc1 = 0;
 
@@ -191,9 +193,9 @@ shard_punch_req_cb(const struct crt_cb_info *cb_info)
 	} else {
 		rc1 = opo->opo_ret;
 		if (rc1 == -DER_INPROGRESS) {
-			daos_dti_copy(&shard_arg->exec_dce.dce_xid,
+			daos_dti_copy(&sub->dss_dce.dce_xid,
 				      &opo->opo_dti_conflict);
-			shard_arg->exec_dce.dce_dkey = opo->opo_dkey_conflict;
+			sub->dss_dce.dce_dkey = opo->opo_dkey_conflict;
 		}
 	}
 
@@ -201,7 +203,7 @@ shard_punch_req_cb(const struct crt_cb_info *cb_info)
 		rc = rc1;
 
 	if (arg->comp_cb)
-		arg->comp_cb(arg->cb_arg, rc);
+		arg->comp_cb(dlh, arg->idx, rc);
 
 	crt_req_decref(parent_req);
 	D_FREE_PTR(arg);
@@ -209,14 +211,14 @@ shard_punch_req_cb(const struct crt_cb_info *cb_info)
 
 /* Execute punch on the remote target */
 int
-ds_obj_remote_punch(struct dtx_handle *dth, void *data, int idx,
-		    dtx_exec_shard_comp_cb_t comp_cb, void *cb_arg)
+ds_obj_remote_punch(struct dtx_leader_handle *dlh, void *data, int idx,
+		    dtx_sub_comp_cb_t comp_cb)
 {
 	struct ds_obj_exec_arg		*obj_exec_arg = data;
-	struct dtx_exec_arg		*arg = dth->dth_exec_arg;
 	struct daos_shard_tgt		*shard_tgt;
-	struct dtx_exec_shard_arg	*shard_arg;
 	struct obj_remote_cb_arg	*remote_arg;
+	struct dtx_handle		*dth = &dlh->dlh_handle;
+	struct dtx_sub_status		*sub;
 	crt_endpoint_t			 tgt_ep;
 	crt_rpc_t			*parent_req = obj_exec_arg->rpc;
 	crt_rpc_t			*req;
@@ -225,10 +227,9 @@ ds_obj_remote_punch(struct dtx_handle *dth, void *data, int idx,
 	crt_opcode_t			opc;
 	int				rc = 0;
 
-	D_ASSERT(arg != NULL);
-	D_ASSERT(idx < arg->shard_cnt);
-	shard_arg = &arg->exec_shards_args[idx];
-	shard_tgt = shard_arg->exec_shard_tgt;
+	D_ASSERT(idx < dlh->dlh_sub_cnt);
+	sub = &dlh->dlh_subs[idx];
+	shard_tgt = &sub->dss_tgt;
 	D_ALLOC_PTR(remote_arg);
 	if (remote_arg == NULL)
 		D_GOTO(out, rc = -DER_NOMEM);
@@ -237,11 +238,12 @@ ds_obj_remote_punch(struct dtx_handle *dth, void *data, int idx,
 	tgt_ep.ep_rank = shard_tgt->st_rank;
 	tgt_ep.ep_tag = shard_tgt->st_tgt_idx;
 
+	remote_arg->dlh = dlh;
 	remote_arg->comp_cb = comp_cb;
-	remote_arg->cb_arg = cb_arg;
-	remote_arg->shard_arg = shard_arg;
+	remote_arg->idx = idx;
 	crt_req_addref(parent_req);
 	remote_arg->parent_req = parent_req;
+
 	if (opc_get(parent_req->cr_opc) == DAOS_OBJ_RPC_PUNCH)
 		opc = DAOS_OBJ_RPC_TGT_PUNCH;
 	else if (opc_get(parent_req->cr_opc) == DAOS_OBJ_RPC_TGT_PUNCH_DKEYS)
@@ -258,7 +260,7 @@ ds_obj_remote_punch(struct dtx_handle *dth, void *data, int idx,
 	opi_parent = crt_req_get(parent_req);
 	opi = crt_req_get(req);
 	*opi = *opi_parent;
-	opi->opi_oid.id_shard = shard_arg->exec_shard_tgt->st_shard;
+	opi->opi_oid.id_shard = shard_tgt->st_shard;
 	uuid_copy(opi->opi_co_hdl, opi_parent->opi_co_hdl);
 	uuid_copy(opi->opi_co_uuid, opi_parent->opi_co_uuid);
 	opi->opi_shard_tgts.ca_count = 0;
@@ -281,10 +283,9 @@ ds_obj_remote_punch(struct dtx_handle *dth, void *data, int idx,
 
 out:
 	if (rc) {
-		shard_arg->exec_shard_rc = rc;
-		rc = dss_abterr2der(rc);
+		sub->dss_result = rc;
 		if (comp_cb != NULL)
-			comp_cb(cb_arg, rc);
+			comp_cb(dlh, idx, rc);
 		if (remote_arg) {
 			if (remote_arg->parent_req)
 				crt_req_decref(remote_arg->parent_req);

--- a/src/vos/tests/vts_dtx.c
+++ b/src/vos/tests/vts_dtx.c
@@ -181,7 +181,6 @@ vts_dtx_begin(struct dtx_id *xid, daos_unit_oid_t *oid, daos_handle_t coh,
 	dth->dth_coh = coh;
 	dth->dth_epoch = epoch;
 	D_INIT_LIST_HEAD(&dth->dth_shares);
-	dth->dth_handled_time = crt_hlc_get();
 	dth->dth_dkey_hash = dkey_hash;
 	dth->dth_ver = pm_ver;
 	dth->dth_intent = intent;


### PR DESCRIPTION
1. Split dtx into leader/local dtx, so leader dtx
will take care distribute transaction, and local
dtx will take care undo log.

2. Move some dtx related stuff from object module
to dtx module.

3. Some minor fixes and cleanup.

Signed-off-by: Wang Di <di.wang@intel.com>