### PR TITLE
DAOS-3532 vos: evict obejct from cache if modification aborted

### DIFF
--- a/src/vos/tests/vts_aggregate.c
+++ b/src/vos/tests/vts_aggregate.c
@@ -215,7 +215,7 @@ lookup_object(struct io_test_args *arg, daos_unit_oid_t oid)
 			  vos_hdl2cont(arg->ctx.tc_co_hdl), oid, &epr, true,
 			  DAOS_INTENT_DEFAULT, true, &obj);
 	if (rc == 0)
-		vos_obj_release(vos_obj_cache_current(), obj);
+		vos_obj_release(vos_obj_cache_current(), obj, false);
 	return rc;
 }
 

--- a/src/vos/tests/vts_io.c
+++ b/src/vos/tests/vts_io.c
@@ -827,12 +827,12 @@ io_obj_cache_test(void **state)
 	rc = vos_obj_hold(occ, vos_hdl2cont(ctx->tc_co_hdl), oids[0], &epr,
 			  false, DAOS_INTENT_DEFAULT, true, &objs[0]);
 	assert_int_equal(rc, 0);
-	vos_obj_release(occ, objs[0]);
+	vos_obj_release(occ, objs[0], false);
 
 	rc = vos_obj_hold(occ, vos_hdl2cont(l_coh), oids[1], &epr, false,
 			  DAOS_INTENT_DEFAULT, true, &objs[0]);
 	assert_int_equal(rc, 0);
-	vos_obj_release(occ, objs[0]);
+	vos_obj_release(occ, objs[0], false);
 
 	rc = hold_objects(objs, occ, &ctx->tc_co_hdl, &oids[0], 0, 10, true, 0);
 	assert_int_equal(rc, 0);
@@ -847,20 +847,20 @@ io_obj_cache_test(void **state)
 			  DAOS_INTENT_DEFAULT, true, &objs[16]);
 	assert_int_equal(rc, 0);
 
-	vos_obj_release(occ, objs[16]);
+	vos_obj_release(occ, objs[16], false);
 
 	for (i = 0; i < 5; i++)
-		vos_obj_release(occ, objs[i]);
+		vos_obj_release(occ, objs[i], false);
 	for (i = 10; i < 15; i++)
-		vos_obj_release(occ, objs[i]);
+		vos_obj_release(occ, objs[i], false);
 
 	rc = hold_objects(objs, occ, &l_coh, &oids[1], 15, 20, true, 0);
 	assert_int_equal(rc, 0);
 
 	for (i = 5; i < 10; i++)
-		vos_obj_release(occ, objs[i]);
+		vos_obj_release(occ, objs[i], false);
 	for (i = 15; i < 20; i++)
-		vos_obj_release(occ, objs[i]);
+		vos_obj_release(occ, objs[i], false);
 
 	rc = vos_cont_close(l_coh);
 	assert_int_equal(rc, 0);

--- a/src/vos/vos_dtx.c
+++ b/src/vos/vos_dtx.c
@@ -1097,6 +1097,6 @@ vos_dtx_mark_sync(daos_handle_t coh, daos_unit_oid_t oid, daos_epoch_t epoch)
 		}
 	}
 
-	vos_obj_release(occ, obj);
+	vos_obj_release(occ, obj, false);
 	return rc;
 }

--- a/src/vos/vos_dtx_cos.c
+++ b/src/vos/vos_dtx_cos.c
@@ -386,7 +386,7 @@ vos_dtx_add_cos(daos_handle_t coh, daos_unit_oid_t *oid, struct dtx_id *dti,
 		if (rc != 0)
 			return rc;
 
-		vos_obj_release(occ, obj);
+		vos_obj_release(occ, obj, false);
 	}
 
 	D_ASSERT(epoch != DAOS_EPOCH_MAX);

--- a/src/vos/vos_io.c
+++ b/src/vos/vos_io.c
@@ -149,13 +149,13 @@ vos_ioc_reserve_init(struct vos_io_context *ioc)
 }
 
 static void
-vos_ioc_destroy(struct vos_io_context *ioc)
+vos_ioc_destroy(struct vos_io_context *ioc, bool evict)
 {
 	if (ioc->ic_biod != NULL)
 		bio_iod_free(ioc->ic_biod);
 
 	if (ioc->ic_obj)
-		vos_obj_release(vos_obj_cache_current(), ioc->ic_obj);
+		vos_obj_release(vos_obj_cache_current(), ioc->ic_obj, evict);
 
 	vos_ioc_reserve_fini(ioc);
 	vos_ilog_fetch_finish(&ioc->ic_dkey_info);
@@ -240,7 +240,7 @@ vos_ioc_create(daos_handle_t coh, daos_unit_oid_t oid, bool read_only,
 	return 0;
 error:
 	if (ioc != NULL)
-		vos_ioc_destroy(ioc);
+		vos_ioc_destroy(ioc, false);
 	return rc;
 }
 
@@ -687,7 +687,7 @@ vos_fetch_end(daos_handle_t ioh, int err)
 
 	/* NB: it's OK to use the stale ioc->ic_obj for fetch_end */
 	D_ASSERT(!ioc->ic_update);
-	vos_ioc_destroy(ioc);
+	vos_ioc_destroy(ioc, false);
 	return err;
 }
 
