### PR TITLE
DAOS-3116 vos: Optimize incarnation log update

### DIFF
--- a/src/vos/ilog.c
+++ b/src/vos/ilog.c
@@ -759,12 +759,12 @@ update_inplace(struct ilog_context *lctx, struct ilog_id *id_out,
 }
 
 static int
-collapse_tree(struct ilog_context *lctx, daos_handle_t *toh, daos_handle_t *ih)
+collapse_tree(struct ilog_context *lctx, daos_handle_t *toh)
 {
 	struct ilog_root	*root = lctx->ic_root;
 	int			 rc;
 	struct ilog_root	 tmp = {0};
-	struct ilog_id		 key;
+	struct ilog_id		 key = {0};
 	struct btr_attr		 attr;
 	d_iov_t			 key_iov;
 	d_iov_t			 val_iov;
@@ -774,8 +774,10 @@ collapse_tree(struct ilog_context *lctx, daos_handle_t *toh, daos_handle_t *ih)
 	if (attr.ba_count > 1)
 		return 0;
 
-	rc = dbtree_iter_probe(*ih, BTR_PROBE_FIRST, DAOS_INTENT_DEFAULT, NULL,
-			       NULL);
+	d_iov_set(&val_iov, &punch, sizeof(punch));
+	d_iov_set(&key_iov, &key, sizeof(key));
+	rc = dbtree_fetch(*toh, BTR_PROBE_GT, DAOS_INTENT_DEFAULT, &key_iov,
+			  &key_iov, &val_iov);
 	if (rc == -DER_NONEXIST) {
 		rc = 0;
 		key.id_epoch = 0;
@@ -785,27 +787,10 @@ collapse_tree(struct ilog_context *lctx, daos_handle_t *toh, daos_handle_t *ih)
 	}
 
 	if (rc != 0) {
-		D_ERROR("Could not probe iterator: rc = %s\n", d_errstr(rc));
-		goto fail;
-	}
-
-	d_iov_set(&val_iov, &punch, sizeof(punch));
-	d_iov_set(&key_iov, &key, sizeof(key));
-
-	rc = dbtree_iter_fetch(*ih, &key_iov, &val_iov, NULL);
-	if (rc != 0) {
-		D_ERROR("Could not fetch from iterator: rc = %s\n",
-			d_errstr(rc));
-		goto fail;
-	}
-set:
-	rc = dbtree_iter_finish(*ih);
-	if (rc != 0) {
-		D_ERROR("Could not finalize iterator: rc = %s\n", d_errstr(rc));
+		D_ERROR("dbtree_fetch failed: rc = %s\n", d_errstr(rc));
 		goto done;
 	}
-	*ih = DAOS_HDL_INVAL;
-
+set:
 	rc = dbtree_destroy(*toh, NULL);
 	if (rc != 0) {
 		D_ERROR("Could not destroy table: rc = %s\n", d_errstr(rc));
@@ -819,25 +804,22 @@ set:
 	rc = ilog_ptr_set(lctx, root, &tmp);
 done:
 	return rc;
-fail:
-	dbtree_iter_finish(*ih);
-	return rc;
 }
 
 static int
 consolidate_tree(struct ilog_context *lctx, const daos_epoch_range_t *epr,
-		 daos_handle_t *toh, daos_handle_t *ih, int opc,
-		 const struct ilog_id *id_in, bool is_punch)
+		 daos_handle_t *toh, int opc, const struct ilog_id *id_in,
+		 bool is_punch)
 {
 	int			 rc = 0;
 
 	D_ASSERT(opc == ILOG_OP_ABORT);
 
-	rc = dbtree_iter_delete(*ih, NULL);
+	rc = dbtree_delete(*toh, BTR_PROBE_BYPASS, NULL, NULL);
 	if (rc != 0)
 		return rc;
 
-	return collapse_tree(lctx, toh, ih);
+	return collapse_tree(lctx, toh);
 }
 
 static int
