### PR TITLE
DAOS-3954 vos: not create punch target for non-rebuild case

### DIFF
--- a/src/dtx/dtx_common.c
+++ b/src/dtx/dtx_common.c
@@ -586,6 +586,9 @@ dtx_leader_end(struct dtx_leader_handle *dlh, struct ds_cont_child *cont,
 	if (result < 0 || rc < 0)
 		D_GOTO(out, result = result < 0 ? result : rc);
 
+	if (!dth->dth_actived)
+		D_GOTO(out, result = 0);
+
 	if (dth->dth_intent == DAOS_INTENT_PUNCH)
 		flags |= DCF_FOR_PUNCH;
 	if (dth->dth_has_ilog)
@@ -638,12 +641,13 @@ out:
 
 	D_DEBUG(DB_TRACE,
 		"Stop the DTX "DF_DTI" ver %u, dkey %llu, intent %s, "
-		"%s, %s participator(s): rc = %d\n",
+		"%s, %s participator(s), modified %s: rc = %d\n",
 		DP_DTI(&dth->dth_xid), dth->dth_ver,
 		(unsigned long long)dth->dth_dkey_hash,
 		dth->dth_intent == DAOS_INTENT_PUNCH ? "Punch" : "Update",
 		dth->dth_sync ? "sync" : "async",
-		dth->dth_solo ? "single" : "multiple", result);
+		dth->dth_solo ? "single" : "multiple",
+		dth->dth_actived ? "something" : "nothing", result);
 
 	D_ASSERTF(result <= 0, "unexpected return value %d\n", result);
 

--- a/src/vos/vos_dtx.c
+++ b/src/vos/vos_dtx.c
@@ -1704,9 +1704,11 @@ vos_dtx_cleanup_dth(struct dtx_handle *dth)
 	d_iov_set(&kiov, &dth->dth_xid, sizeof(dth->dth_xid));
 	rc = dbtree_delete(vos_hdl2cont(dth->dth_coh)->vc_dtx_active_hdl,
 			   BTR_PROBE_EQ, &kiov, NULL);
-	if (rc != 0)
+	if (rc != 0) {
 		D_ERROR(DF_UOID" failed to remove DTX entry "DF_DTI": %d\n",
 			DP_UOID(dth->dth_oid), DP_DTI(&dth->dth_xid), rc);
-	else
+	} else {
+		dth->dth_ent = NULL;
 		dth->dth_actived = 0;
+	}
 }

--- a/src/vos/vos_obj.c
+++ b/src/vos/vos_obj.c
@@ -74,17 +74,22 @@ key_punch(struct vos_object *obj, daos_epoch_t epoch, uint32_t pm_ver,
 				    flags);
 		if (rc != 0)
 			D_GOTO(out, rc);
-
 	} else {
 		daos_handle_t		 toh;
 		int			 i;
 
-		rc = key_tree_prepare(obj, obj->obj_toh, VOS_BTR_DKEY,
-				      dkey, SUBTR_CREATE, DAOS_INTENT_PUNCH,
-				      &krec, &toh);
+		/* For non-rebuild case, if the key does not exist,
+		 * don't create it.
+		 */
+		rc = key_tree_prepare(obj, obj->obj_toh, VOS_BTR_DKEY, dkey,
+				flags & VOS_OF_REPLAY_PC ? SUBTR_CREATE : 0,
+				DAOS_INTENT_PUNCH, &krec, &toh);
 		if (rc) {
-			D_ERROR("Error preparing dkey: rc="DF_RC"\n",
-				DP_RC(rc));
+			if (rc == -DER_NONEXIST && !(flags & VOS_OF_REPLAY_PC))
+				rc = 0;
+			else
+				D_ERROR("Error preparing dkey: rc="DF_RC"\n",
+					DP_RC(rc));
 			D_GOTO(out, rc);
 		}
 
@@ -161,15 +166,21 @@ vos_obj_punch(daos_handle_t coh, daos_unit_oid_t oid, daos_epoch_t epoch,
 		dth->dth_dti_cos_done = 1;
 	}
 
-	/* NB: punch always generate a new incarnation of the object */
+	/* NB: punch always generate a new incarnation of the object.
+	 *
+	 * For non-rebuild case, if the object does not exist, don't create it.
+	 */
 	rc = vos_obj_hold(vos_obj_cache_current(), vos_hdl2cont(coh), oid, &epr,
-			  false, DAOS_INTENT_PUNCH, true, &obj);
+			  flags & VOS_OF_REPLAY_PC ? false : true,
+			  DAOS_INTENT_PUNCH, true, &obj);
 	if (rc == 0) {
 		if (dkey) /* key punch */
 			rc = key_punch(obj, epoch, pm_ver, dkey,
 				       akey_nr, akeys, flags);
 		else /* object punch */
 			rc = obj_punch(coh, obj, epoch, flags);
+	} else if (rc == -DER_NONEXIST && !(flags & VOS_OF_REPLAY_PC)) {
+		rc = 0;
 	}
 
 	if (dth != NULL && rc == 0)

