### PR TITLE
DAOS-2429 dtx: DTX performance optimization - V8

### DIFF
--- a/src/dtx/dtx_internal.h
+++ b/src/dtx/dtx_internal.h
@@ -71,7 +71,12 @@ CRT_RPC_DECLARE(dtx, DAOS_ISEQ_DTX, DAOS_OSEQ_DTX);
 /* The count threshould for triggerring DTX aggregation.
  * This threshould should consider the real SCM size.
  */
-#define DTX_AGG_THRESHOLD_CNT		(1 << 27)
+#define DTX_AGG_THRESHOLD_CNT_UPPER	(1 << 27)
+
+/* If the DTX entries are not more than this count threshould,
+ * then no need DTX aggregation.
+ */
+#define DTX_AGG_THRESHOLD_CNT_LOWER	(1 << 17)
 
 /* The time threshould for triggerring DTX aggregation. If the oldest
  * DTX in the DTX table exceeds such threshould, it will trigger DTX
@@ -83,8 +88,6 @@ CRT_RPC_DECLARE(dtx, DAOS_ISEQ_DTX, DAOS_OSEQ_DTX);
  * this threshold will be aggregated.
  */
 #define DTX_AGG_THRESHOLD_AGE_LOWER	3600
-
-#define DTX_AGG_YIELD_INTERVAL		DTX_THRESHOLD_COUNT
 
 extern struct crt_proto_format dtx_proto_fmt;
 extern btr_ops_t dbtree_dtx_cf_ops;

--- a/src/dtx/dtx_resync.c
+++ b/src/dtx/dtx_resync.c
@@ -116,9 +116,9 @@ dtx_resync_commit(uuid_t po_uuid, struct ds_cont_child *cont,
 					true : false);
 		if (rc == -DER_NONEXIST) {
 			rc = vos_dtx_add_cos(cont->sc_hdl, &dre->dre_oid,
-				&dre->dre_xid, dre->dre_hash, dre->dre_epoch,
+				&dre->dre_xid, dre->dre_hash, dre->dre_epoch, 0,
 				dre->dre_intent == DAOS_INTENT_PUNCH ?
-				true : false, false);
+				true : false);
 			if (rc < 0)
 				D_WARN("Fail to add DTX "DF_DTI" to CoS cache: "
 				       "rc = %d\n",  DP_DTI(&dre->dre_xid), rc);
@@ -289,10 +289,6 @@ dtx_iter_cb(uuid_t co_uuid, vos_iter_entry_t *ent, void *args)
 	struct dtx_resync_args		*dra = args;
 	struct dtx_resync_entry		*dre;
 
-	/* Ignore new DTX after the rebuild/recovery start. */
-	if (ent->ie_dtx_time > dra->cont->sc_dtx_resync_time)
-		return 0;
-
 	/* We commit the DTXs periodically, there will be not too many DTXs
 	 * to be checked when resync. So we can load all those uncommitted
 	 * DTXs in RAM firstly, then check the state one by one. That avoid
@@ -352,7 +348,9 @@ dtx_resync(daos_handle_t po_hdl, uuid_t po_uuid, uuid_t co_uuid, uint32_t ver,
 	cont->sc_dtx_resyncing = 1;
 	ABT_mutex_unlock(cont->sc_mutex);
 
-	cont->sc_dtx_resync_time = crt_hlc_get();
+	rc = vos_dtx_update_resync_gen(cont->sc_hdl);
+	if (rc != 0)
+		goto fail;
 
 	dra.cont = cont;
 	uuid_copy(dra.po_uuid, po_uuid);
@@ -375,6 +373,7 @@ dtx_resync(daos_handle_t po_hdl, uuid_t po_uuid, uuid_t co_uuid, uint32_t ver,
 	if (rc >= 0)
 		rc = rc1;
 
+fail:
 	D_DEBUG(DB_TRACE, "resync DTX scan "DF_UUID"/"DF_UUID" stop: rc = %d\n",
 		DP_UUID(po_uuid), DP_UUID(co_uuid), rc);
 

--- a/src/dtx/dtx_srv.c
+++ b/src/dtx/dtx_srv.c
@@ -33,13 +33,19 @@
 #include <daos_srv/dtx_srv.h>
 #include "dtx_internal.h"
 
+#define DTX_YIELD_CYCLE		(DTX_THRESHOLD_COUNT >> 3)
+
 static void
 dtx_handler(crt_rpc_t *rpc)
 {
 	struct dtx_in		*din = crt_req_get(rpc);
 	struct dtx_out		*dout = crt_reply_get(rpc);
 	struct ds_cont_child	*cont = NULL;
+	struct dtx_id		*dtis;
 	uint32_t		 opc = opc_get(rpc->cr_opc);
+	int			 count = DTX_YIELD_CYCLE;
+	int			 i = 0;
+	int			 rc1;
 	int			 rc;
 
 	rc = ds_cont_child_lookup(din->di_po_uuid, din->di_co_uuid, &cont);
@@ -52,13 +58,31 @@ dtx_handler(crt_rpc_t *rpc)
 
 	switch (opc) {
 	case DTX_COMMIT:
-		rc = vos_dtx_commit(cont->sc_hdl, din->di_dtx_array.ca_arrays,
-				    din->di_dtx_array.ca_count);
+		while (i < din->di_dtx_array.ca_count) {
+			if (i + count > din->di_dtx_array.ca_count)
+				count = din->di_dtx_array.ca_count - i;
+
+			dtis = (struct dtx_id *)din->di_dtx_array.ca_arrays + i;
+			rc1 = vos_dtx_commit(cont->sc_hdl, dtis, count);
+			if (rc == 0 && rc1 != 0)
+				rc = rc1;
+
+			i += count;
+		}
 		break;
 	case DTX_ABORT:
-		rc = vos_dtx_abort(cont->sc_hdl, din->di_epoch,
-				   din->di_dtx_array.ca_arrays,
-				   din->di_dtx_array.ca_count, true);
+		while (i < din->di_dtx_array.ca_count) {
+			if (i + count > din->di_dtx_array.ca_count)
+				count = din->di_dtx_array.ca_count - i;
+
+			dtis = (struct dtx_id *)din->di_dtx_array.ca_arrays + i;
+			rc1 = vos_dtx_abort(cont->sc_hdl, din->di_epoch,
+					    dtis, count);
+			if (rc == 0 && rc1 != 0)
+				rc = rc1;
+
+			i += count;
+		}
 		break;
 	case DTX_CHECK:
 		/* Currently, only support to check single DTX state. */

