### PR TITLE
DAOS-2983 doc: update admin guide for Lustre integration

### DIFF
--- a/doc/admin/app_interface_tiering.md
+++ b/doc/admin/app_interface_tiering.md
@@ -181,6 +181,34 @@ The DAOS tier can be tightly integrated with the Lustre parallel filesystem in
 which DAOS containers will be represented through the Lustre namespace. This
 capability is under development and is scheduled for DAOS v1.2.
 
+Current state of work can be summarized as follow :
+
+-   DAOS integration with Lustre uses the Lustre foreign file/dir feature
+    (from LU-11376 and associated patches)
+ 
+-   each time a DAOS POSIX container is created, using `daos` utility and its
+    '--path' UNS option, a Lustre foreign file/dir of 'daos' type is being
+    created with a specific LOV/LMV EA content that will allow to store the
+    DAOS pool and containers UUIDs. 
+
+-   Lustre Client patch for LU-12682, adds DAOS specific support to the Lustre
+    foreign file/dir feature. It allows for foreign file/dir of `daos` type
+    to be presented and act as `<absolute-prefix>/<pool-uuid>/<container-uuid>`
+    a symlink to the Linux Kernel/VFS.
+
+-   the <absolute-prefix> can be specified as the new `daos=<absolute-prefix>`
+    Lustre Client mount option, or also thru the new `llite.*.daos_prefix`
+    Lustre dynamic tuneable. And both <pool-uuid> and <container-uuid> are
+    extracted from foreign file/dir LOV/LMV EA.
+ 
+-   to allow for symlink resolution and transparent access to DAOS concerned
+    container content, it is expected that a DFuse/DFS instance/mount, of
+    DAOS Server root, exists on <absolute-prefix> presenting all served
+    pools/containers as `<pool-uuid>/<container-uuid>` relative paths.
+
+-   `daos` foreign support is enabled at mount time with `daos=` option
+    present, or dynamically thru `llite.*.daos_enable` setting.
+
 ## HPC I/O Middleware Support
 
 Several HPC I/O middleware libraries have been ported to the native API.


### PR DESCRIPTION
Update to admin guide in order to give details on UNS/Lustre
integration implementation.

Change-Id: I155a80244e0b3f023d6406c2b2866d944c739bce
Signed-off-by: Bruno Faccini <bruno.faccini@intel.com>