### PR TITLE
WIP: SPDK init needs more than shmId

### DIFF
--- a/src/control/server/ctl_storage.go
+++ b/src/control/server/ctl_storage.go
@@ -58,7 +58,7 @@ func DefaultStorageControlService(log logging.Logger, cfg *Configuration) (*Stor
 	}
 
 	return NewStorageControlService(log,
-		newNvmeStorage(log, cfg.NvmeShmID, spdkScript, cfg.ext),
+		newNvmeStorage(log, cfg.NvmeShmID, cfg.NrHugepages, spdkScript, cfg.ext),
 		newScmStorage(log, cfg.ext), cfg.Servers,
 		getDrpcClientConnection(cfg.SocketDir)), nil
 }

--- a/src/control/server/ctl_storage.go
+++ b/src/control/server/ctl_storage.go
@@ -57,8 +57,14 @@ func DefaultStorageControlService(log logging.Logger, cfg *Configuration) (*Stor
 		nrHugePages: cfg.NrHugepages,
 	}
 
+	opts := spdkOpts{
+		shmID:        cfg.NvmeShmID,
+		memSize:      cfg.NrHugepages,
+		pciBlacklist: cfg.BdevExclude,
+		pciWhitelist: cfg.BdevInclude,
+	}
 	return NewStorageControlService(log,
-		newNvmeStorage(log, cfg.NvmeShmID, cfg.NrHugepages, spdkScript, cfg.ext),
+		newNvmeStorage(log, opts, spdkScript, cfg.ext),
 		newScmStorage(log, cfg.ext), cfg.Servers,
 		getDrpcClientConnection(cfg.SocketDir)), nil
 }

--- a/src/control/server/storage_nvme.go
+++ b/src/control/server/storage_nvme.go
@@ -142,6 +142,7 @@ type nvmeStorage struct {
 	nvme        spdk.NVME // SPDK NVMe interface
 	spdk        SpdkSetup // SPDK shell configuration interface
 	shmID       int
+	spdkMem     int
 	controllers types.NvmeControllers
 	initialized bool
 	formatted   bool
@@ -208,8 +209,13 @@ func (n *nvmeStorage) Discover() error {
 		return nil
 	}
 
-	// specify shmID to be set as opt in SPDK env init
-	if err := n.env.InitSPDKEnv(n.shmID); err != nil {
+	opts := spdk.EnvOptions{
+		// specify shmID to be set as opt in SPDK env init
+		ShmID: n.shmID,
+		// memory, in MB, for DCPM
+		MemSize: n.spdkMem,
+	}
+	if err := n.env.InitSPDKEnv(opts); err != nil {
 		return errors.WithMessage(err, msgSpdkInitFail)
 	}
 
@@ -521,13 +527,14 @@ func loadHealthStats(health []spdk.DeviceHealth) (_health types.NvmeHealthstats)
 }
 
 // newNvmeStorage creates a new instance of nvmeStorage struct.
-func newNvmeStorage(log logging.Logger, shmID int, spdkScript *spdkSetup, ext External) *nvmeStorage {
+func newNvmeStorage(log logging.Logger, shmID, spdkMem int, spdkScript *spdkSetup, ext External) *nvmeStorage {
 	return &nvmeStorage{
-		log:   log,
-		ext:   ext,
-		spdk:  spdkScript,
-		env:   &spdk.Env{},
-		nvme:  &spdk.Nvme{},
-		shmID: shmID,
+		log:     log,
+		ext:     ext,
+		spdk:    spdkScript,
+		env:     &spdk.Env{},
+		nvme:    &spdk.Nvme{},
+		shmID:   shmID,
+		spdkMem: spdkMem,
 	}
 }

--- a/src/control/server/storage_nvme_test.go
+++ b/src/control/server/storage_nvme_test.go
@@ -99,7 +99,7 @@ type mockSpdkEnv struct {
 	initRet error // ENV interface InitSPDKEnv() return value
 }
 
-func (m *mockSpdkEnv) InitSPDKEnv(int) error { return m.initRet }
+func (m *mockSpdkEnv) InitSPDKEnv(EnvOptions) error { return m.initRet }
 
 func newMockSpdkEnv(initRet error) ENV { return &mockSpdkEnv{initRet} }
 


### PR DESCRIPTION
Supply some other parameter to avoid default behavior
which does not work with multiple primary processes.