### PR TITLE
DAOS-3196 debug: key format for debug log

### DIFF
--- a/src/common/debug.c
+++ b/src/common/debug.c
@@ -222,3 +222,30 @@ DP_UUID(const void *uuid)
 	thread_uuid_str_buf_idx = (thread_uuid_str_buf_idx + 1) % DF_UUID_MAX;
 	return buf;
 }
+
+#define DF_KEY_MAX		8
+#define DF_KEY_STR_SIZE		64
+
+static __thread int thread_key_buf_idx;
+static __thread char thread_key_buf[DF_KEY_MAX][DF_KEY_STR_SIZE];
+
+char *
+daos_key2str(daos_key_t *key)
+{
+	char *buf = thread_key_buf[thread_key_buf_idx];
+
+	if (!key->iov_buf || key->iov_len == 0) {
+		strcpy(buf, "<NULL>");
+	} else {
+		int len = min(key->iov_len, DF_KEY_STR_SIZE - 1);
+
+		if (isprint(*(char *)key->iov_buf)) {
+			strncpy(buf, key->iov_buf, len);
+			buf[len] = 0;
+		} else {
+			strcpy(buf, "????");
+		}
+	}
+	thread_key_buf_idx = (thread_key_buf_idx + 1) % DF_KEY_MAX;
+	return buf;
+}

--- a/src/include/daos/common.h
+++ b/src/include/daos/common.h
@@ -95,6 +95,11 @@ char *DP_UUID(const void *uuid);
 #define DF_CONT			DF_UUID"/"DF_UUID
 #define DP_CONT(puuid, cuuid)	DP_UUID(puuid), DP_UUID(cuuid)
 
