### PR TITLE
DAOS-2666 arrays: fix bug where array read/write hang if OH is invalid

### DIFF
--- a/src/client/array/dc_array.c
+++ b/src/client/array/dc_array.c
@@ -1087,7 +1087,7 @@ dc_array_io(daos_handle_t array_oh, daos_handle_t th,
 
 	array = array_hdl2ptr(array_oh);
 	if (array == NULL)
-		return -DER_NO_HDL;
+		D_GOTO(err_task, rc = -DER_NO_HDL);
 
 	if (op_type == DAOS_OPC_ARRAY_PUNCH) {
 		D_ASSERT(user_sgl == NULL);

--- a/src/tests/suite/daos_array.c
+++ b/src/tests/suite/daos_array.c
@@ -27,7 +27,6 @@
  */
 
 #include <daos.h>
-#include <daos_array.h>
 #include "daos_test.h"
 
 /** number of elements to write to array */
@@ -229,7 +228,7 @@ small_io(void **state)
 	daos_array_iod_t iod;
 	d_sg_list_t	sgl;
 	daos_range_t	rg;
-	d_iov_t	iov;
+	d_iov_t		iov;
 	char		buf[BUFLEN], rbuf[BUFLEN];
 	daos_size_t	array_size;
 	int		rc;


### PR DESCRIPTION
- on error, the task should be completed

Signed-off-by: Mohamad Chaarawi <mohamad.chaarawi@intel.com>