### PR TITLE
DAOS-3956 control: remove access_point requirement for BioHealthQuery

### DIFF
--- a/src/control/server/mgmt_svc.go
+++ b/src/control/server/mgmt_svc.go
@@ -530,9 +530,13 @@ func (svc *mgmtSvc) PoolDeleteACL(ctx context.Context, req *mgmtpb.DeleteACLReq)
 func (svc *mgmtSvc) BioHealthQuery(ctx context.Context, req *mgmtpb.BioHealthReq) (*mgmtpb.BioHealthResp, error) {
 	svc.log.Debugf("MgmtSvc.BioHealthQuery dispatch, req:%+v\n", *req)
 
-	mi, err := svc.harness.GetMSLeaderInstance()
-	if err != nil {
-		return nil, err
+	var mi *IOServerInstance
+	for _, i := range svc.harness.Instances() {
+		mi = i
+	}
+
+	if mi == nil {
+		return nil, errors.New("rank instance not found on this server")
 	}
 
 	dresp, err := mi.CallDrpc(drpc.ModuleMgmt, drpc.MethodBioHealth, req)


### PR DESCRIPTION
- execute across all client connections not just service leader
- look for the first instance to use for dRPC send in gRPC handler

Signed-off-by: Tom Nabarro <tom.nabarro@intel.com>