### PR TITLE
DAOS-2444 obj: EC refining (client)

### DIFF
--- a/src/include/daos/common.h
+++ b/src/include/daos/common.h
@@ -213,6 +213,41 @@ daos_size_t daos_sgl_buf_size(d_sg_list_t *sgl);
 daos_size_t daos_sgls_buf_size(d_sg_list_t *sgls, int nr);
 daos_size_t daos_sgls_packed_size(d_sg_list_t *sgls, int nr,
 				  daos_size_t *buf_size);
+/** Move to next iov, it's caller's responsibility to ensure the idx boundary */
+#define daos_sgl_next_iov(iov_idx, iov_off)				\
+	do {								\
+		(iov_idx)++;						\
+		(iov_off) = 0;						\
+	} while (0)
+/** Get the leftover space in an iov of sgl */
+#define daos_iov_left(sgl, iov_idx, iov_off)				\
+	((sgl)->sg_iovs[iov_idx].iov_len - (iov_off))
+/**
+ * Move sgl forward from iov_idx/iov_off, with move_dist distance. It is
+ * caller's responsibility to check the boundary.
+ */
+#define daos_sgl_move(sgl, iov_idx, iov_off, move_dist)			       \
+	do {								       \
+		uint64_t moved = 0, step, iov_left;			       \
+		if ((move_dist) <= 0)					       \
+			break;						       \
+		while (moved < (move_dist)) {				       \
+			iov_left = daos_iov_left(sgl, iov_idx, iov_off);       \
+			step = MIN(iov_left, (move_dist) - moved);	       \
+			(iov_off) += step;				       \
+			moved += step;					       \
+			if (daos_iov_left(sgl, iov_idx, iov_off) == 0)	       \
+				daos_sgl_next_iov(iov_idx, iov_off);	       \
+		}							       \
+		D_ASSERT(moved == (move_dist));				       \
+	} while (0)
+
+#ifndef roundup
+#define roundup(x, y)		((((x) + ((y) - 1)) / (y)) * (y))
+#endif
+#ifndef rounddown
+#define rounddown(x, y)		(((x) / (y)) * (y))
+#endif
 
 /**
  * Request a buffer of length \a bytes_needed from the sgl starting at

--- a/src/object/cli_shard.c
+++ b/src/object/cli_shard.c
@@ -394,6 +394,14 @@ dc_obj_shard_rw(struct dc_obj_shard *shard, enum obj_rpc_opc opc,
 		orw->orw_bulks.ca_arrays = NULL;
 	}
 
+	if (args->ec_recxs != NULL) {
+		D_ASSERT(args->ec_bulks != NULL);
+		orw->orw_ec_recxs.ca_count = nr;
+		orw->orw_ec_recxs.ca_arrays = args->ec_recxs;
+		orw->orw_ec_bulks.ca_count = nr;
+		orw->orw_ec_bulks.ca_arrays = args->ec_bulks;
+	}
+
 	crt_req_addref(req);
 	rw_args.rpc = req;
 	rw_args.hdlp = (daos_handle_t *)pool;

--- a/src/object/obj_class.c
+++ b/src/object/obj_class.c
@@ -499,6 +499,11 @@ obj_ec_codec_init()
 		ec_codec = &oc_ec_codecs[i++].ec_codec;
 		k = oc->oc_attr.ca_ec_k;
 		p = oc->oc_attr.ca_ec_p;
+		if (k > OBJ_EC_MAX_K || p > OBJ_EC_MAX_P) {
+			D_ERROR("invalid k %d p %d (max k %d, max p %d)\n",
+				k, p, OBJ_EC_MAX_K, OBJ_EC_MAX_P);
+			D_GOTO(failed, rc = -DER_INVAL);
+		}
 		m = k + p;
 		/* 32B needed for data generated for each input coefficient */
 		D_ALLOC(ec_codec->ec_gftbls, k * p * 32);

