### PR TITLE
DAOS-2667 bio: preparatory work for dev state transition

### DIFF
--- a/src/bio/bio_buffer.c
+++ b/src/bio/bio_buffer.c
@@ -662,18 +662,27 @@ dma_rw(struct bio_desc *biod, bool prep)
 	xs_ctxt = biod->bd_ctxt->bic_xs_ctxt;
 	blob = biod->bd_ctxt->bic_blob;
 	channel = xs_ctxt->bxc_io_channel;
-	D_ASSERT(blob != NULL && channel != NULL);
+
+	biod->bd_inflights = 0;
+	biod->bd_dma_issued = 0;
+	biod->bd_result = 0;
 
 	/* Bypass NVMe I/O, used by daos_perf for performance evaluation */
 	if (daos_io_bypass & IOBP_NVME)
 		return;
 
+	if (!is_blob_valid(biod->bd_ctxt)) {
+		D_ERROR("Blobstore is invalid. blob:%p, closing:%d\n",
+			blob, biod->bd_ctxt->bic_closing);
+		biod->bd_result = -DER_NO_HDL;
+		return;
+	}
+
+	D_ASSERT(channel != NULL);
+	biod->bd_ctxt->bic_inflight_dmas++;
+
 	D_DEBUG(DB_IO, "DMA start, blob:%p, update:%d, rmw:%d\n",
 		blob, biod->bd_update, rmw_read);
-
-	biod->bd_inflights = 0;
-	biod->bd_dma_issued = 0;
-	biod->bd_result = 0;
 
 	for (i = 0; i < rsrvd_dma->brd_rg_cnt; i++) {
 		rg = &rsrvd_dma->brd_regions[i];
@@ -750,6 +759,7 @@ dma_rw(struct bio_desc *biod, bool prep)
 		ABT_mutex_unlock(biod->bd_mutex);
 	}
 
+	biod->bd_ctxt->bic_inflight_dmas--;
 	D_DEBUG(DB_IO, "DMA done, blob:%p, update:%d, rmw:%d\n",
 		blob, biod->bd_update, rmw_read);
 }
@@ -965,4 +975,134 @@ bio_iod_copy(struct bio_desc *biod, d_sg_list_t *sgls, unsigned int nr_sgl)
 	arg.ca_sgl_cnt = nr_sgl;
 
 	return iterate_biov(biod, copy_one, &arg);
+}
+
+static int
+bio_rwv(struct bio_io_context *ioctxt, struct bio_sglist *bsgl_in,
+	d_sg_list_t *sgl, bool update)
+{
+	struct bio_sglist	*bsgl;
+	struct bio_desc		*biod;
+	int			 i, rc;
+
+	/* allocate blob I/O descriptor */
+	biod = bio_iod_alloc(ioctxt, 1 /* single bsgl */, update);
+	if (biod == NULL)
+		return -DER_NOMEM;
+
+	/*
+	 * copy the passed in @bsgl_in to the bsgl attached on bio_desc,
+	 * since we don't want following bio ops change caller's bsgl.
+	 */
+	bsgl = bio_iod_sgl(biod, 0);
+
+	rc = bio_sgl_init(bsgl, bsgl_in->bs_nr);
+	if (rc)
+		goto out;
+
+	for (i = 0; i < bsgl->bs_nr; i++) {
+		D_ASSERT(bsgl_in->bs_iovs[i].bi_buf == NULL);
+		D_ASSERT(bsgl_in->bs_iovs[i].bi_data_len != 0);
+		bsgl->bs_iovs[i] = bsgl_in->bs_iovs[i];
+	}
+	bsgl->bs_nr_out = bsgl->bs_nr;
+
+	/* map the biov to DMA safe buffer, fill DMA buffer if read operation */
+	rc = bio_iod_prep(biod);
+	if (rc)
+		goto out;
+
+	for (i = 0; i < bsgl->bs_nr; i++)
+		D_ASSERT(bsgl->bs_iovs[i].bi_buf != NULL);
+
+	rc = bio_iod_copy(biod, sgl, 1 /* single sgl */);
+	if (rc)
+		D_ERROR("Copy biod failed, rc:%d\n", rc);
+
+	/* release DMA buffer, write data back to NVMe device for write */
+	rc = bio_iod_post(biod);
+
+out:
+	bio_iod_free(biod); /* also calls bio_sgl_fini */
+
+	return rc;
+}
+
+int
+bio_readv(struct bio_io_context *ioctxt, struct bio_sglist *bsgl,
+	  d_sg_list_t *sgl)
+{
+	int	rc;
+
+	rc = bio_rwv(ioctxt, bsgl, sgl, false);
+	if (rc)
+		D_ERROR("Readv to blob:%p failed for xs:%p, rc:%d\n",
+			ioctxt->bic_blob, ioctxt->bic_xs_ctxt, rc);
+	else
+		D_DEBUG(DB_IO, "Readv to blob %p for xs:%p successfully\n",
+			ioctxt->bic_blob, ioctxt->bic_xs_ctxt);
+
+	return rc;
+}
+
+int
+bio_writev(struct bio_io_context *ioctxt, struct bio_sglist *bsgl,
+	   d_sg_list_t *sgl)
+{
+	int	rc;
+
+	rc = bio_rwv(ioctxt, bsgl, sgl, true);
+	if (rc)
+		D_ERROR("Writev to blob:%p failed for xs:%p, rc:%d\n",
+			ioctxt->bic_blob, ioctxt->bic_xs_ctxt, rc);
+	else
+		D_DEBUG(DB_IO, "Writev to blob %p for xs:%p successfully\n",
+			ioctxt->bic_blob, ioctxt->bic_xs_ctxt);
+
+	return rc;
+}
+
+static int
+bio_rw(struct bio_io_context *ioctxt, bio_addr_t addr, d_iov_t *iov,
+	bool update)
+{
+	struct bio_sglist	bsgl;
+	struct bio_iov		biov;
+	d_sg_list_t		sgl;
+	int			rc;
+
+	biov.bi_buf = NULL;
+	biov.bi_addr = addr;
+	biov.bi_data_len = iov->iov_len;
+	bsgl.bs_iovs = &biov;
+	bsgl.bs_nr = bsgl.bs_nr_out = 1;
+
+	sgl.sg_iovs = iov;
+	sgl.sg_nr = 1;
+	sgl.sg_nr_out = 0;
+
+	rc = bio_rwv(ioctxt, &bsgl, &sgl, update);
+	if (rc)
+		D_ERROR("%s to blob:%p failed for xs:%p, rc:%d\n",
+			update ? "Write" : "Read", ioctxt->bic_blob,
+			ioctxt->bic_xs_ctxt, rc);
+	else
+		D_DEBUG(DB_IO, "%s to blob %p for xs:%p successfully\n",
+			update ? "Write" : "Read", ioctxt->bic_blob,
+			ioctxt->bic_xs_ctxt);
+
+	return rc;
+}
+
+int
+bio_read(struct bio_io_context *ioctxt, bio_addr_t addr, d_iov_t *iov)
+{
+	return bio_rw(ioctxt, addr, iov, false);
+}
+
+
+int
+bio_write(struct bio_io_context *ioctxt, bio_addr_t addr, d_iov_t *iov)
+{
+	return bio_rw(ioctxt, addr, iov, true);
 }

