### PR TITLE
CORCI-817 build: Better step name for RPM build logs

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -264,7 +264,7 @@ pipeline {
                                        result: "FAILURE", ignore_failure: true
                         }
                         unsuccessful {
-                            sh label: "Collect artifacts",
+                            sh label: "Build Log",
                                script: '''mockroot=/var/lib/mock/epel-7-x86_64
                                           artdir=$PWD/artifacts/centos7
                                           if srpms=$(ls _topdir/SRPMS/*); then
@@ -343,7 +343,7 @@ pipeline {
                                        result: "FAILURE", ignore_failure: true
                         }
                         unsuccessful {
-                            sh label: "Collect artifacts",
+                            sh label: "Build Log",
                                script: '''mockroot=/var/lib/mock/suse-12.3-x86_64
                                           cat $mockroot/result/{root,build}.log
                                           artdir=$PWD/artifacts/sles12.3
@@ -422,7 +422,7 @@ pipeline {
                                        result: "FAILURE", ignore_failure: true
                         }
                         unsuccessful {
-                            sh label: "Collect artifacts",
+                            sh label: "Build Log",
                                script: '''mockroot=/var/lib/mock/opensuse-leap-42.3-x86_64
                                           cat $mockroot/result/{root,build}.log
                                           artdir=$PWD/artifacts/leap42.3
@@ -496,7 +496,7 @@ pipeline {
                                        result: "FAILURE"
                         }
                         unsuccessful {
-                            sh label: "Collect artifacts",
+                            sh label: "Build Log",
                                script: '''mockroot=/var/lib/mock/opensuse-leap-15.1-x86_64
                                           cat $mockroot/result/{root,build}.log
                                           artdir=$PWD/artifacts/leap15


### PR DESCRIPTION

The step that the logs for an RPM build failure can be seen in is called
"Collect Artifacts".  When the build fails, this should be called
"Build Log".

Signed-off-by: Brian J. Murrell <brian.murrell@intel.com>