### PR TITLE
WIP refactoring for discussion

### DIFF
--- a/src/control/ioserver/config.go
+++ b/src/control/ioserver/config.go
@@ -58,9 +58,6 @@ type (
 	// and comprises command line arguments as well
 	// as environment variables
 	Config struct {
-		SystemName               string
-		ShouldReformatSuperblock bool
-
 		SettableOptions map[string]SettableOption
 
 		setCmdLineArgs   []*CmdLineArg

--- a/src/control/ioserver/config.go
+++ b/src/control/ioserver/config.go
@@ -1,0 +1,740 @@
+package ioserver
+
+import (
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+	"unicode"
+)
+
+type (
+	// ValidationError represents an error found while validating
+	// an option
+	ValidationError struct {
+		Option       string
+		ErrorMessage string
+	}
+
+	// SettableOption defines an interface to be implemented
+	// by types which resolve a configuration option to a
+	// command line argument or an environment variable
+	SettableOption interface {
+		Name() string
+		Set(...interface{}) error
+	}
+
+	setterFunc func(...interface{}) error
+
+	// CmdLineArg represents an option which resolves to a
+	// command line argument (switch or option) passed to
+	// an instance on start
+	CmdLineArg struct {
+		Description string
+		LongOption  string
+		ShortOption string
+		Value       string
+
+		optionName    string
+		isEnabledBool bool
+		validateFunc  func(*CmdLineArg) error
+		setterFunc    setterFunc
+	}
+
+	// EnvVar represents an option which resolves
+	// to an environment variable set in the instance's
+	// environment before starting
+	EnvVar struct {
+		Description string
+		Key         string
+		Value       string
+
+		optionName   string
+		validateFunc func(*EnvVar) error
+		setterFunc   setterFunc
+	}
+
+	// Config represents an instance's configuration
+	// and comprises command line arguments as well
+	// as environment variables
+	Config struct {
+		SystemName               string
+		ShouldReformatSuperblock bool
+
+		SettableOptions map[string]SettableOption
+
+		setCmdLineArgs   []*CmdLineArg
+		setEnvVars       []*EnvVar
+		availableOptions []SettableOption
+	}
+)
+
+// NewConfig returns an initialized *Config with all
+// available options defined but not set
+func NewConfig() *Config {
+	cfg := &Config{
+		SettableOptions: make(map[string]SettableOption),
+	}
+	cfg.availableOptions = []SettableOption{
+		&CmdLineArg{
+			optionName:  "storagePath",
+			Description: "SCM mount path",
+			LongOption:  "storage",
+			ShortOption: "s",
+			setterFunc: func(i ...interface{}) error {
+				arg, err := getSingleStringArg("storagePath", i...)
+				if err != nil {
+					return err
+				}
+				cfg.WithStoragePath(arg)
+				return nil
+			},
+		},
+		&CmdLineArg{
+			optionName:  "serverRank",
+			Description: "Server rank",
+			LongOption:  "rank",
+			ShortOption: "r",
+			setterFunc: func(i ...interface{}) error {
+				if len(i) == 1 {
+					if arg, ok := i[0].(uint32); ok {
+						cfg.WithRank(arg)
+						return nil
+					}
+				}
+				return vErr("serverRank", "invalid Set() arguments")
+			},
+		},
+		&CmdLineArg{
+			optionName:  "targetCount",
+			Description: "Number of targets to use",
+			LongOption:  "targets",
+			ShortOption: "t",
+			setterFunc: func(i ...interface{}) error {
+				arg, err := getSingleIntArg("targetCount", i...)
+				if err != nil {
+					return err
+				}
+				cfg.WithTargetCount(arg)
+				return nil
+			},
+		},
+		&CmdLineArg{
+			optionName:  "serviceThreadCore",
+			Description: "Index of core to be used for service thread",
+			LongOption:  "firstcore",
+			ShortOption: "f",
+			setterFunc: func(i ...interface{}) error {
+				arg, err := getSingleIntArg("serviceThreadCore", i...)
+				if err != nil {
+					return err
+				}
+				cfg.WithServiceThreadCore(arg)
+				return nil
+			},
+		},
+		&CmdLineArg{
+			optionName:  "xsHelperCount",
+			Description: "Number of XS helpers per VOS target",
+			LongOption:  "xshelpernr",
+			ShortOption: "x",
+			setterFunc: func(i ...interface{}) error {
+				arg, err := getSingleIntArg("xsHelperCount", i...)
+				if err != nil {
+					return err
+				}
+				cfg.WithXSHelperCount(arg)
+				return nil
+			},
+			validateFunc: func(arg *CmdLineArg) error {
+				if arg.Value != "0" && arg.Value != "2" {
+					return vErr("xsHelperCount", "must be either 0 or 2")
+				}
+				return nil
+			},
+		},
+		&CmdLineArg{
+			optionName:  "pathToNVMeConfig",
+			Description: "Path to NVMe configuration file",
+			LongOption:  "nvme",
+			ShortOption: "n",
+			setterFunc: func(i ...interface{}) error {
+				arg, err := getSingleStringArg("pathToNVMeConfig", i...)
+				if err != nil {
+					return err
+				}
+				cfg.WithPathToNVMeConfig(arg)
+				return nil
+			},
+			validateFunc: func(arg *CmdLineArg) error {
+				opt := "pathToNVMeConfig"
+				if arg.Value == "" {
+					return vErr(opt, "cannot be empty")
+				}
+				_, err := os.Stat(arg.Value)
+				if err != nil {
+					return vErr(opt, err.Error())
+				}
+				return nil
+			},
+		},
+		&CmdLineArg{
+			optionName:  "attachInfoPath",
+			Description: "Attach info path (non-PMIx clients)",
+			LongOption:  "attach_info",
+			ShortOption: "a",
+			setterFunc: func(i ...interface{}) error {
+				arg, err := getSingleStringArg("attachInfoPath", i...)
+				if err != nil {
+					return err
+				}
+				cfg.WithAttachInfoPath(arg)
+				return nil
+			},
+			validateFunc: func(arg *CmdLineArg) error {
+				opt := "attachInfoPath"
+				if arg.Value == "" {
+					return vErr(opt, "cannot be empty")
+				}
+				st, err := os.Stat(arg.Value)
+				if err != nil {
+					return vErr(opt, err.Error())
+				}
+				if !st.IsDir() {
+					return vErr(opt, "must be a valid directory")
+				}
+				return nil
+			},
+		},
+		&CmdLineArg{
+			optionName:  "serverModules",
+			Description: "Server modules to load",
+			LongOption:  "modules",
+			ShortOption: "m",
+			setterFunc: func(args ...interface{}) error {
+				stringArgs, err := toStringArgs("serverModules", args...)
+				if err != nil {
+					return err
+				}
+				cfg.WithModules(stringArgs...)
+				return nil
+			},
+		},
+		&CmdLineArg{
+			optionName:  "serverGroup",
+			Description: "Server group name",
+			LongOption:  "group",
+			ShortOption: "g",
+			setterFunc: func(i ...interface{}) error {
+				arg, err := getSingleStringArg("serverGroup", i...)
+				if err != nil {
+					return err
+				}
+				cfg.WithServerGroup(arg)
+				return nil
+			},
+		},
+		&CmdLineArg{
+			optionName:  "socketDir",
+			Description: "Directory for daos_io_server sockets",
+			LongOption:  "socket_dir",
+			ShortOption: "d",
+			setterFunc: func(i ...interface{}) error {
+				arg, err := getSingleStringArg("socketDir", i...)
+				if err != nil {
+					return err
+				}
+				cfg.WithSocketDir(arg)
+				return nil
+			},
+			validateFunc: func(arg *CmdLineArg) error {
+				opt := "socketDir"
+				if arg.Value == "" {
+					return vErr(opt, "cannot be empty")
+				}
+				st, err := os.Stat(arg.Value)
+				if err != nil {
+					return vErr(opt, err.Error())
+				}
+				if !st.IsDir() {
+					return vErr(opt, "must be a valid directory")
+				}
+				return nil
+			},
+		},
+		&CmdLineArg{
+			optionName:  "sharedSegmentID",
+			Description: "Shared segment ID for multiprocess mode in SPDK",
+			LongOption:  "shm_id",
+			ShortOption: "i",
+			setterFunc: func(i ...interface{}) error {
+				arg, err := getSingleIntArg("sharedSegmentID", i...)
+				if err != nil {
+					return err
+				}
+				cfg.WithSharedSegmentID(arg)
+				return nil
+			},
+		},
+		&EnvVar{
+			optionName:  "cartTimeout",
+			Description: "CaRT RPC Timeout",
+			Key:         "CRT_TIMEOUT",
+			setterFunc: func(i ...interface{}) error {
+				arg, err := getSingleIntArg("cartTimeout", i...)
+				if err != nil {
+					return err
+				}
+				cfg.WithCartTimeout(arg)
+				return nil
+			},
+		},
+		&EnvVar{
+			optionName:  "cartProvider",
+			Description: "CaRT provider",
+			Key:         "CRT_PHY_ADDR_STR",
+			setterFunc: func(i ...interface{}) error {
+				arg, err := getSingleStringArg("cartProvider", i...)
+				if err != nil {
+					return err
+				}
+				cfg.WithCartProvider(arg)
+				return nil
+			},
+		},
+		&EnvVar{
+			optionName:  "cartContextShareAddress",
+			Description: "CaRT context share address",
+			Key:         "CRT_CTX_SHARE_ADDR",
+			setterFunc: func(i ...interface{}) error {
+				arg, err := getSingleIntArg("cartContextShareAddress", i...)
+				if err != nil {
+					return err
+				}
+				cfg.WithCartContextShareAddress(arg)
+				return nil
+			},
+		},
+		&EnvVar{
+			optionName:  "fabricInterface",
+			Description: "OFI interface",
+			Key:         "OFI_INTERFACE",
+			setterFunc: func(i ...interface{}) error {
+				arg, err := getSingleStringArg("fabricInterface", i...)
+				if err != nil {
+					return err
+				}
+				cfg.WithFabricInterface(arg)
+				return nil
+			},
+		},
+		&EnvVar{
+			optionName: "debugSubsystems",
+			Key:        "DD_SUBSYS",
+			setterFunc: func(args ...interface{}) error {
+				stringArgs, err := toStringArgs("debugSubsystems", args...)
+				if err != nil {
+					return err
+				}
+				cfg.WithDebugSubsystems(stringArgs...)
+				return nil
+			},
+		},
+		&EnvVar{
+			optionName:  "logMask",
+			Description: "Log mask",
+			Key:         "D_LOG_MASK",
+			setterFunc: func(args ...interface{}) error {
+				stringArgs, err := toStringArgs("logMask", args...)
+				if err != nil {
+					return err
+				}
+				cfg.WithLogMask(stringArgs...)
+				return nil
+			},
+		},
+		&EnvVar{
+			optionName:  "logFile",
+			Description: "Path to log file",
+			Key:         "D_LOG_FILE",
+			setterFunc: func(i ...interface{}) error {
+				arg, err := getSingleStringArg("logFile", i...)
+				if err != nil {
+					return err
+				}
+				cfg.WithLogFile(arg)
+				return nil
+			},
+		},
+		&EnvVar{
+			optionName:  "metadataCap",
+			Description: "DAOS metadata cap",
+			Key:         "DAOS_MD_CAP",
+			setterFunc: func(i ...interface{}) error {
+				arg, err := getSingleIntArg("metadataCap", i...)
+				if err != nil {
+					return err
+				}
+				cfg.WithMetadataCap(arg)
+				return nil
+			},
+		},
+	}
+
+	// build up a map of name -> opt so that we don't
+	// have to define it by hand
+	for _, opt := range cfg.availableOptions {
+		cfg.SettableOptions[opt.Name()] = opt
+	}
+	return cfg
+}
+
+// WithRank sets the MPI rank
+func (cfg *Config) WithRank(rank uint32) *Config {
+	arg := cfg.getArg("serverRank")
+	arg.Value = strconv.Itoa(int(rank))
+	return cfg.updateArgument(arg)
+}
+
+// WithTargetCount sets the desired number of targets to use
+func (cfg *Config) WithTargetCount(numTargets int) *Config {
+	arg := cfg.getArg("targetCount")
+	arg.Value = strconv.Itoa(numTargets)
+	return cfg.updateArgument(arg)
+}
+
+// WithStoragePath sets the path to the SCM mountpoint
+func (cfg *Config) WithStoragePath(mountPoint string) *Config {
+	arg := cfg.getArg("storagePath")
+	arg.Value = mountPoint
+	return cfg.updateArgument(arg)
+}
+
+// WithServiceThreadCore sets the core to be used by the service thread
+func (cfg *Config) WithServiceThreadCore(idx int) *Config {
+	arg := cfg.getArg("serviceThreadCore")
+	arg.Value = strconv.Itoa(idx)
+	return cfg.updateArgument(arg)
+
+}
+
+// WithXSHelperCount sets the number of XS helpers per VOS target
+func (cfg *Config) WithXSHelperCount(numHelpers int) *Config {
+	arg := cfg.getArg("xsHelperCount")
+	arg.Value = strconv.Itoa(numHelpers)
+	return cfg.updateArgument(arg)
+}
+
+// WithModules sets the list of server modules to be loaded
+func (cfg *Config) WithModules(modList ...string) *Config {
+	arg := cfg.getArg("serverModules")
+	arg.Value = strings.Join(modList, ",")
+	return cfg.updateArgument(arg)
+}
+
+// WithServerGroup sets the DAOS server group identifier
+func (cfg *Config) WithServerGroup(groupName string) *Config {
+	arg := cfg.getArg("serverGroup")
+	arg.Value = groupName
+	return cfg.updateArgument(arg)
+}
+
+// WithSocketDir sets the path to the socket directory
+func (cfg *Config) WithSocketDir(socketDir string) *Config {
+	arg := cfg.getArg("socketDir")
+	arg.Value = socketDir
+	return cfg.updateArgument(arg)
+}
+
+// WithPathToNVMeConfig sets the path to the NVMe configuration
+// file to be used by SPDK
+func (cfg *Config) WithPathToNVMeConfig(cfgPath string) *Config {
+	arg := cfg.getArg("pathToNVMeConfig")
+	arg.Value = cfgPath
+	return cfg.updateArgument(arg)
+}
+
+// WithSharedSegmentID sets the NVMe shared segment ID
+func (cfg *Config) WithSharedSegmentID(id int) *Config {
+	arg := cfg.getArg("sharedSegmentID")
+	arg.Value = strconv.Itoa(id)
+	return cfg.updateArgument(arg)
+}
+
+// WithAttachInfoPath sets the path to the, um, attachInfo, whatever that is
+func (cfg *Config) WithAttachInfoPath(attachPath string) *Config {
+	arg := cfg.getArg("attachInfoPath")
+	arg.Value = attachPath
+	return cfg.updateArgument(arg)
+}
+
+// WithCartTimeout sets the timeout Value for CaRT RPCs
+func (cfg *Config) WithCartTimeout(timeout int) *Config {
+	ev := cfg.getEnv("cartTimeout")
+	ev.Value = strconv.Itoa(timeout)
+	return cfg.updateEnvironment(ev)
+}
+
+// WithCartProvider sets the CaRT provider string
+func (cfg *Config) WithCartProvider(provString string) *Config {
+	ev := cfg.getEnv("cartProvider")
+	ev.Value = provString
+	return cfg.updateEnvironment(ev)
+}
+
+// WithFabricInterface sets the fabric interface to be used by this instance
+func (cfg *Config) WithFabricInterface(ifaceString string) *Config {
+	ev := cfg.getEnv("fabricInterface")
+	ev.Value = ifaceString
+	return cfg.updateEnvironment(ev)
+}
+
+// WithLogMask sets the logging subsystem mask
+func (cfg *Config) WithLogMask(masks ...string) *Config {
+	ev := cfg.getEnv("logMask")
+	ev.Value = strings.Join(masks, ",")
+	return cfg.updateEnvironment(ev)
+}
+
+// WithLogFile sets the path to the log file
+func (cfg *Config) WithLogFile(logFile string) *Config {
+	ev := cfg.getEnv("logFile")
+	ev.Value = logFile
+	return cfg.updateEnvironment(ev)
+}
+
+// WithMetadataCap sets a cap on metadata or something
+func (cfg *Config) WithMetadataCap(cap int) *Config {
+	ev := cfg.getEnv("metadataCap")
+	ev.Value = strconv.Itoa(cap)
+	return cfg.updateEnvironment(ev)
+}
+
+// WithCartContextShareAddress sets this thing whatever it is
+func (cfg *Config) WithCartContextShareAddress(shareAddr int) *Config {
+	ev := cfg.getEnv("cartContextShareAddress")
+	ev.Value = strconv.Itoa(shareAddr)
+	return cfg.updateEnvironment(ev)
+}
+
+// WithDebugSubsystems sets this Value
+func (cfg *Config) WithDebugSubsystems(subsystems ...string) *Config {
+	ev := cfg.getEnv("debugSubsystems")
+	ev.Value = strings.Join(subsystems, ",")
+	return cfg.updateEnvironment(ev)
+}
+
+// CmdLineArgs validates all options which resolve to
+// command line arguments and returns them as a []string
+// suitable for use with an *exec.Cmd
+func (cfg *Config) CmdLineArgs() ([]string, error) {
+	args := make([]string, 0, len(cfg.setCmdLineArgs))
+
+	for _, arg := range cfg.setCmdLineArgs {
+		if arg.Value == "" && !arg.isEnabledBool {
+			return nil, vErr(arg.optionName, "cannot have an empty Value")
+		}
+		if hasWhiteSpace(arg.Value) {
+			return nil, vErr(arg.optionName, "cannot have whitespace in Value")
+		}
+		if arg.validateFunc != nil {
+			if err := arg.validateFunc(arg); err != nil {
+				return nil, err
+			}
+		}
+		args = append(args, arg.String())
+	}
+
+	return args, nil
+}
+
+// EnvVars validates all options which resolve to
+// environment variables and returns them as a []string
+// suitable for use with an *exec.Cmd
+func (cfg *Config) EnvVars() ([]string, error) {
+	vars := make([]string, 0, len(cfg.setEnvVars))
+
+	// TODO: validateFunc these as a set?
+	for _, ev := range cfg.setEnvVars {
+		if ev.validateFunc != nil {
+			if ev.Value == "" {
+				return nil, vErr(ev.optionName, "cannot have an empty Value")
+			}
+			if hasWhiteSpace(ev.Value) {
+				return nil, vErr(ev.optionName, "cannot have whitespace in Value")
+			}
+			if err := ev.validateFunc(ev); err != nil {
+				return nil, err
+			}
+		}
+		vars = append(vars, ev.String())
+	}
+
+	return vars, nil
+}
+
+// Set attempts to resolve the supplied option name to a SettableOption
+// and set the provided value
+func (cfg *Config) Set(optionName string, args ...interface{}) error {
+	if opt, found := cfg.SettableOptions[optionName]; found {
+		return opt.Set(args...)
+	}
+	return fmt.Errorf("%q is not a valid option", optionName)
+}
+
+// Get attempts to resolve the supplied option name to a SettableOption
+// and returns the set value
+func (cfg *Config) Get(optionName string) (string, error) {
+	if opt, found := cfg.SettableOptions[optionName]; found {
+		switch opt := opt.(type) {
+		case *CmdLineArg:
+			for _, setOpt := range cfg.setCmdLineArgs {
+				if setOpt.optionName == opt.optionName {
+					return setOpt.Value, nil
+				}
+			}
+			return "", fmt.Errorf("option %q was not set", optionName)
+		case *EnvVar:
+			for _, setOpt := range cfg.setEnvVars {
+				if setOpt.optionName == opt.optionName {
+					return setOpt.Value, nil
+				}
+			}
+			return "", fmt.Errorf("option %q was not set", optionName)
+		default:
+			return "", fmt.Errorf("unhandled option %q", optionName)
+		}
+	}
+	return "", fmt.Errorf("%q is not a valid option", optionName)
+}
+
+// Reset reverts the *Config to an unset state
+func (cfg *Config) Reset() {
+	cfg.setCmdLineArgs = nil
+	cfg.setEnvVars = nil
+}
+
+func (ve *ValidationError) Error() string {
+	return fmt.Sprintf("Config validation error: %s: %s", ve.Option, ve.ErrorMessage)
+}
+
+func vErr(option, message string) *ValidationError {
+	return &ValidationError{
+		Option:       option,
+		ErrorMessage: message,
+	}
+}
+
+func hasWhiteSpace(in string) bool {
+	for _, r := range in {
+		if unicode.IsSpace(r) {
+			return true
+		}
+	}
+	return false
+}
+
+func toStringArgs(optionName string, args ...interface{}) ([]string, error) {
+	stringArgs := make([]string, len(args))
+	for idx, val := range args {
+		if str, ok := val.(string); ok {
+			stringArgs[idx] = str
+			continue
+		}
+		return nil, vErr(optionName, "invalid input")
+	}
+	return stringArgs, nil
+}
+
+func getSingleStringArg(optionName string, i ...interface{}) (string, error) {
+	if len(i) == 1 {
+		if arg, ok := i[0].(string); ok {
+			return arg, nil
+		}
+	}
+	return "", vErr(optionName, "invalid input")
+}
+
+func getSingleIntArg(optionName string, i ...interface{}) (int, error) {
+	if len(i) == 1 {
+		if arg, ok := i[0].(int); ok {
+			return arg, nil
+		}
+	}
+	return 0, vErr(optionName, "invalid input")
+}
+
+// Name returns the configuration name
+func (ev *EnvVar) Name() string {
+	return ev.optionName
+}
+
+// Set sets the value
+func (ev *EnvVar) Set(args ...interface{}) error {
+	if ev.setterFunc == nil {
+		return fmt.Errorf("EnvVar %s has no setterFunc", ev.optionName)
+	}
+	return ev.setterFunc(args...)
+}
+
+func (ev *EnvVar) String() string {
+	return fmt.Sprintf("%s=%s", ev.Key, ev.Value)
+}
+
+// Name returns the configuration name
+func (arg *CmdLineArg) Name() string {
+	return arg.optionName
+}
+
+// Set sets the value
+func (arg *CmdLineArg) Set(args ...interface{}) error {
+	if arg.setterFunc == nil {
+		return fmt.Errorf("CmdLineArg %s has no setterFunc", arg.optionName)
+	}
+	return arg.setterFunc(args...)
+}
+
+func (arg *CmdLineArg) String() string {
+	if arg.isEnabledBool {
+		if arg.LongOption != "" {
+			return fmt.Sprintf("--%s", arg.LongOption)
+		}
+		return fmt.Sprintf("-%s", arg.ShortOption)
+	}
+	if arg.LongOption != "" {
+		return fmt.Sprintf("--%s=%s", arg.LongOption, arg.Value)
+	}
+	return fmt.Sprintf("-%s %s", arg.ShortOption, arg.Value)
+}
+
+func (cfg *Config) getArg(argName string) *CmdLineArg {
+	// NB: May panic if misused!
+	return cfg.SettableOptions[argName].(*CmdLineArg)
+}
+
+func (cfg *Config) getEnv(envName string) *EnvVar {
+	// NB: May panic if misused!
+	return cfg.SettableOptions[envName].(*EnvVar)
+}
+
+func (cfg *Config) updateEnvironment(newEnv *EnvVar) *Config {
+	for i, ev := range cfg.setEnvVars {
+		if ev.optionName == newEnv.optionName {
+			cfg.setEnvVars[i] = newEnv
+			return cfg
+		}
+	}
+	cfg.setEnvVars = append(cfg.setEnvVars, newEnv)
+	return cfg
+}
+
+func (cfg *Config) updateArgument(newArg *CmdLineArg) *Config {
+	for i, arg := range cfg.setCmdLineArgs {
+		if arg.optionName == newArg.optionName {
+			cfg.setCmdLineArgs[i] = newArg
+			return cfg
+		}
+	}
+	cfg.setCmdLineArgs = append(cfg.setCmdLineArgs, newArg)
+	return cfg
+}

--- a/src/control/ioserver/config_test.go
+++ b/src/control/ioserver/config_test.go
@@ -1,0 +1,237 @@
+package ioserver_test
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"reflect"
+	"testing"
+
+	"github.com/daos-stack/daos/src/control/ioserver"
+)
+
+func testArgExpected(t *testing.T, cfg *ioserver.Config, expected []string) {
+	t.Helper()
+	args, err := cfg.CmdLineArgs()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(args) != len(expected) {
+		t.Fatalf("Expected %v length to be %d, but it's %d", args, len(expected), len(args))
+	}
+	if !reflect.DeepEqual(args, expected) {
+		t.Fatalf("expected %v, got %v", expected, args)
+	}
+}
+
+func testStringArg(t *testing.T, cfg *ioserver.Config, name, expected, arg string) {
+	t.Helper()
+	if err := cfg.Set(name, arg); err != nil {
+		t.Fatal(err)
+	}
+	testArgExpected(t, cfg, []string{expected})
+	cfg.Reset()
+}
+
+func testIntArg(t *testing.T, cfg *ioserver.Config, name, expected string, arg int) {
+	t.Helper()
+	if err := cfg.Set(name, arg); err != nil {
+		t.Fatal(err)
+	}
+	testArgExpected(t, cfg, []string{expected})
+	cfg.Reset()
+}
+
+func testEnvExpected(t *testing.T, cfg *ioserver.Config, expected []string) {
+	t.Helper()
+	env, err := cfg.EnvVars()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(env) != len(expected) {
+		t.Fatalf("Expected %v length to be %d, but it's %d", env, len(expected), len(env))
+	}
+	if !reflect.DeepEqual(env, expected) {
+		t.Fatalf("expected %v, got %v", expected, env)
+	}
+}
+
+func testStringEnv(t *testing.T, cfg *ioserver.Config, key, expected, arg string) {
+	t.Helper()
+	if err := cfg.Set(key, arg); err != nil {
+		t.Fatal(err)
+	}
+	testEnvExpected(t, cfg, []string{expected})
+	cfg.Reset()
+}
+
+func testIntEnv(t *testing.T, cfg *ioserver.Config, key, expected string, arg int) {
+	t.Helper()
+	if err := cfg.Set(key, arg); err != nil {
+		t.Fatal(err)
+	}
+	testEnvExpected(t, cfg, []string{expected})
+	cfg.Reset()
+}
+
+// TestSetters verifies that there is a test for every settable option
+// TODO: Run each option as a subtest? Maybe just for the ones with
+// custom validators?
+func TestSetters(t *testing.T) {
+	cfg := ioserver.NewConfig()
+	for name, opt := range cfg.SettableOptions {
+		switch opt := opt.(type) {
+		case *ioserver.CmdLineArg:
+			switch name {
+			case "storagePath":
+				testVal := "/mnt/foo/bar"
+				expected := fmt.Sprintf("--%s=%s", opt.LongOption, testVal)
+				testStringArg(t, cfg, name, expected, testVal)
+			case "serverGroup":
+				testVal := "super_daos_server"
+				expected := fmt.Sprintf("--%s=%s", opt.LongOption, testVal)
+				testStringArg(t, cfg, name, expected, testVal)
+			case "socketDir":
+				testDir, err := ioutil.TempDir("", fmt.Sprintf("%s-*-socketDir", t.Name()))
+				if err != nil {
+					t.Fatal(err)
+				}
+				defer os.RemoveAll(testDir)
+				expected := fmt.Sprintf("--%s=%s", opt.LongOption, testDir)
+				testStringArg(t, cfg, name, expected, testDir)
+			case "sharedSegmentID":
+				testVal := 12345
+				expected := fmt.Sprintf("--%s=%d", opt.LongOption, testVal)
+				testIntArg(t, cfg, name, expected, testVal)
+			case "targetCount":
+				testVal := 42
+				expected := fmt.Sprintf("--%s=%d", opt.LongOption, testVal)
+				testIntArg(t, cfg, name, expected, testVal)
+			case "serviceThreadCore":
+				testVal := 3
+				expected := fmt.Sprintf("--%s=%d", opt.LongOption, testVal)
+				testIntArg(t, cfg, name, expected, testVal)
+			case "xsHelperCount":
+				testVal := 2
+				expected := fmt.Sprintf("--%s=%d", opt.LongOption, testVal)
+				testIntArg(t, cfg, name, expected, testVal)
+			case "pathToNVMeConfig":
+				testFile, err := ioutil.TempFile("", fmt.Sprintf("%s-*-pathToNVMeConfig", t.Name()))
+				if err != nil {
+					t.Fatal(err)
+				}
+				defer os.Remove(testFile.Name())
+				expected := fmt.Sprintf("--%s=%s", opt.LongOption, testFile.Name())
+				testStringArg(t, cfg, name, expected, testFile.Name())
+			case "attachInfoPath":
+				testDir, err := ioutil.TempDir("", fmt.Sprintf("%s-*-attachInfoPath", t.Name()))
+				if err != nil {
+					t.Fatal(err)
+				}
+				defer os.RemoveAll(testDir)
+				expected := fmt.Sprintf("--%s=%s", opt.LongOption, testDir)
+				testStringArg(t, cfg, name, expected, testDir)
+			case "serverModules":
+				// simple case
+				testVal := "foo,bar,baz"
+				expected := fmt.Sprintf("--%s=%s", opt.LongOption, testVal)
+				testStringArg(t, cfg, name, expected, testVal)
+
+				// variadic args
+				if err := cfg.Set(name, "foo", "bar", "baz"); err != nil {
+					t.Fatal(err)
+				}
+				testArgExpected(t, cfg, []string{expected})
+				cfg.Reset()
+			case "serverRank":
+				rank := uint32(128)
+				expected := fmt.Sprintf("--%s=%d", opt.LongOption, rank)
+				if err := cfg.Set(name, rank); err != nil {
+					t.Fatal(err)
+				}
+				testArgExpected(t, cfg, []string{expected})
+				cfg.Reset()
+			default:
+				t.Fatalf("Untested option: %s", name)
+			}
+		case *ioserver.EnvVar:
+			switch name {
+			case "metadataCap":
+				testVal := 1024
+				expected := fmt.Sprintf("%s=%d", opt.Key, testVal)
+				testIntEnv(t, cfg, name, expected, testVal)
+			case "fabricInterface":
+				testVal := "eth1000"
+				expected := fmt.Sprintf("%s=%s", opt.Key, testVal)
+				testStringEnv(t, cfg, name, expected, testVal)
+			case "cartTimeout":
+				testVal := 30
+				expected := fmt.Sprintf("%s=%d", opt.Key, testVal)
+				testIntEnv(t, cfg, name, expected, testVal)
+			case "cartProvider":
+				testVal := "foo+bar"
+				expected := fmt.Sprintf("%s=%s", opt.Key, testVal)
+				testStringEnv(t, cfg, name, expected, testVal)
+			case "cartContextShareAddress":
+				testVal := 11
+				expected := fmt.Sprintf("%s=%d", opt.Key, testVal)
+				testIntEnv(t, cfg, name, expected, testVal)
+			case "logFile":
+				testVal := "/path/to/logfile"
+				expected := fmt.Sprintf("%s=%s", opt.Key, testVal)
+				testStringEnv(t, cfg, name, expected, testVal)
+			case "logMask":
+				// simple case
+				testVal := "oink,moo=err,squeak"
+				expected := fmt.Sprintf("%s=%s", opt.Key, testVal)
+				testStringEnv(t, cfg, name, expected, testVal)
+
+				// variadic args
+				if err := cfg.Set(name, "oink", "moo=err", "squeak"); err != nil {
+					t.Fatal(err)
+				}
+				testEnvExpected(t, cfg, []string{expected})
+				cfg.Reset()
+			case "debugSubsystems":
+				// simple case
+				testVal := "bip,blorp,nom"
+				expected := fmt.Sprintf("%s=%s", opt.Key, testVal)
+				testStringEnv(t, cfg, name, expected, testVal)
+
+				// variadic args
+				if err := cfg.Set(name, "bip", "blorp", "nom"); err != nil {
+					t.Fatal(err)
+				}
+				testEnvExpected(t, cfg, []string{expected})
+				cfg.Reset()
+			default:
+				t.Fatalf("Untested option: %s", name)
+			}
+		default:
+			t.Fatalf("Untested option: %s", name)
+		}
+	}
+}
+
+func TestMultiple(t *testing.T) {
+	cfg := ioserver.NewConfig()
+
+	if err := cfg.Set("debugSubsystems", "cow,dog,cat"); err != nil {
+		t.Fatal(err)
+	}
+	if err := cfg.Set("serviceThreadCore", 11); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg.WithFabricInterface("realFast0")
+	cfg.WithTargetCount(42)
+
+	testEnvExpected(t, cfg, []string{
+		"DD_SUBSYS=cow,dog,cat",
+		"OFI_INTERFACE=realFast0",
+	})
+	testArgExpected(t, cfg, []string{
+		"--firstcore=11",
+		"--targets=42",
+	})
+}

--- a/src/control/ioserver/exec.go
+++ b/src/control/ioserver/exec.go
@@ -1,0 +1,39 @@
+// +build linux
+
+package ioserver
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"syscall"
+
+	"github.com/pkg/errors"
+
+	"github.com/daos-stack/daos/src/control/log"
+)
+
+const binaryName = "daos_io_server"
+
+func (srv *Instance) run(ctx context.Context, args, env []string) error {
+	binaryPath, err := exec.LookPath(binaryName)
+	if err != nil {
+		return errors.Wrapf(err, "Unable to find %s in path", binaryName)
+	}
+
+	cmd := exec.CommandContext(ctx, binaryPath, args...)
+	// TODO: Configure stdout/stderr to log
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	cmd.Env = env
+
+	// I/O server should get a SIGKILL if this process dies.
+	cmd.SysProcAttr = &syscall.SysProcAttr{
+		Pdeathsig: syscall.SIGKILL,
+	}
+
+	log.Debugf("Starting instance: %s %s", binaryPath, args)
+	log.Debugf("Env: %s", env)
+	//signal.Notify(srv.sigchld, syscall.SIGCHLD)
+	return errors.Wrapf(cmd.Run(), "%s exited", binaryPath)
+}

