### PR TITLE
DAOS-3204 doc: server config env values should not be quoted

### DIFF
--- a/utils/config/daos_server.yml
+++ b/utils/config/daos_server.yml
@@ -232,7 +232,7 @@
 #  log_file: /tmp/daos_server1.log
 #
 #  # Pass specific environment variables to the DAOS server.
-#  # Empty by default.
+#  # Empty by default. Values should be supplied without encapsulating quotes.
 #
 #  env_vars:
 #      - CRT_TIMEOUT=30
@@ -325,7 +325,7 @@
 #  log_file: /tmp/daos_server2.log
 #
 #  # Pass specific environment variables to the DAOS server
-#  # Empty by default.
+#  # Empty by default. Values should be supplied without encapsulating quotes.
 #
 #  env_vars:
 #      - CRT_TIMEOUT=100

--- a/utils/config/examples/daos_server_psm2.yml
+++ b/utils/config/examples/daos_server_psm2.yml
@@ -36,6 +36,8 @@ servers:
   fabric_iface_port: 31416  # map to OFI_PORT=31416
   log_mask: ERR             # map to D_LOG_MASK=ERR
   log_file: /tmp/server.log # map to D_LOG_FILE=/tmp/server.log
+
+  # Environment variable values should be supplied without encapsulating quotes.
   env_vars:                 # influence DAOS IO Server behaviour by setting env variables
   - DAOS_MD_CAP=1024
   - CRT_CTX_SHARE_ADDR=0

--- a/utils/config/examples/daos_server_sockets.yml
+++ b/utils/config/examples/daos_server_sockets.yml
@@ -36,6 +36,8 @@ servers:
   fabric_iface_port: 31416  # map to OFI_PORT=31416
   log_mask: ERR             # map to D_LOG_MASK=ERR
   log_file: /tmp/server.log # map to D_LOG_FILE=/tmp/server.log
+
+  # Environment variable values should be supplied without encapsulating quotes.
   env_vars:                 # influence DAOS IO Server behaviour by setting env variables
   - DAOS_MD_CAP=1024
   - CRT_CTX_SHARE_ADDR=0

--- a/utils/config/examples/daos_server_unittests.yml
+++ b/utils/config/examples/daos_server_unittests.yml
@@ -30,6 +30,8 @@ servers:
   fabric_iface: lo          # map to OFI_INTERFACE=lo
   log_mask: DEBUG,RPC=ERR,MEM=ERR
   log_file: /tmp/server.log # map to D_LOG_FILE=/tmp/server.log
+
+  # Environment variable values should be supplied without encapsulating quotes.
   env_vars:                 # influence DAOS IO Server behaviour by setting env variables
   - DAOS_MD_CAP=1024
   - CRT_CTX_SHARE_ADDR=0


### PR DESCRIPTION
Notify in server config file descriptions and example files that when
specifying values of arbitrary environment variables in per-server
section (env_var parameter), encapsulating quotes should not be used.

Signed-off-by: Tom Nabarro <tom.nabarro@intel.com>