### PR TITLE
DAOS-2727 dtx: detect fake DTX conflict only when leader committable

### DIFF
--- a/src/dtx/dtx_common.c
+++ b/src/dtx/dtx_common.c
@@ -318,7 +318,7 @@ dtx_leader_wait(struct dtx_leader_handle *dlh, struct dtx_conflict_entry **dces,
 	rc = ABT_future_wait(dlh->dlh_future);
 	D_ASSERTF(rc == ABT_SUCCESS, "ABT_future_wait failed %d.\n", rc);
 	rc = dlh->dlh_result;
-	if (rc == -DER_INPROGRESS) {
+	if (rc == -DER_INPROGRESS && dces_cnt != NULL) {
 		struct dtx_conflict_entry	*conflict;
 		int				shard_cnt = dlh->dlh_sub_cnt;
 		int				i;
@@ -519,7 +519,7 @@ dtx_leader_end(struct dtx_leader_handle *dlh, struct ds_cont_hdl *cont_hdl,
 	/* NB: even the local request failure, dth_ent == NULL, we
 	 * should still wait for remote object to finish the request.
 	 */
-	rc = dtx_leader_wait(dlh, &dces, &dces_cnt);
+	rc = dtx_leader_wait(dlh, &dces, result >= 0 ? &dces_cnt : NULL);
 	if (rc == -DER_INPROGRESS && dces != NULL) {
 		/* XXX: The local modification has been done, but remote
 		 *	replica failed because of some uncommitted DTX,


### PR DESCRIPTION
When splitting DTX leader and non-leader logic, the logic of detect
and handle fake DTX conflict for non-leader replicas is broken:

We should NOT detect that if the leader replica also hit some DTX
conflict. Under such case, it is real conflict, not fake, we have
not enough knowledge to abort or commit the conflict DTX. Current
implementation may abort other normal conflict DTX by wrong as to
related tests failure or to be blocked.

Signed-off-by: Fan Yong <fan.yong@intel.com>