### PR TITLE
DAOS-2752: test: Reduce timeout of daos_core_test

### DIFF
--- a/src/tests/ftest/daos_test/daos_core_test-rebuild.yaml
+++ b/src/tests/ftest/daos_test/daos_core_test-rebuild.yaml
@@ -10,7 +10,7 @@ hosts:
     - boro-F
     - boro-G
     - boro-H
-timeout: 1500
+timeout: 600
 server_config:
   name: daos_server
 daos_tests:
@@ -23,6 +23,7 @@ daos_tests:
       daos_test: r
       test_name: rebuild tests 0-24
       args: -s3 -u subtests="0-24"
+      test_timeout: 1500
     test_r_25:
       daos_test: r
       test_name: rebuild tests 25

--- a/src/tests/ftest/daos_test/daos_core_test.yaml
+++ b/src/tests/ftest/daos_test/daos_core_test.yaml
@@ -10,7 +10,10 @@ hosts:
     - boro-F
     - boro-G
     - boro-H
-timeout: 900
+# Note that subtests below can set their own timeout so this
+# should be a general average of all tests not including outliers
+# (I'm looking at you "rebuild tests")
+timeout: 600
 server_config:
   name: daos_server
 daos_tests:
@@ -37,6 +40,7 @@ daos_tests:
     test_i:
       daos_test: i
       test_name: IO test
+      test_timeout: 900
     test_A:
       daos_test: A
       test_name: DAOS Array tests
@@ -52,3 +56,4 @@ daos_tests:
     test_O:
       daos_test: O
       test_name: OID Allocator tests
+      test_timeout: 900

--- a/src/tests/ftest/util/daos_core_base.py
+++ b/src/tests/ftest/util/daos_core_base.py
@@ -38,6 +38,11 @@ class DaosCoreBase(TestWithServers):
         super(DaosCoreBase, self).__init__(*args, **kwargs)
         self.subtest_name = None
 
+        test_timeout = self.params.get("test_timeout",
+                                       '/run/daos_tests/Tests/*')
+        if test_timeout:
+            self.timeout = test_timeout
+
     def setUp(self):
         super(DaosCoreBase, self).setUp()
         self.subtest_name = self.params.get("test_name",


### PR DESCRIPTION
Currently the daos_core_test timeout is 5000s per subtest. That is grossly
over-specified. The current test time of the longest subtest in the most
recent runs is about 1000s

Let's reduce this timeout to something in the neighborhood of about 1.5x
current typical, or 1500s.

But since we can specify timeouts per "variant" in avocado, let's have a
low global timeout value that covers most of the tests which are quick
and just override the timeout on the one or two outliers.