### PR TITLE
DAOS-3677 errno: Allow gurt/errno.h to be included before daos_errno.h

### DIFF
--- a/src/include/daos_errno.h
+++ b/src/include/daos_errno.h
@@ -31,6 +31,14 @@
 extern "C" {
 #endif
 
+#ifdef __GURT_ERRNO_H__
+#ifdef DAOS_VERSION
+#error "daos_errno.h included after gurt/errno.h"
+#endif
+/* Detects when a 3rd party user includes gurt/errno.h first */
+#define DAOS_USE_GURT_ERRNO
+#endif
+
 #define D_ERRNO_V2
 #include <gurt/errno.h>
 
@@ -86,8 +94,22 @@ extern "C" {
 	/** Record size error */					\
 	ACTION(DER_REC_SIZE,		(DER_ERR_DAOS_BASE + 24))
 
+#ifdef DAOS_USE_GURT_ERRNO
+	/* When new errno's added above, we need to define them here
+	 * as well numerically.   For instance, if we add a new one named
+	 * DER_FOO, we would put this here:
+	 *
+	 * #define DER_FOO (DER_ERR_DAOS_BASE + 25)
+	 *
+	 * This isn't strictly necessary as it's only needed for external
+	 * support if they reference an errno directly by name.  If they
+	 * use d_errstr(errno), they will get the correct string in such
+	 * cases.
+	 */
+#else
 /** Define the DAOS error numbers */
 D_DEFINE_RANGE_ERRNO(DAOS, 2000)
+#endif
 
 /** Register the DAOS error codes with gurt */
 int


### PR DESCRIPTION
For external libraries that use daos, we must allow gurt/errno.h to be
included before daos_errno.h.   This enables that without changing cart.

Signed-off-by: Jeff Olivier <jeffrey.v.olivier@intel.com>