### PR TITLE
DAOS-2695 Security: Add agent Certificate loading in daos_agent for g…

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -45,7 +45,8 @@ def sanitized_JOB_NAME = JOB_NAME.toLowerCase().replaceAll('/', '-').replaceAll(
 
 def rpm_test_pre = '''export PDSH_SSH_ARGS_APPEND="-i ci_key"
                       nodelist=(${NODELIST//,/ })
-                      scp -i ci_key src/tests/ftest/data/daos_server_baseline.yaml jenkins@${nodelist[0]}:/tmp
+                      scp -i ci_key src/tests/ftest/data/daos_server_baseline.yaml \
+				    jenkins@${nodelist[0]}:/tmp
                       ssh -i ci_key jenkins@${nodelist[0]} "set -ex
                       repo_file_base=\"*_job_\${JOB_NAME%%/*}_job_\"
                       for repo in openpa libfabric pmix   \
@@ -70,6 +71,7 @@ def rpm_test_daos_test = '''me=\\\$(whoami)
                             sudo mount -t tmpfs -o size=16777216k tmpfs /mnt/daos
                             sudo cp /tmp/daos_server_baseline.yaml /usr/etc/daos_server.yml
                             cat /usr/etc/daos_server.yml
+                            cat /usr/etc/daos_agent.yml
                             coproc orterun -np 1 -H \\\$HOSTNAME --enable-recovery -x DAOS_SINGLETON_CLI=1  daos_server -c 1 -a /tmp -o /usr/etc/daos_server.yml
                             trap 'set -x; kill -INT \\\$COPROC_PID' EXIT
                             line=\"\"
@@ -78,7 +80,7 @@ def rpm_test_daos_test = '''me=\\\$(whoami)
                                 echo \"Server stdout: \\\$line\"
                             done
                             echo \"Server started!\"
-                            daos_agent &
+                            daos_agent -o /usr/etc/daos_agent.yml -i &
                             AGENT_PID=\\\$!
                             trap 'set -x; kill -INT \\\$AGENT_PID \\\$COPROC_PID' EXIT
                             orterun -np 1 -x OFI_INTERFACE=eth0 -x CRT_ATTACH_INFO_PATH=/tmp -x DAOS_SINGLETON_CLI=1 daos_test -m'''

--- a/src/control/cmd/agent/main.go
+++ b/src/control/cmd/agent/main.go
@@ -29,7 +29,8 @@ import (
 	"path/filepath"
 	"syscall"
 
-	"github.com/jessevdk/go-flags"
+	flags "github.com/jessevdk/go-flags"
+	"github.com/pkg/errors"
 
 	"github.com/daos-stack/daos/src/control/client"
 	"github.com/daos-stack/daos/src/control/common"
@@ -43,7 +44,8 @@ const (
 )
 
 type cliOptions struct {
-	ConfigPath string `short:"o" long:"config-path" description:"Path to agent configuration file"`
+	ConfigPath string `short:"o" long:"config-path" description:"Path to agent configuration file" default:"etc/daos_agent.yml"`
+	Insecure   bool   `short:"i" long:"insecure" description:"have agent attempt to connect without certificates"`
 	RuntimeDir string `short:"s" long:"runtime_dir" description:"Path to agent communications socket"`
 	LogFile    string `short:"l" long:"logfile" description:"Full path and filename for daos agent log file"`
 }
@@ -69,7 +71,10 @@ func applyCmdLineOverrides(c *client.Configuration, opts *cliOptions) {
 		log.Debugf("Overriding LogFile path from config file with %s", opts.LogFile)
 		c.LogFile = opts.LogFile
 	}
-
+	if opts.Insecure == true {
+		log.Debugf("Overriding AllowInsecure from config file with %t", opts.Insecure)
+		c.TransportConfig.AllowInsecure = true
+	}
 }
 
 func agentMain() error {
@@ -115,6 +120,11 @@ func agentMain() error {
 	defer f.Close()
 	log.SetOutput(f)
 
+	err = config.TransportConfig.PreLoadCertData()
+	if err != nil {
+		return errors.Wrap(err, "Unable to load Cerificate Data")
+	}
+
 	// Setup signal handlers so we can block till we get SIGINT or SIGTERM
 	signals := make(chan os.Signal, 1)
 	finish := make(chan bool, 1)
@@ -129,7 +139,7 @@ func agentMain() error {
 	module := &SecurityModule{}
 	module.InitModule(nil)
 	drpcServer.RegisterRPCModule(module)
-	drpcServer.RegisterRPCModule(&mgmtModule{config.AccessPoints[0]})
+	drpcServer.RegisterRPCModule(&mgmtModule{config.AccessPoints[0], config.TransportConfig})
 
 	err = drpcServer.Start()
 	if err != nil {

--- a/src/tests/ftest/util/agent_utils.py
+++ b/src/tests/ftest/util/agent_utils.py
@@ -117,7 +117,8 @@ def run_agent(basepath, server_list, client_list=None):
         cmd = [
             "ssh",
             client,
-            daos_agent_bin
+            daos_agent_bin,
+            "-i"
         ]
 
         p = subprocess.Popen(cmd,

--- a/utils/config/SConscript
+++ b/utils/config/SConscript
@@ -5,7 +5,8 @@ def scons():
     """Execute build"""
     Import('env')
 
-    env.Install("$PREFIX/etc", ['daos_server.yml', 'daos.yml'])
+    env.Install("$PREFIX/etc", ['daos_server.yml', 'daos.yml',
+                                'daos_agent.yml'])
 
 if __name__ == "SCons.Script":
     scons()

--- a/utils/rpms/daos.spec
+++ b/utils/rpms/daos.spec
@@ -5,7 +5,7 @@
 
 Name:          daos
 Version:       0.5.0
-Release:       3%{?dist}
+Release:       4%{?dist}
 Summary:       DAOS Storage Engine
 
 License:       Apache
@@ -198,6 +198,7 @@ echo "%{_libdir}/daos_srv" > %{?buildroot}/%{_sysconfdir}/ld.so.conf.d/daos.conf
 %{_libdir}/libioil.so
 %{_datadir}/%{name}/ioil-ld-opts
 %{_prefix}%{_sysconfdir}/daos.yml
+%{_prefix}%{_sysconfdir}/daos_agent.yml
 
 %files tests
 %{daoshome}/utils/py
@@ -221,6 +222,9 @@ echo "%{_libdir}/daos_srv" > %{?buildroot}/%{_sysconfdir}/ld.so.conf.d/daos.conf
 %{_libdir}/*.a
 
 %changelog
+* Fri Jun 21 2019 David Quigley <dquigley@intel.com>
+- Add daos_agent.yml to the list of packaged files
+
 * Thu Jun 12 2019 Brian J. Murrell <brian.murrell@intel.com>
 - move obj_ctl daos_gen_io_conf daos_run_io_conf to
   daos-tests sub-package


### PR DESCRIPTION
…RPC and provide --insecure flag

The gRPC server in daos_server can use a TLS channel to protect its
communications. This loads up the certificates needed to verify the agent
identity and encrypt the transport channel. It also provides an insecure flag
to tell the sever not to attempt any authentication or encryption.

Signed-off-by: David Quigley <david.quigley@intel.com>