### PR TITLE
DAOS-2954 bio: multiple io channel per VOS target

### DIFF
--- a/src/bio/bio_internal.h
+++ b/src/bio/bio_internal.h
@@ -134,7 +134,41 @@ struct bio_xs_context {
 	d_list_t		 bxc_io_ctxts;
 	struct spdk_bdev_desc	*bxc_desc; /* for io stat only, read-only */
 	uint64_t		 bxc_io_stat_age;
+	bool			 bxc_auxi;
 };
+
+struct bio_io_channel {
+	int			 bic_cnt;
+	struct spdk_io_channel	*bic_channels[2];
+};
+
+extern struct bio_io_channel	channel_table[BIO_XS_CNT_MAX];
+
+static inline void
+bio_set_io_channel(struct bio_xs_context *ctxt, int tgt_id)
+{
+	struct bio_io_channel	*channel = &channel_table[tgt_id];
+
+	D_ASSERTF(channel->bic_cnt >= 0 && channel->bic_cnt < 2,
+		  "channel count: %d", channel->bic_cnt);
+	channel->bic_channels[channel->bic_cnt] = ctxt->bxc_io_channel;
+	ctxt->bxc_auxi = (channel->bic_cnt > 0);
+	channel->bic_cnt++;
+}
+
+static inline struct spdk_io_channel *
+bio_get_io_channel(int tgt_id)
+{
+	struct bio_io_channel	*channel = &channel_table[tgt_id];
+
+	if (channel->bic_cnt == 1)
+		return channel->bic_channels[0];
+	else if (channel->bic_cnt == 2)
+		return channel->bic_channels[1];
+
+	D_ASSERTF(0, "Invalid channel count %d\n", channel->bic_cnt);
+	return NULL;
+}
 
 /* Per VOS instance I/O context */
 struct bio_io_context {
@@ -182,8 +216,12 @@ struct bio_desc {
 	struct bio_io_context	*bd_ctxt;
 	/* DMA buffers reserved by this io descriptor */
 	struct bio_rsrvd_dma	 bd_rsrvd;
-	/* Report blob i/o completion */
-	ABT_eventual		 bd_dma_done;
+	/*
+	 * SPDK blob io completion could run on different xstream
+	 * when NVMe poll is on helper xstream.
+	 */
+	ABT_mutex		 bd_mutex;
+	ABT_cond		 bd_dma_done;
 	/* Inflight SPDK DMA transfers */
 	unsigned int		 bd_inflights;
 	int			 bd_result;

--- a/src/bio/bio_monitor.c
+++ b/src/bio/bio_monitor.c
@@ -427,12 +427,14 @@ bio_xs_io_stat(struct bio_xs_context *ctxt, uint64_t now)
 
 		D_ASSERT(bdev != NULL);
 
-		D_PRINT("SPDK IO STAT: tgt[%d] dev[%s] read_bytes["DF_U64"], "
-			"read_ops["DF_U64"], write_bytes["DF_U64"], "
-			"write_ops["DF_U64"], read_latency_ticks["DF_U64"], "
+		D_PRINT("SPDK IO STAT: tgt_id[%d] auxi[%d] dev[%s] "
+			"read_bytes["DF_U64"], read_ops["DF_U64"], "
+			"write_bytes["DF_U64"], write_ops["DF_U64"], "
+			"read_latency_ticks["DF_U64"], "
 			"write_latency_ticks["DF_U64"]\n",
-			ctxt->bxc_tgt_id, spdk_bdev_get_name(bdev),
-			stat.bytes_read, stat.num_read_ops, stat.bytes_written,
+			ctxt->bxc_tgt_id, ctxt->bxc_auxi,
+			spdk_bdev_get_name(bdev), stat.bytes_read,
+			stat.num_read_ops, stat.bytes_written,
 			stat.num_write_ops, stat.read_latency_ticks,
 			stat.write_latency_ticks);
 	}

--- a/src/bio/bio_xstream.c
+++ b/src/bio/bio_xstream.c
@@ -51,6 +51,8 @@ void spdk_set_thread(struct spdk_thread *thread);
 #define DAOS_DMA_CHUNK_CNT_INIT	2		/* Per-xstream init chunks */
 #define DAOS_DMA_CHUNK_CNT_MAX	32		/* Per-xstream max chunks */
 
+struct bio_io_channel	channel_table[BIO_XS_CNT_MAX];
+
 /* Chunk size of DMA buffer in pages */
 unsigned int bio_chk_sz;
 /* Per-xstream maximum DMA buffer size (in chunk count) */
@@ -764,6 +766,7 @@ init_blobstore_ctxt(struct bio_xs_context *ctxt, int tgt_id)
 		D_ERROR("Failed to create io channel\n");
 		return -DER_NOMEM;
 	}
+	bio_set_io_channel(ctxt, tgt_id);
 
 	return 0;
 }

--- a/src/iosrv/sched.c
+++ b/src/iosrv/sched.c
@@ -249,8 +249,7 @@ sched_pop_nvme_poll(struct sched_data *data, ABT_pool pool)
 	if (cycle->sc_ults_tot == 0)
 		cycle->sc_cycle_started = 0;
 
-	/* Only main xstream (VOS xstream) has NVMe poll ULT */
-	if (!dx->dx_main_xs)
+	if (!dx->dx_nvme)
 		return ABT_UNIT_NULL;
 
 	ret = ABT_pool_pop(pool, &unit);

--- a/src/iosrv/srv_internal.h
+++ b/src/iosrv/srv_internal.h
@@ -68,6 +68,7 @@ struct dss_xstream {
 	int			dx_ctx_id;
 	bool			dx_main_xs;	/* true for main XS */
 	bool			dx_comm;	/* true with cart context */
+	bool			dx_nvme;	/* true with NVMe context */
 	bool			dx_dsc_started;	/* DSC progress ULT started */
 };
 


### PR DESCRIPTION
Use the first helper xstream to submit/poll NVMe I/O to see if
it can improve performance.

Signed-off-by: Niu Yawei <yawei.niu@intel.com>
Change-Id: Idbe8dfc0497090ba7fba46c1da181ae2b720114e