### PR TITLE
DAOS-2902 Security: Fixes for Certificate Generation support

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -102,6 +102,9 @@ def scons():
     # install the configuration files
     SConscript('utils/config/SConscript')
 
+    # install certificate generation files
+    SConscript('utils/certs/SConscript')
+
     Default('build')
     Depends('install', 'build')
 

--- a/utils/certs/SConscript
+++ b/utils/certs/SConscript
@@ -1,4 +1,4 @@
-"""Build DAOS config"""
+"""Build DAOS Certificate Generation"""
 import os
 
 def scons():

--- a/utils/certs/SConscript
+++ b/utils/certs/SConscript
@@ -1,0 +1,12 @@
+"""Build DAOS config"""
+import os
+
+def scons():
+    """Execute build"""
+    Import('env')
+
+    env.Install("$PREFIX/lib/daos/certgen", ['admin.cnf', 'agent.cnf', 'ca.cnf',
+                                             'server.cnf', 'gen_certificates.sh'])
+
+if __name__ == "SCons.Script":
+    scons()

--- a/utils/certs/ca.cnf
+++ b/utils/certs/ca.cnf
@@ -12,7 +12,7 @@ certificate		= $dir/daosCA.crt
 private_key		= $dir/private/daosCA.key
 
 default_md		= sha512	# SAFE Crypto Requires SHA-512
-default_days		= 365		# how long to certify for
+default_days		= 3650		# how long to certify for
 copy_extensions		= copy
 unique_subject		= no
 

