### PR TITLE
DAOS-656 Security: Add Admin Certificate loading in dmg for gRPC and…

### DIFF
--- a/src/control/client/config.go
+++ b/src/control/client/config.go
@@ -31,8 +31,9 @@ import (
 
 	"github.com/daos-stack/daos/src/control/common"
 	"github.com/daos-stack/daos/src/control/log"
+	"github.com/daos-stack/daos/src/control/security"
 	"github.com/pkg/errors"
-	"gopkg.in/yaml.v2"
+	yaml "gopkg.in/yaml.v2"
 )
 
 const (
@@ -64,32 +65,32 @@ func (e *ext) Getenv(key string) string {
 
 // Configuration contains all known configuration variables available to the client
 type Configuration struct {
-	SystemName    string   `yaml:"name"`
-	AccessPoints  []string `yaml:"access_points"`
-	Port          int      `yaml:"port"`
-	HostList      []string `yaml:"hostlist"`
-	RuntimeDir    string   `yaml:"runtime_dir"`
-	HostFile      string   `yaml:"host_file"`
-	Cert          string   `yaml:"cert"`
-	Key           string   `yaml:"key"`
-	LogFile       string   `yaml:"log_file"`
-	LogFileFormat string   `yaml:"log_file_format"`
-	Path          string
-	Ext           External
+	SystemName      string   `yaml:"name"`
+	AccessPoints    []string `yaml:"access_points"`
+	Port            int      `yaml:"port"`
+	HostList        []string `yaml:"hostlist"`
+	RuntimeDir      string   `yaml:"runtime_dir"`
+	HostFile        string   `yaml:"host_file"`
+	LogFile         string   `yaml:"log_file"`
+	LogFileFormat   string   `yaml:"log_file_format"`
+	Path            string
+	TransportConfig *security.TransportConfig `yaml:"transport_config"`
+	Ext             External
 }
 
 // newDefaultConfiguration creates a new instance of configuration struct
 // populated with defaults.
 func newDefaultConfiguration(ext External) *Configuration {
 	return &Configuration{
-		SystemName:   defaultSystemName,
-		AccessPoints: []string{"localhost:10001"},
-		Port:         defaultPort,
-		HostList:     []string{"localhost:10001"},
-		RuntimeDir:   defaultRuntimeDir,
-		LogFile:      defaultLogFile,
-		Path:         defaultConfigPath,
-		Ext:          ext,
+		SystemName:      defaultSystemName,
+		AccessPoints:    []string{"localhost"},
+		Port:            defaultPort,
+		HostList:        []string{"localhost:10001"},
+		RuntimeDir:      defaultRuntimeDir,
+		LogFile:         defaultLogFile,
+		Path:            defaultConfigPath,
+		TransportConfig: security.DefaultClientTransportConfig(),
+		Ext:             ext,
 	}
 }
 

--- a/src/control/client/connect.go
+++ b/src/control/client/connect.go
@@ -31,6 +31,7 @@ import (
 
 	"github.com/daos-stack/daos/src/control/common"
 	pb "github.com/daos-stack/daos/src/control/common/proto/mgmt"
+	"github.com/daos-stack/daos/src/control/security"
 )
 
 const (
@@ -79,17 +80,17 @@ func (rm ResultMap) String() string {
 
 // ControllerFactory is an interface providing capability to connect clients.
 type ControllerFactory interface {
-	create(string) (Control, error)
+	create(string, *security.TransportConfig) (Control, error)
 }
 
 // controllerFactory as an implementation of ControllerFactory.
 type controllerFactory struct{}
 
 // create instantiates and connects a client to server at given address.
-func (c *controllerFactory) create(address string) (Control, error) {
+func (c *controllerFactory) create(address string, cfg *security.TransportConfig) (Control, error) {
 	controller := &control{}
 
-	err := controller.connect(address)
+	err := controller.connect(address, cfg)
 
 	return controller, err
 }
@@ -97,8 +98,12 @@ func (c *controllerFactory) create(address string) (Control, error) {
 // Connect is an external interface providing functionality across multiple
 // connected clients (controllers).
 type Connect interface {
-	ConnectClients(Addresses) ResultMap // connect addresses
-	GetActiveConns(ResultMap) ResultMap // remove inactive conns
+	// SetTransportConfig sets the gRPC transport confguration
+	SetTransportConfig(*security.TransportConfig)
+	// ConnectClients attempts to connect a list of addresses
+	ConnectClients(Addresses) ResultMap
+	// GetActiveConns verifies states and removes inactive conns
+	GetActiveConns(ResultMap) ResultMap
 	ClearConns() ResultMap
 	ScanStorage() (ClientCtrlrMap, ClientModuleMap)
 	FormatStorage() (ClientCtrlrMap, ClientMountMap)
@@ -114,8 +119,15 @@ type Connect interface {
 // connList is an implementation of Connect and stores controllers
 // (connections to clients, one per DAOS server).
 type connList struct {
-	factory     ControllerFactory
-	controllers []Control
+	transportConfig *security.TransportConfig
+	factory         ControllerFactory
+	controllers     []Control
+}
+
+// SetTransportConfig sets the internal transport credentials to be passed
+// to subsequent connect calls as the gRPC dial credentials.
+func (c *connList) SetTransportConfig(cfg *security.TransportConfig) {
+	c.transportConfig = cfg
 }
 
 // ConnectClients populates collection of client-server controllers.
@@ -128,7 +140,7 @@ func (c *connList) ConnectClients(addresses Addresses) ResultMap {
 
 	for _, address := range addresses {
 		go func(f ControllerFactory, addr string, ch chan ClientResult) {
-			c, err := f.create(addr)
+			c, err := f.create(addr, c.transportConfig)
 			ch <- ClientResult{addr, c, err}
 		}(c.factory, address, ch)
 	}
@@ -249,7 +261,8 @@ func (c *connList) makeRequests(
 // multiple clients.
 func NewConnect() Connect {
 	return &connList{
-		factory:     &controllerFactory{},
-		controllers: []Control{},
+		transportConfig: nil,
+		factory:         &controllerFactory{},
+		controllers:     []Control{},
 	}
 }

--- a/src/control/client/control.go
+++ b/src/control/client/control.go
@@ -25,13 +25,14 @@ package client
 
 import (
 	pb "github.com/daos-stack/daos/src/control/common/proto/mgmt"
+	"github.com/daos-stack/daos/src/control/security"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/connectivity"
 )
 
 // Control interface provides connection handling capabilities.
 type Control interface {
-	connect(string) error
+	connect(string, *security.TransportConfig) error
 	disconnect() error
 	connected() (connectivity.State, bool)
 	getAddress() string
@@ -52,9 +53,14 @@ type control struct {
 //
 // It takes address and port in a string.
 //	addr: address and port number separated by a ":"
-func (c *control) connect(addr string) (err error) {
+func (c *control) connect(addr string, cfg *security.TransportConfig) (err error) {
 	var opts []grpc.DialOption
-	opts = append(opts, grpc.WithInsecure())
+
+	creds, err := security.DialOptionForTransportConfig(cfg)
+	if err != nil {
+		return err
+	}
+	opts = append(opts, creds)
 
 	conn, err := grpc.Dial(addr, opts...)
 	if err != nil {

--- a/src/control/client/mocks.go
+++ b/src/control/client/mocks.go
@@ -29,6 +29,7 @@ import (
 
 	"github.com/daos-stack/daos/src/control/common"
 	pb "github.com/daos-stack/daos/src/control/common/proto/mgmt"
+	"github.com/daos-stack/daos/src/control/security"
 	"github.com/pkg/errors"
 	"golang.org/x/net/context"
 	grpc "google.golang.org/grpc"
@@ -287,7 +288,7 @@ type mockControl struct {
 	svcClient  pb.MgmtSvcClient
 }
 
-func (m *mockControl) connect(addr string) error {
+func (m *mockControl) connect(addr string, cfg *security.TransportConfig) error {
 	if m.connectRet == nil {
 		m.address = addr
 	}
@@ -335,7 +336,7 @@ type mockControllerFactory struct {
 	connectRet error
 }
 
-func (m *mockControllerFactory) create(address string) (Control, error) {
+func (m *mockControllerFactory) create(address string, cfg *security.TransportConfig) (Control, error) {
 	// returns controller with mock properties specified in constructor
 	cClient := newMockMgmtCtlClient(
 		m.features, m.ctrlrs, m.ctrlrResults,
@@ -347,7 +348,7 @@ func (m *mockControllerFactory) create(address string) (Control, error) {
 	controller := newMockControl(
 		address, m.state, m.connectRet, cClient, sClient)
 
-	err := controller.connect(address)
+	err := controller.connect(address, cfg)
 
 	return controller, err
 }

--- a/src/control/cmd/dmg/main.go
+++ b/src/control/cmd/dmg/main.go
@@ -30,12 +30,14 @@ import (
 
 	"github.com/daos-stack/daos/src/control/client"
 	"github.com/daos-stack/daos/src/control/log"
+
 	flags "github.com/jessevdk/go-flags"
 	"github.com/pkg/errors"
 )
 
 type cliOptions struct {
 	HostList string `short:"l" long:"host-list" description:"comma separated list of addresses <ipv4addr/hostname:port>"`
+	Insecure bool   `short:"i" long:"insecure" description:"have dmg attempt to connect without certificates"`
 	// TODO: implement host file parsing
 	HostFile   string  `short:"f" long:"host-file" description:"path of hostfile specifying list of addresses <ipv4addr/hostname:port>, if specified takes preference over HostList"`
 	ConfigPath string  `short:"o" long:"config-path" description:"Client config file path"`
@@ -64,6 +66,16 @@ func appSetup(broadcast bool) error {
 	if opts.HostFile != "" {
 		return errors.New("hostfile option not implemented")
 	}
+
+	if opts.Insecure == true {
+		config.TransportConfig.AllowInsecure = true
+	}
+
+	err = config.TransportConfig.PreLoadCertData()
+	if err != nil {
+		return errors.Wrap(err, "Unable to load Cerificate Data")
+	}
+	conns.SetTransportConfig(config.TransportConfig)
 
 	// broadcast app requests to host list by default
 	addresses := config.HostList
@@ -99,6 +111,7 @@ func dmgMain() error {
 
 	_, err := p.Parse()
 	if err != nil {
+		fmt.Println(err.Error())
 		return err
 	}
 

--- a/src/control/security/config.go
+++ b/src/control/security/config.go
@@ -1,0 +1,91 @@
+package security
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+
+	"github.com/pkg/errors"
+)
+
+// FIXME: These should probably not be used directly;
+// instead, add a function which determines the correct
+// root path and prepends it -- need to make it easy
+// to test, though.
+const (
+	defaultCACert     = ".daos/daosCA.crt"
+	defaultServerCert = ".daos/daos_server.crt"
+	defaultServerKey  = ".daos/daos_server.key"
+	defaultClientCert = ".daos/client.crt"
+	defaultClientKey  = ".daos/client.key"
+	defaultServer     = "server"
+	defaultInsecure   = false
+)
+
+type TransportConfig struct {
+	AllowInsecure     bool `yaml:"allow_insecure"`
+	CertificateConfig `yaml:",inline"`
+}
+
+type CertificateConfig struct {
+	ServerName      string           `yaml:"server_name,omitempty"`
+	CARootPath      string           `yaml:"ca_cert"`
+	CertificatePath string           `yaml:"cert"`
+	PrivateKeyPath  string           `yaml:"key"`
+	TLSKeypair      *tls.Certificate `yaml:"-"`
+	CAPool          *x509.CertPool   `yaml:"-"`
+}
+
+// TODO: Add docs/test coverage for these functions
+
+func DefaultClientTransportConfig() *TransportConfig {
+	return &TransportConfig{
+		AllowInsecure: defaultInsecure,
+		CertificateConfig: CertificateConfig{
+			ServerName:      defaultServer,
+			CARootPath:      defaultCACert,
+			CertificatePath: defaultClientCert,
+			PrivateKeyPath:  defaultClientKey,
+			TLSKeypair:      nil,
+			CAPool:          nil,
+		},
+	}
+}
+
+func DefaultServerTransportConfig() *TransportConfig {
+	return &TransportConfig{
+		AllowInsecure: defaultInsecure,
+		CertificateConfig: CertificateConfig{
+			CARootPath:      defaultCACert,
+			CertificatePath: defaultServerCert,
+			PrivateKeyPath:  defaultServerKey,
+			TLSKeypair:      nil,
+			CAPool:          nil,
+		},
+	}
+}
+
+func (cfg *TransportConfig) PreLoadCertData() error {
+	if cfg == nil {
+		return errors.New("nil TransportConfig")
+	}
+	if cfg.TLSKeypair != nil && cfg.CAPool != nil || cfg.AllowInsecure == true {
+		// In this case the data is already preloaded.
+		// In order to reload data use ReloadCertDatA
+		return nil
+	}
+	certificate, certPool, err := loadCertWithCustomCA(cfg.CARootPath, cfg.CertificatePath, cfg.PrivateKeyPath)
+	if err != nil {
+		return err
+	}
+
+	cfg.TLSKeypair = certificate
+	cfg.CAPool = certPool
+
+	return nil
+}
+
+func (cfg *TransportConfig) ReloadCertData() error {
+	cfg.TLSKeypair = nil
+	cfg.CAPool = nil
+	return cfg.PreLoadCertData()
+}

--- a/utils/certs/admin.cnf
+++ b/utils/certs/admin.cnf
@@ -6,7 +6,7 @@ basicConstraints = CA:FALSE
 
 [ distinguished_name ]
 organizationName = DAOS
-commonName = shell
+commonName = admin
 
 #In the future we can do username based certs for login
 #commonName = <username>

--- a/utils/certs/ca.cnf
+++ b/utils/certs/ca.cnf
@@ -41,6 +41,6 @@ extendedKeyUsage = clientAuth
 keyUsage = critical,digitalSignature,keyEncipherment
 extendedKeyUsage = serverAuth
 
-[ signing_shell ]
+[ signing_admin ]
 keyUsage = critical,digitalSignature,keyEncipherment
 extendedKeyUsage = clientAuth

--- a/utils/certs/gen_certificates.sh
+++ b/utils/certs/gen_certificates.sh
@@ -87,24 +87,24 @@ function generate_agent_cert () {
 	$CERTS/agent.crt"
 }
 
-function generate_shell_cert () {
-	echo "Generating Shell Certificate"
+function generate_admin_cert () {
+	echo "Generating Admin Certificate"
 	# Generate Private key and set its permissions
-	openssl genrsa -out $CERTS/shell.key 4096
-	chmod 400 $CERTS/shell.key
+	openssl genrsa -out $CERTS/admin.key 4096
+	chmod 400 $CERTS/admin.key
 	# Generate a Certificate Signing Request (CRS)
-	openssl req -new -config shell.cnf -key $CERTS/shell.key \
-		-out shell.csr -batch
+	openssl req -new -config admin.cnf -key $CERTS/admin.key \
+		-out admin.csr -batch
 	# Create Certificate from request
 	openssl ca -config ca.cnf -keyfile $PRIVATE/daosCA.key \
 		-cert $CERTS/daosCA.crt -policy signing_policy \
-		-extensions signing_shell -out $CERTS/shell.crt \
-		-outdir $CERTS -in shell.csr -batch
+		-extensions signing_admin -out $CERTS/admin.crt \
+		-outdir $CERTS -in admin.csr -batch
 
-	echo "Required Shell Certificate Files:
+	echo "Required Admin Certificate Files:
 	$CERTS/daosCA.crt
-	$CERTS/shell.key
-	$CERTS/shell.crt"
+	$CERTS/admin.key
+	$CERTS/admin.crt"
 }
 
 function generate_server_cert () {
@@ -130,7 +130,7 @@ function generate_server_cert () {
 function cleanup () {
 	rm -f $CERTS/*pem
 	rm -f agent.csr
-	rm -f shell.csr
+	rm -f admin.csr
 	rm -f server.csr
 }
 
@@ -138,7 +138,7 @@ function main () {
 	setup_directories
 	generate_ca_cert
 	generate_agent_cert
-	generate_shell_cert
+	generate_admin_cert
 	generate_server_cert
 	cleanup
 }

--- a/utils/config/daos_agent.yml
+++ b/utils/config/daos_agent.yml
@@ -30,16 +30,16 @@
 #hostlist: ['localhost:10001']
 
 ## Transport Credentials Specifying certificates to secure communications
-
+#
 #transport_config:
 #  # Specify to bypass loading certificates and use insecure communications channnels
 #  allow_insecure: false
 #  # Custom CA Root certificate for generated certs
 #  ca_cert: .daos/daosCA.crt
-#  # Server certificate for use in TLS handshakes
-#  cert: .daos/daos_server.crt
+#  # Agent certificate for use in TLS handshakes
+#  cert: .daos/daos_agent.crt
 #  # Key portion of Server Certificate
-#  key: .daos/daos_server.key
+#  key: .daos/daos_agent.key
 #  # Name of server accodring to its certificate
 #  server_name: server
 


### PR DESCRIPTION
… provide --insecure flag

The gRPC channel between the admin client and daos_server is protected with a
TLS channel. This adds the certificate loading and transport credential setup
to ensure that the channel is protected. It also adds an --insecure flag to the
dmg client to tell it to bypass trying to establish the channel and just use an
unencrypted http connection.

Signed-off-by: David Quigley <david.quigley@intel.com>