### PR TITLE
DAOS-623 vos: Reduce logging from garbage collector

### DIFF
--- a/src/vos/vos_gc.c
+++ b/src/vos/vos_gc.c
@@ -739,6 +739,16 @@ vos_gc_run(int *credits)
 		return -DER_INVAL;
 	}
 
+	if (d_list_empty(pools)) {
+		/* Garbage collection has nothing to do.  Just consume the
+		 * credits and return to check when more credits are available.
+		 * No logging here as it causes log explosion when trace is
+		 * set.
+		 */
+		*credits = 0;
+		return 0;
+	}
+
 	while (!d_list_empty(pools)) {
 		struct vos_pool *pool;
 		bool		 empty = false;


### PR DESCRIPTION
If we forego logging in garbage collector when there are no pools
in the list, we see a huge reduction in log size for tests.  The
issue is the garbage collector spins and does nothing but produce
logs when there are no pools to collect.

Signed-off-by: Jeff Olivier <jeffrey.v.olivier@intel.com>