### PR TITLE
DAOS-WIP control: Log ioserver command on startup

### DIFF
--- a/src/control/server/iosrv.go
+++ b/src/control/server/iosrv.go
@@ -373,6 +373,8 @@ func (srv *iosrv) startCmd() error {
 
 	signal.Notify(srv.sigchld, syscall.SIGCHLD)
 
+	log.Debugf("args: %+v", srv.cmd.Args)
+	log.Debugf("env: %+v", srv.cmd.Env)
 	// Start the DAOS I/O server.
 	err = srv.cmd.Start()
 	if err != nil {

--- a/src/control/server/server.go
+++ b/src/control/server/server.go
@@ -94,6 +94,11 @@ func Main() error {
 		defer ctlLogFile.Close()
 	}
 
+	log.Debugf("cfg: %+v", config)
+	for _, srv := range config.Servers {
+		log.Debugf("ioSrv: %+v", srv)
+	}
+
 	// Create and setup control service.
 	mgmtCtlSvc, err := newControlService(
 		config, getDrpcClientConnection(config.SocketDir))


### PR DESCRIPTION
Log the cmdline/environment supplied to daos_io_server.

Signed-off-by: Michael MacDonald <mjmac.macdonald@intel.com>
Quick-build: true