### PR TITLE
DAOS-1754 control: use custom slice types across packages

### DIFF
--- a/src/control/client/mocks.go
+++ b/src/control/client/mocks.go
@@ -27,19 +27,20 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/daos-stack/daos/src/control/common"
-	pb "github.com/daos-stack/daos/src/control/common/proto/mgmt"
-	"github.com/daos-stack/daos/src/control/security"
 	"github.com/pkg/errors"
 	"golang.org/x/net/context"
 	grpc "google.golang.org/grpc"
 	"google.golang.org/grpc/connectivity"
+
+	. "github.com/daos-stack/daos/src/control/common"
+	pb "github.com/daos-stack/daos/src/control/common/proto/mgmt"
+	"github.com/daos-stack/daos/src/control/security"
 )
 
 var (
 	MockServers  = Addresses{"1.2.3.4:10000", "1.2.3.5:10001"}
-	MockFeatures = []*pb.Feature{common.MockFeaturePB()}
-	MockCtrlrs   = NvmeControllers{common.MockControllerPB("")}
+	MockFeatures = []*pb.Feature{MockFeaturePB()}
+	MockCtrlrs   = NvmeControllers{MockControllerPB("")}
 	MockState    = pb.ResponseState{
 		Status: pb.ResponseStatus_CTRL_ERR_APP,
 		Error:  "example application error",
@@ -50,14 +51,14 @@ var (
 			State:   &MockState,
 		},
 	}
-	MockModules       = ScmModules{common.MockModulePB()}
+	MockModules       = ScmModules{MockModulePB()}
 	MockModuleResults = ScmModuleResults{
 		&pb.ScmModuleResult{
 			Loc:   &pb.ScmModule_Location{},
 			State: &MockState,
 		},
 	}
-	MockMounts       = ScmMounts{common.MockMountPB()}
+	MockMounts       = ScmMounts{MockMountPB()}
 	MockMountResults = ScmMountResults{
 		&pb.ScmMountResult{
 			Mntpoint: "/mnt/daos",
@@ -228,11 +229,18 @@ func (m *mockMgmtCtlClient) KillRank(
 }
 
 func newMockMgmtCtlClient(
-	features []*pb.Feature, ctrlrs NvmeControllers,
-	ctrlrResults NvmeControllerResults, modules ScmModules,
-	moduleResults ScmModuleResults, mountResults ScmMountResults,
-	scanRet error, formatRet error, updateRet error, burninRet error,
-	killRet error) pb.MgmtCtlClient {
+	features []*pb.Feature,
+	ctrlrs NvmeControllers,
+	ctrlrResults NvmeControllerResults,
+	modules ScmModules,
+	moduleResults ScmModuleResults,
+	mountResults ScmMountResults,
+	scanRet error,
+	formatRet error,
+	updateRet error,
+	burninRet error,
+	killRet error,
+) pb.MgmtCtlClient {
 
 	return &mockMgmtCtlClient{
 		MockFeatures, ctrlrs, ctrlrResults, modules, moduleResults,

--- a/src/control/common/storage_types.go
+++ b/src/control/common/storage_types.go
@@ -21,12 +21,11 @@
 // portions thereof marked with this legend must also reproduce the markings.
 //
 
-package client
+package common
 
 import (
 	"bytes"
 	"fmt"
-	"sort"
 
 	pb "github.com/daos-stack/daos/src/control/common/proto/mgmt"
 )
@@ -51,6 +50,10 @@ func (nc NvmeControllers) String() string {
 
 	return buf.String()
 }
+
+// NvmeNamespaces is an alias for protobuf NvmeController_Namespace message slice
+// representing namespaces existing on a NVMe SSD.
+type NvmeNamespaces []*pb.NvmeController_Namespace
 
 // NvmeControllerResults is an alias for protobuf NvmeControllerResult messages
 // representing operation results on a number of NVMe controllers.
@@ -96,26 +99,6 @@ func (cr CtrlrResults) String() string {
 	}
 
 	return "no controllers found"
-}
-
-// ClientCtrlrMap is an alias for query results of NVMe controllers (and
-// any residing namespaces) on connected servers keyed on address.
-type ClientCtrlrMap map[string]CtrlrResults
-
-func (ccm ClientCtrlrMap) String() string {
-	var buf bytes.Buffer
-	servers := make([]string, 0, len(ccm))
-
-	for server := range ccm {
-		servers = append(servers, server)
-	}
-	sort.Strings(servers)
-
-	for _, server := range servers {
-		fmt.Fprintf(&buf, "%s:\n%s\n", server, ccm[server])
-	}
-
-	return buf.String()
 }
 
 // ScmMounts is an alias for protobuf ScmMount message slice representing
@@ -178,26 +161,6 @@ func (mr MountResults) String() string {
 	return "no scm mounts found"
 }
 
-// ClientMountMap is an alias for query results of SCM regions mounted
-// on connected servers keyed on address.
-type ClientMountMap map[string]MountResults
-
-func (cmm ClientMountMap) String() string {
-	var buf bytes.Buffer
-	servers := make([]string, 0, len(cmm))
-
-	for server := range cmm {
-		servers = append(servers, server)
-	}
-	sort.Strings(servers)
-
-	for _, server := range servers {
-		fmt.Fprintf(&buf, "%s:\n%s\n", server, cmm[server])
-	}
-
-	return buf.String()
-}
-
 // ScmModules is an alias for protobuf ScmModule message slice representing
 // a number of SCM modules installed on a storage node.
 type ScmModules []*pb.ScmModule
@@ -256,31 +219,4 @@ func (mr ModuleResults) String() string {
 	}
 
 	return "no scm modules found"
-}
-
-// ClientModuleMap is an alias for query results of SCM modules installed
-// on connected servers keyed on address.
-type ClientModuleMap map[string]ModuleResults
-
-func (cmm ClientModuleMap) String() string {
-	var buf bytes.Buffer
-	servers := make([]string, 0, len(cmm))
-
-	for server := range cmm {
-		servers = append(servers, server)
-	}
-	sort.Strings(servers)
-
-	for _, server := range servers {
-		fmt.Fprintf(&buf, "%s:\n%s\n", server, cmm[server])
-	}
-
-	return buf.String()
-}
-
-// storageResult generic container for results of storage subsystems queries.
-type storageResult struct {
-	nvmeCtrlr CtrlrResults
-	scmModule ModuleResults
-	scmMount  MountResults
 }

--- a/src/control/common/test_mocks.go
+++ b/src/control/common/test_mocks.go
@@ -23,9 +23,7 @@
 
 package common
 
-import (
-	pb "github.com/daos-stack/daos/src/control/common/proto/mgmt"
-)
+import pb "github.com/daos-stack/daos/src/control/common/proto/mgmt"
 
 // MockFeaturePB is a mock protobuf Feature message used in tests for multiple
 // packages.

--- a/src/control/server/mgmt_storage.go
+++ b/src/control/server/mgmt_storage.go
@@ -78,8 +78,10 @@ func (c *controlService) doFormat(i int, resp *pb.FormatStorageResp) error {
 		serverFormatted = true
 	}
 
-	c.nvme.Format(i, &resp.Crets)
-	c.scm.Format(i, &resp.Mrets)
+	ctrlrResults := common.NvmeControllerResults(resp.Crets)
+	c.nvme.Format(i, &ctrlrResults)
+	mountResults := common.ScmMountResults(resp.Mrets)
+	c.scm.Format(i, &mountResults)
 
 	if !serverFormatted && c.nvme.formatted && c.scm.formatted {
 		// storage subsystem format successful, broadcast formatted
@@ -130,8 +132,10 @@ func (c *controlService) UpdateStorage(
 	resp := new(pb.UpdateStorageResp)
 
 	for i := range c.config.Servers {
-		c.nvme.Update(i, req.Nvme, &resp.Crets)
-		c.scm.Update(i, req.Scm, &resp.Mrets)
+		ctrlrResults := common.NvmeControllerResults(resp.Crets)
+		c.nvme.Update(i, req.Nvme, &ctrlrResults)
+		moduleResults := common.ScmModuleResults(resp.Mrets)
+		c.scm.Update(i, req.Scm, &moduleResults)
 	}
 
 	if err := stream.Send(resp); err != nil {

--- a/src/control/server/mgmt_storage_test.go
+++ b/src/control/server/mgmt_storage_test.go
@@ -28,12 +28,13 @@ import (
 	"sync"
 	"testing"
 
-	. "github.com/daos-stack/daos/src/control/common"
-	pb "github.com/daos-stack/daos/src/control/common/proto/mgmt"
 	ipmctl "github.com/daos-stack/go-ipmctl/ipmctl"
 	spdk "github.com/daos-stack/go-spdk/spdk"
 	"github.com/pkg/errors"
 	"google.golang.org/grpc"
+
+	. "github.com/daos-stack/daos/src/control/common"
+	pb "github.com/daos-stack/daos/src/control/common/proto/mgmt"
 )
 
 // mockFormatStorageServer provides mocking for server side streaming,
@@ -102,9 +103,9 @@ func TestScanStorage(t *testing.T) {
 		{
 			"success", nil, nil, nil, true, true,
 			pb.ScanStorageResp{
-				Ctrlrs:    []*pb.NvmeController{pbCtrlr},
+				Ctrlrs:    NvmeControllers{pbCtrlr},
 				Nvmestate: new(pb.ResponseState),
-				Modules:   []*pb.ScmModule{pbModule},
+				Modules:   ScmModules{pbModule},
 				Scmstate:  new(pb.ResponseState),
 			}, "",
 		},
@@ -116,7 +117,7 @@ func TestScanStorage(t *testing.T) {
 						": example failure",
 					Status: pb.ResponseStatus_CTRL_ERR_NVME,
 				},
-				Modules:  []*pb.ScmModule{pbModule},
+				Modules:  ScmModules{pbModule},
 				Scmstate: new(pb.ResponseState),
 			}, "",
 		},
@@ -128,14 +129,14 @@ func TestScanStorage(t *testing.T) {
 						": example failure",
 					Status: pb.ResponseStatus_CTRL_ERR_NVME,
 				},
-				Modules:  []*pb.ScmModule{pbModule},
+				Modules:  ScmModules{pbModule},
 				Scmstate: new(pb.ResponseState),
 			}, "",
 		},
 		{
 			"ipmctl discover fail", nil, nil, errExample, true, false,
 			pb.ScanStorageResp{
-				Ctrlrs:    []*pb.NvmeController{pbCtrlr},
+				Ctrlrs:    NvmeControllers{pbCtrlr},
 				Nvmestate: new(pb.ResponseState),
 				Scmstate: &pb.ResponseState{
 					Error: msgIpmctlDiscoverFail +
@@ -227,8 +228,8 @@ func TestFormatStorage(t *testing.T) {
 		bDevs            []string
 		expNvmeFormatted bool
 		expScmFormatted  bool
-		mountRets        []*pb.ScmMountResult
-		ctrlrRets        []*pb.NvmeControllerResult
+		mountRets        ScmMountResults
+		ctrlrRets        NvmeControllerResults
 		desc             string
 	}{
 		{
@@ -237,7 +238,7 @@ func TestFormatStorage(t *testing.T) {
 			sClass:          scmRAM,
 			sSize:           6,
 			expScmFormatted: true,
-			ctrlrRets: []*pb.NvmeControllerResult{
+			ctrlrRets: NvmeControllerResults{
 				{
 					Pciaddr: "",
 					State: &pb.ResponseState{
@@ -246,7 +247,7 @@ func TestFormatStorage(t *testing.T) {
 					},
 				},
 			},
-			mountRets: []*pb.ScmMountResult{
+			mountRets: ScmMountResults{
 				{
 					Mntpoint: "/mnt/daos",
 					State:    new(pb.ResponseState),
@@ -259,7 +260,7 @@ func TestFormatStorage(t *testing.T) {
 			sClass:          scmDCPM,
 			sDevs:           []string{"/dev/pmem1"},
 			expScmFormatted: true,
-			ctrlrRets: []*pb.NvmeControllerResult{
+			ctrlrRets: NvmeControllerResults{
 				{
 					Pciaddr: "",
 					State: &pb.ResponseState{
@@ -268,7 +269,7 @@ func TestFormatStorage(t *testing.T) {
 					},
 				},
 			},
-			mountRets: []*pb.ScmMountResult{
+			mountRets: ScmMountResults{
 				{
 					Mntpoint: "/mnt/daos",
 					State:    new(pb.ResponseState),
@@ -284,13 +285,13 @@ func TestFormatStorage(t *testing.T) {
 			bDevs:            []string{"0000:81:00.0"},
 			expScmFormatted:  true,
 			expNvmeFormatted: true,
-			ctrlrRets: []*pb.NvmeControllerResult{
+			ctrlrRets: NvmeControllerResults{
 				{
 					Pciaddr: "0000:81:00.0",
 					State:   new(pb.ResponseState),
 				},
 			},
-			mountRets: []*pb.ScmMountResult{
+			mountRets: ScmMountResults{
 				{
 					Mntpoint: "/mnt/daos",
 					State:    new(pb.ResponseState),
@@ -307,13 +308,13 @@ func TestFormatStorage(t *testing.T) {
 			bDevs:            []string{"0000:81:00.0"},
 			expScmFormatted:  true,
 			expNvmeFormatted: true,
-			ctrlrRets: []*pb.NvmeControllerResult{
+			ctrlrRets: NvmeControllerResults{
 				{
 					Pciaddr: "0000:81:00.0",
 					State:   new(pb.ResponseState),
 				},
 			},
-			mountRets: []*pb.ScmMountResult{
+			mountRets: ScmMountResults{
 				{
 					Mntpoint: "/mnt/daos",
 					State:    new(pb.ResponseState),
@@ -331,7 +332,7 @@ func TestFormatStorage(t *testing.T) {
 			bDevs:            []string{"0000:81:00.0"},
 			expScmFormatted:  true,
 			expNvmeFormatted: true,
-			ctrlrRets: []*pb.NvmeControllerResult{
+			ctrlrRets: NvmeControllerResults{
 				{
 					Pciaddr: "",
 					State: &pb.ResponseState{
@@ -340,7 +341,7 @@ func TestFormatStorage(t *testing.T) {
 					},
 				},
 			},
-			mountRets: []*pb.ScmMountResult{
+			mountRets: ScmMountResults{
 				{
 					Mntpoint: "/mnt/daos",
 					State: &pb.ResponseState{
@@ -431,8 +432,8 @@ func TestUpdateStorage(t *testing.T) {
 		bDevs      []string
 		nvmeParams *pb.UpdateNvmeReq // provided in client gRPC call
 		scmParams  *pb.UpdateScmReq
-		moduleRets []*pb.ScmModuleResult
-		ctrlrRets  []*pb.NvmeControllerResult
+		moduleRets ScmModuleResults
+		ctrlrRets  NvmeControllerResults
 		desc       string
 	}{
 		{
@@ -442,13 +443,13 @@ func TestUpdateStorage(t *testing.T) {
 				Startrev: "1.0.0",
 				Model:    "ABC",
 			},
-			ctrlrRets: []*pb.NvmeControllerResult{
+			ctrlrRets: NvmeControllerResults{
 				{
 					Pciaddr: pciAddr,
 					State:   new(pb.ResponseState),
 				},
 			},
-			moduleRets: []*pb.ScmModuleResult{
+			moduleRets: ScmModuleResults{
 				{
 					Loc: &pb.ScmModule_Location{},
 					State: &pb.ResponseState{
@@ -465,7 +466,7 @@ func TestUpdateStorage(t *testing.T) {
 				Startrev: "1.0.0",
 				Model:    "AB",
 			},
-			ctrlrRets: []*pb.NvmeControllerResult{
+			ctrlrRets: NvmeControllerResults{
 				{
 					Pciaddr: pciAddr,
 					State: &pb.ResponseState{
@@ -476,7 +477,7 @@ func TestUpdateStorage(t *testing.T) {
 					},
 				},
 			},
-			moduleRets: []*pb.ScmModuleResult{
+			moduleRets: ScmModuleResults{
 				{
 					Loc: &pb.ScmModule_Location{},
 					State: &pb.ResponseState{
@@ -493,7 +494,7 @@ func TestUpdateStorage(t *testing.T) {
 				Startrev: "2.0.0",
 				Model:    "ABC",
 			},
-			ctrlrRets: []*pb.NvmeControllerResult{
+			ctrlrRets: NvmeControllerResults{
 				{
 					Pciaddr: pciAddr,
 					State: &pb.ResponseState{
@@ -504,7 +505,7 @@ func TestUpdateStorage(t *testing.T) {
 					},
 				},
 			},
-			moduleRets: []*pb.ScmModuleResult{
+			moduleRets: ScmModuleResults{
 				{
 					Loc: &pb.ScmModule_Location{},
 					State: &pb.ResponseState{

--- a/src/control/server/storage_nvme.go
+++ b/src/control/server/storage_nvme.go
@@ -135,7 +135,7 @@ type nvmeStorage struct {
 	nvme        spdk.NVME      // SPDK NVMe interface
 	spdk        SpdkSetup      // SPDK shell configuration interface
 	config      *configuration // server configuration structure
-	controllers []*pb.NvmeController
+	controllers common.NvmeControllers
 	initialized bool
 	formatted   bool
 }
@@ -255,7 +255,7 @@ func newCret(
 // One result with empty Pciaddr will be reported if there are preliminary
 // errors occurring before devices could be accessed. Otherwise a result will
 // be populated for each device in bdev_list.
-func (n *nvmeStorage) Format(i int, results *([]*pb.NvmeControllerResult)) {
+func (n *nvmeStorage) Format(i int, results *(common.NvmeControllerResults)) {
 	var pciAddr string
 	srv := n.config.Servers[i]
 	log.Debugf("performing device format on NVMe controllers")
@@ -352,7 +352,8 @@ func (n *nvmeStorage) Format(i int, results *([]*pb.NvmeControllerResult)) {
 // errors occurring before devices could be accessed. Otherwise a result will
 // be populated for each device in bdev_list.
 func (n *nvmeStorage) Update(
-	i int, req *pb.UpdateNvmeReq, results *([]*pb.NvmeControllerResult)) {
+	i int, req *pb.UpdateNvmeReq, results *(common.NvmeControllerResults),
+) {
 
 	var pciAddr string
 	srv := n.config.Servers[i]
@@ -515,7 +516,8 @@ func (n *nvmeStorage) BurnIn(pciAddr string, nsID int32, configPath string) (
 // loadControllers converts slice of Controller into protobuf equivalent.
 // Implemented as a pure function.
 func loadControllers(ctrlrs []spdk.Controller, nss []spdk.Namespace) (
-	pbCtrlrs []*pb.NvmeController) {
+	pbCtrlrs common.NvmeControllers) {
+
 	for _, c := range ctrlrs {
 		pbCtrlrs = append(
 			pbCtrlrs,
@@ -533,9 +535,8 @@ func loadControllers(ctrlrs []spdk.Controller, nss []spdk.Namespace) (
 
 // loadNamespaces converts slice of Namespace into protobuf equivalent.
 // Implemented as a pure function.
-func loadNamespaces(
-	ctrlrPciAddr string, nss []spdk.Namespace) (
-	_nss []*pb.NvmeController_Namespace) {
+func loadNamespaces(ctrlrPciAddr string, nss []spdk.Namespace) (
+	_nss common.NvmeNamespaces) {
 
 	for _, ns := range nss {
 		if ns.CtrlrPciAddr == ctrlrPciAddr {

--- a/src/control/server/storage_nvme_test.go
+++ b/src/control/server/storage_nvme_test.go
@@ -28,10 +28,11 @@ import (
 	"strings"
 	"testing"
 
-	. "github.com/daos-stack/daos/src/control/common"
-	pb "github.com/daos-stack/daos/src/control/common/proto/mgmt"
 	. "github.com/daos-stack/go-spdk/spdk"
 	"github.com/pkg/errors"
+
+	. "github.com/daos-stack/daos/src/control/common"
+	pb "github.com/daos-stack/daos/src/control/common/proto/mgmt"
 )
 
 var nvmeFormatCalls []string // record calls to nvme.Format()
@@ -219,13 +220,13 @@ func TestDiscoverNvmeSingle(t *testing.T) {
 
 		if tt.inited {
 			AssertEqual(
-				t, sn.controllers, []*pb.NvmeController(nil),
+				t, sn.controllers, NvmeControllers(nil),
 				"unexpected list of protobuf format controllers")
 			continue
 		}
 
 		AssertEqual(
-			t, sn.controllers, []*pb.NvmeController{pbC},
+			t, sn.controllers, NvmeControllers{pbC},
 			"unexpected list of protobuf format controllers")
 	}
 }
@@ -323,14 +324,14 @@ func TestFormatNvme(t *testing.T) {
 		formatted    bool
 		devFormatRet error
 		pciAddrs     []string
-		expResults   []*pb.NvmeControllerResult
+		expResults   NvmeControllerResults
 		desc         string
 	}{
 		{
 			false,
 			nil,
 			[]string{},
-			[]*pb.NvmeControllerResult{
+			NvmeControllerResults{
 				{
 					Pciaddr: "",
 					State: &pb.ResponseState{
@@ -345,7 +346,7 @@ func TestFormatNvme(t *testing.T) {
 			true,
 			nil,
 			[]string{},
-			[]*pb.NvmeControllerResult{
+			NvmeControllerResults{
 				{
 					Pciaddr: "",
 					State: &pb.ResponseState{
@@ -360,7 +361,7 @@ func TestFormatNvme(t *testing.T) {
 			false,
 			nil,
 			[]string{""},
-			[]*pb.NvmeControllerResult{
+			NvmeControllerResults{
 				{
 					Pciaddr: "",
 					State: &pb.ResponseState{
@@ -375,7 +376,7 @@ func TestFormatNvme(t *testing.T) {
 			false,
 			nil,
 			[]string{"0000:81:00.0"},
-			[]*pb.NvmeControllerResult{
+			NvmeControllerResults{
 				{
 					Pciaddr: "0000:81:00.0",
 					State:   new(pb.ResponseState),
@@ -387,7 +388,7 @@ func TestFormatNvme(t *testing.T) {
 			false,
 			nil,
 			[]string{"0000:83:00.0"},
-			[]*pb.NvmeControllerResult{
+			NvmeControllerResults{
 				{
 					Pciaddr: "0000:83:00.0",
 					State: &pb.ResponseState{
@@ -402,7 +403,7 @@ func TestFormatNvme(t *testing.T) {
 			false,
 			nil,
 			[]string{"0000:81:00.0", "0000:83:00.0"},
-			[]*pb.NvmeControllerResult{
+			NvmeControllerResults{
 				{
 					Pciaddr: "0000:81:00.0",
 					State:   new(pb.ResponseState),
@@ -421,7 +422,7 @@ func TestFormatNvme(t *testing.T) {
 			false,
 			nil,
 			[]string{"0000:83:00.0", "0000:81:00.0"},
-			[]*pb.NvmeControllerResult{
+			NvmeControllerResults{
 				{
 					Pciaddr: "0000:83:00.0",
 					State: &pb.ResponseState{
@@ -440,7 +441,7 @@ func TestFormatNvme(t *testing.T) {
 			false,
 			errors.New("example format failure"),
 			[]string{"0000:83:00.0", "0000:81:00.0"},
-			[]*pb.NvmeControllerResult{
+			NvmeControllerResults{
 				{
 					Pciaddr: "0000:83:00.0",
 					State: &pb.ResponseState{
@@ -481,7 +482,7 @@ func TestFormatNvme(t *testing.T) {
 			false, &config)
 		sn.formatted = tt.formatted
 
-		results := []*pb.NvmeControllerResult{}
+		results := NvmeControllerResults{}
 
 		// not concerned with response
 		sn.Discover(new(pb.ScanStorageResp))
@@ -528,22 +529,22 @@ func TestUpdateNvme(t *testing.T) {
 	serial := "123ABC"
 	startRev := "1.0.0"      // only update if at specified starting revision
 	defaultEndRev := "1.0.1" // default fw revision after update
-	newDefaultCtrlrs := func(rev string) []*pb.NvmeController {
-		return []*pb.NvmeController{
+	newDefaultCtrlrs := func(rev string) NvmeControllers {
+		return NvmeControllers{
 			NewMockControllerPB(
 				pciAddr, rev, model, serial,
-				[]*pb.NvmeController_Namespace(nil)),
+				NvmeNamespaces(nil)),
 		}
 	}
 
 	tests := []struct {
 		inited       bool
 		devUpdateRet error
-		pciAddrs     []string                   // pci addresses in config to be updated
-		endRev       *string                    // force resultant revision to test against
-		initCtrlrs   []Controller               // initially discovered ctrlrs
-		expResults   []*pb.NvmeControllerResult // expected response results
-		expCtrlrs    []*pb.NvmeController       // expected resultant ctrlr details
+		pciAddrs     []string              // pci addresses in config to be updated
+		endRev       *string               // force resultant revision to test against
+		initCtrlrs   []Controller          // initially discovered ctrlrs
+		expResults   NvmeControllerResults // expected response results
+		expCtrlrs    NvmeControllers       // expected resultant ctrlr details
 		desc         string
 	}{
 		{
@@ -553,7 +554,7 @@ func TestUpdateNvme(t *testing.T) {
 		{
 			inited:   true,
 			pciAddrs: []string{""},
-			expResults: []*pb.NvmeControllerResult{
+			expResults: NvmeControllerResults{
 				{
 					Pciaddr: "",
 					State: &pb.ResponseState{
@@ -568,7 +569,7 @@ func TestUpdateNvme(t *testing.T) {
 			inited:     true,
 			pciAddrs:   []string{pciAddr},
 			initCtrlrs: []Controller{MockController(startRev)},
-			expResults: []*pb.NvmeControllerResult{
+			expResults: NvmeControllerResults{
 				{
 					Pciaddr: pciAddr,
 					State:   new(pb.ResponseState),
@@ -581,7 +582,7 @@ func TestUpdateNvme(t *testing.T) {
 			inited:     true,
 			pciAddrs:   []string{"0000:aa:00.0"},
 			initCtrlrs: []Controller{MockController(startRev)},
-			expResults: []*pb.NvmeControllerResult{
+			expResults: NvmeControllerResults{
 				{
 					Pciaddr: "0000:aa:00.0",
 					State: &pb.ResponseState{
@@ -599,7 +600,7 @@ func TestUpdateNvme(t *testing.T) {
 			initCtrlrs: []Controller{ // device has different model
 				NewMockController(pciAddr, startRev, "UKNOWN1", serial),
 			},
-			expResults: []*pb.NvmeControllerResult{
+			expResults: NvmeControllerResults{
 				{
 					Pciaddr: pciAddr,
 					State: &pb.ResponseState{
@@ -610,10 +611,10 @@ func TestUpdateNvme(t *testing.T) {
 					},
 				},
 			},
-			expCtrlrs: []*pb.NvmeController{
+			expCtrlrs: NvmeControllers{
 				NewMockControllerPB(
 					pciAddr, startRev, "UKNOWN1", serial,
-					[]*pb.NvmeController_Namespace(nil)),
+					NvmeNamespaces(nil)),
 			},
 			desc: "single device different model",
 		},
@@ -623,7 +624,7 @@ func TestUpdateNvme(t *testing.T) {
 			initCtrlrs: []Controller{ // device has different start rev
 				NewMockController(pciAddr, "2.0.0", model, serial),
 			},
-			expResults: []*pb.NvmeControllerResult{
+			expResults: NvmeControllerResults{
 				{
 					Pciaddr: pciAddr,
 					State: &pb.ResponseState{
@@ -634,10 +635,10 @@ func TestUpdateNvme(t *testing.T) {
 					},
 				},
 			},
-			expCtrlrs: []*pb.NvmeController{
+			expCtrlrs: NvmeControllers{
 				NewMockControllerPB(
 					pciAddr, "2.0.0", model, serial,
-					[]*pb.NvmeController_Namespace(nil)),
+					NvmeNamespaces(nil)),
 			},
 			desc: "single device different starting rev",
 		},
@@ -646,7 +647,7 @@ func TestUpdateNvme(t *testing.T) {
 			pciAddrs:     []string{pciAddr},
 			devUpdateRet: errors.New("spdk format failed"),
 			initCtrlrs:   []Controller{MockController(startRev)},
-			expResults: []*pb.NvmeControllerResult{
+			expResults: NvmeControllerResults{
 				{
 					Pciaddr: pciAddr,
 					State: &pb.ResponseState{
@@ -665,7 +666,7 @@ func TestUpdateNvme(t *testing.T) {
 			pciAddrs:   []string{pciAddr},
 			endRev:     &startRev, // force resultant rev, non-update
 			initCtrlrs: []Controller{MockController(startRev)},
-			expResults: []*pb.NvmeControllerResult{
+			expResults: NvmeControllerResults{
 				{
 					Pciaddr: pciAddr,
 					State: &pb.ResponseState{
@@ -683,7 +684,7 @@ func TestUpdateNvme(t *testing.T) {
 			pciAddrs:   []string{pciAddr},
 			endRev:     new(string), // force resultant rev, non-update
 			initCtrlrs: []Controller{MockController(startRev)},
-			expResults: []*pb.NvmeControllerResult{
+			expResults: NvmeControllerResults{
 				{
 					Pciaddr: pciAddr,
 					State: &pb.ResponseState{
@@ -706,7 +707,7 @@ func TestUpdateNvme(t *testing.T) {
 				NewMockController("0000:aa:00.0", defaultEndRev, model, serial),
 				NewMockController("0000:81:00.1", startRev, model, serial),
 			},
-			expResults: []*pb.NvmeControllerResult{
+			expResults: NvmeControllerResults{
 				{
 					Pciaddr: pciAddr,
 					State: &pb.ResponseState{
@@ -737,16 +738,16 @@ func TestUpdateNvme(t *testing.T) {
 					},
 				},
 			},
-			expCtrlrs: []*pb.NvmeController{
+			expCtrlrs: NvmeControllers{
 				NewMockControllerPB(
 					"0000:ab:00.0", startRev, "UKN", serial,
-					[]*pb.NvmeController_Namespace(nil)),
+					NvmeNamespaces(nil)),
 				NewMockControllerPB(
 					"0000:aa:00.0", defaultEndRev, model, serial,
-					[]*pb.NvmeController_Namespace(nil)),
+					NvmeNamespaces(nil)),
 				NewMockControllerPB(
 					"0000:81:00.1", defaultEndRev, model, serial,
-					[]*pb.NvmeController_Namespace(nil)),
+					NvmeNamespaces(nil)),
 			},
 			desc: "multiple devices (missing,mismatch rev/model,success)",
 		},
@@ -771,7 +772,7 @@ func TestUpdateNvme(t *testing.T) {
 				nil, nil, tt.devUpdateRet),
 			false, &config)
 
-		results := []*pb.NvmeControllerResult{}
+		results := NvmeControllerResults{}
 
 		if tt.inited {
 			sn.Discover(new(pb.ScanStorageResp)) // not concerned with response

--- a/src/control/server/storage_scm.go
+++ b/src/control/server/storage_scm.go
@@ -56,7 +56,7 @@ var (
 type scmStorage struct {
 	ipmctl      ipmctl.IpmCtl  // ipmctl NVM API interface
 	config      *configuration // server configuration structure
-	modules     []*pb.ScmModule
+	modules     common.ScmModules
 	initialized bool
 	formatted   bool
 }
@@ -85,7 +85,7 @@ func (s *scmStorage) Teardown() error {
 	return nil
 }
 
-func loadModules(mms []ipmctl.DeviceDiscovery) (pbMms []*pb.ScmModule) {
+func loadModules(mms []ipmctl.DeviceDiscovery) (pbMms common.ScmModules) {
 	for _, c := range mms {
 		pbMms = append(
 			pbMms,
@@ -234,7 +234,7 @@ func newMntRet(
 
 // Format attempts to format (forcefully) SCM mounts on a given server
 // as specified in config file and populates resp ScmMountResult.
-func (s *scmStorage) Format(i int, results *([]*pb.ScmMountResult)) {
+func (s *scmStorage) Format(i int, results *(common.ScmMountResults)) {
 	srv := s.config.Servers[i]
 	mntPoint := srv.ScmMount
 	log.Debugf("performing SCM device reset, format and mount")
@@ -312,7 +312,7 @@ func (s *scmStorage) Format(i int, results *([]*pb.ScmMountResult)) {
 
 // Update is currently a placeholder method stubbing SCM module fw update.
 func (s *scmStorage) Update(
-	i int, req *pb.UpdateScmReq, results *([]*pb.ScmModuleResult)) {
+	i int, req *pb.UpdateScmReq, results *(common.ScmModuleResults)) {
 
 	// respond with single result indicating no implementation
 	*results = append(

--- a/src/control/server/storage_scm_test.go
+++ b/src/control/server/storage_scm_test.go
@@ -27,10 +27,11 @@ import (
 	"fmt"
 	"testing"
 
-	. "github.com/daos-stack/daos/src/control/common"
-	pb "github.com/daos-stack/daos/src/control/common/proto/mgmt"
 	. "github.com/daos-stack/go-ipmctl/ipmctl"
 	"github.com/pkg/errors"
+
+	. "github.com/daos-stack/daos/src/control/common"
+	pb "github.com/daos-stack/daos/src/control/common/proto/mgmt"
 )
 
 // MockModule returns a mock SCM module of type exported from go-ipmctl.
@@ -84,25 +85,25 @@ func TestDiscoverScm(t *testing.T) {
 		inited            bool
 		ipmctlDiscoverRet error
 		errMsg            string
-		expModules        []*pb.ScmModule
+		expModules        ScmModules
 	}{
 		{
 			true,
 			nil,
 			"",
-			[]*pb.ScmModule(nil),
+			ScmModules(nil),
 		},
 		{
 			false,
 			nil,
 			"",
-			[]*pb.ScmModule{mPB},
+			ScmModules{mPB},
 		},
 		{
 			false,
 			errors.New("ipmctl example failure"),
 			msgIpmctlDiscoverFail + ": ipmctl example failure",
-			[]*pb.ScmModule{mPB},
+			ScmModules{mPB},
 		},
 	}
 
@@ -142,13 +143,13 @@ func TestFormatScm(t *testing.T) {
 		devs       []string
 		size       int
 		expCmds    []string // expected arguments in syscall methods
-		expResults []*pb.ScmMountResult
+		expResults ScmMountResults
 		desc       string
 	}{
 		{
 			inited: false,
 			mount:  "/mnt/daos",
-			expResults: []*pb.ScmMountResult{
+			expResults: ScmMountResults{
 				{
 					Mntpoint: "/mnt/daos",
 					State: &pb.ResponseState{
@@ -163,7 +164,7 @@ func TestFormatScm(t *testing.T) {
 			inited:    true,
 			mount:     "/mnt/daos",
 			formatted: true,
-			expResults: []*pb.ScmMountResult{
+			expResults: ScmMountResults{
 				{
 					Mntpoint: "/mnt/daos",
 					State: &pb.ResponseState{
@@ -176,7 +177,7 @@ func TestFormatScm(t *testing.T) {
 		},
 		{
 			inited: true,
-			expResults: []*pb.ScmMountResult{
+			expResults: ScmMountResults{
 				{
 					Mntpoint: "",
 					State: &pb.ResponseState{
@@ -190,7 +191,7 @@ func TestFormatScm(t *testing.T) {
 		{
 			inited: true,
 			mount:  "/mnt/daos",
-			expResults: []*pb.ScmMountResult{
+			expResults: ScmMountResults{
 				{
 					Mntpoint: "/mnt/daos",
 					State: &pb.ResponseState{
@@ -206,7 +207,7 @@ func TestFormatScm(t *testing.T) {
 			mount:  "/mnt/daos",
 			class:  scmRAM,
 			size:   6,
-			expResults: []*pb.ScmMountResult{
+			expResults: ScmMountResults{
 				{
 					Mntpoint: "/mnt/daos",
 					State:    &pb.ResponseState{},
@@ -225,7 +226,7 @@ func TestFormatScm(t *testing.T) {
 			mount:  "/mnt/daos",
 			class:  scmDCPM,
 			devs:   []string{"/dev/pmem0"},
-			expResults: []*pb.ScmMountResult{
+			expResults: ScmMountResults{
 				{
 					Mntpoint: "/mnt/daos",
 					State:    &pb.ResponseState{},
@@ -246,7 +247,7 @@ func TestFormatScm(t *testing.T) {
 			mount:  "/mnt/daos",
 			class:  scmDCPM,
 			devs:   []string{},
-			expResults: []*pb.ScmMountResult{
+			expResults: ScmMountResults{
 				{
 					Mntpoint: "/mnt/daos",
 					State: &pb.ResponseState{
@@ -262,7 +263,7 @@ func TestFormatScm(t *testing.T) {
 			mount:  "/mnt/daos",
 			class:  scmDCPM,
 			devs:   []string(nil),
-			expResults: []*pb.ScmMountResult{
+			expResults: ScmMountResults{
 				{
 					Mntpoint: "/mnt/daos",
 					State: &pb.ResponseState{
@@ -278,7 +279,7 @@ func TestFormatScm(t *testing.T) {
 			mount:  "/mnt/daos",
 			class:  scmDCPM,
 			devs:   []string{""},
-			expResults: []*pb.ScmMountResult{
+			expResults: ScmMountResults{
 				{
 					Mntpoint: "/mnt/daos",
 					State: &pb.ResponseState{
@@ -302,7 +303,7 @@ func TestFormatScm(t *testing.T) {
 			nil, []DeviceDiscovery{}, false, config)
 		ss.formatted = tt.formatted
 
-		results := []*pb.ScmMountResult{}
+		results := ScmMountResults{}
 
 		if tt.inited {
 			// not concerned with response
@@ -349,11 +350,11 @@ func TestFormatScm(t *testing.T) {
 // implemented state in result.
 func TestUpdateScm(t *testing.T) {
 	tests := []struct {
-		expResults []*pb.ScmModuleResult
+		expResults ScmModuleResults
 		desc       string
 	}{
 		{
-			expResults: []*pb.ScmModuleResult{
+			expResults: ScmModuleResults{
 				{
 					Loc: &pb.ScmModule_Location{},
 					State: &pb.ResponseState{
@@ -373,7 +374,7 @@ func TestUpdateScm(t *testing.T) {
 		ss := newMockScmStorage(
 			nil, []DeviceDiscovery{}, false, &config)
 
-		results := []*pb.ScmModuleResult{}
+		results := ScmModuleResults{}
 
 		req := &pb.UpdateScmReq{}
 		ss.Update(srvIdx, req, &results)


### PR DESCRIPTION
Export custom types for reference slices of commonly used storage
related protobuf messages from common package. Enabling consistent
usage of type methods including Stringer implementations.

Signed-off-by: Tom Nabarro <tom.nabarro@intel.com>