### PR TITLE
DAOS-3248 control: Start up properly with unformatted DCPM

### DIFF
--- a/src/control/server/ctl_storage_rpc.go
+++ b/src/control/server/ctl_storage_rpc.go
@@ -185,16 +185,23 @@ func NewStorageControlService(log logging.Logger, cfg *Configuration) (*StorageC
 func (c *ControlService) doFormat(i *IOServerInstance, resp *pb.StorageFormatResp) error {
 	hasSuperblock := false
 
-	needsSuperblock, err := i.NeedsSuperblock()
+	needsScmFormat, err := i.NeedsScmFormat()
 	if err != nil {
-		return err
+		return errors.Wrap(err, "unable to check storage formatting")
 	}
 
-	if !needsSuperblock {
+	if !needsScmFormat {
+		needsSuperblock, err := i.NeedsSuperblock()
+		if err != nil {
+			return errors.Wrap(err, "unable to check instance superblock")
+		}
+		hasSuperblock = !needsSuperblock
+	}
+
+	if hasSuperblock {
 		// server already formatted, populate response appropriately
 		c.nvme.formatted = true
 		c.scm.formatted = true
-		hasSuperblock = true
 	}
 
 	// scaffolding

--- a/src/control/server/harness_test.go
+++ b/src/control/server/harness_test.go
@@ -47,7 +47,9 @@ func TestHarnessCreateSuperblocks(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	ext := &mockExt{}
+	ext := &mockExt{
+		isMountPointRet: true,
+	}
 	h := NewIOServerHarness(ext, log)
 	for idx, mnt := range []string{"one", "two"} {
 		if err := os.MkdirAll(filepath.Join(testDir, mnt), 0777); err != nil {

--- a/src/control/server/harness_test.go
+++ b/src/control/server/harness_test.go
@@ -81,21 +81,21 @@ func TestHarnessCreateSuperblocks(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if mi.superblock == nil {
+	if mi._superblock == nil {
 		t.Fatal("instance superblock is nil after CreateSuperblocks()")
 	}
-	if mi.superblock.System != t.Name() {
-		t.Fatalf("expected superblock system name to be %q, got %q", t.Name(), mi.superblock.System)
+	if mi._superblock.System != t.Name() {
+		t.Fatalf("expected superblock system name to be %q, got %q", t.Name(), mi._superblock.System)
 	}
 
 	for idx, i := range h.Instances() {
-		if uint32(*i.superblock.Rank) != uint32(idx) {
-			t.Fatalf("instance %d has rank %s (not %d)", idx, i.superblock.Rank, idx)
+		if uint32(*i._superblock.Rank) != uint32(idx) {
+			t.Fatalf("instance %d has rank %s (not %d)", idx, i._superblock.Rank, idx)
 		}
 		if i == mi {
 			continue
 		}
-		if i.superblock.UUID == mi.superblock.UUID {
+		if i._superblock.UUID == mi._superblock.UUID {
 			t.Fatal("second instance has same superblock as first")
 		}
 	}

--- a/src/control/server/ioserver/exec_test.go
+++ b/src/control/server/ioserver/exec_test.go
@@ -114,8 +114,8 @@ func TestRunnerContextExit(t *testing.T) {
 	cancel()
 
 	exitErr := <-errOut
-	if errors.Cause(exitErr).Error() != "context canceled" {
-		t.Fatalf("expected context cancel; got %s", exitErr)
+	if errors.Cause(exitErr) == NormalExit {
+		t.Fatal("expected process to not exit normally")
 	}
 }
 


### PR DESCRIPTION
The storage ready checks shouldn't conflate storage format
with superblock creation. Separates storage formatted check
from superblock exists check.
