### PR TITLE
DAOS-3938 control: Fix test issues

### DIFF
--- a/src/control/lib/atm/bool.go
+++ b/src/control/lib/atm/bool.go
@@ -1,0 +1,89 @@
+//
+// (C) Copyright 2020 Intel Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// GOVERNMENT LICENSE RIGHTS-OPEN SOURCE SOFTWARE
+// The Government's rights to use, modify, reproduce, release, perform, display,
+// or disclose this software are subject to the terms of the Apache License as
+// provided in Contract No. 8F-30005.
+// Any reproduction of computer software, computer software documentation, or
+// portions thereof marked with this legend must also reproduce the markings.
+//
+
+// Package atm provides a collection of thread-safe types.
+package atm
+
+import "sync/atomic"
+
+// Bool provides an atomic boolean value.
+type Bool uint32
+
+// NewBool returns a Bool set to the provided starting value.
+func NewBool(in bool) Bool {
+	var b Bool
+	if in {
+		b.SetTrue()
+	}
+	return b
+}
+
+// SetTrue sets the Bool to true.
+func (b *Bool) SetTrue() {
+	atomic.StoreUint32((*uint32)(b), 1)
+}
+
+// SetTrueCond sets the Bool to true if it's false.
+// Returns a bool indicating whether or not the value changed.
+func (b *Bool) SetTrueCond() bool {
+	return atomic.CompareAndSwapUint32((*uint32)(b), 0, 1)
+}
+
+// IsTrue returns true if the value is true.
+func (b *Bool) IsTrue() bool {
+	return b.Load()
+}
+
+// SetFalse sets the Bool to false.
+func (b *Bool) SetFalse() {
+	atomic.StoreUint32((*uint32)(b), 0)
+}
+
+// SetFalseCond sets the Bool to false if it's true.
+// Returns a bool indicating whether or not the value changed.
+func (b *Bool) SetFalseCond() bool {
+	return atomic.CompareAndSwapUint32((*uint32)(b), 1, 0)
+}
+
+// IsFalse returns false if the value is false.
+func (b *Bool) IsFalse() bool {
+	return !b.Load()
+}
+
+// Load returns a bool representing the value.
+func (b *Bool) Load() bool {
+	return atomic.LoadUint32((*uint32)(b)) == 1
+}
+
+// Toggle attempts to flip the value and returns a bool indicating whether
+// or not the value changed.
+func (b *Bool) Toggle() bool {
+	// NB: This isn't perfect, but there isn't a truly atomic way to
+	// implement this.
+	old := atomic.LoadUint32((*uint32)(b))
+	var new uint32
+	if old == 0 {
+		new = 1
+	}
+	return atomic.CompareAndSwapUint32((*uint32)(b), old, new)
+}

--- a/src/control/lib/atm/bool.go
+++ b/src/control/lib/atm/bool.go
@@ -43,12 +43,6 @@ func (b *Bool) SetTrue() {
 	atomic.StoreUint32((*uint32)(b), 1)
 }
 
