### PR TITLE
DAOS-3979 control: Allow 'sm' fabric provider in config

### DIFF
--- a/src/control/lib/netdetect/netdetect.go
+++ b/src/control/lib/netdetect/netdetect.go
@@ -805,6 +805,13 @@ func ValidateProviderConfig(device string, provider string) error {
 		return errors.New("provider required")
 	}
 
+	// Allow provider 'sm' (shared memory) to pass validation without passing any of the checks
+	// The provider is valid to use, but does not use devices.  Therefore, it is handled specially to avoid
+	// flagging it as an error.
+	if provider == "sm" {
+		return nil
+	}
+
 	if device == "" {
 		return errors.New("device required")
 	}

--- a/src/control/lib/netdetect/netdetect_test.go
+++ b/src/control/lib/netdetect/netdetect_test.go
@@ -302,3 +302,22 @@ func TestDeviceAlias(t *testing.T) {
 		})
 	}
 }
+
+// TestValidateProviderSm verifies that using the shared memory provider 'sm'
+// is validated with a positive result.
+func TestValidateProviderSm(t *testing.T) {
+	provider := "" // an empty provider string is a search for 'all'
+	results, err := ScanFabric(provider)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(results) == 0 {
+		t.Fatal(err)
+	}
+
+	for _, sf := range results {
+		err := ValidateProviderConfig(sf.DeviceName, "sm")
+		AssertEqual(t, err, nil, "Network device configuration is invalid - provider not supported")
+	}
+}


### PR DESCRIPTION
	Implements a special case handler in ValidateProviderConfig() that allows
	provider 'sm' to pass through validation successfully.  This provider may
	be specified to daos_server, but it will not be validated against the
	network device name given.

Signed-off-by: Joel Rosenzweig <joel.b.rosenzweig@intel.com>