### PR TITLE
DAOS-3600 tse: some refining related with refcount

### DIFF
--- a/src/common/tests/sched.c
+++ b/src/common/tests/sched.c
@@ -118,10 +118,12 @@ sched_test_1()
 	}
 
 	print_message("CANCEL non empty scheduler\n");
+	tse_sched_addref(&sched);
 	tse_sched_complete(&sched, 0, true);
 
 	print_message("Check scheduler is empty\n");
 	flag = tse_sched_check_complete(&sched);
+	tse_sched_decref(&sched);
 	if (!flag) {
 		print_error("Scheduler should not have in-flight tasks\n");
 		D_GOTO(out, rc = -DER_INVAL);
@@ -318,10 +320,12 @@ sched_test_2()
 	tse_task_complete(task, 0);
 
 	print_message("COMPLETE Scheduler\n");
+	tse_sched_addref(&sched);
 	tse_sched_complete(&sched, 0, false);
 
 	print_message("Check scheduler is empty\n");
 	flag = tse_sched_check_complete(&sched);
+	tse_sched_decref(&sched);
 	if (!flag) {
 		print_error("Scheduler should not have in-flight tasks\n");
 		D_GOTO(out, rc = -DER_INVAL);

--- a/src/include/daos/tse.h
+++ b/src/include/daos/tse.h
@@ -103,6 +103,22 @@ void
 tse_sched_fini(tse_sched_t *sched);
 
 /**
+ * Take reference of the scheduler.
+ *
+ * \param sched [input]		the scheduler pointer.
+ */
+void
+tse_sched_addref(tse_sched_t *sched);
+
+/**
+ * Release reference of the scheduler.
+ *
+ * \param sched [input]		the scheduler pointer.
+ */
+void
+tse_sched_decref(tse_sched_t *sched);
+
+/**
  * Wait for all tasks in the scheduler to complete and finalize it.
  * If another thread is completing the scheduler, this returns immediately.
  *


### PR DESCRIPTION
1) fix a bug of dsp refcount handling in tse_task_complete
   The original code addref but didnot decref for a case, that possibly
   cause refcount overflow for long time running. Actually need not
   addref in that case.
2) refine scheduler refcount handling
   addref when insert task to scheduler, decref when remove.
   when task reinit, for a completed task need to take another refcount
3) fix sched.c UT's problem that should take ref before call
   tse_sched_check_complete().
4) to make 3) be possible, exports tse_sched_addref()/_decref().

Signed-off-by: Xuezhao Liu <xuezhao.liu@intel.com>