### PR TITLE
CORCI-697 SLES 12.3 RPM Builder Image has incorrect version of go

### DIFF
--- a/utils/docker/Dockerfile-rpmbuild.sles.12.3
+++ b/utils/docker/Dockerfile-rpmbuild.sles.12.3
@@ -112,7 +112,8 @@ RUN zypper --non-interactive rm libpmem1;                                      \
                                      libpmemobj-devel raft-devel               \
                                      argobots-devel cart-devel                 \
                                      ipmctl-devel readline-devel               \
-                                     go1.10 fio\ \<\ 3.4
+                                     go1.10 fio\ \<\ 3.4;                      \
+    zypper --non-interactive rm go1.7 go1.8 go1.9
 
 # force an upgrade to get any newly built RPMs
 ARG CACHEBUST=1

--- a/utils/docker/Dockerfile-rpmbuild.sles.12.3
+++ b/utils/docker/Dockerfile-rpmbuild.sles.12.3
@@ -106,14 +106,18 @@ RUN zypper --non-interactive ar --gpgcheck-allow-unsigned -f ${JENKINS_URL}job/d
                                                         cart fio                                                                                                                                \
                                                         'The Go Programming Language (SLE_12_SP3_Backports)'                                                                                    \
                                                         'home:jhli (SLE_15)'
+ARG go_version=1.10
+ENV go_version=${go_version}
+# Note the need to erase old go packages: CORCI-697
 RUN zypper --non-interactive rm libpmem1;                                      \
     zypper --non-interactive install spdk-devel spdk-tools libisa-l-devel      \
                                      protobuf-c-devel fuse-devel libpmem-devel \
                                      libpmemobj-devel raft-devel               \
                                      argobots-devel cart-devel                 \
                                      ipmctl-devel readline-devel               \
-                                     go1.10 fio\ \<\ 3.4;                      \
-    zypper --non-interactive rm go1.7 go1.8 go1.9
+                                     go${go_version} fio\ \<\ 3.4;             \
+    rpm -qa | grep ^go\[1-9\]\* | grep -v ^go${go_version/\./\\.} |            \
+        xargs zypper --non-interactive rm
 
 # force an upgrade to get any newly built RPMs
 ARG CACHEBUST=1


### PR DESCRIPTION
For an unknown reason, zypper is installing go1.[7-9] in addition
to go1.10 when only the latter is being requested.  This is leaving
the last version installed or updated as the default version since
they are all equivillent priority "alternatives".

Simply remove all unwanted versions so that there is no last-one-
wins scenario.