### PR TITLE
DAOS-623 build: Fix compiler warnings on Fedora 30

### DIFF
--- a/src/bio/bio_monitor.c
+++ b/src/bio/bio_monitor.c
@@ -33,6 +33,23 @@
 /* Used to preallocate buffer to query error log pages from SPDK health info */
 #define DAOS_MAX_ERROR_LOG_PAGES 256
 
+/* See DAOS-3319 on this.  We should generally try to avoid reading unaligned
+ * variables directly as it results in more than one instruction for each such
+ * access.  The instances of these possible unaligned accesses happen with
+ * default gcc on Fedora 30.
+ */
+#if !defined(__has_warning)  /* gcc */
+#if __GNUC__ >= 9
+	#pragma GCC diagnostic ignored "-Waddress-of-packed-member"
+#endif /* warning only defined in version 9 or later */
+#else /* __has_warning is defined */
+#if __has_warning("-Waddress-of-packed-member") /* valid clang warning */
+	#pragma GCC diagnostic ignored "-Waddress-of-packed-member"
+#endif /* Warning is defined in clang */
+#endif /* __has_warning not defined */
+
+
+
 /*
  * Used for getting bio device state, which requires exclusive access from
  * the device owner xstream.

--- a/src/client/dfs/dfs.c
+++ b/src/client/dfs/dfs.c
@@ -2240,8 +2240,8 @@ dfs_stat(dfs_t *dfs, dfs_obj_t *parent, const char *name, struct stat *stbuf)
 
 	if (name == NULL) {
 		if (strcmp(parent->name, "/") != 0) {
-			D_ERROR("Invalid path %s and entry name %s)\n",
-				parent->name, name);
+			D_ERROR("Invalid path %s and entry name is NULL)\n",
+				parent->name);
 			return EINVAL;
 		}
 		name = parent->name;
@@ -2299,8 +2299,8 @@ dfs_access(dfs_t *dfs, dfs_obj_t *parent, const char *name, int mask)
 		return ENOTDIR;
 	if (name == NULL) {
 		if (strcmp(parent->name, "/") != 0) {
-			D_ERROR("Invalid path %s and entry name %s\n",
-				parent->name, name);
+			D_ERROR("Invalid path %s and entry name is NULL\n",
+				parent->name);
 			return EINVAL;
 		}
 		name = parent->name;
@@ -2372,8 +2372,8 @@ dfs_chmod(dfs_t *dfs, dfs_obj_t *parent, const char *name, mode_t mode)
 		return ENOTDIR;
 	if (name == NULL) {
 		if (strcmp(parent->name, "/") != 0) {
-			D_ERROR("Invalid path %s and entry name %s)\n",
-				parent->name, name);
+			D_ERROR("Invalid path %s and entry name is NULL)\n",
+				parent->name);
 			return EINVAL;
 		}
 		name = parent->name;

--- a/src/client/dfuse/test/test_ioil.c
+++ b/src/client/dfuse/test/test_ioil.c
@@ -39,7 +39,10 @@
 #include "dfuse_ioctl.h"
 #include "ioil_api.h"
 
-static char *mount_dir;
+/* This test isn't presently enabled.  If mount_dir is NULL, it causes compiler
+ * warning in sanity(...) with some newer compilers
+ */
+static char *mount_dir = "/tmp";
 static uint64_t max_read_size;
 static uint64_t max_iov_read_size;
 

--- a/src/vos/tests/evt_ctl.c
+++ b/src/vos/tests/evt_ctl.c
@@ -337,7 +337,7 @@ ts_add_rect(void **state)
 	arg = tst_fn_val.optval;
 
 	if (arg == NULL) {
-		D_PRINT("No parameters %s\n", arg);
+		D_PRINT("No parameters\n");
 		fail();
 	}
 


### PR DESCRIPTION
There are a few instances of printing a string of known NULL
values.  Additionally, filed DAOS-3319 on the bio unaligned
access warnings that show up after I updated my box to
Fedora 30.

Signed-off-by: Jeff Olivier <jeffrey.v.olivier@intel.com>