### PR TITLE
DAOS-3115 vos: Add new tests for punch model change

### DIFF
--- a/src/vos/tests/SConscript
+++ b/src/vos/tests/SConscript
@@ -15,7 +15,8 @@ def scons():
 
     vos_test_src = ['vos_tests.c', 'vts_io.c', 'vts_pool.c', 'vts_container.c',
                     denv.Object("vts_common.c"), 'vts_aggregate.c', 'vts_dtx.c',
-                    'vts_gc.c', 'csum_extent_tests.c', 'vts_ilog.c']
+                    'vts_gc.c', 'csum_extent_tests.c', 'vts_ilog.c',
+                    'vts_array.c', 'vts_pm.c']
     vos_tests = daos_build.program(denv, 'vos_tests', vos_test_src,
                                    LIBS=libraries)
     denv.AppendUnique(CPPPATH=["../../common/tests"])

--- a/src/vos/tests/vos_tests.c
+++ b/src/vos/tests/vos_tests.c
@@ -55,6 +55,7 @@ print_usage()
 	print_message("vos_tests -A|--all_tests\n");
 	print_message("vos_tests -f|--filter <filter>\n");
 	print_message("vos_tests -e|--exclude <filter>\n");
+	print_message("vos_tests -m|--punch-model-tests\n");
 	print_message("vos_tests -h|--help\n");
 	print_message("Default <vos_tests> runs all tests\n");
 }
@@ -81,6 +82,7 @@ run_all_tests(int keys, bool nest_iterators)
 	int	i;
 	int	j;
 
