### PR TITLE
DAOS-2281 dfuse: Add support for using symlinks.

### DIFF
--- a/src/client/dfuse/SConscript
+++ b/src/client/dfuse/SConscript
@@ -23,6 +23,8 @@ OPS_SRC = ['create',
            'opendir',
            'read',
            'readdir',
+           'readlink',
+           'symlink',
            'unlink',
            'write']
 

--- a/src/client/dfuse/dfuse.h
+++ b/src/client/dfuse/dfuse.h
@@ -119,6 +119,8 @@ struct dfuse_inode_ops {
 			   struct fuse_file_info *fi);
 	void (*readdir)(fuse_req_t req, struct dfuse_inode_entry *inode,
 			size_t size, off_t offset, struct fuse_file_info *fi);
+	void (*symlink)(fuse_req_t req, const char *link,
+			struct dfuse_inode_entry *parent, const char *name);
 	void (*unlink)(fuse_req_t req, struct dfuse_inode_entry *parent,
 		       const char *name);
 };
@@ -275,16 +277,16 @@ struct fuse_lowlevel_ops *dfuse_get_fuse_ops();
 					__rc, strerror(-__rc));		\
 	} while (0)
 
-#define DFUSE_REPLY_READLINK(dfuse_req, path)				\
+#define DFUSE_REPLY_READLINK(req, path)					\
 	do {								\
 		int __rc;						\
-		DFUSE_TRA_DEBUG(dfuse_req, "Returning path '%s'", path); \
-		__rc = fuse_reply_readlink((dfuse_req)->ir_req, path);	\
+		DFUSE_TRA_DEBUG(req, "Returning path '%s'", path);	\
+		__rc = fuse_reply_readlink(req, path);			\
 		if (__rc != 0)						\
-			DFUSE_TRA_ERROR(dfuse_req,			\
+			DFUSE_TRA_ERROR(req,				\
 					"fuse_reply_readlink returned %d:%s", \
 					__rc, strerror(-__rc));		\
-		DFUSE_TRA_DOWN(dfuse_req);				\
+		DFUSE_TRA_DOWN(req);					\
 	} while (0)
 
 #define DFUSE_REPLY_WRITE(handle, req, bytes)				\
@@ -489,6 +491,10 @@ dfuse_cb_write(fuse_req_t, fuse_ino_t, const char *, size_t, off_t,
 void
 dfuse_cb_setattr(fuse_req_t, fuse_ino_t, struct stat *, int,
 		 struct fuse_file_info *);
+
+void
+dfuse_cb_symlink(fuse_req_t, const char *, struct dfuse_inode_entry *,
+		 const char *);
 
 /* Return inode information to fuse
  *

--- a/src/client/dfuse/dfuse_core.c
+++ b/src/client/dfuse/dfuse_core.c
@@ -23,7 +23,6 @@
 
 #include "dfuse_common.h"
 #include "dfuse.h"
-#include "dfuse_da.h"
 
 /* Inode record hash table operations */
 

--- a/src/client/dfuse/ops/lookup.c
+++ b/src/client/dfuse/ops/lookup.c
@@ -120,6 +120,16 @@ dfuse_cb_lookup(fuse_req_t req, struct dfuse_inode_entry *parent,
 	if (rc)
 		D_GOTO(err, rc = -rc);
 
+	/* If the new entry is a link allocate an inode number here, as dfs
+	 * does not assign it an object id to be able to save an inode.
+	 *
+	 * see comment in symlink.c
+	 */
+	if (S_ISLNK(ie->ie_stat.st_mode)) {
+		ie->ie_stat.st_ino = atomic_fetch_add(&fs_handle->dpi_ino_next,
+						      1);
+	}
+
 	dfuse_reply_entry(fs_handle, ie, false, req);
 	return true;
 

--- a/src/client/dfuse/ops/readlink.c
+++ b/src/client/dfuse/ops/readlink.c
@@ -24,68 +24,39 @@
 #include "dfuse_common.h"
 #include "dfuse.h"
 
-static bool
-readlink_cb(struct dfuse_request *request)
-{
-	struct dfuse_string_out *out = request->out;
-
-	DFUSE_REQUEST_RESOLVE(request, out);
-	if (request->ir_rc) {
-		D_GOTO(out_err, 0);
-	}
-
-	DFUSE_REPLY_READLINK(request, out->path);
-
-	D_FREE(request);
-	return false;
-
-out_err:
-	DFUSE_REPLY_ERR(request, request->ir_rc);
-	D_FREE(request);
-	return false;
-
-}
-
-static const struct dfuse_request_api api = {
-	.on_result	= readlink_cb,
-};
-
 void
 dfuse_cb_readlink(fuse_req_t req, fuse_ino_t ino)
 {
-	struct dfuse_projection_info *fs_handle = fuse_req_userdata(req);
-	struct dfuse_request		*request;
-	int rc;
-	int ret;
+	struct dfuse_projection_info	*fs_handle = fuse_req_userdata(req);
+	struct dfuse_inode_entry	*inode;
+	d_list_t			*rlink;
+	char				*buf = NULL;
+	size_t				size = 0;
+	int				rc;
 
-	D_ALLOC_PTR(request);
-	if (!request) {
-		D_GOTO(out_no_request, ret = ENOMEM);
+	rlink = d_hash_rec_find(&fs_handle->dpi_iet, &ino, sizeof(ino));
+	if (!rlink) {
+		DFUSE_TRA_ERROR(fs_handle, "Failed to find inode %lu", ino);
+		D_GOTO(err, rc = ENOENT);
 	}
 
-	DFUSE_REQUEST_INIT(request, fs_handle);
-	DFUSE_REQUEST_RESET(request);
+	inode = container_of(rlink, struct dfuse_inode_entry, ie_htl);
 
-	DFUSE_TRA_UP(request, fs_handle, "readlink");
-	DFUSE_TRA_INFO(request, "statfs %lu", ino);
+	rc = dfs_get_symlink_value(inode->ie_obj, NULL, &size);
+	if (rc)
+		D_GOTO(err, rc = -rc);
 
-	request->ir_req = req;
-	request->ir_api = &api;
-	request->ir_ht = RHS_INODE_NUM;
-	request->ir_inode_num = ino;
+	D_ALLOC(buf, size + 1);
 
-	rc = dfuse_fs_send(request);
-	if (rc != 0) {
-		D_GOTO(out_err, ret = EIO);
-	}
+	rc = dfs_get_symlink_value(inode->ie_obj, &buf[0], &size);
+	if (rc)
+		D_GOTO(err, rc = -rc);
 
+	DFUSE_REPLY_READLINK(req, buf);
+	D_FREE(buf);
 	return;
 
-out_no_request:
-	DFUSE_REPLY_ERR_RAW(fs_handle, req, ret);
-	return;
-
-out_err:
-	DFUSE_REPLY_ERR(request, ret);
-	D_FREE(request);
+err:
+	DFUSE_REPLY_ERR_RAW(fs_handle, req, rc);
+	D_FREE(buf);
 }

--- a/src/client/dfuse/ops/symlink.c
+++ b/src/client/dfuse/ops/symlink.c
@@ -24,44 +24,49 @@
 #include "dfuse_common.h"
 #include "dfuse.h"
 
-#define REQ_NAME request
-#define POOL_NAME dpi_symlink
-#define TYPE_NAME entry_req
-
-static const struct dfuse_request_api api;
-
 void
-dfuse_cb_symlink(fuse_req_t req, const char *link, fuse_ino_t parent,
+dfuse_cb_symlink(fuse_req_t req, const char *link,
+		 struct dfuse_inode_entry *parent,
 		 const char *name)
 {
 	struct dfuse_projection_info	*fs_handle = fuse_req_userdata(req);
-	struct entry_req		*desc = NULL;
+	struct dfuse_inode_entry	*ie = NULL;
 	int rc;
 
-	DFUSE_TRA_INFO(fs_handle, "Parent:%lu '%s'", parent, name);
-	DFUSE_REQ_INIT_REQ(desc, fs_handle, api, req, rc);
-	if (rc)
-		D_GOTO(err, rc);
-
-	D_STRNDUP(desc->dest, link, 4096);
-	if (!desc->dest)
+	D_ALLOC_PTR(ie);
+	if (!ie)
 		D_GOTO(err, rc = ENOMEM);
 
-	desc->da = fs_handle->dpi_symlink;
-	strncpy(desc->ie->ie_name, name, NAME_MAX);
-	desc->ie->ie_name[NAME_MAX] = '\0';
-	desc->ie->ie_parent = parent;
-
-	desc->request.ir_inode_num = parent;
-
-	rc = dfuse_fs_send(&desc->request);
+	rc = dfs_open(parent->ie_dfs->dfs_ns, parent->ie_obj, name, S_IFLNK,
+		      O_CREAT, 0, 0, link, &ie->ie_obj);
 	if (rc != 0)
-		D_GOTO(err, 0);
+		D_GOTO(err, rc = -rc);
+
+	DFUSE_TRA_INFO(ie, "obj is %p", ie->ie_obj);
+
+	strncpy(ie->ie_name, name, NAME_MAX);
+	ie->ie_name[NAME_MAX] = '\0';
+	ie->ie_parent = parent->ie_stat.st_ino;
+	ie->ie_dfs = parent->ie_dfs;
+	atomic_fetch_add(&ie->ie_ref, 1);
+
+	rc = dfs_ostat(parent->ie_dfs->dfs_ns, ie->ie_obj, &ie->ie_stat);
+	if (rc)
+		D_GOTO(err, rc = -rc);
+
+	/* Allocate an inode number for the symlink.
+	 *
+	 * This is needed for the symlink itself, as dfs does not allocate an
+	 * object for links so the standard inode lookup does not work.
+	 */
+	ie->ie_stat.st_ino = atomic_fetch_add(&fs_handle->dpi_ino_next, 1);
+
+	DFUSE_TRA_INFO(ie, "Inserting inode %lu", ie->ie_stat.st_ino);
+
+	dfuse_reply_entry(fs_handle, ie, false, req);
+
 	return;
 err:
+	D_FREE(ie);
 	DFUSE_REPLY_ERR_RAW(fs_handle, req, rc);
-	if (desc) {
-		DFUSE_TRA_DOWN(&desc->request);
-		dfuse_da_release(fs_handle->dpi_symlink, desc);
-	}
 }


### PR DESCRIPTION
Add callbacks for symlink and readlink, and modify lookup to
work correctly with symlinks.