### PR TITLE
DAOS-2733 container: oid allocation should check for more crt errors …

### DIFF
--- a/src/container/cli.c
+++ b/src/container/cli.c
@@ -953,7 +953,8 @@ cont_oid_alloc_complete(tse_task_t *task, void *data)
 	struct dc_cont *cont = arg->coaa_cont;
 	int rc = task->dt_result;
 
-	if (daos_rpc_retryable_rc(rc)) {
+	if (daos_rpc_retryable_rc(rc) || daos_crt_network_error(rc) ||
+	    rc == -DER_STALE) {
 		tse_sched_t *sched = tse_task2sched(task);
 		daos_pool_query_t *pargs;
 		tse_task_t *ptask;

--- a/src/tests/suite/daos_oid_alloc.c
+++ b/src/tests/suite/daos_oid_alloc.c
@@ -267,7 +267,6 @@ check:
 			      MPI_COMM_WORLD);
 		rc = rc_reduce;
 	}
-	assert(rc == 0);
 	assert_int_equal(rc, 0);
 	if (arg->myrank == 0)
 		print_message("Allocation done. Verifying no overlaps...\n");


### PR DESCRIPTION
…to issue retry

- also update test to fail if any oid allocation returns non 0.

Signed-off-by: Mohamad Chaarawi <mohamad.chaarawi@intel.com>