### PR TITLE
DAOS-2429 dtx: DTX performance optimization - V7

### DIFF
--- a/src/container/srv_target.c
+++ b/src/container/srv_target.c
@@ -86,7 +86,6 @@ cont_child_alloc_ref(void *key, unsigned int ksize, void *varg,
 		goto out_cond;
 
 	uuid_copy(cont->sc_uuid, key);
-	cont->sc_dtx_resync_time = crt_hlc_get();
 	/* prevent aggregation till snapshot iv refreshed */
 	cont->sc_aggregation_max = 0;
 	cont->sc_snapshots_nr = 0;
@@ -103,6 +102,80 @@ cont_child_alloc_ref(void *key, unsigned int ksize, void *varg,
  out:
 	D_FREE(cont);
 	return rc;
+}
+
+void
+ds_cont_dtx_reindex_ult(void *arg)
+{
+	struct ds_cont_child		*cont	= arg;
+	struct dss_module_info		*dmi	= dss_get_module_info();
+	uint64_t			 hint	= 0;
+	int				 rc;
+
+	D_DEBUG(DF_DSMS, DF_CONT": starting DTX reindex ULT on xstream %d\n",
+		DP_CONT(NULL, cont->sc_uuid), dmi->dmi_tgt_id);
+
+	while (!cont->sc_dtx_reindex_abort) {
+		rc = vos_dtx_reindex(cont->sc_hdl, &hint);
+		if (rc < 0) {
+			D_ERROR(DF_UUID": DTX reindex failed: rc = %d\n",
+				DP_UUID(cont->sc_uuid), rc);
+			goto out;
+		}
+
+		if (rc > 0) {
+			D_DEBUG(DF_DSMS, DF_CONT": DTX reindex done\n",
+				DP_CONT(NULL, cont->sc_uuid));
+			goto out;
+		}
+
+		if (dss_xstream_exiting(dmi->dmi_xstream))
+			break;
+
+		ABT_thread_yield();
+	}
+
+	D_DEBUG(DF_DSMS, DF_CONT": stopping DTX reindex ULT on stream %d\n",
+		DP_CONT(NULL, cont->sc_uuid), dmi->dmi_tgt_id);
+
+out:
+	cont->sc_dtx_reindex = 0;
+	ds_cont_child_put(cont);
+}
+
+static int
+cont_start_dtx_reindex_ult(struct ds_cont_child *cont)
+{
+	int rc;
+
+	D_ASSERT(cont != NULL);
+
+	if (cont->sc_dtx_reindex || cont->sc_dtx_reindex_abort)
+		return 0;
+
+	ds_cont_child_get(cont);
+	cont->sc_dtx_reindex = 1;
+	rc = dss_ult_create(ds_cont_dtx_reindex_ult, cont,
+			    DSS_ULT_DTX_RESYNC, DSS_TGT_SELF, 0, NULL);
+	if (rc != 0) {
+		D_ERROR(DF_UUID": Failed to create DTX reindex ULT: rc %d\n",
+			DP_UUID(cont->sc_uuid), rc);
+		cont->sc_dtx_reindex = 0;
+		ds_cont_child_put(cont);
+	}
+
+	return rc;
+}
+
+static void
+cont_stop_dtx_reindex_ult(struct ds_cont_child *cont)
+{
+	cont->sc_dtx_reindex_abort = 1;
+
+	while (cont->sc_dtx_reindex)
+		ABT_thread_yield();
+
+	cont->sc_dtx_reindex_abort = 0;
 }
 
 static int
@@ -131,6 +204,9 @@ static void
 cont_stop_agg_ult(struct ds_cont_child *cont)
 {
 	int rc;
+
+	if (!cont->sc_vos_aggregating)
+		return;
 
 	D_DEBUG(DF_DSMS, DF_CONT": Stopping aggregation ULT\n",
 		DP_CONT(NULL, cont->sc_uuid));
@@ -811,6 +887,10 @@ ds_cont_local_open(uuid_t pool_uuid, uuid_t cont_hdl_uuid, uuid_t cont_uuid,
 		if (rc)
 			goto err_cont;
 
+		rc = cont_start_dtx_reindex_ult(hdl->sch_cont);
+		if (rc != 0)
+			goto err_cont;
+
 		rc = dtx_batched_commit_register(hdl);
 		if (rc != 0) {
 			D_ERROR("Failed to register the container "DF_UUID
@@ -842,6 +922,8 @@ err_cont:
 	if (hdl->sch_cont)
 		cont_child_put(tls->dt_cont_cache, hdl->sch_cont);
 
+	cont_stop_dtx_reindex_ult(hdl->sch_cont);
+	cont_stop_agg_ult(hdl->sch_cont);
 	if (vos_co_created) {
 		D_DEBUG(DF_DSMS, DF_CONT": destroying new vos container\n",
 			DP_CONT(hdl->sch_pool->spc_uuid, cont_uuid));

--- a/src/dtx/dtx_common.c
+++ b/src/dtx/dtx_common.c
@@ -49,7 +49,7 @@ dtx_aggregate(void *arg)
 	while (!cont->sc_closing) {
 		int	rc;
 
-		rc = vos_dtx_aggregate(cont->sc_hdl, DTX_AGG_YIELD_INTERVAL,
+		rc = vos_dtx_aggregate(cont->sc_hdl, DTX_YIELD_CYCLE,
 				       DTX_AGG_THRESHOLD_AGE_LOWER);
 		if (rc != 0)
 			break;
@@ -205,7 +205,7 @@ dtx_handle_init(struct dtx_id *dti, daos_unit_oid_t *oid, daos_handle_t coh,
 		daos_epoch_t epoch, uint64_t dkey_hash, uint32_t pm_ver,
 		uint32_t intent, struct dtx_conflict_entry *conflict,
 		struct dtx_id *dti_cos, int dti_cos_count, bool leader,
-		bool no_rep, struct dtx_handle *dth)
+		bool single_participator, struct dtx_handle *dth)
 {
 	dth->dth_xid = *dti;
 	dth->dth_oid = *oid;
@@ -216,7 +216,7 @@ dtx_handle_init(struct dtx_id *dti, daos_unit_oid_t *oid, daos_handle_t coh,
 	dth->dth_ver = pm_ver;
 	dth->dth_intent = intent;
 	dth->dth_leader = leader ? 1 : 0;
-	dth->dth_non_rep = no_rep ? 1 : 0;
+	dth->dth_single_participator = single_participator ? 1 : 0;
 	dth->dth_dti_cos = dti_cos;
 	dth->dth_dti_cos_count = dti_cos_count;
 	dth->dth_conflict = conflict;
@@ -274,7 +274,6 @@ dtx_leader_begin(struct dtx_id *dti, daos_unit_oid_t *oid, daos_handle_t coh,
 		return 0;
 	}
 
-	dlh->dlh_handled_time = crt_hlc_get();
 	dlh->dlh_future = ABT_FUTURE_NULL;
 	D_ALLOC(dlh->dlh_subs, tgts_cnt * sizeof(*dlh->dlh_subs));
 	if (dlh->dlh_subs == NULL)
@@ -582,50 +581,8 @@ dtx_leader_end(struct dtx_leader_handle *dlh, struct ds_cont_hdl *cont_hdl,
 	if (result < 0 || rc < 0 || daos_is_zero_dti(&dth->dth_xid))
 		D_GOTO(fail, result = (result == 0 ? rc : result));
 
-	/* If the DTX is started befoe DTX resync operation (for rebuild),
-	 * then it is possbile that the DTX resync ULT may have aborted
-	 * or committed the DTX during current ULT waiting for the reply.
-	 * let's check DTX status locally before marking as 'committable'.
-	 */
-	if (dlh->dlh_handled_time <= cont->sc_dtx_resync_time) {
-		rc = vos_dtx_check(cont->sc_hdl, &dth->dth_xid);
-		switch (rc) {
-		case DTX_ST_PREPARED:
-			rc = vos_dtx_lookup_cos(dth->dth_coh, &dth->dth_oid,
-					&dth->dth_xid, dth->dth_dkey_hash,
-					dth->dth_intent == DAOS_INTENT_PUNCH ?
-					true : false);
-			/* The resync ULT has already added it into the CoS
-			 * cache, current ULT needs to do nothing.
-			 */
-			if (rc == 0)
-				D_GOTO(out_free, result = 0);
-
-			/* normal case, then add it to CoS cache. */
-			if (rc == -DER_NONEXIST)
-				break;
-
-			D_GOTO(fail, result = (rc >= 0 ? -DER_INVAL : rc));
-		case DTX_ST_COMMITTED:
-			/* The DTX has been committed by resync ULT by race,
-			 * set dth_sync to indicate that in log.
-			 */
-			dth->dth_sync = 1;
-			D_GOTO(out_free, result = 0);
-		case -DER_NONEXIST:
-			/* The DTX has been aborted by resync ULT, ask the
-			 * client to retry via returning -DER_INPROGRESS.
-			 */
-			result = -DER_INPROGRESS;
-			goto out_free;
-		default:
-			result = rc >= 0 ? -DER_INVAL : rc;
-			goto fail;
-		}
-	}
-
 	rc = vos_dtx_add_cos(dth->dth_coh, &dth->dth_oid, &dth->dth_xid,
-			     dth->dth_dkey_hash, dth->dth_epoch,
+			     dth->dth_dkey_hash, dth->dth_epoch, dth->dth_gen,
 			     dth->dth_intent == DAOS_INTENT_PUNCH ?
 			     true : false, true);
 	if (rc == -DER_INPROGRESS) {
@@ -635,6 +592,18 @@ dtx_leader_end(struct dtx_leader_handle *dlh, struct ds_cont_hdl *cont_hdl,
 		       dth->dth_epoch);
 		D_GOTO(fail, result = rc);
 	}
+
+	/* The DTX has been aborted by resync ULT, ask the client to retry. */
+	if (rc == -DER_NONEXIST) {
+		D_WARN(DF_UUID": Fail to add DTX "DF_DTI" with eph "DF_U64
+		       "to CoS because of being aborted by race\n",
+		       DP_UUID(cont->sc_uuid), DP_DTI(&dth->dth_xid),
+		       dth->dth_epoch);
+		D_GOTO(out_free, result = -DER_INPROGRESS);
+	}
+
+	if (rc == -DER_ALREADY)
+		D_GOTO(out_free, result = 0);
 
 	if (rc != 0) {
 		D_WARN(DF_UUID": Fail to add DTX "DF_DTI" to CoS cache: %d. "
@@ -673,7 +642,8 @@ out_free:
 		(unsigned long long)dth->dth_dkey_hash,
 		dth->dth_intent == DAOS_INTENT_PUNCH ? "Punch" : "Update",
 		dth->dth_sync ? "sync" : "async",
-		dth->dth_non_rep ? "non-replicated" : "replicated", result);
+		dth->dth_single_participator ? "single-participator" :
+		"multiple-participators", result);
 
 	if (dth->dth_dti_cos != NULL)
 		D_FREE(dth->dth_dti_cos);
@@ -895,6 +865,7 @@ dtx_handle_resend(daos_handle_t coh, daos_unit_oid_t *oid, struct dtx_id *dti,
 		 */
 		return -DER_NONEXIST;
 
+again:
 	rc = vos_dtx_check_resend(coh, oid, dti, dkey_hash, punch, epoch);
 	switch (rc) {
 	case DTX_ST_PREPARED:
@@ -910,6 +881,12 @@ dtx_handle_resend(daos_handle_t coh, daos_unit_oid_t *oid, struct dtx_id *dti,
 			rc = -DER_EP_OLD;
 		}
 		return rc;
+	case -DER_AGAIN:
+		/* Re-index committed DTX table is not completed yet,
+		 * let's wait and retry.
+		 */
+		ABT_thread_yield();
+		goto again;
 	default:
 		return rc >= 0 ? -DER_INVAL : rc;
 	}

--- a/src/dtx/dtx_internal.h
+++ b/src/dtx/dtx_internal.h
@@ -71,7 +71,7 @@ CRT_RPC_DECLARE(dtx, DAOS_ISEQ_DTX, DAOS_OSEQ_DTX);
 /* The count threshould for triggerring DTX aggregation.
  * This threshould should consider the real SCM size.
  */
-#define DTX_AGG_THRESHOLD_CNT		(1 << 27)
+#define DTX_AGG_THRESHOLD_CNT		(1 << 28)
 
 /* The time threshould for triggerring DTX aggregation. If the oldest
  * DTX in the DTX table exceeds such threshould, it will trigger DTX
@@ -84,7 +84,7 @@ CRT_RPC_DECLARE(dtx, DAOS_ISEQ_DTX, DAOS_OSEQ_DTX);
  */
 #define DTX_AGG_THRESHOLD_AGE_LOWER	3600
 
-#define DTX_AGG_YIELD_INTERVAL		DTX_THRESHOLD_COUNT
+#define DTX_YIELD_CYCLE			(DTX_THRESHOLD_COUNT >> 3)
 
 extern struct crt_proto_format dtx_proto_fmt;
 extern btr_ops_t dbtree_dtx_cf_ops;

--- a/src/dtx/dtx_rpc.c
+++ b/src/dtx/dtx_rpc.c
@@ -655,7 +655,7 @@ dtx_abort(uuid_t po_uuid, uuid_t co_uuid, daos_epoch_t epoch,
 	D_ASSERT(dti != NULL);
 
 	/* Local abort firstly. */
-	rc = vos_dtx_abort(cont->sc_hdl, epoch, dti, count, false);
+	rc = vos_dtx_abort(cont->sc_hdl, epoch, dti, count);
 
 	if (rc == -DER_NONEXIST)
 		rc = 0;

--- a/src/dtx/dtx_srv.c
+++ b/src/dtx/dtx_srv.c
@@ -39,7 +39,11 @@ dtx_handler(crt_rpc_t *rpc)
 	struct dtx_in		*din = crt_req_get(rpc);
 	struct dtx_out		*dout = crt_reply_get(rpc);
 	struct ds_cont_child	*cont = NULL;
+	struct dtx_id		*dtis;
 	uint32_t		 opc = opc_get(rpc->cr_opc);
+	int			 count = DTX_YIELD_CYCLE;
+	int			 i = 0;
+	int			 rc1;
 	int			 rc;
 
 	rc = ds_cont_child_lookup(din->di_po_uuid, din->di_co_uuid, &cont);
@@ -52,13 +56,31 @@ dtx_handler(crt_rpc_t *rpc)
 
 	switch (opc) {
 	case DTX_COMMIT:
-		rc = vos_dtx_commit(cont->sc_hdl, din->di_dtx_array.ca_arrays,
-				    din->di_dtx_array.ca_count);
+		while (i < din->di_dtx_array.ca_count) {
+			if (i + count > din->di_dtx_array.ca_count)
+				count = din->di_dtx_array.ca_count - i;
+
+			dtis = (struct dtx_id *)din->di_dtx_array.ca_arrays + i;
+			rc1 = vos_dtx_commit(cont->sc_hdl, dtis, count);
+			if (rc == 0 && rc1 != 0)
+				rc = rc1;
+
+			i += count;
+		}
 		break;
 	case DTX_ABORT:
-		rc = vos_dtx_abort(cont->sc_hdl, din->di_epoch,
-				   din->di_dtx_array.ca_arrays,
-				   din->di_dtx_array.ca_count, true);
+		while (i < din->di_dtx_array.ca_count) {
+			if (i + count > din->di_dtx_array.ca_count)
+				count = din->di_dtx_array.ca_count - i;
+
+			dtis = (struct dtx_id *)din->di_dtx_array.ca_arrays + i;
+			rc1 = vos_dtx_abort(cont->sc_hdl, din->di_epoch,
+					    dtis, count);
+			if (rc == 0 && rc1 != 0)
+				rc = rc1;
+
+			i += count;
+		}
 		break;
 	case DTX_CHECK:
 		/* Currently, only support to check single DTX state. */

--- a/src/include/daos_srv/container.h
+++ b/src/include/daos_srv/container.h
@@ -59,10 +59,10 @@ struct ds_cont_child {
 	ABT_mutex		 sc_mutex;
 	ABT_cond		 sc_dtx_resync_cond;
 	void			*sc_dtx_flush_cbdata;
-	/* The time for the latest DTX resync operation. */
-	uint64_t		 sc_dtx_resync_time;
 	uint32_t		 sc_dtx_resyncing:1,
 				 sc_dtx_aggregating:1,
+				 sc_dtx_reindex:1,
+				 sc_dtx_reindex_abort:1,
 				 sc_vos_aggregating:1,
 				 sc_abort_vos_aggregating:1,
 				 sc_closing:1,

--- a/src/include/daos_srv/dtx_srv.h
+++ b/src/include/daos_srv/dtx_srv.h
@@ -60,6 +60,8 @@ struct dtx_handle {
 	daos_handle_t			 dth_coh;
 	/** The epoch# for the DTX. */
 	daos_epoch_t			 dth_epoch;
+	/* The generation when the DTX is handled on the server. */
+	uint64_t			 dth_gen;
 	/** The {obj/dkey/akey}-tree records that are created
 	 * by other DTXs, but not ready for commit yet.
 	 */
@@ -72,7 +74,8 @@ struct dtx_handle {
 	uint32_t			 dth_intent;
 	uint32_t			 dth_sync:1, /* commit synchronously. */
 					 dth_leader:1, /* leader replica. */
-					 dth_non_rep:1, /* non-replicated. */
+					 /* Only one participator in the DTX. */
+					 dth_single_participator:1,
 					 /* dti_cos has been committed. */
 					 dth_dti_cos_done:1;
 	/* The count the DTXs in the dth_dti_cos array. */
@@ -98,8 +101,6 @@ struct dtx_sub_status {
 struct dtx_leader_handle {
 	/* The dtx handle on the leader node */
 	struct dtx_handle		dlh_handle;
-	/* The time when the DTX is handled on the server. */
-	uint64_t			dlh_handled_time;
 	/* result for the distribute transaction */
 	int				dlh_result;
 

--- a/src/include/daos_srv/vos.h
+++ b/src/include/daos_srv/vos.h
@@ -38,6 +38,17 @@
 #include <daos_srv/vos_types.h>
 
 /**
+ * Refresh the DTX resync generation.
+ *
+ * \param coh	[IN]	Container open handle.
+ *
+ * \return		Zero on success.
+ * \return		Negative value if error.
+ */
+int
+vos_dtx_update_resync_gen(daos_handle_t coh);
+
+/**
  * Add the given DTX to the Commit-on-Share (CoS) cache (in DRAM).
  *
  * \param coh		[IN]	Container open handle.
@@ -45,6 +56,7 @@
  * \param dti		[IN]	The DTX identifier.
  * \param dkey_hash	[IN]	The hashed dkey.
  * \param epoch		[IN]	The DTX epoch.
+ * \param gen		[IN]	The DTX generation.
  * \param punch		[IN]	For punch DTX or not.
  * \param check		[IN]	Check whether the DTX need restart because
  *				of sync epoch or not.
@@ -55,7 +67,8 @@
  */
 int
 vos_dtx_add_cos(daos_handle_t coh, daos_unit_oid_t *oid, struct dtx_id *dti,
-		uint64_t dkey_hash, daos_epoch_t epoch, bool punch, bool check);
+		uint64_t dkey_hash, daos_epoch_t epoch, uint64_t gen,
+		bool punch, bool check);
 
 /**
  * Search the specified DTX is in the CoS cache or not.
@@ -174,14 +187,12 @@ vos_dtx_commit(daos_handle_t coh, struct dtx_id *dtis, int count);
  * \param epoch	[IN]	The max epoch for the DTX to be aborted.
  * \param dtis	[IN]	The array for DTX identifiers to be aborted.
  * \param count [IN]	The count of DTXs to be aborted.
- * \param force [IN]	Force abort even if some replica(s) have not
- *			'prepared' related DTXs.
  *
  * \return		Zero on success, negative value if error.
  */
 int
 vos_dtx_abort(daos_handle_t coh, daos_epoch_t epoch, struct dtx_id *dtis,
-	      int count, bool force);
+	      int count);
 
 /**
  * Aggregate the committed DTXs.
@@ -217,6 +228,20 @@ vos_dtx_stat(daos_handle_t coh, struct dtx_stat *stat);
  */
 int
 vos_dtx_mark_sync(daos_handle_t coh, daos_unit_oid_t oid, daos_epoch_t epoch);
+
+/**
+ * Establish the indexed committed DTX table in DRAM.
+ *
+ * \param coh	[IN]		Container open handle.
+ * \param hint	[IN,OUT]	Pointer to the address (offset in SCM) that
+ *				contains committed DTX entries to be handled.
+ *
+ * \return	Zero on success, need further re-index.
+ *		Positive, re-index is completed.
+ *		Negative value if error.
+ */
+int
+vos_dtx_reindex(daos_handle_t coh, void *hint);
 
 /**
  * Initialize the environment for a VOS instance

--- a/src/include/daos_srv/vos_types.h
+++ b/src/include/daos_srv/vos_types.h
@@ -201,8 +201,8 @@ typedef struct {
 	union {
 		/** Returned earliest update epoch for a key */
 		daos_epoch_t			ie_earliest;
-		/** Return the DTX handled time for DTX iteration. */
-		uint64_t			ie_dtx_time;
+		/** record size */
+		daos_size_t			ie_rsize;
 	};
 	union {
 		/** Returned entry for container UUID iterator */
@@ -220,8 +220,6 @@ typedef struct {
 			uint32_t		ie_dtx_intent;
 		};
 		struct {
-			/** record size */
-			daos_size_t		ie_rsize;
 			/** record extent */
 			daos_recx_t		ie_recx;
 			/* original in-tree extent */

--- a/src/object/srv_obj.c
+++ b/src/object/srv_obj.c
@@ -1044,7 +1044,7 @@ ds_obj_tgt_update_handler(crt_rpc_t *rpc)
 			 * that it can be aborted.
 			 */
 			rc = vos_dtx_abort(cont->sc_hdl, DAOS_EPOCH_MAX,
-					   &orw->orw_dti, 1, true);
+					   &orw->orw_dti, 1);
 
 		if (rc != 0 && rc != -DER_NONEXIST)
 			D_GOTO(out, rc);
@@ -1156,7 +1156,11 @@ ds_obj_rw_handler(crt_rpc_t *rpc)
 		orw->orw_map_ver, map_ver, DP_DTI(&orw->orw_dti));
 	/* FIXME: until distributed transaction. */
 	if (orw->orw_epoch == DAOS_EPOCH_MAX) {
-		orw->orw_epoch = crt_hlc_get();
+		if (daos_is_zero_dti(&orw->orw_dti) ||
+		    orw->orw_flags & ORF_RESEND)
+			orw->orw_epoch = crt_hlc_get();
+		else
+			orw->orw_epoch = orw->orw_dti.dti_hlc;
 		D_DEBUG(DB_IO, "overwrite epoch "DF_U64"\n", orw->orw_epoch);
 	}
 
@@ -1657,7 +1661,7 @@ ds_obj_tgt_punch_handler(crt_rpc_t *rpc)
 			 * that it can be aborted.
 			 */
 			rc = vos_dtx_abort(cont->sc_hdl, DAOS_EPOCH_MAX,
-					   &opi->opi_dti, 1, true);
+					   &opi->opi_dti, 1);
 
 		if (rc != 0 && rc != -DER_NONEXIST)
 			D_GOTO(out, rc);
@@ -1745,7 +1749,11 @@ ds_obj_punch_handler(crt_rpc_t *rpc)
 
 	/* FIXME: until distributed transaction. */
 	if (opi->opi_epoch == DAOS_EPOCH_MAX) {
-		opi->opi_epoch = crt_hlc_get();
+		if (daos_is_zero_dti(&opi->opi_dti) ||
+		    opi->opi_flags & ORF_RESEND)
+			opi->opi_epoch = crt_hlc_get();
+		else
+			opi->opi_epoch = opi->opi_dti.dti_hlc;
 		D_DEBUG(DB_IO, "overwrite epoch "DF_U64"\n", opi->opi_epoch);
 	}
 

--- a/src/vos/tests/vos_tests.c
+++ b/src/vos/tests/vos_tests.c
@@ -164,7 +164,7 @@ main(int argc, char **argv)
 	index = 0;
 	optind = 0;
 
-	while ((opt = getopt_long(argc, argv, "apcdnti:A:hf:e:",
+	while ((opt = getopt_long(argc, argv, "apcdntXi:A:hf:e:",
 				  long_options, &index)) != -1) {
 		switch (opt) {
 		case 'p':

--- a/src/vos/tests/vts_dtx.c
+++ b/src/vos/tests/vts_dtx.c
@@ -44,7 +44,7 @@ vts_dtx_cos(void **state, bool punch)
 
 	/* Insert a DTX into CoS cache. */
 	rc = vos_dtx_add_cos(args->ctx.tc_co_hdl, &args->oid, &xid,
-			     dkey_hash, DAOS_EPOCH_MAX - 1, punch, false);
+			     dkey_hash, DAOS_EPOCH_MAX - 1, 0, punch, false);
 	assert_int_equal(rc, 0);
 
 	/* Query the DTX with different @punch parameter will find nothing. */
@@ -99,7 +99,7 @@ dtx_3(void **state)
 		daos_dti_gen(&xid, false);
 
 		rc = vos_dtx_add_cos(args->ctx.tc_co_hdl, &args->oid, &xid,
-				     dkey_hash, DAOS_EPOCH_MAX - 1,
+				     dkey_hash, DAOS_EPOCH_MAX - 1, 0,
 				     i % 2 ? true : false, false);
 		assert_int_equal(rc, 0);
 	}
@@ -139,7 +139,7 @@ dtx_4(void **state)
 		dkey_hash = lrand48();
 
 		rc = vos_dtx_add_cos(args->ctx.tc_co_hdl, &args->oid, &xid[i],
-				     dkey_hash, DAOS_EPOCH_MAX - 1,
+				     dkey_hash, DAOS_EPOCH_MAX - 1, 0,
 				     i % 2 ? false : true, false);
 		assert_int_equal(rc, 0);
 	}
@@ -300,7 +300,7 @@ dtx_5(void **state)
 
 	/* Add former DTX into CoS cache. */
 	rc = vos_dtx_add_cos(args->ctx.tc_co_hdl, &args->oid, &xid,
-			     dkey_hash, epoch, false, false);
+			     dkey_hash, epoch, 0, false, false);
 	assert_int_equal(rc, 0);
 
 	vos_dtx_stat(args->ctx.tc_co_hdl, &stat);
@@ -388,10 +388,10 @@ vts_dtx_commit_visibility(struct io_test_args *args, bool ext, bool punch_obj)
 	assert_int_equal(rc, 0);
 
 	if (punch_obj)
-		rc = vos_obj_punch(args->ctx.tc_co_hdl, args->oid, ++epoch,
+		rc = vos_obj_punch(args->ctx.tc_co_hdl, args->oid, epoch,
 				   1, 0, NULL, 0, NULL, dth);
 	else
-		rc = vos_obj_punch(args->ctx.tc_co_hdl, args->oid, ++epoch,
+		rc = vos_obj_punch(args->ctx.tc_co_hdl, args->oid, epoch,
 				   1, 0, &dkey, 1, &akey, dth);
 	assert_int_equal(rc, 0);
 
@@ -499,7 +499,7 @@ vts_dtx_abort_visibility(struct io_test_args *args, bool ext, bool punch_obj)
 	vts_dtx_end(dth);
 
 	/* Aborted the update DTX. */
-	rc = vos_dtx_abort(args->ctx.tc_co_hdl, epoch, &xid, 1, false);
+	rc = vos_dtx_abort(args->ctx.tc_co_hdl, epoch, &xid, 1);
 	assert_int_equal(rc, 0);
 
 	memset(fetch_buf, 0, UPDATE_BUF_SIZE);
@@ -533,7 +533,7 @@ vts_dtx_abort_visibility(struct io_test_args *args, bool ext, bool punch_obj)
 	vts_dtx_end(dth);
 
 	/* Aborted the punch DTX. */
-	rc = vos_dtx_abort(args->ctx.tc_co_hdl, epoch, &xid, 1, false);
+	rc = vos_dtx_abort(args->ctx.tc_co_hdl, epoch, &xid, 1);
 	assert_int_equal(rc, 0);
 
 	memset(fetch_buf, 0, UPDATE_BUF_SIZE);
@@ -636,7 +636,7 @@ dtx_14(void **state)
 	 * But we cannot check "assert_int_not_equal(rc, 0)" that depends
 	 * on the umem_tx_abort() which may return 0 for vmem based case.
 	 */
-	vos_dtx_abort(args->ctx.tc_co_hdl, epoch, &xid, 1, false);
+	vos_dtx_abort(args->ctx.tc_co_hdl, epoch, &xid, 1);
 
 	memset(fetch_buf, 0, UPDATE_BUF_SIZE);
 	d_iov_set(&val_iov, fetch_buf, UPDATE_BUF_SIZE);
@@ -698,11 +698,11 @@ dtx_15(void **state)
 	vts_dtx_end(dth);
 
 	/* Aborted the update DTX. */
-	rc = vos_dtx_abort(args->ctx.tc_co_hdl, epoch, &xid, 1, false);
+	rc = vos_dtx_abort(args->ctx.tc_co_hdl, epoch, &xid, 1);
 	assert_int_equal(rc, 0);
 
 	/* Double aborted the DTX is harmless. */
-	vos_dtx_abort(args->ctx.tc_co_hdl, epoch, &xid, 1, false);
+	vos_dtx_abort(args->ctx.tc_co_hdl, epoch, &xid, 1);
 
 	memset(fetch_buf, 0, UPDATE_BUF_SIZE);
 	d_iov_set(&val_iov, fetch_buf, UPDATE_BUF_SIZE);
@@ -791,7 +791,7 @@ dtx_16(void **state)
 
 	/* Insert a DTX into CoS cache. */
 	rc = vos_dtx_add_cos(args->ctx.tc_co_hdl, &args->oid, &xid,
-			     dkey_hash, epoch, false, false);
+			     dkey_hash, epoch, 0, false, false);
 	assert_int_equal(rc, 0);
 
 	/* Fetch again. */
@@ -979,13 +979,14 @@ dtx_18(void **state)
 	rc = vos_dtx_commit(args->ctx.tc_co_hdl, xid, 10);
 	assert_int_equal(rc, 0);
 
-	/* Aggregate the first 4 DTXs. */
 	for (i = 0; i < 10; i++) {
 		rc = vos_dtx_check(args->ctx.tc_co_hdl, &xid[i]);
 		assert_int_equal(rc, DTX_ST_COMMITTED);
 	}
 
 	sleep(3);
+
+	/* Aggregate the first 4 DTXs. */
 	rc = vos_dtx_aggregate(args->ctx.tc_co_hdl, 4, 1);
 	assert_int_equal(rc, 0);
 
@@ -1124,14 +1125,14 @@ vts_dtx_shares(struct io_test_args *args, int *commit_list, int commit_count,
 		for (i = 0; i < abort_count; i++) {
 			rc = vos_dtx_abort(args->ctx.tc_co_hdl,
 					   epoch[abort_list[i]],
-					   &xid[abort_list[i]], 1, false);
+					   &xid[abort_list[i]], 1);
 			assert_int_equal(rc, 0);
 		}
 	} else {
 		for (i = 0; i < abort_count; i++) {
 			rc = vos_dtx_abort(args->ctx.tc_co_hdl,
 					   epoch[abort_list[i]],
-					   &xid[abort_list[i]], 1, false);
+					   &xid[abort_list[i]], 1);
 			assert_int_equal(rc, 0);
 		}
 
@@ -1396,14 +1397,13 @@ vts_dtx_shares_with_punch(struct io_test_args *args, bool punch_obj, bool abort)
 
 	/* Abort or commit the punch DTX. */
 	if (abort)
-		rc = vos_dtx_abort(args->ctx.tc_co_hdl, epoch[3], &xid[3], 1,
-				   false);
+		rc = vos_dtx_abort(args->ctx.tc_co_hdl, epoch[3], &xid[3], 1);
 	else
 		rc = vos_dtx_commit(args->ctx.tc_co_hdl, &xid[3], 1);
 	assert_int_equal(rc, 0);
 
 	/* Abort the first update DTX. */
-	rc = vos_dtx_abort(args->ctx.tc_co_hdl, epoch[0], &xid[0], 1, false);
+	rc = vos_dtx_abort(args->ctx.tc_co_hdl, epoch[0], &xid[0], 1);
 	assert_int_equal(rc, 0);
 
 	/* Commit the third update DTX. */

--- a/src/vos/vos_container.c
+++ b/src/vos/vos_container.c
@@ -100,6 +100,7 @@ cont_df_rec_alloc(struct btr_instance *tins, d_iov_t *key_iov,
 
 	cont_df = umem_off2ptr(&tins->ti_umm, offset);
 	uuid_copy(cont_df->cd_id, ukey->uuid);
+	cont_df->cd_dtx_resync_gen = 1;
 
 	rc = dbtree_create_inplace_ex(VOS_BTR_OBJ_TABLE, 0, VOS_OBJ_ORDER,
 				      &pool->vp_uma, &cont_df->cd_obj_root,
@@ -110,11 +111,15 @@ cont_df_rec_alloc(struct btr_instance *tins, d_iov_t *key_iov,
 	}
 	dbtree_close(hdl);
 
-	rc = vos_dtx_table_create(pool, &cont_df->cd_dtx_table_df);
+	rc = dbtree_create_inplace_ex(VOS_BTR_DTX_ACTIVE_TABLE, 0,
+				      DTX_BTREE_ORDER, &pool->vp_uma,
+				      &cont_df->cd_dtx_active,
+				      DAOS_HDL_INVAL, pool, &hdl);
 	if (rc) {
-		D_ERROR("Failed to create DTX table: rc = %d\n", rc);
+		D_ERROR("Failed to create active DTX table: rc = %d\n", rc);
 		D_GOTO(failed, rc);
 	}
+	dbtree_close(hdl);
 
 	args->ca_cont_df = cont_df;
 	rec->rec_off = offset;
@@ -197,9 +202,14 @@ cont_free(struct d_ulink *ulink)
 
 	if (!daos_handle_is_inval(cont->vc_dtx_cos_hdl))
 		dbtree_destroy(cont->vc_dtx_cos_hdl, NULL);
-	D_ASSERT(d_list_empty(&cont->vc_dtx_committable));
+	D_ASSERT(d_list_empty(&cont->vc_dtx_committable_list));
+
+	if (!daos_handle_is_inval(cont->vc_dtx_committed_hdl))
+		dbtree_destroy(cont->vc_dtx_committed_hdl, NULL);
+	D_ASSERT(d_list_empty(&cont->vc_dtx_committed_list));
+	D_ASSERT(d_list_empty(&cont->vc_dtx_committed_tmp_list));
+
 	dbtree_close(cont->vc_dtx_active_hdl);
-	dbtree_close(cont->vc_dtx_committed_hdl);
 	dbtree_close(cont->vc_btr_hdl);
 
 	for (i = 0; i < VOS_IOS_CNT; i++) {
@@ -363,9 +373,15 @@ vos_cont_open(daos_handle_t poh, uuid_t co_uuid, daos_handle_t *coh)
 	uuid_copy(cont->vc_id, co_uuid);
 	cont->vc_pool	 = pool;
 	cont->vc_cont_df = args.ca_cont_df;
+	cont->vc_dtx_committed_hdl = DAOS_HDL_INVAL;
 	cont->vc_dtx_cos_hdl = DAOS_HDL_INVAL;
-	D_INIT_LIST_HEAD(&cont->vc_dtx_committable);
+	D_INIT_LIST_HEAD(&cont->vc_dtx_committable_list);
+	D_INIT_LIST_HEAD(&cont->vc_dtx_committed_list);
+	D_INIT_LIST_HEAD(&cont->vc_dtx_committed_tmp_list);
 	cont->vc_dtx_committable_count = 0;
+	cont->vc_dtx_committed_count = 0;
+	cont->vc_dtx_committed_tmp_count = 0;
+	cont->vc_dtx_resync_gen = cont->vc_cont_df->cd_dtx_resync_gen;
 
 	/* Cache this btr object ID in container handle */
 	rc = dbtree_open_inplace_ex(&cont->vc_cont_df->cd_obj_root,
@@ -376,17 +392,8 @@ vos_cont_open(daos_handle_t poh, uuid_t co_uuid, daos_handle_t *coh)
 		D_GOTO(exit, rc);
 	}
 
-	rc = dbtree_open_inplace(
-			&cont->vc_cont_df->cd_dtx_table_df.tt_committed_btr,
-			&pool->vp_uma, &cont->vc_dtx_committed_hdl);
-	if (rc) {
-		D_ERROR("Failed to open committed DTX table: rc = %d\n", rc);
-		D_GOTO(exit, rc);
-	}
-
-	rc = dbtree_open_inplace(
-			&cont->vc_cont_df->cd_dtx_table_df.tt_active_btr,
-			&pool->vp_uma, &cont->vc_dtx_active_hdl);
+	rc = dbtree_open_inplace(&cont->vc_cont_df->cd_dtx_active,
+				 &pool->vp_uma, &cont->vc_dtx_active_hdl);
 	if (rc) {
 		D_ERROR("Failed to open active DTX table: rc = %d\n", rc);
 		D_GOTO(exit, rc);
@@ -394,10 +401,19 @@ vos_cont_open(daos_handle_t poh, uuid_t co_uuid, daos_handle_t *coh)
 
 	memset(&uma, 0, sizeof(uma));
 	uma.uma_id = UMEM_CLASS_VMEM;
-	memset(&cont->vc_dtx_cos_btr, 0, sizeof(cont->vc_dtx_cos_btr));
-	rc = dbtree_create_inplace(VOS_BTR_DTX_COS, 0, VOS_CONT_ORDER, &uma,
-				   &cont->vc_dtx_cos_btr,
-				   &cont->vc_dtx_cos_hdl);
+	rc = dbtree_create_inplace_ex(VOS_BTR_DTX_COMMITTED_TABLE, 0,
+				      DTX_BTREE_ORDER, &uma,
+				      &cont->vc_dtx_committed_btr,
+				      DAOS_HDL_INVAL, cont,
+				      &cont->vc_dtx_committed_hdl);
+	if (rc != 0) {
+		D_ERROR("Failed to create DTX committed btree: rc = %d\n", rc);
+		D_GOTO(exit, rc);
+	}
+
+	rc = dbtree_create_inplace_ex(VOS_BTR_DTX_COS, 0, DTX_BTREE_ORDER, &uma,
+				      &cont->vc_dtx_cos_btr, DAOS_HDL_INVAL,
+				      cont, &cont->vc_dtx_cos_hdl);
 	if (rc != 0) {
 		D_ERROR("Failed to create DTX CoS btree: rc = %d\n", rc);
 		D_GOTO(exit, rc);
@@ -521,6 +537,7 @@ int
 vos_cont_destroy(daos_handle_t poh, uuid_t co_uuid)
 {
 
+	daos_handle_t		 hdl;
 	struct vos_pool		*pool;
 	struct vos_container	*cont;
 	struct cont_df_args	 args;
@@ -571,6 +588,18 @@ vos_cont_destroy(daos_handle_t poh, uuid_t co_uuid)
 		D_GOTO(exit, rc);
 	}
 
+	rc = dbtree_open_inplace(&args.ca_cont_df->cd_dtx_active,
+				 &pool->vp_uma, &hdl);
+	if (rc == 0)
+		rc = dbtree_destroy(hdl, NULL);
+
+	if (rc != 0 && rc != -DER_NONEXIST) {
+		D_ERROR("Failed to destroy active DTX table: rc = %d\n", rc);
+		rc = vos_tx_end(pool, rc);
+
+		D_GOTO(exit, rc);
+	}
+
 	d_iov_set(&iov, &key, sizeof(struct d_uuid));
 	rc = dbtree_delete(pool->vp_cont_th, BTR_PROBE_EQ, &iov, NULL);
 
@@ -613,6 +642,31 @@ vos_cont_tab_register()
 	rc = dbtree_class_register(VOS_BTR_CONT_TABLE, 0, &vct_ops);
 	if (rc)
 		D_ERROR("dbtree create failed\n");
+	return rc;
+}
+
+int
+vos_dtx_update_resync_gen(daos_handle_t coh)
+{
+	struct vos_container	*cont;
+	struct vos_cont_df	*cont_df;
+	int			 rc;
+
+	cont = vos_hdl2cont(coh);
+	D_ASSERT(cont != NULL);
+
+	cont_df = cont->vc_cont_df;
+	rc = vos_tx_begin(cont->vc_pool);
+	if (rc == 0) {
+		umem_tx_add_ptr(&cont->vc_pool->vp_umm,
+				&cont_df->cd_dtx_resync_gen,
+				sizeof(cont_df->cd_dtx_resync_gen));
+		cont_df->cd_dtx_resync_gen++;
+		rc = vos_tx_end(cont->vc_pool, rc);
+		if (rc == 0)
+			cont->vc_dtx_resync_gen = cont_df->cd_dtx_resync_gen;
+	}
+
 	return rc;
 }
 

--- a/src/vos/vos_dtx.c
+++ b/src/vos/vos_dtx.c
@@ -37,6 +37,30 @@
 /* Dummy offset for some unknown DTX address. */
 #define DTX_UMOFF_UNKNOWN		2
 
+#define DTX_COMMITTED_BLOB_SIZE	(1 << 20)
+
+/* Committed DTX entry on-disk layout */
+struct dtx_committed_df {
+	/* 64-bits * 3 */
+	struct dtx_id	dcd_xid;
+	/* 64-bits * 1 */
+	daos_epoch_t	dcd_epoch;
+};
+
+struct dtx_committed_blob {
+	/* The total (filled + free) slots in the blob. */
+	int				dcb_cap;
+	/* Already filled slots count. */
+	int				dcb_count;
+	/* The first valid DTX entry index in the blob. */
+	int				dcb_first;
+	/* For 64-bits alignment. */
+	int				dcb_pad;
+	/* Next dtx_committed_blob. */
+	umem_off_t			dcb_next;
+	struct dtx_committed_df		dcb_data[0];
+};
+
 static inline bool
 dtx_is_aborted(umem_off_t umoff)
 {
@@ -65,9 +89,8 @@ static inline int
 dtx_inprogress(struct vos_dtx_entry_df *dtx, int pos)
 {
 	if (dtx != NULL)
-		D_DEBUG(DB_TRACE, "Hit uncommitted DTX "DF_DTI
-			" with state %u at %d\n",
-			DP_DTI(&dtx->te_xid), dtx->te_state, pos);
+		D_DEBUG(DB_TRACE, "Hit uncommitted DTX "DF_DTI" at %d\n",
+			DP_DTI(&dtx->te_xid), pos);
 	else
 		D_DEBUG(DB_TRACE, "Hit uncommitted (unknown) DTX at %d\n", pos);
 
@@ -114,8 +137,8 @@ dtx_hkey_cmp(struct btr_instance *tins, struct btr_record *rec, void *hkey)
 }
 
 static int
-dtx_rec_alloc(struct btr_instance *tins, d_iov_t *key_iov,
-	      d_iov_t *val_iov, struct btr_record *rec)
+dtx_active_rec_alloc(struct btr_instance *tins, d_iov_t *key_iov,
+		     d_iov_t *val_iov, struct btr_record *rec)
 {
 	struct dtx_rec_bundle	*rbund;
 
@@ -129,7 +152,8 @@ dtx_rec_alloc(struct btr_instance *tins, d_iov_t *key_iov,
 }
 
 static int
-dtx_rec_free(struct btr_instance *tins, struct btr_record *rec, void *args)
+dtx_active_rec_free(struct btr_instance *tins, struct btr_record *rec,
+		    void *args)
 {
 	D_ASSERT(!UMOFF_IS_NULL(rec->rec_off));
 
@@ -156,8 +180,8 @@ dtx_rec_free(struct btr_instance *tins, struct btr_record *rec, void *args)
 }
 
 static int
-dtx_rec_fetch(struct btr_instance *tins, struct btr_record *rec,
-	      d_iov_t *key_iov, d_iov_t *val_iov)
+dtx_active_rec_fetch(struct btr_instance *tins, struct btr_record *rec,
+		     d_iov_t *key_iov, d_iov_t *val_iov)
 {
 	struct vos_dtx_entry_df	*dtx;
 
@@ -169,116 +193,114 @@ dtx_rec_fetch(struct btr_instance *tins, struct btr_record *rec,
 }
 
 static int
-dtx_rec_update(struct btr_instance *tins, struct btr_record *rec,
-	       d_iov_t *key, d_iov_t *val)
+dtx_active_rec_update(struct btr_instance *tins, struct btr_record *rec,
+		      d_iov_t *key, d_iov_t *val)
 {
 	D_ASSERTF(0, "Should never been called\n");
 	return 0;
 }
 
-static btr_ops_t dtx_btr_ops = {
+static btr_ops_t dtx_active_btr_ops = {
 	.to_hkey_size	= dtx_hkey_size,
 	.to_hkey_gen	= dtx_hkey_gen,
 	.to_hkey_cmp	= dtx_hkey_cmp,
-	.to_rec_alloc	= dtx_rec_alloc,
-	.to_rec_free	= dtx_rec_free,
-	.to_rec_fetch	= dtx_rec_fetch,
-	.to_rec_update	= dtx_rec_update,
+	.to_rec_alloc	= dtx_active_rec_alloc,
+	.to_rec_free	= dtx_active_rec_free,
+	.to_rec_fetch	= dtx_active_rec_fetch,
+	.to_rec_update	= dtx_active_rec_update,
 };
 
-#define DTX_BTREE_ORDER		20
+struct dtx_committed_rec {
+	struct dtx_id	dcr_xid;
+	daos_epoch_t	dcr_epoch;
+	d_list_t	dcr_link;
+	bool		dcr_reindex;
+};
+
+static int
+dtx_committed_rec_alloc(struct btr_instance *tins, d_iov_t *key_iov,
+			d_iov_t *val_iov, struct btr_record *rec)
+{
+	struct vos_container		*cont = tins->ti_priv;
+	struct dtx_committed_rec	*dcr = val_iov->iov_buf;
+
+	rec->rec_off = umem_ptr2off(&tins->ti_umm, dcr);
+	if (cont->vc_reindex_dtx && !dcr->dcr_reindex) {
+		d_list_add_tail(&dcr->dcr_link,
+				&cont->vc_dtx_committed_tmp_list);
+		cont->vc_dtx_committed_tmp_count++;
+	} else {
+		d_list_add_tail(&dcr->dcr_link, &cont->vc_dtx_committed_list);
+		cont->vc_dtx_committed_count++;
+	}
+
+	return 0;
+}
+
+static int
+dtx_committed_rec_free(struct btr_instance *tins, struct btr_record *rec,
+		       void *args)
+{
+	struct vos_container		*cont = tins->ti_priv;
+	struct dtx_committed_rec	*dcr;
+
+	D_ASSERT(!UMOFF_IS_NULL(rec->rec_off));
+
+	dcr = umem_off2ptr(&tins->ti_umm, rec->rec_off);
+	d_list_del(&dcr->dcr_link);
+	if (cont->vc_reindex_dtx && !dcr->dcr_reindex)
+		cont->vc_dtx_committed_tmp_count--;
+	else
+		cont->vc_dtx_committed_count--;
+	D_FREE(dcr);
+
+	return 0;
+}
+
+static int
+dtx_committed_rec_fetch(struct btr_instance *tins, struct btr_record *rec,
+			d_iov_t *key_iov, d_iov_t *val_iov)
+{
+	return 0;
+}
+
+static int
+dtx_committed_rec_update(struct btr_instance *tins, struct btr_record *rec,
+			 d_iov_t *key, d_iov_t *val)
+{
+	struct dtx_committed_rec	*dcr = val->iov_buf;
+
+	D_ASSERT(dcr->dcr_reindex);
+	dcr->dcr_reindex = false;
+	return 0;
+}
+
+static btr_ops_t dtx_committed_btr_ops = {
+	.to_hkey_size	= dtx_hkey_size,
+	.to_hkey_gen	= dtx_hkey_gen,
+	.to_hkey_cmp	= dtx_hkey_cmp,
+	.to_rec_alloc	= dtx_committed_rec_alloc,
+	.to_rec_free	= dtx_committed_rec_free,
+	.to_rec_fetch	= dtx_committed_rec_fetch,
+	.to_rec_update	= dtx_committed_rec_update,
+};
 
 int
 vos_dtx_table_register(void)
 {
 	int	rc;
 
-	D_DEBUG(DB_DF, "Registering DTX table class: %d\n", VOS_BTR_DTX_TABLE);
+	rc = dbtree_class_register(VOS_BTR_DTX_ACTIVE_TABLE, 0,
+				   &dtx_active_btr_ops);
+	if (rc != 0) {
+		D_ERROR("Failed to register DTX active dbtree: %d\n", rc);
+		return rc;
+	}
 
-	rc = dbtree_class_register(VOS_BTR_DTX_TABLE, 0, &dtx_btr_ops);
+	rc = dbtree_class_register(VOS_BTR_DTX_COMMITTED_TABLE, 0,
+				   &dtx_committed_btr_ops);
 	if (rc != 0)
-		D_ERROR("Failed to register DTX dbtree: rc = %d\n", rc);
-
-	return rc;
-}
-
-int
-vos_dtx_table_create(struct vos_pool *pool, struct vos_dtx_table_df *dtab_df)
-{
-	daos_handle_t	hdl;
-	int		rc;
-
-	if (pool == NULL || dtab_df == NULL) {
-		D_ERROR("Invalid handle\n");
-		return -DER_INVAL;
-	}
-
-	D_ASSERT(dtab_df->tt_active_btr.tr_class == 0);
-	D_ASSERT(dtab_df->tt_committed_btr.tr_class == 0);
-
-	D_DEBUG(DB_DF, "create DTX dbtree in-place for pool "DF_UUID": %d\n",
-		DP_UUID(pool->vp_id), VOS_BTR_DTX_TABLE);
-
-	rc = dbtree_create_inplace(VOS_BTR_DTX_TABLE, 0,
-				   DTX_BTREE_ORDER, &pool->vp_uma,
-				   &dtab_df->tt_active_btr, &hdl);
-	if (rc != 0) {
-		D_ERROR("Failed to create DTX active dbtree for pool "
-			DF_UUID": rc = %d\n", DP_UUID(pool->vp_id), rc);
-		return rc;
-	}
-
-	dbtree_close(hdl);
-
-	rc = dbtree_create_inplace(VOS_BTR_DTX_TABLE, 0,
-				   DTX_BTREE_ORDER, &pool->vp_uma,
-				   &dtab_df->tt_committed_btr, &hdl);
-	if (rc != 0) {
-		D_ERROR("Failed to create DTX committed dbtree for pool "
-			DF_UUID": rc = %d\n", DP_UUID(pool->vp_id), rc);
-		return rc;
-	}
-
-	dtab_df->tt_count = 0;
-	dtab_df->tt_entry_head = UMOFF_NULL;
-	dtab_df->tt_entry_tail = UMOFF_NULL;
-
-	dbtree_close(hdl);
-	return 0;
-}
-
-int
-vos_dtx_table_destroy(struct vos_pool *pool, struct vos_dtx_table_df *dtab_df)
-{
-	daos_handle_t	hdl;
-	int		rc = 0;
-
-	if (pool == NULL || dtab_df == NULL) {
-		D_ERROR("Invalid handle\n");
-		return -DER_INVAL;
-	}
-
-	if (dtab_df->tt_active_btr.tr_class != 0) {
-		rc = dbtree_open_inplace(&dtab_df->tt_active_btr,
-					 &pool->vp_uma, &hdl);
-		if (rc == 0)
-			rc = dbtree_destroy(hdl, NULL);
-
-		if (rc != 0)
-			D_ERROR("Fail to destroy DTX active dbtree for pool"
-				DF_UUID": rc = %d\n", DP_UUID(pool->vp_id), rc);
-	}
-
-	if (dtab_df->tt_committed_btr.tr_class != 0) {
-		rc = dbtree_open_inplace(&dtab_df->tt_committed_btr,
-					 &pool->vp_uma, &hdl);
-		if (rc == 0)
-			rc = dbtree_destroy(hdl, NULL);
-
-		if (rc != 0)
-			D_ERROR("Fail to destroy DTX committed dbtree for pool"
-				DF_UUID": rc = %d\n", DP_UUID(pool->vp_id), rc);
-	}
+		D_ERROR("Failed to register DTX committed dbtree: %d\n", rc);
 
 	return rc;
 }
@@ -646,14 +668,11 @@ dtx_key_rec_release(struct umem_instance *umm, struct vos_krec_df *key,
 
 static void
 dtx_rec_release(struct umem_instance *umm, umem_off_t umoff,
-		bool abort, bool destroy, bool logged)
+		bool abort, bool destroy)
 {
 	struct vos_dtx_entry_df		*dtx;
 
 	dtx = umem_off2ptr(umm, umoff);
-	if (!logged)
-		umem_tx_add_ptr(umm, dtx, sizeof(*dtx));
-
 	while (!dtx_is_null(dtx->te_records)) {
 		umem_off_t			 rec_umoff = dtx->te_records;
 		struct vos_dtx_record_df	*rec;
@@ -664,7 +683,8 @@ dtx_rec_release(struct umem_instance *umm, umem_off_t umoff,
 			struct vos_obj_df	*obj;
 
 			obj = umem_off2ptr(umm, rec->tr_record);
-			umem_tx_add_ptr(umm, obj, sizeof(*obj));
+			umem_tx_add_ptr(umm, &obj->vo_dtx,
+					VOS_OBJ_SIZE_PARTIAL);
 			dtx_obj_rec_release(umm, obj, rec, umoff, abort);
 			break;
 		}
@@ -672,7 +692,8 @@ dtx_rec_release(struct umem_instance *umm, umem_off_t umoff,
 			struct vos_krec_df	*key;
 
 			key = umem_off2ptr(umm, rec->tr_record);
-			umem_tx_add_ptr(umm, key, sizeof(*key));
+			umem_tx_add_ptr(umm, &key->kr_dtx,
+					VOS_KEY_SIZE_PARTIAL);
 			dtx_key_rec_release(umm, key, rec, umoff, abort);
 			break;
 		}
@@ -709,107 +730,69 @@ dtx_rec_release(struct umem_instance *umm, umem_off_t umoff,
 		umem_free(umm, rec_umoff);
 	}
 
-	D_DEBUG(DB_TRACE, "dtx_rec_release: %s/%s the DTX "DF_DTI"\n",
-		abort ? "abort" : "commit", destroy ? "destroy" : "keep",
-		DP_DTI(&dtx->te_xid));
-
 	if (destroy)
 		umem_free(umm, umoff);
 	else
 		dtx->te_flags &= ~(DTX_EF_EXCHANGE_PENDING | DTX_EF_SHARES);
 }
 
-static void
-vos_dtx_unlink_entry(struct umem_instance *umm, struct vos_dtx_table_df *tab,
-		     struct vos_dtx_entry_df *dtx)
-{
-	struct vos_dtx_entry_df	*ent;
-
-	if (dtx_is_null(dtx->te_next)) { /* The tail of the DTXs list. */
-		if (dtx_is_null(dtx->te_prev)) { /* The unique one on list. */
-			tab->tt_entry_head = UMOFF_NULL;
-			tab->tt_entry_tail = UMOFF_NULL;
-		} else {
-			ent = umem_off2ptr(umm, dtx->te_prev);
-			umem_tx_add_ptr(umm, &ent->te_next,
-					sizeof(ent->te_next));
-			ent->te_next = UMOFF_NULL;
-			tab->tt_entry_tail = dtx->te_prev;
-			dtx->te_prev = UMOFF_NULL;
-		}
-	} else if (dtx_is_null(dtx->te_prev)) { /* The head of DTXs list */
-		ent = umem_off2ptr(umm, dtx->te_next);
-		umem_tx_add_ptr(umm, &ent->te_prev, sizeof(ent->te_prev));
-		ent->te_prev = UMOFF_NULL;
-		tab->tt_entry_head = dtx->te_next;
-		dtx->te_next = UMOFF_NULL;
-	} else {
-		ent = umem_off2ptr(umm, dtx->te_next);
-		umem_tx_add_ptr(umm, &ent->te_prev, sizeof(ent->te_prev));
-		ent->te_prev = dtx->te_prev;
-
-		ent = umem_off2ptr(umm, dtx->te_prev);
-		umem_tx_add_ptr(umm, &ent->te_next, sizeof(ent->te_next));
-		ent->te_next = dtx->te_next;
-
-		dtx->te_prev = UMOFF_NULL;
-		dtx->te_next = UMOFF_NULL;
-	}
-}
-
 static int
-vos_dtx_commit_one(struct vos_container *cont, struct dtx_id *dti)
+vos_dtx_commit_one(struct vos_container *cont, struct dtx_id *dti,
+		   umem_off_t umoff)
 {
 	struct umem_instance		*umm = &cont->vc_pool->vp_umm;
+	struct dtx_committed_rec	*dcr = NULL;
 	struct vos_dtx_entry_df		*dtx;
-	struct vos_dtx_entry_df		*ent;
-	struct vos_dtx_table_df		*tab;
-	struct dtx_rec_bundle		 rbund;
-	d_iov_t			 kiov;
-	d_iov_t			 riov;
-	umem_off_t			 umoff;
+	struct dtx_committed_blob	*dcb;
+	d_iov_t				 kiov;
+	d_iov_t				 riov;
 	int				 rc = 0;
+	bool				 drop_cos = false;
 
 	d_iov_set(&kiov, dti, sizeof(*dti));
-	rc = dbtree_delete(cont->vc_dtx_active_hdl, BTR_PROBE_EQ,
-			   &kiov, &umoff);
-	if (rc == -DER_NONEXIST) {
-		d_iov_set(&riov, NULL, 0);
-		rc = dbtree_lookup(cont->vc_dtx_committed_hdl, &kiov, &riov);
-		goto out;
+	if (dtx_is_null(umoff)) {
+		rc = dbtree_delete(cont->vc_dtx_active_hdl, BTR_PROBE_EQ,
+				   &kiov, &umoff);
+		if (rc == -DER_NONEXIST) {
+			d_iov_set(&riov, NULL, 0);
+			rc = dbtree_lookup(cont->vc_dtx_committed_hdl,
+					   &kiov, NULL);
+			goto out;
+		}
+
+		if (rc != 0)
+			goto out;
+
+		drop_cos = true;
 	}
 
-	if (rc != 0)
-		goto out;
-
 	dtx = umem_off2ptr(umm, umoff);
-	umem_tx_add_ptr(umm, dtx, sizeof(*dtx));
 
-	dtx->te_state = DTX_ST_COMMITTED;
-	rbund.trb_umoff = umoff;
-	d_iov_set(&riov, &rbund, sizeof(rbund));
+	D_ALLOC_PTR(dcr);
+	if (dcr == NULL)
+		D_GOTO(out, rc = -DER_NOMEM);
+
+	dcr->dcr_xid = *dti;
+	dcr->dcr_epoch = dtx->te_epoch;
+	dcr->dcr_reindex = false;
+
+	d_iov_set(&riov, dcr, sizeof(*dcr));
 	rc = dbtree_upsert(cont->vc_dtx_committed_hdl, BTR_PROBE_EQ,
 			   DAOS_INTENT_UPDATE, &kiov, &riov);
 	if (rc != 0)
 		goto out;
 
-	tab = &cont->vc_cont_df->cd_dtx_table_df;
-	umem_tx_add_ptr(umm, tab, sizeof(*tab));
+	dcb = umem_off2ptr(umm, cont->vc_cont_df->cd_dtx_committed_tail);
+	D_ASSERT(dcb->dcb_count < dcb->dcb_cap);
 
-	tab->tt_count++;
-	if (dtx_is_null(tab->tt_entry_tail)) {
-		D_ASSERT(dtx_is_null(tab->tt_entry_head));
+	dcb->dcb_data[dcb->dcb_count].dcd_xid = *dti;
+	dcb->dcb_data[dcb->dcb_count].dcd_epoch = dtx->te_epoch;
+	dcb->dcb_count++;
 
-		tab->tt_entry_head = umoff;
-		tab->tt_entry_tail = tab->tt_entry_head;
-	} else {
-		ent = umem_off2ptr(umm, tab->tt_entry_tail);
-		umem_tx_add_ptr(umm, &ent->te_next, sizeof(ent->te_next));
-
-		ent->te_next = umoff;
-		dtx->te_prev = tab->tt_entry_tail;
-		tab->tt_entry_tail = ent->te_next;
-	}
+	if (drop_cos)
+		/* For single participator case, the DTX is not in COS cache. */
+		vos_dtx_del_cos(cont, &dtx->te_oid, dti, dtx->te_dkey_hash,
+			dtx->te_intent == DAOS_INTENT_PUNCH ? true : false);
 
 	/* XXX: Only mark the DTX as DTX_ST_COMMITTED (when commit) is not
 	 *	enough. Otherwise, some subsequent modification may change
@@ -817,20 +800,20 @@ vos_dtx_commit_one(struct vos_container *cont, struct dtx_id *dti)
 	 *	record as to the current DTX will have invalid reference(s)
 	 *	via its DTX record(s).
 	 */
-	dtx_rec_release(umm, umoff, false, false, true);
-	vos_dtx_del_cos(cont, &dtx->te_oid, dti, dtx->te_dkey_hash,
-			dtx->te_intent == DAOS_INTENT_PUNCH ? true : false);
+	dtx_rec_release(umm, umoff, false, true);
 
 out:
 	D_DEBUG(DB_TRACE, "Commit the DTX "DF_DTI": rc = %d\n",
 		DP_DTI(dti), rc);
+	if (rc != 0)
+		D_FREE(dcr);
 
 	return rc;
 }
 
 static int
 vos_dtx_abort_one(struct vos_container *cont, daos_epoch_t epoch,
-		  struct dtx_id *dti, bool force)
+		  struct dtx_id *dti)
 {
 	d_iov_t			kiov;
 	umem_off_t		off;
@@ -856,13 +839,10 @@ vos_dtx_abort_one(struct vos_container *cont, daos_epoch_t epoch,
 
 	rc = dbtree_delete(cont->vc_dtx_active_hdl, opc, &kiov, &off);
 	if (rc == 0)
-		dtx_rec_release(&cont->vc_pool->vp_umm, off, true, true, false);
+		dtx_rec_release(&cont->vc_pool->vp_umm, off, true, true);
 
 out:
 	D_DEBUG(DB_TRACE, "Abort the DTX "DF_DTI": rc = %d\n", DP_DTI(dti), rc);
-
-	if (rc != 0 && force)
-		rc = 0;
 
 	return rc;
 }
@@ -879,18 +859,17 @@ vos_dtx_is_normal_entry(struct umem_instance *umm, umem_off_t entry)
 
 static int
 vos_dtx_alloc(struct umem_instance *umm, struct dtx_handle *dth,
-	      umem_off_t rec_umoff, struct vos_dtx_entry_df **dtxp)
+	      struct vos_dtx_entry_df **dtxp)
 {
 	struct vos_dtx_entry_df	*dtx;
 	struct vos_container	*cont;
 	umem_off_t		 dtx_umoff;
-	d_iov_t		 kiov;
-	d_iov_t		 riov;
 	struct dtx_rec_bundle	 rbund;
-	int			 rc;
 
 	cont = vos_hdl2cont(dth->dth_coh);
 	D_ASSERT(cont != NULL);
+
+	dth->dth_gen = cont->vc_dtx_resync_gen;
 
 	dtx_umoff = umem_zalloc(umm, sizeof(struct vos_dtx_entry_df));
 	if (dtx_is_null(dtx_umoff))
@@ -902,32 +881,42 @@ vos_dtx_alloc(struct umem_instance *umm, struct dtx_handle *dth,
 	dtx->te_dkey_hash = dth->dth_dkey_hash;
 	dtx->te_epoch = dth->dth_epoch;
 	dtx->te_ver = dth->dth_ver;
-	dtx->te_state = DTX_ST_PREPARED;
 	dtx->te_flags = dth->dth_leader ? DTX_EF_LEADER : 0;
 	dtx->te_intent = dth->dth_intent;
-	dtx->te_time = crt_hlc_get();
-	dtx->te_records = rec_umoff;
-	dtx->te_next = UMOFF_NULL;
-	dtx->te_prev = UMOFF_NULL;
+	dtx->te_gen = dth->dth_gen;
+	dtx->te_records = UMOFF_NULL;
 
-	rbund.trb_umoff = dtx_umoff;
-	d_iov_set(&riov, &rbund, sizeof(rbund));
-	d_iov_set(&kiov, &dth->dth_xid, sizeof(dth->dth_xid));
-	rc = dbtree_upsert(cont->vc_dtx_active_hdl, BTR_PROBE_EQ,
-			   DAOS_INTENT_UPDATE, &kiov, &riov);
-	if (rc == 0) {
-		dth->dth_ent = dtx_umoff;
-		*dtxp = dtx;
+	/* For single participator case, the DTX will be committed immediately
+	 * just after the local modification done. So it is unnecessary to add
+	 * the DTX into the active DTX table and be remove very soon, instead,
+	 * it will be directly inserted into committed DTX table when commit.
+	 */
+	if (!dth->dth_single_participator) {
+		d_iov_t		kiov;
+		d_iov_t		riov;
+		int		rc;
+
+		rbund.trb_umoff = dtx_umoff;
+		d_iov_set(&riov, &rbund, sizeof(rbund));
+		d_iov_set(&kiov, &dth->dth_xid, sizeof(dth->dth_xid));
+		rc = dbtree_upsert(cont->vc_dtx_active_hdl, BTR_PROBE_EQ,
+				   DAOS_INTENT_UPDATE, &kiov, &riov);
+		if (rc != 0)
+			return rc;
 	}
 
-	return rc;
+	dth->dth_ent = dtx_umoff;
+	*dtxp = dtx;
+
+	return 0;
 }
 
-static void
+static int
 vos_dtx_append(struct umem_instance *umm, struct dtx_handle *dth,
-	       umem_off_t rec_umoff, umem_off_t record, uint32_t type,
-	       uint32_t flags, struct vos_dtx_entry_df **dtxp)
+	       umem_off_t record, uint32_t type, uint32_t flags,
+	       struct vos_dtx_entry_df **dtxp)
 {
+	umem_off_t			 rec_umoff;
 	struct vos_dtx_entry_df		*dtx;
 	struct vos_dtx_record_df	*rec;
 	struct vos_dtx_record_df	*tgt;
@@ -936,14 +925,22 @@ vos_dtx_append(struct umem_instance *umm, struct dtx_handle *dth,
 	 * vos_dtx_register_record(), no need umem_tx_add_ptr().
 	 */
 	dtx = umem_off2ptr(umm, dth->dth_ent);
-	dtx->te_time = crt_hlc_get();
+
+	rec_umoff = umem_zalloc(umm, sizeof(struct vos_dtx_record_df));
+	if (dtx_is_null(rec_umoff))
+		return -DER_NOSPACE;
+
 	rec = umem_off2ptr(umm, rec_umoff);
+	rec->tr_type = type;
+	rec->tr_flags = flags;
+	rec->tr_record = record;
 	rec->tr_next = dtx->te_records;
+
 	dtx->te_records = rec_umoff;
 	*dtxp = dtx;
 
 	if (flags == 0)
-		return;
+		return 0;
 
 	/*
 	 * XXX: Currently, we only support DTX_RF_EXCHANGE_SRC when register
@@ -967,16 +964,20 @@ vos_dtx_append(struct umem_instance *umm, struct dtx_handle *dth,
 		struct vos_obj_df	*obj;
 
 		obj = umem_off2ptr(umm, record);
+		umem_tx_add_ptr(umm, &obj->vo_oi_attr, sizeof(obj->vo_oi_attr));
 		obj->vo_oi_attr |= VOS_OI_REMOVED;
 	} else {
 		struct vos_krec_df	*key;
 
 		key = umem_off2ptr(umm, record);
+		umem_tx_add_ptr(umm, &key->kr_bmap, sizeof(key->kr_bmap));
 		key->kr_bmap |= KREC_BF_REMOVED;
 	}
 
 	D_DEBUG(DB_TRACE, "Register exchange source for %s DTX "DF_DTI"\n",
 		type == DTX_RT_OBJ ? "OBJ" : "KEY", DP_DTI(&dtx->te_xid));
+
+	return 0;
 }
 
 static int
@@ -1018,13 +1019,13 @@ vos_dtx_share_obj(struct umem_instance *umm, struct dtx_handle *dth,
 
 	rc = vos_dtx_append_share(umm, dtx, dts);
 	if (rc != 0) {
-		D_DEBUG(DB_TRACE, "The DTX "DF_DTI" failed to shares obj "
+		D_ERROR("The DTX "DF_DTI" failed to shares obj "
 			"with others:: rc = %d\n",
 			DP_DTI(&dth->dth_xid), rc);
 		return rc;
 	}
 
-	umem_tx_add_ptr(umm, obj, sizeof(*obj));
+	umem_tx_add_ptr(umm, &obj->vo_dtx_shares, sizeof(obj->vo_dtx_shares));
 
 	/* The to be shared obj has been aborted, reuse it. */
 	if (dtx_is_aborted(obj->vo_dtx)) {
@@ -1045,6 +1046,7 @@ vos_dtx_share_obj(struct umem_instance *umm, struct dtx_handle *dth,
 		D_DEBUG(DB_TRACE, "The DTX "DF_DTI" shares obj "
 			"with unknown DTXs, shares count %u.\n",
 			DP_DTI(&dth->dth_xid), obj->vo_dtx_shares);
+		umem_tx_add_ptr(umm, &obj->vo_dtx, sizeof(obj->vo_dtx));
 		obj->vo_dtx = dth->dth_ent;
 		return 0;
 	}
@@ -1053,11 +1055,8 @@ vos_dtx_share_obj(struct umem_instance *umm, struct dtx_handle *dth,
 
 	sh_dtx = umem_off2ptr(umm, obj->vo_dtx);
 	D_ASSERT(dtx != sh_dtx);
-	D_ASSERTF(sh_dtx->te_state == DTX_ST_PREPARED,
-		  "Invalid shared obj DTX state: %u\n",
-		  sh_dtx->te_state);
 
-	umem_tx_add_ptr(umm, sh_dtx, sizeof(*sh_dtx));
+	umem_tx_add_ptr(umm, &sh_dtx->te_flags, sizeof(sh_dtx->te_flags));
 	sh_dtx->te_flags |= DTX_EF_SHARES;
 
 	D_DEBUG(DB_TRACE, "The DTX "DF_DTI" try to shares obj "DF_X64
@@ -1077,16 +1076,30 @@ vos_dtx_share_key(struct umem_instance *umm, struct dtx_handle *dth,
 	struct vos_dtx_entry_df	*sh_dtx;
 	int			 rc;
 
+	key = umem_off2ptr(umm, dts->dts_record);
+	/* The to be shared key has been committed. */
+	if (dtx_is_null(key->kr_dtx))
+		return 0;
+
 	rc = vos_dtx_append_share(umm, dtx, dts);
 	if (rc != 0) {
-		D_DEBUG(DB_TRACE, "The DTX "DF_DTI" failed to shares key "
+		D_ERROR("The DTX "DF_DTI" failed to shares key "
 			"with others:: rc = %d\n",
 			DP_DTI(&dth->dth_xid), rc);
 		return rc;
 	}
 
-	key = umem_off2ptr(umm, dts->dts_record);
-	umem_tx_add_ptr(umm, key, sizeof(*key));
+	umem_tx_add_ptr(umm, &key->kr_dtx_shares, sizeof(key->kr_dtx_shares));
+
+	/* The to be shared key has been aborted, reuse it. */
+	if (dtx_is_aborted(key->kr_dtx)) {
+		D_ASSERTF(key->kr_dtx_shares == 0,
+			  "Invalid shared key DTX shares %d\n",
+			  key->kr_dtx_shares);
+		key->kr_dtx_shares = 1;
+		return 0;
+	}
+
 	key->kr_dtx_shares++;
 	*shared = true;
 
@@ -1097,6 +1110,7 @@ vos_dtx_share_key(struct umem_instance *umm, struct dtx_handle *dth,
 		D_DEBUG(DB_TRACE, "The DTX "DF_DTI" shares key "
 			"with unknown DTXs, shares count %u.\n",
 			DP_DTI(&dth->dth_xid), key->kr_dtx_shares);
+		umem_tx_add_ptr(umm, &key->kr_dtx, sizeof(key->kr_dtx));
 		key->kr_dtx = dth->dth_ent;
 		return 0;
 	}
@@ -1105,11 +1119,8 @@ vos_dtx_share_key(struct umem_instance *umm, struct dtx_handle *dth,
 
 	sh_dtx = umem_off2ptr(umm, key->kr_dtx);
 	D_ASSERT(dtx != sh_dtx);
-	D_ASSERTF(sh_dtx->te_state == DTX_ST_PREPARED,
-		  "Invalid shared key DTX state: %u\n",
-		  sh_dtx->te_state);
 
-	umem_tx_add_ptr(umm, sh_dtx, sizeof(*sh_dtx));
+	umem_tx_add_ptr(umm, &sh_dtx->te_flags, sizeof(sh_dtx->te_flags));
 	sh_dtx->te_flags |= DTX_EF_SHARES;
 
 	D_DEBUG(DB_TRACE, "The DTX "DF_DTI" try to shares key "DF_X64
@@ -1198,6 +1209,7 @@ vos_dtx_check_availability(struct umem_instance *umm, daos_handle_t coh,
 	struct dtx_handle		*dth = vos_dth_get();
 	struct vos_dtx_entry_df		*dtx = NULL;
 	umem_off_t			*addr = NULL;
+	int				 rc;
 	bool				 hidden = false;
 
 	switch (type) {
@@ -1295,97 +1307,82 @@ vos_dtx_check_availability(struct umem_instance *umm, daos_handle_t coh,
 		return ALB_AVAILABLE_CLEAN;
 
 	dtx = umem_off2ptr(umm, entry);
-	switch (dtx->te_state) {
-	case DTX_ST_COMMITTED:
-		return hidden ? ALB_UNAVAILABLE : ALB_AVAILABLE_CLEAN;
-	case DTX_ST_PREPARED: {
-		struct vos_container	*cont = vos_hdl2cont(coh);
-		int			 rc;
-
-		rc = vos_dtx_lookup_cos(coh, &dtx->te_oid, &dtx->te_xid,
+	rc = vos_dtx_lookup_cos(coh, &dtx->te_oid, &dtx->te_xid,
 			dtx->te_dkey_hash,
 			dtx->te_intent == DAOS_INTENT_PUNCH ? true : false);
-		if (rc == 0) {
-			/* XXX: For the committable punch DTX, if there is
-			 *	pending exchange (of sub-trees) operation,
-			 *	then do it, otherwise the subsequent fetch
-			 *	cannot get the proper sub-trees.
-			 */
-			if (dtx->te_flags & DTX_EF_EXCHANGE_PENDING) {
-				rc = vos_tx_begin(cont->vc_pool);
-				if (rc == 0) {
-					dtx_rec_release(umm, entry,
-							false, false, false);
-					rc = vos_tx_end(cont->vc_pool, 0);
-				}
+	if (rc == 0) {
+		/* XXX: For the committable punch DTX, if there is pending
+		 *	exchange (of sub-trees) operation, then do it, otherwise
+		 *	the subsequent fetch cannot get the proper sub-trees.
+		 */
+		if (dtx->te_flags & DTX_EF_EXCHANGE_PENDING) {
+			struct vos_container	*cont = vos_hdl2cont(coh);
 
-				if (rc != 0)
-					return rc;
+			rc = vos_tx_begin(cont->vc_pool);
+			if (rc == 0) {
+				umem_tx_add_ptr(umm, dtx, sizeof(*dtx));
+				dtx_rec_release(umm, entry, false, false);
+				rc = vos_tx_end(cont->vc_pool, 0);
 			}
 
-			return hidden ? ALB_UNAVAILABLE : ALB_AVAILABLE_CLEAN;
+			if (rc != 0)
+				return rc;
 		}
 
-		if (rc != -DER_NONEXIST)
-			return rc;
-
-		/* The followings are for non-committable cases. */
-
-		if (intent == DAOS_INTENT_DEFAULT ||
-		    intent == DAOS_INTENT_REBUILD) {
-			if (!(dtx->te_flags & DTX_EF_LEADER) ||
-			    DAOS_FAIL_CHECK(DAOS_VOS_NON_LEADER)) {
-				/* Inavailable for rebuild case. */
-				if (intent == DAOS_INTENT_REBUILD)
-					return hidden ? ALB_AVAILABLE_CLEAN :
-						ALB_UNAVAILABLE;
-
-				D_DEBUG(DB_TRACE, "Let's ask leader "DF_DTI
-					"\n", DP_DTI(&dtx->te_xid));
-				/* Non-leader and non-rebuild case,
-				 * return -DER_INPROGRESS, then the
-				 * caller will retry the RPC with
-				 * leader replica.
-				 */
-				return dtx_inprogress(dtx, 2);
-			}
-
-			/* For leader, non-committed DTX is unavailable. */
-			return hidden ? ALB_AVAILABLE_CLEAN : ALB_UNAVAILABLE;
-		}
-
-		/* PUNCH DTX cannot be shared by others. */
-		if (dtx->te_intent == DAOS_INTENT_PUNCH) {
-			if (dth == NULL)
-				/* XXX: For rebuild case, if some normal IO
-				 *	has generated punch-record (by race)
-				 *	before rebuild logic handling that,
-				 *	then rebuild logic should ignore such
-				 *	punch-record, because the punch epoch
-				 *	will be higher than the rebuild epoch.
-				 *	The rebuild logic needs to create the
-				 *	original target record that exists on
-				 *	other healthy replicas before punch.
-				 */
-				return ALB_UNAVAILABLE;
-
-			dtx_record_conflict(dth, dtx);
-
-			return dtx_inprogress(dtx, 3);
-		}
-
-		if (dtx->te_intent != DAOS_INTENT_UPDATE) {
-			D_ERROR("Unexpected DTX intent %u\n", dtx->te_intent);
-			return -DER_INVAL;
-		}
-
-		return vos_dtx_check_shares(umm, coh, dth, dtx, record, intent,
-					    type, addr);
+		return hidden ? ALB_UNAVAILABLE : ALB_AVAILABLE_CLEAN;
 	}
-	default:
-		D_ERROR("Unexpected DTX state %u\n", dtx->te_state);
+
+	if (rc != -DER_NONEXIST)
+		return rc;
+
+	/* The followings are for non-committable cases. */
+
+	if (intent == DAOS_INTENT_DEFAULT || intent == DAOS_INTENT_REBUILD) {
+		if (!(dtx->te_flags & DTX_EF_LEADER) ||
+		    DAOS_FAIL_CHECK(DAOS_VOS_NON_LEADER)) {
+			/* Inavailable for rebuild case. */
+			if (intent == DAOS_INTENT_REBUILD)
+				return hidden ? ALB_AVAILABLE_CLEAN :
+					ALB_UNAVAILABLE;
+
+			/* Non-leader and non-rebuild case, return
+			 * -DER_INPROGRESS, then the caller will retry
+			 *  the RPC with leader replica.
+			 */
+			return dtx_inprogress(dtx, 2);
+		}
+
+		/* For leader, non-committed DTX is unavailable. */
+		return hidden ? ALB_AVAILABLE_CLEAN : ALB_UNAVAILABLE;
+	}
+
+	/* PUNCH DTX cannot be shared by others. */
+	if (dtx->te_intent == DAOS_INTENT_PUNCH) {
+		if (dth == NULL)
+			/* XXX: For rebuild case, if some normal IO
+			 *	has generated punch-record (by race)
+			 *	before rebuild logic handling that,
+			 *	then rebuild logic should ignore such
+			 *	punch-record, because the punch epoch
+			 *	will be higher than the rebuild epoch.
+			 *	The rebuild logic needs to create the
+			 *	original target record that exists on
+			 *	other healthy replicas before punch.
+			 */
+			return ALB_UNAVAILABLE;
+
+		dtx_record_conflict(dth, dtx);
+
+		return dtx_inprogress(dtx, 3);
+	}
+
+	if (dtx->te_intent != DAOS_INTENT_UPDATE) {
+		D_ERROR("Unexpected DTX intent %u\n", dtx->te_intent);
 		return -DER_INVAL;
 	}
+
+	return vos_dtx_check_shares(umm, coh, dth, dtx, record, intent,
+				    type, addr);
 }
 
 /* The caller has started PMDK transaction. */
@@ -1395,10 +1392,8 @@ vos_dtx_register_record(struct umem_instance *umm, umem_off_t record,
 {
 	struct dtx_handle		*dth = vos_dth_get();
 	struct vos_dtx_entry_df		*dtx;
-	struct vos_dtx_record_df	*rec;
 	struct dtx_share		*dts;
 	struct dtx_share		*next;
-	umem_off_t			 rec_umoff = UMOFF_NULL;
 	umem_off_t			*entry = NULL;
 	uint32_t			*shares = NULL;
 	int				 rc = 0;
@@ -1416,9 +1411,7 @@ vos_dtx_register_record(struct umem_instance *umm, umem_off_t record,
 		/* "flags == 0" means new created object. It is unnecessary
 		 * to umem_tx_add_ptr() for new created object.
 		 */
-		if (flags != 0)
-			umem_tx_add_ptr(umm, obj, sizeof(*obj));
-		else if (dth != NULL)
+		if (flags == 0 && dth != NULL)
 			dth->dth_obj = record;
 		break;
 	}
@@ -1429,9 +1422,6 @@ vos_dtx_register_record(struct umem_instance *umm, umem_off_t record,
 		entry = &key->kr_dtx;
 		if (dth == NULL || dth->dth_intent == DAOS_INTENT_UPDATE)
 			shares = &key->kr_dtx_shares;
-
-		if (flags != 0)
-			umem_tx_add_ptr(umm, key, sizeof(*key));
 		break;
 	}
 	case DTX_RT_SVT: {
@@ -1461,25 +1451,28 @@ vos_dtx_register_record(struct umem_instance *umm, umem_off_t record,
 		return 0;
 	}
 
-	rec_umoff = umem_zalloc(umm, sizeof(struct vos_dtx_record_df));
-	if (dtx_is_null(rec_umoff))
-		return -DER_NOSPACE;
-
-	rec = umem_off2ptr(umm, rec_umoff);
-	rec->tr_type = type;
-	rec->tr_flags = flags;
-	rec->tr_record = record;
-	rec->tr_next = UMOFF_NULL;
-
 	if (dtx_is_null(dth->dth_ent)) {
 		D_ASSERT(flags == 0);
 
-		rc = vos_dtx_alloc(umm, dth, rec_umoff, &dtx);
+		rc = vos_dtx_alloc(umm, dth, &dtx);
 		if (rc != 0)
 			return rc;
-	} else {
-		vos_dtx_append(umm, dth, rec_umoff, record, type, flags, &dtx);
 	}
+
+	/* For single participator case, we only need the DTX entry
+	 * without DTX records for related targets to be modified.
+	 */
+	if (dth->dth_single_participator) {
+		*entry = UMOFF_NULL;
+		if (shares != NULL)
+			*shares = 0;
+
+		return 0;
+	}
+
+	rc = vos_dtx_append(umm, dth, record, type, flags, &dtx);
+	if (rc != 0)
+		return rc;
 
 	*entry = dth->dth_ent;
 	if (shares != NULL)
@@ -1525,10 +1518,12 @@ vos_dtx_deregister_record(struct umem_instance *umm,
 		rec = umem_off2ptr(umm, rec_umoff);
 		if (record == rec->tr_record) {
 			if (prev == NULL) {
-				umem_tx_add_ptr(umm, dtx, sizeof(*dtx));
+				umem_tx_add_ptr(umm, &dtx->te_records,
+						sizeof(dtx->te_records));
 				dtx->te_records = rec->tr_next;
 			} else {
-				umem_tx_add_ptr(umm, prev, sizeof(*prev));
+				umem_tx_add_ptr(umm, &prev->tr_next,
+						sizeof(prev->tr_next));
 				prev->tr_next = rec->tr_next;
 			}
 
@@ -1553,7 +1548,7 @@ vos_dtx_deregister_record(struct umem_instance *umm,
 		obj = umem_off2ptr(umm, record);
 		D_ASSERT(obj->vo_dtx == entry);
 
-		umem_tx_add_ptr(umm, obj, sizeof(*obj));
+		umem_tx_add_ptr(umm, &obj->vo_dtx, VOS_OBJ_SIZE_PARTIAL);
 		if (dtx->te_intent == DAOS_INTENT_UPDATE) {
 			obj->vo_dtx_shares--;
 			if (obj->vo_dtx_shares > 0)
@@ -1566,7 +1561,8 @@ vos_dtx_deregister_record(struct umem_instance *umm,
 		D_ASSERT(key->kr_dtx == entry);
 
 		if (dtx->te_intent == DAOS_INTENT_UPDATE) {
-			umem_tx_add_ptr(umm, key, sizeof(*key));
+			umem_tx_add_ptr(umm, &key->kr_dtx,
+					VOS_KEY_SIZE_PARTIAL);
 			key->kr_dtx_shares--;
 			if (key->kr_dtx_shares > 0)
 				dtx_set_unknown(&key->kr_dtx);
@@ -1590,16 +1586,11 @@ vos_dtx_prepared(struct dtx_handle *dth)
 	/* The caller has already started the PMDK transaction
 	 * and add the DTX into the PMDK transaction.
 	 */
-	dtx->te_state = DTX_ST_PREPARED;
 
-	if (dth->dth_non_rep) {
+	if (dth->dth_single_participator) {
 		dth->dth_sync = 0;
-		rc = vos_dtx_commit_one(cont, &dth->dth_xid);
-		if (rc == 0)
-			dth->dth_ent = UMOFF_NULL;
-		else
-			D_ERROR(DF_UOID" fail to commit for "DF_DTI" rc = %d\n",
-				DP_UOID(dtx->te_oid), DP_DTI(&dtx->te_xid), rc);
+		vos_dtx_commit_internal(cont, &dth->dth_xid, 1, dth->dth_ent);
+		dth->dth_ent = UMOFF_NULL;
 	} else if (dtx->te_flags & DTX_EF_SHARES || dtx->te_dkey_hash == 0) {
 		/* If some DTXs share something (object/key) with others,
 		 * or punch object that is quite possible affect subsequent
@@ -1636,11 +1627,11 @@ do_vos_dtx_check(daos_handle_t coh, struct dtx_id *dti, daos_epoch_t *epoch)
 			*epoch = dtx->te_epoch;
 		}
 
-		return dtx->te_state;
+		return DTX_ST_PREPARED;
 	}
 
 	if (rc == -DER_NONEXIST) {
-		rc = dbtree_lookup(cont->vc_dtx_committed_hdl, &kiov, &riov);
+		rc = dbtree_lookup(cont->vc_dtx_committed_hdl, &kiov, NULL);
 		if (rc == 0)
 			return DTX_ST_COMMITTED;
 	}
@@ -1653,7 +1644,8 @@ vos_dtx_check_resend(daos_handle_t coh, daos_unit_oid_t *oid,
 		     struct dtx_id *xid, uint64_t dkey_hash,
 		     bool punch, daos_epoch_t *epoch)
 {
-	int	rc;
+	struct vos_container	*cont;
+	int			 rc;
 
 	rc = vos_dtx_lookup_cos(coh, oid, xid, dkey_hash, punch);
 	if (rc == 0)
@@ -1662,7 +1654,17 @@ vos_dtx_check_resend(daos_handle_t coh, daos_unit_oid_t *oid,
 	if (rc != -DER_NONEXIST)
 		return rc;
 
-	return do_vos_dtx_check(coh, xid, epoch);
+	rc = do_vos_dtx_check(coh, xid, epoch);
+	if (rc != -DER_NONEXIST)
+		return rc;
+
+	cont = vos_hdl2cont(coh);
+	D_ASSERT(cont != NULL);
+
+	if (cont->vc_reindex_dtx)
+		rc = -DER_AGAIN;
+
+	return rc;
 }
 
 int
@@ -1673,12 +1675,84 @@ vos_dtx_check(daos_handle_t coh, struct dtx_id *dti)
 
 void
 vos_dtx_commit_internal(struct vos_container *cont, struct dtx_id *dtis,
-			int count)
+			int count, umem_off_t umoff)
 {
-	int	i;
+	struct vos_cont_df		*cont_df = cont->vc_cont_df;
+	struct umem_instance		*umm = &cont->vc_pool->vp_umm;
+	struct dtx_committed_blob	*dcb;
+	umem_off_t			 dcb_off;
+	int				 slots = 0;
+	int				 i;
+
+	if (!dtx_is_null(umoff))
+		D_ASSERT(count == 1);
+
+	if (dtx_is_null(cont_df->cd_dtx_committed_tail)) {
+		D_ASSERT(dtx_is_null(cont_df->cd_dtx_committed_head));
+
+		dcb_off = umem_zalloc(umm, DTX_COMMITTED_BLOB_SIZE);
+		if (dtx_is_null(dcb_off)) {
+			D_ERROR("No space to store committed DTX (1) %d "
+				DF_DTI"\n", count, DP_DTI(&dtis[0]));
+			return;
+		}
+
+		dcb = umem_off2ptr(umm, dcb_off);
+		dcb->dcb_cap = (DTX_COMMITTED_BLOB_SIZE -
+				sizeof(struct dtx_committed_blob)) /
+			       sizeof(struct dtx_committed_df);
+		dcb->dcb_next = UMOFF_NULL;
+
+		umem_tx_add_ptr(umm, &cont_df->cd_dtx_committed_head,
+				sizeof(cont_df->cd_dtx_committed_head));
+		umem_tx_add_ptr(umm, &cont_df->cd_dtx_committed_tail,
+				sizeof(cont_df->cd_dtx_committed_tail));
+		cont_df->cd_dtx_committed_head = dcb_off;
+		cont_df->cd_dtx_committed_tail = dcb_off;
+	} else {
+		dcb = umem_off2ptr(umm, cont_df->cd_dtx_committed_tail);
+	}
+
+	/* Not allow to commit too many DTX together. */
+	D_ASSERTF(count < dcb->dcb_cap, "Too many DTX: %d/%d\n",
+		  count, dcb->dcb_cap);
+
+	slots = dcb->dcb_cap - dcb->dcb_count;
+	if (count < slots)
+		slots = count;
+
+	count -= slots;
+	if (dcb->dcb_count > 0) {
+		umem_tx_add_ptr(umm, &dcb->dcb_count, sizeof(dcb->dcb_count));
+		umem_tx_add_ptr(umm, &dcb->dcb_data[dcb->dcb_count],
+				sizeof(struct dtx_committed_df) * slots);
+	}
+
+	for (i = 0; i < slots; i++)
+		vos_dtx_commit_one(cont, &dtis[i], umoff);
+
+	if (count == 0)
+		return;
+
+	dcb_off = umem_zalloc(umm, DTX_COMMITTED_BLOB_SIZE);
+	if (dtx_is_null(dcb_off)) {
+		D_ERROR("No space to store committed DTX (2) %d "DF_DTI"\n",
+			count, DP_DTI(&dtis[slots]));
+		return;
+	}
+
+	dcb = umem_off2ptr(umm, dcb_off);
+	dcb->dcb_cap = (DTX_COMMITTED_BLOB_SIZE -
+			sizeof(struct dtx_committed_blob)) /
+		       sizeof(struct dtx_committed_df);
+	dcb->dcb_next = cont_df->cd_dtx_committed_tail;
+
+	umem_tx_add_ptr(umm, &cont_df->cd_dtx_committed_tail,
+			sizeof(cont_df->cd_dtx_committed_tail));
+	cont_df->cd_dtx_committed_tail = dcb_off;
 
 	for (i = 0; i < count; i++)
-		vos_dtx_commit_one(cont, &dtis[i]);
+		vos_dtx_commit_one(cont, &dtis[i + slots], umoff);
 }
 
 int
@@ -1693,8 +1767,8 @@ vos_dtx_commit(daos_handle_t coh, struct dtx_id *dtis, int count)
 	/* Commit multiple DTXs via single PMDK transaction. */
 	rc = vos_tx_begin(cont->vc_pool);
 	if (rc == 0) {
-		vos_dtx_commit_internal(cont, dtis, count);
-		rc = vos_tx_end(cont->vc_pool, rc);
+		vos_dtx_commit_internal(cont, dtis, count, UMOFF_NULL);
+		vos_tx_end(cont->vc_pool, 0);
 	}
 
 	return rc;
@@ -1702,7 +1776,7 @@ vos_dtx_commit(daos_handle_t coh, struct dtx_id *dtis, int count)
 
 int
 vos_dtx_abort(daos_handle_t coh, daos_epoch_t epoch, struct dtx_id *dtis,
-	      int count, bool force)
+	      int count)
 {
 	struct vos_container	*cont;
 	int			 rc;
@@ -1713,60 +1787,80 @@ vos_dtx_abort(daos_handle_t coh, daos_epoch_t epoch, struct dtx_id *dtis,
 
 	/* Abort multiple DTXs via single PMDK transaction. */
 	rc = vos_tx_begin(cont->vc_pool);
-	if (rc != 0)
-		return rc;
+	if (rc == 0) {
+		for (i = 0; rc == 0 && i < count; i++)
+			vos_dtx_abort_one(cont, epoch, &dtis[i]);
 
-	for (i = 0; rc == 0 && i < count; i++)
-		rc = vos_dtx_abort_one(cont, epoch, &dtis[i], force);
+		vos_tx_end(cont->vc_pool, 0);
+	}
 
-	return vos_tx_end(cont->vc_pool, rc);
+	return rc;
 }
 
 int
 vos_dtx_aggregate(daos_handle_t coh, uint64_t max, uint64_t age)
 {
-	struct vos_container		*cont;
-	struct umem_instance		*umm;
-	struct vos_dtx_table_df		*tab;
-	umem_off_t			 dtx_umoff;
-	uint64_t			 count;
-	int				 rc = 0;
+	struct vos_container	*cont;
+	int			 i;
 
 	cont = vos_hdl2cont(coh);
 	D_ASSERT(cont != NULL);
 
-	umm = &cont->vc_pool->vp_umm;
-	tab = &cont->vc_cont_df->cd_dtx_table_df;
+	for (i = 0;
+	     i < max && !d_list_empty(&cont->vc_dtx_committed_list); i++) {
+		struct dtx_committed_rec	*dcr;
+		d_iov_t				 kiov;
 
-	rc = vos_tx_begin(cont->vc_pool);
-	if (rc != 0)
-		return rc;
-
-	umem_tx_add_ptr(umm, tab, sizeof(*tab));
-	for (count = 0, dtx_umoff = tab->tt_entry_head;
-	     count < max && !dtx_is_null(dtx_umoff); count++) {
-		struct vos_dtx_entry_df	*dtx;
-		d_iov_t		 kiov;
-		umem_off_t		 umoff;
-
-		dtx = umem_off2ptr(umm, dtx_umoff);
-		if (dtx_hlc_age2sec(dtx->te_time) < age)
+		dcr = d_list_entry(cont->vc_dtx_committed_list.next,
+				   struct dtx_committed_rec, dcr_link);
+		if (dtx_hlc_age2sec(dcr->dcr_epoch) < age)
 			break;
 
-		d_iov_set(&kiov, &dtx->te_xid, sizeof(dtx->te_xid));
-		rc = dbtree_delete(cont->vc_dtx_committed_hdl, BTR_PROBE_EQ,
-				   &kiov, &umoff);
-		D_ASSERT(rc == 0);
-
-		tab->tt_count--;
-		dtx_umoff = dtx->te_next;
-		umem_tx_add_ptr(umm, dtx, sizeof(*dtx));
-		vos_dtx_unlink_entry(umm, tab, dtx);
-		dtx_rec_release(umm, umoff, false, true, true);
+		d_iov_set(&kiov, &dcr->dcr_xid, sizeof(dcr->dcr_xid));
+		dbtree_delete(cont->vc_dtx_committed_hdl, BTR_PROBE_EQ,
+			      &kiov, NULL);
 	}
 
-	vos_tx_end(cont->vc_pool, 0);
-	return count < max ? 1 : 0;
+	if (i > 0) {
+		struct umem_instance		*umm = &cont->vc_pool->vp_umm;
+		struct vos_cont_df		*cont_df = cont->vc_cont_df;
+		struct dtx_committed_blob	*dcb;
+		umem_off_t			 dcb_off;
+		int				 count = i;
+		int				 rc;
+
+		dcb_off = cont_df->cd_dtx_committed_head;
+		dcb = umem_off2ptr(umm, dcb_off);
+
+		D_ASSERT(dcb != NULL);
+		/* Not allow to aggregate too many DTX together. */
+		D_ASSERTF(count < dcb->dcb_cap, "Too many DTX: %d/%d\n",
+			  count, dcb->dcb_cap);
+
+		rc = vos_tx_begin(cont->vc_pool);
+		if (rc < 0)
+			return rc;
+
+		if (count + dcb->dcb_first >= dcb->dcb_cap) {
+			umem_tx_add_ptr(umm, &cont_df->cd_dtx_committed_head,
+					sizeof(cont_df->cd_dtx_committed_head));
+			cont_df->cd_dtx_committed_head = dcb->dcb_next;
+			count -= dcb->dcb_cap - dcb->dcb_first;
+			umem_free(umm, dcb_off);
+
+			dcb = umem_off2ptr(umm, cont_df->cd_dtx_committed_head);
+		}
+
+		if (dcb != NULL) {
+			umem_tx_add_ptr(umm, &dcb->dcb_first,
+					sizeof(dcb->dcb_first));
+			dcb->dcb_first += count;
+		}
+
+		vos_tx_end(cont->vc_pool, 0);
+	}
+
+	return i < max ? 1 : 0;
 }
 
 void
@@ -1779,15 +1873,15 @@ vos_dtx_stat(daos_handle_t coh, struct dtx_stat *stat)
 
 	stat->dtx_committable_count = cont->vc_dtx_committable_count;
 	stat->dtx_oldest_committable_time = vos_dtx_cos_oldest(cont);
-	stat->dtx_committed_count = cont->vc_cont_df->cd_dtx_table_df.tt_count;
-	if (!dtx_is_null(cont->vc_cont_df->cd_dtx_table_df.tt_entry_head)) {
-		struct vos_dtx_entry_df	*dtx;
-
-		dtx = umem_off2ptr(&cont->vc_pool->vp_umm,
-			cont->vc_cont_df->cd_dtx_table_df.tt_entry_head);
-		stat->dtx_oldest_committed_time = dtx->te_time;
-	} else {
+	stat->dtx_committed_count = cont->vc_dtx_committed_count;
+	if (d_list_empty(&cont->vc_dtx_committed_list)) {
 		stat->dtx_oldest_committed_time = 0;
+	} else {
+		struct dtx_committed_rec	*dcr;
+
+		dcr = d_list_entry(cont->vc_dtx_committed_list.next,
+				   struct dtx_committed_rec, dcr_link);
+		stat->dtx_oldest_committed_time = dcr->dcr_epoch;
 	}
 }
 
@@ -1831,5 +1925,77 @@ vos_dtx_mark_sync(daos_handle_t coh, daos_unit_oid_t oid, daos_epoch_t epoch)
 	}
 
 	vos_obj_release(occ, obj);
+	return rc;
+}
+
+int
+vos_dtx_reindex(daos_handle_t coh, void *hint)
+{
+	struct vos_container		*cont;
+	struct umem_instance		*umm;
+	struct vos_cont_df		*cont_df;
+	struct dtx_committed_blob	*dcb;
+	struct dtx_committed_rec	*dcr = NULL;
+	umem_off_t			*dcb_off = hint;
+	d_iov_t				 kiov;
+	d_iov_t				 riov;
+	int				 rc = 0;
+	int				 i;
+
+	cont = vos_hdl2cont(coh);
+	D_ASSERT(cont != NULL);
+
+	umm = &cont->vc_pool->vp_umm;
+	cont_df = cont->vc_cont_df;
+
+	if (dtx_is_null(*dcb_off))
+		dcb = umem_off2ptr(umm, cont_df->cd_dtx_committed_head);
+	else
+		dcb = umem_off2ptr(umm, *dcb_off);
+
+	if (dcb == NULL)
+		D_GOTO(out, rc = 1);
+
+	cont->vc_reindex_dtx = 1;
+
+	for (i = dcb->dcb_first; i < dcb->dcb_count; i++) {
+		D_ALLOC_PTR(dcr);
+		if (dcr == NULL)
+			D_GOTO(out, rc = -DER_NOMEM);
+
+		dcr->dcr_xid = dcb->dcb_data[i].dcd_xid;
+		dcr->dcr_epoch = dcb->dcb_data[i].dcd_epoch;
+		dcr->dcr_reindex = true;
+
+		d_iov_set(&kiov, &dcr->dcr_xid, sizeof(dcr->dcr_xid));
+		d_iov_set(&riov, dcr, sizeof(*dcr));
+		rc = dbtree_upsert(cont->vc_dtx_committed_hdl, BTR_PROBE_EQ,
+				   DAOS_INTENT_UPDATE, &kiov, &riov);
+		if (rc != 0)
+			goto out;
+
+		/* The committed DTX entry is already in the index.
+		 * Related re-index logic can stop.
+		 */
+		if (!dcr->dcr_reindex)
+			D_GOTO(out, rc = 1);
+	}
+
+	if (dcb->dcb_count < dcb->dcb_cap ||
+	    dtx_is_null(dcb->dcb_next))
+		D_GOTO(out, rc = 1);
+
+	*dcb_off = dcb->dcb_next;
+
+out:
+	if (rc > 0) {
+		d_list_splice_init(&cont->vc_dtx_committed_tmp_list,
+				   &cont->vc_dtx_committed_list);
+		cont->vc_dtx_committed_count +=
+				cont->vc_dtx_committed_tmp_count;
+		cont->vc_dtx_committed_tmp_count = 0;
+		cont->vc_reindex_dtx = 0;
+	}
+
 	return rc;
 }

--- a/src/vos/vos_dtx_cos.c
+++ b/src/vos/vos_dtx_cos.c
@@ -47,8 +47,6 @@ struct dtx_cos_rec {
 	int			 dcr_update_count;
 	/* The number of the PUNCH DTXs in the dcr_punch_list. */
 	int			 dcr_punch_count;
-	/* Pointer to the container. */
-	struct vos_container	*dcr_cont;
 };
 
 /* Above dtx_cos_rec is consisted of a series of dtx_cos_rec_child uints.
@@ -56,7 +54,7 @@ struct dtx_cos_rec {
  * related object and dkey (that attached to the dtx_cos_rec).
  */
 struct dtx_cos_rec_child {
-	/* Link into the container::vc_dtx_committable. */
+	/* Link into the container::vc_dtx_committable_list. */
 	d_list_t		 dcrc_committable;
 	/* Link into related dcr_{update,punch}_list. */
 	d_list_t		 dcrc_link;
@@ -64,14 +62,11 @@ struct dtx_cos_rec_child {
 	struct dtx_id		 dcrc_dti;
 	/* The DTX epoch. */
 	daos_epoch_t		 dcrc_epoch;
-	/* Timestamp of handling the DTX on server. */
-	uint64_t		 dcrc_time;
 	/* Pointer to the dtx_cos_rec. */
 	struct dtx_cos_rec	*dcrc_ptr;
 };
 
 struct dtx_cos_rec_bundle {
-	struct vos_container	*cont;
 	struct dtx_id		*dti;
 	daos_epoch_t		 epoch;
 	bool			 punch;
@@ -112,6 +107,7 @@ static int
 dtx_cos_rec_alloc(struct btr_instance *tins, d_iov_t *key_iov,
 		  d_iov_t *val_iov, struct btr_record *rec)
 {
+	struct vos_container		*cont = tins->ti_priv;
 	struct dtx_cos_key		*key;
 	struct dtx_cos_rec_bundle	*rbund;
 	struct dtx_cos_rec		*dcr;
@@ -129,7 +125,6 @@ dtx_cos_rec_alloc(struct btr_instance *tins, d_iov_t *key_iov,
 	dcr->dcr_oid = key->oid;
 	D_INIT_LIST_HEAD(&dcr->dcr_update_list);
 	D_INIT_LIST_HEAD(&dcr->dcr_punch_list);
-	dcr->dcr_cont = rbund->cont;
 
 	D_ALLOC_PTR(dcrc);
 	if (dcrc == NULL) {
@@ -139,12 +134,11 @@ dtx_cos_rec_alloc(struct btr_instance *tins, d_iov_t *key_iov,
 
 	dcrc->dcrc_dti = *rbund->dti;
 	dcrc->dcrc_epoch = rbund->epoch;
-	dcrc->dcrc_time = crt_hlc_get();
 	dcrc->dcrc_ptr = dcr;
 
 	d_list_add_tail(&dcrc->dcrc_committable,
-			&rbund->cont->vc_dtx_committable);
-	rbund->cont->vc_dtx_committable_count++;
+			&cont->vc_dtx_committable_list);
+	cont->vc_dtx_committable_count++;
 
 	if (rbund->punch) {
 		d_list_add_tail(&dcrc->dcrc_link, &dcr->dcr_punch_list);
@@ -161,6 +155,7 @@ dtx_cos_rec_alloc(struct btr_instance *tins, d_iov_t *key_iov,
 static int
 dtx_cos_rec_free(struct btr_instance *tins, struct btr_record *rec, void *args)
 {
+	struct vos_container		*cont = tins->ti_priv;
 	struct dtx_cos_rec		*dcr;
 	struct dtx_cos_rec_child	*dcrc;
 	struct dtx_cos_rec_child	*next;
@@ -173,14 +168,14 @@ dtx_cos_rec_free(struct btr_instance *tins, struct btr_record *rec, void *args)
 		d_list_del(&dcrc->dcrc_link);
 		d_list_del(&dcrc->dcrc_committable);
 		D_FREE_PTR(dcrc);
-		dcr->dcr_cont->vc_dtx_committable_count--;
+		cont->vc_dtx_committable_count--;
 	}
 	d_list_for_each_entry_safe(dcrc, next, &dcr->dcr_punch_list,
 				   dcrc_link) {
 		d_list_del(&dcrc->dcrc_link);
 		d_list_del(&dcrc->dcrc_committable);
 		D_FREE_PTR(dcrc);
-		dcr->dcr_cont->vc_dtx_committable_count--;
+		cont->vc_dtx_committable_count--;
 	}
 	D_FREE_PTR(dcr);
 
@@ -205,6 +200,7 @@ static int
 dtx_cos_rec_update(struct btr_instance *tins, struct btr_record *rec,
 		   d_iov_t *key, d_iov_t *val)
 {
+	struct vos_container		*cont = tins->ti_priv;
 	struct dtx_cos_rec_bundle	*rbund;
 	struct dtx_cos_rec		*dcr;
 	struct dtx_cos_rec_child	*dcrc;
@@ -220,12 +216,11 @@ dtx_cos_rec_update(struct btr_instance *tins, struct btr_record *rec,
 
 	dcrc->dcrc_dti = *rbund->dti;
 	dcrc->dcrc_epoch = rbund->epoch;
-	dcrc->dcrc_time = crt_hlc_get();
 	dcrc->dcrc_ptr = dcr;
 
 	d_list_add_tail(&dcrc->dcrc_committable,
-			&rbund->cont->vc_dtx_committable);
-	rbund->cont->vc_dtx_committable_count++;
+			&cont->vc_dtx_committable_list);
+	cont->vc_dtx_committable_count++;
 
 	if (rbund->punch) {
 		d_list_add_tail(&dcrc->dcrc_link, &dcr->dcr_punch_list);
@@ -360,7 +355,8 @@ out:
 
 int
 vos_dtx_add_cos(daos_handle_t coh, daos_unit_oid_t *oid, struct dtx_id *dti,
-		uint64_t dkey_hash, daos_epoch_t epoch, bool punch, bool check)
+		uint64_t dkey_hash, daos_epoch_t epoch, uint64_t gen,
+		bool punch, bool check)
 {
 	struct vos_container		*cont;
 	struct dtx_cos_key		 key;
@@ -371,6 +367,41 @@ vos_dtx_add_cos(daos_handle_t coh, daos_unit_oid_t *oid, struct dtx_id *dti,
 
 	cont = vos_hdl2cont(coh);
 	D_ASSERT(cont != NULL);
+
+	/* If the DTX is started befoe DTX resync operation (for rebuild),
+	 * then it is possbile that the DTX resync ULT may have aborted
+	 * or committed the DTX during current ULT waiting for the reply.
+	 * let's check DTX status locally before marking as 'committable'.
+	 */
+	if (gen != 0 && gen < cont->vc_dtx_resync_gen) {
+		rc = vos_dtx_check(coh, dti);
+		switch (rc) {
+		case DTX_ST_PREPARED:
+			rc = vos_dtx_lookup_cos(coh, oid, dti,
+						dkey_hash, punch);
+			/* The resync ULT has already added it into the
+			 * CoS cache, current ULT needs to do nothing.
+			 */
+			if (rc == 0)
+				return -DER_ALREADY;
+
+			/* Normal case, then add it to CoS cache. */
+			if (rc == -DER_NONEXIST)
+				break;
+
+			return rc >= 0 ? -DER_INVAL : rc;
+		case DTX_ST_COMMITTED:
+			/* The DTX has been committed by resync ULT by race. */
+			return -DER_ALREADY;
+		case -DER_NONEXIST:
+			/* The DTX has been aborted by resync ULT, ask the
+			 * client to retry.
+			 */
+			return rc;
+		default:
+			return rc >= 0 ? -DER_INVAL : rc;
+		}
+	}
 
 	if (check) {
 		struct daos_lru_cache	*occ = vos_obj_cache_current();
@@ -394,7 +425,6 @@ vos_dtx_add_cos(daos_handle_t coh, daos_unit_oid_t *oid, struct dtx_id *dti,
 	key.dkey = dkey_hash;
 	d_iov_set(&kiov, &key, sizeof(key));
 
-	rbund.cont = cont;
 	rbund.dti = dti;
 	rbund.epoch = epoch;
 	rbund.punch = punch;
@@ -417,8 +447,8 @@ vos_dtx_lookup_cos(daos_handle_t coh, daos_unit_oid_t *oid,
 {
 	struct vos_container		*cont;
 	struct dtx_cos_key		 key;
-	d_iov_t			 kiov;
-	d_iov_t			 riov;
+	d_iov_t				 kiov;
+	d_iov_t				 riov;
 	struct dtx_cos_rec		*dcr;
 	struct dtx_cos_rec_child	*dcrc;
 	d_list_t			*head;
@@ -474,7 +504,7 @@ vos_dtx_fetch_committable(daos_handle_t coh, uint32_t max_cnt,
 	if (dte == NULL)
 		return -DER_NOMEM;
 
-	d_list_for_each_entry(dcrc, &cont->vc_dtx_committable,
+	d_list_for_each_entry(dcrc, &cont->vc_dtx_committable_list,
 			      dcrc_committable) {
 		if (oid != NULL &&
 		    daos_unit_oid_compare(dcrc->dcrc_ptr->dcr_oid, *oid) != 0)
@@ -559,10 +589,10 @@ vos_dtx_cos_oldest(struct vos_container *cont)
 {
 	struct dtx_cos_rec_child	*dcrc;
 
-	if (d_list_empty(&cont->vc_dtx_committable))
+	if (d_list_empty(&cont->vc_dtx_committable_list))
 		return 0;
 
-	dcrc = d_list_entry(cont->vc_dtx_committable.next,
+	dcrc = d_list_entry(cont->vc_dtx_committable_list.next,
 			    struct dtx_cos_rec_child, dcrc_committable);
-	return dcrc->dcrc_time;
+	return dcrc->dcrc_epoch;
 }

--- a/src/vos/vos_internal.h
+++ b/src/vos/vos_internal.h
@@ -45,6 +45,8 @@
 #define VOS_KTR_ORDER		23	/* order of d/a-key tree */
 #define VOS_SVT_ORDER		5	/* order of single value tree */
 #define VOS_EVT_ORDER		23	/* evtree order */
+#define DTX_BTREE_ORDER		23	/* Order for DTX tree */
+
 
 
 #define DAOS_VOS_VERSION 1
@@ -119,20 +121,30 @@ struct vos_container {
 	struct vos_pool		*vc_pool;
 	/* Unique UID of VOS container */
 	uuid_t			vc_id;
+	/* DAOS handle for object index btree */
+	daos_handle_t		vc_btr_hdl;
 	/* The handle for active DTX table */
 	daos_handle_t		vc_dtx_active_hdl;
 	/* The handle for committed DTX table */
 	daos_handle_t		vc_dtx_committed_hdl;
-	/* DAOS handle for object index btree */
-	daos_handle_t		vc_btr_hdl;
 	/* The objects with committable DTXs in DRAM. */
 	daos_handle_t		vc_dtx_cos_hdl;
+	/** The root of the B+ tree for committed DTXs. */
+	struct btr_root		vc_dtx_committed_btr;
 	/* The DTX COS-btree. */
 	struct btr_root		vc_dtx_cos_btr;
-	/* The global list for commiitable DTXs. */
-	d_list_t		vc_dtx_committable;
-	/* The count of commiitable DTXs. */
+	/* The global list for committable DTXs. */
+	d_list_t		vc_dtx_committable_list;
+	/* The global list for committed DTXs. */
+	d_list_t		vc_dtx_committed_list;
+	/* The temporary list for committed DTXs during re-index. */
+	d_list_t		vc_dtx_committed_tmp_list;
+	/* The count of committable DTXs. */
 	uint32_t		vc_dtx_committable_count;
+	/* The count of committed DTXs. */
+	uint32_t		vc_dtx_committed_count;
+	/* The items count in vc_dtx_committed_tmp_list. */
+	uint32_t		vc_dtx_committed_tmp_count;
 	/** Direct pointer to the VOS container */
 	struct vos_cont_df	*vc_cont_df;
 	/**
@@ -142,8 +154,10 @@ struct vos_container {
 	struct vea_hint_context	*vc_hint_ctxt[VOS_IOS_CNT];
 	/* Various flags */
 	unsigned int		vc_in_aggregation:1,
-				vc_abort_aggregation:1;
+				vc_abort_aggregation:1,
+				vc_reindex_dtx:1;
 	unsigned int		vc_open_count;
+	uint64_t		vc_dtx_resync_gen;
 };
 
 struct vos_imem_strts {
@@ -294,30 +308,6 @@ int
 vos_obj_tab_register();
 
 /**
- * DTX table create
- * Called from cont_df_rec_alloc.
- *
- * \param pool		[IN]	vos pool
- * \param dtab_df	[IN]	Pointer to the DTX table (pmem data structure)
- *
- * \return		0 on success and negative on failure
- */
-int
-vos_dtx_table_create(struct vos_pool *pool, struct vos_dtx_table_df *dtab_df);
-
-/**
- * DTX table destroy
- * Called from vos_cont_destroy
- *
- * \param pool		[IN]	vos pool
- * \param dtab_df	[IN]	Pointer to the DTX table (pmem data structure)
- *
- * \return		0 on success and negative on failure
- */
-int
-vos_dtx_table_destroy(struct vos_pool *pool, struct vos_dtx_table_df *dtab_df);
-
-/**
  * Register dbtree class for DTX table, it is called within vos_init().
  *
  * \return		0 on success and negative on failure
@@ -391,7 +381,7 @@ vos_dtx_prepared(struct dtx_handle *dth);
 
 void
 vos_dtx_commit_internal(struct vos_container *cont, struct dtx_id *dtis,
-			int count);
+			int count, umem_off_t umoff);
 
 /**
  * Register dbtree class for DTX CoS, it is called within vos_init().
@@ -427,21 +417,23 @@ vos_dtx_cos_oldest(struct vos_container *cont);
 
 enum vos_tree_class {
 	/** the first reserved tree class */
-	VOS_BTR_BEGIN		= DBTREE_VOS_BEGIN,
+	VOS_BTR_BEGIN			= DBTREE_VOS_BEGIN,
 	/** distribution key tree */
-	VOS_BTR_DKEY		= (VOS_BTR_BEGIN + 0),
+	VOS_BTR_DKEY			= (VOS_BTR_BEGIN + 0),
 	/** attribute key tree */
-	VOS_BTR_AKEY		= (VOS_BTR_BEGIN + 1),
+	VOS_BTR_AKEY			= (VOS_BTR_BEGIN + 1),
 	/** single value + epoch tree */
-	VOS_BTR_SINGV		= (VOS_BTR_BEGIN + 2),
+	VOS_BTR_SINGV			= (VOS_BTR_BEGIN + 2),
 	/** object index table */
-	VOS_BTR_OBJ_TABLE	= (VOS_BTR_BEGIN + 3),
+	VOS_BTR_OBJ_TABLE		= (VOS_BTR_BEGIN + 3),
 	/** container index table */
-	VOS_BTR_CONT_TABLE	= (VOS_BTR_BEGIN + 4),
+	VOS_BTR_CONT_TABLE		= (VOS_BTR_BEGIN + 4),
 	/** DAOS two-phase commit transation table */
-	VOS_BTR_DTX_TABLE	= (VOS_BTR_BEGIN + 5),
+	VOS_BTR_DTX_ACTIVE_TABLE	= (VOS_BTR_BEGIN + 5),
+	/** DAOS two-phase commit transation table */
+	VOS_BTR_DTX_COMMITTED_TABLE	= (VOS_BTR_BEGIN + 6),
 	/** The objects with committable DTXs in DRAM */
-	VOS_BTR_DTX_COS		= (VOS_BTR_BEGIN + 6),
+	VOS_BTR_DTX_COS			= (VOS_BTR_BEGIN + 7),
 	/** the last reserved tree class */
 	VOS_BTR_END,
 };

--- a/src/vos/vos_io.c
+++ b/src/vos/vos_io.c
@@ -1297,7 +1297,7 @@ vos_update_end(daos_handle_t ioh, uint32_t pm_ver, daos_key_t *dkey, int err,
 	if (dth != NULL && dth->dth_dti_cos_count > 0 &&
 	    dth->dth_dti_cos_done == 0) {
 		vos_dtx_commit_internal(ioc->ic_obj->obj_cont, dth->dth_dti_cos,
-					dth->dth_dti_cos_count);
+					dth->dth_dti_cos_count, UMOFF_NULL);
 		dth->dth_dti_cos_done = 1;
 	}
 

--- a/src/vos/vos_layout.h
+++ b/src/vos/vos_layout.h
@@ -235,36 +235,16 @@ struct vos_dtx_entry_df {
 	daos_epoch_t			te_epoch;
 	/** Pool map version. */
 	uint32_t			te_ver;
-	/** DTX status, see enum dtx_status. */
-	uint32_t			te_state;
-	/** DTX flags, see enum vos_dtx_entry_flags. */
-	uint32_t			te_flags;
 	/** The intent of related modification. */
 	uint32_t			te_intent;
-	/** The timestamp when handles the transaction. */
-	uint64_t			te_time;
+	/** The server generation when handles the DTX. */
+	uint64_t			te_gen;
+	/** DTX flags, see enum vos_dtx_entry_flags. */
+	uint32_t			te_flags;
+	/** For 64-bits alignment. */
+	uint32_t			te_padding;
 	/** The list of vos_dtx_record_df in SCM. */
 	umem_off_t			te_records;
-	/** The next committed DTX in global list. */
-	umem_off_t			te_next;
-	/** The prev committed DTX in global list. */
-	umem_off_t			te_prev;
-};
-
-/**
- * DAOS two-phase commit transaction table.
- */
-struct vos_dtx_table_df {
-	/** The count of committed DTXs in the table. */
-	uint64_t			tt_count;
-	/** The list head of committed DTXs. */
-	umem_off_t			tt_entry_head;
-	/** The list tail of committed DTXs. */
-	umem_off_t			tt_entry_tail;
-	/** The root of the B+ tree for committed DTXs. */
-	struct btr_root			tt_committed_btr;
-	/** The root of the B+ tree for active (prepared) DTXs. */
-	struct btr_root			tt_active_btr;
 };
 
 enum vos_io_stream {
@@ -282,11 +262,16 @@ enum vos_io_stream {
 struct vos_cont_df {
 	uuid_t				cd_id;
 	uint64_t			cd_nobjs;
+	uint64_t			cd_dtx_resync_gen;
 	daos_size_t			cd_used;
 	daos_epoch_t			cd_hae;
 	struct btr_root			cd_obj_root;
-	/** The DTXs table. */
-	struct vos_dtx_table_df		cd_dtx_table_df;
+	/** The active DTX table. */
+	struct btr_root			cd_dtx_active;
+	/** The committed DTXs blob head. */
+	umem_off_t			cd_dtx_committed_head;
+	/** The committed DTXs blob tail. */
+	umem_off_t			cd_dtx_committed_tail;
 	/** Allocation hints for block allocator. */
 	struct vea_hint_df		cd_hint_df[VOS_IOS_CNT];
 };
@@ -346,6 +331,14 @@ D_CASSERT(offsetof(struct vos_krec_df, kr_earliest) ==
 	  offsetof(struct vos_krec_df, kr_latest) +
 	  sizeof(((struct vos_krec_df *)0)->kr_latest));
 
+D_CASSERT(offsetof(struct vos_krec_df, kr_dtx_shares) ==
+	  offsetof(struct vos_krec_df, kr_dtx) +
+	  sizeof(((struct vos_krec_df *)0)->kr_dtx));
+
+#define VOS_KEY_DTX_SIZE	sizeof(((struct vos_krec_df *)0)->kr_dtx)
+#define VOS_KEY_SHARES_SIZE	sizeof(((struct vos_krec_df *)0)->kr_dtx_shares)
+#define VOS_KEY_SIZE_PARTIAL	(VOS_KEY_DTX_SIZE + VOS_KEY_SHARES_SIZE)
+
 /**
  * Persisted VOS single value & epoch record, it is referenced by
  * btr_record::rec_off of btree VOS_BTR_SINGV.
@@ -399,5 +392,13 @@ struct vos_obj_df {
 D_CASSERT(offsetof(struct vos_obj_df, vo_earliest) ==
 	  offsetof(struct vos_obj_df, vo_latest) +
 	  sizeof(((struct vos_obj_df *)0)->vo_latest));
+
+D_CASSERT(offsetof(struct vos_obj_df, vo_dtx_shares) ==
+	  offsetof(struct vos_obj_df, vo_dtx) +
+	  sizeof(((struct vos_obj_df *)0)->vo_dtx));
+
+#define VOS_OBJ_DTX_SIZE	sizeof(((struct vos_obj_df *)0)->vo_dtx)
+#define VOS_OBJ_SHARES_SIZE	sizeof(((struct vos_obj_df *)0)->vo_dtx_shares)
+#define VOS_OBJ_SIZE_PARTIAL	(VOS_OBJ_DTX_SIZE + VOS_OBJ_SHARES_SIZE)
 
 #endif

--- a/src/vos/vos_obj.c
+++ b/src/vos/vos_obj.c
@@ -152,7 +152,7 @@ vos_obj_punch(daos_handle_t coh, daos_unit_oid_t oid, daos_epoch_t epoch,
 	if (dth != NULL && dth->dth_dti_cos_count > 0 &&
 	    dth->dth_dti_cos_done == 0) {
 		vos_dtx_commit_internal(cont, dth->dth_dti_cos,
-					dth->dth_dti_cos_count);
+					dth->dth_dti_cos_count, UMOFF_NULL);
 		dth->dth_dti_cos_done = 1;
 	}
 

--- a/src/vos/vos_obj_index.c
+++ b/src/vos/vos_obj_index.c
@@ -301,12 +301,13 @@ int
 vos_oi_punch(struct vos_container *cont, daos_unit_oid_t oid,
 	     daos_epoch_t epoch, uint32_t flags, struct vos_obj_df *obj)
 {
-	struct oi_hkey	*hkey;
-	struct oi_key	 key;
-	d_iov_t	 key_iov;
-	d_iov_t	 val_iov;
-	int		 rc = 0;
-	bool		 replay = (flags & VOS_OF_REPLAY_PC);
+	struct dtx_handle	*dth;
+	struct oi_hkey		*hkey;
+	struct oi_key		 key;
+	d_iov_t			 key_iov;
+	d_iov_t			 val_iov;
+	int			 rc = 0;
+	bool			 replay = (flags & VOS_OF_REPLAY_PC);
 
 	D_DEBUG(DB_TRACE, "Punch obj "DF_UOID", epoch="DF_U64".\n",
 		DP_UOID(oid), epoch);
@@ -337,7 +338,8 @@ vos_oi_punch(struct vos_container *cont, daos_unit_oid_t oid,
 	if (rc != 0 || replay)
 		goto out;
 
-	if (vos_dth_get() == NULL) {
+	dth = vos_dth_get();
+	if (dth == NULL || dth->dth_single_participator) {
 		struct vos_obj_df *tmp;
 
 		D_ASSERT((obj->vo_oi_attr & VOS_OI_PUNCHED) == 0);

--- a/src/vos/vos_tree.c
+++ b/src/vos/vos_tree.c
@@ -1048,6 +1048,7 @@ int
 key_tree_punch(struct vos_object *obj, daos_handle_t toh, d_iov_t *key_iov,
 	       d_iov_t *val_iov, int flags)
 {
+	struct dtx_handle	*dth;
 	struct vos_key_bundle	*kbund;
 	struct vos_rec_bundle	*rbund;
 	struct vos_krec_df	*krec;
@@ -1096,7 +1097,8 @@ key_tree_punch(struct vos_object *obj, daos_handle_t toh, d_iov_t *key_iov,
 	if (rc != 0 || replay)
 		return rc;
 
-	if (vos_dth_get() == NULL) { /* delete the max epoch */
+	dth = vos_dth_get();
+	if (dth == NULL || dth->dth_single_participator) {
 		struct umem_instance	*umm = vos_obj2umm(obj);
 		struct vos_krec_df	*krec2;
 		struct vos_key_bundle	 kbund2;


### PR DESCRIPTION
Mainly include the following:

1. Increase the CPU yield frequency during DTX aggregation and
   batched commit to allow more normal IO schedule.

2. Use client-side HLC in the DTX ID as the modification epoch.

3. Replace HLC based race detection between DTX resync and normal
   modification handling logic with server-side generation.

4. Fine-grained contents for PMDK undo log to reduce the overhead
   caused by PMDK related logic.

5. Store the indexed committed DTX table in DRAM rather than SCM.

   When a DTX is committed, it is added into the in-DRAM committed
   DTX table that is organized as a B+tree. If related DAOS server
   restarts because of some reason, for supporting DAOS server to
   rejoin system (if is not evicted), then we need to re-establish
   the indexed committed DTX table in DRAM. So we will store the
   committed DTX entries in SCM without index (only append) when
   they are committed.

   A dedicated ULT will scan the non-indexed committed DTX entries
   in SCM to re-generate the indexed committed DTX table in DRAM
   when open the container.

6. Some DTX logic can be optimized if the DTX contains single
   participator (such as modifying single replicated object).
   For example: the DTX can be committed immediately after
   local modification done.

6.1. It is unnecessary to allocate related DTX records for the
     target (object/dkey/akey/SV/EV rec) to be modified.

6.2. It is unnecessary to insert the DTX into active DTX tree,
     instead, it can be directly inserted into the committed
     DTX table when commit.

6.3. Punch logic can be simplified as without DTX case.

6.4. CoS logic can be bypassed.

Signed-off-by: Fan Yong <fan.yong@intel.com>