### PR TITLE
DAOS-3101 dtx: sync object

### DIFF
--- a/src/client/api/init.c
+++ b/src/client/api/init.c
@@ -44,6 +44,7 @@ static pthread_mutex_t	module_lock = PTHREAD_MUTEX_INITIALIZER;
 static bool		module_initialized;
 
 const struct daos_task_api dc_funcs[] = {
+	/** Managment */
 	{dc_mgmt_svc_rip, sizeof(daos_svc_rip_t)},
 	{dc_pool_create, sizeof(daos_pool_create_t)},
 	{dc_pool_destroy, sizeof(daos_pool_destroy_t)},
@@ -52,6 +53,8 @@ const struct daos_task_api dc_funcs[] = {
 	{dc_mgmt_set_params, sizeof(daos_set_params_t)},
 	{dc_pool_add_replicas, sizeof(daos_pool_replicas_t)},
 	{dc_pool_remove_replicas, sizeof(daos_pool_replicas_t)},
+
+	/** Pool */
 	{dc_pool_connect, sizeof(daos_pool_connect_t)},
 	{dc_pool_disconnect, sizeof(daos_pool_disconnect_t)},
 	{dc_pool_exclude, sizeof(daos_pool_update_t)},
@@ -63,6 +66,8 @@ const struct daos_task_api dc_funcs[] = {
 	{dc_pool_get_attr, sizeof(daos_pool_get_attr_t)},
 	{dc_pool_set_attr, sizeof(daos_pool_set_attr_t)},
 	{dc_pool_stop_svc, sizeof(daos_pool_stop_svc_t)},
+
+	/** Container */
 	{dc_cont_create, sizeof(daos_cont_create_t)},
 	{dc_cont_open, sizeof(daos_cont_open_t)},
 	{dc_cont_close, sizeof(daos_cont_close_t)},
@@ -78,11 +83,15 @@ const struct daos_task_api dc_funcs[] = {
 	{dc_cont_list_snap, sizeof(daos_cont_list_snap_t)},
 	{dc_cont_create_snap, sizeof(daos_cont_create_snap_t)},
 	{dc_cont_destroy_snap, sizeof(daos_cont_destroy_snap_t)},
+
+	/** Transaction */
 	{dc_tx_open, sizeof(daos_tx_open_t)},
 	{dc_tx_commit, sizeof(daos_tx_commit_t)},
 	{dc_tx_abort, sizeof(daos_tx_abort_t)},
 	{dc_tx_open_snap, sizeof(daos_tx_open_snap_t)},
 	{dc_tx_close, sizeof(daos_tx_close_t)},
+
+	/** Object */
 	{dc_obj_register_class, sizeof(daos_obj_register_class_t)},
 	{dc_obj_query_class, sizeof(daos_obj_query_class_t)},
 	{dc_obj_list_class, sizeof(daos_obj_list_class_t)},
@@ -93,19 +102,27 @@ const struct daos_task_api dc_funcs[] = {
 	{dc_obj_punch_akeys, sizeof(daos_obj_punch_t)},
 	{dc_obj_query, sizeof(daos_obj_query_t)},
 	{dc_obj_query_key, sizeof(daos_obj_query_key_t)},
+	{dc_obj_sync, sizeof(struct daos_obj_sync_args)},
 	{dc_obj_fetch_shard, sizeof(struct daos_obj_fetch_shard)},
 	{dc_obj_fetch, sizeof(daos_obj_fetch_t)},
 	{dc_obj_update, sizeof(daos_obj_update_t)},
 	{dc_obj_list_dkey, sizeof(daos_obj_list_dkey_t)},
 	{dc_obj_list_akey, sizeof(daos_obj_list_akey_t)},
 	{dc_obj_list_rec, sizeof(daos_obj_list_recx_t)},
+	{dc_obj_list_obj, sizeof(daos_obj_list_obj_t)},
+
+	/** Array */
 	{dc_array_create, sizeof(daos_array_create_t)},
 	{dc_array_open, sizeof(daos_array_open_t)},
 	{dc_array_close, sizeof(daos_array_close_t)},
+	{dc_array_destroy, sizeof(daos_array_destroy_t)},
 	{dc_array_read, sizeof(daos_array_io_t)},
 	{dc_array_write, sizeof(daos_array_io_t)},
+	{dc_array_punch, sizeof(daos_array_io_t)},
 	{dc_array_get_size, sizeof(daos_array_get_size_t)},
 	{dc_array_set_size, sizeof(daos_array_set_size_t)},
+
+	/** HL */
 	{dc_kv_get, sizeof(daos_kv_get_t)},
 	{dc_kv_put, sizeof(daos_kv_put_t)},
 	{dc_kv_remove, sizeof(daos_kv_remove_t)},

--- a/src/client/api/task_internal.h
+++ b/src/client/api/task_internal.h
@@ -36,6 +36,7 @@ struct daos_task_args {
 	uint32_t			ta_magic;
 	uint32_t			ta_opc;
 	union {
+		/** Managment */
 		daos_svc_rip_t		svc_rip;
 		daos_pool_create_t	pool_create;
 		daos_pool_destroy_t	pool_destroy;
@@ -44,11 +45,19 @@ struct daos_task_args {
 		daos_set_params_t	mgmt_set_params;
 		daos_pool_replicas_t	pool_add_replicas;
 		daos_pool_replicas_t	pool_remove_replicas;
+
+		/** Pool */
 		daos_pool_connect_t	pool_connect;
 		daos_pool_disconnect_t	pool_disconnect;
 		daos_pool_update_t	pool_update;
 		daos_pool_query_t	pool_query;
 		daos_pool_query_target_t pool_query_tgt;
+		daos_pool_list_attr_t	pool_list_attr;
+		daos_pool_get_attr_t	pool_get_attr;
+		daos_pool_set_attr_t	pool_set_attr;
+		daos_pool_stop_svc_t	pool_stop_svc;
+
+		/** Container */
 		daos_cont_create_t	cont_create;
 		daos_cont_open_t	cont_open;
 		daos_cont_close_t	cont_close;
@@ -64,10 +73,14 @@ struct daos_task_args {
 		daos_cont_list_snap_t	cont_list_snap;
 		daos_cont_create_snap_t	cont_create_snap;
 		daos_cont_destroy_snap_t cont_destroy_snap;
+
+		/** Transaction */
 		daos_tx_open_t		tx_open;
 		daos_tx_commit_t	tx_commit;
 		daos_tx_abort_t		tx_abort;
 		daos_tx_close_t		tx_close;
+
+		/** Object */
 		daos_obj_register_class_t obj_reg_class;
 		daos_obj_query_class_t	obj_query_class;
 		daos_obj_list_class_t	obj_list_class;
@@ -76,13 +89,16 @@ struct daos_task_args {
 		daos_obj_punch_t	obj_punch;
 		daos_obj_query_t	obj_query;
 		daos_obj_query_key_t	obj_query_key;
-		struct daos_obj_fetch_shard	obj_fetch_shard;
+		struct daos_obj_sync_args obj_sync;
+		struct daos_obj_fetch_shard obj_fetch_shard;
 		daos_obj_fetch_t	obj_fetch;
 		daos_obj_update_t	obj_update;
 		daos_obj_list_dkey_t	obj_list_dkey;
 		daos_obj_list_akey_t	obj_list_akey;
 		daos_obj_list_recx_t	obj_list_recx;
 		daos_obj_list_obj_t	obj_list_obj;
+
+		/** Array */
 		daos_array_create_t	array_create;
 		daos_array_open_t	array_open;
 		daos_array_close_t	array_close;
@@ -90,6 +106,8 @@ struct daos_task_args {
 		daos_array_io_t		array_io;
 		daos_array_get_size_t	array_get_size;
 		daos_array_set_size_t	array_set_size;
+
+		/** HL */
 		daos_kv_get_t		kv_get;
 		daos_kv_put_t		kv_put;
 		daos_kv_remove_t	kv_remove;

--- a/src/dtx/dtx_common.c
+++ b/src/dtx/dtx_common.c
@@ -88,7 +88,8 @@ dtx_flush_committable(struct dss_module_info *dmi,
 		struct dtx_entry	*dtes = NULL;
 
 		rc = vos_dtx_fetch_committable(cont->sc_hdl,
-					       DTX_THRESHOLD_COUNT, &dtes);
+					       DTX_THRESHOLD_COUNT, NULL,
+					       DAOS_EPOCH_MAX, &dtes);
 		if (rc <= 0)
 			break;
 
@@ -150,7 +151,8 @@ dtx_batched_commit(void *arg)
 		     dtx_hlc_age2sec(stat.dtx_oldest_committable_time) >
 		     DTX_COMMIT_THRESHOLD_AGE)) {
 			rc = vos_dtx_fetch_committable(cont->sc_hdl,
-						DTX_THRESHOLD_COUNT, &dtes);
+						DTX_THRESHOLD_COUNT, NULL,
+						DAOS_EPOCH_MAX, &dtes);
 			if (rc > 0) {
 				rc = dtx_commit(dbca->dbca_pool->spc_uuid,
 					cont->sc_uuid, dtes, rc,
@@ -628,13 +630,21 @@ dtx_leader_end(struct dtx_leader_handle *dlh, struct ds_cont_hdl *cont_hdl,
 	}
 
 	rc = vos_dtx_add_cos(dth->dth_coh, &dth->dth_oid, &dth->dth_xid,
-			     dth->dth_dkey_hash, dlh->dlh_handled_time,
+			     dth->dth_dkey_hash, dth->dth_epoch,
 			     dth->dth_intent == DAOS_INTENT_PUNCH ?
-			     true : false);
+			     true : false, true);
+	if (rc == -DER_INPROGRESS) {
+		D_WARN(DF_UUID": Fail to add DTX "DF_DTI" to CoS "
+		       "because of using old epoch "DF_U64"\n",
+		       DP_UUID(cont->sc_uuid), DP_DTI(&dth->dth_xid),
+		       dth->dth_epoch);
+		D_GOTO(fail, result = rc);
+	}
+
 	if (rc != 0) {
-		D_ERROR(DF_UUID": Fail to add DTX "DF_DTI" to CoS cache: %d. "
-			"Try to commit it sychronously.\n",
-			DP_UUID(cont->sc_uuid), DP_DTI(&dth->dth_xid), rc);
+		D_WARN(DF_UUID": Fail to add DTX "DF_DTI" to CoS cache: %d. "
+		       "Try to commit it sychronously.\n",
+		       DP_UUID(cont->sc_uuid), DP_DTI(&dth->dth_xid), rc);
 		dth->dth_sync = 1;
 	}
 
@@ -1035,5 +1045,40 @@ exec:
 	/* Then execute the local operation */
 	rc = func(dlh, func_arg, -1, NULL);
 out:
+	return rc;
+}
+
+int
+dtx_obj_sync(uuid_t po_uuid, uuid_t co_uuid, daos_handle_t coh,
+	     daos_unit_oid_t oid, daos_epoch_t epoch, uint32_t map_ver)
+{
+	int	rc = 0;
+
+	while (1) {
+		struct dtx_entry	*dtes = NULL;
+
+		rc = vos_dtx_fetch_committable(coh, DTX_THRESHOLD_COUNT, &oid,
+					       epoch, &dtes);
+		if (rc < 0) {
+			D_ERROR(DF_UOID" fail to fetch dtx: rc = %d\n",
+				DP_UOID(oid), rc);
+			break;
+		}
+
+		if (rc == 0)
+			break;
+
+		rc = dtx_commit(po_uuid, co_uuid, dtes, rc, map_ver);
+		dtx_free_committable(dtes);
+		if (rc < 0) {
+			D_ERROR(DF_UOID" fail to commit dtx: rc = %d\n",
+				DP_UOID(oid), rc);
+			break;
+		}
+	}
+
+	if (rc == 0)
+		rc = vos_dtx_mark_sync(coh, oid, epoch);
+
 	return rc;
 }

--- a/src/dtx/dtx_resync.c
+++ b/src/dtx/dtx_resync.c
@@ -116,9 +116,9 @@ dtx_resync_commit(uuid_t po_uuid, struct ds_cont_child *cont,
 					true : false);
 		if (rc == -DER_NONEXIST) {
 			rc = vos_dtx_add_cos(cont->sc_hdl, &dre->dre_oid,
-				&dre->dre_xid, dre->dre_hash, crt_hlc_get(),
+				&dre->dre_xid, dre->dre_hash, dre->dre_epoch,
 				dre->dre_intent == DAOS_INTENT_PUNCH ?
-				true : false);
+				true : false, false);
 			if (rc < 0)
 				D_WARN("Fail to add DTX "DF_DTI" to CoS cache: "
 				       "rc = %d\n",  DP_DTI(&dre->dre_xid), rc);

--- a/src/include/daos/dtx.h
+++ b/src/include/daos/dtx.h
@@ -87,6 +87,7 @@ enum daos_ops_intent {
 	DAOS_INTENT_REBUILD	= 4,	/* for rebuild related scan */
 	DAOS_INTENT_CHECK	= 5,	/* check aborted or not */
 	DAOS_INTENT_KILL	= 6,	/* delete object/key */
+	DAOS_INTENT_COS		= 7,	/* add something into CoS cache. */
 };
 
 enum daos_dtx_alb {

--- a/src/include/daos/object.h
+++ b/src/include/daos/object.h
@@ -351,6 +351,7 @@ int dc_obj_punch_dkeys(tse_task_t *task);
 int dc_obj_punch_akeys(tse_task_t *task);
 int dc_obj_query(tse_task_t *task);
 int dc_obj_query_key(tse_task_t *task);
+int dc_obj_sync(tse_task_t *task);
 int dc_obj_fetch_shard(tse_task_t *task);
 int dc_obj_fetch(tse_task_t *task);
 int dc_obj_update(tse_task_t *task);

--- a/src/include/daos/task.h
+++ b/src/include/daos/task.h
@@ -74,6 +74,10 @@ dc_obj_query_key_task_create(daos_handle_t oh, daos_handle_t th,
 			     daos_recx_t *recx, daos_event_t *ev,
 			     tse_sched_t *tse, tse_task_t **task);
 int
+dc_obj_sync_task_create(daos_handle_t oh, daos_handle_t th,
+			daos_epoch_t **epoch, int *nr, daos_event_t *ev,
+			tse_sched_t *tse, tse_task_t **task);
+int
 dc_obj_fetch_shard_task_create(daos_handle_t oh, daos_handle_t th,
 			       unsigned int flags, unsigned int shard,
 			       daos_key_t *dkey, unsigned int nr,

--- a/src/include/daos_srv/dtx_srv.h
+++ b/src/include/daos_srv/dtx_srv.h
@@ -175,6 +175,9 @@ int dtx_batched_commit_register(struct ds_cont_hdl *hdl);
 
 void dtx_batched_commit_deregister(struct ds_cont_hdl *hdl);
 
+int dtx_obj_sync(uuid_t po_uuid, uuid_t co_uuid, daos_handle_t coh,
+		 daos_unit_oid_t oid, daos_epoch_t epoch, uint32_t map_ver);
+
 /**
  * Check whether the given DTX is resent one or not.
  *

--- a/src/include/daos_srv/vos.h
+++ b/src/include/daos_srv/vos.h
@@ -44,15 +44,18 @@
  * \param oid		[IN]	The target object (shard) ID.
  * \param dti		[IN]	The DTX identifier.
  * \param dkey_hash	[IN]	The hashed dkey.
- * \param time		[IN]	Timestamp of handling the DTX on server.
+ * \param epoch		[IN]	The DTX epoch.
  * \param punch		[IN]	For punch DTX or not.
+ * \param check		[IN]	Check whether the DTX need restart because
+ *				of sync epoch or not.
  *
- * \return		Zero on success and need not additional actions.
- * \return		Negative value if error.
+ * \return		Zero on success.
+ * \return		-DER_INPROGRESS	retry with newer epoch.
+ * \return		Other negative value if error.
  */
 int
 vos_dtx_add_cos(daos_handle_t coh, daos_unit_oid_t *oid, struct dtx_id *dti,
-		uint64_t dkey_hash, uint64_t time, bool punch);
+		uint64_t dkey_hash, daos_epoch_t epoch, bool punch, bool check);
 
 /**
  * Search the specified DTX is in the CoS cache or not.
@@ -91,15 +94,21 @@ vos_dtx_list_cos(daos_handle_t coh, daos_unit_oid_t *oid, uint64_t dkey_hash,
 /**
  * Fetch the list of the DTXs that can be committed.
  *
- * \param coh	[IN]	Container open handle.
- * \param max	[IN]	The max size of the array for DTX entries.
- * \param dtes	[OUT]	The array for DTX entries can be committed.
+ * \param coh		[IN]	Container open handle.
+ * \param max_cnt	[IN]	The max size of the array for DTX entries.
+ * \param oid		[IN]	Only return the DTXs belong to the specified
+ *				object if it is non-NULL.
+ * \param epoch		[IN]	Only return the DTXs that is not newer than
+ *				the specified epoch.
+ * \param dtes		[OUT]	The array for DTX entries can be committed.
  *
  * \return		Positve value for the @dtes array size.
  *			Negative value on failure.
  */
 int
-vos_dtx_fetch_committable(daos_handle_t coh, int max, struct dtx_entry **dtes);
+vos_dtx_fetch_committable(daos_handle_t coh, uint32_t max_cnt,
+			  daos_unit_oid_t *oid, daos_epoch_t epoch,
+			  struct dtx_entry **dtes);
 
 /**
  * Check whether the given DTX is resent one or not.
@@ -196,6 +205,18 @@ vos_dtx_aggregate(daos_handle_t coh, uint64_t max, uint64_t age);
  */
 void
 vos_dtx_stat(daos_handle_t coh, struct dtx_stat *stat);
+
+/**
+ * Mark the object has been synced at the specified epoch.
+ *
+ * \param coh	[IN]	Container open handle.
+ * \param oid	[IN]	The object ID.
+ * \param epoch	[IN]	The epoch against that we sync DTXs for the object.
+ *
+ * \return	Zero on success, negative value if error.
+ */
+int
+vos_dtx_mark_sync(daos_handle_t coh, daos_unit_oid_t oid, daos_epoch_t epoch);
 
 /**
  * Initialize the environment for a VOS instance

--- a/src/include/daos_task.h
+++ b/src/include/daos_task.h
@@ -101,6 +101,7 @@ typedef enum {
 	DAOS_OPC_OBJ_PUNCH_AKEYS,
 	DAOS_OPC_OBJ_QUERY,
 	DAOS_OPC_OBJ_QUERY_KEY,
+	DAOS_OPC_OBJ_SYNC,
 	DAOS_OPC_OBJ_FETCH_SHARD,
 	DAOS_OPC_OBJ_FETCH,
 	DAOS_OPC_OBJ_UPDATE,
@@ -435,6 +436,13 @@ struct daos_obj_fetch_shard {
 	daos_obj_fetch_t	base;
 	unsigned int		flags;
 	unsigned int		shard;
+};
+
+struct daos_obj_sync_args {
+	daos_handle_t		oh;
+	daos_handle_t		th;
+	daos_epoch_t		**epoch;
+	int			*nr;
 };
 
 typedef struct {

--- a/src/object/cli_obj.c
+++ b/src/object/cli_obj.c
@@ -554,7 +554,7 @@ struct obj_req_tgts {
 static int
 obj_shards_2_fwtgts(struct dc_object *obj, uint32_t map_ver, uint64_t tgt_set,
 		    uint32_t start_shard, uint32_t shard_cnt, uint32_t grp_nr,
-		    struct obj_req_tgts *req_tgts)
+		    struct obj_req_tgts *req_tgts, bool forward)
 {
 	struct daos_shard_tgt	*tgt = NULL;
 	uint32_t		 leader_shard = -1;
@@ -616,7 +616,11 @@ obj_shards_2_fwtgts(struct dc_object *obj, uint32_t map_ver, uint64_t tgt_set,
 						  tgt++);
 			if (rc != 0)
 				return rc;
+
+			if (!forward)
+				continue;
 		}
+
 		for (j = 0; j < grp_size; j++, shard_idx++) {
 			if (shard_idx == leader_shard ||
 			    (tgt_set && !(tgt_set & 1UL << i)))
@@ -627,7 +631,9 @@ obj_shards_2_fwtgts(struct dc_object *obj, uint32_t map_ver, uint64_t tgt_set,
 				return rc;
 		}
 	}
-	D_ASSERT(tgt == req_tgts->ort_shard_tgts + shard_nr);
+
+	if (forward)
+		D_ASSERT(tgt == req_tgts->ort_shard_tgts + shard_nr);
 
 	return 0;
 }
@@ -986,9 +992,10 @@ struct obj_auxi_args {
 	 * request only targets for one shard.
 	 */
 	union {
-		struct shard_rw_args	rw_args;
-		struct shard_punch_args	p_args;
-		struct shard_list_args	l_args;
+		struct shard_rw_args	 rw_args;
+		struct shard_punch_args	 p_args;
+		struct shard_list_args	 l_args;
+		struct shard_sync_args	 s_args;
 	};
 };
 
@@ -1376,6 +1383,21 @@ obj_req_valid(void *args, int opc, daos_epoch_t *epoch)
 			rc = 0;
 		}
 		break;
+	case DAOS_OBJ_RPC_SYNC: {
+		struct daos_obj_sync_args	*s_args = args;
+
+		rc = dc_tx_check(s_args->th, false, epoch);
+		if (rc != 0) {
+			if (rc != -DER_INVAL)
+				D_GOTO(out, rc);
+
+			/* FIXME: until distributed transaction. */
+			*epoch = dc_io_epoch();
+			D_DEBUG(DB_IO, "set epoch "DF_U64"\n", *epoch);
+			rc = 0;
+		}
+		break;
+	}
 	default:
 		D_ERROR("bad opc %d.\n", opc);
 		D_GOTO(out, rc = -DER_INVAL);
@@ -1441,7 +1463,7 @@ obj_req_get_tgts(struct dc_object *obj, enum obj_rpc_opc opc, int *shard,
 		}
 		req_tgts->ort_start_shard = shard_idx;
 		rc = obj_shards_2_fwtgts(obj, map_ver, tgt_set, shard_idx,
-					 shard_cnt, grp_nr, req_tgts);
+					 shard_cnt, grp_nr, req_tgts, true);
 		if (rc != 0) {
 			D_ERROR("opc %d "DF_OID", obj_shards_2_fwtgts failed "
 				"%d.\n", opc, DP_OID(obj->cob_md.omd_id), rc);
@@ -1478,6 +1500,20 @@ obj_req_get_tgts(struct dc_object *obj, enum obj_rpc_opc opc, int *shard,
 		if (rc != 0)
 			goto out;
 		break;
+	case DAOS_OBJ_RPC_SYNC: {
+		uint32_t	shard_idx;
+		uint32_t	shard_cnt;
+		uint32_t	grp_nr;
+
+		obj_ptr2shards(obj, &shard_idx, &shard_cnt, &grp_nr);
+		req_tgts->ort_start_shard = shard_idx;
+		rc = obj_shards_2_fwtgts(obj, map_ver, tgt_set, shard_idx,
+					 shard_cnt, grp_nr, req_tgts, false);
+		if (rc != 0)
+			D_ERROR("opc %d "DF_OID", obj_shards_2_fwtgts failed "
+				"%d.\n", opc, DP_OID(obj->cob_md.omd_id), rc);
+		break;
+	}
 	default:
 		D_ERROR("bad opc %d.\n", opc);
 		rc = -DER_INVAL;
@@ -1596,6 +1632,8 @@ obj_embedded_shard_arg(struct obj_auxi_args *obj_auxi)
 	case DAOS_OBJ_AKEY_RPC_ENUMERATE:
 	case DAOS_OBJ_RECX_RPC_ENUMERATE:
 		return &obj_auxi->l_args.la_auxi;
+	case DAOS_OBJ_RPC_SYNC:
+		return &obj_auxi->s_args.sa_auxi;
 	default:
 		D_ERROR("bad opc %d.\n", obj_auxi->opc);
 		return NULL;
@@ -1653,7 +1691,7 @@ shard_io_task(tse_task_t *task)
 typedef int (*shard_io_prep_cb_t)(struct shard_auxi_args *shard_auxi,
 				  struct dc_object *obj,
 				  struct obj_auxi_args *obj_auxi,
-				  uint64_t dkey_hash);
+				  uint64_t dkey_hash, uint32_t grp_idx);
 
 struct shard_task_reset_arg {
 	struct obj_req_tgts	*req_tgts;
@@ -1751,7 +1789,8 @@ obj_req_fanout(struct dc_object *obj, struct obj_auxi_args *obj_auxi,
 		shard_auxi->obj = obj;
 		shard_auxi->obj_auxi = obj_auxi;
 		shard_auxi->shard_io_cb = io_cb;
-		rc = io_prep_cb(shard_auxi, obj, obj_auxi, dkey_hash);
+		rc = io_prep_cb(shard_auxi, obj, obj_auxi, dkey_hash,
+				shard_auxi->grp_idx);
 		if (rc)
 			goto out_task;
 
@@ -1781,7 +1820,8 @@ obj_req_fanout(struct dc_object *obj, struct obj_auxi_args *obj_auxi,
 		shard_auxi->obj = obj;
 		shard_auxi->obj_auxi = obj_auxi;
 		shard_auxi->shard_io_cb = io_cb;
-		rc = io_prep_cb(shard_auxi, obj, obj_auxi, dkey_hash);
+		rc = io_prep_cb(shard_auxi, obj, obj_auxi, dkey_hash,
+				shard_auxi->grp_idx);
 		if (rc) {
 			tse_task_complete(shard_task, rc);
 			goto out_task;
@@ -1936,6 +1976,7 @@ obj_comp_cb(tse_task_t *task, void *data)
 	case DAOS_OBJ_RPC_PUNCH_DKEYS:
 	case DAOS_OBJ_RPC_PUNCH_AKEYS:
 	case DAOS_OBJ_RPC_QUERY_KEY:
+	case DAOS_OBJ_RPC_SYNC:
 		obj = *((struct dc_object **)data);
 		if (task->dt_result != 0)
 			break;
@@ -1996,6 +2037,18 @@ obj_comp_cb(tse_task_t *task, void *data)
 		obj_retry_cb(task, obj, obj_auxi);
 
 	if (!obj_auxi->io_retry) {
+		if (obj_auxi->opc == DAOS_OBJ_RPC_SYNC &&
+		    task->dt_result != 0) {
+			struct daos_obj_sync_args	*sync_args;
+
+			sync_args = dc_task_get_args(task);
+			D_ASSERT(sync_args->epoch != NULL);
+
+			D_FREE(*sync_args->epoch);
+			*sync_args->epoch = NULL;
+			*sync_args->nr = 0;
+		}
+
 		if (obj_auxi->req_tgts.ort_shard_tgts !=
 		    obj_auxi->req_tgts.ort_tgts_inline)
 			D_FREE(obj_auxi->req_tgts.ort_shard_tgts);
@@ -2032,7 +2085,8 @@ obj_reg_comp_cb(tse_task_t *task, int opc, uint32_t map_ver,
 
 static int
 shard_rw_prep(struct shard_auxi_args *shard_auxi, struct dc_object *obj,
-		 struct obj_auxi_args *obj_auxi, uint64_t dkey_hash)
+	      struct obj_auxi_args *obj_auxi, uint64_t dkey_hash,
+	      uint32_t grp_idx)
 {
 	daos_obj_rw_t		*obj_args;
 	struct shard_rw_args	*shard_arg;
@@ -2202,7 +2256,8 @@ out_task:
 
 static int
 shard_list_prep(struct shard_auxi_args *shard_auxi, struct dc_object *obj,
-		struct obj_auxi_args *obj_auxi, uint64_t dkey_hash)
+		struct obj_auxi_args *obj_auxi, uint64_t dkey_hash,
+		uint32_t grp_idx)
 {
 	daos_obj_list_t		*obj_args;
 	struct shard_list_args	*shard_arg;
@@ -2327,7 +2382,8 @@ dc_obj_list_rec(tse_task_t *task)
 
 static int
 shard_punch_prep(struct shard_auxi_args *shard_auxi, struct dc_object *obj,
-		 struct obj_auxi_args *obj_auxi, uint64_t dkey_hash)
+		 struct obj_auxi_args *obj_auxi, uint64_t dkey_hash,
+		 uint32_t grp_idx)
 {
 	daos_obj_punch_t	*obj_args;
 	struct shard_punch_args	*shard_arg;
@@ -2746,5 +2802,97 @@ out_task:
 		tse_task_list_traverse(head, shard_task_abort, &rc);
 	}
 
+	return rc;
+}
+
+static int
+shard_sync_prep(struct shard_auxi_args *shard_auxi, struct dc_object *obj,
+		struct obj_auxi_args *obj_auxi, uint64_t dkey_hash,
+		uint32_t grp_idx)
+{
+	struct daos_obj_sync_args	*obj_args;
+	struct shard_sync_args		*shard_args;
+
+	obj_args = dc_task_get_args(obj_auxi->obj_task);
+	shard_args = container_of(shard_auxi, struct shard_sync_args, sa_auxi);
+	shard_args->sa_epoch = &(*obj_args->epoch)[grp_idx];
+
+	return 0;
+}
+
+int
+dc_obj_sync(tse_task_t *task)
+{
+	struct daos_obj_sync_args	*args;
+	struct obj_auxi_args		*obj_auxi = NULL;
+	struct dc_object		*obj = NULL;
+	daos_epoch_t			 epoch;
+	uint32_t			 map_ver;
+	int				 rc;
+	int				 i;
+
+	if (srv_io_mode != DIM_DTX_FULL_ENABLED)
+		D_GOTO(out_task, rc = 0);
+
+	args = dc_task_get_args(task);
+	D_ASSERTF(args != NULL,
+		  "Task Argument OPC does not match DC OPC\n");
+
+	rc = obj_req_valid(args, DAOS_OBJ_RPC_SYNC, &epoch);
+	if (rc != 0)
+		D_GOTO(out_task, rc);
+
+	D_ASSERT(epoch);
+
+	obj = obj_hdl2ptr(args->oh);
+	if (obj == NULL)
+		D_GOTO(out_task, rc = -DER_NO_HDL);
+
+	rc = obj_ptr2pm_ver(obj, &map_ver);
+	if (rc != 0) {
+		obj_decref(obj);
+		D_GOTO(out_task, rc);
+	}
+
+	rc = obj_reg_comp_cb(task, DAOS_OBJ_RPC_SYNC, map_ver, &obj_auxi,
+			     &obj, sizeof(obj));
+	if (rc != 0) {
+		obj_decref(obj);
+		D_GOTO(out_task, rc);
+	}
+
+	/* Need to mark sync epoch on server, so even if the @replicas is 1,
+	 * we still need to send SYNC RPC to the server.
+	 */
+	if (!obj_auxi->io_retry) {
+		daos_epoch_t	*tmp = NULL;
+
+		D_ALLOC_ARRAY(tmp, obj->cob_grp_nr);
+		if (tmp == NULL)
+			D_GOTO(out_task, rc = -DER_NOMEM);
+
+		*args->nr = obj->cob_grp_nr;
+		*args->epoch = tmp;
+	} else {
+		D_ASSERT(*args->epoch != NULL);
+
+		for (i = 0; i < *args->nr; i++)
+			*args->epoch[i] = 0;
+	}
+
+	rc = obj_req_get_tgts(obj, DAOS_OBJ_RPC_SYNC, NULL, 0, 0, map_ver,
+			      true, false, &obj_auxi->req_tgts);
+	if (rc != 0)
+		D_GOTO(out_task, rc);
+
+	D_DEBUG(DB_IO, "sync "DF_OID", reps %d\n",
+		DP_OID(obj->cob_md.omd_id), obj_get_replicas(obj));
+
+	rc = obj_req_fanout(obj, obj_auxi, 0, map_ver, epoch,
+			    shard_sync_prep, dc_obj_shard_sync, task);
+	return rc;
+
+out_task:
+	tse_task_complete(task, rc);
 	return rc;
 }

--- a/src/object/cli_shard.c
+++ b/src/object/cli_shard.c
@@ -1002,3 +1002,130 @@ out:
 	tse_task_complete(task, rc);
 	return rc;
 }
+
+struct obj_shard_sync_cb_args {
+	crt_rpc_t	*rpc;
+	daos_epoch_t	*epoch;
+	uint32_t	*map_ver;
+};
+
+static int
+obj_shard_sync_cb(tse_task_t *task, void *data)
+{
+	struct obj_shard_sync_cb_args	*cb_args;
+	struct obj_sync_out		*oso;
+	int				 ret = task->dt_result;
+	int				 rc = 0;
+	crt_rpc_t			*rpc;
+
+	cb_args = (struct obj_shard_sync_cb_args *)data;
+	rpc = cb_args->rpc;
+
+	if (ret != 0) {
+		D_ERROR("OBJ_SYNC RPC failed: rc = %d\n", ret);
+		D_GOTO(out, rc = ret);
+	}
+
+	oso = crt_reply_get(rpc);
+	rc = oso->oso_ret;
+	if (rc == -DER_NONEXIST)
+		D_GOTO(out, rc = 0);
+
+	if (rc == -DER_INPROGRESS) {
+		D_DEBUG(DB_TRACE,
+			"rpc %p OBJ_SYNC_RPC may need retry: rc = %d\n",
+			rpc, rc);
+		D_GOTO(out, rc);
+	}
+
+	if (rc != 0) {
+		D_ERROR("rpc %p OBJ_SYNC_RPC failed: rc = %d\n", rpc, rc);
+		D_GOTO(out, rc);
+	}
+
+	*cb_args->epoch = oso->oso_epoch;
+	*cb_args->map_ver = oso->oso_map_version;
+
+	D_DEBUG(DB_IO, "OBJ_SYNC_RPC reply: eph "DF_U64", version %u.\n",
+		oso->oso_epoch, oso->oso_map_version);
+
+out:
+	crt_req_decref(rpc);
+	return rc;
+}
+
+int
+dc_obj_shard_sync(struct dc_obj_shard *shard, enum obj_rpc_opc opc,
+		  void *shard_args, struct daos_shard_tgt *fw_shard_tgts,
+		  uint32_t fw_cnt, tse_task_t *task)
+{
+	struct shard_sync_args		*args = shard_args;
+	struct dc_pool			*pool = NULL;
+	uuid_t				 cont_hdl_uuid;
+	uuid_t				 cont_uuid;
+	struct obj_sync_in		*osi;
+	crt_rpc_t			*req;
+	struct obj_shard_sync_cb_args	 cb_args;
+	crt_endpoint_t			 tgt_ep;
+	int				 rc;
+
+	pool = obj_shard_ptr2pool(shard);
+	if (pool == NULL)
+		D_GOTO(out, rc = -DER_NO_HDL);
+
+	rc = dc_cont_hdl2uuid(shard->do_co_hdl, &cont_hdl_uuid, &cont_uuid);
+	if (rc != 0)
+		D_GOTO(out, rc);
+
+	tgt_ep.ep_grp	= pool->dp_sys->sy_group;
+	tgt_ep.ep_tag	= shard->do_target_idx;
+	tgt_ep.ep_rank	= shard->do_target_rank;
+	if ((int)tgt_ep.ep_rank < 0)
+		D_GOTO(out, rc = (int)tgt_ep.ep_rank);
+
+	D_DEBUG(DB_IO, "OBJ_SYNC_RPC, rank=%d tag=%d.\n",
+		tgt_ep.ep_rank, tgt_ep.ep_tag);
+
+	rc = obj_req_create(daos_task2ctx(task), &tgt_ep, opc, &req);
+	if (rc != 0)
+		D_GOTO(out, rc);
+
+	crt_req_addref(req);
+	cb_args.rpc	= req;
+	cb_args.epoch	= args->sa_epoch;
+	cb_args.map_ver = &args->sa_auxi.map_ver;
+
+	rc = tse_task_register_comp_cb(task, obj_shard_sync_cb, &cb_args,
+				       sizeof(cb_args));
+	if (rc != 0)
+		D_GOTO(out_req, rc);
+
+	osi = crt_req_get(req);
+	D_ASSERT(osi != NULL);
+
+	uuid_copy(osi->osi_co_hdl, cont_hdl_uuid);
+	uuid_copy(osi->osi_pool_uuid, pool->dp_pool);
+	uuid_copy(osi->osi_co_uuid, cont_uuid);
+	osi->osi_oid		= shard->do_id;
+	osi->osi_epoch		= args->sa_auxi.epoch;
+	osi->osi_map_ver	= args->sa_auxi.map_ver;
+
+	rc = daos_rpc_send(req, task);
+	if (rc != 0) {
+		D_ERROR("OBJ_SYNC_RPC failed: rc = %d\n", rc);
+		D_GOTO(out_req, rc);
+	}
+
+	dc_pool_put(pool);
+	return 0;
+
+out_req:
+	crt_req_decref(req);
+
+out:
+	if (pool != NULL)
+		dc_pool_put(pool);
+
+	tse_task_complete(task, rc);
+	return rc;
+}

--- a/src/object/obj_internal.h
+++ b/src/object/obj_internal.h
@@ -215,6 +215,11 @@ struct shard_list_args {
 	daos_obj_list_t		*la_api_args;
 };
 
+struct shard_sync_args {
+	struct shard_auxi_args	 sa_auxi;
+	daos_epoch_t		*sa_epoch;
+};
+
 int dc_obj_shard_open(struct dc_object *obj, daos_unit_oid_t id,
 		      unsigned int mode, struct dc_obj_shard *shard);
 void dc_obj_shard_close(struct dc_obj_shard *shard);
@@ -240,6 +245,10 @@ int dc_obj_shard_query_key(struct dc_obj_shard *shard, daos_epoch_t epoch,
 			   daos_recx_t *recx, const uuid_t coh_uuid,
 			   const uuid_t cont_uuid, unsigned int *map_ver,
 			   tse_task_t *task);
+
+int dc_obj_shard_sync(struct dc_obj_shard *shard, enum obj_rpc_opc opc,
+		      void *shard_args, struct daos_shard_tgt *fw_shard_tgts,
+		      uint32_t fw_cnt, tse_task_t *task);
 
 static inline bool
 obj_retry_error(int err)
@@ -274,6 +283,7 @@ void ds_obj_enum_handler(crt_rpc_t *rpc);
 void ds_obj_punch_handler(crt_rpc_t *rpc);
 void ds_obj_tgt_punch_handler(crt_rpc_t *rpc);
 void ds_obj_query_key_handler(crt_rpc_t *rpc);
+void ds_obj_sync_handler(crt_rpc_t *rpc);
 ABT_pool ds_obj_abt_pool_choose_cb(crt_rpc_t *rpc, ABT_pool *pools);
 typedef int (*ds_iofw_cb_t)(crt_rpc_t *req, void *arg);
 

--- a/src/object/obj_rpc.c
+++ b/src/object/obj_rpc.c
@@ -397,6 +397,7 @@ CRT_RPC_DEFINE(obj_fetch, DAOS_ISEQ_OBJ_RW, DAOS_OSEQ_OBJ_RW)
 CRT_RPC_DEFINE(obj_key_enum, DAOS_ISEQ_OBJ_KEY_ENUM, DAOS_OSEQ_OBJ_KEY_ENUM)
 CRT_RPC_DEFINE(obj_punch, DAOS_ISEQ_OBJ_PUNCH, DAOS_OSEQ_OBJ_PUNCH)
 CRT_RPC_DEFINE(obj_query_key, DAOS_ISEQ_OBJ_QUERY_KEY, DAOS_OSEQ_OBJ_QUERY_KEY)
+CRT_RPC_DEFINE(obj_sync, DAOS_ISEQ_OBJ_SYNC, DAOS_OSEQ_OBJ_SYNC)
 
 /* Define for cont_rpcs[] array population below.
  * See OBJ_PROTO_*_RPC_LIST macro definition
@@ -451,6 +452,9 @@ obj_reply_set_status(crt_rpc_t *rpc, int status)
 	case DAOS_OBJ_RPC_QUERY_KEY:
 		((struct obj_query_key_out *)reply)->okqo_ret = status;
 		break;
+	case DAOS_OBJ_RPC_SYNC:
+		((struct obj_sync_out *)reply)->oso_ret = status;
+		break;
 	default:
 		D_ASSERT(0);
 	}
@@ -480,6 +484,8 @@ obj_reply_get_status(crt_rpc_t *rpc)
 		return ((struct obj_punch_out *)reply)->opo_ret;
 	case DAOS_OBJ_RPC_QUERY_KEY:
 		return ((struct obj_query_key_out *)reply)->okqo_ret;
+	case DAOS_OBJ_RPC_SYNC:
+		return ((struct obj_sync_out *)reply)->oso_ret;
 	default:
 		D_ASSERT(0);
 	}
@@ -516,6 +522,9 @@ obj_reply_map_version_set(crt_rpc_t *rpc, uint32_t map_version)
 		((struct obj_query_key_out *)reply)->okqo_map_version =
 			map_version;
 		break;
+	case DAOS_OBJ_RPC_SYNC:
+		((struct obj_sync_out *)reply)->oso_map_version = map_version;
+		break;
 	default:
 		D_ASSERT(0);
 	}
@@ -545,6 +554,8 @@ obj_reply_map_version_get(crt_rpc_t *rpc)
 		return ((struct obj_punch_out *)reply)->opo_map_version;
 	case DAOS_OBJ_RPC_QUERY_KEY:
 		return ((struct obj_query_key_out *)reply)->okqo_map_version;
+	case DAOS_OBJ_RPC_SYNC:
+		return ((struct obj_sync_out *)reply)->oso_map_version;
 	default:
 		D_ASSERT(0);
 	}

--- a/src/object/obj_rpc.h
+++ b/src/object/obj_rpc.h
@@ -85,6 +85,9 @@
 	X(DAOS_OBJ_RPC_QUERY_KEY,					\
 		0, &CQF_obj_query_key,					\
 		ds_obj_query_key_handler, NULL),			\
+	X(DAOS_OBJ_RPC_SYNC,						\
+		0, &CQF_obj_sync,					\
+		ds_obj_sync_handler, NULL),				\
 	X(DAOS_OBJ_RPC_TGT_UPDATE,					\
 		0, &CQF_obj_update,					\
 		ds_obj_tgt_update_handler, NULL),			\
@@ -234,6 +237,22 @@ CRT_RPC_DECLARE(obj_punch, DAOS_ISEQ_OBJ_PUNCH, DAOS_OSEQ_OBJ_PUNCH)
 	((daos_recx_t)		(okqo_recx)		CRT_VAR)
 
 CRT_RPC_DECLARE(obj_query_key, DAOS_ISEQ_OBJ_QUERY_KEY, DAOS_OSEQ_OBJ_QUERY_KEY)
+
+#define DAOS_ISEQ_OBJ_SYNC /* input fields */			 \
+	((uuid_t)		(osi_co_hdl)		CRT_VAR) \
+	((uuid_t)		(osi_pool_uuid)		CRT_VAR) \
+	((uuid_t)		(osi_co_uuid)		CRT_VAR) \
+	((daos_unit_oid_t)	(osi_oid)		CRT_VAR) \
+	((uint64_t)		(osi_epoch)		CRT_VAR) \
+	((uint32_t)		(osi_map_ver)		CRT_VAR) \
+	((uint32_t)		(osi_padding)		CRT_VAR)
+
+#define DAOS_OSEQ_OBJ_SYNC /* output fields */			 \
+	((int32_t)		(oso_ret)		CRT_VAR) \
+	((uint32_t)		(oso_map_version)	CRT_VAR) \
+	((uint64_t)		(oso_epoch)		CRT_VAR)
+
+CRT_RPC_DECLARE(obj_sync, DAOS_ISEQ_OBJ_SYNC, DAOS_OSEQ_OBJ_SYNC)
 
 static inline int
 obj_req_create(crt_context_t crt_ctx, crt_endpoint_t *tgt_ep, crt_opcode_t opc,

--- a/src/object/obj_task.c
+++ b/src/object/obj_task.c
@@ -166,6 +166,28 @@ dc_obj_query_key_task_create(daos_handle_t oh, daos_handle_t th,
 	return 0;
 }
 
+int
+dc_obj_sync_task_create(daos_handle_t oh, daos_handle_t th,
+			daos_epoch_t **epoch, int *nr, daos_event_t *ev,
+			tse_sched_t *tse, tse_task_t **task)
+{
+	struct daos_obj_sync_args	*args;
+	int				 rc;
+
+	DAOS_API_ARG_ASSERT(*args, OBJ_SYNC);
+	rc = dc_task_create(dc_obj_sync, tse, ev, task);
+	if (rc)
+		return rc;
+
+	args = dc_task_get_args(*task);
+	args->oh	= oh;
+	args->th	= th;
+	args->epoch	= epoch;
+	args->nr	= nr;
+
+	return 0;
+}
+
 static void
 dc_obj_fetch_task_fill_args(daos_obj_fetch_t *args, daos_handle_t oh,
 			    daos_handle_t th, daos_key_t *dkey, unsigned int nr,

--- a/src/object/srv_obj.c
+++ b/src/object/srv_obj.c
@@ -715,9 +715,9 @@ out:
 static int
 ds_pre_check(daos_unit_oid_t oid, uint32_t rpc_map_ver, uuid_t pool_uuid,
 	     uuid_t hdl_uuid, uuid_t co_uuid, uint32_t opc,
-	     struct ds_cont_hdl **hdlp, struct ds_cont_child **contp)
+	     struct ds_cont_hdl **hdlp, struct ds_cont_child **contp,
+	     uint32_t *map_ver)
 {
-	uint32_t	map_ver;
 	int		rc;
 
 	*hdlp = NULL;
@@ -727,9 +727,9 @@ ds_pre_check(daos_unit_oid_t oid, uint32_t rpc_map_ver, uuid_t pool_uuid,
 		return rc;
 
 	D_ASSERT((*hdlp)->sch_pool != NULL);
-	map_ver = (*hdlp)->sch_pool->spc_map_version;
+	*map_ver = (*hdlp)->sch_pool->spc_map_version;
 
-	if (rpc_map_ver > map_ver ||
+	if (rpc_map_ver > *map_ver ||
 	   (*hdlp)->sch_pool->spc_pool->sp_map == NULL ||
 	   DAOS_FAIL_CHECK(DAOS_FORCE_REFRESH_POOL_MAP)) {
 		/* XXX: Client (or leader replica) has newer pool map than
@@ -758,12 +758,17 @@ ds_pre_check(daos_unit_oid_t oid, uint32_t rpc_map_ver, uuid_t pool_uuid,
 		 * pool map to avoid any possible issue
 		 */
 		D_DEBUG(DB_IO, "stale server map_version %d req %d\n",
-			map_ver, rpc_map_ver);
+			*map_ver, rpc_map_ver);
 		rc = ds_pool_child_map_refresh_async((*hdlp)->sch_pool);
-		D_GOTO(out_put, rc = rc ? : -DER_STALE);
-	} else if (rpc_map_ver < map_ver) {
+		if (rc == 0) {
+			*map_ver = (*hdlp)->sch_pool->spc_map_version;
+			rc = -DER_STALE;
+		}
+
+		D_GOTO(out_put, rc);
+	} else if (rpc_map_ver < *map_ver) {
 		D_DEBUG(DB_IO, "stale version req %d map_version %d\n",
-			rpc_map_ver, map_ver);
+			rpc_map_ver, *map_ver);
 		if (obj_is_modification_opc(opc))
 			D_GOTO(out_put, rc = -DER_STALE);
 		/* It is harmless if fetch with old pool map version. */
@@ -803,12 +808,11 @@ ds_obj_tgt_update_handler(crt_rpc_t *rpc)
 
 	rc = ds_pre_check(orw->orw_oid, orw->orw_map_ver, orw->orw_pool_uuid,
 			  orw->orw_co_hdl, orw->orw_co_uuid,
-			  opc_get(rpc->cr_opc), &cont_hdl, &cont);
+			  opc_get(rpc->cr_opc), &cont_hdl, &cont, &map_ver);
 	if (rc)
 		goto out;
 
 	D_ASSERT(cont_hdl->sch_pool != NULL);
-	map_ver = cont_hdl->sch_pool->spc_map_version;
 
 	D_DEBUG(DB_TRACE, "rpc %p opc %d "DF_UOID" dkey %d %s tag/xs %d/%d eph "
 		DF_U64", pool ver %u/%u with "DF_DTI".\n",
@@ -920,12 +924,11 @@ ds_obj_rw_handler(crt_rpc_t *rpc)
 
 	rc = ds_pre_check(orw->orw_oid, orw->orw_map_ver, orw->orw_pool_uuid,
 			  orw->orw_co_hdl, orw->orw_co_uuid,
-			  opc_get(rpc->cr_opc), &cont_hdl, &cont);
+			  opc_get(rpc->cr_opc), &cont_hdl, &cont, &map_ver);
 	if (rc)
 		goto out;
 
 	D_ASSERT(cont_hdl->sch_pool != NULL);
-	map_ver = cont_hdl->sch_pool->spc_map_version;
 
 	D_DEBUG(DB_TRACE, "rpc %p opc %d "DF_UOID" dkey %d %s tag/xs %d/%d eph "
 		DF_U64", pool ver %u/%u with "DF_DTI".\n",
@@ -1080,12 +1083,11 @@ ds_iter_vos(crt_rpc_t *rpc, struct vos_iter_anchors *anchors,
 
 	rc = ds_pre_check(oei->oei_oid, oei->oei_map_ver, oei->oei_pool_uuid,
 			  oei->oei_co_hdl, oei->oei_co_uuid, opc, &cont_hdl,
-			  &cont);
+			  &cont, map_version);
 	if (rc)
 		D_GOTO(out, rc);
 
 	D_ASSERT(cont_hdl->sch_pool != NULL);
-	*map_version = cont_hdl->sch_pool->spc_map_version;
 
 	/* prepare enumeration parameters */
 	param.ip_hdl = cont->sc_hdl;
@@ -1405,7 +1407,7 @@ ds_obj_tgt_punch_handler(crt_rpc_t *rpc)
 	D_ASSERT(opi != NULL);
 	rc = ds_pre_check(opi->opi_oid, opi->opi_map_ver, opi->opi_pool_uuid,
 			  opi->opi_co_hdl, opi->opi_co_uuid,
-			  opc_get(rpc->cr_opc), &cont_hdl, &cont);
+			  opc_get(rpc->cr_opc), &cont_hdl, &cont, &map_version);
 	if (rc)
 		goto out;
 
@@ -1509,7 +1511,7 @@ ds_obj_punch_handler(crt_rpc_t *rpc)
 	D_ASSERT(opi != NULL);
 	rc = ds_pre_check(opi->opi_oid, opi->opi_map_ver, opi->opi_pool_uuid,
 			  opi->opi_co_hdl, opi->opi_co_uuid,
-			  opc_get(rpc->cr_opc), &cont_hdl, &cont);
+			  opc_get(rpc->cr_opc), &cont_hdl, &cont, &map_version);
 	if (rc)
 		goto out;
 
@@ -1669,6 +1671,58 @@ out:
 	rc = crt_reply_send(rpc);
 	if (rc != 0)
 		D_ERROR("send reply failed: %d\n", rc);
+}
+
+void
+ds_obj_sync_handler(crt_rpc_t *rpc)
+{
+	struct obj_sync_in	*osi;
+	struct obj_sync_out	*oso;
+	struct ds_cont_hdl	*cont_hdl = NULL;
+	struct ds_cont_child	*cont = NULL;
+	daos_epoch_t		 epoch = crt_hlc_get();
+	uint32_t		 map_ver = 0;
+	int			 rc;
+
+	osi = crt_req_get(rpc);
+	D_ASSERT(osi != NULL);
+
+	oso = crt_reply_get(rpc);
+	D_ASSERT(oso != NULL);
+
+	if (osi->osi_epoch == 0)
+		oso->oso_epoch = epoch;
+	else
+		oso->oso_epoch = min(epoch, osi->osi_epoch);
+
+	D_DEBUG(DB_IO, "ds_obj_sync_handler start: "DF_UOID", eph "DF_U64"\n",
+		DP_UOID(osi->osi_oid), oso->oso_epoch);
+
+	rc = ds_pre_check(osi->osi_oid, osi->osi_map_ver, osi->osi_pool_uuid,
+			  osi->osi_co_hdl, osi->osi_co_uuid,
+			  opc_get(rpc->cr_opc), &cont_hdl, &cont, &map_ver);
+	if (rc != 0)
+		D_GOTO(out, rc);
+
+	rc = dtx_obj_sync(osi->osi_pool_uuid, osi->osi_co_uuid, cont->sc_hdl,
+			  osi->osi_oid, oso->oso_epoch, map_ver);
+
+out:
+	if (cont_hdl != NULL)
+		ds_cont_hdl_put(cont_hdl);
+	if (cont != NULL)
+		ds_cont_child_put(cont);
+
+	obj_reply_set_status(rpc, rc);
+	obj_reply_map_version_set(rpc, map_ver);
+
+	D_DEBUG(DB_IO, "ds_obj_sync_handler stop: "
+		DF_UOID", eph "DF_U64", rd = %d\n",
+		DP_UOID(osi->osi_oid), oso->oso_epoch, rc);
+
+	rc = crt_reply_send(rpc);
+	if (rc != 0)
+		D_ERROR("ds_obj_sync_handler: send reply failed: %d\n", rc);
 }
 
 /**

--- a/src/vos/tests/vts_dtx.c
+++ b/src/vos/tests/vts_dtx.c
@@ -44,7 +44,7 @@ vts_dtx_cos(void **state, bool punch)
 
 	/* Insert a DTX into CoS cache. */
 	rc = vos_dtx_add_cos(args->ctx.tc_co_hdl, &args->oid, &xid,
-			     dkey_hash, crt_hlc_get(), punch);
+			     dkey_hash, DAOS_EPOCH_MAX - 1, punch, false);
 	assert_int_equal(rc, 0);
 
 	/* Query the DTX with different @punch parameter will find nothing. */
@@ -99,8 +99,8 @@ dtx_3(void **state)
 		daos_dti_gen(&xid, false);
 
 		rc = vos_dtx_add_cos(args->ctx.tc_co_hdl, &args->oid, &xid,
-				     dkey_hash, crt_hlc_get(),
-				     i % 2 ? true : false);
+				     dkey_hash, DAOS_EPOCH_MAX - 1,
+				     i % 2 ? true : false, false);
 		assert_int_equal(rc, 0);
 	}
 
@@ -139,12 +139,13 @@ dtx_4(void **state)
 		dkey_hash = lrand48();
 
 		rc = vos_dtx_add_cos(args->ctx.tc_co_hdl, &args->oid, &xid[i],
-				     dkey_hash, crt_hlc_get(),
-				     i % 2 ? false : true);
+				     dkey_hash, DAOS_EPOCH_MAX - 1,
+				     i % 2 ? false : true, false);
 		assert_int_equal(rc, 0);
 	}
 
-	rc = vos_dtx_fetch_committable(args->ctx.tc_co_hdl, 100, &dtes);
+	rc = vos_dtx_fetch_committable(args->ctx.tc_co_hdl, 100, NULL,
+				       DAOS_EPOCH_MAX, &dtes);
 	assert_int_equal(rc, 10);
 
 	for (i = 0; i < 10; i++) {
@@ -299,7 +300,7 @@ dtx_5(void **state)
 
 	/* Add former DTX into CoS cache. */
 	rc = vos_dtx_add_cos(args->ctx.tc_co_hdl, &args->oid, &xid,
-			     dkey_hash, epoch, false);
+			     dkey_hash, epoch, false, false);
 	assert_int_equal(rc, 0);
 
 	vos_dtx_stat(args->ctx.tc_co_hdl, &stat);
@@ -790,7 +791,7 @@ dtx_16(void **state)
 
 	/* Insert a DTX into CoS cache. */
 	rc = vos_dtx_add_cos(args->ctx.tc_co_hdl, &args->oid, &xid,
-			     dkey_hash, epoch, false);
+			     dkey_hash, epoch, false, false);
 	assert_int_equal(rc, 0);
 
 	/* Fetch again. */

--- a/src/vos/vos_dtx_cos.c
+++ b/src/vos/vos_dtx_cos.c
@@ -62,6 +62,8 @@ struct dtx_cos_rec_child {
 	d_list_t		 dcrc_link;
 	/* The DTX identifier. */
 	struct dtx_id		 dcrc_dti;
+	/* The DTX epoch. */
+	daos_epoch_t		 dcrc_epoch;
 	/* Timestamp of handling the DTX on server. */
 	uint64_t		 dcrc_time;
 	/* Pointer to the dtx_cos_rec. */
@@ -71,7 +73,7 @@ struct dtx_cos_rec_child {
 struct dtx_cos_rec_bundle {
 	struct vos_container	*cont;
 	struct dtx_id		*dti;
-	uint64_t		 time;
+	daos_epoch_t		 epoch;
 	bool			 punch;
 };
 
@@ -136,7 +138,8 @@ dtx_cos_rec_alloc(struct btr_instance *tins, d_iov_t *key_iov,
 	}
 
 	dcrc->dcrc_dti = *rbund->dti;
-	dcrc->dcrc_time = rbund->time;
+	dcrc->dcrc_epoch = rbund->epoch;
+	dcrc->dcrc_time = crt_hlc_get();
 	dcrc->dcrc_ptr = dcr;
 
 	d_list_add_tail(&dcrc->dcrc_committable,
@@ -216,7 +219,8 @@ dtx_cos_rec_update(struct btr_instance *tins, struct btr_record *rec,
 		return -DER_NOMEM;
 
 	dcrc->dcrc_dti = *rbund->dti;
-	dcrc->dcrc_time = rbund->time;
+	dcrc->dcrc_epoch = rbund->epoch;
+	dcrc->dcrc_time = crt_hlc_get();
 	dcrc->dcrc_ptr = dcr;
 
 	d_list_add_tail(&dcrc->dcrc_committable,
@@ -356,17 +360,35 @@ out:
 
 int
 vos_dtx_add_cos(daos_handle_t coh, daos_unit_oid_t *oid, struct dtx_id *dti,
-		uint64_t dkey_hash, uint64_t time, bool punch)
+		uint64_t dkey_hash, daos_epoch_t epoch, bool punch, bool check)
 {
 	struct vos_container		*cont;
 	struct dtx_cos_key		 key;
 	struct dtx_cos_rec_bundle	 rbund;
-	d_iov_t			 kiov;
-	d_iov_t			 riov;
+	d_iov_t				 kiov;
+	d_iov_t				 riov;
 	int				 rc;
 
 	cont = vos_hdl2cont(coh);
 	D_ASSERT(cont != NULL);
+
+	if (check) {
+		struct daos_lru_cache	*occ = vos_obj_cache_current();
+		struct vos_object	*obj = NULL;
+
+		/* Sync epoch check inside vos_obj_hold(). We do not
+		 * care about whether it is for punch or update , so
+		 * use DAOS_INTENT_COS to bypass DTX conflict check.
+		 */
+		rc = vos_obj_hold(occ, cont, *oid, epoch, true,
+				  DAOS_INTENT_COS, &obj);
+		if (rc != 0)
+			return rc;
+
+		vos_obj_release(occ, obj);
+	}
+
+	D_ASSERT(epoch != DAOS_EPOCH_MAX);
 
 	key.oid = *oid;
 	key.dkey = dkey_hash;
@@ -374,7 +396,7 @@ vos_dtx_add_cos(daos_handle_t coh, daos_unit_oid_t *oid, struct dtx_id *dti,
 
 	rbund.cont = cont;
 	rbund.dti = dti;
-	rbund.time = time;
+	rbund.epoch = epoch;
 	rbund.punch = punch;
 	d_iov_set(&riov, &rbund, sizeof(rbund));
 
@@ -429,22 +451,20 @@ vos_dtx_lookup_cos(daos_handle_t coh, daos_unit_oid_t *oid,
 }
 
 int
-vos_dtx_fetch_committable(daos_handle_t coh, int max, struct dtx_entry **dtes)
+vos_dtx_fetch_committable(daos_handle_t coh, uint32_t max_cnt,
+			  daos_unit_oid_t *oid, daos_epoch_t epoch,
+			  struct dtx_entry **dtes)
 {
 	struct dtx_entry		*dte = NULL;
 	struct dtx_cos_rec_child	*dcrc;
 	struct vos_container		*cont;
-	int				 count;
-	int				 i = 0;
+	uint32_t			 count;
+	uint32_t			 i = 0;
 
 	cont = vos_hdl2cont(coh);
 	D_ASSERT(cont != NULL);
 
-	if (cont->vc_dtx_committable_count > max)
-		count = max;
-	else
-		count = cont->vc_dtx_committable_count;
-
+	count = min(cont->vc_dtx_committable_count, max_cnt);
 	if (count == 0) {
 		*dtes = NULL;
 		return 0;
@@ -456,6 +476,13 @@ vos_dtx_fetch_committable(daos_handle_t coh, int max, struct dtx_entry **dtes)
 
 	d_list_for_each_entry(dcrc, &cont->vc_dtx_committable,
 			      dcrc_committable) {
+		if (oid != NULL &&
+		    daos_unit_oid_compare(dcrc->dcrc_ptr->dcr_oid, *oid) != 0)
+			continue;
+
+		if (epoch < dcrc->dcrc_epoch)
+			continue;
+
 		dte[i].dte_xid = dcrc->dcrc_dti;
 		dte[i].dte_oid = dcrc->dcrc_ptr->dcr_oid;
 
@@ -463,8 +490,14 @@ vos_dtx_fetch_committable(daos_handle_t coh, int max, struct dtx_entry **dtes)
 			break;
 	}
 
-	*dtes = dte;
-	return count;
+	if (i == 0) {
+		D_FREE(dte);
+		*dtes = NULL;
+	} else {
+		*dtes = dte;
+	}
+
+	return min(count, i);
 }
 
 void

--- a/src/vos/vos_layout.h
+++ b/src/vos/vos_layout.h
@@ -375,6 +375,8 @@ struct vos_irec_df {
  */
 struct vos_obj_df {
 	daos_unit_oid_t			vo_id;
+	/** The latest sync epoch */
+	daos_epoch_t			vo_sync;
 	/** Attributes of object.  See vos_oi_attr */
 	uint64_t			vo_oi_attr;
 	/** Latest known update timestamp or punched timestamp */

--- a/src/vos/vos_obj.h
+++ b/src/vos/vos_obj.h
@@ -56,6 +56,8 @@ struct vos_object {
 	daos_handle_t			obj_ih;
 	/** epoch when the object(cache) is initialized */
 	daos_epoch_t			obj_epoch;
+	/** The latest sync epoch */
+	daos_epoch_t			obj_sync_epoch;
 	/** cached vos_obj_df::vo_incarnation, for revalidation. */
 	uint32_t			obj_incarnation;
 	/** nobody should access this object */

--- a/src/vos/vos_obj_index.c
+++ b/src/vos/vos_obj_index.c
@@ -138,6 +138,7 @@ oi_rec_alloc(struct btr_instance *tins, d_iov_t *key_iov,
 	key = key_iov->iov_buf;
 	hkey = &key->oi_hkey;
 
+	obj->vo_sync	= 0;
 	obj->vo_id	= hkey->oi_oid;
 	obj->vo_earliest = key->oi_epc_lo;
 	if (hkey->oi_epc == DAOS_EPOCH_MAX) {


### PR DESCRIPTION
New object based RPC: DAOS_OBJ_RPC_SYNC. When client wants to sync object
against some epoch, it will send DAOS_OBJ_RPC_SYNC RPC to leader replica.
If the object data resides on multiple redundancy groups, the RPC will be
sent to leader replicas in all related redundancy groups.

On the server side, related RPC handler will commit the DTXs that modify the
specified object and which epochs are not newer than the specified epoch. If
some DTX which epoch is older than the given epoch but not ready for commit
at that time, then it will be aborted, related IO RPC handler will reply to
the client -DER_INPROGRESS that will cause client to retry related RPC with
newer epoch sometime later.

If the RPC sponsor does not know which epoch should be used for sync, it can
use DAOS_EPOCH_MAX, then the leader replica will replace it with its current
highest epoch for the sync boundary, all current committable DTXs belonging
to such object will be committed by force, and such epoch will be returned
to the client.

Please note that above sync is object based and persistent (we store related
epoch in the vos object on disk). After the sync done, nobody can modify the
object with the epoch that is not newer than the sync epoch. The sync epoch
is incremental only. If the new sync epoch is not newer than current stored
sync epoch, then it will be ignored.

To avoid confusing, we do not directly export object sync API to application,
instead, the object sync can be internally used by other DAOS components. For
example, the object consistency verification logic needs to sync the object.

Signed-off-by: Fan Yong <fan.yong@intel.com>