### PR TITLE
DAOS-3788 control: Quiet daos_admin logging

### DIFF
--- a/src/control/lib/ipmctl/nvm.go
+++ b/src/control/lib/ipmctl/nvm.go
@@ -70,7 +70,6 @@ func (n *NvmMgmt) Discover() (devices []DeviceDiscovery, err error) {
 		return
 	}
 	if count == 0 {
-		println("no NVDIMMs found!")
 		return
 	}
 

--- a/src/control/pbin/pbin.go
+++ b/src/control/pbin/pbin.go
@@ -29,4 +29,8 @@ const (
 	// DisableReqFwdEnvVar is the name of the environment variable which
 	// can be set to disable forwarding requests to the privileged binary.
 	DisableReqFwdEnvVar = "DAOS_DISABLE_REQ_FWD"
+
+	// DaosAdminLogFileEnvVar is the name of the environment variable which
+	// can be set to enable non-ERROR logging in the privileged binary.
+	DaosAdminLogFileEnvVar = "DAOS_ADMIN_LOG_FILE"
 )

--- a/src/control/server/config.go
+++ b/src/control/server/config.go
@@ -65,6 +65,7 @@ type Configuration struct {
 	ControlLogMask      ControlLogLevel           `yaml:"control_log_mask"`
 	ControlLogFile      string                    `yaml:"control_log_file"`
 	ControlLogJSON      bool                      `yaml:"control_log_json,omitempty"`
+	HelperLogFile       string                    `yaml:"helper_log_file"`
 	UserName            string                    `yaml:"user_name"`
 	GroupName           string                    `yaml:"group_name"`
 	RecreateSuperblocks bool                      `yaml:"recreate_superblocks"`
@@ -281,6 +282,12 @@ func (c *Configuration) WithControlLogFile(filePath string) *Configuration {
 // WithControlLogJSON enables or disables JSON output.
 func (c *Configuration) WithControlLogJSON(enabled bool) *Configuration {
 	c.ControlLogJSON = enabled
+	return c
+}
+
+// WithHelperLogFile sets the path to the daos_admin logfile.
+func (c *Configuration) WithHelperLogFile(filePath string) *Configuration {
+	c.HelperLogFile = filePath
 	return c
 }
 

--- a/src/control/server/instance.go
+++ b/src/control/server/instance.go
@@ -56,14 +56,14 @@ type IOServerStarter interface {
 // be used with IOServerHarness to manage and monitor multiple instances
 // per node.
 type IOServerInstance struct {
-	log           logging.Logger
-	runner        IOServerStarter
-	bdevProvider  *bdev.ClassProvider
-	scmProvider   *scm.Provider
-	msClient      *mgmtSvcClient
-	instanceReady chan *srvpb.NotifyReadyReq
-	storageReady  chan struct{}
-	fsRoot        string
+	log               logging.Logger
+	runner            IOServerStarter
+	bdevClassProvider *bdev.ClassProvider
+	scmProvider       *scm.Provider
+	msClient          *mgmtSvcClient
+	instanceReady     chan *srvpb.NotifyReadyReq
+	storageReady      chan struct{}
+	fsRoot            string
 
 	sync.RWMutex
 	// these must be protected by a mutex in order to
@@ -76,17 +76,17 @@ type IOServerInstance struct {
 // NewIOServerInstance returns an *IOServerInstance initialized with
 // its dependencies.
 func NewIOServerInstance(log logging.Logger,
-	bp *bdev.ClassProvider, sp *scm.Provider,
+	bcp *bdev.ClassProvider, sp *scm.Provider,
 	msc *mgmtSvcClient, r IOServerStarter) *IOServerInstance {
 
 	return &IOServerInstance{
-		log:           log,
-		runner:        r,
-		bdevProvider:  bp,
-		scmProvider:   sp,
-		msClient:      msc,
-		instanceReady: make(chan *srvpb.NotifyReadyReq),
-		storageReady:  make(chan struct{}),
+		log:               log,
+		runner:            r,
+		bdevClassProvider: bcp,
+		scmProvider:       sp,
+		msClient:          msc,
+		instanceReady:     make(chan *srvpb.NotifyReadyReq),
+		storageReady:      make(chan struct{}),
 	}
 }
 
@@ -205,10 +205,10 @@ func (srv *IOServerInstance) Start(ctx context.Context, errChan chan<- error) er
 			return errors.Wrap(err, "start failed; no superblock")
 		}
 	}
-	if err := srv.bdevProvider.PrepareDevices(); err != nil {
+	if err := srv.bdevClassProvider.PrepareDevices(); err != nil {
 		return errors.Wrap(err, "start failed; unable to prepare NVMe device(s)")
 	}
-	if err := srv.bdevProvider.GenConfigFile(); err != nil {
+	if err := srv.bdevClassProvider.GenConfigFile(); err != nil {
 		return errors.Wrap(err, "start failed; unable to generate NVMe configuration for SPDK")
 	}
 

--- a/src/control/server/server.go
+++ b/src/control/server/server.go
@@ -38,6 +38,7 @@ import (
 	ctlpb "github.com/daos-stack/daos/src/control/common/proto/ctl"
 	mgmtpb "github.com/daos-stack/daos/src/control/common/proto/mgmt"
 	"github.com/daos-stack/daos/src/control/logging"
+	"github.com/daos-stack/daos/src/control/pbin"
 	"github.com/daos-stack/daos/src/control/security"
 	"github.com/daos-stack/daos/src/control/server/ioserver"
 	"github.com/daos-stack/daos/src/control/server/storage/bdev"
@@ -68,6 +69,12 @@ func Start(log *logging.LeveledLogger, cfg *Configuration) error {
 
 	// Backup active config.
 	saveActiveConfig(log, cfg)
+
+	if cfg.HelperLogFile != "" {
+		if err := os.Setenv(pbin.DaosAdminLogFileEnvVar, cfg.HelperLogFile); err != nil {
+			return errors.Wrap(err, "unable to configure privileged helper logging")
+		}
+	}
 
 	// Create the root context here. All contexts should
 	// inherit from this one so that they can be shut down


### PR DESCRIPTION
Changes default loglevel to ERROR to reduce console spam. Adds
a new server config param (helper_log_file) which, if set, will
enable daos_admin debug logging to that file.

Also includes a small follow-on from the previous DAOS-3485 commit
which moved bdev class functionality into the bdev package.