+	failed += run_pm_tests();
 	failed += run_pool_test();
 	failed += run_co_test();
 	for (i = 0; dkey_feats[i] >= 0; i++) {
@@ -107,7 +109,7 @@ main(int argc, char **argv)
 	int	ofeats;
 	int	keys;
 	bool	nest_iterators = false;
-	const char *short_options = "apcdglni:XA:hf:e:";
+	const char *short_options = "apcdglni:mXA:hf:e:";
 	static struct option long_options[] = {
 		{"all_tests",		required_argument, 0, 'A'},
 		{"pool_tests",		no_argument, 0, 'p'},
@@ -117,6 +119,7 @@ main(int argc, char **argv)
 		{"nest_iterators",	no_argument, 0, 'n'},
 		{"aggregate_tests",	no_argument, 0, 'a'},
 		{"dtx_tests",		no_argument, 0, 'X'},
+		{"punch_model_tests",	no_argument, 0, 'm'},
 		{"garbage_collector",	no_argument, 0, 'g'},
 		{"ilog_tests",		no_argument, 0, 'l'},
 		{"help",		no_argument, 0, 'h'},
@@ -201,6 +204,10 @@ main(int argc, char **argv)
 			break;
 		case 'X':
 			nr_failed += run_dtx_tests();
+			test_run = true;
+			break;
+		case 'm':
+			nr_failed += run_pm_tests();
 			test_run = true;
 			break;
 		case 'A':

--- a/src/vos/tests/vts_array.c
+++ b/src/vos/tests/vts_array.c
@@ -1,0 +1,646 @@
+/**
+ * (C) Copyright 2019 Intel Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * GOVERNMENT LICENSE RIGHTS-OPEN SOURCE SOFTWARE
+ * The Government's rights to use, modify, reproduce, release, perform, display,
+ * or disclose this software are subject to the terms of the Apache License as
+ * provided in Contract No. B609815.
+ * Any reproduction of computer software, computer software documentation, or
+ * portions thereof marked with this legend must also reproduce the markings.
+ */
+/**
+ * This file is part of vos/tests/
+ *
+ * vos/tests/vts_array.c
+ */
+#define D_LOGFAC	DD_FAC(tests)
+
+#include "vts_io.h"
+#include "vts_array.h"
+
+struct vts_metadata {
+	uint64_t	 vm_magic;
+	uint64_t	 vm_record_size;
+	uint64_t	 vm_per_key;
+	uint64_t	 vm_akey_size;
+};
+
+struct vts_array {
+	daos_unit_oid_t		 va_oid;
+	daos_handle_t		 va_coh;
+	daos_iod_t		 va_iod;
+	daos_iod_t		 va_sv_iod;
+	d_iov_t			 va_dkey;
+	uint64_t		 va_recx_nr;
+	daos_recx_t		*va_recx;
+	d_iov_t			*va_iovs;
+	uint64_t		 va_dkey_value;
+	uint64_t		 va_io_size;
+	d_sg_list_t		 va_sgl;
+	struct vts_metadata	 va_meta;
+	uint8_t			*va_akey_value;
+	uint8_t			*va_zero;
+};
+
+#define ARRAY_MAGIC 0xdeadbeef
+
+static daos_handle_t
+vts_array2hdl(struct vts_array *array)
+{
+	daos_handle_t	aoh;
+
+	aoh.cookie = (uint64_t)array;
+
+	return aoh;
+}
+
+static struct vts_array *
+vts_hdl2array(daos_handle_t aoh)
+{
+	struct vts_array	*array = (struct vts_array *)aoh.cookie;
+
+	D_ASSERT(array != NULL && array->va_meta.vm_magic == ARRAY_MAGIC);
+
+	return array;
+}
+
+static int
+array_open(struct vts_array *array)
+{
+	D_ALLOC_ARRAY(array->va_akey_value, array->va_meta.vm_akey_size);
+	if (array->va_akey_value == NULL)
+		return -DER_NOMEM;
+
+	D_ALLOC_ARRAY(array->va_zero, array->va_meta.vm_record_size);
+	if (array->va_zero == NULL)
+		return -DER_NOMEM;
+
+	array->va_recx_nr = array->va_io_size = array->va_meta.vm_per_key;
+	D_ALLOC_ARRAY(array->va_recx, array->va_io_size);
+	if (array->va_recx == NULL)
+		return -DER_NOMEM;
+
+	D_ALLOC_ARRAY(array->va_iovs, array->va_io_size);
+	if (array->va_recx == NULL)
+		return -DER_NOMEM;
+
+	return 0;
+}
+
+static int
+array_init(struct vts_array *in, daos_handle_t coh, daos_unit_oid_t oid,
+	   struct vts_array **out)
+{
+	D_ASSERT((in == NULL && out != NULL) || (in != NULL && out == NULL));
+
+	if (in == NULL) {
+		D_ALLOC_PTR(in);
+		if (in == NULL)
+			return -DER_NOMEM;
+	} else {
+		memset(in, 0, sizeof(*in));
+	}
+
+	if (out)
+		*out = in;
+
+	d_iov_set(&in->va_dkey, &in->va_dkey_value, sizeof(in->va_dkey_value));
+	in->va_iod.iod_type = DAOS_IOD_ARRAY;
+	in->va_iod.iod_recxs = in->va_recx;
+	in->va_iod.iod_nr = 1;
+	in->va_coh = coh;
+	in->va_oid = oid;
+
+	in->va_sv_iod.iod_type = DAOS_IOD_SINGLE;
+	in->va_sv_iod.iod_recxs = NULL;
+	in->va_sv_iod.iod_nr = 1;
+	in->va_sv_iod.iod_size = sizeof(struct vts_metadata);
+
+	return 0;
+}
+
+static void
+array_fini(struct vts_array *in, bool free_array)
+{
+	in->va_meta.vm_magic = 0;
+	if (!free_array)
+		return;
+
+	D_FREE(in->va_zero);
+	D_FREE(in->va_akey_value);
+	D_FREE(in->va_recx);
+	D_FREE(in->va_iovs);
+	D_FREE(in);
+}
+
+static int
+update_array(struct vts_array *array, daos_epoch_t epoch, uint64_t dkey,
+	     uint64_t rec_size, uint64_t offset, uint64_t nr, void *values)
+{
+	d_sg_list_t	*sgls = NULL;
+	d_sg_list_t	 sgl;
+	uint64_t	 cursor = offset;
+	uint64_t	 left = nr;
+	int		 idx = 0;
+
+	if (values)
+		sgls = &sgl;
+
+	while (cursor < (offset + nr)) {
+		array->va_recx[idx].rx_idx = cursor;
+		if (left > array->va_io_size)
+			array->va_recx[idx].rx_nr = array->va_io_size;
+		else
+			array->va_recx[idx].rx_nr = left;
+		if (values) {
+			d_iov_set(&array->va_iovs[idx],
+				  values + (cursor - offset) * rec_size,
+				  array->va_recx[idx].rx_nr * rec_size);
+		}
+
+		cursor += array->va_io_size;
+		left -= array->va_io_size;
+		idx++;
+	}
+
+	array->va_iod.iod_recxs = array->va_recx;
+	array->va_iod.iod_nr = idx;
+	sgl.sg_iovs = array->va_iovs;
+	sgl.sg_nr = idx;
+	sgl.sg_nr_out = 0;
+
+	array->va_dkey_value = dkey;
+	array->va_iod.iod_size = rec_size;
+	d_iov_set(&array->va_iod.iod_name, array->va_akey_value,
+		  array->va_meta.vm_akey_size);
+
+	D_DEBUG(DB_IO, "Writing "DF_U64" records of size "DF_U64" at offset "
+		DF_U64"\n", nr, rec_size, offset);
+	return vos_obj_update(array->va_coh, array->va_oid, epoch, 0,
+			      &array->va_dkey, 1, &array->va_iod, sgls);
+}
+
+static int
+fetch_array(struct vts_array *array, daos_epoch_t epoch, uint64_t dkey,
+	    uint64_t rec_size, uint64_t offset, uint64_t nr, void *values)
+{
+	d_sg_list_t	 sgl;
+	d_sg_list_t	*sgls = &sgl;
+	uint64_t	 cursor = offset;
+	uint64_t	 left = nr;
+	int		 idx = 0;
+
+	while (cursor < (offset + nr)) {
+		array->va_recx[idx].rx_idx = cursor;
+		if (left > array->va_io_size)
+			array->va_recx[idx].rx_nr = array->va_io_size;
+		else
+			array->va_recx[idx].rx_nr = left;
+		if (values) {
+			d_iov_set(&array->va_iovs[idx],
+				  values + (cursor - offset) * rec_size,
+				  array->va_recx[idx].rx_nr * rec_size);
+		}
+
+		cursor += array->va_io_size;
+		left -= array->va_io_size;
+		idx++;
+	}
+
+	array->va_iod.iod_nr = idx;
+	sgl.sg_iovs = array->va_iovs;
+	sgl.sg_nr = idx;
+	sgl.sg_nr_out = 0;
+
+	array->va_iod.iod_size = rec_size;
+	array->va_dkey_value = dkey;
+	d_iov_set(&array->va_iod.iod_name, array->va_akey_value,
+		  array->va_meta.vm_akey_size);
+
+	D_DEBUG(DB_IO, "Reading "DF_U64" records of size "DF_U64" at offset "
+		DF_U64"\n", nr, rec_size, offset);
+	return vos_obj_fetch(array->va_coh, array->va_oid, epoch,
+			     &array->va_dkey, 1, &array->va_iod, sgls);
+}
+
+static int
+update_meta(struct vts_array *array, daos_epoch_t epoch,
+	    struct vts_metadata *meta)
+{
+	d_sg_list_t	 sgl = {0};
+	d_iov_t		 iov;
+	uint8_t		 akey = 0;
+
+	array->va_dkey_value = 0;
+	d_iov_set(&iov, meta, sizeof(*meta));
+	sgl.sg_iovs = &iov;
+	sgl.sg_nr = 1;
+
+	d_iov_set(&array->va_sv_iod.iod_name, &akey, sizeof(akey));
+
+	D_DEBUG(DB_IO, "Writing metadata at epoch "DF_U64"\n", epoch);
+	return vos_obj_update(array->va_coh, array->va_oid, epoch, 0,
+			      &array->va_dkey, 1, &array->va_sv_iod, &sgl);
+}
+
+static int
+fetch_meta(struct vts_array *array, daos_epoch_t epoch,
+	   struct vts_metadata *meta)
+{
+	d_sg_list_t	 sgl = {0};
+	d_iov_t		 iov;
+	uint8_t		 akey = 0;
+
+	array->va_dkey_value = 0;
+	d_iov_set(&iov, meta, sizeof(*meta));
+	sgl.sg_iovs = &iov;
+	sgl.sg_nr = 1;
+
+	d_iov_set(&array->va_sv_iod.iod_name, &akey, sizeof(akey));
+
+	D_DEBUG(DB_IO, "Reading metadata at epoch "DF_U64"\n", epoch);
+	return vos_obj_fetch(array->va_coh, array->va_oid, epoch,
+			     &array->va_dkey, 1, &array->va_sv_iod, &sgl);
+}
+
+
+int
+vts_array_alloc(daos_handle_t coh, daos_epoch_t epoch, daos_size_t record_size,
+		daos_size_t nr_per_key, daos_size_t akey_size,
+		daos_unit_oid_t *oid)
+{
+	struct vts_array	 array;
+	struct vts_metadata	 meta;
+	int			 rc = 0;
+
+	*oid = dts_unit_oid_gen(0, DAOS_OF_DKEY_UINT64, 0);
+	rc = array_init(&array, coh, *oid, NULL);
+	if (rc != 0)
+		return rc;
+
+	meta.vm_magic = ARRAY_MAGIC;
+	meta.vm_record_size = record_size;
+	meta.vm_per_key = nr_per_key ? nr_per_key : 8;
+	meta.vm_akey_size = akey_size ? akey_size : 1;
+	rc = update_meta(&array, epoch, &meta);
+
+	array_fini(&array, false);
+
+	if (rc != 0)
+		D_ERROR("Failed to create array: "DF_RC"\n", DP_RC(rc));
+
+	return rc;
+}
+
+int
+vts_array_free(daos_handle_t coh, daos_unit_oid_t oid)
+{
+	return vos_obj_delete(coh, oid);
+}
+
+int
+vts_array_open(daos_handle_t coh, daos_unit_oid_t oid, daos_handle_t *aoh)
+{
+	struct vts_array	*array;
+	int			 rc;
+
+	rc = array_init(NULL, coh, oid, &array);
+	if (rc != 0)
+		return rc;
+
+	rc = fetch_meta(array, DAOS_EPOCH_MAX, &array->va_meta);
+	if (rc != 0 || array->va_meta.vm_magic != ARRAY_MAGIC) {
+		if (rc == 0)
+			rc = -DER_INVAL;
+		array_fini(array, true);
+		return rc;
+	}
+
+	rc = array_open(array);
+	if (rc != 0) {
+		array_fini(array, true);
+		return rc;
+	}
+
+	D_ASSERT(array->va_meta.vm_magic == ARRAY_MAGIC);
+	*aoh = vts_array2hdl(array);
+	return 0;
+}
+
+int
+vts_array_reset(daos_handle_t *aoh, daos_epoch_t punch_epoch,
+		daos_epoch_t create_epoch, daos_size_t record_size,
+		daos_size_t nr_per_key, daos_size_t akey_size)
+{
+	struct vts_array	*array = vts_hdl2array(*aoh);
+	struct vts_metadata	 meta;
+	daos_handle_t		 coh;
+	daos_unit_oid_t		 oid;
+	int			 rc;
+
+	D_ASSERT(punch_epoch < create_epoch);
+
+	rc = vos_obj_punch(array->va_coh, array->va_oid, punch_epoch, 0, 0,
+			   NULL, 0, NULL, NULL);
+	if (rc != 0)
+		return rc;
+
+	meta.vm_magic = ARRAY_MAGIC;
+	meta.vm_record_size = record_size;
+	meta.vm_per_key = nr_per_key ? nr_per_key : 8;
+	meta.vm_akey_size = akey_size ? akey_size : 1;
+	rc = update_meta(array, create_epoch, &meta);
+	if (rc != 0)
+		return rc;
+
+	oid = array->va_oid;
+	coh = array->va_coh;
+
+	vts_array_close(*aoh);
+	return vts_array_open(coh, oid, aoh);
+}
+
+void
+vts_array_close(daos_handle_t aoh)
+{
+	struct vts_array	*array = vts_hdl2array(aoh);
+
+	array_fini(array, true);
+}
+
+int
+vts_array_set_size(daos_handle_t aoh, daos_epoch_t epoch, daos_size_t new_size)
+{
+	struct vts_array	*array = vts_hdl2array(aoh);
+	daos_size_t		 old_size;
+	int			 rc;
+
+	/* Should probably put this in vos transaction but keep it simple for
+	 * now.
+	 */
+	D_DEBUG(DB_IO, "Getting the old array size\n");
+	rc = vts_array_get_size(aoh, epoch, &old_size);
+	if (rc != 0)
+		return rc;
+
+	D_DEBUG(DB_IO, "Old size is "DF_U64"\n", old_size);
+	if (old_size > new_size) {
+		D_DEBUG(DB_IO, "Truncate at "DF_U64"\n", new_size);
+		rc = vts_array_punch(aoh, epoch, new_size, old_size - new_size);
+		if (rc != 0)
+			return rc;
+		D_DEBUG(DB_IO, "Checking array size again\n");
+		rc = vts_array_get_size(aoh, epoch, &old_size);
+		if (rc != 0)
+			return rc;
+		D_DEBUG(DB_IO, "Size is now "DF_U64"\n", old_size);
+	}
+
+	if (old_size == new_size)
+		return 0;
+
+	return vts_array_write(aoh, epoch, new_size - 1, 1, array->va_zero);
+}
+
+int
+vts_array_get_size(daos_handle_t aoh, daos_epoch_t epoch, daos_size_t *size)
+{
+	struct vts_array	*array = vts_hdl2array(aoh);
+	daos_recx_t		 recx;
+	int			 rc;
+	d_iov_t			 dkey;
+	uint64_t		 val;
+
+	d_iov_set(&dkey, NULL, 0);
+	d_iov_set(&array->va_iod.iod_name, array->va_akey_value,
+		  array->va_meta.vm_akey_size);
+
+	rc = vos_obj_query_key(array->va_coh, array->va_oid,
+			       DAOS_GET_DKEY | DAOS_GET_RECX | DAOS_GET_MAX,
+			       epoch, &dkey, &array->va_iod.iod_name,
+			       &recx);
+
+	if (rc == -DER_NONEXIST) {
+		*size = 0;
+		return 0;
+	}
+
+	if (rc != 0)
+		return rc;
+
+	val = *(uint64_t *)dkey.iov_buf;
+	if (val == 0) {
+		*size = 0;
+		return 0;
+	}
+
+	*size = (val - 1) * array->va_meta.vm_per_key + recx.rx_idx +
+		recx.rx_nr;
+
+	return 0;
+}
+
+int
+vts_array_set_iosize(daos_handle_t aoh, uint64_t io_size)
+{
+	struct vts_array	*array = vts_hdl2array(aoh);
+	uint64_t		 new_size;
+	uint64_t		 count;
+
+	new_size = io_size;
+
+	if (io_size != 0 && io_size <= array->va_meta.vm_per_key)
+		goto resize;
+
+	/* Default to per_key */
+	new_size = array->va_meta.vm_per_key;
+resize:
+	count = array->va_meta.vm_per_key / new_size;
+	if (array->va_meta.vm_per_key % new_size)
+		count++;
+
+	if (count > array->va_recx_nr) {
+		d_iov_t		*iovs;
+		daos_recx_t	*recx;
+
+		count = count * 2;
+		D_ALLOC_ARRAY(recx, count);
+		if (recx == NULL)
+			return -DER_NOMEM;
+		D_ALLOC_ARRAY(iovs, count);
+		if (iovs == NULL) {
+			D_FREE(recx);
+			return -DER_NOMEM;
+		}
+
+		D_FREE(array->va_recx);
+		D_FREE(array->va_iovs);
+		array->va_recx_nr = count;
+		array->va_recx = recx;
+		array->va_iovs = iovs;
+	}
+
+	array->va_io_size = new_size;
+	return 0;
+}
+
+int
+vts_array_write(daos_handle_t aoh, daos_epoch_t epoch, uint64_t offset,
+		uint64_t count, void *elements)
+{
+	struct vts_array	*array = vts_hdl2array(aoh);
+	void			*cursor = elements;
+	uint64_t		 first;
+	uint64_t		 last;
+	uint64_t		 stripe;
+	uint64_t		 stripe_offset;
+	uint64_t		 nr;
+	int			 rc = 0;
+
+	first = offset / array->va_meta.vm_per_key;
+	last = (offset + count - 1) / array->va_meta.vm_per_key;
+
+	D_ASSERT(last >= first);
+	for (stripe = first; stripe <= last; stripe++) {
+		uint64_t	tmp;
+
+		stripe_offset = 0;
+		nr = array->va_meta.vm_per_key;
+
+		tmp = offset % array->va_meta.vm_per_key;
+		if (stripe == first && tmp != 0) {
+			stripe_offset = tmp;
+			nr = array->va_meta.vm_per_key - stripe_offset;
+		}
+		if (stripe == last) {
+			tmp = (count + offset) % array->va_meta.vm_per_key;
+			if (tmp == 0)
+				tmp = array->va_meta.vm_per_key;
+			nr = tmp - stripe_offset;
+		}
+
+		rc = update_array(array, epoch, stripe + 1,
+				  array->va_meta.vm_record_size, stripe_offset,
+				  nr, cursor);
+		if (rc != 0)
+			break;
+		cursor += nr * array->va_meta.vm_record_size;
+	}
+
+	D_ASSERT(cursor ==
+		 (elements + (count * array->va_meta.vm_record_size)));
+
+	return rc;
+}
+
+int
+vts_array_punch(daos_handle_t aoh, daos_epoch_t epoch, uint64_t offset,
+		uint64_t count)
+{
+	struct vts_array	*array = vts_hdl2array(aoh);
+	uint64_t		 first;
+	uint64_t		 last;
+	uint64_t		 stripe;
+	uint64_t		 stripe_offset;
+	uint64_t		 nr;
+	int			 rc = 0;
+
+	first = offset / array->va_meta.vm_per_key;
+	last = (offset + count - 1) / array->va_meta.vm_per_key;
+
+	D_ASSERT(last >= first);
+	for (stripe = first; stripe <= last; stripe++) {
+		uint64_t	tmp;
+
+		stripe_offset = 0;
+		nr = array->va_meta.vm_per_key;
+
+		tmp = offset % array->va_meta.vm_per_key;
+		if (stripe == first && tmp != 0) {
+			stripe_offset = tmp;
+			nr = array->va_meta.vm_per_key - stripe_offset;
+		}
+		if (stripe == last) {
+			tmp = (count + offset) % array->va_meta.vm_per_key;
+			if (tmp == 0)
+				tmp = array->va_meta.vm_per_key;
+			nr = tmp - stripe_offset;
+		}
+
+		if (nr != array->va_meta.vm_per_key) {
+			rc = update_array(array, epoch, stripe + 1,
+					  0 /* punch */, stripe_offset, nr,
+					  NULL);
+		} else {
+			array->va_dkey_value = stripe + 1;
+			rc = vos_obj_punch(array->va_coh, array->va_oid, epoch,
+					   0, 0, &array->va_dkey, 0, NULL,
+					   NULL);
+		}
+		if (rc != 0)
+			break;
+	}
+
+	return rc;
+}
+
+int
+vts_array_read(daos_handle_t aoh, daos_epoch_t epoch, uint64_t offset,
+	       uint64_t count, void *elements)
+{
+	struct vts_array	*array = vts_hdl2array(aoh);
+	void			*cursor = elements;
+	uint64_t		 first;
+	uint64_t		 last;
+	uint64_t		 stripe;
+	uint64_t		 stripe_offset;
+	uint64_t		 nr;
+	int			 rc = 0;
+
+	first = offset / array->va_meta.vm_per_key;
+	last = (offset + count - 1) / array->va_meta.vm_per_key;
+
+	D_ASSERT(last >= first);
+	for (stripe = first; stripe <= last; stripe++) {
+		uint64_t	tmp;
+
+		stripe_offset = 0;
+		nr = array->va_meta.vm_per_key;
+
+		tmp = offset % array->va_meta.vm_per_key;
+		if (stripe == first && tmp != 0) {
+			stripe_offset = tmp;
+			nr = array->va_meta.vm_per_key - stripe_offset;
+		}
+		if (stripe == last) {
+			tmp = (count + offset) % array->va_meta.vm_per_key;
+			if (tmp == 0)
+				tmp = array->va_meta.vm_per_key;
+			nr = tmp - stripe_offset;
+		}
+
+		rc = fetch_array(array, epoch, stripe + 1,
+				 array->va_meta.vm_record_size, stripe_offset,
+				 nr, cursor);
+		if (rc != 0)
+			break;
+		cursor += nr * array->va_meta.vm_record_size;
+	}
+
+	D_ASSERT(cursor ==
+		 (elements + (count * array->va_meta.vm_record_size)));
+
+	return rc;
+}

--- a/src/vos/tests/vts_array.h
+++ b/src/vos/tests/vts_array.h
@@ -1,0 +1,160 @@
+/**
+ * (C) Copyright 2019 Intel Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * GOVERNMENT LICENSE RIGHTS-OPEN SOURCE SOFTWARE
+ * The Government's rights to use, modify, reproduce, release, perform, display,
+ * or disclose this software are subject to the terms of the Apache License as
+ * provided in Contract No. B609815.
+ * Any reproduction of computer software, computer software documentation, or
+ * portions thereof marked with this legend must also reproduce the markings.
+ */
+/**
+ * This simulates the array API (array of integers only) on top of VOS only
+ *
+ * vos/tests/vts_array.h
+ */
+#ifndef __VTS_ARRAY_H__
+#define __VTS_ARRAY_H__
+
+#include <daos_srv/vos.h>
+/* This library is convenient for testing daos_array like features on a single
+ * VOS standalone target
+ */
+
+/** Create a new vos test array object at the specified epoch
+ * \param	coh[in]		Container handle
+ * \param	epoch[in]	Creation epoch
+ * \param	record_size[in]	Size of each record
+ * \param	nr_per_key[in]	Records per key (0 for default)
+ * \param	akey_size[in]	Size of the akey (0 for default)
+ * \param	oid[out]	Generated oid for created array
+ *
+ * \return 0 or error code
+ */
+int
+vts_array_alloc(daos_handle_t coh, daos_epoch_t epoch, daos_size_t record_size,
+		daos_size_t nr_per_key, daos_size_t akey_size,
+		daos_unit_oid_t *oid);
+
+/** Calls vos_obj_delete on specified object to remove it from the tree
+ * \param	coh[in]		Container handle
+ * \param	oid[in]		Object to destroy
+ *
+ * \return 0 or error code
+ */
+int
+vts_array_free(daos_handle_t coh, daos_unit_oid_t oid);
+
+/** Creates a handle to a vos test array object
+ * \param	coh[in]		Container handle
+ * \param	oid[in]		Object to open
+ * \param	aoh[out]	The open handle
+ *
+ * \return 0 or error code
+ */
+int
+vts_array_open(daos_handle_t coh, daos_unit_oid_t oid, daos_handle_t *aoh);
+
+/** Set the I/O size of the array.  Reads and writes will be split
+ *  into chunks
+ *
+ *  \param	aoh[in]		Open array handle
+ *  \param	io_size[in]	The new io_size (default is record size)
+ *
+ * \return 0 or error code
+ */
+int
+vts_array_set_iosize(daos_handle_t aoh, uint64_t io_size);
+
+/** Punches the vos test array object and recreates it.  Handle remains open
+ * \param	aoh[in,out]		Open array handle, returns new handle
+ * \param	punch_epoch[in]		punch epoch
+ * \param	create_epoch[in]	creation epoch (must be > punch_epoch)
+ * \param	record_size[in]		Size of each record
+ * \param	nr_per_key[in]		Records per key (0 for default)
+ * \param	akey_size[in]		Size of the akey (0 for default)
+ *
+ * \return 0 or error code
+ */
+int
+vts_array_reset(daos_handle_t *aoh, daos_epoch_t punch_epoch,
+		daos_epoch_t create_epoch, daos_size_t record_size,
+		daos_size_t nr_per_key, daos_size_t akey_size);
+
+/** Closes the open vos test array object handle
+ * \param	aoh[in]			Open array handle
+ */
+void
+vts_array_close(daos_handle_t aoh);
+
+/** Sets the array size
+ * \param	aoh[in]		Open array handle
+ * \param	epoch[in]	epoch for size setting
+ * \param	new_size[in]	New size
+ *
+ * \return 0 or error code
+ */
+int
+vts_array_set_size(daos_handle_t aoh, daos_epoch_t epoch, daos_size_t new_size);
+
+/** Gets the array size
+ * \param	aoh[in]		Open array handle
+ * \param	epoch[in]	epoch for size setting
+ * \param	size[out]	Retrieved size
+ *
+ * \return 0 or error code
+ */
+int
+vts_array_get_size(daos_handle_t aoh, daos_epoch_t epoch, daos_size_t *size);
+
+/** Writes to the array
+ * \param	aoh[in]		Open array handle
+ * \param	epoch[in]	epoch for update
+ * \param	offset[in]	start index
+ * \param	count[in]	Number of items
+ * \param	elements[in]	data to write
+ *
+ * \return 0 or error code
+ */
+int
+vts_array_write(daos_handle_t aoh, daos_epoch_t epoch, uint64_t offset,
+		uint64_t count, void *elements);
+
+/** Punches extents in the array
+ * \param	aoh[in]		Open array handle
+ * \param	epoch[in]	epoch for update
+ * \param	offset[in]	start index
+ * \param	count[in]	Number of items
+ *
+ * \return 0 or error code
+ */
+int
+vts_array_punch(daos_handle_t aoh, daos_epoch_t epoch, uint64_t offset,
+		uint64_t count);
+
+/** Reads from the array
+ * \param	aoh[in]		Open array handle
+ * \param	epoch[in]	epoch for update
+ * \param	offset[in]	start index
+ * \param	count[in]	Number of items
+ * \param	elements[out]	buffer in which to read
+ *
+ * \return 0 or error code
+ */
+int
+vts_array_read(daos_handle_t aoh, daos_epoch_t epoch, uint64_t offset,
+	       uint64_t count, void *elements);
+
+#endif

--- a/src/vos/tests/vts_common.h
+++ b/src/vos/tests/vts_common.h
@@ -126,6 +126,7 @@ int run_discard_tests(void);
 int run_aggregate_tests(bool slow);
 int run_dtx_tests(void);
 int run_gc_tests(void);
+int run_pm_tests(void);
 int run_io_test(daos_ofeat_t feats, int keys, bool nest_iterators);
 
 int run_ilog_tests(void);

--- a/src/vos/tests/vts_io.c
+++ b/src/vos/tests/vts_io.c
@@ -336,7 +336,11 @@ io_akey_iterate(struct io_test_args *arg, vos_iter_param_t *param,
 	}
 
 	rc = vos_iter_probe(ih, NULL);
-	if (rc != 0 && rc != -DER_NONEXIST) {
+	if (rc == -DER_NONEXIST) {
+		rc = 0;
+		goto out;
+	}
+	if (rc != 0) {
 		print_error("Failed to set iterator cursor: %d\n", rc);
 		goto out;
 	}
@@ -415,13 +419,13 @@ io_obj_iter_test(struct io_test_args *arg, daos_epoch_range_t *epr,
 	}
 
 	rc = vos_iter_probe(ih, NULL);
-	if (rc != 0) {
+	if (rc != 0 && rc != -DER_NONEXIST) {
 		print_error("Failed to set iterator cursor: %d\n",
 			    rc);
 		goto out;
 	}
 
-	while (1) {
+	while (rc == 0) {
 		vos_iter_entry_t	ent;
 		daos_anchor_t		anchor;
 
@@ -445,8 +449,10 @@ io_obj_iter_test(struct io_test_args *arg, daos_epoch_range_t *epr,
 
 		nr++;
 		rc = vos_iter_next(ih);
-		if (rc == -DER_NONEXIST)
+		if (rc == -DER_NONEXIST) {
+			print_message("Finishing d-key iteration\n");
 			break;
+		}
 
 		if (rc != 0) {
 			print_error("Failed to move cursor: %d\n", rc);
@@ -472,6 +478,7 @@ io_obj_iter_test(struct io_test_args *arg, daos_epoch_range_t *epr,
 			goto out;
 		}
 	}
+	rc = 0;
  out:
 	vos_iter_finish(ih);
 	*num_dkeys = nr;
@@ -744,7 +751,7 @@ static inline int
 hold_objects(struct vos_object **objs, struct daos_lru_cache *occ,
 	     daos_handle_t *coh, daos_unit_oid_t *oid, int start, int end)
 {
-	int i = 0, rc = 0;
+	int	i = 0, rc = 0;
 
 	for (i = start; i < end; i++) {
 		rc = vos_obj_hold(occ, vos_hdl2cont(*coh), *oid, 1, true,
@@ -1588,209 +1595,6 @@ io_simple_punch(void **state)
 	 */
 	rc = io_update_and_fetch_dkey(arg, 10, 10);
 	assert_int_equal(rc, 0);
-}
-
-struct counts {
-	int	recx_nr;
-	int	obj_nr;
-	int	dkey_nr;
-	int	akey_nr;
-	int	akey_punch_nr;
-	int	dkey_punch_nr;
-};
-
-static int
-count_cb(daos_handle_t ih, vos_iter_entry_t *entry, vos_iter_type_t type,
-	 vos_iter_param_t *param, void *cb_arg, unsigned int *acts)
-{
-	struct counts	*counts = cb_arg;
-
-	switch (type) {
-	default:
-		break;
-	case VOS_ITER_DKEY:
-		counts->dkey_nr++;
-		if (entry->ie_key_punch)
-			counts->dkey_punch_nr++;
-		break;
-	case VOS_ITER_AKEY:
-		counts->akey_nr++;
-		if (entry->ie_key_punch)
-			counts->akey_punch_nr++;
-		break;
-	case VOS_ITER_RECX:
-		counts->recx_nr++;
-		break;
-	}
-
-	return 0;
-}
-
-static void
-punch_model_test(void **state)
-{
-	struct io_test_args	*arg = *state;
-	int			rc = 0;
-	daos_key_t		dkey;
-	daos_key_t		akey;
-	daos_recx_t		rex;
-	daos_iod_t		iod;
-	d_sg_list_t		sgl;
-	const char		*expected = "HelloWorld";
-	const char		*under = "HelloLonelyWorld";
-	char			buf[32] = {0};
-	char			dkey_buf[UPDATE_DKEY_SIZE];
-	char			akey_buf[UPDATE_AKEY_SIZE];
-	struct vos_iter_anchors	anchors = {0};
-	vos_iter_param_t	param = {0};
-	struct counts		counts = {0};
-	daos_unit_oid_t		oid;
-
-	memset(&rex, 0, sizeof(rex));
-	memset(&iod, 0, sizeof(iod));
-	D_INFO("punch model test\n");
-
-	/* Set up dkey and akey */
-	oid = gen_oid(arg->ofeat);
-	vts_key_gen(&dkey_buf[0], arg->dkey_size, true, arg);
-	vts_key_gen(&akey_buf[0], arg->akey_size, false, arg);
-	set_iov(&dkey, &dkey_buf[0], arg->ofeat & DAOS_OF_DKEY_UINT64);
-	set_iov(&akey, &akey_buf[0], arg->ofeat & DAOS_OF_AKEY_UINT64);
-
-	rex.rx_idx = 0;
-	rex.rx_nr = strlen(under);
-
-	iod.iod_type = DAOS_IOD_ARRAY;
-	iod.iod_size = 1;
-	iod.iod_name = akey;
-	iod.iod_recxs = &rex;
-	iod.iod_nr = 1;
-
-	/* Allocate memory for the scatter-gather list */
-	rc = daos_sgl_init(&sgl, 1);
-	assert_int_equal(rc, 0);
-
-	d_iov_set(&sgl.sg_iovs[0], (void *)under, strlen(under));
-
-	/* Write the original value (under) */
-	rc = vos_obj_update(arg->ctx.tc_co_hdl, oid, 1, 0, &dkey, 1, &iod,
-			    &sgl);
-	assert_int_equal(rc, 0);
-	/* Punch the akey */
-	rc = vos_obj_punch(arg->ctx.tc_co_hdl, oid, 2, 0, 0, &dkey, 1, &akey,
-			   NULL);
-	assert_int_equal(rc, 0);
-
-	/* Write the new value (expected) */
-	rex.rx_nr = strlen(expected);
-	d_iov_set(&sgl.sg_iovs[0], (void *)expected, strlen(expected));
-	rc = vos_obj_update(arg->ctx.tc_co_hdl, oid, 3, 0, &dkey, 1, &iod,
-			    &sgl);
-	assert_int_equal(rc, 0);
-
-	/* Now read back original # of bytes */
-	rex.rx_nr = strlen(under);
-	d_iov_set(&sgl.sg_iovs[0], (void *)buf, strlen(under));
-	rc = vos_obj_fetch(arg->ctx.tc_co_hdl, oid, 4, &dkey, 1, &iod, &sgl);
-	assert_int_equal(rc, 0);
-
-	assert_int_equal(strncmp(buf, expected, strlen(under)), 0);
-
-	/* Write the original value at latest epoch (under) */
-	d_iov_set(&sgl.sg_iovs[0], (void *)under, strlen(under));
-	rc = vos_obj_update(arg->ctx.tc_co_hdl, oid, 5, 0, &dkey, 1, &iod,
-			    &sgl);
-	assert_int_equal(rc, 0);
-	/* Punch the dkey */
-	rc = vos_obj_punch(arg->ctx.tc_co_hdl, oid, 6, 0, 0, &dkey, 0, NULL,
-			   NULL);
-	assert_int_equal(rc, 0);
-
-	/* Write the new value (expected) at latest epoch*/
-	rex.rx_nr = strlen(expected);
-	d_iov_set(&sgl.sg_iovs[0], (void *)expected, strlen(expected));
-	rc = vos_obj_update(arg->ctx.tc_co_hdl, oid, 7, 0, &dkey, 1, &iod,
-			    &sgl);
-	assert_int_equal(rc, 0);
-
-	memset(buf, 0, sizeof(buf));
-	/* Now read back original # of bytes */
-	rex.rx_nr = strlen(under);
-	d_iov_set(&sgl.sg_iovs[0], (void *)buf, strlen(under));
-	rc = vos_obj_fetch(arg->ctx.tc_co_hdl, oid, 8, &dkey, 1, &iod, &sgl);
-	assert_int_equal(rc, 0);
-
-	D_INFO("checking punch model test\n");
-	assert_int_equal(strncmp(buf, expected, strlen(under)), 0);
-
-	/* Write one more at 9 */
-	rex.rx_nr = strlen(expected);
-	d_iov_set(&sgl.sg_iovs[0], (void *)expected, strlen(expected));
-	rc = vos_obj_update(arg->ctx.tc_co_hdl, oid, 9, 0, &dkey, 1, &iod,
-			    &sgl);
-	assert_int_equal(rc, 0);
-
-	/** read old one for sanity */
-	memset(buf, 0, sizeof(buf));
-	rex.rx_nr = strlen(under);
-	d_iov_set(&sgl.sg_iovs[0], (void *)buf, strlen(under));
-	rc = vos_obj_fetch(arg->ctx.tc_co_hdl, oid, 5, &dkey, 1, &iod, &sgl);
-	assert_int_equal(rc, 0);
-	assert_int_equal(strncmp(buf, under, strlen(under)), 0);
-
-	/* Non recursive iteration first */
-	param.ip_hdl = arg->ctx.tc_co_hdl;
-	param.ip_ih = DAOS_HDL_INVAL;
-	param.ip_oid = oid;
-	param.ip_dkey = dkey;
-	param.ip_akey = akey;
-	param.ip_epr.epr_hi = 8;
-	param.ip_epr.epr_lo = 0;
-	rc = vos_iterate(&param, VOS_ITER_RECX, false, &anchors, count_cb,
-			 &counts);
-	assert_int_equal(rc, 0);
-	assert_int_equal(counts.recx_nr, 1);
-	assert_int_equal(counts.akey_nr, 0);
-	assert_int_equal(counts.dkey_nr, 0);
-
-	/* Now recurse at an epoch prior to punches */
-	memset(&counts, 0, sizeof(counts));
-	param.ip_hdl = arg->ctx.tc_co_hdl;
-	param.ip_ih = DAOS_HDL_INVAL;
-	d_iov_set(&param.ip_dkey, NULL, 0);
-	d_iov_set(&param.ip_akey, NULL, 0);
-	param.ip_epr.epr_hi = 1;
-	param.ip_epr.epr_lo = 0;
-	memset(&anchors, 0, sizeof(anchors));
-	rc = vos_iterate(&param, VOS_ITER_DKEY, true, &anchors, count_cb,
-			 &counts);
-	assert_int_equal(rc, 0);
-	assert_int_equal(counts.akey_nr, 1);
-	assert_int_equal(counts.dkey_nr, 1);
-	assert_int_equal(counts.akey_punch_nr, 1);
-	assert_int_equal(counts.dkey_punch_nr, 1);
-	assert_int_equal(counts.recx_nr, 1);
-
-	/* Now recurse including punched entries */
-	memset(&counts, 0, sizeof(counts));
-	param.ip_hdl = arg->ctx.tc_co_hdl;
-	param.ip_flags = VOS_IT_PUNCHED;
-	param.ip_ih = DAOS_HDL_INVAL;
-	param.ip_epr.epr_hi = 8;
-	param.ip_epr.epr_lo = 0;
-	memset(&anchors, 0, sizeof(anchors));
-	rc = vos_iterate(&param, VOS_ITER_DKEY, true, &anchors, count_cb,
-			 &counts);
-	assert_int_equal(rc, 0);
-	assert_int_equal(counts.akey_nr, 1);
-	assert_int_equal(counts.dkey_nr, 1);
-	assert_int_equal(counts.akey_punch_nr, 1);
-	assert_int_equal(counts.dkey_punch_nr, 1);
-	/* Five total extents but we are reading at epoch 8 */
-	assert_int_equal(counts.recx_nr, 4);
-
-	daos_sgl_fini(&sgl, false);
-	D_INFO("done punch model test\n");
 }
 
 static void
@@ -2658,7 +2462,6 @@ static const struct CMUnitTest io_tests[] = {
 		csum_fault_injection_multiple_extents_tests, NULL, NULL},
 	{ "VOS351: Checksum fault injection test : Single Value",
 		io_csum_fault_injection_single_value, NULL, NULL},
-	{ "VOS351: Simple punch model test", punch_model_test, NULL, NULL},
 };
 
 static const struct CMUnitTest int_tests[] = {

--- a/src/vos/tests/vts_pm.c
+++ b/src/vos/tests/vts_pm.c
@@ -1,0 +1,844 @@
+/**
+ * (C) Copyright 2019 Intel Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * GOVERNMENT LICENSE RIGHTS-OPEN SOURCE SOFTWARE
+ * The Government's rights to use, modify, reproduce, release, perform, display,
+ * or disclose this software are subject to the terms of the Apache License as
+ * provided in Contract No. B609815.
+ * Any reproduction of computer software, computer software documentation, or
+ * portions thereof marked with this legend must also reproduce the markings.
+ */
+/**
+ * This file is part of vos/tests/
+ *
+ * vos/tests/vts_pm.c
+ */
+#define D_LOGFAC	DD_FAC(tests)
+
+#include "vts_io.h"
+#include "vts_array.h"
+
+#define BUF_SIZE 2000
+static int buf_size = BUF_SIZE;
+struct pm_info {
+	daos_unit_oid_t	pi_oid;
+	daos_handle_t	pi_aoh;
+	daos_epoch_t	pi_epoch;
+	char		pi_fetch_buf[BUF_SIZE];
+	char		pi_update_buf[BUF_SIZE];
+	char		pi_fill_buf[BUF_SIZE];
+};
+
+
+static int
+pm_setup(void **state)
+{
+	struct io_test_args	*arg = *state;
+	struct pm_info		*info;
+	int			 rc;
+
+	arg->custom = NULL;
+
+	D_ALLOC_PTR(info);
+	if (info == NULL)
+		return -DER_NOMEM;
+
+	info->pi_epoch = 1;
+
+	rc = vts_array_alloc(arg->ctx.tc_co_hdl, info->pi_epoch,
+			     sizeof(int32_t), 0, 0, &info->pi_oid);
+	if (rc != 0)
+		goto fail;
+
+	memset(info->pi_fill_buf, 0xa, sizeof(info->pi_fill_buf));
+
+	rc = vts_array_open(arg->ctx.tc_co_hdl, info->pi_oid, &info->pi_aoh);
+	if (rc == 0) {
+		arg->custom = info;
+		return 0;
+	}
+
+	vts_array_free(arg->ctx.tc_co_hdl, info->pi_oid);
+fail:
+	D_FREE(info);
+	return rc;
+}
+
+static int
+pm_teardown(void **state)
+{
+	struct io_test_args	*arg = *state;
+	struct pm_info		*info = arg->custom;
+
+	vts_array_close(info->pi_aoh);
+	vts_array_free(arg->ctx.tc_co_hdl, info->pi_oid);
+
+	D_FREE(info);
+
+	return 0;
+}
+
+struct counts {
+	int num_objs;
+	int num_punched_objs;
+	int num_dkeys;
+	int num_punched_dkeys;
+	int num_akeys;
+	int num_punched_akeys;
+	int num_recx;
+	int num_punched_recx;
+};
+
+static int
+count_cb(daos_handle_t ih, vos_iter_entry_t *entry, vos_iter_type_t type,
+	 vos_iter_param_t *param, void *cb_arg, unsigned int *acts)
+{
+	struct counts	*counts = cb_arg;
+
+	switch (type) {
+	default:
+		break;
+	case VOS_ITER_DKEY:
+		counts->num_dkeys++;
+		if (entry->ie_key_punch)
+			counts->num_punched_dkeys++;
+		break;
+	case VOS_ITER_AKEY:
+		counts->num_akeys++;
+		if (entry->ie_key_punch)
+			counts->num_punched_akeys++;
+		break;
+	case VOS_ITER_RECX:
+		counts->num_recx++;
+		if (bio_addr_is_hole(&entry->ie_biov.bi_addr))
+			counts->num_punched_recx++;
+		break;
+	case VOS_ITER_OBJ:
+		counts->num_objs++;
+		if (entry->ie_obj_punch)
+			counts->num_punched_objs++;
+		break;
+	}
+
+	return 0;
+}
+
+static void
+vos_check(void **state, vos_iter_param_t *param, vos_iter_type_t type,
+	  const struct counts *expected)
+{
+	struct counts		 counts = {0};
+	struct vos_iter_anchors	 anchors = {0};
+	int			 rc;
+
+	rc = vos_iterate(param, type, true, &anchors, count_cb, &counts);
+	assert_int_equal(rc, 0);
+	/*
+	 * Enable these checks with punch model change
+	assert_int_equal(expected->num_objs, counts.num_objs);
+	assert_int_equal(expected->num_dkeys, counts.num_dkeys);
+	assert_int_equal(expected->num_akeys, counts.num_akeys);
+	assert_int_equal(expected->num_recx, counts.num_recx);
+	assert_int_equal(expected->num_punched_objs, counts.num_punched_objs);
+	assert_int_equal(expected->num_punched_dkeys, counts.num_punched_dkeys);
+	assert_int_equal(expected->num_punched_akeys, counts.num_punched_akeys);
+	assert_int_equal(expected->num_punched_recx, counts.num_punched_recx);
+	*/
+}
+
+static void
+vos_check_obj(void **state, daos_epoch_t epoch, int flags, int objs,
+	      int punched_objs, int dkeys, int punched_dkeys, int akeys,
+	      int punched_akeys, int recxs, int punched_recx)
+{
+	struct io_test_args	*arg = *state;
+	vos_iter_param_t	 param = {0};
+	struct counts		 counts = {0};
+
+	param.ip_hdl = arg->ctx.tc_co_hdl;
+	param.ip_flags = flags;
+	param.ip_ih = DAOS_HDL_INVAL;
+	param.ip_epr.epr_hi = epoch;
+	param.ip_epr.epr_lo = 0;
+	counts.num_objs = objs;
+	counts.num_dkeys = dkeys;
+	counts.num_akeys = akeys;
+	counts.num_recx = recxs;
+	counts.num_punched_objs = punched_objs;
+	counts.num_punched_dkeys = punched_dkeys;
+	counts.num_punched_akeys = punched_akeys;
+	counts.num_punched_recx = punched_recx;
+
+	vos_check(state, &param, VOS_ITER_OBJ, &counts);
+}
+
+static void
+vos_check_dkey(void **state, daos_epoch_t epoch, int flags, daos_unit_oid_t oid,
+	       int dkeys, int punched_dkeys, int akeys, int punched_akeys,
+	       int recxs, int punched_recx)
+{
+	struct io_test_args	*arg = *state;
+	vos_iter_param_t	 param = {0};
+	struct counts		 counts = {0};
+
+	param.ip_hdl = arg->ctx.tc_co_hdl;
+	param.ip_flags = flags;
+	param.ip_ih = DAOS_HDL_INVAL;
+	param.ip_epr.epr_hi = epoch;
+	param.ip_epr.epr_lo = 0;
+	param.ip_oid = oid;
+	counts.num_dkeys = dkeys;
+	counts.num_akeys = akeys;
+	counts.num_recx = recxs;
+	counts.num_punched_dkeys = punched_dkeys;
+	counts.num_punched_akeys = punched_akeys;
+	counts.num_punched_recx = punched_recx;
+
+	vos_check(state, &param, VOS_ITER_DKEY, &counts);
+}
+
+static void
+vos_check_akey(void **state, daos_epoch_t epoch, int flags, daos_unit_oid_t oid,
+	       daos_key_t *dkey, int akeys, int punched_akeys, int recxs,
+	       int punched_recx)
+{
+	struct io_test_args	*arg = *state;
+	vos_iter_param_t	 param = {0};
+	struct counts		 counts = {0};
+
+	param.ip_hdl = arg->ctx.tc_co_hdl;
+	param.ip_flags = flags;
+	param.ip_ih = DAOS_HDL_INVAL;
+	param.ip_epr.epr_hi = epoch;
+	param.ip_epr.epr_lo = 0;
+	param.ip_oid = oid;
+	param.ip_dkey = *dkey;
+	counts.num_akeys = akeys;
+	counts.num_recx = recxs;
+	counts.num_punched_akeys = punched_akeys;
+	counts.num_punched_recx = punched_recx;
+
+	vos_check(state, &param, VOS_ITER_AKEY, &counts);
+}
+
+static void
+vos_check_recx(void **state, daos_epoch_t epoch, int flags, daos_unit_oid_t oid,
+	       daos_key_t *dkey, daos_key_t *akey, int recxs, int punched_recx)
+{
+	struct io_test_args	*arg = *state;
+	vos_iter_param_t	 param = {0};
+	struct counts		 counts = {0};
+
+	param.ip_hdl = arg->ctx.tc_co_hdl;
+	param.ip_flags = flags;
+	param.ip_ih = DAOS_HDL_INVAL;
+	param.ip_epr.epr_hi = epoch;
+	param.ip_epr.epr_lo = 0;
+	param.ip_oid = oid;
+	param.ip_dkey = *dkey;
+	param.ip_akey = *akey;
+	counts.num_recx = recxs;
+	counts.num_punched_recx = punched_recx;
+
+	vos_check(state, &param, VOS_ITER_RECX, &counts);
+}
+
+static void
+array_set_get_size(void **state)
+{
+	struct io_test_args	*arg = *state;
+	struct pm_info		*info = arg->custom;
+	size_t			 size;
+	int			 rc;
+	int			 flags;
+
+	rc = vts_array_set_size(info->pi_aoh, 2, 1000);
+	assert_int_equal(rc, 0);
+
+	rc = vts_array_get_size(info->pi_aoh, 3, &size);
+	assert_int_equal(rc, 0);
+	assert_int_equal(size, 1000);
+
+	rc = vts_array_set_size(info->pi_aoh, 4, 5);
+	assert_int_equal(rc, 0);
+
+	rc = vts_array_get_size(info->pi_aoh, 5, &size);
+	assert_int_equal(rc, 0);
+	assert_int_equal(size, 5);
+
+	rc = vts_array_reset(&info->pi_aoh, 6, 7, 1, 0, 0);
+	assert_int_equal(rc, 0);
+
+	rc = vts_array_get_size(info->pi_aoh, 8, &size);
+	assert_int_equal(rc, 0);
+	assert_int_equal(size, 0);
+
+	flags = VOS_IT_EPC_RR | VOS_IT_RECX_VISIBLE;
+	vos_check_obj(state, 9, flags, 1, 0, 1, 0, 1, 0, 0, 0);
+	vos_check_obj(state, 3, flags, 1, 1, 2, 1, 2, 0, 1, 0);
+	vos_check_obj(state, 5, flags, 1, 1, 2, 0, 2, 0, 2, 1);
+}
+
+static void
+array_size_write(void **state)
+{
+	struct io_test_args	*arg = *state;
+	struct pm_info		*info = arg->custom;
+	uint64_t		 start_size;
+	uint64_t		 punch_size;
+	uint64_t		 per_key = 3;
+	uint64_t		 akey_size = 5;
+	daos_epoch_t		 epoch = 10;
+	int			 rc;
+	int			 i;
+
+	rc = vts_array_reset(&info->pi_aoh, epoch, epoch + 1, 1, 2, 1);
+	epoch += 2;
+
+	memset(info->pi_update_buf, 'x', BUF_SIZE);
+
+	for (i = 0; i < 5; i++) {
+		for (start_size = BUF_SIZE, punch_size = 0;
+		     punch_size < start_size;
+		     start_size -= 11, punch_size += 53) {
+			rc = vts_array_write(info->pi_aoh, epoch++, 0,
+					     start_size, info->pi_update_buf);
+			assert_int_equal(rc, 0);
+
+			memcpy(info->pi_fetch_buf, info->pi_fill_buf, BUF_SIZE);
+			rc = vts_array_read(info->pi_aoh, epoch++, 0, BUF_SIZE,
+					    info->pi_fetch_buf);
+			assert_int_equal(rc, 0);
+			assert_memory_equal(info->pi_fetch_buf,
+					    info->pi_update_buf, start_size);
+			assert_memory_equal(info->pi_fetch_buf + start_size,
+					    info->pi_fill_buf,
+					    BUF_SIZE - start_size);
+
+			rc = vts_array_set_size(info->pi_aoh, epoch++,
+						punch_size);
+			assert_int_equal(rc, 0);
+
+			memcpy(info->pi_fetch_buf, info->pi_fill_buf, BUF_SIZE);
+			rc = vts_array_read(info->pi_aoh, epoch++, 0, BUF_SIZE,
+					    info->pi_fetch_buf);
+			assert_int_equal(rc, 0);
+			assert_memory_equal(info->pi_fetch_buf,
+					    info->pi_update_buf, punch_size);
+			assert_memory_equal(info->pi_fetch_buf + punch_size,
+					    info->pi_fill_buf,
+					    BUF_SIZE - punch_size);
+		}
+
+		rc = vts_array_reset(&info->pi_aoh, epoch, epoch + 1, 1,
+				     per_key, akey_size);
+		per_key += 11;
+		akey_size += 7;
+		epoch += 2;
+	}
+}
+
+/* User fills update buffer, after finished, fetch buffer should have identical
+ * contents.
+ */
+static void
+array_read_write_punch_size(void **state, daos_epoch_t epc_in,
+			    daos_epoch_t *epc_out, bool punch, int iter,
+			    size_t rec_size, size_t max_elem, int inc)
+{
+	struct io_test_args	*arg = *state;
+	struct pm_info		*info = arg->custom;
+	daos_epoch_t		 epoch = epc_in;
+	daos_size_t		 size;
+	uint64_t		 per_key = 5;
+	uint64_t		 akey_size = 1;
+	uint64_t		 new_size = 7;
+	int			 rc;
+	int			 div = 2;
+	int			 i;
+
+	rc = vts_array_reset(&info->pi_aoh, epoch, epoch + 1, rec_size,
+			     per_key, akey_size);
+	assert_int_equal(rc, 0);
+	epoch += 2;
+
+	per_key += inc;
+	akey_size += inc;
+
+	for (i = 0; i < iter; i++) {
+		rc = vts_array_write(info->pi_aoh, epoch++, 0, max_elem,
+				     info->pi_update_buf);
+		assert_int_equal(rc, 0);
+
+		rc = vts_array_get_size(info->pi_aoh, epoch++, &size);
+		assert_int_equal(rc, 0);
+		assert_int_equal(size, max_elem);
+
+		memset(info->pi_fetch_buf, 0xa, max_elem * rec_size);
+		rc = vts_array_read(info->pi_aoh, epoch++, 0, max_elem,
+				    info->pi_fetch_buf);
+		assert_int_equal(rc, 0);
+		assert_memory_equal(info->pi_update_buf, info->pi_fetch_buf,
+				    max_elem * rec_size);
+
+		rc = vts_array_set_size(info->pi_aoh, epoch++, new_size);
+		assert_int_equal(rc, 0);
+
+		memset(info->pi_fetch_buf, 0xa, max_elem * rec_size);
+		rc = vts_array_read(info->pi_aoh, epoch++, 0, max_elem,
+				    info->pi_fetch_buf);
+		assert_int_equal(rc, 0);
+		assert_memory_equal(info->pi_update_buf, info->pi_fetch_buf,
+				    new_size * rec_size);
+		assert_memory_equal(info->pi_fetch_buf + (rec_size * new_size),
+				    info->pi_fill_buf,
+				    (max_elem - new_size) * rec_size);
+
+		rc = vts_array_get_size(info->pi_aoh, epoch++, &size);
+		assert_int_equal(rc, 0);
+		assert_int_equal(size, new_size);
+
+		new_size++;
+		if (!punch)
+			continue;
+
+		rc = vts_array_reset(&info->pi_aoh, epoch, epoch + 1,
+				     rec_size, per_key, akey_size);
+		assert_int_equal(rc, 0);
+		epoch += 2;
+		per_key += inc;
+		akey_size += inc;
+
+		rc = vts_array_set_iosize(info->pi_aoh, per_key / div);
+		div++;
+
+		rc = vts_array_get_size(info->pi_aoh, epoch++, &size);
+		assert_int_equal(rc, 0);
+		assert_int_equal(size, 0);
+
+	}
+
+	/* Now make sure fetch buf == update buf by writing again and reading */
+	rc = vts_array_write(info->pi_aoh, epoch++, 0, max_elem,
+			     info->pi_update_buf);
+	assert_int_equal(rc, 0);
+
+	memset(info->pi_fetch_buf, 0xa, max_elem * rec_size);
+	rc = vts_array_read(info->pi_aoh, epoch++, 0, max_elem,
+			    info->pi_fetch_buf);
+	assert_int_equal(rc, 0);
+
+	*epc_out = epoch;
+}
+
+static void
+array_1(void **state)
+{
+	struct io_test_args	*arg = *state;
+	struct pm_info		*info = arg->custom;
+	int32_t			*fetch_buf = (int32_t *)info->pi_fetch_buf;
+	int32_t			*update_buf = (int32_t *)info->pi_update_buf;
+	daos_epoch_t		 epoch = 0;
+	int			 max_elem = buf_size / sizeof(int32_t);
+	int			 i;
+
+	/** Setup initial input */
+	for (i = 0; i < max_elem; i++)
+		update_buf[i] = i;
+
+	array_read_write_punch_size(state, 2, &epoch, true, 10,
+				    sizeof(int32_t), max_elem, 1);
+
+	assert_memory_equal(update_buf, fetch_buf,
+			    sizeof(update_buf[0]) * max_elem);
+
+	/** Change up the input array */
+	for (i = 0; i < max_elem; i++)
+		update_buf[i] = i + 1;
+
+	/* Run it again without the punches */
+	array_read_write_punch_size(state, epoch, &epoch, false, 10,
+				    sizeof(int32_t), max_elem, 1);
+
+	assert_memory_equal(update_buf, fetch_buf,
+			    sizeof(update_buf[0]) * max_elem);
+}
+
+static void
+array_2(void **state)
+{
+	struct io_test_args	*arg = *state;
+	struct pm_info		*info = arg->custom;
+	char			*fetch_buf = (char *)info->pi_fetch_buf;
+	char			*update_buf = (char *)info->pi_update_buf;
+	daos_epoch_t		 epoch = 0;
+	int			 max_elem = buf_size / sizeof(char);
+	int			 i;
+
+	/** Setup initial input */
+	for (i = 0; i < max_elem; i++)
+		update_buf[i] = i % 26 + 'a';
+
+	array_read_write_punch_size(state, 2, &epoch, true, 10,
+				    sizeof(char), max_elem, 1);
+
+	assert_memory_equal(update_buf, fetch_buf,
+			    sizeof(update_buf[0]) * max_elem);
+
+	/** Change up the input array */
+	for (i = 0; i < max_elem; i++)
+		update_buf[i] = (i + 1) % 26 + 'a';
+
+	/* Run it again without the punches */
+	array_read_write_punch_size(state, epoch, &epoch, false, 10,
+				    sizeof(char), max_elem, 1);
+
+	assert_memory_equal(update_buf, fetch_buf,
+			    sizeof(update_buf[0]) * max_elem);
+}
+
+static void
+array_3(void **state)
+{
+	struct io_test_args	*arg = *state;
+	struct pm_info		*info = arg->custom;
+	int32_t			*fetch_buf = (int32_t *)info->pi_fetch_buf;
+	int32_t			*update_buf = (int32_t *)info->pi_update_buf;
+	daos_epoch_t		 epoch = 0;
+	int			 max_elem = buf_size / sizeof(int32_t);
+	int			 i;
+
+	/** Setup initial input */
+	for (i = 0; i < max_elem; i++)
+		update_buf[i] = i;
+
+	array_read_write_punch_size(state, 2, &epoch, true, 10,
+				    sizeof(int32_t), max_elem, 0);
+
+	assert_memory_equal(update_buf, fetch_buf,
+			    sizeof(update_buf[0]) * max_elem);
+
+	/** Change up the input array */
+	for (i = 0; i < max_elem; i++)
+		update_buf[i] = i + 1;
+
+	/* Run it again without the punches */
+	array_read_write_punch_size(state, epoch, &epoch, false, 10,
+				    sizeof(int32_t), max_elem, 0);
+
+	assert_memory_equal(update_buf, fetch_buf,
+			    sizeof(update_buf[0]) * max_elem);
+}
+
+static void
+array_4(void **state)
+{
+	struct io_test_args	*arg = *state;
+	struct pm_info		*info = arg->custom;
+	char			*fetch_buf = (char *)info->pi_fetch_buf;
+	char			*update_buf = (char *)info->pi_update_buf;
+	daos_epoch_t		 epoch = 0;
+	int			 max_elem = buf_size / sizeof(char);
+	int			 i;
+
+	/** Setup initial input */
+	for (i = 0; i < max_elem; i++)
+		update_buf[i] = i % 26 + 'a';
+
+	array_read_write_punch_size(state, 2, &epoch, true, 10,
+				    sizeof(char), max_elem, 0);
+
+	assert_memory_equal(update_buf, fetch_buf,
+			    sizeof(update_buf[0]) * max_elem);
+
+	/** Change up the input array */
+	for (i = 0; i < max_elem; i++)
+		update_buf[i] = (i + 1) % 26 + 'a';
+
+	/* Run it again without the punches */
+	array_read_write_punch_size(state, epoch, &epoch, false, 10,
+				    sizeof(char), max_elem, 0);
+
+	assert_memory_equal(update_buf, fetch_buf,
+			    sizeof(update_buf[0]) * max_elem);
+}
+
+
+static void
+punch_model_test(void **state)
+{
+	struct io_test_args	*arg = *state;
+	int			rc = 0;
+	daos_key_t		dkey;
+	daos_key_t		akey;
+	daos_recx_t		rex;
+	daos_iod_t		iod;
+	d_sg_list_t		sgl;
+	const char		*expected = "HelloWorld";
+	const char		*under = "HelloLonelyWorld";
+	const char		*latest = "Goodbye";
+	char			buf[32] = {0};
+	char			dkey_buf[UPDATE_DKEY_SIZE];
+	char			akey_buf[UPDATE_AKEY_SIZE];
+	daos_unit_oid_t		oid;
+
+	test_args_reset(arg, VPOOL_SIZE);
+
+	memset(&rex, 0, sizeof(rex));
+	memset(&iod, 0, sizeof(iod));
+
+	/* Set up dkey and akey */
+	oid = gen_oid(arg->ofeat);
+	vts_key_gen(&dkey_buf[0], arg->dkey_size, true, arg);
+	vts_key_gen(&akey_buf[0], arg->akey_size, false, arg);
+	set_iov(&dkey, &dkey_buf[0], arg->ofeat & DAOS_OF_DKEY_UINT64);
+	set_iov(&akey, &akey_buf[0], arg->ofeat & DAOS_OF_AKEY_UINT64);
+
+	rex.rx_idx = 0;
+	rex.rx_nr = strlen(under);
+
+	iod.iod_type = DAOS_IOD_ARRAY;
+	iod.iod_size = 1;
+	iod.iod_name = akey;
+	iod.iod_recxs = &rex;
+	iod.iod_nr = 1;
+
+	/* Allocate memory for the scatter-gather list */
+	rc = daos_sgl_init(&sgl, 1);
+	assert_int_equal(rc, 0);
+
+	d_iov_set(&sgl.sg_iovs[0], (void *)under, strlen(under));
+
+	/* Write the original value (under) */
+	rc = vos_obj_update(arg->ctx.tc_co_hdl, oid, 1, 0, &dkey, 1, &iod,
+			    &sgl);
+	assert_int_equal(rc, 0);
+	/* Punch the akey */
+	rc = vos_obj_punch(arg->ctx.tc_co_hdl, oid, 2, 0, 0, &dkey, 1, &akey,
+			   NULL);
+	assert_int_equal(rc, 0);
+
+	/* Write the new value (expected) */
+	rex.rx_nr = strlen(expected);
+	d_iov_set(&sgl.sg_iovs[0], (void *)expected, strlen(expected));
+	rc = vos_obj_update(arg->ctx.tc_co_hdl, oid, 3, 0, &dkey, 1, &iod,
+			    &sgl);
+	assert_int_equal(rc, 0);
+
+	/* Now read back original # of bytes */
+	rex.rx_nr = strlen(under);
+	d_iov_set(&sgl.sg_iovs[0], (void *)buf, strlen(under));
+	rc = vos_obj_fetch(arg->ctx.tc_co_hdl, oid, 4, &dkey, 1, &iod, &sgl);
+	assert_int_equal(rc, 0);
+
+	assert_int_equal(strncmp(buf, expected, strlen(under)), 0);
+
+	/* Write the original value at latest epoch (under) */
+	d_iov_set(&sgl.sg_iovs[0], (void *)under, strlen(under));
+	rc = vos_obj_update(arg->ctx.tc_co_hdl, oid, 5, 0, &dkey, 1, &iod,
+			    &sgl);
+	assert_int_equal(rc, 0);
+	/* Punch the dkey */
+	rc = vos_obj_punch(arg->ctx.tc_co_hdl, oid, 6, 0, 0, &dkey, 0, NULL,
+			   NULL);
+	assert_int_equal(rc, 0);
+
+	/* Write the new value (expected) at latest epoch*/
+	rex.rx_nr = strlen(expected);
+	d_iov_set(&sgl.sg_iovs[0], (void *)expected, strlen(expected));
+	rc = vos_obj_update(arg->ctx.tc_co_hdl, oid, 7, 0, &dkey, 1, &iod,
+			    &sgl);
+	assert_int_equal(rc, 0);
+
+	memset(buf, 0, sizeof(buf));
+	/* Now read back original # of bytes */
+	rex.rx_nr = strlen(under);
+	d_iov_set(&sgl.sg_iovs[0], (void *)buf, strlen(under));
+	rc = vos_obj_fetch(arg->ctx.tc_co_hdl, oid, 8, &dkey, 1, &iod, &sgl);
+	assert_int_equal(rc, 0);
+
+	assert_int_equal(strncmp(buf, expected, strlen(under)), 0);
+
+	/* Write one more at 9 */
+	rex.rx_nr = strlen(expected);
+	d_iov_set(&sgl.sg_iovs[0], (void *)expected, strlen(expected));
+	rc = vos_obj_update(arg->ctx.tc_co_hdl, oid, 9, 0, &dkey, 1, &iod,
+			    &sgl);
+	assert_int_equal(rc, 0);
+
+	/* Punch the object at 10 */
+	rc = vos_obj_punch(arg->ctx.tc_co_hdl, oid, 10, 0, 0, NULL, 0, NULL,
+			   NULL);
+	assert_int_equal(rc, 0);
+
+	/* Write one more at 11 */
+	rex.rx_nr = strlen(latest);
+	d_iov_set(&sgl.sg_iovs[0], (void *)latest, strlen(latest));
+	rc = vos_obj_update(arg->ctx.tc_co_hdl, oid, 11, 0, &dkey, 1, &iod,
+			    &sgl);
+	assert_int_equal(rc, 0);
+
+	/** read old one for sanity */
+	memset(buf, 0, sizeof(buf));
+	rex.rx_nr = strlen(under);
+	d_iov_set(&sgl.sg_iovs[0], (void *)buf, strlen(under));
+	rc = vos_obj_fetch(arg->ctx.tc_co_hdl, oid, 5, &dkey, 1, &iod, &sgl);
+	assert_int_equal(rc, 0);
+	assert_int_equal(strncmp(buf, under, strlen(under)), 0);
+
+	/* Non recursive iteration first */
+	vos_check_recx(state, 8, 0, oid, &dkey, &akey, 1, 0);
+
+	(void)vos_check_akey; /* For now, unused. Reference to avoid warning */
+
+	/* Now recurse at an epoch prior to punches */
+	vos_check_dkey(state, 1, 0, oid, 1, 1, 1, 1, 1, 0);
+
+	/* Now recurse including punched entries */
+	vos_check_dkey(state, 8, VOS_IT_PUNCHED, oid, 1, 0, 1, 0, 4, 0);
+
+	/* Now recurse after punch, not including punched entries */
+	vos_check_obj(state, 10, 0, 0, 0, 0, 0, 0, 0, 0, 0);
+
+	/* Now recurse including punched entries after object punch */
+	vos_check_obj(state, 10, VOS_IT_PUNCHED, 1, 0, 1, 0, 1, 0, 5, 0);
+
+	/* Now recurse visible entries at 11 */
+	vos_check_obj(state, 11, 0, 1, 0, 1, 0, 1, 0, 1, 0);
+
+	/** Read the value at 11 */
+	memset(buf, 0, sizeof(buf));
+	rex.rx_nr = strlen(under);
+	d_iov_set(&sgl.sg_iovs[0], (void *)buf, strlen(under));
+	rc = vos_obj_fetch(arg->ctx.tc_co_hdl, oid, 11, &dkey, 1, &iod, &sgl);
+	assert_int_equal(rc, 0);
+	assert_int_equal(sgl.sg_iovs[0].iov_len, strlen(latest));
+	assert_int_equal(strncmp(buf, latest, strlen(latest)), 0);
+
+	daos_sgl_fini(&sgl, false);
+
+	rc = vos_obj_query_key(arg->ctx.tc_co_hdl, oid,
+			       DAOS_GET_RECX | DAOS_GET_MAX,
+			       11, &dkey, &akey, &rex);
+	assert_int_equal(rc, 0);
+	assert_int_equal(rex.rx_idx, 0);
+	assert_int_equal(rex.rx_nr, strlen(latest));
+}
+
+static void
+simple_multi_update(void **state)
+{
+	struct io_test_args	*arg = *state;
+	int			rc = 0;
+	daos_key_t		dkey;
+	daos_iod_t		iod[2] = {0};
+	d_sg_list_t		sgl[2] = {0};
+	const char		*values[2] = {"HelloWorld", "HelloLonelyWorld"};
+	const char		*overwrite[2] = {"ByeWorld", "ByeLonelyWorld"};
+	uint8_t			dkey_val = 0;
+	char			akey[2] = {'a', 'b'};
+	char			buf[2][32] = {0};
+	daos_unit_oid_t		oid;
+	int			i;
+
+	test_args_reset(arg, VPOOL_SIZE);
+
+	memset(iod, 0, sizeof(iod));
+
+	/* Set up dkey and akey */
+	oid = gen_oid(0);
+	d_iov_set(&dkey, &dkey_val, sizeof(dkey_val));
+
+	for (i = 0; i < 2; i++) {
+		rc = daos_sgl_init(&sgl[i], 1);
+		assert_int_equal(rc, 0);
+		iod[i].iod_type = DAOS_IOD_SINGLE;
+		iod[i].iod_size = strlen(values[i]) + 1;
+		d_iov_set(&sgl[i].sg_iovs[0], (void *)values[i],
+			  strlen(values[i]) + 1);
+		d_iov_set(&iod[i].iod_name, &akey[i], sizeof(akey[i]));
+		iod[i].iod_nr = 1;
+		iod[i].iod_recxs = NULL;
+	}
+
+	rc = vos_obj_update(arg->ctx.tc_co_hdl, oid, 1, 0, &dkey, 2, iod, sgl);
+	assert_int_equal(rc, 0);
+
+	for (i = 0; i < 2; i++) {
+		iod[i].iod_size = 0; /* size fetch */
+		d_iov_set(&sgl[i].sg_iovs[0], (void *)buf[i], sizeof(buf[i]));
+	}
+
+	rc = vos_obj_fetch(arg->ctx.tc_co_hdl, oid, 1, &dkey, 2, iod, sgl);
+	assert_int_equal(rc, 0);
+
+	for (i = 0; i < 2; i++) {
+		assert_true(iod[i].iod_size == (strlen(values[i]) + 1));
+		assert_memory_equal(buf[i], values[i], strlen(values[i]) + 1);
+		/* Setup next update */
+		iod[i].iod_size = strlen(overwrite[i]) + 1;
+		d_iov_set(&sgl[i].sg_iovs[0], (void *)overwrite[i],
+			  strlen(overwrite[i]) + 1);
+	}
+
+	rc = vos_obj_punch(arg->ctx.tc_co_hdl, oid, 2, 0, 0, NULL, 0, NULL,
+			   NULL);
+	assert_int_equal(rc, 0);
+
+	rc = vos_obj_update(arg->ctx.tc_co_hdl, oid, 1, 0, &dkey, 2, iod, sgl);
+	assert_int_equal(rc, 0);
+
+	for (i = 0; i < 2; i++) {
+		iod[i].iod_size = 0; /* size fetch */
+		d_iov_set(&sgl[i].sg_iovs[0], (void *)buf[i], sizeof(buf[i]));
+	}
+
+	rc = vos_obj_fetch(arg->ctx.tc_co_hdl, oid, 1, &dkey, 2, iod, sgl);
+	assert_int_equal(rc, 0);
+
+	for (i = 0; i < 2; i++) {
+		assert_true(iod[i].iod_size == (strlen(overwrite[i]) + 1));
+		assert_memory_equal(buf[i], overwrite[i],
+				    strlen(overwrite[i]) + 1);
+		daos_sgl_fini(&sgl[i], false);
+	}
+}
+
+static const struct CMUnitTest punch_model_tests[] = {
+	{ "VOS800: VOS punch model array set/get size",
+	  array_set_get_size, pm_setup, pm_teardown },
+	{ "VOS801: VOS punch model array read/write/punch int32_t",
+	  array_1, pm_setup, pm_teardown },
+	{ "VOS802: VOS punch model array read/write/punch char",
+	  array_2, pm_setup, pm_teardown },
+	{ "VOS803: VOS punch model array read/write/punch int32_t static",
+	  array_3, pm_setup, pm_teardown },
+	{ "VOS804: VOS punch model array read/write/punch char static",
+	  array_4, pm_setup, pm_teardown },
+	{ "VOS805: Simple punch model test", punch_model_test, NULL, NULL},
+	{ "VOS806: Multi update", simple_multi_update, NULL, NULL},
+	{ "VOS807: Array Set/get size, write, punch",
+	  array_size_write, pm_setup, pm_teardown },
+};
+
+int
+run_pm_tests(void)
+{
+	if (RUNNING_ON_VALGRIND)
+		buf_size = 100;
+	return cmocka_run_group_tests_name("VOS Punch Model tests",
+					   punch_model_tests, setup_io,
+					   teardown_io);
+}


### PR DESCRIPTION
This adds a new vts_array library to mimic the daos_array
API at the VOS level or at least to mimic the operations
that API causes to occur in VOS.

Signed-off-by: Jeff Olivier <jeffrey.v.olivier@intel.com>