### PR TITLE
DAOS-3147 mgmt: pack user and group in drpc create pool handler

### DIFF
--- a/src/mgmt/cli_pool.c
+++ b/src/mgmt/cli_pool.c
@@ -136,6 +136,10 @@ add_ownership_props(daos_prop_t **prop_out, daos_prop_t *prop_in,
 
 	/* We always free this prop in the callback - so need to make a copy */
 	final_prop = daos_prop_alloc(entries);
+	if (final_prop == NULL) {
+		D_ERROR("failed to allocate props");
+		D_GOTO(err_out, -DER_NOMEM);
+	}
 
 	if (prop_in != NULL) {
 		rc = daos_prop_copy(final_prop, prop_in);


### PR DESCRIPTION
Pack formatted user and group names received from control plane
into the property structure in drpc create pool internal call so that
created pool has an owner and group.

Signed-off-by: Tom Nabarro <tom.nabarro@intel.com>