### PR TITLE
DAOS-2429 dtx: misc fixes for DTX logic

### DIFF
--- a/src/dtx/dtx_common.c
+++ b/src/dtx/dtx_common.c
@@ -230,14 +230,17 @@ dtx_handle_init(struct dtx_id *dti, daos_unit_oid_t *oid, daos_handle_t coh,
 	dth->dth_dkey_hash = dkey_hash;
 	dth->dth_ver = pm_ver;
 	dth->dth_intent = intent;
-	dth->dth_leader = leader ? 1 : 0;
-	dth->dth_solo = solo ? 1 : 0;
 	dth->dth_dti_cos = dti_cos;
 	dth->dth_dti_cos_count = dti_cos_count;
 	dth->dth_conflict = conflict;
 	dth->dth_ent = NULL;
 	dth->dth_obj = UMOFF_NULL;
 	dth->dth_sync = 0;
+	dth->dth_leader = leader ? 1 : 0;
+	dth->dth_solo = solo ? 1 : 0;
+	dth->dth_dti_cos_done = 0;
+	dth->dth_has_ilog = 0;
+	dth->dth_renew = 0;
 }
 
 /**
@@ -581,6 +584,8 @@ dtx_leader_end(struct dtx_leader_handle *dlh, struct ds_cont_child *cont,
 				DP_DTI(&dth->dth_xid));
 			return -DER_AGAIN;
 		}
+	} else if (rc == -DER_AGAIN) {
+		dth->dth_renew = 1;
 	}
 
 	if (result < 0 || rc < 0)
@@ -936,6 +941,9 @@ dtx_leader_exec_ops_ult(void *arg)
 	for (i = 0; i < dlh->dlh_sub_cnt; i++) {
 		struct dtx_sub_status *sub = &dlh->dlh_subs[i];
 
+		sub->dss_result = 0;
+		memset(&sub->dss_dce, 0, sizeof(sub->dss_dce));
+
 		if (sub->dss_tgt.st_rank == TGTS_IGNORE) {
 			int ret;
 
@@ -945,8 +953,6 @@ dtx_leader_exec_ops_ult(void *arg)
 			continue;
 		}
 
-		sub->dss_result = 0;
-		memset(&sub->dss_dce, 0, sizeof(sub->dss_dce));
 		rc = ult_arg->func(dlh, ult_arg->func_arg, i,
 				   dtx_sub_comp_cb);
 		if (rc) {

--- a/src/include/daos_srv/dtx_srv.h
+++ b/src/include/daos_srv/dtx_srv.h
@@ -79,7 +79,9 @@ struct dtx_handle {
 					 /* dti_cos has been committed. */
 					 dth_dti_cos_done:1,
 					 /* XXX: touch ilog entry. */
-					 dth_has_ilog:1;
+					 dth_has_ilog:1,
+					 /* epoch conflict, need to renew. */
+					 dth_renew:1;
 	/* The count the DTXs in the dth_dti_cos array. */
 	uint32_t			 dth_dti_cos_count;
 	/* The array of the DTXs for Commit on Share (conflcit). */

--- a/src/object/srv_obj.c
+++ b/src/object/srv_obj.c
@@ -1292,6 +1292,8 @@ ds_obj_rw_handler(crt_rpc_t *rpc)
 	}
 
 	D_TIME_START(tls->ot_sp, time_start, OBJ_PF_UPDATE);
+
+renew:
 	/*
 	 * Since we do not know if other replicas execute the
 	 * operation, so even the operation has been execute
@@ -1334,6 +1336,14 @@ out:
 	/* Stop the distribute transaction */
 	rc = dtx_leader_end(&dlh, cont, rc);
 	if (rc == -DER_AGAIN) {
+		if (dlh.dlh_handle.dth_renew) {
+			/* epoch conflict, renew it and retry. */
+			orw->orw_epoch = crt_hlc_get();
+			flags &= ~ORF_RESEND;
+			memset(&dlh, 0, sizeof(dlh));
+			D_GOTO(renew, rc);
+		}
+
 		flags |= ORF_RESEND;
 		D_GOTO(again, rc);
 	}
@@ -1832,6 +1842,25 @@ ds_obj_punch_handler(crt_rpc_t *rpc)
 	if (rc)
 		goto out;
 