@@ -1309,7 +1309,7 @@ abort:
 out:
 	if (err != 0)
 		update_cancel(ioc);
-	vos_ioc_destroy(ioc);
+	vos_ioc_destroy(ioc, err != 0);
 	vos_dth_set(NULL);
 
 	return err;

--- a/src/vos/vos_obj.c
+++ b/src/vos/vos_obj.c
@@ -177,7 +177,7 @@ vos_obj_punch(daos_handle_t coh, daos_unit_oid_t oid, daos_epoch_t epoch,
 
 	rc = vos_tx_end(vos_cont2umm(cont), rc);
 	if (obj != NULL)
-		vos_obj_release(vos_obj_cache_current(), obj);
+		vos_obj_release(vos_obj_cache_current(), obj, rc != 0);
 
 reset:
 	vos_dth_set(NULL);
@@ -223,7 +223,7 @@ vos_obj_delete(daos_handle_t coh, daos_unit_oid_t oid)
 	/* NB: noop for full-stack mode */
 	gc_wait();
 out:
-	vos_obj_release(occ, obj);
+	vos_obj_release(occ, obj, true);
 	return rc;
 }
 
@@ -1179,7 +1179,7 @@ nested_dkey_iter_init(struct vos_obj_iter *oiter, struct vos_iter_info *info)
 
 	return 0;
 failed:
-	vos_obj_release(vos_obj_cache_current(), oiter->it_obj);
+	vos_obj_release(vos_obj_cache_current(), oiter->it_obj, false);
 
 	return rc;
 }
@@ -1303,7 +1303,7 @@ vos_obj_iter_fini(struct vos_iterator *iter)
 	 */
 	if (oiter->it_obj != NULL &&
 	    (iter->it_type == VOS_ITER_DKEY || !iter->it_from_parent))
-		vos_obj_release(vos_obj_cache_current(), oiter->it_obj);
+		vos_obj_release(vos_obj_cache_current(), oiter->it_obj, false);
 
 	vos_ilog_fetch_finish(&oiter->it_ilog_info);
 	D_FREE(oiter);

--- a/src/vos/vos_obj.h
+++ b/src/vos/vos_obj.h
@@ -106,7 +106,7 @@ vos_obj_hold(struct daos_lru_cache *occ, struct vos_container *cont,
  * \param obj	[IN]	Reference to be released.
  */
 void
-vos_obj_release(struct daos_lru_cache *occ, struct vos_object *obj);
+vos_obj_release(struct daos_lru_cache *occ, struct vos_object *obj, bool evict);
 
 static inline int
 vos_obj_refcount(struct vos_object *obj)

--- a/src/vos/vos_obj_cache.c
+++ b/src/vos/vos_obj_cache.c
@@ -187,10 +187,14 @@ vos_obj_cache_current(void)
 }
 
 void
-vos_obj_release(struct daos_lru_cache *occ, struct vos_object *obj)
+vos_obj_release(struct daos_lru_cache *occ, struct vos_object *obj, bool evict)
 {
 
 	D_ASSERT((occ != NULL) && (obj != NULL));
+
+	if (evict)
+		daos_lru_ref_evict(&obj->obj_llink);
+
 	daos_lru_ref_release(occ, &obj->obj_llink);
 }
 
@@ -329,7 +333,7 @@ out:
 	*obj_p = obj;
 	return 0;
 failed:
-	vos_obj_release(occ, obj);
+	vos_obj_release(occ, obj, true);
 failed_2:
 	if (rc != -DER_NONEXIST)
 		D_CDEBUG(rc == -DER_INPROGRESS, DB_TRACE, DLOG_ERR,

--- a/src/vos/vos_query.c
+++ b/src/vos/vos_query.c
@@ -429,6 +429,6 @@ vos_obj_query_key(daos_handle_t coh, daos_unit_oid_t oid, uint32_t flags,
 		dbtree_close(query.qt_dkey_toh);
 out:
 	if (obj)
-		vos_obj_release(vos_obj_cache_current(), obj);
+		vos_obj_release(vos_obj_cache_current(), obj, false);
 	return rc;
 }


### PR DESCRIPTION
It is possible that the modification has created the object and put
it in the VOS object cache. If the modification is aborted for some
reason (such as failed to modify something), then we should remove
the object from cache, because the cached obejct still references
the new created dkey/dkey/sv/ev records that will be auto released
when related PMDK transaction is aborted.

Signed-off-by: Fan Yong <fan.yong@intel.com>