### PR TITLE
DAOS-3570 object: check cont_hdl for checksum

### DIFF
--- a/src/object/srv_obj.c
+++ b/src/object/srv_obj.c
@@ -121,8 +121,9 @@ obj_rw_reply(crt_rpc_t *rpc, int status, uint32_t map_version,
 			orwo->orw_nrs.ca_count = 0;
 		}
 
-		daos_csummer_free_dcbs(cont_hdl->sch_csummer,
-				       &orwo->orw_csum.ca_arrays);
+		if (cont_hdl)
+			daos_csummer_free_dcbs(cont_hdl->sch_csummer,
+					       &orwo->orw_csum.ca_arrays);
 		orwo->orw_csum.ca_count = 0;
 	}
 }


### PR DESCRIPTION
Check cont_hdl before checksum in case cont_hdl is NULL
if there is failure.

Signed-off-by: Di Wang <di.wang@intel.com>