### PR TITLE
DAOS-623 build: Add TARGET_PREFIX builder

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1035,7 +1035,7 @@ pipeline {
                         }
                     }
                 }
-                stage('Build on Leap 15 with Intel-C') {
+                stage('Build on Leap 15 with Intel-C and TARGET_PREFIX') {
                     when {
                         beforeAgent true
                         allOf {
@@ -1055,7 +1055,7 @@ pipeline {
                     }
                     steps {
                         sconsBuild clean: "_build.external${arch}", COMPILER: "icc",
-                                   failure_artifacts: 'config.log-leap15-icc'
+                                   TARGET_PREFIX: 'install/opt', failure_artifacts: 'config.log-leap15-icc'
                     }
                     post {
                         always {


### PR DESCRIPTION
We have many times seen SConscript bugs leak into master because we don't build with
TARGET_PREFIX in CI.  This adds TARGET_PREFIX to existing build step.

I tried adding as a new build step but JENKINS-37984 prevents me from doing so as groovy
crashes when a script reaches a certain size.   We will have to deal with this at some point
but this addresses the immediate problem.