### PR TITLE
DAOS-2790 evtree: Fix some issues with evtree distance sort

### DIFF
--- a/src/include/daos_srv/evtree.h
+++ b/src/include/daos_srv/evtree.h
@@ -380,6 +380,7 @@ struct evt_policy_ops {
 	 * Calculate weight of a rectangle \a rect and return it to \a weight.
 	 */
 	int	(*po_rect_weight)(struct evt_context *tcx,
+				  daos_epoch_t epoch,
 				  const struct evt_rect *rect,
 				  struct evt_weight *weight);
 

--- a/src/include/daos_srv/evtree.h
+++ b/src/include/daos_srv/evtree.h
@@ -380,7 +380,6 @@ struct evt_policy_ops {
 	 * Calculate weight of a rectangle \a rect and return it to \a weight.
 	 */
 	int	(*po_rect_weight)(struct evt_context *tcx,
-				  daos_epoch_t epoch,
 				  const struct evt_rect *rect,
 				  struct evt_weight *weight);
 

--- a/src/vos/evtree.c
+++ b/src/vos/evtree.c
@@ -186,7 +186,7 @@ evt_weight_diff(struct evt_weight *wt1, struct evt_weight *wt2,
 	/* NB: they can be negative */
 	wt_diff->wt_major = wt1->wt_major - wt2->wt_major;
 	/** wt2 is the difference to the original mbr */
-	wt_diff->wt_minor = wt2->wt_minor;
+	wt_diff->wt_minor = wt1->wt_major - wt2->wt_minor;
 }
 
 /** Internal function for initializing an array.   Using 0 for max
@@ -1400,7 +1400,7 @@ evt_root_destroy(struct evt_context *tcx)
 	return evt_root_free(tcx);
 }
 
-static uint64_t
+static int64_t
 evt_epoch_dist(struct evt_context *tcx, struct evt_node *nd,
 	       const struct evt_rect *rect)
 {
@@ -2452,7 +2452,7 @@ evt_common_rect_weight(struct evt_context *tcx, const struct evt_rect *rect,
 {
 	memset(weight, 0, sizeof(*weight));
 	weight->wt_major = rect->rc_ex.ex_hi - rect->rc_ex.ex_lo;
-	weight->wt_minor = -rect->rc_epc;
+	weight->wt_minor = 0; /* Disable minor weight in favor of distance */
 
 	return 0;
 }

--- a/src/vos/evtree.c
+++ b/src/vos/evtree.c
@@ -185,7 +185,8 @@ evt_weight_diff(struct evt_weight *wt1, struct evt_weight *wt2,
 {
 	/* NB: they can be negative */
 	wt_diff->wt_major = wt1->wt_major - wt2->wt_major;
-	wt_diff->wt_minor = wt1->wt_minor - wt2->wt_minor;
+	/** wt2 is the difference to the original mbr */
+	wt_diff->wt_minor = wt2->wt_minor;
 }
 
 /** Internal function for initializing an array.   Using 0 for max
@@ -1237,27 +1238,15 @@ evt_node_weight_diff(struct evt_context *tcx, struct evt_node *nd,
 	struct evt_rect	   rtmp;
 	struct evt_weight  wt_org;
 	struct evt_weight  wt_new;
-	int		   range;
-	int		   time;
-
-	evt_rect_overlap(&nd->tn_mbr, rect, &range, &time);
-	if ((time & (RT_OVERLAP_SAME | RT_OVERLAP_OVER)) &&
-	    (range & RT_OVERLAP_INCLUDED)) {
-		/* no difference, because the rectangle is included by the
-		 * MBR of the node.
-		 */
-		memset(weight_diff, 0, sizeof(*weight_diff));
-		return;
-	}
 
 	memset(&wt_org, 0, sizeof(wt_org));
 	memset(&wt_new, 0, sizeof(wt_new));
 
 	rtmp = nd->tn_mbr;
-	tcx->tc_ops->po_rect_weight(tcx, &rtmp, &wt_org);
+	tcx->tc_ops->po_rect_weight(tcx, rect->rc_epc, &rtmp, &wt_org);
 
 	evt_rect_merge(&rtmp, rect);
-	tcx->tc_ops->po_rect_weight(tcx, &rtmp, &wt_new);
+	tcx->tc_ops->po_rect_weight(tcx, rect->rc_epc, &rtmp, &wt_new);
 
 	evt_weight_diff(&wt_new, &wt_org, weight_diff);
 }
