### PR TITLE
DAOS-2391 pool: Automatic service membership changes

### DIFF
--- a/src/common/rsvc.c
+++ b/src/common/rsvc.c
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2017 Intel Corporation.
+ * (C) Copyright 2017-2019 Intel Corporation.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -104,8 +104,17 @@ rsvc_client_process_error(struct rsvc_client *client, int rc,
 {
 	int leader_index = client->sc_leader_index;
 
-	if (client->sc_leader_known && client->sc_leader_aliveness > 0 &&
-	    ep->ep_rank == client->sc_ranks->rl_ranks[leader_index]) {
+	if (rc == -DER_NONEXIST) {
+		int rc_tmp;
+
+		rc_tmp = daos_rank_list_del(client->sc_ranks, ep->ep_rank);
+		if (rc_tmp == -DER_NOMEM)
+			client->sc_ranks = NULL;
+		client->sc_leader_aliveness = 0;
+		/** TODO: Request list of replicas from management service.  **/
+
+	} else if (client->sc_leader_known && client->sc_leader_aliveness > 0 &&
+		   ep->ep_rank == client->sc_ranks->rl_ranks[leader_index]) {
 		if (rc == -DER_NOTLEADER)
 			client->sc_leader_aliveness = 0;
 		else
@@ -221,6 +230,13 @@ rsvc_client_complete_rpc(struct rsvc_client *client, const crt_endpoint_t *ep,
 		rsvc_client_process_hint(client, hint, false /* !from_leader */,
 					 ep);
 		return RSVC_CLIENT_RECHOOSE;
+	} else if (rc_svc == -DER_NONEXIST) {
+		/* This may happen when a service replica was destroyed. */
+		D_DEBUG(DB_MD, "service not found reply from rank %u: ",
+			ep->ep_rank);
+		rsvc_client_process_error(client, rc_svc, ep);
+		return client->sc_ranks == NULL ?
+			RSVC_CLIENT_PROCEED : RSVC_CLIENT_RECHOOSE;
 	} else if (hint == NULL || !(hint->sh_flags & RSVC_HINT_VALID)) {
 		/* This may happen if the service wasn't found. */
 		D_DEBUG(DB_MD, "\"leader\" reply without hint from rank %u: "

--- a/src/include/daos/common.h
+++ b/src/include/daos/common.h
@@ -340,6 +340,7 @@ daos_crt_network_error(int err)
 #define daos_rank_list_identical	d_rank_list_identical
 #define daos_rank_in_rank_list		d_rank_in_rank_list
 #define daos_rank_list_append		d_rank_list_append
+#define daos_rank_list_del		d_rank_list_del
 
 /* the key of various type of parameters, used by DAOS client to set
  * different parameters globally on all servers.


### PR DESCRIPTION
This patch fixes the problem of service membership changes not being
propagated to the client.

If a service replica gets destroyed, the server returns -DER_NONEXIST
in which case that rank will get deleted from the service rank list
cached on the client. The operation fails once all ranks have been
deleted (this may happen if all the original service replicas have
been replaced). In the future, the client must retrieve an updated
list of service ranks from the management service via the DAOS agent.

Signed-off-by: Omkar Kulkarni <omkar.kulkarni@intel.com>
Change-Id: I67945ef9a64a48c7f7d23d7f84a76ffc51fd8044