### PR TITLE
DAOS-3407 control: Add IP address support to HostList

### DIFF
--- a/src/control/lib/hostlist/api_test.go
+++ b/src/control/lib/hostlist/api_test.go
@@ -86,6 +86,10 @@ func TestHostList_Expand(t *testing.T) {
 		"huey,dewey,louie": {
 			expOut: "dewey,huey,louie",
 		},
+		"10.5.1.[10-15]:10001,10.5.1.42:10001": {
+			expOut: `10.5.1.10:10001,10.5.1.11:10001,10.5.1.12:10001,` +
+				`10.5.1.13:10001,10.5.1.14:10001,10.5.1.15:10001,10.5.1.42:10001`,
+		},
 	} {
 		t.Run(input, func(t *testing.T) {
 			gotOut, gotErr := hostlist.Expand(input)
@@ -121,6 +125,10 @@ func TestHostList_Compress(t *testing.T) {
 		"huey,dewey,louie": {
 			expOut: "dewey,huey,louie",
 		},
+		`10.5.1.10:10001,10.5.1.11:10001,10.5.1.12:10001,` +
+			`10.5.1.13:10001,10.5.1.14:10001,10.5.1.15:10001,10.5.1.42:10001`: {
+			expOut: "10.5.1.[10-15,42]:10001",
+		},
 	} {
 		t.Run(input, func(t *testing.T) {
 			gotOut, gotErr := hostlist.Compress(input)
@@ -153,6 +161,10 @@ func TestHostList_Count(t *testing.T) {
 		},
 		"huey,dewey,louie": {
 			expCount: 3,
+		},
+		`10.5.1.10:10001,10.5.1.11:10001,10.5.1.12:10001,10.5.1.13:10001,` +
+			`10.5.1.14:10001,10.5.1.15:10001,10.5.1.42:10001`: {
+			expCount: 7,
 		},
 	} {
 		t.Run(input, func(t *testing.T) {

--- a/src/control/lib/hostlist/hostlist.go
+++ b/src/control/lib/hostlist/hostlist.go
@@ -76,7 +76,12 @@ func (hn *hostName) Parse(input string) error {
 
 	matches := re.FindStringSubmatch(input)
 	if matches == nil {
-		return fmt.Errorf("invalid hostname %q", input)
+		// Try a special case for IP addresses, where the first three octets
+		// are treated as a prefix, and the fourth is treated as a host number.
+		re = regexp.MustCompile(`^(\d{1,3}\.\d{1,3}\.\d{1,3}\.)(\d{1,3})(.*)`)
+		if matches = re.FindStringSubmatch(input); matches == nil {
+			return fmt.Errorf("invalid hostname %q", input)
+		}
 	}
 
 	if len(matches[1]) == 0 {

--- a/src/control/lib/hostlist/hostlist_test.go
+++ b/src/control/lib/hostlist/hostlist_test.go
@@ -72,6 +72,12 @@ func TestHostList_Create(t *testing.T) {
 			expUniqOut:   "node1-[1,3],node2-1",
 			expUniqCount: 3,
 		},
+		"IP address range": {
+			startList:    "10.5.1.[2-32]:10001,10.5.1.42:10001,10.5.1.1:10001",
+			expRawOut:    "10.5.1.[2-32,42,1]:10001",
+			expUniqOut:   "10.5.1.[1-32,42]:10001",
+			expUniqCount: 33,
+		},
 		"duplicates removed": {
 			startList:    "node[1-128],node2,node4,node8,node16,node32,node64,node128",
 			expRawOut:    "node[1-128,2,4,8,16,32,64,128]",


### PR DESCRIPTION
Missed this in testing. IP ranges were correctly handled, but
individual IP addresses were not parsed correctly.