### PR TITLE
DAOS-3318 DUNS: change the xattr format of the unified namespace

### DIFF
--- a/src/client/dfs/dfs.c
+++ b/src/client/dfs/dfs.c
@@ -1223,6 +1223,17 @@ dfs_umount(dfs_t *dfs)
 	return 0;
 }
 
+int
+dfs_query(dfs_t *dfs, dfs_attr_t *attr)
+{
+	if (dfs == NULL || !dfs->mounted)
+		return EINVAL;
+
+	memcpy(attr, &dfs->attr, sizeof(dfs_attr_t));
+
+	return 0;
+}
+
 /* Structure of global buffer for dfs */
 struct dfs_glob {
 	uint32_t		magic;

--- a/src/include/daos_fs.h
+++ b/src/include/daos_fs.h
@@ -105,6 +105,17 @@ int
 dfs_umount(dfs_t *dfs);
 
 /**
+ * Query attributes of a DFS mount.
+ *
+ * \param[in]	dfs	Pointer to the mounted file system.
+ * \param[out]	attr	Attributes on the DFS container.
+ *
+ * \return              0 on success, errno code on failure.
+ */
+int
+dfs_query(dfs_t *dfs, dfs_attr_t *attr);
+
+/**
  * Convert a local dfs mount to global representation data which can be
  * shared with peer processes.
  * If glob->iov_buf is set to NULL, the actual size of the global handle is

--- a/src/include/daos_uns.h
+++ b/src/include/daos_uns.h
@@ -57,9 +57,8 @@ struct duns_attr_t {
  * type, and create a new DAOS container in the pool that is passed in \a
  * attr.da_puuid. The uuid of the container is returned in \a attr.da_cuuid. Set
  * extended attributes on the dir/file created that points to pool uuid,
- * container uuid, and default object class to be used for object in that
- * container. This is to be used in a unified namespace solution to be able to
- * map a path in the unified namespace to a location in the DAOS tier.
+ * container uuid. This is to be used in a unified namespace solution to be able
+ * to map a path in the unified namespace to a location in the DAOS tier.
  *
  * \param[in]	poh	Pool handle
  * \param[in]	path	Valid path in an existing namespace.
@@ -75,7 +74,8 @@ duns_create_path(daos_handle_t poh, const char *path,
 
 /**
  * Retrieve the extended attributes on a path corresponding to DAOS location and
- * properties of that path.
+ * properties of that path. This includes the pool and container uuid and the
+ * container type. The rest of the fields are not populated in attr struct.
  *
  * \param[in]	path	Valid path in an existing namespace.
  * \param[out]	attr	Struct containing the xattrs on the path.

--- a/src/utils/daos.c
+++ b/src/utils/daos.c
@@ -601,8 +601,6 @@ cont_op_hdlr(struct cmd_args_s *ap)
 		ap->type = dattr.da_type;
 		uuid_copy(ap->p_uuid, dattr.da_puuid);
 		uuid_copy(ap->c_uuid, dattr.da_cuuid);
-		ap->oclass = dattr.da_oclass_id;
-		ap->chunk_size = dattr.da_chunk_size;
 	} else {
 		ARGS_VERIFY_PUUID(ap, out, rc = RC_PRINT_HELP);
 	}


### PR DESCRIPTION
- exclude chunk size and object class since they are stored in the
  file SB if a POSIX container.
- add a dfs_query() call to retrieve those attrs.
- update daos tool implementation accordingly.
- note this doesn't affect the tool usage or output.

Signed-off-by: Mohamad Chaarawi <mohamad.chaarawi@intel.com>