### PR TITLE
DAOS-2684 obj: fix bug in epoch io test

### DIFF
--- a/src/tests/suite/daos_epoch_io.c
+++ b/src/tests/suite/daos_epoch_io.c
@@ -267,7 +267,8 @@ fio_test_cb_uf(test_arg_t *arg, struct test_op_record *op, char **rbuf,
 		D_GOTO(out, rc = -DER_NOMEM);
 	if (op->or_op == TEST_OP_UPDATE)
 		test_buf_init(buf, buf_size, uf_arg->ua_recxs,
-			      uf_arg->ua_values, uf_arg->ua_recx_num,
+			      uf_arg->ua_values ?: &uf_arg->ua_single_value,
+			      uf_arg->ua_values ? uf_arg->ua_recx_num : 1,
 			      iod_size);
 	fd = array ? key_rec->or_fd_array : key_rec->or_fd_single;
 	D_ASSERT(fd != 0);

--- a/src/tests/suite/io_conf/daos_io_conf_1
+++ b/src/tests/suite/io_conf/daos_io_conf_1
@@ -62,15 +62,17 @@ akey akey_1
 iod_size 32
 
 update --epoch 1 --recx "[0, 2] [3, 8] [12, 18]"
-update --epoch 1 --single
 update --epoch 2 --recx "[1, 3] [5, 10] [12, 14] [100, 108]"
 update --epoch 3 --recx "[0, 8] [13, 17] [90, 104]"
 update --epoch 4 --recx "[1, 20] [80, 96] [110, 120]"
-update --epoch 4 --single
 
 fetch --epoch 1 --recx "[0, 2] [3, 8] [12, 18]"
 fetch --epoch 2 --recx "[0, 4] [5, 7] [13, 15] [100, 108]"
-fetch --epoch 2 --single
 fetch --epoch 3 --recx "[0, 8] [13, 17] [90, 104]"
 fetch --epoch 4 --recx "[0, 20] [80, 96] [100, 120]"
+
+akey akey_s
+update --epoch 1 --single
+update --epoch 4 --single
+fetch --epoch 2 --single
 fetch --epoch 4 --single

--- a/src/tests/suite/io_conf/daos_io_conf_2
+++ b/src/tests/suite/io_conf/daos_io_conf_2
@@ -62,11 +62,9 @@ akey akey_2
 iod_size 3
 
 update -e 1 -r "[0, 1000]"
-update -e 1 --single
 update -e 2 -r "[2, 500] [510, 990]"
 update -e 3 -r "[4, 40] [60, 80] [200, 490] [550, 800] [900, 1100]"
 update -e 4 -r "[20, 70] [78, 333] [377, 488] [600, 2000]"
-update -e 4 --single
 update -e 9 -r "[0, 2000]"
 update --epoch 100 --recx "[4, 40] [60, 80] [200, 490] [550, 800] [900, 1100]"
 update --epoch 200 --recx "[10, 71] [78, 344] [377, 444] [610, 1000]"
@@ -75,10 +73,8 @@ update -e 100 -d dkey_another -a akey_another -r "[0, 3000]"
 
 fetch -e 1 -r "[0, 1000]"
 fetch -e 2 -r "[0, 50] [300, 1000]"
-fetch -e 2 -s
 fetch -e 3 -r "[1, 20] [30, 80] [100, 290] [250, 400] [500, 1100]"
 fetch -e 4 -r "[20, 30] [48, 333] [377, 388] [400, 2000]"
-fetch -e 4 -s
 fetch -e 4 -d dkey_another -a akey_another -r "[0, 2000]"
 fetch -e 110 -d dkey_another -a akey_another -r "[0, 3000]"
 fetch -e 10 -r "[0, 2000]"


### PR DESCRIPTION
1) fix the io_conf file, now vos changed to ony with one type (single
   or array) under one akey.
2) fix on bug in fio_test_cb_uf.

Signed-off-by: Xuezhao Liu <xuezhao.liu@intel.com>