### PR TITLE
DAOS-2657 control: improve test coverage of client result maps

### DIFF
--- a/src/control/client/mocks.go
+++ b/src/control/client/mocks.go
@@ -36,33 +36,34 @@ import (
 )
 
 var (
-	addresses    = Addresses{"1.2.3.4:10000", "1.2.3.5:10001"}
-	features     = []*pb.Feature{common.MockFeaturePB()}
-	ctrlrs       = NvmeControllers{common.MockControllerPB("")}
-	exampleState = pb.ResponseState{
+	MockServers  = Addresses{"1.2.3.4:10000", "1.2.3.5:10001"}
+	MockFeatures = []*pb.Feature{common.MockFeaturePB()}
+	MockCtrlrs   = NvmeControllers{common.MockControllerPB("")}
+	MockState    = pb.ResponseState{
 		Status: pb.ResponseStatus_CTRL_ERR_APP,
 		Error:  "example application error",
 	}
-	ctrlrResults = NvmeControllerResults{
+	MockCtrlrResults = NvmeControllerResults{
 		&pb.NvmeControllerResult{
 			Pciaddr: "0000:81:00.0",
-			State:   &exampleState,
+			State:   &MockState,
 		},
 	}
-	modules       = ScmModules{common.MockModulePB()}
-	moduleResults = ScmModuleResults{
+	MockModules       = ScmModules{common.MockModulePB()}
+	MockModuleResults = ScmModuleResults{
 		&pb.ScmModuleResult{
 			Loc:   &pb.ScmModule_Location{},
-			State: &exampleState,
+			State: &MockState,
 		},
 	}
-	mountResults = ScmMountResults{
+	MockMounts       = ScmMounts{common.MockMountPB()}
+	MockMountResults = ScmMountResults{
 		&pb.ScmMountResult{
 			Mntpoint: "/mnt/daos",
-			State:    &exampleState,
+			State:    &MockState,
 		},
 	}
-	errExample = errors.New("unknown failure")
+	MockErr = errors.New("unknown failure")
 )
 
 type mgmtCtlListFeaturesClient struct {
@@ -233,7 +234,7 @@ func newMockMgmtCtlClient(
 	killRet error) pb.MgmtCtlClient {
 
 	return &mockMgmtCtlClient{
-		features, ctrlrs, ctrlrResults, modules, moduleResults,
+		MockFeatures, ctrlrs, ctrlrResults, modules, moduleResults,
 		mountResults, scanRet, formatRet, updateRet, burninRet, killRet,
 	}
 }
@@ -343,7 +344,7 @@ func newMockConnect(
 
 	return &connList{
 		factory: &mockControllerFactory{
-			state, features, ctrlrs, ctrlrResults, modules,
+			state, MockFeatures, ctrlrs, ctrlrResults, modules,
 			moduleResults, mountResults, scanRet, formatRet,
 			updateRet, burninRet, killRet, connectRet,
 		},
@@ -352,8 +353,8 @@ func newMockConnect(
 
 func defaultMockConnect() Connect {
 	return newMockConnect(
-		connectivity.Ready, features, ctrlrs, ctrlrResults, modules,
-		moduleResults, mountResults, nil, nil, nil, nil, nil, nil)
+		connectivity.Ready, MockFeatures, MockCtrlrs, MockCtrlrResults, MockModules,
+		MockModuleResults, MockMountResults, nil, nil, nil, nil, nil, nil)
 }
 
 // NewClientFM provides a mock ClientFeatureMap for testing.
@@ -370,6 +371,15 @@ func NewClientFM(features []*pb.Feature, addrs Addresses) ClientFeatureMap {
 	return cf
 }
 
+// NewClientNvme provides a mock ClientCtrlrMap populated with ctrlr details
+func NewClientNvme(ctrlrs NvmeControllers, addrs Addresses) ClientCtrlrMap {
+	cMap := make(ClientCtrlrMap)
+	for _, addr := range addrs {
+		cMap[addr] = CtrlrResults{Ctrlrs: ctrlrs}
+	}
+	return cMap
+}
+
 // NewClientNvmeResults provides a mock ClientCtrlrMap populated with controller
 // operation responses
 func NewClientNvmeResults(
@@ -378,15 +388,6 @@ func NewClientNvmeResults(
 	cMap := make(ClientCtrlrMap)
 	for _, addr := range addrs {
 		cMap[addr] = CtrlrResults{Responses: results}
-	}
-	return cMap
-}
-
-// NewClientNvme provides a mock ClientCtrlrMap populated with ctrlr details
-func NewClientNvme(ctrlrs NvmeControllers, addrs Addresses) ClientCtrlrMap {
-	cMap := make(ClientCtrlrMap)
-	for _, addr := range addrs {
-		cMap[addr] = CtrlrResults{Ctrlrs: ctrlrs}
 	}
 	return cMap
 }
@@ -400,26 +401,35 @@ func NewClientScm(mms ScmModules, addrs Addresses) ClientModuleMap {
 	return cMap
 }
 
-// NewClientMountResults provides a mock ClientMountMap populated with scm mount
-// operation responses
-func NewClientMountResults(
-	results []*pb.ScmMountResult, addrs Addresses) ClientMountMap {
-
-	cMap := make(ClientMountMap)
-	for _, addr := range addrs {
-		cMap[addr] = MountResults{Responses: results}
-	}
-	return cMap
-}
-
-// NewClientModuleResults provides a mock ClientModuleMap populated with scm
+// NewClientScmResults provides a mock ClientModuleMap populated with scm
 // module operation responses
-func NewClientModuleResults(
+func NewClientScmResults(
 	results []*pb.ScmModuleResult, addrs Addresses) ClientModuleMap {
 
 	cMap := make(ClientModuleMap)
 	for _, addr := range addrs {
 		cMap[addr] = ModuleResults{Responses: results}
+	}
+	return cMap
+}
+
+// NewClientScmMount provides a mock ClientMountMap populated with scm mount details
+func NewClientScmMount(mounts ScmMounts, addrs Addresses) ClientMountMap {
+	cMap := make(ClientMountMap)
+	for _, addr := range addrs {
+		cMap[addr] = MountResults{Mounts: mounts}
+	}
+	return cMap
+}
+
+// NewClientScmMountResults provides a mock ClientMountMap populated with scm mount
+// operation responses
+func NewClientScmMountResults(
+	results []*pb.ScmMountResult, addrs Addresses) ClientMountMap {
+
+	cMap := make(ClientMountMap)
+	for _, addr := range addrs {
+		cMap[addr] = MountResults{Responses: results}
 	}
 	return cMap
 }

--- a/src/control/common/test_mocks.go
+++ b/src/control/common/test_mocks.go
@@ -72,7 +72,6 @@ func NewMockControllerPB(
 	}
 }
 
-// MockModulePB is a mock protobuf Module message used in tests for
 // multiple packages.
 func MockModulePB() *pb.ScmModule {
 	return &pb.ScmModule{
@@ -85,6 +84,13 @@ func MockModulePB() *pb.ScmModule {
 			Socket:     uint32(4),
 		},
 	}
+}
+
+// MockMountPB is a mock protobuf Mount message used in tests for
+// multiple packages.
+func MockMountPB() *pb.ScmMount {
+	// MockModulePB is a mock protobuf Module message used in tests for
+	return &pb.ScmMount{Mntpoint: "/mnt/daos"}
 }
 
 // MockCheckMountOk mocks CheckMount and always returns nil error.

--- a/src/control/dmg/utils_test.go
+++ b/src/control/dmg/utils_test.go
@@ -24,7 +24,6 @@
 package main
 
 import (
-	"errors"
 	"os"
 	"testing"
 
@@ -32,14 +31,6 @@ import (
 	. "github.com/daos-stack/daos/src/control/common"
 	pb "github.com/daos-stack/daos/src/control/common/proto/mgmt"
 	"github.com/daos-stack/daos/src/control/log"
-)
-
-var (
-	addresses  = Addresses{"1.2.3.4:10000", "1.2.3.5:10001"}
-	features   = []*pb.Feature{MockFeaturePB()}
-	ctrlrs     = NvmeControllers{MockControllerPB("")}
-	modules    = ScmModules{MockModulePB()}
-	errExample = errors.New("something went wrong")
 )
 
 func init() {
@@ -60,24 +51,24 @@ func TestHasConnection(t *testing.T) {
 			"Active connections: [1.2.3.4:10000]\n",
 		},
 		{
-			ResultMap{"1.2.3.4:10000": ClientResult{"1.2.3.4:10000", nil, errExample}},
-			"failed to connect to 1.2.3.4:10000 (something went wrong)\nActive connections: []\nNo active connections!",
+			ResultMap{"1.2.3.4:10000": ClientResult{"1.2.3.4:10000", nil, MockErr}},
+			"failed to connect to 1.2.3.4:10000 (unknown failure)\nActive connections: []\nNo active connections!",
 		},
 		{
 			ResultMap{"1.2.3.4:10000": ClientResult{"1.2.3.4:10000", nil, nil}, "1.2.3.5:10001": ClientResult{"1.2.3.5:10001", nil, nil}},
 			"Active connections: [1.2.3.4:10000 1.2.3.5:10001]\n",
 		},
 		{
-			ResultMap{"1.2.3.4:10000": ClientResult{"1.2.3.4:10000", nil, errExample}, "1.2.3.5:10001": ClientResult{"1.2.3.5:10001", nil, errExample}},
-			"failed to connect to 1.2.3.4:10000 (something went wrong)\nfailed to connect to 1.2.3.5:10001 (something went wrong)\nActive connections: []\nNo active connections!",
+			ResultMap{"1.2.3.4:10000": ClientResult{"1.2.3.4:10000", nil, MockErr}, "1.2.3.5:10001": ClientResult{"1.2.3.5:10001", nil, MockErr}},
+			"failed to connect to 1.2.3.4:10000 (unknown failure)\nfailed to connect to 1.2.3.5:10001 (unknown failure)\nActive connections: []\nNo active connections!",
 		},
 		{
-			ResultMap{"1.2.3.4:10000": ClientResult{"1.2.3.4:10000", nil, errExample}, "1.2.3.5:10001": ClientResult{"1.2.3.5:10001", nil, nil}},
-			"failed to connect to 1.2.3.4:10000 (something went wrong)\nActive connections: [1.2.3.5:10001]\n",
+			ResultMap{"1.2.3.4:10000": ClientResult{"1.2.3.4:10000", nil, MockErr}, "1.2.3.5:10001": ClientResult{"1.2.3.5:10001", nil, nil}},
+			"failed to connect to 1.2.3.4:10000 (unknown failure)\nActive connections: [1.2.3.5:10001]\n",
 		},
 		{
-			ResultMap{"1.2.3.4:10000": ClientResult{"1.2.3.4:10000", nil, nil}, "1.2.3.5:10001": ClientResult{"1.2.3.5:10001", nil, errExample}},
-			"failed to connect to 1.2.3.5:10001 (something went wrong)\nActive connections: [1.2.3.4:10000]\n",
+			ResultMap{"1.2.3.4:10000": ClientResult{"1.2.3.4:10000", nil, nil}, "1.2.3.5:10001": ClientResult{"1.2.3.5:10001", nil, MockErr}},
+			"failed to connect to 1.2.3.5:10001 (unknown failure)\nActive connections: [1.2.3.4:10000]\n",
 		},
 	}
 
@@ -98,23 +89,53 @@ func TestCheckSprint(t *testing.T) {
 		out string
 	}{
 		{
-			NewClientFM(features, addresses).String(),
+			NewClientFM(MockFeatures, MockServers).String(),
 			"1.2.3.4:10000:\nburn-name: category nvme, run workloads on device to test\n\n1.2.3.5:10001:\nburn-name: category nvme, run workloads on device to test\n\n",
 		},
 		{
-			NewClientNvme(ctrlrs, addresses).String(),
+			NewClientNvme(MockCtrlrs, MockServers).String(),
 			"1.2.3.4:10000:\n\tPCI Address:0000:81:00.0 Serial:123ABC Model:ABC\n\t\tNamespace: id:12345 capacity:99999 \n\n1.2.3.5:10001:\n\tPCI Address:0000:81:00.0 Serial:123ABC Model:ABC\n\t\tNamespace: id:12345 capacity:99999 \n\n",
 		},
 		{
-			NewClientScm(modules, addresses).String(),
+			NewClientScm(MockModules, MockServers).String(),
 			"1.2.3.4:10000:\n\tphysicalid:12345 capacity:12345 loc:<channel:1 channelpos:2 memctrlr:3 socket:4 > \n\n1.2.3.5:10001:\n\tphysicalid:12345 capacity:12345 loc:<channel:1 channelpos:2 memctrlr:3 socket:4 > \n\n",
 		},
 		{
-			ResultMap{"1.2.3.4:10000": ClientResult{"1.2.3.4:10000", nil, errExample}, "1.2.3.5:10001": ClientResult{"1.2.3.5:10001", nil, errExample}}.String(),
-			"1.2.3.4:10000:\nerror: something went wrong\n1.2.3.5:10001:\nerror: something went wrong\n",
+			NewClientScmMount(MockMounts, MockServers).String(),
+			"1.2.3.4:10000:\n\tmntpoint:\"/mnt/daos\" \n\n1.2.3.5:10001:\n\tmntpoint:\"/mnt/daos\" \n\n",
 		},
 		{
-			NewClientMountResults(
+			ResultMap{"1.2.3.4:10000": ClientResult{"1.2.3.4:10000", nil, MockErr}, "1.2.3.5:10001": ClientResult{"1.2.3.5:10001", nil, MockErr}}.String(),
+			"1.2.3.4:10000:\nerror: unknown failure\n1.2.3.5:10001:\nerror: unknown failure\n",
+		},
+		{
+			NewClientNvmeResults(
+				[]*pb.NvmeControllerResult{
+					{
+						Pciaddr: "0000:81:00.0",
+						State: &pb.ResponseState{
+							Status: pb.ResponseStatus_CTRL_ERR_APP,
+							Error:  "example application error",
+						},
+					},
+				}, MockServers).String(),
+			"1.2.3.4:10000:\n\tpci-address 0000:81:00.0: status CTRL_ERR_APP error: example application error\n\n1.2.3.5:10001:\n\tpci-address 0000:81:00.0: status CTRL_ERR_APP error: example application error\n\n",
+		},
+		{
+			NewClientScmResults(
+				[]*pb.ScmModuleResult{
+					{
+						Loc: MockModulePB().Loc,
+						State: &pb.ResponseState{
+							Status: pb.ResponseStatus_CTRL_ERR_APP,
+							Error:  "example application error",
+						},
+					},
+				}, MockServers).String(),
+			"1.2.3.4:10000:\n\tmodule location channel:1 channelpos:2 memctrlr:3 socket:4 : status CTRL_ERR_APP error: example application error\n\n1.2.3.5:10001:\n\tmodule location channel:1 channelpos:2 memctrlr:3 socket:4 : status CTRL_ERR_APP error: example application error\n\n",
+		},
+		{
+			NewClientScmMountResults(
 				[]*pb.ScmMountResult{
 					{
 						Mntpoint: "/mnt/daos",
@@ -123,10 +144,9 @@ func TestCheckSprint(t *testing.T) {
 							Error:  "example application error",
 						},
 					},
-				}, addresses).String(),
+				}, MockServers).String(),
 			"1.2.3.4:10000:\n\tmntpoint /mnt/daos: status CTRL_ERR_APP error: example application error\n\n1.2.3.5:10001:\n\tmntpoint /mnt/daos: status CTRL_ERR_APP error: example application error\n\n",
 		},
-		// TODO: add test cases for feature/mount, ctrlr/module results
 	}
 	for _, tt := range shelltests {
 		AssertEqual(t, tt.m, tt.out, "bad output")


### PR DESCRIPTION
Consolidate mock definitions and make naming consistent, improve
dmg/client test coverage of displaying different result types from
multiple clients.

Signed-off-by: Tom Nabarro <tom.nabarro@intel.com>