### PR TITLE
DAOS-3558 tests: Updating PYTHONPATH definition in launch.py

### DIFF
--- a/ftest.sh
+++ b/ftest.sh
@@ -305,13 +305,6 @@ if ${SETUP_ONLY:-false}; then
 fi
 
 # now run it!
-launch_py=\$(sed -ne '1s/^#!//'p launch.py)
-launch_py_vers=\$(\$launch_py -c 'import sys; \
-print(\"{}.{}\".format(sys.version_info[0], sys.version_info[1]))')
-
-export PYTHONPATH=./util:../../utils/py/:./util/apricot:\
-../../../install/lib/python\$launch_py_vers/site-packages
-
 if ! ./launch.py -c -a -r -i -s -ts ${TEST_NODES} ${TEST_TAG_ARR[*]}; then
     rc=\${PIPESTATUS[0]}
 else

--- a/src/tests/ftest/launch.py
+++ b/src/tests/ftest/launch.py
@@ -30,6 +30,7 @@ import os
 import re
 import socket
 import subprocess
+from sys import version_info
 import time
 import yaml
 
@@ -104,12 +105,13 @@ def set_test_environment():
     os.environ["CRT_ATTACH_INFO_PATH"] = os.path.join(base_dir, "tmp")
 
     # Python paths required for functional testing
+    python_version = "python{}{}".format(
+        version_info.major,
+        "" if version_info.major > 2 else ".{}".format(version_info.minor))
     required_python_paths = [
         os.path.abspath("util/apricot"),
         os.path.abspath("util"),
-        os.path.abspath("../../utils/py"),
-        os.path.join(base_dir, "lib", "python2.7", "site-packages"),
-        os.path.join(base_dir, "lib", "python3", "site-packages"),
+        os.path.join(base_dir, "lib", python_version, "site-packages"),
     ]
 
     # Check the PYTHONPATH env definition


### PR DESCRIPTION
Updating the PYTHONPATH definition used to run the functional tests to
make use of the name path to the pydaos.raw files.

Signed-off-by: Phillip Henderson <phillip.henderson@intel.com>