### PR TITLE
DAOS-3121 object: debug patch for obj_rw_out::orw_sizes

### DIFF
--- a/src/dtx/dtx_common.c
+++ b/src/dtx/dtx_common.c
@@ -510,7 +510,9 @@ out:
 	if (abort_dtes != NULL)
 		D_FREE(abort_dtes);
 
-	return rc > 0 ? 0 : rc;
+	D_ASSERTF(rc <= 0, "unexpected return value %d\n", rc);
+
+	return rc;
 }
 
 /**
@@ -682,8 +684,11 @@ out_free:
 
 	if (dth->dth_dti_cos != NULL)
 		D_FREE(dth->dth_dti_cos);
+
+	D_ASSERTF(result <= 0, "unexpected return value %d\n", result);
+
 out:
-	return result > 0 ? 0 : result;
+	return result;
 }
 
 /**
@@ -763,8 +768,11 @@ dtx_end(struct dtx_handle *dth, struct ds_cont_hdl *cont_hdl,
 		(unsigned long long)dth->dth_dkey_hash,
 		dth->dth_intent == DAOS_INTENT_PUNCH ? "Punch" : "Update",
 		result);
+
+	D_ASSERTF(result <= 0, "unexpected return value %d\n", result);
+
 out:
-	return result > 0 ? 0 : result;
+	return result;
 }
 
 

--- a/src/object/cli_shard.c
+++ b/src/object/cli_shard.c
@@ -182,9 +182,11 @@ dc_rw_cb(tse_task_t *task, void *arg)
 		sizes = orwo->orw_sizes.ca_arrays;
 
 		if (orwo->orw_sizes.ca_count != orw->orw_nr) {
-			D_ERROR("out:%u != in:%u\n",
+			D_ERROR("out:%u != in:%u for "DF_UOID" with eph "
+				DF_U64".\n",
 				(unsigned)orwo->orw_sizes.ca_count,
-				orw->orw_nr);
+				orw->orw_nr, DP_UOID(orw->orw_oid),
+				orw->orw_epoch);
 			D_GOTO(out, rc = -DER_PROTO);
 		}
 


### PR DESCRIPTION
Check whether obj_rw_out::orw_sizes.ca_count is properly set or not.
Fix some potential improper error handling logic.

Signed-off-by: Fan Yong <fan.yong@intel.com>