### PR TITLE
DAOS-3287 placement: Add pl_init and pl_fini

### DIFF
--- a/src/client/api/init.c
+++ b/src/client/api/init.c
@@ -37,6 +37,7 @@
 #include <daos/kv.h>
 #include <daos/btree.h>
 #include <daos/btree_class.h>
+#include <daos/placement.h>
 #include "task_internal.h"
 #include <pthread.h>
 
@@ -157,10 +158,15 @@ daos_init(void)
 		D_GOTO(out_hhash, rc);
 	}
 
+	/** set up placement */
+	rc = pl_init();
+	if (rc != 0)
+		goto out_eq;
+
 	/** set up management interface */
 	rc = dc_mgmt_init();
 	if (rc != 0)
-		D_GOTO(out_eq, rc);
+		D_GOTO(out_pl, rc);
 
 	/** set up pool */
 	rc = dc_pool_init();
@@ -193,6 +199,8 @@ out_pool:
 	dc_pool_fini();
 out_mgmt:
 	dc_mgmt_fini();
+out_pl:
+	pl_fini();
 out_eq:
 	daos_eq_lib_fini();
 out_hhash:
@@ -228,6 +236,7 @@ daos_fini(void)
 	dc_mgmt_fini();
 	dc_agent_fini();
 
+	pl_fini();
 	daos_hhash_fini();
 	daos_debug_fini();
 	module_initialized = false;

--- a/src/include/daos/placement.h
+++ b/src/include/daos/placement.h
@@ -109,6 +109,9 @@ struct pl_map {
 	struct pl_map_ops       *pl_ops;
 };
 
+int pl_init(void);
+void pl_fini(void);
+
 int pl_map_create(struct pool_map *pool_map, struct pl_map_init_attr *mia,
 		  struct pl_map **pl_mapp);
 void pl_map_destroy(struct pl_map *map);

--- a/src/placement/tests/place_obj.c
+++ b/src/placement/tests/place_obj.c
@@ -193,6 +193,12 @@ main(int argc, char **argv)
 	if (rc != 0)
 		return rc;
 
+	rc = pl_init();
+	if (rc != 0) {
+		daos_debug_fini();
+		return rc;
+	}
+
 	uuid_generate(pl_uuid);
 	srand(time(NULL));
 	oid.lo = rand();
@@ -338,6 +344,7 @@ main(int argc, char **argv)
 
 	pool_map_decref(po_map);
 	pool_buf_free(buf);
+	pl_fini();
 	daos_debug_fini();
 	D_PRINT("\nall tests passed!\n");
 	return 0;


### PR DESCRIPTION
pl_htable is created on demand. This requires all placement module API
methods to carefully check whether pl_htable has been initialized before
using it. There have been bugs caused by the absence of such checks in
the past. The latest one is triggered by pl_map_disconnect called from
the ds_pool_tgt_pool_disconnect code path. As both libdaos applications
and daos_io_servers almost always need to create pl_maps, this PR adds
pl_init and pl_fini to initialize pl_htable when callers initialize the
module, instead of on demand.

Signed-off-by: Li Wei <wei.g.li@intel.com>