### PR TITLE
DAOS-3531 object: extra reference for inflight bulk

### DIFF
--- a/src/object/srv_obj.c
+++ b/src/object/srv_obj.c
@@ -208,6 +208,7 @@ ds_bulk_transfer(crt_rpc_t *rpc, crt_bulk_op_t bulk_op, bool bulk_bind,
 
 	D_DEBUG(DB_IO, "bulk_op:%d sgl_nr%d\n", bulk_op, sgl_nr);
 
+	arg.bulks_inflight++;
 	for (i = 0; i < sgl_nr; i++) {
 		d_sg_list_t		*sgl, tmp_sgl;
 		struct crt_bulk_desc	 bulk_desc;
@@ -320,7 +321,7 @@ next:
 			break;
 	}
 
-	if (arg.bulks_inflight == 0)
+	if (--arg.bulks_inflight == 0)
 		ABT_eventual_set(arg.eventual, &rc, sizeof(rc));
 
 	ret = ABT_eventual_wait(arg.eventual, (void **)&status);
@@ -627,6 +628,7 @@ ec_update_bulk_transfer(crt_rpc_t *rpc, bool bulk_bind,
 	if (rc != 0)
 		return dss_abterr2der(rc);
 
+	arg.bulks_inflight++;
 	for (i = 0; i < sgl_nr; i++) {
 		d_sg_list_t		*sgl, tmp_sgl;
 		struct crt_bulk_desc	 bulk_desc;
@@ -724,7 +726,7 @@ next:
 		D_FREE(skip_list[i]);
 	}
 
-	if (arg.bulks_inflight == 0)
+	if (--arg.bulks_inflight == 0)
 		ABT_eventual_set(arg.eventual, &rc, sizeof(rc));
 
 	ret = ABT_eventual_wait(arg.eventual, (void **)&status);


### PR DESCRIPTION
Add extra reference for inflight bulk, so to avoid
bulk_comp_cb is called even before fire all bulk
transfer, then then eventual might be set even before
all bulk transfer is finished.

Signed-off-by: Di Wang <di.wang@intel.com>