### PR TITLE
DAOS-623 build: Use our build of hwloc in control plane

### DIFF
--- a/src/control/SConscript
+++ b/src/control/SConscript
@@ -78,7 +78,7 @@ def scons():
     env.AppendUnique(LIBPATH=[Dir('.')])
 
     denv = env.Clone()
-    prereqs.require(denv, 'spdk')
+    prereqs.require(denv, 'spdk', 'hwloc')
 
     # if SPDK_PREFIX differs from PREFIX, copy dir so files can be accessed at
     # runtime
@@ -161,10 +161,11 @@ def scons():
     # CGO shell env vars.
     denv.AppendENVPath(
         "CGO_LDFLAGS",
-        denv.subst("-L%s -L$SPDK_PREFIX/lib $_RPATH" % gopath))
+        denv.subst("-L%s -L$SPDK_PREFIX/lib -L$HWLOC_PREFIX/lib $_RPATH" %
+                   gopath))
     denv.AppendENVPath(
         "CGO_CFLAGS",
-        denv.subst("-I$SPDK_PREFIX/include"))
+        denv.subst("-I$SPDK_PREFIX/include -I$HWLOC_PREFIX/include"))
 
     # copy server init files to be used at runtime, explicitly
     # remove first because recursive Delete() on dir fails.

--- a/src/control/SConscript
+++ b/src/control/SConscript
@@ -78,7 +78,7 @@ def scons():
     env.AppendUnique(LIBPATH=[Dir('.')])
 
     denv = env.Clone()
-    prereqs.require(denv, 'spdk', 'hwloc')
+    prereqs.require(denv, 'spdk', 'hwloc', 'ofi')
 
     # if SPDK_PREFIX differs from PREFIX, copy dir so files can be accessed at
     # runtime
@@ -161,11 +161,12 @@ def scons():
     # CGO shell env vars.
     denv.AppendENVPath(
         "CGO_LDFLAGS",
-        denv.subst("-L%s -L$SPDK_PREFIX/lib -L$HWLOC_PREFIX/lib $_RPATH" %
-                   gopath))
+        denv.subst("-L%s -L$SPDK_PREFIX/lib -L$HWLOC_PREFIX/lib -L$OFI_PREFIX"
+                   " $_RPATH" % gopath))
     denv.AppendENVPath(
         "CGO_CFLAGS",
-        denv.subst("-I$SPDK_PREFIX/include -I$HWLOC_PREFIX/include"))
+        denv.subst("-I$SPDK_PREFIX/include -I$HWLOC_PREFIX/include"
+                   " -I$OFI_PREFIX/include"))
 
     # copy server init files to be used at runtime, explicitly
     # remove first because recursive Delete() on dir fails.


### PR DESCRIPTION
Settle on one version of hwloc.  Since we build it, we should not depend on the external version to be installed.

Signed-off-by: Jeff Olivier <jeffrey.v.olivier@intel.com>