### PR TITLE
DAOS-2412 doc: update docker files & instructions

### DIFF
--- a/doc/admin/installation.md
+++ b/doc/admin/installation.md
@@ -41,14 +41,18 @@ under consideration.
 
 To check out the DAOS source code, run the following command:
 
-    git clone https://github.com/daos-stack/daos.git
+```
+    $ git clone https://github.com/daos-stack/daos.git
+```
 
 This command clones the DAOS git repository (path referred as ${daospath}
 below). Then initialize the submodules with:
 
-    cd ${daospath}
-    git submodule init
-    git submodule update
+```
+    $ cd ${daospath}
+    $ git submodule init
+    $ git submodule update
+```
 
 ## DAOS from Scratch
 
@@ -91,7 +95,7 @@ If all the software dependencies listed previously are already satisfied, then
 type the following command in the top source directory to build the DAOS stack:
 
 ```
-    scons --config=force install
+    $ scons --config=force install
 ```
 
 If you are a developer of DAOS, we recommend following the instructions in the
@@ -101,7 +105,7 @@ Otherwise, the missing dependencies can be built automatically by invoking scons
 with the following parameters:
 
 ```
-    scons --config=force --build-deps=yes install
+    $ scons --config=force --build-deps=yes install
 ```
 
 By default, DAOS and its dependencies are installed under ${daospath}/install.
@@ -129,16 +133,36 @@ specified through PREFIX.
 
 ## DAOS in Docker
 
+This section describes how to build and run the DAOS service in a Docker
+container. A minimum of 5GB of DRAM and 16GB of disk space will be required.
+
+### Building from GitHub
+
 To build the Docker image directly from GitHub, run the following command:
 
 ```
     $ docker build -t daos -f Dockerfile.centos.7 github.com/daos-stack/daos#:utils/docker
 ```
 
-This creates a CentOS7 image, fetches the latest DAOS version from GitHub and
-builds it in the container. For Ubuntu and other Linux distributions, replace
-Dockerfile.centos.7 with Dockerfile.ubuntu.18.04 and the appropriate version
-of interest.
+This creates a CentOS7 image, fetches the latest DAOS version from GitHub,
+builds it and install it in the image.
+For Ubuntu and other Linux distributions, replace Dockerfile.centos.7 with
+Dockerfile.ubuntu.18.04 and the appropriate version of interest.
+
+Once the image created, one can start start a container that will run eventually
+run the DAOS service (see section below):
+
+```
+    $ docker run -it -d --privileged --name server \
+            -v /tmp/uri:/tmp/uri \
+            -v /dev/hugepages:/dev/hugepages \
+            daos
+```
+
+If Docker is being run on a non Linux system (e.g. OSX), the export of /dev/hugepages
+should be removed since it is not supported.
+
+### Building from Local Tree
 
 To build from a local tree stored on the host, a volume must be created to share
 the source tree with the Docker container. To do so, please execute the following
@@ -148,14 +172,62 @@ command to create a docker image without checking out the DAOS source tree:
     $ docker build -t daos -f utils/docker/Dockerfile.centos.7 --build-arg NOBUILD=1 .
 ```
 
-Then please execute the following command to export the DAOS source tree to the
-docker container and build it:
+Then create a container that can access the local DAOS source tree:
 
 ```
