### PR TITLE
CORCI-536: test: Install DAOS-enabled IOR for test

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -43,23 +43,14 @@
 def arch = ""
 def sanitized_JOB_NAME = JOB_NAME.toLowerCase().replaceAll('/', '-').replaceAll('%2f', '-')
 
+def daos_repos = "openpa libfabric pmix ompi mercury spdk isa-l fio dpdk protobuf-c fuse pmdk argobots raft cart@daos_devel1 daos@${env.BRANCH_NAME}:${env.BUILD_NUMBER}"
+def ior_repos = "mpich@daos_adio-rpm ior-hpc@daos"
+
 def rpm_test_pre = '''export PDSH_SSH_ARGS_APPEND="-i ci_key"
                       nodelist=(${NODELIST//,/ })
                       scp -i ci_key src/tests/ftest/data/daos_server_baseline.yaml \
-				    jenkins@${nodelist[0]}:/tmp
-                      ssh -i ci_key jenkins@${nodelist[0]} "set -ex
-                      repo_file_base=\"*_job_\${JOB_NAME%%/*}_job_\"
-                      for repo in openpa libfabric pmix   \
-                                  ompi mercury spdk isa-l \
-                                  fio dpdk protobuf-c     \
-                                  fuse pmdk argobots raft \
-                                  cart@daos_devel1; do     \
-                          if [[ \\\$repo = *@* ]]; then
-                              branch=\"\\\${repo#*@}\"
-                              repo=\"\\\${repo%@*}\"
-                          else
-                              branch=\"master\"
-                          fi\n'''
+                                    jenkins@${nodelist[0]}:/tmp
+                      ssh -i ci_key jenkins@${nodelist[0]} "set -ex\n'''
 
 def rpm_test_daos_test = '''me=\\\$(whoami)
                             for dir in server agent; do
@@ -104,7 +95,10 @@ pipeline {
         BAHTTPS_PROXY = "${env.HTTP_PROXY ? '--build-arg HTTP_PROXY="' + env.HTTP_PROXY + '" --build-arg http_proxy="' + env.HTTP_PROXY + '"' : ''}"
         BAHTTP_PROXY = "${env.HTTP_PROXY ? '--build-arg HTTPS_PROXY="' + env.HTTPS_PROXY + '" --build-arg https_proxy="' + env.HTTPS_PROXY + '"' : ''}"
         UID=sh(script: "id -u", returnStdout: true)
-        BUILDARGS = "--build-arg NOBUILD=1 --build-arg UID=$env.UID $env.BAHTTP_PROXY $env.BAHTTPS_PROXY"
+        BUILDARGS = "$env.BAHTTP_PROXY $env.BAHTTPS_PROXY "                   +
+                    "--build-arg NOBUILD=1 --build-arg UID=$env.UID "         +
+                    "--build-arg JENKINS_URL=$env.JENKINS_URL "               +
+                    "--build-arg CACHEBUST=${currentBuild.startTimeInMillis}"
     }
 
     options {
@@ -979,7 +973,9 @@ pipeline {
                     steps {
                         provisionNodes NODELIST: env.NODELIST,
                                        node_count: 9,
-                                       snapshot: true
+                                       snapshot: true,
+                                       inst_repos: daos_repos + ' ' + ior_repos,
+                                       inst_rpms: "ior-hpc mpich-autoload"
                         runTest stashes: [ 'CentOS-install', 'CentOS-build-vars' ],
                                 script: '''export SSH_KEY_ARGS="-i ci_key"
                                            export PDSH_SSH_ARGS_APPEND="$SSH_KEY_ARGS"
