### PR TITLE
DAOS-2514 control: Fix daos_server prep/format flow

### DIFF
--- a/src/control/common/storage/types.go
+++ b/src/control/common/storage/types.go
@@ -69,6 +69,15 @@ type NvmeNamespaces []*pb.NvmeController_Namespace
 // representing operation results on a number of NVMe controllers.
 type NvmeControllerResults []*pb.NvmeControllerResult
 
+func (ncr NvmeControllerResults) HasErrors() bool {
+	for _, res := range ncr {
+		if res.State.Error != "" {
+			return true
+		}
+	}
+	return false
+}
+
 func (ncr NvmeControllerResults) String() string {
 	var buf bytes.Buffer
 
@@ -143,6 +152,15 @@ func (sm ScmMounts) String() string {
 // ScmMountResults is an alias for protobuf ScmMountResult message slice
 // representing operation results on a number of SCM mounts.
 type ScmMountResults []*pb.ScmMountResult
+
+func (smr ScmMountResults) HasErrors() bool {
+	for _, res := range smr {
+		if res.State.Error != "" {
+			return true
+		}
+	}
+	return false
+}
 
 func (smr ScmMountResults) String() string {
 	var buf bytes.Buffer

--- a/src/control/server/ctl_storage_rpc.go
+++ b/src/control/server/ctl_storage_rpc.go
@@ -114,6 +114,8 @@ func (c *StorageControlService) doScmPrepare(req *pb.PrepareScmReq) (resp *pb.Pr
 func (c *StorageControlService) StoragePrepare(ctx context.Context, req *pb.StoragePrepareReq) (
 	*pb.StoragePrepareResp, error) {
 
+	c.log.Debug("received StoragePrepare RPC; proceeding to instance storage preparation")
+
 	resp := &pb.StoragePrepareResp{}
 
 	if req.Nvme != nil {
@@ -129,6 +131,8 @@ func (c *StorageControlService) StoragePrepare(ctx context.Context, req *pb.Stor
 // StorageScan discovers non-volatile storage hardware on node.
 func (c *StorageControlService) StorageScan(ctx context.Context, req *pb.StorageScanReq) (
 	*pb.StorageScanResp, error) {
+
+	c.log.Debug("received StorageScan RPC")
 
 	msg := "Storage Scan "
 	resp := new(pb.StorageScanResp)
@@ -165,6 +169,8 @@ func (c *StorageControlService) StorageScan(ctx context.Context, req *pb.Storage
 func (c *ControlService) doFormat(i *IOServerInstance, resp *pb.StorageFormatResp) error {
 	hasSuperblock := false
 
+	c.log.Infof("formatting storage for I/O server instance %d", i.Index)
+
 	needsScmFormat, err := i.NeedsScmFormat()
 	if err != nil {
 		return errors.Wrap(err, "unable to check storage formatting")
@@ -184,19 +190,46 @@ func (c *ControlService) doFormat(i *IOServerInstance, resp *pb.StorageFormatRes
 		c.scm.formatted = true
 	}
 
+	var formatFailed bool
+
 	// scaffolding
-	ctrlrResults := types.NvmeControllerResults{}
-	c.nvme.Format(i.runner.Config.Storage.Bdev, &ctrlrResults)
-	resp.Crets = ctrlrResults
-
-	mountResults := types.ScmMountResults{}
-	c.scm.Format(i.runner.Config.Storage.SCM, &mountResults)
-	resp.Mrets = mountResults
-
-	if !hasSuperblock && c.nvme.formatted && c.scm.formatted {
-		c.log.Debugf("storage format successful on server %d\n", i.runner.Config.Index)
+	bdevConfig, err := i.bdevConfig()
+	if err != nil {
+		return err
 	}
-	i.NotifyStorageReady()
+	ctrlrResults := types.NvmeControllerResults{}
+	// A config with SCM and no block devices is valid, apparently.
+	if len(bdevConfig.DeviceList) > 0 {
+		c.nvme.Format(bdevConfig, &ctrlrResults)
+		resp.Crets = ctrlrResults
+		formatFailed = ctrlrResults.HasErrors()
+	}
+
+	scmConfig, err := i.scmConfig()
+	if err != nil {
+		return err
+	}
+	mountResults := types.ScmMountResults{}
+	c.scm.Format(scmConfig, &mountResults)
+	resp.Mrets = mountResults
+	formatFailed = formatFailed || mountResults.HasErrors()
+
+	c.log.Debugf("nvme formatted: %t, scm formatted: %t, has superblock: %t",
+		c.nvme.formatted, c.scm.formatted, hasSuperblock)
+
+	if c.nvme.formatted && c.scm.formatted {
+		// Use this an indicator for whether storage format was requested and completed
+		// vs. storage was already formatted and skipped.
+		// TODO: Rework this logic to be less convoluted.
+		if !hasSuperblock {
+			c.log.Infof("storage format successful on server %d\n", i.runner.Config.Index)
+		}
+	}
+
+	// Only notify that storage is ready if there were no errors.
+	if !formatFailed {
+		i.NotifyStorageReady()
+	}
 
 	return nil
 }
@@ -211,6 +244,8 @@ func (c *ControlService) doFormat(i *IOServerInstance, resp *pb.StorageFormatRes
 // and nvme controllers.
 func (c *ControlService) StorageFormat(req *pb.StorageFormatReq, stream pb.MgmtCtl_StorageFormatServer) error {
 	resp := new(pb.StorageFormatResp)
+
+	c.log.Debug("received StorageFormat RPC; proceeding to instance storage format")
 
 	// TODO: We may want to ease this restriction at some point, but having this
 	// here for now should help to cut down on shenanigans which might result
@@ -241,6 +276,8 @@ func (c *ControlService) StorageFormat(req *pb.StorageFormatReq, stream pb.MgmtC
 // and nvme controllers.
 func (c *ControlService) StorageUpdate(req *pb.StorageUpdateReq, stream pb.MgmtCtl_StorageUpdateServer) error {
 	resp := new(pb.StorageUpdateResp)
+
+	c.log.Debug("received StorageUpdate RPC; proceeding to instance storage update")
 
 	// TODO: We may want to ease this restriction at some point, but having this
 	// here for now should help to cut down on shenanigans which might result
@@ -275,6 +312,8 @@ func (c *ControlService) StorageUpdate(req *pb.StorageUpdateReq, stream pb.MgmtC
 // Send response containing multiple results of burn-in operations on scm mounts
 // and nvme controllers.
 func (c *ControlService) StorageBurnIn(req *pb.StorageBurnInReq, stream pb.MgmtCtl_StorageBurnInServer) error {
+
+	c.log.Debug("received StorageBurnIn RPC; proceeding to instance storage burnin")
 
 	return errors.New("StorageBurnIn not implemented")
 	//	for i := range c.config.Servers {

--- a/src/control/server/ctl_storage_rpc_test.go
+++ b/src/control/server/ctl_storage_rpc_test.go
@@ -541,6 +541,7 @@ func TestStorageFormat(t *testing.T) {
 				if err := os.MkdirAll(filepath.Join(testDir, tt.sMount), 0777); err != nil {
 					t.Fatal(err)
 				}
+				// if the instance is expected to have a valid superblock, create one
 				if tt.superblockExists {
 					if err := i.CreateSuperblock(&mgmtInfo{}); err != nil {
 						t.Fatal(err)

--- a/src/control/server/harness.go
+++ b/src/control/server/harness.go
@@ -166,6 +166,7 @@ func (h *IOServerHarness) AwaitStorageReady(ctx context.Context) error {
 		}
 
 		if !needsScmFormat {
+			h.log.Debug("no SCM format required; checking for superblock")
 			needsSuperblock, err := instance.NeedsSuperblock()
 			if err != nil {
 				return errors.Wrap(err, "failed to check instance superblock")
@@ -174,6 +175,7 @@ func (h *IOServerHarness) AwaitStorageReady(ctx context.Context) error {
 				continue
 			}
 		}
+		h.log.Debug("SCM format required")
 		instance.AwaitStorageReady(ctx)
 	}
 	return ctx.Err()

--- a/src/control/server/instance.go
+++ b/src/control/server/instance.go
@@ -91,9 +91,21 @@ func (srv *IOServerInstance) scmConfig() (storage.ScmConfig, error) {
 		return nullCfg, errors.New("no runner configured")
 	}
 	if srv.runner.Config == nil {
-		return nullCfg, errors.New("no SCM config set on runner")
+		return nullCfg, errors.New("no ioserver config set on runner")
 	}
 	return srv.runner.Config.Storage.SCM, nil
+}
+
+// bdevConfig returns the block device configuration assigned to this instance.
+func (srv *IOServerInstance) bdevConfig() (storage.BdevConfig, error) {
+	var nullCfg storage.BdevConfig
+	if srv.runner == nil {
+		return nullCfg, errors.New("no runner configured")
+	}
+	if srv.runner.Config == nil {
+		return nullCfg, errors.New("no ioserver config set on runner")
+	}
+	return srv.runner.Config.Storage.Bdev, nil
 }
 
 // MountScmDevice mounts the configured SCM device (DCPM or ramdisk emulation)

--- a/src/control/server/server.go
+++ b/src/control/server/server.go
@@ -163,8 +163,8 @@ func Start(log *logging.LeveledLogger, cfg *Configuration) error {
 			return err
 		}
 	}
-	reformat := false // TODO: make this configurable
-	if err := harness.CreateSuperblocks(reformat); err != nil {
+	recreate := false // TODO: make this configurable
+	if err := harness.CreateSuperblocks(recreate); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
Discovered this while testing to make sure that daos_server supports the workflow we want to use in CI:

* Don't signal instance storage ready unless it's really ready