### PR TITLE
DAOS-3780: Fixing few memory leaks in daos_test -i (IO) tests.

### DIFF
--- a/src/tests/suite/daos_obj.c
+++ b/src/tests/suite/daos_obj.c
@@ -1669,6 +1669,9 @@ punch_simple_internal(void **state, daos_obj_id_t oid)
 
 	D_FREE(buf);
 	D_FREE(data_buf);
+	for (i = 0; i < PUNCH_NUM_KEYS; i++) {
+		D_FREE(dkeys[i]);
+	}
 	ioreq_fini(&req);
 	MPI_Barrier(MPI_COMM_WORLD);
 }
@@ -3395,6 +3398,9 @@ split_sgl_internal(void **state, int size)
 	/** close object */
 	rc = daos_obj_close(oh, NULL);
 	assert_int_equal(rc, 0);
+
+	D_FREE(sbuf1);
+	D_FREE(sbuf2);
 }
 
 static void


### PR DESCRIPTION
Signed-off-by: Samir Raval <samir.raval@intel.com>