### PR TITLE
DAOS-3108 vos: Cache the DTX state in sorted iterator

### DIFF
--- a/src/include/daos_srv/evtree.h
+++ b/src/include/daos_srv/evtree.h
@@ -291,8 +291,8 @@ struct evt_entry {
 	bio_addr_t			en_addr;
 	/** update epoch of extent */
 	daos_epoch_t			en_epoch;
-	/** the returned evt_desc address for delete/iterator */
-	umem_off_t			en_desc;
+	/** availability check result for the entry */
+	int				en_avail_rc;
 };
 
 struct evt_list_entry {

--- a/src/vos/evt_iter.c
+++ b/src/vos/evt_iter.c
@@ -236,12 +236,10 @@ evt_iter_move(struct evt_context *tcx, struct evt_iterator *iter)
 
 			entry = evt_ent_array_get(&iter->it_entries,
 						  iter->it_index);
-			desc = evt_off2desc(tcx, entry->en_desc);
-			rc1 = evt_desc_log_status(tcx, desc, intent);
-			if (rc1 < 0)
-				return rc1;
+			if (entry->en_avail_rc < 0)
+				return entry->en_avail_rc;
 
-			if (rc1 == ALB_UNAVAILABLE)
+			if (entry->en_avail_rc == ALB_UNAVAILABLE)
 				continue;
 
 			if (iter->it_options & EVT_ITER_SKIP_HOLES &&
@@ -591,7 +589,8 @@ evt_iter_fetch(daos_handle_t ih, unsigned int *inob, struct evt_entry *entry,
 	rect  = evt_node_rect_at(tcx, node, trace->tr_at);
 
 	if (entry)
-		evt_entry_fill(tcx, node, trace->tr_at, NULL, entry);
+		evt_entry_fill(tcx, node, trace->tr_at, NULL,
+			       evt_iter_intent(iter), entry);
 set_anchor:
 	*inob = tcx->tc_inob;
 

--- a/src/vos/evt_priv.h
+++ b/src/vos/evt_priv.h
@@ -398,13 +398,14 @@ static inline struct evt_rect *evt_nd_off_rect_at(struct evt_context *tcx,
  * \param[IN]	node		The tree node
  * \param[IN]	at		The index in the node
  * \param[IN]	rect_srch	The original rectangle used for the search
+ * \param[IN]	intent		The operation intent
  * \param[OUT]	entry		The entry to fill
  *
  * The selected extent will be trimmed by the search rectangle used.
  */
 void evt_entry_fill(struct evt_context *tcx, struct evt_node *node,
 		    unsigned int at, const struct evt_rect *rect_srch,
-		    struct evt_entry *entry);
+		    uint32_t intent, struct evt_entry *entry);
 
 /**
  * Check whether the EVT record is available or not.

--- a/src/vos/evtree.c
+++ b/src/vos/evtree.c
@@ -1833,7 +1833,7 @@ out:
 void
 evt_entry_fill(struct evt_context *tcx, struct evt_node *node,
 	       unsigned int at, const struct evt_rect *rect_srch,
-	       struct evt_entry *entry)
+	       uint32_t intent, struct evt_entry *entry)
 {
 	struct evt_desc	   *desc;
 	struct evt_rect	   *rect;
@@ -1870,8 +1870,8 @@ evt_entry_fill(struct evt_context *tcx, struct evt_node *node,
 
 	entry->en_addr = desc->dc_ex_addr;
 	entry->en_ver = desc->dc_ver;
-	entry->en_desc = umem_ptr2off(evt_umm(tcx), desc);
 	evt_entry_csum_fill(tcx, desc, entry);
+	entry->en_avail_rc = evt_desc_log_status(tcx, desc, intent);
 
 	if (offset != 0) {
 		/* Adjust cached pointer since we're only referencing a
@@ -2040,7 +2040,7 @@ evt_ent_array_fill(struct evt_context *tcx, enum evt_find_opc find_opc,
 				goto out;
 			}
 
-			evt_entry_fill(tcx, node, i, rect, ent);
+			evt_entry_fill(tcx, node, i, rect, intent, ent);
 			switch (find_opc) {
 			default:
 				D_ASSERTF(0, "%d\n", find_opc);


### PR DESCRIPTION
For sorted iterator, we should cache the state at the time
it was taken.  This prevents potential to dereference stale
pointers internally.  The user can still mess up by dereferencing
the bio_addr_t but we leave this to aggregation to handle.

Traversing the iterator to pass a deleted cached entry isn't
necessarily a bug and we shouldn't crash if it happens.

Signed-off-by: Jeff Olivier <jeffrey.v.olivier@intel.com>