### PR TITLE
DAOS-3639: DRPC Add better log message for agent connection failure

### DIFF
--- a/src/common/drpc.c
+++ b/src/common/drpc.c
@@ -169,8 +169,8 @@ unixcomm_connect(char *sockaddr, int flags)
 	ret = connect(handle->fd, (struct sockaddr *) &address,
 			sizeof(address));
 	if (ret < 0) {
-		D_ERROR("Failed to connect to socket fd %d, errno=%d\n",
-			handle->fd, errno);
+		D_ERROR("Failed to connect to %s, errno=%d(%s)\n",
+			address.sun_path, errno, strerror(errno));
 		unixcomm_close(handle);
 		return NULL;
 	}


### PR DESCRIPTION
The management and security modules will return DER_BADPATH in the event that
drpc_connect failed. drpc_connect returns a pointer so we do not get an error
code back that we can use to decode the reason for failure. However we can add
a more meaningful message inside unixcomm_connect which will give the path the
connect was attempting to connect to and the errno with a descriptive message
for the failure.

Signed-off-by: David Quigley <david.quigley@intel.com>