### PR TITLE
DAOS-2720 doc: Prefer "Go" vs "Golang" as the language name

### DIFF
--- a/doc/admin/installation.md
+++ b/doc/admin/installation.md
@@ -8,7 +8,7 @@ distributions.
 Software Dependencies
 ---------------------
 
-DAOS requires a C99-capable compiler, a golang compiler, and the scons
+DAOS requires a C99-capable compiler, a Go compiler, and the scons
 build tool. Moreover, the DAOS stack leverages the following open source
 projects:
 

--- a/doc/development.md
+++ b/doc/development.md
@@ -28,7 +28,7 @@ With this approach DAOS would get built using the prebuilt dependencies in ${dao
 
 If you wish to compile DAOS with clang rather than gcc, set COMPILER=clang on the scons command line.   This option is also saved for future compilations.
 
-## Golang dependencies
+## Go dependencies
 
 Developers contributing Go code may need to change the external dependencies located in the src/control/vendor directory. The DAOS codebase uses [dep](https://github.com/golang/dep) to manage these dependencies.
 

--- a/doc/quickstart.md
+++ b/doc/quickstart.md
@@ -12,7 +12,7 @@ Storage-class memory (SCM) can be emulated with DRAM by creating tmpfs mountpoin
 
 ## Software Dependencies
 
-DAOS requires a C99-capable compiler, a golang compiler, and the scons build tool. Moreover, the DAOS stack leverages the following open source projects:
+DAOS requires a C99-capable compiler, a Go compiler, and the scons build tool. Moreover, the DAOS stack leverages the following open source projects:
 - [CaRT](https://github.com/daos-stack/cart) that relies on both [Mercury](https://mercury-hpc.github.io) and [Libfabric](https://ofiwg.github.io/libfabric/) for lightweight network transport and [PMIx](https://github.com/pmix/master) for process set management. See the CaRT repository for more information on how to build the CaRT library.
 - [PMDK](https://github.com/pmem/pmdk.git) for persistent memory programming.
 - [SPDK](http://spdk.io) for userspace NVMe device access and management.

--- a/src/common/README.md
+++ b/src/common/README.md
@@ -78,7 +78,7 @@ code [here](/src/include/daos/tse.h).
 
 ## dRPC C API
 
-For a general overview of dRPC concepts and the corresponding Golang API, see [here](/src/control/drpc/README.md).
+For a general overview of dRPC concepts and the corresponding Go API, see [here](/src/control/drpc/README.md).
 
 In the C API, an active dRPC connection is represented by a pointer to a context object (`struct drpc`). The context supplies all the state information required to communicate over the Unix Domain Socket. When finished with a context, the object should be freed by using `drpc_close()`.
 

--- a/src/control/README.md
+++ b/src/control/README.md
@@ -2,7 +2,7 @@
 
 DAOS operates over two, closely integrated planes, Control and Data. The Data plane handles the heavy lifting transport operations while the Control plane orchestrates process and storage management, facilitating the operation of the Data plane.
 
-[DAOS Server](server) implements the DAOS Control Plane and is written in Golang. It is tasked with network and storage hardware provisioning and allocation in addition to instantiation and management of the DAOS IO Servers (Data Plane written in C) running on the same host. Users of DAOS will interact directly only with the Control Plane in the form of the DAOS Server and associated tools.
+[DAOS Server](server) implements the DAOS Control Plane and is written in Go. It is tasked with network and storage hardware provisioning and allocation in addition to instantiation and management of the DAOS IO Servers (Data Plane written in C) running on the same host. Users of DAOS will interact directly only with the Control Plane in the form of the DAOS Server and associated tools.
 
 The DAOS Server implements the [gRPC protocol](https://grpc.io/) to communicate with client gRPC applications and interacts with DAOS IO Servers through Unix domain sockets.
 
@@ -32,7 +32,7 @@ First a view of software component architecture:
 
 ## Development Requirements
 
-- [Golang](https://golang.org/) 1.9 or higher
+- [Go](https://golang.org/) 1.10 or higher
 - [gRPC](https://grpc.io/)
 - [Protocol Buffers](https://developers.google.com/protocol-buffers/)
 - [Dep](https://github.com/golang/dep/) for managing dependencies in vendor directory.

--- a/src/iosrv/README.md
+++ b/src/iosrv/README.md
@@ -32,7 +32,7 @@ DAOS uses IV (incast variable) to share values and statuses among servers under 
 
 ## dRPC Server
 
-The I/O server includes a dRPC server that listens for activity on a given Unix Domain Socket. See the [dRPC documentation](src/control/drpc/README.md) for more details on the basics of dRPC, and the low-level APIs in Golang and C.
+The I/O server includes a dRPC server that listens for activity on a given Unix Domain Socket. See the [dRPC documentation](src/control/drpc/README.md) for more details on the basics of dRPC, and the low-level APIs in Go and C.
 
 The dRPC server polls periodically for incoming client connections and requests. It can handle multiple simultaneous client connections via the `struct drpc_progress_context` object, which manages the `struct drpc` objects for the listening socket as well as any active client connections.
 


### PR DESCRIPTION
The language's name is Go. This commit tweaks documentation
to reflect this preference.

https://golang.org/doc/faq#go_or_golang

Signed-off-by: Michael MacDonald <mjmac.macdonald@intel.com>