### PR TITLE
DAOS-3485 control: Forward NVMe requests to privileged helper

### DIFF
--- a/ftest.sh
+++ b/ftest.sh
@@ -175,6 +175,21 @@ wq
 EOF
 mount \\\"$DAOS_BASE\\\"\"
 
+# set up symlinks to spdk scripts (none of this would be
+# necessary if we were testing from RPMs) in order to
+# perform NVMe operations via daos_admin
+sudo mkdir -p /usr/share/daos/control
+sudo ln -sf $SL_PREFIX/share/daos/control/setup_spdk.sh \
+           /usr/share/daos/control
+sudo mkdir -p /usr/share/spdk/scripts
+sudo ln -sf $SL_PREFIX/share/spdk/scripts/setup.sh \
+           /usr/share/spdk/scripts
+sudo ln -sf $SL_PREFIX/share/spdk/scripts/common.sh \
+           /usr/share/spdk/scripts
+sudo rm -f /usr/share/spdk/include
+sudo ln -s $SL_PREFIX/include \
+           /usr/share/spdk/include
+
 # first, strip the execute bit from the in-tree binary,
 # then copy daos_admin binary into \$PATH and fix perms
 chmod -x $DAOS_BASE/install/bin/daos_admin && \

--- a/ftest.sh
+++ b/ftest.sh
@@ -91,6 +91,11 @@ cleanup() {
                 while [ \$x -lt 30 ] &&
                       grep $DAOS_BASE /proc/mounts &&
                       ! sudo umount $DAOS_BASE; do
+                    for culprit in \$(/usr/sbin/lsof -Fp +D $DAOS_BASE \
+                                      | cut -c 2-); do
+                        ps -fp \$culprit
+                        sudo kill \$culprit
+                    done
                     sleep 1
                     let x+=1
                 done

--- a/src/control/SConscript
+++ b/src/control/SConscript
@@ -138,7 +138,6 @@ def scons():
 
     install_go_bin(denv, gosrc, gopath, None, "agent", "daos_agent")
     install_go_bin(denv, gosrc, gopath, None, "dmg", "dmg")
-    install_go_bin(denv, gosrc, gopath, None, "daos_admin", "daos_admin")
     install_go_bin(denv, gosrc, gopath, None, "drpc_test", "hello_drpc")
 
     agentbin = get_bin_path(gopath, "agent")
@@ -178,6 +177,8 @@ def scons():
 
     install_go_bin(senv, gosrc, gopath, [denv.nvmecontrol], "daos_server",
                    "daos_server")
+    install_go_bin(senv, gosrc, gopath, [denv.nvmecontrol], "daos_admin",
+                   "daos_admin")
 
     serverbin = get_bin_path(gopath, "daos_server")
     AlwaysBuild([serverbin,])

--- a/src/control/cmd/daos_admin/main.go
+++ b/src/control/cmd/daos_admin/main.go
@@ -33,6 +33,7 @@ import (
 	"github.com/daos-stack/daos/src/control/common"
 	"github.com/daos-stack/daos/src/control/logging"
 	"github.com/daos-stack/daos/src/control/pbin"
+	"github.com/daos-stack/daos/src/control/server/storage/bdev"
 	"github.com/daos-stack/daos/src/control/server/storage/scm"
 )
 
@@ -81,7 +82,8 @@ func main() {
 	}
 
 	scmProvider := scm.DefaultProvider(log).WithForwardingDisabled()
-	if err := handleRequest(log, scmProvider, req, conn); err != nil {
+	bdevProvider := bdev.DefaultProvider(log).WithForwardingDisabled()
+	if err := handleRequest(log, scmProvider, bdevProvider, req, conn); err != nil {
 		exitWithError(log, err)
 	}
 }

--- a/src/control/cmd/daos_server/main.go
+++ b/src/control/cmd/daos_server/main.go
@@ -24,6 +24,7 @@
 package main
 
 import (
+	"context"
 	"os"
 
 	"github.com/jessevdk/go-flags"
@@ -33,6 +34,7 @@ import (
 	"github.com/daos-stack/daos/src/control/fault"
 	"github.com/daos-stack/daos/src/control/lib/netdetect"
 	"github.com/daos-stack/daos/src/control/logging"
+	"github.com/daos-stack/daos/src/control/server"
 )
 
 type mainOpts struct {
@@ -125,6 +127,10 @@ func main() {
 	var opts mainOpts
 
 	if err := parseOpts(os.Args[1:], &opts, log); err != nil {
+		if errors.Cause(err) == context.Canceled {
+			log.Infof("%s (pid %d) shutting down", server.ControlPlaneName, os.Getpid())
+			os.Exit(0)
+		}
 		exitWithError(log, err)
 	}
 }

--- a/src/control/fault/code/codes.go
+++ b/src/control/fault/code/codes.go
@@ -47,6 +47,8 @@ const (
 	// Bdev fault codes
 	BdevUnknown Code = iota + 300
 	BdevFormatBadParam
+	BdevFormatFailure
+	BdevFormatBadPciAddress
 
 	// security fault codes
 	SecurityUnknown Code = iota + 900

--- a/src/control/pbin/decode_test.go
+++ b/src/control/pbin/decode_test.go
@@ -1,0 +1,85 @@
+//
+// (C) Copyright 2019 Intel Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// GOVERNMENT LICENSE RIGHTS-OPEN SOURCE SOFTWARE
+// The Government's rights to use, modify, reproduce, release, perform, display,
+// or disclose this software are subject to the terms of the Apache License as
+// provided in Contract No. 8F-30005.
+// Any reproduction of computer software, computer software documentation, or
+// portions thereof marked with this legend must also reproduce the markings.
+//
+package pbin
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/pkg/errors"
+
+	"github.com/daos-stack/daos/src/control/common"
+)
+
+func TestPbin_decodeResponse(t *testing.T) {
+	for name, tc := range map[string]struct {
+		input  []byte
+		expRes *Response
+		expErr error
+	}{
+		"normal input": {
+			input: []byte(`{"Error":null,"Payload":{"Controllers":[]}}`),
+			expRes: &Response{
+				Payload: json.RawMessage(`{"Error":null,"Payload":{"Controllers":[]}}`),
+			},
+		},
+		"deal with SPDK spew": {
+			input: []byte(`EAL:   Invalid NUMA socket, default to 0\nEAL:   Invalid NUMA socket` +
+				`, default to 0\n{"Error":null,"Payload":{"Controllers":[]}}`),
+			expRes: &Response{
+				Payload: json.RawMessage(`{"Error":null,"Payload":{"Controllers":[]}}`),
+			},
+		},
+		"some weird suffix": {
+			input: []byte(`EAL:   Invalid NUMA socket, default to 0\nEAL:   Invalid NUMA socket` +
+				`, default to 0\n{"Error":null,"Payload":{"Controllers":[]}}abbabananafish`),
+			expRes: &Response{
+				Payload: json.RawMessage(`{"Error":null,"Payload":{"Controllers":[]}}`),
+			},
+		},
+		"unrecoverable nonsense": {
+			input: []byte(`{"Error":null,"Payload":{"Controllers":[Hwæt. We Gardena in geardagum,` +
+				`þeodcyninga, þrym gefrunon, hu ða æþelingas ellen fremedon.]}}`),
+			expErr: errors.New("invalid character"),
+		},
+		"more nonsense": {
+			input: []byte(`{"Error":null,"Payload":{"Controllers":[Hwæt. We Gardena in geardagum,` +
+				`þeodcyninga, þrym gefrunon, hu ða æþelingas ellen fremedon.]`),
+			expErr: errors.New("invalid character"),
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			gotRes, gotErr := decodeResponse(tc.input)
+
+			common.CmpErr(t, tc.expErr, gotErr)
+			if tc.expErr == nil {
+				return
+			}
+
+			if diff := cmp.Diff(tc.expRes, gotRes); diff != "" {
+				t.Fatalf("unexpected response (-want, +got)\n%s\n", diff)
+			}
+		})
+	}
+}

--- a/src/control/pbin/exec.go
+++ b/src/control/pbin/exec.go
@@ -25,7 +25,10 @@ package pbin
 import (
 	"context"
 	"encoding/json"
+	"io"
+	"os"
 	"os/exec"
+	"strings"
 
 	"github.com/pkg/errors"
 
@@ -88,6 +91,32 @@ func (cl *cmdLogger) Write(data []byte) (int, error) {
 	return len(data), nil
 }
 
+func decodeResponse(resBuf []byte) (*Response, error) {
+	res := new(Response)
+	err := json.Unmarshal(resBuf, res)
+	if err == nil {
+		return res, nil
+	}
+
+	switch err.(type) {
+	case *json.SyntaxError:
+		// Try to pull out a valid JSON payload.
+		start := strings.Index(string(resBuf), "{")
+		end := strings.LastIndex(string(resBuf), "}")
+		if end < 0 {
+			break
+		}
+		end += 1
+		resBuf = resBuf[start:end]
+		err = json.Unmarshal(resBuf, res)
+		if err == nil {
+			return res, nil
+		}
+	}
+
+	return nil, errors.Wrapf(err, "pbin failed to decode response data(%q)", resBuf)
+}
+
 func ExecReq(parent context.Context, log logging.Logger, binPath string, req *Request) (res *Response, err error) {
 	if req == nil {
 		return nil, errors.New("nil request")
@@ -110,6 +139,10 @@ func ExecReq(parent context.Context, log logging.Logger, binPath string, req *Re
 		return nil, err
 	}
 	conn := NewStdioConn("server", binPath, fromChild, toChild)
+
+	// ensure that /usr/sbin is in $PATH
+	os.Setenv("PATH", os.Getenv("PATH")+":/usr/sbin")
+	child.Env = os.Environ()
 
 	if err := child.Start(); err != nil {
 		return nil, err
@@ -135,19 +168,28 @@ func ExecReq(parent context.Context, log logging.Logger, binPath string, req *Re
 		return nil, errors.Wrap(err, "pbin write failed")
 	}
 
-	recvData := make([]byte, MaxMessageSize)
-	recvLen, err := conn.Read(recvData)
-	if err != nil {
-		return nil, errors.Wrap(err, "pbin read failed")
-	}
+	maxReadAttempts := 5
+	readCount := 0
+	for {
+		recvData := make([]byte, MaxMessageSize)
+		recvLen, err := conn.Read(recvData)
+		if err != nil {
+			return nil, errors.Wrap(err, "pbin read failed")
+		}
 
-	res = &Response{}
-	if err := json.Unmarshal(recvData[:recvLen], res); err != nil {
-		return nil, err
-	}
-	if res.Error != nil {
-		return nil, res.Error
-	}
+		res, err = decodeResponse(recvData[:recvLen])
+		if err != nil && err != io.EOF {
+			log.Debugf("discarding garbage response %q", recvData[:recvLen])
+			readCount++
+			if readCount < maxReadAttempts {
+				continue
+			}
+			return nil, err
+		}
+		if res.Error != nil {
+			return nil, res.Error
+		}
 
-	return res, nil
+		return res, nil
+	}
 }

--- a/src/control/pbin/forwarding.go
+++ b/src/control/pbin/forwarding.go
@@ -1,0 +1,125 @@
+//
+// (C) Copyright 2019 Intel Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// GOVERNMENT LICENSE RIGHTS-OPEN SOURCE SOFTWARE
+// The Government's rights to use, modify, reproduce, release, perform, display,
+// or disclose this software are subject to the terms of the Apache License as
+// provided in Contract No. 8F-30005.
+// Any reproduction of computer software, computer software documentation, or
+// portions thereof marked with this legend must also reproduce the markings.
+//
+package pbin
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"strconv"
+
+	"github.com/pkg/errors"
+
+	"github.com/daos-stack/daos/src/control/common"
+	"github.com/daos-stack/daos/src/control/logging"
+)
+
+type (
+	// Forwarder provides a common implementation of a request forwarder.
+	Forwarder struct {
+		Disabled bool
+
+		log      logging.Logger
+		pbinName string
+	}
+
+	// ForwardableRequest is intended to be embedded into
+	// request types that can be forwarded to the privileged
+	// binary.
+	ForwardableRequest struct {
+		Forwarded bool
+	}
+
+	// ForwardChecker defines an interface for any request that
+	// could have been forwarded.
+	ForwardChecker interface {
+		IsForwarded() bool
+	}
+)
+
+// IsForwarded implements the ForwardChecker interface.
+func (r ForwardableRequest) IsForwarded() bool {
+	return r.Forwarded
+}
+
+// NewForwarder returns a configured *Forwarder.
+func NewForwarder(log logging.Logger, pbinName string) *Forwarder {
+	fwd := &Forwarder{
+		log:      log,
+		pbinName: pbinName,
+	}
+
+	if val, set := os.LookupEnv(DisableReqFwdEnvVar); set {
+		disabled, err := strconv.ParseBool(val)
+		if err != nil {
+			log.Errorf("%s was set to non-boolean value (%q); not disabling",
+				DisableReqFwdEnvVar, val)
+			return fwd
+		}
+		fwd.Disabled = disabled
+	}
+
+	return fwd
+}
+
+// SendReq is responsible for marshaling the forwarded request into a message
+// that is sent to the privileged binary, then unmarshaling the response for
+// the caller.
+func (f *Forwarder) SendReq(method string, fwdReq interface{}, fwdRes interface{}) error {
+	if fwdReq == nil {
+		return errors.New("nil request")
+	}
+	if fwdRes == nil {
+		return errors.New("nil response")
+	}
+
+	pbinPath, err := common.FindBinary(f.pbinName)
+	if err != nil {
+		return err
+	}
+
+	payload, err := json.Marshal(fwdReq)
+	if err != nil {
+		return errors.Wrap(err, "failed to marshal forwarded request as payload")
+	}
+
+	req := &Request{
+		Method:  method,
+		Payload: payload,
+	}
+
+	ctx := context.TODO()
+	res, err := ExecReq(ctx, f.log, pbinPath, req)
+	if err != nil {
+		if IsFailedRequest(err) {
+			return err
+		}
+		return errors.Wrap(err, "privileged binary execution failed")
+	}
+
+	if err := json.Unmarshal(res.Payload, fwdRes); err != nil {
+		return errors.Wrap(err, "failed to unmarshal forwarded response")
+	}
+
+	return nil
+}

--- a/src/control/server/ctl_storage_rpc_test.go
+++ b/src/control/server/ctl_storage_rpc_test.go
@@ -372,7 +372,7 @@ func TestStoragePrepare(t *testing.T) {
 				Nvme: &PrepareNvmeResp{
 					State: &ResponseState{
 						Status: ResponseStatus_CTL_ERR_NVME,
-						Error:  "SPDK setup: nvme prep error",
+						Error:  "SPDK prepare: nvme prep error",
 					},
 				},
 				Scm: &PrepareScmResp{

--- a/src/control/server/harness.go
+++ b/src/control/server/harness.go
@@ -149,7 +149,7 @@ func (h *IOServerHarness) AwaitStorageReady(ctx context.Context, skipMissingSupe
 		return errors.New("can't wait for storage: harness already started")
 	}
 
-	h.log.Info("Waiting for I/O server instance storage to be ready...")
+	h.log.Infof("Waiting for %s instance storage to be ready...", DataPlaneName)
 	for _, instance := range h.instances {
 		needsScmFormat, err := instance.NeedsScmFormat()
 		if err != nil {

--- a/src/control/server/instance.go
+++ b/src/control/server/instance.go
@@ -218,7 +218,7 @@ func (srv *IOServerInstance) Start(ctx context.Context, errChan chan<- error) er
 // NotifyReady receives a ready message from the running IOServer
 // instance.
 func (srv *IOServerInstance) NotifyReady(msg *srvpb.NotifyReadyReq) {
-	srv.log.Debugf("I/O server instance %d ready: %v", srv.Index(), msg)
+	srv.log.Debugf("%s instance %d ready: %v", DataPlaneName, srv.Index(), msg)
 
 	// Activate the dRPC client connection to this iosrv
 	srv.setDrpcClient(drpc.NewClientConnection(msg.DrpcListenerSock))
@@ -237,7 +237,7 @@ func (srv *IOServerInstance) AwaitReady() chan *srvpb.NotifyReadyReq {
 
 // NotifyStorageReady releases any blocks on AwaitStorageReady().
 func (srv *IOServerInstance) NotifyStorageReady() {
-	srv.log.Debugf("I/O server instance %d notifying storage ready", srv.Index())
+	srv.log.Debugf("%s instance %d notifying storage ready", DataPlaneName, srv.Index())
 	go func() {
 		close(srv.storageReady)
 	}()
@@ -247,9 +247,9 @@ func (srv *IOServerInstance) NotifyStorageReady() {
 func (srv *IOServerInstance) AwaitStorageReady(ctx context.Context) {
 	select {
 	case <-ctx.Done():
-		srv.log.Infof("I/O server instance %d storage not ready: %s", srv.Index(), ctx.Err())
+		srv.log.Infof("%s instance %d storage not ready: %s", DataPlaneName, srv.Index(), ctx.Err())
 	case <-srv.storageReady:
-		srv.log.Infof("I/O server instance %d storage ready", srv.Index())
+		srv.log.Infof("%s instance %d storage ready", DataPlaneName, srv.Index())
 	}
 }
 
@@ -324,7 +324,7 @@ func (srv *IOServerInstance) StartManagementService() error {
 
 	// should have been loaded by now
 	if superblock == nil {
-		return errors.Errorf("I/O server instance %d: nil superblock", srv.Index())
+		return errors.Errorf("%s instance %d: nil superblock", DataPlaneName, srv.Index())
 	}
 
 	if superblock.CreateMS {

--- a/src/control/server/ioserver/exec.go
+++ b/src/control/server/ioserver/exec.go
@@ -108,7 +108,6 @@ func (r *Runner) run(ctx context.Context, args, env []string) error {
 		},
 	}
 
-	r.log.Debugf("%s:%d config: %#v", ioServerBin, r.Config.Index, r.Config)
 	r.log.Debugf("%s:%d args: %s", ioServerBin, r.Config.Index, args)
 	r.log.Debugf("%s:%d env: %s", ioServerBin, r.Config.Index, env)
 	r.log.Infof("Starting I/O server instance %d: %s", r.Config.Index, binPath)

--- a/src/control/server/storage/bdev/class.go
+++ b/src/control/server/storage/bdev/class.go
@@ -222,7 +222,7 @@ func (p *ClassProvider) PrepareDevices() error {
 	return p.bdev.prep(p.log, p.cfg)
 }
 
-func (p *ClassProvider) GenConfigFile() error {
+func (p *ClassProvider) GenConfigFile() (err error) {
 	if p.cfgPath == "" {
 		return nil
 	}
@@ -237,7 +237,12 @@ func (p *ClassProvider) GenConfigFile() error {
 	}
 
 	f, err := os.Create(p.cfgPath)
-	defer f.Close()
+	defer func() {
+		ce := f.Close()
+		if err == nil {
+			err = ce
+		}
+	}()
 	if err != nil {
 		return errors.Wrapf(err, "spdk: failed to create NVMe config file %s", p.cfgPath)
 	}

--- a/src/control/server/storage/bdev/faults.go
+++ b/src/control/server/storage/bdev/faults.go
@@ -23,17 +23,38 @@
 package bdev
 
 import (
+	"fmt"
+
 	"github.com/daos-stack/daos/src/control/fault"
 	"github.com/daos-stack/daos/src/control/fault/code"
 )
 
 var (
 	FaultUnknown = bdevFault(code.BdevUnknown, "unknown bdev error", "")
-
-	FaultFormatUnknownClass = bdevFault(
-		code.BdevFormatBadParam, "format request contains unhandled block device class", "",
-	)
 )
+
+func FaultFormatBadPciAddr(pciAddr string) *fault.Fault {
+	return bdevFault(
+		code.BdevFormatBadPciAddress,
+		fmt.Sprintf("format request contains invalid NVMe PCI address %q", pciAddr),
+		"check your configuration, restart the server, and retry the format operation",
+	)
+}
+
+func FaultFormatUnknownClass(class string) *fault.Fault {
+	return bdevFault(
+		code.BdevFormatBadParam,
+		fmt.Sprintf("format request contains unhandled block device class %q", class),
+		"check your configuration and restart the server",
+	)
+}
+
+func FaultFormatError(err error) *fault.Fault {
+	return bdevFault(
+		code.BdevFormatFailure,
+		fmt.Sprintf("NVMe format failed: %s", err), "",
+	)
+}
 
 func bdevFault(code code.Code, desc, res string) *fault.Fault {
 	return &fault.Fault{

--- a/src/control/server/storage/bdev/forwarder.go
+++ b/src/control/server/storage/bdev/forwarder.go
@@ -20,7 +20,7 @@
 // Any reproduction of computer software, computer software documentation, or
 // portions thereof marked with this legend must also reproduce the markings.
 //
-package scm
+package bdev
 
 import (
 	"github.com/daos-stack/daos/src/control/logging"
@@ -39,55 +39,22 @@ func NewForwarder(log logging.Logger) *Forwarder {
 	}
 }
 
-func (f *Forwarder) Mount(req MountRequest) (*MountResponse, error) {
+func (f *Forwarder) Init(req InitRequest) error {
 	req.Forwarded = true
 
-	res := new(MountResponse)
-	if err := f.SendReq("ScmMount", req, res); err != nil {
-		return nil, err
+	res := new(InitResponse)
+	if err := f.SendReq("BdevInit", req, res); err != nil {
+		return err
 	}
 
-	return res, nil
-}
-
-func (f *Forwarder) Unmount(req MountRequest) (*MountResponse, error) {
-	req.Forwarded = true
-
-	res := new(MountResponse)
-	if err := f.SendReq("ScmUnmount", req, res); err != nil {
-		return nil, err
-	}
-
-	return res, nil
-}
-
-func (f *Forwarder) Format(req FormatRequest) (*FormatResponse, error) {
-	req.Forwarded = true
-
-	res := new(FormatResponse)
-	if err := f.SendReq("ScmFormat", req, res); err != nil {
-		return nil, err
-	}
-
-	return res, nil
-}
-
-func (f *Forwarder) CheckFormat(req FormatRequest) (*FormatResponse, error) {
-	req.Forwarded = true
-
-	res := new(FormatResponse)
-	if err := f.SendReq("ScmCheckFormat", req, res); err != nil {
-		return nil, err
-	}
-
-	return res, nil
+	return nil
 }
 
 func (f *Forwarder) Scan(req ScanRequest) (*ScanResponse, error) {
 	req.Forwarded = true
 
 	res := new(ScanResponse)
-	if err := f.SendReq("ScmScan", req, res); err != nil {
+	if err := f.SendReq("BdevScan", req, res); err != nil {
 		return nil, err
 	}
 
@@ -98,7 +65,18 @@ func (f *Forwarder) Prepare(req PrepareRequest) (*PrepareResponse, error) {
 	req.Forwarded = true
 
 	res := new(PrepareResponse)
-	if err := f.SendReq("ScmPrepare", req, res); err != nil {
+	if err := f.SendReq("BdevPrepare", req, res); err != nil {
+		return nil, err
+	}
+
+	return res, nil
+}
+
+func (f *Forwarder) Format(req FormatRequest) (*FormatResponse, error) {
+	req.Forwarded = true
+
+	res := new(FormatResponse)
+	if err := f.SendReq("BdevFormat", req, res); err != nil {
 		return nil, err
 	}
 

--- a/src/control/server/storage/bdev/mocks.go
+++ b/src/control/server/storage/bdev/mocks.go
@@ -114,12 +114,9 @@ func (mb *MockBackend) Prepare(_ int, _, _ string) error {
 }
 
 func NewMockProvider(log logging.Logger, mbc *MockBackendConfig) *Provider {
-	return &Provider{
-		log:     log,
-		backend: NewMockBackend(mbc),
-	}
+	return NewProvider(log, NewMockBackend(mbc)).WithForwardingDisabled()
 }
 
 func DefaultMockProvider(log logging.Logger) *Provider {
-	return NewMockProvider(log, nil)
+	return NewMockProvider(log, nil).WithForwardingDisabled()
 }

--- a/src/control/server/storage/bdev/provider_test.go
+++ b/src/control/server/storage/bdev/provider_test.go
@@ -82,7 +82,7 @@ func TestBdevScan(t *testing.T) {
 			log, buf := logging.NewTestLogger(name)
 			defer common.ShowBufferOnFailure(t, buf)
 
-			p := NewProvider(log, NewMockBackend(tc.mbc))
+			p := NewMockProvider(log, tc.mbc)
 
 			gotRes, gotErr := p.Scan(tc.req)
 			common.CmpErr(t, tc.expErr, gotErr)
@@ -136,7 +136,7 @@ func TestBdevPrepare(t *testing.T) {
 			log, buf := logging.NewTestLogger(name)
 			defer common.ShowBufferOnFailure(t, buf)
 
-			p := NewProvider(log, NewMockBackend(tc.mbc))
+			p := NewMockProvider(log, tc.mbc)
 
 			gotRes, gotErr := p.Prepare(tc.req)
 			common.CmpErr(t, tc.expErr, gotErr)
@@ -172,7 +172,7 @@ func TestBdevFormat(t *testing.T) {
 			expRes: &FormatResponse{
 				DeviceResponses: DeviceFormatResponses{
 					"foo": &DeviceFormatResponse{
-						Error: errors.Wrap(FaultFormatUnknownClass, "whoops"),
+						Error: FaultFormatUnknownClass("whoops"),
 					},
 				},
 			},
@@ -277,7 +277,7 @@ func TestBdevFormat(t *testing.T) {
 					},
 					storage.MockNvmeController(2).PciAddr: &DeviceFormatResponse{
 						Formatted: false,
-						Error:     errors.New("format failed"),
+						Error:     FaultFormatError(errors.New("format failed")),
 					},
 					storage.MockNvmeController(3).PciAddr: &DeviceFormatResponse{
 						Formatted:  true,
@@ -291,7 +291,7 @@ func TestBdevFormat(t *testing.T) {
 			log, buf := logging.NewTestLogger(name)
 			defer common.ShowBufferOnFailure(t, buf)
 
-			p := NewProvider(log, NewMockBackend(tc.mbc))
+			p := NewMockProvider(log, tc.mbc)
 
 			gotRes, gotErr := p.Format(tc.req)
 			common.CmpErr(t, tc.expErr, gotErr)

--- a/src/control/server/storage/bdev/runner_test.go
+++ b/src/control/server/storage/bdev/runner_test.go
@@ -109,7 +109,7 @@ func TestBdevRunnerPrepare(t *testing.T) {
 				},
 			}
 			b := newBackend(log, s)
-			p := NewProvider(log, b)
+			p := NewProvider(log, b).WithForwardingDisabled()
 
 			_, gotErr := p.Prepare(tc.req)
 			common.CmpErr(t, tc.expErr, gotErr)

--- a/src/tests/ftest/util/server_utils.py
+++ b/src/tests/ftest/util/server_utils.py
@@ -451,7 +451,7 @@ class ServerManager(ExecutableCommand):
                 cmd_touch_log = "touch {}".format(lfile)
                 pcmd(self._hosts, cmd_touch_log, False)
         if storage_prep_flag != "ram":
-            storage_prepare(self._hosts, "root", storage_prep_flag)
+            storage_prepare(self._hosts, getpass.getuser(), storage_prep_flag)
             self.runner.mca.value = {"plm_rsh_args": "-l root"}
 
         try:
@@ -569,7 +569,7 @@ def storage_prepare(hosts, user, device_type):
         device_args = " --hugepages=4096"
     else:
         raise ServerFailed("Invalid device type")
-    cmd = ("sudo {} storage prepare {} -u \"{}\" {} -f"
+    cmd = ("{} storage prepare {} -u \"{}\" {} -f"
            .format(daos_srv_bin[0], dev_param, user, device_args))
     result = pcmd(hosts, cmd, timeout=120)
     if len(result) > 1 or 0 not in result:


### PR DESCRIPTION
With this commit, daos_server should be able to run entirely as a non-root
user by relying on the daos_admin helper binary to run all privileged
operations.

Includes a few other improvements as well:
  * DAOS-3486 control: Automatic NVMe prep on startup
  * DAOS-2210 control: Clean up SPDK output
  * Exit quietly on normal daos_server shutdown
  * Remove debug output of server config
  * Consistent naming of data plane/control plane components in log messages