### PR TITLE
DAOS-3968 control: disable ext4 delayed allocation

### DIFF
--- a/src/control/server/storage/scm/provider.go
+++ b/src/control/server/storage/scm/provider.go
@@ -50,7 +50,7 @@ const (
 	fsTypeTmpfs = "tmpfs"
 
 	dcpmFsType    = fsTypeExt4
-	dcpmMountOpts = "dax"
+	dcpmMountOpts = "dax,nodelalloc"
 
 	ramFsType = fsTypeTmpfs
 


### PR DESCRIPTION
The ext4 delayed allocation feature does not play well with pmem
and significantly increate umount time. Disable it at mount time.

Signed-off-by: Johann Lombardi <johann.lombardi@intel.com>