### PR TITLE
Revert "DAOS-623 build: Update scons_local ref to latest. (#1340)"

### DIFF
--- a/src/control/SConscript
+++ b/src/control/SConscript
@@ -88,14 +88,16 @@ def scons():
             sharedir = join("share", "spdk", "scripts")
             tpath = join(denv.subst("$PREFIX"), sharedir)
             if not check_dir_exists(tpath):
-                spath = join(denv.subst("$SPDK_PREFIX"), sharedir)
-                if tpath != spath:
-                    denv.Command(tpath, spath, Copy("$TARGET", "$SOURCE"))
+                denv.Command(
+                    tpath,
+                    join(denv.subst("$SPDK_PREFIX"), sharedir),
+                    Copy("$TARGET", "$SOURCE"))
         tpath = join(denv.subst("$PREFIX"), "include")
         if not check_dir_exists(tpath):
-            spath = join(denv.subst("$SPDK_PREFIX"), "include")
-            if tpath != spath:
-                denv.Command(tpath, spath, Copy("$TARGET", "$SOURCE"))
+            denv.Command(
+                tpath,
+                join(denv.subst("$SPDK_PREFIX"), "include"),
+                Copy("$TARGET", "$SOURCE"))
 
     def check_go_version(context):
         """Check GO Version"""

--- a/utils/run_test.sh
+++ b/utils/run_test.sh
@@ -110,8 +110,7 @@ if [ -d "/mnt/daos" ]; then
     # Satisfy requirement for starting daos_server w/o config file
     export CRT_PHY_ADDR_STR=ofi+sockets
     export OFI_INTERFACE=lo
-    # Disable this as it doesn't work for now.
-    # run_test src/rdb/tests/rdb_test_runner.py "${SL_OMPI_PREFIX}"
+    run_test src/rdb/tests/rdb_test_runner.py "${SL_OMPI_PREFIX}"
     run_test build/src/security/tests/cli_security_tests
     run_test build/src/security/tests/srv_acl_tests
     run_test build/src/common/tests/acl_api_tests


### PR DESCRIPTION
It pulls in psm2 and we are not ready for that.  We need to wait until cart is updated.

This reverts commit 8e03101ca44100476a5c35773e6d2a0851cf685e.

Signed-off-by: Jeff Olivier <jeffrey.v.olivier@intel.com>