### PR TITLE
DAOS-2916 control: fix display of nvme storage responses

### DIFF
--- a/src/control/client/mocks.go
+++ b/src/control/client/mocks.go
@@ -40,7 +40,7 @@ import (
 var (
 	MockServers  = Addresses{"1.2.3.4:10000", "1.2.3.5:10001"}
 	MockFeatures = []*pb.Feature{MockFeaturePB()}
-	MockCtrlrs   = NvmeControllers{MockControllerPB("")}
+	MockCtrlrs   = NvmeControllers{MockControllerPB("E2010413")}
 	MockState    = pb.ResponseState{
 		Status: pb.ResponseStatus_CTRL_ERR_APP,
 		Error:  "example application error",

--- a/src/control/cmd/dmg/utils_test.go
+++ b/src/control/cmd/dmg/utils_test.go
@@ -88,7 +88,7 @@ func TestCheckSprint(t *testing.T) {
 		},
 		{
 			NewClientNvme(MockCtrlrs, MockServers).String(),
-			"1.2.3.4:10000:\n\tPCI Address:0000:81:00.0 Serial:123ABC Model:ABC\n\t\tNamespace: id:12345 capacity:99999 \n\n1.2.3.5:10001:\n\tPCI Address:0000:81:00.0 Serial:123ABC Model:ABC\n\t\tNamespace: id:12345 capacity:99999 \n\n",
+			"1.2.3.4:10000:\n\tPCI Address:0000:81:00.0 Serial:123ABC\n\tModel:ABC Fwrev:E2010413\n\t\tNamespace: id:12345 capacity:99999 \n\n1.2.3.5:10001:\n\tPCI Address:0000:81:00.0 Serial:123ABC\n\tModel:ABC Fwrev:E2010413\n\t\tNamespace: id:12345 capacity:99999 \n\n",
 		},
 		{
 			NewClientScm(MockModules, MockServers).String(),

--- a/src/control/common/storage_types.go
+++ b/src/control/common/storage_types.go
@@ -39,8 +39,8 @@ func (nc NvmeControllers) String() string {
 
 	for _, ctrlr := range nc {
 		fmt.Fprintf(
-			&buf, "\tPCI Address:%s Serial:%s Model:%s\n",
-			ctrlr.Pciaddr, ctrlr.Serial, ctrlr.Model)
+			&buf, "\tPCI Address:%s Serial:%s\n\tModel:%s Fwrev:%s\n",
+			ctrlr.Pciaddr, ctrlr.Serial, ctrlr.Model, ctrlr.Fwrev)
 
 		for _, ns := range ctrlr.Namespaces {
 			fmt.Fprintf(

--- a/src/control/server/mgmt_storage.go
+++ b/src/control/server/mgmt_storage.go
@@ -79,10 +79,13 @@ func (c *controlService) doFormat(i int, resp *pb.FormatStorageResp) error {
 		serverFormatted = true
 	}
 
-	ctrlrResults := common.NvmeControllerResults(resp.Crets)
+	ctrlrResults := common.NvmeControllerResults{}
 	c.nvme.Format(i, &ctrlrResults)
-	mountResults := common.ScmMountResults(resp.Mrets)
+	resp.Crets = ctrlrResults
+
+	mountResults := common.ScmMountResults{}
 	c.scm.Format(i, &mountResults)
+	resp.Mrets = mountResults
 
 	if !serverFormatted && c.nvme.formatted && c.scm.formatted {
 		// storage subsystem format successful, broadcast formatted
@@ -133,10 +136,13 @@ func (c *controlService) UpdateStorage(
 	resp := new(pb.UpdateStorageResp)
 
 	for i := range c.config.Servers {
-		ctrlrResults := common.NvmeControllerResults(resp.Crets)
+		ctrlrResults := common.NvmeControllerResults{}
 		c.nvme.Update(i, req.Nvme, &ctrlrResults)
-		moduleResults := common.ScmModuleResults(resp.Mrets)
+		resp.Crets = ctrlrResults
+
+		moduleResults := common.ScmModuleResults{}
 		c.scm.Update(i, req.Scm, &moduleResults)
+		resp.Mrets = moduleResults
 	}
 
 	if err := stream.Send(resp); err != nil {


### PR DESCRIPTION
Fix display of NVMe storage request results including adding firmware
revision of controllers to details displayed and correcting the population
of device results for format and update actions in response over gRPC.

Signed-off-by: Tom Nabarro <tom.nabarro@intel.com>