### PR TITLE
DAOS-3488 iosrv: add timeout scheduler for ULT

### DIFF
--- a/src/include/daos_srv/container.h
+++ b/src/include/daos_srv/container.h
@@ -31,6 +31,7 @@
 
 #include <daos/common.h>
 #include <daos_types.h>
+#include <daos_srv/daos_server.h>
 #include <daos_srv/pool.h>
 #include <daos_srv/rsvc.h>
 #include <daos_srv/vos_types.h>
@@ -68,6 +69,9 @@ struct ds_cont_child {
 				 sc_closing:1,
 				 sc_destroying:1;
 	uint32_t		 sc_dtx_flush_wait_count;
+
+	/* Aggregate ULT */
+	struct dss_sleep_ult	 *sc_agg_ult;
 	/** Aggregation limit (set when snapshot is in progress) **/
 	uint64_t		 sc_aggregation_max;
 	uint64_t		*sc_snapshots;

--- a/src/include/daos_srv/daos_server.h
+++ b/src/include/daos_srv/daos_server.h
@@ -357,6 +357,17 @@ int dss_ult_create_execute(int (*func)(void *), void *arg,
 			   void (*user_cb)(void *), void *cb_args,
 			   int ult_type, int tgt_id, size_t stack_size);
 
+struct dss_sleep_ult {
+	ABT_thread	dsu_thread;
+	uint64_t	dsu_expire_time;
+	d_list_t	dsu_list;
+};
+
+struct dss_sleep_ult *dss_sleep_ult_create(void);
+void dss_sleep_ult_destroy(struct dss_sleep_ult *dsu);
+void dss_ult_sleep(struct dss_sleep_ult *dsu, uint64_t expire_secs);
+void dss_ult_wakeup(struct dss_sleep_ult *dsu);
+
 /* Pack return codes with additional argument to reduce */
 struct dss_stream_arg_type {
 	/** return value */

--- a/src/iosrv/srv.c
+++ b/src/iosrv/srv.c
@@ -214,14 +214,14 @@ dss_sched_unit_pop(ABT_pool *pools, ABT_pool *pool)
 	int		rc;
 
 	/* pop highest priority pool first */
-	rc = ABT_pool_get_total_size(pools[DSS_POOL_URGENT], &cnt);
+	rc = ABT_pool_get_size(pools[DSS_POOL_URGENT], &cnt);
 	if (rc != ABT_SUCCESS)
 		return ABT_UNIT_NULL;
 	if (cnt != 0 && rand() % 100 <= dss_first_res_percentage)
 		return unit_pop(pools, DSS_POOL_URGENT, pool);
 
 	/* then pop other pools */
-	rc = ABT_pool_get_total_size(pools[DSS_POOL_REBUILD], &cnt);
+	rc = ABT_pool_get_size(pools[DSS_POOL_REBUILD], &cnt);
 	if (rc != ABT_SUCCESS)
 		return ABT_UNIT_NULL;
 
@@ -231,6 +231,116 @@ dss_sched_unit_pop(ABT_pool *pools, ABT_pool *pool)
 		return unit_pop(pools, DSS_POOL_REBUILD, pool);
 
 	return ABT_UNIT_NULL;
+}
+
+static struct dss_xstream *
+dss_xstream_get(int stream_id)
+{
+	if (stream_id == DSS_XS_SELF)
+		return dss_get_module_info()->dmi_xstream;
+
+	D_ASSERTF(stream_id >= 0 && stream_id < xstream_data.xd_xs_nr,
+		  "invalid stream id %d (xstream_data.xd_xs_nr %d).\n",
+		  stream_id, xstream_data.xd_xs_nr);
+
+	return xstream_data.xd_xs_ptrs[stream_id];
+}
+
+/* Add to the sorted(by expire time) list */
+static void
+add_sleep_list(struct dss_xstream *dx, struct dss_sleep_ult *new)
+{
+	struct dss_sleep_ult	*dsu;
+
+	d_list_for_each_entry(dsu, &dx->dx_sleep_ult_list, dsu_list) {
+		if (dsu->dsu_expire_time > new->dsu_expire_time) {
+			d_list_add_tail(&new->dsu_list, &dsu->dsu_list);
+			return;
+		}
+	}
+
+	d_list_add_tail(&new->dsu_list, &dx->dx_sleep_ult_list);
+}
+
+struct dss_sleep_ult
+*dss_sleep_ult_create(void)
+{
+	struct dss_sleep_ult *dsu;
+	ABT_thread	     self;
+
+	D_ALLOC_PTR(dsu);
+	if (dsu == NULL)
+		return NULL;
+
+	ABT_thread_self(&self);
+	dsu->dsu_expire_time = 0;
+	dsu->dsu_thread = self;
+	D_INIT_LIST_HEAD(&dsu->dsu_list);
+
+	return dsu;
+}
+
+void
+dss_sleep_ult_destroy(struct dss_sleep_ult *dsu)
+{
+	D_ASSERT(d_list_empty(&dsu->dsu_list));
+	D_FREE_PTR(dsu);
+}
+
+/* Reset the expire to force the ult to exit now */
+void
+dss_ult_wakeup(struct dss_sleep_ult *dsu)
+{
+	ABT_thread thread;
+
+	ABT_thread_self(&thread);
+	/* Only others can force the ULT to exit */
+	D_ASSERT(thread != dsu->dsu_thread);
+	d_list_del_init(&dsu->dsu_list);
+	dsu->dsu_expire_time = 0;
+	ABT_thread_resume(dsu->dsu_thread);
+}
+
+/* Schedule the ULT(dtu->ult) and reschedule in @expire_secs seconds */
+void
+dss_ult_sleep(struct dss_sleep_ult *dsu, uint64_t expire_secs)
+{
+	struct dss_xstream	*dx = dss_xstream_get(DSS_XS_SELF);
+	ABT_thread		thread;
+	uint64_t		now = 0;
+
+	ABT_thread_self(&thread);
+	D_ASSERT(thread == dsu->dsu_thread);
+
+	D_ASSERT(d_list_empty(&dsu->dsu_list));
+	daos_gettime_coarse(&now);
+	dsu->dsu_expire_time = now + expire_secs;
+	D_DEBUG(DB_TRACE, "dsu %p expire in "DF_U64" secs\n", dsu, expire_secs);
+	add_sleep_list(dx, dsu);
+	ABT_self_suspend();
+}
+
+static void
+check_sleep_list()
+{
+	struct dss_xstream	*dx;
+	uint64_t		now = 0;
+	bool			shutdown = false;
+	struct dss_sleep_ult	*dsu;
+	struct dss_sleep_ult	*tmp;
+
+	dx = dss_xstream_get(DSS_XS_SELF);
+	if (dss_xstream_exiting(dx))
+		shutdown = true;
+
+	daos_gettime_coarse(&now);
+	d_list_for_each_entry_safe(dsu, tmp, &dx->dx_sleep_ult_list,
+				   dsu_list) {
+		if (dsu->dsu_expire_time <= now || shutdown)
+			dss_ult_wakeup(dsu);
+		else
+			break;
+	}
 }
 
 static void
@@ -482,12 +592,16 @@ dss_srv_handler(void *arg)
 		if (dx->dx_main_xs)
 			bio_nvme_poll(dmi->dmi_nvme_ctxt);
 
-		if (dss_xstream_exiting(dx))
+		if (dss_xstream_exiting(dx)) {
+			check_sleep_list();
 			break;
+		}
 
+		check_sleep_list();
 		ABT_thread_yield();
 	}
 
