### PR TITLE
DAOS-3146 build: fix broken master build due to merge conflict

### DIFF
--- a/src/control/server/commands.go
+++ b/src/control/server/commands.go
@@ -85,14 +85,14 @@ func (s *ScanStorCmd) Execute(args []string) (errs error) {
 		log.Error("nvme scan: " + resp.Nvmestate.Error)
 		isErrored = true
 	} else {
-		fmt.Printf("\nNVMe SSD controller and constituent namespaces:\n%s",
+		log.Infof("\nNVMe SSD controller and constituent namespaces:\n%s",
 			srv.nvme.controllers)
 	}
 	if resp.Scmstate.Status != pb.ResponseStatus_CTRL_SUCCESS {
 		log.Error("scm scan: " + resp.Scmstate.Error)
 		isErrored = true
 	} else {
-		fmt.Printf("\nSCM modules:\n%s", srv.scm.modules)
+		log.Infof("\nSCM modules:\n%s", srv.scm.modules)
 	}
 
 	if isErrored {


### PR DESCRIPTION
Master build broken due to simultaneous landing of
462aae1f25d384ccded4e5a381df5321676015cd and
0056b96bd727c3062bd37e96db48d50292e5a1fc causing conflict.

Signed-off-by: Tom Nabarro <tom.nabarro@intel.com>