### PR TITLE
DAOS-3185 container: remove assert from container open

### DIFF
--- a/src/container/srv_target.c
+++ b/src/container/srv_target.c
@@ -828,7 +828,9 @@ ds_cont_tgt_open(uuid_t pool_uuid, uuid_t cont_hdl_uuid,
 	struct ds_pool		*pool = NULL;
 	struct ds_cont		*cont = NULL;
 	struct cont_tgt_open_arg arg;
-	int			 rc;
+	struct dss_coll_ops	coll_ops = { 0 };
+	struct dss_coll_args	coll_args = { 0 };
+	int			rc;
 
 	uuid_copy(arg.pool_uuid, pool_uuid);
 	uuid_copy(arg.cont_hdl_uuid, cont_hdl_uuid);
@@ -838,8 +840,35 @@ ds_cont_tgt_open(uuid_t pool_uuid, uuid_t cont_hdl_uuid,
 	D_DEBUG(DB_TRACE, "open pool/cont/hdl "DF_UUID"/"DF_UUID"/"DF_UUID"\n",
 		DP_UUID(pool_uuid), DP_UUID(cont_uuid), DP_UUID(cont_hdl_uuid));
 
-	rc = dss_thread_collective(cont_open_one, &arg, 0);
-	D_ASSERTF(rc == 0, "%d\n", rc);
+	/* collective operations */
+	coll_ops.co_func = cont_open_one;
+	coll_args.ca_func_args	= &arg;
+
+	/* setting aggregator args */
+	rc = ds_pool_get_failed_tgt_idx(pool_uuid, &coll_args.ca_exclude_tgts,
+					&coll_args.ca_exclude_tgts_cnt);
+	if (rc) {
+		D_ERROR(DF_UUID "failed to get index : rc %d\n",
+			DP_UUID(pool_uuid), rc);
+		return rc;
+	}
+
+	rc = dss_thread_collective_reduce(&coll_ops, &coll_args, 0);
+	if (coll_args.ca_exclude_tgts)
+		D_FREE(coll_args.ca_exclude_tgts);
+
+	if (rc != 0) {
+		/* Once it exclude the target from the pool, since the target
+		 * might still in the cart group, so IV cont open might still
+		 * come to this target, especially if cont open/close will be
+		 * done by IV asynchronously, so this cont_open_one might return
+		 * -DER_NO_HDL if it can not find pool handle. (DAOS-3185)
+		 */
+		D_ERROR("open "DF_UUID"/"DF_UUID"/"DF_UUID":%d\n",
+			DP_UUID(pool_uuid), DP_UUID(cont_uuid),
+			DP_UUID(cont_hdl_uuid), rc);
+		return rc;
+	}
 
 	pool = ds_pool_lookup(pool_uuid);
 	D_ASSERT(pool != NULL);

--- a/src/include/daos_srv/daos_server.h
+++ b/src/include/daos_srv/daos_server.h
@@ -414,7 +414,7 @@ struct dss_coll_args {
 	void				*ca_func_args;
 	void				*ca_aggregator;
 	int				*ca_exclude_tgts;
-	int				ca_exclude_tgts_cnt;
+	unsigned int			ca_exclude_tgts_cnt;
 	/** Stream arguments for all streams */
 	struct dss_coll_stream_args	ca_stream_args;
 };

--- a/src/include/daos_srv/pool.h
+++ b/src/include/daos_srv/pool.h
@@ -193,4 +193,7 @@ map_ranks_fini(d_rank_list_t *ranks);
 
 int ds_pool_get_ranks(const uuid_t pool_uuid, int status,
 		      d_rank_list_t *ranks);
+
+int ds_pool_get_failed_tgt_idx(const uuid_t pool_uuid, int **failed_tgts,
+			       unsigned int *failed_tgts_cnt);
 #endif /* __DAOS_SRV_POOL_H__ */


### PR DESCRIPTION
Remove assert for container open on each target, because
if the target is removed from the pool map(only exclude),
then it might return DER_NO_HDL.

Signed-off-by: Wang Di <di.wang@intel.com>