### PR TITLE
DAOS-2667 bio: device faulty reaction

### DIFF
--- a/src/bio/bio_context.c
+++ b/src/bio/bio_context.c
@@ -76,14 +76,14 @@ blob_cp_arg_fini(struct blob_cp_arg *ba)
 }
 
 static void
-free_blob_msg_arg(struct blob_msg_arg *bma)
+blob_msg_arg_free(struct blob_msg_arg *bma)
 {
 	blob_cp_arg_fini(&bma->bma_cp_arg);
 	D_FREE(bma);
 }
 
 static struct blob_msg_arg *
-alloc_blob_msg_arg()
+blob_msg_arg_alloc()
 {
 	struct blob_msg_arg	*bma;
 	int			 rc;
@@ -154,7 +154,7 @@ blob_open_cb(void *arg, struct spdk_blob *blob, int rc)
 		ioc->bic_opening = 0;
 		if (rc == 0)
 			ioc->bic_blob = blob;
-		free_blob_msg_arg(bma);
+		blob_msg_arg_free(bma);
 	}
 }
 
@@ -172,7 +172,7 @@ blob_close_cb(void *arg, int rc)
 		ioc->bic_closing = 0;
 		if (rc == 0)
 			ioc->bic_blob = NULL;
-		free_blob_msg_arg(bma);
+		blob_msg_arg_free(bma);
 	}
 }
 
@@ -261,7 +261,7 @@ bio_bs_hold(struct bio_blobstore *bbs)
 	    bbs->bb_state == BIO_BS_STATE_OUT) {
 		D_ERROR("Blobstore %p is in %d state, reject request.\n",
 			bbs, bbs->bb_state);
-		rc = -DER_STALE;
+		rc = -DER_DOS;
 		goto out;
 	}
 
@@ -472,7 +472,7 @@ bio_blob_open(struct bio_io_context *ctxt, uuid_t uuid, bool async)
 	}
 	blob_id = smd_pool.npi_blob_id;
 
-	bma = alloc_blob_msg_arg();
+	bma = blob_msg_arg_alloc();
 	if (bma == NULL)
 		return -DER_NOMEM;
 	ba = &bma->bma_cp_arg;
@@ -506,7 +506,7 @@ bio_blob_open(struct bio_io_context *ctxt, uuid_t uuid, bool async)
 		ctxt->bic_blob = ba->bca_blob;
 	}
 
-	free_blob_msg_arg(bma);
+	blob_msg_arg_free(bma);
 	return rc;
 }
 
@@ -550,7 +550,7 @@ bio_ioctxt_open(struct bio_io_context **pctxt, struct bio_xs_context *xs_ctxt,
 	return rc;
 }
 
-static int
+int
 bio_blob_close(struct bio_io_context *ctxt, bool async)
 {
 	struct blob_msg_arg	*bma;
@@ -571,7 +571,7 @@ bio_blob_close(struct bio_io_context *ctxt, bool async)
 		return -DER_BUSY;
 	}
 
-	bma = alloc_blob_msg_arg();
+	bma = blob_msg_arg_alloc();
 	if (bma == NULL)
 		return -DER_NOMEM;
 	ba = &bma->bma_cp_arg;
@@ -605,7 +605,7 @@ bio_blob_close(struct bio_io_context *ctxt, bool async)
 		ctxt->bic_blob = NULL;
 	}
 
-	free_blob_msg_arg(bma);
+	blob_msg_arg_free(bma);
 	return rc;
 }
 

