### PR TITLE
DAOS-3275 control: rediscover storage during scan

### DIFF
--- a/src/control/server/storage_nvme.go
+++ b/src/control/server/storage_nvme.go
@@ -193,10 +193,6 @@ func (n *nvmeStorage) Teardown() (err error) {
 //       process, presumably we want to be able to detect updates during
 //       process lifetime.
 func (n *nvmeStorage) Discover() error {
-	if n.initialized {
-		return nil
-	}
-
 	// specify shmID to be set as opt in SPDK env init
 	if err := n.env.InitSPDKEnv(n.shmID); err != nil {
 		return errors.WithMessage(err, msgSpdkInitFail)

--- a/src/control/server/storage_nvme_test.go
+++ b/src/control/server/storage_nvme_test.go
@@ -230,12 +230,6 @@ func TestDiscoverNvmeSingle(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		if tt.inited {
-			AssertEqual(t, sn.controllers, NvmeControllers(nil),
-				"unexpected list of protobuf format controllers")
-			continue
-		}
-
 		AssertEqual(t, sn.controllers, NvmeControllers{pbC},
 			"unexpected list of protobuf format controllers")
 	}

--- a/src/control/server/storage_scm.go
+++ b/src/control/server/storage_scm.go
@@ -96,10 +96,6 @@ func (s *scmStorage) PrepReset(state types.ScmState) (needsReboot bool, err erro
 
 // Discover method implementation for scmStorage
 func (s *scmStorage) Discover() error {
-	if s.initialized {
-		return nil
-	}
-
 	mms, err := s.ipmctl.Discover()
 	if err != nil {
 		return errors.WithMessage(err, msgIpmctlDiscoverFail)

--- a/src/control/server/storage_scm_test.go
+++ b/src/control/server/storage_scm_test.go
@@ -225,12 +225,6 @@ func TestDiscoverScm(t *testing.T) {
 		errMsg            string
 		expModules        ScmModules
 	}{
-		"already initialized": {
-			true,
-			nil,
-			"",
-			ScmModules(nil),
-		},
 		"normal run": {
 			false,
 			nil,


### PR DESCRIPTION
If prepare NVMe is performed while the server is running (from
management tool), scan will not show updated results (devices will
not be shown even though they are accessible to SPDK).

This is because the devices are not rediscovered during the scan
process (results are cached).

Don't cache and rediscover devices on each scan, overhead is deemed
minimal and the benefit of having up-to-date information beneficial.

Signed-off-by: Tom Nabarro <tom.nabarro@intel.com>