### PR TITLE
DAOS-2928 object: fix dtx related log message

### DIFF
--- a/src/object/cli_shard.c
+++ b/src/object/cli_shard.c
@@ -154,22 +154,25 @@ dc_rw_cb(tse_task_t *task, void *arg)
 		 * If any failure happens inside Cart, let's reset failure to
 		 * TIMEDOUT, so the upper layer can retry.
 		 */
-		D_ERROR("RPC %d failed: %d\n",
-			opc_get(rw_args->rpc->cr_opc), ret);
+		D_ERROR("RPC %d failed: %d\n", opc, ret);
 		D_GOTO(out, ret);
 	}
 
 	rc = obj_reply_get_status(rw_args->rpc);
 	if (rc != 0) {
-		D_ERROR("rpc %p RPC %d failed: %d\n", rw_args->rpc,
-			 opc_get(rw_args->rpc->cr_opc), rc);
+		if (rc == -DER_INPROGRESS)
+			D_DEBUG(DB_TRACE, "rpc %p RPC %d may need retry: %d\n",
+				rw_args->rpc, opc, rc);
+		else
+			D_ERROR("rpc %p RPC %d failed: %d\n",
+				rw_args->rpc, opc, rc);
 		D_GOTO(out, rc);
 	}
 	*rw_args->map_ver = obj_reply_map_version_get(rw_args->rpc);
 
 	orwo = crt_reply_get(rw_args->rpc);
 	rw_args->dobj->do_attr = orwo->orw_attr;
-	if (opc_get(rw_args->rpc->cr_opc) == DAOS_OBJ_RPC_FETCH) {
+	if (opc == DAOS_OBJ_RPC_FETCH) {
 		daos_iod_t	*iods;
 		uint64_t	*sizes;
 		int		 i, j;
@@ -554,6 +557,7 @@ dc_enumerate_cb(tse_task_t *task, void *arg)
 	struct obj_enum_args	*enum_args = (struct obj_enum_args *)arg;
 	struct obj_key_enum_in	*oei;
 	struct obj_key_enum_out	*oeo;
+	int			 opc = opc_get(enum_args->rpc->cr_opc);
 	int			 ret = task->dt_result;
 	int			 rc = 0;
 
@@ -564,8 +568,7 @@ dc_enumerate_cb(tse_task_t *task, void *arg)
 		/* If any failure happens inside Cart, let's reset
 		 * failure to TIMEDOUT, so the upper layer can retry
 		 **/
-		D_ERROR("RPC %d failed: %d\n",
-			opc_get(enum_args->rpc->cr_opc), ret);
+		D_ERROR("RPC %d failed: %d\n", opc, ret);
 		D_GOTO(out, ret);
 	}
 
@@ -576,9 +579,12 @@ dc_enumerate_cb(tse_task_t *task, void *arg)
 			D_DEBUG(DB_IO, "key size "DF_U64" too big.\n",
 				oeo->oeo_size);
 			enum_args->eaa_kds[0].kd_key_len = oeo->oeo_size;
+		} else if (rc == -DER_INPROGRESS) {
+			D_DEBUG(DB_TRACE, "rpc %p RPC %d may need retry: %d\n",
+				enum_args->rpc, opc, rc);
 		} else {
-			D_ERROR("rpc %p RPC %d failed: %d\n", enum_args->rpc,
-				 opc_get(enum_args->rpc->cr_opc), rc);
+			D_ERROR("rpc %p RPC %d failed: %d\n",
+				enum_args->rpc, opc, rc);
 		}
 		D_GOTO(out, rc);
 	}
@@ -807,6 +813,7 @@ obj_shard_query_key_cb(tse_task_t *task, void *data)
 	struct obj_query_key_in		*okqi;
 	struct obj_query_key_out	*okqo;
 	uint32_t			flags;
+	int				opc;
 	int				ret = task->dt_result;
 	int				rc = 0;
 	crt_rpc_t			*rpc;
@@ -818,10 +825,10 @@ obj_shard_query_key_cb(tse_task_t *task, void *data)
 	D_ASSERT(okqi != NULL);
 
 	flags = okqi->okqi_flags;
+	opc = opc_get(cb_args->rpc->cr_opc);
 
 	if (ret != 0) {
-		D_ERROR("RPC %d failed: %d\n",
-			opc_get(cb_args->rpc->cr_opc), ret);
+		D_ERROR("RPC %d failed: %d\n", opc, ret);
 		D_GOTO(out, ret);
 	}
 
