### PR TITLE
DAO-2223 rebuild: fix a memleak by adding co_post_reply callback

### DIFF
--- a/src/rebuild/rebuild_internal.h
+++ b/src/rebuild/rebuild_internal.h
@@ -291,6 +291,7 @@ void rebuild_obj_handler(crt_rpc_t *rpc);
 void rebuild_tgt_scan_handler(crt_rpc_t *rpc);
 int rebuild_tgt_scan_aggregator(crt_rpc_t *source, crt_rpc_t *result,
 				void *priv);
+int rebuild_tgt_scan_post_reply(crt_rpc_t *rpc, void *arg);
 
 int rebuild_iv_fetch(void *ns, struct rebuild_iv *rebuild_iv);
 int rebuild_iv_update(void *ns, struct rebuild_iv *rebuild_iv,

--- a/src/rebuild/scan.c
+++ b/src/rebuild/scan.c
@@ -899,7 +899,10 @@ out:
 	}
 
 	dss_rpc_reply(rpc, DAOS_REBUILD_DROP_SCAN);
-	d_rank_list_free(fail_list);
+	/* will fix cart to call co_post_reply() for this case, freeing
+	 * it immediately at here is potentially unsafe.
+	 */
+	/* d_rank_list_free(fail_list); */
 }
 
 int
@@ -935,3 +938,13 @@ rebuild_tgt_scan_aggregator(crt_rpc_t *source, crt_rpc_t *result,
 	return 0;
 }
 
+int
+rebuild_tgt_scan_post_reply(crt_rpc_t *rpc, void *arg)
+{
+	struct rebuild_scan_out *out = crt_reply_get(rpc);
+
+	if (out->rso_ranks_list != NULL)
+		d_rank_list_free(out->rso_ranks_list);
+
+	return 0;
+}

--- a/src/rebuild/srv.c
+++ b/src/rebuild/srv.c
@@ -1997,6 +1997,7 @@ out:
 static struct crt_corpc_ops rebuild_tgt_scan_co_ops = {
 	.co_aggregate	= rebuild_tgt_scan_aggregator,
 	.co_pre_forward	= NULL,
+	.co_post_reply	= rebuild_tgt_scan_post_reply,
 };
 
 /* Define for cont_rpcs[] array population below.


### PR DESCRIPTION
Add rebuild_tgt_scan_post_reply to free allocated rank list in
aggregator, as the new cart added co_post_reply for corpc.

Signed-off-by: Xuezhao Liu <xuezhao.liu@intel.com>