### PR TITLE
DAOS-1540 control: Add logging.Logger interface

### DIFF
--- a/src/control/logging/logger.go
+++ b/src/control/logging/logger.go
@@ -28,6 +28,16 @@ import (
 )
 
 type (
+	// Logger defines a standard logging interface
+	Logger interface {
+		DebugLogger
+		Debug(msg string)
+		InfoLogger
+		Info(msg string)
+		ErrorLogger
+		Error(msg string)
+	}
+
 	// DebugLogger defines an interface to be implemented
 	// by Debug loggers.
 	DebugLogger interface {

--- a/src/control/server/iosrv.go
+++ b/src/control/server/iosrv.go
@@ -47,6 +47,7 @@ import (
 	mgmtpb "github.com/daos-stack/daos/src/control/common/proto/mgmt"
 	srvpb "github.com/daos-stack/daos/src/control/common/proto/srv"
 	"github.com/daos-stack/daos/src/control/drpc"
+	"github.com/daos-stack/daos/src/control/logging"
 	log "github.com/daos-stack/daos/src/control/logging"
 	"github.com/daos-stack/daos/src/control/security"
 )
@@ -257,7 +258,7 @@ func writeIosrvSuper(path string, super *iosrvSuper) error {
 //
 // NOTE: The superblock supercedes the format-time configuration in config.
 type iosrv struct {
-	log     serverLogger
+	log     logging.Logger
 	super   *iosrvSuper
 	config  *Configuration
 	index   int
@@ -267,7 +268,7 @@ type iosrv struct {
 	conn    *drpc.ClientConnection
 }
 
-func newIosrv(logger serverLogger, config *Configuration, i int) (*iosrv, error) {
+func newIosrv(logger logging.Logger, config *Configuration, i int) (*iosrv, error) {
 	super, err := readIosrvSuper(iosrvSuperPath(config.Servers[i].ScmMount))
 	if err != nil {
 		return nil, err

--- a/src/control/server/server.go
+++ b/src/control/server/server.go
@@ -38,15 +38,6 @@ import (
 	"github.com/daos-stack/daos/src/control/security/acl"
 )
 
-type serverLogger interface {
-	Debug(string)
-	Debugf(string, ...interface{})
-	Info(string)
-	Infof(string, ...interface{})
-	Error(string)
-	Errorf(string, ...interface{})
-}
-
 // Start is the entry point for a daos_server instance.
 func Start(log *logging.LeveledLogger, config *Configuration) error {
 	// FIXME(mjmac): Temporarily set a global logger


### PR DESCRIPTION
This was an oversight. While it's true that packages
could define their own logging interface, in practice
everything is likely to use the methods defined in
this one.