### PR TITLE
DAOS-3304 tests: Enabling daos_agent on local host.

### DIFF
--- a/ftest.sh
+++ b/ftest.sh
@@ -312,7 +312,7 @@ print(\"{}.{}\".format(sys.version_info[0], sys.version_info[1]))')
 export PYTHONPATH=./util:../../utils/py/:./util/apricot:\
 ../../../install/lib/python\$launch_py_vers/site-packages
 
-if ! ./launch.py -c -a -r -s -ts ${TEST_NODES} ${TEST_TAG_ARR[*]}; then
+if ! ./launch.py -c -a -r -i -s -ts ${TEST_NODES} ${TEST_TAG_ARR[*]}; then
     rc=\${PIPESTATUS[0]}
 else
     rc=0

--- a/src/tests/ftest/launch.py
+++ b/src/tests/ftest/launch.py
@@ -410,7 +410,7 @@ def run_tests(test_files, tag_filter, args):
             # Optionally clean the log files before running this test on the
             # servers and clients specified for this test
             if args.clean:
-                if not clean_logs(test_file["yaml"]):
+                if not clean_logs(test_file["yaml"], args):
                     return 128
 
             # Execute this test
@@ -423,7 +423,7 @@ def run_tests(test_files, tag_filter, args):
             # Optionally store all of the doas server and client log files
             # along with the test results
             if args.archive:
-                archive_logs(avocado_logs_dir, test_file["yaml"])
+                archive_logs(avocado_logs_dir, test_file["yaml"], args)
 
             # Optionally rename the test results directory for this test
             if args.rename:
@@ -519,7 +519,7 @@ def find_yaml_hosts(test_yaml):
     return find_values(get_yaml_data(test_yaml), SERVER_KEYS + CLIENT_KEYS)
 
 
-def get_hosts_from_yaml(test_yaml):
+def get_hosts_from_yaml(test_yaml, args):
     """Extract the list of hosts from the test yaml file.
 
     This host will be included in the list if no clients are explicitly called
@@ -527,12 +527,15 @@ def get_hosts_from_yaml(test_yaml):
 
     Args:
         test_yaml (str): test yaml file
+        args (argparse.Namespace): command line arguments for this program
 
     Returns:
         list: a unique list of hosts specified in the test's yaml file
 
     """
     host_set = set()
+    if args.include_localhost:
+        host_set.add(socket.gethostname().split(".")[0])
     found_client_key = False
     for key, value in find_yaml_hosts(test_yaml).items():
         host_set.update(value)
@@ -546,17 +549,18 @@ def get_hosts_from_yaml(test_yaml):
     return sorted(list(host_set))
 
 
-def clean_logs(test_yaml):
+def clean_logs(test_yaml, args):
     """Remove the test log files on each test host.
 
     Args:
         test_yaml (str): yaml file containing host names
+        args (argparse.Namespace): command line arguments for this program
     """
     # Use the default server yaml and then the test yaml to update the default
     # DAOS log file locations.  This should simulate how the test defines which
     # log files it will use when it is run.
     log_files = get_log_files(test_yaml, get_log_files(BASE_LOG_FILE_YAML))
-    host_list = get_hosts_from_yaml(test_yaml)
+    host_list = get_hosts_from_yaml(test_yaml, args)
     command = "ssh {{host}} \"rm -fr {}\"".format(" ".join(log_files.values()))
     print("Cleaning logs on {}".format(host_list))
     if not spawn_commands(host_list, command):
@@ -566,16 +570,17 @@ def clean_logs(test_yaml):
     return True
 
 
-def archive_logs(avocado_logs_dir, test_yaml):
+def archive_logs(avocado_logs_dir, test_yaml, args):
     """Copy all of the host test log files to the avocado results directory.
 
     Args:
         avocado_logs_dir ([type]): [description]
         test_yaml (str): yaml file containing host names
+        args (argparse.Namespace): command line arguments for this program
     """
     this_host = socket.gethostname().split(".")[0]
     log_files = get_log_files(TEST_LOG_FILE_YAML)
-    host_list = get_hosts_from_yaml(test_yaml)
+    host_list = get_hosts_from_yaml(test_yaml, args)
     doas_logs_dir = os.path.join(avocado_logs_dir, "latest", "daos_logs")
 
     # Create a subdirectory in the avocado logs directory for this test
@@ -699,6 +704,10 @@ def main():
         action="store_true",
         help="when replacing server/client yaml file placeholders, discard "
              "any placeholders that do not end up with a replacement value")
+    parser.add_argument(
+        "-i", "--include_localhost",
+        action="store_true",
+        help="include the local host when cleaning and archiving")
     parser.add_argument(
         "-l", "--list",
         action="store_true",

--- a/src/tests/ftest/util/agent_utils.py
+++ b/src/tests/ftest/util/agent_utils.py
@@ -66,8 +66,7 @@ def run_agent(basepath, server_list, client_list=None):
     user = getpass.getuser()
 
     # if empty client list, 'self' is effectively client
-    if client_list is None:
-        client_list = [socket.gethostname().split('.', 1)[0]]
+    client_list = include_local_host(client_list)
 
     # Verify the domain socket directory is present and owned by this user
     file_checks = (
@@ -140,6 +139,24 @@ def run_agent(basepath, server_list, client_list=None):
     return sessions
 
 
+def include_local_host(hosts):
+    """Ensure the local host is included in the specified host list.
+
+    Args:
+        hosts (list): list of hosts
+
+    Returns:
+        list: list of hosts including the local host
+
+    """
+    local_host = socket.gethostname().split('.', 1)[0]
+    if hosts is None:
+        hosts = [local_host]
+    elif local_host not in hosts:
+        hosts.append(local_host)
+    return hosts
+
+
 def stop_agent(sessions, client_list=None):
     """Kill ssh and the agent.
 
@@ -156,8 +173,7 @@ def stop_agent(sessions, client_list=None):
 
     """
     # if empty client list, 'self' is effectively client
-    if client_list is None:
-        client_list = [socket.gethostname().split('.', 1)[0]]
+    client_list = include_local_host(client_list)
 
     # Kill the agents processes
     pcmd(client_list, "pkill daos_agent", False)


### PR DESCRIPTION
Ensure a daos_agent is run on the host executing launch.py in order to
prevent failures in DaosAPI calls.  Include the daos logs on this host
in the clean and archive opperations performed by launch.py.

Signed-off-by: Phillip Henderson <phillip.henderson@intel.com>