### PR TITLE
DAOS-2534 utils: add obj commands, misc tool enhancements

### DIFF
--- a/src/include/daos/rpc.h
+++ b/src/include/daos/rpc.h
@@ -205,22 +205,25 @@ int daos_rpc_send(crt_rpc_t *rpc, tse_task_t *task);
 int daos_rpc_complete(crt_rpc_t *rpc, tse_task_t *task);
 int daos_rpc_send_wait(crt_rpc_t *rpc);
 
-#define DAOS_DEFAULT_GROUP_ID "daos_server"
+#define DAOS_DEFAULT_SYS_NAME "daos_server"
+
 
 static inline int
-daos_group_attach(const char *group_id, crt_group_t **group)
+daos_group_attach(const char *daos_sys_name, crt_group_t **group)
 {
-	if (group_id == NULL)
-		group_id = DAOS_DEFAULT_GROUP_ID;
-	D_DEBUG(DB_NET, "attaching to group '%s'\n", group_id);
-	return crt_group_attach((char *)group_id, group);
+	if (daos_sys_name == NULL)
+		daos_sys_name = DAOS_DEFAULT_SYS_NAME;
+	D_DEBUG(DB_NET, "DAOS system '%s': attach associated CaRT group",
+		daos_sys_name);
+	return crt_group_attach((char *)daos_sys_name, group);
 }
 
 static inline int
 daos_group_detach(crt_group_t *group)
 {
 	D_ASSERT(group != NULL);
-	D_DEBUG(DB_NET, "detaching from group '%s'\n", group->cg_grpid);
+	D_DEBUG(DB_NET, "DAOS system '%s': detach associated CaRT group\n",
+		group->cg_grpid);
 	return crt_group_detach(group);
 }
 

--- a/src/iosrv/init.c
+++ b/src/iosrv/init.c
@@ -52,8 +52,8 @@ static char		modules[MAX_MODULE_OPTIONS + 1];
  */
 static unsigned int	nr_threads;
 
-/** Server crt group ID */
-static char	       *server_group_id = DAOS_DEFAULT_GROUP_ID;
+/** DAOS system name (corresponds to crt group ID) */
+static char	       *daos_sysname = DAOS_DEFAULT_SYS_NAME;
 
 /** Storage path (hack) */
 const char	       *dss_storage_path = "/mnt/daos";
@@ -373,7 +373,7 @@ server_init(int argc, char *argv[])
 		pmixless = true;
 	if (sys_map_path != NULL || pmixless)
 		flags |= CRT_FLAG_BIT_PMIX_DISABLE;
