### PR TITLE
DAOS-623 iosrv: Zero initialize sigaction struct

### DIFF
--- a/src/iosrv/init.c
+++ b/src/iosrv/init.c
@@ -801,7 +801,7 @@ struct sigaction old_handlers[_NSIG];
 static int
 daos_register_sighand(int signo, void (*handler) (int, siginfo_t *, void *))
 {
-	struct sigaction	act;
+	struct sigaction	act = {0};
 	int			rc;
 
 	if ((signo < 0) || (signo >= _NSIG)) {


### PR DESCRIPTION
Valgrind reports uninitialized memory on the call to register
signal handler.  Initializing the struct to 0 prevents this
issue.

Signed-off-by: Jeff Olivier <jeffrey.v.olivier@intel.com>