### PR TITLE
DAOS-3557 pool: allocate buffer by real pool size

### DIFF
--- a/src/common/pool_map.c
+++ b/src/common/pool_map.c
@@ -696,6 +696,17 @@ pool_tree_count(struct pool_domain *tree, struct pool_comp_cntr *cntr)
 	}
 }
 
+int
+pool_map_comp_cnt(struct pool_map *map)
+{
+	struct pool_comp_cntr cntr = {0};
+
+	D_ASSERT(map->po_tree != NULL);
+	pool_tree_count(&map->po_tree[1], &cntr);
+
+	return cntr.cc_domains + cntr.cc_targets;
+}
+
 /**
  * Calculate memory size of the component tree.
  */

--- a/src/include/daos/pool_map.h
+++ b/src/include/daos/pool_map.h
@@ -175,6 +175,8 @@ int  pool_buf_extract(struct pool_map *map, struct pool_buf **buf_pp);
 int  pool_buf_attach(struct pool_buf *buf, struct pool_component *comps,
 		     unsigned int comp_nr);
 
+int pool_map_comp_cnt(struct pool_map *map);
+
 int  pool_map_create(struct pool_buf *buf, uint32_t version,
 		     struct pool_map **mapp);
 void pool_map_addref(struct pool_map *map);

--- a/src/pool/cli.c
+++ b/src/pool/cli.c
@@ -150,7 +150,7 @@ flags_are_valid(unsigned int flags)
 #define DC_POOL_DEFAULT_COMPONENTS_NR 128
 
 static struct dc_pool *
-pool_alloc(void)
+pool_alloc(unsigned int nr)
 {
 	struct dc_pool *pool;
 	int rc = 0;
@@ -179,7 +179,7 @@ pool_alloc(void)
 		goto failed;
 	}
 
-	pool->dp_map_sz = pool_buf_size(DC_POOL_DEFAULT_COMPONENTS_NR);
+	pool->dp_map_sz = pool_buf_size(nr);
 
 	return pool;
 
@@ -471,7 +471,7 @@ dc_pool_local_open(uuid_t pool_uuid, uuid_t pool_hdl_uuid,
 	}
 
 	/** allocate and fill in pool connection */
-	pool = pool_alloc();
+	pool = pool_alloc(pool_map_comp_cnt(map));
 	if (pool == NULL)
 		D_GOTO(out, rc = -DER_NOMEM);
 
@@ -551,7 +551,7 @@ dc_pool_connect(tse_task_t *task)
 			D_GOTO(out_task, rc = -DER_INVAL);
 
 		/** allocate and fill in pool connection */
-		pool = pool_alloc();
+		pool = pool_alloc(DC_POOL_DEFAULT_COMPONENTS_NR);
 		if (pool == NULL)
 			D_GOTO(out_task, rc = -DER_NOMEM);
 		uuid_copy(pool->dp_pool, args->uuid);
@@ -964,7 +964,7 @@ dc_pool_g2l(struct dc_pool_glob *pool_glob, size_t len, daos_handle_t *poh)
 	D_ASSERT(map_buf != NULL);
 
 	/** allocate and fill in pool connection */
-	pool = pool_alloc();
+	pool = pool_alloc(pool_glob->dpg_map_pb_nr);
 	if (pool == NULL)
 		D_GOTO(out, rc = -DER_NOMEM);
 


### PR DESCRIPTION
Allocate the pool buffer by real pool size, otherwise
dc_pool_l2g(g2l) will use the default pool size, which
might force the client to query the pool multiple times.

Signed-off-by: Di Wang <di.wang@intel.com>