### PR TITLE
DAOS-3579 bio: Fini health monitoring properly

### DIFF
--- a/src/bio/bio_monitor.c
+++ b/src/bio/bio_monitor.c
@@ -389,16 +389,33 @@ bio_xs_io_stat(struct bio_xs_context *ctxt, uint64_t now)
 void
 bio_fini_health_monitoring(struct bio_blobstore *bb)
 {
+	struct bio_dev_health	*bdh = &bb->bb_dev_health;
+
 	/* Free NVMe admin passthru DMA buffers */
-	spdk_dma_free(bb->bb_dev_health.bdh_health_buf);
-	spdk_dma_free(bb->bb_dev_health.bdh_ctrlr_buf);
-	spdk_dma_free(bb->bb_dev_health.bdh_error_buf);
+	if (bdh->bdh_health_buf) {
+		spdk_dma_free(bdh->bdh_health_buf);
+		bdh->bdh_health_buf = NULL;
+	}
+	if (bdh->bdh_ctrlr_buf) {
+		spdk_dma_free(bdh->bdh_ctrlr_buf);
+		bdh->bdh_ctrlr_buf = NULL;
+	}
+	if (bdh->bdh_error_buf) {
+		spdk_dma_free(bdh->bdh_error_buf);
+		bdh->bdh_error_buf = NULL;
+	}
 
 	/* Release I/O channel reference */
-	spdk_put_io_channel(bb->bb_dev_health.bdh_io_channel);
+	if (bdh->bdh_io_channel) {
+		spdk_put_io_channel(bdh->bdh_io_channel);
+		bdh->bdh_io_channel = NULL;
+	}
 
 	/* Close device health monitoring descriptor */
-	spdk_bdev_close(bb->bb_dev_health.bdh_desc);
+	if (bdh->bdh_desc) {
+		spdk_bdev_close(bdh->bdh_desc);
+		bdh->bdh_desc = NULL;
+	}
 }
 
 /*

--- a/src/bio/bio_xstream.c
+++ b/src/bio/bio_xstream.c
@@ -264,6 +264,12 @@ stop_poller(struct spdk_poller *poller, void *ctxt)
 	D_FREE(nvme_poller);
 }
 
+static inline bool
+is_bbs_owner(struct bio_xs_context *ctxt, struct bio_blobstore *bbs)
+{
+	return bbs->bb_owner_xs == ctxt;
+}
+
 /*
  * Execute the messages on msg ring, call all registered pollers.
  *
@@ -308,10 +314,9 @@ bio_nvme_poll(struct bio_xs_context *ctxt)
 	 * Query and print the SPDK device health stats for only the device
 	 * owner xstream.
 	 */
-	if (ctxt->bxc_blobstore != NULL) {
-		if (ctxt->bxc_blobstore->bb_owner_xs == ctxt)
-			bio_bs_monitor(ctxt, now);
-	}
+	if (ctxt->bxc_blobstore != NULL &&
+	    is_bbs_owner(ctxt, ctxt->bxc_blobstore))
+		bio_bs_monitor(ctxt, now);
 
 	return count;
 }
@@ -557,9 +562,6 @@ free_bio_blobstore(struct bio_blobstore *bb)
 	ABT_mutex_free(&bb->bb_mutex);
 	D_FREE(bb->bb_xs_ctxts);
 
-	/* Free all device health monitoring info as well */
-	bio_fini_health_monitoring(bb);
-
 	D_FREE(bb);
 }
 
@@ -578,7 +580,7 @@ put_bio_blobstore(struct bio_blobstore *bb, struct bio_xs_context *ctxt)
 
 	ABT_mutex_lock(bb->bb_mutex);
 	/* Unload the blobstore in the same xstream where it was loaded. */
-	if (bb->bb_owner_xs == ctxt && bb->bb_bs != NULL) {
+	if (is_bbs_owner(ctxt, bb) && bb->bb_bs != NULL) {
 		bs = bb->bb_bs;
 		bb->bb_bs = NULL;
 	}
@@ -804,12 +806,27 @@ init_blobstore_ctxt(struct bio_xs_context *ctxt, int tgt_id)
 		return daos_errno2der(-rc);
 	}
 
+	/*
+	 * If no bbs (BIO blobstore) is attached to the device, attach one and
+	 * set current xstream as bbs owner.
+	 */
 	if (d_bdev->bb_blobstore == NULL) {
 		d_bdev->bb_blobstore = alloc_bio_blobstore(ctxt);
 		if (d_bdev->bb_blobstore == NULL)
 			return -DER_NOMEM;
+	}
 
-		rc = bio_init_health_monitoring(d_bdev->bb_blobstore,
+	/* Hold bbs refcount for current xstream */
+	ctxt->bxc_blobstore = get_bio_blobstore(d_bdev->bb_blobstore, ctxt);
+	if (ctxt->bxc_blobstore == NULL)
+		return -DER_NOMEM;
+
+	/*
+	 * bbs owner xstream is responsible to initialize monitoring context
+	 * and open SPDK blobstore.
+	 */
+	if (is_bbs_owner(ctxt, ctxt->bxc_blobstore)) {
+		rc = bio_init_health_monitoring(ctxt->bxc_blobstore,
 						d_bdev->bb_bdev);
 		if (rc != 0) {
 			D_ERROR("BIO health monitoring not allocated\n");
@@ -822,16 +839,14 @@ init_blobstore_ctxt(struct bio_xs_context *ctxt, int tgt_id)
 		if (bs == NULL)
 			return -DER_INVAL;
 
-		d_bdev->bb_blobstore->bb_bs = bs;
+		ctxt->bxc_blobstore->bb_bs = bs;
 
 		D_DEBUG(DB_MGMT, "Loaded bs, tgt_id:%d, xs:%p dev:%s\n",
 			tgt_id, ctxt, spdk_bdev_get_name(d_bdev->bb_bdev));
+
 	}
 
-	ctxt->bxc_blobstore = get_bio_blobstore(d_bdev->bb_blobstore, ctxt);
-	if (ctxt->bxc_blobstore == NULL)
-		return -DER_NOMEM;
-
+	/* Open IO channel for current xstream */
 	bs = ctxt->bxc_blobstore->bb_bs;
 	D_ASSERT(bs != NULL);
 	ctxt->bxc_io_channel = spdk_bs_alloc_io_channel(bs);
@@ -864,6 +879,10 @@ bio_xsctxt_free(struct bio_xs_context *ctxt)
 
 	if (ctxt->bxc_blobstore != NULL) {
 		put_bio_blobstore(ctxt->bxc_blobstore, ctxt);
+
+		if (is_bbs_owner(ctxt, ctxt->bxc_blobstore))
+			bio_fini_health_monitoring(ctxt->bxc_blobstore);
+
 		ctxt->bxc_blobstore = NULL;
 	}
 


### PR DESCRIPTION
Health monitoring context should be initialized & finalized by the
BIO blobstore owner xstream but not the global BIO init xstream.

Signed-off-by: Niu Yawei <yawei.niu@intel.com>
Change-Id: Ica86d82d3ab4245bf99aa81af350fdd8f0b45f77