### PR TITLE
DAOS-2715 tests: Adding small ior test ro be run in CI

### DIFF
--- a/src/tests/ftest/io/ior_single_server.py
+++ b/src/tests/ftest/io/ior_single_server.py
@@ -67,6 +67,9 @@ class IorSingleServer(Test):
                                             self.workdir, None))
         print("Host file clientsis: {}".format(self.hostfile_clients))
 
+        # set ior_flags to be used by test
+        self.ior_flags = self.params.get("F", '/run/ior/iorflags/')
+        
         self.agent_sessions = agent_utils.run_agent(self.basepath,
                                                     self.hostlist_servers,
                                                     self.hostlist_clients)
@@ -105,7 +108,6 @@ class IorSingleServer(Test):
         # ior parameters
         client_processes = self.params.get("np", '/run/ior/client_processes/*/')
         iteration = self.params.get("iter", '/run/ior/iteration/')
-        ior_flags = self.params.get("F", '/run/ior/iorflags/')
         transfer_size = self.params.get("t",
                                         '/run/ior/transfersize_blocksize/*/')
         block_size = self.params.get("b", '/run/ior/transfersize_blocksize/*/')
@@ -126,7 +128,7 @@ class IorSingleServer(Test):
                 svc_list += str(tmp_rank_list[item]) + ":"
             svc_list = svc_list[:-1]
 
-            ior_utils.run_ior_daos(self.hostfile_clients, ior_flags, iteration,
+            ior_utils.run_ior_daos(self.hostfile_clients, self.ior_flags, iteration,
                                    block_size, transfer_size, pool_uuid,
                                    svc_list, object_class, self.basepath,
                                    client_processes)

--- a/src/tests/ftest/io/ior_single_server.py
+++ b/src/tests/ftest/io/ior_single_server.py
@@ -69,7 +69,7 @@ class IorSingleServer(Test):
 
         # set ior_flags to be used by test
         self.ior_flags = self.params.get("F", '/run/ior/iorflags/')
-        
+
         self.agent_sessions = agent_utils.run_agent(self.basepath,
                                                     self.hostlist_servers,
                                                     self.hostlist_clients)
@@ -128,10 +128,10 @@ class IorSingleServer(Test):
                 svc_list += str(tmp_rank_list[item]) + ":"
             svc_list = svc_list[:-1]
 
-            ior_utils.run_ior_daos(self.hostfile_clients, self.ior_flags, iteration,
-                                   block_size, transfer_size, pool_uuid,
-                                   svc_list, object_class, self.basepath,
-                                   client_processes)
+            ior_utils.run_ior_daos(self.hostfile_clients, self.ior_flags,
+                                   iteration, block_size, transfer_size,
+                                   pool_uuid, svc_list, object_class,
+                                   self.basepath, client_processes)
 
         except (DaosApiError, ior_utils.IorFailed) as excep:
             self.fail("<Single Server Test FAILED>\n {}".format(excep))

--- a/src/tests/ftest/io/ior_single_server.py
+++ b/src/tests/ftest/io/ior_single_server.py
@@ -67,8 +67,9 @@ class IorSingleServer(Test):
                                             self.workdir, None))
         print("Host file clientsis: {}".format(self.hostfile_clients))
 
-        # set ior_flags to be used by test
+        # set ior_flags and object class to be used by test
         self.ior_flags = self.params.get("F", '/run/ior/iorflags/')
