### PR TITLE
DAOS-2787 cont: fix an cont_open handling

### DIFF
--- a/src/container/container_iv.c
+++ b/src/container/container_iv.c
@@ -653,7 +653,7 @@ cont_iv_capability_update(void *ns, uuid_t cont_hdl_uuid, uuid_t cont_uuid,
 
 	rc = cont_iv_update(ns, IV_CONT_CAPA, cont_hdl_uuid, &iv_entry,
 			    sizeof(struct cont_iv_entry),
-			    CRT_IV_SHORTCUT_TO_ROOT, CRT_IV_SYNC_LAZY);
+			    CRT_IV_SHORTCUT_TO_ROOT, CRT_IV_SYNC_EAGER);
 	return rc;
 }
 


### PR DESCRIPTION
1) Now in cont_open handling, it calls cont_iv_capability_update inside
   which do the IV update in lazy mode. And on other nodes it depends on
   cont_iv_capa_ent_update to do the ds_cont_tgt_open.
   So it is possible that when daos_cont_open() returns the above process
   is still pending.
2) And if user immediately do daos_cont_close, in server's
   cont_close_one_rec it cannot find it by cont_hdl_lookup_internal and
   treats it as cont already closed.
3) Here the pending ds_cont_tgt_open in step 1) possibly be executed.
4) Then if user do daos_cont_destroy(), it found un-released ref for cont.

This patch fix it by do the cont_iv_capability_update in EAGER mode, to
make sure 3) happens at step 1).

Probably can refine it by not do the ds_cont_tgt_open in IV path later.

Signed-off-by: Xuezhao Liu <xuezhao.liu@intel.com>