### PR TITLE
DAOS-3745 iosrv: Improve server scheduler

### DIFF
--- a/src/dtx/dtx_srv.c
+++ b/src/dtx/dtx_srv.c
@@ -135,7 +135,7 @@ dtx_setup(void)
 {
 	int	rc;
 
-	rc = dss_ult_create_all(dtx_batched_commit, NULL, true);
+	rc = dss_ult_create_all(dtx_batched_commit, NULL, DSS_ULT_GC, true);
 	if (rc != 0)
 		D_ERROR("Failed to create DTX batched commit ULT: "DF_RC"\n",
 			DP_RC(rc));

--- a/src/include/daos_srv/daos_server.h
+++ b/src/include/daos_srv/daos_server.h
@@ -152,24 +152,6 @@ dss_module_key_get(struct dss_thread_local_storage *dtls,
 void dss_register_key(struct dss_module_key *key);
 void dss_unregister_key(struct dss_module_key *key);
 
-/**
- * Different type of ES pools, there are 4 pools for now
- *
- *  DSS_POOL_URGENT	The highest priority pool. ULTs in this pool will be
- *			scheduled firstly.
- *  DSS_POOL_PRIV	Private pool: I/O requests will be added to this pool.
- *  DSS_POOL_SHARE	Shared pool: Other requests and ULT created during
- *			processing rpc.
- *  DSS_POOL_REBUILD	rebuild pool: pools specially for rebuild tasks.
- */
-enum {
-	DSS_POOL_URGENT,
-	DSS_POOL_PRIV,
-	DSS_POOL_SHARE,
-	DSS_POOL_REBUILD,
-	DSS_POOL_CNT,
-};
-
 #define DSS_XS_NAME_LEN		64
 
 /* Opaque xstream configuration data */
@@ -206,7 +188,7 @@ dss_get_module_info(void)
 }
 
 static inline struct dss_xstream *
-dss_get_xstream(void)
+dss_current_xstream(void)
 {
 	return dss_get_module_info()->dmi_xstream;
 }
@@ -317,8 +299,7 @@ struct dss_module {
 };
 
 /**
- * DSS_TGT_SELF can be passed to dss_ult_xs to indicate scheduling ULT on
- * caller's self XS.
+ * DSS_TGT_SELF indicates scheduling ULT on caller's self XS.
  */
 #define DSS_TGT_SELF	(-1)
 
@@ -344,6 +325,8 @@ enum dss_ult_type {
 	DSS_ULT_DRPC_LISTENER,
 	/** drpc handler ULT */
 	DSS_ULT_DRPC_HANDLER,
+	/** GC & batched commit ULTs */
+	DSS_ULT_GC,
 	/** miscellaneous ULT */
 	DSS_ULT_MISC,
 };
@@ -356,10 +339,10 @@ void dss_abt_pool_choose_cb_register(unsigned int mod_id,
 				     dss_abt_pool_choose_cb_t cb);
 int dss_ult_create(void (*func)(void *), void *arg, int ult_type, int tgt_id,
 		   size_t stack_size, ABT_thread *ult);
-int dss_ult_create_all(void (*func)(void *), void *arg, bool main);
-int dss_ult_create_execute(int (*func)(void *), void *arg,
-			   void (*user_cb)(void *), void *cb_args,
-			   int ult_type, int tgt_id, size_t stack_size);
+int dss_ult_execute(int (*func)(void *), void *arg, void (*user_cb)(void *),
+		    void *cb_args, int ult_type, int tgt_id, size_t stack_size);
+int dss_ult_create_all(void (*func)(void *), void *arg, int ult_type,
+		       bool main);
 
 struct dss_sleep_ult {
 	ABT_thread	dsu_thread;

--- a/src/iosrv/SConscript
+++ b/src/iosrv/SConscript
@@ -26,7 +26,7 @@ def scons():
                                 'drpc_listener.c', 'drpc_progress.c', 'init.c',
                                 'module.c', 'srv_cli.c', 'profile.c', 'rpc.c',
                                 'server_iv.c', 'srv.c', 'srv.pb-c.c', 'tls.c',
-                                'vos.c'],
+                                'sched.c', 'ult.c', 'vos.c'],
                                LIBS=libraries)
     denv.Install('$PREFIX/bin', iosrv)
 

