### PR TITLE
DAOS-2881 control: Fix MS bootstrap issue with multiple servers

### DIFF
--- a/src/control/server/harness.go
+++ b/src/control/server/harness.go
@@ -216,10 +216,14 @@ func (h *IOServerHarness) Start(parent context.Context) error {
 				return err
 			}
 		}
-	}
 
-	if err := h.StartManagementService(ctx); err != nil {
-		return errors.Wrap(err, "failed to start management service")
+		// If this instance is a MS replica, start it before
+		// moving on so that other instances can join.
+		if instance.IsMSReplica() {
+			if err := instance.StartManagementService(); err != nil {
+				return errors.Wrap(err, "failed to start management service")
+			}
+		}
 	}
 
 	// now monitor them


### PR DESCRIPTION
The MS service should be started before moving on to other
instances.