### PR TITLE
DAOS-3749 aggregation: aggregate only if no I/O

### DIFF
--- a/src/include/daos/common.h
+++ b/src/include/daos/common.h
@@ -476,18 +476,6 @@ daos_crt_network_error(int err)
 #define daos_rank_in_rank_list		d_rank_in_rank_list
 #define daos_rank_list_append		d_rank_list_append
 
-/* the key of various type of parameters, used by DAOS client to set
- * different parameters globally on all servers.
- */
-enum {
-	DSS_KEY_FAIL_LOC = 0,
-	DSS_KEY_FAIL_VALUE,
-	DSS_KEY_FAIL_NUM,
-	DSS_REBUILD_RES_PERCENTAGE,
-	DSS_DISABLE_AGGREGATION,
-	DSS_KEY_NUM,
-};
-
 void
 daos_fail_loc_set(uint64_t id);
 void

--- a/src/include/daos_mgmt.h
+++ b/src/include/daos_mgmt.h
@@ -209,23 +209,6 @@ daos_pool_add_tgt(const uuid_t uuid, const char *grp,
 		  daos_event_t *ev);
 
 /**
- * Set parameter on servers.
- *
- * \param grp	[IN]	Process set name of the DAOS servers managing the pool
- * \param rank	[IN]	Ranks to set parameter. -1 means setting on all servers.
- * \param key_id [IN]	key ID of the parameter.
- * \param value [IN]	value of the parameter.
- * \param value [IN]	optional extra value to set the fail value when
- *			\a key_id is DSS_KEY_FAIL_LOC and \a value is in
- *			DAOS_FAIL_VALUE mode.
- * \param ev	[IN]	Completion event, it is optional and can be NULL.
- *			The function will run in blocking mode if \a ev is NULL.
- */
-int
-daos_mgmt_set_params(const char *grp, d_rank_t rank, unsigned int key_id,
-		     uint64_t value, uint64_t value_extra, daos_event_t *ev);
-
-/**
  * Exclude completely a set of storage targets from a pool. Compared with
  * daos_pool_tgt_exclude(), this API will mark the targets to be DOWNOUT, i.e.
  * the rebuilding for this target is done, while daos_pool_tgt_exclude() only
@@ -348,6 +331,35 @@ daos_pool_remove_replicas(const uuid_t uuid, const char *group,
 int
 daos_mgmt_list_pools(const char *group, daos_size_t *npools,
 		     daos_mgmt_pool_info_t *pools, daos_event_t *ev);
+
+/**
+ * The operation code for DAOS client to set different parameters globally
+ * on all servers.
+ */
+enum {
+	DMG_KEY_FAIL_LOC	 = 0,
+	DMG_KEY_FAIL_VALUE,
+	DMG_KEY_FAIL_NUM,
+	DMG_KEY_REBUILD_THROTTLING,
+	DMG_KEY_NUM,
+};
+
+/**
+ * Set parameter on servers.
+ *
+ * \param grp	[IN]	Process set name of the DAOS servers managing the pool
+ * \param rank	[IN]	Ranks to set parameter. -1 means setting on all servers.
+ * \param key_id [IN]	key ID of the parameter.
+ * \param value [IN]	value of the parameter.
+ * \param value [IN]	optional extra value to set the fail value when
+ *			\a key_id is DMG_CMD_FAIL_LOC and \a value is in
+ *			DAOS_FAIL_VALUE mode.
+ * \param ev	[IN]	Completion event, it is optional and can be NULL.
+ *			The function will run in blocking mode if \a ev is NULL.
+ */
+int
+daos_mgmt_set_params(const char *grp, d_rank_t rank, unsigned int key_id,
+		     uint64_t value, uint64_t value_extra, daos_event_t *ev);
 
 /**
  * Add mark to servers.

--- a/src/include/daos_srv/daos_server.h
+++ b/src/include/daos_srv/daos_server.h
@@ -176,6 +176,7 @@ enum {
 struct dss_xstream;
 
 bool dss_xstream_exiting(struct dss_xstream *dxs);
+bool dss_xstream_is_busy(void);
 
 struct dss_module_info {
 	crt_context_t		dmi_ctx;
@@ -464,6 +465,33 @@ dss_abterr2der(int abt_errno)
 	}
 }
 
+/** RPC counter types */
+enum dss_rpc_cntr_id {
+	DSS_RC_OBJ	= 0,
+	DSS_RC_CONT,
+	DSS_RC_POOL,
+	DSS_RC_MAX,
+};
+
+/** RPC counter */
+struct dss_rpc_cntr {
+	/**
+	 * starting wall-clock time, it can be used to calculate average
+	 * workload.
+	 */
+	uint64_t		rc_stime;
+	/** number of active RPCs */
+	uint64_t		rc_active;
+	/** total number of processed RPCs since \a rc_stime */
+	uint64_t		rc_total;
+	/** total number of failed RPCs since \a rc_stime */
+	uint64_t		rc_errors;
+};
+
+void dss_rpc_cntr_enter(enum dss_rpc_cntr_id id);
+void dss_rpc_cntr_exit(enum dss_rpc_cntr_id id, bool failed);
+struct dss_rpc_cntr *dss_rpc_cntr_get(enum dss_rpc_cntr_id id);
+
 int dss_rpc_send(crt_rpc_t *rpc);
 void dss_sleep(int ms);
 int dss_rpc_reply(crt_rpc_t *rpc, unsigned int fail_loc);
@@ -622,7 +650,7 @@ void dss_init_state_set(enum dss_init_state state);
  */
 void dss_gc_run(daos_handle_t poh, int credits);
 
-bool dss_aggregation_disabled(void);
+bool dss_agg_disabled(void);
 
 int notify_bio_error(bool unmap, bool update, int tgt_id);
 

--- a/src/iosrv/srv.c
+++ b/src/iosrv/srv.c
@@ -36,6 +36,7 @@
 #include <daos/common.h>
 #include <daos/event.h>
 #include <daos_errno.h>
+#include <daos_mgmt.h>
 #include <daos_srv/bio.h>
 #include <daos_srv/smd.h>
 #include <daos_srv/vos.h>
@@ -108,13 +109,6 @@ static void dss_gc_ult(void *args);
 #define REBUILD_DEFAULT_SCHEDULE_RATIO	30
 unsigned int	dss_rebuild_res_percentage = REBUILD_DEFAULT_SCHEDULE_RATIO;
 unsigned int	dss_first_res_percentage = FIRST_DEFAULT_SCHEDULE_RATIO;
-bool		dss_agg_disabled;
-
-bool
-dss_aggregation_disabled(void)
-{
-	return dss_agg_disabled;
-}
 
 #define DSS_SYS_XS_NAME_FMT	"daos_sys_%d"
 #define DSS_TGT_XS_NAME_FMT	"daos_tgt_%d_xs_%d"
@@ -337,8 +331,7 @@ check_sleep_list()
 		shutdown = true;
 
 	daos_gettime_coarse(&now);