--- a/src/iosrv/sched.c
+++ b/src/iosrv/sched.c
@@ -1,0 +1,542 @@
+/**
+ * (C) Copyright 2016-2019 Intel Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * GOVERNMENT LICENSE RIGHTS-OPEN SOURCE SOFTWARE
+ * The Government's rights to use, modify, reproduce, release, perform, display,
+ * or disclose this software are subject to the terms of the Apache License as
+ * provided in Contract No. B609815.
+ * Any reproduction of computer software, computer software documentation, or
+ * portions thereof marked with this legend must also reproduce the markings.
+ */
+
+#define D_LOGFAC       DD_FAC(server)
+
+#include <abt.h>
+#include <daos/common.h>
+#include <daos_errno.h>
+#include "srv_internal.h"
+
+/*
+ * A schedule cycle consists of three stages:
+ * 1. Starting with a network poll ULT, number of ULTs to be executed in this
+ *    cycle is queried by ABT_pool_get_size() for each non-poll ABT pool;
+ * 2. Executing all other ULTs which not for hardware polling;
+ * 3. Ending with a NVMe poll ULT;
+ *
+ * Extra network & NVMe poll ULTs could be scheduled in executing stage
+ * according to network/NVMe poll age and request/IO statistics.
+ */
+struct sched_cycle {
+	uint32_t	sc_ults_cnt[DSS_POOL_CNT];
+	uint32_t	sc_ults_tot;
+	/*
+	 * bound[0]: Minimum network/NVMe poll age, scheduler always try to
+	 * execute few ULTs (if there is any) before next poll.
+	 *
+	 * bound[1]: Maximum network/NVMe poll age, scheduler will do an extra
+	 * poll if it's not polled after executing cerntain amout of ULTs.
+	 */
+	uint32_t	sc_age_net_bound[2];
+	uint32_t	sc_age_nvme_bound[2];
+	uint32_t	sc_age_net;
+	uint32_t	sc_age_nvme;
+	unsigned int	sc_new_cycle:1,
+			sc_cycle_started:1;
+};
+
+struct sched_data {
+	struct sched_cycle	 sd_cycle;
+	struct dss_xstream	*sd_dx;
+	uint32_t		 sd_event_freq;
+};
+
+static unsigned int sched_throttle[DSS_POOL_CNT] = {
+	0,	/* DSS_POOL_NET_POLL */
+	0,	/* DSS_POOL_NVME_POLL */
+	0,	/* DSS_POOL_IO */
+	30,	/* DSS_POOL_REBUILD */
+	0,	/* DSS_POOL_AGGREGATE */
+	0,	/* DSS_POOL_GC */
+};
+
+int
+sched_set_throttle(int pool_idx, unsigned int percent)
+{
+	if (percent >= 100) {
+		D_ERROR("Invalid throttle number: %d\n", percent);
+		return -DER_INVAL;
+	}
+
+	if (pool_idx >= DSS_POOL_CNT) {
+		D_ERROR("Invalid pool idx: %d\n", pool_idx);
+		return -DER_INVAL;
+	}
+
+	if (pool_idx == DSS_POOL_NET_POLL || pool_idx == DSS_POOL_NVME_POLL) {
+		D_ERROR("Can't throttle network or NVMe poll\n");
+		return -DER_INVAL;
+	}
+
+	sched_throttle[pool_idx] = percent;
+	return 0;
+}
+
+/* #define SCHED_DEBUG */
+static void
+sched_dump_data(struct sched_data *data)
+{
+#ifdef SCHED_DEBUG
+	struct dss_xstream	*dx = data->sd_dx;
+	struct sched_cycle	*cycle = &data->sd_cycle;
+
+	D_PRINT("XS(%d): comm:%d main:%d. age_net:%u, [%u, %u], "
+		"age_nvme:%u, [%u, %u] new_cycle:%d cycle_started:%d "
+		"total_ults:%u [%u, %u, %u, %u]\n", dx->dx_xs_id,
+		dx->dx_comm, dx->dx_main_xs, cycle->sc_age_net,
+		cycle->sc_age_net_bound[0], cycle->sc_age_net_bound[1],
+		cycle->sc_age_nvme, cycle->sc_age_nvme_bound[0],
+		cycle->sc_age_nvme_bound[1], cycle->sc_new_cycle,
+		cycle->sc_cycle_started, cycle->sc_ults_tot,
+		cycle->sc_ults_cnt[DSS_POOL_IO],
+		cycle->sc_ults_cnt[DSS_POOL_REBUILD],
+		cycle->sc_ults_cnt[DSS_POOL_AGGREGATE],
+		cycle->sc_ults_cnt[DSS_POOL_GC]);
+#endif
+}
+
+#define SCHED_AGE_NET_MIN		32
+#define SCHED_AGE_NET_MAX		512
+#define SCHED_AGE_NVME_MIN		32
+#define SCHED_AGE_NVME_MAX		512
+
+static int
+sched_init(ABT_sched sched, ABT_sched_config config)
+{
+	struct sched_data	*data;
+	struct sched_cycle	*cycle;
+	int			 ret;
+
+	D_ALLOC_PTR(data);
+	if (data == NULL)
+		return ABT_ERR_MEM;
+
+	ret = ABT_sched_config_read(config, 2, &data->sd_event_freq,
+				    &data->sd_dx);
+	if (ret != ABT_SUCCESS) {
+		D_ERROR("Failed to read ABT sched config: %d\n", ret);
+		return ret;
+	}
+
+	cycle = &data->sd_cycle;
+	cycle->sc_age_net_bound[0] = SCHED_AGE_NET_MIN;
+	cycle->sc_age_net_bound[1] = SCHED_AGE_NET_MAX;
+	cycle->sc_age_nvme_bound[0] = SCHED_AGE_NVME_MIN;
+	cycle->sc_age_nvme_bound[1] = SCHED_AGE_NVME_MAX;
+
+	ret = ABT_sched_set_data(sched, (void *)data);
+	return ret;
+}
+
+static bool
+need_net_poll(struct sched_cycle *cycle)
+{
+	/* Need net poll to start new cycle */
+	if (!cycle->sc_cycle_started) {
+		D_ASSERT(cycle->sc_ults_tot == 0);
+		return true;
+	}
+
+	/* Need a nvme poll to end current cycle */
+	if (cycle->sc_ults_tot == 0)
+		return false;
+
+	/*
+	 * Need extra net poll when too many ULTs are processed in
+	 * current cycle.
+	 */
+	if (cycle->sc_age_net > cycle->sc_age_net_bound[1])
+		return true;
+
+	/* TODO: Take network request statistics into account */
+
+	return false;
+}
+
+static ABT_unit
+sched_pop_net_poll(struct sched_data *data, ABT_pool pool)
+{
+	struct dss_xstream	*dx = data->sd_dx;
+	struct sched_cycle	*cycle = &data->sd_cycle;
+	ABT_unit		 unit;
+	int			 ret;
+
+	if (!need_net_poll(cycle))
+		return ABT_UNIT_NULL;
+
+	cycle->sc_age_net = 0;
+	cycle->sc_age_nvme++;
+	if (cycle->sc_ults_tot == 0) {
+		D_ASSERT(!cycle->sc_cycle_started);
+		cycle->sc_new_cycle = 1;
+	}
+
+	/* XXX Enabled this check once dss_srv_handler() is revised */
+#if 0
+	/* The xstream without network poll ULT */
+	if (!dx->dx_comm)
+		return ABT_UNIT_NULL;
+#endif
+	ret = ABT_pool_pop(pool, &unit);
+	if (ret != ABT_SUCCESS) {
+		D_ERROR("XS(%d) failed to pop network poll ULT: %d\n",
+			dx->dx_xs_id, ret);
+		return ABT_UNIT_NULL;
+	}
+
+	return unit;
+}
+
+static bool
+need_nvme_poll(struct sched_cycle *cycle)
+{
+	/* Need net poll to start new cycle */
+	if (!cycle->sc_cycle_started) {
+		D_ASSERT(cycle->sc_ults_tot == 0);
+		return false;
+	}
+
+	/* Need nvme poll to end current cycle */
+	if (cycle->sc_ults_tot == 0)
+		return true;
+
+	/*
+	 * Need extra NVMe poll when too many ULTs are processed in
+	 * current cycle.
+	 */
+	if (cycle->sc_age_nvme > cycle->sc_age_nvme_bound[1])
+		return true;
+
+	/* TODO: Take NVMe I/O statistics into account */
+
+	return false;
+}
+
+static ABT_unit
+sched_pop_nvme_poll(struct sched_data *data, ABT_pool pool)
+{
+	struct dss_xstream	*dx = data->sd_dx;
+	struct sched_cycle	*cycle = &data->sd_cycle;
+	ABT_unit		 unit;
+	int			 ret;
+
+	if (!need_nvme_poll(cycle))
+		return ABT_UNIT_NULL;
+
+	D_ASSERT(cycle->sc_cycle_started);
+	cycle->sc_age_nvme = 0;
+	cycle->sc_age_net++;
+	if (cycle->sc_ults_tot == 0)
+		cycle->sc_cycle_started = 0;
+
+	/* Only main xstream (VOS xstream) has NVMe poll ULT */
+	if (!dx->dx_main_xs)
+		return ABT_UNIT_NULL;
+
+	ret = ABT_pool_pop(pool, &unit);
+	if (ret != ABT_SUCCESS) {
+		D_ERROR("XS(%d) failed to pop NVMe poll ULT: %d\n",
+			dx->dx_xs_id, ret);
+		return ABT_UNIT_NULL;
+	}
+
+	return unit;
+}
+
+static ABT_unit
+sched_pop_one(struct sched_data *data, ABT_pool pool, int pool_idx)
+{
+	struct dss_xstream	*dx = data->sd_dx;
+	struct sched_cycle	*cycle = &data->sd_cycle;
+	ABT_unit		 unit;
+	int			 ret;
+
+	D_ASSERT(cycle->sc_ults_tot >= cycle->sc_ults_cnt[pool_idx]);
+	if (cycle->sc_ults_cnt[pool_idx] == 0)
+		return ABT_UNIT_NULL;
+
+	ret = ABT_pool_pop(pool, &unit);
+	if (ret != ABT_SUCCESS) {
+		D_ERROR("XS(%d) failed to pop ULT for ABT pool(%d): %d\n",
+			dx->dx_xs_id, pool_idx, ret);
+		return ABT_UNIT_NULL;
+	}
+
+	/* XXX Need to figure out why it can pop a NULL unit */
+	if (unit == ABT_UNIT_NULL)
+		D_ERROR("XS(%d) poped NULL unit for ABT pool(%d)\n",
+			dx->dx_xs_id, pool_idx);
+
+	cycle->sc_age_net++;
+	cycle->sc_age_nvme++;
+	cycle->sc_ults_cnt[pool_idx] -= 1;
+	cycle->sc_ults_tot -= 1;
+
+	return unit;
+}
+
+static void
+sched_start_cycle(struct sched_data *data, ABT_pool *pools)
+{
+	struct dss_xstream	*dx = data->sd_dx;
+	struct sched_cycle	*cycle = &data->sd_cycle;
+	size_t			 cnt;
+	uint32_t		 limit = 0;
+	bool			 space_pressure = false;
+	int			 i, ret;
+
+	D_ASSERT(cycle->sc_new_cycle == 1);
+	D_ASSERT(cycle->sc_cycle_started == 0);
+	D_ASSERT(cycle->sc_ults_tot == 0);
+
+	cycle->sc_new_cycle = 0;
+	cycle->sc_cycle_started = 1;
+
+	/* Get number of ULTS for each ABT pool */
+	for (i = DSS_POOL_IO; i < DSS_POOL_CNT; i++) {
+		D_ASSERT(cycle->sc_ults_cnt[i] == 0);
+
+		ret = ABT_pool_get_size(pools[i], &cnt);
+		if (ret != ABT_SUCCESS) {
+			D_ERROR("XS(%d) get ABT pool(%d) size error: %d\n",
+				dx->dx_xs_id, i, ret);
+			cnt = 0;
+		}
+
+		cycle->sc_ults_cnt[i] = cnt;
+		cycle->sc_ults_tot += cycle->sc_ults_cnt[i];
+
+		if (sched_throttle[i] > 0 && cycle->sc_ults_cnt[i] > 1)
+			limit = 1;
+	}
+
+	/* No throttling for helper xstream so far */
+	if (!dx->dx_main_xs)
+		return;
+
+	if (!limit && !space_pressure)
+		return;
+
+	/*
+	 * Throttle the ABT pools which have throttle setting.
+	 * TODO: If it's under space pressure, throttle IO pool.
+	 */
+	for (i = DSS_POOL_IO; i < DSS_POOL_CNT; i++) {
+		unsigned int	throttle = sched_throttle[i];
+		int		diff;
+
+		if (sched_throttle[i] == 0)
+			continue;
+
+		/*
+		 * No ULTs from other ABT pools in current cycle, or too few
+		 * ULTs in current cycle.
+		 */
+		if (cycle->sc_ults_cnt[i] == cycle->sc_ults_tot ||
+		    cycle->sc_ults_tot <= cycle->sc_age_net_bound[0])
+			continue;
+
+		D_ASSERT(throttle < 100);
+		limit = max(cycle->sc_ults_tot * throttle / 100, 1);
+		diff = cycle->sc_ults_cnt[i] - limit;
+
+		D_ASSERT(cycle->sc_ults_tot > diff);
+		if (diff > 0 &&
+		    (cycle->sc_ults_tot - diff) > cycle->sc_age_net_bound[0]) {
+			cycle->sc_ults_cnt[i] -= diff;
+			cycle->sc_ults_tot -= diff;
+		}
+	}
+}
+
+static void
+sched_run(ABT_sched sched)
+{
+	struct sched_data	*data;
+	struct sched_cycle	*cycle;
+	struct dss_xstream	*dx;
+	ABT_pool		 pools[DSS_POOL_CNT];
+	ABT_pool		 pool;
+	ABT_unit		 unit;
+	uint32_t		 work_count = 0;
+	int			 i, ret;
+
+	ABT_sched_get_data(sched, (void **)&data);
+	cycle = &data->sd_cycle;
+	dx = data->sd_dx;
+
+	ret = ABT_sched_get_pools(sched, DSS_POOL_CNT, 0, pools);
+	if (ret != ABT_SUCCESS) {
+		D_ERROR("XS(%d) get ABT pools error: %d\n",
+			dx->dx_xs_id, ret);
+		return;
+	}
+
+	while (1) {
+		/* Try to pick network poll ULT */
+		pool = pools[DSS_POOL_NET_POLL];
+		unit = sched_pop_net_poll(data, pool);
+		if (unit != ABT_UNIT_NULL)
+			goto execute;
+
+		/* Try to pick NVMe poll ULT */
+		pool = pools[DSS_POOL_NVME_POLL];
+		unit = sched_pop_nvme_poll(data, pool);
+		if (unit != ABT_UNIT_NULL)
+			goto execute;
+
+		if (cycle->sc_ults_tot == 0)
+			goto start_cycle;
+
+		/* Try to pick a ULT from other ABT pools */
+		for (i = DSS_POOL_IO; i < DSS_POOL_CNT; i++) {
+			pool = pools[i];
+			unit = sched_pop_one(data, pool, i);
+			if (unit != ABT_UNIT_NULL)
+				goto execute;
+		}
+
+		/*
+		 * Nothing to be executed? Could be idle helper XS or poll ULT
+		 * hasn't started yet.
+		 */
+		goto check_event;
+execute:
+		D_ASSERT(pool != ABT_UNIT_NULL);
+		ABT_xstream_run_unit(unit, pool);
+start_cycle:
+		if (cycle->sc_new_cycle) {
+			sched_start_cycle(data, pools);
+			sched_dump_data(data);
+		}
+check_event:
+		if (++work_count >= data->sd_event_freq) {
+			ABT_bool stop;
+
+			ABT_sched_has_to_stop(sched, &stop);
+			if (stop == ABT_TRUE) {
+				D_DEBUG(DB_TRACE, "XS(%d) stop scheduler\n",
+					dx->dx_xs_id);
+				break;
+			}
+			work_count = 0;
+			ABT_xstream_check_events(sched);
+		}
+	}
+}
+
+static int
+sched_free(ABT_sched sched)
+{
+	struct sched_data	*data;
+
+	ABT_sched_get_data(sched, (void **)&data);
+	D_FREE(data);
+
+	return ABT_SUCCESS;
+}
+
+static void
+sched_free_pools(struct dss_xstream *dx)
+{
+	int	i;
+
+	for (i = 0; i < DSS_POOL_CNT; i++) {
+		if (dx->dx_pools[i] != ABT_POOL_NULL) {
+			ABT_pool_free(&dx->dx_pools[i]);
+			dx->dx_pools[i] = ABT_POOL_NULL;
+		}
+	}
+}
+
+static int
+sched_create_pools(struct dss_xstream *dx)
+{
+	int	i, rc;
+
+	for (i = 0; i < DSS_POOL_CNT; i++) {
+		/*
+		 * All pools should be created with ABT_POOL_ACCESS_MPSC to
+		 * allow in-pool ULTs creating new ULTs for other xstreams.
+		 *
+		 * Set 'automatic' as ABT_TRUE, so the pools will be freed
+		 * automatically.
+		 */
+		D_ASSERT(dx->dx_pools[i] == ABT_POOL_NULL);
+		rc = ABT_pool_create_basic(ABT_POOL_FIFO, ABT_POOL_ACCESS_MPSC,
+					   ABT_TRUE, &dx->dx_pools[i]);
+		if (rc != ABT_SUCCESS)
+			return rc;
+	}
+	return ABT_SUCCESS;
+}
+
+void
+dss_sched_fini(struct dss_xstream *dx)
+{
+	D_ASSERT(dx->dx_sched != ABT_SCHED_NULL);
+	/* Pools will be automatically freed by ABT_sched_free() */
+	ABT_sched_free(&dx->dx_sched);
+}
+
+int
+dss_sched_init(struct dss_xstream *dx)
+{
+	ABT_sched_config	config;
+	ABT_sched_config_var	event_freq = {
+		.idx	= 0,
+		.type	= ABT_SCHED_CONFIG_INT
+	};
+	ABT_sched_config_var	dx_ptr = {
+		.idx	= 1,
+		.type	= ABT_SCHED_CONFIG_PTR
+	};
+	ABT_sched_def		sched_def = {
+		.type	= ABT_SCHED_TYPE_ULT,
+		.init	= sched_init,
+		.run	= sched_run,
+		.free	= sched_free,
+		.get_migr_pool = NULL
+	};
+	int			rc;
+
+	/* Create argobots pools */
+	rc = sched_create_pools(dx);
+	if (rc != ABT_SUCCESS)
+		goto out;
+
+	/* Create a scheduler config */
+	rc = ABT_sched_config_create(&config, event_freq, 512, dx_ptr, dx,
+				     ABT_sched_config_var_end);
+	if (rc != ABT_SUCCESS)
+		goto out;
+
+	rc = ABT_sched_create(&sched_def, DSS_POOL_CNT, dx->dx_pools, config,
+			      &dx->dx_sched);
+	ABT_sched_config_free(&config);
+out:
+	if (rc)
+		sched_free_pools(dx);
+	return dss_abterr2der(rc);
+}

