### PR TITLE
DAOS-3514 control: Properly parse ndctl list output

### DIFF
--- a/src/control/common/test_utils.go
+++ b/src/control/common/test_utils.go
@@ -95,6 +95,21 @@ func ExpectError(
 	}
 }
 
+// CmpErr compares two errors for equality or at least close similarity in their messages.
+func CmpErr(t *testing.T, want, got error) {
+	t.Helper()
+
+	if want == got {
+		return
+	}
+	if want == nil || got == nil {
+		t.Fatalf("unexpected error (wanted: %v, got: %v)", want, got)
+	}
+	if !strings.Contains(got.Error(), want.Error()) {
+		t.Fatalf("unexpected error (wanted: %s, got: %s)", want, got)
+	}
+}
+
 // LoadTestFiles reads inputs and outputs from file and do basic sanity checks.
 // Both files contain entries of multiple lines separated by blank line.
 // Return inputs and outputs, both of which are slices of string slices.

--- a/src/control/server/drpc_test.go
+++ b/src/control/server/drpc_test.go
@@ -33,6 +33,7 @@ import (
 
 	"github.com/pkg/errors"
 
+	"github.com/daos-stack/daos/src/control/common"
 	mgmtpb "github.com/daos-stack/daos/src/control/common/proto/mgmt"
 	"github.com/daos-stack/daos/src/control/drpc"
 )
@@ -308,7 +309,7 @@ func TestDrpc_Errors(t *testing.T) {
 			}
 
 			_, err := makeDrpcCall(mc, mgmtModuleID, poolCreate, &mgmtpb.PoolCreateReq{})
-			cmpErr(t, tc.expErr, err)
+			common.CmpErr(t, tc.expErr, err)
 		})
 	}
 }

--- a/src/control/server/harness_test.go
+++ b/src/control/server/harness_test.go
@@ -41,20 +41,6 @@ import (
 	"github.com/daos-stack/daos/src/control/server/storage/scm"
 )
 
-func cmpErr(t *testing.T, want, got error) {
-	t.Helper()
-
-	if want == got {
-		return
-	}
-	if want == nil || got == nil {
-		t.Fatalf("unexpected error (wanted: %v, got: %v)", want, got)
-	}
-	if want.Error() != got.Error() && !strings.Contains(got.Error(), want.Error()) {
-		t.Fatalf("unexpected error (wanted: %s, got: %s)", want, got)
-	}
-}
-
 func TestHarnessCreateSuperblocks(t *testing.T) {
 	log, buf := logging.NewTestLogger(t.Name())
 	defer common.ShowBufferOnFailure(t, buf)()
@@ -242,7 +228,7 @@ func TestHarnessGetMSLeaderInstance(t *testing.T) {
 			}
 
 			_, err := h.GetMSLeaderInstance()
-			cmpErr(t, tc.expError, err)
+			common.CmpErr(t, tc.expError, err)
 		})
 	}
 }

--- a/src/control/server/instance_test.go
+++ b/src/control/server/instance_test.go
@@ -106,7 +106,7 @@ func TestIOServerInstance_CallDrpc(t *testing.T) {
 			}
 
 			_, err := instance.CallDrpc(mgmtModuleID, poolCreate, &mgmtpb.PoolCreateReq{})
-			cmpErr(t, tc.expErr, err)
+			common.CmpErr(t, tc.expErr, err)
 		})
 	}
 }
@@ -201,7 +201,7 @@ func TestIOServerInstance_MountScmDevice(t *testing.T) {
 			instance := NewIOServerInstance(log, nil, mp, nil, runner)
 
 			gotErr := instance.MountScmDevice()
-			cmpErr(t, tc.expErr, gotErr)
+			common.CmpErr(t, tc.expErr, gotErr)
 		})
 	}
 }
