### PR TITLE
DAOS-3267 container: check container closed when destroy

### DIFF
--- a/src/include/daos_srv/container.h
+++ b/src/include/daos_srv/container.h
@@ -63,6 +63,7 @@ struct ds_cont_child {
 	uint64_t		 sc_dtx_resync_time;
 	uint32_t		 sc_dtx_resyncing:1,
 				 sc_dtx_aggregating:1,
+				 sc_dtx_registered:1,
 				 sc_closing:1,
 				 sc_destroying:1;
 	uint32_t		 sc_dtx_flush_wait_count;
@@ -81,8 +82,7 @@ struct ds_cont_hdl {
 	struct ds_pool_child	*sch_pool;
 	struct ds_cont_child	*sch_cont;
 	int			sch_ref;
-	uint32_t		sch_dtx_registered:1,
-				sch_deleted:1;
+	uint32_t		sch_deleted:1;
 };
 
 struct ds_cont_hdl *ds_cont_hdl_lookup(const uuid_t uuid);

--- a/src/include/daos_srv/dtx_srv.h
+++ b/src/include/daos_srv/dtx_srv.h
@@ -171,9 +171,10 @@ dtx_end(struct dtx_handle *dth, struct ds_cont_hdl *cont_hdl,
 int dtx_leader_exec_ops(struct dtx_leader_handle *dth, dtx_sub_func_t exec_func,
 			void *func_arg);
 
-int dtx_batched_commit_register(struct ds_cont_hdl *hdl);
+int dtx_batched_commit_register(struct ds_pool_child *pool,
+				struct ds_cont_child *cont);
 
-void dtx_batched_commit_deregister(struct ds_cont_hdl *hdl);
+void dtx_batched_commit_deregister(struct ds_cont_child *cont);
 
 int dtx_obj_sync(uuid_t po_uuid, uuid_t co_uuid, daos_handle_t coh,
 		 daos_unit_oid_t oid, daos_epoch_t epoch, uint32_t map_ver);


### PR DESCRIPTION
If the container is not closed when destroy, return -DER_BUSY.

Signed-off-by: Fan Yong <fan.yong@intel.com>