-    $ docker run -v ${daospath}:/home/daos/daos:Z daos /bin/bash -c "scons --config=force --build-deps=yes install"
+    $ docker run -it -d --privileged --name server \
+            -v ${daospath}:/home/daos/daos:Z \
+            -v /tmp/uri:/tmp/uri \
+            -v /dev/hugepages:/dev/hugepages \
+            daos
 ```
 
 ${daospath} should be replaced with the full path to your DAOS source tree.
+As mentioned above, the export of /dev/hugepages should be removed if the
+host is a not a Linux system.
+
+Then please execute the following command to build and install DAOS in the
+container:
+
+```
+    $ docker exec server scons --build-deps=yes install PREFIX=/usr
+```
+
+### Running DAOS Service in Docker
+
+First of all, SPDK should be initialized in this newly created container.
+This can be done by running the following command:
+
+```
+    $ docker exec server daos_server storage prep-nvme
+```
+
+Please note that this command reports that /dev/hugepages is not accessible on
+OSX. This still allows to run the DAOS service despite the error.
+
+The DAOS service can then be started as follows:
+
+```
+    $ docker exec server orterun -allow-run-as-root -H localhost -np 1 \
+            daos_server start \
+            -a /tmp/uri \
+            -o /home/daos/daos/utils/config/examples/daos_server_local.yml
+```
+
+The daos_server_local.yml configuration file sets up a simple local DAOS system
+with a single server instance running in the container. By default, it uses 4GB
+of DRAM to emulate persistent memory and 16GB of bulk storage under /tmp.
+The storage size can be tweaked in the yaml file if necessariy.
+
+Once started, the DAOS server waits for the administrator to format the system.
+This can be triggered in a different shell via the following command:
+
+```
+    $ docker exec server daos_shell -i storage format -f
+```
+
+Upon successful completion of format, the storage engine is started and pools
+can be created via the daos admin tool (see next section).
 
 ## DAOS for Development
 
@@ -214,21 +286,21 @@ located in the src/control/vendor directory. The DAOS codebase uses
 On EL7 and later:
 
 ```
-    yum install yum-plugin-copr
-    yum copr enable hnakamur/golang-dep
-    yum install golang-dep
+    $ yum install yum-plugin-copr
+    $ yum copr enable hnakamur/golang-dep
+    $ yum install golang-dep
 ```
 
 On Fedora 27 and later:
 
 ```
-    dnf install dep
+    $ dnf install dep
 ```
 
 On Ubuntu 18.04 and later:
 
 ```
-    apt-get install go-dep
+    $ apt-get install go-dep
 ```
 
 For OSes that don't supply a package:
@@ -237,8 +309,8 @@ For OSes that don't supply a package:
 your PATH:
 
 ```
-    mkdir -p $GOPATH/bin
-    export PATH=$GOPATH/bin:$PATH
+    $ mkdir -p $GOPATH/bin
+    $ export PATH=$GOPATH/bin:$PATH
 ```
 
 - Then follow the [installation instructions on Github](https://github.com/golang/dep).
@@ -253,8 +325,8 @@ sure DAOS is cloned into
 Then:
 
 ```
-    cd $GOPATH/src/github.com/daos-stack/daos/src/control
-    dep ensure
+    $ cd $GOPATH/src/github.com/daos-stack/daos/src/control
+    $ dep ensure
 ```
 
 ### Protobuf Compiler
@@ -283,7 +355,7 @@ Generate the Go file using the gRPC plugin. You can designate the directory
 location:
 
 ```
-	protoc myfile.proto --go_out=plugins=grpc:<go_file_dir>
+    $ protoc myfile.proto --go_out=plugins=grpc:<go_file_dir>
 ```
 
 Generate the C files using Protobuf-C. As the header and source files in DAOS
@@ -291,7 +363,7 @@ are typically kept in separate locations, you will need to move them manually
 to their destination directories:
 
 ```
