### PR TITLE
DAOS-3265 control: fail server if spdk can't access specified devices

### DIFF
--- a/src/control/cmd/daos_server/storage.go
+++ b/src/control/cmd/daos_server/storage.go
@@ -100,10 +100,15 @@ func (cmd *storagePrepareCmd) Execute(args []string) error {
 		return err
 	}
 
-	svc, err := server.NewStorageControlService(cmd.log, server.NewConfiguration())
+	cfg := server.NewConfiguration()
+	svc, err := server.NewStorageControlService(cmd.log, cfg)
 	if err != nil {
-		return errors.WithMessage(err, "initialising ControlService")
+		return errors.WithMessage(err, "init control service")
 	}
+	if err := svc.Setup(cfg); err != nil {
+		return errors.Wrap(err, "setup control service")
+	}
+	defer svc.Teardown()
 
 	op := "Preparing"
 	if cmd.Reset {

--- a/src/control/cmd/daos_server/storage.go
+++ b/src/control/cmd/daos_server/storage.go
@@ -42,7 +42,7 @@ type storageScanCmd struct {
 }
 
 func (cmd *storageScanCmd) Execute(args []string) error {
-	svc, err := server.NewStorageControlService(cmd.log, server.NewConfiguration())
+	svc, err := server.DefaultStorageControlService(cmd.log, server.NewConfiguration())
 	if err != nil {
 		return errors.WithMessage(err, "failed to init ControlService")
 	}
@@ -101,7 +101,7 @@ func (cmd *storagePrepareCmd) Execute(args []string) error {
 	}
 
 	cfg := server.NewConfiguration()
-	svc, err := server.NewStorageControlService(cmd.log, cfg)
+	svc, err := server.DefaultStorageControlService(cmd.log, cfg)
 	if err != nil {
 		return errors.WithMessage(err, "init control service")
 	}

--- a/src/control/cmd/daos_server/storage.go
+++ b/src/control/cmd/daos_server/storage.go
@@ -105,10 +105,6 @@ func (cmd *storagePrepareCmd) Execute(args []string) error {
 	if err != nil {
 		return errors.WithMessage(err, "init control service")
 	}
-	if err := svc.Setup(cfg); err != nil {
-		return errors.Wrap(err, "setup control service")
-	}
-	defer svc.Teardown()
 
 	op := "Preparing"
 	if cmd.Reset {

--- a/src/control/server/config_test.go
+++ b/src/control/server/config_test.go
@@ -73,7 +73,13 @@ func uncommentServerConfig(t *testing.T, outFile string) {
 	}
 }
 
-// defaultMoc2kConfig returns configuration populated from blank config file
+// emptyMockConfig returns unpopulated configuration with a default mock
+// external interfacing implementation.
+func emptyMockConfig(t *testing.T) *Configuration {
+	return newDefaultConfiguration(defaultMockExt())
+}
+
+// defaultMockConfig returns configuration populated from blank config file
 // with mocked external interface.
 func defaultMockConfig(t *testing.T) *Configuration {
 	return mockConfigFromFile(t, defaultMockExt(), socketsExample)

--- a/src/control/server/ctl_storage.go
+++ b/src/control/server/ctl_storage.go
@@ -157,6 +157,10 @@ func (c *StorageControlService) GetScmState() (types.ScmState, error) {
 		return state, errors.Errorf("%s must be run as root or sudo", os.Args[0])
 	}
 
+	if err := c.scm.Setup(); err != nil {
+		return state, errors.WithMessage(err, "SCM setup")
+	}
+
 	if !c.scm.initialized {
 		return state, errors.New(msgScmNotInited)
 	}

--- a/src/control/server/ctl_storage_rpc_test.go
+++ b/src/control/server/ctl_storage_rpc_test.go
@@ -129,14 +129,14 @@ func TestStorageScan(t *testing.T) {
 			"spdk init fail", errExample, nil, nil, false, true,
 			defaultMockConfig(t),
 			pb.StorageScanResp{},
-			msgSpdkFailHasBdevs + ": " + msgSpdkInitFail + ": example failure",
+			msgBdevNotFound + ": missing [0000:81:00.0]",
 			"",
 		},
 		{
 			"spdk discover fail", nil, errExample, nil, false, true,
 			defaultMockConfig(t),
 			pb.StorageScanResp{},
-			msgSpdkFailHasBdevs + ": " + msgSpdkDiscoverFail + ": example failure",
+			msgBdevNotFound + ": missing [0000:81:00.0]",
 			"",
 		},
 		{
@@ -160,7 +160,7 @@ func TestStorageScan(t *testing.T) {
 			"all discover fail", nil, errExample, errExample, false, false,
 			defaultMockConfig(t),
 			pb.StorageScanResp{},
-			msgSpdkFailHasBdevs + ": " + msgSpdkDiscoverFail + ": example failure",
+			msgBdevNotFound + ": missing [0000:81:00.0]",
 			"",
 		},
 		{

--- a/src/control/server/ctl_storage_rpc_test.go
+++ b/src/control/server/ctl_storage_rpc_test.go
@@ -106,11 +106,14 @@ func TestStorageScan(t *testing.T) {
 		ipmctlDiscoverRet error
 		expNvmeInited     bool
 		expScmInited      bool
+		config            *Configuration
 		expResp           pb.StorageScanResp
-		errMsg            string
+		setupErrMsg       string
+		scanErrMsg        string
 	}{
 		{
 			"success", nil, nil, nil, true, true,
+			defaultMockConfig(t),
 			pb.StorageScanResp{
 				Nvme: &pb.ScanNvmeResp{
 					Ctrlrs: NvmeControllers{pbCtrlr},
@@ -120,10 +123,63 @@ func TestStorageScan(t *testing.T) {
 					Modules: ScmModules{pbModule},
 					State:   new(pb.ResponseState),
 				},
-			}, "",
+			}, "", "",
 		},
 		{
 			"spdk init fail", errExample, nil, nil, false, true,
+			defaultMockConfig(t),
+			pb.StorageScanResp{},
+			msgSpdkFailHasBdevs + ": " + msgSpdkInitFail + ": example failure",
+			"",
+		},
+		{
+			"spdk discover fail", nil, errExample, nil, false, true,
+			defaultMockConfig(t),
+			pb.StorageScanResp{},
+			msgSpdkFailHasBdevs + ": " + msgSpdkDiscoverFail + ": example failure",
+			"",
+		},
+		{
+			"ipmctl discover fail", nil, nil, errExample, true, false,
+			defaultMockConfig(t),
+			pb.StorageScanResp{
+				Nvme: &pb.ScanNvmeResp{
+					Ctrlrs: NvmeControllers{pbCtrlr},
+					State:  new(pb.ResponseState),
+				},
+				Scm: &pb.ScanScmResp{
+					State: &pb.ResponseState{
+						Error: "SCM storage scan: " + msgIpmctlDiscoverFail +
+							": example failure",
+						Status: pb.ResponseStatus_CTRL_ERR_SCM,
+					},
+				},
+			}, "", "",
+		},
+		{
+			"all discover fail", nil, errExample, errExample, false, false,
+			defaultMockConfig(t),
+			pb.StorageScanResp{},
+			msgSpdkFailHasBdevs + ": " + msgSpdkDiscoverFail + ": example failure",
+			"",
+		},
+		{
+			"success empty config", nil, nil, nil, true, true,
+			emptyMockConfig(t),
+			pb.StorageScanResp{
+				Nvme: &pb.ScanNvmeResp{
+					Ctrlrs: NvmeControllers{pbCtrlr},
+					State:  new(pb.ResponseState),
+				},
+				Scm: &pb.ScanScmResp{
+					Modules: ScmModules{pbModule},
+					State:   new(pb.ResponseState),
+				},
+			}, "", "",
+		},
+		{
+			"spdk init fail empty config", errExample, nil, nil, false, true,
+			emptyMockConfig(t),
 			pb.StorageScanResp{
 				Nvme: &pb.ScanNvmeResp{
 					State: &pb.ResponseState{
@@ -136,10 +192,11 @@ func TestStorageScan(t *testing.T) {
 					Modules: ScmModules{pbModule},
 					State:   new(pb.ResponseState),
 				},
-			}, "",
+			}, "", "",
 		},
 		{
-			"spdk discover fail", nil, errExample, nil, false, true,
+			"spdk discover fail empty config", nil, errExample, nil, false, true,
+			emptyMockConfig(t),
 			pb.StorageScanResp{
 				Nvme: &pb.ScanNvmeResp{
 					State: &pb.ResponseState{
@@ -152,10 +209,11 @@ func TestStorageScan(t *testing.T) {
 					Modules: ScmModules{pbModule},
 					State:   new(pb.ResponseState),
 				},
-			}, "",
+			}, "", "",
 		},
 		{
-			"ipmctl discover fail", nil, nil, errExample, true, false,
+			"ipmctl discover fail empty config", nil, nil, errExample, true, false,
+			emptyMockConfig(t),
 			pb.StorageScanResp{
 				Nvme: &pb.ScanNvmeResp{
 					Ctrlrs: NvmeControllers{pbCtrlr},
@@ -168,10 +226,11 @@ func TestStorageScan(t *testing.T) {
 						Status: pb.ResponseStatus_CTRL_ERR_SCM,
 					},
 				},
-			}, "",
+			}, "", "",
 		},
 		{
-			"all discover fail", nil, errExample, errExample, false, false,
+			"all discover fail empty config", nil, errExample, errExample, false, false,
+			emptyMockConfig(t),
 			pb.StorageScanResp{
 				Scm: &pb.ScanScmResp{
 					State: &pb.ResponseState{
@@ -187,7 +246,7 @@ func TestStorageScan(t *testing.T) {
 						Status: pb.ResponseStatus_CTRL_ERR_NVME,
 					},
 				},
-			}, "",
+			}, "", "",
 		},
 	}
 
@@ -196,7 +255,8 @@ func TestStorageScan(t *testing.T) {
 			log, buf := logging.NewTestLogger(t.Name())
 			defer ShowBufferOnFailure(t, buf)()
 
-			config := defaultMockConfig(t)
+			// test for both empty and default config cases
+			config := tt.config
 			cs := defaultMockControlService(t, log)
 			cs.scm = newMockScmStorage(log, config.ext, tt.ipmctlDiscoverRet,
 				[]ipmctl.DeviceDiscovery{module}, false, newMockPrepScm())
@@ -212,12 +272,20 @@ func TestStorageScan(t *testing.T) {
 				false)
 			_ = new(pb.StorageScanResp)
 
-			cs.Setup() // runs discovery for nvme & scm
+			// runs discovery for nvme & scm
+			err := cs.Setup(config)
+			if err != nil {
+				AssertEqual(t, err.Error(), tt.setupErrMsg, tt.desc)
+				return
+			}
+			AssertEqual(t, "", tt.setupErrMsg, tt.desc)
+
 			resp, err := cs.StorageScan(context.TODO(), &pb.StorageScanReq{})
 			if err != nil {
-				AssertEqual(t, err.Error(), tt.errMsg, tt.desc)
+				AssertEqual(t, err.Error(), tt.scanErrMsg, tt.desc)
+				return
 			}
-			AssertEqual(t, "", tt.errMsg, tt.desc)
+			AssertEqual(t, "", tt.scanErrMsg, tt.desc)
 
 			AssertEqual(t, len(cs.nvme.controllers), len(resp.Nvme.Ctrlrs), "unexpected number of controllers")
 			AssertEqual(t, len(cs.scm.modules), len(resp.Scm.Modules), "unexpected number of modules")
@@ -348,7 +416,10 @@ func TestStoragePrepare(t *testing.T) {
 					nil, nil, nil), false)
 			_ = new(pb.StoragePrepareResp)
 
-			cs.Setup() // runs discovery for nvme & scm
+			// runs discovery for nvme & scm
+			if err := cs.Setup(config); err != nil {
+				t.Fatal(err.Error() + tt.desc)
+			}
 			resp, err := cs.StoragePrepare(context.TODO(), &tt.inReq)
 			if err != nil {
 				AssertEqual(t, err.Error(), tt.errMsg, tt.desc)
@@ -525,9 +596,12 @@ func TestStorageFormat(t *testing.T) {
 			config := newMockStorageConfig(tt.mountRet, tt.unmountRet, tt.mkdirRet,
 				tt.removeRet, tt.sMount, tt.sClass, tt.sDevs, tt.sSize,
 				tt.bClass, tt.bDevs, tt.superblockExists, tt.isRoot)
-
 			cs := mockControlService(t, log, config)
-			cs.Setup() // init channel used for sync
+
+			// runs discovery for nvme & scm
+			if err := cs.Setup(config); err != nil {
+				t.Fatal(err.Error() + tt.desc)
+			}
 
 			mock := &mockStorageFormatServer{}
 			mockWg := new(sync.WaitGroup)
@@ -701,8 +775,14 @@ func TestStorageUpdate(t *testing.T) {
 			log, buf := logging.NewTestLogger(t.Name())
 			defer ShowBufferOnFailure(t, buf)()
 
-			cs := mockControlService(t, log, defaultMockConfig(t))
-			cs.Setup() // init channel used for sync
+			config := defaultMockConfig(t)
+			cs := mockControlService(t, log, config)
+
+			// runs discovery for nvme & scm
+			if err := cs.Setup(config); err != nil {
+				t.Fatal(err)
+			}
+
 			mock := &mockStorageUpdateServer{}
 
 			req := &pb.StorageUpdateReq{
@@ -711,7 +791,7 @@ func TestStorageUpdate(t *testing.T) {
 			}
 
 			if err := cs.StorageUpdate(req, mock); err != nil {
-				t.Fatal(err)
+				t.Fatal(err.Error() + tt.desc)
 			}
 
 			AssertEqual(

--- a/src/control/server/ctl_storage_rpc_test.go
+++ b/src/control/server/ctl_storage_rpc_test.go
@@ -257,7 +257,7 @@ func TestStorageScan(t *testing.T) {
 
 			// test for both empty and default config cases
 			config := tt.config
-			cs := defaultMockControlService(t, log)
+			cs := mockControlService(t, log, config)
 			cs.scm = newMockScmStorage(log, config.ext, tt.ipmctlDiscoverRet,
 				[]ipmctl.DeviceDiscovery{module}, false, newMockPrepScm())
 			cs.nvme = newMockNvmeStorage(
@@ -273,7 +273,7 @@ func TestStorageScan(t *testing.T) {
 			_ = new(pb.StorageScanResp)
 
 			// runs discovery for nvme & scm
-			err := cs.Setup(config)
+			err := cs.Setup()
 			if err != nil {
 				AssertEqual(t, err.Error(), tt.setupErrMsg, tt.desc)
 				return
@@ -417,7 +417,7 @@ func TestStoragePrepare(t *testing.T) {
 			_ = new(pb.StoragePrepareResp)
 
 			// runs discovery for nvme & scm
-			if err := cs.Setup(config); err != nil {
+			if err := cs.Setup(); err != nil {
 				t.Fatal(err.Error() + tt.desc)
 			}
 			resp, err := cs.StoragePrepare(context.TODO(), &tt.inReq)
@@ -599,7 +599,7 @@ func TestStorageFormat(t *testing.T) {
 			cs := mockControlService(t, log, config)
 
 			// runs discovery for nvme & scm
-			if err := cs.Setup(config); err != nil {
+			if err := cs.Setup(); err != nil {
 				t.Fatal(err.Error() + tt.desc)
 			}
 
@@ -779,7 +779,7 @@ func TestStorageUpdate(t *testing.T) {
 			cs := mockControlService(t, log, config)
 
 			// runs discovery for nvme & scm
-			if err := cs.Setup(config); err != nil {
+			if err := cs.Setup(); err != nil {
 				t.Fatal(err)
 			}
 

--- a/src/control/server/ctl_svc.go
+++ b/src/control/server/ctl_svc.go
@@ -45,7 +45,7 @@ type ControlService struct {
 }
 
 func NewControlService(l logging.Logger, h *IOServerHarness, cfg *Configuration) (*ControlService, error) {
-	scs, err := NewStorageControlService(l, cfg)
+	scs, err := DefaultStorageControlService(l, cfg)
 	if err != nil {
 		return nil, err
 	}

--- a/src/control/server/ctl_svc_test.go
+++ b/src/control/server/ctl_svc_test.go
@@ -26,6 +26,7 @@ package server
 import (
 	"testing"
 
+	"github.com/daos-stack/daos/src/control/drpc"
 	"github.com/daos-stack/daos/src/control/logging"
 	"github.com/daos-stack/daos/src/control/server/ioserver"
 	"github.com/daos-stack/daos/src/control/server/storage"
@@ -40,11 +41,11 @@ func mockControlService(t *testing.T, log logging.Logger, cfg *Configuration) *C
 	t.Helper()
 
 	cs := ControlService{
-		StorageControlService: StorageControlService{
-			log:  log,
-			nvme: defaultMockNvmeStorage(log, cfg.ext),
-			scm:  defaultMockScmStorage(log, cfg.ext),
-		},
+		StorageControlService: *NewStorageControlService(log,
+			defaultMockNvmeStorage(log, cfg.ext),
+			defaultMockScmStorage(log, cfg.ext),
+			cfg.Servers, &drpc.ClientConnection{},
+		),
 		harness: &IOServerHarness{
 			log: log,
 		},

--- a/src/control/server/server.go
+++ b/src/control/server/server.go
@@ -106,7 +106,7 @@ func Start(log *logging.LeveledLogger, cfg *Configuration) error {
 	if err != nil {
 		return errors.Wrap(err, "init control service")
 	}
-	if err := controlService.Setup(cfg); err != nil {
+	if err := controlService.Setup(); err != nil {
 		return errors.Wrap(err, "setup control service")
 	}
 	defer controlService.Teardown()

--- a/src/control/server/server.go
+++ b/src/control/server/server.go
@@ -104,9 +104,11 @@ func Start(log *logging.LeveledLogger, cfg *Configuration) error {
 	// Create and setup control service.
 	controlService, err := NewControlService(log, harness, cfg)
 	if err != nil {
-		return errors.Wrap(err, "init control server")
+		return errors.Wrap(err, "init control service")
 	}
-	controlService.Setup()
+	if err := controlService.Setup(cfg); err != nil {
+		return errors.Wrap(err, "setup control service")
+	}
 	defer controlService.Teardown()
 
 	// Create and start listener on management network.

--- a/src/control/server/storage/config.go
+++ b/src/control/server/storage/config.go
@@ -119,6 +119,10 @@ type BdevConfig struct {
 	Hostname    string    `yaml:"-"` // used when generating templates
 }
 
-func (nc *BdevConfig) Validate() error {
+func (bc *BdevConfig) Validate() error {
 	return nil
+}
+
+func (bc *BdevConfig) HasNvmeDevs() bool {
+	return bc.Class == BdevClassNvme && len(bc.DeviceList) > 0
 }

--- a/src/control/server/storage/config.go
+++ b/src/control/server/storage/config.go
@@ -123,6 +123,10 @@ func (bc *BdevConfig) Validate() error {
 	return nil
 }
 
-func (bc *BdevConfig) HasNvmeDevs() bool {
-	return bc.Class == BdevClassNvme && len(bc.DeviceList) > 0
+func (bc *BdevConfig) GetNvmeDevs() []string {
+	if bc.Class == BdevClassNvme {
+		return bc.DeviceList
+	}
+
+	return []string{}
 }

--- a/src/control/server/storage_nvme.go
+++ b/src/control/server/storage_nvme.go
@@ -58,6 +58,7 @@ const (
 	msgBdevNotInited          = "nvme storage not initialized"
 	msgBdevClassNotSupported  = "operation unsupported on bdev class"
 	msgSpdkInitFail           = "SPDK env init, has setup been run?"
+	msgSpdkFailHasBdevs       = "config specifies nvme and nvme setup failed"
 	msgSpdkDiscoverFail       = "SPDK controller discovery"
 	msgBdevFwrevStartMismatch = "controller fwrev unexpected before update"
 	msgBdevFwrevEndMismatch   = "controller fwrev unchanged after update"

--- a/src/control/server/storage_nvme.go
+++ b/src/control/server/storage_nvme.go
@@ -58,7 +58,6 @@ const (
 	msgBdevNotInited          = "nvme storage not initialized"
 	msgBdevClassNotSupported  = "operation unsupported on bdev class"
 	msgSpdkInitFail           = "SPDK env init, has setup been run?"
-	msgSpdkFailHasBdevs       = "config specifies nvme and nvme setup failed"
 	msgSpdkDiscoverFail       = "SPDK controller discovery"
 	msgBdevFwrevStartMismatch = "controller fwrev unexpected before update"
 	msgBdevFwrevEndMismatch   = "controller fwrev unchanged after update"
@@ -145,6 +144,16 @@ type nvmeStorage struct {
 	controllers types.NvmeControllers
 	initialized bool
 	formatted   bool
+}
+
+func (n *nvmeStorage) hasControllers(pciAddrs []string) (missing []string, ok bool) {
+	for _, addr := range pciAddrs {
+		if n.getController(addr) == nil {
+			missing = append(missing, addr)
+		}
+	}
+
+	return missing, len(missing) == 0
 }
 
 func (n *nvmeStorage) getController(pciAddr string) *pb.NvmeController {


### PR DESCRIPTION
If SPDK cannot access NVMe SSDs and SSD PCI addresses have been
specified in IO-server configs, don't attempt to start IO instances.

Notify the user of NVMe SSD PCI addresses specified in the config
that are not accessible through SPDK

This is a workaround for DAOS-3265 and prevents the issue from
occurring in known scenarios, it does not fix the root cause.

Signed-off-by: Tom Nabarro <tom.nabarro@intel.com>