### PR TITLE
DAOS-2429 dtx: store committed DTX in SCM without index

### DIFF
--- a/src/container/srv_target.c
+++ b/src/container/srv_target.c
@@ -104,6 +104,80 @@ cont_child_alloc_ref(void *key, unsigned int ksize, void *varg,
 	return rc;
 }
 
+void
+ds_cont_dtx_reindex_ult(void *arg)
+{
+	struct ds_cont_child		*cont	= arg;
+	struct dss_module_info		*dmi	= dss_get_module_info();
+	uint64_t			 hint	= 0;
+	int				 rc;
+
+	D_DEBUG(DF_DSMS, DF_CONT": starting DTX reindex ULT on xstream %d\n",
+		DP_CONT(NULL, cont->sc_uuid), dmi->dmi_tgt_id);
+
+	while (!cont->sc_dtx_reindex_abort) {
+		rc = vos_dtx_reindex(cont->sc_hdl, &hint);
+		if (rc < 0) {
+			D_ERROR(DF_UUID": DTX reindex failed: rc = %d\n",
+				DP_UUID(cont->sc_uuid), rc);
+			goto out;
+		}
+
+		if (rc > 0) {
+			D_DEBUG(DF_DSMS, DF_CONT": DTX reindex done\n",
+				DP_CONT(NULL, cont->sc_uuid));
+			goto out;
+		}
+
+		if (dss_xstream_exiting(dmi->dmi_xstream))
+			break;
+
+		ABT_thread_yield();
+	}
+
+	D_DEBUG(DF_DSMS, DF_CONT": stopping DTX reindex ULT on stream %d\n",
+		DP_CONT(NULL, cont->sc_uuid), dmi->dmi_tgt_id);
+
+out:
+	cont->sc_dtx_reindex = 0;
+	ds_cont_child_put(cont);
+}
+
+static int
+cont_start_dtx_reindex_ult(struct ds_cont_child *cont)
+{
+	int rc;
+
+	D_ASSERT(cont != NULL);
+
+	if (cont->sc_dtx_reindex || cont->sc_dtx_reindex_abort)
+		return 0;
+
+	ds_cont_child_get(cont);
+	cont->sc_dtx_reindex = 1;
+	rc = dss_ult_create(ds_cont_dtx_reindex_ult, cont,
+			    DSS_ULT_DTX_RESYNC, DSS_TGT_SELF, 0, NULL);
+	if (rc != 0) {
+		D_ERROR(DF_UUID": Failed to create DTX reindex ULT: rc %d\n",
+			DP_UUID(cont->sc_uuid), rc);
+		cont->sc_dtx_reindex = 0;
+		ds_cont_child_put(cont);
+	}
+
+	return rc;
+}
+
+static void
+cont_stop_dtx_reindex_ult(struct ds_cont_child *cont)
+{
+	cont->sc_dtx_reindex_abort = 1;
+
+	while (cont->sc_dtx_reindex)
+		ABT_thread_yield();
+
+	cont->sc_dtx_reindex_abort = 0;
+}
+
 static int
 cont_start_agg_ult(struct ds_cont_child *cont)
 {
@@ -130,6 +204,9 @@ static void
 cont_stop_agg_ult(struct ds_cont_child *cont)
 {
 	int rc;
+
+	if (!cont->sc_vos_aggregating)
+		return;
 
 	D_DEBUG(DF_DSMS, DF_CONT": Stopping aggregation ULT\n",
 		DP_CONT(NULL, cont->sc_uuid));
@@ -810,6 +887,10 @@ ds_cont_local_open(uuid_t pool_uuid, uuid_t cont_hdl_uuid, uuid_t cont_uuid,
 		if (rc)
 			goto err_cont;
 
+		rc = cont_start_dtx_reindex_ult(hdl->sch_cont);
+		if (rc != 0)
+			goto err_cont;
+
 		rc = dtx_batched_commit_register(hdl);
 		if (rc != 0) {
 			D_ERROR("Failed to register the container "DF_UUID
@@ -841,6 +922,8 @@ err_cont:
 	if (hdl->sch_cont)
 		cont_child_put(tls->dt_cont_cache, hdl->sch_cont);
 
+	cont_stop_dtx_reindex_ult(hdl->sch_cont);
+	cont_stop_agg_ult(hdl->sch_cont);
 	if (vos_co_created) {
 		D_DEBUG(DF_DSMS, DF_CONT": destroying new vos container\n",
 			DP_CONT(hdl->sch_pool->spc_uuid, cont_uuid));

--- a/src/include/daos_srv/container.h
+++ b/src/include/daos_srv/container.h
@@ -61,6 +61,8 @@ struct ds_cont_child {
 	void			*sc_dtx_flush_cbdata;
 	uint32_t		 sc_dtx_resyncing:1,
 				 sc_dtx_aggregating:1,
+				 sc_dtx_reindex:1,
+				 sc_dtx_reindex_abort:1,
 				 sc_vos_aggregating:1,
 				 sc_abort_vos_aggregating:1,
 				 sc_closing:1,

--- a/src/include/daos_srv/vos.h
+++ b/src/include/daos_srv/vos.h
@@ -230,6 +230,20 @@ int
 vos_dtx_mark_sync(daos_handle_t coh, daos_unit_oid_t oid, daos_epoch_t epoch);
 
 /**
+ * Establish the indexed committed DTX table in DRAM.
+ *
+ * \param coh	[IN]		Container open handle.
+ * \param hint	[IN,OUT]	Pointer to the address (offset in SCM) that
+ *				contains committed DTX entries to be handled.
+ *
+ * \return	Zero on success, need further re-index.
+ *		Positive, re-index is completed.
+ *		Negative value if error.
+ */
+int
+vos_dtx_reindex(daos_handle_t coh, void *hint);
+
+/**
  * Initialize the environment for a VOS instance
  * Must be called once before starting a VOS instance
  *

--- a/src/vos/tests/vts_dtx.c
+++ b/src/vos/tests/vts_dtx.c
@@ -388,10 +388,10 @@ vts_dtx_commit_visibility(struct io_test_args *args, bool ext, bool punch_obj)
 	assert_int_equal(rc, 0);
 
 	if (punch_obj)
-		rc = vos_obj_punch(args->ctx.tc_co_hdl, args->oid, ++epoch,
+		rc = vos_obj_punch(args->ctx.tc_co_hdl, args->oid, epoch,
 				   1, 0, NULL, 0, NULL, dth);
 	else
-		rc = vos_obj_punch(args->ctx.tc_co_hdl, args->oid, ++epoch,
+		rc = vos_obj_punch(args->ctx.tc_co_hdl, args->oid, epoch,
 				   1, 0, &dkey, 1, &akey, dth);
 	assert_int_equal(rc, 0);
 

--- a/src/vos/vos_internal.h
+++ b/src/vos/vos_internal.h
@@ -137,10 +137,14 @@ struct vos_container {
 	d_list_t		vc_dtx_committable_list;
 	/* The global list for committed DTXs. */
 	d_list_t		vc_dtx_committed_list;
+	/* The temporary list for committed DTXs during re-index. */
+	d_list_t		vc_dtx_committed_tmp_list;
 	/* The count of committable DTXs. */
 	uint32_t		vc_dtx_committable_count;
 	/* The count of committed DTXs. */
 	uint32_t		vc_dtx_committed_count;
+	/* The items count in vc_dtx_committed_tmp_list. */
+	uint32_t		vc_dtx_committed_tmp_count;
 	/** Direct pointer to the VOS container */
 	struct vos_cont_df	*vc_cont_df;
 	/**
@@ -150,7 +154,8 @@ struct vos_container {
 	struct vea_hint_context	*vc_hint_ctxt[VOS_IOS_CNT];
 	/* Various flags */
 	unsigned int		vc_in_aggregation:1,
-				vc_abort_aggregation:1;
+				vc_abort_aggregation:1,
+				vc_reindex_dtx:1;
 	unsigned int		vc_open_count;
 	uint64_t		vc_dtx_resync_gen;
 };
@@ -376,7 +381,7 @@ vos_dtx_prepared(struct dtx_handle *dth);
 
 void
 vos_dtx_commit_internal(struct vos_container *cont, struct dtx_id *dtis,
-			int count);
+			int count, umem_off_t umoff);
 
 /**
  * Register dbtree class for DTX CoS, it is called within vos_init().

--- a/src/vos/vos_io.c
+++ b/src/vos/vos_io.c
@@ -1297,7 +1297,7 @@ vos_update_end(daos_handle_t ioh, uint32_t pm_ver, daos_key_t *dkey, int err,
 	if (dth != NULL && dth->dth_dti_cos_count > 0 &&
 	    dth->dth_dti_cos_done == 0) {
 		vos_dtx_commit_internal(ioc->ic_obj->obj_cont, dth->dth_dti_cos,
-					dth->dth_dti_cos_count);
+					dth->dth_dti_cos_count, UMOFF_NULL);
 		dth->dth_dti_cos_done = 1;
 	}
 

--- a/src/vos/vos_layout.h
+++ b/src/vos/vos_layout.h
@@ -266,8 +266,12 @@ struct vos_cont_df {
 	daos_size_t			cd_used;
 	daos_epoch_t			cd_hae;
 	struct btr_root			cd_obj_root;
-	/** The DTXs table. */
-	struct btr_root			cd_dtx_root;
+	/** The active DTX table. */
+	struct btr_root			cd_dtx_active;
+	/** The committed DTXs blob head. */
+	umem_off_t			cd_dtx_committed_head;
+	/** The committed DTXs blob tail. */
+	umem_off_t			cd_dtx_committed_tail;
 	/** Allocation hints for block allocator. */
 	struct vea_hint_df		cd_hint_df[VOS_IOS_CNT];
 };

--- a/src/vos/vos_obj.c
+++ b/src/vos/vos_obj.c
@@ -152,7 +152,7 @@ vos_obj_punch(daos_handle_t coh, daos_unit_oid_t oid, daos_epoch_t epoch,
 	if (dth != NULL && dth->dth_dti_cos_count > 0 &&
 	    dth->dth_dti_cos_done == 0) {
 		vos_dtx_commit_internal(cont, dth->dth_dti_cos,
-					dth->dth_dti_cos_count);
+					dth->dth_dti_cos_count, UMOFF_NULL);
 		dth->dth_dti_cos_done = 1;
 	}
 


### PR DESCRIPTION
When a DTX is committed, it is added into the in-DRAM committed
DTX table that is organized as a B+tree. If related DAOS server
restarts because of some reason, for supporting DAOS server to
rejoin system (if is not evicted), then we need to re-establish
the indexed committed DTX table in DRAM. So we will store the
committed DTX entries in SCM without index (only append) when
it is committed.

A dedicated ULT will scan the non-indexed committed DTX entries
in SCM to re-generate the indexed committed DTX table in DRAM
when open the container.

Signed-off-by: Fan Yong <fan.yong@intel.com>