### PR TITLE
DAOS-3106 pool: NVMe faulty reaction ops

### DIFF
--- a/src/bio/bio_internal.h
+++ b/src/bio/bio_internal.h
@@ -240,7 +240,7 @@ void bio_media_error(void *msg_arg);
 int bio_blob_close(struct bio_io_context *ctxt, bool async);
 
 /* bio_recovery.c */
-extern struct bio_reaction_ops *ract_ops;
 int bio_bs_state_transit(struct bio_blobstore *bbs);
+int bio_bs_state_set(struct bio_blobstore *bbs, enum bio_bs_state new_state);
 
 #endif /* __BIO_INTERNAL_H__ */

--- a/src/bio/bio_monitor.c
+++ b/src/bio/bio_monitor.c
@@ -28,10 +28,13 @@
 #include "bio_internal.h"
 #include <daos_srv/smd.h>
 
-/* Period to query SPDK device health stats (1 min period) */
-#define DAOS_SPDK_STATS_PERIOD	(60 * (NSEC_PER_SEC / NSEC_PER_USEC))
+/*
+ * Period to query raw device health stats, auto detect faulty and transit
+ * device state. 60 seconds by default.
+ */
+#define NVME_MONITOR_PERIOD	(60ULL * (NSEC_PER_SEC / NSEC_PER_USEC))
 /* Used to preallocate buffer to query error log pages from SPDK health info */
-#define DAOS_MAX_ERROR_LOG_PAGES 256
+#define NVME_MAX_ERROR_LOG_PAGES	256
 
 /* See DAOS-3319 on this.  We should generally try to avoid reading unaligned
  * variables directly as it results in more than one instruction for each such
@@ -158,7 +161,7 @@ get_spdk_identify_ctrlr_completion(struct spdk_bdev_io *bdev_io, bool success,
 	cmd.cdw10 = numdl << 16;
 	cmd.cdw10 |= SPDK_NVME_LOG_ERROR;
 	cmd.cdw11 = numdu;
-	if (cdata->elpe >= DAOS_MAX_ERROR_LOG_PAGES) {
+	if (cdata->elpe >= NVME_MAX_ERROR_LOG_PAGES) {
 		D_ERROR("Device error log page size exceeds buffer size\n");
 		dev_health->bdh_inflights--;
 		goto out;
@@ -258,30 +261,36 @@ out:
 	spdk_bdev_free_io(bdev_io);
 }
 
-/* Get the SPDK device health state log and print all useful stats */
-void
-bio_bs_monitor(struct bio_xs_context *ctxt, uint64_t now)
+static int
+auto_detect_faulty(struct bio_blobstore *bbs)
 {
-	struct bio_dev_health	*dev_health;
+	if (bbs->bb_state != BIO_BS_STATE_NORMAL &&
+	    bbs->bb_state != BIO_BS_STATE_REPLACED &&
+	    bbs->bb_state != BIO_BS_STATE_REINT)
+		return 0;
+	/*
+	 * TODO: Check the health data stored in @bbs, and mark the bbs as
+	 *	 faulty when certain faulty criteria are satisfied.
+	 */
+	if (DAOS_FAIL_CHECK(DAOS_NVME_FAULTY))
+		return bio_bs_state_set(bbs, BIO_BS_STATE_FAULTY);
+
+	return 0;
+}
+
+/* Collect the raw device health state through SPDK admin APIs */
+static void
+collect_raw_health_data(struct bio_dev_health *dev_health)
+{
 	struct spdk_bdev	*bdev;
 	struct spdk_nvme_cmd	 cmd;
-	int			 rc;
 	uint32_t		 numd, numdl, numdu;
 	uint32_t		 health_page_sz;
+	int			 rc;
 
-	D_ASSERT(ctxt != NULL);
-	D_ASSERT(ctxt->bxc_blobstore != NULL);
-	dev_health = &ctxt->bxc_blobstore->bb_dev_health;
+	D_ASSERT(dev_health != NULL);
 	D_ASSERT(dev_health->bdh_io_channel != NULL);
 	D_ASSERT(dev_health->bdh_desc != NULL);
-
-	/*
-	 * TODO Decide on an appropriate period to query device health
-	 * stats. Currently set at 1 min.
-	 */
-	if (dev_health->bdh_stat_age + DAOS_SPDK_STATS_PERIOD >= now)
-		return;
-	dev_health->bdh_stat_age = now;
 
 	bdev = spdk_bdev_desc_get_bdev(dev_health->bdh_desc);
 	if (bdev == NULL) {
@@ -289,24 +298,8 @@ bio_bs_monitor(struct bio_xs_context *ctxt, uint64_t now)
 		return;
 	}
 
-	/* Return if non-NVMe device */
 	if (get_bdev_type(bdev) != BDEV_CLASS_NVME)
 		return;
-
-	/*
-	 * TODO:
-	 * Faulty device criteria check (Check current in-memory device health
-	 * state).
-	 * Mechanism to notify admin of if any BIO errors exist. Given I/O
-	 * error, checksum error and health monitoring information, admin can
-	 * determine if device should be marked as FAULTY (SMD device state
-	 * updated).
-	 */
-
-
-	/*
-	 * Continue querying current SPDK device health stats.
-	 */
 
 	if (!spdk_bdev_io_type_supported(bdev, SPDK_BDEV_IO_TYPE_NVME_ADMIN)) {
 		D_ERROR("Bdev NVMe admin passthru not supported!\n");
@@ -345,6 +338,33 @@ bio_bs_monitor(struct bio_xs_context *ctxt, uint64_t now)
 		D_ERROR("NVMe admin passthru (health log), rc:%d\n", rc);
 		dev_health->bdh_inflights--;
 	}
+}
+
+void
+bio_bs_monitor(struct bio_xs_context *ctxt, uint64_t now)
+{
+	struct bio_dev_health	*dev_health;
+	int			 rc;
+
+	D_ASSERT(ctxt != NULL);
+	D_ASSERT(ctxt->bxc_blobstore != NULL);
+	dev_health = &ctxt->bxc_blobstore->bb_dev_health;
+
+	if (dev_health->bdh_stat_age + NVME_MONITOR_PERIOD >= now)
+		return;
+	dev_health->bdh_stat_age = now;
+
+	rc = auto_detect_faulty(ctxt->bxc_blobstore);
+	if (rc)
+		D_ERROR("Auto faulty detect on target %d failed. %d\n",
+			ctxt->bxc_tgt_id, rc);
+
+	rc = bio_bs_state_transit(ctxt->bxc_blobstore);
+	if (rc)
+		D_ERROR("State transition on target %d failed. %d\n",
+			ctxt->bxc_tgt_id, rc);
+
+	collect_raw_health_data(dev_health);
 }
 
 /* Print the io stat every few seconds, for debug only */
