### PR TITLE
DAOS-3168 pool: skip DOWN targets for pool space query

### DIFF
--- a/src/container/srv_target.c
+++ b/src/container/srv_target.c
@@ -1034,7 +1034,7 @@ ds_cont_tgt_query_handler(crt_rpc_t *rpc)
 	struct cont_tgt_query_in	*in  = crt_req_get(rpc);
 	struct cont_tgt_query_out	*out = crt_reply_get(rpc);
 	struct dss_coll_ops		coll_ops;
-	struct dss_coll_args		coll_args;
+	struct dss_coll_args		coll_args = { 0 };
 	struct xstream_cont_query	pack_args;
 
 	out->tqo_min_purged_epoch  = DAOS_EPOCH_MAX;

--- a/src/include/daos/pool_map.h
+++ b/src/include/daos/pool_map.h
@@ -202,11 +202,19 @@ int pool_map_find_upin_tgts(struct pool_map *map, struct pool_target **tgt_pp,
 			  unsigned int *tgt_cnt);
 int pool_map_find_target_by_rank_idx(struct pool_map *map, uint32_t rank,
 				 uint32_t tgt_idx, struct pool_target **tgts);
+int pool_map_find_failed_tgts_by_rank(struct pool_map *map,
+				  struct pool_target ***tgt_ppp,
+				  unsigned int *tgt_cnt, d_rank_t rank);
 bool
 pool_map_node_status_match(struct pool_domain *dom, unsigned int status);
 
 struct pool_domain *
 pool_map_find_node_by_rank(struct pool_map *map, uint32_t rank);
+
+int pool_map_find_by_rank_status(struct pool_map *map,
+				 struct pool_target ***tgt_ppp,
+				 unsigned int *tgt_cnt, unsigned int status,
+				 d_rank_t rank);
 
 static inline struct pool_target *
 pool_map_targets(struct pool_map *map)

--- a/src/include/daos_srv/daos_server.h
+++ b/src/include/daos_srv/daos_server.h
@@ -411,6 +411,8 @@ struct dss_coll_args {
 	/** Arguments for dss_collective func (Mandatory) */
 	void				*ca_func_args;
 	void				*ca_aggregator;
+	int				*ca_exclude_tgts;
+	int				ca_exclude_tgts_cnt;
 	/** Stream arguments for all streams */
 	struct dss_coll_stream_args	ca_stream_args;
 };

--- a/src/iosrv/srv.c
+++ b/src/iosrv/srv.c
@@ -1218,6 +1218,21 @@ dss_collective_reduce_internal(struct dss_coll_ops *ops,
 		stream			= &stream_args->csa_streams[tid];
 		stream->st_coll_args	= &carg;
 
+		if (args->ca_exclude_tgts_cnt) {
+			int i;
+
+			for (i = 0; i < args->ca_exclude_tgts_cnt; i++)
+				if (args->ca_exclude_tgts[i] == tid)
+					break;
+
+			if (i < args->ca_exclude_tgts_cnt) {
+				D_DEBUG(DB_TRACE, "Skip tgt %d\n", tid);
+				rc = ABT_future_set(future, (void *)stream);
+				D_ASSERTF(rc == ABT_SUCCESS, "%d\n", rc);
+				continue;
+			}
+		}
+
 		dx = dss_xstream_get(DSS_MAIN_XS_ID(tid));
 		if (create_ult)
 			rc = ABT_thread_create(dx->dx_pools[DSS_POOL_SHARE],
@@ -1228,9 +1243,8 @@ dss_collective_reduce_internal(struct dss_coll_ops *ops,
 					     collective_func, stream, NULL);
 
 		if (rc != ABT_SUCCESS) {
-			aggregator.at_args.st_rc = dss_abterr2der(rc);
-			rc = ABT_future_set(future,
-					    (void *)&aggregator);
+			stream->st_rc = dss_abterr2der(rc);
+			rc = ABT_future_set(future, (void *)stream);
 			D_ASSERTF(rc == ABT_SUCCESS, "%d\n", rc);
 		}
 	}
@@ -1300,12 +1314,8 @@ static int
 dss_collective_internal(int (*func)(void *), void *arg, bool thread, int flag)
 {
 	int				rc;
-	struct dss_coll_ops		coll_ops;
-	struct dss_coll_args		coll_args;
-
-
-	memset(&coll_ops, 0, sizeof(coll_ops));
-	memset(&coll_args, 0, sizeof(coll_args));
+	struct dss_coll_ops		coll_ops = { 0 };
+	struct dss_coll_args		coll_args = { 0 };
 
 	coll_ops.co_func	= func;
 	coll_args.ca_func_args	= arg;


### PR DESCRIPTION
Skip DOWN targets for pool state query.

Add excluded target list for collective operation.

Signed-off-by: Wang Di <di.wang@intel.com>