### PR TITLE
DAOS-3803 dfuse: Update admin guide for new dfuse options.

### DIFF
--- a/doc/admin/app_interface_tiering.md
+++ b/doc/admin/app_interface_tiering.md
@@ -154,7 +154,7 @@ is granted access to the pool and container).
 To mount an existing POSIX container with dfuse, run the following command:
 
 ```
-$ dfuse -p a171434a-05a5-4671-8fe2-615aa0d05094 -s 0 -c 464e68ca-0a30-4a5f-8829-238e890899d2 -m /tmp/daos -S
+$ dfuse --pool a171434a-05a5-4671-8fe2-615aa0d05094 -s 0 --container 464e68ca-0a30-4a5f-8829-238e890899d2 -m /tmp/daos
 ```
 
 The UUID after -p and -c should be replaced with respectively the pool and
@@ -163,15 +163,20 @@ local directory where the mount point will be setup.
 When done, the file system can be unmounted via fusermount:
 
 ```
-$ fusermount -u /tmp/daos
+$ fusermount3 -u /tmp/daos
 ```
 
 ### libioil
 
-An interception library called libioil is under development. This library will
-work in conjunction with dfuse and allow to intercept POSIX read(2) and write(2)
-and issue the I/O operations directly from the application context through
-libdaos and without any application changes.
+An interception library called libioil is available to work with dfuse. This
+library works in conjunction with dfuse and allow to interception of POSIX I/O
+calls and issue the I/O operations directly from the application context through
+libdaos without any appliction changes.  This provides kernel-bypass for I/O data
+leading to improved performance.
+To use this set the LD_PRELOAD to point to the shared libray in the DOAS install
+dir
+
+LD_PRELOAD=/path/to/daos/install/lib/libioil.so
 
 Support for libioil is currently planned for DAOS v1.2.
 


### PR DESCRIPTION
Use long versions of options and remove -S from example.

Improve the text on interception library support.