### PR TITLE
DAOS-2797 vos: Add epoch range to value interfaces

### DIFF
--- a/src/control/SConscript
+++ b/src/control/SConscript
@@ -44,10 +44,11 @@ def get_bin_path(gopath, name):
     return join(gopath, "bin", name)
 
 def show_go_info():
+    """Show the go version information"""
     from distutils import spawn
     go_bin = spawn.find_executable("go")
     go_version = os.popen('%s version' % go_bin).read()
-    print("Go compiler installed at %s: %s" % (go_bin, go_version)),
+    print("Go compiler installed at %s: %s" % (go_bin, go_version))
 
 #pylint: disable=too-many-arguments
 def install_go_bin(denv, gosrc, gopath, libs, name, install_name):
@@ -152,7 +153,8 @@ def scons():
                 Copy("$TARGET", "$SOURCE")
             ])
 
-    install_go_bin(denv, gosrc, gopath, [nvmecontrol], "daos_server", "daos_server")
+    install_go_bin(denv, gosrc, gopath, [nvmecontrol], "daos_server",
+                   "daos_server")
     install_go_bin(denv, gosrc, gopath, None, "dmg", "daos_shell")
     install_go_bin(denv, gosrc, gopath, None, "drpc_test", "hello_drpc")
 

--- a/src/include/daos_srv/evtree.h
+++ b/src/include/daos_srv/evtree.h
@@ -459,11 +459,13 @@ int evt_delete(daos_handle_t toh, const struct evt_rect *rect,
  * \a rect to \a ent_array.
  *
  * \param toh		[IN]		The tree open handle
- * \param rect		[IN]		The versioned extent to search
+ * \param epr		[IN]		Epoch range to search
+ * \param extent	[IN]		The extent to search
  * \param ent_array	[IN,OUT]	Pass in initialized list, filled in by
  *					the function
  */
-int evt_find(daos_handle_t toh, const struct evt_rect *rect,
+int evt_find(daos_handle_t toh, const daos_epoch_range_t *epr,
+	     const struct evt_extent *extent,
 	     struct evt_entry_array *ent_array);
 
 /**

--- a/src/tests/security/SConscript
+++ b/src/tests/security/SConscript
@@ -2,7 +2,7 @@
 
 def scons():
     """Execute build"""
-    Import('env', 'prereqs', 'dc_sectest_tgts', 'dc_security_tgts')
+    Import('env', 'prereqs', 'dc_sectest_tgts')
 
     libs = ['gurt', 'daos', 'daos_common', 'protobuf-c']
     sec_sources = ['security_test.c', dc_sectest_tgts]

--- a/src/vea/SConscript
+++ b/src/vea/SConscript
@@ -1,6 +1,5 @@
 """Build versioned extent allocator"""
 import os
-import daos_build
 
 def scons():
     """Execute build"""

--- a/src/vos/SConscript
+++ b/src/vos/SConscript
@@ -41,7 +41,6 @@ def scons():
 
     # Compiler options
     denv.Append(CPPPATH=[Dir('.').srcnode()])
-    denv.AppendUnique(LIBPATH=['../vea'])
 
     build_vos(denv, False)
     build_vos(denv, True)

--- a/src/vos/evtree.c
+++ b/src/vos/evtree.c
@@ -2030,11 +2030,13 @@ struct evt_max_rect {
  * Please check API comment in evtree.h for the details.
  */
 int
-evt_find(daos_handle_t toh, const struct evt_rect *rect,
+evt_find(daos_handle_t toh, const daos_epoch_range_t *epr,
+	 const struct evt_extent *extent,
 	 struct evt_entry_array *ent_array)
 {
 	struct evt_context	*tcx;
 	struct evt_filter	 filter;
+	struct evt_rect		 rect;
 	int			 rc;
 
 	tcx = evt_hdl2tcx(toh);
@@ -2042,12 +2044,12 @@ evt_find(daos_handle_t toh, const struct evt_rect *rect,
 		return -DER_NO_HDL;
 
 	evt_ent_array_init(ent_array);
-	filter.fr_ex = rect->rc_ex;
-	filter.fr_epr.epr_lo = 0;
-	filter.fr_epr.epr_hi = rect->rc_epc;
+	rect.rc_ex = filter.fr_ex = *extent;
+	filter.fr_epr = *epr;
+	rect.rc_epc = epr->epr_hi;
 
 	rc = evt_ent_array_fill(tcx, EVT_FIND_ALL, DAOS_INTENT_DEFAULT,
-				&filter, rect, ent_array);
+				&filter, &rect, ent_array);
 	if (rc == 0)
 		rc = evt_ent_array_sort(tcx, ent_array, EVT_VISIBLE);
 	if (rc != 0)


### PR DESCRIPTION
With incarnation log, the subtree will have many values
that are punched so we need to be able to limit the
epoch search range.  Modify the low level interfaces
accordingly to add a range.  This doesn't change
present behavior.
Also cleanup a few SConscript pylint issues