### PR TITLE
DAOS-3397 build: Disable build and test of SLES 12.3 (and Leap 42.3) RPM

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -279,7 +279,7 @@ pipeline {
                     when {
                         beforeAgent true
                         allOf {
-                            false
+                            expression { false }
                             environment name: 'SLES12_3_DOCKER', value: 'true'
                             not { branch 'weekly-testing' }
                             expression { env.CHANGE_TARGET != 'weekly-testing' }
@@ -352,7 +352,7 @@ pipeline {
                     when {
                         beforeAgent true
                         allOf {
-                            false
+                            expression { false }
                             not { branch 'weekly-testing' }
                             expression { env.CHANGE_TARGET != 'weekly-testing' }
                         }
@@ -1304,7 +1304,7 @@ pipeline {
                     when {
                         beforeAgent true
                         allOf {
-                            false
+                            expression { false }
                             not { branch 'weekly-testing' }
                             expression { env.CHANGE_TARGET != 'weekly-testing' }
                             expression { return env.QUICKBUILD == '1' }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -279,6 +279,7 @@ pipeline {
                     when {
                         beforeAgent true
                         allOf {
+                            false
                             environment name: 'SLES12_3_DOCKER', value: 'true'
                             not { branch 'weekly-testing' }
                             expression { env.CHANGE_TARGET != 'weekly-testing' }
@@ -351,6 +352,7 @@ pipeline {
                     when {
                         beforeAgent true
                         allOf {
+                            false
                             not { branch 'weekly-testing' }
                             expression { env.CHANGE_TARGET != 'weekly-testing' }
                         }
@@ -1302,6 +1304,7 @@ pipeline {
                     when {
                         beforeAgent true
                         allOf {
+                            false
                             not { branch 'weekly-testing' }
                             expression { env.CHANGE_TARGET != 'weekly-testing' }
                             expression { return env.QUICKBUILD == '1' }


### PR DESCRIPTION

SLES 12.3 (and by extension Leap 42.3) are just getting too old to be
supportable.  The BUS is on the move toward SLES 15 so we should stop
wasting time on supporting SLES 12.3 and refocus that time on supporting
SLES 15.

Disable build and test on SLES 12.3 and Leap 42.3.

Signed-off-by: Brian J. Murrell <brian.murrell@intel.com>