### PR TITLE
DAOS-3863: Fix launch.py /usr/sbin env setup.

### DIFF
--- a/src/tests/ftest/launch.py
+++ b/src/tests/ftest/launch.py
@@ -125,7 +125,7 @@ def set_test_environment():
     # /usr/sbin is not setup on non-root user for CI nodes.
     # SCM formatting tool mkfs.ext4 is located under
     # /usr/sbin directory.
-    usr_sbin = os.path.join("/usr/", "sbin")
+    usr_sbin = os.path.sep + os.path.join("usr", "sbin")
     path = os.environ.get("PATH")
 
     # Update env definitions


### PR DESCRIPTION
Signed-off-by: Padmanabhan <ravindran.padmanabhan@intel.com>