### PR TITLE
DAOS-2921 DTX Fix DTX commit to work for EC objects.

### DIFF
--- a/src/dtx/dtx_rpc.c
+++ b/src/dtx/dtx_rpc.c
@@ -396,7 +396,8 @@ dtx_get_tgt_cnt(daos_unit_oid_t *oid, struct pl_obj_layout *layout)
 
 	/* XXX: Need some special handling for EC case in the future. */
 
-	if (oc_attr->ca_resil != DAOS_RES_REPL && oc_attr->ca_resil != DAOS_RES_EC)
+	if (oc_attr->ca_resil != DAOS_RES_REPL &&
+					 oc_attr->ca_resil != DAOS_RES_EC)
 		return -DER_NOTAPPLICABLE;
 	if ( oc_attr->ca_resil == DAOS_RES_REPL)
 		tgt_cnt = oc_attr->u.rp.r_num;

--- a/src/dtx/dtx_rpc.c
+++ b/src/dtx/dtx_rpc.c
@@ -399,7 +399,7 @@ dtx_get_tgt_cnt(daos_unit_oid_t *oid, struct pl_obj_layout *layout)
 	if (oc_attr->ca_resil != DAOS_RES_REPL &&
 					 oc_attr->ca_resil != DAOS_RES_EC)
 		return -DER_NOTAPPLICABLE;
