### PR TITLE
DAOS-3485 control: Move bdev*.go into bdev package

### DIFF
--- a/src/control/server/ctl_svc_test.go
+++ b/src/control/server/ctl_svc_test.go
@@ -28,7 +28,7 @@ import (
 
 	"github.com/daos-stack/daos/src/control/logging"
 	"github.com/daos-stack/daos/src/control/server/ioserver"
-	"github.com/daos-stack/daos/src/control/server/storage"
+	"github.com/daos-stack/daos/src/control/server/storage/bdev"
 	"github.com/daos-stack/daos/src/control/server/storage/scm"
 )
 
@@ -55,7 +55,7 @@ func mockControlService(t *testing.T, log logging.Logger, cfg *Configuration, mb
 
 	scmProvider := cs.StorageControlService.scm
 	for _, srvCfg := range cfg.Servers {
-		bp, err := storage.NewBdevProvider(log, "", &srvCfg.Storage.Bdev)
+		bp, err := bdev.NewClassProvider(log, "", &srvCfg.Storage.Bdev)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/src/control/server/harness_test.go
+++ b/src/control/server/harness_test.go
@@ -40,7 +40,7 @@ import (
 	"github.com/daos-stack/daos/src/control/drpc"
 	"github.com/daos-stack/daos/src/control/logging"
 	"github.com/daos-stack/daos/src/control/server/ioserver"
-	"github.com/daos-stack/daos/src/control/server/storage"
+	"github.com/daos-stack/daos/src/control/server/storage/bdev"
 	"github.com/daos-stack/daos/src/control/server/storage/scm"
 )
 
@@ -294,7 +294,7 @@ func TestHarnessIOServerStart(t *testing.T) {
 					tc.trc.StartCb = func() { instanceStarts++ }
 				}
 				runner := ioserver.NewTestRunner(tc.trc, srvCfg)
-				bdevProvider, err := storage.NewBdevProvider(log,
+				bdevProvider, err := bdev.NewClassProvider(log,
 					srvCfg.Storage.SCM.MountPoint, &srvCfg.Storage.Bdev)
 				if err != nil {
 					t.Fatal(err)
@@ -304,7 +304,7 @@ func TestHarnessIOServerStart(t *testing.T) {
 					ControlAddr:  &net.TCPAddr{},
 					AccessPoints: []string{"localhost"},
 				}
-				msClient := newMgmtSvcClient(nil, log, msClientCfg)
+				msClient := newMgmtSvcClient(context.TODO(), log, msClientCfg)
 				srv := NewIOServerInstance(log, bdevProvider, scmProvider, msClient, runner)
 				if err := harness.AddInstance(srv); err != nil {
 					t.Fatal(err)

--- a/src/control/server/instance.go
+++ b/src/control/server/instance.go
@@ -37,6 +37,7 @@ import (
 	"github.com/daos-stack/daos/src/control/logging"
 	"github.com/daos-stack/daos/src/control/server/ioserver"
 	"github.com/daos-stack/daos/src/control/server/storage"
+	"github.com/daos-stack/daos/src/control/server/storage/bdev"
 	"github.com/daos-stack/daos/src/control/server/storage/scm"
 )
 
@@ -57,7 +58,7 @@ type IOServerStarter interface {
 type IOServerInstance struct {
 	log           logging.Logger
 	runner        IOServerStarter
-	bdevProvider  *storage.BdevProvider
+	bdevProvider  *bdev.ClassProvider
 	scmProvider   *scm.Provider
 	msClient      *mgmtSvcClient
 	instanceReady chan *srvpb.NotifyReadyReq
@@ -75,7 +76,7 @@ type IOServerInstance struct {
 // NewIOServerInstance returns an *IOServerInstance initialized with
 // its dependencies.
 func NewIOServerInstance(log logging.Logger,
-	bp *storage.BdevProvider, sp *scm.Provider,
+	bp *bdev.ClassProvider, sp *scm.Provider,
 	msc *mgmtSvcClient, r IOServerStarter) *IOServerInstance {
 
 	return &IOServerInstance{

--- a/src/control/server/server.go
+++ b/src/control/server/server.go
@@ -40,7 +40,7 @@ import (
 	"github.com/daos-stack/daos/src/control/logging"
 	"github.com/daos-stack/daos/src/control/security"
 	"github.com/daos-stack/daos/src/control/server/ioserver"
-	"github.com/daos-stack/daos/src/control/server/storage"
+	"github.com/daos-stack/daos/src/control/server/storage/bdev"
 	"github.com/daos-stack/daos/src/control/server/storage/scm"
 )
 
@@ -94,7 +94,7 @@ func Start(log *logging.LeveledLogger, cfg *Configuration) error {
 			break
 		}
 
-		bp, err := storage.NewBdevProvider(log, srvCfg.Storage.SCM.MountPoint, &srvCfg.Storage.Bdev)
+		bp, err := bdev.NewClassProvider(log, srvCfg.Storage.SCM.MountPoint, &srvCfg.Storage.Bdev)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
No functional changes, just a preparatory step toward moving
all nvme/spdk logic into bdev package.