### PR TITLE
DAOS-2070 vos: remove vos_tx_begin/end

### DIFF
--- a/src/include/daos/mem.h
+++ b/src/include/daos/mem.h
@@ -410,6 +410,15 @@ umem_tx_abort(struct umem_instance *umm, int err)
 		return 0;
 }
 
+static inline int
+umem_tx_end(struct umem_instance *umm, int err)
+{
+	if (err)
+		return umem_tx_abort(umm, err);
+	else
+		return umem_tx_commit(umm);
+}
+
 static inline umem_off_t
 umem_reserve(struct umem_instance *umm, struct pobj_action *act, size_t size)
 {

--- a/src/include/daos_srv/daos_server.h
+++ b/src/include/daos_srv/daos_server.h
@@ -650,8 +650,6 @@ void dss_init_state_set(enum dss_init_state state);
  */
 void dss_gc_run(daos_handle_t poh, int credits);
 
-bool dss_agg_disabled(void);
-
 int notify_bio_error(bool unmap, bool update, int tgt_id);
 
 #endif /* __DSS_API_H__ */

--- a/src/vos/ilog.c
+++ b/src/vos/ilog.c
@@ -367,7 +367,7 @@ ilog_tx_begin(struct ilog_context *lctx)
 	if (lctx->ic_in_txn)
 		return 0;
 
-	rc = vos_tx_begin(&lctx->ic_umm);
+	rc = umem_tx_begin(&lctx->ic_umm, NULL);
 	if (rc != 0)
 		return rc;
 
@@ -400,7 +400,7 @@ ilog_tx_end(struct ilog_context *lctx, int rc)
 
 done:
 	lctx->ic_in_txn = false;
-	return vos_tx_end(&lctx->ic_umm, rc);
+	return umem_tx_end(&lctx->ic_umm, rc);
 }
 
 static inline bool

--- a/src/vos/tests/vts_ilog.c
+++ b/src/vos/tests/vts_ilog.c
@@ -44,7 +44,7 @@ ilog_alloc_root(struct umem_instance *umm)
 	int		 rc = 0;
 	umem_off_t	 ilog_off = UMOFF_NULL;
 
-	rc = vos_tx_begin(umm);
+	rc = umem_tx_begin(umm, NULL);
 	if (rc != 0) {
 		print_message("Tx begin failed\n");
 		goto done;
@@ -56,7 +56,7 @@ ilog_alloc_root(struct umem_instance *umm)
 		rc = -DER_NOSPACE;
 	}
 
-	rc = vos_tx_end(umm, rc);
+	rc = umem_tx_end(umm, rc);
 done:
 	assert_int_equal(rc, 0);
 
@@ -68,7 +68,7 @@ ilog_free_root(struct umem_instance *umm, struct ilog_df *ilog)
 {
 	int		 rc = 0;
 
-	rc = vos_tx_begin(umm);
+	rc = umem_tx_begin(umm, NULL);
 	if (rc != 0) {
 		print_message("Tx begin failed\n");
 		goto done;
@@ -76,7 +76,7 @@ ilog_free_root(struct umem_instance *umm, struct ilog_df *ilog)
 
 	rc = umem_free(umm, umem_ptr2off(umm, ilog));
 
-	rc = vos_tx_end(umm, rc);
+	rc = umem_tx_end(umm, rc);
 done:
 	assert_int_equal(rc, 0);
 }

--- a/src/vos/vos_container.c
+++ b/src/vos/vos_container.c
@@ -296,7 +296,7 @@ vos_cont_create(daos_handle_t poh, uuid_t co_uuid)
 		D_GOTO(exit, rc = -DER_EXIST);
 	}
 
-	rc = vos_tx_begin(vos_pool2umm(vpool));
+	rc = umem_tx_begin(vos_pool2umm(vpool), NULL);
 	if (rc != 0)
 		goto exit;
 
@@ -305,7 +305,7 @@ vos_cont_create(daos_handle_t poh, uuid_t co_uuid)
 
 	rc = dbtree_update(vpool->vp_cont_th, &key, &value);
 
-	rc = vos_tx_end(vos_pool2umm(vpool), rc);
+	rc = umem_tx_end(vos_pool2umm(vpool), rc);
 exit:
 	return rc;
 }
@@ -584,7 +584,7 @@ vos_cont_destroy(daos_handle_t poh, uuid_t co_uuid)
 		D_GOTO(exit, rc);
 	}
 
