### PR TITLE
DAOS-2781 build: limit spdk required version required in spec

### DIFF
--- a/utils/rpms/daos.spec
+++ b/utils/rpms/daos.spec
@@ -82,7 +82,7 @@ Requires: libpmem1, libpmemobj1
 %endif
 Requires: fuse >= 3.4.2
 Requires: protobuf-c
-Requires: spdk
+Requires: spdk <= 18.07
 Requires: fio < 3.4
 Requires: openssl
 # ensure we get exactly the right cart RPM


### PR DESCRIPTION
... so PRs updating SPDK/DPDK RPM versions don't break DAOS build.

Signed-off-by: Tom Nabarro <tom.nabarro@intel.com>