### PR TITLE
DASS-3578 control: spdk setup attempts chown on bad paths

### DIFF
--- a/src/control/server/init/setup_spdk.sh
+++ b/src/control/server/init/setup_spdk.sh
@@ -23,8 +23,8 @@ else
 		'/sys/class/uio/uio*/device/config'	\
 		'/sys/class/uio/uio*/device/resource*'; do
 
-		if list=$(ls $glob); then
-			echo "RUN: ls $glob | xargs -r chown -R $_TARGET_USER"
+		if list=$(ls -d $glob); then
+			echo "RUN: ls -d $glob | xargs -r chown -R $_TARGET_USER"
 			echo "$list" | xargs -r chown -R "$_TARGET_USER"
 		fi
 	done


### PR DESCRIPTION
When evaluating globs list full paths so subsequent operations will
succeed on valid paths.

Signed-off-by: Tom Nabarro <tom.nabarro@intel.com>