--- a/src/include/daos_srv/container.h
+++ b/src/include/daos_srv/container.h
@@ -60,10 +60,10 @@ struct ds_cont_child {
 	ABT_mutex		 sc_mutex;
 	ABT_cond		 sc_dtx_resync_cond;
 	void			*sc_dtx_flush_cbdata;
-	/* The time for the latest DTX resync operation. */
-	uint64_t		 sc_dtx_resync_time;
 	uint32_t		 sc_dtx_resyncing:1,
 				 sc_dtx_aggregating:1,
+				 sc_dtx_reindex:1,
+				 sc_dtx_reindex_abort:1,
 				 sc_vos_aggregating:1,
 				 sc_abort_vos_aggregating:1,
 				 sc_closing:1,

--- a/src/include/daos_srv/dtx_srv.h
+++ b/src/include/daos_srv/dtx_srv.h
@@ -60,6 +60,8 @@ struct dtx_handle {
 	daos_handle_t			 dth_coh;
 	/** The epoch# for the DTX. */
 	daos_epoch_t			 dth_epoch;
+	/* The generation when the DTX is handled on the server. */
+	uint64_t			 dth_gen;
 	/** The {obj/dkey/akey}-tree records that are created
 	 * by other DTXs, but not ready for commit yet.
 	 */
@@ -72,7 +74,8 @@ struct dtx_handle {
 	uint32_t			 dth_intent;
 	uint32_t			 dth_sync:1, /* commit synchronously. */
 					 dth_leader:1, /* leader replica. */
-					 dth_non_rep:1, /* non-replicated. */
+					 /* Only one participator in the DTX. */
+					 dth_solo:1,
 					 /* dti_cos has been committed. */
 					 dth_dti_cos_done:1;
 	/* The count the DTXs in the dth_dti_cos array. */
@@ -81,8 +84,8 @@ struct dtx_handle {
 	struct dtx_id			*dth_dti_cos;
 	/* The identifier of the DTX that conflict with current one. */
 	struct dtx_conflict_entry	*dth_conflict;
-	/** The address of the DTX entry in SCM. */
-	umem_off_t			 dth_ent;
+	/** Pointer to the DTX entry in DRAM. */
+	void				*dth_ent;
 	/** The address (offset) of the (new) object to be modified. */
 	umem_off_t			 dth_obj;
 };
@@ -98,8 +101,6 @@ struct dtx_sub_status {
 struct dtx_leader_handle {
 	/* The dtx handle on the leader node */
 	struct dtx_handle		dlh_handle;
-	/* The time when the DTX is handled on the server. */
-	uint64_t			dlh_handled_time;
 	/* result for the distribute transaction */
 	int				dlh_result;
 
@@ -114,15 +115,6 @@ struct dtx_leader_handle {
 	uint32_t			dlh_sub_cnt;
 	/* Sub transaction handle to manage the dtx leader */
 	struct dtx_sub_status		*dlh_subs;
-};
-
-struct dtx_share {
-	/** Link into the dtx_handle::dth_shares */
-	d_list_t		dts_link;
-	/** The DTX record type. */
-	uint32_t		dts_type;
-	/** The record in the related tree in SCM. */
-	umem_off_t		dts_record;
 };
 
 struct dtx_stat {

--- a/src/include/daos_srv/vos_types.h
+++ b/src/include/daos_srv/vos_types.h
@@ -224,12 +224,6 @@ typedef struct {
 	/** Returned epoch. It is ignored for container iteration. */
 	daos_epoch_t				ie_epoch;
 	union {
-		/** Returned earliest update epoch for a key */
-		daos_epoch_t			ie_earliest;
-		/** Return the DTX handled time for DTX iteration. */
-		uint64_t			ie_dtx_time;
-	};
-	union {
 		/** Returned entry for container UUID iterator */
 		uuid_t				ie_couuid;
 		struct {

--- a/src/vos/vos_container.c
+++ b/src/vos/vos_container.c
@@ -35,9 +35,10 @@
 #include <gurt/hash.h>
 #include <daos/btree.h>
 #include <daos_types.h>
-#include <vos_internal.h>
 #include <vos_obj.h>
 #include <daos/checksum.h>
+
+#include "vos_internal.h"
 
 /**
  * Parameters for vos_cont_df btree
@@ -100,6 +101,7 @@ cont_df_rec_alloc(struct btr_instance *tins, d_iov_t *key_iov,
 
 	cont_df = umem_off2ptr(&tins->ti_umm, offset);
 	uuid_copy(cont_df->cd_id, ukey->uuid);
+	cont_df->cd_dtx_resync_gen = 1;
 
 	rc = dbtree_create_inplace_ex(VOS_BTR_OBJ_TABLE, 0, VOS_OBJ_ORDER,
 				      &pool->vp_uma, &cont_df->cd_obj_root,
@@ -109,12 +111,6 @@ cont_df_rec_alloc(struct btr_instance *tins, d_iov_t *key_iov,
 		D_GOTO(failed, rc);
 	}
 	dbtree_close(hdl);
-
-	rc = vos_dtx_table_create(pool, &cont_df->cd_dtx_table_df);
-	if (rc) {
-		D_ERROR("Failed to create DTX table: rc = %d\n", rc);
-		D_GOTO(failed, rc);
-	}
 
 	args->ca_cont_df = cont_df;
 	rec->rec_off = offset;
@@ -189,17 +185,31 @@ cont_cmp(struct d_ulink *ulink, void *cmp_args)
 void
 cont_free(struct d_ulink *ulink)
 {
-	struct vos_container	*cont;
-	int			 i;
+	struct vos_container		*cont;
+	struct dtx_batched_cleanup_blob	*bcb;
+	int				 i;
 
 	cont = container_of(ulink, struct vos_container, vc_uhlink);
 	D_ASSERT(cont->vc_open_count == 0);
 
 	if (!daos_handle_is_inval(cont->vc_dtx_cos_hdl))
 		dbtree_destroy(cont->vc_dtx_cos_hdl, NULL);
-	D_ASSERT(d_list_empty(&cont->vc_dtx_committable));
-	dbtree_close(cont->vc_dtx_active_hdl);
-	dbtree_close(cont->vc_dtx_committed_hdl);
+	if (!daos_handle_is_inval(cont->vc_dtx_active_hdl))
+		dbtree_destroy(cont->vc_dtx_active_hdl, NULL);
+	if (!daos_handle_is_inval(cont->vc_dtx_committed_hdl))
+		dbtree_destroy(cont->vc_dtx_committed_hdl, NULL);
+
+	D_ASSERT(d_list_empty(&cont->vc_dtx_committable_list));
+	D_ASSERT(d_list_empty(&cont->vc_dtx_committed_list));
+	D_ASSERT(d_list_empty(&cont->vc_dtx_committed_tmp_list));
+
+	while ((bcb = d_list_pop_entry(&cont->vc_batched_cleanup_list,
+				       struct dtx_batched_cleanup_blob,
+				       bcb_cont_link)) != NULL) {
+		D_ASSERT(d_list_empty(&bcb->bcb_dce_list));
+		D_FREE(bcb);
+	}
+
 	dbtree_close(cont->vc_btr_hdl);
 
 	for (i = 0; i < VOS_IOS_CNT; i++) {
@@ -363,9 +373,17 @@ vos_cont_open(daos_handle_t poh, uuid_t co_uuid, daos_handle_t *coh)
 	uuid_copy(cont->vc_id, co_uuid);
 	cont->vc_pool	 = pool;
 	cont->vc_cont_df = args.ca_cont_df;
+	cont->vc_dtx_active_hdl = DAOS_HDL_INVAL;
+	cont->vc_dtx_committed_hdl = DAOS_HDL_INVAL;
 	cont->vc_dtx_cos_hdl = DAOS_HDL_INVAL;
-	D_INIT_LIST_HEAD(&cont->vc_dtx_committable);
+	D_INIT_LIST_HEAD(&cont->vc_dtx_committable_list);
+	D_INIT_LIST_HEAD(&cont->vc_dtx_committed_list);
+	D_INIT_LIST_HEAD(&cont->vc_dtx_committed_tmp_list);
+	D_INIT_LIST_HEAD(&cont->vc_batched_cleanup_list);
 	cont->vc_dtx_committable_count = 0;
+	cont->vc_dtx_committed_count = 0;
+	cont->vc_dtx_committed_tmp_count = 0;
+	cont->vc_dtx_resync_gen = cont->vc_cont_df->cd_dtx_resync_gen;
 
 	/* Cache this btr object ID in container handle */
 	rc = dbtree_open_inplace_ex(&cont->vc_cont_df->cd_obj_root,
@@ -376,28 +394,34 @@ vos_cont_open(daos_handle_t poh, uuid_t co_uuid, daos_handle_t *coh)
 		D_GOTO(exit, rc);
 	}
 
-	rc = dbtree_open_inplace(
-			&cont->vc_cont_df->cd_dtx_table_df.tt_committed_btr,
-			&pool->vp_uma, &cont->vc_dtx_committed_hdl);
-	if (rc) {
-		D_ERROR("Failed to open committed DTX table: rc = %d\n", rc);
-		D_GOTO(exit, rc);
-	}
-
-	rc = dbtree_open_inplace(
-			&cont->vc_cont_df->cd_dtx_table_df.tt_active_btr,
-			&pool->vp_uma, &cont->vc_dtx_active_hdl);
-	if (rc) {
-		D_ERROR("Failed to open active DTX table: rc = %d\n", rc);
-		D_GOTO(exit, rc);
-	}
-
 	memset(&uma, 0, sizeof(uma));
 	uma.uma_id = UMEM_CLASS_VMEM;
-	memset(&cont->vc_dtx_cos_btr, 0, sizeof(cont->vc_dtx_cos_btr));
-	rc = dbtree_create_inplace(VOS_BTR_DTX_COS, 0, VOS_CONT_ORDER, &uma,
-				   &cont->vc_dtx_cos_btr,
-				   &cont->vc_dtx_cos_hdl);
+
+	rc = dbtree_create_inplace_ex(VOS_BTR_DTX_ACT_TABLE, 0,
+				      DTX_BTREE_ORDER, &uma,
+				      &cont->vc_dtx_active_btr,
+				      DAOS_HDL_INVAL, cont,
+				      &cont->vc_dtx_active_hdl);
+	if (rc != 0) {
+		D_ERROR("Failed to create DTX active btree: rc = %d\n", rc);
+		D_GOTO(exit, rc);
+	}
+
+	rc = dbtree_create_inplace_ex(VOS_BTR_DTX_CMT_TABLE, 0,
+				      DTX_BTREE_ORDER, &uma,
+				      &cont->vc_dtx_committed_btr,
+				      DAOS_HDL_INVAL, cont,
+				      &cont->vc_dtx_committed_hdl);
+	if (rc != 0) {
+		D_ERROR("Failed to create DTX committed btree: rc = %d\n", rc);
+		D_GOTO(exit, rc);
+	}
+
+	rc = dbtree_create_inplace_ex(VOS_BTR_DTX_COS, 0,
+				      DTX_BTREE_ORDER, &uma,
+				      &cont->vc_dtx_cos_btr,
+				      DAOS_HDL_INVAL, cont,
+				      &cont->vc_dtx_cos_hdl);
 	if (rc != 0) {
 		D_ERROR("Failed to create DTX CoS btree: rc = %d\n", rc);
 		D_GOTO(exit, rc);
@@ -421,6 +445,12 @@ vos_cont_open(daos_handle_t poh, uuid_t co_uuid, daos_handle_t *coh)
 	rc = cont_insert(cont, &ukey, &pkey, coh);
 	if (rc != 0) {
 		D_ERROR("Error inserting vos container handle to uuid hash\n");
+		goto exit;
+	}
+
+	rc = vos_dtx_act_reindex(cont);
+	if (rc != 0) {
+		D_ERROR("Fail to reindex active DTX entries: %d\n", rc);
 	} else {
 		cont->vc_open_count = 1;
 
@@ -450,8 +480,9 @@ vos_cont_close(daos_handle_t coh)
 		return -DER_NO_HDL;
 	}
 
-	D_ASSERTF(cont->vc_open_count > 0, "Invalid close, open count %d\n",
-		  cont->vc_open_count);
+	D_ASSERTF(cont->vc_open_count > 0,
+		  "Invalid close "DF_UUID", open count %d\n",
+		  DP_UUID(cont->vc_id), cont->vc_open_count);
 
 	cont->vc_open_count--;
 	if (cont->vc_open_count == 0)
@@ -615,6 +646,31 @@ vos_cont_tab_register()
 	rc = dbtree_class_register(VOS_BTR_CONT_TABLE, 0, &vct_ops);
 	if (rc)
 		D_ERROR("dbtree create failed\n");
+	return rc;
+}
+
+int
+vos_dtx_update_resync_gen(daos_handle_t coh)
+{
+	struct vos_container	*cont;
+	struct vos_cont_df	*cont_df;
+	int			 rc;
+
+	cont = vos_hdl2cont(coh);
+	D_ASSERT(cont != NULL);
+
+	cont_df = cont->vc_cont_df;
+	rc = vos_tx_begin(vos_cont2umm(cont));
+	if (rc == 0) {
+		umem_tx_add_ptr(vos_cont2umm(cont),
+				&cont_df->cd_dtx_resync_gen,
+				sizeof(cont_df->cd_dtx_resync_gen));
+		cont_df->cd_dtx_resync_gen++;
+		rc = vos_tx_end(vos_cont2umm(cont), 0);
+		if (rc == 0)
+			cont->vc_dtx_resync_gen = cont_df->cd_dtx_resync_gen;
+	}
+
 	return rc;
 }
 

--- a/src/vos/vos_dtx.c
+++ b/src/vos/vos_dtx.c
@@ -27,6 +27,7 @@
  */
 #define D_LOGFAC	DD_FAC(vos)
 
+#include <libpmem.h>
 #include <daos_srv/vos.h>
 #include "vos_layout.h"
 #include "vos_internal.h"
@@ -36,6 +37,21 @@
 
 /* Dummy offset for some unknown DTX address. */
 #define DTX_UMOFF_UNKNOWN		2
+
+/* 128 KB per SCM blob */
+#define DTX_SCM_BLOB_SIZE		(1 << 17)
+
+#define DTX_ACT_BLOB_MAGIC		0x14130a2b
+#define DTX_CMT_BLOB_MAGIC		0x2502191c
+
+struct dtx_share {
+	/** Link into the dtx_handle::dth_shares */
+	d_list_t		dts_link;
+	/** The DTX record type. */
+	uint32_t		dts_type;
+	/** The record in the related tree in SCM. */
+	umem_off_t		dts_record;
+};
 
 static inline bool
 dtx_is_aborted(umem_off_t umoff)
@@ -62,12 +78,11 @@ dtx_set_unknown(umem_off_t *umoff)
 }
 
 static inline int
-dtx_inprogress(struct vos_dtx_entry_df *dtx, int pos)
+dtx_inprogress(struct vos_dtx_act_ent *dae, int pos)
 {
-	if (dtx != NULL)
-		D_DEBUG(DB_TRACE, "Hit uncommitted DTX "DF_DTI
-			" with state %u at %d\n",
-			DP_DTI(&dtx->te_xid), dtx->te_state, pos);
+	if (dae != NULL)
+		D_DEBUG(DB_TRACE, "Hit uncommitted DTX "DF_DTI" at %d\n",
+			DP_DTI(&DAE_XID(dae)), pos);
 	else
 		D_DEBUG(DB_TRACE, "Hit uncommitted (unknown) DTX at %d\n", pos);
 
@@ -75,17 +90,83 @@ dtx_inprogress(struct vos_dtx_entry_df *dtx, int pos)
 }
 
 static inline void
-dtx_record_conflict(struct dtx_handle *dth, struct vos_dtx_entry_df *dtx)
+dtx_record_conflict(struct dtx_handle *dth, struct vos_dtx_act_ent *dae)
 {
-	if (dth != NULL && dth->dth_conflict != NULL && dtx != NULL) {
-		daos_dti_copy(&dth->dth_conflict->dce_xid, &dtx->te_xid);
-		dth->dth_conflict->dce_dkey = dtx->te_dkey_hash;
+	if (dth != NULL && dth->dth_conflict != NULL && dae != NULL) {
+		daos_dti_copy(&dth->dth_conflict->dce_xid, &DAE_XID(dae));
+		dth->dth_conflict->dce_dkey = DAE_DKEY_HASH(dae);
 	}
 }
 
-struct dtx_rec_bundle {
-	umem_off_t	trb_umoff;
-};
+static struct dtx_batched_cleanup_blob *
+dtx_bcb_alloc(struct vos_container *cont, struct vos_dtx_scm_blob *dsb)
+{
+	struct dtx_batched_cleanup_blob	*bcb;
+
+	D_ALLOC(bcb, sizeof(*bcb) + sizeof(umem_off_t) * dsb->dsb_cap);
+	if (bcb != NULL) {
+		D_INIT_LIST_HEAD(&bcb->bcb_dce_list);
+		bcb->bcb_dsb_off = umem_ptr2off(vos_cont2umm(cont), dsb);
+		d_list_add_tail(&bcb->bcb_cont_link,
+				&cont->vc_batched_cleanup_list);
+	}
+
+	return bcb;
+}
+
+static void
+dtx_batched_cleanup(struct vos_container *cont,
+		    struct dtx_batched_cleanup_blob *bcb, umem_off_t *next_dsb)
+{
+	struct umem_instance	*umm = vos_cont2umm(cont);
+	struct vos_cont_df	*cont_df = cont->vc_cont_df;
+	struct vos_dtx_scm_blob	*dsb;
+	struct vos_dtx_scm_blob	*tmp;
+	struct vos_dtx_cmt_ent	*dce;
+	int			 i;
+
+	dsb = umem_off2ptr(umm, bcb->bcb_dsb_off);
+	for (i = 0; i < dsb->dsb_index; i++) {
+		if (!dtx_is_null(bcb->bcb_recs[i]))
+			umem_free(umm, bcb->bcb_recs[i]);
+	}
+
+	if (next_dsb != NULL)
+		*next_dsb = dsb->dsb_next;
+
+	tmp = umem_off2ptr(umm, dsb->dsb_prev);
+	if (tmp != NULL) {
+		umem_tx_add_ptr(umm, &tmp->dsb_next, sizeof(tmp->dsb_next));
+		tmp->dsb_next = dsb->dsb_next;
+	}
+
+	tmp = umem_off2ptr(umm, dsb->dsb_next);
+	if (tmp != NULL) {
+		umem_tx_add_ptr(umm, &tmp->dsb_prev, sizeof(tmp->dsb_prev));
+		tmp->dsb_prev = dsb->dsb_prev;
+	}
+
+	if (cont_df->cd_dtx_active_head == bcb->bcb_dsb_off) {
+		umem_tx_add_ptr(umm, &cont_df->cd_dtx_active_head,
+				sizeof(cont_df->cd_dtx_active_head));
+		cont_df->cd_dtx_active_head = dsb->dsb_next;
+	}
+
+	if (cont_df->cd_dtx_active_tail == bcb->bcb_dsb_off) {
+		umem_tx_add_ptr(umm, &cont_df->cd_dtx_active_tail,
+				sizeof(cont_df->cd_dtx_active_tail));
+		cont_df->cd_dtx_active_tail = dsb->dsb_prev;
+	}
+
+	while ((dce = d_list_pop_entry(&bcb->bcb_dce_list,
+				       struct vos_dtx_cmt_ent,
+				       dce_bcb_link)) != NULL)
+		; /* NOP */
+
+	d_list_del(&bcb->bcb_cont_link);
+	umem_free(umm, bcb->bcb_dsb_off);
+	D_FREE(bcb);
+}
 
 static int
 dtx_hkey_size(void)
@@ -114,184 +195,250 @@ dtx_hkey_cmp(struct btr_instance *tins, struct btr_record *rec, void *hkey)
 }
 
 static int
-dtx_rec_alloc(struct btr_instance *tins, d_iov_t *key_iov,
-	      d_iov_t *val_iov, struct btr_record *rec)
+dtx_act_ent_alloc(struct btr_instance *tins, d_iov_t *key_iov,
+		  d_iov_t *val_iov, struct btr_record *rec)
 {
-	struct dtx_rec_bundle	*rbund;
+	struct vos_dtx_act_ent	*dae = val_iov->iov_buf;
 
-	rbund = (struct dtx_rec_bundle *)val_iov->iov_buf;
-	D_ASSERT(!dtx_is_null(rbund->trb_umoff));
-
-	/* Directly reference the input addreass (in SCM). */
-	rec->rec_off = rbund->trb_umoff;
+	rec->rec_off = umem_ptr2off(&tins->ti_umm, dae);
 
 	return 0;
 }
 
 static int
-dtx_rec_free(struct btr_instance *tins, struct btr_record *rec, void *args)
+dtx_act_ent_free(struct btr_instance *tins, struct btr_record *rec,
+		 void *args)
 {
-	D_ASSERT(!UMOFF_IS_NULL(rec->rec_off));
+	struct vos_dtx_act_ent	*dae;
+
+	dae = umem_off2ptr(&tins->ti_umm, rec->rec_off);
+	rec->rec_off = UMOFF_NULL;
 
 	if (args != NULL) {
-		umem_off_t	*umoff;
-
-		/* Return the record addreass (offset in SCM).
+		/* Return the record addreass (offset in DRAM).
 		 * The caller will release it after using.
 		 */
-		umoff = (umem_off_t *)args;
-		*umoff = rec->rec_off;
-		umem_tx_add_ptr(&tins->ti_umm, &rec->rec_off,
-				sizeof(rec->rec_off));
-		rec->rec_off = UMOFF_NULL;
-	} else {
-		/* This only can happen when the dtx entry is allocated but
-		 * fail to be inserted into DTX table. Under such case, the
-		 * new allocated dtx entry will be automatically freed when
-		 * related PMDK transaction is aborted.
-		 */
+		D_ASSERT(dae != NULL);
+		*(struct vos_dtx_act_ent **)args = dae;
+	} else if (dae != NULL) {
+		D_FREE(dae->dae_records);
+		D_FREE_PTR(dae);
 	}
 
 	return 0;
 }
 
 static int
-dtx_rec_fetch(struct btr_instance *tins, struct btr_record *rec,
-	      d_iov_t *key_iov, d_iov_t *val_iov)
+dtx_act_ent_fetch(struct btr_instance *tins, struct btr_record *rec,
+		  d_iov_t *key_iov, d_iov_t *val_iov)
 {
-	struct vos_dtx_entry_df	*dtx;
+	struct vos_dtx_act_ent	*dae;
 
 	D_ASSERT(val_iov != NULL);
 
-	dtx = umem_off2ptr(&tins->ti_umm, rec->rec_off);
-	d_iov_set(val_iov, dtx, sizeof(*dtx));
+	dae = umem_off2ptr(&tins->ti_umm, rec->rec_off);
+	d_iov_set(val_iov, dae, sizeof(*dae));
+
 	return 0;
 }
 
 static int
-dtx_rec_update(struct btr_instance *tins, struct btr_record *rec,
-	       d_iov_t *key, d_iov_t *val)
+dtx_act_ent_update(struct btr_instance *tins, struct btr_record *rec,
+		   d_iov_t *key, d_iov_t *val)
 {
 	D_ASSERTF(0, "Should never been called\n");
 	return 0;
 }
 
-static btr_ops_t dtx_btr_ops = {
+static btr_ops_t dtx_active_btr_ops = {
 	.to_hkey_size	= dtx_hkey_size,
 	.to_hkey_gen	= dtx_hkey_gen,
 	.to_hkey_cmp	= dtx_hkey_cmp,
-	.to_rec_alloc	= dtx_rec_alloc,
-	.to_rec_free	= dtx_rec_free,
-	.to_rec_fetch	= dtx_rec_fetch,
-	.to_rec_update	= dtx_rec_update,
+	.to_rec_alloc	= dtx_act_ent_alloc,
+	.to_rec_free	= dtx_act_ent_free,
+	.to_rec_fetch	= dtx_act_ent_fetch,
+	.to_rec_update	= dtx_act_ent_update,
 };
 
-#define DTX_BTREE_ORDER		20
+static int
+dtx_cmt_ent_alloc(struct btr_instance *tins, d_iov_t *key_iov,
+		  d_iov_t *val_iov, struct btr_record *rec)
+{
+	struct vos_container	*cont = tins->ti_priv;
+	struct vos_dtx_cmt_ent	*dce = val_iov->iov_buf;
+
+	rec->rec_off = umem_ptr2off(&tins->ti_umm, dce);
+	if (!cont->vc_reindex_cmt_dtx || dce->dce_reindex) {
+		d_list_add_tail(&dce->dce_committed_link,
+				&cont->vc_dtx_committed_list);
+		cont->vc_dtx_committed_count++;
+	} else {
+		d_list_add_tail(&dce->dce_committed_link,
+				&cont->vc_dtx_committed_tmp_list);
+		cont->vc_dtx_committed_tmp_count++;
+	}
+
+	return 0;
+}
+
+static int
+dtx_cmt_ent_free(struct btr_instance *tins, struct btr_record *rec,
+		 void *args)
+{
+	struct vos_container	*cont = tins->ti_priv;
+	struct vos_dtx_cmt_ent	*dce;
+	int			 rc = 0;
+
+	dce = umem_off2ptr(&tins->ti_umm, rec->rec_off);
+	D_ASSERT(dce != NULL);
+
+	rec->rec_off = UMOFF_NULL;
+	d_list_del(&dce->dce_committed_link);
+	if (!cont->vc_reindex_cmt_dtx || dce->dce_reindex)
+		cont->vc_dtx_committed_count--;
+	else
+		cont->vc_dtx_committed_tmp_count--;
+
+	/* The committed DTX entry may be in aggregation now, if related
+	 * active DTX entry is waitting for batched cleanup, then cleanup
+	 * it by force before destroy the committed DTX entry (mainly for
+	 * DTX aggregation).
+	 */
+	if (!d_list_empty(&dce->dce_bcb_link)) {
+		struct umem_instance		*umm = vos_cont2umm(cont);
+		struct dtx_batched_cleanup_blob	*bcb = dce->dce_bcb;
+		struct vos_dtx_scm_blob		*dsb;
+		int				 idx;
+
+		D_ASSERT(bcb != NULL);
+
+		idx = dce->dce_index;
+		dsb = umem_off2ptr(umm, bcb->bcb_dsb_off);
+
+		if (dsb->dsb_active_data[idx].dae_flags != DTX_EF_INVALID) {
+			struct vos_dtx_act_ent_df	*dae_df;
+
+			rc = vos_tx_begin(umm);
+			if (rc != 0)
+				return rc;
+
+			dae_df = &dsb->dsb_active_data[idx];
+			umem_tx_add_ptr(umm, &dae_df->dae_flags,
+					sizeof(dae_df->dae_flags));
+			dae_df->dae_flags = DTX_EF_INVALID;
+
+			D_ASSERT(dsb->dsb_count > bcb->bcb_dae_count);
+			umem_tx_add_ptr(umm, &dsb->dsb_count,
+					sizeof(dsb->dsb_count));
+			dsb->dsb_count--;
+
+			if (!dtx_is_null(bcb->bcb_recs[idx])) {
+				umem_free(umm, bcb->bcb_recs[idx]);
+				bcb->bcb_recs[idx] = UMOFF_NULL;
+			}
+
+			rc = vos_tx_end(umm, 0);
+		}
+
+		d_list_del(&dce->dce_bcb_link);
+	}
+
+	D_FREE_PTR(dce);
+
+	return rc;
+}
+
+static int
+dtx_cmt_ent_fetch(struct btr_instance *tins, struct btr_record *rec,
+		  d_iov_t *key_iov, d_iov_t *val_iov)
+{
+	if (val_iov != NULL) {
+		struct vos_dtx_cmt_ent	*dce;
+
+		dce = umem_off2ptr(&tins->ti_umm, rec->rec_off);
+		d_iov_set(val_iov, dce, sizeof(*dce));
+	}
+
+	return 0;
+}
+
+static int
+dtx_cmt_ent_update(struct btr_instance *tins, struct btr_record *rec,
+		   d_iov_t *key, d_iov_t *val)
+{
+	struct vos_dtx_cmt_ent	*dce = val->iov_buf;
+
+	dce->dce_exist = 1;
+
+	return 0;
+}
+
+static btr_ops_t dtx_committed_btr_ops = {
+	.to_hkey_size	= dtx_hkey_size,
+	.to_hkey_gen	= dtx_hkey_gen,
+	.to_hkey_cmp	= dtx_hkey_cmp,
+	.to_rec_alloc	= dtx_cmt_ent_alloc,
+	.to_rec_free	= dtx_cmt_ent_free,
+	.to_rec_fetch	= dtx_cmt_ent_fetch,
+	.to_rec_update	= dtx_cmt_ent_update,
+};
 
 int
 vos_dtx_table_register(void)
 {
 	int	rc;
 
-	D_DEBUG(DB_DF, "Registering DTX table class: %d\n", VOS_BTR_DTX_TABLE);
+	rc = dbtree_class_register(VOS_BTR_DTX_ACT_TABLE, 0,
+				   &dtx_active_btr_ops);
+	if (rc != 0) {
+		D_ERROR("Failed to register DTX active dbtree: %d\n", rc);
+		return rc;
+	}
 
-	rc = dbtree_class_register(VOS_BTR_DTX_TABLE, 0, &dtx_btr_ops);
+	rc = dbtree_class_register(VOS_BTR_DTX_CMT_TABLE, 0,
+				   &dtx_committed_btr_ops);
 	if (rc != 0)
-		D_ERROR("Failed to register DTX dbtree: rc = %d\n", rc);
+		D_ERROR("Failed to register DTX committed dbtree: %d\n", rc);
 
 	return rc;
 }
 
-int
-vos_dtx_table_create(struct vos_pool *pool, struct vos_dtx_table_df *dtab_df)
+void
+vos_dtx_table_destroy(struct umem_instance *umm, struct vos_cont_df *cont_df)
 {
-	daos_handle_t	hdl;
-	int		rc;
+	struct vos_dtx_scm_blob		*dsb;
+	umem_off_t			 dsb_off;
 
-	if (pool == NULL || dtab_df == NULL) {
-		D_ERROR("Invalid handle\n");
-		return -DER_INVAL;
+	while (!dtx_is_null(cont_df->cd_dtx_committed_head)) {
+		dsb_off = cont_df->cd_dtx_committed_head;
+		dsb = umem_off2ptr(umm, dsb_off);
+		cont_df->cd_dtx_committed_head = dsb->dsb_next;
+		umem_free(umm, dsb_off);
 	}
 
-	D_ASSERT(dtab_df->tt_active_btr.tr_class == 0);
-	D_ASSERT(dtab_df->tt_committed_btr.tr_class == 0);
+	cont_df->cd_dtx_committed_head = UMOFF_NULL;
+	cont_df->cd_dtx_committed_tail = UMOFF_NULL;
 
-	D_DEBUG(DB_DF, "create DTX dbtree in-place for pool "DF_UUID": %d\n",
-		DP_UUID(pool->vp_id), VOS_BTR_DTX_TABLE);
-
-	rc = dbtree_create_inplace(VOS_BTR_DTX_TABLE, 0,
-				   DTX_BTREE_ORDER, &pool->vp_uma,
-				   &dtab_df->tt_active_btr, &hdl);
-	if (rc != 0) {
-		D_ERROR("Failed to create DTX active dbtree for pool "
-			DF_UUID": rc = %d\n", DP_UUID(pool->vp_id), rc);
-		return rc;
+	while (!dtx_is_null(cont_df->cd_dtx_active_head)) {
+		dsb_off = cont_df->cd_dtx_active_head;
+		dsb = umem_off2ptr(umm, dsb_off);
+		cont_df->cd_dtx_active_head = dsb->dsb_next;
+		umem_free(umm, dsb_off);
 	}
 
-	dbtree_close(hdl);
-
-	rc = dbtree_create_inplace(VOS_BTR_DTX_TABLE, 0,
-				   DTX_BTREE_ORDER, &pool->vp_uma,
-				   &dtab_df->tt_committed_btr, &hdl);
-	if (rc != 0) {
-		D_ERROR("Failed to create DTX committed dbtree for pool "
-			DF_UUID": rc = %d\n", DP_UUID(pool->vp_id), rc);
-		return rc;
-	}
-
-	dtab_df->tt_count = 0;
-	dtab_df->tt_entry_head = UMOFF_NULL;
-	dtab_df->tt_entry_tail = UMOFF_NULL;
-
-	dbtree_close(hdl);
-	return 0;
-}
-
-int
-vos_dtx_table_destroy(struct vos_pool *pool, struct vos_dtx_table_df *dtab_df)
-{
-	daos_handle_t	hdl;
-	int		rc = 0;
-
-	if (pool == NULL || dtab_df == NULL) {
-		D_ERROR("Invalid handle\n");
-		return -DER_INVAL;
-	}
-
-	if (dtab_df->tt_active_btr.tr_class != 0) {
-		rc = dbtree_open_inplace(&dtab_df->tt_active_btr,
-					 &pool->vp_uma, &hdl);
-		if (rc == 0)
-			rc = dbtree_destroy(hdl, NULL);
-
-		if (rc != 0)
-			D_ERROR("Fail to destroy DTX active dbtree for pool"
-				DF_UUID": rc = %d\n", DP_UUID(pool->vp_id), rc);
-	}
-
-	if (dtab_df->tt_committed_btr.tr_class != 0) {
-		rc = dbtree_open_inplace(&dtab_df->tt_committed_btr,
-					 &pool->vp_uma, &hdl);
-		if (rc == 0)
-			rc = dbtree_destroy(hdl, NULL);
-
-		if (rc != 0)
-			D_ERROR("Fail to destroy DTX committed dbtree for pool"
-				DF_UUID": rc = %d\n", DP_UUID(pool->vp_id), rc);
-	}
-
-	return rc;
+	cont_df->cd_dtx_active_head = UMOFF_NULL;
+	cont_df->cd_dtx_active_tail = UMOFF_NULL;
 }
 
 static void
 dtx_obj_rec_exchange(struct umem_instance *umm, struct vos_obj_df *obj,
-		     struct vos_dtx_entry_df *dtx,
-		     struct vos_dtx_record_df *rec, bool abort)
+		     struct vos_dtx_record_df *rec, struct vos_dtx_act_ent *dae,
+		     bool abort)
 {
 	struct vos_dtx_record_df	*tgt_rec;
 	struct vos_obj_df		*tgt_obj;
 
-	if (rec->tr_flags == DTX_RF_EXCHANGE_TGT) {
+	if (rec->dr_flags == DTX_RF_EXCHANGE_TGT) {
 		/* For commit case, should already have been handled
 		 * during handling the source.
 		 *
@@ -305,15 +452,15 @@ dtx_obj_rec_exchange(struct umem_instance *umm, struct vos_obj_df *obj,
 		return;
 	}
 
-	if (rec->tr_flags != DTX_RF_EXCHANGE_SRC) {
+	if (rec->dr_flags != DTX_RF_EXCHANGE_SRC) {
 		D_ERROR(DF_UOID" with OBJ DTX ("DF_DTI") missed SRC flag\n",
-			DP_UOID(dtx->te_oid), DP_DTI(&dtx->te_xid));
+			DP_UOID(DAE_OID(dae)), DP_DTI(&DAE_XID(dae)));
 		return;
 	}
 
 	if (!(obj->vo_oi_attr & VOS_OI_REMOVED)) {
 		D_ERROR(DF_UOID" with OBJ DTX ("DF_DTI") missed REMOVED flag\n",
-			DP_UOID(dtx->te_oid), DP_DTI(&dtx->te_xid));
+			DP_UOID(DAE_OID(dae)), DP_DTI(&DAE_XID(dae)));
 		return;
 	}
 
@@ -324,22 +471,26 @@ dtx_obj_rec_exchange(struct umem_instance *umm, struct vos_obj_df *obj,
 		return;
 	}
 
-	/* XXX: If the exchange target still exist, it will be the next
+	/* XXX: If the exchange target still exist, it will be the prior
 	 *	record. If it does not exist, then either it is crashed
 	 *	or it has already deregistered from the DTX records list.
 	 *	We cannot commit the DTX under any the two cases. Fail
 	 *	the DTX commit is meaningless, then some warnings.
 	 */
-	if (dtx_is_null(rec->tr_next)) {
+	if (rec == DAE_REC_INLINE(dae)) {
 		D_ERROR(DF_UOID" miss OBJ DTX ("DF_DTI") exchange pairs (1)\n",
-			DP_UOID(dtx->te_oid), DP_DTI(&dtx->te_xid));
+			DP_UOID(DAE_OID(dae)), DP_DTI(&DAE_XID(dae)));
 		return;
 	}
 
-	tgt_rec = umem_off2ptr(umm, rec->tr_next);
-	if (tgt_rec->tr_flags != DTX_RF_EXCHANGE_TGT) {
+	if (rec == dae->dae_records)
+		tgt_rec = &DAE_REC_INLINE(dae)[DTX_INLINE_REC_CNT - 1];
+	else
+		tgt_rec = rec - 1;
+
+	if (tgt_rec->dr_flags != DTX_RF_EXCHANGE_TGT) {
 		D_ERROR(DF_UOID" miss OBJ DTX ("DF_DTI") exchange pairs (2)\n",
-			DP_UOID(dtx->te_oid), DP_DTI(&dtx->te_xid));
+			DP_UOID(DAE_OID(dae)), DP_DTI(&DAE_XID(dae)));
 		return;
 	}
 
@@ -347,10 +498,10 @@ dtx_obj_rec_exchange(struct umem_instance *umm, struct vos_obj_df *obj,
 	 * epoch record. The record with max epoch will be removed when
 	 * aggregation or some special cleanup.
 	 */
-	tgt_obj = umem_off2ptr(umm, tgt_rec->tr_record);
+	tgt_obj = umem_off2ptr(umm, tgt_rec->dr_record);
 	if (!(tgt_obj->vo_oi_attr & VOS_OI_PUNCHED)) {
 		D_ERROR(DF_UOID" with OBJ DTX ("DF_DTI") missed PUNCHED flag\n",
-			DP_UOID(dtx->te_oid), DP_DTI(&dtx->te_xid));
+			DP_UOID(DAE_OID(dae)), DP_DTI(&DAE_XID(dae)));
 		return;
 	}
 
@@ -362,7 +513,7 @@ dtx_obj_rec_exchange(struct umem_instance *umm, struct vos_obj_df *obj,
 	 */
 	tgt_obj->vo_tree = obj->vo_tree;
 	tgt_obj->vo_earliest = obj->vo_earliest;
-	tgt_obj->vo_latest = dtx->te_epoch;
+	tgt_obj->vo_latest = DAE_EPOCH(dae);
 	tgt_obj->vo_incarnation = obj->vo_incarnation;
 	tgt_obj->vo_dtx = UMOFF_NULL;
 
@@ -374,13 +525,12 @@ dtx_obj_rec_exchange(struct umem_instance *umm, struct vos_obj_df *obj,
 	obj->vo_dtx = UMOFF_NULL;
 
 	D_DEBUG(DB_TRACE, "Exchanged OBJ DTX records for "DF_DTI"\n",
-		DP_DTI(&dtx->te_xid));
+		DP_DTI(&DAE_XID(dae)));
 }
 
 static int
-dtx_ilog_rec_release(struct umem_instance *umm,
-		     struct vos_dtx_entry_df *dtx,
-		     struct vos_dtx_record_df *rec, umem_off_t umoff,
+dtx_ilog_rec_release(struct umem_instance *umm, struct vos_container *cont,
+		     struct vos_dtx_record_df *rec, struct vos_dtx_act_ent *dae,
 		     bool abort)
 {
 	struct ilog_df		*ilog;
@@ -389,15 +539,15 @@ dtx_ilog_rec_release(struct umem_instance *umm,
 	struct ilog_id		 id;
 	int			 rc;
 
-	ilog = umem_off2ptr(umm, rec->tr_record);
+	ilog = umem_off2ptr(umm, rec->dr_record);
 
-	vos_ilog_desc_cbs_init(&cbs, DAOS_HDL_INVAL);
+	vos_ilog_desc_cbs_init(&cbs, vos_cont2hdl(cont));
 	rc = ilog_open(umm, ilog, &cbs, &loh);
 	if (rc != 0)
 		return rc;
 
-	id.id_epoch = dtx->te_epoch;
-	id.id_tx_id = umoff;
+	id.id_epoch = DAE_EPOCH(dae);
+	id.id_tx_id = dae->dae_df_off;
 
 	if (abort)
 		rc = ilog_abort(loh, &id);
@@ -410,12 +560,11 @@ dtx_ilog_rec_release(struct umem_instance *umm,
 
 static void
 dtx_obj_rec_release(struct umem_instance *umm, struct vos_obj_df *obj,
-		    struct vos_dtx_record_df *rec, umem_off_t umoff, bool abort)
+		    struct vos_dtx_record_df *rec, struct vos_dtx_act_ent *dae,
+		    bool abort)
 {
-	struct vos_dtx_entry_df		*dtx;
-
-	dtx = umem_off2ptr(umm, umoff);
-	if (dtx->te_intent == DAOS_INTENT_PUNCH) {
+	if (DAE_INTENT(dae) == DAOS_INTENT_PUNCH) {
+		umem_tx_add_ptr(umm, obj, sizeof(*obj));
 		if (dtx_is_null(obj->vo_dtx)) {
 			/* Two possible cases:
 			 *
@@ -428,22 +577,24 @@ dtx_obj_rec_release(struct umem_instance *umm, struct vos_obj_df *obj,
 			 *    that will be punched in the modification.
 			 *    The flag is zero under such case.
 			 */
-			if (rec->tr_flags == 0 && abort)
+			if (rec->dr_flags == 0 && abort)
 				dtx_set_aborted(&obj->vo_dtx);
-		} else if (obj->vo_dtx != umoff) {
+		} else if (obj->vo_dtx != dae->dae_df_off) {
 			/* Because PUNCH cannot share with others, the vo_dtx
 			 * should reference current DTX.
 			 */
 			D_ERROR("The OBJ "DF_UOID" should referece DTX "
 				DF_DTI", but referenced "UMOFF_PF" by wrong.\n",
-				DP_UOID(dtx->te_oid), DP_DTI(&dtx->te_xid),
+				DP_UOID(DAE_OID(dae)), DP_DTI(&DAE_XID(dae)),
 				UMOFF_P(obj->vo_dtx));
 		} else {
-			dtx_obj_rec_exchange(umm, obj, dtx, rec, abort);
+			dtx_obj_rec_exchange(umm, obj, rec, dae, abort);
 		}
 
 		return;
 	}
+
+	umem_tx_add_ptr(umm, &obj->vo_dtx, VOS_OBJ_SIZE_PARTIAL);
 
 	/* Because PUNCH and UPDATE cannot share, both current DTX
 	 * and the obj former referenced DTX should be for UPDATE.
@@ -479,7 +630,7 @@ dtx_obj_rec_release(struct umem_instance *umm, struct vos_obj_df *obj,
 		if (obj->vo_dtx_shares == 0)
 			/* The last shared UPDATE DTX is aborted. */
 			dtx_set_aborted(&obj->vo_dtx);
-		else if (obj->vo_dtx == umoff)
+		else if (obj->vo_dtx == dae->dae_df_off)
 			/* I am the original DTX that create the object that
 			 * is still shared by others. Now, I will be aborted,
 			 * set the reference as UNKNOWN for other left shares.
@@ -491,167 +642,238 @@ dtx_obj_rec_release(struct umem_instance *umm, struct vos_obj_df *obj,
 }
 
 static void
-dtx_rec_release(struct umem_instance *umm, umem_off_t umoff,
-		bool abort, bool destroy, bool logged)
+do_dtx_rec_release(struct umem_instance *umm, struct vos_container *cont,
+		   struct vos_dtx_act_ent *dae, struct vos_dtx_record_df *rec,
+		   struct vos_dtx_record_df *rec_df, int index, bool abort,
+		   bool *sync)
 {
-	struct vos_dtx_entry_df		*dtx;
+	if (dtx_is_null(rec->dr_record))
+		return;
 
-	dtx = umem_off2ptr(umm, umoff);
-	if (!logged)
-		umem_tx_add_ptr(umm, dtx, sizeof(*dtx));
+	/* Has been deregistered. */
+	if (rec_df != NULL && dtx_is_null(rec_df[index].dr_record))
+		return;
 
-	while (!dtx_is_null(dtx->te_records)) {
-		umem_off_t			 rec_umoff = dtx->te_records;
-		struct vos_dtx_record_df	*rec;
+	switch (rec->dr_type) {
+	case DTX_RT_OBJ: {
+		struct vos_obj_df	*obj;
 
-		rec = umem_off2ptr(umm, rec_umoff);
-		switch (rec->tr_type) {
-		case DTX_RT_OBJ: {
-			struct vos_obj_df	*obj;
-
-			obj = umem_off2ptr(umm, rec->tr_record);
-			umem_tx_add_ptr(umm, obj, sizeof(*obj));
-			dtx_obj_rec_release(umm, obj, rec, umoff, abort);
-			break;
-		}
-		case DTX_RT_ILOG: {
-			dtx_ilog_rec_release(umm, dtx, rec, umoff, abort);
-			break;
-		}
-		case DTX_RT_SVT: {
-			struct vos_irec_df	*svt;
-
-			svt = umem_off2ptr(umm, rec->tr_record);
-			umem_tx_add_ptr(umm, &svt->ir_dtx, sizeof(svt->ir_dtx));
-			if (abort)
-				dtx_set_aborted(&svt->ir_dtx);
-			else
-				svt->ir_dtx = UMOFF_NULL;
-			break;
-		}
-		case DTX_RT_EVT: {
-			struct evt_desc		*evt;
-
-			evt = umem_off2ptr(umm, rec->tr_record);
-			umem_tx_add_ptr(umm, &evt->dc_dtx, sizeof(evt->dc_dtx));
-			if (abort)
-				dtx_set_aborted(&evt->dc_dtx);
-			else
-				evt->dc_dtx = UMOFF_NULL;
-			break;
-		}
-		default:
-			D_ERROR(DF_UOID" unknown DTX "DF_DTI" type %u\n",
-				DP_UOID(dtx->te_oid), DP_DTI(&dtx->te_xid),
-				rec->tr_type);
-			break;
-		}
-
-		dtx->te_records = rec->tr_next;
-		umem_free(umm, rec_umoff);
+		obj = umem_off2ptr(umm, rec->dr_record);
+		dtx_obj_rec_release(umm, obj, rec, dae, abort);
+		if (!abort)
+			*sync = false;
+		break;
 	}
+	case DTX_RT_ILOG: {
+		dtx_ilog_rec_release(umm, cont, rec, dae, abort);
+		break;
+	}
+	case DTX_RT_SVT: {
+		struct vos_irec_df	*svt;
 
-	D_DEBUG(DB_TRACE, "dtx_rec_release: %s/%s the DTX "DF_DTI"\n",
-		abort ? "abort" : "commit", destroy ? "destroy" : "keep",
-		DP_DTI(&dtx->te_xid));
+		svt = umem_off2ptr(umm, rec->dr_record);
+		if (abort) {
+			if (DAE_INDEX(dae) != -1)
+				umem_tx_add_ptr(umm, &svt->ir_dtx,
+						sizeof(svt->ir_dtx));
+			dtx_set_aborted(&svt->ir_dtx);
+		} else {
+			umem_tx_add_ptr(umm, &svt->ir_dtx, sizeof(svt->ir_dtx));
+			svt->ir_dtx = UMOFF_NULL;
+			*sync = false;
+		}
+		break;
+	}
+	case DTX_RT_EVT: {
+		struct evt_desc		*evt;
 
-	if (destroy)
-		umem_free(umm, umoff);
-	else
-		dtx->te_flags &= ~(DTX_EF_EXCHANGE_PENDING | DTX_EF_SHARES);
+		evt = umem_off2ptr(umm, rec->dr_record);
+		if (abort) {
+			if (DAE_INDEX(dae) != -1)
+				umem_tx_add_ptr(umm, &evt->dc_dtx,
+						sizeof(evt->dc_dtx));
+			dtx_set_aborted(&evt->dc_dtx);
+		} else {
+			umem_tx_add_ptr(umm, &evt->dc_dtx, sizeof(evt->dc_dtx));
+			evt->dc_dtx = UMOFF_NULL;
+			*sync = false;
+		}
+		break;
+	}
+	default:
+		D_ERROR(DF_UOID" unknown DTX "DF_DTI" type %u\n",
+			DP_UOID(DAE_OID(dae)), DP_DTI(&DAE_XID(dae)),
+			rec->dr_type);
+		break;
+	}
 }
 
 static void
-vos_dtx_unlink_entry(struct umem_instance *umm, struct vos_dtx_table_df *tab,
-		     struct vos_dtx_entry_df *dtx)
+dtx_rec_release(struct umem_instance *umm, struct vos_container *cont,
+		struct vos_dtx_act_ent *dae, bool abort, bool destroy,
+		struct dtx_batched_cleanup_blob **bcb_p)
 {
-	struct vos_dtx_entry_df	*ent;
+	struct vos_dtx_act_ent_df	*dae_df;
+	struct vos_dtx_record_df	*rec_df = NULL;
+	struct vos_dtx_scm_blob		*dsb;
+	struct dtx_batched_cleanup_blob	*bcb;
+	int				 count;
+	int				 i;
+	bool				 sync = false;
 
-	if (dtx_is_null(dtx->te_next)) { /* The tail of the DTXs list. */
-		if (dtx_is_null(dtx->te_prev)) { /* The unique one on list. */
-			tab->tt_entry_head = UMOFF_NULL;
-			tab->tt_entry_tail = UMOFF_NULL;
-		} else {
-			ent = umem_off2ptr(umm, dtx->te_prev);
-			umem_tx_add_ptr(umm, &ent->te_next,
-					sizeof(ent->te_next));
-			ent->te_next = UMOFF_NULL;
-			tab->tt_entry_tail = dtx->te_prev;
-			dtx->te_prev = UMOFF_NULL;
-		}
-	} else if (dtx_is_null(dtx->te_prev)) { /* The head of DTXs list */
-		ent = umem_off2ptr(umm, dtx->te_next);
-		umem_tx_add_ptr(umm, &ent->te_prev, sizeof(ent->te_prev));
-		ent->te_prev = UMOFF_NULL;
-		tab->tt_entry_head = dtx->te_next;
-		dtx->te_next = UMOFF_NULL;
-	} else {
-		ent = umem_off2ptr(umm, dtx->te_next);
-		umem_tx_add_ptr(umm, &ent->te_prev, sizeof(ent->te_prev));
-		ent->te_prev = dtx->te_prev;
+	/* XXX: To avoid complex ilog related status check, let's
+	 *	check next record directly. For pure ilog touched
+	 *	DTX case, we do NOT handle it via batched cleanup.
+	 *
+	 *	For abort or non-destroy case, cleanup DTX entry
+	 *	synchronously.
+	 */
+	if (abort || !destroy || (DAE_REC_CNT(dae) > 0 &&
+	    DAE_REC_INLINE(dae)[0].dr_type == DTX_RT_ILOG))
+		sync = true;
 
-		ent = umem_off2ptr(umm, dtx->te_prev);
-		umem_tx_add_ptr(umm, &ent->te_next, sizeof(ent->te_next));
-		ent->te_next = dtx->te_next;
+	dae_df = umem_off2ptr(umm, dae->dae_df_off);
+	if (dae->dae_records != NULL) {
+		D_ASSERT(DAE_REC_CNT(dae) > DTX_INLINE_REC_CNT);
 
-		dtx->te_prev = UMOFF_NULL;
-		dtx->te_next = UMOFF_NULL;
+		if (dae_df != NULL &&
+		    dae_df->dae_layout_gen != DAE_LAYOUT_GEN(dae))
+			rec_df = umem_off2ptr(umm, dae_df->dae_rec_off);
+
+		for (i = DAE_REC_CNT(dae) - DTX_INLINE_REC_CNT - 1; i >= 0; i--)
+			do_dtx_rec_release(umm, cont, dae, &dae->dae_records[i],
+					   rec_df, i, abort, &sync);
+
+		D_FREE(dae->dae_records);
+		dae->dae_records = NULL;
+		dae->dae_rec_cap = 0;
 	}
+
+	if (dae_df != NULL && dae_df->dae_layout_gen != DAE_LAYOUT_GEN(dae))
+		rec_df = dae_df->dae_rec_inline;
+
+	if (DAE_REC_CNT(dae) > DTX_INLINE_REC_CNT)
+		count = DTX_INLINE_REC_CNT;
+	else
+		count = DAE_REC_CNT(dae);
+
+	for (i = count - 1; i >= 0; i--)
+		do_dtx_rec_release(umm, cont, dae, &DAE_REC_INLINE(dae)[i],
+				   rec_df, i, abort, &sync);
+
+	/* Non-prepared case, not need to change on-disk things. */
+	if (DAE_INDEX(dae) == -1) {
+		D_ASSERT(abort);
+		D_FREE_PTR(dae);
+		return;
+	}
+
+	D_ASSERT(dae_df != NULL);
+
+	dsb = dae->dae_dsb;
+	D_ASSERT(dsb->dsb_magic == DTX_ACT_BLOB_MAGIC);
+
+	bcb = dae->dae_bcb;
+	D_ASSERT(bcb != NULL);
+	D_ASSERT(bcb->bcb_dae_count > 0);
+
+	if (sync) {
+		if (!destroy) {
+			int	size;
+
+			DAE_FLAGS(dae) &= ~(DTX_EF_EXCHANGE_PENDING |
+					    DTX_EF_SHARES);
+			DAE_REC_CNT(dae) = 0;
+
+			size = sizeof(dae_df->dae_flags) +
+				sizeof(dae_df->dae_rec_cnt);
+			if (!dtx_is_null(dae_df->dae_rec_off))
+				size += sizeof(dae_df->dae_rec_off);
+
+			umem_tx_add_ptr(umm, &dae_df->dae_flags, size);
+		} else if (DAE_INDEX(dae) != -1 && (bcb->bcb_dae_count > 1 ||
+			   dsb->dsb_index < dsb->dsb_cap)) {
+			umem_tx_add_ptr(umm, &dae_df->dae_flags,
+					sizeof(dae_df->dae_flags));
+			/* Mark the DTX entry as invalid in SCM. */
+			dae_df->dae_flags = DTX_EF_INVALID;
+
+			umem_tx_add_ptr(umm, &dsb->dsb_count,
+					sizeof(dsb->dsb_count));
+			dsb->dsb_count--;
+		}
+
+		if (!dtx_is_null(dae_df->dae_rec_off))
+			umem_free(umm, dae_df->dae_rec_off);
+
+		if (!destroy) {
+			dae_df->dae_flags = DAE_FLAGS(dae);
+			dae_df->dae_rec_cnt = 0;
+			dae_df->dae_rec_off = UMOFF_NULL;
+			memset(DAE_REC_INLINE(dae), 0,
+			       sizeof(struct vos_dtx_record_df) * count);
+
+			return;
+		}
+	} else {
+		bcb->bcb_recs[DAE_INDEX(dae)] = DAE_REC_OFF(dae);
+	}
+
+	bcb->bcb_dae_count--;
+	if (bcb->bcb_dae_count == 0 && dsb->dsb_index >= dsb->dsb_cap) {
+		dtx_batched_cleanup(cont, bcb, NULL);
+	} else if (!sync) {
+		D_ASSERT(bcb_p != NULL);
+
+		*bcb_p = bcb;
+	}
+
+	D_FREE_PTR(dae);
 }
 
 static int
-vos_dtx_commit_one(struct vos_container *cont, struct dtx_id *dti)
+vos_dtx_commit_one(struct vos_container *cont, struct dtx_id *dti,
+		   daos_epoch_t epoch, struct vos_dtx_cmt_ent **dce_p)
 {
-	struct umem_instance		*umm = &cont->vc_pool->vp_umm;
-	struct vos_dtx_entry_df		*dtx;
-	struct vos_dtx_entry_df		*ent;
-	struct vos_dtx_table_df		*tab;
-	struct dtx_rec_bundle		 rbund;
-	d_iov_t			 kiov;
-	d_iov_t			 riov;
-	umem_off_t			 umoff;
+	struct umem_instance		*umm = vos_cont2umm(cont);
+	struct vos_dtx_act_ent		*dae = NULL;
+	struct vos_dtx_cmt_ent		*dce = NULL;
+	d_iov_t				 kiov;
+	d_iov_t				 riov;
 	int				 rc = 0;
 
 	d_iov_set(&kiov, dti, sizeof(*dti));
-	rc = dbtree_delete(cont->vc_dtx_active_hdl, BTR_PROBE_EQ,
-			   &kiov, &umoff);
-	if (rc == -DER_NONEXIST) {
-		d_iov_set(&riov, NULL, 0);
-		rc = dbtree_lookup(cont->vc_dtx_committed_hdl, &kiov, &riov);
-		goto out;
+	if (epoch == 0) {
+		rc = dbtree_delete(cont->vc_dtx_active_hdl, BTR_PROBE_EQ,
+				   &kiov, &dae);
+		if (rc == -DER_NONEXIST) {
+			rc = dbtree_lookup(cont->vc_dtx_committed_hdl,
+					   &kiov, NULL);
+			goto out;
+		}
+
+		if (rc != 0)
+			goto out;
 	}
 
-	if (rc != 0)
-		goto out;
+	D_ALLOC_PTR(dce);
+	if (dce == NULL)
+		D_GOTO(out, rc = -DER_NOMEM);
 
-	dtx = umem_off2ptr(umm, umoff);
-	umem_tx_add_ptr(umm, dtx, sizeof(*dtx));
+	D_INIT_LIST_HEAD(&dce->dce_bcb_link);
+	DCE_XID(dce) = *dti;
+	DCE_EPOCH(dce) = epoch != 0 ? epoch : DAE_EPOCH(dae);
+	dce->dce_index = epoch != 0 ? -1 : DAE_INDEX(dae);
+	dce->dce_reindex = 0;
 
-	dtx->te_state = DTX_ST_COMMITTED;
-	rbund.trb_umoff = umoff;
-	d_iov_set(&riov, &rbund, sizeof(rbund));
+	d_iov_set(&riov, dce, sizeof(*dce));
 	rc = dbtree_upsert(cont->vc_dtx_committed_hdl, BTR_PROBE_EQ,
 			   DAOS_INTENT_UPDATE, &kiov, &riov);
-	if (rc != 0)
+	if (rc != 0 || epoch != 0)
 		goto out;
 
-	tab = &cont->vc_cont_df->cd_dtx_table_df;
-	umem_tx_add_ptr(umm, tab, sizeof(*tab));
-
-	tab->tt_count++;
-	if (dtx_is_null(tab->tt_entry_tail)) {
-		D_ASSERT(dtx_is_null(tab->tt_entry_head));
-
-		tab->tt_entry_head = umoff;
-		tab->tt_entry_tail = tab->tt_entry_head;
-	} else {
-		ent = umem_off2ptr(umm, tab->tt_entry_tail);
-		umem_tx_add_ptr(umm, &ent->te_next, sizeof(ent->te_next));
-
-		ent->te_next = umoff;
-		dtx->te_prev = tab->tt_entry_tail;
-		tab->tt_entry_tail = ent->te_next;
-	}
+	vos_dtx_del_cos(cont, &DAE_OID(dae), dti, DAE_DKEY_HASH(dae),
+			DAE_INTENT(dae) == DAOS_INTENT_PUNCH ? true : false);
 
 	/* XXX: Only mark the DTX as DTX_ST_COMMITTED (when commit) is not
 	 *	enough. Otherwise, some subsequent modification may change
@@ -659,52 +881,53 @@ vos_dtx_commit_one(struct vos_container *cont, struct dtx_id *dti)
 	 *	record as to the current DTX will have invalid reference(s)
 	 *	via its DTX record(s).
 	 */
-	dtx_rec_release(umm, umoff, false, false, true);
-	vos_dtx_del_cos(cont, &dtx->te_oid, dti, dtx->te_dkey_hash,
-			dtx->te_intent == DAOS_INTENT_PUNCH ? true : false);
+	dtx_rec_release(umm, cont, dae, false, true, &dce->dce_bcb);
+	if (dce->dce_bcb != NULL)
+		d_list_add_tail(&dce->dce_bcb_link,
+				&dce->dce_bcb->bcb_dce_list);
 
 out:
 	D_DEBUG(DB_TRACE, "Commit the DTX "DF_DTI": rc = %d\n",
 		DP_DTI(dti), rc);
+	if (rc != 0)
+		D_FREE_PTR(dce);
+	else
+		*dce_p = dce;
 
 	return rc;
 }
 
 static int
 vos_dtx_abort_one(struct vos_container *cont, daos_epoch_t epoch,
-		  struct dtx_id *dti, bool force)
+		  struct dtx_id *dti)
 {
-	d_iov_t			kiov;
-	umem_off_t		off;
-	dbtree_probe_opc_t	opc = BTR_PROBE_EQ;
-	int			rc;
+	struct vos_dtx_act_ent	*dae;
+	d_iov_t			 riov;
+	d_iov_t			 kiov;
+	dbtree_probe_opc_t	 opc = BTR_PROBE_EQ;
+	int			 rc;
 
 	d_iov_set(&kiov, dti, sizeof(*dti));
 	if (epoch != 0) {
-		struct vos_dtx_entry_df	*dtx;
-		d_iov_t			 riov;
-
 		d_iov_set(&riov, NULL, 0);
 		rc = dbtree_lookup(cont->vc_dtx_active_hdl, &kiov, &riov);
 		if (rc != 0)
 			goto out;
 
-		dtx = (struct vos_dtx_entry_df *)riov.iov_buf;
-		if (dtx->te_epoch > epoch)
+		dae = (struct vos_dtx_act_ent *)riov.iov_buf;
+		if (DAE_EPOCH(dae) > epoch)
 			D_GOTO(out, rc = -DER_NONEXIST);
 
 		opc = BTR_PROBE_BYPASS;
 	}
 
-	rc = dbtree_delete(cont->vc_dtx_active_hdl, opc, &kiov, &off);
+	rc = dbtree_delete(cont->vc_dtx_active_hdl, opc, &kiov, &dae);
 	if (rc == 0)
-		dtx_rec_release(vos_cont2umm(cont), off, true, true, false);
+		dtx_rec_release(vos_cont2umm(cont), cont, dae, true, true,
+				NULL);
 
 out:
 	D_DEBUG(DB_TRACE, "Abort the DTX "DF_DTI": rc = %d\n", DP_DTI(dti), rc);
-
-	if (rc != 0 && force)
-		rc = 0;
 
 	return rc;
 }
@@ -720,72 +943,182 @@ vos_dtx_is_normal_entry(struct umem_instance *umm, umem_off_t entry)
 }
 
 static int
-vos_dtx_alloc(struct umem_instance *umm, struct dtx_handle *dth,
-	      umem_off_t rec_umoff, struct vos_dtx_entry_df **dtxp)
+vos_dtx_extend_act_table(struct vos_container *cont)
 {
-	struct vos_dtx_entry_df	*dtx;
-	struct vos_container	*cont;
-	umem_off_t		 dtx_umoff;
-	d_iov_t		 kiov;
-	d_iov_t		 riov;
-	struct dtx_rec_bundle	 rbund;
-	int			 rc;
+	struct umem_instance		*umm = vos_cont2umm(cont);
+	struct vos_cont_df		*cont_df = cont->vc_cont_df;
+	struct dtx_batched_cleanup_blob	*bcb;
+	struct vos_dtx_scm_blob		*dsb;
+	struct vos_dtx_scm_blob		*tmp;
+	umem_off_t			 dsb_off;
+
+	dsb_off = umem_zalloc(umm, DTX_SCM_BLOB_SIZE);
+	if (dtx_is_null(dsb_off)) {
+		D_ERROR("No space when create actvie DTX table.\n");
+		return -DER_NOSPACE;
+	}
+
+	dsb = umem_off2ptr(umm, dsb_off);
+	dsb->dsb_magic = DTX_ACT_BLOB_MAGIC;
+	dsb->dsb_cap = (DTX_SCM_BLOB_SIZE - sizeof(struct vos_dtx_scm_blob)) /
+			sizeof(struct vos_dtx_act_ent_df);
+
+	bcb = dtx_bcb_alloc(cont, dsb);
+	if (bcb == NULL) {
+		umem_free(umm, dsb_off);
+		return -DER_NOMEM;
+	}
+
+	tmp = umem_off2ptr(umm, cont_df->cd_dtx_active_tail);
+	if (tmp == NULL) {
+		D_ASSERT(dtx_is_null(cont_df->cd_dtx_active_head));
+
+		/* cd_dtx_active_tail is next to cd_dtx_active_head */
+		umem_tx_add_ptr(umm, &cont_df->cd_dtx_active_head,
+				sizeof(cont_df->cd_dtx_active_head) +
+				sizeof(cont_df->cd_dtx_active_tail));
+		cont_df->cd_dtx_active_head = dsb_off;
+	} else {
+		umem_tx_add_ptr(umm, &tmp->dsb_next, sizeof(tmp->dsb_next));
+		tmp->dsb_next = dsb_off;
+
+		dsb->dsb_prev = cont_df->cd_dtx_active_tail;
+		umem_tx_add_ptr(umm, &cont_df->cd_dtx_active_tail,
+				sizeof(cont_df->cd_dtx_active_tail));
+	}
+
+	cont_df->cd_dtx_active_tail = dsb_off;
+
+	return 0;
+}
+
+static int
+vos_dtx_alloc(struct umem_instance *umm, struct dtx_handle *dth)
+{
+	struct vos_dtx_act_ent		*dae = NULL;
+	struct dtx_batched_cleanup_blob	*bcb = NULL;
+	struct vos_container		*cont;
+	struct vos_cont_df		*cont_df;
+	struct vos_dtx_scm_blob		*dsb;
+	d_iov_t				 kiov;
+	d_iov_t				 riov;
+	int				 rc;
 
 	cont = vos_hdl2cont(dth->dth_coh);
 	D_ASSERT(cont != NULL);
 
-	dtx_umoff = umem_zalloc(umm, sizeof(struct vos_dtx_entry_df));
-	if (dtx_is_null(dtx_umoff))
-		return -DER_NOSPACE;
+	cont_df = cont->vc_cont_df;
+	dth->dth_gen = cont->vc_dtx_resync_gen;
 
-	dtx = umem_off2ptr(umm, dtx_umoff);
-	dtx->te_xid = dth->dth_xid;
-	dtx->te_oid = dth->dth_oid;
-	dtx->te_dkey_hash = dth->dth_dkey_hash;
-	dtx->te_epoch = dth->dth_epoch;
-	dtx->te_ver = dth->dth_ver;
-	dtx->te_state = DTX_ST_PREPARED;
-	dtx->te_flags = dth->dth_leader ? DTX_EF_LEADER : 0;
-	dtx->te_intent = dth->dth_intent;
-	dtx->te_time = crt_hlc_get();
-	dtx->te_records = rec_umoff;
-	dtx->te_next = UMOFF_NULL;
-	dtx->te_prev = UMOFF_NULL;
+	D_ALLOC_PTR(dae);
+	if (dae == NULL)
+		return -DER_NOMEM;
 
-	rbund.trb_umoff = dtx_umoff;
-	d_iov_set(&riov, &rbund, sizeof(rbund));
-	d_iov_set(&kiov, &dth->dth_xid, sizeof(dth->dth_xid));
+	DAE_XID(dae) = dth->dth_xid;
+	DAE_OID(dae) = dth->dth_oid;
+	DAE_DKEY_HASH(dae) = dth->dth_dkey_hash;
+	DAE_EPOCH(dae) = dth->dth_epoch;
+	DAE_FLAGS(dae) = dth->dth_leader ? DTX_EF_LEADER : 0;
+	DAE_INTENT(dae) = dth->dth_intent;
+	DAE_SRV_GEN(dae) = dth->dth_gen;
+	DAE_LAYOUT_GEN(dae) = dth->dth_gen;
+
+	dsb = umem_off2ptr(umm, cont_df->cd_dtx_active_tail);
+	if (dsb == NULL || dsb->dsb_index >= dsb->dsb_cap) {
+		rc = vos_dtx_extend_act_table(cont);
+		if (rc != 0)
+			goto out;
+
+		dsb = umem_off2ptr(umm, cont_df->cd_dtx_active_tail);
+	}
+
+	bcb = d_list_entry(cont->vc_batched_cleanup_list.prev,
+			   struct dtx_batched_cleanup_blob, bcb_cont_link);
+
+	/* Set it as dsb::dsb_index via vos_dtx_prepared(). */
+	DAE_INDEX(dae) = -1;
+	dae->dae_df_off = umem_ptr2off(umm, dsb) +
+			offsetof(struct vos_dtx_scm_blob, dsb_active_data) +
+			sizeof(struct vos_dtx_act_ent_df) * dsb->dsb_index;
+	dae->dae_dsb = dsb;
+	dae->dae_bcb = bcb;
+
+	d_iov_set(&kiov, &DAE_XID(dae), sizeof(DAE_XID(dae)));
+	d_iov_set(&riov, dae, sizeof(*dae));
 	rc = dbtree_upsert(cont->vc_dtx_active_hdl, BTR_PROBE_EQ,
 			   DAOS_INTENT_UPDATE, &kiov, &riov);
-	if (rc == 0) {
-		dth->dth_ent = dtx_umoff;
-		*dtxp = dtx;
+	if (rc == 0)
+		dth->dth_ent = dae;
+
+out:
+	if (rc != 0) {
+		D_FREE_PTR(dae);
+		D_FREE_PTR(bcb);
 	}
 
 	return rc;
 }
 
-static void
-vos_dtx_append(struct umem_instance *umm, struct dtx_handle *dth,
-	       umem_off_t rec_umoff, umem_off_t record, uint32_t type,
-	       uint32_t flags, struct vos_dtx_entry_df **dtxp)
+static int
+vos_dtx_rec_extend(struct vos_dtx_act_ent *dae)
 {
-	struct vos_dtx_entry_df		*dtx;
+	struct vos_dtx_record_df	*rec;
+	int				 count;
+
+	if (dae->dae_rec_cap == 0)
+		count = DTX_REC_CAP_DEFAULT;
+	else
+		count = dae->dae_rec_cap * 2;
+
+	D_ALLOC(rec, sizeof(*rec) * count);
+	if (rec == NULL)
+		return -DER_NOMEM;
+
+	if (dae->dae_records != NULL) {
+		memcpy(rec, dae->dae_records, sizeof(*rec) * dae->dae_rec_cap);
+		D_FREE(dae->dae_records);
+	}
+
+	dae->dae_records = rec;
+	dae->dae_rec_cap = count;
+
+	return 0;
+}
+
+static int
+vos_dtx_append(struct umem_instance *umm, struct dtx_handle *dth,
+	       umem_off_t record, uint32_t type, uint32_t flags)
+{
+	struct vos_dtx_act_ent		*dae = dth->dth_ent;
 	struct vos_dtx_record_df	*rec;
 	struct vos_dtx_record_df	*tgt;
+	struct vos_obj_df		*obj;
 
-	/* The @dtx must be new created via former
-	 * vos_dtx_register_record(), no need umem_tx_add_ptr().
-	 */
-	dtx = umem_off2ptr(umm, dth->dth_ent);
-	dtx->te_time = crt_hlc_get();
-	rec = umem_off2ptr(umm, rec_umoff);
-	rec->tr_next = dtx->te_records;
-	dtx->te_records = rec_umoff;
-	*dtxp = dtx;
+	D_ASSERT(dae != NULL);
+
+	if (DAE_REC_CNT(dae) < DTX_INLINE_REC_CNT) {
+		rec = &DAE_REC_INLINE(dae)[DAE_REC_CNT(dae)];
+	} else {
+		if (DAE_REC_CNT(dae) >= dae->dae_rec_cap + DTX_INLINE_REC_CNT) {
+			int	rc;
+
+			rc = vos_dtx_rec_extend(dae);
+			if (rc != 0)
+				return rc;
+		}
+
+		rec = &dae->dae_records[DAE_REC_CNT(dae) - DTX_INLINE_REC_CNT];
+	}
+
+	rec->dr_type = type;
+	rec->dr_flags = flags;
+	rec->dr_record = record;
+
+	/* The rec_cnt on-disk value will be refreshed via vos_dtx_prepared() */
+	DAE_REC_CNT(dae)++;
 
 	if (flags == 0)
-		return;
+		return 0;
 
 	/*
 	 * XXX: Currently, we only support DTX_RF_EXCHANGE_SRC when register
@@ -795,73 +1128,88 @@ vos_dtx_append(struct umem_instance *umm, struct dtx_handle *dth,
 	 */
 	D_ASSERT(flags == DTX_RF_EXCHANGE_SRC);
 	D_ASSERT(type == DTX_RT_OBJ);
+	D_ASSERT(rec != DAE_REC_INLINE(dae));
 
 	/* The @tgt must be new created via former
 	 * vos_dtx_register_record(), no need umem_tx_add_ptr().
 	 */
-	tgt = umem_off2ptr(umm, rec->tr_next);
-	D_ASSERT(tgt->tr_flags == 0);
+	if (rec == dae->dae_records)
+		tgt = &DAE_REC_INLINE(dae)[DTX_INLINE_REC_CNT - 1];
+	else
+		tgt = rec - 1;
+	D_ASSERT(tgt->dr_flags == 0);
 
-	tgt->tr_flags = DTX_RF_EXCHANGE_TGT;
-	dtx->te_flags |= DTX_EF_EXCHANGE_PENDING;
+	tgt->dr_flags = DTX_RF_EXCHANGE_TGT;
+	DAE_FLAGS(dae) |= DTX_EF_EXCHANGE_PENDING;
 
-	if (type == DTX_RT_OBJ) {
-		struct vos_obj_df	*obj;
+	obj = umem_off2ptr(umm, record);
+	umem_tx_add_ptr(umm, &obj->vo_oi_attr, sizeof(obj->vo_oi_attr));
+	obj->vo_oi_attr |= VOS_OI_REMOVED;
 
-		obj = umem_off2ptr(umm, record);
-		obj->vo_oi_attr |= VOS_OI_REMOVED;
-	}
+	D_DEBUG(DB_TRACE, "Register exchange source for OBJ DTX "DF_DTI"\n",
+		DP_DTI(&DAE_XID(dae)));
 
-	D_DEBUG(DB_TRACE, "Register exchange source for %s DTX "DF_DTI"\n",
-		type == DTX_RT_OBJ ? "OBJ" : "KEY", DP_DTI(&dtx->te_xid));
+	return 0;
 }
 
 static int
-vos_dtx_append_share(struct umem_instance *umm, struct vos_dtx_entry_df *dtx,
+vos_dtx_append_share(struct umem_instance *umm, struct vos_dtx_act_ent *dae,
 		     struct dtx_share *dts)
 {
 	struct vos_dtx_record_df	*rec;
-	umem_off_t			 rec_umoff;
 
-	rec_umoff = umem_zalloc(umm, sizeof(struct vos_dtx_record_df));
-	if (dtx_is_null(rec_umoff))
-		return -DER_NOSPACE;
+	if (DAE_REC_CNT(dae) < DTX_INLINE_REC_CNT) {
+		rec = &DAE_REC_INLINE(dae)[DAE_REC_CNT(dae)];
+	} else {
+		if (DAE_REC_CNT(dae) >= dae->dae_rec_cap + DTX_INLINE_REC_CNT) {
+			int	rc;
 
-	rec = umem_off2ptr(umm, rec_umoff);
-	rec->tr_type = dts->dts_type;
-	rec->tr_flags = 0;
-	rec->tr_record = dts->dts_record;
+			rc = vos_dtx_rec_extend(dae);
+			if (rc != 0)
+				return rc;
+		}
 
-	rec->tr_next = dtx->te_records;
-	dtx->te_records = rec_umoff;
+		rec = &dae->dae_records[DAE_REC_CNT(dae) - DTX_INLINE_REC_CNT];
+	}
+
+	rec->dr_type = dts->dts_type;
+	rec->dr_flags = 0;
+	rec->dr_record = dts->dts_record;
+
+	/* The rec_cnt on-disk value will be refreshed via vos_dtx_prepared() */
+	DAE_REC_CNT(dae)++;
 
 	return 0;
 }
 
 static int
 vos_dtx_share_obj(struct umem_instance *umm, struct dtx_handle *dth,
-		  struct vos_dtx_entry_df *dtx, struct dtx_share *dts,
+		  struct vos_dtx_act_ent *dae, struct dtx_share *dts,
 		  bool *shared)
 {
-	struct vos_obj_df	*obj;
-	struct vos_dtx_entry_df	*sh_dtx;
-	int			 rc;
+	struct vos_container		*cont;
+	struct vos_obj_df		*obj;
+	struct vos_dtx_act_ent_df	*sh_dae_df;
+	struct vos_dtx_act_ent		*sh_dae;
+	d_iov_t				 kiov;
+	d_iov_t				 riov;
+	int				 rc;
 
 	obj = umem_off2ptr(umm, dts->dts_record);
-	dth->dth_obj = dts->dts_record;
 	/* The to be shared obj has been committed. */
 	if (dtx_is_null(obj->vo_dtx))
 		return 0;
 
-	rc = vos_dtx_append_share(umm, dtx, dts);
+	rc = vos_dtx_append_share(umm, dae, dts);
 	if (rc != 0) {
-		D_DEBUG(DB_TRACE, "The DTX "DF_DTI" failed to shares obj "
+		D_ERROR("The DTX "DF_DTI" failed to shares obj "
 			"with others:: rc = %d\n",
-			DP_DTI(&dth->dth_xid), rc);
+			DP_DTI(&DAE_XID(dae)), rc);
 		return rc;
 	}
 
-	umem_tx_add_ptr(umm, obj, sizeof(*obj));
+	dth->dth_obj = dts->dts_record;
+	umem_tx_add_ptr(umm, &obj->vo_dtx_shares, sizeof(obj->vo_dtx_shares));
 
 	/* The to be shared obj has been aborted, reuse it. */
 	if (dtx_is_aborted(obj->vo_dtx)) {
@@ -879,42 +1227,51 @@ vos_dtx_share_obj(struct umem_instance *umm, struct dtx_handle *dth,
 	 * still share the obj. Then set the vo_dtx to current DTX.
 	 */
 	if (dtx_is_unknown(obj->vo_dtx)) {
+		D_ASSERT(dae != NULL);
+
 		D_DEBUG(DB_TRACE, "The DTX "DF_DTI" shares obj "
 			"with unknown DTXs, shares count %u.\n",
-			DP_DTI(&dth->dth_xid), obj->vo_dtx_shares);
-		obj->vo_dtx = dth->dth_ent;
+			DP_DTI(&DAE_XID(dae)), obj->vo_dtx_shares);
+		umem_tx_add_ptr(umm, &obj->vo_dtx, sizeof(obj->vo_dtx));
+		obj->vo_dtx = dae->dae_df_off;
 		return 0;
 	}
 
 	D_ASSERT(vos_dtx_is_normal_entry(umm, obj->vo_dtx));
 
-	sh_dtx = umem_off2ptr(umm, obj->vo_dtx);
-	D_ASSERT(dtx != sh_dtx);
-	D_ASSERTF(sh_dtx->te_state == DTX_ST_PREPARED,
-		  "Invalid shared obj DTX state: %u\n",
-		  sh_dtx->te_state);
+	cont = vos_hdl2cont(dth->dth_coh);
+	sh_dae_df = umem_off2ptr(umm, obj->vo_dtx);
+	d_iov_set(&kiov, &sh_dae_df->dae_xid, sizeof(sh_dae_df->dae_xid));
+	d_iov_set(&riov, NULL, 0);
+	rc = dbtree_lookup(cont->vc_dtx_active_hdl, &kiov, &riov);
+	if (rc != 0) {
+		D_ERROR("Cannot find shared active DTX entry with "
+			DF_DTI"\n", DP_DTI(&sh_dae_df->dae_xid));
+		return rc;
+	}
 
-	umem_tx_add_ptr(umm, sh_dtx, sizeof(*sh_dtx));
-	sh_dtx->te_flags |= DTX_EF_SHARES;
+	sh_dae = (struct vos_dtx_act_ent *)riov.iov_buf;
+	D_ASSERT(dae != sh_dae);
+	DAE_FLAGS(sh_dae) |= DTX_EF_SHARES;
+
+	umem_tx_add_ptr(umm, &sh_dae_df->dae_flags,
+			sizeof(sh_dae_df->dae_flags));
+	sh_dae_df->dae_flags |= DTX_EF_SHARES;
 
 	D_DEBUG(DB_TRACE, "The DTX "DF_DTI" try to shares obj "DF_X64
 		" with other DTX "DF_DTI", the shares count %u\n",
-		DP_DTI(&dth->dth_xid), dts->dts_record,
-		DP_DTI(&sh_dtx->te_xid), obj->vo_dtx_shares);
+		DP_DTI(&DAE_XID(dae)), dts->dts_record,
+		DP_DTI(&DAE_XID(sh_dae)), obj->vo_dtx_shares);
 
 	return 0;
 }
 
 static int
-vos_dtx_check_shares(struct umem_instance *umm, daos_handle_t coh,
-		     struct dtx_handle *dth, struct vos_dtx_entry_df *dtx,
-		     umem_off_t record, uint32_t intent, uint32_t type,
-		     umem_off_t *addr)
+vos_dtx_check_shares(struct umem_instance *umm, struct dtx_handle *dth,
+		     struct vos_dtx_act_ent *dae, umem_off_t record,
+		     uint32_t intent, uint32_t type, umem_off_t *addr)
 {
 	struct dtx_share	*dts;
-
-	if (dtx != NULL)
-		D_ASSERT(dtx->te_intent == DAOS_INTENT_UPDATE);
 
 	/* PUNCH cannot share with others. */
 	if (intent == DAOS_INTENT_PUNCH) {
@@ -925,18 +1282,18 @@ vos_dtx_check_shares(struct umem_instance *umm, daos_handle_t coh,
 		 *	me, so we can NOT set dth::dth_conflict that
 		 *	will be used by DTX conflict handling logic.
 		 */
-		dtx_record_conflict(dth, dtx);
+		dtx_record_conflict(dth, dae);
 
-		return dtx_inprogress(dtx, 4);
+		return dtx_inprogress(dae, 1);
 	}
 
 	D_ASSERT(intent == DAOS_INTENT_UPDATE);
 
 	/* Only OBJ record can be shared by new update. */
 	if (type != DTX_RT_OBJ) {
-		dtx_record_conflict(dth, dtx);
+		dtx_record_conflict(dth, dae);
 
-		return dtx_inprogress(dtx, 5);
+		return dtx_inprogress(dae, 2);
 	}
 
 	/* Here, if the obj/key has 'prepared' DTX, but current @dth is NULL,
@@ -947,21 +1304,21 @@ vos_dtx_check_shares(struct umem_instance *umm, daos_handle_t coh,
 	 * the shared target (obj/key) to guarantee the rebuild can go ahead.
 	 */
 	if (dth == NULL) {
-		struct vos_container	*cont = vos_hdl2cont(coh);
-		int			 rc;
+		int	rc;
 
 		D_ASSERT(addr != NULL);
 
-		rc = vos_tx_begin(vos_cont2umm(cont));
-		if (rc == 0) {
-			umem_tx_add_ptr(umm, addr, sizeof(*addr));
-			*addr = UMOFF_NULL;
-			rc = vos_tx_end(vos_cont2umm(cont), 0);
-		}
+		rc = vos_tx_begin(umm);
 		if (rc != 0)
 			return rc;
 
-		return ALB_AVAILABLE_CLEAN;
+		umem_tx_add_ptr(umm, addr, sizeof(*addr));
+		*addr = UMOFF_NULL;
+		rc = vos_tx_end(umm, 0);
+		if (rc == 0)
+			rc = ALB_AVAILABLE_CLEAN;
+
+		return rc;
 	}
 
 	D_ALLOC_PTR(dts);
@@ -981,8 +1338,13 @@ vos_dtx_check_availability(struct umem_instance *umm, daos_handle_t coh,
 			   uint32_t type)
 {
 	struct dtx_handle		*dth = vos_dth_get();
-	struct vos_dtx_entry_df		*dtx = NULL;
+	struct vos_container		*cont;
+	struct vos_dtx_act_ent		*dae = NULL;
+	struct vos_dtx_act_ent_df	*dae_df = NULL;
 	umem_off_t			*addr = NULL;
+	d_iov_t				 kiov;
+	d_iov_t				 riov;
+	int				 rc;
 	bool				 hidden = false;
 
 	switch (type) {
@@ -1025,8 +1387,11 @@ vos_dtx_check_availability(struct umem_instance *umm, daos_handle_t coh,
 	}
 
 	if (intent == DAOS_INTENT_CHECK || intent == DAOS_INTENT_COS) {
-		if (dtx_is_aborted(entry))
+		if (dtx_is_aborted(entry)) {
+			D_ASSERT(!hidden);
+
 			return ALB_UNAVAILABLE;
+		}
 
 		if (dtx_is_null(entry) && hidden)
 			return ALB_UNAVAILABLE;
@@ -1049,8 +1414,11 @@ vos_dtx_check_availability(struct umem_instance *umm, daos_handle_t coh,
 		return hidden ? ALB_AVAILABLE_CLEAN : ALB_AVAILABLE_DIRTY;
 
 	/* Aborted */
-	if (dtx_is_aborted(entry))
-		return hidden ? ALB_AVAILABLE_CLEAN : ALB_UNAVAILABLE;
+	if (dtx_is_aborted(entry)) {
+		D_ASSERT(!hidden);
+
+		return ALB_UNAVAILABLE;
+	}
 
 	if (dtx_is_unknown(entry)) {
 		/* The original DTX must be with DAOS_INTENT_UPDATE, then
@@ -1063,123 +1431,123 @@ vos_dtx_check_availability(struct umem_instance *umm, daos_handle_t coh,
 		    intent == DAOS_INTENT_REBUILD)
 			return hidden ? ALB_AVAILABLE_CLEAN : ALB_UNAVAILABLE;
 
-		return vos_dtx_check_shares(umm, coh, dth, NULL, record, intent,
+		return vos_dtx_check_shares(umm, dth, NULL, record, intent,
 					    type, addr);
 	}
 
 	/* The DTX owner can always see the DTX. */
-	if (dth != NULL && entry == dth->dth_ent)
-		return ALB_AVAILABLE_CLEAN;
-
-	dtx = umem_off2ptr(umm, entry);
-	switch (dtx->te_state) {
-	case DTX_ST_COMMITTED:
-		return hidden ? ALB_UNAVAILABLE : ALB_AVAILABLE_CLEAN;
-	case DTX_ST_PREPARED: {
-		struct vos_container	*cont = vos_hdl2cont(coh);
-		int			 rc;
-
-		if (cont == NULL)
-			goto skip_cos;
-
-		rc = vos_dtx_lookup_cos(coh, &dtx->te_oid, &dtx->te_xid,
-			dtx->te_dkey_hash,
-			dtx->te_intent == DAOS_INTENT_PUNCH ? true : false);
-		if (rc == 0) {
-			/* XXX: For the committable punch DTX, if there is
-			 *	pending exchange (of sub-trees) operation,
-			 *	then do it, otherwise the subsequent fetch
-			 *	cannot get the proper sub-trees.
-			 */
-			if (dtx->te_flags & DTX_EF_EXCHANGE_PENDING) {
-				rc = vos_tx_begin(vos_cont2umm(cont));
-				if (rc == 0) {
-					dtx_rec_release(vos_cont2umm(cont),
-							entry, false, false,
-							false);
-					rc = vos_tx_end(vos_cont2umm(cont), 0);
-				}
-
-				if (rc != 0)
-					return rc;
-			}
-
-			return hidden ? ALB_UNAVAILABLE : ALB_AVAILABLE_CLEAN;
-		}
-
-		if (rc != -DER_NONEXIST)
-			return rc;
-
-		/* The followings are for non-committable cases. */
-
-skip_cos:
-		if (intent == DAOS_INTENT_DEFAULT ||
-		    intent == DAOS_INTENT_REBUILD) {
-			if (!(dtx->te_flags & DTX_EF_LEADER) ||
-			    DAOS_FAIL_CHECK(DAOS_VOS_NON_LEADER)) {
-				/* Inavailable for rebuild case. */
-				if (intent == DAOS_INTENT_REBUILD)
-					return hidden ? ALB_AVAILABLE_CLEAN :
-						ALB_UNAVAILABLE;
-
-				D_DEBUG(DB_TRACE, "Let's ask leader "DF_DTI
-					"\n", DP_DTI(&dtx->te_xid));
-				/* Non-leader and non-rebuild case,
-				 * return -DER_INPROGRESS, then the
-				 * caller will retry the RPC with
-				 * leader replica.
-				 */
-				return dtx_inprogress(dtx, 2);
-			}
-
-			/* For leader, non-committed DTX is unavailable. */
-			return hidden ? ALB_AVAILABLE_CLEAN : ALB_UNAVAILABLE;
-		}
-
-		/* PUNCH DTX cannot be shared by others. */
-		if (dtx->te_intent == DAOS_INTENT_PUNCH) {
-			if (dth == NULL)
-				/* XXX: For rebuild case, if some normal IO
-				 *	has generated punch-record (by race)
-				 *	before rebuild logic handling that,
-				 *	then rebuild logic should ignore such
-				 *	punch-record, because the punch epoch
-				 *	will be higher than the rebuild epoch.
-				 *	The rebuild logic needs to create the
-				 *	original target record that exists on
-				 *	other healthy replicas before punch.
-				 */
-				return ALB_UNAVAILABLE;
-
-			dtx_record_conflict(dth, dtx);
-
-			return dtx_inprogress(dtx, 3);
-		}
-
-		if (dtx->te_intent != DAOS_INTENT_UPDATE) {
-			D_ERROR("Unexpected DTX intent %u\n", dtx->te_intent);
-			return -DER_INVAL;
-		}
-
-		return vos_dtx_check_shares(umm, coh, dth, dtx, record, intent,
-					    type, addr);
+	if (dth != NULL && dth->dth_ent != NULL) {
+		dae = dth->dth_ent;
+		if (dae->dae_df_off == entry)
+			return ALB_AVAILABLE_CLEAN;
 	}
-	default:
-		D_ERROR("Unexpected DTX state %u\n", dtx->te_state);
+
+	cont = vos_hdl2cont(coh);
+	D_ASSERT(cont != NULL);
+
+	dae_df = umem_off2ptr(umm, entry);
+	d_iov_set(&kiov, &dae_df->dae_xid, sizeof(dae_df->dae_xid));
+	d_iov_set(&riov, NULL, 0);
+	rc = dbtree_lookup(cont->vc_dtx_active_hdl, &kiov, &riov);
+	if (rc != 0) {
+		if (rc == -DER_NONEXIST)
+			/* Handle it as aborted one. */
+			return ALB_UNAVAILABLE;
+
+		D_WARN("Cannot find active DTX entry for "DF_DTI"\n",
+		       DP_DTI(&dae_df->dae_xid));
+		return rc;
+	}
+
+	dae = (struct vos_dtx_act_ent *)riov.iov_buf;
+
+	rc = vos_dtx_lookup_cos(coh, &DAE_OID(dae), &DAE_XID(dae),
+			DAE_DKEY_HASH(dae),
+			DAE_INTENT(dae) == DAOS_INTENT_PUNCH ? true : false);
+	if (rc == 0) {
+		/* XXX: For the committable punch DTX, if there is pending
+		 *	exchange (of sub-trees) operation, then do it, otherwise
+		 *	the subsequent fetch cannot get the proper sub-trees.
+		 */
+		if (DAE_FLAGS(dae) & DTX_EF_EXCHANGE_PENDING) {
+			rc = vos_tx_begin(umm);
+			if (rc != 0)
+				return rc;
+
+			dtx_rec_release(umm, cont, dae, false, false, NULL);
+			rc = vos_tx_end(umm, 0);
+			if (rc != 0)
+				return rc;
+		}
+
+		return hidden ? ALB_UNAVAILABLE : ALB_AVAILABLE_CLEAN;
+	}
+
+	if (rc != -DER_NONEXIST)
+		return rc;
+
+	/* The followings are for non-committable cases. */
+
+	if (intent == DAOS_INTENT_DEFAULT || intent == DAOS_INTENT_REBUILD) {
+		if (!(DAE_FLAGS(dae) & DTX_EF_LEADER) ||
+		    DAOS_FAIL_CHECK(DAOS_VOS_NON_LEADER)) {
+			/* Inavailable for rebuild case. */
+			if (intent == DAOS_INTENT_REBUILD)
+				return hidden ? ALB_AVAILABLE_CLEAN :
+					ALB_UNAVAILABLE;
+
+			/* Non-leader and non-rebuild case, return
+			 * -DER_INPROGRESS, then the caller will retry
+			 * the RPC with leader replica.
+			 */
+			return dtx_inprogress(dae, 3);
+		}
+
+		/* For leader, non-committed DTX is unavailable. */
+		return hidden ? ALB_AVAILABLE_CLEAN : ALB_UNAVAILABLE;
+	}
+
+	/* PUNCH DTX cannot be shared by others. */
+	if (DAE_INTENT(dae) == DAOS_INTENT_PUNCH) {
+		if (dth == NULL)
+			/* XXX: For rebuild case, if some normal IO
+			 *	has generated punch-record (by race)
+			 *	before rebuild logic handling that,
+			 *	then rebuild logic should ignore such
+			 *	punch-record, because the punch epoch
+			 *	will be higher than the rebuild epoch.
+			 *	The rebuild logic needs to create the
+			 *	original target record that exists on
+			 *	other healthy replicas before punch.
+			 */
+			return ALB_UNAVAILABLE;
+
+		dtx_record_conflict(dth, dae);
+
+		return dtx_inprogress(dae, 4);
+	}
+
+	if (DAE_INTENT(dae) != DAOS_INTENT_UPDATE) {
+		D_ERROR("Unexpected DTX intent %u\n", DAE_INTENT(dae));
 		return -DER_INVAL;
 	}
+
+	return vos_dtx_check_shares(umm, dth, dae, record, intent,
+				    type, addr);
 }
 
 umem_off_t
 vos_dtx_get(void)
 {
-	struct dtx_handle		*dth = vos_dth_get();
+	struct dtx_handle	*dth = vos_dth_get();
+	struct vos_dtx_act_ent	*dae;
 
-
-	if (dth == NULL)
+	if (dth == NULL || dth->dth_solo)
 		return UMOFF_NULL;
 
-	return dth->dth_ent;
+	dae = dth->dth_ent;
+
+	return dae->dae_df_off;
 }
 
 /* The caller has started PMDK transaction. */
@@ -1187,16 +1555,14 @@ int
 vos_dtx_register_record(struct umem_instance *umm, umem_off_t record,
 			uint32_t type, uint32_t flags)
 {
-	struct dtx_handle		*dth = vos_dth_get();
-	struct vos_dtx_entry_df		*dtx;
-	struct vos_dtx_record_df	*rec;
-	struct dtx_share		*dts;
-	struct dtx_share		*next;
-	umem_off_t			 rec_umoff = UMOFF_NULL;
-	umem_off_t			*entry = NULL;
-	uint32_t			*shares = NULL;
-	int				 rc = 0;
-	bool				 shared = false;
+	struct dtx_handle	*dth = vos_dth_get();
+	struct vos_dtx_act_ent	*dae;
+	struct dtx_share	*dts;
+	struct dtx_share	*next;
+	umem_off_t		*entry = NULL;
+	uint32_t		*shares = NULL;
+	int			 rc = 0;
+	bool			 shared = false;
 
 	switch (type) {
 	case DTX_RT_OBJ: {
@@ -1207,12 +1573,7 @@ vos_dtx_register_record(struct umem_instance *umm, umem_off_t record,
 		if (dth == NULL || dth->dth_intent == DAOS_INTENT_UPDATE)
 			shares = &obj->vo_dtx_shares;
 
-		/* "flags == 0" means new created object. It is unnecessary
-		 * to umem_tx_add_ptr() for new created object.
-		 */
-		if (flags != 0)
-			umem_tx_add_ptr(umm, obj, sizeof(*obj));
-		else if (dth != NULL)
+		if (flags == 0 && dth != NULL)
 			dth->dth_obj = record;
 		break;
 	}
@@ -1235,7 +1596,10 @@ vos_dtx_register_record(struct umem_instance *umm, umem_off_t record,
 		return -DER_INVAL;
 	}
 
-	if (dth == NULL) {
+	/* For single participator case, we only need the DTX entry
+	 * without DTX records for related targets to be modified.
+	 */
+	if (dth == NULL || dth->dth_solo) {
 		*entry = UMOFF_NULL;
 		if (shares != NULL)
 			*shares = 0;
@@ -1243,27 +1607,20 @@ vos_dtx_register_record(struct umem_instance *umm, umem_off_t record,
 		return 0;
 	}
 
-	rec_umoff = umem_zalloc(umm, sizeof(struct vos_dtx_record_df));
-	if (dtx_is_null(rec_umoff))
-		return -DER_NOSPACE;
-
-	rec = umem_off2ptr(umm, rec_umoff);
-	rec->tr_type = type;
-	rec->tr_flags = flags;
-	rec->tr_record = record;
-	rec->tr_next = UMOFF_NULL;
-
-	if (dtx_is_null(dth->dth_ent)) {
+	if (dth->dth_ent == NULL) {
 		D_ASSERT(flags == 0);
 
-		rc = vos_dtx_alloc(umm, dth, rec_umoff, &dtx);
+		rc = vos_dtx_alloc(umm, dth);
 		if (rc != 0)
 			return rc;
-	} else {
-		vos_dtx_append(umm, dth, rec_umoff, record, type, flags, &dtx);
 	}
 
-	*entry = dth->dth_ent;
+	rc = vos_dtx_append(umm, dth, record, type, flags);
+	if (rc != 0)
+		return rc;
+
+	dae = dth->dth_ent;
+	*entry = dae->dae_df_off;
 	if (shares != NULL)
 		*shares = 1;
 
@@ -1271,8 +1628,9 @@ vos_dtx_register_record(struct umem_instance *umm, umem_off_t record,
 		return 0;
 
 	d_list_for_each_entry_safe(dts, next, &dth->dth_shares, dts_link) {
-		if (dts->dts_type == DTX_RT_OBJ)
-			rc = vos_dtx_share_obj(umm, dth, dtx, dts, &shared);
+		D_ASSERT(dts->dts_type == DTX_RT_OBJ);
+
+		rc = vos_dtx_share_obj(umm, dth, dae, dts, &shared);
 		if (rc != 0)
 			return rc;
 
@@ -1281,7 +1639,7 @@ vos_dtx_register_record(struct umem_instance *umm, umem_off_t record,
 	}
 
 	if (rc == 0 && shared)
-		dtx->te_flags |= DTX_EF_SHARES;
+		DAE_FLAGS(dae) |= DTX_EF_SHARES;
 
 	return rc;
 }
@@ -1290,80 +1648,128 @@ int
 vos_dtx_register_ilog(struct umem_instance *umm, umem_off_t record,
 		      umem_off_t *tx_id)
 {
-	struct dtx_handle		*dth = vos_dth_get();
-	struct vos_dtx_entry_df		*dtx;
-	struct vos_dtx_record_df	*rec;
-	umem_off_t			 rec_umoff = UMOFF_NULL;
-	int				 rc = 0;
+	struct dtx_handle	*dth = vos_dth_get();
+	int			 rc = 0;
 
-	if (dth == NULL) {
+	/* For single participator case, we only need the DTX entry
+	 * without DTX records for related targets to be modified.
+	 */
+	if (dth == NULL || dth->dth_solo) {
 		*tx_id = UMOFF_NULL;
 		return 0;
 	}
 
-	rec_umoff = umem_zalloc(umm, sizeof(struct vos_dtx_record_df));
-	if (dtx_is_null(rec_umoff))
-		return -DER_NOSPACE;
-
-	rec = umem_off2ptr(umm, rec_umoff);
-	rec->tr_type = DTX_RT_ILOG;
-	rec->tr_flags = 0;
-	rec->tr_record = record;
-	rec->tr_next = UMOFF_NULL;
-
-	if (dtx_is_null(dth->dth_ent)) {
-		rc = vos_dtx_alloc(umm, dth, rec_umoff, &dtx);
+	if (dth->dth_ent == NULL) {
+		rc = vos_dtx_alloc(umm, dth);
 		if (rc != 0)
 			return rc;
-	} else {
-		vos_dtx_append(umm, dth, rec_umoff, record, DTX_RT_ILOG, 0,
-			       &dtx);
 	}
 
-	/* Incarnation log entry implies a share */
-	*tx_id = dth->dth_ent;
+	rc = vos_dtx_append(umm, dth, record, DTX_RT_ILOG, 0);
+	if (rc == 0) {
+		struct vos_dtx_act_ent	*dae = dth->dth_ent;
+
+		/* Incarnation log entry implies a share */
+		*tx_id = dae->dae_df_off;
+	}
 
 	return rc;
 }
 
 /* The caller has started PMDK transaction. */
 void
-vos_dtx_deregister_record(struct umem_instance *umm,
-			  umem_off_t entry, umem_off_t record, uint32_t type)
+vos_dtx_deregister_record(struct umem_instance *umm, daos_handle_t coh,
+			  umem_off_t entry, umem_off_t record)
 {
-	struct vos_dtx_entry_df		*dtx;
-	struct vos_dtx_record_df	*rec;
-	struct vos_dtx_record_df	*prev = NULL;
-	umem_off_t			 rec_umoff;
-
-	D_ASSERT(type != DTX_RT_KEY);
+	struct vos_container		*cont;
+	struct vos_dtx_act_ent_df	*dae_df;
+	struct vos_dtx_record_df	*rec_df;
+	int				 type = -1;
+	int				 count;
+	int				 rc;
+	int				 i;
 
 	if (!vos_dtx_is_normal_entry(umm, entry))
 		return;
 
-	dtx = umem_off2ptr(umm, entry);
-	rec_umoff = dtx->te_records;
-	while (!dtx_is_null(rec_umoff)) {
-		rec = umem_off2ptr(umm, rec_umoff);
-		if (record == rec->tr_record) {
-			if (prev == NULL) {
-				umem_tx_add_ptr(umm, dtx, sizeof(*dtx));
-				dtx->te_records = rec->tr_next;
-			} else {
-				umem_tx_add_ptr(umm, prev, sizeof(*prev));
-				prev->tr_next = rec->tr_next;
-			}
+	dae_df = umem_off2ptr(umm, entry);
+	if (daos_is_zero_dti(&dae_df->dae_xid) ||
+	    dae_df->dae_flags & DTX_EF_INVALID)
+		return;
 
-			umem_free(umm, rec_umoff);
-			break;
+	cont = vos_hdl2cont(coh);
+	if (cont != NULL) {
+		struct vos_dtx_act_ent		*dae;
+		d_iov_t				 kiov;
+		d_iov_t				 riov;
+
+		d_iov_set(&kiov, &dae_df->dae_xid, sizeof(dae_df->dae_xid));
+		d_iov_set(&riov, NULL, 0);
+		rc = dbtree_lookup(cont->vc_dtx_active_hdl, &kiov, &riov);
+		if (rc != 0) {
+			D_WARN("NOT find active DTX entry when deregister for "
+			       DF_DTI"\n", DP_DTI(&dae_df->dae_xid));
+			return;
 		}
 
-		prev = rec;
-		rec_umoff = rec->tr_next;
+		dae = (struct vos_dtx_act_ent *)riov.iov_buf;
+		if (DAE_REC_CNT(dae) > DTX_INLINE_REC_CNT)
+			count = DTX_INLINE_REC_CNT;
+		else
+			count = DAE_REC_CNT(dae);
+
+		for (i = 0; i < count; i++) {
+			if (record == DAE_REC_INLINE(dae)[i].dr_record) {
+				DAE_REC_INLINE(dae)[i].dr_record = UMOFF_NULL;
+				goto handle_df;
+			}
+		}
+
+		for (i = 0; i < DAE_REC_CNT(dae) - DTX_INLINE_REC_CNT; i++) {
+			if (record == dae->dae_records[i].dr_record) {
+				dae->dae_records[i].dr_record = UMOFF_NULL;
+				goto handle_df;
+			}
+		}
+
+		/* Not found */
+		return;
 	}
 
-	if (dtx_is_null(rec_umoff))
-		return;
+handle_df:
+	if (dae_df->dae_rec_cnt > DTX_INLINE_REC_CNT)
+		count = DTX_INLINE_REC_CNT;
+	else
+		count = dae_df->dae_rec_cnt;
+
+	rec_df = dae_df->dae_rec_inline;
+	for (i = 0; i < count; i++) {
+		if (rec_df[i].dr_record == record) {
+			rec_df[i].dr_record = UMOFF_NULL;
+			type = rec_df[i].dr_type;
+			if (cont == NULL)
+				dae_df->dae_layout_gen++;
+			break;
+		}
+	}
+
+	if (type == -1) {
+		rec_df = umem_off2ptr(umm, dae_df->dae_rec_off);
+
+		/* Not found */
+		if (rec_df == NULL)
+			return;
+
+		for (i = 0; i < dae_df->dae_rec_cnt - DTX_INLINE_REC_CNT; i++) {
+			if (rec_df[i].dr_record == record) {
+				rec_df[i].dr_record = UMOFF_NULL;
+				type = rec_df[i].dr_type;
+				if (cont == NULL)
+					dae_df->dae_layout_gen++;
+				break;
+			}
+		}
+	}
 
 	/* The caller will destroy related OBJ/KEY/SVT/EVT record after
 	 * deregistered the DTX record. So not reset DTX reference inside
@@ -1375,8 +1781,10 @@ vos_dtx_deregister_record(struct umem_instance *umm,
 		obj = umem_off2ptr(umm, record);
 		D_ASSERT(obj->vo_dtx == entry);
 
-		umem_tx_add_ptr(umm, obj, sizeof(*obj));
-		if (dtx->te_intent == DAOS_INTENT_UPDATE) {
+		if (dae_df->dae_intent == DAOS_INTENT_UPDATE) {
+			if (obj->vo_dtx_shares > 1)
+				umem_tx_add_ptr(umm, &obj->vo_dtx,
+						VOS_OBJ_SIZE_PARTIAL);
 			obj->vo_dtx_shares--;
 			if (obj->vo_dtx_shares > 0)
 				dtx_set_unknown(&obj->vo_dtx);
@@ -1388,45 +1796,78 @@ int
 vos_dtx_prepared(struct dtx_handle *dth)
 {
 	struct vos_container	*cont;
-	struct vos_dtx_entry_df	*dtx;
-	int			 rc = 0;
-
-	D_ASSERT(!dtx_is_null(dth->dth_ent));
 
 	cont = vos_hdl2cont(dth->dth_coh);
 	D_ASSERT(cont != NULL);
 
-	dtx = umem_off2ptr(&cont->vc_pool->vp_umm, dth->dth_ent);
 	/* The caller has already started the PMDK transaction
 	 * and add the DTX into the PMDK transaction.
 	 */
-	dtx->te_state = DTX_ST_PREPARED;
 
-	if (dth->dth_non_rep) {
-		dth->dth_sync = 0;
-		rc = vos_dtx_commit_one(cont, &dth->dth_xid);
-		if (rc == 0)
-			dth->dth_ent = UMOFF_NULL;
-		else
-			D_ERROR(DF_UOID" fail to commit for "DF_DTI" rc = %d\n",
-				DP_UOID(dtx->te_oid), DP_DTI(&dtx->te_xid), rc);
-	} else if (dtx->te_flags & DTX_EF_SHARES || dtx->te_dkey_hash == 0) {
+	if (dth->dth_solo) {
+		vos_dtx_commit_internal(cont, &dth->dth_xid, 1, dth->dth_epoch);
+		dth->dth_sync = 1;
+	} else {
+		struct umem_instance		*umm = vos_cont2umm(cont);
+		struct vos_dtx_act_ent		*dae = dth->dth_ent;
+		struct vos_dtx_scm_blob		*dsb = dae->dae_dsb;
+
 		/* If some DTXs share something (object/key) with others,
 		 * or punch object that is quite possible affect subsequent
 		 * operations, then synchronously commit the DTX when it
 		 * becomes committable to avoid availability trouble.
 		 */
-		dth->dth_sync = 1;
+		if (DAE_FLAGS(dae) & DTX_EF_SHARES || DAE_DKEY_HASH(dae) == 0)
+			dth->dth_sync = 1;
+
+		if (dae->dae_records != NULL) {
+			struct vos_dtx_record_df	*rec_df;
+			umem_off_t			 rec_off;
+			int				 size;
+
+			size = sizeof(struct vos_dtx_record_df) *
+				(DAE_REC_CNT(dae) - DTX_INLINE_REC_CNT);
+			rec_off = umem_zalloc(umm, size);
+			if (dtx_is_null(rec_off)) {
+				D_ERROR("No space to store active DTX (3) "
+					DF_DTI"\n", DP_DTI(&DAE_XID(dae)));
+				return -DER_NOSPACE;
+			}
+
+			rec_df = umem_off2ptr(umm, rec_off);
+			memcpy(rec_df, dae->dae_records, size);
+			DAE_REC_OFF(dae) = rec_off;
+		}
+
+		DAE_INDEX(dae) = dsb->dsb_index;
+		if (DAE_INDEX(dae) > 0) {
+			pmem_memcpy_nodrain(umem_off2ptr(umm, dae->dae_df_off),
+					    &dae->dae_base,
+					    sizeof(struct vos_dtx_act_ent_df));
+			/* dsb_index is next to dsb_count */
+			umem_tx_add_ptr(umm, &dsb->dsb_count,
+					sizeof(dsb->dsb_count) +
+					sizeof(dsb->dsb_index));
+		} else {
+			memcpy(umem_off2ptr(umm, dae->dae_df_off),
+			       &dae->dae_base,
+			       sizeof(struct vos_dtx_act_ent_df));
+		}
+
+		dsb->dsb_count++;
+		dsb->dsb_index++;
+
+		dae->dae_bcb->bcb_dae_count++;
 	}
 
-	return rc;
+	return 0;
 }
 
 static int
 do_vos_dtx_check(daos_handle_t coh, struct dtx_id *dti, daos_epoch_t *epoch)
 {
 	struct vos_container	*cont;
-	struct vos_dtx_entry_df	*dtx;
+	struct vos_dtx_act_ent	*dae;
 	d_iov_t			 kiov;
 	d_iov_t			 riov;
 	int			 rc;
@@ -1438,19 +1879,19 @@ do_vos_dtx_check(daos_handle_t coh, struct dtx_id *dti, daos_epoch_t *epoch)
 	d_iov_set(&riov, NULL, 0);
 	rc = dbtree_lookup(cont->vc_dtx_active_hdl, &kiov, &riov);
 	if (rc == 0) {
-		dtx = (struct vos_dtx_entry_df *)riov.iov_buf;
+		dae = (struct vos_dtx_act_ent *)riov.iov_buf;
 		if (epoch != NULL) {
-			if (*epoch != 0 && *epoch != dtx->te_epoch)
+			if (*epoch == 0)
+				*epoch = DAE_EPOCH(dae);
+			else if (*epoch != DAE_EPOCH(dae))
 				return -DER_MISMATCH;
-
-			*epoch = dtx->te_epoch;
 		}
 
-		return dtx->te_state;
+		return DTX_ST_PREPARED;
 	}
 
 	if (rc == -DER_NONEXIST) {
-		rc = dbtree_lookup(cont->vc_dtx_committed_hdl, &kiov, &riov);
+		rc = dbtree_lookup(cont->vc_dtx_committed_hdl, &kiov, NULL);
 		if (rc == 0)
 			return DTX_ST_COMMITTED;
 	}
@@ -1463,7 +1904,8 @@ vos_dtx_check_resend(daos_handle_t coh, daos_unit_oid_t *oid,
 		     struct dtx_id *xid, uint64_t dkey_hash,
 		     bool punch, daos_epoch_t *epoch)
 {
-	int	rc;
+	struct vos_container	*cont;
+	int			 rc;
 
 	rc = vos_dtx_lookup_cos(coh, oid, xid, dkey_hash, punch);
 	if (rc == 0)
@@ -1472,7 +1914,17 @@ vos_dtx_check_resend(daos_handle_t coh, daos_unit_oid_t *oid,
 	if (rc != -DER_NONEXIST)
 		return rc;
 
-	return do_vos_dtx_check(coh, xid, epoch);
+	rc = do_vos_dtx_check(coh, xid, epoch);
+	if (rc != -DER_NONEXIST)
+		return rc;
+
+	cont = vos_hdl2cont(coh);
+	D_ASSERT(cont != NULL);
+
+	if (cont->vc_reindex_cmt_dtx)
+		rc = -DER_AGAIN;
+
+	return rc;
 }
 
 int
@@ -1481,14 +1933,157 @@ vos_dtx_check(daos_handle_t coh, struct dtx_id *dti)
 	return do_vos_dtx_check(coh, dti, NULL);
 }
 
-void
+int
 vos_dtx_commit_internal(struct vos_container *cont, struct dtx_id *dtis,
-			int count)
+			int count, daos_epoch_t epoch)
 {
-	int	i;
+	struct vos_cont_df		*cont_df = cont->vc_cont_df;
+	struct umem_instance		*umm = vos_cont2umm(cont);
+	struct vos_dtx_scm_blob		*dsb;
+	struct vos_dtx_scm_blob		*dsb_prev;
+	umem_off_t			 dsb_off;
+	struct vos_dtx_cmt_ent_df	*dce_df;
+	int				 slots = 0;
+	int				 cur = 0;
+	int				 rc = 0;
+	int				 rc1 = 0;
+	int				 i;
+	int				 j;
 
-	for (i = 0; i < count; i++)
-		vos_dtx_commit_one(cont, &dtis[i]);
+	dsb = umem_off2ptr(umm, cont_df->cd_dtx_committed_tail);
+	if (dsb != NULL)
+		slots = dsb->dsb_cap - dsb->dsb_count;
+
+	if (slots == 0)
+		goto new_blob;
+
+	umem_tx_add_ptr(umm, &dsb->dsb_count, sizeof(dsb->dsb_count));
+
+again:
+	if (slots > count)
+		slots = count;
+
+	count -= slots;
+
+	if (slots > 1) {
+		D_ALLOC(dce_df, sizeof(*dce_df) * slots);
+		if (dce_df == NULL)
+			return -DER_NOMEM;
+	} else {
+		dce_df = &dsb->dsb_commmitted_data[dsb->dsb_count];
+	}
+
+	for (i = 0, j = 0; i < slots; i++, cur++) {
+		struct vos_dtx_cmt_ent	*dce = NULL;
+
+		rc = vos_dtx_commit_one(cont, &dtis[cur], epoch, &dce);
+		if (rc1 == 0)
+			rc1 = rc;
+
+		if (dce != NULL) {
+			if (slots == 1)
+				pmem_memcpy_nodrain(dce_df, &dce->dce_base,
+						    sizeof(*dce_df));
+			else
+				memcpy(&dce_df[j], &dce->dce_base,
+				       sizeof(dce_df[j]));
+			j++;
+		}
+	}
+
+	if (dce_df != &dsb->dsb_commmitted_data[dsb->dsb_count]) {
+		if (j > 0)
+			pmem_memcpy_nodrain(
+				&dsb->dsb_commmitted_data[dsb->dsb_count],
+				dce_df, sizeof(*dce_df) * j);
+		D_FREE(dce_df);
+	}
+
+	if (j > 0)
+		dsb->dsb_count += j;
+
+	if (count == 0)
+		return rc != 0 ? rc : rc1;
+
+	if (j < slots) {
+		slots -= j;
+		goto again;
+	}
+
+new_blob:
+	dsb_prev = dsb;
+
+	/* Need new @dsb */
+	dsb_off = umem_zalloc(umm, DTX_SCM_BLOB_SIZE);
+	if (dtx_is_null(dsb_off)) {
+		D_ERROR("No space to store committed DTX %d "DF_DTI"\n",
+			count, DP_DTI(&dtis[cur]));
+		return -DER_NOSPACE;
+	}
+
+	dsb = umem_off2ptr(umm, dsb_off);
+	dsb->dsb_magic = DTX_CMT_BLOB_MAGIC;
+	dsb->dsb_cap = (DTX_SCM_BLOB_SIZE - sizeof(struct vos_dtx_scm_blob)) /
+		       sizeof(struct vos_dtx_cmt_ent_df);
+	dsb->dsb_prev = umem_ptr2off(umm, dsb_prev);
+
+	/* Not allow to commit too many DTX together. */
+	D_ASSERTF(count < dsb->dsb_cap, "Too many DTX: %d/%d\n",
+		  count, dsb->dsb_cap);
+
+	if (count > 1) {
+		D_ALLOC(dce_df, sizeof(*dce_df) * count);
+		if (dce_df == NULL) {
+			umem_free(umm, dsb_off);
+			return -DER_NOMEM;
+		}
+	} else {
+		dce_df = &dsb->dsb_commmitted_data[0];
+	}
+
+	if (dsb_prev == NULL) {
+		D_ASSERT(dtx_is_null(cont_df->cd_dtx_committed_head));
+		D_ASSERT(dtx_is_null(cont_df->cd_dtx_committed_tail));
+
+		/* cd_dtx_committed_tail is next to cd_dtx_committed_head */
+		umem_tx_add_ptr(umm, &cont_df->cd_dtx_committed_head,
+				sizeof(cont_df->cd_dtx_committed_head) +
+				sizeof(cont_df->cd_dtx_committed_tail));
+		cont_df->cd_dtx_committed_head = dsb_off;
+	} else {
+		umem_tx_add_ptr(umm, &dsb_prev->dsb_next,
+				sizeof(dsb_prev->dsb_next));
+		dsb_prev->dsb_next = dsb_off;
+
+		umem_tx_add_ptr(umm, &cont_df->cd_dtx_committed_tail,
+				sizeof(cont_df->cd_dtx_committed_tail));
+	}
+
+	cont_df->cd_dtx_committed_tail = dsb_off;
+
+	for (i = 0, j = 0; i < count; i++, cur++) {
+		struct vos_dtx_cmt_ent	*dce = NULL;
+
+		rc = vos_dtx_commit_one(cont, &dtis[cur], epoch, &dce);
+		if (rc1 == 0)
+			rc1 = rc;
+
+		if (dce != NULL) {
+			memcpy(&dce_df[j], &dce->dce_base, sizeof(dce_df[j]));
+			j++;
+		}
+	}
+
+	if (dce_df != &dsb->dsb_commmitted_data[0]) {
+		if (j > 0)
+			memcpy(&dsb->dsb_commmitted_data[0], dce_df,
+			       sizeof(*dce_df) * j);
+		D_FREE(dce_df);
+	}
+
+	dsb->dsb_count = j;
+
+	return rc != 0 ? rc : rc1;
 }
 
 int
@@ -1503,7 +2098,7 @@ vos_dtx_commit(daos_handle_t coh, struct dtx_id *dtis, int count)
 	/* Commit multiple DTXs via single PMDK transaction. */
 	rc = vos_tx_begin(vos_cont2umm(cont));
 	if (rc == 0) {
-		vos_dtx_commit_internal(cont, dtis, count);
+		rc = vos_dtx_commit_internal(cont, dtis, count, 0);
 		rc = vos_tx_end(vos_cont2umm(cont), rc);
 	}
 
@@ -1512,7 +2107,7 @@ vos_dtx_commit(daos_handle_t coh, struct dtx_id *dtis, int count)
 
 int
 vos_dtx_abort(daos_handle_t coh, daos_epoch_t epoch, struct dtx_id *dtis,
-	      int count, bool force)
+	      int count)
 {
 	struct vos_container	*cont;
 	int			 rc;
@@ -1523,84 +2118,97 @@ vos_dtx_abort(daos_handle_t coh, daos_epoch_t epoch, struct dtx_id *dtis,
 
 	/* Abort multiple DTXs via single PMDK transaction. */
 	rc = vos_tx_begin(vos_cont2umm(cont));
-	if (rc != 0)
-		return rc;
+	if (rc == 0) {
+		for (i = 0; i < count; i++)
+			vos_dtx_abort_one(cont, epoch, &dtis[i]);
 
-	for (i = 0; rc == 0 && i < count; i++)
-		rc = vos_dtx_abort_one(cont, epoch, &dtis[i], force);
+		rc = vos_tx_end(vos_cont2umm(cont), 0);
+	}
 
-	return vos_tx_end(vos_cont2umm(cont), rc);
+	return rc;
 }
 
 int
-vos_dtx_aggregate(daos_handle_t coh, uint64_t max, uint64_t age)
+vos_dtx_aggregate(daos_handle_t coh)
 {
 	struct vos_container		*cont;
+	struct vos_cont_df		*cont_df;
 	struct umem_instance		*umm;
-	struct vos_dtx_table_df		*tab;
-	umem_off_t			 dtx_umoff;
-	uint64_t			 count;
-	int				 rc = 0;
+	struct vos_dtx_scm_blob		*dsb;
+	struct vos_dtx_scm_blob		*tmp;
+	umem_off_t			 dsb_off;
+	int				 rc;
+	int				 i;
 
 	cont = vos_hdl2cont(coh);
 	D_ASSERT(cont != NULL);
 
-	umm = &cont->vc_pool->vp_umm;
-	tab = &cont->vc_cont_df->cd_dtx_table_df;
+	umm = vos_cont2umm(cont);
+	cont_df = cont->vc_cont_df;
 
-	rc = vos_tx_begin(vos_cont2umm(cont));
+	dsb_off = cont_df->cd_dtx_committed_head;
+	dsb = umem_off2ptr(umm, dsb_off);
+	if (dsb == NULL || dsb->dsb_count == 0)
+		return 0;
+
+	rc = vos_tx_begin(umm);
 	if (rc != 0)
 		return rc;
 
-	umem_tx_add_ptr(umm, tab, sizeof(*tab));
-	for (count = 0, dtx_umoff = tab->tt_entry_head;
-	     count < max && !dtx_is_null(dtx_umoff); count++) {
-		struct vos_dtx_entry_df	*dtx;
-		d_iov_t		 kiov;
-		umem_off_t		 umoff;
+	for (i = 0; i < dsb->dsb_count &&
+	     !d_list_empty(&cont->vc_dtx_committed_list); i++) {
+		struct vos_dtx_cmt_ent	*dce;
+		d_iov_t			 kiov;
 
-		dtx = umem_off2ptr(umm, dtx_umoff);
-		if (dtx_hlc_age2sec(dtx->te_time) < age)
-			break;
-
-		d_iov_set(&kiov, &dtx->te_xid, sizeof(dtx->te_xid));
-		rc = dbtree_delete(cont->vc_dtx_committed_hdl, BTR_PROBE_EQ,
-				   &kiov, &umoff);
-		D_ASSERT(rc == 0);
-
-		tab->tt_count--;
-		dtx_umoff = dtx->te_next;
-		umem_tx_add_ptr(umm, dtx, sizeof(*dtx));
-		vos_dtx_unlink_entry(umm, tab, dtx);
-		dtx_rec_release(umm, umoff, false, true, true);
+		dce = d_list_entry(cont->vc_dtx_committed_list.next,
+				   struct vos_dtx_cmt_ent, dce_committed_link);
+		d_iov_set(&kiov, &DCE_XID(dce), sizeof(DCE_XID(dce)));
+		dbtree_delete(cont->vc_dtx_committed_hdl, BTR_PROBE_EQ,
+			      &kiov, NULL);
 	}
 
-	/* This function needs to handle failures.  tx_add_ptr can fail as
-	 * can dbtree_delete
-	 */
-	vos_tx_end(vos_cont2umm(cont), 0);
-	return count < max ? 1 : 0;
+	tmp = umem_off2ptr(umm, dsb->dsb_next);
+	if (tmp == NULL) {
+		/* The last blob for committed DTX blob. */
+		D_ASSERT(cont_df->cd_dtx_committed_tail ==
+			 cont_df->cd_dtx_committed_head);
+
+		umem_tx_add_ptr(umm, &cont_df->cd_dtx_committed_tail,
+				sizeof(cont_df->cd_dtx_committed_tail));
+		cont_df->cd_dtx_committed_tail = UMOFF_NULL;
+	} else {
+		umem_tx_add_ptr(umm, &tmp->dsb_prev, sizeof(tmp->dsb_prev));
+		tmp->dsb_prev = UMOFF_NULL;
+	}
+
+	umem_tx_add_ptr(umm, &cont_df->cd_dtx_committed_head,
+			sizeof(cont_df->cd_dtx_committed_head));
+	cont_df->cd_dtx_committed_head = dsb->dsb_next;
+
+	umem_free(umm, dsb_off);
+
+	return vos_tx_end(umm, 0);
 }
 
 void
 vos_dtx_stat(daos_handle_t coh, struct dtx_stat *stat)
 {
-	struct vos_container		*cont;
+	struct vos_container	*cont;
 
 	cont = vos_hdl2cont(coh);
 	D_ASSERT(cont != NULL);
 
 	stat->dtx_committable_count = cont->vc_dtx_committable_count;
 	stat->dtx_oldest_committable_time = vos_dtx_cos_oldest(cont);
-	stat->dtx_committed_count = cont->vc_cont_df->cd_dtx_table_df.tt_count;
-	if (!dtx_is_null(cont->vc_cont_df->cd_dtx_table_df.tt_entry_head)) {
-		struct vos_dtx_entry_df	*dtx;
-
-		dtx = umem_off2ptr(&cont->vc_pool->vp_umm,
-			cont->vc_cont_df->cd_dtx_table_df.tt_entry_head);
-		stat->dtx_oldest_committed_time = dtx->te_time;
-	} else {
+	stat->dtx_committed_count = cont->vc_dtx_committed_count;
+	if (d_list_empty(&cont->vc_dtx_committed_list)) {
 		stat->dtx_oldest_committed_time = 0;
+	} else {
+		struct vos_dtx_cmt_ent	*dce;
+
+		dce = d_list_entry(cont->vc_dtx_committed_list.next,
+				   struct vos_dtx_cmt_ent, dce_committed_link);
+		stat->dtx_oldest_committed_time = DCE_EPOCH(dce);
 	}
 }
 
@@ -1623,13 +2231,14 @@ vos_dtx_mark_sync(daos_handle_t coh, daos_unit_oid_t oid, daos_epoch_t epoch)
 	}
 
 	if (obj->obj_df != NULL && obj->obj_df->vo_sync < epoch) {
-		rc = vos_tx_begin(vos_cont2umm(cont));
+		struct umem_instance	*umm = vos_cont2umm(cont);
+
+		rc = vos_tx_begin(umm);
 		if (rc == 0) {
-			umem_tx_add_ptr(&cont->vc_pool->vp_umm,
-					&obj->obj_df->vo_sync,
+			umem_tx_add_ptr(umm, &obj->obj_df->vo_sync,
 					sizeof(obj->obj_df->vo_sync));
 			obj->obj_df->vo_sync = epoch;
-			rc = vos_tx_end(vos_cont2umm(cont), rc);
+			rc = vos_tx_end(umm, 0);
 		}
 
 		if (rc == 0) {
@@ -1645,4 +2254,276 @@ vos_dtx_mark_sync(daos_handle_t coh, daos_unit_oid_t oid, daos_epoch_t epoch)
 
 	vos_obj_release(occ, obj);
 	return rc;
+}
+
+/*
+ * \return	+2 if current DTX blob is batched cleanup.
+ *		+1 if current DTX entry has ever been committed.
+ *		Zero if the DTX entry is not committed.
+ *		Negative value if error.
+ */
+static int
+dtx_act_handle_batched_cleanup(struct vos_container *cont,
+			       struct dtx_batched_cleanup_blob *bcb,
+			       struct vos_dtx_act_ent_df *dae_df,
+			       umem_off_t *next_dsb)
+{
+	struct umem_instance		*umm;
+	struct vos_dtx_scm_blob		*dsb;
+	struct vos_dtx_record_df	*rec_df;
+	int				 rc;
+
+	if (daos_is_zero_dti(&dae_df->dae_xid) ||
+	    dae_df->dae_flags & DTX_EF_INVALID)
+		return 1;
+
+	if (dae_df->dae_rec_cnt == 0)
+		return 0;
+
+	umm = vos_cont2umm(cont);
+	rec_df = &dae_df->dae_rec_inline[0];
+	switch (rec_df->dr_type) {
+	case DTX_RT_OBJ: {
+		struct vos_obj_df	*obj;
+
+		obj = umem_off2ptr(umm, rec_df->dr_record);
+		if (!dtx_is_null(obj->vo_dtx))
+			return 0;
+		break;
+	}
+	case DTX_RT_ILOG:
+		/* XXX: For pure ilog touched DTX case, we do NOT handle it
+		 *	via batched cleanup.
+		 */
+		return 0;
+	case DTX_RT_SVT: {
+		struct vos_irec_df	*svt;
+
+		svt = umem_off2ptr(umm, rec_df->dr_record);
+		if (!dtx_is_null(svt->ir_dtx))
+			return 0;
+		break;
+	}
+	case DTX_RT_EVT: {
+		struct evt_desc		*evt;
+
+		evt = umem_off2ptr(umm, rec_df->dr_record);
+		if (!dtx_is_null(evt->dc_dtx))
+			return 0;
+		break;
+	}
+	default:
+		D_ERROR(DF_UOID" invalid DTX record type %d for DTX "DF_DTI"\n",
+			DP_UOID(dae_df->dae_oid), rec_df->dr_type,
+			DP_DTI(&dae_df->dae_xid));
+		return -DER_IO;
+	}
+
+	rc = vos_tx_begin(umm);
+	if (rc != 0)
+		return rc;
+
+	if (!dtx_is_null(dae_df->dae_rec_off))
+		umem_free(umm, dae_df->dae_rec_off);
+
+	bcb->bcb_dae_count--;
+	dsb = umem_off2ptr(umm, bcb->bcb_dsb_off);
+	if (bcb->bcb_dae_count > 0 || dsb->dsb_index < dsb->dsb_cap) {
+		umem_tx_add_ptr(umm, &dae_df->dae_flags,
+				sizeof(dae_df->dae_flags));
+		dae_df->dae_flags = DTX_EF_INVALID;
+		umem_tx_add_ptr(umm, &dsb->dsb_count, sizeof(dsb->dsb_count));
+		dsb->dsb_count--;
+		rc = 1;
+	} else {
+		dtx_batched_cleanup(cont, bcb, next_dsb);
+		rc = 2;
+	}
+
+	return vos_tx_end(umm, 0);
+}
+
+int
+vos_dtx_act_reindex(struct vos_container *cont)
+{
+	struct umem_instance		*umm = vos_cont2umm(cont);
+	struct vos_cont_df		*cont_df = cont->vc_cont_df;
+	struct vos_dtx_scm_blob		*dsb;
+	umem_off_t			 dsb_off = cont_df->cd_dtx_active_head;
+	d_iov_t				 kiov;
+	d_iov_t				 riov;
+	int				 rc = 0;
+	int				 i;
+
+	while (1) {
+		struct dtx_batched_cleanup_blob	*bcb;
+
+next:
+		dsb = umem_off2ptr(umm, dsb_off);
+		if (dsb == NULL)
+			break;
+
+		D_ASSERT(dsb->dsb_magic == DTX_ACT_BLOB_MAGIC);
+
+		bcb = dtx_bcb_alloc(cont, dsb);
+		if (bcb == NULL)
+			D_GOTO(out, rc = -DER_NOMEM);
+
+		bcb->bcb_dae_count = dsb->dsb_count;
+		if (bcb->bcb_dae_count == 0) {
+			if (cont_df->cd_dtx_active_tail != dsb_off) {
+				D_ERROR("Invalid active DTX blob\n");
+				rc = -DER_IO;
+			}
+
+			D_GOTO(out, rc);
+		}
+
+		for (i = 0; i < dsb->dsb_index; i++) {
+			struct vos_dtx_act_ent_df	*dae_df;
+			struct vos_dtx_act_ent		*dae;
+			int				 count;
+
+			dae_df = &dsb->dsb_active_data[i];
+			rc = dtx_act_handle_batched_cleanup(cont, bcb, dae_df,
+							    &dsb_off);
+			if (rc > 1)
+				goto next;
+
+			if (rc == 1)
+				continue;
+
+			if (rc < 0)
+				D_GOTO(out, rc);
+
+			D_ALLOC_PTR(dae);
+			if (dae == NULL)
+				D_GOTO(out, rc = -DER_NOMEM);
+
+			memcpy(&dae->dae_base, dae_df, sizeof(dae->dae_base));
+			dae->dae_df_off = umem_ptr2off(umm, dae_df);
+			dae->dae_dsb = dsb;
+			dae->dae_bcb = bcb;
+
+			if (DAE_REC_CNT(dae) <= DTX_INLINE_REC_CNT)
+				goto insert;
+
+			count = DAE_REC_CNT(dae) - DTX_INLINE_REC_CNT;
+			D_ALLOC(dae->dae_records,
+				sizeof(*dae->dae_records) * count);
+			if (dae->dae_records == NULL) {
+				D_FREE_PTR(dae);
+				D_GOTO(out, rc = -DER_NOMEM);
+			}
+
+			memcpy(dae->dae_records,
+			       umem_off2ptr(umm, dae_df->dae_rec_off),
+			       sizeof(*dae->dae_records) * count);
+			dae->dae_rec_cap = count;
+
+insert:
+			d_iov_set(&kiov, &DAE_XID(dae), sizeof(DAE_XID(dae)));
+			d_iov_set(&riov, dae, sizeof(*dae));
+			rc = dbtree_upsert(cont->vc_dtx_active_hdl,
+					   BTR_PROBE_EQ, DAOS_INTENT_UPDATE,
+					   &kiov, &riov);
+			if (rc != 0) {
+				D_FREE(dae->dae_records);
+				D_FREE_PTR(dae);
+				goto out;
+			}
+		}
+
+		dsb_off = dsb->dsb_next;
+	}
+
+out:
+	return rc > 0 ? 0 : rc;
+}
+
+int
+vos_dtx_cmt_reindex(daos_handle_t coh, void *hint)
+{
+	struct umem_instance		*umm;
+	struct vos_container		*cont;
+	struct vos_cont_df		*cont_df;
+	struct vos_dtx_cmt_ent		*dce;
+	struct vos_dtx_scm_blob		*dsb;
+	umem_off_t			*dsb_off = hint;
+	d_iov_t				 kiov;
+	d_iov_t				 riov;
+	int				 rc = 0;
+	int				 i;
+
+	cont = vos_hdl2cont(coh);
+	D_ASSERT(cont != NULL);
+
+	umm = vos_cont2umm(cont);
+	cont_df = cont->vc_cont_df;
+
+	if (dtx_is_null(*dsb_off))
+		dsb = umem_off2ptr(umm, cont_df->cd_dtx_committed_head);
+	else
+		dsb = umem_off2ptr(umm, *dsb_off);
+
+	if (dsb == NULL)
+		D_GOTO(out, rc = 1);
+
+	D_ASSERT(dsb->dsb_magic == DTX_CMT_BLOB_MAGIC);
+
+	cont->vc_reindex_cmt_dtx = 1;
+
+	for (i = 0; i < dsb->dsb_count; i++) {
+		if (dsb->dsb_commmitted_data[i].dce_epoch == 0)
+			continue;
+
+		D_ALLOC_PTR(dce);
+		if (dce == NULL)
+			D_GOTO(out, rc = -DER_NOMEM);
+
+		D_INIT_LIST_HEAD(&dce->dce_bcb_link);
+		memcpy(&dce->dce_base, &dsb->dsb_commmitted_data[i],
+		       sizeof(dce->dce_base));
+		dce->dce_reindex = 1;
+
+		d_iov_set(&kiov, &DCE_XID(dce), sizeof(DCE_XID(dce)));
+		d_iov_set(&riov, dce, sizeof(*dce));
+		rc = dbtree_upsert(cont->vc_dtx_committed_hdl, BTR_PROBE_EQ,
+				   DAOS_INTENT_UPDATE, &kiov, &riov);
+		if (rc != 0)
+			goto out;
+
+		/* The committed DTX entry is already in the index.
+		 * Related re-index logic can stop.
+		 */
+		if (dce->dce_exist)
+			D_GOTO(out, rc = 1);
+	}
+
+	if (dsb->dsb_count < dsb->dsb_cap || dtx_is_null(dsb->dsb_next))
+		D_GOTO(out, rc = 1);
+
+	*dsb_off = dsb->dsb_next;
+
+out:
+	if (rc > 0) {
+		d_list_splice_init(&cont->vc_dtx_committed_tmp_list,
+				   &cont->vc_dtx_committed_list);
+		cont->vc_dtx_committed_count +=
+				cont->vc_dtx_committed_tmp_count;
+		cont->vc_dtx_committed_tmp_count = 0;
+		cont->vc_reindex_cmt_dtx = 0;
+	}
+
+	return rc;
+}
+
+void
+vos_dtx_handle_cleanup(struct dtx_handle *dth)
+{
+	struct dtx_share	*dts;
+
+	while ((dts = d_list_pop_entry(&dth->dth_shares, struct dtx_share,
+				       dts_link)) != NULL)
+		D_FREE_PTR(dts);
 }

--- a/src/vos/vos_dtx_iter.c
+++ b/src/vos/vos_dtx_iter.c
@@ -120,10 +120,33 @@ static int
 dtx_iter_next(struct vos_iterator *iter)
 {
 	struct vos_dtx_iter	*oiter = iter2oiter(iter);
+	struct vos_dtx_act_ent	*dae;
+	d_iov_t			 rec_iov;
+	int			 rc = 0;
 
 	D_ASSERT(iter->it_type == VOS_ITER_DTX);
 
-	return dbtree_iter_next(oiter->oit_hdl);
+	while (1) {
+		rc = dbtree_iter_next(oiter->oit_hdl);
+		if (rc != 0)
+			break;
+
+		d_iov_set(&rec_iov, NULL, 0);
+		rc = dbtree_iter_fetch(oiter->oit_hdl, NULL, &rec_iov, NULL);
+		if (rc != 0)
+			break;
+
+		D_ASSERT(rec_iov.iov_len == sizeof(struct vos_dtx_act_ent));
+		dae = (struct vos_dtx_act_ent *)rec_iov.iov_buf;
+
+		/* Only need to return the DTX that was handled before the
+		 * latest DTX resync.
+		 */
+		if (DAE_SRV_GEN(dae) < oiter->oit_cont->vc_dtx_resync_gen)
+			break;
+	}
+
+	return rc;
 }
 
 static int
@@ -131,8 +154,8 @@ dtx_iter_fetch(struct vos_iterator *iter, vos_iter_entry_t *it_entry,
 	       daos_anchor_t *anchor)
 {
 	struct vos_dtx_iter	*oiter = iter2oiter(iter);
-	struct vos_dtx_entry_df	*dtx;
-	d_iov_t		 rec_iov;
+	struct vos_dtx_act_ent	*dae;
+	d_iov_t			 rec_iov;
 	int			 rc;
 
 	D_ASSERT(iter->it_type == VOS_ITER_DTX);
@@ -144,18 +167,17 @@ dtx_iter_fetch(struct vos_iterator *iter, vos_iter_entry_t *it_entry,
 		return rc;
 	}
 
-	D_ASSERT(rec_iov.iov_len == sizeof(struct vos_dtx_entry_df));
-	dtx = (struct vos_dtx_entry_df *)rec_iov.iov_buf;
+	D_ASSERT(rec_iov.iov_len == sizeof(struct vos_dtx_act_ent));
+	dae = (struct vos_dtx_act_ent *)rec_iov.iov_buf;
 
-	it_entry->ie_epoch = dtx->te_epoch;
-	it_entry->ie_xid = dtx->te_xid;
-	it_entry->ie_oid = dtx->te_oid;
-	it_entry->ie_dtx_time = dtx->te_time;
-	it_entry->ie_dtx_intent = dtx->te_intent;
-	it_entry->ie_dtx_hash = dtx->te_dkey_hash;
+	it_entry->ie_xid = DAE_XID(dae);
+	it_entry->ie_oid = DAE_OID(dae);
+	it_entry->ie_epoch = DAE_EPOCH(dae);
+	it_entry->ie_dtx_intent = DAE_INTENT(dae);
+	it_entry->ie_dtx_hash = DAE_DKEY_HASH(dae);
 
 	D_DEBUG(DB_TRACE, "DTX iterator fetch the one "DF_DTI"\n",
-		DP_DTI(&dtx->te_xid));
+		DP_DTI(&DAE_XID(dae)));
 
 	return 0;
 }

--- a/src/vos/vos_gc.c
+++ b/src/vos/vos_gc.c
@@ -226,6 +226,16 @@ gc_drain_cont(struct vos_gc *gc, struct vos_pool *pool,
 	return gc_drain_btr(gc, pool, &cont->cd_obj_root, credits, empty);
 }
 
+static int
+gc_free_cont(struct vos_gc *gc, struct vos_pool *pool, struct vos_gc_item *item)
+{
+	vos_dtx_table_destroy(&pool->vp_umm,
+			      umem_off2ptr(&pool->vp_umm, item->it_addr));
+	umem_free(&pool->vp_umm, item->it_addr);
+
+	return 0;
+}
+
 static struct vos_gc	gc_table[] = {
 	{
 		.gc_name		= "akey",
@@ -254,7 +264,7 @@ static struct vos_gc	gc_table[] = {
 		.gc_type		= GC_CONT,
 		.gc_drain_creds		= 1,
 		.gc_drain		= gc_drain_cont,
-		.gc_free		= NULL,
+		.gc_free		= gc_free_cont,
 	},
 	{
 		.gc_name		= "unknown",

--- a/src/vos/vos_io.c
+++ b/src/vos/vos_io.c
@@ -1457,7 +1457,7 @@ vos_update_end(daos_handle_t ioh, uint32_t pm_ver, daos_key_t *dkey, int err,
 	if (dth != NULL && dth->dth_dti_cos_count > 0 &&
 	    dth->dth_dti_cos_done == 0) {
 		vos_dtx_commit_internal(ioc->ic_obj->obj_cont, dth->dth_dti_cos,
-					dth->dth_dti_cos_count);
+					dth->dth_dti_cos_count, 0);
 		dth->dth_dti_cos_done = 1;
 	}
 

--- a/src/vos/vos_layout.h
+++ b/src/vos/vos_layout.h
@@ -51,8 +51,8 @@
  * Garbage collection bag
  */
 struct vos_cont_df;
-struct vos_dtx_table_df;
-struct vos_dtx_entry_df;
+struct vos_dtx_act_ent_df;
+struct vos_dtx_cmt_ent_df;
 struct vos_dtx_record_df;
 struct vos_obj_df;
 struct vos_krec_df;
@@ -75,8 +75,6 @@ POBJ_LAYOUT_BEGIN(vos_pool_layout);
 
 POBJ_LAYOUT_ROOT(vos_pool_layout, struct vos_pool_df);
 POBJ_LAYOUT_TOID(vos_pool_layout, struct vos_cont_df);
-POBJ_LAYOUT_TOID(vos_pool_layout, struct vos_dtx_table_df);
-POBJ_LAYOUT_TOID(vos_pool_layout, struct vos_dtx_entry_df);
 POBJ_LAYOUT_TOID(vos_pool_layout, struct vos_dtx_record_df);
 POBJ_LAYOUT_TOID(vos_pool_layout, struct vos_obj_df);
 POBJ_LAYOUT_TOID(vos_pool_layout, struct vos_krec_df);
@@ -199,20 +197,6 @@ enum vos_dtx_record_flags {
 	DTX_RF_EXCHANGE_TGT	= 2,
 };
 
-/**
- * The agent of the record being modified via the DTX.
- */
-struct vos_dtx_record_df {
-	/** The DTX record type, see enum vos_dtx_record_types. */
-	uint32_t			tr_type;
-	/** The DTX record flags, see enum vos_dtx_record_flags. */
-	uint32_t			tr_flags;
-	/** The record in the related tree in SCM. */
-	umem_off_t			tr_record;
-	/** The next vos_dtx_record_df for the same DTX. */
-	umem_off_t			tr_next;
-};
-
 enum vos_dtx_entry_flags {
 	/* The DTX contains exchange of some record(s). */
 	DTX_EF_EXCHANGE_PENDING		= (1 << 0),
@@ -220,54 +204,92 @@ enum vos_dtx_entry_flags {
 	DTX_EF_SHARES			= (1 << 1),
 	/* The DTX is the leader */
 	DTX_EF_LEADER			= (1 << 2),
+	/* The DTX entry is invalid. */
+	DTX_EF_INVALID			= (1 << 3),
 };
 
-/**
- * Persisted DTX entry, it is referenced by btr_record::rec_off
- * of btree VOS_BTR_DTX_TABLE.
- */
-struct vos_dtx_entry_df {
+/** The agent of the record being modified via the DTX in both SCM and DRAM. */
+struct vos_dtx_record_df {
+	/** The DTX record type, see enum vos_dtx_record_types. */
+	uint32_t			dr_type;
+	/** The DTX record flags, see enum vos_dtx_record_flags. */
+	uint32_t			dr_flags;
+	/** The modified record in the related tree in SCM. */
+	umem_off_t			dr_record;
+};
+
+#define DTX_INLINE_REC_CNT	4
+#define DTX_REC_CAP_DEFAULT	4
+
+
+/** Active DTX entry on-disk layout in both SCM and DRAM. */
+struct vos_dtx_act_ent_df {
 	/** The DTX identifier. */
-	struct dtx_id			te_xid;
+	struct dtx_id			dae_xid;
 	/** The identifier of the modified object (shard). */
-	daos_unit_oid_t			te_oid;
+	daos_unit_oid_t			dae_oid;
 	/** The hashed dkey if applicable. */
-	uint64_t			te_dkey_hash;
+	uint64_t			dae_dkey_hash;
 	/** The epoch# for the DTX. */
-	daos_epoch_t			te_epoch;
-	/** Pool map version. */
-	uint32_t			te_ver;
-	/** DTX status, see enum dtx_status. */
-	uint32_t			te_state;
-	/** DTX flags, see enum vos_dtx_entry_flags. */
-	uint32_t			te_flags;
+	daos_epoch_t			dae_epoch;
+	/** The server generation when handles the DTX. */
+	uint64_t			dae_srv_gen;
+	/** The active DTX entry on-disk layout generation. */
+	uint64_t			dae_layout_gen;
 	/** The intent of related modification. */
-	uint32_t			te_intent;
-	/** The timestamp when handles the transaction. */
-	uint64_t			te_time;
-	/** The list of vos_dtx_record_df in SCM. */
-	umem_off_t			te_records;
-	/** The next committed DTX in global list. */
-	umem_off_t			te_next;
-	/** The prev committed DTX in global list. */
-	umem_off_t			te_prev;
+	uint32_t			dae_intent;
+	/** The index in the current vos_dtx_scm_blob. */
+	uint32_t			dae_index;
+	/** The inlined dtx records. */
+	struct vos_dtx_record_df	dae_rec_inline[DTX_INLINE_REC_CNT];
+	/** DTX flags, see enum vos_dtx_entry_flags. */
+	uint32_t			dae_flags;
+	/** The DTX records count, including inline case. */
+	uint32_t			dae_rec_cnt;
+	/** The offset for the list of vos_dtx_record_df if out of inline. */
+	umem_off_t			dae_rec_off;
 };
 
-/**
- * DAOS two-phase commit transaction table.
- */
-struct vos_dtx_table_df {
-	/** The count of committed DTXs in the table. */
-	uint64_t			tt_count;
-	/** The list head of committed DTXs. */
-	umem_off_t			tt_entry_head;
-	/** The list tail of committed DTXs. */
-	umem_off_t			tt_entry_tail;
-	/** The root of the B+ tree for committed DTXs. */
-	struct btr_root			tt_committed_btr;
-	/** The root of the B+ tree for active (prepared) DTXs. */
-	struct btr_root			tt_active_btr;
+/* Assume dae_rec_cnt is next to dae_flags. */
+D_CASSERT(offsetof(struct vos_dtx_act_ent_df, dae_rec_cnt) ==
+	  offsetof(struct vos_dtx_act_ent_df, dae_flags) +
+	  sizeof(((struct vos_dtx_act_ent_df *)0)->dae_flags));
+
+/* Assume dae_rec_off is next to dae_rec_cnt. */
+D_CASSERT(offsetof(struct vos_dtx_act_ent_df, dae_rec_off) ==
+	  offsetof(struct vos_dtx_act_ent_df, dae_rec_cnt) +
+	  sizeof(((struct vos_dtx_act_ent_df *)0)->dae_rec_cnt));
+
+/** Committed DTX entry on-disk layout in both SCM and DRAM. */
+struct vos_dtx_cmt_ent_df {
+	struct dtx_id			dce_xid;
+	daos_epoch_t			dce_epoch;
 };
+
+struct vos_dtx_scm_blob {
+	/** Magic number, can be used to distinguish active or committed DTX. */
+	int					dsb_magic;
+	/** The total (filled + free) slots in the blob. */
+	int					dsb_cap;
+	/** Already filled slots count. */
+	int					dsb_count;
+	/** The next available slot for active DTX entry in the blob. */
+	int					dsb_index;
+	/** Prev dtx_scm_blob. */
+	umem_off_t				dsb_prev;
+	/** Next dtx_scm_blob. */
+	umem_off_t				dsb_next;
+	/** Append only DTX entries in the blob. */
+	union {
+		struct vos_dtx_act_ent_df	dsb_active_data[0];
+		struct vos_dtx_cmt_ent_df	dsb_commmitted_data[0];
+	};
+};
+
+/* Assume dsb_index is next to dsb_count. */
+D_CASSERT(offsetof(struct vos_dtx_scm_blob, dsb_index) ==
+	  offsetof(struct vos_dtx_scm_blob, dsb_count) +
+	  sizeof(((struct vos_dtx_scm_blob *)0)->dsb_count));
 
 enum vos_io_stream {
 	/**
@@ -284,14 +306,31 @@ enum vos_io_stream {
 struct vos_cont_df {
 	uuid_t				cd_id;
 	uint64_t			cd_nobjs;
+	uint64_t			cd_dtx_resync_gen;
 	daos_size_t			cd_used;
 	daos_epoch_t			cd_hae;
 	struct btr_root			cd_obj_root;
-	/** The DTXs table. */
-	struct vos_dtx_table_df		cd_dtx_table_df;
+	/** The active DTXs blob head. */
+	umem_off_t			cd_dtx_active_head;
+	/** The active DTXs blob tail. */
+	umem_off_t			cd_dtx_active_tail;
+	/** The committed DTXs blob head. */
+	umem_off_t			cd_dtx_committed_head;
+	/** The committed DTXs blob tail. */
+	umem_off_t			cd_dtx_committed_tail;
 	/** Allocation hints for block allocator. */
 	struct vea_hint_df		cd_hint_df[VOS_IOS_CNT];
 };
+
+/* Assume cd_dtx_active_tail is just after cd_dtx_active_head. */
+D_CASSERT(offsetof(struct vos_cont_df, cd_dtx_active_tail) ==
+	  offsetof(struct vos_cont_df, cd_dtx_active_head) +
+	  sizeof(((struct vos_cont_df *)0)->cd_dtx_active_head));
+
+/* Assume cd_dtx_committed_tail is just after cd_dtx_committed_head. */
+D_CASSERT(offsetof(struct vos_cont_df, cd_dtx_committed_tail) ==
+	  offsetof(struct vos_cont_df, cd_dtx_committed_head) +
+	  sizeof(((struct vos_cont_df *)0)->cd_dtx_committed_head));
 
 /** btree (d/a-key) record bit flags */
 enum vos_krec_bf {
@@ -320,12 +359,6 @@ struct vos_krec_df {
 	uint32_t			kr_size;
 	/** Incarnation log for key */
 	struct ilog_df			kr_ilog;
-	/** The DTX entry in SCM. */
-	umem_off_t			kr_dtx;
-	/** The count of uncommitted DTXs that share the key. */
-	uint32_t			kr_dtx_shares;
-	/** For 64-bits alignment. */
-	uint32_t			kr_padding;
 	union {
 		/** btree root under the key */
 		struct btr_root			kr_btr;
@@ -388,5 +421,13 @@ struct vos_obj_df {
 D_CASSERT(offsetof(struct vos_obj_df, vo_earliest) ==
 	  offsetof(struct vos_obj_df, vo_latest) +
 	  sizeof(((struct vos_obj_df *)0)->vo_latest));
+
+D_CASSERT(offsetof(struct vos_obj_df, vo_dtx_shares) ==
+	  offsetof(struct vos_obj_df, vo_dtx) +
+	  sizeof(((struct vos_obj_df *)0)->vo_dtx));
+
+#define VOS_OBJ_DTX_SIZE	sizeof(((struct vos_obj_df *)0)->vo_dtx)
+#define VOS_OBJ_SHARES_SIZE	sizeof(((struct vos_obj_df *)0)->vo_dtx_shares)
+#define VOS_OBJ_SIZE_PARTIAL	(VOS_OBJ_DTX_SIZE + VOS_OBJ_SHARES_SIZE)
 
 #endif

--- a/src/vos/vos_obj.c
+++ b/src/vos/vos_obj.c
@@ -176,7 +176,7 @@ vos_obj_punch(daos_handle_t coh, daos_unit_oid_t oid, daos_epoch_t epoch,
 	if (dth != NULL && dth->dth_dti_cos_count > 0 &&
 	    dth->dth_dti_cos_done == 0) {
 		vos_dtx_commit_internal(cont, dth->dth_dti_cos,
-					dth->dth_dti_cos_count);
+					dth->dth_dti_cos_count, 0);
 		dth->dth_dti_cos_done = 1;
 	}
 


### PR DESCRIPTION
Mainly include the following:

1. Store the indexed committed DTX table in DRAM rather than SCM.

   When a DTX is committed, it is added into the in-DRAM committed
   DTX table that is organized as a B+tree. If related DAOS server
   restarts because of some reason, for supporting DAOS server to
   rejoin system (if is not evicted), then we need to re-establish
   the indexed committed DTX table in DRAM. So we will store the
   committed DTX entries in SCM without index (only append) when
   they are committed.

   A dedicated ULT will scan the non-indexed committed DTX entries
   in SCM to re-generate the indexed committed DTX table in DRAM
   when open the container.

2. Similar optimization for active DTX table: the indexed active
   DTX table in DRAM, non-indexed one in SCM. Re-establish the
   indexed active DTX table when open the container.

3. Some DTX logic can be optimized if the DTX contains single
   participator (such as modifying single replicated object).
   For example: the DTX can be committed immediately after
   local modification done.

3.1. It is unnecessary to allocate related DTX records for the
     target (object/dkey/akey/SV/EV rec) to be modified.

3.2. It is unnecessary to insert the DTX entry into active DTX
     table, instead, it can be directly inserted into committed
     DTX table when commit.

3.3. Punch logic can be simplified as without DTX case.

3.4. CoS logic can be bypassed.

4. Increase the CPU yield frequency during DTX aggregation and
   batched commit to allow more normal IO schedule.

5. Use client-side HLC in the DTX ID as the modification epoch.

6. Replace HLC based race detection between DTX resync and normal
   modification handling logic with server-side generation.

7. Fine-grained contents for PMDK undo log to reduce the overhead
   caused by PMDK related logic.

8. Batched update the committed DTX table to reduce SCM write
   frequency for DTX batched commit.

9. Execute DTX RPC (commit/abort) on remote and local replicas in
   parallel to reduce DTX (commit/abort) related latency.

10. Make vos_dtx_record_df inline vos_dtx_act_ent_df to avoid
    additional DTX record allocation in SCM for most of cases
    if the modified targets count is less than the inline slots.

11. Introduce batched cleanup mechanism for DTX commit: when
    commit an DTX, we do NOT modify related active DTX entry
    in SCM, that will cause a lot of random SCM modifcation;
    instead, we keep related committed DTX entries info DRAM
    and postpone to modify the active DTX table until the DTX
    entries in one DTX entry blob all have been committed, then
    we directly release such DTX entry blob via single umem_free().

Fix some test cases issues.