### PR TITLE
DAOS-2763 iosrv: use immutable target ID for BIO

### DIFF
--- a/src/iosrv/srv.c
+++ b/src/iosrv/srv.c
@@ -409,7 +409,7 @@ dss_srv_handler(void *arg)
 
 	/* Initialize NVMe context for main XS which accesses NVME */
 	if (dx->dx_main_xs) {
-		rc = bio_xsctxt_alloc(&dmi->dmi_nvme_ctxt, dmi->dmi_xs_id);
+		rc = bio_xsctxt_alloc(&dmi->dmi_nvme_ctxt, dmi->dmi_tgt_id);
 		if (rc != 0) {
 			D_ERROR("failed to init spdk context for xstream(%d) "
 				"rc:%d\n", dmi->dmi_xs_id, rc);


### PR DESCRIPTION
Use immutable target ID for bio_xsctxt_alloc() instead of xstream ID,
the latter one could be changed when the configure of offload thread
count is changed.

Signed-off-by: Niu Yawei <yawei.niu@intel.com>
Change-Id: I8f541fa486fea57e87a18f3f0b823b294649e316