### PR TITLE
DAOS-2757 control: rename symbols to ResourceAction format

### DIFF
--- a/src/control/client/connect.go
+++ b/src/control/client/connect.go
@@ -105,11 +105,11 @@ type Connect interface {
 	// GetActiveConns verifies states and removes inactive conns
 	GetActiveConns(ResultMap) ResultMap
 	ClearConns() ResultMap
-	ScanStorage() (ClientCtrlrMap, ClientModuleMap)
-	FormatStorage() (ClientCtrlrMap, ClientMountMap)
-	UpdateStorage(*pb.UpdateStorageReq) (ClientCtrlrMap, ClientModuleMap)
+	StorageScan() (ClientCtrlrMap, ClientModuleMap)
+	StorageFormat() (ClientCtrlrMap, ClientMountMap)
+	StorageUpdate(*pb.StorageUpdateReq) (ClientCtrlrMap, ClientModuleMap)
 	// TODO: implement Burnin client features
-	//BurninStorage() (ClientCtrlrMap, ClientModuleMap)
+	//StorageBurnIn() (ClientCtrlrMap, ClientModuleMap)
 	ListFeatures() ClientFeatureMap
 	KillRank(uuid string, rank uint32) ResultMap
 	CreatePool(*pb.CreatePoolReq) ResultMap

--- a/src/control/client/connect_test.go
+++ b/src/control/client/connect_test.go
@@ -161,12 +161,12 @@ func TestListFeatures(t *testing.T) {
 		"unexpected client features returned")
 }
 
