### PR TITLE
DAOS-3865 rebuild: add co_pre_forward callback for REBUILD_OBJECTS_SCAN

### DIFF
--- a/src/rebuild/rebuild_internal.h
+++ b/src/rebuild/rebuild_internal.h
@@ -299,6 +299,7 @@ void rebuild_obj_handler(crt_rpc_t *rpc);
 void rebuild_tgt_scan_handler(crt_rpc_t *rpc);
 int rebuild_tgt_scan_aggregator(crt_rpc_t *source, crt_rpc_t *result,
 				void *priv);
+int rebuild_tgt_scan_pre_forward(crt_rpc_t *rpc, void *arg);
 int rebuild_tgt_scan_post_reply(crt_rpc_t *rpc, void *arg);
 
 int rebuild_iv_fetch(void *ns, struct rebuild_iv *rebuild_iv);

--- a/src/tests/suite/daos_epoch_io.c
+++ b/src/tests/suite/daos_epoch_io.c
@@ -1364,7 +1364,8 @@ cmd_line_run(test_arg_t *arg, struct test_op_record *op_rec)
 	D_ASSERT(lvl == TEST_LVL_DAOS || lvl == TEST_LVL_VOS);
 
 	/* for modification OP, just go through DAOS stack and return */
-	if (test_op_is_modify(op) || op == TEST_OP_POOL_QUERY)
+	if (test_op_is_modify(op) || op == TEST_OP_POOL_QUERY ||
+	    op == TEST_OP_ADD || op == TEST_OP_EXCLUDE)
 		return op_dict[op].op_cb[lvl](arg, op_rec, NULL, 0);
 
 	/* for verification OP, firstly retrieve it through DAOS stack */


### PR DESCRIPTION
Add rebuild_tgt_scan_pre_forward() callback to update group version
ahead. Although the new pool map can be propagated by IV (and then
update the pool's group version), but the SCAN request possibly arrive
ahead, in that case will cause the -DER_GRPVER returned and retry until
IV propagated to this node.
Adding the co_pre_forward for SCAN RPC can avoid that unnecessary retry.

Signed-off-by: Xuezhao Liu <xuezhao.liu@intel.com>