### PR TITLE
DAOS-3299 control: Run gofmt check in test preflight

### DIFF
--- a/src/control/common/test_mocks.go
+++ b/src/control/common/test_mocks.go
@@ -48,20 +48,20 @@ func MockNamespacePB() *pb.NvmeController_Namespace {
 // multiple packages.
 func MockDeviceHealthPB() *pb.NvmeController_Health {
 	return &pb.NvmeController_Health{
-		Temp:		uint32(300),
-		Tempwarn:	uint32(0),
-		Tempcrit:	uint32(0),
-		Ctrlbusy:	uint64(0),
-		Powercycles:	uint64(99),
-		Poweronhours:	uint64(9999),
+		Temp:            uint32(300),
+		Tempwarn:        uint32(0),
+		Tempcrit:        uint32(0),
+		Ctrlbusy:        uint64(0),
+		Powercycles:     uint64(99),
+		Poweronhours:    uint64(9999),
 		Unsafeshutdowns: uint64(1),
-		Mediaerrors:	uint64(0),
-		Errorlogs:	uint64(0),
-		Tempwarning:	false,
-		Availspare:	false,
-		Reliability:	false,
-		Readonly:	false,
-		Volatilemem:	false,
+		Mediaerrors:     uint64(0),
+		Errorlogs:       uint64(0),
+		Tempwarning:     false,
+		Availspare:      false,
+		Reliability:     false,
+		Readonly:        false,
+		Volatilemem:     false,
 	}
 }
 
@@ -84,11 +84,11 @@ func NewMockControllerPB(
 	nss []*pb.NvmeController_Namespace, dh []*pb.NvmeController_Health) *pb.NvmeController {
 
 	return &pb.NvmeController{
-		Model:      model,
-		Serial:     serial,
-		Pciaddr:    pciAddr,
-		Fwrev:      fwRev,
-		Namespaces: nss,
+		Model:       model,
+		Serial:      serial,
+		Pciaddr:     pciAddr,
+		Fwrev:       fwRev,
+		Namespaces:  nss,
 		Healthstats: dh,
 	}
 }

--- a/src/control/lib/spdk/nvme.go
+++ b/src/control/lib/spdk/nvme.go
@@ -87,20 +87,20 @@ type Namespace struct {
 // and describes the raw SPDK device health stats
 // of a controller (NVMe SSD).
 type DeviceHealth struct {
-	Temp		uint32
-	TempWarnTime	uint32
-	TempCritTime	uint32
-	CtrlBusyTime	uint64
-	PowerCycles	uint64
-	PowerOnHours	uint64
-	UnsafeShutdowns	uint64
-	MediaErrors	uint64
-	ErrorLogEntries	uint64
-	TempWarn	bool
-	AvailSpareWarn	bool
+	Temp            uint32
+	TempWarnTime    uint32
+	TempCritTime    uint32
+	CtrlBusyTime    uint64
+	PowerCycles     uint64
+	PowerOnHours    uint64
+	UnsafeShutdowns uint64
+	MediaErrors     uint64
+	ErrorLogEntries uint64
+	TempWarn        bool
+	AvailSpareWarn  bool
 	ReliabilityWarn bool
-	ReadOnlyWarn	bool
-	VolatileWarn	bool
+	ReadOnlyWarn    bool
+	VolatileWarn    bool
 }
 
 // Discover calls C.nvme_discover which returns
@@ -175,21 +175,21 @@ func c2GoController(ctrlr *C.struct_ctrlr_t) Controller {
 }
 
 func c2GoDeviceHealth(health *C.struct_dev_health_t) DeviceHealth {
-	return DeviceHealth {
-		Temp:		 uint32(health.temperature),
-		TempWarnTime:	 uint32(health.warn_temp_time),
-		TempCritTime:	 uint32(health.crit_temp_time),
-		CtrlBusyTime:	 uint64(health.ctrl_busy_time),
-		PowerCycles:	 uint64(health.power_cycles),
-		PowerOnHours:	 uint64(health.power_on_hours),
+	return DeviceHealth{
+		Temp:            uint32(health.temperature),
+		TempWarnTime:    uint32(health.warn_temp_time),
+		TempCritTime:    uint32(health.crit_temp_time),
+		CtrlBusyTime:    uint64(health.ctrl_busy_time),
+		PowerCycles:     uint64(health.power_cycles),
+		PowerOnHours:    uint64(health.power_on_hours),
 		UnsafeShutdowns: uint64(health.unsafe_shutdowns),
-		MediaErrors:	 uint64(health.media_errors),
+		MediaErrors:     uint64(health.media_errors),
 		ErrorLogEntries: uint64(health.error_log_entries),
-		TempWarn:	 bool(health.temp_warning),
-		AvailSpareWarn:	 bool(health.avail_spare_warning),
+		TempWarn:        bool(health.temp_warning),
+		AvailSpareWarn:  bool(health.avail_spare_warning),
 		ReliabilityWarn: bool(health.dev_reliabilty_warning),
-		ReadOnlyWarn:	 bool(health.read_only_warning),
-		VolatileWarn:	 bool(health.volatile_mem_warning),
+		ReadOnlyWarn:    bool(health.read_only_warning),
+		VolatileWarn:    bool(health.volatile_mem_warning),
 	}
 }
 

--- a/src/control/run_go_tests.sh
+++ b/src/control/run_go_tests.sh
@@ -56,25 +56,42 @@ function setup_environment()
 	CGO_CFLAGS+=" -I${SL_HWLOC_PREFIX}/include"
 }
 
+function check_formatting()
+{
+	srcdir=${1:-"./"}
+	output=$(find "$srcdir/" -name '*.go' -and -not -path '*vendor*' \
+		-print0 | xargs -0 gofmt -d)
+	if [ -n "$output" ]; then
+		echo "ERROR: Your code hasn't been run through gofmt!"
+		echo "Please configure your editor to run gofmt on save."
+		echo "Alternatively, at a minimum, run the following command:"
+		echo -n "find $srcdir/ -name '*.go' -and -not -path '*vendor*'"
+		echo "| xargs gofmt -w"
+		echo -e "\ngofmt check found the following:\n\n$output\n"
+		exit 1
+	fi
+}
+
 check=$(check_environment)
 
 if [ "$check" == "false" ]; then
 	setup_environment
 fi
 
+DIR="$(readlink -f "$(dirname "${BASH_SOURCE[0]}")")"
+GOPATH="$(readlink -f "$DIR/../../build/src/control")"
+repopath=github.com/daos-stack/daos
+controldir="$GOPATH/src/$repopath/src/control"
+
+check_formatting "$controldir"
+
 echo "Environment:"
 echo "  LD_LIBRARY_PATH: $LD_LIBRARY_PATH"
 echo "  CGO_LDFLAGS: $CGO_LDFLAGS"
 echo "  CGO_CFLAGS: $CGO_CFLAGS"
 
-DIR="$(readlink -f "$(dirname "${BASH_SOURCE[0]}")")"
-
-GOPATH="$(readlink -f "$DIR/../../build/src/control")"
 echo "  GOPATH: $GOPATH"
 echo
-
-repopath=github.com/daos-stack/daos
-controldir="$GOPATH/src/$repopath/src/control"
 
 echo "Running all tests under $controldir..."
 pushd "$controldir" >/dev/null

--- a/src/control/server/storage_nvme.go
+++ b/src/control/server/storage_nvme.go
@@ -470,7 +470,7 @@ func loadControllers(ctrlrs []spdk.Controller, nss []spdk.Namespace,
 				Fwrev:    c.FWRev,
 				Socketid: c.SocketID,
 				// repeated pb field
-				Namespaces: loadNamespaces(c.PCIAddr, nss),
+				Namespaces:  loadNamespaces(c.PCIAddr, nss),
 				Healthstats: loadHealthStats(health),
 			})
 	}