-	if ( oc_attr->ca_resil == DAOS_RES_REPL)
+	if (oc_attr->ca_resil == DAOS_RES_REPL)
 		tgt_cnt = oc_attr->u.rp.r_num;
 	else {
 		D_ASSERT(oc_attr->ca_resil == DAOS_RES_EC);

--- a/src/dtx/dtx_rpc.c
+++ b/src/dtx/dtx_rpc.c
@@ -211,8 +211,8 @@ dtx_req_list_cb(void **args)
 			switch (drr->drr_result) {
 			case DTX_ST_COMMITTED:
 				dra->dra_result = DTX_ST_COMMITTED;
-				/* As long as one replica has committed the DTX,
-				 * then the DTX is committable on all replicas.
+				/* As long as one target has committed the DTX,
+				 * then the DTX is committable on all targets.
 				 */
 				D_DEBUG(DB_TRACE,
 					"The DTX "DF_DTI" has been committed "
@@ -384,10 +384,10 @@ btr_ops_t dbtree_dtx_cf_ops = {
 #define DTX_CF_BTREE_ORDER	20
 
 static int
-dtx_get_replicas(daos_unit_oid_t *oid, struct pl_obj_layout *layout)
+dtx_get_tgt_cnt(daos_unit_oid_t *oid, struct pl_obj_layout *layout)
 {
 	struct daos_oclass_attr	*oc_attr;
-	int			 replicas;
+	int			 tgt_cnt;
 
 	if (layout->ol_nr <= oid->id_shard)
 		return -DER_INVAL;
@@ -396,17 +396,22 @@ dtx_get_replicas(daos_unit_oid_t *oid, struct pl_obj_layout *layout)
 
 	/* XXX: Need some special handling for EC case in the future. */
 
-	if (oc_attr->ca_resil != DAOS_RES_REPL)
+	if (oc_attr->ca_resil != DAOS_RES_REPL && oc_attr->ca_resil != DAOS_RES_EC)
 		return -DER_NOTAPPLICABLE;
+	if ( oc_attr->ca_resil == DAOS_RES_REPL)
+		tgt_cnt = oc_attr->u.rp.r_num;
+	else {
+		D_ASSERT(oc_attr->ca_resil == DAOS_RES_EC);
+		tgt_cnt = oc_attr->u.ec.e_k + oc_attr->u.ec.e_p;
+	}
 
-	replicas = oc_attr->u.rp.r_num;
-	if (replicas == DAOS_OBJ_REPL_MAX)
-		replicas = layout->ol_grp_size;
+	if (tgt_cnt == DAOS_OBJ_REPL_MAX)
+		tgt_cnt = layout->ol_grp_size;
 
-	if (replicas < 1)
+	if (tgt_cnt < 1)
 		return -DER_INVAL;
 
-	return replicas;
+	return tgt_cnt;
 }
 
 static int
@@ -419,7 +424,7 @@ dtx_dti_classify_one(struct ds_pool *pool, struct pl_map *map, uuid_t po_uuid,
 	struct daos_obj_md		 md = { 0 };
 	struct dtx_cf_rec_bundle	 dcrb;
 	d_rank_t			 myrank;
-	int				 replicas;
+	int				 tgt_cnt;
 	int				 start;
 	int				 rc;
 	int				 i;
@@ -430,14 +435,14 @@ dtx_dti_classify_one(struct ds_pool *pool, struct pl_map *map, uuid_t po_uuid,
 	if (rc != 0)
 		return rc;
 
-	replicas = dtx_get_replicas(oid, layout);
-	if (replicas < 0) {
-		rc = replicas;
+	tgt_cnt = dtx_get_tgt_cnt(oid, layout);
+	if (tgt_cnt < 0) {
+		rc = tgt_cnt;
 		goto out;
 	}
 
-	/* Skip single replicated object. */
-	if (replicas == 1)
+	/* Skip single-redundancy object. */
+	if (tgt_cnt == 1)
 		D_GOTO(out, rc = 0);
 
 	dcrb.dcrb_count = count;
@@ -446,14 +451,14 @@ dtx_dti_classify_one(struct ds_pool *pool, struct pl_map *map, uuid_t po_uuid,
 	dcrb.dcrb_length = length;
 
 	crt_group_rank(pool->sp_group, &myrank);
-	start = (oid->id_shard / replicas) * replicas;
-	for (i = start; i < start + replicas && rc >= 0; i++) {
+	start = (oid->id_shard / tgt_cnt) * tgt_cnt;
+	for (i = start; i < start + tgt_cnt && rc >= 0; i++) {
 		struct pl_obj_shard	*shard;
 		struct pool_target	*target;
 		d_iov_t		 kiov;
 		d_iov_t		 riov;
 
-		/* skip unavailable replica(s). */
+		/* skip unavailable target(s). */
 		shard = &layout->ol_shards[i];
 		if (shard->po_target == -1 || shard->po_rebuilding)
 			continue;
@@ -542,10 +547,10 @@ out:
  * be committed by remote server via signle PMDK transaction.
  *
  * After the DTX classification, send DTX_COMMIT RPC to related servers, and
- * then call DTX commit locally. For a DTX, it is possible that some replicas
+ * then call DTX commit locally. For a DTX, it is possible that some targets
  * have committed successfully, but others failed. That is no matter. As long
- * as one replica has committed, then the DTX logic can re-sync those failed
- * replicas when dtx_resync() is triggered next time
+ * as one target has committed, then the DTX logic can re-sync those failed
+ * targets when dtx_resync() is triggered next time
  */
 int
 dtx_commit(uuid_t po_uuid, uuid_t co_uuid, struct dtx_entry *dtes,
@@ -680,7 +685,7 @@ dtx_check(uuid_t po_uuid, uuid_t co_uuid, struct dtx_entry *dte,
 	struct dtx_req_rec	*next;
 	d_list_t		 head;
 	d_rank_t		 myrank;
-	int			 replicas;
+	int			 tgt_cnt;
 	int			 length = 0;
 	int			 start;
 	int			 rc = 0;
@@ -689,14 +694,14 @@ dtx_check(uuid_t po_uuid, uuid_t co_uuid, struct dtx_entry *dte,
 	if (layout->ol_nr <= oid->id_shard)
 		return -DER_INVAL;
 
-	replicas = dtx_get_replicas(oid, layout);
-	if (replicas < 0)
-		return replicas;
+	tgt_cnt = dtx_get_tgt_cnt(oid, layout);
+	if (tgt_cnt < 0)
+		return tgt_cnt;
 
-	/* If no other replica, then currnet replica is the unique
+	/* If no other target, then current target is the unique
 	 * one that can be committed if it is 'prepared'.
 	 */
-	if (replicas == 1)
+	if (tgt_cnt == 1)
 		return DTX_ST_PREPARED;
 
 	pool = ds_pool_lookup(po_uuid);
@@ -705,12 +710,12 @@ dtx_check(uuid_t po_uuid, uuid_t co_uuid, struct dtx_entry *dte,
 
 	D_INIT_LIST_HEAD(&head);
 	crt_group_rank(pool->sp_group, &myrank);
-	start = (oid->id_shard / replicas) * replicas;
-	for (i = start; i < start + replicas; i++) {
+	start = (oid->id_shard / tgt_cnt) * tgt_cnt;
+	for (i = start; i < start + tgt_cnt; i++) {
 		struct pl_obj_shard	*shard;
 		struct pool_target	*target;
 
-		/* skip unavailable replica(s). */
+		/* skip unavailable target(s). */
 		shard = &layout->ol_shards[i];
 		if (shard->po_target == -1 || shard->po_rebuilding)
 			continue;
@@ -739,7 +744,7 @@ dtx_check(uuid_t po_uuid, uuid_t co_uuid, struct dtx_entry *dte,
 		length++;
 	}
 
-	/* If no other available replicas, then currnet replica is the
+	/* If no other available targets, then current target is the
 	 * unique valid one, it can be committed if it is also 'prepared'.
 	 */
 	if (d_list_empty(&head))


### PR DESCRIPTION
Changed former dtx_get_replica() function to properly use EC side of union
(in object class) to calculate target count. Change replica to target (or tgt).

Signed-off-by: Joseph Moore <joseph.moore@intel.com>