### PR TITLE
DAOS-3135 test: Disable MdtestSmall.test_mdtest_small

### DIFF
--- a/src/tests/ftest/io/mdtest_small.py
+++ b/src/tests/ftest/io/mdtest_small.py
@@ -42,7 +42,7 @@ class MdtestSmall(MdtestBase):
             write bytes: 0|4K
             read bytes: 0|4K
             depth of hierarchical directory structure: 0|5
-        :avocado: tags=all,pr,vm,mdtest,mdtestsmall
+        :avocado: tags=all,mdtest,mdtestsmall
         """
         mdtest_flags = self.params.get("flags", "/run/mdtest/*")
         self.mdtest_cmd.flags.update(mdtest_flags)


### PR DESCRIPTION
Until it's intermittent failure cause can be resolved.

Signed-off-by: Brian J. Murrell <brian.murrell@intel.com>