-	d_list_for_each_entry_safe(dsu, tmp, &dx->dx_sleep_ult_list,
-				   dsu_list) {
+	d_list_for_each_entry_safe(dsu, tmp, &dx->dx_sleep_ult_list, dsu_list) {
 		if (dsu->dsu_expire_time <= now || shutdown)
 			dss_ult_wakeup(dsu);
 		else
@@ -426,6 +419,44 @@ dss_sched_create(ABT_pool *pools, int pool_num, ABT_sched *new_sched)
 	ABT_sched_config_free(&config);
 
 	return dss_abterr2der(ret);
+}
+
+struct dss_rpc_cntr *
+dss_rpc_cntr_get(enum dss_rpc_cntr_id id)
+{
+	struct dss_xstream  *dx = dss_xstream_get(DSS_XS_SELF);
+
+	D_ASSERT(id < DSS_RC_MAX);
+	return &dx->dx_rpc_cntrs[id];
+}
+
+/** increase the active and total counters for the RPC type */
+void
+dss_rpc_cntr_enter(enum dss_rpc_cntr_id id)
+{
+	struct dss_rpc_cntr *cntr = dss_rpc_cntr_get(id);
+
+	/* TODO: add interface to calculate average workload and reset stime */
+	if (cntr->rc_stime == 0)
+		daos_gettime_coarse(&cntr->rc_stime);
+
+	cntr->rc_active++;
+	cntr->rc_total++;
+}
+
+/**
+ * Decrease the active counter for the RPC type, also increase error counter
+ * if @faield is true.
+ */
+void
+dss_rpc_cntr_exit(enum dss_rpc_cntr_id id, bool error)
+{
+	struct dss_rpc_cntr *cntr = dss_rpc_cntr_get(id);
+
+	D_ASSERT(cntr->rc_active > 0);
+	cntr->rc_active--;
+	if (error)
+		cntr->rc_errors++;
 }
 
 /**
@@ -900,6 +931,14 @@ static bool
 dss_xstreams_empty(void)
 {
 	return xstream_data.xd_xs_nr == 0;
+}
+
+bool
+dss_xstream_is_busy(void)
+{
+	struct dss_rpc_cntr *cntr = dss_rpc_cntr_get(DSS_RC_OBJ);
+
+	return cntr->rc_active != 0;
 }
 
 static int
@@ -1597,15 +1636,15 @@ dss_parameters_set(unsigned int key_id, uint64_t value)
 	int rc = 0;
 
 	switch (key_id) {
-	case DSS_KEY_FAIL_LOC:
+	case DMG_KEY_FAIL_LOC:
 		daos_fail_loc_set(value);
 		break;
-	case DSS_KEY_FAIL_VALUE:
+	case DMG_KEY_FAIL_VALUE:
 		daos_fail_value_set(value);
 		break;
-	case DSS_KEY_FAIL_NUM:
+	case DMG_KEY_FAIL_NUM:
 		daos_fail_num_set(value);
-	case DSS_REBUILD_RES_PERCENTAGE:
+	case DMG_KEY_REBUILD_THROTTLING:
 		if (value >= 100) {
 			D_ERROR("invalid value "DF_U64"\n", value);
 			rc = -DER_INVAL;
@@ -1613,11 +1652,6 @@ dss_parameters_set(unsigned int key_id, uint64_t value)
 		}
 		D_WARN("set rebuild percentage to "DF_U64"\n", value);
 		dss_rebuild_res_percentage = value;
-		break;
-	case DSS_DISABLE_AGGREGATION:
-		dss_agg_disabled = (value != 0);
-		D_WARN("online aggregation is %s\n",
-		       value != 0 ? "disabled" : "enabled");
 		break;
 	default:
 		D_ERROR("invalid key_id %d\n", key_id);

--- a/src/iosrv/srv_internal.h
+++ b/src/iosrv/srv_internal.h
@@ -27,26 +27,27 @@
 
 /** Per-xstream configuration data */
 struct dss_xstream {
-	char		dx_name[DSS_XS_NAME_LEN];
-	ABT_future	dx_shutdown;
-	hwloc_cpuset_t	dx_cpuset;
-	ABT_xstream	dx_xstream;
-	ABT_pool	dx_pools[DSS_POOL_CNT];
-	ABT_sched	dx_sched;
-	ABT_thread	dx_progress;
-	d_list_t	dx_sleep_ult_list;
-	tse_sched_t	dx_sched_dsc;
+	char			dx_name[DSS_XS_NAME_LEN];
+	ABT_future		dx_shutdown;
+	hwloc_cpuset_t		dx_cpuset;
+	ABT_xstream		dx_xstream;
+	ABT_pool		dx_pools[DSS_POOL_CNT];
+	ABT_sched		dx_sched;
+	ABT_thread		dx_progress;
+	d_list_t		dx_sleep_ult_list;
+	tse_sched_t		dx_sched_dsc;
+	struct dss_rpc_cntr	dx_rpc_cntrs[DSS_RC_MAX];
 	/* xstream id, [0, DSS_XS_NR_TOTAL - 1] */
-	int		dx_xs_id;
+	int			dx_xs_id;
 	/* VOS target id, [0, dss_tgt_nr - 1]. Invalid (-1) for system XS.
 	 * For offload XS it is same value as its main XS.
 	 */
-	int		dx_tgt_id;
+	int			dx_tgt_id;
 	/* CART context id, invalid (-1) for the offload XS w/o CART context */
-	int		dx_ctx_id;
-	bool		dx_main_xs;	/* true for main XS */
-	bool		dx_comm;	/* true with cart context */
-	bool		dx_dsc_started;	/* DSC progress ULT started */
+	int			dx_ctx_id;
+	bool			dx_main_xs;	/* true for main XS */
+	bool			dx_comm;	/* true with cart context */
+	bool			dx_dsc_started;	/* DSC progress ULT started */
 };
 
 /** Server node topology */

--- a/src/mgmt/srv.c
+++ b/src/mgmt/srv.c
@@ -37,6 +37,7 @@
 #include <daos_srv/daos_server.h>
 #include <daos_srv/rsvc.h>
 #include <daos/drpc_modules.h>
+#include <daos_mgmt.h>
 
 #include "srv_internal.h"
 #include "drpc_internal.h"
@@ -178,8 +179,8 @@ ds_mgmt_params_set_hdlr(crt_rpc_t *rpc)
 	if (ps_in->ps_rank != -1) {
 		/* Only set local parameter */
 		rc = dss_parameters_set(ps_in->ps_key_id, ps_in->ps_value);
-		if (rc == 0 && ps_in->ps_key_id == DSS_KEY_FAIL_LOC)
-			rc = dss_parameters_set(DSS_KEY_FAIL_VALUE,
+		if (rc == 0 && ps_in->ps_key_id == DMG_KEY_FAIL_LOC)
+			rc = dss_parameters_set(DMG_KEY_FAIL_VALUE,
 						ps_in->ps_value_extra);
 		if (rc)
 			D_ERROR("Set parameter failed key_id %d: rc %d\n",

--- a/src/mgmt/srv_target.c
+++ b/src/mgmt/srv_target.c
@@ -35,6 +35,7 @@
 #include <daos_srv/vos.h>
 #include <daos_srv/pool.h>
 #include <daos_srv/daos_mgmt_srv.h>
+#include <daos_mgmt.h>
 
 #include "srv_internal.h"
 #include "srv_layout.h"		/* for a couple of constants only */
@@ -736,8 +737,8 @@ ds_mgmt_tgt_params_set_hdlr(crt_rpc_t *rpc)
 	D_ASSERT(in != NULL);
 
 	rc = dss_parameters_set(in->tps_key_id, in->tps_value);
-	if (rc == 0 && in->tps_key_id == DSS_KEY_FAIL_LOC)
-		rc = dss_parameters_set(DSS_KEY_FAIL_VALUE,
+	if (rc == 0 && in->tps_key_id == DMG_KEY_FAIL_LOC)
+		rc = dss_parameters_set(DMG_KEY_FAIL_VALUE,
 					in->tps_value_extra);
 	if (rc)
 		D_ERROR("Set parameter failed key_id %d: rc %d\n",

--- a/src/object/srv_obj.c
+++ b/src/object/srv_obj.c
@@ -44,6 +44,15 @@
 #include "obj_rpc.h"
 #include "obj_internal.h"
 
+/* handles, pointers for handling I/O */
+struct obj_io_context {
+	struct ds_cont_hdl	*ioc_coh;
+	struct ds_cont_child	*ioc_coc;
+	daos_handle_t		 ioc_vos_coh;
+	uint32_t		 ioc_map_ver;
+	bool			 ioc_began;
+};
+
 static int
 obj_verify_bio_csum(crt_rpc_t *rpc, struct bio_desc *biod,
 		    struct daos_csummer *csummer);
@@ -133,8 +142,8 @@ obj_rw_reply(crt_rpc_t *rpc, int status, uint32_t map_version,
 
 struct obj_bulk_args {
 	int		bulks_inflight;
-	ABT_eventual	eventual;
 	int		result;
+	ABT_eventual	eventual;
 };
 
 static int
@@ -352,33 +361,6 @@ obj_bulk_transfer(crt_rpc_t *rpc, crt_bulk_op_t bulk_op, bool bulk_bind,
 }
 
 static int
-obj_prep_enum_sgls(d_sg_list_t *dst_sgls, d_sg_list_t *sgls, int number)
-{
-	int i;
-	int j;
-	int rc = 0;
-
-	for (i = 0; i < number; i++) {
-		dst_sgls[i].sg_nr = sgls[i].sg_nr;
-		D_ALLOC_ARRAY(dst_sgls[i].sg_iovs, sgls[i].sg_nr);
-		if (dst_sgls[i].sg_iovs == NULL)
-			D_GOTO(out, rc = -DER_NOMEM);
-
-		for (j = 0; j < dst_sgls[i].sg_nr; j++) {
-			dst_sgls[i].sg_iovs[j].iov_buf_len =
-				sgls[i].sg_iovs[j].iov_buf_len;
-
-			D_ALLOC(dst_sgls[i].sg_iovs[j].iov_buf,
-				dst_sgls[i].sg_iovs[j].iov_buf_len);
-			if (dst_sgls[i].sg_iovs[j].iov_buf == NULL)
-				D_GOTO(out, rc = -DER_NOMEM);
-		}
-	}
-out:
-	return rc;
-}
-
-static int
 obj_set_reply_sizes(crt_rpc_t *rpc)
 {
 	struct obj_rw_in	*orw = crt_req_get(rpc);
@@ -477,75 +459,8 @@ obj_set_reply_nrs(crt_rpc_t *rpc, daos_handle_t ioh, d_sg_list_t *sgls)
 	return 0;
 }
 
-/**
- * Lookup and return the container handle, if it is a rebuild handle, which
- * will never associate a particular container, then the container structure
- * will be returned to \a contp.
- */
-static int
-obj_verify_cont_hdl(uuid_t pool_uuid, uuid_t cont_hdl_uuid, uuid_t cont_uuid,
-		    int opc, struct ds_cont_hdl **hdlp,
-		    struct ds_cont_child **contp)
-{
-	struct ds_cont_hdl	*cont_hdl;
-	int			 rc;
-
-	rc = cont_iv_capa_fetch(pool_uuid, cont_hdl_uuid, cont_uuid, &cont_hdl);
-	if (rc) {
-		if (rc == -DER_NONEXIST)
-			rc = -DER_NO_HDL;
-		D_GOTO(out, rc);
-	}
-
-	if (obj_is_modification_opc(opc) &&
-	    !(cont_hdl->sch_capas & DAOS_COO_RW)) {
-		D_ERROR("cont "DF_UUID" hdl "DF_UUID" sch_capas "DF_U64", "
-			"NO_PERM to update.\n", DP_UUID(cont_uuid),
-			DP_UUID(cont_hdl_uuid), cont_hdl->sch_capas);
-		D_GOTO(out, rc = -DER_NO_PERM);
-	}
-
-	/* normal container open handle with ds_cont_child attached */
-	if (cont_hdl->sch_cont != NULL) {
-		ds_cont_child_get(cont_hdl->sch_cont);
-		*contp = cont_hdl->sch_cont;
-		D_GOTO(out, rc = 0);
-	}
-
-	if (!is_rebuild_container(pool_uuid, cont_hdl_uuid)) {
-		D_ERROR("Empty container "DF_UUID" (ref=%d) handle?\n",
-			DP_UUID(cont_uuid), cont_hdl->sch_ref);
-		D_GOTO(out, rc = -DER_NO_HDL);
-	}
-
-	/* rebuild handle is a dummy and never attached by a real container */
-	if (DAOS_FAIL_CHECK(DAOS_REBUILD_NO_HDL))
-		D_GOTO(out, rc = -DER_NO_HDL);
-
-	if (DAOS_FAIL_CHECK(DAOS_REBUILD_STALE_POOL))
-		D_GOTO(out, rc = -DER_STALE);
-
-	D_DEBUG(DB_TRACE, DF_UUID"/%p is rebuild cont hdl\n",
-		DP_UUID(cont_hdl_uuid), cont_hdl);
-
-	/* load VOS container on demand for rebuild */
-	rc = ds_cont_child_lookup(pool_uuid, cont_uuid, contp);
-	if (rc)
-		D_GOTO(out, rc);
-out:
-	if (cont_hdl != NULL && rc != 0) {
-		ds_cont_hdl_put(cont_hdl);
-		cont_hdl = NULL;
-	}
-
-	*hdlp = cont_hdl;
-
-	return rc;
-}
-
-void
-ds_obj_rw_echo_handler(crt_rpc_t *rpc, daos_iod_t *split_iods,
-		      uint64_t *split_offs)
+static void
+obj_echo_rw(crt_rpc_t *rpc, daos_iod_t *split_iods, uint64_t *split_offs)
 {
 	struct obj_rw_in	*orw = crt_req_get(rpc);
 	struct obj_rw_out	*orwo = crt_reply_get(rpc);
@@ -886,7 +801,7 @@ obj_local_rw(crt_rpc_t *rpc, struct ds_cont_hdl *cont_hdl,
 
 	if (daos_obj_is_echo(orw->orw_oid.id_pub) ||
 	    (daos_io_bypass & IOBP_TARGET)) {
-		ds_obj_rw_echo_handler(rpc, split_iods, split_offs);
+		obj_echo_rw(rpc, split_iods, split_offs);
 		D_GOTO(out, rc = 0);
 	}
 
@@ -990,31 +905,106 @@ out:
 	return rc;
 }
 
+/**
+ * Lookup and return the container handle, if it is a rebuild handle, which
+ * will never associate a particular container, then the container structure
+ * will be returned to \a ioc::ioc_coc.
+ */
+static int
+obj_ioc_init(uuid_t pool_uuid, uuid_t coh_uuid, uuid_t cont_uuid, int opc,
+	     struct obj_io_context *ioc)
+{
+	struct ds_cont_hdl   *coh;
+	struct ds_cont_child *coc;
+	int		      rc;
+
+	memset(ioc, 0, sizeof(*ioc));
+	rc = cont_iv_capa_fetch(pool_uuid, coh_uuid, cont_uuid, &coh);
+	if (rc) {
+		if (rc == -DER_NONEXIST)
+			rc = -DER_NO_HDL;
+		return rc;
+	}
+
+	if (obj_is_modification_opc(opc) && !(coh->sch_capas & DAOS_COO_RW)) {
+		D_ERROR("cont "DF_UUID" hdl "DF_UUID" sch_capas "DF_U64", "
+			"NO_PERM to update.\n", DP_UUID(cont_uuid),
+			DP_UUID(coh_uuid), coh->sch_capas);
+		D_GOTO(failed, rc = -DER_NO_PERM);
+	}
+
+	/* normal container open handle with ds_cont_child attached */
+	if (coh->sch_cont != NULL) {
+		ds_cont_child_get(coh->sch_cont);
+		coc = coh->sch_cont;
+		D_GOTO(out, rc = 0);
+	}
+
+	if (!is_rebuild_container(pool_uuid, coh_uuid)) {
+		D_ERROR("Empty container "DF_UUID" (ref=%d) handle?\n",
+			DP_UUID(cont_uuid), coh->sch_ref);
+		D_GOTO(failed, rc = -DER_NO_HDL);
+	}
+
+	/* rebuild handle is a dummy and never attached by a real container */
+	if (DAOS_FAIL_CHECK(DAOS_REBUILD_NO_HDL))
+		D_GOTO(failed, rc = -DER_NO_HDL);
+
+	if (DAOS_FAIL_CHECK(DAOS_REBUILD_STALE_POOL))
+		D_GOTO(failed, rc = -DER_STALE);
+
+	D_DEBUG(DB_TRACE, DF_UUID"/%p is rebuild cont hdl\n",
+		DP_UUID(coh_uuid), coh);
+
+	/* load VOS container on demand for rebuild */
+	rc = ds_cont_child_lookup(pool_uuid, cont_uuid, &coc);
+	if (rc)
+		D_GOTO(failed, rc);
+
+out:
+	D_ASSERT(coc->sc_pool != NULL);
+	ioc->ioc_map_ver = coc->sc_pool->spc_map_version;
+	ioc->ioc_vos_coh = coc->sc_hdl;
+	ioc->ioc_coc	 = coc;
+	ioc->ioc_coh	 = coh;
+	return 0;
+failed:
+	ds_cont_hdl_put(coh);
+	return rc;
+}
+
+static void
+obj_ioc_fini(struct obj_io_context *ioc)
+{
+	if (ioc->ioc_coh != NULL) {
+		ds_cont_hdl_put(ioc->ioc_coh);
+		ioc->ioc_coh = NULL;
+	}
+
+	if (ioc->ioc_coc != NULL) {
+		ds_cont_child_put(ioc->ioc_coc);
+		ioc->ioc_coc = NULL;
+	}
+	ioc->ioc_map_ver = 0;
+}
+
 /* Various check before access VOS */
 static int
-obj_verify_req(daos_unit_oid_t oid, uint32_t rpc_map_ver, uuid_t pool_uuid,
-	       uuid_t hdl_uuid, uuid_t co_uuid, uint32_t opc,
-	       struct ds_cont_hdl **hdlp, struct ds_cont_child **contp,
-	       uint32_t *map_ver)
+obj_ioc_begin(daos_unit_oid_t oid, uint32_t rpc_map_ver, uuid_t pool_uuid,
+	      uuid_t coh_uuid, uuid_t cont_uuid, uint32_t opc,
+	      struct obj_io_context *ioc)
 {
-	struct ds_pool_child	*pool_child;
-	int			 rc;
+	struct ds_pool_child *poc;
+	int		      rc;
 
-	*hdlp = NULL;
-	*contp = NULL;
-	rc = obj_verify_cont_hdl(pool_uuid, hdl_uuid, co_uuid, opc,
-				 hdlp, contp);
+	rc = obj_ioc_init(pool_uuid, coh_uuid, cont_uuid, opc, ioc);
 	if (rc)
 		return rc;
 
-	D_ASSERT((*hdlp) != NULL);
-	D_ASSERT((*contp) != NULL);
+	poc = ioc->ioc_coc->sc_pool;
+	D_ASSERT(poc != NULL);
 
-	pool_child = (*contp)->sc_pool;
-	D_ASSERT(pool_child != NULL);
-	*map_ver = pool_child->spc_map_version;
-
-	if (rpc_map_ver > *map_ver || pool_child->spc_pool->sp_map == NULL ||
+	if (rpc_map_ver > ioc->ioc_map_ver || poc->spc_pool->sp_map == NULL ||
 	    DAOS_FAIL_CHECK(DAOS_FORCE_REFRESH_POOL_MAP)) {
 		/* XXX: Client (or leader replica) has newer pool map than
 		 *	current replica. Two possibile cases:
@@ -1042,32 +1032,38 @@ obj_verify_req(daos_unit_oid_t oid, uint32_t rpc_map_ver, uuid_t pool_uuid,
 		 * pool map to avoid any possible issue
 		 */
 		D_DEBUG(DB_IO, "stale server map_version %d req %d\n",
-			*map_ver, rpc_map_ver);
-		rc = ds_pool_child_map_refresh_async(pool_child);
+			ioc->ioc_map_ver, rpc_map_ver);
+		rc = ds_pool_child_map_refresh_async(poc);
 		if (rc == 0) {
-			*map_ver = pool_child->spc_map_version;
+			ioc->ioc_map_ver = poc->spc_map_version;
 			rc = -DER_STALE;
 		}
 
 		D_GOTO(out_put, rc);
-	} else if (rpc_map_ver < *map_ver) {
+	} else if (rpc_map_ver < ioc->ioc_map_ver) {
 		D_DEBUG(DB_IO, "stale version req %d map_version %d\n",
-			rpc_map_ver, *map_ver);
+			rpc_map_ver, ioc->ioc_map_ver);
 		if (obj_is_modification_opc(opc))
 			D_GOTO(out_put, rc = -DER_STALE);
 		/* It is harmless if fetch with old pool map version. */
 	}
+	dss_rpc_cntr_enter(DSS_RC_OBJ);
+	ioc->ioc_began = true;
+	return 0;
 
 out_put:
-	if (rc) {
-		ds_cont_child_put(*contp);
-		*contp = NULL;
-
-		ds_cont_hdl_put(*hdlp);
-		*hdlp = NULL;
-	}
-
+	obj_ioc_fini(ioc);
 	return rc;
+}
+
+void
+obj_ioc_end(struct obj_io_context *ioc, int err)
+{
+	if (ioc->ioc_began) {
+		dss_rpc_cntr_exit(DSS_RC_OBJ, !!err);
+		ioc->ioc_began = false;
+	}
+	obj_ioc_fini(ioc);
 }
 
 void
@@ -1076,22 +1072,18 @@ ds_obj_tgt_update_handler(crt_rpc_t *rpc)
 	struct obj_rw_in		*orw = crt_req_get(rpc);
 	struct obj_rw_out		*orwo = crt_reply_get(rpc);
 	daos_key_t			*dkey = &orw->orw_dkey;
-	struct ds_cont_hdl		*cont_hdl = NULL;
-	struct ds_cont_child		*cont = NULL;
-	struct dtx_handle		dth = { 0 };
-	struct dtx_handle		*handle = &dth;
+	struct obj_io_context		 ioc;
+	struct dtx_handle                dth = { 0 };
 	struct dtx_conflict_entry	 conflict = { 0 };
-	uint32_t			 map_ver = 0;
 	uint32_t			 opc = opc_get(rpc->cr_opc);
 	int				 rc;
 
 	D_ASSERT(orw != NULL);
 	D_ASSERT(orwo != NULL);
 
-	rc = obj_verify_req(orw->orw_oid, orw->orw_map_ver,
-			    orw->orw_pool_uuid, orw->orw_co_hdl,
-			    orw->orw_co_uuid, opc_get(rpc->cr_opc),
-			    &cont_hdl, &cont, &map_ver);
+	rc = obj_ioc_begin(orw->orw_oid, orw->orw_map_ver,
+			   orw->orw_pool_uuid, orw->orw_co_hdl,
+			   orw->orw_co_uuid, opc_get(rpc->cr_opc), &ioc);
 	if (rc)
 		goto out;
 
@@ -1108,11 +1100,11 @@ ds_obj_tgt_update_handler(crt_rpc_t *rpc)
 		rpc, opc, DP_UOID(orw->orw_oid), DP_KEY(dkey),
 		dss_get_module_info()->dmi_tgt_id,
 		dss_get_module_info()->dmi_xs_id, orw->orw_epoch,
-		orw->orw_map_ver, map_ver, DP_DTI(&orw->orw_dti));
+		orw->orw_map_ver, ioc.ioc_map_ver, DP_DTI(&orw->orw_dti));
 
 	/* Handle resend. */
 	if (orw->orw_flags & ORF_RESEND) {
-		rc = dtx_handle_resend(cont->sc_hdl, &orw->orw_oid,
+		rc = dtx_handle_resend(ioc.ioc_vos_coh, &orw->orw_oid,
 				       &orw->orw_dti,
 				       orw->orw_dkey_hash, false,
 				       &orw->orw_epoch);
@@ -1128,7 +1120,7 @@ ds_obj_tgt_update_handler(crt_rpc_t *rpc)
 			/* Abort it by force with MAX epoch to guarantee
 			 * that it can be aborted.
 			 */
-			rc = vos_dtx_abort(cont->sc_hdl, DAOS_EPOCH_MAX,
+			rc = vos_dtx_abort(ioc.ioc_vos_coh, DAOS_EPOCH_MAX,
 					   &orw->orw_dti, 1);
 
 		if (rc != 0 && rc != -DER_NONEXIST)
@@ -1140,23 +1132,24 @@ ds_obj_tgt_update_handler(crt_rpc_t *rpc)
 	 */
 	if (DAOS_FAIL_CHECK(DAOS_VC_LOST_DATA)) {
 		if (orw->orw_dti_cos.ca_count > 0)
-			vos_dtx_commit(cont->sc_hdl, orw->orw_dti_cos.ca_arrays,
+			vos_dtx_commit(ioc.ioc_vos_coh,
+				       orw->orw_dti_cos.ca_arrays,
 				       orw->orw_dti_cos.ca_count);
 
 		D_GOTO(out, rc = 0);
 	}
 
-	rc = dtx_begin(&orw->orw_dti, &orw->orw_oid, cont->sc_hdl,
+	rc = dtx_begin(&orw->orw_dti, &orw->orw_oid, ioc.ioc_vos_coh,
 		       orw->orw_epoch, orw->orw_dkey_hash,
 		       &conflict, orw->orw_dti_cos.ca_arrays,
 		       orw->orw_dti_cos.ca_count, orw->orw_map_ver,
-		       DAOS_INTENT_UPDATE, handle);
+		       DAOS_INTENT_UPDATE, &dth);
 	if (rc != 0) {
 		D_ERROR(DF_UOID": Failed to start DTX for update %d.\n",
 			DP_UOID(orw->orw_oid), rc);
 		D_GOTO(out, rc);
 	}
-	rc = obj_local_rw(rpc, cont_hdl, cont, NULL, NULL, handle);
+	rc = obj_local_rw(rpc, ioc.ioc_coh, ioc.ioc_coc, NULL, NULL, &dth);
 	if (rc != 0) {
 		D_ERROR(DF_UOID": error=%d.\n", DP_UOID(orw->orw_oid), rc);
 		D_GOTO(out, rc);
@@ -1167,13 +1160,9 @@ out:
 	    DAOS_FAIL_CHECK(DAOS_DTX_NONLEADER_ERROR))
 		rc = -DER_IO;
 
-	rc = dtx_end(handle, cont_hdl, cont, rc);
-	obj_rw_reply(rpc, rc, map_ver, &conflict, cont_hdl);
-
-	if (cont_hdl)
-		ds_cont_hdl_put(cont_hdl);
-	if (cont)
-		ds_cont_child_put(cont);
+	rc = dtx_end(&dth, ioc.ioc_coh, ioc.ioc_coc, rc);
+	obj_rw_reply(rpc, rc, ioc.ioc_map_ver, &conflict, ioc.ioc_coh);
+	obj_ioc_end(&ioc, rc);
 }
 
 static int
@@ -1214,13 +1203,11 @@ ds_obj_rw_handler(crt_rpc_t *rpc)
 {
 	struct obj_rw_in		*orw = crt_req_get(rpc);
 	struct obj_rw_out		*orwo = crt_reply_get(rpc);
-	struct ds_cont_hdl		*cont_hdl = NULL;
-	struct ds_cont_child		*cont = NULL;
-	struct dtx_leader_handle	dlh = { 0 };
 	struct obj_tls			*tls = obj_tls_get();
+	struct dtx_leader_handle	dlh = { 0 };
 	struct ds_obj_exec_arg		exec_arg = { 0 };
+	struct obj_io_context		ioc;
 	uint64_t			time_start = 0;
-	uint32_t			map_ver = 0;
 	uint32_t			flags = 0;
 	uint32_t			opc = opc_get(rpc->cr_opc);
 	struct obj_ec_split_req		*split_req = NULL;
@@ -1228,13 +1215,11 @@ ds_obj_rw_handler(crt_rpc_t *rpc)
 
 	D_ASSERT(orw != NULL);
 	D_ASSERT(orwo != NULL);
-	rc = obj_verify_req(orw->orw_oid, orw->orw_map_ver,
-			    orw->orw_pool_uuid, orw->orw_co_hdl,
-			    orw->orw_co_uuid, opc_get(rpc->cr_opc),
-			    &cont_hdl, &cont, &map_ver);
+	rc = obj_ioc_begin(orw->orw_oid, orw->orw_map_ver,
+			   orw->orw_pool_uuid, orw->orw_co_hdl,
+			   orw->orw_co_uuid, opc_get(rpc->cr_opc), &ioc);
 	if (rc != 0) {
 		D_ASSERTF(rc < 0, "unexpected error# %d\n", rc);
-
 		goto reply;
 	}
 
@@ -1244,7 +1229,7 @@ ds_obj_rw_handler(crt_rpc_t *rpc)
 		rpc, opc, DP_UOID(orw->orw_oid), DP_KEY(&orw->orw_dkey),
 		dss_get_module_info()->dmi_tgt_id,
 		dss_get_module_info()->dmi_xs_id, orw->orw_epoch,
-		orw->orw_map_ver, map_ver, DP_DTI(&orw->orw_dti));
+		orw->orw_map_ver, ioc.ioc_map_ver, DP_DTI(&orw->orw_dti));
 
 	/* FIXME: until distributed transaction. */
 	if (orw->orw_epoch == DAOS_EPOCH_MAX) {
@@ -1253,7 +1238,8 @@ ds_obj_rw_handler(crt_rpc_t *rpc)
 	}
 
 	if (obj_rpc_is_fetch(rpc)) {
-		rc = obj_local_rw(rpc, cont_hdl, cont, NULL, NULL, NULL);
+		rc = obj_local_rw(rpc, ioc.ioc_coh, ioc.ioc_coc,
+				  NULL, NULL, NULL);
 		if (rc != 0) {
 			D_ERROR(DF_UOID": error=%d.\n",
 				DP_UOID(orw->orw_oid), rc);
@@ -1273,9 +1259,9 @@ ds_obj_rw_handler(crt_rpc_t *rpc)
 	if (orw->orw_flags & ORF_RESEND) {
 		daos_epoch_t	tmp = 0;
 
-		rc = dtx_handle_resend(cont->sc_hdl, &orw->orw_oid,
-				       &orw->orw_dti,
-				       orw->orw_dkey_hash, false, &tmp);
+		rc = dtx_handle_resend(ioc.ioc_vos_coh, &orw->orw_oid,
+				       &orw->orw_dti, orw->orw_dkey_hash,
+				       false, &tmp);
 		if (rc == -DER_ALREADY)
 			D_GOTO(out, rc = 0);
 
@@ -1306,7 +1292,7 @@ renew:
 	 * modification or not, so still need to dispatch
 	 * the RPC to other replicas.
 	 */
-	rc = dtx_leader_begin(&orw->orw_dti, &orw->orw_oid, cont->sc_hdl,
+	rc = dtx_leader_begin(&orw->orw_dti, &orw->orw_oid, ioc.ioc_vos_coh,
 			      orw->orw_epoch, orw->orw_dkey_hash,
 			      orw->orw_map_ver, DAOS_INTENT_UPDATE,
 			      orw->orw_shard_tgts.ca_arrays,
@@ -1320,12 +1306,12 @@ renew:
 	if (orw->orw_flags & ORF_DTX_SYNC)
 		dlh.dlh_handle.dth_sync = 1;
 
-	exec_arg.rpc = rpc;
-	exec_arg.cont_hdl = cont_hdl;
-	exec_arg.cont = cont;
-	exec_arg.args = split_req;
+	exec_arg.rpc	  = rpc;
+	exec_arg.cont_hdl = ioc.ioc_coh;
+	exec_arg.cont	  = ioc.ioc_coc;
+	exec_arg.args	  = split_req;
 again:
-	exec_arg.flags = flags;
+	exec_arg.flags	  = flags;
 	/* Execute the operation on all targets */
 	rc = dtx_leader_exec_ops(&dlh, obj_tgt_update, &exec_arg);
 out:
@@ -1334,7 +1320,7 @@ out:
 		rc = -DER_IO;
 
 	/* Stop the distribute transaction */
-	rc = dtx_leader_end(&dlh, cont, rc);
+	rc = dtx_leader_end(&dlh, ioc.ioc_coc, rc);
 	if (rc == -DER_AGAIN) {
 		if (dlh.dlh_handle.dth_renew) {
 			/* epoch conflict, renew it and retry. */
@@ -1353,16 +1339,12 @@ out:
 		goto cleanup;
 
 reply:
-	obj_rw_reply(rpc, rc, map_ver, NULL, cont_hdl);
+	obj_rw_reply(rpc, rc, ioc.ioc_map_ver, NULL, ioc.ioc_coh);
 
 cleanup:
 	D_TIME_END(tls->ot_sp, time_start, OBJ_PF_UPDATE);
-
-	if (cont_hdl)
-		ds_cont_hdl_put(cont_hdl);
-	if (cont)
-		ds_cont_child_put(cont);
 	obj_ec_split_req_fini(split_req);
+	obj_ioc_end(&ioc, rc);
 }
 
 static void
@@ -1397,27 +1379,18 @@ obj_enum_complete(crt_rpc_t *rpc, int status, int map_version)
 }
 
 static int
-obj_iter_vos(crt_rpc_t *rpc, struct vos_iter_anchors *anchors,
-	     struct dss_enum_arg *enum_arg, uint32_t *map_version)
+obj_local_enum(struct obj_io_context *ioc, crt_rpc_t *rpc,
+	       struct vos_iter_anchors *anchors, struct dss_enum_arg *enum_arg)
 {
 	vos_iter_param_t	param = { 0 };
 	struct obj_key_enum_in	*oei = crt_req_get(rpc);
 	int			opc = opc_get(rpc->cr_opc);
-	struct ds_cont_hdl	*cont_hdl;
-	struct ds_cont_child	*cont;
 	int			type;
 	int			rc;
 	bool			recursive = false;
 
-	rc = obj_verify_req(oei->oei_oid, oei->oei_map_ver,
-			    oei->oei_pool_uuid, oei->oei_co_hdl,
-			    oei->oei_co_uuid, opc, &cont_hdl,
-			    &cont, map_version);
-	if (rc)
-		D_GOTO(out, rc);
-
 	/* prepare enumeration parameters */
-	param.ip_hdl = cont->sc_hdl;
+	param.ip_hdl = ioc->ioc_vos_coh;
 	param.ip_oid = oei->oei_oid;
 	if (oei->oei_dkey.iov_len > 0)
 		param.ip_dkey = oei->oei_dkey;
@@ -1431,7 +1404,7 @@ obj_iter_vos(crt_rpc_t *rpc, struct vos_iter_anchors *anchors,
 	if (opc == DAOS_OBJ_RECX_RPC_ENUMERATE) {
 		if (oei->oei_dkey.iov_len == 0 ||
 		    oei->oei_akey.iov_len == 0)
-			D_GOTO(out_cont_hdl, rc = -DER_PROTO);
+			D_GOTO(failed, rc = -DER_PROTO);
 
 		if (oei->oei_rec_type == DAOS_IOD_ARRAY)
 			type = VOS_ITER_RECX;
@@ -1476,7 +1449,7 @@ obj_iter_vos(crt_rpc_t *rpc, struct vos_iter_anchors *anchors,
 		anchors->ia_sv = anchors->ia_ev;
 	else if (oei->oei_oid.id_shard % 2 == 0 &&
 		DAOS_FAIL_CHECK(DAOS_VC_LOST_REPLICA))
-		D_GOTO(out_cont_hdl, rc =  -DER_NONEXIST);
+		D_GOTO(failed, rc =  -DER_NONEXIST);
 
 	rc = dss_enum_pack(&param, type, recursive, anchors, enum_arg);
 
@@ -1487,12 +1460,7 @@ obj_iter_vos(crt_rpc_t *rpc, struct vos_iter_anchors *anchors,
 		" rc %d\n", DP_UOID(oei->oei_oid), param.ip_epr.epr_lo,
 		param.ip_epr.epr_hi, type, dss_get_module_info()->dmi_tgt_id,
 		rc);
-out_cont_hdl:
-	if (cont_hdl)
-		ds_cont_hdl_put(cont_hdl);
-	if (cont)
-		ds_cont_child_put(cont);
-out:
+failed:
 	return rc;
 }
 
@@ -1553,6 +1521,33 @@ obj_enum_reply_bulk(crt_rpc_t *rpc)
 	return rc;
 }
 
+static int
+obj_enum_prep_sgls(d_sg_list_t *dst_sgls, d_sg_list_t *sgls, int number)
+{
+	int i;
+	int j;
+	int rc = 0;
+
+	for (i = 0; i < number; i++) {
+		dst_sgls[i].sg_nr = sgls[i].sg_nr;
+		D_ALLOC_ARRAY(dst_sgls[i].sg_iovs, sgls[i].sg_nr);
+		if (dst_sgls[i].sg_iovs == NULL)
+			D_GOTO(out, rc = -DER_NOMEM);
+
+		for (j = 0; j < dst_sgls[i].sg_nr; j++) {
+			dst_sgls[i].sg_iovs[j].iov_buf_len =
+				sgls[i].sg_iovs[j].iov_buf_len;
+
+			D_ALLOC(dst_sgls[i].sg_iovs[j].iov_buf,
+				dst_sgls[i].sg_iovs[j].iov_buf_len);
+			if (dst_sgls[i].sg_iovs[j].iov_buf == NULL)
+				D_GOTO(out, rc = -DER_NOMEM);
+		}
+	}
+out:
+	return rc;
+}
+
 void
 ds_obj_enum_handler(crt_rpc_t *rpc)
 {
@@ -1560,8 +1555,8 @@ ds_obj_enum_handler(crt_rpc_t *rpc)
 	struct vos_iter_anchors	anchors = { 0 };
 	struct obj_key_enum_in	*oei;
 	struct obj_key_enum_out	*oeo;
+	struct obj_io_context	ioc;
 	int			opc = opc_get(rpc->cr_opc);
-	unsigned int		map_version = 0;
 	int			rc = 0;
 
 	oei = crt_req_get(rpc);
@@ -1569,6 +1564,11 @@ ds_obj_enum_handler(crt_rpc_t *rpc)
 	oeo = crt_reply_get(rpc);
 	D_ASSERT(oeo != NULL);
 	/* prepare buffer for enumerate */
+
+	rc = obj_ioc_begin(oei->oei_oid, oei->oei_map_ver, oei->oei_pool_uuid,
+			   oei->oei_co_hdl, oei->oei_co_uuid, opc, &ioc);
+	if (rc)
+		D_GOTO(out, rc);
 
 	anchors.ia_dkey = oei->oei_dkey_anchor;
 	anchors.ia_akey = oei->oei_akey_anchor;
@@ -1598,7 +1598,7 @@ ds_obj_enum_handler(crt_rpc_t *rpc)
 		enum_arg.recxs_cap = oei->oei_nr;
 		enum_arg.recxs_len = 0;
 	} else {
-		rc = obj_prep_enum_sgls(&oeo->oeo_sgl, &oei->oei_sgl, 1);
+		rc = obj_enum_prep_sgls(&oeo->oeo_sgl, &oei->oei_sgl, 1);
 		if (rc != 0)
 			D_GOTO(out, rc);
 		enum_arg.sgl = &oeo->oeo_sgl;
@@ -1615,16 +1615,12 @@ ds_obj_enum_handler(crt_rpc_t *rpc)
 		enum_arg.kds_len = 0;
 	}
 
-	/* keep trying until the key_buffer is fully filled or
-	 * reaching the end of the stream
+	/* keep trying until the key_buffer is fully filled or reaching the
+	 * end of the stream.
 	 */
-	rc = obj_iter_vos(rpc, &anchors, &enum_arg, &map_version);
-	if (rc == 1) {
-		/* If the buffer is full, exit and
-		 * reset failure.
-		 */
+	rc = obj_local_enum(&ioc, rpc, &anchors, &enum_arg);
+	if (rc == 1) /* If the buffer is full, exit and reset failure. */
 		rc = 0;
-	}
 
 	if (rc)
 		D_GOTO(out, rc);
@@ -1653,7 +1649,8 @@ out:
 	/* for KEY2BIG case, just reuse the oeo_size to reply the key len */
 	if (rc == -DER_KEY2BIG)
 		oeo->oeo_size = enum_arg.kds[0].kd_key_len;
-	obj_enum_complete(rpc, rc, map_version);
+	obj_enum_complete(rpc, rc, ioc.ioc_map_ver);
+	obj_ioc_end(&ioc, rc);
 }
 
 static void
@@ -1720,27 +1717,23 @@ out:
 void
 ds_obj_tgt_punch_handler(crt_rpc_t *rpc)
 {
-	struct ds_cont_hdl		*cont_hdl = NULL;
-	struct ds_cont_child		*cont = NULL;
-	struct dtx_handle		dth = { 0 };
-	struct dtx_handle		*handle = &dth;
+	struct dtx_handle		 dth = { 0 };
 	struct dtx_conflict_entry	 conflict = { 0 };
+	struct obj_io_context		 ioc;
 	struct obj_punch_in		*opi;
-	uint32_t			 map_version = 0;
 	int				 rc;
 
 	opi = crt_req_get(rpc);
 	D_ASSERT(opi != NULL);
-	rc = obj_verify_req(opi->opi_oid, opi->opi_map_ver,
+	rc = obj_ioc_begin(opi->opi_oid, opi->opi_map_ver,
 			    opi->opi_pool_uuid, opi->opi_co_hdl,
-			    opi->opi_co_uuid, opc_get(rpc->cr_opc),
-			    &cont_hdl, &cont, &map_version);
+			    opi->opi_co_uuid, opc_get(rpc->cr_opc), &ioc);
 	if (rc)
 		goto out;
 
 	/* Handle resend. */
 	if (opi->opi_flags & ORF_RESEND) {
-		rc = dtx_handle_resend(cont->sc_hdl, &opi->opi_oid,
+		rc = dtx_handle_resend(ioc.ioc_vos_coh, &opi->opi_oid,
 				       &opi->opi_dti, opi->opi_dkey_hash,
 				       true, &opi->opi_epoch);
 
@@ -1755,7 +1748,7 @@ ds_obj_tgt_punch_handler(crt_rpc_t *rpc)
 			/* Abort it by force with MAX epoch to guarantee
 			 * that it can be aborted.
 			 */
-			rc = vos_dtx_abort(cont->sc_hdl, DAOS_EPOCH_MAX,
+			rc = vos_dtx_abort(ioc.ioc_vos_coh, DAOS_EPOCH_MAX,
 					   &opi->opi_dti, 1);
 
 		if (rc != 0 && rc != -DER_NONEXIST)
@@ -1763,11 +1756,11 @@ ds_obj_tgt_punch_handler(crt_rpc_t *rpc)
 	}
 
 	/* Start the local transaction */
-	rc = dtx_begin(&opi->opi_dti, &opi->opi_oid, cont->sc_hdl,
+	rc = dtx_begin(&opi->opi_dti, &opi->opi_oid, ioc.ioc_vos_coh,
 		       opi->opi_epoch, opi->opi_dkey_hash,
 		       &conflict, opi->opi_dti_cos.ca_arrays,
 		       opi->opi_dti_cos.ca_count, opi->opi_map_ver,
-		       DAOS_INTENT_PUNCH, handle);
+		       DAOS_INTENT_PUNCH, &dth);
 	if (rc != 0) {
 		D_ERROR(DF_UOID": Failed to start DTX for punch %d.\n",
 			DP_UOID(opi->opi_oid), rc);
@@ -1775,7 +1768,8 @@ ds_obj_tgt_punch_handler(crt_rpc_t *rpc)
 	}
 
 	/* local RPC handler */
-	rc = obj_local_punch(opi, opc_get(rpc->cr_opc), cont_hdl, cont, handle);
+	rc = obj_local_punch(opi, opc_get(rpc->cr_opc), ioc.ioc_coh,
+			     ioc.ioc_coc, &dth);
 	if (rc != 0) {
 		D_ERROR(DF_UOID": error=%d.\n", DP_UOID(opi->opi_oid), rc);
 		D_GOTO(out, rc);
@@ -1785,12 +1779,9 @@ out:
 		rc = -DER_IO;
 
 	/* Stop the local transaction */
-	rc = dtx_end(handle, cont_hdl, cont, rc);
-	obj_punch_complete(rpc, rc, map_version, &conflict);
-	if (cont_hdl)
-		ds_cont_hdl_put(cont_hdl);
-	if (cont)
-		ds_cont_child_put(cont); /* -1 for rebuild container */
+	rc = dtx_end(&dth, ioc.ioc_coh, ioc.ioc_coc, rc);
+	obj_punch_complete(rpc, rc, ioc.ioc_map_ver, &conflict);
+	obj_ioc_end(&ioc, rc);
 }
 
 static int
@@ -1824,21 +1815,18 @@ obj_tgt_punch(struct dtx_leader_handle *dlh, void *arg, int idx,
 void
 ds_obj_punch_handler(crt_rpc_t *rpc)
 {
-	struct ds_cont_hdl		*cont_hdl = NULL;
-	struct ds_cont_child		*cont = NULL;
 	struct dtx_leader_handle	dlh = { 0 };
 	struct obj_punch_in		*opi;
 	struct ds_obj_exec_arg		exec_arg = { 0 };
-	uint32_t			map_version = 0;
+	struct obj_io_context		ioc;
 	uint32_t			flags = 0;
 	int				rc;
 
 	opi = crt_req_get(rpc);
 	D_ASSERT(opi != NULL);
-	rc = obj_verify_req(opi->opi_oid, opi->opi_map_ver,
-			    opi->opi_pool_uuid, opi->opi_co_hdl,
-			    opi->opi_co_uuid, opc_get(rpc->cr_opc),
-			    &cont_hdl, &cont, &map_version);
+	rc = obj_ioc_begin(opi->opi_oid, opi->opi_map_ver,
+			   opi->opi_pool_uuid, opi->opi_co_hdl,
+			   opi->opi_co_uuid, opc_get(rpc->cr_opc), &ioc);
 	if (rc)
 		goto out;
 
@@ -1849,7 +1837,8 @@ ds_obj_punch_handler(crt_rpc_t *rpc)
 			rpc, DP_UOID(opi->opi_oid),
 			dss_get_module_info()->dmi_tgt_id,
 			dss_get_module_info()->dmi_xs_id, opi->opi_epoch,
-			opi->opi_map_ver, map_version, DP_DTI(&opi->opi_dti));
+			opi->opi_map_ver, ioc.ioc_map_ver,
+			DP_DTI(&opi->opi_dti));
 	else
 		D_DEBUG(DB_TRACE,
 			"punch key %p oid "DF_UOID" dkey "
@@ -1859,7 +1848,8 @@ ds_obj_punch_handler(crt_rpc_t *rpc)
 			DP_KEY(&opi->opi_dkeys.ca_arrays[0]),
 			dss_get_module_info()->dmi_tgt_id,
 			dss_get_module_info()->dmi_xs_id, opi->opi_epoch,
-			opi->opi_map_ver, map_version, DP_DTI(&opi->opi_dti));
+			opi->opi_map_ver, ioc.ioc_map_ver,
+			DP_DTI(&opi->opi_dti));
 
 	/* FIXME: until distributed transaction. */
 	if (opi->opi_epoch == DAOS_EPOCH_MAX) {
@@ -1869,8 +1859,8 @@ ds_obj_punch_handler(crt_rpc_t *rpc)
 
 	if (opi->opi_shard_tgts.ca_arrays == NULL) {
 		/* local RPC handler */
-		rc = obj_local_punch(opi, opc_get(rpc->cr_opc), cont_hdl, cont,
-				     NULL);
+		rc = obj_local_punch(opi, opc_get(rpc->cr_opc), ioc.ioc_coh,
+				     ioc.ioc_coc, NULL);
 		if (rc != 0) {
 			D_ERROR(DF_UOID": error=%d.\n",
 				DP_UOID(opi->opi_oid), rc);
@@ -1884,7 +1874,7 @@ ds_obj_punch_handler(crt_rpc_t *rpc)
 	if (opi->opi_flags & ORF_RESEND) {
 		daos_epoch_t	tmp = 0;
 
-		rc = dtx_handle_resend(cont->sc_hdl, &opi->opi_oid,
+		rc = dtx_handle_resend(ioc.ioc_vos_coh, &opi->opi_oid,
 				       &opi->opi_dti, opi->opi_dkey_hash,
 				       true, &tmp);
 		if (rc == -DER_ALREADY)
@@ -1916,7 +1906,7 @@ renew:
 	 * modification or not, so still need to dispatch
 	 * the RPC to other replicas.
 	 */
-	rc = dtx_leader_begin(&opi->opi_dti, &opi->opi_oid, cont->sc_hdl,
+	rc = dtx_leader_begin(&opi->opi_dti, &opi->opi_oid, ioc.ioc_vos_coh,
 			      opi->opi_epoch, opi->opi_dkey_hash,
 			      opi->opi_map_ver, DAOS_INTENT_PUNCH,
 			      opi->opi_shard_tgts.ca_arrays,
@@ -1931,8 +1921,8 @@ renew:
 		dlh.dlh_handle.dth_sync = 1;
 
 	exec_arg.rpc = rpc;
-	exec_arg.cont_hdl = cont_hdl;
-	exec_arg.cont = cont;
+	exec_arg.cont_hdl = ioc.ioc_coh;
+	exec_arg.cont = ioc.ioc_coc;
 again:
 	exec_arg.flags = flags;
 	/* Execute the operation on all shards */
@@ -1942,7 +1932,7 @@ out:
 		rc = -DER_IO;
 
 	/* Stop the distribute transaction */
-	rc = dtx_leader_end(&dlh, cont, rc);
+	rc = dtx_leader_end(&dlh, ioc.ioc_coc, rc);
 	if (rc == -DER_AGAIN) {
 		if (dlh.dlh_handle.dth_renew) {
 			/* epoch conflict, renew it and retry. */
@@ -1960,12 +1950,9 @@ out:
 	    DAOS_FAIL_CHECK(DAOS_DTX_LOST_RPC_REPLY))
 		goto cleanup;
 
-	obj_punch_complete(rpc, rc, map_version, NULL);
+	obj_punch_complete(rpc, rc, ioc.ioc_map_ver, NULL);
 cleanup:
-	if (cont_hdl)
-		ds_cont_hdl_put(cont_hdl);
-	if (cont)
-		ds_cont_child_put(cont); /* -1 for rebuild container */
+	obj_ioc_end(&ioc, rc);
 }
 
 void
@@ -1973,12 +1960,10 @@ ds_obj_query_key_handler(crt_rpc_t *rpc)
 {
 	struct obj_query_key_in		*okqi;
 	struct obj_query_key_out	*okqo;
-	struct ds_cont_hdl		*cont_hdl = NULL;
-	struct ds_cont_child		*cont = NULL;
 	daos_key_t			*dkey;
 	daos_key_t			*akey;
-	uint32_t			map_version = 0;
-	int				rc;
+	struct obj_io_context		 ioc;
+	int				 rc;
 
 	okqi = crt_req_get(rpc);
 	D_ASSERT(okqi != NULL);
@@ -1993,14 +1978,11 @@ ds_obj_query_key_handler(crt_rpc_t *rpc)
 		D_DEBUG(DB_IO, "overwrite epoch "DF_U64"\n", okqi->okqi_epoch);
 	}
 
-	rc = obj_verify_cont_hdl(okqi->okqi_pool_uuid, okqi->okqi_co_hdl,
-				 okqi->okqi_co_uuid, opc_get(rpc->cr_opc),
-				 &cont_hdl, &cont);
+	rc = obj_ioc_begin(okqi->okqi_oid, okqi->okqi_map_ver,
+			   okqi->okqi_pool_uuid, okqi->okqi_co_hdl,
+			   okqi->okqi_co_uuid, opc_get(rpc->cr_opc), &ioc);
 	if (rc)
 		D_GOTO(out, rc);
-
-	D_ASSERT(cont != NULL && cont->sc_pool != NULL);
-	map_version = cont->sc_pool->spc_map_version;
 
 	dkey = &okqi->okqi_dkey;
 	akey = &okqi->okqi_akey;
@@ -2011,16 +1993,13 @@ ds_obj_query_key_handler(crt_rpc_t *rpc)
 	if (okqi->okqi_flags & DAOS_GET_AKEY)
 		akey = &okqo->okqo_akey;
 
-	rc = vos_obj_query_key(cont->sc_hdl, okqi->okqi_oid, okqi->okqi_flags,
-			       okqi->okqi_epoch, dkey, akey, &okqo->okqo_recx);
+	rc = vos_obj_query_key(ioc.ioc_vos_coh, okqi->okqi_oid,
+			       okqi->okqi_flags, okqi->okqi_epoch,
+			       dkey, akey, &okqo->okqo_recx);
 out:
-	if (cont_hdl)
-		ds_cont_hdl_put(cont_hdl);
-	if (cont)
-		ds_cont_child_put(cont); /* -1 for rebuild container */
-
 	obj_reply_set_status(rpc, rc);
-	obj_reply_map_version_set(rpc, map_version);
+	obj_reply_map_version_set(rpc, ioc.ioc_map_ver);
+	obj_ioc_end(&ioc, rc);
 
 	rc = crt_reply_send(rpc);
 	if (rc != 0)
@@ -2032,10 +2011,8 @@ ds_obj_sync_handler(crt_rpc_t *rpc)
 {
 	struct obj_sync_in	*osi;
 	struct obj_sync_out	*oso;
-	struct ds_cont_hdl	*cont_hdl = NULL;
-	struct ds_cont_child	*cont = NULL;
+	struct obj_io_context	 ioc;
 	daos_epoch_t		 epoch = crt_hlc_get();
-	uint32_t		 map_ver = 0;
 	int			 rc;
 
 	osi = crt_req_get(rpc);
@@ -2052,24 +2029,19 @@ ds_obj_sync_handler(crt_rpc_t *rpc)
 	D_DEBUG(DB_IO, "start: "DF_UOID", epc "DF_U64"\n",
 		DP_UOID(osi->osi_oid), oso->oso_epoch);
 
-	rc = obj_verify_req(osi->osi_oid, osi->osi_map_ver,
-			    osi->osi_pool_uuid, osi->osi_co_hdl,
-			    osi->osi_co_uuid, opc_get(rpc->cr_opc),
-			    &cont_hdl, &cont, &map_ver);
+	rc = obj_ioc_begin(osi->osi_oid, osi->osi_map_ver,
+			   osi->osi_pool_uuid, osi->osi_co_hdl,
+			   osi->osi_co_uuid, opc_get(rpc->cr_opc), &ioc);
 	if (rc != 0)
 		D_GOTO(out, rc);
 
-	rc = dtx_obj_sync(osi->osi_pool_uuid, osi->osi_co_uuid, cont->sc_hdl,
-			  osi->osi_oid, oso->oso_epoch, map_ver);
+	rc = dtx_obj_sync(osi->osi_pool_uuid, osi->osi_co_uuid, ioc.ioc_vos_coh,
+			  osi->osi_oid, oso->oso_epoch, ioc.ioc_map_ver);
 
 out:
-	if (cont_hdl != NULL)
-		ds_cont_hdl_put(cont_hdl);
-	if (cont != NULL)
-		ds_cont_child_put(cont);
-
+	obj_reply_map_version_set(rpc, ioc.ioc_map_ver);
 	obj_reply_set_status(rpc, rc);
-	obj_reply_map_version_set(rpc, map_ver);
+	obj_ioc_end(&ioc, rc);
 
 	D_DEBUG(DB_IO, "stop: "DF_UOID", epc "DF_U64", rd = %d\n",
 		DP_UOID(osi->osi_oid), oso->oso_epoch, rc);

--- a/src/rebuild/srv.c
+++ b/src/rebuild/srv.c
@@ -34,6 +34,7 @@
 #include <daos_srv/container.h>
 #include <daos_srv/iv.h>
 #include <daos_srv/rebuild.h>
+#include <daos_mgmt.h>
 #include "rpc.h"
 #include "rebuild_internal.h"
 
@@ -1448,7 +1449,7 @@ void
 rebuild_hang(void)
 {
 	D_DEBUG(DB_REBUILD, "Hang current rebuild process.\n");
-	dss_parameters_set(DSS_REBUILD_RES_PERCENTAGE, 0);
+	dss_parameters_set(DMG_KEY_REBUILD_THROTTLING, 0);
 }
 
 static int

--- a/src/tests/daos_perf.c
+++ b/src/tests/daos_perf.c
@@ -676,11 +676,11 @@ ts_rebuild_perf(double *start_time, double *end_time)
 		return rc;
 
 	if (ts_rebuild_only_iteration)
-		daos_mgmt_set_params(NULL, -1, DSS_KEY_FAIL_LOC,
+		daos_mgmt_set_params(NULL, -1, DMG_KEY_FAIL_LOC,
 				     DAOS_REBUILD_NO_REBUILD,
 				     0, NULL);
 	else if (ts_rebuild_no_update)
-		daos_mgmt_set_params(NULL, -1, DSS_KEY_FAIL_LOC,
+		daos_mgmt_set_params(NULL, -1, DMG_KEY_FAIL_LOC,
 				     DAOS_REBUILD_NO_UPDATE,
 				     0, NULL);
 
@@ -694,7 +694,7 @@ ts_rebuild_perf(double *start_time, double *end_time)
 
 	rc = ts_add_server(RANK_ZERO);
 
-	daos_mgmt_set_params(NULL, -1, DSS_KEY_FAIL_LOC, 0, 0, NULL);
+	daos_mgmt_set_params(NULL, -1, DMG_KEY_FAIL_LOC, 0, 0, NULL);
 
 	return rc;
 }

--- a/src/tests/suite/daos_container.c
+++ b/src/tests/suite/daos_container.c
@@ -237,7 +237,7 @@ co_properties(void **state)
 		rc = daos_pool_query(arg->pool.poh, NULL, &info, NULL, NULL);
 		assert_int_equal(rc, 0);
 		rc = daos_mgmt_set_params(arg->group, info.pi_leader,
-			DSS_KEY_FAIL_LOC, DAOS_FORCE_PROP_VERIFY, 0, NULL);
+			DMG_KEY_FAIL_LOC, DAOS_FORCE_PROP_VERIFY, 0, NULL);
 		assert_int_equal(rc, 0);
 	}
 	MPI_Barrier(MPI_COMM_WORLD);
@@ -290,7 +290,7 @@ co_properties(void **state)
 	}
 
 	if (arg->myrank == 0)
-		daos_mgmt_set_params(arg->group, -1, DSS_KEY_FAIL_LOC, 0,
+		daos_mgmt_set_params(arg->group, -1, DMG_KEY_FAIL_LOC, 0,
 				     0, NULL);
 	MPI_Barrier(MPI_COMM_WORLD);
 
@@ -325,7 +325,7 @@ co_op_retry(void **state)
 	print_message("success\n");
 
 	print_message("setting DAOS_CONT_QUERY_FAIL_CORPC ... ");
-	rc = daos_mgmt_set_params(arg->group, 0, DSS_KEY_FAIL_LOC,
+	rc = daos_mgmt_set_params(arg->group, 0, DMG_KEY_FAIL_LOC,
 				  DAOS_CONT_QUERY_FAIL_CORPC | DAOS_FAIL_ONCE,
 				  0, NULL);
 	assert_int_equal(rc, 0);
@@ -337,7 +337,7 @@ co_op_retry(void **state)
 	print_message("success\n");
 
 	print_message("setting DAOS_CONT_CLOSE_FAIL_CORPC ... ");
-	rc = daos_mgmt_set_params(arg->group, 0, DSS_KEY_FAIL_LOC,
+	rc = daos_mgmt_set_params(arg->group, 0, DMG_KEY_FAIL_LOC,
 				  DAOS_CONT_CLOSE_FAIL_CORPC | DAOS_FAIL_ONCE,
 				  0, NULL);
 	assert_int_equal(rc, 0);
@@ -349,7 +349,7 @@ co_op_retry(void **state)
 	print_message("success\n");
 
 	print_message("setting DAOS_CONT_DESTROY_FAIL_CORPC ... ");
-	rc = daos_mgmt_set_params(arg->group, 0, DSS_KEY_FAIL_LOC,
+	rc = daos_mgmt_set_params(arg->group, 0, DMG_KEY_FAIL_LOC,
 				  DAOS_CONT_DESTROY_FAIL_CORPC | DAOS_FAIL_ONCE,
 				  0, NULL);
 	assert_int_equal(rc, 0);

--- a/src/tests/suite/daos_dtx.c
+++ b/src/tests/suite/daos_dtx.c
@@ -43,7 +43,7 @@ static void
 dtx_set_fail_loc(test_arg_t *arg, uint64_t fail_loc)
 {
 	if (arg->myrank == 0)
-		daos_mgmt_set_params(arg->group, -1, DSS_KEY_FAIL_LOC,
+		daos_mgmt_set_params(arg->group, -1, DMG_KEY_FAIL_LOC,
 				     fail_loc, 0, NULL);
 	MPI_Barrier(MPI_COMM_WORLD);
 }

--- a/src/tests/suite/daos_mgmt.c
+++ b/src/tests/suite/daos_mgmt.c
@@ -398,7 +398,7 @@ pool_create_and_destroy_retry(void **state)
 		return;
 
 	print_message("setting DAOS_POOL_CREATE_FAIL_CORPC ... ");
-	rc = daos_mgmt_set_params(arg->group, 0, DSS_KEY_FAIL_LOC,
+	rc = daos_mgmt_set_params(arg->group, 0, DMG_KEY_FAIL_LOC,
 				  DAOS_POOL_CREATE_FAIL_CORPC | DAOS_FAIL_ONCE,
 				  0, NULL);
 	assert_int_equal(rc, 0);
@@ -414,7 +414,7 @@ pool_create_and_destroy_retry(void **state)
 	print_message("success uuid = "DF_UUIDF"\n", DP_UUID(uuid));
 
 	print_message("setting DAOS_POOL_DESTROY_FAIL_CORPC ... ");
-	rc = daos_mgmt_set_params(arg->group, 0, DSS_KEY_FAIL_LOC,
+	rc = daos_mgmt_set_params(arg->group, 0, DMG_KEY_FAIL_LOC,
 				  DAOS_POOL_DESTROY_FAIL_CORPC | DAOS_FAIL_ONCE,
 				  0, NULL);
 	assert_int_equal(rc, 0);

--- a/src/tests/suite/daos_nvme_recovery.c
+++ b/src/tests/suite/daos_nvme_recovery.c
@@ -36,7 +36,7 @@ static void
 set_fail_loc(test_arg_t *arg, d_rank_t rank, uint64_t fail_loc)
 {
 	if (arg->myrank == 0)
-		daos_mgmt_set_params(arg->group, rank, DSS_KEY_FAIL_LOC,
+		daos_mgmt_set_params(arg->group, rank, DMG_KEY_FAIL_LOC,
 				     fail_loc, 0, NULL);
 	MPI_Barrier(MPI_COMM_WORLD);
 }

--- a/src/tests/suite/daos_obj.c
+++ b/src/tests/suite/daos_obj.c
@@ -2784,7 +2784,7 @@ tgt_idx_change_retry(void **state)
 	arg->fail_loc = DAOS_OBJ_TGT_IDX_CHANGE;
 	arg->fail_num = replica;
 	if (arg->myrank == 0) {
-		daos_mgmt_set_params(arg->group, -1, DSS_KEY_FAIL_LOC,
+		daos_mgmt_set_params(arg->group, -1, DMG_KEY_FAIL_LOC,
 				     DAOS_OBJ_TGT_IDX_CHANGE,
 				     replica, NULL);
 	}
@@ -2854,7 +2854,7 @@ tgt_idx_change_retry(void **state)
 
 	daos_fail_loc_set(0);
 	if (arg->myrank == 0) {
-		daos_mgmt_set_params(arg->group, -1, DSS_KEY_FAIL_LOC, 0,
+		daos_mgmt_set_params(arg->group, -1, DMG_KEY_FAIL_LOC, 0,
 				     0, NULL);
 	}
 	MPI_Barrier(MPI_COMM_WORLD);
@@ -2925,7 +2925,7 @@ fetch_replica_unavail(void **state)
 		rc = daos_pool_query(arg->pool.poh, NULL, &info, NULL, NULL);
 		assert_int_equal(rc, 0);
 		rc = daos_mgmt_set_params(arg->group, info.pi_leader,
-			DSS_KEY_FAIL_LOC, DAOS_REBUILD_DISABLE, 0,
+			DMG_KEY_FAIL_LOC, DAOS_REBUILD_DISABLE, 0,
 			NULL);
 		assert_int_equal(rc, 0);
 
@@ -2946,7 +2946,7 @@ fetch_replica_unavail(void **state)
 	if (arg->myrank == 0) {
 		/* re-enable rebuild */
 		rc = daos_mgmt_set_params(arg->group, info.pi_leader,
-					  DSS_KEY_FAIL_LOC, 0, 0, NULL);
+					  DMG_KEY_FAIL_LOC, 0, 0, NULL);
 
 		/* wait until rebuild done */
 		test_rebuild_wait(&arg, 1);
@@ -3430,7 +3430,7 @@ io_pool_map_refresh_trigger(void **state)
 	oid = dts_oid_set_rank(oid, leader - 1);
 
 	if (arg->myrank == 0)
-		daos_mgmt_set_params(arg->group, -1, DSS_KEY_FAIL_LOC,
+		daos_mgmt_set_params(arg->group, -1, DMG_KEY_FAIL_LOC,
 				 DAOS_FORCE_REFRESH_POOL_MAP | DAOS_FAIL_ONCE,
 				 0, NULL);
 	MPI_Barrier(MPI_COMM_WORLD);
@@ -3441,7 +3441,7 @@ io_pool_map_refresh_trigger(void **state)
 		      strlen("data") + 1, DAOS_TX_NONE, &req);
 
 	if (arg->myrank == 0)
-		daos_mgmt_set_params(arg->group, -1, DSS_KEY_FAIL_LOC,
+		daos_mgmt_set_params(arg->group, -1, DMG_KEY_FAIL_LOC,
 				     0, 0, NULL);
 
 	ioreq_fini(&req);
@@ -3630,7 +3630,7 @@ io_capa_iv_fetch(void **state)
 	oid = dts_oid_set_rank(oid, leader - 1);
 
 	if (arg->myrank == 0)
-		daos_mgmt_set_params(arg->group, -1, DSS_KEY_FAIL_LOC,
+		daos_mgmt_set_params(arg->group, -1, DMG_KEY_FAIL_LOC,
 				 DAOS_FORCE_CAPA_FETCH | DAOS_FAIL_ONCE,
 				 0, NULL);
 	MPI_Barrier(MPI_COMM_WORLD);
@@ -3641,7 +3641,7 @@ io_capa_iv_fetch(void **state)
 		      strlen("data") + 1, DAOS_TX_NONE, &req);
 
 	if (arg->myrank == 0)
-		daos_mgmt_set_params(arg->group, -1, DSS_KEY_FAIL_LOC,
+		daos_mgmt_set_params(arg->group, -1, DMG_KEY_FAIL_LOC,
 				     0, 0, NULL);
 
 	ioreq_fini(&req);

--- a/src/tests/suite/daos_pool.c
+++ b/src/tests/suite/daos_pool.c
@@ -488,7 +488,7 @@ pool_properties(void **state)
 		rc = daos_pool_query(arg->pool.poh, NULL, &info, NULL, NULL);
 		assert_int_equal(rc, 0);
 		rc = daos_mgmt_set_params(arg->group, info.pi_leader,
-			DSS_KEY_FAIL_LOC, DAOS_FORCE_PROP_VERIFY, 0, NULL);
+			DMG_KEY_FAIL_LOC, DAOS_FORCE_PROP_VERIFY, 0, NULL);
 		assert_int_equal(rc, 0);
 	}
 	MPI_Barrier(MPI_COMM_WORLD);
@@ -553,7 +553,7 @@ pool_properties(void **state)
 	}
 
 	if (arg->myrank == 0)
-		daos_mgmt_set_params(arg->group, -1, DSS_KEY_FAIL_LOC, 0,
+		daos_mgmt_set_params(arg->group, -1, DMG_KEY_FAIL_LOC, 0,
 				     0, NULL);
 	MPI_Barrier(MPI_COMM_WORLD);
 
@@ -574,7 +574,7 @@ pool_op_retry(void **state)
 		return;
 
 	print_message("setting DAOS_POOL_CONNECT_FAIL_CORPC ... ");
-	rc = daos_mgmt_set_params(arg->group, 0, DSS_KEY_FAIL_LOC,
+	rc = daos_mgmt_set_params(arg->group, 0, DMG_KEY_FAIL_LOC,
 				  DAOS_POOL_CONNECT_FAIL_CORPC | DAOS_FAIL_ONCE,
 				  0, NULL);
 	assert_int_equal(rc, 0);
@@ -591,7 +591,7 @@ pool_op_retry(void **state)
 	print_message("success\n");
 
 	print_message("setting DAOS_POOL_QUERY_FAIL_CORPC ... ");
-	rc = daos_mgmt_set_params(arg->group, 0, DSS_KEY_FAIL_LOC,
+	rc = daos_mgmt_set_params(arg->group, 0, DMG_KEY_FAIL_LOC,
 				  DAOS_POOL_QUERY_FAIL_CORPC | DAOS_FAIL_ONCE,
 				  0, NULL);
 	assert_int_equal(rc, 0);
@@ -606,7 +606,7 @@ pool_op_retry(void **state)
 	print_message("success\n");
 
 	print_message("setting DAOS_POOL_DISCONNECT_FAIL_CORPC ... ");
-	rc = daos_mgmt_set_params(arg->group, 0, DSS_KEY_FAIL_LOC,
+	rc = daos_mgmt_set_params(arg->group, 0, DMG_KEY_FAIL_LOC,
 				  DAOS_POOL_DISCONNECT_FAIL_CORPC |
 				  DAOS_FAIL_ONCE, 0, NULL);
 	assert_int_equal(rc, 0);

--- a/src/tests/suite/daos_rebuild.c
+++ b/src/tests/suite/daos_rebuild.c
@@ -383,7 +383,7 @@ rebuild_drop_scan(void **state)
 
 	/* Set drop scan fail_loc on server 0 */
 	if (arg->myrank == 0)
-		daos_mgmt_set_params(arg->group, 0, DSS_KEY_FAIL_LOC,
+		daos_mgmt_set_params(arg->group, 0, DMG_KEY_FAIL_LOC,
 				     DAOS_REBUILD_NO_HDL | DAOS_FAIL_ONCE,
 				     0, NULL);
 
@@ -414,8 +414,8 @@ rebuild_retry_rebuild(void **state)
 	rebuild_io(arg, oids, OBJ_NR);
 
 	/* Set no hdl fail_loc on all servers */
-	if (arg->myrank == 0)	
-		daos_mgmt_set_params(arg->group, -1, DSS_KEY_FAIL_LOC,
+	if (arg->myrank == 0)
+		daos_mgmt_set_params(arg->group, -1, DMG_KEY_FAIL_LOC,
 				     DAOS_REBUILD_NO_HDL | DAOS_FAIL_ONCE,
 				     0, NULL);
 	MPI_Barrier(MPI_COMM_WORLD);
@@ -444,7 +444,7 @@ rebuild_retry_for_stale_pool(void **state)
 
 	/* Set no hdl fail_loc on all servers */
 	if (arg->myrank == 0)
-		daos_mgmt_set_params(arg->group, -1, DSS_KEY_FAIL_LOC,
+		daos_mgmt_set_params(arg->group, -1, DMG_KEY_FAIL_LOC,
 				     DAOS_REBUILD_STALE_POOL | DAOS_FAIL_ONCE,
 				     0, NULL);
 	MPI_Barrier(MPI_COMM_WORLD);
@@ -473,7 +473,7 @@ rebuild_drop_obj(void **state)
 
 	/* Set drop REBUILD_OBJECTS reply on all servers */
 	if (arg->myrank == 0)
-		daos_mgmt_set_params(arg->group, 0, DSS_KEY_FAIL_LOC,
+		daos_mgmt_set_params(arg->group, 0, DMG_KEY_FAIL_LOC,
 				     DAOS_REBUILD_DROP_OBJ | DAOS_FAIL_ONCE,
 				     0, NULL);
 	MPI_Barrier(MPI_COMM_WORLD);
@@ -504,7 +504,7 @@ rebuild_update_failed(void **state)
 
 	/* Set drop scan reply on all servers */
 	if (arg->myrank == 0)
-		daos_mgmt_set_params(arg->group, 0, DSS_KEY_FAIL_LOC,
+		daos_mgmt_set_params(arg->group, 0, DMG_KEY_FAIL_LOC,
 				     DAOS_REBUILD_UPDATE_FAIL | DAOS_FAIL_ONCE,
 				     0, NULL);
 	MPI_Barrier(MPI_COMM_WORLD);
@@ -727,7 +727,7 @@ rebuild_destroy_pool_cb(void *data)
 		      DP_UUID(arg->pool.pool_uuid));
 	/* Disable fail_loc and start rebuild */
 	if (arg->myrank == 0)
-		daos_mgmt_set_params(arg->group, -1, DSS_KEY_FAIL_LOC,
+		daos_mgmt_set_params(arg->group, -1, DMG_KEY_FAIL_LOC,
 				     0, 0, NULL);
 
 	MPI_Barrier(MPI_COMM_WORLD);
@@ -760,7 +760,7 @@ rebuild_destroy_pool_internal(void **state, uint64_t fail_loc)
 
 	/* hang the rebuild */
 	if (arg->myrank == 0)
-		daos_mgmt_set_params(arg->group, -1, DSS_KEY_FAIL_LOC, fail_loc,
+		daos_mgmt_set_params(arg->group, -1, DMG_KEY_FAIL_LOC, fail_loc,
 				     0, NULL);
 
 	new_arg->rebuild_cb = rebuild_destroy_pool_cb;
@@ -800,7 +800,7 @@ rebuild_iv_tgt_fail(void **state)
 
 	/* Set no hdl fail_loc on all servers */
 	if (arg->myrank == 0)
-		daos_mgmt_set_params(arg->group, -1, DSS_KEY_FAIL_LOC,
+		daos_mgmt_set_params(arg->group, -1, DMG_KEY_FAIL_LOC,
 				     DAOS_REBUILD_TGT_IV_UPDATE_FAIL |
 				     DAOS_FAIL_ONCE, 0, NULL);
 	MPI_Barrier(MPI_COMM_WORLD);
@@ -832,7 +832,7 @@ rebuild_tgt_start_fail(void **state)
 	/* failed to start rebuild on rank 0 */
 	if (arg->myrank == 0)
 		daos_mgmt_set_params(arg->group, exclude_rank,
-				     DSS_KEY_FAIL_LOC,
+				     DMG_KEY_FAIL_LOC,
 				  DAOS_REBUILD_TGT_START_FAIL | DAOS_FAIL_ONCE,
 				  0, NULL);
 	MPI_Barrier(MPI_COMM_WORLD);
@@ -861,7 +861,7 @@ rebuild_send_objects_fail(void **state)
 
 	/* Skip object send on all of the targets */
 	if (arg->myrank == 0)
-		daos_mgmt_set_params(arg->group, -1, DSS_KEY_FAIL_LOC,
+		daos_mgmt_set_params(arg->group, -1, DMG_KEY_FAIL_LOC,
 				     DAOS_REBUILD_TGT_SEND_OBJS_FAIL, 0, NULL);
 	MPI_Barrier(MPI_COMM_WORLD);
 	/* Even do not sending the objects, the rebuild should still be
@@ -871,7 +871,7 @@ rebuild_send_objects_fail(void **state)
 
 	/* failed to start rebuild on rank 0 */
 	if (arg->myrank == 0)
-		daos_mgmt_set_params(arg->group, -1, DSS_KEY_FAIL_LOC, 0,
+		daos_mgmt_set_params(arg->group, -1, DMG_KEY_FAIL_LOC, 0,
 				     0, NULL);
 	MPI_Barrier(MPI_COMM_WORLD);
 
@@ -946,7 +946,7 @@ rebuild_pool_disconnect_cb(void *data)
 
 	/* Disable fail_loc and start rebuild */
 	if (arg->myrank == 0)
-		daos_mgmt_set_params(arg->group, -1, DSS_KEY_FAIL_LOC,
+		daos_mgmt_set_params(arg->group, -1, DMG_KEY_FAIL_LOC,
 				     0, 0, NULL);
 	MPI_Barrier(MPI_COMM_WORLD);
 
@@ -986,7 +986,7 @@ rebuild_tgt_pool_disconnect_internal(void **state, unsigned int fail_loc)
 
 	/* hang the rebuild during scan */
 	if (arg->myrank == 0)
-		daos_mgmt_set_params(arg->group, -1, DSS_KEY_FAIL_LOC, fail_loc,
+		daos_mgmt_set_params(arg->group, -1, DMG_KEY_FAIL_LOC, fail_loc,
 				     0, NULL);
 	MPI_Barrier(MPI_COMM_WORLD);
 
@@ -1030,7 +1030,7 @@ rebuild_pool_connect_cb(void *data)
 	rebuild_pool_connect_internal(data);
 	/* Disable fail_loc and start rebuild */
 	if (arg->myrank == 0)
-		daos_mgmt_set_params(arg->group, -1, DSS_KEY_FAIL_LOC,
+		daos_mgmt_set_params(arg->group, -1, DMG_KEY_FAIL_LOC,
 				     0, 0, NULL);
 	MPI_Barrier(MPI_COMM_WORLD);
 	return 0;
@@ -1055,7 +1055,7 @@ rebuild_offline_pool_connect_internal(void **state, unsigned int fail_loc)
 
 	/* hang the rebuild */
 	if (arg->myrank == 0)
-		daos_mgmt_set_params(arg->group, -1, DSS_KEY_FAIL_LOC, fail_loc,
+		daos_mgmt_set_params(arg->group, -1, DMG_KEY_FAIL_LOC, fail_loc,
 				     0, NULL);
 	MPI_Barrier(MPI_COMM_WORLD);
 
@@ -1140,13 +1140,13 @@ rebuild_change_leader_cb(void *arg)
 
 	/* Skip appendentry to re-elect the leader */
 	if (test_arg->myrank == 0) {
-		daos_mgmt_set_params(test_arg->group, leader, DSS_KEY_FAIL_LOC,
+		daos_mgmt_set_params(test_arg->group, leader, DMG_KEY_FAIL_LOC,
 				     DAOS_RDB_SKIP_APPENDENTRIES_FAIL, 0, NULL);
 		print_message("sleep 15 seconds for re-election leader\n");
 		/* Sleep 15 seconds to make sure the leader is changed */
 		sleep(15);
 		/* Continue the rebuild */
-		daos_mgmt_set_params(test_arg->group, -1, DSS_KEY_FAIL_LOC,
+		daos_mgmt_set_params(test_arg->group, -1, DMG_KEY_FAIL_LOC,
 				     0, 0, NULL);
 	}
 	MPI_Barrier(MPI_COMM_WORLD);
@@ -1172,7 +1172,7 @@ rebuild_master_change_during_scan(void **state)
 
 	/* All ranks should wait before rebuild */
 	if (arg->myrank == 0)
-		daos_mgmt_set_params(arg->group, -1, DSS_KEY_FAIL_LOC,
+		daos_mgmt_set_params(arg->group, -1, DMG_KEY_FAIL_LOC,
 				     DAOS_REBUILD_TGT_SCAN_HANG, 0, NULL);
 	MPI_Barrier(MPI_COMM_WORLD);
 	arg->rebuild_cb = rebuild_change_leader_cb;
@@ -1202,7 +1202,7 @@ rebuild_master_change_during_rebuild(void **state)
 
 	/* All ranks should wait before rebuild */
 	if (arg->myrank == 0)
-		daos_mgmt_set_params(arg->group, -1, DSS_KEY_FAIL_LOC,
+		daos_mgmt_set_params(arg->group, -1, DMG_KEY_FAIL_LOC,
 				     DAOS_REBUILD_TGT_REBUILD_HANG, 0, NULL);
 	MPI_Barrier(MPI_COMM_WORLD);
 	arg->rebuild_cb = rebuild_change_leader_cb;
@@ -1222,7 +1222,7 @@ rebuild_nospace_cb(void *data)
 	sleep(60);
 
 	if (arg->myrank == 0)
-		daos_mgmt_set_params(arg->group, -1, DSS_KEY_FAIL_LOC,
+		daos_mgmt_set_params(arg->group, -1, DMG_KEY_FAIL_LOC,
 				     0, 0, NULL);
 
 	print_message("re-enable recovery\n");
@@ -1230,8 +1230,8 @@ rebuild_nospace_cb(void *data)
 		/* Resume the rebuild. FIXME: fix this once we have better
 		 * way to resume rebuild through mgmt cmd.
 		 */
-		daos_mgmt_set_params(arg->group, -1, DSS_REBUILD_RES_PERCENTAGE,
-				     30, 0, NULL);
+		daos_mgmt_set_params(arg->group, -1,
+				     DMG_KEY_REBUILD_THROTTLING, 30, 0, NULL);
 
 	MPI_Barrier(MPI_COMM_WORLD);
 
@@ -1256,7 +1256,7 @@ rebuild_nospace(void **state)
 	rebuild_io(arg, oids, OBJ_NR);
 
 	if (arg->myrank == 0)
-		daos_mgmt_set_params(arg->group, -1, DSS_KEY_FAIL_LOC,
+		daos_mgmt_set_params(arg->group, -1, DMG_KEY_FAIL_LOC,
 				     DAOS_REBUILD_TGT_NOSPACE, 0, NULL);
 
 	MPI_Barrier(MPI_COMM_WORLD);
@@ -1295,7 +1295,7 @@ rebuild_multiple_tgts(void **state)
 		int fail_cnt = 0;
 
 		/* All ranks should wait before rebuild */
-		daos_mgmt_set_params(arg->group, -1, DSS_KEY_FAIL_LOC,
+		daos_mgmt_set_params(arg->group, -1, DMG_KEY_FAIL_LOC,
 				     DAOS_REBUILD_HANG, 0, NULL);
 		/* kill 2 ranks at the same time */
 		D_ASSERT(layout->ol_shards[0]->os_replica_nr > 2);
@@ -1313,7 +1313,7 @@ rebuild_multiple_tgts(void **state)
 			}
 		}
 
-		daos_mgmt_set_params(arg->group, -1, DSS_KEY_FAIL_LOC, 0,
+		daos_mgmt_set_params(arg->group, -1, DMG_KEY_FAIL_LOC, 0,
 				     0, NULL);
 	}
 
@@ -1494,7 +1494,7 @@ rebuild_fail_all_replicas_before_rebuild(void **state)
 	daos_obj_layout_get(arg->coh, oid, &layout);
 
 	/* HOLD rebuild ULT */
-	daos_mgmt_set_params(arg->group, -1, DSS_KEY_FAIL_LOC,
+	daos_mgmt_set_params(arg->group, -1, DMG_KEY_FAIL_LOC,
 			     DAOS_REBUILD_HANG, 0, NULL);
 
 	/* Kill one replica and start rebuild */
@@ -1515,7 +1515,7 @@ rebuild_fail_all_replicas_before_rebuild(void **state)
 			    &arg->pool.svc, shard->os_ranks[1]);
 
 	/* Continue rebuild */
-	daos_mgmt_set_params(arg->group, -1, DSS_KEY_FAIL_LOC, 0, 0, NULL);
+	daos_mgmt_set_params(arg->group, -1, DMG_KEY_FAIL_LOC, 0, 0, NULL);
 
 	sleep(5);
 	if (arg->myrank == 0)

--- a/src/tests/suite/daos_verify_consistency.c
+++ b/src/tests/suite/daos_verify_consistency.c
@@ -64,11 +64,11 @@ vc_set_fail_loc(test_arg_t *arg, uint64_t fail_loc, int total, int cur)
 	if (cur == total) {
 		MPI_Barrier(MPI_COMM_WORLD);
 		if (arg->myrank == 0)
-			daos_mgmt_set_params(arg->group, -1, DSS_KEY_FAIL_LOC,
+			daos_mgmt_set_params(arg->group, -1, DMG_KEY_FAIL_LOC,
 					     0, 0, NULL);
 	} else {
 		if (arg->myrank == 0)
-			daos_mgmt_set_params(arg->group, -1, DSS_KEY_FAIL_LOC,
+			daos_mgmt_set_params(arg->group, -1, DMG_KEY_FAIL_LOC,
 					     fail_loc, 0, NULL);
 		MPI_Barrier(MPI_COMM_WORLD);
 	}
@@ -319,7 +319,7 @@ vc_8(void **state)
 	vc_gen_modifications(arg, &req, oid, 7, 7, 7, 0, 0, 0);
 
 	if (arg->myrank == 0)
-		daos_mgmt_set_params(arg->group, -1, DSS_KEY_FAIL_LOC,
+		daos_mgmt_set_params(arg->group, -1, DMG_KEY_FAIL_LOC,
 				     DAOS_VC_LOST_REPLICA, 0, NULL);
 	MPI_Barrier(MPI_COMM_WORLD);
 
@@ -328,7 +328,7 @@ vc_8(void **state)
 
 	MPI_Barrier(MPI_COMM_WORLD);
 	if (arg->myrank == 0)
-		daos_mgmt_set_params(arg->group, -1, DSS_KEY_FAIL_LOC,
+		daos_mgmt_set_params(arg->group, -1, DMG_KEY_FAIL_LOC,
 				     0, 0, NULL);
 
 	ioreq_fini(&req);


### PR DESCRIPTION
- run aggregation only if there is no object RPC by default
  this is the default property of pool, but it could be
  changed so aggregation can run in normal prioriy in the
  future after performance tuning of aggregation.

- check aggregation property change every 4 seconds, instead
  of 90 seconds

- remove DMG command of disabling aggregation

- code cleanups
  add obj_io_context to store data structures required by RPC
  move related functions together
  rename prefix of DMG control opcodes from DSS to DMG

Signed-off-by: Liang Zhen <liang.zhen@intel.com>