### PR TITLE
DAOS-3896 gRPC: Restrict TLS cipher suites allowed for gRPC

### DIFF
--- a/src/control/security/grpc_certs.go
+++ b/src/control/security/grpc_certs.go
@@ -44,9 +44,16 @@ func GetServerTransportCredentials(cfg *TransportConfig) (credentials.TransportC
 	}
 
 	tlsConfig := tls.Config{
-		ClientAuth:   tls.RequireAndVerifyClientCert,
-		Certificates: []tls.Certificate{*cfg.tlsKeypair},
-		ClientCAs:    cfg.caPool,
+		ClientAuth:               tls.RequireAndVerifyClientCert,
+		Certificates:             []tls.Certificate{*cfg.tlsKeypair},
+		ClientCAs:                cfg.caPool,
+		MinVersion:               tls.VersionTLS12,
+		MaxVersion:               tls.VersionTLS12,
+		PreferServerCipherSuites: true,
+		CipherSuites: []uint16{
+			tls.TLS_RSA_WITH_AES_128_GCM_SHA256,
+			tls.TLS_RSA_WITH_AES_256_GCM_SHA384,
+		},
 	}
 	creds := credentials.NewTLS(&tlsConfig)
 	return creds, nil
@@ -65,9 +72,16 @@ func GetClientTransportCredentials(cfg *TransportConfig) (credentials.TransportC
 	}
 
 	tlsConfig := tls.Config{
-		ServerName:   cfg.ServerName,
-		Certificates: []tls.Certificate{*cfg.tlsKeypair},
-		RootCAs:      cfg.caPool,
+		ServerName:               cfg.ServerName,
+		Certificates:             []tls.Certificate{*cfg.tlsKeypair},
+		RootCAs:                  cfg.caPool,
+		MinVersion:               tls.VersionTLS12,
+		MaxVersion:               tls.VersionTLS12,
+		PreferServerCipherSuites: true,
+		CipherSuites: []uint16{
+			tls.TLS_RSA_WITH_AES_128_GCM_SHA256,
+			tls.TLS_RSA_WITH_AES_256_GCM_SHA384,
+		},
 	}
 	creds := credentials.NewTLS(&tlsConfig)
 	return creds, nil


### PR DESCRIPTION
Harden the TLS support for gRPC channels by restricting the TLS version to 1.2
and the acceptable cipher suites to the ones reported below. By pinning the 
TLS version and cipher suites we prevent downgrade attacks.

Starting Nmap 6.40 ( http://nmap.org ) at 2019-12-13 00:47 MST
Nmap scan report for localhost (127.0.0.1)
Host is up (0.000051s latency).
PORT      STATE SERVICE
10001/tcp open  scp-config
| ssl-enum-ciphers:
|   TLSv1.2:
|     ciphers:
|       TLS_RSA_WITH_AES_128_GCM_SHA256 - strong
|       TLS_RSA_WITH_AES_256_GCM_SHA384 - strong
|     compressors:
|       NULL
|_  least strength: strong

Signed-off-by: David Quigley <david.quigley@intel.com>