### PR TITLE
DAOS-3946 build: Include daos_cont.h in install/include

### DIFF
--- a/src/SConscript
+++ b/src/SConscript
@@ -5,7 +5,8 @@ import os
 HEADERS = ['daos.h', 'daos_api.h', 'daos_types.h', 'daos_errno.h', 'daos_kv.h',
            'daos_event.h', 'daos_mgmt.h', 'daos_types.h', 'daos_array.h',
            'daos_task.h', 'daos_fs.h', 'daos_uns.h', 'daos_security.h',
-           'daos_prop.h', 'daos_obj_class.h', 'daos_obj.h', 'daos_cont.h']
+           'daos_prop.h', 'daos_obj_class.h', 'daos_obj.h', 'daos_pool.h',
+           'daos_cont.h']
 HEADERS_SRV = ['vos.h', 'vos_types.h']
 
 def scons():

--- a/src/SConscript
+++ b/src/SConscript
@@ -5,7 +5,7 @@ import os
 HEADERS = ['daos.h', 'daos_api.h', 'daos_types.h', 'daos_errno.h', 'daos_kv.h',
            'daos_event.h', 'daos_mgmt.h', 'daos_types.h', 'daos_array.h',
            'daos_task.h', 'daos_fs.h', 'daos_uns.h', 'daos_security.h',
-           'daos_prop.h', 'daos_obj_class.h', 'daos_obj.h']
+           'daos_prop.h', 'daos_obj_class.h', 'daos_obj.h', 'daos_cont.h']
 HEADERS_SRV = ['vos.h', 'vos_types.h']
 
 def scons():


### PR DESCRIPTION
Including the recently added src/include/daos_cont.h and
src/include/daos_pool.h in the install/include directory to
prevent mpich build errors.

Signed-off-by: Phillip Henderson <phillip.henderson@intel.com>