### PR TITLE
DAOS-2185 obj: retry for ESTALE case specific shard

### DIFF
--- a/src/object/cli_obj.c
+++ b/src/object/cli_obj.c
@@ -2078,14 +2078,12 @@ obj_comp_cb(tse_task_t *task, void *data)
 	if (obj_retry_error(task->dt_result)) {
 		/* If the RPC sponsor set the @spec_shard, then means it wants
 		 * to fetch data from the specified shard. If such shard isn't
-		 * ready for read, we should let the caller know that, instead
-		 * of re-direct the fetch RPC to other replica. But there are
-		 * some other cases we need to retry the RPC with current shard,
-		 * such as -DER_TIMEDOUT or daos_crt_network_error().
+		 * ready for read, we should let the caller know that, But there
+		 * are some other cases we need to retry the RPC with current
+		 * shard, such as -DER_TIMEDOUT or daos_crt_network_error().
 		 */
 		if (!obj_auxi->spec_shard ||
-		    (task->dt_result != -DER_STALE &&
-		     task->dt_result != -DER_INPROGRESS))
+		    task->dt_result != -DER_INPROGRESS)
 			obj_auxi->io_retry = 1;
 
 		if (!obj_auxi->spec_shard && task->dt_result == -DER_INPROGRESS)


### PR DESCRIPTION
Retry for ESTALE case even for specific shard fetch,
since client might return ESTALE if the pool map is
stale.

Signed-off-by: Di Wang <di.wang@intel.com>