### PR TITLE
DAOS-2788 control: Update Go imports for consistency

### DIFF
--- a/src/control/client/config.go
+++ b/src/control/client/config.go
@@ -29,11 +29,12 @@ import (
 	"os/exec"
 	"path/filepath"
 
+	"github.com/pkg/errors"
+	yaml "gopkg.in/yaml.v2"
+
 	"github.com/daos-stack/daos/src/control/common"
 	"github.com/daos-stack/daos/src/control/log"
 	"github.com/daos-stack/daos/src/control/security"
-	"github.com/pkg/errors"
-	yaml "gopkg.in/yaml.v2"
 )
 
 const (

--- a/src/control/client/connect_test.go
+++ b/src/control/client/connect_test.go
@@ -27,11 +27,12 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/pkg/errors"
+	. "google.golang.org/grpc/connectivity"
+
 	"github.com/daos-stack/daos/src/control/common"
 	. "github.com/daos-stack/daos/src/control/common"
 	pb "github.com/daos-stack/daos/src/control/common/proto/mgmt"
-	"github.com/pkg/errors"
-	. "google.golang.org/grpc/connectivity"
 )
 
 func connectSetup(

--- a/src/control/client/control.go
+++ b/src/control/client/control.go
@@ -24,10 +24,11 @@
 package client
 
 import (
-	pb "github.com/daos-stack/daos/src/control/common/proto/mgmt"
-	"github.com/daos-stack/daos/src/control/security"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/connectivity"
+
+	pb "github.com/daos-stack/daos/src/control/common/proto/mgmt"
+	"github.com/daos-stack/daos/src/control/security"
 )
 
 // Control interface provides connection handling capabilities.

--- a/src/control/client/feature.go
+++ b/src/control/client/feature.go
@@ -30,9 +30,9 @@ import (
 	"sort"
 	"time"
 
-	pb "github.com/daos-stack/daos/src/control/common/proto/mgmt"
-
 	"golang.org/x/net/context"
+
+	pb "github.com/daos-stack/daos/src/control/common/proto/mgmt"
 )
 
 // FeatureMap is an alias for mgmt features supported by gRPC server.

--- a/src/control/client/mocks.go
+++ b/src/control/client/mocks.go
@@ -27,13 +27,14 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/daos-stack/daos/src/control/common"
-	pb "github.com/daos-stack/daos/src/control/common/proto/mgmt"
-	"github.com/daos-stack/daos/src/control/security"
 	"github.com/pkg/errors"
 	"golang.org/x/net/context"
 	grpc "google.golang.org/grpc"
 	"google.golang.org/grpc/connectivity"
+
+	"github.com/daos-stack/daos/src/control/common"
+	pb "github.com/daos-stack/daos/src/control/common/proto/mgmt"
+	"github.com/daos-stack/daos/src/control/security"
 )
 
 var (

--- a/src/control/client/pool.go
+++ b/src/control/client/pool.go
@@ -24,8 +24,9 @@
 package client
 
 import (
-	pb "github.com/daos-stack/daos/src/control/common/proto/mgmt"
 	"golang.org/x/net/context"
+
+	pb "github.com/daos-stack/daos/src/control/common/proto/mgmt"
 )
 
 // CreatePool will create a DAOS pool using provided parameters and return uuid

--- a/src/control/client/service.go
+++ b/src/control/client/service.go
@@ -24,8 +24,9 @@
 package client
 
 import (
-	pb "github.com/daos-stack/daos/src/control/common/proto/mgmt"
 	"golang.org/x/net/context"
+
+	pb "github.com/daos-stack/daos/src/control/common/proto/mgmt"
 )
 
 // KillRank Will terminate server running at given rank on pool specified by

--- a/src/control/client/storage.go
+++ b/src/control/client/storage.go
@@ -28,10 +28,11 @@ import (
 	"io"
 	"time"
 
-	pb "github.com/daos-stack/daos/src/control/common/proto/mgmt"
-	"github.com/daos-stack/daos/src/control/log"
 	"github.com/pkg/errors"
 	"golang.org/x/net/context"
+
+	pb "github.com/daos-stack/daos/src/control/common/proto/mgmt"
+	"github.com/daos-stack/daos/src/control/log"
 )
 
 const (

--- a/src/control/cmd/agent/security_rpc.go
+++ b/src/control/cmd/agent/security_rpc.go
@@ -24,12 +24,14 @@
 package main
 
 import (
-	"github.com/daos-stack/daos/src/control/drpc"
-	"github.com/daos-stack/daos/src/control/security"
-	"github.com/golang/protobuf/proto"
-	"github.com/pkg/errors"
 	"os/user"
 	"strconv"
+
+	"github.com/golang/protobuf/proto"
+	"github.com/pkg/errors"
+
+	"github.com/daos-stack/daos/src/control/drpc"
+	"github.com/daos-stack/daos/src/control/security"
 )
 
 // Module id for the Agent security module

--- a/src/control/cmd/dmg/main.go
+++ b/src/control/cmd/dmg/main.go
@@ -28,11 +28,11 @@ import (
 	"os"
 	"strings"
 
-	"github.com/daos-stack/daos/src/control/client"
-	"github.com/daos-stack/daos/src/control/log"
-
 	flags "github.com/jessevdk/go-flags"
 	"github.com/pkg/errors"
+
+	"github.com/daos-stack/daos/src/control/client"
+	"github.com/daos-stack/daos/src/control/log"
 )
 
 type cliOptions struct {

--- a/src/control/cmd/dmg/pool.go
+++ b/src/control/cmd/dmg/pool.go
@@ -28,10 +28,11 @@ import (
 	"os"
 	"strings"
 
-	"github.com/daos-stack/daos/src/control/common"
-	pb "github.com/daos-stack/daos/src/control/common/proto/mgmt"
 	"github.com/inhies/go-bytesize"
 	"github.com/pkg/errors"
+
+	"github.com/daos-stack/daos/src/control/common"
+	pb "github.com/daos-stack/daos/src/control/common/proto/mgmt"
 )
 
 const (

--- a/src/control/cmd/dmg/pool_test.go
+++ b/src/control/cmd/dmg/pool_test.go
@@ -26,8 +26,9 @@ package main
 import (
 	"testing"
 
-	. "github.com/daos-stack/daos/src/control/common"
 	. "github.com/inhies/go-bytesize"
+
+	. "github.com/daos-stack/daos/src/control/common"
 )
 
 // TestGetSize verifies the correct number of bytes are returned from input

--- a/src/control/cmd/dmg/shell.go
+++ b/src/control/cmd/dmg/shell.go
@@ -28,9 +28,10 @@ import (
 	"strconv"
 	"strings"
 
-	pb "github.com/daos-stack/daos/src/control/common/proto/mgmt"
 	"github.com/daos-stack/ishell"
 	"github.com/pkg/errors"
+
+	pb "github.com/daos-stack/daos/src/control/common/proto/mgmt"
 )
 
 func getUpdateStorageReq(c *ishell.Context) (*pb.UpdateStorageReq, error) {

--- a/src/control/cmd/drpc_test/hello/drpc_test_module.go
+++ b/src/control/cmd/drpc_test/hello/drpc_test_module.go
@@ -26,9 +26,9 @@ package hello
 import (
 	"fmt"
 
-	"github.com/daos-stack/daos/src/control/drpc"
-
 	"github.com/golang/protobuf/proto"
+
+	"github.com/daos-stack/daos/src/control/drpc"
 )
 
 //HelloModule is the RPC Handler for the Hello Module

--- a/src/control/cmd/drpc_test/main.go
+++ b/src/control/cmd/drpc_test/main.go
@@ -30,11 +30,12 @@ import (
 	"os/signal"
 	"syscall"
 
+	"github.com/golang/protobuf/proto"
+	"github.com/pkg/errors"
+
 	"github.com/daos-stack/daos/src/control/cmd/drpc_test/hello"
 	"github.com/daos-stack/daos/src/control/drpc"
 	"github.com/daos-stack/daos/src/control/log"
-	"github.com/golang/protobuf/proto"
-	"github.com/pkg/errors"
 )
 
 var (

--- a/src/control/common/file_utils.go
+++ b/src/control/common/file_utils.go
@@ -32,9 +32,10 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/daos-stack/daos/src/control/log"
 	"github.com/pkg/errors"
 	yaml "gopkg.in/yaml.v2"
+
+	"github.com/daos-stack/daos/src/control/log"
 )
 
 const (

--- a/src/control/drpc/drpc_client_test.go
+++ b/src/control/drpc/drpc_client_test.go
@@ -29,9 +29,10 @@ import (
 	"os"
 	"testing"
 
+	"github.com/golang/protobuf/proto"
+
 	. "github.com/daos-stack/daos/src/control/common"
 	"github.com/daos-stack/daos/src/control/log"
-	"github.com/golang/protobuf/proto"
 )
 
 // testSockPath is an arbitrary path string to use for testing. These tests

--- a/src/control/lib/netdetect/netdetect.go
+++ b/src/control/lib/netdetect/netdetect.go
@@ -24,6 +24,7 @@
 //
 
 package netdetect
+
 /*
 #cgo CFLAGS: -I${SRCDIR}/../../include
 #cgo LDFLAGS: -lhwloc
@@ -32,11 +33,11 @@ package netdetect
 #include <stdio.h>
 */
 import "C"
-import "unsafe"
 
 import (
 	"fmt"
 	"net"
+	"unsafe"
 
 	"github.com/pkg/errors"
 
@@ -44,9 +45,9 @@ import (
 )
 
 type DeviceAffinity struct {
-	DeviceName	string
-	CPUSet	string
-	NodeSet	string
+	DeviceName string
+	CPUSet     string
+	NodeSet    string
 }
 
 func (da *DeviceAffinity) String() string {
@@ -108,7 +109,7 @@ func GetAffinityForNetworkDevices(deviceNames []string) ([]DeviceAffinity, error
 	var nodeset *C.char
 
 	topology, err := initLib()
-	if (err != nil) {
+	if err != nil {
 		log.Debugf("Error from initLib %v", err)
 		return nil,
 			errors.New("unable to initialize hwloc library")
@@ -147,9 +148,9 @@ func GetAffinityForNetworkDevices(deviceNames []string) ([]DeviceAffinity, error
 			ancestorNode.nodeset)
 		if cpusetLen > 0 && nodesetLen > 0 {
 			deviceNode := DeviceAffinity{
-				DeviceName : C.GoString(node.name),
-				CPUSet : C.GoString(cpuset),
-				NodeSet : C.GoString(nodeset),
+				DeviceName: C.GoString(node.name),
+				CPUSet:     C.GoString(cpuset),
+				NodeSet:    C.GoString(nodeset),
 			}
 			affinity = append(affinity, deviceNode)
 		}

--- a/src/control/lib/netdetect/netdetect_test.go
+++ b/src/control/lib/netdetect/netdetect_test.go
@@ -24,8 +24,8 @@
 package netdetect
 
 import (
-	"testing"
 	"os"
+	"testing"
 
 	. "github.com/daos-stack/daos/src/control/common"
 	"github.com/daos-stack/daos/src/control/log"
@@ -47,12 +47,12 @@ func TestParseTopology(t *testing.T) {
 		{[]string{"eth0"}, "testdata/boro-84.xml", []string{"eth0:0x000000ff,0xffff0000,0x00ffffff:0x00000001"}},
 		{[]string{"eth1"}, "testdata/boro-84.xml", []string{"eth1:0x000000ff,0xffff0000,0x00ffffff:0x00000001"}},
 		{[]string{"ib0"}, "testdata/boro-84.xml", []string{"ib0:0x000000ff,0xffff0000,0x00ffffff:0x00000001"}},
-		{[]string{"eth0","eth1"}, "testdata/boro-84.xml", []string{"eth0:0x000000ff,0xffff0000,0x00ffffff:0x00000001","eth1:0x000000ff,0xffff0000,0x00ffffff:0x00000001"}},
-		{[]string{"eth0","eth1","ib0"}, "testdata/boro-84.xml", []string{"ib0:0x000000ff,0xffff0000,0x00ffffff:0x00000001","eth0:0x000000ff,0xffff0000,0x00ffffff:0x00000001","eth1:0x000000ff,0xffff0000,0x00ffffff:0x00000001"}},
-		{[]string{"ib0","eth0","ib1","eth1"}, "testdata/boro-84.xml", []string{"ib0:0x000000ff,0xffff0000,0x00ffffff:0x00000001","eth0:0x000000ff,0xffff0000,0x00ffffff:0x00000001","eth1:0x000000ff,0xffff0000,0x00ffffff:0x00000001"}},
-		{[]string{"eth0","eth1","ib0"}, "testdata/boro-84.xml", []string{"ib0:0x000000ff,0xffff0000,0x00ffffff:0x00000001","eth0:0x000000ff,0xffff0000,0x00ffffff:0x00000001","eth1:0x000000ff,0xffff0000,0x00ffffff:0x00000001"}},
-		{[]string{"eth0","eth1","ib0"}, "testdata/boro-84.xml", []string{"ib0:0x000000ff,0xffff0000,0x00ffffff:0x00000001","eth0:0x000000ff,0xffff0000,0x00ffffff:0x00000001","eth1:0x000000ff,0xffff0000,0x00ffffff:0x00000001"}},
-		{[]string{"eth0","eth1","ib0"}, "testdata/boro-84.xml", []string{"ib0:0x000000ff,0xffff0000,0x00ffffff:0x00000001","eth0:0x000000ff,0xffff0000,0x00ffffff:0x00000001","eth1:0x000000ff,0xffff0000,0x00ffffff:0x00000001"}},
+		{[]string{"eth0", "eth1"}, "testdata/boro-84.xml", []string{"eth0:0x000000ff,0xffff0000,0x00ffffff:0x00000001", "eth1:0x000000ff,0xffff0000,0x00ffffff:0x00000001"}},
+		{[]string{"eth0", "eth1", "ib0"}, "testdata/boro-84.xml", []string{"ib0:0x000000ff,0xffff0000,0x00ffffff:0x00000001", "eth0:0x000000ff,0xffff0000,0x00ffffff:0x00000001", "eth1:0x000000ff,0xffff0000,0x00ffffff:0x00000001"}},
+		{[]string{"ib0", "eth0", "ib1", "eth1"}, "testdata/boro-84.xml", []string{"ib0:0x000000ff,0xffff0000,0x00ffffff:0x00000001", "eth0:0x000000ff,0xffff0000,0x00ffffff:0x00000001", "eth1:0x000000ff,0xffff0000,0x00ffffff:0x00000001"}},
+		{[]string{"eth0", "eth1", "ib0"}, "testdata/boro-84.xml", []string{"ib0:0x000000ff,0xffff0000,0x00ffffff:0x00000001", "eth0:0x000000ff,0xffff0000,0x00ffffff:0x00000001", "eth1:0x000000ff,0xffff0000,0x00ffffff:0x00000001"}},
+		{[]string{"eth0", "eth1", "ib0"}, "testdata/boro-84.xml", []string{"ib0:0x000000ff,0xffff0000,0x00ffffff:0x00000001", "eth0:0x000000ff,0xffff0000,0x00ffffff:0x00000001", "eth1:0x000000ff,0xffff0000,0x00ffffff:0x00000001"}},
+		{[]string{"eth0", "eth1", "ib0"}, "testdata/boro-84.xml", []string{"ib0:0x000000ff,0xffff0000,0x00ffffff:0x00000001", "eth0:0x000000ff,0xffff0000,0x00ffffff:0x00000001", "eth1:0x000000ff,0xffff0000,0x00ffffff:0x00000001"}},
 		// wolf-133 has two NUMA nodes, with eth0, eth1, ib0 on NUMA 0,
 		// and ib1 on NUMA 1.  Notice that the cpuset and nodeset for ib1
 		// reflect that they are on a different node
@@ -60,10 +60,10 @@ func TestParseTopology(t *testing.T) {
 		{[]string{"eth1"}, "testdata/wolf-133.xml", []string{"eth1:0x000000ff,0xffff0000,0x00ffffff:0x00000001"}},
 		{[]string{"ib0"}, "testdata/wolf-133.xml", []string{"ib0:0x000000ff,0xffff0000,0x00ffffff:0x00000001"}},
 		{[]string{"ib1"}, "testdata/wolf-133.xml", []string{"ib1:0xffffff00,0x0000ffff,0xff000000:0x00000002"}},
-		{[]string{"eth0","eth1"}, "testdata/wolf-133.xml", []string{"eth0:0x000000ff,0xffff0000,0x00ffffff:0x00000001","eth1:0x000000ff,0xffff0000,0x00ffffff:0x00000001"}},
-		{[]string{"ib0", "eth0","eth1"}, "testdata/wolf-133.xml", []string{"ib0:0x000000ff,0xffff0000,0x00ffffff:0x00000001","eth0:0x000000ff,0xffff0000,0x00ffffff:0x00000001","eth1:0x000000ff,0xffff0000,0x00ffffff:0x00000001"}},
-		{[]string{"ib0","eth0","ib1","eth1"}, "testdata/wolf-133.xml", []string{"ib0:0x000000ff,0xffff0000,0x00ffffff:0x00000001","eth0:0x000000ff,0xffff0000,0x00ffffff:0x00000001","eth1:0x000000ff,0xffff0000,0x00ffffff:0x00000001","ib1:0xffffff00,0x0000ffff,0xff000000:0x00000002"}},
-}
+		{[]string{"eth0", "eth1"}, "testdata/wolf-133.xml", []string{"eth0:0x000000ff,0xffff0000,0x00ffffff:0x00000001", "eth1:0x000000ff,0xffff0000,0x00ffffff:0x00000001"}},
+		{[]string{"ib0", "eth0", "eth1"}, "testdata/wolf-133.xml", []string{"ib0:0x000000ff,0xffff0000,0x00ffffff:0x00000001", "eth0:0x000000ff,0xffff0000,0x00ffffff:0x00000001", "eth1:0x000000ff,0xffff0000,0x00ffffff:0x00000001"}},
+		{[]string{"ib0", "eth0", "ib1", "eth1"}, "testdata/wolf-133.xml", []string{"ib0:0x000000ff,0xffff0000,0x00ffffff:0x00000001", "eth0:0x000000ff,0xffff0000,0x00ffffff:0x00000001", "eth1:0x000000ff,0xffff0000,0x00ffffff:0x00000001", "ib1:0xffffff00,0x0000ffff,0xff000000:0x00000002"}},
+	}
 	log.NewDefaultLogger(log.Debug, "", os.Stderr)
 	for _, tt := range tests {
 		_, err := os.Stat(tt.topology)

--- a/src/control/security/auth_sys.go
+++ b/src/control/security/auth_sys.go
@@ -28,10 +28,10 @@ import (
 	"os"
 	"os/user"
 
-	"github.com/daos-stack/daos/src/control/security/auth"
-
 	"github.com/golang/protobuf/proto"
 	"github.com/pkg/errors"
+
+	"github.com/daos-stack/daos/src/control/security/auth"
 )
 
 // User is an interface wrapping a representation of a specific system user

--- a/src/control/security/auth_sys_test.go
+++ b/src/control/security/auth_sys_test.go
@@ -30,10 +30,10 @@ import (
 	"syscall"
 	"testing"
 
+	"github.com/golang/protobuf/proto"
+
 	. "github.com/daos-stack/daos/src/control/common"
 	"github.com/daos-stack/daos/src/control/security/auth"
-
-	"github.com/golang/protobuf/proto"
 )
 
 // Mocks

--- a/src/control/security/context.go
+++ b/src/control/security/context.go
@@ -24,10 +24,10 @@
 package security
 
 import (
-	"github.com/daos-stack/daos/src/control/security/auth"
 	"github.com/pkg/errors"
-
 	uuid "github.com/satori/go.uuid"
+
+	"github.com/daos-stack/daos/src/control/security/auth"
 )
 
 // Context holds the accounting information for requested

--- a/src/control/security/domain_info.go
+++ b/src/control/security/domain_info.go
@@ -27,9 +27,10 @@ import (
 	"net"
 	"syscall"
 
-	"github.com/daos-stack/daos/src/control/log"
 	"github.com/pkg/errors"
 	"golang.org/x/sys/unix"
+
+	"github.com/daos-stack/daos/src/control/log"
 )
 
 // DomainInfo holds our socket credentials to be used by the DomainSocketServer

--- a/src/control/server/commands.go
+++ b/src/control/server/commands.go
@@ -27,9 +27,10 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/pkg/errors"
+
 	"github.com/daos-stack/daos/src/control/common"
 	pb "github.com/daos-stack/daos/src/control/common/proto/mgmt"
-	"github.com/pkg/errors"
 )
 
 // cliOptions struct defined flags that can be used when invoking daos_server.

--- a/src/control/server/config.go
+++ b/src/control/server/config.go
@@ -31,10 +31,11 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/daos-stack/daos/src/control/common"
-	"github.com/daos-stack/daos/src/control/log"
 	"github.com/pkg/errors"
 	yaml "gopkg.in/yaml.v2"
+
+	"github.com/daos-stack/daos/src/control/common"
+	"github.com/daos-stack/daos/src/control/log"
 )
 
 const (

--- a/src/control/server/config_test.go
+++ b/src/control/server/config_test.go
@@ -32,9 +32,10 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/pkg/errors"
+
 	"github.com/daos-stack/daos/src/control/common"
 	. "github.com/daos-stack/daos/src/control/common"
-	"github.com/pkg/errors"
 )
 
 const (

--- a/src/control/server/drpc.go
+++ b/src/control/server/drpc.go
@@ -27,9 +27,10 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/daos-stack/daos/src/control/drpc"
 	"github.com/golang/protobuf/proto"
 	"github.com/pkg/errors"
+
+	"github.com/daos-stack/daos/src/control/drpc"
 )
 
 const sockFileName = "daos_server.sock"

--- a/src/control/server/external.go
+++ b/src/control/server/external.go
@@ -23,22 +23,23 @@
 
 package server
 
+//#include <unistd.h>
+//#include <errno.h>
+import "C"
+
 import (
 	"fmt"
 	"os"
 	"os/user"
 	"path/filepath"
+	"strings"
 	"syscall"
+
+	"github.com/pkg/errors"
 
 	"github.com/daos-stack/daos/src/control/common"
 	"github.com/daos-stack/daos/src/control/log"
-	"github.com/pkg/errors"
-
-	//#include <unistd.h>
-	//#include <errno.h>
-	"C"
 )
-import "strings"
 
 const (
 	msgUnmount      = "syscall: calling unmount with %s, MNT_DETACH"

--- a/src/control/server/iosrv.go
+++ b/src/control/server/iosrv.go
@@ -34,6 +34,7 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/golang/protobuf/proto"
 	"github.com/pkg/errors"
 	uuid "github.com/satori/go.uuid"
 	"golang.org/x/net/context"
@@ -46,7 +47,6 @@ import (
 	"github.com/daos-stack/daos/src/control/drpc"
 	"github.com/daos-stack/daos/src/control/log"
 	"github.com/daos-stack/daos/src/control/security"
-	"github.com/golang/protobuf/proto"
 )
 
 func formatIosrvs(config *configuration, reformat bool) error {

--- a/src/control/server/mgmt.go
+++ b/src/control/server/mgmt.go
@@ -30,11 +30,12 @@ import (
 	"os"
 	"syscall"
 
+	"github.com/pkg/errors"
+
 	"github.com/daos-stack/daos/src/control/common"
 	pb "github.com/daos-stack/daos/src/control/common/proto/mgmt"
 	"github.com/daos-stack/daos/src/control/drpc"
 	"github.com/daos-stack/daos/src/control/log"
-	"github.com/pkg/errors"
 )
 
 var jsonDBRelPath = "share/daos/control/mgmtinit_db.json"

--- a/src/control/server/mgmt_ctl_svc.go
+++ b/src/control/server/mgmt_ctl_svc.go
@@ -24,11 +24,12 @@
 package server
 
 import (
-	pb "github.com/daos-stack/daos/src/control/common/proto/mgmt"
-	"github.com/daos-stack/daos/src/control/log"
 	"github.com/golang/protobuf/proto"
 	"github.com/pkg/errors"
 	"golang.org/x/net/context"
+
+	pb "github.com/daos-stack/daos/src/control/common/proto/mgmt"
+	"github.com/daos-stack/daos/src/control/log"
 )
 
 // ControlService mgmt methods forward gRPC request from management tool to

--- a/src/control/server/mgmt_feature.go
+++ b/src/control/server/mgmt_feature.go
@@ -24,9 +24,10 @@
 package server
 
 import (
-	pb "github.com/daos-stack/daos/src/control/common/proto/mgmt"
 	"github.com/pkg/errors"
 	"golang.org/x/net/context"
+
+	pb "github.com/daos-stack/daos/src/control/common/proto/mgmt"
 )
 
 // FeatureMap is a type alias

--- a/src/control/server/mgmt_feature_test.go
+++ b/src/control/server/mgmt_feature_test.go
@@ -28,7 +28,6 @@ import (
 	"testing"
 
 	. "github.com/daos-stack/daos/src/control/common"
-
 	pb "github.com/daos-stack/daos/src/control/common/proto/mgmt"
 )
 

--- a/src/control/server/mgmt_storage.go
+++ b/src/control/server/mgmt_storage.go
@@ -24,11 +24,12 @@
 package server
 
 import (
+	"github.com/pkg/errors"
+	"golang.org/x/net/context"
+
 	"github.com/daos-stack/daos/src/control/common"
 	pb "github.com/daos-stack/daos/src/control/common/proto/mgmt"
 	"github.com/daos-stack/daos/src/control/log"
-	"github.com/pkg/errors"
-	"golang.org/x/net/context"
 )
 
 // addState creates, populates and returns ResponseState in addition

--- a/src/control/server/mgmt_storage_test.go
+++ b/src/control/server/mgmt_storage_test.go
@@ -28,12 +28,13 @@ import (
 	"sync"
 	"testing"
 
-	. "github.com/daos-stack/daos/src/control/common"
-	pb "github.com/daos-stack/daos/src/control/common/proto/mgmt"
-	ipmctl "github.com/daos-stack/go-ipmctl/ipmctl"
-	spdk "github.com/daos-stack/go-spdk/spdk"
 	"github.com/pkg/errors"
 	"google.golang.org/grpc"
+
+	. "github.com/daos-stack/daos/src/control/common"
+	pb "github.com/daos-stack/daos/src/control/common/proto/mgmt"
+	"github.com/daos-stack/go-ipmctl/ipmctl"
+	"github.com/daos-stack/go-spdk/spdk"
 )
 
 // mockFormatStorageServer provides mocking for server side streaming,

--- a/src/control/server/privileges.go
+++ b/src/control/server/privileges.go
@@ -27,8 +27,9 @@ import (
 	"os/user"
 	"strconv"
 
-	"github.com/daos-stack/daos/src/control/log"
 	"github.com/pkg/errors"
+
+	"github.com/daos-stack/daos/src/control/log"
 )
 
 func getUID(ext External, userName string) (*user.User, int64, error) {

--- a/src/control/server/security.go
+++ b/src/control/server/security.go
@@ -26,6 +26,7 @@ package server
 // #cgo CFLAGS: -I${SRCDIR}/../../include
 // #include <daos/drpc_modules.h>
 import "C"
+
 import (
 	"context"
 

--- a/src/control/server/security_rpc.go
+++ b/src/control/server/security_rpc.go
@@ -26,11 +26,12 @@ package server
 import (
 	"bytes"
 
+	"github.com/golang/protobuf/proto"
+	"github.com/pkg/errors"
+
 	"github.com/daos-stack/daos/src/control/drpc"
 	"github.com/daos-stack/daos/src/control/security"
 	"github.com/daos-stack/daos/src/control/security/auth"
-	"github.com/golang/protobuf/proto"
-	"github.com/pkg/errors"
 )
 
 // Module id for the Server security module

--- a/src/control/server/security_test.go
+++ b/src/control/server/security_test.go
@@ -27,11 +27,12 @@ import (
 	"context"
 	"testing"
 
+	"github.com/golang/protobuf/proto"
+	"github.com/pkg/errors"
+
 	. "github.com/daos-stack/daos/src/control/common"
 	"github.com/daos-stack/daos/src/control/drpc"
 	"github.com/daos-stack/daos/src/control/security/acl"
-	"github.com/golang/protobuf/proto"
-	"github.com/pkg/errors"
 )
 
 // mockDrpcClient is a mock of the DomainSocketClient interface

--- a/src/control/server/server.go
+++ b/src/control/server/server.go
@@ -28,13 +28,14 @@ import (
 	"net"
 	"os"
 
+	flags "github.com/jessevdk/go-flags"
+	"github.com/pkg/errors"
+	"google.golang.org/grpc"
+
 	mgmtpb "github.com/daos-stack/daos/src/control/common/proto/mgmt"
 	"github.com/daos-stack/daos/src/control/log"
 	"github.com/daos-stack/daos/src/control/security"
 	"github.com/daos-stack/daos/src/control/security/acl"
-	flags "github.com/jessevdk/go-flags"
-	"github.com/pkg/errors"
-	"google.golang.org/grpc"
 )
 
 func parseCliOpts(opts *cliOptions) error {

--- a/src/control/server/storage_nvme.go
+++ b/src/control/server/storage_nvme.go
@@ -31,11 +31,12 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/pkg/errors"
+
 	"github.com/daos-stack/daos/src/control/common"
 	pb "github.com/daos-stack/daos/src/control/common/proto/mgmt"
 	"github.com/daos-stack/daos/src/control/log"
 	"github.com/daos-stack/go-spdk/spdk"
-	"github.com/pkg/errors"
 )
 
 const (

--- a/src/control/server/storage_nvme_test.go
+++ b/src/control/server/storage_nvme_test.go
@@ -28,10 +28,11 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/pkg/errors"
+
 	. "github.com/daos-stack/daos/src/control/common"
 	pb "github.com/daos-stack/daos/src/control/common/proto/mgmt"
 	. "github.com/daos-stack/go-spdk/spdk"
-	"github.com/pkg/errors"
 )
 
 var nvmeFormatCalls []string // record calls to nvme.Format()

--- a/src/control/server/storage_scm.go
+++ b/src/control/server/storage_scm.go
@@ -27,11 +27,12 @@ import (
 	"fmt"
 	"strconv"
 
+	"github.com/pkg/errors"
+
 	"github.com/daos-stack/daos/src/control/common"
 	pb "github.com/daos-stack/daos/src/control/common/proto/mgmt"
 	"github.com/daos-stack/daos/src/control/log"
 	"github.com/daos-stack/go-ipmctl/ipmctl"
-	"github.com/pkg/errors"
 )
 
 var (

--- a/src/control/server/storage_scm_test.go
+++ b/src/control/server/storage_scm_test.go
@@ -27,10 +27,11 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/pkg/errors"
+
 	. "github.com/daos-stack/daos/src/control/common"
 	pb "github.com/daos-stack/daos/src/control/common/proto/mgmt"
 	. "github.com/daos-stack/go-ipmctl/ipmctl"
-	"github.com/pkg/errors"
 )
 
 // MockModule returns a mock SCM module of type exported from go-ipmctl.


### PR DESCRIPTION
Mass update to all *.go files to impose best practices for
import grouping.

Any non-import updates to files are the result of the file being run through gofmt, which should have happened before committing.