### PR TITLE
DAOS-3166 tests: Fixing return status for pool info checks.

### DIFF
--- a/src/tests/ftest/pool/info_tests.py
+++ b/src/tests/ftest/pool/info_tests.py
@@ -62,7 +62,7 @@ class InfoTests(TestWithServers):
         # Verify the pool information
         checks = {
             "pi_uuid": self.pool.uuid,
-            # "pi_ntargets": len(self.hostlist_servers) * targets,  DAOS-2799
+            "pi_ntargets": len(self.hostlist_servers) * targets,
             "pi_nnodes": len(self.hostlist_servers),
             "pi_ndisabled": 0,
             "pi_map_ver": 1,

--- a/src/tests/ftest/pool/info_tests.yaml
+++ b/src/tests/ftest/pool/info_tests.yaml
@@ -3,7 +3,7 @@ hosts:
     - boro-A
 server_config:
   name: daos_server
-  targets: 4
+  targets: 1
 pool:
   createmode: !mux
     mode_all:

--- a/src/tests/ftest/util/test_utils.py
+++ b/src/tests/ftest/util/test_utils.py
@@ -433,7 +433,6 @@ class TestPool(TestDaosApiBase):
                 "Verifying the pool %s: %s %s %s",
                 check, actual, compare[0], expect)
             if not compare[1](actual, expect):
-            check_status = compare[1](actual, expect)
                 msg = "  The {} {}: actual={}, expected={}".format(
                     check, compare[2], actual, expect)
                 self.log.error(msg)

--- a/src/tests/ftest/util/test_utils.py
+++ b/src/tests/ftest/util/test_utils.py
@@ -262,6 +262,11 @@ class TestPool(TestDaosApiBase):
             pi_leader (int, optional): pool leader. Defaults to None.
             pi_bits (int, optional): pool bits. Defaults to None.
 
+        Note:
+            Arguments may also be provided as a string with a number preceeded
+            by '<', '<=', '>', or '>=' for other comparisions besides the
+            default '=='.
+
         Returns:
             bool: True if at least one expected value is specified and all the
                 specified values match; False otherwise
@@ -292,6 +297,11 @@ class TestPool(TestDaosApiBase):
             ps_ntargets (int, optional): number of targets. Defaults to None.
             ps_padding (int, optional): space padding. Defaults to None.
 
+        Note:
+            Arguments may also be provided as a string with a number preceeded
+            by '<', '<=', '>', or '>=' for other comparisions besides the
+            default '=='.
+
         Returns:
             bool: True if at least one expected value is specified and all the
                 specified values match; False otherwise
@@ -320,6 +330,11 @@ class TestPool(TestDaosApiBase):
         Args:
             s_total (list, optional): total space per device. Defaults to None.
             s_free (list, optional): free space per device. Defaults to None.
+
+        Note:
+            Arguments may also be provided as a string with a number preceeded
+            by '<', '<=', '>', or '>=' for other comparisions besides the
+            default '=='.
 
         Returns:
             bool: True if at least one expected value is specified and all the
@@ -355,6 +370,11 @@ class TestPool(TestDaosApiBase):
             rs_rec_nr (int, optional): number of rebuilt records.
                 Defaults to None.
 
+        Note:
+            Arguments may also be provided as a string with a number preceeded
+            by '<', '<=', '>', or '>=' for other comparisions besides the
+            default '=='.
+
         Returns:
             bool: True if at least one expected value is specified and all the
                 specified values match; False otherwise
@@ -373,7 +393,10 @@ class TestPool(TestDaosApiBase):
         Args:
             check_list (list): a list of tuples containing the name of the pool
                 information attribute to check, the current value of the
-                attribute, and the expected value of the attribute.
+                attribute, and the expected value of the attribute. If the
+                expected value is specified as a string with a number preceeded
+                by '<', '<=', '>', or '>=' then this comparision will be used
+                instead of the defult '=='.
 
         Returns:
             bool: True if at least one check has been specified and all the
@@ -382,6 +405,7 @@ class TestPool(TestDaosApiBase):
         """
         check_status = len(check_list) > 0
         for check, actual, expect in check_list:
+            # Determine which comparision to utilize for this check
             compare = ("==", lambda x, y: x == y, "does not match")
             if isinstance(expect, str):
                 comparisions = {
@@ -393,7 +417,7 @@ class TestPool(TestDaosApiBase):
                         lambda x, y: x >= y, "is too small or does not match"),
                 }
                 for key, val in comparisions.items():
-                    # If the expected value is preceeded by one of the know
+                    # If the expected value is preceeded by one of the known
                     # comparision keys, use the comparision and remove the key
                     # from the expected value
                     if expect[:len(key)] == key:
@@ -408,11 +432,12 @@ class TestPool(TestDaosApiBase):
             self.log.info(
                 "Verifying the pool %s: %s %s %s",
                 check, actual, compare[0], expect)
+            if not compare[1](actual, expect):
             check_status = compare[1](actual, expect)
-            if not check_status:
                 msg = "  The {} {}: actual={}, expected={}".format(
                     check, compare[2], actual, expect)
                 self.log.error(msg)
+                check_status = False
         return check_status
 
     def rebuild_complete(self):


### PR DESCRIPTION
Resolving an issue where TestPool.check_*() methods could return True
status even when one of the checks failed.  In relation, updating the
pool/info_test.py test case to request one target per server to pass
on the CI VM hosts.

Signed-off-by: Phil Henderson <phillip.henderson@intel.com>