### PR TITLE
DAOS-1213 control: remove format_override config references

### DIFF
--- a/src/control/server/README.md
+++ b/src/control/server/README.md
@@ -233,7 +233,7 @@ TODO: return details of AppDirect memory regions
 
 Format can be [triggered](../dmg/README.md#subcommands) through the management tool at DAOS system installation time, formatting and mounting of SCM device namespace is performed as specified in config file parameters prefixed with `scm_`.
 
-SCM device format is expected only to be performed when installing DAOS system for the first time and requires `daos_server` to be started by rot user.
+SCM device format is expected only to be performed when installing DAOS system for the first time and requires `daos_server` to be started by root user.
 
 If `daos_server` is run by root user, data plane will be started automatically ONLY if the DAOS superblock exists within the specified `scm_mount`.
 Otherwise, the control plane will wait until an administrator calls "[storage format](../dmg/README.md#subcommands)" over the client API from the management tool.

--- a/src/control/server/README.md
+++ b/src/control/server/README.md
@@ -233,16 +233,19 @@ TODO: return details of AppDirect memory regions
 
 Format can be [triggered](../dmg/README.md#subcommands) through the management tool at DAOS system installation time, formatting and mounting of SCM device namespace is performed as specified in config file parameters prefixed with `scm_`.
 
-SCM device format is expected only to be performed when installing DAOS system for the first time.
+SCM device format is expected only to be performed when installing DAOS system for the first time and requires `daos_server` to be started by rot user.
 
-##### `format_override` == true
+If `daos_server` is run by root user, data plane will be started automatically ONLY if the DAOS superblock exists within the specified `scm_mount`.
+Otherwise, the control plane will wait until an administrator calls "[storage format](../dmg/README.md#subcommands)" over the client API from the management tool.
+If `storage format` call is successful, control plane will continue to start data plane instances when SCM and NVMe have been formatted, SCM mounted and superblock and nvme.conf successfully written to SCM mount.
 
-If `format_override` IS SET to `true` in config file, control plane will attempt to use whatever is mounted at `scm_mount` location specified in config file and start data plane instances regardless of whether the server has been formatted.
+If `daos_server` is run by a normal (non-root) user, the data plane will be started automatically if the DAOS superblock exists within the specified `scm_mount`.
 If `scm_mount` IS NOT mounted, control plane will fail to start data plane.
 If `scm_mount` IS mounted but no superblock exists, control plane will attempt to create superblock and start data plane.
 
+
 <details>
-<summary>Example output from invoking `daos_server` on single host with `format_override` TRUE when `scm_mount` IS NOT mounted</summary>
+<summary>Example output from invoking `daos_server` on single host when run as a normal user and `scm_mount` IS NOT mounted</summary>
 <p>
 
 ```bash
@@ -274,7 +277,7 @@ wolf-72.wolf.hpdd.intel.com 2019/04/10 04:04:09 main.go:129: error: Failed to fo
 </p>
 
 <details>
-<summary>Example output from invoking `daos_server` on single host with `format_override` TRUE when `scm_mount` IS mounted</summary>
+<summary>Example output from invoking `daos_server` on single host run as a normal user and `scm_mount` IS mounted</summary>
 <p>
 
 ```bash
@@ -307,15 +310,8 @@ DAOS I/O server (v0.4.0) process 135939 started on rank 0 (out of 1) with 1 targ
 </details>
 </p>
 
-##### `format_override` == false
-
-If `format_override` IS SET to `false` in config file, control plane will attempt to start the data plane instances ONLY if the DAOS superblock exists within the specified `scm_mount`.
-Otherwise, the control plane will wait until an administrator calls "[storage format](../dmg/README.md#subcommands)" over the client API from the management tool.
-If `storage format` call is successful, control plane will continue to start data plane instances when SCM and NVMe have been formatted, SCM mounted and superblock and nvme.conf successfully written to SCM mount.
-If a superblock exists in `scm_mount`, and the location is mounted, the control plane will fail (so as to not inadvertently wipe a useful SCM location).
-
 <details>
-<summary>Example output from invoking `daos_server` on single host with `format_override` FALSE when superblock already exists</summary>
+<summary>Example output from invoking `daos_server` on single host when run as root user when superblock already exists</summary>
 <p>
 
 ```bash
@@ -345,7 +341,7 @@ DAOS I/O server (v0.4.0) process 135671 started on rank 0 (out of 1) with 1 targ
 </details>
 
 <details>
-<summary>Example output from invoking `daos_server` on single host with `format_override` FALSE when `scm_mount` location is not mounted</summary>
+<summary>Example output from invoking `daos_server` on single host when run as root and `scm_mount` location is not mounted</summary>
 <p>
 
 ```bash

--- a/utils/config/daos_server.yml
+++ b/utils/config/daos_server.yml
@@ -166,14 +166,6 @@
 #control_log_file: /tmp/daos_control.log
 #
 #
-## Format override when true will continue to format and start data plane
-## without waiting for client API storage format call (which formats
-## NVMe and SCM storage devices.
-#
-## default: true
-#format_override: false
-#
-#
 ## Username used to lookup user uid/gid to drop privileges to if started
 ## as root. After control plane start-up and configuration, before starting
 ## data plane, process ownership will be dropped to those of supplied user.


### PR DESCRIPTION
Update readme to reflect format_override server config option is no
longer supported.

Signed-off-by: Tom Nabarro <tom.nabarro@intel.com>