@@ -830,8 +837,13 @@ obj_shard_query_key_cb(tse_task_t *task, void *data)
 	if (rc != 0) {
 		if (rc == -DER_NONEXIST)
 			D_GOTO(out, rc = 0);
-		D_ERROR("rpc %p RPC %d failed: %d\n", cb_args->rpc,
-			opc_get(cb_args->rpc->cr_opc), rc);
+
+		if (rc == -DER_INPROGRESS)
+			D_DEBUG(DB_TRACE, "rpc %p RPC %d may need retry: %d\n",
+				cb_args->rpc, opc, rc);
+		else
+			D_ERROR("rpc %p RPC %d failed: %d\n",
+				cb_args->rpc, opc, rc);
 		D_GOTO(out, rc);
 	}
 	*cb_args->map_ver = obj_reply_map_version_get(rpc);

--- a/src/vos/vos_io.c
+++ b/src/vos/vos_io.c
@@ -602,7 +602,11 @@ dkey_fetch(struct vos_io_context *ioc, daos_key_t *dkey)
 	}
 
 	if (rc != 0) {
-		D_ERROR("Failed to prepare subtree: %d\n", rc);
+		if (rc == -DER_INPROGRESS)
+			D_DEBUG(DB_TRACE, "Cannot prepare subtree because "
+				"of conflict modification: %d\n", rc);
+		else
+			D_ERROR("Failed to prepare subtree: %d\n", rc);
 		return rc;
 	}
 
@@ -886,7 +890,13 @@ dkey_update(struct vos_io_context *ioc, uint32_t pm_ver, daos_key_t *dkey)
 					      DAOS_INTENT_UPDATE,
 					      &krec, &ak_toh);
 			if (rc != 0) {
-				D_ERROR("Error preparing dkey tree: %d\n", rc);
+				if (rc == -DER_INPROGRESS)
+					D_DEBUG(DB_TRACE, "Cannot preparing "
+						"dkey tree because of conflict "
+						"modification: %d\n", rc);
+				else
+					D_ERROR("Error preparing dkey tree: "
+						"%d\n", rc);
 				goto out;
 			}
 			subtr_created = true;
@@ -1420,7 +1430,13 @@ vos_obj_fetch(daos_handle_t coh, daos_unit_oid_t oid, daos_epoch_t epoch,
 	rc = vos_fetch_begin(coh, oid, epoch, dkey, iod_nr, iods, size_fetch,
 			     &ioh);
 	if (rc) {
-		D_ERROR("Fetch "DF_UOID" failed %d\n", DP_UOID(oid), rc);
+		if (rc == -DER_INPROGRESS)
+			D_DEBUG(DB_TRACE, "Cannot fetch "DF_UOID" because of "
+				"conflict modification: %d\n",
+				DP_UOID(oid), rc);
+		else
+			D_ERROR("Fetch "DF_UOID" failed %d\n",
+				DP_UOID(oid), rc);
 		return rc;
 	}
 

--- a/src/vos/vos_iterator.c
+++ b/src/vos/vos_iterator.c
@@ -137,9 +137,12 @@ nested_prepare(vos_iter_type_t type, struct vos_iter_dict *dict,
 		    rc == -DER_NONEXIST)
 			D_DEBUG(DB_TRACE, "%s iterator does not exist\n",
 				dict->id_name);
+		else if (rc == -DER_INPROGRESS)
+			D_DEBUG(DB_TRACE, "Cannot fetch nested tree from "
+				"because of conflict modification: %d\n", rc);
 		else
 			D_ERROR("Problem fetching nested tree from iterator:"
-				" %d", rc);
+				" %d\n", rc);
 		return rc;
 	}
 
@@ -556,8 +559,13 @@ probe:
 			daos_anchor_set_eof(anchor);
 			rc = 0;
 		} else {
-			D_ERROR("failed to probe iterator (type=%d anchor=%p): "
-				"%d\n", type, probe_anchor, rc);
+			if (rc == -DER_INPROGRESS)
+				D_DEBUG(DB_TRACE, "Cannot probe because of "
+					"some conflict modification: %d\n", rc);
+			else
+				D_ERROR("failed to probe iterator (type=%d "
+					"anchor=%p): %d\n",
+					type, probe_anchor, rc);
 		}
 		D_GOTO(out, rc);
 	}
