### PR TITLE
DAOS-623 build: Update CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,6 @@
+# have release-engineering added as a reviewer to any PR that updates
+# a component sha1
+utils/build.config @daos-stack/release-engineering
+
+# any PR that touches Go files should get a review from go-owners
+*.go @daos-stack/go-owners

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,3 +1,0 @@
-# have release-engineering added as a reviewer to any PR that updates
-# a component sha1
-utils/build.config @release-engineering


### PR DESCRIPTION
Move it under .github/ and add the go-owners team. Also fixes
the release-engineering name.