### PR TITLE
DAOS-1213 control: explain access and broadcast command types

### DIFF
--- a/src/control/README.md
+++ b/src/control/README.md
@@ -30,6 +30,16 @@ First a view of software component architecture:
 
 ![Architecture diagram](/doc/graph/system_architecture.png)
 
+There are operations that will be performed on individual nodes in parallel, such as hardware provisioning, which will execute through storage or network libraries.
+
+Such broadcast commands (which will connect to a list of hosts) will usually be issued by the [management tool](dmg), a gRPC client, and handled by the gRPC [MgmtCtlServer](server/mgmt.go) running in `daos_server`.
+These commands will not traverse dRPC but will perform node-local functions such as hardware (network and storage) provisioning.
+
+Other operations which will interact with the DAOS data plane through the replicated management service.
+Such operations will be triggered via a single control plane instance (access point) and use the replicated management service (running in the data plane) to perform a distributed operation such as creating a storage pool.
+
+Commands which require connection to an access point will be forwarded to the data plane ([iosrv](/src/iosrv)), redirected by gRPC [MgmtSvc](server/mgmt_svc.go) over dRPC channel and handled by the [mgmt](/src/mgmt/srv.c) module.
+
 ## Development Requirements
 
 - [Go](https://golang.org/) 1.10 or higher

--- a/src/control/server/mgmt.go
+++ b/src/control/server/mgmt.go
@@ -39,7 +39,8 @@ import (
 
 var jsonDBRelPath = "share/daos/control/mgmtinit_db.json"
 
-// controlService type is the data container for the service.
+// controlService implements the control plane control service, satisfying
+// pb.MgmtCtlServer, and is the data container for the service.
 type controlService struct {
 	nvme              *nvmeStorage
 	scm               *scmStorage


### PR DESCRIPTION
Describe how commands can be targeted at a list of either hosts
(for hardware provisioning) or access points (replicated
management service for distributed DAOS operations).

Signed-off-by: Tom Nabarro <tom.nabarro@intel.com>