### PR TITLE
DAOS-3935 control: Fix TestRunnerNormalExit failures

### DIFF
--- a/src/control/server/ioserver/exec_test.go
+++ b/src/control/server/ioserver/exec_test.go
@@ -31,6 +31,7 @@ import (
 	"os"
 	"path"
 	"path/filepath"
+	"sort"
 	"strings"
 	"testing"
 	"time"
@@ -56,7 +57,9 @@ func TestMain(m *testing.M) {
 		// remove this once we're running so that it doesn't pollute test results
 		os.Unsetenv("LD_LIBRARY_PATH")
 		os.Unsetenv(testModeVar)
-		fmt.Printf("%s%s%s\n", testEnvStr, testSep, strings.Join(os.Environ(), " "))
+		env := os.Environ()
+		sort.Strings(env)
+		fmt.Printf("%s%s%s\n", testEnvStr, testSep, strings.Join(env, " "))
 		fmt.Printf("%s%s%s\n", testArgsStr, testSep, strings.Join(os.Args[1:], " "))
 		os.Exit(0)
 	case "RunnerContextExit":
@@ -159,7 +162,12 @@ func TestRunnerNormalExit(t *testing.T) {
 	// Light integration testing of arg/env generation; unit tests elsewhere.
 	wantArgs := "-t 42 -x 1 -p 1 -I 0"
 	var gotArgs string
-	wantEnv := "OFI_INTERFACE=qib0 D_LOG_MASK=DEBUG,MGMT=DEBUG,RPC=ERR,MEM=ERR"
+	env := []string{
+		"OFI_INTERFACE=qib0",
+		"D_LOG_MASK=DEBUG,MGMT=DEBUG,RPC=ERR,MEM=ERR",
+	}
+	sort.Strings(env)
+	wantEnv := strings.Join(env, " ")
 	var gotEnv string
 
 	splitLine := func(line, marker string, dest *string) {


### PR DESCRIPTION
TestRunnerNormalExit sometimes fails like this:

  === RUN   TestRunnerNormalExit
  [...]
  DEBUG 03:44:10.845069 exec.go:113: daos_io_server:0 env:
  [D_LOG_MASK=DEBUG,MGMT=DEBUG,RPC=ERR,MEM=ERR OFI_INTERFACE=qib0]
  TestRunnerNormalExit INFO 2019/12/26 03:44:10 daos_io_server:0
  IOSERVER_TEST_ENV===D_LOG_MASK=DEBUG,MGMT=DEBUG,RPC=ERR,MEM=ERR
  OFI_INTERFACE=qib0
  [...]
  --- FAIL: TestRunnerNormalExit (1.13s)
      exec_test.go:187: wanted
      "OFI_INTERFACE=qib0 D_LOG_MASK=DEBUG,MGMT=DEBUG,RPC=ERR,MEM=ERR";
      got
      "D_LOG_MASK=DEBUG,MGMT=DEBUG,RPC=ERR,MEM=ERR OFI_INTERFACE=qib0"

Since os.Environ's doc does not say anything about the []string's order,
the test should sort the []string and its expectation itself.

Signed-off-by: Li Wei <wei.g.li@intel.com>