### PR TITLE
DAOS-2065 control: Always provide default logger

### DIFF
--- a/src/control/log/log.go
+++ b/src/control/log/log.go
@@ -27,6 +27,7 @@ import (
 	"fmt"
 	"io"
 	"log"
+	"os"
 )
 
 // Log levels.
@@ -37,6 +38,11 @@ const (
 
 // global default logger
 var logger *Logger
+
+func init() {
+	// Always provide a logger, but this can be overridden
+	NewDefaultLogger(Debug, "default", os.Stdout)
+}
 
 // NewLogger creates a Logger instance and returns reference
 //


### PR DESCRIPTION
In some instances it's possible to invoke the logger without
having first explicitly set it up, and this results in a crash
due to nil pointer dereference. This commit just sets up a
default logger which will usually be overridden by explicit
setup.