### PR TITLE
DAOS-3163 rebuild: stop rebuild during pool destory

### DIFF
--- a/src/mgmt/srv_target.c
+++ b/src/mgmt/srv_target.c
@@ -34,6 +34,7 @@
 
 #include <daos_srv/vos.h>
 #include <daos_srv/pool.h>
+#include <daos_srv/rebuild.h>
 #include <daos_srv/daos_mgmt_srv.h>
 
 #include "srv_internal.h"
@@ -681,6 +682,7 @@ ds_mgmt_hdlr_tgt_destroy(crt_rpc_t *td_req)
 	td_out = crt_reply_get(td_req);
 	D_ASSERT(td_in != NULL && td_out != NULL);
 
+	ds_rebuild_leader_stop(td_in->td_pool_uuid, -1);
 	/** generate path to the target directory */
 	rc = ds_mgmt_tgt_file(td_in->td_pool_uuid, NULL, NULL, &path);
 	if (rc)

--- a/src/pool/srv_pool.c
+++ b/src/pool/srv_pool.c
@@ -735,7 +735,6 @@ ds_pool_svc_destroy(const uuid_t pool_uuid)
 	crt_group_t    *group;
 	int		rc;
 
-	ds_rebuild_leader_stop(pool_uuid, -1);
 	rc = ds_pool_get_ranks(pool_uuid, MAP_RANKS_DOWN, &excluded);
 	if (rc)
 		return rc;


### PR DESCRIPTION
It should not stop the rebuild leader in pool_svc_stop,
since it is called by mgmt module, which is on rank 0,
not on the real pool leader.

Instead it should try stop the rebuild on all targets.

Signed-off-by: Wang Di <di.wang@intel.com>