-	rc = vos_tx_begin(vos_pool2umm(pool));
+	rc = umem_tx_begin(vos_pool2umm(pool), NULL);
 	if (rc) {
 		D_ERROR("Failed to start pmdk transaction: "DF_RC"\n",
 			DP_RC(rc));
@@ -594,7 +594,7 @@ vos_cont_destroy(daos_handle_t poh, uuid_t co_uuid)
 	d_iov_set(&iov, &key, sizeof(struct d_uuid));
 	rc = dbtree_delete(pool->vp_cont_th, BTR_PROBE_EQ, &iov, NULL);
 
-	rc = vos_tx_end(vos_pool2umm(pool), rc);
+	rc = umem_tx_end(vos_pool2umm(pool), rc);
 	if (rc) {
 		D_ERROR("Failed to end pmdk transaction: "DF_RC"\n", DP_RC(rc));
 		D_GOTO(exit, rc);

--- a/src/vos/vos_dtx.c
+++ b/src/vos/vos_dtx.c
@@ -1379,10 +1379,10 @@ vos_dtx_commit(daos_handle_t coh, struct dtx_id *dtis, int count)
 	D_ASSERT(cont != NULL);
 
 	/* Commit multiple DTXs via single PMDK transaction. */
-	rc = vos_tx_begin(vos_cont2umm(cont));
+	rc = umem_tx_begin(vos_cont2umm(cont), NULL);
 	if (rc == 0) {
 		rc = vos_dtx_commit_internal(cont, dtis, count, 0);
-		rc = vos_tx_end(vos_cont2umm(cont), rc);
+		rc = umem_tx_end(vos_cont2umm(cont), rc);
 	}
 
 	return rc;
@@ -1400,7 +1400,7 @@ vos_dtx_abort(daos_handle_t coh, daos_epoch_t epoch, struct dtx_id *dtis,
 	D_ASSERT(cont != NULL);
 
 	/* Abort multiple DTXs via single PMDK transaction. */
-	rc = vos_tx_begin(vos_cont2umm(cont));
+	rc = umem_tx_begin(vos_cont2umm(cont), NULL);
 	if (rc == 0) {
 		int	aborted = 0;
 
@@ -1418,7 +1418,7 @@ vos_dtx_abort(daos_handle_t coh, daos_epoch_t epoch, struct dtx_id *dtis,
 		 * DRAM) even if we abort this PMDK transaction, then let's
 		 * commit the PMDK transaction anyway.
 		 */
-		rc = vos_tx_end(vos_cont2umm(cont), aborted > 0 ? 0 : rc);
+		rc = umem_tx_end(vos_cont2umm(cont), aborted > 0 ? 0 : rc);
 	}
 
 	return rc;
@@ -1447,7 +1447,7 @@ vos_dtx_aggregate(daos_handle_t coh)
 	if (dbd == NULL || dbd->dbd_count == 0)
 		return 0;
 
-	rc = vos_tx_begin(umm);
+	rc = umem_tx_begin(umm, NULL);
 	if (rc != 0)
 		return rc;
 
@@ -1483,7 +1483,7 @@ vos_dtx_aggregate(daos_handle_t coh)
 
 	umem_free(umm, dbd_off);
 
-	return vos_tx_end(umm, 0);
+	return umem_tx_end(umm, 0);
 }
 
 void

--- a/src/vos/vos_gc.c
+++ b/src/vos/vos_gc.c
@@ -576,7 +576,7 @@ gc_reclaim_pool(struct vos_pool *pool, int *credits, bool *empty_ret)
 		return 0;
 	}
 
-	rc = vos_tx_begin(&pool->vp_umm);
+	rc = umem_tx_begin(&pool->vp_umm, NULL);
 	if (rc) {
 		D_ERROR("Failed to start transacton for "DF_UUID": %s\n",
 			DP_UUID(pool->vp_id), d_errstr(rc));
@@ -633,7 +633,7 @@ gc_reclaim_pool(struct vos_pool *pool, int *credits, bool *empty_ret)
 		"pool="DF_UUID", creds origin=%d, current=%d, rc=%s\n",
 		DP_UUID(pool->vp_id), *credits, creds, d_errstr(rc));
 
-	rc = vos_tx_end(&pool->vp_umm, rc);
+	rc = umem_tx_end(&pool->vp_umm, rc);
 	if (rc == 0)
 		*credits = creds;
 

--- a/src/vos/vos_internal.h
+++ b/src/vos/vos_internal.h
@@ -975,22 +975,6 @@ vos_cont2umm(struct vos_container *cont)
 	return vos_pool2umm(cont->vc_pool);
 }
 
