### PR TITLE
DAOS-2694 control: fix linter warnings for server package

### DIFF
--- a/src/control/server/config.go
+++ b/src/control/server/config.go
@@ -148,7 +148,9 @@ func saveActiveConfig(config *configuration) {
 // hash produces unique int from string, mask MSB on conversion to signed int
 func hash(s string) int {
 	h := fnv.New32a()
-	_, _ = h.Write([]byte(s)) // ignore return values
+	if _, err := h.Write([]byte(s)); err != nil {
+		panic(err) // should never happen
+	}
 
 	return int(h.Sum32() & 0x7FFFFFFF) // mask MSB of uint32 as this will be sign bit
 }

--- a/src/control/server/config.go
+++ b/src/control/server/config.go
@@ -148,9 +148,9 @@ func saveActiveConfig(config *configuration) {
 // hash produces unique int from string, mask MSB on conversion to signed int
 func hash(s string) int {
 	h := fnv.New32a()
-	h.Write([]byte(s))
-	// mask MSB of uint32 as this will be sign bit
-	return int(h.Sum32() & 0x7FFFFFFF)
+	_, _ = h.Write([]byte(s)) // ignore return values
+
+	return int(h.Sum32() & 0x7FFFFFFF) // mask MSB of uint32 as this will be sign bit
 }
 
 // populateCliOpts populates options string slice for single I/O service
@@ -266,8 +266,6 @@ func (c *configuration) cmdlineOverride(opts *cliOptions) {
 	if opts.Map != nil {
 		c.SystemMap = *opts.Map
 	}
-
-	return
 }
 
 // validateConfig asserts that config meets minimum requirements

--- a/src/control/server/config_bdev.go
+++ b/src/control/server/config_bdev.go
@@ -192,6 +192,10 @@ func (c *configuration) parseNvme(i int) (err error) {
 		return
 	}
 
+	if msg := bdev.isValid(srv); msg != "" {
+		log.Debugf("spdk %s: %s (server %d)\n", srv.BdevClass, msg, i)
+	}
+
 	if err = bdev.prep(i, c); err != nil {
 		return
 	}

--- a/src/control/server/external.go
+++ b/src/control/server/external.go
@@ -123,7 +123,7 @@ func (e *ext) createEmpty(path string, size int64) (err error) {
 		if ok && (e == syscall.ENOSYS || e == syscall.EOPNOTSUPP) {
 			log.Debugf(
 				"Warning: Fallocate not supported, attempting Truncate: ", e)
-			err = file.Truncate(size)
+			_ = file.Truncate(size)
 		}
 	}
 	return

--- a/src/control/server/external_mocks.go
+++ b/src/control/server/external_mocks.go
@@ -26,8 +26,6 @@ package main
 import (
 	"fmt"
 	"os/user"
-
-	"github.com/pkg/errors"
 )
 
 // mockExt implements the External interface.
@@ -155,8 +153,4 @@ func newMockExt(
 
 func defaultMockExt() External {
 	return &mockExt{}
-}
-
-func cmdFailMockExt() External {
-	return &mockExt{cmdRet: errors.New("exit status 1")}
 }

--- a/src/control/server/iosrv.go
+++ b/src/control/server/iosrv.go
@@ -35,7 +35,7 @@ import (
 	"time"
 
 	"github.com/pkg/errors"
-	"github.com/satori/go.uuid"
+	uuid "github.com/satori/go.uuid"
 	"golang.org/x/net/context"
 	"google.golang.org/grpc"
 	"gopkg.in/yaml.v2"
@@ -240,7 +240,7 @@ func (srv *iosrv) start() (err error) {
 	}
 	defer func() {
 		if err != nil {
-			srv.stopCmd()
+			_ = srv.stopCmd()
 		}
 	}()
 
@@ -320,7 +320,7 @@ func (srv *iosrv) startCmd() error {
 
 func (srv *iosrv) stopCmd() error {
 	// Ignore potential errors, as the I/O server may have already died.
-	srv.cmd.Process.Kill()
+	_ = srv.cmd.Process.Kill()
 
 	if err := srv.cmd.Wait(); err != nil {
 		return errors.WithStack(err)

--- a/src/control/server/main.go
+++ b/src/control/server/main.go
@@ -120,7 +120,9 @@ func serverMain() error {
 	secServer := newSecurityService(getDrpcClientConnection(config.SocketDir))
 	acl.RegisterAccessControlServer(grpcServer, secServer)
 
-	go grpcServer.Serve(lis)
+	go func() {
+		_ = grpcServer.Serve(lis)
+	}()
 	defer grpcServer.GracefulStop()
 
 	// Wait for storage to be formatted if necessary and subsequently drop

--- a/src/control/server/mgmt_feature_test.go
+++ b/src/control/server/mgmt_feature_test.go
@@ -24,6 +24,7 @@
 package main
 
 import (
+	"context"
 	"testing"
 
 	. "github.com/daos-stack/daos/src/control/common"
@@ -41,14 +42,14 @@ func TestGetFeature(t *testing.T) {
 	fMap[mockFeature.Fname.Name] = mockFeature
 	cs.supportedFeatures = fMap
 
-	feature, err := cs.GetFeature(nil, mockFeature.Fname)
+	feature, err := cs.GetFeature(context.TODO(), mockFeature.Fname)
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	AssertEqual(t, feature, mockFeature, "")
 
-	feature, err = cs.GetFeature(nil, &pb.FeatureName{Name: "non-existent"})
+	_, err = cs.GetFeature(context.TODO(), &pb.FeatureName{Name: "non-existent"})
 	if err == nil {
 		t.Fatal(err)
 	}

--- a/src/control/server/mgmt_storage_test.go
+++ b/src/control/server/mgmt_storage_test.go
@@ -24,6 +24,7 @@
 package main
 
 import (
+	"context"
 	"sync"
 	"testing"
 
@@ -174,10 +175,10 @@ func TestScanStorage(t *testing.T) {
 				[]spdk.Namespace{MockNamespace(&ctrlr)},
 				tt.spdkDiscoverRet, nil, nil),
 			false, cs.config)
-		resp := new(pb.ScanStorageResp)
+		_ = new(pb.ScanStorageResp)
 
 		cs.Setup() // runs discovery for nvme & scm
-		resp, err := cs.ScanStorage(nil, &pb.ScanStorageReq{})
+		resp, err := cs.ScanStorage(context.TODO(), &pb.ScanStorageReq{})
 		if err != nil {
 			AssertEqual(t, err.Error(), tt.errMsg, tt.desc)
 		}
@@ -229,7 +230,6 @@ func TestFormatStorage(t *testing.T) {
 		mountRets        []*pb.ScmMountResult
 		ctrlrRets        []*pb.NvmeControllerResult
 		desc             string
-		errMsg           string
 	}{
 		{
 			desc:            "ram success",
@@ -373,7 +373,7 @@ func TestFormatStorage(t *testing.T) {
 		go func() {
 			// should signal wait group in srv to unlock if
 			// successful once format completed
-			cs.FormatStorage(nil, mock)
+			_ = cs.FormatStorage(nil, mock)
 			mockWg.Done()
 		}()
 
@@ -428,14 +428,12 @@ func TestUpdateStorage(t *testing.T) {
 	pciAddr := "0000:81:00.0" // default pciaddr for tests
 
 	tests := []struct {
-		updateRet  error
 		bDevs      []string
 		nvmeParams *pb.UpdateNvmeReq // provided in client gRPC call
 		scmParams  *pb.UpdateScmReq
 		moduleRets []*pb.ScmModuleResult
 		ctrlrRets  []*pb.NvmeControllerResult
 		desc       string
-		errMsg     string
 	}{
 		{
 			desc:  "nvme update success",
@@ -529,7 +527,7 @@ func TestUpdateStorage(t *testing.T) {
 			Scm:  tt.scmParams,
 		}
 
-		cs.UpdateStorage(req, mock)
+		_ = cs.UpdateStorage(req, mock)
 
 		AssertEqual(
 			t, len(mock.Results), 1,

--- a/src/control/server/mgmt_svc.go
+++ b/src/control/server/mgmt_svc.go
@@ -50,7 +50,7 @@ func CheckReplica(
 	isReplica, bootstrap, err := checkMgmtSvcReplica(
 		lis.Addr().(*net.TCPAddr), accessPoints)
 	if err != nil {
-		srv.Process.Kill()
+		_ = srv.Process.Kill()
 		return
 	}
 	if isReplica {
@@ -181,7 +181,7 @@ func (svc *mgmtSvc) Join(ctx context.Context, req *pb.JoinReq) (*pb.JoinResp, er
 func (svc *mgmtSvc) CreatePool(
 	ctx context.Context, req *pb.CreatePoolReq) (*pb.CreatePoolResp, error) {
 
-	log.Debugf("%T.CreatePool dispatch, req:%+v\n", *svc, *req)
+	log.Debugf("MgmtSvc.CreatePool dispatch, req:%+v\n", *req)
 	// TODO: implement lock and drpc IDs & handler in iosrv
 	// svc.mutex.Lock()
 	// dresp, err := makeDrpcCall(c.drpc, mgmtModuleID, poolCreate, req)

--- a/src/control/server/security_rpc.go
+++ b/src/control/server/security_rpc.go
@@ -52,8 +52,8 @@ func processValidateCredentials(body []byte) ([]byte, error) {
 	}
 
 	// Check our verifier
-	hash, err := security.HashFromToken(credential.Token)
-	if bytes.Compare(hash, credential.Verifier.Data) != 0 {
+	hash, _ := security.HashFromToken(credential.Token)
+	if !bytes.Equal(hash, credential.Verifier.Data) {
 		return nil, errors.Errorf("Verifier does not match token")
 	}
 

--- a/src/control/server/security_test.go
+++ b/src/control/server/security_test.go
@@ -24,6 +24,7 @@
 package main
 
 import (
+	"context"
 	"testing"
 
 	. "github.com/daos-stack/daos/src/control/common"
@@ -113,7 +114,7 @@ func TestNewSecurityService(t *testing.T) {
 func TestSetPermissions_NilPermissions(t *testing.T) {
 	service := newTestSecurityService(newMockDrpcClient())
 
-	result, err := service.SetPermissions(nil, nil)
+	result, err := service.SetPermissions(context.TODO(), nil)
 
 	AssertEqual(t, result, (*acl.Response)(nil), "Expected no response")
 	ExpectError(t, err, "requested permissions were nil",
@@ -173,7 +174,7 @@ func TestSetPermissions_Success(t *testing.T) {
 	client.setSendMsgResponse(drpc.Status_SUCCESS,
 		aclResponseToBytes(expectedResp))
 
-	result, err := service.SetPermissions(nil, perms)
+	result, err := service.SetPermissions(context.TODO(), perms)
 
 	// Check the results
 	expectAclResponse(t, result, err, expectedResp)
@@ -189,7 +190,7 @@ func TestSetPermissions_SendMsgFailed(t *testing.T) {
 	client.SendMsgOutputError = errors.Errorf(expectedError)
 	service := newTestSecurityService(client)
 
-	result, err := service.SetPermissions(nil,
+	result, err := service.SetPermissions(context.TODO(),
 		newValidAclEntryPermissions())
 
 	AssertEqual(t, result, (*acl.Response)(nil), "Expected no response")
@@ -201,7 +202,7 @@ func TestSetPermissions_SendMsgResponseStatusFailed(t *testing.T) {
 	service := newTestSecurityService(client)
 	client.setSendMsgResponse(drpc.Status_FAILURE, nil)
 
-	result, err := service.SetPermissions(nil,
+	result, err := service.SetPermissions(context.TODO(),
 		newValidAclEntryPermissions())
 
 	AssertEqual(t, result, (*acl.Response)(nil), "Expected no response")
@@ -218,7 +219,7 @@ func TestSetPermissions_SendMsgResponseBodyInvalid(t *testing.T) {
 	}
 	client.setSendMsgResponse(drpc.Status_SUCCESS, badResp)
 
-	result, err := service.SetPermissions(nil,
+	result, err := service.SetPermissions(context.TODO(),
 		newValidAclEntryPermissions())
 
 	AssertEqual(t, result, (*acl.Response)(nil), "Expected no response")
@@ -230,7 +231,7 @@ func TestSetPermissions_SendMsgResponseNil(t *testing.T) {
 	client := newMockDrpcClient()
 	service := newTestSecurityService(client)
 
-	result, err := service.SetPermissions(nil,
+	result, err := service.SetPermissions(context.TODO(),
 		newValidAclEntryPermissions())
 
 	AssertEqual(t, result, (*acl.Response)(nil), "Expected no response")
@@ -244,7 +245,7 @@ func TestSetPermissions_ConnectFailed(t *testing.T) {
 	client.ConnectOutputError = errors.Errorf(expectedError)
 	service := newTestSecurityService(client)
 
-	result, err := service.SetPermissions(nil,
+	result, err := service.SetPermissions(context.TODO(),
 		newValidAclEntryPermissions())
 
 	AssertEqual(t, result, (*acl.Response)(nil), "Expected no response")
@@ -259,7 +260,7 @@ func TestSetPermissions_CloseFailed(t *testing.T) {
 	client.setSendMsgResponse(drpc.Status_SUCCESS,
 		aclResponseToBytes(&acl.Response{}))
 
-	result, err := service.SetPermissions(nil,
+	result, err := service.SetPermissions(context.TODO(),
 		newValidAclEntryPermissions())
 
 	// We ignore Close errors - not useful to us if we got a good message
@@ -273,7 +274,7 @@ func TestSetPermissions_CloseFailed(t *testing.T) {
 func TestGetPermissions_NilEntry(t *testing.T) {
 	service := newTestSecurityService(newMockDrpcClient())
 
-	result, err := service.GetPermissions(nil, nil)
+	result, err := service.GetPermissions(context.TODO(), nil)
 
 	AssertEqual(t, result, (*acl.Response)(nil), "Expected no response")
 	ExpectError(t, err, "requested entry was nil",
@@ -297,7 +298,7 @@ func TestGetPermissions_Success(t *testing.T) {
 	client.setSendMsgResponse(drpc.Status_SUCCESS,
 		aclResponseToBytes(expectedResp))
 
-	result, err := service.GetPermissions(nil, entry)
+	result, err := service.GetPermissions(context.TODO(), entry)
 
 	// Check the results
 	expectAclResponse(t, result, err, expectedResp)
@@ -313,7 +314,7 @@ func TestGetPermissions_SendMsgFailed(t *testing.T) {
 	client.SendMsgOutputError = errors.Errorf(expectedError)
 	service := newTestSecurityService(client)
 
-	result, err := service.GetPermissions(nil, newValidAclEntry())
+	result, err := service.GetPermissions(context.TODO(), newValidAclEntry())
 
 	AssertEqual(t, result, (*acl.Response)(nil), "Expected no response")
 	ExpectError(t, err, expectedError, "Should pass up the dRPC call error")
@@ -325,7 +326,7 @@ func TestGetPermissions_ConnectFailed(t *testing.T) {
 	client.ConnectOutputError = errors.Errorf(expectedError)
 	service := newTestSecurityService(client)
 
-	result, err := service.GetPermissions(nil, newValidAclEntry())
+	result, err := service.GetPermissions(context.TODO(), newValidAclEntry())
 
 	AssertEqual(t, result, (*acl.Response)(nil), "Expected no response")
 	ExpectError(t, err, expectedError, "Should pass up the dRPC call error")
@@ -339,7 +340,7 @@ func TestGetPermissions_CloseFailed(t *testing.T) {
 	client.setSendMsgResponse(drpc.Status_SUCCESS,
 		aclResponseToBytes(&acl.Response{}))
 
-	result, err := service.GetPermissions(nil, newValidAclEntry())
+	result, err := service.GetPermissions(context.TODO(), newValidAclEntry())
 
 	// We ignore Close errors - not useful to us if we got a good message
 	AssertEqual(t, err, (error)(nil), "Expected no error")
@@ -352,7 +353,7 @@ func TestGetPermissions_CloseFailed(t *testing.T) {
 func TestDestroyAclEntry_NilEntry(t *testing.T) {
 	service := newTestSecurityService(newMockDrpcClient())
 
-	result, err := service.DestroyAclEntry(nil, nil)
+	result, err := service.DestroyAclEntry(context.TODO(), nil)
 
 	AssertEqual(t, result, (*acl.Response)(nil), "Expected no response")
 	ExpectError(t, err, "requested entry was nil",
@@ -371,7 +372,7 @@ func TestDestroyAclEntry_Success(t *testing.T) {
 	client.setSendMsgResponse(drpc.Status_SUCCESS,
 		aclResponseToBytes(expectedResp))
 
-	result, err := service.DestroyAclEntry(nil, entry)
+	result, err := service.DestroyAclEntry(context.TODO(), entry)
 
 	// Check the results
 	expectAclResponse(t, result, err, expectedResp)

--- a/src/control/server/storage_nvme.go
+++ b/src/control/server/storage_nvme.go
@@ -336,7 +336,6 @@ func (n *nvmeStorage) Format(i int, results *([]*pb.NvmeControllerResult)) {
 
 	log.Debugf("device format on NVMe controllers completed")
 	n.formatted = true
-	return
 }
 
 // Update attempts to update firmware on NVMe controllers attached to a
@@ -467,7 +466,6 @@ func (n *nvmeStorage) Update(
 	}
 
 	log.Debugf("device fwupdates on specified NVMe controllers completed\n")
-	return
 }
 
 // BurnIn method implementation for nvmeStorage

--- a/src/control/server/storage_nvme_test.go
+++ b/src/control/server/storage_nvme_test.go
@@ -118,7 +118,7 @@ func (m *mockSpdkNvme) Update(pciAddr string, path string, slot int32) (
 	return m.initCtrlrs, m.initNss, m.updateRet
 }
 
-func (m *mockSpdkNvme) Cleanup() { return }
+func (m *mockSpdkNvme) Cleanup() {}
 
 func newMockSpdkNvme(
 	fwBefore string, fwAfter string, ctrlrs []Controller, nss []Namespace,
@@ -789,7 +789,6 @@ func TestUpdateNvme(t *testing.T) {
 			t, len(results), len(tt.expResults),
 			"unexpected number of response results, "+tt.desc)
 
-		successPciaddrs := []string{}
 		for i, result := range results {
 			AssertEqual(
 				t, result.State.Error, tt.expResults[i].State.Error,
@@ -800,10 +799,6 @@ func TestUpdateNvme(t *testing.T) {
 			AssertEqual(
 				t, result.Pciaddr, tt.expResults[i].Pciaddr,
 				"unexpected pciaddr, "+tt.desc)
-
-			if result.State.Status == pb.ResponseStatus_CTRL_SUCCESS {
-				successPciaddrs = append(successPciaddrs, result.Pciaddr)
-			}
 		}
 
 		// verify controller details have been updated

--- a/src/control/server/storage_scm.go
+++ b/src/control/server/storage_scm.go
@@ -180,8 +180,7 @@ func (s *scmStorage) reFormat(devPath string) (err error) {
 func (s *scmStorage) makeMount(
 	devPath string, mntPoint string, devType string, mntOpts string) (err error) {
 
-	var flags uintptr
-	flags = syscall.MS_NOATIME | syscall.MS_SILENT
+	flags := uintptr(syscall.MS_NOATIME | syscall.MS_SILENT)
 	flags |= syscall.MS_NODEV | syscall.MS_NOEXEC | syscall.MS_NOSUID
 
 	if err = s.config.ext.mkdir(mntPoint); err != nil {
@@ -312,7 +311,6 @@ func (s *scmStorage) Format(i int, results *([]*pb.ScmMountResult)) {
 
 	log.Debugf("SCM device reset, format and mount completed")
 	s.formatted = true
-	return
 }
 
 // Update is currently a placeholder method stubbing SCM module fw update.


### PR DESCRIPTION
golangci-lint used as that will be used in CI.
"composite literal uses unkeyed fields (govet)" warnings ignored.

Signed-off-by: Tom Nabarro <tom.nabarro@intel.com>