### PR TITLE
DAOS-3294 control: fix default access_point port assignment

### DIFF
--- a/doc/admin/deployment.md
+++ b/doc/admin/deployment.md
@@ -410,9 +410,8 @@ a single DAOS I/O instance where possible.
 (e.g. `/dev/pmem1`)
 - DAOS Control Servers will need to be restarted on all hosts after
 updates to the server configuration file.
-- Pick one host in the system and set `access_points` to host and
-listening port (probably going to be the same as server config `port`
-parameter).
+- Pick one host in the system and set `access_points` to list of that
+host's hostname or IP address (don't need to specify port).
 This will be the host which bootstraps the DAOS management service
 (MS).
 
@@ -443,7 +442,7 @@ populated as follows:
 ```
 <snip>
 port: 10001
-access_points: ["wolf-71:10001"] # <----- updated
+access_points: ["wolf-71"] # <----- updated
 <snip>
 servers:
 -

--- a/src/control/client/config.go
+++ b/src/control/client/config.go
@@ -167,7 +167,7 @@ func (c *Configuration) Validate(log logging.Logger) (err error) {
 
 		// warn if access point port differs from config control port
 		if strconv.Itoa(c.ControlPort) != port {
-			log.Debugf("access point (%s) port (%s) differs from control port (%s)",
+			log.Debugf("access point (%s) port (%s) differs from control port (%d)",
 				host, port, c.ControlPort)
 		}
 

--- a/src/control/client/faults.go
+++ b/src/control/client/faults.go
@@ -34,12 +34,12 @@ var (
 		"",
 	)
 	FaultConfigBadControlPort = clientFault(
-		code.ClientConfigBadParam,
+		code.ClientConfigBadControlPort,
 		"invalid control port in configuration",
 		"specify a nonzero control port in configuration ('port' parameter) and retry the client application",
 	)
 	FaultConfigBadAccessPoints = clientFault(
-		code.ClientConfigBadParam,
+		code.ClientConfigBadAccessPoints,
 		"invalid list of access points in configuration",
 		"only a single access point is currently supported, specify only one and retry the client application",
 	)

--- a/src/control/client/faults.go
+++ b/src/control/client/faults.go
@@ -1,0 +1,55 @@
+//
+// (C) Copyright 2020 Intel Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// GOVERNMENT LICENSE RIGHTS-OPEN SOURCE SOFTWARE
+// The Government's rights to use, modify, reproduce, release, perform, display,
+// or disclose this software are subject to the terms of the Apache License as
+// provided in Contract No. 8F-30005.
+// Any reproduction of computer software, computer software documentation, or
+// portions thereof marked with this legend must also reproduce the markings.
+//
+package client
+
+import (
+	"github.com/daos-stack/daos/src/control/fault"
+	"github.com/daos-stack/daos/src/control/fault/code"
+)
+
+var (
+	FaultUnknown = clientFault(
+		code.ClientUnknown,
+		"unknown client error",
+		"",
+	)
+	FaultConfigBadControlPort = clientFault(
+		code.ClientConfigBadParam,
+		"invalid control port in configuration",
+		"specify a nonzero control port in configuration ('port' parameter) and retry the client application",
+	)
+	FaultConfigBadAccessPoints = clientFault(
+		code.ClientConfigBadParam,
+		"invalid list of access points in configuration",
+		"only a single access point is currently supported, specify only one and retry the client application",
+	)
+)
+
+func clientFault(code code.Code, desc, res string) *fault.Fault {
+	return &fault.Fault{
+		Domain:      "client",
+		Code:        code,
+		Description: desc,
+		Resolution:  res,
+	}
+}

--- a/src/control/cmd/daos_server/start.go
+++ b/src/control/cmd/daos_server/start.go
@@ -92,7 +92,7 @@ func (cmd *startCmd) setCLIOverrides() error {
 		}
 	}
 
-	return cmd.config.Validate()
+	return cmd.config.Validate(cmd.log)
 }
 
 func (cmd *startCmd) configureLogging() error {

--- a/src/control/cmd/dmg/main.go
+++ b/src/control/cmd/dmg/main.go
@@ -143,7 +143,7 @@ func parseOpts(args []string, opts *cliOptions, conns client.Connect, log *loggi
 		}
 
 		if opts.HostList != "" {
-			hostlist, err := flattenHostAddrs(opts.HostList, config.Port)
+			hostlist, err := flattenHostAddrs(opts.HostList, config.ControlPort)
 			if err != nil {
 				return err
 			}

--- a/src/control/cmd/dmg/storage.go
+++ b/src/control/cmd/dmg/storage.go
@@ -28,6 +28,7 @@ import (
 	"fmt"
 
 	"github.com/daos-stack/daos/src/control/client"
+	"github.com/daos-stack/daos/src/control/common"
 	ctlpb "github.com/daos-stack/daos/src/control/common/proto/ctl"
 	mgmtpb "github.com/daos-stack/daos/src/control/common/proto/mgmt"
 	types "github.com/daos-stack/daos/src/control/common/storage"
@@ -143,7 +144,7 @@ func groupScanResults(result *client.StorageScanResp, summary bool) (groups host
 	for _, srv := range result.Servers {
 		buf.Reset()
 
-		host, _, err = splitPort(srv, 0) // disregard port when grouping output
+		host, _, err = common.SplitPort(srv, 0) // disregard port when grouping output
 		if err != nil {
 			return
 		}
@@ -255,7 +256,7 @@ func groupFormatResults(results client.StorageFormatResults, summary bool) (grou
 		buf.Reset()
 		result := results[srv]
 
-		host, _, err = splitPort(srv, 0) // disregard port when grouping output
+		host, _, err = common.SplitPort(srv, 0) // disregard port when grouping output
 		if err != nil {
 			return
 		}

--- a/src/control/cmd/dmg/utils.go
+++ b/src/control/cmd/dmg/utils.go
@@ -27,44 +27,15 @@ import (
 	"bytes"
 	"fmt"
 	"sort"
-	"strconv"
 	"strings"
 
 	"github.com/pkg/errors"
 
 	"github.com/daos-stack/daos/src/control/client"
+	"github.com/daos-stack/daos/src/control/common"
 	"github.com/daos-stack/daos/src/control/lib/hostlist"
 	"github.com/daos-stack/daos/src/control/lib/txtfmt"
 )
-
-// splitPort separates port from compressed host string
-func splitPort(addrPattern string, defaultPort int) (string, string, error) {
-	var port string
-	hp := strings.Split(addrPattern, ":")
-
-	switch len(hp) {
-	case 1:
-		// no port specified, use default
-		port = strconv.Itoa(defaultPort)
-	case 2:
-		port = hp[1]
-		if port == "" {
-			return "", "", errors.Errorf("invalid port %q", port)
-		}
-		if _, err := strconv.Atoi(port); err != nil {
-			return "", "", errors.WithMessagef(err, "cannot parse %q",
-				addrPattern)
-		}
-	default:
-		return "", "", errors.Errorf("cannot parse %q", addrPattern)
-	}
-
-	if hp[0] == "" {
-		return "", "", errors.Errorf("invalid host %q", hp[0])
-	}
-
-	return hp[0], port, nil
-}
 
 // hostsByPort takes slice of address patterns and returns a HostGroups mapping
 // of ports to HostSets.
@@ -79,7 +50,7 @@ func hostsByPort(addrPatterns string, defaultPort int) (portHosts hostlist.HostG
 	}
 
 	for _, ptn := range strings.Split(inHostSet.DerangedString(), ",") {
-		hostSet, port, err = splitPort(ptn, defaultPort)
+		hostSet, port, err = common.SplitPort(ptn, defaultPort)
 		if err != nil {
 			return
 		}

--- a/src/control/cmd/dmg/utils_test.go
+++ b/src/control/cmd/dmg/utils_test.go
@@ -62,10 +62,10 @@ func TestFlattenAddrs(t *testing.T) {
 			addrPatterns: "localhost:10001,abc-[1-3]",
 			expAddrs:     "abc-1:9999,abc-2:9999,abc-3:9999,localhost:10001",
 		},
-		"too many colons":     {"bad:addr:here", "", "cannot parse \"bad:addr:here\""},
+		"too many colons":     {"bad:addr:here", "", "address bad:addr:here: too many colons in address"},
 		"no host":             {"valid:10001,:100", "", "invalid hostname \":100\""},
 		"bad host number":     {"1001", "", "invalid hostname \"1001\""},
-		"bad port alphabetic": {"foo:bar", "", "cannot parse \"foo:bar\": strconv.Atoi: parsing \"bar\": invalid syntax"},
+		"bad port alphabetic": {"foo:bar", "", "invalid port \"bar\""},
 		"bad port empty":      {"foo:", "", "invalid port \"\""},
 	} {
 		t.Run(name, func(t *testing.T) {

--- a/src/control/common/file_utils_test.go
+++ b/src/control/common/file_utils_test.go
@@ -34,7 +34,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 )
 
-func TestResolvePath(t *testing.T) {
+func TestUtils_ResolvePath(t *testing.T) {
 	workingDir, err := os.Getwd()
 	if err != nil {
 		t.Fatal(err)
@@ -67,7 +67,7 @@ func TestResolvePath(t *testing.T) {
 	}
 }
 
-func TestFindBinaryInPath(t *testing.T) {
+func TestUtils_FindBinaryInPath(t *testing.T) {
 	testDir, err := ioutil.TempDir("", t.Name())
 	if err != nil {
 		t.Fatal(err)
@@ -104,7 +104,7 @@ func TestFindBinaryInPath(t *testing.T) {
 	})
 }
 
-func TestFindBinaryAdjacent(t *testing.T) {
+func TestUtils_FindBinaryAdjacent(t *testing.T) {
 	testDir := filepath.Dir(os.Args[0])
 	testFile, err := os.OpenFile(path.Join(testDir, t.Name()), os.O_RDWR|os.O_CREATE, 0755)
 	if err != nil {

--- a/src/control/common/net_utils.go
+++ b/src/control/common/net_utils.go
@@ -1,0 +1,32 @@
+//
+// (C) Copyright 2020 Intel Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// GOVERNMENT LICENSE RIGHTS-OPEN SOURCE SOFTWARE
+// The Government's rights to use, modify, reproduce, release, perform, display,
+// or disclose this software are subject to the terms of the Apache License as
+// provided in Contract No. 8F-30005.
+// Any reproduction of computer software, computer software documentation, or
+// portions thereof marked with this legend must also reproduce the markings.
+//
+
+package common
+
+import "strings"
+
+// HasPort checks if addr specifies a port. This only works with IPv4
+// addresses at the moment.
+func HasPort(addr string) bool {
+	return strings.Contains(addr, ":")
+}

--- a/src/control/common/net_utils.go
+++ b/src/control/common/net_utils.go
@@ -23,10 +23,45 @@
 
 package common
 
-import "strings"
+import (
+	"strconv"
+	"strings"
+
+	"github.com/pkg/errors"
+)
 
 // HasPort checks if addr specifies a port. This only works with IPv4
 // addresses at the moment.
 func HasPort(addr string) bool {
 	return strings.Contains(addr, ":")
+}
+
+// SplitPort separates port from host in address and can apply default port if
+// address doesn't contain one.
+func SplitPort(addrPattern string, defaultPort int) (string, string, error) {
+	var port string
+	hp := strings.Split(addrPattern, ":")
+
+	switch len(hp) {
+	case 1:
+		// no port specified, use default
+		port = strconv.Itoa(defaultPort)
+	case 2:
+		port = hp[1]
+		if port == "" {
+			return "", "", errors.Errorf("invalid port %q", port)
+		}
+		if _, err := strconv.Atoi(port); err != nil {
+			return "", "", errors.WithMessagef(err, "cannot parse %q",
+				addrPattern)
+		}
+	default:
+		return "", "", errors.Errorf("cannot parse %q", addrPattern)
+	}
+
+	if hp[0] == "" {
+		return "", "", errors.Errorf("invalid host %q", hp[0])
+	}
+
+	return hp[0], port, nil
 }

--- a/src/control/common/net_utils_test.go
+++ b/src/control/common/net_utils_test.go
@@ -42,3 +42,34 @@ func TestUtils_HasPort(t *testing.T) {
 		})
 	}
 }
+
+func TestUtils_SplitPort(t *testing.T) {
+	for name, tc := range map[string]struct {
+		addr      string
+		dPort     int
+		expHost   string
+		expPort   string
+		expErrMsg string
+	}{
+		"host has port": {"localhost:10001", 10000, "localhost", "10001", ""},
+		"host no port":  {"localhost", 10000, "localhost", "10000", ""},
+		"ip has port":   {"192.168.1.1:10001", 10000, "192.168.1.1", "10001", ""},
+		"ip no port":    {"192.168.1.1", 10000, "192.168.1.1", "10000", ""},
+		"empty port":    {"192.168.1.1:", 10000, "", "", "invalid port \"\""},
+		"bad port": {"192.168.1.1:abc", 10000, "", "",
+			"cannot parse \"192.168.1.1:abc\": strconv.Atoi: parsing \"abc\": invalid syntax"},
+		"bad host":    {":10001", 10000, "", "", "invalid host \"\""},
+		"bad address": {"192.168.1.1:10001:", 10000, "", "", "cannot parse \"192.168.1.1:10001:\""},
+	} {
+		t.Run(name, func(t *testing.T) {
+			h, p, err := SplitPort(tc.addr, tc.dPort)
+			ExpectError(t, err, tc.expErrMsg, name)
+			if tc.expErrMsg != "" {
+				return
+			}
+
+			AssertEqual(t, tc.expHost, h, name)
+			AssertEqual(t, tc.expPort, p, name)
+		})
+	}
+}

--- a/src/control/common/net_utils_test.go
+++ b/src/control/common/net_utils_test.go
@@ -1,0 +1,44 @@
+//
+// (C) Copyright 2020 Intel Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// GOVERNMENT LICENSE RIGHTS-OPEN SOURCE SOFTWARE
+// The Government's rights to use, modify, reproduce, release, perform, display,
+// or disclose this software are subject to the terms of the Apache License as
+// provided in Contract No. 8F-30005.
+// Any reproduction of computer software, computer software documentation, or
+// portions thereof marked with this legend must also reproduce the markings.
+//
+
+package common
+
+import (
+	"testing"
+)
+
+func TestUtils_HasPort(t *testing.T) {
+	for name, tc := range map[string]struct {
+		addr   string
+		expRes bool
+	}{
+		"host has port": {"localhost:10001", true},
+		"host no port":  {"localhost", false},
+		"ip has port":   {"192.168.1.1:10001", true},
+		"ip no port":    {"192.168.1.1", false},
+	} {
+		t.Run(name, func(t *testing.T) {
+			AssertEqual(t, tc.expRes, HasPort(tc.addr), name)
+		})
+	}
+}

--- a/src/control/common/net_utils_test.go
+++ b/src/control/common/net_utils_test.go
@@ -56,10 +56,9 @@ func TestUtils_SplitPort(t *testing.T) {
 		"ip has port":   {"192.168.1.1:10001", 10000, "192.168.1.1", "10001", ""},
 		"ip no port":    {"192.168.1.1", 10000, "192.168.1.1", "10000", ""},
 		"empty port":    {"192.168.1.1:", 10000, "", "", "invalid port \"\""},
-		"bad port": {"192.168.1.1:abc", 10000, "", "",
-			"cannot parse \"192.168.1.1:abc\": strconv.Atoi: parsing \"abc\": invalid syntax"},
-		"bad host":    {":10001", 10000, "", "", "invalid host \"\""},
-		"bad address": {"192.168.1.1:10001:", 10000, "", "", "cannot parse \"192.168.1.1:10001:\""},
+		"bad port":      {"192.168.1.1:abc", 10000, "", "", "invalid port \"abc\""},
+		"bad address": {"192.168.1.1:10001:", 10000, "", "",
+			"address 192.168.1.1:10001:: too many colons in address"},
 	} {
 		t.Run(name, func(t *testing.T) {
 			h, p, err := SplitPort(tc.addr, tc.dPort)

--- a/src/control/fault/code/codes.go
+++ b/src/control/fault/code/codes.go
@@ -56,8 +56,12 @@ const (
 	SystemMemberMissing
 	SystemMemberChanged
 
+	// Client fault codes
+	ClientUnknown Code = iota + 500
+	ClientConfigBadParam
+
 	// Server fault codes
-	ServerUnknown Code = iota + 400
+	ServerUnknown Code = iota + 600
 	ServerConfigBadParam
 
 	// security fault codes

--- a/src/control/fault/code/codes.go
+++ b/src/control/fault/code/codes.go
@@ -56,6 +56,10 @@ const (
 	SystemMemberMissing
 	SystemMemberChanged
 
+	// Server fault codes
+	ServerUnknown Code = iota + 400
+	ServerConfigBadParam
+
 	// security fault codes
 	SecurityUnknown Code = iota + 900
 )

--- a/src/control/fault/code/codes.go
+++ b/src/control/fault/code/codes.go
@@ -58,11 +58,17 @@ const (
 
 	// Client fault codes
 	ClientUnknown Code = iota + 500
-	ClientConfigBadParam
+	ClientConfigBadControlPort
+	ClientConfigBadAccessPoints
 
 	// Server fault codes
 	ServerUnknown Code = iota + 600
-	ServerConfigBadParam
+	ServerBadConfig
+	ServerNoConfigPath
+	ServerConfigBadControlPort
+	ServerConfigBadAccessPoints
+	ServerConfigBadProvider
+	ServerConfigNoServers
 
 	// security fault codes
 	SecurityUnknown Code = iota + 900

--- a/src/control/server/config.go
+++ b/src/control/server/config.go
@@ -404,7 +404,7 @@ func (c *Configuration) Validate(log logging.Logger) (err error) {
 
 		// warn if access point port differs from config control port
 		if strconv.Itoa(c.ControlPort) != port {
-			log.Debugf("access point (%s) port (%s) differs from control port (%s)",
+			log.Debugf("access point (%s) port (%s) differs from control port (%d)",
 				host, port, c.ControlPort)
 		}
 

--- a/src/control/server/config.go
+++ b/src/control/server/config.go
@@ -397,7 +397,7 @@ func (c *Configuration) Validate() (err error) {
 	}
 	// apply configured control port if not supplied
 	for i := range c.AccessPoints {
-		if !hasPort(c.AccessPoints[i]) {
+		if !common.HasPort(c.AccessPoints[i]) {
 			c.AccessPoints[i] += fmt.Sprintf(":%d", c.ControlPort)
 		}
 		if strings.Split(c.AccessPoints[i], ":")[1] == "0" {

--- a/src/control/server/config.go
+++ b/src/control/server/config.go
@@ -28,6 +28,7 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/pkg/errors"
 	yaml "gopkg.in/yaml.v2"
@@ -51,6 +52,7 @@ const (
 	msgConfigNoPath          = "no config path set"
 	msgConfigNoServers       = "no servers specified in config"
 	msgConfigBadAccessPoints = "only a single access point is currently supported"
+	msgConfigBadPort         = "please specify a nonzero control port"
 )
 
 type networkProviderValidation func(string, string) error
@@ -397,6 +399,15 @@ func (c *Configuration) Validate() (err error) {
 	// only single access point valid for now
 	if len(c.AccessPoints) != 1 {
 		return errors.New(msgConfigBadAccessPoints)
+	}
+	// apply configured control port if not supplied
+	for i := range c.AccessPoints {
+		if !hasPort(c.AccessPoints[i]) {
+			c.AccessPoints[i] += fmt.Sprintf(":%d", c.ControlPort)
+		}
+		if strings.Split(c.AccessPoints[i], ":")[1] == "0" {
+			return errors.New(msgConfigBadPort)
+		}
 	}
 
 	if len(c.Servers) == 0 {

--- a/src/control/server/config_test.go
+++ b/src/control/server/config_test.go
@@ -306,6 +306,19 @@ func TestConfigValidation(t *testing.T) {
 			},
 			msgBadConfig + relConfExamplesPath + ": " + msgConfigBadAccessPoints,
 		},
+		"single access point no port": {
+			func(c *Configuration) *Configuration {
+				return c.WithAccessPoints("1.2.3.4")
+			},
+			"",
+		},
+		"single access point invalid port": {
+			func(c *Configuration) *Configuration {
+				return c.WithAccessPoints("1.2.3.4").
+					WithControlPort(0)
+			},
+			msgBadConfig + relConfExamplesPath + ": " + msgConfigBadPort,
+		},
 	} {
 		t.Run(name, func(t *testing.T) {
 			testDir, err := ioutil.TempDir("", strings.Replace(t.Name(), "/", "-", -1))

--- a/src/control/server/config_test.go
+++ b/src/control/server/config_test.go
@@ -211,7 +211,7 @@ func TestConstructedConfig(t *testing.T) {
 		WithSystemName("daos").
 		WithSocketDir("./.daos/daos_server").
 		WithFabricProvider("ofi+verbs;ofi_rxm").
-		WithAccessPoints("hostname1:10001").
+		WithAccessPoints("hostname1").
 		WithFaultCb("./.daos/fd_callback").
 		WithFaultPath("/vcdu0/rack1/hostname").
 		WithHyperthreads(true).

--- a/src/control/server/config_test.go
+++ b/src/control/server/config_test.go
@@ -1,5 +1,5 @@
 //
-// (C) Copyright 2018-2019 Intel Corporation.
+// (C) Copyright 2018-2020 Intel Corporation.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -38,6 +38,7 @@ import (
 
 	. "github.com/daos-stack/daos/src/control/common"
 	"github.com/daos-stack/daos/src/control/lib/netdetect"
+	"github.com/daos-stack/daos/src/control/logging"
 	"github.com/daos-stack/daos/src/control/security"
 	"github.com/daos-stack/daos/src/control/server/ioserver"
 )
@@ -119,6 +120,9 @@ func TestConfig_MarshalUnmarshal(t *testing.T) {
 		},
 	} {
 		t.Run(name, func(t *testing.T) {
+			log, buf := logging.NewTestLogger(t.Name())
+			defer ShowBufferOnFailure(t, buf)
+
 			testDir, err := ioutil.TempDir("", strings.Replace(t.Name(), "/", "-", -1))
 			defer os.RemoveAll(testDir)
 			if err != nil {
@@ -137,7 +141,7 @@ func TestConfig_MarshalUnmarshal(t *testing.T) {
 			configA.Path = tt.inPath
 			err = configA.Load()
 			if err == nil {
-				err = configA.Validate()
+				err = configA.Validate(log)
 			}
 
 			CmpErr(t, tt.expErr, err)
@@ -158,7 +162,7 @@ func TestConfig_MarshalUnmarshal(t *testing.T) {
 
 			err = configB.Load()
 			if err == nil {
-				err = configB.Validate()
+				err = configB.Validate(log)
 			}
 
 			if err != nil {
@@ -312,6 +316,9 @@ func TestConfig_Validation(t *testing.T) {
 		},
 	} {
 		t.Run(name, func(t *testing.T) {
+			log, buf := logging.NewTestLogger(t.Name())
+			defer ShowBufferOnFailure(t, buf)
+
 			testDir, err := ioutil.TempDir("", strings.Replace(t.Name(), "/", "-", -1))
 			defer os.RemoveAll(testDir)
 			if err != nil {
@@ -326,7 +333,7 @@ func TestConfig_Validation(t *testing.T) {
 			// Apply extra config test case
 			config = tt.extraConfig(config)
 
-			CmpErr(t, tt.expErr, config.Validate())
+			CmpErr(t, tt.expErr, config.Validate(log))
 		})
 	}
 }

--- a/src/control/server/config_test.go
+++ b/src/control/server/config_test.go
@@ -319,6 +319,12 @@ func TestConfigValidation(t *testing.T) {
 			},
 			msgBadConfig + relConfExamplesPath + ": " + msgConfigBadPort,
 		},
+		"single access point including invalid port": {
+			func(c *Configuration) *Configuration {
+				return c.WithAccessPoints("1.2.3.4:0").
+			},
+			msgBadConfig + relConfExamplesPath + ": " + msgConfigBadPort,
+		},
 	} {
 		t.Run(name, func(t *testing.T) {
 			testDir, err := ioutil.TempDir("", strings.Replace(t.Name(), "/", "-", -1))

--- a/src/control/server/faults.go
+++ b/src/control/server/faults.go
@@ -1,0 +1,73 @@
+//
+// (C) Copyright 2020 Intel Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// GOVERNMENT LICENSE RIGHTS-OPEN SOURCE SOFTWARE
+// The Government's rights to use, modify, reproduce, release, perform, display,
+// or disclose this software are subject to the terms of the Apache License as
+// provided in Contract No. 8F-30005.
+// Any reproduction of computer software, computer software documentation, or
+// portions thereof marked with this legend must also reproduce the markings.
+//
+package server
+
+import (
+	"github.com/daos-stack/daos/src/control/fault"
+	"github.com/daos-stack/daos/src/control/fault/code"
+)
+
+var (
+	FaultUnknown = serverFault(
+		code.ServerUnknown,
+		"unknown control server error", "")
+	FaultBadConfig = serverFault(
+		code.ServerConfigBadParam,
+		"insufficient information in configuration",
+		"supply path to valid configuration file, use examples for reference",
+	)
+	FaultConfigBadControlPort = serverFault(
+		code.ServerConfigBadParam,
+		"invalid control port in configuration",
+		"specify a nonzero control port in configuration ('port' parameter) and restart the control server",
+	)
+	FaultConfigNoProvider = serverFault(
+		code.ServerConfigBadParam,
+		"provider not specified in configuration",
+		"specify a valid network provider in configuration ('provider' parameter) and restart the control server",
+	)
+	FaultConfigNoPath = serverFault(
+		code.ServerConfigBadParam,
+		"configuration file path not set",
+		"supply the path to a server configuration file when restarting the control server with commandline option '-o'",
+	)
+	FaultConfigNoServers = serverFault(
+		code.ServerConfigBadParam,
+		"no DAOS IO Servers specified in configuration",
+		"specify at least one IO Server configuration ('servers' list parameter) and restart the control server",
+	)
+	FaultConfigBadAccessPoints = serverFault(
+		code.ServerConfigBadParam,
+		"invalid list of access points in configuration",
+		"only a single access point is currently supported, specify only one and restart the control server",
+	)
+)
+
+func serverFault(code code.Code, desc, res string) *fault.Fault {
+	return &fault.Fault{
+		Domain:      "server",
+		Code:        code,
+		Description: desc,
+		Resolution:  res,
+	}
+}

--- a/src/control/server/faults.go
+++ b/src/control/server/faults.go
@@ -32,34 +32,34 @@ var (
 		code.ServerUnknown,
 		"unknown control server error", "")
 	FaultBadConfig = serverFault(
-		code.ServerConfigBadParam,
+		code.ServerBadConfig,
 		"insufficient information in configuration",
 		"supply path to valid configuration file, use examples for reference",
 	)
-	FaultConfigBadControlPort = serverFault(
-		code.ServerConfigBadParam,
-		"invalid control port in configuration",
-		"specify a nonzero control port in configuration ('port' parameter) and restart the control server",
-	)
-	FaultConfigNoProvider = serverFault(
-		code.ServerConfigBadParam,
-		"provider not specified in configuration",
-		"specify a valid network provider in configuration ('provider' parameter) and restart the control server",
-	)
 	FaultConfigNoPath = serverFault(
-		code.ServerConfigBadParam,
+		code.ServerNoConfigPath,
 		"configuration file path not set",
 		"supply the path to a server configuration file when restarting the control server with commandline option '-o'",
 	)
-	FaultConfigNoServers = serverFault(
-		code.ServerConfigBadParam,
-		"no DAOS IO Servers specified in configuration",
-		"specify at least one IO Server configuration ('servers' list parameter) and restart the control server",
+	FaultConfigBadControlPort = serverFault(
+		code.ServerConfigBadControlPort,
+		"invalid control port in configuration",
+		"specify a nonzero control port in configuration ('port' parameter) and restart the control server",
 	)
 	FaultConfigBadAccessPoints = serverFault(
-		code.ServerConfigBadParam,
+		code.ServerConfigBadAccessPoints,
 		"invalid list of access points in configuration",
 		"only a single access point is currently supported, specify only one and restart the control server",
+	)
+	FaultConfigNoProvider = serverFault(
+		code.ServerConfigBadProvider,
+		"provider not specified in configuration",
+		"specify a valid network provider in configuration ('provider' parameter) and restart the control server",
+	)
+	FaultConfigNoServers = serverFault(
+		code.ServerConfigNoServers,
+		"no DAOS IO Servers specified in configuration",
+		"specify at least one IO Server configuration ('servers' list parameter) and restart the control server",
 	)
 )
 

--- a/src/control/server/mgmt_svc.go
+++ b/src/control/server/mgmt_svc.go
@@ -35,6 +35,7 @@ import (
 	"golang.org/x/net/context"
 	"google.golang.org/grpc/peer"
 
+	"github.com/daos-stack/daos/src/control/common"
 	mgmtpb "github.com/daos-stack/daos/src/control/common/proto/mgmt"
 	"github.com/daos-stack/daos/src/control/drpc"
 	"github.com/daos-stack/daos/src/control/logging"
@@ -149,7 +150,7 @@ func checkMgmtSvcReplica(self *net.TCPAddr, accessPoints []string) (isReplica, b
 func resolveAccessPoints(accessPoints []string) (addrs []*net.TCPAddr, err error) {
 	defaultPort := NewConfiguration().ControlPort
 	for _, ap := range accessPoints {
-		if !hasPort(ap) {
+		if !common.HasPort(ap) {
 			ap = net.JoinHostPort(ap, strconv.Itoa(defaultPort))
 		}
 		t, err := net.ResolveTCPAddr("tcp", ap)
@@ -159,12 +160,6 @@ func resolveAccessPoints(accessPoints []string) (addrs []*net.TCPAddr, err error
 		addrs = append(addrs, t)
 	}
 	return addrs, nil
-}
-
-// hasPort checks if addr specifies a port. This only works with IPv4
-// addresses at the moment.
-func hasPort(addr string) bool {
-	return strings.Contains(addr, ":")
 }
 
 // getListenIPs takes the address this server listens on and returns a list of

--- a/src/control/server/mgmt_svc_test.go
+++ b/src/control/server/mgmt_svc_test.go
@@ -55,24 +55,6 @@ func makeBadBytes(count int) (badBytes []byte) {
 	return
 }
 
-func TestHasPort(t *testing.T) {
-	tests := []struct {
-		addr        string
-		expectedHas bool
-	}{
-		{"localhost", false},
-		{"localhost:10000", true},
-		{"192.168.1.1", false},
-		{"192.168.1.1:10000", true},
-	}
-
-	for _, test := range tests {
-		if has := hasPort(test.addr); has != test.expectedHas {
-			t.Errorf("hasPort(%q) = %v", test.addr, has)
-		}
-	}
-}
-
 func TestCheckMgmtSvcReplica(t *testing.T) {
 	defaultPort := strconv.Itoa(NewConfiguration().ControlPort)
 

--- a/src/control/server/server.go
+++ b/src/control/server/server.go
@@ -71,7 +71,7 @@ const maxIoServers = 2
 
 // Start is the entry point for a daos_server instance.
 func Start(log *logging.LeveledLogger, cfg *Configuration) error {
-	err := cfg.Validate()
+	err := cfg.Validate(log)
 	if err != nil {
 		return errors.Wrapf(err, "%s: validation failed", cfg.Path)
 	}

--- a/utils/config/daos.yml
+++ b/utils/config/daos.yml
@@ -15,8 +15,8 @@
 # default: daos_server
 #name: daos
 
-# Force different port number to connect to access points.
-# default: 10000
+# Default destination port to use if port not specified in host list addresses.
+# default: 10001
 #port: 10001
 
 # Hostlist

--- a/utils/config/daos_agent.yml
+++ b/utils/config/daos_agent.yml
@@ -19,10 +19,9 @@
 # Must have the same value for all agents and servers in a system.
 # default: hostname of this node at port 10001 for local testing
 #access_points: ['hostname1:10001','hostname2:10001','hostname3:10001']
-#access_points: [hostname1,hostname2,hostname3]
 
 # Force different port number to connect to access points.
-# default: 10000
+# default: 10001
 #port: 10001
 
 # Hostlist

--- a/utils/config/daos_agent.yml
+++ b/utils/config/daos_agent.yml
@@ -17,8 +17,8 @@
 
 # Management server access points
 # Must have the same value for all agents and servers in a system.
-# default: hostname of this node at port 10001 for local testing
-#access_points: ['hostname1:10001','hostname2:10001','hostname3:10001']
+# default: hostname of this node
+#access_points: ['hostname1']
 
 # Force different port number to connect to access points.
 # default: 10001

--- a/utils/config/daos_server.yml
+++ b/utils/config/daos_server.yml
@@ -19,7 +19,7 @@
 ## Hosts can be specified with or without port, default port below
 ## assumed if not specified.
 #
-## default: hostname of this node at port 10000 for local testing
+## default: hostname of this node at port 10001 for local testing
 #access_points: ['hostname1:10001']
 #
 #
@@ -28,7 +28,7 @@
 ## Force different port number to bind daos_server to, this will also
 ## be used when connecting to access points if no port is specified.
 #
-## default: 10000
+## default: 10001
 #port: 10001
 #
 ## Transport Credentials Specifying certificates to secure communications

--- a/utils/config/daos_server.yml
+++ b/utils/config/daos_server.yml
@@ -19,14 +19,14 @@
 ## Hosts can be specified with or without port, default port below
 ## assumed if not specified.
 #
-## default: hostname of this node at port 10001 for local testing
-#access_points: ['hostname1:10001']
+## default: hostname of this node
+#access_points: ['hostname1']
 #
 #
-## Force default port
+## Default port
 #
-## Force different port number to bind daos_server to, this will also
-## be used when connecting to access points if no port is specified.
+## Port number to bind daos_server to, this will also
+## be used when connecting to access points unless a port is specified.
 #
 ## default: 10001
 #port: 10001

--- a/utils/config/examples/daos_server_local.yml
+++ b/utils/config/examples/daos_server_local.yml
@@ -1,7 +1,7 @@
 # For a single-server system
 
 name: daos_server
-access_points: ['localhost:10001']
+access_points: ['localhost']
 port: 10001
 provider: ofi+sockets
 nr_hugepages: 4096

--- a/utils/config/examples/daos_server_local.yml
+++ b/utils/config/examples/daos_server_local.yml
@@ -2,7 +2,7 @@
 
 name: daos_server
 access_points: ['localhost']
-port: 10001
+# port: 10001
 provider: ofi+sockets
 nr_hugepages: 4096
 control_log_file: /tmp/daos_control.log

--- a/utils/config/examples/daos_server_psm2.yml
+++ b/utils/config/examples/daos_server_psm2.yml
@@ -1,20 +1,13 @@
 # Example configuration file for OPA
 
 name: daos_server   # map to -g daos_server
-access_points: ['example:10001']
+access_points: ['example:10001'] # management service replicas
 port: 10001         # mgmt port
 provider: ofi+psm2  # map to CRT_PHY_ADDR_STR=ofi+psm2
 socket_dir: /tmp/daos_psm2
 nr_hugepages: 4096
 control_log_mask: DEBUG
 control_log_file: /tmp/daos_control.log
-## uncomment to manually assign management service leader, if left unset
-## this will be the first daos_server instance to start
-#access_points: ['hostname1:10001']
-## uncomment to drop privileges before starting data plane
-## (if started as root to perform hardware provisioning)
-# user_name: daosuser
-# group_name: daosgroup # (optional)
 
 ## Transport Credentials Specifying certificates to secure communications
 ##

--- a/utils/config/examples/daos_server_psm2.yml
+++ b/utils/config/examples/daos_server_psm2.yml
@@ -1,7 +1,7 @@
 # Example configuration file for OPA
 
 name: daos_server   # map to -g daos_server
-access_points: ['example:10001'] # management service replicas
+access_points: ['example'] # management service replicas
 port: 10001         # mgmt port
 provider: ofi+psm2  # map to CRT_PHY_ADDR_STR=ofi+psm2
 socket_dir: /tmp/daos_psm2

--- a/utils/config/examples/daos_server_psm2.yml
+++ b/utils/config/examples/daos_server_psm2.yml
@@ -1,8 +1,8 @@
 # Example configuration file for OPA
 
 name: daos_server   # map to -g daos_server
-access_points: ['example'] # management service replicas
-port: 10001         # mgmt port
+access_points: ['example']  # management service leader (bootstrap)
+# port: 10001               # control listen port, default 10001
 provider: ofi+psm2  # map to CRT_PHY_ADDR_STR=ofi+psm2
 socket_dir: /tmp/daos_psm2
 nr_hugepages: 4096

--- a/utils/config/examples/daos_server_sockets.yml
+++ b/utils/config/examples/daos_server_sockets.yml
@@ -1,20 +1,13 @@
 # Example configuration file using sockets
 
 name: daos_server           # map to -g daos_server
-access_points: ['example:10001']
+access_points: ['example:10001'] # management service replicas
 port: 10001                 # mgmt port
 provider: ofi+sockets       # map to CRT_PHY_ADDR_STR=ofi+sockets
 socket_dir: /tmp/daos_sockets
 nr_hugepages: 4096
 control_log_mask: DEBUG
 control_log_file: /tmp/daos_control.log
-## uncomment to manually assign management service leader, if left unset
-## this will be the first daos_server instance to start
-#access_points: ['hostname1:10001']
-## uncomment to drop privileges before starting data plane
-## (if started as root to perform hardware provisioning)
-# user_name: daosuser
-# group_name: daosgroup # (optional)
 
 ## Transport Credentials Specifying certificates to secure communications
 ##

--- a/utils/config/examples/daos_server_sockets.yml
+++ b/utils/config/examples/daos_server_sockets.yml
@@ -1,8 +1,8 @@
 # Example configuration file using sockets
 
 name: daos_server           # map to -g daos_server
-access_points: ['example'] # management service replicas
-port: 10001                 # mgmt port
+access_points: ['example']  # management service leader (bootstrap)
+# port: 10001               # control listen port, default 10001
 provider: ofi+sockets       # map to CRT_PHY_ADDR_STR=ofi+sockets
 socket_dir: /tmp/daos_sockets
 nr_hugepages: 4096

--- a/utils/config/examples/daos_server_sockets.yml
+++ b/utils/config/examples/daos_server_sockets.yml
@@ -1,7 +1,7 @@
 # Example configuration file using sockets
 
 name: daos_server           # map to -g daos_server
-access_points: ['example:10001'] # management service replicas
+access_points: ['example'] # management service replicas
 port: 10001                 # mgmt port
 provider: ofi+sockets       # map to CRT_PHY_ADDR_STR=ofi+sockets
 socket_dir: /tmp/daos_sockets

--- a/utils/config/examples/daos_server_unittests.yml
+++ b/utils/config/examples/daos_server_unittests.yml
@@ -1,7 +1,7 @@
 # Example configuration file using sockets
 
 name: daos_server           # map to -g daos_server
-access_points: ['example:10001']
+access_points: ['example:10001'] # management service replicas
 port: 10001                 # mgmt port
 provider: ofi+sockets       # map to CRT_PHY_ADDR_STR=ofi+sockets
 socket_dir: /tmp/daos_sockets

--- a/utils/config/examples/daos_server_unittests.yml
+++ b/utils/config/examples/daos_server_unittests.yml
@@ -1,8 +1,8 @@
 # Example configuration file using sockets
 
 name: daos_server           # map to -g daos_server
-access_points: ['example'] # management service replicas
-port: 10001                 # mgmt port
+access_points: ['example']  # management service leader (bootstrap)
+# port: 10001               # control listen port, default 10001
 provider: ofi+sockets       # map to CRT_PHY_ADDR_STR=ofi+sockets
 socket_dir: /tmp/daos_sockets
 control_log_mask: DEBUG

--- a/utils/config/examples/daos_server_unittests.yml
+++ b/utils/config/examples/daos_server_unittests.yml
@@ -1,7 +1,7 @@
 # Example configuration file using sockets
 
 name: daos_server           # map to -g daos_server
-access_points: ['example:10001'] # management service replicas
+access_points: ['example'] # management service replicas
 port: 10001                 # mgmt port
 provider: ofi+sockets       # map to CRT_PHY_ADDR_STR=ofi+sockets
 socket_dir: /tmp/daos_sockets


### PR DESCRIPTION
If access point address in config does not contain a port assignment,
use the control port value specified in the same config file.

Given it should be a non-standard situation if a port is specified in
the access point address in the config file, remove access point port
from addresses specified in the example config files.

Print message to debug if specified access point port doesn't match the
configured control port (the value specified in the config file or coded
default if absent from config, default currently "10001").

- update comments in config files
- remove unused CheckReplicas()
- add relevant config.Validate() logic to apply access point port when
  missing in both server and client configurations and log to debug
- add test cases for config validation
- move hasPort() and splitPort() to common utils and add tests
- add faults file to both client and server packages
- add test case for relative config path (unrelated)

Signed-off-by: Tom Nabarro <tom.nabarro@intel.com>