### PR TITLE
DAOS-3140 build: Have Leap15 auto update.

### DIFF
--- a/utils/docker/Dockerfile.leap.15
+++ b/utils/docker/Dockerfile.leap.15
@@ -6,7 +6,7 @@
 #
 
 # Pull base image
-FROM opensuse/leap:15.0
+FROM opensuse/leap:15
 MAINTAINER Johann Lombardi <johann.lombardi@intel.com>
 
 # Build arguments can be set via -build-arg


### PR DESCRIPTION
Change the Dockerfile for Leap 15 to use the latest Leap15.x release
to make it compatible with how we do CentOS 7.

Signed-off-by: John.E.Malmberg <john.e.malmberg@intel.com>