### PR TITLE
DAOS-3755 vos: Assertion failure in key_tree_prepare on fetch

### DIFF
--- a/src/vos/tests/vts_pm.c
+++ b/src/vos/tests/vts_pm.c
@@ -813,6 +813,76 @@ simple_multi_update(void **state)
 	}
 }
 
+static void
+object_punch_and_fetch(void **state)
+{
+	struct io_test_args	*arg = *state;
+	const char		*value = "HelloCruelWorld";
+	daos_key_t		 update_keys[2];
+	daos_key_t		 punch_keys[2];
+	daos_key_t		*punch_akeys[2];
+	daos_key_t		*actual_keys[2];
+	daos_key_t		 dkey;
+	daos_iod_t		 iod = {0};
+	d_sg_list_t		 sgl = {0};
+	daos_unit_oid_t		 oid;
+	daos_epoch_t		 epoch = 1;
+	int			 i = 0;
+	int			 rc = 0;
+	uint8_t			 stable_key = 0;
+	char			 key1 = 'a';
+	char			 key2 = 'b';
+	char			 buf[32] = {0};
+
+	test_args_reset(arg, VPOOL_SIZE);
+
+	rc = daos_sgl_init(&sgl, 1);
+	assert_int_equal(rc, 0);
+	d_iov_set(&update_keys[0], &stable_key, sizeof(stable_key));
+	d_iov_set(&update_keys[1], &key1, sizeof(key1));
+	d_iov_set(&punch_keys[0], &stable_key, sizeof(stable_key));
+	d_iov_set(&punch_keys[1], &key2, sizeof(key2));
+	punch_akeys[0] = &punch_keys[1];
+	punch_akeys[1] = NULL;
+	actual_keys[0] = &dkey;
+	actual_keys[1] = &iod.iod_name;
+
+	for (i = 0; i < 2; i++) {
+		/* Set up dkey and akey */
+		oid = gen_oid(0);
+
+		*actual_keys[0] = update_keys[i];
+		*actual_keys[1] = update_keys[1 - i];
+
+		iod.iod_type = DAOS_IOD_SINGLE;
+		iod.iod_size = 0;
+		d_iov_set(&sgl.sg_iovs[0], (void *)value, sizeof(value));
+		iod.iod_nr = 1;
+		iod.iod_recxs = NULL;
+
+		rc = vos_obj_update(arg->ctx.tc_co_hdl, oid, epoch++, 0, &dkey,
+				    1, &iod, &sgl);
+		assert_int_equal(rc, 0);
+
+		*actual_keys[0] = punch_keys[i];
+		*actual_keys[1] = punch_keys[1 - i];
+
+		rc = vos_obj_punch(arg->ctx.tc_co_hdl, oid, epoch++, 0, 0,
+				   &dkey, 1 - i, punch_akeys[i], NULL);
+		assert_int_equal(rc, 0);
+
+		iod.iod_size = 0;
+		d_iov_set(&sgl.sg_iovs[0], (void *)buf, sizeof(buf));
+
+		rc = vos_obj_fetch(arg->ctx.tc_co_hdl, oid, epoch++, &dkey, 1,
+				   &iod, &sgl);
+		assert_int_equal(rc, 0);
+		assert_int_equal(iod.iod_size, 0);
+	}
+
+	daos_sgl_fini(&sgl, false);
+}
+
 static const struct CMUnitTest punch_model_tests[] = {
 	{ "VOS800: VOS punch model array set/get size",
 	  array_set_get_size, pm_setup, pm_teardown },
@@ -828,6 +898,8 @@ static const struct CMUnitTest punch_model_tests[] = {
 	{ "VOS806: Multi update", simple_multi_update, NULL, NULL},
 	{ "VOS807: Array Set/get size, write, punch",
 	  array_size_write, pm_setup, pm_teardown },
+	{ "VOS808: Object punch and fetch",
+	  object_punch_and_fetch, NULL, NULL },
 };
 
 int

--- a/src/vos/vos_tree.c
+++ b/src/vos/vos_tree.c
@@ -813,7 +813,13 @@ tree_open_create(struct vos_object *obj, enum vos_tree_class tclass, int flags,
 		goto out;
 	}
 
-	D_ASSERT(flags & SUBTR_CREATE);
+	if ((flags & SUBTR_CREATE) == 0) {
+		/** This can happen if application does a punch first before any
+		 *  updates.   Simply return -DER_NONEXIST in such case.
+		 */
+		rc = -DER_NONEXIST;
+		goto out;
+	}
 
 	if (flags & SUBTR_EVT) {
 		rc = evt_create(&krec->kr_evt, vos_evt_feats, VOS_EVT_ORDER,


### PR DESCRIPTION
If the key is punched before an update, it is possible to have
a key created but not have any actual subtree initialized.
An assertion was triggering in this case for HDF5

Add a regression test as well.

This is new with punch model change as we allow under punch
even in non-rebuild case.   We could disallow this by using
the rebuild flag but I don't see it as being a big deal.  I
imagine MVCC will prevent it in non-rebuild case in the
future.

Signed-off-by: Jeff Olivier <jeffrey.v.olivier@intel.com>