### PR TITLE
DAOS-3192 hlc: use hlc for I/O

### DIFF
--- a/src/container/cli.c
+++ b/src/container/cli.c
@@ -1827,7 +1827,7 @@ dc_cont_create_snap(tse_task_t *task)
 		return -DER_INVAL;
 	}
 
-	*args->epoch = daos_ts2epoch();
+	*args->epoch = crt_hlc_get();
 	return dc_epoch_op(args->coh, CONT_SNAP_CREATE, args->epoch, task);
 }
 

--- a/src/container/cli_tx.c
+++ b/src/container/cli_tx.c
@@ -187,7 +187,7 @@ daos_tx_hdl2epoch(daos_handle_t th, daos_epoch_t *epoch)
 	struct dc_tx *tx = NULL;
 
 	if (daos_handle_is_inval(th)) {
-		*epoch = daos_ts2epoch();
+		*epoch = crt_hlc_get();
 		return 0;
 	}
 
@@ -216,7 +216,7 @@ dc_tx_open(tse_task_t *task)
 		D_GOTO(out, rc = -DER_NOMEM);
 
 	tx->tx_coh	= args->coh;
-	tx->tx_epoch	= daos_ts2epoch();
+	tx->tx_epoch	= crt_hlc_get();
 	tx->tx_status	= TX_OPEN;
 	tx->tx_mode	= TX_RW;
 

--- a/src/container/srv_epoch.c
+++ b/src/container/srv_epoch.c
@@ -813,7 +813,7 @@ ds_cont_epoch_aggregate(struct rdb_tx *tx, struct ds_pool_hdl *pool_hdl,
 	if (epoch >= DAOS_EPOCH_MAX)
 		return -DER_INVAL;
 	else if (in->cei_epoch == 0)
-		epoch = daos_ts2epoch();
+		epoch = crt_hlc_get();
 
 	rc = trigger_aggregation(tx, 0, epoch, epoch, cont, rpc->cr_ctx);
 

--- a/src/object/srv_obj.c
+++ b/src/object/srv_obj.c
@@ -936,7 +936,7 @@ ds_obj_rw_handler(crt_rpc_t *rpc)
 		orw->orw_map_ver, map_ver, DP_DTI(&orw->orw_dti));
 	/* FIXME: until distributed transaction. */
 	if (orw->orw_epoch == DAOS_EPOCH_MAX) {
-		orw->orw_epoch = daos_ts2epoch();
+		orw->orw_epoch = crt_hlc_get();
 		D_DEBUG(DB_IO, "overwrite epoch "DF_U64"\n", orw->orw_epoch);
 	}
 
@@ -1241,7 +1241,7 @@ ds_obj_enum_handler(crt_rpc_t *rpc)
 
 	/* FIXME: until distributed transaction. */
 	if (oei->oei_epoch == DAOS_EPOCH_MAX) {
-		oei->oei_epoch = daos_ts2epoch();
+		oei->oei_epoch = crt_hlc_get();
 		D_DEBUG(DB_IO, "overwrite epoch "DF_U64"\n", oei->oei_epoch);
 	}
 
@@ -1515,7 +1515,7 @@ ds_obj_punch_handler(crt_rpc_t *rpc)
 
 	/* FIXME: until distributed transaction. */
 	if (opi->opi_epoch == DAOS_EPOCH_MAX) {
-		opi->opi_epoch = daos_ts2epoch();
+		opi->opi_epoch = crt_hlc_get();
 		D_DEBUG(DB_IO, "overwrite epoch "DF_U64"\n", opi->opi_epoch);
 	}
 
@@ -1633,7 +1633,7 @@ ds_obj_query_key_handler(crt_rpc_t *rpc)
 
 	/* FIXME: until distributed transaction. */
 	if (okqi->okqi_epoch == DAOS_EPOCH_MAX) {
-		okqi->okqi_epoch = daos_ts2epoch();
+		okqi->okqi_epoch = crt_hlc_get();
 		D_DEBUG(DB_IO, "overwrite epoch "DF_U64"\n", okqi->okqi_epoch);
 	}
 

--- a/src/tests/suite/daos_rebuild.c
+++ b/src/tests/suite/daos_rebuild.c
@@ -278,7 +278,7 @@ static void
 rebuild_io(test_arg_t *arg, daos_obj_id_t *oids, int oids_nr)
 {
 	struct ioreq	req;
-	daos_epoch_t	eph = arg->hce + arg->index * 2 + 1;
+	daos_epoch_t	eph = arg->index * 2 + 1;
 	int		i;
 	int		punch_idx = 1;
 
@@ -302,7 +302,7 @@ rebuild_io_validate(test_arg_t *arg, daos_obj_id_t *oids, int oids_nr,
 		    bool discard)
 {
 	struct ioreq	req;
-	daos_epoch_t	eph = arg->hce + arg->index * 2 + 1;
+	daos_epoch_t	eph = arg->index * 2 + 1;
 	int		i;
 	int		punch_idx = 1;
 

--- a/src/tests/suite/daos_test.h
+++ b/src/tests/suite/daos_test.h
@@ -143,7 +143,6 @@ typedef struct {
 	int			srv_ntgts;
 	int			srv_disabled_ntgts;
 	int			index;
-	daos_epoch_t		hce;
 	/* The callback is called before pool rebuild. like disconnect
 	 * pool etc.
 	 */

--- a/src/tests/suite/daos_test_common.c
+++ b/src/tests/suite/daos_test_common.c
@@ -493,8 +493,6 @@ test_runable(test_arg_t *arg, unsigned int required_nodes)
 		for (i = 0; i < MAX_KILLS; i++)
 			ranks_to_kill[i] = arg->srv_nnodes -
 					   disable_nodes - i - 1;
-
-		arg->hce = daos_ts2epoch();
 	}
 
 	MPI_Bcast(&runable, 1, MPI_INT, 0, MPI_COMM_WORLD);


### PR DESCRIPTION
Use hlc instead of clocktime as the epoch
for object I/O, but client still use MAX EPOCH
to make sure normal I/O will use newer epoch.

Some minor cleanup for rebuild test.

Signed-off-by: Wang Di <di.wang@intel.com>