### PR TITLE
DAOS-3922 tests: fix daos_racer

### DIFF
--- a/src/tests/daos_racer.c
+++ b/src/tests/daos_racer.c
@@ -452,6 +452,7 @@ main(int argc, char **argv)
 			rc = uuid_parse(optarg, ts_ctx.tsc_cont_uuid);
 			if (rc)
 				return rc;
+			break;
 		case 't':
 			duration = strtoul(optarg, &endp, 0);
 			break;
@@ -464,17 +465,17 @@ main(int argc, char **argv)
 	}
 	srand(seed);
 
-	if (ts_ctx.tsc_mpi_rank == 0 && uuid_is_null(ts_ctx.tsc_pool_uuid))
-		uuid_generate(ts_ctx.tsc_pool_uuid);
-	if (ts_ctx.tsc_mpi_rank == 0 && uuid_is_null(ts_ctx.tsc_cont_uuid))
-		uuid_generate(ts_ctx.tsc_cont_uuid);
-
 	ts_ctx.tsc_svc.rl_nr = 1;
 	ts_ctx.tsc_svc.rl_ranks  = &svc_rank;
 	ts_ctx.tsc_scm_size	= scm_size;
 	ts_ctx.tsc_nvme_size	= nvme_size;
 
 	if (ts_ctx.tsc_mpi_rank == 0) {
+		if (uuid_is_null(ts_ctx.tsc_pool_uuid))
+			uuid_generate(ts_ctx.tsc_pool_uuid);
+		if (uuid_is_null(ts_ctx.tsc_cont_uuid))
+			uuid_generate(ts_ctx.tsc_cont_uuid);
+
 		fprintf(stdout,
 			"racer start with %d threads duration %u secs\n"
 			"\tpool size     : SCM: %u MB, NVMe: %u MB\n",


### PR DESCRIPTION
The old implementation missed "break" the swith block for
parsing parameters, as to the default value for adjacent
time parameter (-t) is always random.

The patch fixes it, and some other code adjustment.

Signed-off-by: Fan Yong <fan.yong@intel.com>