### PR TITLE
DAOS-2540: Adjust vos_obj_delete so it deletes newly cached objects

### DIFF
--- a/src/vos/vos_obj_cache.c
+++ b/src/vos/vos_obj_cache.c
@@ -305,7 +305,7 @@ vos_obj_hold(struct daos_lru_cache *occ, struct vos_container *cont,
 		D_DEBUG(DB_TRACE, "nonexistent obj "DF_UOID"\n",
 			DP_UOID(oid));
 		if (intent == DAOS_INTENT_KILL) {
-			vos_obj_release(obj);
+			vos_obj_release(occ, obj);
 			D_GOTO(failed, rc = -DER_NONEXIST);
 		}
 		goto out;


### PR DESCRIPTION
The vos_obj_hold code has a couple of issues with deleted objects
1. It doesn't check if the actual object exists on disk
2. It will call vos_oi_find unecessarily

This fixes both issues.

Signed-off-by: Jeff Olivier <jeffrey.v.olivier@intel.com>