### PR TITLE
DAOS-647 common: Add method to parse ACL principal

### DIFF
--- a/src/common/acl_principal.c
+++ b/src/common/acl_principal.c
@@ -32,7 +32,9 @@
 
 #define DEFAULT_BUF_LEN	1024
 #define USER_PREFIX	"u:"
+#define USER_PREFIX_LEN	(sizeof(USER_PREFIX) - 1)
 #define GRP_PREFIX	"g:"
+#define GRP_PREFIX_LEN	(sizeof(GRP_PREFIX) - 1)
 
 /*
  * No platform-agnostic way to fetch the max buflen - so let's try a
@@ -333,6 +335,25 @@ static int
 get_principal_type_from_str(const char *principal_str,
 			    enum daos_acl_principal_type *type)
 {
+	/*
+	 * Named user or group will be designated by prefix
+	 */
+	if (strncmp(principal_str, USER_PREFIX, USER_PREFIX_LEN) == 0) {
+		*type = DAOS_ACL_USER;
+		return 0;
+	}
+
+	if (strncmp(principal_str, GRP_PREFIX, GRP_PREFIX_LEN) == 0) {
+		*type = DAOS_ACL_GROUP;
+		return 0;
+	}
+
+	if (strncmp(principal_str, DAOS_ACL_PRINCIPAL_EVERYONE,
+		    DAOS_ACL_MAX_PRINCIPAL_BUF_LEN) == 0) {
+		*type = DAOS_ACL_EVERYONE;
+		return 0;
+	}
+
 	if (strncmp(principal_str, DAOS_ACL_PRINCIPAL_OWNER,
 		    DAOS_ACL_MAX_PRINCIPAL_BUF_LEN) == 0) {
 		*type = DAOS_ACL_OWNER;
@@ -345,25 +366,6 @@ get_principal_type_from_str(const char *principal_str,
 		return 0;
 	}
 
-	if (strncmp(principal_str, DAOS_ACL_PRINCIPAL_EVERYONE,
-		    DAOS_ACL_MAX_PRINCIPAL_BUF_LEN) == 0) {
-		*type = DAOS_ACL_EVERYONE;
-		return 0;
-	}
-
-	/*
-	 * Named user or group will be designated by prefix
-	 */
-	if (strncmp(principal_str, USER_PREFIX, strlen(USER_PREFIX)) == 0) {
-		*type = DAOS_ACL_USER;
-		return 0;
-	}
-
-	if (strncmp(principal_str, GRP_PREFIX, strlen(GRP_PREFIX)) == 0) {
-		*type = DAOS_ACL_GROUP;
-		return 0;
-	}
-
 	return -DER_INVAL;
 }
 
@@ -373,9 +375,9 @@ get_start_of_name(const char *principal_str, enum daos_acl_principal_type type)
 	size_t idx;
 
 	if (type == DAOS_ACL_USER)
-		idx = strlen(USER_PREFIX);
+		idx = USER_PREFIX_LEN;
 	else
-		idx = strlen(GRP_PREFIX);
+		idx = GRP_PREFIX_LEN;
 
 	return &principal_str[idx];
 }

--- a/src/common/acl_principal.c
+++ b/src/common/acl_principal.c
@@ -30,7 +30,9 @@
 #include <pwd.h>
 #include <grp.h>
 