--- a/src/bio/bio_recovery.c
+++ b/src/bio/bio_recovery.c
@@ -1,0 +1,250 @@
+/**
+ * (C) Copyright 2018-2019 Intel Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * GOVERNMENT LICENSE RIGHTS-OPEN SOURCE SOFTWARE
+ * The Government's rights to use, modify, reproduce, release, perform, display,
+ * or disclose this software are subject to the terms of the Apache License as
+ * provided in Contract No. B620873.
+ * Any reproduction of computer software, computer software documentation, or
+ * portions thereof marked with this legend must also reproduce the markings.
+ */
+#define D_LOGFAC	DD_FAC(bio)
+
+#include <spdk/io_channel.h>
+#include <spdk/blob.h>
+#include "bio_internal.h"
+
+/*
+ * The BIO blobstore (mapped to one NVMe device) owner xstream polls the
+ * state periodically, and takes predefined reaction routines on state
+ * transition, all the reaction routines must be non-blocking, otherwise
+ * the DAOS progress ULT will be blocked, and NVMe device qpair won't be
+ * polled.
+ */
+struct bio_reaction_ops	*ract_ops;
+
+/*
+ * Return value:	0: Faulty reaction is done;
+ *			1: Faulty reaction is in progress;
+ *			-ve: Error;
+ */
+static int
+on_faulty(struct bio_blobstore *bbs)
+{
+	int	tgt_ids[BIO_XS_CNT_MAX];
+	int	tgt_cnt, i, rc;
+
+	/* Transit to next state if faulty reaction isn't registered */
+	if (ract_ops == NULL || ract_ops->faulty_reaction == NULL)
+		return 0;
+
+	ABT_mutex_lock(bbs->bb_mutex);
+	tgt_cnt = bbs->bb_ref;
+	D_ASSERT(tgt_cnt <= BIO_XS_CNT_MAX && tgt_cnt > 0);
+
+	for (i = 0; i < tgt_cnt; i++)
+		tgt_ids[i] = bbs->bb_xs_ctxts[i]->bxc_xs_id;
+	ABT_mutex_unlock(bbs->bb_mutex);
+
+	rc = ract_ops->faulty_reaction(tgt_ids, tgt_cnt);
+	if (rc < 0)
+		D_ERROR("Faulty reaction failed. %d\n", rc);
+
+	return rc;
+}
+
+/*
+ * Return value:	0: Per-xstream context is torn down;
+ *			1: Per-xstream context teardown is in progress;
+ */
+static int
+teardown_xstream(struct bio_xs_context *xs_ctxt)
+{
+	struct bio_io_context	*ioc;
+	int			 opened_blobs = 0;
+
+	D_ASSERT(xs_ctxt != NULL);
+	/* Teardown work for this xstream is done */
+	if (xs_ctxt->bxc_io_channel == NULL)
+		return 0;
+
+	/* Try to close all blobs */
+	d_list_for_each_entry(ioc, &xs_ctxt->bxc_io_ctxts, bic_link) {
+		D_ASSERT(ioc->bic_opening == 0);
+
+		if (ioc->bic_blob == NULL)
+			continue;
+
+		opened_blobs++;
+		if (ioc->bic_closing)
+			continue;
+
+		bio_blob_close(ioc, true);
+	}
+
+	if (opened_blobs)
+		return 1;
+
+	/* Put the io channel */
+	D_ASSERT(xs_ctxt->bxc_io_channel != NULL);
+	spdk_bs_free_io_channel(xs_ctxt->bxc_io_channel);
+	xs_ctxt->bxc_io_channel = NULL;
+
+	return 0;
+}
+
+static void
+unload_bs_cp(void *arg, int rc)
+{
+	struct bio_blobstore *bbs = arg;
+
+	if (rc != 0)
+		D_ERROR("Failed to unload bs:%p, %d\n", bbs, rc);
+	else
+		bbs->bb_bs = NULL;
+}
+
+/*
+ * Return value:	0: Blobstore is torn down;
+ *			1: Blobstore teardown is in progress;
+ */
+static int
+on_teardown(struct bio_blobstore *bbs)
+{
+	int	i, rc = 0, ret;
+
+	/*
+	 * The blobstore is already closed, transit to next state.
+	 * TODO: Need to cleanup bdev when supporting reintegration.
+	 */
+	if (bbs->bb_bs == NULL)
+		return 0;
+
+	ABT_mutex_lock(bbs->bb_mutex);
+
+	if (bbs->bb_holdings != 0) {
+		D_DEBUG(DB_MGMT, "Blobstore %p is inuse:%d, retry later.\n",
+			bbs, bbs->bb_holdings);
+		ABT_mutex_unlock(bbs->bb_mutex);
+		return 1;
+	}
+
+	/* Hold the lock to prevent other xstreams from exiting */
+	for (i = 0; i < bbs->bb_ref; i++) {
+		ret = teardown_xstream(bbs->bb_xs_ctxts[i]);
+		rc += ret;
+	}
+
+	ABT_mutex_unlock(bbs->bb_mutex);
+
+	if (rc == 0) {
+		/* Unload the blobstore */
+		D_ASSERT(bbs->bb_bs != NULL);
+		D_ASSERT(bbs->bb_holdings == 0);
+		spdk_bs_unload(bbs->bb_bs, unload_bs_cp, bbs);
+	}
+
+	return 1;
+}
+
+int
+bio_bs_state_set(struct bio_blobstore *bbs, enum bio_bs_state new_state)
+{
+	int	rc = 0;
+
+	D_ASSERT(bbs != NULL);
+
+	ABT_mutex_lock(bbs->bb_mutex);
+	if (bbs->bb_state == new_state) {
+		ABT_mutex_unlock(bbs->bb_mutex);
+		return 0;
+	}
+
+	switch (new_state) {
+	case BIO_BS_STATE_NORMAL:
+		if (bbs->bb_state != BIO_BS_STATE_REINT)
+			rc = -DER_INVAL;
+		break;
+	case BIO_BS_STATE_FAULTY:
+		if (bbs->bb_state != BIO_BS_STATE_NORMAL &&
+		    bbs->bb_state != BIO_BS_STATE_REPLACED &&
+		    bbs->bb_state != BIO_BS_STATE_REINT)
+			rc = -DER_INVAL;
+		break;
+	case BIO_BS_STATE_TEARDOWN:
+		if (bbs->bb_state != BIO_BS_STATE_FAULTY)
+			rc = -DER_INVAL;
+		break;
+	case BIO_BS_STATE_OUT:
+		if (bbs->bb_state != BIO_BS_STATE_TEARDOWN)
+			rc = -DER_INVAL;
+	case BIO_BS_STATE_REPLACED:
+	case BIO_BS_STATE_REINT:
+		rc = -DER_NOSYS;
+		break;
+	default:
+		rc = -DER_INVAL;
+		D_ASSERTF(0, "Invalid bs state: %u\n", new_state);
+		break;
+	}
+
+	if (rc) {
+		D_ERROR("BS state transit error! xs_id: %d, %u -> %u\n",
+			bbs->bb_owner_xs->bxc_xs_id, bbs->bb_state, new_state);
+	} else {
+		D_DEBUG(DB_MGMT, "BS state transited. xs_id: %d, %u -> %u\n",
+			bbs->bb_owner_xs->bxc_xs_id, bbs->bb_state, new_state);
+		bbs->bb_state = new_state;
+		/* TODO: Call SMD to update persistent device state */
+	}
+	ABT_mutex_unlock(bbs->bb_mutex);
+
+	return rc;
+}
+
+int
+bio_bs_state_transit(struct bio_blobstore *bbs)
+{
+	int	rc;
+
+	D_ASSERT(bbs != NULL);
+
+	switch (bbs->bb_state) {
+	case BIO_BS_STATE_NORMAL:
+	case BIO_BS_STATE_OUT:
+		rc = 0;
+		break;
+	case BIO_BS_STATE_FAULTY:
+		rc = on_faulty(bbs);
+		if (rc == 0)
+			rc = bio_bs_state_set(bbs, BIO_BS_STATE_TEARDOWN);
+		break;
+	case BIO_BS_STATE_TEARDOWN:
+		rc = on_teardown(bbs);
+		if (rc == 0)
+			rc = bio_bs_state_set(bbs, BIO_BS_STATE_OUT);
+		break;
+	case BIO_BS_STATE_REPLACED:
+	case BIO_BS_STATE_REINT:
+		rc = -DER_NOSYS;
+		break;
+	default:
+		rc = -DER_INVAL;
+		D_ASSERTF(0, "Invalid bs state:%u\n", bbs->bb_state);
+		break;
+	}
+
+	return (rc < 0) ? rc : 0;
+}

