### PR TITLE
DAOS-2660 api: fix indenting in python wrapper

### DIFF
--- a/src/utils/py/daos_api.py
+++ b/src/utils/py/daos_api.py
@@ -742,7 +742,7 @@ class DaosObj(object):
         func = self.context.get_function('generate-oid')
 
         # XXX convert object class
-	cls = int(ConvertObjClass[DaosObjClassOld(objcls)])
+        cls = int(ConvertObjClass[DaosObjClassOld(objcls)])
 
         func.restype = DaosObjId
         self.c_oid = func(cls, 0, 0)


### PR DESCRIPTION
Use space instead of tabs.

Signed-off-by: Johann Lombardi <johann.lombardi@intel.com>