### PR TITLE
DAOS-3422 vos: Aggregation of object, key, and incarnation log

### DIFF
--- a/src/include/daos_srv/vos.h
+++ b/src/include/daos_srv/vos.h
@@ -793,6 +793,20 @@ int
 vos_iter_delete(daos_handle_t ih, void *args);
 
 /**
+ * Aggregate the incarnation log for the iterator entry. Only applicable
+ * to VOS_ITER_OBJ, VOS_ITER_DKEY, and VOS_ITER_AKEY
+ *
+ * \param ih		[IN]	Iterator handle
+ * \param discard	[IN]	Discard all entries
+ *
+ * \return		Zero on Success
+ *			-DER_NONEXIST if cursor does
+ *			not exist. negative value if error
+ */
+int
+vos_iter_aggregate(daos_handle_t ih, bool discard);
+
+/**
  * If the iterator has any element. The condition provided to vos_iter_prepare
  * will not be taken into account, so even if there is no element can match
  * the iterator condition, but the function still returns false if there is

--- a/src/include/daos_srv/vos_types.h
+++ b/src/include/daos_srv/vos_types.h
@@ -232,22 +232,24 @@ typedef struct {
 		/** Returned entry for container UUID iterator */
 		uuid_t				ie_couuid;
 		struct {
-			/** dkey or akey */
-			daos_key_t		ie_key;
 			/** Non-zero if punched */
-			daos_epoch_t		ie_key_punch;
-		};
-		struct {
-			/** The DTX identifier. */
-			struct dtx_id		ie_xid;
-			/** oid */
-			daos_unit_oid_t		ie_oid;
-			/** Non-zero if punched */
-			daos_epoch_t		ie_obj_punch;
-			/* The DTX dkey hash for DTX iteration. */
-			uint64_t		ie_dtx_hash;
-			/* The DTX intent for DTX iteration. */
-			uint32_t		ie_dtx_intent;
+			daos_epoch_t		ie_punch;
+			union {
+				struct {
+					/** dkey or akey */
+					daos_key_t		ie_key;
+				};
+				struct {
+					/** The DTX identifier. */
+					struct dtx_id		ie_xid;
+					/** oid */
+					daos_unit_oid_t		ie_oid;
+					/* The dkey hash for DTX iteration. */
+					uint64_t		ie_dtx_hash;
+					/* The DTX intent for DTX iteration. */
+					uint32_t		ie_dtx_intent;
+				};
+			};
 		};
 		struct {
 			/** record size */

--- a/src/iosrv/vos.c
+++ b/src/iosrv/vos.c
@@ -150,15 +150,15 @@ fill_key(daos_handle_t ih, vos_iter_entry_t *key_ent, struct dss_enum_arg *arg,
 	D_ASSERT(vos_type == VOS_ITER_DKEY || vos_type == VOS_ITER_AKEY);
 
 	total_size = key_ent->ie_key.iov_len;
-	if (key_ent->ie_key_punch)
-		total_size += sizeof(key_ent->ie_key_punch);
+	if (key_ent->ie_punch)
+		total_size += sizeof(key_ent->ie_punch);
 
 	type = vos_iter_type_2pack_type(vos_type);
 	/* for tweaking kds_len in fill_rec() */
 	arg->last_type = type;
 
 	/* Check if sgl or kds is full */
-	if (arg->need_punch && key_ent->ie_key_punch != 0)
+	if (arg->need_punch && key_ent->ie_punch != 0)
 		kds_cap = arg->kds_cap - 1; /* one extra kds for punch eph */
 	else
 		kds_cap = arg->kds_cap;
@@ -193,8 +193,8 @@ fill_key(daos_handle_t ih, vos_iter_entry_t *key_ent, struct dss_enum_arg *arg,
 
 	iov->iov_len += key_ent->ie_key.iov_len;
 
-	if (key_ent->ie_key_punch != 0 && arg->need_punch) {
-		int pi_size = sizeof(key_ent->ie_key_punch);
+	if (key_ent->ie_punch != 0 && arg->need_punch) {
+		int pi_size = sizeof(key_ent->ie_punch);
 
 		arg->kds[arg->kds_len].kd_key_len = pi_size;
 		arg->kds[arg->kds_len].kd_csum_len = 0;
@@ -207,7 +207,7 @@ fill_key(daos_handle_t ih, vos_iter_entry_t *key_ent, struct dss_enum_arg *arg,
 		arg->kds_len++;
 
 		D_ASSERT(iov->iov_len + pi_size < iov->iov_buf_len);
-		memcpy(iov->iov_buf + iov->iov_len, &key_ent->ie_key_punch,
+		memcpy(iov->iov_buf + iov->iov_len, &key_ent->ie_punch,
 		       pi_size);
 
 		iov->iov_len += pi_size;
@@ -216,7 +216,7 @@ fill_key(daos_handle_t ih, vos_iter_entry_t *key_ent, struct dss_enum_arg *arg,
 	D_DEBUG(DB_IO, "Pack key "DF_KEY" iov total %zd kds len %d eph "
 		DF_U64" punched eph num "DF_U64"\n", DP_KEY(&key_ent->ie_key),
 		iov->iov_len, arg->kds_len - 1, key_ent->ie_epoch,
-		key_ent->ie_key_punch);
+		key_ent->ie_punch);
 	return 0;
 }
 

--- a/src/vos/ilog.h
+++ b/src/vos/ilog.h
@@ -165,16 +165,24 @@ int
 ilog_abort(daos_handle_t loh, const struct ilog_id *id);
 
 /**
- * Remove entries in the epoch range leaving only the latest update
+ * Cleanup the incarnation log
  *
- *  \param	loh[in]		Open log handle
- *  \param	epr[in]		Epoch range to scan
+ *  \param	umm[in]		The umem instance
+ *  \param	root_off[in]	Offset to ilog root
+ *  \param	cbs[in]		Incarnation log transaction log callbacks
+ *  \param	epr[in]		Epoch range for cleanup
+ *  \param	discard[in]	Normally, aggregate will only remove entries
+ *				that are provably not needed.  If discard is
+ *				set, it will remove everything in the epoch
+ *				range.
  *
  *  \return 0 on success, error code on failure, 1 if the log is empty after
  *  completion.
  */
 int
-ilog_aggregate(daos_handle_t loh, const daos_epoch_range_t *epr);
+ilog_aggregate(struct umem_instance *umm, umem_off_t root_off,
+	       const struct ilog_desc_cbs *cbs, const daos_epoch_range_t *epr,
+	       bool discard);
 
 /** Incarnation log entry description */
 struct ilog_entry {

--- a/src/vos/tests/vts_ilog.c
+++ b/src/vos/tests/vts_ilog.c
@@ -788,6 +788,7 @@ ilog_test_aggregate(void **state)
 	struct vos_pool		*pool;
 	struct umem_instance	*umm;
 	struct ilog_df		*ilog;
+	umem_off_t		 ilog_off;
 	struct entries		*entries = args->custom;
 	struct ilog_id		 id;
 	daos_epoch_range_t	 epr = {0, DAOS_EPOCH_MAX};
@@ -800,6 +801,7 @@ ilog_test_aggregate(void **state)
 	umm = vos_pool2umm(pool);
 
 	ilog = ilog_alloc_root(umm);
+	ilog_off = umem_ptr2off(umm, ilog);
 
 	rc = ilog_create(umm, ilog);
 	if (rc != 0) {
@@ -847,7 +849,7 @@ ilog_test_aggregate(void **state)
 
 	epr.epr_lo = 2;
 	epr.epr_hi = 4;
-	rc = ilog_aggregate(loh, &epr);
+	rc = ilog_aggregate(umm, ilog_off, &ilog_callbacks, &epr, false);
 	if (rc != 0) {
 		print_message("Failed to aggregate log entry: "DF_RC"\n",
 			      DP_RC(rc));
@@ -875,7 +877,7 @@ ilog_test_aggregate(void **state)
 
 	epr.epr_lo = 0;
 	epr.epr_hi = 6;
-	rc = ilog_aggregate(loh, &epr);
+	rc = ilog_aggregate(umm, ilog_off, &ilog_callbacks, &epr, false);
 	if (rc != 0) {
 		print_message("Failed to aggregate log entry: "DF_RC"\n",
 			      DP_RC(rc));
@@ -894,7 +896,7 @@ ilog_test_aggregate(void **state)
 	}
 
 	epr.epr_hi = 7;
-	rc = ilog_aggregate(loh, &epr);
+	rc = ilog_aggregate(umm, ilog_off, &ilog_callbacks, &epr, false);
 	if (rc != 1) { /* 1 means empty */
 		print_message("Failed to aggregate log entry: "DF_RC"\n",
 			      DP_RC(rc));

--- a/src/vos/tests/vts_pm.c
+++ b/src/vos/tests/vts_pm.c
@@ -112,12 +112,12 @@ count_cb(daos_handle_t ih, vos_iter_entry_t *entry, vos_iter_type_t type,
 		break;
 	case VOS_ITER_DKEY:
 		counts->num_dkeys++;
-		if (entry->ie_key_punch)
+		if (entry->ie_punch)
 			counts->num_punched_dkeys++;
 		break;
 	case VOS_ITER_AKEY:
 		counts->num_akeys++;
-		if (entry->ie_key_punch)
+		if (entry->ie_punch)
 			counts->num_punched_akeys++;
 		break;
 	case VOS_ITER_RECX:
@@ -127,7 +127,7 @@ count_cb(daos_handle_t ih, vos_iter_entry_t *entry, vos_iter_type_t type,
 		break;
 	case VOS_ITER_OBJ:
 		counts->num_objs++;
-		if (entry->ie_obj_punch)
+		if (entry->ie_punch)
 			counts->num_punched_objs++;
 		break;
 	}

--- a/src/vos/vos_ilog.c
+++ b/src/vos/vos_ilog.c
@@ -318,6 +318,29 @@ update:
 	return rc;
 }
 
+int
+vos_ilog_aggregate(daos_handle_t coh, struct ilog_df *ilog,
+		   const daos_epoch_range_t *epr,
+		   struct vos_ilog_info *info, bool discard)
+{
+#if 0
+	struct vos_container	*cont = vos_hdl2cont(coh);
+	struct umem_instance	*umm = vos_cont2umm(cont);
+	struct ilog_desc_cbs	 cbs;
+	int			 rc;
+
+	vos_ilog_desc_cbs_init(&cbs, coh);
+	rc = ilog_aggregate(umm, ilog_off, &cbs, epr, discard);
+
+	if (rc == 1) /* Ignore empty ilog for now. */
+		return 0;
+
+	return rc;
+#else
+	return 0;
+#endif
+}
+
 void
 vos_ilog_fetch_init(struct vos_ilog_info *info)
 {

--- a/src/vos/vos_ilog.h
+++ b/src/vos/vos_ilog.h
@@ -133,6 +133,22 @@ vos_ilog_check_(struct vos_ilog_info *info, const daos_epoch_range_t *epr_in,
 void
 vos_ilog_desc_cbs_init(struct ilog_desc_cbs *cbs, daos_handle_t coh);
 
+/** Aggregate (or discard) the incarnation log in the specified range
+ *
+ * \param	coh[IN]		container handle
+ * \param	ilog[IN]	Incarnation log
+ * \param	epr[IN]		Aggregation range
+ * \param	info[IN]	Incarnation log info
+ * \param	discard[IN]	Discard all entries in range
+ *
+ * \return	0	Success
+ *		error	Failure
+ */
+int
+vos_ilog_aggregate(daos_handle_t coh, struct ilog_df *ilog,
+		   const daos_epoch_range_t *epr, struct vos_ilog_info *info,
+		   bool discard);
+
 #ifdef ILOG_TRACE
 #undef vos_ilog_fetch
 #undef vos_ilog_update

--- a/src/vos/vos_internal.h
+++ b/src/vos/vos_internal.h
@@ -878,6 +878,8 @@ struct vos_iter_ops {
 	/** Delete the record that the cursor points to */
 	int	(*iop_delete)(struct vos_iterator *iter,
 			      void *args);
+	/** Aggregate the current entry */
+	int	(*iop_aggregate)(struct vos_iterator *iter, bool discard);
 	/**
 	 * Optional, the iterator has no element.
 	 *

--- a/src/vos/vos_iterator.c
+++ b/src/vos/vos_iterator.c
@@ -359,6 +359,23 @@ vos_iter_copy(daos_handle_t ih, vos_iter_entry_t *it_entry,
 }
 
 int
+vos_iter_aggregate(daos_handle_t ih, bool discard)
+{
+	struct vos_iterator *iter = vos_hdl2iter(ih);
+	int rc;
+
+	rc = iter_verify_state(iter);
+	if (rc)
+		return rc;
+
+	D_ASSERT(iter->it_ops != NULL);
+	if (iter->it_ops->iop_aggregate == NULL)
+		return -DER_NOSYS;
+
+	return iter->it_ops->iop_aggregate(iter, discard);
+}
+
+int
 vos_iter_delete(daos_handle_t ih, void *args)
 {
 	struct vos_iterator *iter = vos_hdl2iter(ih);


### PR DESCRIPTION
This is a TEST of code review team assignment...not ready for review

VOS aggregation is updated to aggregate empty keys and objects
as well as collapsing the incarnation logs.

Signed-off-by: Jeff Olivier <jeffrey.v.olivier@intel.com>