### PR TITLE
DAOS-0000 vos: land small io to SCM

### DIFF
--- a/src/vos/vos_aggregate.c
+++ b/src/vos/vos_aggregate.c
@@ -599,7 +599,8 @@ reserve_segment(struct vos_object *obj, struct agg_io_context *io,
 	int			 rc;
 
 	memset(addr, 0, sizeof(*addr));
-	media = vos_media_select(obj->obj_cont, DAOS_IOD_ARRAY, size);
+	media = vos_media_select(obj->obj_cont, DAOS_IOD_ARRAY, size,
+				 VOS_IOS_AGGREGATION);
 
 	if (media == DAOS_MEDIA_SCM) {
 		struct pobj_action	*scm_ext;

--- a/src/vos/vos_internal.h
+++ b/src/vos/vos_internal.h
@@ -890,7 +890,7 @@ key_tree_punch(struct vos_object *obj, daos_handle_t toh, d_iov_t *key_iov,
 /* vos_io.c */
 uint16_t
 vos_media_select(struct vos_container *cont, daos_iod_type_t type,
-		 daos_size_t size);
+		 daos_size_t size, enum vos_io_stream ios);
 int
 vos_publish_blocks(struct vos_container *cont, d_list_t *blk_list, bool publish,
 		   enum vos_io_stream ios);


### PR DESCRIPTION
Land small io (< 64k) to SCM and rely on aggregation to coalesce
and migrate them to NVMe.

Signed-off-by: Niu Yawei <yawei.niu@intel.com>
Change-Id: I9017b65cadd8d1a2f658dda1fd805af1ace2d3fe