@@ -500,20 +500,20 @@ func loadHealthStats(health []spdk.DeviceHealth) (_health types.NvmeHealthstats)
 		_health = append(
 			_health,
 			&pb.NvmeController_Health{
-				Temp:		 h.Temp,
-				Tempwarn:	 h.TempWarnTime,
-				Tempcrit:	 h.TempCritTime,
-				Ctrlbusy:	 h.CtrlBusyTime,
-				Powercycles:	 h.PowerCycles,
-				Poweronhours:	 h.PowerOnHours,
+				Temp:            h.Temp,
+				Tempwarn:        h.TempWarnTime,
+				Tempcrit:        h.TempCritTime,
+				Ctrlbusy:        h.CtrlBusyTime,
+				Powercycles:     h.PowerCycles,
+				Poweronhours:    h.PowerOnHours,
 				Unsafeshutdowns: h.UnsafeShutdowns,
-				Mediaerrors:	 h.MediaErrors,
-				Errorlogs:	 h.ErrorLogEntries,
-				Tempwarning:	 h.TempWarn,
-				Availspare: 	 h.AvailSpareWarn,
-				Reliability:	 h.ReliabilityWarn,
-				Readonly:	 h.ReadOnlyWarn,
-				Volatilemem:	 h.VolatileWarn,
+				Mediaerrors:     h.MediaErrors,
+				Errorlogs:       h.ErrorLogEntries,
+				Tempwarning:     h.TempWarn,
+				Availspare:      h.AvailSpareWarn,
+				Reliability:     h.ReliabilityWarn,
+				Readonly:        h.ReadOnlyWarn,
+				Volatilemem:     h.VolatileWarn,
 			})
 	}
 

