### PR TITLE
Adding runtime packages to the Docker images

### DIFF
--- a/utils/docker/Dockerfile.centos.7
+++ b/utils/docker/Dockerfile.centos.7
@@ -68,6 +68,7 @@ RUN yum -y install \
            python2-avocado python2-avocado-plugins-output-html \
            python2-avocado-plugins-varianter-yaml-to-mux       \
            yum-plugin-copr python-pathlib                      \
+           ndctl ipmctl                                        \
            python2-clustershell python2-Cython python2-pip;    \
     yum -y copr enable jhli/ipmctl;                            \
     yum -y copr enable jhli/safeclib;                          \

--- a/utils/docker/Dockerfile.ubuntu.18.04
+++ b/utils/docker/Dockerfile.ubuntu.18.04
@@ -35,7 +35,7 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y \
     add-apt-repository ppa:jhli/libsafec;                               \
     add-apt-repository ppa:jhli/ipmctl;                                 \
     apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y \
-                       libsafec-dev libipmctl-dev
+                       libsafec-dev libipmctl-dev ndctl ipmctl
 
 # hack the default shell to bash instead of dash
 RUN rm /bin/sh && ln -s bash /bin/sh


### PR DESCRIPTION
This minimalistic PR adds the following packages:

 - ndctl
 - ipmctl

to both Ubuntu and CentOS based Dockerfile. Those packages allow the resulting container to be used as the runtime, just as pointed on the instructions at https://daos-stack.github.io/admin/installation/#running-daos-service-in-docker

Without those packages, the `orterun` command will fail in certain scenarios (in my scenario I was using `dcpm` SCM class, so at least that was failing).

With those changes, the resulting images have both `ndctl` and `ipmctl` utilities.