### PR TITLE
DAOS-3872 object: fix segfault in tse in size query

### DIFF
--- a/src/object/cli_obj.c
+++ b/src/object/cli_obj.c
@@ -1781,12 +1781,11 @@ obj_shard_task_sched(struct obj_auxi_args *obj_auxi, uint64_t epoch)
 	obj_auxi->shard_task_scheded = 0;
 	tse_task_list_traverse(&obj_auxi->shard_task_head, shard_task_sched,
 			       &epoch);
-	/* It is possible that the IO retried by stale pm version found, but
-	 * the IO involved shards' targets not changed. No any shard task
-	 * re-scheduled for this case, can complete the obj IO task.
-	 */
-	if (obj_auxi->shard_task_scheded == 0 && obj_auxi->obj_task)
+	sleep(1);
+	if (obj_auxi->shard_task_scheded == 0) {
+		D_ASSERT(obj_auxi->obj_task);
 		tse_task_complete(obj_auxi->obj_task, 0);
+	}
 }
 
 static struct shard_auxi_args *

--- a/src/object/cli_obj.c
+++ b/src/object/cli_obj.c
@@ -1785,7 +1785,7 @@ obj_shard_task_sched(struct obj_auxi_args *obj_auxi, uint64_t epoch)
 	 * the IO involved shards' targets not changed. No any shard task
 	 * re-scheduled for this case, can complete the obj IO task.
 	 */
-	if (obj_auxi->shard_task_scheded == 0)
+	if (obj_auxi->shard_task_scheded == 0 && obj_auxi->obj_task)
 		tse_task_complete(obj_auxi->obj_task, 0);
 }
 


### PR DESCRIPTION
When doing size query in DFS, we are hitting a segfault when oclass is S1.
happened with multithreaded test with -F

Signed-off-by: Mohamad Chaarawi <mohamad.chaarawi@intel.com>