### PR TITLE
DAOS-3553 bio: SCM RDMA update over DRAM buffer

### DIFF
--- a/src/bio/bio_buffer.c
+++ b/src/bio/bio_buffer.c
@@ -34,7 +34,10 @@ dma_free_chunk(struct bio_dma_chunk *chunk)
 	D_ASSERT(chunk->bdc_ref == 0);
 	D_ASSERT(d_list_empty(&chunk->bdc_link));
 
-	spdk_dma_free(chunk->bdc_ptr);
+	if (bio_is_nvme_configured())
+		spdk_dma_free(chunk->bdc_ptr);
+	else
+		D_FREE(chunk->bdc_ptr);
 	D_FREE(chunk);
 }
 
@@ -51,7 +54,10 @@ dma_alloc_chunk(unsigned int cnt)
 		return NULL;
 	}
 
-	chunk->bdc_ptr = spdk_dma_malloc(bytes, BIO_DMA_PAGE_SZ, NULL);
+	if (bio_is_nvme_configured())
+		chunk->bdc_ptr = spdk_dma_malloc(bytes, BIO_DMA_PAGE_SZ, NULL);
+	else
+		D_ALLOC(chunk->bdc_ptr, bytes);
 	if (chunk->bdc_ptr == NULL) {
 		D_ERROR("Failed to allocate %u pages DMA buffer\n", cnt);
 		D_FREE(chunk);
@@ -61,7 +67,6 @@ dma_alloc_chunk(unsigned int cnt)
 
 	return chunk;
 }
-
 
 static void
 dma_buffer_shrink(struct bio_dma_buffer *buf, unsigned int cnt)
