### PR TITLE
DAOS-2743 dtx: skip local replica properly when dispatch DTX RPC

### DIFF
--- a/src/dtx/dtx_rpc.c
+++ b/src/dtx/dtx_rpc.c
@@ -463,7 +463,9 @@ dtx_dti_classify_one(struct ds_pool *pool, struct pl_map *map, uuid_t po_uuid,
 		D_ASSERT(rc == 1);
 
 		/* skip myself. */
-		if (myrank == target->ta_comp.co_rank)
+		if (myrank == target->ta_comp.co_rank &&
+		    dss_get_module_info()->dmi_tgt_id ==
+		    target->ta_comp.co_index)
 			continue;
 
 		dcrb.dcrb_rank = target->ta_comp.co_rank;
@@ -718,7 +720,9 @@ dtx_check(uuid_t po_uuid, uuid_t co_uuid, struct dtx_entry *dte,
 		D_ASSERT(rc == 1);
 
 		/* skip myself. */
-		if (myrank == target->ta_comp.co_rank)
+		if (myrank == target->ta_comp.co_rank &&
+		    dss_get_module_info()->dmi_tgt_id ==
+		    target->ta_comp.co_index)
 			continue;
 
 		D_ALLOC_PTR(drr);


### PR DESCRIPTION
When dispatch DTX RPC to other replicas, we need to skip the local
replica that can be handled by the DTX RPC sponsor. Originally, we
check whether the target replica is local one via only checking the
target's rank, but that is not enough. For the case that if there
are multiple replicas reside on the same server node, such checking
will skip the replicas on the server node by wrong.

This patch also checks the target's index to make sure it is really
the local replica or not.

Signed-off-by: Fan Yong <fan.yong@intel.com>