### PR TITLE
DAOS-2917 container: add container IV invalidate

### DIFF
--- a/src/container/rpc.h
+++ b/src/container/rpc.h
@@ -303,6 +303,7 @@ struct cont_tgt_close_rec {
 };
 
 #define DAOS_ISEQ_TGT_CLOSE	/* input fields */		 \
+	((uuid_t)		(tci_pool_uuid)		CRT_VAR) \
 	((struct cont_tgt_close_rec) (tci_recs)		CRT_ARRAY)
 
 #define DAOS_OSEQ_TGT_CLOSE	/* output fields */		 \

--- a/src/container/srv_container.c
+++ b/src/container/srv_container.c
@@ -786,6 +786,7 @@ cont_close_bcast(crt_context_t ctx, struct cont_svc *svc,
 	in = crt_req_get(rpc);
 	in->tci_recs.ca_arrays = recs;
 	in->tci_recs.ca_count = nrecs;
+	uuid_copy(in->tci_pool_uuid, svc->cs_pool_uuid);
 
 	rc = dss_rpc_send(rpc);
 	if (rc != 0)

--- a/src/container/srv_internal.h
+++ b/src/container/srv_internal.h
@@ -139,6 +139,9 @@ struct cont_iv_entry {
 };
 
 struct cont_iv_key {
+	/* SNAP/PROP_IV the key is the container uuid.
+	 * CAPA the key is the container hdl uuid.
+	 */
 	uuid_t		cont_uuid;
 	/* IV class id, to differentiate SNAP/CAPA/PROP IV */
 	uint32_t	class_id;
@@ -241,6 +244,7 @@ int ds_cont_iv_init(void);
 int ds_cont_iv_fini(void);
 int cont_iv_capability_update(void *ns, uuid_t cont_hdl_uuid, uuid_t cont_uuid,
 			      uint64_t capas);
+int cont_iv_capability_invalidate(void *ns, uuid_t cont_hdl_uuid);
 int cont_iv_prop_update(void *ns, uuid_t cont_hdl_uuid, uuid_t cont_uuid,
 			daos_prop_t *prop);
 

--- a/src/container/srv_target.c
+++ b/src/container/srv_target.c
@@ -283,7 +283,8 @@ cont_hdl_rec_free(struct d_hash_table *htable, d_list_t *rlink)
 			hdl->sch_cont->sc_uuid));
 		cont_child_put(tls->dt_cont_cache, hdl->sch_cont);
 	}
-	ds_pool_child_put(hdl->sch_pool);
+	if (hdl->sch_pool)
+		ds_pool_child_put(hdl->sch_pool);
 	D_FREE(hdl);
 }
 
@@ -668,7 +669,7 @@ ds_cont_child_lookup(uuid_t pool_uuid, uuid_t cont_uuid,
  * server container lookup and create. If the container is created,
  * it will return 1, otherwise return 0 or error code.
  **/
-int
+static int
 ds_cont_child_lookup_or_create(struct ds_cont_hdl *hdl, uuid_t cont_uuid)
 {
 	struct dsm_tls	*tls = dsm_tls_get();
@@ -791,9 +792,11 @@ ds_cont_local_open(uuid_t pool_uuid, uuid_t cont_hdl_uuid, uuid_t cont_uuid,
 	if (hdl == NULL)
 		D_GOTO(err, rc = -DER_NOMEM);
 
-	hdl->sch_pool = ds_pool_child_lookup(pool_uuid);
-	if (hdl->sch_pool == NULL)
-		D_GOTO(err_hdl, rc = -DER_NO_HDL);
+	if (pool_uuid != NULL) {
+		hdl->sch_pool = ds_pool_child_lookup(pool_uuid);
+		if (hdl->sch_pool == NULL)
+			D_GOTO(err_hdl, rc = -DER_NO_HDL);
+	}
 
 	if (cont_uuid != NULL) {
 		rc = ds_cont_child_lookup_or_create(hdl, cont_uuid);
@@ -973,8 +976,8 @@ ds_cont_tgt_open(uuid_t pool_uuid, uuid_t cont_hdl_uuid,
 	rc = ds_cont_lookup_create(cont_uuid, &cont_uuid, &cont);
 	if (rc)
 		D_GOTO(out, rc);
-
 	cont->sc_iv_ns = pool->sp_iv_ns;
+
 	ds_cont_tgt_snapshots_refresh(pool_uuid, cont_uuid);
 out:
 	if (pool)
@@ -1031,8 +1034,8 @@ cont_close_one_rec(struct cont_tgt_close_rec *rec)
 static int
 cont_close_one(void *vin)
 {
-	struct cont_tgt_close_in       *in = vin;
-	struct cont_tgt_close_rec      *recs = in->tci_recs.ca_arrays;
+	struct cont_tgt_close_in	*in = vin;
+	struct cont_tgt_close_rec	*recs = in->tci_recs.ca_arrays;
 	int				i;
 	int				rc = 0;
 
@@ -1053,6 +1056,8 @@ ds_cont_tgt_close_handler(crt_rpc_t *rpc)
 	struct cont_tgt_close_in       *in = crt_req_get(rpc);
 	struct cont_tgt_close_out      *out = crt_reply_get(rpc);
 	struct cont_tgt_close_rec      *recs = in->tci_recs.ca_arrays;
+	struct ds_pool			*pool;
+	int				i;
 	int				rc;
 
 	if (in->tci_recs.ca_count == 0)
@@ -1065,6 +1070,14 @@ ds_cont_tgt_close_handler(crt_rpc_t *rpc)
 		"recs[0].hce="DF_U64" nres="DF_U64"\n", DP_CONT(NULL, NULL),
 		rpc, DP_UUID(recs[0].tcr_hdl), recs[0].tcr_hce,
 		in->tci_recs.ca_count);
+
+	pool = ds_pool_lookup(in->tci_pool_uuid);
+	if (pool) {
+		for (i = 0; i < in->tci_recs.ca_count; i++)
+			cont_iv_capability_invalidate(pool->sp_iv_ns,
+						      recs[i].tcr_hdl);
+		ds_pool_put(pool);
+	}
 
 	rc = dss_thread_collective(cont_close_one, in, 0);
 	D_ASSERTF(rc == 0, "%d\n", rc);

--- a/src/include/daos_srv/container.h
+++ b/src/include/daos_srv/container.h
@@ -109,8 +109,6 @@ int
 ds_cont_local_close(uuid_t cont_hdl_uuid);
 
 int
-ds_cont_child_lookup_or_create(struct ds_cont_hdl *hdl, uuid_t cont_uuid);
-int
 ds_cont_child_lookup(uuid_t pool_uuid, uuid_t cont_uuid,
 		     struct ds_cont_child **ds_cont);
 

--- a/src/pool/srv_iv.c
+++ b/src/pool/srv_iv.c
@@ -218,7 +218,10 @@ pool_iv_ent_refresh(struct ds_iv_entry *entry, struct ds_iv_key *key,
 	struct ds_pool		*pool;
 	int			rc;
 
-	D_ASSERT(src_iv != NULL);
+	if (src == NULL) /* invalidate */
+		return 0;
+
+	src_iv = src->sg_iovs[0].iov_buf;
 	D_ASSERT(dst_iv != NULL);
 	rc = pool_iv_ent_copy(entry->iv_class->iv_class_id,
 			      &entry->iv_value, src);


### PR DESCRIPTION
Add container iv invalidate for container close,
so after container close, each xstream will not
be able to find the container handle(capability).

Fix container handle cleanup in I/O failure path.

Signed-off-by: Di Wang <di.wang@intel.com>