### PR TITLE
DAOS-3415 control: spdk setup no chmod as root

### DIFF
--- a/src/control/server/init/setup_spdk.sh
+++ b/src/control/server/init/setup_spdk.sh
@@ -19,11 +19,12 @@ else
 
 	# build arglist manually to filter missing directories/files
 	# so we don't error on non-existent entities
-	for glob in /dev/hugepages '/dev/uio*'		\
+	for glob in '/dev/hugepages' '/dev/uio*'		\
 		'/sys/class/uio/uio*/device/config'	\
 		'/sys/class/uio/uio*/device/resource*'; do
 
-		if list=$(ls "$glob"); then
+		if list=$(ls $glob); then
+			echo "RUN: ls $glob | xargs -r chown -R $_TARGET_USER"
 			echo "$list" | xargs -r chown -R "$_TARGET_USER"
 		fi
 	done


### PR DESCRIPTION
Follow on change to fix bug introduced by fixing a checkpatch warning
by quoting to avoid unwanted variable expansion when in fact it was
necessary.  Also print stdout of spdk setup script if debug option
selected in storage prepare command.

Signed-off-by: Tom Nabarro <tom.nabarro@intel.com>