### PR TITLE
DAOS-3157 dtx: skip resent RPC check if DTX is disabled

### DIFF
--- a/src/dtx/dtx_common.c
+++ b/src/dtx/dtx_common.c
@@ -876,7 +876,17 @@ dtx_handle_resend(daos_handle_t coh, daos_unit_oid_t *oid, struct dtx_id *dti,
 	int	rc;
 
 	if (daos_is_zero_dti(dti))
-		return 0;
+		/* If DTX is disabled, then means that the appplication does
+		 * not care about the replicas consistency. Under such case,
+		 * if client resends some modification RPC, then just handle
+		 * it as non-resent case, return -DER_NONEXIST.
+		 *
+		 * It will cause trouble if related modification has ever
+		 * been handled before the resending. But since we cannot
+		 * trace (if without DTX) whether it has ever been handled
+		 * or not, then just handle it as original without DTX case.
+		 */
+		return -DER_NONEXIST;
 
 	rc = vos_dtx_check_resend(coh, oid, dti, dkey_hash, punch, epoch);
 	switch (rc) {

--- a/src/vos/vos_dtx.c
+++ b/src/vos/vos_dtx.c
@@ -131,19 +131,26 @@ dtx_rec_alloc(struct btr_instance *tins, d_iov_t *key_iov,
 static int
 dtx_rec_free(struct btr_instance *tins, struct btr_record *rec, void *args)
 {
-	umem_off_t	*umoff;
-
-	D_ASSERT(args != NULL);
 	D_ASSERT(!UMOFF_IS_NULL(rec->rec_off));
 
-	/* Return the record addreass (offset in SCM). The caller will
-	 * release it after using.
-	 */
-	umoff = (umem_off_t *)args;
-	*umoff = rec->rec_off;
+	if (args != NULL) {
+		umem_off_t	*umoff;
 
-	umem_tx_add_ptr(&tins->ti_umm, &rec->rec_off, sizeof(rec->rec_off));
-	rec->rec_off = UMOFF_NULL;
+		/* Return the record addreass (offset in SCM).
+		 * The caller will release it after using.
+		 */
+		umoff = (umem_off_t *)args;
+		*umoff = rec->rec_off;
+		umem_tx_add_ptr(&tins->ti_umm, &rec->rec_off,
+				sizeof(rec->rec_off));
+		rec->rec_off = UMOFF_NULL;
+	} else {
+		/* This only can happen when the dtx entry is allocated but
+		 * fail to be inserted into DTX table. Under such case, the
+		 * new allocated dtx entry will be automatically freed when
+		 * related PMDK transaction is aborted.
+		 */
+	}
 
 	return 0;
 }
@@ -638,14 +645,12 @@ dtx_key_rec_release(struct umem_instance *umm, struct vos_krec_df *key,
 
 static void
 dtx_rec_release(struct umem_instance *umm, umem_off_t umoff,
-		bool abort, bool destroy)
+		bool abort, bool destroy, bool logged)
 {
 	struct vos_dtx_entry_df		*dtx;
 
 	dtx = umem_off2ptr(umm, umoff);
-	if (!destroy &&
-	    (!dtx_is_null(dtx->te_records) ||
-	     dtx->te_flags & (DTX_EF_EXCHANGE_PENDING | DTX_EF_SHARES)))
+	if (!logged)
 		umem_tx_add_ptr(umm, dtx, sizeof(*dtx));
 
 	while (!dtx_is_null(dtx->te_records)) {
@@ -811,7 +816,7 @@ vos_dtx_commit_one(struct vos_container *cont, struct dtx_id *dti)
 	 *	record as to the current DTX will have invalid reference(s)
 	 *	via its DTX record(s).
 	 */
-	dtx_rec_release(umm, umoff, false, false);
+	dtx_rec_release(umm, umoff, false, false, true);
 	vos_dtx_del_cos(cont, &dtx->te_oid, dti, dtx->te_dkey_hash,
 			dtx->te_intent == DAOS_INTENT_PUNCH ? true : false);
 
@@ -850,7 +855,7 @@ vos_dtx_abort_one(struct vos_container *cont, daos_epoch_t epoch,
 
 	rc = dbtree_delete(cont->vc_dtx_active_hdl, opc, &kiov, &off);
 	if (rc == 0)
-		dtx_rec_release(&cont->vc_pool->vp_umm, off, true, true);
+		dtx_rec_release(&cont->vc_pool->vp_umm, off, true, true, false);
 
 out:
 	D_DEBUG(DB_TRACE, "Abort the DTX "DF_DTI": rc = %d\n", DP_DTI(dti), rc);
@@ -1309,7 +1314,7 @@ vos_dtx_check_availability(struct umem_instance *umm, daos_handle_t coh,
 				rc = vos_tx_begin(cont->vc_pool);
 				if (rc == 0) {
 					dtx_rec_release(umm, entry,
-							false, false);
+							false, false, false);
 					rc = vos_tx_end(cont->vc_pool, 0);
 				}
 
@@ -1765,8 +1770,9 @@ vos_dtx_aggregate(daos_handle_t coh, uint64_t max, uint64_t age)
 
 		tab->tt_count--;
 		dtx_umoff = dtx->te_next;
+		umem_tx_add_ptr(umm, dtx, sizeof(*dtx));
 		vos_dtx_unlink_entry(umm, tab, dtx);
-		dtx_rec_release(umm, umoff, false, true);
+		dtx_rec_release(umm, umoff, false, true, true);
 	}
 
 	vos_tx_end(cont->vc_pool, 0);


### PR DESCRIPTION
If DTX is disabled, then means that the appplication does not care
abort the replicas consistency. Under such case, if client resends
some modification RPC, then just handle as non-resent case, return
-DER_NONEXIST. It will cause trouble if related modification has
ever handled before the resending, then it will cause trouble. But
since we have no way to check whether it has ever been handled or
not, then just handle it as without DTX case.

The patch also fixes some potential issues when free DTX record.

Signed-off-by: Fan Yong <fan.yong@intel.com>