--- a/src/object/obj_ec.h
+++ b/src/object/obj_ec.h
@@ -1,0 +1,139 @@
+/**
+ * (C) Copyright 2019 Intel Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * GOVERNMENT LICENSE RIGHTS-OPEN SOURCE SOFTWARE
+ * The Government's rights to use, modify, reproduce, release, perform, display,
+ * or disclose this software are subject to the terms of the Apache License as
+ * provided in Contract No. B609815.
+ * Any reproduction of computer software, computer software documentation, or
+ * portions thereof marked with this legend must also reproduce the markings.
+ */
+
+#ifndef __OBJ_EC_H__
+#define __OBJ_EC_H__
+
+#include <daos_types.h>
+#include <daos_obj.h>
+
+#include <isa-l.h>
+
+/**
+ * Flag to differentiate EC cell size defined as number of
+ * records (== 1) or bytes (== 0).
+ */
+#define OBJ_EC_CELL_ON_RECORD	(0)
+/** MAX number of data cells */
+#define OBJ_EC_MAX_K		(48)
+/** MAX number of parity cells */
+/** if (k + p) exceed 64, need to change tgt_set related code */
+#define OBJ_EC_MAX_P		(16)
+
+/** EC codec for object EC encoding/decoding */
+struct obj_ec_codec {
+	/** encode matrix, can be used to generate decode matrix */
+	unsigned char		*ec_en_matrix;
+	/**
+	 * GF (galois field) tables, pointer to array of input tables generated
+	 * from coding coefficients. Needed for both encoding and decoding.
+	 */
+	unsigned char		*ec_gftbls;
+};
+
+/**
+ * To record the recxs in original iod which include full stripes,
+ * size 8B aligned as will be used in RPC request.
+ */
+struct obj_ec_recx {
+	/** index of the recx in original iod::iod_recxs array */
+	uint32_t		oer_idx;
+	/** number of full stripes in oer_recx */
+	uint32_t		oer_stripe_nr;
+	/**
+	 * the byte offset of the start of oer_recx, in the extends covered by
+	 * iod::iod_recxs array. Can be used to find corresponding sgl offset.
+	 */
+	uint64_t		oer_byte_off;
+	/** the extend that includes the full stripes */
+	daos_recx_t		oer_recx;
+	/** checksum associate with the checksum (TODO) */
+	daos_csum_buf_t		oer_csum;
+};
+
+/** To record all full stripe recxs in one iod, size 8B aligned. */
+struct obj_ec_recx_array {
+	/* number of valid items in oer_recxs array */
+	uint32_t		 oer_nr;
+	/* total number of full stripes in oer_recxs array */
+	uint32_t		 oer_stripe_total;
+	struct obj_ec_recx	*oer_recxs;
+};
+
+/**
+ * EC parity code structure for all iods, each field is an array pointer that
+ * with daos_obj_rw_t::nr elements.
+ */
+struct obj_ec_pcode {
+	struct obj_ec_recx_array	*oep_ec_recxs;
+	crt_bulk_t			*oep_bulks;
+	d_sg_list_t			*oep_sgls;
+};
+
+static inline void
+obj_ec_recx_array_dump(struct obj_ec_recx_array *ac_rexc_array)
+{
+	struct obj_ec_recx	*ec_recx;
+	int			 i;
+
+	D_PRINT("obj_ec_recx_array %p:\n", ac_rexc_array);
+	D_PRINT("oer_nr %d\n", ac_rexc_array->oer_nr);
+	D_PRINT("oer_stripe_total %d\n", ac_rexc_array->oer_stripe_total);
+	for (i = 0; i < ac_rexc_array->oer_nr; i++) {
+		ec_recx = &ac_rexc_array->oer_recxs[i];
+		D_PRINT("oer_recxs: [%3d] - idx %d, stripe_nr %d, byte_off %d, "
+			"recx_idx %d, recx_nr %d.\n", i, ec_recx->oer_idx,
+			ec_recx->oer_stripe_nr, (int)ec_recx->oer_byte_off,
+			(int)ec_recx->oer_recx.rx_idx,
+			(int)ec_recx->oer_recx.rx_nr);
+	}
+}
+
+#if OBJ_EC_CELL_ON_RECORD
+/** Query the number of records in EC full stripe */
+#define obj_ec_stripe_rec_nr(iod, oca)					\
+	((oca)->u.ec.e_k * (oca)->u.ec.e_len)
+/** Query the number of bytes in EC cell */
+#define obj_ec_cell_bytes(iod, oca)					\
+	(((oca)->u.ec.e_len) * ((iod)->iod_size))
+#else
+#define obj_ec_stripe_rec_nr(iod, oca)					\
+	(((oca)->u.ec.e_k * (oca)->u.ec.e_len) / ((iod)->iod_size))
+#define obj_ec_cell_bytes(iod, oca)					\
+	((oca)->u.ec.e_len)
+#endif
+
+/* obj_class.c */
+int obj_ec_codec_init(void);
+void obj_ec_codec_fini(void);
+struct obj_ec_codec *obj_ec_codec_get(daos_oclass_id_t oc_id);
+
+/* cli_ec.c */
+int obj_ec_recxs_init(struct obj_ec_recx_array *recxs, uint32_t recx_nr);
+void obj_ec_recxs_fini(struct obj_ec_recx_array *recxs);
+void obj_ec_pcode_fini(struct obj_ec_pcode *pcode, uint32_t nr);
+int obj_ec_update_encode(daos_obj_update_t *args, daos_obj_id_t oid,
+			 struct daos_oclass_attr *oca,
+			 struct obj_ec_pcode *pcode, uint64_t *tgt_set);
+
+#endif /* __OBJ_EC_H__ */

