### PR TITLE
DAOS-3840 tests: CI tests take advantage of OPA adapters

### DIFF
--- a/ftest.sh
+++ b/ftest.sh
@@ -203,7 +203,10 @@ rm -rf $DAOS_BASE/install/tmp
 mkdir -p $DAOS_BASE/install/tmp
 cd $DAOS_BASE
 export CRT_PHY_ADDR_STR=ofi+sockets
-export OFI_INTERFACE=eth0
+
+# Disable OFI_INTERFACE to allow launch.py to pick the fastest interface
+unset OFI_INTERFACE
+
 # At Oct2018 Longmond F2F it was decided that per-server logs are preferred
 # But now we need to collect them!  Avoid using 'client_daos.log' due to
 # conflicts with the daos_test log renaming.

--- a/src/tests/ftest/launch.py
+++ b/src/tests/ftest/launch.py
@@ -140,9 +140,9 @@ def set_test_environment():
         with open(os.path.join(net_path, device, "operstate"), "r") as buffer:
             state = buffer.read().strip()
         with open(os.path.join(net_path, device, "type"), "r") as buffer:
-            dtype = buffer.read().strip()
+            dtype = int(buffer.read().strip())
         print(
-            "  device: {0:<5}, type: {1:<4}, state: {2}".format(
+            "  - {0:<5} (type: {1:<2} state: {2})".format(
                 device, dtype, state))
         if state.lower() == "up" and dtype not in available_interfaces:
             available_interfaces[dtype] = device

--- a/src/tests/ftest/launch.py
+++ b/src/tests/ftest/launch.py
@@ -133,20 +133,27 @@ def set_test_environment():
     #   - Exclude the loopback device
     #   - Only include the first active interface for each interface type (name)
     #   - Use sorting to prioritize ib<n> over eth<n>
-    print("ifconfig output: {}".format(get_output("ifconfig")))
-    output = get_output(
-        r"ifconfig 2>&1 | sed -En '/LOOPBACK/! s/^([a-z0-9]+):.*/\1/p'")
-    interfaces_by_type = {
-        re.sub(r"[0-9]+", "", item): item for item in reversed(output.split())}
-    available_interfaces = [
-        interfaces_by_type[key] for key in sorted(interfaces_by_type)]
+    print("Detecting network devices")
+    available_interfaces = []
+    net_path = os.path.join(os.path.sep, "sys", "class", "net")
+    for device in sorted([dev for dev in os.listdir(net_path) if dev != "lo"]):
+        dev_type = re.sub(r"[0-9]+", "", device)
+        with open(os.path.join(net_path, device, "operstate"), "r") as buffer:
+            state = buffer.read().strip()
+        print(
+            "  device: {0:<5}, type: {1:<4}, state: {2}".format(
+                device, dev_type, state))
+        if state.lower() == "up":
+            available_interfaces.append(device)
     try:
-        interface = available_interfaces[-1]
+        interface = sorted(available_interfaces)[-1]
     except IndexError:
-        print("Error obtaining a default interface from: '{}'".format(output))
+        print(
+            "Error obtaining a default interface from: {}".format(
+                os.listdir(net_path)))
         exit(1)
     print(
-        "Using {} as the default interface from: {}".format(
+        "Using {} as the default interface from {}".format(
             interface, available_interfaces))
 
     # Update env definitions

--- a/src/tests/ftest/launch.py
+++ b/src/tests/ftest/launch.py
@@ -133,6 +133,7 @@ def set_test_environment():
     #   - Exclude the loopback device
     #   - Only include the first active interface for each interface type (name)
     #   - Use sorting to prioritize ib<n> over eth<n>
+    print("ifconfig output: {}".format(get_output("ifconfig")))
     output = get_output(
         r"ifconfig 2>&1 | sed -En '/LOOPBACK/! s/^([a-z0-9]+):.*/\1/p'")
     interfaces_by_type = {
@@ -142,7 +143,7 @@ def set_test_environment():
     try:
         interface = available_interfaces[-1]
     except IndexError:
-        print("Error obtaining a default interface from: {}".format(output))
+        print("Error obtaining a default interface from: '{}'".format(output))
         exit(1)
     print(
         "Using {} as the default interface from: {}".format(

--- a/src/tests/ftest/launch.py
+++ b/src/tests/ftest/launch.py
@@ -125,19 +125,17 @@ def set_test_environment():
     path = os.environ.get("PATH")
 
     # Get the default interface to use if OFI_INTERFACE is not set
-    #   - Only include interfaces that are active (UP state)
+    #   - Only include interfaces that are active/up (default ifconfig listing)
+    #   - Exclude the loopback device
     #   - Select the last active interface: e.g. selecte ib<n> over eth<n>
-    commands = [
-        "ip link show",
-        r"sed -En 's/^[0-9]+:\s+([a-z0-9]+):.*\s+state\s+(\w+)\s+.*/\1-\2/p'"
-    ]
-    output = get_output(" | ".join(commands))
+    output = get_output(
+        "ifconfig | sed -En '/LOOPBACK/! s/^([a-z0-9]+):.*/\1/p'")
     available_interfaces = [
         link.split("-")[0] for link in output.split() if "UP" in link
     ]
     try:
         interface = sorted(available_interfaces)[-1]
-    except IndexError as err:
+    except IndexError:
         print("Error obtaining a default interface from: {}".format(output))
         exit(1)
     print(

--- a/src/tests/ftest/network/cart_self_test.py
+++ b/src/tests/ftest/network/cart_self_test.py
@@ -78,7 +78,7 @@ class CartSelfTest(TestWithoutServers):
         self.env_dict = {
             "CRT_PHY_ADDR_STR":     "ofi+sockets",
             "CRT_CTX_NUM":          "8",
-            "OFI_INTERFACE":        "eth0",
+            "OFI_INTERFACE":        os.environ.get("OFI_INTERFACE", "eth0"),
             "CRT_CTX_SHARE_ADDR":   str(self.share_addr)
         }
         self.env_list = []

--- a/src/tests/ftest/util/server_utils.py
+++ b/src/tests/ftest/util/server_utils.py
@@ -86,7 +86,6 @@ class DaosServer(DaosCommand):
 
     def get_action_command(self):
         """Set the action command object based on the yaml provided value."""
-        # pylint: disable=redefined-variable-type
         if self.action.value == "start":
             self.action_command = self.ServerStartSubCommand()
         else:
@@ -551,7 +550,7 @@ def storage_prepare(hosts, user, device_type):
         hosts (str): a string of comma-separated host names
         user (str): username for file permissions
         device_type (str): storage type - scm or nvme
-    
+
     Raises:
         ServerFailed: if server failed to prepare storage
 

--- a/src/tests/ftest/util/server_utils.py
+++ b/src/tests/ftest/util/server_utils.py
@@ -52,6 +52,7 @@ SESSIONS = {}
 
 AVOCADO_FILE = "daos_avocado_test.yaml"
 
+
 class ServerFailed(Exception):
     """Server didn't start/stop properly."""
 
@@ -60,7 +61,7 @@ class DaosServer(DaosCommand):
     """Defines an object representing a server command."""
 
     def __init__(self, path=""):
-        """Create a server command object
+        """Create a server command object.
 
         Args:
             path (str): path to location of daos_server binary.
@@ -160,6 +161,10 @@ class DaosServerConfig(ObjectWithParameters):
             super(DaosServerConfig.SingleServerConfig, self).__init__(
                 "/run/server_config/servers/*")
 
+            # Use environment variables to get default parameters
+            default_interface = os.environ.get("OFI_INTERFACE", "eth0")
+            default_port = os.environ.get("OFI_PORT", 31416)
+
             # Parameters
             #   targets:                count of VOS targets
             #   first_core:             starting index for targets
@@ -178,8 +183,8 @@ class DaosServerConfig(ObjectWithParameters):
             self.targets = BasicParameter(None, 8)
             self.first_core = BasicParameter(None, 0)
             self.nr_xs_helpers = BasicParameter(None, 2)
-            self.fabric_iface = BasicParameter(None, "eth0")
-            self.fabric_iface_port = BasicParameter(None, 31416)
+            self.fabric_iface = BasicParameter(None, default_interface)
+            self.fabric_iface_port = BasicParameter(None, default_port)
             self.log_mask = BasicParameter(None, "DEBUG,RPC=ERR,MEM=ERR")
             self.log_file = BasicParameter(None, "/tmp/server.log")
             self.env_vars = BasicParameter(
@@ -332,7 +337,6 @@ class DaosServerConfig(ObjectWithParameters):
 
 class ServerManager(ExecutableCommand):
     """Defines object to manage server functions and launch server command."""
-    # pylint: disable=pylint-no-self-use
 
     def __init__(self, daosbinpath, runnerpath, timeout=300):
         """Create a ServerManager object.
@@ -373,7 +377,7 @@ class ServerManager(ExecutableCommand):
 
     @hosts.setter
     def hosts(self, value):
-        """Hosts attribute setter
+        """Hosts attribute setter.
 
         Args:
             value (tuple): (list of hosts, workdir, slots)
@@ -386,8 +390,10 @@ class ServerManager(ExecutableCommand):
         self.runner.job.server_list = self._hosts
 
     def get_params(self, test):
-        """Get values from the yaml file and assign them respectively
-            to the server command and the orterun command.
+        """Get values from the yaml file.
+
+        Assign the ServerManager parameters to their respective ServerCommand
+        and Orterun class parameters.
 
         Args:
             test (Test): avocado Test object
@@ -517,12 +523,14 @@ class ServerManager(ExecutableCommand):
 
 
 def storage_prepare(hosts, user):
-    """
-    Prepare the storage on servers using the DAOS server's yaml settings file.
+    """Prepare storage on servers using the DAOS server's yaml settings file.
+
     Args:
         hosts (str): a string of comma-separated host names
+
     Raises:
         ServerFailed: if server failed to prepare storage
+
     """
     daos_srv_bin = get_file_path("bin/daos_server")
     cmd = ("sudo {} storage prepare -n -u \"{}\" --hugepages=4096 -f"
@@ -533,12 +541,14 @@ def storage_prepare(hosts, user):
 
 
 def storage_reset(hosts):
-    """
-    Reset the Storage on servers using the DAOS server's yaml settings file.
+    """Reset the Storage on servers using the DAOS server's yaml settings file.
+
     Args:
         hosts (str): a string of comma-separated host names
+
     Raises:
         ServerFailed: if server failed to reset storage
+
     """
     daos_srv_bin = get_file_path("bin/daos_server")
     cmd = "sudo {} storage prepare -n --reset -f".format(daos_srv_bin[0])


### PR DESCRIPTION
CI functional testing will now use an active ib0 device for test
execution instead of the eth0 device if it is available on the launch
node.

The OFI_INTERFACE environment variable default value will now be set by
launch.py using the list of active devices on the launch node.  The code
that defines the daos_server yaml configuration file will use the
OFI_INTERFACE setting as the default 'fabric_iface' entry.  The ability
to specify a specific interface through the test yaml file is still
retained, as well as the ability to export an OFI_INTERFACE value to
launch.py to override the default.

Signed-off-by: Phillip Henderson <phillip.henderson@intel.com>