### PR TITLE
DAOS-3480 control: Protect access to dRPC client

### DIFF
--- a/src/control/server/harness.go
+++ b/src/control/server/harness.go
@@ -31,7 +31,6 @@ import (
 
 	"github.com/pkg/errors"
 
-	"github.com/daos-stack/daos/src/control/drpc"
 	"github.com/daos-stack/daos/src/control/logging"
 	"github.com/daos-stack/daos/src/control/server/ioserver"
 )
@@ -87,20 +86,9 @@ func (h *IOServerHarness) AddInstance(srv *IOServerInstance) error {
 	return nil
 }
 
-// GetManagementClient returns a dRPC client for the IO Server instance to
-// be used as a management target.
-func (h *IOServerHarness) GetManagementClient() (drpc.DomainSocketClient, error) {
-	li, err := h.GetMSLeaderInstance()
-	if err != nil {
-		return nil, err
-	}
-
-	return li.getDrpcClient()
-}
-
-// GetManagementInstance returns a managed IO Server instance
-// to be used as a management target.
-func (h *IOServerHarness) GetManagementInstance() (*IOServerInstance, error) {
+// GetMSLeaderInstance returns a managed IO Server instance to be used as a
+// management target and fails if selected instance is not MS Leader.
+func (h *IOServerHarness) GetMSLeaderInstance() (*IOServerInstance, error) {
 	h.RLock()
 	defer h.RUnlock()
 
@@ -108,31 +96,15 @@ func (h *IOServerHarness) GetManagementInstance() (*IOServerInstance, error) {
 		return nil, errors.New("harness has no managed instances")
 	}
 
-	if defaultManagementInstance > len(h.instances) {
-		return nil, errors.Errorf("no instance index %d", defaultManagementInstance)
+	var err error
+	for _, mi := range h.Instances() {
+		// try each instance, returning the first one that is a replica (if any are)
+		if err = checkIsMSReplica(mi); err == nil {
+			return mi, nil
+		}
 	}
 
-	// Just pick one for now.
-	return h.instances[defaultManagementInstance], nil
-}
-
-// GetMSLeaderInstance returns a managed IO Server instance to be used as a
-// management target and fails if selected instance is not MS Leader.
-func (h *IOServerHarness) GetMSLeaderInstance() (*IOServerInstance, error) {
-	h.RLock()
-	defer h.RUnlock()
-
-	mi, err := h.GetManagementInstance()
-	if err != nil {
-		return nil, err
-	}
-	// currently, as there is only one access point, the only replica will
-	// also be the leader.
-	if err := checkIsMSReplica(mi); err != nil {
-		return nil, err
-	}
-
-	return mi, nil
+	return nil, err
 }
 
 // CreateSuperblocks creates instance superblocks as needed.

--- a/src/control/server/harness.go
+++ b/src/control/server/harness.go
@@ -31,6 +31,7 @@ import (
 
 	"github.com/pkg/errors"
 
+	"github.com/daos-stack/daos/src/control/drpc"
 	"github.com/daos-stack/daos/src/control/logging"
 	"github.com/daos-stack/daos/src/control/server/ioserver"
 )
@@ -84,6 +85,17 @@ func (h *IOServerHarness) AddInstance(srv *IOServerInstance) error {
 
 	h.instances = append(h.instances, srv)
 	return nil
+}
+
+// GetManagementClient returns a dRPC client for the IO Server instance to
+// be used as a management target.
+func (h *IOServerHarness) GetManagementClient() (drpc.DomainSocketClient, error) {
+	li, err := h.GetMSLeaderInstance()
+	if err != nil {
+		return nil, err
+	}
+
+	return li.getDrpcClient()
 }
 
 // GetManagementInstance returns a managed IO Server instance

--- a/src/control/server/instance.go
+++ b/src/control/server/instance.go
@@ -322,12 +322,7 @@ func (srv *IOServerInstance) SetRank(ctx context.Context, ready *srvpb.NotifyRea
 }
 
 func (srv *IOServerInstance) callSetRank(rank ioserver.Rank) error {
-	dc, err := srv.getDrpcClient()
-	if err != nil {
-		return err
-	}
-
-	dresp, err := makeDrpcCall(dc, mgmtModuleID, setRank, &mgmtpb.SetRankReq{Rank: uint32(rank)})
+	dresp, err := srv.CallDrpc(mgmtModuleID, setRank, &mgmtpb.SetRankReq{Rank: uint32(rank)})
 	if err != nil {
 		return err
 	}
@@ -402,12 +397,7 @@ func (srv *IOServerInstance) callCreateMS(superblock *Superblock) error {
 		req.Addr = msAddr
 	}
 
-	dc, err := srv.getDrpcClient()
-	if err != nil {
-		return err
-	}
-
-	dresp, err := makeDrpcCall(dc, mgmtModuleID, createMS, req)
+	dresp, err := srv.CallDrpc(mgmtModuleID, createMS, req)
 	if err != nil {
 		return err
 	}
@@ -424,12 +414,7 @@ func (srv *IOServerInstance) callCreateMS(superblock *Superblock) error {
 }
 
 func (srv *IOServerInstance) callStartMS() error {
-	dc, err := srv.getDrpcClient()
-	if err != nil {
-		return err
-	}
-
-	dresp, err := makeDrpcCall(dc, mgmtModuleID, startMS, nil)
+	dresp, err := srv.CallDrpc(mgmtModuleID, startMS, nil)
 	if err != nil {
 		return err
 	}
@@ -446,12 +431,7 @@ func (srv *IOServerInstance) callStartMS() error {
 }
 
 func (srv *IOServerInstance) callSetUp() error {
-	dc, err := srv.getDrpcClient()
-	if err != nil {
-		return err
-	}
-
-	dresp, err := makeDrpcCall(dc, mgmtModuleID, setUp, nil)
+	dresp, err := srv.CallDrpc(mgmtModuleID, setUp, nil)
 	if err != nil {
 		return err
 	}
@@ -467,6 +447,17 @@ func (srv *IOServerInstance) callSetUp() error {
 	return nil
 }
 
+// IsMSReplica indicates whether or not this instance is a management service replica.
 func (srv *IOServerInstance) IsMSReplica() bool {
 	return srv.hasSuperblock() && srv.getSuperblock().MS
+}
+
+// CallDrpc makes the supplied dRPC call via this instance's dRPC client.
+func (srv *IOServerInstance) CallDrpc(module, method int32, body proto.Message) (*drpc.Response, error) {
+	dc, err := srv.getDrpcClient()
+	if err != nil {
+		return nil, err
+	}
+
+	return makeDrpcCall(dc, module, method, body)
 }

--- a/src/control/server/instance.go
+++ b/src/control/server/instance.go
@@ -53,7 +53,6 @@ type IOServerInstance struct {
 	log           logging.Logger
 	runner        *ioserver.Runner
 	bdevProvider  *storage.BdevProvider
-	drpcClient    drpc.DomainSocketClient
 	msClient      *mgmtSvcClient
 	instanceReady chan *srvpb.NotifyReadyReq
 	storageReady  chan struct{}
@@ -62,6 +61,7 @@ type IOServerInstance struct {
 	sync.RWMutex
 	// these must be protected by a mutex in order to
 	// avoid racy access.
+	_drpcClient   drpc.DomainSocketClient
 	_scmStorageOk bool // cache positive result of NeedsStorageFormat()
 	_superblock   *Superblock
 }
@@ -105,6 +105,21 @@ func (srv *IOServerInstance) bdevConfig() (storage.BdevConfig, error) {
 		return nullCfg, errors.New("no ioserver config set on runner")
 	}
 	return srv.runner.Config.Storage.Bdev, nil
+}
+
+func (srv *IOServerInstance) setDrpcClient(c drpc.DomainSocketClient) {
+	srv.Lock()
+	defer srv.Unlock()
+	srv._drpcClient = c
+}
+
+func (srv *IOServerInstance) getDrpcClient() (drpc.DomainSocketClient, error) {
+	srv.RLock()
+	defer srv.RUnlock()
+	if srv._drpcClient == nil {
+		return nil, errors.New("no dRPC client set (data plane not started?)")
+	}
+	return srv._drpcClient, nil
 }
 
 // MountScmDevice mounts the configured SCM device (DCPM or ramdisk emulation)
@@ -228,7 +243,7 @@ func (srv *IOServerInstance) NotifyReady(msg *srvpb.NotifyReadyReq) {
 	srv.log.Debugf("I/O server instance %d ready: %v", srv.Index, msg)
 
 	// Activate the dRPC client connection to this iosrv
-	srv.drpcClient = drpc.NewClientConnection(msg.DrpcListenerSock)
+	srv.setDrpcClient(drpc.NewClientConnection(msg.DrpcListenerSock))
 
 	go func() {
 		srv.instanceReady <- msg
@@ -307,7 +322,12 @@ func (srv *IOServerInstance) SetRank(ctx context.Context, ready *srvpb.NotifyRea
 }
 
 func (srv *IOServerInstance) callSetRank(rank ioserver.Rank) error {
-	dresp, err := makeDrpcCall(srv.drpcClient, mgmtModuleID, setRank, &mgmtpb.SetRankReq{Rank: uint32(rank)})
+	dc, err := srv.getDrpcClient()
+	if err != nil {
+		return err
+	}
+
+	dresp, err := makeDrpcCall(dc, mgmtModuleID, setRank, &mgmtpb.SetRankReq{Rank: uint32(rank)})
 	if err != nil {
 		return err
 	}
@@ -382,7 +402,12 @@ func (srv *IOServerInstance) callCreateMS(superblock *Superblock) error {
 		req.Addr = msAddr
 	}
 
-	dresp, err := makeDrpcCall(srv.drpcClient, mgmtModuleID, createMS, req)
+	dc, err := srv.getDrpcClient()
+	if err != nil {
+		return err
+	}
+
+	dresp, err := makeDrpcCall(dc, mgmtModuleID, createMS, req)
 	if err != nil {
 		return err
 	}
@@ -399,7 +424,12 @@ func (srv *IOServerInstance) callCreateMS(superblock *Superblock) error {
 }
 
 func (srv *IOServerInstance) callStartMS() error {
-	dresp, err := makeDrpcCall(srv.drpcClient, mgmtModuleID, startMS, nil)
+	dc, err := srv.getDrpcClient()
+	if err != nil {
+		return err
+	}
+
+	dresp, err := makeDrpcCall(dc, mgmtModuleID, startMS, nil)
 	if err != nil {
 		return err
 	}
@@ -416,7 +446,12 @@ func (srv *IOServerInstance) callStartMS() error {
 }
 
 func (srv *IOServerInstance) callSetUp() error {
-	dresp, err := makeDrpcCall(srv.drpcClient, mgmtModuleID, setUp, nil)
+	dc, err := srv.getDrpcClient()
+	if err != nil {
+		return err
+	}
+
+	dresp, err := makeDrpcCall(dc, mgmtModuleID, setUp, nil)
 	if err != nil {
 		return err
 	}

--- a/src/control/server/instance_test.go
+++ b/src/control/server/instance_test.go
@@ -65,7 +65,8 @@ func TestIOServerInstance_NotifyReady(t *testing.T) {
 
 	instance.NotifyReady(req)
 
-	if instance.drpcClient == nil {
+	dc, err := instance.getDrpcClient()
+	if err != nil || dc == nil {
 		t.Fatal("Expected a dRPC client connection")
 	}
 

--- a/src/control/server/ioserver/rank.go
+++ b/src/control/server/ioserver/rank.go
@@ -61,6 +61,15 @@ func (r *Rank) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	return nil
 }
 
+// Equals compares this rank to the given rank. If either value is
+// nil, the comparison is always false.
+func (r *Rank) Equals(other *Rank) bool {
+	if r == nil || other == nil {
+		return false
+	}
+	return *r == *other
+}
+
 func checkRank(r Rank) error {
 	if r == NilRank {
 		return errors.Errorf("rank %d out of range [0, %d]", r, MaxRank)

--- a/src/control/server/ioserver/rank_test.go
+++ b/src/control/server/ioserver/rank_test.go
@@ -81,3 +81,40 @@ func TestRankYaml(t *testing.T) {
 		})
 	}
 }
+
+func TestRankEquals(t *testing.T) {
+	for name, tc := range map[string]struct {
+		a      *Rank
+		b      *Rank
+		equals bool
+	}{
+		"both nil": {
+			equals: false,
+		},
+		"a is nil": {
+			b:      NewRankPtr(1),
+			equals: false,
+		},
+		"b is nil": {
+			a:      NewRankPtr(1),
+			equals: false,
+		},
+		"a == b": {
+			a:      NewRankPtr(1),
+			b:      NewRankPtr(1),
+			equals: true,
+		},
+		"a != b": {
+			a:      NewRankPtr(1),
+			b:      NewRankPtr(2),
+			equals: false,
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			got := tc.a.Equals(tc.b)
+			if got != tc.equals {
+				t.Fatalf("expected %v.Equals(%v) to be %t, but was %t", tc.a, tc.b, tc.equals, got)
+			}
+		})
+	}
+}

--- a/src/control/server/mgmt_svc.go
+++ b/src/control/server/mgmt_svc.go
@@ -161,12 +161,12 @@ func newMgmtSvc(h *IOServerHarness) *mgmtSvc {
 }
 
 func (svc *mgmtSvc) GetAttachInfo(ctx context.Context, req *mgmtpb.GetAttachInfoReq) (*mgmtpb.GetAttachInfoResp, error) {
-	dc, err := svc.harness.GetManagementClient()
+	mi, err := svc.harness.GetMSLeaderInstance()
 	if err != nil {
 		return nil, err
 	}
 
-	dresp, err := makeDrpcCall(dc, mgmtModuleID, getAttachInfo, req)
+	dresp, err := mi.CallDrpc(mgmtModuleID, getAttachInfo, req)
 	if err != nil {
 		return nil, err
 	}
@@ -211,12 +211,12 @@ func (svc *mgmtSvc) Join(ctx context.Context, req *mgmtpb.JoinReq) (*mgmtpb.Join
 			"combining peer addr with listener port")
 	}
 
-	dc, err := svc.harness.GetManagementClient()
+	mi, err := svc.harness.GetMSLeaderInstance()
 	if err != nil {
 		return nil, err
 	}
 
-	dresp, err := makeDrpcCall(dc, mgmtModuleID, join, req)
+	dresp, err := mi.CallDrpc(mgmtModuleID, join, req)
 	if err != nil {
 		return nil, err
 	}
@@ -267,12 +267,12 @@ func checkIsMSReplica(mi *IOServerInstance) error {
 func (svc *mgmtSvc) PoolCreate(ctx context.Context, req *mgmtpb.PoolCreateReq) (*mgmtpb.PoolCreateResp, error) {
 	svc.log.Debugf("MgmtSvc.PoolCreate dispatch, req:%+v\n", *req)
 
-	dc, err := svc.harness.GetManagementClient()
+	mi, err := svc.harness.GetMSLeaderInstance()
 	if err != nil {
 		return nil, err
 	}
 
-	dresp, err := makeDrpcCall(dc, mgmtModuleID, poolCreate, req)
+	dresp, err := mi.CallDrpc(mgmtModuleID, poolCreate, req)
 	if err != nil {
 		return nil, err
 	}
@@ -291,12 +291,12 @@ func (svc *mgmtSvc) PoolCreate(ctx context.Context, req *mgmtpb.PoolCreateReq) (
 func (svc *mgmtSvc) PoolDestroy(ctx context.Context, req *mgmtpb.PoolDestroyReq) (*mgmtpb.PoolDestroyResp, error) {
 	svc.log.Debugf("MgmtSvc.PoolDestroy dispatch, req:%+v\n", *req)
 
-	dc, err := svc.harness.GetManagementClient()
+	mi, err := svc.harness.GetMSLeaderInstance()
 	if err != nil {
 		return nil, err
 	}
 
-	dresp, err := makeDrpcCall(dc, mgmtModuleID, poolDestroy, req)
+	dresp, err := mi.CallDrpc(mgmtModuleID, poolDestroy, req)
 	if err != nil {
 		return nil, err
 	}
@@ -315,12 +315,12 @@ func (svc *mgmtSvc) PoolDestroy(ctx context.Context, req *mgmtpb.PoolDestroyReq)
 func (svc *mgmtSvc) BioHealthQuery(ctx context.Context, req *mgmtpb.BioHealthReq) (*mgmtpb.BioHealthResp, error) {
 	svc.log.Debugf("MgmtSvc.BioHealthQuery dispatch, req:%+v\n", *req)
 
-	dc, err := svc.harness.GetManagementClient()
+	mi, err := svc.harness.GetMSLeaderInstance()
 	if err != nil {
 		return nil, err
 	}
 
-	dresp, err := makeDrpcCall(dc, mgmtModuleID, bioHealth, req)
+	dresp, err := mi.CallDrpc(mgmtModuleID, bioHealth, req)
 	if err != nil {
 		return nil, err
 	}
@@ -337,12 +337,12 @@ func (svc *mgmtSvc) BioHealthQuery(ctx context.Context, req *mgmtpb.BioHealthReq
 func (svc *mgmtSvc) SmdListDevs(ctx context.Context, req *mgmtpb.SmdDevReq) (*mgmtpb.SmdDevResp, error) {
 	svc.log.Debugf("MgmtSvc.SmdListDevs dispatch, req:%+v\n", *req)
 
-	dc, err := svc.harness.GetManagementClient()
+	mi, err := svc.harness.GetMSLeaderInstance()
 	if err != nil {
 		return nil, err
 	}
 
-	dresp, err := makeDrpcCall(dc, mgmtModuleID, smdDevs, req)
+	dresp, err := mi.CallDrpc(mgmtModuleID, smdDevs, req)
 	if err != nil {
 		return nil, err
 	}
@@ -357,12 +357,12 @@ func (svc *mgmtSvc) SmdListDevs(ctx context.Context, req *mgmtpb.SmdDevReq) (*mg
 
 // SmdListPools implements the method defined for the Management Service.
 func (svc *mgmtSvc) SmdListPools(ctx context.Context, req *mgmtpb.SmdPoolReq) (*mgmtpb.SmdPoolResp, error) {
-	dc, err := svc.harness.GetManagementClient()
+	mi, err := svc.harness.GetMSLeaderInstance()
 	if err != nil {
 		return nil, err
 	}
 
-	dresp, err := makeDrpcCall(dc, mgmtModuleID, smdPools, req)
+	dresp, err := mi.CallDrpc(mgmtModuleID, smdPools, req)
 	if err != nil {
 		return nil, err
 	}

--- a/src/control/server/mgmt_system.go
+++ b/src/control/server/mgmt_system.go
@@ -92,12 +92,7 @@ func (svc *mgmtSvc) KillRank(ctx context.Context, req *mgmtpb.DaosRank) (*mgmtpb
 		return nil, errors.Errorf("rank %d not found on this server", req.Rank)
 	}
 
-	dc, err := mi.getDrpcClient()
-	if err != nil {
-		return nil, err
-	}
-
-	dresp, err := makeDrpcCall(dc, mgmtModuleID, killRank, req)
+	dresp, err := mi.CallDrpc(mgmtModuleID, killRank, req)
 	if err != nil {
 		return nil, err
 	}

--- a/src/control/server/server.go
+++ b/src/control/server/server.go
@@ -147,7 +147,9 @@ func Start(log *logging.LeveledLogger, cfg *Configuration) error {
 			select {
 			case sig := <-sigChan:
 				log.Debugf("Caught signal: %s", sig)
-				drpcCleanup(cfg.SocketDir)
+				if err := drpcCleanup(cfg.SocketDir); err != nil {
+					log.Errorf("error during dRPC cleanup: %s", err)
+				}
 				shutdown()
 			}
 		}


### PR DESCRIPTION
In some scenarios, it is possible for the control plane to
receive management service requests (e.g. pool create) before
the data plane has signaled that it has started. We should
check for this condition and return an error if the client has
not been set yet.