### PR TITLE
DAOS-3157 smd: use ABT mutex instead of pthread rwlock

### DIFF
--- a/src/bio/smd/smd_internal.h
+++ b/src/bio/smd/smd_internal.h
@@ -30,6 +30,7 @@
 #ifndef __SMD_INTERNAL_H__
 #define __SMD_INTERNAL_H__
 
+#include <abt.h>
 #include <daos_types.h>
 #include <daos/btree.h>
 #include <daos/mem.h>
@@ -54,7 +55,7 @@ struct smd_df {
 /* SMD store (DRAM structure) */
 struct smd_store {
 	struct umem_instance	ss_umm;
-	pthread_rwlock_t	ss_rwlock;
+	ABT_mutex		ss_mutex;
 	daos_handle_t		ss_dev_hdl;
 	daos_handle_t		ss_pool_hdl;
 	daos_handle_t		ss_tgt_hdl;
@@ -82,6 +83,18 @@ smd_tx_end(struct smd_store *store, int rc)
 		return umem_tx_abort(&store->ss_umm, rc);
 
 	return umem_tx_commit(&store->ss_umm);
+}
+
+static inline void
+smd_lock(struct smd_store *store)
+{
+	ABT_mutex_lock(store->ss_mutex);
+}
+
+static inline void
+smd_unlock(struct smd_store *store)
+{
+	ABT_mutex_unlock(store->ss_mutex);
 }
 
 extern struct smd_store		smd_store;

--- a/src/bio/smd/smd_pool.c
+++ b/src/bio/smd/smd_pool.c
@@ -55,7 +55,7 @@ smd_pool_assign(uuid_t pool_id, int tgt_id, uint64_t blob_id)
 	D_ASSERT(!daos_handle_is_inval(smd_store.ss_pool_hdl));
 
 	uuid_copy(key_pool.uuid, pool_id);
-	D_RWLOCK_WRLOCK(&smd_store.ss_rwlock);
+	smd_lock(&smd_store);
 
 	/* Fetch pool if it's already existing */
 	d_iov_set(&key, &key_pool, sizeof(key_pool));
@@ -98,7 +98,7 @@ smd_pool_assign(uuid_t pool_id, int tgt_id, uint64_t blob_id)
 		goto out;
 	}
 out:
-	D_RWLOCK_UNLOCK(&smd_store.ss_rwlock);
+	smd_unlock(&smd_store);
 	return rc;
 }
 
@@ -115,7 +115,7 @@ smd_pool_unassign(uuid_t pool_id, int tgt_id)
 	D_ASSERT(!daos_handle_is_inval(smd_store.ss_pool_hdl));
 
 	uuid_copy(key_pool.uuid, pool_id);
-	D_RWLOCK_WRLOCK(&smd_store.ss_rwlock);
+	smd_lock(&smd_store);
 
 	d_iov_set(&key, &key_pool, sizeof(key_pool));
 	d_iov_set(&val, &entry, sizeof(entry));
@@ -162,7 +162,7 @@ smd_pool_unassign(uuid_t pool_id, int tgt_id)
 				DP_UUID(&key_pool.uuid), rc);
 	}
 out:
-	D_RWLOCK_UNLOCK(&smd_store.ss_rwlock);
+	smd_unlock(&smd_store);
 	return rc;
 }
 
@@ -211,7 +211,7 @@ smd_pool_get(uuid_t pool_id, struct smd_pool_info **pool_info)
 	D_ASSERT(!daos_handle_is_inval(smd_store.ss_pool_hdl));
 
 	uuid_copy(key_pool.uuid, pool_id);
-	D_RWLOCK_RDLOCK(&smd_store.ss_rwlock);
+	smd_lock(&smd_store);
 
 	d_iov_set(&key, &key_pool, sizeof(key_pool));
 	d_iov_set(&val, &entry, sizeof(entry));
@@ -230,7 +230,7 @@ smd_pool_get(uuid_t pool_id, struct smd_pool_info **pool_info)
 	}
 	*pool_info = info;
 out:
