### PR TITLE
DAOS-2444 RPC: fix some RPC fileds unalign issue

### DIFF
--- a/src/include/daos_types.h
+++ b/src/include/daos_types.h
@@ -785,9 +785,9 @@ typedef struct {
 	 */
 	uint32_t	kd_val_types;
 	/** Checksum type */
-	unsigned int	kd_csum_type;
+	uint16_t	kd_csum_type;
 	/** Checksum length */
-	unsigned short	kd_csum_len;
+	uint16_t	kd_csum_len;
 } daos_key_desc_t;
 
 /**

--- a/src/object/cli_obj.c
+++ b/src/object/cli_obj.c
@@ -1915,7 +1915,7 @@ obj_comp_cb(tse_task_t *task, void *data)
 
 /* register the completion cb for obj IO request */
 static int
-obj_comp_cb_reg(tse_task_t *task, int opc, uint32_t map_ver,
+obj_reg_comp_cb(tse_task_t *task, int opc, uint32_t map_ver,
 		struct obj_auxi_args **auxi, void *cb_arg, daos_size_t arg_sz)
 {
 	struct obj_auxi_args	*obj_auxi;
@@ -1975,7 +1975,7 @@ dc_obj_fetch(tse_task_t *task)
 		D_GOTO(out_task, rc);
 	}
 
-	rc = obj_comp_cb_reg(task, DAOS_OBJ_RPC_FETCH, map_ver, &obj_auxi,
+	rc = obj_reg_comp_cb(task, DAOS_OBJ_RPC_FETCH, map_ver, &obj_auxi,
 			     &obj, sizeof(obj));
 	if (rc != 0) {
 		obj_decref(obj);
@@ -2046,7 +2046,7 @@ dc_obj_update(tse_task_t *task)
 		}
 	}
 
-	rc = obj_comp_cb_reg(task, DAOS_OBJ_RPC_UPDATE, map_ver, &obj_auxi,
+	rc = obj_reg_comp_cb(task, DAOS_OBJ_RPC_UPDATE, map_ver, &obj_auxi,
 			     &obj, sizeof(obj));
 	if (rc != 0) {
 		obj_decref(obj);
@@ -2128,7 +2128,7 @@ dc_obj_list_internal(tse_task_t *task, int opc, daos_obj_list_t *args)
 	list_args.anchor = args->anchor;
 	list_args.dkey_anchor = args->dkey_anchor;
 	list_args.akey_anchor = args->akey_anchor;
-	rc = obj_comp_cb_reg(task, opc, map_ver, &obj_auxi, &list_args,
+	rc = obj_reg_comp_cb(task, opc, map_ver, &obj_auxi, &list_args,
 			     sizeof(list_args));
 	if (rc != 0) {
 		obj_decref(obj);
@@ -2268,7 +2268,7 @@ obj_punch_internal(tse_task_t *task, enum obj_rpc_opc opc,
 		goto out_task;
 	}
 
-	rc = obj_comp_cb_reg(task, opc, map_ver, &obj_auxi, &obj, sizeof(obj));
+	rc = obj_reg_comp_cb(task, opc, map_ver, &obj_auxi, &obj, sizeof(obj));
 	if (rc) {
 		obj_decref(obj);
 		goto out_task;

--- a/src/object/obj_rpc.c
+++ b/src/object/obj_rpc.c
@@ -60,7 +60,7 @@ crt_proc_daos_key_desc_t(crt_proc_t proc, daos_key_desc_t *key)
 	if (rc != 0)
 		return -DER_HG;
 
-	rc = crt_proc_uint32_t(proc, &key->kd_csum_type);
+	rc = crt_proc_uint16_t(proc, &key->kd_csum_type);
 	if (rc != 0)
 		return -DER_HG;
 

--- a/src/object/obj_rpc.h
+++ b/src/object/obj_rpc.h
@@ -143,8 +143,8 @@ enum obj_rpc_flags {
 	((uint64_t)		(orw_dkey_conflict)	CRT_VAR) \
 	((struct dtx_id)	(orw_dti_conflict)	CRT_VAR) \
 	((daos_size_t)		(orw_sizes)		CRT_ARRAY) \
-	((uint32_t)		(orw_nrs)		CRT_ARRAY) \
-	((d_sg_list_t)	(orw_sgls)		CRT_ARRAY)
+	((d_sg_list_t)	(orw_sgls)		CRT_ARRAY)	   \
+	((uint32_t)		(orw_nrs)		CRT_ARRAY)
 
 CRT_RPC_DECLARE(obj_rw, DAOS_ISEQ_OBJ_RW, DAOS_OSEQ_OBJ_RW)
 CRT_RPC_DECLARE(obj_update, DAOS_ISEQ_OBJ_RW, DAOS_OSEQ_OBJ_RW)

--- a/src/rsvc/rpc.h
+++ b/src/rsvc/rpc.h
@@ -64,9 +64,9 @@ enum rsvc_operation {
 extern struct crt_proto_format rsvc_proto_fmt;
 
 #define DAOS_ISEQ_RSVC_START /* input fields */			 \
-	((uint32_t)		(sai_class)		CRT_VAR) \
 	((d_iov_t)		(sai_svc_id)		CRT_VAR) \
 	((uuid_t)		(sai_db_uuid)		CRT_VAR) \
+	((uint32_t)		(sai_class)		CRT_VAR) \
 	((uint32_t)		(sai_flags)		CRT_VAR) \
 	((uint64_t)		(sai_size)		CRT_VAR) \
 	((d_rank_list_t)	(sai_ranks)		CRT_PTR)
@@ -77,8 +77,8 @@ extern struct crt_proto_format rsvc_proto_fmt;
 CRT_RPC_DECLARE(rsvc_start, DAOS_ISEQ_RSVC_START, DAOS_OSEQ_RSVC_START)
 
 #define DAOS_ISEQ_RSVC_STOP /* input fields */			 \
-	((uint32_t)		(soi_class)		CRT_VAR) \
 	((d_iov_t)		(soi_svc_id)		CRT_VAR) \
+	((uint32_t)		(soi_class)		CRT_VAR) \
 	((uint32_t)		(soi_flags)		CRT_VAR) \
 	((d_rank_list_t)	(soi_ranks)		CRT_PTR)
 


### PR DESCRIPTION
Fix some RPC input/output unalign issues, for obj and rsvc.

Signed-off-by: Xuezhao Liu <xuezhao.liu@intel.com>