### PR TITLE
DAOS-3650 vos: add version for pool and smd DF

### DIFF
--- a/src/bio/smd/smd_internal.h
+++ b/src/bio/smd/smd_internal.h
@@ -43,10 +43,18 @@ POBJ_LAYOUT_END(smd_md_layout);
 /* Maximum target(VOS xstream) count */
 #define SMD_MAX_TGT_CNT		64
 
+#define SMD_DF_MAGIC		0x5eaf00d
+
+#define SMD_DF_VER_1		1
+/* The current SMD DF version */
+#define SMD_DF_VERSION		SMD_DF_VER_1
+
 /* SMD root durable format */
 struct smd_df {
+	/** magic number to idenfity durable formatn */
 	uint32_t	smd_magic;
-	uint32_t	smd_compat;
+	/** the current version of durable format */
+	uint32_t	smd_version;
 	struct btr_root	smd_dev_tab;	/* device table */
 	struct btr_root	smd_pool_tab;	/* pool table */
 	struct btr_root	smd_tgt_tab;	/* target table */

--- a/src/bio/smd/smd_store.c
+++ b/src/bio/smd/smd_store.c
@@ -103,7 +103,6 @@ smd_store_check(char *fname, bool *existing)
 }
 
 #define SMD_FILE_SIZE	(128UL << 20)	/* 128MB */
-#define SMD_MAGIC	(0xdcab0918)
 #define SMD_TREE_ODR	32
 
 static int
@@ -172,7 +171,11 @@ smd_store_create(char *fname)
 		goto tx_end;
 
 	memset(smd_df, 0, sizeof(*smd_df));
-	smd_df->smd_magic = SMD_MAGIC;
+	smd_df->smd_magic = SMD_DF_MAGIC;
+	if (DAOS_FAIL_CHECK(FLC_SMD_DF_VER))
+		smd_df->smd_version = 0;
+	else
+		smd_df->smd_version = SMD_DF_VERSION;
 
 	/* Create device table */
 	rc = dbtree_create_inplace(DBTREE_CLASS_UV, 0, SMD_TREE_ODR, &uma,
@@ -261,6 +264,19 @@ smd_store_open(char *fname)
 	}
 
 	smd_df = smd_pop2df(ph);
+	if (smd_df->smd_magic != SMD_DF_MAGIC) {
+		D_CRIT("Unknown DF magic %x\n", smd_df->smd_magic);
+		rc = -DER_DF_INVAL;
+		goto error;
+	}
+
+	if (smd_df->smd_version > SMD_DF_VERSION ||
+	    smd_df->smd_version < SMD_DF_VER_1) {
+		D_ERROR("Unsupported DF version %d\n", smd_df->smd_version);
+		rc = -DER_DF_INCOMPT;
+		goto error;
+	}
+
 	/* Open device table */
 	rc = dbtree_open_inplace(&smd_df->smd_dev_tab, &uma,
 				 &smd_store.ss_dev_hdl);

--- a/src/include/daos/common.h
+++ b/src/include/daos/common.h
@@ -545,6 +545,10 @@ enum {
 #define DAOS_CONT_CLOSE_FAIL_CORPC	(DAOS_FAIL_UNIT_TEST_GROUP_LOC | 0x66)
 #define DAOS_CONT_QUERY_FAIL_CORPC	(DAOS_FAIL_UNIT_TEST_GROUP_LOC | 0x67)
 
+/** interoperability failure inject */
+#define FLC_SMD_DF_VER			(DAOS_FAIL_UNIT_TEST_GROUP_LOC | 0x70)
+#define FLC_POOL_DF_VER			(DAOS_FAIL_UNIT_TEST_GROUP_LOC | 0x71)
+
 #define DAOS_FAIL_CHECK(id) daos_fail_check(id)
 
 static inline int __is_po2(unsigned long long val)

--- a/src/include/daos_errno.h
+++ b/src/include/daos_errno.h
@@ -33,6 +33,13 @@ extern "C" {
 
 #include <gurt/errno.h>
 
+#ifndef DER_DF_INCOMPT
+# define DER_DF_INCOMPT		DER_IO
+#endif
+
+#ifndef DER_DF_INVAL
+# define DER_DF_INVAL		DER_IO
+#endif
 
 #if defined(__cplusplus)
 }

--- a/src/vos/tests/vts_pool.c
+++ b/src/vos/tests/vts_pool.c
@@ -60,7 +60,7 @@ pool_set_param(enum vts_ops_type seq[], int cnt, bool flag, bool *cflag,
 }
 
 static int
-pool_ref_count_setup(void **state)
+pool_file_setup(void **state)
 {
 	struct vp_test_args	*arg = *state;
 	int			ret = 0;
@@ -73,6 +73,19 @@ pool_ref_count_setup(void **state)
 
 	ret = vts_alloc_gen_fname(&arg->fname[0]);
 	assert_int_equal(ret, 0);
+	return 0;
+}
+
+static int
+pool_file_destroy(void **state)
+{
+	struct vp_test_args	*arg = *state;
+
+	if (arg->fname[0]) {
+		remove(arg->fname[0]);
+		D_FREE(arg->fname[0]);
+	}
+	D_FREE(arg->fname);
 	return 0;
 }
 
@@ -103,19 +116,26 @@ pool_ref_count_test(void **state)
 	assert_int_equal(ret, 0);
 }
 
