### PR TITLE
DAOS-3319 bio: bio_monitor takes addresses of packed struct members

### DIFF
--- a/src/bio/bio_monitor.c
+++ b/src/bio/bio_monitor.c
@@ -36,15 +36,6 @@
 /* Used to preallocate buffer to query error log pages from SPDK health info */
 #define NVME_MAX_ERROR_LOG_PAGES	256
 
-/* See DAOS-3319 on this.  We should generally try to avoid reading unaligned
- * variables directly as it results in more than one instruction for each such
- * access.  The instances of these possible unaligned accesses happen with
- * default gcc on Fedora 30.
- */
-#if D_HAS_WARNING(9, "-Waddress-of-packed-member")
-	#pragma GCC diagnostic ignored "-Waddress-of-packed-member"
-#endif
-
 /*
  * Used for getting bio device state, which requires exclusive access from
  * the device owner xstream.
@@ -224,7 +215,8 @@ get_spdk_log_page_completion(struct spdk_bdev_io *bdev_io, bool success,
 	dev_state->bds_read_only_warning = crit_warn;
 	crit_warn = hp->critical_warning.bits.volatile_memory_backup;
 	dev_state->bds_volatile_mem_warning = crit_warn;
-	dev_state->bds_media_errors = hp->media_errors;
+	memcpy(dev_state->bds_media_errors, hp->media_errors,
+	       sizeof(hp->media_errors));
 
 	/* Prep NVMe command to get controller data */
 	cp_sz = sizeof(struct spdk_nvme_ctrlr_data);

--- a/src/include/daos_srv/bio.h
+++ b/src/include/daos_srv/bio.h
@@ -93,7 +93,7 @@ struct bio_blob_hdr {
  */
 struct bio_dev_state {
 	uint64_t	 bds_timestamp;
-	uint64_t	*bds_media_errors; /* supports 128-bit values */
+	uint64_t	 bds_media_errors[2]; /* supports 128-bit values */
 	uint64_t	 bds_error_count; /* error log page */
 	/* I/O error counters */
 	uint32_t	 bds_bio_read_errs;

--- a/src/mgmt/srv_drpc.c
+++ b/src/mgmt/srv_drpc.c
@@ -1218,10 +1218,7 @@ ds_mgmt_drpc_bio_health_query(Drpc__Call *drpc_req, Drpc__Response *drpc_resp)
 	bds = bio_health->mb_dev_state;
 	resp->error_count = bds.bds_error_count;
 	resp->temperature = bds.bds_temperature;
-	if (bds.bds_media_errors)
-		resp->media_errors = bds.bds_media_errors[0];
-	else
-		resp->media_errors = 0;
+	resp->media_errors = bds.bds_media_errors[0];
 	resp->read_errs = bds.bds_bio_read_errs;
 	resp->write_errs = bds.bds_bio_write_errs;
 	resp->unmap_errs = bds.bds_bio_unmap_errs;


### PR DESCRIPTION
Re-enabled Fedora 30 compiler warning for unaligned accesses.
Issue stemmed from taking address of media_errors in packed
struct bio_dev_state{}

Signed-off-by: Sydney Vanda <sydney.m.vanda@intel.com>