@@ -432,7 +452,7 @@ bio_init_health_monitoring(struct bio_blobstore *bb,
 	}
 
 	ep_sz = sizeof(struct spdk_nvme_error_information_entry);
-	ep_buf_sz = ep_sz * DAOS_MAX_ERROR_LOG_PAGES;
+	ep_buf_sz = ep_sz * NVME_MAX_ERROR_LOG_PAGES;
 	bb->bb_dev_health.bdh_error_buf = spdk_dma_zmalloc(ep_buf_sz, 0, NULL);
 	if (bb->bb_dev_health.bdh_error_buf == NULL) {
 		spdk_dma_free(bb->bb_dev_health.bdh_health_buf);

--- a/src/bio/bio_recovery.c
+++ b/src/bio/bio_recovery.c
@@ -34,7 +34,12 @@
  * the DAOS progress ULT will be blocked, and NVMe device qpair won't be
  * polled.
  */
-struct bio_reaction_ops	*ract_ops;
+static struct bio_reaction_ops	*ract_ops;
+
+void bio_register_ract_ops(struct bio_reaction_ops *ops)
+{
+	ract_ops = ops;
+}
 
 /*
  * Return value:	0: Faulty reaction is done;
@@ -191,6 +196,7 @@ bio_bs_state_set(struct bio_blobstore *bbs, enum bio_bs_state new_state)
 	case BIO_BS_STATE_OUT:
 		if (bbs->bb_state != BIO_BS_STATE_TEARDOWN)
 			rc = -DER_INVAL;
+		break;
 	case BIO_BS_STATE_REPLACED:
 	case BIO_BS_STATE_REINT:
 		rc = -DER_NOSYS;

--- a/src/bio/bio_xstream.c
+++ b/src/bio/bio_xstream.c
@@ -84,8 +84,7 @@ static struct bio_nvme_data nvme_glb;
 uint64_t io_stat_period;
 
 int
-bio_nvme_init(const char *storage_path, const char *nvme_conf, int shm_id,
-	      struct bio_reaction_ops *ops)
+bio_nvme_init(const char *storage_path, const char *nvme_conf, int shm_id)
 {
 	char		*env;
 	int		rc, fd;
@@ -155,7 +154,6 @@ bio_nvme_init(const char *storage_path, const char *nvme_conf, int shm_id,
 	io_stat_period *= (NSEC_PER_SEC / NSEC_PER_USEC);
 
 	nvme_glb.bd_shm_id = shm_id;
-	ract_ops = ops;
 	return 0;
 
 free_cond:

--- a/src/include/daos/common.h
+++ b/src/include/daos/common.h
@@ -532,6 +532,8 @@ enum {
 #define DAOS_VC_LOST_DATA		(DAOS_FAIL_UNIT_TEST_GROUP_LOC | 0x42)
 #define DAOS_VC_LOST_REPLICA		(DAOS_FAIL_UNIT_TEST_GROUP_LOC | 0x43)
 
+#define DAOS_NVME_FAULTY		(DAOS_FAIL_UNIT_TEST_GROUP_LOC | 0x50)
+
 #define DAOS_FAIL_CHECK(id) daos_fail_check(id)
 
 static inline int __is_po2(unsigned long long val)

--- a/src/include/daos_srv/bio.h
+++ b/src/include/daos_srv/bio.h
@@ -199,18 +199,23 @@ struct bio_reaction_ops {
 	int (*reint_reaction)(int *tgt_ids, int tgt_cnt);
 };
 
+/*
+ * Register faulty/reint reaction callbacks.
+ *
+ * \param ops[IN]	Reaction callback functions
+ */
+void bio_register_ract_ops(struct bio_reaction_ops *ops);
+
 /**
  * Global NVMe initialization.
  *
  * \param[IN] storage_path	daos storage directory path
  * \param[IN] nvme_conf		NVMe config file
  * \param[IN] shm_id		shm id to enable multiprocess mode in SPDK
- * \param[IN] ops		Reaction callback functions
  *
  * \return		Zero on success, negative value on error
  */
-int bio_nvme_init(const char *storage_path, const char *nvme_conf, int shm_id,
-		  struct bio_reaction_ops *ops);
+int bio_nvme_init(const char *storage_path, const char *nvme_conf, int shm_id);
 
 /**
  * Global NVMe finilization.

--- a/src/include/daos_types.h
+++ b/src/include/daos_types.h
@@ -381,7 +381,10 @@ typedef enum {
 	DAOS_EVS_ABORTED,
 } daos_ev_status_t;
 
-/* rank/target list for target */
+/**
+ * Pool target list, each target is identified by rank & target
+ * index within the rank
+ */
 struct d_tgt_list {
 	d_rank_t	*tl_ranks;
 	int32_t		*tl_tgts;

--- a/src/iosrv/srv.c
+++ b/src/iosrv/srv.c
@@ -1611,8 +1611,7 @@ dss_srv_init()
 	dss_register_key(&daos_srv_modkey);
 	xstream_data.xd_init_step = XD_INIT_REG_KEY;
 
-	rc = bio_nvme_init(dss_storage_path, dss_nvme_conf, dss_nvme_shm_id,
-			   NULL);
+	rc = bio_nvme_init(dss_storage_path, dss_nvme_conf, dss_nvme_shm_id);
 	if (rc != 0)
 		D_GOTO(failed, rc);
 	xstream_data.xd_init_step = XD_INIT_NVME;

--- a/src/iosrv/srv_cli.c
+++ b/src/iosrv/srv_cli.c
@@ -334,5 +334,5 @@ dsc_pool_tgt_exclude(const uuid_t uuid, const char *grp,
 	args->tgts	= tgts;
 	uuid_copy((unsigned char *)args->uuid, uuid);
 
-	return dsc_task_run(task, NULL, NULL, 0, false);
+	return dsc_task_run(task, NULL, NULL, 0, true);
 }

--- a/src/mgmt/cli_mgmt.c
+++ b/src/mgmt/cli_mgmt.c
@@ -452,10 +452,12 @@ detach_group(bool server, bool pmixless, crt_group_t *group)
 {
 	int rc = 0;
 
-	if (!pmixless)
-		rc = crt_group_detach(group);
-	else if (!server)
-		rc = crt_group_view_destroy(group);
+	if (!server) {
+		if (!pmixless)
+			rc = crt_group_detach(group);
+		else
+			rc = crt_group_view_destroy(group);
+	}
 	D_ASSERTF(rc == 0, "%d\n", rc);
 }
 

--- a/src/pool/cli.c
+++ b/src/pool/cli.c
@@ -1121,22 +1121,16 @@ dc_pool_update_internal(tse_task_t *task, daos_pool_update_t *args,
 	int				i;
 	int				rc;
 
+	if (args->tgts == NULL || args->tgts->tl_nr == 0) {
+		D_ERROR("NULL tgts or tgts->tl_nr is zero\n");
+		D_GOTO(out_task, rc = -DER_INVAL);
+	}
+
+	D_DEBUG(DF_DSMC, DF_UUID": opc %d targets:%u tgts[0]=%u/%d\n",
+		DP_UUID(args->uuid), opc, args->tgts->tl_nr,
+		args->tgts->tl_ranks[0], args->tgts->tl_tgts[0]);
+
 	if (state == NULL) {
-		if (args->tgts == NULL || args->tgts->tl_nr == 0) {
-			D_ERROR("NULL tgts or tgts->tl_nr is zero\n");
-			D_GOTO(out_task, rc = -DER_INVAL);
-		} else if ((opc == POOL_EXCLUDE || opc == POOL_EXCLUDE_OUT) &&
-			   args->tgts->tl_nr > 1) {
-			D_ERROR("pool exclude can only work with "
-				"(tgts->tl_nr == 1) for now.\n");
-			D_GOTO(out_task, rc = -DER_INVAL);
-		}
-
-		D_DEBUG(DF_DSMC, DF_UUID": opc %d targets:%u"
-			" tgts[0]=%u/%d\n", DP_UUID(args->uuid), opc,
-			args->tgts->tl_nr, args->tgts->tl_ranks[0],
-			args->tgts->tl_tgts[0]);
-
 		D_ALLOC_PTR(state);
 		if (state == NULL) {
 			D_ERROR(DF_UUID": failed to allocate state\n",
@@ -1179,7 +1173,6 @@ dc_pool_update_internal(tse_task_t *task, daos_pool_update_t *args,
 		D_GOTO(out_client, rc);
 	}
 
-	/* XXX Let's update all targets on the node */
 	for (i = 0; i < args->tgts->tl_nr; i++) {
 		list.pta_addrs[i].pta_rank = args->tgts->tl_ranks[i];
 		list.pta_addrs[i].pta_target = args->tgts->tl_tgts[i];

--- a/src/pool/srv.c
+++ b/src/pool/srv.c
@@ -31,6 +31,7 @@
 #include <daos_srv/pool.h>
 #include <daos/rpc.h>
 #include <daos_srv/daos_server.h>
+#include <daos_srv/bio.h>
 #include "rpc.h"
 #include "srv_internal.h"
 #include "srv_layout.h"
@@ -58,6 +59,7 @@ init(void)
 
 	ds_pool_rsvc_class_register();
 
+	bio_register_ract_ops(&nvme_reaction_ops);
 	return 0;
 
 err_pool_iv:

--- a/src/pool/srv_internal.h
+++ b/src/pool/srv_internal.h
@@ -133,6 +133,7 @@ int ds_pool_map_tgts_update(struct pool_map *map,
 			    struct pool_target_id_list *tgts, int opc);
 int ds_pool_check_failed_replicas(struct pool_map *map, d_rank_list_t *replicas,
 				  d_rank_list_t *failed, d_rank_list_t *alt);
+extern struct bio_reaction_ops nvme_reaction_ops;
 
 /*
  * srv_iv.c

--- a/src/pool/srv_util.c
+++ b/src/pool/srv_util.c
@@ -26,6 +26,8 @@
 #define D_LOGFAC	DD_FAC(pool)
 
 #include <daos_srv/pool.h>
+#include <daos_srv/bio.h>
+#include <daos_srv/smd.h>
 
 #include <daos/pool_map.h>
 #include "rpc.h"
@@ -529,3 +531,257 @@ output:
 		ds_pool_put(pool);
 	return rc;
 }
+
+/* See nvme_faulty_reaction() for return values */
+static int
+check_pool_targets(uuid_t pool_id, int *tgt_ids, int tgt_cnt, d_rank_t *pl_rank)
+{
+	struct ds_pool		*pool;
+	struct pool_target	*target = NULL;
+	d_rank_t		 rank = dss_self_rank();
+	int			 nr_downout, nr_down;
+	int			 i, nr, rc = 0;
+
+	/* Get pool map to check the target status */
+	pool = ds_pool_lookup(pool_id);
+	/*
+	 * FIXME: Not supporting offline faulty reaction so far.
+	 *
+	 * The pool cache & pool map IV implementation will be improved
+	 * later to not rely on pool connect or rebuild later, then we can
+	 * setup pool cache/IV by a local pool open.
+	 */
+	if (pool == NULL) {
+		D_DEBUG(DB_MGMT, DF_UUID": Pool cache not found\n",
+			DP_UUID(pool_id));
+		return -DER_NOSYS;
+	}
+
+	nr_downout = nr_down = 0;
+	ABT_rwlock_rdlock(pool->sp_lock);
+	for (i = 0; i < tgt_cnt; i++) {
+		nr = pool_map_find_target_by_rank_idx(pool->sp_map, rank,
+						      tgt_ids[i], &target);
+		if (nr != 1) {
+			D_ERROR(DF_UUID": Failed to get rank:%u, idx:%d\n",
+				DP_UUID(pool_id), rank, tgt_ids[i]);
+			rc = -DER_NONEXIST;
+			break;
+		}
+
+		D_ASSERT(target != NULL);
+		switch (target->ta_comp.co_status) {
+		case PO_COMP_ST_DOWNOUT:
+			nr_downout++;
+			break;
+		case PO_COMP_ST_DOWN:
+			nr_down++;
+			break;
+		default:
+			break;
+		}
+	}
+	D_ASSERT(nr_downout + nr_down <= tgt_cnt);
+
+	if (pool->sp_iv_ns != NULL)
+		*pl_rank = pool->sp_iv_ns->iv_master_rank;
+	else
+		*pl_rank = -1;
+
+	ABT_rwlock_unlock(pool->sp_lock);
+	ds_pool_put(pool);
+
+	if (rc)
+		return rc;
+	else if (nr_downout == tgt_cnt)
+		return 0;
+	else if (nr_downout + nr_down == tgt_cnt)
+		return 1;
+	else
+		return (*pl_rank == -1) ? -DER_NOSYS : 2;
+}
+
+struct exclude_targets_arg {
+	uuid_t		 eta_pool_id;
+	d_rank_t	 eta_pl_rank;
+	d_rank_t	*eta_ranks;
+	int		*eta_tgts;
+	int		 eta_nr;
+};
+
+static void
+free_exclude_targets_arg(struct exclude_targets_arg *eta)
+{
+	D_ASSERT(eta != NULL);
+	if (eta->eta_ranks != NULL)
+		D_FREE(eta->eta_ranks);
+	if (eta->eta_tgts != NULL)
+		D_FREE(eta->eta_tgts);
+	D_FREE(eta);
+}
+
+static struct exclude_targets_arg *
+alloc_exclude_targets_arg(uuid_t pool_id, int *tgt_ids, int tgt_cnt,
+			  d_rank_t pl_rank)
+{
+	struct exclude_targets_arg	*eta;
+	d_rank_t			 rank;
+	int				 i;
+
+	D_ASSERT(tgt_cnt > 0);
+	D_ASSERT(tgt_ids != NULL);
+
+	D_ALLOC_PTR(eta);
+	if (eta == NULL)
+		return NULL;
+
+	D_ALLOC_ARRAY(eta->eta_ranks, tgt_cnt);
+	if (eta->eta_ranks == NULL)
+		goto free;
+
+	D_ALLOC_ARRAY(eta->eta_tgts, tgt_cnt);
+	if (eta->eta_tgts == NULL)
+		goto free;
+
+	uuid_copy(eta->eta_pool_id, pool_id);
+	eta->eta_pl_rank = pl_rank;
+	eta->eta_nr = tgt_cnt;
+	rank = dss_self_rank();
+	for (i = 0; i < eta->eta_nr; i++) {
+		eta->eta_ranks[i] = rank;
+		eta->eta_tgts[i] = tgt_ids[i];
+	}
+
+	return eta;
+free:
+	free_exclude_targets_arg(eta);
+	return NULL;
+}
+
+static void
+exclude_targets_ult(void *arg)
+{
+	struct exclude_targets_arg	*eta = arg;
+	struct d_tgt_list		 tgt_list;
+	d_rank_list_t			 svc;
+	int				 rc;
+
+	svc.rl_ranks = &eta->eta_pl_rank;
+	svc.rl_nr = 1;
+
+	tgt_list.tl_nr = eta->eta_nr;
+	tgt_list.tl_ranks = eta->eta_ranks;
+	tgt_list.tl_tgts = eta->eta_tgts;
+
+	rc = dsc_pool_tgt_exclude(eta->eta_pool_id, NULL /* grp */, &svc,
+				  &tgt_list);
+	if (rc)
+		D_ERROR(DF_UUID": Exclude targets failed. %d\n",
+			DP_UUID(eta->eta_pool_id), rc);
+
+	free_exclude_targets_arg(eta);
+}
+
+/*
+ * The NVMe faulty reaction is called from bio_nvme_poll() which is on
+ * progress (hardware poll) ULT, and it will call into client stack to
+ * exclude pool targets, blocking calls could be made in this code path,
+ * so we have to perform the faulty reactions asynchronously in a new ULT
+ * to avoid blocking the hardware poll.
+ */
+static int
+exclude_pool_targets(uuid_t pool_id, int *tgt_ids, int tgt_cnt,
+		     d_rank_t pl_rank)
+{
+	struct exclude_targets_arg	*eta;
+	int				 rc;
+
+	eta = alloc_exclude_targets_arg(pool_id, tgt_ids, tgt_cnt, pl_rank);
+	if (eta == NULL)
+		return -DER_NOMEM;
+
+	rc = dss_ult_create(exclude_targets_ult, eta, DSS_ULT_MISC,
+			    DSS_TGT_SELF, 0, NULL);
+	if (rc) {
+		D_ERROR(DF_UUID": Failed to start excluding ULT. %d\n",
+			DP_UUID(pool_id), rc);
+		free_exclude_targets_arg(eta);
+	}
+
+	return rc;
+}
+
+static int
+nvme_faulty_reaction(int *tgt_ids, int tgt_cnt)
+{
+	struct smd_pool_info	*pool_info, *tmp;
+	d_list_t		 pool_list;
+	d_rank_t		 pl_rank;
+	int			 pool_cnt, ret, rc;
+
+	D_ASSERT(tgt_cnt > 0);
+	D_ASSERT(tgt_ids != NULL);
+
+	D_INIT_LIST_HEAD(&pool_list);
+	rc = smd_pool_list(&pool_list, &pool_cnt);
+	if (rc) {
+		D_ERROR("Failed to list pools: %d\n", rc);
+		return rc;
+	}
+
+	d_list_for_each_entry_safe(pool_info, tmp, &pool_list, spi_link) {
+		ret = check_pool_targets(pool_info->spi_id, tgt_ids, tgt_cnt,
+					 &pl_rank);
+		switch (ret) {
+		case 0:
+			/*
+			 * All affected targets are in DOWN_OUT, it's safe to
+			 * transit NVMe state to BIO_BS_STATE_TEARDOWN now.
+			 */
+			D_DEBUG(DB_MGMT, DF_UUID": Targets are excluded out.\n",
+				DP_UUID(pool_info->spi_id));
+			break;
+		case 1:
+			/*
+			 * Some affected targets are still in DOWN, the NVMe
+			 * state needs to stick to BIO_BS_STATE_FAULTY.
+			 */
+			D_DEBUG(DB_MGMT, DF_UUID": Targets are in excluding.\n",
+				DP_UUID(pool_info->spi_id));
+			if (rc == 0)
+				rc = 1;
+			break;
+		case 2:
+			/*
+			 * Some affected targets are still in UP or UPIN, need
+			 * to send exclude RPC.
+			 */
+			D_DEBUG(DB_MGMT, DF_UUID": Trigger targets exclude.\n",
+				DP_UUID(pool_info->spi_id));
+			rc = exclude_pool_targets(pool_info->spi_id, tgt_ids,
+						  tgt_cnt, pl_rank);
+			if (rc == 0)
+				rc = 1;
+			break;
+		default:
+			/* Errors */
+			D_ERROR(DF_UUID": Check targets status failed: %d\n",
+				DP_UUID(pool_info->spi_id), ret);
+			if (rc >= 0)
+				rc = ret;
+			break;
+		}
+
+		d_list_del(&pool_info->spi_link);
+		smd_free_pool_info(pool_info);
+	}
+
+	D_DEBUG(DB_MGMT, "Faulty reaction done. tgt_cnt:%d, rc:%d\n",
+		tgt_cnt, rc);
+	return rc;
+}
+
+struct bio_reaction_ops nvme_reaction_ops = {
+	.faulty_reaction	= nvme_faulty_reaction,
+	.reint_reaction		= NULL,
+};

--- a/src/tests/suite/daos_nvme_recovery.c
+++ b/src/tests/suite/daos_nvme_recovery.c
@@ -1,0 +1,146 @@
+/**
+ * (C) Copyright 2019 Intel Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * GOVERNMENT LICENSE RIGHTS-OPEN SOURCE SOFTWARE
+ * The Government's rights to use, modify, reproduce, release, perform, display,
+ * or disclose this software are subject to the terms of the Apache License as
+ * provided in Contract No. B609815.
+ * Any reproduction of computer software, computer software documentation, or
+ * portions thereof marked with this legend must also reproduce the markings.
+ */
+/**
+ * This file is part of daos
+ *
+ * tests/suite/daos_nvme_recovery.c
+ *
+ *
+ */
+#define D_LOGFAC	DD_FAC(tests)
+
+#include "daos_test.h"
+#include "daos_iotest.h"
+
+static void
+set_fail_loc(test_arg_t *arg, d_rank_t rank, uint64_t fail_loc)
+{
+	if (arg->myrank == 0)
+		daos_mgmt_set_params(arg->group, rank, DSS_KEY_FAIL_LOC,
+				     fail_loc, 0, NULL);
+	MPI_Barrier(MPI_COMM_WORLD);
+}
+
+static bool
+is_nvme_enabled(test_arg_t *arg)
+{
+	daos_pool_info_t	 pinfo = { 0 };
+	struct daos_pool_space	*ps = &pinfo.pi_space;
+	int			 rc;
+
+	pinfo.pi_bits = DPI_ALL;
+	rc = test_pool_get_info(arg, &pinfo);
+	assert_int_equal(rc, 0);
+
+	return ps->ps_free_min[DAOS_MEDIA_NVME] != 0;
+}
+
+/* Online faulty reaction */
+static void
+nvme_recov_1(void **state)
+{
+	test_arg_t	*arg = *state;
+	daos_obj_id_t	 oid;
+	struct ioreq	 req;
+	char		 dkey[DTS_KEY_LEN] = { 0 };
+	char		 akey[DTS_KEY_LEN] = { 0 };
+	int		 obj_class, key_nr = 10;
+	int		 rank = 0, tgt_idx = 0;
+	int		 i, j;
+
+	if (!is_nvme_enabled(arg)) {
+		print_message("NVMe isn't enabled.\n");
+		skip();
+	}
+
+	if (arg->pool.pool_info.pi_nnodes < 2)
+		obj_class = DAOS_OC_R1S_SPEC_RANK;
+	else
+		obj_class = DAOS_OC_R2S_SPEC_RANK;
+
+	oid = dts_oid_gen(obj_class, 0, arg->myrank);
+	oid = dts_oid_set_rank(oid, rank);
+	oid = dts_oid_set_tgt(oid, tgt_idx);
+	ioreq_init(&req, arg->coh, oid, DAOS_IOD_ARRAY, arg);
+
+	print_message("Generating data on obj "DF_OID"...\n", DP_OID(oid));
+	for (i = 0; i < key_nr; i++) {
+		dts_key_gen(dkey, DTS_KEY_LEN, "dkey");
+		for (j = 0; j < key_nr; j++) {
+			dts_key_gen(akey, DTS_KEY_LEN, "akey");
+			insert_single(dkey, akey, 0, "data", strlen("data") + 1,
+				      DAOS_TX_NONE, &req);
+		}
+	}
+	ioreq_fini(&req);
+
+	print_message("Error injection to simulate device faulty.\n");
+	set_fail_loc(arg, rank, DAOS_NVME_FAULTY | DAOS_FAIL_ONCE);
+
+	/*
+	 * FIXME: Due to lack of infrastructures for checking each target
+	 *	  status, let's just wait for an arbitray time and hope the
+	 *	  faulty reaction & rebuild is triggered.
+	 */
+	print_message("Waiting for faulty reaction being triggered...\n");
+	sleep(60);
+
+	print_message("Waiting for rebuild done...\n");
+	if (arg->myrank == 0)
+		test_rebuild_wait(&arg, 1);
+	MPI_Barrier(MPI_COMM_WORLD);
+
+	/*
+	 * FIXME: Need to verify target is in DOWNOUT when the infrastructure
+	 *	  is ready.
+	 */
+	print_message("Waiting for faulty reaction done...\n");
+	sleep(60);
+	print_message("Done\n");
+}
+
+static const struct CMUnitTest nvme_recov_tests[] = {
+	{"NVMe Recovery 1: Online faulty reaction",
+	 nvme_recov_1, NULL, test_case_teardown},
+};
+
+int
+run_daos_nvme_recov_test(int rank, int size, int *sub_tests,
+			 int sub_tests_size)
+{
+	int rc = 0;
+
+	MPI_Barrier(MPI_COMM_WORLD);
+	if (sub_tests_size == 0) {
+		sub_tests_size = ARRAY_SIZE(nvme_recov_tests);
+		sub_tests = NULL;
+	}
+
+	rc = run_daos_sub_tests(nvme_recov_tests, ARRAY_SIZE(nvme_recov_tests),
+				DEFAULT_POOL_SIZE, sub_tests, sub_tests_size,
+				NULL, NULL);
+
+	MPI_Barrier(MPI_COMM_WORLD);
+
+	return rc;
+}

--- a/src/tests/suite/daos_test.c
+++ b/src/tests/suite/daos_test.c
@@ -34,7 +34,7 @@
  * all will be run if no test is specified. Tests will be run in order
  * so tests that kill nodes must be last.
  */
-#define TESTS "mpceXVizADKCoROdrF"
+#define TESTS "mpceXVizADKCoROdrFN"
 /**
  * These tests will only be run if explicity specified. They don't get
  * run if no test is specified.
@@ -75,6 +75,7 @@ print_usage(int rank)
 	print_message("daos_test -R|--MD_replication_tests\n");
 	print_message("daos_test -O|--oid_alloc\n");
 	print_message("daos_test -r|--rebuild\n");
+	print_message("daos_test -N|--nvme_recovery\n");
 	print_message("daos_test -a|--daos_all_tests\n");
 	print_message("Default <daos_tests> runs all tests\n=============\n");
 	print_message("Options: Use one of these arg(s) to modify the "
@@ -223,6 +224,13 @@ run_specified_tests(const char *tests, int rank, int size,
 			nr_failed += run_daos_fs_test(rank, size, sub_tests,
 						      sub_tests_size);
 			break;
+		case 'N':
+			daos_test_print(rank, "\n\n=================");
+			daos_test_print(rank, "DAOS NVMe recovery tests..");
+			daos_test_print(rank, "==================");
+			nr_failed += run_daos_nvme_recov_test(rank, size,
+						sub_tests, sub_tests_size);
+			break;
 		default:
 			D_ASSERT(0);
 		}
@@ -278,6 +286,7 @@ main(int argc, char **argv)
 		{"oid_alloc",	no_argument,		NULL,	'O'},
 		{"degraded",	no_argument,		NULL,	'd'},
 		{"rebuild",	no_argument,		NULL,	'r'},
+		{"nvme_recovery",	no_argument,	NULL,	'N'},
 		{"group",	required_argument,	NULL,	'g'},
 		{"csum_type",	required_argument,	NULL,
 						CHECKSUM_ARG_VAL_TYPE},
@@ -305,7 +314,7 @@ main(int argc, char **argv)
 	memset(tests, 0, sizeof(tests));
 
 	while ((opt = getopt_long(argc, argv,
-				  "ampcCdXVizxADKeoROg:s:u:E:f:Fw:W:hr",
+				  "ampcCdXVizxADKeoROg:s:u:E:f:Fw:W:hrN",
 				  long_options, &index)) != -1) {
 		if (strchr(all_tests_defined, opt) != NULL) {
 			tests[ntests] = opt;

--- a/src/tests/suite/daos_test.h
+++ b/src/tests/suite/daos_test.h
@@ -277,6 +277,8 @@ int run_daos_dtx_test(int rank, int size, int *tests, int test_size);
 int run_daos_vc_test(int rank, int size, int *tests, int test_size);
 int run_daos_checksum_test(int rank, int size);
 int run_daos_fs_test(int rank, int size, int *tests, int test_size);
+int run_daos_nvme_recov_test(int rank, int size, int *sub_tests,
+			     int sub_tests_size);
 
 void daos_kill_server(test_arg_t *arg, const uuid_t pool_uuid, const char *grp,
 		      d_rank_list_t *svc, d_rank_t rank);

--- a/src/vos/vos_common.c
+++ b/src/vos/vos_common.c
@@ -290,8 +290,7 @@ vos_nvme_init(void)
 	if (rc != 0 && rc != -DER_EXIST)
 		return rc;
 
-	rc = bio_nvme_init(VOS_STORAGE_PATH, VOS_NVME_CONF, VOS_NVME_SHM_ID,
-			   NULL);
+	rc = bio_nvme_init(VOS_STORAGE_PATH, VOS_NVME_CONF, VOS_NVME_SHM_ID);
 	if (rc)
 		return rc;
 	vsa_nvme_init = true;


### PR DESCRIPTION
Implemented NVMe faulty reaction operation, added nvme_recovery test
suite.

Limitations:
- Due to lack of the infrastructure to get pool map offline, the
  offline NVMe faulty reaction isn't supported. It'll be done once
  the pool cache & pool map IV cleanup done.

- The nvme_recovery test can only run manually, because NVMe reint
  isn't supported yet, the failed VOS target can't be reintegrated
  back and DAOS server needs be restarted after each run.

Signed-off-by: Niu Yawei <yawei.niu@intel.com>
Change-Id: I04aa76ab240fb51f003feae24627b64d4c68f66b