### PR TITLE
DAOS-623 test: Fix for strncpy Usage

### DIFF
--- a/src/object/tests/srv_checksum_tests.c
+++ b/src/object/tests/srv_checksum_tests.c
@@ -62,7 +62,7 @@ fake_update(struct daos_csummer *obj, uint8_t *buf, size_t buf_len)
 		strncpy(fake_update_buf, (char *)buf, buf_len);
 		fake_update_buf += buf_len;
 		fake_update_bytes += buf_len;
-		strncpy(fake_update_buf, "|", 1);
+		fake_update_buf[0] = '|';
 		fake_update_buf++;
 		fake_update_bytes++;
 	}


### PR DESCRIPTION
Remove strncpy of a single char and just set directly

Skip-func-test: true
Skip-func-hw-test: true

Signed-off-by: Ryon Jensen <ryon.jensen@intel.com>