@@ -329,7 +329,7 @@ func TestIOServerInstance_NeedsScmFormat(t *testing.T) {
 			instance := NewIOServerInstance(log, nil, mp, nil, runner)
 
 			gotNeedsFormat, gotErr := instance.NeedsScmFormat()
-			cmpErr(t, tc.expErr, gotErr)
+			common.CmpErr(t, tc.expErr, gotErr)
 			if diff := cmp.Diff(tc.expNeedsFormat, gotNeedsFormat); diff != "" {
 				t.Fatalf("unexpected needs format (-want, +got):\n%s\n", diff)
 			}

--- a/src/control/server/storage/scm/ipmctl.go
+++ b/src/control/server/storage/scm/ipmctl.go
@@ -43,7 +43,7 @@ const (
 	cmdScmRemoveRegions    = "ipmctl create -f -goal MemoryMode=100"
 	cmdScmDeleteGoal       = "ipmctl delete -goal"
 	cmdScmCreateNamespace  = "ndctl create-namespace" // returns json ns info
-	cmdScmListNamespaces   = "ndctl list -N"          // returns json ns info
+	cmdScmListNamespaces   = "ndctl list -N -v"       // returns json ns info
 	cmdScmDisableNamespace = "ndctl disable-namespace %s"
 	cmdScmDestroyNamespace = "ndctl destroy-namespace %s"
 )
@@ -235,7 +235,7 @@ func (r *cmdRunner) PrepReset(state types.ScmState) (bool, error) {
 }
 
 func (r *cmdRunner) removeNamespace(devName string) (err error) {
-	r.log.Infof("removing SCM namespace, may take a few minutes...\n")
+	r.log.Infof("removing SCM namespace %q, may take a few minutes...\n", devName)
 
 	_, err = r.runCmd(fmt.Sprintf(cmdScmDisableNamespace, devName))
 	if err != nil {

--- a/src/control/server/storage/scm/ipmctl_test.go
+++ b/src/control/server/storage/scm/ipmctl_test.go
@@ -28,8 +28,10 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
 	"github.com/pkg/errors"
 
+	"github.com/daos-stack/daos/src/control/common"
 	. "github.com/daos-stack/daos/src/control/common"
 	"github.com/daos-stack/daos/src/control/lib/ipmctl"
 	"github.com/daos-stack/daos/src/control/logging"
@@ -201,6 +203,74 @@ func TestGetState(t *testing.T) {
 			AssertEqual(t, commands, tt.expCommands, tt.desc+": unexpected list of commands run")
 			AssertEqual(t, needsReboot, tt.expRebootRequired, tt.desc+": unexpected value for is reboot required")
 			AssertEqual(t, namespaces, tt.expNamespaces, tt.desc+": unexpected list of pmem device file names")
+		})
+	}
+}
+
+func TestParseNamespaces(t *testing.T) {
+	// template for `ndctl list -N` output
+	listTmpl := `{
+   "dev":"namespace%d.0",
+   "mode":"fsdax",
+   "map":"dev",
+   "size":"2964.94 GiB (3183.58 GB)",
+   "uuid":"842fc847-28e0-4bb6-8dfc-d24afdba1528",
+   "raw_uuid":"dedb4b28-dc4b-4ccd-b7d1-9bd475c91264",
+   "sector_size":512,
+   "blockdev":"pmem%d",
+   "numa_node":%d
+}`
+
+	for name, tc := range map[string]struct {
+		in            string
+		expNamespaces []Namespace
+		expErr        error
+	}{
+		"empty": {
+			expNamespaces: []Namespace{},
+		},
+		"single": {
+			in: fmt.Sprintf(listTmpl, 0, 0, 0),
+			expNamespaces: []Namespace{
+				{
+					Name:        "namespace0.0",
+					BlockDevice: "pmem0",
+					NumaNode:    0,
+					UUID:        "842fc847-28e0-4bb6-8dfc-d24afdba1528",
+				},
+			},
+		},
+		"double": {
+			in: strings.Join([]string{
+				"[", fmt.Sprintf(listTmpl, 0, 0, 0), ",",
+				fmt.Sprintf(listTmpl, 1, 1, 1), "]"}, ""),
+			expNamespaces: []Namespace{
+				{
+					Name:        "namespace0.0",
+					BlockDevice: "pmem0",
+					NumaNode:    0,
+					UUID:        "842fc847-28e0-4bb6-8dfc-d24afdba1528",
+				},
+				{
+					Name:        "namespace1.0",
+					BlockDevice: "pmem1",
+					NumaNode:    1,
+					UUID:        "842fc847-28e0-4bb6-8dfc-d24afdba1528",
+				},
+			},
+		},
+		"malformed": {
+			in:     `{"dev":"foo`,
+			expErr: errors.New("JSON input"),
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			gotNamespaces, gotErr := parseNamespaces(tc.in)
+
+			common.CmpErr(t, tc.expErr, gotErr)
+			if diff := cmp.Diff(tc.expNamespaces, gotNamespaces); diff != "" {
+				t.Fatalf("unexpected namespace result (-want, +got):\n%s\n", diff)
+			}
 		})
 	}
 }

--- a/src/control/server/storage/scm/provider.go
+++ b/src/control/server/storage/scm/provider.go
@@ -69,9 +69,9 @@ type (
 
 	// Namespace represents a mapping between AppDirect regions and block device files.
 	Namespace struct {
-		UUID        string
-		BlockDevice string
-		Name        string
+		UUID        string `json:"uuid"`
+		BlockDevice string `json:"blockdev"`
+		Name        string `json:"dev"`
 		NumaNode    uint32 `json:"numa_node"`
 	}
 )


### PR DESCRIPTION
The SCM refactor didn't add test coverage to ensure that
DCPM namespaces were properly unmarshaled from JSON. This
commit fixes the error and adds a unit test.

Also moves server.cmpErr to common.CmpErr.