### PR TITLE
DAOS-2429 dtx: DTX performance optimization - keep committed DTX in DRAM - based on new punch model

### DIFF
--- a/src/container/srv_target.c
+++ b/src/container/srv_target.c
@@ -87,7 +87,6 @@ cont_child_alloc_ref(void *key, unsigned int ksize, void *varg,
 		goto out_cond;
 
 	uuid_copy(cont->sc_uuid, key);
-	cont->sc_dtx_resync_time = crt_hlc_get();
 	/* prevent aggregation till snapshot iv refreshed */
 	cont->sc_aggregation_max = 0;
 	cont->sc_snapshots_nr = 0;
@@ -104,6 +103,80 @@ cont_child_alloc_ref(void *key, unsigned int ksize, void *varg,
  out:
 	D_FREE(cont);
 	return rc;
+}
+
+void
+ds_cont_dtx_reindex_ult(void *arg)
+{
+	struct ds_cont_child		*cont	= arg;
+	struct dss_module_info		*dmi	= dss_get_module_info();
+	uint64_t			 hint	= 0;
+	int				 rc;
+
+	D_DEBUG(DF_DSMS, DF_CONT": starting DTX reindex ULT on xstream %d\n",
+		DP_CONT(NULL, cont->sc_uuid), dmi->dmi_tgt_id);
+
+	while (!cont->sc_dtx_reindex_abort) {
+		rc = vos_dtx_reindex(cont->sc_hdl, &hint);
+		if (rc < 0) {
+			D_ERROR(DF_UUID": DTX reindex failed: rc = %d\n",
+				DP_UUID(cont->sc_uuid), rc);
+			goto out;
+		}
+
+		if (rc > 0) {
+			D_DEBUG(DF_DSMS, DF_CONT": DTX reindex done\n",
+				DP_CONT(NULL, cont->sc_uuid));
+			goto out;
+		}
+
+		if (dss_xstream_exiting(dmi->dmi_xstream))
+			break;
+
+		ABT_thread_yield();
+	}
+
+	D_DEBUG(DF_DSMS, DF_CONT": stopping DTX reindex ULT on stream %d\n",
+		DP_CONT(NULL, cont->sc_uuid), dmi->dmi_tgt_id);
+
+out:
+	cont->sc_dtx_reindex = 0;
+	ds_cont_child_put(cont);
+}
+
+static int
+cont_start_dtx_reindex_ult(struct ds_cont_child *cont)
+{
+	int rc;
+
+	D_ASSERT(cont != NULL);
+
+	if (cont->sc_dtx_reindex || cont->sc_dtx_reindex_abort)
+		return 0;
+
+	ds_cont_child_get(cont);
+	cont->sc_dtx_reindex = 1;
+	rc = dss_ult_create(ds_cont_dtx_reindex_ult, cont,
+			    DSS_ULT_DTX_RESYNC, DSS_TGT_SELF, 0, NULL);
+	if (rc != 0) {
+		D_ERROR(DF_UUID": Failed to create DTX reindex ULT: rc %d\n",
+			DP_UUID(cont->sc_uuid), rc);
+		cont->sc_dtx_reindex = 0;
+		ds_cont_child_put(cont);
+	}
+
+	return rc;
+}
+
+static void
+cont_stop_dtx_reindex_ult(struct ds_cont_child *cont)
+{
+	cont->sc_dtx_reindex_abort = 1;
+
+	while (cont->sc_dtx_reindex)
+		ABT_thread_yield();
+
+	cont->sc_dtx_reindex_abort = 0;
 }
 
 static int
@@ -132,6 +205,9 @@ static void
 cont_stop_agg_ult(struct ds_cont_child *cont)
 {
 	int rc;
+
+	if (!cont->sc_vos_aggregating)
+		return;
 
 	D_DEBUG(DF_DSMS, DF_CONT": Stopping aggregation ULT\n",
 		DP_CONT(NULL, cont->sc_uuid));
@@ -850,6 +926,10 @@ ds_cont_local_open(uuid_t pool_uuid, uuid_t cont_hdl_uuid, uuid_t cont_uuid,
 		if (rc)
 			goto err_cont;
 
+		rc = cont_start_dtx_reindex_ult(hdl->sch_cont);
+		if (rc != 0)
+			goto err_cont;
+
 		rc = dtx_batched_commit_register(hdl);
 		if (rc != 0) {
 			D_ERROR("Failed to register the container "DF_UUID
@@ -887,6 +967,8 @@ err_cont:
 	if (hdl->sch_cont)
 		cont_child_put(tls->dt_cont_cache, hdl->sch_cont);
 
+	cont_stop_dtx_reindex_ult(hdl->sch_cont);
+	cont_stop_agg_ult(hdl->sch_cont);
 	if (vos_co_created) {
 		D_DEBUG(DF_DSMS, DF_CONT": destroying new vos container\n",
 			DP_CONT(hdl->sch_pool->spc_uuid, cont_uuid));

--- a/src/dtx/dtx_common.c
+++ b/src/dtx/dtx_common.c
@@ -49,7 +49,7 @@ dtx_aggregate(void *arg)
 	while (!cont->sc_closing) {
 		int	rc;
 
-		rc = vos_dtx_aggregate(cont->sc_hdl, DTX_AGG_YIELD_INTERVAL,
+		rc = vos_dtx_aggregate(cont->sc_hdl, DTX_YIELD_CYCLE,
 				       DTX_AGG_THRESHOLD_AGE_LOWER);
 		if (rc != 0)
 			break;
@@ -205,7 +205,7 @@ dtx_handle_init(struct dtx_id *dti, daos_unit_oid_t *oid, daos_handle_t coh,
 		daos_epoch_t epoch, uint64_t dkey_hash, uint32_t pm_ver,
 		uint32_t intent, struct dtx_conflict_entry *conflict,
 		struct dtx_id *dti_cos, int dti_cos_count, bool leader,
-		bool no_rep, struct dtx_handle *dth)
+		bool single_participator, struct dtx_handle *dth)
 {
 	dth->dth_xid = *dti;
 	dth->dth_oid = *oid;
@@ -216,7 +216,7 @@ dtx_handle_init(struct dtx_id *dti, daos_unit_oid_t *oid, daos_handle_t coh,
 	dth->dth_ver = pm_ver;
 	dth->dth_intent = intent;
 	dth->dth_leader = leader ? 1 : 0;
-	dth->dth_non_rep = no_rep ? 1 : 0;
+	dth->dth_single_participator = single_participator ? 1 : 0;
 	dth->dth_dti_cos = dti_cos;
 	dth->dth_dti_cos_count = dti_cos_count;
 	dth->dth_conflict = conflict;
@@ -274,7 +274,6 @@ dtx_leader_begin(struct dtx_id *dti, daos_unit_oid_t *oid, daos_handle_t coh,
 		return 0;
 	}
 
-	dlh->dlh_handled_time = crt_hlc_get();
 	dlh->dlh_future = ABT_FUTURE_NULL;
 	D_ALLOC(dlh->dlh_subs, tgts_cnt * sizeof(*dlh->dlh_subs));
 	if (dlh->dlh_subs == NULL)
@@ -582,50 +581,8 @@ dtx_leader_end(struct dtx_leader_handle *dlh, struct ds_cont_hdl *cont_hdl,
 	if (result < 0 || rc < 0 || daos_is_zero_dti(&dth->dth_xid))
 		D_GOTO(fail, result = (result == 0 ? rc : result));
 
-	/* If the DTX is started befoe DTX resync operation (for rebuild),
-	 * then it is possbile that the DTX resync ULT may have aborted
-	 * or committed the DTX during current ULT waiting for the reply.
-	 * let's check DTX status locally before marking as 'committable'.
-	 */
-	if (dlh->dlh_handled_time <= cont->sc_dtx_resync_time) {
-		rc = vos_dtx_check(cont->sc_hdl, &dth->dth_xid);
-		switch (rc) {
-		case DTX_ST_PREPARED:
-			rc = vos_dtx_lookup_cos(dth->dth_coh, &dth->dth_oid,
-					&dth->dth_xid, dth->dth_dkey_hash,
-					dth->dth_intent == DAOS_INTENT_PUNCH ?
-					true : false);
-			/* The resync ULT has already added it into the CoS
-			 * cache, current ULT needs to do nothing.
-			 */
-			if (rc == 0)
-				D_GOTO(out_free, result = 0);
-
-			/* normal case, then add it to CoS cache. */
-			if (rc == -DER_NONEXIST)
-				break;
-
-			D_GOTO(fail, result = (rc >= 0 ? -DER_INVAL : rc));
-		case DTX_ST_COMMITTED:
-			/* The DTX has been committed by resync ULT by race,
-			 * set dth_sync to indicate that in log.
-			 */
-			dth->dth_sync = 1;
-			D_GOTO(out_free, result = 0);
-		case -DER_NONEXIST:
-			/* The DTX has been aborted by resync ULT, ask the
-			 * client to retry via returning -DER_INPROGRESS.
-			 */
-			result = -DER_INPROGRESS;
-			goto out_free;
-		default:
-			result = rc >= 0 ? -DER_INVAL : rc;
-			goto fail;
-		}
-	}
-
 	rc = vos_dtx_add_cos(dth->dth_coh, &dth->dth_oid, &dth->dth_xid,
-			     dth->dth_dkey_hash, dth->dth_epoch,
+			     dth->dth_dkey_hash, dth->dth_epoch, dth->dth_gen,
 			     dth->dth_intent == DAOS_INTENT_PUNCH ?
 			     true : false, true);
 	if (rc == -DER_INPROGRESS) {
@@ -635,6 +592,18 @@ dtx_leader_end(struct dtx_leader_handle *dlh, struct ds_cont_hdl *cont_hdl,
 		       dth->dth_epoch);
 		D_GOTO(fail, result = rc);
 	}
+
+	/* The DTX has been aborted by resync ULT, ask the client to retry. */
+	if (rc == -DER_NONEXIST) {
+		D_WARN(DF_UUID": Fail to add DTX "DF_DTI" with eph "DF_U64
+		       "to CoS because of being aborted by race\n",
+		       DP_UUID(cont->sc_uuid), DP_DTI(&dth->dth_xid),
+		       dth->dth_epoch);
+		D_GOTO(out_free, result = -DER_INPROGRESS);
+	}
+
+	if (rc == -DER_ALREADY)
+		D_GOTO(out_free, result = 0);
 
 	if (rc != 0) {
 		D_WARN(DF_UUID": Fail to add DTX "DF_DTI" to CoS cache: %d. "
@@ -673,7 +642,8 @@ out_free:
 		(unsigned long long)dth->dth_dkey_hash,
 		dth->dth_intent == DAOS_INTENT_PUNCH ? "Punch" : "Update",
 		dth->dth_sync ? "sync" : "async",
-		dth->dth_non_rep ? "non-replicated" : "replicated", result);
+		dth->dth_single_participator ? "single-participator" :
+		"multiple-participators", result);
 
 	if (dth->dth_dti_cos != NULL)
 		D_FREE(dth->dth_dti_cos);
@@ -895,6 +865,7 @@ dtx_handle_resend(daos_handle_t coh, daos_unit_oid_t *oid, struct dtx_id *dti,
 		 */
 		return -DER_NONEXIST;
 
+again:
 	rc = vos_dtx_check_resend(coh, oid, dti, dkey_hash, punch, epoch);
 	switch (rc) {
 	case DTX_ST_PREPARED:
@@ -910,6 +881,12 @@ dtx_handle_resend(daos_handle_t coh, daos_unit_oid_t *oid, struct dtx_id *dti,
 			rc = -DER_EP_OLD;
 		}
 		return rc;
+	case -DER_AGAIN:
+		/* Re-index committed DTX table is not completed yet,
+		 * let's wait and retry.
+		 */
+		ABT_thread_yield();
+		goto again;
 	default:
 		return rc >= 0 ? -DER_INVAL : rc;
 	}

--- a/src/dtx/dtx_internal.h
+++ b/src/dtx/dtx_internal.h
@@ -71,7 +71,7 @@ CRT_RPC_DECLARE(dtx, DAOS_ISEQ_DTX, DAOS_OSEQ_DTX);
 /* The count threshould for triggerring DTX aggregation.
  * This threshould should consider the real SCM size.
  */
-#define DTX_AGG_THRESHOLD_CNT		(1 << 27)
+#define DTX_AGG_THRESHOLD_CNT		(1 << 28)
 
 /* The time threshould for triggerring DTX aggregation. If the oldest
  * DTX in the DTX table exceeds such threshould, it will trigger DTX
@@ -84,7 +84,7 @@ CRT_RPC_DECLARE(dtx, DAOS_ISEQ_DTX, DAOS_OSEQ_DTX);
  */
 #define DTX_AGG_THRESHOLD_AGE_LOWER	3600
 
-#define DTX_AGG_YIELD_INTERVAL		DTX_THRESHOLD_COUNT
+#define DTX_YIELD_CYCLE			(DTX_THRESHOLD_COUNT >> 3)
 
 extern struct crt_proto_format dtx_proto_fmt;
 extern btr_ops_t dbtree_dtx_cf_ops;

--- a/src/dtx/dtx_rpc.c
+++ b/src/dtx/dtx_rpc.c
@@ -655,7 +655,7 @@ dtx_abort(uuid_t po_uuid, uuid_t co_uuid, daos_epoch_t epoch,
 	D_ASSERT(dti != NULL);
 
 	/* Local abort firstly. */
-	rc = vos_dtx_abort(cont->sc_hdl, epoch, dti, count, false);
+	rc = vos_dtx_abort(cont->sc_hdl, epoch, dti, count);
 
 	if (rc == -DER_NONEXIST)
 		rc = 0;

--- a/src/dtx/dtx_srv.c
+++ b/src/dtx/dtx_srv.c
@@ -39,7 +39,11 @@ dtx_handler(crt_rpc_t *rpc)
 	struct dtx_in		*din = crt_req_get(rpc);
 	struct dtx_out		*dout = crt_reply_get(rpc);
 	struct ds_cont_child	*cont = NULL;
+	struct dtx_id		*dtis;
 	uint32_t		 opc = opc_get(rpc->cr_opc);
+	int			 count = DTX_YIELD_CYCLE;
+	int			 i = 0;
+	int			 rc1;
 	int			 rc;
 
 	rc = ds_cont_child_lookup(din->di_po_uuid, din->di_co_uuid, &cont);
@@ -52,13 +56,31 @@ dtx_handler(crt_rpc_t *rpc)
 
 	switch (opc) {
 	case DTX_COMMIT:
-		rc = vos_dtx_commit(cont->sc_hdl, din->di_dtx_array.ca_arrays,
-				    din->di_dtx_array.ca_count);
+		while (i < din->di_dtx_array.ca_count) {
+			if (i + count > din->di_dtx_array.ca_count)
+				count = din->di_dtx_array.ca_count - i;
+
+			dtis = (struct dtx_id *)din->di_dtx_array.ca_arrays + i;
+			rc1 = vos_dtx_commit(cont->sc_hdl, dtis, count);
+			if (rc == 0 && rc1 != 0)
+				rc = rc1;
+
+			i += count;
+		}
 		break;
 	case DTX_ABORT:
-		rc = vos_dtx_abort(cont->sc_hdl, din->di_epoch,
-				   din->di_dtx_array.ca_arrays,
-				   din->di_dtx_array.ca_count, true);
+		while (i < din->di_dtx_array.ca_count) {
+			if (i + count > din->di_dtx_array.ca_count)
+				count = din->di_dtx_array.ca_count - i;
+
+			dtis = (struct dtx_id *)din->di_dtx_array.ca_arrays + i;
+			rc1 = vos_dtx_abort(cont->sc_hdl, din->di_epoch,
+					    dtis, count);
+			if (rc == 0 && rc1 != 0)
+				rc = rc1;
+
+			i += count;
+		}
 		break;
 	case DTX_CHECK:
 		/* Currently, only support to check single DTX state. */

--- a/src/include/daos_srv/container.h
+++ b/src/include/daos_srv/container.h
@@ -59,10 +59,10 @@ struct ds_cont_child {
 	ABT_mutex		 sc_mutex;
 	ABT_cond		 sc_dtx_resync_cond;
 	void			*sc_dtx_flush_cbdata;
-	/* The time for the latest DTX resync operation. */
-	uint64_t		 sc_dtx_resync_time;
 	uint32_t		 sc_dtx_resyncing:1,
 				 sc_dtx_aggregating:1,
+				 sc_dtx_reindex:1,
+				 sc_dtx_reindex_abort:1,
 				 sc_vos_aggregating:1,
 				 sc_abort_vos_aggregating:1,
 				 sc_closing:1,

--- a/src/include/daos_srv/dtx_srv.h
+++ b/src/include/daos_srv/dtx_srv.h
@@ -60,6 +60,8 @@ struct dtx_handle {
 	daos_handle_t			 dth_coh;
 	/** The epoch# for the DTX. */
 	daos_epoch_t			 dth_epoch;
+	/* The generation when the DTX is handled on the server. */
+	uint64_t			 dth_gen;
 	/** The {obj/dkey/akey}-tree records that are created
 	 * by other DTXs, but not ready for commit yet.
 	 */
@@ -72,7 +74,8 @@ struct dtx_handle {
 	uint32_t			 dth_intent;
 	uint32_t			 dth_sync:1, /* commit synchronously. */
 					 dth_leader:1, /* leader replica. */
-					 dth_non_rep:1, /* non-replicated. */
+					 /* Only one participator in the DTX. */
+					 dth_single_participator:1,
 					 /* dti_cos has been committed. */
 					 dth_dti_cos_done:1;
 	/* The count the DTXs in the dth_dti_cos array. */
@@ -98,8 +101,6 @@ struct dtx_sub_status {
 struct dtx_leader_handle {
 	/* The dtx handle on the leader node */
 	struct dtx_handle		dlh_handle;
-	/* The time when the DTX is handled on the server. */
-	uint64_t			dlh_handled_time;
 	/* result for the distribute transaction */
 	int				dlh_result;
 

--- a/src/include/daos_srv/vos.h
+++ b/src/include/daos_srv/vos.h
@@ -38,6 +38,17 @@
 #include <daos_srv/vos_types.h>
 
 /**
+ * Refresh the DTX resync generation.
+ *
+ * \param coh	[IN]	Container open handle.
+ *
+ * \return		Zero on success.
+ * \return		Negative value if error.
+ */
+int
+vos_dtx_update_resync_gen(daos_handle_t coh);
+
+/**
  * Add the given DTX to the Commit-on-Share (CoS) cache (in DRAM).
  *
  * \param coh		[IN]	Container open handle.
@@ -45,6 +56,7 @@
  * \param dti		[IN]	The DTX identifier.
  * \param dkey_hash	[IN]	The hashed dkey.
  * \param epoch		[IN]	The DTX epoch.
+ * \param gen		[IN]	The DTX generation.
  * \param punch		[IN]	For punch DTX or not.
  * \param check		[IN]	Check whether the DTX need restart because
  *				of sync epoch or not.
@@ -55,7 +67,8 @@
  */
 int
 vos_dtx_add_cos(daos_handle_t coh, daos_unit_oid_t *oid, struct dtx_id *dti,
-		uint64_t dkey_hash, daos_epoch_t epoch, bool punch, bool check);
+		uint64_t dkey_hash, daos_epoch_t epoch, uint64_t gen,
+		bool punch, bool check);
 
 /**
  * Search the specified DTX is in the CoS cache or not.
@@ -174,14 +187,12 @@ vos_dtx_commit(daos_handle_t coh, struct dtx_id *dtis, int count);
  * \param epoch	[IN]	The max epoch for the DTX to be aborted.
  * \param dtis	[IN]	The array for DTX identifiers to be aborted.
  * \param count [IN]	The count of DTXs to be aborted.
- * \param force [IN]	Force abort even if some replica(s) have not
- *			'prepared' related DTXs.
  *
  * \return		Zero on success, negative value if error.
  */
 int
 vos_dtx_abort(daos_handle_t coh, daos_epoch_t epoch, struct dtx_id *dtis,
-	      int count, bool force);
+	      int count);
 
 /**
  * Aggregate the committed DTXs.
@@ -217,6 +228,20 @@ vos_dtx_stat(daos_handle_t coh, struct dtx_stat *stat);
  */
 int
 vos_dtx_mark_sync(daos_handle_t coh, daos_unit_oid_t oid, daos_epoch_t epoch);
+
+/**
+ * Establish the indexed committed DTX table in DRAM.
+ *
+ * \param coh	[IN]		Container open handle.
+ * \param hint	[IN,OUT]	Pointer to the address (offset in SCM) that
+ *				contains committed DTX entries to be handled.
+ *
+ * \return	Zero on success, need further re-index.
+ *		Positive, re-index is completed.
+ *		Negative value if error.
+ */
+int
+vos_dtx_reindex(daos_handle_t coh, void *hint);
 
 /**
  * Initialize the environment for a VOS instance

--- a/src/include/daos_srv/vos_types.h
+++ b/src/include/daos_srv/vos_types.h
@@ -226,8 +226,8 @@ typedef struct {
 	union {
 		/** Returned earliest update epoch for a key */
 		daos_epoch_t			ie_earliest;
-		/** Return the DTX handled time for DTX iteration. */
-		uint64_t			ie_dtx_time;
+		/** record size */
+		daos_size_t			ie_rsize;
 	};
 	union {
 		/** Returned entry for container UUID iterator */
@@ -251,8 +251,6 @@ typedef struct {
 			uint32_t		ie_dtx_intent;
 		};
 		struct {
-			/** record size */
-			daos_size_t		ie_rsize;
 			/** record extent */
 			daos_recx_t		ie_recx;
 			/* original in-tree extent */

--- a/src/object/srv_obj.c
+++ b/src/object/srv_obj.c
@@ -1042,7 +1042,7 @@ ds_obj_tgt_update_handler(crt_rpc_t *rpc)
 			 * that it can be aborted.
 			 */
 			rc = vos_dtx_abort(cont->sc_hdl, DAOS_EPOCH_MAX,
-					   &orw->orw_dti, 1, true);
+					   &orw->orw_dti, 1);
 
 		if (rc != 0 && rc != -DER_NONEXIST)
 			D_GOTO(out, rc);
@@ -1154,7 +1154,11 @@ ds_obj_rw_handler(crt_rpc_t *rpc)
 		orw->orw_map_ver, map_ver, DP_DTI(&orw->orw_dti));
 	/* FIXME: until distributed transaction. */
 	if (orw->orw_epoch == DAOS_EPOCH_MAX) {
-		orw->orw_epoch = crt_hlc_get();
+		if (daos_is_zero_dti(&orw->orw_dti) ||
+		    orw->orw_flags & ORF_RESEND)
+			orw->orw_epoch = crt_hlc_get();
+		else
+			orw->orw_epoch = orw->orw_dti.dti_hlc;
 		D_DEBUG(DB_IO, "overwrite epoch "DF_U64"\n", orw->orw_epoch);
 	}
 
@@ -1654,7 +1658,7 @@ ds_obj_tgt_punch_handler(crt_rpc_t *rpc)
 			 * that it can be aborted.
 			 */
 			rc = vos_dtx_abort(cont->sc_hdl, DAOS_EPOCH_MAX,
-					   &opi->opi_dti, 1, true);
+					   &opi->opi_dti, 1);
 
 		if (rc != 0 && rc != -DER_NONEXIST)
 			D_GOTO(out, rc);
@@ -1742,7 +1746,11 @@ ds_obj_punch_handler(crt_rpc_t *rpc)
 
 	/* FIXME: until distributed transaction. */
 	if (opi->opi_epoch == DAOS_EPOCH_MAX) {
-		opi->opi_epoch = crt_hlc_get();
+		if (daos_is_zero_dti(&opi->opi_dti) ||
+		    opi->opi_flags & ORF_RESEND)
+			opi->opi_epoch = crt_hlc_get();
+		else
+			opi->opi_epoch = opi->opi_dti.dti_hlc;
 		D_DEBUG(DB_IO, "overwrite epoch "DF_U64"\n", opi->opi_epoch);
 	}
 

--- a/src/vos/tests/vts_dtx.c
+++ b/src/vos/tests/vts_dtx.c
@@ -44,7 +44,7 @@ vts_dtx_cos(void **state, bool punch)
 
 	/* Insert a DTX into CoS cache. */
 	rc = vos_dtx_add_cos(args->ctx.tc_co_hdl, &args->oid, &xid,
-			     dkey_hash, DAOS_EPOCH_MAX - 1, punch, false);
+			     dkey_hash, DAOS_EPOCH_MAX - 1, 0, punch, false);
 	assert_int_equal(rc, 0);
 
 	/* Query the DTX with different @punch parameter will find nothing. */
@@ -99,7 +99,7 @@ dtx_3(void **state)
 		daos_dti_gen(&xid, false);
 
 		rc = vos_dtx_add_cos(args->ctx.tc_co_hdl, &args->oid, &xid,
-				     dkey_hash, DAOS_EPOCH_MAX - 1,
+				     dkey_hash, DAOS_EPOCH_MAX - 1, 0,
 				     i % 2 ? true : false, false);
 		assert_int_equal(rc, 0);
 	}
@@ -139,7 +139,7 @@ dtx_4(void **state)
 		dkey_hash = lrand48();
 
 		rc = vos_dtx_add_cos(args->ctx.tc_co_hdl, &args->oid, &xid[i],
-				     dkey_hash, DAOS_EPOCH_MAX - 1,
+				     dkey_hash, DAOS_EPOCH_MAX - 1, 0,
 				     i % 2 ? false : true, false);
 		assert_int_equal(rc, 0);
 	}
@@ -300,7 +300,7 @@ dtx_5(void **state)
 
 	/* Add former DTX into CoS cache. */
 	rc = vos_dtx_add_cos(args->ctx.tc_co_hdl, &args->oid, &xid,
-			     dkey_hash, epoch, false, false);
+			     dkey_hash, epoch, 0, false, false);
 	assert_int_equal(rc, 0);
 
 	vos_dtx_stat(args->ctx.tc_co_hdl, &stat);
@@ -388,10 +388,10 @@ vts_dtx_commit_visibility(struct io_test_args *args, bool ext, bool punch_obj)
 	assert_int_equal(rc, 0);
 
 	if (punch_obj)
-		rc = vos_obj_punch(args->ctx.tc_co_hdl, args->oid, ++epoch,
+		rc = vos_obj_punch(args->ctx.tc_co_hdl, args->oid, epoch,
 				   1, 0, NULL, 0, NULL, dth);
 	else
-		rc = vos_obj_punch(args->ctx.tc_co_hdl, args->oid, ++epoch,
+		rc = vos_obj_punch(args->ctx.tc_co_hdl, args->oid, epoch,
 				   1, 0, &dkey, 1, &akey, dth);
 	assert_int_equal(rc, 0);
 
@@ -509,7 +509,7 @@ vts_dtx_abort_visibility(struct io_test_args *args, bool ext, bool punch_obj)
 	vts_dtx_end(dth);
 
 	/* Aborted the update DTX. */
-	rc = vos_dtx_abort(args->ctx.tc_co_hdl, epoch, &xid, 1, false);
+	rc = vos_dtx_abort(args->ctx.tc_co_hdl, epoch, &xid, 1);
 	assert_int_equal(rc, 0);
 
 	memset(fetch_buf, 0, UPDATE_BUF_SIZE);
@@ -543,7 +543,7 @@ vts_dtx_abort_visibility(struct io_test_args *args, bool ext, bool punch_obj)
 	vts_dtx_end(dth);
 
 	/* Aborted the punch DTX. */
-	rc = vos_dtx_abort(args->ctx.tc_co_hdl, epoch, &xid, 1, false);
+	rc = vos_dtx_abort(args->ctx.tc_co_hdl, epoch, &xid, 1);
 	assert_int_equal(rc, 0);
 
 	memset(fetch_buf, 0, UPDATE_BUF_SIZE);
@@ -646,7 +646,7 @@ dtx_14(void **state)
 	 * But we cannot check "assert_int_not_equal(rc, 0)" that depends
 	 * on the umem_tx_abort() which may return 0 for vmem based case.
 	 */
-	vos_dtx_abort(args->ctx.tc_co_hdl, epoch, &xid, 1, false);
+	vos_dtx_abort(args->ctx.tc_co_hdl, epoch, &xid, 1);
 
 	memset(fetch_buf, 0, UPDATE_BUF_SIZE);
 	d_iov_set(&val_iov, fetch_buf, UPDATE_BUF_SIZE);
@@ -708,11 +708,11 @@ dtx_15(void **state)
 	vts_dtx_end(dth);
 
 	/* Aborted the update DTX. */
-	rc = vos_dtx_abort(args->ctx.tc_co_hdl, epoch, &xid, 1, false);
+	rc = vos_dtx_abort(args->ctx.tc_co_hdl, epoch, &xid, 1);
 	assert_int_equal(rc, 0);
 
 	/* Double aborted the DTX is harmless. */
-	vos_dtx_abort(args->ctx.tc_co_hdl, epoch, &xid, 1, false);
+	vos_dtx_abort(args->ctx.tc_co_hdl, epoch, &xid, 1);
 
 	memset(fetch_buf, 0, UPDATE_BUF_SIZE);
 	d_iov_set(&val_iov, fetch_buf, UPDATE_BUF_SIZE);
@@ -801,7 +801,7 @@ dtx_16(void **state)
 
 	/* Insert a DTX into CoS cache. */
 	rc = vos_dtx_add_cos(args->ctx.tc_co_hdl, &args->oid, &xid,
-			     dkey_hash, epoch, false, false);
+			     dkey_hash, epoch, 0, false, false);
 	assert_int_equal(rc, 0);
 
 	/* Fetch again. */
@@ -989,13 +989,14 @@ dtx_18(void **state)
 	rc = vos_dtx_commit(args->ctx.tc_co_hdl, xid, 10);
 	assert_int_equal(rc, 0);
 
-	/* Aggregate the first 4 DTXs. */
 	for (i = 0; i < 10; i++) {
 		rc = vos_dtx_check(args->ctx.tc_co_hdl, &xid[i]);
 		assert_int_equal(rc, DTX_ST_COMMITTED);
 	}
 
 	sleep(3);
+
+	/* Aggregate the first 4 DTXs. */
 	rc = vos_dtx_aggregate(args->ctx.tc_co_hdl, 4, 1);
 	assert_int_equal(rc, 0);
 
@@ -1134,14 +1135,14 @@ vts_dtx_shares(struct io_test_args *args, int *commit_list, int commit_count,
 		for (i = 0; i < abort_count; i++) {
 			rc = vos_dtx_abort(args->ctx.tc_co_hdl,
 					   epoch[abort_list[i]],
-					   &xid[abort_list[i]], 1, false);
+					   &xid[abort_list[i]], 1);
 			assert_int_equal(rc, 0);
 		}
 	} else {
 		for (i = 0; i < abort_count; i++) {
 			rc = vos_dtx_abort(args->ctx.tc_co_hdl,
 					   epoch[abort_list[i]],
-					   &xid[abort_list[i]], 1, false);
+					   &xid[abort_list[i]], 1);
 			assert_int_equal(rc, 0);
 		}
 
@@ -1406,14 +1407,13 @@ vts_dtx_shares_with_punch(struct io_test_args *args, bool punch_obj, bool abort)
 
 	/* Abort or commit the punch DTX. */
 	if (abort)
-		rc = vos_dtx_abort(args->ctx.tc_co_hdl, epoch[3], &xid[3], 1,
-				   false);
+		rc = vos_dtx_abort(args->ctx.tc_co_hdl, epoch[3], &xid[3], 1);
 	else
 		rc = vos_dtx_commit(args->ctx.tc_co_hdl, &xid[3], 1);
 	assert_int_equal(rc, 0);
 
 	/* Abort the first update DTX. */
-	rc = vos_dtx_abort(args->ctx.tc_co_hdl, epoch[0], &xid[0], 1, false);
+	rc = vos_dtx_abort(args->ctx.tc_co_hdl, epoch[0], &xid[0], 1);
 	assert_int_equal(rc, 0);
 
 	/* Commit the third update DTX. */

--- a/src/vos/vos_container.c
+++ b/src/vos/vos_container.c
@@ -100,6 +100,7 @@ cont_df_rec_alloc(struct btr_instance *tins, d_iov_t *key_iov,
 
 	cont_df = umem_off2ptr(&tins->ti_umm, offset);
 	uuid_copy(cont_df->cd_id, ukey->uuid);
+	cont_df->cd_dtx_resync_gen = 1;
 
 	rc = dbtree_create_inplace_ex(VOS_BTR_OBJ_TABLE, 0, VOS_OBJ_ORDER,
 				      &pool->vp_uma, &cont_df->cd_obj_root,
@@ -110,11 +111,15 @@ cont_df_rec_alloc(struct btr_instance *tins, d_iov_t *key_iov,
 	}
 	dbtree_close(hdl);
 
-	rc = vos_dtx_table_create(pool, &cont_df->cd_dtx_table_df);
+	rc = dbtree_create_inplace_ex(VOS_BTR_DTX_ACT_TABLE, 0,
+				      DTX_BTREE_ORDER, &pool->vp_uma,
+				      &cont_df->cd_dtx_active,
+				      DAOS_HDL_INVAL, pool, &hdl);
 	if (rc) {
-		D_ERROR("Failed to create DTX table: rc = %d\n", rc);
+		D_ERROR("Failed to create active DTX table: rc = %d\n", rc);
 		D_GOTO(failed, rc);
 	}
+	dbtree_close(hdl);
 
 	args->ca_cont_df = cont_df;
 	rec->rec_off = offset;
@@ -197,9 +202,14 @@ cont_free(struct d_ulink *ulink)
 
 	if (!daos_handle_is_inval(cont->vc_dtx_cos_hdl))
 		dbtree_destroy(cont->vc_dtx_cos_hdl, NULL);
-	D_ASSERT(d_list_empty(&cont->vc_dtx_committable));
+	D_ASSERT(d_list_empty(&cont->vc_dtx_committable_list));
+
+	if (!daos_handle_is_inval(cont->vc_dtx_committed_hdl))
+		dbtree_destroy(cont->vc_dtx_committed_hdl, NULL);
+	D_ASSERT(d_list_empty(&cont->vc_dtx_committed_list));
+	D_ASSERT(d_list_empty(&cont->vc_dtx_committed_tmp_list));
+
 	dbtree_close(cont->vc_dtx_active_hdl);
-	dbtree_close(cont->vc_dtx_committed_hdl);
 	dbtree_close(cont->vc_btr_hdl);
 
 	for (i = 0; i < VOS_IOS_CNT; i++) {
@@ -363,9 +373,15 @@ vos_cont_open(daos_handle_t poh, uuid_t co_uuid, daos_handle_t *coh)
 	uuid_copy(cont->vc_id, co_uuid);
 	cont->vc_pool	 = pool;
 	cont->vc_cont_df = args.ca_cont_df;
+	cont->vc_dtx_committed_hdl = DAOS_HDL_INVAL;
 	cont->vc_dtx_cos_hdl = DAOS_HDL_INVAL;
-	D_INIT_LIST_HEAD(&cont->vc_dtx_committable);
+	D_INIT_LIST_HEAD(&cont->vc_dtx_committable_list);
+	D_INIT_LIST_HEAD(&cont->vc_dtx_committed_list);
+	D_INIT_LIST_HEAD(&cont->vc_dtx_committed_tmp_list);
 	cont->vc_dtx_committable_count = 0;
+	cont->vc_dtx_committed_count = 0;
+	cont->vc_dtx_committed_tmp_count = 0;
+	cont->vc_dtx_resync_gen = cont->vc_cont_df->cd_dtx_resync_gen;
 
 	/* Cache this btr object ID in container handle */
 	rc = dbtree_open_inplace_ex(&cont->vc_cont_df->cd_obj_root,
@@ -376,17 +392,8 @@ vos_cont_open(daos_handle_t poh, uuid_t co_uuid, daos_handle_t *coh)
 		D_GOTO(exit, rc);
 	}
 
-	rc = dbtree_open_inplace(
-			&cont->vc_cont_df->cd_dtx_table_df.tt_committed_btr,
-			&pool->vp_uma, &cont->vc_dtx_committed_hdl);
-	if (rc) {
-		D_ERROR("Failed to open committed DTX table: rc = %d\n", rc);
-		D_GOTO(exit, rc);
-	}
-
-	rc = dbtree_open_inplace(
-			&cont->vc_cont_df->cd_dtx_table_df.tt_active_btr,
-			&pool->vp_uma, &cont->vc_dtx_active_hdl);
+	rc = dbtree_open_inplace(&cont->vc_cont_df->cd_dtx_active,
+				 &pool->vp_uma, &cont->vc_dtx_active_hdl);
 	if (rc) {
 		D_ERROR("Failed to open active DTX table: rc = %d\n", rc);
 		D_GOTO(exit, rc);
@@ -394,10 +401,19 @@ vos_cont_open(daos_handle_t poh, uuid_t co_uuid, daos_handle_t *coh)
 
 	memset(&uma, 0, sizeof(uma));
 	uma.uma_id = UMEM_CLASS_VMEM;
-	memset(&cont->vc_dtx_cos_btr, 0, sizeof(cont->vc_dtx_cos_btr));
-	rc = dbtree_create_inplace(VOS_BTR_DTX_COS, 0, VOS_CONT_ORDER, &uma,
-				   &cont->vc_dtx_cos_btr,
-				   &cont->vc_dtx_cos_hdl);
+	rc = dbtree_create_inplace_ex(VOS_BTR_DTX_CMT_TABLE, 0,
+				      DTX_BTREE_ORDER, &uma,
+				      &cont->vc_dtx_committed_btr,
+				      DAOS_HDL_INVAL, cont,
+				      &cont->vc_dtx_committed_hdl);
+	if (rc != 0) {
+		D_ERROR("Failed to create DTX committed btree: rc = %d\n", rc);
+		D_GOTO(exit, rc);
+	}
+
+	rc = dbtree_create_inplace_ex(VOS_BTR_DTX_COS, 0, DTX_BTREE_ORDER, &uma,
+				      &cont->vc_dtx_cos_btr, DAOS_HDL_INVAL,
+				      cont, &cont->vc_dtx_cos_hdl);
 	if (rc != 0) {
 		D_ERROR("Failed to create DTX CoS btree: rc = %d\n", rc);
 		D_GOTO(exit, rc);
@@ -521,6 +537,7 @@ int
 vos_cont_destroy(daos_handle_t poh, uuid_t co_uuid)
 {
 
+	daos_handle_t		 hdl;
 	struct vos_pool		*pool;
 	struct vos_container	*cont;
 	struct cont_df_args	 args;
@@ -572,6 +589,18 @@ vos_cont_destroy(daos_handle_t poh, uuid_t co_uuid)
 		D_GOTO(exit, rc);
 	}
 
+	rc = dbtree_open_inplace(&args.ca_cont_df->cd_dtx_active,
+				 &pool->vp_uma, &hdl);
+	if (rc == 0)
+		rc = dbtree_destroy(hdl, NULL);
+
+	if (rc != 0 && rc != -DER_NONEXIST) {
+		D_ERROR("Failed to destroy active DTX table: rc = %d\n", rc);
+		rc = vos_tx_end(vos_pool2umm(pool), rc);
+
+		D_GOTO(exit, rc);
+	}
+
 	d_iov_set(&iov, &key, sizeof(struct d_uuid));
 	rc = dbtree_delete(pool->vp_cont_th, BTR_PROBE_EQ, &iov, NULL);
 
@@ -614,6 +643,31 @@ vos_cont_tab_register()
 	rc = dbtree_class_register(VOS_BTR_CONT_TABLE, 0, &vct_ops);
 	if (rc)
 		D_ERROR("dbtree create failed\n");
+	return rc;
+}
+
+int
+vos_dtx_update_resync_gen(daos_handle_t coh)
+{
+	struct vos_container	*cont;
+	struct vos_cont_df	*cont_df;
+	int			 rc;
+
+	cont = vos_hdl2cont(coh);
+	D_ASSERT(cont != NULL);
+
+	cont_df = cont->vc_cont_df;
+	rc = vos_tx_begin(vos_cont2umm(cont));
+	if (rc == 0) {
+		umem_tx_add_ptr(vos_cont2umm(cont),
+				&cont_df->cd_dtx_resync_gen,
+				sizeof(cont_df->cd_dtx_resync_gen));
+		cont_df->cd_dtx_resync_gen++;
+		rc = vos_tx_end(vos_cont2umm(cont), rc);
+		if (rc == 0)
+			cont->vc_dtx_resync_gen = cont_df->cd_dtx_resync_gen;
+	}
+
 	return rc;
 }
 

--- a/src/vos/vos_dtx_cos.c
+++ b/src/vos/vos_dtx_cos.c
@@ -47,8 +47,6 @@ struct dtx_cos_rec {
 	int			 dcr_update_count;
 	/* The number of the PUNCH DTXs in the dcr_punch_list. */
 	int			 dcr_punch_count;
-	/* Pointer to the container. */
-	struct vos_container	*dcr_cont;
 };
 
 /* Above dtx_cos_rec is consisted of a series of dtx_cos_rec_child uints.
@@ -56,7 +54,7 @@ struct dtx_cos_rec {
  * related object and dkey (that attached to the dtx_cos_rec).
  */
 struct dtx_cos_rec_child {
-	/* Link into the container::vc_dtx_committable. */
+	/* Link into the container::vc_dtx_committable_list. */
 	d_list_t		 dcrc_committable;
 	/* Link into related dcr_{update,punch}_list. */
 	d_list_t		 dcrc_link;
@@ -64,14 +62,11 @@ struct dtx_cos_rec_child {
 	struct dtx_id		 dcrc_dti;
 	/* The DTX epoch. */
 	daos_epoch_t		 dcrc_epoch;
-	/* Timestamp of handling the DTX on server. */
-	uint64_t		 dcrc_time;
 	/* Pointer to the dtx_cos_rec. */
 	struct dtx_cos_rec	*dcrc_ptr;
 };
 
 struct dtx_cos_rec_bundle {
-	struct vos_container	*cont;
 	struct dtx_id		*dti;
 	daos_epoch_t		 epoch;
 	bool			 punch;
@@ -112,6 +107,7 @@ static int
 dtx_cos_rec_alloc(struct btr_instance *tins, d_iov_t *key_iov,
 		  d_iov_t *val_iov, struct btr_record *rec)
 {
+	struct vos_container		*cont = tins->ti_priv;
 	struct dtx_cos_key		*key;
 	struct dtx_cos_rec_bundle	*rbund;
 	struct dtx_cos_rec		*dcr;
@@ -129,7 +125,6 @@ dtx_cos_rec_alloc(struct btr_instance *tins, d_iov_t *key_iov,
 	dcr->dcr_oid = key->oid;
 	D_INIT_LIST_HEAD(&dcr->dcr_update_list);
 	D_INIT_LIST_HEAD(&dcr->dcr_punch_list);
-	dcr->dcr_cont = rbund->cont;
 
 	D_ALLOC_PTR(dcrc);
 	if (dcrc == NULL) {
@@ -139,12 +134,11 @@ dtx_cos_rec_alloc(struct btr_instance *tins, d_iov_t *key_iov,
 
 	dcrc->dcrc_dti = *rbund->dti;
 	dcrc->dcrc_epoch = rbund->epoch;
-	dcrc->dcrc_time = crt_hlc_get();
 	dcrc->dcrc_ptr = dcr;
 
 	d_list_add_tail(&dcrc->dcrc_committable,
-			&rbund->cont->vc_dtx_committable);
-	rbund->cont->vc_dtx_committable_count++;
+			&cont->vc_dtx_committable_list);
+	cont->vc_dtx_committable_count++;
 
 	if (rbund->punch) {
 		d_list_add_tail(&dcrc->dcrc_link, &dcr->dcr_punch_list);
@@ -161,6 +155,7 @@ dtx_cos_rec_alloc(struct btr_instance *tins, d_iov_t *key_iov,
 static int
 dtx_cos_rec_free(struct btr_instance *tins, struct btr_record *rec, void *args)
 {
+	struct vos_container		*cont = tins->ti_priv;
 	struct dtx_cos_rec		*dcr;
 	struct dtx_cos_rec_child	*dcrc;
 	struct dtx_cos_rec_child	*next;
@@ -173,14 +168,14 @@ dtx_cos_rec_free(struct btr_instance *tins, struct btr_record *rec, void *args)
 		d_list_del(&dcrc->dcrc_link);
 		d_list_del(&dcrc->dcrc_committable);
 		D_FREE_PTR(dcrc);
-		dcr->dcr_cont->vc_dtx_committable_count--;
+		cont->vc_dtx_committable_count--;
 	}
 	d_list_for_each_entry_safe(dcrc, next, &dcr->dcr_punch_list,
 				   dcrc_link) {
 		d_list_del(&dcrc->dcrc_link);
 		d_list_del(&dcrc->dcrc_committable);
 		D_FREE_PTR(dcrc);
-		dcr->dcr_cont->vc_dtx_committable_count--;
+		cont->vc_dtx_committable_count--;
 	}
 	D_FREE_PTR(dcr);
 
@@ -205,6 +200,7 @@ static int
 dtx_cos_rec_update(struct btr_instance *tins, struct btr_record *rec,
 		   d_iov_t *key, d_iov_t *val)
 {
+	struct vos_container		*cont = tins->ti_priv;
 	struct dtx_cos_rec_bundle	*rbund;
 	struct dtx_cos_rec		*dcr;
 	struct dtx_cos_rec_child	*dcrc;
@@ -220,12 +216,11 @@ dtx_cos_rec_update(struct btr_instance *tins, struct btr_record *rec,
 
 	dcrc->dcrc_dti = *rbund->dti;
 	dcrc->dcrc_epoch = rbund->epoch;
-	dcrc->dcrc_time = crt_hlc_get();
 	dcrc->dcrc_ptr = dcr;
 
 	d_list_add_tail(&dcrc->dcrc_committable,
-			&rbund->cont->vc_dtx_committable);
-	rbund->cont->vc_dtx_committable_count++;
+			&cont->vc_dtx_committable_list);
+	cont->vc_dtx_committable_count++;
 
 	if (rbund->punch) {
 		d_list_add_tail(&dcrc->dcrc_link, &dcr->dcr_punch_list);
@@ -360,7 +355,8 @@ out:
 
 int
 vos_dtx_add_cos(daos_handle_t coh, daos_unit_oid_t *oid, struct dtx_id *dti,
-		uint64_t dkey_hash, daos_epoch_t epoch, bool punch, bool check)
+		uint64_t dkey_hash, daos_epoch_t epoch, uint64_t gen,
+		bool punch, bool check)
 {
 	struct vos_container		*cont;
 	struct dtx_cos_key		 key;
@@ -371,6 +367,41 @@ vos_dtx_add_cos(daos_handle_t coh, daos_unit_oid_t *oid, struct dtx_id *dti,
 
 	cont = vos_hdl2cont(coh);
 	D_ASSERT(cont != NULL);
+
+	/* If the DTX is started befoe DTX resync operation (for rebuild),
+	 * then it is possbile that the DTX resync ULT may have aborted
+	 * or committed the DTX during current ULT waiting for the reply.
+	 * let's check DTX status locally before marking as 'committable'.
+	 */
+	if (gen != 0 && gen < cont->vc_dtx_resync_gen) {
+		rc = vos_dtx_check(coh, dti);
+		switch (rc) {
+		case DTX_ST_PREPARED:
+			rc = vos_dtx_lookup_cos(coh, oid, dti,
+						dkey_hash, punch);
+			/* The resync ULT has already added it into the
+			 * CoS cache, current ULT needs to do nothing.
+			 */
+			if (rc == 0)
+				return -DER_ALREADY;
+
+			/* Normal case, then add it to CoS cache. */
+			if (rc == -DER_NONEXIST)
+				break;
+
+			return rc >= 0 ? -DER_INVAL : rc;
+		case DTX_ST_COMMITTED:
+			/* The DTX has been committed by resync ULT by race. */
+			return -DER_ALREADY;
+		case -DER_NONEXIST:
+			/* The DTX has been aborted by resync ULT, ask the
+			 * client to retry.
+			 */
+			return rc;
+		default:
+			return rc >= 0 ? -DER_INVAL : rc;
+		}
+	}
 
 	if (check) {
 		struct daos_lru_cache	*occ = vos_obj_cache_current();
@@ -394,7 +425,6 @@ vos_dtx_add_cos(daos_handle_t coh, daos_unit_oid_t *oid, struct dtx_id *dti,
 	key.dkey = dkey_hash;
 	d_iov_set(&kiov, &key, sizeof(key));
 
-	rbund.cont = cont;
 	rbund.dti = dti;
 	rbund.epoch = epoch;
 	rbund.punch = punch;
@@ -417,8 +447,8 @@ vos_dtx_lookup_cos(daos_handle_t coh, daos_unit_oid_t *oid,
 {
 	struct vos_container		*cont;
 	struct dtx_cos_key		 key;
-	d_iov_t			 kiov;
-	d_iov_t			 riov;
+	d_iov_t				 kiov;
+	d_iov_t				 riov;
 	struct dtx_cos_rec		*dcr;
 	struct dtx_cos_rec_child	*dcrc;
 	d_list_t			*head;
@@ -474,7 +504,7 @@ vos_dtx_fetch_committable(daos_handle_t coh, uint32_t max_cnt,
 	if (dte == NULL)
 		return -DER_NOMEM;
 
-	d_list_for_each_entry(dcrc, &cont->vc_dtx_committable,
+	d_list_for_each_entry(dcrc, &cont->vc_dtx_committable_list,
 			      dcrc_committable) {
 		if (oid != NULL &&
 		    daos_unit_oid_compare(dcrc->dcrc_ptr->dcr_oid, *oid) != 0)
@@ -559,10 +589,10 @@ vos_dtx_cos_oldest(struct vos_container *cont)
 {
 	struct dtx_cos_rec_child	*dcrc;
 
-	if (d_list_empty(&cont->vc_dtx_committable))
+	if (d_list_empty(&cont->vc_dtx_committable_list))
 		return 0;
 
-	dcrc = d_list_entry(cont->vc_dtx_committable.next,
+	dcrc = d_list_entry(cont->vc_dtx_committable_list.next,
 			    struct dtx_cos_rec_child, dcrc_committable);
-	return dcrc->dcrc_time;
+	return dcrc->dcrc_epoch;
 }

--- a/src/vos/vos_internal.h
+++ b/src/vos/vos_internal.h
@@ -46,6 +46,8 @@
 #define VOS_KTR_ORDER		23	/* order of d/a-key tree */
 #define VOS_SVT_ORDER		5	/* order of single value tree */
 #define VOS_EVT_ORDER		23	/* evtree order */
+#define DTX_BTREE_ORDER		23	/* Order for DTX tree */
+
 
 
 #define DAOS_VOS_VERSION 1
@@ -120,20 +122,30 @@ struct vos_container {
 	struct vos_pool		*vc_pool;
 	/* Unique UID of VOS container */
 	uuid_t			vc_id;
+	/* DAOS handle for object index btree */
+	daos_handle_t		vc_btr_hdl;
 	/* The handle for active DTX table */
 	daos_handle_t		vc_dtx_active_hdl;
 	/* The handle for committed DTX table */
 	daos_handle_t		vc_dtx_committed_hdl;
-	/* DAOS handle for object index btree */
-	daos_handle_t		vc_btr_hdl;
 	/* The objects with committable DTXs in DRAM. */
 	daos_handle_t		vc_dtx_cos_hdl;
+	/** The root of the B+ tree for committed DTXs. */
+	struct btr_root		vc_dtx_committed_btr;
 	/* The DTX COS-btree. */
 	struct btr_root		vc_dtx_cos_btr;
-	/* The global list for commiitable DTXs. */
-	d_list_t		vc_dtx_committable;
-	/* The count of commiitable DTXs. */
+	/* The global list for committable DTXs. */
+	d_list_t		vc_dtx_committable_list;
+	/* The global list for committed DTXs. */
+	d_list_t		vc_dtx_committed_list;
+	/* The temporary list for committed DTXs during re-index. */
+	d_list_t		vc_dtx_committed_tmp_list;
+	/* The count of committable DTXs. */
 	uint32_t		vc_dtx_committable_count;
+	/* The count of committed DTXs. */
+	uint32_t		vc_dtx_committed_count;
+	/* The items count in vc_dtx_committed_tmp_list. */
+	uint32_t		vc_dtx_committed_tmp_count;
 	/** Direct pointer to the VOS container */
 	struct vos_cont_df	*vc_cont_df;
 	/**
@@ -143,8 +155,10 @@ struct vos_container {
 	struct vea_hint_context	*vc_hint_ctxt[VOS_IOS_CNT];
 	/* Various flags */
 	unsigned int		vc_in_aggregation:1,
-				vc_abort_aggregation:1;
+				vc_abort_aggregation:1,
+				vc_reindex_dtx:1;
 	unsigned int		vc_open_count;
+	uint64_t		vc_dtx_resync_gen;
 };
 
 struct vos_imem_strts {
@@ -295,30 +309,6 @@ int
 vos_obj_tab_register();
 
 /**
- * DTX table create
- * Called from cont_df_rec_alloc.
- *
- * \param pool		[IN]	vos pool
- * \param dtab_df	[IN]	Pointer to the DTX table (pmem data structure)
- *
- * \return		0 on success and negative on failure
- */
-int
-vos_dtx_table_create(struct vos_pool *pool, struct vos_dtx_table_df *dtab_df);
-
-/**
- * DTX table destroy
- * Called from vos_cont_destroy
- *
- * \param pool		[IN]	vos pool
- * \param dtab_df	[IN]	Pointer to the DTX table (pmem data structure)
- *
- * \return		0 on success and negative on failure
- */
-int
-vos_dtx_table_destroy(struct vos_pool *pool, struct vos_dtx_table_df *dtab_df);
-
-/**
  * Register dbtree class for DTX table, it is called within vos_init().
  *
  * \return		0 on success and negative on failure
@@ -409,7 +399,7 @@ vos_dtx_prepared(struct dtx_handle *dth);
 
 void
 vos_dtx_commit_internal(struct vos_container *cont, struct dtx_id *dtis,
-			int count);
+			int count, umem_off_t umoff);
 
 /**
  * Register dbtree class for DTX CoS, it is called within vos_init().
@@ -456,12 +446,14 @@ enum vos_tree_class {
 	VOS_BTR_OBJ_TABLE	= (VOS_BTR_BEGIN + 3),
 	/** container index table */
 	VOS_BTR_CONT_TABLE	= (VOS_BTR_BEGIN + 4),
-	/** DAOS two-phase commit transation table */
-	VOS_BTR_DTX_TABLE	= (VOS_BTR_BEGIN + 5),
+	/** DAOS two-phase commit transation table (active) */
+	VOS_BTR_DTX_ACT_TABLE	= (VOS_BTR_BEGIN + 5),
+	/** DAOS two-phase commit transation table (committed) */
+	VOS_BTR_DTX_CMT_TABLE	= (VOS_BTR_BEGIN + 6),
 	/** The objects with committable DTXs in DRAM */
-	VOS_BTR_DTX_COS		= (VOS_BTR_BEGIN + 6),
+	VOS_BTR_DTX_COS		= (VOS_BTR_BEGIN + 7),
 	/** The VOS incarnation log tree */
-	VOS_BTR_ILOG		= (VOS_BTR_BEGIN + 7),
+	VOS_BTR_ILOG		= (VOS_BTR_BEGIN + 8),
 	/** the last reserved tree class */
 	VOS_BTR_END,
 };

--- a/src/vos/vos_io.c
+++ b/src/vos/vos_io.c
@@ -1455,7 +1455,7 @@ vos_update_end(daos_handle_t ioh, uint32_t pm_ver, daos_key_t *dkey, int err,
 	if (dth != NULL && dth->dth_dti_cos_count > 0 &&
 	    dth->dth_dti_cos_done == 0) {
 		vos_dtx_commit_internal(ioc->ic_obj->obj_cont, dth->dth_dti_cos,
-					dth->dth_dti_cos_count);
+					dth->dth_dti_cos_count, UMOFF_NULL);
 		dth->dth_dti_cos_done = 1;
 	}
 

--- a/src/vos/vos_layout.h
+++ b/src/vos/vos_layout.h
@@ -237,36 +237,16 @@ struct vos_dtx_entry_df {
 	daos_epoch_t			te_epoch;
 	/** Pool map version. */
 	uint32_t			te_ver;
-	/** DTX status, see enum dtx_status. */
-	uint32_t			te_state;
-	/** DTX flags, see enum vos_dtx_entry_flags. */
-	uint32_t			te_flags;
 	/** The intent of related modification. */
 	uint32_t			te_intent;
-	/** The timestamp when handles the transaction. */
-	uint64_t			te_time;
+	/** The server generation when handles the DTX. */
+	uint64_t			te_gen;
+	/** DTX flags, see enum vos_dtx_entry_flags. */
+	uint32_t			te_flags;
+	/** For 64-bits alignment. */
+	uint32_t			te_padding;
 	/** The list of vos_dtx_record_df in SCM. */
 	umem_off_t			te_records;
-	/** The next committed DTX in global list. */
-	umem_off_t			te_next;
-	/** The prev committed DTX in global list. */
-	umem_off_t			te_prev;
-};
-
-/**
- * DAOS two-phase commit transaction table.
- */
-struct vos_dtx_table_df {
-	/** The count of committed DTXs in the table. */
-	uint64_t			tt_count;
-	/** The list head of committed DTXs. */
-	umem_off_t			tt_entry_head;
-	/** The list tail of committed DTXs. */
-	umem_off_t			tt_entry_tail;
-	/** The root of the B+ tree for committed DTXs. */
-	struct btr_root			tt_committed_btr;
-	/** The root of the B+ tree for active (prepared) DTXs. */
-	struct btr_root			tt_active_btr;
 };
 
 enum vos_io_stream {
@@ -284,11 +264,16 @@ enum vos_io_stream {
 struct vos_cont_df {
 	uuid_t				cd_id;
 	uint64_t			cd_nobjs;
+	uint64_t			cd_dtx_resync_gen;
 	daos_size_t			cd_used;
 	daos_epoch_t			cd_hae;
 	struct btr_root			cd_obj_root;
-	/** The DTXs table. */
-	struct vos_dtx_table_df		cd_dtx_table_df;
+	/** The active DTX table. */
+	struct btr_root			cd_dtx_active;
+	/** The committed DTXs blob head. */
+	umem_off_t			cd_dtx_committed_head;
+	/** The committed DTXs blob tail. */
+	umem_off_t			cd_dtx_committed_tail;
 	/** Allocation hints for block allocator. */
 	struct vea_hint_df		cd_hint_df[VOS_IOS_CNT];
 };
@@ -388,5 +373,13 @@ struct vos_obj_df {
 D_CASSERT(offsetof(struct vos_obj_df, vo_earliest) ==
 	  offsetof(struct vos_obj_df, vo_latest) +
 	  sizeof(((struct vos_obj_df *)0)->vo_latest));
+
+D_CASSERT(offsetof(struct vos_obj_df, vo_dtx_shares) ==
+	  offsetof(struct vos_obj_df, vo_dtx) +
+	  sizeof(((struct vos_obj_df *)0)->vo_dtx));
+
+#define VOS_OBJ_DTX_SIZE	sizeof(((struct vos_obj_df *)0)->vo_dtx)
+#define VOS_OBJ_SHARES_SIZE	sizeof(((struct vos_obj_df *)0)->vo_dtx_shares)
+#define VOS_OBJ_SIZE_PARTIAL	(VOS_OBJ_DTX_SIZE + VOS_OBJ_SHARES_SIZE)
 
 #endif

--- a/src/vos/vos_obj.c
+++ b/src/vos/vos_obj.c
@@ -176,7 +176,7 @@ vos_obj_punch(daos_handle_t coh, daos_unit_oid_t oid, daos_epoch_t epoch,
 	if (dth != NULL && dth->dth_dti_cos_count > 0 &&
 	    dth->dth_dti_cos_done == 0) {
 		vos_dtx_commit_internal(cont, dth->dth_dti_cos,
-					dth->dth_dti_cos_count);
+					dth->dth_dti_cos_count, UMOFF_NULL);
 		dth->dth_dti_cos_done = 1;
 	}
 

--- a/src/vos/vos_obj_index.c
+++ b/src/vos/vos_obj_index.c
@@ -301,12 +301,13 @@ int
 vos_oi_punch(struct vos_container *cont, daos_unit_oid_t oid,
 	     daos_epoch_t epoch, uint32_t flags, struct vos_obj_df *obj)
 {
-	struct oi_hkey	*hkey;
-	struct oi_key	 key;
-	d_iov_t	 key_iov;
-	d_iov_t	 val_iov;
-	int		 rc = 0;
-	bool		 replay = (flags & VOS_OF_REPLAY_PC);
+	struct dtx_handle	*dth;
+	struct oi_hkey		*hkey;
+	struct oi_key		 key;
+	d_iov_t			 key_iov;
+	d_iov_t			 val_iov;
+	int			 rc = 0;
+	bool			 replay = (flags & VOS_OF_REPLAY_PC);
 
 	D_DEBUG(DB_TRACE, "Punch obj "DF_UOID", epoch="DF_U64".\n",
 		DP_UOID(oid), epoch);
@@ -337,7 +338,8 @@ vos_oi_punch(struct vos_container *cont, daos_unit_oid_t oid,
 	if (rc != 0 || replay)
 		goto out;
 
-	if (vos_dth_get() == NULL) {
+	dth = vos_dth_get();
+	if (dth == NULL || dth->dth_single_participator) {
 		struct vos_obj_df *tmp;
 
 		D_ASSERT((obj->vo_oi_attr & VOS_OI_PUNCHED) == 0);


### PR DESCRIPTION
Mainly include the following:

1. Increase the CPU yield frequency during DTX aggregation and
   batched commit to allow more normal IO schedule.

2. Use client-side HLC in the DTX ID as the modification epoch.

3. Replace HLC based race detection between DTX resync and normal
   modification handling logic with server-side generation.

4. Fine-grained contents for PMDK undo log to reduce the overhead
   caused by PMDK related logic.

5. Store the indexed committed DTX table in DRAM rather than SCM.

   When a DTX is committed, it is added into the in-DRAM committed
   DTX table that is organized as a B+tree. If related DAOS server
   restarts because of some reason, for supporting DAOS server to
   rejoin system (if is not evicted), then we need to re-establish
   the indexed committed DTX table in DRAM. So we will store the
   committed DTX entries in SCM without index (only append) when
   they are committed.

   A dedicated ULT will scan the non-indexed committed DTX entries
   in SCM to re-generate the indexed committed DTX table in DRAM
   when open the container.

6. Some DTX logic can be optimized if the DTX contains single
   participator (such as modifying single replicated object).
   For example: the DTX can be committed immediately after
   local modification done.

6.1. It is unnecessary to allocate related DTX records for the
     target (object/dkey/akey/SV/EV rec) to be modified.

6.2. It is unnecessary to insert the DTX into active DTX tree,
     instead, it can be directly inserted into the committed
     DTX table when commit.

6.3. Punch logic can be simplified as without DTX case.

6.4. CoS logic can be bypassed.

Signed-off-by: Fan Yong <fan.yong@intel.com>