### PR TITLE
DAOS-3735 vos: Add some useful debugging and minor tweaks

### DIFF
--- a/src/vos/ilog.c
+++ b/src/vos/ilog.c
@@ -224,7 +224,7 @@ ilog_log_add(struct ilog_context *lctx, struct ilog_id *id)
 		return rc;
 	}
 
-	D_DEBUG(DB_IO, "Registered ilog="DF_U64" epoch="DF_U64" tx_id="
+	D_DEBUG(DB_IO, "Registered ilog="DF_X64" epoch="DF_U64" tx_id="
 		DF_U64"\n", lctx->ic_root_off, id->id_epoch,
 		id->id_tx_id);
 
@@ -248,7 +248,7 @@ ilog_log_del(struct ilog_context *lctx, const struct ilog_id *id)
 		return rc;
 	}
 
-	D_DEBUG(DB_IO, "De-registered ilog="DF_U64" epoch="DF_U64" tx_id="
+	D_DEBUG(DB_IO, "De-registered ilog="DF_X64" epoch="DF_U64" tx_id="
 		DF_U64"\n", lctx->ic_root_off, id->id_epoch,
 		id->id_tx_id);
 
@@ -500,6 +500,7 @@ ilog_create(struct umem_instance *umm, struct ilog_df *root)
 {
 	struct ilog_context	lctx = {
 		.ic_root = (struct ilog_root *)root,
+		.ic_root_off = umem_ptr2off(umm, root),
 		.ic_umm = *umm,
 		.ic_ref = 0,
 		.ic_in_txn = 0,
@@ -954,9 +955,9 @@ ilog_modify(daos_handle_t loh, const struct ilog_id *id_in,
 
 	root = lctx->ic_root;
 
-	D_DEBUG(DB_IO, "%s in incarnation log: epoch:" DF_U64
-		" tree_version: %d\n", opc_str[opc], id_in->id_epoch,
-		ilog_mag2ver(root->lr_magic));
+	D_DEBUG(DB_IO, "%s in incarnation log: log:"DF_X64 " epoch:" DF_U64
+		" tree_version: %d\n", opc_str[opc], lctx->ic_root_off,
+		id_in->id_epoch, ilog_mag2ver(root->lr_magic));
 
 	if (root->lr_tree.it_embedded && root->lr_id.id_epoch <= epr->epr_hi
 	    && root->lr_id.id_epoch >= epr->epr_lo) {
@@ -1290,7 +1291,7 @@ ilog_status_refresh(struct ilog_context *lctx, uint32_t intent,
 }
 
 static bool
-ilog_fetch_needed(struct umem_instance *umm, struct ilog_root *root,
+ilog_fetch_cached(struct umem_instance *umm, struct ilog_root *root,
 		  const struct ilog_desc_cbs *cbs, uint32_t intent,
 		  struct ilog_entries *entries)
 {
@@ -1306,9 +1307,12 @@ ilog_fetch_needed(struct umem_instance *umm, struct ilog_root *root,
 		goto reset;
 	}
 
+	if (priv->ip_rc == -DER_NONEXIST)
+		return true;
+
 	ilog_status_refresh(&priv->ip_lctx, intent, entries);
 
-	return false;
+	return true;
 reset:
 	memset(lctx, 0, sizeof(*lctx));
 	lctx->ic_root = root;
@@ -1325,7 +1329,7 @@ reset:
 	priv->ip_log_version = ilog_mag2ver(lctx->ic_root->lr_magic);
 	priv->ip_rc = 0;
 
-	return true;
+	return false;
 }
 
 static int
@@ -1438,7 +1442,7 @@ ilog_fetch(struct umem_instance *umm, struct ilog_df *root_df,
 
 	root = (struct ilog_root *)root_df;
 
-	if (!ilog_fetch_needed(umm, root, cbs, intent, entries)) {
+	if (ilog_fetch_cached(umm, root, cbs, intent, entries)) {
 		if (priv->ip_rc == -DER_INPROGRESS ||
 		    priv->ip_rc == -DER_NONEXIST)
 			return priv->ip_rc;
@@ -1483,7 +1487,7 @@ ilog_fetch(struct umem_instance *umm, struct ilog_df *root_df,
 		D_GOTO(out, rc = 0);
 
 	if (rc != 0) {
-		D_ERROR("Error probing ilog: rc = %s\n", d_errstr(rc));
+		D_ERROR("Error probing ilog: "DF_RC"\n", DP_RC(rc));
 		goto fail;
 	}
 
@@ -1516,7 +1520,9 @@ ilog_fetch(struct umem_instance *umm, struct ilog_df *root_df,
 			goto fail;
 	}
 out:
-	/* Cache whole log */
+	/* We don't exit loop early with -DER_INPROGRESS so we cache the while
+	 * log for future updates.
+	 */
 	if (in_progress)
 		rc = -DER_INPROGRESS;
 

--- a/src/vos/ilog.h
+++ b/src/vos/ilog.h
@@ -46,6 +46,8 @@ struct  ilog_df {
 struct umem_instance;
 
 enum ilog_status {
+	/** Log status is not set */
+	ILOG_INVALID,
 	/** Log entry is visible to caller */
 	ILOG_COMMITTED,
 	/** Log entry is not yet visible */

--- a/src/vos/vos_ilog.c
+++ b/src/vos/vos_ilog.c
@@ -164,9 +164,9 @@ vos_parse_ilog(struct vos_ilog_info *info, daos_epoch_t epoch,
 }
 
 int
-vos_ilog_fetch(struct umem_instance *umm, daos_handle_t coh, uint32_t intent,
-	       struct ilog_df *ilog, daos_epoch_t epoch, daos_epoch_t punched,
-	       const struct vos_ilog_info *parent, struct vos_ilog_info *info)
+vos_ilog_fetch_(struct umem_instance *umm, daos_handle_t coh, uint32_t intent,
+		struct ilog_df *ilog, daos_epoch_t epoch, daos_epoch_t punched,
+		const struct vos_ilog_info *parent, struct vos_ilog_info *info)
 {
 	struct ilog_desc_cbs	 cbs;
 	daos_epoch_t		 punch;
@@ -203,8 +203,8 @@ init:
 }
 
 int
-vos_ilog_check(struct vos_ilog_info *info, const daos_epoch_range_t *epr_in,
-	       daos_epoch_range_t *epr_out, bool visible_only)
+vos_ilog_check_(struct vos_ilog_info *info, const daos_epoch_range_t *epr_in,
+		daos_epoch_range_t *epr_out, bool visible_only)
 {
 	if (epr_out && epr_out != epr_in)
 		*epr_out = *epr_in;
@@ -251,9 +251,9 @@ vos_ilog_update_check(struct vos_ilog_info *info, const daos_epoch_range_t *epr)
 	return 0;
 }
 
-int vos_ilog_update(struct vos_container *cont, struct ilog_df *ilog,
-		    const daos_epoch_range_t *epr, struct vos_ilog_info *parent,
-		    struct vos_ilog_info *info)
+int vos_ilog_update_(struct vos_container *cont, struct ilog_df *ilog,
+		     const daos_epoch_range_t *epr,
+		     struct vos_ilog_info *parent, struct vos_ilog_info *info)
 {
 	daos_epoch_range_t	max_epr = *epr;
 	struct ilog_desc_cbs	cbs;

--- a/src/vos/vos_ilog.h
+++ b/src/vos/vos_ilog.h
@@ -82,10 +82,11 @@ vos_ilog_fetch_finish(struct vos_ilog_info *info);
  *		0		Successful fetch
  *		other		Appropriate error code
  */
+#define vos_ilog_fetch vos_ilog_fetch_
 int
-vos_ilog_fetch(struct umem_instance *umm, daos_handle_t coh, uint32_t intent,
-	       struct ilog_df *ilog, daos_epoch_t epoch, daos_epoch_t punched,
-	       const struct vos_ilog_info *parent, struct vos_ilog_info *info);
+vos_ilog_fetch_(struct umem_instance *umm, daos_handle_t coh, uint32_t intent,
+		struct ilog_df *ilog, daos_epoch_t epoch, daos_epoch_t punched,
+		const struct vos_ilog_info *parent, struct vos_ilog_info *info);
 
 /**
  * Check the incarnation log if an update is needed and update it.  Refreshes
@@ -102,6 +103,7 @@ vos_ilog_fetch(struct umem_instance *umm, daos_handle_t coh, uint32_t intent,
  * \return	0		Successful update
  *		other		Appropriate error code
  */
+#define vos_ilog_update vos_ilog_update_
 int
 vos_ilog_update(struct vos_container *cont, struct ilog_df *ilog,
 		const daos_epoch_range_t *epr, struct vos_ilog_info *parent,
@@ -122,12 +124,75 @@ vos_ilog_update(struct vos_container *cont, struct ilog_df *ilog,
  *					there is no covered entries either.
  *		0			success
  */
+#define vos_ilog_check vos_ilog_check_
 int
-vos_ilog_check(struct vos_ilog_info *info, const daos_epoch_range_t *epr_in,
-	       daos_epoch_range_t *epr_out, bool visible_only);
+vos_ilog_check_(struct vos_ilog_info *info, const daos_epoch_range_t *epr_in,
+		daos_epoch_range_t *epr_out, bool visible_only);
 
 /** Initialize callbacks for vos incarnation log */
 void
 vos_ilog_desc_cbs_init(struct ilog_desc_cbs *cbs, daos_handle_t coh);
+
+#ifdef ILOG_TRACE
+#undef vos_ilog_fetch
+#undef vos_ilog_update
+#undef vos_ilog_check
+/* Useful for debugging the incarnation log but too much information for
+ * normal debugging.
+ */
+#define vos_ilog_fetch(umm, coh, intent, ilog, epoch, punched, parent, info)\
+({									\
+	int __rc;							\
+									\
+	D_DEBUG(DB_TRACE, "vos_ilog_fetch: log="DF_X64" intent=%d"	\
+		" epoch="DF_U64" punched="DF_U64"\n",			\
+		umem_ptr2off(umm, ilog), intent, epoch,			\
+		(uint64_t)punched);					\
+	__rc = vos_ilog_fetch_(umm, coh, intent, ilog, epoch, punched,	\
+			       parent, info);				\
+	D_DEBUG(DB_TRACE, "vos_ilog_fetch: returned "DF_RC" create="	\
+		DF_U64" pp="DF_U64" pap="DF_U64" np="DF_U64" %s\n",	\
+		DP_RC(__rc), (info)->ii_create, (info)->ii_prior_punch,	\
+		(info)->ii_prior_any_punch, (info)->ii_next_punch,	\
+		(info)->ii_empty ? "is empty" : "");			\
+	__rc;								\
+})
+
+#define vos_ilog_update(cont, ilog, epr, parent, info)			\
+({									\
+	struct umem_instance	*__umm = vos_cont2umm(cont);		\
+	int			 __rc;					\
+									\
+	D_DEBUG(DB_TRACE, "vos_ilog_update: log="DF_X64" epr="		\
+		DF_U64"-"DF_U64"\n", umem_ptr2off(__umm, ilog),		\
+		(epr)->epr_lo, (epr)->epr_hi);				\
+	__rc = vos_ilog_update_(cont, ilog, epr, parent, info);		\
+	D_DEBUG(DB_TRACE, "vos_ilog_update: returned "DF_RC" create="	\
+		DF_U64" pap="DF_U64"\n", DP_RC(__rc), (info)->ii_create,\
+		(info)->ii_prior_any_punch);				\
+	__rc;								\
+})
+
+#define vos_ilog_check(info, epr_in, epr_out, visible_only)		\
+({									\
+	int __rc;							\
+									\
+	_Pragma("GCC diagnostic push")					\
+	_Pragma("GCC diagnostic ignored \"-Waddress\"")			\
+	D_DEBUG(DB_TRACE, "vos_ilog_check: epr_in="DF_U64"-"DF_U64	\
+		"%s\n", (epr_in)->epr_lo, (epr_in)->epr_hi,		\
+		(visible_only) ? "visible" : "all");			\
+	__rc = vos_ilog_check_(info, epr_in, epr_out, visible_only);	\
+	D_DEBUG(DB_TRACE, "vos_ilog_check: returned "DF_RC" %s"		\
+		DF_U64"-"DF_U64"\n", DP_RC(__rc),			\
+		((epr_out) != NULL) ? " epr_out=" : " #",		\
+		((epr_out) != NULL) ? (epr_out)->epr_lo : 0,		\
+		((epr_out) != NULL) ? (epr_out)->epr_hi : 0);		\
+	_Pragma("GCC diagnostic pop")					\
+	__rc;								\
+})
+
+#endif
+
 
 #endif /* __VOS_ILOG_H__ */

--- a/src/vos/vos_ilog.h
+++ b/src/vos/vos_ilog.h
@@ -105,9 +105,9 @@ vos_ilog_fetch_(struct umem_instance *umm, daos_handle_t coh, uint32_t intent,
  */
 #define vos_ilog_update vos_ilog_update_
 int
-vos_ilog_update(struct vos_container *cont, struct ilog_df *ilog,
-		const daos_epoch_range_t *epr, struct vos_ilog_info *parent,
-		struct vos_ilog_info *info);
+vos_ilog_update_(struct vos_container *cont, struct ilog_df *ilog,
+		 const daos_epoch_range_t *epr, struct vos_ilog_info *parent,
+		 struct vos_ilog_info *info);
 
 
 /**


### PR DESCRIPTION
I've found that debugging the incarnation log is painful so
added some trace debugging that is disabled by default but
can easily be enabled.
Fixed a few minor issues from previous patch.

Signed-off-by: Jeff Olivier <jeffrey.v.olivier@intel.com>