### PR TITLE
DAOS-3435 control: Agent help shouldn't display twice

### DIFF
--- a/src/control/cmd/agent/main.go
+++ b/src/control/cmd/agent/main.go
@@ -89,7 +89,7 @@ func applyCmdLineOverrides(log logging.Logger, c *client.Configuration, opts *cl
 func agentMain(log *logging.LeveledLogger, opts *cliOptions) error {
 	log.Info("Starting daos_agent:")
 
-	p := flags.NewParser(opts, flags.Default)
+	p := flags.NewParser(opts, flags.HelpFlag|flags.PassDoubleDash)
 
 	_, err := p.Parse()
 	if err != nil {


### PR DESCRIPTION
The go-flags library needs to be configured so that it
doesn't print parse errors in addition to returning them.