### PR TITLE
DAOS-3126 tests: Fix timeouts for daos_agent and ssh

### DIFF
--- a/src/tests/ftest/util/agent_utils.py
+++ b/src/tests/ftest/util/agent_utils.py
@@ -88,13 +88,14 @@ def run_agent(basepath, server_list, client_list=None):
 
     for client in client_list:
         sessions[client] = subprocess.Popen(
-            ["ssh", client, "{} -i".format(daos_agent_bin)],
+            ["ssh", client, "-o ConnectTimeout=10",
+	    "{} -i".format(daos_agent_bin)],
             stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE
+            stderr=subprocess.STDOUT
         )
 
     # double check agent launched successfully
-    timeout = 5
+    timeout = 15
     started_clients = []
     for client in client_list:
         file_desc = sessions[client].stdout.fileno()


### PR DESCRIPTION
agent_utils.py attempts to start daos_agent with ssh and this may ocassional
cause errors. If the agent timeout is hit before ssh times out it will appear
that the agent hung when it was ssh. To be able to differentiate between an
agent startup hang and an ssh timeout the timeout for agent startup has been
raised to 15 seconds from 5 seconds and the timeout for ssh connect has been
lowered to 10 seconds from the system default TCP timeout of 20 seconds.

Signed-off-by: David Quigley <david.quigley@intel.com>