### PR TITLE
DAOS-2822 rdb: Remove unused rdb_create_bcast

### DIFF
--- a/src/rdb/rdb_internal.h
+++ b/src/rdb/rdb_internal.h
@@ -255,7 +255,6 @@ CRT_RPC_DECLARE(rdb_installsnapshot, DAOS_ISEQ_RDB_INSTALLSNAPSHOT,
 int rdb_create_raft_rpc(crt_opcode_t opc, raft_node_t *node, crt_rpc_t **rpc);
 int rdb_send_raft_rpc(crt_rpc_t *rpc, struct rdb *db);
 int rdb_abort_raft_rpcs(struct rdb *db);
-int rdb_create_bcast(crt_opcode_t opc, crt_group_t *group, crt_rpc_t **rpc);
 void rdb_recvd(void *arg);
 
 /* rdb_tx.c *******************************************************************/

--- a/src/rdb/rdb_rpc.c
+++ b/src/rdb/rdb_rpc.c
@@ -310,20 +310,6 @@ rdb_create_raft_rpc(crt_opcode_t opc, raft_node_t *node, crt_rpc_t **rpc)
 	return crt_req_create(info->dmi_ctx, &ep, opc_full, rpc);
 }
 
-int
-rdb_create_bcast(crt_opcode_t opc, crt_group_t *group, crt_rpc_t **rpc)
-{
-	struct dss_module_info *info = dss_get_module_info();
-	crt_opcode_t		opc_full;
-
-	opc_full = DAOS_RPC_OPCODE(opc, DAOS_RDB_MODULE, DAOS_RDB_VERSION);
-	return crt_corpc_req_create(info->dmi_ctx, group,
-				    NULL /* excluded_ranks */, opc_full,
-				    NULL /* co_bulk_hdl */, NULL /* priv */,
-				    0 /* flags */,
-				    crt_tree_topo(CRT_TREE_FLAT, 0), rpc);
-}
-
 struct rdb_raft_rpc {
 	d_list_t	drc_entry;	/* in rdb::{d_requests,d_replies} */
 	crt_rpc_t      *drc_rpc;


### PR DESCRIPTION
rdb_create_bcast was used by distributed start and stop functions. Since
these have been moved into rsvc, rdb_create_bcast is no longer required.

Signed-off-by: Li Wei <wei.g.li@intel.com>