### PR TITLE
DAOS-3298 rebuild: two small bug fixing

### DIFF
--- a/src/rebuild/scan.c
+++ b/src/rebuild/scan.c
@@ -759,6 +759,7 @@ rebuild_tgt_scan_handler(crt_rpc_t *rpc)
 	struct rebuild_scan_arg		*scan_arg;
 	struct umem_attr		 uma;
 	struct rebuild_tgt_pool_tracker	*rpt = NULL;
+	d_rank_list_t			*fail_list = NULL;
 	int				 rc;
 
 	rsi = crt_req_get(rpc);
@@ -877,25 +878,28 @@ out:
 	ro = crt_reply_get(rpc);
 	ro->rso_status = rc;
 	if (rc) {
-		d_rank_list_t *fail_list;
-
 		/* If it failed, tell the master the target can not
 		 * start the rebuild, so master will put the target
 		 * into DOWN state.
 		 */
 		fail_list = d_rank_list_alloc(1);
-		if (rpt && rpt->rt_pool)
-			crt_group_rank(rpt->rt_pool->sp_group,
-				       &fail_list->rl_ranks[0]);
-		else
-			crt_group_rank(NULL, &fail_list->rl_ranks[0]);
+		if (fail_list != NULL) {
+			if (rpt && rpt->rt_pool)
+				crt_group_rank(rpt->rt_pool->sp_group,
+					       &fail_list->rl_ranks[0]);
+			else
+				crt_group_rank(NULL, &fail_list->rl_ranks[0]);
 
-		ro->rso_ranks_list = fail_list;
+			ro->rso_ranks_list = fail_list;
+		} else {
+			D_ERROR("failed to alloc rank list.\n");
+		}
 		if (rpt)
 			rpt->rt_abort = 1;
 	}
 
 	dss_rpc_reply(rpc, DAOS_REBUILD_DROP_SCAN);
+	d_rank_list_free(fail_list);
 }
 
 int

--- a/src/rebuild/srv.c
+++ b/src/rebuild/srv.c
@@ -1686,9 +1686,14 @@ rebuild_tgt_status_check(void *arg)
 		memset(&iv, 0, sizeof(iv));
 		uuid_copy(iv.riv_pool_uuid, rpt->rt_pool_uuid);
 
-		D_ASSERT(status.obj_count >= rpt->rt_reported_obj_cnt);
-		D_ASSERT(status.rec_count >= rpt->rt_reported_rec_cnt);
 		D_ASSERT(rpt->rt_toberb_objs >= rpt->rt_reported_toberb_objs);
+		/* rebuild_tgt_query above possibly lost some counter
+		 * when target being excluded.
+		 */
+		if (status.obj_count < rpt->rt_reported_obj_cnt)
+			status.obj_count = rpt->rt_reported_obj_cnt;
+		if (status.rec_count < rpt->rt_reported_rec_cnt)
+			status.rec_count = rpt->rt_reported_rec_cnt;
 		if (rpt->rt_re_report) {
 			iv.riv_toberb_obj_count = rpt->rt_toberb_objs;
 			iv.riv_obj_count = status.obj_count;


### PR DESCRIPTION
1) in dss_rebuild_check_one should still add its rebuild counter
   if some tgt is excluded. To fix the assertion of
   D_ASSERT(status.obj_count >= rpt->rt_reported_obj_cnt)
   in rebuild_tgt_status_check().
2) fix a memleak in rebuild_tgt_scan_handler().

Signed-off-by: Xuezhao Liu <xuezhao.liu@intel.com>