### PR TITLE
DAOS-3182 daos: use CART HLC instead of physical timestamp for the epoch

### DIFF
--- a/src/container/cli.c
+++ b/src/container/cli.c
@@ -1827,7 +1827,7 @@ dc_cont_create_snap(tse_task_t *task)
 		return -DER_INVAL;
 	}
 
-	*args->epoch = daos_ts2epoch();
+	*args->epoch = crt_hlc_get();
 	return dc_epoch_op(args->coh, CONT_SNAP_CREATE, args->epoch, task);
 }
 

--- a/src/container/cli_tx.c
+++ b/src/container/cli_tx.c
@@ -187,7 +187,7 @@ daos_tx_hdl2epoch(daos_handle_t th, daos_epoch_t *epoch)
 	struct dc_tx *tx = NULL;
 
 	if (daos_handle_is_inval(th)) {
-		*epoch = daos_ts2epoch();
+		*epoch = crt_hlc_get();
 		return 0;
 	}
 
@@ -216,7 +216,7 @@ dc_tx_open(tse_task_t *task)
 		D_GOTO(out, rc = -DER_NOMEM);
 
 	tx->tx_coh	= args->coh;
-	tx->tx_epoch	= daos_ts2epoch();
+	tx->tx_epoch	= crt_hlc_get();
 	tx->tx_status	= TX_OPEN;
 	tx->tx_mode	= TX_RW;
 

--- a/src/container/srv_epoch.c
+++ b/src/container/srv_epoch.c
@@ -813,7 +813,7 @@ ds_cont_epoch_aggregate(struct rdb_tx *tx, struct ds_pool_hdl *pool_hdl,
 	if (epoch >= DAOS_EPOCH_MAX)
 		return -DER_INVAL;
 	else if (in->cei_epoch == 0)
-		epoch = daos_ts2epoch();
+		epoch = crt_hlc_get();
 
 	rc = trigger_aggregation(tx, 0, epoch, epoch, cont, rpc->cr_ctx);
 

--- a/src/include/daos_types.h
+++ b/src/include/daos_types.h
@@ -352,15 +352,6 @@ typedef struct {
 
 typedef uint64_t	daos_epoch_t;
 
-static inline daos_epoch_t
-daos_ts2epoch(void)
-{
-	struct timespec ts;
-
-	clock_gettime(CLOCK_REALTIME, &ts);
-	return ts.tv_sec * 1e9 + ts.tv_nsec;
-}
-
 typedef struct {
 	/** Low bound of the epoch range */
 	daos_epoch_t	epr_lo;

--- a/src/object/cli_obj.c
+++ b/src/object/cli_obj.c
@@ -1288,7 +1288,7 @@ static daos_epoch_t
 dc_io_epoch()
 {
 	return (srv_io_mode != DIM_CLIENT_DISPATCH) ?
-			DAOS_EPOCH_MAX : daos_ts2epoch();
+			DAOS_EPOCH_MAX : crt_hlc_get();
 }
 
 /* check if the obj request is valid */

--- a/src/object/srv_obj.c
+++ b/src/object/srv_obj.c
@@ -936,7 +936,7 @@ ds_obj_rw_handler(crt_rpc_t *rpc)
 		orw->orw_map_ver, map_ver, DP_DTI(&orw->orw_dti));
 	/* FIXME: until distributed transaction. */
 	if (orw->orw_epoch == DAOS_EPOCH_MAX) {
-		orw->orw_epoch = daos_ts2epoch();
+		orw->orw_epoch = crt_hlc_get();
 		D_DEBUG(DB_IO, "overwrite epoch "DF_U64"\n", orw->orw_epoch);
 	}
 
@@ -1241,7 +1241,7 @@ ds_obj_enum_handler(crt_rpc_t *rpc)
 
 	/* FIXME: until distributed transaction. */
 	if (oei->oei_epoch == DAOS_EPOCH_MAX) {
-		oei->oei_epoch = daos_ts2epoch();
+		oei->oei_epoch = crt_hlc_get();
 		D_DEBUG(DB_IO, "overwrite epoch "DF_U64"\n", oei->oei_epoch);
 	}
 
@@ -1515,7 +1515,7 @@ ds_obj_punch_handler(crt_rpc_t *rpc)
 
 	/* FIXME: until distributed transaction. */
 	if (opi->opi_epoch == DAOS_EPOCH_MAX) {
-		opi->opi_epoch = daos_ts2epoch();
+		opi->opi_epoch = crt_hlc_get();
 		D_DEBUG(DB_IO, "overwrite epoch "DF_U64"\n", opi->opi_epoch);
 	}
 
@@ -1633,7 +1633,7 @@ ds_obj_query_key_handler(crt_rpc_t *rpc)
 
 	/* FIXME: until distributed transaction. */
 	if (okqi->okqi_epoch == DAOS_EPOCH_MAX) {
-		okqi->okqi_epoch = daos_ts2epoch();
+		okqi->okqi_epoch = crt_hlc_get();
 		D_DEBUG(DB_IO, "overwrite epoch "DF_U64"\n", okqi->okqi_epoch);
 	}
 

--- a/src/tests/suite/daos_test_common.c
+++ b/src/tests/suite/daos_test_common.c
@@ -494,7 +494,7 @@ test_runable(test_arg_t *arg, unsigned int required_nodes)
 			ranks_to_kill[i] = arg->srv_nnodes -
 					   disable_nodes - i - 1;
 
-		arg->hce = daos_ts2epoch();
+		arg->hce = crt_hlc_get();
 	}
 
 	MPI_Bcast(&runable, 1, MPI_INT, 0, MPI_COMM_WORLD);


### PR DESCRIPTION

Signed-off-by: Mohamad Chaarawi <mohamad.chaarawi@intel.com>