+        self.object_class = self.params.get("o", '/run/ior/objectclass/')
 
         self.agent_sessions = agent_utils.run_agent(self.basepath,
                                                     self.hostlist_servers,
@@ -111,7 +112,6 @@ class IorSingleServer(Test):
         transfer_size = self.params.get("t",
                                         '/run/ior/transfersize_blocksize/*/')
         block_size = self.params.get("b", '/run/ior/transfersize_blocksize/*/')
-        object_class = self.params.get("o", '/run/ior/objectclass/')
 
         try:
             # initialize a python pool object then create the underlying
@@ -130,7 +130,7 @@ class IorSingleServer(Test):
 
             ior_utils.run_ior_daos(self.hostfile_clients, self.ior_flags,
                                    iteration, block_size, transfer_size,
-                                   pool_uuid, svc_list, object_class,
+                                   pool_uuid, svc_list, self.object_class,
                                    self.basepath, client_processes)
 
         except (DaosApiError, ior_utils.IorFailed) as excep:

--- a/src/tests/ftest/io/ior_small.py
+++ b/src/tests/ftest/io/ior_small.py
@@ -45,4 +45,5 @@ class IorSmall(IorSingleServer):
         # override ior flags and object class
         self.ior_flags = self.params.get("F", '/run/ior/iorflags/*/')
         self.object_class = self.params.get("o", '/run/ior/objectclass/*/')
+
         IorSingleServer.test_singleserver(self)

--- a/src/tests/ftest/io/ior_small.py
+++ b/src/tests/ftest/io/ior_small.py
@@ -42,5 +42,7 @@ class IorSmall(IorSingleServer):
                   multiple client processes in two separate nodes.
         :avocado: tags=all,daosio,small,iorsmall
         """
+        # override ior flags and object class
         self.ior_flags = self.params.get("F", '/run/ior/iorflags/*/')
+        self.object_class = self.params.get("o", '/run/ior/objectclass/*/')
         IorSingleServer.test_singleserver(self)

--- a/src/tests/ftest/io/ior_small.py
+++ b/src/tests/ftest/io/ior_small.py
@@ -44,4 +44,3 @@ class IorSmall(IorSingleServer):
         """
         self.ior_flags = self.params.get("F", '/run/ior/iorflags/*/')
         IorSingleServer.test_singleserver(self)
-

--- a/src/tests/ftest/io/ior_small.py
+++ b/src/tests/ftest/io/ior_small.py
@@ -1,0 +1,47 @@
+#!/usr/bin/python
+'''
+  (C) Copyright 2018-2019 Intel Corporation.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+  GOVERNMENT LICENSE RIGHTS-OPEN SOURCE SOFTWARE
+  The Government's rights to use, modify, reproduce, release, perform, display,
+  or disclose this software are subject to the terms of the Apache License as
+  provided in Contract No. B609815.
+  Any reproduction of computer software, computer software documentation, or
+  portions thereof marked with this legend must also reproduce the markings.
+'''
+
+from ior_single_server import IorSingleServer
+
+class IorSmall(IorSingleServer):
+    """
+    Running Ior for smaller configuration
+    :avocado: recursive
+    """
+    def test_ior_small(self):
+        """
+        Jira ID: DAOS-2715
+        Test Description: Purpose of this test is to have small ior test
+                          to check basic functionality.
+        Use case: Run ior with read, write, CheckWrite, CheckRead in ssf mode.
+                  Run ior with read, write, CheckWrite, CheckRead in fpp mode.
+                  Run ior with read, write, CheckWrite and access to random
+                  offset instead of sequential.
+                  All above three cases to be run with single client and
+                  multiple client processes in two separate nodes.
+        :avocado: tags=all,daosio,small,iorsmall
+        """
+        self.ior_flags = self.params.get("F", '/run/ior/iorflags/*/')
+        IorSingleServer.test_singleserver(self)
+

--- a/src/tests/ftest/io/ior_small.yaml
+++ b/src/tests/ftest/io/ior_small.yaml
@@ -1,0 +1,42 @@
+hosts:
+   test_machines:
+        test_servers:
+            - boro-A
+        test_clients:
+            - boro-B
+            - boro-C
+timeout: 600
+server_config:
+    name: daos_server
+createtests:
+    createmode:
+        mode_RW:
+             mode: 146
+    createset:
+        setname: daos_server
+    createsize:
+        size: 3000000000
+    createsvc:
+        svcn: 1
+ior:
+    client_processes: !mux
+        np_1:
+            np: 1
+        np_8:
+            np: 8
+    iteration:
+        iter: 3
+    iorflags: !mux
+        ssf:
+          F: "-v -W -w -r -R"
+        fpp:
+          F: "-v -W -w -r -R -F"
+# Uncomment when DAOS-1733 is resolved
+#        random:
+#          F: "-v -W -w -r -z"
+    transfersize_blocksize:
+        1M:
+            t: '1M'
+            b: '64M'
+    objectclass:
+            o: "LARGE"

--- a/src/tests/ftest/io/ior_small.yaml
+++ b/src/tests/ftest/io/ior_small.yaml
@@ -1,11 +1,16 @@
 hosts:
    test_machines:
         test_servers:
-            - boro-A
+            - boro-64
+            - boro-60
+            - boro-61
+            - boro-62
         test_clients:
-            - boro-B
-            - boro-C
-timeout: 600
+            - boro-8
+            - boro-61
+#            - boro-11
+#            - boro-61
+timeout: 6000
 server_config:
     name: daos_server
 createtests:
@@ -15,28 +20,36 @@ createtests:
     createset:
         setname: daos_server
     createsize:
-        size: 3000000000
+        size: 6000000000
     createsvc:
         svcn: 1
 ior:
     client_processes: !mux
-        np_1:
-            np: 1
-        np_8:
-            np: 8
+        np_16:
+            np: 16
+#        np_8:
+#            np: 16
+#        np_32:
+#            np: 32
     iteration:
-        iter: 3
+        iter: 2
     iorflags: !mux
-        ssf:
-          F: "-v -W -w -r -R"
+#        ssf:
+#          F: "-v -W -w -r -R"
         fpp:
           F: "-v -W -w -r -R -F"
 # Uncomment when DAOS-1733 is resolved
 #        random:
 #          F: "-v -W -w -r -z"
-    transfersize_blocksize:
-        1M:
-            t: '1M'
-            b: '64M'
-    objectclass:
-            o: "LARGE"
+    transfersize_blocksize: !mux
+        256B:
+            t: '256B'
+            b: '4M'
+#        1M:
+#            t: '1M'
+#            b: '32M'
+    objectclass: !mux
+#        oclass_Large:
+#            o: "LARGE"
+        oclass_R2:
+            o: "R2"

--- a/src/tests/ftest/io/ior_small.yaml
+++ b/src/tests/ftest/io/ior_small.yaml
@@ -1,16 +1,16 @@
 hosts:
    test_machines:
         test_servers:
-            - boro-64
-            - boro-60
-            - boro-61
-            - boro-62
+            - boro-A
+            - boro-B
+            - boro-C
+            - boro-D
         test_clients:
-            - boro-8
-            - boro-61
-#            - boro-11
-#            - boro-61
-timeout: 6000
+            - boro-E
+            - boro-F
+            - boro-G
+            - boro-H
+timeout: 300
 server_config:
     name: daos_server
 createtests:
@@ -20,22 +20,18 @@ createtests:
     createset:
         setname: daos_server
     createsize:
-        size: 6000000000
+        size: 3000000000
     createsvc:
         svcn: 1
 ior:
-    client_processes: !mux
+    client_processes:
         np_16:
             np: 16
-#        np_8:
-#            np: 16
-#        np_32:
-#            np: 32
     iteration:
         iter: 2
     iorflags: !mux
-#        ssf:
-#          F: "-v -W -w -r -R"
+        ssf:
+          F: "-v -W -w -r -R"
         fpp:
           F: "-v -W -w -r -R -F"
 # Uncomment when DAOS-1733 is resolved
@@ -45,11 +41,12 @@ ior:
         256B:
             t: '256B'
             b: '4M'
-#        1M:
-#            t: '1M'
-#            b: '32M'
+        1M:
+            t: '1M'
+            b: '32M'
     objectclass: !mux
-#        oclass_Large:
-#            o: "LARGE"
-        oclass_R2:
-            o: "R2"
+        oclass_Large:
+            o: "LARGE"
+# Uncomment when DAOS-2305 is resolved
+#        oclass_R2:
+#            o: "R2"


### PR DESCRIPTION
Intention of this test is to be run as part of regular
CI test with each pr submission.
Use cases:
Run ior with read, write, CheckWrite, CheckRead in ssf mode.
Run ior with read, write, CheckWrite, CheckRead in fpp mode.
Run ior with read, write, CheckWrite and access to random
offset instead of sequential.
All above three cases to be run with single client and
multiple client processes in two separate nodes.

Change-Id: I2b2a2ebe64bdf49d4517d985db86b826945a17f3
Signed-off-by: Saurabh Tandan <saurabh.tandan@intel.com>