### PR TITLE
DAOS-623 doc: Remove USE_INSTALLED from documentation

### DIFF
--- a/doc/quickstart.md
+++ b/doc/quickstart.md
@@ -123,7 +123,7 @@ If you are a developer of DAOS, we recommend following the instructions in [DAOS
 Otherwise, the missing dependencies can be built automatically by invoking scons with the following parameters:
 
 ```
-    scons --config=force --build-deps=yes USE_INSTALLED=all install
+    scons --config=force --build-deps=yes install
 ```
 
 By default, DAOS and its dependencies are installed under \${daospath}/install. The installation path can be modified by adding the PREFIX= option to the above command line (e.g., PREFIX=/usr/local).


### PR DESCRIPTION
People continually have issues with finding things that are
installed on the system, particularly fio.  The option should
only be used when it is known that everything required is
actually installed or it should be used to specify individual
components that are installed.  This is not the common case
for the public documentation at least until we have RPMs at
which point we can revisit this.