### PR TITLE
DAOS-1829 utils: Create systemd unit files

### DIFF
--- a/doc/admin/deployment.md
+++ b/doc/admin/deployment.md
@@ -1005,7 +1005,7 @@ systemctl start daos-server
 To check the component status use:
 systemctl status daos-server
 
-DAOS Agent failed to start check the logs with:
+If DAOS Server failed to start check the logs with:
 journalctl --unit daos-server
 ```
 
@@ -1283,7 +1283,7 @@ systemctl start daos-agent
 To check the component status use:
 systemctl status daos-agent
 
-DAOS Agent failed to start check the logs with:
+If DAOS Agent failed to start check the logs with:
 journalctl --unit daos-agent
 ```
 

--- a/doc/admin/deployment.md
+++ b/doc/admin/deployment.md
@@ -997,15 +997,16 @@ modify the ExecStart line to point to your in tree daos_server binary.
 
 Once the service file is installed you can start daos_server
 with the following commands:
-
 ```
 systemctl enable daos-server
 systemctl start daos-server
-
+```
 To check the component status use:
+```
 systemctl status daos-server
-
+```
 If DAOS Server failed to start check the logs with:
+```
 journalctl --unit daos-server
 ```
 
@@ -1279,11 +1280,13 @@ with the following commands:
 ```
 systemctl enable daos-agent
 systemctl start daos-agent
-
+```
 To check the component status use:
+```
 systemctl status daos-agent
-
+```
 If DAOS Agent failed to start check the logs with:
+```
 journalctl --unit daos-agent
 ```
 

--- a/doc/admin/deployment.md
+++ b/doc/admin/deployment.md
@@ -985,10 +985,29 @@ TODO: add instructions
 
 ### Systemd Integration
 
-A preliminary systemd script to manage the DAOS server is available
-under utils/system. That being said, this startup method is not
-supported yet since the current DAOS version still relies on PMIx for
-DAOS server wireup.
+Systemd support for daos_server is still experimental as it will start the
+daos_server and daos_io_server components in PMIXless mode which is still in
+development.
+
+DAOS Server can be started as a systemd service. The DAOS Server
+unit file is installed in the correct location when installing from RPMs.
+If you wish to use systemd with a development build you must copy the service
+file from utils/systemd to /usr/lib/systemd/system. Once the file is copied
+modify the ExecStart line to point to your in tree daos_server binary.
+
+Once the service file is installed you can start daos_server
+with the following commands:
+
+```
+systemctl enable daos-server
+systemctl start daos-server
+
+To check the component status use:
+systemctl status daos-server
+
+DAOS Agent failed to start check the logs with:
+journalctl --unit daos-server
+```
 
 ### Kubernetes Pod
 
@@ -1243,9 +1262,29 @@ to communicate with the control plane over unencrypted channels. The following
 example shows daos_agent being configured to operate in insecure mode due to
 incomplete integration of certificate support as of the 0.6 release.
 
-To start the DAOS Agent, run:
+To start the DAOS Agent from the command line, run:
 ```
 daos_agent -i
+```
+
+Alternatively the DAOS Agent can be started as a systemd service. The DAOS Agent
+unit file is installed in the correct location when installing from RPMs.
+If you wish to use systemd with a development build you must copy the service
+file from utils/systemd to /usr/lib/systemd/system. Once the file is copied
+modify the ExecStart line to point to your in tree daos_agent binary.
+
+Once the service file is installed you can start daos_agent
+with the following commands:
+
+```
+systemctl enable daos-agent
+systemctl start daos-agent
+
+To check the component status use:
+systemctl status daos-agent
+
+DAOS Agent failed to start check the logs with:
+journalctl --unit daos-agent
 ```
 
 System Validation

--- a/utils/rpms/daos.spec
+++ b/utils/rpms/daos.spec
@@ -5,7 +5,7 @@
 
 Name:          daos
 Version:       0.6.0
-Release:       3%{?relval}%{?dist}
+Release:       4%{?relval}%{?dist}
 Summary:       DAOS Storage Engine
 
 License:       Apache
@@ -34,6 +34,7 @@ BuildRequires: libevent-devel
 BuildRequires: libyaml-devel
 BuildRequires: libcmocka-devel
 BuildRequires: readline-devel
+BuildRequires: systemd
 %if (0%{?rhel} >= 7)
 BuildRequires:  numactl-devel
 BuildRequires: CUnit-devel
@@ -141,6 +142,9 @@ cp -al src/utils/py/daos_cref.py %{?buildroot}%{daoshome}/utils/py
 cp -al src/utils/py/conversion.py %{?buildroot}%{daoshome}/utils/py
 mkdir -p %{?buildroot}/%{_sysconfdir}/ld.so.conf.d/
 echo "%{_libdir}/daos_srv" > %{?buildroot}/%{_sysconfdir}/ld.so.conf.d/daos.conf
