### PR TITLE
DAOS-3933 control: Set D_LOG_MASK correctly

### DIFF
--- a/src/control/server/ioserver/config.go
+++ b/src/control/server/ioserver/config.go
@@ -97,7 +97,7 @@ func (fc *FabricConfig) Validate() error {
 func mergeEnvVars(curVars []string, newVars []string) (merged []string) {
 	mergeMap := make(map[string]string)
 	for _, pair := range curVars {
-		kv := strings.Split(pair, "=")
+		kv := strings.SplitN(pair, "=", 2)
 		if len(kv) != 2 || kv[0] == "" || kv[1] == "" {
 			continue
 		}
@@ -111,7 +111,7 @@ func mergeEnvVars(curVars []string, newVars []string) (merged []string) {
 
 	mergedKeys := make(map[string]struct{})
 	for _, pair := range newVars {
-		kv := strings.Split(pair, "=")
+		kv := strings.SplitN(pair, "=", 2)
 		if len(kv) != 2 || kv[0] == "" || kv[1] == "" {
 			continue
 		}

--- a/src/control/server/ioserver/config_test.go
+++ b/src/control/server/ioserver/config_test.go
@@ -68,6 +68,11 @@ func TestMergeEnvVars(t *testing.T) {
 			mergeVars: []string{"C=D"},
 			wantVars:  []string{"A=B", "C=D"},
 		},
+		"complex value": {
+			baseVars:  []string{"SIMPLE=OK"},
+			mergeVars: []string{"COMPLEX=FOO;bar=quux;woof=meow"},
+			wantVars:  []string{"SIMPLE=OK", "COMPLEX=FOO;bar=quux;woof=meow"},
+		},
 		"append no base": {
 			baseVars:  []string{},
 			mergeVars: []string{"C=D"},
@@ -81,7 +86,7 @@ func TestMergeEnvVars(t *testing.T) {
 	} {
 		t.Run(name, func(t *testing.T) {
 			gotVars := mergeEnvVars(tc.baseVars, tc.mergeVars)
-			if diff := cmp.Diff(gotVars, tc.wantVars, cmpOpts()...); diff != "" {
+			if diff := cmp.Diff(tc.wantVars, gotVars, cmpOpts()...); diff != "" {
 				t.Fatalf("(-want, +got):\n%s", diff)
 			}
 		})

--- a/src/control/server/ioserver/exec_test.go
+++ b/src/control/server/ioserver/exec_test.go
@@ -142,6 +142,7 @@ func TestRunnerNormalExit(t *testing.T) {
 		WithTargetCount(42).
 		WithHelperStreamCount(1).
 		WithFabricInterface("qib0").
+		WithLogMask("DEBUG,MGMT=DEBUG,RPC=ERR,MEM=ERR").
 		WithPinnedNumaNode(&numaNode)
 	runner := NewRunner(log, cfg)
 	errOut := make(chan error)
@@ -158,7 +159,7 @@ func TestRunnerNormalExit(t *testing.T) {
 	// Light integration testing of arg/env generation; unit tests elsewhere.
 	wantArgs := "-t 42 -x 1 -p 1 -I 0"
 	var gotArgs string
-	wantEnv := "OFI_INTERFACE=qib0"
+	wantEnv := "OFI_INTERFACE=qib0 D_LOG_MASK=DEBUG,MGMT=DEBUG,RPC=ERR,MEM=ERR"
 	var gotEnv string
 
 	splitLine := func(line, marker string, dest *string) {

--- a/src/control/server/ioserver/tags_test.go
+++ b/src/control/server/ioserver/tags_test.go
@@ -130,8 +130,7 @@ func TestParseEnvVars(t *testing.T) {
 }
 
 func TestCircularRef(t *testing.T) {
-	var circular testConfig
-	circular = *testStruct
+	circular := *testStruct
 	circular.CircularRef = &circular
 
 	got, err := parseCmdTags(&circular, shortFlagTag, joinShortArgs, nil)


### PR DESCRIPTION
A bug in the code responsible for merging sets of environment
variables resulted in this variable not being set properly.