### PR TITLE
DAOS-2711 build: Use pkg-config instead of relative paths

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -63,7 +63,7 @@ def scons():
         except ImportError:
             print ('Using traditional build')
 
-    env = Environment(TOOLS=['extra', 'default'])
+    env = Environment(TOOLS=['extra', 'default', 'textfile'])
 
     opts_file = os.path.join(Dir('#').abspath, 'daos_m.conf')
     opts = Variables(opts_file)

--- a/src/SConscript
+++ b/src/SConscript
@@ -17,6 +17,8 @@ def scons():
     env.Install(os.path.join('$PREFIX', 'include/daos'), 'include/daos/tse.h')
     env.Install(os.path.join('$PREFIX', 'include/daos'),
                 'include/daos/drpc_modules.h')
+    env.Depends(env.subst('$PREFIX/include/daos/drpc_modules.h'),
+                'include/daos/drpc_modules.h')
 
     # Generic DAOS includes
     env.AppendUnique(CPPPATH=[Dir('include').srcnode()])

--- a/src/SConscript
+++ b/src/SConscript
@@ -15,7 +15,8 @@ def scons():
     # For Common library (tse.h)
     env.AppendUnique(CPPPATH=[Dir('include/daos').srcnode()])
     env.Install(os.path.join('$PREFIX', 'include/daos'), 'include/daos/tse.h')
-    env.Install(os.path.join('$PREFIX', 'include/daos'), 'include/daos/drpc_modules.h')
+    env.Install(os.path.join('$PREFIX', 'include/daos'),
+                'include/daos/drpc_modules.h')
 
     # Generic DAOS includes
     env.AppendUnique(CPPPATH=[Dir('include').srcnode()])

--- a/src/SConscript
+++ b/src/SConscript
@@ -15,6 +15,7 @@ def scons():
     # For Common library (tse.h)
     env.AppendUnique(CPPPATH=[Dir('include/daos').srcnode()])
     env.Install(os.path.join('$PREFIX', 'include/daos'), 'include/daos/tse.h')
+    env.Install(os.path.join('$PREFIX', 'include/daos'), 'include/daos/drpc_modules.h')
 
     # Generic DAOS includes
     env.AppendUnique(CPPPATH=[Dir('include').srcnode()])

--- a/src/client/api/SConscript
+++ b/src/client/api/SConscript
@@ -8,7 +8,10 @@ def scons():
     env.AppendUnique(LIBPATH=[Dir('.')])
     denv = env.Clone()
 
-    env.Substfile('libdaos.pc.in', SUBST_DICT={'\@VERSION\@': DAOS_VERSION, '\@PREFIX\@': env.get('PREFIX')})
+    env.Substfile('libdaos.pc.in', SUBST_DICT={
+        '@VERSION@': DAOS_VERSION,
+        '@PREFIX@': env.get('PREFIX'),
+    })
     env.Install('$PREFIX/lib/pkgconfig', ['libdaos.pc', 'libdaos.pc'])
     env.Depends(env.subst('$PREFIX/lib/pkgconfig/libdaos.pc'), 'libdaos.pc')
 

--- a/src/client/api/SConscript
+++ b/src/client/api/SConscript
@@ -14,6 +14,8 @@ def scons():
     })
     env.Install('$PREFIX/lib/pkgconfig', ['libdaos.pc', 'libdaos.pc'])
     env.Depends(env.subst('$PREFIX/lib/pkgconfig/libdaos.pc'), 'libdaos.pc')
+    env.Depends(env.subst('$PREFIX/lib/pkgconfig/libdaos.pc'),
+                env.subst('$PREFIX/include/daos/drpc_modules.h'))
 
     dc_tgts = denv.SharedObject(Glob('*.c'))
 

--- a/src/client/api/SConscript
+++ b/src/client/api/SConscript
@@ -8,6 +8,10 @@ def scons():
     env.AppendUnique(LIBPATH=[Dir('.')])
     denv = env.Clone()
 
