### PR TITLE
DAOS-2429 dtx: DTX performance optimization

### DIFF
--- a/src/container/srv_target.c
+++ b/src/container/srv_target.c
@@ -86,7 +86,6 @@ cont_child_alloc_ref(void *key, unsigned int ksize, void *varg,
 		goto out_cond;
 
 	uuid_copy(cont->sc_uuid, key);
-	cont->sc_dtx_resync_time = crt_hlc_get();
 
 	*link = &cont->sc_list;
 	return 0;

--- a/src/dtx/dtx_internal.h
+++ b/src/dtx/dtx_internal.h
@@ -71,7 +71,7 @@ CRT_RPC_DECLARE(dtx, DAOS_ISEQ_DTX, DAOS_OSEQ_DTX);
 /* The count threshould for triggerring DTX aggregation.
  * This threshould should consider the real SCM size.
  */
-#define DTX_AGG_THRESHOLD_CNT		(1 << 27)
+#define DTX_AGG_THRESHOLD_CNT		(1 << 28)
 
 /* The time threshould for triggerring DTX aggregation. If the oldest
  * DTX in the DTX table exceeds such threshould, it will trigger DTX
@@ -84,7 +84,7 @@ CRT_RPC_DECLARE(dtx, DAOS_ISEQ_DTX, DAOS_OSEQ_DTX);
  */
 #define DTX_AGG_THRESHOLD_AGE_LOWER	3600
 
-#define DTX_AGG_YIELD_INTERVAL		DTX_THRESHOLD_COUNT
+#define DTX_YIELD_CYCLE			(DTX_THRESHOLD_COUNT >> 3)
 
 extern struct crt_proto_format dtx_proto_fmt;
 extern btr_ops_t dbtree_dtx_cf_ops;

--- a/src/dtx/dtx_rpc.c
+++ b/src/dtx/dtx_rpc.c
@@ -655,7 +655,7 @@ dtx_abort(uuid_t po_uuid, uuid_t co_uuid, daos_epoch_t epoch,
 	D_ASSERT(dti != NULL);
 
 	/* Local abort firstly. */
-	rc = vos_dtx_abort(cont->sc_hdl, epoch, dti, count, false);
+	rc = vos_dtx_abort(cont->sc_hdl, epoch, dti, count);
 
 	if (rc == -DER_NONEXIST)
 		rc = 0;

--- a/src/dtx/dtx_srv.c
+++ b/src/dtx/dtx_srv.c
@@ -39,7 +39,11 @@ dtx_handler(crt_rpc_t *rpc)
 	struct dtx_in		*din = crt_req_get(rpc);
 	struct dtx_out		*dout = crt_reply_get(rpc);
 	struct ds_cont_child	*cont = NULL;
+	struct dtx_id		*dtis;
 	uint32_t		 opc = opc_get(rpc->cr_opc);
+	int			 count = DTX_YIELD_CYCLE;
+	int			 i = 0;
+	int			 rc1;
 	int			 rc;
 
 	rc = ds_cont_child_lookup(din->di_po_uuid, din->di_co_uuid, &cont);
@@ -52,13 +56,31 @@ dtx_handler(crt_rpc_t *rpc)
 
 	switch (opc) {
 	case DTX_COMMIT:
-		rc = vos_dtx_commit(cont->sc_hdl, din->di_dtx_array.ca_arrays,
-				    din->di_dtx_array.ca_count);
+		while (i < din->di_dtx_array.ca_count) {
+			if (i + count > din->di_dtx_array.ca_count)
+				count = din->di_dtx_array.ca_count - i;
+
+			dtis = (struct dtx_id *)din->di_dtx_array.ca_arrays + i;
+			rc1 = vos_dtx_commit(cont->sc_hdl, dtis, count);
+			if (rc == 0 && rc1 != 0)
+				rc = rc1;
+
+			i += count;
+		}
 		break;
 	case DTX_ABORT:
-		rc = vos_dtx_abort(cont->sc_hdl, din->di_epoch,
-				   din->di_dtx_array.ca_arrays,
-				   din->di_dtx_array.ca_count, true);
+		while (i < din->di_dtx_array.ca_count) {
+			if (i + count > din->di_dtx_array.ca_count)
+				count = din->di_dtx_array.ca_count - i;
+
+			dtis = (struct dtx_id *)din->di_dtx_array.ca_arrays + i;
+			rc1 = vos_dtx_abort(cont->sc_hdl, din->di_epoch,
+					    dtis, count);
+			if (rc == 0 && rc1 != 0)
+				rc = rc1;
+
+			i += count;
+		}
 		break;
 	case DTX_CHECK:
 		/* Currently, only support to check single DTX state. */

--- a/src/include/daos_srv/container.h
+++ b/src/include/daos_srv/container.h
@@ -59,8 +59,6 @@ struct ds_cont_child {
 	ABT_mutex		 sc_mutex;
 	ABT_cond		 sc_dtx_resync_cond;
 	void			*sc_dtx_flush_cbdata;
-	/* The time for the latest DTX resync operation. */
-	uint64_t		 sc_dtx_resync_time;
 	uint32_t		 sc_dtx_resyncing:1,
 				 sc_dtx_aggregating:1,
 				 sc_closing:1,

--- a/src/include/daos_srv/dtx_srv.h
+++ b/src/include/daos_srv/dtx_srv.h
@@ -60,6 +60,8 @@ struct dtx_handle {
 	daos_handle_t			 dth_coh;
 	/** The epoch# for the DTX. */
 	daos_epoch_t			 dth_epoch;
+	/* The generation when the DTX is handled on the server. */
+	uint64_t			 dth_gen;
 	/** The {obj/dkey/akey}-tree records that are created
 	 * by other DTXs, but not ready for commit yet.
 	 */
@@ -72,7 +74,8 @@ struct dtx_handle {
 	uint32_t			 dth_intent;
 	uint32_t			 dth_sync:1, /* commit synchronously. */
 					 dth_leader:1, /* leader replica. */
-					 dth_non_rep:1, /* non-replicated. */
+					 /* Only one participator in the DTX. */
+					 dth_single_participator:1,
 					 /* dti_cos has been committed. */
 					 dth_dti_cos_done:1;
 	/* The count the DTXs in the dth_dti_cos array. */
@@ -98,8 +101,6 @@ struct dtx_sub_status {
 struct dtx_leader_handle {
 	/* The dtx handle on the leader node */
 	struct dtx_handle		dlh_handle;
-	/* The time when the DTX is handled on the server. */
-	uint64_t			dlh_handled_time;
 	/* result for the distribute transaction */
 	int				dlh_result;
 

--- a/src/include/daos_srv/vos.h
+++ b/src/include/daos_srv/vos.h
@@ -38,6 +38,17 @@
 #include <daos_srv/vos_types.h>
 
 /**
+ * Refresh the DTX resync generation.
+ *
+ * \param coh	[IN]	Container open handle.
+ *
+ * \return		Zero on success.
+ * \return		Negative value if error.
+ */
+int
+vos_dtx_update_resync_gen(daos_handle_t coh);
+
+/**
  * Add the given DTX to the Commit-on-Share (CoS) cache (in DRAM).
  *
  * \param coh		[IN]	Container open handle.
@@ -45,6 +56,7 @@
  * \param dti		[IN]	The DTX identifier.
  * \param dkey_hash	[IN]	The hashed dkey.
  * \param epoch		[IN]	The DTX epoch.
+ * \param gen		[IN]	The DTX generation.
  * \param punch		[IN]	For punch DTX or not.
  * \param check		[IN]	Check whether the DTX need restart because
  *				of sync epoch or not.
@@ -55,7 +67,8 @@
  */
 int
 vos_dtx_add_cos(daos_handle_t coh, daos_unit_oid_t *oid, struct dtx_id *dti,
-		uint64_t dkey_hash, daos_epoch_t epoch, bool punch, bool check);
+		uint64_t dkey_hash, daos_epoch_t epoch, uint64_t gen,
+		bool punch, bool check);
 
 /**
  * Search the specified DTX is in the CoS cache or not.
@@ -174,14 +187,12 @@ vos_dtx_commit(daos_handle_t coh, struct dtx_id *dtis, int count);
  * \param epoch	[IN]	The max epoch for the DTX to be aborted.
  * \param dtis	[IN]	The array for DTX identifiers to be aborted.
  * \param count [IN]	The count of DTXs to be aborted.
- * \param force [IN]	Force abort even if some replica(s) have not
- *			'prepared' related DTXs.
  *
  * \return		Zero on success, negative value if error.
  */
 int
 vos_dtx_abort(daos_handle_t coh, daos_epoch_t epoch, struct dtx_id *dtis,
-	      int count, bool force);
+	      int count);
 
 /**
  * Aggregate the committed DTXs.

--- a/src/include/daos_srv/vos_types.h
+++ b/src/include/daos_srv/vos_types.h
@@ -201,8 +201,8 @@ typedef struct {
 	union {
 		/** Returned earliest update epoch for a key */
 		daos_epoch_t			ie_earliest;
-		/** Return the DTX handled time for DTX iteration. */
-		uint64_t			ie_dtx_time;
+		/** record size */
+		daos_size_t			ie_rsize;
 	};
 	union {
 		/** Returned entry for container UUID iterator */
@@ -220,8 +220,6 @@ typedef struct {
 			uint32_t		ie_dtx_intent;
 		};
 		struct {
-			/** record size */
-			daos_size_t		ie_rsize;
 			/** record extent */
 			daos_recx_t		ie_recx;
 			/* original in-tree extent */

--- a/src/object/srv_obj.c
+++ b/src/object/srv_obj.c
@@ -1036,7 +1036,7 @@ ds_obj_tgt_update_handler(crt_rpc_t *rpc)
 			 * that it can be aborted.
 			 */
 			rc = vos_dtx_abort(cont->sc_hdl, DAOS_EPOCH_MAX,
-					   &orw->orw_dti, 1, true);
+					   &orw->orw_dti, 1);
 
 		if (rc != 0 && rc != -DER_NONEXIST)
 			D_GOTO(out, rc);
@@ -1137,7 +1137,11 @@ ds_obj_rw_handler(crt_rpc_t *rpc)
 		orw->orw_map_ver, map_ver, DP_DTI(&orw->orw_dti));
 	/* FIXME: until distributed transaction. */
 	if (orw->orw_epoch == DAOS_EPOCH_MAX) {
-		orw->orw_epoch = crt_hlc_get();
+		if (daos_is_zero_dti(&orw->orw_dti) ||
+		    orw->orw_flags & ORF_RESEND)
+			orw->orw_epoch = crt_hlc_get();
+		else
+			orw->orw_epoch = orw->orw_dti.dti_hlc;
 		D_DEBUG(DB_IO, "overwrite epoch "DF_U64"\n", orw->orw_epoch);
 	}
 
@@ -1628,7 +1632,7 @@ ds_obj_tgt_punch_handler(crt_rpc_t *rpc)
 			 * that it can be aborted.
 			 */
 			rc = vos_dtx_abort(cont->sc_hdl, DAOS_EPOCH_MAX,
-					   &opi->opi_dti, 1, true);
+					   &opi->opi_dti, 1);
 
 		if (rc != 0 && rc != -DER_NONEXIST)
 			D_GOTO(out, rc);
@@ -1716,7 +1720,11 @@ ds_obj_punch_handler(crt_rpc_t *rpc)
 
 	/* FIXME: until distributed transaction. */
 	if (opi->opi_epoch == DAOS_EPOCH_MAX) {
-		opi->opi_epoch = crt_hlc_get();
+		if (daos_is_zero_dti(&opi->opi_dti) ||
+		    opi->opi_flags & ORF_RESEND)
+			opi->opi_epoch = crt_hlc_get();
+		else
+			opi->opi_epoch = opi->opi_dti.dti_hlc;
 		D_DEBUG(DB_IO, "overwrite epoch "DF_U64"\n", opi->opi_epoch);
 	}
 

--- a/src/vos/tests/vts_dtx.c
+++ b/src/vos/tests/vts_dtx.c
@@ -44,7 +44,7 @@ vts_dtx_cos(void **state, bool punch)
 
 	/* Insert a DTX into CoS cache. */
 	rc = vos_dtx_add_cos(args->ctx.tc_co_hdl, &args->oid, &xid,
-			     dkey_hash, DAOS_EPOCH_MAX - 1, punch, false);
+			     dkey_hash, DAOS_EPOCH_MAX - 1, 0, punch, false);
 	assert_int_equal(rc, 0);
 
 	/* Query the DTX with different @punch parameter will find nothing. */
@@ -99,7 +99,7 @@ dtx_3(void **state)
 		daos_dti_gen(&xid, false);
 
 		rc = vos_dtx_add_cos(args->ctx.tc_co_hdl, &args->oid, &xid,
-				     dkey_hash, DAOS_EPOCH_MAX - 1,
+				     dkey_hash, DAOS_EPOCH_MAX - 1, 0,
 				     i % 2 ? true : false, false);
 		assert_int_equal(rc, 0);
 	}
@@ -139,7 +139,7 @@ dtx_4(void **state)
 		dkey_hash = lrand48();
 
 		rc = vos_dtx_add_cos(args->ctx.tc_co_hdl, &args->oid, &xid[i],
-				     dkey_hash, DAOS_EPOCH_MAX - 1,
+				     dkey_hash, DAOS_EPOCH_MAX - 1, 0,
 				     i % 2 ? false : true, false);
 		assert_int_equal(rc, 0);
 	}
@@ -300,7 +300,7 @@ dtx_5(void **state)
 
 	/* Add former DTX into CoS cache. */
 	rc = vos_dtx_add_cos(args->ctx.tc_co_hdl, &args->oid, &xid,
-			     dkey_hash, epoch, false, false);
+			     dkey_hash, epoch, 0, false, false);
 	assert_int_equal(rc, 0);
 
 	vos_dtx_stat(args->ctx.tc_co_hdl, &stat);
