### PR TITLE
DAOS-2969 mgmt: Fix double free on ranklist

### DIFF
--- a/src/mgmt/srv_pool.c
+++ b/src/mgmt/srv_pool.c
@@ -481,7 +481,7 @@ ds_mgmt_hdlr_pool_create(crt_rpc_t *rpc_req)
 	if (rc != 0)
 		D_ERROR("crt_reply_send failed, rc: %d (pc_tgt_dev: %s).\n",
 			rc, pc_in->pc_tgt_dev);
-	if (pc_out->pc_rc != 0)
+	if (pc_out->pc_rc == 0)
 		d_rank_list_free(pc_out->pc_svc);
 }
 

--- a/src/mgmt/srv_pool.c
+++ b/src/mgmt/srv_pool.c
@@ -438,8 +438,10 @@ ds_mgmt_create_pool(uuid_t pool_uuid, const char *group, char *tgt_dev,
 	ds_mgmt_pool_list();
 
 out_svcp:
-	if (rc != 0)
+	if (rc) {
 		d_rank_list_free(*svcp);
+		*svcp = NULL;
+	}
 out_uuids:
 	D_FREE(tgt_uuids);
 tgt_fail:
@@ -479,7 +481,7 @@ ds_mgmt_hdlr_pool_create(crt_rpc_t *rpc_req)
 	if (rc != 0)
 		D_ERROR("crt_reply_send failed, rc: %d (pc_tgt_dev: %s).\n",
 			rc, pc_in->pc_tgt_dev);
-	if (pc_out->pc_svc != NULL)
+	if (pc_out->pc_rc != 0)
 		d_rank_list_free(pc_out->pc_svc);
 }
 

--- a/src/pool/srv_pool.c
+++ b/src/pool/srv_pool.c
@@ -2435,9 +2435,10 @@ out:
 
 static int
 pool_find_all_targets_by_addr(uuid_t pool_uuid,
-			struct pool_target_addr_list *list,
-			struct pool_target_id_list *tgt_list,
-			struct pool_target_addr_list *out_list)
+			      struct pool_target_addr_list *list,
+			      struct pool_target_id_list *tgt_list,
+			      struct pool_target_addr_list *out_list,
+			      struct rsvc_hint *hint)
 {
 	struct pool_svc	*svc;
 	struct rdb_tx	tx;
@@ -2537,7 +2538,7 @@ ds_pool_update(uuid_t pool_uuid, crt_opcode_t opc,
 
 	/* Convert target address list to target id list */
 	rc = pool_find_all_targets_by_addr(pool_uuid, list, &target_list,
-					   out_list);
+					   out_list, hint);
 	if (rc)
 		D_GOTO(out, rc);
 

--- a/src/pool/srv_pool.c
+++ b/src/pool/srv_pool.c
@@ -2446,7 +2446,7 @@ pool_find_all_targets_by_addr(uuid_t pool_uuid,
 	int		i;
 	int		rc;
 
-	rc = pool_svc_lookup_leader(pool_uuid, &svc, NULL);
+	rc = pool_svc_lookup_leader(pool_uuid, &svc, hint);
 	if (rc != 0)
 		D_GOTO(out, rc);
 


### PR DESCRIPTION
The replica rank-list is freed but not nulled in case of an error
during pool creation. As a result, it gets freed again at a later
point causing a segfault.

Also fixes an issue with pool update that does not return a hint
when an error occurs.

Signed-off-by: Omkar Kulkarni <omkar.kulkarni@intel.com>