@@ -565,8 +573,13 @@ probe:
 	while (1) {
 		rc = vos_iter_fetch(ih, &iter_ent, anchor);
 		if (rc != 0) {
-			D_ERROR("failed to fetch iterator (type=%d): %d\n",
-				type, rc);
+			if (rc == -DER_INPROGRESS)
+				D_DEBUG(DB_TRACE, "Cannot fetch iterator "
+					"(type=%d) because of conflict "
+					"modification: %d\n", type, rc);
+			else
+				D_ERROR("failed to fetch iterator (type=%d): "
+					"%d\n", type, rc);
 			break;
 		}
 

--- a/src/vos/vos_obj.c
+++ b/src/vos/vos_obj.c
@@ -319,7 +319,11 @@ key_iter_match(struct vos_obj_iter *oiter, vos_iter_entry_t *ent, int *probe_p)
 
 	rc = key_iter_fetch(oiter, ent, NULL);
 	if (rc) {
-		D_ERROR("Failed to fetch the entry: %d\n", rc);
+		if (rc == -DER_INPROGRESS)
+			D_DEBUG(DB_TRACE, "Cannot fetch the entry because of "
+				"conflict modification: %d\n", rc);
+		else
+			D_ERROR("Failed to fetch the entry: %d\n", rc);
 		return rc;
 	}
 
@@ -494,7 +498,11 @@ akey_iter_prepare(struct vos_obj_iter *oiter, daos_key_t *dkey)
 			      VOS_BTR_DKEY, dkey, 0,
 			      vos_iter_intent(&oiter->it_iter), NULL, &toh);
 	if (rc != 0) {
-		D_ERROR("Cannot load the akey tree: %d\n", rc);
+		if (rc == -DER_INPROGRESS)
+			D_DEBUG(DB_TRACE, "Cannot load the akey tree because "
+				"of some conflict modification: %d\n", rc);
+		else
+			D_ERROR("Cannot load the akey tree: %d\n", rc);
 		return rc;
 	}
 

--- a/src/vos/vos_obj_index.c
+++ b/src/vos/vos_obj_index.c
@@ -438,7 +438,11 @@ oi_iter_nested_tree_fetch(struct vos_iterator *iter, vos_iter_type_t type,
 	d_iov_set(&rec_iov, NULL, 0);
 	rc = dbtree_iter_fetch(oiter->oit_hdl, NULL, &rec_iov, NULL);
 	if (rc != 0) {
-		D_ERROR("Error while fetching oid info\n");
+		if (rc == -DER_INPROGRESS)
+			D_DEBUG(DB_TRACE, "Cannot fetch oid infor because of "
+				"conflict modification: %d\n", rc);
+		else
+			D_ERROR("Error while fetching oid info: %d\n", rc);
 		return rc;
 	}
 
@@ -624,7 +628,11 @@ oi_iter_fetch(struct vos_iterator *iter, vos_iter_entry_t *it_entry,
 	d_iov_set(&rec_iov, NULL, 0);
 	rc = dbtree_iter_fetch(oiter->oit_hdl, NULL, &rec_iov, anchor);
 	if (rc != 0) {
-		D_ERROR("Error while fetching oid info\n");
+		if (rc == -DER_INPROGRESS)
+			D_DEBUG(DB_TRACE, "Cannot fetch oid info because of "
+				"conflict modification: %d\n", rc);
+		else
+			D_ERROR("Error while fetching oid info: %d\n", rc);
 		return rc;
 	}
 

--- a/src/vos/vos_tree.c
+++ b/src/vos/vos_tree.c
@@ -956,6 +956,11 @@ key_tree_prepare(struct vos_object *obj, daos_epoch_t epoch,
 		D_ERROR("fetch failed: %d\n", rc);
 		goto out;
 
+	case -DER_INPROGRESS:
+		/* Log for -DER_INPROGRESS has already been handled by
+		 * dtx_inprogress().
+		 */
+		goto out;
 	case -DER_NONEXIST:
 		if (!(flags & SUBTR_CREATE))
 			goto out;


### PR DESCRIPTION
Under some cases, the server may ask the client to retry
the RPC with DTX leader because of some non-committed DTX.
That is normal, not error. Fix related log message to avoid
confusing.

Signed-off-by: Fan Yong <fan.yong@intel.com>