### PR TITLE
DAOS-2822 object: Fix dc_obj_shard_query_key's dc_pool leaks

### DIFF
--- a/src/object/cli_shard.c
+++ b/src/object/cli_shard.c
@@ -1034,7 +1034,9 @@ dc_obj_shard_query_key(struct dc_obj_shard *shard, daos_epoch_t epoch,
 		D_ERROR("query_key rpc failed rc %d\n", rc);
 		D_GOTO(out_req, rc);
 	}
-	return rc;
+
+	dc_pool_put(pool);
+	return 0;
 
 out_req:
 	crt_req_decref(req);


### PR DESCRIPTION
dc_obj_shard_query_key leaks a dc_pool reference on the normal path.

Signed-off-by: Li Wei <wei.g.li@intel.com>