### PR TITLE
DAOS-3245 control: align daos_server storage prepare syntax with daos…

### DIFF
--- a/src/control/cmd/daos_server/storage.go
+++ b/src/control/cmd/daos_server/storage.go
@@ -71,16 +71,18 @@ func (cmd *storageScanCmd) Execute(args []string) error {
 		e <- err
 	}()
 
-	select {
-	case err := <-e:
-		scanErrors = append(scanErrors, err)
-		if len(scanErrors) == 2 {
-			break
+	for {
+		select {
+		case err := <-e:
+			scanErrors = append(scanErrors, err)
+			if len(scanErrors) == 2 {
+				break
+			}
+		case modules := <-m:
+			cmd.log.Infof("SCM modules:\n%s", modules)
+		case controllers := <-c:
+			cmd.log.Infof("NVMe SSD controller and constituent namespaces:\n%s", controllers)
 		}
-	case modules := <-m:
-		cmd.log.Infof("SCM modules:\n%s", modules)
-	case controllers := <-c:
-		cmd.log.Infof("NVMe SSD controller and constituent namespaces:\n%s", controllers)
 	}
 
 	if len(scanErrors) > 0 {
@@ -153,11 +155,13 @@ func (cmd *storagePrepareCmd) Execute(args []string) error {
 		e <- nil
 	}()
 
-	select {
-	case err := <-e:
-		scanErrors = append(scanErrors, err)
-		if len(scanErrors) == 2 {
-			break
+	for {
+		select {
+		case err := <-e:
+			scanErrors = append(scanErrors, err)
+			if len(scanErrors) == 2 {
+				break
+			}
 		}
 	}
 

--- a/src/control/cmd/daos_server/storage.go
+++ b/src/control/cmd/daos_server/storage.go
@@ -28,7 +28,6 @@ import (
 
 	"github.com/pkg/errors"
 
-	"github.com/daos-stack/daos/src/control/common"
 	commands "github.com/daos-stack/daos/src/control/common/storage"
 	"github.com/daos-stack/daos/src/control/server"
 )
@@ -83,15 +82,8 @@ type storagePrepareCmd struct {
 }
 
 func (cmd *storagePrepareCmd) Execute(args []string) error {
-	ok, _ := common.CheckSudo()
-	if !ok {
-		return errors.New("subcommand must be run as root or sudo")
-	}
-
-	cmd.log.Info(commands.MsgStoragePrepareWarn)
-
-	if !cmd.Force && !common.GetConsent() {
-		return errors.New("consent not given")
+	if err := cmd.Init(); err != nil {
+		return err
 	}
 
 	svc, err := server.NewStorageControlService(cmd.log, server.NewConfiguration())

--- a/src/control/cmd/dmg/main.go
+++ b/src/control/cmd/dmg/main.go
@@ -85,12 +85,12 @@ type cliOptions struct {
 	Debug    bool   `short:"d" long:"debug" description:"enable debug output"`
 	JSON     bool   `short:"j" long:"json" description:"Enable JSON output"`
 	// TODO: implement host file parsing
-	HostFile   string  `short:"f" long:"host-file" description:"path of hostfile specifying list of addresses <ipv4addr/hostname:port>, if specified takes preference over HostList"`
-	ConfigPath string  `short:"o" long:"config-path" description:"Client config file path"`
-	Storage    StorCmd `command:"storage" alias:"st" description:"Perform tasks related to storage attached to remote servers"`
-	Service    SvcCmd  `command:"service" alias:"sv" description:"Perform distributed tasks related to DAOS system"`
-	Network    NetCmd  `command:"network" alias:"n" description:"Perform tasks related to network devices attached to remote servers"`
-	Pool       PoolCmd `command:"pool" alias:"p" description:"Perform tasks related to DAOS pools"`
+	HostFile   string     `short:"f" long:"host-file" description:"path of hostfile specifying list of addresses <ipv4addr/hostname:port>, if specified takes preference over HostList"`
+	ConfigPath string     `short:"o" long:"config-path" description:"Client config file path"`
+	Storage    storageCmd `command:"storage" alias:"st" description:"Perform tasks related to storage attached to remote servers"`
+	Service    SvcCmd     `command:"service" alias:"sv" description:"Perform distributed tasks related to DAOS system"`
+	Network    NetCmd     `command:"network" alias:"n" description:"Perform tasks related to network devices attached to remote servers"`
+	Pool       PoolCmd    `command:"pool" alias:"p" description:"Perform tasks related to DAOS pools"`
 }
 
 // appSetup loads config file, processes cli overrides and connects clients.

--- a/src/control/cmd/dmg/storage.go
+++ b/src/control/cmd/dmg/storage.go
@@ -31,8 +31,8 @@ import (
 	log "github.com/daos-stack/daos/src/control/logging"
 )
 
-// StorCmd is the struct representing the top-level storage subcommand.
-type StorCmd struct {
+// storageCmd is the struct representing the top-level storage subcommand.
+type storageCmd struct {
 	Prepare storagePrepareCmd `command:"prepare" alias:"p" description:"Prepare SCM and NVMe storage attached to remote servers."`
 	Scan    storageScanCmd    `command:"scan" alias:"s" description:"Scan SCM and NVMe storage attached to remote servers."`
 	Format  storageFormatCmd  `command:"format" alias:"f" description:"Format SCM and NVMe storage attached to remote servers."`
@@ -48,17 +48,15 @@ func storagePrepare(conns client.Connect, req *pb.StoragePrepareReq, force bool)
 	}
 }
 
-// StoragePrepareCmd is the struct representing the prep storage subcommand.
-type StoragePrepareCmd struct {
+// storagePrepareCmd is the struct representing the prep storage subcommand.
+type storagePrepareCmd struct {
 	broadcastCmd
 	connectedCmd
-	types.StoragePrepareNvmeCmd
-	types.StoragePrepareScmCmd
-	Force bool `short:"f" long:"force" description:"Perform format without prompting for confirmation"`
+	types.StoragePrepareCmd
 }
 
-// Execute is run when StoragePrepareCmd activates
-func (cmd *StoragePrepareCmd) Execute(args []string) error {
+// Execute is run when storagePrepareCmd activates
+func (cmd *storagePrepareCmd) Execute(args []string) error {
 	storagePrepare(
 		cmd.conns,
 		&pb.StoragePrepareReq{
@@ -66,18 +64,18 @@ func (cmd *StoragePrepareCmd) Execute(args []string) error {
 				Pciwhitelist: cmd.PCIWhiteList,
 				Nrhugepages:  int32(cmd.NrHugepages),
 				Targetuser:   cmd.TargetUser,
-				Reset_:       cmd.ResetNvme,
+				Reset_:       cmd.Reset,
 			},
 			Scm: &pb.PrepareScmReq{
-				Reset_: cmd.ResetScm,
+				Reset_: cmd.Reset,
 			},
 		}, cmd.Force)
 
 	return nil
 }
 
-// StorageScanCmd is the struct representing the scan storage subcommand.
-type StorageScanCmd struct {
+// storageScanCmd is the struct representing the scan storage subcommand.
+type storageScanCmd struct {
 	broadcastCmd
 	connectedCmd
 }
@@ -89,14 +87,14 @@ func storageScan(conns client.Connect) {
 	log.Infof("SCM modules:\n%s", cModules)
 }
 
-// Execute is run when StorageScanCmd activates
-func (s *StorageScanCmd) Execute(args []string) error {
+// Execute is run when storageScanCmd activates
+func (s *storageScanCmd) Execute(args []string) error {
 	storageScan(s.conns)
 	return nil
 }
 
-// StorageFormatCmd is the struct representing the format storage subcommand.
-type StorageFormatCmd struct {
+// storageFormatCmd is the struct representing the format storage subcommand.
+type storageFormatCmd struct {
 	broadcastCmd
 	connectedCmd
 	Force bool `short:"f" long:"force" description:"Perform format without prompting for confirmation"`
@@ -117,14 +115,14 @@ func storageFormat(conns client.Connect, force bool) {
 	}
 }
 
-// Execute is run when StorageFormatCmd activates
-func (s *StorageFormatCmd) Execute(args []string) error {
+// Execute is run when storageFormatCmd activates
+func (s *storageFormatCmd) Execute(args []string) error {
 	storageFormat(s.conns, s.Force)
 	return nil
 }
 
-// StorageUpdateCmd is the struct representing the update storage subcommand.
-type StorageUpdateCmd struct {
+// storageUpdateCmd is the struct representing the update storage subcommand.
+type storageUpdateCmd struct {
 	broadcastCmd
 	connectedCmd
 	Force        bool   `short:"f" long:"force" description:"Perform update without prompting for confirmation"`
@@ -150,8 +148,8 @@ func storageUpdate(conns client.Connect, req *pb.StorageUpdateReq, force bool) {
 	}
 }
 
-// Execute is run when StorageUpdateCmd activates
-func (u *StorageUpdateCmd) Execute(args []string) error {
+// Execute is run when storageUpdateCmd activates
+func (u *storageUpdateCmd) Execute(args []string) error {
 	// only populate nvme fwupdate params for the moment
 	storageUpdate(
 		u.conns,

--- a/src/control/cmd/dmg/storage.go
+++ b/src/control/cmd/dmg/storage.go
@@ -60,12 +60,7 @@ func (cmd *storagePrepareCmd) Execute(args []string) error {
 	var nReq *pb.PrepareNvmeReq
 	var sReq *pb.PrepareScmReq
 
-	if !cmd.Nvme && !cmd.Scm {
-		cmd.Nvme = true
-		cmd.Scm = true
-	}
-
-	if cmd.Nvme {
+	if cmd.NvmeOnly || !cmd.ScmOnly {
 		nReq = &pb.PrepareNvmeReq{
 			Pciwhitelist: cmd.PCIWhiteList,
 			Nrhugepages:  int32(cmd.NrHugepages),
@@ -73,7 +68,7 @@ func (cmd *storagePrepareCmd) Execute(args []string) error {
 			Reset_:       cmd.Reset,
 		}
 	}
-	if cmd.Scm {
+	if cmd.ScmOnly || !cmd.NvmeOnly {
 		sReq = &pb.PrepareScmReq{
 			Reset_: cmd.Reset,
 		}

--- a/src/control/cmd/dmg/storage.go
+++ b/src/control/cmd/dmg/storage.go
@@ -57,19 +57,30 @@ type storagePrepareCmd struct {
 
 // Execute is run when storagePrepareCmd activates
 func (cmd *storagePrepareCmd) Execute(args []string) error {
-	storagePrepare(
-		cmd.conns,
-		&pb.StoragePrepareReq{
-			Nvme: &pb.PrepareNvmeReq{
-				Pciwhitelist: cmd.PCIWhiteList,
-				Nrhugepages:  int32(cmd.NrHugepages),
-				Targetuser:   cmd.TargetUser,
-				Reset_:       cmd.Reset,
-			},
-			Scm: &pb.PrepareScmReq{
-				Reset_: cmd.Reset,
-			},
-		}, cmd.Force)
+	var nReq *pb.PrepareNvmeReq
+	var sReq *pb.PrepareScmReq
+
+	if !cmd.Nvme && !cmd.Scm {
+		cmd.Nvme = true
+		cmd.Scm = true
+	}
+
+	if cmd.Nvme {
+		nReq = &pb.PrepareNvmeReq{
+			Pciwhitelist: cmd.PCIWhiteList,
+			Nrhugepages:  int32(cmd.NrHugepages),
+			Targetuser:   cmd.TargetUser,
+			Reset_:       cmd.Reset,
+		}
+	}
+	if cmd.Scm {
+		sReq = &pb.PrepareScmReq{
+			Reset_: cmd.Reset,
+		}
+	}
+
+	storagePrepare(cmd.conns, &pb.StoragePrepareReq{Nvme: nReq, Scm: sReq},
+		cmd.Force)
 
 	return nil
 }

--- a/src/control/cmd/dmg/storage.go
+++ b/src/control/cmd/dmg/storage.go
@@ -33,17 +33,14 @@ import (
 
 // StorCmd is the struct representing the top-level storage subcommand.
 type StorCmd struct {
-	Prepare StoragePrepareCmd `command:"prepare" alias:"p" description:"Prepare SCM and NVMe storage attached to remote servers."`
-	Scan    StorageScanCmd    `command:"scan" alias:"s" description:"Scan SCM and NVMe storage attached to remote servers."`
-	Format  StorageFormatCmd  `command:"format" alias:"f" description:"Format SCM and NVMe storage attached to remote servers."`
-	Update  StorageUpdateCmd  `command:"fwupdate" alias:"u" description:"Update firmware on NVMe storage attached to remote servers."`
+	Prepare storagePrepareCmd `command:"prepare" alias:"p" description:"Prepare SCM and NVMe storage attached to remote servers."`
+	Scan    storageScanCmd    `command:"scan" alias:"s" description:"Scan SCM and NVMe storage attached to remote servers."`
+	Format  storageFormatCmd  `command:"format" alias:"f" description:"Format SCM and NVMe storage attached to remote servers."`
+	Update  storageUpdateCmd  `command:"fwupdate" alias:"u" description:"Update firmware on NVMe storage attached to remote servers."`
 }
 
 func storagePrepare(conns client.Connect, req *pb.StoragePrepareReq, force bool) {
-	log.Info(
-		"This could be a destructive operation and storage devices " +
-			"may have data erased. Please be patient as it may take several minutes " +
-			"and a subsequent reboot maybe required.\n")
+	log.Info(types.MsgStoragePrepareWarn)
 
 	if force || common.GetConsent() {
 		log.Info("")

--- a/src/control/common/storage/commands.go
+++ b/src/control/common/storage/commands.go
@@ -23,6 +23,13 @@
 
 package common_storage
 
+import (
+	"github.com/pkg/errors"
+
+	"github.com/daos-stack/daos/src/control/common"
+	log "github.com/daos-stack/daos/src/control/logging"
+)
+
 const MsgStoragePrepareWarn = "Memory allocation goals for SCM will be changed and " +
 	"namespaces modified, this will be a destructive operation. Please ensure " +
 	"namespaces are unmounted and locally attached SCM & NVMe devices " +
@@ -44,4 +51,18 @@ type StoragePrepareCmd struct {
 	ScmOnly  bool `short:"s" long:"scm-only" description:"Only prepare SCM."`
 	Reset    bool `long:"reset" description:"Reset SCM modules to memory mode after removing namespaces. Reset SPDK returning NVMe device bindings back to kernel modules."`
 	Force    bool `short:"f" long:"force" description:"Perform format without prompting for confirmation"`
+}
+
+func (cmd *StoragePrepareCmd) Init() error {
+	if cmd.NvmeOnly && cmd.ScmOnly {
+		return errors.New("nvme-only and scm-only options should not be set together")
+	}
+
+	log.Info(MsgStoragePrepareWarn)
+
+	if !cmd.Force && !common.GetConsent() {
+		return errors.New("consent not given")
+	}
+
+	return nil
 }

--- a/src/control/common/storage/commands.go
+++ b/src/control/common/storage/commands.go
@@ -40,8 +40,8 @@ type StoragePrepareScmCmd struct{}
 type StoragePrepareCmd struct {
 	StoragePrepareNvmeCmd
 	StoragePrepareScmCmd
-	Nvme  bool `long:"nvme" description:"Only prepare NVMe storage."`
-	Scm   bool `long:"scm" description:"Only prepare SCM."`
-	Reset bool `long:"reset" description:"Reset SCM modules to memory mode after removing namespaces. Reset SPDK returning NVMe device bindings back to kernel modules."`
-	Force bool `short:"f" long:"force" description:"Perform format without prompting for confirmation"`
+	NvmeOnly bool `short:"n" long:"nvme-only" description:"Only prepare NVMe storage."`
+	ScmOnly  bool `short:"s" long:"scm-only" description:"Only prepare SCM."`
+	Reset    bool `long:"reset" description:"Reset SCM modules to memory mode after removing namespaces. Reset SPDK returning NVMe device bindings back to kernel modules."`
+	Force    bool `short:"f" long:"force" description:"Perform format without prompting for confirmation"`
 }

--- a/src/control/common/storage/commands.go
+++ b/src/control/common/storage/commands.go
@@ -40,6 +40,8 @@ type StoragePrepareScmCmd struct{}
 type StoragePrepareCmd struct {
 	StoragePrepareNvmeCmd
 	StoragePrepareScmCmd
+	Nvme  bool `long:"nvme" description:"Only prepare NVMe storage."`
+	Scm   bool `long:"scm" description:"Only prepare SCM."`
 	Reset bool `long:"reset" description:"Reset SCM modules to memory mode after removing namespaces. Reset SPDK returning NVMe device bindings back to kernel modules."`
 	Force bool `short:"f" long:"force" description:"Perform format without prompting for confirmation"`
 }

--- a/src/control/common/storage/commands.go
+++ b/src/control/common/storage/commands.go
@@ -23,8 +23,10 @@
 
 package common_storage
 
-const MsgStoragePrepareWarn = "This could be a destructive operation and storage devices " +
-	"may have data erased. Please be patient as it may take several minutes " +
+const MsgStoragePrepareWarn = "Memory allocation goals for SCM will be changed and " +
+	"namespaces modified, this will be a destructive operation. Please ensure " +
+	"namespaces are unmounted and locally attached SCM & NVMe devices " +
+	"are not in use. Please be patient as it may take several minutes " +
 	"and subsequent reboot maybe required.\n"
 
 type StoragePrepareNvmeCmd struct {

--- a/src/control/common/storage/commands.go
+++ b/src/control/common/storage/commands.go
@@ -23,13 +23,21 @@
 
 package common_storage
 
+const MsgStoragePrepareWarn = "This could be a destructive operation and storage devices " +
+	"may have data erased. Please be patient as it may take several minutes " +
+	"and subsequent reboot maybe required.\n"
+
 type StoragePrepareNvmeCmd struct {
 	PCIWhiteList string `short:"w" long:"pci-whitelist" description:"Whitespace separated list of PCI devices (by address) to be unbound from Kernel driver and used with SPDK (default is all PCI devices)."`
 	NrHugepages  int    `short:"p" long:"hugepages" description:"Number of hugepages to allocate (in MB) for use by SPDK (default 1024)"`
 	TargetUser   string `short:"u" long:"target-user" description:"User that will own hugepage mountpoint directory and vfio groups."`
-	ResetNvme    bool   `long:"reset-nvme" description:"Reset SPDK returning devices to kernel modules"`
 }
 
-type StoragePrepareScmCmd struct {
-	ResetScm bool `long:"reset-scm" description:"Reset modules to memory mode after removing namespaces"`
+type StoragePrepareScmCmd struct{}
+
+type StoragePrepareCmd struct {
+	StoragePrepareNvmeCmd
+	StoragePrepareScmCmd
+	Reset bool `long:"reset" description:"Reset SCM modules to memory mode after removing namespaces. Reset SPDK returning NVMe device bindings back to kernel modules."`
+	Force bool `short:"f" long:"force" description:"Perform format without prompting for confirmation"`
 }

--- a/src/control/server/ctl_storage.go
+++ b/src/control/server/ctl_storage.go
@@ -79,6 +79,12 @@ type PrepareScmRequest struct {
 //
 // Suitable for commands invoked directly on server, not over gRPC.
 func (c *StorageControlService) PrepareScm(req PrepareScmRequest) (needsReboot bool, pmemDevs []pmemDev, err error) {
+	ok, _ := common.CheckSudo()
+	if !ok {
+		err = errors.Errorf("%s must be run as root or sudo", os.Args[0])
+		return
+	}
+
 	if err = c.scm.Setup(); err != nil {
 		err = errors.WithMessage(err, "SCM setup")
 		return

--- a/src/control/server/ctl_storage_rpc.go
+++ b/src/control/server/ctl_storage_rpc.go
@@ -111,8 +111,12 @@ func (c *StorageControlService) StoragePrepare(ctx context.Context, req *pb.Stor
 
 	resp := &pb.StoragePrepareResp{}
 
-	resp.Nvme = c.doNvmePrepare(req.Nvme)
-	resp.Scm = c.doScmPrepare(req.Scm)
+	if req.Nvme != nil {
+		resp.Nvme = c.doNvmePrepare(req.Nvme)
+	}
+	if req.Scm != nil {
+		resp.Scm = c.doScmPrepare(req.Scm)
+	}
 
 	return resp, nil
 }


### PR DESCRIPTION
…_shell

DAOS-3245 bug exists because cli flags to prep-nvme changed.

Align syntax with daos_shell for storage prepare (single top-level
subcommand) and make storage subsystem type specific operations
concurrent.

Signed-off-by: Tom Nabarro <tom.nabarro@intel.com>