### PR TITLE
DAOS-623 vos: Fix unitialized memory in single value iteration

### DIFF
--- a/src/vos/vos_obj.c
+++ b/src/vos/vos_obj.c
@@ -704,7 +704,7 @@ static int
 singv_iter_probe(struct vos_obj_iter *oiter, daos_anchor_t *anchor)
 {
 	vos_iter_entry_t	entry;
-	daos_anchor_t		tmp;
+	daos_anchor_t		tmp = {0};
 	int			opc;
 	int			rc;
 


### PR DESCRIPTION
The tempory buffer used to store the anchor is not initialized entirely
by dbtree_iter_fetch so needs to be zero initialized.

Signed-off-by: Jeff Olivier <jeffrey.v.olivier@intel.com>