### PR TITLE
DAOS-3940 control: Move TableFormatter into txtfmt package

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -159,7 +159,7 @@ pipeline {
                     steps {
                         checkPatch user: GITHUB_USER_USR,
                                    password: GITHUB_USER_PSW,
-                                   ignored_files: "src/control/vendor/*:src/include/daos/*.pb-c.h:src/common/*.pb-c.[ch]:src/mgmt/*.pb-c.[ch]:src/iosrv/*.pb-c.[ch]:src/security/*.pb-c.[ch]:*.crt:*.pem"
+                                   ignored_files: "src/control/vendor/*:src/include/daos/*.pb-c.h:src/common/*.pb-c.[ch]:src/mgmt/*.pb-c.[ch]:src/iosrv/*.pb-c.[ch]:src/security/*.pb-c.[ch]:*.crt:*.pem:*_test.go"
                     }
                     post {
                         always {

--- a/src/control/cmd/dmg/storage_tables.go
+++ b/src/control/cmd/dmg/storage_tables.go
@@ -1,5 +1,5 @@
 //
-// (C) Copyright 2019 Intel Corporation.
+// (C) Copyright 2019-2020 Intel Corporation.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -31,6 +31,7 @@ import (
 	bytesize "github.com/inhies/go-bytesize"
 
 	"github.com/daos-stack/daos/src/control/common/proto"
+	"github.com/daos-stack/daos/src/control/lib/txtfmt"
 	"github.com/daos-stack/daos/src/control/server/storage"
 )
 
@@ -49,15 +50,15 @@ func scmModuleScanTable(ms storage.ScmModules) string {
 	slotTitle := "Channel Slot"
 	capacityTitle := "Capacity"
 
-	formatter := NewTableFormatter([]string{
+	formatter := txtfmt.NewTableFormatter(
 		physicalIdTitle, socketTitle, memCtrlrTitle, channelTitle, slotTitle, capacityTitle,
-	})
-	var table []TableRow
+	)
+	var table []txtfmt.TableRow
 
 	sort.Slice(ms, func(i, j int) bool { return ms[i].PhysicalID < ms[j].PhysicalID })
 
 	for _, m := range ms {
-		row := TableRow{physicalIdTitle: fmt.Sprint(m.PhysicalID)}
+		row := txtfmt.TableRow{physicalIdTitle: fmt.Sprint(m.PhysicalID)}
 		row[socketTitle] = fmt.Sprint(m.SocketID)
 		row[memCtrlrTitle] = fmt.Sprint(m.ControllerID)
 		row[channelTitle] = fmt.Sprint(m.ChannelID)
@@ -84,13 +85,13 @@ func scmNsScanTable(nss storage.ScmNamespaces) string {
 	socketTitle := "Socket ID"
 	capacityTitle := "Capacity"
 
-	formatter := NewTableFormatter([]string{deviceTitle, socketTitle, capacityTitle})
-	var table []TableRow
+	formatter := txtfmt.NewTableFormatter(deviceTitle, socketTitle, capacityTitle)
+	var table []txtfmt.TableRow
 
 	sort.Slice(nss, func(i, j int) bool { return nss[i].BlockDevice < nss[j].BlockDevice })
 
 	for _, ns := range nss {
-		row := TableRow{deviceTitle: ns.BlockDevice}
+		row := txtfmt.TableRow{deviceTitle: ns.BlockDevice}
 		row[socketTitle] = fmt.Sprint(ns.NumaNode)
 		row[capacityTitle] = bytesize.New(float64(ns.Size)).String()
 
@@ -113,13 +114,13 @@ func scmFormatTable(smr proto.ScmMountResults) string {
 	mntTitle := "SCM Mount"
 	resultTitle := "Format Result"
 
-	formatter := NewTableFormatter([]string{mntTitle, resultTitle})
-	var table []TableRow
+	formatter := txtfmt.NewTableFormatter(mntTitle, resultTitle)
+	var table []txtfmt.TableRow
 
 	sort.Slice(smr, func(i, j int) bool { return smr[i].Mntpoint < smr[j].Mntpoint })
 
 	for _, mnt := range smr {
-		row := TableRow{mntTitle: mnt.Mntpoint}
+		row := txtfmt.TableRow{mntTitle: mnt.Mntpoint}
 
 		result := mnt.State.Status.String()
 		if mnt.State.Error != "" {
@@ -153,10 +154,10 @@ func nvmeScanTable(ncs proto.NvmeControllers) string {
 	socketTitle := "Socket ID"
 	capacityTitle := "Capacity"
 
-	formatter := NewTableFormatter([]string{
+	formatter := txtfmt.NewTableFormatter(
 		pciTitle, modelTitle, fwTitle, socketTitle, capacityTitle,
-	})
-	var table []TableRow
+	)
+	var table []txtfmt.TableRow
 
 	sort.Slice(ncs, func(i, j int) bool { return ncs[i].Pciaddr < ncs[j].Pciaddr })
 
@@ -166,7 +167,7 @@ func nvmeScanTable(ncs proto.NvmeControllers) string {
 			tCap += bytesize.GB * bytesize.New(float64(ns.Size))
 		}
 
-		row := TableRow{pciTitle: ctrlr.Pciaddr}
+		row := txtfmt.TableRow{pciTitle: ctrlr.Pciaddr}
 		row[modelTitle] = ctrlr.Model
 		row[fwTitle] = ctrlr.Fwrev
 		row[socketTitle] = fmt.Sprint(ctrlr.Socketid)
@@ -191,13 +192,13 @@ func nvmeFormatTable(ncr proto.NvmeControllerResults) string {
 	pciTitle := "NVMe PCI"
 	resultTitle := "Format Result"
 
-	formatter := NewTableFormatter([]string{pciTitle, resultTitle})
-	var table []TableRow
+	formatter := txtfmt.NewTableFormatter(pciTitle, resultTitle)
+	var table []txtfmt.TableRow
 
 	sort.Slice(ncr, func(i, j int) bool { return ncr[i].Pciaddr < ncr[j].Pciaddr })
 
 	for _, ctrlr := range ncr {
-		row := TableRow{pciTitle: ctrlr.Pciaddr}
+		row := txtfmt.TableRow{pciTitle: ctrlr.Pciaddr}
 
 		result := ctrlr.State.Status.String()
 		if ctrlr.State.Error != "" {

--- a/src/control/cmd/dmg/system.go
+++ b/src/control/cmd/dmg/system.go
@@ -1,5 +1,5 @@
 //
-// (C) Copyright 2019 Intel Corporation.
+// (C) Copyright 2019-2020 Intel Corporation.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -31,6 +31,7 @@ import (
 
 	"github.com/daos-stack/daos/src/control/client"
 	"github.com/daos-stack/daos/src/control/lib/hostlist"
+	"github.com/daos-stack/daos/src/control/lib/txtfmt"
 )
 
 // SystemCmd is the struct representing the top-level system subcommand.
@@ -134,11 +135,11 @@ func (cmd *systemMemberQueryCmd) Execute(args []string) error {
 	addrTitle := "Control Address"
 	stateTitle := "State"
 
-	formatter := NewTableFormatter([]string{rankTitle, uuidTitle, addrTitle, stateTitle})
-	var table []TableRow
+	formatter := txtfmt.NewTableFormatter(rankTitle, uuidTitle, addrTitle, stateTitle)
+	var table []txtfmt.TableRow
 
 	for _, m := range members {
-		row := TableRow{rankTitle: fmt.Sprintf("%d", m.Rank)}
+		row := txtfmt.TableRow{rankTitle: fmt.Sprintf("%d", m.Rank)}
 		row[uuidTitle] = m.UUID
 		row[addrTitle] = m.Addr.String()
 		row[stateTitle] = m.State().String()
@@ -190,11 +191,11 @@ func (cmd *systemListPoolsCmd) Execute(args []string) error {
 	uuidTitle := "Pool UUID"
 	svcRepTitle := "Svc Replicas"
 
-	formatter := NewTableFormatter([]string{uuidTitle, svcRepTitle})
-	var table []TableRow
+	formatter := txtfmt.NewTableFormatter(uuidTitle, svcRepTitle)
+	var table []txtfmt.TableRow
 
 	for _, pool := range resp.Pools {
-		row := TableRow{uuidTitle: pool.UUID}
+		row := txtfmt.TableRow{uuidTitle: pool.UUID}
 
 		if len(pool.SvcReplicas) != 0 {
 			row[svcRepTitle] = formatPoolSvcReps(pool.SvcReplicas)

--- a/src/control/cmd/dmg/utils.go
+++ b/src/control/cmd/dmg/utils.go
@@ -1,5 +1,5 @@
 //
-// (C) Copyright 2018-2019 Intel Corporation.
+// (C) Copyright 2018-2020 Intel Corporation.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -34,6 +34,7 @@ import (
 
 	"github.com/daos-stack/daos/src/control/client"
 	"github.com/daos-stack/daos/src/control/lib/hostlist"
+	"github.com/daos-stack/daos/src/control/lib/txtfmt"
 )
 
 // splitPort separates port from compressed host string
@@ -156,11 +157,11 @@ func tabulateHostGroups(groups hostlist.HostGroups, titles ...string) (string, e
 	groupTitle := titles[0]
 	columnTitles := titles[1:]
 
-	formatter := NewTableFormatter(titles)
-	var table []TableRow
+	formatter := txtfmt.NewTableFormatter(titles...)
+	var table []txtfmt.TableRow
 
 	for _, result := range groups.Keys() {
-		row := TableRow{groupTitle: groups[result].RangedString()}
+		row := txtfmt.TableRow{groupTitle: groups[result].RangedString()}
 
 		summary := strings.Split(result, rowFieldSep)
 		if len(summary) != len(columnTitles) {

--- a/src/control/lib/txtfmt/entity.go
+++ b/src/control/lib/txtfmt/entity.go
@@ -1,0 +1,87 @@
+//
+// (C) Copyright 2019-2020 Intel Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// GOVERNMENT LICENSE RIGHTS-OPEN SOURCE SOFTWARE
+// The Government's rights to use, modify, reproduce, release, perform, display,
+// or disclose this software are subject to the terms of the Apache License as
+// provided in Contract No. 8F-30005.
+// Any reproduction of computer software, computer software documentation, or
+// portions thereof marked with this legend must also reproduce the markings.
+//
+
+package txtfmt
+
+import (
+	"fmt"
+	"text/tabwriter"
+)
+
+// EntityFormatter is a variant of TableFormatter that can be used
+// for neatly displaying attributes of a single entity.
+type EntityFormatter struct {
+	TableFormatter
+}
+
+// Format generates an output string for the supplied table rows.
+// It includes a single subject header, and each row is printed as an
+// attribute/value pair.
+func (f *EntityFormatter) Format(table []TableRow) string {
+	if len(f.titles) > 0 && f.titles[0] != "" {
+		f.formatHeader()
+	}
+
+	for _, row := range table {
+		for key, val := range row {
+			fmt.Fprintf(f.writer, "%s\t%s\t\n", key, val)
+		}
+	}
+
+	f.writer.Flush()
+	return f.out.String()
+}
+
+// Init instantiates internal variables.
+func (f *EntityFormatter) Init(padWidth int) {
+	f.writer = tabwriter.NewWriter(&f.out, padWidth, 0, 0, ' ', 0)
+}
+
+// NewEntityFormatter returns an initialized EntityFormatter.
+func NewEntityFormatter(title string, padWidth int) *EntityFormatter {
+	f := &EntityFormatter{}
+	f.Init(padWidth)
+	f.SetColumnTitles(title)
+	return f
+}
+
+// GetEntityPadding will determine the minimum width necessary
+// to display the entity attributes.
+func GetEntityPadding(table []TableRow) (padding int) {
+	for _, row := range table {
+		for key := range row {
+			if len(key) > padding {
+				padding = len(key) + 1
+			}
+		}
+	}
+
+	return
+}
+
+// FormatEntity returns a formatted string from the supplied entity title
+// and table of attributes.
+func FormatEntity(title string, attrs []TableRow) string {
+	f := NewEntityFormatter(title, GetEntityPadding(attrs))
+	return f.Format(attrs)
+}

--- a/src/control/lib/txtfmt/entity.go
+++ b/src/control/lib/txtfmt/entity.go
@@ -1,5 +1,5 @@
 //
-// (C) Copyright 2019-2020 Intel Corporation.
+// (C) Copyright 2020 Intel Corporation.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -24,27 +24,42 @@
 package txtfmt
 
 import (
+	"bytes"
 	"fmt"
 	"text/tabwriter"
 )
 
-// EntityFormatter is a variant of TableFormatter that can be used
-// for neatly displaying attributes of a single entity.
+// EntityFormatter can be used for neatly displaying attributes
+// of a single entity.
 type EntityFormatter struct {
-	TableFormatter
+	title  string
+	writer *tabwriter.Writer
+	out    bytes.Buffer
+
+	Separator string
+}
+
+func (f *EntityFormatter) formatHeader() {
+	if f.title == "" {
+		return
+	}
+
+	fmt.Fprintf(&f.out, "%s\n", f.title)
+	for i := 0; i < len(f.title); i++ {
+		fmt.Fprintf(&f.out, "-")
+	}
+	fmt.Fprintf(&f.out, "\n")
 }
 
 // Format generates an output string for the supplied table rows.
 // It includes a single subject header, and each row is printed as an
 // attribute/value pair.
 func (f *EntityFormatter) Format(table []TableRow) string {
-	if len(f.titles) > 0 && f.titles[0] != "" {
-		f.formatHeader()
-	}
+	f.formatHeader()
 
 	for _, row := range table {
 		for key, val := range row {
-			fmt.Fprintf(f.writer, "%s\t%s\t\n", key, val)
+			fmt.Fprintf(f.writer, "%s\t%s%s\t\n", key, f.Separator, val)
 		}
 	}
 
@@ -59,9 +74,11 @@ func (f *EntityFormatter) Init(padWidth int) {
 
 // NewEntityFormatter returns an initialized EntityFormatter.
 func NewEntityFormatter(title string, padWidth int) *EntityFormatter {
-	f := &EntityFormatter{}
+	f := &EntityFormatter{
+		title:     title,
+		Separator: ": ",
+	}
 	f.Init(padWidth)
-	f.SetColumnTitles(title)
 	return f
 }
 

--- a/src/control/lib/txtfmt/entity_test.go
+++ b/src/control/lib/txtfmt/entity_test.go
@@ -1,5 +1,5 @@
 //
-// (C) Copyright 2019-2020 Intel Corporation.
+// (C) Copyright 2020 Intel Corporation.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -42,23 +42,35 @@ func TestEntityFormatter(t *testing.T) {
 				{"c": "d"},
 				{"bananas": "grapes"},
 			},
-			expectedResult: `title   
------   
-a       b       
-c       d       
-bananas grapes  
+			expectedResult: `title
+-----
+a       : b     
+c       : d     
+bananas : grapes
 `,
 		},
 		"empty title": {
 			attrs: []TableRow{
 				{"a": "b"},
 			},
-			expectedResult: "a b \n",
+			expectedResult: "a : b\n",
 		},
 		"empty attrs": {
 			title: "empty",
 			expectedResult: `empty
 -----
+`,
+		},
+		"long title": {
+			title: "long title is long",
+			attrs: []TableRow{
+				{"a": "b"},
+				{"foo": "bar"},
+			},
+			expectedResult: `long title is long
+------------------
+a   : b  
+foo : bar
 `,
 		},
 	} {

--- a/src/control/lib/txtfmt/entity_test.go
+++ b/src/control/lib/txtfmt/entity_test.go
@@ -1,0 +1,73 @@
+//
+// (C) Copyright 2019-2020 Intel Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// GOVERNMENT LICENSE RIGHTS-OPEN SOURCE SOFTWARE
+// The Government's rights to use, modify, reproduce, release, perform, display,
+// or disclose this software are subject to the terms of the Apache License as
+// provided in Contract No. 8F-30005.
+// Any reproduction of computer software, computer software documentation, or
+// portions thereof marked with this legend must also reproduce the markings.
+//
+
+package txtfmt
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestEntityFormatter(t *testing.T) {
+	for name, tc := range map[string]struct {
+		title          string
+		attrs          []TableRow
+		expectedResult string
+	}{
+		"normal": {
+			title: "title",
+			attrs: []TableRow{
+				{"a": "b"},
+				{"c": "d"},
+				{"bananas": "grapes"},
+			},
+			expectedResult: `title   
+-----   
+a       b       
+c       d       
+bananas grapes  
+`,
+		},
+		"empty title": {
+			attrs: []TableRow{
+				{"a": "b"},
+			},
+			expectedResult: "a b \n",
+		},
+		"empty attrs": {
+			title: "empty",
+			expectedResult: `empty
+-----
+`,
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			result := FormatEntity(tc.title, tc.attrs)
+
+			if diff := cmp.Diff(tc.expectedResult, result); diff != "" {
+				t.Fatalf("unexpected result (-want, +got):\n%s\n", diff)
+			}
+		})
+	}
+}

--- a/src/control/lib/txtfmt/table.go
+++ b/src/control/lib/txtfmt/table.go
@@ -1,5 +1,5 @@
 //
-// (C) Copyright 2019 Intel Corporation.
+// (C) Copyright 2019-2020 Intel Corporation.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -21,7 +21,7 @@
 // portions thereof marked with this legend must also reproduce the markings.
 //
 
-package main
+package txtfmt
 
 import (
 	"bytes"
@@ -46,7 +46,7 @@ func (t *TableFormatter) Init() {
 }
 
 // SetColumnTitles sets the ordered column titles for the table.
-func (t *TableFormatter) SetColumnTitles(c []string) {
+func (t *TableFormatter) SetColumnTitles(c ...string) {
 	if c == nil {
 		t.titles = []string{}
 		return
@@ -95,9 +95,9 @@ func (t *TableFormatter) Format(table []TableRow) string {
 }
 
 // NewTableFormatter creates and instantiates a new TableFormatter.
-func NewTableFormatter(columnTitles []string) *TableFormatter {
+func NewTableFormatter(columnTitles ...string) *TableFormatter {
 	f := &TableFormatter{}
 	f.Init()
-	f.SetColumnTitles(columnTitles)
+	f.SetColumnTitles(columnTitles...)
 	return f
 }

--- a/src/control/lib/txtfmt/table_test.go
+++ b/src/control/lib/txtfmt/table_test.go
@@ -1,5 +1,5 @@
 //
-// (C) Copyright 2019 Intel Corporation.
+// (C) Copyright 2019-2020 Intel Corporation.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -21,7 +21,7 @@
 // portions thereof marked with this legend must also reproduce the markings.
 //
 
-package main
+package txtfmt
 
 import (
 	"testing"
@@ -30,7 +30,7 @@ import (
 )
 
 func TestNewTableFormatter_NoTitles(t *testing.T) {
-	f := NewTableFormatter(nil)
+	f := NewTableFormatter()
 	if f.writer == nil {
 		t.Fatal("no tabwriter set!")
 	}
@@ -41,7 +41,7 @@ func TestNewTableFormatter_NoTitles(t *testing.T) {
 
 func TestNewTableFormatter_WithTitles(t *testing.T) {
 	titles := []string{"One", "Two", "Three"}
-	f := NewTableFormatter(titles)
+	f := NewTableFormatter(titles...)
 	if f.writer == nil {
 		t.Fatal("no tabwriter set!")
 	}
@@ -87,7 +87,7 @@ func TestTableFormatter_SetColumnTitles(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			f := &TableFormatter{titles: tt.startingTitles}
 
-			f.SetColumnTitles(tt.titles)
+			f.SetColumnTitles(tt.titles...)
 
 			if diff := cmp.Diff(tt.expectedTitles, f.titles); diff != "" {
 				t.Fatalf("unexpected titles (-want, +got):\n%s\n", diff)
@@ -148,7 +148,7 @@ func TestTableFormatter_Format(t *testing.T) {
 		},
 	} {
 		t.Run(name, func(t *testing.T) {
-			f := NewTableFormatter(tt.titles)
+			f := NewTableFormatter(tt.titles...)
 
 			result := f.Format(tt.table)
 


### PR DESCRIPTION
Enables reuse outside of dmg. Also cleans up the API to use
variadic parameters for titles so that callers don't need
to construct string slices.

Adds a new EntityFormatter type which can be used for neatly
displaying attributes of a single entity. The FormatEntity()
function can be used to do the formatting in a single operation.