### PR TITLE
Revert "DAOS-2799 iosrv: allow more xstream than the number of cores"

### DIFF
--- a/src/iosrv/init.c
+++ b/src/iosrv/init.c
@@ -207,18 +207,16 @@ dss_tgt_nr_get(int ncores, int nr)
 	if (nr_default == 0)
 		nr_default = 1;
 
-	/* accept the user required target number even if it's more than the
-	 * default available number calculated above, but inform the user that
-	 * creating more threads than #cores may have performance impact.
+	/* If user requires less target threads then set it as dss_tgt_nr,
+	 * if user requires more then uses the number calculated above
+	 * as creating more threads than #cores may hurt performance.
 	 */
-	if (nr_default < nr)
-		D_PRINT("%d target XS(xstream) requested exceeded the "
-			"available XS (%d) of %d cores, Will accept the "
-			"requested %d target XS with potential performance "
-			"impact\n", nr, nr_default, ncores, nr);
-
-	if (nr >= 1)
+	if (nr >= 1 && nr < nr_default)
 		nr_default = nr;
+
+	if (nr_default != nr)
+		D_PRINT("%d target XS(xstream) requested (#cores %d); "
+			"use (%d) target XS\n", nr, ncores, nr_default);
 
 	return nr_default;
 }

--- a/src/tests/ftest/container/basic_tx_test.yaml
+++ b/src/tests/ftest/container/basic_tx_test.yaml
@@ -21,7 +21,6 @@ faults: !mux
       fault_list: []
 server_config:
    name: daos_server
-   targets: 1
 poolparams:
    createmode:
      mode: 511

--- a/src/tests/ftest/container/delete.yaml
+++ b/src/tests/ftest/container/delete.yaml
@@ -7,7 +7,6 @@ hosts:
 timeout: 50
 server_config:
   name: daos_server
-  targets: 1
 createtests:
   createmode:
     mode: 511

--- a/src/tests/ftest/container/global_handle.yaml
+++ b/src/tests/ftest/container/global_handle.yaml
@@ -6,7 +6,6 @@ hosts:
 timeout: 50
 server_config:
   name: daos_server
-  targets: 1
 testparams:
   createmode:
     mode: 511

--- a/src/tests/ftest/container/simple_create_delete_test.yaml
+++ b/src/tests/ftest/container/simple_create_delete_test.yaml
@@ -5,7 +5,6 @@ hosts:
       - boro-A
 server_config:
    name: daos_server
-   targets: 1
 pool:
    createmode:
      mode: 511

--- a/src/tests/ftest/container/snapshot.yaml
+++ b/src/tests/ftest/container/snapshot.yaml
@@ -11,7 +11,6 @@ faults:
       fault_list: []
 server_config:
    name: daos_server
-   targets: 1
 poolparams:
    createmode:
      mode: 511

--- a/src/tests/ftest/control/dmg_nvme_scan_test.yaml
+++ b/src/tests/ftest/control/dmg_nvme_scan_test.yaml
@@ -6,7 +6,6 @@ hosts:
 server_config:
   name: daos_server
   port: 10001
-  targets: 1
 dmg:
   request: storage
   action: scan

--- a/src/tests/ftest/daos_test/daos_core_test.yaml
+++ b/src/tests/ftest/daos_test/daos_core_test.yaml
@@ -16,7 +16,6 @@ hosts:
 timeout: 600
 server_config:
   name: daos_server
-  targets: 1
 daos_tests:
   num_clients:
     num_clients: 1
@@ -26,7 +25,6 @@ daos_tests:
     test_d:
       daos_test: d
       test_name: DAOS degraded-mode tests
-      test_timeout: 1200
     test_m:
       daos_test: m
       test_name: Management tests
@@ -45,7 +43,7 @@ daos_tests:
     test_i:
       daos_test: i
       test_name: IO test
-      test_timeout: 1200
+      test_timeout: 900
     test_A:
       daos_test: A
       test_name: DAOS Object Array tests

--- a/src/tests/ftest/io/llnl_mpi4py_hdf5.yaml
+++ b/src/tests/ftest/io/llnl_mpi4py_hdf5.yaml
@@ -6,7 +6,6 @@ hosts:
 timeout: 1800
 server_config:
     name: daos_server
