### PR TITLE
DAOS-3407 control: dmg call nodeset to parse hostlists

### DIFF
--- a/src/control/client/types.go
+++ b/src/control/client/types.go
@@ -325,7 +325,7 @@ func (result *ScmScanResult) Summary() (out string) {
 	default:
 		out = result.Modules.Summary()
 	}
-	return fmt.Sprintf("SCM: %s", out)
+	return fmt.Sprintf("%s", out)
 }
 
 // ScmScanMap maps ScmModuleScanResult structs to the addresses
@@ -357,7 +357,7 @@ func (result *NvmeScanResult) Summary() (out string) {
 	if result.Err != nil {
 		return fmt.Sprintf("NVMe Error: %s", result.Err)
 	}
-	return fmt.Sprintf("NVMe: %s", result.Ctrlrs.Summary())
+	return fmt.Sprintf("%s", result.Ctrlrs.Summary())
 }
 
 // NvmeScanResults maps NvmeScanResult structs to the addresses
@@ -423,8 +423,9 @@ func (ssr *StorageScanResp) String() string {
 func (ssr *StorageScanResp) Summary() string {
 	var buf bytes.Buffer
 
+	fmt.Fprintf(&buf, "HOST\t\tSCM-CAP\tNS-COUNT\tNVMe-CAP\tSSD-COUNT\n")
 	for _, srv := range ssr.Servers {
-		fmt.Fprintf(&buf, "%s %s %s\n", srv,
+		fmt.Fprintf(&buf, "%s\t%s\t\t%s\n", srv,
 			ssr.Scm[srv].Summary(), ssr.Nvme[srv].Summary())
 	}
 

--- a/src/control/client/types.go
+++ b/src/control/client/types.go
@@ -411,11 +411,20 @@ func (ssr *StorageScanResp) String() string {
 
 	for _, srv := range ssr.Servers {
 		fmt.Fprintf(&buf, "%s\n", srv)
-		if !ssr.summary {
-			fmt.Fprintf(&buf, "\t%s", ssr.Scm[srv].String())
-			fmt.Fprintf(&buf, "\t%s", ssr.Nvme[srv].String())
-		}
+		fmt.Fprintf(&buf, "\t%s", ssr.Scm[srv].String())
+		fmt.Fprintf(&buf, "\t%s", ssr.Nvme[srv].String())
 		fmt.Fprintf(&buf, "\tSummary:\n\t\t%s\n\t\t%s\n",
+			ssr.Scm[srv].Summary(), ssr.Nvme[srv].Summary())
+	}
+
+	return buf.String()
+}
+
+func (ssr *StorageScanResp) Summary() string {
+	var buf bytes.Buffer
+
+	for _, srv := range ssr.Servers {
+		fmt.Fprintf(&buf, "%s %s %s\n", srv,
 			ssr.Scm[srv].Summary(), ssr.Nvme[srv].Summary())
 	}
 

--- a/src/control/cmd/dmg/faults.go
+++ b/src/control/cmd/dmg/faults.go
@@ -1,5 +1,5 @@
 //
-// (C) Copyright 2018-2019 Intel Corporation.
+// (C) Copyright 2019 Intel Corporation.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -20,36 +20,28 @@
 // Any reproduction of computer software, computer software documentation, or
 // portions thereof marked with this legend must also reproduce the markings.
 //
+package main
 
-package code
-
-// Code represents a stable fault code.
-//
-// NB: All control plane errors should register their codes in the
-// following block in order to avoid conflicts.
-type Code int
-
-const (
-	// general fault codes
-	Unknown Code = iota
-	MissingSoftwareDependency
-
-	// generic storage fault codes
-	StorageUnknown Code = iota + 100
-	StorageAlreadyFormatted
-	StorageFilesystemAlreadyMounted
-	StorageDeviceAlreadyMounted
-
-	// SCM fault codes
-	ScmUnknown Code = iota + 200
-	ScmFormatBadParam
-
-	// Bdev fault codes
-	BdevUnknown Code = iota + 300
-
-	// dmg fault codes
-	DmgUnknown Code = iota + 400
-
-	// security fault codes
-	SecurityUnknown Code = iota + 900
+import (
+	"github.com/daos-stack/daos/src/control/fault"
+	"github.com/daos-stack/daos/src/control/fault/code"
 )
+
+var (
+	FaultUnknown = dmgFault(
+		code.DmgUnknown, "unknown dmg error", "",
+	)
+	FaultMissingNodeset = dmgFault(
+		code.MissingSoftwareDependency,
+		"nodeset utility not found", "install the clustershell software for your OS",
+	)
+)
+
+func dmgFault(code code.Code, desc, res string) *fault.Fault {
+	return &fault.Fault{
+		Domain:      "dmg",
+		Code:        code,
+		Description: desc,
+		Resolution:  res,
+	}
+}

--- a/src/control/common/storage/pb_types.go
+++ b/src/control/common/storage/pb_types.go
@@ -30,7 +30,6 @@ import (
 
 	bytesize "github.com/inhies/go-bytesize"
 
-	"github.com/daos-stack/daos/src/control/common"
 	ctlpb "github.com/daos-stack/daos/src/control/common/proto/ctl"
 )
 
@@ -151,8 +150,7 @@ func (ncs NvmeControllers) Summary() string {
 		}
 	}
 
-	return fmt.Sprintf("%s total capacity over %d %s",
-		tCap, len(ncs), common.Pluralise("controller", len(ncs)))
+	return fmt.Sprintf("%s\t\t%d", tCap, len(ncs))
 }
 
 // NvmeControllerResults is an alias for protobuf NvmeControllerResult messages

--- a/src/control/server/storage/types.go
+++ b/src/control/server/storage/types.go
@@ -26,7 +26,6 @@ import (
 	"bytes"
 	"fmt"
 
-	"github.com/daos-stack/daos/src/control/common"
 	bytesize "github.com/inhies/go-bytesize"
 )
 
@@ -104,8 +103,7 @@ func (ms ScmModules) Summary() string {
 		tCap += bytesize.New(float64(m.Capacity))
 	}
 
-	return fmt.Sprintf("%s total capacity over %d %s (unprepared)",
-		tCap, len(ms), common.Pluralise("module", len(ms)))
+	return fmt.Sprintf("%s\t%d", tCap, len(ms))
 }
 
 func (n *ScmNamespace) String() string {
@@ -134,6 +132,5 @@ func (ns ScmNamespaces) Summary() string {
 		tCap += bytesize.New(float64(n.Size))
 	}
 
-	return fmt.Sprintf("%s total capacity over %d %s",
-		tCap, len(ns), common.Pluralise("namespace", len(ns)))
+	return fmt.Sprintf("%s\t%d", tCap, len(ns))
 }


### PR DESCRIPTION
Simple implementation calling clustershell's nodeset binary if it
exists to parse supplied hostlist.

Signed-off-by: Tom Nabarro <tom.nabarro@intel.com>