### PR TITLE
DAOS-2884 dtx: commit dtx during dtx_resync

### DIFF
--- a/src/common/tse_internal.h
+++ b/src/common/tse_internal.h
@@ -70,7 +70,7 @@ struct tse_task_private {
 					 dtp_completing:1,
 					/* task is in running state */
 					 dtp_running:1,
-					 dtp_dep_cnt:30;
+					 dtp_dep_cnt:29;
 	/* refcount of the task */
 	uint32_t			 dtp_refcnt;
 	/**

--- a/src/dtx/dtx_common.c
+++ b/src/dtx/dtx_common.c
@@ -429,42 +429,40 @@ dtx_conflict(daos_handle_t coh, struct dtx_leader_handle *dlh, uuid_t po_uuid,
 			}
 		}
 
-		if (!skip) {
-			rc = vos_dtx_lookup_cos(coh, oid, &dces[i].dce_xid,
-						dces[i].dce_dkey, true);
-			if (rc != -DER_NONEXIST)
-				goto found;
+		if (skip)
+			continue;
 
-			rc = vos_dtx_lookup_cos(coh, oid,
-						&dces[i].dce_xid,
-						dces[i].dce_dkey, false);
-			if (rc != -DER_NONEXIST)
-				goto found;
+		rc = vos_dtx_lookup_cos(coh, oid, &dces[i].dce_xid,
+					dces[i].dce_dkey, true);
+		if (rc != -DER_NONEXIST)
+			goto found;
 
-			rc = vos_dtx_check_committable(coh, NULL,
-						&dces[i].dce_xid,
-						dces[i].dce_dkey, true);
-			if (rc == DTX_ST_COMMITTED)
-				rc = 0;
-			else if (rc >= 0)
-				rc = -DER_NONEXIST;
+		rc = vos_dtx_lookup_cos(coh, oid, &dces[i].dce_xid,
+					dces[i].dce_dkey, false);
+		if (rc != -DER_NONEXIST)
+			goto found;
+
+		rc = vos_dtx_check(coh, &dces[i].dce_xid);
+		if (rc == DTX_ST_COMMITTED)
+			rc = 0;
+		else if (rc >= 0)
+			rc = -DER_NONEXIST;
 
 found:
-			if (rc == 0) {
-				daos_dti_copy(&commit_ids[commit_cnt++],
-					      &dces[i].dce_xid);
-				continue;
-			}
-
-			if (rc == -DER_NONEXIST) {
-				daos_dti_copy(&abort_dtes[abort_cnt].dte_xid,
-					      &dces[i].dce_xid);
-				abort_dtes[abort_cnt++].dte_oid = *oid;
-				continue;
-			}
-
-			goto out;
+		if (rc == 0) {
+			daos_dti_copy(&commit_ids[commit_cnt++],
+				      &dces[i].dce_xid);
+			continue;
 		}
+
+		if (rc == -DER_NONEXIST) {
+			daos_dti_copy(&abort_dtes[abort_cnt].dte_xid,
+				      &dces[i].dce_xid);
+			abort_dtes[abort_cnt++].dte_oid = *oid;
+			continue;
+		}
+
+		goto out;
 	}
 
 	if (commit_cnt > 0) {
@@ -566,24 +564,53 @@ dtx_leader_end(struct dtx_leader_handle *dlh, struct ds_cont_hdl *cont_hdl,
 		if (result == 0)
 			result = rc;
 
-		D_GOTO(fail, rc);
+		D_GOTO(fail, result);
 	} else if (rc < 0 || daos_is_zero_dti(&dth->dth_xid)) {
 		if (result == 0)
 			result = rc;
-		D_GOTO(fail, rc);
+
+		D_GOTO(fail, result);
 	}
 
 	/* If the DTX is started befoe DTX resync operation (for rebuild),
 	 * then it is possbile that the DTX resync ULT may have aborted
-	 * current DTX before remote replica(s) modification by race. So
+	 * or committed the DTX during current ULT waiting for the reply.
 	 * let's check DTX status locally before marking as 'committable'.
 	 */
 	if (dlh->dlh_handled_time <= cont->sc_dtx_resync_time) {
-		rc = vos_dtx_check_committable(cont->sc_hdl, NULL,
-					       &dth->dth_xid, 0, false);
-		if (rc < 0) {
-			result = (rc == -DER_NONEXIST ? -DER_INPROGRESS : rc);
-			D_GOTO(fail, result);
+		rc = vos_dtx_check(cont->sc_hdl, &dth->dth_xid);
+		switch (rc) {
+		case DTX_ST_PREPARED:
+			rc = vos_dtx_lookup_cos(dth->dth_coh, &dth->dth_oid,
+					&dth->dth_xid, dth->dth_dkey_hash,
+					dth->dth_intent == DAOS_INTENT_PUNCH ?
+					true : false);
+			/* The resync ULT has already added it into the CoS
+			 * cache, current ULT needs to do nothing.
+			 */
+			if (rc == 0)
+				D_GOTO(out_free, result = 0);
+
+			/* normal case, then add it to CoS cache. */
+			if (rc == -DER_NONEXIST)
+				break;
+
+			D_GOTO(fail, result = (rc >= 0 ? -DER_INVAL : rc));
+		case DTX_ST_COMMITTED:
+			/* The DTX has been committed by resync ULT by race,
+			 * set dth_sync to indicate that in log.
+			 */
+			dth->dth_sync = 1;
+			D_GOTO(out_free, result = 0);
+		case -DER_NONEXIST:
+			/* The DTX has been aborted by resync ULT, ask the
+			 * client to retry via returning -DER_INPROGRESS.
+			 */
+			result = -DER_INPROGRESS;
+			goto out_free;
+		default:
+			result = rc >= 0 ? -DER_INVAL : rc;
+			goto fail;
 		}
 	}
 
@@ -836,7 +863,14 @@ dtx_handle_resend(daos_handle_t coh, daos_unit_oid_t *oid,
 	if (daos_is_zero_dti(dti))
 		return 0;
 
-	rc = vos_dtx_check_committable(coh, oid, dti, dkey_hash, punch);
+	rc = vos_dtx_lookup_cos(coh, oid, dti, dkey_hash, punch);
+	if (rc == 0)
+		return -DER_ALREADY;
+
+	if (rc != -DER_NONEXIST)
+		return rc >= 0 ? -DER_INVAL : rc;
+
+	rc = vos_dtx_check(coh, dti);
 	switch (rc) {
 	case DTX_ST_PREPARED:
 		return 0;

--- a/src/dtx/dtx_resync.c
+++ b/src/dtx/dtx_resync.c
@@ -40,6 +40,7 @@ struct dtx_resync_entry {
 	struct dtx_entry	dre_dte;
 	uint64_t		dre_hash;
 	uint32_t		dre_intent;
+	uint32_t		dre_in_cache:1;
 };
 
 #define dre_oid		dre_dte.dte_oid
@@ -73,6 +74,7 @@ dtx_resync_commit(uuid_t po_uuid, struct ds_cont_child *cont,
 	struct dtx_entry		*dte = NULL;
 	int				 rc = 0;
 	int				 i = 0;
+	int				 j = 0;
 
 	D_ASSERT(drh->drh_count >= count);
 
@@ -80,29 +82,66 @@ dtx_resync_commit(uuid_t po_uuid, struct ds_cont_child *cont,
 	if (dte == NULL)
 		return -DER_NOMEM;
 
-	do {
+	for (i = 0; i < count; i++) {
 		dre = d_list_entry(drh->drh_list.next,
 				   struct dtx_resync_entry, dre_link);
-		dte[i].dte_xid = dre->dre_xid;
-		dte[i].dte_oid = dre->dre_oid;
+		/* Someone (the DTX owner or batched commit ULT) may have
+		 * committed or aborted the DTX during we handling other
+		 * DTXs. So double check the on-disk status before current
+		 * commit.
+		 */
+		rc = vos_dtx_check(cont->sc_hdl, &dre->dre_xid);
 
-		rc = vos_dtx_add_cos(cont->sc_hdl, &dre->dre_oid, &dre->dre_xid,
-				     dre->dre_hash, crt_hlc_get(),
-				     dre->dre_intent == DAOS_INTENT_PUNCH ?
-				     true : false);
-		if (rc != 0)
-			D_WARN("Fail to add DTX "DF_DTI" to CoS cache: %d.\n",
+		/* Skip this DTX since it has been committed or aggregated. */
+		if (rc == DTX_ST_COMMITTED || rc == -DER_NONEXIST)
+			goto next;
+
+		if (rc != DTX_ST_PREPARED) {
+			/* If we failed to check the on-disk status, commit
+			 * it again, that is harmless. But we cannot add it
+			 * to CoS cache.
+			 */
+			D_WARN("Fail to check DTX "DF_DTI" status: %d.\n",
 			       DP_DTI(&dre->dre_xid), rc);
+			goto commit;
+		}
 
+		if (dre->dre_in_cache)
+			goto commit;
+
+		rc = vos_dtx_lookup_cos(cont->sc_hdl, &dre->dre_oid,
+					&dre->dre_xid, dre->dre_hash,
+					dre->dre_intent == DAOS_INTENT_PUNCH ?
+					true : false);
+		if (rc == -DER_NONEXIST) {
+			rc = vos_dtx_add_cos(cont->sc_hdl, &dre->dre_oid,
+				&dre->dre_xid, dre->dre_hash, crt_hlc_get(),
+				dre->dre_intent == DAOS_INTENT_PUNCH ?
+				true : false);
+			if (rc < 0)
+				D_WARN("Fail to add DTX "DF_DTI" to CoS cache: "
+				       "rc = %d\n",  DP_DTI(&dre->dre_xid), rc);
+		}
+
+commit:
+		dte[j].dte_xid = dre->dre_xid;
+		dte[j].dte_oid = dre->dre_oid;
+		++j;
+
+next:
 		dtx_dre_release(drh, dre);
-	} while (++i < count);
+	}
 
-	rc = dtx_commit(po_uuid, cont->sc_uuid, dte, count, version);
+	if (j > 0) {
+		rc = dtx_commit(po_uuid, cont->sc_uuid, dte, j, version);
+		if (rc < 0)
+			D_ERROR("Failed to commit the DTXs: rc = %d\n", rc);
+	} else {
+		rc = 0;
+	}
+
 	D_FREE(dte);
-	if (rc < 0)
-		D_ERROR("Failed to commit the DTX: rc = %d\n", rc);
-
-	return rc > 0 ? 0 : rc;
+	return rc;
 }
 
 static int
@@ -121,11 +160,19 @@ dtx_status_handle(struct dtx_resync_args *dra)
 		return 0;
 
 	d_list_for_each_entry_safe(dre, next, &drh->drh_list, dre_link) {
-		int	rc1;
-
 		if (layout != NULL) {
 			pl_obj_layout_free(layout);
 			layout = NULL;
+		}
+
+		rc = vos_dtx_lookup_cos(cont->sc_hdl, &dre->dre_oid,
+					&dre->dre_xid, dre->dre_hash,
+					dre->dre_intent == DAOS_INTENT_PUNCH ?
+					true : false);
+		/* If it is in CoS cache, no need to check remote replicas. */
+		if (rc == 0) {
+			dre->dre_in_cache = 1;
+			goto commit;
 		}
 
 		rc = ds_pool_check_leader(dra->po_uuid, &dre->dre_oid,
@@ -148,46 +195,55 @@ dtx_status_handle(struct dtx_resync_args *dra)
 
 		rc = dtx_check(dra->po_uuid, cont->sc_uuid,
 			       &dre->dre_dte, layout);
-		if (rc != DTX_ST_COMMITTED && rc != DTX_ST_PREPARED) {
+
+		/* The DTX has been committed (or) ready to be committed on
+		 * some remote replica(s), let's commit the it globally.
+		 */
+		if (rc == DTX_ST_COMMITTED || rc == DTX_ST_PREPARED)
+			goto commit;
+
+		if (rc != -DER_NONEXIST) {
 			/* We are not sure about whether the DTX can be
 			 * committed or not, then we have to skip it.
 			 */
 			D_WARN("Not sure about whether the DTX "DF_UOID
-			       "/"DF_DTI" can be committed or not: %d (1)\n",
+			       "/"DF_DTI" can be committed or not: %d\n",
 			       DP_UOID(dre->dre_oid),
 			       DP_DTI(&dre->dre_xid), rc);
 			dtx_dre_release(drh, dre);
 			continue;
 		}
 
-		/* It is possible that the current DTX becomes committable (in
-		 * CoS cache) or has been committed (on-disk) during above dtx
-		 * check remotely. Let's re-check its state locally.
+		/* Someone (the DTX owner or batched commit ULT) may have
+		 * committed or aborted the DTX during we handling other
+		 * DTXs. So double check the on-disk status before current
+		 * commit.
 		 */
-		rc1 = vos_dtx_check_committable(cont->sc_hdl, &dre->dre_oid,
-					&dre->dre_xid, dre->dre_hash,
-					dre->dre_intent == DAOS_INTENT_PUNCH ?
-					true : false);
-		if (rc1 == DTX_ST_COMMITTED) {
-			/* The DTX is in CoS cache (committable), do nothing. */
+		rc = vos_dtx_check(cont->sc_hdl, &dre->dre_xid);
+
+		/* Skip this DTX since it has been committed or aborted or
+		 * fail to get the status.
+		 */
+		if (rc != DTX_ST_PREPARED) {
+			if (rc < 0 && rc != -DER_NONEXIST)
+				D_WARN("Not sure about whether the DTX "DF_UOID
+				       "/"DF_DTI" can be abort or not: %d\n",
+				       DP_UOID(dre->dre_oid),
+				       DP_DTI(&dre->dre_xid), rc);
 			dtx_dre_release(drh, dre);
 			continue;
 		}
 
-		/* The DTX has been committed on some remote replica(s), let's
-		 * commit the it globally.
-		 */
-		if (rc == DTX_ST_COMMITTED)
+		rc = vos_dtx_lookup_cos(cont->sc_hdl, &dre->dre_oid,
+					&dre->dre_xid, dre->dre_hash,
+					dre->dre_intent == DAOS_INTENT_PUNCH ?
+					true : false);
+		if (rc == 0) {
+			dre->dre_in_cache = 1;
 			goto commit;
+		}
 
-		switch (rc1) {
-		case DTX_ST_PREPARED:
-			/* Both local and remote replicas are 'prepared', then
-			 * it is committable.
-			 */
-			if (rc == DTX_ST_PREPARED)
-				goto commit;
-
+		if (rc == -DER_NONEXIST) {
 			/* If we abort multiple non-ready DTXs together, then
 			 * there is race that one DTX may become committable
 			 * when we abort some other DTX(s). To avoid complex
@@ -195,18 +251,12 @@ dtx_status_handle(struct dtx_resync_args *dra)
 			 */
 			rc = dtx_abort(dra->po_uuid, cont->sc_uuid,
 				       &dre->dre_dte, 1, dra->version);
-			dtx_dre_release(drh, dre);
 			if (rc < 0)
 				err = rc;
-			continue;
-		default:
-			D_WARN("Not sure about whether the DTX "DF_UOID
-			       "/"DF_DTI" can be committed or not: %d (3)\n",
-			       DP_UOID(dre->dre_oid),
-			       DP_DTI(&dre->dre_xid), rc);
-			dtx_dre_release(drh, dre);
-			continue;
 		}
+
+		dtx_dre_release(drh, dre);
+		continue;
 
 commit:
 		if (++count >= DTX_THRESHOLD_COUNT) {

--- a/src/dtx/dtx_srv.c
+++ b/src/dtx/dtx_srv.c
@@ -64,12 +64,8 @@ dtx_handler(crt_rpc_t *rpc)
 		if (din->di_dtx_array.ca_count != 1)
 			rc = -DER_PROTO;
 		else
-			/* For the remote query about DTX check, it is NOT
-			 * necessary to lookup CoS cache, so set the 'oid'
-			 * as zero to bypass CoS cache.
-			 */
-			rc = vos_dtx_check_committable(cont->sc_hdl, NULL,
-					din->di_dtx_array.ca_arrays, 0, false);
+			rc = vos_dtx_check(cont->sc_hdl,
+					   din->di_dtx_array.ca_arrays);
 		break;
 	default:
 		rc = -DER_INVAL;

--- a/src/include/daos_srv/vos.h
+++ b/src/include/daos_srv/vos.h
@@ -102,13 +102,10 @@ int
 vos_dtx_fetch_committable(daos_handle_t coh, int max, struct dtx_entry **dtes);
 
 /**
- * Check whether the specified DTX can be committed or not.
+ * Check the specified DTX's persistent status.
  *
  * \param coh		[IN]	Container open handle.
- * \param oid		[IN]	Pointer to the object ID.
  * \param xid		[IN]	Pointer to the DTX identifier.
- * \param dkey_hash	[IN]	The hashed dkey.
- * \param punch		[IN]	For punch operation or not.
  *
  * \return		DTX_ST_PREPARED	means that the DTX has been 'prepared',
  *					so the local modification has been done
@@ -119,9 +116,7 @@ vos_dtx_fetch_committable(daos_handle_t coh, int max, struct dtx_entry **dtes);
  *			Negative value if error.
  */
 int
-vos_dtx_check_committable(daos_handle_t coh, daos_unit_oid_t *oid,
-			  struct dtx_id *dti, uint64_t dkey_hash,
-			  bool punch);
+vos_dtx_check(daos_handle_t coh, struct dtx_id *dti);
 
 /**
  * Commit the specified DTXs.

--- a/src/vos/tests/vts_dtx.c
+++ b/src/vos/tests/vts_dtx.c
@@ -980,8 +980,7 @@ dtx_18(void **state)
 
 	/* Aggregate the first 4 DTXs. */
 	for (i = 0; i < 10; i++) {
-		rc = vos_dtx_check_committable(args->ctx.tc_co_hdl, NULL,
-					       &xid[i], 0, false);
+		rc = vos_dtx_check(args->ctx.tc_co_hdl, &xid[i]);
 		assert_int_equal(rc, DTX_ST_COMMITTED);
 	}
 
@@ -990,14 +989,12 @@ dtx_18(void **state)
 	assert_int_equal(rc, 0);
 
 	for (i = 0; i < 4; i++) {
-		rc = vos_dtx_check_committable(args->ctx.tc_co_hdl, NULL,
-					       &xid[i], 0, false);
+		rc = vos_dtx_check(args->ctx.tc_co_hdl, &xid[i]);
 		assert_int_equal(rc, -DER_NONEXIST);
 	}
 
 	for (; i < 10; i++) {
-		rc = vos_dtx_check_committable(args->ctx.tc_co_hdl, NULL,
-					       &xid[i], 0, false);
+		rc = vos_dtx_check(args->ctx.tc_co_hdl, &xid[i]);
 		assert_int_equal(rc, DTX_ST_COMMITTED);
 	}
 
@@ -1006,8 +1003,7 @@ dtx_18(void **state)
 	assert_int_equal(rc, 1);
 
 	for (i = 4; i < 10; i++) {
-		rc = vos_dtx_check_committable(args->ctx.tc_co_hdl, NULL,
-					       &xid[i], 0, false);
+		rc = vos_dtx_check(args->ctx.tc_co_hdl, &xid[i]);
 		assert_int_equal(rc, -DER_NONEXIST);
 	}
 

--- a/src/vos/vos_dtx.c
+++ b/src/vos/vos_dtx.c
@@ -1539,9 +1539,7 @@ vos_dtx_prepared(struct dtx_handle *dth)
 }
 
 int
-vos_dtx_check_committable(daos_handle_t coh, daos_unit_oid_t *oid,
-			  struct dtx_id *dti, uint64_t dkey_hash,
-			  bool punch)
+vos_dtx_check(daos_handle_t coh, struct dtx_id *dti)
 {
 	struct vos_container	*cont;
 	d_iov_t			 kiov;
@@ -1550,18 +1548,6 @@ vos_dtx_check_committable(daos_handle_t coh, daos_unit_oid_t *oid,
 
 	cont = vos_hdl2cont(coh);
 	D_ASSERT(cont != NULL);
-
-	if (oid != NULL) {
-		rc = vos_dtx_lookup_cos(coh, oid, dti, dkey_hash, punch);
-		if (rc == 0)
-			return DTX_ST_COMMITTED;
-		if (rc != -DER_NONEXIST) {
-			D_ERROR(DF_UOID" DTX ("DF_DTI") vos_dtx_lookup_cos "
-				"failed, %d.\n", DP_UOID(*oid), DP_DTI(dti),
-				rc);
-			return rc;
-		}
-	}
 
 	d_iov_set(&kiov, dti, sizeof(*dti));
 	d_iov_set(&riov, NULL, 0);


### PR DESCRIPTION
The object rebuild logic will trigger DTX resync before scanning.
For performance consideration, the DTX maybe just inside the CoS
cache on the leader. But that is not enough. Because if there is
another failure on current leader (rebuild 32 does) after current
rebuild, then related DTX (that was committable and cached on the
old failed leader) on the new leader will be 'prepared', but the
new target (by the first rebuild just now) does not has such DTX
information. So DTX resync for the second rebuild will be confused.
The right behavior is to force commit the committable DTX during
the DTX resync.

Signed-off-by: Fan Yong <fan.yong@intel.com>