### PR TITLE
DAOS-3144 vos: Partial revert of #969

### DIFF
--- a/src/vos/vos_aggregate.c
+++ b/src/vos/vos_aggregate.c
@@ -239,15 +239,6 @@ vos_agg_obj(daos_handle_t ih, vos_iter_entry_t *entry,
 	}
 
 	if (agg_param->ap_discard) {
-		if (agg_param->ap_sub_tree_empty) {
-			struct vos_obj_iter	*oiter = vos_hdl2oiter(ih);
-			struct vos_object	*obj = oiter->it_obj;
-
-			D_ASSERT(daos_unit_oid_compare(obj->obj_id,
-						       entry->ie_oid) == 0);
-			vos_obj_evict(obj);
-		}
-
 		rc = agg_discard_parent(ih, entry, agg_param, acts);
 		agg_param->ap_sub_tree_empty = 0;
 		return rc;

--- a/utils/docker/Dockerfile.leap.15
+++ b/utils/docker/Dockerfile.leap.15
@@ -6,7 +6,7 @@
 #
 
 # Pull base image
-FROM opensuse/leap:15.0
+FROM opensuse/leap:15
 MAINTAINER Johann Lombardi <johann.lombardi@intel.com>
 
 # Build arguments can be set via -build-arg


### PR DESCRIPTION
It added an assertion that causes vos_tests to fail.  There must be
a conflict with a later patch.   Reverting just the part that causes
the failure

Signed-off-by: Jeff Olivier <jeffrey.v.olivier@intel.com>