### PR TITLE
DAOS-2817 test: Create a unique daos log name for each test

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -928,7 +928,9 @@ pipeline {
                                                OLD_CI=false utils/run_test.sh
                                                rm -rf run_test.sh/
                                                mkdir run_test.sh/
-                                               [ -f /tmp/daos.log ] && mv /tmp/daos.log run_test.sh/
+                                               if ls /tmp/daos*.log > /dev/null; then
+                                                   mv /tmp/daos*.log run_test.sh/
+                                               fi
                                                # servers can sometimes take a while to stop when the test is done
                                                x=0
                                                while [ \"\\\$x\" -lt \"10\" ] &&

--- a/utils/run_test.sh
+++ b/utils/run_test.sh
@@ -19,10 +19,7 @@
 #check for existence of /mnt/daos first:
 failed=0
 failures=()
-
-if [ -d /work ]; then
-    export D_LOG_FILE=/work/daos.log
-fi
+log_num=0
 
 # this can be rmeoved once we are no longer using the old CI system
 if ${OLD_CI:-true}; then
@@ -43,6 +40,12 @@ fi
 
 run_test()
 {
+    in="$*"
+    a="${in// /-}"
+    b="${a////-}"
+    export D_LOG_FILE="/tmp/daos_${b}-${log_num}.log"
+    echo "Running $* with log file: ${D_LOG_FILE}"
+
     # We use flock as a way of locking /mnt/daos so multiple runs can't hit it
     #     at the same time.
     # We use grep to filter out any potential "SUCCESS! NO TEST FAILURES"
@@ -56,6 +59,8 @@ run_test()
         ((failed = failed + 1))
         failures+=("$*")
     fi
+
+    ((log_num += 1))
 }
 
 if [ -d "/mnt/daos" ]; then

--- a/utils/run_test.sh
+++ b/utils/run_test.sh
@@ -40,9 +40,9 @@ fi
 
 run_test()
 {
-    in="$*"
-    a="${in// /-}"
-    b="${a////-}"
+    local in="$*"
+    local a="${in// /-}"
+    local b="${a////-}"
     export D_LOG_FILE="/tmp/daos_${b}-${log_num}.log"
     echo "Running $* with log file: ${D_LOG_FILE}"
 


### PR DESCRIPTION
In order to facilitate finding issues, it's best if we can
limit our search to the specific unit test's log rather than
having all logs concatenated together.