### PR TITLE
DAOS-2846 tse: use 8 bytes aligned size for task buf

### DIFF
--- a/src/common/tse.c
+++ b/src/common/tse.c
@@ -100,12 +100,15 @@ tse_task_buf_embedded(tse_task_t *task, int size)
 
 	/** Let's assume dtp_buf is always enough at the moment */
 	/** MSC - should malloc if size requested is bigger */
+	size = tse_task_buf_size(size);
 	avail_size = sizeof(dtp->dtp_buf) - dtp->dtp_stack_top;
-	D_ASSERTF(tse_task_buf_size(size) <= avail_size,
+	D_ASSERTF(size <= avail_size,
 		  "req size %u avail size %u (all_size %lu stack_top %u)\n",
-		  tse_task_buf_size(size), avail_size, sizeof(dtp->dtp_buf),
+		  size, avail_size, sizeof(dtp->dtp_buf),
 		  dtp->dtp_stack_top);
 	dtp->dtp_embed_top = size;
+	D_ASSERT((dtp->dtp_stack_top + dtp->dtp_embed_top) <=
+		  sizeof(dtp->dtp_buf));
 	return (void *)dtp->dtp_buf;
 }
 
@@ -118,6 +121,7 @@ tse_task_stack_push(tse_task_t *task, uint32_t size)
 
 	avail_size = sizeof(dtp->dtp_buf) -
 		     (dtp->dtp_stack_top + dtp->dtp_embed_top);
+	size = tse_task_buf_size(size);
 	D_ASSERTF(size <= avail_size, "push size %u exceed avail size %u "
 		   "(all_size %lu, stack_top %u, embed_top %u).\n",
 		   size, avail_size, sizeof(dtp->dtp_buf),
@@ -137,6 +141,7 @@ tse_task_stack_pop(tse_task_t *task, uint32_t size)
 	struct tse_task_private	*dtp = tse_task2priv(task);
 	void			*poped_ptr;
 
+	size = tse_task_buf_size(size);
 	D_ASSERTF(size <= dtp->dtp_stack_top,
 		   "pop size %u exceed stack_top %u.\n",
 		   size, dtp->dtp_stack_top);

--- a/src/object/cli_obj.c
+++ b/src/object/cli_obj.c
@@ -1725,6 +1725,8 @@ obj_req_fanout(struct dc_object *obj, struct obj_auxi_args *obj_auxi,
 		}
 	}
 
+	D_ASSERT(!obj_auxi->args_initialized);
+
 	/* if with only one target, need not to create separate shard task */
 	if (tgts_nr == 1) {
 		shard_auxi = obj_embedded_shard_arg(obj_auxi);
@@ -1978,6 +1980,10 @@ obj_comp_cb(tse_task_t *task, void *data)
 			D_ASSERT(d_list_empty(head));
 		}
 		obj_bulk_fini(obj_auxi);
+		/* zero it as user might reuse/resched the task, for example
+		 * the usage in dac_array_set_size().
+		 */
+		memset(obj_auxi, 0, sizeof(*obj_auxi));
 	}
 
 	obj_decref(obj);
@@ -2631,6 +2637,7 @@ dc_obj_query_key(tse_task_t *api_task)
 		goto task_sched;
 	}
 
+	D_ASSERT(!obj_auxi->args_initialized);
 	D_ASSERT(d_list_empty(head));
 
 	/* In each redundancy group, the QUERY RPC only needs to be sent


### PR DESCRIPTION
use 8 bytes aligned size for task embedded buf, and for stack push/pop.

Signed-off-by: Xuezhao Liu <xuezhao.liu@intel.com>