### PR TITLE
DAOS-3548 control: Distinguish between formatted and mountable

### DIFF
--- a/src/control/server/instance.go
+++ b/src/control/server/instance.go
@@ -190,8 +190,15 @@ func (srv *IOServerInstance) NeedsScmFormat() (bool, error) {
 		return false, err
 	}
 
-	srv.log.Debugf("%s (%s) needs format: %t", scmCfg.MountPoint, scmCfg.Class, !res.Formatted)
-	return !res.Formatted, nil
+	// Logic:
+	// 1. If the SCM is mounted, assume here that it doesn't need to be formatted.
+	// 2. If not mounted, check:
+	// 2a. Does it appear to be formatted with something?
+	// AND
+	// 2b. Does it appear to be mountable by us?
+	needsFormat := !res.Mounted && !(res.Formatted && res.Mountable)
+	srv.log.Debugf("%s (%s) needs format: %t", scmCfg.MountPoint, scmCfg.Class, needsFormat)
+	return needsFormat, nil
 }
 
 // Start checks to make sure that the instance has a valid superblock before

--- a/src/control/server/instance.go
+++ b/src/control/server/instance.go
@@ -190,13 +190,7 @@ func (srv *IOServerInstance) NeedsScmFormat() (bool, error) {
 		return false, err
 	}
 
-	// Logic:
-	// 1. If the SCM is mounted, assume here that it doesn't need to be formatted.
-	// 2. If not mounted, check:
-	// 2a. Does it appear to be formatted with something?
-	// AND
-	// 2b. Does it appear to be mountable by us?
-	needsFormat := !res.Mounted && !(res.Formatted && res.Mountable)
+	needsFormat := !res.Mounted && !res.Mountable
 	srv.log.Debugf("%s (%s) needs format: %t", scmCfg.MountPoint, scmCfg.Class, needsFormat)
 	return needsFormat, nil
 }

--- a/src/control/server/storage/scm/provider.go
+++ b/src/control/server/storage/scm/provider.go
@@ -645,6 +645,10 @@ func (p *Provider) formatRamdisk(req FormatRequest) (*FormatResponse, error) {
 		return nil, err
 	}
 
