### PR TITLE
DAOS-2447 obj: set iov_len for bulk fetch

### DIFF
--- a/src/bio/bio_buffer.c
+++ b/src/bio/bio_buffer.c
@@ -176,23 +176,18 @@ bio_iod_sgl(struct bio_desc *biod, unsigned int idx)
 struct bio_desc *
 bio_iod_alloc(struct bio_io_context *ctxt, unsigned int sgl_cnt, bool update)
 {
-	struct bio_desc *biod;
+	struct bio_desc	*biod;
+
 	D_ASSERT(ctxt != NULL && ctxt->bic_umem != NULL);
 	D_ASSERT(sgl_cnt != 0);
 
-	D_ALLOC_PTR(biod);
+	D_ALLOC(biod, offsetof(struct bio_desc, bd_sgls[sgl_cnt]));
 	if (biod == NULL)
 		return NULL;
 
 	biod->bd_ctxt = ctxt;
 	biod->bd_update = update;
 	biod->bd_sgl_cnt = sgl_cnt;
-
-	D_ALLOC_ARRAY(biod->bd_sgls, sgl_cnt);
-	if (biod->bd_sgls == NULL) {
-		D_FREE(biod);
-		return NULL;
-	}
 
 	biod->bd_dma_done = ABT_EVENTUAL_NULL;
 	return biod;
@@ -210,7 +205,6 @@ bio_iod_free(struct bio_desc *biod)
 
 	for (i = 0; i < biod->bd_sgl_cnt; i++)
 		bio_sgl_fini(&biod->bd_sgls[i]);
-	D_FREE(biod->bd_sgls);
 	D_FREE(biod);
 }
 

