### PR TITLE
DAOS-3148 evtree: Mark entries punched by outer layer as EVT_COVERED

### DIFF
--- a/src/include/daos_srv/evtree.h
+++ b/src/include/daos_srv/evtree.h
@@ -121,6 +121,8 @@ struct evt_rect {
 struct evt_filter {
 	struct evt_extent	fr_ex;	/**< extent range */
 	daos_epoch_range_t	fr_epr;	/**< epoch range */
+	/** higher level punch epoch (0 if not punched) */
+	daos_epoch_t		fr_punch;
 };
 
 /** Log format of extent */
@@ -150,11 +152,11 @@ struct evt_filter {
 
 /** Log format of evtree filter */
 #define DF_FILTER			\
-	DF_EXT "@" DF_U64"-"DF_U64
+	DF_EXT "@" DF_U64"-"DF_U64"(punch="DF_U64")"
 
 #define DP_FILTER(filter)					\
 	DP_EXT(&(filter)->fr_ex), (filter)->fr_epr.epr_lo,	\
-	(filter)->fr_epr.epr_hi
+	(filter)->fr_epr.epr_hi, (filter)->fr_punch
 
 /** Return the width of an extent */
 static inline daos_size_t

--- a/src/vos/evt_iter.c
+++ b/src/vos/evt_iter.c
@@ -95,6 +95,7 @@ evt_iter_prepare(daos_handle_t toh, unsigned int options,
 	iter->it_filter.fr_ex.ex_lo = 0;
 	iter->it_filter.fr_epr.epr_lo = 0;
 	iter->it_filter.fr_epr.epr_hi = DAOS_EPOCH_MAX;
+	iter->it_filter.fr_punch = 0;
 	if (filter)
 		iter->it_filter = *filter;
  out:
@@ -328,7 +329,7 @@ evt_iter_probe_sorted(struct evt_context *tcx, struct evt_iterator *iter,
 	rc = evt_ent_array_fill(tcx, EVT_FIND_ALL, intent, &iter->it_filter,
 				&rtmp, enta);
 	if (rc == 0)
-		rc = evt_ent_array_sort(tcx, enta, flags);
+		rc = evt_ent_array_sort(tcx, enta, &iter->it_filter, flags);
 
 	if (rc != 0)
 		return rc;
@@ -591,6 +592,12 @@ evt_iter_fetch(daos_handle_t ih, unsigned int *inob, struct evt_entry *entry,
 	if (entry)
 		evt_entry_fill(tcx, node, trace->tr_at, NULL,
 			       evt_iter_intent(iter), entry);
+
+	/* There is no visiblity flag for sorted entries but go ahead and set it
+	 * EVT_COVERED if user has specified a punch epoch in the filter
+	 */
+	if (entry->en_epoch <= iter->it_filter.fr_punch)
+		entry->en_visibility = EVT_COVERED;
 set_anchor:
 	*inob = tcx->tc_inob;
 

--- a/src/vos/evt_priv.h
+++ b/src/vos/evt_priv.h
@@ -307,6 +307,7 @@ evt_ent2rect(struct evt_rect *rect, const struct evt_entry *ent)
 /** Sort entries in an entry array
  * \param[IN]		tcx		The evtree context
  * \param[IN, OUT]	ent_array	The entry array to sort
+ * \param[IN]		filter		The evt_filter for upper layer punch
  * \param[IN]		flags		Visibility flags
  *					EVT_VISIBLE: Return visible records
  *					EVT_COVERED: Return covered records
@@ -314,7 +315,9 @@ evt_ent2rect(struct evt_rect *rect, const struct evt_entry *ent)
  * be sorted by start offset, high epoch
  */
 int evt_ent_array_sort(struct evt_context *tcx,
-		       struct evt_entry_array *ent_array, int flags);
+		       struct evt_entry_array *ent_array,
+		       const struct evt_filter *filter,
+		       int flags);
 /** Scan the tree and select all rectangles that match
  * \param[IN]		tcx		The evtree context
  * \param[IN]		opc		The opcode for the scan
@@ -395,6 +398,7 @@ static inline struct evt_rect *evt_nd_off_rect_at(struct evt_context *tcx,
 
 /** Fill an evt_entry from the record at an index in a tree node
  * \param[IN]	tcx		The evtree context
+ * \param[IN]	filter		The passed filter for punched epoch
  * \param[IN]	node		The tree node
  * \param[IN]	at		The index in the node
  * \param[IN]	rect_srch	The original rectangle used for the search

--- a/src/vos/evtree.c
+++ b/src/vos/evtree.c
@@ -705,7 +705,7 @@ evt_find_visible(struct evt_context *tcx, struct evt_entry_array *ent_array,
  */
 int
 evt_ent_array_sort(struct evt_context *tcx, struct evt_entry_array *ent_array,
-		   int flags)
+		   const struct evt_filter *filter, int flags)
 {
 	struct evt_list_entry	*ents;
 	struct evt_entry	*ent;
@@ -743,6 +743,20 @@ evt_ent_array_sort(struct evt_context *tcx, struct evt_entry_array *ent_array,
 	}
 
 re_sort:
+	if (filter && filter->fr_punch != 0) {
+		/** If items are punched by outer layer, mark them covered */
+		evt_ent_array_for_each(ent, ent_array) {
+			if (ent->en_epoch > filter->fr_punch)
+				continue;
+			if (evt_flags_get(ent->en_visibility) == EVT_COVERED)
+				continue;
+			ent->en_visibility ^= EVT_VISIBLE;
+			ent->en_visibility |= EVT_COVERED;
+			D_ASSERT(evt_flags_equal(ent->en_visibility,
+						 EVT_COVERED));
+		}
+	}
+
 	ents = ent_array->ea_ents;
 	total = ent_array->ea_ent_nr;
 	compar = evt_ent_list_cmp;
@@ -1786,6 +1800,7 @@ evt_insert(daos_handle_t toh, const struct evt_entry_in *entry)
 	filter.fr_ex = entry->ei_rect.rc_ex;
 	filter.fr_epr.epr_lo = entry->ei_rect.rc_epc;
 	filter.fr_epr.epr_hi = entry->ei_rect.rc_epc;
+	filter.fr_punch = 0;
 	/* Phase-1: Check for overwrite */
 	rc = evt_ent_array_fill(tcx, EVT_FIND_OVERWRITE, DAOS_INTENT_UPDATE,
 				&filter, &entry->ei_rect, &ent_array);
@@ -1831,9 +1846,9 @@ out:
 
 /** Fill the entry with the extent at the specified position of \a node */
 void
-evt_entry_fill(struct evt_context *tcx, struct evt_node *node,
-	       unsigned int at, const struct evt_rect *rect_srch,
-	       uint32_t intent, struct evt_entry *entry)
+evt_entry_fill(struct evt_context *tcx, struct evt_node *node, unsigned int at,
+	       const struct evt_rect *rect_srch, uint32_t intent,
+	       struct evt_entry *entry)
 {
 	struct evt_desc	   *desc;
 	struct evt_rect	   *rect;
@@ -2118,12 +2133,13 @@ evt_find(daos_handle_t toh, const daos_epoch_range_t *epr,
 	evt_ent_array_init(ent_array);
 	rect.rc_ex = filter.fr_ex = *extent;
 	filter.fr_epr = *epr;
+	filter.fr_punch = 0;
 	rect.rc_epc = epr->epr_hi;
 
 	rc = evt_ent_array_fill(tcx, EVT_FIND_ALL, DAOS_INTENT_DEFAULT,
 				&filter, &rect, ent_array);
 	if (rc == 0)
-		rc = evt_ent_array_sort(tcx, ent_array, EVT_VISIBLE);
+		rc = evt_ent_array_sort(tcx, ent_array, NULL, EVT_VISIBLE);
 	if (rc != 0)
 		evt_ent_array_fini(ent_array);
 	return rc;
@@ -2953,6 +2969,7 @@ int evt_delete(daos_handle_t toh, const struct evt_rect *rect,
 	filter.fr_ex = rect->rc_ex;
 	filter.fr_epr.epr_lo = rect->rc_epc;
 	filter.fr_epr.epr_hi = rect->rc_epc;
+	filter.fr_punch = 0;
 	rc = evt_ent_array_fill(tcx, EVT_FIND_SAME, DAOS_INTENT_PUNCH,
 				&filter, rect, &ent_array);
 	if (rc != 0)

--- a/src/vos/vos_obj.c
+++ b/src/vos/vos_obj.c
@@ -802,7 +802,7 @@ recx_iter_prepare(struct vos_obj_iter *oiter, daos_key_t *dkey,
 		  daos_key_t *akey)
 {
 	struct vos_object	*obj = oiter->it_obj;
-	struct evt_filter	 filter;
+	struct evt_filter	 filter = {0};
 	daos_handle_t		 dk_toh;
 	daos_handle_t		 ak_toh;
 	int			 rc;
@@ -1087,7 +1087,7 @@ vos_obj_iter_nested_prep(vos_iter_type_t type, struct vos_iter_info *info,
 	struct vos_object	*obj = info->ii_obj;
 	struct vos_obj_iter	*oiter;
 	struct evt_desc_cbs	 cbs;
-	struct evt_filter	 filter;
+	struct evt_filter	 filter = {0};
 	daos_handle_t		 toh;
 	int			 rc = 0;
 	uint32_t		 options;

--- a/src/vos/vos_query.c
+++ b/src/vos/vos_query.c
@@ -129,7 +129,7 @@ query_recx(struct open_query *query, daos_recx_t *recx)
 	struct evt_entry	entry;
 	daos_handle_t		toh;
 	daos_handle_t		ih;
-	struct evt_filter	filter;
+	struct evt_filter	filter = {0};
 	int			rc;
 	int			close_rc;
 	int			opc;


### PR DESCRIPTION
This will simplify iteration for aggregation in the punch model
change.   It simply does a pass on the array to mark any entries
punched by an object or key as EVT_COVERED so aggregation can remove
them accordingly.

Signed-off-by: Jeff Olivier <jeffrey.v.olivier@intel.com>