### PR TITLE
DAOS-2444 test: add EC test to epoch_io test

### DIFF
--- a/src/tests/suite/SConscript
+++ b/src/tests/suite/SConscript
@@ -22,6 +22,7 @@ def scons():
     denv.Install('$PREFIX/bin/', test)
     denv.Install('$PREFIX/bin/io_conf', Glob('io_conf/daos_io_conf_1'))
     denv.Install('$PREFIX/bin/io_conf', Glob('io_conf/daos_io_conf_2'))
+    denv.Install('$PREFIX/bin/io_conf', Glob('io_conf/daos_io_conf_3'))
     SConscript('io_conf/SConscript', exports='denv')
 
 if __name__ == "SCons.Script":

--- a/src/tests/suite/daos_epoch_io.c
+++ b/src/tests/suite/daos_epoch_io.c
@@ -1213,6 +1213,21 @@ cmd_line_parse(test_arg_t *arg, char *cmd_line, struct test_op_record **op)
 		D_STRNDUP(arg->eio_args.op_akey, akey, strlen(akey));
 	} else if (strcmp(argv[0], "iod_size") == 0) {
 		arg->eio_args.op_iod_size = atoi(argv[1]);
+	} else if (strcmp(argv[0], "obj_class") == 0) {
+		if (strcmp(argv[1], "ec") == 0) {
+			arg->eio_args.op_ec = 1;
+			arg->eio_args.op_oid = dts_oid_gen(dts_ec_obj_class, 0,
+							   arg->myrank);
+			print_message("the test is for EC object.\n");
+		} else if (strcmp(argv[1], "replica") == 0) {
+			arg->eio_args.op_ec = 0;
+			arg->eio_args.op_oid = dts_oid_gen(dts_obj_class, 0,
+							   arg->myrank);
+			print_message("the test is for replica object.\n");
+		} else {
+			print_message("bad obj_class %s.\n", argv[1]);
+			rc = -DER_INVAL;
+		}
 	} else if (strcmp(argv[0], "oid") == 0) {
 		rc = cmd_parse_oid(arg, argc, argv);
 	} else if (strcmp(argv[0], "update") == 0) {
@@ -1341,7 +1356,7 @@ cmd_line_run(test_arg_t *arg, struct test_op_record *op_rec)
 	D_ASSERT(lvl == TEST_LVL_DAOS || lvl == TEST_LVL_VOS);
 
 	/* for modification OP, just go through DAOS stack and return */
-	if (test_op_is_modify(op))
+	if (test_op_is_modify(op) || op == TEST_OP_POOL_QUERY)
 		return op_dict[op].op_cb[lvl](arg, op_rec, NULL, 0);
 
 	/* for verification OP, firstly retrieve it through DAOS stack */

--- a/src/tests/suite/daos_iotest.h
+++ b/src/tests/suite/daos_iotest.h
@@ -35,6 +35,9 @@
 extern int dts_obj_class;
 extern int dts_obj_replica_cnt;
 
+extern int dts_ec_obj_class;
+extern int dts_ec_grp_size;
+
 #define UPDATE_CSUM_SIZE	32
 #define IOREQ_IOD_NR	5
 #define IOREQ_SG_NR	5

--- a/src/tests/suite/daos_obj.c
+++ b/src/tests/suite/daos_obj.c
@@ -35,6 +35,9 @@
 int dts_obj_class	= OC_RP_2G1;
 int dts_obj_replica_cnt	= 2;
 
+int dts_ec_obj_class	= OC_EC_2P2G1;
+int dts_ec_grp_size	= 4;
+
 void
 ioreq_init(struct ioreq *req, daos_handle_t coh, daos_obj_id_t oid,
 	   daos_iod_type_t iod_type, test_arg_t *arg)

--- a/src/tests/suite/daos_test.h
+++ b/src/tests/suite/daos_test.h
@@ -113,7 +113,8 @@ struct epoch_io_args {
 	/* cached dkey/akey used last time, so need not specify it every time */
 	char			*op_dkey;
 	char			*op_akey;
-	int			op_no_verify:1;
+	int			op_no_verify:1,
+				op_ec:1; /* true for EC, false for replica */
 };
 
 typedef struct {

--- a/src/tests/suite/io_conf/daos_io_conf_1
+++ b/src/tests/suite/io_conf/daos_io_conf_1
@@ -30,6 +30,7 @@
 # dkey xxx
 # akey xxx
 # iod_size xxx (default is 1)
+# obj_class xxx(ec or replica, default is replica)
 #
 # 2) update
 # 2.1) update array and take snapshot

--- a/src/tests/suite/io_conf/daos_io_conf_2
+++ b/src/tests/suite/io_conf/daos_io_conf_2
@@ -30,6 +30,7 @@
 ## dkey xxx
 ## akey xxx
 ## iod_size xxx (default is 1)
+## obj_class xxx(ec or replica, default is replica)
 ##
 ## 2) update
 ## 2.1) update array and take snapshot

--- a/src/tests/suite/io_conf/daos_io_conf_3
+++ b/src/tests/suite/io_conf/daos_io_conf_3
@@ -1,0 +1,65 @@
+#/*
+## * (C) Copyright 2018-2019 Intel Corporation.
+## *
+## * Licensed under the Apache License, Version 2.0 (the "License");
+## * you may not use this file except in compliance with the License.
+## * You may obtain a copy of the License at
+## *
+## *    http://www.apache.org/licenses/LICENSE-2.0
+## *
+## * Unless required by applicable law or agreed to in writing, software
+## * distributed under the License is distributed on an "AS IS" BASIS,
+## * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+## * See the License for the specific language governing permissions and
+## * limitations under the License.
+## *
+## * GOVERNMENT LICENSE RIGHTS-OPEN SOURCE SOFTWARE
+## * The Government's rights to use, modify, reproduce, release, perform, display,
+## * or disclose this software are subject to the terms of the Apache License as
+## * provided in Contract No. B609815.
+## * Any reproduction of computer software, computer software documentation, or
+## * portions thereof marked with this legend must also reproduce the markings.
+## */
+##/**
+## * An example daos EPOCH IO test conf file.
+## */
+#
+# io conf file format:
+# 1) some setting:
+# test_lvl xxx (daos or vos, default is daos)
+# dkey xxx
+# akey xxx
+# iod_size xxx (default is 1)
+# obj_class xxx(ec or replica, default is replica)
+#
+# 2) update
+# 2.1) update array and take snapshot
+# update --tx x --snap --recx "[idx_start1, idx_end1] [idx_start2, idx_end2] ..."
+# The max number of recxs is 5 (IOREQ_IOD_NR).
+# 2.2) update single type record and take snapshot
+# update --tx x --snap --single
+#
+# If no --epoch specified, then use default epoch 1.
+# Other two options: --dkey xxx --akey xxx. If not specified then use the last
+# dkey/akey set at above 1).
+# for the option name:
+# --single      == -s
+# --recx        == -r
+# --dkey        == -d
+# --akey        == -a
+#
+# 3) fetch and verify based on snapshot teaken after update.
+# same parameter usage as above 2)
+#
+# 4) discard
+#
+# 5) punch
+#
+
+test_lvl daos
+dkey dkey_3
+akey akey_3
+iod_size 32768
+obj_class ec
+
+update --tx 1 -r "[0, 2]"


### PR DESCRIPTION
Add "obj_class_ec" cmd to io_conf file for EC obj test.
Add daos_io_conf_3 for basic EC IO test.
Fixed a bug of pool_query OP caused segfault in replay.

Signed-off-by: Xuezhao Liu <xuezhao.liu@intel.com>