### PR TITLE
DAOS-3084 dfuse: Add statfs/df support.

### DIFF
--- a/src/client/dfuse/SConscript
+++ b/src/client/dfuse/SConscript
@@ -32,7 +32,8 @@ OPS_SRC = ['create',
            'setattr',
            'symlink',
            'unlink',
-           'write']
+           'write',
+           'statfs']
 
 IOIL_SRC = ['int_posix.c', 'int_read.c', 'int_write.c']
 

--- a/src/client/dfuse/dfuse.h
+++ b/src/client/dfuse/dfuse.h
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2016-2019 Intel Corporation.
+ * (C) Copyright 2016-2020 Intel Corporation.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -146,7 +146,7 @@ struct dfuse_inode_ops {
 			  size_t size);
 	void (*removexattr)(fuse_req_t req, struct dfuse_inode_entry *inode,
 			    const char *name);
-
+	void (*statfs)(fuse_req_t req, struct dfuse_inode_entry *inode);
 };
 
 extern struct dfuse_inode_ops dfuse_dfs_ops;
@@ -365,6 +365,17 @@ struct fuse_lowlevel_ops *dfuse_get_fuse_ops();
 					__rc, strerror(-__rc));		\
 	} while (0)
 
+#define DFUSE_REPLY_STATFS(desc, req, stat)				\
+	do {								\
+		int __rc;						\
+		DFUSE_TRA_DEBUG(desc, "Returning statfs");		\
+		__rc = fuse_reply_statfs(req, stat);			\
+		if (__rc != 0)						\
+			DFUSE_TRA_ERROR(desc,				\
+					"fuse_reply_statfs returned %d:%s", \
+					__rc, strerror(-__rc));		\
+	} while (0)
+
 #define DFUSE_REPLY_IOCTL(handle, req, arg)			\
 	DFUSE_REPLY_IOCTL_SIZE(handle, req, &(arg), sizeof(arg))
 
@@ -531,6 +542,9 @@ dfuse_cb_removexattr(fuse_req_t, struct dfuse_inode_entry *, const char *);
 
 void
 dfuse_cb_setattr(fuse_req_t, struct dfuse_inode_entry *, struct stat *, int);
+
+void
+dfuse_cb_statfs(fuse_req_t, struct dfuse_inode_entry *);
 
 void dfuse_cb_ioctl(fuse_req_t req, fuse_ino_t ino, unsigned int cmd, void *arg,
 		    struct fuse_file_info *fi, unsigned int flags,

--- a/src/client/dfuse/dfuse_fuseops.c
+++ b/src/client/dfuse/dfuse_fuseops.c
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2016-2020 intel Corporation.
+ * (C) Copyright 2016-2020 Intel Corporation.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/client/dfuse/dfuse_fuseops.c
+++ b/src/client/dfuse/dfuse_fuseops.c
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2016-2019 Intel Corporation.
+ * (C) Copyright 2016-2020 intel Corporation.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -593,6 +593,35 @@ err:
 }
 
 static void