--- a/src/control/server/storage_nvme_test.go
+++ b/src/control/server/storage_nvme_test.go
@@ -77,20 +77,20 @@ func MockNamespace(ctrlr *Controller) Namespace {
 func MockDeviceHealth(ctrlr *Controller) DeviceHealth {
 	h := MockDeviceHealthPB()
 	return DeviceHealth{
-		Temp:		 h.Temp,
-		TempWarnTime:	 h.Tempwarn,
-		TempCritTime:	 h.Tempcrit,
-		CtrlBusyTime:	 h.Ctrlbusy,
-		PowerCycles:	 h.Powercycles,
-		PowerOnHours:	 h.Poweronhours,
+		Temp:            h.Temp,
+		TempWarnTime:    h.Tempwarn,
+		TempCritTime:    h.Tempcrit,
+		CtrlBusyTime:    h.Ctrlbusy,
+		PowerCycles:     h.Powercycles,
+		PowerOnHours:    h.Poweronhours,
 		UnsafeShutdowns: h.Unsafeshutdowns,
-		MediaErrors:	 h.Mediaerrors,
+		MediaErrors:     h.Mediaerrors,
 		ErrorLogEntries: h.Errorlogs,
-		TempWarn:	 h.Tempwarning,
+		TempWarn:        h.Tempwarning,
 		AvailSpareWarn:  h.Availspare,
 		ReliabilityWarn: h.Reliability,
-		ReadOnlyWarn:	 h.Readonly,
-		VolatileWarn:	 h.Volatilemem,
+		ReadOnlyWarn:    h.Readonly,
+		VolatileWarn:    h.Volatilemem,
 	}
 }
 
@@ -140,7 +140,7 @@ func (m *mockSpdkNvme) Update(pciAddr string, path string, slot int32) (
 		if ctrlr.PCIAddr == pciAddr && m.updateRet == nil {
 			m.initCtrlrs[i].FWRev = m.fwRevAfter
 		}
-	 }
+	}
 
 	return m.initCtrlrs, m.initNss, m.updateRet
 }
