### PR TITLE
DAOS-2429 object: predict to fetch from leader replica

### DIFF
--- a/src/include/daos/common.h
+++ b/src/include/daos/common.h
@@ -517,4 +517,16 @@ daos_unparse_ctype(daos_cont_layout_t ctype, char *string)
 	}
 }
 
+static inline int daos_gettime_coarse(uint64_t *time)
+{
+	struct timespec	now;
+	int		rc;
+
+	rc = clock_gettime(CLOCK_MONOTONIC_COARSE, &now);
+	if (rc == 0)
+		*time = now.tv_sec;
+
+	return rc;
+}
+
 #endif /* __DAOS_COMMON_H__ */

--- a/src/object/obj_internal.h
+++ b/src/object/obj_internal.h
@@ -115,6 +115,12 @@ struct dc_object {
 	unsigned int		 cob_version;
 	unsigned int		 cob_shards_nr;
 	unsigned int		 cob_grp_size;
+	unsigned int		 cob_grp_nr;
+	/**
+	 * The array for the latest time (in second) of
+	 * being asked to fetch from leader.
+	 */
+	uint64_t		*cob_time_fetch_leader;
 	/** shard object ptrs */
 	struct dc_obj_layout	*cob_shards;
 };

--- a/src/vea/vea_alloc.c
+++ b/src/vea/vea_alloc.c
@@ -431,7 +431,7 @@ persistent_alloc(struct vea_space_info *vsi, struct vea_free_extent *vfe)
 	if (found_end > vfe_end) {
 		frag.vfe_blk_off = vfe->vfe_blk_off + vfe->vfe_blk_cnt;
 		frag.vfe_blk_cnt = found_end - vfe_end;
-		rc = get_current_age(&frag.vfe_age);
+		rc = daos_gettime_coarse(&frag.vfe_age);
 		if (rc)
 			return rc;
 

--- a/src/vea/vea_free.c
+++ b/src/vea/vea_free.c
@@ -160,7 +160,7 @@ compound_free(struct vea_space_info *vsi, struct vea_free_extent *vfe,
 	dummy.ve_ext = *vfe;
 
 	if (flags & VEA_FL_GEN_AGE) {
-		rc = get_current_age(&cur_time);
+		rc = daos_gettime_coarse(&cur_time);
 		if (rc)
 			return rc;
 		dummy.ve_ext.vfe_age = cur_time;
@@ -268,7 +268,7 @@ aggregated_free(struct vea_space_info *vsi, struct vea_free_extent *vfe)
 	memset(&dummy, 0, sizeof(dummy));
 	D_INIT_LIST_HEAD(&dummy.ve_link);
 	dummy.ve_ext = *vfe;
-	rc = get_current_age(&dummy.ve_ext.vfe_age);
+	rc = daos_gettime_coarse(&dummy.ve_ext.vfe_age);
 	if (rc)
 		return rc;
 
@@ -325,7 +325,7 @@ migrate_end_cb(void *data, bool noop)
 	if (noop)
 		return;
 
-	rc = get_current_age(&cur_time);
+	rc = daos_gettime_coarse(&cur_time);
 	if (rc)
 		return;
 
@@ -436,7 +436,7 @@ migrate_free_exts(struct vea_space_info *vsi)
 	 * Check aggregation time in advance to avoid unnecessary
 	 * umem_tx_add_callback() calls.
 	 */
-	rc = get_current_age(&cur_time);
+	rc = daos_gettime_coarse(&cur_time);
 	if (rc)
 		return;
 

--- a/src/vea/vea_internal.h
+++ b/src/vea/vea_internal.h
@@ -141,19 +141,6 @@ static inline bool ext_is_idle(struct vea_free_extent *vfe)
 	return vfe->vfe_age == VEA_EXT_AGE_MAX;
 }
 
-static inline int get_current_age(uint64_t *age)
-{
-	struct timespec now;
-	int rc;
-
-	rc = clock_gettime(CLOCK_MONOTONIC_COARSE, &now);
-	if (rc != 0)
-		return rc;
-	*age = now.tv_sec;
-
-	return 0;
-}
-
 enum vea_free_flags {
 	VEA_FL_NO_MERGE		= (1 << 0),
 	VEA_FL_GEN_AGE		= (1 << 1),


### PR DESCRIPTION
If the client has been asked to fetch (list/query) from leader replica,
then means that related data is associated with some prepared DTX that
may be committable on the leader replica. According to our current DTX
batched commit policy, it is quite possible that such DTX is not ready
to be committed, or it is committable but cached on the leader replica
for some time. On the other hand, such DTX may contain more data update
than current fetch. If the subsequent fetch against the same redundancy
group comes very soon (less than OBJ_FETCH_LEADER_INTERVAL), then it is
possible that related target for the next fetch is convered by the same
DTX that is still not committed yet. If the assumption is right, asking
the application to fetch from leader replica directly can avoid one RPC
round-trip with non-leader replica. But if such assumption is not right,
it will not affect the fetch result, but will increase the leader server
load in a short time.

Signed-off-by: Fan Yong <fan.yong@intel.com>