### PR TITLE
DAOS-2676 test: skip rebuild test if pool create fails

### DIFF
--- a/src/include/daos_srv/pool.h
+++ b/src/include/daos_srv/pool.h
@@ -190,4 +190,7 @@ map_ranks_init(const struct pool_map *map, enum map_ranks_class class,
 
 void
 map_ranks_fini(d_rank_list_t *ranks);
+
+int ds_pool_get_ranks(const uuid_t pool_uuid, int status,
+		      d_rank_list_t *ranks);
 #endif /* __DAOS_SRV_POOL_H__ */

--- a/src/include/daos_srv/rsvc.h
+++ b/src/include/daos_srv/rsvc.h
@@ -142,7 +142,8 @@ int ds_rsvc_dist_start(enum ds_rsvc_class_id class, d_iov_t *id,
 		       const uuid_t dbid, const d_rank_list_t *ranks,
 		       bool create, bool bootstrap, size_t size);
 int ds_rsvc_dist_stop(enum ds_rsvc_class_id class, d_iov_t *id,
-		      const d_rank_list_t *ranks, bool destroy);
+		      const d_rank_list_t *ranks, d_rank_list_t *excluded,
+		      bool destroy);
 int ds_rsvc_add_replicas_s(struct ds_rsvc *svc, d_rank_list_t *ranks,
 			   size_t size);
 int ds_rsvc_add_replicas(enum ds_rsvc_class_id class, d_iov_t *id,

--- a/src/mgmt/srv_pool.c
+++ b/src/mgmt/srv_pool.c
@@ -32,7 +32,6 @@
 static int
 ds_mgmt_tgt_pool_destroy(uuid_t pool_uuid, crt_group_t *grp)
 {
-	struct ds_pool			*pool;
 	crt_rpc_t			*td_req;
 	struct mgmt_tgt_destroy_in	*td_in;
 	d_rank_list_t			excluded = { 0 };
@@ -41,21 +40,9 @@ ds_mgmt_tgt_pool_destroy(uuid_t pool_uuid, crt_group_t *grp)
 	int				topo;
 	int				rc;
 
-	pool = ds_pool_lookup(pool_uuid);
-	if (pool != NULL) {
-		/* This may not be the pool leader node, so down targets
-		 * may not be updated, then the following collective RPC
-		 * might be timeout. XXX
-		 */
-		ABT_rwlock_rdlock(pool->sp_lock);
-		rc = map_ranks_init(pool->sp_map, MAP_RANKS_DOWN, &excluded);
-		ABT_rwlock_unlock(pool->sp_lock);
-		if (rc != 0) {
-			D_ERROR(DF_UUID": failed to create rank list: %d\n",
-				DP_UUID(pool->sp_uuid), rc);
-			return rc;
-		}
-	}
+	rc = ds_pool_get_ranks(pool_uuid, MAP_RANKS_DOWN, &excluded);
+	if (rc)
+		return rc;
 
 	/* Collective RPC to destroy the pool on all of targets */
 	topo = crt_tree_topo(CRT_TREE_KNOMIAL, 4);
@@ -65,7 +52,7 @@ ds_mgmt_tgt_pool_destroy(uuid_t pool_uuid, crt_group_t *grp)
 				  &excluded, opc, NULL, NULL, 0, topo,
 				  &td_req);
 	if (rc)
-		return rc;
+		D_GOTO(fini_ranks, rc);
 
 	td_in = crt_req_get(td_req);
 	D_ASSERT(td_in != NULL);
@@ -82,8 +69,9 @@ ds_mgmt_tgt_pool_destroy(uuid_t pool_uuid, crt_group_t *grp)
 			DP_UUID(pool_uuid), rc);
 out_rpc:
 	crt_req_decref(td_req);
-	map_ranks_fini(&excluded);
 
+fini_ranks:
+	map_ranks_fini(&excluded);
 	return rc;
 }
 

--- a/src/rdb/tests/rdb_test.c
+++ b/src/rdb/tests/rdb_test.c
@@ -460,7 +460,8 @@ rdbt_fini_handler(crt_rpc_t *rpc)
 	MUST(ds_rsvc_lookup(DS_RSVC_CLASS_TEST, &test_svc_id, &svc));
 	MUST(rdb_get_ranks(svc->s_db, &ranks));
 	ds_rsvc_put(svc);
-	MUST(ds_rsvc_dist_stop(DS_RSVC_CLASS_TEST, &test_svc_id, ranks, true));
+	MUST(ds_rsvc_dist_stop(DS_RSVC_CLASS_TEST, &test_svc_id, ranks, NULL,
+			       true));
 	crt_reply_send(rpc);
 }
 

