### PR TITLE
DAOS-2849 evtree: adjust 'ne' position in evt_node_delete()

### DIFF
--- a/src/vos/evtree.c
+++ b/src/vos/evtree.c
@@ -2882,8 +2882,12 @@ evt_node_delete(struct evt_context *tcx, bool remove)
 			continue;
 
 		changed_level = level;
-		if (offset < 0)
+		if (offset < 0) {
+			D_ASSERTF(trace->tr_at >= -offset,
+				  "at:%u, offset:%d\n", trace->tr_at, offset);
 			trace->tr_at += offset;
+			ne = evt_node_entry_at(tcx, node, trace->tr_at);
+		}
 	}
 
 fix_trace:
@@ -2914,7 +2918,7 @@ int evt_delete(daos_handle_t toh, const struct evt_rect *rect,
 		return rc;
 
 	if (ent_array.ea_ent_nr == 0)
-		return -DER_NONEXIST;
+		return -DER_ENOENT;
 
 	D_ASSERT(ent_array.ea_ent_nr == 1);
 	if (ent != NULL)


### PR DESCRIPTION
When fixing trace in evt_node_delete(), the position of rect entry
wasn't updated accordingly, that'll result in wrong MBR calculation.

This is the root cause of the occasional evtree aggregation failure
when new dist split algorithm enabled. With old split algorithm, all
the rectangles within the node are sorted in ascending order, so the
defect didn't cause trouble until we switch to new split algorithm.

This patch also reverted an error code in evt_delete() back to
-DER_ENOENT, because -DER_NONEXIST will be ignored by vos_iterate()
and the evtree aggregation failure will be covered up.

Signed-off-by: Niu Yawei <yawei.niu@intel.com>
Change-Id: I4b38d30ae34dcd8e01e96d0911955ae7aa0dca91