-// SetTrueCond sets the Bool to true if it's false.
-// Returns a bool indicating whether or not the value changed.
-func (b *Bool) SetTrueCond() bool {
-	return atomic.CompareAndSwapUint32((*uint32)(b), 0, 1)
-}
-
 // IsTrue returns true if the value is true.
 func (b *Bool) IsTrue() bool {
 	return b.Load()
@@ -59,12 +53,6 @@ func (b *Bool) SetFalse() {
 	atomic.StoreUint32((*uint32)(b), 0)
 }
 
-// SetFalseCond sets the Bool to false if it's true.
-// Returns a bool indicating whether or not the value changed.
-func (b *Bool) SetFalseCond() bool {
-	return atomic.CompareAndSwapUint32((*uint32)(b), 1, 0)
-}
-
 // IsFalse returns false if the value is false.
 func (b *Bool) IsFalse() bool {
 	return !b.Load()
@@ -73,17 +61,4 @@ func (b *Bool) IsFalse() bool {
 // Load returns a bool representing the value.
 func (b *Bool) Load() bool {
 	return atomic.LoadUint32((*uint32)(b)) != 0
-}
-
-// Toggle attempts to flip the value and returns a bool indicating whether
-// or not the value changed.
-func (b *Bool) Toggle() bool {
-	// NB: This isn't perfect, but there isn't a truly atomic way to
-	// implement this.
-	old := atomic.LoadUint32((*uint32)(b))
-	var new uint32
-	if old == 0 {
-		new = 1
-	}
-	return atomic.CompareAndSwapUint32((*uint32)(b), old, new)
 }

--- a/src/control/lib/atm/bool.go
+++ b/src/control/lib/atm/bool.go
@@ -72,7 +72,7 @@ func (b *Bool) IsFalse() bool {
 
 // Load returns a bool representing the value.
 func (b *Bool) Load() bool {
-	return atomic.LoadUint32((*uint32)(b)) == 1
+	return atomic.LoadUint32((*uint32)(b)) != 0
 }
 
 // Toggle attempts to flip the value and returns a bool indicating whether

--- a/src/control/lib/atm/bool_test.go
+++ b/src/control/lib/atm/bool_test.go
@@ -66,17 +66,6 @@ func TestAtomicBool(t *testing.T) {
 			op:     "SetFalse",
 			expEnd: false,
 		},
-		"true-SetTrueCond": {
-			start:  true,
-			op:     "SetTrueCond",
-			expEnd: true,
-		},
-		"true-SetFalseCond": {
-			start:      true,
-			op:         "SetFalseCond",
-			expEnd:     false,
-			expChanged: true,
-		},
 		"false-SetTrue": {
 			start:  false,
 			op:     "SetTrue",
@@ -86,29 +75,6 @@ func TestAtomicBool(t *testing.T) {
 			start:  false,
 			op:     "SetFalse",
 			expEnd: false,
-		},
-		"false-SetTrueCond": {
-			start:      false,
-			op:         "SetTrueCond",
-			expEnd:     true,
-			expChanged: true,
-		},
-		"false-SetFalseCond": {
-			start:  false,
-			op:     "SetFalseCond",
-			expEnd: false,
-		},
-		"true-Toggle": {
-			start:      true,
-			op:         "Toggle",
-			expEnd:     false,
-			expChanged: true,
-		},
-		"false-Toggle": {
-			start:      false,
-			op:         "Toggle",
-			expEnd:     true,
-			expChanged: true,
 		},
 	} {
 		cmpBool := func(t *testing.T, expected, actual bool) {
@@ -126,25 +92,13 @@ func TestAtomicBool(t *testing.T) {
 			case "SetTrue":
 				b.SetTrue()
 				cmpBool(t, b.Load(), tc.expEnd)
-			case "SetTrueCond":
-				changed := b.SetTrueCond()
-				cmpBool(t, b.Load(), tc.expEnd)
-				cmpBool(t, tc.expChanged, changed)
 			case "IsTrue":
 				cmpBool(t, b.IsTrue(), tc.expEnd)
 			case "SetFalse":
 				b.SetFalse()
 				cmpBool(t, b.Load(), tc.expEnd)
-			case "SetFalseCond":
-				changed := b.SetFalseCond()
-				cmpBool(t, b.Load(), tc.expEnd)
-				cmpBool(t, tc.expChanged, changed)
 			case "IsFalse":
 				cmpBool(t, b.IsFalse(), tc.expEnd)
-			case "Toggle":
-				changed := b.Toggle()
-				cmpBool(t, b.Load(), tc.expEnd)
-				cmpBool(t, tc.expChanged, changed)
 			default:
 				t.Fatalf("unhandled op %q", tc.op)
 			}

--- a/src/control/lib/atm/bool_test.go
+++ b/src/control/lib/atm/bool_test.go
@@ -1,0 +1,153 @@
+//
+// (C) Copyright 2020 Intel Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// GOVERNMENT LICENSE RIGHTS-OPEN SOURCE SOFTWARE
+// The Government's rights to use, modify, reproduce, release, perform, display,
+// or disclose this software are subject to the terms of the Apache License as
+// provided in Contract No. 8F-30005.
+// Any reproduction of computer software, computer software documentation, or
+// portions thereof marked with this legend must also reproduce the markings.
+//
+
+package atm_test
+
+import (
+	"testing"
+
+	"github.com/daos-stack/daos/src/control/lib/atm"
+)
+
+func TestAtomicBool(t *testing.T) {
+	for name, tc := range map[string]struct {
+		start      bool
+		op         string
+		expEnd     bool
+		expChanged bool
+	}{
+		"true-IsTrue": {
+			start:  true,
+			op:     "IsTrue",
+			expEnd: true,
+		},
+		"true-IsFalse": {
+			start:  true,
+			op:     "IsFalse",
+			expEnd: false,
+		},
+		"false-IsTrue": {
+			start:  false,
+			op:     "IsTrue",
+			expEnd: false,
+		},
+		"false-IsFalse": {
+			start:  false,
+			op:     "IsFalse",
+			expEnd: true,
+		},
+		"true-SetTrue": {
+			start:  true,
+			op:     "SetTrue",
+			expEnd: true,
+		},
+		"true-SetFalse": {
+			start:  true,
+			op:     "SetFalse",
+			expEnd: false,
+		},
+		"true-SetTrueCond": {
+			start:  true,
+			op:     "SetTrueCond",
+			expEnd: true,
+		},
+		"true-SetFalseCond": {
+			start:      true,
+			op:         "SetFalseCond",
+			expEnd:     false,
+			expChanged: true,
+		},
+		"false-SetTrue": {
+			start:  false,
+			op:     "SetTrue",
+			expEnd: true,
+		},
+		"false-SetFalse": {
+			start:  false,
+			op:     "SetFalse",
+			expEnd: false,
+		},
+		"false-SetTrueCond": {
+			start:      false,
+			op:         "SetTrueCond",
+			expEnd:     true,
+			expChanged: true,
+		},
+		"false-SetFalseCond": {
+			start:  false,
+			op:     "SetFalseCond",
+			expEnd: false,
+		},
+		"true-Toggle": {
+			start:      true,
+			op:         "Toggle",
+			expEnd:     false,
+			expChanged: true,
+		},
+		"false-Toggle": {
+			start:      false,
+			op:         "Toggle",
+			expEnd:     true,
+			expChanged: true,
+		},
+	} {
+		cmpBool := func(t *testing.T, expected, actual bool) {
+			t.Helper()
+
+			if actual != expected {
+				t.Fatalf("expected %t; got %t", expected, actual)
+			}
+		}
+
+		t.Run(name, func(t *testing.T) {
+			b := atm.NewBool(tc.start)
+
+			switch tc.op {
+			case "SetTrue":
+				b.SetTrue()
+				cmpBool(t, b.Load(), tc.expEnd)
+			case "SetTrueCond":
+				changed := b.SetTrueCond()
+				cmpBool(t, b.Load(), tc.expEnd)
+				cmpBool(t, tc.expChanged, changed)
+			case "IsTrue":
+				cmpBool(t, b.IsTrue(), tc.expEnd)
+			case "SetFalse":
+				b.SetFalse()
+				cmpBool(t, b.Load(), tc.expEnd)
+			case "SetFalseCond":
+				changed := b.SetFalseCond()
+				cmpBool(t, b.Load(), tc.expEnd)
+				cmpBool(t, tc.expChanged, changed)
+			case "IsFalse":
+				cmpBool(t, b.IsFalse(), tc.expEnd)
+			case "Toggle":
+				changed := b.Toggle()
+				cmpBool(t, b.Load(), tc.expEnd)
+				cmpBool(t, tc.expChanged, changed)
+			default:
+				t.Fatalf("unhandled op %q", tc.op)
+			}
+		})
+	}
+}

--- a/src/mgmt/tests/mocks.c
+++ b/src/mgmt/tests/mocks.c
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright 2019 Intel Corporation.
+ * (C) Copyright 2019-2020 Intel Corporation.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -307,6 +307,7 @@ void
 mock_ds_mgmt_pool_set_prop_teardown(void)
 {
 	daos_prop_free(ds_mgmt_pool_set_prop_result);
+	daos_prop_free(ds_mgmt_pool_set_prop_prop);
 }
 
 /*


### PR DESCRIPTION
Fixes a few minor test issues:
  * Make storage/scm/MockSystemProvider's isMounted state atomic
  * Protect storage/scm/MockBackend's curState with a mutex
  * Fix memory leak in pool set-prop tests