### PR TITLE
DAOS-3992 daos_test arg parsing conflict with rebuild_simple

### DIFF
--- a/src/tests/suite/daos_test.c
+++ b/src/tests/suite/daos_test.c
@@ -295,7 +295,7 @@ main(int argc, char **argv)
 		{"oid_alloc",	no_argument,		NULL,	'O'},
 		{"degraded",	no_argument,		NULL,	'd'},
 		{"rebuild",	no_argument,		NULL,	'r'},
-		{"rebuild_simple",	no_argument,	NULL,	's'},
+		{"rebuild_simple",	no_argument,	NULL,	'v'},
 		{"nvme_recovery",	no_argument,	NULL,	'N'},
 		{"group",	required_argument,	NULL,	'g'},
 		{"csum_type",	required_argument,	NULL,


### PR DESCRIPTION
This change fixes typo that resulted in a a clash between the
getopt_long() options for --svcn and --rebuild_simple that both
specified 's'.

Skip-test: true

Signed-off-by: Ken Cain <kenneth.c.cain@intel.com>