### PR TITLE
DAOS-3691 dtx: invalid ASSERT in dtx_leader_wait

### DIFF
--- a/src/dtx/dtx_common.c
+++ b/src/dtx/dtx_common.c
@@ -363,10 +363,13 @@ dtx_leader_wait(struct dtx_leader_handle *dlh, struct dtx_conflict_entry **dces,
 			}
 		}
 
-		D_ASSERT(j > 0);
-
-		*dces = conflict;
 		*dces_cnt = j;
+		if (j > 0) {
+			*dces = conflict;
+		} else {
+			D_FREE(conflict);
+			*dces = NULL;
+		}
 	}
 
 out:


### PR DESCRIPTION
When the modification on non-leader replica hit some DTX related
conflict, it will reply to the leader replica with -DER_INPROGRESS.
If the conflict is caused by some known DTX, its ID will also be
returned to the leader replica for further conflict handling. The
leader replica needs to check whether the remote replica returned
valid DTX ID or not to avoid fake ASSERT() trouble.

Signed-off-by: Fan Yong <fan.yong@intel.com>