### PR TITLE
DAOS-2540 VOS: add new API evt_drain

### DIFF
--- a/src/include/daos/btree.h
+++ b/src/include/daos/btree.h
@@ -427,11 +427,8 @@ typedef struct {
 struct btr_instance {
 	/** instance of memory class for the tree */
 	struct umem_instance		 ti_umm;
-	/**
-	 * NVMe free space tracking information used for NVMe record
-	 * alloc & free.
-	 */
-	void				*ti_blks_info;
+	/** Private data for opener */
+	void				*ti_priv;
 	/**
 	 * The container open handle.
 	 */
@@ -489,13 +486,13 @@ int  dbtree_create_inplace(unsigned int tree_class, uint64_t tree_feats,
 int  dbtree_create_inplace_ex(unsigned int tree_class, uint64_t tree_feats,
 			      unsigned int tree_order, struct umem_attr *uma,
 			      struct btr_root *root, daos_handle_t coh,
-			      daos_handle_t *toh);
+			      void *priv, daos_handle_t *toh);
 int  dbtree_open(umem_off_t root_off, struct umem_attr *uma,
 		 daos_handle_t *toh);
 int  dbtree_open_inplace(struct btr_root *root, struct umem_attr *uma,
 			 daos_handle_t *toh);
 int  dbtree_open_inplace_ex(struct btr_root *root, struct umem_attr *uma,
-			    daos_handle_t coh, void *info, daos_handle_t *toh);
+			    daos_handle_t coh, void *priv, daos_handle_t *toh);
 int  dbtree_close(daos_handle_t toh);
 int  dbtree_destroy(daos_handle_t toh, void *args);
 int  dbtree_drain(daos_handle_t toh, int *credits, void *args, bool *destroyed);

--- a/src/include/daos_srv/evtree.h
+++ b/src/include/daos_srv/evtree.h
@@ -61,6 +61,48 @@ struct evt_desc {
 	uint8_t				pt_csum[0];
 };
 
+/**
+ * Callbacks and parameters for evtree descriptor
+ *
+ * NB:
+ * - evtree is a standalone algorithm, it should not depend on the rest part
+ *   of VOS, this function table is abstraction of those direct calls to
+ *   VOS/DTX.
+ *
+ * - Most part of this function table is about undo log callbacks, we might
+ *   want to separate those fuctions to a dedicated function table for undo
+ *   log in the future. So both evtree & dbtree can share the same definition
+ *   of undo log.
+ */
+struct evt_desc_cbs {
+	/**
+	 * callback to free bio address, EVtree does not allocate bio address
+	 * so it wouldn't free it as well, user should provide callback to
+	 * free it.
+	 */
+	int		(*dc_bio_free_cb)(struct umem_instance *umm,
+					  struct evt_desc *desc,
+					  daos_size_t nob, void *args);
+	void		 *dc_bio_free_args;
+	/**
+	 * Availability check, it is for data tracked by DTX undo log.
+	 * It is optional, EVTree always treats data extent is available if
+	 * this method is absent.
+	 */
+	int		(*dc_log_status_cb)(struct umem_instance *umm,
+					    struct evt_desc *desc,
+					    int intent, void *args);
+	void		 *dc_log_status_args;
+	/** Add a descriptor to undo log */
+	int		(*dc_log_add_cb)(struct umem_instance *umm,
+					 struct evt_desc *desc, void *args);
+	void		 *dc_log_add_args;
+	/** remove a descriptor to undo log */
+	int		(*dc_log_del_cb)(struct umem_instance *umm,
+					 struct evt_desc *desc, void *args);
+	void		 *dc_log_del_args;
+};
+
 struct evt_extent {
 	daos_off_t	ex_lo;	/**< low offset */
 	daos_off_t	ex_hi;	/**< high offset */
@@ -230,6 +272,7 @@ enum evt_visibility {
 	/** In sorted iterator, marks final entry */
 	EVT_LAST	= (1 << 3),
 };
+
 /**
  * Data struct to pass in or return a versioned extent and its data block.
  */
@@ -248,8 +291,8 @@ struct evt_entry {
 	bio_addr_t			en_addr;
 	/** update epoch of extent */
 	daos_epoch_t			en_epoch;
-	/** The DTX entry address */
-	umem_off_t			en_dtx;
+	/** the returned evt_desc address for delete/iterator */
+	umem_off_t			en_desc;
 };
 
 struct evt_list_entry {
@@ -399,8 +442,9 @@ struct evt_policy_ops {
  * \return		0	Success
  *			-ve	error code
  */
-int evt_create(uint64_t feats, unsigned int order, struct umem_attr *uma,
-	       struct evt_root *root, daos_handle_t coh, daos_handle_t *toh);
+int evt_create(struct evt_root *root, uint64_t feats, unsigned int order,
+	       struct umem_attr *uma, struct evt_desc_cbs *cbs,
+	       daos_handle_t *toh);
 /**
  * Open a tree by its root address \a root
  *
@@ -413,8 +457,8 @@ int evt_create(uint64_t feats, unsigned int order, struct umem_attr *uma,
  * \return		0	Success
  *			-ve	error code
  */
-int evt_open(struct evt_root *root, struct umem_attr *uma, daos_handle_t coh,
-	     void *info, daos_handle_t *toh);
+int evt_open(struct evt_root *root, struct umem_attr *uma,
+	     struct evt_desc_cbs *cbs, daos_handle_t *toh);
 
 /**
  * Close a opened tree
@@ -429,6 +473,18 @@ int evt_close(daos_handle_t toh);
  * \param toh		[IN]	The tree open handle
  */
 int evt_destroy(daos_handle_t toh);
+
+/**
+ * This function drains rectangles from the tree, each time it deletes a
+ * rectangle, it consumes a @credits, which is input paramter of this function.
+ * It returns if all input credits are consumed or the tree is empty, in the
+ * later case, it also destroys the evtree.
+ *
+ * \param toh		[IN]	 Tree open handle.
+ * \param credis	[IN/OUT] Input and returned drain credits
+ * \param destroyed	[OUT]	 Tree is empty and destroyed
+ */
+int evt_drain(daos_handle_t toh, int *credits, bool *destroyed);
 
 /**
  * Insert a new extented version \a rect and its data memory ID \a addr to
@@ -580,10 +636,9 @@ int evt_iter_empty(daos_handle_t ih);
  * entries can move around in the tree.
  *
  * \param ih		[IN]	Iterator open handle.
- * \param value_out	[OUT]	Optional, buffer to preserve value while
- *				deleting evtree node.
+ * \param ent		[OUT]	If not NULL, returns the cached entry.
  */
-int evt_iter_delete(daos_handle_t ih, void *value_out);
+int evt_iter_delete(daos_handle_t ih, struct evt_entry *ent);
 
 /**
  * Fetch the extent and its data address from the current iterator position.

--- a/src/vos/evt_priv.h
+++ b/src/vos/evt_priv.h
@@ -78,6 +78,10 @@ struct evt_context {
 	uint16_t			 tc_order;
 	/** cached tree depth (reduce PMEM access) */
 	uint16_t			 tc_depth;
+	/** number of credits for "drain" operation */
+	int				 tc_creds:30;
+	/** credits is enabled */
+	int				 tc_creds_on:1;
 	/** cached number of bytes per entry */
 	uint32_t			 tc_inob;
 	/** cached tree feature bits (reduce PMEM access) */
@@ -86,11 +90,6 @@ struct evt_context {
 	struct umem_instance		 tc_umm;
 	/** pmemobj pool uuid */
 	uint64_t			 tc_pmempool_uuid;
-	/**
-	 * NVMe free space tracking information used for NVMe record
-	 * alloc & free
-	 */
-	void				*tc_blks_info;
 	/** embedded iterator */
 	struct evt_iterator		 tc_iter;
 	/** space to store tree search path */
@@ -99,8 +98,7 @@ struct evt_context {
 	struct evt_trace		*tc_trace;
 	/** customized operation table for different tree policies */
 	struct evt_policy_ops		*tc_ops;
-	/* The container open handle */
-	daos_handle_t			 tc_coh;
+	struct evt_desc_cbs		 tc_desc_cbs;
 };
 
 #define EVT_NODE_NULL			UMOFF_NULL
@@ -144,6 +142,9 @@ evt_off2desc(struct evt_context *tcx, umem_off_t offset)
 
 	return desc;
 }
+
+int
+evt_desc_log_status(struct evt_context *tcx, struct evt_desc *desc, int intent);
 
 /** Helper function for starting a PMDK transaction, if applicable */
 static inline int
@@ -229,13 +230,12 @@ int evt_tcx_clone(struct evt_context *tcx, struct evt_context **tcx_pp);
 /** Remove the leaf node at the current trace
  *
  * \param[IN]	tcx	The context to use for delete
- * \param[IN]	remove	If true, payload is free'd internally
  *
  *  The trace is set as if evt_move_trace were called.
  *
  * Returns -DER_NONEXIST if it's the last item in the trace
  */
-int evt_node_delete(struct evt_context *tcx, bool remove);
+int evt_node_delete(struct evt_context *tcx);
 
 #define EVT_HDL_ALIVE	0xbabecafe
 #define EVT_HDL_DEAD	0xdeadbeef

--- a/src/vos/evtree.c
+++ b/src/vos/evtree.c
@@ -834,14 +834,12 @@ evt_tcx_reset_trace(struct evt_context *tcx)
  * \param root		[IN]	root address for inplace open
  * \param feats		[IN]	Optional, feature bits for create
  * \param order		[IN]	Optional, tree order for create
- * \param uma		[IN]	Memory attribute for the tree
- * \param coh		[IN]	The container open handle
- * \param info		[IN]	NVMe free space info
+ * \param cbs		[IN]	Callbacks and arguments for evt_desc
  * \param tcx_pp	[OUT]	The returned tree context
  */
 static int
 evt_tcx_create(struct evt_root *root, uint64_t feats, unsigned int order,
-	       struct umem_attr *uma, daos_handle_t coh, void *info,
+	       struct umem_attr *uma, struct evt_desc_cbs *cbs,
 	       struct evt_context **tcx_pp)
 {
 	struct evt_context	*tcx;
@@ -855,18 +853,16 @@ evt_tcx_create(struct evt_root *root, uint64_t feats, unsigned int order,
 	if (tcx == NULL)
 		return -DER_NOMEM;
 
-	tcx->tc_ref = 1; /* for the caller */
-	tcx->tc_magic = EVT_HDL_ALIVE;
+	tcx->tc_ref	 = 1; /* for the caller */
+	tcx->tc_magic	 = EVT_HDL_ALIVE;
+	tcx->tc_root	 = root;
+	tcx->tc_desc_cbs = *cbs;
 
 	rc = umem_class_init(uma, &tcx->tc_umm);
 	if (rc != 0) {
 		D_ERROR("Failed to setup mem class %d: %d\n", uma->uma_id, rc);
 		D_GOTO(failed, rc);
 	}
-	tcx->tc_blks_info = info;
-
-	tcx->tc_root = root;
-	tcx->tc_coh = coh;
 
 	if (feats != -1) { /* tree creation */
 		tcx->tc_feats	= feats;
@@ -875,7 +871,7 @@ evt_tcx_create(struct evt_root *root, uint64_t feats, unsigned int order,
 		V_TRACE(DB_TRACE, "Create context for a new tree\n");
 
 	} else {
-		if (root->tr_pool_uuid != umem_get_uuid(&tcx->tc_umm)) {
+		if (root->tr_pool_uuid != umem_get_uuid(evt_umm(tcx))) {
 			D_ERROR("Mixing pools in same evtree not allowed\n");
 			rc = -DER_INVAL;
 			goto failed;
@@ -905,7 +901,6 @@ evt_tcx_create(struct evt_root *root, uint64_t feats, unsigned int order,
 	}
 	D_DEBUG(DB_IO, "EVTree sort policy is 0x%x\n", policy);
 
-
 	/* Initialize the embedded iterator entry array.  This is a minor
 	 * optimization if the iterator is used more than once
 	 */
@@ -930,40 +925,58 @@ evt_tcx_clone(struct evt_context *tcx, struct evt_context **tcx_pp)
 	if (!tcx->tc_root || tcx->tc_root->tr_feats == 0)
 		return -DER_INVAL;
 
-	rc = evt_tcx_create(tcx->tc_root, -1, -1, &uma, tcx->tc_coh,
-			    tcx->tc_blks_info, tcx_pp);
+	rc = evt_tcx_create(tcx->tc_root, -1, -1, &uma,
+			    &tcx->tc_desc_cbs, tcx_pp);
 	return rc;
 }
 
-static int
-evt_desc_free(struct evt_context *tcx, struct evt_desc *desc, daos_size_t size)
+int
+evt_desc_bio_free(struct evt_context *tcx, struct evt_desc *desc,
+		  daos_size_t nob)
 {
-	bio_addr_t	*addr = &desc->dc_ex_addr;
-	int		 rc = 0;
+	struct evt_desc_cbs *cbs = &tcx->tc_desc_cbs;
 
-	if (bio_addr_is_hole(addr))
-		return 0;
+	/* Free the bio address referenced by dst_desc, it is a callback
+	 * because evtree should not depend on bio functions
+	 */
+	D_ASSERT(cbs && cbs->dc_bio_free_cb);
+	return cbs->dc_bio_free_cb(evt_umm(tcx), desc, nob,
+				   cbs->dc_bio_free_args);
+}
 
-	if (addr->ba_type == DAOS_MEDIA_SCM) {
-		rc = umem_free(evt_umm(tcx), addr->ba_off);
+int
+evt_desc_log_status(struct evt_context *tcx, struct evt_desc *desc,
+		  int intent)
+{
+	struct evt_desc_cbs *cbs = &tcx->tc_desc_cbs;
+
+	D_ASSERT(cbs);
+	if (!cbs->dc_log_status_cb) {
+		return ALB_AVAILABLE_CLEAN;
 	} else {
-		struct vea_space_info *vsi = tcx->tc_blks_info;
-		uint64_t blk_off;
-		uint32_t blk_cnt;
-
-		D_ASSERT(addr->ba_type == DAOS_MEDIA_NVME);
-		D_ASSERT(vsi != NULL);
-
-		blk_off = vos_byte2blkoff(addr->ba_off);
-		blk_cnt = vos_byte2blkcnt(size);
-
-		rc = vea_free(vsi, blk_off, blk_cnt);
-		if (rc)
-			D_ERROR("Error on block ["DF_U64", %u] free. %d\n",
-				blk_off, blk_cnt, rc);
+		return cbs->dc_log_status_cb(evt_umm(tcx), desc, intent,
+					     cbs->dc_log_status_args);
 	}
+}
 
-	return rc;
+int
+evt_desc_log_add(struct evt_context *tcx, struct evt_desc *desc)
+{
+	struct evt_desc_cbs *cbs = &tcx->tc_desc_cbs;
+
+	D_ASSERT(cbs);
+	return cbs->dc_log_add_cb ?
+	       cbs->dc_log_add_cb(evt_umm(tcx), desc, cbs->dc_log_add_args) : 0;
+}
+
+int
+evt_desc_log_del(struct evt_context *tcx, struct evt_desc *desc)
+{
+	struct evt_desc_cbs *cbs = &tcx->tc_desc_cbs;
+
+	D_ASSERT(cbs);
+	return cbs->dc_log_del_cb ?
+	       cbs->dc_log_del_cb(evt_umm(tcx), desc, cbs->dc_log_del_args) : 0;
 }
 
 static int
@@ -976,13 +989,22 @@ evt_node_entry_free(struct evt_context *tcx, struct evt_node_entry *ne)
 		return 0;
 
 	desc = evt_off2desc(tcx, ne->ne_child);
-	vos_dtx_deregister_record(evt_umm(tcx), desc->dc_dtx,
-				  ne->ne_child, DTX_RT_EVT);
-	rc = evt_desc_free(tcx, desc,
-			   tcx->tc_inob * evt_rect_width(&ne->ne_rect));
-	if (rc == 0)
-		rc = umem_free(evt_umm(tcx), ne->ne_child);
+	rc = evt_desc_log_del(tcx, desc);
+	if (rc)
+		goto out;
 
+	rc = evt_desc_bio_free(tcx, desc,
+			       tcx->tc_inob * evt_rect_width(&ne->ne_rect));
+	if (rc)
+		goto out;
+
+	rc = umem_free(evt_umm(tcx), ne->ne_child);
+	if (rc)
+		goto out;
+
+	return 0;
+out:
+	D_ERROR("Failed to release entry: %s\n", d_errstr(rc));
 	return rc;
 }
 
@@ -1110,10 +1132,12 @@ evt_node_free(struct evt_context *tcx, umem_off_t nd_off)
  * data extents.
  */
 static int
-evt_node_destroy(struct evt_context *tcx, umem_off_t nd_off, int level)
+evt_node_destroy(struct evt_context *tcx, umem_off_t nd_off, int level,
+		 bool *empty_ret)
 {
 	struct evt_node_entry	*ne;
 	struct evt_node		*nd;
+	bool			 empty;
 	bool			 leaf;
 	int			 i;
 	int			 rc = 0;
@@ -1124,17 +1148,59 @@ evt_node_destroy(struct evt_context *tcx, umem_off_t nd_off, int level)
 	V_TRACE(DB_TRACE, "Destroy %s node at level %d (nr = %d)\n",
 		leaf ? "leaf" : "", level, nd->tn_nr);
 
-	for (i = 0; i < nd->tn_nr; i++) {
+	empty = true;
+	for (i = nd->tn_nr - 1; i >= 0; i--) {
 		ne = evt_node_entry_at(tcx, nd, i);
-		if (leaf)
+		if (leaf) {
 			/* NB: This will be replaced with a callback */
 			rc = evt_node_entry_free(tcx, ne);
-		else
-			rc = evt_node_destroy(tcx, ne->ne_child, level + 1);
-		if (rc != 0)
-			return rc;
+			if (rc)
+				goto out;
+
+			if (!tcx->tc_creds_on)
+				continue;
+
+			D_ASSERT(tcx->tc_creds > 0);
+			tcx->tc_creds--;
+			if (tcx->tc_creds == 0) {
+				empty = (i == 0);
+				break;
+			}
+		} else {
+			rc = evt_node_destroy(tcx, ne->ne_child, level + 1,
+					      &empty);
+			if (rc) {
+				D_ERROR("destroy failed: %s\n", d_errstr(rc));
+				goto out;
+			}
+
+			if (!tcx->tc_creds_on || tcx->tc_creds > 0) {
+				D_ASSERT(empty);
+				continue;
+			}
+			D_ASSERT(tcx->tc_creds == 0);
+
+			if (empty) {
+				if (i > 0) /* some children are not empty */
+					empty = false;
+			} else {
+				i += 1;
+			}
+			break;
+		}
 	}
-	return evt_node_free(tcx, nd_off);
+
+	if (empty) {
+		rc = evt_node_free(tcx, nd_off);
+	} else {
+		evt_node_tx_add(tcx, nd);
+		nd->tn_nr = i;
+	}
+
+	if (empty_ret)
+		*empty_ret = empty;
+out:
+	return rc;
 }
 
 /** Return the MBR of a node */
@@ -1142,14 +1208,6 @@ static struct evt_rect *
 evt_node_mbr_get(struct evt_context *tcx, struct evt_node *node)
 {
 	return &node->tn_mbr;
-}
-
-int
-evt_dtx_check_availability(struct evt_context *tcx, umem_off_t entry,
-			   uint32_t intent)
-{
-	return vos_dtx_check_availability(evt_umm(tcx), tcx->tc_coh, entry,
-					  UMOFF_NULL, intent, DTX_RT_EVT);
 }
 
 /** (Re)compute MBR for a tree node */
@@ -1263,8 +1321,7 @@ evt_root_empty(struct evt_context *tcx)
 static int
 evt_root_tx_add(struct evt_context *tcx)
 {
-	struct umem_instance	*umm = evt_umm(tcx);
-	void			*root;
+	void	*root;
 
 	if (!evt_has_tx(tcx))
 		return 0;
@@ -1272,7 +1329,7 @@ evt_root_tx_add(struct evt_context *tcx)
 	D_ASSERT(tcx->tc_root != NULL);
 	root = tcx->tc_root;
 
-	return umem_tx_add_ptr(umm, root, sizeof(*tcx->tc_root));
+	return umem_tx_add_ptr(evt_umm(tcx), root, sizeof(*root));
 }
 
 /** Initialize the tree root */
@@ -1291,7 +1348,7 @@ evt_root_init(struct evt_context *tcx)
 	root->tr_feats = tcx->tc_feats;
 	root->tr_order = tcx->tc_order;
 	root->tr_node  = UMOFF_NULL;
-	root->tr_pool_uuid = umem_get_uuid(&tcx->tc_umm);
+	root->tr_pool_uuid = umem_get_uuid(evt_umm(tcx));
 
 	return 0;
 }
@@ -1383,20 +1440,25 @@ evt_root_deactivate(struct evt_context *tcx)
 
 /** Destroy the root node and all its descendants. */
 static int
-evt_root_destroy(struct evt_context *tcx)
+evt_root_destroy(struct evt_context *tcx, bool *destroyed)
 {
-	umem_off_t	node;
-	int		rc;
+	struct evt_root *root;
+	int		 rc;
+	bool		 empty = true;
 
-	node = tcx->tc_root->tr_node;
-	if (!UMOFF_IS_NULL(node)) {
+	root = tcx->tc_root;
+	if (root && !UMOFF_IS_NULL(root->tr_node)) {
 		/* destroy the root node and all descendants */
-		rc = evt_node_destroy(tcx, node, 0);
+		rc = evt_node_destroy(tcx, root->tr_node, 0, &empty);
 		if (rc != 0)
 			return rc;
 	}
 
-	return evt_root_free(tcx);
+	*destroyed = empty;
+	if (empty)
+		evt_root_free(tcx);
+
+	return 0;
 }
 
 static int64_t
@@ -1449,8 +1511,8 @@ static int
 evt_insert_or_split(struct evt_context *tcx, const struct evt_entry_in *ent_new)
 {
 	struct evt_rect		*mbr	  = NULL;
-	struct evt_node		*nd_tmp = NULL;
-	umem_off_t		 nm_save = UMOFF_NULL;
+	struct evt_node		*nd_tmp   = NULL;
+	umem_off_t		 nm_save  = UMOFF_NULL;
 	struct evt_entry_in	 entry	  = *ent_new;
 	int			 rc	  = 0;
 	int			 level	  = tcx->tc_depth - 1;
@@ -1679,13 +1741,11 @@ evt_desc_copy(struct evt_context *tcx, const struct evt_entry_in *ent)
 	D_ASSERT(ent->ei_inob != 0);
 	size = ent->ei_inob * evt_rect_width(&ent->ei_rect);
 
-	/* Free the pmem that dst_desc references */
-	rc = evt_desc_free(tcx, dst_desc, size);
+	rc = evt_desc_bio_free(tcx, dst_desc, size);
 	if (rc != 0)
 		return rc;
 
 	csum_buf_len = evt_csum_buf_len(tcx, &ent->ei_rect.rc_ex);
-
 	rc = umem_tx_add_ptr(evt_umm(tcx), dst_desc,
 			     sizeof(*dst_desc) + csum_buf_len);
 	if (rc != 0)
@@ -1810,7 +1870,7 @@ evt_entry_fill(struct evt_context *tcx, struct evt_node *node,
 
 	entry->en_addr = desc->dc_ex_addr;
 	entry->en_ver = desc->dc_ver;
-	entry->en_dtx = desc->dc_dtx;
+	entry->en_desc = umem_ptr2off(evt_umm(tcx), desc);
 	evt_entry_csum_fill(tcx, desc, entry);
 
 	if (offset != 0) {
@@ -1917,8 +1977,7 @@ evt_ent_array_fill(struct evt_context *tcx, enum evt_find_opc find_opc,
 			V_TRACE(DB_TRACE, "Found overlapped leaf rect\n");
 
 			desc = evt_node_desc_at(tcx, node, i);
-			rc = evt_dtx_check_availability(tcx, desc->dc_dtx,
-							intent);
+			rc = evt_desc_log_status(tcx, desc, intent);
 			/* Skip the unavailable record. */
 			if (rc == ALB_UNAVAILABLE)
 				continue;
@@ -2123,8 +2182,8 @@ evt_move_trace(struct evt_context *tcx)
  * Please check API comment in evtree.h for the details.
  */
 int
-evt_open(struct evt_root *root, struct umem_attr *uma, daos_handle_t coh,
-	 void *info, daos_handle_t *toh)
+evt_open(struct evt_root *root, struct umem_attr *uma,
+	 struct evt_desc_cbs *cbs, daos_handle_t *toh)
 {
 	struct evt_context *tcx;
 	int		    rc;
@@ -2134,7 +2193,7 @@ evt_open(struct evt_root *root, struct umem_attr *uma, daos_handle_t coh,
 		return -DER_INVAL;
 	}
 
-	rc = evt_tcx_create(root, -1, -1, uma, coh, info, &tcx);
+	rc = evt_tcx_create(root, -1, -1, uma, cbs, &tcx);
 	if (rc != 0)
 		return rc;
 
@@ -2165,8 +2224,8 @@ evt_close(daos_handle_t toh)
  * Please check API comment in evtree.h for the details.
  */
 int
-evt_create(uint64_t feats, unsigned int order, struct umem_attr *uma,
-	   struct evt_root *root, daos_handle_t coh, daos_handle_t *toh)
+evt_create(struct evt_root *root, uint64_t feats, unsigned int order,
+	   struct umem_attr *uma, struct evt_desc_cbs *cbs, daos_handle_t *toh)
 {
 	struct evt_context *tcx;
 	int		    rc;
@@ -2181,8 +2240,7 @@ evt_create(uint64_t feats, unsigned int order, struct umem_attr *uma,
 		return -DER_INVAL;
 	}
 
-	rc = evt_tcx_create(root, feats, order, uma,
-			    coh, NULL, &tcx);
+	rc = evt_tcx_create(root, feats, order, uma, cbs, &tcx);
 	if (rc != 0)
 		return rc;
 
@@ -2210,6 +2268,7 @@ int
 evt_destroy(daos_handle_t toh)
 {
 	struct evt_context *tcx;
+	bool		    destroyed;
 	int		    rc;
 
 	tcx = evt_hdl2tcx(toh);
@@ -2220,7 +2279,9 @@ evt_destroy(daos_handle_t toh)
 	if (rc != 0)
 		return rc;
 
-	rc = evt_root_destroy(tcx);
+	D_ASSERT(!tcx->tc_creds_on);
+	rc = evt_root_destroy(tcx, &destroyed);
+	D_ASSERT(rc || destroyed);
 
 	rc = evt_tx_end(tcx, rc);
 
@@ -2302,7 +2363,6 @@ evt_debug(daos_handle_t toh, int debug_level)
 	return 0;
 }
 
-
 /**
  * Tree policies
  *
@@ -2354,8 +2414,7 @@ evt_common_insert(struct evt_context *tcx, struct evt_node *nd,
 		}
 
 		desc = evt_off2desc(tcx, ne->ne_child);
-		rc = evt_dtx_check_availability(tcx, desc->dc_dtx,
-						DAOS_INTENT_CHECK);
+		rc = evt_desc_log_status(tcx, desc, DAOS_INTENT_CHECK);
 		if (rc != ALB_UNAVAILABLE) {
 			nr = nd->tn_nr - i;
 			memmove(ne + 1, ne, nr * sizeof(*ne));
@@ -2385,8 +2444,7 @@ evt_common_insert(struct evt_context *tcx, struct evt_node *nd,
 		if (i != 0 && leaf) {
 			ne = evt_node_entry_at(tcx, nd, i - 1);
 			desc = evt_off2desc(tcx, ne->ne_child);
-			rc = evt_dtx_check_availability(tcx, desc->dc_dtx,
-							DAOS_INTENT_CHECK);
+			rc = evt_desc_log_status(tcx, desc, DAOS_INTENT_CHECK);
 			if (rc == ALB_UNAVAILABLE) {
 				umem_off_t	off = ne->ne_child;
 
@@ -2424,8 +2482,7 @@ evt_common_insert(struct evt_context *tcx, struct evt_node *nd,
 			return -DER_NOSPACE;
 		ne->ne_child = desc_off;
 		desc = evt_off2ptr(tcx, desc_off);
-		rc = vos_dtx_register_record(evt_umm(tcx), desc_off,
-					     DTX_RT_EVT, 0);
+		rc = evt_desc_log_add(tcx, desc);
 		if (rc != 0)
 			/* It is unnecessary to free the PMEM that will be
 			 * dropped automatically when the PMDK transaction
@@ -2745,7 +2802,7 @@ evt_tcx_fix_trace(struct evt_context *tcx, int level)
 
 /* Delete the node pointed to by current trace */
 int
-evt_node_delete(struct evt_context *tcx, bool remove)
+evt_node_delete(struct evt_context *tcx)
 {
 	struct evt_trace	*trace;
 	struct evt_node		*node;
@@ -2764,7 +2821,7 @@ evt_node_delete(struct evt_context *tcx, bool remove)
 	 * adjustments.
 	 */
 	while (1) {
-		int			 count;
+		int	count;
 
 		trace = &tcx->tc_trace[level];
 		nm_cur = trace->tr_node;
@@ -2776,24 +2833,8 @@ evt_node_delete(struct evt_context *tcx, bool remove)
 		if (!UMOFF_IS_NULL(old_cur))
 			D_ASSERT(old_cur == ne->ne_child);
 		if (leaf) {
-			struct evt_rect	*rect;
-			struct evt_desc	*desc;
-			size_t		 width;
-
 			/* Free the evt_desc */
-			if (remove) {
-				rect = evt_node_rect_at(tcx, node,
-							trace->tr_at);
-				width = tcx->tc_inob * evt_rect_width(rect);
-				desc = evt_off2desc(tcx, ne->ne_child);
-				vos_dtx_deregister_record(evt_umm(tcx),
-					desc->dc_dtx, ne->ne_child, DTX_RT_EVT);
-				rc = evt_desc_free(tcx, desc, width);
-				if (rc != 0)
-					return rc;
-			}
-
-			rc = umem_free(evt_umm(tcx), ne->ne_child);
+			rc = evt_node_entry_free(tcx, ne);
 			if (rc != 0)
 				return rc;
 		}
@@ -2928,7 +2969,7 @@ int evt_delete(daos_handle_t toh, const struct evt_rect *rect,
 	if (rc != 0)
 		return rc;
 
-	rc = evt_node_delete(tcx, ent == NULL);
+	rc = evt_node_delete(tcx);
 
 	/* We return NON_EXIST from evt_node_delete if there
 	 * are no subsequent nodes in the tree.  We can
@@ -3014,8 +3055,9 @@ evt_entry_csum_fill(struct evt_context *tcx, struct evt_desc *desc,
 	}
 }
 
-int evt_overhead_get(int alloc_overhead, int tree_order,
-		     struct daos_tree_overhead *ovhd)
+int
+evt_overhead_get(int alloc_overhead, int tree_order,
+		 struct daos_tree_overhead *ovhd)
 {
 	if (ovhd == NULL) {
 		D_ERROR("Invalid ovhd argument\n");
@@ -3031,4 +3073,40 @@ int evt_overhead_get(int alloc_overhead, int tree_order,
 	ovhd->to_node_overhead.no_order = tree_order;
 
 	return 0;
+}
+
+int
+evt_drain(daos_handle_t toh, int *credits, bool *destroyed)
+{
+	struct evt_context *tcx;
+	int		    rc;
+
+	tcx = evt_hdl2tcx(toh);
+	if (tcx == NULL)
+		return -DER_NO_HDL;
+
+	if (credits) {
+		if (*credits <= 0)
+			return -DER_INVAL;
+
+		tcx->tc_creds = *credits;
+		tcx->tc_creds_on = 1;
+	}
+
+	rc = evt_tx_begin(tcx);
+	if (rc != 0)
+		return rc;
+
+	rc = evt_root_destroy(tcx, destroyed);
+	if (rc)
+		goto out;
+
+	if (tcx->tc_creds_on)
+		*credits = tcx->tc_creds;
+out:
+	rc = evt_tx_end(tcx, rc);
+
+	tcx->tc_creds_on = 0;
+	tcx->tc_creds = 0;
+	return rc;
 }

--- a/src/vos/tests/evt_ctl.c
+++ b/src/vos/tests/evt_ctl.c
@@ -53,6 +53,7 @@
  */
 struct test_input_value {
 	bool             input;
+	int		 rect_nr;
 	char             *optval;
 };
 
@@ -87,6 +88,48 @@ static daos_handle_t		ts_toh;
 #define D_1M_SIZE		(1024 * 1024)
 #define D_256M_SIZE		(256 * 1024 * 1024)
 
+#define POOL_NAME "/mnt/daos/evtree-utest"
+#define POOL_SIZE ((1024 * 1024  * 1024ULL))
+
+struct test_arg {
+	struct utest_context	*ta_utx;
+	struct umem_attr	*ta_uma;
+	struct evt_root		*ta_root;
+	char			*ta_pool_name;
+};
+
+static int
+ts_evt_bio_free(struct umem_instance *umm, struct evt_desc *desc,
+		daos_size_t nob, void *args)
+{
+	struct utest_context *utx;
+
+	if (args)
+		utx = ((struct test_arg *)args)->ta_utx;
+	else
+		utx = ts_utx;
+
+	if (!bio_addr_is_hole(&desc->dc_ex_addr))
+		utest_free(utx, desc->dc_ex_addr.ba_off);
+	return 0;
+}
+
+static struct evt_desc_cbs	ts_evt_desc_cbs  = {
+	.dc_bio_free_cb		= ts_evt_bio_free,
+};
+
+static int
+ts_evt_bio_nofree(struct umem_instance *umm, struct evt_desc *desc,
+		daos_size_t nob, void *args)
+{
+	/* caller is responsible for free */
+	return 0;
+}
+
+static struct evt_desc_cbs	ts_evt_desc_nofree_cbs  = {
+	.dc_bio_free_cb		= ts_evt_bio_nofree,
+};
+
 static void
 ts_open_create(void **state)
 {
@@ -118,11 +161,11 @@ ts_open_create(void **state)
 
 	if (create) {
 		D_PRINT("Create evtree with order %d\n", ts_order);
-		rc = evt_create(ts_feats, ts_order, ts_uma, ts_root,
-				DAOS_HDL_INVAL, &ts_toh);
+		rc = evt_create(ts_root, ts_feats, ts_order, ts_uma,
+				&ts_evt_desc_cbs, &ts_toh);
 	} else {
 		D_PRINT("Open evtree\n");
-		rc = evt_open(ts_root, ts_uma, DAOS_HDL_INVAL, NULL, &ts_toh);
+		rc = evt_open(ts_root, ts_uma, &ts_evt_desc_cbs, &ts_toh);
 	}
 
 	if (rc != 0) {
@@ -361,16 +404,13 @@ ts_delete_rect(void **state)
 		total_deleted++;
 
 	if (should_pass) {
-		if (rc != 0)
+		if (rc != 0) {
 			D_FATAL("Delete rect failed %d\n", rc);
-		else if (evt_rect_width(&rect) !=
-			 evt_extent_width(&ent.en_sel_ext)) {
+		} else if (evt_rect_width(&rect) !=
+			   evt_extent_width(&ent.en_sel_ext)) {
 			rc = 1;
 			D_FATAL("Returned rectangle width doesn't match\n");
 		}
-
-		if (!bio_addr_is_hole(&ent.en_addr))
-			utest_free(ts_utx, ent.en_addr.ba_off);
 	} else {
 		if (rc == 0) {
 			D_FATAL("Delete rect should have failed\n");
@@ -588,6 +628,11 @@ ts_many_add(void **state)
 	 * n: number of extents
 	 */
 	arg = tst_fn_val.optval;
+	if (!arg) {
+		D_PRINT("need input parameters s:NUM,e:NUM,n:NUM\n");
+		fail();
+	}
+
 	if (arg[0] == 's') {
 		if (arg[1] != EVT_SEP_VAL) {
 			D_PRINT("Invalid parameter %s\n", arg);
@@ -626,6 +671,7 @@ ts_many_add(void **state)
 		D_PRINT("Invalid extent number %d\n", nr);
 		fail();
 	}
+	tst_fn_val.rect_nr = nr;
 
 	D_ALLOC(buf, size);
 	if (!buf)
@@ -644,7 +690,7 @@ ts_many_add(void **state)
 		rect->rc_ex.ex_hi = rect->rc_ex.ex_lo + size - 1;
 		rect->rc_epc = (seq[i] % TS_VAL_CYCLE) + 1;
 
-		memset(buf, 'a' + seq[i] % TS_VAL_CYCLE, size);
+		memset(buf, 'a' + seq[i] % TS_VAL_CYCLE, size - 1);
 
 		rc = bio_strdup(ts_utx, &bio_addr, buf);
 		if (rc != 0) {
@@ -677,15 +723,30 @@ ts_tree_debug(void **state)
 	evt_debug(ts_toh, level);
 }
 
-#define POOL_NAME "/mnt/daos/evtree-utest"
-#define POOL_SIZE ((1024 * 1024  * 1024ULL))
+static void
+ts_drain(void **state)
+{
+	static int const drain_creds = 256;
+	int	rc;
 
-struct test_arg {
-	struct utest_context	*ta_utx;
-	struct umem_attr	*ta_uma;
-	struct evt_root		*ta_root;
-	char			*ta_pool_name;
-};
+	ts_many_add(state);
+	while (1) {
+		bool destroyed = false;
+		int creds = drain_creds;
+
+		rc = evt_drain(ts_toh, &creds, &destroyed);
+		if (rc) {
+			print_message("Failed to drain: %s\n", d_errstr(rc));
+			fail();
+		}
+		print_message("drained %d of %d\n", drain_creds - creds,
+			      tst_fn_val.rect_nr);
+		if (destroyed) {
+			print_message("tree is empty\n");
+			break;
+		}
+	}
+}
 
 int
 teardown_builtin(void **state)
@@ -702,6 +763,7 @@ teardown_builtin(void **state)
 	rc = utest_utx_destroy(arg->ta_utx);
 
 	D_FREE(arg->ta_pool_name);
+	ts_evt_desc_cbs.dc_bio_free_args = NULL;
 
 	return rc;
 }
@@ -728,6 +790,7 @@ setup_builtin(void **state)
 
 	arg->ta_root = utest_utx2root(arg->ta_utx);
 	arg->ta_uma = utest_utx2uma(arg->ta_utx);
+	ts_evt_desc_cbs.dc_bio_free_args = arg;
 
 	return 0;
 failed:
@@ -956,8 +1019,8 @@ test_evt_iter_flags(void **state)
 	int		t_repeats;
 
 	/* Create a evtree */
-	rc = evt_create(ts_feats, ORDER_DEF_INTERNAL, arg->ta_uma, arg->ta_root,
-			DAOS_HDL_INVAL, &toh);
+	rc = evt_create(arg->ta_root, ts_feats, ORDER_DEF_INTERNAL, arg->ta_uma,
+			&ts_evt_desc_cbs, &toh);
 	assert_int_equal(rc, 0);
 	D_ALLOC_ARRAY(data, (NUM_EPOCHS+1));
 	if (data == NULL)
@@ -1121,8 +1184,8 @@ test_evt_iter_delete(void **state)
 	struct evt_filter	 filter;
 	uint32_t		 inob;
 
-	rc = evt_create(ts_feats, ORDER_DEF_INTERNAL, arg->ta_uma, arg->ta_root,
-			DAOS_HDL_INVAL, &toh);
+	rc = evt_create(arg->ta_root, ts_feats, ORDER_DEF_INTERNAL, arg->ta_uma,
+			&ts_evt_desc_nofree_cbs, &toh);
 	assert_int_equal(rc, 0);
 	rc = utest_sync_mem_status(arg->ta_utx);
 	assert_int_equal(rc, 0);
@@ -1189,20 +1252,18 @@ test_evt_iter_delete(void **state)
 
 	/* Delete some of the entries */
 	for (;;) {
-		bio_addr_t addr;
-
-		rc = evt_iter_delete(ih, &addr);
+		rc = evt_iter_delete(ih, &ent);
 		if (rc == -DER_NONEXIST)
 			break;
 
 		assert_int_equal(rc, 0);
 
-		assert_false(bio_addr_is_hole(&addr));
+		assert_false(bio_addr_is_hole(&ent.en_addr));
 
-		value = utest_off2ptr(arg->ta_utx, addr.ba_off);
+		value = utest_off2ptr(arg->ta_utx, ent.en_addr.ba_off);
 
 		sum += *value;
-		utest_free(arg->ta_utx, addr.ba_off);
+		utest_free(arg->ta_utx, ent.en_addr.ba_off);
 	}
 	expected_sum = NUM_PARTIAL * (NUM_EXTENTS * (NUM_EXTENTS + 1) / 2);
 	assert_int_equal(expected_sum, sum);
@@ -1219,17 +1280,15 @@ test_evt_iter_delete(void **state)
 
 	/* Ok, delete the rest */
 	while (!evt_iter_empty(ih)) {
-		bio_addr_t addr;
-
-		rc = evt_iter_delete(ih, &addr);
+		rc = evt_iter_delete(ih, &ent);
 		assert_int_equal(rc, 0);
 
-		assert_false(bio_addr_is_hole(&addr));
+		assert_false(bio_addr_is_hole(&ent.en_addr));
 
-		value = utest_off2ptr(arg->ta_utx, addr.ba_off);
+		value = utest_off2ptr(arg->ta_utx, ent.en_addr.ba_off);
 
 		sum += *value;
-		utest_free(arg->ta_utx, addr.ba_off);
+		utest_free(arg->ta_utx, ent.en_addr.ba_off);
 		rc = utest_check_mem_decrease(arg->ta_utx);
 		assert_int_equal(rc, 0);
 		rc = utest_sync_mem_status(arg->ta_utx);
@@ -1265,8 +1324,8 @@ test_evt_find_internal(void **state)
 	char testdata[] = "deadbeef";
 
 	/* Create a evtree */
-	rc = evt_create(ts_feats, ORDER_DEF_INTERNAL, arg->ta_uma, arg->ta_root,
-			DAOS_HDL_INVAL, &toh);
+	rc = evt_create(arg->ta_root, ts_feats, ORDER_DEF_INTERNAL, arg->ta_uma,
+			&ts_evt_desc_cbs, &toh);
 	assert_int_equal(rc, 0);
 	rc = utest_sync_mem_status(arg->ta_utx);
 	assert_int_equal(rc, 0);
@@ -1401,8 +1460,8 @@ test_evt_iter_delete_internal(void **state)
 	int			 val[] = {10, 26, 2, 18, 4, 20, 6, 22, 0};
 	int			 iter_count;
 
-	rc = evt_create(ts_feats, ORDER_DEF_INTERNAL, arg->ta_uma, arg->ta_root,
-			DAOS_HDL_INVAL, &toh);
+	rc = evt_create(arg->ta_root, ts_feats, ORDER_DEF_INTERNAL, arg->ta_uma,
+			&ts_evt_desc_cbs, &toh);
 	assert_int_equal(rc, 0);
 
 	/* Insert a bunch of entries */
@@ -1424,6 +1483,8 @@ test_evt_iter_delete_internal(void **state)
 	}
 	for (iter_count = 0; iter_count < (
 		sizeof(val)/sizeof(int)); iter_count++) {
+		struct evt_entry ent;
+
 		/* No filter so delete everything */
 		rc = evt_iter_prepare(toh, val[iter_count], NULL, &ih);
 		assert_int_equal(rc, 0);
@@ -1433,7 +1494,7 @@ test_evt_iter_delete_internal(void **state)
 
 		/* Ok, delete the rest */
 		while (!evt_iter_empty(ih)) {
-			rc = evt_iter_delete(ih, NULL);
+			rc = evt_iter_delete(ih, &ent);
 			if (val[iter_count] == 0) {
 				assert_int_equal(rc, 0);
 			} else {
@@ -1462,8 +1523,8 @@ test_evt_variable_record_size_internal(void **state)
 	uint64_t		data_size;
 	char                     *data;
 
-	rc = evt_create(ts_feats, ORDER_DEF_INTERNAL, arg->ta_uma, arg->ta_root,
-		DAOS_HDL_INVAL, &toh);
+	rc = evt_create(arg->ta_root, ts_feats, ORDER_DEF_INTERNAL,
+			arg->ta_uma, &ts_evt_desc_cbs, &toh);
 	assert_int_equal(rc, 0);
 	for (count = 0; count < sizeof(val)/sizeof(int); count++) {
 		/* Try to insert a bunch of entries with variable data sizes */
@@ -1518,9 +1579,8 @@ test_evt_various_data_size_internal(void **state)
 	daos_epoch_range_t	 epr;
 
 	for (count = 0; count < sizeof(val)/sizeof(int); count++) {
-		rc = evt_create(ts_feats, ORDER_DEF_INTERNAL,
-			arg->ta_uma, arg->ta_root,
-			DAOS_HDL_INVAL, &toh);
+		rc = evt_create(arg->ta_root, ts_feats, ORDER_DEF_INTERNAL,
+				arg->ta_uma, &ts_evt_desc_cbs, &toh);
 		assert_int_equal(rc, 0);
 		rc = utest_sync_mem_status(arg->ta_utx);
 		assert_int_equal(rc, 0);
@@ -1652,8 +1712,8 @@ test_evt_ent_alloc_bug(void **state)
 	int			 last = 0;
 	int			 idx1, nr1, idx2, nr2, idx3, nr3;
 
-	rc = evt_create(ts_feats, ORDER_DEF_INTERNAL, arg->ta_uma, arg->ta_root,
-			DAOS_HDL_INVAL, &toh);
+	rc = evt_create(arg->ta_root, ts_feats, ORDER_DEF_INTERNAL, arg->ta_uma,
+			&ts_evt_desc_cbs, &toh);
 	assert_int_equal(rc, 0);
 
 	idx1 = 0;
@@ -1722,8 +1782,8 @@ test_evt_root_deactivate_bug(void **state)
 	struct evt_entry_in	 entry_in = {0};
 	int			 rc;
 
-	rc = evt_create(ts_feats, ORDER_DEF_INTERNAL, arg->ta_uma, arg->ta_root,
-			DAOS_HDL_INVAL, &toh);
+	rc = evt_create(arg->ta_root, ts_feats, ORDER_DEF_INTERNAL, arg->ta_uma,
+			&ts_evt_desc_cbs, &toh);
 	assert_int_equal(rc, 0);
 
 	entry_in.ei_ver = 0;
@@ -1841,24 +1901,36 @@ run_tree_debug_test(void)
 }
 
 static int
+run_drain_test(void)
+{
+	static const struct CMUnitTest evt_drain[] = {
+		{ "EVT009: evt_drain", ts_drain, NULL, NULL},
+		{ NULL, NULL, NULL, NULL }
+	};
+
+	return cmocka_run_group_tests_name("evtree drain test",
+					   evt_drain, NULL, NULL);
+}
+
+static int
 run_internal_tests(void)
 {
 	static const struct CMUnitTest evt_builtin[] = {
-		{ "EVT009: evt_iter_delete", test_evt_iter_delete,
+		{ "EVT050: evt_iter_delete", test_evt_iter_delete,
 			setup_builtin, teardown_builtin},
-		{ "EVT010: evt_iter_delete_internal",
+		{ "EVT051: evt_iter_delete_internal",
 			test_evt_iter_delete_internal,
 			setup_builtin, teardown_builtin},
-		{ "EVT011: evt_ent_alloc_bug",
+		{ "EVT052: evt_ent_alloc_bug",
 			test_evt_ent_alloc_bug,
 			setup_builtin, teardown_builtin},
-		{ "EVT012: evt_root_deactivate_bug",
+		{ "EVT053: evt_root_deactivate_bug",
 			test_evt_root_deactivate_bug,
 			setup_builtin, teardown_builtin},
-		{ "EVT013: evt_iter_flags",
+		{ "EVT054: evt_iter_flags",
 			test_evt_iter_flags,
 			setup_builtin, teardown_builtin},
-		{ "EVT014: evt_find_internal",
+		{ "EVT055: evt_find_internal",
 			test_evt_find_internal,
 			setup_builtin, teardown_builtin},
 		{ "EVT015: evt_various_data_size_internal",
@@ -1879,6 +1951,7 @@ static struct option ts_ops[] = {
 	{ "destroy",	no_argument,		NULL,	'D'	},
 	{ "open",	no_argument,		NULL,	'o'	},
 	{ "close",	no_argument,		NULL,	'c'	},
+	{ "drain",	required_argument,	NULL,	'e'	},
 	{ "add",	required_argument,	NULL,	'a'	},
 	{ "many_add",	required_argument,	NULL,	'm'	},
 	{ "find",	required_argument,	NULL,	'f'	},
@@ -1919,6 +1992,9 @@ ts_cmd_run(char opc, char *args)
 		break;
 	case 'm':
 		rc = run_many_add_test();
+		break;
+	case 'e':
+		rc = run_drain_test();
 		break;
 	case 'f':
 		rc = run_find_rect_test();
@@ -1987,7 +2063,7 @@ main(int argc, char **argv)
 		goto out;
 	}
 
-	while ((rc = getopt_long(argc, argv, "C:a:m:f:g:d:b:Docl::ts:",
+	while ((rc = getopt_long(argc, argv, "C:a:m:e:f:g:d:b:Docl::ts:",
 				 ts_ops, NULL)) != -1) {
 		rc = ts_cmd_run(rc, optarg);
 		if (rc != 0)

--- a/src/vos/tests/evt_ctl.sh
+++ b/src/vos/tests/evt_ctl.sh
@@ -10,7 +10,8 @@ DAOS_DIR=$(cd "${cwd}/../../.." && echo "$PWD")
 source "$DAOS_DIR/.build_vars.sh"
 EVT_CTL="$SL_PREFIX/bin/evt_ctl"
 
-cmd="$VCMD $EVT_CTL $* -C o:4"
+cmd_create="$VCMD $EVT_CTL $* -C o:4"
+cmd=$cmd_create
 
 function word_set {
     ((flag = $1 % 2))
@@ -159,4 +160,15 @@ echo "$cmd"
 $cmd -t
 result="${PIPESTATUS[0]}"
 echo "Test returned $result"
+if (( result != 0 )); then
+	exit "$result"
+fi
+
+cmd=$cmd_create
+cmd+=" -e s:0,e:128,n:2379 -c"
+echo "$cmd"
+$cmd
+
+result="${PIPESTATUS[0]}"
+echo "Drain test returned $result"
 exit "$result"

--- a/src/vos/vos_common.c
+++ b/src/vos/vos_common.c
@@ -82,6 +82,32 @@ vos_csum_compute(d_sg_list_t *sgl, daos_csum_buf_t *csum)
 	return rc;
 }
 
+int
+vos_bio_addr_free(struct vos_pool *pool, bio_addr_t *addr, daos_size_t nob)
+{
+	int	rc;
+
+	if (bio_addr_is_hole(addr))
+		return 0;
+
+	if (addr->ba_type == DAOS_MEDIA_SCM) {
+		rc = umem_free(&pool->vp_umm, addr->ba_off);
+	} else {
+		uint64_t blk_off;
+		uint32_t blk_cnt;
+
+		D_ASSERT(addr->ba_type == DAOS_MEDIA_NVME);
+		blk_off = vos_byte2blkoff(addr->ba_off);
+		blk_cnt = vos_byte2blkcnt(nob);
+
+		rc = vea_free(pool->vp_vea_info, blk_off, blk_cnt);
+		if (rc)
+			D_ERROR("Error on block ["DF_U64", %u] free. %d\n",
+				blk_off, blk_cnt, rc);
+	}
+	return rc;
+}
+
 /**
  * VOS in-memory structure creation.
  * Handle-hash:

--- a/src/vos/vos_container.c
+++ b/src/vos/vos_container.c
@@ -373,8 +373,7 @@ vos_cont_open(daos_handle_t poh, uuid_t co_uuid, daos_handle_t *coh)
 	rc = dbtree_open_inplace_ex(&cont->vc_otab_df->obt_btr,
 				    &cont->vc_pool->vp_uma,
 				    vos_cont2hdl(cont),
-				    cont->vc_pool->vp_vea_info,
-				    &cont->vc_btr_hdl);
+				    cont->vc_pool, &cont->vc_btr_hdl);
 	if (rc) {
 		D_ERROR("No Object handle, Tree open failed\n");
 		D_GOTO(exit, rc);

--- a/src/vos/vos_internal.h
+++ b/src/vos/vos_internal.h
@@ -1026,6 +1026,13 @@ enum {
 	SUBTR_EVT	= (1 << 1),	/**< subtree is evtree */
 };
 
+int
+vos_bio_addr_free(struct vos_pool *pool, bio_addr_t *addr, daos_size_t nob);
+
+void
+vos_evt_desc_cbs_init(struct evt_desc_cbs *cbs, struct vos_pool *pool,
+		      daos_handle_t coh);
+
 /* vos_obj.c */
 int
 key_tree_prepare(struct vos_object *obj, daos_epoch_t epoch,

--- a/src/vos/vos_obj_index.c
+++ b/src/vos/vos_obj_index.c
@@ -179,11 +179,11 @@ oi_rec_free(struct btr_instance *tins, struct btr_record *rec, void *args)
 
 		umem_attr_get(&tins->ti_umm, &uma);
 		rc = dbtree_open_inplace_ex(&obj->vo_tree, &uma, tins->ti_coh,
-					    tins->ti_blks_info, &toh);
+					    tins->ti_priv, &toh);
 		if (rc != 0)
 			D_ERROR("Failed to open OI tree: %d\n", rc);
 		else
-			dbtree_destroy(toh, NULL);
+			dbtree_destroy(toh, args);
 	}
 	umem_free(umm, rec->rec_off);
 	return rc;
@@ -741,8 +741,7 @@ vos_obj_tab_destroy(struct vos_pool *pool, struct vos_obj_table_df *otab_df)
 	}
 
 	rc = dbtree_open_inplace_ex(&otab_df->obt_btr, &pool->vp_uma,
-				    DAOS_HDL_INVAL, pool->vp_vea_info,
-				    &btr_hdl);
+				    DAOS_HDL_INVAL, pool, &btr_hdl);
 	if (rc) {
 		D_ERROR("No Object handle, Tree open failed\n");
 		D_GOTO(exit, rc = -DER_NONEXIST);

--- a/src/vos/vos_query.c
+++ b/src/vos/vos_query.c
@@ -36,14 +36,13 @@
 
 struct open_query {
 	daos_epoch_t		 qt_epoch;
-	struct umem_attr	*qt_uma;
 	struct btr_root		*qt_dkey_root;
 	daos_handle_t		 qt_dkey_toh;
 	struct btr_root		*qt_akey_root;
 	daos_handle_t		 qt_akey_toh;
 	struct evt_root		*qt_recx_root;
 	uint32_t		 qt_flags;
-	struct vea_space_info	*qt_vea_info;
+	struct vos_pool		*qt_pool;
 	daos_handle_t		 qt_coh;
 };
 
@@ -54,9 +53,9 @@ find_key(struct open_query *query, daos_handle_t toh, daos_key_t *key,
 	daos_handle_t		 ih;
 	struct vos_key_bundle	 kbund;
 	struct vos_rec_bundle	 rbund;
-	d_iov_t		 kiov;
-	d_iov_t		 kbund_kiov;
-	d_iov_t		 riov;
+	d_iov_t			 kiov;
+	d_iov_t			 kbund_kiov;
+	d_iov_t			 riov;
 	daos_csum_buf_t		 csum;
 	daos_epoch_range_t	 epr;
 	int			 rc = 0;
@@ -126,6 +125,7 @@ out:
 static int
 query_recx(struct open_query *query, daos_recx_t *recx)
 {
+	struct evt_desc_cbs	cbs;
 	struct evt_entry	entry;
 	daos_handle_t		toh;
 	daos_handle_t		ih;
@@ -138,8 +138,8 @@ query_recx(struct open_query *query, daos_recx_t *recx)
 	recx->rx_idx = 0;
 	recx->rx_nr = 0;
 
-	rc = evt_open(query->qt_recx_root, query->qt_uma, query->qt_coh,
-		      query->qt_vea_info, &toh);
+	vos_evt_desc_cbs_init(&cbs, query->qt_pool, query->qt_coh);
+	rc = evt_open(query->qt_recx_root, &query->qt_pool->vp_uma, &cbs, &toh);
 	if (rc != 0)
 		return rc;
 
@@ -192,8 +192,8 @@ open_and_query_key(struct open_query *query, daos_key_t *key,
 	daos_csum_buf_t		 csum = {0};
 	struct vos_key_bundle	 kbund;
 	struct vos_rec_bundle	 rbund;
-	d_iov_t		 kiov;
-	d_iov_t		 riov;
+	d_iov_t			 kiov;
+	d_iov_t			 riov;
 	enum vos_tree_class	 tclass;
 	int			 rc = 0;
 
@@ -210,8 +210,8 @@ open_and_query_key(struct open_query *query, daos_key_t *key,
 	if (to_open->tr_class == 0)
 		return -DER_NONEXIST;
 
-	rc = dbtree_open_inplace_ex(to_open, query->qt_uma,
-				    query->qt_coh, NULL, toh);
+	rc = dbtree_open_inplace_ex(to_open, &query->qt_pool->vp_uma,
+				    query->qt_coh, query->qt_pool, toh);
 	if (rc != 0)
 		return rc;
 
@@ -233,7 +233,6 @@ open_and_query_key(struct open_query *query, daos_key_t *key,
 
 	rc = dbtree_fetch(*toh, BTR_PROBE_GE | BTR_PROBE_MATCHED,
 			  DAOS_INTENT_DEFAULT, &kiov, NULL, &riov);
-
 	if (rc != 0)
 		return rc;
 
@@ -334,12 +333,11 @@ vos_obj_query_key(daos_handle_t coh, daos_unit_oid_t oid, uint32_t flags,
 
 	query.qt_dkey_toh = DAOS_HDL_INVAL;
 	query.qt_akey_toh = DAOS_HDL_INVAL;
-	query.qt_epoch = epoch;
-	query.qt_flags = flags;
-	query.qt_uma = vos_obj2uma(obj);
+	query.qt_epoch	  = epoch;
+	query.qt_flags	  = flags;
 	query.qt_dkey_root = &obj->obj_df->vo_tree;
-	query.qt_coh = coh;
-	query.qt_vea_info = obj->obj_cont->vc_pool->vp_vea_info;
+	query.qt_coh	  = coh;
+	query.qt_pool	  = vos_obj2pool(obj);
 
 	for (;;) {
 		rc = open_and_query_key(&query, dkey, DAOS_GET_DKEY,


### PR DESCRIPTION
This patch includes a few EVtree API changes:

- Add a new API evt_drain
  This function drains data extents from the tree, each time it frees
  an extent it consumes a "credit" which is input paramter of this
  function. It returns if all input credits are consumed, or the tree
  is empty, in the later case, it also destroys the evtree.

- Add a new function table for evt_desc
  It is passed in while openning an evtree, this function table defines
  callbacks for:
  . add evt_desc to undo log
  . remove evt_desc to undo log
  . check log status of evt_desc
  . free storage space for evt_desc

Signed-off-by: Liang Zhen <liang.zhen@intel.com>