### PR TITLE
DAOS-3952 iv: return ENOTLEADER if leader change

### DIFF
--- a/src/iosrv/server_iv.c
+++ b/src/iosrv/server_iv.c
@@ -408,8 +408,19 @@ ivc_on_fetch(crt_iv_namespace_t ivns, crt_iv_key_t *iv_key,
 	/* Forward the request to its parent if it is not root, and
 	 * let's caller decide how to deal with leader.
 	 */
-	if (!valid && ns->iv_master_rank != dss_self_rank())
-		return -DER_IVCB_FORWARD;
+	if (!valid) {
+		/* If the rank inside the iv_fetch request(key) does not
+		 * match the current ns information, then it means the new
+		 * leader just steps up.  Let's return -DER_NOTLEADER in this
+		 * case, so IV fetch can keep retry, until the IV information
+		 * is updated on all nodes.
+		 */
+		if ((key.rank == dss_self_rank() &&
+		     key.rank != ns->iv_master_rank))
+			return -DER_NOTLEADER;
+		else if (ns->iv_master_rank != dss_self_rank())
+			return -DER_IVCB_FORWARD;
+	}
 
 	rc = fetch_iv_value(entry, &key, iv_value, &entry->iv_value, priv);
 	if (rc == 0)


### PR DESCRIPTION
Let's return ENOTLEADER if the leader has changed
during iv fetch, so iv fetch can retry until the
new leader information is updated over all servers.

Signed-off-by: Di Wang <di.wang@intel.com>