### PR TITLE
DAOS-3302 test: Targets specification needs to be under "servers:"

### DIFF
--- a/src/tests/ftest/io/ior_small.yaml
+++ b/src/tests/ftest/io/ior_small.yaml
@@ -13,7 +13,7 @@ hosts:
 timeout: 500
 server_config:
     name: daos_server
-    server:
+    servers:
         bdev_class: nvme
         bdev_list: ["0000:81:00.0","0000:da:00.0"]
 pool:

--- a/src/tests/ftest/pool/destroy_rebuild.yaml
+++ b/src/tests/ftest/pool/destroy_rebuild.yaml
@@ -13,7 +13,8 @@ hosts:
     - boro-G
 server_config:
   name: daos_server
-  targets: 8
+  servers:
+    targets: 8
 pool:
   mode: 511
   name: daos_server

--- a/src/tests/ftest/pool/info_tests.yaml
+++ b/src/tests/ftest/pool/info_tests.yaml
@@ -3,7 +3,8 @@ hosts:
     - boro-A
 server_config:
   name: daos_server
-  targets: 1
+  servers:
+    targets: 1
 pool:
   createmode: !mux
     mode_all:

--- a/src/tests/ftest/pool/rebuild_no_cap.yaml
+++ b/src/tests/ftest/pool/rebuild_no_cap.yaml
@@ -14,7 +14,8 @@ hosts:
 timeout: 120
 server_config:
   name: daos_server
-  targets: 8
+  servers:
+    targets: 8
 pool:
   createmode:
     mode: 511

--- a/src/tests/ftest/pool/rebuild_tests.yaml
+++ b/src/tests/ftest/pool/rebuild_tests.yaml
@@ -11,7 +11,8 @@ hosts:
 timeout: 1200
 server_config:
   name: daos_server
-  targets: 8
+  servers:
+    targets: 8
 pool:
   mode: 511
   name: daos_server

--- a/src/tests/ftest/pool/rebuild_with_io.yaml
+++ b/src/tests/ftest/pool/rebuild_with_io.yaml
@@ -11,7 +11,8 @@ hosts:
 timeout: 5000
 server_config:
   name: daos_server
-  targets: 8
+  servers:
+    targets: 8
 pool:
   mode: 511
   name: daos_server

--- a/src/tests/ftest/pool/rebuild_with_ior.yaml
+++ b/src/tests/ftest/pool/rebuild_with_ior.yaml
@@ -12,7 +12,8 @@ hosts:
 timeout: 600
 server_config:
   name: daos_server
-  targets: 8
+  servers:
+    targets: 8
 testparams:
   ranks:
     rank_to_kill: 3

--- a/src/tests/ftest/rebuild/container_create.yaml
+++ b/src/tests/ftest/rebuild/container_create.yaml
@@ -10,7 +10,8 @@ hosts:
 timeout: 480
 server_config:
   name: daos_server
-  targets: 1
+  servers:
+    targets: 1
 pool:
   mode: 511
   group: daos_server

--- a/src/tests/ftest/rebuild/read_array.yaml
+++ b/src/tests/ftest/rebuild/read_array.yaml
@@ -12,7 +12,7 @@ hosts:
 timeout: 240
 server_config:
   name: daos_server
-  server:
+  servers:
     targets: 1
 pool:
   mode: 511

--- a/src/tests/ftest/util/apricot/apricot/test.py
+++ b/src/tests/ftest/util/apricot/apricot/test.py
@@ -199,7 +199,7 @@ class TestWithServers(TestWithoutServers):
         server_count = self.params.get("server_count", "/run/hosts/*")
         client_count = self.params.get("client_count", "/run/hosts/*")
         self.nvme_parameter = self.params.get(
-            "bdev_class", '/server_config/server/')
+            "bdev_class", '/server_config/servers/')
         # If server or client host list are defined through valid slurm
         # partition names override any hosts specified through lists.
         test_servers, self.partition_servers = self.get_partition_hosts(

--- a/src/tests/ftest/util/server_utils.py
+++ b/src/tests/ftest/util/server_utils.py
@@ -91,12 +91,12 @@ def create_server_yaml(basepath, log_filename):
 
     # Update values from avocado_testcase.yaml in DAOS yaml variables.
     if new_value_set:
-        if 'server' in new_value_set['server_config']:
-            for key in new_value_set['server_config']['server']:
+        if 'servers' in new_value_set['server_config']:
+            for key in new_value_set['server_config']['servers']:
                 default_value_set['servers'][0][key] = \
-                        new_value_set['server_config']['server'][key]
+                        new_value_set['server_config']['servers'][key]
         for key in new_value_set['server_config']:
-            if 'server' not in key:
+            if 'servers' not in key:
                 default_value_set[key] = new_value_set['server_config'][key]
 
     # if sepcific log file name specified use that


### PR DESCRIPTION
 - Modified the ftest yaml files to have the targets under
   server_config/servers
 - Modified the apricot test.py and server_utils.py
   to have /server_config/servers

Signed-off-by: Logan Sundaram <logan.sundaram@intel.com>