### PR TITLE
DAOS-2447 obj: add single value EC update/fetch/punch

### DIFF
--- a/src/object/cli_obj.c
+++ b/src/object/cli_obj.c
@@ -676,6 +676,7 @@ obj_rw_req_reassemb(struct dc_object *obj, daos_obj_rw_t *args,
 			      obj_auxi->opc == DAOS_OBJ_RPC_UPDATE);
 	if (rc == 0) {
 		obj_auxi->flags |= ORF_DTX_SYNC;
+		obj_auxi->flags |= ORF_EC;
 		obj_auxi->req_reasbed = true;
 		if (reasb_req->orr_iods != NULL)
 			args->iods = reasb_req->orr_iods;
@@ -2368,9 +2369,6 @@ shard_rw_prep(struct shard_auxi_args *shard_auxi, struct dc_object *obj,
 				shard_auxi->shard - shard_auxi->start_shard);
 			D_ASSERT(toiod != NULL);
 			shard_arg->oiods = toiod->oto_oiods;
-			D_ASSERT(shard_arg->oiods[0].oiod_nr == 1 &&
-				 (shard_arg->oiods[0].oiod_flags &
-				  OBJ_SIOD_PROC_ONE) != 0);
 			shard_arg->offs = toiod->oto_offs;
 			D_ASSERT(shard_arg->offs != NULL);
 		} else {

--- a/src/object/obj_ec.h
+++ b/src/object/obj_ec.h
@@ -65,6 +65,8 @@ struct obj_shard_iod {
 #define OBJ_SIOD_EVEN_DIST	((uint32_t)1 << 0)
 /** Flag used only for proc func, to only proc to one specific target */
 #define OBJ_SIOD_PROC_ONE	((uint32_t)1 << 1)
+/** Flag of single value EC */
+#define OBJ_SIOD_SINGV		((uint32_t)1 << 2)
 
 /**
  * Object IO descriptor.
@@ -134,7 +136,6 @@ struct obj_tgt_oiod {
 	uint32_t		 oto_tgt_idx;
 	/* number of iods */
 	uint32_t		 oto_iod_nr;
-	uint32_t		 oto_tgt_nr;
 	/* offset array, oto_iod_nr offsets for each target */
 	uint64_t		*oto_offs;
 	/* oiod array, oto_iod_nr oiods for each target,
@@ -325,9 +326,12 @@ obj_io_desc_init(struct obj_io_desc *oiod, uint32_t tgt_nr, uint32_t flags)
 		return 0;
 	}
 #endif
-	D_ALLOC_ARRAY(oiod->oiod_siods, tgt_nr);
-	if (oiod->oiod_siods == NULL)
-		return -DER_NOMEM;
+	if ((flags & OBJ_SIOD_SINGV) == 0) {
+		D_ALLOC_ARRAY(oiod->oiod_siods, tgt_nr);
+		if (oiod->oiod_siods == NULL)
+			return -DER_NOMEM;
+	}
+	oiod->oiod_flags = flags;
 	oiod->oiod_nr = tgt_nr;
 	return 0;
 }

--- a/src/object/obj_rpc.c
+++ b/src/object/obj_rpc.c
@@ -29,7 +29,8 @@
 #include <daos/event.h>
 #include <daos/rpc.h>
 #include <daos/object.h>
-#include "obj_rpc.h"
+
+#include "obj_internal.h"
 
 /** proc functions defined in other files */
 int
@@ -259,7 +260,9 @@ crt_proc_daos_iod_t(crt_proc_t proc, crt_proc_op_t proc_op, daos_iod_t *dvi,
 #endif
 
 	if (proc_op == CRT_PROC_ENCODE || proc_op == CRT_PROC_FREE) {
-		if (dvi->iod_type == DAOS_IOD_ARRAY && dvi->iod_recxs != NULL)
+		/* PARITY_INDICATOR flag indicates singv EC */
+		if (dvi->iod_recxs != NULL && (dvi->iod_type == DAOS_IOD_ARRAY
+		    || (dvi->iod_recxs[0].rx_idx & PARITY_INDICATOR) != 0))
 			existing_flags |= IOD_REC_EXIST;
 	}
 

--- a/src/object/obj_rpc.h
+++ b/src/object/obj_rpc.h
@@ -123,6 +123,11 @@ enum obj_rpc_flags {
 	ORF_RESEND		= (1 << 1),
 	/** Commit DTX synchronously. */
 	ORF_DTX_SYNC		= (1 << 2),
+	/**
+	 * Erasure coding flag, to avoid server recheck from oca,
+	 * now only used for single value EC handling.
+	 */
+	ORF_EC			= (1 << 3),
 };
 
 struct obj_iod_array {

--- a/src/object/srv_ec.c
+++ b/src/object/srv_ec.c
@@ -62,10 +62,11 @@ obj_ec_rw_req_split(struct obj_rw_in *orw, struct obj_ec_split_req **split_req)
 	D_ASSERT(tgt_nr >= 2);
 	D_ASSERT(oiods != NULL);
 	/* as we select the last parity node as leader, and for any update
-	 * there must be a siod (the last siod) for leader.
+	 * there must be a siod (the last siod) for leader except for singv.
 	 */
-	D_ASSERT(oiods[0].oiod_nr >= 2);
-	tgt_max_idx = oiods[0].oiod_siods[oiods[0].oiod_nr - 1].siod_tgt_idx;
+	D_ASSERT((oiods[0].oiod_flags & OBJ_SIOD_SINGV) ||
+		 oiods[0].oiod_nr >= 2);
+	tgt_max_idx = orw->orw_oid.id_shard - start_shard;
 
 	req_size = roundup(sizeof(struct obj_ec_split_req), 8);
 	iods_size = roundup(sizeof(daos_iod_t) * iod_nr, 8);
@@ -94,15 +95,24 @@ obj_ec_rw_req_split(struct obj_rw_in *orw, struct obj_ec_split_req **split_req)
 
 	split_iods = req->osr_iods;
 	for (i = 0; i < iod_nr; i++) {
+		int	idx;
+
 		iod = &iods[i];
 		split_iod = &split_iods[i];
 		split_iod->iod_name = iod->iod_name;
 		split_iod->iod_type = iod->iod_type;
 		split_iod->iod_size = iod->iod_size;
-		siod = &tgt_oiod->oto_oiods[i].oiod_siods[0];
-		split_iod->iod_nr = siod->siod_nr;
+		if (tgt_oiod->oto_oiods[i].oiod_flags & OBJ_SIOD_SINGV) {
+			D_ASSERT(iod->iod_type == DAOS_IOD_SINGLE);
+			idx = 0;
+			split_iod->iod_nr = 1;
+		} else {
+			siod = &tgt_oiod->oto_oiods[i].oiod_siods[0];
+			split_iod->iod_nr = siod->siod_nr;
+			idx = siod->siod_idx;
+		}
 		if (iod->iod_recxs != NULL)
-			split_iod->iod_recxs = &iod->iod_recxs[siod->siod_idx];
+			split_iod->iod_recxs = &iod->iod_recxs[idx];
 	}
 
 	*split_req = req;

--- a/src/object/srv_obj.c
+++ b/src/object/srv_obj.c
@@ -772,18 +772,20 @@ obj_singv_ec_rw_filter(struct obj_rw_in *orw, daos_iod_t *iods, uint64_t *offs,
 	tgt_idx = orw->orw_oid.id_shard - orw->orw_start_shard;
 	for (i = 0; i < orw->orw_nr; i++) {
 		iod = &iods[i];
-		if (iod->iod_type != DAOS_IOD_SINGLE || iod->iod_recxs == NULL)
+		if (iod->iod_type != DAOS_IOD_SINGLE ||
+		    (orw->orw_flags & ORF_EC) == 0)
 			continue;
 		/* for singv EC */
+		D_ASSERT(iod->iod_recxs == NULL);
 		if (iod->iod_size == DAOS_REC_ANY) /* punch */
 			continue;
 		if (oca == NULL) {
 			oca = daos_oclass_attr_find(orw->orw_oid.id_pub);
 			D_ASSERT(oca != NULL && DAOS_OC_IS_EC(oca));
 		}
-		/* using rx_nr to pass ir_gsize (through akey_update_single) */
+		/* using iod_recxs to pass ir_gsize (akey_update_single) */
 		if (for_update)
-			iod->iod_recxs[0].rx_nr = iod->iod_size;
+			iod->iod_recxs = (void *)iod->iod_size;
 		if (!obj_ec_singv_one_tgt(iod, NULL, oca)) {
 			obj_ec_singv_local_sz(iod->iod_size, oca, tgt_idx,
 					      &loc);

--- a/src/object/srv_obj.c
+++ b/src/object/srv_obj.c
@@ -758,6 +758,41 @@ csum_add2iods(daos_handle_t ioh, daos_iod_t *iods, uint32_t iods_nr,
 	return rc;
 }
 
+/** Filter and prepare for the sing value EC update/fetch */
+static void
+obj_singv_ec_rw_filter(struct obj_rw_in *orw, daos_iod_t *iods, uint64_t *offs,
+		       bool for_update)
+{
+	struct daos_oclass_attr		*oca = NULL;
+	daos_iod_t			*iod;
+	struct obj_ec_singv_local	 loc;
+	uint32_t			 tgt_idx;
+	uint32_t			 i;
+
+	tgt_idx = orw->orw_oid.id_shard - orw->orw_start_shard;
+	for (i = 0; i < orw->orw_nr; i++) {
+		iod = &iods[i];
+		if (iod->iod_type != DAOS_IOD_SINGLE || iod->iod_recxs == NULL)
+			continue;
+		/* for singv EC */
+		D_ASSERT(iod->iod_size != DAOS_REC_ANY);
+		if (oca == NULL) {
+			oca = daos_oclass_attr_find(orw->orw_oid.id_pub);
+			D_ASSERT(oca != NULL && DAOS_OC_IS_EC(oca));
+		}
+		/* using rx_nr to pass ir_gsize (through akey_update_single) */
+		if (for_update)
+			iod->iod_recxs[0].rx_nr = iod->iod_size;
+		if (!obj_ec_singv_one_tgt(iod, NULL, oca)) {
+			obj_ec_singv_local_sz(iod->iod_size, oca, tgt_idx,
+					      &loc);
+			offs[i] = loc.esl_off;
+			if (for_update)
+				iod->iod_size = loc.esl_size;
+		}
+	}
+}
+
 static int
 obj_local_rw(crt_rpc_t *rpc, struct ds_cont_hdl *cont_hdl,
 	     struct ds_cont_child *cont, daos_iod_t *split_iods,
@@ -806,6 +841,7 @@ obj_local_rw(crt_rpc_t *rpc, struct ds_cont_hdl *cont_hdl,
 
 	/* Prepare IO descriptor */
 	if (obj_rpc_is_update(rpc)) {
+		obj_singv_ec_rw_filter(orw, iods, offs, true);
 		bulk_op = CRT_BULK_GET;
 		rc = vos_update_begin(cont->sc_hdl, orw->orw_oid,
 				      orw->orw_epoch, dkey, orw->orw_nr, iods,
@@ -843,6 +879,7 @@ obj_local_rw(crt_rpc_t *rpc, struct ds_cont_hdl *cont_hdl,
 			orwo->orw_sgls.ca_count = orw->orw_sgls.ca_count;
 			orwo->orw_sgls.ca_arrays = orw->orw_sgls.ca_arrays;
 		}
+		obj_singv_ec_rw_filter(orw, iods, offs, false);
 	}
 
 	biod = vos_ioh2desc(ioh);

--- a/src/object/srv_obj.c
+++ b/src/object/srv_obj.c
@@ -775,7 +775,8 @@ obj_singv_ec_rw_filter(struct obj_rw_in *orw, daos_iod_t *iods, uint64_t *offs,
 		if (iod->iod_type != DAOS_IOD_SINGLE || iod->iod_recxs == NULL)
 			continue;
 		/* for singv EC */
-		D_ASSERT(iod->iod_size != DAOS_REC_ANY);
+		if (iod->iod_size == DAOS_REC_ANY) /* punch */
+			continue;
 		if (oca == NULL) {
 			oca = daos_oclass_attr_find(orw->orw_oid.id_pub);
 			D_ASSERT(oca != NULL && DAOS_OC_IS_EC(oca));

--- a/src/tests/suite/daos_iotest.h
+++ b/src/tests/suite/daos_iotest.h
@@ -226,6 +226,7 @@ struct test_add_exclude_arg {
 };
 
 struct test_punch_arg {
+	bool		 pa_singv;
 	daos_recx_t	*pa_recxs;
 	int		 pa_recxs_num;
 };

--- a/src/tests/suite/io_conf/daos_io_conf_3
+++ b/src/tests/suite/io_conf/daos_io_conf_3
@@ -58,7 +58,7 @@
 
 test_lvl daos
 dkey dkey_3
-akey akey_3
+akey akey_array_1
 iod_size 1024
 obj_class ec
 
@@ -78,3 +78,18 @@ fetch --tx 3 -r "[1, 5]"
 update --tx 3 -r "[1, 2]6"
 fetch --tx 3 -r "[0, 18]"
 fetch --tx 3 -r "[1, 15]"
+
+# single value on one target
+akey akey_single_1
+iod_size 1024
+obj_class ec
+update --tx 10 -s -u 13
+fetch --tx 10 -s
+
+# single value evenly distributed to all targets
+akey akey_single_2
+iod_size 10240
+obj_class ec
+update --tx 11 -s -u 17
+fetch --tx 11 -s
+

--- a/src/tests/suite/io_conf/daos_io_conf_3
+++ b/src/tests/suite/io_conf/daos_io_conf_3
@@ -85,6 +85,7 @@ iod_size 1024
 obj_class ec
 update --tx 10 -s -u 13
 fetch --tx 10 -s
+punch -d dkey_3 -a akey_single_1 --tx 10 -s
 
 # single value evenly distributed to all targets
 akey akey_single_2
@@ -92,4 +93,4 @@ iod_size 10240
 obj_class ec
 update --tx 11 -s -u 17
 fetch --tx 11 -s
-
+punch -d dkey_3 -a akey_single_2 --tx 11 -s

--- a/src/vos/tests/vts_aggregate.c
+++ b/src/vos/tests/vts_aggregate.c
@@ -74,7 +74,7 @@ update_value(struct io_test_args *arg, daos_unit_oid_t oid, daos_epoch_t epoch,
 	iod.iod_nr = 1;
 	iod.iod_type = type;
 	iod.iod_size = iod_size;
-	iod.iod_recxs = recx;
+	iod.iod_recxs = (type == DAOS_IOD_SINGLE) ? NULL : recx;
 
 	if (arg->ta_flags & TF_PUNCH) {
 		memset(buf, 0, buf_len);

--- a/src/vos/vos_io.c
+++ b/src/vos/vos_io.c
@@ -976,10 +976,13 @@ akey_update(struct vos_io_context *ioc, uint32_t pm_ver, daos_handle_t ak_toh)
 	}
 
 	if (iod->iod_type == DAOS_IOD_SINGLE) {
+		uint64_t	gsize;
+
 		D_DEBUG(DB_IO, "Single update eph "DF_U64"\n",
 			ioc->ic_epr.epr_hi);
-		rc = akey_update_single(toh, pm_ver, iod->iod_size,
-					iod->iod_size, ioc);
+		gsize = (iod->iod_recxs == NULL) ? iod->iod_size :
+			iod->iod_recxs[0].rx_nr;
+		rc = akey_update_single(toh, pm_ver, iod->iod_size, gsize, ioc);
 		goto out;
 	} /* else: array */
 

--- a/src/vos/vos_io.c
+++ b/src/vos/vos_io.c
@@ -981,7 +981,7 @@ akey_update(struct vos_io_context *ioc, uint32_t pm_ver, daos_handle_t ak_toh)
 		D_DEBUG(DB_IO, "Single update eph "DF_U64"\n",
 			ioc->ic_epr.epr_hi);
 		gsize = (iod->iod_recxs == NULL) ? iod->iod_size :
-			iod->iod_recxs[0].rx_nr;
+						   (uintptr_t)iod->iod_recxs;
 		rc = akey_update_single(toh, pm_ver, iod->iod_size, gsize, ioc);
 		goto out;
 	} /* else: array */


### PR DESCRIPTION
1. Adding single value EC update/fetch/punch support.
2. Changing epoch io test tool to support single value punch operaption
3. Adding  a test case of src/tests/suite/io_conf/daos_io_conf_3

Signed-off-by: Xuezhao Liu <xuezhao.liu@intel.com>