--- a/src/iosrv/srv.c
+++ b/src/iosrv/srv.c
@@ -82,10 +82,8 @@
  *		rebalance request,
  *		IV, bcast, and SWIM message handling.
  *
- * Two helper functions:
- * 1) daos_rpc_tag() to query the target tag (context ID) of specific RPC
- *    request,
- * 2) dss_ult_xs() to query the XS id of the xstream for specific ULT task.
+ * Helper function:
+ * daos_rpc_tag() to query the target tag (context ID) of specific RPC request.
  */
 
 /** Number of dRPC xstreams */
@@ -104,11 +102,6 @@ dss_ctx_nr_get(void)
 }
 
 static void dss_gc_ult(void *args);
-
-#define FIRST_DEFAULT_SCHEDULE_RATIO	80
-#define REBUILD_DEFAULT_SCHEDULE_RATIO	30
-unsigned int	dss_rebuild_res_percentage = REBUILD_DEFAULT_SCHEDULE_RATIO;
-unsigned int	dss_first_res_percentage = FIRST_DEFAULT_SCHEDULE_RATIO;
 
 #define DSS_SYS_XS_NAME_FMT	"daos_sys_%d"
 #define DSS_TGT_XS_NAME_FMT	"daos_tgt_%d_xs_%d"
@@ -131,30 +124,6 @@ struct dss_xstream_data {
 
 static struct dss_xstream_data	xstream_data;
 
-struct sched_data {
-    uint32_t event_freq;
-};
-
-static int
-dss_sched_init(ABT_sched sched, ABT_sched_config config)
-{
-	struct sched_data	*p_data;
-	int			 ret;
-
-	D_ALLOC_PTR(p_data);
-	if (p_data == NULL)
-		return ABT_ERR_MEM;
-
-	/* Set the variables from the config */
-	ret = ABT_sched_config_read(config, 1, &p_data->event_freq);
-	if (ret != ABT_SUCCESS)
-		return ret;
-
-	ret = ABT_sched_set_data(sched, (void *)p_data);
-
-	return ret;
-}
-
 bool
 dss_xstream_exiting(struct dss_xstream *dxs)
 {
@@ -166,75 +135,17 @@ dss_xstream_exiting(struct dss_xstream *dxs)
 	return state == ABT_TRUE;
 }
 
-static ABT_unit
-unit_pop(ABT_pool *pools, int pool_idx, ABT_pool *pool)
+int
+dss_xstream_cnt(void)
 {
-	ABT_unit unit;
-
-	ABT_pool_pop(pools[pool_idx], &unit);
-	if (unit != ABT_UNIT_NULL) {
-		*pool = pools[pool_idx];
-		return unit;
-	}
-
-	return ABT_UNIT_NULL;
+	return xstream_data.xd_xs_nr;
 }
 
-static ABT_unit
-normal_unit_pop(ABT_pool *pools, ABT_pool *pool)
-{
-	ABT_unit unit;
-
-	/* Let's pop I/O request ULT first */
-	unit = unit_pop(pools, DSS_POOL_PRIV, pool);
-	if (unit != ABT_UNIT_NULL)
-		return unit;
-
-	/* Other request and collective ULT or created ULT */
-	unit = unit_pop(pools, DSS_POOL_SHARE, pool);
-	if (unit != ABT_UNIT_NULL)
-		return unit;
-
-	return ABT_UNIT_NULL;
-}
-
-/**
- * Choose ULT from the pool.
- * Firstly with dss_first_res_percentage to schedule the task in
- * DSS_POOL_URGENT, then with dss_rebuild_res_percentage (of left) to
- * schedule rebuild task.
- */
-static ABT_unit
-dss_sched_unit_pop(ABT_pool *pools, ABT_pool *pool)
-{
-	size_t		cnt;
-	int		rc;
-
-	/* pop highest priority pool first */
-	rc = ABT_pool_get_size(pools[DSS_POOL_URGENT], &cnt);
-	if (rc != ABT_SUCCESS)
-		return ABT_UNIT_NULL;
-	if (cnt != 0 && rand() % 100 <= dss_first_res_percentage)
-		return unit_pop(pools, DSS_POOL_URGENT, pool);
-
-	/* then pop other pools */
-	rc = ABT_pool_get_size(pools[DSS_POOL_REBUILD], &cnt);
-	if (rc != ABT_SUCCESS)
-		return ABT_UNIT_NULL;
-
-	if (cnt == 0 || rand() % 100 >= dss_rebuild_res_percentage)
-		return normal_unit_pop(pools, pool);
-	else
-		return unit_pop(pools, DSS_POOL_REBUILD, pool);
-
-	return ABT_UNIT_NULL;
-}
-
-static struct dss_xstream *
-dss_xstream_get(int stream_id)
+struct dss_xstream *
+dss_get_xstream(int stream_id)
 {
 	if (stream_id == DSS_XS_SELF)
-		return dss_get_module_info()->dmi_xstream;
+		return dss_current_xstream();
 
 	D_ASSERTF(stream_id >= 0 && stream_id < xstream_data.xd_xs_nr,
 		  "invalid stream id %d (xstream_data.xd_xs_nr %d).\n",
@@ -302,7 +213,7 @@ dss_ult_wakeup(struct dss_sleep_ult *dsu)
 void
 dss_ult_sleep(struct dss_sleep_ult *dsu, uint64_t expire_secs)
 {
-	struct dss_xstream	*dx = dss_xstream_get(DSS_XS_SELF);
+	struct dss_xstream	*dx = dss_current_xstream();
 	ABT_thread		thread;
 	uint64_t		now = 0;
 
@@ -326,7 +237,7 @@ check_sleep_list()
 	struct dss_sleep_ult	*dsu;
 	struct dss_sleep_ult	*tmp;
 
-	dx = dss_xstream_get(DSS_XS_SELF);
+	dx = dss_current_xstream();
 	if (dss_xstream_exiting(dx))
 		shutdown = true;
 
@@ -339,92 +250,10 @@ check_sleep_list()
 	}
 }
 
-static void
-dss_sched_run(ABT_sched sched)
-{
-	uint32_t		work_count = 0;
-	struct sched_data	*p_data;
-	ABT_pool		pools[DSS_POOL_CNT];
-	ABT_pool		pool = ABT_POOL_NULL;
-	ABT_unit		unit;
-	int			ret;
-
-	ABT_sched_get_data(sched, (void **)&p_data);
-
-	ret = ABT_sched_get_pools(sched, DSS_POOL_CNT, 0, pools);
-	if (ret != ABT_SUCCESS) {
-		D_ERROR("ABT_sched_get_pools");
-		return;
-	}
-
-	while (1) {
-		/* Execute one work unit from the scheduler's pool */
-		unit = dss_sched_unit_pop(pools, &pool);
-		if (unit != ABT_UNIT_NULL && pool != ABT_UNIT_NULL)
-			ABT_xstream_run_unit(unit, pool);
-		if (++work_count >= p_data->event_freq) {
-			ABT_bool stop;
-
-			ABT_sched_has_to_stop(sched, &stop);
-			if (stop == ABT_TRUE) {
-				D_DEBUG(DB_TRACE, "ABT_sched_has_to_stop!\n");
-				break;
-			}
-			work_count = 0;
-			ABT_xstream_check_events(sched);
-		}
-	}
-}
-
-static int
-dss_sched_free(ABT_sched sched)
-{
-	struct sched_data *p_data;
-
-	ABT_sched_get_data(sched, (void **)&p_data);
-	D_FREE(p_data);
-
-	return ABT_SUCCESS;
-}
-
-/**
- * Create scheduler
- */
-static int
-dss_sched_create(ABT_pool *pools, int pool_num, ABT_sched *new_sched)
-{
-	int			ret;
-	ABT_sched_config	config;
-	ABT_sched_config_var	cv_event_freq = {
-		.idx	= 0,
-		.type	= ABT_SCHED_CONFIG_INT
-	};
-
-	ABT_sched_def		sched_def = {
-		.type	= ABT_SCHED_TYPE_ULT,
-		.init	= dss_sched_init,
-		.run	= dss_sched_run,
-		.free	= dss_sched_free,
-		.get_migr_pool = NULL
-	};
-
-	/* Create a scheduler config */
-	ret = ABT_sched_config_create(&config, cv_event_freq, 512,
-				      ABT_sched_config_var_end);
-	if (ret != ABT_SUCCESS)
-		return dss_abterr2der(ret);
-
-	ret = ABT_sched_create(&sched_def, pool_num, pools, config,
-			       new_sched);
-	ABT_sched_config_free(&config);
-
-	return dss_abterr2der(ret);
-}
-
 struct dss_rpc_cntr *
 dss_rpc_cntr_get(enum dss_rpc_cntr_id id)
 {
-	struct dss_xstream  *dx = dss_xstream_get(DSS_XS_SELF);
+	struct dss_xstream  *dx = dss_current_xstream();
 
 	D_ASSERT(id < DSS_RC_MAX);
 	return &dx->dx_rpc_cntrs[id];
@@ -459,33 +288,42 @@ dss_rpc_cntr_exit(enum dss_rpc_cntr_id id, bool error)
 		cntr->rc_errors++;
 }
 
-/**
- * Process the rpc received, let's create a ABT thread for each request.
- */
-int
-dss_process_rpc(crt_context_t *ctx, crt_rpc_t *rpc,
-		void (*real_rpc_hdlr)(void *), void *arg)
+static int
+dss_rpc_hdlr(crt_context_t *ctx, crt_rpc_t *rpc,
+	     void (*real_rpc_hdlr)(void *), void *arg)
 {
-	unsigned int	mod_id = opc_get_mod_id(rpc->cr_opc);
-	struct dss_module *module = dss_module_get(mod_id);
-	ABT_pool	*pools = arg;
-	ABT_pool	pool;
-	int		rc;
+	unsigned int		 mod_id = opc_get_mod_id(rpc->cr_opc);
+	struct dss_module	*module = dss_module_get(mod_id);
+	ABT_pool		*pools = arg;
+	ABT_pool		 pool;
+	int			 rc;
 
-	/* For RPC originally from CART might still come here, and its mod_id
-	 * is 0xfe, and module would be NULL.
+	/*
+	 * The mod_id for the RPC originated from CART is 0xfe, and 'module'
+	 * will be NULL for this case.
 	 */
 	if (module != NULL && module->sm_mod_ops != NULL &&
 	    module->sm_mod_ops->dms_abt_pool_choose_cb)
 		pool = module->sm_mod_ops->dms_abt_pool_choose_cb(rpc, pools);
 	else
-		pool = pools[DSS_POOL_SHARE];
+		pool = pools[DSS_POOL_IO];
 
-	rc = ABT_thread_create(pool, real_rpc_hdlr, rpc,
-			       ABT_THREAD_ATTR_NULL, NULL);
-	if (rc != ABT_SUCCESS)
-		rc = dss_abterr2der(rc);
-	return rc;
+	rc = ABT_thread_create(pool, real_rpc_hdlr, rpc, ABT_THREAD_ATTR_NULL,
+			       NULL);
+	return dss_abterr2der(rc);
+}
+
+static void
+dss_nvme_poll_ult(void *args)
+{
+	struct dss_module_info	*dmi = dss_get_module_info();
+	struct dss_xstream	*dx = dss_current_xstream();
+
+	D_ASSERT(dx->dx_main_xs);
+	while (!dss_xstream_exiting(dx)) {
+		bio_nvme_poll(dmi->dmi_nvme_ctxt);
+		ABT_thread_yield();
+	}
 }
 
 /**
@@ -535,8 +373,7 @@ dss_srv_handler(void *arg)
 			goto tls_fini;
 		}
 
-		rc = crt_context_register_rpc_task(dmi->dmi_ctx,
-						   dss_process_rpc,
+		rc = crt_context_register_rpc_task(dmi->dmi_ctx, dss_rpc_hdlr,
 						   dx->dx_pools);
 		if (rc != 0) {
 			D_ERROR("failed to register process cb "DF_RC"\n",
@@ -587,13 +424,23 @@ dss_srv_handler(void *arg)
 			D_GOTO(tse_fini, rc);
 		}
 
-		rc = ABT_thread_create(dx->dx_pools[DSS_POOL_SHARE],
+		rc = ABT_thread_create(dx->dx_pools[DSS_POOL_GC],
 				       dss_gc_ult, NULL,
 				       ABT_THREAD_ATTR_NULL, NULL);
 		if (rc != ABT_SUCCESS) {
 			D_ERROR("create GC ULT failed: %d\n", rc);
 			D_GOTO(nvme_fini, rc = dss_abterr2der(rc));
 		}
+
+		/*
+		 * TODO: This whole dss_srv_handler() needs be revised, it
+		 * should be a pure network poll ULT function, all other
+		 * stuff needs be moved out.
+		 */
+		rc = ABT_thread_create(dx->dx_pools[DSS_POOL_NVME_POLL],
+				       dss_nvme_poll_ult, NULL,
+				       ABT_THREAD_ATTR_NULL, NULL);
+		D_ASSERT(rc == ABT_SUCCESS);
 	}
 
 	dmi->dmi_xstream = dx;
@@ -625,9 +472,6 @@ dss_srv_handler(void *arg)
 				 */
 			}
 		}
