### PR TITLE
DAOS-2881 control: Add SCM-only multi-IO support

### DIFF
--- a/src/control/provider/system/system_linux.go
+++ b/src/control/provider/system/system_linux.go
@@ -28,6 +28,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"path/filepath"
 	"strings"
 	"syscall"
 
@@ -79,6 +80,7 @@ func (s LinuxProvider) IsMounted(target string) (bool, error) {
 	var scanField int
 	switch {
 	case st.IsDir():
+		target = filepath.Clean(target)
 		scanField = miMountPoint
 	case st.Mode()&os.ModeDevice != 0:
 		scanField = miMajorMinor

--- a/src/control/server/ctl_storage_rpc.go
+++ b/src/control/server/ctl_storage_rpc.go
@@ -236,10 +236,7 @@ func (c *ControlService) doFormat(i *IOServerInstance, reformat bool, resp *ctlp
 	c.log.Infof("formatting storage for I/O server instance %d (reformat: %t)",
 		i.Index, reformat)
 
-	scmConfig, err := i.scmConfig()
-	if err != nil {
-		return errors.Wrap(err, "get scm config")
-	}
+	scmConfig := i.scmConfig()
 
 	// If not reformatting, check if SCM is already formatted.
 	if !reformat {
@@ -273,6 +270,7 @@ func (c *ControlService) doFormat(i *IOServerInstance, reformat bool, resp *ctlp
 			return nil // don't continue if we can't format SCM
 		}
 	} else {
+		var err error
 		// If SCM was already formatted, verify if superblock exists.
 		needsSuperblock, err = i.NeedsSuperblock()
 		if err != nil {
@@ -284,10 +282,7 @@ func (c *ControlService) doFormat(i *IOServerInstance, reformat bool, resp *ctlp
 
 	// If no superblock exists, populate NVMe response with format results.
 	if needsSuperblock {
-		bdevConfig, err := i.bdevConfig()
-		if err != nil {
-			return errors.Wrap(err, "get bdev config")
-		}
+		bdevConfig := i.bdevConfig()
 
 		// A config with SCM and no block devices is valid.
 		// TODO: pull protobuf specifics out of c.nvme into this file.
@@ -376,7 +371,7 @@ func (c *ControlService) StorageUpdate(req *ctlpb.StorageUpdateReq, stream ctlpb
 
 	// temporary scaffolding
 	for _, i := range c.harness.Instances() {
-		stCfg := i.runner.Config.Storage
+		stCfg := i.runner.GetConfig().Storage
 		ctrlrResults := types.NvmeControllerResults{}
 		c.nvme.Update(stCfg.Bdev, req.Nvme, &ctrlrResults)
 		resp.Crets = ctrlrResults

--- a/src/control/server/harness.go
+++ b/src/control/server/harness.go
@@ -76,9 +76,7 @@ func (h *IOServerHarness) AddInstance(srv *IOServerInstance) error {
 
 	h.Lock()
 	defer h.Unlock()
-	srvIdx := len(h.instances)
-	srv.Index = uint32(srvIdx)
-	srv.runner.Config.Index = uint32(srvIdx)
+	srv.SetIndex(uint32(len(h.instances)))
 
 	h.instances = append(h.instances, srv)
 	return nil
@@ -131,7 +129,7 @@ func (h *IOServerHarness) CreateSuperblocks(recreate bool) error {
 
 	for _, instance := range toCreate {
 		// Only the first I/O server can be an MS replica.
-		if instance.Index == 0 {
+		if instance.Index() == 0 {
 			mInfo, err := getMgmtInfo(instance)
 			if err != nil {
 				return err
@@ -231,20 +229,20 @@ func (h *IOServerHarness) Start(parent context.Context) error {
 	}
 
 	// now monitor them
-	for {
-		select {
-		case <-parent.Done():
-			return nil
-		case err := <-errChan:
-			// If we receive an error from any instance, shut them all down.
-			// TODO: Restart failed instances rather than shutting everything
-			// down.
-			h.log.Errorf("instance error: %s", err)
-			if err != nil {
-				return errors.Wrap(err, "Instance error")
-			}
+	select {
+	case <-parent.Done():
+		return parent.Err()
+	case err := <-errChan:
+		// If we receive an error from any instance, shut them all down.
+		// TODO: Restart failed instances rather than shutting everything
+		// down.
+		h.log.Errorf("instance error: %s", err)
+		if err != nil {
+			return errors.Wrap(err, "Instance error")
 		}
 	}
+
+	return nil
 }
 
 // StartManagementService starts the DAOS management service on this node.

--- a/src/control/server/instance.go
+++ b/src/control/server/instance.go
@@ -40,6 +40,13 @@ import (
 	"github.com/daos-stack/daos/src/control/server/storage/scm"
 )
 
+// IOServerStarter defines an interface for starting the actual
+// daos_io_server.
+type IOServerStarter interface {
+	Start(context.Context, chan<- error) error
+	GetConfig() *ioserver.Config
+}
+
 // IOServerInstance encapsulates control-plane specific configuration
 // and functionality for managed I/O server instances. The distinction
 // between this structure and what's in the ioserver package is that the
@@ -48,10 +55,8 @@ import (
 // be used with IOServerHarness to manage and monitor multiple instances
 // per node.
 type IOServerInstance struct {
-	Index uint32
-
 	log           logging.Logger
-	runner        *ioserver.Runner
+	runner        IOServerStarter
 	bdevProvider  *storage.BdevProvider
 	scmProvider   *scm.Provider
 	msClient      *mgmtSvcClient
@@ -71,10 +76,9 @@ type IOServerInstance struct {
 // its dependencies.
 func NewIOServerInstance(log logging.Logger,
 	bp *storage.BdevProvider, sp *scm.Provider,
-	msc *mgmtSvcClient, r *ioserver.Runner) *IOServerInstance {
+	msc *mgmtSvcClient, r IOServerStarter) *IOServerInstance {
 
 	return &IOServerInstance{
-		Index:         r.Config.Index,
 		log:           log,
 		runner:        r,
 		bdevProvider:  bp,
@@ -85,28 +89,14 @@ func NewIOServerInstance(log logging.Logger,
 	}
 }
 
-// scmConfig returns the SCM configuration assigned to this instance.
-func (srv *IOServerInstance) scmConfig() (storage.ScmConfig, error) {
-	var nullCfg storage.ScmConfig
-	if srv.runner == nil {
-		return nullCfg, errors.New("no runner configured")
-	}
-	if srv.runner.Config == nil {
-		return nullCfg, errors.New("no ioserver config set on runner")
-	}
-	return srv.runner.Config.Storage.SCM, nil
+// scmConfig returns the scm configuration assigned to this instance.
+func (srv *IOServerInstance) scmConfig() storage.ScmConfig {
+	return srv.runner.GetConfig().Storage.SCM
 }
 
 // bdevConfig returns the block device configuration assigned to this instance.
-func (srv *IOServerInstance) bdevConfig() (storage.BdevConfig, error) {
-	var nullCfg storage.BdevConfig
-	if srv.runner == nil {
-		return nullCfg, errors.New("no runner configured")
-	}
-	if srv.runner.Config == nil {
-		return nullCfg, errors.New("no ioserver config set on runner")
-	}
-	return srv.runner.Config.Storage.Bdev, nil
+func (srv *IOServerInstance) bdevConfig() storage.BdevConfig {
+	return srv.runner.GetConfig().Storage.Bdev
 }
 
 func (srv *IOServerInstance) setDrpcClient(c drpc.DomainSocketClient) {
@@ -124,14 +114,21 @@ func (srv *IOServerInstance) getDrpcClient() (drpc.DomainSocketClient, error) {
 	return srv._drpcClient, nil
 }
 
+// SetIndex sets the server index assigned by the harness.
+func (srv *IOServerInstance) SetIndex(idx uint32) {
+	srv.runner.GetConfig().Index = idx
+}
+
+// Index returns the server index assigned by the harness.
+func (srv *IOServerInstance) Index() uint32 {
+	return srv.runner.GetConfig().Index
+}
+
 // MountScmDevice mounts the configured SCM device (DCPM or ramdisk emulation)
 // at the mountpoint specified in the configuration. If the device is already
 // mounted, the function returns nil, indicating success.
 func (srv *IOServerInstance) MountScmDevice() error {
-	scmCfg, err := srv.scmConfig()
-	if err != nil {
-		return err
-	}
+	scmCfg := srv.scmConfig()
 
 	isMount, err := srv.scmProvider.IsMounted(scmCfg.MountPoint)
 	if err != nil && !os.IsNotExist(errors.Cause(err)) {
@@ -174,10 +171,7 @@ func (srv *IOServerInstance) NeedsScmFormat() (bool, error) {
 	}
 	srv.RUnlock()
 
-	scmCfg, err := srv.scmConfig()
-	if err != nil {
-		return false, err
-	}
+	scmCfg := srv.scmConfig()
 
 	srv.log.Debugf("%s: checking formatting", scmCfg.MountPoint)
 
@@ -222,7 +216,7 @@ func (srv *IOServerInstance) Start(ctx context.Context, errChan chan<- error) er
 // NotifyReady receives a ready message from the running IOServer
 // instance.
 func (srv *IOServerInstance) NotifyReady(msg *srvpb.NotifyReadyReq) {
-	srv.log.Debugf("I/O server instance %d ready: %v", srv.Index, msg)
+	srv.log.Debugf("I/O server instance %d ready: %v", srv.Index(), msg)
 
 	// Activate the dRPC client connection to this iosrv
 	srv.setDrpcClient(drpc.NewClientConnection(msg.DrpcListenerSock))
@@ -241,7 +235,7 @@ func (srv *IOServerInstance) AwaitReady() chan *srvpb.NotifyReadyReq {
 
 // NotifyStorageReady releases any blocks on AwaitStorageReady().
 func (srv *IOServerInstance) NotifyStorageReady() {
-	srv.log.Debugf("I/O server instance %d notifying storage ready", srv.Index)
+	srv.log.Debugf("I/O server instance %d notifying storage ready", srv.Index())
 	go func() {
 		close(srv.storageReady)
 	}()
@@ -251,9 +245,9 @@ func (srv *IOServerInstance) NotifyStorageReady() {
 func (srv *IOServerInstance) AwaitStorageReady(ctx context.Context) {
 	select {
 	case <-ctx.Done():
-		srv.log.Infof("I/O server instance %d storage not ready: %s", srv.Index, ctx.Err())
+		srv.log.Infof("I/O server instance %d storage not ready: %s", srv.Index(), ctx.Err())
 	case <-srv.storageReady:
-		srv.log.Infof("I/O server instance %d storage ready", srv.Index)
+		srv.log.Infof("I/O server instance %d storage ready", srv.Index())
 	}
 }
 
@@ -328,7 +322,7 @@ func (srv *IOServerInstance) StartManagementService() error {
 
 	// should have been loaded by now
 	if superblock == nil {
-		return errors.Errorf("I/O server instance %d: nil superblock", srv.Index)
+		return errors.Errorf("I/O server instance %d: nil superblock", srv.Index())
 	}
 
 	if superblock.CreateMS {

--- a/src/control/server/ioserver/exec.go
+++ b/src/control/server/ioserver/exec.go
@@ -126,3 +126,8 @@ func (r *Runner) Start(ctx context.Context, errOut chan<- error) error {
 
 	return nil
 }
+
+// GetConfig returns the runner's configuration
+func (r *Runner) GetConfig() *Config {
+	return r.Config
+}

--- a/src/control/server/ioserver/mocks.go
+++ b/src/control/server/ioserver/mocks.go
@@ -1,0 +1,75 @@
+//
+// (C) Copyright 2019 Intel Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// GOVERNMENT LICENSE RIGHTS-OPEN SOURCE SOFTWARE
+// The Government's rights to use, modify, reproduce, release, perform, display,
+// or disclose this software are subject to the terms of the Apache License as
+// provided in Contract No. 8F-30005.
+// Any reproduction of computer software, computer software documentation, or
+// portions thereof marked with this legend must also reproduce the markings.
+//
+package ioserver
+
+import "context"
+
+type (
+	TestRunnerConfig struct {
+		StartCb    func()
+		StartErr   error
+		ErrChanCb  func() error
+		ErrChanErr error
+	}
+
+	TestRunner struct {
+		runnerCfg TestRunnerConfig
+		serverCfg *Config
+	}
+)
+
+func NewTestRunner(trc *TestRunnerConfig, sc *Config) *TestRunner {
+	if trc == nil {
+		trc = &TestRunnerConfig{}
+	}
+	return &TestRunner{
+		runnerCfg: *trc,
+		serverCfg: sc,
+	}
+}
+
+func (tr *TestRunner) Start(ctx context.Context, errChan chan<- error) error {
+	if tr.runnerCfg.StartCb != nil {
+		tr.runnerCfg.StartCb()
+	}
+	if tr.runnerCfg.ErrChanCb == nil {
+		tr.runnerCfg.ErrChanCb = func() error {
+			return tr.runnerCfg.ErrChanErr
+		}
+	}
+
+	go func() {
+		select {
+		case <-ctx.Done():
+			return
+		case errChan <- tr.runnerCfg.ErrChanCb():
+			return
+		}
+	}()
+
+	return tr.runnerCfg.StartErr
+}
+
+func (tr *TestRunner) GetConfig() *Config {
+	return tr.serverCfg
+}

--- a/src/control/server/server.go
+++ b/src/control/server/server.go
@@ -45,7 +45,7 @@ import (
 )
 
 // define supported maximum number of I/O servers
-const maxIoServers = 1
+const maxIoServers = 2
 
 // Start is the entry point for a daos_server instance.
 func Start(log *logging.LeveledLogger, cfg *Configuration) error {
@@ -73,6 +73,9 @@ func Start(log *logging.LeveledLogger, cfg *Configuration) error {
 	for i, srvCfg := range cfg.Servers {
 		if i+1 > maxIoServers {
 			break
+		}
+		if len(cfg.Servers) > 1 && len(srvCfg.Storage.Bdev.DeviceList) > 0 {
+			return errors.New("multi-io support with NVMe not supported in this release")
 		}
 
 		bp, err := storage.NewBdevProvider(log, srvCfg.Storage.SCM.MountPoint, &srvCfg.Storage.Bdev)

--- a/src/control/server/superblock.go
+++ b/src/control/server/superblock.go
@@ -71,7 +71,8 @@ func (sb *Superblock) Unmarshal(raw []byte) error {
 }
 
 func (srv *IOServerInstance) superblockPath() string {
-	storagePath := srv.runner.Config.Storage.SCM.MountPoint
+	scmConfig := srv.scmConfig()
+	storagePath := scmConfig.MountPoint
 	if storagePath == "" {
 		storagePath = defaultStoragePath
 	}
@@ -101,13 +102,11 @@ func (srv *IOServerInstance) NeedsSuperblock() (bool, error) {
 		return false, nil
 	}
 
-	scmCfg, err := srv.scmConfig()
-	if err != nil {
-		return false, err
-	}
+	scmCfg := srv.scmConfig()
+
 	srv.log.Debugf("%s: checking superblock", scmCfg.MountPoint)
 
-	err = srv.ReadSuperblock()
+	err := srv.ReadSuperblock()
 	if os.IsNotExist(errors.Cause(err)) {
 		srv.log.Debugf("%s: needs superblock (doesn't exist)", scmCfg.MountPoint)
 		return true, nil
@@ -131,7 +130,8 @@ func (srv *IOServerInstance) CreateSuperblock(msInfo *mgmtInfo) error {
 		return errors.Wrap(err, "Failed to generate instance UUID")
 	}
 
-	systemName := srv.runner.Config.SystemName
+	cfg := srv.runner.GetConfig()
+	systemName := cfg.SystemName
 	if systemName == "" {
 		systemName = defaultGroupName
 	}
@@ -146,10 +146,10 @@ func (srv *IOServerInstance) CreateSuperblock(msInfo *mgmtInfo) error {
 		BootstrapMS: msInfo.shouldBootstrap,
 	}
 
-	if srv.runner.Config.Rank != nil || msInfo.isReplica && msInfo.shouldBootstrap {
+	if cfg.Rank != nil || msInfo.isReplica && msInfo.shouldBootstrap {
 		superblock.Rank = new(ioserver.Rank)
-		if srv.runner.Config.Rank != nil {
-			*superblock.Rank = *srv.runner.Config.Rank
+		if cfg.Rank != nil {
+			*superblock.Rank = *cfg.Rank
 		}
 	}
 	srv.setSuperblock(superblock)


### PR DESCRIPTION
Preliminary support for multiple I/O servers per node. NVMe
storage is not supported yet due to complications with SPDK.