### PR TITLE
DAOS-3536 dmg: Add verbose mode to pool get-ACL

### DIFF
--- a/src/control/cmd/dmg/acl.go
+++ b/src/control/cmd/dmg/acl.go
@@ -74,7 +74,7 @@ func parseACL(reader io.Reader) (*client.AccessControlList, error) {
 }
 
 // formatACL converts the AccessControlList to a human-readable string.
-func formatACL(acl *client.AccessControlList) string {
+func formatACL(acl *client.AccessControlList, verbose bool) string {
 	var builder strings.Builder
 
 	if acl.HasOwner() {
@@ -92,8 +92,115 @@ func formatACL(acl *client.AccessControlList) string {
 	}
 
 	for _, ace := range acl.Entries {
+		if verbose {
+			fmt.Fprintf(&builder, "# %s\n", getVerboseACE(ace))
+		}
 		fmt.Fprintf(&builder, "%s\n", ace)
 	}
 
 	return builder.String()
+}
+
+// formatACLDefault formats the AccessControlList in non-verbose mode.
+func formatACLDefault(acl *client.AccessControlList) string {
+	return formatACL(acl, false)
+}
+
+func getVerboseACE(shortACE string) string {
+	if shortACE == "" {
+		return ""
+	}
+
+	const (
+		// Field indices
+		ACETypes = iota
+		ACEFlags
+		ACEIdentity
+		ACEPerms
+		ACENumFields // Must be last
+	)
+
+	fields := strings.Split(shortACE, ":")
+	if len(fields) != ACENumFields {
+		return "invalid ACE"
+	}
+
+	var b strings.Builder
+
+	fmt.Fprintf(&b, "%s:", getVerboseType(fields[ACETypes]))
+
+	if fields[ACEFlags] != "" {
+		b.WriteString(getVerboseFlags(fields[ACEFlags]))
+	}
+	b.WriteString(":")
+
+	fmt.Fprintf(&b, "%s:", getVerboseIdentity(fields[ACEIdentity]))
+
+	b.WriteString(getVerbosePermissions(fields[ACEPerms]))
+
+	return b.String()
+}
+
+func getVerboseType(field string) string {
+	types := map[string]string{
+		"A": "Allow",
+	}
+
+	return getVerboseField(field, types)
+}
+
+func getVerboseFlags(field string) string {
+	flags := map[string]string{
+		"G": "Group",
+	}
+
+	return getVerboseField(field, flags)
+}
+
+func getVerboseIdentity(field string) string {
+	specialIDs := map[string]string{
+		"OWNER@":    "Owner",
+		"GROUP@":    "Owner-Group",
+		"EVERYONE@": "Everyone",
+	}
+
+	identity := field
+	if identity == "" {
+		identity = "None"
+	} else if v, ok := specialIDs[identity]; ok {
+		identity = v
+	}
+
+	return identity
+}
+
+func getVerbosePermissions(field string) string {
+	perms := map[string]string{
+		"r": "Read",
+		"w": "Write",
+	}
+
+	return getVerboseField(field, perms)
+}
+
+func getVerboseField(field string, verbose map[string]string) string {
+	if field == "" {
+		return "None"
+	}
+
+	var b strings.Builder
+	for i, c := range field {
+		if i != 0 {
+			b.WriteString("/")
+		}
+		var verboseVal string
+		if v, ok := verbose[string(c)]; ok {
+			verboseVal = v
+		} else {
+			verboseVal = "Unknown"
+		}
+		b.WriteString(verboseVal)
+	}
+
+	return b.String()
 }

--- a/src/control/cmd/dmg/pool.go
+++ b/src/control/cmd/dmg/pool.go
@@ -181,9 +181,10 @@ func (c *PoolSetPropCmd) Execute(_ []string) error {
 type PoolGetACLCmd struct {
 	logCmd
 	connectedCmd
-	UUID  string `long:"pool" required:"1" description:"UUID of DAOS pool"`
-	File  string `short:"o" long:"outfile" required:"0" description:"Output ACL to file"`
-	Force bool   `short:"f" long:"force" required:"0" description:"Allow to clobber output file"`
+	UUID    string `long:"pool" required:"1" description:"UUID of DAOS pool"`
+	File    string `short:"o" long:"outfile" required:"0" description:"Output ACL to file"`
+	Force   bool   `short:"f" long:"force" required:"0" description:"Allow to clobber output file"`
+	Verbose bool   `short:"v" long:"verbose" required:"0" description:"Add descriptive comments to ACL entries"`
 }
 
 // Execute is run when the PoolGetACLCmd subcommand is activated
@@ -198,7 +199,7 @@ func (d *PoolGetACLCmd) Execute(args []string) error {
 
 	d.log.Debugf("Pool-get-ACL command succeeded, UUID: %s\n", d.UUID)
 
-	acl := formatACL(resp.ACL)
+	acl := formatACL(resp.ACL, d.Verbose)
 
 	if d.File != "" {
 		err = d.writeACLToFile(acl)
@@ -266,7 +267,7 @@ func (d *PoolOverwriteACLCmd) Execute(args []string) error {
 	}
 
 	d.log.Infof("Pool-overwrite-ACL command succeeded, UUID: %s\n", d.UUID)
-	d.log.Info(formatACL(resp.ACL))
+	d.log.Info(formatACLDefault(resp.ACL))
 
 	return nil
 }
@@ -312,7 +313,7 @@ func (d *PoolUpdateACLCmd) Execute(args []string) error {
 	}
 
 	d.log.Infof("Pool-update-ACL command succeeded, UUID: %s\n", d.UUID)
-	d.log.Info(formatACL(resp.ACL))
+	d.log.Info(formatACLDefault(resp.ACL))
 
 	return nil
 }
@@ -340,7 +341,7 @@ func (d *PoolDeleteACLCmd) Execute(args []string) error {
 	}
 
 	d.log.Infof("Pool-delete-ACL command succeeded, UUID: %s\n", d.UUID)
-	d.log.Info(formatACL(resp.ACL))
+	d.log.Info(formatACLDefault(resp.ACL))
 
 	return nil
 }

--- a/src/control/cmd/dmg/pool_test.go
+++ b/src/control/cmd/dmg/pool_test.go
@@ -132,7 +132,7 @@ func createACLFile(t *testing.T, path string, acl *client.AccessControlList) {
 	}
 	defer file.Close()
 
-	_, err = file.WriteString(formatACL(acl))
+	_, err = file.WriteString(formatACLDefault(acl))
 	if err != nil {
 		t.Fatalf("Couldn't write to file: %v", err)
 	}
@@ -315,6 +315,17 @@ func TestPoolCommands(t *testing.T) {
 		{
 			"Get pool ACL",
 			"pool get-acl --pool 031bcaf8-f0f5-42ef-b3c5-ee048676dceb",
+			strings.Join([]string{
+				"ConnectClients",
+				fmt.Sprintf("PoolGetACL-%+v", client.PoolGetACLReq{
+					UUID: "031bcaf8-f0f5-42ef-b3c5-ee048676dceb",
+				}),
+			}, " "),
+			nil,
+		},
+		{
+			"Get pool ACL with verbose flag",
+			"pool get-acl --pool 031bcaf8-f0f5-42ef-b3c5-ee048676dceb --verbose",
 			strings.Join([]string{
 				"ConnectClients",
 				fmt.Sprintf("PoolGetACL-%+v", client.PoolGetACLReq{


### PR DESCRIPTION
The verbose option adds comments (starting with '#') that
expand the fields of each ACL entry into more descriptive
strings.

Signed-off-by: Kris Jacque <kristin.jacque@intel.com>