### PR TITLE
DAOS-2822 pool: Clean up pool_svc_step_up_cb

### DIFF
--- a/src/pool/srv_pool.c
+++ b/src/pool/srv_pool.c
@@ -786,11 +786,13 @@ ds_pool_svc_destroy(const uuid_t pool_uuid)
 }
 
 static int
-pool_svc_create_group(struct pool_svc *svc, struct pool_map *map)
+pool_svc_create_group(struct pool_svc *svc, struct pool_buf *map_buf,
+		      uint32_t map_version)
 {
-	char		id[DAOS_UUID_STR_SIZE];
-	crt_group_t    *group;
-	int		rc;
+	char			id[DAOS_UUID_STR_SIZE];
+	crt_group_t	       *group;
+	struct pool_map	       *map;
+	int			rc;
 
 	/* Check if the pool group exists locally. */
 	uuid_unparse_lower(svc->ps_uuid, id);
@@ -798,8 +800,13 @@ pool_svc_create_group(struct pool_svc *svc, struct pool_map *map)
 	if (group != NULL)
 		return 0;
 
+	rc = pool_map_create(map_buf, map_version, &map);
+	if (rc != 0)
+		return rc;
+
 	/* Attempt to create the pool group. */
 	rc = ds_pool_group_create(svc->ps_uuid, map, &group);
+	pool_map_decref(map);
 	if (rc != 0) {
 		D_ERROR(DF_UUID": failed to create pool group: %d\n",
 			 DP_UUID(svc->ps_uuid), rc);
@@ -976,112 +983,115 @@ pool_svc_free_cb(struct ds_rsvc *rsvc)
 	D_FREE(svc);
 }
 
+/*
+ * Initialize and update svc->ps_pool with map_buf and map_version. This
+ * ensures that svc->ps_pool matches the latest pool map.
+ */
+static int
+init_svc_pool(struct pool_svc *svc, struct pool_buf *map_buf,
+	      uint32_t map_version)
+{
+	struct ds_pool_create_arg	arg;
+	struct ds_pool		       *pool;
+	int				rc;
+
+	arg.pca_map_version = map_version;
+	arg.pca_need_group = 1;
+	rc = ds_pool_lookup_create(svc->ps_uuid, &arg, &pool);
+	if (rc != 0) {
+		D_ERROR(DF_UUID": failed to get ds_pool: %d\n",
+			DP_UUID(svc->ps_uuid), rc);
+		return rc;
+	}
+	rc = ds_pool_tgt_map_update(pool, map_buf, map_version);
+	if (rc != 0) {
+		ds_pool_put(pool);
+		return rc;
+	}
+	D_ASSERT(svc->ps_pool == NULL);
+	svc->ps_pool = pool;
+	return 0;
+}
+
+/* Finalize svc->ps_pool. */
+static void
+fini_svc_pool(struct pool_svc *svc)
+{
+	D_ASSERT(svc->ps_pool != NULL);
+	ds_pool_put(svc->ps_pool);
+	svc->ps_pool = NULL;
+}
+
 static int
 pool_svc_step_up_cb(struct ds_rsvc *rsvc)
 {
-	struct pool_svc		       *svc = pool_svc_obj(rsvc);
-	struct rdb_tx			tx;
-	struct ds_pool		       *pool;
-	d_rank_list_t		       *replicas = NULL;
-	struct pool_map		       *map = NULL;
-	uint32_t			map_version;
-	struct ds_pool_create_arg	arg;
-	d_rank_t			rank;
-	int				rc;
+	struct pool_svc	       *svc = pool_svc_obj(rsvc);
+	struct rdb_tx		tx;
+	d_rank_list_t	       *replicas = NULL;
+	struct pool_buf	       *map_buf = NULL;
+	uint32_t		map_version;
+	bool			cont_svc_up = false;
+	d_rank_t		rank;
+	int			rc;
 
-	/* Read the pool map into map and map_version. */
+	/* Read the pool map into map_buf and map_version. */
 	rc = rdb_tx_begin(rsvc->s_db, rsvc->s_term, &tx);
 	if (rc != 0)
 		goto out;
 	ABT_rwlock_rdlock(svc->ps_lock);
-	rc = read_map(&tx, &svc->ps_root, &map);
-	if (rc == 0)
-		rc = rdb_get_ranks(rsvc->s_db, &replicas);
-	ABT_rwlock_unlock(svc->ps_lock);
-	rdb_tx_end(&tx);
+	rc = read_map_buf(&tx, &svc->ps_root, &map_buf, &map_version);
 	if (rc != 0) {
 		if (rc == -DER_NONEXIST) {
-			D_DEBUG(DF_DSMS, DF_UUID": new db\n",
+			D_DEBUG(DB_MD, DF_UUID": new db\n",
 				DP_UUID(svc->ps_uuid));
-			rc = DER_UNINIT;
+			rc = +DER_UNINIT;
 		} else {
-			D_ERROR(DF_UUID": failed to get %s: %d\n",
-				DP_UUID(svc->ps_uuid),
-				map == NULL ? "pool map" : "replica ranks", rc);
+			D_ERROR(DF_UUID": failed to read pool map buffer: %d\n",
+				DP_UUID(svc->ps_uuid), rc);
 		}
-		goto out;
+		goto out_lock;
 	}
-	map_version = pool_map_get_version(map);
-
-	/* Create the pool group. */
-	rc = pool_svc_create_group(svc, map);
+	rc = rdb_get_ranks(rsvc->s_db, &replicas);
+	if (rc != 0)
+		D_ERROR(DF_UUID": failed to get pool service replica: %d\n",
+			DP_UUID(svc->ps_uuid), rc);
+out_lock:
+	ABT_rwlock_unlock(svc->ps_lock);
+	rdb_tx_end(&tx);
 	if (rc != 0)
 		goto out;
 
-	/* Create or revalidate svc->ps_pool with map and map_version. */
-	D_ASSERT(svc->ps_pool == NULL);
-	arg.pca_map_version = map_version;
-	arg.pca_need_group = 1;
-	rc = ds_pool_lookup_create(svc->ps_uuid, &arg, &svc->ps_pool);
-	if (rc != 0) {
-		D_ERROR(DF_UUID": failed to get ds_pool: %d\n",
-			DP_UUID(svc->ps_uuid), rc);
+	/* Create the pool group. */
+	rc = pool_svc_create_group(svc, map_buf, map_version);
+	if (rc != 0)
 		goto out;
-	}
-	pool = svc->ps_pool;
-	ABT_rwlock_wrlock(pool->sp_lock);
-	if (pool->sp_map != map) {
-		/* An existing ds_pool; map not used yet. */
-		D_ASSERTF(pool->sp_map_version <= map_version, "%u <= %u\n",
-			  pool->sp_map_version, map_version);
-		D_ASSERTF(pool->sp_map == NULL ||
-			  pool_map_get_version(pool->sp_map) <= map_version,
-			  "%u <= %u\n", pool_map_get_version(pool->sp_map),
-			  map_version);
-		if (pool->sp_map == NULL ||
-		    pool_map_get_version(pool->sp_map) < map_version) {
-			struct pool_map *tmp;
 
-			rc = pl_map_update(pool->sp_uuid, map,
-					   pool->sp_map != NULL ? false : true,
-					   DEFAULT_PL_TYPE);
-			if (rc != 0) {
-				svc->ps_pool = NULL;
-				ABT_rwlock_unlock(pool->sp_lock);
-				ds_pool_put(pool);
-				goto out;
-			}
-
-			/* Need to update pool->sp_map. Swap with map. */
-			tmp = pool->sp_map;
-			pool->sp_map = map;
-			map = tmp;
-			pool->sp_map_version = map_version;
-		}
-	} else {
-		map = NULL; /* taken over by pool */
-	}
-	ABT_rwlock_unlock(pool->sp_lock);
+	rc = init_svc_pool(svc, map_buf, map_version);
+	if (rc != 0)
+		goto out;
 
 	ds_cont_svc_step_up(svc->ps_cont_svc);
+	cont_svc_up = true;
 
-	rc = ds_rebuild_regenerate_task(pool, replicas);
-	if (rc != 0) {
-		ds_cont_svc_step_down(svc->ps_cont_svc);
-		ds_pool_put(svc->ps_pool);
-		svc->ps_pool = NULL;
+	rc = ds_rebuild_regenerate_task(svc->ps_pool, replicas);
+	if (rc != 0)
 		goto out;
-	}
 
 	rc = crt_group_rank(NULL, &rank);
 	D_ASSERTF(rc == 0, "%d\n", rc);
 	D_PRINT(DF_UUID": rank %u became pool service leader "DF_U64"\n",
 		DP_UUID(svc->ps_uuid), rank, svc->ps_rsvc.s_term);
 out:
-	if (map != NULL)
-		pool_map_decref(map);
-	if (replicas)
+	if (rc != 0) {
+		if (cont_svc_up)
+			ds_cont_svc_step_down(svc->ps_cont_svc);
+		if (svc->ps_pool != NULL)
+			fini_svc_pool(svc);
+	}
+	if (replicas != NULL)
 		d_rank_list_free(replicas);
+	if (map_buf != NULL)
+		D_FREE(map_buf);
 	return rc;
 }
 
@@ -1093,9 +1103,7 @@ pool_svc_step_down_cb(struct ds_rsvc *rsvc)
 	int			rc;
 
 	ds_cont_svc_step_down(svc->ps_cont_svc);
-	D_ASSERT(svc->ps_pool != NULL);
-	ds_pool_put(svc->ps_pool);
-	svc->ps_pool = NULL;
+	fini_svc_pool(svc);
 
 	rc = crt_group_rank(NULL, &rank);
 	D_ASSERTF(rc == 0, "%d\n", rc);


### PR DESCRIPTION
This patch cleans up the following aspects of pool_svc_step_up_cb:

  - Updating the cached pool map could reuse ds_pool_tgt_map_update.
      - This requires map to be replaced with map_buf.
  - The -DER_NONEXIST check should be performed on the rc of
    read_map_buf only.
  - The error handling could be slightly cleaned up for redundant code.

Signed-off-by: Li Wei <wei.g.li@intel.com>