### PR TITLE
DAOS-2281 dfuse: Correctly set fi->fh in create() and use elsewhere.

### DIFF
--- a/src/client/dfuse/dfuse.h
+++ b/src/client/dfuse/dfuse.h
@@ -503,7 +503,7 @@ dfuse_cb_symlink(fuse_req_t, const char *, struct dfuse_inode_entry *,
 void
 dfuse_reply_entry(struct dfuse_projection_info *fs_handle,
 		  struct dfuse_inode_entry *inode,
-		  bool create,
+		  struct fuse_file_info *fi_out,
 		  fuse_req_t req);
 
 /* dfuse_cont.c */

--- a/src/client/dfuse/dfuse_cont.c
+++ b/src/client/dfuse/dfuse_cont.c
@@ -152,7 +152,7 @@ dfuse_cont_open(fuse_req_t req, struct dfuse_inode_entry *parent,
 	dfs->dfs_root = ie->ie_stat.st_ino;
 	dfs->dfs_ops = &dfuse_dfs_ops;
 
-	dfuse_reply_entry(fs_handle, ie, false, req);
+	dfuse_reply_entry(fs_handle, ie, NULL, req);
 	return true;
 
 release:

--- a/src/client/dfuse/dfuse_pool.c
+++ b/src/client/dfuse/dfuse_pool.c
@@ -150,7 +150,7 @@ dfuse_pool_lookup(fuse_req_t req, struct dfuse_inode_entry *parent,
 	dfs->dfs_root = ie->ie_stat.st_ino;
 	dfs->dfs_ops = &dfuse_cont_ops;
 
-	dfuse_reply_entry(fs_handle, ie, false, req);
+	dfuse_reply_entry(fs_handle, ie, NULL, req);
 	return true;
 close:
 	daos_pool_disconnect(dfs->dfs_poh, NULL);

--- a/src/client/dfuse/ops/lookup.c
+++ b/src/client/dfuse/ops/lookup.c
@@ -27,7 +27,7 @@
 void
 dfuse_reply_entry(struct dfuse_projection_info *fs_handle,
 		  struct dfuse_inode_entry *ie,
-		  bool create,
+		  struct fuse_file_info *fi_out,
 		  fuse_req_t req)
 {
 	struct fuse_entry_param	entry = {0};
@@ -69,10 +69,8 @@ dfuse_reply_entry(struct dfuse_projection_info *fs_handle,
 		ie_close(fs_handle, ie);
 	}
 
-	if (create) {
-		struct fuse_file_info fi = {0};
-
-		DFUSE_REPLY_CREATE(req, entry, &fi);
+	if (fi_out) {
+		DFUSE_REPLY_CREATE(req, entry, fi_out);
 	} else {
 		DFUSE_REPLY_ENTRY(req, entry);
 	}
@@ -130,7 +128,7 @@ dfuse_cb_lookup(fuse_req_t req, struct dfuse_inode_entry *parent,
 						      1);
 	}
 
-	dfuse_reply_entry(fs_handle, ie, false, req);
+	dfuse_reply_entry(fs_handle, ie, NULL, req);
 	return true;
 
 err:

--- a/src/client/dfuse/ops/opendir.c
+++ b/src/client/dfuse/ops/opendir.c
@@ -55,22 +55,15 @@ void
 dfuse_cb_releasedir(fuse_req_t req, struct dfuse_inode_entry *ino,
 		    struct fuse_file_info *fi)
 {
-	struct dfuse_obj_hdl	*oh;
+	struct dfuse_obj_hdl	*oh = (struct dfuse_obj_hdl *)fi->fh;
 	int			rc;
-
-	if (fi == NULL || fi->fh == 0) {
-		fuse_reply_err(req, 0);
-		return;
-	}
-
-	oh = (struct dfuse_obj_hdl *)fi->fh;
 
 	rc = dfs_release(oh->doh_obj);
 	if (rc == 0) {
-		D_FREE(oh->doh_buf);
-		D_FREE(oh);
-		fi->fh = 0;
+		DFUSE_FUSE_REPLY_ZERO(req);
+	} else {
+		DFUSE_REPLY_ERR_RAW(oh, req, -rc);
 	}
-
-	fuse_reply_err(req, -rc);
-}
+	D_FREE(oh->doh_buf);
+	D_FREE(oh);
+};

--- a/src/client/dfuse/ops/read.c
+++ b/src/client/dfuse/ops/read.c
@@ -28,9 +28,7 @@ void
 dfuse_cb_read(fuse_req_t req, fuse_ino_t ino, size_t len, off_t position,
 	      struct fuse_file_info *fi)
 {
-	struct dfuse_projection_info	*fsh = fuse_req_userdata(req);
-	struct dfuse_inode_entry	*ie;
-	d_list_t			*rlink;
+	struct dfuse_obj_hdl		*oh = (struct dfuse_obj_hdl *)fi->fh;
 	d_iov_t				iov = {};
 	d_sg_list_t			sgl = {};
 	daos_size_t			size;
@@ -47,34 +45,11 @@ dfuse_cb_read(fuse_req_t req, fuse_ino_t ino, size_t len, off_t position,
 	d_iov_set(&iov, (void *)buff, len);
 	sgl.sg_iovs = &iov;
 
-	if (fi && fi->fh) {
-		struct dfuse_obj_hdl *oh = (struct dfuse_obj_hdl *)fi->fh;
-
-		rc = dfs_read(oh->doh_dfs, oh->doh_obj, sgl, position, &size);
-		if (rc == 0) {
-			fuse_reply_buf(req, buff, size);
-		} else {
-			DFUSE_REPLY_ERR_RAW(NULL, req, -rc);
-			D_FREE(buff);
-		}
-		return;
-	}
-
-	rlink = d_hash_rec_find(&fsh->dpi_iet, &ino, sizeof(ino));
-	if (!rlink) {
-		DFUSE_TRA_ERROR(fsh, "Failed to find inode %lu", ino);
-		DFUSE_REPLY_ERR_RAW(NULL, req, ENOENT);
-		return;
-	}
-
-	ie = container_of(rlink, struct dfuse_inode_entry, ie_htl);
-
-	rc = dfs_read(ie->ie_dfs->dfs_ns, ie->ie_obj, sgl, position, &size);
+	rc = dfs_read(oh->doh_dfs, oh->doh_obj, sgl, position, &size);
 	if (rc == 0) {
-		rc = fuse_reply_buf(req, buff, size);
+		fuse_reply_buf(req, buff, size);
 	} else {
 		DFUSE_REPLY_ERR_RAW(NULL, req, -rc);
 		D_FREE(buff);
 	}
-	d_hash_rec_decref(&fsh->dpi_iet, rlink);
 }

--- a/src/client/dfuse/ops/symlink.c
+++ b/src/client/dfuse/ops/symlink.c
@@ -63,7 +63,7 @@ dfuse_cb_symlink(fuse_req_t req, const char *link,
 
 	DFUSE_TRA_INFO(ie, "Inserting inode %lu", ie->ie_stat.st_ino);
 
-	dfuse_reply_entry(fs_handle, ie, false, req);
+	dfuse_reply_entry(fs_handle, ie, NULL, req);
 
 	return;
 err:

--- a/src/client/dfuse/ops/write.c
+++ b/src/client/dfuse/ops/write.c
@@ -28,9 +28,7 @@ void
 dfuse_cb_write(fuse_req_t req, fuse_ino_t ino, const char *buff, size_t len,
 	       off_t position, struct fuse_file_info *fi)
 {
-	struct dfuse_projection_info	*fsh = fuse_req_userdata(req);
-	struct dfuse_inode_entry	*ie;
-	d_list_t			*rlink;
+	struct dfuse_obj_hdl		*oh = (struct dfuse_obj_hdl *)fi->fh;
 	d_iov_t				iov = {};
 	d_sg_list_t			sgl = {};
 	int				rc;
@@ -39,31 +37,9 @@ dfuse_cb_write(fuse_req_t req, fuse_ino_t ino, const char *buff, size_t len,
 	d_iov_set(&iov, (void *)buff, len);
 	sgl.sg_iovs = &iov;
 
-	if (fi && fi->fh) {
-		struct dfuse_obj_hdl *oh = (struct dfuse_obj_hdl *)fi->fh;
-
-		rc = dfs_write(oh->doh_dfs, oh->doh_obj, sgl, position);
-		if (rc == 0)
-			DFUSE_REPLY_WRITE(NULL, req, len);
-		else
-			DFUSE_REPLY_ERR_RAW(NULL, req, -rc);
-		return;
-	}
-
-	rlink = d_hash_rec_find(&fsh->dpi_iet, &ino, sizeof(ino));
-	if (!rlink) {
-		DFUSE_TRA_ERROR(fsh, "Failed to find inode %lu", ino);
-		DFUSE_REPLY_ERR_RAW(NULL, req, ENOENT);
-		return;
-	}
-
-	ie = container_of(rlink, struct dfuse_inode_entry, ie_htl);
-
-	rc = dfs_write(ie->ie_dfs->dfs_ns, ie->ie_obj, sgl, position);
+	rc = dfs_write(oh->doh_dfs, oh->doh_obj, sgl, position);
 	if (rc == 0)
-		DFUSE_REPLY_WRITE(ie, req, len);
+		DFUSE_REPLY_WRITE(oh, req, len);
 	else
-		DFUSE_REPLY_ERR_RAW(ie, req, -rc);
-
-	d_hash_rec_decref(&fsh->dpi_iet, rlink);
+		DFUSE_REPLY_ERR_RAW(oh, req, -rc);
 }


### PR DESCRIPTION
fi->fh was being set on a input struct, but not returned to fuse
as a different output struct was being created on the stack.  Create
a new fi_out struct and populate that where needed, change the
dfuse_reply_entry() to take a pointer to fi_out rather than a boolean
and update all use cases.

Fix a issue where the (previously unused) of was not setting the dfs
entry, leaving to EIO when enabled.

Remove code from read/write/release to handle open handles without
fi->fh set, as that condition can no longer happen.