### PR TITLE
DAOS-3436 Consider prerequisites when creating the daos and scons_local tarballs

### DIFF
--- a/utils/rpms/Makefile
+++ b/utils/rpms/Makefile
@@ -35,15 +35,16 @@ include packaging/Makefile_packaging.mk
 
 PACKAGING_CHECK_DIR ?= ../../../rpm/packaging
 
-scons_local-$(VERSION).tar.gz:
+scons_local-$(VERSION).tar.gz: $(shell git ls-files :/:)
+	echo Creating $@
 	cd ../../scons_local &&                        \
 	git archive --format tar --prefix scons_local/ \
 	            -o $$OLDPWD/$(basename $@) HEAD ./
 	rm -f $@
 	gzip $(basename $@)
 
-$(NAME)-$(VERSION).tar.gz:
-	echo $@
+$(NAME)-$(VERSION).tar.gz: $(shell git ls-files :/:)
+	echo Creating $@
 	echo $(basename $@)
 	cd ../../ &&                                          \
 	git archive --format tar --prefix $(NAME)-$(VERSION)/ \


### PR DESCRIPTION
When building the daos and/or scons_local tarballs in the packaging/
system, consider the files in the repo as prerequisites.