### PR TITLE
DAOS-2846 common: enlarge task stack buffer

### DIFF
--- a/src/common/tse_internal.h
+++ b/src/common/tse_internal.h
@@ -33,8 +33,8 @@
  * Author: Di Wang  <di.wang@intel.com>
  */
 
-/* NB: tse_task_private is TSE_PRIV_SIZE = 1016 bytes for now */
-#define TSE_TASK_ARG_LEN		888
+/* NB: tse_task_private is TSE_PRIV_SIZE = 1528 bytes for now */
+#define TSE_TASK_ARG_LEN		1400
 
 struct tse_task_private {
 	struct tse_sched_private	*dtp_sched;

--- a/src/include/daos/tse.h
+++ b/src/include/daos/tse.h
@@ -34,9 +34,9 @@
  * tse_task is used to track single asynchronous operation.
  * 512 bytes all together.
  */
-#define TSE_TASK_SIZE		1024
+#define TSE_TASK_SIZE		1536
 /* 8 bytes used for public members */
-#define TSE_PRIV_SIZE		1016
+#define TSE_PRIV_SIZE		1528
 
 typedef struct tse_task {
 	int			dt_result;


### PR DESCRIPTION
The DAOS-2846 looks like the update task stack overflowed.
But I cannot find the root point for that. I make a temporary
patch with enlarging the task stack buffer. That will allow
other patches to pass Jenkins tests. It may be not the final
solution, we can replace it when we have more suitable one
in the future.

Signed-off-by: Fan Yong <fan.yong@intel.com>