+    env.Substfile('libdaos.pc.in', SUBST_DICT={'\@VERSION\@': DAOS_VERSION, '\@PREFIX\@': env.get('PREFIX')})
+    env.Install('$PREFIX/lib/pkgconfig', ['libdaos.pc', 'libdaos.pc'])
+    env.Depends(env.subst('$PREFIX/lib/pkgconfig/libdaos.pc'), 'libdaos.pc')
+
     dc_tgts = denv.SharedObject(Glob('*.c'))
 
     Import('dc_pool_tgts', 'dc_co_tgts', 'dc_obj_tgts', 'dc_placement_tgts')

--- a/src/client/api/libdaos.pc.in
+++ b/src/client/api/libdaos.pc.in
@@ -1,0 +1,12 @@
+prefix=@PREFIX@
+exec_prefix=${prefix}
+libdir=${exec_prefix}/lib
+includedir=${prefix}/include
+
+Name: libdaos
+Description: DAOS Client Library
+Version: @VERSION@
+URL: https://github.com/daos-stack/
+Requires:
+Libs: -L${libdir} -ldaos
+Cflags: -I${includedir}

--- a/src/control/SConscript
+++ b/src/control/SConscript
@@ -149,11 +149,13 @@ int main(int argc, char **argv)
 
     conf = Configure(denv, custom_tests={'CheckSPDKVersion': CheckSPDKVersion})
     if not conf.CheckSPDKVersion():
-        print 'Can\'t check SPDK version'
-        Exit(1)
+        print('Can\'t check SPDK version')
     denv = conf.Finish()
-    
-    denv.Substfile('spdk.pc.in', SUBST_DICT={'\@PREFIX\@': env.get('PREFIX'), '\@VERSION\@': denv.get('SPDK_VERSION')})
+
+    denv.Substfile('spdk.pc.in', SUBST_DICT={
+        '@PREFIX@': env.get('PREFIX'),
+        '@VERSION@': denv.get('SPDK_VERSION'),
+    })
     denv.Install('$PREFIX/lib/pkgconfig', ['spdk.pc', 'spdk.pc'])
     denv.Depends(env.subst('$PREFIX/lib/pkgconfig/spdk.pc'), 'spdk.pc')
     denv.Depends(nvmecontrol, denv.subst('$PREFIX/lib/pkgconfig/spdk.pc'))

--- a/src/control/SConscript
+++ b/src/control/SConscript
@@ -112,14 +112,13 @@ def scons():
     denv.Append(GOPATH=[gopath])
     denv.AppendENVPath('GOPATH', denv['GOPATH'])
     denv['ENV']['GOBIN'] = join(gopath, "bin")
+    denv['ENV']['PKG_CONFIG_PATH'] = denv.subst('$PREFIX/lib/pkgconfig')
 
     install_go_bin(denv, gosrc, gopath, None, "agent", "daos_agent")
 
     gospdkpath = join(gosrc, "vendor", "github.com", "daos-stack", "go-spdk",
                       "spdk")
 
-    # CGO prerequisite libs for go-spdk bindings
-    denv.AppendUnique(CPPPATH=[join(gospdkpath, "include")])
     # hack to avoid building this library with cov compiler for the moment
     compiler = denv.get('COMPILER').lower()
     if compiler == "covc":
@@ -130,15 +129,36 @@ def scons():
         join(gospdkpath, "src", "nvme_control.c"),
         CC=compiler, LIBS=['spdk'])
 
-    denv.Install(join(denv.subst("$PREFIX"), "lib"), nvmecontrol)
+    # short-term hack to generate spdk.pc until the project generates it
+    spdk_version_src = """
+#include <stdio.h>
+#include <spdk/version.h>
+int main(int argc, char **argv)
+{
+    printf("%d.%d.%d", SPDK_VERSION_MAJOR, SPDK_VERSION_MINOR, SPDK_VERSION_PATCH);
+    return 0;
+}
+"""
+    def CheckSPDKVersion(context):
+        context.Message('Checking SPDK version... ')
+        result = context.TryRun(spdk_version_src, '.c')
+        if result[0]:
+              context.env.Append(SPDK_VERSION = result[1])
+        context.Result(result[1])
+        return result[1]
 
