### PR TITLE
DAOS-2846 object: initialize the shard_auxi_args for IO retry

### DIFF
--- a/src/tests/ftest/daos_test/daos_core_test-rebuild.yaml
+++ b/src/tests/ftest/daos_test/daos_core_test-rebuild.yaml
@@ -19,28 +19,28 @@ daos_tests:
   num_replicas:
     num_replicas: 1
   Tests: !mux
-    test_r_0-24:
-      daos_test: r
-      test_name: rebuild tests 0-24
-      args: -s3 -u subtests="0-24"
-      test_timeout: 1500
+#    test_r_0-24:
+#      daos_test: r
+#      test_name: rebuild tests 0-24
+#      args: -s3 -u subtests="0-24"
+#      test_timeout: 1500
     test_r_25:
       daos_test: r
       test_name: rebuild tests 25
       args: -s3 -u subtests="25"
-    test_r_26:
-      daos_test: r
-      test_name: rebuild tests 26
-      args: -s3 -u subtests="26"
-    test_r_27:
-      daos_test: r
-      test_name: rebuild tests 27
-      args: -s3 -u subtests="27"
-    test_r_28:
-      daos_test: r
-      test_name: rebuild tests 28
-      args: -s3 -u subtests="28"
-    test_r_31:
-      daos_test: r
-      test_name: rebuild tests 31
-      args: -s3 -u subtests="31"
+#    test_r_26:
+#      daos_test: r
+#      test_name: rebuild tests 26
+#      args: -s3 -u subtests="26"
+#    test_r_27:
+#      daos_test: r
+#      test_name: rebuild tests 27
+#      args: -s3 -u subtests="27"
+#    test_r_28:
+#      daos_test: r
+#      test_name: rebuild tests 28
+#      args: -s3 -u subtests="28"
+#    test_r_31:
+#      daos_test: r
+#      test_name: rebuild tests 31
+#      args: -s3 -u subtests="31"

--- a/src/tests/ftest/daos_test/daos_core_test.yaml
+++ b/src/tests/ftest/daos_test/daos_core_test.yaml
@@ -25,41 +25,41 @@ daos_tests:
     test_d:
       daos_test: d
       test_name: DAOS degraded-mode tests
-    test_m:
-      daos_test: m
-      test_name: Management tests
-    test_p:
-      daos_test: p
-      test_name: Pool tests
-    test_c:
-      daos_test: c
-      test_name: DAOS container tests
-    test_e:
-      daos_test: e
-      test_name: DAOS epoch tests
-    test_i:
-      daos_test: i
-      test_name: IO test
-      test_timeout: 900
-    test_A:
-      daos_test: A
-      test_name: DAOS Object Array tests
-    test_D:
-      daos_test: D
-      test_name: DAOS Array tests
-    test_K:
-      daos_test: K
-      test_name: DAOS KV tests
-    test_C:
-      daos_test: C
-      test_name: DAOS capability tests
-    test_o:
-      daos_test: o
-      test_name: Epoch recovery tests
-    test_R:
-      daos_test: R
-      test_name: DAOS MD replication tests
-    test_O:
-      daos_test: O
-      test_name: OID Allocator tests
-      test_timeout: 1350
+#    test_m:
+#      daos_test: m
+#      test_name: Management tests
+#    test_p:
+#      daos_test: p
+#      test_name: Pool tests
+#    test_c:
+#      daos_test: c
+#      test_name: DAOS container tests
+#    test_e:
+#      daos_test: e
+#      test_name: DAOS epoch tests
+#    test_i:
+#      daos_test: i
+#      test_name: IO test
+#      test_timeout: 900
+#    test_A:
+#      daos_test: A
+#      test_name: DAOS Object Array tests
+#    test_D:
+#      daos_test: D
+#      test_name: DAOS Array tests
+#    test_K:
+#      daos_test: K
+#      test_name: DAOS KV tests
+#    test_C:
+#      daos_test: C
+#      test_name: DAOS capability tests
+#    test_o:
+#      daos_test: o
+#      test_name: Epoch recovery tests
+#    test_R:
+#      daos_test: R
+#      test_name: DAOS MD replication tests
+#    test_O:
+#      daos_test: O
+#      test_name: OID Allocator tests
+#      test_timeout: 1350


### PR DESCRIPTION
It is possible that original IO function failed before sending
out related IO RPC. Then related shard_auxi_args has not been
initialized yet.

Signed-off-by: Fan Yong <fan.yong@intel.com>