### PR TITLE
DAOS-3881 control: Expand per-ioserver configuration options

### DIFF
--- a/src/bio/bio_xstream.c
+++ b/src/bio/bio_xstream.c
@@ -931,9 +931,6 @@ bio_xsctxt_alloc(struct bio_xs_context **pctxt, int tgt_id)
 				" process mode\n");
 		}
 
-		/* set this to create a single hugepage file */
-		opts.hugepage_single_segments = true;
-
 		rc = spdk_env_init(&opts);
 		if (rc != 0) {
 			D_ERROR("failed to initialize SPDK env, rc:%d\n", rc);

--- a/src/bio/bio_xstream.c
+++ b/src/bio/bio_xstream.c
@@ -931,6 +931,9 @@ bio_xsctxt_alloc(struct bio_xs_context **pctxt, int tgt_id)
 				" process mode\n");
 		}
 
+		/* set this to create a single hugepage file */
+		opts.hugepage_single_segments = true;
+
 		rc = spdk_env_init(&opts);
 		if (rc != 0) {
 			D_ERROR("failed to initialize SPDK env, rc:%d\n", rc);

--- a/src/control/cmd/daos_server/start.go
+++ b/src/control/cmd/daos_server/start.go
@@ -77,9 +77,6 @@ func (cmd *startCmd) setCLIOverrides() error {
 	if err != nil {
 		return err
 	}
-	if cmd.config.NvmeShmID == 0 {
-		cmd.config.SetNvmeShmID(host)
-	}
 
 	for _, srv := range cmd.config.Servers {
 		srv.WithHostname(host)

--- a/src/control/cmd/daos_server/start_test.go
+++ b/src/control/cmd/daos_server/start_test.go
@@ -55,7 +55,6 @@ func testExpectedError(t *testing.T, expected, actual error) {
 func genMinimalConfig() *server.Configuration {
 	cfg := server.NewConfiguration().
 		WithFabricProvider("foo").
-		WithNvmeShmID(-1). // don't generate a ShmID in testing
 		WithProviderValidator(netdetect.ValidateProviderStub).
 		WithNUMAValidator(netdetect.ValidateNUMAStub).
 		WithServers(

--- a/src/control/server/config.go
+++ b/src/control/server/config.go
@@ -64,6 +64,7 @@ type Configuration struct {
 	BdevInclude         []string                  `yaml:"bdev_include,omitempty"`
 	BdevExclude         []string                  `yaml:"bdev_exclude,omitempty"`
 	NrHugepages         int                       `yaml:"nr_hugepages"`
+	SetHugepages        bool                      `yaml:"set_hugepages"`
 	ControlLogMask      ControlLogLevel           `yaml:"control_log_mask"`
 	ControlLogFile      string                    `yaml:"control_log_file"`
 	ControlLogJSON      bool                      `yaml:"control_log_json,omitempty"`

--- a/src/control/server/hugepages.go
+++ b/src/control/server/hugepages.go
@@ -1,0 +1,104 @@
+//
+// (C) Copyright 2019 Intel Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// GOVERNMENT LICENSE RIGHTS-OPEN SOURCE SOFTWARE
+// The Government's rights to use, modify, reproduce, release, perform, display,
+// or disclose this software are subject to the terms of the Apache License as
+// provided in Contract No. 8F-30005.
+// Any reproduction of computer software, computer software documentation, or
+// portions thereof marked with this legend must also reproduce the markings.
+//
+package server
+
+import (
+	"bufio"
+	"io"
+	"os"
+	"strconv"
+	"strings"
+
+	"github.com/pkg/errors"
+)
+
+type hugePageInfo struct {
+	Total      int
+	Free       int
+	Reserved   int
+	Surplus    int
+	PageSizeKb int
+}
+
+func (hpi *hugePageInfo) TotalMB() int {
+	return (hpi.Total * hpi.PageSizeKb) / 1024
+}
+
+func (hpi *hugePageInfo) FreeMB() int {
+	return (hpi.Free * hpi.PageSizeKb) / 1024
+}
+
+func parseInt(a string, i *int) {
+	v, err := strconv.Atoi(strings.TrimSpace(a))
+	if err != nil {
+		return
+	}
+	*i = v
+}
+
+func parseHugePageInfo(input io.Reader) (*hugePageInfo, error) {
+	hpi := new(hugePageInfo)
+
+	scn := bufio.NewScanner(input)
+	for scn.Scan() {
+		keyVal := strings.Split(scn.Text(), ":")
+		if len(keyVal) < 2 {
+			continue
+		}
+
+		switch keyVal[0] {
+		case "HugePages_Total":
+			parseInt(keyVal[1], &hpi.Total)
+		case "HugePages_Free":
+			parseInt(keyVal[1], &hpi.Free)
+		case "HugePages_Rsvd":
+			parseInt(keyVal[1], &hpi.Reserved)
+		case "HugePages_Surp":
+			parseInt(keyVal[1], &hpi.Surplus)
+		case "Hugepagesize":
+			sf := strings.Fields(keyVal[1])
+			if len(sf) != 2 {
+				return nil, errors.Errorf("unable to parse %q", keyVal[1])
+			}
+			// units are always kB afaik -- double-check
+			if sf[1] != "kB" {
+				return nil, errors.Errorf("unhandled page size unit %q", sf[1])
+			}
+			parseInt(sf[0], &hpi.PageSizeKb)
+		default:
+			continue
+		}
+	}
+
+	return hpi, scn.Err()
+}
+
+func getHugePageInfo() (*hugePageInfo, error) {
+	f, err := os.Open("/proc/meminfo")
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+
+	return parseHugePageInfo(f)
+}

--- a/src/control/server/hugepages.go
+++ b/src/control/server/hugepages.go
@@ -80,7 +80,8 @@ func parseHugePageInfo(input io.Reader) (*hugePageInfo, error) {
 			if len(sf) != 2 {
 				return nil, errors.Errorf("unable to parse %q", keyVal[1])
 			}
-			// units are always kB afaik -- double-check
+			// units are hard-coded to kB in the kernel, but doesn't hurt
+			// to double-check...
 			if sf[1] != "kB" {
 				return nil, errors.Errorf("unhandled page size unit %q", sf[1])
 			}

--- a/src/control/server/hugepages_test.go
+++ b/src/control/server/hugepages_test.go
@@ -1,0 +1,117 @@
+//
+// (C) Copyright 2019 Intel Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// GOVERNMENT LICENSE RIGHTS-OPEN SOURCE SOFTWARE
+// The Government's rights to use, modify, reproduce, release, perform, display,
+// or disclose this software are subject to the terms of the Apache License as
+// provided in Contract No. 8F-30005.
+// Any reproduction of computer software, computer software documentation, or
+// portions thereof marked with this legend must also reproduce the markings.
+//
+package server
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/pkg/errors"
+
+	"github.com/daos-stack/daos/src/control/common"
+)
+
+func TestServer_getHugePageInfo(t *testing.T) {
+	// Just a simple test to verify that we get something -- it should
+	// pretty much never error.
+	_, err := getHugePageInfo()
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestServer_parseHugePageInfo(t *testing.T) {
+	for name, tc := range map[string]struct {
+		input     string
+		expOut    *hugePageInfo
+		expFreeMB int
+		expErr    error
+	}{
+		"none parsed": {
+			expOut:    &hugePageInfo{},
+			expFreeMB: 0,
+		},
+		"2MB pagesize": {
+			input: `
+HugePages_Total:    1024
+HugePages_Free:     1023
+HugePages_Rsvd:        0
+HugePages_Surp:        0
+Hugepagesize:       2048 kB
+			`,
+			expOut: &hugePageInfo{
+				Total:      1024,
+				Free:       1023,
+				PageSizeKb: 2048,
+			},
+			expFreeMB: 2046,
+		},
+		"1GB pagesize": {
+			input: `
+HugePages_Total:      16
+HugePages_Free:       16
+HugePages_Rsvd:        0
+HugePages_Surp:        0
+Hugepagesize:       1048576 kB
+			`,
+			expOut: &hugePageInfo{
+				Total:      16,
+				Free:       16,
+				PageSizeKb: 1048576,
+			},
+			expFreeMB: 16384,
+		},
+		"weird pagesize": {
+			input: `
+Hugepagesize:       blerble 1 GB
+			`,
+			expErr: errors.New("unable to parse"),
+		},
+		"weird pagesize unit": {
+			input: `
+Hugepagesize:       1 GB
+			`,
+			expErr: errors.New("unhandled page size"),
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			rdr := strings.NewReader(tc.input)
+
+			gotOut, gotErr := parseHugePageInfo(rdr)
+			common.CmpErr(t, tc.expErr, gotErr)
+			if tc.expErr != nil {
+				return
+			}
+
+			if diff := cmp.Diff(tc.expOut, gotOut); diff != "" {
+				t.Fatalf("unexpected output (-want, +got)\n%s\n", diff)
+			}
+
+			if gotOut.FreeMB() != tc.expFreeMB {
+				t.Fatalf("expected FreeMB() to be %d, got %d",
+					tc.expFreeMB, gotOut.FreeMB())
+			}
+		})
+	}
+}

--- a/src/control/server/server.go
+++ b/src/control/server/server.go
@@ -149,11 +149,15 @@ func Start(log *logging.LeveledLogger, cfg *Configuration) error {
 			break
 		}
 
-		// If we have multiple I/O instances with block devices, then we need to apportion
-		// the hugepage memory among the instances.
-		srvCfg.Storage.Bdev.MemSize = hugePages.FreeMB() / len(cfg.Servers)
-		// reserve a little for daos_admin
-		srvCfg.Storage.Bdev.MemSize -= srvCfg.Storage.Bdev.MemSize / 16
+		// If the configuration specifies that we should explicitly set hugepage values
+		// per instance, do it. Otherwise, let SPDK/DPDK figure it out.
+		if cfg.SetHugepages {
+			// If we have multiple I/O instances with block devices, then we need to apportion
+			// the hugepage memory among the instances.
+			srvCfg.Storage.Bdev.MemSize = hugePages.FreeMB() / len(cfg.Servers)
+			// reserve a little for daos_admin
+			srvCfg.Storage.Bdev.MemSize -= srvCfg.Storage.Bdev.MemSize / 16
+		}
 
 		// Each instance must have a unique shmid in order to run as SPDK primary.
 		// Use a stable identifier that's easy to construct elsewhere if we don't

--- a/src/control/server/server.go
+++ b/src/control/server/server.go
@@ -62,6 +62,10 @@ func cfgHasBdev(cfg *Configuration) bool {
 	return false
 }
 
+func instanceShmID(idx int) int {
+	return os.Getpid() + idx + 1
+}
+
 // define supported maximum number of I/O servers
 const maxIoServers = 2
 
@@ -110,8 +114,29 @@ func Start(log *logging.LeveledLogger, cfg *Configuration) error {
 		TargetUser:    runningUser.Username,
 		PCIWhitelist:  strings.Join(cfg.BdevInclude, ","),
 	}
+	log.Debugf("automatic NVMe prepare req: %+v", prepReq)
 	if _, err := bdevProvider.Prepare(prepReq); err != nil {
 		log.Errorf("automatic NVMe prepare failed (check configuration?)\n%s", err)
+	}
+
+	hugePages, err := getHugePageInfo()
+	if err != nil {
+		return errors.Wrap(err, "unable to read system hugepage info")
+	}
+
+	// Don't bother with these checks if there aren't any block devices configured.
+	if cfgHasBdev(cfg) {
+		if hugePages.Free != hugePages.Total {
+			// Not sure if this should be an error, per se, but I think we want to display it
+			// on the console to let the admin know that there might be something that needs
+			// to be cleaned up?
+			log.Errorf("free hugepages does not match total (%d != %d)", hugePages.Free, hugePages.Total)
+		}
+
+		if hugePages.FreeMB() == 0 {
+			// Is this appropriate? Or should we bomb out?
+			log.Error("no free hugepages -- NVMe performance may suffer")
+		}
 	}
 
 	// If this daos_server instance ends up being the MS leader,
@@ -123,6 +148,17 @@ func Start(log *logging.LeveledLogger, cfg *Configuration) error {
 		if i+1 > maxIoServers {
 			break
 		}
+
+		// If we have multiple I/O instances with block devices, then we need to apportion
+		// the hugepage memory among the instances.
+		srvCfg.Storage.Bdev.MemSize = hugePages.FreeMB() / len(cfg.Servers)
+		// reserve a little for daos_admin
+		srvCfg.Storage.Bdev.MemSize -= srvCfg.Storage.Bdev.MemSize / 16
+
+		// Each instance must have a unique shmid in order to run as SPDK primary.
+		// Use a stable identifier that's easy to construct elsewhere if we don't
+		// have access to the instance configuration.
+		srvCfg.Storage.Bdev.ShmID = instanceShmID(i)
 
 		bp, err := bdev.NewClassProvider(log, srvCfg.Storage.SCM.MountPoint, &srvCfg.Storage.Bdev)
 		if err != nil {

--- a/src/control/server/storage/config.go
+++ b/src/control/server/storage/config.go
@@ -122,6 +122,7 @@ type BdevConfig struct {
 	DeviceCount int       `yaml:"bdev_number,omitempty"`
 	FileSize    int       `yaml:"bdev_size,omitempty"`
 	ShmID       int       `yaml:"-" cmdLongFlag:"--shm_id,nonzero" cmdShortFlag:"-i,nonzero"`
+	MemSize     int       `yaml:"-" cmdLongFlag:"--mem_size,nonzero" cmdShortFlag:"-r,nonzero"`
 	VosEnv      string    `yaml:"-" cmdEnv:"VOS_BDEV_CLASS"`
 	Hostname    string    `yaml:"-"` // used when generating templates
 }


### PR DESCRIPTION
Generate a unique shmid for each ioserver instance to enable
starting them as independent SPDK primary processes. When
multiple ioservers are configured and there are block
devices in the configuration, divide the system hugepage
memory among the instances using the new --mem-size
parameter to ioserver.