### PR TITLE
DAOS-2881 control: Correct harness startup sequence

### DIFF
--- a/src/control/server/harness.go
+++ b/src/control/server/harness.go
@@ -224,6 +224,10 @@ func (h *IOServerHarness) Start(parent context.Context) error {
 				return errors.Wrap(err, "failed to start management service")
 			}
 		}
+
+		if err := instance.LoadModules(); err != nil {
+			return errors.Wrap(err, "failed to load I/O server modules")
+		}
 	}
 
 	// now monitor them

--- a/src/control/server/instance.go
+++ b/src/control/server/instance.go
@@ -359,7 +359,11 @@ func (srv *IOServerInstance) StartManagementService() error {
 		}
 	}
 
-	// Notify the I/O server that it may set up its server modules now.
+	return nil
+}
+
+// LoadModules initiates the I/O server startup sequence.
+func (srv *IOServerInstance) LoadModules() error {
 	return srv.callSetUp()
 }
 


### PR DESCRIPTION
Commit 8e8aef7 introduced a regression in the instance startup
sequence. Non-MS instances shouldn't need to call
StartManagementService(), so a new method has been added to allow
them to load modules and start up normally.