### PR TITLE
DAOS-3606 Placement: Added Uniqueness Test to Unit Test.

### DIFF
--- a/src/placement/tests/jump_map_place_obj.c
+++ b/src/placement/tests/jump_map_place_obj.c
@@ -131,7 +131,7 @@ main(int argc, char **argv)
 	daos_obj_generate_id(&oid, 0, OC_RP_4G2, 0);
 	D_PRINT("\ntest initial placement when no failed shard ...\n");
 	plt_obj_place(oid, &lo_1, pl_map);
-	plt_obj_layout_check(lo_1);
+	plt_obj_layout_check(lo_1, COMPONENT_NR);
 
 	/* test plt_obj_place when some/all shards failed */
 	D_PRINT("\ntest to fail all shards  and new placement ...\n");
@@ -139,7 +139,7 @@ main(int argc, char **argv)
 		plt_fail_tgt(lo_1->ol_shards[i].po_target, &po_ver, po_map,
 				pl_debug_msg);
 	plt_obj_place(oid, &lo_2, pl_map);
-	plt_obj_layout_check(lo_2);
+	plt_obj_layout_check(lo_2, COMPONENT_NR);
 	D_ASSERT(!pt_obj_layout_match(lo_1, lo_2, DOM_NR));
 	D_PRINT("spare target candidate:");
 	for (i = 0; i < SPARE_MAX_NUM && i < lo_1->ol_nr; i++) {
@@ -153,7 +153,7 @@ main(int argc, char **argv)
 		plt_add_tgt(lo_1->ol_shards[i].po_target, &po_ver, po_map,
 				pl_debug_msg);
 	plt_obj_place(oid, &lo_3, pl_map);
-	plt_obj_layout_check(lo_3);
+	plt_obj_layout_check(lo_3, COMPONENT_NR);
 	D_ASSERT(pt_obj_layout_match(lo_1, lo_3, DOM_NR));
 
 	/* test pl_obj_find_rebuild */
@@ -166,6 +166,7 @@ main(int argc, char **argv)
 	plt_spare_tgts_get(pl_uuid, oid, failed_tgts, 2, spare_tgt_ranks,
 			pl_debug_msg, shard_ids, &spare_cnt, &po_ver,
 			PL_TYPE_JUMP_MAP, SPARE_MAX_NUM, po_map, pl_map);
+	plt_obj_rebuild_unique_check(shard_ids, spare_cnt, COMPONENT_NR);
 	D_ASSERT(spare_cnt == 2);
 	D_ASSERT(spare_tgt_ranks[0] == spare_tgt_candidate[0]);
 	D_ASSERT(spare_tgt_ranks[1] == spare_tgt_candidate[1]);
@@ -196,6 +197,7 @@ main(int argc, char **argv)
 	plt_spare_tgts_get(pl_uuid, oid, failed_tgts, 3, spare_tgt_ranks,
 			   pl_debug_msg, shard_ids, &spare_cnt, &po_ver,
 			   PL_TYPE_JUMP_MAP, SPARE_MAX_NUM, po_map, pl_map);
+	plt_obj_rebuild_unique_check(shard_ids, spare_cnt, COMPONENT_NR);
 	D_ASSERT(spare_cnt == 2);
 	D_ASSERT(shard_ids[0] == 1);
 	D_ASSERT(shard_ids[1] == 0);
@@ -228,6 +230,7 @@ main(int argc, char **argv)
 	plt_spare_tgts_get(pl_uuid, oid, failed_tgts, 5, spare_tgt_ranks,
 			   pl_debug_msg, shard_ids, &spare_cnt, &po_ver,
 			   PL_TYPE_JUMP_MAP, SPARE_MAX_NUM, po_map, pl_map);
+	plt_obj_rebuild_unique_check(shard_ids, spare_cnt, COMPONENT_NR);
 	D_ASSERT(spare_cnt == 3);
 
 	pl_obj_layout_free(lo_1);

--- a/src/placement/tests/place_obj_common.c
+++ b/src/placement/tests/place_obj_common.c
@@ -51,12 +51,41 @@ plt_obj_place(daos_obj_id_t oid, struct pl_obj_layout **layout,
 }
 
 void
-plt_obj_layout_check(struct pl_obj_layout *layout)
+plt_obj_layout_check(struct pl_obj_layout *layout, uint32_t pool_size)
 {
 	int i;
+	int target_num;
+	uint8_t *target_set;
 
-	for (i = 0; i < layout->ol_nr; i++)
-		D_ASSERT(layout->ol_shards[i].po_target != -1);
+	D_ALLOC_ARRAY(target_set, pool_size);
+	D_ASSERT(target_set != NULL);
+
+	for (i = 0; i < layout->ol_nr; i++) {
+		target_num = layout->ol_shards[i].po_target;
+
+		D_ASSERT(target_num != -1);
+		D_ASSERT(target_set[target_num] != 1);
+		target_set[target_num] = 1;
+	}
+}
+
+void
+plt_obj_rebuild_unique_check(uint32_t *shard_ids, uint32_t num_shards,
+		uint32_t pool_size)
+{
+	int i;
+	int  target_num;
+	uint8_t *target_set;
+
+	D_ALLOC_ARRAY(target_set, pool_size);
+	D_ASSERT(target_set != NULL);
+
+	for (i = 0; i < num_shards; i++) {
+		target_num = shard_ids[i];
+
+		D_ASSERT(target_set[target_num] != 1);
+		target_set[target_num] = 1;
+	}
 }
 
 bool

--- a/src/placement/tests/place_obj_common.h
+++ b/src/placement/tests/place_obj_common.h
@@ -34,7 +34,11 @@ plt_obj_place(daos_obj_id_t oid, struct pl_obj_layout **layout,
 		struct pl_map *pl_map);
 
 void
-plt_obj_layout_check(struct pl_obj_layout *layout);
+plt_obj_layout_check(struct pl_obj_layout *layout, uint32_t pool_size);
+
+void
+plt_obj_rebuild_unique_check(uint32_t *shard_ids, uint32_t num_shards,
+		uint32_t pool_size);
 
 bool
 pt_obj_layout_match(struct pl_obj_layout *lo_1, struct pl_obj_layout *lo_2,

--- a/src/placement/tests/ring_map_place_obj.c
+++ b/src/placement/tests/ring_map_place_obj.c
@@ -132,7 +132,7 @@ main(int argc, char **argv)
 	daos_obj_generate_id(&oid, 0, OC_RP_4G2, 0);
 	D_PRINT("\ntest initial placement when no failed shard ...\n");
 	plt_obj_place(oid, &lo_1, pl_map);
-	plt_obj_layout_check(lo_1);
+	plt_obj_layout_check(lo_1, COMPONENT_NR);
 
 	/* test plt_obj_place when some/all shards failed */
 	D_PRINT("\ntest to fail all shards  and new placement ...\n");
@@ -140,7 +140,7 @@ main(int argc, char **argv)
 		plt_fail_tgt(lo_1->ol_shards[i].po_target, &po_ver, po_map,
 			     pl_debug_msg);
 	plt_obj_place(oid, &lo_2, pl_map);
-	plt_obj_layout_check(lo_2);
+	plt_obj_layout_check(lo_2, COMPONENT_NR);
 	D_ASSERT(!pt_obj_layout_match(lo_1, lo_2, DOM_NR));
 	D_PRINT("spare target candidate:");
 	for (i = 0; i < SPARE_MAX_NUM && i < lo_1->ol_nr; i++) {
@@ -154,7 +154,7 @@ main(int argc, char **argv)
 		plt_add_tgt(lo_1->ol_shards[i].po_target, &po_ver, po_map,
 			    pl_debug_msg);
 	plt_obj_place(oid, &lo_3, pl_map);
-	plt_obj_layout_check(lo_3);
+	plt_obj_layout_check(lo_3, COMPONENT_NR);
 	D_ASSERT(pt_obj_layout_match(lo_1, lo_3, DOM_NR));
 	pl_map_decref(pl_map);
 	pl_map = NULL;
@@ -169,6 +169,7 @@ main(int argc, char **argv)
 	plt_spare_tgts_get(pl_uuid, oid, failed_tgts, 2, spare_tgt_ranks,
 			   pl_debug_msg, shard_ids, &spare_cnt, &po_ver,
 			   PL_TYPE_RING, SPARE_MAX_NUM, po_map, pl_map);
+	plt_obj_rebuild_unique_check(shard_ids, spare_cnt, COMPONENT_NR);
 	D_ASSERT(spare_cnt == 2);
 	D_ASSERT(shard_ids[0] == 0);
 	D_ASSERT(shard_ids[1] == 1);
@@ -183,6 +184,7 @@ main(int argc, char **argv)
 	plt_reint_tgts_get(pl_uuid, oid, failed_tgts, 1, reint_tgts, 1,
 			spare_tgt_ranks, shard_ids, &spare_cnt, PL_TYPE_RING,
 			SPARE_MAX_NUM, po_map, pl_map, &po_ver, pl_debug_msg);
+	plt_obj_rebuild_unique_check(shard_ids, spare_cnt, COMPONENT_NR);
 	D_PRINT("reintegrated target %d. expected target %d\n",
 		reint_tgts[0], lo_3->ol_shards[0].po_target);
 	D_ASSERT(spare_cnt == 1);
@@ -199,6 +201,7 @@ main(int argc, char **argv)
 	plt_spare_tgts_get(pl_uuid, oid, failed_tgts, 3, spare_tgt_ranks,
 			   pl_debug_msg, shard_ids, &spare_cnt, &po_ver,
 			   PL_TYPE_RING, SPARE_MAX_NUM, po_map, pl_map);
+	plt_obj_rebuild_unique_check(shard_ids, spare_cnt, COMPONENT_NR);
 	/* should get next spare targets, the first spare candidate failed,
 	 * and shard[0].fseq > shard[1].fseq, so will select shard[1]'s
 	 * next spare first.
@@ -219,6 +222,7 @@ main(int argc, char **argv)
 	plt_reint_tgts_get(pl_uuid, oid, failed_tgts, 1, reint_tgts, 2,
 			spare_tgt_ranks, shard_ids, &spare_cnt, PL_TYPE_RING,
 			SPARE_MAX_NUM, po_map, pl_map, &po_ver, pl_debug_msg);
+	plt_obj_rebuild_unique_check(shard_ids, spare_cnt, COMPONENT_NR);
 	D_PRINT("reintegrated target %d and %d. expected target "
 		"%d and %d\n", reint_tgts[0], reint_tgts[1],
 		lo_3->ol_shards[0].po_target, spare_tgt_ranks[0]);
@@ -240,6 +244,7 @@ main(int argc, char **argv)
 	plt_spare_tgts_get(pl_uuid, oid, failed_tgts, 5, spare_tgt_ranks,
 			   pl_debug_msg, shard_ids, &spare_cnt, &po_ver,
 			   PL_TYPE_RING, SPARE_MAX_NUM, po_map, pl_map);
+	plt_obj_rebuild_unique_check(shard_ids, spare_cnt, COMPONENT_NR);
 	D_ASSERT(spare_cnt == 3);
 	D_ASSERT(shard_ids[0] == 3);
 	D_ASSERT(shard_ids[1] == 0);


### PR DESCRIPTION
- Added check to verify that the layout generated by
placement does not contain multiples of a single target.

- Added check to verify rebuild and reintegration API returns
unique fall-back targets.

Signed-off-by: Peter Fetros <peter.fetros@intel.com>