### PR TITLE
DAOS-2390 vos: close merge window on iteration error

### DIFF
--- a/src/container/container_iv.c
+++ b/src/container/container_iv.c
@@ -564,10 +564,9 @@ cont_iv_snapshots_refresh(void *ns, uuid_t cont_uuid)
 		goto out;
 	}
 	rc = cont_iv_fetch(ns, IV_CONT_SNAP, cont_uuid, iv_entry, entry_size);
-	if (rc != 0)
-		goto out_free;
-	D_ASSERT(iv_entry->iv_snap.snap_cnt <= MAX_SNAP_CNT);
-out_free:
+	if (rc == 0)
+		D_ASSERT(iv_entry->iv_snap.snap_cnt <= MAX_SNAP_CNT);
+
 	D_FREE(iv_entry);
 out:
 	return rc;

--- a/src/tests/suite/daos_obj.c
+++ b/src/tests/suite/daos_obj.c
@@ -2255,6 +2255,7 @@ tx_discard(void **state)
 	 * new transaction model.
 	 */
 	print_message("Skip obsolete test\n");
+	skip();
 #if 0
 	test_arg_t	*arg = *state;
 	daos_obj_id_t	 oid;
@@ -2433,6 +2434,7 @@ tx_commit(void **state)
 	 * new transaction model.
 	 */
 	print_message("Skip obsolete test\n");
+	skip();
 #if 0
 	test_arg_t	*arg = *state;
 	daos_obj_id_t	 oid;
@@ -3126,6 +3128,7 @@ blob_unmap_trigger(void **state)
 	 * anymore, need to figure out a new way to trigger blob unmap.
 	 */
 	print_message("Skip obsolete test\n");
+	skip();
 #if 0
 	daos_obj_id_t	 oid;
 	test_arg_t	*arg = *state;

--- a/src/vos/vos_aggregate.c
+++ b/src/vos/vos_aggregate.c
@@ -1535,7 +1535,7 @@ static int
 aggregate_enter(struct vos_container *cont, bool discard)
 {
 	if (cont->vc_in_aggregation) {
-		D_ERROR(DF_CONT": Already in agregation. discard:%d\n",
+		D_ERROR(DF_CONT": Already in aggregation. discard:%d\n",
 			DP_CONT(cont->vc_pool->vp_id, cont->vc_id), discard);
 		return -DER_BUSY;
 	}
@@ -1602,8 +1602,10 @@ vos_aggregate(daos_handle_t coh, daos_epoch_range_t *epr)
 	iter_param.ip_flags |= VOS_IT_FOR_PURGE;
 	rc = vos_iterate(&iter_param, VOS_ITER_OBJ, true, &anchors,
 			 vos_aggregate_cb, &agg_param);
-	if (rc != 0)
+	if (rc != 0) {
+		close_merge_window(&agg_param.ap_window, rc);
 		goto exit;
+	}
 
 	/*
 	 * Update LAE, when aggregating for snapshot deletion, the


### PR DESCRIPTION
Evtree aggregation merge windows needs be closed on any iteration
error as well (error happened out side of iteration callback).

Bump the aggregation threshold from 10 seconds to 90 seconds, since
DTX batched commit age is 60 seconds.

Minor cleanup to address the comments from the online aggregation
patch review.

Signed-off-by: Niu Yawei <yawei.niu@intel.com>
Change-Id: Ica57c31052ad22053308cb379bfe83fe317a5521