+	if (opi->opi_dkeys.ca_count == 0)
+		D_DEBUG(DB_TRACE,
+			"punch obj %p oid "DF_UOID" tag/xs %d/%d epc "
+			DF_U64", pmv %u/%u dti "DF_DTI".\n",
+			rpc, DP_UOID(opi->opi_oid),
+			dss_get_module_info()->dmi_tgt_id,
+			dss_get_module_info()->dmi_xs_id, opi->opi_epoch,
+			opi->opi_map_ver, map_version, DP_DTI(&opi->opi_dti));
+	else
+		D_DEBUG(DB_TRACE,
+			"punch key %p oid "DF_UOID" dkey "
+			DF_KEY" tag/xs %d/%d epc "
+			DF_U64", pmv %u/%u dti "DF_DTI".\n",
+			rpc, DP_UOID(opi->opi_oid),
+			DP_KEY(&opi->opi_dkeys.ca_arrays[0]),
+			dss_get_module_info()->dmi_tgt_id,
+			dss_get_module_info()->dmi_xs_id, opi->opi_epoch,
+			opi->opi_map_ver, map_version, DP_DTI(&opi->opi_dti));
+
 	/* FIXME: until distributed transaction. */
 	if (opi->opi_epoch == DAOS_EPOCH_MAX) {
 		opi->opi_epoch = crt_hlc_get();
@@ -1874,6 +1903,7 @@ ds_obj_punch_handler(crt_rpc_t *rpc)
 		goto cleanup;
 	}
 
+renew:
 	/*
 	 * Since we do not know if other replicas execute the
 	 * operation, so even the operation has been execute
@@ -1914,6 +1944,14 @@ out:
 	/* Stop the distribute transaction */
 	rc = dtx_leader_end(&dlh, cont, rc);
 	if (rc == -DER_AGAIN) {
+		if (dlh.dlh_handle.dth_renew) {
+			/* epoch conflict, renew it and retry. */
+			opi->opi_epoch = crt_hlc_get();
+			flags &= ~ORF_RESEND;
+			memset(&dlh, 0, sizeof(dlh));
+			D_GOTO(renew, rc);
+		}
+
 		flags |= ORF_RESEND;
 		D_GOTO(again, rc);
 	}

--- a/src/vos/tests/vts_dtx.c
+++ b/src/vos/tests/vts_dtx.c
@@ -44,7 +44,8 @@ vts_dtx_cos(void **state, bool punch)
 
 	/* Insert a DTX into CoS cache. */
 	rc = vos_dtx_add_cos(args->ctx.tc_co_hdl, &args->oid, &xid,
-			     dkey_hash, DAOS_EPOCH_MAX - 1, 0, punch);
+			     dkey_hash, DAOS_EPOCH_MAX - 1, 0,
+			     punch ? DCF_FOR_PUNCH : 0);
 	assert_int_equal(rc, 0);
 
 	/* Query the DTX with different @punch parameter will find nothing. */
@@ -92,30 +93,38 @@ dtx_3(void **state)
 	struct dtx_id		 xid;
 	struct dtx_stat		 stat = { 0 };
 	uint64_t		 dkey_hash = lrand48();
+	int			 flags[3];
 	int			 rc;
 	int			 i;
+
+	flags[0] = 0;
+	flags[1] = DCF_HAS_ILOG;
+	flags[2] = DCF_FOR_PUNCH;
 
 	for (i = 0; i < 11; i++) {
 		daos_dti_gen(&xid, false);
 
 		rc = vos_dtx_add_cos(args->ctx.tc_co_hdl, &args->oid, &xid,
 				     dkey_hash, DAOS_EPOCH_MAX - 1, 0,
-				     i % 2 ? true : false);
+				     flags[i % 3]);
 		assert_int_equal(rc, 0);
 	}
 
 	rc = vos_dtx_list_cos(args->ctx.tc_co_hdl, &args->oid, dkey_hash,
 			      DCLT_PUNCH, 100, &dti_cos);
-	assert_int_equal(rc, 5);
+	/* xid[1,2,4,5,7,8,10] */
+	assert_int_equal(rc, 7);
 	D_FREE(dti_cos);
 
 	rc = vos_dtx_list_cos(args->ctx.tc_co_hdl, &args->oid, dkey_hash,
 			      DCLT_UPDATE, 100, &dti_cos);
-	assert_int_equal(rc, 6);
+	/* xid[0,1,3,4,6,7,9,10] */
+	assert_int_equal(rc, 8);
 	D_FREE(dti_cos);
 
 	rc = vos_dtx_list_cos(args->ctx.tc_co_hdl, &args->oid, dkey_hash,
 			      DCLT_PUNCH | DCLT_UPDATE, 100, &dti_cos);
