### PR TITLE
DAOS-2429 dtx: remove active DTX entries batched cleanup

### DIFF
--- a/src/dtx/dtx_common.c
+++ b/src/dtx/dtx_common.c
@@ -241,6 +241,7 @@ dtx_handle_init(struct dtx_id *dti, daos_unit_oid_t *oid, daos_handle_t coh,
 	dth->dth_dti_cos_done = 0;
 	dth->dth_has_ilog = 0;
 	dth->dth_renew = 0;
+	dth->dth_actived = 0;
 }
 
 /**
@@ -636,15 +637,10 @@ dtx_leader_end(struct dtx_leader_handle *dlh, struct ds_cont_child *cont,
 	}
 
 out:
-	if (result < 0) {
-		if (dlh->dlh_sub_cnt == 0)
-			vos_dtx_abort(cont->sc_hdl, dth->dth_epoch,
-				      &dth->dth_xid, 1);
-		else
-			dtx_abort(cont->sc_pool->spc_uuid, cont->sc_uuid,
-				  dth->dth_epoch, &dth->dth_dte, 1,
-				  cont->sc_pool->spc_map_version);
-	}
+	if (result < 0 && dlh->dlh_sub_cnt > 0)
+		dtx_abort(cont->sc_pool->spc_uuid, cont->sc_uuid,
+			  dth->dth_epoch, &dth->dth_dte, 1,
+			  cont->sc_pool->spc_map_version);
 
 	D_DEBUG(DB_TRACE,
 		"Stop the DTX "DF_DTI" ver %u, dkey %llu, intent %s, "
@@ -732,8 +728,6 @@ dtx_end(struct dtx_handle *dth, struct ds_cont_hdl *cont_hdl,
 				D_ERROR(DF_UUID": Fail to DTX CoS commit: %d\n",
 					DP_UUID(cont->sc_uuid), rc);
 		}
-
-		vos_dtx_abort(cont->sc_hdl, dth->dth_epoch, &dth->dth_xid, 1);
 	}
 
 	D_DEBUG(DB_TRACE,

--- a/src/include/daos_srv/dtx_srv.h
+++ b/src/include/daos_srv/dtx_srv.h
@@ -81,7 +81,9 @@ struct dtx_handle {
 					 /* XXX: touch ilog entry. */
 					 dth_has_ilog:1,
 					 /* epoch conflict, need to renew. */
-					 dth_renew:1;
+					 dth_renew:1,
+					 /* The DTX entry is in active table. */
+					 dth_actived:1;
 	/* The count the DTXs in the dth_dti_cos array. */
 	uint32_t			 dth_dti_cos_count;
 	/* The array of the DTXs for Commit on Share (conflcit). */

--- a/src/vos/vos_container.c
+++ b/src/vos/vos_container.c
@@ -186,7 +186,6 @@ void
 cont_free(struct d_ulink *ulink)
 {
 	struct vos_container		*cont;
-	struct dtx_batched_cleanup_blob	*bcb;
 	int				 i;
 
 	cont = container_of(ulink, struct vos_container, vc_uhlink);
@@ -202,13 +201,6 @@ cont_free(struct d_ulink *ulink)
 	D_ASSERT(d_list_empty(&cont->vc_dtx_committable_list));
 	D_ASSERT(d_list_empty(&cont->vc_dtx_committed_list));
 	D_ASSERT(d_list_empty(&cont->vc_dtx_committed_tmp_list));
-
-	while ((bcb = d_list_pop_entry(&cont->vc_batched_cleanup_list,
-				       struct dtx_batched_cleanup_blob,
-				       bcb_cont_link)) != NULL) {
-		D_ASSERT(d_list_empty(&bcb->bcb_dce_list));
-		D_FREE(bcb);
-	}
 
 	dbtree_close(cont->vc_btr_hdl);
 
@@ -379,7 +371,6 @@ vos_cont_open(daos_handle_t poh, uuid_t co_uuid, daos_handle_t *coh)
 	D_INIT_LIST_HEAD(&cont->vc_dtx_committable_list);
 	D_INIT_LIST_HEAD(&cont->vc_dtx_committed_list);
 	D_INIT_LIST_HEAD(&cont->vc_dtx_committed_tmp_list);
-	D_INIT_LIST_HEAD(&cont->vc_batched_cleanup_list);
 	cont->vc_dtx_committable_count = 0;
 	cont->vc_dtx_committed_count = 0;
 	cont->vc_dtx_committed_tmp_count = 0;

--- a/src/vos/vos_io.c
+++ b/src/vos/vos_io.c
@@ -1387,8 +1387,10 @@ vos_update_end(daos_handle_t ioh, uint32_t pm_ver, daos_key_t *dkey, int err,
 abort:
 	err = err ? umem_tx_abort(umem, err) : umem_tx_commit(umem);
 out:
-	if (err != 0)
+	if (err != 0) {
+		vos_dtx_cleanup_dth(dth);
 		update_cancel(ioc);
+	}
 	vos_ioc_destroy(ioc, err != 0);
 	vos_dth_set(NULL);
 

--- a/src/vos/vos_layout.h
+++ b/src/vos/vos_layout.h
@@ -219,7 +219,7 @@ struct vos_dtx_act_ent_df {
 	/** The intent of related modification. */
 	uint32_t			dae_intent;
 	/** The index in the current vos_dtx_blob_df. */
-	uint32_t			dae_index;
+	int32_t				dae_index;
 	/** The inlined dtx records. */
 	struct vos_dtx_record_df	dae_rec_inline[DTX_INLINE_REC_CNT];
 	/** DTX flags, see enum vos_dtx_entry_flags. */

--- a/src/vos/vos_obj.c
+++ b/src/vos/vos_obj.c
@@ -180,10 +180,12 @@ vos_obj_punch(daos_handle_t coh, daos_unit_oid_t oid, daos_epoch_t epoch,
 		vos_obj_release(vos_obj_cache_current(), obj, rc != 0);
 
 reset:
-	vos_dth_set(NULL);
-	if (rc != 0)
+	if (rc != 0) {
+		vos_dtx_cleanup_dth(dth);
 		D_DEBUG(DB_IO, "Failed to punch object "DF_UOID": rc = %d\n",
 			DP_UOID(oid), rc);
+	}
+	vos_dth_set(NULL);
 
 	return rc;
 }


### PR DESCRIPTION
The active DTX entries batched cleanup is used for improving DTX
commit efficiency. But now, we face some trouble with such logic:

1. The targets that are modified via the DTX may have been removed
   by vos aggregation before the DTX entry being batched cleanup,
   if the server restart before the batched cleanup, then we cannot
   know how to re-establish the index (in DRAM) for related active
   DTX entries (in SCM).

2. If some DTX entries in the batched cleanup blob are not committed
   (or aborted) in time for some reason, such as lost related RPC,
   or failed to execute related commit (or abort), then the batched
   cleanup for such blob will be blocked (may be for very long time).
   That may cause the active DTX table to be huge.

3. Because the inconsistency between in-DRAM active DTX index and
   in-SCM active DTX table, we are afraid that it may affect DTX
   resync related behavior, then cause rebuild trouble.

4. Commit-on-Share is another potential trouble. If the PMDK transaction
    is failed, then it is difficult to rollback the batched cleanup blob for the
    DTX entries that have been handled via the Commit-on-Share logic.
 
So, be as the temporary solution, we will disable batched cleanup
logic until we find out suitable solutions for related issues.

Signed-off-by: Fan Yong <fan.yong@intel.com>