-func TestScanStorage(t *testing.T) {
+func TestStorageScan(t *testing.T) {
 	defer common.ShowLogOnFailure(t)()
 
 	cc := defaultClientSetup()
 
-	clientNvme, clientScm := cc.ScanStorage()
+	clientNvme, clientScm := cc.StorageScan()
 
 	AssertEqual(
 		t, clientNvme, NewClientNvme(MockCtrlrs, MockServers),
@@ -177,7 +177,7 @@ func TestScanStorage(t *testing.T) {
 		"unexpected client SCM modules returned")
 }
 
-func TestFormatStorage(t *testing.T) {
+func TestStorageFormat(t *testing.T) {
 	defer common.ShowLogOnFailure(t)()
 
 	tests := []struct {
@@ -197,7 +197,7 @@ func TestFormatStorage(t *testing.T) {
 			MockModuleResults, MockMountResults, nil, tt.formatRet, nil, nil,
 			nil, nil)
 
-		cNvmeMap, cMountMap := cc.FormatStorage()
+		cNvmeMap, cMountMap := cc.StorageFormat()
 
 		if tt.formatRet != nil {
 			for _, addr := range MockServers {
@@ -223,7 +223,7 @@ func TestFormatStorage(t *testing.T) {
 	}
 }
 
-func TestUpdateStorage(t *testing.T) {
+func TestStorageUpdate(t *testing.T) {
 	defer common.ShowLogOnFailure(t)()
 
 	tests := []struct {
@@ -243,7 +243,7 @@ func TestUpdateStorage(t *testing.T) {
 			MockModuleResults, MockMountResults, nil, nil, tt.updateRet, nil,
 			nil, nil)
 
-		cNvmeMap, cModuleMap := cc.UpdateStorage(new(pb.UpdateStorageReq))
+		cNvmeMap, cModuleMap := cc.StorageUpdate(new(pb.StorageUpdateReq))
 
 		if tt.updateRet != nil {
 			for _, addr := range MockServers {

--- a/src/control/client/mocks.go
+++ b/src/control/client/mocks.go
@@ -84,58 +84,58 @@ func (m *mgmtCtlListFeaturesClient) Recv() (*pb.Feature, error) {
 	return m.features[0], nil
 }
 
-type mgmtCtlFormatStorageClient struct {
+type mgmtCtlStorageFormatClient struct {
 	grpc.ClientStream
 	ctrlrResults  NvmeControllerResults
 	mountResults  ScmMountResults
 	alreadyCalled bool
 }
 
-func (m *mgmtCtlFormatStorageClient) Recv() (*pb.FormatStorageResp, error) {
+func (m *mgmtCtlStorageFormatClient) Recv() (*pb.StorageFormatResp, error) {
 	if m.alreadyCalled {
 		return nil, io.EOF
 	}
 	m.alreadyCalled = true
 
-	return &pb.FormatStorageResp{
+	return &pb.StorageFormatResp{
 		Crets: m.ctrlrResults,
 		Mrets: m.mountResults,
 	}, nil
 }
 
-type mgmtCtlUpdateStorageClient struct {
+type mgmtCtlStorageUpdateClient struct {
 	grpc.ClientStream
 	ctrlrResults  NvmeControllerResults
 	moduleResults ScmModuleResults
 	alreadyCalled bool
 }
 
-func (m *mgmtCtlUpdateStorageClient) Recv() (*pb.UpdateStorageResp, error) {
+func (m *mgmtCtlStorageUpdateClient) Recv() (*pb.StorageUpdateResp, error) {
 	if m.alreadyCalled {
 		return nil, io.EOF
 	}
 	m.alreadyCalled = true
 
-	return &pb.UpdateStorageResp{
+	return &pb.StorageUpdateResp{
 		Crets: m.ctrlrResults,
 		Mrets: m.moduleResults,
 	}, nil
 }
 
-type mgmtCtlBurninStorageClient struct {
+type mgmtCtlStorageBurnInClient struct {
 	grpc.ClientStream
 	ctrlrResults  NvmeControllerResults
 	mountResults  ScmMountResults
 	alreadyCalled bool
 }
 
-func (m *mgmtCtlBurninStorageClient) Recv() (*pb.BurninStorageResp, error) {
+func (m *mgmtCtlStorageBurnInClient) Recv() (*pb.StorageBurnInResp, error) {
 	if m.alreadyCalled {
 		return nil, io.EOF
 	}
 	m.alreadyCalled = true
 
-	return &pb.BurninStorageResp{
+	return &pb.StorageBurnInResp{
 		Crets: m.ctrlrResults,
 		Mrets: m.mountResults,
 	}, nil
@@ -176,40 +176,40 @@ func (m *mockMgmtCtlClient) ListFeatures(
 	return &mgmtCtlListFeaturesClient{features: m.features}, nil
 }
 
-func (m *mockMgmtCtlClient) ScanStorage(
-	ctx context.Context, req *pb.ScanStorageReq, o ...grpc.CallOption) (
-	*pb.ScanStorageResp, error) {
+func (m *mockMgmtCtlClient) StorageScan(
+	ctx context.Context, req *pb.StorageScanReq, o ...grpc.CallOption) (
+	*pb.StorageScanResp, error) {
 	// return successful query results, state member messages
 	// initialise with zero values indicating mgmt.CTRL_SUCCESS
-	return &pb.ScanStorageResp{
+	return &pb.StorageScanResp{
 		Ctrlrs:  m.ctrlrs,
 		Modules: m.modules,
 	}, m.scanRet
 }
 
-func (m *mockMgmtCtlClient) FormatStorage(
-	ctx context.Context, req *pb.FormatStorageReq, o ...grpc.CallOption) (
-	pb.MgmtCtl_FormatStorageClient, error) {
+func (m *mockMgmtCtlClient) StorageFormat(
+	ctx context.Context, req *pb.StorageFormatReq, o ...grpc.CallOption) (
+	pb.MgmtCtl_StorageFormatClient, error) {
 
-	return &mgmtCtlFormatStorageClient{
+	return &mgmtCtlStorageFormatClient{
 		ctrlrResults: m.ctrlrResults, mountResults: m.mountResults,
 	}, m.formatRet
 }
 
-func (m *mockMgmtCtlClient) UpdateStorage(
-	ctx context.Context, req *pb.UpdateStorageReq, o ...grpc.CallOption) (
-	pb.MgmtCtl_UpdateStorageClient, error) {
+func (m *mockMgmtCtlClient) StorageUpdate(
+	ctx context.Context, req *pb.StorageUpdateReq, o ...grpc.CallOption) (
+	pb.MgmtCtl_StorageUpdateClient, error) {
 
-	return &mgmtCtlUpdateStorageClient{
+	return &mgmtCtlStorageUpdateClient{
 		ctrlrResults: m.ctrlrResults, moduleResults: m.moduleResults,
 	}, m.updateRet
 }
 
-func (m *mockMgmtCtlClient) BurninStorage(
-	ctx context.Context, req *pb.BurninStorageReq, o ...grpc.CallOption) (
-	pb.MgmtCtl_BurninStorageClient, error) {
+func (m *mockMgmtCtlClient) StorageBurnIn(
+	ctx context.Context, req *pb.StorageBurnInReq, o ...grpc.CallOption) (
+	pb.MgmtCtl_StorageBurnInClient, error) {
 
-	return &mgmtCtlBurninStorageClient{
+	return &mgmtCtlStorageBurnInClient{
 		ctrlrResults: m.ctrlrResults, mountResults: m.mountResults,
 	}, m.burninRet
 }

--- a/src/control/cmd/dmg/command_test.go
+++ b/src/control/cmd/dmg/command_test.go
@@ -96,18 +96,18 @@ func (tc *testConn) ClearConns() client.ResultMap {
 	return nil
 }
 
-func (tc *testConn) ScanStorage() (client.ClientCtrlrMap, client.ClientModuleMap) {
-	tc.appendInvocation("ScanStorage")
+func (tc *testConn) StorageScan() (client.ClientCtrlrMap, client.ClientModuleMap) {
+	tc.appendInvocation("StorageScan")
 	return nil, nil
 }
 
-func (tc *testConn) FormatStorage() (client.ClientCtrlrMap, client.ClientMountMap) {
-	tc.appendInvocation("FormatStorage")
+func (tc *testConn) StorageFormat() (client.ClientCtrlrMap, client.ClientMountMap) {
+	tc.appendInvocation("StorageFormat")
 	return nil, nil
 }
 
-func (tc *testConn) UpdateStorage(req *pb.UpdateStorageReq) (client.ClientCtrlrMap, client.ClientModuleMap) {
-	tc.appendInvocation(fmt.Sprintf("UpdateStorage-%s", req))
+func (tc *testConn) StorageUpdate(req *pb.StorageUpdateReq) (client.ClientCtrlrMap, client.ClientModuleMap) {
+	tc.appendInvocation(fmt.Sprintf("StorageUpdate-%s", req))
 	return nil, nil
 }
 

--- a/src/control/cmd/dmg/storage.go
+++ b/src/control/cmd/dmg/storage.go
@@ -32,39 +32,39 @@ import (
 
 // StorCmd is the struct representing the top-level storage subcommand.
 type StorCmd struct {
-	Scan   ScanStorCmd   `command:"scan" alias:"s" description:"Scan SCM and NVMe storage attached to remote servers."`
-	Format FormatStorCmd `command:"format" alias:"f" description:"Format SCM and NVMe storage attached to remote servers."`
-	Update UpdateStorCmd `command:"fwupdate" alias:"u" description:"Update firmware on NVMe storage attached to remote servers."`
+	Scan   StorageScanCmd   `command:"scan" alias:"s" description:"Scan SCM and NVMe storage attached to remote servers."`
+	Format StorageFormatCmd `command:"format" alias:"f" description:"Format SCM and NVMe storage attached to remote servers."`
+	Update StorageUpdateCmd `command:"fwupdate" alias:"u" description:"Update firmware on NVMe storage attached to remote servers."`
 }
 
-// ScanStorCmd is the struct representing the scan storage subcommand.
-type ScanStorCmd struct {
+// StorageScanCmd is the struct representing the scan storage subcommand.
+type StorageScanCmd struct {
 	broadcastCmd
 	connectedCmd
 }
 
 // run NVMe and SCM storage query on all connected servers
-func scanStor(conns client.Connect) {
-	cCtrlrs, cModules := conns.ScanStorage()
+func storageScan(conns client.Connect) {
+	cCtrlrs, cModules := conns.StorageScan()
 	log.Infof("NVMe SSD controller and constituent namespaces:\n%s", cCtrlrs)
 	log.Infof("SCM modules:\n%s", cModules)
 }
 
-// Execute is run when ScanStorCmd activates
-func (s *ScanStorCmd) Execute(args []string) error {
-	scanStor(s.conns)
+// Execute is run when StorageScanCmd activates
+func (s *StorageScanCmd) Execute(args []string) error {
+	storageScan(s.conns)
 	return nil
 }
 
-// FormatStorCmd is the struct representing the format storage subcommand.
-type FormatStorCmd struct {
+// StorageFormatCmd is the struct representing the format storage subcommand.
+type StorageFormatCmd struct {
 	broadcastCmd
 	connectedCmd
 	Force bool `short:"f" long:"force" description:"Perform format without prompting for confirmation"`
 }
 
 // run NVMe and SCM storage format on all connected servers
-func formatStor(conns client.Connect, force bool) {
+func storageFormat(conns client.Connect, force bool) {
 	log.Info(
 		"This is a destructive operation and storage devices " +
 			"specified in the server config file will be erased.\n" +
@@ -72,20 +72,20 @@ func formatStor(conns client.Connect, force bool) {
 
 	if force || common.GetConsent() {
 		log.Info("")
-		cCtrlrResults, cMountResults := conns.FormatStorage()
+		cCtrlrResults, cMountResults := conns.StorageFormat()
 		log.Infof("NVMe storage format results:\n%s", cCtrlrResults)
 		log.Infof("SCM storage format results:\n%s", cMountResults)
 	}
 }
 
-// Execute is run when FormatStorCmd activates
-func (s *FormatStorCmd) Execute(args []string) error {
-	formatStor(s.conns, s.Force)
+// Execute is run when StorageFormatCmd activates
+func (s *StorageFormatCmd) Execute(args []string) error {
+	storageFormat(s.conns, s.Force)
 	return nil
 }
 
-// UpdateStorCmd is the struct representing the update storage subcommand.
-type UpdateStorCmd struct {
+// StorageUpdateCmd is the struct representing the update storage subcommand.
+type StorageUpdateCmd struct {
 	broadcastCmd
 	connectedCmd
 	Force        bool   `short:"f" long:"force" description:"Perform update without prompting for confirmation"`
@@ -96,7 +96,7 @@ type UpdateStorCmd struct {
 }
 
 // run NVMe and SCM storage update on all connected servers
-func updateStor(conns client.Connect, req *pb.UpdateStorageReq, force bool) {
+func storageUpdate(conns client.Connect, req *pb.StorageUpdateReq, force bool) {
 	log.Info(
 		"This could be a destructive operation and storage devices " +
 			"specified in the server config file will have firmware " +
@@ -105,18 +105,18 @@ func updateStor(conns client.Connect, req *pb.UpdateStorageReq, force bool) {
 
 	if force || common.GetConsent() {
 		log.Info("")
-		cCtrlrResults, cModuleResults := conns.UpdateStorage(req)
+		cCtrlrResults, cModuleResults := conns.StorageUpdate(req)
 		log.Infof("NVMe storage update results:\n%s", cCtrlrResults)
 		log.Infof("SCM storage update results:\n%s", cModuleResults)
 	}
 }
 
-// Execute is run when UpdateStorCmd activates
-func (u *UpdateStorCmd) Execute(args []string) error {
+// Execute is run when StorageUpdateCmd activates
+func (u *StorageUpdateCmd) Execute(args []string) error {
 	// only populate nvme fwupdate params for the moment
-	updateStor(
+	storageUpdate(
 		u.conns,
-		&pb.UpdateStorageReq{
+		&pb.StorageUpdateReq{
 			Nvme: &pb.UpdateNvmeReq{
 				Model: u.NVMeModel, Startrev: u.NVMeStartRev,
 				Path: u.NVMeFwPath, Slot: int32(u.NVMeFwSlot),

--- a/src/control/cmd/dmg/storage_test.go
+++ b/src/control/cmd/dmg/storage_test.go
@@ -46,7 +46,7 @@ func TestStorageCommands(t *testing.T) {
 		{
 			"Format with force",
 			"storage format --force",
-			"ConnectClients FormatStorage",
+			"ConnectClients StorageFormat",
 			nil,
 			cmdSuccess,
 		},
@@ -70,7 +70,7 @@ func TestStorageCommands(t *testing.T) {
 			"storage fwupdate --force --nvme-model foo --nvme-fw-path bar --nvme-fw-rev 123",
 			strings.Join([]string{
 				"ConnectClients",
-				fmt.Sprintf("UpdateStorage-%s", &pb.UpdateStorageReq{
+				fmt.Sprintf("StorageUpdate-%s", &pb.StorageUpdateReq{
 					Nvme: &pb.UpdateNvmeReq{
 						Model:    "foo",
 						Startrev: "123",
@@ -84,7 +84,7 @@ func TestStorageCommands(t *testing.T) {
 		{
 			"Scan",
 			"storage scan",
-			"ConnectClients ScanStorage",
+			"ConnectClients StorageScan",
 			nil,
 			cmdSuccess,
 		},

--- a/src/control/common/proto/mgmt/control.pb.go
+++ b/src/control/common/proto/mgmt/control.pb.go
@@ -35,14 +35,14 @@ const _ = grpc.SupportPackageIsVersion4
 //
 // For semantics around ctx use and closing/ending streaming RPCs, please refer to https://godoc.org/google.golang.org/grpc#ClientConn.NewStream.
 type MgmtCtlClient interface {
-	// Retrieve details of nonvolatile storage devices on server
-	ScanStorage(ctx context.Context, in *ScanStorageReq, opts ...grpc.CallOption) (*ScanStorageResp, error)
+	// Retrieve details of nonvolatile storage on server
+	StorageScan(ctx context.Context, in *StorageScanReq, opts ...grpc.CallOption) (*StorageScanResp, error)
 	// Format nonvolatile storage devices for use with DAOS
-	FormatStorage(ctx context.Context, in *FormatStorageReq, opts ...grpc.CallOption) (MgmtCtl_FormatStorageClient, error)
+	StorageFormat(ctx context.Context, in *StorageFormatReq, opts ...grpc.CallOption) (MgmtCtl_StorageFormatClient, error)
 	// Update nonvolatile storage device firmware
-	UpdateStorage(ctx context.Context, in *UpdateStorageReq, opts ...grpc.CallOption) (MgmtCtl_UpdateStorageClient, error)
+	StorageUpdate(ctx context.Context, in *StorageUpdateReq, opts ...grpc.CallOption) (MgmtCtl_StorageUpdateClient, error)
 	// Perform burn-in testing to verify nonvolatile storage devices
-	BurninStorage(ctx context.Context, in *BurninStorageReq, opts ...grpc.CallOption) (MgmtCtl_BurninStorageClient, error)
+	StorageBurnIn(ctx context.Context, in *StorageBurnInReq, opts ...grpc.CallOption) (MgmtCtl_StorageBurnInClient, error)
 	// Fetch FIO configuration file specifying burn-in jobs/workloads
 	FetchFioConfigPaths(ctx context.Context, in *EmptyReq, opts ...grpc.CallOption) (MgmtCtl_FetchFioConfigPathsClient, error)
 	// Kill a given rank associated with a given pool
@@ -59,21 +59,21 @@ func NewMgmtCtlClient(cc *grpc.ClientConn) MgmtCtlClient {
 	return &mgmtCtlClient{cc}
 }
 
-func (c *mgmtCtlClient) ScanStorage(ctx context.Context, in *ScanStorageReq, opts ...grpc.CallOption) (*ScanStorageResp, error) {
-	out := new(ScanStorageResp)
-	err := c.cc.Invoke(ctx, "/mgmt.MgmtCtl/ScanStorage", in, out, opts...)
+func (c *mgmtCtlClient) StorageScan(ctx context.Context, in *StorageScanReq, opts ...grpc.CallOption) (*StorageScanResp, error) {
+	out := new(StorageScanResp)
+	err := c.cc.Invoke(ctx, "/mgmt.MgmtCtl/StorageScan", in, out, opts...)
 	if err != nil {
 		return nil, err
 	}
 	return out, nil
 }
 
-func (c *mgmtCtlClient) FormatStorage(ctx context.Context, in *FormatStorageReq, opts ...grpc.CallOption) (MgmtCtl_FormatStorageClient, error) {
-	stream, err := c.cc.NewStream(ctx, &_MgmtCtl_serviceDesc.Streams[0], "/mgmt.MgmtCtl/FormatStorage", opts...)
+func (c *mgmtCtlClient) StorageFormat(ctx context.Context, in *StorageFormatReq, opts ...grpc.CallOption) (MgmtCtl_StorageFormatClient, error) {
+	stream, err := c.cc.NewStream(ctx, &_MgmtCtl_serviceDesc.Streams[0], "/mgmt.MgmtCtl/StorageFormat", opts...)
 	if err != nil {
 		return nil, err
 	}
-	x := &mgmtCtlFormatStorageClient{stream}
+	x := &mgmtCtlStorageFormatClient{stream}
 	if err := x.ClientStream.SendMsg(in); err != nil {
 		return nil, err
 	}
@@ -83,29 +83,29 @@ func (c *mgmtCtlClient) FormatStorage(ctx context.Context, in *FormatStorageReq,
 	return x, nil
 }
 
-type MgmtCtl_FormatStorageClient interface {
-	Recv() (*FormatStorageResp, error)
+type MgmtCtl_StorageFormatClient interface {
+	Recv() (*StorageFormatResp, error)
 	grpc.ClientStream
 }
 
-type mgmtCtlFormatStorageClient struct {
+type mgmtCtlStorageFormatClient struct {
 	grpc.ClientStream
 }
 
-func (x *mgmtCtlFormatStorageClient) Recv() (*FormatStorageResp, error) {
-	m := new(FormatStorageResp)
+func (x *mgmtCtlStorageFormatClient) Recv() (*StorageFormatResp, error) {
+	m := new(StorageFormatResp)
 	if err := x.ClientStream.RecvMsg(m); err != nil {
 		return nil, err
 	}
 	return m, nil
 }
 
-func (c *mgmtCtlClient) UpdateStorage(ctx context.Context, in *UpdateStorageReq, opts ...grpc.CallOption) (MgmtCtl_UpdateStorageClient, error) {
-	stream, err := c.cc.NewStream(ctx, &_MgmtCtl_serviceDesc.Streams[1], "/mgmt.MgmtCtl/UpdateStorage", opts...)
+func (c *mgmtCtlClient) StorageUpdate(ctx context.Context, in *StorageUpdateReq, opts ...grpc.CallOption) (MgmtCtl_StorageUpdateClient, error) {
+	stream, err := c.cc.NewStream(ctx, &_MgmtCtl_serviceDesc.Streams[1], "/mgmt.MgmtCtl/StorageUpdate", opts...)
 	if err != nil {
 		return nil, err
 	}
-	x := &mgmtCtlUpdateStorageClient{stream}
+	x := &mgmtCtlStorageUpdateClient{stream}
 	if err := x.ClientStream.SendMsg(in); err != nil {
 		return nil, err
 	}
@@ -115,29 +115,29 @@ func (c *mgmtCtlClient) UpdateStorage(ctx context.Context, in *UpdateStorageReq,
 	return x, nil
 }
 
-type MgmtCtl_UpdateStorageClient interface {
-	Recv() (*UpdateStorageResp, error)
+type MgmtCtl_StorageUpdateClient interface {
+	Recv() (*StorageUpdateResp, error)
 	grpc.ClientStream
 }
 
-type mgmtCtlUpdateStorageClient struct {
+type mgmtCtlStorageUpdateClient struct {
 	grpc.ClientStream
 }
 
-func (x *mgmtCtlUpdateStorageClient) Recv() (*UpdateStorageResp, error) {
-	m := new(UpdateStorageResp)
+func (x *mgmtCtlStorageUpdateClient) Recv() (*StorageUpdateResp, error) {
+	m := new(StorageUpdateResp)
 	if err := x.ClientStream.RecvMsg(m); err != nil {
 		return nil, err
 	}
 	return m, nil
 }
 
-func (c *mgmtCtlClient) BurninStorage(ctx context.Context, in *BurninStorageReq, opts ...grpc.CallOption) (MgmtCtl_BurninStorageClient, error) {
-	stream, err := c.cc.NewStream(ctx, &_MgmtCtl_serviceDesc.Streams[2], "/mgmt.MgmtCtl/BurninStorage", opts...)
+func (c *mgmtCtlClient) StorageBurnIn(ctx context.Context, in *StorageBurnInReq, opts ...grpc.CallOption) (MgmtCtl_StorageBurnInClient, error) {
+	stream, err := c.cc.NewStream(ctx, &_MgmtCtl_serviceDesc.Streams[2], "/mgmt.MgmtCtl/StorageBurnIn", opts...)
 	if err != nil {
 		return nil, err
 	}
-	x := &mgmtCtlBurninStorageClient{stream}
+	x := &mgmtCtlStorageBurnInClient{stream}
 	if err := x.ClientStream.SendMsg(in); err != nil {
 		return nil, err
 	}
@@ -147,17 +147,17 @@ func (c *mgmtCtlClient) BurninStorage(ctx context.Context, in *BurninStorageReq,
 	return x, nil
 }
 
-type MgmtCtl_BurninStorageClient interface {
-	Recv() (*BurninStorageResp, error)
+type MgmtCtl_StorageBurnInClient interface {
+	Recv() (*StorageBurnInResp, error)
 	grpc.ClientStream
 }
 
-type mgmtCtlBurninStorageClient struct {
+type mgmtCtlStorageBurnInClient struct {
 	grpc.ClientStream
 }
 
-func (x *mgmtCtlBurninStorageClient) Recv() (*BurninStorageResp, error) {
-	m := new(BurninStorageResp)
+func (x *mgmtCtlStorageBurnInClient) Recv() (*StorageBurnInResp, error) {
+	m := new(StorageBurnInResp)
 	if err := x.ClientStream.RecvMsg(m); err != nil {
 		return nil, err
 	}
@@ -239,14 +239,14 @@ func (x *mgmtCtlListFeaturesClient) Recv() (*Feature, error) {
 
 // MgmtCtlServer is the server API for MgmtCtl service.
 type MgmtCtlServer interface {
-	// Retrieve details of nonvolatile storage devices on server
-	ScanStorage(context.Context, *ScanStorageReq) (*ScanStorageResp, error)
+	// Retrieve details of nonvolatile storage on server
+	StorageScan(context.Context, *StorageScanReq) (*StorageScanResp, error)
 	// Format nonvolatile storage devices for use with DAOS
-	FormatStorage(*FormatStorageReq, MgmtCtl_FormatStorageServer) error
+	StorageFormat(*StorageFormatReq, MgmtCtl_StorageFormatServer) error
 	// Update nonvolatile storage device firmware
-	UpdateStorage(*UpdateStorageReq, MgmtCtl_UpdateStorageServer) error
+	StorageUpdate(*StorageUpdateReq, MgmtCtl_StorageUpdateServer) error
 	// Perform burn-in testing to verify nonvolatile storage devices
-	BurninStorage(*BurninStorageReq, MgmtCtl_BurninStorageServer) error
+	StorageBurnIn(*StorageBurnInReq, MgmtCtl_StorageBurnInServer) error
 	// Fetch FIO configuration file specifying burn-in jobs/workloads
 	FetchFioConfigPaths(*EmptyReq, MgmtCtl_FetchFioConfigPathsServer) error
 	// Kill a given rank associated with a given pool
@@ -259,84 +259,84 @@ func RegisterMgmtCtlServer(s *grpc.Server, srv MgmtCtlServer) {
 	s.RegisterService(&_MgmtCtl_serviceDesc, srv)
 }
 
-func _MgmtCtl_ScanStorage_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
-	in := new(ScanStorageReq)
+func _MgmtCtl_StorageScan_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(StorageScanReq)
 	if err := dec(in); err != nil {
 		return nil, err
 	}
 	if interceptor == nil {
-		return srv.(MgmtCtlServer).ScanStorage(ctx, in)
+		return srv.(MgmtCtlServer).StorageScan(ctx, in)
 	}
 	info := &grpc.UnaryServerInfo{
 		Server:     srv,
-		FullMethod: "/mgmt.MgmtCtl/ScanStorage",
+		FullMethod: "/mgmt.MgmtCtl/StorageScan",
 	}
 	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
-		return srv.(MgmtCtlServer).ScanStorage(ctx, req.(*ScanStorageReq))
+		return srv.(MgmtCtlServer).StorageScan(ctx, req.(*StorageScanReq))
 	}
 	return interceptor(ctx, in, info, handler)
 }
 
-func _MgmtCtl_FormatStorage_Handler(srv interface{}, stream grpc.ServerStream) error {
-	m := new(FormatStorageReq)
+func _MgmtCtl_StorageFormat_Handler(srv interface{}, stream grpc.ServerStream) error {
+	m := new(StorageFormatReq)
 	if err := stream.RecvMsg(m); err != nil {
 		return err
 	}
-	return srv.(MgmtCtlServer).FormatStorage(m, &mgmtCtlFormatStorageServer{stream})
+	return srv.(MgmtCtlServer).StorageFormat(m, &mgmtCtlStorageFormatServer{stream})
 }
 
-type MgmtCtl_FormatStorageServer interface {
-	Send(*FormatStorageResp) error
+type MgmtCtl_StorageFormatServer interface {
+	Send(*StorageFormatResp) error
 	grpc.ServerStream
 }
 
-type mgmtCtlFormatStorageServer struct {
+type mgmtCtlStorageFormatServer struct {
 	grpc.ServerStream
 }
 
-func (x *mgmtCtlFormatStorageServer) Send(m *FormatStorageResp) error {
+func (x *mgmtCtlStorageFormatServer) Send(m *StorageFormatResp) error {
 	return x.ServerStream.SendMsg(m)
 }
 
-func _MgmtCtl_UpdateStorage_Handler(srv interface{}, stream grpc.ServerStream) error {
-	m := new(UpdateStorageReq)
+func _MgmtCtl_StorageUpdate_Handler(srv interface{}, stream grpc.ServerStream) error {
+	m := new(StorageUpdateReq)
 	if err := stream.RecvMsg(m); err != nil {
 		return err
 	}
-	return srv.(MgmtCtlServer).UpdateStorage(m, &mgmtCtlUpdateStorageServer{stream})
+	return srv.(MgmtCtlServer).StorageUpdate(m, &mgmtCtlStorageUpdateServer{stream})
 }
 
-type MgmtCtl_UpdateStorageServer interface {
-	Send(*UpdateStorageResp) error
+type MgmtCtl_StorageUpdateServer interface {
+	Send(*StorageUpdateResp) error
 	grpc.ServerStream
 }
 
-type mgmtCtlUpdateStorageServer struct {
+type mgmtCtlStorageUpdateServer struct {
 	grpc.ServerStream
 }
 
-func (x *mgmtCtlUpdateStorageServer) Send(m *UpdateStorageResp) error {
+func (x *mgmtCtlStorageUpdateServer) Send(m *StorageUpdateResp) error {
 	return x.ServerStream.SendMsg(m)
 }
 
-func _MgmtCtl_BurninStorage_Handler(srv interface{}, stream grpc.ServerStream) error {
-	m := new(BurninStorageReq)
+func _MgmtCtl_StorageBurnIn_Handler(srv interface{}, stream grpc.ServerStream) error {
+	m := new(StorageBurnInReq)
 	if err := stream.RecvMsg(m); err != nil {
 		return err
 	}
-	return srv.(MgmtCtlServer).BurninStorage(m, &mgmtCtlBurninStorageServer{stream})
+	return srv.(MgmtCtlServer).StorageBurnIn(m, &mgmtCtlStorageBurnInServer{stream})
 }
 
-type MgmtCtl_BurninStorageServer interface {
-	Send(*BurninStorageResp) error
+type MgmtCtl_StorageBurnInServer interface {
+	Send(*StorageBurnInResp) error
 	grpc.ServerStream
 }
 
-type mgmtCtlBurninStorageServer struct {
+type mgmtCtlStorageBurnInServer struct {
 	grpc.ServerStream
 }
 
-func (x *mgmtCtlBurninStorageServer) Send(m *BurninStorageResp) error {
+func (x *mgmtCtlStorageBurnInServer) Send(m *StorageBurnInResp) error {
 	return x.ServerStream.SendMsg(m)
 }
 
@@ -405,8 +405,8 @@ var _MgmtCtl_serviceDesc = grpc.ServiceDesc{
 	HandlerType: (*MgmtCtlServer)(nil),
 	Methods: []grpc.MethodDesc{
 		{
-			MethodName: "ScanStorage",
-			Handler:    _MgmtCtl_ScanStorage_Handler,
+			MethodName: "StorageScan",
+			Handler:    _MgmtCtl_StorageScan_Handler,
 		},
 		{
 			MethodName: "KillRank",
@@ -415,18 +415,18 @@ var _MgmtCtl_serviceDesc = grpc.ServiceDesc{
 	},
 	Streams: []grpc.StreamDesc{
 		{
-			StreamName:    "FormatStorage",
-			Handler:       _MgmtCtl_FormatStorage_Handler,
+			StreamName:    "StorageFormat",
+			Handler:       _MgmtCtl_StorageFormat_Handler,
 			ServerStreams: true,
 		},
 		{
-			StreamName:    "UpdateStorage",
-			Handler:       _MgmtCtl_UpdateStorage_Handler,
+			StreamName:    "StorageUpdate",
+			Handler:       _MgmtCtl_StorageUpdate_Handler,
 			ServerStreams: true,
 		},
 		{
-			StreamName:    "BurninStorage",
-			Handler:       _MgmtCtl_BurninStorage_Handler,
+			StreamName:    "StorageBurnIn",
+			Handler:       _MgmtCtl_StorageBurnIn_Handler,
 			ServerStreams: true,
 		},
 		{
@@ -443,25 +443,25 @@ var _MgmtCtl_serviceDesc = grpc.ServiceDesc{
 	Metadata: "control.proto",
 }
 
-func init() { proto.RegisterFile("control.proto", fileDescriptor_control_9bed00f28660b3bc) }
+func init() { proto.RegisterFile("control.proto", fileDescriptor_control_bb1d988ebc7a91b0) }
 
-var fileDescriptor_control_9bed00f28660b3bc = []byte{
+var fileDescriptor_control_bb1d988ebc7a91b0 = []byte{
 	// 268 bytes of a gzipped FileDescriptorProto
-	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0x6c, 0x91, 0xcb, 0x4e, 0xc3, 0x30,
-	0x10, 0x45, 0x41, 0x20, 0x1e, 0xa6, 0xe9, 0xc2, 0xbc, 0xa4, 0x2c, 0x59, 0xa3, 0x88, 0xc7, 0x0a,
-	0x89, 0x15, 0x2d, 0xde, 0x00, 0x12, 0x6a, 0xc5, 0x07, 0x98, 0xe0, 0xa6, 0x16, 0xb6, 0x27, 0xd8,
-	0x53, 0x24, 0x3e, 0x8c, 0xff, 0x43, 0x53, 0xbb, 0x22, 0x71, 0xbb, 0xcb, 0x3d, 0x99, 0x7b, 0x46,
-	0xf2, 0xb0, 0xa2, 0x06, 0x87, 0x1e, 0x4c, 0xd5, 0x7a, 0x40, 0xe0, 0xbb, 0xb6, 0xb1, 0x58, 0x0e,
-	0x6a, 0xb0, 0x16, 0x5c, 0x64, 0x65, 0x11, 0x10, 0xbc, 0x6c, 0x54, 0x8a, 0xc3, 0x99, 0x92, 0xb8,
-	0xf0, 0x2a, 0xa4, 0x7c, 0x18, 0xfc, 0x77, 0xfc, 0xbc, 0xf9, 0xdd, 0x61, 0xfb, 0x2f, 0x8d, 0xc5,
-	0x11, 0x1a, 0x7e, 0xcf, 0x8e, 0xa6, 0xb5, 0x74, 0xd3, 0xd8, 0xe5, 0x27, 0x15, 0x99, 0xab, 0x0e,
-	0x9a, 0xa8, 0xaf, 0xf2, 0x74, 0x03, 0x0d, 0xed, 0xc5, 0x16, 0x1f, 0xb3, 0x42, 0x80, 0xb7, 0x12,
-	0x57, 0xfd, 0xb3, 0x38, 0xd9, 0x83, 0x64, 0x38, 0xdf, 0xc8, 0xc9, 0x71, 0xb5, 0x4d, 0x96, 0xb7,
-	0xf6, 0x43, 0xa2, 0xca, 0x2c, 0x3d, 0xd8, 0xb1, 0x64, 0xfc, 0xdf, 0xf2, 0xb0, 0xf0, 0x4e, 0xbb,
-	0xcc, 0xd2, 0x83, 0x1d, 0x4b, 0xc6, 0x93, 0xe5, 0x8e, 0x1d, 0x0b, 0x85, 0xf5, 0x5c, 0x68, 0x18,
-	0x81, 0x9b, 0xe9, 0xe6, 0x55, 0xe2, 0x3c, 0xf0, 0x61, 0xec, 0x3c, 0xda, 0x16, 0x7f, 0xc8, 0x91,
-	0xb2, 0xd0, 0x46, 0xd1, 0xc0, 0xb2, 0x7a, 0xc9, 0x0e, 0x9e, 0xb4, 0x31, 0x13, 0xe9, 0x3e, 0x57,
-	0xf3, 0x63, 0x09, 0x81, 0x72, 0xd9, 0xcd, 0xf1, 0xe9, 0xae, 0xd9, 0xe0, 0x59, 0x07, 0x14, 0xe9,
-	0x4a, 0x6b, 0x1b, 0x8a, 0xb4, 0x21, 0xfe, 0xa7, 0x05, 0xef, 0x7b, 0xcb, 0xf3, 0xdd, 0xfe, 0x05,
-	0x00, 0x00, 0xff, 0xff, 0x28, 0xa2, 0xc8, 0xee, 0x0d, 0x02, 0x00, 0x00,
+	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0x6c, 0x91, 0x4d, 0x4b, 0x03, 0x31,
+	0x10, 0x86, 0x15, 0xc5, 0x8f, 0xd8, 0xed, 0x21, 0x7e, 0xc1, 0x1e, 0x3d, 0xcb, 0xe2, 0xc7, 0x49,
+	0xf0, 0x64, 0x6b, 0x40, 0x54, 0x90, 0x16, 0x7f, 0x40, 0x5c, 0xd3, 0x6d, 0x30, 0xc9, 0xac, 0xc9,
+	0x54, 0xf0, 0x87, 0xf9, 0xff, 0x24, 0x9d, 0x2c, 0x6c, 0x9b, 0xde, 0xf6, 0x7d, 0x76, 0xe6, 0x79,
+	0x21, 0xc3, 0x8a, 0x1a, 0x1c, 0x7a, 0x30, 0x55, 0xeb, 0x01, 0x81, 0xef, 0xda, 0xc6, 0x62, 0x39,
+	0xa8, 0xc1, 0x5a, 0x70, 0xc4, 0xca, 0x22, 0x20, 0x78, 0xd9, 0xa8, 0x14, 0x87, 0x33, 0x25, 0x71,
+	0xe1, 0x55, 0x48, 0xf9, 0x30, 0xf8, 0x1f, 0xfa, 0xbc, 0xf9, 0xdb, 0x61, 0xfb, 0xaf, 0x8d, 0xc5,
+	0x11, 0x1a, 0x7e, 0xcf, 0x8e, 0xa6, 0xb4, 0x37, 0xad, 0xa5, 0xe3, 0x27, 0x55, 0x34, 0x57, 0x3d,
+	0x34, 0x51, 0xdf, 0xe5, 0xe9, 0x06, 0x1a, 0xda, 0x8b, 0x2d, 0x3e, 0x66, 0x45, 0x82, 0x02, 0xbc,
+	0x95, 0xc8, 0xcf, 0x56, 0x26, 0x09, 0x46, 0xc3, 0xf9, 0x46, 0x1e, 0x1d, 0x57, 0xdb, 0x3d, 0xcb,
+	0x7b, 0xfb, 0x29, 0x51, 0xad, 0x59, 0x08, 0xe6, 0x96, 0x8e, 0x67, 0x96, 0x87, 0x85, 0x77, 0x4f,
+	0x6e, 0xcd, 0x42, 0x30, 0xb7, 0x74, 0x3c, 0x59, 0xee, 0xd8, 0xb1, 0x50, 0x58, 0xcf, 0x85, 0x86,
+	0x11, 0xb8, 0x99, 0x6e, 0xde, 0x24, 0xce, 0x03, 0x1f, 0xd2, 0xce, 0xa3, 0x6d, 0xf1, 0x37, 0x3a,
+	0x52, 0x16, 0xda, 0xa8, 0x38, 0xb0, 0x5c, 0xbd, 0x64, 0x07, 0xcf, 0xda, 0x98, 0x89, 0x74, 0x5f,
+	0xdd, 0xfc, 0x58, 0x42, 0x88, 0xb9, 0xec, 0x67, 0x7a, 0xba, 0x6b, 0x36, 0x78, 0xd1, 0x01, 0x45,
+	0xba, 0x52, 0xd6, 0x50, 0xa4, 0x06, 0xfa, 0x1f, 0x0b, 0x3e, 0xf6, 0x96, 0xe7, 0xbb, 0xfd, 0x0f,
+	0x00, 0x00, 0xff, 0xff, 0x35, 0x21, 0xab, 0xf5, 0x0d, 0x02, 0x00, 0x00,
 }

--- a/src/control/common/proto/mgmt/storage.pb.go
+++ b/src/control/common/proto/mgmt/storage.pb.go
@@ -18,38 +18,54 @@ var _ = math.Inf
 // proto package needs to be updated.
 const _ = proto.ProtoPackageIsVersion2 // please upgrade the proto package
 
-type ScanStorageReq struct {
-	XXX_NoUnkeyedLiteral struct{} `json:"-"`
-	XXX_unrecognized     []byte   `json:"-"`
-	XXX_sizecache        int32    `json:"-"`
+type StorageScanReq struct {
+	Nvme                 *ScanNvmeReq `protobuf:"bytes,1,opt,name=nvme,proto3" json:"nvme,omitempty"`
+	Scm                  *ScanScmReq  `protobuf:"bytes,2,opt,name=scm,proto3" json:"scm,omitempty"`
+	XXX_NoUnkeyedLiteral struct{}     `json:"-"`
+	XXX_unrecognized     []byte       `json:"-"`
+	XXX_sizecache        int32        `json:"-"`
 }
 
-func (m *ScanStorageReq) Reset()         { *m = ScanStorageReq{} }
-func (m *ScanStorageReq) String() string { return proto.CompactTextString(m) }
-func (*ScanStorageReq) ProtoMessage()    {}
-func (*ScanStorageReq) Descriptor() ([]byte, []int) {
-	return fileDescriptor_storage_fbaf07d8be8e1d9c, []int{0}
+func (m *StorageScanReq) Reset()         { *m = StorageScanReq{} }
+func (m *StorageScanReq) String() string { return proto.CompactTextString(m) }
+func (*StorageScanReq) ProtoMessage()    {}
+func (*StorageScanReq) Descriptor() ([]byte, []int) {
+	return fileDescriptor_storage_d031b2d9797048d3, []int{0}
 }
-func (m *ScanStorageReq) XXX_Unmarshal(b []byte) error {
-	return xxx_messageInfo_ScanStorageReq.Unmarshal(m, b)
+func (m *StorageScanReq) XXX_Unmarshal(b []byte) error {
+	return xxx_messageInfo_StorageScanReq.Unmarshal(m, b)
 }
-func (m *ScanStorageReq) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
-	return xxx_messageInfo_ScanStorageReq.Marshal(b, m, deterministic)
+func (m *StorageScanReq) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	return xxx_messageInfo_StorageScanReq.Marshal(b, m, deterministic)
 }
-func (dst *ScanStorageReq) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_ScanStorageReq.Merge(dst, src)
+func (dst *StorageScanReq) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_StorageScanReq.Merge(dst, src)
 }
-func (m *ScanStorageReq) XXX_Size() int {
-	return xxx_messageInfo_ScanStorageReq.Size(m)
+func (m *StorageScanReq) XXX_Size() int {
+	return xxx_messageInfo_StorageScanReq.Size(m)
 }
-func (m *ScanStorageReq) XXX_DiscardUnknown() {
-	xxx_messageInfo_ScanStorageReq.DiscardUnknown(m)
+func (m *StorageScanReq) XXX_DiscardUnknown() {
+	xxx_messageInfo_StorageScanReq.DiscardUnknown(m)
 }
 
-var xxx_messageInfo_ScanStorageReq proto.InternalMessageInfo
+var xxx_messageInfo_StorageScanReq proto.InternalMessageInfo
 
-// ScanStorageResp returns discovered storage devices.
-type ScanStorageResp struct {
+func (m *StorageScanReq) GetNvme() *ScanNvmeReq {
+	if m != nil {
+		return m.Nvme
+	}
+	return nil
+}
+
+func (m *StorageScanReq) GetScm() *ScanScmReq {
+	if m != nil {
+		return m.Scm
+	}
+	return nil
+}
+
+// StorageScanResp returns discovered storage devices.
+type StorageScanResp struct {
 	Ctrlrs               []*NvmeController `protobuf:"bytes,1,rep,name=ctrlrs,proto3" json:"ctrlrs,omitempty"`
 	Nvmestate            *ResponseState    `protobuf:"bytes,2,opt,name=nvmestate,proto3" json:"nvmestate,omitempty"`
 	Modules              []*ScmModule      `protobuf:"bytes,3,rep,name=modules,proto3" json:"modules,omitempty"`
@@ -59,89 +75,89 @@ type ScanStorageResp struct {
 	XXX_sizecache        int32             `json:"-"`
 }
 
-func (m *ScanStorageResp) Reset()         { *m = ScanStorageResp{} }
-func (m *ScanStorageResp) String() string { return proto.CompactTextString(m) }
-func (*ScanStorageResp) ProtoMessage()    {}
-func (*ScanStorageResp) Descriptor() ([]byte, []int) {
-	return fileDescriptor_storage_fbaf07d8be8e1d9c, []int{1}
+func (m *StorageScanResp) Reset()         { *m = StorageScanResp{} }
+func (m *StorageScanResp) String() string { return proto.CompactTextString(m) }
+func (*StorageScanResp) ProtoMessage()    {}
+func (*StorageScanResp) Descriptor() ([]byte, []int) {
+	return fileDescriptor_storage_d031b2d9797048d3, []int{1}
 }
-func (m *ScanStorageResp) XXX_Unmarshal(b []byte) error {
-	return xxx_messageInfo_ScanStorageResp.Unmarshal(m, b)
+func (m *StorageScanResp) XXX_Unmarshal(b []byte) error {
+	return xxx_messageInfo_StorageScanResp.Unmarshal(m, b)
 }
-func (m *ScanStorageResp) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
-	return xxx_messageInfo_ScanStorageResp.Marshal(b, m, deterministic)
+func (m *StorageScanResp) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	return xxx_messageInfo_StorageScanResp.Marshal(b, m, deterministic)
 }
-func (dst *ScanStorageResp) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_ScanStorageResp.Merge(dst, src)
+func (dst *StorageScanResp) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_StorageScanResp.Merge(dst, src)
 }
-func (m *ScanStorageResp) XXX_Size() int {
-	return xxx_messageInfo_ScanStorageResp.Size(m)
+func (m *StorageScanResp) XXX_Size() int {
+	return xxx_messageInfo_StorageScanResp.Size(m)
 }
-func (m *ScanStorageResp) XXX_DiscardUnknown() {
-	xxx_messageInfo_ScanStorageResp.DiscardUnknown(m)
+func (m *StorageScanResp) XXX_DiscardUnknown() {
+	xxx_messageInfo_StorageScanResp.DiscardUnknown(m)
 }
 
-var xxx_messageInfo_ScanStorageResp proto.InternalMessageInfo
+var xxx_messageInfo_StorageScanResp proto.InternalMessageInfo
 
-func (m *ScanStorageResp) GetCtrlrs() []*NvmeController {
+func (m *StorageScanResp) GetCtrlrs() []*NvmeController {
 	if m != nil {
 		return m.Ctrlrs
 	}
 	return nil
 }
 
-func (m *ScanStorageResp) GetNvmestate() *ResponseState {
+func (m *StorageScanResp) GetNvmestate() *ResponseState {
 	if m != nil {
 		return m.Nvmestate
 	}
 	return nil
 }
 
-func (m *ScanStorageResp) GetModules() []*ScmModule {
+func (m *StorageScanResp) GetModules() []*ScmModule {
 	if m != nil {
 		return m.Modules
 	}
 	return nil
 }
 
-func (m *ScanStorageResp) GetScmstate() *ResponseState {
+func (m *StorageScanResp) GetScmstate() *ResponseState {
 	if m != nil {
 		return m.Scmstate
 	}
 	return nil
 }
 
-type FormatStorageReq struct {
+type StorageFormatReq struct {
 	XXX_NoUnkeyedLiteral struct{} `json:"-"`
 	XXX_unrecognized     []byte   `json:"-"`
 	XXX_sizecache        int32    `json:"-"`
 }
 
-func (m *FormatStorageReq) Reset()         { *m = FormatStorageReq{} }
-func (m *FormatStorageReq) String() string { return proto.CompactTextString(m) }
-func (*FormatStorageReq) ProtoMessage()    {}
-func (*FormatStorageReq) Descriptor() ([]byte, []int) {
-	return fileDescriptor_storage_fbaf07d8be8e1d9c, []int{2}
+func (m *StorageFormatReq) Reset()         { *m = StorageFormatReq{} }
+func (m *StorageFormatReq) String() string { return proto.CompactTextString(m) }
+func (*StorageFormatReq) ProtoMessage()    {}
+func (*StorageFormatReq) Descriptor() ([]byte, []int) {
+	return fileDescriptor_storage_d031b2d9797048d3, []int{2}
 }
-func (m *FormatStorageReq) XXX_Unmarshal(b []byte) error {
-	return xxx_messageInfo_FormatStorageReq.Unmarshal(m, b)
+func (m *StorageFormatReq) XXX_Unmarshal(b []byte) error {
+	return xxx_messageInfo_StorageFormatReq.Unmarshal(m, b)
 }
-func (m *FormatStorageReq) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
-	return xxx_messageInfo_FormatStorageReq.Marshal(b, m, deterministic)
+func (m *StorageFormatReq) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	return xxx_messageInfo_StorageFormatReq.Marshal(b, m, deterministic)
 }
-func (dst *FormatStorageReq) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_FormatStorageReq.Merge(dst, src)
+func (dst *StorageFormatReq) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_StorageFormatReq.Merge(dst, src)
 }
-func (m *FormatStorageReq) XXX_Size() int {
-	return xxx_messageInfo_FormatStorageReq.Size(m)
+func (m *StorageFormatReq) XXX_Size() int {
+	return xxx_messageInfo_StorageFormatReq.Size(m)
 }
-func (m *FormatStorageReq) XXX_DiscardUnknown() {
-	xxx_messageInfo_FormatStorageReq.DiscardUnknown(m)
+func (m *StorageFormatReq) XXX_DiscardUnknown() {
+	xxx_messageInfo_StorageFormatReq.DiscardUnknown(m)
 }
 
-var xxx_messageInfo_FormatStorageReq proto.InternalMessageInfo
+var xxx_messageInfo_StorageFormatReq proto.InternalMessageInfo
 
-type FormatStorageResp struct {
+type StorageFormatResp struct {
 	Crets                []*NvmeControllerResult `protobuf:"bytes,1,rep,name=crets,proto3" json:"crets,omitempty"`
 	Mrets                []*ScmMountResult       `protobuf:"bytes,2,rep,name=mrets,proto3" json:"mrets,omitempty"`
 	XXX_NoUnkeyedLiteral struct{}                `json:"-"`
@@ -149,45 +165,45 @@ type FormatStorageResp struct {
 	XXX_sizecache        int32                   `json:"-"`
 }
 
-func (m *FormatStorageResp) Reset()         { *m = FormatStorageResp{} }
-func (m *FormatStorageResp) String() string { return proto.CompactTextString(m) }
-func (*FormatStorageResp) ProtoMessage()    {}
-func (*FormatStorageResp) Descriptor() ([]byte, []int) {
-	return fileDescriptor_storage_fbaf07d8be8e1d9c, []int{3}
+func (m *StorageFormatResp) Reset()         { *m = StorageFormatResp{} }
+func (m *StorageFormatResp) String() string { return proto.CompactTextString(m) }
+func (*StorageFormatResp) ProtoMessage()    {}
+func (*StorageFormatResp) Descriptor() ([]byte, []int) {
+	return fileDescriptor_storage_d031b2d9797048d3, []int{3}
 }
-func (m *FormatStorageResp) XXX_Unmarshal(b []byte) error {
-	return xxx_messageInfo_FormatStorageResp.Unmarshal(m, b)
+func (m *StorageFormatResp) XXX_Unmarshal(b []byte) error {
+	return xxx_messageInfo_StorageFormatResp.Unmarshal(m, b)
 }
-func (m *FormatStorageResp) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
-	return xxx_messageInfo_FormatStorageResp.Marshal(b, m, deterministic)
+func (m *StorageFormatResp) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	return xxx_messageInfo_StorageFormatResp.Marshal(b, m, deterministic)
 }
-func (dst *FormatStorageResp) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_FormatStorageResp.Merge(dst, src)
+func (dst *StorageFormatResp) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_StorageFormatResp.Merge(dst, src)
 }
-func (m *FormatStorageResp) XXX_Size() int {
-	return xxx_messageInfo_FormatStorageResp.Size(m)
+func (m *StorageFormatResp) XXX_Size() int {
+	return xxx_messageInfo_StorageFormatResp.Size(m)
 }
-func (m *FormatStorageResp) XXX_DiscardUnknown() {
-	xxx_messageInfo_FormatStorageResp.DiscardUnknown(m)
+func (m *StorageFormatResp) XXX_DiscardUnknown() {
+	xxx_messageInfo_StorageFormatResp.DiscardUnknown(m)
 }
 
-var xxx_messageInfo_FormatStorageResp proto.InternalMessageInfo
+var xxx_messageInfo_StorageFormatResp proto.InternalMessageInfo
 
-func (m *FormatStorageResp) GetCrets() []*NvmeControllerResult {
+func (m *StorageFormatResp) GetCrets() []*NvmeControllerResult {
 	if m != nil {
 		return m.Crets
 	}
 	return nil
 }
 
-func (m *FormatStorageResp) GetMrets() []*ScmMountResult {
+func (m *StorageFormatResp) GetMrets() []*ScmMountResult {
 	if m != nil {
 		return m.Mrets
 	}
 	return nil
 }
 
-type UpdateStorageReq struct {
+type StorageUpdateReq struct {
 	Nvme                 *UpdateNvmeReq `protobuf:"bytes,1,opt,name=nvme,proto3" json:"nvme,omitempty"`
 	Scm                  *UpdateScmReq  `protobuf:"bytes,2,opt,name=scm,proto3" json:"scm,omitempty"`
 	XXX_NoUnkeyedLiteral struct{}       `json:"-"`
@@ -195,45 +211,45 @@ type UpdateStorageReq struct {
 	XXX_sizecache        int32          `json:"-"`
 }
 
-func (m *UpdateStorageReq) Reset()         { *m = UpdateStorageReq{} }
-func (m *UpdateStorageReq) String() string { return proto.CompactTextString(m) }
-func (*UpdateStorageReq) ProtoMessage()    {}
-func (*UpdateStorageReq) Descriptor() ([]byte, []int) {
-	return fileDescriptor_storage_fbaf07d8be8e1d9c, []int{4}
+func (m *StorageUpdateReq) Reset()         { *m = StorageUpdateReq{} }
+func (m *StorageUpdateReq) String() string { return proto.CompactTextString(m) }
+func (*StorageUpdateReq) ProtoMessage()    {}
+func (*StorageUpdateReq) Descriptor() ([]byte, []int) {
+	return fileDescriptor_storage_d031b2d9797048d3, []int{4}
 }
-func (m *UpdateStorageReq) XXX_Unmarshal(b []byte) error {
-	return xxx_messageInfo_UpdateStorageReq.Unmarshal(m, b)
+func (m *StorageUpdateReq) XXX_Unmarshal(b []byte) error {
+	return xxx_messageInfo_StorageUpdateReq.Unmarshal(m, b)
 }
-func (m *UpdateStorageReq) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
-	return xxx_messageInfo_UpdateStorageReq.Marshal(b, m, deterministic)
+func (m *StorageUpdateReq) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	return xxx_messageInfo_StorageUpdateReq.Marshal(b, m, deterministic)
 }
-func (dst *UpdateStorageReq) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_UpdateStorageReq.Merge(dst, src)
+func (dst *StorageUpdateReq) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_StorageUpdateReq.Merge(dst, src)
 }
-func (m *UpdateStorageReq) XXX_Size() int {
-	return xxx_messageInfo_UpdateStorageReq.Size(m)
+func (m *StorageUpdateReq) XXX_Size() int {
+	return xxx_messageInfo_StorageUpdateReq.Size(m)
 }
-func (m *UpdateStorageReq) XXX_DiscardUnknown() {
-	xxx_messageInfo_UpdateStorageReq.DiscardUnknown(m)
+func (m *StorageUpdateReq) XXX_DiscardUnknown() {
+	xxx_messageInfo_StorageUpdateReq.DiscardUnknown(m)
 }
 
-var xxx_messageInfo_UpdateStorageReq proto.InternalMessageInfo
+var xxx_messageInfo_StorageUpdateReq proto.InternalMessageInfo
 
-func (m *UpdateStorageReq) GetNvme() *UpdateNvmeReq {
+func (m *StorageUpdateReq) GetNvme() *UpdateNvmeReq {
 	if m != nil {
 		return m.Nvme
 	}
 	return nil
 }
 
-func (m *UpdateStorageReq) GetScm() *UpdateScmReq {
+func (m *StorageUpdateReq) GetScm() *UpdateScmReq {
 	if m != nil {
 		return m.Scm
 	}
 	return nil
 }
 
-type UpdateStorageResp struct {
+type StorageUpdateResp struct {
 	Crets                []*NvmeControllerResult `protobuf:"bytes,1,rep,name=crets,proto3" json:"crets,omitempty"`
 	Mrets                []*ScmModuleResult      `protobuf:"bytes,2,rep,name=mrets,proto3" json:"mrets,omitempty"`
 	XXX_NoUnkeyedLiteral struct{}                `json:"-"`
@@ -241,45 +257,45 @@ type UpdateStorageResp struct {
 	XXX_sizecache        int32                   `json:"-"`
 }
 
-func (m *UpdateStorageResp) Reset()         { *m = UpdateStorageResp{} }
-func (m *UpdateStorageResp) String() string { return proto.CompactTextString(m) }
-func (*UpdateStorageResp) ProtoMessage()    {}
-func (*UpdateStorageResp) Descriptor() ([]byte, []int) {
-	return fileDescriptor_storage_fbaf07d8be8e1d9c, []int{5}
+func (m *StorageUpdateResp) Reset()         { *m = StorageUpdateResp{} }
+func (m *StorageUpdateResp) String() string { return proto.CompactTextString(m) }
+func (*StorageUpdateResp) ProtoMessage()    {}
+func (*StorageUpdateResp) Descriptor() ([]byte, []int) {
+	return fileDescriptor_storage_d031b2d9797048d3, []int{5}
 }
-func (m *UpdateStorageResp) XXX_Unmarshal(b []byte) error {
-	return xxx_messageInfo_UpdateStorageResp.Unmarshal(m, b)
+func (m *StorageUpdateResp) XXX_Unmarshal(b []byte) error {
+	return xxx_messageInfo_StorageUpdateResp.Unmarshal(m, b)
 }
-func (m *UpdateStorageResp) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
-	return xxx_messageInfo_UpdateStorageResp.Marshal(b, m, deterministic)
+func (m *StorageUpdateResp) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	return xxx_messageInfo_StorageUpdateResp.Marshal(b, m, deterministic)
 }
-func (dst *UpdateStorageResp) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_UpdateStorageResp.Merge(dst, src)
+func (dst *StorageUpdateResp) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_StorageUpdateResp.Merge(dst, src)
 }
-func (m *UpdateStorageResp) XXX_Size() int {
-	return xxx_messageInfo_UpdateStorageResp.Size(m)
+func (m *StorageUpdateResp) XXX_Size() int {
+	return xxx_messageInfo_StorageUpdateResp.Size(m)
 }
-func (m *UpdateStorageResp) XXX_DiscardUnknown() {
-	xxx_messageInfo_UpdateStorageResp.DiscardUnknown(m)
+func (m *StorageUpdateResp) XXX_DiscardUnknown() {
+	xxx_messageInfo_StorageUpdateResp.DiscardUnknown(m)
 }
 
-var xxx_messageInfo_UpdateStorageResp proto.InternalMessageInfo
+var xxx_messageInfo_StorageUpdateResp proto.InternalMessageInfo
 
-func (m *UpdateStorageResp) GetCrets() []*NvmeControllerResult {
+func (m *StorageUpdateResp) GetCrets() []*NvmeControllerResult {
 	if m != nil {
 		return m.Crets
 	}
 	return nil
 }
 
-func (m *UpdateStorageResp) GetMrets() []*ScmModuleResult {
+func (m *StorageUpdateResp) GetMrets() []*ScmModuleResult {
 	if m != nil {
 		return m.Mrets
 	}
 	return nil
 }
 
-type BurninStorageReq struct {
+type StorageBurnInReq struct {
 	Nvme                 *BurninNvmeReq `protobuf:"bytes,1,opt,name=nvme,proto3" json:"nvme,omitempty"`
 	Scm                  *BurninScmReq  `protobuf:"bytes,2,opt,name=scm,proto3" json:"scm,omitempty"`
 	XXX_NoUnkeyedLiteral struct{}       `json:"-"`
@@ -287,45 +303,45 @@ type BurninStorageReq struct {
 	XXX_sizecache        int32          `json:"-"`
 }
 
-func (m *BurninStorageReq) Reset()         { *m = BurninStorageReq{} }
-func (m *BurninStorageReq) String() string { return proto.CompactTextString(m) }
-func (*BurninStorageReq) ProtoMessage()    {}
-func (*BurninStorageReq) Descriptor() ([]byte, []int) {
-	return fileDescriptor_storage_fbaf07d8be8e1d9c, []int{6}
+func (m *StorageBurnInReq) Reset()         { *m = StorageBurnInReq{} }
+func (m *StorageBurnInReq) String() string { return proto.CompactTextString(m) }
+func (*StorageBurnInReq) ProtoMessage()    {}
+func (*StorageBurnInReq) Descriptor() ([]byte, []int) {
+	return fileDescriptor_storage_d031b2d9797048d3, []int{6}
 }
-func (m *BurninStorageReq) XXX_Unmarshal(b []byte) error {
-	return xxx_messageInfo_BurninStorageReq.Unmarshal(m, b)
+func (m *StorageBurnInReq) XXX_Unmarshal(b []byte) error {
+	return xxx_messageInfo_StorageBurnInReq.Unmarshal(m, b)
 }
-func (m *BurninStorageReq) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
-	return xxx_messageInfo_BurninStorageReq.Marshal(b, m, deterministic)
+func (m *StorageBurnInReq) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	return xxx_messageInfo_StorageBurnInReq.Marshal(b, m, deterministic)
 }
-func (dst *BurninStorageReq) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_BurninStorageReq.Merge(dst, src)
+func (dst *StorageBurnInReq) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_StorageBurnInReq.Merge(dst, src)
 }
-func (m *BurninStorageReq) XXX_Size() int {
-	return xxx_messageInfo_BurninStorageReq.Size(m)
+func (m *StorageBurnInReq) XXX_Size() int {
+	return xxx_messageInfo_StorageBurnInReq.Size(m)
 }
-func (m *BurninStorageReq) XXX_DiscardUnknown() {
-	xxx_messageInfo_BurninStorageReq.DiscardUnknown(m)
+func (m *StorageBurnInReq) XXX_DiscardUnknown() {
+	xxx_messageInfo_StorageBurnInReq.DiscardUnknown(m)
 }
 
-var xxx_messageInfo_BurninStorageReq proto.InternalMessageInfo
+var xxx_messageInfo_StorageBurnInReq proto.InternalMessageInfo
 
-func (m *BurninStorageReq) GetNvme() *BurninNvmeReq {
+func (m *StorageBurnInReq) GetNvme() *BurninNvmeReq {
 	if m != nil {
 		return m.Nvme
 	}
 	return nil
 }
 
-func (m *BurninStorageReq) GetScm() *BurninScmReq {
+func (m *StorageBurnInReq) GetScm() *BurninScmReq {
 	if m != nil {
 		return m.Scm
 	}
 	return nil
 }
 
-type BurninStorageResp struct {
+type StorageBurnInResp struct {
 	Crets                []*NvmeControllerResult `protobuf:"bytes,1,rep,name=crets,proto3" json:"crets,omitempty"`
 	Mrets                []*ScmMountResult       `protobuf:"bytes,2,rep,name=mrets,proto3" json:"mrets,omitempty"`
 	XXX_NoUnkeyedLiteral struct{}                `json:"-"`
@@ -333,38 +349,38 @@ type BurninStorageResp struct {
 	XXX_sizecache        int32                   `json:"-"`
 }
 
-func (m *BurninStorageResp) Reset()         { *m = BurninStorageResp{} }
-func (m *BurninStorageResp) String() string { return proto.CompactTextString(m) }
-func (*BurninStorageResp) ProtoMessage()    {}
-func (*BurninStorageResp) Descriptor() ([]byte, []int) {
-	return fileDescriptor_storage_fbaf07d8be8e1d9c, []int{7}
+func (m *StorageBurnInResp) Reset()         { *m = StorageBurnInResp{} }
+func (m *StorageBurnInResp) String() string { return proto.CompactTextString(m) }
+func (*StorageBurnInResp) ProtoMessage()    {}
+func (*StorageBurnInResp) Descriptor() ([]byte, []int) {
+	return fileDescriptor_storage_d031b2d9797048d3, []int{7}
 }
-func (m *BurninStorageResp) XXX_Unmarshal(b []byte) error {
-	return xxx_messageInfo_BurninStorageResp.Unmarshal(m, b)
+func (m *StorageBurnInResp) XXX_Unmarshal(b []byte) error {
+	return xxx_messageInfo_StorageBurnInResp.Unmarshal(m, b)
 }
-func (m *BurninStorageResp) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
-	return xxx_messageInfo_BurninStorageResp.Marshal(b, m, deterministic)
+func (m *StorageBurnInResp) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	return xxx_messageInfo_StorageBurnInResp.Marshal(b, m, deterministic)
 }
-func (dst *BurninStorageResp) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_BurninStorageResp.Merge(dst, src)
+func (dst *StorageBurnInResp) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_StorageBurnInResp.Merge(dst, src)
 }
-func (m *BurninStorageResp) XXX_Size() int {
-	return xxx_messageInfo_BurninStorageResp.Size(m)
+func (m *StorageBurnInResp) XXX_Size() int {
+	return xxx_messageInfo_StorageBurnInResp.Size(m)
 }
-func (m *BurninStorageResp) XXX_DiscardUnknown() {
-	xxx_messageInfo_BurninStorageResp.DiscardUnknown(m)
+func (m *StorageBurnInResp) XXX_DiscardUnknown() {
+	xxx_messageInfo_StorageBurnInResp.DiscardUnknown(m)
 }
 
-var xxx_messageInfo_BurninStorageResp proto.InternalMessageInfo
+var xxx_messageInfo_StorageBurnInResp proto.InternalMessageInfo
 
-func (m *BurninStorageResp) GetCrets() []*NvmeControllerResult {
+func (m *StorageBurnInResp) GetCrets() []*NvmeControllerResult {
 	if m != nil {
 		return m.Crets
 	}
 	return nil
 }
 
-func (m *BurninStorageResp) GetMrets() []*ScmMountResult {
+func (m *StorageBurnInResp) GetMrets() []*ScmMountResult {
 	if m != nil {
 		return m.Mrets
 	}
@@ -372,40 +388,42 @@ func (m *BurninStorageResp) GetMrets() []*ScmMountResult {
 }
 
 func init() {
-	proto.RegisterType((*ScanStorageReq)(nil), "mgmt.ScanStorageReq")
-	proto.RegisterType((*ScanStorageResp)(nil), "mgmt.ScanStorageResp")
-	proto.RegisterType((*FormatStorageReq)(nil), "mgmt.FormatStorageReq")
-	proto.RegisterType((*FormatStorageResp)(nil), "mgmt.FormatStorageResp")
-	proto.RegisterType((*UpdateStorageReq)(nil), "mgmt.UpdateStorageReq")
-	proto.RegisterType((*UpdateStorageResp)(nil), "mgmt.UpdateStorageResp")
-	proto.RegisterType((*BurninStorageReq)(nil), "mgmt.BurninStorageReq")
-	proto.RegisterType((*BurninStorageResp)(nil), "mgmt.BurninStorageResp")
+	proto.RegisterType((*StorageScanReq)(nil), "mgmt.StorageScanReq")
+	proto.RegisterType((*StorageScanResp)(nil), "mgmt.StorageScanResp")
+	proto.RegisterType((*StorageFormatReq)(nil), "mgmt.StorageFormatReq")
+	proto.RegisterType((*StorageFormatResp)(nil), "mgmt.StorageFormatResp")
+	proto.RegisterType((*StorageUpdateReq)(nil), "mgmt.StorageUpdateReq")
+	proto.RegisterType((*StorageUpdateResp)(nil), "mgmt.StorageUpdateResp")
+	proto.RegisterType((*StorageBurnInReq)(nil), "mgmt.StorageBurnInReq")
+	proto.RegisterType((*StorageBurnInResp)(nil), "mgmt.StorageBurnInResp")
 }
 
-func init() { proto.RegisterFile("storage.proto", fileDescriptor_storage_fbaf07d8be8e1d9c) }
+func init() { proto.RegisterFile("storage.proto", fileDescriptor_storage_d031b2d9797048d3) }
 
-var fileDescriptor_storage_fbaf07d8be8e1d9c = []byte{
-	// 349 bytes of a gzipped FileDescriptorProto
-	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0xb4, 0x93, 0xdd, 0x4e, 0xe3, 0x30,
-	0x10, 0x85, 0x95, 0xfe, 0xed, 0xee, 0x74, 0x77, 0xdb, 0x18, 0x90, 0xa2, 0x5c, 0x55, 0x11, 0x12,
-	0xe5, 0x47, 0x05, 0xca, 0x1b, 0x80, 0xc4, 0x1d, 0x5c, 0x38, 0xe2, 0x1a, 0x05, 0xd7, 0xaa, 0x90,
-	0x32, 0x76, 0x62, 0x3b, 0x7d, 0x4c, 0x9e, 0x09, 0xd9, 0x4e, 0x68, 0x1a, 0x81, 0x2a, 0x21, 0x71,
-	0x7b, 0xe6, 0x9b, 0x39, 0x3e, 0x33, 0x32, 0xfc, 0xd3, 0x46, 0xaa, 0x6c, 0xcd, 0x17, 0x85, 0x92,
-	0x46, 0x92, 0x01, 0xae, 0xd1, 0xc4, 0x7f, 0x99, 0x44, 0x94, 0xc2, 0x6b, 0x31, 0xa9, 0x91, 0x67,
-	0xb1, 0xc1, 0x9a, 0x8b, 0xc3, 0x46, 0xd3, 0x0c, 0xbd, 0x94, 0x4c, 0xe1, 0x7f, 0xca, 0x32, 0x91,
-	0xfa, 0x02, 0xe5, 0x65, 0xf2, 0x16, 0xc0, 0x64, 0x47, 0xd2, 0x05, 0xb9, 0x80, 0x11, 0x33, 0x2a,
-	0x57, 0x3a, 0x0a, 0x66, 0xfd, 0xf9, 0x78, 0x79, 0xb8, 0xb0, 0x8e, 0x8b, 0xc7, 0x0d, 0xf2, 0x3b,
-	0x29, 0x8c, 0x92, 0x79, 0xce, 0x15, 0xad, 0x19, 0x72, 0x0d, 0x7f, 0xac, 0xa9, 0x36, 0x99, 0xe1,
-	0x51, 0x6f, 0x16, 0xcc, 0xc7, 0xcb, 0x03, 0xdf, 0x60, 0x87, 0x49, 0xa1, 0x79, 0x6a, 0x4b, 0x74,
-	0x4b, 0x91, 0x53, 0xf8, 0x85, 0x72, 0x55, 0xe5, 0x5c, 0x47, 0x7d, 0xe7, 0x30, 0xf1, 0x0d, 0x29,
-	0xc3, 0x07, 0xa7, 0xd3, 0xa6, 0x4e, 0x2e, 0xe1, 0xb7, 0x66, 0xe8, 0x87, 0x0f, 0xbe, 0x1e, 0xfe,
-	0x01, 0x25, 0x04, 0xa6, 0xf7, 0x52, 0x61, 0x66, 0x5a, 0x21, 0x4b, 0x08, 0x3b, 0x9a, 0x2e, 0xc8,
-	0x15, 0x0c, 0x99, 0xe2, 0xa6, 0x09, 0x19, 0x7f, 0x1a, 0x92, 0xeb, 0x2a, 0x37, 0xd4, 0x83, 0xe4,
-	0x0c, 0x86, 0xe8, 0x3a, 0x7a, 0xed, 0xb5, 0xb8, 0x47, 0x57, 0xc2, 0x34, 0xac, 0x43, 0x92, 0x0c,
-	0xa6, 0x4f, 0xc5, 0x2a, 0x33, 0x7c, 0xfb, 0x0c, 0x72, 0x02, 0x03, 0xbb, 0x83, 0x28, 0x68, 0xe7,
-	0xf0, 0x94, 0xb5, 0xa5, 0xbc, 0xa4, 0x0e, 0x20, 0xc7, 0xd0, 0xd7, 0x0c, 0xeb, 0x65, 0x92, 0x36,
-	0x97, 0x32, 0xb4, 0x98, 0x2d, 0x27, 0x0a, 0xc2, 0x8e, 0xc5, 0xb7, 0x52, 0x9d, 0xef, 0xa6, 0x3a,
-	0xea, 0x9e, 0xa2, 0x1b, 0xeb, 0xb6, 0x52, 0xe2, 0x55, 0xec, 0x8b, 0xe5, 0xa9, 0xfd, 0xb1, 0xea,
-	0x69, 0xad, 0x58, 0x25, 0x84, 0x1d, 0x8b, 0x9f, 0x3e, 0xd6, 0xcb, 0xc8, 0xfd, 0x8e, 0x9b, 0xf7,
-	0x00, 0x00, 0x00, 0xff, 0xff, 0x69, 0x61, 0x59, 0x37, 0x69, 0x03, 0x00, 0x00,
+var fileDescriptor_storage_d031b2d9797048d3 = []byte{
+	// 371 bytes of a gzipped FileDescriptorProto
+	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0xb4, 0x93, 0x5d, 0x4b, 0xfb, 0x30,
+	0x14, 0xc6, 0xe9, 0xde, 0xfe, 0x7f, 0x33, 0x75, 0x5b, 0x54, 0x28, 0xbd, 0x1a, 0x45, 0x71, 0xbe,
+	0x30, 0x75, 0x7e, 0x03, 0x05, 0xc1, 0x0b, 0xbd, 0x48, 0xf1, 0xca, 0x0b, 0xa9, 0x59, 0x18, 0x42,
+	0x4f, 0xd2, 0x26, 0xe9, 0x3e, 0xa6, 0x9f, 0x49, 0x92, 0x34, 0x5b, 0x3b, 0x1c, 0x82, 0xe0, 0xed,
+	0x79, 0x7e, 0x79, 0xce, 0x79, 0xfa, 0x50, 0xb4, 0xa7, 0xb4, 0x90, 0xe9, 0x82, 0x4d, 0x73, 0x29,
+	0xb4, 0xc0, 0x1d, 0x58, 0x80, 0x8e, 0x76, 0xa9, 0x00, 0x10, 0xdc, 0xcd, 0x22, 0x5c, 0x21, 0x6f,
+	0x7c, 0x09, 0x15, 0x17, 0x8d, 0xfc, 0x4c, 0x51, 0x70, 0xa3, 0xf8, 0x15, 0xed, 0x27, 0x6e, 0x98,
+	0xd0, 0x94, 0x13, 0x56, 0xe0, 0x13, 0xd4, 0x31, 0x4f, 0xc2, 0x60, 0x1c, 0x4c, 0xfa, 0xb3, 0xd1,
+	0xd4, 0x78, 0x4f, 0x8d, 0xf8, 0xbc, 0x04, 0x46, 0x58, 0x41, 0xac, 0x8c, 0x63, 0xd4, 0x56, 0x14,
+	0xc2, 0x96, 0xa5, 0x86, 0x6b, 0x2a, 0xa1, 0x60, 0x20, 0x23, 0xc6, 0x9f, 0x01, 0x1a, 0x34, 0xdc,
+	0x55, 0x8e, 0x2f, 0x51, 0x8f, 0x6a, 0x99, 0x49, 0x15, 0x06, 0xe3, 0xf6, 0xa4, 0x3f, 0x3b, 0x74,
+	0x4f, 0x8d, 0xf9, 0xbd, 0xe0, 0x5a, 0x8a, 0x2c, 0x63, 0x92, 0x54, 0x0c, 0xbe, 0x41, 0x3b, 0x66,
+	0x9b, 0xd2, 0xa9, 0x66, 0xd5, 0xae, 0x03, 0xf7, 0xc0, 0x98, 0x09, 0xae, 0x58, 0x62, 0x24, 0xb2,
+	0xa6, 0xf0, 0x19, 0xfa, 0x07, 0x62, 0x5e, 0x66, 0x4c, 0x85, 0x6d, 0xbb, 0x61, 0xe0, 0x8f, 0x83,
+	0x27, 0x3b, 0x27, 0x5e, 0xc7, 0x57, 0xe8, 0xbf, 0xa2, 0xe0, 0xcc, 0x3b, 0xdb, 0xcd, 0x57, 0x50,
+	0x8c, 0xd1, 0xb0, 0xca, 0xf3, 0x20, 0x24, 0xa4, 0x9a, 0xb0, 0x22, 0x2e, 0xd0, 0x68, 0x63, 0xa6,
+	0x72, 0x7c, 0x8d, 0xba, 0x54, 0x32, 0xed, 0x43, 0x46, 0xdf, 0x86, 0x64, 0xaa, 0xcc, 0x34, 0x71,
+	0x20, 0x3e, 0x47, 0x5d, 0xb0, 0x2f, 0x5a, 0xf5, 0xcf, 0x62, 0x8f, 0x2e, 0xb9, 0xf6, 0xac, 0x45,
+	0xe2, 0x74, 0x75, 0xc6, 0x4b, 0x3e, 0x37, 0x17, 0xb2, 0x02, 0x9f, 0x36, 0x6a, 0xab, 0x72, 0x38,
+	0xb9, 0x59, 0xdc, 0x71, 0xbd, 0x38, 0x5c, 0xe7, 0xea, 0xd5, 0xc9, 0x55, 0x2a, 0xbf, 0xe2, 0x57,
+	0xa9, 0x2e, 0x9a, 0xa9, 0x8e, 0x36, 0xab, 0xd8, 0x12, 0xeb, 0xae, 0x94, 0xfc, 0x91, 0x6f, 0x8d,
+	0x65, 0xe4, 0x0f, 0xfe, 0x73, 0x2c, 0xc7, 0xd5, 0x63, 0xad, 0xcb, 0xf2, 0x2b, 0xfe, 0xba, 0xac,
+	0xf7, 0x9e, 0xfd, 0xd1, 0x6e, 0xbf, 0x02, 0x00, 0x00, 0xff, 0xff, 0xd2, 0xe2, 0x94, 0xd4, 0xb4,
+	0x03, 0x00, 0x00,
 }

--- a/src/control/server/README.md
+++ b/src/control/server/README.md
@@ -374,7 +374,7 @@ wolf-72.wolf.hpdd.intel.com 2019/04/10 04:00:21 external.go:54: debug: exec 'wip
 wolf-72.wolf.hpdd.intel.com 2019/04/10 04:00:21 external.go:54: debug: exec 'mkfs.ext4 /dev/pmem4'
 wolf-72.wolf.hpdd.intel.com 2019/04/10 04:00:22 external.go:98: debug: calling mount with /dev/pmem4, /mnt/daos, ext4, 33806, dax
 wolf-72.wolf.hpdd.intel.com 2019/04/10 04:00:22 external.go:54: debug: exec 'mount | grep ' /mnt/daos ''
-wolf-72.wolf.hpdd.intel.com 2019/04/10 04:00:22 mgmt.go:153: debug: FormatStorage: storage format successful on server 0
+wolf-72.wolf.hpdd.intel.com 2019/04/10 04:00:22 mgmt.go:153: debug: StorageFormat: storage format successful on server 0
 wolf-72.wolf.hpdd.intel.com 2019/04/10 04:00:22 iosrv.go:128: debug: format server /mnt/daos (createMS=false bootstrapMS=false)
 wolf-72.wolf.hpdd.intel.com 2019/04/10 04:00:23 main.go:156: debug: DAOS server listening on 0.0.0.0:10001
 DAOS I/O server (v0.4.0) process 135863 started on rank 0 (out of 1) with 1 target xstream set(s), 2 helper XS per target, firstcore 0.

--- a/src/control/server/mgmt.go
+++ b/src/control/server/mgmt.go
@@ -81,7 +81,7 @@ func (c *ControlService) Teardown() {
 }
 
 func (c *ControlService) ScanNVMe() (common.NvmeControllers, error) {
-	resp := new(pb.ScanStorageResp)
+	resp := new(pb.StorageScanResp)
 
 	c.nvme.Discover(resp)
 	if resp.Nvmestate.Status != pb.ResponseStatus_CTRL_SUCCESS {
@@ -91,7 +91,7 @@ func (c *ControlService) ScanNVMe() (common.NvmeControllers, error) {
 }
 
 func (c *ControlService) ScanSCM() (common.ScmModules, error) {
-	resp := new(pb.ScanStorageResp)
+	resp := new(pb.StorageScanResp)
 
 	c.scm.Discover(resp)
 	if resp.Scmstate.Status != pb.ResponseStatus_CTRL_SUCCESS {

--- a/src/control/server/mgmt_storage.go
+++ b/src/control/server/mgmt_storage.go
@@ -49,12 +49,12 @@ func addState(
 	return state
 }
 
-// ScanStorage discovers non-volatile storage hardware on node.
-func (c *ControlService) ScanStorage(
-	ctx context.Context, req *pb.ScanStorageReq) (
-	*pb.ScanStorageResp, error) {
+// StorageScan discovers non-volatile storage hardware on node.
+func (c *ControlService) StorageScan(
+	ctx context.Context, req *pb.StorageScanReq) (
+	*pb.StorageScanResp, error) {
 
-	resp := new(pb.ScanStorageResp)
+	resp := new(pb.StorageScanResp)
 
 	c.nvme.Discover(resp)
 	c.scm.Discover(resp)
@@ -64,7 +64,7 @@ func (c *ControlService) ScanStorage(
 
 // doFormat performs format on storage subsystems, populates response results
 // in storage subsystem routines and broadcasts (closes channel) if successful.
-func (c *ControlService) doFormat(i int, resp *pb.FormatStorageResp) error {
+func (c *ControlService) doFormat(i int, resp *pb.StorageFormatResp) error {
 	srv := c.config.Servers[i]
 	serverFormatted := false
 
@@ -104,11 +104,11 @@ func (c *ControlService) doFormat(i int, resp *pb.FormatStorageResp) error {
 //
 // Send response containing multiple results of format operations on scm mounts
 // and nvme controllers.
-func (c *ControlService) FormatStorage(
-	req *pb.FormatStorageReq,
-	stream pb.MgmtCtl_FormatStorageServer) error {
+func (c *ControlService) StorageFormat(
+	req *pb.StorageFormatReq,
+	stream pb.MgmtCtl_StorageFormatServer) error {
 
-	resp := new(pb.FormatStorageResp)
+	resp := new(pb.StorageFormatResp)
 
 	for i := range c.config.Servers {
 		if err := c.doFormat(i, resp); err != nil {
@@ -129,11 +129,11 @@ func (c *ControlService) FormatStorage(
 //
 // Send response containing multiple results of update operations on scm mounts
 // and nvme controllers.
-func (c *ControlService) UpdateStorage(
-	req *pb.UpdateStorageReq,
-	stream pb.MgmtCtl_UpdateStorageServer) error {
+func (c *ControlService) StorageUpdate(
+	req *pb.StorageUpdateReq,
+	stream pb.MgmtCtl_StorageUpdateServer) error {
 
-	resp := new(pb.UpdateStorageResp)
+	resp := new(pb.StorageUpdateResp)
 
 	for i := range c.config.Servers {
 		ctrlrResults := common.NvmeControllerResults{}
@@ -158,11 +158,11 @@ func (c *ControlService) UpdateStorage(
 //
 // Send response containing multiple results of burn-in operations on scm mounts
 // and nvme controllers.
-func (c *ControlService) BurninStorage(
-	req *pb.BurninStorageReq,
-	stream pb.MgmtCtl_BurninStorageServer) error {
+func (c *ControlService) StorageBurnIn(
+	req *pb.StorageBurnInReq,
+	stream pb.MgmtCtl_StorageBurnInServer) error {
 
-	return errors.New("BurninStorage not implemented")
+	return errors.New("StorageBurnIn not implemented")
 	//	for i := range c.config.Servers {
 	//		c.nvme.BurnIn(i, req.Nvme, resp)
 	//		c.scm.BurnIn(i, req.Scm, resp)

--- a/src/control/server/mgmt_storage_test.go
+++ b/src/control/server/mgmt_storage_test.go
@@ -37,26 +37,26 @@ import (
 	"github.com/daos-stack/daos/src/control/lib/spdk"
 )
 
-// mockFormatStorageServer provides mocking for server side streaming,
+// mockStorageFormatServer provides mocking for server side streaming,
 // implement send method and record sent format responses.
-type mockFormatStorageServer struct {
+type mockStorageFormatServer struct {
 	grpc.ServerStream
-	Results []*pb.FormatStorageResp
+	Results []*pb.StorageFormatResp
 }
 
-func (m *mockFormatStorageServer) Send(resp *pb.FormatStorageResp) error {
+func (m *mockStorageFormatServer) Send(resp *pb.StorageFormatResp) error {
 	m.Results = append(m.Results, resp)
 	return nil
 }
 
-// mockUpdateStorageServer provides mocking for server side streaming,
+// mockStorageUpdateServer provides mocking for server side streaming,
 // implement send method and record sent update responses.
-type mockUpdateStorageServer struct {
+type mockStorageUpdateServer struct {
 	grpc.ServerStream
-	Results []*pb.UpdateStorageResp
+	Results []*pb.StorageUpdateResp
 }
 
-func (m *mockUpdateStorageServer) Send(resp *pb.UpdateStorageResp) error {
+func (m *mockStorageUpdateServer) Send(resp *pb.StorageUpdateResp) error {
 	m.Results = append(m.Results, resp)
 	return nil
 }
@@ -83,7 +83,7 @@ func newMockStorageConfig(
 	return c
 }
 
-func TestScanStorage(t *testing.T) {
+func TestStorageScan(t *testing.T) {
 	ctrlr := MockController("")
 	pbCtrlr := MockControllerPB("")
 	module := MockModule()
@@ -97,12 +97,12 @@ func TestScanStorage(t *testing.T) {
 		ipmctlDiscoverRet error
 		expNvmeInited     bool
 		expScmInited      bool
-		expResp           pb.ScanStorageResp
+		expResp           pb.StorageScanResp
 		errMsg            string
 	}{
 		{
 			"success", nil, nil, nil, true, true,
-			pb.ScanStorageResp{
+			pb.StorageScanResp{
 				Ctrlrs:    NvmeControllers{pbCtrlr},
 				Nvmestate: new(pb.ResponseState),
 				Modules:   ScmModules{pbModule},
@@ -111,7 +111,7 @@ func TestScanStorage(t *testing.T) {
 		},
 		{
 			"spdk init fail", errExample, nil, nil, false, true,
-			pb.ScanStorageResp{
+			pb.StorageScanResp{
 				Nvmestate: &pb.ResponseState{
 					Error: msgSpdkInitFail +
 						": example failure",
@@ -123,7 +123,7 @@ func TestScanStorage(t *testing.T) {
 		},
 		{
 			"spdk discover fail", nil, errExample, nil, false, true,
-			pb.ScanStorageResp{
+			pb.StorageScanResp{
 				Nvmestate: &pb.ResponseState{
 					Error: msgSpdkDiscoverFail +
 						": example failure",
@@ -135,7 +135,7 @@ func TestScanStorage(t *testing.T) {
 		},
 		{
 			"ipmctl discover fail", nil, nil, errExample, true, false,
-			pb.ScanStorageResp{
+			pb.StorageScanResp{
 				Ctrlrs:    NvmeControllers{pbCtrlr},
 				Nvmestate: new(pb.ResponseState),
 				Scmstate: &pb.ResponseState{
@@ -147,7 +147,7 @@ func TestScanStorage(t *testing.T) {
 		},
 		{
 			"all discover fail", nil, errExample, errExample, false, false,
-			pb.ScanStorageResp{
+			pb.StorageScanResp{
 				Nvmestate: &pb.ResponseState{
 					Error: msgSpdkDiscoverFail +
 						": example failure",
@@ -176,10 +176,10 @@ func TestScanStorage(t *testing.T) {
 				[]spdk.Namespace{MockNamespace(&ctrlr)},
 				tt.spdkDiscoverRet, nil, nil),
 			false, cs.config)
-		_ = new(pb.ScanStorageResp)
+		_ = new(pb.StorageScanResp)
 
 		cs.Setup() // runs discovery for nvme & scm
-		resp, err := cs.ScanStorage(context.TODO(), &pb.ScanStorageReq{})
+		resp, err := cs.StorageScan(context.TODO(), &pb.StorageScanReq{})
 		if err != nil {
 			AssertEqual(t, err.Error(), tt.errMsg, tt.desc)
 		}
@@ -213,7 +213,7 @@ func TestScanStorage(t *testing.T) {
 	}
 }
 
-func TestFormatStorage(t *testing.T) {
+func TestStorageFormat(t *testing.T) {
 	tests := []struct {
 		superblockExists bool
 		mountRet         error
@@ -364,7 +364,7 @@ func TestFormatStorage(t *testing.T) {
 		cs := mockControlService(config)
 		cs.Setup() // init channel used for sync
 
-		mock := &mockFormatStorageServer{}
+		mock := &mockStorageFormatServer{}
 		mockWg := new(sync.WaitGroup)
 		mockWg.Add(1)
 
@@ -374,7 +374,7 @@ func TestFormatStorage(t *testing.T) {
 		go func() {
 			// should signal wait group in srv to unlock if
 			// successful once format completed
-			_ = cs.FormatStorage(nil, mock)
+			_ = cs.StorageFormat(nil, mock)
 			mockWg.Done()
 		}()
 
@@ -425,7 +425,7 @@ func TestFormatStorage(t *testing.T) {
 	}
 }
 
-func TestUpdateStorage(t *testing.T) {
+func TestStorageUpdate(t *testing.T) {
 	pciAddr := "0000:81:00.0" // default pciaddr for tests
 
 	tests := []struct {
@@ -521,14 +521,14 @@ func TestUpdateStorage(t *testing.T) {
 		config := defaultMockConfig(t)
 		cs := mockControlService(config)
 		cs.Setup() // init channel used for sync
-		mock := &mockUpdateStorageServer{}
+		mock := &mockStorageUpdateServer{}
 
-		req := &pb.UpdateStorageReq{
+		req := &pb.StorageUpdateReq{
 			Nvme: tt.nvmeParams,
 			Scm:  tt.scmParams,
 		}
 
-		_ = cs.UpdateStorage(req, mock)
+		_ = cs.StorageUpdate(req, mock)
 
 		AssertEqual(
 			t, len(mock.Results), 1,

--- a/src/control/server/storage_nvme.go
+++ b/src/control/server/storage_nvme.go
@@ -157,7 +157,7 @@ func (n *nvmeStorage) getController(pciAddr string) *pb.NvmeController {
 // NOTE: doesn't attempt SPDK prep which requires elevated privileges,
 //       that instead can be performed explicitly with subcommand.
 func (n *nvmeStorage) Setup() error {
-	resp := new(pb.ScanStorageResp)
+	resp := new(pb.StorageScanResp)
 	n.Discover(resp)
 
 	if resp.Nvmestate.Status != pb.ResponseStatus_CTRL_SUCCESS {
@@ -194,7 +194,7 @@ func (n *nvmeStorage) Teardown() (err error) {
 // TODO: This is currently a one-time only discovery for the lifetime of this
 //       process, presumably we want to be able to detect updates during
 //       process lifetime.
-func (n *nvmeStorage) Discover(resp *pb.ScanStorageResp) {
+func (n *nvmeStorage) Discover(resp *pb.StorageScanResp) {
 	addStateDiscover := func(
 		status pb.ResponseStatus, errMsg string,
 		infoMsg string) *pb.ResponseState {

--- a/src/control/server/storage_nvme_test.go
+++ b/src/control/server/storage_nvme_test.go
@@ -214,7 +214,7 @@ func TestDiscoverNvmeSingle(t *testing.T) {
 			tt.inited,
 			config)
 
-		resp := new(pb.ScanStorageResp)
+		resp := new(pb.StorageScanResp)
 		sn.Discover(resp)
 		if tt.errMsg != "" {
 			AssertEqual(t, resp.Nvmestate.Error, tt.errMsg, "")
@@ -290,7 +290,7 @@ func TestDiscoverNvmeMulti(t *testing.T) {
 			config)
 
 		// not concerned with response
-		sn.Discover(new(pb.ScanStorageResp))
+		sn.Discover(new(pb.StorageScanResp))
 
 		if len(tt.ctrlrs) != len(sn.controllers) {
 			t.Fatalf(
@@ -494,7 +494,7 @@ func TestFormatNvme(t *testing.T) {
 		results := NvmeControllerResults{}
 
 		// not concerned with response
-		sn.Discover(new(pb.ScanStorageResp))
+		sn.Discover(new(pb.StorageScanResp))
 
 		sn.Format(srvIdx, &results)
 
@@ -784,7 +784,7 @@ func TestUpdateNvme(t *testing.T) {
 		results := NvmeControllerResults{}
 
 		if tt.inited {
-			sn.Discover(new(pb.ScanStorageResp)) // not concerned with response
+			sn.Discover(new(pb.StorageScanResp)) // not concerned with response
 		}
 
 		// create parameters message with desired model name & starting fwrev
@@ -863,7 +863,7 @@ func TestBurnInNvme(t *testing.T) {
 
 		if tt.inited {
 			// not concerned with response
-			sn.Discover(new(pb.ScanStorageResp))
+			sn.Discover(new(pb.StorageScanResp))
 		}
 
 		cmdName, args, env, err := sn.BurnIn(c.Pciaddr, int32(nsID), configPath)

--- a/src/control/server/storage_scm.go
+++ b/src/control/server/storage_scm.go
@@ -358,7 +358,7 @@ func (s *scmStorage) getNamespaces() (devs []pmemDev, err error) {
 
 // Setup implementation for scmStorage providing initial device discovery
 func (s *scmStorage) Setup() error {
-	resp := new(pb.ScanStorageResp)
+	resp := new(pb.StorageScanResp)
 	s.Discover(resp)
 
 	if resp.Scmstate.Status != pb.ResponseStatus_CTRL_SUCCESS {
@@ -393,7 +393,7 @@ func loadModules(mms []ipmctl.DeviceDiscovery) (pbMms common.ScmModules) {
 }
 
 // Discover method implementation for scmStorage
-func (s *scmStorage) Discover(resp *pb.ScanStorageResp) {
+func (s *scmStorage) Discover(resp *pb.StorageScanResp) {
 	addStateDiscover := func(
 		status pb.ResponseStatus, errMsg string,
 		infoMsg string) *pb.ResponseState {

--- a/src/control/server/storage_scm_test.go
+++ b/src/control/server/storage_scm_test.go
@@ -183,7 +183,7 @@ func TestGetState(t *testing.T) {
 	for _, tt := range tests {
 		config := defaultMockConfig(t)
 		ss := defaultMockScmStorage(config).withRunCmd(mockRun)
-		ss.Discover(new(pb.ScanStorageResp)) // not concerned with response
+		ss.Discover(new(pb.StorageScanResp)) // not concerned with response
 
 		// reset to initial values between tests
 		regionsOut = tt.showRegionOut
@@ -241,7 +241,7 @@ func TestDiscoverScm(t *testing.T) {
 			tt.ipmctlDiscoverRet, []DeviceDiscovery{m}, tt.inited,
 			config)
 
-		resp := new(pb.ScanStorageResp)
+		resp := new(pb.StorageScanResp)
 		ss.Discover(resp)
 		if tt.errMsg != "" {
 			AssertEqual(t, resp.Scmstate.Error, tt.errMsg, "")
@@ -436,7 +436,7 @@ func TestFormatScm(t *testing.T) {
 
 		if tt.inited {
 			// not concerned with response
-			ss.Discover(new(pb.ScanStorageResp))
+			ss.Discover(new(pb.StorageScanResp))
 		}
 
 		ss.Format(srvIdx, &results)

--- a/src/proto/mgmt/control.proto
+++ b/src/proto/mgmt/control.proto
@@ -32,18 +32,21 @@ import "srv.proto";
 // Service definitions for communications between gRPC management server and
 // client regarding tasks related to DAOS storage server hardware.
 service MgmtCtl {
-	// Retrieve details of nonvolatile storage devices on server
-	rpc ScanStorage(ScanStorageReq) returns (ScanStorageResp) {};
-	// Format nonvolatile storage devices for use with DAOS
-	rpc FormatStorage(FormatStorageReq) returns (stream FormatStorageResp) {};
-	// Update nonvolatile storage device firmware
-	rpc UpdateStorage(UpdateStorageReq) returns (stream UpdateStorageResp) {};
-	// Perform burn-in testing to verify nonvolatile storage devices
-	rpc BurninStorage(BurninStorageReq) returns (stream BurninStorageResp) {};
-	// Fetch FIO configuration file specifying burn-in jobs/workloads
-	rpc FetchFioConfigPaths(EmptyReq) returns (stream FilePath) {};
-	// Kill a given rank associated with a given pool
-	rpc KillRank(DaosRank) returns (DaosResp) {};
-	// List features supported on remote storage server/DAOS system
-	rpc ListFeatures(EmptyReq) returns (stream Feature) {};
+        // Retrieve details of nonvolatile storage on server
+        rpc StorageScan(StorageScanReq) returns(StorageScanResp) {};
+        // Format nonvolatile storage devices for use with DAOS
+        rpc StorageFormat(StorageFormatReq)
+            returns(stream StorageFormatResp) {};
+        // Update nonvolatile storage device firmware
+        rpc StorageUpdate(StorageUpdateReq)
+            returns(stream StorageUpdateResp) {};
+        // Perform burn-in testing to verify nonvolatile storage devices
+        rpc StorageBurnIn(StorageBurnInReq)
+            returns(stream StorageBurnInResp) {};
+        // Fetch FIO configuration file specifying burn-in jobs/workloads
+        rpc FetchFioConfigPaths(EmptyReq) returns(stream FilePath) {};
+        // Kill a given rank associated with a given pool
+        rpc KillRank(DaosRank) returns(DaosResp) {};
+        // List features supported on remote storage server/DAOS system
+        rpc ListFeatures(EmptyReq) returns(stream Feature) {};
 }

--- a/src/proto/mgmt/storage.proto
+++ b/src/proto/mgmt/storage.proto
@@ -31,10 +31,13 @@ import "storage_scm.proto";
 // Management Service Protobuf Definitions related to interactions between
 // DAOS control server and locally attached storage.
 
-message ScanStorageReq {}
+message StorageScanReq {
+	ScanNvmeReq nvme = 1;
+	ScanScmReq scm = 2;
+}
 
-// ScanStorageResp returns discovered storage devices.
-message ScanStorageResp {
+// StorageScanResp returns discovered storage devices.
+message StorageScanResp {
 	repeated NvmeController ctrlrs = 1;
 	ResponseState nvmestate = 2;		// Single non-ctrlr-specific state
 	repeated ScmModule modules = 3;
@@ -42,29 +45,29 @@ message ScanStorageResp {
 	// TODO: add scan for scm regions/mount
 }
 
-message FormatStorageReq {}
+message StorageFormatReq {}
 
-message FormatStorageResp {
+message StorageFormatResp {
 	repeated NvmeControllerResult crets = 1;	// One per controller format attempt
 	repeated ScmMountResult mrets = 2;		// One per scm format and mount attempt
 }
 
-message UpdateStorageReq {
+message StorageUpdateReq {
 	UpdateNvmeReq nvme = 1;
 	UpdateScmReq scm = 2;
 }
 
-message UpdateStorageResp {
+message StorageUpdateResp {
 	repeated NvmeControllerResult crets = 1;	// One per SSD firmware update attempt
 	repeated ScmModuleResult mrets = 2;		// One per module firmware update attempt
 }
 
-message BurninStorageReq {
+message StorageBurnInReq {
 	BurninNvmeReq nvme = 1;
 	BurninScmReq scm = 2;
 }
 
-message BurninStorageResp {
+message StorageBurnInResp {
 	repeated NvmeControllerResult crets = 1;	// One per SSD burnin test, report in state.info
 	repeated ScmMountResult mrets = 2;		// One per SCM mount burnin test
 }


### PR DESCRIPTION
In advance of adding "storage prepare" functionality to gRPC client
align symbol names to follow <resource><action> style e.g. StorageScan

Signed-off-by: Tom Nabarro <tom.nabarro@intel.com>