### PR TITLE
DAOS-2444 obj: add basic EC obj fetch handling

### DIFF
--- a/src/client/api/task_internal.h
+++ b/src/client/api/task_internal.h
@@ -31,7 +31,7 @@
 
 #define DAOS_TASK_MAGIC			0xbabeface
 
-/* size of daos_task_args should within limitation of TSE_TASK_ARG_LEN (248) */
+/* size of daos_task_args should within limitation of TSE_TASK_ARG_LEN */
 struct daos_task_args {
 	uint32_t			ta_magic;
 	uint32_t			ta_opc;

--- a/src/common/tse.c
+++ b/src/common/tse.c
@@ -38,6 +38,9 @@
 #include <daos/tse.h>
 #include "tse_internal.h"
 
+D_CASSERT(sizeof(struct tse_task) == TSE_TASK_SIZE);
+D_CASSERT(sizeof(struct tse_task_private) <= TSE_PRIV_SIZE);
+
 struct tse_task_link {
 	d_list_t		 tl_link;
 	tse_task_t		*tl_task;

--- a/src/dtx/dtx_common.c
+++ b/src/dtx/dtx_common.c
@@ -222,14 +222,7 @@ dtx_handle_init(struct dtx_id *dti, daos_unit_oid_t *oid, daos_handle_t coh,
 	dth->dth_conflict = conflict;
 	dth->dth_ent = UMOFF_NULL;
 	dth->dth_obj = UMOFF_NULL;
-	/**
-	 * XXX, for EC obj, now works in synchronous commit mode, to simplify
-	 * the EC fetch handling. Can refine it as async commit later.
-	 */
-	if (leader && daos_oclass_is_ec(oid->id_pub, NULL))
-		dth->dth_sync = 1;
-	else
-		dth->dth_sync = 0;
+	dth->dth_sync = 0;
 }
 
 static inline void

--- a/src/include/daos/tse.h
+++ b/src/include/daos/tse.h
@@ -32,7 +32,7 @@
 #include <gurt/list.h>
 /**
  * tse_task is used to track single asynchronous operation.
- * 512 bytes all together.
+ * 1K bytes all together.
  */
 #define TSE_TASK_SIZE		1024
 /* 8 bytes used for public members */

--- a/src/iosrv/init.c
+++ b/src/iosrv/init.c
@@ -373,6 +373,7 @@ server_init(int argc, char *argv[])
 	uint32_t	flags = CRT_FLAG_BIT_SERVER | CRT_FLAG_BIT_LM_DISABLE;
 	d_rank_t	rank = -1;
 	uint32_t	size = -1;
+	char		hostname[256] = { 0 };
 
 	rc = daos_debug_init(NULL);
 	if (rc != 0)
@@ -489,11 +490,12 @@ server_init(int argc, char *argv[])
 		goto exit_drpc_fini;
 	D_INFO("Modules successfully set up\n");
 
+	gethostname(hostname, 255);
 	D_PRINT("DAOS I/O server (v%s) process %u started on rank %u "
-		"(out of %u) with %u target xstream set(s), %d helper XS "
-		"per target, firstcore %d.\n",
-		DAOS_VERSION, getpid(), rank, size, dss_tgt_nr,
-		dss_tgt_offload_xs_nr, dss_core_offset);
+		"(out of %u) with %u target, %d helper XS per target, "
+		"firstcore %d, host %s.\n", DAOS_VERSION, getpid(), rank,
+		size, dss_tgt_nr, dss_tgt_offload_xs_nr, dss_core_offset,
+		hostname);
 
 	return 0;
 

--- a/src/object/cli_obj.c
+++ b/src/object/cli_obj.c
@@ -333,30 +333,6 @@ obj_get_grp_size(struct dc_object *obj)
 	return obj->cob_grp_size;
 }
 
