### PR TITLE
DAOS-2929 drpc: Clean up dRPC code

### DIFF
--- a/src/common/drpc.c
+++ b/src/common/drpc.c
@@ -136,13 +136,14 @@ new_unixcomm_socket(int flags)
 
 	comm->fd = socket(AF_UNIX, SOCK_SEQPACKET, 0);
 	if (comm->fd < 0) {
-		D_ERROR("Failed to open socket\n");
+		D_ERROR("Failed to open socket, errno=%d\n", errno);
 		D_FREE(comm);
 		return NULL;
 	}
 
 	if (fcntl(comm->fd, F_SETFL, flags) < 0) {
-		D_ERROR("Failed to set flags on socket fd %d\n", comm->fd);
+		D_ERROR("Failed to set flags on socket fd %d, errno=%d\n",
+			comm->fd, errno);
 		unixcomm_close(comm);
 		return NULL;
 	}
@@ -176,7 +177,8 @@ unixcomm_connect(char *sockaddr, int flags)
 	ret = connect(handle->fd, (struct sockaddr *) &address,
 			sizeof(address));
 	if (ret < 0) {
-		D_ERROR("Failed to connect to socket fd %d\n", handle->fd);
+		D_ERROR("Failed to connect to socket fd %d, errno=%d\n",
+			handle->fd, errno);
 		unixcomm_close(handle);
 		return NULL;
 	}
@@ -197,14 +199,15 @@ unixcomm_listen(char *sockaddr, int flags)
 	fill_socket_address(sockaddr, &address);
 	if (bind(comm->fd, (struct sockaddr *)&address,
 		 sizeof(struct sockaddr_un)) < 0) {
-		D_ERROR("Failed to bind socket fd %d\n", comm->fd);
+		D_ERROR("Failed to bind socket fd %d, errno=%d\n",
+			comm->fd, errno);
 		unixcomm_close(comm);
 		return NULL;
 	}
 
 	if (listen(comm->fd, SOMAXCONN) < 0) {
-		D_ERROR("Failed to start listening on socket fd %d\n",
-			comm->fd);
+		D_ERROR("Failed to start listening on socket fd %d, errno=%d\n",
+			comm->fd, errno);
 		unixcomm_close(comm);
 		return NULL;
 	}
@@ -225,8 +228,8 @@ unixcomm_accept(struct unixcomm *listener)
 
 	comm->fd = accept(listener->fd, NULL, NULL);
 	if (comm->fd < 0) {
-		D_ERROR("Failed to accept connection on listener fd %d\n",
-			listener->fd);
+		D_ERROR("Failed to accept connection on listener fd %d, "
+			"errno=%d\n", listener->fd, errno);
 		D_FREE(comm);
 		return NULL;
 	}
@@ -246,7 +249,8 @@ unixcomm_close(struct unixcomm *handle)
 	D_FREE(handle);
 
 	if (ret < 0) {
-		D_ERROR("Failed to close socket fd %d\n", handle->fd);
+		D_ERROR("Failed to close socket fd %d, errno=%d\n",
+			handle->fd, errno);
 		return daos_errno2der(errno);
 	}
 