--- a/src/bio/bio_xstream.c
+++ b/src/bio/bio_xstream.c
@@ -125,7 +125,8 @@ print_io_stat(struct bio_xs_context *ctxt, uint64_t now)
 }
 
 int
-bio_nvme_init(const char *storage_path, const char *nvme_conf, int shm_id)
+bio_nvme_init(const char *storage_path, const char *nvme_conf, int shm_id,
+	      struct bio_reaction_ops *ops)
 {
 	char		*env;
 	int		rc, fd;
@@ -195,6 +196,7 @@ bio_nvme_init(const char *storage_path, const char *nvme_conf, int shm_id)
 	io_stat_period *= (NSEC_PER_SEC / NSEC_PER_USEC);
 
 	nvme_glb.bd_shm_id = shm_id;
+	ract_ops = ops;
 	return 0;
 
 free_cond:
@@ -696,16 +698,17 @@ get_bio_blobstore(struct bio_blobstore *bb, struct bio_xs_context *ctxt)
 			return NULL;
 		} else if (bb->bb_xs_ctxts[i] == NULL) {
 			bb->bb_xs_ctxts[i] = ctxt;
+			bb->bb_ref++;
 			break;
 		}
 	}
+
+	ABT_mutex_unlock(bb->bb_mutex);
+
 	if (i == xs_cnt_max) {
 		D_ERROR("Too many xstreams per device!\n");
-		ABT_mutex_unlock(bb->bb_mutex);
 		return NULL;
 	}
