### PR TITLE
DAOS-3887 control: make port and access point defaults consistent

### DIFF
--- a/src/control/client/config.go
+++ b/src/control/client/config.go
@@ -42,7 +42,7 @@ const (
 	defaultLogFile    = "/tmp/daos_agent.log"
 	defaultConfigPath = "etc/daos.yml"
 	defaultSystemName = "daos_server"
-	defaultPort       = 10000
+	defaultPort       = 10001
 )
 
 // External interface provides methods to support various os operations.
@@ -84,9 +84,9 @@ type Configuration struct {
 func newDefaultConfiguration(ext External) *Configuration {
 	return &Configuration{
 		SystemName:      defaultSystemName,
-		AccessPoints:    []string{"localhost"},
+		AccessPoints:    []string{"localhost:" + defaultPort},
 		Port:            defaultPort,
-		HostList:        []string{"localhost:10001"},
+		HostList:        []string{"localhost:" + defaultPort},
 		RuntimeDir:      defaultRuntimeDir,
 		LogFile:         defaultLogFile,
 		Path:            defaultConfigPath,

--- a/src/control/client/config.go
+++ b/src/control/client/config.go
@@ -24,6 +24,7 @@
 package client
 
 import (
+	"fmt"
 	"io/ioutil"
 	"os"
 	"os/exec"
@@ -84,9 +85,9 @@ type Configuration struct {
 func newDefaultConfiguration(ext External) *Configuration {
 	return &Configuration{
 		SystemName:      defaultSystemName,
-		AccessPoints:    []string{"localhost:" + defaultPort},
+		AccessPoints:    []string{fmt.Sprintf("localhost:%d", defaultPort)},
 		Port:            defaultPort,
-		HostList:        []string{"localhost:" + defaultPort},
+		HostList:        []string{fmt.Sprintf("localhost:%d", defaultPort)},
 		RuntimeDir:      defaultRuntimeDir,
 		LogFile:         defaultLogFile,
 		Path:            defaultConfigPath,

--- a/src/control/server/config.go
+++ b/src/control/server/config.go
@@ -43,7 +43,7 @@ const (
 	defaultRuntimeDir        = "/var/run/daos_server"
 	defaultConfigPath        = "etc/daos_server.yml"
 	defaultSystemName        = "daos_server"
-	defaultPort              = 10000
+	defaultPort              = 10001
 	configOut                = ".daos_server.active.yml"
 	relConfExamplesPath      = "utils/config/examples/"
 	msgBadConfig             = "insufficient config file, see examples in "
@@ -306,7 +306,7 @@ func newDefaultConfiguration(ext External) *Configuration {
 	return &Configuration{
 		SystemName:         defaultSystemName,
 		SocketDir:          defaultRuntimeDir,
-		AccessPoints:       []string{"localhost"},
+		AccessPoints:       []string{"localhost:" + defaultPort},
 		ControlPort:        defaultPort,
 		TransportConfig:    security.DefaultServerTransportConfig(),
 		Hyperthreads:       false,

--- a/src/control/server/config.go
+++ b/src/control/server/config.go
@@ -24,6 +24,7 @@
 package server
 
 import (
+	"fmt"
 	"hash/fnv"
 	"io/ioutil"
 	"os"
@@ -306,7 +307,7 @@ func newDefaultConfiguration(ext External) *Configuration {
 	return &Configuration{
 		SystemName:         defaultSystemName,
 		SocketDir:          defaultRuntimeDir,
-		AccessPoints:       []string{"localhost:" + defaultPort},
+		AccessPoints:       []string{fmt.Sprintf("localhost:%d", defaultPort)},
 		ControlPort:        defaultPort,
 		TransportConfig:    security.DefaultServerTransportConfig(),
 		Hyperthreads:       false,


### PR DESCRIPTION
Server side port assignments should have a consistent default 10001
value everywhere they are referenced.

Signed-off-by: Tom Nabarro <tom.nabarro@intel.com>