@@ -499,7 +499,7 @@ vts_dtx_abort_visibility(struct io_test_args *args, bool ext, bool punch_obj)
 	vts_dtx_end(dth);
 
 	/* Aborted the update DTX. */
-	rc = vos_dtx_abort(args->ctx.tc_co_hdl, epoch, &xid, 1, false);
+	rc = vos_dtx_abort(args->ctx.tc_co_hdl, epoch, &xid, 1);
 	assert_int_equal(rc, 0);
 
 	memset(fetch_buf, 0, UPDATE_BUF_SIZE);
@@ -533,7 +533,7 @@ vts_dtx_abort_visibility(struct io_test_args *args, bool ext, bool punch_obj)
 	vts_dtx_end(dth);
 
 	/* Aborted the punch DTX. */
-	rc = vos_dtx_abort(args->ctx.tc_co_hdl, epoch, &xid, 1, false);
+	rc = vos_dtx_abort(args->ctx.tc_co_hdl, epoch, &xid, 1);
 	assert_int_equal(rc, 0);
 
 	memset(fetch_buf, 0, UPDATE_BUF_SIZE);
@@ -636,7 +636,7 @@ dtx_14(void **state)
 	 * But we cannot check "assert_int_not_equal(rc, 0)" that depends
 	 * on the umem_tx_abort() which may return 0 for vmem based case.
 	 */
-	vos_dtx_abort(args->ctx.tc_co_hdl, epoch, &xid, 1, false);
+	vos_dtx_abort(args->ctx.tc_co_hdl, epoch, &xid, 1);
 
 	memset(fetch_buf, 0, UPDATE_BUF_SIZE);
 	d_iov_set(&val_iov, fetch_buf, UPDATE_BUF_SIZE);
@@ -698,11 +698,11 @@ dtx_15(void **state)
 	vts_dtx_end(dth);
 
 	/* Aborted the update DTX. */
-	rc = vos_dtx_abort(args->ctx.tc_co_hdl, epoch, &xid, 1, false);
+	rc = vos_dtx_abort(args->ctx.tc_co_hdl, epoch, &xid, 1);
 	assert_int_equal(rc, 0);
 
 	/* Double aborted the DTX is harmless. */
-	vos_dtx_abort(args->ctx.tc_co_hdl, epoch, &xid, 1, false);
+	vos_dtx_abort(args->ctx.tc_co_hdl, epoch, &xid, 1);
 
 	memset(fetch_buf, 0, UPDATE_BUF_SIZE);
 	d_iov_set(&val_iov, fetch_buf, UPDATE_BUF_SIZE);
@@ -791,7 +791,7 @@ dtx_16(void **state)
 
 	/* Insert a DTX into CoS cache. */
 	rc = vos_dtx_add_cos(args->ctx.tc_co_hdl, &args->oid, &xid,
-			     dkey_hash, epoch, false, false);
+			     dkey_hash, epoch, 0, false, false);
 	assert_int_equal(rc, 0);
 
 	/* Fetch again. */
@@ -1124,14 +1124,14 @@ vts_dtx_shares(struct io_test_args *args, int *commit_list, int commit_count,
 		for (i = 0; i < abort_count; i++) {
 			rc = vos_dtx_abort(args->ctx.tc_co_hdl,
 					   epoch[abort_list[i]],
-					   &xid[abort_list[i]], 1, false);
+					   &xid[abort_list[i]], 1);
 			assert_int_equal(rc, 0);
 		}
 	} else {
 		for (i = 0; i < abort_count; i++) {
 			rc = vos_dtx_abort(args->ctx.tc_co_hdl,
 					   epoch[abort_list[i]],
-					   &xid[abort_list[i]], 1, false);
+					   &xid[abort_list[i]], 1);
 			assert_int_equal(rc, 0);
 		}
 
@@ -1396,14 +1396,13 @@ vts_dtx_shares_with_punch(struct io_test_args *args, bool punch_obj, bool abort)
 
 	/* Abort or commit the punch DTX. */
 	if (abort)
-		rc = vos_dtx_abort(args->ctx.tc_co_hdl, epoch[3], &xid[3], 1,
-				   false);
+		rc = vos_dtx_abort(args->ctx.tc_co_hdl, epoch[3], &xid[3], 1);
 	else
 		rc = vos_dtx_commit(args->ctx.tc_co_hdl, &xid[3], 1);
 	assert_int_equal(rc, 0);
 
 	/* Abort the first update DTX. */
-	rc = vos_dtx_abort(args->ctx.tc_co_hdl, epoch[0], &xid[0], 1, false);
+	rc = vos_dtx_abort(args->ctx.tc_co_hdl, epoch[0], &xid[0], 1);
 	assert_int_equal(rc, 0);
 
 	/* Commit the third update DTX. */

--- a/src/vos/vos_dtx.c
+++ b/src/vos/vos_dtx.c
@@ -65,9 +65,8 @@ static inline int
 dtx_inprogress(struct vos_dtx_entry_df *dtx, int pos)
 {
 	if (dtx != NULL)
-		D_DEBUG(DB_TRACE, "Hit uncommitted DTX "DF_DTI
-			" with state %u at %d\n",
-			DP_DTI(&dtx->te_xid), dtx->te_state, pos);
+		D_DEBUG(DB_TRACE, "Hit uncommitted DTX "DF_DTI" at %d\n",
+			DP_DTI(&dtx->te_xid), pos);
 	else
 		D_DEBUG(DB_TRACE, "Hit uncommitted (unknown) DTX at %d\n", pos);
 
@@ -114,8 +113,8 @@ dtx_hkey_cmp(struct btr_instance *tins, struct btr_record *rec, void *hkey)
 }
 
 static int