--- a/src/object/obj_internal.h
+++ b/src/object/obj_internal.h
@@ -41,6 +41,7 @@
 #include <daos_srv/dtx_srv.h>
 
 #include "obj_rpc.h"
+#include "obj_ec.h"
 
 /**
  * This environment is mostly for performance evaluation.
@@ -123,17 +124,6 @@ struct dc_object {
 	struct dc_obj_layout	*cob_shards;
 };
 
-/** EC codec for object EC encoding/decoding */
-struct obj_ec_codec {
-	/** encode matrix, can be used to generate decode matrix */
-	unsigned char		*ec_en_matrix;
-	/**
-	 * GF (galois field) tables, pointer to array of input tables generated
-	 * from coding coefficients. Needed for both encoding and decoding.
-	 */
-	unsigned char		*ec_gftbls;
-};
-
 static inline void
 enum_anchor_copy(daos_anchor_t *dst, daos_anchor_t *src)
 {
@@ -191,11 +181,13 @@ struct shard_auxi_args {
 };
 
 struct shard_rw_args {
-	struct shard_auxi_args	 auxi;
-	daos_obj_rw_t		*api_args;
-	struct dtx_id		 dti;
-	uint64_t		 dkey_hash;
-	crt_bulk_t		*bulks;
+	struct shard_auxi_args		 auxi;
+	daos_obj_rw_t			*api_args;
+	struct dtx_id			 dti;
+	uint64_t			 dkey_hash;
+	crt_bulk_t			*bulks;
+	struct obj_ec_recx_array	*ec_recxs;
+	crt_bulk_t			*ec_bulks;
 };
 
 struct shard_punch_args {
@@ -365,10 +357,6 @@ obj_dkey2hash(daos_key_t *dkey)
 int  obj_utils_init(void);
 void obj_utils_fini(void);
 
-/* obj_class.c */
-int obj_ec_codec_init(void);
-void obj_ec_codec_fini(void);
-struct obj_ec_codec *obj_ec_codec_get(daos_oclass_id_t oc_id);
 int obj_encode_full_stripe(daos_obj_id_t oid, d_sg_list_t *sgl,
 			   uint32_t *sg_idx, size_t *sg_off,
 			   struct obj_ec_parity *parity, int p_idx);

--- a/src/object/obj_rpc.h
+++ b/src/object/obj_rpc.h
@@ -39,6 +39,8 @@
 #include <daos/dtx.h>
 #include <daos/object.h>
 
+#include "obj_ec.h"
+
 /* It cannot exceed the mercury unexpected msg size (4KB), reserves half-KB
  * for other RPC fields and cart/HG headers.
  */
@@ -140,6 +142,8 @@ enum obj_rpc_flags {
 	((daos_iod_t)		(orw_iods)		CRT_ARRAY) \
 	((d_sg_list_t)		(orw_sgls)		CRT_ARRAY) \
 	((crt_bulk_t)		(orw_bulks)		CRT_ARRAY) \
+	((struct obj_ec_recx_array)	(orw_ec_recxs)	CRT_ARRAY) \
+	((crt_bulk_t)		(orw_ec_bulks)		CRT_ARRAY) \
 	((struct daos_shard_tgt) (orw_shard_tgts)	CRT_ARRAY)
 
 #define DAOS_OSEQ_OBJ_RW	/* output fields */		 \

--- a/src/object/srv_ec.c
+++ b/src/object/srv_ec.c
@@ -21,7 +21,7 @@
  * portions thereof marked with this legend must also reproduce the markings.
  */
 /**
- * This file is part of daos_sr
+ * DAOS server erasure-coded object handling.
  *
  * src/object/srv_ec.c
  */


### PR DESCRIPTION
At client-side add EC by steps of:
1) obj_ec_recx_scan
   scan input IOD to get which set of extends need to do EN encoding,
   record it by struct obj_ec_recx_array.
2) obj_ec_recx_encode
   Generate the parity code according to obj_ec_recx_array. And create
   one separate bulk handle for parity buffer.

RPC change: add obj_ec_recx_array and ec_bulks to RPC request.

Server-side (TODO) based on obj_ec_recx_array can filter each target
applicable portion.

Signed-off-by: Xuezhao Liu <xuezhao.liu@intel.com>