### PR TITLE
DAOS-2379 object: enable disable dtx

### DIFF
--- a/src/object/cli_mod.c
+++ b/src/object/cli_mod.c
@@ -32,7 +32,7 @@
 #include "obj_rpc.h"
 #include "obj_internal.h"
 
-bool	srv_io_dispatch = true;
+unsigned int	srv_io_mode = DIM_DTX_FULL_ENABLED;
 
 /**
  * Initialize object interface
@@ -40,15 +40,16 @@ bool	srv_io_dispatch = true;
 int
 dc_obj_init(void)
 {
-	uint32_t	mode = DIM_DTX_FULL_ENABLED;
-	int		rc;
+	int rc;
 
-	d_getenv_int("DAOS_IO_MODE", &mode);
-	if (mode == DIM_CLIENT_DISPATCH) {
-		srv_io_dispatch = false;
-		D_DEBUG(DB_IO, "Server IO dispatch disabled.\n");
+	d_getenv_int("DAOS_IO_MODE", &srv_io_mode);
+	if (srv_io_mode == DIM_CLIENT_DISPATCH) {
+		D_DEBUG(DB_IO, "Client dispatch.\n");
+	} else if (srv_io_mode == DIM_SERVER_DISPATCH) {
+		D_DEBUG(DB_IO, "Server dispatch but without dtx.\n");
 	} else {
-		D_DEBUG(DB_IO, "Server IO dispatch enabled.\n");
+		srv_io_mode = DIM_DTX_FULL_ENABLED;
+		D_DEBUG(DB_IO, "Full dtx mode by default\n");
 	}
 
 	rc = daos_rpc_register(&obj_proto_fmt, OBJ_PROTO_CLI_COUNT,

--- a/src/object/cli_shard.c
+++ b/src/object/cli_shard.c
@@ -297,7 +297,8 @@ dc_obj_shard_rw(struct dc_obj_shard *shard, enum obj_rpc_opc opc,
 					  DAOS_FAIL_ONCE);
 		}
 	}
-	if (DAOS_FAIL_CHECK(DAOS_OBJ_TGT_IDX_CHANGE) && !srv_io_dispatch) {
+	if (DAOS_FAIL_CHECK(DAOS_OBJ_TGT_IDX_CHANGE) &&
+	    srv_io_mode == DIM_CLIENT_DISPATCH) {
 		/* to trigger retry on all other shards */
 		if (args->auxi.shard != daos_fail_value_get()) {
 			D_INFO("complete shard %d update as -DER_TIMEDOUT.\n",

--- a/src/object/obj_internal.h
+++ b/src/object/obj_internal.h
@@ -61,8 +61,7 @@
  */
 extern bool	cli_bypass_rpc;
 /** Switch of server-side IO dispatch */
-extern bool	srv_io_dispatch;
-extern bool	srv_enable_dtx;
+extern unsigned int	srv_io_mode;
 
 /** client object shard */
 struct dc_obj_shard {

--- a/src/object/obj_rpc.h
+++ b/src/object/obj_rpc.h
@@ -114,8 +114,6 @@ enum obj_rpc_flags {
 	ORF_BULK_BIND		= (1 << 0),
 	/** It is a resent RPC. */
 	ORF_RESEND		= (1 << 1),
-	/** Disable DTX or not. */
-	ORF_DTX_DISABLED	= (1 << 3),
 };
 
 /* common for update/fetch */

--- a/src/object/srv_mod.c
+++ b/src/object/srv_mod.c
@@ -35,21 +35,10 @@
 /**
  * Swtich of enable DTX or not, enabled by default.
  */
-bool srv_enable_dtx = true;
-
 static int
 obj_mod_init(void)
 {
-	uint32_t	mode = DIM_DTX_FULL_ENABLED;
-	int		rc;
-
-	d_getenv_int("DAOS_IO_MODE", &mode);
-	if (mode != DIM_DTX_FULL_ENABLED) {
-		srv_enable_dtx = false;
-		D_DEBUG(DB_IO, "DTX is disabled.\n");
-	} else {
-		D_DEBUG(DB_IO, "DTX is enabled.\n");
-	}
+	int	rc;
 
 	rc = obj_ec_codec_init();
 	if (rc != 0)

--- a/src/object/srv_obj.c
+++ b/src/object/srv_obj.c
@@ -626,6 +626,11 @@ obj_local_rw(crt_rpc_t *rpc, struct ds_cont_hdl *cont_hdl,
 	bool			bulk_bind;
 	int			rc, err;
 
+	if (daos_is_zero_dti(&orw->orw_dti)) {
+		D_DEBUG(DB_TRACE, "disable dtx\n");
+		dth = NULL;
+	}
+
 	if (daos_oc_echo_type(daos_obj_id2class(orw->orw_oid.id_pub)) ||
 	    (daos_io_bypass & IOBP_TARGET)) {
 		ds_obj_rw_echo_handler(rpc);
@@ -711,32 +716,11 @@ out:
 	return rc;
 }
 
-static int
-ds_obj_check_dtx_config(uint32_t opc, uint32_t flags, struct dtx_id *dti)
-{
-	if (obj_is_tgt_modification_opc(opc)) {
-		if (((flags & ORF_DTX_DISABLED) == 0) != srv_enable_dtx) {
-			D_ERROR("Inconsistent DTX configuration among "
-				"servers.\n");
-			return -DER_PROTO;
-		}
-	} else {
-		if (daos_is_zero_dti(dti) && srv_enable_dtx) {
-			D_ERROR("Inconsistent DTX configuration between "
-				"client and server.\n");
-			return -DER_PROTO;
-		}
-	}
-
-	return 0;
-}
-
 /* Various check before access VOS */
 static int
 ds_pre_check(daos_unit_oid_t oid, uint32_t rpc_map_ver, uuid_t pool_uuid,
-	     uuid_t hdl_uuid, uuid_t co_uuid, uint32_t opc, uint32_t flags,
-	     struct dtx_id *dti, struct ds_cont_hdl **hdlp,
-	     struct ds_cont_child **contp)
+	     uuid_t hdl_uuid, uuid_t co_uuid, uint32_t opc,
+	     struct ds_cont_hdl **hdlp, struct ds_cont_child **contp)
 {
 	uint32_t	map_ver;
 	int		rc;
@@ -790,14 +774,6 @@ ds_pre_check(daos_unit_oid_t oid, uint32_t rpc_map_ver, uuid_t pool_uuid,
 		/* It is harmless if fetch with old pool map version. */
 	}
 
-	/* Check DTX configuration. */
-	if (obj_is_modification_opc(opc) &&
-	    !daos_oc_echo_type(daos_obj_id2class(oid.id_pub))) {
-		rc = ds_obj_check_dtx_config(opc, flags, dti);
-		if (rc != 0)
-			D_GOTO(out_put, rc);
-	}
-
 out_put:
 	if (rc) {
 		if (*contp != NULL) {
@@ -821,6 +797,7 @@ ds_obj_tgt_update_handler(crt_rpc_t *rpc)
 	struct ds_cont_hdl		*cont_hdl = NULL;
 	struct ds_cont_child		*cont = NULL;
 	struct dtx_handle		dth = { 0 };
+	struct dtx_handle		*handle = &dth;
 	struct dtx_conflict_entry	 conflict = { 0 };
 	uint32_t			 map_ver = 0;
 	int				 rc;
@@ -830,8 +807,7 @@ ds_obj_tgt_update_handler(crt_rpc_t *rpc)
 
 	rc = ds_pre_check(orw->orw_oid, orw->orw_map_ver, orw->orw_pool_uuid,
 			  orw->orw_co_hdl, orw->orw_co_uuid,
-			  opc_get(rpc->cr_opc), orw->orw_flags, &orw->orw_dti,
-			  &cont_hdl, &cont);
+			  opc_get(rpc->cr_opc), &cont_hdl, &cont);
 	if (rc)
 		goto out;
 
@@ -855,22 +831,17 @@ ds_obj_tgt_update_handler(crt_rpc_t *rpc)
 			D_GOTO(out, rc = 0);
 	}
 
-	/**
-	 * XXX we should use different api for local dtx, will fix in the
-	 * following patch.
-	 **/
 	rc = dtx_begin(&orw->orw_dti, &orw->orw_oid, cont->sc_hdl,
 		       orw->orw_epoch, orw->orw_dkey_hash,
 		       &conflict, orw->orw_dti_cos.ca_arrays,
 		       orw->orw_dti_cos.ca_count, orw->orw_map_ver,
-		       DAOS_INTENT_UPDATE, &dth);
+		       DAOS_INTENT_UPDATE, handle);
 	if (rc != 0) {
 		D_ERROR(DF_UOID": Failed to start DTX for update %d.\n",
 			DP_UOID(orw->orw_oid), rc);
 		D_GOTO(out, rc);
 	}
-
-	rc = obj_local_rw(rpc, cont_hdl, cont, &dth);
+	rc = obj_local_rw(rpc, cont_hdl, cont, handle);
 	if (rc != 0) {
 		D_ERROR(DF_UOID": rw_local (update) failed %d.\n",
 			DP_UOID(orw->orw_oid), rc);
@@ -878,7 +849,7 @@ ds_obj_tgt_update_handler(crt_rpc_t *rpc)
 	}
 
 out:
-	rc = dtx_end(&dth, cont_hdl, cont, rc);
+	rc = dtx_end(handle, cont_hdl, cont, rc);
 	ds_obj_rw_reply(rpc, rc, map_ver, &conflict);
 
 	if (cont_hdl)
@@ -933,8 +904,7 @@ ds_obj_rw_handler(crt_rpc_t *rpc)
 
 	rc = ds_pre_check(orw->orw_oid, orw->orw_map_ver, orw->orw_pool_uuid,
 			  orw->orw_co_hdl, orw->orw_co_uuid,
-			  opc_get(rpc->cr_opc), orw->orw_flags, &orw->orw_dti,
-			  &cont_hdl, &cont);
+			  opc_get(rpc->cr_opc), &cont_hdl, &cont);
 	if (rc)
 		goto out;
 
@@ -1079,8 +1049,8 @@ ds_iter_vos(crt_rpc_t *rpc, struct vos_iter_anchors *anchors,
 	bool			recursive = false;
 
 	rc = ds_pre_check(oei->oei_oid, oei->oei_map_ver, oei->oei_pool_uuid,
-			  oei->oei_co_hdl, oei->oei_co_uuid, opc, 0, NULL,
-			  &cont_hdl, &cont);
+			  oei->oei_co_hdl, oei->oei_co_uuid, opc, &cont_hdl,
+			  &cont);
 	if (rc)
 		D_GOTO(out, rc);
 
@@ -1351,6 +1321,11 @@ obj_local_punch(struct obj_punch_in *opi, crt_opcode_t opc,
 {
 	int	rc = 0;
 
+	if (daos_is_zero_dti(&opi->opi_dti)) {
+		D_DEBUG(DB_TRACE, "disable dtx\n");
+		dth = NULL;
+	}
+
 	switch (opc) {
 	case DAOS_OBJ_RPC_PUNCH:
 	case DAOS_OBJ_RPC_TGT_PUNCH:
@@ -1390,6 +1365,7 @@ ds_obj_tgt_punch_handler(crt_rpc_t *rpc)
 	struct ds_cont_hdl		*cont_hdl = NULL;
 	struct ds_cont_child		*cont = NULL;
 	struct dtx_handle		dth = { 0 };
+	struct dtx_handle		*handle = &dth;
 	struct dtx_conflict_entry	 conflict = { 0 };
 	struct obj_punch_in		*opi;
 	uint32_t			 map_version = 0;
@@ -1399,8 +1375,7 @@ ds_obj_tgt_punch_handler(crt_rpc_t *rpc)
 	D_ASSERT(opi != NULL);
 	rc = ds_pre_check(opi->opi_oid, opi->opi_map_ver, opi->opi_pool_uuid,
 			  opi->opi_co_hdl, opi->opi_co_uuid,
-			  opc_get(rpc->cr_opc), opi->opi_flags, &opi->opi_dti,
-			  &cont_hdl, &cont);
+			  opc_get(rpc->cr_opc), &cont_hdl, &cont);
 	if (rc)
 		goto out;
 
@@ -1417,7 +1392,7 @@ ds_obj_tgt_punch_handler(crt_rpc_t *rpc)
 		       opi->opi_epoch, opi->opi_dkey_hash,
 		       &conflict, opi->opi_dti_cos.ca_arrays,
 		       opi->opi_dti_cos.ca_count, opi->opi_map_ver,
-		       DAOS_INTENT_PUNCH, &dth);
+		       DAOS_INTENT_PUNCH, handle);
 	if (rc != 0) {
 		D_ERROR(DF_UOID": Failed to start DTX for punch %d.\n",
 			DP_UOID(opi->opi_oid), rc);
@@ -1425,7 +1400,7 @@ ds_obj_tgt_punch_handler(crt_rpc_t *rpc)
 	}
 
 	/* local RPC handler */
-	rc = obj_local_punch(opi, opc_get(rpc->cr_opc), cont_hdl, cont, &dth);
+	rc = obj_local_punch(opi, opc_get(rpc->cr_opc), cont_hdl, cont, handle);
 	if (rc != 0) {
 		D_ERROR(DF_UOID": obj_local_punch failed %d.\n",
 			DP_UOID(opi->opi_oid), rc);
@@ -1433,7 +1408,7 @@ ds_obj_tgt_punch_handler(crt_rpc_t *rpc)
 	}
 out:
 	/* Stop the local transaction */
-	rc = dtx_end(&dth, cont_hdl, cont, rc);
+	rc = dtx_end(handle, cont_hdl, cont, rc);
 	obj_punch_complete(rpc, rc, map_version, &conflict);
 	if (cont_hdl)
 		ds_cont_hdl_put(cont_hdl);
@@ -1485,8 +1460,7 @@ ds_obj_punch_handler(crt_rpc_t *rpc)
 	D_ASSERT(opi != NULL);
 	rc = ds_pre_check(opi->opi_oid, opi->opi_map_ver, opi->opi_pool_uuid,
 			  opi->opi_co_hdl, opi->opi_co_uuid,
-			  opc_get(rpc->cr_opc), opi->opi_flags, &opi->opi_dti,
-			  &cont_hdl, &cont);
+			  opc_get(rpc->cr_opc), &cont_hdl, &cont);
 	if (rc)
 		goto out;
 

--- a/src/object/srv_obj_remote.c
+++ b/src/object/srv_obj_remote.c
@@ -144,8 +144,6 @@ ds_obj_remote_update(struct dtx_leader_handle *dlh, void *data, int idx,
 	orw->orw_shard_tgts.ca_count	= 0;
 	orw->orw_shard_tgts.ca_arrays	= NULL;
 	orw->orw_flags |= ORF_BULK_BIND | obj_exec_arg->flags;
-	if (!srv_enable_dtx)
-		orw->orw_flags |= ORF_DTX_DISABLED;
 	orw->orw_dti_cos.ca_count	= dth->dth_dti_cos_count;
 	orw->orw_dti_cos.ca_arrays	= dth->dth_dti_cos;
 
@@ -266,8 +264,6 @@ ds_obj_remote_punch(struct dtx_leader_handle *dlh, void *data, int idx,
 	opi->opi_shard_tgts.ca_count = 0;
 	opi->opi_shard_tgts.ca_arrays = NULL;
 	opi->opi_flags |= obj_exec_arg->flags;
-	if (!srv_enable_dtx)
-		opi->opi_flags |= ORF_DTX_DISABLED;
 	opi->opi_dti_cos.ca_count = dth->dth_dti_cos_count;
 	opi->opi_dti_cos.ca_arrays = dth->dth_dti_cos;
 


### PR DESCRIPTION
Use zero dti to indicate disable dtx on server side process,
so it does not need set any environment for dtx disable test.

Remove some unnecessary dtx config check and ORF_DTX_DISABLED.

A few fixes about dtx disable mode.

Signed-off-by: Wang Di <di.wang@intel.com>