### PR TITLE
DAOS-3196 vos: force VEA reclaim on cont destroy

### DIFF
--- a/src/container/srv_target.c
+++ b/src/container/srv_target.c
@@ -509,6 +509,18 @@ cont_child_destroy_one(void *vin)
 	 * synchronous GC for now.
 	 */
 	dss_gc_run(-1);
+
+	/*
+	 * Force VEA to expire all the just freed extents and make them
+	 * available for allocation immediately.
+	 */
+	vos_pool_ctl(pool->spc_hdl, VOS_PO_CTL_VEA_FLUSH);
+	if (rc) {
+		D_ERROR(DF_CONT": VEA flush failed. %d\n",
+			DP_CONT(pool->spc_uuid, in->tdi_uuid), rc);
+		goto out_pool;
+	}
+
 out_pool:
 	ds_pool_child_put(pool);
 out:

--- a/src/include/daos_srv/vea.h
+++ b/src/include/daos_srv/vea.h
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2018 Intel Corporation.
+ * (C) Copyright 2018-2019 Intel Corporation.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -315,5 +315,13 @@ int vea_get_ext_vector(struct vea_space_info *vsi, uint64_t blk_off,
  */
 int vea_query(struct vea_space_info *vsi, struct vea_attr *attr,
 	      struct vea_stat *stat);
+
+/**
+ * Force flushing the free extents in aging buffer and make them available
+ * for allocation immediately.
+ *
+ * \param vsi       [IN]	In-memory compund index
+ */
+void vea_flush(struct vea_space_info *vsi);
 
 #endif /* __VEA_API_H__ */

--- a/src/include/daos_srv/vos.h
+++ b/src/include/daos_srv/vos.h
@@ -919,6 +919,8 @@ vos_pool_get_scm_cutoff(void);
 enum vos_pool_opc {
 	/** reset pool GC statistics */
 	VOS_PO_CTL_RESET_GC,
+	/** force VEA flush */
+	VOS_PO_CTL_VEA_FLUSH,
 };
 
 /**

--- a/src/vea/vea_api.c
+++ b/src/vea/vea_api.c
@@ -718,3 +718,12 @@ vea_query(struct vea_space_info *vsi, struct vea_attr *attr,
 
 	return 0;
 }
+
+void
+vea_flush(struct vea_space_info *vsi)
+{
+	D_ASSERT(vsi != NULL);
+
+	vsi->vsi_agg_time = 0;
+	migrate_free_exts(vsi);
+}

--- a/src/vos/vos_pool.c
+++ b/src/vos/vos_pool.c
@@ -728,6 +728,10 @@ vos_pool_ctl(daos_handle_t poh, enum vos_pool_opc opc)
 	case VOS_PO_CTL_RESET_GC:
 		memset(&pool->vp_gc_stat, 0, sizeof(pool->vp_gc_stat));
 		break;
+	case VOS_PO_CTL_VEA_FLUSH:
+		if (pool->vp_vea_info != NULL)
+			vea_flush(pool->vp_vea_info);
+		break;
 	}
 	return 0;
 }


### PR DESCRIPTION
When a NVMe extent is freed by vea_free(), it won't be available
for next allocation immediately, instead, it'll stay in an aging
buffer for few seconds, so that it could be coalesced with other
recent freed extents, the coalesced extent will be unmapped (NVMe
unmap) and being available for next allocation once it's expired.

On container destroy, there will be huge amount of NVMe extents
being freed all together, so we'd force all of them available for
allocation immediately.

Signed-off-by: Niu Yawei <yawei.niu@intel.com>
Change-Id: I531ca4a37f92623a9a1d33e7081c531009e8d7d4