### PR TITLE
DAOS-2262 mgmt: Pass in ACL to create pool

### DIFF
--- a/src/control/cmd/dmg/acl.go
+++ b/src/control/cmd/dmg/acl.go
@@ -31,34 +31,10 @@ import (
 	"github.com/pkg/errors"
 )
 
-// readableFile is an interface for a file that can be read from the filesystem
-type readableFile interface {
-	Close() error
-	Read(p []byte) (n int, err error)
-}
-
-// fileOpener is an interface for opening a file.
-type fileOpener interface {
-	OpenFile(filename string) (readableFile, error)
-}
-
-// fileOpenerImpl is a concrete implementation of the fileOpener interface
-type fileOpenerImpl struct{}
-
-// OpenFile calls into the OS to open a file
-func (e *fileOpenerImpl) OpenFile(filename string) (readableFile, error) {
-	return os.Open(filename)
-}
-
-// newFileOpener creates a new instance of a fileOpener
-func newFileOpener() fileOpener {
-	return &fileOpenerImpl{}
-}
-
 // readACLFile opens and reads in the ACL file line by line, assuming ACEs are
 // provided line by line.
-func readACLFile(opener fileOpener, aclFile string) ([]string, error) {
-	file, err := opener.OpenFile(aclFile)
+func readACLFile(aclFile string) ([]string, error) {
+	file, err := os.Open(aclFile)
 	if err != nil {
 		return nil, errors.WithMessage(err, "opening ACL file")
 	}

--- a/src/control/cmd/dmg/pool.go
+++ b/src/control/cmd/dmg/pool.go
@@ -183,7 +183,7 @@ func createPool(conns client.Connect, scmSize string, nvmeSize string,
 
 	var acl []string
 	if aclFile != "" {
-		acl, err = readACLFile(newFileOpener(), aclFile)
+		acl, err = readACLFile(aclFile)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
(demo alt testing approach)

- Add support for ACL file parameter in daos_shell pool
  create command. The ACL file should have a single ACE
  on each line, in the short ACL string format.