### PR TITLE
DAOS-3145 rebuild: report rebuild status

### DIFF
--- a/src/rebuild/srv.c
+++ b/src/rebuild/srv.c
@@ -1758,7 +1758,7 @@ rebuild_tgt_status_check(void *arg)
 			rpt->rt_global_scan_done, rpt->rt_global_done,
 			iv.riv_status);
 
-		if (rpt->rt_global_done || rpt->rt_abort)
+		if (rpt->rt_global_done)
 			break;
 	}
 


### PR DESCRIPTION
Since the rebuild leader needs to track every
server rebuild status then decide to stop/abort
the pool rebuild.

So once rebuild fails locally, each server needs
to report its status to the leader, then wait for
leader to let it abort the local rebuild, instead
of abort rebuild by itself, which might make leader
wait forever.

Signed-off-by: Wang Di <di.wang@intel.com>