### PR TITLE
DAOS-3882 object: Use server-side HLC as modification epoch

### DIFF
--- a/src/object/srv_obj.c
+++ b/src/object/srv_obj.c
@@ -1212,11 +1212,7 @@ ds_obj_rw_handler(crt_rpc_t *rpc)
 
 	/* FIXME: until distributed transaction. */
 	if (orw->orw_epoch == DAOS_EPOCH_MAX) {
-		if (daos_is_zero_dti(&orw->orw_dti) ||
-		    orw->orw_flags & ORF_RESEND)
-			orw->orw_epoch = crt_hlc_get();
-		else
-			orw->orw_epoch = orw->orw_dti.dti_hlc;
+		orw->orw_epoch = crt_hlc_get();
 		D_DEBUG(DB_IO, "overwrite epoch "DF_U64"\n", orw->orw_epoch);
 	}
 
@@ -1814,11 +1810,7 @@ ds_obj_punch_handler(crt_rpc_t *rpc)
 
 	/* FIXME: until distributed transaction. */
 	if (opi->opi_epoch == DAOS_EPOCH_MAX) {
-		if (daos_is_zero_dti(&opi->opi_dti) ||
-		    opi->opi_flags & ORF_RESEND)
-			opi->opi_epoch = crt_hlc_get();
-		else
-			opi->opi_epoch = opi->opi_dti.dti_hlc;
+		opi->opi_epoch = crt_hlc_get();
 		D_DEBUG(DB_IO, "overwrite epoch "DF_U64"\n", opi->opi_epoch);
 	}
 


### PR DESCRIPTION
Currently, we do not have efficient way to guarantee the uniqueness
of client-side HLC among multiple processes of client nodes. If we
use client-side HLC as related modification epoch, then different
modifications may use the same epoch, that will cause fake overlap
in the evtree. So now, we have to use server-side (DTX leader) HLC
as the modification epoch until we have some better solution (that
is necessary for distributed transaction in the future).

Signed-off-by: Fan Yong <fan.yong@intel.com>