@@ -847,12 +829,12 @@ ilog_tree_modify(struct ilog_context *lctx, const struct ilog_id *id_in,
 	struct ilog_root	*root;
 	bool			*punchp;
 	struct ilog_id		*keyp;
-	struct ilog_id		 key;
 	struct ilog_id		 id = *id_in;
 	daos_handle_t		 toh = DAOS_HDL_INVAL;
-	daos_handle_t		 ih = DAOS_HDL_INVAL;
+	d_iov_t			 key_iov_in;
 	d_iov_t			 key_iov;
 	d_iov_t			 val_iov;
+	bool			 is_equal;
 	int			 visibility = ILOG_COMMITTED;
 	struct umem_attr	 uma;
 	int			 rc = 0;
@@ -867,77 +849,58 @@ ilog_tree_modify(struct ilog_context *lctx, const struct ilog_id *id_in,
 		goto done;
 	}
 
-	rc = dbtree_iter_prepare(toh, BTR_ITER_EMBEDDED, &ih);
+	d_iov_set(&key_iov_in, (struct ilog_id *)&id, sizeof(id));
+	d_iov_set(&val_iov, NULL, 0);
+	d_iov_set(&key_iov, NULL, 0);
+	rc = dbtree_fetch(toh, BTR_PROBE_LE, DAOS_INTENT_DEFAULT, &key_iov_in,
+			  &key_iov, &val_iov);
+
+	if (rc == -DER_NONEXIST)
+		goto insert;
+
 	if (rc != 0) {
-		D_ERROR("Could not prepare iterator: rc = %s\n", d_errstr(rc));
-		return rc;
-	}
-
-	for (;;) {
-		bool	is_equal;
-
-		d_iov_set(&key_iov, (struct ilog_id *)&id, sizeof(id));
-
-		rc = dbtree_iter_probe(ih, BTR_PROBE_LE, DAOS_INTENT_DEFAULT,
-				       &key_iov, NULL);
-		if (rc == -DER_NONEXIST)
-			break; /* Skip to handler */
-		if (rc != 0) {
-			D_ERROR("Could not probe iterator: rc = %s\n",
-				d_errstr(rc));
-			goto done;
-		}
-
-		d_iov_set(&key_iov, NULL, 0);
-		d_iov_set(&val_iov, NULL, 0);
-
-		rc = dbtree_iter_fetch(ih, &key_iov, &val_iov, NULL);
-		if (rc != 0) {
-			D_ERROR("Could not fetch from iterator: rc = %s\n",
-				d_errstr(rc));
-			goto done;
-		}
-
-		punchp = (bool *)val_iov.iov_buf;
-		keyp = (struct ilog_id *)key_iov.iov_buf;
-
-		visibility = ILOG_UNCOMMITTED;
-
-		if (keyp->id_epoch <= epr->epr_hi &&
-		    keyp->id_epoch >= epr->epr_lo) {
-			visibility = ilog_status_get(lctx, keyp->id_tx_id,
-						     DAOS_INTENT_UPDATE);
-			if (visibility < 0) {
-				rc = visibility;
-				goto done;
-			}
-		}
-
-		rc = update_inplace(lctx, keyp, punchp, id_in, opc, punch,
-				    &is_equal);
-		if (rc != 0)
-			goto done;
-
-		if (is_equal) {
-			if (opc != ILOG_OP_ABORT)
-				goto done;
-
-			rc = consolidate_tree(lctx, epr, &toh, &ih, opc,
-					      id_in, *punchp);
-
-			goto done;
-		}
-
-		if (opc != ILOG_OP_UPDATE) {
-			D_DEBUG(DB_IO, "No entry found, done\n");
-			goto done;
-		}
-
-		if (punch || visibility == ILOG_UNCOMMITTED || *punchp)
-			break; /* handle entry */
-		/* the new update is "covered" by a previous one */
+		D_ERROR("Fetch of ilog entry failed: rc = %s\n", d_errstr(rc));
 		goto done;
 	}
+
+	punchp = (bool *)val_iov.iov_buf;
+	keyp = (struct ilog_id *)key_iov.iov_buf;
+
+	visibility = ILOG_UNCOMMITTED;
+
+	if (keyp->id_epoch <= epr->epr_hi &&
+	    keyp->id_epoch >= epr->epr_lo) {
+		visibility = ilog_status_get(lctx, keyp->id_tx_id,
+					     DAOS_INTENT_UPDATE);
+		if (visibility < 0) {
+			rc = visibility;
+			goto done;
+		}
+	}
+
+	rc = update_inplace(lctx, keyp, punchp, id_in, opc, punch,
+			    &is_equal);
+	if (rc != 0)
+		goto done;
+
+	if (is_equal) {
+		if (opc != ILOG_OP_ABORT)
+			goto done;
+
+		rc = consolidate_tree(lctx, epr, &toh, opc,
+				      id_in, *punchp);
+
+		goto done;
+	}
+
+	if (opc != ILOG_OP_UPDATE) {
+		D_DEBUG(DB_IO, "No entry found, done\n");
+		goto done;
+	}
+
+	if (!punch && visibility != ILOG_UNCOMMITTED && !*punchp)
+		goto done;
+insert:
 
 	rc = ilog_tx_begin(lctx);
 	if (rc != 0)
@@ -947,18 +910,18 @@ ilog_tree_modify(struct ilog_context *lctx, const struct ilog_id *id_in,
 	if (rc != 0)
 		goto done;
 
-	d_iov_set(&key_iov, &key, sizeof(key));
 	d_iov_set(&val_iov, &punch, sizeof(punch));
-	key = id;
-	rc = dbtree_update(toh, &key_iov, &val_iov);
+	/* Can't use BTR_PROBE_BYPASS because it inserts before existing
+	 * entry and we need it to append.   We could modify btree to
+	 * support this use case.
+	 */
+	rc = dbtree_update(toh, &key_iov_in, &val_iov);
 	if (rc) {
 		D_ERROR("Failed to update incarnation log: rc = %s\n",
 			d_errstr(rc));
 		goto done;
 	}
 done:
-	if (!daos_handle_is_inval(ih))
-		dbtree_iter_finish(ih);
 	if (!daos_handle_is_inval(toh))
 		dbtree_close(toh);
 
@@ -1246,7 +1209,7 @@ next:
 	}
 
 collapse:
-	rc = collapse_tree(lctx, &toh, &ih);
+	rc = collapse_tree(lctx, &toh);
 
 	empty = ilog_empty(root);
 done:

--- a/src/vos/vos_ilog.c
+++ b/src/vos/vos_ilog.c
@@ -242,11 +242,9 @@ vos_ilog_check(struct vos_ilog_info *info, const daos_epoch_range_t *epr_in,
 	return 0;
 }
 
-static int
+static inline int
 vos_ilog_update_check(struct vos_ilog_info *info, const daos_epoch_range_t *epr)
 {
-	if (info->ii_create == 0)
-		return -DER_NONEXIST;
 	if (info->ii_create <= info->ii_prior_any_punch)
 		return -DER_NONEXIST;
 

--- a/src/vos/vos_ilog.c
+++ b/src/vos/vos_ilog.c
@@ -242,6 +242,84 @@ vos_ilog_check(struct vos_ilog_info *info, const daos_epoch_range_t *epr_in,
 	return 0;
 }
 
+static int
+vos_ilog_update_check(struct vos_ilog_info *info, const daos_epoch_range_t *epr)
+{
+	if (info->ii_create == 0)
+		return -DER_NONEXIST;
+	if (info->ii_create <= info->ii_prior_any_punch)
+		return -DER_NONEXIST;
+
+	return 0;
+}
+
+int vos_ilog_update(struct vos_container *cont, struct ilog_df *ilog,
+		    const daos_epoch_range_t *epr, struct vos_ilog_info *parent,
+		    struct vos_ilog_info *info)
+{
+	daos_epoch_range_t	max_epr = *epr;
+	struct ilog_desc_cbs	cbs;
+	daos_handle_t		loh;
+	int			rc;
+
+	if (parent != NULL) {
+		D_ASSERT(parent->ii_prior_any_punch >= parent->ii_prior_punch);
+
+		if (parent->ii_prior_any_punch > max_epr.epr_lo)
+			max_epr.epr_lo = parent->ii_prior_any_punch;
+	}
+
+	D_DEBUG(DB_TRACE, "Checking and updating incarnation log in range "
+		DF_U64"-"DF_U64"\n", max_epr.epr_lo, max_epr.epr_hi);
+
+	/** Do a fetch first.  The log may already exist */
+	rc = vos_ilog_fetch(vos_cont2umm(cont), vos_cont2hdl(cont),
+			    DAOS_INTENT_UPDATE, ilog, epr->epr_hi,
+			    0, parent, info);
+	if (rc == -DER_NONEXIST)
+		goto update;
+	if (rc != 0) {
+		D_ERROR("Could not update ilog %p at "DF_U64": "DF_RC"\n",
+			ilog, epr->epr_hi, DP_RC(rc));
+		return rc;
+	}
+
+	rc = vos_ilog_update_check(info, &max_epr);
+	if (rc == 0)
+		return rc;
+	if (rc != -DER_NONEXIST) {
+		D_ERROR("Check failed: "DF_RC"\n", DP_RC(rc));
+		return rc;
+	}
+update:
+	vos_ilog_desc_cbs_init(&cbs, vos_cont2hdl(cont));
+	rc = ilog_open(vos_cont2umm(cont), ilog, &cbs, &loh);
+	if (rc != 0) {
+		D_ERROR("Could not open incarnation log: "DF_RC"\n", DP_RC(rc));
+		return rc;
+	}
+
+	rc = ilog_update(loh, &max_epr, epr->epr_hi, false);
+
+	ilog_close(loh);
+
+	if (rc != 0) {
+		D_ERROR("Could not update incarnation log: "DF_RC"\n",
+			DP_RC(rc));
+		return rc;
+	}
+
+	rc = vos_ilog_fetch(vos_cont2umm(cont), vos_cont2hdl(cont),
+			    DAOS_INTENT_UPDATE, ilog, epr->epr_hi,
+			    0, parent, info);
+	if (rc != 0) {
+		D_ERROR("Could not fetch incarnation log: "DF_RC"\n",
+			DP_RC(rc));
+	}
+
+	return rc;
+}
+
 void
 vos_ilog_fetch_init(struct vos_ilog_info *info)
 {

--- a/src/vos/vos_ilog.h
+++ b/src/vos/vos_ilog.h
@@ -33,6 +33,8 @@
 #include <daos/common.h>
 #include <ilog.h>
 
+struct vos_container;
+
 struct vos_ilog_info {
 	struct ilog_entries	ii_entries;
 	/** If non-zero, earliest creation timestamp in current incarnation. */
@@ -84,6 +86,27 @@ int
 vos_ilog_fetch(struct umem_instance *umm, daos_handle_t coh, uint32_t intent,
 	       struct ilog_df *ilog, daos_epoch_t epoch, daos_epoch_t punched,
 	       const struct vos_ilog_info *parent, struct vos_ilog_info *info);
+
+/**
+ * Check the incarnation log if an update is needed and update it.  Refreshes
+ * the log into \p entries.
+ *
+ * \param	cont[IN]	Pointer to vos container
+ * \param	ilog[IN]	The incarnation log root
+ * \param	epr[IN]		Range of update
+ * \param	parent[IN]	parent incarnation log info (NULL if no parent
+ *				log exists).  Fetch should have already been
+ *				called at same epoch or parent.
+ * \param	info[IN,OUT]	incarnation log info
+ *
+ * \return	0		Successful update
+ *		other		Appropriate error code
+ */
+int
+vos_ilog_update(struct vos_container *cont, struct ilog_df *ilog,
+		const daos_epoch_range_t *epr, struct vos_ilog_info *parent,
+		struct vos_ilog_info *info);
+
 
 /**
  * Check the incarnation log for existence and return important information

--- a/src/vos/vos_obj.c
+++ b/src/vos/vos_obj.c
@@ -1157,7 +1157,7 @@ nested_dkey_iter_init(struct vos_obj_iter *oiter, struct vos_iter_info *info)
 	D_ASSERTF(rc != -DER_NONEXIST,
 		  "Nested iterator called without setting probe");
 	if (rc != 0) {
-		/** -DER_NONEXIST and -DER_INPROGESS should be caught earlier.
+		/** -DER_NONEXIST and -DER_INPROGRESS should be caught earlier.
 		 *  This function should only be called after a successful
 		 *  probe.
 		 */


### PR DESCRIPTION
Add a new vos_ilog_update API to check the log first before
calling ilog_update.   It will first fetch the existing log and then
check to see if the creation time is later than any punches
(committed or uncommitted).

A combination of COS removal and update only checking
the previous entry means that we can add hundreds of
incarnation log entries on non-leader ranks.   This solves
part of the problem by making sure we don't add new
entries if the log has committed creation time.

We need to also add something, perhaps indexed by
ilog offset, force commit of transactions if the incarnation
log is growing.  This would be similar to old COS except
commit is not required for correctness, only for avoiding
too many unnecessary log entries.

With full logging on IO9, I was seeing logs with thousands
of modifications (tree_version) on non-leader ranks.  With
this change and a much longer run, it cut down to 90 or
so.   So we will still need something to give commit hints
for commit on heavily shared objects/keys.   Aggregation
will help as well.

Signed-off-by: Jeff Olivier <jeffrey.v.olivier@intel.com>