### PR TITLE
DAOS-3627 vos: Exit aggregation when -DER_SHUTDOWN is returned

### DIFF
--- a/src/container/srv_target.c
+++ b/src/container/srv_target.c
@@ -1556,13 +1556,11 @@ ds_cont_aggregate_ult(void *arg)
 		uint64_t sleep; /* nano secs */
 
 		rc = cont_child_aggregate(cont, &sleep);
-		if (rc < 0) {
+		if (rc > 0 || rc == -DER_SHUTDOWN) {
+			break;	/* aggregation aborted */
+		} else if (rc < 0) {
 			D_ERROR(DF_UUID": VOS aggregate failed. %d\n",
 				DP_UUID(cont->sc_uuid), rc);
-			if (rc == -DER_SHUTDOWN)
-				break;
-		} else if (rc) {
-			break;	/* aggregation aborted */
 		}
 
 		if (dss_xstream_exiting(dmi->dmi_xstream))

--- a/src/container/srv_target.c
+++ b/src/container/srv_target.c
@@ -1558,7 +1558,7 @@ ds_cont_aggregate_ult(void *arg)
 		rc = cont_child_aggregate(cont, &sleep);
 		if (rc > 0 || rc == -DER_SHUTDOWN) {
 			break;	/* aggregation aborted */
-		} else if (rc < 0) {
+		} else if (rc) {
 			D_ERROR(DF_UUID": VOS aggregate failed. %d\n",
 				DP_UUID(cont->sc_uuid), rc);
 		}

--- a/src/container/srv_target.c
+++ b/src/container/srv_target.c
@@ -1556,11 +1556,14 @@ ds_cont_aggregate_ult(void *arg)
 		uint64_t sleep; /* nano secs */
 
 		rc = cont_child_aggregate(cont, &sleep);
-		if (rc < 0)
+		if (rc < 0) {
 			D_ERROR(DF_UUID": VOS aggregate failed. %d\n",
 				DP_UUID(cont->sc_uuid), rc);
-		else if (rc)
+			if (rc == -DER_SHUTDOWN)
+				break;
+		} else if (rc) {
 			break;	/* aggregation aborted */
+		}
 
 		if (dss_xstream_exiting(dmi->dmi_xstream))
 			break;


### PR DESCRIPTION
The temporary return value we use for pool shutdown in vos_obj_hold
is -DER_SHUTDOWN.   We should exit the aggregation loop when this
error is returned from vos_aggregate.

Signed-off-by: Jeff Olivier <jeffrey.v.olivier@intel.com>