### PR TITLE
DAOS-3581 rebuild: check rebuild done after mark down targets

### DIFF
--- a/src/common/misc.c
+++ b/src/common/misc.c
@@ -410,26 +410,6 @@ out:
 	return ranks;
 }
 
-/* Find the first unset bit. */
-int
-daos_first_unset_bit(uint32_t *bits, unsigned int size)
-{
-	unsigned int idx = 0;
-	unsigned int off;
-
-	while (*bits == (uint32_t)(-1) && ++idx < size)
-		bits++;
-
-	if (idx == size)
-		return -1;
-
-	for (off = 0; off < 32; off++)
-		if (isclr(bits, off))
-			break;
-
-	return idx * 32 + off;
-}
-
 bool
 daos_file_is_dax(const char *pathname)
 {

--- a/src/include/daos/common.h
+++ b/src/include/daos/common.h
@@ -263,10 +263,6 @@ bool daos_iov_cmp(d_iov_t *iov1, d_iov_t *iov2);
 
 #define daos_key_match(key1, key2)	daos_iov_cmp(key1, key2)
 
-/* The DAOS BITS is composed by uint32_t[x] */
-#define DAOS_BITS_SIZE  (sizeof(uint32_t) * NBBY)
-int daos_first_unset_bit(uint32_t *bits, unsigned int size);
-
 #if !defined(container_of)
 /* given a pointer @ptr to the field @member embedded into type (usually
  *  * struct) @type, return pointer to the embedding instance of @type. */

--- a/src/include/daos/pool_map.h
+++ b/src/include/daos/pool_map.h
@@ -242,10 +242,16 @@ pool_map_node_nr(struct pool_map *map)
 }
 
 static inline bool
+pool_component_unavail(struct pool_component *comp)
+{
+	return comp->co_status == PO_COMP_ST_DOWN ||
+	       comp->co_status == PO_COMP_ST_DOWNOUT;
+}
+
+static inline bool
 pool_target_unavail(struct pool_target *tgt)
 {
-	return tgt->ta_comp.co_status == PO_COMP_ST_DOWN ||
-	       tgt->ta_comp.co_status == PO_COMP_ST_DOWNOUT;
+	return pool_component_unavail(&tgt->ta_comp);
 }
 
 pool_comp_state_t pool_comp_str2state(const char *name);

--- a/src/rebuild/rebuild_internal.h
+++ b/src/rebuild/rebuild_internal.h
@@ -143,13 +143,13 @@ struct rebuild_global_pool_tracker {
 	uint32_t	rgt_rebuild_ver;
 
 	/* bits to track scan status for all targets */
-	uint32_t	*rgt_scan_bits;
+	uint8_t		*rgt_scan_bits;
 
 	/* bits to track pull status for all targets */
-	uint32_t	*rgt_pull_bits;
+	uint8_t		*rgt_pull_bits;
 
-	/* The size of rt_global_scan_bits and
-	 * rt_global_pull_bits in bit
+	/* The size of rgt_scan_bits and
+	 * rgt_pull_bits in bit
 	 */
 	uint32_t	rgt_bits_size;
 
@@ -157,9 +157,7 @@ struct rebuild_global_pool_tracker {
 	uint64_t	rgt_leader_term;
 
 	uint64_t	rgt_time_start;
-	unsigned int	rgt_scan_done:1,
-			rgt_done:1,
-			rgt_abort:1;
+	unsigned int	rgt_abort:1;
 };
 
 /* Structure on raft replica nodes to serve completed rebuild status querying */
@@ -305,6 +303,27 @@ int rebuild_iv_update(void *ns, struct rebuild_iv *rebuild_iv,
 int rebuild_iv_ns_create(struct ds_pool *pool, uint32_t map_ver,
 			 d_rank_list_t *exclude_tgts,
 			 unsigned int master_rank);
+
+static inline bool
+is_rebuild_global_pull_done(struct rebuild_global_pool_tracker *rgt)
+{
+	return isset_range(rgt->rgt_pull_bits, 0, rgt->rgt_bits_size - 1);
+}
+
+static inline bool
+is_rebuild_global_scan_done(struct rebuild_global_pool_tracker *rgt)
+{
+	return isset_range(rgt->rgt_scan_bits, 0, rgt->rgt_bits_size - 1);
+}
+
+static inline bool
+is_rebuild_global_done(struct rebuild_global_pool_tracker *rgt)
+{
+	return is_rebuild_global_scan_done(rgt) &&
+	       is_rebuild_global_pull_done(rgt);
+
+}
+
 int rebuild_iv_init(void);
 int rebuild_iv_fini(void);
 


### PR DESCRIPTION
Let's check if rebuild is done after mark all current DOWN
targets, in case all targets are DOWN, then no one will
send rebuild status update, so rgt_done will never be updated.

Signed-off-by: Di Wang <di.wang@intel.com>