### PR TITLE
DAOS-623 build: Add MPI_PKG option

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -261,6 +261,8 @@ def scons():
         commits_file = None
 
     prereqs = PreReqComponent(env, opts, commits_file)
+    prereqs.add_opts(('MPI_PKG',
+                      'MPI package to load from external environment', None))
     preload_prereqs(prereqs)
     if prereqs.check_component('valgrind_devel'):
         env.AppendUnique(CPPDEFINES=["DAOS_HAS_VALGRIND"])

--- a/utils/daos_build.py
+++ b/utils/daos_build.py
@@ -26,8 +26,24 @@ def install(env, subdir, files):
     path = "$PREFIX/%s" % subdir
     denv.Install(path, files)
 
+def _configure_mpi_pkg(env):
+    """Configure MPI using pkg-config"""
+    try:
+        env.ParseConfig("pkg-config --cflags --libs $MPI_PKG")
+    except OSError as e:
+        print("\n**********************************")
+        print("Could not find package MPI_PKG=%s\n" % env.subst("$MPI_PKG"))
+        print("Unset it or update PKG_CONFIG_PATH")
+        print("**********************************")
+        raise e
+
+    return env.subst("$MPI_PKG")
+
 def configure_mpi(prereqs, env, required=None):
     """Check if mpi exists and configure environment"""
+    if env.subst("$MPI_PKG") != "":
+        return _configure_mpi_pkg(env)
+
     mpis = ['ompi', 'mpich']
     if not required is None:
         if isinstance(required, str):


### PR DESCRIPTION
Sometimes it is desireable to have more control over which
MPI daos_test, etc are built with.   This enables user to
setup PKG_CONFIG_PATH (via module load or manually) and just
pass in a package to load ont he command line.  It's a sticky
option.

If set, it will fail if ParseConfig fails rather than continuing
without building MPI dependent items.

Skip-test: true

Signed-off-by: Jeff Olivier <jeffrey.v.olivier@intel.com>