### PR TITLE
DAOS-2444 obj: refine io retry handling

### DIFF
--- a/src/container/srv_target.c
+++ b/src/container/srv_target.c
@@ -453,6 +453,7 @@ cont_child_destroy_one(void *vin)
 	if (rc == 0) {
 		/* Should evict if idle, but no such interface at the moment. */
 		cont_child_put(tls->dt_cont_cache, cont);
+		D_ERROR("cont_child_lookup non-empty, return %d.\n", -DER_BUSY);
 		D_GOTO(out_pool, rc = -DER_BUSY);
 	} else if (rc != -DER_NONEXIST) {
 		D_GOTO(out_pool, rc);

--- a/src/object/cli_obj.c
+++ b/src/object/cli_obj.c
@@ -976,9 +976,6 @@ obj_retry_cb(tse_task_t *task, struct dc_object *obj,
 	int		  result = task->dt_result;
 	int		  rc;
 
-	if (result == -DER_INPROGRESS)
-		obj_auxi->retry_with_leader = 1;
-
 	/* For the case of retry with leader, if it is for modification,
 	 * since we always send modification RPC to the leader, then no
 	 * need to refresh the pool map. Because if the client used old
@@ -1449,12 +1446,23 @@ shard_task_abort(tse_task_t *task, void *arg)
 	return 0;
 }
 
+static void
+shard_auxi_set_param(struct shard_auxi_args *shard_arg, uint32_t map_ver,
+		     uint32_t shard, uint32_t tgt_id, uint64_t epoch)
+{
+	shard_arg->epoch = epoch;
+	shard_arg->shard = shard;
+	shard_arg->target = tgt_id;
+	shard_arg->map_ver = map_ver;
+}
+
 static int
 shard_task_sched(tse_task_t *task, void *arg)
 {
 	tse_task_t			*obj_task;
 	struct obj_auxi_args		*obj_auxi;
 	struct shard_auxi_args		*shard_auxi;
+	uint64_t			*epoch = arg;
 	uint32_t			 target;
 	unsigned int			 map_ver;
 	int				 rc = 0;
@@ -1471,7 +1479,9 @@ shard_task_sched(tse_task_t *task, void *arg)
 		 * Also retry the shard IO if it got retryable error last time.
 		 */
 		target = obj_shard2tgtid(shard_auxi->obj, shard_auxi->shard);
-		if (obj_retry_error(task->dt_result) ||
+		if (obj_auxi->req_tgts.ort_srv_disp ||
+		    obj_retry_error(task->dt_result) ||
+		    *epoch != shard_auxi->epoch ||
 		    target != shard_auxi->target) {
 			D_DEBUG(DB_IO, "shard %d, dt_result %d, target %d @ "
 				"map_ver %d, target %d @ last_map_ver %d, "
@@ -1487,8 +1497,9 @@ shard_task_sched(tse_task_t *task, void *arg)
 			if (rc != 0)
 				goto out;
 
-			shard_auxi->map_ver		= map_ver;
-			shard_auxi->target		= target;
+			if (!obj_auxi->req_tgts.ort_srv_disp)
+				shard_auxi_set_param(shard_auxi, map_ver,
+					shard_auxi->shard, target, *epoch);
 			obj_auxi->shard_task_scheded	= 1;
 		}
 	} else {
@@ -1503,12 +1514,12 @@ out:
 }
 
 static void
-obj_shard_task_sched(struct obj_auxi_args *obj_auxi)
+obj_shard_task_sched(struct obj_auxi_args *obj_auxi, uint64_t epoch)
 {
 	D_ASSERT(!d_list_empty(&obj_auxi->shard_task_head));
 	obj_auxi->shard_task_scheded = 0;
 	tse_task_list_traverse(&obj_auxi->shard_task_head, shard_task_sched,
-			       NULL);
+			       &epoch);
 	/* It is possible that the IO retried by stale pm version found, but
 	 * the IO involved shards' targets not changed. No any shard task
 	 * re-scheduled for this case, can complete the obj IO task.
@@ -1590,26 +1601,30 @@ shard_io_task(tse_task_t *task)
 typedef int (*shard_io_prep_cb_t)(struct shard_auxi_args *shard_auxi,
 				  struct dc_object *obj,
 				  struct obj_auxi_args *obj_auxi,
-				  uint64_t dkey_hash, uint32_t map_ver,
-				  daos_epoch_t epoch);
+				  uint64_t dkey_hash);
+
+struct shard_task_reset_arg {
+	struct obj_req_tgts	*req_tgts;
+	uint64_t		 epoch;
+};
 
 static int
-shard_task_reset_target(tse_task_t *shard_task, void *arg)
+shard_task_reset_param(tse_task_t *shard_task, void *arg)
 {
-	struct obj_req_tgts	*req_tgts = arg;
-	struct obj_auxi_args	*obj_auxi;
-	struct shard_auxi_args	*shard_arg;
-	struct daos_shard_tgt	*leader_tgt;
+	struct shard_task_reset_arg	*reset_arg = arg;
+	struct obj_req_tgts		*req_tgts = reset_arg->req_tgts;
+	struct obj_auxi_args		*obj_auxi;
+	struct shard_auxi_args		*shard_arg;
+	struct daos_shard_tgt		*leader_tgt;
 
 	shard_arg = tse_task_buf_embedded(shard_task, sizeof(*shard_arg));
 	D_ASSERT(shard_arg->grp_idx < req_tgts->ort_grp_nr);
 	obj_auxi = container_of(req_tgts, struct obj_auxi_args, req_tgts);
 	leader_tgt = req_tgts->ort_shard_tgts +
 		     shard_arg->grp_idx * req_tgts->ort_grp_size;
-	shard_arg->shard = leader_tgt->st_shard;
-	shard_arg->target = leader_tgt->st_tgt_id;
-	shard_arg->map_ver = obj_auxi->map_ver_req;
-
+	shard_auxi_set_param(shard_arg, obj_auxi->map_ver_req,
+			     leader_tgt->st_shard, leader_tgt->st_tgt_id,
+			     reset_arg->epoch);
 	return 0;
 }
 
@@ -1624,8 +1639,12 @@ obj_req_fanout(struct dc_object *obj, struct obj_auxi_args *obj_auxi,
 	tse_task_t		*shard_task;
 	struct shard_auxi_args	*shard_auxi;
 	struct daos_shard_tgt	*tgt;
-	uint32_t			 i, tgts_nr;
-	int				 rc = 0;
+	uint32_t		 i, tgts_nr;
+	int			 rc = 0;
+
+	tgt = req_tgts->ort_shard_tgts;
+	tgts_nr = req_tgts->ort_srv_disp ? req_tgts->ort_grp_nr :
+		  req_tgts->ort_grp_nr * req_tgts->ort_grp_size;
 
 	/* for retried obj IO, reuse the previous shard tasks and resched it */
 	if (obj_auxi->io_retry) {
@@ -1641,6 +1660,10 @@ obj_req_fanout(struct dc_object *obj, struct obj_auxi_args *obj_auxi,
 
 		/* if with shard task list, reuse it and re-schedule */
 		if (!d_list_empty(task_list)) {
+			struct shard_task_reset_arg reset_arg;
+
+			reset_arg.req_tgts = req_tgts;
+			reset_arg.epoch = epoch;
 			/* For srv dispatch, the task_list non-empty is only for
 			 * obj punch that with multiple RDG that each with a
 			 * leader. Here reset the header for the shard task.
@@ -1648,33 +1671,33 @@ obj_req_fanout(struct dc_object *obj, struct obj_auxi_args *obj_auxi,
 			if (req_tgts->ort_srv_disp) {
 				D_ASSERT(obj_auxi->opc == DAOS_OBJ_RPC_PUNCH);
 				tse_task_list_traverse(task_list,
-					shard_task_reset_target, req_tgts);
+					shard_task_reset_param, &reset_arg);
 			}
 			goto task_sched;
+		} else {
+			D_ASSERT(tgts_nr == 1);
+			shard_auxi = obj_embedded_shard_arg(obj_auxi);
+			D_ASSERT(shard_auxi != NULL);
+			shard_auxi_set_param(shard_auxi, map_ver, tgt->st_shard,
+					     tgt->st_tgt_id, epoch);
+			shard_auxi->shard_io_cb = io_cb;
+			rc = shard_io(obj_task, shard_auxi);
+			return rc;
 		}
-
-		/* for srv dispatch request and empty task_list, below code
-		 * will reset leader's shard and target.
-		 */
 	}
 
-	tgt = req_tgts->ort_shard_tgts;
-	tgts_nr = req_tgts->ort_srv_disp ? req_tgts->ort_grp_nr :
-		  req_tgts->ort_grp_nr * req_tgts->ort_grp_size;
 	/* if with only one target, need not to create separate shard task */
 	if (tgts_nr == 1) {
 		shard_auxi = obj_embedded_shard_arg(obj_auxi);
 		D_ASSERT(shard_auxi != NULL);
+		shard_auxi_set_param(shard_auxi, map_ver, tgt->st_shard,
+				     tgt->st_tgt_id, epoch);
 		shard_auxi->grp_idx = 0;
-		shard_auxi->map_ver = map_ver;
-		shard_auxi->shard = tgt->st_shard;
-		shard_auxi->target = tgt->st_tgt_id;
 		shard_auxi->start_shard = req_tgts->ort_start_shard;
 		shard_auxi->obj = obj;
 		shard_auxi->obj_auxi = obj_auxi;
 		shard_auxi->shard_io_cb = io_cb;
-		rc = io_prep_cb(shard_auxi, obj, obj_auxi, dkey_hash, map_ver,
-				epoch);
+		rc = io_prep_cb(shard_auxi, obj, obj_auxi, dkey_hash);
 		if (rc)
 			goto out_task;
 
@@ -1692,17 +1715,15 @@ obj_req_fanout(struct dc_object *obj, struct obj_auxi_args *obj_auxi,
 
 		shard_auxi = tse_task_buf_embedded(shard_task,
 						   sizeof(*shard_auxi));
+		shard_auxi_set_param(shard_auxi, map_ver, tgt->st_shard,
+				     tgt->st_tgt_id, epoch);
 		shard_auxi->grp_idx = req_tgts->ort_srv_disp ? i :
 				      (i / req_tgts->ort_grp_size);
-		shard_auxi->map_ver = map_ver;
-		shard_auxi->shard = tgt->st_shard;
-		shard_auxi->target = tgt->st_tgt_id;
 		shard_auxi->start_shard = req_tgts->ort_start_shard;
 		shard_auxi->obj = obj;
 		shard_auxi->obj_auxi = obj_auxi;
 		shard_auxi->shard_io_cb = io_cb;
-		rc = io_prep_cb(shard_auxi, obj, obj_auxi, dkey_hash, map_ver,
-				epoch);
+		rc = io_prep_cb(shard_auxi, obj, obj_auxi, dkey_hash);
 		if (rc) {
 			tse_task_complete(shard_task, rc);
 			goto out_task;
@@ -1723,7 +1744,7 @@ obj_req_fanout(struct dc_object *obj, struct obj_auxi_args *obj_auxi,
 	}
 
 task_sched:
-	obj_shard_task_sched(obj_auxi);
+	obj_shard_task_sched(obj_auxi, epoch);
 	return 0;
 
 out_task:
@@ -1744,8 +1765,8 @@ shard_result_process(tse_task_t *task, void *arg)
 	/*
 	 * Check shard IO task's completion status:
 	 * 1) if succeed just stores the highest replied pm version.
-	 * 2) if any shard got retryable error, mark the IO as retryable.
-	 * 3) for the un-retryable failure, store it in obj_auxi->result.
+	 * 2) if any shard failed, store it in obj_auxi->result, the
+	 *    un-retryable error with higher priority.
 	 */
 	shard_auxi = tse_task_buf_embedded(task, sizeof(*shard_auxi));
 	if (ret == 0) {
@@ -1753,9 +1774,8 @@ shard_result_process(tse_task_t *task, void *arg)
 			obj_auxi->map_ver_reply = shard_auxi->map_ver;
 	} else if (obj_retry_error(ret)) {
 		D_DEBUG(DB_IO, "shard %d ret %d.\n", shard_auxi->shard, ret);
-		obj_auxi->io_retry = 1;
-		if (ret == -DER_INPROGRESS)
-			obj_auxi->retry_with_leader = 1;
+		if (obj_auxi->result == 0)
+			obj_auxi->result = ret;
 	} else {
 		/* for un-retryable failure, set the err to whole obj IO */
 		D_DEBUG(DB_IO, "shard %d ret %d.\n", shard_auxi->shard, ret);
@@ -1867,14 +1887,7 @@ obj_comp_cb(tse_task_t *task, void *data)
 		D_ASSERT(!d_list_empty(head));
 		obj_auxi->result = 0;
 		tse_task_list_traverse(head, shard_result_process, obj_auxi);
-		/* for stale pm version, retry the obj IO at there will check
-		 * if need to retry shard IO.
-		 */
-		if (obj_auxi->map_ver_reply > obj_auxi->map_ver_req) {
-			D_DEBUG(DB_IO, "map_ver stale (req %d, reply %d).\n",
-				obj_auxi->map_ver_req, obj_auxi->map_ver_reply);
-			obj_auxi->io_retry = 1;
-		}
+		task->dt_result = obj_auxi->result;
 		break;
 	default:
 		D_ERROR("incorrect opc %#x.\n", obj_auxi->opc);
@@ -1882,15 +1895,19 @@ obj_comp_cb(tse_task_t *task, void *data)
 		break;
 	};
 
-	if (obj_auxi->map_ver_reply > obj_auxi->map_ver_req)
+	if (obj_auxi->map_ver_reply > obj_auxi->map_ver_req) {
+		D_DEBUG(DB_IO, "map_ver stale (req %d, reply %d).\n",
+			obj_auxi->map_ver_req, obj_auxi->map_ver_reply);
 		pm_stale = true;
-	if (obj_retry_error(task->dt_result))
+	}
+	if (obj_retry_error(task->dt_result)) {
 		obj_auxi->io_retry = 1;
+		if (task->dt_result == -DER_INPROGRESS)
+			obj_auxi->retry_with_leader = 1;
+	}
 
 	if (pm_stale || obj_auxi->io_retry)
 		obj_retry_cb(task, obj, obj_auxi);
-	else if (task->dt_result == 0)
-		task->dt_result = obj_auxi->result;
 
 	if (!obj_auxi->io_retry) {
 		if (obj_auxi->req_tgts.ort_shard_tgts !=
@@ -1925,8 +1942,7 @@ obj_reg_comp_cb(tse_task_t *task, int opc, uint32_t map_ver,
 
 static int
 shard_rw_prep(struct shard_auxi_args *shard_auxi, struct dc_object *obj,
-		 struct obj_auxi_args *obj_auxi, uint64_t dkey_hash,
-		 uint32_t map_ver, daos_epoch_t epoch)
+		 struct obj_auxi_args *obj_auxi, uint64_t dkey_hash)
 {
 	daos_obj_rw_t		*obj_args;
 	struct shard_rw_args	*shard_arg;
@@ -1937,7 +1953,6 @@ shard_rw_prep(struct shard_auxi_args *shard_auxi, struct dc_object *obj,
 	if (obj_auxi->opc == DAOS_OBJ_RPC_UPDATE)
 		daos_dti_gen(&shard_arg->dti,
 			     srv_io_mode != DIM_DTX_FULL_ENABLED);
-	shard_arg->epoch		= epoch;
 	shard_arg->dkey_hash		= dkey_hash;
 	shard_arg->bulks		= obj_auxi->bulks;
 
@@ -2075,15 +2090,13 @@ out_task:
 
 static int
 shard_list_prep(struct shard_auxi_args *shard_auxi, struct dc_object *obj,
-		struct obj_auxi_args *obj_auxi, uint64_t dkey_hash,
-		uint32_t map_ver, daos_epoch_t epoch)
+		struct obj_auxi_args *obj_auxi, uint64_t dkey_hash)
 {
 	daos_obj_list_t		*obj_args;
 	struct shard_list_args	*shard_arg;
 
 	obj_args = dc_task_get_args(obj_auxi->obj_task);
 	shard_arg = container_of(shard_auxi, struct shard_list_args, la_auxi);
-	shard_arg->la_epoch		= epoch;
 	shard_arg->la_api_args		= obj_args;
 
 	return 0;
@@ -2204,8 +2217,7 @@ dc_obj_list_rec(tse_task_t *task)
 
 static int
 shard_punch_prep(struct shard_auxi_args *shard_auxi, struct dc_object *obj,
-		 struct obj_auxi_args *obj_auxi, uint64_t dkey_hash,
-		 uint32_t map_ver, daos_epoch_t epoch)
+		 struct obj_auxi_args *obj_auxi, uint64_t dkey_hash)
 {
 	daos_obj_punch_t	*obj_args;
 	struct shard_punch_args	*shard_arg;
@@ -2224,7 +2236,6 @@ shard_punch_prep(struct shard_auxi_args *shard_auxi, struct dc_object *obj,
 
 	obj_args = dc_task_get_args(obj_auxi->obj_task);
 	shard_arg = container_of(shard_auxi, struct shard_punch_args, pa_auxi);
-	shard_arg->pa_epoch		= epoch;
 	shard_arg->pa_api_args		= obj_args;
 	daos_dti_gen(&shard_arg->pa_dti, srv_io_mode != DIM_DTX_FULL_ENABLED);
 	shard_arg->pa_opc		= obj_auxi->opc;
@@ -2605,7 +2616,7 @@ dc_obj_query_key(tse_task_t *api_task)
 	}
 
 task_sched:
-	obj_shard_task_sched(obj_auxi);
+	obj_shard_task_sched(obj_auxi, epoch);
 	return rc;
 
 out_task:

--- a/src/object/cli_shard.c
+++ b/src/object/cli_shard.c
@@ -325,7 +325,7 @@ dc_obj_shard_rw(struct dc_obj_shard *shard, enum obj_rpc_opc opc,
 	D_DEBUG(DB_TRACE, "rpc %p opc:%d "DF_UOID" %d %s rank:%d tag:%d eph "
 		DF_U64"\n", req, opc, DP_UOID(shard->do_id), (int)dkey->iov_len,
 		(char *)dkey->iov_buf, tgt_ep.ep_rank, tgt_ep.ep_tag,
-		args->epoch);
+		args->auxi.epoch);
 	if (rc != 0)
 		D_GOTO(out_pool, rc);
 
@@ -354,7 +354,7 @@ dc_obj_shard_rw(struct dc_obj_shard *shard, enum obj_rpc_opc opc,
 	orw->orw_dti_cos.ca_count = 0;
 	orw->orw_dti_cos.ca_arrays = NULL;
 
-	orw->orw_epoch = args->epoch;
+	orw->orw_epoch = args->auxi.epoch;
 	orw->orw_dkey_hash = args->dkey_hash;
 	orw->orw_nr = nr;
 	orw->orw_dkey = *dkey;
@@ -364,7 +364,7 @@ dc_obj_shard_rw(struct dc_obj_shard *shard, enum obj_rpc_opc opc,
 	D_DEBUG(DB_TRACE, "opc %d "DF_UOID" %d %s rank %d tag %d eph "
 		DF_U64", DTI = "DF_DTI"\n", opc, DP_UOID(shard->do_id),
 		(int)dkey->iov_len, (char *)dkey->iov_buf, tgt_ep.ep_rank,
-		tgt_ep.ep_tag, args->epoch, DP_DTI(&orw->orw_dti));
+		tgt_ep.ep_tag, args->auxi.epoch, DP_DTI(&orw->orw_dti));
 
 	if (args->bulks != NULL) {
 		orw->orw_sgls.ca_count = 0;
@@ -475,7 +475,7 @@ dc_obj_shard_punch(struct dc_obj_shard *shard, enum obj_rpc_opc opc,
 		D_GOTO(out, rc = (int)tgt_ep.ep_rank);
 
 	D_DEBUG(DB_IO, "opc=%d, rank=%d tag=%d epoch "DF_U64".\n",
-		 opc, tgt_ep.ep_rank, tgt_ep.ep_tag, args->pa_epoch);
+		 opc, tgt_ep.ep_rank, tgt_ep.ep_tag, args->pa_auxi.epoch);
 
 	rc = obj_req_create(daos_task2ctx(task), &tgt_ep, opc, &req);
 	if (rc != 0)
@@ -493,7 +493,7 @@ dc_obj_shard_punch(struct dc_obj_shard *shard, enum obj_rpc_opc opc,
 	D_ASSERT(opi != NULL);
 
 	opi->opi_map_ver	 = args->pa_auxi.map_ver;
-	opi->opi_epoch		 = args->pa_epoch;
+	opi->opi_epoch		 = args->pa_auxi.epoch;
 	opi->opi_dkey_hash	 = args->pa_dkey_hash;
 	opi->opi_oid		 = oid;
 	opi->opi_dkeys.ca_count  = (dkey == NULL) ? 0 : 1;
@@ -703,7 +703,7 @@ dc_obj_shard_list(struct dc_obj_shard *obj_shard, enum obj_rpc_opc opc,
 		oei->oei_akey = *obj_args->akey;
 	oei->oei_oid		= obj_shard->do_id;
 	oei->oei_map_ver	= args->la_auxi.map_ver;
-	oei->oei_epoch		= args->la_epoch;
+	oei->oei_epoch		= args->la_auxi.epoch;
 	oei->oei_nr		= *obj_args->nr;
 	oei->oei_rec_type	= obj_args->type;
 	uuid_copy(oei->oei_pool_uuid, pool->dp_pool);

--- a/src/object/obj_internal.h
+++ b/src/object/obj_internal.h
@@ -175,6 +175,7 @@ struct shard_auxi_args {
 	struct dc_object	*obj;
 	struct obj_auxi_args	*obj_auxi;
 	shard_io_cb_t		 shard_io_cb;
+	uint64_t		 epoch;
 	uint32_t		 shard;
 	uint32_t		 target;
 	uint32_t		 map_ver;
@@ -188,7 +189,6 @@ struct shard_auxi_args {
 struct shard_rw_args {
 	struct shard_auxi_args	 auxi;
 	daos_obj_rw_t		*api_args;
-	daos_epoch_t		 epoch;
 	struct dtx_id		 dti;
 	uint64_t		 dkey_hash;
 	crt_bulk_t		*bulks;
@@ -196,11 +196,10 @@ struct shard_rw_args {
 
 struct shard_punch_args {
 	struct shard_auxi_args	 pa_auxi;
+	daos_obj_punch_t	*pa_api_args;
 	uuid_t			 pa_coh_uuid;
 	uuid_t			 pa_cont_uuid;
-	daos_obj_punch_t	*pa_api_args;
 	uint64_t		 pa_dkey_hash;
-	daos_epoch_t		 pa_epoch;
 	struct dtx_id		 pa_dti;
 	uint32_t		 pa_opc;
 };
@@ -208,7 +207,6 @@ struct shard_punch_args {
 struct shard_list_args {
 	struct shard_auxi_args	 la_auxi;
 	daos_obj_list_t		*la_api_args;
-	daos_epoch_t		 la_epoch;
 };
 
 int dc_obj_shard_open(struct dc_object *obj, daos_unit_oid_t id,


### PR DESCRIPTION
1) should not generate new dti for io retry
   by only call the io_prep_cb once.
2) should be able to reset the epoch/map_ver/shard/tgt_id for retry
3) simplify some parameter handling

Signed-off-by: Xuezhao Liu <xuezhao.liu@intel.com>