### PR TITLE
DAOS-3247 control: fix storage cmds run without config

### DIFF
--- a/src/control/cmd/daos_server/storage.go
+++ b/src/control/cmd/daos_server/storage.go
@@ -40,12 +40,11 @@ type storageCmd struct {
 }
 
 type storageScanCmd struct {
-	cfgCmd
 	logCmd
 }
 
 func (cmd *storageScanCmd) Execute(args []string) error {
-	svc, err := server.NewStorageControlService(cmd.log, cmd.config)
+	svc, err := server.NewStorageControlService(cmd.log, server.NewConfiguration())
 	if err != nil {
 		return errors.WithMessage(err, "failed to init ControlService")
 	}
@@ -79,12 +78,11 @@ func (cmd *storageScanCmd) Execute(args []string) error {
 
 type storagePrepNvmeCmd struct {
 	logCmd
-	cfgCmd
 	types.StoragePrepareNvmeCmd
 }
 
 func (cmd *storagePrepNvmeCmd) Execute(args []string) error {
-	svc, err := server.NewStorageControlService(cmd.log, cmd.config)
+	svc, err := server.NewStorageControlService(cmd.log, server.NewConfiguration())
 	if err != nil {
 		return errors.WithMessage(err, "initialising ControlService")
 	}
@@ -98,7 +96,6 @@ func (cmd *storagePrepNvmeCmd) Execute(args []string) error {
 }
 
 type storagePrepScmCmd struct {
-	cfgCmd
 	logCmd
 	types.StoragePrepareScmCmd
 	Force bool `short:"f" long:"force" description:"Perform format without prompting for confirmation"`
@@ -118,7 +115,7 @@ func (cmd *storagePrepScmCmd) Execute(args []string) (err error) {
 		return errors.New("consent not given")
 	}
 
-	svc, err := server.NewStorageControlService(cmd.log, cmd.config)
+	svc, err := server.NewStorageControlService(cmd.log, server.NewConfiguration())
 	if err != nil {
 		return errors.WithMessage(err, "initialising ControlService")
 	}


### PR DESCRIPTION
Fix regression so that daos_server storage subcommands can be run
without config file. Remove cfgCmd embedded type from relevant
storage subcommand structs and initialise StorageControlService
with a new configuration.

Signed-off-by: Tom Nabarro <tom.nabarro@intel.com>