### PR TITLE
DAOS-648 common: Convert ACL to string list

### DIFF
--- a/src/common/tests/acl_util_tests.c
+++ b/src/common/tests/acl_util_tests.c
@@ -1317,6 +1317,8 @@ test_acl_from_strs_bad_input(void **state)
 	assert_int_equal(daos_acl_from_strs(NULL, 1, &acl), -DER_INVAL);
 	assert_int_equal(daos_acl_from_strs(valid_aces, 0, &acl),
 			 -DER_INVAL);
+	assert_int_equal(daos_acl_from_strs(valid_aces, 1, NULL),
+			 -DER_INVAL);
 	assert_int_equal(daos_acl_from_strs(garbage, 1, &acl), -DER_INVAL);
 }
 
@@ -1348,6 +1350,85 @@ test_acl_from_strs_success(void **state)
 	assert_int_equal(actual_count, aces_nr);
 	assert_null(current);
 
+	daos_acl_free(acl);
+}
+
+static void
+test_acl_to_strs_bad_input(void **state)
+{
+	struct daos_acl	*acl;
+	char		**result = NULL;
+	size_t		len = 0;
+
+	acl = daos_acl_create(NULL, 0); /* empty is valid */
+
+	assert_int_equal(daos_acl_to_strs(NULL, &result, &len), -DER_INVAL);
+	assert_int_equal(daos_acl_to_strs(acl, NULL, &len), -DER_INVAL);
+	assert_int_equal(daos_acl_to_strs(acl, &result, NULL), -DER_INVAL);
+
+	/* mess up the length so the ACL is invalid */
+	acl->dal_len = 1;
+	assert_int_equal(daos_acl_to_strs(acl, &result, &len), -DER_INVAL);
+
+	daos_acl_free(acl);
+}
+
+static void
+test_acl_to_strs_empty(void **state)
+{
+	struct daos_acl	*acl;
+	char		**result = NULL;
+	size_t		len = 0;
+
+	acl = daos_acl_create(NULL, 0); /* empty is valid */
+
+	assert_int_equal(daos_acl_to_strs(acl, &result, &len), 0);
+
+	assert_null(result); /* no point in allocating if there's nothing */
+	assert_int_equal(len, 0);
+
+	daos_acl_free(acl);
+}
+
+static void
+test_acl_to_strs_success(void **state)
+{
+	struct daos_acl	*acl;
+	struct daos_ace	*ace = NULL;
+	char		**result = NULL;
+	size_t		len = 0;
+	char		*expected_result[] = {"A::OWNER@:rw",
+					      "A::user1@:rw",
+					      "A:G:readers@:r"};
+	size_t		expected_len = sizeof(expected_result) / sizeof(char *);
+	size_t		i;
+
+	/* Set up with direct conversion from expected results */
+	acl = daos_acl_create(NULL, 0);
+	for (i = 0; i < expected_len; i++) {
+		assert_int_equal(daos_ace_from_str(expected_result[i], &ace),
+				 0);
+		daos_acl_add_ace(&acl, ace);
+
+		daos_ace_free(ace);
+		ace = NULL;
+	}
+
+	assert_int_equal(daos_acl_to_strs(acl, &result, &len), 0);
+
+	assert_int_equal(len, expected_len);
+	assert_non_null(result);
+
+	for (i = 0; i < expected_len; i++) {
+		assert_non_null(result[i]);
+		assert_string_equal(result[i], expected_result[i]);
+	}
+
+	/* Free up dynamically allocated strings */
+	for (i = 0; i < len; i++) {
+		D_FREE(result[i]);
+	}
+	D_FREE(result);
 	daos_acl_free(acl);
 }
 
@@ -1431,7 +1512,10 @@ main(void)
 		cmocka_unit_test(test_ace_to_str_different_perms),
 		cmocka_unit_test(test_ace_from_str_and_back_again),
 		cmocka_unit_test(test_acl_from_strs_bad_input),
-		cmocka_unit_test(test_acl_from_strs_success)
+		cmocka_unit_test(test_acl_from_strs_success),
+		cmocka_unit_test(test_acl_to_strs_bad_input),
+		cmocka_unit_test(test_acl_to_strs_empty),
+		cmocka_unit_test(test_acl_to_strs_success),
 	};
 
 	return cmocka_run_group_tests(tests, NULL, NULL);

--- a/src/include/daos_security.h
+++ b/src/include/daos_security.h
@@ -474,6 +474,24 @@ daos_ace_to_str(struct daos_ace *ace, char *buf, size_t buf_len);
 int
 daos_acl_from_strs(const char **ace_strs, size_t ace_nr, struct daos_acl **acl);
 
+/**
+ * Convert an Access Control List (daos_acl) to a list of Access Control Entries
+ * formatted as strings.
+ *
+ * Each entry in ace_strs is dynamically allocated. So is the array itself. It
+ * is the caller's responsibility to free all of them.
+ *
+ * \param[in]	acl		DAOS ACL
+ * \param[out]	ace_strs	Newly allocated array of strings
+ * \param[out]	ace_nr		Length of ace_strs
+ *
+ * \return	0		Success
+ *		-DER_INVAL	Invalid input
+ *		-DER_NOMEM	Could not allocate memory
+ */
+int
+daos_acl_to_strs(struct daos_acl *acl, char ***ace_strs, size_t *ace_nr);
+
 #if defined(__cplusplus)
 }
 #endif


### PR DESCRIPTION
Add a method to convert an Access Control List (daos_acl)
to an array of dynamically-allocated strings representing
Access Control Entries.

Signed-off-by: Kris Jacque <kristin.jacque@intel.com>