### PR TITLE
DAOS-2697 object: key enumerate should not invoke bulk if nothing to enumerate

### DIFF
--- a/src/object/srv_obj.c
+++ b/src/object/srv_obj.c
@@ -1201,7 +1201,7 @@ obj_enum_reply_bulk(crt_rpc_t *rpc)
 
 	oei = crt_req_get(rpc);
 	oeo = crt_reply_get(rpc);
-	if (oei->oei_kds_bulk) {
+	if (oei->oei_kds_bulk && oeo->oeo_kds.ca_count > 0) {
 		tmp_iov.iov_buf = oeo->oeo_kds.ca_arrays;
 		tmp_iov.iov_buf_len = oeo->oeo_kds.ca_count *
 				      sizeof(daos_key_desc_t);


### PR DESCRIPTION

If client specifies num of entries > 128, bulk is created in enumeration,
but when nothing is enumerated from server side, bulk is still invoked
causing error returned from CART. this patch checks for sgl len to not
invoke bulk if nothing is enumerated.

Signed-off-by: Mohamad Chaarawi <mohamad.chaarawi@intel.com>