### PR TITLE
DAOS-2447 obj: refine EC handing for evenly distribution case

### DIFF
--- a/src/object/cli_obj.c
+++ b/src/object/cli_obj.c
@@ -625,19 +625,23 @@ obj_reasb_req_fini(struct obj_auxi_args *obj_auxi)
 {
 	struct obj_reasb_req		*reasb_req = &obj_auxi->reasb_req;
 	daos_iod_t			*iod;
+	struct obj_io_desc		*oiod;
 	int				 i;
 
 	for (i = 0; i < obj_auxi->iod_nr; i++) {
 		iod = reasb_req->orr_iods + i;
+		oiod = reasb_req->orr_oiods + i;
 		if (iod == NULL)
 			return;
 		if (iod->iod_recxs != NULL)
 			D_FREE(iod->iod_recxs);
 		/* iod_csums freed by obj_update_csum_destroy() */
-		if (iod->iod_eprs != NULL)
-			D_FREE(iod->iod_eprs);
+		if ((oiod->oiod_flags & OBJ_SIOD_EVEN_DIST) == 0) {
+			if (iod->iod_eprs != NULL)
+				D_FREE(iod->iod_eprs);
+		}
 		daos_sgl_fini(reasb_req->orr_sgls + i, false);
-		obj_io_desc_fini(reasb_req->orr_oiods + i);
+		obj_io_desc_fini(oiod);
 		obj_ec_recxs_fini(&reasb_req->orr_recxs[i]);
 		obj_ec_seg_sorter_fini(&reasb_req->orr_sorters[i]);
 		obj_ec_tgt_oiod_fini(reasb_req->tgt_oiods);
@@ -2306,9 +2310,6 @@ shard_rw_prep(struct shard_auxi_args *shard_auxi, struct dc_object *obj,
 				shard_auxi->shard - shard_auxi->start_shard);
 			D_ASSERT(toiod != NULL);
 			shard_arg->oiods = toiod->oto_oiods;
-			D_ASSERT(shard_arg->oiods[0].oiod_nr == 1 &&
-				 (shard_arg->oiods[0].oiod_flags &
-				  OBJ_SIOD_PROC_ONE) != 0);
 			shard_arg->offs = toiod->oto_offs;
 			D_ASSERT(shard_arg->offs != NULL);
 		} else {

--- a/src/object/obj_internal.h
+++ b/src/object/obj_internal.h
@@ -49,13 +49,6 @@
  */
 #define IO_BYPASS_ENV	"DAOS_IO_BYPASS"
 
-/* EC parity is stored in a private address range that is selected by setting
- * the most-significant bit of the offset (an unsigned long). This effectively
- * limits the addressing of user extents to the lower 63 bits of the offset
- * range. The client stack should enforce this limitation.
- */
-#define PARITY_INDICATOR (1UL << 63)
-
 /**
  * Bypass client I/O RPC, it means the client stack will complete the
  * fetch/update RPC immediately, nothing will be submitted to remote server.

--- a/src/object/obj_rpc.h
+++ b/src/object/obj_rpc.h
@@ -46,6 +46,13 @@
  */
 #define OBJ_BULK_LIMIT	(3584) /* (3K + 512) bytes */
 
+/* EC parity is stored in a private address range that is selected by setting
+ * the most-significant bit of the offset (an unsigned long). This effectively
+ * limits the addressing of user extents to the lower 63 bits of the offset
+ * range. The client stack should enforce this limitation.
+ */
+#define PARITY_INDICATOR (1UL << 63)
+
 /*
  * RPC operation codes
  *


### PR DESCRIPTION
When the recxs evenly distributed to all targets for update, or all
data targets for fetch, need not regenerate new IOD/recxs or siods to
save RPC size.
It is helpful for singv handing as well as it is even distribution for
most cases.

Met a problem for checksum calculation, probably this patch is not very
helpful and make the code more complex. Upload just for backup now, can
pick it up later when needed.

Signed-off-by: Xuezhao Liu <xuezhao.liu@intel.com>