### PR TITLE
Added the e2fsprogs package to CentOS Dockerfile

### DIFF
--- a/utils/docker/Dockerfile.centos.7
+++ b/utils/docker/Dockerfile.centos.7
@@ -68,7 +68,7 @@ RUN yum -y install \
            python2-avocado python2-avocado-plugins-output-html \
            python2-avocado-plugins-varianter-yaml-to-mux       \
            yum-plugin-copr python-pathlib                      \
-           ndctl ipmctl                                        \
+           ndctl ipmctl e2fsprogs                              \
            python2-clustershell python2-Cython python2-pip     \
            python36-clustershell python36-paramiko             \
            python36-numpy python36-jira python3-pip;           \


### PR DESCRIPTION
In certain scenarios (not sure how many, but mine at least: I am using OptaneDC as SCM), the `dmg -i storage format` was failing due to the `e2fsprogs` package not being installed and thus the `mkfs.ext4` not being available in the container.

This PR simply adds this package to the CentOS Dockerfile.

AFAICT, the Ubuntu 18.04 base image (in which the DAOS Ubuntu Dockerfile is based) *does* have the `mkfs.ext4`. I have not thoroughly tested the whole DAOS workflow for Ubuntu, but I do have checked the command is available there.