-#define DEFAULT_BUF_LEN 1024
+#define DEFAULT_BUF_LEN	1024
+#define USER_PREFIX	"u:"
+#define GRP_PREFIX	"g:"
 
 /*
  * No platform-agnostic way to fetch the max buflen - so let's try a
@@ -308,4 +310,117 @@ daos_acl_principal_to_gid(const char *principal, gid_t *gid)
 out:
 	D_FREE(buf);
 	return rc;
+}
+
+static bool
+is_special_type(enum daos_acl_principal_type type)
+{
+	switch (type) {
+	case DAOS_ACL_OWNER:
+	case DAOS_ACL_OWNER_GROUP:
+	case DAOS_ACL_EVERYONE:
+		return true;
+	case DAOS_ACL_USER:
+	case DAOS_ACL_GROUP:
+	default:
+		break;
+	}
+
+	return false;
+}
+
+static int
+get_principal_type_from_str(const char *principal_str,
+			    enum daos_acl_principal_type *type)
+{
+	if (strncmp(principal_str, DAOS_ACL_PRINCIPAL_OWNER,
+		    DAOS_ACL_MAX_PRINCIPAL_BUF_LEN) == 0) {
+		*type = DAOS_ACL_OWNER;
+		return 0;
+	}
+
+	if (strncmp(principal_str, DAOS_ACL_PRINCIPAL_OWNER_GRP,
+		    DAOS_ACL_MAX_PRINCIPAL_BUF_LEN) == 0) {
+		*type = DAOS_ACL_OWNER_GROUP;
+		return 0;
+	}
+
+	if (strncmp(principal_str, DAOS_ACL_PRINCIPAL_EVERYONE,
+		    DAOS_ACL_MAX_PRINCIPAL_BUF_LEN) == 0) {
+		*type = DAOS_ACL_EVERYONE;
+		return 0;
+	}
+
+	/*
+	 * Named user or group will be designated by prefix
+	 */
+	if (strncmp(principal_str, USER_PREFIX, strlen(USER_PREFIX)) == 0) {
+		*type = DAOS_ACL_USER;
+		return 0;
+	}
+
+	if (strncmp(principal_str, GRP_PREFIX, strlen(GRP_PREFIX)) == 0) {
+		*type = DAOS_ACL_GROUP;
+		return 0;
+	}
+
+	return -DER_INVAL;
+}
+
+static const char *
+get_start_of_name(const char *principal_str, enum daos_acl_principal_type type)
+{
+	size_t idx;
+
+	if (type == DAOS_ACL_USER)
+		idx = strlen(USER_PREFIX);
+	else
+		idx = strlen(GRP_PREFIX);
+
+	return &principal_str[idx];
+}
+
+int
+daos_acl_principal_from_str(const char *principal_str,
+			    enum daos_acl_principal_type *type,
+			    char **name)
+{
+	int		rc;
+	const char	*p_name;
+
+	if (principal_str == NULL || type == NULL || name == NULL) {
+		D_INFO("Null input: principal_str=%p, type=%p, name=%p\n",
+		       principal_str, type, name);
+		return -DER_INVAL;
+	}
+
+	rc = get_principal_type_from_str(principal_str, type);
+	if (rc != 0) {
+		D_INFO("Badly-formatted principal string\n");
+		return rc;
+	}
+
+	/*
+	 * Nothing else to do for special types.
+	 */
+	if (is_special_type(*type)) {
+		*name = NULL;
+		return 0;
+	}
+
+	/*
+	 * Make sure the name is something sane before we go through the
+	 * trouble of allocating it.
+	 */
+	p_name = get_start_of_name(principal_str, *type);
+	if (!daos_acl_principal_is_valid(p_name)) {
+		D_INFO("Invalid principal name\n");
+		return -DER_INVAL;
+	}
+
+	D_STRNDUP(*name, p_name, DAOS_ACL_MAX_PRINCIPAL_LEN);
+	if (*name == NULL)
+		return -DER_NOMEM;
+
+	return 0;
 }

--- a/src/common/acl_util.c
+++ b/src/common/acl_util.c
@@ -31,13 +31,6 @@
 #include <gurt/debug.h>
 
 /*
- * String values for special principal types
- */
-#define PRINCIPAL_OWNER_STR	"OWNER@"
-#define PRINCIPAL_OWNER_GRP_STR	"GROUP@"
-#define PRINCIPAL_EVERYONE_STR	"EVERYONE@"
-
-/*
  * Characters representing access flags
  */
 #define FLAG_GROUP_CH		'G'
