### PR TITLE
DAOS-2429 dtx: avoid accessing NULL-pointer for vos_dtx_get

### DIFF
--- a/src/include/daos_srv/dtx_srv.h
+++ b/src/include/daos_srv/dtx_srv.h
@@ -206,10 +206,4 @@ dtx_hlc_age2sec(uint64_t hlc)
 	return (crt_hlc_get() - hlc) / NSEC_PER_SEC;
 }
 
-static inline bool
-dtx_is_null(umem_off_t umoff)
-{
-	return umoff == UMOFF_NULL;
-}
-
 #endif /* __DAOS_DTX_SRV_H__ */


### PR DESCRIPTION
dtx_handle::dth_ent may be NULL when call vos_dtx_get().

Rename dtx_is_null() as umoff_is_null(), and some code adjustment.

Signed-off-by: Fan Yong <fan.yong@intel.com>