### PR TITLE
DAOS-2881 control: Move logging.LogBuffer into logger.go

### DIFF
--- a/src/control/logging/defaults.go
+++ b/src/control/logging/defaults.go
@@ -23,10 +23,8 @@
 package logging
 
 import (
-	"bytes"
 	"io"
 	"os"
-	"sync"
 )
 
 const (
@@ -77,36 +75,6 @@ func NewCombinedLogger(prefix string, output io.Writer) *LeveledLogger {
 			NewErrorLogger(prefix, output),
 		},
 	}
-}
-
-// LogBuffer provides a thread-safe wrapper for bytes.Buffer.
-type LogBuffer struct {
-	sync.Mutex
-	buf bytes.Buffer
-}
-
-func (lb *LogBuffer) Read(p []byte) (int, error) {
-	lb.Lock()
-	defer lb.Unlock()
-	return lb.buf.Read(p)
-}
-
-func (lb *LogBuffer) Write(p []byte) (int, error) {
-	lb.Lock()
-	defer lb.Unlock()
-	return lb.buf.Write(p)
-}
-
-func (lb *LogBuffer) String() string {
-	lb.Lock()
-	defer lb.Unlock()
-	return lb.buf.String()
-}
-
-func (lb *LogBuffer) Reset() {
-	lb.Lock()
-	defer lb.Unlock()
-	lb.buf.Reset()
 }
 
 // NewTestLogger returns a logger and a *LogBuffer,

--- a/src/control/logging/logger.go
+++ b/src/control/logging/logger.go
@@ -23,6 +23,7 @@
 package logging
 
 import (
+	"bytes"
 	"io"
 	"sync"
 )
@@ -205,4 +206,38 @@ func (ll *LeveledLogger) Errorf(format string, args ...interface{}) {
 	for _, l := range loggers {
 		l.Errorf(format, args...)
 	}
+}
+
+// LogBuffer provides a thread-safe wrapper for bytes.Buffer.
+// It only wraps a subset of bytes.Buffer's methods; just enough
+// to implement io.Reader, io.Writer, and fmt.Stringer. The
+// Reset() method is also wrapped in order to make it useful
+// for testing.
+type LogBuffer struct {
+	sync.Mutex
+	buf bytes.Buffer
+}
+
+func (lb *LogBuffer) Read(p []byte) (int, error) {
+	lb.Lock()
+	defer lb.Unlock()
+	return lb.buf.Read(p)
+}
+
+func (lb *LogBuffer) Write(p []byte) (int, error) {
+	lb.Lock()
+	defer lb.Unlock()
+	return lb.buf.Write(p)
+}
+
+func (lb *LogBuffer) String() string {
+	lb.Lock()
+	defer lb.Unlock()
+	return lb.buf.String()
+}
+
+func (lb *LogBuffer) Reset() {
+	lb.Lock()
+	defer lb.Unlock()
+	lb.buf.Reset()
 }

--- a/src/control/server/ioserver/rank.go
+++ b/src/control/server/ioserver/rank.go
@@ -36,7 +36,7 @@ type Rank uint32
 const (
 	// MaxRank is the largest valid Rank value
 	MaxRank Rank = math.MaxUint32 - 1
-	// NilRank is a an unset Rank (0 is a valid Rank)
+	// NilRank is an unset Rank (0 is a valid Rank)
 	NilRank Rank = math.MaxUint32
 )
 

--- a/src/control/server/storage/bdev_test.go
+++ b/src/control/server/storage/bdev_test.go
@@ -82,10 +82,10 @@ func TestParseBdev(t *testing.T) {
 			bdevList:  []string{"myfile", "myotherfile"},
 			bdevSize:  5, // GB/file
 			wantBuf: []string{
-				"[AIO]",
-				"    AIO myfile AIO__0 4096",
-				"    AIO myotherfile AIO__1 4096",
-				"",
+				`[AIO]`,
+				`    AIO myfile AIO__0 4096`,
+				`    AIO myotherfile AIO__1 4096`,
+				``,
 			},
 			vosEnv: "AIO",
 		},
@@ -93,10 +93,10 @@ func TestParseBdev(t *testing.T) {
 			bdevClass: BdevClassKdev,
 			bdevList:  []string{"sdb", "sdc"},
 			wantBuf: []string{
-				"[AIO]",
+				`[AIO]`,
 				`    AIO sdb AIO__0`,
 				`    AIO sdc AIO__1`,
-				"",
+				``,
 			},
 			vosEnv: "AIO",
 		},
@@ -105,10 +105,10 @@ func TestParseBdev(t *testing.T) {
 			bdevSize:   5, // GB/file
 			bdevNumber: 2, // number of LUNs
 			wantBuf: []string{
-				"[Malloc]",
-				"    NumberOfLuns 2",
-				"    LunSizeInMB 5000",
-				"",
+				`[Malloc]`,
+				`    NumberOfLuns 2`,
+				`    LunSizeInMB 5000`,
+				``,
 			},
 			vosEnv: "MALLOC",
 		},


### PR DESCRIPTION
Didn't make sense to have it in defaults.go. Also addresses a bit
more review feedback that didn't make it into the original PR landing.