--- a/src/bio/bio_internal.h
+++ b/src/bio/bio_internal.h
@@ -172,9 +172,6 @@ struct bio_rsrvd_dma {
 /* I/O descriptor */
 struct bio_desc {
 	struct bio_io_context	*bd_ctxt;
-	/* SG lists involved in this io descriptor */
-	unsigned int		 bd_sgl_cnt;
-	struct bio_sglist	*bd_sgls;
 	/* DMA buffers reserved by this io descriptor */
 	struct bio_rsrvd_dma	 bd_rsrvd;
 	/* Report blob i/o completion */
@@ -187,6 +184,9 @@ struct bio_desc {
 				 bd_update:1,
 				 bd_dma_issued:1,
 				 bd_retry:1;
+	/* SG lists involved in this io descriptor */
+	unsigned int		 bd_sgl_cnt;
+	struct bio_sglist	 bd_sgls[0];
 };
 
 static inline struct spdk_thread *

--- a/src/object/cli_shard.c
+++ b/src/object/cli_shard.c
@@ -221,12 +221,12 @@ dc_rw_cb(tse_task_t *task, void *arg)
 		int		 i, j;
 
 		iods = orw->orw_iods.ca_arrays;
-		sizes = orwo->orw_sizes.ca_arrays;
+		sizes = orwo->orw_iod_sizes.ca_arrays;
 
-		if (orwo->orw_sizes.ca_count != orw->orw_nr) {
+		if (orwo->orw_iod_sizes.ca_count != orw->orw_nr) {
 			D_ERROR("out:%u != in:%u for "DF_UOID" with eph "
 				DF_U64".\n",
-				(unsigned)orwo->orw_sizes.ca_count,
+				(unsigned)orwo->orw_iod_sizes.ca_count,
 				orw->orw_nr, DP_UOID(orw->orw_oid),
 				orw->orw_epoch);
 			D_GOTO(out, rc = -DER_PROTO);
@@ -248,11 +248,13 @@ dc_rw_cb(tse_task_t *task, void *arg)
 			d_iov_t		*iov;
 			uint32_t	*nrs;
 			uint32_t	 nrs_count;
-			daos_size_t	 data_size;
+			daos_size_t	*replied_sizes;
+			daos_size_t	 data_size, size_in_iod;
 			daos_size_t	 buf_size;
 
 			nrs = orwo->orw_nrs.ca_arrays;
 			nrs_count = orwo->orw_nrs.ca_count;
+			replied_sizes = orwo->orw_data_sizes.ca_arrays;
 			if (nrs_count != orw->orw_nr) {
 				D_ERROR("Invalid nrs %u != %u\n", nrs_count,
 					orw->orw_nr);
@@ -270,12 +272,14 @@ dc_rw_cb(tse_task_t *task, void *arg)
 					sgls[i].sg_nr_out = 0;
 					continue;
 				}
-				data_size = daos_iods_len(&iods[i], 1);
-				if (data_size == -1) {
+				size_in_iod = daos_iods_len(&iods[i], 1);
+				if (size_in_iod == -1) {
 					/* only for echo mode */
 					sgls[i].sg_nr_out = sgls[i].sg_nr;
 					continue;
 				}
+				data_size = replied_sizes[i];
+				D_ASSERT(data_size <= size_in_iod);
 				buf_size = 0;
 				for (j = 0; j < sgls[i].sg_nr; j++) {
 					iov = &sgls[i].sg_iovs[j];

--- a/src/object/obj_rpc.h
+++ b/src/object/obj_rpc.h
@@ -147,7 +147,8 @@ enum obj_rpc_flags {
 	((uint32_t)		(orw_map_version)	CRT_VAR) \
 	((uint64_t)		(orw_dkey_conflict)	CRT_VAR) \
 	((struct dtx_id)	(orw_dti_conflict)	CRT_VAR) \
-	((daos_size_t)		(orw_sizes)		CRT_ARRAY) \
+	((daos_size_t)		(orw_iod_sizes)		CRT_ARRAY) \
+	((daos_size_t)		(orw_data_sizes)	CRT_ARRAY) \
 	((d_sg_list_t)		(orw_sgls)		CRT_ARRAY) \
 	((uint32_t)		(orw_nrs)		CRT_ARRAY) \
 	((daos_csum_buf_t)	(orw_csum)		CRT_ARRAY)

--- a/src/tests/suite/daos_obj.c
+++ b/src/tests/suite/daos_obj.c
@@ -1868,7 +1868,7 @@ basic_byte_array(void **state)
 	d_sg_list_t	 sgl;
 	d_iov_t	 sg_iov[2];
 	daos_iod_t	 iod;
-	daos_recx_t	 recx[4];
+	daos_recx_t	 recx[5];
 	char		 stack_buf_out[STACK_BUF_LEN];
 	char		 stack_buf[STACK_BUF_LEN];
 	char		 *bulk_buf = NULL;
@@ -1954,17 +1954,39 @@ next_step:
 	assert_int_equal(rc, 0);
 	assert_int_equal(sgl.sg_nr_out, 0);
 
-	print_message("reading data back ...\n");
+	print_message("reading all data back ...\n");
 	memset(buf_out, 0, buf_len);
 	sgl.sg_nr_out	= 0;
 	iod.iod_nr	= 3;
 	iod.iod_recxs	= recx;
+	iod.iod_size	= DAOS_REC_ANY;
 	rc = daos_obj_fetch(oh, DAOS_TX_NONE, &dkey, 1, &iod, &sgl, NULL, NULL);
 	assert_int_equal(rc, 0);
 	/** Verify data consistency */
-	print_message("validating data ... sg_nr_out %d.\n", sgl.sg_nr_out);
+	print_message("validating data ... sg_nr_out %d, iod_size %d.\n",
+		      sgl.sg_nr_out, (int)iod.iod_size);
 	assert_int_equal(sgl.sg_nr_out, 2);
 	assert_memory_equal(buf, buf_out, sizeof(buf));
+
+	print_message("short read should get iov_len with tail hole trimmed\n");
+	memset(buf_out, 0, buf_len);
+	tmp_len = buf_len / 3;
+	sgl.sg_nr_out	= 0;
+	sgl.sg_nr = 1;
+	d_iov_set(&sg_iov[0], buf_out, tmp_len + 99);
+	recx[4].rx_idx	= 0;
+	recx[4].rx_nr	= tmp_len + 44;
+	iod.iod_nr	= 1;
+	iod.iod_recxs	= &recx[4];
+	iod.iod_size	= DAOS_REC_ANY;
+	rc = daos_obj_fetch(oh, DAOS_TX_NONE, &dkey, 1, &iod, &sgl, NULL, NULL);
+	assert_int_equal(rc, 0);
+	/** Verify data consistency */
+	print_message("validating data ... sg_nr_out %d, iov_len %d.\n",
+		      sgl.sg_nr_out, (int)sgl.sg_iovs[0].iov_len);
+	assert_int_equal(sgl.sg_nr_out, 1);
+	assert_int_equal(sgl.sg_iovs[0].iov_len, tmp_len);
+	assert_memory_equal(buf, buf_out, tmp_len);
 
 	if (step++ == 1)
 		goto next_step;

--- a/src/vos/vos_io.c
+++ b/src/vos/vos_io.c
@@ -700,7 +700,7 @@ akey_fetch(struct vos_io_context *ioc, const daos_epoch_range_t *epr,
 		if (rsize == 0)
 			continue;
 
-		if (iod->iod_size == 0)
+		if (iod->iod_size == DAOS_REC_ANY)
 			iod->iod_size = rsize;
 
 		if (iod->iod_size != rsize) {


### PR DESCRIPTION
For obj fetch, will set sgl's iov_len. The tail holes' size will be reduced
from length.

Signed-off-by: Xuezhao Liu <xuezhao.liu@intel.com>