### PR TITLE
DAOS-3255 control: Provide log as a dep for dmg/agent

### DIFF
--- a/src/control/client/config.go
+++ b/src/control/client/config.go
@@ -33,7 +33,7 @@ import (
 	yaml "gopkg.in/yaml.v2"
 
 	"github.com/daos-stack/daos/src/control/common"
-	log "github.com/daos-stack/daos/src/control/logging"
+	"github.com/daos-stack/daos/src/control/logging"
 	"github.com/daos-stack/daos/src/control/security"
 )
 
@@ -98,7 +98,7 @@ func newDefaultConfiguration(ext External) *Configuration {
 // GetConfig loads a configuration file from the path given,
 // or from the default location if none is provided.  It returns a populated
 // Configuration struct based upon the default values and any config file overrides.
-func GetConfig(ConfigPath string) (*Configuration, error) {
+func GetConfig(log logging.Logger, ConfigPath string) (*Configuration, error) {
 	config := NewConfiguration()
 	if ConfigPath != "" {
 		log.Debugf("Overriding default config path with: %s", ConfigPath)

--- a/src/control/client/config_test.go
+++ b/src/control/client/config_test.go
@@ -1,3 +1,26 @@
+//
+// (C) Copyright 2018-2019 Intel Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// GOVERNMENT LICENSE RIGHTS-OPEN SOURCE SOFTWARE
+// The Government's rights to use, modify, reproduce, release, perform, display,
+// or disclose this software are subject to the terms of the Apache License as
+// provided in Contract No. 8F-30005.
+// Any reproduction of computer software, computer software documentation, or
+// portions thereof marked with this legend must also reproduce the markings.
+//
+
 package client_test
 
 import (
@@ -9,6 +32,7 @@ import (
 
 	"github.com/daos-stack/daos/src/control/client"
 	"github.com/daos-stack/daos/src/control/common"
+	"github.com/daos-stack/daos/src/control/logging"
 )
 
 func getDefaultConfig(t *testing.T) *client.Configuration {
@@ -36,9 +60,12 @@ func getTestFile(t *testing.T) *os.File {
 }
 
 func TestLoadConfigDefaultsNoFile(t *testing.T) {
+	log, buf := logging.NewTestLogger(t.Name())
+	defer common.ShowBufferOnFailure(t, buf)()
+
 	defaultConfig := getDefaultConfig(t)
 
-	cfg, err := client.GetConfig("")
+	cfg, err := client.GetConfig(log, "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -48,6 +75,9 @@ func TestLoadConfigDefaultsNoFile(t *testing.T) {
 }
 
 func TestLoadConfigFromDefaultFile(t *testing.T) {
+	log, buf := logging.NewTestLogger(t.Name())
+	defer common.ShowBufferOnFailure(t, buf)()
+
 	defaultConfig := getDefaultConfig(t)
 	if err := os.MkdirAll(path.Dir(defaultConfig.Path), 0755); err != nil {
 		t.Fatal(err)
@@ -65,7 +95,7 @@ func TestLoadConfigFromDefaultFile(t *testing.T) {
 	}
 	f.Close()
 
-	cfg, err := client.GetConfig("")
+	cfg, err := client.GetConfig(log, "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -75,6 +105,9 @@ func TestLoadConfigFromDefaultFile(t *testing.T) {
 }
 
 func TestLoadConfigFromFile(t *testing.T) {
+	log, buf := logging.NewTestLogger(t.Name())
+	defer common.ShowBufferOnFailure(t, buf)()
+
 	testFile := getTestFile(t)
 	defer os.Remove(testFile.Name())
 
@@ -84,7 +117,7 @@ func TestLoadConfigFromFile(t *testing.T) {
 	}
 	testFile.Close()
 
-	cfg, err := client.GetConfig(testFile.Name())
+	cfg, err := client.GetConfig(log, testFile.Name())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -94,6 +127,9 @@ func TestLoadConfigFromFile(t *testing.T) {
 }
 
 func TestLoadConfigFailures(t *testing.T) {
+	log, buf := logging.NewTestLogger(t.Name())
+	defer common.ShowBufferOnFailure(t, buf)()
+
 	testFile := getTestFile(t)
 	defer os.Remove(testFile.Name())
 
@@ -104,7 +140,7 @@ func TestLoadConfigFailures(t *testing.T) {
 	testFile.Close()
 
 	t.Run("unparseable file", func(t *testing.T) {
-		_, err := client.GetConfig(testFile.Name())
+		_, err := client.GetConfig(log, testFile.Name())
 		if err == nil {
 			t.Fatal("Expected GetConfig() to fail on unparseable file")
 		}
@@ -115,14 +151,14 @@ func TestLoadConfigFailures(t *testing.T) {
 	}
 
 	t.Run("unreadable file", func(t *testing.T) {
-		_, err := client.GetConfig(testFile.Name())
+		_, err := client.GetConfig(log, testFile.Name())
 		if err == nil {
 			t.Fatal("Expected GetConfig() to fail on unreadable file")
 		}
 	})
 
 	t.Run("nonexistent file", func(t *testing.T) {
-		_, err := client.GetConfig("/this/is/a/bad/path.yml")
+		_, err := client.GetConfig(log, "/this/is/a/bad/path.yml")
 		if err == nil {
 			t.Fatal("Expected GetConfig() to fail on nonexistent file")
 		}

--- a/src/control/client/control.go
+++ b/src/control/client/control.go
@@ -1,5 +1,5 @@
 //
-// (C) Copyright 2018 Intel Corporation.
+// (C) Copyright 2018-2019 Intel Corporation.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -28,6 +28,7 @@ import (
 	"google.golang.org/grpc/connectivity"
 
 	pb "github.com/daos-stack/daos/src/control/common/proto/mgmt"
+	"github.com/daos-stack/daos/src/control/logging"
 	"github.com/daos-stack/daos/src/control/security"
 )
 
@@ -39,6 +40,7 @@ type Control interface {
 	getAddress() string
 	getCtlClient() pb.MgmtCtlClient
 	getSvcClient() pb.MgmtSvcClient
+	logger() logging.Logger
 }
 
 // control is an abstraction around the Mgmt{Control,Svc}Clients
@@ -48,6 +50,11 @@ type control struct {
 	ctlClient pb.MgmtCtlClient
 	svcClient pb.MgmtSvcClient
 	gconn     *grpc.ClientConn
+	log       logging.Logger
+}
+
+func (c *control) logger() logging.Logger {
+	return c.log
 }
 
 // connect provides an easy interface to connect to Mgmt DAOS server.

--- a/src/control/client/mocks.go
+++ b/src/control/client/mocks.go
@@ -35,6 +35,7 @@ import (
 	. "github.com/daos-stack/daos/src/control/common"
 	pb "github.com/daos-stack/daos/src/control/common/proto/mgmt"
 	. "github.com/daos-stack/daos/src/control/common/storage"
+	"github.com/daos-stack/daos/src/control/logging"
 	"github.com/daos-stack/daos/src/control/security"
 )
 
@@ -274,6 +275,7 @@ type mockControl struct {
 	connectRet error
 	ctlClient  pb.MgmtCtlClient
 	svcClient  pb.MgmtSvcClient
+	log        logging.Logger
 }
 
 func (m *mockControl) connect(addr string, cfg *security.TransportConfig) error {
@@ -300,11 +302,16 @@ func (m *mockControl) getSvcClient() pb.MgmtSvcClient {
 	return m.svcClient
 }
 
+func (m *mockControl) logger() logging.Logger {
+	return m.log
+}
+
 func newMockControl(
+	log logging.Logger,
 	address string, state connectivity.State, connectRet error,
 	cClient pb.MgmtCtlClient, sClient pb.MgmtSvcClient) Control {
 
-	return &mockControl{address, state, connectRet, cClient, sClient}
+	return &mockControl{address, state, connectRet, cClient, sClient, log}
 }
 
 type mockControllerFactory struct {
@@ -315,6 +322,7 @@ type mockControllerFactory struct {
 	modules       ScmModules
 	moduleResults ScmModuleResults
 	mountResults  ScmMountResults
+	log           logging.Logger
 	// to provide error injection into Control objects
 	scanRet    error
 	formatRet  error
@@ -333,7 +341,7 @@ func (m *mockControllerFactory) create(address string, cfg *security.TransportCo
 
 	sClient := newMockMgmtSvcClient()
 
-	controller := newMockControl(address, m.state, m.connectRet, cClient, sClient)
+	controller := newMockControl(m.log, address, m.state, m.connectRet, cClient, sClient)
 
 	err := controller.connect(address, cfg)
 
@@ -341,6 +349,7 @@ func (m *mockControllerFactory) create(address string, cfg *security.TransportCo
 }
 
 func newMockConnect(
+	log logging.Logger,
 	state connectivity.State, features []*pb.Feature, ctrlrs NvmeControllers,
 	ctrlrResults NvmeControllerResults, modules ScmModules,
 	moduleResults ScmModuleResults, mountResults ScmMountResults,
@@ -350,15 +359,15 @@ func newMockConnect(
 	return &connList{
 		factory: &mockControllerFactory{
 			state, MockFeatures, ctrlrs, ctrlrResults, modules,
-			moduleResults, mountResults, scanRet, formatRet,
+			moduleResults, mountResults, log, scanRet, formatRet,
 			updateRet, burninRet, killRet, connectRet,
 		},
 	}
 }
 
-func defaultMockConnect() Connect {
+func defaultMockConnect(log logging.Logger) Connect {
 	return newMockConnect(
-		connectivity.Ready, MockFeatures, MockCtrlrs, MockCtrlrResults, MockModules,
+		log, connectivity.Ready, MockFeatures, MockCtrlrs, MockCtrlrResults, MockModules,
 		MockModuleResults, MockMountResults, nil, nil, nil, nil, nil, nil)
 }
 

--- a/src/control/client/storage.go
+++ b/src/control/client/storage.go
@@ -35,7 +35,6 @@ import (
 
 	pb "github.com/daos-stack/daos/src/control/common/proto/mgmt"
 	types "github.com/daos-stack/daos/src/control/common/storage"
-	log "github.com/daos-stack/daos/src/control/logging"
 )
 
 const (
@@ -118,7 +117,7 @@ func storagePrepareRequest(mc Control, req interface{}, ch chan ClientResult) {
 	if !ok {
 		err := errors.Errorf(msgTypeAssert, &pb.StoragePrepareReq{}, req)
 
-		log.Errorf(err.Error())
+		mc.logger().Errorf(err.Error())
 		ch <- ClientResult{mc.getAddress(), nil, err}
 		return // type err
 	}
@@ -233,7 +232,7 @@ func StorageFormatRequest(mc Control, parms interface{}, ch chan ClientResult) {
 		}
 		if err != nil {
 			err := errors.Wrapf(err, msgStreamRecv, stream)
-			log.Errorf(err.Error())
+			mc.logger().Errorf(err.Error())
 			ch <- ClientResult{mc.getAddress(), nil, err}
 			return // recv err
 		}
@@ -300,14 +299,14 @@ func storageUpdateRequest(
 		err := errors.Errorf(
 			msgTypeAssert, pb.StorageUpdateReq{}, req)
 
-		log.Errorf(err.Error())
+		mc.logger().Errorf(err.Error())
 		ch <- ClientResult{mc.getAddress(), nil, err}
 		return // type err
 	}
 
 	stream, err := mc.getCtlClient().StorageUpdate(ctx, updateReq)
 	if err != nil {
-		log.Errorf(err.Error())
+		mc.logger().Errorf(err.Error())
 		ch <- ClientResult{mc.getAddress(), nil, err}
 		return // stream err
 	}
@@ -319,7 +318,7 @@ func storageUpdateRequest(
 		}
 		if err != nil {
 			err := errors.Wrapf(err, msgStreamRecv, stream)
-			log.Errorf(err.Error())
+			mc.logger().Errorf(err.Error())
 			ch <- ClientResult{mc.getAddress(), nil, err}
 			return // recv err
 		}

--- a/src/control/cmd/daos_server/storage.go
+++ b/src/control/cmd/daos_server/storage.go
@@ -82,7 +82,7 @@ type storagePrepareCmd struct {
 }
 
 func (cmd *storagePrepareCmd) Execute(args []string) error {
-	if err := cmd.Init(); err != nil {
+	if err := cmd.Init(cmd.log); err != nil {
 		return err
 	}
 

--- a/src/control/cmd/dmg/main.go
+++ b/src/control/cmd/dmg/main.go
@@ -32,19 +32,7 @@ import (
 	"github.com/pkg/errors"
 
 	"github.com/daos-stack/daos/src/control/client"
-	log "github.com/daos-stack/daos/src/control/logging"
-)
-
-type dmgErr string
-
-func (de dmgErr) Error() string {
-	return string(de)
-}
-
-const (
-	// use this error type to signal that a
-	// subcommand completed without error
-	cmdSuccess dmgErr = "command execution completed"
+	"github.com/daos-stack/daos/src/control/logging"
 )
 
 type (
@@ -79,6 +67,18 @@ func (cmd *connectedCmd) setConns(conns client.Connect) {
 	cmd.conns = conns
 }
 
+type cmdLogger interface {
+	setLog(*logging.LeveledLogger)
+}
+
+type logCmd struct {
+	log *logging.LeveledLogger
+}
+
+func (c *logCmd) setLog(log *logging.LeveledLogger) {
+	c.log = log
+}
+
 type cliOptions struct {
 	HostList string `short:"l" long:"host-list" description:"comma separated list of addresses <ipv4addr/hostname:port>"`
 	Insecure bool   `short:"i" long:"insecure" description:"have dmg attempt to connect without certificates"`
@@ -94,16 +94,8 @@ type cliOptions struct {
 }
 
 // appSetup loads config file, processes cli overrides and connects clients.
-func appSetup(broadcast bool, opts *cliOptions, conns client.Connect) error {
-	if opts.Debug {
-		log.SetLevel(log.LogLevelDebug)
-		log.Debug("debug output enabled")
-	}
-	if opts.JSON {
-		log.SetJSONOutput()
-	}
-
-	config, err := client.GetConfig(opts.ConfigPath)
+func appSetup(log logging.Logger, broadcast bool, opts *cliOptions, conns client.Connect) error {
+	config, err := client.GetConfig(log, opts.ConfigPath)
 	if err != nil {
 		return errors.WithMessage(err, "processing config file")
 	}
@@ -143,14 +135,12 @@ func appSetup(broadcast bool, opts *cliOptions, conns client.Connect) error {
 	return nil
 }
 
-func exitWithError(err error) {
+func exitWithError(log logging.Logger, err error) {
 	log.Errorf("%s: %v", path.Base(os.Args[0]), err)
 	os.Exit(1)
 }
 
-func parseOpts(args []string, conns client.Connect) (*cliOptions, error) {
-	opts := new(cliOptions)
-
+func parseOpts(args []string, opts *cliOptions, conns client.Connect, log *logging.LeveledLogger) error {
 	p := flags.NewParser(opts, flags.Default)
 	p.Options ^= flags.PrintErrors // Don't allow the library to print errors
 	p.CommandHandler = func(cmd flags.Commander, args []string) error {
@@ -158,8 +148,20 @@ func parseOpts(args []string, conns client.Connect) (*cliOptions, error) {
 			return nil
 		}
 
+		if opts.Debug {
+			log.WithLogLevel(logging.LogLevelDebug)
+			log.Debug("debug output enabled")
+		}
+		if opts.JSON {
+			log.WithJSONOutput()
+		}
+
+		if logCmd, ok := cmd.(cmdLogger); ok {
+			logCmd.setLog(log)
+		}
+
 		_, shouldBroadcast := cmd.(broadcaster)
-		if err := appSetup(shouldBroadcast, opts, conns); err != nil {
+		if err := appSetup(log, shouldBroadcast, opts, conns); err != nil {
 			return err
 		}
 		if wantsConn, ok := cmd.(connector); ok {
@@ -169,28 +171,20 @@ func parseOpts(args []string, conns client.Connect) (*cliOptions, error) {
 			return err
 		}
 
-		return cmdSuccess
+		return nil
 	}
 
-	unparsed, err := p.ParseArgs(args)
-	if err != nil {
-		return nil, err
-	}
-	if len(unparsed) > 0 {
-		log.Debugf("Unparsed arguments: %v", unparsed)
-	}
-
-	return opts, nil
+	_, err := p.ParseArgs(args)
+	return err
 }
 
 func main() {
-	conns := client.NewConnect()
+	var opts cliOptions
+	log := logging.NewCommandLineLogger()
 
-	_, err := parseOpts(os.Args[1:], conns)
-	if err != nil {
-		if err == cmdSuccess {
-			os.Exit(0)
-		}
-		exitWithError(err)
+	conns := client.NewConnect(log)
+
+	if err := parseOpts(os.Args[1:], &opts, conns, log); err != nil {
+		exitWithError(log, err)
 	}
 }

--- a/src/control/cmd/dmg/pool.go
+++ b/src/control/cmd/dmg/pool.go
@@ -33,7 +33,7 @@ import (
 	"github.com/daos-stack/daos/src/control/client"
 	"github.com/daos-stack/daos/src/control/common"
 	pb "github.com/daos-stack/daos/src/control/common/proto/mgmt"
-	log "github.com/daos-stack/daos/src/control/logging"
+	"github.com/daos-stack/daos/src/control/logging"
 )
 
 const (
@@ -50,6 +50,7 @@ type PoolCmd struct {
 
 // CreatePoolCmd is the struct representing the command to create a DAOS pool.
 type CreatePoolCmd struct {
+	logCmd
 	connectedCmd
 	GroupName  string `short:"g" long:"group" description:"DAOS pool to be owned by given group, format name@domain"`
 	UserName   string `short:"u" long:"user" description:"DAOS pool to be owned by given user, format name@domain"`
@@ -63,13 +64,14 @@ type CreatePoolCmd struct {
 
 // Execute is run when CreatePoolCmd subcommand is activated
 func (c *CreatePoolCmd) Execute(args []string) error {
-	return createPool(c.conns,
+	return createPool(c.log, c.conns,
 		c.ScmSize, c.NVMeSize, c.RankList, c.NumSvcReps,
 		c.GroupName, c.UserName, c.Sys, c.ACLFile)
 }
 
 // DestroyPoolCmd is the struct representing the command to destroy a DAOS pool.
 type DestroyPoolCmd struct {
+	logCmd
 	connectedCmd
 	Uuid  string `short:"u" long:"uuid" required:"1" description:"UUID of DAOS pool to destroy"`
 	Force bool   `short:"f" long:"force" description:"Force removal of DAOS pool"`
@@ -77,7 +79,7 @@ type DestroyPoolCmd struct {
 
 // Execute is run when DestroyPoolCmd subcommand is activated
 func (d *DestroyPoolCmd) Execute(args []string) error {
-	return destroyPool(d.conns, d.Uuid, d.Force)
+	return destroyPool(d.log, d.conns, d.Uuid, d.Force)
 }
 
 // getSize retrieves number of bytes from human readable string representation
@@ -101,7 +103,7 @@ func getSize(sizeStr string) (bytesize.ByteSize, error) {
 }
 
 // calcStorage calculates SCM & NVMe size for pool from user supplied parameters
-func calcStorage(scmSize string, nvmeSize string) (
+func calcStorage(log logging.Logger, scmSize string, nvmeSize string) (
 	scmBytes bytesize.ByteSize, nvmeBytes bytesize.ByteSize, err error) {
 
 	scmBytes, err = getSize(scmSize)
@@ -172,11 +174,12 @@ func formatNameGroup(usr string, grp string) (string, string, error) {
 }
 
 // createPool with specified parameters.
-func createPool(conns client.Connect, scmSize string, nvmeSize string,
+func createPool(log logging.Logger,
+	conns client.Connect, scmSize string, nvmeSize string,
 	rankList string, numSvcReps uint32, groupName string,
 	userName string, sys string, aclFile string) error {
 
-	scmBytes, nvmeBytes, err := calcStorage(scmSize, nvmeSize)
+	scmBytes, nvmeBytes, err := calcStorage(log, scmSize, nvmeSize)
 	if err != nil {
 		return errors.Wrap(err, "calculating pool storage sizes")
 	}
@@ -210,7 +213,7 @@ func createPool(conns client.Connect, scmSize string, nvmeSize string,
 }
 
 // destroyPool identified by UUID.
-func destroyPool(conns client.Connect, uuid string, force bool) error {
+func destroyPool(log logging.Logger, conns client.Connect, uuid string, force bool) error {
 	req := &pb.DestroyPoolReq{Uuid: uuid, Force: force}
 
 	log.Infof("Destroying DAOS pool: %+v\n", req)

--- a/src/control/cmd/dmg/service.go
+++ b/src/control/cmd/dmg/service.go
@@ -23,11 +23,6 @@
 
 package main
 
-import (
-	"github.com/daos-stack/daos/src/control/client"
-	log "github.com/daos-stack/daos/src/control/logging"
-)
-
 // SvcCmd is the struct representing the top-level service subcommand.
 type SvcCmd struct {
 	KillRank KillRankSvcCmd `command:"kill-rank" alias:"kr" description:"Terminate server running as specific rank on a DAOS pool"`
@@ -36,18 +31,14 @@ type SvcCmd struct {
 // KillRankSvcCmd is the struct representing the command to kill server
 // identified by rank on given pool identified by uuid.
 type KillRankSvcCmd struct {
+	logCmd
 	connectedCmd
 	Rank     uint32 `short:"r" long:"rank" description:"Rank identifying DAOS server" required:"1"`
 	PoolUUID string `short:"p" long:"pool-uuid" description:"Pool uuid that rank relates to" required:"1"`
 }
 
-// run kill rank command with specified parameters on all connected servers
-func killRankSvc(conns client.Connect, uuid string, rank uint32) {
-	log.Infof("Kill Rank command results:\n%s", conns.KillRank(uuid, rank))
-}
-
 // Execute is run when KillRankSvcCmd activates
 func (k *KillRankSvcCmd) Execute(args []string) error {
-	killRankSvc(k.conns, k.PoolUUID, k.Rank)
+	k.log.Infof("Kill Rank command results:\n%s", k.conns.KillRank(k.PoolUUID, k.Rank))
 	return nil
 }

--- a/src/control/cmd/dmg/service_test.go
+++ b/src/control/cmd/dmg/service_test.go
@@ -35,7 +35,6 @@ func TestServiceCommands(t *testing.T) {
 			"Kill rank with missing arguments",
 			"service kill-rank",
 			"ConnectClients KillRank",
-			nil,
 			errMissingFlag,
 		},*/
 		{
@@ -43,13 +42,11 @@ func TestServiceCommands(t *testing.T) {
 			"service kill-rank --pool-uuid 031bcaf8-f0f5-42ef-b3c5-ee048676dceb --rank 2",
 			"ConnectClients KillRank-uuid 031bcaf8-f0f5-42ef-b3c5-ee048676dceb, rank 2",
 			nil,
-			cmdSuccess,
 		},
 		{
 			"Nonexistent subcommand",
 			"service quack",
 			"",
-			nil,
 			fmt.Errorf("Unknown command"),
 		},
 	})

--- a/src/control/cmd/dmg/storage.go
+++ b/src/control/cmd/dmg/storage.go
@@ -28,7 +28,7 @@ import (
 	"github.com/daos-stack/daos/src/control/common"
 	pb "github.com/daos-stack/daos/src/control/common/proto/mgmt"
 	types "github.com/daos-stack/daos/src/control/common/storage"
-	log "github.com/daos-stack/daos/src/control/logging"
+	"github.com/daos-stack/daos/src/control/logging"
 )
 
 // storageCmd is the struct representing the top-level storage subcommand.
@@ -41,6 +41,7 @@ type storageCmd struct {
 
 // storagePrepareCmd is the struct representing the prep storage subcommand.
 type storagePrepareCmd struct {
+	logCmd
 	broadcastCmd
 	connectedCmd
 	types.StoragePrepareCmd
@@ -51,7 +52,7 @@ func (cmd *storagePrepareCmd) Execute(args []string) error {
 	var nReq *pb.PrepareNvmeReq
 	var sReq *pb.PrepareScmReq
 
-	if err := cmd.Init(); err != nil {
+	if err := cmd.Init(cmd.log); err != nil {
 		return err
 	}
 
@@ -68,7 +69,7 @@ func (cmd *storagePrepareCmd) Execute(args []string) error {
 		sReq = &pb.PrepareScmReq{Reset_: cmd.Reset}
 	}
 
-	log.Infof("NVMe & SCM preparation:\n%s",
+	cmd.log.Infof("NVMe & SCM preparation:\n%s",
 		cmd.conns.StoragePrepare(&pb.StoragePrepareReq{Nvme: nReq, Scm: sReq}))
 
 	return nil
@@ -76,12 +77,13 @@ func (cmd *storagePrepareCmd) Execute(args []string) error {
 
 // storageScanCmd is the struct representing the scan storage subcommand.
 type storageScanCmd struct {
+	logCmd
 	broadcastCmd
 	connectedCmd
 }
 
 // run NVMe and SCM storage query on all connected servers
-func storageScan(conns client.Connect) {
+func storageScan(log logging.Logger, conns client.Connect) {
 	cCtrlrs, cModules := conns.StorageScan()
 	log.Infof("NVMe SSD controller and constituent namespaces:\n%s", cCtrlrs)
 	log.Infof("SCM modules:\n%s", cModules)
@@ -89,25 +91,26 @@ func storageScan(conns client.Connect) {
 
 // Execute is run when storageScanCmd activates
 func (s *storageScanCmd) Execute(args []string) error {
-	storageScan(s.conns)
+	storageScan(s.log, s.conns)
 	return nil
 }
 
 // storageFormatCmd is the struct representing the format storage subcommand.
 type storageFormatCmd struct {
+	logCmd
 	broadcastCmd
 	connectedCmd
 	Force bool `short:"f" long:"force" description:"Perform format without prompting for confirmation"`
 }
 
 // run NVMe and SCM storage format on all connected servers
-func storageFormat(conns client.Connect, force bool) {
+func storageFormat(log logging.Logger, conns client.Connect, force bool) {
 	log.Info(
 		"This is a destructive operation and storage devices " +
 			"specified in the server config file will be erased.\n" +
 			"Please be patient as it may take several minutes.\n")
 
-	if force || common.GetConsent() {
+	if force || common.GetConsent(log) {
 		log.Info("")
 		cCtrlrResults, cMountResults := conns.StorageFormat()
 		log.Infof("NVMe storage format results:\n%s", cCtrlrResults)
@@ -117,12 +120,13 @@ func storageFormat(conns client.Connect, force bool) {
 
 // Execute is run when storageFormatCmd activates
 func (s *storageFormatCmd) Execute(args []string) error {
-	storageFormat(s.conns, s.Force)
+	storageFormat(s.log, s.conns, s.Force)
 	return nil
 }
 
 // storageUpdateCmd is the struct representing the update storage subcommand.
 type storageUpdateCmd struct {
+	logCmd
 	broadcastCmd
 	connectedCmd
 	Force        bool   `short:"f" long:"force" description:"Perform update without prompting for confirmation"`
@@ -133,14 +137,14 @@ type storageUpdateCmd struct {
 }
 
 // run NVMe and SCM storage update on all connected servers
-func storageUpdate(conns client.Connect, req *pb.StorageUpdateReq, force bool) {
+func storageUpdate(log logging.Logger, conns client.Connect, req *pb.StorageUpdateReq, force bool) {
 	log.Info(
 		"This could be a destructive operation and storage devices " +
 			"specified in the server config file will have firmware " +
 			"updated. Please check this is a supported upgrade path " +
 			"and be patient as it may take several minutes.\n")
 
-	if force || common.GetConsent() {
+	if force || common.GetConsent(log) {
 		log.Info("")
 		cCtrlrResults, cModuleResults := conns.StorageUpdate(req)
 		log.Infof("NVMe storage update results:\n%s", cCtrlrResults)
@@ -152,6 +156,7 @@ func storageUpdate(conns client.Connect, req *pb.StorageUpdateReq, force bool) {
 func (u *storageUpdateCmd) Execute(args []string) error {
 	// only populate nvme fwupdate params for the moment
 	storageUpdate(
+		u.log,
 		u.conns,
 		&pb.StorageUpdateReq{
 			Nvme: &pb.UpdateNvmeReq{

--- a/src/control/cmd/dmg/storage_test.go
+++ b/src/control/cmd/dmg/storage_test.go
@@ -41,20 +41,17 @@ func TestStorageCommands(t *testing.T) {
 			"storage format",
 			"ConnectClients",
 			nil,
-			cmdSuccess,
 		},
 		{
 			"Format with force",
 			"storage format --force",
 			"ConnectClients StorageFormat",
 			nil,
-			cmdSuccess,
 		},
 		{
 			"Update with missing arguments",
 			"storage fwupdate",
 			"",
-			nil,
 			errMissingFlag,
 		},
 		{
@@ -63,7 +60,6 @@ func TestStorageCommands(t *testing.T) {
 			"storage fwupdate --nvme-model foo --nvme-fw-path bar --nvme-fw-rev 123",
 			"ConnectClients",
 			nil,
-			cmdSuccess,
 		},
 		{
 			"Update with force",
@@ -79,20 +75,17 @@ func TestStorageCommands(t *testing.T) {
 				}),
 			}, " "),
 			nil,
-			cmdSuccess,
 		},
 		{
 			"Scan",
 			"storage scan",
 			"ConnectClients StorageScan",
 			nil,
-			cmdSuccess,
 		},
 		{
 			"Nonexistent subcommand",
 			"storage quack",
 			"",
-			nil,
 			fmt.Errorf("Unknown command"),
 		},
 	})

--- a/src/control/cmd/dmg/utils_test.go
+++ b/src/control/cmd/dmg/utils_test.go
@@ -27,14 +27,11 @@ import (
 	"testing"
 
 	. "github.com/daos-stack/daos/src/control/client"
-	"github.com/daos-stack/daos/src/control/common"
 	. "github.com/daos-stack/daos/src/control/common"
 	pb "github.com/daos-stack/daos/src/control/common/proto/mgmt"
 )
 
 func TestHasConnection(t *testing.T) {
-	defer common.ShowLogOnFailure(t)()
-
 	var shelltests = []struct {
 		results ResultMap
 		out     string
@@ -76,8 +73,6 @@ func TestHasConnection(t *testing.T) {
 }
 
 func TestCheckSprint(t *testing.T) {
-	defer common.ShowLogOnFailure(t)()
-
 	var shelltests = []struct {
 		m   string
 		out string

--- a/src/control/common/storage/commands.go
+++ b/src/control/common/storage/commands.go
@@ -27,7 +27,7 @@ import (
 	"github.com/pkg/errors"
 
 	"github.com/daos-stack/daos/src/control/common"
-	log "github.com/daos-stack/daos/src/control/logging"
+	"github.com/daos-stack/daos/src/control/logging"
 )
 
 const MsgStoragePrepareWarn = "Memory allocation goals for SCM will be changed and " +
@@ -53,14 +53,14 @@ type StoragePrepareCmd struct {
 	Force    bool `short:"f" long:"force" description:"Perform format without prompting for confirmation"`
 }
 
-func (cmd *StoragePrepareCmd) Init() error {
+func (cmd *StoragePrepareCmd) Init(log logging.Logger) error {
 	if cmd.NvmeOnly && cmd.ScmOnly {
 		return errors.New("nvme-only and scm-only options should not be set together")
 	}
 
 	log.Info(MsgStoragePrepareWarn)
 
-	if !cmd.Force && !common.GetConsent() {
+	if !cmd.Force && !common.GetConsent(log) {
 		return errors.New("consent not given")
 	}
 

--- a/src/control/common/user_utils.go
+++ b/src/control/common/user_utils.go
@@ -27,7 +27,7 @@ import (
 	"fmt"
 	"os"
 
-	log "github.com/daos-stack/daos/src/control/logging"
+	"github.com/daos-stack/daos/src/control/logging"
 )
 
 // CheckSudo returns true if current process is running as root or with sudo.
@@ -42,7 +42,7 @@ func CheckSudo() (bool, string) {
 }
 
 // GetConsent scans stdin for yes/no
-func GetConsent() bool {
+func GetConsent(log logging.Logger) bool {
 	var response string
 
 	log.Info("Are you sure you want to continue? (yes/no)\n")
@@ -57,7 +57,7 @@ func GetConsent() bool {
 		return false
 	} else if response != "yes" {
 		log.Info("Please type yes or no and then press enter:")
-		return GetConsent()
+		return GetConsent(log)
 	}
 
 	return true


### PR DESCRIPTION
Bring these commands in line with daos_server, which was updated
to create a single log instance and pass it as a dependency where
it is needed.

Also cleans up dmg command testing to remove the unused opts
test.