### PR TITLE
DAOS-3100 vos: Fix an issue with punch

### DIFF
--- a/src/vos/vos_iterator.c
+++ b/src/vos/vos_iterator.c
@@ -598,7 +598,8 @@ probe:
 			goto probe;
 		}
 
-		if (recursive && !is_last_level(type) && !skipped) {
+		if (recursive && !is_last_level(type) && !skipped &&
+		    iter_ent.ie_child_type != VOS_ITER_NONE) {
 			vos_iter_param_t	child_param = *param;
 
 			child_param.ip_ih = ih;

--- a/src/vos/vos_obj.c
+++ b/src/vos/vos_obj.c
@@ -233,9 +233,10 @@ key_iter_fetch(struct vos_obj_iter *oiter, vos_iter_entry_t *ent,
 		if (oiter->it_iter.it_type == VOS_ITER_AKEY) {
 			if (rbund.rb_krec->kr_bmap & KREC_BF_EVT) {
 				ent->ie_child_type = VOS_ITER_RECX;
-			} else {
-				D_ASSERT(rbund.rb_krec->kr_bmap & KREC_BF_BTR);
+			} else if (rbund.rb_krec->kr_bmap & KREC_BF_BTR) {
 				ent->ie_child_type = VOS_ITER_SINGLE;
+			} else {
+				ent->ie_child_type = VOS_ITER_NONE;
 			}
 		} else {
 			ent->ie_child_type = VOS_ITER_AKEY;


### PR DESCRIPTION
If a key is punched but never updated, KREC_BF_BTR/EVT will
not be set.  Rather than asserting, return with ITER_NONE
so vos_iterate will not recurse.

Signed-off-by: Jeff Olivier <jeffrey.v.olivier@intel.com>