### PR TITLE
Use EL 7.7

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -39,6 +39,7 @@
 // To use a test branch (i.e. PR) until it lands to master
 // I.e. for testing library changes
 //@Library(value="pipeline-lib@your_branch") _
+@Library(value="pipeline-lib@use-el7.7") _
 
 def arch = ""
 def sanitized_JOB_NAME = JOB_NAME.toLowerCase().replaceAll('/', '-').replaceAll('%2f', '-')

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1029,7 +1029,7 @@ pipeline {
                                        node_count: 1,
                                        snapshot: true,
                                        inst_repos: component_repos,
-                                       inst_rpms: "argobots cart fuse3-libs hwloc-devel libisa-l libpmem libpmemobj protobuf-c spdk-devel"
+                                       inst_rpms: "argobots cart fuse3-libs hwloc-devel libisa-l libpmem libpmemobj protobuf-c spdk-devel libfabric-devel"
                         runTest stashes: [ 'CentOS-tests', 'CentOS-install', 'CentOS-build-vars' ],
                                 script: '''# JENKINS-52781 tar function is breaking symlinks
                                            rm -rf test_results


### PR DESCRIPTION

Because EPEL no longer has the EL 7.6 packages we need.

Signed-off-by: Brian J. Murrell <brian.murrell@intel.com>
Quick-build: true