+	D_ASSERT(d_list_empty(&dx->dx_sleep_ult_list));
 	/* Let's wait until all of queue ULTs has been executed, in case dmi_ctx
 	 * might be used by some other ULTs.
 	 */
@@ -640,6 +754,7 @@ dss_start_one_xstream(hwloc_cpuset_t cpus, int xs_id)
 	dx->dx_comm	= comm;
 	dx->dx_main_xs	= xs_id >= dss_sys_xs_nr && xs_offset == 0;
 	dx->dx_dsc_started = false;
+	D_INIT_LIST_HEAD(&dx->dx_sleep_ult_list);
 
 	rc = dss_sched_create(dx->dx_pools, DSS_POOL_CNT, &dx->dx_sched);
 	if (rc != 0) {
@@ -942,19 +1057,6 @@ struct dss_module_key daos_srv_modkey = {
 	.dmk_init = dss_srv_tls_init,
 	.dmk_fini = dss_srv_tls_fini,
 };
-
-static struct dss_xstream *
-dss_xstream_get(int stream_id)
-{
-	if (stream_id == DSS_XS_SELF)
-		return dss_get_module_info()->dmi_xstream;
-
-	D_ASSERTF(stream_id >= 0 && stream_id < xstream_data.xd_xs_nr,
-		  "invalid stream id %d (xstream_data.xd_xs_nr %d).\n",
-		  stream_id, xstream_data.xd_xs_nr);
-
-	return xstream_data.xd_xs_ptrs[stream_id];
-}
 
 /**
  * Create a ULT to execute \a func(\a arg). If \a ult is not NULL, the caller

--- a/src/iosrv/srv_internal.h
+++ b/src/iosrv/srv_internal.h
@@ -34,6 +34,7 @@ struct dss_xstream {
 	ABT_pool	dx_pools[DSS_POOL_CNT];
 	ABT_sched	dx_sched;
 	ABT_thread	dx_progress;
+	d_list_t	dx_sleep_ult_list;
 	tse_sched_t	dx_sched_dsc;
 	/* xstream id, [0, DSS_XS_NR_TOTAL - 1] */
 	int		dx_xs_id;


### PR DESCRIPTION
Add thread list for each xstream, so those timeout
ULT will be attached to the list and suspended, then
the main xstream will resume the xstream when timeout
is over, so to avoid the xstream being scheduled before
the timeout.

And also replace rand() with another faster version
of random generator(fast_rand).

Signed-off-by: Di Wang <di.wang@intel.com>