### PR TITLE
DAOS-3489 container: Move aggregation ULT to IO ULT pool

### DIFF
--- a/src/iosrv/srv_internal.h
+++ b/src/iosrv/srv_internal.h
@@ -174,9 +174,9 @@ dss_ult_pool(int ult_type)
 	case DSS_ULT_RDB:
 	case DSS_ULT_MISC:
 	case DSS_ULT_DRPC_HANDLER:
+	case DSS_ULT_AGGREGATE:
 		return DSS_POOL_SHARE;
 	case DSS_ULT_REBUILD:
-	case DSS_ULT_AGGREGATE:
 		return DSS_POOL_REBUILD;
 	default:
 		D_ASSERTF(0, "bad ult_type %d.\n", ult_type);


### PR DESCRIPTION
Create aggregation ULT in IO ULT pool instead of rebuild ULT pool,
otherwise, the aggregation ULT will be scheduled too often.

This is a temporary solution to solve the overhead introduced by
aggregation ULT scheduling. In the future, the ULT pools should be
categorized by ULT purposes, like IO pool, aggregation pool,
rebuild pool, progress pool, etc. and the scheduler should be
improved to schedule ULTs according to current workload, free space,
ULT priority, CPU quota, etc.

Signed-off-by: Niu Yawei <yawei.niu@intel.com>