--- a/src/bio/bio_context.c
+++ b/src/bio/bio_context.c
@@ -42,6 +42,15 @@ struct blob_cp_arg {
 	int			 bca_rc;
 };
 
+struct blob_msg_arg {
+	struct spdk_blob_opts	 bma_opts;
+	struct spdk_blob_store	*bma_bs;
+	struct bio_io_context	*bma_ioc;
+	spdk_blob_id		 bma_blob_id;
+	struct blob_cp_arg	 bma_cp_arg;
+	bool			 bma_async;
+};
+
 static int
 blob_cp_arg_init(struct blob_cp_arg *ba)
 {
@@ -67,6 +76,32 @@ blob_cp_arg_fini(struct blob_cp_arg *ba)
 }
 
 static void
+free_blob_msg_arg(struct blob_msg_arg *bma)
+{
+	blob_cp_arg_fini(&bma->bma_cp_arg);
+	D_FREE(bma);
+}
+
+static struct blob_msg_arg *
+alloc_blob_msg_arg()
+{
+	struct blob_msg_arg	*bma;
+	int			 rc;
+
+	D_ALLOC_PTR(bma);
+	if (bma == NULL)
+		return NULL;
+
+	rc = blob_cp_arg_init(&bma->bma_cp_arg);
+	if (rc) {
+		D_FREE(bma);
+		return NULL;
+	}
+
+	return bma;
+}
+
+static void
 blob_common_cb(struct blob_cp_arg *ba, int rc)
 {
 	ABT_mutex_lock(ba->bca_mutex);
@@ -80,28 +115,72 @@ blob_common_cb(struct blob_cp_arg *ba, int rc)
 	ABT_mutex_unlock(ba->bca_mutex);
 }
 
+/*
+ * The blobstore MD operations such as blob open/close/create/delete are
+ * always issued by device owner xstream. When a device is shared by multiple
+ * xtreams, the non-owner xstream will have to send the MD operations to the
+ * owner xstream by spdk_thread_send_msg().
+ *
+ * The completion callback is called on owner xstream.
+ */
 static void
 blob_create_cb(void *arg, spdk_blob_id blob_id, int rc)
 {
-	struct blob_cp_arg	*ba = arg;
+	struct blob_msg_arg	*bma = arg;
+	struct blob_cp_arg	*ba = &bma->bma_cp_arg;
 
 	ba->bca_id = blob_id;
 	blob_common_cb(ba, rc);
 }
 
+/*
+ * Async open/close happens only when the blobs are being setup or torn down
+ * on device replaced/faulty event. In this stage, the bio_io_context is
+ * guaranteed to be accessed by device owner xstream exclusively, so it's ok
+ * to change the io context without locking in async mode.
+ */
 static void
 blob_open_cb(void *arg, struct spdk_blob *blob, int rc)
 {
-	struct blob_cp_arg	*ba = arg;
+	struct blob_msg_arg	*bma = arg;
+	struct blob_cp_arg	*ba = &bma->bma_cp_arg;
 
 	ba->bca_blob = blob;
 	blob_common_cb(ba, rc);
+
+	if (bma->bma_async) {
+		struct bio_io_context	*ioc = bma->bma_ioc;
+
+		ioc->bic_opening = 0;
+		if (rc == 0)
+			ioc->bic_blob = blob;
+		free_blob_msg_arg(bma);
+	}
+}
+
+static void
+blob_close_cb(void *arg, int rc)
+{
+	struct blob_msg_arg	*bma = arg;
+	struct blob_cp_arg	*ba = &bma->bma_cp_arg;
+
+	blob_common_cb(ba, rc);
+
+	if (bma->bma_async) {
+		struct bio_io_context	*ioc = bma->bma_ioc;
+
+		ioc->bic_closing = 0;
+		if (rc == 0)
+			ioc->bic_blob = NULL;
+		free_blob_msg_arg(bma);
+	}
 }
 
 static void
 blob_cb(void *arg, int rc)
 {
-	struct blob_cp_arg	*ba = arg;
+	struct blob_msg_arg	*bma = arg;
+	struct blob_cp_arg	*ba = &bma->bma_cp_arg;
 
 	blob_common_cb(ba, rc);
 }
@@ -121,21 +200,13 @@ blob_wait_completion(struct bio_xs_context *xs_ctxt, struct blob_cp_arg *ba)
 	}
 }
 
-struct blob_msg_arg {
-	struct spdk_blob_opts	 bma_opts;
-	struct spdk_blob_store	*bma_bs;
-	struct spdk_blob	*bma_blob;
-	spdk_blob_id		 bma_blob_id;
-	void			*bma_cp_arg;
-};
-
 static void
 blob_msg_create(void *msg_arg)
 {
 	struct blob_msg_arg *arg = msg_arg;
 
 	spdk_bs_create_blob_ext(arg->bma_bs, &arg->bma_opts, blob_create_cb,
-				arg->bma_cp_arg);
+				msg_arg);
 }
 
 static void
@@ -143,8 +214,7 @@ blob_msg_delete(void *msg_arg)
 {
 	struct blob_msg_arg *arg = msg_arg;
 
-	spdk_bs_delete_blob(arg->bma_bs, arg->bma_blob_id, blob_cb,
-			    arg->bma_cp_arg);
+	spdk_bs_delete_blob(arg->bma_bs, arg->bma_blob_id, blob_cb, msg_arg);
 }
 
 static void
