### PR TITLE
DAOS-3570 control: print rank number not pointer address

### DIFF
--- a/src/control/client/storage.go
+++ b/src/control/client/storage.go
@@ -158,7 +158,7 @@ func (c *connList) StoragePrepare(req *ctlpb.StoragePrepareReq) ResultMap {
 	return c.makeRequests(req, storagePrepareRequest)
 }
 
-// storageScan/etc/equest returns all discovered SCM and NVMe storage devices
+// storageScanRequest returns all discovered SCM and NVMe storage devices
 // discovered on a remote server by calling over gRPC channel.
 func storageScanRequest(mc Control, req interface{}, ch chan ClientResult) {
 	sRes := StorageResult{}

--- a/src/control/server/ioserver/rank.go
+++ b/src/control/server/ioserver/rank.go
@@ -46,6 +46,9 @@ func NewRankPtr(in uint32) *Rank {
 }
 
 func (r Rank) String() string {
+	if r == NilRank {
+		return "nil"
+	}
 	return strconv.FormatUint(uint64(r), 10)
 }
 

--- a/src/control/server/ioserver/rank.go
+++ b/src/control/server/ioserver/rank.go
@@ -45,11 +45,15 @@ func NewRankPtr(in uint32) *Rank {
 	return &r
 }
 
-func (r Rank) String() string {
-	if r == NilRank {
+func (r *Rank) String() string {
+	switch {
+	case r == nil:
 		return "nil"
+	case *r == NilRank:
+		return "NilRank"
+	default:
+		return strconv.FormatUint(uint64(*r), 10)
 	}
-	return strconv.FormatUint(uint64(r), 10)
 }
 
 func (r *Rank) UnmarshalYAML(unmarshal func(interface{}) error) error {

--- a/src/control/server/superblock.go
+++ b/src/control/server/superblock.go
@@ -153,7 +153,7 @@ func (srv *IOServerInstance) CreateSuperblock(msInfo *mgmtInfo) error {
 		}
 	}
 	srv.setSuperblock(superblock)
-	srv.log.Debugf("creating %s: (rank: %d, uuid: %s)",
+	srv.log.Debugf("creating %s: (rank: %s, uuid: %s)",
 		srv.superblockPath(), superblock.Rank, superblock.UUID)
 
 	return srv.WriteSuperblock()

--- a/src/control/server/superblock.go
+++ b/src/control/server/superblock.go
@@ -154,7 +154,7 @@ func (srv *IOServerInstance) CreateSuperblock(msInfo *mgmtInfo) error {
 	}
 	srv.setSuperblock(superblock)
 	srv.log.Debugf("creating %s: (rank: %d, uuid: %s)",
-		srv.superblockPath(), *superblock.Rank, superblock.UUID)
+		srv.superblockPath(), superblock.Rank, superblock.UUID)
 
 	return srv.WriteSuperblock()
 }

--- a/src/control/server/superblock.go
+++ b/src/control/server/superblock.go
@@ -154,7 +154,7 @@ func (srv *IOServerInstance) CreateSuperblock(msInfo *mgmtInfo) error {
 	}
 	srv.setSuperblock(superblock)
 	srv.log.Debugf("creating %s: (rank: %d, uuid: %s)",
-		srv.superblockPath(), superblock.Rank, superblock.UUID)
+		srv.superblockPath(), *superblock.Rank, superblock.UUID)
 
 	return srv.WriteSuperblock()
 }


### PR DESCRIPTION
Rank was being printed as a pointer address, add Stringer interface for
Rank pointer type receiver to differentiate between nil pointer and
special NilRank value.

Signed-off-by: Tom Nabarro <tom.nabarro@intel.com>