### PR TITLE
DAOS-2215: NVMe test Plan: IO: Unaligned IO (Update daos_run_io_conf and daos_generate_io_conf.)

### DIFF
--- a/src/tests/suite/daos_epoch_io.c
+++ b/src/tests/suite/daos_epoch_io.c
@@ -848,13 +848,13 @@ cmd_parse_punch(test_arg_t *arg, int argc, char **argv,
 {
 	struct test_op_record	*op_rec;
 	struct test_punch_arg	*pu_arg;
-	char					*dkey = NULL;
-	char					*akey = NULL;
-	daos_recx_t				*recxs = NULL;
-	unsigned int			recxs_num;
-	int						tx = 1;
-	int						opt;
-	int						rc = 0;
+	char			*dkey = NULL;
+	char			*akey = NULL;
+	daos_recx_t		*recxs = NULL;
+	unsigned int		recxs_num;
+	int			tx = 1;
+	int			opt;
+	int			rc = 0;
 
 	static struct epoch_io_cmd_option options[] = {
 		{"--dkey",	true,	'd'},

--- a/src/tests/suite/daos_epoch_io.c
+++ b/src/tests/suite/daos_epoch_io.c
@@ -166,15 +166,15 @@ daos_test_cb_uf(test_arg_t *arg, struct test_op_record *op, char **rbuf,
 	struct test_update_fetch_arg	*uf_arg = &op->uf_arg;
 	const char			*dkey = key_rec->or_dkey;
 	const char			*akey = key_rec->or_akey;
-	daos_size_t			iod_size = key_rec->or_iod_size;
-	bool				array = uf_arg->ua_array;
-	daos_iod_type_t			iod_type;
-	daos_size_t			buf_size;
+	daos_size_t			 iod_size = key_rec->or_iod_size;
+	bool				 array = uf_arg->ua_array;
+	daos_iod_type_t			 iod_type;
+	daos_size_t			 buf_size;
 	char				*buf = NULL;
-	struct ioreq			req;
-	int				rc = 0;
-	daos_handle_t			th_open;
-	daos_epoch_t		        snap_epoch;
+	struct ioreq			 req;
+	int				 rc = 0;
+	daos_handle_t			 th_open;
+	daos_epoch_t		         snap_epoch;
 
 	if (array)
 		D_ASSERT(uf_arg->ua_recxs != NULL && uf_arg->ua_recx_num >= 1);
@@ -941,7 +941,7 @@ cmd_parse_update_fetch(test_arg_t *arg, int argc, char **argv, int opc,
 		{"--recx",	true,	'r'},
 		{"--verify",	false,	'v'},
 		{"--value",	true,	'u'},
-		{"--snap", false, 't'},
+		{"--snap",      false,  't'},
 		{0}
 	};
 
@@ -1408,7 +1408,7 @@ io_conf_run(test_arg_t *arg, const char *io_conf)
 	char			cmd_line[CMD_LINE_LEN_MAX] = {};
 	int			rc = 0;
 	/*Array for snapshot epoch*/
-	daos_epoch_t		sn_epoch[MAX_EPOCH_TIMES] = {};
+	daos_epoch_t		sn_epoch[DTS_MAX_EPOCH_TIMES] = {};
 
 	if (io_conf == NULL || strlen(io_conf) == 0) {
 		print_message("invalid io_conf.\n");
@@ -1426,12 +1426,10 @@ io_conf_run(test_arg_t *arg, const char *io_conf)
 
 	do {
 		memset(cmd_line, 0, CMD_LINE_LEN_MAX);
-
 		if (cmd_line_get(fp, cmd_line) != 0)
 			break;
 
 		rc = cmd_line_parse(arg, cmd_line, &op);
-
 		if (rc != 0) {
 			print_message("bad cmd_line %s, exit.\n", cmd_line);
 			break;

--- a/src/tests/suite/daos_epoch_io.c
+++ b/src/tests/suite/daos_epoch_io.c
@@ -798,8 +798,8 @@ cmd_parse_add_exclude(test_arg_t *arg, int argc, char **argv,
 {
 	struct test_op_record		*op_rec = NULL;
 	struct test_add_exclude_arg	*ae_arg;
-	int				opt;
-	int				rc = 0;
+	int				 opt;
+	int				 rc = 0;
 
 	static struct epoch_io_cmd_option options[] = {
 		{"--rank",	true,	'r'},
@@ -851,10 +851,10 @@ cmd_parse_punch(test_arg_t *arg, int argc, char **argv,
 	char			*dkey = NULL;
 	char			*akey = NULL;
 	daos_recx_t		*recxs = NULL;
-	unsigned int		recxs_num;
-	int			tx = 1;
-	int			opt;
-	int			rc = 0;
+	unsigned int		 recxs_num;
+	int			 tx = 1;
+	int			 opt;
+	int			 rc = 0;
 
 	static struct epoch_io_cmd_option options[] = {
 		{"--dkey",	true,	'd'},
@@ -925,13 +925,13 @@ cmd_parse_update_fetch(test_arg_t *arg, int argc, char **argv, int opc,
 	struct test_update_fetch_arg	*uf_arg;
 	daos_recx_t			*recxs = NULL;
 	int				*values = NULL;
-	unsigned int			recx_num = 0;
+	unsigned int			 recx_num = 0;
 	char				*dkey = NULL;
 	char				*akey = NULL;
-	int				tx = 1;
-	bool				array = true;
-	int				opt;
-	int				rc = 0;
+	int				 tx = 1;
+	bool				 array = true;
+	int				 opt;
+	int				 rc = 0;
 
 	static struct epoch_io_cmd_option options[] = {
 		{"--dkey",	true,	'd'},
@@ -1031,11 +1031,11 @@ static int
 cmd_parse_oid(test_arg_t *arg, int argc, char **argv)
 {
 	struct epoch_io_args	*eio_arg = &arg->eio_args;
-	int			opt;
+	int			 opt;
 	char			*obj_class = NULL;
-	int			type;
-	d_rank_t		rank = -1;
-	int			rc = 0;
+	int			 type;
+	d_rank_t		 rank = -1;
+	int			 rc = 0;
 
 	static struct epoch_io_cmd_option options[] = {
 		{"--type",	true,	't'},
@@ -1126,10 +1126,10 @@ static int
 cmd_parse_pool(test_arg_t *arg, int argc, char *argv[],
 	       struct test_op_record **op)
 {
-	struct test_op_record		*op_rec = NULL;
-	int				opc = -1;
-	int				opt;
-	int				rc = 0;
+	struct test_op_record	*op_rec = NULL;
+	int			 opc = -1;
+	int			 opt;
+	int			 rc = 0;
 
 	static struct epoch_io_cmd_option options[] = {
 		{"--query",	false,	'q'},
@@ -1405,8 +1405,8 @@ io_conf_run(test_arg_t *arg, const char *io_conf)
 {
 	struct test_op_record	*op = NULL;
 	FILE			*fp;
-	char			cmd_line[CMD_LINE_LEN_MAX] = {};
-	int			rc = 0;
+	char			 cmd_line[CMD_LINE_LEN_MAX] = {};
+	int			 rc = 0;
 	/*Array for snapshot epoch*/
 	daos_epoch_t		sn_epoch[DTS_MAX_EPOCH_TIMES] = {};
 

--- a/src/tests/suite/daos_epoch_io.c
+++ b/src/tests/suite/daos_epoch_io.c
@@ -757,7 +757,7 @@ test_key_rec_add_op(struct test_key_record *key_rec,
 		d_list_add_tail(&op_rec->or_queue_link, &rec->or_queue_link);
 		key_rec->or_op_num++;
 #if CMD_LINE_DBG
-		print_message("added op %d, epoch "DF_U64", dkey %s akey %s, "
+		print_message("added op %d, tx %d, dkey %s akey %s, "
 			      "to queue, op_num %d.\n", op_rec->or_op,
 			      op_rec->tx, key_rec->or_dkey,
 			      key_rec->or_akey, key_rec->or_op_num);

--- a/src/tests/suite/daos_epoch_io.c
+++ b/src/tests/suite/daos_epoch_io.c
@@ -166,13 +166,15 @@ daos_test_cb_uf(test_arg_t *arg, struct test_op_record *op, char **rbuf,
 	struct test_update_fetch_arg	*uf_arg = &op->uf_arg;
 	const char			*dkey = key_rec->or_dkey;
 	const char			*akey = key_rec->or_akey;
-	daos_size_t			 iod_size = key_rec->or_iod_size;
-	bool				 array = uf_arg->ua_array;
-	daos_iod_type_t			 iod_type;
-	daos_size_t			 buf_size;
+	daos_size_t			iod_size = key_rec->or_iod_size;
+	bool				array = uf_arg->ua_array;
+	daos_iod_type_t			iod_type;
+	daos_size_t			buf_size;
 	char				*buf = NULL;
-	struct ioreq			 req;
-	int				 rc = 0;
+	struct ioreq			req;
+	int				rc = 0;
+	daos_handle_t			th_open;
+	daos_epoch_t		        snap_epoch;
 
 	if (array)
 		D_ASSERT(uf_arg->ua_recxs != NULL && uf_arg->ua_recx_num >= 1);
@@ -193,22 +195,42 @@ daos_test_cb_uf(test_arg_t *arg, struct test_op_record *op, char **rbuf,
 			      uf_arg->ua_values ? uf_arg->ua_recx_num : 1,
 			      iod_size);
 
-	if (array) {
-		if (op->or_op == TEST_OP_UPDATE)
+	if (op->or_op == TEST_OP_UPDATE)
+		test_buf_init(buf, buf_size, uf_arg->ua_recxs,
+			      uf_arg->ua_values ?: &uf_arg->ua_single_value,
+			      uf_arg->ua_values ? uf_arg->ua_recx_num : 1,
+			      iod_size);
+
+	if (op->or_op == TEST_OP_UPDATE) {
+		if (array)
 			insert_recxs(dkey, akey, iod_size, DAOS_TX_NONE,
 				     uf_arg->ua_recxs, uf_arg->ua_recx_num, buf,
 				     buf_size, &req);
 		else
-			lookup_recxs(dkey, akey, iod_size, DAOS_TX_NONE,
-				     uf_arg->ua_recxs, uf_arg->ua_recx_num, buf,
-				     buf_size, &req);
-	} else {
-		if (op->or_op == TEST_OP_UPDATE)
 			insert_single(dkey, akey, 0, buf, buf_size,
 				      DAOS_TX_NONE, &req);
+		/*Take the snapshot*/
+		if (uf_arg->snap == true) {
+			rc = daos_cont_create_snap(arg->coh, &snap_epoch, NULL,
+						   NULL);
+			*op->snap_epoch  = snap_epoch;
+		}
+	} else{
+		th_open = DAOS_TX_NONE;
+		/*Open snapshot and read the data from snapshot epoch*/
+		if (uf_arg->snap == true) {
+			rc = daos_tx_open_snap(arg->coh, *op->snap_epoch,
+					       &th_open, NULL);
+			D_ASSERT(rc == 0);
+			}
+		if (array)
+			lookup_recxs(dkey, akey, iod_size, th_open,
+				uf_arg->ua_recxs,
+				uf_arg->ua_recx_num, buf, buf_size,
+				&req);
 		else
-			lookup_single(dkey, akey, 0, buf, buf_size,
-				      DAOS_TX_NONE, &req);
+			lookup_single(dkey, akey, 0, buf, buf_size, th_open,
+				      &req);
 	}
 
 	if (uf_arg->ua_verify)
@@ -346,9 +368,20 @@ daos_test_cb_query(test_arg_t *arg, struct test_op_record *op,
 	daos_pool_info_t pinfo = { 0 };
 	int rc;
 
+	/*get only pool space info*/
+	pinfo.pi_bits = DPI_SPACE;
 	rc = daos_pool_query(arg->pool.poh, NULL, &pinfo, NULL, NULL);
-	if (rc != 0)
+	if (rc != 0) {
 		print_message("pool query failed %d\n", rc);
+		return rc;
+	}
+
+	print_message("AEP space: Total = %" PRIu64 "  Free= %" PRIu64"\t"
+		"NVMe space: Total = %" PRIu64 "  Free= %" PRIu64"\n",
+		pinfo.pi_space.ps_space.s_total[0],
+		pinfo.pi_space.ps_space.s_free[0],
+		pinfo.pi_space.ps_space.s_total[1],
+		pinfo.pi_space.ps_space.s_free[1]);
 
 	return rc;
 }
@@ -718,7 +751,7 @@ test_key_rec_add_op(struct test_key_record *key_rec,
 	/* insert modification OP to the queue in epoch order */
 	if (test_op_is_modify(op_rec->or_op)) {
 		d_list_for_each_entry(rec, &key_rec->or_queue, or_queue_link) {
-			if (rec->or_epoch > op_rec->or_epoch)
+			if (rec->tx > op_rec->tx)
 				break;
 		}
 		d_list_add_tail(&op_rec->or_queue_link, &rec->or_queue_link);
@@ -726,7 +759,7 @@ test_key_rec_add_op(struct test_key_record *key_rec,
 #if CMD_LINE_DBG
 		print_message("added op %d, epoch "DF_U64", dkey %s akey %s, "
 			      "to queue, op_num %d.\n", op_rec->or_op,
-			      op_rec->or_epoch, key_rec->or_dkey,
+			      op_rec->tx, key_rec->or_dkey,
 			      key_rec->or_akey, key_rec->or_op_num);
 
 #endif
@@ -813,20 +846,20 @@ static int
 cmd_parse_punch(test_arg_t *arg, int argc, char **argv,
 		struct test_op_record **op)
 {
-	struct test_op_record		*op_rec;
-	struct test_punch_arg		*pu_arg;
-	char				*dkey = NULL;
-	char				*akey = NULL;
-	daos_recx_t			*recxs = NULL;
+	struct test_op_record	*op_rec;
+	struct test_punch_arg	*pu_arg;
+	char					*dkey = NULL;
+	char					*akey = NULL;
+	daos_recx_t				*recxs = NULL;
 	unsigned int			recxs_num;
-	daos_epoch_t			epoch = 1;
-	int				opt;
-	int				rc = 0;
+	int						tx = 1;
+	int						opt;
+	int						rc = 0;
 
 	static struct epoch_io_cmd_option options[] = {
 		{"--dkey",	true,	'd'},
 		{"--akey",	true,	'a'},
-		{"--epoch",	true,	'e'},
+		{"--tx",	true,	'e'},
 		{"--recx",	true,	'r'},
 		{0}
 	};
@@ -841,7 +874,7 @@ cmd_parse_punch(test_arg_t *arg, int argc, char **argv,
 	while ((opt = epoch_io_getopt(argc, argv, options)) != -1) {
 		switch (opt) {
 		case 'e':
-			epoch = atoi(eio_optarg);
+			tx = atoi(eio_optarg);
 			break;
 		case 'd':
 			D_STRNDUP(dkey, eio_optarg, strlen(eio_optarg));
@@ -865,7 +898,7 @@ cmd_parse_punch(test_arg_t *arg, int argc, char **argv,
 		}
 	}
 
-	op_rec->or_epoch = epoch;
+	op_rec->tx = tx;
 
 	rc = test_op_record_bind(arg, dkey, akey, op_rec);
 	if (rc == 0)
@@ -892,22 +925,23 @@ cmd_parse_update_fetch(test_arg_t *arg, int argc, char **argv, int opc,
 	struct test_update_fetch_arg	*uf_arg;
 	daos_recx_t			*recxs = NULL;
 	int				*values = NULL;
-	unsigned int			 recx_num = 0;
+	unsigned int			recx_num = 0;
 	char				*dkey = NULL;
 	char				*akey = NULL;
-	daos_epoch_t			 epoch = 1;
-	bool				 array = true;
-	int				 opt;
-	int				 rc = 0;
+	int				tx = 1;
+	bool				array = true;
+	int				opt;
+	int				rc = 0;
 
 	static struct epoch_io_cmd_option options[] = {
 		{"--dkey",	true,	'd'},
 		{"--akey",	true,	'a'},
 		{"--single",	false,	's'},
-		{"--epoch",	true,	'e'},
+		{"--tx",	true,	'e'},
 		{"--recx",	true,	'r'},
 		{"--verify",	false,	'v'},
 		{"--value",	true,	'u'},
+		{"--snap", false, 't'},
 		{0}
 	};
 
@@ -916,12 +950,16 @@ cmd_parse_update_fetch(test_arg_t *arg, int argc, char **argv, int opc,
 		return -DER_NOMEM;
 	D_INIT_LIST_HEAD(&op_rec->or_queue_link);
 	uf_arg = &op_rec->uf_arg;
+	uf_arg->snap = false;
 
 	eio_optind = 1;
 	while ((opt = epoch_io_getopt(argc, argv, options)) != -1) {
 		switch (opt) {
 		case 'e':
-			epoch = atoi(eio_optarg);
+			tx = atoi(eio_optarg);
+			break;
+		case 't':
+			uf_arg->snap = true;
 			break;
 		case 'd':
 			D_STRNDUP(dkey, eio_optarg, strlen(eio_optarg));
@@ -965,7 +1003,7 @@ cmd_parse_update_fetch(test_arg_t *arg, int argc, char **argv, int opc,
 		}
 	}
 
-	op_rec->or_epoch = epoch;
+	op_rec->tx = tx;
 	op_rec->or_op = opc;
 	uf_arg->ua_array = array;
 	if (uf_arg->ua_array && uf_arg->ua_recxs == NULL) {
@@ -1267,14 +1305,14 @@ test_op_queue_replay(test_arg_t *arg, struct test_key_record *key_rec,
 	}
 
 	d_list_for_each_entry(op_rec, &key_rec->or_queue, or_queue_link) {
-		if (op_rec->or_epoch < key_rec->or_replayed_epoch)
+		if (op_rec->tx < key_rec->or_replayed_epoch)
 			continue;
-		if (op_rec->or_epoch > epoch)
+		if (op_rec->tx > epoch)
 			break;
 		rc = op_dict[op_rec->or_op].op_cb[TEST_LVL_FIO](
 			arg, op_rec, NULL, NULL);
 		if (rc == 0) {
-			key_rec->or_replayed_epoch = op_rec->or_epoch;
+			key_rec->or_replayed_epoch = op_rec->tx;
 		} else {
 			print_message("op_dict[%d].op_cb[%d] failed, rc %d.\n",
 				      op_rec->or_op, TEST_LVL_FIO, rc);
@@ -1320,10 +1358,10 @@ cmd_line_run(test_arg_t *arg, struct test_op_record *op_rec)
 	/* then replay the modification OPs in the queue, retrieve it through
 	 * fio and compare the result data.
 	 */
-	rc = test_op_queue_replay(arg, op_rec->or_key_rec, op_rec->or_epoch);
+	rc = test_op_queue_replay(arg, op_rec->or_key_rec, op_rec->tx);
 	if (rc) {
-		print_message("test_op_queue_replay epoch "DF_U64" failed, "
-			      "rc %d.\n", op_rec->or_epoch, rc);
+		print_message("test_op_queue_replay epoch %d failed,"
+			"rc %d.\n", op_rec->tx, rc);
 		D_GOTO(out, rc);
 	}
 
@@ -1367,8 +1405,10 @@ io_conf_run(test_arg_t *arg, const char *io_conf)
 {
 	struct test_op_record	*op = NULL;
 	FILE			*fp;
-	char			 cmd_line[CMD_LINE_LEN_MAX];
-	int			 rc = 0;
+	char			cmd_line[CMD_LINE_LEN_MAX] = {};
+	int			rc = 0;
+	/*Array for snapshot epoch*/
+	daos_epoch_t		sn_epoch[MAX_EPOCH_TIMES] = {};
 
 	if (io_conf == NULL || strlen(io_conf) == 0) {
 		print_message("invalid io_conf.\n");
@@ -1386,20 +1426,23 @@ io_conf_run(test_arg_t *arg, const char *io_conf)
 
 	do {
 		memset(cmd_line, 0, CMD_LINE_LEN_MAX);
+
 		if (cmd_line_get(fp, cmd_line) != 0)
 			break;
 
 		rc = cmd_line_parse(arg, cmd_line, &op);
+
 		if (rc != 0) {
 			print_message("bad cmd_line %s, exit.\n", cmd_line);
 			break;
 		}
 
 		if (op != NULL) {
+			op->snap_epoch = &sn_epoch[op->tx];
 			rc = cmd_line_run(arg, op);
 			if (rc) {
 				print_message("run cmd_line %s failed, "
-					      "rc %d.\n", cmd_line, rc);
+					"rc %d.\n", cmd_line, rc);
 				break;
 			}
 		}

--- a/src/tests/suite/daos_iotest.h
+++ b/src/tests/suite/daos_iotest.h
@@ -40,12 +40,11 @@ extern int dts_obj_replica_cnt;
 #define IOREQ_SG_NR	5
 #define IOREQ_SG_IOD_NR	5
 
-#define MAX_EXT_NUM		5
-#define MAX_DISTANCE		10
-#define MAX_EXTENT_SIZE		50
-#define MAX_OFFSET		1048576
-#define SINGLE_REC_RATE		20
-#define MAX_EPOCH_TIMES		20
+#define DTS_MAX_EXT_NUM		5
+#define DTS_MAX_DISTANCE	10
+#define DTS_MAX_EXTENT_SIZE	50
+#define DTS_MAX_OFFSET		1048576
+#define DTS_MAX_EPOCH_TIMES	20
 
 struct ioreq {
 	daos_handle_t		oh;
@@ -167,8 +166,7 @@ enum test_op_type {
 	TEST_OP_ADD		= 5,
 	TEST_OP_EXCLUDE		= 6,
 	TEST_OP_POOL_QUERY	= 7,
-	TEST_OP_SNAPSHOT_CREATE = 8,
-	TEST_OP_MAX		= 8,
+	TEST_OP_MAX		= 7,
 };
 
 static inline bool

--- a/src/tests/suite/daos_iotest.h
+++ b/src/tests/suite/daos_iotest.h
@@ -212,7 +212,7 @@ struct test_update_fetch_arg {
 	int			 ua_single_value;
 	int			 ua_array:1, /* false for single */
 				 ua_verify:1;
-	bool 		        snap;
+	bool 		         snap;
 };
 
 struct test_add_exclude_arg {

--- a/src/tests/suite/daos_iotest.h
+++ b/src/tests/suite/daos_iotest.h
@@ -208,11 +208,11 @@ struct test_key_record {
 struct test_update_fetch_arg {
 	daos_recx_t		*ua_recxs;
 	int			*ua_values;
-	int			 ua_recx_num;
-	int			 ua_single_value;
-	int			 ua_array:1, /* false for single */
-				 ua_verify:1;
-	bool 		         snap;
+	int			ua_recx_num;
+	int			ua_single_value;
+	int			ua_array:1, /* false for single */
+				ua_verify:1;
+	bool			snap;
 };
 
 struct test_add_exclude_arg {

--- a/src/tests/suite/daos_iotest.h
+++ b/src/tests/suite/daos_iotest.h
@@ -40,6 +40,13 @@ extern int dts_obj_replica_cnt;
 #define IOREQ_SG_NR	5
 #define IOREQ_SG_IOD_NR	5
 
+#define MAX_EXT_NUM		5
+#define MAX_DISTANCE		10
+#define MAX_EXTENT_SIZE		50
+#define MAX_OFFSET		1048576
+#define SINGLE_REC_RATE		20
+#define MAX_EPOCH_TIMES		20
+
 struct ioreq {
 	daos_handle_t		oh;
 	test_arg_t		*arg;
@@ -160,7 +167,8 @@ enum test_op_type {
 	TEST_OP_ADD		= 5,
 	TEST_OP_EXCLUDE		= 6,
 	TEST_OP_POOL_QUERY	= 7,
-	TEST_OP_MAX		= 7,
+	TEST_OP_SNAPSHOT_CREATE = 8,
+	TEST_OP_MAX		= 8,
 };
 
 static inline bool
@@ -204,6 +212,7 @@ struct test_update_fetch_arg {
 	int			 ua_single_value;
 	int			 ua_array:1, /* false for single */
 				 ua_verify:1;
+	bool 		        snap;
 };
 
 struct test_add_exclude_arg {
@@ -219,10 +228,11 @@ struct test_punch_arg {
 /* one OP record per cmd line in the ioconf file */
 struct test_op_record {
 	/* link to test_key_record::or_queue */
-	d_list_t		 or_queue_link;
+	d_list_t		or_queue_link;
 	struct test_key_record	*or_key_rec; /* back pointer */
-	daos_epoch_t		 or_epoch;
-	enum test_op_type	 or_op;
+	int			tx;
+	daos_epoch_t		*snap_epoch;
+	enum test_op_type	or_op;
 	union {
 		struct test_update_fetch_arg	uf_arg;
 		struct test_punch_arg		pu_arg;

--- a/src/tests/suite/daos_test.h
+++ b/src/tests/suite/daos_test.h
@@ -136,7 +136,7 @@ typedef struct {
 	int			srv_disabled_ntgts;
 	int			index;
 	daos_epoch_t		hce;
-
+	daos_epoch_t		snap_epoch;
 	/* The callback is called before pool rebuild. like disconnect
 	 * pool etc.
 	 */

--- a/src/tests/suite/daos_test.h
+++ b/src/tests/suite/daos_test.h
@@ -136,7 +136,6 @@ typedef struct {
 	int			srv_disabled_ntgts;
 	int			index;
 	daos_epoch_t		hce;
-	daos_epoch_t		snap_epoch;
 	/* The callback is called before pool rebuild. like disconnect
 	 * pool etc.
 	 */

--- a/src/tests/suite/io_conf/daos_generate_io_conf.c
+++ b/src/tests/suite/io_conf/daos_generate_io_conf.c
@@ -202,11 +202,13 @@ update_array_internal(int index, uint64_t eph, struct extent *extents,
 	}
 
 	if (update) {
-		sprintf(output_buf, "update --tx %"PRId64" --snap --recx \"%s\"\n",
+		sprintf(output_buf,
+			"update --tx %"PRId64" --snap --recx \"%s\"\n",
 			eph, rec_buf);
 		records[index].records[0].snap = true;
 	} else {
-		sprintf(output_buf, "punch --tx %"PRId64" --recx \"%s\"\n",
+		sprintf(output_buf,
+			"punch --tx %"PRId64" --recx \"%s\"\n",
 			eph, rec_buf);
 		records[index].records[0].snap = false;
 	}
@@ -265,8 +267,9 @@ update_single(int index, uint64_t eph, struct extent *extents,
 			eph, value);
 	} else {
 		records[index].records[0].snap = false;
-		sprintf(output_buf, "update --tx %" PRId64 " --single --value %d\n", eph,
-			value);
+		sprintf(output_buf,
+			"update --tx %" PRId64 " --single --value %d\n",
+			eph, value);
 	}
 
 	return 0;
@@ -303,10 +306,12 @@ fetch_array(int index, uint64_t eph, struct extent *extents,
 	if (rec_length != 0) {
 		if (record->records[0].snap == true)
 			sprintf(output_buf,
-				"fetch --tx %" PRId64 " -v --snap --recx \"%s\"\n",
+				"fetch --tx %" PRId64 " -v "
+				"--snap --recx \"%s\"\n",
 				record->eph, rec_buf);
 		else
-			sprintf(output_buf, "fetch --tx %" PRId64 " --recx \"%s\"\n",
+			sprintf(output_buf,
+				"fetch --tx %" PRId64 " --recx \"%s\"\n",
 				record->eph, rec_buf);
 	}
 	return 0;
@@ -342,7 +347,8 @@ static int fetch_single(int index, uint64_t eph, struct extent *extents,
 	if (rec_length != 0) {
 		if (record->records[0].snap == true)
 			sprintf(output_buf,
-				"fetch --tx %" PRId64 " -v --snap --single --value %d\n",
+				"fetch --tx %" PRId64 " -v --snap"
+				" --single --value %d\n",
 				record->eph, record->records[0].single.value);
 		else
 			sprintf(output_buf,

--- a/src/tests/suite/io_conf/daos_generate_io_conf.c
+++ b/src/tests/suite/io_conf/daos_generate_io_conf.c
@@ -21,7 +21,7 @@
  * portions thereof marked with this legend must also reproduce the markings.
  */
 /**
- * This file is part of daos, to generate the epoch io test.
+ * This file is part of daos, to generate the io test.
  */
 #define D_LOGFAC	DD_FAC(tests)
 
@@ -36,20 +36,19 @@ static int iod_size = 1;
 static char *default_class = "repl_3_small_rw_spec_rank";
 static char *obj_class;
 
-#define MAX_EXT_NUM		5
-#define MAX_DISTANCE		10
-#define MAX_EXTENT_SIZE		50
-#define MAX_OFFSET		1048576
-#define SINGLE_REC_RATE		20
-#define MAX_EPOCH_TIMES		20
-
 enum op {
 	UPDATE_ARRAY,
-	PUNCH_ARRAY,
-	UPDATE_SINGLE,
-	PUNCH_AKEY,
 	FETCH,
+	PUNCH_ARRAY,
+	PUNCH_AKEY,
 	MAX_OPS,
+};
+
+enum single_record_op {
+	UPDATE_SINGLE,
+	FETCH_SINGLE,
+	PUNCH_AKEY_SINGLE,
+	MAX_OPS_SINGLE,
 };
 
 enum type {
@@ -62,7 +61,7 @@ struct current_status {
 	int		cur_dkey_num;
 	int		cur_akey_num;
 	int		cur_rank;
-	daos_epoch_t	cur_eph;
+	int	    	cur_tx;
 };
 
 enum rec_types {
@@ -91,10 +90,11 @@ struct record {
 	};
 	int		rec_size;
 	int		type;
+	bool    	snap;
 };
 
 struct records {
-	daos_epoch_t	eph;
+	int		eph;
 	int		records_num;
 	struct record	records[MAX_EXT_NUM];
 };
@@ -137,7 +137,7 @@ extent_twist(struct extent *input, struct extent *output, int off, bool add)
 }
 
 static int
-update_array_internal(int index, daos_epoch_t eph, struct extent *extents,
+update_array_internal(int index, int eph, struct extent *extents,
 		      int extents_num, int rec_size,
 		      struct records *records, char *output_buf, bool update)
 {
@@ -201,18 +201,21 @@ update_array_internal(int index, daos_epoch_t eph, struct extent *extents,
 		rec_length += length + 1;
 	}
 
-	if (update)
-		sprintf(output_buf, "update --epoch "DF_U64" --recx \"%s\"\n",
+	if (update) {
+		sprintf(output_buf, "update --tx %d --snap --recx \"%s\"\n",
 			eph, rec_buf);
-	else
-		sprintf(output_buf, "punch --epoch "DF_U64" --recx \"%s\"\n",
+		records[index].records[0].snap = true;
+	} else {
+		sprintf(output_buf, "punch --tx %d --recx \"%s\"\n",
 			eph, rec_buf);
+		records[index].records[0].snap = false;
+	}
 
 	return 0;
 }
 
 static int
-update_array(int index, daos_epoch_t eph, struct extent *extents,
+update_array(int index, int eph, struct extent *extents,
 	     int extents_num, int rec_size, struct records *records,
 	     char *output_buf)
 {
@@ -221,7 +224,7 @@ update_array(int index, daos_epoch_t eph, struct extent *extents,
 }
 
 static int
-punch_array(int index, daos_epoch_t eph, struct extent *extents,
+punch_array(int index, int eph, struct extent *extents,
 	    int extents_num, int rec_size, struct records *records,
 	    char *output_buf)
 {
@@ -230,19 +233,19 @@ punch_array(int index, daos_epoch_t eph, struct extent *extents,
 }
 
 static int
-_punch_akey(int index, daos_epoch_t eph, struct extent *extents,
+_punch_akey(int index, int eph, struct extent *extents,
 	    int extents_num, int rec_size, struct records *records,
 	    char *output_buf)
 {
 	records[index].eph = eph;
 	records[index].records_num = 0;
-	sprintf(output_buf, "punch --epoch "DF_U64"\n", eph);
+	sprintf(output_buf, "punch --tx %d\n", eph);
 	return 0;
 }
 
 /* Update single record */
 static int
-update_single(int index, daos_epoch_t eph, struct extent *extents,
+update_single(int index, int eph, struct extent *extents,
 	      int extents_num, int rec_size, struct records *records,
 	      char *output_buf)
 {
@@ -255,57 +258,101 @@ update_single(int index, daos_epoch_t eph, struct extent *extents,
 	records[index].records[0].type = SINGLE;
 	records[index].records[0].single.value = value;
 
-	sprintf(output_buf, "update --epoch "DF_U64" --single --value %d\n",
-		eph, value);
+	if (value % 2 != 0) {
+		records[index].records[0].snap = true;
+		sprintf(output_buf,
+			"update --tx %d --snap --single --value %d\n",
+			eph, value);
+	} else {
+		records[index].records[0].snap = false;
+		sprintf(output_buf, "update --tx %d --single --value %d\n", eph,
+			value);
+	}
 
 	return 0;
 }
 
-static int
-fetch_array(int index, daos_epoch_t eph, struct extent *extents,
-	    int extents_num, int rec_size, struct records *records,
-	    char *output_buf)
+static int fetch_array(int index, int eph, struct extent *extents,
+	int extents_num, int rec_size, struct records *records,
+	char *output_buf)
 {
 	struct records *record;
-	char rec_buf[512] = { 0 };
-	int fetch_index;
-	int rec_length = 0;
-	int i;
+	char            rec_buf[512] = {0};
+	int             fetch_index;
+	int             rec_length = 0;
+	int             i;
 
 	D_ASSERT(index > 0);
 
 	fetch_index = rand() % index;
-	record = &records[fetch_index];
+	record      = &records[fetch_index];
 	for (i = 0; i < record->records_num; i++) {
 		struct array *array = &record->records[i].array;
-		int length;
-		char rec[64];
+		int           length;
+		char          rec[64];
 
-		length = sprintf(rec, "["DF_U64", "DF_U64"]%d",
-				 array->extent.start,
-				 array->extent.end, array->value);
+		length = sprintf(rec, "[" DF_U64 ", " DF_U64 "]%d",
+				 array->extent.start, array->extent.end,
+				 array->value);
 
 		sprintf(rec_buf + rec_length, "%s ", rec);
 		rec_length += length + 1;
 	}
 
-	if (rec_length == 0) {
-		sprintf(output_buf, "fetch --epoch "DF_U64" -s -v --value 0\n",
-			record->eph);
-	} else {
-		if (record->records[0].type == SINGLE)
-			sprintf(output_buf, "fetch --epoch "DF_U64" -v --single"
-				" --value %d\n", record->eph,
-				record->records[0].single.value);
+	if (rec_length != 0) {
+		if (record->records[0].snap == true)
+			sprintf(output_buf,
+				"fetch --tx %d -v --snap --recx \"%s\"\n",
+				record->eph, rec_buf);
 		else
-			sprintf(output_buf, "fetch --epoch "DF_U64" -v --recx"
-				" \"%s\"\n", record->eph, rec_buf);
+			sprintf(output_buf, "fetch --tx %d --recx \"%s\"\n",
+				record->eph, rec_buf);
 	}
-
 	return 0;
 }
 
-int choose_op(int index)
+static int fetch_single(int index, int eph, struct extent *extents,
+	int extents_num, int rec_size, struct records *records,
+	char *output_buf)
+{
+	struct records *record;
+	char            rec_buf[512] = {0};
+	int             fetch_index;
+	int             rec_length = 0;
+	int             i;
+
+	D_ASSERT(index > 0);
+
+	fetch_index = rand() % index;
+	record      = &records[fetch_index];
+	for (i = 0; i < record->records_num; i++) {
+		struct array *array = &record->records[i].array;
+		int           length;
+		char          rec[64];
+
+		length = sprintf(rec, "[" DF_U64 ", " DF_U64 "]%d",
+				 array->extent.start, array->extent.end,
+				 array->value);
+
+		sprintf(rec_buf + rec_length, "%s ", rec);
+		rec_length += length + 1;
+	}
+
+	if (rec_length != 0) {
+		if (record->records[0].snap == true)
+			sprintf(output_buf,
+				"fetch --tx %d -v --snap --single --value %d\n",
+				record->eph, record->records[0].single.value);
+		else
+			sprintf(output_buf,
+				"fetch --tx %d --single --value %d\n",
+			    record->eph, record->records[0].single.value);
+
+	}
+	return 0;
+}
+
+int choose_op(int index, int max_operation)
 {
 	if (index == 0)
 		return UPDATE_ARRAY;
@@ -313,11 +360,11 @@ int choose_op(int index)
 	/* FIXME: it should be able to specify the percentage
 	 * of each operation to generate the special workload.
 	 */
-	return rand() % MAX_OPS;
+	return rand() % max_operation;
 }
 
 struct operation {
-	int (*op)(int index, daos_epoch_t eph, struct extent *extents,
+	int (*op)(int index, int eph, struct extent *extents,
 		  int extents_num, int rec_size, struct records *records,
 		  char *output_buf);
 };
@@ -326,34 +373,40 @@ struct operation operations[] = {
 	[UPDATE_ARRAY] = {
 		.op = &update_array,
 	},
+	[FETCH] = {
+		.op = &fetch_array,
+	},
 	[PUNCH_ARRAY] = {
 		.op = &punch_array,
-	},
-	[UPDATE_SINGLE] = {
-		.op = &update_single,
 	},
 	[PUNCH_AKEY] = {
 		.op = &_punch_akey,
 	},
-	[FETCH] = {
-		.op = &fetch_array,
+};
+
+struct operation single_operations[] = {
+	[UPDATE_SINGLE] = {
+	    .op = &update_single,
+	},
+	[FETCH_SINGLE] = {
+	    .op = &fetch_single,
+	},
+	[PUNCH_AKEY_SINGLE] = {
+	    .op = &_punch_akey,
 	},
 };
 
 /* Generate the ioconf
  *
- * update --epoch 1 --recx "[0, 2] [3, 8] [12, 18]"
- * update --epoch 1 --single
- * update --epoch 2 --recx "[1, 3] [5, 10] [12, 14] [100, 108]"
- * update --epoch 3 --recx "[0, 8] [13, 17] [90, 104]"
- * update --epoch 4 --recx "[1, 20] [80, 96] [110, 120]"
- * update --epoch 4 --single
- *
+ * update --tx 1 --snap --recx "[0, 2] [3, 8] [12, 18]"
+ * update --tx 2 --snap --recx "[1, 3] [5, 10] [12, 14] [100, 108]"
+ * update --tx 3 --snap --recx "[0, 8] [13, 17] [90, 104]"
+ * update --tx 4 --snap --recx "[1, 20] [80, 96] [110, 120]"
+  *
  * fail --rank %d --tgt %d
- * fetch --epoch 1 --recx "[0, 2] [3, 8] [12, 18]"
- * fetch --epoch 2 --recx "[0, 4] [5, 7] [13, 15] [100, 108]"
- * fetch --epoch 2 --single
- */
+ * fetch --tx 1 --snap --recx "[0, 2] [3, 8] [12, 18]"
+ * fetch --tx 2 --snap --recx "[1, 3] [5, 10] [12, 14] [100, 108]"
+  */
 int
 generate_io_conf_rec(int fd, struct current_status *status)
 {
@@ -361,7 +414,7 @@ generate_io_conf_rec(int fd, struct current_status *status)
 	unsigned int	offset = 0;
 	struct extent	extents[MAX_EXT_NUM] = { 0 };
 	struct records recs[MAX_EPOCH_TIMES] = { 0 };
-	daos_epoch_t	eph;
+	int		eph;
 	int		dist;
 	int		extent_num;
 	int		extent_size;
@@ -371,6 +424,7 @@ generate_io_conf_rec(int fd, struct current_status *status)
 	int		rc1;
 	int		rc = 0;
 	int		tgt;
+	int		op;
 
 	sprintf(line, "iod_size %d\n", iod_size);
 	rc1 = write(fd, line, strlen(line));
@@ -382,7 +436,6 @@ generate_io_conf_rec(int fd, struct current_status *status)
 	extent_size = (rand() % MAX_EXTENT_SIZE + 1) * MAX_EXTENT_SIZE;
 	offset = rand() % MAX_OFFSET;
 	epoch_times = rand() % MAX_EPOCH_TIMES + 1;
-
 	/* create rec string */
 	for (i = 0; i < extent_num; i++) {
 		extents[i].start = offset;
@@ -390,15 +443,23 @@ generate_io_conf_rec(int fd, struct current_status *status)
 		offset += extent_size + dist;
 	}
 
-	eph = status->cur_eph;
+	eph = status->cur_tx;
 	inject_fail_idx = rand() % epoch_times;
 	tgt = rand() % tgt_size;
+	enum type record_type = rand() % 2;
+
 	for (i = 0; i < epoch_times; i++) {
 		char	buffer[512];
-		int	op = choose_op(i);
 
-		rc = (*operations[op].op)(i, eph + i, extents, extent_num,
-					  1, recs, buffer);
+		if (record_type == ARRAY) {
+			op = choose_op(i, MAX_OPS);
+			rc = (*operations[op].op)(i, eph + i, extents,
+						  extent_num, 1, recs, buffer);
+		} else {
+			op = choose_op(i, MAX_OPS_SINGLE);
+			rc = (*single_operations[op].op)(
+			    i, eph + i, extents, extent_num, 1, recs, buffer);
+		}
 		if (rc)
 			goto out;
 
@@ -435,7 +496,7 @@ generate_io_conf_rec(int fd, struct current_status *status)
 	}
 	rc = 0;
 
-	status->cur_eph += i;
+	status->cur_tx += i;
 out:
 	return rc;
 }
@@ -447,6 +508,7 @@ generate_io_conf_akey(int fd, struct current_status *status)
 	int rc = 0;
 
 	while (status->cur_akey_num < akey_num) {
+		status->cur_tx = 0;
 		sprintf(akey, "akey akey_%d\n",
 			status->cur_akey_num);
 		rc = write(fd, akey, strlen(akey));

--- a/src/tests/suite/io_conf/daos_generate_io_conf.c
+++ b/src/tests/suite/io_conf/daos_generate_io_conf.c
@@ -61,7 +61,7 @@ struct current_status {
 	int		cur_dkey_num;
 	int		cur_akey_num;
 	int		cur_rank;
-	int	    	cur_tx;
+	int		cur_tx;
 };
 
 enum rec_types {
@@ -90,7 +90,7 @@ struct record {
 	};
 	int		rec_size;
 	int		type;
-	bool    	snap;
+	bool		snap;
 };
 
 struct records {

--- a/src/tests/suite/io_conf/daos_io_conf_1
+++ b/src/tests/suite/io_conf/daos_io_conf_1
@@ -1,5 +1,5 @@
 #/*
-# * (C) Copyright 2018 Intel Corporation.
+# * (C) Copyright 2018-2019 Intel Corporation.
 # *
 # * Licensed under the Apache License, Version 2.0 (the "License");
 # * you may not use this file except in compliance with the License.
@@ -32,23 +32,22 @@
 # iod_size xxx (default is 1)
 #
 # 2) update
-# 2.1) update array
-# update --epoch x --recx "[idx_start1, idx_end1] [idx_start2, idx_end2] ..."
+# 2.1) update array and take snapshot
+# update --tx x --snap --recx "[idx_start1, idx_end1] [idx_start2, idx_end2] ..."
 # The max number of recxs is 5 (IOREQ_IOD_NR).
-# 2.2) update single type record
-# update --epoch x --single
+# 2.2) update single type record and take snapshot
+# update --tx x --snap --single
 #
 # If no --epoch specified, then use default epoch 1.
 # Other two options: --dkey xxx --akey xxx. If not specified then use the last
 # dkey/akey set at above 1).
 # for the option name:
-# --epoch	== -e
 # --single	== -s
 # --recx	== -r
 # --dkey	== -d
 # --akey	== -a
 #
-# 3) fetch
+# 3) fetch and verify based on snapshot teaken after update.
 # same parameter usage as above 2)
 #
 # 4) discard
@@ -61,18 +60,18 @@ dkey dkey_1
 akey akey_1
 iod_size 32
 
-update --epoch 1 --recx "[0, 2] [3, 8] [12, 18]"
-update --epoch 2 --recx "[1, 3] [5, 10] [12, 14] [100, 108]"
-update --epoch 3 --recx "[0, 8] [13, 17] [90, 104]"
-update --epoch 4 --recx "[1, 20] [80, 96] [110, 120]"
+update --tx 1 --snap --recx "[0, 2] [3, 8] [12, 18]"
+update --tx 2 --snap --recx "[1, 3] [5, 10] [12, 14] [100, 108]"
+update --tx 3 --snap --recx "[0, 8] [13, 17] [90, 104]"
+update --tx 4 --snap --recx "[1, 20] [80, 96] [110, 120]"
 
-fetch --epoch 1 --recx "[0, 2] [3, 8] [12, 18]"
-fetch --epoch 2 --recx "[0, 4] [5, 7] [13, 15] [100, 108]"
-fetch --epoch 3 --recx "[0, 8] [13, 17] [90, 104]"
-fetch --epoch 4 --recx "[0, 20] [80, 96] [100, 120]"
+fetch --tx 1 --recx "[0, 2] [3, 8] [12, 18]"
+fetch --tx 2 --recx "[0, 4] [5, 7] [13, 15] [100, 108]"
+fetch --tx 3 --recx "[0, 8] [13, 17] [90, 104]"
+fetch --tx 4 --recx "[0, 20] [80, 96] [100, 120]"
 
 akey akey_s
-update --epoch 1 --single
-update --epoch 4 --single
-fetch --epoch 2 --single
-fetch --epoch 4 --single
+update --tx 1 --single
+update --tx 4 --single
+fetch --tx 2 --single
+fetch --tx 4 --single

--- a/src/tests/suite/io_conf/daos_io_conf_2
+++ b/src/tests/suite/io_conf/daos_io_conf_2
@@ -1,59 +1,59 @@
 #/*
-# * (C) Copyright 2018 Intel Corporation.
-# *
-# * Licensed under the Apache License, Version 2.0 (the "License");
-# * you may not use this file except in compliance with the License.
-# * You may obtain a copy of the License at
-# *
-# *    http://www.apache.org/licenses/LICENSE-2.0
-# *
-# * Unless required by applicable law or agreed to in writing, software
-# * distributed under the License is distributed on an "AS IS" BASIS,
-# * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# * See the License for the specific language governing permissions and
-# * limitations under the License.
-# *
-# * GOVERNMENT LICENSE RIGHTS-OPEN SOURCE SOFTWARE
-# * The Government's rights to use, modify, reproduce, release, perform, display,
-# * or disclose this software are subject to the terms of the Apache License as
-# * provided in Contract No. B609815.
-# * Any reproduction of computer software, computer software documentation, or
-# * portions thereof marked with this legend must also reproduce the markings.
-# */
-#/**
-# * An example daos EPOCH IO test conf file.
-# */
-
-# io conf file format:
-# 1) some setting:
-# test_lvl xxx (daos or vos, default is daos)
-# dkey xxx
-# akey xxx
-# iod_size xxx (default is 1)
+## * (C) Copyright 2018-2019 Intel Corporation.
+## *
+## * Licensed under the Apache License, Version 2.0 (the "License");
+## * you may not use this file except in compliance with the License.
+## * You may obtain a copy of the License at
+## *
+## *    http://www.apache.org/licenses/LICENSE-2.0
+## *
+## * Unless required by applicable law or agreed to in writing, software
+## * distributed under the License is distributed on an "AS IS" BASIS,
+## * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+## * See the License for the specific language governing permissions and
+## * limitations under the License.
+## *
+## * GOVERNMENT LICENSE RIGHTS-OPEN SOURCE SOFTWARE
+## * The Government's rights to use, modify, reproduce, release, perform, display,
+## * or disclose this software are subject to the terms of the Apache License as
+## * provided in Contract No. B609815.
+## * Any reproduction of computer software, computer software documentation, or
+## * portions thereof marked with this legend must also reproduce the markings.
+## */
+##/**
+## * An example daos EPOCH IO test conf file.
+## */
 #
-# 2) update
-# 2.1) update array
-# update --epoch x --recx "[idx_start1, idx_end1] [idx_start2, idx_end2] ..."
-# The max number of recxs is 5 (IOREQ_IOD_NR).
-# 2.2) update single type record
-# update --epoch x --single
-#
-# If no --epoch specified, then use default epoch 1.
-# Other two options: --dkey xxx --akey xxx. If not specified then use the last
-# dkey/akey set at above 1).
-# for the option name:
-# --epoch	== -e
-# --single	== -s
-# --recx	== -r
-# --dkey	== -d
-# --akey	== -a
-#
-# 3) fetch
-# same parameter usage as above 2)
-#
-# 4) discard
-#
-# 5) punch
+## io conf file format:
+## 1) some setting:
+## test_lvl xxx (daos or vos, default is daos)
+## dkey xxx
+## akey xxx
+## iod_size xxx (default is 1)
+##
+## 2) update
+## 2.1) update array and take snapshot
+## update --tx x --snap --recx "[idx_start1, idx_end1] [idx_start2, idx_end2] ..."
+## The max number of recxs is 5 (IOREQ_IOD_NR).
+## 2.2) update single type record and take snapshot
+## update --tx x --snap --single
+##
+## If no --epoch specified, then use default epoch 1.
+## Other two options: --dkey xxx --akey xxx. If not specified then use the last
+## dkey/akey set at above 1).
+## for the option name:
+## --single      == -s
+## --recx        == -r
+## --dkey        == -d
+## --akey        == -a
+##
+## 3) fetch and verify based on snapshot teaken after update.
+## same parameter usage as above 2)
+##
+## 4) discard
+##
+## 5) punch
+##
 #
 
 test_lvl daos
@@ -61,22 +61,23 @@ dkey dkey_2
 akey akey_2
 iod_size 3
 
-update -e 1 -r "[0, 1000]"
-update -e 2 -r "[2, 500] [510, 990]"
-update -e 3 -r "[4, 40] [60, 80] [200, 490] [550, 800] [900, 1100]"
-update -e 4 -r "[20, 70] [78, 333] [377, 488] [600, 2000]"
-update -e 9 -r "[0, 2000]"
-update --epoch 100 --recx "[4, 40] [60, 80] [200, 490] [550, 800] [900, 1100]"
-update --epoch 200 --recx "[10, 71] [78, 344] [377, 444] [610, 1000]"
-update -e 4 -d dkey_another -a akey_another -r "[20, 70] [78, 333] [377, 488] [600, 2000]"
-update -e 100 -d dkey_another -a akey_another -r "[0, 3000]"
+update --tx 1 -r "[0, 1000]"
+update --tx 2 -r "[2, 500] [510, 990]"
+update --tx 3 -r "[4, 40] [60, 80] [200, 490] [550, 800] [900, 1100]"
+update --tx 4 -r "[20, 70] [78, 333] [377, 488] [600, 2000]"
+update --tx 9 -r "[0, 2000]"
+update --tx 100 --recx "[4, 40] [60, 80] [200, 490] [550, 800] [900, 1100]"
+update --tx 200 --recx "[10, 71] [78, 344] [377, 444] [610, 1000]"
+update --tx 4 -d dkey_another -a akey_another -r "[20, 70] [78, 333] [377, 488] [600, 2000]"
+update --tx 100 -d dkey_another -a akey_another -r "[0, 3000]"
 
-fetch -e 1 -r "[0, 1000]"
-fetch -e 2 -r "[0, 50] [300, 1000]"
-fetch -e 3 -r "[1, 20] [30, 80] [100, 290] [250, 400] [500, 1100]"
-fetch -e 4 -r "[20, 30] [48, 333] [377, 388] [400, 2000]"
-fetch -e 4 -d dkey_another -a akey_another -r "[0, 2000]"
-fetch -e 110 -d dkey_another -a akey_another -r "[0, 3000]"
-fetch -e 10 -r "[0, 2000]"
-fetch -e 150 -r "[0, 2000]"
-fetch -e 250 -r "[0, 2000]"
+fetch --tx 1 -r "[0, 1000]"
+fetch --tx 2 -r "[0, 50] [300, 1000]"
+fetch --tx 3 -r "[1, 20] [30, 80] [100, 290] [250, 400] [500, 1100]"
+fetch --tx 4 -r "[20, 30] [48, 333] [377, 388] [400, 2000]"
+fetch --tx 4 -d dkey_another -a akey_another -r "[0, 2000]"
+fetch --tx 110 -d dkey_another -a akey_another -r "[0, 3000]"
+fetch --tx 10 -r "[0, 2000]"
+fetch --tx 150 -r "[0, 2000]"
+fetch --tx 250 -r "[0, 2000]"
+pool --query


### PR DESCRIPTION
- Removed multiple data type for key store. Now each key will have
  either single/array.
- Adding Snapshot. Snapshot will be taken after update. if data
  fetch request for previous transaction, data will be fetched
  using the the snapshot epoch.

Testing done with the below configration:
daos_gen_io_conf -o 1 -d 1 -a 1 -s 1 test1
daos_gen_io_conf -o 1 -d 1 -a 1 -s 100 test2
daos_gen_io_conf -o 1 -d 1 -a 10 -s 100 test3
daos_gen_io_conf -o 1 -d 10 -a 10 -s 100 test4

Signed-off-by: Samir <samir.raval@intel.com>