@@ -152,23 +222,135 @@ blob_msg_open(void *msg_arg)
 {
 	struct blob_msg_arg *arg = msg_arg;
 
-	spdk_bs_open_blob(arg->bma_bs, arg->bma_blob_id, blob_open_cb,
-			  arg->bma_cp_arg);
+	spdk_bs_open_blob(arg->bma_bs, arg->bma_blob_id, blob_open_cb, msg_arg);
 }
 
 static void
 blob_msg_close(void *msg_arg)
 {
-	struct blob_msg_arg *arg = msg_arg;
+	struct blob_msg_arg	*arg = msg_arg;
+	struct spdk_blob	*blob = arg->bma_ioc->bic_blob;
 
-	spdk_blob_close(arg->bma_blob, blob_cb, arg->bma_cp_arg);
+	spdk_blob_close(blob, blob_close_cb, msg_arg);
+}
+
+static void
+bio_bs_unhold(struct bio_blobstore *bbs)
+{
+	D_ASSERT(bbs != NULL);
+	ABT_mutex_lock(bbs->bb_mutex);
+	D_ASSERT(bbs->bb_holdings > 0);
+	bbs->bb_holdings--;
+	ABT_mutex_unlock(bbs->bb_mutex);
+}
+
+static int
+bio_bs_hold(struct bio_blobstore *bbs)
+{
+	int rc = 0;
+
+	D_ASSERT(bbs != NULL);
+	ABT_mutex_lock(bbs->bb_mutex);
+	if (bbs->bb_bs == NULL) {
+		D_ERROR("Blobstore %p is closed, fail request.\n", bbs);
+		rc = -DER_NO_HDL;
+		goto out;
+	}
+
+	if (bbs->bb_state == BIO_BS_STATE_TEARDOWN ||
+	    bbs->bb_state == BIO_BS_STATE_OUT) {
+		D_ERROR("Blobstore %p is in %d state, reject request.\n",
+			bbs, bbs->bb_state);
+		rc = -DER_STALE;
+		goto out;
+	}
+
+	/*
+	 * Hold the blobstore, and the blobs teardown on faulty reaction taken
+	 * by device owner xstream will be deferred until the blobstore is
+	 * unheld. That ensures owner xstream's exclusive access to the io
+	 * context when tearing down blobs.
+	 */
+	bbs->bb_holdings++;
+out:
+	ABT_mutex_unlock(bbs->bb_mutex);
+	return rc;
+}
+
+int
+bio_blob_delete(uuid_t uuid, struct bio_xs_context *xs_ctxt)
+{
+	struct blob_msg_arg		 bma = { 0 };
+	struct blob_cp_arg		*ba = &bma.bma_cp_arg;
+	struct bio_blobstore		*bbs;
+	struct smd_nvme_pool_info	 smd_pool;
+	spdk_blob_id			 blob_id;
+	int				 rc;
+
+	D_ASSERT(xs_ctxt != NULL);
+	/**
+	 * Query per-server metadata to get blobID for this pool:xstream
+	 */
+	rc = smd_nvme_get_pool(uuid, xs_ctxt->bxc_xs_id, &smd_pool);
+	if (rc != 0) {
+		D_WARN("Blob for xs:%p, pool:"DF_UUID" doesn't exist\n",
+		       xs_ctxt, DP_UUID(uuid));
+		/*
+		 * User may create a pool w/o NVMe partition even with NVMe
+		 * configured.
+		 *
+		 * TODO: Let's simply return success for this moment, the
+		 * pool create & destroy code needs be re-organized later to
+		 * handle various middle failure cases, then we should
+		 * improve this by checking the 'pd_nvme_sz' and avoid
+		 * calling into this function when 'pd_nvme_sz' == 0.
+		 */
+		return 0;
+	}
+	blob_id = smd_pool.npi_blob_id;
+
+	rc = blob_cp_arg_init(ba);
+	if (rc != 0)
+		return rc;
+
+	bbs = xs_ctxt->bxc_blobstore;
+	rc = bio_bs_hold(bbs);
+	if (rc) {
+		blob_cp_arg_fini(ba);
+		return rc;
+	}
+
+	D_DEBUG(DB_MGMT, "Deleting blobID "DF_U64" for pool:"DF_UUID" xs:%p\n",
+		blob_id, DP_UUID(uuid), xs_ctxt);
+
+	ba->bca_inflights = 1;
+	bma.bma_bs = bbs->bb_bs;
+	bma.bma_blob_id = blob_id;
+	spdk_thread_send_msg(owner_thread(bbs), blob_msg_delete, &bma);
+
+	/* Wait for blob delete done */
+	blob_wait_completion(xs_ctxt, ba);
+	rc = ba->bca_rc;
+
+	if (rc != 0)
+		D_ERROR("Delete blobID "DF_U64" failed for pool:"DF_UUID" "
+			"xs:%p rc:%d\n",
+			blob_id, DP_UUID(uuid), xs_ctxt, rc);
+	else
+		D_DEBUG(DB_MGMT, "Successfully deleted blobID "DF_U64" for "
+			"pool:"DF_UUID" xs:%p\n",
+			blob_id, DP_UUID(uuid), xs_ctxt);
+
+	bio_bs_unhold(bbs);
+	blob_cp_arg_fini(ba);
+	return rc;
 }
 
 int
 bio_blob_create(uuid_t uuid, struct bio_xs_context *xs_ctxt, uint64_t blob_sz)
 {
 	struct blob_msg_arg		 bma = { 0 };
-	struct blob_cp_arg		 ba = { 0 };
+	struct blob_cp_arg		*ba = &bma.bma_cp_arg;
 	struct bio_blobstore		*bbs;
 	struct smd_nvme_pool_info	 smd_pool;
 	uint64_t			 cluster_sz;
@@ -176,12 +358,8 @@ bio_blob_create(uuid_t uuid, struct bio_xs_context *xs_ctxt, uint64_t blob_sz)
 
 	D_ASSERT(xs_ctxt != NULL);
 	bbs = xs_ctxt->bxc_blobstore;
-	D_ASSERT(bbs != NULL);
-
-	ABT_mutex_lock(bbs->bb_mutex);
 	cluster_sz = bbs->bb_bs != NULL ?
 		spdk_bs_get_cluster_size(bbs->bb_bs) : 0;
-	ABT_mutex_unlock(bbs->bb_mutex);
 
 	if (cluster_sz == 0) {
 		D_ERROR("Blobstore is already closed?\n");
@@ -209,39 +387,36 @@ bio_blob_create(uuid_t uuid, struct bio_xs_context *xs_ctxt, uint64_t blob_sz)
 		return -DER_EXIST;
 	}
 
-	rc = blob_cp_arg_init(&ba);
+	rc = blob_cp_arg_init(ba);
 	if (rc != 0)
 		return rc;
 
-	ba.bca_inflights = 1;
-	ABT_mutex_lock(bbs->bb_mutex);
-	if (bbs->bb_bs != NULL) {
-		bma.bma_bs = bbs->bb_bs;
-		bma.bma_cp_arg = &ba;
-
-		spdk_thread_send_msg(bbs->bb_ctxt->bxc_thread,
-				     blob_msg_create, &bma);
-	} else {
-		blob_create_cb(&ba, 0, -DER_NO_HDL);
+	rc = bio_bs_hold(bbs);
+	if (rc) {
+		blob_cp_arg_fini(ba);
+		return rc;
 	}
-	ABT_mutex_unlock(bbs->bb_mutex);
+
+	ba->bca_inflights = 1;
+	bma.bma_bs = bbs->bb_bs;
+	spdk_thread_send_msg(owner_thread(bbs), blob_msg_create, &bma);
 
 	/* Wait for blob creation done */
-	blob_wait_completion(xs_ctxt, &ba);
-	rc = ba.bca_rc;
+	blob_wait_completion(xs_ctxt, ba);
+	rc = ba->bca_rc;
 
 	if (rc != 0) {
 		D_ERROR("Create blob failed for xs:%p pool:"DF_UUID" rc:%d\n",
-			xs_ctxt, DP_UUID(uuid), ba.bca_rc);
+			xs_ctxt, DP_UUID(uuid), rc);
 	} else {
-		D_ASSERT(ba.bca_id != 0);
+		D_ASSERT(ba->bca_id != 0);
 		D_DEBUG(DB_MGMT, "Successfully created blobID "DF_U64" for xs:"
 			"%p pool:"DF_UUID" blob size:"DF_U64" clusters\n",
-			ba.bca_id, xs_ctxt, DP_UUID(uuid),
+			ba->bca_id, xs_ctxt, DP_UUID(uuid),
 			bma.bma_opts.num_clusters);
 
 		/* Update per-server metadata */
-		smd_nvme_set_pool_info(uuid, xs_ctxt->bxc_xs_id, ba.bca_id,
+		smd_nvme_set_pool_info(uuid, xs_ctxt->bxc_xs_id, ba->bca_id,
 				       &smd_pool);
 		rc = smd_nvme_add_pool(&smd_pool);
 		if (rc != 0) {
@@ -250,16 +425,88 @@ bio_blob_create(uuid_t uuid, struct bio_xs_context *xs_ctxt, uint64_t blob_sz)
 			if (bio_blob_delete(uuid, xs_ctxt))
 				D_ERROR("Unable to delete newly created blobID "
 					""DF_U64" for xs:%p pool:"DF_UUID"\n",
-					ba.bca_id, xs_ctxt, DP_UUID(uuid));
+					ba->bca_id, xs_ctxt, DP_UUID(uuid));
 		} else {
 			D_DEBUG(DB_MGMT, "Successfully added entry to SMD pool "
 				"table, pool:"DF_UUID", xs_id:%d, "
 				"blobID:"DF_U64"\n", DP_UUID(uuid),
-				xs_ctxt->bxc_xs_id, ba.bca_id);
+				xs_ctxt->bxc_xs_id, ba->bca_id);
 		}
 	}
 
