### PR TITLE
DAOS-3316 drpc: make locking of drpc client implicit during call

### DIFF
--- a/src/control/drpc/drpc_client.go
+++ b/src/control/drpc/drpc_client.go
@@ -25,6 +25,7 @@ package drpc
 
 import (
 	"net"
+	"sync"
 
 	"github.com/golang/protobuf/proto"
 	"github.com/pkg/errors"
@@ -33,6 +34,7 @@ import (
 // DomainSocketClient is the interface to a dRPC client communicating over a
 // Unix Domain Socket
 type DomainSocketClient interface {
+	sync.Locker
 	IsConnected() bool
 	Connect() error
 	Close() error
@@ -54,6 +56,7 @@ type domainSocketDialer interface {
 
 // ClientConnection represents a client connection to a dRPC server
 type ClientConnection struct {
+	sync.Mutex
 	socketPath string             // Filesystem location of dRPC socket
 	dialer     domainSocketDialer // Interface to connect to the socket
 	conn       domainSocketConn   // UDS connection

--- a/src/control/server/drpc.go
+++ b/src/control/server/drpc.go
@@ -171,19 +171,17 @@ func makeDrpcCall(client drpc.DomainSocketClient, module int32, method int32,
 	}
 
 	client.Lock()
+	defer client.Unlock()
 
 	// Forward the request to the I/O server via dRPC
 	if err = client.Connect(); err != nil {
-		client.Unlock()
 		return drpcResp, errors.Wrap(err, "connect to client")
 	}
 	defer client.Close()
 
 	if drpcResp, err = client.SendMsg(drpcCall); err != nil {
-		client.Unlock()
 		return drpcResp, errors.Wrap(err, "send message")
 	}
-	client.Unlock()
 
 	if err = checkDrpcResponse(drpcResp); err != nil {
 		return drpcResp, errors.Wrap(err, "validate response")

--- a/src/control/server/mgmt_drpc.go
+++ b/src/control/server/mgmt_drpc.go
@@ -53,7 +53,6 @@ const (
 	notifyReady = C.DRPC_METHOD_SRV_NOTIFY_READY
 )
 
-// mgmtModule is the management drpc module struct
 // mgmtModule represents the daos_server mgmt dRPC module. It sends dRPCs to
 // the daos_io_server iosrv module (src/iosrv).
 type mgmtModule struct{}

--- a/src/control/server/mgmt_svc.go
+++ b/src/control/server/mgmt_svc.go
@@ -173,9 +173,7 @@ func (svc *mgmtSvc) GetAttachInfo(ctx context.Context, req *mgmtpb.GetAttachInfo
 		return nil, err
 	}
 
-	svc.mutex.Lock()
 	dresp, err := makeDrpcCall(mi.drpcClient, mgmtModuleID, getAttachInfo, req)
-	svc.mutex.Unlock()
 	if err != nil {
 		return nil, err
 	}
@@ -194,9 +192,7 @@ func (svc *mgmtSvc) Join(ctx context.Context, req *mgmtpb.JoinReq) (*mgmtpb.Join
 		return nil, err
 	}
 
-	svc.mutex.Lock()
 	dresp, err := makeDrpcCall(mi.drpcClient, mgmtModuleID, join, req)
-	svc.mutex.Unlock()
 	if err != nil {
 		return nil, err
 	}
@@ -252,9 +248,7 @@ func (svc *mgmtSvc) PoolCreate(ctx context.Context, req *mgmtpb.PoolCreateReq) (
 
 	svc.log.Debugf("MgmtSvc.PoolCreate dispatch, req:%+v\n", *req)
 
-	svc.mutex.Lock()
 	dresp, err := makeDrpcCall(mi.drpcClient, mgmtModuleID, poolCreate, req)
-	svc.mutex.Unlock()
 	if err != nil {
 		return nil, err
 	}
@@ -281,9 +275,7 @@ func (svc *mgmtSvc) PoolDestroy(ctx context.Context, req *mgmtpb.PoolDestroyReq)
 
 	svc.log.Debugf("MgmtSvc.PoolDestroy dispatch, req:%+v\n", *req)
 
-	svc.mutex.Lock()
 	dresp, err := makeDrpcCall(mi.drpcClient, mgmtModuleID, poolDestroy, req)
-	svc.mutex.Unlock()
 	if err != nil {
 		return nil, err
 	}
@@ -307,9 +299,7 @@ func (svc *mgmtSvc) BioHealthQuery(ctx context.Context, req *mgmtpb.BioHealthReq
 
 	svc.log.Debugf("MgmtSvc.BioHealthQuery dispatch, req:%+v\n", *req)
 
-	svc.mutex.Lock()
 	dresp, err := makeDrpcCall(mi.drpcClient, mgmtModuleID, bioHealth, req)
-	svc.mutex.Unlock()
 	if err != nil {
 		return nil, err
 	}
@@ -331,9 +321,7 @@ func (svc *mgmtSvc) SmdListDevs(ctx context.Context, req *mgmtpb.SmdDevReq) (*mg
 
 	svc.log.Debugf("MgmtSvc.SmdListDevs dispatch, req:%+v\n", *req)
 
-	svc.mutex.Lock()
 	dresp, err := makeDrpcCall(mi.drpcClient, mgmtModuleID, smdDevs, req)
-	svc.mutex.Unlock()
 	if err != nil {
 		return nil, err
 	}
@@ -358,9 +346,7 @@ func (svc *mgmtSvc) KillRank(ctx context.Context, req *mgmtpb.DaosRank) (*mgmtpb
 
 	svc.log.Debugf("MgmtSvc.KillRank dispatch, req:%+v\n", *req)
 
-	svc.mutex.Lock()
 	dresp, err := makeDrpcCall(mi.drpcClient, mgmtModuleID, killRank, req)
-	svc.mutex.Unlock()
 	if err != nil {
 		return nil, err
 	}

--- a/src/control/server/security_test.go
+++ b/src/control/server/security_test.go
@@ -25,6 +25,7 @@ package server
 
 import (
 	"context"
+	"sync"
 	"testing"
 
 	"github.com/golang/protobuf/proto"
@@ -37,6 +38,7 @@ import (
 
 // mockDrpcClient is a mock of the DomainSocketClient interface
 type mockDrpcClient struct {
+	sync.Mutex
 	ConnectOutputError    error
 	CloseOutputError      error
 	CloseCallCount        int


### PR DESCRIPTION
DRY up by moving locking of client connection into makeDrpcCall function.

Signed-off-by: Tom Nabarro <tom.nabarro@intel.com>