-static int
-pool_ref_count_destroy(void **state)
+static void
+pool_interop(void **state)
 {
 	struct vp_test_args	*arg = *state;
+	uuid_t			uuid;
+	daos_handle_t		poh;
+	int			ret;
 
-	if (arg->fname[0]) {
-		remove(arg->fname[0]);
-		D_FREE(arg->fname[0]);
-	}
-	D_FREE(arg->fname);
-	return 0;
+	uuid_generate(uuid);
+
+	daos_fail_loc_set(FLC_POOL_DF_VER | DAOS_FAIL_ONCE);
+	ret = vos_pool_create(arg->fname[0], uuid, VPOOL_16M, 0);
+	assert_int_equal(ret, 0);
+
+	ret = vos_pool_open(arg->fname[0], uuid, &poh);
+	assert_int_equal(ret, -DER_DF_INCOMPT);
+
+	ret = vos_pool_destroy(arg->fname[0], uuid);
+	assert_int_equal(ret, 0);
 }
-
 
 static void
 pool_ops_run(void **state)
@@ -383,10 +403,12 @@ static const struct CMUnitTest pool_tests[] = {
 		pool_ops_run, pool_create_empty, pool_unit_teardown},
 	{ "VOS3: Pool Destroy", pool_ops_run,
 		pool_destroy, pool_unit_teardown},
+	{ "VOS4: Pool DF interoperability", pool_interop,
+		 pool_file_setup, pool_file_destroy},
 	{ "VOS5: Pool Close after open", pool_ops_run,
 		pool_open_close, pool_unit_teardown},
 	{ "VOS6: Pool handle refcount", pool_ref_count_test,
-		 pool_ref_count_setup, pool_ref_count_destroy},
+		 pool_file_setup, pool_file_destroy},
 	{ "VOS7: Pool Query after open", pool_ops_run,
 		pool_query_after_open, pool_unit_teardown},
 	{ "VOS8: Pool all APIs empty file handle", pool_ops_run,

--- a/src/vos/vos_layout.h
+++ b/src/vos/vos_layout.h
@@ -140,28 +140,36 @@ enum vos_gc_type {
 	GC_MAX,
 };
 
+#define POOL_DF_MAGIC				0x5ca1ab1e
+
+#define POOL_DF_VER_1				1
+#define POOL_DF_VERSION				POOL_DF_VER_1
+
 /**
- * VOS Pool root object
+ * Durable format for VOS pool
  */
 struct vos_pool_df {
-	/* Structs stored in LE or BE representation */
+	/** Structs stored in LE or BE representation */
 	uint32_t				pd_magic;
-	/* Unique PoolID for each VOS pool assigned on creation */
-	uuid_t					pd_id;
-	/* Flags for compatibility features */
+	/** durable-format version */
+	uint32_t				pd_version;
+	/** reserved: flags for compatibility features */
 	uint64_t				pd_compat_flags;
-	/* Flags for incompatibility features */
+	/** reserved: flags for incompatibility features */
 	uint64_t				pd_incompat_flags;
-	/* Total space in bytes on SCM */
+	/** Unique PoolID for each VOS pool assigned on creation */
+	uuid_t					pd_id;
+	/** Total space in bytes on SCM */
 	uint64_t				pd_scm_sz;
-	/* Total space in bytes on NVMe */
+	/** Total space in bytes on NVMe */
 	uint64_t				pd_nvme_sz;
-	/* # of containers in this pool */
+	/** # of containers in this pool */
 	uint64_t				pd_cont_nr;
-	/* Typed PMEMoid pointer for the container index table */
+	/** Typed PMEMoid pointer for the container index table */
 	struct btr_root				pd_cont_root;
-	/* Free space tracking for NVMe device */
+	/** Free space tracking for NVMe device */
 	struct vea_space_df			pd_vea_df;
+	/** GC bins for container/object/dkey... */
 	struct vos_gc_bin_df			pd_gc_bins[GC_MAX];
 };
 


### PR DESCRIPTION
- add version for durable formats(DF) of pool and SMD
- check DF version number while openning pool and SMD
- unit test for pool DF version check

NB: SMB unit test is not included in this patch, it might
need some test code reorg and can be in a separate patch.

Signed-off-by: Liang Zhen <liang.zhen@intel.com>