-	protoc-c myfile.proto --c_out=.
-	mv myfile.pb-c.h <c_file_include_dir>
-	mv myfile.pb-c.c <c_file_src_dir>
+    $ protoc-c myfile.proto --c_out=.
+    $ mv myfile.pb-c.h <c_file_include_dir>
+    $ mv myfile.pb-c.c <c_file_src_dir>
 ```

--- a/src/control/server/storage_nvme.go
+++ b/src/control/server/storage_nvme.go
@@ -314,6 +314,7 @@ func (n *nvmeStorage) Format(i int, results *(common.NvmeControllerResults)) {
 			addCretFormat(pb.ResponseStatus_CTRL_SUCCESS, "")
 			n.controllers = loadControllers(cs, ns)
 		}
+	case bdFile:
 	default:
 		addCretFormat(
 			pb.ResponseStatus_CTRL_ERR_CONF,

--- a/utils/config/examples/daos_server_local.yml
+++ b/utils/config/examples/daos_server_local.yml
@@ -1,0 +1,37 @@
+# access_points: ['localhost:10001']
+name: daos_server
+port: 10001
+provider: ofi+sockets
+socket_dir: /tmp/daos_sockets
+nr_hugepages: 4096
+control_log_file: /tmp/daos_control.log
+transport_config:
+   allow_insecure: true
+
+servers:
+-
+  targets: 1
+  first_core: 0
+  nr_xs_helpers: 0
+  fabric_iface: eth0
+  fabric_iface_port: 31416
+  log_file: /tmp/daos_server.log
+
+  env_vars:
+  - DAOS_MD_CAP=1024
+  - CRT_CTX_SHARE_ADDR=0
+  - CRT_TIMEOUT=30
+  - FI_SOCKETS_MAX_CONN_RETRY=1
+  - FI_SOCKETS_CONN_TIMEOUT=2000
+
+  # Storage definitions
+
+  # When scm_class is set to ram, tmpfs will be used to emulate SCM.
+  # The size of ram is specified by scm_size in GB units.
+  scm_mount: /mnt/daos	# map to -s /mnt/daos
+  scm_class: ram
+  scm_size: 4
+
+  bdev_class: file
+  bdev_size: 16
+  bdev_list: [/tmp/daos-bdev]

--- a/utils/docker/Dockerfile-mockbuild.centos.7
+++ b/utils/docker/Dockerfile-mockbuild.centos.7
@@ -6,7 +6,7 @@
 
 # Pull base image
 FROM centos:7
-MAINTAINER Brian J. Murrell <brian.murrell@intel.com>
+MAINTAINER <daos@daos.groups.io>
 
 # use same UID as host and default value of 1000 if not specified
 ARG UID=1000

--- a/utils/docker/Dockerfile-rpmbuild.sles.12.3
+++ b/utils/docker/Dockerfile-rpmbuild.sles.12.3
@@ -6,7 +6,7 @@
 
 # Pull base image
 FROM suse/sles:12.3
-MAINTAINER Brian J. Murrell <brian.murrell@intel.com>
+MAINTAINER <daos@daos.groups.io>
 
 # use same UID as host and default value of 1000 if not specified
 ARG UID=1000

--- a/utils/docker/Dockerfile.centos.7
+++ b/utils/docker/Dockerfile.centos.7
@@ -41,7 +41,7 @@
 
 # Pull base image
 FROM centos:7
-MAINTAINER Johann Lombardi <johann.lombardi@intel.com>
+MAINTAINER <daos@daos.groups.io>
 
 # Build arguments can be set via --build-arg
 # use same UID as host and default value of 1000 if not specified
@@ -60,7 +60,7 @@ RUN yum -y install epel-release; \
         make meson nasm ninja-build numactl-devel openssl-devel        \
 	pandoc patch pylint python python-devel python36-devel         \
 	python-pep8 python-requests python2-pygithub readline-devel    \
-	scons sg3_utils ShellCheck yasm
+	scons sg3_utils ShellCheck yasm pciutils
 
 # DAOS specific
 RUN yum -y install \
@@ -117,7 +117,7 @@ ARG CACHEBUST=1
 RUN yum -y upgrade --exclude=dpdk-devel,dpdk
 
 # Switch to new user
-USER $USER
+#USER $USER
 WORKDIR /home/$USER
 
 # set NOBUILD to disable git clone & build
@@ -129,11 +129,11 @@ WORKDIR /home/$USER/daos
 
 # Build DAOS & dependencies
 RUN if [ "x$NOBUILD" = "x" ] ; then git submodule init && git submodule update; fi
-RUN if [ "x$NOBUILD" = "x" ] ; then scons --build-deps=yes install; fi
+RUN if [ "x$NOBUILD" = "x" ] ; then scons --build-deps=yes install PREFIX=/usr; fi
 
 # Set environment variables
-ENV PATH=/home/daos/daos/install/bin:$PATH
-ENV LD_LIBRARY_PATH=/home/daos/daos/install/lib:/home/daos/daos/install/lib/daos_srv:$LD_LIBRARY_PATH
-ENV CPATH=/home/daos/daos/install/include:$CPATH
+ENV LD_LIBRARY_PATH=/usr/lib:$LD_LIBRARY_PATH
 ENV CRT_PHY_ADDR_STR="ofi+sockets"
 ENV OFI_INTERFACE=eth0
+ENV FI_SOCKETS_MAX_CONN_RETRY=1
+ENV CRT_ATTACH_INFO_PATH=/tmp/uri

--- a/utils/docker/Dockerfile.leap.15
+++ b/utils/docker/Dockerfile.leap.15
@@ -7,7 +7,7 @@
 
 # Pull base image
 FROM opensuse/leap:15
-MAINTAINER Johann Lombardi <johann.lombardi@intel.com>
+MAINTAINER <daos@daos.groups.io>
 
 # Build arguments can be set via -build-arg
 # use same UID as host and default value of 1000 if not specified
@@ -52,7 +52,7 @@ RUN mkdir /mnt/daos
 RUN chown daos.daos /mnt/daos || { cat /etc/passwd; cat /etc/group; cat /etc/shadow; chown daos /mnt/daos; chgrp daos /mnt/daos; ls -ld /mnt/daos; }
 
 # Switch to new user
-USER $USER
+#USER $USER
 WORKDIR /home/$USER
 
 # set NOBUILD to disable git clone & build
@@ -63,11 +63,11 @@ WORKDIR /home/$USER/daos
 
 # Build DAOS & dependencies
 RUN if [ "x$NOBUILD" = "x" ] ; then git submodule init && git submodule update; fi
-RUN if [ "x$NOBUILD" = "x" ] ; then scons --build-deps=yes install; fi
+RUN if [ "x$NOBUILD" = "x" ] ; then scons --build-deps=yes install PREFIX=/usr; fi
 
 # Set environment variables
-ENV PATH=/home/daos/daos/install/bin:$PATH
-ENV LD_LIBRARY_PATH=/home/daos/daos/install/lib:/home/daos/daos/install/lib/daos_srv:$LD_LIBRARY_PATH
-ENV CPATH=/home/daos/daos/install/include:$CPATH
+ENV LD_LIBRARY_PATH=/usr/lib:$LD_LIBRARY_PATH
 ENV CRT_PHY_ADDR_STR="ofi+sockets"
 ENV OFI_INTERFACE=eth0
+ENV FI_SOCKETS_MAX_CONN_RETRY=1
+ENV CRT_ATTACH_INFO_PATH=/tmp/uri

--- a/utils/docker/Dockerfile.leap.42.3
+++ b/utils/docker/Dockerfile.leap.42.3
@@ -7,7 +7,7 @@
 
 # Pull base image
 FROM opensuse/leap:42.3
-MAINTAINER Johann Lombardi <johann.lombardi@intel.com>
+MAINTAINER <daos@daos.groups.io>
 
 # Build arguments can be set via -build-arg
 # use same UID as host and default value of 1000 if not specified
@@ -56,7 +56,7 @@ RUN mkdir /mnt/daos
 RUN chown daos.daos /mnt/daos || { cat /etc/passwd; cat /etc/group; cat /etc/shadow; chown daos /mnt/daos; chgrp daos /mnt/daos; ls -ld /mnt/daos; }
 
 # Switch to new user
-USER $USER
+#USER $USER
 WORKDIR /home/$USER
 
 # set NOBUILD to disable git clone & build
@@ -68,11 +68,11 @@ WORKDIR /home/$USER/daos
 
 # Build DAOS & dependencies
 RUN if [ "x$NOBUILD" = "x" ] ; then git submodule init && git submodule update; fi
-RUN if [ "x$NOBUILD" = "x" ] ; then scons --build-deps=yes install; fi
+RUN if [ "x$NOBUILD" = "x" ] ; then scons --build-deps=yes install PREFIX=/usr; fi
 
 # Set environment variables
-ENV PATH=/home/daos/daos/install/bin:$PATH
-ENV LD_LIBRARY_PATH=/home/daos/daos/install/lib:/home/daos/daos/install/lib/daos_srv:$LD_LIBRARY_PATH
-ENV CPATH=/home/daos/daos/install/include:$CPATH
+ENV LD_LIBRARY_PATH=/usr/lib:$LD_LIBRARY_PATH
 ENV CRT_PHY_ADDR_STR="ofi+sockets"
 ENV OFI_INTERFACE=eth0
+ENV FI_SOCKETS_MAX_CONN_RETRY=1
+ENV CRT_ATTACH_INFO_PATH=/tmp/uri

--- a/utils/docker/Dockerfile.sles.12.3
+++ b/utils/docker/Dockerfile.sles.12.3
@@ -7,7 +7,7 @@
 
 # Pull base image
 FROM suse/sles:12.3
-MAINTAINER Johann Lombardi <johann.lombardi@intel.com>
+MAINTAINER <daos@daos.groups.io>
 
 # Build arguments can be set via -build-arg
 # use same UID as host and default value of 1000 if not specified
@@ -84,7 +84,7 @@ RUN mkdir /mnt/daos
 RUN chown daos.daos /mnt/daos || { cat /etc/passwd; cat /etc/group; cat /etc/shadow; chown daos /mnt/daos; chgrp daos /mnt/daos; ls -ld /mnt/daos; }
 
 # Switch to new user
-USER $USER
+#USER $USER
 WORKDIR /home/$USER
 
 # set NOBUILD to disable git clone & build
@@ -96,11 +96,11 @@ WORKDIR /home/$USER/daos
 
 # Build DAOS & dependencies
 RUN if [ "x$NOBUILD" = "x" ] ; then git submodule init && git submodule update; fi
-RUN if [ "x$NOBUILD" = "x" ] ; then scons --build-deps=yes install; fi
+RUN if [ "x$NOBUILD" = "x" ] ; then scons --build-deps=yes install PREFIX=/usr; fi
 
 # Set environment variables
-ENV PATH=/home/daos/daos/install/bin:$PATH
-ENV LD_LIBRARY_PATH=/home/daos/daos/install/lib:/home/daos/daos/install/lib/daos_srv:$LD_LIBRARY_PATH
-ENV CPATH=/home/daos/daos/install/include:$CPATH
+ENV LD_LIBRARY_PATH=/usr/lib:$LD_LIBRARY_PATH
 ENV CRT_PHY_ADDR_STR="ofi+sockets"
 ENV OFI_INTERFACE=eth0
+ENV FI_SOCKETS_MAX_CONN_RETRY=1
+ENV CRT_ATTACH_INFO_PATH=/tmp/uri

--- a/utils/docker/Dockerfile.ubuntu.18.04
+++ b/utils/docker/Dockerfile.ubuntu.18.04
@@ -7,7 +7,7 @@
 
 # Pull base image
 FROM ubuntu:18.04
-MAINTAINER Johann Lombardi <johann.lombardi@intel.com>
+MAINTAINER <daos@daos.groups.io>
 
 # Build arguments can be set via -build-arg
 # use same UID as host and default value of 1000 if not specified
@@ -55,7 +55,7 @@ RUN mkdir /mnt/daos
 RUN chown daos.daos /mnt/daos
 
 # Switch to new user
-USER $USER
+#USER $USER
 WORKDIR /home/$USER
 
 # set NOBUILD to disable git clone & build
@@ -67,11 +67,11 @@ WORKDIR /home/$USER/daos
 
 # Build DAOS & dependencies
 RUN if [ "x$NOBUILD" = "x" ] ; then git submodule init && git submodule update; fi
-RUN if [ "x$NOBUILD" = "x" ] ; then scons --build-deps=yes install; fi
+RUN if [ "x$NOBUILD" = "x" ] ; then scons --build-deps=yes install PREFIX=/usr; fi
 
 # Set environment variables
-ENV PATH=/home/daos/daos/install/bin:$PATH
-ENV LD_LIBRARY_PATH=/home/daos/daos/install/lib:/home/daos/daos/install/lib/daos_srv:$LD_LIBRARY_PATH
-ENV CPATH=/home/daos/daos/install/include:$CPATH
+ENV LD_LIBRARY_PATH=/usr/lib:$LD_LIBRARY_PATH
 ENV CRT_PHY_ADDR_STR="ofi+sockets"
 ENV OFI_INTERFACE=eth0
+ENV FI_SOCKETS_MAX_CONN_RETRY=1
+ENV CRT_ATTACH_INFO_PATH=/tmp/uri

--- a/utils/docker/README.md
+++ b/utils/docker/README.md
@@ -1,53 +1,5 @@
 # DAOS in Docker
 
-Docker is the fastest way to build, install and run DAOS on a non-Linux system.
-
-## Building DAOS in a Container
-
-To build the Docker image directly from GitHub, run the following command:
-
-```
-    $ docker build -t daos -f Dockerfile.centos\:7 github.com/daos-stack/daos#:utils/docker
-```
-
-This creates a CentOS7 image, fetches the latest DAOS version from GitHub and  builds it in the container.
-For Ubuntu, replace Dockerfile.centos\:7 with Dockerfile.ubuntu\:18.04.
-
-To build from a local tree stored on the host, a volume must be created to share the source tree with the Docker container. To do so, execute the following command to create a docker image without checking out the DAOS source tree:
-
-```
-    $ docker build -t daos -f utils/docker/Dockerfile.centos\:7 --build-arg NOBUILD=1 .
-```
-
-Then execute the following command to export the DAOS source tree to the docker container and build it:
-
-```
-    $ docker run -v ${daospath}:/home/daos/daos:Z daos /bin/bash -c "scons --build-deps=yes USE_INSTALLED=all install"
-```
-
-## Running DAOS in a Container
-
-Start by creating a container that will run the DAOS service:
-
-```
-    $ docker run -it -d --name server --tmpfs /mnt/daos:rw,uid=1000,size=1G -v /tmp/uri:/tmp/uri daos
-```
-
-Add "-v \${daospath}:/home/daos/daos:Z" to this command line if the DAOS source tree is stored on the host.
-
-This allocates 1GB of DRAM for DAOS storage. The more, the better.
-
-To start the DAOS service in this newly created container, execute the following command:
-
-```
-    $ docker exec server orterun -H localhost -np 1 --report-uri /tmp/uri/uri.txt daos_server
-```
-
-Once the DAOS server is started, the integration tests can be run as follows:
-
-```
-    $ docker run -v /tmp/uri:/tmp/uri daos \
-      orterun -H localhost -np 1 --ompi-server file:/tmp/uri/uri.txt daos_test
-```
-
-Again, "-v \${daospath}:/home/daos/daos:Z" must be added if the DAOS source tree is shared with the host.
+Docker files for different Linux distributions. Please refer to the [online
+documenation](http://daos.io) for instructions on how to build and use DAOS
+in docker.


### PR DESCRIPTION
Add new configuration file setting up a local DAOS system
with 4GB of DRAM and 16GB of bulk storage in /tmp.
Fix control plane to support formatting with device file.

In addition, change the docker files and instructions as follows:
- point docker files at the public mailing list
- install DAOS binaries and libraries under /usr
- run DAOS service in a privileged container (required for SPDK)
- use newly added local configuration file
- add instructions on how to reformat

Signed-off-by: Johann Lombardi <johann.lombardi@intel.com>