-	rc = crt_init_opt(server_group_id, flags,
+	rc = crt_init_opt(daos_sysname, flags,
 			  daos_crt_init_opt_get(true, DSS_CTX_NR_TOTAL));
 	if (rc)
 		D_GOTO(exit_mod_init, rc);
@@ -386,7 +386,7 @@ server_init(int argc, char *argv[])
 		if (rc != 0)
 			D_ERROR("failed to set self rank %u: %d\n", self_rank,
 				rc);
-		rc = dss_sys_map_load(sys_map_path, server_group_id, self_rank,
+		rc = dss_sys_map_load(sys_map_path, daos_sysname, self_rank,
 				      DSS_CTX_NR_TOTAL);
 		if (rc) {
 			D_ERROR("failed to load %s: %d\n", sys_map_path, rc);
@@ -579,7 +579,7 @@ Options:\n\
       [Temporary] Self rank (default none; ignored if no --map|-y)\n\
   --help, -h\n\
       Print this description\n",
-		prog, prog, modules, server_group_id, dss_storage_path,
+		prog, prog, modules, daos_sysname, dss_storage_path,
 		dss_socket_dir, dss_nvme_conf);
 }
 
@@ -658,12 +658,12 @@ parse(int argc, char **argv)
 		case 'g':
 			if (strnlen(optarg, DAOS_SYS_NAME_MAX + 1) >
 			    DAOS_SYS_NAME_MAX) {
-				printf("group name must be at most %d bytes\n",
-				       DAOS_SYS_NAME_MAX);
+				printf("DAOS system name must be at most "
+				       "%d bytes\n", DAOS_SYS_NAME_MAX);
 				rc = -DER_INVAL;
 				break;
 			}
-			server_group_id = optarg;
+			daos_sysname = optarg;
 			break;
 		case 's':
 			dss_storage_path = optarg;

--- a/src/utils/daos_hdlr.c
+++ b/src/utils/daos_hdlr.c
@@ -37,6 +37,7 @@
 #include <daos/common.h>
 #include <daos/rpc.h>
 #include <daos/debug.h>
+#include <daos/object.h>
 
 #include "daos_types.h"
 #include "daos_api.h"
@@ -70,7 +71,7 @@ pool_query_hdlr(struct cmd_args_s *ap)
 	assert(ap != NULL);
 	assert(ap->p_op == POOL_QUERY);
 
-	rc = daos_pool_connect(ap->p_uuid, ap->group,
+	rc = daos_pool_connect(ap->p_uuid, ap->sysname,
 			       ap->mdsrv, DAOS_PC_RO, &ap->pool,
 			       NULL /* info */, NULL /* ev */);
 	if (rc != 0) {
@@ -187,7 +188,7 @@ cont_create_uns_hdlr(struct cmd_args_s *ap)
 	dattr.da_oclass = ap->oclass;
 	dattr.da_chunk_size = ap->chunk_size;
 
-	rc = duns_link_path(ap->path, ap->group, ap->mdsrv, &dattr);
+	rc = duns_link_path(ap->path, ap->sysname, ap->mdsrv, &dattr);
 	if (rc) {
 		fprintf(stderr, "duns_link_path() error: rc=%d\n", rc);
 		D_GOTO(err_rc, rc);
@@ -207,8 +208,22 @@ err_rc:
 int
 cont_query_hdlr(struct cmd_args_s *ap)
 {
+	daos_cont_info_t	cont_info;
 	char			oclass[10], type[10];
-	int	rc = 0;
+	int			rc;
+
+	rc = daos_cont_query(ap->cont, &cont_info, NULL, NULL);
+	if (rc) {
+		fprintf(stderr, "Container query failed, result: %d\n", rc);
+		D_GOTO(err_out, rc);
+	}
+
+	printf("Pool UUID:\t"DF_UUIDF"\n", DP_UUID(ap->p_uuid));
+	printf("Container UUID:\t"DF_UUIDF"\n", DP_UUID(cont_info.ci_uuid));
+	printf("Number of snapshots: %i\n", (int)cont_info.ci_nsnapshots);
+	printf("Latest Persistent Snapshot: %i\n",
+		(int)cont_info.ci_lsnapshot);
+	/* TODO: list snapshot epoch numbers, including ~80 column wrap. */
 
 	if (ap->path != NULL) {
 		/* cont_op_hdlr() already did resolve_by_path()
@@ -223,14 +238,13 @@ cont_query_hdlr(struct cmd_args_s *ap)
 		daos_unparse_ctype(ap->type, type);
 		daos_unparse_oclass(ap->oclass, oclass);
 		printf("Container Type:\t%s\n", type);
-		printf("Pool UUID:\t"DF_UUIDF"\n", DP_UUID(ap->p_uuid));
-		printf("Container UUID:\t"DF_UUIDF"\n", DP_UUID(ap->c_uuid));
 		printf("Object Class:\t%s\n", oclass);
 		printf("Chunk Size:\t%zu\n", ap->chunk_size);
 	}
 
-	/* TODO: add container query API call and print */
+	return 0;
 
+err_out:
 	return rc;
 }
 
@@ -239,8 +253,7 @@ cont_destroy_hdlr(struct cmd_args_s *ap)
 {
 	int	rc;
 
-	assert(ap->c_op == CONT_DESTROY);
-
+	/* TODO: when API supports, change arg 3 to ap->force_destroy. */
 	rc = daos_cont_destroy(ap->pool, ap->c_uuid, 1, NULL);
 	if (rc != 0)
 		fprintf(stderr, "failed to destroy container: %d\n", rc);
@@ -248,5 +261,39 @@ cont_destroy_hdlr(struct cmd_args_s *ap)
 		fprintf(stdout, "Successfully destroyed container "
 				DF_UUIDF"\n", DP_UUID(ap->c_uuid));
 
+	return rc;
+}
+
+int
+obj_query_hdlr(struct cmd_args_s *ap)
+{
+	struct daos_obj_layout *layout;
+	int			i;
+	int			j;
+	int			rc;
+
+	rc = daos_obj_layout_get(ap->cont, ap->oid, &layout);
+	if (rc) {
+		fprintf(stderr, "daos_obj_layout_get failed, rc: %d\n", rc);
+		D_GOTO(out, rc);
+	}
+
+	/* Print the object layout */
+	fprintf(stdout, "oid: "DF_OID" ver %d grp_nr: %d\n", DP_OID(ap->oid),
+		layout->ol_ver, layout->ol_nr);
+
+	for (i = 0; i < layout->ol_nr; i++) {
+		struct daos_obj_shard *shard;
+
+		shard = layout->ol_shards[i];
+		fprintf(stdout, "grp: %d\n", i);
+		for (j = 0; j < shard->os_replica_nr; j++)
+			fprintf(stdout, "replica %d %d\n", j,
+				shard->os_ranks[j]);
+	}
+
+	daos_obj_layout_free(layout);
+
+out:
 	return rc;
 }

--- a/src/utils/daos_hdlr.h
+++ b/src/utils/daos_hdlr.h
@@ -49,7 +49,8 @@ enum pool_op {
 };
 
 enum obj_op {
-	OBJ_GET_LAYOUT,
+	OBJ_QUERY,
+	OBJ_LIST_KEYS,
 	OBJ_DUMP
 };
 
@@ -60,15 +61,15 @@ enum obj_op {
 struct cmd_args_s {
 	enum pool_op		p_op;		/* pool sub-command */
 	enum cont_op		c_op;		/* cont sub-command */
-	char			*group;		/* --group */
-	char			*p_uuid_str;	/* --pool */
-	uuid_t			p_uuid;
+	enum obj_op		o_op;		/* obj sub-command */
+	char			*sysname;	/* --sys-name or --sys */
+	uuid_t			p_uuid;		/* --pool */
 	daos_handle_t		pool;
-	char			*c_uuid_str;	/* --cont */
-	uuid_t			c_uuid;
+	uuid_t			c_uuid;		/* --cont */
 	daos_handle_t		cont;
 	char			*mdsrv_str;	/* --svc */
 	d_rank_list_t		*mdsrv;
+	int			force_destroy;	/* --force (cont destroy) */
 	char			*attrname_str;	/* --attr attribute name */
 	char			*value_str;	/* --value attribute value */
 
@@ -84,6 +85,7 @@ struct cmd_args_s {
 	char			*epcrange_str;	/* --epcrange cont epochs */
 	daos_epoch_t		epcrange_begin;
 	daos_epoch_t		epcrange_end;
+	daos_obj_id_t		oid;
 
 	FILE			*ostream;	/* help_hdlr() stream */
 };
@@ -117,6 +119,14 @@ struct cmd_args_s {
 	do {								\
 		if (uuid_is_null((ap)->c_uuid)) {			\
 			fprintf(stderr, "container UUID required\n");	\
+			D_GOTO(label, (rcexpr));			\
+		}							\
+	} while (0)
+
+#define ARGS_VERIFY_OID(ap, label, rcexpr)				\
+	do {								\
+		if (((ap)->oid.hi == 0) && ((ap)->oid.lo == 0)) {	\
+			fprintf(stderr, "object ID required\n");	\
 			D_GOTO(label, (rcexpr));			\
 		}							\
 	} while (0)
@@ -192,3 +202,4 @@ int cont_destroy_hdlr(struct cmd_args_s *ap);
  * int cont_rollback_hdlr()
  */
 
+int obj_query_hdlr(struct cmd_args_s *ap);


### PR DESCRIPTION
With this change, the existing dmg object layout command is
integrated into the common user administration 'daos' utility.
Additional daos object resource commands to be added later,
list-keys and dump, are added to the help output.

Also with this change, as a result of discussions associated with
DAOS-2679, the --group argument is renamed to --sys/--sys-name.
This better reflects the value being the DAOS system name, and
prevents a conflict with other usages of "group", for example with
pool and container access control features. The new 'daos' utility
accepts only the --sys options, while the existing 'dmg' tool
(temporarily, until it is replaced) accepts both --sys and --gruop.

Support for daos container query by CUUID is added, including the
functionality currently present in 'daosctl'.

Help/usage output for container options is organized by associated
commands, and indicates when options are required or optional.

Signed-off-by: Ken Cain <kenneth.c.cain@intel.com>