### PR TITLE
DAOS-623 vos: Cleanup a few spurious error messages

### DIFF
--- a/src/vos/vos_io.c
+++ b/src/vos/vos_io.c
@@ -637,6 +637,7 @@ akey_fetch(struct vos_io_context *ioc, const daos_epoch_range_t *epr,
 					(char *)iod->iod_name.iov_buf);
 				iod_empty_sgl(ioc, ioc->ic_sgl_at);
 				rc = 0;
+				goto out;
 			}
 
 			if (rc == -DER_INPROGRESS)

--- a/src/vos/vos_obj_index.c
+++ b/src/vos/vos_obj_index.c
@@ -585,10 +585,9 @@ oi_iter_match_probe(struct vos_iterator *iter)
  out:
 	return 0;
  failed:
-	if (rc == -DER_NONEXIST)
-		return 0; /* end of iteration, not a failure */
+	if (rc != -DER_NONEXIST)
+		D_ERROR("iterator %s failed, rc=%d\n", str, rc);
 
-	D_ERROR("iterator %s failed, rc=%d\n", str, rc);
 	return rc;
 }
 


### PR DESCRIPTION
1. oi_iter_probe should return -DER_NONEXIST if it reaches the
   end of iteration lest a subsequent fetch try to load a
   non-existent object
2. akey_fetch was printing an error message when it doesn't
   exist with DER_SUCCESS as the rc.   It already prints a
   debug message in such case as the key doesn't exist.

Signed-off-by: Jeff Olivier <jeffrey.v.olivier@intel.com>