### PR TITLE
DAOS-2666 Array: add DAOS byte array feat bit

### DIFF
--- a/src/client/dfs/dfs.c
+++ b/src/client/dfs/dfs.c
@@ -266,7 +266,8 @@ oid_gen(dfs_t *dfs, uint16_t oclass, bool file, daos_obj_id_t *oid)
 
 	/** if a regular file, use UINT64 typed dkeys for the array object */
 	if (file)
-		feat = DAOS_OF_DKEY_UINT64 | DAOS_OF_KV_FLAT;
+		feat = DAOS_OF_DKEY_UINT64 | DAOS_OF_KV_FLAT |
+			DAOS_OF_ARRAY_BYTE;
 
 	/** generate the daos object ID (set the DAOS owned bits) */
 	daos_obj_generate_id(oid, feat, oclass, 0);

--- a/src/include/daos_obj.h
+++ b/src/include/daos_obj.h
@@ -94,6 +94,8 @@ enum {
 	DAOS_OF_ARRAY		= (1 << 5),
 	/** reserved: Multi Dimensional Array */
 	DAOS_OF_ARRAY_MD	= (1 << 6),
+	/** reserved: Byte Array with no metadata (eg DFS/POSIX) */
+	DAOS_OF_ARRAY_BYTE	= (1 << 7),
 	/**
 	 * benchmark-only feature bit, I/O is a network echo, no data is going
 	 * to be stored/returned


### PR DESCRIPTION
- Change DFS to set it for files
- meant to optimize rebuild, but ignored in this patch.

Signed-off-by: Mohamad Chaarawi <mohamad.chaarawi@intel.com>