### PR TITLE
DAOS-2660 api: further cleanup after obj class cleanup

### DIFF
--- a/src/SConscript
+++ b/src/SConscript
@@ -4,7 +4,8 @@ import os
 
 HEADERS = ['daos.h', 'daos_api.h', 'daos_types.h', 'daos_errno.h',
            'daos_event.h', 'daos_mgmt.h', 'daos_types.h', 'daos_addons.h',
-           'daos_task.h', 'daos_fs.h', 'daos_uns.h', 'daos_security.h']
+           'daos_task.h', 'daos_fs.h', 'daos_uns.h', 'daos_security.h',
+           'daos_prop.h', 'daos_obj_class.h', 'daos_obj.h']
 HEADERS_SRV = ['vos.h', 'vos_types.h']
 
 def scons():

--- a/src/client/dfs/dfs.c
+++ b/src/client/dfs/dfs.c
@@ -1905,9 +1905,9 @@ dfs_dup(dfs_t *dfs, dfs_obj_t *obj, int flags, dfs_obj_t **_new_obj)
 	case S_IFREG:
 	{
 		char		buf[1024];
-		daos_iov_t	ghdl;
+		d_iov_t		ghdl;
 
-		daos_iov_set(&ghdl, buf, 1024);
+		d_iov_set(&ghdl, buf, 1024);
 
 		rc = daos_array_local2global(obj->oh, &ghdl);
 		if (rc)

--- a/src/client/dfs/dfs.c
+++ b/src/client/dfs/dfs.c
@@ -459,14 +459,14 @@ insert_entry(daos_handle_t oh, daos_handle_t th, const char *name,
 }
 
 static int
-get_nlinks(daos_handle_t oh, daos_handle_t th, uint32_t *nlinks,
-	   bool check_empty)
+get_num_entries(daos_handle_t oh, daos_handle_t th, uint32_t *nr,
+		bool check_empty)
 {
 	daos_key_desc_t	kds[ENUM_DESC_NR];
 	daos_anchor_t	anchor = {0};
 	uint32_t	key_nr = 0;
 	d_sg_list_t	sgl;
-	d_iov_t	iov;
+	d_iov_t		iov;
 	char		enum_buf[ENUM_DESC_BUF] = {0};
 
 	sgl.sg_nr = 1;
@@ -494,7 +494,7 @@ get_nlinks(daos_handle_t oh, daos_handle_t th, uint32_t *nlinks,
 			break;
 	}
 
-	*nlinks = key_nr;
+	*nr = key_nr;
 	return 0;
 }
 
@@ -505,7 +505,6 @@ entry_stat(dfs_t *dfs, daos_handle_t th, daos_handle_t oh, const char *name,
 	struct dfs_entry	entry = {0};
 	bool			exists;
 	daos_size_t		size;
-	uint32_t		nlinks;
 	int			rc;
 
 	memset(stbuf, 0, sizeof(struct stat));
@@ -520,30 +519,8 @@ entry_stat(dfs_t *dfs, daos_handle_t th, daos_handle_t oh, const char *name,
 
 	switch (entry.mode & S_IFMT) {
 	case S_IFDIR:
-	{
-		daos_handle_t	dir_oh;
-
 		size = sizeof(entry);
-		rc = daos_obj_open(dfs->coh, entry.oid, DAOS_OO_RO,
-				   &dir_oh, NULL);
-		if (rc)
-			return -daos_der2errno(rc);
-
-		/*
-		 * TODO - This makes stat very slow now. Need to figure out a
-		 * different way to get/maintain nlinks.
-		 */
-		rc = get_nlinks(dir_oh, th, &nlinks, false);
-		if (rc) {
-			daos_obj_close(dir_oh, NULL);
-			return rc;
-		}
-
-		rc = daos_obj_close(dir_oh, NULL);
-		if (rc)
-			return -daos_der2errno(rc);
 		break;
-	}
 	case S_IFREG:
 	{
 		daos_handle_t	file_oh;
@@ -572,8 +549,6 @@ entry_stat(dfs_t *dfs, daos_handle_t th, daos_handle_t oh, const char *name,
 		if (rc)
 			return -daos_der2errno(rc);
 
-		nlinks = 1;
-
 		/*
 		 * TODO - this is not accurate since it does not account for
 		 * sparse files or file metadata or xattributes.
@@ -584,14 +559,13 @@ entry_stat(dfs_t *dfs, daos_handle_t th, daos_handle_t oh, const char *name,
 	case S_IFLNK:
 		size = strlen(entry.value);
 		D_FREE(entry.value);
-		nlinks = 1;
 		break;
 	default:
 		D_ERROR("Invalid entry type (not a dir, file, symlink).\n");
 		return -EINVAL;
 	}
 
-	stbuf->st_nlink = (nlink_t)nlinks;
+	stbuf->st_nlink = 1;
 	stbuf->st_size = size;
 	stbuf->st_mode = entry.mode;
 	stbuf->st_uid = dfs->uid;
@@ -1329,7 +1303,7 @@ dfs_remove(dfs_t *dfs, dfs_obj_t *parent, const char *name, bool force)
 		D_GOTO(out, rc = -ENOENT);
 
 	if (S_ISDIR(entry.mode)) {
-		uint32_t nlinks = 0;
+		uint32_t nr = 0;
 		daos_handle_t oh;
 
 		/** check if dir is empty */
@@ -1339,7 +1313,7 @@ dfs_remove(dfs_t *dfs, dfs_obj_t *parent, const char *name, bool force)
 			D_GOTO(out, rc = -daos_der2errno(rc));
 		}
 
-		rc = get_nlinks(oh, th, &nlinks, true);
+		rc = get_num_entries(oh, th, &nr, true);
 		if (rc) {
 			daos_obj_close(oh, NULL);
 			D_GOTO(out, rc);
@@ -1349,10 +1323,10 @@ dfs_remove(dfs_t *dfs, dfs_obj_t *parent, const char *name, bool force)
 		if (rc)
 			D_GOTO(out, rc = -daos_der2errno(rc));
 
-		if (!force && nlinks != 0)
+		if (!force && nr != 0)
 			D_GOTO(out, rc = -ENOTEMPTY);
 
-		if (force && nlinks != 0) {
+		if (force && nr != 0) {
 			rc = remove_dir_contents(dfs, th, entry);
 			if (rc)
 				D_GOTO(out, rc);
@@ -1533,19 +1507,6 @@ out:
 err_obj:
 	D_FREE(obj);
 	goto out;
-}
-
-int
-dfs_nlinks(dfs_t *dfs, dfs_obj_t *obj, uint32_t *nlinks)
-{
-	if (dfs == NULL || !dfs->mounted)
-		return -EINVAL;
-	if (obj == NULL || !S_ISDIR(obj->mode))
-		return -ENOTDIR;
-	if (nlinks == NULL)
-		return -EINVAL;
-
-	return get_nlinks(obj->oh, DAOS_TX_NONE, nlinks, false);
 }
 
 int
@@ -2481,7 +2442,7 @@ dfs_move(dfs_t *dfs, dfs_obj_t *parent, char *name, dfs_obj_t *new_parent,
 
 	if (exists) {
 		if (S_ISDIR(new_entry.mode)) {
-			uint32_t nlinks = 0;
+			uint32_t nr = 0;
 			daos_handle_t oh;
 
 			/** if old entry not a dir, return error */
@@ -2498,7 +2459,7 @@ dfs_move(dfs_t *dfs, dfs_obj_t *parent, char *name, dfs_obj_t *new_parent,
 				D_GOTO(out, rc = -daos_der2errno(rc));
 			}
 
-			rc = get_nlinks(oh, th, &nlinks, true);
+			rc = get_num_entries(oh, th, &nr, true);
 			if (rc) {
 				D_ERROR("failed to check dir %s (%d)\n",
 					new_name, rc);
@@ -2512,7 +2473,7 @@ dfs_move(dfs_t *dfs, dfs_obj_t *parent, char *name, dfs_obj_t *new_parent,
 				D_GOTO(out, rc = -daos_der2errno(rc));
 			}
 
-			if (nlinks != 0) {
+			if (nr != 0) {
 				D_ERROR("target dir is not empty\n");
 				D_GOTO(out, rc = -ENOTEMPTY);
 			}

--- a/src/client/dfs/dfuse_hl.c
+++ b/src/client/dfs/dfuse_hl.c
@@ -1159,7 +1159,7 @@ int main(int argc, char *argv[])
 	/** Connect to DAOS pool */
 	rc = daos_pool_connect(pool_uuid, dfuse_fs.group, svcl, DAOS_PC_RW,
 			       &poh, &pool_info, NULL);
-	daos_rank_list_free(svcl);
+	d_rank_list_free(svcl);
 	if (rc < 0) {
 		fprintf(stderr, "Failed to connect to pool (%d)\n", rc);
 		D_GOTO(out_daos, rc = 1);

--- a/src/client/dfs/duns.c
+++ b/src/client/dfs/duns.c
@@ -95,7 +95,7 @@ duns_resolve_path(const char *path, struct duns_attr_t *attr)
 	}
 
 	t = strtok_r(NULL, "/", &saveptr);
-	daos_oclass_str2id(t, &attr->da_oclass);
+	attr->da_oclass = daos_oclass_name2id(t);
 
 	t = strtok_r(NULL, "/", &saveptr);
 	attr->da_chunk_size = strtoull(t, NULL, 10);
@@ -161,7 +161,7 @@ duns_link_path(const char *path, const char *sysname,
 	}
 
 	uuid_unparse(attrp->da_puuid, pool);
-	daos_oclass_id2str(attrp->da_oclass, oclass);
+	daos_oclass_id2name(attrp->da_oclass, oclass);
 	daos_unparse_ctype(attrp->da_type, type);
 
 	/* create container with specified container uuid (try_multiple=0)

--- a/src/client/dfuse/dfuse_main.c
+++ b/src/client/dfuse/dfuse_main.c
@@ -273,7 +273,7 @@ out_open:
 		D_FREE(dfs);
 	}
 out:
-	daos_rank_list_free(dfuse_info->di_svcl);
+	d_rank_list_free(dfuse_info->di_svcl);
 	DFUSE_TRA_DOWN(dfuse_info);
 	DFUSE_LOG_INFO("Exiting with status %d", ret);
 	D_FREE(dfuse_info);

--- a/src/container/container_iv.c
+++ b/src/container/container_iv.c
@@ -391,7 +391,7 @@ cont_iv_capa_alloc_internal(d_sg_list_t *sgl)
 		return -DER_NOMEM;
 	}
 
-	daos_iov_set(&sgl->sg_iovs[0], entry, sizeof(*entry));
+	d_iov_set(&sgl->sg_iovs[0], entry, sizeof(*entry));
 	return 0;
 }
 

--- a/src/include/daos/common.h
+++ b/src/include/daos/common.h
@@ -135,20 +135,6 @@ daos_rank_list_valid(const d_rank_list_t *rl)
 	return rl && rl->rl_ranks && rl->rl_nr;
 }
 
-/**
- * Generate a rank list from a string with a seprator argument. This is a
- * convenience function to generate the rank list required by
- * daos_pool_connect().
- *
- * \param[in]	str	string with the rank list
- * \param[in]	sep	separator of the ranks in \a str.
- *			dmg uses ":" as the separator.
- *
- * \return		allocated rank list that user is responsible to free
- *			with d_rank_list_free().
- */
-d_rank_list_t *daos_rank_list_parse(const char *str, const char *sep);
-
 static inline uint64_t
 daos_get_ntime(void)
 {

--- a/src/include/daos/object.h
+++ b/src/include/daos/object.h
@@ -228,7 +228,6 @@ struct daos_oclass_attr *daos_oclass_attr_find(daos_obj_id_t oid);
 unsigned int daos_oclass_grp_size(struct daos_oclass_attr *oc_attr);
 unsigned int daos_oclass_grp_nr(struct daos_oclass_attr *oc_attr,
 				struct daos_obj_md *md);
-int daos_oclass_name2id(const char *name);
 
 /** bits for the specified rank */
 #define DAOS_OC_SR_SHIFT	24
@@ -281,9 +280,6 @@ daos_oclass_st_set_tgt(daos_obj_id_t oid, int tgt)
 	oid.hi |= (uint64_t)tgt << DAOS_OC_ST_SHIFT;
 	return oid;
 }
-
-void daos_oclass_str2id(const char *str, daos_oclass_id_t *oc_id);
-void daos_oclass_id2str(daos_oclass_id_t oc_id, char *str);
 
 static inline bool
 daos_unit_oid_is_null(daos_unit_oid_t oid)

--- a/src/include/daos_api.h
+++ b/src/include/daos_api.h
@@ -34,6 +34,20 @@ extern "C" {
 #endif
 
 /**
+ * Generate a rank list from a string with a seprator argument. This is a
+ * convenience function to generate the rank list required by
+ * daos_pool_connect().
+ *
+ * \param[in]	str	string with the rank list
+ * \param[in]	sep	separator of the ranks in \a str.
+ *			dmg uses ":" as the separator.
+ *
+ * \return		allocated rank list that user is responsible to free
+ *			with d_rank_list_free().
+ */
+d_rank_list_t *daos_rank_list_parse(const char *str, const char *sep);
+
+/**
  * Connect to the DAOS pool identified by UUID \a uuid. Upon a successful
  * completion, \a poh returns the pool handle, and \a info returns the latest
  * pool information.

--- a/src/include/daos_fs.h
+++ b/src/include/daos_fs.h
@@ -235,18 +235,6 @@ int
 dfs_punch(dfs_t *dfs, dfs_obj_t *obj, daos_off_t offset, daos_size_t len);
 
 /**
- * Query number of link in dir object.
- *
- * \param[in]	dfs	Pointer to the mounted file system.
- * \param[in]	obj	Opened directory object.
- * \param[out]	nlinks	Number of links returned.
- *
- * \return		0 on Success. Negative errno on Failure.
- */
-int
-dfs_nlinks(dfs_t *dfs, dfs_obj_t *obj, uint32_t *nlinks);
-
-/**
  * directory readdir.
  *
  * \param[in]	dfs	Pointer to the mounted file system.

--- a/src/include/daos_obj_class.h
+++ b/src/include/daos_obj_class.h
@@ -27,9 +27,6 @@
 extern "C" {
 #endif
 
-#include <daos/common.h>
-#include <daos_types.h>
-
 /**
  * Predefined object classes
  * It describes schema of data distribution & protection.

--- a/src/include/daos_obj_class.h
+++ b/src/include/daos_obj_class.h
@@ -449,6 +449,28 @@ struct daos_oclass_list {
 };
 
 /**
+ * Return the Object class ID given the object class name in string format.
+ *
+ * \param[in]	name	Object class name.
+ *
+ * \return		The Object class ID, -1 if unknown.
+ */
+int
+daos_oclass_name2id(const char *name);
+
+/**
+ * Return the object class name given it's ID.
+ *
+ * \param[in]	oc_id	Object class ID.
+ * \param[out]	name	buffer for the name of the object class to be copied
+ *			into it.
+ *
+ * \return		0 on success, -1 if invalid class.
+ */
+int
+daos_oclass_id2name(daos_oclass_id_t oc_id, char *name);
+
+/**
  * Register a new object class in addition to the default ones (see DAOS_OC_*).
  * An object class cannot be unregistered for the time being.
  *

--- a/src/include/daos_obj_class.h
+++ b/src/include/daos_obj_class.h
@@ -453,7 +453,7 @@ struct daos_oclass_list {
  *
  * \param[in]	name	Object class name.
  *
- * \return		The Object class ID, -1 if unknown.
+ * \return		The Object class ID, 0 / OC_UNKNOWN if unknown.
  */
 int
 daos_oclass_name2id(const char *name);

--- a/src/include/daos_task.h
+++ b/src/include/daos_task.h
@@ -35,6 +35,7 @@ extern "C" {
 #include <daos_obj.h>
 #include <daos_addons.h>
 #include <daos_errno.h>
+#include <daos_prop.h>
 #include <daos/tse.h>
 
 /** DAOS operation codes for task creation */

--- a/src/include/daos_types.h
+++ b/src/include/daos_types.h
@@ -53,15 +53,6 @@ extern "C" {
 typedef uint64_t	daos_size_t;
 typedef uint64_t	daos_off_t;
 
-/**
- * daos_sg_list_t/daos_iov_t/daos_iov_set is for keeping compatibility for
- * upper layer.
- */
-#define daos_sg_list_t			d_sg_list_t
-#define daos_iov_t			d_iov_t
-#define daos_iov_set(iov, buf, size)	d_iov_set((iov), (buf), (size))
-#define daos_rank_list_free(r)		d_rank_list_free((r))
-
 #define crt_proc_daos_key_t	crt_proc_d_iov_t
 #define crt_proc_daos_size_t	crt_proc_uint64_t
 #define crt_proc_daos_epoch_t	crt_proc_uint64_t

--- a/src/object/cli_ec.c
+++ b/src/object/cli_ec.c
@@ -1,4 +1,3 @@
-
 /**
  * (C) Copyright 2016-2019 Intel Corporation.
  *
@@ -28,6 +27,7 @@
  */
 #define D_LOGFAC	DD_FAC(object)
 
+#include <daos/common.h>
 #include <daos_task.h>
 #include <daos_types.h>
 #include "obj_rpc.h"
@@ -358,7 +358,7 @@ ec_obj_update_encode(tse_task_t *task, daos_obj_id_t oid,
 	int			 rc = 0;
 
 	for (i = 0; i < args->nr; i++) {
-		daos_sg_list_t	*sgl = &args->sgls[i];
+		d_sg_list_t	*sgl = &args->sgls[i];
 		daos_iod_t	*iod = &args->iods[i];
 
 		if (ec_has_full_stripe(iod, oca, tgt_set)) {

--- a/src/object/obj_class.c
+++ b/src/object/obj_class.c
@@ -357,6 +357,22 @@ daos_oclass_name2id(const char *name)
 	return oc->oc_id;
 }
 
+int
+daos_oclass_id2name(daos_oclass_id_t oc_id, char *str)
+{
+	struct daos_obj_class   *oc;
+
+	for (oc = &daos_obj_classes[0]; oc->oc_id != OC_UNKNOWN; oc++) {
+		if (oc->oc_id == oc_id) {
+			strcpy(str, oc->oc_name);
+			return 0;
+		}
+	}
+
+	D_ASSERT(oc->oc_id == OC_UNKNOWN);
+	return -1;
+}
+
 /** Return the redundancy group size of @oc_attr */
 unsigned int
 daos_oclass_grp_size(struct daos_oclass_attr *oc_attr)
@@ -402,55 +418,6 @@ daos_oclass_grp_nr(struct daos_oclass_attr *oc_attr, struct daos_obj_md *md)
 {
 	/* NB: @md is unsupported for now */
 	return oc_attr->ca_grp_nr;
-}
-
-void
-daos_oclass_str2id(const char *str, daos_oclass_id_t *oc_id)
-{
-	/* XXX should just scan the class table */
-	if (strcasecmp(str, "tiny") == 0)
-		*oc_id = OC_S1;
-	else if (strcasecmp(str, "small") == 0)
-		*oc_id = OC_S4;
-	else if (strcasecmp(str, "large") == 0)
-		*oc_id = OC_SX;
-	else if (strcasecmp(str, "R2") == 0)
-		*oc_id = OC_RP_2G2;
-	else if (strcasecmp(str, "R2S") == 0)
-		*oc_id = OC_RP_2G1;
-	else if (strcasecmp(str, "repl_max") == 0)
-		*oc_id = OC_RP_XSF;
-	else
-		*oc_id = OC_UNKNOWN;
-}
-
-void
-daos_oclass_id2str(daos_oclass_id_t oc_id, char *str)
-{
-	/* XXX should just scan the class table */
-	switch (oc_id) {
-	case OC_S1:
-		strcpy(str, "tiny");
-		break;
-	case OC_S4:
-		strcpy(str, "small");
-		break;
-	case OC_SX:
-		strcpy(str, "large");
-		break;
-	case OC_RP_2G2:
-		strcpy(str, "R2");
-		break;
-	case OC_RP_2G1:
-	       strcpy(str, "R2S");
-	       break;
-	case OC_RP_XSF:
-	       strcpy(str, "repl_max");
-	       break;
-	default:
-		strcpy(str, "unknown");
-		break;
-	}
 }
 
 /** a structure to map EC object class to EC codec structure */

--- a/src/object/obj_class.c
+++ b/src/object/obj_class.c
@@ -349,12 +349,11 @@ daos_oclass_name2id(const char *name)
 
 	for (oc = &daos_obj_classes[0]; oc->oc_id != OC_UNKNOWN; oc++) {
 		if (strncmp(oc->oc_name, name, strlen(name)) == 0)
-			break;
+			return oc->oc_id;
 	}
-	if (oc->oc_id == OC_UNKNOWN)
-		return -1;
 
-	return oc->oc_id;
+	D_ASSERT(oc->oc_id == OC_UNKNOWN);
+	return OC_UNKNOWN;
 }
 
 int

--- a/src/pool/srv_pool.c
+++ b/src/pool/srv_pool.c
@@ -1736,8 +1736,8 @@ ds_pool_connect_handler(crt_rpc_t *rpc)
 	struct pool_buf			*map_buf;
 	uint32_t			map_version;
 	struct rdb_tx			tx;
-	daos_iov_t			key;
-	daos_iov_t			value;
+	d_iov_t				key;
+	d_iov_t				value;
 	struct pool_hdl			hdl;
 	d_iov_t				iv_iov;
 	unsigned int			iv_ns_id;
@@ -2323,9 +2323,9 @@ replace_failed_replicas(struct pool_svc *svc, struct pool_map *map)
 		if (!daos_rank_list_identical(replicas, tmp_replicas))
 			D_DEBUG(DB_MD, DF_UUID": failed to update replicas\n",
 				DP_UUID(svc->ps_uuid));
-		daos_rank_list_free(tmp_replicas);
+		d_rank_list_free(tmp_replicas);
 	}
-	daos_rank_list_free(replicas);
+	d_rank_list_free(replicas);
 out:
 	return rc;
 }

--- a/src/rdb/tests/rdb_test.c
+++ b/src/rdb/tests/rdb_test.c
@@ -31,7 +31,7 @@
 #define DB_CAP	(1L << 25)
 
 static char		*test_svc_name = "rsvc_test";
-static daos_iov_t	 test_svc_id;
+static d_iov_t	 test_svc_id;
 static uuid_t		 test_db_uuid;
 
 #define ID_OK(id) ioveq((id), &test_svc_id)
@@ -60,7 +60,7 @@ ioveq(const d_iov_t *iov1, const d_iov_t *iov2)
 }
 
 static int
-test_svc_name_cb(daos_iov_t *id, char **name)
+test_svc_name_cb(d_iov_t *id, char **name)
 {
 	ID_OK(id);
 	D_STRNDUP(*name, test_svc_name, strlen(test_svc_name));
@@ -69,7 +69,7 @@ test_svc_name_cb(daos_iov_t *id, char **name)
 }
 
 static int
-test_svc_load_uuid_cb(daos_iov_t *id, uuid_t db_uuid)
+test_svc_load_uuid_cb(d_iov_t *id, uuid_t db_uuid)
 {
 	ID_OK(id);
 	uuid_copy(db_uuid, test_db_uuid);
@@ -77,21 +77,21 @@ test_svc_load_uuid_cb(daos_iov_t *id, uuid_t db_uuid)
 }
 
 static int
-test_svc_store_uuid_cb(daos_iov_t *id, uuid_t db_uuid)
+test_svc_store_uuid_cb(d_iov_t *id, uuid_t db_uuid)
 {
 	ID_OK(id);
 	return 0;
 }
 
 static int
-test_svc_delete_uuid_cb(daos_iov_t *id)
+test_svc_delete_uuid_cb(d_iov_t *id)
 {
 	ID_OK(id);
 	return 0;
 }
 
 static int
-test_svc_locate_cb(daos_iov_t *id, char **path)
+test_svc_locate_cb(d_iov_t *id, char **path)
 {
 	char	uuid_string[DAOS_UUID_STR_SIZE];
 	int	rc;
@@ -105,7 +105,7 @@ test_svc_locate_cb(daos_iov_t *id, char **path)
 }
 
 static int
-test_svc_alloc_cb(daos_iov_t *id, struct ds_rsvc **svcp)
+test_svc_alloc_cb(d_iov_t *id, struct ds_rsvc **svcp)
 {
 	ID_OK(id);
 	D_ALLOC_PTR(*svcp);
@@ -481,7 +481,7 @@ rdbt_test_handler(crt_rpc_t *rpc)
 static int
 rdbt_module_init(void)
 {
-	daos_iov_set(&test_svc_id, test_svc_name, strlen(test_svc_name) + 1);
+	d_iov_set(&test_svc_id, test_svc_name, strlen(test_svc_name) + 1);
 	ds_rsvc_class_register(DS_RSVC_CLASS_TEST, &test_svc_rsvc_class);
 	return 0;
 }

--- a/src/rsvc/srv.c
+++ b/src/rsvc/srv.c
@@ -834,7 +834,7 @@ out_stop:
 }
 
 int
-ds_rsvc_add_replicas(enum ds_rsvc_class_id class, daos_iov_t *id,
+ds_rsvc_add_replicas(enum ds_rsvc_class_id class, d_iov_t *id,
 		     d_rank_list_t *ranks, size_t size, struct rsvc_hint *hint)
 {
 	struct ds_rsvc	*svc;
@@ -865,12 +865,12 @@ ds_rsvc_remove_replicas_s(struct ds_rsvc *svc, d_rank_list_t *ranks)
 	if (stop_ranks->rl_nr > 0)
 		ds_rsvc_dist_stop(svc->s_class, &svc->s_id, stop_ranks,
 				  true /* destroy */);
-	daos_rank_list_free(stop_ranks);
+	d_rank_list_free(stop_ranks);
 	return rc;
 }
 
 int
-ds_rsvc_remove_replicas(enum ds_rsvc_class_id class, daos_iov_t *id,
+ds_rsvc_remove_replicas(enum ds_rsvc_class_id class, d_iov_t *id,
 			d_rank_list_t *ranks, struct rsvc_hint *hint)
 {
 	struct ds_rsvc	*svc;

--- a/src/utils/daos.c
+++ b/src/utils/daos.c
@@ -402,7 +402,7 @@ common_op_parse_hdlr(int argc, char *argv[], struct cmd_args_s *ap)
 			break;
 		case 'o':
 			ap->oclass = daos_oclass_name2id(optarg);
-			if (ap->oclass == -1) {
+			if (ap->oclass == OC_UNKNOWN) {
 				fprintf(stderr, "unknown object class: %s\n",
 						optarg);
 				D_GOTO(out_free, rc = RC_PRINT_HELP);

--- a/src/utils/daos.c
+++ b/src/utils/daos.c
@@ -124,7 +124,7 @@ cmd_args_print(struct cmd_args_s *ap)
 	if (ap == NULL)
 		return;
 
-	daos_oclass_id2str(ap->oclass, oclass);
+	daos_oclass_id2name(ap->oclass, oclass);
 	daos_unparse_ctype(ap->type, type);
 
 	D_INFO("\tDAOS system name: %s\n", ap->sysname);
@@ -401,8 +401,8 @@ common_op_parse_hdlr(int argc, char *argv[], struct cmd_args_s *ap)
 			}
 			break;
 		case 'o':
-			daos_oclass_str2id(optarg, &ap->oclass);
-			if (ap->oclass == OC_UNKNOWN) {
+			ap->oclass = daos_oclass_name2id(optarg);
+			if (ap->oclass == -1) {
 				fprintf(stderr, "unknown object class: %s\n",
 						optarg);
 				D_GOTO(out_free, rc = RC_PRINT_HELP);

--- a/src/utils/daos.c
+++ b/src/utils/daos.c
@@ -505,7 +505,7 @@ common_op_parse_hdlr(int argc, char *argv[], struct cmd_args_s *ap)
 	return 0;
 
 out_free:
-	daos_rank_list_free(ap->mdsrv);
+	d_rank_list_free(ap->mdsrv);
 	if (ap->sysname != NULL)
 		D_FREE(ap->sysname);
 	if (ap->mdsrv_str != NULL)
@@ -948,7 +948,7 @@ main(int argc, char *argv[])
 	rc = hdlr(&dargs);
 
 	/* Clean up dargs.mdsrv allocated in common_op_parse_hdlr() */
-	daos_rank_list_free(dargs.mdsrv);
+	d_rank_list_free(dargs.mdsrv);
 
 	daos_fini();
 

--- a/src/utils/daos_hdlr.c
+++ b/src/utils/daos_hdlr.c
@@ -236,7 +236,7 @@ cont_query_hdlr(struct cmd_args_s *ap)
 		printf("DAOS Unified Namespace Attributes on path %s:\n",
 			ap->path);
 		daos_unparse_ctype(ap->type, type);
-		daos_oclass_id2str(ap->oclass, oclass);
+		daos_oclass_id2name(ap->oclass, oclass);
 		printf("Container Type:\t%s\n", type);
 		printf("Object Class:\t%s\n", oclass);
 		printf("Chunk Size:\t%zu\n", ap->chunk_size);


### PR DESCRIPTION
- remove deprecated daos_iov_t and daos_sg_list_t
- make daos_rank_list_parse public again
- remove deprecated daos_rank_list_free
- have to install public headers that were added

Signed-off-by: Mohamad Chaarawi <mohamad.chaarawi@intel.com>