### PR TITLE
DAOS-3620 control: make header check robust

### DIFF
--- a/src/control/lib/spdk/ctests/SConscript
+++ b/src/control/lib/spdk/ctests/SConscript
@@ -1,8 +1,5 @@
-#!/bin/env python
 """Build go-spdk bindings C tests"""
 from __future__ import print_function
-import os
-from os.path import join, isdir
 import daos_build
 
 def scons():
@@ -12,21 +9,24 @@ def scons():
     unit_env = senv.Clone()
     prereqs.require(unit_env, 'pmdk', 'spdk', 'hwloc', 'cmocka')
 
-    # equivalent to -I flags for spdk/lib/nvme and spdk/include for ut mocking
-    spdk_src = unit_env.subst("$SPDK_SRC")
-    unit_env.AppendUnique(CPPPATH=[join(spdk_src, 'lib', 'nvme'),
-                                   join(spdk_src, 'include')])
+    # spdk/lib/nvme to expose normally opaque types during tests
+    unit_env.AppendUnique(CPPPATH=["$SPDK_SRC/lib/nvme",
+                                   "$SPDK_SRC/include"])
 
-    if isdir(spdk_src) and len(os.listdir(spdk_src)) != 0:
-        tests = daos_build.test(unit_env, 'nvme_control_ctests',
-                                ['nvme_control_ut.c', unit_env.ncc,
-                                 unit_env.nc],
-                                LIBS=['spdk', 'spdk_env_dpdk', 'numa',
-                                      'cmocka', 'pthread', 'dl'])
-        unit_env.Install(join(senv.subst("$PREFIX"), 'bin'), tests)
+    config = Configure(unit_env)
+
+    if config.CheckHeader("nvme_internal.h"):
+        testbin = daos_build.test(unit_env, 'nvme_control_ctests',
+                                  ['nvme_control_ut.c', unit_env.ncc,
+                                   unit_env.nc],
+                                  LIBS=['spdk', 'spdk_env_dpdk', 'numa',
+                                        'cmocka', 'pthread', 'dl'])
+        unit_env.Install("$PREFIX/bin", testbin)
     else:
-        print("SPDK src directory empty (%s), skipping nvme_control_ut build",
+        print("SPDK nvme_internal.h missing, skipping nvme_control_ut build",
               spdk_src)
+
+    config.Finish()
 
 if __name__ == "SCons.Script":
     scons()

--- a/src/control/lib/spdk/ctests/nvme_control_ut.c
+++ b/src/control/lib/spdk/ctests/nvme_control_ut.c
@@ -106,7 +106,7 @@ mock_spdk_nvme_ctrlr_get_data(struct spdk_nvme_ctrlr *ctrlr)
 {
 	struct spdk_nvme_ctrlr_data *data;
 
-	data = malloc(sizeof(struct spdk_nvme_ctrlr_data));
+	data = calloc(1, sizeof(struct spdk_nvme_ctrlr_data));
 
 	(void)ctrlr;
 	return (const struct spdk_nvme_ctrlr_data *)data;
@@ -117,7 +117,7 @@ mock_spdk_nvme_ctrlr_get_pci_device(struct spdk_nvme_ctrlr *ctrlr)
 {
 	struct spdk_pci_device *dev;
 
-	dev = malloc(sizeof(struct spdk_pci_device));
+	dev = calloc(1, sizeof(struct spdk_pci_device));
 
 	(void)ctrlr;
 	return dev;


### PR DESCRIPTION
Signed-off-by: Tom Nabarro <tom.nabarro@intel.com>