-static int
-obj_dkey2grp(struct dc_object *obj, uint64_t hash, unsigned int map_ver)
-{
-	int		grp_size;
-	uint64_t	grp_idx;
-
-	grp_size = obj_get_grp_size(obj);
-	D_ASSERT(grp_size > 0);
-
-	D_RWLOCK_RDLOCK(&obj->cob_lock);
-	if (obj->cob_version != map_ver) {
-		D_RWLOCK_UNLOCK(&obj->cob_lock);
-		return -DER_STALE;
-	}
-
-	D_ASSERT(obj->cob_shards_nr >= grp_size);
-
-	/* XXX, consistent hash? */
-	grp_idx = hash % (obj->cob_shards_nr / grp_size);
-	D_RWLOCK_UNLOCK(&obj->cob_lock);
-
-	return grp_idx;
-}
-
 /* Get a valid shard from an object group */
 static int
 obj_grp_valid_shard_get(struct dc_object *obj, int idx,
@@ -441,15 +417,39 @@ obj_grp_leader_get(struct dc_object *obj, int idx, unsigned int map_ver)
 #define		OBJ_FETCH_LEADER_INTERVAL	2
 
 static int
-obj_dkeyhash2shard(struct dc_object *obj, uint64_t hash, unsigned int map_ver,
-		   uint32_t op, bool to_leader)
+obj_dkey2grpidx(struct dc_object *obj, uint64_t hash, unsigned int map_ver)
+{
+	int		grp_size;
+	uint64_t	grp_idx;
+
+	grp_size = obj_get_grp_size(obj);
+	D_ASSERT(grp_size > 0);
+
+	D_RWLOCK_RDLOCK(&obj->cob_lock);
+	if (obj->cob_version != map_ver) {
+		D_RWLOCK_UNLOCK(&obj->cob_lock);
+		return -DER_STALE;
+	}
+
+	D_ASSERT(obj->cob_shards_nr >= grp_size);
+
+	/* XXX, consistent hash? */
+	grp_idx = hash % (obj->cob_shards_nr / grp_size);
+	D_RWLOCK_UNLOCK(&obj->cob_lock);
+
+	return grp_idx;
+}
+
+static int
+obj_dkey2shard(struct dc_object *obj, uint64_t hash, unsigned int map_ver,
+	       uint32_t op, bool to_leader)
 {
 	uint64_t	time = 0;
 	int		grp_idx;
 	int		grp_size;
 	int		idx;
 
-	grp_idx = obj_dkey2grp(obj, hash, map_ver);
+	grp_idx = obj_dkey2grpidx(obj, hash, map_ver);
 	if (grp_idx < 0)
 		return grp_idx;
 
@@ -469,12 +469,12 @@ obj_dkeyhash2shard(struct dc_object *obj, uint64_t hash, unsigned int map_ver,
 }
 
 static int
-obj_dkeyhash2update_grp(struct dc_object *obj, uint64_t hash, uint32_t map_ver,
-			uint32_t *start_shard, uint32_t *grp_size)
+obj_dkey2grpmemb(struct dc_object *obj, uint64_t hash, uint32_t map_ver,
+		 uint32_t *start_shard, uint32_t *grp_size)
 {
 	int	 grp_idx;
 
-	grp_idx = obj_dkey2grp(obj, hash, map_ver);
+	grp_idx = obj_dkey2grpidx(obj, hash, map_ver);
 	if (grp_idx < 0)
 		return grp_idx;
 
@@ -549,6 +549,39 @@ struct obj_req_tgts {
 	uint32_t		 ort_srv_disp:1;
 };
 
+/* a helper for debugging purpose */
+void
+obj_req_tgts_dump(struct obj_req_tgts *req_tgts)
+{
+	int	i, j;
+
+	D_PRINT("content of obj_req_tgts %p:\n", req_tgts);
+	D_PRINT("ort_srv_disp %d, ort_start_shard %d, ort_grp_nr %d, "
+		"ort_grp_size %d.\n", req_tgts->ort_srv_disp,
+		req_tgts->ort_start_shard, req_tgts->ort_grp_nr,
+		req_tgts->ort_grp_size);
+	for (i = 0; i < req_tgts->ort_grp_nr; i++) {
+		struct daos_shard_tgt *tgt;
+
+		tgt = req_tgts->ort_shard_tgts + i * req_tgts->ort_grp_size;
+		D_PRINT("grp %4d - ", i);
+		for (j = 0; j < req_tgts->ort_grp_size; j++) {
+			if (j > 0)
+				D_PRINT("           ");
+			D_PRINT("[%4d] rank %4d, shard %4d, tgt_idx %4d, "
+				"tgt_id %4d.\n", j, tgt->st_rank, tgt->st_shard,
+				tgt->st_tgt_idx, tgt->st_tgt_id);
+			tgt++;
+		}
+		D_PRINT("\n");
+	}
+}
+
+/* only send to leader and need not forward */
+#define OBJ_TGT_FLAG_LEADER_ONLY	(1U << 0)
+/* client side dispatch, despite of srv_io_mode setting */
+#define OBJ_TGT_FLAG_CLI_DISPATCH	(1U << 1)
+
 /* The tgt_set parameter is a bit map indicating the proper subset of targets
  * to forward the update for EC ojbects. For non-EC objects, and for EC updates
  * that include a full-stripe update (i.e., parity has been generated), the
@@ -557,19 +590,22 @@ struct obj_req_tgts {
 static int
 obj_shards_2_fwtgts(struct dc_object *obj, uint32_t map_ver, uint64_t tgt_set,
 		    uint32_t start_shard, uint32_t shard_cnt, uint32_t grp_nr,
-		    struct obj_req_tgts *req_tgts, bool forward)
+		    struct obj_req_tgts *req_tgts, uint32_t flags)
 {
 	struct daos_shard_tgt	*tgt = NULL;
 	uint32_t		 leader_shard = -1;
 	uint32_t		 i, j;
 	uint32_t		 shard_idx, shard_nr, grp_size;
+	bool			 cli_disp = flags & OBJ_TGT_FLAG_CLI_DISPATCH;
 	int			 rc;
 
 	D_ASSERT(shard_cnt >= 1);
 	grp_size = shard_cnt / grp_nr;
 	D_ASSERT(grp_size * grp_nr == shard_cnt);
+	if (cli_disp)
+		D_ASSERT(grp_nr == 1);
 	req_tgts->ort_srv_disp = (srv_io_mode != DIM_CLIENT_DISPATCH) &&
-				  grp_size > 1;
+				  !cli_disp && grp_size > 1;
 
 	if (tgt_set != 0) {
 		D_ASSERT(grp_nr == 1);
@@ -619,7 +655,7 @@ obj_shards_2_fwtgts(struct dc_object *obj, uint32_t map_ver, uint64_t tgt_set,
 			if (rc != 0)
 				return rc;
 
-			if (!forward)
+			if (flags & OBJ_TGT_FLAG_LEADER_ONLY)
 				continue;
 		}
 
@@ -634,7 +670,7 @@ obj_shards_2_fwtgts(struct dc_object *obj, uint32_t map_ver, uint64_t tgt_set,
 		}
 	}
 
-	if (forward)
+	if (flags == 0 && tgt_set == 0)
 		D_ASSERT(tgt == req_tgts->ort_shard_tgts + shard_nr);
 
 	return 0;
@@ -1421,60 +1457,73 @@ obj_req_get_tgts(struct dc_object *obj, enum obj_rpc_opc opc, int *shard,
 	int		rc;
 
 	switch (opc) {
+	uint32_t	shard_idx;
+	uint32_t	shard_cnt;
+	uint32_t	grp_nr;
+
 	case DAOS_OBJ_RPC_FETCH:
-		if (spec_shard) {
-			D_ASSERT(shard != NULL);
+		if (tgt_set == 0) {
+			if (spec_shard) {
+				D_ASSERT(shard != NULL);
 
-			rc = obj_dkey2grp(obj, dkey_hash, map_ver);
-			if (rc < 0)
-				goto out;
+				rc = obj_dkey2grpidx(obj, dkey_hash, map_ver);
+				if (rc < 0)
+					goto out;
 
-			rc *= obj->cob_grp_size;
-			if (*shard < rc || *shard >= rc + obj->cob_grp_size)
-				D_GOTO(out, rc = -DER_INVAL);
+				rc *= obj->cob_grp_size;
+				if (*shard < rc ||
+				    *shard >= rc + obj->cob_grp_size)
+					D_GOTO(out, rc = -DER_INVAL);
 
-			rc = *shard;
+				rc = *shard;
+			} else {
+				rc = obj_dkey2shard(obj, dkey_hash, map_ver,
+						    opc, to_leader);
+				if (rc < 0)
+					goto out;
+			}
+			shard_idx = rc;
+			shard_cnt = 1;
 		} else {
-			rc = obj_dkeyhash2shard(obj, dkey_hash, map_ver, opc,
-						to_leader);
-			if (rc < 0)
+			rc = obj_dkey2grpmemb(obj, dkey_hash, map_ver,
+					      &shard_idx, &shard_cnt);
+			if (rc != 0)
 				goto out;
 		}
-		req_tgts->ort_shard_tgts = req_tgts->ort_tgts_inline;
-		req_tgts->ort_srv_disp = 0;
-		req_tgts->ort_grp_nr = 1;
-		req_tgts->ort_grp_size = 1;
-		rc = obj_shard_tgts_query(obj, map_ver, rc,
-					  req_tgts->ort_shard_tgts);
-		if (rc != 0)
+		grp_nr = 1;
+
+		rc = obj_shards_2_fwtgts(obj, map_ver, tgt_set, shard_idx,
+					 shard_cnt, grp_nr, req_tgts,
+					 OBJ_TGT_FLAG_CLI_DISPATCH);
+		if (rc != 0) {
+			D_ERROR("opc %d "DF_OID", obj_shards_2_fwtgts failed "
+				"%d.\n", opc, DP_OID(obj->cob_md.omd_id), rc);
 			goto out;
+		}
+		/* obj_req_tgts_dump(req_tgts); */
 		break;
 	case DAOS_OBJ_RPC_UPDATE:
 	case DAOS_OBJ_RPC_PUNCH:
 	case DAOS_OBJ_RPC_PUNCH_DKEYS:
-	case DAOS_OBJ_RPC_PUNCH_AKEYS: {
-		uint32_t	shard_idx;
-		uint32_t	shard_cnt;
-		uint32_t	grp_nr = 1;
-
+	case DAOS_OBJ_RPC_PUNCH_AKEYS:
 		if (opc == DAOS_OBJ_RPC_PUNCH) {
 			obj_ptr2shards(obj, &shard_idx, &shard_cnt, &grp_nr);
 		} else {
-			rc = obj_dkeyhash2update_grp(obj, dkey_hash, map_ver,
-						     &shard_idx, &shard_cnt);
+			grp_nr = 1;
+			rc = obj_dkey2grpmemb(obj, dkey_hash, map_ver,
+					      &shard_idx, &shard_cnt);
 			if (rc != 0)
 				goto out;
 		}
 		req_tgts->ort_start_shard = shard_idx;
 		rc = obj_shards_2_fwtgts(obj, map_ver, tgt_set, shard_idx,
-					 shard_cnt, grp_nr, req_tgts, true);
+					 shard_cnt, grp_nr, req_tgts, 0);
 		if (rc != 0) {
 			D_ERROR("opc %d "DF_OID", obj_shards_2_fwtgts failed "
 				"%d.\n", opc, DP_OID(obj->cob_md.omd_id), rc);
 			goto out;
 		}
 		break;
-	}
 	case DAOS_OBJ_DKEY_RPC_ENUMERATE:
 	case DAOS_OBJ_RPC_ENUMERATE:
 	case DAOS_OBJ_AKEY_RPC_ENUMERATE:
@@ -1490,8 +1539,8 @@ obj_req_get_tgts(struct dc_object *obj, enum obj_rpc_opc opc, int *shard,
 			if (*shard < 0)
 				D_GOTO(out, rc = *shard);
 		} else {
-			*shard = obj_dkeyhash2shard(obj, dkey_hash, map_ver,
-						    opc, to_leader);
+			*shard = obj_dkey2shard(obj, dkey_hash, map_ver,
+						opc, to_leader);
 			if (*shard < 0)
 				D_GOTO(out, rc = *shard);
 		}
@@ -1504,20 +1553,16 @@ obj_req_get_tgts(struct dc_object *obj, enum obj_rpc_opc opc, int *shard,
 		if (rc != 0)
 			goto out;
 		break;
-	case DAOS_OBJ_RPC_SYNC: {
-		uint32_t	shard_idx;
-		uint32_t	shard_cnt;
-		uint32_t	grp_nr;
-
+	case DAOS_OBJ_RPC_SYNC:
 		obj_ptr2shards(obj, &shard_idx, &shard_cnt, &grp_nr);
 		req_tgts->ort_start_shard = shard_idx;
 		rc = obj_shards_2_fwtgts(obj, map_ver, tgt_set, shard_idx,
-					 shard_cnt, grp_nr, req_tgts, false);
+					 shard_cnt, grp_nr, req_tgts,
+					 OBJ_TGT_FLAG_LEADER_ONLY);
 		if (rc != 0)
 			D_ERROR("opc %d "DF_OID", obj_shards_2_fwtgts failed "
 				"%d.\n", opc, DP_OID(obj->cob_md.omd_id), rc);
 		break;
-	}
 	default:
 		D_ERROR("bad opc %d.\n", opc);
 		rc = -DER_INVAL;
@@ -2113,8 +2158,11 @@ do_dc_obj_fetch(tse_task_t *task, daos_obj_fetch_t *args,
 {
 	struct obj_auxi_args	*obj_auxi;
 	struct dc_object	*obj;
+	struct daos_oclass_attr	*oca;
 	unsigned int		 map_ver;
 	uint64_t		 dkey_hash;
+	uint64_t		 tgt_set = 0;
+	bool			 is_ec;
 	daos_epoch_t		 epoch;
 	int			 rc;
 
@@ -2132,6 +2180,12 @@ do_dc_obj_fetch(tse_task_t *task, daos_obj_fetch_t *args,
 		D_GOTO(out_task, rc);
 	}
 
+	is_ec = daos_oclass_is_ec(obj->cob_md.omd_id, &oca);
+	if (is_ec) {
+		ec_get_tgt_set(args->iods, args->nr, oca, false, &tgt_set);
+		D_ASSERT(tgt_set != 0);
+	}
+
 	rc = obj_reg_comp_cb(task, DAOS_OBJ_RPC_FETCH, map_ver, &obj_auxi,
 			     &obj, sizeof(obj));
 	if (rc != 0) {
@@ -2146,7 +2200,7 @@ do_dc_obj_fetch(tse_task_t *task, daos_obj_fetch_t *args,
 	else
 		obj_auxi->to_leader = (flags & DIOF_TO_LEADER) != 0;
 	rc = obj_req_get_tgts(obj, DAOS_OBJ_RPC_FETCH, (int *)&shard,
-			      dkey_hash, 0, map_ver, obj_auxi->to_leader,
+			      dkey_hash, tgt_set, map_ver, obj_auxi->to_leader,
 			      obj_auxi->spec_shard, &obj_auxi->req_tgts);
 	if (rc != 0)
 		D_GOTO(out_task, rc);
@@ -2193,6 +2247,7 @@ dc_obj_update(tse_task_t *task)
 	unsigned int		 map_ver;
 	uint64_t		 dkey_hash;
 	daos_epoch_t		 epoch;
+	bool			 is_ec;
 	int			 rc;
 
 	rc = obj_req_valid(args, DAOS_OBJ_RPC_UPDATE, &epoch);
@@ -2212,7 +2267,8 @@ dc_obj_update(tse_task_t *task)
 		goto out_task;
 	}
 
-	if (daos_oclass_is_ec(obj->cob_md.omd_id, &oca)) {
+	is_ec = daos_oclass_is_ec(obj->cob_md.omd_id, &oca);
+	if (is_ec) {
 		rc = ec_obj_update_encode(task, obj->cob_md.omd_id, oca,
 					  &tgt_set);
 		if (rc != 0) {
@@ -2235,7 +2291,7 @@ dc_obj_update(tse_task_t *task)
 	if (rc)
 		goto out_task;
 
-	if (DAOS_FAIL_CHECK(DAOS_DTX_COMMIT_SYNC))
+	if (is_ec || DAOS_FAIL_CHECK(DAOS_DTX_COMMIT_SYNC))
 		obj_auxi->flags |= ORF_DTX_SYNC;
 
 	D_DEBUG(DB_IO, "update "DF_OID" dkey_hash "DF_U64"\n",
@@ -2455,7 +2511,8 @@ obj_punch_internal(tse_task_t *task, enum obj_rpc_opc opc,
 	if (rc != 0)
 		goto out_task;
 
-	if (DAOS_FAIL_CHECK(DAOS_DTX_COMMIT_SYNC))
+	if (daos_oclass_is_ec(obj->cob_md.omd_id, NULL) ||
+	    DAOS_FAIL_CHECK(DAOS_DTX_COMMIT_SYNC))
 		obj_auxi->flags |= ORF_DTX_SYNC;
 
 	D_DEBUG(DB_IO, "punch "DF_OID" dkey %llu\n",
@@ -2713,9 +2770,9 @@ dc_obj_query_key(tse_task_t *api_task)
 	} else {
 		replicas = obj->cob_shards_nr;
 		/* For the specified dkey, only need to query one replica. */
-		shard_first = obj_dkeyhash2shard(obj, dkey_hash, map_ver,
-						 DAOS_OPC_OBJ_QUERY,
-						 obj_auxi->to_leader);
+		shard_first = obj_dkey2shard(obj, dkey_hash, map_ver,
+					     DAOS_OPC_OBJ_QUERY,
+					     obj_auxi->to_leader);
 		if (shard_first < 0)
 			D_GOTO(out_task, rc = shard_first);
 	}

--- a/src/object/obj_internal.h
+++ b/src/object/obj_internal.h
@@ -348,6 +348,11 @@ ec_parity_target(unsigned int ptgt_idx, unsigned int nr, daos_iod_t *iods,
 int
 ec_copy_iods(daos_iod_t *in, int nr, daos_iod_t **out);
 
+/* cli_ec.c */
+void
+ec_get_tgt_set(daos_iod_t *iods, unsigned int nr, struct daos_oclass_attr *oca,
+	       bool parify_include, uint64_t *tgt_set);
+
 void
 ec_free_iods(daos_iod_t *iods, int nr);
 

--- a/src/tests/suite/daos_epoch_io.c
+++ b/src/tests/suite/daos_epoch_io.c
@@ -305,14 +305,14 @@ fio_test_cb_uf(test_arg_t *arg, struct test_op_record *op, char **rbuf,
 				data_len = pwrite(fd, data, len, off);
 			else
 				data_len = pread(fd, data, len, off);
-			if (data_len != len) {
+			if (data_len != len && op->or_op == TEST_OP_UPDATE) {
 				print_message("fio %s/%s failed, len %zu "
 					      "got %zu.\n", dkey, akey,
 					      len, data_len);
 				D_GOTO(out, rc = -DER_IO);
 			}
 			data += len;
-			total_len += len;
+			total_len += data_len;
 		}
 	} else {
 		if (op->or_op == TEST_OP_UPDATE)
@@ -320,7 +320,7 @@ fio_test_cb_uf(test_arg_t *arg, struct test_op_record *op, char **rbuf,
 		else
 			total_len = pread(fd, buf, buf_size, 0);
 	}
-	if (total_len != buf_size) {
+	if (total_len != buf_size && op->or_op == TEST_OP_UPDATE) {
 		print_message("fio %s/%s failed, buf_size "DF_U64", total_len "
 			      "%zu.\n", dkey, akey, buf_size, total_len);
 		rc = -DER_IO;

--- a/src/tests/suite/io_conf/daos_io_conf_3
+++ b/src/tests/suite/io_conf/daos_io_conf_3
@@ -62,4 +62,5 @@ akey akey_3
 iod_size 32768
 obj_class ec
 
-update --tx 1 -r "[0, 2]"
+update --tx 1 -r "[0, 2] [5, 6] [10, 17]"
+fetch --tx 1 -r "[0, 18]"


### PR DESCRIPTION
Add basic EC obj fetch handling based on synchronous update commit.
1) IO patch changed for EC fetch
2) Reuse ORF_DTX_SYNC flag for EC obj
3) And minor change to tse.

This patch mainly to make it work (now the full stripe update/fetch can
pass the test), but some related details need to be refined by following
patches.

Signed-off-by: Xuezhao Liu <xuezhao.liu@intel.com>