@@ -271,7 +275,8 @@ unixcomm_send(struct unixcomm *hndl, uint8_t *buffer, size_t buflen,
 
 	bsent = sendmsg(hndl->fd, &msg, 0);
 	if (bsent < 0) {
-		D_ERROR("Failed to sendmsg on socket fd %d\n", hndl->fd);
+		D_ERROR("Failed to sendmsg on socket fd %d, errno=%d\n",
+			hndl->fd, errno);
 		ret = daos_errno2der(errno);
 	} else {
 		if (sent != NULL)
@@ -299,7 +304,8 @@ unixcomm_recv(struct unixcomm *hndl, uint8_t *buffer, size_t buflen,
 
 	brcvd = recvmsg(hndl->fd, &msg, 0);
 	if (brcvd < 0) {
-		D_ERROR("Failed to recvmsg on socket fd %d\n", hndl->fd);
+		D_ERROR("Failed to recvmsg on socket fd %d, errno=%d\n",
+			hndl->fd, errno);
 		ret = daos_errno2der(errno);
 	} else {
 		if (rcvd != NULL)

--- a/src/common/drpc.c
+++ b/src/common/drpc.c
@@ -130,16 +130,19 @@ new_unixcomm_socket(int flags)
 
 	D_ALLOC_PTR(comm);
 	if (comm == NULL) {
+		D_ERROR("Failed to allocate unixcomm\n");
 		return NULL;
 	}
 
 	comm->fd = socket(AF_UNIX, SOCK_SEQPACKET, 0);
 	if (comm->fd < 0) {
+		D_ERROR("Failed to open socket\n");
 		D_FREE(comm);
 		return NULL;
 	}
 
 	if (fcntl(comm->fd, F_SETFL, flags) < 0) {
+		D_ERROR("Failed to set flags on socket fd %d\n", comm->fd);
 		unixcomm_close(comm);
 		return NULL;
 	}
@@ -166,14 +169,14 @@ unixcomm_connect(char *sockaddr, int flags)
 	struct unixcomm		*handle = NULL;
 
 	handle = new_unixcomm_socket(flags);
-	if (handle == NULL) {
+	if (handle == NULL)
 		return NULL;
-	}
 
 	fill_socket_address(sockaddr, &address);
 	ret = connect(handle->fd, (struct sockaddr *) &address,
 			sizeof(address));
 	if (ret < 0) {
+		D_ERROR("Failed to connect to socket fd %d\n", handle->fd);
 		unixcomm_close(handle);
 		return NULL;
 	}
@@ -188,18 +191,20 @@ unixcomm_listen(char *sockaddr, int flags)
 	struct unixcomm		*comm;
 
 	comm = new_unixcomm_socket(flags);
-	if (comm == NULL) {
+	if (comm == NULL)
 		return NULL;
-	}
 
 	fill_socket_address(sockaddr, &address);
 	if (bind(comm->fd, (struct sockaddr *)&address,
-			sizeof(struct sockaddr_un)) < 0) {
+		 sizeof(struct sockaddr_un)) < 0) {
+		D_ERROR("Failed to bind socket fd %d\n", comm->fd);
 		unixcomm_close(comm);
 		return NULL;
 	}
 
 	if (listen(comm->fd, SOMAXCONN) < 0) {
+		D_ERROR("Failed to start listening on socket fd %d\n",
+			comm->fd);
 		unixcomm_close(comm);
 		return NULL;
 	}
@@ -214,12 +219,14 @@ unixcomm_accept(struct unixcomm *listener)
 
 	D_ALLOC_PTR(comm);
 	if (comm == NULL) {
+		D_ERROR("Failed to allocate new unixcomm\n");
 		return NULL;
 	}
 
 	comm->fd = accept(listener->fd, NULL, NULL);
 	if (comm->fd < 0) {
-		/* couldn't get a connection */
+		D_ERROR("Failed to accept connection on listener fd %d\n",
+			listener->fd);
 		D_FREE(comm);
 		return NULL;
 	}
@@ -234,10 +241,12 @@ unixcomm_close(struct unixcomm *handle)
 
 	if (!handle)
 		return 0;
+
 	ret = close(handle->fd);
 	D_FREE(handle);
 
 	if (ret < 0) {
+		D_ERROR("Failed to close socket fd %d\n", handle->fd);
 		return daos_errno2der(errno);
 	}
 
@@ -262,11 +271,11 @@ unixcomm_send(struct unixcomm *hndl, uint8_t *buffer, size_t buflen,
 
 	bsent = sendmsg(hndl->fd, &msg, 0);
 	if (bsent < 0) {
+		D_ERROR("Failed to sendmsg on socket fd %d\n", hndl->fd);
 		ret = daos_errno2der(errno);
 	} else {
-		if (sent != NULL) {
+		if (sent != NULL)
 			*sent = bsent;
-		}
 		ret = 0;
 	}
 	return ret;
@@ -290,11 +299,11 @@ unixcomm_recv(struct unixcomm *hndl, uint8_t *buffer, size_t buflen,
 
 	brcvd = recvmsg(hndl->fd, &msg, 0);
 	if (brcvd < 0) {
+		D_ERROR("Failed to recvmsg on socket fd %d\n", hndl->fd);
 		ret = daos_errno2der(errno);
 	} else {
-		if (rcvd != NULL) {
+		if (rcvd != NULL)
 			*rcvd = brcvd;
-		}
 		ret = 0;
 	}
 	return ret;
@@ -307,6 +316,7 @@ drpc_marshal_call(Drpc__Call *msg, uint8_t **bytes)
 	uint8_t	*buf;
 
 	if (!msg) {
+		D_ERROR("NULL Drpc__Call\n");
 		return -DER_INVAL;
 	}
 
@@ -314,6 +324,7 @@ drpc_marshal_call(Drpc__Call *msg, uint8_t **bytes)
 
 	D_ALLOC(buf, buf_len);
 	if (!buf) {
+		D_ERROR("Failed to allocate buffer of size %d\n", buf_len);
 		return -DER_NOMEM;
 	}
 
@@ -356,16 +367,14 @@ drpc_call(struct drpc *ctx, int flags, Drpc__Call *msg,
 
 	msg->sequence = ctx->sequence++;
 	pbLen = drpc_marshal_call(msg, &messagePb);
-	if (pbLen < 0) {
-		return -DER_NOMEM;
-	}
+	if (pbLen < 0)
+		return pbLen;
 
 	ret = unixcomm_send(ctx->comm, messagePb, pbLen, &sent);
 	D_FREE(messagePb);
 
-	if (ret < 0) {
+	if (ret < 0)
 		return ret;
-	}
 
 	if (!(flags & R_SYNC)) {
 		response = drpc_response_create(msg);
@@ -376,6 +385,7 @@ drpc_call(struct drpc *ctx, int flags, Drpc__Call *msg,
 
 	D_ALLOC(responseBuf, UNIXCOMM_MAXMSGSIZE);
 	if (!responseBuf) {
+		D_ERROR("Failed to allocate response buffer\n");
 		return -DER_NOMEM;
 	}
 
@@ -406,6 +416,7 @@ drpc_connect(char *sockaddr)
 
 	D_ALLOC_PTR(ctx);
 	if (!ctx) {
+		D_ERROR("Failed to allocate drpc context\n");
 		return NULL;
 	}
 
@@ -438,11 +449,14 @@ drpc_listen(char *sockaddr, drpc_handler_t handler)
 	struct drpc *ctx;
 
 	if (sockaddr == NULL || handler == NULL) {
+		D_ERROR("Bad input, sockaddr=%p, handler=%p\n",
+			sockaddr, handler);
 		return NULL;
 	}
 
 	D_ALLOC_PTR(ctx);
 	if (ctx == NULL) {
+		D_ERROR("Failed to allocate drpc context\n");
 		return NULL;
 	}
 
@@ -488,11 +502,13 @@ drpc_accept(struct drpc *listener_ctx)
 	struct drpc *session_ctx;
 
 	if (!drpc_is_valid_listener(listener_ctx)) {
+		D_ERROR("dRPC context is not a listener\n");
 		return NULL;
 	}
 
 	D_ALLOC_PTR(session_ctx);
 	if (session_ctx == NULL) {
+		D_ERROR("Failed to allocate a session context\n");
 		return NULL;
 	}
 
@@ -518,6 +534,7 @@ send_response(struct drpc *ctx, Drpc__Response *response)
 
 	D_ALLOC(buffer, buffer_len);
 	if (buffer == NULL) {
+		D_ERROR("Failed to allocate buffer of size %lu\n", buffer_len);
 		return -DER_NOMEM;
 	}
 
@@ -539,6 +556,7 @@ handle_incoming_message(struct drpc *ctx, Drpc__Response **response)
 
 	D_ALLOC(buffer, buffer_size);
 	if (buffer == NULL) {
+		D_ERROR("Failed to allocate buffer of size %lu\n", buffer_size);
 		return -DER_NOMEM;
 	}
 
@@ -553,7 +571,7 @@ handle_incoming_message(struct drpc *ctx, Drpc__Response **response)
 	D_FREE(buffer);
 	if (request == NULL) {
 		D_ERROR("Couldn't unpack message into Drpc__Call\n");
-		return -DER_MISC;
+		return -DER_PROTO;
 	}
 
 	*response = drpc_response_create(request);
@@ -579,7 +597,7 @@ handle_incoming_message(struct drpc *ctx, Drpc__Response **response)
  *		-DER_NOMEM	Out of memory
  *		-DER_AGAIN	Listener socket is nonblocking and there was no
  *					pending message on the pipe.
- *		-DER_MISC	Error processing message
+ *		-DER_PROTO	Error processing message
  */
 int
 drpc_recv(struct drpc *session_ctx)
@@ -588,13 +606,13 @@ drpc_recv(struct drpc *session_ctx)
 	Drpc__Response	*response;
 
 	if (!drpc_is_valid_listener(session_ctx)) {
+		D_ERROR("dRPC context isn't a valid listener\n");
 		return -DER_INVAL;
 	}
 
 	rc = handle_incoming_message(session_ctx, &response);
-	if (rc != DER_SUCCESS) {
+	if (rc != 0)
 		return rc;
-	}
 
 	rc = send_response(session_ctx, response);
 
@@ -615,6 +633,7 @@ drpc_close(struct drpc *ctx)
 	int ret;
 
 	if (!ctx || !ctx->comm) {
+		D_ERROR("Context is already closed\n");
 		return -DER_INVAL;
 	}
 

--- a/src/common/drpc.c
+++ b/src/common/drpc.c
@@ -199,8 +199,8 @@ unixcomm_listen(char *sockaddr, int flags)
 	fill_socket_address(sockaddr, &address);
 	if (bind(comm->fd, (struct sockaddr *)&address,
 		 sizeof(struct sockaddr_un)) < 0) {
-		D_ERROR("Failed to bind socket fd %d, errno=%d\n",
-			comm->fd, errno);
+		D_ERROR("Failed to bind socket at '%.4096s', fd=%d, errno=%d\n",
+			sockaddr, comm->fd, errno);
 		unixcomm_close(comm);
 		return NULL;
 	}

--- a/src/common/tests/drpc_tests.c
+++ b/src/common/tests/drpc_tests.c
@@ -568,7 +568,7 @@ test_drpc_recv_fails_if_incoming_call_malformed(void **state)
 	recvmsg_return = sizeof(recvmsg_msg_content);
 	memset(recvmsg_msg_content, 1, sizeof(recvmsg_msg_content));
 
-	assert_int_equal(drpc_recv(ctx), -DER_MISC);
+	assert_int_equal(drpc_recv(ctx), -DER_PROTO);
 
 	free_drpc(ctx);
 }

--- a/src/iosrv/drpc_internal.h
+++ b/src/iosrv/drpc_internal.h
@@ -66,8 +66,8 @@ struct drpc_list {
  *
  * \return	Newly allocated drpc_progress_context, or NULL if none created
  */
-struct drpc_progress_context *drpc_progress_context_create(
-		struct drpc *listener);
+struct drpc_progress_context *
+drpc_progress_context_create(struct drpc *listener);
 
 /**
  * Close all open drpc contexts in the drpc_progress_context, including the
@@ -90,7 +90,7 @@ void drpc_progress_context_close(struct drpc_progress_context *ctx);
  * \param[in]		timeout_ms	Timeout in milliseconds. Negative value
  *						blocks forever.
  *
- * \return	DER_SUCCESS		Successfully processed activity
+ * \return	0			Successfully processed activity
  *		-DER_INVAL		Invalid ctx
  *		-DER_TIMEDOUT		No activity
  *		-DER_AGAIN		Couldn't process activity, try again
@@ -102,8 +102,9 @@ int drpc_progress(struct drpc_progress_context *ctx, int timeout);
 /**
  * Start up the dRPC listener thread.
  *
- * \return	0	Success
- *		Error code if failed to start ULT
+ * \return	0		Success
+ *		-DER_NOMEM	Out of memory
+ *		-DER_INVAL	Invalid internal state
  */
 int drpc_listener_init(void);
 

--- a/src/iosrv/drpc_listener.c
+++ b/src/iosrv/drpc_listener.c
@@ -115,7 +115,7 @@ setup_listener_ctx(struct drpc_progress_context **new_ctx)
 	listener = drpc_listen(sockpath, drpc_hdlr_process_msg);
 	if (listener == NULL) {
 		D_ERROR("Failed to create listener socket at '%s'\n",
-				sockpath);
+			sockpath);
 		return -DER_UNKNOWN;
 	}
 
@@ -123,10 +123,10 @@ setup_listener_ctx(struct drpc_progress_context **new_ctx)
 	if (*new_ctx == NULL) {
 		D_ERROR("Failed to create drpc_progress_context\n");
 		drpc_close(listener);
-		return -DER_UNKNOWN;
+		return -DER_NOMEM;
 	}
 
-	return DER_SUCCESS;
+	return 0;
 }
 
 /*
@@ -153,7 +153,7 @@ drpc_listener_start_ult(ABT_thread *thread)
 		return rc;
 	}
 
-	return DER_SUCCESS;
+	return 0;
 }
 
 static int
@@ -168,7 +168,7 @@ generate_socket_path(void)
 		return -DER_NOMEM;
 	}
 
-	return DER_SUCCESS;
+	return 0;
 }
 
 int
@@ -177,9 +177,8 @@ drpc_listener_init(void)
 	int rc;
 
 	rc = generate_socket_path();
-	if (rc != DER_SUCCESS) {
+	if (rc != 0)
 		return rc;
-	}
 
 	memset(&status, 0, sizeof(status));
 	rc = ABT_mutex_create(&status.running_mutex);
@@ -207,7 +206,7 @@ drpc_listener_stop(void)
 		return dss_abterr2der(rc);
 	}
 
-	return DER_SUCCESS;
+	return 0;
 }
 
 int

--- a/src/iosrv/drpc_progress.c
+++ b/src/iosrv/drpc_progress.c
@@ -56,11 +56,13 @@ drpc_progress_context_create(struct drpc *listener)
 	struct drpc_progress_context *result;
 
 	if (!drpc_is_valid_listener(listener)) {
+		D_ERROR("Invalid dRPC listener\n");
 		return NULL;
 	}
 
 	D_ALLOC_PTR(result);
 	if (result == NULL) {
+		D_ERROR("Unable to allocate drpc_progress_context\n");
 		return NULL;
 	}
 
@@ -77,6 +79,7 @@ drpc_progress_context_close(struct drpc_progress_context *ctx)
 	struct drpc_list	*next;
 
 	if (ctx == NULL) {
+		D_ERROR("NULL drpc_progress_context passed\n");
 		return;
 	}
 
@@ -97,13 +100,12 @@ poll_events_to_unixcomm_activity(int event_bits)
 {
 	enum unixcomm_activity activity = UNIXCOMM_ACTIVITY_NONE;
 
-	if (event_bits & POLLHUP) {
+	if (event_bits & POLLHUP)
 		activity = UNIXCOMM_ACTIVITY_PEER_DISCONNECTED;
-	} else if (event_bits & POLLERR) {
+	else if (event_bits & POLLERR)
 		activity = UNIXCOMM_ACTIVITY_ERROR;
-	} else if (event_bits & POLLIN) {
+	else if (event_bits & POLLIN)
 		activity = UNIXCOMM_ACTIVITY_DATA_IN;
-	}
 
 	return activity;
 }
@@ -123,11 +125,11 @@ unixcomm_poll(struct unixcomm_poll *comms, size_t num_comms, int timeout_ms)
 	}
 
 	poll_rc = poll(fds, num_comms, timeout_ms);
-	if (poll_rc == 0) { /* timeout */
+	if (poll_rc == 0)
 		return -DER_TIMEDOUT;
-	}
 
-	if (poll_rc < 0) { /* failure */
+	if (poll_rc < 0) {
+		D_ERROR("Polling failed, errno=%u\n", errno);
 		return daos_errno2der(errno);
 	}
 
@@ -151,6 +153,8 @@ get_open_drpc_session_count(struct drpc_progress_context *ctx)
 
 	d_list_for_each_entry(current, &ctx->session_ctx_list, link) {
 		if (!drpc_is_valid_listener(current->ctx)) {
+			D_ERROR("drpc_progress_context session ctx is not a "
+				"valid listener\n");
 			return -DER_INVAL;
 		}
 
@@ -174,6 +178,7 @@ drpc_progress_context_to_unixcomms(struct drpc_progress_context *ctx,
 
 	num_comms = get_open_drpc_session_count(ctx);
 	if (num_comms < 0) {
+		D_ERROR("Failed to count open drpc sessions\n");
 		return num_comms;
 	}
 
@@ -182,6 +187,7 @@ drpc_progress_context_to_unixcomms(struct drpc_progress_context *ctx,
 
 	D_ALLOC_ARRAY(new_comms, num_comms);
 	if (new_comms == NULL) {
+		D_ERROR("Could not allocate unixcomm_poll structures\n");
 		return -DER_NOMEM;
 	}
 
@@ -215,11 +221,13 @@ drpc_progress_context_accept(struct drpc_progress_context *ctx)
 		/*
 		 * Any failure to accept is weird and surprising
 		 */
+		D_ERROR("Failed to accept new drpc connection\n");
 		return -DER_UNKNOWN;
 	}
 
 	D_ALLOC_PTR(session_node);
 	if (session_node == NULL) {
+		D_ERROR("Could not allocate new session node\n");
 		D_FREE(session);
 		return -DER_NOMEM;
 	}
@@ -234,7 +242,7 @@ static int
 process_listener_activity(struct drpc_progress_context *ctx,
 		struct unixcomm_poll *comms, size_t num_comms)
 {
-	int			rc = DER_SUCCESS;
+	int			rc = 0;
 	size_t			last_idx = num_comms - 1;
 	struct unixcomm_poll	*listener_comm = &(comms[last_idx]);
 	/* Last comm is the listener */
@@ -249,6 +257,8 @@ process_listener_activity(struct drpc_progress_context *ctx,
 	case UNIXCOMM_ACTIVITY_ERROR:
 	case UNIXCOMM_ACTIVITY_PEER_DISCONNECTED:
 		/* Unexpected - don't do anything */
+		D_INFO("Ignoring surprising listener activity: %u\n",
+		       listener_comm->activity);
 		rc = -DER_UNKNOWN;
 		break;
 
@@ -271,24 +281,27 @@ static int
 process_session_activity(struct drpc_list *session_node,
 		struct unixcomm_poll *session_comm)
 {
-	int rc = DER_SUCCESS;
+	int rc = 0;
 
 	D_ASSERT(session_comm->comm->fd == session_node->ctx->comm->fd);
 
 	switch (session_comm->activity) {
 	case UNIXCOMM_ACTIVITY_DATA_IN:
 		rc = drpc_recv(session_node->ctx);
-		if (rc != DER_SUCCESS && rc != -DER_AGAIN) {
+		if (rc != 0 && rc != -DER_AGAIN) {
+			D_ERROR("Error processing incoming session %u data\n",
+				session_comm->comm->fd);
 			destroy_session_node(session_node);
 
 			/* No further action needed */
-			rc = DER_SUCCESS;
+			rc = 0;
 		}
 		break;
 
 	case UNIXCOMM_ACTIVITY_ERROR:
 	case UNIXCOMM_ACTIVITY_PEER_DISCONNECTED:
-		/* connection is dead */
+		D_INFO("Session %u connection has been terminated\n",
+		       session_comm->comm->fd);
 		destroy_session_node(session_node);
 		break;
 
@@ -303,7 +316,7 @@ static int
 process_all_session_activities(struct drpc_progress_context *ctx,
 		struct unixcomm_poll *comms, size_t num_comms)
 {
-	int			rc = DER_SUCCESS;
+	int			rc = 0;
 	struct drpc_list	*current;
 	struct drpc_list	*next;
 	size_t			i = 0;
@@ -318,9 +331,8 @@ process_all_session_activities(struct drpc_progress_context *ctx,
 		 * Only overwrite with first error.
 		 * Keep trying other sessions.
 		 */
-		if (rc == DER_SUCCESS) {
+		if (rc == 0)
 			rc = session_rc;
-		}
 
 		i++;
 	}
@@ -338,10 +350,9 @@ process_activity(struct drpc_progress_context *ctx,
 	rc = process_all_session_activities(ctx, comms, num_comms);
 
 	listener_rc = process_listener_activity(ctx, comms, num_comms);
-	if (rc == DER_SUCCESS) {
-		/* Only overwrite if there wasn't a session error */
+	/* Only overwrite if there wasn't a previous session error */
+	if (rc == 0)
 		rc = listener_rc;
-	}
 
 	return rc;
 }
@@ -354,11 +365,14 @@ drpc_progress(struct drpc_progress_context *ctx, int timeout_ms)
 	int			rc;
 
 	if (!drpc_progress_context_is_valid(ctx)) {
+		D_ERROR("Invalid drpc_progress_context\n");
 		return -DER_INVAL;
 	}
 
 	rc = drpc_progress_context_to_unixcomms(ctx, &comms);
 	if (rc < 0) {
+		D_ERROR("Failed to convert drpc_progress_context to unixcomm "
+			"structures, rc=%d\n", rc);
 		return rc;
 	}
 

--- a/src/iosrv/tests/drpc_listener_tests.c
+++ b/src/iosrv/tests/drpc_listener_tests.c
@@ -228,7 +228,7 @@ test_drpc_listener_init_cant_create_prog_ctx(void **state)
 	/* drpc_progress_context_create returns null */
 	mock_drpc_progress_context_create_teardown();
 
-	assert_int_equal(drpc_listener_init(), -DER_UNKNOWN);
+	assert_int_equal(drpc_listener_init(), -DER_NOMEM);
 
 	/*
 	 * Listener should have been freed.


### PR DESCRIPTION
- Clean up dRPC code style.
- Add log messages for error cases to improve debugging
  ability.

Signed-off-by: Kris Jacque <kristin.jacque@intel.com>