### PR TITLE
DAOS-2982: build: Add a git hash to Release string

### DIFF
--- a/utils/rpms/Makefile
+++ b/utils/rpms/Makefile
@@ -9,7 +9,13 @@ PATCHES  = scons_local-$(VERSION).tar.$(SRC_EXT)
 
 dist: $(SOURCES)
 
-COMMON_RPM_ARGS := --define "%_topdir $$PWD/_topdir"
+GIT_SHORT       := $(shell git rev-parse --short HEAD)
+GIT_NUM_COMMITS := $(shell git rev-list HEAD --count)
+
+BUILD_DEFINES := --define "%relval .$(GIT_NUM_COMMITS).g$(GIT_SHORT)"
+MOCK_OPTIONS  := $(BUILD_DEFINES)
+COMMON_RPM_ARGS := --define "%_topdir $$PWD/_topdir" $(BUILD_DEFINES)
+
 DIST    := $(shell rpm $(COMMON_RPM_ARGS) --eval %{?dist})
 ifeq ($(DIST),)
 SED_EXPR := 1p

--- a/utils/rpms/daos.spec
+++ b/utils/rpms/daos.spec
@@ -5,7 +5,7 @@
 
 Name:          daos
 Version:       0.6.0
-Release:       2%{?dist}
+Release:       3%{?relval}%{?dist}
 Summary:       DAOS Storage Engine
 
 License:       Apache
@@ -226,10 +226,13 @@ echo "%{_libdir}/daos_srv" > %{?buildroot}/%{_sysconfdir}/ld.so.conf.d/daos.conf
 %{_libdir}/*.a
 
 %changelog
+* Thu Jul 25 2019 Brian J. Murrell <brian.murrell@intel.com>
+- Add git hash and commit count to release
+
 * Thu Jul 18 2019 David Quigley <david.quigley@intel.com>
 - Add certificate generation files to packaging.
 
-* Tue Jul 9 2019 Johann Lombardi <johann.lombardi@intel.com>
+* Tue Jul 09 2019 Johann Lombardi <johann.lombardi@intel.com>
 - Version bump up to 0.6.0
 
 * Fri Jun 21 2019 David Quigley <dquigley@intel.com>


### PR DESCRIPTION
... in RPM builds.

For forensic purposes, it would be useful to have the git hash of the
DAOS build in the Release of the RPM.