### PR TITLE
DAOS-3608 mgmt: Check ACL validity in pool create

### DIFF
--- a/src/common/acl_util.c
+++ b/src/common/acl_util.c
@@ -293,8 +293,8 @@ daos_ace_from_str(const char *str, struct daos_ace **ace)
 	return 0;
 }
 
-static const char *
-get_principal_name_str(struct daos_ace *ace)
+const char *
+daos_ace_get_principal_str(struct daos_ace *ace)
 {
 	switch (ace->dae_principal_type) {
 	case DAOS_ACL_OWNER:
@@ -410,7 +410,7 @@ daos_ace_to_str(struct daos_ace *ace, char *buf, size_t buf_len)
 		rc = write_char(&pen, FLAG_POOL_INHERIT_CH, &remaining_len);
 
 	written = snprintf(pen, remaining_len, ":%s:",
-			   get_principal_name_str(ace));
+			   daos_ace_get_principal_str(ace));
 	if (written > remaining_len) {
 		remaining_len = 0;
 	} else {

--- a/src/common/tests/acl_api_tests.c
+++ b/src/common/tests/acl_api_tests.c
@@ -1933,6 +1933,9 @@ test_acl_is_valid_duplicate_user(void **state)
 	ace[0] = daos_ace_create(DAOS_ACL_USER, "user1@");
 	ace[1] = daos_ace_create(DAOS_ACL_USER, "anotheruser@");
 	ace[2] = daos_ace_create(DAOS_ACL_USER, "user1@");
+	/* Give the duplicate instance different perms */
+	ace[2]->dae_access_types = DAOS_ACL_ACCESS_ALLOW;
+	ace[2]->dae_allow_perms = DAOS_ACL_PERM_READ;
 	acl = daos_acl_create(ace, num_aces);
 
 	assert_int_equal(daos_acl_validate(acl), -DER_INVAL);

--- a/src/common/tests/acl_util_tests.c
+++ b/src/common/tests/acl_util_tests.c
@@ -42,6 +42,33 @@
  */
 
 static void
+expect_string_for_principal(enum daos_acl_principal_type type, const char *name,
+			    const char *exp_str)
+{
+	struct daos_ace *ace;
+
+	ace = daos_ace_create(type, name);
+	assert_string_equal(daos_ace_get_principal_str(ace),
+			    exp_str);
+	daos_ace_free(ace);
+}
+
+static void
+test_ace_get_principal_str(void **state)
+{
+	expect_string_for_principal(DAOS_ACL_OWNER, NULL,
+				    DAOS_ACL_PRINCIPAL_OWNER);
+	expect_string_for_principal(DAOS_ACL_OWNER_GROUP, NULL,
+				    DAOS_ACL_PRINCIPAL_OWNER_GRP);
+	expect_string_for_principal(DAOS_ACL_EVERYONE, NULL,
+				    DAOS_ACL_PRINCIPAL_EVERYONE);
+	expect_string_for_principal(DAOS_ACL_USER, "acl_user@",
+				    "acl_user@");
+	expect_string_for_principal(DAOS_ACL_GROUP, "acl_grp@",
+				    "acl_grp@");
+}
+
+static void
 test_ace_from_str_null_str(void **state)
 {
 	struct daos_ace *ace = NULL;
@@ -768,6 +795,7 @@ int
 main(void)
 {
 	const struct CMUnitTest tests[] = {
+		cmocka_unit_test(test_ace_get_principal_str),
 		cmocka_unit_test(test_ace_from_str_null_str),
 		cmocka_unit_test(test_ace_from_str_null_ptr),
 		cmocka_unit_test(test_ace_from_str_owner),

--- a/src/include/daos_security.h
+++ b/src/include/daos_security.h
@@ -436,6 +436,17 @@ int
 daos_acl_principal_to_gid(const char *principal, gid_t *gid);
 
 /**
+ * Get the principal name string from an Access Control Entry.
+ *
+ * \param[in]	ace	Access Control Entry
+ *
+ * \return	Either the string from the principal name field, or one of the
+ *		special principal names: OWNER@, GROUP@, EVERYONE@
+ */
+const char *
+daos_ace_get_principal_str(struct daos_ace *ace);
+
+/**
  * Convert an Access Control Entry formatted as a string to a daos_ace
  * structure.
  *

--- a/src/mgmt/srv_drpc.c
+++ b/src/mgmt/srv_drpc.c
@@ -351,6 +351,10 @@ create_pool_props(daos_prop_t **out_prop, char *owner, char *owner_grp,
 		if (rc != 0)
 			D_GOTO(err_out, rc);
 
+		rc = daos_acl_validate(out_acl);
+		if (rc != 0)
+			D_GOTO(err_out, rc);
+
 		entries++;
 	}
 

--- a/src/mgmt/tests/srv_drpc_tests.c
+++ b/src/mgmt/tests/srv_drpc_tests.c
@@ -1429,6 +1429,81 @@ test_drpc_pool_query_success_rebuild_err(void **state)
 	D_FREE(resp.body.data);
 }
 
+/*
+ * dRPC pool create tests
+ */
+static void
+expect_create_resp_with_error(Drpc__Response *resp, int exp_error)
+{
+	Mgmt__PoolCreateResp	*pc_resp = NULL;
+
+	assert_int_equal(resp->status, DRPC__STATUS__SUCCESS);
+	assert_non_null(resp->body.data);
+
+	pc_resp = mgmt__pool_create_resp__unpack(NULL, resp->body.len,
+						 resp->body.data);
+	assert_non_null(pc_resp);
+	assert_int_equal(pc_resp->status, exp_error);
+
+	mgmt__pool_create_resp__free_unpacked(pc_resp, NULL);
+}
+
+static void
+pack_pool_create_req(Mgmt__PoolCreateReq *req, Drpc__Call *call)
+{
+	size_t	len;
+	uint8_t	*body;
+
+	len = mgmt__pool_create_req__get_packed_size(req);
+	D_ALLOC(body, len);
+	assert_non_null(body);
+
+	mgmt__pool_create_req__pack(req, body);
+
+	call->body.data = body;
+	call->body.len = len;
+}
+
+static void
+test_drpc_pool_create_invalid_acl(void **state)
+{
+	Drpc__Call		call = DRPC__CALL__INIT;
+	Drpc__Response		resp = DRPC__RESPONSE__INIT;
+	Mgmt__PoolCreateReq	pc_req = MGMT__POOL_CREATE_REQ__INIT;
+	size_t			num_acl = 2;
+	size_t			i;
+	char			**bad_acl;
+	const char		*ace = "A::myuser@:rw"; /* to be duplicated */
+
+	pc_req.uuid = TEST_UUID;
+
+	/* Duplicate entries in the ACL should be invalid */
+	D_ALLOC_ARRAY(bad_acl, num_acl);
+	assert_non_null(bad_acl);
+	for (i = 0; i < num_acl; i++) {
+		D_STRNDUP(bad_acl[i], ace, DAOS_ACL_MAX_ACE_STR_LEN);
+		assert_non_null(bad_acl[i]);
+	}
+
+	pc_req.n_acl = num_acl;
+	pc_req.acl = bad_acl;
+
+	pack_pool_create_req(&pc_req, &call);
+
+	ds_mgmt_drpc_pool_create(&call, &resp);
+
+	expect_create_resp_with_error(&resp, -DER_INVAL);
+
+	/* clean up */
+	for (i = 0; i < num_acl; i++) {
+		D_FREE(bad_acl[i]);
+	}
+	D_FREE(bad_acl);
+	D_FREE(call.body.data);
+	D_FREE(resp.body.data);
+
+}
+
 #define ACL_TEST(x)	cmocka_unit_test_setup_teardown(x, \
 						drpc_pool_acl_setup, \
 						drpc_pool_acl_teardown)
@@ -1448,6 +1523,8 @@ test_drpc_pool_query_success_rebuild_err(void **state)
 
 #define QUERY_TEST(x)	cmocka_unit_test_setup(x, \
 						drpc_pool_query_setup)
+
+#define POOL_CREATE_TEST(x)	cmocka_unit_test(x)
 
 int
 main(void)
@@ -1489,6 +1566,7 @@ main(void)
 		QUERY_TEST(test_drpc_pool_query_success_rebuild_busy),
 		QUERY_TEST(test_drpc_pool_query_success_rebuild_done),
 		QUERY_TEST(test_drpc_pool_query_success_rebuild_err),
+		POOL_CREATE_TEST(test_drpc_pool_create_invalid_acl),
 	};
 
 	return cmocka_run_group_tests(tests, NULL, NULL);


### PR DESCRIPTION
Pool create via DMG was allowing invalid ACLs to be passed
in. So there were cases where a pool would be created with
no error, but pool get-acl would return -DER_INVAL.

- Validate the incoming ACL when translating from strings
  in the pool create dRPC handler. If it's invalid, return
  -DER_INVAL and don't create the pool.
- Fix daos_acl_validate() to correctly detect multiple
  entries for the same principal. Previously if the entry
  wasn't identical (i.e. same permissions), it was missed
  as a duplicate.
- Make daos_ace_get_principal_str() a public function.

Signed-off-by: Kris Jacque <kristin.jacque@intel.com>