-	bb->bb_ref++;
-	ABT_mutex_unlock(bb->bb_mutex);
 	return bb;
 }
 

--- a/src/include/daos_srv/bio.h
+++ b/src/include/daos_srv/bio.h
@@ -162,15 +162,32 @@ bio_sgl_convert(struct bio_sglist *bsgl, d_sg_list_t *sgl)
 }
 
 /**
+ * Callbacks called on NVMe device state transition
+ *
+ * \param tgt_ids[IN]	Affected target IDs
+ * \param tgt_cnt[IN]	Target count
+ *
+ * \return		0: Reaction finished;
+ *			1: Reaction is in progress;
+ *			-ve: Error happened;
+ */
+struct bio_reaction_ops {
+	int (*faulty_reaction)(int *tgt_ids, int tgt_cnt);
+	int (*reint_reaction)(int *tgt_ids, int tgt_cnt);
+};
+
+/**
  * Global NVMe initialization.
  *
  * \param[IN] storage_path	daos storage directory path
  * \param[IN] nvme_conf		NVMe config file
  * \param[IN] shm_id		shm id to enable multiprocess mode in SPDK
+ * \param[IN] ops		Reaction callback functions
  *
  * \return		Zero on success, negative value on error
  */
-int bio_nvme_init(const char *storage_path, const char *nvme_conf, int shm_id);
+int bio_nvme_init(const char *storage_path, const char *nvme_conf, int shm_id,
+		  struct bio_reaction_ops *ops);
 
 /**
  * Global NVMe finilization.

--- a/src/iosrv/srv.c
+++ b/src/iosrv/srv.c
@@ -1671,7 +1671,8 @@ dss_srv_init()
 	dss_register_key(&daos_srv_modkey);
 	xstream_data.xd_init_step = XD_INIT_REG_KEY;
 
-	rc = bio_nvme_init(dss_storage_path, dss_nvme_conf, dss_nvme_shm_id);
+	rc = bio_nvme_init(dss_storage_path, dss_nvme_conf, dss_nvme_shm_id,
+			   NULL);
 	if (rc != 0)
 		D_GOTO(failed, rc);
 	xstream_data.xd_init_step = XD_INIT_NVME;

--- a/src/vos/vos_common.c
+++ b/src/vos/vos_common.c
@@ -288,7 +288,8 @@ vos_nvme_init(void)
 	if (rc != 0 && rc != -DER_EXIST)
 		return rc;
 
-	rc = bio_nvme_init(VOS_STORAGE_PATH, VOS_NVME_CONF, VOS_NVME_SHM_ID);
+	rc = bio_nvme_init(VOS_STORAGE_PATH, VOS_NVME_CONF, VOS_NVME_SHM_ID,
+			   NULL);
 	if (rc)
 		return rc;
 	vsa_nvme_init = true;


### PR DESCRIPTION
Introduced bio_bs_state_transit() which will be periodically called
by device monitor (device owner xstream) to keep the state rolling.

bio_reaction_ops is provided for upper layer to register faulty
reaction callback, this callback will mark all the affected targets
in pool maps to trigger rebuilds.

Signed-off-by: Niu Yawei <yawei.niu@intel.com>
Change-Id: I445a9755615eb6d8641db9a4c27e2ce348263fc3