### PR TITLE
DAOS-3095: build: Improve build times when iterating a fix on CI

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -43,7 +43,9 @@
 def arch = ""
 def sanitized_JOB_NAME = JOB_NAME.toLowerCase().replaceAll('/', '-').replaceAll('%2f', '-')
 
-def daos_repos = "openpa libfabric pmix ompi mercury spdk isa-l fio dpdk protobuf-c fuse pmdk argobots raft cart@daos_devel1 daos@${env.BRANCH_NAME}:${env.BUILD_NUMBER}"
+def component_repos = "openpa libfabric pmix ompi mercury spdk isa-l fio dpdk protobuf-c fuse pmdk argobots raft cart@daos_devel1"
+def daos_repo = "daos@${env.BRANCH_NAME}:${env.BUILD_NUMBER}"
+def daos_repos = component_repos + ' ' + daos_repo
 def ior_repos = "mpich@daos_adio-rpm ior-hpc@daos"
 
 def rpm_test_pre = '''if git show -s --format=%B | grep "^Skip-test: true"; then
@@ -97,11 +99,13 @@ pipeline {
         GITHUB_USER = credentials('daos-jenkins-review-posting')
         BAHTTPS_PROXY = "${env.HTTP_PROXY ? '--build-arg HTTP_PROXY="' + env.HTTP_PROXY + '" --build-arg http_proxy="' + env.HTTP_PROXY + '"' : ''}"
         BAHTTP_PROXY = "${env.HTTP_PROXY ? '--build-arg HTTPS_PROXY="' + env.HTTPS_PROXY + '" --build-arg https_proxy="' + env.HTTPS_PROXY + '"' : ''}"
-        UID=sh(script: "id -u", returnStdout: true)
+        UID = sh(script: "id -u", returnStdout: true)
         BUILDARGS = "$env.BAHTTP_PROXY $env.BAHTTPS_PROXY "                   +
                     "--build-arg NOBUILD=1 --build-arg UID=$env.UID "         +
                     "--build-arg JENKINS_URL=$env.JENKINS_URL "               +
                     "--build-arg CACHEBUST=${currentBuild.startTimeInMillis}"
+        QUICKBUILD = sh(script: "git show -s --format=%B | grep \"^Quick-build: true\"",
+                        returnStatus: true)
     }
 
     options {
@@ -117,6 +121,10 @@ pipeline {
             }
         }
         stage('Pre-build') {
+            when {
+                beforeAgent true
+                expression { return env.QUICKBUILD == '1' }
+            }
             parallel {
                 stage('checkpatch') {
                     agent {
@@ -182,6 +190,10 @@ pipeline {
             }
             parallel {
                 stage('Build RPM on CentOS 7') {
+                    when {
+                        beforeAgent true
+                        expression { return env.QUICKBUILD == '1' }
+                    }
                     agent {
                         dockerfile {
                             filename 'Dockerfile-mockbuild.centos.7'
@@ -241,6 +253,10 @@ pipeline {
                     }
                 }
                 stage('Build RPM on SLES 12.3') {
+                    when {
+                        beforeAgent true
+                        expression { return env.QUICKBUILD == '1' }
+                    }
                     agent {
                         dockerfile {
                             filename 'Dockerfile-rpmbuild.sles.12.3'
@@ -302,7 +318,9 @@ pipeline {
                             filename 'Dockerfile.centos.7'
                             dir 'utils/docker'
                             label 'docker_runner'
-                            additionalBuildArgs "-t ${sanitized_JOB_NAME}-centos7 " + '$BUILDARGS'
+                            additionalBuildArgs "-t ${sanitized_JOB_NAME}-centos7 " +
+                                                '$BUILDARGS ' +
+                                                "--build-arg QUICKBUILD=" + env.QUICKBUILD
                         }
                     }
                     steps {
@@ -393,8 +411,13 @@ pipeline {
                     }
                 }
                 stage('Build on CentOS 7 with Clang') {
-                    when { beforeAgent true
-                           branch 'master' }
+                    when {
+                        beforeAgent true
+                        allOf {
+                            branch 'master'
+                            expression { return env.QUICKBUILD == '1' }
+                        }
+                    }
                     agent {
                         dockerfile {
                             filename 'Dockerfile.centos.7'
@@ -462,8 +485,13 @@ pipeline {
                     }
                 }
                 stage('Build on Ubuntu 18.04') {
-                    when { beforeAgent true
-                           branch 'master' }
+                    when {
+                        beforeAgent true
+                        allOf {
+                            branch 'master'
+                            expression { return env.QUICKBUILD == '1' }
+                        }
+                    }
                     agent {
                         dockerfile {
                             filename 'Dockerfile.ubuntu.18.04'
@@ -531,6 +559,10 @@ pipeline {
                     }
                 }
                 stage('Build on Ubuntu 18.04 with Clang') {
+                    when {
+                        beforeAgent true
+                        expression { return env.QUICKBUILD == '1' }
+                    }
                     agent {
                         dockerfile {
                             filename 'Dockerfile.ubuntu.18.04'
@@ -598,8 +630,13 @@ pipeline {
                     }
                 }
                 stage('Build on SLES 12.3') {
-                    when { beforeAgent true
-                           environment name: 'SLES12_3_DOCKER', value: 'true' }
+                    when {
+                        beforeAgent true
+                        allOf {
+                            environment name: 'SLES12_3_DOCKER', value: 'true'
+                            expression { return env.QUICKBUILD == '1' }
+                        }
+                    }
                     agent {
                         dockerfile {
                             filename 'Dockerfile.sles.12.3'
@@ -669,8 +706,13 @@ pipeline {
                     }
                 }
                 stage('Build on Leap 42.3') {
-                    when { beforeAgent true
-                           environment name: 'LEAP42_3_DOCKER', value: 'true' }
+                    when {
+                        beforeAgent true
+                        allOf {
+                            environment name: 'LEAP42_3_DOCKER', value: 'true'
+                            expression { return env.QUICKBUILD == '1' }
+                        }
+                    }
                     agent {
                         dockerfile {
                             filename 'Dockerfile.leap.42.3'
@@ -740,8 +782,13 @@ pipeline {
                     }
                 }
                 stage('Build on Leap 15') {
-                    when { beforeAgent true
-                           branch 'master' }
+                    when {
+                        beforeAgent true
+                        allOf {
+                            branch 'master'
+                            expression { return env.QUICKBUILD == '1' }
+                        }
+                    }
                     agent {
                         dockerfile {
                             filename 'Dockerfile.leap.15'
@@ -809,8 +856,13 @@ pipeline {
                     }
                 }
                 stage('Build on Leap 15 with Clang') {
-                    when { beforeAgent true
-                           branch 'master' }
+                    when {
+                        beforeAgent true
+                        allOf {
+                            branch 'master'
+                            expression { return env.QUICKBUILD == '1' }
+                        }
+                    }
                     agent {
                         dockerfile {
                             filename 'Dockerfile.leap.15'
@@ -878,6 +930,10 @@ pipeline {
                     }
                 }
                 stage('Build on Leap 15 with Intel-C') {
+                    when {
+                        beforeAgent true
+                        expression { return env.QUICKBUILD == '1' }
+                    }
                     agent {
                         dockerfile {
                             filename 'Dockerfile.leap.15'
@@ -964,7 +1020,9 @@ pipeline {
                     steps {
                         provisionNodes NODELIST: env.NODELIST,
                                        node_count: 1,
-                                       snapshot: true
+                                       snapshot: true,
+                                       inst_repos: component_repos,
+                                       inst_rpms: "argobots cart fuse3-libs hwloc-devel libisa-l libpmem libpmemobj protobuf-c spdk-devel"
                         runTest stashes: [ 'CentOS-tests', 'CentOS-install', 'CentOS-build-vars' ],
                                 script: '''export SSH_KEY_ARGS="-i ci_key"
                                            export PDSH_SSH_ARGS_APPEND="$SSH_KEY_ARGS"
