### PR TITLE
DAOS-2692: Correct the usage of component status  UP vs UPIN

### DIFF
--- a/src/common/pool_map.c
+++ b/src/common/pool_map.c
@@ -490,7 +490,7 @@ pool_buf_parse(struct pool_buf *buf, struct pool_domain **tree_pp)
 	/* Initialize the root */
 	parent = &tree[0]; /* root */
 	parent->do_comp.co_type   = PO_COMP_TP_ROOT;
-	parent->do_comp.co_status = PO_COMP_ST_UP;
+	parent->do_comp.co_status = PO_COMP_ST_UPIN;
 	if (buf->pb_domain_nr == 0) {
 		/* nodes are directly attached under the root */
 		parent->do_target_nr = buf->pb_node_nr;
@@ -962,7 +962,7 @@ pool_map_initialise(struct pool_map *map, bool activate,
 		for (j = 0; j < sorter->cs_nr; j++) {
 			if (activate &&
 			    tree[j].do_comp.co_status == PO_COMP_ST_NEW)
-				tree[j].do_comp.co_status = PO_COMP_ST_UP;
+				tree[j].do_comp.co_status = PO_COMP_ST_UPIN;
 
 			sorter->cs_comps[j] = &tree[j].do_comp;
 		}
@@ -986,7 +986,7 @@ pool_map_initialise(struct pool_map *map, bool activate,
 		map->po_target_sorter.cs_comps[i] = &ta->ta_comp;
 
 		if (activate && ta->ta_comp.co_status == PO_COMP_ST_NEW)
-			ta->ta_comp.co_status = PO_COMP_ST_UP;
+			ta->ta_comp.co_status = PO_COMP_ST_UPIN;
 	}
 
 	rc = comp_sorter_sort(&map->po_target_sorter);
@@ -1081,7 +1081,7 @@ pool_map_compat(struct pool_map *map, uint32_t version,
 				if (existed)
 					return -DER_NO_PERM;
 
-			} else if (dc->co_status == PO_COMP_ST_UP) {
+			} else if (dc->co_status == PO_COMP_ST_UPIN) {
 				if (!existed)
 					return -DER_INVAL;
 
@@ -1268,7 +1268,7 @@ pool_map_merge(struct pool_map *map, uint32_t version,
 						pool_comp_type2str(dc->co_type),
 						dc->co_id);
 
-					dc->co_status = PO_COMP_ST_UP;
+					dc->co_status = PO_COMP_ST_UPIN;
 
 					*child = sdom->do_children[j];
 					child++;
@@ -1299,7 +1299,7 @@ pool_map_merge(struct pool_map *map, uint32_t version,
 					D_DEBUG(DB_MGMT, "New target[%d]\n",
 						tc->co_id);
 
-					tc->co_status = PO_COMP_ST_UP;
+					tc->co_status = PO_COMP_ST_UPIN;
 
 					*target = sdom->do_targets[j];
 					target++;
@@ -1817,14 +1817,14 @@ pool_map_find_failed_tgts(struct pool_map *map, struct pool_target **tgt_pp,
  * rebuild one by one.
  */
 int
-pool_map_find_up_tgts(struct pool_map *map, struct pool_target **tgt_pp,
+pool_map_find_upin_tgts(struct pool_map *map, struct pool_target **tgt_pp,
 		      unsigned int *tgt_cnt)
 {
 	struct find_tgts_param param;
 
 	memset(&param, 0, sizeof(param));
 	param.ftp_chk_status = 1;
-	param.ftp_status = PO_COMP_ST_UP;
+	param.ftp_status = PO_COMP_ST_UPIN;
 
 	return pool_map_find_tgts(map, &param, &fseq_sort_ops, tgt_pp,
 				  tgt_cnt);

--- a/src/container/cli.c
+++ b/src/container/cli.c
@@ -1024,7 +1024,7 @@ get_tgt_rank(struct dc_pool *pool, unsigned int *rank)
 	unsigned int		tgt_cnt;
 	int			rc;
 
-	rc = pool_map_find_up_tgts(pool->dp_map, &tgts, &tgt_cnt);
+	rc = pool_map_find_upin_tgts(pool->dp_map, &tgts, &tgt_cnt);
 	if (rc)
 		return rc;
 

--- a/src/include/daos/pool_map.h
+++ b/src/include/daos/pool_map.h
@@ -198,7 +198,7 @@ int pool_map_find_down_tgts(struct pool_map *map, struct pool_target **tgt_pp,
 			    unsigned int *tgt_cnt);
 int pool_map_find_failed_tgts(struct pool_map *map, struct pool_target **tgt_pp,
 			      unsigned int *tgt_cnt);
-int pool_map_find_up_tgts(struct pool_map *map, struct pool_target **tgt_pp,
+int pool_map_find_upin_tgts(struct pool_map *map, struct pool_target **tgt_pp,
 			  unsigned int *tgt_cnt);
 int pool_map_find_target_by_rank_idx(struct pool_map *map, uint32_t rank,
 				 uint32_t tgt_idx, struct pool_target **tgts);

--- a/src/placement/tests/place_obj.c
+++ b/src/placement/tests/place_obj.c
@@ -131,7 +131,7 @@ static void
 plt_add_tgt(uint32_t id)
 {
 	po_ver++;
-	plt_set_tgt_status(id, PO_COMP_ST_UP, po_ver);
+	plt_set_tgt_status(id, PO_COMP_ST_UPIN, po_ver);
 }
 
 static void
@@ -199,7 +199,7 @@ main(int argc, char **argv)
 	/* fake the pool map */
 	for (i = 0; i < DOM_NR; i++, comp++) {
 		comp->co_type   = PO_COMP_TP_RACK;
-		comp->co_status = PO_COMP_ST_UP;
+		comp->co_status = PO_COMP_ST_UPIN;
 		comp->co_id	= i;
 		comp->co_rank   = i;
 		comp->co_ver    = 1;
@@ -208,7 +208,7 @@ main(int argc, char **argv)
 
 	for (i = 0; i < DOM_NR * TARGET_PER_DOM; i++, comp++) {
 		comp->co_type   = PO_COMP_TP_TARGET;
-		comp->co_status = PO_COMP_ST_UP;
+		comp->co_status = PO_COMP_ST_UPIN;
 		comp->co_id	= i;
 		comp->co_rank   = i;
 		comp->co_ver    = 1;

--- a/src/pool/srv_pool.c
+++ b/src/pool/srv_pool.c
@@ -471,7 +471,7 @@ init_pool_metadata(struct rdb_tx *tx, const rdb_path_t *kvs,
 	/* fill domains */
 	for (i = 0; i < ndomains; i++) {
 		map_comp.co_type = PO_COMP_TP_RACK;	/* TODO */
-		map_comp.co_status = PO_COMP_ST_UP;
+		map_comp.co_status = PO_COMP_ST_UPIN;
 		map_comp.co_index = i;
 		map_comp.co_id = i;
 		map_comp.co_rank = 0;
@@ -490,7 +490,7 @@ init_pool_metadata(struct rdb_tx *tx, const rdb_path_t *kvs,
 				    sizeof(uuid_t), uuid_compare_cb);
 
 		map_comp.co_type = PO_COMP_TP_NODE;
-		map_comp.co_status = PO_COMP_ST_UP;
+		map_comp.co_status = PO_COMP_ST_UPIN;
 		map_comp.co_index = i;
 		map_comp.co_id = p - uuids;
 		map_comp.co_rank = target_addrs->rl_ranks[i];
@@ -509,7 +509,7 @@ init_pool_metadata(struct rdb_tx *tx, const rdb_path_t *kvs,
 
 		for (j = 0; j < dss_tgt_nr; j++) {
 			map_comp.co_type = PO_COMP_TP_TARGET;
-			map_comp.co_status = PO_COMP_ST_UP;
+			map_comp.co_status = PO_COMP_ST_UPIN;
 			map_comp.co_index = j;
 			map_comp.co_id = i * dss_tgt_nr + j;
 			map_comp.co_rank = target_addrs->rl_ranks[i];

--- a/src/pool/srv_util.c
+++ b/src/pool/srv_util.c
@@ -337,10 +337,10 @@ ds_pool_map_tgts_update(struct pool_map *map, struct pool_target_id_list *tgts,
 			D_PRINT("Target (rank %u idx %u) is added.\n",
 				target->ta_comp.co_rank,
 				target->ta_comp.co_index);
-			target->ta_comp.co_status = PO_COMP_ST_UP;
+			target->ta_comp.co_status = PO_COMP_ST_UPIN;
 			target->ta_comp.co_fseq = 1;
 			nchanges++;
-			dom->do_comp.co_status = PO_COMP_ST_UP;
+			dom->do_comp.co_status = PO_COMP_ST_UPIN;
 		} else if (opc == POOL_EXCLUDE_OUT &&
 			 target->ta_comp.co_status == PO_COMP_ST_DOWN) {
 			D_DEBUG(DF_DSMS, "change target %u/%u to DOWNOUT %p\n",

--- a/src/rebuild/srv.c
+++ b/src/rebuild/srv.c
@@ -398,7 +398,7 @@ is_current_tgt_up(struct rebuild_tgt_pool_tracker *rpt)
 	rc = pool_map_find_target_by_rank_idx(rpt->rt_pool->sp_map, rank,
 					      idx, &tgt);
 	D_ASSERT(rc == 1);
-	if (tgt->ta_comp.co_status != PO_COMP_ST_UP) {
+	if (tgt->ta_comp.co_status != PO_COMP_ST_UPIN) {
 		D_DEBUG(DB_REBUILD, "%d/%d target status %d\n",
 			rank, idx, tgt->ta_comp.co_status);
 		return false;
@@ -752,7 +752,7 @@ rebuild_pool_group_prepare(struct ds_pool *pool)
 		return 0;
 	}
 
-	rc = pool_map_find_up_tgts(pool->sp_map, &tgts, &tgt_cnt);
+	rc = pool_map_find_upin_tgts(pool->sp_map, &tgts, &tgt_cnt);
 	if (rc)
 		return rc;
 


### PR DESCRIPTION
Some places use the component status PO_COMP_ST_UP when
they should be using PO_COMP_ST_UPIN. UP is meant to be used
for components that are being added or reintegrated, but are
not yet fully included in the pool. UPIN signifies that the
component is integrated in the pool map and can be used normally.

Signed-off-by: Peter Fetros <peter.fetros@intel.com>