--- a/src/rsvc/srv.c
+++ b/src/rsvc/srv.c
@@ -828,7 +828,7 @@ out_stop:
 	if (ranks->rl_nr > 0) {
 		D_ASSERT(rc != 0);
 		ds_rsvc_dist_stop(svc->s_class, &svc->s_id, ranks,
-				  true /* destroy */);
+				  NULL, true /* destroy */);
 	}
 	return rc;
 }
@@ -864,7 +864,7 @@ ds_rsvc_remove_replicas_s(struct ds_rsvc *svc, d_rank_list_t *ranks)
 	daos_rank_list_filter(ranks, stop_ranks, true /* exclude */);
 	if (stop_ranks->rl_nr > 0)
 		ds_rsvc_dist_stop(svc->s_class, &svc->s_id, stop_ranks,
-				  true /* destroy */);
+				  NULL, true /* destroy */);
 	d_rank_list_free(stop_ranks);
 	return rc;
 }
@@ -897,14 +897,15 @@ enum rdb_stop_flag {
 };
 
 static int
-bcast_create(crt_opcode_t opc, crt_group_t *group, crt_rpc_t **rpc)
+bcast_create(crt_opcode_t opc, crt_group_t *group, d_rank_list_t *excluded,
+	     crt_rpc_t **rpc)
 {
 	struct dss_module_info *info = dss_get_module_info();
 	crt_opcode_t		opc_full;
 
 	opc_full = DAOS_RPC_OPCODE(opc, DAOS_RSVC_MODULE, DAOS_RSVC_VERSION);
 	return crt_corpc_req_create(info->dmi_ctx, group,
-				    NULL /* excluded_ranks */, opc_full,
+				    excluded /* excluded_ranks */, opc_full,
 				    NULL /* co_bulk_hdl */, NULL /* priv */,
 				    0 /* flags */,
 				    crt_tree_topo(CRT_TREE_FLAT, 0), rpc);
@@ -941,7 +942,7 @@ ds_rsvc_dist_start(enum ds_rsvc_class_id class, d_iov_t *id,
 	 * If ranks doesn't include myself, creating a group with ranks will
 	 * fail; bcast to the primary group instead.
 	 */
-	rc = bcast_create(RSVC_START, NULL /* group */, &rpc);
+	rc = bcast_create(RSVC_START, NULL /* group */, NULL, &rpc);
 	if (rc != 0)
 		goto out;
 	in = crt_req_get(rpc);
@@ -966,7 +967,7 @@ ds_rsvc_dist_start(enum ds_rsvc_class_id class, d_iov_t *id,
 	if (rc != 0) {
 		D_ERROR(DF_UUID": failed to start%s %d replicas\n",
 			DP_UUID(dbid), create ? "/create" : "", rc);
-		ds_rsvc_dist_stop(class, id, ranks, create);
+		ds_rsvc_dist_stop(class, id, ranks, NULL, create);
 		rc = -DER_IO;
 	}
 
@@ -1028,14 +1029,21 @@ ds_rsvc_start_aggregator(crt_rpc_t *source, crt_rpc_t *result, void *priv)
  * all replicas of a database spanning \a ranks. This method can be called on
  * any rank. \a ranks may be NULL.
  *
+ * XXX excluded and ranks are a bit duplicate here, since this function only
+ * suppose to send RPC to @ranks list, but cart does not have such interface
+ * for collective RPC, so we have to use both ranks and exclued for the moment,
+ * and it should be simplied once cart can provide rank list collective RPC.
+ *
  * \param[in]	class		replicated service class
  * \param[in]	id		replicated service ID
  * \param[in]	ranks		list of \a ranks->rl_nr replica ranks
+ * \param[in]	excluded	excluded rank list.
  * \param[in]	destroy		destroy after close
  */
 int
 ds_rsvc_dist_stop(enum ds_rsvc_class_id class, d_iov_t *id,
-		  const d_rank_list_t *ranks, bool destroy)
+		  const d_rank_list_t *ranks, d_rank_list_t *excluded,
+		  bool destroy)
 {
 	crt_rpc_t		*rpc;
 	struct rsvc_stop_in	*in;
@@ -1046,7 +1054,7 @@ ds_rsvc_dist_stop(enum ds_rsvc_class_id class, d_iov_t *id,
 	 * If ranks doesn't include myself, creating a group with ranks will
 	 * fail; bcast to the primary group instead.
 	 */
-	rc = bcast_create(RSVC_STOP, NULL /* group */, &rpc);
+	rc = bcast_create(RSVC_STOP, NULL /* group */,  excluded, &rpc);
 	if (rc != 0)
 		goto out;
 	in = crt_req_get(rpc);


### PR DESCRIPTION
Skip rebuild test if pool create fails due to
rank failure.

Signed-off-by: Wang Di <di.wang@intel.com>