### PR TITLE
DAOS-3420 control: specify uuid in pool destroy with --pool option

### DIFF
--- a/src/control/cmd/dmg/pool.go
+++ b/src/control/cmd/dmg/pool.go
@@ -73,7 +73,8 @@ func (c *PoolCreateCmd) Execute(args []string) error {
 type PoolDestroyCmd struct {
 	logCmd
 	connectedCmd
-	Uuid  string `short:"u" long:"uuid" required:"1" description:"UUID of DAOS pool to destroy"`
+	// TODO: implement --sys & --svc options (currently unsupported server side)
+	Uuid  string `long:"pool" required:"1" description:"UUID of DAOS pool to destroy"`
 	Force bool   `short:"f" long:"force" description:"Force removal of DAOS pool"`
 }
 

--- a/src/control/cmd/dmg/pool_test.go
+++ b/src/control/cmd/dmg/pool_test.go
@@ -217,7 +217,7 @@ func TestPoolCommands(t *testing.T) {
 		},
 		{
 			"Destroy pool with force",
-			"pool destroy --uuid 031bcaf8-f0f5-42ef-b3c5-ee048676dceb --force",
+			"pool destroy --pool 031bcaf8-f0f5-42ef-b3c5-ee048676dceb --force",
 			strings.Join([]string{
 				"ConnectClients",
 				fmt.Sprintf("PoolDestroy-%+v", &client.PoolDestroyReq{


### PR DESCRIPTION
--uuid option in control plane implementation of pool destroy is
inconsistent with "daos" tool, change instead to --pool.

Signed-off-by: Tom Nabarro <tom.nabarro@intel.com>