+	if !res.Mounted {
+		return nil, errors.Errorf("%s was not mounted", req.Mountpoint)
+	}
+
 	if err := os.Chown(req.Mountpoint, req.OwnerUID, req.OwnerGID); err != nil {
 		return nil, errors.Wrapf(err, "failed to set ownership of %s to %d.%d",
 			req.Mountpoint, req.OwnerUID, req.OwnerGID)
@@ -652,9 +656,9 @@ func (p *Provider) formatRamdisk(req FormatRequest) (*FormatResponse, error) {
 
 	return &FormatResponse{
 		Mountpoint: res.Target,
-		Formatted:  res.Mounted,
-		Mounted:    res.Mounted,
-		Mountable:  !res.Mounted,
+		Formatted:  true,
+		Mounted:    true,
+		Mountable:  false,
 	}, nil
 }
 
@@ -681,6 +685,10 @@ func (p *Provider) formatDcpm(req FormatRequest) (*FormatResponse, error) {
 		return nil, err
 	}
 
+	if !res.Mounted {
+		return nil, errors.Errorf("%s was not mounted", req.Mountpoint)
+	}
+
 	if err := os.Chown(req.Mountpoint, req.OwnerUID, req.OwnerGID); err != nil {
 		return nil, errors.Wrapf(err, "failed to set ownership of %s to %d.%d",
 			req.Mountpoint, req.OwnerUID, req.OwnerGID)
@@ -688,9 +696,9 @@ func (p *Provider) formatDcpm(req FormatRequest) (*FormatResponse, error) {
 
 	return &FormatResponse{
 		Mountpoint: res.Target,
-		Formatted:  res.Mounted,
-		Mounted:    res.Mounted,
-		Mountable:  !res.Mounted,
+		Formatted:  true,
+		Mounted:    true,
+		Mountable:  false,
 	}, nil
 }
 

--- a/src/control/server/storage/scm/provider.go
+++ b/src/control/server/storage/scm/provider.go
@@ -555,31 +555,29 @@ func (p *Provider) CheckFormat(req FormatRequest) (*FormatResponse, error) {
 		return res, nil
 	}
 
-	if req.Dcpm != nil {
-		fsType, err := p.sys.Getfs(req.Dcpm.Device)
-		if err != nil {
-			if os.IsNotExist(errors.Cause(err)) {
-				return nil, errors.Wrap(FaultFormatMissingDevice, req.Dcpm.Device)
-			}
-			return nil, errors.Wrapf(err, "failed to check if %s is formatted", req.Dcpm.Device)
-		}
-
-		p.log.Debugf("device %s filesystem: %s", req.Dcpm.Device, fsType)
-
-		switch fsType {
-		case fsTypeExt4:
-			res.Mountable = true
-		case fsTypeNone:
-			res.Formatted = false
-		}
-
-		return res, nil
-	} else {
+	if req.Dcpm == nil {
 		// ramdisk
-		res.Mountable = true
+		res.Formatted = false
+		return res, nil
 	}
 
-	res.Formatted = false
+	fsType, err := p.sys.Getfs(req.Dcpm.Device)
+	if err != nil {
+		if os.IsNotExist(errors.Cause(err)) {
+			return nil, errors.Wrap(FaultFormatMissingDevice, req.Dcpm.Device)
+		}
+		return nil, errors.Wrapf(err, "failed to check if %s is formatted", req.Dcpm.Device)
+	}
+
+	p.log.Debugf("device %s filesystem: %s", req.Dcpm.Device, fsType)
+
+	switch fsType {
+	case fsTypeExt4:
+		res.Mountable = true
+	case fsTypeNone:
+		res.Formatted = false
+	}
+
 	return res, nil
 }
 

--- a/src/control/server/storage/scm/provider_test.go
+++ b/src/control/server/storage/scm/provider_test.go
@@ -381,7 +381,6 @@ func TestProviderCheckFormat(t *testing.T) {
 			isMountedErr: os.ErrNotExist,
 			expResponse: &FormatResponse{
 				Mountpoint: goodMountPoint,
-				Mountable:  true,
 				Formatted:  false,
 			},
 		},

--- a/src/control/server/storage/scm/provider_test.go
+++ b/src/control/server/storage/scm/provider_test.go
@@ -381,6 +381,7 @@ func TestProviderCheckFormat(t *testing.T) {
 			isMountedErr: os.ErrNotExist,
 			expResponse: &FormatResponse{
 				Mountpoint: goodMountPoint,
+				Mountable:  true,
 				Formatted:  false,
 			},
 		},
@@ -390,6 +391,7 @@ func TestProviderCheckFormat(t *testing.T) {
 			expResponse: &FormatResponse{
 				Mountpoint: goodMountPoint,
 				Formatted:  true,
+				Mounted:    true,
 			},
 		},
 		"getFs fails": {
@@ -401,7 +403,7 @@ func TestProviderCheckFormat(t *testing.T) {
 			},
 			getFsErr: errors.New("getfs failed"),
 		},
-		"already formatted": {
+		"already formatted; not mountable": {
 			request: &FormatRequest{
 				Mountpoint: goodMountPoint,
 				Dcpm: &DcpmParams{
@@ -411,6 +413,20 @@ func TestProviderCheckFormat(t *testing.T) {
 			getFsStr: "reiserfs",
 			expResponse: &FormatResponse{
 				Mountpoint: goodMountPoint,
+				Formatted:  true,
+			},
+		},
+		"already formatted; mountable": {
+			request: &FormatRequest{
+				Mountpoint: goodMountPoint,
+				Dcpm: &DcpmParams{
+					Device: goodDevice,
+				},
+			},
+			getFsStr: fsTypeExt4,
+			expResponse: &FormatResponse{
+				Mountpoint: goodMountPoint,
+				Mountable:  true,
 				Formatted:  true,
 			},
 		},
@@ -544,6 +560,7 @@ func TestProviderFormat(t *testing.T) {
 			expResponse: &FormatResponse{
 				Mountpoint: goodMountPoint,
 				Formatted:  true,
+				Mounted:    true,
 			},
 		},
 		"ramdisk: already mounted, no reformat": {
@@ -561,6 +578,7 @@ func TestProviderFormat(t *testing.T) {
 			expResponse: &FormatResponse{
 				Mountpoint: goodMountPoint,
 				Formatted:  true,
+				Mounted:    true,
 			},
 		},
 		"ramdisk: not mounted; mkdir fails": {
@@ -585,6 +603,7 @@ func TestProviderFormat(t *testing.T) {
 			expResponse: &FormatResponse{
 				Mountpoint: goodMountPoint,
 				Formatted:  true,
+				Mounted:    true,
 			},
 		},
 		"ramdisk: already mounted; reformat; unmount fails": {
@@ -652,6 +671,7 @@ func TestProviderFormat(t *testing.T) {
 			expResponse: &FormatResponse{
 				Mountpoint: goodMountPoint,
 				Formatted:  true,
+				Mounted:    true,
 			},
 		},
 		"dcpm: not mounted; already formatted; reformat": {
@@ -666,6 +686,7 @@ func TestProviderFormat(t *testing.T) {
 			expResponse: &FormatResponse{
 				Mountpoint: goodMountPoint,
 				Formatted:  true,
+				Mounted:    true,
 			},
 		},
 		"dcpm: mounted; already formatted; reformat": {
@@ -680,6 +701,7 @@ func TestProviderFormat(t *testing.T) {
 			expResponse: &FormatResponse{
 				Mountpoint: goodMountPoint,
 				Formatted:  true,
+				Mounted:    true,
 			},
 		},
 		"dcpm: mountpoint doesn't exist; not formatted": {
@@ -694,6 +716,7 @@ func TestProviderFormat(t *testing.T) {
 			expResponse: &FormatResponse{
 				Mountpoint: goodMountPoint,
 				Formatted:  true,
+				Mounted:    true,
 			},
 		},
 		"dcpm: not mounted; not formatted": {
@@ -707,6 +730,7 @@ func TestProviderFormat(t *testing.T) {
 			expResponse: &FormatResponse{
 				Mountpoint: goodMountPoint,
 				Formatted:  true,
+				Mounted:    true,
 			},
 		},
 		"dcpm: not mounted; not formatted; mkfs fails": {


### PR DESCRIPTION
Add logic to determine when SCM appears to be formatted but isn't
mountable. This will allow us to detect an incompatible existing
filesystem and signal to the user that a reformat is necessary.