### PR TITLE
DAOS-3964 control: Fix tabular output padding/format

### DIFF
--- a/src/control/cmd/dmg/utils_test.go
+++ b/src/control/cmd/dmg/utils_test.go
@@ -1,5 +1,5 @@
 //
-// (C) Copyright 2018-2019 Intel Corporation.
+// (C) Copyright 2018-2020 Intel Corporation.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -272,7 +272,13 @@ func TestTabulateHostGroups(t *testing.T) {
 		"formatted results": {
 			g:       mockHostGroups(t),
 			cTitles: mockColumnTitles,
-			out:     "Hosts\t\tSCM\t\tNVME\t\t\t\n-----\t\t---\t\t----\t\t\t\nhost5\t\t10GB (2 devices)200TB (1 devices)\t\nhost[1-2]\t13GB (3 devices)200TB (4 devices)\t\nhost[3-4]\t13GB (3 devices)400TB (4 devices)\t\n",
+			out: `
+Hosts     SCM              NVME              
+-----     ---              ----              
+host5     10GB (2 devices) 200TB (1 devices) 
+host[1-2] 13GB (3 devices) 200TB (4 devices) 
+host[3-4] 13GB (3 devices) 400TB (4 devices) 
+`,
 		},
 		"column number mismatch": {
 			g:         mockHostGroups(t),
@@ -288,7 +294,7 @@ func TestTabulateHostGroups(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			table, err := tabulateHostGroups(tt.g, tt.cTitles...)
 			ExpectError(t, err, tt.expErrMsg, name)
-			if diff := cmp.Diff(tt.out, table); diff != "" {
+			if diff := cmp.Diff(strings.TrimLeft(tt.out, "\n"), table); diff != "" {
 				t.Fatalf("unexpected output (-want, +got):\n%s\n", diff)
 			}
 		})

--- a/src/control/lib/txtfmt/entity_test.go
+++ b/src/control/lib/txtfmt/entity_test.go
@@ -24,6 +24,7 @@
 package txtfmt
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -42,7 +43,8 @@ func TestEntityFormatter(t *testing.T) {
 				{"c": "d"},
 				{"bananas": "grapes"},
 			},
-			expectedResult: `title
+			expectedResult: `
+title
 -----
 a       : b     
 c       : d     
@@ -57,7 +59,8 @@ bananas : grapes
 		},
 		"empty attrs": {
 			title: "empty",
-			expectedResult: `empty
+			expectedResult: `
+empty
 -----
 `,
 		},
@@ -67,7 +70,8 @@ bananas : grapes
 				{"a": "b"},
 				{"foo": "bar"},
 			},
-			expectedResult: `long title is long
+			expectedResult: `
+long title is long
 ------------------
 a   : b  
 foo : bar
@@ -77,7 +81,7 @@ foo : bar
 		t.Run(name, func(t *testing.T) {
 			result := FormatEntity(tc.title, tc.attrs)
 
-			if diff := cmp.Diff(tc.expectedResult, result); diff != "" {
+			if diff := cmp.Diff(strings.TrimLeft(tc.expectedResult, "\n"), result); diff != "" {
 				t.Fatalf("unexpected result (-want, +got):\n%s\n", diff)
 			}
 		})

--- a/src/control/lib/txtfmt/table.go
+++ b/src/control/lib/txtfmt/table.go
@@ -42,7 +42,7 @@ type TableFormatter struct {
 
 // Init instantiates internal variables.
 func (t *TableFormatter) Init() {
-	t.writer = tabwriter.NewWriter(&t.out, 8, 8, 0, '\t', 0)
+	t.writer = tabwriter.NewWriter(&t.out, 0, 0, 1, ' ', 0)
 }
 
 // SetColumnTitles sets the ordered column titles for the table.

--- a/src/control/lib/txtfmt/table_test.go
+++ b/src/control/lib/txtfmt/table_test.go
@@ -24,6 +24,7 @@
 package txtfmt
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -107,44 +108,93 @@ func TestTableFormatter_Format(t *testing.T) {
 			expectedResult: "",
 		},
 		"single row": {
-			titles:         []string{"One"},
-			table:          []TableRow{{"One": "1"}},
-			expectedResult: "One\t\n---\t\n1\t\n",
+			titles: []string{"One"},
+			table:  []TableRow{{"One": "1"}},
+			expectedResult: `
+One 
+--- 
+1   
+`,
 		},
 		"multi-row": {
-			titles:         []string{"One"},
-			table:          []TableRow{{"One": "1"}, {"One": "2"}, {"One": "3"}},
-			expectedResult: "One\t\n---\t\n1\t\n2\t\n3\t\n",
+			titles: []string{"One"},
+			table:  []TableRow{{"One": "1"}, {"One": "2"}, {"One": "3"}},
+			expectedResult: `
+One 
+--- 
+1   
+2   
+3   
+`,
 		},
 		"multi-column": {
-			titles:         []string{"One", "Two", "Three"},
-			table:          []TableRow{{"One": "1", "Two": "2", "Three": "3"}, {"One": "4", "Two": "5", "Three": "6"}},
-			expectedResult: "One\tTwo\tThree\t\n---\t---\t-----\t\n1\t2\t3\t\n4\t5\t6\t\n",
+			titles: []string{"One", "Two", "Three"},
+			table:  []TableRow{{"One": "1", "Two": "2", "Three": "3"}, {"One": "4", "Two": "5", "Three": "6"}},
+			expectedResult: `
+One Two Three 
+--- --- ----- 
+1   2   3     
+4   5   6     
+`,
 		},
 		"empty table": {
-			titles:         []string{"One"},
-			table:          []TableRow{},
-			expectedResult: "One\t\n---\t\n",
+			titles: []string{"One"},
+			table:  []TableRow{},
+			expectedResult: `
+One 
+--- 
+`,
 		},
 		"no matches for titles": {
-			titles:         []string{"One", "Two"},
-			table:          []TableRow{{}},
-			expectedResult: "One\tTwo\t\n---\t---\t\nNone\tNone\t\n",
+			titles: []string{"One", "Two"},
+			table:  []TableRow{{}},
+			expectedResult: `
+One  Two  
+---  ---  
+None None 
+`,
 		},
 		"matches for some titles": {
-			titles:         []string{"One", "Two"},
-			table:          []TableRow{{"One": "1"}, {"Two": "2"}},
-			expectedResult: "One\tTwo\t\n---\t---\t\n1\tNone\t\nNone\t2\t\n",
+			titles: []string{"One", "Two"},
+			table:  []TableRow{{"One": "1"}, {"Two": "2"}},
+			expectedResult: `
+One  Two  
+---  ---  
+1    None 
+None 2    
+`,
 		},
 		"extra keys ignored": {
-			titles:         []string{"One", "Three"},
-			table:          []TableRow{{"One": "1", "Two": "2", "Three": "3", "Four": "4"}},
-			expectedResult: "One\tThree\t\n---\t-----\t\n1\t3\t\n",
+			titles: []string{"One", "Three"},
+			table:  []TableRow{{"One": "1", "Two": "2", "Three": "3", "Four": "4"}},
+			expectedResult: `
+One Three 
+--- ----- 
+1   3     
+`,
 		},
 		"tabbing for long string": {
-			titles:         []string{"One", "Two"},
-			table:          []TableRow{{"One": "1", "Two": "2"}, {"One": "too darn long"}},
-			expectedResult: "One\t\tTwo\t\n---\t\t---\t\n1\t\t2\t\ntoo darn long\tNone\t\n",
+			titles: []string{"One", "Two"},
+			table:  []TableRow{{"One": "1", "Two": "2"}, {"One": "too darn long"}},
+			expectedResult: `
+One           Two  
+---           ---  
+1             2    
+too darn long None 
+`,
+		},
+		"8-char field should be padded": {
+			titles: []string{"Hosts", "SCM Total", "NVMe Total"},
+			table: []TableRow{{
+				"Hosts":      "wolf-118",
+				"SCM Total":  "5.79TB (2 namespaces)",
+				"NVMe Total": "1.46TB (2 controllers)",
+			}},
+			expectedResult: `
+Hosts    SCM Total             NVMe Total             
+-----    ---------             ----------             
+wolf-118 5.79TB (2 namespaces) 1.46TB (2 controllers) 
+`,
 		},
 	} {
 		t.Run(name, func(t *testing.T) {
@@ -152,8 +202,8 @@ func TestTableFormatter_Format(t *testing.T) {
 
 			result := f.Format(tt.table)
 
-			if result != tt.expectedResult {
-				t.Fatalf("want: '%s', got: '%s'", tt.expectedResult, result)
+			if diff := cmp.Diff(strings.TrimLeft(tt.expectedResult, "\n"), result); diff != "" {
+				t.Fatalf("unexpected result (-want, +got):\n%s\n", diff)
 			}
 		})
 	}


### PR DESCRIPTION
* Ensure that cell contents are padded (make boundaries clearer)
 * Use space instead of tab for padding (consistent output)