### PR TITLE
DAOS-623 test: Restore ior install in functional tests

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -49,7 +49,7 @@ def el7_component_repos = ""
 def component_repos = ""
 def daos_repo = "daos@${env.BRANCH_NAME}:${env.BUILD_NUMBER}"
 def el7_daos_repos = el7_component_repos + ' ' + component_repos + ' ' + daos_repo
-def functional_rpms  = "--exclude openmpi openmpi3 hwloc ndctl" +
+def functional_rpms  = "--exclude openmpi openmpi3 hwloc ndctl " +
                        "ior-hpc-cart-4-daos-0 mpich-autoload-cart-4-daos-0 " +
                        "romio-tests-cart-4-daos-0 hdf5-tests-cart-4-daos-0 " +
                        "mpi4py-tests-cart-4-daos-0 testmpio-cart-4-daos-0"


### PR DESCRIPTION
New installation packages were added recently but there is no
space between ndctl and the ior package os the latter doesn't
get installed.

Signed-off-by: Jeff Olivier <jeffrey.v.olivier@intel.com>