### PR TITLE
CORCI-610 build: Revert SUCCESS -> FAILURE for pr-branch

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -84,7 +84,7 @@ def rpm_test_daos_test = '''me=\\\$(whoami)
 if (!env.CHANGE_ID &&
     (env.BRANCH_NAME != "weekly-testing" &&
      env.BRANCH_NAME != "master")) {
-   currentBuild.result = 'FAILURE'
+   currentBuild.result = 'SUCCESS'
    return
 }
 


### PR DESCRIPTION
Because this results in a red X in the GitHub status making the PR look like it failed
test.

Signed-off-by: Brian J. Murrell <brian.murrell@intel.com>