### PR TITLE
DAOS-3109 test: Register mock_assert with gurt in unit tests

### DIFF
--- a/src/client/api/tests/agent_tests.c
+++ b/src/client/api/tests/agent_tests.c
@@ -118,6 +118,8 @@ main(void)
 			test_dc_agent_init_with_env),
 	};
 
+	d_register_alt_assert(mock_assert);
+
 	return cmocka_run_group_tests(tests, NULL, NULL);
 }
 

--- a/src/client/api/tests/eq_tests.c
+++ b/src/client/api/tests/eq_tests.c
@@ -989,6 +989,8 @@ main(int argc, char **argv)
 	int		test_fail = 0;
 	int		rc;
 
+	d_register_alt_assert(mock_assert);
+
 	setenv("DAOS_SINGLETON_CLI", "1", 1);
 	setenv("OFI_INTERFACE", "lo", 1);
 

--- a/src/common/tests/btree.c
+++ b/src/common/tests/btree.c
@@ -1002,6 +1002,8 @@ main(int argc, char **argv)
 	int		opt;
 	int		dynamic_flag = 0;
 
+	d_register_alt_assert(mock_assert);
+
 	gettimeofday(&tv, NULL);
 	srand(tv.tv_usec);
 

--- a/src/common/tests/btree_direct.c
+++ b/src/common/tests/btree_direct.c
@@ -1148,6 +1148,8 @@ main(int argc, char **argv)
 	int		opt;
 	int		rc;
 
+	d_register_alt_assert(mock_assert);
+
 	gettimeofday(&tv, NULL);
 	srand(tv.tv_usec);
 

--- a/src/common/tests/umem_test.c
+++ b/src/common/tests/umem_test.c
@@ -264,6 +264,8 @@ main(int argc, char **argv)
 		{ NULL, NULL, NULL, NULL }
 	};
 
+	d_register_alt_assert(mock_assert);
+
 	return cmocka_run_group_tests_name("umem tests", umem_tests,
 					   global_setup, global_teardown);
 }

--- a/src/tests/suite/daos_test.c
+++ b/src/tests/suite/daos_test.c
@@ -204,6 +204,8 @@ main(int argc, char **argv)
 	int		 size;
 	int		 rc;
 
+	d_register_alt_assert(mock_assert);
+
 	MPI_Init(&argc, &argv);
 
 	MPI_Comm_rank(MPI_COMM_WORLD, &rank);

--- a/src/vos/tests/evt_ctl.c
+++ b/src/vos/tests/evt_ctl.c
@@ -2405,6 +2405,8 @@ main(int argc, char **argv)
 	struct timeval	tv;
 	int		rc;
 
+	d_register_alt_assert(mock_assert);
+
 	gettimeofday(&tv, NULL);
 	srand(tv.tv_usec);
 

--- a/src/vos/tests/vos_tests.c
+++ b/src/vos/tests/vos_tests.c
@@ -106,6 +106,8 @@ main(int argc, char **argv)
 	int	keys;
 	bool	nest_iterators = false;
 
+	d_register_alt_assert(mock_assert);
+
 	static struct option long_options[] = {
 		{"all_tests",		required_argument, 0, 'A'},
 		{"pool_tests",		no_argument, 0, 'p'},


### PR DESCRIPTION
This will enable us to catch internal assertions in the tests
and properly report them in jenkins rather than just exiting
the test application.

Note that this currently only works with D_ASSERT.  Cart
has a pull request (No 218) to fix that issue.  The version
of cart can be updated independently, however.   This patch
immediately solves half of the issue at hand.

Signed-off-by: Jeff Olivier <jeffrey.v.olivier@intel.com>