### PR TITLE
DAOS-3297 build: Update argobots and enable valgrind in build

### DIFF
--- a/utils/build.config
+++ b/utils/build.config
@@ -2,7 +2,7 @@
 component=daos
 
 [commit_versions]
-ARGOBOTS = 9d48af08403bac649598942b5ee848c14600cd8a
+ARGOBOTS = 89507c1f8cfec4e918e8b9861e41b4e9cef71461
 CART = 585d6acf1ac798e6ea5e68f891a8b6b622f84519
 PMDK = 1.5.1
 ISAL = v2.26.0

--- a/utils/docker/Dockerfile.centos.7
+++ b/utils/docker/Dockerfile.centos.7
@@ -60,7 +60,8 @@ RUN yum -y install epel-release; \
         make meson nasm ninja-build numactl-devel openssl-devel        \
         pandoc patch pylint python python-devel python36-devel         \
         python-pep8 python-pygit2 python2-pygithub python-requests     \
-        readline-devel scons sg3_utils ShellCheck yasm pciutils
+        readline-devel scons sg3_utils ShellCheck yasm pciutils        \
+        valgrind-devel
 
 # DAOS specific
 RUN yum -y install \

--- a/utils/docker/Dockerfile.leap.15
+++ b/utils/docker/Dockerfile.leap.15
@@ -27,7 +27,7 @@ RUN zypper --non-interactive --no-gpg-checks refresh; \
            libuuid-devel libyaml-devel                                \
            make man meson nasm ninja pandoc patch python2-pip         \
            readline-devel sg3_utils which yasm                        \
-	   python-devel python3-devel
+	   python-devel python3-devel valgrind-devel
 
 RUN pip install --upgrade pip; \
     pip install -U setuptools; \

--- a/utils/docker/Dockerfile.leap.42.3
+++ b/utils/docker/Dockerfile.leap.42.3
@@ -26,7 +26,7 @@ RUN zypper --non-interactive install                                   \
            libnuma-devel libopenssl-devel libuuid-devel libyaml-devel  \
            make man nasm ninja pandoc patch                            \
            python python-devel python-xml python3 python3-devel        \
-           readline-devel rsync yasm valgrind
+           readline-devel rsync yasm valgrind valgrind-devel
 
 RUN curl -ksS "https://bootstrap.pypa.io/get-pip.py" -o "/tmp/git-pip.py"; \
     python /tmp/git-pip.py pip; \

--- a/utils/docker/Dockerfile.sles.12.3
+++ b/utils/docker/Dockerfile.sles.12.3
@@ -26,7 +26,7 @@ RUN zypper --non-interactive install                                   \
            libnuma-devel libopenssl-devel libuuid-devel libyaml-devel  \
            make man nasm ninja pandoc patch                            \
            python python-devel python-xml python3 python3-devel        \
-           readline-devel rsync yasm valgrind
+           readline-devel rsync yasm valgrind valgrind-devel
 
 RUN curl -ksS "https://bootstrap.pypa.io/get-pip.py" -o "/tmp/git-pip.py"; \
     python /tmp/git-pip.py pip; \

--- a/utils/docker/Dockerfile.ubuntu.18.04
+++ b/utils/docker/Dockerfile.ubuntu.18.04
@@ -28,7 +28,7 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y \
             libssl-dev libtool-bin libyaml-dev                          \
             locales make meson nasm ninja-build pandoc patch            \
             pylint python-dev python3-dev scons         \
-            sg3-utils uuid-dev yasm valgrind-dev
+            sg3-utils uuid-dev yasm valgrind
 
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y \
                        software-properties-common &&                    \

--- a/utils/docker/Dockerfile.ubuntu.18.04
+++ b/utils/docker/Dockerfile.ubuntu.18.04
@@ -28,7 +28,7 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y \
             libssl-dev libtool-bin libyaml-dev                          \
             locales make meson nasm ninja-build pandoc patch            \
             pylint python-dev python3-dev scons         \
-            sg3-utils uuid-dev yasm
+            sg3-utils uuid-dev yasm valgrind-dev
 
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y \
                        software-properties-common &&                    \

--- a/utils/rpms/daos.spec
+++ b/utils/rpms/daos.spec
@@ -34,6 +34,7 @@ BuildRequires: libevent-devel
 BuildRequires: libyaml-devel
 BuildRequires: libcmocka-devel
 BuildRequires: readline-devel
+BuildRequires: valgrind-devel
 BuildRequires: systemd
 %if (0%{?rhel} >= 7)
 BuildRequires:  numactl-devel
@@ -240,6 +241,9 @@ install -m 644 utils/systemd/daos-agent.service %{?buildroot}/%{_unitdir}
 %{_libdir}/*.a
 
 %changelog
+* Thu Sep 19 2019 Jeff Olivier <jeffrey.v.olivier@intel.com>
+- Add valgrind-devel requirement for argobots change
+
 * Tue Sep 10 2019 Tom Nabarro <tom.nabarro@intel.com>
 - Add requires ndctl as runtime dep for control plane.
 


### PR DESCRIPTION
Argobots has long been suspected as the entity disallowing
valgrind on the daos_io_server.   This enables valgrind support
in the argobots build and updates argobots to a version that
provides support without overhead when valgrind isn't active.

Signed-off-by: Jeff Olivier <jeffrey.v.olivier@intel.com>