### PR TITLE
DAOS-2372 Security: Add server Certificate loading in daos_server for…

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -70,7 +70,7 @@ def rpm_test_daos_test = '''me=\\\$(whoami)
                             sudo mount -t tmpfs -o size=16777216k tmpfs /mnt/daos
                             sudo cp /tmp/daos_server_baseline.yaml /usr/etc/daos_server.yml
                             cat /usr/etc/daos_server.yml
-                            coproc orterun -np 1 -H \\\$HOSTNAME --enable-recovery -x DAOS_SINGLETON_CLI=1  daos_server -c 1 -a /tmp -o /usr/etc/daos_server.yml
+                            coproc orterun -np 1 -H \\\$HOSTNAME --enable-recovery -x DAOS_SINGLETON_CLI=1  daos_server -c 1 -a /tmp -o /usr/etc/daos_server.yml -i
                             trap 'set -x; kill -INT \\\$COPROC_PID' EXIT
                             line=\"\"
                             while [[ \"\\\$line\" != *started\\\\ on\\\\ rank\\\\ 0* ]]; do

--- a/src/control/server/commands.go
+++ b/src/control/server/commands.go
@@ -48,6 +48,7 @@ type cliOptions struct {
 	Rank        *rank   `short:"r" long:"rank" description:"[Temporary] Self rank"`
 	SocketDir   string  `short:"d" long:"socket_dir" description:"Location for all daos_server & daos_io_server sockets"`
 	Storage     StorCmd `command:"storage" alias:"st" description:"Perform tasks related to locally-attached storage"`
+	Insecure    bool    `short:"i" long:"insecure" description:"allow for insecure connections"`
 }
 
 // StorCmd is the struct representing the top-level storage subcommand.

--- a/src/control/server/config.go
+++ b/src/control/server/config.go
@@ -107,6 +107,11 @@ func loadConfigOpts(cliOpts *cliOptions, host string) (
 	}
 	log.Debugf("DAOS config read from %s", config.Path)
 
+	// Override certificate support if specified in cliOpts
+	if cliOpts.Insecure == true {
+		config.TransportConfig.AllowInsecure = true
+	}
+
 	// get unique identifier to activate SPDK multiprocess mode
 	config.NvmeShmID = hash(host + strconv.Itoa(os.Getpid()))
 
@@ -223,7 +228,9 @@ func (c *configuration) cmdlineOverride(opts *cliOptions) {
 		// global rank parameter should only apply to first I/O service
 		c.Servers[0].Rank = opts.Rank
 	}
-
+	if opts.Insecure == true {
+		c.TransportConfig.AllowInsecure = true
+	}
 	// override each per-server config
 	for i := range c.Servers {
 		srv := &c.Servers[i]

--- a/src/control/server/config_types.go
+++ b/src/control/server/config_types.go
@@ -24,15 +24,17 @@
 package server
 
 import (
-	"os"
 	"fmt"
 	"math"
+	"os"
 	"path/filepath"
 	"strconv"
 	"strings"
 
 	"github.com/pkg/errors"
-	"gopkg.in/yaml.v2"
+	yaml "gopkg.in/yaml.v2"
+
+	"github.com/daos-stack/daos/src/control/security"
 )
 
 const (
@@ -175,7 +177,7 @@ type server struct {
 	// ioParams represents commandline options and environment variables
 	// to be passed on I/O server invocation.
 	CliOpts   []string      // tuples (short option, value) e.g. ["-p", "10000"...]
-	Hostname string   // used when generating templates
+	Hostname  string        // used when generating templates
 	formatted chan struct{} // closed when server is formatted
 }
 
@@ -187,7 +189,7 @@ func newDefaultServer() server {
 	return server{
 		ScmClass:    scmDCPM,
 		BdevClass:   bdNVMe,
-		Hostname:  host,
+		Hostname:    host,
 		NrXsHelpers: 2,
 	}
 }
@@ -215,27 +217,25 @@ func (s *server) UnmarshalYAML(unmarshal func(interface{}) error) error {
 // configuration describes options for DAOS control plane.
 // See utils/config/daos_server.yml for parameter descriptions.
 type configuration struct {
-	SystemName     string          `yaml:"name"`
-	Servers        []server        `yaml:"servers"`
-	Provider       string          `yaml:"provider"`
-	SocketDir      string          `yaml:"socket_dir"`
-	AccessPoints   []string        `yaml:"access_points"`
-	Port           int             `yaml:"port"`
-	CaCert         string          `yaml:"ca_cert"`
-	Cert           string          `yaml:"cert"`
-	Key            string          `yaml:"key"`
-	FaultPath      string          `yaml:"fault_path"`
-	FaultCb        string          `yaml:"fault_cb"`
-	FabricIfaces   []string        `yaml:"fabric_ifaces"`
-	ScmMountPath   string          `yaml:"scm_mount_path"`
-	BdevInclude    []string        `yaml:"bdev_include"`
-	BdevExclude    []string        `yaml:"bdev_exclude"`
-	Hyperthreads   bool            `yaml:"hyperthreads"`
-	NrHugepages    int             `yaml:"nr_hugepages"`
-	ControlLogMask ControlLogLevel `yaml:"control_log_mask"`
-	ControlLogFile string          `yaml:"control_log_file"`
-	UserName       string          `yaml:"user_name"`
-	GroupName      string          `yaml:"group_name"`
+	SystemName      string                    `yaml:"name"`
+	Servers         []server                  `yaml:"servers"`
+	Provider        string                    `yaml:"provider"`
+	SocketDir       string                    `yaml:"socket_dir"`
+	AccessPoints    []string                  `yaml:"access_points"`
+	Port            int                       `yaml:"port"`
+	TransportConfig *security.TransportConfig `yaml:"transport_config"`
+	FaultPath       string                    `yaml:"fault_path"`
+	FaultCb         string                    `yaml:"fault_cb"`
+	FabricIfaces    []string                  `yaml:"fabric_ifaces"`
+	ScmMountPath    string                    `yaml:"scm_mount_path"`
+	BdevInclude     []string                  `yaml:"bdev_include"`
+	BdevExclude     []string                  `yaml:"bdev_exclude"`
+	Hyperthreads    bool                      `yaml:"hyperthreads"`
+	NrHugepages     int                       `yaml:"nr_hugepages"`
+	ControlLogMask  ControlLogLevel           `yaml:"control_log_mask"`
+	ControlLogFile  string                    `yaml:"control_log_file"`
+	UserName        string                    `yaml:"user_name"`
+	GroupName       string                    `yaml:"group_name"`
 	// development (subject to change) config fields
 	Modules   string
 	Attach    string
@@ -273,19 +273,18 @@ func (c *configuration) checkMount(path string) error {
 // populated with defaults.
 func newDefaultConfiguration(ext External) configuration {
 	return configuration{
-		SystemName:     "daos_server",
-		SocketDir:      "/var/run/daos_server",
-		AccessPoints:   []string{"localhost"},
-		Port:           10000,
-		Cert:           "./.daos/daos_server.crt",
-		Key:            "./.daos/daos_server.key",
-		ScmMountPath:   "/mnt/daos",
-		Hyperthreads:   false,
-		NrHugepages:    1024,
-		Path:           "etc/daos_server.yml",
-		NvmeShmID:      0,
-		ControlLogMask: cLogDebug,
-		ext:            ext,
+		SystemName:      "daos_server",
+		SocketDir:       "/var/run/daos_server",
+		AccessPoints:    []string{"localhost"},
+		Port:            10000,
+		TransportConfig: security.DefaultServerTransportConfig(),
+		ScmMountPath:    "/mnt/daos",
+		Hyperthreads:    false,
+		NrHugepages:     1024,
+		Path:            "etc/daos_server.yml",
+		NvmeShmID:       0,
+		ControlLogMask:  cLogDebug,
+		ext:             ext,
 	}
 }
 

--- a/src/control/server/iosrv.go
+++ b/src/control/server/iosrv.go
@@ -38,13 +38,14 @@ import (
 	uuid "github.com/satori/go.uuid"
 	"golang.org/x/net/context"
 	"google.golang.org/grpc"
-	"gopkg.in/yaml.v2"
+	yaml "gopkg.in/yaml.v2"
 
 	"github.com/daos-stack/daos/src/control/common"
 	mgmtpb "github.com/daos-stack/daos/src/control/common/proto/mgmt"
 	srvpb "github.com/daos-stack/daos/src/control/common/proto/srv"
 	"github.com/daos-stack/daos/src/control/drpc"
 	"github.com/daos-stack/daos/src/control/log"
+	"github.com/daos-stack/daos/src/control/security"
 	"github.com/golang/protobuf/proto"
 )
 
@@ -337,13 +338,15 @@ func (srv *iosrv) setRank(ready *srvpb.NotifyReadyReq) error {
 	}
 
 	if !srv.super.ValidRank || !srv.super.MS {
-		resp, err := mgmtJoin(srv.config.AccessPoints[0], &mgmtpb.JoinReq{
-			Uuid:  srv.super.UUID,
-			Rank:  uint32(r),
-			Uri:   ready.Uri,
-			Nctxs: ready.Nctxs,
-			Addr:  fmt.Sprintf("0.0.0.0:%d", srv.config.Port),
-		})
+		resp, err := mgmtJoin(srv.config.AccessPoints[0],
+			srv.config.TransportConfig,
+			&mgmtpb.JoinReq{
+				Uuid:  srv.super.UUID,
+				Rank:  uint32(r),
+				Uri:   ready.Uri,
+				Nctxs: ready.Nctxs,
+				Addr:  fmt.Sprintf("0.0.0.0:%d", srv.config.Port),
+			})
 		if err != nil {
 			return err
 		} else if resp.State == mgmtpb.JoinResp_OUT {
@@ -432,12 +435,18 @@ func (srv *iosrv) writeSuper() error {
 
 // mgmtJoin sends the Join request to MS, retrying indefinitely until MS
 // responses.
-func mgmtJoin(ap string, req *mgmtpb.JoinReq) (*mgmtpb.JoinResp, error) {
+func mgmtJoin(ap string, tc *security.TransportConfig, req *mgmtpb.JoinReq) (*mgmtpb.JoinResp, error) {
 	log.Debugf("join(%s, %+v)", ap, *req)
+	var opts []grpc.DialOption
+	authDialOption, err := security.DialOptionForTransportConfig(tc)
+	if err != nil {
+		return nil, errors.Wrap(err, "Failed to determine dial option from TransportConfig")
+	}
 
-	conn, err := grpc.Dial(ap, grpc.WithInsecure(), grpc.WithBlock(),
-		grpc.WithBackoffMaxDelay(5*time.Second),
-		grpc.WithDefaultCallOptions(grpc.FailFast(false)))
+	// Setup Dial Options that will always be included.
+	opts = append(opts, grpc.WithBlock(), grpc.WithBackoffMaxDelay(5*time.Second),
+		grpc.WithDefaultCallOptions(grpc.FailFast(false)), authDialOption)
+	conn, err := grpc.Dial(ap, opts...)
 	if err != nil {
 		return nil, errors.Wrapf(err, "dial %s", ap)
 	}

--- a/src/control/server/server.go
+++ b/src/control/server/server.go
@@ -30,6 +30,7 @@ import (
 
 	mgmtpb "github.com/daos-stack/daos/src/control/common/proto/mgmt"
 	"github.com/daos-stack/daos/src/control/log"
+	"github.com/daos-stack/daos/src/control/security"
 	"github.com/daos-stack/daos/src/control/security/acl"
 	flags "github.com/jessevdk/go-flags"
 	"google.golang.org/grpc"
@@ -85,7 +86,6 @@ func Main() error {
 	if f != nil {
 		defer f.Close()
 	}
-
 	// Create and setup control service.
 	mgmtCtlSvc, err := newControlService(
 		&config, getDrpcClientConnection(config.SocketDir))
@@ -108,8 +108,13 @@ func Main() error {
 	// Create new grpc server, register services and start serving (after
 	// dropping privileges).
 	var sOpts []grpc.ServerOption
-	// TODO: This will need to be extended to take certificate information for
-	// the TLS protected channel. Currently it is an "insecure" channel.
+
+	opt, err := security.ServerOptionForTransportConfig(config.TransportConfig)
+	if err != nil {
+		return err
+	}
+	sOpts = append(sOpts, opt)
+
 	grpcServer := grpc.NewServer(sOpts...)
 
 	mgmtpb.RegisterMgmtCtlServer(grpcServer, mgmtCtlSvc)

--- a/src/control/server/testdata/expect_daos_server.yml
+++ b/src/control/server/testdata/expect_daos_server.yml
@@ -5,9 +5,11 @@ socket_dir: /var/run/daos_server
 access_points:
 - localhost
 port: 10000
-ca_cert: ""
-cert: ./.daos/daos_server.crt
-key: ./.daos/daos_server.key
+transport_config:
+  allow_insecure: false
+  ca_cert: .daos/daosCA.crt
+  cert: .daos/daos_server.crt
+  key: .daos/daos_server.key
 fault_path: ""
 fault_cb: ""
 fabric_ifaces: []

--- a/src/control/server/testdata/expect_daos_server_psm2.yml
+++ b/src/control/server/testdata/expect_daos_server_psm2.yml
@@ -29,9 +29,11 @@ socket_dir: /tmp/daos_psm2
 access_points:
 - localhost
 port: 10001
-ca_cert: ""
-cert: ./.daos/daos_server.crt
-key: ./.daos/daos_server.key
+transport_config:
+  allow_insecure: false
+  ca_cert: .daos/daosCA.crt
+  cert: .daos/daos_server.crt
+  key: .daos/daos_server.key
 fault_path: ""
 fault_cb: ""
 fabric_ifaces: []

--- a/src/control/server/testdata/expect_daos_server_sockets.yml
+++ b/src/control/server/testdata/expect_daos_server_sockets.yml
@@ -30,9 +30,11 @@ socket_dir: /tmp/daos_sockets
 access_points:
 - localhost
 port: 10001
-ca_cert: ""
-cert: ./.daos/daos_server.crt
-key: ./.daos/daos_server.key
+transport_config:
+  allow_insecure: false
+  ca_cert: .daos/daosCA.crt
+  cert: .daos/daos_server.crt
+  key: .daos/daos_server.key
 fault_path: ""
 fault_cb: ""
 fabric_ifaces: []

--- a/src/control/server/testdata/expect_daos_server_uncomment.yml
+++ b/src/control/server/testdata/expect_daos_server_uncomment.yml
@@ -51,9 +51,11 @@ access_points:
 - hostname2
 - hostname3
 port: 10001
-ca_cert: ./.daos/ca.crt
-cert: ./.daosa/daos_server.crt
-key: ./.daosa/daos_server.key
+transport_config:
+  allow_insecure: false
+  ca_cert: .daos/daosCA.crt
+  cert: .daos/daos_server.crt
+  key: .daos/daos_server.key
 fault_path: /vcdu0/rack1/hostname
 fault_cb: ./.daos/fd_callback
 fabric_ifaces:

--- a/src/control/server/testdata/input_good.txt
+++ b/src/control/server/testdata/input_good.txt
@@ -9,9 +9,10 @@ access_points:
 - foo1.com:9999
 - bar1.com:1111
 port: 11111
-ca_cert: /tmp/ca.crt
-cert: /tmp/serv.crt
-key: /tmp/serv.key
+transport_config:
+  ca_cert: /tmp/ca.crt
+  cert: /tmp/serv.crt
+  key: /tmp/serv.key
 fault_path: /foo.com
 fault_cb: /tmp/daos_fault_cb.sh
 fabric_ifaces:

--- a/src/control/server/testdata/output_success.txt
+++ b/src/control/server/testdata/output_success.txt
@@ -5,9 +5,11 @@ socket_dir: /var/run/daos_server
 access_points:
 - localhost
 port: 10000
-ca_cert: ""
-cert: ./.daos/daos_server.crt
-key: ./.daos/daos_server.key
+transport_config:
+  allow_insecure: false
+  ca_cert: .daos/daosCA.crt
+  cert: .daos/daos_server.crt
+  key: .daos/daos_server.key
 fault_path: ""
 fault_cb: ""
 fabric_ifaces: []
@@ -23,9 +25,11 @@ socket_dir: /var/run/daos_server
 access_points:
 - localhost
 port: 10000
-ca_cert: ""
-cert: ./.daos/daos_server.crt
-key: ./.daos/daos_server.key
+transport_config:
+  allow_insecure: false
+  ca_cert: .daos/daosCA.crt
+  cert: .daos/daos_server.crt
+  key: .daos/daos_server.key
 fault_path: ""
 fault_cb: ""
 fabric_ifaces: []
@@ -42,9 +46,11 @@ access_points:
 - foo1.com:9999
 - bar1.com:1111
 port: 11111
-ca_cert: /tmp/ca.crt
-cert: /tmp/serv.crt
-key: /tmp/serv.key
+transport_config:
+  allow_insecure: false
+  ca_cert: /tmp/ca.crt
+  cert: /tmp/serv.crt
+  key: /tmp/serv.key
 fault_path: /foo.com
 fault_cb: /tmp/daos_fault_cb.sh
 fabric_ifaces:
@@ -57,4 +63,3 @@ bdev_include:
 bdev_exclude:
 - pcie1000.0.0.0.7
 hyperthreads: true
-

--- a/src/rdb/tests/rdb_test_runner.py
+++ b/src/rdb/tests/rdb_test_runner.py
@@ -105,7 +105,7 @@ def start_server(binfo):
     cmd += "-x LD_LIBRARY_PATH "
     cmd += binfo.get("PREFIX") + "/bin/daos_server "
     cmd += "-o {} ".format(config_file)
-    cmd += "-d ./ -t 1 -m vos,rdb,rsvc,rdbt "
+    cmd += "-d ./ -t 1 -m vos,rdb,rsvc,rdbt -i"
     print("Running command:\n{}".format(cmd))
     sys.stdout.flush()
 

--- a/src/tests/ftest/util/server_utils.py
+++ b/src/tests/ftest/util/server_utils.py
@@ -163,7 +163,8 @@ def run_server(hostfile, setname, basepath, uri_path=None, env_dict=None):
             server_cmd.extend(["--report-uri", uri_path])
         server_cmd.extend(["--hostfile", hostfile, "--enable-recovery"])
         server_cmd.extend(env_args)
-        server_cmd.extend([daos_srv_bin,
+	# For now run server in insecure mode until Certificate tests are in place
+        server_cmd.extend([daos_srv_bin, "-i",
                            "-a", os.path.join(basepath, "install", "tmp"),
                            "-o", '{}/{}'.format(basepath, AVOCADO_FILE)])
 

--- a/utils/config/daos_server.yml
+++ b/utils/config/daos_server.yml
@@ -31,22 +31,17 @@
 ## default: 10000
 #port: 10001
 #
+## Transport Credentials Specifying certificates to secure communications
 #
-## Path to CA certificate
-#
-## If not specified, DAOS will start in insecure way which means that
-## anybody can administrate the DAOS installation and access data
-#
-#ca_cert: ./.daos/ca.crt
-#
-#
-## Path to server certificate and key file
-#
-## Discarded if no CA certificate is passed.
-#
-## default: ./.daos/daos_server.{crt,key}
-#cert: ./.daosa/daos_server.crt
-#key: ./.daosa/daos_server.key
+#transport_config:
+#  # Specify to bypass loading certificates and use insecure communications channnels
+#  allow_insecure: false
+#  # Custom CA Root certificate for generated certs
+#  ca_cert: .daos/daosCA.crt
+#  # Server certificate for use in TLS handshakes
+#  cert: .daos/daos_server.crt
+#  # Key portion of Server Certificate
+#  key: .daos/daos_server.key
 #
 #
 ## Fault domain path


### PR DESCRIPTION
… gRPC and provide --insecure flag

The gRPC server in daos_server can use a TLS channel to protect its
communications. This loads up the certificates needed to verify the client
identity and encrypt the transport channel. It also provides an insecure flag
to tell the sever not to attempt any authentication or encryption.

Signed-off-by: David Quigley <david.quigley@intel.com>