-static inline int
-vos_tx_begin(struct umem_instance *umm)
-{
-	return umem_tx_begin(umm, NULL);
-}
-
-static inline int
-vos_tx_end(struct umem_instance *umm, int rc)
-{
-	if (rc != 0)
-		return umem_tx_abort(umm, rc);
-
-	return umem_tx_commit(umm);
-
-}
-
 static inline uint32_t
 vos_iter_intent(struct vos_iterator *iter)
 {

--- a/src/vos/vos_obj.c
+++ b/src/vos/vos_obj.c
@@ -149,7 +149,7 @@ vos_obj_punch(daos_handle_t coh, daos_unit_oid_t oid, daos_epoch_t epoch,
 	vos_dth_set(dth);
 	cont = vos_hdl2cont(coh);
 
-	rc = vos_tx_begin(vos_cont2umm(cont));
+	rc = umem_tx_begin(vos_cont2umm(cont), NULL);
 	if (rc != 0)
 		goto reset;
 
@@ -175,7 +175,7 @@ vos_obj_punch(daos_handle_t coh, daos_unit_oid_t oid, daos_epoch_t epoch,
 	if (dth != NULL && rc == 0)
 		rc = vos_dtx_prepared(dth);
 
-	rc = vos_tx_end(vos_cont2umm(cont), rc);
+	rc = umem_tx_end(vos_cont2umm(cont), rc);
 	if (obj != NULL)
 		vos_obj_release(vos_obj_cache_current(), obj, rc != 0);
 
@@ -210,7 +210,7 @@ vos_obj_delete(daos_handle_t coh, daos_unit_oid_t oid)
 		return rc;
 	}
 
-	rc = vos_tx_begin(umm);
+	rc = umem_tx_begin(umm, NULL);
 	if (rc)
 		goto out;
 
@@ -218,7 +218,7 @@ vos_obj_delete(daos_handle_t coh, daos_unit_oid_t oid)
 	if (rc)
 		D_ERROR("Failed to delete object: %s\n", d_errstr(rc));
 
-	rc = vos_tx_end(umm, rc);
+	rc = umem_tx_end(umm, rc);
 	if (rc)
 		goto out;
 
@@ -1404,13 +1404,13 @@ obj_iter_delete(struct vos_obj_iter *oiter, void *args)
 
 	umm = vos_obj2umm(oiter->it_obj);
 
-	rc = vos_tx_begin(umm);
+	rc = umem_tx_begin(umm, NULL);
 	if (rc != 0)
 		goto exit;
 
 	rc = dbtree_iter_delete(oiter->it_hdl, args);
 
-	rc = vos_tx_end(umm, rc);
+	rc = umem_tx_end(umm, rc);
 exit:
 	if (rc != 0)
 		D_ERROR("Failed to delete iter entry: %d\n", rc);

--- a/src/vos/vos_obj_index.c
+++ b/src/vos/vos_obj_index.c
@@ -610,13 +610,13 @@ oi_iter_delete(struct vos_iterator *iter, void *args)
 
 	D_ASSERT(iter->it_type == VOS_ITER_OBJ);
 
-	rc = vos_tx_begin(vos_cont2umm(oiter->oit_cont));
+	rc = umem_tx_begin(vos_cont2umm(oiter->oit_cont), NULL);
 	if (rc != 0)
 		goto exit;
 
 	rc = dbtree_iter_delete(oiter->oit_hdl, args);
 
-	rc = vos_tx_end(vos_cont2umm(oiter->oit_cont), rc);
+	rc = umem_tx_end(vos_cont2umm(oiter->oit_cont), rc);
 
 	if (rc != 0)
 		D_ERROR("Failed to delete oid entry: %d\n", rc);


### PR DESCRIPTION
This is the first step of separating dtx and vos_dtx, dtx is the
2PC library, vos_dtx is more about transaction API which can group
multiple VOS operations as atomic one.

- add a new wrapper function umem_tx_finish, it can either commit
  or abort pmdk transaction based on error code
- replace vos_tx_begin with umem_tx_begin, vos_tx_end with
  umem_tx_finish, vos_tx is reserved for undo log API which groups
  multiple VOS operations.

Signed-off-by: Liang Zhen <liang.zhen@intel.com>