### PR TITLE
DAOS-3823 utils: add version sub-cmd to daos cmd

### DIFF
--- a/src/utils/daos.c
+++ b/src/utils/daos.c
@@ -802,6 +802,7 @@ help_hdlr(struct cmd_args_s *ap)
 "resources:\n"
 "	  pool             pool\n"
 "	  container (cont) container\n"
+"	  version          print command version\n"
 "	  help             print this message and exit\n");
 
 	fprintf(stream, "\n"
@@ -909,9 +910,13 @@ main(int argc, char *argv[])
 	command_hdlr_t		hdlr = NULL;
 	struct cmd_args_s	dargs = {0};
 
-	/* argv[1] is RESOURCE or "help";
+	/* argv[1] is RESOURCE or "help" or "version";
 	 * argv[2] if provided is a resource-specific command
 	 */
+	if (argc <= 2 || strcmp(argv[1], "version") == 0) {
+		fprintf(stdout, "daos version %s\n", DAOS_VERSION);
+		return 0;
+	}
 	if (argc <= 2 || strcmp(argv[1], "help") == 0)
 		hdlr = help_hdlr;
 	else if ((strcmp(argv[1], "container") == 0) ||

--- a/src/utils/daos.c
+++ b/src/utils/daos.c
@@ -913,13 +913,12 @@ main(int argc, char *argv[])
 	/* argv[1] is RESOURCE or "help" or "version";
 	 * argv[2] if provided is a resource-specific command
 	 */
-	if (argc <= 2 || strcmp(argv[1], "version") == 0) {
+	if (argc < 2 || strcmp(argv[1], "help") == 0)
+		hdlr = help_hdlr;
+	else if (strcmp(argv[1], "version") == 0) {
 		fprintf(stdout, "daos version %s\n", DAOS_VERSION);
 		return 0;
-	}
-	if (argc <= 2 || strcmp(argv[1], "help") == 0)
-		hdlr = help_hdlr;
-	else if ((strcmp(argv[1], "container") == 0) ||
+	} else if ((strcmp(argv[1], "container") == 0) ||
 		 (strcmp(argv[1], "cont") == 0))
 		hdlr = cont_op_hdlr;
 	else if (strcmp(argv[1], "pool") == 0)


### PR DESCRIPTION
Add version sub-command to display version of daos
command. This complies to the behaviour of others
commands like dmg/daos_server/daos_agent/daos_admin.

Change-Id: Id597ee970767d3659cb90c60f4a6e815023e7858
Signed-off-by: Bruno Faccini <bruno.faccini@intel.com>