### PR TITLE
DAOS-2723 mgmt: check target before pool destory

### DIFF
--- a/src/include/daos_srv/pool.h
+++ b/src/include/daos_srv/pool.h
@@ -178,4 +178,16 @@ int
 ds_pool_child_map_refresh_sync(struct ds_pool_child *dpc);
 int
 ds_pool_child_map_refresh_async(struct ds_pool_child *dpc);
+
+enum map_ranks_class {
+	MAP_RANKS_UP,
+	MAP_RANKS_DOWN
+};
+
+int
+map_ranks_init(const struct pool_map *map, enum map_ranks_class class,
+	       d_rank_list_t *ranks);
+
+void
+map_ranks_fini(d_rank_list_t *ranks);
 #endif /* __DAOS_SRV_POOL_H__ */

--- a/src/pool/srv_util.c
+++ b/src/pool/srv_util.c
@@ -31,11 +31,6 @@
 #include "rpc.h"
 #include "srv_internal.h"
 
-enum map_ranks_class {
-	MAP_RANKS_UP,
-	MAP_RANKS_DOWN
-};
-
 static inline int
 map_ranks_include(enum map_ranks_class class, int status)
 {
@@ -53,7 +48,7 @@ map_ranks_include(enum map_ranks_class class, int status)
 }
 
 /* Build a rank list of targets with certain status. */
-static int
+int
 map_ranks_init(const struct pool_map *map, enum map_ranks_class class,
 	       d_rank_list_t *ranks)
 {
@@ -100,7 +95,7 @@ map_ranks_init(const struct pool_map *map, enum map_ranks_class class,
 	return 0;
 }
 
-static void
+void
 map_ranks_fini(d_rank_list_t *ranks)
 {
 	if (ranks->rl_ranks != NULL) {


### PR DESCRIPTION
Checking target status from the pool map before
pool destroy collective RPC to avoid sending RPC
to DOWN targets.

Signed-off-by: Wang Di <di.wang@intel.com>