### PR TITLE
DAOS-2905: test: daos_test -O timeout dangerously low

### DIFF
--- a/src/tests/ftest/daos_test/daos_core_test.yaml
+++ b/src/tests/ftest/daos_test/daos_core_test.yaml
@@ -56,4 +56,4 @@ daos_tests:
     test_O:
       daos_test: O
       test_name: OID Allocator tests
-      test_timeout: 900
+      test_timeout: 1350


### PR DESCRIPTION
The 900s timeout for the DaosCore -O test is dangerously low.  The test
is taking in the 13-14m rnage currently and can timeout easily.  Let's
increase to 1350.