### PR TITLE
DAOS-2940 container: distribute capability asynchronously

### DIFF
--- a/src/container/container_iv.c
+++ b/src/container/container_iv.c
@@ -653,7 +653,7 @@ cont_iv_capability_update(void *ns, uuid_t cont_hdl_uuid, uuid_t cont_uuid,
 
 	rc = cont_iv_update(ns, IV_CONT_CAPA, cont_hdl_uuid, &iv_entry,
 			    sizeof(struct cont_iv_entry),
-			    CRT_IV_SHORTCUT_TO_ROOT, CRT_IV_SYNC_EAGER);
+			    CRT_IV_SHORTCUT_TO_ROOT, CRT_IV_SYNC_LAZY);
 	return rc;
 }
 


### PR DESCRIPTION
Since the rw handler can check and fetch capa by its own,
let's distribute IV capability asynchronously to avoid
taking too much time on container open.

Signed-off-by: Wang Di <di.wang@intel.com>