### PR TITLE
DAOS-3279 tests: Enhancing the command-utils.py classes.

### DIFF
--- a/src/tests/ftest/server/metadata.py
+++ b/src/tests/ftest/server/metadata.py
@@ -23,6 +23,7 @@
 '''
 from __future__ import print_function
 
+import os
 import traceback
 import uuid
 import threading
@@ -32,7 +33,8 @@ import avocado
 from apricot import TestWithServers, skipForTicket
 from agent_utils import run_agent, stop_agent
 from daos_api import DaosContainer, DaosApiError
-from ior_utils import IorCommand, IorFailed
+from ior_utils import IorCommand
+from command_utils import Orterun, CommandFailure
 from server_utils import run_server, stop_server
 from write_host_file import write_host_file
 from test_utils import TestPool
@@ -40,29 +42,24 @@ from test_utils import TestPool
 NO_OF_MAX_CONTAINER = 13180
 
 
-def ior_runner_thread(ior_cmd, uuids, mgr, attach, procs, hostfile, results):
+def ior_runner_thread(manager, uuids, results):
     """IOR run thread method.
 
     Args:
-        ior_cmd (IorCommand): [description]
+        manager (str): mpi job manager command
         uuids (list): [description]
-        mgr (str): mpi job manager command
-        attach (str): CART attach info path
-        procs (int): number of host processes
-        hostfile (str): file defining host names and slots
         results (Queue): queue for returning thread results
     """
     for index, cont_uuid in enumerate(uuids):
-        ior_cmd.daos_cont.update(cont_uuid, "ior.cont_uuid")
+        manager.job.daos_cont.update(cont_uuid, "ior.cont_uuid")
         try:
-            ior_cmd.run(mgr, attach, procs, hostfile, False)
-            results.put("PASS")
-
-        except IorFailed as error:
+            manager.run()
+        except CommandFailure as error:
             print(
                 "--- FAIL --- Thread-{0} Failed to run IOR {1}: "
                 "Exception {2}".format(
-                    index, "read" if "-r" in ior_cmd.flags.value else "write",
+                    index,
+                    "read" if "-r" in manager.job.flags.value else "write",
                     str(error)))
             results.put("FAIL")
 
@@ -224,17 +221,19 @@ class ObjectMetadata(TestWithServers):
                 ior_cmd.flags.value = self.params.get(
                     "F", "/run/ior/ior{}flags/".format(operation))
 
+                # Define the job manager for the IOR command
+                path = os.path.join(self.ompi_prefix, "bin")
+                manager = Orterun(ior_cmd, path)
+                env = ior_cmd.get_default_env(str(manager), self.tmp)
+                manager.setup_command(env, self.hostfile_clients, processes)
+
                 # Add a thread for these IOR arguments
                 threads.append(
                     threading.Thread(
                         target=ior_runner_thread,
                         kwargs={
-                            "ior_cmd": ior_cmd,
+                            "manager": manager,
                             "uuids": list_of_uuid_lists[index],
-                            "mgr": self.orterun,
-                            "attach": self.tmp,
-                            "hostfile": self.hostfile_clients,
-                            "procs": processes,
                             "results": self.out_queue}))
 
                 self.log.info(

--- a/src/tests/ftest/util/command_utils.py
+++ b/src/tests/ftest/util/command_utils.py
@@ -23,7 +23,16 @@
 """
 from __future__ import print_function
 
+import time
 import os
+import signal
+
+from avocado.utils import process
+
+
+class CommandFailure(Exception):
+    """Base exception for this module."""
+
 
 class BasicParameter(object):
     """A class for parameters whose values are read from a yaml file."""
@@ -95,13 +104,25 @@ class FormattedParameter(BasicParameter):
         if isinstance(self._default, bool) and self.value:
             return self._str_format
         elif not isinstance(self._default, bool) and self.value is not None:
-            return self._str_format.format(self.value)
+            if isinstance(self.value, (list, tuple)):
+                return " ".join(
+                    [self._str_format.format(value) for value in self.value])
+            else:
+                return self._str_format.format(self.value)
         else:
             return ""
 
 
 class ObjectWithParameters(object):
     """A class for an object with parameters."""
+
+    def __init__(self, namespace):
+        """Create a ObjectWithParameters object.
+
+        Args:
+            namespace (str): yaml namespace (path to parameters)
+        """
+        self.namespace = namespace
 
     def get_attribute_names(self, attr_type=None):
         """Get a sorted list of the names of the attr_type attributes.
@@ -128,7 +149,7 @@ class ObjectWithParameters(object):
         """
         return self.get_attribute_names(BasicParameter)
 
-    def get_params(self, test, path):
+    def get_params(self, test):
         """Get values for all of the command params from the yaml file.
 
         Sets each BasicParameter object's value to the yaml key that matches
@@ -141,24 +162,26 @@ class ObjectWithParameters(object):
 
         Args:
             test (Test): avocado Test object
-            path (str): yaml namespace.
         """
         for name in self.get_param_names():
-            getattr(self, name).get_yaml_value(name, test, path)
+            getattr(self, name).get_yaml_value(name, test, self.namespace)
 
 
 class CommandWithParameters(ObjectWithParameters):
     """A class for command with paramaters."""
 
-    def __init__(self, command, path=""):
+    def __init__(self, namespace, command, path=""):
         """Create a CommandWithParameters object.
 
         Uses Avocado's utils.process module to run a command str provided.
 
         Args:
-            path (str): path to location of command binary file
+            namespace (str): yaml namespace (path to parameters)
             command (str): string of the command to be executed.
+            path (str, optional): path to location of command binary file.
+                Defaults to "".
         """
+        super(CommandWithParameters, self).__init__(namespace)
         self._command = command
         self._path = path
 
@@ -177,3 +200,347 @@ class CommandWithParameters(ObjectWithParameters):
             if value != "":
                 params.append(value)
         return " ".join([os.path.join(self._path, self._command)] + params)
+
+
+class ExecutableCommand(CommandWithParameters):
+    """A class for command with paramaters."""
+
+    def __init__(self, namespace, command, path="", subprocess=False):
+        """Create a ExecutableCommand object.
+
+        Uses Avocado's utils.process module to run a command str provided.
+
+        Args:
+            namespace (str): yaml namespace (path to parameters)
+            command (str): string of the command to be executed.
+            path (str, optional): path to location of command binary file.
+                Defaults to "".
+            subprocess (bool, optional): whether the command is run as a
+                subprocess. Defaults to False.
+        """
+        super(ExecutableCommand, self).__init__(namespace, command, path)
+        self._process = None
+        self.run_as_subprocess = subprocess
+        self.timeout = None
+        self.verbose = True
+        self.env = None
+        self.sudo = False
+
+    def run(self):
+        """Run the command.
+
+        Raises:
+            CommandFailure: if there is an error running the command
+
+        """
+        if self.run_as_subprocess:
+            self._run_subprocess()
+        else:
+            self._run_process()
+
+    def _run_process(self):
+        """Run the command as a foreground process.
+
+        Raises:
+            CommandFailure: if there is an error running the command
+
+        """
+        command = self.__str__()
+        kwargs = {
+            "cmd": command,
+            "timeout": self.timeout,
+            "verbose": self.verbose,
+            "allow_output_check": "combined",
+            "shell": True,
+            "env": self.env,
+            "sudo": self.sudo,
+        }
+        try:
+            # Block until the command is complete or times out
+            process.run(**kwargs)
+
+        except process.CmdError as error:
+            # Command failed or possibly timed out
+            msg = "Error occurred running '{}': {}".format(command, error)
+            print(msg)
+            raise CommandFailure(msg)
+
+    def _run_subprocess(self):
+        """Run the command as a sub process.
+
+        Raises:
+            CommandFailure: if there is an error running the command
+
+        """
+        if self._process is None:
+            # Start the job manager command as a subprocess
+            kwargs = {
+                "cmd": self.__str__(),
+                "verbose": self.verbose,
+                "allow_output_check": "combined",
+                "shell": True,
+                "env": self.env,
+                "sudo": self.sudo,
+            }
+            self._process = process.SubProcess(**kwargs)
+            self._process.start()
+
+            # Deterime if the command has launched correctly using its
+            # check_subprocess_status() method.
+            if not self.check_subprocess_status(self._process):
+                msg = "Command '{}' did not launch correctly".format(self)
+                print(msg)
+                raise CommandFailure(msg)
+        else:
+            print("Process is already running")
+
+    def check_subprocess_status(self, process):
+        """Verify command status when called in a subprocess.
+
+        Optional method to provide a means for detecting successful command
+        execution when running the command as a subprocess.
+
+        Args:
+            process (process.SubProcess): sub process used to run the command
+
+        Returns:
+            bool: whether or not the command progress has been detected
+
+        """
+        return True
+
+    def stop(self):
+        """Stop the subprocess command.
+
+        Raises:
+            CommandFailure: if unable to stop
+
+        """
+        if self._process is not None:
+            # Use a list to send signals to the process with one second delays:
+            #   Interupt + wait 3 seconds
+            #   Terminate + wait 2 seconds
+            #   Quit + wait 1 second
+            #   Kill
+            signal_list = [
+                signal.SIGINT, None, None, None,
+                signal.SIGTERM, None, None,
+                signal.SIGQUIT, None,
+                signal.SIGKILL]
+
+            # Keep sending signals and or waiting while the process is alive
+            while self._process.poll() is None and signal_list:
+                signal_type = signal_list.pop(0)
+                if signal_type is not None:
+                    self._process.send_signal(signal_type)
+                if signal_list:
+                    time.sleep(1)
+            if not signal_list:
+                # Indicate an error if the process required a SIGKILL
+                raise CommandFailure("Error stopping '{}'".format(self))
+            self._process = None
+
+
+class EnvironmentVariables(dict):
+    """Dictionary of environment variable keys and values."""
+
+    def get_list(self):
+        """Get a list of environment variable assignments.
+
+        Returns:
+            list: a list of environment variable assignment (key=value) strings
+
+        """
+        return ["{}={}".format(key, value) for key, value in self.items()]
+
+    def get_export_str(self, separator=";"):
+        """Get the command to export all of the environment variables.
+
+        Args:
+            separator (str, optional): export command separtor.
+                Defaults to ";".
+
+        Returns:
+            str: a string of export commands for each environment variable
+
+        """
+        join_str = "{} export".format(separator)
+        return "export {}".format(join_str.join(self.get_list()))
+
+
+class JobManager(ExecutableCommand):
+    """A class for commands with parameters that manage other commands."""
+
+    def __init__(self, namespace, command, job, path="", subprocess=False):
+        """Create a JobManager object.
+
+        Args:
+            namespace (str): yaml namespace (path to parameters)
+            command (str): string of the command to be executed.
+            job (ExecutableCommand): command object to manage.
+            path (str, optional): path to location of command binary file.
+                Defaults to "".
+            subprocess (bool, optional): whether the command is run as a
+                subprocess. Defaults to False.
+        """
+        super(JobManager, self).__init__(namespace, command, path, subprocess)
+        self.job = job
+
+    def __str__(self):
+        """Return the command with all of its defined parameters as a string.
+
+        Returns:
+            str: the command with all the defined parameters
+
+        """
+        # Join the job manager command with the command to manage
+        job_manager_command = super(JobManager, self).__str__()
+        return "{} {}".format(job_manager_command, self.job)
+
+    def check_subprocess_status(self, process):
+        """Verify command status when called in a subprocess.
+
+        Args:
+            process (process.SubProcess): sub process used to run the command
+
+        Returns:
+            bool: whether or not the command progress has been detected
+
+        """
+        return self.job.check_subprocess_status(process)
+
+    def setup_command(self, env, hostfile, processes):
+        """Set up the job manager command with common inputs.
+
+        Args:
+            env (EnvironmentVariables): the environment variables to use with
+                the launch command
+            hostfile (str): file defining host names and slots
+            processes (int): number of host processes
+        """
+        pass
+
+
+class Orterun(JobManager):
+    """A class for the orterun job manager command."""
+
+    def __init__(self, job, path="", subprocess=False):
+        """Create a Orterun object.
+
+        Args:
+            job (ExecutableCommand): command object to manage.
+            path (str, optional): path to location of command binary file.
+                Defaults to "".
+            subprocess (bool, optional): whether the command is run as a
+                subprocess. Defaults to False.
+        """
+        super(Orterun, self).__init__(
+            "/run/orterun", "orterun", job, path, subprocess)
+
+        self.hostfile = FormattedParameter("--hostfile {}", None)
+        self.processes = FormattedParameter("-np {}", 1)
+        self.display_map = FormattedParameter("--display-map", True)
+        self.map_by = FormattedParameter("--map-by {}", "node")
+        self.export = FormattedParameter("-x {}", None)
+        self.enable_recovery = FormattedParameter("--enable-recovery", True)
+        self.report_uri = FormattedParameter("--report-uri {}", None)
+
+    def setup_command(self, env, hostfile, processes):
+        """Set up the orterun command with common inputs.
+
+        Args:
+            env (EnvironmentVariables): the environment variables to use with
+                the launch command
+            hostfile (str): file defining host names and slots
+            processes (int): number of host processes
+        """
+        # Setup the env for the job to export with the orterun command
+        if self.export.value is None:
+            self.export.value = []
+        self.export.value.extend(env.get_list())
+
+        # Setup the orterun command
+        self.hostfile.value = hostfile
+        self.processes.value = processes
+
+
+class Mpirun(JobManager):
+    """A class for the mpirun job manager command."""
+
+    def __init__(self, job, path="", subprocess=False):
+        """Create a Mpirun object.
+
+        Args:
+            job (ExecutableCommand): command object to manage.
+            path (str, optional): path to location of command binary file.
+                Defaults to "".
+            subprocess (bool, optional): whether the command is run as a
+                subprocess. Defaults to False.
+        """
+        super(Mpirun, self).__init__(
+            "/run/mpirun", "mpirun", job, path, subprocess)
+
+        self.hostfile = FormattedParameter("-hostfile {}", None)
+        self.processes = FormattedParameter("-np {}", 1)
+
+    def setup_command(self, env, hostfile, processes):
+        """Set up the mpirun command with common inputs.
+
+        Args:
+            env (EnvironmentVariables): the environment variables to use with
+                the launch command
+            hostfile (str): file defining host names and slots
+            processes (int): number of host processes
+        """
+        # Setup the env for the job to export with the mpirun command
+        if not self.env:
+            self.env = {}
+        self.env.update(env)
+
+        # Setup the orterun command
+        self.hostfile.value = hostfile
+        self.processes.value = processes
+
+
+class Srun(JobManager):
+    """A class for the srun job manager command."""
+
+    def __init__(self, job, path="", subprocess=False):
+        """Create a Srun object.
+
+        Args:
+            job (ExecutableCommand): command object to manage.
+            path (str, optional): path to location of command binary file.
+                Defaults to "".
+            subprocess (bool, optional): whether the command is run as a
+                subprocess. Defaults to False.
+        """
+        super(Srun, self).__init__("/run/srun", "srun", job, path, subprocess)
+
+        self.label = FormattedParameter("--label", False)
+        self.mpi = FormattedParameter("--mpi={}", None)
+        self.export = FormattedParameter("--export={}", None)
+        self.ntasks = FormattedParameter("--ntasks={}", None)
+        self.distribution = FormattedParameter("--distribution={}", None)
+        self.nodefile = FormattedParameter("--nodefile={}", None)
+
+    def setup_command(self, env, hostfile, processes):
+        """Set up the srun command with common inputs.
+
+        Args:
+            env (EnvironmentVariables): the environment variables to use with
+                the launch command
+            hostfile (str): file defining host names and slots
+            processes (int): number of host processes
+        """
+        # Setup the env for the job to export with the srun command
+        self.export.value = ",".join(["ALL"] + env.get_list())
+
+        # Setup the srun command
+        self.label.value = True
+        self.mpi.value = "pmi2"
+        if processes is not None:
+            self.ntasks.value = processes
+            self.distribution.value = "cyclic"
+        if hostfile is not None:
+            self.nodefile.value = hostfile

--- a/src/tests/ftest/util/command_utils.py
+++ b/src/tests/ftest/util/command_utils.py
@@ -315,6 +315,9 @@ class ExecutableCommand(CommandWithParameters):
             bool: whether or not the command progress has been detected
 
         """
+        print(
+            "Checking status of the {} command in {}".format(
+                self._command, subprocess))
         return True
 
     def stop(self):

--- a/src/tests/ftest/util/command_utils.py
+++ b/src/tests/ftest/util/command_utils.py
@@ -302,14 +302,14 @@ class ExecutableCommand(CommandWithParameters):
         else:
             print("Process is already running")
 
-    def check_subprocess_status(self, process):
+    def check_subprocess_status(self, subprocess):
         """Verify command status when called in a subprocess.
 
         Optional method to provide a means for detecting successful command
         execution when running the command as a subprocess.
 
         Args:
-            process (process.SubProcess): sub process used to run the command
+            subprocess (process.SubProcess): subprocess used to run the command
 
         Returns:
             bool: whether or not the command progress has been detected
@@ -405,17 +405,17 @@ class JobManager(ExecutableCommand):
         job_manager_command = super(JobManager, self).__str__()
         return "{} {}".format(job_manager_command, self.job)
 
-    def check_subprocess_status(self, process):
+    def check_subprocess_status(self, subprocess):
         """Verify command status when called in a subprocess.
 
         Args:
-            process (process.SubProcess): sub process used to run the command
+            subprocess (process.SubProcess): subprocess used to run the command
 
         Returns:
             bool: whether or not the command progress has been detected
 
         """
-        return self.job.check_subprocess_status(process)
+        return self.job.check_subprocess_status(subprocess)
 
     def setup_command(self, env, hostfile, processes):
         """Set up the job manager command with common inputs.

--- a/src/tests/ftest/util/dmg_utils.py
+++ b/src/tests/ftest/util/dmg_utils.py
@@ -23,17 +23,16 @@
 """
 from __future__ import print_function
 
-from command_utils import CommandWithParameters
+from command_utils import ExecutableCommand
 from command_utils import BasicParameter, FormattedParameter
-from avocado.utils import process
 
 
-class DmgCommand(CommandWithParameters):
+class DmgCommand(ExecutableCommand):
     """Defines a object representing a dmg (or daos_shell) command."""
 
     def __init__(self, path):
         """Create a dmg Command object."""
-        super(DmgCommand, self).__init__("daos_shell", path)
+        super(DmgCommand, self).__init__("/run/dmg/*", "daos_shell", path)
 
         self.request = BasicParameter("{}")
         self.action = BasicParameter("{}")
@@ -65,39 +64,3 @@ class DmgCommand(CommandWithParameters):
         names = self.get_attribute_names(FormattedParameter)
         names.extend(["request", "action"])
         return names
-
-    def get_params(self, test, path="/run/dmg/*"):
-        """Get values for all of the dmg command params using a yaml file.
-
-        Sets each BasicParameter object's value to the yaml key that matches
-        the assigned name of the BasicParameter object in this class. For
-        example, the self.block_size.value will be set to the value in the yaml
-        file with the key 'block_size'.
-
-        Args:
-            test (Test): avocado Test object
-            path (str, optional): yaml namespace. Defaults to "/run/dmg/*".
-
-        """
-        super(DmgCommand, self).get_params(test, path)
-
-    def run(self, timeout=None, verbose=True, env=None, sudo=False):
-        """ Run the dmg command.
-
-        Args:
-            timeout (int, optional): timeout in seconds. Defaults to None.
-            verbose (bool, optional): display command output. Defaults to True.
-            env (dict, optional): env for the command. Defaults to None.
-            sudo (bool, optional): sudo will be prepended to the command.
-                Defaults to False.
-
-        Raises:
-            process.CmdError: Avocado command exception
-
-        Returns:
-            process.CmdResult: CmdResult object containing the results from
-            the command.
-
-        """
-        return process.run(self.__str__(), timeout, verbose, env=env,
-                           shell=True, sudo=sudo)

--- a/src/tests/ftest/util/ior_utils.py
+++ b/src/tests/ftest/util/ior_utils.py
@@ -26,14 +26,11 @@ from __future__ import print_function
 import re
 import uuid
 
-from avocado.utils.process import run, CmdError
-from command_utils import FormattedParameter, CommandWithParameters
+from command_utils import FormattedParameter, ExecutableCommand
+from command_utils import EnvironmentVariables, CommandFailure
 
 
-class IorFailed(Exception):
-    """Raise if Ior failed."""
-
-class IorCommand(CommandWithParameters):
+class IorCommand(ExecutableCommand):
     """Defines a object for executing an IOR command.
 
     Example:
@@ -41,14 +38,16 @@ class IorCommand(CommandWithParameters):
         >>> ior_cmd = IorCommand()
         >>> ior_cmd.get_params(self)
         >>> ior_cmd.set_daos_params(self.server_group, self.pool)
-        >>> ior_cmd.run(
-                self.basepath, len(self.hostlist_clients),
-                self.hostfile_clients)
+        >>> mpirun = Mpirun()
+        >>> env = self.ior_cmd.get_default_env(self.tmp, self.client_log)
+        >>> processes = len(self.hostlist_clients)
+        >>> mpirun.setup_command(env, self.hostfile_clients, processes)
+        >>> mpirun.run()
     """
 
     def __init__(self):
         """Create an IorCommand object."""
-        super(IorCommand, self).__init__("ior")
+        super(IorCommand, self).__init__("/run/ior/*", "ior")
 
         # Flags
         self.flags = FormattedParameter("{}")
@@ -124,21 +123,6 @@ class IorCommand(CommandWithParameters):
 
         return param_names
 
-    def get_params(self, test, path="/run/ior/*"):
-        """Get values for all of the ior command params using a yaml file.
-
-        Sets each BasicParameter object's value to the yaml key that matches
-        the assigned name of the BasicParameter object in this class. For
-        example, the self.block_size.value will be set to the value in the yaml
-        file with the key 'block_size'.
-
-        Args:
-            test (Test): avocado Test object
-            path (str, optional): yaml namespace. Defaults to "/run/ior/*".
-
-        """
-        super(IorCommand, self).get_params(test, path)
-
     def set_daos_params(self, group, pool, cont_uuid=None, display=True):
         """Set the IOR parameters for the DAOS group, pool, and container uuid.
 
@@ -162,7 +146,6 @@ class IorCommand(CommandWithParameters):
             pool (DaosPool): DAOS pool API object
             display (bool, optional): print updated params. Defaults to True.
         """
-        #self.daos_pool.value = pool.uuid
         self.daos_pool.update(
             pool.pool.get_uuid_str(), "daos_pool" if display else None)
         self.set_daos_svcl_param(pool, display)
@@ -189,6 +172,9 @@ class IorCommand(CommandWithParameters):
         Returns:
             int: total number of bytes written
 
+        Raises:
+            CommandFailure: if there is an error obtaining the aggregate total
+
         """
         power = {"k": 1, "m": 2, "g": 3, "t": 4}
         total = processes
@@ -203,12 +189,12 @@ class IorCommand(CommandWithParameters):
                         if key in power:
                             total *= 1024**power[key]
                         else:
-                            raise IorFailed(
+                            raise CommandFailure(
                                 "Error obtaining the IOR aggregate total from "
                                 "the {} - bad key: value: {}, split: {}, "
                                 "key: {}".format(name, item, sub_item, key))
                 else:
-                    raise IorFailed(
+                    raise CommandFailure(
                         "Error obtaining the IOR aggregate total from the {}: "
                         "value: {}, split: {}".format(name, item, sub_item))
 
@@ -225,110 +211,30 @@ class IorCommand(CommandWithParameters):
 
         return total
 
-    def get_launch_command(self, manager, attach_info, processes, hostfile,
-                           client_log=None):
-        """Get the process launch command used to run IOR.
+    def get_default_env(self, manager_cmd, attach_info, log_file=None):
+        """Get the default enviroment settings for running IOR.
 
         Args:
-            manager (str): mpi job manager command
+            manager_cmd (str): job manager command
             attach_info (str): CART attach info path
-            mpi_prefix (str): path for the mpi launch command
-            processes (int): number of host processes
-            hostfile (str): file defining host names and slots
-            client_log (str, optional): client log dir
-
-        Raises:
-            IorFailed: if an error occured building the IOR command
+            log_file (str, optional): log file. Defaults to None.
 
         Returns:
-            str: ior launch command
+            EnvironmentVariables: a dictionary of environment names and values
 
         """
-        print("Getting launch command for {}".format(manager))
-        exports = ""
-        env = {
-            "CRT_ATTACH_INFO_PATH": attach_info,
-            "MPI_LIB": "\"\"",
-            "DAOS_SINGLETON_CLI": 1,
-        }
-        if client_log:
-            env.update({"D_LOG_FILE": client_log})
+        env = EnvironmentVariables()
+        env["CRT_ATTACH_INFO_PATH"] = attach_info
+        env["MPI_LIB"] = "\"\""
+        env["DAOS_SINGLETON_CLI"] = 1
+        env["FI_PSM2_DISCONNECT"] = 1
+        if log_file:
+            env["D_LOG_FILE"] = log_file
 
-        if manager.endswith("mpirun"):
-            env.update({
-                "DAOS_POOL": self.daos_pool.value,
-                "DAOS_SVCL": self.daos_svcl.value,
-                "FI_PSM2_DISCONNECT": 1,
-                "IOR_HINT__MPI__romio_daos_obj_class":
-                self.daos_oclass.value
-            })
-            assign_env = ["{}={}".format(key, val) for key, val in env.items()]
-            exports = "export {}; ".format("; export ".join(assign_env))
-            args = [
-                "-np {}".format(processes),
-                "-hostfile {}".format(hostfile),
-                # "-map-by node",
-            ]
+        if "mpirun" in manager_cmd or "srun" in manager_cmd:
+            env["DAOS_POOL"] = self.daos_pool.value
+            env["DAOS_SVCL"] = self.daos_svcl.value
+            env["FI_PSM2_DISCONNECT"] = 1
+            env["IOR_HINT__MPI__romio_daos_obj_class"] = self.daos_oclass.value
 
-        elif manager.endswith("orterun"):
-            assign_env = ["{}={}".format(key, val) for key, val in env.items()]
-            args = [
-                "-np {}".format(processes),
-                "-hostfile {}".format(hostfile),
-                "-map-by node",
-            ]
-            args.extend(["-x {}".format(assign) for assign in assign_env])
-
-        elif manager.endswith("srun"):
-            env.update({
-                "DAOS_POOL": self.daos_pool.value,
-                "DAOS_SVCL": self.daos_svcl.value,
-                "FI_PSM2_DISCONNECT": 1,
-            })
-            assign_env = ["{}={}".format(key, val) for key, val in env.items()]
-            args = [
-                "-l",
-                "--mpi=pmi2",
-                "--export={}".format(",".join(["ALL"] + assign_env)),
-            ]
-            if processes is not None:
-                args.append("--ntasks={}".format(processes))
-                args.append("--distribution=cyclic")            # --map-by node
-            if hostfile is not None:
-                args.append("--nodefile={}".format(hostfile))
-
-        else:
-            raise IorFailed("Unsupported job manager: {}".format(manager))
-
-        return "{}{} {} {}".format(
-            exports, manager, " ".join(args), self.__str__())
-
-    def run(self, manager, attach_info, processes, hostfile, display=True,
-            client_log=None):
-        """Run the IOR command.
-
-        Args:
-            manager (str): mpi job manager command
-            attach_info (str): CART attach info path
-            processes (int): number of host processes
-            hostfile (str): file defining host names and slots
-            display (bool, optional): print IOR output to the console.
-                Defaults to True.
-            client_log (str, optional): client log dir
-
-        Raises:
-            IorFailed: if an error occured runnig the IOR command
-
-        """
-        command = self.get_launch_command(
-            manager, attach_info, processes, hostfile, client_log)
-        if display:
-            print("<IOR CMD>: {}".format(command))
-
-        # Run IOR
-        try:
-            run(command, allow_output_check="combined", shell=True)
-
-        except CmdError as error:
-            print("<IorRunFailed> Exception occurred: {}".format(error))
-            raise IorFailed("IOR Run process Failed: {}".format(error))
+        return env

--- a/src/tests/ftest/util/mdtest_utils.py
+++ b/src/tests/ftest/util/mdtest_utils.py
@@ -27,17 +27,19 @@ from __future__ import print_function
 import uuid
 
 from avocado.utils.process import run, CmdError
-from command_utils import FormattedParameter, CommandWithParameters
+from command_utils import FormattedParameter, ExecutableCommand
+
 
 class MdtestFailed(Exception):
-    """Raise if mdtest failed"""
+    """Raise if mdtest failed."""
 
-class MdtestCommand(CommandWithParameters):
+
+class MdtestCommand(ExecutableCommand):
     """Defines a object representing a mdtest command."""
 
     def __init__(self):
         """Create an MdtestCommand object."""
-        super(MdtestCommand, self).__init__("mdtest")
+        super(MdtestCommand, self).__init__("/run/mdtest/*", "mdtest")
         self.flags = FormattedParameter("{}")   # mdtest flags
         # Optional arguments
         #  -a=STRING             API for I/O [POSIX|DUMMY]
@@ -127,21 +129,10 @@ class MdtestCommand(CommandWithParameters):
         self.dfs_group = FormattedParameter("--dfs.group {}")
         self.dfs_destroy = FormattedParameter("--dfs.destroy", True)
 
-    def get_params(self, test, path="/run/mdtest/*"):
-        """Get values for all of the mdtest command params using a yaml file.
-        Sets each BasicParameter object's value to the yaml key that matches
-        the assigned name of the BasicParameter object in this class. For
-        example, the self.depth.value will be set to the value in the yaml
-        file with the key 'depth'.
-        Args:
-            test (Test): avocado Test object
-            path (str, optional): yaml namespace. Defaults to "/run/mdtest/*".
-        """
-        super(MdtestCommand, self).get_params(test, path)
-
     def set_daos_params(self, group, pool, cont_uuid=None, display=True):
         """Set the Mdtest parameters for the DAOS group, pool, and container
            uuid.
+
         Args:
             group (str): DAOS server group name
             pool (TestPool): DAOS test pool object
@@ -157,6 +148,7 @@ class MdtestCommand(CommandWithParameters):
 
     def set_daos_pool_params(self, pool, display=True):
         """Set the Mdtest parameters that are based on a DAOS pool.
+
         Args:
             pool (TestPool): DAOS test pool object
             display (bool, optional): print updated params. Defaults to True.
@@ -166,7 +158,8 @@ class MdtestCommand(CommandWithParameters):
         self.set_daos_svcl_param(pool, display)
 
     def set_daos_svcl_param(self, pool, display=True):
-        """Set the Mdtest daos_svcl param from the ranks of a DAOS pool object
+        """Set the Mdtest daos_svcl param from the ranks of a DAOS pool object.
+
         Args:
             pool (TestPool): DAOS test pool object
             display (bool, optional): print updated params. Defaults to True.
@@ -179,7 +172,8 @@ class MdtestCommand(CommandWithParameters):
 
     def get_launch_command(self, manager, attach_info, processes, hostfile,
                            client_log=None):
-        """Get the process launch command used to run Mdtest
+        """Get the process launch command used to run Mdtest.
+
         Args:
             manager (str): mpi job manager command
             attach_info (str): CART attach info path
@@ -187,10 +181,13 @@ class MdtestCommand(CommandWithParameters):
             processes (int): number of host processes
             hostfile (str): file defining host names and slots
             client_log (str, optional): client log dir
+
         Raises:
             MdtestFailed: if an error occured building the Mdtest command
+
         Returns:
             str: mdtest launch command
+
         """
         print("Getting launch command for {}".format(manager))
         exports = ""
@@ -249,6 +246,7 @@ class MdtestCommand(CommandWithParameters):
     def run(self, manager, attach_info, processes, hostfile, display=True,
             client_log=None):
         """Run the Mdtest command.
+
         Args:
             manager (str): mpi job manager command
             attach_info (str): CART attach info path
@@ -260,6 +258,7 @@ class MdtestCommand(CommandWithParameters):
 
         Raises:
             MdtestFailed: if an error occured runnig the Mdtest command
+
         """
         command = self.get_launch_command(
             manager, attach_info, processes, hostfile, client_log)

--- a/src/tests/ftest/util/mdtest_utils.py
+++ b/src/tests/ftest/util/mdtest_utils.py
@@ -26,12 +26,8 @@ from __future__ import print_function
 
 import uuid
 
-from avocado.utils.process import run, CmdError
 from command_utils import FormattedParameter, ExecutableCommand
-
-
-class MdtestFailed(Exception):
-    """Raise if mdtest failed."""
+from command_utils import EnvironmentVariables
 
 
 class MdtestCommand(ExecutableCommand):
@@ -130,8 +126,7 @@ class MdtestCommand(ExecutableCommand):
         self.dfs_destroy = FormattedParameter("--dfs.destroy", True)
 
     def set_daos_params(self, group, pool, cont_uuid=None, display=True):
-        """Set the Mdtest parameters for the DAOS group, pool, and container
-           uuid.
+        """Set the Mdtest params for the DAOS group, pool, and container uuid.
 
         Args:
             group (str): DAOS server group name
@@ -170,105 +165,29 @@ class MdtestCommand(ExecutableCommand):
                 for index in range(pool.pool.svc.rl_nr)]])
         self.dfs_svcl.update(svcl, "dfs_svcl" if display else None)
 
-    def get_launch_command(self, manager, attach_info, processes, hostfile,
-                           client_log=None):
-        """Get the process launch command used to run Mdtest.
+    def get_default_env(self, manager_cmd, attach_info, log_file=None):
+        """Get the default enviroment settings for running mdtest.
 
         Args:
-            manager (str): mpi job manager command
+            manager_cmd (str): job manager command
             attach_info (str): CART attach info path
-            mpi_prefix (str): path for the mpi launch command
-            processes (int): number of host processes
-            hostfile (str): file defining host names and slots
-            client_log (str, optional): client log dir
-
-        Raises:
-            MdtestFailed: if an error occured building the Mdtest command
+            log_file (str, optional): log file. Defaults to None.
 
         Returns:
-            str: mdtest launch command
+            EnvironmentVariables: a dictionary of environment names and values
 
         """
-        print("Getting launch command for {}".format(manager))
-        exports = ""
-        env = {
-            "CRT_ATTACH_INFO_PATH": attach_info,
-            "MPI_LIB": "\"\"",
-            "DAOS_SINGLETON_CLI": 1,
-            "D_LOG_FILE": client_log
-        }
-        if manager.endswith("mpirun"):
-            env.update({
-                "DAOS_POOL": self.dfs_pool_uuid.value,
-                "DAOS_SVCL": self.dfs_svcl.value,
-                "FI_PSM2_DISCONNECT": 1,
-            })
-            assign_env = ["{}={}".format(key, val) for key, val in env.items()]
-            exports = "export {}; ".format("; export ".join(assign_env))
-            args = [
-                "-np {}".format(processes),
-                "-hostfile {}".format(hostfile),
-            ]
+        env = EnvironmentVariables()
+        env["CRT_ATTACH_INFO_PATH"] = attach_info
+        env["MPI_LIB"] = "\"\""
+        env["DAOS_SINGLETON_CLI"] = 1
+        env["FI_PSM2_DISCONNECT"] = 1
+        if log_file:
+            env["D_LOG_FILE"] = log_file
 
-        elif manager.endswith("orterun"):
-            assign_env = ["{}={}".format(key, val) for key, val in env.items()]
-            args = [
-                "-np {}".format(processes),
-                "-hostfile {}".format(hostfile),
-                "-map-by node",
-            ]
-            args.extend(["-x {}".format(assign) for assign in assign_env])
+        if "mpirun" in manager_cmd or "srun" in manager_cmd:
+            env["DAOS_POOL"] = self.dfs_pool_uuid.value
+            env["DAOS_SVCL"] = self.dfs_svcl.value
+            env["FI_PSM2_DISCONNECT"] = 1
 
-        elif manager.endswith("srun"):
-            env.update({
-                "DAOS_POOL": self.dfs_pool_uuid.value,
-                "DAOS_SVCL": self.dfs_svcl.value,
-                "FI_PSM2_DISCONNECT": 1,
-            })
-            assign_env = ["{}={}".format(key, val) for key, val in env.items()]
-            args = [
-                "-l",
-                "--mpi=pmi2",
-                "--export={}".format(",".join(["ALL"] + assign_env)),
-            ]
-            if processes is not None:
-                args.append("--ntasks={}".format(processes))
-                args.append("--distribution=cyclic")
-            if hostfile is not None:
-                args.append("--nodefile={}".format(hostfile))
-
-        else:
-            raise MdtestFailed("Unsupported job manager: {}".format(manager))
-
-        return "{}{} {} {}".format(
-            exports, manager, " ".join(args), self.__str__())
-
-    def run(self, manager, attach_info, processes, hostfile, display=True,
-            client_log=None):
-        """Run the Mdtest command.
-
-        Args:
-            manager (str): mpi job manager command
-            attach_info (str): CART attach info path
-            processes (int): number of host processes
-            hostfile (str): file defining host names and slots
-            display (bool, optional): print Mdtest output to the console.
-                Defaults to True.
-            client_log (str, optional): client log dir
-
-        Raises:
-            MdtestFailed: if an error occured runnig the Mdtest command
-
-        """
-        command = self.get_launch_command(
-            manager, attach_info, processes, hostfile, client_log)
-        if display:
-            print("<MDTEST CMD>: {}".format(command))
-
-        # Run Mdtest
-        try:
-            run(command, allow_output_check="combined", shell=True)
-
-        except CmdError as error:
-            print("<MdtestRunFailed> Exception occurred: {}".format(error))
-            raise MdtestFailed("Mdtest Run process Failed: {}".format(error))
+        return env

--- a/src/tests/ftest/util/server_utils.py
+++ b/src/tests/ftest/util/server_utils.py
@@ -168,24 +168,23 @@ def run_server(hostfile, setname, basepath, uri_path=None, env_dict=None,
         orterun_bin = os.path.join(build_vars["OMPI_PREFIX"], "bin", "orterun")
         daos_srv_bin = os.path.join(build_vars["PREFIX"], "bin", "daos_server")
 
-        env_args = []
+        server_cmd = [orterun_bin, "--np", str(server_count)]
+        if uri_path is not None:
+            server_cmd.extend(["--report-uri", uri_path])
+        server_cmd.extend(["--hostfile", hostfile, "--enable-recovery"])
+
         # Add any user supplied environment
         if env_dict is not None:
             for key, value in env_dict.items():
                 os.environ[key] = value
-                env_args.extend(["-x", "{}={}".format(key, value)])
+                server_cmd.extend(["-x", "{}={}".format(key, value)])
+
         # the remote orte needs to know where to find daos, in the
         # case that it's not in the system prefix
         # but it should already be in our PATH, so just pass our
         # PATH along to the remote
         if build_vars["PREFIX"] != "/usr":
-            env_args.extend(["-x", "PATH"])
-
-        server_cmd = [orterun_bin, "--np", str(server_count)]
-        if uri_path is not None:
-            server_cmd.extend(["--report-uri", uri_path])
-        server_cmd.extend(["--hostfile", hostfile, "--enable-recovery"])
-        server_cmd.extend(env_args)
+            server_cmd.extend(["-x", "PATH"])
 
         # Run server in insecure mode until Certificate tests are in place
         server_cmd.extend([daos_srv_bin,

--- a/src/tests/ftest/util/server_utils.py
+++ b/src/tests/ftest/util/server_utils.py
@@ -208,7 +208,7 @@ def run_server(hostfile, setname, basepath, uri_path=None, env_dict=None,
         fcntl.fcntl(fdesc, fcntl.F_SETFL, fstat | os.O_NONBLOCK)
         timeout = 600
         start_time = time.time()
-        result = 0
+        matches = 0
         pattern = "DAOS I/O server.*started"
         expected_data = "Starting Servers\n"
         while True:
@@ -221,11 +221,11 @@ def run_server(hostfile, setname, basepath, uri_path=None, env_dict=None,
                 continue
             match = re.findall(pattern, output)
             expected_data += output
-            result += len(match)
-            if not output or result == server_count or \
+            matches += len(match)
+            if not output or matches == server_count or \
                time.time() - start_time > timeout:
                 print("<SERVER>: {}".format(expected_data))
-                if result != server_count:
+                if matches != server_count:
                     raise ServerFailed("Server didn't start!")
                 break
         print(

--- a/src/tests/ftest/util/test_utils.py
+++ b/src/tests/ftest/util/test_utils.py
@@ -82,13 +82,15 @@ class TestDaosApiBase(ObjectWithParameters):
     # pylint: disable=too-few-public-methods
     """A base class for functional testing of DaosPools objects."""
 
-    def __init__(self, cb_handler=None):
+    def __init__(self, namespace, cb_handler=None):
         """Create a TestDaosApi object.
 
         Args:
+            namespace (str): yaml namespace (path to parameters)
             cb_handler (CallbackHandler, optional): callback object to use with
                 the API methods. Defaults to None.
         """
+        super(TestDaosApiBase, self).__init__(namespace)
         self.cb_handler = cb_handler
 
     def _call_method(self, method, kwargs):
@@ -118,7 +120,7 @@ class TestPool(TestDaosApiBase):
             cb_handler (CallbackHandler, optional): callback object to use with
                 the API methods. Defaults to None.
         """
-        super(TestPool, self).__init__(cb_handler)
+        super(TestPool, self).__init__("/run/pool/*", cb_handler)
         self.context = context
         self.log = log
         self.uid = os.geteuid()
@@ -137,15 +139,6 @@ class TestPool(TestDaosApiBase):
         self.info = None
         self.svc_ranks = None
         self.connected = False
-
-    def get_params(self, test, path="/run/pool/*"):
-        """Get the pool parameters from the yaml file.
-
-        Args:
-            test (Test): avocado Test object
-            path (str, optional): yaml namespace. Defaults to "/run/pool/*".
-        """
-        super(TestPool, self).get_params(test, path)
 
     @fail_on(DaosApiError)
     def create(self):
@@ -733,7 +726,7 @@ class TestContainer(TestDaosApiBase):
             cb_handler (CallbackHandler, optional): callback object to use with
                 the API methods. Defaults to None.
         """
-        super(TestContainer, self).__init__(cb_handler)
+        super(TestContainer, self).__init__("/run/container/*", cb_handler)
         self.pool = pool
         self.log = self.pool.log
 
@@ -747,16 +740,6 @@ class TestContainer(TestDaosApiBase):
         self.uuid = None
         self.opened = False
         self.written_data = []
-
-    def get_params(self, test, path="/run/container/*"):
-        """Get the container parameters from the yaml file.
-
-        Args:
-            test (Test): avocado Test object
-            path (str, optional): yaml namespace. Defaults to
-                "/run/container/*".
-        """
-        super(TestContainer, self).get_params(test, path)
 
     @fail_on(DaosApiError)
     def create(self, uuid=None):


### PR DESCRIPTION
Implementing a set of new features to the command_utils.py classes
that will be utilized in a future pull requests:
- The yaml namespace is now provided as an input to the
ObjectWthParameters classes - negating the need to override the
get_params() method with the yaml namespace.
- There is now a common run() method for all the classes that inherited
the CommandWithParameters class - now named ExecutableCommand
- FormattedParameter object whose value is a list will now result in a
string where each value in the list is included in the string with the
same argument key.
- Job managers, e.g. orterun, mpirun, srun, etc. are now implemented as
their own ExecutableCommand class with the abilitly to run any other
ExecutableCommand object.

Signed-off-by: Phillip Henderson <phillip.henderson@intel.com>