@@ -284,9 +284,9 @@ func TestDiscoverNvmeMulti(t *testing.T) {
 			},
 			[]DeviceHealth{
 				{300, 0, 0, 0, 0, 1000, 1, 0, 0,
-				 false, false, false, false, false},
+					false, false, false, false, false},
 				{300, 0, 0, 0, 0, 1000, 1, 0, 0,
-				 false, false, false, false, false},
+					false, false, false, false, false},
 			},
 		},
 		{
@@ -297,9 +297,9 @@ func TestDiscoverNvmeMulti(t *testing.T) {
 			[]Namespace{},
 			[]DeviceHealth{
 				{300, 0, 0, 0, 0, 1000, 1, 0, 0,
-				 false, false, false, false, false},
+					false, false, false, false, false},
 				{300, 0, 0, 0, 0, 1000, 1, 0, 0,
-				 false, false, false, false, false},
+					false, false, false, false, false},
 			},
 		},
 		{
@@ -317,9 +317,9 @@ func TestDiscoverNvmeMulti(t *testing.T) {
 			},
 			[]DeviceHealth{
 				{300, 0, 0, 0, 0, 1000, 1, 0, 0,
-				 false, false, false, false, false},
+					false, false, false, false, false},
 				{300, 0, 0, 0, 0, 1000, 1, 0, 0,
-				 false, false, false, false, false},
+					false, false, false, false, false},
 			},
 		},
 	}
