### PR TITLE
DAOS-623 build: Import hwloc where required to allow access to header files.

### DIFF
--- a/src/bio/SConscript
+++ b/src/bio/SConscript
@@ -9,7 +9,7 @@ def scons():
     env.AppendUnique(LIBPATH=[Dir('.')])
 
     denv = env.Clone()
-    prereqs.require(denv, 'pmdk', 'spdk', 'argobots', 'protobufc')
+    prereqs.require(denv, 'pmdk', 'spdk', 'argobots', 'protobufc', 'hwloc')
 
     SConscript('smd/SConscript')
     denv.AppendUnique(LIBPATH=['smd'])

--- a/src/container/SConscript
+++ b/src/container/SConscript
@@ -8,7 +8,7 @@ def scons():
     env.AppendUnique(LIBPATH=[Dir('.')])
     denv = env.Clone()
 
-    prereqs.require(denv, 'argobots', 'protobufc')
+    prereqs.require(denv, 'argobots', 'protobufc', 'hwloc')
 
     common = denv.SharedObject(['rpc.c'])
     # ds_cont: Container Server

--- a/src/dtx/SConscript
+++ b/src/dtx/SConscript
@@ -8,7 +8,7 @@ def scons():
     env.AppendUnique(LIBPATH=[Dir('.')])
     denv = env.Clone()
 
-    prereqs.require(denv, 'argobots', 'protobufc')
+    prereqs.require(denv, 'argobots', 'protobufc', 'hwloc')
 
     # dtx
     dtx = daos_build.library(denv, 'dtx',

--- a/src/mgmt/SConscript
+++ b/src/mgmt/SConscript
@@ -9,7 +9,7 @@ def scons():
 
     denv = env.Clone()
 
-    prereqs.require(denv, 'argobots', 'protobufc')
+    prereqs.require(denv, 'argobots', 'protobufc', 'hwloc')
 
     common = denv.SharedObject(['rpc.c', 'mgmt.pb-c.c', 'pool.pb-c.c',
                                 'srv.pb-c.c', 'storage_query.pb-c.c'])

--- a/src/object/SConscript
+++ b/src/object/SConscript
@@ -9,7 +9,7 @@ def scons():
 
     denv = env.Clone()
 
-    prereqs.require(denv, 'argobots', 'protobufc')
+    prereqs.require(denv, 'argobots', 'protobufc', 'hwloc')
 
     # Common object code
     common_tgts = denv.SharedObject(['obj_class.c', 'obj_rpc.c', 'obj_task.c',

--- a/src/pool/SConscript
+++ b/src/pool/SConscript
@@ -8,7 +8,7 @@ def scons():
     env.AppendUnique(LIBPATH=[Dir('.')])
     denv = env.Clone()
 
-    prereqs.require(denv, 'argobots', 'protobufc')
+    prereqs.require(denv, 'argobots', 'protobufc', 'hwloc')
 
     common = denv.SharedObject(['rpc.c'])
     # ds_pool: Pool Server

--- a/src/rdb/SConscript
+++ b/src/rdb/SConscript
@@ -11,7 +11,7 @@ def scons():
     # rdb-specific env
     denv = env.Clone()
 
-    prereqs.require(denv, 'argobots', 'protobufc')
+    prereqs.require(denv, 'argobots', 'protobufc', 'hwloc')
 
     denv.AppendUnique(CPPPATH=[Dir('raft/include').srcnode()])
     denv.AppendUnique(LIBPATH=[Dir('raft/src')])

--- a/src/rebuild/SConscript
+++ b/src/rebuild/SConscript
@@ -8,7 +8,7 @@ def scons():
     env.AppendUnique(LIBPATH=[Dir('.')])
     denv = env.Clone()
 
-    prereqs.require(denv, 'argobots', 'protobufc')
+    prereqs.require(denv, 'argobots', 'protobufc', 'hwloc')
 
     denv.Append(CCFLAGS=['-Wframe-larger-than=131072'])
     # rebuild

--- a/src/rsvc/SConscript
+++ b/src/rsvc/SConscript
@@ -8,7 +8,7 @@ def scons():
     # rsvc-specific env
     denv = env.Clone()
 
-    prereqs.require(denv, 'argobots', 'protobufc')
+    prereqs.require(denv, 'argobots', 'protobufc', 'hwloc')
 
     # ds_rsvc
     ds_rsvc = daos_build.library(denv, 'rsvc', ['srv.c',

--- a/src/security/SConscript
+++ b/src/security/SConscript
@@ -17,7 +17,7 @@ def scons():
     env.AppendUnique(LIBPATH=[Dir('.')])
     denv = env.Clone()
 
-    prereqs.require(denv, 'protobufc', 'argobots')
+    prereqs.require(denv, 'protobufc', 'argobots', 'hwloc')
 
     # Populate the object cache
     cache = {}

--- a/src/tests/SConscript
+++ b/src/tests/SConscript
@@ -14,7 +14,7 @@ def scons():
     denv.AppendUnique(RPATH=[Literal(r'\$$ORIGIN/../lib/daos_srv')])
 
     denv.Append(CPPPATH=[Dir('suite').srcnode()])
-    prereqs.require(denv, 'ompi', 'argobots')
+    prereqs.require(denv, 'ompi', 'argobots', 'hwloc')
 
     daos_build.program(denv, 'simple_array', 'simple_array.c', LIBS=libs)
     daosbench = daos_build.program(denv, 'daosbench', 'daosbench.c', LIBS=libs)

--- a/src/tests/security/SConscript
+++ b/src/tests/security/SConscript
@@ -12,7 +12,7 @@ def scons():
     denv.AppendUnique(CFLAGS=['-std=gnu99'])
     denv.AppendUnique(CPPDEFINES=['TEST'])
 
-    prereqs.require(denv, 'ompi', 'argobots', 'protobufc')
+    prereqs.require(denv, 'ompi', 'argobots', 'protobufc', 'hwloc')
 
     security_test = denv.Program('security_test', sec_sources, LIBS=libs)
     env.Install('$PREFIX/bin/', security_test)

--- a/src/vos/SConscript
+++ b/src/vos/SConscript
@@ -39,7 +39,7 @@ def scons():
 
     denv = env.Clone()
 
-    prereqs.require(denv, 'pmdk', 'argobots', 'protobufc')
+    prereqs.require(denv, 'pmdk', 'argobots', 'protobufc', 'hwloc')
 
     # Compiler options
     denv.Append(CPPPATH=[Dir('.').srcnode()])


### PR DESCRIPTION
This is needed on systems where hwloc.h isn't on the default include path.