@@ -156,13 +149,13 @@ get_ace_from_identity(const char *identity, uint16_t flags)
 {
 	enum daos_acl_principal_type type;
 
-	if (strncmp(identity, PRINCIPAL_OWNER_STR,
+	if (strncmp(identity, DAOS_ACL_PRINCIPAL_OWNER,
 		    DAOS_ACL_MAX_PRINCIPAL_BUF_LEN) == 0)
 		type = DAOS_ACL_OWNER;
-	else if (strncmp(identity, PRINCIPAL_OWNER_GRP_STR,
+	else if (strncmp(identity, DAOS_ACL_PRINCIPAL_OWNER_GRP,
 			 DAOS_ACL_MAX_PRINCIPAL_BUF_LEN) == 0)
 		type = DAOS_ACL_OWNER_GROUP;
-	else if (strncmp(identity, PRINCIPAL_EVERYONE_STR,
+	else if (strncmp(identity, DAOS_ACL_PRINCIPAL_EVERYONE,
 			 DAOS_ACL_MAX_PRINCIPAL_BUF_LEN) == 0)
 		type = DAOS_ACL_EVERYONE;
 	else if (flags & DAOS_ACL_FLAG_GROUP)
@@ -305,11 +298,11 @@ get_principal_name_str(struct daos_ace *ace)
 {
 	switch (ace->dae_principal_type) {
 	case DAOS_ACL_OWNER:
-		return PRINCIPAL_OWNER_STR;
+		return DAOS_ACL_PRINCIPAL_OWNER;
 	case DAOS_ACL_OWNER_GROUP:
-		return PRINCIPAL_OWNER_GRP_STR;
+		return DAOS_ACL_PRINCIPAL_OWNER_GRP;
 	case DAOS_ACL_EVERYONE:
-		return PRINCIPAL_EVERYONE_STR;
+		return DAOS_ACL_PRINCIPAL_EVERYONE;
 	case DAOS_ACL_USER:
 	case DAOS_ACL_GROUP:
 	default:

--- a/src/include/daos_security.h
+++ b/src/include/daos_security.h
@@ -51,6 +51,13 @@ extern "C" {
 #define DAOS_ACL_MAX_PRINCIPAL_BUF_LEN	(DAOS_ACL_MAX_PRINCIPAL_LEN + 1)
 
 /**
+ * String values for the special principal types
+ */
+#define DAOS_ACL_PRINCIPAL_OWNER	"OWNER@"
+#define DAOS_ACL_PRINCIPAL_OWNER_GRP	"GROUP@"
+#define DAOS_ACL_PRINCIPAL_EVERYONE	"EVERYONE@"
+
+/**
  * Maximum length of daos_acl::dal_ace (dal_len's value).
  */
 #define DAOS_ACL_MAX_ACE_LEN		(8192)
@@ -491,6 +498,31 @@ daos_acl_from_strs(const char **ace_strs, size_t ace_nr, struct daos_acl **acl);
  */
 int
 daos_acl_to_strs(struct daos_acl *acl, char ***ace_strs, size_t *ace_nr);
+
+/**
+ * Convert a formatted principal string to an ACL principal type and name
+ * suitable for creating or looking up an Access Control Entry.
+ *
+ * The format of the input string is:
+ * - For named user: "u:username@"
+ * - For named group: "g:groupname@"
+ * - For special types: "OWNER@", "GROUP@", or "EVERYONE@"
+ *
+ * \param[in]	principal_str	Formatted principal string
+ * \param[out]	type		Type determined from the string
+ * \param[out]	name		Newly-allocated name string. Caller is
+ *				responsible for freeing.
+ *				Result may be NULL if the principal is one of
+ *				the special types.
+ *
+ * \return	0		Success
+ *		-DER_INVAL	Invalid input
+ *		-DER_NOMEM	Could not allocate memory
+ */
+int
+daos_acl_principal_from_str(const char *principal_str,
+			    enum daos_acl_principal_type *type,
+			    char **name);
 
 #if defined(__cplusplus)
 }


### PR DESCRIPTION
Commands to delete ACL entries need a format that
designates user and group principal names on the
command line.

This patch adds a common method to decode principal
names in that string format to a type and name,
which can be used to manipulate daos_acl and daos_ace
structures.

Signed-off-by: Kris Jacque <kristin.jacque@intel.com>