### PR TITLE
DAOS-2846 tse: take mutex before tse callback

### DIFF
--- a/src/include/daos/tse.h
+++ b/src/include/daos/tse.h
@@ -32,11 +32,11 @@
 #include <gurt/list.h>
 /**
  * tse_task is used to track single asynchronous operation.
- * 512 bytes all together.
+ * 512 * 3 bytes all together.
  */
-#define TSE_TASK_SIZE		1024
+#define TSE_TASK_SIZE		(512 * 3)
 /* 8 bytes used for public members */
-#define TSE_PRIV_SIZE		1016
+#define TSE_PRIV_SIZE		(TSE_TASK_SIZE - 8)
 
 typedef struct tse_task {
 	int			dt_result;


### PR DESCRIPTION
When the client receives RPC reply from the server, it will call
tse_task_complete(), that will trigger other registerd callbacks.
The latter ones may cause related RPC to be retried, for example:
obj_comp_cb() => obj_retry_cb(). Such retried RPC will cause the
tse_task_complete() to be triggered again. If tse_task_complete()
for retried RPC comes too soon as to current tse_task_complete()
has not returned yet, then these tse_task_complete() instances
(may not only two under quite special casess) against the same
@task may cause some unpredictable behavior.

This patch introduces a mutex tse_task_private::dtp_callback_lock
to avoid multiple instances against the save @task. It supports
the tse_task_complete() to be re-entered with special handling.

It also fix some other issues:

1. Modify the bit flags tse_task_private::dtp_completing with the
   protection by the lock tse_sched_private::dsp_lock.

2. Split the task dependency refcount from multiple-bits variable
   to independent uint32_t.

Signed-off-by: Fan Yong <fan.yong@intel.com>