@@ -407,10 +407,10 @@ func TestFormatNvme(t *testing.T) {
 		desc         string
 	}{
 		{
-			formatted:	false,
-			devFormatRet:	nil,
-			pciAddrs:	[]string{},
-			expResults:	NvmeControllerResults{
+			formatted:    false,
+			devFormatRet: nil,
+			pciAddrs:     []string{},
+			expResults: NvmeControllerResults{
 				{
 					Pciaddr: "",
 					State: &pb.ResponseState{
@@ -419,14 +419,14 @@ func TestFormatNvme(t *testing.T) {
 					},
 				},
 			},
-			expCtrlrs:	newDefaultCtrlrs(),
-			desc:		"no devices",
+			expCtrlrs: newDefaultCtrlrs(),
+			desc:      "no devices",
 		},
 		{
-			formatted:	true,
-			devFormatRet:	nil,
-			pciAddrs:	[]string{},
-			expResults:	NvmeControllerResults{
+			formatted:    true,
+			devFormatRet: nil,
+			pciAddrs:     []string{},
+			expResults: NvmeControllerResults{
 				{
 					Pciaddr: "",
 					State: &pb.ResponseState{
@@ -435,14 +435,14 @@ func TestFormatNvme(t *testing.T) {
 					},
 				},
 			},
-			expCtrlrs:	newDefaultCtrlrs(),
-			desc:		"already formatted",
+			expCtrlrs: newDefaultCtrlrs(),
+			desc:      "already formatted",
 		},
 		{
-			formatted:	false,
-			devFormatRet:	nil,
-			pciAddrs:	[]string{""},
-			expResults:	NvmeControllerResults{
+			formatted:    false,
+			devFormatRet: nil,
+			pciAddrs:     []string{""},
+			expResults: NvmeControllerResults{
 				{
 					Pciaddr: "",
 					State: &pb.ResponseState{
@@ -451,27 +451,27 @@ func TestFormatNvme(t *testing.T) {
 					},
 				},
 			},
-			expCtrlrs:	newDefaultCtrlrs(),
-			desc:		"empty device string",
+			expCtrlrs: newDefaultCtrlrs(),
+			desc:      "empty device string",
 		},
 		{
-			formatted:	false,
-			devFormatRet:	nil,
-			pciAddrs:	[]string{"0000:81:00.0"},
-			expResults:	NvmeControllerResults{
+			formatted:    false,
+			devFormatRet: nil,
+			pciAddrs:     []string{"0000:81:00.0"},
+			expResults: NvmeControllerResults{
 				{
 					Pciaddr: "0000:81:00.0",
 					State:   new(pb.ResponseState),
 				},
 			},
-			expCtrlrs:	newDefaultCtrlrs(),
-			desc:		"single device",
+			expCtrlrs: newDefaultCtrlrs(),
+			desc:      "single device",
 		},
 		{
-			formatted:	false,
-			devFormatRet:	nil,
-			pciAddrs:	[]string{"0000:83:00.0"},
-			expResults:	NvmeControllerResults{
+			formatted:    false,
+			devFormatRet: nil,
+			pciAddrs:     []string{"0000:83:00.0"},
+			expResults: NvmeControllerResults{
 				{
 					Pciaddr: "0000:83:00.0",
 					State: &pb.ResponseState{
@@ -480,14 +480,14 @@ func TestFormatNvme(t *testing.T) {
 					},
 				},
 			},
-			expCtrlrs:	newDefaultCtrlrs(),
-			desc:		"single device not discovered",
+			expCtrlrs: newDefaultCtrlrs(),
+			desc:      "single device not discovered",
 		},
 		{
-			formatted:	false,
-			devFormatRet:	nil,
-			pciAddrs:	[]string{"0000:81:00.0", "0000:83:00.0"},
-			expResults:	NvmeControllerResults{
+			formatted:    false,
+			devFormatRet: nil,
+			pciAddrs:     []string{"0000:81:00.0", "0000:83:00.0"},
+			expResults: NvmeControllerResults{
 				{
 					Pciaddr: "0000:81:00.0",
 					State:   new(pb.ResponseState),
@@ -500,14 +500,14 @@ func TestFormatNvme(t *testing.T) {
 					},
 				},
 			},
-			expCtrlrs:	newDefaultCtrlrs(),
-			desc:		"first device found, second not discovered",
+			expCtrlrs: newDefaultCtrlrs(),
+			desc:      "first device found, second not discovered",
 		},
 		{
-			formatted:	false,
-			devFormatRet:	nil,
-			pciAddrs:	[]string{"0000:83:00.0", "0000:81:00.0"},
-			expResults:	NvmeControllerResults{
+			formatted:    false,
+			devFormatRet: nil,
+			pciAddrs:     []string{"0000:83:00.0", "0000:81:00.0"},
+			expResults: NvmeControllerResults{
 				{
 					Pciaddr: "0000:83:00.0",
 					State: &pb.ResponseState{
@@ -520,14 +520,14 @@ func TestFormatNvme(t *testing.T) {
 					State:   new(pb.ResponseState),
 				},
 			},
-			expCtrlrs:	newDefaultCtrlrs(),
-			desc:		"first not discovered, second found",
+			expCtrlrs: newDefaultCtrlrs(),
+			desc:      "first not discovered, second found",
 		},
 		{
-			formatted:	false,
-			devFormatRet:	errors.New("example format failure"),
-			pciAddrs:	[]string{"0000:83:00.0", "0000:81:00.0"},
-			expResults:	NvmeControllerResults{
+			formatted:    false,
+			devFormatRet: errors.New("example format failure"),
+			pciAddrs:     []string{"0000:83:00.0", "0000:81:00.0"},
+			expResults: NvmeControllerResults{
 				{
 					Pciaddr: "0000:83:00.0",
 					State: &pb.ResponseState{
@@ -544,8 +544,8 @@ func TestFormatNvme(t *testing.T) {
 					},
 				},
 			},
-			expCtrlrs:	newDefaultCtrlrs(),
-			desc:		"first not discovered, second failed to format",
+			expCtrlrs: newDefaultCtrlrs(),
+			desc:      "first not discovered, second failed to format",
 		},
 	}
 


### PR DESCRIPTION
Some recent commits have introduced formatting oddities that
would have been prevented if we were running a gofmt check in CI.
This commit fixes those formatting issues.

This commit also adds a formatting check which runs before the tests
and fails with an informative error message if gofmt finds any files
that should have been formatted before saving.