### PR TITLE
DAOS-3085 control: Fix go test runner environment

### DIFF
--- a/src/control/run_go_tests.sh
+++ b/src/control/run_go_tests.sh
@@ -20,15 +20,15 @@ function find_build_source()
 
 function check_environment()
 {
-	if [ -z "$LD_LIBRARY_PATH" ]; then
+	if [ -z "${LD_LIBRARY_PATH:-}" ]; then
 		echo "false" && return
 	fi
 
-	if [ -z "$CGO_LDFLAGS" ]; then
+	if [ -z "${CGO_LDFLAGS:-}" ]; then
 		echo "false" && return
 	fi
 
-	if [ -z "$CGO_CFLAGS" ]; then
+	if [ -z "${CGO_CFLAGS:-}" ]; then
 		echo "false" && return
 	fi
 	echo "true" && return
@@ -44,10 +44,16 @@ function setup_environment()
 
 	source "${build_source}"
 
-	LD_LIBRARY_PATH="${SL_PREFIX}/lib:${SL_SPDK_PREFIX}/lib:${LD_LIBRARY_PATH}"
-	export LD_LIBRARY_PATH
-	export CGO_LDFLAGS="-L${SL_SPDK_PREFIX}/lib -L${SL_PREFIX}/lib"
-	export CGO_CFLAGS="-I${SL_SPDK_PREFIX}/include"
+	# ugh, appease the linter...
+	LD_LIBRARY_PATH=${SL_PREFIX}/lib
+	LD_LIBRARY_PATH="$LD_LIBRARY_PATH:${SL_SPDK_PREFIX}/lib"
+	LD_LIBRARY_PATH="$LD_LIBRARY_PATH:${SL_HWLOC_PREFIX}/lib"
+	CGO_LDFLAGS=-L${SL_PREFIX}/lib
+	CGO_LDFLAGS="$CGO_LDFLAGS -L${SL_SPDK_PREFIX}/lib"
+	CGO_LDFLAGS="$CGO_LDFLAGS -L${SL_HWLOC_PREFIX}/lib"
+	CGO_CFLAGS=-I${SL_PREFIX}/include
+	CGO_CFLAGS="$CGO_CFLAGS -I${SL_SPDK_PREFIX}/include"
+	CGO_CFLAGS="$CGO_CFLAGS -I${SL_HWLOC_PREFIX}/include"
 }
 
 check=$(check_environment)
@@ -56,10 +62,16 @@ if [ "$check" == "false" ]; then
 	setup_environment
 fi
 
+echo "Environment:"
+echo "  LD_LIBRARY_PATH: $LD_LIBRARY_PATH"
+echo "  CGO_LDFLAGS: $CGO_LDFLAGS"
+echo "  CGO_CFLAGS: $CGO_CFLAGS"
+
 DIR="$(readlink -f "$(dirname "${BASH_SOURCE[0]}")")"
 
 GOPATH="$(readlink -f "$DIR/../../build/src/control")"
-echo "GOPATH: $GOPATH"
+echo "  GOPATH: $GOPATH"
+echo
 
 repopath=github.com/daos-stack/daos
 controldir="$GOPATH/src/$repopath/src/control"
@@ -67,7 +79,11 @@ controldir="$GOPATH/src/$repopath/src/control"
 echo "Running all tests under $controldir..."
 pushd "$controldir" >/dev/null
 set +e
-GOPATH="$GOPATH" go test -race -cover -v ./...
+LD_LIBRARY_PATH="$LD_LIBRARY_PATH" \
+CGO_LDFLAGS="$CGO_LDFLAGS" \
+CGO_CFLAGS="$CGO_CFLAGS" \
+GOPATH="$GOPATH" \
+	go test -race -cover -v ./...
 testrc=$?
 popd >/dev/null
 


### PR DESCRIPTION
Missed this in local/CI testing because the variables were
set externally. In the case where build environment variables
need to be set, provide default empty values to avoid triggering
unset variable errors. Also adds hwloc path to environment.