### PR TITLE
DAOS-3605 common: Check length of ACL principal

### DIFF
--- a/src/common/acl_api.c
+++ b/src/common/acl_api.c
@@ -1156,6 +1156,10 @@ daos_ace_is_valid(struct daos_ace *ace)
 		return false;
 	}
 
+	if (ace->dae_principal_len > 0 &&
+	    !daos_acl_principal_is_valid(ace->dae_principal))
+		return false;
+
 	if (!permissions_match_access_type(ace, DAOS_ACL_ACCESS_ALLOW) ||
 	    !permissions_match_access_type(ace, DAOS_ACL_ACCESS_AUDIT) ||
 	    !permissions_match_access_type(ace, DAOS_ACL_ACCESS_ALARM)) {

--- a/src/common/acl_util.c
+++ b/src/common/acl_util.c
@@ -522,6 +522,11 @@ create_ace_from_mutable_str(char *str, struct daos_ace **ace)
 			state = process_flags(field, &flags);
 			break;
 		case ACE_IDENTITY:
+			if (!daos_acl_principal_is_valid(field)) {
+				state = ACE_INVALID;
+				break;
+			}
+
 			new_ace = get_ace_from_identity(field, flags);
 			if (new_ace == NULL) {
 				D_ERROR("Couldn't alloc ACE structure\n");

--- a/src/common/tests/acl_util_tests.c
+++ b/src/common/tests/acl_util_tests.c
@@ -1031,6 +1031,30 @@ test_ace_from_str_too_long(void **state)
 }
 
 static void
+test_ace_from_str_principal_too_long(void **state)
+{
+	size_t		i;
+	char		bad_username[DAOS_ACL_MAX_PRINCIPAL_BUF_LEN + 1];
+	char		input[DAOS_ACL_MAX_ACE_STR_LEN + 1];
+	struct daos_ace	*ace = NULL;
+
+	memset(bad_username, 0, sizeof(bad_username));
+
+	/* create a long principal string > principal max by 1 */
+	for (i = 0; i < DAOS_ACL_MAX_PRINCIPAL_LEN; i++) {
+		bad_username[i] = 'u';
+	}
+	bad_username[i] = '@'; /* gotta be a properly formatted principal */
+
+	snprintf(input, sizeof(input), "A::%s:rw", bad_username);
+
+	/* Should interpret as invalid */
+	assert_int_equal(daos_ace_from_str(input, &ace), -DER_INVAL);
+
+	assert_null(ace);
+}
+
+static void
 test_ace_to_str_null_ace(void **state)
 {
 	char buf[DAOS_ACL_MAX_ACE_STR_LEN];
@@ -1494,6 +1518,7 @@ main(void)
 		cmocka_unit_test(test_ace_from_str_not_all_fields),
 		cmocka_unit_test(test_ace_from_str_too_many_fields),
 		cmocka_unit_test(test_ace_from_str_too_long),
+		cmocka_unit_test(test_ace_from_str_principal_too_long),
 		cmocka_unit_test(test_ace_to_str_null_ace),
 		cmocka_unit_test(test_ace_to_str_null_buf),
 		cmocka_unit_test(test_ace_to_str_zero_len_buf),


### PR DESCRIPTION
The conversion function daos_ace_from_str wasn't checking
the principal name length or validity, so it could be used to 
generate invalid ACLs.

The validity check for ACEs also wasn't accounting for the
principal length, so it would be possible to convert an on-
disk ACE to a truncated string even if the principal name was
far too long or otherwise invalid.

Signed-off-by: Kris Jacque <kristin.jacque@intel.com>