--- a/src/vos/vos_obj_index.c
+++ b/src/vos/vos_obj_index.c
@@ -217,6 +217,7 @@ int
 vos_oi_find_alloc(struct vos_container *cont, daos_unit_oid_t oid,
 		  daos_epoch_t epoch, bool log, struct vos_obj_df **obj_p)
 {
+	struct dtx_handle	*dth = vos_dth_get();
 	struct vos_obj_df	*obj = NULL;
 	d_iov_t			 key_iov;
 	d_iov_t			 val_iov;
@@ -240,7 +241,8 @@ vos_oi_find_alloc(struct vos_container *cont, daos_unit_oid_t oid,
 	d_iov_set(&val_iov, NULL, 0);
 	d_iov_set(&key_iov, &oid, sizeof(oid));
 
-	rc = dbtree_upsert(cont->vc_btr_hdl, BTR_PROBE_EQ, DAOS_INTENT_DEFAULT,
+	rc = dbtree_upsert(cont->vc_btr_hdl, BTR_PROBE_EQ,
+			   dth != NULL ? dth->dth_intent : DAOS_INTENT_UPDATE,
 			   &key_iov, &val_iov);
 	if (rc) {
 		D_ERROR("Failed to update Key for Object index\n");

--- a/src/vos/vos_tree.c
+++ b/src/vos/vos_tree.c
@@ -977,12 +977,12 @@ key_tree_punch(struct vos_object *obj, daos_handle_t toh, daos_epoch_t epoch,
 	daos_handle_t		 loh = DAOS_HDL_INVAL;
 	int			 rc;
 
-	rc = dbtree_fetch(toh, BTR_PROBE_EQ, DAOS_INTENT_UPDATE, key_iov, NULL,
+	rc = dbtree_fetch(toh, BTR_PROBE_EQ, DAOS_INTENT_PUNCH, key_iov, NULL,
 			  val_iov);
 	if (rc != 0) {
 		D_ASSERT(rc == -DER_NONEXIST);
 		/* use BTR_PROBE_BYPASS to avoid probe again */
-		rc = dbtree_upsert(toh, BTR_PROBE_BYPASS, DAOS_INTENT_UPDATE,
+		rc = dbtree_upsert(toh, BTR_PROBE_BYPASS, DAOS_INTENT_PUNCH,
 				   key_iov, val_iov);
 		if (rc) {
 			D_ERROR("Failed to add new punch, rc="DF_RC"\n",

--- a/src/vos/vos_tree.c
+++ b/src/vos/vos_tree.c
@@ -981,6 +981,16 @@ key_tree_punch(struct vos_object *obj, daos_handle_t toh, daos_epoch_t epoch,
 			  val_iov);
 	if (rc != 0) {
 		D_ASSERT(rc == -DER_NONEXIST);
+
+		/* For non-rebuild case, if the key does not exist,
+		 * don't create it.
+		 */
+		if (!(flags & VOS_OF_REPLAY_PC))
+			return 0;
+
+		/* For rebuild case, bypass DTX. */
+		D_ASSERT(vos_dth_get() == NULL);
+
 		/* use BTR_PROBE_BYPASS to avoid probe again */
 		rc = dbtree_upsert(toh, BTR_PROBE_BYPASS, DAOS_INTENT_PUNCH,
 				   key_iov, val_iov);


### PR DESCRIPTION
For non-rebuild case, in spite of for punch object or punch key,
if the target does not exist, it is not necessary to create the
target firstly, then punch it; otherwise, it will leave useless
information in related tree and cause additional incarnation log
and DTX operations.

For DTX logic, if nothing is modified, then do not add it into CoS
cache, instead, release the DTX directly.

Signed-off-by: Fan Yong <fan.yong@intel.com>