### PR TITLE
DAOS-2702 bio: typo in bio_nvme_poll()

### DIFF
--- a/src/bio/bio_xstream.c
+++ b/src/bio/bio_xstream.c
@@ -331,7 +331,7 @@ bio_nvme_poll(struct bio_xs_context *ctxt)
 
 	/* Call all registered poller one by one */
 	d_list_for_each_entry(poller, &ctxt->bxc_pollers, bnp_link) {
-		if (poller->bnp_period_us != 0 && poller->bnp_expire_us < now)
+		if (poller->bnp_period_us != 0 && poller->bnp_expire_us > now)
 			continue;
 
 		poller->bnp_fn(poller->bnp_arg);


### PR DESCRIPTION
Typo in comparison of 'expire time' and 'now' can cause the poller
with non-zero 'period time' never being called.

Signed-off-by: Niu Yawei <yawei.niu@intel.com>
Change-Id: Ib6b6a5bb2f0387c2e7513bbb12c0e6d91e841d70