### PR TITLE
DAOS-3742 bio: Add BIO device state string to log output

### DIFF
--- a/src/bio/bio_monitor.c
+++ b/src/bio/bio_monitor.c
@@ -29,7 +29,7 @@
 #include <daos_srv/smd.h>
 
 /*
- * Period to query raw device health stats, auto detect faulty and transit
+ * Period to query raw device health stats, auto detect faulty and transition
  * device state. 60 seconds by default.
  */
 #define NVME_MONITOR_PERIOD	(60ULL * (NSEC_PER_SEC / NSEC_PER_USEC))

--- a/src/bio/smd/smd_device.c
+++ b/src/bio/smd/smd_device.c
@@ -118,6 +118,17 @@ smd_dev_unassign(uuid_t dev_id, int tgt_id)
 	return -DER_NOSYS;
 }
 
+static char *
+smd_state_enum_to_str(enum smd_dev_state state)
+{
+	switch (state) {
+	case SMD_DEV_NORMAL: return "NORMAL";
+	case SMD_DEV_FAULTY: return "FAULTY";
+	}
+
+	return "Undefined state";
+}
+
 int
 smd_dev_set_state(uuid_t dev_id, enum smd_dev_state state)
 {
@@ -145,10 +156,13 @@ smd_dev_set_state(uuid_t dev_id, enum smd_dev_state state)
 	entry.sde_state = state;
 	rc = dbtree_update(smd_store.ss_dev_hdl, &key, &val);
 	if (rc) {
-		D_ERROR("Update dev "DF_UUID" failed. %d\n",
+		D_ERROR("SMD dev "DF_UUID" state set failed. %d\n",
 			DP_UUID(&key_dev.uuid), rc);
 		goto out;
-	}
+	} else
+		D_DEBUG(DB_MGMT, "SMD dev "DF_UUID" state set to %s\n",
+			DP_UUID(&key_dev.uuid),
+			smd_state_enum_to_str(state));
 out:
 	smd_unlock(&smd_store);
 	return rc;


### PR DESCRIPTION
During device state transition, currently only the enum values are
printed. Instead print the BIO blobstore state string associated with the
enum value to the log, ie NORMAL, FAULTY, TEARDOWN, OUT, REPLACED, REINT.

Signed-off-by: Sydney Vanda <sydney.m.vanda@intel.com>