+	/* xid[all] */
 	assert_int_equal(rc, 11);
 	D_FREE(dti_cos);
 
@@ -129,10 +138,15 @@ dtx_4(void **state)
 {
 	struct io_test_args	*args = *state;
 	struct dtx_entry	*dtes = NULL;
-	struct dtx_id		 xid[11];
+	struct dtx_id		 xid[10];
 	uint64_t		 dkey_hash;
+	int			 flags[3];
 	int			 rc;
 	int			 i;
+
+	flags[0] = 0;
+	flags[1] = DCF_HAS_ILOG;
+	flags[2] = DCF_FOR_PUNCH;
 
 	for (i = 0; i < 10; i++) {
 		daos_dti_gen(&xid[i], false);
@@ -140,7 +154,7 @@ dtx_4(void **state)
 
 		rc = vos_dtx_add_cos(args->ctx.tc_co_hdl, &args->oid, &xid[i],
 				     dkey_hash, DAOS_EPOCH_MAX - 1, 0,
-				     i % 2 ? false : true);
+				     flags[i % 3]);
 		assert_int_equal(rc, 0);
 	}
 
@@ -296,7 +310,7 @@ dtx_5(void **state)
 
 	/* Add former DTX into CoS cache. */
 	rc = vos_dtx_add_cos(args->ctx.tc_co_hdl, &args->oid, &xid,
-			     dkey_hash, epoch, 0, false);
+			     dkey_hash, epoch, 0, 0);
 	assert_int_equal(rc, 0);
 
 	vos_dtx_stat(args->ctx.tc_co_hdl, &stat);
@@ -782,7 +796,7 @@ dtx_16(void **state)
 
 	/* Insert a DTX into CoS cache. */
 	rc = vos_dtx_add_cos(args->ctx.tc_co_hdl, &args->oid, &xid,
-			     dkey_hash, epoch, 0, false);
+			     dkey_hash, epoch, 0, 0);
 	assert_int_equal(rc, 0);
 
 	/* Fetch again. */

--- a/src/vos/vos_dtx_cos.c
+++ b/src/vos/vos_dtx_cos.c
@@ -607,9 +607,8 @@ vos_dtx_del_cos(struct vos_container *cont, daos_unit_oid_t *oid,
 			continue;
 
 		D_DEBUG(DB_TRACE, "Remove DTX "DF_DTI" from CoS cache, "
-			"key %llu, intent %s, has not ilog entry\n",
-			DP_DTI(&dcrc->dcrc_dti), (unsigned long long)dkey_hash,
-			punch ? "Punch" : "Update");
+			"key %llu, intent Update, has not ilog entry\n",
+			DP_DTI(&dcrc->dcrc_dti), (unsigned long long)dkey_hash);
 
 		d_list_del(&dcrc->dcrc_committable);
 		d_list_del(&dcrc->dcrc_link);

--- a/src/vos/vos_obj_index.c
+++ b/src/vos/vos_obj_index.c
@@ -87,6 +87,7 @@ static int
 oi_rec_alloc(struct btr_instance *tins, d_iov_t *key_iov,
 	     d_iov_t *val_iov, struct btr_record *rec)
 {
+	struct dtx_handle	*dth = vos_dth_get();
 	struct vos_obj_df	*obj;
 	daos_unit_oid_t		*key;
 	umem_off_t		 obj_off;
@@ -113,6 +114,13 @@ oi_rec_alloc(struct btr_instance *tins, d_iov_t *key_iov,
 
 	d_iov_set(val_iov, obj, sizeof(struct vos_obj_df));
 	rec->rec_off = obj_off;
+
+	/* For new created object, commit it synchronously to reduce
+	 * potential conflict with subsequent modifications against
+	 * the same object.
+	 */
+	if (dth != NULL)
+		dth->dth_sync = 1;
 
 	D_DEBUG(DB_TRACE, "alloc "DF_UOID" rec "DF_X64"\n",
 		DP_UOID(obj->vo_id), rec->rec_off);


### PR DESCRIPTION
Include the followings:

1. Incarnation log may return -DER_AGAIN when hit non-committed
   DTX with the same epoch. Under such case, the DTX leader will
   retry with newer epoch (HLC).

2. Synchronously commit the DTX if it creates new object, that
   can reduce potential conflict with subsequent modifications
   against the same object.

3. Fix vos_test for DTX CoS.

4. Some debug message and code adjustment.

Signed-off-by: Fan Yong <fan.yong@intel.com>