### PR TITLE
DAOS-3839 security: Assert for impossible invalid ACE

### DIFF
--- a/src/common/acl_api.c
+++ b/src/common/acl_api.c
@@ -107,10 +107,15 @@ flatten_aces(uint8_t *buffer, uint32_t buf_len, struct daos_ace *aces[],
 	pen = buffer;
 	for (i = 0; i < num_aces; i++) {
 		ssize_t ace_size = daos_ace_get_size(aces[i]);
+		/*
+		 * Should have checked the ACE size validity during allocation
+		 * of the input buffer.
+		 */
+		D_ASSERTF(ace_size > 0, "ACE size became invalid");
 
 		/* Internal error if we walk outside the buffer */
 		D_ASSERTF((pen + ace_size) <= (buffer + buf_len),
-				"ACEs too long for buffer size %u", buf_len);
+			  "ACEs too long for buffer size %u", buf_len);
 
 		memcpy(pen, aces[i], ace_size);
 		pen += ace_size;


### PR DESCRIPTION
In practice we shouldn't be able to get to the situation
where the ace_size is invalid in flatten_aces(). To
allocate the input buffer, we should have already called
get_flattened_ace_size(), which checks the result of
daos_ace_get_size() for each ACE. To change the result
between the two calls, we'd need to experience a memory
corruption or some other alarming disruption of the
internal state of the system.

Signed-off-by: Kris Jacque <kristin.jacque@intel.com>