### PR TITLE
DAOS-2429 dtx: DTX performance optimization - keep committed DTX in DRAM - based on old punch model

### DIFF
--- a/src/container/srv_target.c
+++ b/src/container/srv_target.c
@@ -86,7 +86,6 @@ cont_child_alloc_ref(void *key, unsigned int ksize, void *varg,
 		goto out_cond;
 
 	uuid_copy(cont->sc_uuid, key);
-	cont->sc_dtx_resync_time = crt_hlc_get();
 	/* prevent aggregation till snapshot iv refreshed */
 	cont->sc_aggregation_max = 0;
 	cont->sc_snapshots_nr = 0;

--- a/src/dtx/dtx_internal.h
+++ b/src/dtx/dtx_internal.h
@@ -71,7 +71,7 @@ CRT_RPC_DECLARE(dtx, DAOS_ISEQ_DTX, DAOS_OSEQ_DTX);
 /* The count threshould for triggerring DTX aggregation.
  * This threshould should consider the real SCM size.
  */
-#define DTX_AGG_THRESHOLD_CNT		(1 << 27)
+#define DTX_AGG_THRESHOLD_CNT		(1 << 28)
 
 /* The time threshould for triggerring DTX aggregation. If the oldest
  * DTX in the DTX table exceeds such threshould, it will trigger DTX
@@ -84,7 +84,7 @@ CRT_RPC_DECLARE(dtx, DAOS_ISEQ_DTX, DAOS_OSEQ_DTX);
  */
 #define DTX_AGG_THRESHOLD_AGE_LOWER	3600
 
-#define DTX_AGG_YIELD_INTERVAL		DTX_THRESHOLD_COUNT
+#define DTX_YIELD_CYCLE			(DTX_THRESHOLD_COUNT >> 3)
 
 extern struct crt_proto_format dtx_proto_fmt;
 extern btr_ops_t dbtree_dtx_cf_ops;

--- a/src/dtx/dtx_rpc.c
+++ b/src/dtx/dtx_rpc.c
@@ -655,7 +655,7 @@ dtx_abort(uuid_t po_uuid, uuid_t co_uuid, daos_epoch_t epoch,
 	D_ASSERT(dti != NULL);
 
 	/* Local abort firstly. */
-	rc = vos_dtx_abort(cont->sc_hdl, epoch, dti, count, false);
+	rc = vos_dtx_abort(cont->sc_hdl, epoch, dti, count);
 
 	if (rc == -DER_NONEXIST)
 		rc = 0;

--- a/src/dtx/dtx_srv.c
+++ b/src/dtx/dtx_srv.c
@@ -39,7 +39,11 @@ dtx_handler(crt_rpc_t *rpc)
 	struct dtx_in		*din = crt_req_get(rpc);
 	struct dtx_out		*dout = crt_reply_get(rpc);
 	struct ds_cont_child	*cont = NULL;
+	struct dtx_id		*dtis;
 	uint32_t		 opc = opc_get(rpc->cr_opc);
+	int			 count = DTX_YIELD_CYCLE;
+	int			 i = 0;
+	int			 rc1;
 	int			 rc;
 
 	rc = ds_cont_child_lookup(din->di_po_uuid, din->di_co_uuid, &cont);
@@ -52,13 +56,31 @@ dtx_handler(crt_rpc_t *rpc)
 
 	switch (opc) {
 	case DTX_COMMIT:
-		rc = vos_dtx_commit(cont->sc_hdl, din->di_dtx_array.ca_arrays,
-				    din->di_dtx_array.ca_count);
+		while (i < din->di_dtx_array.ca_count) {
+			if (i + count > din->di_dtx_array.ca_count)
+				count = din->di_dtx_array.ca_count - i;
+
+			dtis = (struct dtx_id *)din->di_dtx_array.ca_arrays + i;
+			rc1 = vos_dtx_commit(cont->sc_hdl, dtis, count);
+			if (rc == 0 && rc1 != 0)
+				rc = rc1;
+
+			i += count;
+		}
 		break;
 	case DTX_ABORT:
-		rc = vos_dtx_abort(cont->sc_hdl, din->di_epoch,
-				   din->di_dtx_array.ca_arrays,
-				   din->di_dtx_array.ca_count, true);
+		while (i < din->di_dtx_array.ca_count) {
+			if (i + count > din->di_dtx_array.ca_count)
+				count = din->di_dtx_array.ca_count - i;
+
+			dtis = (struct dtx_id *)din->di_dtx_array.ca_arrays + i;
+			rc1 = vos_dtx_abort(cont->sc_hdl, din->di_epoch,
+					    dtis, count);
+			if (rc == 0 && rc1 != 0)
+				rc = rc1;
+
+			i += count;
+		}
 		break;
 	case DTX_CHECK:
 		/* Currently, only support to check single DTX state. */

--- a/src/include/daos_srv/container.h
+++ b/src/include/daos_srv/container.h
@@ -59,8 +59,6 @@ struct ds_cont_child {
 	ABT_mutex		 sc_mutex;
 	ABT_cond		 sc_dtx_resync_cond;
 	void			*sc_dtx_flush_cbdata;
-	/* The time for the latest DTX resync operation. */
-	uint64_t		 sc_dtx_resync_time;
 	uint32_t		 sc_dtx_resyncing:1,
 				 sc_dtx_aggregating:1,
 				 sc_vos_aggregating:1,

--- a/src/include/daos_srv/dtx_srv.h
+++ b/src/include/daos_srv/dtx_srv.h
@@ -60,6 +60,8 @@ struct dtx_handle {
 	daos_handle_t			 dth_coh;
 	/** The epoch# for the DTX. */
 	daos_epoch_t			 dth_epoch;
+	/* The generation when the DTX is handled on the server. */
+	uint64_t			 dth_gen;
 	/** The {obj/dkey/akey}-tree records that are created
 	 * by other DTXs, but not ready for commit yet.
 	 */
@@ -72,7 +74,8 @@ struct dtx_handle {
 	uint32_t			 dth_intent;
 	uint32_t			 dth_sync:1, /* commit synchronously. */
 					 dth_leader:1, /* leader replica. */
-					 dth_non_rep:1, /* non-replicated. */
+					 /* Only one participator in the DTX. */
+					 dth_single_participator:1,
 					 /* dti_cos has been committed. */
 					 dth_dti_cos_done:1;
 	/* The count the DTXs in the dth_dti_cos array. */
@@ -98,8 +101,6 @@ struct dtx_sub_status {
 struct dtx_leader_handle {
 	/* The dtx handle on the leader node */
 	struct dtx_handle		dlh_handle;
-	/* The time when the DTX is handled on the server. */
-	uint64_t			dlh_handled_time;
 	/* result for the distribute transaction */
 	int				dlh_result;
 

--- a/src/include/daos_srv/vos.h
+++ b/src/include/daos_srv/vos.h
@@ -38,6 +38,17 @@
 #include <daos_srv/vos_types.h>
 
 /**
+ * Refresh the DTX resync generation.
+ *
+ * \param coh	[IN]	Container open handle.
+ *
+ * \return		Zero on success.
+ * \return		Negative value if error.
+ */
+int
+vos_dtx_update_resync_gen(daos_handle_t coh);
+
+/**
  * Add the given DTX to the Commit-on-Share (CoS) cache (in DRAM).
  *
  * \param coh		[IN]	Container open handle.
@@ -45,6 +56,7 @@
  * \param dti		[IN]	The DTX identifier.
  * \param dkey_hash	[IN]	The hashed dkey.
  * \param epoch		[IN]	The DTX epoch.
+ * \param gen		[IN]	The DTX generation.
  * \param punch		[IN]	For punch DTX or not.
  * \param check		[IN]	Check whether the DTX need restart because
  *				of sync epoch or not.
@@ -55,7 +67,8 @@
  */
 int
 vos_dtx_add_cos(daos_handle_t coh, daos_unit_oid_t *oid, struct dtx_id *dti,
-		uint64_t dkey_hash, daos_epoch_t epoch, bool punch, bool check);
+		uint64_t dkey_hash, daos_epoch_t epoch, uint64_t gen,
+		bool punch, bool check);
 
 /**
  * Search the specified DTX is in the CoS cache or not.
@@ -174,14 +187,12 @@ vos_dtx_commit(daos_handle_t coh, struct dtx_id *dtis, int count);
  * \param epoch	[IN]	The max epoch for the DTX to be aborted.
  * \param dtis	[IN]	The array for DTX identifiers to be aborted.
  * \param count [IN]	The count of DTXs to be aborted.
- * \param force [IN]	Force abort even if some replica(s) have not
- *			'prepared' related DTXs.
  *
  * \return		Zero on success, negative value if error.
  */
 int
 vos_dtx_abort(daos_handle_t coh, daos_epoch_t epoch, struct dtx_id *dtis,
-	      int count, bool force);
+	      int count);
 
 /**
  * Aggregate the committed DTXs.

--- a/src/include/daos_srv/vos_types.h
+++ b/src/include/daos_srv/vos_types.h
@@ -201,8 +201,8 @@ typedef struct {
 	union {
 		/** Returned earliest update epoch for a key */
 		daos_epoch_t			ie_earliest;
-		/** Return the DTX handled time for DTX iteration. */
-		uint64_t			ie_dtx_time;
+		/** record size */
+		daos_size_t			ie_rsize;
 	};
 	union {
 		/** Returned entry for container UUID iterator */
@@ -220,8 +220,6 @@ typedef struct {
 			uint32_t		ie_dtx_intent;
 		};
 		struct {
-			/** record size */
-			daos_size_t		ie_rsize;
 			/** record extent */
 			daos_recx_t		ie_recx;
 			/* original in-tree extent */

--- a/src/object/srv_obj.c
+++ b/src/object/srv_obj.c
@@ -1044,7 +1044,7 @@ ds_obj_tgt_update_handler(crt_rpc_t *rpc)
 			 * that it can be aborted.
 			 */
 			rc = vos_dtx_abort(cont->sc_hdl, DAOS_EPOCH_MAX,
-					   &orw->orw_dti, 1, true);
+					   &orw->orw_dti, 1);
 
 		if (rc != 0 && rc != -DER_NONEXIST)
 			D_GOTO(out, rc);
@@ -1156,7 +1156,11 @@ ds_obj_rw_handler(crt_rpc_t *rpc)
 		orw->orw_map_ver, map_ver, DP_DTI(&orw->orw_dti));
 	/* FIXME: until distributed transaction. */
 	if (orw->orw_epoch == DAOS_EPOCH_MAX) {
-		orw->orw_epoch = crt_hlc_get();
+		if (daos_is_zero_dti(&orw->orw_dti) ||
+		    orw->orw_flags & ORF_RESEND)
+			orw->orw_epoch = crt_hlc_get();
+		else
+			orw->orw_epoch = orw->orw_dti.dti_hlc;
 		D_DEBUG(DB_IO, "overwrite epoch "DF_U64"\n", orw->orw_epoch);
 	}
 
@@ -1657,7 +1661,7 @@ ds_obj_tgt_punch_handler(crt_rpc_t *rpc)
 			 * that it can be aborted.
 			 */
 			rc = vos_dtx_abort(cont->sc_hdl, DAOS_EPOCH_MAX,
-					   &opi->opi_dti, 1, true);
+					   &opi->opi_dti, 1);
 
 		if (rc != 0 && rc != -DER_NONEXIST)
 			D_GOTO(out, rc);
@@ -1745,7 +1749,11 @@ ds_obj_punch_handler(crt_rpc_t *rpc)
 
 	/* FIXME: until distributed transaction. */
 	if (opi->opi_epoch == DAOS_EPOCH_MAX) {
-		opi->opi_epoch = crt_hlc_get();
+		if (daos_is_zero_dti(&opi->opi_dti) ||
+		    opi->opi_flags & ORF_RESEND)
+			opi->opi_epoch = crt_hlc_get();
+		else
+			opi->opi_epoch = opi->opi_dti.dti_hlc;
 		D_DEBUG(DB_IO, "overwrite epoch "DF_U64"\n", opi->opi_epoch);
 	}
 

--- a/src/vos/tests/vos_tests.c
+++ b/src/vos/tests/vos_tests.c
@@ -164,7 +164,7 @@ main(int argc, char **argv)
 	index = 0;
 	optind = 0;
 
-	while ((opt = getopt_long(argc, argv, "apcdnti:A:hf:e:",
+	while ((opt = getopt_long(argc, argv, "apcdntXi:A:hf:e:",
 				  long_options, &index)) != -1) {
 		switch (opt) {
 		case 'p':

--- a/src/vos/vos_container.c
+++ b/src/vos/vos_container.c
@@ -100,6 +100,7 @@ cont_df_rec_alloc(struct btr_instance *tins, d_iov_t *key_iov,
 
 	cont_df = umem_off2ptr(&tins->ti_umm, offset);
 	uuid_copy(cont_df->cd_id, ukey->uuid);
+	cont_df->cd_dtx_resync_gen = 1;
 
 	rc = dbtree_create_inplace_ex(VOS_BTR_OBJ_TABLE, 0, VOS_OBJ_ORDER,
 				      &pool->vp_uma, &cont_df->cd_obj_root,
@@ -110,11 +111,15 @@ cont_df_rec_alloc(struct btr_instance *tins, d_iov_t *key_iov,
 	}
 	dbtree_close(hdl);
 
-	rc = vos_dtx_table_create(pool, &cont_df->cd_dtx_table_df);
+	rc = dbtree_create_inplace_ex(VOS_BTR_DTX_ACTIVE_TABLE, 0,
+				      DTX_BTREE_ORDER, &pool->vp_uma,
+				      &cont_df->cd_dtx_root,
+				      DAOS_HDL_INVAL, pool, &hdl);
 	if (rc) {
-		D_ERROR("Failed to create DTX table: rc = %d\n", rc);
+		D_ERROR("Failed to create active DTX table: rc = %d\n", rc);
 		D_GOTO(failed, rc);
 	}
+	dbtree_close(hdl);
 
 	args->ca_cont_df = cont_df;
 	rec->rec_off = offset;
@@ -197,9 +202,13 @@ cont_free(struct d_ulink *ulink)
 
 	if (!daos_handle_is_inval(cont->vc_dtx_cos_hdl))
 		dbtree_destroy(cont->vc_dtx_cos_hdl, NULL);
-	D_ASSERT(d_list_empty(&cont->vc_dtx_committable));
+	D_ASSERT(d_list_empty(&cont->vc_dtx_committable_list));
+
+	if (!daos_handle_is_inval(cont->vc_dtx_committed_hdl))
+		dbtree_destroy(cont->vc_dtx_committed_hdl, NULL);
+	D_ASSERT(d_list_empty(&cont->vc_dtx_committed_list));
+
 	dbtree_close(cont->vc_dtx_active_hdl);
-	dbtree_close(cont->vc_dtx_committed_hdl);
 	dbtree_close(cont->vc_btr_hdl);
 
 	for (i = 0; i < VOS_IOS_CNT; i++) {
@@ -363,9 +372,13 @@ vos_cont_open(daos_handle_t poh, uuid_t co_uuid, daos_handle_t *coh)
 	uuid_copy(cont->vc_id, co_uuid);
 	cont->vc_pool	 = pool;
 	cont->vc_cont_df = args.ca_cont_df;
+	cont->vc_dtx_committed_hdl = DAOS_HDL_INVAL;
 	cont->vc_dtx_cos_hdl = DAOS_HDL_INVAL;
-	D_INIT_LIST_HEAD(&cont->vc_dtx_committable);
+	D_INIT_LIST_HEAD(&cont->vc_dtx_committable_list);
+	D_INIT_LIST_HEAD(&cont->vc_dtx_committed_list);
 	cont->vc_dtx_committable_count = 0;
+	cont->vc_dtx_committed_count = 0;
+	cont->vc_dtx_resync_gen = cont->vc_cont_df->cd_dtx_resync_gen;
 
 	/* Cache this btr object ID in container handle */
 	rc = dbtree_open_inplace_ex(&cont->vc_cont_df->cd_obj_root,
@@ -376,17 +389,8 @@ vos_cont_open(daos_handle_t poh, uuid_t co_uuid, daos_handle_t *coh)
 		D_GOTO(exit, rc);
 	}
 
-	rc = dbtree_open_inplace(
-			&cont->vc_cont_df->cd_dtx_table_df.tt_committed_btr,
-			&pool->vp_uma, &cont->vc_dtx_committed_hdl);
-	if (rc) {
-		D_ERROR("Failed to open committed DTX table: rc = %d\n", rc);
-		D_GOTO(exit, rc);
-	}
-
-	rc = dbtree_open_inplace(
-			&cont->vc_cont_df->cd_dtx_table_df.tt_active_btr,
-			&pool->vp_uma, &cont->vc_dtx_active_hdl);
+	rc = dbtree_open_inplace(&cont->vc_cont_df->cd_dtx_root,
+				 &pool->vp_uma, &cont->vc_dtx_active_hdl);
 	if (rc) {
 		D_ERROR("Failed to open active DTX table: rc = %d\n", rc);
 		D_GOTO(exit, rc);
@@ -394,10 +398,19 @@ vos_cont_open(daos_handle_t poh, uuid_t co_uuid, daos_handle_t *coh)
 
 	memset(&uma, 0, sizeof(uma));
 	uma.uma_id = UMEM_CLASS_VMEM;
-	memset(&cont->vc_dtx_cos_btr, 0, sizeof(cont->vc_dtx_cos_btr));
-	rc = dbtree_create_inplace(VOS_BTR_DTX_COS, 0, VOS_CONT_ORDER, &uma,
-				   &cont->vc_dtx_cos_btr,
-				   &cont->vc_dtx_cos_hdl);
+	rc = dbtree_create_inplace_ex(VOS_BTR_DTX_COMMITTED_TABLE, 0,
+				      DTX_BTREE_ORDER, &uma,
+				      &cont->vc_dtx_committed_btr,
+				      DAOS_HDL_INVAL, cont,
+				      &cont->vc_dtx_committed_hdl);
+	if (rc != 0) {
+		D_ERROR("Failed to create DTX committed btree: rc = %d\n", rc);
+		D_GOTO(exit, rc);
+	}
+
+	rc = dbtree_create_inplace_ex(VOS_BTR_DTX_COS, 0, DTX_BTREE_ORDER, &uma,
+				      &cont->vc_dtx_cos_btr, DAOS_HDL_INVAL,
+				      cont, &cont->vc_dtx_cos_hdl);
 	if (rc != 0) {
 		D_ERROR("Failed to create DTX CoS btree: rc = %d\n", rc);
 		D_GOTO(exit, rc);
@@ -521,6 +534,7 @@ int
 vos_cont_destroy(daos_handle_t poh, uuid_t co_uuid)
 {
 
+	daos_handle_t		 hdl;
 	struct vos_pool		*pool;
 	struct vos_container	*cont;
 	struct cont_df_args	 args;
@@ -571,6 +585,18 @@ vos_cont_destroy(daos_handle_t poh, uuid_t co_uuid)
 		D_GOTO(exit, rc);
 	}
 
+	rc = dbtree_open_inplace(&args.ca_cont_df->cd_dtx_root,
+				 &pool->vp_uma, &hdl);
+	if (rc == 0)
+		rc = dbtree_destroy(hdl, NULL);
+
+	if (rc != 0 && rc != -DER_NONEXIST) {
+		D_ERROR("Failed to destroy active DTX table: rc = %d\n", rc);
+		rc = vos_tx_end(pool, rc);
+
+		D_GOTO(exit, rc);
+	}
+
 	d_iov_set(&iov, &key, sizeof(struct d_uuid));
 	rc = dbtree_delete(pool->vp_cont_th, BTR_PROBE_EQ, &iov, NULL);
 
@@ -613,6 +639,31 @@ vos_cont_tab_register()
 	rc = dbtree_class_register(VOS_BTR_CONT_TABLE, 0, &vct_ops);
 	if (rc)
 		D_ERROR("dbtree create failed\n");
+	return rc;
+}
+
+int
+vos_dtx_update_resync_gen(daos_handle_t coh)
+{
+	struct vos_container	*cont;
+	struct vos_cont_df	*cont_df;
+	int			 rc;
+
+	cont = vos_hdl2cont(coh);
+	D_ASSERT(cont != NULL);
+
+	cont_df = cont->vc_cont_df;
+	rc = vos_tx_begin(cont->vc_pool);
+	if (rc == 0) {
+		umem_tx_add_ptr(&cont->vc_pool->vp_umm,
+				&cont_df->cd_dtx_resync_gen,
+				sizeof(cont_df->cd_dtx_resync_gen));
+		cont_df->cd_dtx_resync_gen++;
+		rc = vos_tx_end(cont->vc_pool, rc);
+		if (rc == 0)
+			cont->vc_dtx_resync_gen = cont_df->cd_dtx_resync_gen;
+	}
+
 	return rc;
 }
 

--- a/src/vos/vos_dtx_cos.c
+++ b/src/vos/vos_dtx_cos.c
@@ -47,8 +47,6 @@ struct dtx_cos_rec {
 	int			 dcr_update_count;
 	/* The number of the PUNCH DTXs in the dcr_punch_list. */
 	int			 dcr_punch_count;
-	/* Pointer to the container. */
-	struct vos_container	*dcr_cont;
 };
 
 /* Above dtx_cos_rec is consisted of a series of dtx_cos_rec_child uints.
@@ -56,7 +54,7 @@ struct dtx_cos_rec {
  * related object and dkey (that attached to the dtx_cos_rec).
  */
 struct dtx_cos_rec_child {
-	/* Link into the container::vc_dtx_committable. */
+	/* Link into the container::vc_dtx_committable_list. */
 	d_list_t		 dcrc_committable;
 	/* Link into related dcr_{update,punch}_list. */
 	d_list_t		 dcrc_link;
@@ -64,14 +62,11 @@ struct dtx_cos_rec_child {
 	struct dtx_id		 dcrc_dti;
 	/* The DTX epoch. */
 	daos_epoch_t		 dcrc_epoch;
-	/* Timestamp of handling the DTX on server. */
-	uint64_t		 dcrc_time;
 	/* Pointer to the dtx_cos_rec. */
 	struct dtx_cos_rec	*dcrc_ptr;
 };
 
 struct dtx_cos_rec_bundle {
-	struct vos_container	*cont;
 	struct dtx_id		*dti;
 	daos_epoch_t		 epoch;
 	bool			 punch;
@@ -112,6 +107,7 @@ static int
 dtx_cos_rec_alloc(struct btr_instance *tins, d_iov_t *key_iov,
 		  d_iov_t *val_iov, struct btr_record *rec)
 {
+	struct vos_container		*cont = tins->ti_priv;
 	struct dtx_cos_key		*key;
 	struct dtx_cos_rec_bundle	*rbund;
 	struct dtx_cos_rec		*dcr;
@@ -129,7 +125,6 @@ dtx_cos_rec_alloc(struct btr_instance *tins, d_iov_t *key_iov,
 	dcr->dcr_oid = key->oid;
 	D_INIT_LIST_HEAD(&dcr->dcr_update_list);
 	D_INIT_LIST_HEAD(&dcr->dcr_punch_list);
-	dcr->dcr_cont = rbund->cont;
 
 	D_ALLOC_PTR(dcrc);
 	if (dcrc == NULL) {
@@ -139,12 +134,11 @@ dtx_cos_rec_alloc(struct btr_instance *tins, d_iov_t *key_iov,
 
 	dcrc->dcrc_dti = *rbund->dti;
 	dcrc->dcrc_epoch = rbund->epoch;
-	dcrc->dcrc_time = crt_hlc_get();
 	dcrc->dcrc_ptr = dcr;
 
 	d_list_add_tail(&dcrc->dcrc_committable,
-			&rbund->cont->vc_dtx_committable);
-	rbund->cont->vc_dtx_committable_count++;
+			&cont->vc_dtx_committable_list);
+	cont->vc_dtx_committable_count++;
 
 	if (rbund->punch) {
 		d_list_add_tail(&dcrc->dcrc_link, &dcr->dcr_punch_list);
@@ -161,6 +155,7 @@ dtx_cos_rec_alloc(struct btr_instance *tins, d_iov_t *key_iov,
 static int
 dtx_cos_rec_free(struct btr_instance *tins, struct btr_record *rec, void *args)
 {
+	struct vos_container		*cont = tins->ti_priv;
 	struct dtx_cos_rec		*dcr;
 	struct dtx_cos_rec_child	*dcrc;
 	struct dtx_cos_rec_child	*next;
@@ -173,14 +168,14 @@ dtx_cos_rec_free(struct btr_instance *tins, struct btr_record *rec, void *args)
 		d_list_del(&dcrc->dcrc_link);
 		d_list_del(&dcrc->dcrc_committable);
 		D_FREE_PTR(dcrc);
-		dcr->dcr_cont->vc_dtx_committable_count--;
+		cont->vc_dtx_committable_count--;
 	}
 	d_list_for_each_entry_safe(dcrc, next, &dcr->dcr_punch_list,
 				   dcrc_link) {
 		d_list_del(&dcrc->dcrc_link);
 		d_list_del(&dcrc->dcrc_committable);
 		D_FREE_PTR(dcrc);
-		dcr->dcr_cont->vc_dtx_committable_count--;
+		cont->vc_dtx_committable_count--;
 	}
 	D_FREE_PTR(dcr);
 
@@ -205,6 +200,7 @@ static int
 dtx_cos_rec_update(struct btr_instance *tins, struct btr_record *rec,
 		   d_iov_t *key, d_iov_t *val)
 {
+	struct vos_container		*cont = tins->ti_priv;
 	struct dtx_cos_rec_bundle	*rbund;
 	struct dtx_cos_rec		*dcr;
 	struct dtx_cos_rec_child	*dcrc;
@@ -220,12 +216,11 @@ dtx_cos_rec_update(struct btr_instance *tins, struct btr_record *rec,
 
 	dcrc->dcrc_dti = *rbund->dti;
 	dcrc->dcrc_epoch = rbund->epoch;
-	dcrc->dcrc_time = crt_hlc_get();
 	dcrc->dcrc_ptr = dcr;
 
 	d_list_add_tail(&dcrc->dcrc_committable,
-			&rbund->cont->vc_dtx_committable);
-	rbund->cont->vc_dtx_committable_count++;
+			&cont->vc_dtx_committable_list);
+	cont->vc_dtx_committable_count++;
 
 	if (rbund->punch) {
 		d_list_add_tail(&dcrc->dcrc_link, &dcr->dcr_punch_list);
@@ -360,7 +355,8 @@ out:
 
 int
 vos_dtx_add_cos(daos_handle_t coh, daos_unit_oid_t *oid, struct dtx_id *dti,
-		uint64_t dkey_hash, daos_epoch_t epoch, bool punch, bool check)
+		uint64_t dkey_hash, daos_epoch_t epoch, uint64_t gen,
+		bool punch, bool check)
 {
 	struct vos_container		*cont;
 	struct dtx_cos_key		 key;
@@ -371,6 +367,41 @@ vos_dtx_add_cos(daos_handle_t coh, daos_unit_oid_t *oid, struct dtx_id *dti,
 
 	cont = vos_hdl2cont(coh);
 	D_ASSERT(cont != NULL);
+
+	/* If the DTX is started befoe DTX resync operation (for rebuild),
+	 * then it is possbile that the DTX resync ULT may have aborted
+	 * or committed the DTX during current ULT waiting for the reply.
+	 * let's check DTX status locally before marking as 'committable'.
+	 */
+	if (gen != 0 && gen < cont->vc_dtx_resync_gen) {
+		rc = vos_dtx_check(coh, dti);
+		switch (rc) {
+		case DTX_ST_PREPARED:
+			rc = vos_dtx_lookup_cos(coh, oid, dti,
+						dkey_hash, punch);
+			/* The resync ULT has already added it into the
+			 * CoS cache, current ULT needs to do nothing.
+			 */
+			if (rc == 0)
+				return -DER_ALREADY;
+
+			/* Normal case, then add it to CoS cache. */
+			if (rc == -DER_NONEXIST)
+				break;
+
+			return rc >= 0 ? -DER_INVAL : rc;
+		case DTX_ST_COMMITTED:
+			/* The DTX has been committed by resync ULT by race. */
+			return -DER_ALREADY;
+		case -DER_NONEXIST:
+			/* The DTX has been aborted by resync ULT, ask the
+			 * client to retry.
+			 */
+			return rc;
+		default:
+			return rc >= 0 ? -DER_INVAL : rc;
+		}
+	}
 
 	if (check) {
 		struct daos_lru_cache	*occ = vos_obj_cache_current();
@@ -394,7 +425,6 @@ vos_dtx_add_cos(daos_handle_t coh, daos_unit_oid_t *oid, struct dtx_id *dti,
 	key.dkey = dkey_hash;
 	d_iov_set(&kiov, &key, sizeof(key));
 
-	rbund.cont = cont;
 	rbund.dti = dti;
 	rbund.epoch = epoch;
 	rbund.punch = punch;
@@ -417,8 +447,8 @@ vos_dtx_lookup_cos(daos_handle_t coh, daos_unit_oid_t *oid,
 {
 	struct vos_container		*cont;
 	struct dtx_cos_key		 key;
-	d_iov_t			 kiov;
-	d_iov_t			 riov;
+	d_iov_t				 kiov;
+	d_iov_t				 riov;
 	struct dtx_cos_rec		*dcr;
 	struct dtx_cos_rec_child	*dcrc;
 	d_list_t			*head;
@@ -474,7 +504,7 @@ vos_dtx_fetch_committable(daos_handle_t coh, uint32_t max_cnt,
 	if (dte == NULL)
 		return -DER_NOMEM;
 
-	d_list_for_each_entry(dcrc, &cont->vc_dtx_committable,
+	d_list_for_each_entry(dcrc, &cont->vc_dtx_committable_list,
 			      dcrc_committable) {
 		if (oid != NULL &&
 		    daos_unit_oid_compare(dcrc->dcrc_ptr->dcr_oid, *oid) != 0)
@@ -559,10 +589,10 @@ vos_dtx_cos_oldest(struct vos_container *cont)
 {
 	struct dtx_cos_rec_child	*dcrc;
 
-	if (d_list_empty(&cont->vc_dtx_committable))
+	if (d_list_empty(&cont->vc_dtx_committable_list))
 		return 0;
 
-	dcrc = d_list_entry(cont->vc_dtx_committable.next,
+	dcrc = d_list_entry(cont->vc_dtx_committable_list.next,
 			    struct dtx_cos_rec_child, dcrc_committable);
-	return dcrc->dcrc_time;
+	return dcrc->dcrc_epoch;
 }

--- a/src/vos/vos_obj_index.c
+++ b/src/vos/vos_obj_index.c
@@ -301,12 +301,13 @@ int
 vos_oi_punch(struct vos_container *cont, daos_unit_oid_t oid,
 	     daos_epoch_t epoch, uint32_t flags, struct vos_obj_df *obj)
 {
-	struct oi_hkey	*hkey;
-	struct oi_key	 key;
-	d_iov_t	 key_iov;
-	d_iov_t	 val_iov;
-	int		 rc = 0;
-	bool		 replay = (flags & VOS_OF_REPLAY_PC);
+	struct dtx_handle	*dth;
+	struct oi_hkey		*hkey;
+	struct oi_key		 key;
+	d_iov_t			 key_iov;
+	d_iov_t			 val_iov;
+	int			 rc = 0;
+	bool			 replay = (flags & VOS_OF_REPLAY_PC);
 
 	D_DEBUG(DB_TRACE, "Punch obj "DF_UOID", epoch="DF_U64".\n",
 		DP_UOID(oid), epoch);
@@ -337,7 +338,8 @@ vos_oi_punch(struct vos_container *cont, daos_unit_oid_t oid,
 	if (rc != 0 || replay)
 		goto out;
 
-	if (vos_dth_get() == NULL) {
+	dth = vos_dth_get();
+	if (dth == NULL || dth->dth_single_participator) {
 		struct vos_obj_df *tmp;
 
 		D_ASSERT((obj->vo_oi_attr & VOS_OI_PUNCHED) == 0);

--- a/src/vos/vos_tree.c
+++ b/src/vos/vos_tree.c
@@ -1048,6 +1048,7 @@ int
 key_tree_punch(struct vos_object *obj, daos_handle_t toh, d_iov_t *key_iov,
 	       d_iov_t *val_iov, int flags)
 {
+	struct dtx_handle	*dth;
 	struct vos_key_bundle	*kbund;
 	struct vos_rec_bundle	*rbund;
 	struct vos_krec_df	*krec;
@@ -1096,7 +1097,8 @@ key_tree_punch(struct vos_object *obj, daos_handle_t toh, d_iov_t *key_iov,
 	if (rc != 0 || replay)
 		return rc;
 
-	if (vos_dth_get() == NULL) { /* delete the max epoch */
+	dth = vos_dth_get();
+	if (dth == NULL || dth->dth_single_participator) {
 		struct umem_instance	*umm = vos_obj2umm(obj);
 		struct vos_krec_df	*krec2;
 		struct vos_key_bundle	 kbund2;


### PR DESCRIPTION
Mainly include the following:

1. Increase the CPU yield frequency during DTX aggregation and
   batched commit to allow more normal IO schedule.

2. Use client-side HLC in the DTX ID as the modification epoch.

3. Replace HLC based race detection between DTX resync and normal
   modification handling logic with server-side generation.

4. Fine-grained contents for PMDK undo log to reduce the overhead
   caused by PMDK related logic.

5. Store the committed DTX table in DRAM rather than SCM.

6. Some DTX logic can be optimized if the DTX contains single
   participator (such as modifying single replicated object).
   For example: the DTX can be committed immediately after
   local modification done.

6.1. It is unnecessary to allocate related DTX records for the
     target (object/dkey/akey/SV/EV rec) to be modified.

6.2. It is unnecessary to insert the DTX into active DTX tree,
     instead, it can be directly inserted into the committed
     DTX table when commit.

6.3. Punch logic can be simplified as without DTX case.

6.4. CoS logic can be bypassed.

Signed-off-by: Fan Yong <fan.yong@intel.com>