### PR TITLE
DAOS-2920 control: miscellaneous minor changes

### DIFF
--- a/src/control/cmd/dmg/storage.go
+++ b/src/control/cmd/dmg/storage.go
@@ -68,8 +68,7 @@ func formatStor(conns client.Connect, force bool) {
 	fmt.Println(
 		"This is a destructive operation and storage devices " +
 			"specified in the server config file will be erased.\n" +
-			"Please be patient as it may take several minutes.\n" +
-			"Are you sure you want to continue? (yes/no)")
+			"Please be patient as it may take several minutes.\n")
 
 	if force || getConsent() {
 		fmt.Println("")
@@ -102,8 +101,7 @@ func updateStor(conns client.Connect, req *pb.UpdateStorageReq, force bool) {
 		"This could be a destructive operation and storage devices " +
 			"specified in the server config file will have firmware " +
 			"updated. Please check this is a supported upgrade path " +
-			"and be patient as it may take several minutes.\n" +
-			"Are you sure you want to continue? (yes/no)")
+			"and be patient as it may take several minutes.\n")
 
 	if force || getConsent() {
 		fmt.Println("")

--- a/src/control/cmd/dmg/utils.go
+++ b/src/control/cmd/dmg/utils.go
@@ -70,6 +70,8 @@ func sprintConns(results client.ResultMap) (out string) {
 func getConsent() bool {
 	var response string
 
+	fmt.Println("Are you sure you want to continue? (yes/no)")
+
 	_, err := fmt.Scanln(&response)
 	if err != nil {
 		fmt.Printf("Error reading input: %s\n", err)

--- a/src/control/server/config.go
+++ b/src/control/server/config.go
@@ -94,17 +94,15 @@ func (c *configuration) setPath(path string) error {
 
 // loadConfigOpts derives file location and parses configuration options
 // from both config file and commandline flags.
-func loadConfigOpts(cliOpts *cliOptions, host string) (
-	config configuration, err error) {
-
-	config = newConfiguration()
+func loadConfigOpts(cliOpts *cliOptions, host string) (*configuration, error) {
+	config := newConfiguration()
 
 	if err := config.setPath(cliOpts.ConfigPath); err != nil {
-		return config, errors.WithMessage(err, "set path")
+		return nil, errors.WithMessage(err, "set path")
 	}
 
 	if err := config.loadConfig(); err != nil {
-		return config, errors.WithMessagef(err, "loading %s", config.Path)
+		return nil, errors.WithMessagef(err, "loading %s", config.Path)
 	}
 	log.Debugf("DAOS config read from %s", config.Path)
 
@@ -116,20 +114,20 @@ func loadConfigOpts(cliOpts *cliOptions, host string) (
 	// get unique identifier to activate SPDK multiprocess mode
 	config.NvmeShmID = hash(host + strconv.Itoa(os.Getpid()))
 
-	if err = config.getIOParams(cliOpts); err != nil {
-		return config, errors.Wrap(
+	if err := config.getIOParams(cliOpts); err != nil {
+		return nil, errors.Wrap(
 			err, "failed to retrieve I/O service params")
 	}
 
 	if len(config.Servers) == 0 {
-		return config, errors.New("missing I/O service params")
+		return nil, errors.New("missing I/O service params")
 	}
 
 	for idx := range config.Servers {
 		config.Servers[idx].Hostname = host
 	}
 
-	return config, nil
+	return &config, nil
 }
 
 // saveActiveConfig saves read-only active config, tries config dir then /tmp/
@@ -382,9 +380,17 @@ func (c *configuration) setLogging(name string) (*os.File, error) {
 		return f, nil
 	}
 
+	log.Errorf("no control log file specified")
+
 	// if no logfile specified, output from multiple hosts
 	// may get aggregated, prefix entries with hostname
 	log.NewDefaultLogger(log.Debug, name+" ", os.Stderr)
+
+	for i, srv := range c.Servers {
+		if srv.LogFile == "" {
+			log.Errorf("no daos log file specified for server %d", i)
+		}
+	}
 
 	return nil, nil
 }

--- a/src/control/server/server.go
+++ b/src/control/server/server.go
@@ -74,19 +74,19 @@ func Main() error {
 	}
 
 	// Backup active config.
-	saveActiveConfig(&config)
+	saveActiveConfig(config)
 
-	f, err := config.setLogging(host)
+	ctlLogFile, err := config.setLogging(host)
 	if err != nil {
 		return errors.Wrap(err, "configure logging")
 	}
-	if f != nil {
-		defer f.Close()
+	if ctlLogFile != nil {
+		defer ctlLogFile.Close()
 	}
 
 	// Create and setup control service.
 	mgmtCtlSvc, err := newControlService(
-		&config, getDrpcClientConnection(config.SocketDir))
+		config, getDrpcClientConnection(config.SocketDir))
 	if err != nil {
 		return errors.Wrap(err, "init control server")
 	}
@@ -97,12 +97,11 @@ func Main() error {
 	addr := fmt.Sprintf("0.0.0.0:%d", config.Port)
 	lis, err := net.Listen("tcp4", addr)
 	if err != nil {
-		return errors.Wrap(err, "enable to listen on management interface")
+		return errors.Wrap(err, "unable to listen on management interface")
 	}
 	log.Debugf("DAOS control server listening on %s", addr)
 
-	// Create new grpc server, register services and start serving (after
-	// dropping privileges).
+	// Create new grpc server, register services and start serving.
 	var sOpts []grpc.ServerOption
 
 	opt, err := security.ServerOptionForTransportConfig(config.TransportConfig)
@@ -114,7 +113,7 @@ func Main() error {
 	grpcServer := grpc.NewServer(sOpts...)
 
 	mgmtpb.RegisterMgmtCtlServer(grpcServer, mgmtCtlSvc)
-	mgmtpb.RegisterMgmtSvcServer(grpcServer, newMgmtSvc(&config))
+	mgmtpb.RegisterMgmtSvcServer(grpcServer, newMgmtSvc(config))
 	secServer := newSecurityService(getDrpcClientConnection(config.SocketDir))
 	acl.RegisterAccessControlServer(grpcServer, secServer)
 
@@ -125,26 +124,26 @@ func Main() error {
 
 	// Wait for storage to be formatted if necessary and subsequently drop
 	// current process privileges to that of normal user.
-	if err = awaitStorageFormat(&config); err != nil {
+	if err = awaitStorageFormat(config); err != nil {
 		return errors.Wrap(err, "format storage")
 	}
 
 	// Format the unformatted servers by writing persistant superblock.
-	if err = formatIosrvs(&config, false); err != nil {
+	if err = formatIosrvs(config, false); err != nil {
 		return errors.Wrap(err, "format servers")
 	}
 
 	// Only start single io_server for now.
 	// TODO: Extend to start two io_servers per host.
-	iosrv, err := newIosrv(&config, 0)
+	iosrv, err := newIosrv(config, 0)
 	if err != nil {
-		return errors.Wrap(err, "load server")
+		return errors.WithMessage(err, "load server")
 	}
 	if err = drpcSetup(config.SocketDir, iosrv); err != nil {
-		return errors.Wrap(err, "set up dRPC")
+		return errors.WithMessage(err, "set up dRPC")
 	}
 	if err = iosrv.start(); err != nil {
-		return errors.Wrap(err, "start server")
+		return errors.WithMessage(err, "start server")
 	}
 
 	extraText, err := CheckReplica(lis, config.AccessPoints, iosrv.cmd)
@@ -156,7 +155,7 @@ func Main() error {
 	// Wait for I/O server to return.
 	err = iosrv.wait()
 	if err != nil {
-		return errors.Wrap(err, "DAOS I/O server exited with error")
+		return errors.WithMessage(err, "DAOS I/O server exited with error")
 	}
 
 	return err


### PR DESCRIPTION
Split out from DAOS-2644 for clarity.

* return config reference rather than dereferencing
* don't wrap errors unnecessarily
* log error if no io_srv logfile specified in config
* don't display confirmation prompt if force opt set

Signed-off-by: Tom Nabarro <tom.nabarro@intel.com>