-    targets: 1
 pool:
     createmode:
         mode_RW:

--- a/src/tests/ftest/io/romio.yaml
+++ b/src/tests/ftest/io/romio.yaml
@@ -8,6 +8,5 @@ timeout: 240
 # romio test suite directory in CI nodes when available.
 server_config:
     name: daos_server
-    targets: 1
 romio:
     romio_repo: "/home/standan/mpiotest/build/src/mpi/romio/test/"

--- a/src/tests/ftest/network/cart_self_test.yaml
+++ b/src/tests/ftest/network/cart_self_test.yaml
@@ -6,7 +6,6 @@ hosts:
 timeout: 180
 server_config:
   name: daos_server
-  targets: 1
 testparams:
   repetitions: 1000
   endpoint: 0:0

--- a/src/tests/ftest/object/array_obj_test.yaml
+++ b/src/tests/ftest/object/array_obj_test.yaml
@@ -6,7 +6,6 @@ hosts:
 timeout: 100
 server_config:
    name: daos_server
-   targets: 1
 pool_params:
    createmode:
         mode: 511

--- a/src/tests/ftest/object/punch_test.yaml
+++ b/src/tests/ftest/object/punch_test.yaml
@@ -8,7 +8,6 @@ hosts:
 timeout: 100
 server_config:
    name: daos_server
-   targets: 1
 pool:
    createmode:
      mode: 511

--- a/src/tests/ftest/pool/attribute.yaml
+++ b/src/tests/ftest/pool/attribute.yaml
@@ -6,7 +6,6 @@ hosts:
 timeout: 120
 server_config:
   name: daos_server
-  targets: 1
 attrtests:
   createmode:
     mode: 511

--- a/src/tests/ftest/pool/connect_test.yaml
+++ b/src/tests/ftest/pool/connect_test.yaml
@@ -6,7 +6,6 @@ hosts:
     - boro-B
 server_config:
   name: daos_server
-  targets: 1
 tests:
   setnames: !mux
     validsetname:

--- a/src/tests/ftest/pool/destroy_tests.yaml
+++ b/src/tests/ftest/pool/destroy_tests.yaml
@@ -10,7 +10,6 @@ hosts:
     - boro-G
 server_config:
    name: daos_server
-   targets: 1
 timeout: 400
 pool:
    createmode:

--- a/src/tests/ftest/pool/evict_test.yaml
+++ b/src/tests/ftest/pool/evict_test.yaml
@@ -6,7 +6,6 @@ hosts:
     - boro-D
 server_config:
    name: daos_server
-   targets: 1
 timeout: 400
 pool:
    mode: 146

--- a/src/tests/ftest/pool/global_handle.yaml
+++ b/src/tests/ftest/pool/global_handle.yaml
@@ -6,7 +6,6 @@ hosts:
 timeout: 5000
 server_config:
   name: daos_server
-  targets: 1
 testparams:
   createmode:
     mode: 511

--- a/src/tests/ftest/pool/multiple_creates_test.yaml
+++ b/src/tests/ftest/pool/multiple_creates_test.yaml
@@ -6,7 +6,6 @@ hosts:
     - boro-B
 server_config:
    name: daos_server
-   targets: 1
 timeout: 240
 tests:
    modes:

--- a/src/tests/ftest/pool/pool_svc.yaml
+++ b/src/tests/ftest/pool/pool_svc.yaml
@@ -7,7 +7,6 @@ hosts:
             - boro-D
 server_config:
     name: daos_server
-    targets: 1
 timeout: 180
 createtests:
     createmode:

--- a/src/tests/ftest/security/pool_connect_init.yaml
+++ b/src/tests/ftest/security/pool_connect_init.yaml
@@ -6,7 +6,6 @@ hosts:
 timeout: 200
 server_config:
    name: daos_server
-   targets: 1
 pool:
   mode: 511
   name: daos_server

--- a/src/tests/ftest/server/metadata.yaml
+++ b/src/tests/ftest/server/metadata.yaml
@@ -10,7 +10,6 @@ hosts:
 timeout: 1800
 server_config:
    name: daos_server
-   targets: 1
 pool:
   createmode:
     mode: 511


### PR DESCRIPTION
Reverts daos-stack/daos#888