--- a/src/control/ioserver/instance.go
+++ b/src/control/ioserver/instance.go
@@ -1,0 +1,40 @@
+package ioserver
+
+import (
+	"context"
+)
+
+// Instance is an instance of a DAOS IO Server
+type Instance struct {
+	cfg *Config
+}
+
+// NewInstance returns a configured ioserver.Instance
+func NewInstance(config *Config) *Instance {
+	return &Instance{
+		cfg: config,
+	}
+}
+
+// Start asynchronously starts the IOServer instance
+// and reports any errors on the output channel
+func (srv *Instance) Start(ctx context.Context, errOut chan<- error) error {
+	args, err := srv.cfg.CmdLineArgs()
+	if err != nil {
+		return err
+	}
+	env, err := srv.cfg.EnvVars()
+	if err != nil {
+		return err
+	}
+
+	go func() {
+		errOut <- srv.run(ctx, args, env)
+	}()
+
+	return nil
+}
+
+func (srv *Instance) Shutdown(ctx context.Context) error {
+	return nil
+}

--- a/src/control/server/drpc.go
+++ b/src/control/server/drpc.go
@@ -45,7 +45,7 @@ func getDrpcClientConnection(sockDir string) *drpc.ClientConnection {
 
 // drpcSetup creates socket directory, specifies socket path and then
 // starts drpc server.
-func drpcSetup(sockDir string, iosrv *iosrv) error {
+func drpcSetup(sockDir string, iosrv *IOServerHarness) error {
 	// Create our socket directory if it doesn't exist
 	_, err := os.Stat(sockDir)
 	if err != nil && os.IsPermission(err) {

--- a/src/control/server/harness.go
+++ b/src/control/server/harness.go
@@ -1,0 +1,113 @@
+package main
+
+import (
+	"context"
+	"os"
+	"time"
+
+	srvpb "github.com/daos-stack/daos/src/control/common/proto/srv"
+	"github.com/daos-stack/daos/src/control/ioserver"
+	"github.com/pkg/errors"
+)
+
+type managedInstance struct {
+	cfg                      *ioserver.Config
+	instance                 *ioserver.Instance
+	superblock               *Superblock
+	shouldReformatSuperblock bool
+	fsRoot                   string
+}
+
+func (mi *managedInstance) Setup() (err error) {
+	mi.superblock, err = mi.ReadSuperblock()
+	if err == nil && !mi.shouldReformatSuperblock {
+		return nil
+	}
+
+	if !os.IsNotExist(errors.Cause(err)) {
+		if !mi.shouldReformatSuperblock {
+			return errors.Wrap(err, "Failed to read existing superblock and reformat is false")
+		}
+	}
+
+	if err := mi.CreateSuperblock(); err != nil {
+		return errors.Wrap(err, "Setup failed to format superblock")
+	}
+
+	mi.superblock, err = mi.ReadSuperblock()
+	return errors.Wrap(err, "Setup failed to read superblock after (re)-format")
+}
+
+func (mi *managedInstance) Start(ctx context.Context, errChan chan<- error) error {
+	return mi.instance.Start(ctx, errChan)
+}
+
+func (mi *managedInstance) Shutdown(ctx context.Context) error {
+	return mi.instance.Shutdown(ctx)
+}
+
+// IOServerHarness is responsible for managing IOServer instances
+type IOServerHarness struct {
+	instances []*managedInstance
+}
+
+// NewHarness returns an initialized *IOServerHarness
+func NewIOServerHarness() *IOServerHarness {
+	return &IOServerHarness{
+		instances: make([]*managedInstance, 0, 2),
+	}
+}
+
+// SetReady indicates that the harness should proceed
+func (h *IOServerHarness) SetReady(r *srvpb.NotifyReadyReq) {
+	// NOOP for now
+	// FIXME: How should this interact with multiple instances?
+	// FIXME: Should probably not be mixing protobuffer stuff in here
+}
+
+// AddInstance adds a new IOServer instance to be managed
+func (h *IOServerHarness) AddInstance(cfg *ioserver.Config) {
+	mi := &managedInstance{
+		cfg:      cfg,
+		instance: ioserver.NewInstance(cfg),
+	}
+	h.instances = append(h.instances, mi)
+}
+
+// StartInstances starts each of the configured instances and waits for
+// them to exit.
+func (h *IOServerHarness) StartInstances(parent context.Context) error {
+	errChan := make(chan error, len(h.instances))
+	for _, instance := range h.instances {
+		if err := instance.Setup(); err != nil {
+			return errors.Wrap(err, "Failed to setup instance")
+		}
+		if err := instance.Start(parent, errChan); err != nil {
+			return err
+		}
+	}
+
+	shutdown := func() {
+		for _, instance := range h.instances {
+			ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+			if err := instance.Shutdown(ctx); err != nil {
+				// TODO: Log shutdown error
+			}
+			defer cancel()
+		}
+	}
+
+	for {
+		select {
+		case <-parent.Done():
+			shutdown()
+			return nil
+		case err := <-errChan:
+			// If we receive an error from any instance, shut them all down
+			if err != nil {
+				shutdown()
+				return errors.Wrap(err, "Instance error")
+			}
+		}
+	}
+}

--- a/src/control/server/mgmt.go
+++ b/src/control/server/mgmt.go
@@ -110,11 +110,11 @@ func awaitStorageFormat(config *configuration) error {
 			<-srv.formatted
 		}
 
-		if err := dropPrivileges(config); err != nil {
+		/*if err := dropPrivileges(config); err != nil {
 			log.Errorf(
 				"Failed to drop privileges: %s, running as root "+
 					"is dangerous and is not advised!", err)
-		}
+		}*/
 
 		return nil
 	}

--- a/src/control/server/mgmt_drpc.go
+++ b/src/control/server/mgmt_drpc.go
@@ -69,7 +69,7 @@ func (m *mgmtModule) ID() int32 {
 // srvModule represents the daos_server dRPC module. It handles dRPCs sent by
 // the daos_io_server iosrv module (src/iosrv).
 type srvModule struct {
-	iosrv *iosrv
+	iosrv *IOServerHarness
 }
 
 // HandleCall is the handler for calls to the srvModule
@@ -94,7 +94,7 @@ func (mod *srvModule) handleNotifyReady(reqb []byte) error {
 		return errors.Wrap(err, "unmarshal NotifyReady request")
 	}
 
-	mod.iosrv.ready <- req
+	mod.iosrv.SetReady(req)
 
 	return nil
 }

--- a/src/control/server/superblock.go
+++ b/src/control/server/superblock.go
@@ -1,0 +1,103 @@
+package main
+
+import (
+	"io/ioutil"
+	"path/filepath"
+
+	"github.com/daos-stack/daos/src/control/common"
+	"github.com/pkg/errors"
+	uuid "github.com/satori/go.uuid"
+	"gopkg.in/yaml.v2"
+)
+
+const (
+	defaultStoragePath = "/mnt/daos"
+	defaultGroupName   = "daos_io_server"
+	superblockVersion  = 0
+)
+
+// Superblock is the per-Instance superblock
+type Superblock struct {
+	Version uint8
+	UUID    string
+	System  string
+	Rank    string
+}
+
+// TODO: Marshal/Unmarshal using a binary representation?
+
+// Marshal transforms the Superblock into a storable representation
+func (sb *Superblock) Marshal() ([]byte, error) {
+	data, err := yaml.Marshal(sb)
+	if err != nil {
+		return nil, errors.Wrapf(err, "Failed to marshal %+v", sb)
+	}
+	return data, nil
+}
+
+// Unmarshal reconstitutes a Superblock from a Marshaled representation
+func (sb *Superblock) Unmarshal(raw []byte) error {
+	return yaml.Unmarshal(raw, sb)
+}
+
+func (mi *managedInstance) superblockPath() string {
+	storagePath, err := mi.cfg.Get("storagePath")
+	if err != nil {
+		storagePath = defaultStoragePath
+	}
+	return filepath.Join(mi.fsRoot, storagePath, "superblock")
+}
+
+// CreateSuperblock creates the superblock for this Instance
+func (mi *managedInstance) CreateSuperblock() error {
+	u, err := uuid.NewV4()
+	if err != nil {
+		return errors.Wrap(err, "Failed to generate instance UUID")
+	}
+
+	systemName, err := mi.cfg.Get("serverGroup")
+	if err != nil {
+		systemName = defaultGroupName
+	}
+	rank, err := mi.cfg.Get("serverRank")
+	if err != nil {
+		rank = nilRank.String()
+	}
+
+	mi.superblock = &Superblock{
+		Version: superblockVersion,
+		UUID:    u.String(),
+		System:  systemName,
+		Rank:    rank,
+	}
+
+	return mi.WriteSuperblock(mi.superblock)
+}
+
+// WriteSuperblock writes the server's Superblock
+func (mi *managedInstance) WriteSuperblock(sb *Superblock) error {
+	sbPath := mi.superblockPath()
+	data, err := sb.Marshal()
+	if err != nil {
+		return err
+	}
+
+	return errors.Wrapf(common.WriteFileAtomic(sbPath, data, 0600),
+		"Failed to write Superblock to %s", sbPath)
+}
+
+// ReadSuperblock attempts to read the server's Superblock
+func (mi *managedInstance) ReadSuperblock() (*Superblock, error) {
+	sbPath := mi.superblockPath()
+	data, err := ioutil.ReadFile(sbPath)
+	if err != nil {
+		return nil, errors.Wrapf(err, "Failed to read Superblock from %s", sbPath)
+	}
+
+	sb := &Superblock{}
+	if err := sb.Unmarshal(data); err != nil {
+		return nil, err
+	}
+
+	return sb, nil
+}

--- a/src/control/server/superblock_test.go
+++ b/src/control/server/superblock_test.go
@@ -1,0 +1,47 @@
+package main
+
+import (
+	"io/ioutil"
+	"os"
+	"path"
+	"strconv"
+	"testing"
+
+	. "github.com/daos-stack/daos/src/control/common"
+	"github.com/daos-stack/daos/src/control/ioserver"
+)
+
+// Quick test to demonstrate writing/reading superblock in a temp dir
+// in order to avoid mocking OS calls
+func TestSuperblock(t *testing.T) {
+	testDir, err := ioutil.TempDir("", "TestSuperblock-*")
+	defer os.RemoveAll(testDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	storagePath := "/mnt/daos-test"
+	if err := os.MkdirAll(path.Join(testDir, storagePath), 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	rank := 42
+	systemName := "testSystem"
+	testInstance := &managedInstance{
+		cfg: ioserver.NewConfig().
+			WithStoragePath(storagePath).
+			WithServerGroup(systemName).
+			WithRank(uint32(rank)),
+		fsRoot: testDir,
+	}
+	if err := testInstance.CreateSuperblock(); err != nil {
+		t.Fatal(err)
+	}
+
+	sb, err := testInstance.ReadSuperblock()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	AssertEqual(t, sb.Rank, strconv.Itoa(rank), "superblock rank")
+	AssertEqual(t, sb.System, systemName, "superblock system")
+}


### PR DESCRIPTION
Pushing this for early feedback on the overall approach. It works enough to start a simple instance.

The first commit creates a new ioserver package and a configuration facility that enables the instances to be configured using human-friendly options with type safety and validation. The long term goal here would be to allow configuration of daos_io_server instances as a user via config file or as a programmer via API without needing to know about all of the command line arguments and environment variables. The existing yaml configuration mechanism could be modified to use the friendly options instead.

Futher context on the proposed config update: https://wiki.hpdd.intel.com/display/~mjmac/DAOS+IOServer+Configuration+updates

The second commit begins to deconflate daos_server and daos_io_server by using the new configuration facility introduced in the first commit. It also begins to explore some ideas for reorganizing daos_server code into smaller chunks which are easier to modify and test in isolation.