### PR TITLE
DAOS-4000 Documentation: Update sections for network scanning and con…

### DIFF
--- a/doc/admin/installation.md
+++ b/doc/admin/installation.md
@@ -28,6 +28,10 @@ Moreover, the DAOS stack leverages the following open source projects:
 
 -   [*Argobots*](https://github.com/pmodels/argobots) for thread management.
 
+-   [*hwloc*](https://github.com/open-mpi/hwloc) for discovering system devices,         detecting their NUMA node affinity and for CPU binding
+
+-   [*libfabric*](https://github.com/ofiwg/libfabric) for detecting fabric               interfaces, providers and connection management.
+
 The DAOS build system can be configured to download and build any missing
 dependencies automatically.
 


### PR DESCRIPTION
…figuration

	Updated the installation and deployment sections with information
	relating to the daos_server network scan; how to run it, and what to do
	with the data it provides.

Skip-build: true
Skip-test: true

Signed-off-by: Joel Rosenzweig <joel.b.rosenzweig@intel.com>