### PR TITLE
DAOS-2767 control: fix nvme format

### DIFF
--- a/src/control/Gopkg.toml
+++ b/src/control/Gopkg.toml
@@ -60,7 +60,7 @@
 # pin with commit hash rather than just tip of master until tags exist.
 [[constraint]]
   name = "github.com/daos-stack/go-spdk"
-  revision = "7b664cdac14f4265934fa895f1b366136f3407d6"
+  revision = "ba6457edb1f7651cf1066dedfc0f25c55a9a176c"
 
 # go-bytesize: BSD 3-Clause, handle conversion from human readable size
 # strings to bytes.

--- a/src/control/Gopkg.toml
+++ b/src/control/Gopkg.toml
@@ -60,7 +60,7 @@
 # pin with commit hash rather than just tip of master until tags exist.
 [[constraint]]
   name = "github.com/daos-stack/go-spdk"
-  revision = "ba6457edb1f7651cf1066dedfc0f25c55a9a176c"
+  revision = "546f63c70bb70e32c69b7f7de11fcc219285f8e1"
 
 # go-bytesize: BSD 3-Clause, handle conversion from human readable size
 # strings to bytes.

--- a/src/control/vendor/github.com/daos-stack/go-spdk/spdk/src/nvme_control.c
+++ b/src/control/vendor/github.com/daos-stack/go-spdk/spdk/src/nvme_control.c
@@ -182,7 +182,7 @@ collect(struct ret_t *ret)
 		pci_dev = spdk_nvme_ctrlr_get_pci_device(ns_entry->ctrlr);
 		if (!pci_dev) {
 			snprintf(ret->err, sizeof(ret->err),
-				 "%s: get_pci_device", __func_tep
+				 "%s: get_pci_device", __func__);
 
 			ret->rc = -NVMEC_ERR_GET_PCI_DEV;
 			return;


### PR DESCRIPTION
Fix issue where SPDK blobs are not being removed reliably from all NVMe
SSDs during control plane storage format. Bump go-spdk version in
vendor directory to incorporate the following changes:

* set format.ses (secure erase) flag to wipe user data
* refactor controller lookup routine to be more reliable
* store pci_addr in top-level entry to simplify usage

Signed-off-by: Tom Nabarro <tom.nabarro@intel.com>