### PR TITLE
DAOS-2751 obj: fix a bug of DAOS_OBJ_REPL_MAX's layout

### DIFF
--- a/src/dtx/dtx_rpc.c
+++ b/src/dtx/dtx_rpc.c
@@ -401,7 +401,7 @@ dtx_get_replicas(daos_unit_oid_t *oid, struct pl_obj_layout *layout)
 
 	replicas = oc_attr->u.repl.r_num;
 	if (replicas == DAOS_OBJ_REPL_MAX)
-		replicas = layout->ol_nr;
+		replicas = layout->ol_grp_size;
 
 	if (replicas < 1)
 		return -DER_INVAL;

--- a/src/include/daos/placement.h
+++ b/src/include/daos/placement.h
@@ -75,6 +75,8 @@ struct pl_obj_shard {
 
 struct pl_obj_layout {
 	uint32_t		 ol_ver;
+	uint32_t		 ol_grp_size;
+	uint32_t		 ol_grp_nr;
 	uint32_t		 ol_nr;
 	struct pl_obj_shard	*ol_shards;
 };
@@ -143,7 +145,7 @@ pl_obj_get_shard(void *data, int idx)
 	return &layout->ol_shards[idx];
 }
 
-int pl_select_leader(daos_obj_id_t oid, uint32_t shard_idx, int shards_nr,
+int pl_select_leader(daos_obj_id_t oid, uint32_t shard_idx, uint32_t grp_size,
 		     bool for_tgt_id, pl_get_shard_t pl_get_shard, void *data);
 
 void obj_layout_dump(daos_obj_id_t oid, struct pl_obj_layout *layout);

--- a/src/object/obj_internal.h
+++ b/src/object/obj_internal.h
@@ -112,8 +112,9 @@ struct dc_object {
 	/* cob_lock protects layout and shard objects ptrs */
 	pthread_rwlock_t	 cob_lock;
 
-	unsigned int		cob_version;
-	unsigned int		cob_shards_nr;
+	unsigned int		 cob_version;
+	unsigned int		 cob_shards_nr;
+	unsigned int		 cob_grp_size;
 	/** shard object ptrs */
 	struct dc_obj_layout	*cob_shards;
 };

--- a/src/placement/pl_map.c
+++ b/src/placement/pl_map.c
@@ -537,7 +537,7 @@ pl_map_version(struct pl_map *map)
  *
  * \param [IN]	oid		The object identifier.
  * \param [IN]	shard_idx	The shard index.
- * \param [IN]	shards_ns	Total count of the object's shards.
+ * \param [IN]	grp_size	Group size of obj layout.
  * \param [IN]	for_tgt_id	Require leader target id or leader shard index.
  * \param [IN]	pl_get_shard	The callback function to parse out pl_obj_shard
  *				from the given @data.
@@ -547,7 +547,7 @@ pl_map_version(struct pl_map *map)
  *				shard index. Negative value if error.
  */
 int
-pl_select_leader(daos_obj_id_t oid, uint32_t shard_idx, int shards_nr,
+pl_select_leader(daos_obj_id_t oid, uint32_t shard_idx, uint32_t grp_size,
 		 bool for_tgt_id, pl_get_shard_t pl_get_shard, void *data)
 {
 	struct pl_obj_shard		*shard;
@@ -558,10 +558,8 @@ pl_select_leader(daos_obj_id_t oid, uint32_t shard_idx, int shards_nr,
 	int				 start;
 	int				 pos;
 	int				 off;
+	int				 replica_idx;
 	int				 i;
-
-	if (shards_nr <= shard_idx)
-		return -DER_INVAL;
 
 	oc_attr = daos_oclass_attr_find(oid);
 	if (oc_attr->ca_resil != DAOS_RES_REPL) {
@@ -575,7 +573,7 @@ pl_select_leader(daos_obj_id_t oid, uint32_t shard_idx, int shards_nr,
 
 	replicas = oc_attr->u.repl.r_num;
 	if (replicas == DAOS_OBJ_REPL_MAX)
-		replicas = shards_nr;
+		replicas = grp_size;
 
 	if (replicas < 1)
 		return -DER_INVAL;
@@ -605,9 +603,11 @@ pl_select_leader(daos_obj_id_t oid, uint32_t shard_idx, int shards_nr,
 	 */
 	rdg_idx = shard_idx / replicas;
 	start = rdg_idx * replicas;
-	preferred = start + (oid.lo + rdg_idx) % replicas;
+	replica_idx = (oid.lo + rdg_idx) % replicas;
+	preferred = start + replica_idx;
 	for (i = 0, off = preferred, pos = -1; i < replicas;
-	     i++, off = (off + 1) % replicas + start) {
+	     i++, replica_idx = (replica_idx + 1) % replicas,
+	     off = start + replica_idx) {
 		shard = pl_get_shard(data, off);
 		if (shard->po_target == -1 || shard->po_rebuilding)
 			continue;

--- a/src/placement/ring_map.c
+++ b/src/placement/ring_map.c
@@ -1257,6 +1257,8 @@ ring_obj_layout_fill(struct pl_map *map, struct daos_obj_md *md,
 	unsigned int		 pos, i, j, k, rc = 0;
 
 	layout->ol_ver = pl_map_version(map);
+	layout->ol_grp_size = rop->rop_grp_size;
+	layout->ol_grp_nr = rop->rop_grp_nr;
 
 	plts = ring_oid2ring(rimap, md->omd_id)->ri_targets;
 	plts_nr = rimap->rmp_target_nr;
@@ -1423,7 +1425,7 @@ ring_obj_find_rebuild(struct pl_map *map, struct daos_obj_md *md,
 					goto fill;
 
 				leader = pl_select_leader(md->omd_id,
-					l_shard->po_shard, layout->ol_nr,
+					l_shard->po_shard, layout->ol_grp_size,
 					true, pl_obj_get_shard, layout);
 				if (leader < 0) {
 					D_WARN("Not sure whether current shard "

--- a/src/pool/srv_pool.c
+++ b/src/pool/srv_pool.c
@@ -3012,8 +3012,9 @@ ds_pool_check_leader(uuid_t pool_uuid, daos_unit_oid_t *oid,
 	if (rc != 0)
 		goto out;
 
-	leader = pl_select_leader(oid->id_pub, oid->id_shard, layout->ol_nr,
-				  true, pl_obj_get_shard, layout);
+	leader = pl_select_leader(oid->id_pub, oid->id_shard,
+				  layout->ol_grp_size, true,
+				  pl_obj_get_shard, layout);
 	if (leader < 0) {
 		D_WARN("Failed to select leader for "DF_UOID
 		       "version = %d: rc = %d\n",


### PR DESCRIPTION
When generate the obj layout based on ring_obj_placement, the
pl_obj_layout did not carry grp_size and grp_nr information.
And later for obj IO's layout calculation the obj_get_grp_size
returns incorrect info for DAOS_OBJ_REPL_MAX.

Signed-off-by: Xuezhao Liu <xuezhao.liu@intel.com>