### PR TITLE
Add a CODEOWNERS file

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,3 @@
+# have release-engineering added as a reviewer to any PR that updates
+# a component sha1
+utils/build.config @release-engineering


### PR DESCRIPTION
And populate it initially with release-engineering being added as a reviewer
on PRs touching utils/build.config.

This is to give release-engineering a heads-up when a component sha1 is
going to be updated.

Skip-build: true
Skip-test: true