-	blob_cp_arg_fini(&ba);
+	bio_bs_unhold(bbs);
+	blob_cp_arg_fini(ba);
+	return rc;
+}
+
+static int
+bio_blob_open(struct bio_io_context *ctxt, uuid_t uuid, bool async)
+{
+	struct bio_xs_context		*xs_ctxt = ctxt->bic_xs_ctxt;
+	struct smd_nvme_pool_info	 smd_pool;
+	spdk_blob_id			 blob_id;
+	struct blob_msg_arg		*bma;
+	struct blob_cp_arg		*ba;
+	struct bio_blobstore		*bbs;
+	int				 rc;
+
+	if (ctxt->bic_blob != NULL) {
+		D_ERROR("Blob %p is already opened\n", ctxt->bic_blob);
+		return -DER_ALREADY;
+	} else if (ctxt->bic_opening) {
+		D_ERROR("Blob is in opening\n");
+		return -DER_AGAIN;
+	}
+	D_ASSERT(!ctxt->bic_closing);
+
+	D_ASSERT(xs_ctxt != NULL);
+	bbs = ctxt->bic_xs_ctxt->bxc_blobstore;
+	/*
+	 * Query per-server metadata to get blobID for this pool:xstream.
+	 */
+	rc = smd_nvme_get_pool(uuid, xs_ctxt->bxc_xs_id, &smd_pool);
+	if (rc != 0) {
+		D_ERROR("Failed to find blobID for xs:%p, pool:"DF_UUID"\n",
+			xs_ctxt, DP_UUID(uuid));
+		return -DER_NONEXIST;
+	}
+	blob_id = smd_pool.npi_blob_id;
+
+	bma = alloc_blob_msg_arg();
+	if (bma == NULL)
+		return -DER_NOMEM;
+	ba = &bma->bma_cp_arg;
+
+	D_DEBUG(DB_MGMT, "Opening blobID "DF_U64" for xs:%p pool:"DF_UUID"\n",
+		blob_id, xs_ctxt, DP_UUID(uuid));
+
+	ctxt->bic_opening = 1;
+	ba->bca_inflights = 1;
+	bma->bma_bs = bbs->bb_bs;
+	bma->bma_blob_id = blob_id;
+	bma->bma_async = async;
+	spdk_thread_send_msg(owner_thread(bbs), blob_msg_open, bma);
+
+	if (async)
+		return 0;
+
+	/* Wait for blob open done */
+	blob_wait_completion(xs_ctxt, ba);
+	rc = ba->bca_rc;
+	ctxt->bic_opening = 0;
+
+	if (rc != 0) {
+		D_ERROR("Open blobID "DF_U64" failed for xs:%p pool:"DF_UUID" "
+			"rc:%d\n", blob_id, xs_ctxt, DP_UUID(uuid), rc);
+	} else {
+		D_ASSERT(ba->bca_blob != NULL);
+		D_DEBUG(DB_MGMT, "Successfully opened blobID "DF_U64" for xs:%p"
+			" pool:"DF_UUID" blob:%p\n", blob_id, xs_ctxt,
+			DP_UUID(uuid), ba->bca_blob);
+		ctxt->bic_blob = ba->bca_blob;
+	}
+
+	free_blob_msg_arg(bma);
 	return rc;
 }
 