@@ -1038,11 +1034,15 @@ pipeline {
                         // First snapshot provision the VM at beginning of list
                         provisionNodes NODELIST: env.NODELIST,
                                        node_count: 1,
-                                       snapshot: true
+                                       snapshot: true,
+                                       inst_repos: daos_repos + ' ' + ior_repos,
+                                       inst_rpms: "ior-hpc mpich-autoload"
                         // Then just reboot the physical nodes
                         provisionNodes NODELIST: env.NODELIST,
                                        node_count: 9,
-                                       power_only: true
+                                       power_only: true,
+                                       inst_repos: daos_repos + ' ' + ior_repos,
+                                       inst_rpms: "ior-hpc mpich-autoload"
                         runTest stashes: [ 'CentOS-install', 'CentOS-build-vars' ],
                                 script: '''export SSH_KEY_ARGS="-i ci_key"
                                            export PDSH_SSH_ARGS_APPEND="$SSH_KEY_ARGS"
@@ -1101,17 +1101,11 @@ pipeline {
                         provisionNodes NODELIST: env.NODELIST,
                                        distro: 'el7.6',
                                        node_count: 1,
-                                       snapshot: true
+                                       snapshot: true,
+                                       inst_repos: daos_repos + ' ' + ior_repos,
+                                       inst_rpms: "ior-hpc mpich-autoload"
                         runTest script: "${rpm_test_pre}" +
-                                    '''     sudo yum-config-manager --add-repo=\${JENKINS_URL}job/\${JOB_NAME%%/*}/job/\\\${repo}/job/\\\${branch}/lastSuccessfulBuild/artifact/artifacts/centos7/
-                                            sudo bash -c \\\"echo \\\\\\"gpgcheck = False\\\\\\" >> /etc/yum.repos.d/\\\${repo_file_base}\\\${repo}_job_\\\${branch}_lastSuccessfulBuild_artifact_artifacts_centos7_.repo\\\"
-
-                                        done
-                                        sudo yum-config-manager --add-repo=\${BUILD_URL}artifact/artifacts/centos7/
-                                        sudo bash -c \\\"echo \\\\\\"gpgcheck = False\\\\\\" >> /etc/yum.repos.d/\\\${repo_file_base}daos_job_\${JOB_BASE_NAME}_\${BUILD_ID}_artifact_artifacts_centos7_.repo\\\"
-                                        # work around openmpi -> ompi
-                                        sudo yum -y erase metabench mdtest simul IOR
-                                        sudo yum -y install daos-client
+                                     '''sudo yum -y install daos-client
                                         sudo yum -y history rollback last-1
                                         sudo yum -y install daos-server
                                         sudo yum -y install daos-tests\n''' +
@@ -1128,13 +1122,11 @@ pipeline {
                         provisionNodes NODELIST: env.NODELIST,
                                        distro: 'sles12sp3',
                                        node_count: 1,
-                                       snapshot: true
+                                       snapshot: true,
+                                       inst_repos: daos_repos + " python-pathlib"
                         runTest script: "${rpm_test_pre}" +
-                                     '''    sudo zypper --non-interactive ar --gpgcheck-allow-unsigned -f \${JENKINS_URL}job/\${JOB_NAME%%/*}/job/\\\${repo}/job/\\\${branch}/lastSuccessfulBuild/artifact/artifacts/sles12.3/ \\\$repo
-                                        done
-                                        sudo zypper --non-interactive ar --gpgcheck-allow-unsigned -f \${JENKINS_URL}job/\${JOB_NAME%%/*}/job/python-pathlib/job/master/lastSuccessfulBuild/artifact/artifacts/sles12.3/ python-pathlib
-                                        sudo zypper --non-interactive ar --gpgcheck-allow-unsigned -f \${BUILD_URL}artifact/artifacts/sles12.3/ daos
-                                        sudo zypper --non-interactive ar -f https://download.opensuse.org/repositories/science:/HPC:/SLE12SP3_Missing/SLE_12_SP3/ hwloc
+                                     '''sudo zypper --non-interactive ar -f https://download.opensuse.org/repositories/science:/HPC:/SLE12SP3_Missing/SLE_12_SP3/ hwloc
+                                        # for libcmocka
                                         sudo zypper --non-interactive ar https://download.opensuse.org/repositories/home:/jhli/SLE_15/home:jhli.repo
                                         sudo zypper --non-interactive ar https://download.opensuse.org/repositories/devel:libraries:c_c++/SLE_12_SP3/devel:libraries:c_c++.repo
                                         sudo zypper --non-interactive --gpg-auto-import-keys ref

--- a/ftest.sh
+++ b/ftest.sh
@@ -183,37 +183,7 @@ rm -rf \"${TEST_TAG_DIR:?}/\"
 mkdir -p \"$TEST_TAG_DIR/\"
 if [ -z \"\$JENKINS_URL\" ]; then
     exit 0
-fi
-sudo bash -c 'set -ex
-yum -y install yum-utils
-repo_file_base=\"*_job_${JOB_NAME%%/*}_job_\"
-# pkgs are of the format pkgname[:branch]
-pkgs=\"ior-hpc:daos\"
-install_pkgs=\"\"
-for ext in \$pkgs; do
-    IFS=':' read -ra ext <<< \"\$ext\"
-    ext=\"\${ext[0]}\"
-    if [ -n \"\${ext[1]}\" ]; then
-        branch=\"\${ext[1]}\"
-    else
-        branch=\"master\"
-    fi
-    install_pkgs+=\" \$ext\"
-    rm -f /etc/yum.repos.d/\${repo_file_base}\${ext}_job_*.repo
-    yum-config-manager --add-repo=${JENKINS_URL}job/${JOB_NAME%%/*}/job/\${ext}/job/\${branch}/lastSuccessfulBuild/artifact/artifacts/
-    echo \"gpgcheck = False\" >> /etc/yum.repos.d/\${repo_file_base}\${ext}_job_\${branch}_lastSuccessfulBuild_artifact_artifacts_.repo
-done
-# for testing with a PR for a dependency:
-depname=     # i.e. depname=mercury
-pr_num=      # set to which PR number your PR is
-if [ -n \"\$depname\" ]; then
-    rm -f /etc/yum.repos.d/\${repo_file_base}\${depname}_job_PR-\${pr_num}_lastSuccessfulBuild_artifact_artifacts_.repo
-    yum-config-manager --add-repo=${JENKINS_URL}job/${JOB_NAME%%/*}/job/\${depname}/job/PR-\${pr_num}/lastSuccessfulBuild/artifact/artifacts/
-    echo \"gpgcheck = False\" >> /etc/yum.repos.d/\${repo_file_base}\${depname}_job_PR-\${pr_num}_lastSuccessfulBuild_artifact_artifacts_.repo
-    install_pkgs+=\" \${depname}\"
-fi
-yum -y erase \$install_pkgs
-yum -y install \$install_pkgs'" 2>&1 | dshbak -c; then
+fi" 2>&1 | dshbak -c; then
     echo "Cluster setup (i.e. provisioning) failed"
     exit 1
 fi

--- a/src/tests/ftest/util/ior_utils.py
+++ b/src/tests/ftest/util/ior_utils.py
@@ -196,7 +196,7 @@ class IorCommand(CommandWithParameters):
             item = getattr(self, name).value
             if item:
                 sub_item = re.split(r"([^\d])", str(item))
-                if len(sub_item) > 0:
+                if sub_item > 0:
                     total *= int(sub_item[0])
                     if len(sub_item) > 1:
                         key = sub_item[1].lower()

--- a/src/tests/ftest/util/mpio_utils.py
+++ b/src/tests/ftest/util/mpio_utils.py
@@ -43,14 +43,15 @@ class MpioUtils():
 
         try:
             # checking mpich install
-            checkmpich = subprocess.check_output(["ssh", hostlist[0],
-                                                  "which mpichversion"])
+            self.mpichinstall = subprocess.check_output(
+                ["ssh", hostlist[0],
+                 "command -v mpichversion"]).rstrip()[:-len('bin/mpichversion')]
+
             # Obtaning the location where mpich is installed by executing
             # "which mpichversion", which should return
             # /some_path/bin/mpichversion, hence removing 17 characters
             # to obtain just the installed location
-            self.mpichinstall = checkmpich[:-17]
-            print (self.mpichinstall)
+            print(self.mpichinstall)
 
             return True
 
@@ -69,10 +70,7 @@ class MpioUtils():
         """
 
         # environment variables only to be set on client node
-        env_variables = ["export PATH={}/bin:$PATH".format(self.mpichinstall),
-                         "export LD_LIBRARY_PATH={}/lib:$LD_LIBRARY_PATH" \
-                             .format(self.mpichinstall),
-                         "export CRT_ATTACH_INFO_PATH={}/install/tmp/" \
+        env_variables = ["export CRT_ATTACH_INFO_PATH={}/install/tmp/" \
                              .format(basepath),
                          "export MPI_LIB=''", "export DAOS_SINGLETON_CLI=1"]
 
@@ -80,7 +78,7 @@ class MpioUtils():
         cd_cmd = 'cd ' + romio_test_repo
         test_cmd = './runtests -fname=daos:test1 -subset -daos'
         run_cmd = cd_cmd + ' && ' + test_cmd
-        print ("Romio test run command: {}".format(run_cmd))
+        print("Romio test run command: {}".format(run_cmd))
 
         try:
             # establish conection and run romio test
@@ -117,10 +115,7 @@ class MpioUtils():
         """
         print("self.mpichinstall: {}".format(self.mpichinstall))
         # environment variables only to be set on client node
-        env_variables = {"PATH": "{}/bin:$PATH".format(self.mpichinstall),
-                         "LD_LIBRARY_PATH": "{}/lib:$LD_LIBRARY_PATH"\
-                             .format(self.mpichinstall),
-                         "CRT_ATTACH_INFO_PATH": "{}/install/tmp/"\
+        env_variables = {"CRT_ATTACH_INFO_PATH": "{}/install/tmp/"\
                              .format(basepath),
                          "MPI_LIB": '',
                          "MPIO_USER_PATH": "daos:",
@@ -154,7 +149,7 @@ class MpioUtils():
                                               for key, val in
                                               env_variables.items()]),
                             test_cmd])
-        print ("run command: {}".format(run_cmd))
+        print("run command: {}".format(run_cmd))
 
         try:
             process = subprocess.Popen(run_cmd, stdout=subprocess.PIPE,
@@ -164,7 +159,7 @@ class MpioUtils():
                 if output == '' and process.poll() is not None:
                     break
                 if output:
-                    print (output.strip())
+                    print(output.strip())
             if process.poll() != 0:
                 raise MpioFailed("{} Run process".format(test_name)
                                  + " Failed with non zero exit"


### PR DESCRIPTION
Leveraging off of the code added to pipeline-lib to install repos and
packages, install the DAOS-enabled IOR into the testing environemnt for
the Functional tests to be able to use.