### PR TITLE
DAOS-2727 dtx: fix NULL pointer when handle conflict DTX

### DIFF
--- a/src/vos/vos_dtx.c
+++ b/src/vos/vos_dtx.c
@@ -77,7 +77,7 @@ dtx_inprogress(struct vos_dtx_entry_df *dtx, int pos)
 static inline void
 dtx_record_conflict(struct dtx_handle *dth, struct vos_dtx_entry_df *dtx)
 {
-	if (dth != NULL && dtx != NULL) {
+	if (dth != NULL && dth->dth_conflict != NULL && dtx != NULL) {
 		daos_dti_copy(&dth->dth_conflict->dce_xid, &dtx->te_xid);
 		dth->dth_conflict->dce_dkey = dtx->te_dkey_hash;
 	}


### PR DESCRIPTION
After separating DTX leader and non-leader logic, the DTX leader
does not register dtx_handle::dth_conflict. When handle conflict
DTX during the availability check, the dtx_record_conflict logic
should firstly check dtx_handle::dth_conflict before accessing
its internal members.

Signed-off-by: Fan Yong <fan.yong@intel.com>