### PR TITLE
DAOS-3096 vos: Initialize evt_entry_in to 0

### DIFF
--- a/src/vos/tests/evt_ctl.c
+++ b/src/vos/tests/evt_ctl.c
@@ -327,7 +327,7 @@ ts_add_rect(void **state)
 {
 	char			*val;
 	bio_addr_t		 bio_addr = {0}; /* Fake bio addr */
-	struct evt_entry_in	 entry;
+	struct evt_entry_in	 entry = {0};
 	int			 rc;
 	bool			 should_pass;
 	static int		 total_added;
@@ -614,7 +614,7 @@ ts_many_add(void **state)
 	char			*tmp;
 	int			*seq;
 	struct evt_rect		*rect;
-	struct evt_entry_in	 entry;
+	struct evt_entry_in	 entry = {0};
 	bio_addr_t		 bio_addr = {0}; /* Fake bio addr */
 	long			 offset = 0;
 	int			 size;

--- a/src/vos/vos_io.c
+++ b/src/vos/vos_io.c
@@ -758,7 +758,7 @@ akey_update_recx(daos_handle_t toh, daos_epoch_t epoch, uint32_t pm_ver,
 		 daos_size_t rsize,
 		 struct vos_io_context *ioc)
 {
-	struct evt_entry_in ent;
+	struct evt_entry_in ent = {0};
 	struct bio_iov *biov;
 	int rc;
 

--- a/src/vos/vos_io.c
+++ b/src/vos/vos_io.c
@@ -758,7 +758,7 @@ akey_update_recx(daos_handle_t toh, daos_epoch_t epoch, uint32_t pm_ver,
 		 daos_size_t rsize,
 		 struct vos_io_context *ioc)
 {
-	struct evt_entry_in ent = {0};
+	struct evt_entry_in ent;
 	struct bio_iov *biov;
 	int rc;
 


### PR DESCRIPTION
Checksum related fields in evt_entry_in structure had
garbage values so would attempt to copy from or to invalid
memory.

Signed-off-by: Ryon Jensen <ryon.jensen@intel.com>