### PR TITLE
DAOS-2429 dtx: force cleanup DTX entry when deregister

### DIFF
--- a/src/vos/vos_ilog.c
+++ b/src/vos/vos_ilog.c
@@ -85,8 +85,8 @@ vos_ilog_del(struct umem_instance *umm, umem_off_t ilog_off, umem_off_t tx_id,
 	daos_handle_t	coh;
 
 	coh.cookie = (unsigned long)args;
-	vos_dtx_deregister_record(umm, coh, tx_id, ilog_off);
-	return 0;
+	return vos_dtx_deregister_record(umm, coh, tx_id, ilog_off,
+					 DTX_RT_ILOG);
 }
 
 void

--- a/src/vos/vos_internal.h
+++ b/src/vos/vos_internal.h
@@ -446,10 +446,13 @@ vos_dtx_get(void);
  * \param entry		[IN]	The DTX entry address (offset).
  * \param record	[IN]	Address (offset) of the record to be
  *				deregistered.
+ * \param type		[IN]	The record type, see vos_dtx_record_types.
+ *
+ * \return		0 on success and negative on failure.
  */
-void
+int
 vos_dtx_deregister_record(struct umem_instance *umm, daos_handle_t coh,
-			  umem_off_t entry, umem_off_t record);
+			  umem_off_t entry, umem_off_t record, uint32_t type);
 
 /**
  * Mark the DTX as prepared locally.


### PR DESCRIPTION
For active DTX entry batched cleanup case, a DTX may have been
committed, but its DTX entry may be still valid in SCM and wait
the other DTX entries for being cleanup together. But if related
target (SV/EV record) will be removed (by vos aggregation), then
we need to force cleanup the active DTX entry in SCM. Otherwise,
if the server restarts before the batched cleanup, we may cannot
find related target when re-index the active DTX table via
vos_dtx_act_reindex().

Signed-off-by: Fan Yong <fan.yong@intel.com>