### PR TITLE
DAOS-2789 Control: Fix bug where server and agent do not log fatal er…

### DIFF
--- a/src/control/cmd/agent/main.go
+++ b/src/control/cmd/agent/main.go
@@ -24,6 +24,7 @@
 package main
 
 import (
+	"fmt"
 	"os"
 	"os/signal"
 	"path/filepath"
@@ -53,7 +54,12 @@ type cliOptions struct {
 var opts = new(cliOptions)
 
 func main() {
-	if agentMain() != nil {
+	// Set default global logger for application.
+	log.NewDefaultLogger(log.Debug, "", os.Stderr)
+
+	if err := agentMain(); err != nil {
+		fmt.Fprintf(os.Stderr, "fatal error: %s\n", err)
+		log.Errorf("%+v", err)
 		os.Exit(1)
 	}
 }
@@ -78,8 +84,6 @@ func applyCmdLineOverrides(c *client.Configuration, opts *cliOptions) {
 }
 
 func agentMain() error {
-	// Set default global logger for application.
-	log.NewDefaultLogger(log.Debug, "", os.Stderr)
 
 	log.Debugf("Starting daos_agent:")
 

--- a/src/control/cmd/daos_server/main.go
+++ b/src/control/cmd/daos_server/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"fmt"
 	"os"
 
 	"github.com/daos-stack/daos/src/control/log"
@@ -8,7 +9,11 @@ import (
 )
 
 func main() {
+	// Bootstrap default logger before config options get set.
+	log.NewDefaultLogger(log.Debug, "", os.Stderr)
+
 	if err := server.Main(); err != nil {
+		fmt.Fprintf(os.Stderr, "fatal error: %s\n", err)
 		log.Errorf("%+v", err)
 		os.Exit(1)
 	}

--- a/src/control/server/server.go
+++ b/src/control/server/server.go
@@ -55,8 +55,6 @@ func parseCliOpts(opts *cliOptions) error {
 // TODO: Refactor this to decouple CLI functionality from core
 // server logic and allow for easier testing.
 func Main() error {
-	// Bootstrap default logger before config options get set.
-	log.NewDefaultLogger(log.Debug, "", os.Stderr)
 
 	opts := new(cliOptions)
 	if err := parseCliOpts(opts); err != nil {


### PR DESCRIPTION
…rors

The architecture of daos_server and daos_agent handle fatal error by
percolating them all the way up to main and logging them in the event of an
error. The logging statements in the main functions of daos_agent and
daos_server do not actually seem to log the failure. As a fix until the control
plane logging system is redone we add an explicit print statement to stderr to
ensure regardless of the logging configuration we always see the fatal error
that stopped the component from starting. This also fixes the issue where any
error message that relied on being set to main to be printed is not printed
instead of being squelched.

Signed-off-by: David Quigley <david.quigley@intel.com>