### PR TITLE
CORCI-831 test: Always install PR build DAOS

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -44,11 +44,13 @@
 def arch = ""
 def sanitized_JOB_NAME = JOB_NAME.toLowerCase().replaceAll('/', '-').replaceAll('%2f', '-')
 
+def daos_packages_version = ""
 def el7_component_repos = ""
 def component_repos = ""
 def daos_repo = "daos@${env.BRANCH_NAME}:${env.BUILD_NUMBER}"
 def el7_daos_repos = el7_component_repos + ' ' + component_repos + ' ' + daos_repo
-def functional_rpms  = "ior-hpc-cart-4-daos-0 mpich-autoload-cart-4-daos-0 " +
+def functional_rpms  = "--exclude openmpi openmpi3 hwloc ndctl" +
+                       "ior-hpc-cart-4-daos-0 mpich-autoload-cart-4-daos-0 " +
                        "romio-tests-cart-4-daos-0 hdf5-tests-cart-4-daos-0 " +
                        "mpi4py-tests-cart-4-daos-0 testmpio-cart-4-daos-0"
 
@@ -148,6 +150,12 @@ pipeline {
             }
             parallel {
                 stage('checkpatch') {
+                    when {
+                      beforeAgent true
+                      expression {
+                        ! commitPragma(pragma: 'Skip-checkpatch').contains('true')
+                      }
+                    }
                     agent {
                         dockerfile {
                             filename 'Dockerfile.centos.7'
@@ -249,6 +257,10 @@ pipeline {
                                            cp -r . $OLDPWD/artifacts/centos7/)
                                           createrepo artifacts/centos7/
                                           cat $mockroot/result/{root,build}.log'''
+                               script {
+                                   daos_packages_version = sh(script: 'rpm --qf %{version}-%{release}.%{arch} -qp artifacts/centos7/daos-server-*.x86_64.rpm',
+                                      returnStdout: true)
+                               }
                             publishToRepository product: 'daos',
                                                 format: 'yum',
                                                 maturity: 'stable',
@@ -840,7 +852,10 @@ pipeline {
                                        node_count: 1,
                                        snapshot: true,
                                        inst_repos: el7_component_repos + ' ' + component_repos,
-                                       inst_rpms: "openmpi3 hwloc-devel argobots cart-${env.CART_COMMIT} fuse3-libs libisa-l libpmem libpmemobj protobuf-c spdk-devel libfabric-devel pmix numactl-devel"
+                                       inst_rpms: 'openmpi3 hwloc-devel argobots ' +
+                                                  "cart-${env.CART_COMMIT} fuse3-libs " +
+                                                  'libisa-l-devel libpmem libpmemobj protobuf-c ' +
+                                                  'spdk-devel libfabric-devel pmix numactl-devel'
                         runTest stashes: [ 'CentOS-tests', 'CentOS-install', 'CentOS-build-vars' ],
                                 script: '''# JENKINS-52781 tar function is breaking symlinks
                                            rm -rf test_results
@@ -1029,8 +1044,10 @@ pipeline {
                                        node_count: 9,
                                        snapshot: true,
                                        inst_repos: el7_daos_repos,
-                                       inst_rpms: 'openmpi3 hwloc cart-' + env.CART_COMMIT + ' ' +
-                                                  functional_rpms + ' ndctl'
+                                       inst_rpms: 'daos-' + daos_packages_version +
+                                                  ' daos-client-' + daos_packages_version +
+                                                  ' cart-' + env.CART_COMMIT + ' ' +
+                                                  functional_rpms
                         runTest stashes: [ 'CentOS-install', 'CentOS-build-vars' ],
                                 script: '''test_tag=$(git show -s --format=%B | sed -ne "/^Test-tag:/s/^.*: *//p")
                                            if [ -z "$test_tag" ]; then
@@ -1110,15 +1127,19 @@ pipeline {
                                        node_count: 1,
                                        snapshot: true,
                                        inst_repos: el7_daos_repos,
-                                       inst_rpms: 'openmpi3 hwloc cart-' + env.CART_COMMIT + ' ' +
-                                                  functional_rpms + ' ndctl'
+                                       inst_rpms: 'daos-' + daos_packages_version +
+                                                  ' daos-client-' + daos_packages_version +
+                                                  ' cart-' + env.CART_COMMIT + ' ' +
+                                                  functional_rpms
                         // Then just reboot the physical nodes
                         provisionNodes NODELIST: env.NODELIST,
                                        node_count: 9,
                                        power_only: true,
                                        inst_repos: el7_daos_repos,
-                                       inst_rpms: 'openmpi3 hwloc cart-' + env.CART_COMMIT + ' ' +
-                                                  functional_rpms + ' ndctl'
+                                       inst_rpms: 'daos-' + daos_packages_version +
+                                                  ' daos-client-' + daos_packages_version +
+                                                  ' cart-' + env.CART_COMMIT + ' ' +
+                                                  functional_rpms
                         runTest stashes: [ 'CentOS-install', 'CentOS-build-vars' ],
                                 script: '''test_tag=$(git show -s --format=%B | sed -ne "/^Test-tag-hw:/s/^.*: *//p")
                                            if [ -z "$test_tag" ]; then


### PR DESCRIPTION

If a PR lags too far behind master, it could be that the test tools will
use the repo version of DAOS rather than the PR's verison.

Force the PR build DAOS packages to be installed always.

Signed-off-by: Brian J. Murrell <brian.murrell@intel.com>
Quick-build: true