### PR TITLE
DAOS-2877 Docs: Add TransportConfig documentation and update deployme…

### DIFF
--- a/doc/admin/deployment.md
+++ b/doc/admin/deployment.md
@@ -1239,8 +1239,8 @@ log\_file: /tmp/daos\_agent2.log
 
 DAOS Agent is a standalone application to be run on each compute node.
 It can be configured to use secure communications (default) or can be allowed
-to communicate with the control plane over unencrypted channels. The following 
-example shows daos_agent being configured to operate in insecure mode due to 
+to communicate with the control plane over unencrypted channels. The following
+example shows daos_agent being configured to operate in insecure mode due to
 incomplete integration of certificate support as of the 0.6 release.
 
 To start the DAOS Agent, run:

--- a/doc/admin/deployment.md
+++ b/doc/admin/deployment.md
@@ -318,7 +318,10 @@ nodes before starting it.
 
 The DAOS security framework relies on certificates to authenticate
 administrators. The security infrastructure is currently under
-development and will be delivered in DAOS v1.0. Initial support for certificates has been added to DAOS and can be disable either via the command line or in the DAOS server configuration file.
+development and will be delivered in DAOS v1.0. Initial support for certificates
+has been added to DAOS and can be disabled either via the command line or in the
+DAOS server configuration file. Currently the easiest way to disable certificate
+support is to pass the -i flag to daos\_server.
 
 ### Server Configuration File
 
@@ -385,7 +388,9 @@ port: 10001
 
 **Transport Certificate Credentials**
 
-Certificate support for securing the administrative channel for the DAOS components is specified in a key called transport_config: It contains the following keys with these default values
+Certificate support for securing the administrative channel for the DAOS
+components is specified in a key called transport_config: It contains the
+following keys with these default values
 
 
 ***Allow Insecure Communications***
@@ -1122,7 +1127,10 @@ nodes before starting it.
 
 The DAOS security framework relies on certificates to authenticate
 administrators. The security infrastructure is currently under
-development and will be delivered in DAOS v1.0. Initial support for certificates has been added to DAOS and can be disable either via the command line or in the DAOS Agent configuration file.
+development and will be delivered in DAOS v1.0. Initial support for certificates
+has been added to DAOS and can be disabled either via the command line or in the
+DAOS Agent configuration file. Currently the easiest way to disable certificate
+support is to pass the -i flag to daos\_agent.
 
 ### Agent Configuration File
 
@@ -1186,7 +1194,9 @@ port: 10001
 
 **Transport Certificate Credentials**
 
-Certificate support for securing the administrative channel for the DAOS components is specified in a key called transport_config: It contains the following keys with these default values
+Certificate support for securing the administrative channel for the DAOS
+components is specified in a key called transport_config: It contains the
+following keys with these default values
 
 
 ***Allow Insecure Communications***
@@ -1211,7 +1221,8 @@ key: ./.daos/daos\_agent.key
 
 **Use the given directory for creating unix domain sockets**
 
-DAOS Agent uses unix domain sockets for communication with other system components. This setting is the base location to place the sockets in.
+DAOS Agent uses unix domain sockets for communication with other system
+components. This setting is the base location to place the sockets in.
 
 default: /var/run/daos\_agent
 
@@ -1226,7 +1237,11 @@ log\_file: /tmp/daos\_agent2.log
 ## Agent Startup
 --------------
 
-DAOS Agent is a standalone application to be run on each compute node. It can be configured to use secure communications (default) or can be allowed to communicate with the control plane over unencrypted channels. The example below for executing daos_agent specifies to operate in insecure mode as certificate support is not fully integrated into DAOS as of 0.6
+DAOS Agent is a standalone application to be run on each compute node.
+It can be configured to use secure communications (default) or can be allowed
+to communicate with the control plane over unencrypted channels. The example
+below for executing daos_agent specifies to operate in insecure mode as
+certificate support is not fully integrated into DAOS as of 0.6
 
 To start the DAOS Agent, run:
 ```
@@ -1237,7 +1252,8 @@ System Validation
 -----------------
 
 To validate that the DAOS system is properly installed, the daos\_test
-suite can be executed. Ensure the DAOS Agent is configuerd and running before running daos\_test:
+suite can be executed. Ensure the DAOS Agent is configuered and running before
+running daos\_test:
 
 [[]{#_Toc4574315 .anchor}]{#_Toc4572376 .anchor}orterun -np
 &lt;num\_clients&gt; --hostfile \${hostfile} --ompi-server

--- a/doc/admin/deployment.md
+++ b/doc/admin/deployment.md
@@ -1196,7 +1196,7 @@ port: 10001
 
 Certificate support for securing the administrative channel for the DAOS
 components is specified in a key called transport_config: It contains the
-following keys with these default values
+following keys with these default values.
 
 
 ***Allow Insecure Communications***
@@ -1239,9 +1239,9 @@ log\_file: /tmp/daos\_agent2.log
 
 DAOS Agent is a standalone application to be run on each compute node.
 It can be configured to use secure communications (default) or can be allowed
-to communicate with the control plane over unencrypted channels. The example
-below for executing daos_agent specifies to operate in insecure mode as
-certificate support is not fully integrated into DAOS as of 0.6
+to communicate with the control plane over unencrypted channels. The following 
+example shows daos_agent being configured to operate in insecure mode due to 
+incomplete integration of certificate support as of the 0.6 release.
 
 To start the DAOS Agent, run:
 ```
@@ -1252,7 +1252,7 @@ System Validation
 -----------------
 
 To validate that the DAOS system is properly installed, the daos\_test
-suite can be executed. Ensure the DAOS Agent is configuered and running before
+suite can be executed. Ensure the DAOS Agent is configured and running before
 running daos\_test:
 
 [[]{#_Toc4574315 .anchor}]{#_Toc4572376 .anchor}orterun -np


### PR DESCRIPTION
…nt document

When the initial certificate code was merged some copyright notices and code
documentation was overlooked. This adds that documentation and reflects those
changes in the deployment document.

Signed-off-by: David Quigley <david.quigley@intel.com>