+mkdir -p %{?buildroot}/%{_unitdir}
+install -m 644 utils/systemd/daos-server.service %{?buildroot}/%{_unitdir}
+install -m 644 utils/systemd/daos-agent.service %{?buildroot}/%{_unitdir}
 
 %post server -p /sbin/ldconfig
 %postun server -p /sbin/ldconfig
@@ -185,6 +189,7 @@ echo "%{_libdir}/daos_srv" > %{?buildroot}/%{_sysconfdir}/ld.so.conf.d/daos.conf
 %{_libdir}/daos_srv/libsecurity.so
 %{_libdir}/daos_srv/libvos_srv.so
 %{_datadir}/%{name}
+%{_unitdir}/daos-server.service
 
 %files client
 %{_bindir}/daos_shell
@@ -203,6 +208,7 @@ echo "%{_libdir}/daos_srv" > %{?buildroot}/%{_sysconfdir}/ld.so.conf.d/daos.conf
 %{_datadir}/%{name}/ioil-ld-opts
 %{_prefix}%{_sysconfdir}/daos.yml
 %{_prefix}%{_sysconfdir}/daos_agent.yml
+%{_unitdir}/daos-agent.service
 
 %files tests
 %{daoshome}/utils/py
@@ -226,6 +232,9 @@ echo "%{_libdir}/daos_srv" > %{?buildroot}/%{_sysconfdir}/ld.so.conf.d/daos.conf
 %{_libdir}/*.a
 
 %changelog
+* Thu Aug 15 2019 David Quigley <david.quigley@intel.com>
+- Add systemd unit files to packaging.
+
 * Thu Jul 25 2019 Brian J. Murrell <brian.murrell@intel.com>
 - Add git hash and commit count to release
 

--- a/utils/systemd/daos-agent.service
+++ b/utils/systemd/daos-agent.service
@@ -8,6 +8,7 @@ Type=simple
 RuntimeDirectory=daos_agent
 RuntimeDirectoryMode=0755
 #Only specify if you are running out of your development Tree
+#Also comment out the default ExecStart line
 #ExecStart=/<path to>/install/bin/daos_agent -i
 ExecStart=/usr/bin/daos_agent -i
 StandardOutput=journal

--- a/utils/systemd/daos-agent.service
+++ b/utils/systemd/daos-agent.service
@@ -1,16 +1,15 @@
 [Unit]
-Description=DAOS Server
+Description=DAOS Agent
 Wants=network-online.target
 After=network-online.target
 
 [Service]
 Type=simple
-RuntimeDirectory=daos_server
+RuntimeDirectory=daos_agent
 RuntimeDirectoryMode=0755
 #Only specify if you are running out of your development Tree
-#Also comment out the default ExecStart line
-#ExecStart=/<path to>/install/bin/daos_server -t 1 -i
-ExecStart=/usr/bin/daos_server -t 1 -i
+#ExecStart=/<path to>/install/bin/daos_agent -i
+ExecStart=/usr/bin/daos_agent -i
 StandardOutput=journal
 StandardError=journal
-Restart=on-failure
+Restart=always

--- a/utils/systemd/daos-server.service
+++ b/utils/systemd/daos-server.service
@@ -9,8 +9,8 @@ RuntimeDirectory=daos_server
 RuntimeDirectoryMode=0755
 #Only specify if you are running out of your development Tree
 #Also comment out the default ExecStart line
-#ExecStart=/<path to>/install/bin/daos_server -t 1 -i
-ExecStart=/usr/bin/daos_server -t 1 -i
+#ExecStart=/<path to>/install/bin/daos_server -i
+ExecStart=/usr/bin/daos_server -i
 StandardOutput=journal
 StandardError=journal
 Restart=on-failure


### PR DESCRIPTION
This commit adds unit files for daos_agent and daos_server. They are installed
in the correct locations when building the RPMs. If you want to use them with a
development build you must copy the service files from utils/systemd to
/usr/lib/systemd/system. Once they are copied modify the ExecStart line to
point to your in tree daos_server and daos_agent binaries.

Once the service files are installed you can start daos_server and daos_agent
with the following commands:

systemctl enable daos-agent
systemctl enable daos-server
systemctl start daos-agent
systemctl start daos-server

To check the component status use
systemctl status daos-agent
systemctl status daos-server

If either component failed to start check the logs with
journalctl --unit daos-agent
journalctl --unit daos-server

Signed-off-by: David Quigley <david.quigley@intel.com>