### PR TITLE
DAOS-2881 control: Fix race in harness start test

### DIFF
--- a/src/control/server/harness_test.go
+++ b/src/control/server/harness_test.go
@@ -323,13 +323,16 @@ func TestHarnessIOServerStart(t *testing.T) {
 				}))
 			}
 
+			done := make(chan struct{})
 			ctx, shutdown := context.WithCancel(context.Background())
-			go func(t *testing.T) {
-				common.CmpErr(t, tc.expStartErr, harness.Start(ctx))
-			}(t)
+			go func(t *testing.T, expStartErr error, th *IOServerHarness) {
+				common.CmpErr(t, expStartErr, th.Start(ctx))
+				close(done)
+			}(t, tc.expStartErr, harness)
 
 			time.Sleep(50 * time.Millisecond)
 			shutdown()
+			<-done // wait for inner goroutine to finish
 
 			if instanceStarts != tc.expStartCount {
 				t.Fatalf("expected %d starts, got %d", tc.expStartCount, instanceStarts)


### PR DESCRIPTION
Didn't see this in local testing or CI, but apparently on
some systems the race detector was triggered when running the
new harness test. This commit feeds the outer test values into
the goroutine that starts the harness, and also waits for the
inner goroutine to finish before starting the next loop.