### PR TITLE
DAOS-2540 container: GC wait cleanup

### DIFF
--- a/src/container/srv_target.c
+++ b/src/container/srv_target.c
@@ -591,8 +591,7 @@ cont_child_destroy_one(void *vin)
 	/* XXX there might be a race between GC and pool destroy, let's do
 	 * synchronous GC for now.
 	 */
-	dss_gc_run(-1);
-
+	dss_gc_run(pool->spc_hdl, -1);
 	/*
 	 * Force VEA to expire all the just freed extents and make them
 	 * available for allocation immediately.
@@ -603,7 +602,6 @@ cont_child_destroy_one(void *vin)
 			DP_CONT(pool->spc_uuid, in->tdi_uuid), rc);
 		goto out_pool;
 	}
-
 out_pool:
 	ds_pool_child_put(pool);
 out:

--- a/src/include/daos_srv/daos_server.h
+++ b/src/include/daos_srv/daos_server.h
@@ -607,7 +607,10 @@ bool dss_pmixless(void);
 /* default credits */
 #define	DSS_GC_CREDS	256
 
-void dss_gc_run(int credits);
+/**
+ * Run GC for an opened pool, it run GC for all pools if @poh is DAOS_HDL_INVAL
+ */
+void dss_gc_run(daos_handle_t poh, int credits);
 
 bool dss_aggregation_disabled(void);
 

--- a/src/include/daos_srv/vos.h
+++ b/src/include/daos_srv/vos.h
@@ -903,6 +903,8 @@ vos_pool_ctl(daos_handle_t poh, enum vos_pool_opc opc);
 
 int
 vos_gc_run(int *credits);
+int
+vos_gc_pool(daos_handle_t poh, int *credits);
 
 enum vos_cont_opc {
 	/** reset HAE (Highest Aggregated Epoch) **/

--- a/src/iosrv/srv.c
+++ b/src/iosrv/srv.c
@@ -1744,7 +1744,7 @@ dss_dump_ABT_state()
 }
 
 void
-dss_gc_run(int credits)
+dss_gc_run(daos_handle_t poh, int credits)
 {
 	struct dss_xstream *dxs	 = dss_get_xstream();
 	int		    total = 0;
@@ -1757,18 +1757,21 @@ dss_gc_run(int credits)
 			creds = credits - total;
 
 		total += creds;
-		rc = vos_gc_run(&creds);
+		if (daos_handle_is_inval(poh))
+			rc = vos_gc_run(&creds);
+		else
+			rc = vos_gc_pool(poh, &creds);
+
 		if (rc) {
 			D_ERROR("GC run failed: %s\n", d_errstr(rc));
 			break;
 		}
 		total -= creds; /* subtract the remainded credits */
-		if (creds != 0) {
-			break;
-		}
+		if (creds != 0)
+			break; /* reclaimed everything */
 
 		if (credits > 0 && total >= credits)
-			break;
+			break; /* consumed all credits */
 
 		if (dss_xstream_exiting(dxs))
 			break;
@@ -1776,9 +1779,8 @@ dss_gc_run(int credits)
 		ABT_thread_yield();
 	}
 
-	if (total != 0) {
+	if (total != 0) /* did something */
 		D_DEBUG(DB_TRACE, "GC consumed %d credits\n", total);
-	}
 }
 
 static void
@@ -1788,7 +1790,7 @@ dss_gc_ult(void *args)
 
 	 while (!dss_xstream_exiting(dxs)) {
 		/* -1 means GC will run until there is nothing to do */
-		dss_gc_run(-1);
+		dss_gc_run(DAOS_HDL_INVAL, -1);
 		ABT_thread_yield();
 	 }
 }

--- a/src/rdb/rdb_raft.c
+++ b/src/rdb/rdb_raft.c
@@ -1450,7 +1450,7 @@ rdb_compactd(void *arg)
 				": %d\n", DP_DB(db), base, rc);
 			break;
 		}
-		dss_gc_run(-1);
+		dss_gc_run(db->d_pool, -1);
 	}
 	D_DEBUG(DB_MD, DF_DB": compactd stopping\n", DP_DB(db));
 }

--- a/src/vos/tests/vos_tests.c
+++ b/src/vos/tests/vos_tests.c
@@ -197,6 +197,7 @@ main(int argc, char **argv)
 			break;
 		case 'g':
 			nr_failed += run_gc_tests();
+			test_run = true;
 			break;
 		case 'X':
 			nr_failed += run_dtx_tests();
@@ -236,13 +237,6 @@ main(int argc, char **argv)
 		print_message("\nSUCCESS! NO TEST FAILURES\n");
 
 exit_1:
-	/* There is no ULT/thread calls vos_gc_run() in this utility, it is
-	 * possible VOS GC might still take refcount on already closed pools.
-	 * These in-mem pools will be freed by calling gc_wait().
-	 *
-	 * NB: this function is only defined for standalone mode.
-	 */
-	gc_wait();
 	vos_fini();
 exit_0:
 	daos_debug_fini();

