### PR TITLE
DAOS-1883 vos: Return DER_NOSPACE instead of DER_NOMEM

### DIFF
--- a/src/bio/smd/smd_device.c
+++ b/src/bio/smd/smd_device.c
@@ -74,7 +74,7 @@ dtab_df_rec_alloc(struct btr_instance *tins, d_iov_t *key_iov,
 
 	ndev_off = umem_zalloc(&tins->ti_umm, sizeof(struct smd_nvme_dev_df));
 	if (UMOFF_IS_NULL(ndev_off))
-		return -DER_NOMEM;
+		return -DER_NOSPACE;
 	ndev_df = umem_off2ptr(&tins->ti_umm, ndev_off);
 	uuid_copy(ndev_df->nd_dev_id, ukey->uuid);
 	memcpy(ndev_df, val_iov->iov_buf, sizeof(*ndev_df));

--- a/src/bio/smd/smd_pool.c
+++ b/src/bio/smd/smd_pool.c
@@ -104,7 +104,7 @@ ptab_df_rec_alloc(struct btr_instance *tins, d_iov_t *key_iov,
 
 	npool_off = umem_zalloc(&tins->ti_umm, sizeof(struct smd_nvme_pool_df));
 	if (UMOFF_IS_NULL(npool_off))
-		return -DER_NOMEM;
+		return -DER_NOSPACE;
 	npool_df = umem_off2ptr(&tins->ti_umm, npool_off);
 	uuid_copy(npool_df->np_info.npi_pool_uuid, pkey->ptk_pid);
 	npool_df->np_info.npi_stream_id = pkey->ptk_sid;

--- a/src/bio/smd/smd_stream.c
+++ b/src/bio/smd/smd_stream.c
@@ -77,7 +77,7 @@ stab_df_rec_alloc(struct btr_instance *tins, d_iov_t *key_iov,
 	nstream_off = umem_zalloc(&tins->ti_umm,
 				  sizeof(struct smd_nvme_stream_df));
 	if (UMOFF_IS_NULL(nstream_off))
-		return -DER_NOMEM;
+		return -DER_NOSPACE;
 
 	nstream_df = umem_off2ptr(&tins->ti_umm, nstream_off);
 	nstream_df->ns_map.nsm_stream_id = *ukey;

--- a/src/common/btree.c
+++ b/src/common/btree.c
@@ -593,7 +593,7 @@ btr_node_alloc(struct btr_context *tcx, umem_off_t *nd_off_p)
 
 	nd_off = umem_zalloc(btr_umm(tcx), btr_node_size(tcx));
 	if (UMOFF_IS_NULL(nd_off))
-		return -DER_NOMEM;
+		return btr_umm(tcx)->umm_nospc_rc;
 
 	D_DEBUG(DB_TRACE, "Allocate new node "DF_X64"\n", nd_off);
 	nd = btr_off2ptr(tcx, nd_off);
@@ -782,7 +782,7 @@ btr_root_alloc(struct btr_context *tcx)
 	tins->ti_root_off = umem_zalloc(btr_umm(tcx),
 					sizeof(struct btr_root));
 	if (UMOFF_IS_NULL(tins->ti_root_off))
-		return -DER_NOMEM;
+		return btr_umm(tcx)->umm_nospc_rc;
 
 	root = btr_off2ptr(tcx, tins->ti_root_off);
 	return btr_root_init(tcx, root, false);

--- a/src/common/btree_class.c
+++ b/src/common/btree_class.c
@@ -244,7 +244,7 @@ nv_rec_alloc(struct btr_instance *tins, d_iov_t *key, d_iov_t *val,
 
 	name_len = key->iov_len;
 
-	rc = -DER_NOMEM;
+	rc = tins->ti_umm.umm_nospc_rc;
 
 	roff = umem_zalloc(&tins->ti_umm, sizeof(*r) + name_len);
 	if (UMOFF_IS_NULL(roff))
@@ -329,7 +329,7 @@ nv_rec_update(struct btr_instance *tins, struct btr_record *rec,
 
 		voff = umem_alloc(&tins->ti_umm, val->iov_len);
 		if (UMOFF_IS_NULL(voff))
-			return -DER_NOMEM;
+			return tins->ti_umm.umm_nospc_rc;
 
 		umem_free(&tins->ti_umm, r->nr_value);
 
@@ -657,7 +657,7 @@ uv_rec_update(struct btr_instance *tins, struct btr_record *rec,
 
 		voff = umem_alloc(&tins->ti_umm, val->iov_len);
 		if (UMOFF_IS_NULL(voff))
-			return -DER_NOMEM;
+			return tins->ti_umm.umm_nospc_rc;
 
 		umem_free(&tins->ti_umm, r->ur_value);
 
@@ -1111,14 +1111,14 @@ kv_rec_alloc(struct btr_instance *tins, d_iov_t *key, d_iov_t *val,
 
 	roff = umem_zalloc(&tins->ti_umm, sizeof(*r) + key->iov_len);
 	if (UMOFF_IS_NULL(roff))
-		D_GOTO(err, rc = -DER_NOMEM);
+		D_GOTO(err, rc = tins->ti_umm.umm_nospc_rc);
 	r = umem_off2ptr(&tins->ti_umm, roff);
 
 	r->kr_value_len = val->iov_len;
 	r->kr_value_cap = r->kr_value_len;
 	r->kr_value = umem_alloc(&tins->ti_umm, r->kr_value_cap);
 	if (UMOFF_IS_NULL(r->kr_value))
-		D_GOTO(err_r, rc = -DER_NOMEM);
+		D_GOTO(err_r, rc = tins->ti_umm.umm_nospc_rc);
 	v = umem_off2ptr(&tins->ti_umm, r->kr_value);
 	memcpy(v, val->iov_buf, r->kr_value_len);
 
@@ -1182,7 +1182,7 @@ kv_rec_update(struct btr_instance *tins, struct btr_record *rec,
 
 		voff = umem_alloc(&tins->ti_umm, val->iov_len);
 		if (UMOFF_IS_NULL(voff))
-			return -DER_NOMEM;
+			return tins->ti_umm.umm_nospc_rc;
 		umem_free(&tins->ti_umm, r->kr_value);
 		r->kr_value = voff;
 		r->kr_value_cap = val->iov_len;
@@ -1249,14 +1249,14 @@ iv_rec_alloc(struct btr_instance *tins, d_iov_t *key, d_iov_t *val,
 
 	roff = umem_zalloc(&tins->ti_umm, sizeof(*r));
 	if (UMOFF_IS_NULL(roff))
-		D_GOTO(err, rc = -DER_NOMEM);
+		D_GOTO(err, rc = tins->ti_umm.umm_nospc_rc);
 	r = umem_off2ptr(&tins->ti_umm, roff);
 
 	r->ir_value_len = val->iov_len;
 	r->ir_value_cap = r->ir_value_len;
 	r->ir_value = umem_alloc(&tins->ti_umm, r->ir_value_cap);
 	if (UMOFF_IS_NULL(r->ir_value))
-		D_GOTO(err_r, rc = -DER_NOMEM);
+		D_GOTO(err_r, rc = tins->ti_umm.umm_nospc_rc);
 	v = umem_off2ptr(&tins->ti_umm, r->ir_value);
 	memcpy(v, val->iov_buf, r->ir_value_len);
 
@@ -1317,7 +1317,7 @@ iv_rec_update(struct btr_instance *tins, struct btr_record *rec,
 
 		voff = umem_alloc(&tins->ti_umm, val->iov_len);
 		if (UMOFF_IS_NULL(voff))
-			return -DER_NOMEM;
+			return tins->ti_umm.umm_nospc_rc;
 		umem_free(&tins->ti_umm, r->ir_value);
 		r->ir_value = voff;
 		r->ir_value_cap = val->iov_len;
@@ -1392,7 +1392,7 @@ recx_rec_alloc(struct btr_instance *tins, d_iov_t *key, d_iov_t *val,
 
 	roff = umem_zalloc(&tins->ti_umm, sizeof(*r));
 	if (UMOFF_IS_NULL(roff))
-		return -DER_NOMEM;
+		return tins->ti_umm.umm_nospc_rc;
 
 	r = umem_off2ptr(&tins->ti_umm, roff);
 	r->rr_recx = key_recx;

--- a/src/common/mem.c
+++ b/src/common/mem.c
@@ -525,10 +525,12 @@ umem_class_init(struct umem_attr *uma, struct umem_instance *umm)
 	D_DEBUG(DB_MEM, "Instantiate memory class %s\n", umc->umc_name);
 
 	memset(umm, 0, sizeof(*umm));
-	umm->umm_id	= umc->umc_id;
-	umm->umm_ops	= umc->umc_ops;
-	umm->umm_name	= umc->umc_name;
-	umm->umm_pool	= uma->uma_pool;
+	umm->umm_id		= umc->umc_id;
+	umm->umm_ops		= umc->umc_ops;
+	umm->umm_name		= umc->umc_name;
+	umm->umm_pool		= uma->uma_pool;
+	umm->umm_nospc_rc	= umc->umc_id == UMEM_CLASS_VMEM ?
+		-DER_NOMEM : -DER_NOSPACE;
 
 	set_offsets(umm);
 	return 0;

--- a/src/common/tests/utest_common.c
+++ b/src/common/tests/utest_common.c
@@ -155,7 +155,7 @@ utest_vmem_create(size_t root_size, struct utest_context **utx)
 	ctx->uc_root = umem_zalloc(&ctx->uc_umm, sizeof(*root) + root_size);
 
 	if (UMOFF_IS_NULL(ctx->uc_root)) {
-		rc = -DER_NOMEM;
+		rc = ctx->uc_umm.umm_nospc_rc;
 		goto free_ctx;
 	}
 
@@ -251,7 +251,7 @@ utest_alloc(struct utest_context *utx, umem_off_t *off, size_t size,
 
 	*off = umem_alloc(&utx->uc_umm, size);
 	if (UMOFF_IS_NULL(*off)) {
-		rc = -DER_NOMEM;
+		rc = utx->uc_umm.umm_nospc_rc;
 		goto end;
 	}
 

--- a/src/include/daos/mem.h
+++ b/src/include/daos/mem.h
@@ -264,6 +264,7 @@ struct umem_attr {
 /** instance of an unified memory class */
 struct umem_instance {
 	umem_class_id_t		 umm_id;
+	int			 umm_nospc_rc;
 	const char		*umm_name;
 	PMEMobjpool		*umm_pool;
 	/** Cache the pool id field for umem addresses */

--- a/src/vos/evtree.c
+++ b/src/vos/evtree.c
@@ -1064,7 +1064,7 @@ evt_node_alloc(struct evt_context *tcx, unsigned int flags,
 
 	nd_off = umem_zalloc(evt_umm(tcx), evt_node_size(tcx));
 	if (UMOFF_IS_NULL(nd_off))
-		return -DER_NOMEM;
+		return -DER_NOSPACE;
 
 	V_TRACE(DB_TRACE, "Allocate new node "DF_U64" %d bytes\n",
 		nd_off, evt_node_size(tcx));
@@ -2397,7 +2397,7 @@ evt_ssof_insert(struct evt_context *tcx, struct evt_node *nd,
 
 		desc_off = umem_zalloc(evt_umm(tcx), allocation_size);
 		if (UMOFF_IS_NULL(desc_off))
-			return -DER_NOMEM;
+			return -DER_NOSPACE;
 		ne->ne_child = desc_off;
 		desc = evt_off2ptr(tcx, desc_off);
 		rc = vos_dtx_register_record(evt_umm(tcx), desc_off,

--- a/src/vos/vos_container.c
+++ b/src/vos/vos_container.c
@@ -95,7 +95,7 @@ cont_df_rec_alloc(struct btr_instance *tins, d_iov_t *key_iov,
 	args = (struct cont_df_args *)(val_iov->iov_buf);
 	offset = umem_zalloc(&tins->ti_umm, sizeof(struct vos_cont_df));
 	if (UMOFF_IS_NULL(offset))
-		return -DER_NOMEM;
+		return -DER_NOSPACE;
 
 	cont_df = umem_off2ptr(&tins->ti_umm, offset);
 	uuid_copy(cont_df->cd_id, ukey->uuid);

--- a/src/vos/vos_dtx.c
+++ b/src/vos/vos_dtx.c
@@ -820,7 +820,7 @@ vos_dtx_alloc(struct umem_instance *umm, struct dtx_handle *dth,
 
 	dtx_umoff = umem_zalloc(umm, sizeof(struct vos_dtx_entry_df));
 	if (dtx_is_null(dtx_umoff))
-		return -DER_NOMEM;
+		return -DER_NOSPACE;
 
 	dtx = umem_off2ptr(umm, dtx_umoff);
 	dtx->te_xid = dth->dth_xid;
@@ -914,7 +914,7 @@ vos_dtx_append_share(struct umem_instance *umm, struct vos_dtx_entry_df *dtx,
 
 	rec_umoff = umem_zalloc(umm, sizeof(struct vos_dtx_record_df));
 	if (dtx_is_null(rec_umoff))
-		return -DER_NOMEM;
+		return -DER_NOSPACE;
 
 	rec = umem_off2ptr(umm, rec_umoff);
 	rec->tr_type = vds->vds_type;
@@ -1345,7 +1345,7 @@ vos_dtx_register_record(struct umem_instance *umm, umem_off_t record,
 
 	rec_umoff = umem_zalloc(umm, sizeof(struct vos_dtx_record_df));
 	if (dtx_is_null(rec_umoff))
-		return -DER_NOMEM;
+		return -DER_NOSPACE;
 
 	rec = umem_off2ptr(umm, rec_umoff);
 	rec->tr_type = type;

--- a/src/vos/vos_obj_index.c
+++ b/src/vos/vos_obj_index.c
@@ -123,7 +123,7 @@ oi_rec_alloc(struct btr_instance *tins, d_iov_t *key_iov,
 	/* Allocate a PMEM value of type vos_obj_df */
 	obj_off = umem_zalloc(&tins->ti_umm, sizeof(struct vos_obj_df));
 	if (UMOFF_IS_NULL(obj_off))
-		return -DER_NOMEM;
+		return -DER_NOSPACE;
 
 	rc = vos_dtx_register_record(&tins->ti_umm, obj_off, DTX_RT_OBJ, 0);
 	if (rc != 0)

--- a/src/vos/vos_tree.c
+++ b/src/vos/vos_tree.c
@@ -357,7 +357,7 @@ ktr_rec_alloc(struct btr_instance *tins, d_iov_t *key_iov,
 
 	rec->rec_off = umem_zalloc(&tins->ti_umm, vos_krec_size(rbund));
 	if (UMOFF_IS_NULL(rec->rec_off))
-		return -DER_NOMEM;
+		return -DER_NOSPACE;
 
 	krec = vos_rec2krec(tins, rec);
 	if (kbund->kb_epoch == DAOS_EPOCH_MAX) {
@@ -646,7 +646,7 @@ svt_rec_alloc(struct btr_instance *tins, d_iov_t *key_iov,
 		rec->rec_off = umem_alloc(&tins->ti_umm,
 					   vos_irec_size(rbund));
 		if (UMOFF_IS_NULL(rec->rec_off))
-			return -DER_NOMEM;
+			return -DER_NOSPACE;
 	} else {
 		umem_tx_add(&tins->ti_umm, rbund->rb_off,
 			    vos_irec_msize(rbund));


### PR DESCRIPTION
When persistent memory allocations fail, we want to return
DER_NOSPACE to indicate the storage is full rather than
DER_NOMEM which indicates there is no virtual memory.
For many cases, such as VOS, this just assumes we are using
pmem.  But some cases are ambiguous such as generic btree
code so I added a field to the umem_instance to indicate
the out of space error to return for convenience.