### PR TITLE
DAOS-3276 control: Improve error with missing SCM device

### DIFF
--- a/src/control/cmd/daos_server/main.go
+++ b/src/control/cmd/daos_server/main.go
@@ -30,6 +30,7 @@ import (
 	"github.com/pkg/errors"
 
 	"github.com/daos-stack/daos/src/control/common"
+	"github.com/daos-stack/daos/src/control/fault"
 	"github.com/daos-stack/daos/src/control/lib/netdetect"
 	"github.com/daos-stack/daos/src/control/logging"
 )
@@ -66,6 +67,9 @@ func (c *logCmd) setLog(log *logging.LeveledLogger) {
 func exitWithError(log *logging.LeveledLogger, err error) {
 	log.Debugf("%+v", err)
 	log.Errorf("%v", err)
+	if fault.HasResolution(err) {
+		log.Error(fault.ShowResolutionFor(err))
+	}
 	os.Exit(1)
 }
 

--- a/src/control/pbin/exec.go
+++ b/src/control/pbin/exec.go
@@ -62,6 +62,11 @@ type (
 	}
 )
 
+func IsFailedRequest(err error) bool {
+	_, ok := err.(*RequestFailure)
+	return ok
+}
+
 func (rf *RequestFailure) Error() string {
 	if rf == nil {
 		return "nil *RequestFailure"

--- a/src/control/server/harness.go
+++ b/src/control/server/harness.go
@@ -156,7 +156,8 @@ func (h *IOServerHarness) AwaitStorageReady(ctx context.Context, skipMissingSupe
 	for _, instance := range h.instances {
 		needsScmFormat, err := instance.NeedsScmFormat()
 		if err != nil {
-			return errors.Wrap(err, "failed to check storage formatting")
+			h.log.Error(errors.Wrap(err, "failed to check storage formatting").Error())
+			needsScmFormat = true
 		}
 
 		if !needsScmFormat {

--- a/src/control/server/storage/scm/faults.go
+++ b/src/control/server/storage/scm/faults.go
@@ -65,6 +65,11 @@ var (
 		"request included already-mounted mount target (cannot double-mount)",
 		"unmount the target and retry the operation",
 	)
+	FaultFormatMissingDevice = scmFault(
+		code.ScmFormatBadParam,
+		"configured SCM device does not exist",
+		"check the configured value and/or perform the SCM preparation procedure",
+	)
 	FaultMissingNdctl = scmFault(
 		code.MissingSoftwareDependency,
 		"ndctl utility not found", "install the ndctl software for your OS",

--- a/src/control/server/storage/scm/forwarder.go
+++ b/src/control/server/storage/scm/forwarder.go
@@ -63,6 +63,9 @@ func (f *Forwarder) sendReq(method string, fwdReq interface{}, fwdRes interface{
 	ctx := context.TODO()
 	res, err := pbin.ExecReq(ctx, f.log, pbinPath, req)
 	if err != nil {
+		if pbin.IsFailedRequest(err) {
+			return err
+		}
 		return errors.Wrap(err, "privileged binary execution failed")
 	}
 

--- a/src/control/server/storage/scm/provider.go
+++ b/src/control/server/storage/scm/provider.go
@@ -297,7 +297,7 @@ func (ssp *defaultSystemProvider) Mkfs(fsType, device string, force bool) error 
 	return nil
 }
 
-// GetFs probes the specified device in an attempt to determine the
+// Getfs probes the specified device in an attempt to determine the
 // formatted filesystem type, if any.
 func (ssp *defaultSystemProvider) Getfs(device string) (string, error) {
 	cmdPath, err := exec.LookPath("file")
@@ -555,6 +555,9 @@ func (p *Provider) CheckFormat(req FormatRequest) (*FormatResponse, error) {
 	if req.Dcpm != nil {
 		fsType, err := p.sys.Getfs(req.Dcpm.Device)
 		if err != nil {
+			if os.IsNotExist(errors.Cause(err)) {
+				return nil, errors.Wrap(FaultFormatMissingDevice, req.Dcpm.Device)
+			}
 			return nil, errors.Wrapf(err, "failed to check if %s is formatted", req.Dcpm.Device)
 		}
 

--- a/src/control/server/storage/scm/provider_test.go
+++ b/src/control/server/storage/scm/provider_test.go
@@ -729,6 +729,20 @@ func TestProviderFormat(t *testing.T) {
 			getFsStr: fsTypeNone,
 			mountErr: errors.New("mount failed"),
 		},
+		"dcpm: missing device": {
+			request: &FormatRequest{
+				Mountpoint: goodMountPoint,
+				Dcpm: &DcpmParams{
+					Device: "/bad/device",
+				},
+			},
+			getFsErr: &os.PathError{
+				Op:   "stat",
+				Path: "/bad/device",
+				Err:  os.ErrNotExist,
+			},
+			expErr: FaultFormatMissingDevice,
+		},
 	} {
 		t.Run(name, func(t *testing.T) {
 			log, buf := logging.NewTestLogger(t.Name())


### PR DESCRIPTION
When the server configuration contains a DCPM device but the
device doesn't exist, log the error and wait for admin input