### PR TITLE
DAOS-2666 tests: array test names should not contain '&'

### DIFF
--- a/src/tests/suite/daos_array.c
+++ b/src/tests/suite/daos_array.c
@@ -1023,7 +1023,7 @@ static const struct CMUnitTest array_api_tests[] = {
 	 str_mem_str_arr_io, async_disable, NULL},
 	{"Array API: Strided memory and array (non-blocking)",
 	 str_mem_str_arr_io, async_enable, NULL},
-	{"Array API: Read from Empty array & records (blocking)",
+	{"Array API: Read from Empty array and records (blocking)",
 	 read_empty_records, async_disable, NULL},
 	{"Array API: strided_array (blocking)",
 	 strided_array, async_disable, NULL},


### PR DESCRIPTION
Signed-off-by: Mohamad Chaarawi <mohamad.chaarawi@intel.com>