### PR TITLE
DAOS-2447 vos: add global_size to singv record

### DIFF
--- a/src/vos/vos_internal.h
+++ b/src/vos/vos_internal.h
@@ -570,6 +570,8 @@ struct vos_rec_bundle {
 	struct vos_krec_df	*rb_krec;
 	/** input record size */
 	daos_size_t		 rb_rsize;
+	/** global record size, needed for EC singv record */
+	daos_size_t		 rb_gsize;
 	/** pool map version */
 	uint32_t		 rb_ver;
 	/** tree class */

--- a/src/vos/vos_io.c
+++ b/src/vos/vos_io.c
@@ -319,7 +319,8 @@ bsgl_dcb_resize(struct vos_io_context *ioc)
 /** Fetch the single value within the specified epoch range of an key */
 static int
 akey_fetch_single(daos_handle_t toh, const daos_epoch_range_t *epr,
-		  daos_size_t *rsize, struct vos_io_context *ioc)
+		  daos_size_t *rsize, daos_size_t *gsize,
+		  struct vos_io_context *ioc)
 {
 	struct vos_key_bundle	 kbund;
 	struct vos_rec_bundle	 rbund;
@@ -364,6 +365,7 @@ akey_fetch_single(daos_handle_t toh, const daos_epoch_range_t *epr,
 		goto out;
 
 	*rsize = rbund.rb_rsize;
+	*gsize = rbund.rb_gsize;
 out:
 	return rc;
 }
@@ -621,7 +623,8 @@ akey_fetch(struct vos_io_context *ioc, daos_handle_t ak_toh)
 	}
 
 	if (iod->iod_type == DAOS_IOD_SINGLE) {
-		rc = akey_fetch_single(toh, &val_epr, &iod->iod_size, ioc);
+		rc = akey_fetch_single(toh, &val_epr, &iod->iod_size,
+				       &iod->iod_size, ioc);
 		goto out;
 	}
 
@@ -821,7 +824,7 @@ iod_update_biov(struct vos_io_context *ioc)
 
 static int
 akey_update_single(daos_handle_t toh, uint32_t pm_ver, daos_size_t rsize,
-		   struct vos_io_context *ioc)
+		   daos_size_t gsize, struct vos_io_context *ioc)
 {
 	struct vos_key_bundle	 kbund;
 	struct vos_rec_bundle	 rbund;
@@ -857,6 +860,7 @@ akey_update_single(daos_handle_t toh, uint32_t pm_ver, daos_size_t rsize,
 
 	rbund.rb_biov	= biov;
 	rbund.rb_rsize	= rsize;
+	rbund.rb_gsize	= gsize;
 	rbund.rb_off	= umoff;
 	rbund.rb_ver	= pm_ver;
 
@@ -938,7 +942,8 @@ akey_update(struct vos_io_context *ioc, uint32_t pm_ver, daos_handle_t ak_toh)
 	if (iod->iod_type == DAOS_IOD_SINGLE) {
 		D_DEBUG(DB_IO, "Single update eph "DF_U64"\n",
 			ioc->ic_epr.epr_hi);
-		rc = akey_update_single(toh, pm_ver, iod->iod_size, ioc);
+		rc = akey_update_single(toh, pm_ver, iod->iod_size,
+					iod->iod_size, ioc);
 		goto out;
 	} /* else: array */
 

--- a/src/vos/vos_layout.h
+++ b/src/vos/vos_layout.h
@@ -365,6 +365,11 @@ struct vos_irec_df {
 	umem_off_t			ir_dtx;
 	/** length of value */
 	uint64_t			ir_size;
+	/**
+	 * global length of value, it is needed for single value of EC object
+	 * class that the data will be distributed to multiple data cells.
+	 */
+	uint64_t			ir_gsize;
 	/** external payload address */
 	bio_addr_t			ir_ex_addr;
 	/** placeholder for the key checksum & internal value */

--- a/src/vos/vos_tree.c
+++ b/src/vos/vos_tree.c
@@ -444,6 +444,7 @@ svt_rec_store(struct btr_instance *tins, struct btr_record *rec,
 	irec->ir_cs_size = csum->cs_len;
 	irec->ir_cs_type = csum->cs_type;
 	irec->ir_size	 = bio_iov2len(biov);
+	irec->ir_gsize	 = rbund->rb_gsize;
 	irec->ir_ex_addr = biov->bi_addr;
 	irec->ir_ver	 = rbund->rb_ver;
 
@@ -502,6 +503,7 @@ svt_rec_load(struct btr_instance *tins, struct btr_record *rec,
 	}
 
 	rbund->rb_rsize	= irec->ir_size;
+	rbund->rb_gsize	= irec->ir_gsize;
 	rbund->rb_ver	= irec->ir_ver;
 	return 0;
 }


### PR DESCRIPTION
For EC single value, its data will be distributed to multiple data
cells. At VOS level the singv record need to maintain both local
record size and global record size.

Signed-off-by: Xuezhao Liu <xuezhao.liu@intel.com>