### PR TITLE
DAOS-3761 bio: Increase sleep duration for NVMe recovery test

### DIFF
--- a/src/tests/suite/daos_nvme_recovery.c
+++ b/src/tests/suite/daos_nvme_recovery.c
@@ -115,7 +115,7 @@ nvme_recov_1(void **state)
 	 *	  is ready.
 	 */
 	print_message("Waiting for faulty reaction done...\n");
-	sleep(60);
+	sleep(180);
 	print_message("Done\n");
 }
 


### PR DESCRIPTION
Increase the sleep duration for the NVMe recovery test 1 (Online faulty
reaction) before test completion. Current sleep duration is not long enough for
device state transition from TEARDOWN->OUT after rebuild and blobstore teardown
is complete.

Signed-off-by: Sydney Vanda <sydney.m.vanda@intel.com>