### PR TITLE
DAOS-3952 iv: retry for snapshot fetch

### DIFF
--- a/src/container/container_iv.c
+++ b/src/container/container_iv.c
@@ -578,7 +578,7 @@ cont_iv_snapshots_fetch(void *ns, uuid_t cont_uuid, uint64_t **snapshots,
 		return -DER_NOMEM;
 
 	rc = cont_iv_fetch(ns, IV_CONT_SNAP, cont_uuid, iv_entry,
-			   iv_entry_size, false);
+			   iv_entry_size, true);
 	if (rc)
 		D_GOTO(free, rc);
 

--- a/src/iosrv/server_iv.c
+++ b/src/iosrv/server_iv.c
@@ -908,8 +908,12 @@ iv_op(struct ds_iv_ns *ns, struct ds_iv_key *key, d_sg_list_t *value,
 
 retry:
 	rc = iv_op_internal(ns, key, value, sync, shortcut, opc);
-	if (retry && daos_rpc_retryable_rc(rc)) {
-		D_DEBUG(DB_TRACE, "retry upon %d\n", rc);
+	if (retry && (daos_rpc_retryable_rc(rc) || rc == -DER_NOTLEADER)) {
+		/* If the IV ns leader has been changed, then it will retry
+		 * in the mean time, it will rely on others to update the
+		 * ns for it.
+		 */
+		D_WARN("retry upon %d\n", rc);
 		goto retry;
 	}
 	return rc;


### PR DESCRIPTION
Since the leader might change, let's retry for
snapshot fetch during rebuild, otherwise it will
cause rebuild puller failed.

Signed-off-by: Di Wang <di.wang@intel.com>