### PR TITLE
DAOS-2058 drpc: Remove invalid dRPC client code

### DIFF
--- a/src/control/server/ctl_storage.go
+++ b/src/control/server/ctl_storage.go
@@ -29,7 +29,6 @@ import (
 	"github.com/pkg/errors"
 
 	types "github.com/daos-stack/daos/src/control/common/storage"
-	"github.com/daos-stack/daos/src/control/drpc"
 	"github.com/daos-stack/daos/src/control/logging"
 	"github.com/daos-stack/daos/src/control/server/ioserver"
 )
@@ -39,7 +38,6 @@ type StorageControlService struct {
 	log             logging.Logger
 	nvme            *nvmeStorage
 	scm             *scmStorage
-	drpc            drpc.DomainSocketClient
 	instanceStorage []ioserver.StorageConfig
 }
 
@@ -59,13 +57,12 @@ func DefaultStorageControlService(log logging.Logger, cfg *Configuration) (*Stor
 
 	return NewStorageControlService(log,
 		newNvmeStorage(log, cfg.NvmeShmID, spdkScript, cfg.ext),
-		newScmStorage(log, cfg.ext), cfg.Servers,
-		getDrpcClientConnection(cfg.SocketDir)), nil
+		newScmStorage(log, cfg.ext), cfg.Servers), nil
 }
 
 // NewStorageControlService returns an initialized *StorageControlService
 func NewStorageControlService(log logging.Logger, nvme *nvmeStorage, scm *scmStorage,
-	srvCfgs []*ioserver.Config, drpc drpc.DomainSocketClient) *StorageControlService {
+	srvCfgs []*ioserver.Config) *StorageControlService {
 
 	instanceStorage := []ioserver.StorageConfig{}
 	for _, srvCfg := range srvCfgs {
@@ -76,7 +73,6 @@ func NewStorageControlService(log logging.Logger, nvme *nvmeStorage, scm *scmSto
 		log:             log,
 		nvme:            nvme,
 		scm:             scm,
-		drpc:            drpc,
 		instanceStorage: instanceStorage,
 	}
 }

--- a/src/control/server/ctl_svc.go
+++ b/src/control/server/ctl_svc.go
@@ -29,7 +29,6 @@ import (
 
 	"github.com/daos-stack/daos/src/control/common"
 	ctlpb "github.com/daos-stack/daos/src/control/common/proto/ctl"
-	"github.com/daos-stack/daos/src/control/drpc"
 	"github.com/daos-stack/daos/src/control/logging"
 )
 
@@ -40,7 +39,6 @@ var jsonDBRelPath = "share/daos/control/mgmtinit_db.json"
 type ControlService struct {
 	StorageControlService
 	harness           *IOServerHarness
-	drpc              drpc.DomainSocketClient
 	supportedFeatures FeatureMap
 }
 
@@ -58,7 +56,6 @@ func NewControlService(l logging.Logger, h *IOServerHarness, cfg *Configuration)
 	return &ControlService{
 		StorageControlService: *scs,
 		harness:               h,
-		drpc:                  scs.drpc,
 		supportedFeatures:     fMap,
 	}, nil
 }

--- a/src/control/server/ctl_svc_test.go
+++ b/src/control/server/ctl_svc_test.go
@@ -26,7 +26,6 @@ package server
 import (
 	"testing"
 
-	"github.com/daos-stack/daos/src/control/drpc"
 	"github.com/daos-stack/daos/src/control/logging"
 	"github.com/daos-stack/daos/src/control/server/ioserver"
 	"github.com/daos-stack/daos/src/control/server/storage"
@@ -44,7 +43,7 @@ func mockControlService(t *testing.T, log logging.Logger, cfg *Configuration) *C
 		StorageControlService: *NewStorageControlService(log,
 			defaultMockNvmeStorage(log, cfg.ext),
 			defaultMockScmStorage(log, cfg.ext),
-			cfg.Servers, &drpc.ClientConnection{},
+			cfg.Servers,
 		),
 		harness: &IOServerHarness{
 			log: log,

--- a/src/control/server/drpc.go
+++ b/src/control/server/drpc.go
@@ -36,15 +36,6 @@ import (
 
 const sockFileName = "daos_server.sock"
 
-func getDrpcClientSocket(sockDir string) string {
-	return filepath.Join(sockDir, "daos_io_server.sock")
-}
-
-func getDrpcClientConnection(sockDir string) *drpc.ClientConnection {
-	clientSock := getDrpcClientSocket(sockDir)
-	return drpc.NewClientConnection(clientSock)
-}
-
 func checkDrpcClientSocketPath(socketPath string) error {
 	if socketPath == "" {
 		return errors.New("socket path empty")

--- a/src/control/server/server.go
+++ b/src/control/server/server.go
@@ -38,7 +38,6 @@ import (
 	mgmtpb "github.com/daos-stack/daos/src/control/common/proto/mgmt"
 	"github.com/daos-stack/daos/src/control/logging"
 	"github.com/daos-stack/daos/src/control/security"
-	"github.com/daos-stack/daos/src/control/security/acl"
 	"github.com/daos-stack/daos/src/control/server/ioserver"
 	"github.com/daos-stack/daos/src/control/server/storage"
 )
@@ -132,8 +131,6 @@ func Start(log *logging.LeveledLogger, cfg *Configuration) error {
 	// otherwise, only provide gRPC mgmt control service for hardware provisioning.
 	if !needsRespawn {
 		mgmtpb.RegisterMgmtSvcServer(grpcServer, newMgmtSvc(harness))
-		secServer := newSecurityService(getDrpcClientConnection(cfg.SocketDir))
-		acl.RegisterAccessControlServer(grpcServer, secServer)
 	}
 
 	go func() {


### PR DESCRIPTION
- Removed usage of dRPC client that is no longer valid
  with multi-iosrv model. It wasn't used anyway.
- Removed references to unused dRPC module that was
  calling the old client methods.

Signed-off-by: Kris Jacque <kristin.jacque@intel.com>