### PR TITLE
DAOS-2929 drpc: Add API methods to call/respond

### DIFF
--- a/src/include/daos/drpc.h
+++ b/src/include/daos/drpc.h
@@ -76,6 +76,8 @@ struct drpc *drpc_listen(char *sockaddr, drpc_handler_t handler);
 bool drpc_is_valid_listener(struct drpc *ctx);
 struct drpc *drpc_accept(struct drpc *listener_ctx);
 int drpc_recv(struct drpc *ctx);
+int drpc_recv_call(struct drpc *ctx, Drpc__Call **call);
+int drpc_send_response(struct drpc *ctx, Drpc__Response *resp);
 int drpc_close(struct drpc *ctx);
 
 #endif /* __DAOS_DRPC_H__ */


### PR DESCRIPTION
- Add drpc_recv_call method to listen on a socket for
  an incoming Drpc__Call.
- Add drpc_send_response method to send a Drpc__Response
  over the socket.

Signed-off-by: Kris Jacque <kristin.jacque@intel.com>