### PR TITLE
DAOS-3532 vos: register in-modified evtree to PMDK log

### DIFF
--- a/src/include/daos_srv/evtree.h
+++ b/src/include/daos_srv/evtree.h
@@ -414,7 +414,7 @@ struct evt_policy_ops {
 			     struct evt_node *node,
 			     uint64_t in_off,
 			     const struct evt_entry_in *entry,
-			     bool *mbr_changed);
+			     bool *mbr_changed, bool tx_added);
 	/**
 	 * move half entries of the current node \a nd_src to the new
 	 * node \a nd_dst.


### PR DESCRIPTION
When insert new record into the evtree, we need register related
evtree node, in spite of it is leaf node or not, to the PMDK log.
Otherwise there will be two potential trouble:

1. If the PMDK transaction is committed, but because related SCM
   range is not registered to the PMDK log, then related cached
   modification in CPU cache may not be flushed (in time) to the
   SCM when commit the PMDK transaction. If the server crash or
   reboot at that time, then related data will be lost even if
   related PMDK transaction has already been committed.

2. If the PMDK transaction is aborted, then new created evtree
   record (on SCM) will be freed automatically, but its address
   is still referenced by some evtree node. And then, the freed
   SCM space may be allocated to others in subsequent operation
   as to related evtree node references garbage information and
   cause data corruption.

Signed-off-by: Fan Yong <fan.yong@intel.com>