### PR TITLE
DAOS-3841 vos: On fetch, we are not handling holes properly

### DIFF
--- a/src/vos/evtree.c
+++ b/src/vos/evtree.c
@@ -285,7 +285,6 @@ ent_array_alloc(struct evt_context *tcx, struct evt_entry_array *ent_array,
 		 */
 		size *= 3;
 		ent_array->ea_max = size;
-		ent_array->ea_inob = tcx->tc_inob;
 	}
 	if (ent_array->ea_ent_nr == ent_array->ea_size) {
 		/** We should never exceed the maximum number of entries. */
@@ -1920,6 +1919,7 @@ evt_ent_array_fill(struct evt_context *tcx, enum evt_find_opc find_opc,
 		return 0; /* empty tree */
 
 	evt_tcx_reset_trace(tcx);
+	ent_array->ea_inob = tcx->tc_inob;
 
 	level = at = 0;
 	nd_off = tcx->tc_root->tr_node;

--- a/src/vos/tests/vts_pm.c
+++ b/src/vos/tests/vts_pm.c
@@ -1004,8 +1004,7 @@ static const struct CMUnitTest punch_model_tests[] = {
 	  array_size_write, pm_setup, pm_teardown },
 	{ "VOS808: Object punch and fetch",
 	  object_punch_and_fetch, NULL, NULL },
-	{ "VOS809: SGL test",
-	  sgl_test, NULL, NULL },
+	{ "VOS809: SGL test", sgl_test, NULL, NULL },
 };
 
 int


### PR DESCRIPTION
evt_find was not returning ea_inob if the extent is empty.
Move the initialization of ea_inob to evt_ent_array_fill so it's
not dependent on in-tree extents.

Without the inob value, vos_obj_fetch was not inserting a biov
entry for the hole causing issues with filling the input sgl.

Signed-off-by: Jeff Olivier <jeffrey.v.olivier@intel.com>