### PR TITLE
DAOS-3009: test: display agent output if it times out starting up

### DIFF
--- a/src/tests/ftest/util/agent_utils.py
+++ b/src/tests/ftest/util/agent_utils.py
@@ -132,7 +132,9 @@ def run_agent(basepath, server_list, client_list=None):
         while not sessions[client].poll():
             if time.time() - start_time > timeout:
                 print("<AGENT>: {}".format(expected_data))
-                raise AgentFailed("DAOS Agent didn't start!")
+                raise AgentFailed("DAOS Agent didn't start!  Agent reported:\n"
+                                  "{}before we gave up waiting for it to "
+                                  "start".format(expected_data))
             output = ""
             try:
                 output = sessions[client].stderr.read()


### PR DESCRIPTION
If we bail out of the agent start up because our timeout expires before
it emits the string we are looking for to indicate that it started up,
it would be useful to know what it did emit before we gave up on it.