### PR TITLE
DAOS-623 build: Remove unecessary abt.h include

### DIFF
--- a/src/include/daos/drpc.h
+++ b/src/include/daos/drpc.h
@@ -26,7 +26,6 @@
 
 #include <daos/drpc.pb-c.h>
 #include <daos/common.h>
-#include <abt.h>
 
 /*
  * Using a packetsocket over the unix domain socket means that we receive


### PR DESCRIPTION
Signed-off-by: Jeff Olivier <jeffrey.v.olivier@intel.com>