@@ -1065,7 +1123,8 @@ pipeline {
                         provisionNodes NODELIST: env.NODELIST,
                                        node_count: 9,
                                        snapshot: true,
-                                       inst_repos: daos_repos + ' ' + ior_repos,
+                                       inst_repos: component_repos + ' ' + ior_repos +
+                                                   ' daos',
                                        inst_rpms: "ior-hpc mpich-autoload"
                         runTest stashes: [ 'CentOS-install', 'CentOS-build-vars' ],
                                 script: '''export SSH_KEY_ARGS="-i ci_key"
@@ -1126,13 +1185,15 @@ pipeline {
                         provisionNodes NODELIST: env.NODELIST,
                                        node_count: 1,
                                        snapshot: true,
-                                       inst_repos: daos_repos + ' ' + ior_repos,
+                                       inst_repos: component_repos + ' ' + ior_repos +
+                                                   ' daos',
                                        inst_rpms: "ior-hpc mpich-autoload"
                         // Then just reboot the physical nodes
                         provisionNodes NODELIST: env.NODELIST,
                                        node_count: 9,
                                        power_only: true,
-                                       inst_repos: daos_repos + ' ' + ior_repos,
+                                       inst_repos: component_repos + ' ' + ior_repos +
+                                                   ' daos',
                                        inst_rpms: "ior-hpc mpich-autoload"
                         runTest stashes: [ 'CentOS-install', 'CentOS-build-vars' ],
                                 script: '''export SSH_KEY_ARGS="-i ci_key"
@@ -1185,6 +1246,10 @@ pipeline {
                     }
                 }
                 stage('Test CentOS 7 RPMs') {
+                    when {
+                        beforeAgent true
+                        expression { return env.QUICKBUILD == '1' }
+                    }
                     agent {
                         label 'ci_vm1'
                     }
@@ -1208,6 +1273,10 @@ pipeline {
                     }
                 }
                 stage('Test SLES12.3 RPMs') {
+                    when {
+                        beforeAgent true
+                        expression { return env.QUICKBUILD == '1' }
+                    }
                     agent {
                         label 'ci_vm1'
                     }

--- a/src/tests/ftest/util/apricot/apricot/test.py
+++ b/src/tests/ftest/util/apricot/apricot/test.py
@@ -114,10 +114,9 @@ class TestWithoutServers(Test):
         self.prefix = build_paths['PREFIX']
         self.ompi_prefix = build_paths["OMPI_PREFIX"]
         self.tmp = os.path.join(self.prefix, 'tmp')
-        self.daos_test = os.path.join(self.basepath, 'install', 'bin',
-                                      'daos_test')
+        self.daos_test = os.path.join(self.prefix, 'bin', 'daos_test')
         self.orterun = os.path.join(self.ompi_prefix, "bin", "orterun")
-        self.daosctl = os.path.join(self.basepath, 'install', 'bin', 'daosctl')
+        self.daosctl = os.path.join(self.prefix, 'bin', 'daosctl')
 
         # setup fault injection, this MUST be before API setup
         fault_list = self.params.get("fault_list", '/run/faults/*/')

--- a/src/tests/ftest/util/server_utils.py
+++ b/src/tests/ftest/util/server_utils.py
@@ -181,6 +181,12 @@ def run_server(hostfile, setname, basepath, uri_path=None, env_dict=None,
             for key, value in env_dict.items():
                 os.environ[key] = value
                 env_args.extend(["-x", "{}={}".format(key, value)])
+        # the remote orte needs to know where to find daos, in the
+        # case that it's not in the system prefix
+        # but it should already be in our PATH, so just pass our
+        # PATH along to the remote
+        if build_vars["PREFIX"] != "/usr":
+            env_args.extend(["-x", "PATH"])
 
         server_cmd = [orterun_bin, "--np", str(server_count)]
         if uri_path is not None:

--- a/utils/docker/Dockerfile.centos.7
+++ b/utils/docker/Dockerfile.centos.7
@@ -72,10 +72,6 @@ RUN yum -y install \
     yum -y copr enable jhli/safeclib;                          \
     yum -y install libipmctl-devel
 
-# Dependencies
-# Packages for NVML, PMIx, hwloc and OpenMPI exist in CentOS, but are
-# unfortunately outdated. The DAOS build system will rebuild those packages.
-
 # Add DAOS user
 ENV USER daos
 ENV PASSWD daos
@@ -85,6 +81,40 @@ RUN echo "$USER:$PASSWD" | chpasswd
 # Create directory for DAOS backend storage
 RUN mkdir /mnt/daos
 RUN chown daos.daos /mnt/daos
+
+# Dependencies
+# Packages for NVML, PMIx, hwloc and OpenMPI exist in CentOS, but are
+# unfortunately outdated. The DAOS build system will rebuild those packages.
+ARG JENKINS_URL=""
+ARG QUICKBUILD=1
+RUN if [ $QUICKBUILD -eq 0 ]; then                                               \
+        for repo in openpa libfabric pmix ompi mercury spdk isa-l fio dpdk       \
+                    protobuf-c fuse pmdk argobots raft cart@daos_devel1; do      \
+            branch="master";                                                     \
+            build_number="lastSuccessfulBuild";                                  \
+            if [[ $repo = *@* ]]; then                                           \
+                branch="${repo#*@}";                                             \
+                repo="${repo%@*}";                                               \
+                if [[ $branch = *:* ]]; then                                     \
+                    build_number="${branch#*:}";                                 \
+                    branch="${branch%:*}";                                       \
+                fi;                                                              \
+            fi;                                                                  \
+            echo -e "[$repo:$branch:$build_number]\n\
+name=$repo:$branch:$build_number\n\
+baseurl=${JENKINS_URL}job/daos-stack/job/$repo/job/$branch/$build_number/artifact/artifacts/centos7/\n\
+enabled=1\n\
+gpgcheck = False\n" >> /etc/yum.repos.d/$repo:$branch:$build_number.repo;        \
+        done;                                                                    \
+        yum -y install cart-devel argobots-devel libpmem-devel libpmemobj-devel  \
+                       fuse-devel protobuf-c-devel spdk-devel fio libisa-l-devel \
+                       mercury-devel openpa-devel libfabric-devel ompi-devel     \
+                       pmix-devel hwloc-devel dpdk-devel-18.02;                  \
+    fi
+
+# force an upgrade to get any newly built RPMs
+ARG CACHEBUST=1
+RUN yum -y upgrade --exclude=dpdk-devel,dpdk
 
 # Switch to new user
 USER $USER


### PR DESCRIPTION
For reasons where it's difficult to fix something locally, before
pushing to CI, sometimes it's useful or even unavoidable to have to
iterate on something through CI.

When doing so, it would be very useful if builds could happen quickly to
reduce the turnaround time of this iterating.  This can be done by
building DAOS in it's source tree (i.e. not as an RPM itself, but in the
traditional way in which we have built DAOS) and thus maintaining
compatibility with the existing test frameworks but by installing all of
the DAOS dependencies (a.k.a. components) from their RPMs.

This should yield the same result as building the entire DAOS stack in
the source tree but build much more quickly.  This could also eventually
become the last stepping stone to fully testing based on RPMs.

But until then, let's leave this feature optional, to be enabled on
demand and still require the full stack build on all platforms before
allowing landing.

To take advantage of this feature while iterating to the final result,
one can use the `Quick-build: true` pragma in their commit message.