### PR TITLE
DAOS-2540 btree: add new API dbtree_drain

### DIFF
--- a/src/common/btree.c
+++ b/src/common/btree.c
@@ -123,9 +123,16 @@ struct btr_context {
 	/** embedded iterator */
 	struct btr_iterator		 tc_itr;
 	/** cached configured tree order */
-	uint16_t				 tc_order;
+	uint16_t			 tc_order;
 	/** cached tree depth, avoid loading from slow memory */
-	uint16_t				 tc_depth;
+	uint16_t			 tc_depth;
+	/** credits for drain, see dbtree_drain */
+	int				 tc_creds:30;
+	/**
+	 * credits is turned on, \a tcx::tc_creds should be checked
+	 * while draining the tree
+	 */
+	int				 tc_creds_on:1;
 	/**
 	 * returned value of the probe, it should be reset after upsert
 	 * or delete because the probe path could have been changed.
@@ -157,9 +164,8 @@ static struct btr_record *btr_node_rec_at(struct btr_context *tcx,
 static int btr_node_insert_rec(struct btr_context *tcx,
 			       struct btr_trace *trace,
 			       struct btr_record *rec);
-static void btr_node_destroy(struct btr_context *tcx,
-			     umem_off_t nd_off,
-			     void *args);
+static void btr_node_destroy(struct btr_context *tcx, umem_off_t nd_off,
+			     void *args, bool *empty_rc);
 static int btr_root_tx_add(struct btr_context *tcx);
 static bool btr_probe_prev(struct btr_context *tcx);
 static bool btr_probe_next(struct btr_context *tcx);
@@ -1324,7 +1330,7 @@ btr_probe(struct btr_context *tcx, dbtree_probe_opc_t probe_opc,
 	struct btr_check_alb	 alb;
 	struct btr_trace	 traces[BTR_TRACE_MAX];
 	struct btr_trace	*trace = NULL;
-	umem_off_t	 nd_off;
+	umem_off_t		 nd_off;
 
 	if (!btr_probe_valid(probe_opc)) {
 		rc = PROBE_RC_ERR;
@@ -2597,7 +2603,7 @@ btr_root_del_rec(struct btr_context *tcx, struct btr_trace *trace, void *args)
 			btr_node_del_leaf_only(tcx, trace, true, args);
 		} else {
 
-			btr_node_destroy(tcx, trace->tr_node, args);
+			btr_node_destroy(tcx, trace->tr_node, args, NULL);
 			if (btr_has_tx(tcx))
 				btr_root_tx_add(tcx);
 
@@ -2684,7 +2690,7 @@ btr_tx_delete(struct btr_context *tcx, void *args)
  *				args to handle special cases(if any)
  */
 int
-dbtree_delete(daos_handle_t toh, d_iov_t *key,
+dbtree_delete(daos_handle_t toh, dbtree_probe_opc_t opc, d_iov_t *key,
 	      void *args)
 {
 	struct btr_context *tcx;
@@ -2694,7 +2700,7 @@ dbtree_delete(daos_handle_t toh, d_iov_t *key,
 	if (tcx == NULL)
 		return -DER_NO_HDL;
 
-	rc = btr_probe_key(tcx, BTR_PROBE_EQ, DAOS_INTENT_PUNCH, key);
+	rc = btr_probe_key(tcx, opc, DAOS_INTENT_PUNCH, key);
 	if (rc == PROBE_RC_INPROGRESS) {
 		D_DEBUG(DB_TRACE, "Target is in some uncommitted DTX.\n");
 		return -DER_INPROGRESS;
@@ -3049,10 +3055,11 @@ dbtree_close(daos_handle_t toh)
 /** Destroy a tree node and all its children recursively. */
 static void
 btr_node_destroy(struct btr_context *tcx, umem_off_t nd_off,
-		 void *args)
+		 void *args, bool *empty_rc)
 {
 	struct btr_node *nd	= btr_off2ptr(tcx, nd_off);
 	bool		 leaf	= btr_node_is_leaf(tcx, nd_off);
+	bool		 empty	= true;
 	int		 i;
 
 	/* NB: don't need to call TX_ADD_RANGE(nd_off, ...) because I never
@@ -3063,52 +3070,88 @@ btr_node_destroy(struct btr_context *tcx, umem_off_t nd_off,
 		leaf ? "leaf" : "node", nd_off, nd->tn_keyn);
 
 	if (leaf) {
-		for (i = 0; i < nd->tn_keyn; i++) {
+		for (i = nd->tn_keyn - 1; i >= 0; i--) {
 			struct btr_record *rec;
 
 			rec = btr_node_rec_at(tcx, nd_off, i);
 			btr_rec_free(tcx, rec, args);
+			if (!tcx->tc_creds_on)
+				continue;
+
+			/* NB: only leaf record consumes user credits */
+			D_ASSERT(tcx->tc_creds > 0);
+			tcx->tc_creds--;
+			if (tcx->tc_creds == 0) {
+				empty = (i == 0);
+				break;
+			}
 		}
-		return;
+	} else { /* non-leaf */
+		for (i = nd->tn_keyn; i >= 0; i--) {
+			umem_off_t	child_off;
+
+			child_off = btr_node_child_at(tcx, nd_off, i);
+			btr_node_destroy(tcx, child_off, NULL, &empty);
+			if (!tcx->tc_creds_on || tcx->tc_creds > 0) {
+				D_ASSERT(empty);
+				continue;
+			}
+			D_ASSERT(tcx->tc_creds == 0);
+
+			/* current child is empty, other children are not */
+			if (empty && i > 0) {
+				empty = false;
+				i--;
+			}
+			break;
+		}
 	}
 
-	for (i = 0; i <= nd->tn_keyn; i++) {
-		umem_off_t	child_off;
-
-		child_off = btr_node_child_at(tcx, nd_off, i);
-		btr_node_destroy(tcx, child_off, NULL);
+	if (empty) {
+		btr_node_free(tcx, nd_off);
+	} else {
+		if (btr_has_tx(tcx))
+			btr_node_tx_add(tcx, nd_off);
+		/* NB: i can be zero for non-leaf node */
+		D_ASSERT(i >= 0);
+		nd->tn_keyn = i;
 	}
-	btr_node_free(tcx, nd_off);
+
+	if (empty_rc)
+		*empty_rc = empty;
 }
 
 /** destroy all tree nodes and records, then release the root */
 static int
-btr_tree_destroy(struct btr_context *tcx)
+btr_tree_destroy(struct btr_context *tcx, void *args, bool *destroyed)
 {
 	struct btr_root *root;
+	bool		 empty = true;
 
 	D_DEBUG(DB_TRACE, "Destroy "DF_X64", order %d\n",
 		tcx->tc_tins.ti_root_off, tcx->tc_order);
 
 	root = tcx->tc_tins.ti_root;
-	if (!UMOFF_IS_NULL(root->tr_node)) {
+	if (root && !UMOFF_IS_NULL(root->tr_node)) {
 		/* destroy the root and all descendants */
-		btr_node_destroy(tcx, root->tr_node, NULL);
+		btr_node_destroy(tcx, root->tr_node, args, &empty);
 	}
+	*destroyed = empty;
+	if (empty)
+		btr_root_free(tcx);
 
-	btr_root_free(tcx);
 	return 0;
 }
 
 static int
-btr_tx_tree_destroy(struct btr_context *tcx)
+btr_tx_tree_destroy(struct btr_context *tcx, void *args, bool *destroyed)
 {
-	int		      rc = 0;
+	int      rc = 0;
 
 	rc = btr_tx_begin(tcx);
 	if (rc != 0)
 		return rc;
-	rc = btr_tree_destroy(tcx);
+	rc = btr_tree_destroy(tcx, args, destroyed);
 
 	return btr_tx_end(tcx, rc);
 }
@@ -3118,9 +3161,40 @@ btr_tx_tree_destroy(struct btr_context *tcx)
  * The tree open handle is invalid after the destroy.
  *
  * \param toh	[IN]	Tree open handle.
+ * \param args	[IN]	user parameter for btr_ops_t::to_rec_free
  */
 int
-dbtree_destroy(daos_handle_t toh)
+dbtree_destroy(daos_handle_t toh, void *args)
+{
+	struct btr_context *tcx;
+	bool		    destroyed;
+	int		    rc;
+
+	tcx = btr_hdl2tcx(toh);
+	if (tcx == NULL)
+		return -DER_NO_HDL;
+
+	D_ASSERT(!tcx->tc_creds_on);
+	rc = btr_tx_tree_destroy(tcx, args, &destroyed);
+	D_ASSERT(rc || destroyed);
+
+	btr_context_decref(tcx);
+	return rc;
+}
+
+/**
+ * This function drains key/values from the tree, each time it deletes a KV
+ * pair, it consumes a @credits, which is input paramter of this function.
+ * It returns if all input credits are consumed, or the tree is empty, in
+ * the later case, it also destroys the btree.
+ *
+ * \param toh		[IN]	 Tree open handle.
+ * \param credis	[IN/OUT] Input and returned drain credits
+ * \param args		[IN]	 user parameter for btr_ops_t::to_rec_free
+ * \param destroy	[OUT]	 Tree is empty and destroyed
+ */
+int
+dbtree_drain(daos_handle_t toh, int *credits, void *args, bool *destroyed)
 {
 	struct btr_context *tcx;
 	int		    rc;
@@ -3129,9 +3203,25 @@ dbtree_destroy(daos_handle_t toh)
 	if (tcx == NULL)
 		return -DER_NO_HDL;
 
-	rc = btr_tx_tree_destroy(tcx);
+	D_ASSERT(!tcx->tc_creds_on);
+	if (credits) {
+		if (*credits <= 0) {
+			rc = -DER_INVAL;
+			goto failed;
+		}
+		tcx->tc_creds = *credits;
+		tcx->tc_creds_on = 1;
+	}
 
-	btr_context_decref(tcx);
+	rc = btr_tx_tree_destroy(tcx, args, destroyed);
+	if (rc)
+		goto failed;
+
+	if (tcx->tc_creds_on)
+		*credits = tcx->tc_creds;
+failed:
+	tcx->tc_creds_on = 0;
+	tcx->tc_creds = 0;
 	return rc;
 }
 

--- a/src/common/btree_class.c
+++ b/src/common/btree_class.c
@@ -143,12 +143,12 @@ destroy_tree(daos_handle_t tree, d_iov_t *key)
 		return rc;
 
 	if (btr_check_tx(&attr) == BTR_NO_TX) {
-		rc = dbtree_destroy(hdl);
+		rc = dbtree_destroy(hdl, NULL);
 		if (rc != 0) {
 			dbtree_close(hdl);
 			D_GOTO(out, rc);
 		}
-		rc = dbtree_delete(tree, key, NULL);
+		rc = dbtree_delete(tree, BTR_PROBE_EQ, key, NULL);
 		if (rc != 0)
 			D_GOTO(out, rc);
 	} else {
@@ -163,10 +163,10 @@ destroy_tree(daos_handle_t tree, d_iov_t *key)
 			return rc_tmp;
 		}
 
-		rc_tmp = dbtree_destroy(hdl_tmp);
+		rc_tmp = dbtree_destroy(hdl_tmp, NULL);
 		if (rc_tmp == 0) {
 			hdl_tmp = DAOS_HDL_INVAL;
-			rc_tmp = dbtree_delete(tree, key, NULL);
+			rc_tmp = dbtree_delete(tree, BTR_PROBE_EQ, key, NULL);
 		}
 
 		if (!daos_handle_is_inval(hdl_tmp))
@@ -462,7 +462,7 @@ dbtree_nv_delete(daos_handle_t tree, const void *key, size_t key_size)
 
 	d_iov_set(&key_iov, (void *)key, key_size);
 
-	rc = dbtree_delete(tree, &key_iov, NULL);
+	rc = dbtree_delete(tree, BTR_PROBE_EQ, &key_iov, NULL);
 	if (rc != 0) {
 		if (rc == -DER_NONEXIST)
 			D_DEBUG(DB_TRACE, "cannot find \"%s\"\n", (char *)key);
@@ -784,7 +784,7 @@ dbtree_uv_delete(daos_handle_t tree, const uuid_t uuid)
 
 	d_iov_set(&key, (void *)uuid, sizeof(uuid_t));
 
-	rc = dbtree_delete(tree, &key, NULL);
+	rc = dbtree_delete(tree, BTR_PROBE_EQ, &key, NULL);
 	if (rc != 0) {
 		if (rc == -DER_NONEXIST)
 			D_DEBUG(DB_TRACE, "cannot find "DF_UUID"\n",
@@ -1046,7 +1046,7 @@ dbtree_ec_delete(daos_handle_t tree, uint64_t epoch)
 
 	d_iov_set(&key, &epoch, sizeof(epoch));
 
-	rc = dbtree_delete(tree, &key, NULL);
+	rc = dbtree_delete(tree, BTR_PROBE_EQ, &key, NULL);
 	if (rc == -DER_NONEXIST)
 		D_DEBUG(DB_TRACE, "cannot find "DF_U64"\n", epoch);
 	else if (rc != 0)

--- a/src/common/tests/btree.sh
+++ b/src/common/tests/btree.sh
@@ -102,6 +102,11 @@ run_test()
         -o                                          \
         -b "$BAT_NUM"                               \
         -D
+
+        echo "B+tree drain test..."
+        "${VCMD[@]}" "$BTR" "${DYN}" "${PMEM}" -C "${UINT}${IPL}o:$ORDER" \
+        -e -D
+
     else
         echo "B+tree performance test..."
         "${VCMD[@]}" "$BTR" "${DYN}" "${PMEM}" -C "${UINT}${IPL}o:$ORDER" \

--- a/src/common/tests/btree_direct.c
+++ b/src/common/tests/btree_direct.c
@@ -385,7 +385,7 @@ sk_btr_close_destroy(void **state)
 
 	if (destroy) {
 		D_PRINT("Destroy btree\n");
-		rc = dbtree_destroy(sk_toh);
+		rc = dbtree_destroy(sk_toh, NULL);
 	} else {
 		D_PRINT("Close btree\n");
 		rc = dbtree_close(sk_toh);
@@ -497,7 +497,8 @@ sk_btr_kv_operate(void **state)
 			break;
 
 		case BTR_OPC_DELETE:
-			rc = dbtree_delete(sk_toh, &key_iov, NULL);
+			rc = dbtree_delete(sk_toh, BTR_PROBE_EQ,
+					   &key_iov, NULL);
 			if (rc != 0) {
 				sprintf(outbuf, "Failed to delete %s\n", key);
 				fail_msg("%s", outbuf);
@@ -510,7 +511,8 @@ sk_btr_kv_operate(void **state)
 			break;
 
 		case BTR_OPC_DELETE_RETAIN:
-			rc = dbtree_delete(sk_toh, &key_iov, &rec_off);
+			rc = dbtree_delete(sk_toh, BTR_PROBE_EQ,
+					   &key_iov, &rec_off);
 			if (rc != 0) {
 				sprintf(outbuf, "Failed to delete %s\n", key);
 				fail_msg("%s", outbuf);

--- a/src/container/container_iv.c
+++ b/src/container/container_iv.c
@@ -132,7 +132,7 @@ cont_iv_ent_init(struct ds_iv_key *iv_key, void *data,
 	memcpy(entry->iv_value.sg_iovs[0].iov_buf, &root_hdl, sizeof(root_hdl));
 out:
 	if (rc != 0) {
-		dbtree_destroy(root_hdl);
+		dbtree_destroy(root_hdl, NULL);
 		daos_sgl_fini(&entry->iv_value, true);
 	}
 
@@ -189,7 +189,7 @@ cont_iv_ent_destroy(d_sg_list_t *sgl)
 				return rc;
 			}
 		}
-		dbtree_destroy(*root_hdl);
+		dbtree_destroy(*root_hdl, NULL);
 	}
 
 	daos_sgl_fini(sgl, true);

--- a/src/dtx/dtx_rpc.c
+++ b/src/dtx/dtx_rpc.c
@@ -594,7 +594,7 @@ out:
 		D_FREE(dti);
 
 	if (!daos_handle_is_inval(tree_hdl))
-		dbtree_destroy(tree_hdl);
+		dbtree_destroy(tree_hdl, NULL);
 
 	D_ASSERT(d_list_empty(&head));
 
@@ -654,7 +654,7 @@ out:
 		D_FREE(dti);
 
 	if (!daos_handle_is_inval(tree_hdl))
-		dbtree_destroy(tree_hdl);
+		dbtree_destroy(tree_hdl, NULL);
 
 	D_ASSERT(d_list_empty(&head));
 

--- a/src/include/daos/btree.h
+++ b/src/include/daos/btree.h
@@ -331,7 +331,8 @@ typedef struct {
 	 * \param args	[OUT]
 	 *			Optional: opaque buffer for providing arguments
 	 *			to handle special cases for free. for example,
-	 *			to return the freed record to the user
+	 *			allocator/GC address for externally allocated
+	 *			resources.
 	 */
 	int		(*to_rec_free)(struct btr_instance *tins,
 				       struct btr_record *rec, void *args);
@@ -496,14 +497,16 @@ int  dbtree_open_inplace(struct btr_root *root, struct umem_attr *uma,
 int  dbtree_open_inplace_ex(struct btr_root *root, struct umem_attr *uma,
 			    daos_handle_t coh, void *info, daos_handle_t *toh);
 int  dbtree_close(daos_handle_t toh);
-int  dbtree_destroy(daos_handle_t toh);
+int  dbtree_destroy(daos_handle_t toh, void *args);
+int  dbtree_drain(daos_handle_t toh, int *credits, void *args, bool *destroyed);
 int  dbtree_lookup(daos_handle_t toh, d_iov_t *key, d_iov_t *val_out);
 int  dbtree_update(daos_handle_t toh, d_iov_t *key, d_iov_t *val);
 int  dbtree_fetch(daos_handle_t toh, dbtree_probe_opc_t opc, uint32_t intent,
 		  d_iov_t *key, d_iov_t *key_out, d_iov_t *val_out);
 int  dbtree_upsert(daos_handle_t toh, dbtree_probe_opc_t opc, uint32_t intent,
 		   d_iov_t *key, d_iov_t *val);
-int  dbtree_delete(daos_handle_t toh, d_iov_t *key, void *args);
+int  dbtree_delete(daos_handle_t toh, dbtree_probe_opc_t opc,
+		   d_iov_t *key, void *args);
 int  dbtree_query(daos_handle_t toh, struct btr_attr *attr,
 		  struct btr_stat *stat);
 int  dbtree_is_empty(daos_handle_t toh);

--- a/src/object/cli_obj.c
+++ b/src/object/cli_obj.c
@@ -1196,7 +1196,7 @@ obj_recx_valid(unsigned int nr, daos_recx_t *recxs, bool update)
 				break;
 			}
 		}
-		dbtree_destroy(bth);
+		dbtree_destroy(bth, NULL);
 		break;
 	};
 

--- a/src/rebuild/initiator.c
+++ b/src/rebuild/initiator.c
@@ -1111,7 +1111,7 @@ rebuilt_btr_destory_cb(daos_handle_t ih, d_iov_t *key_iov,
 	struct rebuild_root		*root = val_iov->iov_buf;
 	int				rc;
 
-	rc = dbtree_destroy(root->root_hdl);
+	rc = dbtree_destroy(root->root_hdl, NULL);
 	if (rc)
 		D_ERROR("dbtree_destroy, cont "DF_UUID" failed, rc %d.\n",
 			DP_UUID(*(uuid_t *)key_iov->iov_buf), rc);
@@ -1131,7 +1131,7 @@ rebuilt_btr_destroy(daos_handle_t btr_hdl)
 		goto out;
 	}
 
-	rc = dbtree_destroy(btr_hdl);
+	rc = dbtree_destroy(btr_hdl, NULL);
 
 out:
 	return rc;
@@ -1237,7 +1237,7 @@ rebuild_scheduled_obj_insert_cb(struct rebuild_root *cont_root, uuid_t co_uuid,
 		/* possible get more req due to reply lost */
 		if (roid->ro_req_recv >= roid_tmp.ro_req_expect ||
 		    roid->ro_req_recv == 0) {
-			rc = dbtree_delete(cont_root->root_hdl,
+			rc = dbtree_delete(cont_root->root_hdl, BTR_PROBE_EQ,
 					   &key_iov, NULL);
 			if (rc == 0) {
 				*cnt -= 1;

--- a/src/rebuild/scan.c
+++ b/src/rebuild/scan.c
@@ -324,7 +324,7 @@ rebuild_tgt_fini_obj_send_cb(daos_handle_t ih, d_iov_t *key_iov,
 	if (rc < 0)
 		return rc;
 
-	rc = dbtree_destroy(root->root_hdl);
+	rc = dbtree_destroy(root->root_hdl, NULL);
 	if (rc)
 		return rc;
 
@@ -393,7 +393,7 @@ rebuild_tree_create(daos_handle_t toh, unsigned int tree_class,
 out:
 	if (rc < 0) {
 		if (!daos_handle_is_inval(root.root_hdl))
-			dbtree_destroy(root.root_hdl);
+			dbtree_destroy(root.root_hdl, NULL);
 	}
 	return rc;
 }
@@ -738,7 +738,7 @@ put_plmap:
 	pl_map_disconnect(rpt->rt_pool_uuid);
 out_map:
 	rebuild_pool_map_put(map);
-	dbtree_destroy(arg->rebuild_tree_hdl);
+	dbtree_destroy(arg->rebuild_tree_hdl, NULL);
 	tls = rebuild_pool_tls_lookup(rpt->rt_pool_uuid, rpt->rt_rebuild_ver);
 	D_ASSERT(tls != NULL);
 	if (tls->rebuild_pool_status == 0 && rc != 0)
@@ -866,7 +866,7 @@ rebuild_tgt_scan_handler(crt_rpc_t *rpc)
 
 	D_GOTO(out, rc);
 out_tree:
-	dbtree_destroy(scan_arg->rebuild_tree_hdl);
+	dbtree_destroy(scan_arg->rebuild_tree_hdl, NULL);
 out_lock:
 	ABT_mutex_free(&scan_arg->scan_lock);
 out_arg:

--- a/src/rebuild/srv.c
+++ b/src/rebuild/srv.c
@@ -993,7 +993,7 @@ rpt_destroy(struct rebuild_tgt_pool_tracker *rpt)
 	D_ASSERT(rpt->rt_refcount == 0);
 	D_ASSERT(d_list_empty(&rpt->rt_list));
 	if (!daos_handle_is_inval(rpt->rt_tobe_rb_root_hdl)) {
-		dbtree_destroy(rpt->rt_tobe_rb_root_hdl);
+		dbtree_destroy(rpt->rt_tobe_rb_root_hdl, NULL);
 		rpt->rt_tobe_rb_root_hdl = DAOS_HDL_INVAL;
 	}
 	if (!daos_handle_is_inval(rpt->rt_rebuilt_root_hdl)) {

--- a/src/vea/vea_alloc.c
+++ b/src/vea/vea_alloc.c
@@ -64,7 +64,7 @@ compound_alloc(struct vea_space_info *vsi, struct vea_free_extent *vfe,
 	free_class_remove(&vsi->vsi_class, entry);
 
 	d_iov_set(&key, &remain.vfe_blk_off, sizeof(remain.vfe_blk_off));
-	rc = dbtree_delete(vsi->vsi_free_btr, &key, NULL);
+	rc = dbtree_delete(vsi->vsi_free_btr, BTR_PROBE_EQ, &key, NULL);
 	if (rc)
 		return rc;
 
@@ -410,7 +410,7 @@ persistent_alloc(struct vea_space_info *vsi, struct vea_free_extent *vfe)
 	}
 
 	/* Remove the original free extent from persistent tree */
-	rc = dbtree_delete(btr_hdl, &key_out, NULL);
+	rc = dbtree_delete(btr_hdl, BTR_PROBE_EQ, &key_out, NULL);
 	if (rc)
 		return rc;
 

--- a/src/vea/vea_api.c
+++ b/src/vea/vea_api.c
@@ -41,14 +41,14 @@ erase_md(struct umem_instance *umem, struct vea_space_df *md)
 	uma.uma_pool = umem->umm_pool;
 	rc = dbtree_open_inplace(&md->vsd_free_tree, &uma, &free_btr);
 	if (rc == 0) {
-		rc = dbtree_destroy(free_btr);
+		rc = dbtree_destroy(free_btr, NULL);
 		if (rc)
 			D_ERROR("destroy free extent tree error: %d\n", rc);
 	}
 
 	rc = dbtree_open_inplace(&md->vsd_vec_tree, &uma, &vec_btr);
 	if (rc == 0) {
-		rc = dbtree_destroy(vec_btr);
+		rc = dbtree_destroy(vec_btr, NULL);
 		if (rc)
 			D_ERROR("destroy vector tree error: %d\n", rc);
 	}
@@ -185,19 +185,19 @@ vea_unload(struct vea_space_info *vsi)
 
 	/* Destroy the in-memory free extent tree */
 	if (!daos_handle_is_inval(vsi->vsi_free_btr)) {
-		dbtree_destroy(vsi->vsi_free_btr);
+		dbtree_destroy(vsi->vsi_free_btr, NULL);
 		vsi->vsi_free_btr = DAOS_HDL_INVAL;
 	}
 
 	/* Destroy the in-memory extent vector tree */
 	if (!daos_handle_is_inval(vsi->vsi_vec_btr)) {
-		dbtree_destroy(vsi->vsi_vec_btr);
+		dbtree_destroy(vsi->vsi_vec_btr, NULL);
 		vsi->vsi_vec_btr = DAOS_HDL_INVAL;
 	}
 
 	/* Destroy the in-memory aggregation tree */
 	if (!daos_handle_is_inval(vsi->vsi_agg_btr)) {
-		dbtree_destroy(vsi->vsi_agg_btr);
+		dbtree_destroy(vsi->vsi_agg_btr, NULL);
 		vsi->vsi_agg_btr = DAOS_HDL_INVAL;
 	}
 

--- a/src/vea/vea_free.c
+++ b/src/vea/vea_free.c
@@ -114,7 +114,7 @@ repeat:
 		else if (type == VEA_TYPE_AGGREGATE)
 			d_list_del_init(&entry->ve_link);
 
-		rc = dbtree_delete(btr_hdl, &key_out, NULL);
+		rc = dbtree_delete(btr_hdl, BTR_PROBE_EQ, &key_out, NULL);
 		if (rc)
 			return rc;
 	}
@@ -354,7 +354,7 @@ migrate_end_cb(void *data, bool noop)
 		 */
 		d_iov_set(&key, &vfe.vfe_blk_off, sizeof(vfe.vfe_blk_off));
 		D_ASSERT(!daos_handle_is_inval(vsi->vsi_agg_btr));
-		rc = dbtree_delete(vsi->vsi_agg_btr, &key, NULL);
+		rc = dbtree_delete(vsi->vsi_agg_btr, BTR_PROBE_EQ, &key, NULL);
 		if (rc) {
 			D_ERROR("Remove ["DF_U64", %u] from aggregated "
 				"tree error: %d\n", vfe.vfe_blk_off,

--- a/src/vos/vos_container.c
+++ b/src/vos/vos_container.c
@@ -197,7 +197,7 @@ cont_free(struct d_ulink *ulink)
 	D_ASSERT(cont->vc_open_count == 0);
 
 	if (!daos_handle_is_inval(cont->vc_dtx_cos_hdl))
-		dbtree_destroy(cont->vc_dtx_cos_hdl);
+		dbtree_destroy(cont->vc_dtx_cos_hdl, NULL);
 	D_ASSERT(d_list_empty(&cont->vc_dtx_committable));
 	dbtree_close(cont->vc_dtx_active_hdl);
 	dbtree_close(cont->vc_dtx_committed_hdl);
@@ -551,7 +551,7 @@ vos_cont_destroy(daos_handle_t poh, uuid_t co_uuid)
 	}
 
 	d_iov_set(&iov, &key, sizeof(struct d_uuid));
-	rc = dbtree_delete(vpool->vp_cont_th, &iov, NULL);
+	rc = dbtree_delete(vpool->vp_cont_th, BTR_PROBE_EQ, &iov, NULL);
 
 end:
 	rc = vos_tx_end(vpool, rc);

--- a/src/vos/vos_dtx_cos.c
+++ b/src/vos/vos_dtx_cos.c
@@ -514,7 +514,8 @@ vos_dtx_del_cos(struct vos_container *cont, daos_unit_oid_t *oid,
 			dcr->dcr_update_count--;
 
 		if (dcr->dcr_punch_count == 0 && dcr->dcr_update_count == 0)
-			dbtree_delete(cont->vc_dtx_cos_hdl, &kiov, NULL);
+			dbtree_delete(cont->vc_dtx_cos_hdl, BTR_PROBE_EQ,
+				      &kiov, NULL);
 
 		return;
 	}

--- a/src/vos/vos_obj_index.c
+++ b/src/vos/vos_obj_index.c
@@ -183,7 +183,7 @@ oi_rec_free(struct btr_instance *tins, struct btr_record *rec, void *args)
 		if (rc != 0)
 			D_ERROR("Failed to open OI tree: %d\n", rc);
 		else
-			dbtree_destroy(toh);
+			dbtree_destroy(toh, NULL);
 	}
 	umem_free(umm, rec->rec_off);
 	return rc;
@@ -740,7 +740,7 @@ vos_obj_tab_destroy(struct vos_pool *pool, struct vos_obj_table_df *otab_df)
 		D_GOTO(exit, rc = -DER_NONEXIST);
 	}
 
-	rc = dbtree_destroy(btr_hdl);
+	rc = dbtree_destroy(btr_hdl, NULL);
 	if (rc)
 		D_ERROR("OI BTREE destroy failed\n");
 exit:

--- a/src/vos/vos_tree.c
+++ b/src/vos/vos_tree.c
@@ -429,7 +429,7 @@ ktr_rec_free(struct btr_instance *tins, struct btr_record *rec, void *args)
 		if (rc != 0)
 			D_ERROR("Failed to open btree: %d\n", rc);
 		else
-			dbtree_destroy(toh);
+			dbtree_destroy(toh, NULL);
 	} /* It's possible that neither tree is created in case of punch only */
 exit:
 	umem_free(&tins->ti_umm, rec->rec_off);
@@ -1086,7 +1086,7 @@ key_tree_punch(struct vos_object *obj, daos_handle_t toh, d_iov_t *key_iov,
 		kbund2.kb_key	= kbund->kb_key;
 		kbund2.kb_epoch	= DAOS_EPOCH_MAX;
 
-		rc = dbtree_delete(toh, &tmp, NULL);
+		rc = dbtree_delete(toh, BTR_PROBE_EQ, &tmp, NULL);
 		if (rc)
 			D_ERROR("Failed to delete: %d\n", rc);
 	} else {


### PR DESCRIPTION
This patch is for follow-on feature VOS garbage collection,
it includes a few dbtree API changes:

- Add a new API dbtree_drain
  This function drains key/values from the tree, each time it frees
  a KV pair it consumes a "credit" which is input paramter of this
  function. It returns if all input credits are consumed, or the tree
  is empty, in the later case, it also destroys the btree.

- Export probe_opc for dbtree_delete
  The future work of DAOS-2540 will need it.

- Add an extra argument for dbtree_destroy
  dbtree_delete() allows user to pass in a "void *" parameter to
  pass in extra information for the delete, e.g. allocator for
  the externally allocated resources stored in the tree.
  dbtree_destroy() should have the same parameter because it frees
  leaf record as well.

Signed-off-by: Liang Zhen <liang.zhen@intel.com>