### PR TITLE
DAOS-2802 bio: Define in-memory structure for device state information

### DIFF
--- a/src/bio/bio_internal.h
+++ b/src/bio/bio_internal.h
@@ -75,15 +75,16 @@ enum bio_bs_state {
 /*
  * SPDK device health monitoring.
  */
-struct bio_health_monitoring {
+struct bio_dev_health {
+	struct bio_device_health_state	 bdh_health_state;
 	/* writable open descriptor for health info polling */
-	struct spdk_bdev_desc	*bhm_desc;
-	struct spdk_io_channel	*bhm_io_channel;
-	void			*bhm_health_buf; /* device health info logs */
-	void			*bhm_ctrlr_buf; /* controller data */
-	void			*bhm_error_buf; /* device error logs */
-	uint64_t		 bhm_stat_age;
-	unsigned int		 bhm_inflights;
+	struct spdk_bdev_desc		*bdh_desc;
+	struct spdk_io_channel		*bdh_io_channel;
+	void				*bdh_health_buf; /* health info logs */
+	void				*bdh_ctrlr_buf; /* controller data */
+	void				*bdh_error_buf; /* device error logs */
+	uint64_t			 bdh_stat_age;
+	unsigned int			 bdh_inflights;
 };
 
 /*
@@ -91,26 +92,26 @@ struct bio_health_monitoring {
  * blobstore for certain NVMe device.
  */
 struct bio_blobstore {
-	ABT_mutex			 bb_mutex;
-	ABT_cond			 bb_barrier;
-	struct spdk_blob_store		*bb_bs;
+	ABT_mutex		 bb_mutex;
+	ABT_cond		 bb_barrier;
+	struct spdk_blob_store	*bb_bs;
 	/*
 	 * The xstream resposible for blobstore load/unload, monitor
 	 * and faulty/reint reaction.
 	 */
-	struct bio_xs_context		*bb_owner_xs;
+	struct bio_xs_context	*bb_owner_xs;
 	/* All the xstreams using the blobstore */
-	struct bio_xs_context		**bb_xs_ctxts;
+	struct bio_xs_context	**bb_xs_ctxts;
 	/* Device/blobstore health monitoring info */
-	struct bio_health_monitoring	 bb_dev_health;
-	enum bio_bs_state		 bb_state;
+	struct bio_dev_health	 bb_dev_health;
+	enum bio_bs_state	 bb_state;
 	/* Blobstore used by how many xstreams */
-	int				 bb_ref;
+	int			 bb_ref;
 	/*
 	 * Blobstore is held and being accessed by requests from upper
 	 * layer, teardown procedure needs be postponed.
 	 */
-	int				 bb_holdings;
+	int			 bb_holdings;
 };
 
 /* Per-xstream NVMe context */

--- a/src/bio/bio_internal.h
+++ b/src/bio/bio_internal.h
@@ -26,6 +26,7 @@
 
 #include <daos_srv/daos_server.h>
 #include <daos_srv/bio.h>
+#include <spdk/bdev.h>
 
 #define BIO_DMA_PAGE_SHIFT	12	/* 4K */
 #define BIO_DMA_PAGE_SZ		(1UL << BIO_DMA_PAGE_SHIFT)
@@ -203,8 +204,6 @@ is_blob_valid(struct bio_io_context *ctxt)
 {
 	return ctxt->bic_blob != NULL && !ctxt->bic_closing;
 }
-
-struct spdk_bdev;
 
 enum {
 	BDEV_CLASS_NVME = 0,

--- a/src/bio/bio_internal.h
+++ b/src/bio/bio_internal.h
@@ -76,15 +76,15 @@ enum bio_bs_state {
  * SPDK device health monitoring.
  */
 struct bio_dev_health {
-	struct bio_device_health_state	 bdh_health_state;
+	struct bio_dev_state	 bdh_health_state;
 	/* writable open descriptor for health info polling */
-	struct spdk_bdev_desc		*bdh_desc;
-	struct spdk_io_channel		*bdh_io_channel;
-	void				*bdh_health_buf; /* health info logs */
-	void				*bdh_ctrlr_buf; /* controller data */
-	void				*bdh_error_buf; /* device error logs */
-	uint64_t			 bdh_stat_age;
-	unsigned int			 bdh_inflights;
+	struct spdk_bdev_desc	*bdh_desc;
+	struct spdk_io_channel	*bdh_io_channel;
+	void			*bdh_health_buf; /* health info logs */
+	void			*bdh_ctrlr_buf; /* controller data */
+	void			*bdh_error_buf; /* device error logs */
+	uint64_t		 bdh_stat_age;
+	unsigned int		 bdh_inflights;
 };
 
 /*

--- a/src/bio/bio_monitor.c
+++ b/src/bio/bio_monitor.c
@@ -33,8 +33,6 @@
 /* Used to preallocate buffer to query error log pages from SPDK health info */
 #define DAOS_MAX_ERROR_LOG_PAGES 256
 
-uint64_t io_stat_period;
-
 static void
 dprint_uint128_hex(uint64_t *v)
 {
@@ -80,15 +78,16 @@ static void
 get_spdk_err_log_page_completion(struct spdk_bdev_io *bdev_io, bool success,
 				 void *cb_arg)
 {
-	struct bio_health_monitoring			*dev_health = cb_arg;
-	struct spdk_nvme_error_information_entry	*error_entries;
-	struct spdk_nvme_error_information_entry	*error_entry;
-	struct spdk_nvme_ctrlr_data			*cdata;
-	struct spdk_bdev				*bdev;
-	uint32_t					 i;
-	int						 sc, sct;
+	struct bio_dev_health			 *dev_health = cb_arg;
+	struct bio_device_health_state		 *hs;
+	struct spdk_nvme_error_information_entry *error_entries;
+	struct spdk_nvme_error_information_entry *error_entry;
+	struct spdk_nvme_ctrlr_data		 *cdata;
+	struct spdk_bdev			 *bdev;
+	uint32_t				  i;
+	int					  sc, sct;
 
-	D_ASSERT(dev_health->bhm_inflights == 1);
+	D_ASSERT(dev_health->bdh_inflights == 1);
 
 	/* Additional NVMe status information */
 	spdk_bdev_io_get_nvme_status(bdev_io, &sct, &sc);
@@ -97,29 +96,36 @@ get_spdk_err_log_page_completion(struct spdk_bdev_io *bdev_io, bool success,
 		goto out;
 	}
 
-	bdev = spdk_bdev_desc_get_bdev(dev_health->bhm_desc);
+	hs = &dev_health->bdh_health_state;
+
+	bdev = spdk_bdev_desc_get_bdev(dev_health->bdh_desc);
+
 	D_ASSERT(bdev != NULL);
 
-	cdata = dev_health->bhm_ctrlr_buf;
-	error_entries = dev_health->bhm_error_buf;
+	cdata = dev_health->bdh_ctrlr_buf;
+	error_entries = dev_health->bdh_error_buf;
 
-	/* TODO Store device error logs in in-memory health state log. */
+	if (getenv("PRINT_HEALTH_INFO") != NULL) {
+		D_PRINT("==================================================\n");
+		D_PRINT("SPDK Device Error Logs [%s]:\n",
+			spdk_bdev_get_name(bdev));
+		D_PRINT("==================================================\n");
+	}
 
-	/* Only print device error logs to console if env is set */
-	if (getenv("PRINT_HEALTH_INFO") == NULL)
-		goto out;
-
-	D_PRINT("==========================================================\n");
-	D_PRINT("SPDK Device Error Logs [%s]:\n", spdk_bdev_get_name(bdev));
-	D_PRINT("==========================================================\n");
 	for (i = 0; i < cdata->elpe; i++) {
 		error_entry = &error_entries[i];
+		hs->bhs_error_count = error_entry->error_count;
 		if (error_entry->error_count == 0) {
-			D_PRINT("No errors found!\n");
+			if (getenv("PRINT_HEALTH_INFO") != NULL)
+				D_PRINT("No errors found!\n");
 			goto out;
 		}
 		if (i != 0)
 			D_PRINT("-------------\n");
+
+		/* Only print device error logs to console if env is set */
+		if (getenv("PRINT_HEALTH_INFO") == NULL)
+			goto out;
 
 		D_PRINT("Entry: %u\n", i);
 		D_PRINT("Error count:         0x%"PRIx64"\n",
@@ -143,39 +149,37 @@ out:
 	/* Free I/O request in the competion callback */
 	spdk_bdev_free_io(bdev_io);
 	/*Decrease inflights on error or successful callback completion chain*/
-	dev_health->bhm_inflights--;
+	dev_health->bdh_inflights--;
 }
 
 static void
 get_spdk_identify_ctrlr_completion(struct spdk_bdev_io *bdev_io, bool success,
 				   void *cb_arg)
 {
-	struct bio_health_monitoring			*dev_health = cb_arg;
-	struct spdk_nvme_ctrlr_data			*cdata;
-	struct spdk_bdev				*bdev;
-	struct spdk_nvme_cmd				 cmd;
-	uint32_t					 ep_sz;
-	uint32_t					 ep_buf_sz;
-	uint32_t					 numd, numdl, numdu;
-	int						 rc;
-	int						 sc, sct;
+	struct bio_dev_health		*dev_health = cb_arg;
+	struct spdk_nvme_ctrlr_data	*cdata;
+	struct spdk_bdev		*bdev;
+	struct spdk_nvme_cmd		 cmd;
+	uint32_t			 ep_sz;
+	uint32_t			 ep_buf_sz;
+	uint32_t			 numd, numdl, numdu;
+	int				 rc;
+	int				 sc, sct;
 
-	D_ASSERT(dev_health->bhm_inflights == 1);
+	D_ASSERT(dev_health->bdh_inflights == 1);
 
 	/* Additional NVMe status information */
 	spdk_bdev_io_get_nvme_status(bdev_io, &sct, &sc);
 	if (sc) {
 		D_ERROR("NVMe status code/type: %d/%d\n", sc, sct);
-		dev_health->bhm_inflights--;
+		dev_health->bdh_inflights--;
 		goto out;
 	}
 
-	D_ASSERT(dev_health->bhm_io_channel != NULL);
-	bdev = spdk_bdev_desc_get_bdev(dev_health->bhm_desc);
+	D_ASSERT(dev_health->bdh_io_channel != NULL);
+	bdev = spdk_bdev_desc_get_bdev(dev_health->bdh_desc);
 	D_ASSERT(bdev != NULL);
-	cdata = dev_health->bhm_ctrlr_buf;
-
-	/* TODO Store device controller data in in-memory health state log. */
+	cdata = dev_health->bdh_ctrlr_buf;
 
 	/* Only print device controller data to console if env is set */
 	if (getenv("PRINT_HEALTH_INFO") == NULL)
@@ -212,7 +216,7 @@ prep_cmd:
 	cmd.cdw11 = numdu;
 	if (cdata->elpe >= DAOS_MAX_ERROR_LOG_PAGES) {
 		D_ERROR("Device error log page size exceeds buffer size\n");
-		dev_health->bhm_inflights--;
+		dev_health->bdh_inflights--;
 		goto out;
 	}
 	ep_buf_sz = ep_sz * (cdata->elpe + 1);
@@ -221,16 +225,16 @@ prep_cmd:
 	 * Submit an NVMe Admin command to get device error log page
 	 * to the bdev.
 	 */
-	rc = spdk_bdev_nvme_admin_passthru(dev_health->bhm_desc,
-					   dev_health->bhm_io_channel,
+	rc = spdk_bdev_nvme_admin_passthru(dev_health->bdh_desc,
+					   dev_health->bdh_io_channel,
 					   &cmd,
-					   dev_health->bhm_error_buf,
+					   dev_health->bdh_error_buf,
 					   ep_buf_sz,
 					   get_spdk_err_log_page_completion,
 					   dev_health);
 	if (rc) {
 		D_ERROR("NVMe admin passthru (error log), rc:%d\n", rc);
-		dev_health->bhm_inflights--;
+		dev_health->bdh_inflights--;
 	}
 
 out:
@@ -242,30 +246,46 @@ static void
 get_spdk_log_page_completion(struct spdk_bdev_io *bdev_io, bool success,
 			     void *cb_arg)
 {
-	struct bio_health_monitoring			*dev_health = cb_arg;
-	struct spdk_nvme_health_information_page	*hp;
-	struct spdk_bdev				*bdev;
-	struct spdk_nvme_cmd				 cmd;
-	uint32_t					 cp_sz;
-	int						 rc;
-	int						 sc, sct;
+	struct bio_dev_health			 *dev_health = cb_arg;
+	struct spdk_nvme_health_information_page *hp;
+	struct bio_device_health_state		 *hs;
+	struct spdk_bdev			 *bdev;
+	struct spdk_nvme_cmd			  cmd;
+	uint32_t				  cp_sz;
+	uint8_t					  crit_warn;
+	int					  rc;
+	int					  sc, sct;
 
-	D_ASSERT(dev_health->bhm_inflights == 1);
+	D_ASSERT(dev_health->bdh_inflights == 1);
 
 	/* Additional NVMe status information */
 	spdk_bdev_io_get_nvme_status(bdev_io, &sct, &sc);
 	if (sc) {
 		D_ERROR("NVMe status code/type: %d/%d\n", sc, sct);
-		dev_health->bhm_inflights--;
+		dev_health->bdh_inflights--;
 		goto out;
 	}
 
-	D_ASSERT(dev_health->bhm_io_channel != NULL);
-	bdev = spdk_bdev_desc_get_bdev(dev_health->bhm_desc);
+	D_ASSERT(dev_health->bdh_io_channel != NULL);
+	bdev = spdk_bdev_desc_get_bdev(dev_health->bdh_desc);
 	D_ASSERT(bdev != NULL);
-	hp = dev_health->bhm_health_buf;
+	hp = dev_health->bdh_health_buf;
 
-	/* TODO Store device health info in in-memory health state log. */
+	/* Store device health info in in-memory health state log. */
+	hs = &dev_health->bdh_health_state;
+	hs->bhs_timestamp = dev_health->bdh_stat_age;
+	hs->bhs_temperature = hp->temperature;
+	crit_warn = hp->critical_warning.bits.temperature;
+	hs->bhs_temp_warning = crit_warn;
+	crit_warn = hp->critical_warning.bits.available_spare;
+	hs->bhs_avail_spare_warning = crit_warn;
+	crit_warn = hp->critical_warning.bits.device_reliability;
+	hs->bhs_dev_reliabilty_warning = crit_warn;
+	crit_warn = hp->critical_warning.bits.read_only;
+	hs->bhs_read_only_warning = crit_warn;
+	crit_warn = hp->critical_warning.bits.volatile_memory_backup;
+	hs->bhs_volatile_mem_warning = crit_warn;
+	hs->bhs_media_errors = hp->media_errors;
 
 	/* Only print device health info to console if env is set */
 	if (getenv("PRINT_HEALTH_INFO") == NULL)
@@ -340,16 +360,16 @@ prep_cmd:
 	 * Submit an NVMe Admin command to get controller data
 	 * to the bdev.
 	 */
-	rc = spdk_bdev_nvme_admin_passthru(dev_health->bhm_desc,
-					   dev_health->bhm_io_channel,
+	rc = spdk_bdev_nvme_admin_passthru(dev_health->bdh_desc,
+					   dev_health->bdh_io_channel,
 					   &cmd,
-					   dev_health->bhm_ctrlr_buf,
+					   dev_health->bdh_ctrlr_buf,
 					   cp_sz,
 					   get_spdk_identify_ctrlr_completion,
 					   dev_health);
 	if (rc) {
 		D_ERROR("NVMe admin passthru (identify ctrlr), rc:%d\n", rc);
-		dev_health->bhm_inflights--;
+		dev_health->bdh_inflights--;
 	}
 
 out:
@@ -361,29 +381,32 @@ out:
 void
 bio_bs_monitor(struct bio_xs_context *ctxt, uint64_t now)
 {
-	struct bio_health_monitoring	*dev_health;
-	struct spdk_bdev		*bdev;
-	struct spdk_nvme_cmd		 cmd;
-	int				 rc;
-	uint32_t			 numd, numdl, numdu;
-	uint32_t			 health_page_sz;
+	struct bio_dev_health	*dev_health;
+	struct spdk_bdev	*bdev;
+	struct spdk_nvme_cmd	 cmd;
+	int			 rc;
+	uint32_t		 numd, numdl, numdu;
+	uint32_t		 health_page_sz;
 
 	D_ASSERT(ctxt != NULL);
 	D_ASSERT(ctxt->bxc_blobstore != NULL);
 	dev_health = &ctxt->bxc_blobstore->bb_dev_health;
-	D_ASSERT(dev_health->bhm_io_channel != NULL);
-	D_ASSERT(dev_health->bhm_desc != NULL);
+	D_ASSERT(dev_health->bdh_io_channel != NULL);
+	D_ASSERT(dev_health->bdh_desc != NULL);
 
 	/*
 	 * TODO Decide on an appropriate period to query device health
 	 * stats. Currently set at 1 min.
 	 */
-	if (dev_health->bhm_stat_age + DAOS_SPDK_STATS_PERIOD >= now)
+	if (dev_health->bdh_stat_age + DAOS_SPDK_STATS_PERIOD >= now)
 		return;
-	dev_health->bhm_stat_age = now;
+	dev_health->bdh_stat_age = now;
 
-	bdev = spdk_bdev_desc_get_bdev(dev_health->bhm_desc);
-	D_ASSERT(bdev != NULL);
+	bdev = spdk_bdev_desc_get_bdev(dev_health->bdh_desc);
+	if (bdev == NULL) {
+		D_ERROR("No bdev assoicated with device health descriptor\n");
+		return;
+	}
 
 	/* Return if non-NVMe device */
 	if (get_bdev_type(bdev) != BDEV_CLASS_NVME)
@@ -395,9 +418,9 @@ bio_bs_monitor(struct bio_xs_context *ctxt, uint64_t now)
 	}
 
 	/* Check to avoid parallel SPDK device health query calls */
-	if (dev_health->bhm_inflights)
+	if (dev_health->bdh_inflights)
 		return;
-	dev_health->bhm_inflights++;
+	dev_health->bdh_inflights++;
 
 	/* Prep NVMe command to get SPDK device health data */
 	health_page_sz = sizeof(struct spdk_nvme_health_information_page);
@@ -415,16 +438,16 @@ bio_bs_monitor(struct bio_xs_context *ctxt, uint64_t now)
 	 * Submit an NVMe Admin command to get device health log page
 	 * to the bdev.
 	 */
-	rc = spdk_bdev_nvme_admin_passthru(dev_health->bhm_desc,
-					   dev_health->bhm_io_channel,
+	rc = spdk_bdev_nvme_admin_passthru(dev_health->bdh_desc,
+					   dev_health->bdh_io_channel,
 					   &cmd,
-					   dev_health->bhm_health_buf,
+					   dev_health->bdh_health_buf,
 					   health_page_sz,
 					   get_spdk_log_page_completion,
 					   dev_health);
 	if (rc) {
 		D_ERROR("NVMe admin passthru (health log), rc:%d\n", rc);
-		dev_health->bhm_inflights--;
+		dev_health->bdh_inflights--;
 	}
 }
 
@@ -450,6 +473,7 @@ bio_xs_io_stat(struct bio_xs_context *ctxt, uint64_t now)
 		spdk_put_io_channel(channel);
 
 		bdev = spdk_bdev_desc_get_bdev(ctxt->bxc_desc);
+
 		D_ASSERT(bdev != NULL);
 
 		D_PRINT("SPDK IO STAT: xs_id[%d] dev[%s] read_bytes["DF_U64"], "
@@ -470,15 +494,15 @@ void
 bio_fini_health_monitoring(struct bio_blobstore *bb)
 {
 	/* Free NVMe admin passthru DMA buffers */
-	spdk_dma_free(bb->bb_dev_health.bhm_health_buf);
-	spdk_dma_free(bb->bb_dev_health.bhm_ctrlr_buf);
-	spdk_dma_free(bb->bb_dev_health.bhm_error_buf);
+	spdk_dma_free(bb->bb_dev_health.bdh_health_buf);
+	spdk_dma_free(bb->bb_dev_health.bdh_ctrlr_buf);
+	spdk_dma_free(bb->bb_dev_health.bdh_error_buf);
 
 	/* Release I/O channel reference */
-	spdk_put_io_channel(bb->bb_dev_health.bhm_io_channel);
+	spdk_put_io_channel(bb->bb_dev_health.bdh_io_channel);
 
 	/* Close device health monitoring descriptor */
-	spdk_bdev_close(bb->bb_dev_health.bhm_desc);
+	spdk_bdev_close(bb->bb_dev_health.bdh_desc);
 }
 
 /*
@@ -500,30 +524,30 @@ bio_init_health_monitoring(struct bio_blobstore *bb,
 	D_ASSERT(bdev != NULL);
 
 	hp_sz = sizeof(struct spdk_nvme_health_information_page);
-	bb->bb_dev_health.bhm_health_buf = spdk_dma_zmalloc(hp_sz, 0, NULL);
-	if (bb->bb_dev_health.bhm_health_buf == NULL)
+	bb->bb_dev_health.bdh_health_buf = spdk_dma_zmalloc(hp_sz, 0, NULL);
+	if (bb->bb_dev_health.bdh_health_buf == NULL)
 		return -DER_NOMEM;
 
 	cp_sz = sizeof(struct spdk_nvme_ctrlr_data);
-	bb->bb_dev_health.bhm_ctrlr_buf = spdk_dma_zmalloc(cp_sz, 0, NULL);
-	if (bb->bb_dev_health.bhm_ctrlr_buf == NULL) {
-		spdk_dma_free(bb->bb_dev_health.bhm_health_buf);
+	bb->bb_dev_health.bdh_ctrlr_buf = spdk_dma_zmalloc(cp_sz, 0, NULL);
+	if (bb->bb_dev_health.bdh_ctrlr_buf == NULL) {
+		spdk_dma_free(bb->bb_dev_health.bdh_health_buf);
 		return -DER_NOMEM;
 	}
 
 	ep_sz = sizeof(struct spdk_nvme_error_information_entry);
 	ep_buf_sz = ep_sz * DAOS_MAX_ERROR_LOG_PAGES;
-	bb->bb_dev_health.bhm_error_buf = spdk_dma_zmalloc(ep_buf_sz, 0, NULL);
-	if (bb->bb_dev_health.bhm_error_buf == NULL) {
-		spdk_dma_free(bb->bb_dev_health.bhm_health_buf);
-		spdk_dma_free(bb->bb_dev_health.bhm_ctrlr_buf);
+	bb->bb_dev_health.bdh_error_buf = spdk_dma_zmalloc(ep_buf_sz, 0, NULL);
+	if (bb->bb_dev_health.bdh_error_buf == NULL) {
+		spdk_dma_free(bb->bb_dev_health.bdh_health_buf);
+		spdk_dma_free(bb->bb_dev_health.bdh_ctrlr_buf);
 		return -DER_NOMEM;
 	}
 
 
 	 /* Writable descriptor required for device health monitoring */
 	rc = spdk_bdev_open(bdev, true, NULL, NULL,
-			    &bb->bb_dev_health.bhm_desc);
+			    &bb->bb_dev_health.bdh_desc);
 	if (rc != 0) {
 		D_ERROR("Failed to open bdev %s, %d\n",
 			spdk_bdev_get_name(bdev), rc);
@@ -531,11 +555,11 @@ bio_init_health_monitoring(struct bio_blobstore *bb,
 	}
 
 	/* Get and hold I/O channel for device health monitoring */
-	channel = spdk_bdev_get_io_channel(bb->bb_dev_health.bhm_desc);
+	channel = spdk_bdev_get_io_channel(bb->bb_dev_health.bdh_desc);
 	D_ASSERT(channel != NULL);
-	bb->bb_dev_health.bhm_io_channel = channel;
+	bb->bb_dev_health.bdh_io_channel = channel;
 
-	bb->bb_dev_health.bhm_inflights = 0;
+	bb->bb_dev_health.bdh_inflights = 0;
 
 	return 0;
 }

--- a/src/include/daos_srv/bio.h
+++ b/src/include/daos_srv/bio.h
@@ -87,23 +87,21 @@ struct bio_blob_hdr {
 };
 
 /*
- * Current device state (health statistics). Periodically updated in
+ * Current device health state (health statistics). Periodically updated in
  * bio_bs_monitor(). Used to determine faulty device status.
  */
-struct bio_device_health_state {
-	uint64_t	 bhs_timestamp;
-	int		 bhs_bio_err;
-	/* Health log page information */
-	uint64_t	*bhs_media_errors; /* supports 128-bit values */
-	uint16_t	 bhs_temperature; /* in Kelvin */
+struct bio_dev_state {
+	uint64_t	 bds_timestamp;
+	uint64_t	*bds_media_errors; /* supports 128-bit values */
+	uint64_t	 bds_error_count; /* error log page */
+	uint32_t	 bds_bio_err;
+	uint16_t	 bds_temperature; /* in Kelvin */
 	/* Critical warnings */
-	uint8_t		 bhs_temp_warning	: 1;
-	uint8_t		 bhs_avail_spare_warning	: 1;
-	uint8_t		 bhs_dev_reliabilty_warning : 1;
-	uint8_t		 bhs_read_only_warning	: 1;
-	uint8_t		 bhs_volatile_mem_warning: 1; /*volatile memory backup*/
-	/* Error log page */
-	uint64_t	 bhs_error_count;
+	uint8_t		 bds_temp_warning	: 1;
+	uint8_t		 bds_avail_spare_warning	: 1;
+	uint8_t		 bds_dev_reliabilty_warning : 1;
+	uint8_t		 bds_read_only_warning	: 1;
+	uint8_t		 bds_volatile_mem_warning: 1; /*volatile memory backup*/
 };
 
 static inline void

--- a/src/include/daos_srv/bio.h
+++ b/src/include/daos_srv/bio.h
@@ -86,6 +86,26 @@ struct bio_blob_hdr {
 	uuid_t		bbh_pool;
 };
 
+/*
+ * Current device state (health statistics). Periodically updated in
+ * bio_bs_monitor(). Used to determine faulty device status.
+ */
+struct bio_device_health_state {
+	uint64_t	 bhs_timestamp;
+	int		 bhs_bio_err;
+	/* Health log page information */
+	uint64_t	*bhs_media_errors; /* supports 128-bit values */
+	uint16_t	 bhs_temperature; /* in Kelvin */
+	/* Critical warnings */
+	uint8_t		 bhs_temp_warning	: 1;
+	uint8_t		 bhs_avail_spare_warning	: 1;
+	uint8_t		 bhs_dev_reliabilty_warning : 1;
+	uint8_t		 bhs_read_only_warning	: 1;
+	uint8_t		 bhs_volatile_mem_warning: 1; /*volatile memory backup*/
+	/* Error log page */
+	uint64_t	 bhs_error_count;
+};
+
 static inline void
 bio_addr_set(bio_addr_t *addr, uint16_t type, uint64_t off)
 {


### PR DESCRIPTION
Cached in DRAM for device owner xstream. This in-memory structure will be used as determining criteria for faulty device detection. The in-memory device state data includes the most useful health stats and warnings queried from SPDK SMART health logs from NVMe SSDs, and will be updated upon each bio_bs_monitor() polling event (which currently takes place every 60 sec). The in-memory device state stats will most likely get expanded later once faulty device criteria has been investigated further.

TODO:
- Add Blob I/O internal error code and checksum count to the in-memory device health state
- Add dmg command to query raw device health stats and display to console.

Signed-off-by: Sydney Vanda <sydney.m.vanda@intel.com>