+char *daos_key2str(daos_key_t *key);
+
+#define DF_KEY			"[%d] %s"
+#define DP_KEY(key)		(int)(key)->iov_len, daos_key2str(key)
+
 static inline uint64_t
 daos_u64_hash(uint64_t val, unsigned int bits)
 {

--- a/src/iosrv/vos.c
+++ b/src/iosrv/vos.c
@@ -428,8 +428,7 @@ unpack_recxs(daos_iod_t *iod, int *recxs_cap, d_sg_list_t *sgl,
 
 	while (len > 0) {
 		struct obj_enum_rec *rec = *data;
-
-		D_DEBUG(DB_REBUILD, "data %p len "DF_U64"\n", *data, len);
+		daos_size_t len_bak = len;
 
 		/* Every recx begins with an obj_enum_rec. */
 		if (len < sizeof(*rec)) {
@@ -509,7 +508,7 @@ unpack_recxs(daos_iod_t *iod, int *recxs_cap, d_sg_list_t *sgl,
 
 			if (rec->rec_flags & RECX_INLINE) {
 				d_iov_set(iov, *data, rec->rec_size *
-							 rec->rec_recx.rx_nr);
+						      rec->rec_recx.rx_nr);
 			} else {
 				d_iov_set(iov, NULL, 0);
 			}
@@ -521,15 +520,16 @@ unpack_recxs(daos_iod_t *iod, int *recxs_cap, d_sg_list_t *sgl,
 			len -= iov->iov_len;
 		}
 
-		D_DEBUG(DB_REBUILD, "unpack %p idx/nr "DF_U64"/"DF_U64 "ver %u"
-			" epr lo/hi "DF_U64"/"DF_U64" size %zd\n",
-			*data, iod->iod_recxs[iod->iod_nr - 1].rx_idx,
+		D_DEBUG(DB_REBUILD,
+			"unpacked data %p len "DF_U64" idx/nr "DF_U64"/"DF_U64
+			" ver %u epr lo/hi "DF_U64"/"DF_U64" size %zd\n",
+			rec, len_bak, iod->iod_recxs[iod->iod_nr - 1].rx_idx,
 			iod->iod_recxs[iod->iod_nr - 1].rx_nr, rec->rec_version,
 			iod->iod_eprs[iod->iod_nr - 1].epr_lo,
 			iod->iod_eprs[iod->iod_nr - 1].epr_hi, iod->iod_size);
 	}
 
-	D_DEBUG(DB_REBUILD, "pack nr %d version/type /%u/%d rc %d\n",
+	D_DEBUG(DB_REBUILD, "unpacked nr %d version/type /%u/%d rc %d\n",
 		iod->iod_nr, *version, iod->iod_type, rc);
 	return rc;
 }

--- a/src/rebuild/initiator.c
+++ b/src/rebuild/initiator.c
@@ -102,10 +102,10 @@ rebuild_fetch_update_inline(struct rebuild_one *rdone, daos_handle_t oh,
 		}
 	}
 
-	D_DEBUG(DB_REBUILD, DF_UOID" rdone %p dkey %d %s nr %d eph "DF_U64
+	D_DEBUG(DB_REBUILD, DF_UOID" rdone %p dkey "DF_KEY" nr %d eph "DF_U64
 		" fetch %s\n", DP_UOID(rdone->ro_oid), rdone,
-		(int)rdone->ro_dkey.iov_len, (char *)rdone->ro_dkey.iov_buf,
-		rdone->ro_iod_num, rdone->ro_epoch, fetch ? "yes":"no");
+		DP_KEY(&rdone->ro_dkey), rdone->ro_iod_num,
+		rdone->ro_epoch, fetch ? "yes":"no");
 
 	if (fetch) {
 		rc = ds_obj_fetch(oh, rdone->ro_epoch, &rdone->ro_dkey,
@@ -197,18 +197,17 @@ rebuild_fetch_update_bulk(struct rebuild_one *rdone, daos_handle_t oh,
 		sgl_cnt++;
 	}
 
-	D_DEBUG(DB_REBUILD, DF_UOID" rdone %p dkey %d %s nr %d eph "DF_U64"\n",
-		DP_UOID(rdone->ro_oid), rdone, (int)rdone->ro_dkey.iov_len,
-		(char *)rdone->ro_dkey.iov_buf, rdone->ro_iod_num,
-		rdone->ro_epoch);
+	D_DEBUG(DB_REBUILD,
+		DF_UOID" rdone %p dkey "DF_KEY" nr %d eph "DF_U64"\n",
+		DP_UOID(rdone->ro_oid), rdone, DP_KEY(&rdone->ro_dkey),
+		rdone->ro_iod_num, rdone->ro_epoch);
 
 	rc = ds_obj_fetch(oh, rdone->ro_epoch, &rdone->ro_dkey,
 			  rdone->ro_iod_num, rdone->ro_iods,
 			  sgls, NULL);
 	if (rc)
-		D_ERROR("rebuild dkey %d %s failed rc %d\n",
-			(int)rdone->ro_dkey.iov_len,
-			(char *)rdone->ro_dkey.iov_buf, rc);
+		D_ERROR("rebuild dkey "DF_KEY" failed rc %d\n",
+			DP_KEY(&rdone->ro_dkey), rc);
 post:
 	for (i = 0; i < sgl_cnt; i++) {
 		sgl = &sgls[i];
@@ -239,9 +238,10 @@ rebuild_one_punch_keys(struct rebuild_tgt_pool_tracker *rpt,
 
 	/* Punch dkey */
 	if (rdone->ro_max_eph != DAOS_EPOCH_MAX) {
-		D_DEBUG(DB_REBUILD, DF_UOID" punch dkey %d %s eph "DF_U64"\n",
-			DP_UOID(rdone->ro_oid), (int)rdone->ro_dkey.iov_len,
-			(char *)rdone->ro_dkey.iov_buf, rdone->ro_max_eph);
+		D_DEBUG(DB_REBUILD,
+			DF_UOID" punch dkey "DF_KEY" eph "DF_U64"\n",
+			DP_UOID(rdone->ro_oid), DP_KEY(&rdone->ro_dkey),
+			rdone->ro_max_eph);
 		rc = vos_obj_punch(cont->sc_hdl, rdone->ro_oid,
 				   rdone->ro_max_eph, rpt->rt_rebuild_ver,
 				   VOS_OF_REPLAY_PC, &rdone->ro_dkey, 0, NULL,
@@ -258,13 +258,11 @@ rebuild_one_punch_keys(struct rebuild_tgt_pool_tracker *rpt,
 
 	/* Punch akeys */
 	for (i = 0; i < rdone->ro_ephs_num; i++) {
-		D_DEBUG(DB_REBUILD, DF_UOID" rdone %p punch dkey %d %s akey"
-			" %d %s  eph "DF_U64"\n", DP_UOID(rdone->ro_oid),
-			rdone, (int)rdone->ro_dkey.iov_len,
-			(char *)rdone->ro_dkey.iov_buf,
-			(int)rdone->ro_ephs_keys[i].iov_len,
-			(char *)rdone->ro_ephs_keys[i].iov_buf,
-			rdone->ro_ephs[i]);
+		D_DEBUG(DB_REBUILD, DF_UOID" rdone %p punch dkey "DF_KEY
+			" akey "DF_KEY" eph "DF_U64"\n",
+			DP_UOID(rdone->ro_oid), rdone, DP_KEY(&rdone->ro_dkey),
+			DP_KEY(&rdone->ro_ephs_keys[i]), rdone->ro_ephs[i]);
+
 		D_ASSERT(rdone->ro_ephs[i] != DAOS_EPOCH_MAX);
 		rc = vos_obj_punch(cont->sc_hdl, rdone->ro_oid,
 				   rdone->ro_ephs[i], rpt->rt_rebuild_ver,
@@ -431,12 +429,11 @@ rebuild_one_ult(void *arg)
 			d_list_del_init(&rdone->ro_list);
 			if (!rpt->rt_abort) {
 				rc = rebuild_dkey(rpt, rdone);
-				D_DEBUG(DB_REBUILD, DF_UOID" rebuild dkey %d %s"
-					" rc %d tag %d rpt %p\n",
+				D_DEBUG(DB_REBUILD, DF_UOID" rebuild dkey "
+					DF_KEY" rc %d tag %d rpt %p\n",
 					DP_UOID(rdone->ro_oid),
-					(int)rdone->ro_dkey.iov_len,
-					(char *)rdone->ro_dkey.iov_buf, rc,
-					idx, rpt);
+					DP_KEY(&rdone->ro_dkey),
+					rc, idx, rpt);
 			}
 
 			D_ASSERT(puller->rp_inflight > 0);
@@ -524,10 +521,11 @@ rw_iod_pack(struct rebuild_one *rdone, daos_iod_t *iod, d_sg_list_t *sgls)
 			rdone->ro_epoch = iod->iod_eprs[i].epr_lo;
 	}
 
-	D_DEBUG(DB_REBUILD, "idx %d akey %d %s nr %d size "DF_U64" type %d eph "
-		DF_U64"/"DF_U64"\n", idx, (int)iod->iod_name.iov_len,
-		(char *)iod->iod_name.iov_buf, iod->iod_nr, iod->iod_size,
-		iod->iod_type, iod->iod_eprs->epr_lo, iod->iod_eprs->epr_hi);
+	D_DEBUG(DB_REBUILD,
+		"idx %d akey "DF_KEY" nr %d size "DF_U64" type %d eph "
+		DF_U64"/"DF_U64"\n", idx, DP_KEY(&iod->iod_name),
+		iod->iod_nr, iod->iod_size, iod->iod_type,
+		iod->iod_eprs->epr_lo, iod->iod_eprs->epr_hi);
 
 	/* Check if data has been retrieved by iteration */
 	if (sgls) {
@@ -596,9 +594,9 @@ rebuild_one_queue(struct rebuild_iter_obj_arg *iter_arg, daos_unit_oid_t *oid,
 	int				i;
 	int				rc;
 
-	D_DEBUG(DB_REBUILD, "rebuild dkey %d %s iod nr %d dkey_eph "DF_U64"\n",
-		(int)dkey->iov_buf_len, (char *)dkey->iov_buf, iod_eph_total,
-		dkey_eph);
+	D_DEBUG(DB_REBUILD,
+		"rebuild dkey "DF_KEY" iod nr %d dkey_eph "DF_U64"\n",
+		DP_KEY(dkey), iod_eph_total, dkey_eph);
 
 	if (iod_eph_total == 0 || rpt->rt_rebuild_ver <= version) {
 		D_DEBUG(DB_REBUILD, "No need rebuild eph_total %d version %u"
@@ -653,10 +651,9 @@ rebuild_one_queue(struct rebuild_iter_obj_arg *iter_arg, daos_unit_oid_t *oid,
 				D_GOTO(free, rc);
 
 			ephs_cnt++;
-			D_DEBUG(DB_REBUILD, "punched iod idx %d akey %d %s"
+			D_DEBUG(DB_REBUILD, "punched iod idx %d akey "DF_KEY
 				" ephs "DF_U64" ephs_cnt %d\n", i,
-				(int)iods[i].iod_name.iov_len,
-				(char *)iods[i].iod_name.iov_buf,
+				DP_KEY(&iods[i].iod_name),
 				akey_ephs[i], ephs_cnt);
 		}
 
@@ -699,10 +696,10 @@ rebuild_one_queue(struct rebuild_iter_obj_arg *iter_arg, daos_unit_oid_t *oid,
 	rdone->ro_oid = *oid;
 	uuid_copy(rdone->ro_cont_uuid, iter_arg->cont_uuid);
 
-	D_DEBUG(DB_REBUILD, DF_UOID" %p dkey %d %s rebuild on idx %d max eph"
+	D_DEBUG(DB_REBUILD, DF_UOID" %p dkey "DF_KEY" rebuild on idx %d max eph"
 		" "DF_U64" iod_num %d\n", DP_UOID(rdone->ro_oid), rdone,
-		(int)dkey->iov_len, (char *)dkey->iov_buf, iter_arg->tgt_idx,
-		rdone->ro_max_eph, rdone->ro_iod_num);
+		DP_KEY(dkey), iter_arg->tgt_idx, rdone->ro_max_eph,
+		rdone->ro_iod_num);
 
 	ABT_mutex_lock(puller->rp_lock);
 	d_list_add_tail(&rdone->ro_list, &puller->rp_one_list);

--- a/src/rebuild/srv.c
+++ b/src/rebuild/srv.c
@@ -1619,10 +1619,9 @@ rebuild_tgt_fini(struct rebuild_tgt_pool_tracker *rpt)
 		d_list_for_each_entry_safe(rdone, tmp, &puller->rp_one_list,
 					   ro_list) {
 			d_list_del_init(&rdone->ro_list);
-			D_WARN(DF_UUID" left rebuild rdone %*.s\n",
+			D_WARN(DF_UUID" left rebuild rdone key="DF_KEY"\n",
 			       DP_UUID(rpt->rt_pool_uuid),
-			      (int)rdone->ro_dkey.iov_len,
-			      (char *)rdone->ro_dkey.iov_buf);
+			       DP_KEY(&rdone->ro_dkey));
 			rebuild_one_destroy(rdone);
 		}
 	}

--- a/src/vos/evtree.c
+++ b/src/vos/evtree.c
@@ -913,7 +913,7 @@ evt_tcx_create(struct evt_root *root, uint64_t feats, unsigned int order,
 		D_ERROR("Bad sort policy specified: 0x%x\n", policy);
 		D_GOTO(failed, rc = -DER_INVAL);
 	}
-	D_DEBUG(DB_IO, "EVTree sort policy is 0x%x\n", policy);
+	D_DEBUG(DB_TRACE, "EVTree sort policy is 0x%x\n", policy);
 
 	/* Initialize the embedded iterator entry array.  This is a minor
 	 * optimization if the iterator is used more than once

--- a/src/vos/vos_aggregate.c
+++ b/src/vos/vos_aggregate.c
@@ -273,8 +273,8 @@ vos_agg_dkey(daos_handle_t ih, vos_iter_entry_t *entry,
 		agg_param->ap_dkey = entry->ie_key;
 		memset(&agg_param->ap_akey, 0, sizeof(agg_param->ap_akey));
 	} else if (!agg_param->ap_discard) {
-		D_DEBUG(DB_EPC, "Skip dkey:[%s] aggregation on re-probe\n",
-			(char *)entry->ie_key.iov_buf);
+		D_DEBUG(DB_EPC, "Skip dkey: "DF_KEY" aggregation on re-probe\n",
+			DP_KEY(&entry->ie_key));
 		*acts |= VOS_ITER_CB_SKIP;
 	}
 
@@ -393,8 +393,8 @@ vos_agg_akey(daos_handle_t ih, vos_iter_entry_t *entry,
 	if (vos_agg_key_compare(agg_param->ap_akey, entry->ie_key)) {
 		agg_param->ap_akey = entry->ie_key;
 	} else if (!agg_param->ap_discard) {
-		D_DEBUG(DB_EPC, "Skip akey:[%s] aggregation on re-probe\n",
-			(char *)entry->ie_key.iov_buf);
+		D_DEBUG(DB_EPC, "Skip akey: "DF_KEY" aggregation on re-probe\n",
+			DP_KEY(&entry->ie_key));
 		*acts |= VOS_ITER_CB_SKIP;
 	}
 

--- a/src/vos/vos_io.c
+++ b/src/vos/vos_io.c
@@ -477,8 +477,8 @@ akey_fetch(struct vos_io_context *ioc, daos_handle_t ak_toh)
 	int		 i, rc;
 	int		 flags = 0;
 
-	D_DEBUG(DB_IO, "akey %d %s fetch %s eph "DF_U64"\n",
-		(int)iod->iod_name.iov_len, (char *)iod->iod_name.iov_buf,
+	D_DEBUG(DB_IO, "akey "DF_KEY" fetch %s eph "DF_U64"\n",
+		DP_KEY(&iod->iod_name),
 		iod->iod_type == DAOS_IOD_ARRAY ? "array" : "single",
 		ioc->ic_epoch);
 
@@ -494,9 +494,8 @@ akey_fetch(struct vos_io_context *ioc, daos_handle_t ak_toh)
 				      DAOS_INTENT_DEFAULT, NULL, &toh);
 		if (rc != 0) {
 			if (rc == -DER_NONEXIST) {
-				D_DEBUG(DB_IO, "Nonexistent akey %.*s\n",
-					(int)iod->iod_name.iov_len,
-					(char *)iod->iod_name.iov_buf);
+				D_DEBUG(DB_IO, "Nonexistent akey "DF_KEY"\n",
+					DP_KEY(&iod->iod_name));
 				iod_empty_sgl(ioc, ioc->ic_sgl_at);
 				rc = 0;
 			}
@@ -527,7 +526,8 @@ akey_fetch(struct vos_io_context *ioc, daos_handle_t ak_toh)
 				toh = DAOS_HDL_INVAL;
 			}
 
-			D_DEBUG(DB_IO, "repare the key tree for eph "DF_U64"\n",
+			D_DEBUG(DB_IO,
+				"prepare the key tree for eph "DF_U64"\n",
 				val_epr.epr_hi);
 			rc = key_tree_prepare(ioc->ic_obj, val_epr.epr_hi,
 					      ak_toh, VOS_BTR_AKEY,
@@ -535,9 +535,9 @@ akey_fetch(struct vos_io_context *ioc, daos_handle_t ak_toh)
 					      DAOS_INTENT_DEFAULT, &krec, &toh);
 			if (rc != 0) {
 				if (rc == -DER_NONEXIST) {
-					D_DEBUG(DB_IO, "Nonexist akey %.*s\n",
-						(int)iod->iod_name.iov_len,
-						(char *)iod->iod_name.iov_buf);
+					D_DEBUG(DB_IO,
+						"Nonexist akey "DF_KEY"\n",
+						DP_KEY(&iod->iod_name));
 					rc = 0;
 					continue;
 				}
@@ -817,9 +817,9 @@ akey_update(struct vos_io_context *ioc, uint32_t pm_ver, daos_handle_t ak_toh,
 	int		    i;
 	int		    rc = 0;
 
-	D_DEBUG(DB_TRACE, "akey %d %s update %s value eph "DF_U64"\n",
-		(int)iod->iod_name.iov_len, (char *)iod->iod_name.iov_buf,
-		is_array ? "array" : "single", ioc->ic_epoch);
+	D_DEBUG(DB_TRACE, "akey "DF_KEY" update %s value eph "DF_U64"\n",
+		DP_KEY(&iod->iod_name), is_array ? "array" : "single",
+		ioc->ic_epoch);
 
 	if (is_array)
 		flags |= SUBTR_EVT;
@@ -1333,6 +1333,9 @@ vos_update_begin(daos_handle_t coh, daos_unit_oid_t oid, daos_epoch_t epoch,
 	struct vos_io_context	*ioc;
 	int			 rc;
 
+	D_DEBUG(DB_IO, "Prepare IOC for "DF_UOID", iod_nr %d, epc "DF_U64"\n",
+		DP_UOID(oid), iod_nr, epoch);
+
 	rc = vos_ioc_create(coh, oid, false, epoch, iod_nr, iods, false, &ioc);
 	if (rc != 0)
 		goto done;
@@ -1344,12 +1347,7 @@ vos_update_begin(daos_handle_t coh, daos_unit_oid_t oid, daos_epoch_t epoch,
 		vos_update_end(vos_ioc2ioh(ioc), 0, dkey, rc, dth);
 		goto done;
 	}
-
-
-	D_DEBUG(DB_IO, "Prepared io context for updating %d iods\n", iod_nr);
-
 	*ioh = vos_ioc2ioh(ioc);
-
 done:
 	return rc;
 }
@@ -1412,9 +1410,6 @@ vos_obj_update(daos_handle_t coh, daos_unit_oid_t oid, daos_epoch_t epoch,
 {
 	daos_handle_t ioh;
 	int rc;
-
-	D_DEBUG(DB_IO, "Update "DF_UOID", desc_nr %d, epoch "DF_U64"\n",
-		DP_UOID(oid), iod_nr, epoch);
 
 	rc = vos_update_begin(coh, oid, epoch, dkey, iod_nr, iods, &ioh, NULL);
 	if (rc) {

--- a/src/vos/vos_tree.c
+++ b/src/vos/vos_tree.c
@@ -967,7 +967,7 @@ key_tree_prepare(struct vos_object *obj, daos_epoch_t epoch,
 	if (krecp != NULL)
 		*krecp = NULL;
 
-	D_DEBUG(DB_IO, "prepare tree, flags=%x, tclass=%d\n", flags, tclass);
+	D_DEBUG(DB_TRACE, "prepare tree, flags=%x, tclass=%d\n", flags, tclass);
 	if (tclass != VOS_BTR_AKEY && (flags & SUBTR_EVT))
 		D_GOTO(out, rc = -DER_INVAL);
 


### PR DESCRIPTION
The current rebuild system always assumes key is a reasonable sized
string while generating log, this assumption obviously is not true.

This patch adds a function to truncate large string key to 63 bytes
and converts non-printable key to "????"

This patch also removes/disables a few D_DEBUGs which are not very
useful for debugging. With this small change, size of log files
generated can reduce about 10%.

Signed-off-by: Liang Zhen <liang.zhen@intel.com>