--- a/src/vos/tests/vts_gc.c
+++ b/src/vos/tests/vts_gc.c
@@ -205,7 +205,17 @@ gc_wait_check(struct gc_test_args *args, bool cont_delete)
 
 	print_message("wait for VOS GC\n");
 	stat = &pinfo.pif_gc_stat;
-	gc_wait();
+	while (1) {
+		int	creds = 64;
+
+		rc = vos_gc_pool(args->gc_ctx.tsc_poh, &creds);
+		if (rc) {
+			print_error("gc pool failed: %s\n", d_errstr(rc));
+			return rc;
+		}
+		if (creds != 0)
+			break;
+	}
 
 	print_message("query GC result\n");
 	rc = vos_pool_query(args->gc_ctx.tsc_poh, &pinfo);

--- a/src/vos/vos_common.c
+++ b/src/vos/vos_common.c
@@ -316,6 +316,11 @@ vos_fini_locked(void)
 void
 vos_fini(void)
 {
+	/* Clean up things left behind in standalone mode.
+	 * NB: this function is only defined for standalone mode.
+	 */
+	gc_wait();
+
 	D_MUTEX_LOCK(&mutex);
 
 	D_ASSERT(vos_inited > 0);

--- a/src/vos/vos_container.c
+++ b/src/vos/vos_container.c
@@ -580,7 +580,8 @@ vos_cont_destroy(daos_handle_t poh, uuid_t co_uuid)
 		D_ERROR("Failed to end pmdk transaction: "DF_RC"\n", DP_RC(rc));
 		D_GOTO(exit, rc);
 	}
-	gc_wait_pool(pool);
+	gc_wait();
+
 	return 0;
 exit:
 	return rc;

--- a/src/vos/vos_gc.c
+++ b/src/vos/vos_gc.c
@@ -816,38 +816,34 @@ gc_wait(void)
 #endif
 }
 
-/**
- * Function for VOS standalone mode, it reclaims all the delete items for @pool
- */
-void
-gc_wait_pool(struct vos_pool *pool)
+/** public API to reclaim space for a opened pool */
+int
+vos_gc_pool(daos_handle_t poh, int *credits)
 {
-#if VOS_STANDALONE
-	int total = 0;
+	struct vos_pool *pool = vos_hdl2pool(poh);
+	bool		 empty;
+	int		 total;
+	int		 rc;
 
-	while (1) {
-		int	creds = GC_CREDS_PRIV;
-		int	rc;
-		bool	empty;
+	if (!credits || *credits <= 0)
+		return -DER_INVAL;
 
-		if (d_list_empty(&pool->vp_gc_link)) {
-			D_DEBUG(DB_IO, "Nothing to reclaim for this pool\n");
-			return;
-		}
+	if (!pool)
+		return -DER_NO_HDL;
 
-		total += creds;
-		rc = gc_reclaim_pool(pool, &creds, &empty);
-		if (rc) {
-			D_CRIT("GC failed %s\n", d_errstr(rc));
-			return;
-		}
+	if (d_list_empty(&pool->vp_gc_link))
+		return 0; /* nothing to reclaim for this pool */
 
-		if (creds != 0) {
-			D_ASSERT(empty);
-			D_DEBUG(DB_IO, "Consumed %d credits\n", total - creds);
-			gc_log_pool(pool);
-			return;
-		}
+	total = *credits;
+	rc = gc_reclaim_pool(pool, credits, &empty);
+	if (rc) {
+		D_CRIT("GC failed %s\n", d_errstr(rc));
+		return 0; /* caller can't do anything for it */
 	}
-#endif
+	total -= *credits; /* substract the remained credits */
+
+	if (empty && total != 0) /* did something */
+		gc_log_pool(pool);
+
+	return 0;
 }

--- a/src/vos/vos_internal.h
+++ b/src/vos/vos_internal.h
@@ -1014,8 +1014,6 @@ vos_iter_intent(struct vos_iterator *iter)
 
 void
 gc_wait(void);
-void
-gc_wait_pool(struct vos_pool *pool);
 int
 gc_add_pool(struct vos_pool *pool);
 void

--- a/src/vos/vos_obj.c
+++ b/src/vos/vos_obj.c
@@ -239,7 +239,7 @@ vos_obj_delete(daos_handle_t coh, daos_unit_oid_t oid)
 		goto out;
 
 	/* NB: noop for full-stack mode */
-	gc_wait_pool(vos_obj2pool(obj));
+	gc_wait();
 out:
 	vos_obj_release(occ, obj);
 	return rc;


### PR DESCRIPTION
Container destroy should wait for GC of the current pool
instead of all pools

Signed-off-by: Liang Zhen <liang.zhen@intel.com>