### PR TITLE
CORCI-705 build: Don't build non-PR branches

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -85,6 +85,13 @@ def rpm_test_daos_test = '''me=\\\$(whoami)
                             trap 'set -x; kill -INT \\\$AGENT_PID \\\$COPROC_PID' EXIT
                             orterun -np 1 -x OFI_INTERFACE=eth0 -x CRT_ATTACH_INFO_PATH=/tmp -x DAOS_SINGLETON_CLI=1 daos_test -m'''
 
+// bail out of branch builds that are not on a whitelist
+if (!env.CHANGE_ID &&
+    env.BRANCH_NAME != "master") {
+   currentBuild.result = 'SUCCESS'
+   return
+}
+
 pipeline {
     agent { label 'lightweight' }
 


### PR DESCRIPTION
Due to JENKINS-56255 we frequently get the branch build for a PR. Moreover this
branch build's statuses can pollute the PR build statuses in github.

Bail out of the pipeline if the build is not for a PR and is not for a white-
listed branch (i.e. master at the moment).