-
-		if (dx->dx_main_xs)
-			bio_nvme_poll(dmi->dmi_nvme_ctxt);
 
 		if (dss_xstream_exiting(dx)) {
 			check_sleep_list();
@@ -746,30 +590,11 @@ dss_start_one_xstream(hwloc_cpuset_t cpus, int xs_id)
 	int			rc = 0;
 	bool			comm; /* true to create cart ctx for RPC */
 	int			xs_offset;
-	int			i;
 
 	/** allocate & init xstream configuration data */
 	dx = dss_xstream_alloc(cpus);
 	if (dx == NULL)
 		return -DER_NOMEM;
-
-	/** create pools */
-	for (i = 0; i < DSS_POOL_CNT; i++) {
-		ABT_pool_access access;
-
-		/* for DSS_POOL_URGENT, now the only usage is for dtx_resync,
-		 * that creates ULT in DSS_XS_SELF. So ABT_POOL_ACCESS_PRIV
-		 * is fine.
-		 */
-		access = (i == DSS_POOL_SHARE || i == DSS_POOL_REBUILD ||
-			  i == DSS_POOL_URGENT) ?
-			 ABT_POOL_ACCESS_MPSC : ABT_POOL_ACCESS_PRIV;
-
-		rc = ABT_pool_create_basic(ABT_POOL_FIFO, access, ABT_TRUE,
-					   &dx->dx_pools[i]);
-		if (rc != ABT_SUCCESS)
-			D_GOTO(out_pool, rc = dss_abterr2der(rc));
-	}
 
 	/* Partial XS need the RPC communication ability - system XS, each
 	 * main XS and its first offload XS (for IO dispatch).
@@ -793,10 +618,10 @@ dss_start_one_xstream(hwloc_cpuset_t cpus, int xs_id)
 	dx->dx_dsc_started = false;
 	D_INIT_LIST_HEAD(&dx->dx_sleep_ult_list);
 
-	rc = dss_sched_create(dx->dx_pools, DSS_POOL_CNT, &dx->dx_sched);
+	rc = dss_sched_init(dx);
 	if (rc != 0) {
 		D_ERROR("create scheduler fails: "DF_RC"\n", DP_RC(rc));
-		D_GOTO(out_pool, rc);
+		D_GOTO(out_dx, rc);
 	}
 
 	/** start XS, ABT rank 0 is reserved for the primary xstream */
@@ -820,7 +645,7 @@ dss_start_one_xstream(hwloc_cpuset_t cpus, int xs_id)
 	}
 
 	/** start progress ULT */
-	rc = ABT_thread_create(dx->dx_pools[DSS_POOL_SHARE],
+	rc = ABT_thread_create(dx->dx_pools[DSS_POOL_NET_POLL],
 			       dss_srv_handler, dx, attr,
 			       &dx->dx_progress);
 	if (rc != ABT_SUCCESS) {
@@ -853,15 +678,9 @@ out_xstream:
 		ABT_thread_attr_free(&attr);
 	ABT_xstream_join(dx->dx_xstream);
 	ABT_xstream_free(&dx->dx_xstream);
-	dss_xstream_free(dx);
-	return rc;
 out_sched:
-	ABT_sched_free(&dx->dx_sched);
-out_pool:
-	for (i = 0; i < DSS_POOL_CNT; i++) {
-		if (dx->dx_pools[i] != ABT_POOL_NULL)
-			ABT_pool_free(&dx->dx_pools[i]);
-	}
+	dss_sched_fini(dx);
+out_dx:
 	dss_xstream_free(dx);
 	return rc;
 }
@@ -905,7 +724,7 @@ dss_xstreams_fini(bool force)
 		dx = xstream_data.xd_xs_ptrs[i];
 		if (dx == NULL)
 			continue;
-		ABT_sched_free(&dx->dx_sched);
+		dss_sched_fini(dx);
 		dss_xstream_free(dx);
 		xstream_data.xd_xs_ptrs[i] = NULL;
 	}
