### PR TITLE
DAOS-3816 cont: missing dc_cont_put

### DIFF
--- a/src/container/cli.c
+++ b/src/container/cli.c
@@ -2105,10 +2105,15 @@ struct daos_csummer *
 dc_cont_hdl2csummer(daos_handle_t coh)
 {
 	struct dc_cont	*dc;
+	struct daos_csummer *csum;
 
 	dc = dc_hdl2cont(coh);
 	if (dc == NULL)
 		return NULL;
 
-	return dc->dc_csummer;
+	csum = dc->dc_csummer;
+	dc_cont_put(dc);
+
+	return csum;
+
 }


### PR DESCRIPTION
Missing dc_cont_put in dc_cont_hdl2csummer.

Signed-off-by: Di Wang <di.wang@intel.com>