### PR TITLE
DAOS-2716 rebuild: typo in rebuild object send

### DIFF
--- a/src/rebuild/scan.c
+++ b/src/rebuild/scan.c
@@ -268,7 +268,7 @@ rebuild_objects_send(struct rebuild_root *root, unsigned int tgt_id,
 		}
 
 		for (i = 0; i < failed_tgts_cnt; i++) {
-			if (targets[i].ta_comp.co_rank == tgt_id) {
+			if (targets[i].ta_comp.co_id == tgt_id) {
 				target_failed = true;
 				break;
 			}

--- a/src/tests/ftest/daos_test/daos_core_test.yaml
+++ b/src/tests/ftest/daos_test/daos_core_test.yaml
@@ -20,10 +20,38 @@ daos_tests:
   num_replicas:
     num_replicas: 1
   Tests: !mux
-    test_r:
+    test_r_0-24:
       daos_test: r
       test_name: rebuild tests
-      args: -s3 -u subtests="0-23"
+      args: -s3 -u subtests="0-24"
+    test_r_25:
+      daos_test: r
+      test_name: rebuild tests
+      args: -s3 -u subtests="25"
+    test_r_26:
+      daos_test: r
+      test_name: rebuild tests
+      args: -s3 -u subtests="26"
+    test_r_27:
+      daos_test: r
+      test_name: rebuild tests
+      args: -s3 -u subtests="27"
+    test_r_28:
+      daos_test: r
+      test_name: rebuild tests
+      args: -s3 -u subtests="28"
+    test_r_29:
+      daos_test: r
+      test_name: rebuild tests
+      args: -s3 -u subtests="29"
+    test_r_30:
+      daos_test: r
+      test_name: rebuild tests
+      args: -s3 -u subtests="30"
+    test_r_31:
+      daos_test: r
+      test_name: rebuild tests
+      args: -s3 -u subtests="31"
     test_d:
       daos_test: d
       test_name: DAOS degraded-mode tests

--- a/src/tests/suite/daos_rebuild.c
+++ b/src/tests/suite/daos_rebuild.c
@@ -1024,11 +1024,18 @@ static void
 rebuild_tgt_start_fail(void **state)
 {
 	test_arg_t	*arg = *state;
+	test_arg_t	*new_arg = NULL;
 	daos_obj_id_t	oids[OBJ_NR];
 	d_rank_t	exclude_rank = 0;
+	int		rc;
 	int		i;
 
 	if (!test_runable(arg, 6))
+		return;
+
+	/* create/connect another pool */
+	rc = rebuild_pool_create(&new_arg, arg, SETUP_CONT_CONNECT, NULL);
+	if (rc)
 		return;
 
 	for (i = 0; i < OBJ_NR; i++) {
@@ -1036,20 +1043,20 @@ rebuild_tgt_start_fail(void **state)
 		oids[i] = dts_oid_set_rank(oids[i], ranks_to_kill[0]);
 	}
 
-	rebuild_io(arg, oids, OBJ_NR);
+	rebuild_io(new_arg, oids, OBJ_NR);
 
 	/* failed to start rebuild on rank 0 */
 	if (arg->myrank == 0)
-		daos_mgmt_set_params(arg->group, exclude_rank, DSS_KEY_FAIL_LOC,
+		daos_mgmt_set_params(new_arg->group, exclude_rank,
+				     DSS_KEY_FAIL_LOC,
 				  DAOS_REBUILD_TGT_START_FAIL | DAOS_FAIL_ONCE,
 				  0, NULL);
 	MPI_Barrier(MPI_COMM_WORLD);
-	rebuild_single_pool_rank(arg, ranks_to_kill[0]);
 
-	rebuild_io_validate(arg, oids, OBJ_NR, true);
-
-	rebuild_add_back_tgts(arg, ranks_to_kill[0], NULL, 1);
-	rebuild_add_back_tgts(arg, exclude_rank, NULL, 1);
+	/* Rebuild rank 1 */
+	rebuild_single_pool_rank(new_arg, ranks_to_kill[0]);
+	rebuild_io_validate(new_arg, oids, OBJ_NR, true);
+	rebuild_pool_destroy(new_arg);
 }
 
 static void

--- a/src/tests/suite/daos_test_common.c
+++ b/src/tests/suite/daos_test_common.c
@@ -732,7 +732,7 @@ daos_kill_server(test_arg_t *arg, const uuid_t pool_uuid, const char *grp,
 	arg->srv_disabled_ntgts += tgts_per_node;
 	if (d_rank_in_rank_list(svc, rank))
 		svc->rl_nr--;
-	print_message("\tKilling target %d (total of %d with %d already "
+	print_message("\tKilling rank %d (total of %d with %d already "
 		      "disabled, svc->rl_nr %d)!\n", rank, arg->srv_ntgts,
 		       arg->srv_disabled_ntgts - 1, svc->rl_nr);
 


### PR DESCRIPTION
It should compare target id, instead of rank, otherwise
rebuild object might missing.

Signed-off-by: Wang Di <di.wang@intel.com>