### PR TITLE
DAOS-2623 evtree: Fix a bug in evtree node selection

### DIFF
--- a/src/vos/evtree.c
+++ b/src/vos/evtree.c
@@ -1421,7 +1421,7 @@ evt_select_node(struct evt_context *tcx, const struct evt_rect *rect,
 	int			rc;
 
 	evt_node_weight_diff(tcx, nd1, rect, &wt1);
-	evt_node_weight_diff(tcx, nd1, rect, &wt2);
+	evt_node_weight_diff(tcx, nd2, rect, &wt2);
 
 	rc = evt_weight_cmp(&wt1, &wt2);
 	return rc < 0 ? nd1 : nd2;


### PR DESCRIPTION
A typo in evtree node selection function ensures we
make the same decision every time regardless of the
input data.   This explains partially why random
write performance is so bad as we make the wrong
decisions 50% of the time.