@@ -2327,6 +2316,7 @@ evt_common_insert(struct evt_context *tcx, struct evt_node *nd,
 		int	nr;
 
 		ne = evt_node_entry_at(tcx, nd, i);
+
 		rc = cb(tcx, mbr, &ne->ne_rect, &ent->ei_rect);
 		if (rc < 0)
 			continue;
@@ -2422,15 +2412,17 @@ evt_common_insert(struct evt_context *tcx, struct evt_node *nd,
 }
 
 static int
-evt_common_rect_weight(struct evt_context *tcx, const struct evt_rect *rect,
-		       struct evt_weight *weight)
+evt_common_rect_weight(struct evt_context *tcx, daos_epoch_t epoch,
+		       const struct evt_rect *rect, struct evt_weight *weight)
 {
 	memset(weight, 0, sizeof(*weight));
 	weight->wt_major = rect->rc_ex.ex_hi - rect->rc_ex.ex_lo;
-	/* NB: we don't consider about high epoch for SSOF because it's based
-	 * on assumption there is no overwrite.
-	 */
-	weight->wt_minor = -rect->rc_epc;
+	/* Check the distance of the new epoch from the stored one */
+	if (epoch >= rect->rc_epc)
+		weight->wt_minor = epoch - rect->rc_epc;
+	else
+		weight->wt_minor = rect->rc_epc - epoch;
+
 	return 0;
 }
 
@@ -2598,32 +2590,39 @@ evt_sdist_split(struct evt_context *tcx, bool leaf, struct evt_node *nd_src,
 {
 	struct evt_node_entry	*entry_src;
 	struct evt_node_entry	*entry_dst;
+	struct evt_rect		*mbr;
 	int			 nr;
 	int			 delta;
 	int			 boundary;
 	bool			 cond;
 	int64_t			 dist;
 
+	mbr = evt_node_mbr_get(tcx, nd_src);
+
 	D_ASSERT(nd_src->tn_nr == tcx->tc_order);
 	nr = nd_src->tn_nr / 2;
 
 	nr += nd_src->tn_nr % 2;
 
-	entry_src = evt_node_entry_at(tcx, nd_src, nr - 1);
-	dist = evt_mbr_dist(evt_node_mbr_get(tcx, nd_src), &entry_src->ne_rect);
+	entry_src = evt_node_entry_at(tcx, nd_src, nr);
+	dist = evt_mbr_dist(mbr, &entry_src->ne_rect);
+
+	if (dist == 0) /* special case if middle node is equal distance */
+		goto done;
 
 	cond = dist > 0;
 	delta = cond ? -1 : 1;
 	boundary = cond ? 1 : nd_src->tn_nr - 1;
+
 	do {
 		nr += delta;
 		if (nr == boundary)
 			break;
-		entry_src = evt_node_entry_at(tcx, nd_src, nr - 1);
-		dist = evt_mbr_dist(evt_node_mbr_get(tcx, nd_src),
-				    &entry_src->ne_rect);
+		entry_src = evt_node_entry_at(tcx, nd_src, nr);
+		dist = evt_mbr_dist(mbr, &entry_src->ne_rect);
 	} while ((dist > 0) == cond);
 
+done:
 	entry_src = evt_node_entry_at(tcx, nd_src, nr);
 	entry_dst = evt_node_entry_at(tcx, nd_dst, 0);
 	memcpy(entry_dst, entry_src, sizeof(*entry_dst) * (nd_src->tn_nr - nr));
@@ -2883,7 +2882,7 @@ int evt_delete(daos_handle_t toh, const struct evt_rect *rect,
 		return rc;
 
 	if (ent_array.ea_ent_nr == 0)
-		return -DER_ENOENT;
+		return -DER_NONEXIST;
 
 	D_ASSERT(ent_array.ea_ent_nr == 1);
 	if (ent != NULL)

--- a/src/vos/evtree.c
+++ b/src/vos/evtree.c
@@ -185,8 +185,7 @@ evt_weight_diff(struct evt_weight *wt1, struct evt_weight *wt2,
 {
 	/* NB: they can be negative */
 	wt_diff->wt_major = wt1->wt_major - wt2->wt_major;
-	/** wt2 is the difference to the original mbr */
-	wt_diff->wt_minor = wt1->wt_major - wt2->wt_minor;
+	wt_diff->wt_minor = wt1->wt_minor - wt2->wt_minor;
 }
 
 /** Internal function for initializing an array.   Using 0 for max

--- a/src/vos/vos_tree.c
+++ b/src/vos/vos_tree.c
@@ -33,7 +33,7 @@
 #include <daos_srv/vos.h>
 #include "vos_internal.h"
 
-int vos_evt_feats = EVT_FEAT_SORT_SOFF;
+int vos_evt_feats = EVT_FEAT_SORT_DIST;
 
 /**
  * VOS Btree attributes, for tree registration and tree creation.


### PR DESCRIPTION
1. When middle node is equal distant from both sides, just
   split evenly
2. Modify the minor field for the weight to be distance from
   new rectangle to start epoch of mbr.  Use the distance
   between the original mbr and this value as the weight
3. Fix some off by one issues with boundary calculations