### PR TITLE
DAOS-2414 rdb: Enable log compaction by default

### DIFF
--- a/doc/environ.md
+++ b/doc/environ.md
@@ -69,7 +69,7 @@ Raft request timeout used by RDBs in milliseconds. `INTEGER`. Default to 3000 ms
 
 ### `RDB_COMPACT_THRESHOLD`
 
-Raft log compaction threshold in applied entries. `INTEGER`. Default to 0 entries.
+Raft log compaction threshold in applied entries. `INTEGER`. Default to 256 entries.
 
 If set to 0, Raft log entries will never be compacted.
 

--- a/src/rdb/rdb_raft.c
+++ b/src/rdb/rdb_raft.c
@@ -2271,10 +2271,10 @@ rdb_raft_get_request_timeout(void)
 static uint64_t
 rdb_raft_get_compact_thres(void)
 {
-	unsigned int i = 0;
+	unsigned int i = 256;
 
 	d_getenv_int("RDB_COMPACT_THRESHOLD", &i);
-	return i == 0 ? UINT64_MAX : i;
+	return i;
 }
 
 int


### PR DESCRIPTION
Enable RDB log compaction by default. The triggering criterion at the
moment is simple: whenever a log reaches 256 entries, the lower half of
the entries will be compacted away.

Signed-off-by: Li Wei <wei.g.li@intel.com>