### PR TITLE
DAOS-3875 pool: add cart swim event callback for pool

### DIFF
--- a/src/include/daos_srv/pool.h
+++ b/src/include/daos_srv/pool.h
@@ -202,5 +202,9 @@ int ds_pool_get_failed_tgt_idx(const uuid_t pool_uuid, int **failed_tgts,
 int ds_pool_svc_list_cont(uuid_t uuid, d_rank_list_t *ranks,
 			  struct daos_pool_cont_info **containers,
 			  uint64_t *ncontainers);
+void
+ds_pool_disable_evict(void);
+void
+ds_pool_enable_evict(void);
 
 #endif /* __DAOS_SRV_POOL_H__ */

--- a/src/include/daos_srv/rsvc.h
+++ b/src/include/daos_srv/rsvc.h
@@ -166,6 +166,7 @@ int ds_rsvc_lookup(enum ds_rsvc_class_id class, d_iov_t *id,
 		   struct ds_rsvc **svc);
 int ds_rsvc_lookup_leader(enum ds_rsvc_class_id class, d_iov_t *id,
 			  struct ds_rsvc **svcp, struct rsvc_hint *hint);
+void ds_rsvc_get(struct ds_rsvc *svc);
 void ds_rsvc_put(struct ds_rsvc *svc);
 void ds_rsvc_put_leader(struct ds_rsvc *svc);
 void ds_rsvc_set_hint(struct ds_rsvc *svc, struct rsvc_hint *hint);

--- a/src/mgmt/srv_drpc.c
+++ b/src/mgmt/srv_drpc.c
@@ -75,6 +75,10 @@ ds_mgmt_drpc_prep_shutdown(Drpc__Call *drpc_req, Drpc__Response *drpc_resp)
 
 	D_INFO("Received request to prep shutdown %u\n", req->rank);
 
+#ifndef DRPC_TEST
+	ds_pool_disable_evict();
+#endif
+
 	/* TODO: disable auto evict and pool rebuild here */
 	D_INFO("Service rank %d is being prepared for controlled shutdown\n",
 		req->rank);

--- a/src/mgmt/tests/SConscript
+++ b/src/mgmt/tests/SConscript
@@ -9,6 +9,7 @@ def scons():
 
     mocks = denv.Object("mocks.c")
 
+    denv.Append(CPPDEFINES={'DRPC_TEST' : '1'})
     # Isolated unit tests
     daos_build.test(denv, 'srv_drpc_tests',
                     source=[pb, mocks, 'srv_drpc_tests.c', '../srv_drpc.c'],

--- a/src/pool/srv_internal.h
+++ b/src/pool/srv_internal.h
@@ -104,6 +104,7 @@ void ds_pool_attr_list_handler(crt_rpc_t *rpc);
 void ds_pool_attr_get_handler(crt_rpc_t *rpc);
 void ds_pool_attr_set_handler(crt_rpc_t *rpc);
 void ds_pool_list_cont_handler(crt_rpc_t *rpc);
+int ds_pool_evict_rank(uuid_t pool_uuid, d_rank_t rank);
 
 /*
  * srv_target.c

--- a/src/rsvc/srv.c
+++ b/src/rsvc/srv.c
@@ -170,7 +170,7 @@ fini_free(struct ds_rsvc *svc)
 	rsvc_class(svc->s_class)->sc_free(svc);
 }
 
-static void
+void
 ds_rsvc_get(struct ds_rsvc *svc)
 {
 	svc->s_ref++;

--- a/src/tests/suite/daos_rebuild.c
+++ b/src/tests/suite/daos_rebuild.c
@@ -56,6 +56,7 @@ rebuild_exclude_tgt(test_arg_t **args, int arg_cnt, d_rank_t rank,
 		 * targets on this rank.
 		 **/
 		D_ASSERT(tgt_idx == -1);
+		return;
 	}
 
 	for (i = 0; i < arg_cnt; i++) {


### PR DESCRIPTION
Add cart swim event callback for pool, so each pool
will exclude the rank automatically if swim detect the
node is unreachable.

Update the rebuild test, it does not need to exclude
the target anymore, since killing rank will automatically
exclude the server.

Signed-off-by: Di Wang <di.wang@intel.com>