-    # CGO shell env vars.
-    denv.AppendENVPath(
-        "CGO_LDFLAGS",
-        denv.subst("-L%s -L$SPDK_PREFIX/lib $_RPATH" % gopath))
-    denv.AppendENVPath(
-        "CGO_CFLAGS",
-        denv.subst("-I$SPDK_PREFIX/include"))
+    conf = Configure(denv, custom_tests={'CheckSPDKVersion': CheckSPDKVersion})
+    if not conf.CheckSPDKVersion():
+        print 'Can\'t check SPDK version'
+        Exit(1)
+    denv = conf.Finish()
+    
+    denv.Substfile('spdk.pc.in', SUBST_DICT={'\@PREFIX\@': env.get('PREFIX'), '\@VERSION\@': denv.get('SPDK_VERSION')})
+    denv.Install('$PREFIX/lib/pkgconfig', ['spdk.pc', 'spdk.pc'])
+    denv.Depends(env.subst('$PREFIX/lib/pkgconfig/spdk.pc'), 'spdk.pc')
+    denv.Depends(nvmecontrol, denv.subst('$PREFIX/lib/pkgconfig/spdk.pc'))
+
+    denv.Install(join(denv.subst("$PREFIX"), "lib"), nvmecontrol)
 
     # copy server init files to be used at runtime, explicitly
     # remove first because recursive Delete() on dir fails.
@@ -157,7 +177,9 @@ def scons():
     install_go_bin(denv, gosrc, gopath, None, "drpc_test", "hello_drpc")
 
     agentbin = get_bin_path(gopath, "agent")
+    denv.Depends(agentbin, env.subst('$PREFIX/lib/pkgconfig/libdaos.pc'))
     serverbin = get_bin_path(gopath, "server")
+    denv.Depends(agentbin, env.subst('$PREFIX/lib/pkgconfig/libdaos.pc'))
     shellbin = get_bin_path(gopath, "dmg")
     drpcbin = get_bin_path(gopath, "drpc_test")
     AlwaysBuild([agentbin, serverbin, shellbin, drpcbin])

--- a/src/control/SConscript
+++ b/src/control/SConscript
@@ -82,7 +82,6 @@ def scons():
 
     denv = env.Clone()
     prereqs.require(denv, 'spdk')
-    prereqs.require(denv, 'daos')
 
     # if SPDK_PREFIX differs from PREFIX, copy dir so files can be accessed at
     # runtime
@@ -182,7 +181,8 @@ int main(int argc, char **argv)
     agentbin = get_bin_path(gopath, "agent")
     denv.Depends(agentbin, env.subst('$PREFIX/lib/pkgconfig/libdaos.pc'))
     serverbin = get_bin_path(gopath, "server")
-    denv.Depends(agentbin, env.subst('$PREFIX/lib/pkgconfig/libdaos.pc'))
+    denv.Depends(serverbin, env.subst('$PREFIX/lib/pkgconfig/libdaos.pc'))
+    denv.Depends(serverbin, denv.subst('$PREFIX/lib/pkgconfig/spdk.pc'))
     shellbin = get_bin_path(gopath, "dmg")
     drpcbin = get_bin_path(gopath, "drpc_test")
     AlwaysBuild([agentbin, serverbin, shellbin, drpcbin])

--- a/src/control/SConscript
+++ b/src/control/SConscript
@@ -82,6 +82,7 @@ def scons():
 
     denv = env.Clone()
     prereqs.require(denv, 'spdk')
+    prereqs.require(denv, 'daos')
 
     # if SPDK_PREFIX differs from PREFIX, copy dir so files can be accessed at
     # runtime

--- a/src/control/agent/mgmt_rpc.go
+++ b/src/control/agent/mgmt_rpc.go
@@ -23,7 +23,7 @@
 
 package main
 
-// #cgo CFLAGS: -I${SRCDIR}/../../include
+// #cgo pkg-config: libdaos
 // #include <daos/drpc_modules.h>
 import "C"
 

