### PR TITLE
DAOS-3218 build: add ndctl and ipmctl server reqs to rpm.spec

### DIFF
--- a/utils/rpms/daos.spec
+++ b/utils/rpms/daos.spec
@@ -5,7 +5,7 @@
 
 Name:          daos
 Version:       0.6.0
-Release:       4%{?relval}%{?dist}
+Release:       5%{?relval}%{?dist}
 Summary:       DAOS Storage Engine
 
 License:       Apache
@@ -58,7 +58,6 @@ Requires: protobuf-c
 Requires: spdk
 Requires: fio < 3.4
 Requires: openssl
-Requires: ndctl
 
 %description
 The Distributed Asynchronous Object Storage (DAOS) is an open-source
@@ -75,6 +74,8 @@ to optimize performance and cost.
 Summary: The DAOS server
 Requires: %{name} = %{version}-%{release}
 Requires: spdk-tools
+Requires: ndctl
+Requires: ipmctl
 Requires(post): /sbin/ldconfig
 Requires(postun): /sbin/ldconfig
 

--- a/utils/rpms/daos.spec
+++ b/utils/rpms/daos.spec
@@ -58,6 +58,7 @@ Requires: protobuf-c
 Requires: spdk
 Requires: fio < 3.4
 Requires: openssl
+Requires: ndctl
 
 %description
 The Distributed Asynchronous Object Storage (DAOS) is an open-source
@@ -238,6 +239,9 @@ install -m 644 utils/systemd/daos-agent.service %{?buildroot}/%{_unitdir}
 %{_libdir}/*.a
 
 %changelog
+* Tue Sep 10 2019 Tom Nabarro <tom.nabarro@intel.com>
+- Add requires ndctl as runtime dep for control plane.
+
 * Thu Aug 15 2019 David Quigley <david.quigley@intel.com>
 - Add systemd unit files to packaging.
 


### PR DESCRIPTION
ndctl & ipmctl are both required at run time for full control plane
functionality, add to daos.spec server requirements.

Signed-off-by: Tom Nabarro <tom.nabarro@intel.com>