### PR TITLE
DAOS-3923 dtx: simplify dtx batched commit (de)register

### DIFF
--- a/src/container/srv_target.c
+++ b/src/container/srv_target.c
@@ -885,7 +885,15 @@ cont_child_destroy_one(void *vin)
 			break;
 		if (rc != 0)
 			D_GOTO(out_pool, rc);
-		/* found it */
+
+		if (cont->sc_open > 0) {
+			D_ERROR(DF_CONT": Container is still in open(%d)\n",
+				DP_CONT(cont->sc_pool->spc_uuid,
+					cont->sc_uuid), cont->sc_open);
+			cont_child_put(tls->dt_cont_cache, cont);
+			rc = -DER_BUSY;
+			goto out_pool;
+		}
 
 		cont_child_stop(cont);
 
@@ -1126,11 +1134,6 @@ ds_cont_local_open(uuid_t pool_uuid, uuid_t cont_hdl_uuid, uuid_t cont_uuid,
 	if (rc != 0)
 		D_GOTO(err_cont, rc);
 
-	if (cont_hdl != NULL) {
-		cont_hdl_get_internal(&tls->dt_cont_hdl_hash, hdl);
-		*cont_hdl = hdl;
-	}
-
 	/* It is possible to sync DTX status before destroy the CoS for close
 	 * the container. But that may be not enough. Because the server may
 	 * crashed before closing the container. Then the DTXs' status in the
@@ -1160,15 +1163,24 @@ ds_cont_local_open(uuid_t pool_uuid, uuid_t cont_hdl_uuid, uuid_t cont_uuid,
 	if (cont_uuid != NULL) {
 		struct ds_dtx_resync_args	*ddra = NULL;
 
+		/*
+		 * NB: When cont_uuid == NULL, it's not a real container open
+		 *     but for creating rebuild global container handle.
+		 */
+		hdl->sch_cont->sc_open++;
+
 		rc = cont_start_dtx_reindex_ult(hdl->sch_cont);
-		if (rc != 0)
+		if (rc != 0) {
+			hdl->sch_cont->sc_open--;
 			goto err_cont;
+		}
 
 		rc = dtx_batched_commit_register(hdl->sch_cont);
 		if (rc != 0) {
 			D_ERROR("Failed to register the container "DF_UUID
 				" to the DTX batched commit list: rc = %d\n",
 				DP_UUID(cont_uuid), rc);
+			hdl->sch_cont->sc_open--;
 			D_GOTO(err_cont, rc);
 		}
 
@@ -1192,12 +1204,21 @@ ds_cont_local_open(uuid_t pool_uuid, uuid_t cont_hdl_uuid, uuid_t cont_uuid,
 			D_FREE(ddra);
 			D_GOTO(err_register, rc);
 		}
+
+	}
+
+	if (cont_hdl != NULL) {
+		cont_hdl_get_internal(&tls->dt_cont_hdl_hash, hdl);
+		*cont_hdl = hdl;
 	}
 
 	return 0;
 
 err_register:
-	dtx_batched_commit_deregister(hdl->sch_cont);
+	D_ASSERT(hdl->sch_cont->sc_open > 0);
+	hdl->sch_cont->sc_open--;
+	if (hdl->sch_cont->sc_open == 0)
+		dtx_batched_commit_deregister(hdl->sch_cont);
 err_cont:
 	cont_stop_dtx_reindex_ult(hdl->sch_cont);
 	if (hdl->sch_cont)
@@ -1295,8 +1316,9 @@ ds_cont_tgt_open(uuid_t pool_uuid, uuid_t cont_hdl_uuid,
 static int
 cont_close_hdl(uuid_t cont_hdl_uuid)
 {
-	struct dsm_tls	       *tls = dsm_tls_get();
-	struct ds_cont_hdl     *hdl;
+	struct dsm_tls		*tls = dsm_tls_get();
+	struct ds_cont_hdl	*hdl;
+	struct ds_cont_child	*cont_child;
 
 	hdl = cont_hdl_lookup_internal(&tls->dt_cont_hdl_hash, cont_hdl_uuid);
 
@@ -1306,18 +1328,24 @@ cont_close_hdl(uuid_t cont_hdl_uuid)
 		return 0;
 	}
 
-	D_ASSERT(hdl->sch_cont != NULL);
+	cont_child = hdl->sch_cont;
+	D_ASSERT(cont_child != NULL);
 
-	D_DEBUG(DF_DSMS, DF_CONT": closing (%s): hdl="DF_UUID"\n",
-		DP_CONT(hdl->sch_cont->sc_pool->spc_uuid,
-			hdl->sch_cont->sc_uuid),
-		hdl->sch_cont->sc_closing ? "resent" : "new",
-		DP_UUID(cont_hdl_uuid));
+	D_DEBUG(DF_DSMS, DF_CONT": closing (%d): hdl="DF_UUID"\n",
+		DP_CONT(cont_child->sc_pool->spc_uuid,
+			cont_child->sc_uuid),
+		cont_child->sc_open, DP_UUID(cont_hdl_uuid));
 
-	dtx_batched_commit_deregister(hdl->sch_cont);
+	/* Remove the handle from hash first, following steps may yield */
+	ds_cont_local_close(cont_hdl_uuid);
+
 	daos_csummer_destroy(&hdl->sch_csummer);
 
-	ds_cont_local_close(cont_hdl_uuid);
+	D_ASSERT(cont_child->sc_open > 0);
+	cont_child->sc_open--;
+	if (cont_child->sc_open == 0)
+		dtx_batched_commit_deregister(cont_child);
+
 	cont_hdl_put_internal(&tls->dt_cont_hdl_hash, hdl);
 	return 0;
 }

--- a/src/include/daos_srv/container.h
+++ b/src/include/daos_srv/container.h
@@ -65,17 +65,13 @@ struct ds_cont_child {
 
 	ABT_mutex		 sc_mutex;
 	ABT_cond		 sc_dtx_resync_cond;
-	void			*sc_dtx_flush_cbdata;
 	uint32_t		 sc_dtx_resyncing:1,
 				 sc_dtx_aggregating:1,
 				 sc_dtx_reindex:1,
 				 sc_dtx_reindex_abort:1,
 				 sc_vos_aggregating:1,
 				 sc_abort_vos_aggregating:1,
-				 sc_closing:1,
 				 sc_stopping:1;
-	uint32_t		 sc_dtx_flush_wait_count;
-
 	/* Aggregate ULT */
 	struct dss_sleep_ult	 *sc_agg_ult;
 
@@ -101,6 +97,7 @@ struct ds_cont_child {
 	uint64_t		 sc_aggregation_max;
 	uint64_t		*sc_snapshots;
 	uint32_t		 sc_snapshots_nr;
+	uint32_t		 sc_open;
 };
 
 /*


### PR DESCRIPTION
- Introduced open count for ds_cont_child, so that DTX doesn't have
  to track open count in an ad-hoc way, instead, it can leverage the
  generic open count to trigger final flush on container close;

- Simplified DTX batched commit (de)register a bit;

- Check container open count on destroy, fail destroy with -DER_BUSY
  if the container is still in open;

Signed-off-by: Niu Yawei <yawei.niu@intel.com>
Change-Id: Iefa743c4b0ec25e38f685b159b38032e382e37f9