### PR TITLE
DAOS-623 bio: Fix a typo due to uncaught merge conflict

### DIFF
--- a/src/bio/bio_buffer.c
+++ b/src/bio/bio_buffer.c
@@ -644,7 +644,7 @@ rw_completion(void *cb_arg, int err)
 			goto skip_media_error;
 		mem->mem_update = biod->bd_update;
 		mem->mem_bs = biod->bd_ctxt->bic_xs_ctxt->bxc_blobstore;
-		mem->mem_tgt_id = biod->bd_ctxt->bic_xs_ctxt->bxc_xs_id;
+		mem->mem_tgt_id = biod->bd_ctxt->bic_xs_ctxt->bxc_tgt_id;
 		spdk_thread_send_msg(owner_thread(mem->mem_bs), bio_media_error,
 				     mem);
 	}

--- a/src/bio/bio_context.c
+++ b/src/bio/bio_context.c
@@ -703,7 +703,7 @@ bio_blob_unmap(struct bio_io_context *ioctxt, uint64_t off, uint64_t len)
 			goto skip_media_error;
 		mem->mem_unmap = true;
 		mem->mem_bs = ioctxt->bic_xs_ctxt->bxc_blobstore;
-		mem->mem_tgt_id = ioctxt->bic_xs_ctxt->bxc_xs_id;
+		mem->mem_tgt_id = ioctxt->bic_xs_ctxt->bxc_tgt_id;
 		spdk_thread_send_msg(owner_thread(mem->mem_bs), bio_media_error,
 				     mem);
 	} else


### PR DESCRIPTION
Two patches were landed recently that updated the same code.
Pull #767 and #892 were landed without merging changes
so we get a compilation error.

Signed-off-by: Jeff Olivier <jeffrey.v.olivier@intel.com>