### PR TITLE
DAOS-2561 control: Run all go tests in CI

### DIFF
--- a/src/control/logging/syslog_test.go
+++ b/src/control/logging/syslog_test.go
@@ -84,8 +84,6 @@ func TestSyslogOutput(t *testing.T) {
 	}
 
 	jrnlOut := func(t *testing.T, prio int) string {
-		t.Helper()
-
 		time.Sleep(10 * time.Millisecond) // Give it time to settle
 		cmd := exec.Command(journalctl,
 			fmt.Sprintf("_PID=%d", os.Getpid()),
@@ -93,7 +91,11 @@ func TestSyslogOutput(t *testing.T) {
 		)
 		out, err := cmd.Output()
 		if err != nil {
-			t.Fatal(err)
+			var stderr string
+			if ee, ok := err.(*exec.ExitError); ok {
+				stderr = string(ee.Stderr)
+			}
+			t.Fatalf("error: %s\nSTDOUT: %s\nSTDERR: %s", err, out, stderr)
 		}
 		return string(out)
 	}

--- a/src/control/security/auth/auth_sys_test.go
+++ b/src/control/security/auth/auth_sys_test.go
@@ -21,7 +21,7 @@
 // portions thereof marked with this legend must also reproduce the markings.
 //
 
-package auth
+package auth_test
 
 import (
 	"errors"
@@ -33,6 +33,8 @@ import (
 	"github.com/golang/protobuf/proto"
 
 	. "github.com/daos-stack/daos/src/control/common"
+	"github.com/daos-stack/daos/src/control/security"
+	"github.com/daos-stack/daos/src/control/security/auth"
 )
 
 // Mocks
@@ -53,7 +55,7 @@ func (u *mockUser) GroupIDs() ([]uint32, error) {
 
 type mockExt struct {
 	lookupUserIDUid        uint32
-	lookupUserIDResult     User
+	lookupUserIDResult     auth.User
 	lookupUserIDErr        error
 	lookupGroupIDGid       uint32
 	lookupGroupIDResults   []*user.Group
@@ -61,7 +63,7 @@ type mockExt struct {
 	lookupGroupIDErr       error
 }
 
-func (e *mockExt) LookupUserID(uid uint32) (User, error) {
+func (e *mockExt) LookupUserID(uid uint32) (auth.User, error) {
 	e.lookupUserIDUid = uid
 	return e.lookupUserIDResult, e.lookupUserIDErr
 }
@@ -78,8 +80,9 @@ func (e *mockExt) LookupGroupID(gid uint32) (*user.Group, error) {
 
 // Helpers for the unit tests below
 
-func expectAuthSysErrorForToken(t *testing.T, badToken *Token, expectedErrorMessage string) {
-	authSys, err := AuthSysFromAuthToken(badToken)
+func expectAuthSysErrorForToken(t *testing.T, badToken *auth.Token, expectedErrorMessage string) {
+	t.Helper()
+	authSys, err := auth.AuthSysFromAuthToken(badToken)
 
 	if authSys != nil {
 		t.Error("Expected a nil AuthSys")
@@ -95,21 +98,21 @@ func TestAuthSysFromAuthToken_ErrorsWithNilAuthToken(t *testing.T) {
 }
 
 func TestAuthSysFromAuthToken_ErrorsWithWrongAuthTokenFlavor(t *testing.T) {
-	badFlavorToken := Token{Flavor: Flavor_AUTH_NONE}
+	badFlavorToken := auth.Token{Flavor: auth.Flavor_AUTH_NONE}
 	expectAuthSysErrorForToken(t, &badFlavorToken,
 		"Attempting to convert an invalid AuthSys Token")
 }
 
 func TestAuthSysFromAuthToken_ErrorsIfTokenCannotBeUnmarshaled(t *testing.T) {
 	zeroArray := make([]byte, 16)
-	badToken := Token{Flavor: Flavor_AUTH_SYS,
+	badToken := auth.Token{Flavor: auth.Flavor_AUTH_SYS,
 		Data: zeroArray}
 	expectAuthSysErrorForToken(t, &badToken,
-		"unmarshaling AUTH_SYS: proto: Sys: illegal tag 0 (wire type 0)")
+		"unmarshaling AUTH_SYS: proto: auth.Sys: illegal tag 0 (wire type 0)")
 }
 
 func TestAuthSysFromAuthToken_SucceedsWithGoodToken(t *testing.T) {
-	originalAuthSys := Sys{
+	originalAuthSys := auth.Sys{
 		Stamp:       0,
 		Machinename: "something",
 		User:        "niceuser",
@@ -123,12 +126,12 @@ func TestAuthSysFromAuthToken_SucceedsWithGoodToken(t *testing.T) {
 		t.Fatalf("Couldn't marshal during setup: %s", err)
 	}
 
-	goodToken := Token{
-		Flavor: Flavor_AUTH_SYS,
+	goodToken := auth.Token{
+		Flavor: auth.Flavor_AUTH_SYS,
 		Data:   marshaledToken,
 	}
 
-	authSys, err := AuthSysFromAuthToken(&goodToken)
+	authSys, err := auth.AuthSysFromAuthToken(&goodToken)
 
 	if err != nil {
 		t.Fatalf("Expected no error, got: %s", err)
@@ -155,7 +158,7 @@ func TestAuthSysFromAuthToken_SucceedsWithGoodToken(t *testing.T) {
 // AuthSysRequestFromCreds tests
 
 func TestAuthSysRequestFromCreds_failsIfDomainInfoNil(t *testing.T) {
-	result, err := AuthSysRequestFromCreds(&mockExt{}, nil)
+	result, err := auth.AuthSysRequestFromCreds(&mockExt{}, nil, nil)
 
 	if result != nil {
 		t.Error("Expected a nil request")
@@ -164,13 +167,12 @@ func TestAuthSysRequestFromCreds_failsIfDomainInfoNil(t *testing.T) {
 	ExpectError(t, err, "No credentials supplied", "")
 }
 
-func getTestCreds(uid uint32, gid uint32) *DomainInfo {
-	return &DomainInfo{
-		creds: &syscall.Ucred{
-			Uid: uid,
-			Gid: gid,
-		},
+func getTestCreds(uid uint32, gid uint32) *security.DomainInfo {
+	creds := &syscall.Ucred{
+		Uid: uid,
+		Gid: gid,
 	}
+	return security.InitDomainInfo(creds, "test")
 }
 
 func TestAuthSysRequestFromCreds_returnsAuthSys(t *testing.T) {
@@ -200,7 +202,7 @@ func TestAuthSysRequestFromCreds_returnsAuthSys(t *testing.T) {
 			})
 	}
 
-	result, err := AuthSysRequestFromCreds(ext, creds)
+	result, err := auth.AuthSysRequestFromCreds(ext, creds, nil)
 
 	if err != nil {
 		t.Errorf("Unexpected error: %v", err)
@@ -215,11 +217,11 @@ func TestAuthSysRequestFromCreds_returnsAuthSys(t *testing.T) {
 		t.Fatal("Token was nil")
 	}
 
-	if token.GetFlavor() != Flavor_AUTH_SYS {
+	if token.GetFlavor() != auth.Flavor_AUTH_SYS {
 		t.Fatalf("Bad auth flavor: %v", token.GetFlavor())
 	}
 
-	authsys := &Sys{}
+	authsys := &auth.Sys{}
 	err = proto.Unmarshal(token.GetData(), authsys)
 	if err != nil {
 		t.Fatal("Failed to unmarshal token data")
@@ -249,7 +251,7 @@ func TestAuthSysRequestFromCreds_UidLookupFails(t *testing.T) {
 	expectedErr := fmt.Errorf("Failed to lookup uid %v: %v", uid,
 		ext.lookupUserIDErr)
 
-	result, err := AuthSysRequestFromCreds(ext, creds)
+	result, err := auth.AuthSysRequestFromCreds(ext, creds, nil)
 
 	if result != nil {
 		t.Error("Expected a nil result")
@@ -278,7 +280,7 @@ func TestAuthSysRequestFromCreds_GidLookupFails(t *testing.T) {
 	expectedErr := fmt.Errorf("Failed to lookup gid %v: %v", gid,
 		ext.lookupGroupIDErr)
 
-	result, err := AuthSysRequestFromCreds(ext, creds)
+	result, err := auth.AuthSysRequestFromCreds(ext, creds, nil)
 
 	if result != nil {
 		t.Error("Expected a nil result")
@@ -314,7 +316,7 @@ func TestAuthSysRequestFromCreds_GroupIDListFails(t *testing.T) {
 		testUser.username,
 		testUser.groupIDErr)
 
-	result, err := AuthSysRequestFromCreds(ext, creds)
+	result, err := auth.AuthSysRequestFromCreds(ext, creds, nil)
 
 	if result != nil {
 		t.Error("Expected a nil result")


### PR DESCRIPTION
The current method of running these tests in CI uses a
helper script which sets up $GOPATH, etc. This script
should run all go tests, not just a subset defined in
a static list.

Also fixes up some broken security tests which weren't
being run.