### PR TITLE
DAOS-3786 vos: dtx_handle::dth_ent can be NULL for vos_dtx_prepared

### DIFF
--- a/src/vos/vos_dtx.c
+++ b/src/vos/vos_dtx.c
@@ -844,7 +844,8 @@ vos_dtx_prepared(struct dtx_handle *dth)
 	struct vos_dtx_entry_df	*dtx;
 	int			 rc = 0;
 
-	D_ASSERT(!dtx_is_null(dth->dth_ent));
+	if (dtx_is_null(dth->dth_ent))
+		return 0;
 
 	cont = vos_hdl2cont(dth->dth_coh);
 	D_ASSERT(cont != NULL);


### PR DESCRIPTION
It is possible that the modification request sponsored by the client
changes nothing on the server. For example, the given IOD for update
is zero size (daos_recx_t::rx_nr is 0), under such case, it will not
generate DTX entry on the server. So vos_dtx_prepared needs to check
such case and return directly.

Signed-off-by: Fan Yong <fan.yong@intel.com>