@@ -267,21 +514,16 @@ int
 bio_ioctxt_open(struct bio_io_context **pctxt, struct bio_xs_context *xs_ctxt,
 		struct umem_instance *umem, uuid_t uuid)
 {
-	struct bio_io_context		*ctxt;
-	struct blob_msg_arg		 bma = { 0 };
-	struct blob_cp_arg		 ba = { 0 };
-	struct bio_blobstore		*bbs;
-	struct smd_nvme_pool_info	 smd_pool;
-	spdk_blob_id			 blob_id;
-	int				 rc;
+	struct bio_io_context	*ctxt;
+	int			 rc;
 
 	D_ALLOC_PTR(ctxt);
 	if (ctxt == NULL)
 		return -DER_NOMEM;
 
+	D_INIT_LIST_HEAD(&ctxt->bic_link);
 	ctxt->bic_umem = umem;
 	ctxt->bic_pmempool_uuid = umem_get_uuid(umem);
-	ctxt->bic_blob = NULL;
 	ctxt->bic_xs_ctxt = xs_ctxt;
 
 	/* NVMe isn't configured */
@@ -290,321 +532,177 @@ bio_ioctxt_open(struct bio_io_context **pctxt, struct bio_xs_context *xs_ctxt,
 		return 0;
 	}
 
-	/*
-	 * Query per-server metadata to get blobID for this pool:xstream.
-	 */
-	rc = smd_nvme_get_pool(uuid, xs_ctxt->bxc_xs_id, &smd_pool);
-	if (rc != 0) {
-		D_ERROR("Failed to find blobID for xs:%p, pool:"DF_UUID"\n",
-			xs_ctxt, DP_UUID(uuid));
-		D_GOTO(out, rc = -DER_NONEXIST);
+	rc = bio_bs_hold(xs_ctxt->bxc_blobstore);
+	if (rc) {
+		D_FREE(ctxt);
+		return rc;
 	}
 
-	blob_id = smd_pool.npi_blob_id;
-
-	rc = blob_cp_arg_init(&ba);
-	if (rc != 0)
-		goto out;
-
-	D_DEBUG(DB_MGMT, "Opening blobID "DF_U64" for xs:%p pool:"DF_UUID"\n",
-		blob_id, xs_ctxt, DP_UUID(uuid));
-
-	bbs = xs_ctxt->bxc_blobstore;
-	D_ASSERT(bbs != NULL);
-
-	ba.bca_inflights = 1;
-	ABT_mutex_lock(bbs->bb_mutex);
-	if (bbs->bb_bs != NULL) {
-		bma.bma_bs = bbs->bb_bs;
-		bma.bma_blob_id = blob_id;
-		bma.bma_cp_arg = &ba;
-
-		spdk_thread_send_msg(bbs->bb_ctxt->bxc_thread,
-				     blob_msg_open, &bma);
+	rc = bio_blob_open(ctxt, uuid, false);
+	if (rc) {
+		D_FREE(ctxt);
 	} else {
-		blob_open_cb(&ba, NULL, -DER_NO_HDL);
-	}
-	ABT_mutex_unlock(bbs->bb_mutex);
-
-	/* Wait for blob open done */
-	blob_wait_completion(xs_ctxt, &ba);
-	rc = ba.bca_rc;
-
-	if (rc != 0) {
-		D_ERROR("Open blobID "DF_U64" failed for xs:%p pool:"DF_UUID" "
-			"rc:%d\n", blob_id, xs_ctxt, DP_UUID(uuid), rc);
-	} else {
-		D_ASSERT(ba.bca_blob != NULL);
-		D_DEBUG(DB_MGMT, "Successfully opened blobID "DF_U64" for xs:%p"
-			" pool:"DF_UUID" blob:%p\n", blob_id, xs_ctxt,
-			DP_UUID(uuid), ba.bca_blob);
-		ctxt->bic_blob = ba.bca_blob;
+		d_list_add_tail(&ctxt->bic_link, &xs_ctxt->bxc_io_ctxts);
 		*pctxt = ctxt;
 	}
 
-	blob_cp_arg_fini(&ba);
-out:
-	if (rc != 0)
-		D_FREE(ctxt);
+	bio_bs_unhold(xs_ctxt->bxc_blobstore);
+	return rc;
+}
+
+static int
+bio_blob_close(struct bio_io_context *ctxt, bool async)
+{
+	struct blob_msg_arg	*bma;
+	struct blob_cp_arg	*ba;
+	struct bio_blobstore	*bbs;
+	int			 rc;
+
+	D_ASSERT(!ctxt->bic_opening);
+	if (ctxt->bic_blob == NULL) {
+		D_ERROR("Blob is already closed\n");
+		return -DER_ALREADY;
+	} else if (ctxt->bic_closing) {
+		D_ERROR("The blob is in closing\n");
+		return -DER_AGAIN;
+	} else if (ctxt->bic_inflight_dmas) {
+		D_ERROR("There are %u inflight blob IOs\n",
+			ctxt->bic_inflight_dmas);
+		return -DER_BUSY;
+	}
+
+	bma = alloc_blob_msg_arg();
+	if (bma == NULL)
+		return -DER_NOMEM;
+	ba = &bma->bma_cp_arg;
+
+	D_ASSERT(ctxt->bic_xs_ctxt != NULL);
+	bbs = ctxt->bic_xs_ctxt->bxc_blobstore;
+
+	D_DEBUG(DB_MGMT, "Closing blob %p for xs:%p\n", ctxt->bic_blob,
+		ctxt->bic_xs_ctxt);
+
+	ctxt->bic_closing = 1;
+	ba->bca_inflights = 1;
+	bma->bma_ioc = ctxt;
+	bma->bma_async = async;
+	spdk_thread_send_msg(owner_thread(bbs), blob_msg_close, bma);
+
+	if (async)
+		return 0;
+
+	/* Wait for blob close done */
+	blob_wait_completion(ctxt->bic_xs_ctxt, ba);
+	rc = ba->bca_rc;
+	ctxt->bic_closing = 0;
+
+	if (rc != 0) {
+		D_ERROR("Close blob %p failed for xs:%p rc:%d\n",
+			ctxt->bic_blob, ctxt->bic_xs_ctxt, rc);
+	} else {
+		D_DEBUG(DB_MGMT, "Successfully closed blob %p for xs:%p\n",
+			ctxt->bic_blob, ctxt->bic_xs_ctxt);
+		ctxt->bic_blob = NULL;
+	}
+
+	free_blob_msg_arg(bma);
 	return rc;
 }
 
 int
 bio_ioctxt_close(struct bio_io_context *ctxt)
 {
-	struct blob_msg_arg	 bma = { 0 };
-	struct blob_cp_arg	 ba = { 0 };
-	struct bio_blobstore	*bbs;
+	struct bio_xs_context	*xs_ctxt;
 	int			 rc;
 
+	xs_ctxt = ctxt->bic_xs_ctxt;
 	/* NVMe isn't configured */
-	if (ctxt->bic_blob == NULL)
-		D_GOTO(out, rc = 0);
-
-	rc = blob_cp_arg_init(&ba);
-	if (rc != 0)
-		goto out;
-
-	D_DEBUG(DB_MGMT, "Closing blob %p for xs:%p\n", ctxt->bic_blob,
-		ctxt->bic_xs_ctxt);
-
-	D_ASSERT(ctxt->bic_xs_ctxt != NULL);
-	bbs = ctxt->bic_xs_ctxt->bxc_blobstore;
-	D_ASSERT(bbs != NULL);
-
-	ba.bca_inflights = 1;
-	ABT_mutex_lock(bbs->bb_mutex);
-	if (bbs->bb_bs != NULL) {
-		bma.bma_blob = ctxt->bic_blob;
-		bma.bma_cp_arg = &ba;
-
-		spdk_thread_send_msg(bbs->bb_ctxt->bxc_thread,
-				     blob_msg_close, &bma);
-	} else {
-		blob_cb(&ba, -DER_NO_HDL);
+	if (xs_ctxt == NULL) {
+		d_list_del_init(&ctxt->bic_link);
+		D_FREE(ctxt);
+		return 0;
 	}
-	ABT_mutex_unlock(bbs->bb_mutex);
 
-	/* Wait for blob close done */
-	blob_wait_completion(ctxt->bic_xs_ctxt, &ba);
-	rc = ba.bca_rc;
+	rc = bio_bs_hold(xs_ctxt->bxc_blobstore);
+	if (rc)
+		return rc;
 
-	if (rc != 0)
-		D_ERROR("Close blob %p failed for xs:%p rc:%d\n",
-			ctxt->bic_blob, ctxt->bic_xs_ctxt, ba.bca_rc);
-	else
-		D_DEBUG(DB_MGMT, "Successfully closed blob %p for xs:%p\n",
-			ctxt->bic_blob, ctxt->bic_xs_ctxt);
+	rc = bio_blob_close(ctxt, false);
 
-	blob_cp_arg_fini(&ba);
-out:
+	/* Free the io context no matter if close succeeded */
+	d_list_del_init(&ctxt->bic_link);
 	D_FREE(ctxt);
+	bio_bs_unhold(xs_ctxt->bxc_blobstore);
+
 	return rc;
 }
 
 int
-bio_blob_delete(uuid_t uuid, struct bio_xs_context *xs_ctxt)
+bio_blob_unmap(struct bio_io_context *ioctxt, uint64_t off, uint64_t len)
 {
-	struct blob_msg_arg		 bma = { 0 };
-	struct blob_cp_arg		 ba = { 0 };
-	struct bio_blobstore		*bbs;
-	struct smd_nvme_pool_info	 smd_pool;
-	spdk_blob_id			 blob_id;
-	int				 rc;
+	struct blob_cp_arg	 ba;
+	struct spdk_io_channel	*channel;
+	uint64_t		 pg_off;
+	uint64_t		 pg_cnt;
+	int			 rc;
 
-	D_ASSERT(xs_ctxt != NULL);
-	bbs = xs_ctxt->bxc_blobstore;
-	D_ASSERT(bbs != NULL);
-
-	/**
-	 * Query per-server metadata to get blobID for this pool:xstream
+	/*
+	 * TODO: track inflight DMA extents and check the tracked extents
+	 *	 on blob unmap to avoid following very unlikely race:
+	 *
+	 * 1. VOS fetch locates a blob extent and trigger DMA transfer;
+	 * 2. That blob extent is freed by VOS aggregation;
+	 * 3. The freed extent stays in VEA aging buffer for few(10) seconds,
+	 *    then it's being unmapped before being made available for new
+	 *    allocation;
+	 * 4. If the DMA transfer for fetch takes a very long time and isn't
+	 *    done  before the unmap call, corrupted data could be returned.
 	 */
-	rc = smd_nvme_get_pool(uuid, xs_ctxt->bxc_xs_id, &smd_pool);
-	if (rc != 0) {
-		D_WARN("Blob for xs:%p, pool:"DF_UUID" doesn't exist\n",
-		       xs_ctxt, DP_UUID(uuid));
-		/*
-		 * User may create a pool w/o NVMe partition even with NVMe
-		 * configured.
-		 *
-		 * TODO: Let's simply return success for this moment, the
-		 * pool create & destroy code needs be re-organized later to
-		 * handle various middle failure cases, then we should
-		 * improve this by checking the 'pd_nvme_sz' and avoid
-		 * calling into this function when 'pd_nvme_sz' == 0.
-		 */
-		return 0;
-	}
+	D_ASSERT(len > 0);
 
-	blob_id = smd_pool.npi_blob_id;
+	/* blob unmap can only support page aligned offset and length */
+	D_ASSERT((len & (BIO_DMA_PAGE_SZ - 1)) == 0);
+	D_ASSERT((off & (BIO_DMA_PAGE_SZ - 1)) == 0);
+
+	/* convert byte to blob/page offset */
+	pg_off = off >> BIO_DMA_PAGE_SHIFT;
+	pg_cnt = len >> BIO_DMA_PAGE_SHIFT;
+
+	D_ASSERT(ioctxt->bic_xs_ctxt != NULL);
+	channel = ioctxt->bic_xs_ctxt->bxc_io_channel;
+
+	if (!is_blob_valid(ioctxt)) {
+		D_ERROR("Blobstore is invalid. blob:%p, closing:%d\n",
+			ioctxt->bic_blob, ioctxt->bic_closing);
+		return -DER_NO_HDL;
+	}
 
 	rc = blob_cp_arg_init(&ba);
 	if (rc != 0)
 		return rc;
 
-	D_DEBUG(DB_MGMT, "Deleting blobID "DF_U64" for pool:"DF_UUID" xs:%p\n",
-		blob_id, DP_UUID(uuid), xs_ctxt);
+	D_DEBUG(DB_MGMT, "Unmapping blob %p pgoff:"DF_U64" pgcnt:"DF_U64"\n",
+		ioctxt->bic_blob, pg_off, pg_cnt);
 
+	ioctxt->bic_inflight_dmas++;
 	ba.bca_inflights = 1;
-	ABT_mutex_lock(bbs->bb_mutex);
-	if (bbs->bb_bs != NULL) {
-		bma.bma_bs = bbs->bb_bs;
-		bma.bma_blob_id = blob_id;
-		bma.bma_cp_arg = &ba;
+	spdk_blob_io_unmap(ioctxt->bic_blob, channel, pg_off, pg_cnt, blob_cb,
+			   &ba);
 
-		spdk_thread_send_msg(bbs->bb_ctxt->bxc_thread,
-				     blob_msg_delete, &bma);
-	} else {
-		blob_cb(&ba, -DER_NO_HDL);
-	}
-	ABT_mutex_unlock(bbs->bb_mutex);
-
-	/* Wait for blob delete done */
-	blob_wait_completion(xs_ctxt, &ba);
+	/* Wait for blob unmap done */
+	blob_wait_completion(ioctxt->bic_xs_ctxt, &ba);
 	rc = ba.bca_rc;
+	ioctxt->bic_inflight_dmas--;
 
 	if (rc != 0)
-		D_ERROR("Delete blobID "DF_U64" failed for pool:"DF_UUID" "
-			"xs:%p rc:%d\n",
-			blob_id, DP_UUID(uuid), xs_ctxt, rc);
+		D_ERROR("Unmap blob %p failed for xs: %p rc:%d\n",
+			ioctxt->bic_blob, ioctxt->bic_xs_ctxt, rc);
 	else
-		D_DEBUG(DB_MGMT, "Successfully deleted blobID "DF_U64" for "
-			"pool:"DF_UUID" xs:%p\n",
-			blob_id, DP_UUID(uuid), xs_ctxt);
+		D_DEBUG(DB_MGMT, "Successfully unmapped blob %p for xs:%p\n",
+			ioctxt->bic_blob, ioctxt->bic_xs_ctxt);
 
 	blob_cp_arg_fini(&ba);
 	return rc;
-}
-
-static int
-bio_rwv(struct bio_io_context *ioctxt, struct bio_sglist *bsgl_in,
-	d_sg_list_t *sgl, bool update)
-{
-	struct bio_sglist	*bsgl;
-	struct bio_desc		*biod;
-	int			 i, rc;
-
-	/* allocate blob I/O descriptor */
-	biod = bio_iod_alloc(ioctxt, 1 /* single bsgl */, update);
-	if (biod == NULL)
-		return -DER_NOMEM;
-
-	/*
-	 * copy the passed in @bsgl_in to the bsgl attached on bio_desc,
-	 * since we don't want following bio ops change caller's bsgl.
-	 */
-	bsgl = bio_iod_sgl(biod, 0);
-
-	rc = bio_sgl_init(bsgl, bsgl_in->bs_nr);
-	if (rc)
-		goto out;
-
-	for (i = 0; i < bsgl->bs_nr; i++) {
-		D_ASSERT(bsgl_in->bs_iovs[i].bi_buf == NULL);
-		D_ASSERT(bsgl_in->bs_iovs[i].bi_data_len != 0);
-		bsgl->bs_iovs[i] = bsgl_in->bs_iovs[i];
-	}
-	bsgl->bs_nr_out = bsgl->bs_nr;
-
-	/* map the biov to DMA safe buffer, fill DMA buffer if read operation */
-	rc = bio_iod_prep(biod);
-	if (rc)
-		goto out;
-
-	for (i = 0; i < bsgl->bs_nr; i++)
-		D_ASSERT(bsgl->bs_iovs[i].bi_buf != NULL);
-
-	rc = bio_iod_copy(biod, sgl, 1 /* single sgl */);
-	if (rc)
-		D_ERROR("Copy biod failed, rc:%d\n", rc);
-
-	/* release DMA buffer, write data back to NVMe device for write */
-	rc = bio_iod_post(biod);
-
-out:
-	bio_iod_free(biod); /* also calls bio_sgl_fini */
-
-	return rc;
-}
-
-int
-bio_readv(struct bio_io_context *ioctxt, struct bio_sglist *bsgl,
-	  d_sg_list_t *sgl)
-{
-	int	rc;
-
-	rc = bio_rwv(ioctxt, bsgl, sgl, false);
-	if (rc)
-		D_ERROR("Readv to blob:%p failed for xs:%p, rc:%d\n",
-			ioctxt->bic_blob, ioctxt->bic_xs_ctxt, rc);
-	else
-		D_DEBUG(DB_IO, "Readv to blob %p for xs:%p successfully\n",
-			ioctxt->bic_blob, ioctxt->bic_xs_ctxt);
-
-	return rc;
-}
-
-int
-bio_writev(struct bio_io_context *ioctxt, struct bio_sglist *bsgl,
-	   d_sg_list_t *sgl)
-{
-	int	rc;
-
-	rc = bio_rwv(ioctxt, bsgl, sgl, true);
-	if (rc)
-		D_ERROR("Writev to blob:%p failed for xs:%p, rc:%d\n",
-			ioctxt->bic_blob, ioctxt->bic_xs_ctxt, rc);
-	else
-		D_DEBUG(DB_IO, "Writev to blob %p for xs:%p successfully\n",
-			ioctxt->bic_blob, ioctxt->bic_xs_ctxt);
-
-	return rc;
-}
-
-static int
-bio_rw(struct bio_io_context *ioctxt, bio_addr_t addr, d_iov_t *iov,
-	bool update)
-{
-	struct bio_sglist	bsgl;
-	struct bio_iov		biov;
-	d_sg_list_t		sgl;
-	int			rc;
-
-	biov.bi_buf = NULL;
-	biov.bi_addr = addr;
-	biov.bi_data_len = iov->iov_len;
-	bsgl.bs_iovs = &biov;
-	bsgl.bs_nr = bsgl.bs_nr_out = 1;
-
-	sgl.sg_iovs = iov;
-	sgl.sg_nr = 1;
-	sgl.sg_nr_out = 0;
-
-	rc = bio_rwv(ioctxt, &bsgl, &sgl, update);
-	if (rc)
-		D_ERROR("%s to blob:%p failed for xs:%p, rc:%d\n",
-			update ? "Write" : "Read", ioctxt->bic_blob,
-			ioctxt->bic_xs_ctxt, rc);
-	else
-		D_DEBUG(DB_IO, "%s to blob %p for xs:%p successfully\n",
-			update ? "Write" : "Read", ioctxt->bic_blob,
-			ioctxt->bic_xs_ctxt);
-
-	return rc;
-}
-
-int
-bio_read(struct bio_io_context *ioctxt, bio_addr_t addr, d_iov_t *iov)
-{
-	return bio_rw(ioctxt, addr, iov, false);
-}
-
-
-int
-bio_write(struct bio_io_context *ioctxt, bio_addr_t addr, d_iov_t *iov)
-{
-
-	return bio_rw(ioctxt, addr, iov, true);
 }
 
 int
@@ -658,60 +756,5 @@ bio_write_blob_hdr(struct bio_io_context *ioctxt, struct bio_blob_hdr *bio_bh)
 
 	rc = bio_write(ioctxt, addr, &iov);
 
-	return rc;
-}
-
-int
-bio_blob_unmap(struct bio_io_context *ioctxt, uint64_t off, uint64_t len)
-{
-	struct blob_cp_arg	 ba;
-	struct bio_blobstore	*bbs;
-	struct spdk_io_channel	*channel;
-	uint64_t		 pg_off;
-	uint64_t		 pg_cnt;
-	int			 rc;
-
-	D_ASSERT(len > 0);
-
-	/* blob unmap can only support page aligned offset and length */
-	D_ASSERT((len & (BIO_DMA_PAGE_SZ - 1)) == 0);
-	D_ASSERT((off & (BIO_DMA_PAGE_SZ - 1)) == 0);
-
-	/* convert byte to blob/page offset */
-	pg_off = off >> BIO_DMA_PAGE_SHIFT;
-	pg_cnt = len >> BIO_DMA_PAGE_SHIFT;
-
-	D_ASSERT(ioctxt->bic_xs_ctxt != NULL);
-	bbs = ioctxt->bic_xs_ctxt->bxc_blobstore;
-	channel = ioctxt->bic_xs_ctxt->bxc_io_channel;
-
-	rc = blob_cp_arg_init(&ba);
-	if (rc != 0)
-		return rc;
-
-	D_DEBUG(DB_MGMT, "Unmapping blob %p pgoff:"DF_U64" pgcnt:"DF_U64"\n",
-		ioctxt->bic_blob, pg_off, pg_cnt);
-
-	ba.bca_inflights = 1;
-	ABT_mutex_lock(bbs->bb_mutex);
-	if (bbs->bb_bs != NULL)
-		spdk_blob_io_unmap(ioctxt->bic_blob, channel, pg_off, pg_cnt,
-				   blob_cb, &ba);
-	else
-		blob_cb(&ba, -DER_NO_HDL);
-	ABT_mutex_unlock(bbs->bb_mutex);
-
-	/* Wait for blob unmap done */
-	blob_wait_completion(ioctxt->bic_xs_ctxt, &ba);
-	rc = ba.bca_rc;
-
-	if (rc != 0)
-		D_ERROR("Unmap blob %p failed for xs: %p rc:%d\n",
-			ioctxt->bic_blob, ioctxt->bic_xs_ctxt, rc);
-	else
-		D_DEBUG(DB_MGMT, "Successfully unmapped blob %p for xs:%p\n",
-			ioctxt->bic_blob, ioctxt->bic_xs_ctxt);
-
-	blob_cp_arg_fini(&ba);
 	return rc;
 }

--- a/src/bio/bio_xstream.c
+++ b/src/bio/bio_xstream.c
@@ -575,33 +575,59 @@ init_bio_bdevs(struct bio_xs_context *ctxt)
 }
 
 static void
+free_bio_blobstore(struct bio_blobstore *bb)
+{
+	D_ASSERT(bb->bb_bs == NULL);
+	D_ASSERT(bb->bb_ref == 0);
+
+	ABT_cond_free(&bb->bb_barrier);
+	ABT_mutex_free(&bb->bb_mutex);
+	D_FREE(bb->bb_xs_ctxts);
+	D_FREE(bb);
+}
+
+static void
 put_bio_blobstore(struct bio_blobstore *bb, struct bio_xs_context *ctxt)
 {
-	struct spdk_blob_store *bs = NULL;
-	bool last = false;
+	struct spdk_blob_store	*bs = NULL;
+	struct bio_io_context	*ioc, *tmp;
+	int			i, xs_cnt_max = BIO_XS_CNT_MAX;
 
-	/*
-	 * Unload the blobstore within the same thread where is't loaded,
-	 * all server xstreams which should have stopped using the blobstore.
-	 */
+	d_list_for_each_entry_safe(ioc, tmp, &ctxt->bxc_io_ctxts, bic_link) {
+		d_list_del_init(&ioc->bic_link);
+		if (ioc->bic_blob != NULL)
+			D_WARN("Pool isn't closed. xs:%p\n", ctxt);
+	}
+
 	ABT_mutex_lock(bb->bb_mutex);
-	if (bb->bb_ctxt == ctxt && bb->bb_bs != NULL) {
+	/* Unload the blobstore in the same xstream where it was loaded. */
+	if (bb->bb_owner_xs == ctxt && bb->bb_bs != NULL) {
 		bs = bb->bb_bs;
 		bb->bb_bs = NULL;
 	}
 
+	for (i = 0; i < xs_cnt_max; i++) {
+		if (bb->bb_xs_ctxts[i] == ctxt) {
+			bb->bb_xs_ctxts[i] = NULL;
+			break;
+		}
+	}
+	D_ASSERT(i < xs_cnt_max);
+
 	D_ASSERT(bb->bb_ref > 0);
 	bb->bb_ref--;
-	if (bb->bb_ref == 0)
-		last = true;
+
+	/* Wait for other xstreams to put_bio_blobstore() first */
+	if (bs != NULL && bb->bb_ref)
+		ABT_cond_wait(bb->bb_barrier, bb->bb_mutex);
+	else if (bb->bb_ref == 0)
+		ABT_cond_broadcast(bb->bb_barrier);
+
 	ABT_mutex_unlock(bb->bb_mutex);
 
-	if (bs != NULL)
+	if (bs != NULL) {
+		D_ASSERT(bb->bb_holdings == 0);
 		unload_blobstore(ctxt, bs);
-
-	if (last) {
-		ABT_mutex_free(&bb->bb_mutex);
-		D_FREE(bb);
 	}
 }
 
@@ -614,7 +640,7 @@ fini_bio_bdevs(struct bio_xs_context *ctxt)
 		d_list_del_init(&d_bdev->bb_link);
 
 		if (d_bdev->bb_blobstore != NULL)
-			put_bio_blobstore(d_bdev->bb_blobstore, ctxt);
+			free_bio_blobstore(d_bdev->bb_blobstore);
 
 		D_FREE(d_bdev);
 	}
@@ -623,30 +649,61 @@ fini_bio_bdevs(struct bio_xs_context *ctxt)
 static struct bio_blobstore *
 alloc_bio_blobstore(struct bio_xs_context *ctxt)
 {
-	struct bio_blobstore *bb;
-	int rc;
+	struct bio_blobstore	*bb;
+	int			 rc, xs_cnt_max = BIO_XS_CNT_MAX;
 
 	D_ASSERT(ctxt != NULL);
 	D_ALLOC_PTR(bb);
 	if (bb == NULL)
 		return NULL;
 
+	D_ALLOC_ARRAY(bb->bb_xs_ctxts, xs_cnt_max);
+	if (bb->bb_xs_ctxts == NULL)
+		goto out_bb;
+
 	rc = ABT_mutex_create(&bb->bb_mutex);
-	if (rc != ABT_SUCCESS) {
-		D_FREE(bb);
-		return NULL;
-	}
+	if (rc != ABT_SUCCESS)
+		goto out_ctxts;
 
-	bb->bb_ref = 1;
-	bb->bb_ctxt = ctxt;
+	rc = ABT_cond_create(&bb->bb_barrier);
+	if (rc != ABT_SUCCESS)
+		goto out_mutex;
 
+	bb->bb_ref = 0;
+	bb->bb_owner_xs = ctxt;
 	return bb;
+
+out_mutex:
+	ABT_mutex_free(&bb->bb_mutex);
+out_ctxts:
+	D_FREE(bb->bb_xs_ctxts);
+out_bb:
+	D_FREE(bb);
+	return NULL;
 }
 
 static struct bio_blobstore *
-get_bio_blobstore(struct bio_blobstore *bb)
+get_bio_blobstore(struct bio_blobstore *bb, struct bio_xs_context *ctxt)
 {
+	int	i, xs_cnt_max = BIO_XS_CNT_MAX;
+
 	ABT_mutex_lock(bb->bb_mutex);
+
+	for (i = 0; i < xs_cnt_max; i++) {
+		if (bb->bb_xs_ctxts[i] == ctxt) {
+			D_ERROR("Dup xstream context!\n");
+			ABT_mutex_unlock(bb->bb_mutex);
+			return NULL;
+		} else if (bb->bb_xs_ctxts[i] == NULL) {
+			bb->bb_xs_ctxts[i] = ctxt;
+			break;
+		}
+	}
+	if (i == xs_cnt_max) {
+		D_ERROR("Too many xstreams per device!\n");
+		ABT_mutex_unlock(bb->bb_mutex);
+		return NULL;
+	}
 	bb->bb_ref++;
 	ABT_mutex_unlock(bb->bb_mutex);
 	return bb;
@@ -792,7 +849,10 @@ init_blobstore_ctxt(struct bio_xs_context *ctxt, int xs_id)
 			xs_id, ctxt, spdk_bdev_get_name(d_bdev->bb_bdev));
 	}
 
-	ctxt->bxc_blobstore = get_bio_blobstore(d_bdev->bb_blobstore);
+	ctxt->bxc_blobstore = get_bio_blobstore(d_bdev->bb_blobstore, ctxt);
+	if (ctxt->bxc_blobstore == NULL)
+		return -DER_NOMEM;
+
 	bs = ctxt->bxc_blobstore->bb_bs;
 	D_ASSERT(bs != NULL);
 	ctxt->bxc_io_channel = spdk_bs_alloc_io_channel(bs);
@@ -906,6 +966,7 @@ bio_xsctxt_alloc(struct bio_xs_context **pctxt, int xs_id)
 		return -DER_NOMEM;
 
 	D_INIT_LIST_HEAD(&ctxt->bxc_pollers);
+	D_INIT_LIST_HEAD(&ctxt->bxc_io_ctxts);
 	ctxt->bxc_xs_id = xs_id;
 
 	ABT_mutex_lock(nvme_glb.bd_mutex);


### PR DESCRIPTION
- Define bio_blobstore in-memory state;
- bio_blobstore tracks owner xstream context and all other user
  xstream contexts, they'll be used for owner to notify users to
  close SPDK blobs; (Each xtream tracks its own opened blobs).
- Blobstore owner waits for all users putting blobstore before
  closing blobstore;
- Each io context tracks inflight DMAs to avoid closing blob before
  DMA done, it tracks opening/closing state as well;
- Move bio_read/write(), bio_readv/writev() from bio_context.c to
  bio_buffer.c

Signed-off-by: Niu Yawei <yawei.niu@intel.com>
Change-Id: I15dfde43c1c98bfca26619960b9dde336c8c8e81