### PR TITLE
DAOS-2939: test: Abort failures in log cleaning

### DIFF
--- a/src/tests/ftest/launch.py
+++ b/src/tests/ftest/launch.py
@@ -157,10 +157,15 @@ def spawn_commands(host_list, command, timeout=120):
         elapsed += int(time.time()) - start_time
 
     # Terminate any processes that may still be running after timeout
+    return_value = True
     for job in jobs:
         if job.is_alive():
             print("Terminating job {}".format(job.pid))
             job.terminate()
+        if job.exitcode != 0:
+            return_value = False
+
+    return return_value
 
 
 def find_values(obj, keys, key=None, val_type=list):
@@ -277,7 +282,8 @@ def run_tests(test_files, tag_filter, args):
             # Optionally clean the log files before running this test on the
             # servers and clients specified for this test
             if args.clean:
-                clean_logs(test_file["yaml"])
+                if not clean_logs(test_file["yaml"]):
+                    return 128
 
             # Execute this test
             test_command_list = list(command_list)
@@ -420,8 +426,11 @@ def clean_logs(test_yaml):
     host_list = get_hosts_from_yaml(test_yaml)
     command = "ssh {{host}} \"rm -fr {}\"".format(" ".join(log_files.values()))
     print("Cleaning logs on {}".format(host_list))
-    spawn_commands(host_list, command)
+    if not spawn_commands(host_list, command):
+        print("Error cleaning logs, aborting")
+        return False
 
+    return True
 
 def archive_logs(avocado_logs_dir, test_yaml):
     """Copy all of the host test log files to the avocado results directory.
@@ -581,6 +590,9 @@ def main():
             ret_code = 1
         if status & 4 == 4:
             print("ERROR: Detected one or more failed avocado commands!")
+            ret_code = 1
+        if status & 128 == 128:
+            print("ERROR: Failed to clean logs in preparation for test run!")
             ret_code = 1
     exit(ret_code)
 


### PR DESCRIPTION
If the attempt to clean logs on the test nodes fails, don't even bother
trying to run the tests.  Abort the run.