+df_ll_statfs(fuse_req_t req, fuse_ino_t ino)
+{
+	struct dfuse_projection_info	*fs_handle = fuse_req_userdata(req);
+	struct dfuse_inode_entry	*inode;
+	d_list_t			*rlink;
+	int				rc;
+
+	rlink = d_hash_rec_find(&fs_handle->dpi_iet, &ino, sizeof(ino));
+	if (!rlink) {
+		DFUSE_TRA_ERROR(fs_handle, "Failed to find inode %lu", ino);
+		D_GOTO(err, rc = ENOENT);
+	}
+
+	inode = container_of(rlink, struct dfuse_inode_entry, ie_htl);
+
+	if (!inode->ie_dfs->dfs_ops->statfs)
+		D_GOTO(decref, rc = ENOTSUP);
+
+	inode->ie_dfs->dfs_ops->statfs(req, inode);
+
+	d_hash_rec_decref(&fs_handle->dpi_iet, rlink);
+	return;
+decref:
+	d_hash_rec_decref(&fs_handle->dpi_iet, rlink);
+err:
+	DFUSE_REPLY_ERR_RAW(fs_handle, req, rc);
+}
+
+static void
 dfuse_fuse_destroy(void *userdata)
 {
 	D_FREE(userdata);
@@ -615,15 +644,18 @@ struct dfuse_inode_ops dfuse_dfs_ops = {
 	.listxattr	= dfuse_cb_listxattr,
 	.removexattr	= dfuse_cb_removexattr,
 	.setattr	= dfuse_cb_setattr,
+	.statfs		= dfuse_cb_statfs,
 };
 
 struct dfuse_inode_ops dfuse_cont_ops = {
 	.lookup		= dfuse_cont_lookup,
 	.mkdir		= dfuse_cont_mkdir,
+	.statfs		= dfuse_cb_statfs,
 };
 
 struct dfuse_inode_ops dfuse_pool_ops = {
 	.lookup		= dfuse_pool_lookup,
+	.statfs		= dfuse_cb_statfs,
 };
 
 /* Return the ops that should be passed to fuse */
@@ -653,6 +685,7 @@ struct fuse_lowlevel_ops
 	fuse_ops->listxattr	= df_ll_listxattr;
 	fuse_ops->removexattr	= df_ll_removexattr;
 	fuse_ops->setattr	= df_ll_setattr;
+	fuse_ops->statfs	= df_ll_statfs;
 
 	/* Ops that do not need to support per-inode indirection */
 	fuse_ops->init = dfuse_fuse_init;

--- a/src/client/dfuse/ops/statfs.c
+++ b/src/client/dfuse/ops/statfs.c
@@ -1,0 +1,69 @@
+/**
+ * (C) Copyright 2020 Intel Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * GOVERNMENT LICENSE RIGHTS-OPEN SOURCE SOFTWARE
+ * The Government's rights to use, modify, reproduce, release, perform, display,
+ * or disclose this software are subject to the terms of the Apache License as
+ * provided in Contract No. B609815.
+ * Any reproduction of computer software, computer software documentation, or
+ * portions thereof marked with this legend must also reproduce the markings.
+ */
+
+#include "dfuse_common.h"
+#include "dfuse.h"
+
+void
+dfuse_cb_statfs(fuse_req_t req, struct dfuse_inode_entry *inode)
+{
+	struct statvfs stbuf = {};
+	daos_pool_info_t info = {.pi_bits = DPI_SPACE};
+	int rc;
+
+	if (!daos_handle_is_inval(inode->ie_dfs->dfs_poh)) {
+
+		rc = daos_pool_query(inode->ie_dfs->dfs_poh, NULL, &info,
+				     NULL, NULL);
+		if (rc != -DER_SUCCESS)
+			D_GOTO(err, rc = daos_der2errno(rc));
+
+		stbuf.f_blocks = info.pi_space.ps_space.s_total[DAOS_MEDIA_SCM] \
+			+ info.pi_space.ps_space.s_total[DAOS_MEDIA_NVME];
+		stbuf.f_bfree = info.pi_space.ps_space.s_free[DAOS_MEDIA_SCM] \
+			+ info.pi_space.ps_space.s_free[DAOS_MEDIA_NVME];
+
+		DFUSE_TRA_INFO(inode, "blocks %#lx free %#lx",
+			       stbuf.f_blocks, stbuf.f_bfree);
+	} else {
+		stbuf.f_blocks = 1024 * 1024 * 2;
+		stbuf.f_bfree = 1024 * 1024;
+	}
+
+	stbuf.f_bsize = 1;
+	stbuf.f_frsize = 1;
+
+	stbuf.f_files = 1024 * 1024 * 2;
+	stbuf.f_ffree = 1024 * 1024;
+
+	stbuf.f_namemax = 255;
+
+	stbuf.f_bavail = stbuf.f_bfree;
+	stbuf.f_favail = stbuf.f_ffree;
+
+	DFUSE_REPLY_STATFS(inode, req, &stbuf);
+	return;
+err:
+	DFUSE_REPLY_ERR_RAW(inode, req, rc);
+}
+

--- a/src/client/dfuse/ops/statfs.c
+++ b/src/client/dfuse/ops/statfs.c
@@ -31,9 +31,9 @@ dfuse_cb_statfs(fuse_req_t req, struct dfuse_inode_entry *inode)
 	daos_pool_info_t info = {.pi_bits = DPI_SPACE};
 	int rc;
 
-	if (!daos_handle_is_inval(inode->ie_dfs->dfs_poh)) {
-		rc = daos_pool_query(inode->ie_dfs->dfs_poh, NULL, &info,
-				     NULL, NULL);
+	if (!daos_handle_is_inval(inode->ie_dfs->dfs_dfp->dfp_poh)) {
+		rc = daos_pool_query(inode->ie_dfs->dfs_dfp->dfp_poh, NULL,
+				     &info, NULL, NULL);
 		if (rc != -DER_SUCCESS)
 			D_GOTO(err, rc = daos_der2errno(rc));
 

--- a/src/client/dfuse/ops/statfs.c
+++ b/src/client/dfuse/ops/statfs.c
@@ -45,15 +45,15 @@ dfuse_cb_statfs(fuse_req_t req, struct dfuse_inode_entry *inode)
 		DFUSE_TRA_INFO(inode, "blocks %#lx free %#lx",
 			       stbuf.f_blocks, stbuf.f_bfree);
 	} else {
-		stbuf.f_blocks = 1024 * 1024 * 2;
-		stbuf.f_bfree = 1024 * 1024;
+		stbuf.f_blocks = -1;
+		stbuf.f_bfree = -1;
 	}
 
 	stbuf.f_bsize = 1;
 	stbuf.f_frsize = 1;
 
-	stbuf.f_files = 1024 * 1024 * 2;
-	stbuf.f_ffree = 1024 * 1024;
+	stbuf.f_files = -1;
+	stbuf.f_ffree = -1;
 
 	stbuf.f_namemax = 255;
 

--- a/src/client/dfuse/ops/statfs.c
+++ b/src/client/dfuse/ops/statfs.c
@@ -32,7 +32,6 @@ dfuse_cb_statfs(fuse_req_t req, struct dfuse_inode_entry *inode)
 	int rc;
 
 	if (!daos_handle_is_inval(inode->ie_dfs->dfs_poh)) {
-
 		rc = daos_pool_query(inode->ie_dfs->dfs_poh, NULL, &info,
 				     NULL, NULL);
 		if (rc != -DER_SUCCESS)


### PR DESCRIPTION
Handle the statfs call per inode returning capacity/space from DAOS pools.
If no pool for an inode return 2M/1M.
For inode counts always return 2M/1M.

Add together the NVM and SCM values for space usage.