-dtx_rec_alloc(struct btr_instance *tins, d_iov_t *key_iov,
-	      d_iov_t *val_iov, struct btr_record *rec)
+dtx_active_rec_alloc(struct btr_instance *tins, d_iov_t *key_iov,
+		     d_iov_t *val_iov, struct btr_record *rec)
 {
 	struct dtx_rec_bundle	*rbund;
 
@@ -129,7 +128,8 @@ dtx_rec_alloc(struct btr_instance *tins, d_iov_t *key_iov,
 }
 
 static int
-dtx_rec_free(struct btr_instance *tins, struct btr_record *rec, void *args)
+dtx_active_rec_free(struct btr_instance *tins, struct btr_record *rec,
+		    void *args)
 {
 	D_ASSERT(!UMOFF_IS_NULL(rec->rec_off));
 
@@ -156,8 +156,8 @@ dtx_rec_free(struct btr_instance *tins, struct btr_record *rec, void *args)
 }
 
 static int
-dtx_rec_fetch(struct btr_instance *tins, struct btr_record *rec,
-	      d_iov_t *key_iov, d_iov_t *val_iov)
+dtx_active_rec_fetch(struct btr_instance *tins, struct btr_record *rec,
+		     d_iov_t *key_iov, d_iov_t *val_iov)
 {
 	struct vos_dtx_entry_df	*dtx;
 
@@ -176,109 +176,86 @@ dtx_rec_update(struct btr_instance *tins, struct btr_record *rec,
 	return 0;
 }
 
-static btr_ops_t dtx_btr_ops = {
+static btr_ops_t dtx_active_btr_ops = {
 	.to_hkey_size	= dtx_hkey_size,
 	.to_hkey_gen	= dtx_hkey_gen,
 	.to_hkey_cmp	= dtx_hkey_cmp,
-	.to_rec_alloc	= dtx_rec_alloc,
-	.to_rec_free	= dtx_rec_free,
-	.to_rec_fetch	= dtx_rec_fetch,
+	.to_rec_alloc	= dtx_active_rec_alloc,
+	.to_rec_free	= dtx_active_rec_free,
+	.to_rec_fetch	= dtx_active_rec_fetch,
 	.to_rec_update	= dtx_rec_update,
 };
 
-#define DTX_BTREE_ORDER		20
+struct dtx_committed_rec {
+	struct dtx_id	dcr_xid;
+	daos_epoch_t	dcr_epoch;
+	d_list_t	dcr_link;
+};
+
+static int
+dtx_committed_rec_alloc(struct btr_instance *tins, d_iov_t *key_iov,
+			d_iov_t *val_iov, struct btr_record *rec)
+{
+	struct vos_container		*cont = tins->ti_priv;
+	struct dtx_committed_rec	*dcr = val_iov->iov_buf;
+
+	rec->rec_off = umem_ptr2off(&tins->ti_umm, dcr);
+	d_list_add_tail(&dcr->dcr_link, &cont->vc_dtx_committed_list);
+	cont->vc_dtx_committed_count++;
+
+	return 0;
+}
+
+static int
+dtx_committed_rec_free(struct btr_instance *tins, struct btr_record *rec,
+		       void *args)
+{
+	struct vos_container		*cont = tins->ti_priv;
+	struct dtx_committed_rec	*dcr;
+
+	D_ASSERT(!UMOFF_IS_NULL(rec->rec_off));
+
+	dcr = umem_off2ptr(&tins->ti_umm, rec->rec_off);
+	d_list_del(&dcr->dcr_link);
+	D_FREE(dcr);
+	cont->vc_dtx_committed_count--;
+
+	return 0;
+}
+
+static int
+dtx_committed_rec_fetch(struct btr_instance *tins, struct btr_record *rec,
+			d_iov_t *key_iov, d_iov_t *val_iov)
+{
+	return 0;
+}
+
+static btr_ops_t dtx_committed_btr_ops = {
+	.to_hkey_size	= dtx_hkey_size,
+	.to_hkey_gen	= dtx_hkey_gen,
+	.to_hkey_cmp	= dtx_hkey_cmp,
+	.to_rec_alloc	= dtx_committed_rec_alloc,
+	.to_rec_free	= dtx_committed_rec_free,
+	.to_rec_fetch	= dtx_committed_rec_fetch,
+	.to_rec_update	= dtx_rec_update,
+};
 
 int
 vos_dtx_table_register(void)
 {
 	int	rc;
 
-	D_DEBUG(DB_DF, "Registering DTX table class: %d\n", VOS_BTR_DTX_TABLE);
+	rc = dbtree_class_register(VOS_BTR_DTX_ACTIVE_TABLE, 0,
+				   &dtx_active_btr_ops);
+	if (rc != 0) {
+		D_ERROR("Failed to register DTX active dbtree: %d\n", rc);
+		return rc;
+	}
 
-	rc = dbtree_class_register(VOS_BTR_DTX_TABLE, 0, &dtx_btr_ops);
+	rc = dbtree_class_register(VOS_BTR_DTX_COMMITTED_TABLE, 0,
+				   &dtx_committed_btr_ops);
 	if (rc != 0)
-		D_ERROR("Failed to register DTX dbtree: rc = %d\n", rc);
-
-	return rc;
-}
-
-int
-vos_dtx_table_create(struct vos_pool *pool, struct vos_dtx_table_df *dtab_df)
-{
-	daos_handle_t	hdl;
-	int		rc;
-
-	if (pool == NULL || dtab_df == NULL) {
-		D_ERROR("Invalid handle\n");
-		return -DER_INVAL;
-	}
-
-	D_ASSERT(dtab_df->tt_active_btr.tr_class == 0);
-	D_ASSERT(dtab_df->tt_committed_btr.tr_class == 0);
-
-	D_DEBUG(DB_DF, "create DTX dbtree in-place for pool "DF_UUID": %d\n",
-		DP_UUID(pool->vp_id), VOS_BTR_DTX_TABLE);
-
-	rc = dbtree_create_inplace(VOS_BTR_DTX_TABLE, 0,
-				   DTX_BTREE_ORDER, &pool->vp_uma,
-				   &dtab_df->tt_active_btr, &hdl);
-	if (rc != 0) {
-		D_ERROR("Failed to create DTX active dbtree for pool "
-			DF_UUID": rc = %d\n", DP_UUID(pool->vp_id), rc);
-		return rc;
-	}
-
-	dbtree_close(hdl);
-
-	rc = dbtree_create_inplace(VOS_BTR_DTX_TABLE, 0,
-				   DTX_BTREE_ORDER, &pool->vp_uma,
-				   &dtab_df->tt_committed_btr, &hdl);
-	if (rc != 0) {
-		D_ERROR("Failed to create DTX committed dbtree for pool "
-			DF_UUID": rc = %d\n", DP_UUID(pool->vp_id), rc);
-		return rc;
-	}
-
-	dtab_df->tt_count = 0;
-	dtab_df->tt_entry_head = UMOFF_NULL;
-	dtab_df->tt_entry_tail = UMOFF_NULL;
-
-	dbtree_close(hdl);
-	return 0;
-}
-
-int
-vos_dtx_table_destroy(struct vos_pool *pool, struct vos_dtx_table_df *dtab_df)
-{
-	daos_handle_t	hdl;
-	int		rc = 0;
-
-	if (pool == NULL || dtab_df == NULL) {
-		D_ERROR("Invalid handle\n");
-		return -DER_INVAL;
-	}
-
-	if (dtab_df->tt_active_btr.tr_class != 0) {
-		rc = dbtree_open_inplace(&dtab_df->tt_active_btr,
-					 &pool->vp_uma, &hdl);
-		if (rc == 0)
-			rc = dbtree_destroy(hdl, NULL);
-
-		if (rc != 0)
-			D_ERROR("Fail to destroy DTX active dbtree for pool"
-				DF_UUID": rc = %d\n", DP_UUID(pool->vp_id), rc);
-	}
-
-	if (dtab_df->tt_committed_btr.tr_class != 0) {
-		rc = dbtree_open_inplace(&dtab_df->tt_committed_btr,
-					 &pool->vp_uma, &hdl);
-		if (rc == 0)
-			rc = dbtree_destroy(hdl, NULL);
-
-		if (rc != 0)
-			D_ERROR("Fail to destroy DTX committed dbtree for pool"
-				DF_UUID": rc = %d\n", DP_UUID(pool->vp_id), rc);
-	}
+		D_ERROR("Failed to register DTX committed dbtree: %d\n", rc);
 
 	return rc;
 }
@@ -646,14 +623,11 @@ dtx_key_rec_release(struct umem_instance *umm, struct vos_krec_df *key,
 
 static void
 dtx_rec_release(struct umem_instance *umm, umem_off_t umoff,
-		bool abort, bool destroy, bool logged)
+		bool abort, bool destroy)
 {
 	struct vos_dtx_entry_df		*dtx;
 
 	dtx = umem_off2ptr(umm, umoff);
-	if (!logged)
-		umem_tx_add_ptr(umm, dtx, sizeof(*dtx));
-
 	while (!dtx_is_null(dtx->te_records)) {
 		umem_off_t			 rec_umoff = dtx->te_records;
 		struct vos_dtx_record_df	*rec;
@@ -664,7 +638,8 @@ dtx_rec_release(struct umem_instance *umm, umem_off_t umoff,
 			struct vos_obj_df	*obj;
 
 			obj = umem_off2ptr(umm, rec->tr_record);
-			umem_tx_add_ptr(umm, obj, sizeof(*obj));
+			umem_tx_add_ptr(umm, &obj->vo_dtx,
+					VOS_OBJ_SIZE_PARTIAL);
 			dtx_obj_rec_release(umm, obj, rec, umoff, abort);
 			break;
 		}
@@ -672,7 +647,8 @@ dtx_rec_release(struct umem_instance *umm, umem_off_t umoff,
 			struct vos_krec_df	*key;
 
 			key = umem_off2ptr(umm, rec->tr_record);
-			umem_tx_add_ptr(umm, key, sizeof(*key));
+			umem_tx_add_ptr(umm, &key->kr_dtx,
+					VOS_KEY_SIZE_PARTIAL);
 			dtx_key_rec_release(umm, key, rec, umoff, abort);
 			break;
 		}
@@ -709,107 +685,55 @@ dtx_rec_release(struct umem_instance *umm, umem_off_t umoff,
 		umem_free(umm, rec_umoff);
 	}
 
-	D_DEBUG(DB_TRACE, "dtx_rec_release: %s/%s the DTX "DF_DTI"\n",
-		abort ? "abort" : "commit", destroy ? "destroy" : "keep",
-		DP_DTI(&dtx->te_xid));
-
 	if (destroy)
 		umem_free(umm, umoff);
 	else
 		dtx->te_flags &= ~(DTX_EF_EXCHANGE_PENDING | DTX_EF_SHARES);
 }
 
-static void
-vos_dtx_unlink_entry(struct umem_instance *umm, struct vos_dtx_table_df *tab,
-		     struct vos_dtx_entry_df *dtx)
-{
-	struct vos_dtx_entry_df	*ent;
-
-	if (dtx_is_null(dtx->te_next)) { /* The tail of the DTXs list. */
-		if (dtx_is_null(dtx->te_prev)) { /* The unique one on list. */
-			tab->tt_entry_head = UMOFF_NULL;
-			tab->tt_entry_tail = UMOFF_NULL;
-		} else {
-			ent = umem_off2ptr(umm, dtx->te_prev);
-			umem_tx_add_ptr(umm, &ent->te_next,
-					sizeof(ent->te_next));
-			ent->te_next = UMOFF_NULL;
-			tab->tt_entry_tail = dtx->te_prev;
-			dtx->te_prev = UMOFF_NULL;
-		}
-	} else if (dtx_is_null(dtx->te_prev)) { /* The head of DTXs list */
-		ent = umem_off2ptr(umm, dtx->te_next);
-		umem_tx_add_ptr(umm, &ent->te_prev, sizeof(ent->te_prev));
-		ent->te_prev = UMOFF_NULL;
-		tab->tt_entry_head = dtx->te_next;
-		dtx->te_next = UMOFF_NULL;
-	} else {
-		ent = umem_off2ptr(umm, dtx->te_next);
-		umem_tx_add_ptr(umm, &ent->te_prev, sizeof(ent->te_prev));
-		ent->te_prev = dtx->te_prev;
-
-		ent = umem_off2ptr(umm, dtx->te_prev);
-		umem_tx_add_ptr(umm, &ent->te_next, sizeof(ent->te_next));
-		ent->te_next = dtx->te_next;
-
-		dtx->te_prev = UMOFF_NULL;
-		dtx->te_next = UMOFF_NULL;
-	}
-}
-
 static int
-vos_dtx_commit_one(struct vos_container *cont, struct dtx_id *dti)
+vos_dtx_commit_one(struct vos_container *cont, struct dtx_id *dti,
+		   umem_off_t umoff)
 {
 	struct umem_instance		*umm = &cont->vc_pool->vp_umm;
+	struct dtx_committed_rec	*dcr = NULL;
 	struct vos_dtx_entry_df		*dtx;
-	struct vos_dtx_entry_df		*ent;
-	struct vos_dtx_table_df		*tab;
-	struct dtx_rec_bundle		 rbund;
-	d_iov_t			 kiov;
-	d_iov_t			 riov;
-	umem_off_t			 umoff;
+	d_iov_t				 kiov;
+	d_iov_t				 riov;
 	int				 rc = 0;
+	bool				 drop_cos = false;
 
 	d_iov_set(&kiov, dti, sizeof(*dti));
-	rc = dbtree_delete(cont->vc_dtx_active_hdl, BTR_PROBE_EQ,
-			   &kiov, &umoff);
-	if (rc == -DER_NONEXIST) {
-		d_iov_set(&riov, NULL, 0);
-		rc = dbtree_lookup(cont->vc_dtx_committed_hdl, &kiov, &riov);
-		goto out;
+	if (dtx_is_null(umoff)) {
+		rc = dbtree_delete(cont->vc_dtx_active_hdl, BTR_PROBE_EQ,
+				   &kiov, &umoff);
+		if (rc == -DER_NONEXIST) {
+			d_iov_set(&riov, NULL, 0);
+			rc = dbtree_lookup(cont->vc_dtx_committed_hdl,
+					   &kiov, NULL);
+			goto out;
+		}
+
+		if (rc != 0)
+			goto out;
+
+		drop_cos = true;
 	}
 
-	if (rc != 0)
-		goto out;
-
 	dtx = umem_off2ptr(umm, umoff);
-	umem_tx_add_ptr(umm, dtx, sizeof(*dtx));
 
-	dtx->te_state = DTX_ST_COMMITTED;
-	rbund.trb_umoff = umoff;
-	d_iov_set(&riov, &rbund, sizeof(rbund));
+	D_ALLOC_PTR(dcr);
+	if (dcr == NULL)
+		D_GOTO(out, rc = -DER_NOMEM);
+
+	dcr->dcr_xid = *dti;
+	dcr->dcr_epoch = dtx->te_epoch;
+
+	d_iov_set(&riov, dcr, sizeof(*dcr));
 	rc = dbtree_upsert(cont->vc_dtx_committed_hdl, BTR_PROBE_EQ,
 			   DAOS_INTENT_UPDATE, &kiov, &riov);
 	if (rc != 0)
 		goto out;
-
-	tab = &cont->vc_cont_df->cd_dtx_table_df;
-	umem_tx_add_ptr(umm, tab, sizeof(*tab));
-
-	tab->tt_count++;
-	if (dtx_is_null(tab->tt_entry_tail)) {
-		D_ASSERT(dtx_is_null(tab->tt_entry_head));
-
-		tab->tt_entry_head = umoff;
-		tab->tt_entry_tail = tab->tt_entry_head;
-	} else {
-		ent = umem_off2ptr(umm, tab->tt_entry_tail);
-		umem_tx_add_ptr(umm, &ent->te_next, sizeof(ent->te_next));
-
-		ent->te_next = umoff;
-		dtx->te_prev = tab->tt_entry_tail;
-		tab->tt_entry_tail = ent->te_next;
-	}
 
 	/* XXX: Only mark the DTX as DTX_ST_COMMITTED (when commit) is not
 	 *	enough. Otherwise, some subsequent modification may change
@@ -817,20 +741,24 @@ vos_dtx_commit_one(struct vos_container *cont, struct dtx_id *dti)
 	 *	record as to the current DTX will have invalid reference(s)
 	 *	via its DTX record(s).
 	 */
-	dtx_rec_release(umm, umoff, false, false, true);
-	vos_dtx_del_cos(cont, &dtx->te_oid, dti, dtx->te_dkey_hash,
+	dtx_rec_release(umm, umoff, false, true);
+	if (drop_cos)
+		/* For single participator case, the DTX is not in COS cache. */
+		vos_dtx_del_cos(cont, &dtx->te_oid, dti, dtx->te_dkey_hash,
 			dtx->te_intent == DAOS_INTENT_PUNCH ? true : false);
 
 out:
 	D_DEBUG(DB_TRACE, "Commit the DTX "DF_DTI": rc = %d\n",
 		DP_DTI(dti), rc);
+	if (rc != 0)
+		D_FREE(dcr);
 
 	return rc;
 }
 
 static int
 vos_dtx_abort_one(struct vos_container *cont, daos_epoch_t epoch,
-		  struct dtx_id *dti, bool force)
+		  struct dtx_id *dti)
 {
 	d_iov_t			kiov;
 	umem_off_t		off;
@@ -856,13 +784,10 @@ vos_dtx_abort_one(struct vos_container *cont, daos_epoch_t epoch,
 
 	rc = dbtree_delete(cont->vc_dtx_active_hdl, opc, &kiov, &off);
 	if (rc == 0)
-		dtx_rec_release(&cont->vc_pool->vp_umm, off, true, true, false);
+		dtx_rec_release(&cont->vc_pool->vp_umm, off, true, true);
 
 out:
 	D_DEBUG(DB_TRACE, "Abort the DTX "DF_DTI": rc = %d\n", DP_DTI(dti), rc);
-
-	if (rc != 0 && force)
-		rc = 0;
 
 	return rc;
 }
@@ -879,18 +804,17 @@ vos_dtx_is_normal_entry(struct umem_instance *umm, umem_off_t entry)
 
 static int
 vos_dtx_alloc(struct umem_instance *umm, struct dtx_handle *dth,
-	      umem_off_t rec_umoff, struct vos_dtx_entry_df **dtxp)
+	      struct vos_dtx_entry_df **dtxp)
 {
 	struct vos_dtx_entry_df	*dtx;
 	struct vos_container	*cont;
 	umem_off_t		 dtx_umoff;
-	d_iov_t		 kiov;
-	d_iov_t		 riov;
 	struct dtx_rec_bundle	 rbund;
-	int			 rc;
 
 	cont = vos_hdl2cont(dth->dth_coh);
 	D_ASSERT(cont != NULL);
+
+	dth->dth_gen = cont->vc_dtx_resync_gen;
 
 	dtx_umoff = umem_zalloc(umm, sizeof(struct vos_dtx_entry_df));
 	if (dtx_is_null(dtx_umoff))
@@ -902,32 +826,42 @@ vos_dtx_alloc(struct umem_instance *umm, struct dtx_handle *dth,
 	dtx->te_dkey_hash = dth->dth_dkey_hash;
 	dtx->te_epoch = dth->dth_epoch;
 	dtx->te_ver = dth->dth_ver;
-	dtx->te_state = DTX_ST_PREPARED;
 	dtx->te_flags = dth->dth_leader ? DTX_EF_LEADER : 0;
 	dtx->te_intent = dth->dth_intent;
-	dtx->te_time = crt_hlc_get();
-	dtx->te_records = rec_umoff;
-	dtx->te_next = UMOFF_NULL;
-	dtx->te_prev = UMOFF_NULL;
+	dtx->te_gen = dth->dth_gen;
+	dtx->te_records = UMOFF_NULL;
 
-	rbund.trb_umoff = dtx_umoff;
-	d_iov_set(&riov, &rbund, sizeof(rbund));
-	d_iov_set(&kiov, &dth->dth_xid, sizeof(dth->dth_xid));
-	rc = dbtree_upsert(cont->vc_dtx_active_hdl, BTR_PROBE_EQ,
-			   DAOS_INTENT_UPDATE, &kiov, &riov);
-	if (rc == 0) {
-		dth->dth_ent = dtx_umoff;
-		*dtxp = dtx;
+	/* For single participator case, the DTX will be committed immediately
+	 * just after the local modification done. So it is unnecessary to add
+	 * the DTX into the active DTX table and be remove very soon, instead,
+	 * it will be directly inserted into committed DTX table when commit.
+	 */
+	if (!dth->dth_single_participator) {
+		d_iov_t		kiov;
+		d_iov_t		riov;
+		int		rc;
+
+		rbund.trb_umoff = dtx_umoff;
+		d_iov_set(&riov, &rbund, sizeof(rbund));
+		d_iov_set(&kiov, &dth->dth_xid, sizeof(dth->dth_xid));
+		rc = dbtree_upsert(cont->vc_dtx_active_hdl, BTR_PROBE_EQ,
+				   DAOS_INTENT_UPDATE, &kiov, &riov);
+		if (rc != 0)
+			return rc;
 	}
 
-	return rc;
+	dth->dth_ent = dtx_umoff;
+	*dtxp = dtx;
+
+	return 0;
 }
 
-static void
+static int
 vos_dtx_append(struct umem_instance *umm, struct dtx_handle *dth,
-	       umem_off_t rec_umoff, umem_off_t record, uint32_t type,
-	       uint32_t flags, struct vos_dtx_entry_df **dtxp)
+	       umem_off_t record, uint32_t type, uint32_t flags,
+	       struct vos_dtx_entry_df **dtxp)
 {
+	umem_off_t			 rec_umoff;
 	struct vos_dtx_entry_df		*dtx;
 	struct vos_dtx_record_df	*rec;
 	struct vos_dtx_record_df	*tgt;
@@ -936,14 +870,22 @@ vos_dtx_append(struct umem_instance *umm, struct dtx_handle *dth,
 	 * vos_dtx_register_record(), no need umem_tx_add_ptr().
 	 */
 	dtx = umem_off2ptr(umm, dth->dth_ent);
-	dtx->te_time = crt_hlc_get();
+
+	rec_umoff = umem_zalloc(umm, sizeof(struct vos_dtx_record_df));
+	if (dtx_is_null(rec_umoff))
+		return -DER_NOSPACE;
+
 	rec = umem_off2ptr(umm, rec_umoff);
+	rec->tr_type = type;
+	rec->tr_flags = flags;
+	rec->tr_record = record;
 	rec->tr_next = dtx->te_records;
+
 	dtx->te_records = rec_umoff;
 	*dtxp = dtx;
 
 	if (flags == 0)
-		return;
+		return 0;
 
 	/*
 	 * XXX: Currently, we only support DTX_RF_EXCHANGE_SRC when register
@@ -967,16 +909,20 @@ vos_dtx_append(struct umem_instance *umm, struct dtx_handle *dth,
 		struct vos_obj_df	*obj;
 
 		obj = umem_off2ptr(umm, record);
+		umem_tx_add_ptr(umm, &obj->vo_oi_attr, sizeof(obj->vo_oi_attr));
 		obj->vo_oi_attr |= VOS_OI_REMOVED;
 	} else {
 		struct vos_krec_df	*key;
 
 		key = umem_off2ptr(umm, record);
+		umem_tx_add_ptr(umm, &key->kr_bmap, sizeof(key->kr_bmap));
 		key->kr_bmap |= KREC_BF_REMOVED;
 	}
 
 	D_DEBUG(DB_TRACE, "Register exchange source for %s DTX "DF_DTI"\n",
 		type == DTX_RT_OBJ ? "OBJ" : "KEY", DP_DTI(&dtx->te_xid));
+
+	return 0;
 }
 
 static int
@@ -1018,13 +964,13 @@ vos_dtx_share_obj(struct umem_instance *umm, struct dtx_handle *dth,
 
 	rc = vos_dtx_append_share(umm, dtx, dts);
 	if (rc != 0) {
-		D_DEBUG(DB_TRACE, "The DTX "DF_DTI" failed to shares obj "
+		D_ERROR("The DTX "DF_DTI" failed to shares obj "
 			"with others:: rc = %d\n",
 			DP_DTI(&dth->dth_xid), rc);
 		return rc;
 	}
 
-	umem_tx_add_ptr(umm, obj, sizeof(*obj));
+	umem_tx_add_ptr(umm, &obj->vo_dtx_shares, sizeof(obj->vo_dtx_shares));
 
 	/* The to be shared obj has been aborted, reuse it. */
 	if (dtx_is_aborted(obj->vo_dtx)) {
@@ -1045,6 +991,7 @@ vos_dtx_share_obj(struct umem_instance *umm, struct dtx_handle *dth,
 		D_DEBUG(DB_TRACE, "The DTX "DF_DTI" shares obj "
 			"with unknown DTXs, shares count %u.\n",
 			DP_DTI(&dth->dth_xid), obj->vo_dtx_shares);
+		umem_tx_add_ptr(umm, &obj->vo_dtx, sizeof(obj->vo_dtx));
 		obj->vo_dtx = dth->dth_ent;
 		return 0;
 	}
@@ -1053,11 +1000,8 @@ vos_dtx_share_obj(struct umem_instance *umm, struct dtx_handle *dth,
 
 	sh_dtx = umem_off2ptr(umm, obj->vo_dtx);
 	D_ASSERT(dtx != sh_dtx);
-	D_ASSERTF(sh_dtx->te_state == DTX_ST_PREPARED,
-		  "Invalid shared obj DTX state: %u\n",
-		  sh_dtx->te_state);
 
-	umem_tx_add_ptr(umm, sh_dtx, sizeof(*sh_dtx));
+	umem_tx_add_ptr(umm, &sh_dtx->te_flags, sizeof(sh_dtx->te_flags));
 	sh_dtx->te_flags |= DTX_EF_SHARES;
 
 	D_DEBUG(DB_TRACE, "The DTX "DF_DTI" try to shares obj "DF_X64
@@ -1077,16 +1021,30 @@ vos_dtx_share_key(struct umem_instance *umm, struct dtx_handle *dth,
 	struct vos_dtx_entry_df	*sh_dtx;
 	int			 rc;
 
+	key = umem_off2ptr(umm, dts->dts_record);
+	/* The to be shared key has been committed. */
+	if (dtx_is_null(key->kr_dtx))
+		return 0;
+
 	rc = vos_dtx_append_share(umm, dtx, dts);
 	if (rc != 0) {
-		D_DEBUG(DB_TRACE, "The DTX "DF_DTI" failed to shares key "
+		D_ERROR("The DTX "DF_DTI" failed to shares key "
 			"with others:: rc = %d\n",
 			DP_DTI(&dth->dth_xid), rc);
 		return rc;
 	}
 
-	key = umem_off2ptr(umm, dts->dts_record);
-	umem_tx_add_ptr(umm, key, sizeof(*key));
+	umem_tx_add_ptr(umm, &key->kr_dtx_shares, sizeof(key->kr_dtx_shares));
+
+	/* The to be shared key has been aborted, reuse it. */
+	if (dtx_is_aborted(key->kr_dtx)) {
+		D_ASSERTF(key->kr_dtx_shares == 0,
+			  "Invalid shared key DTX shares %d\n",
+			  key->kr_dtx_shares);
+		key->kr_dtx_shares = 1;
+		return 0;
+	}
+
 	key->kr_dtx_shares++;
 	*shared = true;
 
@@ -1097,6 +1055,7 @@ vos_dtx_share_key(struct umem_instance *umm, struct dtx_handle *dth,
 		D_DEBUG(DB_TRACE, "The DTX "DF_DTI" shares key "
 			"with unknown DTXs, shares count %u.\n",
 			DP_DTI(&dth->dth_xid), key->kr_dtx_shares);
+		umem_tx_add_ptr(umm, &key->kr_dtx, sizeof(key->kr_dtx));
 		key->kr_dtx = dth->dth_ent;
 		return 0;
 	}
@@ -1105,11 +1064,8 @@ vos_dtx_share_key(struct umem_instance *umm, struct dtx_handle *dth,
 
 	sh_dtx = umem_off2ptr(umm, key->kr_dtx);
 	D_ASSERT(dtx != sh_dtx);
-	D_ASSERTF(sh_dtx->te_state == DTX_ST_PREPARED,
-		  "Invalid shared key DTX state: %u\n",
-		  sh_dtx->te_state);
 
-	umem_tx_add_ptr(umm, sh_dtx, sizeof(*sh_dtx));
+	umem_tx_add_ptr(umm, &sh_dtx->te_flags, sizeof(sh_dtx->te_flags));
 	sh_dtx->te_flags |= DTX_EF_SHARES;
 
 	D_DEBUG(DB_TRACE, "The DTX "DF_DTI" try to shares key "DF_X64
@@ -1198,6 +1154,7 @@ vos_dtx_check_availability(struct umem_instance *umm, daos_handle_t coh,
 	struct dtx_handle		*dth = vos_dth_get();
 	struct vos_dtx_entry_df		*dtx = NULL;
 	umem_off_t			*addr = NULL;
+	int				 rc;
 	bool				 hidden = false;
 
 	switch (type) {
@@ -1295,97 +1252,82 @@ vos_dtx_check_availability(struct umem_instance *umm, daos_handle_t coh,
 		return ALB_AVAILABLE_CLEAN;
 
 	dtx = umem_off2ptr(umm, entry);
-	switch (dtx->te_state) {
-	case DTX_ST_COMMITTED:
-		return hidden ? ALB_UNAVAILABLE : ALB_AVAILABLE_CLEAN;
-	case DTX_ST_PREPARED: {
-		struct vos_container	*cont = vos_hdl2cont(coh);
-		int			 rc;
-
-		rc = vos_dtx_lookup_cos(coh, &dtx->te_oid, &dtx->te_xid,
+	rc = vos_dtx_lookup_cos(coh, &dtx->te_oid, &dtx->te_xid,
 			dtx->te_dkey_hash,
 			dtx->te_intent == DAOS_INTENT_PUNCH ? true : false);
-		if (rc == 0) {
-			/* XXX: For the committable punch DTX, if there is
-			 *	pending exchange (of sub-trees) operation,
-			 *	then do it, otherwise the subsequent fetch
-			 *	cannot get the proper sub-trees.
-			 */
-			if (dtx->te_flags & DTX_EF_EXCHANGE_PENDING) {
-				rc = vos_tx_begin(cont->vc_pool);
-				if (rc == 0) {
-					dtx_rec_release(umm, entry,
-							false, false, false);
-					rc = vos_tx_end(cont->vc_pool, 0);
-				}
+	if (rc == 0) {
+		/* XXX: For the committable punch DTX, if there is pending
+		 *	exchange (of sub-trees) operation, then do it, otherwise
+		 *	the subsequent fetch cannot get the proper sub-trees.
+		 */
+		if (dtx->te_flags & DTX_EF_EXCHANGE_PENDING) {
+			struct vos_container	*cont = vos_hdl2cont(coh);
 
-				if (rc != 0)
-					return rc;
+			rc = vos_tx_begin(cont->vc_pool);
+			if (rc == 0) {
+				umem_tx_add_ptr(umm, dtx, sizeof(*dtx));
+				dtx_rec_release(umm, entry, false, false);
+				rc = vos_tx_end(cont->vc_pool, 0);
 			}
 
-			return hidden ? ALB_UNAVAILABLE : ALB_AVAILABLE_CLEAN;
+			if (rc != 0)
+				return rc;
 		}
 
-		if (rc != -DER_NONEXIST)
-			return rc;
-
-		/* The followings are for non-committable cases. */
-
-		if (intent == DAOS_INTENT_DEFAULT ||
-		    intent == DAOS_INTENT_REBUILD) {
-			if (!(dtx->te_flags & DTX_EF_LEADER) ||
-			    DAOS_FAIL_CHECK(DAOS_VOS_NON_LEADER)) {
-				/* Inavailable for rebuild case. */
-				if (intent == DAOS_INTENT_REBUILD)
-					return hidden ? ALB_AVAILABLE_CLEAN :
-						ALB_UNAVAILABLE;
-
-				D_DEBUG(DB_TRACE, "Let's ask leader "DF_DTI
-					"\n", DP_DTI(&dtx->te_xid));
-				/* Non-leader and non-rebuild case,
-				 * return -DER_INPROGRESS, then the
-				 * caller will retry the RPC with
-				 * leader replica.
-				 */
-				return dtx_inprogress(dtx, 2);
-			}
-
-			/* For leader, non-committed DTX is unavailable. */
-			return hidden ? ALB_AVAILABLE_CLEAN : ALB_UNAVAILABLE;
-		}
-
-		/* PUNCH DTX cannot be shared by others. */
-		if (dtx->te_intent == DAOS_INTENT_PUNCH) {
-			if (dth == NULL)
-				/* XXX: For rebuild case, if some normal IO
-				 *	has generated punch-record (by race)
-				 *	before rebuild logic handling that,
-				 *	then rebuild logic should ignore such
-				 *	punch-record, because the punch epoch
-				 *	will be higher than the rebuild epoch.
-				 *	The rebuild logic needs to create the
-				 *	original target record that exists on
-				 *	other healthy replicas before punch.
-				 */
-				return ALB_UNAVAILABLE;
-
-			dtx_record_conflict(dth, dtx);
-
-			return dtx_inprogress(dtx, 3);
-		}
-
-		if (dtx->te_intent != DAOS_INTENT_UPDATE) {
-			D_ERROR("Unexpected DTX intent %u\n", dtx->te_intent);
-			return -DER_INVAL;
-		}
-
-		return vos_dtx_check_shares(umm, coh, dth, dtx, record, intent,
-					    type, addr);
+		return hidden ? ALB_UNAVAILABLE : ALB_AVAILABLE_CLEAN;
 	}
-	default:
-		D_ERROR("Unexpected DTX state %u\n", dtx->te_state);
+
+	if (rc != -DER_NONEXIST)
+		return rc;
+
+	/* The followings are for non-committable cases. */
+
+	if (intent == DAOS_INTENT_DEFAULT || intent == DAOS_INTENT_REBUILD) {
+		if (!(dtx->te_flags & DTX_EF_LEADER) ||
+		    DAOS_FAIL_CHECK(DAOS_VOS_NON_LEADER)) {
+			/* Inavailable for rebuild case. */
+			if (intent == DAOS_INTENT_REBUILD)
+				return hidden ? ALB_AVAILABLE_CLEAN :
+					ALB_UNAVAILABLE;
+
+			/* Non-leader and non-rebuild case, return
+			 * -DER_INPROGRESS, then the caller will retry
+			 *  the RPC with leader replica.
+			 */
+			return dtx_inprogress(dtx, 2);
+		}
+
+		/* For leader, non-committed DTX is unavailable. */
+		return hidden ? ALB_AVAILABLE_CLEAN : ALB_UNAVAILABLE;
+	}
+
+	/* PUNCH DTX cannot be shared by others. */
+	if (dtx->te_intent == DAOS_INTENT_PUNCH) {
+		if (dth == NULL)
+			/* XXX: For rebuild case, if some normal IO
+			 *	has generated punch-record (by race)
+			 *	before rebuild logic handling that,
+			 *	then rebuild logic should ignore such
+			 *	punch-record, because the punch epoch
+			 *	will be higher than the rebuild epoch.
+			 *	The rebuild logic needs to create the
+			 *	original target record that exists on
+			 *	other healthy replicas before punch.
+			 */
+			return ALB_UNAVAILABLE;
+
+		dtx_record_conflict(dth, dtx);
+
+		return dtx_inprogress(dtx, 3);
+	}
+
+	if (dtx->te_intent != DAOS_INTENT_UPDATE) {
+		D_ERROR("Unexpected DTX intent %u\n", dtx->te_intent);
 		return -DER_INVAL;
 	}
+
+	return vos_dtx_check_shares(umm, coh, dth, dtx, record, intent,
+				    type, addr);
 }
 
 /* The caller has started PMDK transaction. */
@@ -1395,10 +1337,8 @@ vos_dtx_register_record(struct umem_instance *umm, umem_off_t record,
 {
 	struct dtx_handle		*dth = vos_dth_get();
 	struct vos_dtx_entry_df		*dtx;
-	struct vos_dtx_record_df	*rec;
 	struct dtx_share		*dts;
 	struct dtx_share		*next;
-	umem_off_t			 rec_umoff = UMOFF_NULL;
 	umem_off_t			*entry = NULL;
 	uint32_t			*shares = NULL;
 	int				 rc = 0;
@@ -1416,9 +1356,7 @@ vos_dtx_register_record(struct umem_instance *umm, umem_off_t record,
 		/* "flags == 0" means new created object. It is unnecessary
 		 * to umem_tx_add_ptr() for new created object.
 		 */
-		if (flags != 0)
-			umem_tx_add_ptr(umm, obj, sizeof(*obj));
-		else if (dth != NULL)
+		if (flags == 0 && dth != NULL)
 			dth->dth_obj = record;
 		break;
 	}
@@ -1429,9 +1367,6 @@ vos_dtx_register_record(struct umem_instance *umm, umem_off_t record,
 		entry = &key->kr_dtx;
 		if (dth == NULL || dth->dth_intent == DAOS_INTENT_UPDATE)
 			shares = &key->kr_dtx_shares;
-
-		if (flags != 0)
-			umem_tx_add_ptr(umm, key, sizeof(*key));
 		break;
 	}
 	case DTX_RT_SVT: {
@@ -1461,25 +1396,28 @@ vos_dtx_register_record(struct umem_instance *umm, umem_off_t record,
 		return 0;
 	}
 
-	rec_umoff = umem_zalloc(umm, sizeof(struct vos_dtx_record_df));
-	if (dtx_is_null(rec_umoff))
-		return -DER_NOSPACE;
-
-	rec = umem_off2ptr(umm, rec_umoff);
-	rec->tr_type = type;
-	rec->tr_flags = flags;
-	rec->tr_record = record;
-	rec->tr_next = UMOFF_NULL;
-
 	if (dtx_is_null(dth->dth_ent)) {
 		D_ASSERT(flags == 0);
 
-		rc = vos_dtx_alloc(umm, dth, rec_umoff, &dtx);
+		rc = vos_dtx_alloc(umm, dth, &dtx);
 		if (rc != 0)
 			return rc;
-	} else {
-		vos_dtx_append(umm, dth, rec_umoff, record, type, flags, &dtx);
 	}
+
+	/* For single participator case, we only need the DTX entry
+	 * without DTX records for related targets to be modified.
+	 */
+	if (dth->dth_single_participator) {
+		*entry = UMOFF_NULL;
+		if (shares != NULL)
+			*shares = 0;
+
+		return 0;
+	}
+
+	rc = vos_dtx_append(umm, dth, record, type, flags, &dtx);
+	if (rc != 0)
+		return rc;
 
 	*entry = dth->dth_ent;
 	if (shares != NULL)
@@ -1525,10 +1463,12 @@ vos_dtx_deregister_record(struct umem_instance *umm,
 		rec = umem_off2ptr(umm, rec_umoff);
 		if (record == rec->tr_record) {
 			if (prev == NULL) {
-				umem_tx_add_ptr(umm, dtx, sizeof(*dtx));
+				umem_tx_add_ptr(umm, &dtx->te_records,
+						sizeof(dtx->te_records));
 				dtx->te_records = rec->tr_next;
 			} else {
-				umem_tx_add_ptr(umm, prev, sizeof(*prev));
+				umem_tx_add_ptr(umm, &prev->tr_next,
+						sizeof(prev->tr_next));
 				prev->tr_next = rec->tr_next;
 			}
 
@@ -1553,7 +1493,7 @@ vos_dtx_deregister_record(struct umem_instance *umm,
 		obj = umem_off2ptr(umm, record);
 		D_ASSERT(obj->vo_dtx == entry);
 
-		umem_tx_add_ptr(umm, obj, sizeof(*obj));
+		umem_tx_add_ptr(umm, &obj->vo_dtx, VOS_OBJ_SIZE_PARTIAL);
 		if (dtx->te_intent == DAOS_INTENT_UPDATE) {
 			obj->vo_dtx_shares--;
 			if (obj->vo_dtx_shares > 0)
@@ -1566,7 +1506,8 @@ vos_dtx_deregister_record(struct umem_instance *umm,
 		D_ASSERT(key->kr_dtx == entry);
 
 		if (dtx->te_intent == DAOS_INTENT_UPDATE) {
-			umem_tx_add_ptr(umm, key, sizeof(*key));
+			umem_tx_add_ptr(umm, &key->kr_dtx,
+					VOS_KEY_SIZE_PARTIAL);
 			key->kr_dtx_shares--;
 			if (key->kr_dtx_shares > 0)
 				dtx_set_unknown(&key->kr_dtx);
@@ -1590,11 +1531,10 @@ vos_dtx_prepared(struct dtx_handle *dth)
 	/* The caller has already started the PMDK transaction
 	 * and add the DTX into the PMDK transaction.
 	 */
-	dtx->te_state = DTX_ST_PREPARED;
 
-	if (dth->dth_non_rep) {
+	if (dth->dth_single_participator) {
 		dth->dth_sync = 0;
-		rc = vos_dtx_commit_one(cont, &dth->dth_xid);
+		rc = vos_dtx_commit_one(cont, &dth->dth_xid, dth->dth_ent);
 		if (rc == 0)
 			dth->dth_ent = UMOFF_NULL;
 		else
@@ -1636,11 +1576,11 @@ do_vos_dtx_check(daos_handle_t coh, struct dtx_id *dti, daos_epoch_t *epoch)
 			*epoch = dtx->te_epoch;
 		}
 
-		return dtx->te_state;
+		return DTX_ST_PREPARED;
 	}
 
 	if (rc == -DER_NONEXIST) {
-		rc = dbtree_lookup(cont->vc_dtx_committed_hdl, &kiov, &riov);
+		rc = dbtree_lookup(cont->vc_dtx_committed_hdl, &kiov, NULL);
 		if (rc == 0)
 			return DTX_ST_COMMITTED;
 	}
@@ -1678,7 +1618,7 @@ vos_dtx_commit_internal(struct vos_container *cont, struct dtx_id *dtis,
 	int	i;
 
 	for (i = 0; i < count; i++)
-		vos_dtx_commit_one(cont, &dtis[i]);
+		vos_dtx_commit_one(cont, &dtis[i], UMOFF_NULL);
 }
 
 int
@@ -1694,7 +1634,7 @@ vos_dtx_commit(daos_handle_t coh, struct dtx_id *dtis, int count)
 	rc = vos_tx_begin(cont->vc_pool);
 	if (rc == 0) {
 		vos_dtx_commit_internal(cont, dtis, count);
-		rc = vos_tx_end(cont->vc_pool, rc);
+		vos_tx_end(cont->vc_pool, 0);
 	}
 
 	return rc;
@@ -1702,7 +1642,7 @@ vos_dtx_commit(daos_handle_t coh, struct dtx_id *dtis, int count)
 
 int
 vos_dtx_abort(daos_handle_t coh, daos_epoch_t epoch, struct dtx_id *dtis,
-	      int count, bool force)
+	      int count)
 {
 	struct vos_container	*cont;
 	int			 rc;
@@ -1713,60 +1653,41 @@ vos_dtx_abort(daos_handle_t coh, daos_epoch_t epoch, struct dtx_id *dtis,
 
 	/* Abort multiple DTXs via single PMDK transaction. */
 	rc = vos_tx_begin(cont->vc_pool);
-	if (rc != 0)
-		return rc;
+	if (rc == 0) {
+		for (i = 0; rc == 0 && i < count; i++)
+			vos_dtx_abort_one(cont, epoch, &dtis[i]);
 
-	for (i = 0; rc == 0 && i < count; i++)
-		rc = vos_dtx_abort_one(cont, epoch, &dtis[i], force);
+		vos_tx_end(cont->vc_pool, 0);
+	}
 
-	return vos_tx_end(cont->vc_pool, rc);
+	return rc;
 }
 
 int
 vos_dtx_aggregate(daos_handle_t coh, uint64_t max, uint64_t age)
 {
-	struct vos_container		*cont;
-	struct umem_instance		*umm;
-	struct vos_dtx_table_df		*tab;
-	umem_off_t			 dtx_umoff;
-	uint64_t			 count;
-	int				 rc = 0;
+	struct vos_container	*cont;
+	int			 i;
 
 	cont = vos_hdl2cont(coh);
 	D_ASSERT(cont != NULL);
 
-	umm = &cont->vc_pool->vp_umm;
-	tab = &cont->vc_cont_df->cd_dtx_table_df;
+	for (i = 0;
+	     i < max && d_list_empty(&cont->vc_dtx_committed_list); i++) {
+		struct dtx_committed_rec	*dcr;
+		d_iov_t				 kiov;
 
-	rc = vos_tx_begin(cont->vc_pool);
-	if (rc != 0)
-		return rc;
-
-	umem_tx_add_ptr(umm, tab, sizeof(*tab));
-	for (count = 0, dtx_umoff = tab->tt_entry_head;
-	     count < max && !dtx_is_null(dtx_umoff); count++) {
-		struct vos_dtx_entry_df	*dtx;
-		d_iov_t		 kiov;
-		umem_off_t		 umoff;
-
-		dtx = umem_off2ptr(umm, dtx_umoff);
-		if (dtx_hlc_age2sec(dtx->te_time) < age)
+		dcr = d_list_entry(cont->vc_dtx_committed_list.next,
+				   struct dtx_committed_rec, dcr_link);
+		if (dtx_hlc_age2sec(dcr->dcr_epoch) < age)
 			break;
 
-		d_iov_set(&kiov, &dtx->te_xid, sizeof(dtx->te_xid));
-		rc = dbtree_delete(cont->vc_dtx_committed_hdl, BTR_PROBE_EQ,
-				   &kiov, &umoff);
-		D_ASSERT(rc == 0);
-
-		tab->tt_count--;
-		dtx_umoff = dtx->te_next;
-		umem_tx_add_ptr(umm, dtx, sizeof(*dtx));
-		vos_dtx_unlink_entry(umm, tab, dtx);
-		dtx_rec_release(umm, umoff, false, true, true);
+		d_iov_set(&kiov, &dcr->dcr_xid, sizeof(dcr->dcr_xid));
+		dbtree_delete(cont->vc_dtx_committed_hdl, BTR_PROBE_EQ,
+			      &kiov, NULL);
 	}
 
-	vos_tx_end(cont->vc_pool, 0);
-	return count < max ? 1 : 0;
+	return i < max ? 1 : 0;
 }
 
 void
@@ -1779,15 +1700,15 @@ vos_dtx_stat(daos_handle_t coh, struct dtx_stat *stat)
 
 	stat->dtx_committable_count = cont->vc_dtx_committable_count;
 	stat->dtx_oldest_committable_time = vos_dtx_cos_oldest(cont);
-	stat->dtx_committed_count = cont->vc_cont_df->cd_dtx_table_df.tt_count;
-	if (!dtx_is_null(cont->vc_cont_df->cd_dtx_table_df.tt_entry_head)) {
-		struct vos_dtx_entry_df	*dtx;
-
-		dtx = umem_off2ptr(&cont->vc_pool->vp_umm,
-			cont->vc_cont_df->cd_dtx_table_df.tt_entry_head);
-		stat->dtx_oldest_committed_time = dtx->te_time;
-	} else {
+	stat->dtx_committed_count = cont->vc_dtx_committed_count;
+	if (d_list_empty(&cont->vc_dtx_committed_list)) {
 		stat->dtx_oldest_committed_time = 0;
+	} else {
+		struct dtx_committed_rec	*dcr;
+
+		dcr = d_list_entry(cont->vc_dtx_committed_list.next,
+				   struct dtx_committed_rec, dcr_link);
+		stat->dtx_oldest_committed_time = dcr->dcr_epoch;
 	}
 }
 

--- a/src/vos/vos_dtx_cos.c
+++ b/src/vos/vos_dtx_cos.c
@@ -47,8 +47,6 @@ struct dtx_cos_rec {
 	int			 dcr_update_count;
 	/* The number of the PUNCH DTXs in the dcr_punch_list. */
 	int			 dcr_punch_count;
-	/* Pointer to the container. */
-	struct vos_container	*dcr_cont;
 };
 
 /* Above dtx_cos_rec is consisted of a series of dtx_cos_rec_child uints.
@@ -56,7 +54,7 @@ struct dtx_cos_rec {
  * related object and dkey (that attached to the dtx_cos_rec).
  */
 struct dtx_cos_rec_child {
-	/* Link into the container::vc_dtx_committable. */
+	/* Link into the container::vc_dtx_committable_list. */
 	d_list_t		 dcrc_committable;
 	/* Link into related dcr_{update,punch}_list. */
 	d_list_t		 dcrc_link;
@@ -64,14 +62,11 @@ struct dtx_cos_rec_child {
 	struct dtx_id		 dcrc_dti;
 	/* The DTX epoch. */
 	daos_epoch_t		 dcrc_epoch;
-	/* Timestamp of handling the DTX on server. */
-	uint64_t		 dcrc_time;
 	/* Pointer to the dtx_cos_rec. */
 	struct dtx_cos_rec	*dcrc_ptr;
 };
 
 struct dtx_cos_rec_bundle {
-	struct vos_container	*cont;
 	struct dtx_id		*dti;
 	daos_epoch_t		 epoch;
 	bool			 punch;
@@ -112,6 +107,7 @@ static int
 dtx_cos_rec_alloc(struct btr_instance *tins, d_iov_t *key_iov,
 		  d_iov_t *val_iov, struct btr_record *rec)
 {
+	struct vos_container		*cont = tins->ti_priv;
 	struct dtx_cos_key		*key;
 	struct dtx_cos_rec_bundle	*rbund;
 	struct dtx_cos_rec		*dcr;
@@ -129,7 +125,6 @@ dtx_cos_rec_alloc(struct btr_instance *tins, d_iov_t *key_iov,
 	dcr->dcr_oid = key->oid;
 	D_INIT_LIST_HEAD(&dcr->dcr_update_list);
 	D_INIT_LIST_HEAD(&dcr->dcr_punch_list);
-	dcr->dcr_cont = rbund->cont;
 
 	D_ALLOC_PTR(dcrc);
 	if (dcrc == NULL) {
@@ -139,12 +134,11 @@ dtx_cos_rec_alloc(struct btr_instance *tins, d_iov_t *key_iov,
 
 	dcrc->dcrc_dti = *rbund->dti;
 	dcrc->dcrc_epoch = rbund->epoch;
-	dcrc->dcrc_time = crt_hlc_get();
 	dcrc->dcrc_ptr = dcr;
 
 	d_list_add_tail(&dcrc->dcrc_committable,
-			&rbund->cont->vc_dtx_committable);
-	rbund->cont->vc_dtx_committable_count++;
+			&cont->vc_dtx_committable_list);
+	cont->vc_dtx_committable_count++;
 
 	if (rbund->punch) {
 		d_list_add_tail(&dcrc->dcrc_link, &dcr->dcr_punch_list);
@@ -161,6 +155,7 @@ dtx_cos_rec_alloc(struct btr_instance *tins, d_iov_t *key_iov,
 static int
 dtx_cos_rec_free(struct btr_instance *tins, struct btr_record *rec, void *args)
 {
+	struct vos_container		*cont = tins->ti_priv;
 	struct dtx_cos_rec		*dcr;
 	struct dtx_cos_rec_child	*dcrc;
 	struct dtx_cos_rec_child	*next;
@@ -173,14 +168,14 @@ dtx_cos_rec_free(struct btr_instance *tins, struct btr_record *rec, void *args)
 		d_list_del(&dcrc->dcrc_link);
 		d_list_del(&dcrc->dcrc_committable);
 		D_FREE_PTR(dcrc);
-		dcr->dcr_cont->vc_dtx_committable_count--;
+		cont->vc_dtx_committable_count--;
 	}
 	d_list_for_each_entry_safe(dcrc, next, &dcr->dcr_punch_list,
 				   dcrc_link) {
 		d_list_del(&dcrc->dcrc_link);
 		d_list_del(&dcrc->dcrc_committable);
 		D_FREE_PTR(dcrc);
-		dcr->dcr_cont->vc_dtx_committable_count--;
+		cont->vc_dtx_committable_count--;
 	}
 	D_FREE_PTR(dcr);
 
@@ -205,6 +200,7 @@ static int
 dtx_cos_rec_update(struct btr_instance *tins, struct btr_record *rec,
 		   d_iov_t *key, d_iov_t *val)
 {
+	struct vos_container		*cont = tins->ti_priv;
 	struct dtx_cos_rec_bundle	*rbund;
 	struct dtx_cos_rec		*dcr;
 	struct dtx_cos_rec_child	*dcrc;
@@ -220,12 +216,11 @@ dtx_cos_rec_update(struct btr_instance *tins, struct btr_record *rec,
 
 	dcrc->dcrc_dti = *rbund->dti;
 	dcrc->dcrc_epoch = rbund->epoch;
-	dcrc->dcrc_time = crt_hlc_get();
 	dcrc->dcrc_ptr = dcr;
 
 	d_list_add_tail(&dcrc->dcrc_committable,
-			&rbund->cont->vc_dtx_committable);
-	rbund->cont->vc_dtx_committable_count++;
+			&cont->vc_dtx_committable_list);
+	cont->vc_dtx_committable_count++;
 
 	if (rbund->punch) {
 		d_list_add_tail(&dcrc->dcrc_link, &dcr->dcr_punch_list);
@@ -360,7 +355,8 @@ out:
 
 int
 vos_dtx_add_cos(daos_handle_t coh, daos_unit_oid_t *oid, struct dtx_id *dti,
-		uint64_t dkey_hash, daos_epoch_t epoch, bool punch, bool check)
+		uint64_t dkey_hash, daos_epoch_t epoch, uint64_t gen,
+		bool punch, bool check)
 {
 	struct vos_container		*cont;
 	struct dtx_cos_key		 key;
@@ -371,6 +367,41 @@ vos_dtx_add_cos(daos_handle_t coh, daos_unit_oid_t *oid, struct dtx_id *dti,
 
 	cont = vos_hdl2cont(coh);
 	D_ASSERT(cont != NULL);
+
+	/* If the DTX is started befoe DTX resync operation (for rebuild),
+	 * then it is possbile that the DTX resync ULT may have aborted
+	 * or committed the DTX during current ULT waiting for the reply.
+	 * let's check DTX status locally before marking as 'committable'.
+	 */
+	if (gen != 0 && gen < cont->vc_dtx_resync_gen) {
+		rc = vos_dtx_check(coh, dti);
+		switch (rc) {
+		case DTX_ST_PREPARED:
+			rc = vos_dtx_lookup_cos(coh, oid, dti,
+						dkey_hash, punch);
+			/* The resync ULT has already added it into the
+			 * CoS cache, current ULT needs to do nothing.
+			 */
+			if (rc == 0)
+				return -DER_ALREADY;
+
+			/* Normal case, then add it to CoS cache. */
+			if (rc == -DER_NONEXIST)
+				break;
+
+			return rc >= 0 ? -DER_INVAL : rc;
+		case DTX_ST_COMMITTED:
+			/* The DTX has been committed by resync ULT by race. */
+			return -DER_ALREADY;
+		case -DER_NONEXIST:
+			/* The DTX has been aborted by resync ULT, ask the
+			 * client to retry.
+			 */
+			return rc;
+		default:
+			return rc >= 0 ? -DER_INVAL : rc;
+		}
+	}
 
 	if (check) {
 		struct daos_lru_cache	*occ = vos_obj_cache_current();
@@ -394,7 +425,6 @@ vos_dtx_add_cos(daos_handle_t coh, daos_unit_oid_t *oid, struct dtx_id *dti,
 	key.dkey = dkey_hash;
 	d_iov_set(&kiov, &key, sizeof(key));
 
-	rbund.cont = cont;
 	rbund.dti = dti;
 	rbund.epoch = epoch;
 	rbund.punch = punch;
@@ -417,8 +447,8 @@ vos_dtx_lookup_cos(daos_handle_t coh, daos_unit_oid_t *oid,
 {
 	struct vos_container		*cont;
 	struct dtx_cos_key		 key;
-	d_iov_t			 kiov;
-	d_iov_t			 riov;
+	d_iov_t				 kiov;
+	d_iov_t				 riov;
 	struct dtx_cos_rec		*dcr;
 	struct dtx_cos_rec_child	*dcrc;
 	d_list_t			*head;
@@ -474,7 +504,7 @@ vos_dtx_fetch_committable(daos_handle_t coh, uint32_t max_cnt,
 	if (dte == NULL)
 		return -DER_NOMEM;
 
-	d_list_for_each_entry(dcrc, &cont->vc_dtx_committable,
+	d_list_for_each_entry(dcrc, &cont->vc_dtx_committable_list,
 			      dcrc_committable) {
 		if (oid != NULL &&
 		    daos_unit_oid_compare(dcrc->dcrc_ptr->dcr_oid, *oid) != 0)
@@ -559,10 +589,10 @@ vos_dtx_cos_oldest(struct vos_container *cont)
 {
 	struct dtx_cos_rec_child	*dcrc;
 
-	if (d_list_empty(&cont->vc_dtx_committable))
+	if (d_list_empty(&cont->vc_dtx_committable_list))
 		return 0;
 
-	dcrc = d_list_entry(cont->vc_dtx_committable.next,
+	dcrc = d_list_entry(cont->vc_dtx_committable_list.next,
 			    struct dtx_cos_rec_child, dcrc_committable);
-	return dcrc->dcrc_time;
+	return dcrc->dcrc_epoch;
 }

--- a/src/vos/vos_obj_index.c
+++ b/src/vos/vos_obj_index.c
@@ -301,12 +301,13 @@ int
 vos_oi_punch(struct vos_container *cont, daos_unit_oid_t oid,
 	     daos_epoch_t epoch, uint32_t flags, struct vos_obj_df *obj)
 {
-	struct oi_hkey	*hkey;
-	struct oi_key	 key;
-	d_iov_t	 key_iov;
-	d_iov_t	 val_iov;
-	int		 rc = 0;
-	bool		 replay = (flags & VOS_OF_REPLAY_PC);
+	struct dtx_handle	*dth;
+	struct oi_hkey		*hkey;
+	struct oi_key		 key;
+	d_iov_t			 key_iov;
+	d_iov_t			 val_iov;
+	int			 rc = 0;
+	bool			 replay = (flags & VOS_OF_REPLAY_PC);
 
 	D_DEBUG(DB_TRACE, "Punch obj "DF_UOID", epoch="DF_U64".\n",
 		DP_UOID(oid), epoch);
@@ -337,7 +338,8 @@ vos_oi_punch(struct vos_container *cont, daos_unit_oid_t oid,
 	if (rc != 0 || replay)
 		goto out;
 
-	if (vos_dth_get() == NULL) {
+	dth = vos_dth_get();
+	if (dth == NULL || dth->dth_single_participator) {
 		struct vos_obj_df *tmp;
 
 		D_ASSERT((obj->vo_oi_attr & VOS_OI_PUNCHED) == 0);

--- a/src/vos/vos_tree.c
+++ b/src/vos/vos_tree.c
@@ -1036,6 +1036,7 @@ int
 key_tree_punch(struct vos_object *obj, daos_handle_t toh, d_iov_t *key_iov,
 	       d_iov_t *val_iov, int flags)
 {
+	struct dtx_handle	*dth;
 	struct vos_key_bundle	*kbund;
 	struct vos_rec_bundle	*rbund;
 	struct vos_krec_df	*krec;
@@ -1084,7 +1085,8 @@ key_tree_punch(struct vos_object *obj, daos_handle_t toh, d_iov_t *key_iov,
 	if (rc != 0 || replay)
 		return rc;
 
-	if (vos_dth_get() == NULL) { /* delete the max epoch */
+	dth = vos_dth_get();
+	if (dth == NULL || dth->dth_single_participator) {
 		struct umem_instance	*umm = vos_obj2umm(obj);
 		struct vos_krec_df	*krec2;
 		struct vos_key_bundle	 kbund2;


### PR DESCRIPTION
Mainly include the following:

1. Increase the CPU yield frequency during DTX aggregation and
   batched commit to allow more normal IO schedule.

2. Use client-side HLC in the DTX ID as the modification epoch.

3. Replace HLC based race detection between DTX resync and normal
   modification handling logic with server-side generation.

4. Fine-grained contents for PMDK undo log to reduce the overhead
   PMDK related logic.

5. Store the committed DTX table in DRAM rather than SCM.

6. Some DTX logic can be optimized if the DTX contains single
   participator (such as modifying single replicated object).
   For example: the DTX will be committed immediately after
   local modification done.

6.1. It is unnecessary to allocate related DTX records for the
     target (object/dkey/akey/SV/EV rec) to be modified.

6.2. It is unnecessary to insert the DTX into active DTX tree,
     instead, it can be directly inserted into the committed
     DTX tree when commit.

6.3. Punch logic can be simplified as without DTX case.

6.4. CoS logic can be bypass.

Signed-off-by: Fan Yong <fan.yong@intel.com>