--- a/utils/certs/gen_certificates.sh
+++ b/utils/certs/gen_certificates.sh
@@ -58,7 +58,7 @@ function generate_ca_cert () {
 	openssl genrsa -out $PRIVATE/daosCA.key 4096
 	chmod 400 $PRIVATE/daosCA.key
 	# Generate CA Certificate
-	openssl req -new -x509 -config ca.cnf -days 3650 \
+	openssl req -new -x509 -config ca.cnf -days 3650 -sha512 \
 		-key $PRIVATE/daosCA.key \
 		-out $CERTS/daosCA.crt -batch
 	# Reset the the CA index

--- a/utils/certs/gen_certificates.sh
+++ b/utils/certs/gen_certificates.sh
@@ -40,7 +40,6 @@
 __usage="
 Usage: gen_certificates.sh [OPTIONS]
 Generate certificates for DAOS deployment in the ./daosCA.
-Certificates will be named in the format daos_Component
 "
 
 function print_usage () {
@@ -59,7 +58,8 @@ function generate_ca_cert () {
 	openssl genrsa -out $PRIVATE/daosCA.key 4096
 	chmod 400 $PRIVATE/daosCA.key
 	# Generate CA Certificate
-	openssl req -new -x509 -config ca.cnf -key $PRIVATE/daosCA.key \
+	openssl req -new -x509 -config ca.cnf -days 3650 \
+		-key $PRIVATE/daosCA.key \
 		-out $CERTS/daosCA.crt -batch
 	# Reset the the CA index
 	rm -f ./daosCA/index.txt ./daosCA/serial.txt

--- a/utils/config/examples/daos_server_psm2.yml
+++ b/utils/config/examples/daos_server_psm2.yml
@@ -12,6 +12,18 @@ control_log_file: /tmp/daos_control.log
 # user_name: daosuser
 # group_name: daosgroup # (optional)
 
+## Transport Credentials Specifying certificates to secure communications
+##
+#transport_config:
+#  # Specify to bypass loading certificates and use insecure communications channnels
+#  allow_insecure: false
+#  # Custom CA Root certificate for generated certs
+#  ca_cert: .daos/daosCA.crt
+#  # Server certificate for use in TLS handshakes
+#  cert: .daos/daos_server.crt
+#  # Key portion of Server Certificate
+#  key: .daos/daos_server.key
+
 # single server instance per config file for now
 servers:
 -

--- a/utils/config/examples/daos_server_sockets.yml
+++ b/utils/config/examples/daos_server_sockets.yml
@@ -12,6 +12,18 @@ control_log_file: /tmp/daos_control.log
 # user_name: daosuser
 # group_name: daosgroup # (optional)
 
+## Transport Credentials Specifying certificates to secure communications
+##
+#transport_config:
+#  # Specify to bypass loading certificates and use insecure communications channnels
+#  allow_insecure: false
+#  # Custom CA Root certificate for generated certs
+#  ca_cert: .daos/daosCA.crt
+#  # Server certificate for use in TLS handshakes
+#  cert: .daos/daos_server.crt
+#  # Key portion of Server Certificate
+#  key: .daos/daos_server.key
+
 # single server instance per config file for now
 servers:
 -

--- a/utils/config/examples/daos_server_unittests.yml
+++ b/utils/config/examples/daos_server_unittests.yml
@@ -7,6 +7,18 @@ socket_dir: /tmp/daos_sockets
 control_log_mask: DEBUG
 control_log_file: /tmp/daos_control.log
 
+## Transport Credentials Specifying certificates to secure communications
+##
+#transport_config:
+#  # Specify to bypass loading certificates and use insecure communications channnels
+#  allow_insecure: false
+#  # Custom CA Root certificate for generated certs
+#  ca_cert: .daos/daosCA.crt
+#  # Server certificate for use in TLS handshakes
+#  cert: .daos/daos_server.crt
+#  # Key portion of Server Certificate
+#  key: .daos/daos_server.key
+
 # single server instance per config file for now
 servers:
 -

--- a/utils/rpms/daos.spec
+++ b/utils/rpms/daos.spec
@@ -5,7 +5,7 @@
 
 Name:          daos
 Version:       0.6.0
-Release:       1%{?dist}
+Release:       2%{?dist}
 Summary:       DAOS Storage Engine
 
 License:       Apache
@@ -54,6 +54,7 @@ Requires: fuse >= 3.4.2
 Requires: protobuf-c
 Requires: spdk
 Requires: fio < 3.4
+Requires: openssl
 
 %description
 The Distributed Asynchronous Object Storage (DAOS) is an open-source
@@ -128,7 +129,8 @@ PREFIX="%{?_prefix}"
 sed -i -e s/${BUILDROOT//\//\\/}[^\"]\*/${PREFIX//\//\\/}/g %{?buildroot}%{_prefix}/TESTING/.build_vars.*
 mv %{?buildroot}%{_prefix}/lib{,64}
 #mv %{?buildroot}/{usr/,}etc
-mkdir -p %{?buildroot}/%{daoshome}
+mkdir -p %{?buildroot}/%{_exec_prefix}/lib/%{name}
+mv %{?buildroot}%{_prefix}/lib64/daos %{?buildroot}/%{_exec_prefix}/lib/
 mv %{?buildroot}%{_prefix}/{TESTING,lib/%{name}/}
 cp -al ftest.sh src/tests/ftest %{?buildroot}%{daoshome}/TESTING
 find %{?buildroot}%{daoshome}/TESTING/ftest -name \*.py[co] -print0 | xargs -r0 rm -f
@@ -162,6 +164,8 @@ echo "%{_libdir}/daos_srv" > %{?buildroot}/%{_sysconfdir}/ld.so.conf.d/daos.conf
 %{_libdir}/libdaos_common.so
 # TODO: this should move to %{_libdir}/daos/libplacement.so
 %{_libdir}/daos_srv/libplacement.so
+# Certificate generation files
+%{daoshome}/certgen/
 %doc
 
 %files server
@@ -222,13 +226,16 @@ echo "%{_libdir}/daos_srv" > %{?buildroot}/%{_sysconfdir}/ld.so.conf.d/daos.conf
 %{_libdir}/*.a
 
 %changelog
+* Thu Jul 18 2019 David Quigley <david.quigley@intel.com>
+- Add certificate generation files to packaging.
+
 * Tue Jul 9 2019 Johann Lombardi <johann.lombardi@intel.com>
 - Version bump up to 0.6.0
 
 * Fri Jun 21 2019 David Quigley <dquigley@intel.com>
 - Add daos_agent.yml to the list of packaged files
 
-* Thu Jun 12 2019 Brian J. Murrell <brian.murrell@intel.com>
+* Thu Jun 13 2019 Brian J. Murrell <brian.murrell@intel.com>
 - move obj_ctl daos_gen_io_conf daos_run_io_conf to
   daos-tests sub-package
 - daos-server needs spdk-tools


### PR DESCRIPTION
Certificate generation and config examples needed some fixing to enable longer
certificate default lifetime. Also the rpm specs have been updated to package
these scripts and config files.

Signed-off-by: David Quigley <david.quigley@intel.com>