@@ -1102,434 +921,6 @@ struct dss_module_key daos_srv_modkey = {
 	.dmk_fini = dss_srv_tls_fini,
 };
 
-/**
- * Create a ULT to execute \a func(\a arg). If \a ult is not NULL, the caller
- * is responsible for freeing the ULT handle with ABT_thread_free().
- *
- * \param[in]	func	function to execute
- * \param[in]	arg	argument for \a func
- * \param[in]	stream_id on which xstream to create the ULT.
- * \param[in]	stack_size stacksize of the ULT, if it is 0, then create
- *			default size of ULT.
- * \param[in]	pool	ULT pool type indicates where the ULT is created.
- *
- * \param[out]	ult	ULT handle if not NULL
- */
-static int
-dss_ult_pool_create(void (*func)(void *), void *arg, int stream_id,
-		    size_t stack_size, ABT_thread *ult, int pool)
-{
-	ABT_thread_attr		attr;
-	struct dss_xstream	*dx;
-	int			rc;
-	int			rc1;
-
-	dx = dss_xstream_get(stream_id);
-	if (dx == NULL)
-		return -DER_NONEXIST;
-
-	if (stack_size > 0) {
-		rc = ABT_thread_attr_create(&attr);
-		if (rc != ABT_SUCCESS)
-			return dss_abterr2der(rc);
-
-		rc = ABT_thread_attr_set_stacksize(attr, stack_size);
-		if (rc != ABT_SUCCESS)
-			D_GOTO(free, rc = dss_abterr2der(rc));
-
-		D_DEBUG(DB_TRACE, "Create ult stacksize is %zd\n", stack_size);
-	} else {
-		attr = ABT_THREAD_ATTR_NULL;
-	}
-
-	rc = ABT_thread_create(dx->dx_pools[pool], func, arg,
-			       attr, ult);
-
-free:
-	if (attr != ABT_THREAD_ATTR_NULL) {
-		rc1 = ABT_thread_attr_free(&attr);
-		if (rc == ABT_SUCCESS)
-			rc = rc1;
-	}
-
-	return dss_abterr2der(rc);
-}
-
-/**
- * Create the ult, will internally select the pool and XS based on ult_type
- * and tgt_idx.
- */
-int
-dss_ult_create(void (*func)(void *), void *arg, int ult_type, int tgt_idx,
-	       size_t stack_size, ABT_thread *ult)
-{
-	return dss_ult_pool_create(func, arg, dss_ult_xs(ult_type, tgt_idx),
-				   stack_size, ult, dss_ult_pool(ult_type));
-}
-
-/**
- * Create an ULT on each server xtream to execute a \a func(\a arg)
- *
- * \param[in] func	function to be executed
- * \param[in] arg	argument to be passed to \a func
- * \param[in] main	only create ULT on main XS or not.
- * \return		Success or negative error code
- *			0
- *			-DER_NOMEM
- *			-DER_INVAL
- */
-int
-dss_ult_create_all(void (*func)(void *), void *arg, bool main)
-{
-	struct dss_xstream      *dx;
-	int			 i;
-	int			 rc = 0;
-
-	for (i = 0; i < xstream_data.xd_xs_nr; i++) {
-		dx = xstream_data.xd_xs_ptrs[i];
-		if (main && !dx->dx_main_xs)
-			continue;
-
-		rc = ABT_thread_create(dx->dx_pools[DSS_POOL_SHARE], func, arg,
-				       ABT_THREAD_ATTR_NULL,
-				       NULL /* new thread */);
-		if (rc != ABT_SUCCESS) {
-			rc = dss_abterr2der(rc);
-			break;
-		}
-	}
-	return rc;
-}
-
-struct aggregator_arg_type {
-	struct dss_stream_arg_type	at_args;
-	void				(*at_reduce)(void *a_args,
-						     void *s_args);
-	int				at_rc;
-	int				at_xs_nr;
-};
-
-/**
- * Collective operations among all server xstreams
- */
-struct dss_future_arg {
-	ABT_future	dfa_future;
-	int		(*dfa_func)(void *);
-	void		*dfa_arg;
-	/** User callback for asynchronous mode */
-	void		(*dfa_comp_cb)(void *);
-	/** Argument for the user callback */
-	void		*dfa_comp_arg;
-	int		dfa_status;
-	bool		dfa_async;
-};
-
-static void
-dss_ult_create_execute_cb(void *data)
-{
-	struct dss_future_arg	*arg = data;
-	int			rc;
-
-	rc = arg->dfa_func(arg->dfa_arg);
-	arg->dfa_status = rc;
-
-	if (!arg->dfa_async)
-		ABT_future_set(arg->dfa_future, (void *)(intptr_t)rc);
-	else
-		arg->dfa_comp_cb(arg->dfa_comp_arg);
-}
-
-/**
- * Create an ULT in synchornous or asynchronous mode
- * Sync: wait until it has been executed.
- * Async: return and call user callback from ULT.
- *
- * Note: This is
- * normally used when it needs to create an ULT on other xstream.
- *
- * \param[in]	func		function to execute
- * \param[in]	arg		argument for \a func
- * \param[in]	user_cb		user call back (mandatory for async mode)
- * \param[in]	arg		argument for \a user callback
- * \param[in]	ult_type	type of ULT
- * \param[in]	tgt_id		target index
- * \param[out]			error code.
- *
- */
-int
-dss_ult_create_execute(int (*func)(void *), void *arg, void (*user_cb)(void *),
-		       void *cb_args, int ult_type, int tgt_id,
-		       size_t stack_size)
-{
-	struct dss_future_arg	future_arg;
-	ABT_future		future;
-	int			rc;
-
-	memset(&future_arg, 0, sizeof(future_arg));
-	future_arg.dfa_func = func;
-	future_arg.dfa_arg = arg;
-	future_arg.dfa_status = 0;
-
-	if (user_cb == NULL) {
-		rc = ABT_future_create(1, NULL, &future);
-		if (rc != ABT_SUCCESS)
-			return dss_abterr2der(rc);
-		future_arg.dfa_future = future;
-		future_arg.dfa_async  = false;
-	} else {
-		future_arg.dfa_comp_cb	= user_cb;
-		future_arg.dfa_comp_arg = cb_args;
-		future_arg.dfa_async	= true;
-	}
-
-	rc = dss_ult_create(dss_ult_create_execute_cb, &future_arg,
-			    ult_type, tgt_id, stack_size, NULL);
-	if (rc)
-		D_GOTO(free, rc);
-
-	if (!future_arg.dfa_async)
-		ABT_future_wait(future);
-free:
-	if (rc == 0)
-		rc = future_arg.dfa_status;
-
-	if (!future_arg.dfa_async)
-		ABT_future_free(&future);
-
-	return rc;
-}
-
-struct collective_arg {
-	struct dss_future_arg		ca_future;
-};
-
-static void
-collective_func(void *varg)
-{
-	struct dss_stream_arg_type	*a_args	= varg;
-	struct collective_arg		*carg	= a_args->st_coll_args;
-	struct dss_future_arg		*f_arg	= &carg->ca_future;
-	int				rc;
-
-	/** Update just the rc value */
-	a_args->st_rc = f_arg->dfa_func(f_arg->dfa_arg);
-
-	rc = ABT_future_set(f_arg->dfa_future, (void *)a_args);
-	if (rc != ABT_SUCCESS)
-		D_ERROR("future set failure %d\n", rc);
-}
-
-/* Reduce the return codes into the first element. */
-static void
-collective_reduce(void **arg)
-{
-	struct aggregator_arg_type	*aggregator;
-	struct dss_stream_arg_type	*stream;
-	int				*nfailed;
-	int				 i;
-
-	aggregator = (struct aggregator_arg_type *)arg[0];
-	nfailed = &aggregator->at_args.st_rc;
-
-	for (i = 1; i < aggregator->at_xs_nr + 1; i++) {
-		stream = (struct dss_stream_arg_type *)arg[i];
-		if (stream->st_rc != 0) {
-			if (aggregator->at_rc == 0)
-				aggregator->at_rc = stream->st_rc;
-			(*nfailed)++;
-		}
-
-		/** optional custom aggregator call provided across streams */
-		if (aggregator->at_reduce)
-			aggregator->at_reduce(aggregator->at_args.st_arg,
-					      stream->st_arg);
-	}
-}
-
-static int
-dss_collective_reduce_internal(struct dss_coll_ops *ops,
-			       struct dss_coll_args *args, bool create_ult,
-			       int flag)
-{
-	struct collective_arg		carg;
-	struct dss_coll_stream_args	*stream_args;
-	struct dss_stream_arg_type	*stream;
-	struct aggregator_arg_type	aggregator;
-	struct dss_xstream		*dx;
-	ABT_future			future;
-	int				xs_nr;
-	int				rc;
-	int				tid;
-
-	if (ops == NULL || args == NULL || ops->co_func == NULL) {
-		D_DEBUG(DB_MD, "mandatory args mising dss_collective_reduce");
-		return -DER_INVAL;
-	}
-
-	if (ops->co_reduce_arg_alloc != NULL &&
-	    ops->co_reduce_arg_free == NULL) {
-		D_DEBUG(DB_MD, "Free callback missing for reduce args\n");
-		return -DER_INVAL;
-	}
-
-	if (dss_tgt_nr == 0) {
-		/* May happen when the server is shutting down. */
-		D_DEBUG(DB_TRACE, "no xstreams\n");
-		return -DER_CANCELED;
-	}
-
-	xs_nr = dss_tgt_nr;
-	stream_args = &args->ca_stream_args;
-	D_ALLOC_ARRAY(stream_args->csa_streams, xs_nr);
-	if (stream_args->csa_streams == NULL)
-		return -DER_NOMEM;
-
-	/*
-	 * Use the first, extra element of the value array to store the number
-	 * of failed tasks.
-	 */
-	rc = ABT_future_create(xs_nr + 1, collective_reduce, &future);
-	if (rc != ABT_SUCCESS)
-		D_GOTO(out_streams, rc = dss_abterr2der(rc));
-
-	carg.ca_future.dfa_future = future;
-	carg.ca_future.dfa_func	= ops->co_func;
-	carg.ca_future.dfa_arg	= args->ca_func_args;
-	carg.ca_future.dfa_status = 0;
-
-	memset(&aggregator, 0, sizeof(aggregator));
-	aggregator.at_xs_nr = xs_nr;
-	if (ops->co_reduce) {
-		aggregator.at_args.st_arg = args->ca_aggregator;
-		aggregator.at_reduce	  = ops->co_reduce;
-	}
-
-	if (ops->co_reduce_arg_alloc)
-		for (tid = 0; tid < xs_nr; tid++) {
-			stream = &stream_args->csa_streams[tid];
-			rc = ops->co_reduce_arg_alloc(stream,
-						     aggregator.at_args.st_arg);
-			if (rc)
-				D_GOTO(out_future, rc);
-		}
-
-	rc = ABT_future_set(future, (void *)&aggregator);
-	D_ASSERTF(rc == ABT_SUCCESS, "%d\n", rc);
-
-	for (tid = 0; tid < xs_nr; tid++) {
-		stream			= &stream_args->csa_streams[tid];
-		stream->st_coll_args	= &carg;
-
-		if (args->ca_exclude_tgts_cnt) {
-			int i;
-
-			for (i = 0; i < args->ca_exclude_tgts_cnt; i++)
-				if (args->ca_exclude_tgts[i] == tid)
-					break;
-
-			if (i < args->ca_exclude_tgts_cnt) {
-				D_DEBUG(DB_TRACE, "Skip tgt %d\n", tid);
-				rc = ABT_future_set(future, (void *)stream);
-				D_ASSERTF(rc == ABT_SUCCESS, "%d\n", rc);
-				continue;
-			}
-		}
-
-		dx = dss_xstream_get(DSS_MAIN_XS_ID(tid));
-		if (create_ult)
-			rc = ABT_thread_create(dx->dx_pools[DSS_POOL_SHARE],
-					       collective_func, stream,
-					       ABT_THREAD_ATTR_NULL, NULL);
-		else
-			rc = ABT_task_create(dx->dx_pools[DSS_POOL_SHARE],
-					     collective_func, stream, NULL);
-
-		if (rc != ABT_SUCCESS) {
-			stream->st_rc = dss_abterr2der(rc);
-			rc = ABT_future_set(future, (void *)stream);
-			D_ASSERTF(rc == ABT_SUCCESS, "%d\n", rc);
-		}
-	}
-
-	ABT_future_wait(future);
-
-	rc = aggregator.at_rc;
-
-out_future:
-	ABT_future_free(&future);
-
-	if (ops->co_reduce_arg_free)
-		for (tid = 0; tid < xs_nr; tid++)
-			ops->co_reduce_arg_free(&stream_args->csa_streams[tid]);
-
-out_streams:
-	D_FREE(args->ca_stream_args.csa_streams);
-
-	return rc;
-}
-
-/**
- * General case:
- * Execute \a task(\a arg) collectively on all server xstreams. Can only be
- * called by ULTs. Can only execute tasklet-compatible functions. User specified
- * reduction functions for aggregation after collective
- *
- * \param[in] ops		All dss_collective ops to work on streams
- *				include \a func(\a arg) for collective on all
- *				server xstreams.
- * \param[in] args		All arguments required for dss_collective
- *				including func args.
- * \param[in] flag		collective flag, reserved for future usage.
- *
- * \return			number of failed xstreams or error code
- */
-int
-dss_task_collective_reduce(struct dss_coll_ops *ops,
-			   struct dss_coll_args *args, int flag)
-{
-	return dss_collective_reduce_internal(ops, args, false, flag);
-}
-
-/**
- * General case:
- * Execute \a ULT(\a arg) collectively on all server xstreams. Can only be
- * called by ULTs. Can only execute tasklet-compatible functions. User specified
- * reduction functions for aggregation after collective
- *
- * \param[in] ops		All dss_collective ops to work on streams
- *				include \a func(\a arg) for collective on all
- *				server xstreams.
- * \param[in] args		All arguments required for dss_collective
- *				including func args.
- * \param[in] flag		collective flag, reserved for future usage.
- *
- * \return			number of failed xstreams or error code
- */
-int
-dss_thread_collective_reduce(struct dss_coll_ops *ops,
-			     struct dss_coll_args *args, int flag)
-{
-	return dss_collective_reduce_internal(ops, args, true, flag);
-}
-
-static int
-dss_collective_internal(int (*func)(void *), void *arg, bool thread, int flag)
-{
-	int				rc;
-	struct dss_coll_ops		coll_ops = { 0 };
-	struct dss_coll_args		coll_args = { 0 };
-
-	coll_ops.co_func	= func;
-	coll_args.ca_func_args	= arg;
-
-	if (thread)
-		rc = dss_thread_collective_reduce(&coll_ops, &coll_args, flag);
-	else
-		rc = dss_task_collective_reduce(&coll_ops, &coll_args, flag);
-
-	return rc;
-}
-
 /** TODO: use daos checksum library to offload checksum calculation */
 static int
 compute_checksum_ult(void *args)