-	D_RWLOCK_UNLOCK(&smd_store.ss_rwlock);
+	smd_unlock(&smd_store);
 	return rc;
 }
 
@@ -245,28 +245,29 @@ smd_pool_get_blob(uuid_t pool_id, int tgt_id, uint64_t *blob_id)
 	D_ASSERT(!daos_handle_is_inval(smd_store.ss_pool_hdl));
 
 	uuid_copy(key_pool.uuid, pool_id);
-	D_RWLOCK_RDLOCK(&smd_store.ss_rwlock);
+	smd_lock(&smd_store);
 
 	d_iov_set(&key, &key_pool, sizeof(key_pool));
 	d_iov_set(&val, &entry, sizeof(entry));
 	rc = dbtree_fetch(smd_store.ss_pool_hdl, BTR_PROBE_EQ,
 			  DAOS_INTENT_DEFAULT, &key, NULL, &val);
 	if (rc) {
-		D_ERROR("Fetch pool "DF_UUID" failed. %d\n",
-			DP_UUID(&key_pool.uuid), rc);
+		D_CDEBUG(rc != -DER_NONEXIST, DLOG_ERR, DB_MGMT,
+			 "Fetch pool "DF_UUID" failed. %d\n",
+			 DP_UUID(&key_pool.uuid), rc);
 		goto out;
 	}
 
 	tgt_idx = get_tgt_idx(&entry, tgt_id);
 	if (tgt_idx == -1) {
-		D_ERROR("Pool "DF_UUID" target %d not found.\n",
+		D_DEBUG(DB_MGMT, "Pool "DF_UUID" target %d not found.\n",
 			DP_UUID(key_pool.uuid), tgt_id);
 		rc = -DER_NONEXIST;
 		goto out;
 	}
 	*blob_id = entry.spe_blobs[tgt_idx];
 out:
-	D_RWLOCK_UNLOCK(&smd_store.ss_rwlock);
+	smd_unlock(&smd_store);
 	return rc;
 }
 
@@ -283,7 +284,7 @@ smd_pool_list(d_list_t *pool_list)
 	D_ASSERT(pool_list && d_list_empty(pool_list));
 	D_ASSERT(!daos_handle_is_inval(smd_store.ss_pool_hdl));
 
-	D_RWLOCK_RDLOCK(&smd_store.ss_rwlock);
+	smd_lock(&smd_store);
 
 	rc = dbtree_iter_prepare(smd_store.ss_pool_hdl, 0, &iter_hdl);
 	if (rc) {
@@ -331,6 +332,6 @@ smd_pool_list(d_list_t *pool_list)
 done:
 	dbtree_iter_finish(iter_hdl);
 out:
-	D_RWLOCK_UNLOCK(&smd_store.ss_rwlock);
+	smd_unlock(&smd_store);
 	return rc;
 }

--- a/src/bio/smd/tests/SConscript
+++ b/src/bio/smd/tests/SConscript
@@ -6,7 +6,7 @@ def scons():
     Import('denv')
 
     libraries = ['smd', 'pmemobj', 'cmocka', 'daos_common',
-                 'uuid', 'pthread', 'gurt']
+                 'uuid', 'abt', 'gurt']
 
     denv.AppendUnique(LIBPATH=['..'])
     smd_ut = daos_build.test(denv, 'smd_ut', 'smd_ut.c', LIBS=libraries)


### PR DESCRIPTION
Repalce pthread rwlock with ABT mutex to serializing SMD access,
since dbtree fetch isn't thread safe, we can't allow concurrent
fetch to same dbtree. Furthermore, pthread lock could block the
whole xstream so it shouldn't be used in server stack.

This patch also supressed some unnecessary 'nonexistent' errors.

Signed-off-by: Niu Yawei <yawei.niu@intel.com>
Change-Id: If67f5fee5038677f39acd2dc89bc5840fa8cd62a