### PR TITLE
DAOS-3224 Script fix for pool create failure in bad_evict with null g…

### DIFF
--- a/src/tests/ftest/pool/bad_evict.py
+++ b/src/tests/ftest/pool/bad_evict.py
@@ -140,7 +140,8 @@ class BadEvictTest(Test):
             # trash the pool group value
             if evictset is None:
                 savedgroup = pool.group
-                pool.group = None
+                #DAOS-3224 default group will be set for an empty pool.group
+                pool.group = 'None'
 
             # trash the UUID value in various ways
             if excludeuuid is None:


### PR DESCRIPTION
…roup-name

Updated file: src/tests/ftest/pool/bad_evict.py

Signed-off-by: Ding Ho <ding-hwa.ho@intel.com>