### PR TITLE
DAOS-647 dmg: Use AccessControlList structure

### DIFF
--- a/src/control/client/connect_test.go
+++ b/src/control/client/connect_test.go
@@ -345,14 +345,14 @@ func TestPoolGetACL(t *testing.T) {
 		"success": {
 			addr:             MockServers,
 			getACLRespStatus: 0,
-			expectedResp:     &PoolGetACLResp{ACL: MockACL.acl},
+			expectedResp:     &PoolGetACLResp{ACL: MockACL.ACL()},
 			expectedErr:      "",
 		},
 	} {
 		t.Run(name, func(t *testing.T) {
 			var expectedACL []string
 			if tt.expectedResp != nil {
-				expectedACL = tt.expectedResp.ACL
+				expectedACL = tt.expectedResp.ACL.Entries
 			}
 			aclResult := &mockGetACLResult{
 				acl:    expectedACL,

--- a/src/control/client/mocks.go
+++ b/src/control/client/mocks.go
@@ -278,6 +278,13 @@ type mockGetACLResult struct {
 	err    error
 }
 
+// ACL returns a properly formed AccessControlList from the mock data
+func (m *mockGetACLResult) ACL() *AccessControlList {
+	return &AccessControlList{
+		Entries: m.acl,
+	}
+}
+
 type mockMgmtSvcClient struct {
 	getACLRet *mockGetACLResult
 }

--- a/src/control/client/pool.go
+++ b/src/control/client/pool.go
@@ -40,13 +40,13 @@ type PoolCreateReq struct {
 	Sys        string
 	Usr        string
 	Grp        string
-	Acl        []string
-	Uuid       string
+	ACL        *AccessControlList
+	UUID       string
 }
 
 // PoolCreateResp struct contains response
 type PoolCreateResp struct {
-	Uuid    string
+	UUID    string
 	SvcReps string
 }
 
@@ -70,7 +70,11 @@ func (c *connList) PoolCreate(req *PoolCreateReq) (*PoolCreateResp, error) {
 	rpcReq := &mgmtpb.PoolCreateReq{
 		Scmbytes: req.ScmBytes, Nvmebytes: req.NvmeBytes, Ranks: req.RankList,
 		Numsvcreps: req.NumSvcReps, Sys: req.Sys, User: req.Usr,
-		Usergroup: req.Grp, Acl: req.Acl, Uuid: poolUUIDStr,
+		Usergroup: req.Grp, Uuid: poolUUIDStr,
+	}
+
+	if req.ACL != nil {
+		rpcReq.Acl = req.ACL.Entries
 	}
 
 	c.log.Debugf("Create DAOS pool request: %s\n", rpcReq)
@@ -87,12 +91,12 @@ func (c *connList) PoolCreate(req *PoolCreateReq) (*PoolCreateResp, error) {
 			rpcResp.GetStatus())
 	}
 
-	return &PoolCreateResp{Uuid: poolUUIDStr, SvcReps: rpcResp.GetSvcreps()}, nil
+	return &PoolCreateResp{UUID: poolUUIDStr, SvcReps: rpcResp.GetSvcreps()}, nil
 }
 
 // PoolDestroyReq struct contains request
 type PoolDestroyReq struct {
-	Uuid  string
+	UUID  string
 	Force bool
 }
 
@@ -108,7 +112,7 @@ func (c *connList) PoolDestroy(req *PoolDestroyReq) error {
 		return err
 	}
 
-	rpcReq := &mgmtpb.PoolDestroyReq{Uuid: req.Uuid, Force: req.Force}
+	rpcReq := &mgmtpb.PoolDestroyReq{Uuid: req.UUID, Force: req.Force}
 
 	c.log.Debugf("Destroy DAOS pool request: %s\n", rpcReq)
 
@@ -134,7 +138,7 @@ type PoolGetACLReq struct {
 
 // PoolGetACLResp contains the output results for PoolGetACL
 type PoolGetACLResp struct {
-	ACL []string // Access Control Entries in string format
+	ACL *AccessControlList
 }
 
 // PoolGetACL gets the Access Control List for the pool.
@@ -161,6 +165,6 @@ func (c *connList) PoolGetACL(req *PoolGetACLReq) (*PoolGetACLResp, error) {
 	}
 
 	return &PoolGetACLResp{
-		ACL: pbResp.ACL,
+		ACL: &AccessControlList{Entries: pbResp.ACL},
 	}, nil
 }

--- a/src/control/client/types.go
+++ b/src/control/client/types.go
@@ -27,6 +27,7 @@ import (
 	"bytes"
 	"fmt"
 	"sort"
+	"strings"
 
 	mgmtpb "github.com/daos-stack/daos/src/control/common/proto/mgmt"
 	"github.com/daos-stack/daos/src/control/logging"
@@ -255,4 +256,26 @@ func (c *controllerFactory) create(address string, cfg *security.TransportConfig
 	err := controller.connect(address, cfg)
 
 	return controller, err
+}
+
+// AccessControlList is a structure for the access control list.
+type AccessControlList struct {
+	Entries []string // Access Control Entries in short string format
+}
+
+// String converts the AccessControlList to a human-readable string.
+func (acl *AccessControlList) String() string {
+	var builder strings.Builder
+
+	builder.WriteString("# Entries:\n")
+	if acl == nil || len(acl.Entries) == 0 {
+		builder.WriteString("#   None\n")
+		return builder.String()
+	}
+
+	for _, ace := range acl.Entries {
+		fmt.Fprintf(&builder, "%s\n", ace)
+	}
+
+	return builder.String()
 }

--- a/src/control/client/types_test.go
+++ b/src/control/client/types_test.go
@@ -35,7 +35,6 @@ func TestAccessControlList_String(t *testing.T) {
 		expStr string
 	}{
 		"nil": {
-			acl:    &AccessControlList{},
 			expStr: "# Entries:\n#   None\n",
 		},
 		"empty": {

--- a/src/control/client/types_test.go
+++ b/src/control/client/types_test.go
@@ -1,0 +1,68 @@
+//
+// (C) Copyright 2019 Intel Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// GOVERNMENT LICENSE RIGHTS-OPEN SOURCE SOFTWARE
+// The Government's rights to use, modify, reproduce, release, perform, display,
+// or disclose this software are subject to the terms of the Apache License as
+// provided in Contract No. 8F-30005.
+// Any reproduction of computer software, computer software documentation, or
+// portions thereof marked with this legend must also reproduce the markings.
+//
+
+package client
+
+import (
+	"testing"
+
+	"github.com/daos-stack/daos/src/control/common"
+)
+
+func TestAccessControlList_String(t *testing.T) {
+	for name, tc := range map[string]struct {
+		acl    *AccessControlList
+		expStr string
+	}{
+		"nil": {
+			acl:    &AccessControlList{},
+			expStr: "# Entries:\n#   None\n",
+		},
+		"empty": {
+			acl:    &AccessControlList{},
+			expStr: "# Entries:\n#   None\n",
+		},
+		"single": {
+			acl: &AccessControlList{
+				Entries: []string{
+					"A::user@:rw",
+				},
+			},
+			expStr: "# Entries:\nA::user@:rw\n",
+		},
+		"multiple": {
+			acl: &AccessControlList{
+				Entries: []string{
+					"A::OWNER@:rw",
+					"A:G:GROUP@:rw",
+					"A:G:readers@:r",
+				},
+			},
+			expStr: "# Entries:\nA::OWNER@:rw\nA:G:GROUP@:rw\nA:G:readers@:r\n",
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			common.AssertEqual(t, tc.acl.String(), tc.expStr, "string output didn't match")
+		})
+	}
+}

--- a/src/control/cmd/dmg/acl.go
+++ b/src/control/cmd/dmg/acl.go
@@ -30,11 +30,13 @@ import (
 	"strings"
 
 	"github.com/pkg/errors"
+
+	"github.com/daos-stack/daos/src/control/client"
 )
 
-// readACLFile reads in a file representing an ACL, and translates it into a
-// list of ACE strings.
-func readACLFile(aclFile string) ([]string, error) {
+// readACLFile reads in a file representing an ACL, and translates it into an
+// AccessControlList structure
+func readACLFile(aclFile string) (*client.AccessControlList, error) {
 	file, err := os.Open(aclFile)
 	if err != nil {
 		return nil, errors.WithMessage(err, "opening ACL file")
@@ -50,10 +52,10 @@ func isACLFileComment(line string) bool {
 	return strings.HasPrefix(line, "#")
 }
 
-// parseACL reads the content from io.Reader and puts the results into a list
-// of Access Control Entry strings.
+// parseACL reads the content from io.Reader and puts the results into a
+// client.AccessControlList structure.
 // Assumes that ACE strings are provided one per line.
-func parseACL(reader io.Reader) ([]string, error) {
+func parseACL(reader io.Reader) (*client.AccessControlList, error) {
 	aceList := make([]string, 0)
 	scanner := bufio.NewScanner(reader)
 	for scanner.Scan() {
@@ -67,5 +69,5 @@ func parseACL(reader io.Reader) ([]string, error) {
 		}
 	}
 
-	return aceList, nil
+	return &client.AccessControlList{Entries: aceList}, nil
 }

--- a/src/control/cmd/dmg/pool_test.go
+++ b/src/control/cmd/dmg/pool_test.go
@@ -221,7 +221,7 @@ func TestPoolCommands(t *testing.T) {
 			strings.Join([]string{
 				"ConnectClients",
 				fmt.Sprintf("PoolDestroy-%+v", &client.PoolDestroyReq{
-					Uuid:  "031bcaf8-f0f5-42ef-b3c5-ee048676dceb",
+					UUID:  "031bcaf8-f0f5-42ef-b3c5-ee048676dceb",
 					Force: true,
 				}),
 			}, " "),


### PR DESCRIPTION
Future development will benefit from using a structure to
represent the ACL in the client code.

This patch also cleans up some minor Go linting issues.

Signed-off-by: Kris Jacque <kristin.jacque@intel.com>