### PR TITLE
DAOS-3154 utils: Fix enable/disable on systemd unit files

### DIFF
--- a/utils/systemd/daos-agent.service
+++ b/utils/systemd/daos-agent.service
@@ -14,3 +14,6 @@ ExecStart=/usr/bin/daos_agent -i
 StandardOutput=journal
 StandardError=journal
 Restart=always
+
+[Install]
+WantedBy = multi-user.target

--- a/utils/systemd/daos-server.service
+++ b/utils/systemd/daos-server.service
@@ -14,3 +14,6 @@ ExecStart=/usr/bin/daos_server -i
 StandardOutput=journal
 StandardError=journal
 Restart=on-failure
+
+[Install]
+WantedBy = multi-user.target


### PR DESCRIPTION
Commit adds an install target so systemctl enable/disable work.

Signed-off-by: David Quigley <david.quigley@intel.com>