--- a/src/control/lib/netdetect/netdetect.go
+++ b/src/control/lib/netdetect/netdetect.go
@@ -25,8 +25,7 @@
 
 package netdetect
 /*
-#cgo CFLAGS: -I${SRCDIR}/../../include
-#cgo LDFLAGS: -lhwloc
+#cgo pkg-config: hwloc
 #include <stdlib.h>
 #include <hwloc.h>
 #include <stdio.h>

--- a/src/control/run_go_tests.sh
+++ b/src/control/run_go_tests.sh
@@ -24,13 +24,6 @@ function check_environment()
 		echo "false" && return
 	fi
 
-	if [ -z "$CGO_LDFLAGS" ]; then
-		echo "false" && return
-	fi
-
-	if [ -z "$CGO_CFLAGS" ]; then
-		echo "false" && return
-	fi
 	echo "true" && return
 }
 
@@ -46,8 +39,6 @@ function setup_environment()
 
 	LD_LIBRARY_PATH="${SL_PREFIX}/lib:${SL_SPDK_PREFIX}/lib:${LD_LIBRARY_PATH}"
 	export LD_LIBRARY_PATH
-	export CGO_LDFLAGS="-L${SL_SPDK_PREFIX}/lib -L${SL_PREFIX}/lib"
-	export CGO_CFLAGS="-I${SL_SPDK_PREFIX}/include"
 }
 
 check=$(check_environment)

--- a/src/control/server/mgmt_drpc.go
+++ b/src/control/server/mgmt_drpc.go
@@ -23,7 +23,7 @@
 
 package main
 
-// #cgo CFLAGS: -I${SRCDIR}/../../include
+// #cgo pkg-config: libdaos
 // #include <daos/drpc_modules.h>
 import "C"
 

--- a/src/control/server/security.go
+++ b/src/control/server/security.go
@@ -23,7 +23,7 @@
 
 package main
 
-// #cgo CFLAGS: -I${SRCDIR}/../../include
+// #cgo pkg-config: libdaos
 // #include <daos/drpc_modules.h>
 import "C"
 import (

--- a/src/control/spdk.pc.in
+++ b/src/control/spdk.pc.in
@@ -8,5 +8,5 @@ Version: @VERSION@
 Description: Intel® Storage Performance Development Kit
 URL: https://spdk.io/
 Requires:
-Libs: -L${libdir} -Wl,-rpath -Wl,${libdir} -lspdk 
+Libs: -L${libdir} -Wl,-rpath -Wl,${libdir} -lspdk
 Cflags: -I${includedir}

--- a/src/control/spdk.pc.in
+++ b/src/control/spdk.pc.in
@@ -1,0 +1,12 @@
+prefix=@PREFIX@
+exec_prefix=${prefix}
+libdir=${exec_prefix}/lib
+includedir=${prefix}/include
+
+Name: spdk
+Version: @VERSION@
+Description: Intel® Storage Performance Development Kit
+URL: https://spdk.io/
+Requires:
+Libs: -L${libdir} -Wl,-rpath -Wl,${libdir} -lspdk 
+Cflags: -I${includedir}

--- a/src/control/vendor/github.com/daos-stack/go-spdk/spdk/nvme.go
+++ b/src/control/vendor/github.com/daos-stack/go-spdk/spdk/nvme.go
@@ -23,12 +23,10 @@
 
 package spdk
 
-// CGO_CFLAGS & CGO_LDFLAGS env vars can be used
-// to specify additional dirs.
-
 /*
+#cgo pkg-config: spdk
 #cgo CFLAGS: -I .
-#cgo LDFLAGS: -L . -lnvme_control -lspdk
+#cgo LDFLAGS: -L . -lnvme_control
 
 #include "stdlib.h"
 #include "spdk/stdinc.h"


### PR DESCRIPTION
Generate pkg-config files for libdaos and spdk, and update
cgo to use pkg-config in order to discover include/linker
options.

Signed-off-by: Michael MacDonald <mjmac.macdonald@intel.com>