@@ -434,7 +439,8 @@ iod_add_chunk(struct bio_desc *biod, struct bio_dma_chunk *chk)
 
 static int
 iod_add_region(struct bio_desc *biod, struct bio_dma_chunk *chk,
-	       unsigned int chk_pg_idx, uint64_t off, uint64_t end)
+	       unsigned int chk_pg_idx, uint64_t off, uint64_t end,
+	       uint16_t media)
 {
 	struct bio_rsrvd_dma *rsrvd_dma = &biod->bd_rsrvd;
 	unsigned int max, cnt;
@@ -464,8 +470,27 @@ iod_add_region(struct bio_desc *biod, struct bio_dma_chunk *chk,
 	rsrvd_dma->brd_regions[cnt].brr_pg_idx = chk_pg_idx;
 	rsrvd_dma->brd_regions[cnt].brr_off = off;
 	rsrvd_dma->brd_regions[cnt].brr_end = end;
+	rsrvd_dma->brd_regions[cnt].brr_media = media;
 	rsrvd_dma->brd_rg_cnt++;
 	return 0;
+}
+
+void
+bio_iod_set_bulk(struct bio_desc *biod, bool bulk)
+{
+	biod->bd_bulk = bulk;
+}
+
+static inline bool
+buffered_rdma(struct bio_desc *biod, struct bio_iov *biov)
+{
+	if (biov->bi_addr.ba_type != DAOS_MEDIA_SCM)	/* NVMe rw */
+		return true;
+	else if (!biod->bd_update)			/* SCM read */
+		return false;
+
+	/* Zero-copy RDMA for inline update, buffered RDMA for bulk update */
+	return bio_buffered_scm_rdma && biod->bd_bulk;
 }
 
 /* Convert offset of @biov into memory pointer */
@@ -488,14 +513,13 @@ dma_map_one(struct bio_desc *biod, struct bio_iov *biov,
 		return 0;
 	}
 
-	if (biov->bi_addr.ba_type == DAOS_MEDIA_SCM) {
+	if (!buffered_rdma(biod, biov)) {
 		struct umem_instance *umem = biod->bd_ctxt->bic_umem;
 
 		biov->bi_buf = umem_off2ptr(umem, bio_iov2off(biov));
 		return 0;
 	}
 
-	D_ASSERT(biov->bi_addr.ba_type == DAOS_MEDIA_NVME);
 	bdb = iod_dma_buf(biod);
 
 	off = bio_iov2off(biov);
@@ -534,7 +558,8 @@ dma_map_one(struct bio_desc *biod, struct bio_iov *biov,
 	last_rg = iod_last_region(biod);
 
 	/* First, try consecutive reserve from the last reserved region */
-	if (last_rg) {
+	if (last_rg && last_rg->brr_media == DAOS_MEDIA_NVME &&
+	    biov->bi_addr.ba_type == DAOS_MEDIA_NVME) {
 		uint64_t cur_pg, prev_pg_start, prev_pg_end;
 
 		D_DEBUG(DB_IO, "Last region %p:%d ["DF_U64","DF_U64")\n",
@@ -620,7 +645,47 @@ add_chunk:
 		return rc;
 	}
 add_region:
-	return iod_add_region(biod, chk, chk_pg_idx, off, end);
+	return iod_add_region(biod, chk, chk_pg_idx, off, end,
+			      biov->bi_addr.ba_type);
+}
+
+void
+bio_memcpy(struct bio_desc *biod, uint16_t media, void *media_addr,
+	   void *addr, ssize_t n)
+{
+	struct umem_instance *umem = biod->bd_ctxt->bic_umem;
+
+	if (biod->bd_update && media == DAOS_MEDIA_SCM) {
+		pmemobj_memcpy_persist(umem->umm_pool, media_addr,
+				       addr, n);
+	} else {
+		if (biod->bd_update)
+			memcpy(media_addr, addr, n);
+		else
+			memcpy(addr, media_addr, n);
+	}
+}
+
+static void
+scm_rw(struct bio_desc *biod, struct bio_rsrvd_region *rg)
+{
+	struct umem_instance	*umem = biod->bd_ctxt->bic_umem;
+	void			*payload;
+	unsigned int		 pg_off;
+
+	/* Only SCM update may go through buffer DMA */
+	D_ASSERT(biod->bd_update);
+	D_ASSERT(bio_buffered_scm_rdma);
+
+	payload = rg->brr_chk->bdc_ptr + (rg->brr_pg_idx << BIO_DMA_PAGE_SHIFT);
+	pg_off = rg->brr_off & ((uint64_t)BIO_DMA_PAGE_SZ - 1);
+	payload += pg_off;
+
+	D_DEBUG(DB_IO, "SCM RDMA update, payload:%p pg_off:%u\n",
+		payload, pg_off);
+
+	bio_memcpy(biod, DAOS_MEDIA_SCM, umem_off2ptr(umem, rg->brr_off),
+		   payload, rg->brr_end - rg->brr_off);
 }
 
 static void
@@ -650,27 +715,18 @@ skip_media_error:
 }
 
 static void
-dma_rw(struct bio_desc *biod, bool prep)
+nvme_rw(struct bio_desc *biod, struct bio_rsrvd_region *rg)
 {
-	struct spdk_io_channel	*channel;
-	struct spdk_blob	*blob;
-	struct bio_rsrvd_dma	*rsrvd_dma = &biod->bd_rsrvd;
-	struct bio_rsrvd_region	*rg;
 	struct bio_xs_context	*xs_ctxt;
-	uint64_t		 pg_idx, pg_cnt, pg_end;
-	void			*payload, *pg_rmw = NULL;
-	bool			 rmw_read = (prep && biod->bd_update);
-	unsigned int		 pg_off;
-	int			 i;
+	struct spdk_blob	*blob;
+	struct spdk_io_channel	*channel;
+	void			*payload;
+	uint64_t		 pg_idx, pg_cnt;
 
 	D_ASSERT(biod->bd_ctxt->bic_xs_ctxt);
 	xs_ctxt = biod->bd_ctxt->bic_xs_ctxt;
 	blob = biod->bd_ctxt->bic_blob;
 	channel = xs_ctxt->bxc_io_channel;
-
-	biod->bd_inflights = 0;
-	biod->bd_dma_issued = 0;
-	biod->bd_result = 0;
 
 	/* Bypass NVMe I/O, used by daos_perf for performance evaluation */
 	if (daos_io_bypass & IOBP_NVME)
@@ -684,75 +740,59 @@ dma_rw(struct bio_desc *biod, bool prep)
 	}
 
 	D_ASSERT(channel != NULL);
+	payload = rg->brr_chk->bdc_ptr + (rg->brr_pg_idx << BIO_DMA_PAGE_SHIFT);
+	pg_idx = rg->brr_off >> BIO_DMA_PAGE_SHIFT;
+	pg_cnt = (rg->brr_end + BIO_DMA_PAGE_SZ - 1) >> BIO_DMA_PAGE_SHIFT;
+
+	D_ASSERT(pg_cnt > pg_idx);
+	pg_cnt -= pg_idx;
+
+	biod->bd_inflights++;
+
+	D_DEBUG(DB_IO, "%s blob:%p payload:%p, pg_idx:"DF_U64", "
+		"pg_cnt:"DF_U64"\n", biod->bd_update ? "Write" : "Read",
+		blob, payload, pg_idx, pg_cnt);
+
+	if (biod->bd_update)
+		spdk_blob_io_write(blob, channel, payload, pg_idx, pg_cnt,
+				   rw_completion, biod);
+	else
+		spdk_blob_io_read(blob, channel, payload, pg_idx, pg_cnt,
+				  rw_completion, biod);
+}
+
+static void
+dma_rw(struct bio_desc *biod)
+{
+	struct bio_rsrvd_dma	*rsrvd_dma = &biod->bd_rsrvd;
+	struct bio_rsrvd_region	*rg;
+	struct bio_xs_context	*xs_ctxt;
+	int			 i;
+
+	D_ASSERT(biod->bd_ctxt->bic_xs_ctxt);
+	xs_ctxt = biod->bd_ctxt->bic_xs_ctxt;
+
+	biod->bd_inflights = 0;
+	biod->bd_dma_issued = 0;
+	biod->bd_result = 0;
 	biod->bd_ctxt->bic_inflight_dmas++;
 
-	D_DEBUG(DB_IO, "DMA start, blob:%p, update:%d, rmw:%d\n",
-		blob, biod->bd_update, rmw_read);
+	D_DEBUG(DB_IO, "DMA start, update:%d\n", biod->bd_update);
 
 	for (i = 0; i < rsrvd_dma->brd_rg_cnt; i++) {
 		rg = &rsrvd_dma->brd_regions[i];
 
 		D_ASSERT(rg->brr_chk != NULL);
-		pg_idx = rg->brr_off >> BIO_DMA_PAGE_SHIFT;
-		payload = rg->brr_chk->bdc_ptr +
-			(rg->brr_pg_idx << BIO_DMA_PAGE_SHIFT);
+		D_ASSERT(rg->brr_end > rg->brr_off);
 
-		if (!rmw_read) {
-			pg_cnt = (rg->brr_end + BIO_DMA_PAGE_SZ - 1) >>
-					BIO_DMA_PAGE_SHIFT;
-			D_ASSERT(pg_cnt > pg_idx);
-			pg_cnt -= pg_idx;
-
-			biod->bd_inflights++;
-
-			D_DEBUG(DB_IO, "%s blob:%p payload:%p, "
-				"pg_idx:"DF_U64", pg_cnt:"DF_U64"\n",
-				biod->bd_update ? "Write" : "Read",
-				blob, payload, pg_idx, pg_cnt);
-
-			if (biod->bd_update)
-				spdk_blob_io_write(blob, channel, payload,
-						   pg_idx, pg_cnt,
-						   rw_completion, biod);
-			else
-				spdk_blob_io_read(blob, channel, payload,
-						  pg_idx, pg_cnt,
-						  rw_completion, biod);
-			continue;
-		}
-
-		/*
-		 * Since DAOS doesn't support partial overwrite yet, we don't
-		 * do RMW for partial update, only zeroing the page instead.
-		 */
-		pg_off = rg->brr_off & ((uint64_t)BIO_DMA_PAGE_SZ - 1);
-
-		if (pg_off != 0 && payload != pg_rmw) {
-			D_DEBUG(DB_IO, "Front partial blob:%p payload:%p, "
-				"pg_idx:"DF_U64" pg_off:%d\n",
-				blob, payload, pg_idx, pg_off);
-
-			memset(payload, 0, BIO_DMA_PAGE_SZ);
-			pg_rmw = payload;
-		}
-
-		pg_end = rg->brr_end >> BIO_DMA_PAGE_SHIFT;
-		D_ASSERT(pg_end >= pg_idx);
-		payload += (pg_end - pg_idx) << BIO_DMA_PAGE_SHIFT;
-		pg_off = rg->brr_end & ((uint64_t)BIO_DMA_PAGE_SZ - 1);
-
-		if (pg_off != 0 && payload != pg_rmw) {
-			D_DEBUG(DB_IO, "Rear partial blob:%p payload:%p, "
-				"pg_idx:"DF_U64" pg_off:%d\n",
-				blob, payload, pg_idx, pg_off);
-
-			memset(payload, 0, BIO_DMA_PAGE_SZ);
-			pg_rmw = payload;
-		}
+		if (rg->brr_media == DAOS_MEDIA_SCM)
+			scm_rw(biod, rg);
+		else
+			nvme_rw(biod, rg);
 	}
 
 	if (xs_ctxt->bxc_tgt_id == -1) {
-		D_DEBUG(DB_IO, "Self poll completion, blob:%p\n", blob);
+		D_DEBUG(DB_IO, "Self poll completion\n");
 		xs_poll_completion(xs_ctxt, &biod->bd_inflights);
 	} else {
 		biod->bd_dma_issued = 1;
@@ -761,25 +801,7 @@ dma_rw(struct bio_desc *biod, bool prep)
 	}
 
 	biod->bd_ctxt->bic_inflight_dmas--;
-	D_DEBUG(DB_IO, "DMA done, blob:%p, update:%d, rmw:%d\n",
-		blob, biod->bd_update, rmw_read);
-}
-
-void
-bio_memcpy(struct bio_desc *biod, uint16_t media, void *media_addr,
-	   void *addr, ssize_t n)
-{
-	struct umem_instance *umem = biod->bd_ctxt->bic_umem;
-
-	if (biod->bd_update && media == DAOS_MEDIA_SCM) {
-		pmemobj_memcpy_persist(umem->umm_pool, media_addr,
-				       addr, n);
-	} else {
-		if (biod->bd_update)
-			memcpy(media_addr, addr, n);
-		else
-			memcpy(addr, media_addr, n);
-	}
+	D_DEBUG(DB_IO, "DMA done, update:%d\n", biod->bd_update);
 }
 
 static int
@@ -916,7 +938,11 @@ retry:
 		goto failed;
 	}
 
-	dma_rw(biod, true);
+	if (!biod->bd_update)
+		dma_rw(biod);
+	else
+		biod->bd_result = 0;
+
 	if (biod->bd_result) {
 		rc = biod->bd_result;
 		goto failed;
@@ -944,7 +970,7 @@ bio_iod_post(struct bio_desc *biod)
 	}
 
 	if (biod->bd_update)
-		dma_rw(biod, false);
+		dma_rw(biod);
 	else
 		biod->bd_result = 0;
 

--- a/src/bio/bio_context.c
+++ b/src/bio/bio_context.c
@@ -511,7 +511,7 @@ bio_blob_open(struct bio_io_context *ctxt, uuid_t uuid, bool async)
 
 int
 bio_ioctxt_open(struct bio_io_context **pctxt, struct bio_xs_context *xs_ctxt,
-		struct umem_instance *umem, uuid_t uuid)
+		struct umem_instance *umem, uuid_t uuid, bool skip_blob)
 {
 	struct bio_io_context	*ctxt;
 	int			 rc;
@@ -525,8 +525,8 @@ bio_ioctxt_open(struct bio_io_context **pctxt, struct bio_xs_context *xs_ctxt,
 	ctxt->bic_pmempool_uuid = umem_get_uuid(umem);
 	ctxt->bic_xs_ctxt = xs_ctxt;
 
-	/* NVMe isn't configured */
-	if (xs_ctxt == NULL) {
+	/* NVMe isn't configured or pool doesn't have NVMe partition */
+	if (!bio_is_nvme_configured() || skip_blob) {
 		*pctxt = ctxt;
 		return 0;
 	}
@@ -609,14 +609,14 @@ bio_blob_close(struct bio_io_context *ctxt, bool async)
 }
 
 int
-bio_ioctxt_close(struct bio_io_context *ctxt)
+bio_ioctxt_close(struct bio_io_context *ctxt, bool skip_blob)
 {
 	struct bio_xs_context	*xs_ctxt;
 	int			 rc;
 
 	xs_ctxt = ctxt->bic_xs_ctxt;
-	/* NVMe isn't configured */
-	if (xs_ctxt == NULL) {
+	/* NVMe isn't configured or pool doesn't have NVMe partition */
+	if (!bio_is_nvme_configured() || skip_blob) {
 		d_list_del_init(&ctxt->bic_link);
 		D_FREE(ctxt);
 		return 0;

--- a/src/bio/bio_internal.h
+++ b/src/bio/bio_internal.h
@@ -151,6 +151,8 @@ struct bio_rsrvd_region {
 	uint64_t		 brr_off;
 	/* End (not included) in bytes */
 	uint64_t		 brr_end;
+	/* Media type */
+	uint16_t		 brr_media;
 };
 
 /* Reserved DMA buffer for certain io descriptor */
@@ -186,7 +188,8 @@ struct bio_desc {
 	unsigned int		 bd_buffer_prep:1,
 				 bd_update:1,
 				 bd_dma_issued:1,
-				 bd_retry:1;
+				 bd_retry:1,
+				 bd_bulk:1;
 };
 
 static inline struct spdk_thread *
@@ -221,6 +224,7 @@ extern unsigned int	bio_chk_cnt_max;
 extern uint64_t		io_stat_period;
 void xs_poll_completion(struct bio_xs_context *ctxt, unsigned int *inflights);
 int get_bdev_type(struct spdk_bdev *bdev);
+extern bool bio_buffered_scm_rdma;
 
 /* bio_buffer.c */
 void dma_buffer_destroy(struct bio_dma_buffer *buf);

--- a/src/include/daos_srv/bio.h
+++ b/src/include/daos_srv/bio.h
@@ -219,6 +219,11 @@ int bio_nvme_init(const char *storage_path, const char *nvme_conf, int shm_id,
  */
 void bio_nvme_fini(void);
 
+/**
+ * Check if NVMe is configured
+ */
+bool bio_is_nvme_configured(void);
+
 /*
  * Initialize SPDK env and per-xstream NVMe context.
  *
@@ -276,21 +281,23 @@ int bio_blob_delete(uuid_t uuid, struct bio_xs_context *xs_ctxt);
  * \param[IN] xs_ctxt	Per-xstream NVMe context
  * \param[IN] umem	umem instance
  * \param[IN] uuid	Pool UUID
+ * \param[IN] skip_blob	Skip blob open since no NVMe partition
  *
  * \returns		Zero on success, negative value on error
  */
 int bio_ioctxt_open(struct bio_io_context **pctxt,
 		    struct bio_xs_context *xs_ctxt,
-		    struct umem_instance *umem, uuid_t uuid);
+		    struct umem_instance *umem, uuid_t uuid, bool skip_blob);
 
 /*
  * Finalize per VOS instance I/O context.
  *
  * \param[IN] ctxt	I/O context
+ * \param[IN] skip_blob	Skip blob close since no NVMe partition
  *
  * \returns		Zero on success, negative value on error
  */
-int bio_ioctxt_close(struct bio_io_context *ctxt);
+int bio_ioctxt_close(struct bio_io_context *ctxt, bool skip_blob);
 
 /*
  * Unmap (TRIM) the extent being freed.
@@ -428,6 +435,14 @@ int bio_iod_copy(struct bio_desc *biod, d_sg_list_t *sgls, unsigned int nr_sgl);
  * \return			SG list, or NULL on error
  */
 struct bio_sglist *bio_iod_sgl(struct bio_desc *biod, unsigned int idx);
+
+/*
+ * Mark the iod needing bulk transfer.
+ *
+ * \param biod       [IN]	io descriptor
+ * \param bulk       [IN]	true for false
+ */
+void bio_iod_set_bulk(struct bio_desc *biod, bool bulk);
 
 /*
  * Wrapper of ABT_thread_yield()

--- a/src/object/srv_obj.c
+++ b/src/object/srv_obj.c
@@ -856,6 +856,7 @@ obj_local_rw(crt_rpc_t *rpc, struct ds_cont_hdl *cont_hdl,
 	}
 
 	biod = vos_ioh2desc(ioh);
+	bio_iod_set_bulk(biod, rma);
 	rc = bio_iod_prep(biod);
 	if (rc) {
 		D_ERROR(DF_UOID" bio_iod_prep failed: %d.\n",

--- a/src/vos/vos_pool.c
+++ b/src/vos/vos_pool.c
@@ -119,7 +119,8 @@ pool_hop_free(struct d_ulink *hlink)
 	D_ASSERT(pool->vp_opened == 0);
 
 	if (pool->vp_io_ctxt != NULL) {
-		rc = bio_ioctxt_close(pool->vp_io_ctxt);
+		rc = bio_ioctxt_close(pool->vp_io_ctxt,
+				      pool->vp_pool_df->pd_nvme_sz == 0);
 		if (rc)
 			D_ERROR("Closing VOS I/O context:%p pool:"DF_UUID"\n",
 				pool->vp_io_ctxt, DP_UUID(pool->vp_id));
@@ -207,7 +208,7 @@ vos_blob_format_cb(void *cb_data, struct umem_instance *umem)
 	int			 rc;
 
 	/* Create a bio_io_context to get the blob */
-	rc = bio_ioctxt_open(&ioctxt, xs_ctxt, umem, blob_hdr->bbh_pool);
+	rc = bio_ioctxt_open(&ioctxt, xs_ctxt, umem, blob_hdr->bbh_pool, false);
 	if (rc) {
 		D_ERROR("Failed to create an ioctxt for writing blob header\n");
 		return rc;
@@ -219,7 +220,7 @@ vos_blob_format_cb(void *cb_data, struct umem_instance *umem)
 		D_ERROR("Failed to write header for blob:"DF_U64"\n",
 			blob_hdr->bbh_blob_id);
 
-	rc = bio_ioctxt_close(ioctxt);
+	rc = bio_ioctxt_close(ioctxt, false);
 	if (rc)
 		D_ERROR("Failed to free ioctxt\n");
 
@@ -345,7 +346,7 @@ end:
 	}
 
 	/* SCM only pool or NVMe device isn't configured */
-	if (nvme_sz == 0 || xs_ctxt == NULL)
+	if (nvme_sz == 0 || !bio_is_nvme_configured())
 		goto close;
 
 	/* Create SPDK blob on NVMe device */
@@ -426,7 +427,7 @@ vos_pool_kill(uuid_t uuid, bool force)
 	D_DEBUG(DB_MGMT, "No open handles, OK to delete\n");
 
 	/* NVMe device is configured */
-	if (xs_ctxt) {
+	if (bio_is_nvme_configured()) {
 		D_DEBUG(DB_MGMT, "Deleting blob for xs:%p pool:"DF_UUID"\n",
 			xs_ctxt, DP_UUID(uuid));
 		rc = bio_blob_delete(uuid, xs_ctxt);
@@ -573,18 +574,19 @@ vos_pool_open(const char *path, uuid_t uuid, daos_handle_t *poh)
 		D_GOTO(failed, rc);
 	}
 
-	xs_ctxt = pool_df->pd_nvme_sz == 0 ? NULL : vos_xsctxt_get();
+	xs_ctxt = vos_xsctxt_get();
 
 	D_DEBUG(DB_MGMT, "Opening VOS I/O context for xs:%p pool:"DF_UUID"\n",
 		xs_ctxt, DP_UUID(uuid));
-	rc = bio_ioctxt_open(&pool->vp_io_ctxt, xs_ctxt, &pool->vp_umm, uuid);
+	rc = bio_ioctxt_open(&pool->vp_io_ctxt, xs_ctxt, &pool->vp_umm, uuid,
+			     pool_df->pd_nvme_sz == 0);
 	if (rc) {
 		D_ERROR("Failed to open VOS I/O context for xs:%p "
 			"pool:"DF_UUID" rc=%d\n", xs_ctxt, DP_UUID(uuid), rc);
 		goto failed;
 	}
 
-	if (xs_ctxt != NULL) {
+	if (bio_is_nvme_configured() && pool_df->pd_nvme_sz != 0) {
 		struct vea_unmap_context unmap_ctxt;
 
 		/* set unmap callback fp */


### PR DESCRIPTION
Implement SCM RDMA update over DRAM buffer since the AEP RDMA update
performance isn't good at this moment. This feature can be enabled
by setting env BIO_BUFFERED_SCM_RDMA=1.

Signed-off-by: Niu Yawei <yawei.niu@intel.com>
Change-Id: I2ca05627d6653b4208180a6161a4cd3e74d81001