### PR TITLE
DAOS-2819 btree: not check availability for unmatched result

### DIFF
--- a/src/common/btree.c
+++ b/src/common/btree.c
@@ -1495,7 +1495,8 @@ again:
 	case BTR_PROBE_GT:
 		if (cmp & BTR_CMP_GT) {
 			if ((intent == DAOS_INTENT_UPDATE ||
-			     intent == DAOS_INTENT_PUNCH) &&
+			     intent == DAOS_INTENT_PUNCH ||
+			     probe_opc & BTR_PROBE_MATCHED) &&
 			    !(cmp & BTR_CMP_MATCHED))
 				break;
 
@@ -1548,7 +1549,8 @@ again:
 	case BTR_PROBE_LT:
 		if (cmp & BTR_CMP_LT) {
 			if ((intent == DAOS_INTENT_UPDATE ||
-			     intent == DAOS_INTENT_PUNCH) &&
+			     intent == DAOS_INTENT_PUNCH ||
+			     probe_opc & BTR_PROBE_MATCHED) &&
 			    !(cmp & BTR_CMP_MATCHED))
 				break;
 


### PR DESCRIPTION
If the btr_probe() sponsor wants to locate the target with the
probe_opc 'BTR_PROBE_MATCHED', then we only need to do related
availability check when the found target matches the condition.
That will avoid a lot of fake DTX conflict.

Signed-off-by: Fan Yong <fan.yong@intel.com>