### PR TITLE
DAOS-1864 client: Address coding style issues

### DIFF
--- a/src/common/tests/checksum_timing.c
+++ b/src/common/tests/checksum_timing.c
@@ -42,17 +42,19 @@
 static int
 timebox(int (*cb)(void *), void *arg, uint64_t *usec)
 {
-	struct timespec start, end, result;
+	struct timespec	start, end, result;
+	uint64_t	delta_us;
+	int		rc;
 
 	clock_gettime(CLOCK_MONOTONIC_RAW, &start);
 
-	int rc = cb(arg);
+	rc = cb(arg);
 
 	clock_gettime(CLOCK_MONOTONIC_RAW, &end);
 
 	result = d_timediff(start, end);
 
-	uint64_t delta_us = ((uint64_t)result.tv_sec * 1000000000 +
+	delta_us = ((uint64_t)result.tv_sec * 1000000000 +
 				(uint64_t)result.tv_nsec) / 1000;
 	*usec = delta_us;
 
@@ -63,7 +65,6 @@ struct csum_timing_args {
 	struct daos_csummer *csummer;
 	uint8_t *buf;
 	size_t len;
-
 };
 
 int
@@ -72,6 +73,7 @@ csum_timed_cb(void *arg)
 	struct csum_timing_args *timing_args = arg;
 	int rc =  daos_csummer_update(timing_args->csummer, timing_args->buf,
 				      timing_args->len);
+
 	if (rc)
 		return rc;
 	return daos_csummer_finish(timing_args->csummer);
@@ -81,9 +83,11 @@ int
 run_timings(struct csum_ft *fts[], const int types_count,
 		 const size_t *sizes, const int sizes_count)
 {
-	int size_idx;
-	int type_idx;
-	int rc;
+	int	size_idx;
+	int	type_idx;
+	size_t	usec;
+	int	rc;
+
 
 	for (size_idx = 0; size_idx < sizes_count; size_idx++) {
 		/** create data to checksum */
@@ -99,24 +103,24 @@ run_timings(struct csum_ft *fts[], const int types_count,
 		printf("Data Length: %"PRIu64"\n", len);
 
 		for (type_idx = 0; type_idx < types_count; type_idx++) {
-			struct csum_ft *ft = fts[type_idx];
-			struct daos_csummer *csummer;
+			struct csum_ft		*ft = fts[type_idx];
+			struct daos_csummer	*csummer;
+			struct csum_timing_args	 args;
+			size_t			 csum_size;
+			uint8_t			*csum_buf;
 
 			rc = daos_csummer_init(&csummer, ft, 0);
 			if (rc != 0)
 				return rc;
 
-			struct csum_timing_args args = {
-				.csummer = csummer,
-				.buf = buf,
-				.len = len
-			};
-			size_t csum_size = daos_csummer_get_size(csummer);
-			uint8_t *csum_buf = calloc(csum_size, 1);
+			args.csummer = csummer;
+			args.buf = buf;
+			args.len = len;
+
+			csum_size = daos_csummer_get_size(csummer);
+			csum_buf = calloc(csum_size, 1);
 
 			daos_csummer_set_buffer(csummer, csum_buf, csum_size);
-
-			size_t usec;
 
 			rc = timebox(csum_timed_cb, &args, &usec);
 

--- a/src/common/tests/misc_tests.c
+++ b/src/common/tests/misc_tests.c
@@ -22,7 +22,6 @@
  */
 #define D_LOGFAC        DD_FAC(tests)
 
-
 #include <string.h>
 #include <errno.h>
 #include <getopt.h>
@@ -38,11 +37,10 @@
 
 #include "misc_tests.h"
 
-
 void
 daos_sgl_init_with_strings(d_sg_list_t *sgl, uint32_t count, char *d, ...)
 {
-	int i;
+	uint32_t i;
 	va_list valist;
 	char *arg = d;
 
@@ -63,13 +61,12 @@ daos_sgl_init_with_strings(d_sg_list_t *sgl, uint32_t count, char *d, ...)
 
 static void test_sgl_get_bytes_with_single_iov(void **state)
 {
-	d_sg_list_t	 sgl;
-	uint8_t		*buf = NULL;
-	size_t		 len;
+	uint8_t			*buf = NULL;
+	size_t			 len;
+	d_sg_list_t		 sgl;
+	struct daos_sgl_idx	 idx = {0};
 
 	daos_sgl_init_with_strings(&sgl, 1, "abcd");
-	struct daos_sgl_idx idx = {0};
-
 
 	/** Get the first byte of the sgl */
 	daos_sgl_get_bytes(&sgl, &idx, 1, &buf, &len);
@@ -91,16 +88,15 @@ static void test_sgl_get_bytes_with_single_iov(void **state)
 
 static void test_sgl_get_bytes_with_multiple_iovs(void **state)
 {
-	d_sg_list_t	 sgl;
-	uint8_t		*buf = NULL;
-	size_t		 len;
+	uint8_t			*buf = NULL;
+	size_t			 len;
+	d_sg_list_t		 sgl;
+	struct daos_sgl_idx	 idx = {0};
+	bool			 end;
 
 	daos_sgl_init_with_strings(&sgl, 2, "a", "b");
-	struct daos_sgl_idx idx = {0};
 
-
-	bool end = daos_sgl_get_bytes(&sgl, &idx, 3, &buf, &len);
-
+	end = daos_sgl_get_bytes(&sgl, &idx, 3, &buf, &len);
 	assert_int_equal('a', *(char *)buf);
 	/** even though 3 requested, only got 2 because can only process a
 	 * single iov at a time.
@@ -123,15 +119,16 @@ static void test_sgl_get_bytes_with_multiple_iovs(void **state)
 
 static void test_sgl_get_bytes_trying_to_exceed_len(void **state)
 {
-	d_sg_list_t sgl;
-	struct daos_sgl_idx idx = {0};
-	uint8_t *buf = NULL;
-	size_t len;
+	uint8_t			*buf = NULL;
+	size_t			 len;
+	d_sg_list_t		 sgl;
+	struct daos_sgl_idx	 idx = {0};
+	bool			 end;
+	size_t			 sgl_len;
 
 	daos_sgl_init_with_strings(&sgl, 1, "a");
-	size_t sgl_len = sgl.sg_iovs[0].iov_len;
-
-	bool end = daos_sgl_get_bytes(&sgl, &idx, sgl_len + 1, &buf, &len);
+	sgl_len = sgl.sg_iovs[0].iov_len;
+	end = daos_sgl_get_bytes(&sgl, &idx, sgl_len + 1, &buf, &len);
 
 	assert_int_equal(sgl_len, len); /** len is still only sgl_len */
 	assert_true(end); /** yep, still the end */
@@ -161,7 +158,6 @@ static void test_completely_process_sgl(void **state)
 	sgl_cb_buf_idx = sgl_cb_buf;
 	sgl_cb_call_count = 0;
 
-
 	daos_sgl_init_with_strings(&sgl, 2, "a", "bc");
 
 	daos_sgl_processor(&sgl, &idx, 6, dummy_sgl_cb, NULL);
@@ -175,14 +171,14 @@ static void test_completely_process_sgl(void **state)
 
 static void test_process_sgl_span_iov_with_diff_requests(void **state)
 {
+	d_sg_list_t		sgl;
+	struct daos_sgl_idx	idx = {0};
+
+	sgl_cb_call_count = 0;
 	memset(sgl_cb_buf, 0, SGL_CB_BUFF_SIZE);
 	sgl_cb_buf_idx = sgl_cb_buf;
-	sgl_cb_call_count = 0;
-
-	d_sg_list_t sgl;
 
 	daos_sgl_init_with_strings(&sgl, 2, "abc", "def");
-	struct daos_sgl_idx idx = {0};
 
 	daos_sgl_processor(&sgl, &idx, 2, dummy_sgl_cb, NULL);
 	assert_int_equal(1, sgl_cb_call_count);
@@ -199,7 +195,6 @@ static void test_process_sgl_span_iov_with_diff_requests(void **state)
 	/** idx should be at end */
 	assert_int_equal(2, idx.iov_idx);
 	assert_int_equal(0, idx.iov_offset);
-
 
 	d_sgl_fini(&sgl, true);
 }


### PR DESCRIPTION
- Move variable declaration to beginning of a block
- Aligned variable declarations
- Removed verbose output by default for checksum tests

Signed-off-by: Ryon Jensen <ryon.jensen@intel.com>