@@ -1574,7 +965,7 @@ dss_acc_offload(struct dss_acc_task *at_args)
 
 	switch (at_args->at_offload_type) {
 	case DSS_OFFLOAD_ULT:
-		rc = dss_ult_create_execute(compute_checksum_ult,
+		rc = dss_ult_execute(compute_checksum_ult,
 				at_args->at_params,
 				NULL /* user-cb */,
 				NULL /* user-cb args */,
@@ -1588,39 +979,6 @@ dss_acc_offload(struct dss_acc_task *at_args)
 	}
 
 	return rc;
-}
-
-/**
- * Execute \a func(\a arg) collectively on all server xstreams. Can only be
- * called by ULTs. Can only execute tasklet-compatible functions.
- *
- * \param[in] func	function to be executed
- * \param[in] arg	argument to be passed to \a func
- * \param[in] flag	collective flag, reserved for future usage.
- *
- * \return		number of failed xstreams or error code
- */
-int
-dss_task_collective(int (*func)(void *), void *arg, int flag)
-{
-	return dss_collective_internal(func, arg, false, flag);
-}
-
-/**
- * Execute \a func(\a arg) collectively on all server xstreams. Can only be
- * called by ULTs. Can only execute tasklet-compatible functions.
- *
- * \param[in] func	function to be executed
- * \param[in] arg	argument to be passed to \a func
- * \param[in] flag	collective flag, reserved for future usage.
- *
- * \return		number of failed xstreams or error code
- */
-
-int
-dss_thread_collective(int (*func)(void *), void *arg, int flag)
-{
-	return dss_collective_internal(func, arg, true, flag);
 }
 
 /*
@@ -1654,7 +1012,7 @@ dss_parameters_set(unsigned int key_id, uint64_t value)
 			break;
 		}
 		D_WARN("set rebuild percentage to "DF_U64"\n", value);
-		dss_rebuild_res_percentage = value;
+		rc = sched_set_throttle(DSS_POOL_REBUILD, value);
 		break;
 	default:
 		D_ERROR("invalid key_id %d\n", key_id);
@@ -1834,9 +1192,6 @@ dss_dump_ABT_state()
 				"DAOS xstream %p, ABT xstream %p, sched %p\n",
 				rc, dx, dx->dx_xstream, dx->dx_sched);
 
-		/* only DSS_POOL_CNT (DSS_POOL_PRIV/DSS_POOL_SHARE/
-		 * DSS_POOL_REBUILD) per sched/xstream
-		 */
 		rc = ABT_sched_get_num_pools(dx->dx_sched, &num_pools);
 		if (rc != ABT_SUCCESS) {
 			D_ERROR("ABT_sched_get_num_pools() error, rc = %d, for "
@@ -1887,7 +1242,7 @@ dss_dump_ABT_state()
 void
 dss_gc_run(daos_handle_t poh, int credits)
 {
-	struct dss_xstream *dxs	 = dss_get_xstream();
+	struct dss_xstream *dxs	 = dss_current_xstream();
 	int		    total = 0;
 
 	while (1) {
@@ -1927,7 +1282,7 @@ dss_gc_run(daos_handle_t poh, int credits)
 static void
 dss_gc_ult(void *args)
 {
-	 struct dss_xstream *dxs  = dss_get_xstream();
+	 struct dss_xstream *dxs  = dss_current_xstream();
 
 	 while (!dss_xstream_exiting(dxs)) {
 		/* -1 means GC will run until there is nothing to do */

--- a/src/iosrv/ult.c
+++ b/src/iosrv/ult.c
@@ -1,0 +1,538 @@
+/**
+ * (C) Copyright 2016-2019 Intel Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * GOVERNMENT LICENSE RIGHTS-OPEN SOURCE SOFTWARE
+ * The Government's rights to use, modify, reproduce, release, perform, display,
+ * or disclose this software are subject to the terms of the Apache License as
+ * provided in Contract No. B609815.
+ * Any reproduction of computer software, computer software documentation, or
+ * portions thereof marked with this legend must also reproduce the markings.
+ */
+
+#define D_LOGFAC       DD_FAC(server)
+
+#include <abt.h>
+#include <daos/common.h>
+#include <daos_errno.h>
+#include "srv_internal.h"
+
+/* ============== Thread collective functions ============================ */
+
+struct aggregator_arg_type {
+	struct dss_stream_arg_type	at_args;
+	void				(*at_reduce)(void *a_args,
+						     void *s_args);
+	int				at_rc;
+	int				at_xs_nr;
+};
+
+/**
+ * Collective operations among all server xstreams
+ */
+struct dss_future_arg {
+	ABT_future	dfa_future;
+	int		(*dfa_func)(void *);
+	void		*dfa_arg;
+	/** User callback for asynchronous mode */
+	void		(*dfa_comp_cb)(void *);
+	/** Argument for the user callback */
+	void		*dfa_comp_arg;
+	int		dfa_status;
+	bool		dfa_async;
+};
+
+struct collective_arg {
+	struct dss_future_arg		ca_future;
+};
+
+static void
+collective_func(void *varg)
+{
+	struct dss_stream_arg_type	*a_args	= varg;
+	struct collective_arg		*carg	= a_args->st_coll_args;
+	struct dss_future_arg		*f_arg	= &carg->ca_future;
+	int				rc;
+
+	/** Update just the rc value */
+	a_args->st_rc = f_arg->dfa_func(f_arg->dfa_arg);
+
+	rc = ABT_future_set(f_arg->dfa_future, (void *)a_args);
+	if (rc != ABT_SUCCESS)
+		D_ERROR("future set failure %d\n", rc);
+}
+
+/* Reduce the return codes into the first element. */
+static void
+collective_reduce(void **arg)
+{
+	struct aggregator_arg_type	*aggregator;
+	struct dss_stream_arg_type	*stream;
+	int				*nfailed;
+	int				 i;
+
+	aggregator = (struct aggregator_arg_type *)arg[0];
+	nfailed = &aggregator->at_args.st_rc;
+
+	for (i = 1; i < aggregator->at_xs_nr + 1; i++) {
+		stream = (struct dss_stream_arg_type *)arg[i];
+		if (stream->st_rc != 0) {
+			if (aggregator->at_rc == 0)
+				aggregator->at_rc = stream->st_rc;
+			(*nfailed)++;
+		}
+
+		/** optional custom aggregator call provided across streams */
+		if (aggregator->at_reduce)
+			aggregator->at_reduce(aggregator->at_args.st_arg,
+					      stream->st_arg);
+	}
+}
+
+static int
+dss_collective_reduce_internal(struct dss_coll_ops *ops,
+			       struct dss_coll_args *args, bool create_ult,
+			       int flag)
+{
+	struct collective_arg		carg;
+	struct dss_coll_stream_args	*stream_args;
+	struct dss_stream_arg_type	*stream;
+	struct aggregator_arg_type	aggregator;
+	struct dss_xstream		*dx;
+	ABT_future			future;
+	int				xs_nr;
+	int				rc;
+	int				tid;
+
+	if (ops == NULL || args == NULL || ops->co_func == NULL) {
+		D_DEBUG(DB_MD, "mandatory args mising dss_collective_reduce");
+		return -DER_INVAL;
+	}
+
+	if (ops->co_reduce_arg_alloc != NULL &&
+	    ops->co_reduce_arg_free == NULL) {
+		D_DEBUG(DB_MD, "Free callback missing for reduce args\n");
+		return -DER_INVAL;
+	}
+
+	if (dss_tgt_nr == 0) {
+		/* May happen when the server is shutting down. */
+		D_DEBUG(DB_TRACE, "no xstreams\n");
+		return -DER_CANCELED;
+	}
+
+	xs_nr = dss_tgt_nr;
+	stream_args = &args->ca_stream_args;
+	D_ALLOC_ARRAY(stream_args->csa_streams, xs_nr);
+	if (stream_args->csa_streams == NULL)
+		return -DER_NOMEM;
+
+	/*
+	 * Use the first, extra element of the value array to store the number
+	 * of failed tasks.
+	 */
+	rc = ABT_future_create(xs_nr + 1, collective_reduce, &future);
+	if (rc != ABT_SUCCESS)
+		D_GOTO(out_streams, rc = dss_abterr2der(rc));
+
+	carg.ca_future.dfa_future = future;
+	carg.ca_future.dfa_func	= ops->co_func;
+	carg.ca_future.dfa_arg	= args->ca_func_args;
+	carg.ca_future.dfa_status = 0;
+
+	memset(&aggregator, 0, sizeof(aggregator));
+	aggregator.at_xs_nr = xs_nr;
+	if (ops->co_reduce) {
+		aggregator.at_args.st_arg = args->ca_aggregator;
+		aggregator.at_reduce	  = ops->co_reduce;
+	}
+
+	if (ops->co_reduce_arg_alloc)
+		for (tid = 0; tid < xs_nr; tid++) {
+			stream = &stream_args->csa_streams[tid];
+			rc = ops->co_reduce_arg_alloc(stream,
+						     aggregator.at_args.st_arg);
+			if (rc)
+				D_GOTO(out_future, rc);
+		}
+
+	rc = ABT_future_set(future, (void *)&aggregator);
+	D_ASSERTF(rc == ABT_SUCCESS, "%d\n", rc);
+
+	for (tid = 0; tid < xs_nr; tid++) {
+		stream			= &stream_args->csa_streams[tid];
+		stream->st_coll_args	= &carg;
+
+		if (args->ca_exclude_tgts_cnt) {
+			int i;
+
+			for (i = 0; i < args->ca_exclude_tgts_cnt; i++)
+				if (args->ca_exclude_tgts[i] == tid)
+					break;
+
+			if (i < args->ca_exclude_tgts_cnt) {
+				D_DEBUG(DB_TRACE, "Skip tgt %d\n", tid);
+				rc = ABT_future_set(future, (void *)stream);
+				D_ASSERTF(rc == ABT_SUCCESS, "%d\n", rc);
+				continue;
+			}
+		}
+
+		dx = dss_get_xstream(DSS_MAIN_XS_ID(tid));
+		if (create_ult)
+			rc = ABT_thread_create(dx->dx_pools[DSS_POOL_IO],
+					       collective_func, stream,
+					       ABT_THREAD_ATTR_NULL, NULL);
+		else
+			rc = ABT_task_create(dx->dx_pools[DSS_POOL_IO],
+					     collective_func, stream, NULL);
+
+		if (rc != ABT_SUCCESS) {
+			stream->st_rc = dss_abterr2der(rc);
+			rc = ABT_future_set(future, (void *)stream);
+			D_ASSERTF(rc == ABT_SUCCESS, "%d\n", rc);
+		}
+	}
+
+	ABT_future_wait(future);
+
+	rc = aggregator.at_rc;
+
+out_future:
+	ABT_future_free(&future);
+
+	if (ops->co_reduce_arg_free)
+		for (tid = 0; tid < xs_nr; tid++)
+			ops->co_reduce_arg_free(&stream_args->csa_streams[tid]);
+
+out_streams:
+	D_FREE(args->ca_stream_args.csa_streams);
+
+	return rc;
+}
+
+/**
+ * General case:
+ * Execute \a task(\a arg) collectively on all server xstreams. Can only be
+ * called by ULTs. Can only execute tasklet-compatible functions. User specified
+ * reduction functions for aggregation after collective
+ *
+ * \param[in] ops		All dss_collective ops to work on streams
+ *				include \a func(\a arg) for collective on all
+ *				server xstreams.
+ * \param[in] args		All arguments required for dss_collective
+ *				including func args.
+ * \param[in] flag		collective flag, reserved for future usage.
+ *
+ * \return			number of failed xstreams or error code
+ */
+int
+dss_task_collective_reduce(struct dss_coll_ops *ops,
+			   struct dss_coll_args *args, int flag)
+{
+	return dss_collective_reduce_internal(ops, args, false, flag);
+}
+
+/**
+ * General case:
+ * Execute \a ULT(\a arg) collectively on all server xstreams. Can only be
+ * called by ULTs. Can only execute tasklet-compatible functions. User specified
+ * reduction functions for aggregation after collective
+ *
+ * \param[in] ops		All dss_collective ops to work on streams
+ *				include \a func(\a arg) for collective on all
+ *				server xstreams.
+ * \param[in] args		All arguments required for dss_collective
+ *				including func args.
+ * \param[in] flag		collective flag, reserved for future usage.
+ *
+ * \return			number of failed xstreams or error code
+ */
+int
+dss_thread_collective_reduce(struct dss_coll_ops *ops,
+			     struct dss_coll_args *args, int flag)
+{
+	return dss_collective_reduce_internal(ops, args, true, flag);
+}
+
+static int
+dss_collective_internal(int (*func)(void *), void *arg, bool thread, int flag)
+{
+	int				rc;
+	struct dss_coll_ops		coll_ops = { 0 };
+	struct dss_coll_args		coll_args = { 0 };
+
+	coll_ops.co_func	= func;
+	coll_args.ca_func_args	= arg;
+
+	if (thread)
+		rc = dss_thread_collective_reduce(&coll_ops, &coll_args, flag);
+	else
+		rc = dss_task_collective_reduce(&coll_ops, &coll_args, flag);
+
+	return rc;
+}
+
+
+/**
+ * Execute \a func(\a arg) collectively on all server xstreams. Can only be
+ * called by ULTs. Can only execute tasklet-compatible functions.
+ *
+ * \param[in] func	function to be executed
+ * \param[in] arg	argument to be passed to \a func
+ * \param[in] flag	collective flag, reserved for future usage.
+ *
+ * \return		number of failed xstreams or error code
+ */
+int
+dss_task_collective(int (*func)(void *), void *arg, int flag)
+{
+	return dss_collective_internal(func, arg, false, flag);
+}
+
+/**
+ * Execute \a func(\a arg) collectively on all server xstreams. Can only be
+ * called by ULTs. Can only execute tasklet-compatible functions.
+ *
+ * \param[in] func	function to be executed
+ * \param[in] arg	argument to be passed to \a func
+ * \param[in] flag	collective flag, reserved for future usage.
+ *
+ * \return		number of failed xstreams or error code
+ */
+
+int
+dss_thread_collective(int (*func)(void *), void *arg, int flag)
+{
+	return dss_collective_internal(func, arg, true, flag);
+}
+
+/* ============== ULT create functions =================================== */
+
+static inline int
+sched_ult2pool(int ult_type)
+{
+	switch (ult_type) {
+	case DSS_ULT_DTX_RESYNC:
+	case DSS_ULT_IOFW:
+	case DSS_ULT_EC:
+	case DSS_ULT_CHECKSUM:
+	case DSS_ULT_COMPRESS:
+	case DSS_ULT_POOL_SRV:
+	case DSS_ULT_DRPC_LISTENER:
+	case DSS_ULT_RDB:
+	case DSS_ULT_DRPC_HANDLER:
+	case DSS_ULT_MISC:
+		return DSS_POOL_IO;
+	case DSS_ULT_REBUILD:
+		return DSS_POOL_REBUILD;
+	case DSS_ULT_AGGREGATE:
+		return DSS_POOL_AGGREGATE;
+	case DSS_ULT_GC:
+		return DSS_POOL_GC;
+	default:
+		D_ASSERTF(0, "Invalid ULT type %d.\n", ult_type);
+		return -DER_INVAL;
+	}
+}
+
+static inline int
+sched_ult2xs(int ult_type, int tgt_id)
+{
+	if (tgt_id == DSS_TGT_SELF || ult_type == DSS_ULT_DTX_RESYNC)
+		return DSS_XS_SELF;
+
+	D_ASSERT(tgt_id >= 0 && tgt_id < dss_tgt_nr);
+	switch (ult_type) {
+	case DSS_ULT_IOFW:
+	case DSS_ULT_MISC:
+		return (DSS_MAIN_XS_ID(tgt_id) + 1) % DSS_XS_NR_TOTAL;
+	case DSS_ULT_EC:
+	case DSS_ULT_CHECKSUM:
+	case DSS_ULT_COMPRESS:
+		return DSS_MAIN_XS_ID(tgt_id) + dss_tgt_offload_xs_nr;
+	case DSS_ULT_POOL_SRV:
+	case DSS_ULT_RDB:
+	case DSS_ULT_DRPC_HANDLER:
+		return 0;
+	case DSS_ULT_DRPC_LISTENER:
+		return 1;
+	case DSS_ULT_REBUILD:
+	case DSS_ULT_AGGREGATE:
+	case DSS_ULT_GC:
+		return DSS_MAIN_XS_ID(tgt_id);
+	default:
+		D_ASSERTF(0, "Invalid ULT type %d.\n", ult_type);
+		return -DER_INVAL;
+	}
+}
+
+/**
+ * Create a ULT to execute \a func(\a arg). If \a ult is not NULL, the caller
+ * is responsible for freeing the ULT handle with ABT_thread_free().
+ *
+ * \param[in]	func		function to execute
+ * \param[in]	arg		argument for \a func
+ * \param[in]	ult_type	ULT type
+ * \param[in]	tgt_idx		VOS target index
+ * \param[in]	stack_size	stacksize of the ULT, if it is 0, then create
+ *				default size of ULT.
+ * \param[out]	ult		ULT handle if not NULL
+ */
+int
+dss_ult_create(void (*func)(void *), void *arg, int ult_type, int tgt_idx,
+	       size_t stack_size, ABT_thread *ult)
+{
+	ABT_thread_attr		 attr;
+	struct dss_xstream	*dx;
+	int			 rc, rc1;
+
+	dx = dss_get_xstream(sched_ult2xs(ult_type, tgt_idx));
+	if (dx == NULL)
+		return -DER_NONEXIST;
+
+	if (stack_size > 0) {
+		rc = ABT_thread_attr_create(&attr);
+		if (rc != ABT_SUCCESS)
+			return dss_abterr2der(rc);
+
+		rc = ABT_thread_attr_set_stacksize(attr, stack_size);
+		if (rc != ABT_SUCCESS)
+			D_GOTO(free, rc = dss_abterr2der(rc));
+
+		D_DEBUG(DB_TRACE, "Create ult stacksize is %zd\n", stack_size);
+	} else {
+		attr = ABT_THREAD_ATTR_NULL;
+	}
+
+	rc = ABT_thread_create(dx->dx_pools[sched_ult2pool(ult_type)], func,
+			       arg, attr, ult);
+
+free:
+	if (attr != ABT_THREAD_ATTR_NULL) {
+		rc1 = ABT_thread_attr_free(&attr);
+		if (rc == ABT_SUCCESS)
+			rc = rc1;
+	}
+
+	return dss_abterr2der(rc);
+}
+
+static void
+ult_execute_cb(void *data)
+{
+	struct dss_future_arg	*arg = data;
+	int			rc;
+
+	rc = arg->dfa_func(arg->dfa_arg);
+	arg->dfa_status = rc;
+
+	if (!arg->dfa_async)
+		ABT_future_set(arg->dfa_future, (void *)(intptr_t)rc);
+	else
+		arg->dfa_comp_cb(arg->dfa_comp_arg);
+}
+
+/**
+ * Execute a function in a separate ULT synchornously or asynchronously.
+ *
+ * Sync: wait until it has been executed.
+ * Async: return and call user callback from ULT.
+ * Note: This is normally used when it needs to create an ULT on other
+ * xstream.
+ *
+ * \param[in]	func		function to execute
+ * \param[in]	arg		argument for \a func
+ * \param[in]	user_cb		user call back (mandatory for async mode)
+ * \param[in]	arg		argument for \a user callback
+ * \param[in]	ult_type	type of ULT
+ * \param[in]	tgt_id		target index
+ * \param[out]			error code.
+ */
+int
+dss_ult_execute(int (*func)(void *), void *arg, void (*user_cb)(void *),
+		void *cb_args, int ult_type, int tgt_id, size_t stack_size)
+{
+	struct dss_future_arg	future_arg;
+	ABT_future		future;
+	int			rc;
+
+	memset(&future_arg, 0, sizeof(future_arg));
+	future_arg.dfa_func = func;
+	future_arg.dfa_arg = arg;
+	future_arg.dfa_status = 0;
+
+	if (user_cb == NULL) {
+		rc = ABT_future_create(1, NULL, &future);
+		if (rc != ABT_SUCCESS)
+			return dss_abterr2der(rc);
+		future_arg.dfa_future = future;
+		future_arg.dfa_async  = false;
+	} else {
+		future_arg.dfa_comp_cb	= user_cb;
+		future_arg.dfa_comp_arg = cb_args;
+		future_arg.dfa_async	= true;
+	}
+
+	rc = dss_ult_create(ult_execute_cb, &future_arg, ult_type, tgt_id,
+			    stack_size, NULL);
+	if (rc)
+		D_GOTO(free, rc);
+
+	if (!future_arg.dfa_async)
+		ABT_future_wait(future);
+free:
+	if (rc == 0)
+		rc = future_arg.dfa_status;
+
+	if (!future_arg.dfa_async)
+		ABT_future_free(&future);
+
+	return rc;
+}
+
+/**
+ * Create an ULT on each server xstream to execute a \a func(\a arg)
+ *
+ * \param[in] func	function to be executed
+ * \param[in] arg	argument to be passed to \a func
+ * \param[in] ult_type	ULT type
+ * \param[in] main	only create ULT on main XS or not.
+ *
+ * \return		Success or negative error code
+ *			0
+ *			-DER_NOMEM
+ *			-DER_INVAL
+ */
+int
+dss_ult_create_all(void (*func)(void *), void *arg, int ult_type, bool main)
+{
+	struct dss_xstream      *dx;
+	int			 i, rc = 0;
+
+	for (i = 0; i < dss_xstream_cnt(); i++) {
+		dx = dss_get_xstream(i);
+		if (main && !dx->dx_main_xs)
+			continue;
+
+		rc = ABT_thread_create(dx->dx_pools[sched_ult2pool(ult_type)],
+				       func, arg, ABT_THREAD_ATTR_NULL, NULL);
+		if (rc != ABT_SUCCESS) {
+			rc = dss_abterr2der(rc);
+			break;
+		}
+	}
+
+	return rc;
+}

--- a/src/object/obj_internal.h
+++ b/src/object/obj_internal.h
@@ -366,7 +366,6 @@ void ds_obj_punch_handler(crt_rpc_t *rpc);
 void ds_obj_tgt_punch_handler(crt_rpc_t *rpc);
 void ds_obj_query_key_handler(crt_rpc_t *rpc);
 void ds_obj_sync_handler(crt_rpc_t *rpc);
-ABT_pool ds_obj_abt_pool_choose_cb(crt_rpc_t *rpc, ABT_pool *pools);
 typedef int (*ds_iofw_cb_t)(crt_rpc_t *req, void *arg);
 
 static inline uint64_t

--- a/src/object/srv_mod.c
+++ b/src/object/srv_mod.c
@@ -153,7 +153,7 @@ struct dss_module_key obj_module_key = {
 };
 
 static struct dss_module_ops ds_obj_mod_ops = {
-	.dms_abt_pool_choose_cb = ds_obj_abt_pool_choose_cb,
+	.dms_abt_pool_choose_cb = NULL,
 	.dms_profile_start = ds_obj_profile_start,
 	.dms_profile_stop = ds_obj_profile_stop,
 };

--- a/src/object/srv_obj.c
+++ b/src/object/srv_obj.c
@@ -2053,35 +2053,6 @@ out:
 		D_ERROR("send reply failed: "DF_RC"\n", DP_RC(rc));
 }
 
-/**
- * Choose abt pools for object RPC. Because those update RPC might create pool
- * map refresh ULT, let's put it to share pool. For other RPC, it can be put to
- * the private pool. XXX we might just instruct the server create task for
- * inline I/O.
- */
-ABT_pool
-ds_obj_abt_pool_choose_cb(crt_rpc_t *rpc, ABT_pool *pools)
-{
-	ABT_pool	pool;
-
-	switch (opc_get(rpc->cr_opc)) {
-	case DAOS_OBJ_RPC_ENUMERATE:
-	case DAOS_OBJ_RPC_PUNCH:
-	case DAOS_OBJ_RPC_PUNCH_DKEYS:
-	case DAOS_OBJ_RPC_PUNCH_AKEYS:
-	case DAOS_OBJ_RPC_UPDATE:
-	case DAOS_OBJ_RPC_TGT_UPDATE:
-	case DAOS_OBJ_RPC_FETCH:
-		pool = pools[DSS_POOL_SHARE];
-		break;
-	default:
-		pool = pools[DSS_POOL_PRIV];
-		break;
-	};
-
-	return pool;
-}
-
 static int
 cont_prop_srv_verify(struct ds_iv_ns *ns, uuid_t co_hdl)
 {


### PR DESCRIPTION
Imporve iosrv scheduler:
- Redefined ABT pools based on ULT job type, basically the ULTs
  with same priority will be put into same ABT pool;
- In original scheduler, rebuild ULTs always have 30% percent
  chance to be scheduled regardless of current IO workload, it's
  fixed in this patch;
- Scheduler is now able to control the frequency of network &
  NVMe poll, and dynamically throttle certain type ULTs depends
  on request/IO statistics or space pressure;

Code cleanup:
- Move scheduler code into sched.c
- Move the thread collective & ult create code into ult.c;
- Move the ABT pools definition from daos_server.h to srv_internal.h;

TODO:
- Revise dss_srv_handler() to make it a pure network poll ULT;
- Adjust hardware poll freqency according to request/IO statistics;
- Throttle IO ULTs on space pressure;

Signed-off-by: Niu Yawei <yawei.niu@intel.com>