### PR TITLE
WIP DAOS-2578 - Query device health info using SPDK ctrl API

### DIFF
--- a/src/bio/bio_internal.h
+++ b/src/bio/bio_internal.h
@@ -65,6 +65,11 @@ struct bio_blobstore {
 	struct spdk_blob_store	*bb_bs;
 	struct bio_xs_context	*bb_ctxt;
 	int			 bb_ref;
+	/* Device owner xstream is the first xstream used to open device (for
+	 * multiple xstreams mapped to the same device). Used for faulty device
+	 * detection.
+	 */
+	int			 bb_devowner_xs_id;
 };
 
 /* Per-xstream NVMe context */
@@ -77,7 +82,8 @@ struct bio_xs_context {
 	d_list_t		 bxc_pollers;
 	struct bio_dma_buffer	*bxc_dma_buf;
 	struct spdk_bdev_desc	*bxc_desc; /* for io stat only */
-	uint64_t		 bxc_stat_age;
+	uint64_t		 bxc_io_stat_age;
+	uint64_t		 bxc_health_stat_age;
 };
 
 /* Per VOS instance I/O context */


### PR DESCRIPTION
Currently calls SPDK ctrl API to query device health information and error logs
every 60 seconds. Unlike SPDK_IO_STATS poller which is called on each xstream
to query I/O stats, SPDK health stats are only queried from the device owner xstream.
These stats are currently just diplayed to console for debug purposes but need to be
saved in in-memory device health state.
Admin/user will also eventually need to be notified (stats displayed to console) when a critical
error occurs or if any error logs appear in the logs.

TODO:
- Define in-memory structure for device health state
- Save SPDK device health information in in-memory device health state

Signed-off-by: Sydney Vanda <sydney.m.vanda@intel.com>