### PR TITLE
daos-1871-2 -- Retry checksum errors to alternate replica.

### DIFF
--- a/src/object/cli_obj.c
+++ b/src/object/cli_obj.c
@@ -2425,7 +2425,9 @@ obj_retry_csum_err(struct dc_object *obj, struct obj_auxi_args *obj_auxi,
 		rc = -DER_CSUM;
 		goto out;
 	}
-	setbit(bitmap, next_shard - shard_cnt);
+	D_ASSERT(next_shard - shard_idx >= 0 &&
+		 next_shard - shard_idx <= 7);
+	setbit(bitmap, next_shard - shard_idx);
 out:
 	return rc;
 }

--- a/src/object/cli_obj.c
+++ b/src/object/cli_obj.c
@@ -2412,7 +2412,6 @@ obj_retry_csum_err(struct dc_object *obj, struct obj_auxi_args *obj_auxi,
 			      &shard_idx, &shard_cnt);
 	if (rc != 0)
 		goto out;
-
 	if (obj_auxi->csum_retry_cnt >= shard_cnt) {
 		obj_auxi->spec_shard = 1;
 		rc = -DER_CSUM;
@@ -2421,7 +2420,6 @@ obj_retry_csum_err(struct dc_object *obj, struct obj_auxi_args *obj_auxi,
 	tgt_shard = (obj_auxi->req_tgts.ort_shard_tgts[0].st_shard + 1)
 		% shard_cnt;
 	setbit(bitmap, tgt_shard);
-
 out:
 	return rc;
 }

--- a/src/object/cli_obj.c
+++ b/src/object/cli_obj.c
@@ -2256,8 +2256,15 @@ obj_comp_cb(tse_task_t *task, void *data)
 			obj_auxi->io_retry = 1;
 		}
 
-		if (!obj_auxi->spec_shard && task->dt_result == -DER_CSUM)
-			obj_auxi->csum_retry = 1;
+		//if (!obj_auxi->spec_shard && task->dt_result == -DER_CSUM)
+		if (task->dt_result == -DER_CSUM) {
+			if (!obj_auxi->spec_shard &&
+			    obj_auxi->opc == DAOS_OBJ_RPC_FETCH) {
+				obj_auxi->csum_retry = 1;
+			} else {
+				obj_auxi->io_retry = 0;
+			}
+		}
 
 		if (!obj_auxi->spec_shard && task->dt_result == -DER_INPROGRESS)
 			obj_auxi->to_leader = 1;
@@ -2413,6 +2420,7 @@ obj_retry_csum_err(struct dc_object *obj, struct obj_auxi_args *obj_auxi,
 		goto out;
 
 	if (shard_cnt < 2) {
+		obj_auxi->spec_shard = 1;
 		rc = -DER_CSUM;
 		goto out;
 	}

--- a/src/object/cli_obj.c
+++ b/src/object/cli_obj.c
@@ -776,6 +776,7 @@ obj_shards_2_fwtgts(struct dc_object *obj, uint32_t map_ver, uint8_t *bit_map,
 				  !cli_disp && grp_size > 1;
 
 	if (bit_map != NIL_BITMAP) {
+		D_ASSERT(bit_map);
 		shard_nr = 0;
 		for (i = 0; i < shard_cnt; i++)
 			if (isset(bit_map, i))

--- a/src/object/cli_obj.c
+++ b/src/object/cli_obj.c
@@ -2252,20 +2252,16 @@ obj_comp_cb(tse_task_t *task, void *data)
 		 */
 
 		if (!obj_auxi->spec_shard ||
-		    task->dt_result != -DER_INPROGRESS) {
+		    task->dt_result != -DER_INPROGRESS)
 			obj_auxi->io_retry = 1;
-		}
 
-		//if (!obj_auxi->spec_shard && task->dt_result == -DER_CSUM)
 		if (task->dt_result == -DER_CSUM) {
 			if (!obj_auxi->spec_shard &&
-			    obj_auxi->opc == DAOS_OBJ_RPC_FETCH) {
+			    obj_auxi->opc == DAOS_OBJ_RPC_FETCH)
 				obj_auxi->csum_retry = 1;
-			} else {
+			else
 				obj_auxi->io_retry = 0;
-			}
 		}
-
 		if (!obj_auxi->spec_shard && task->dt_result == -DER_INPROGRESS)
 			obj_auxi->to_leader = 1;
 	}

--- a/src/object/cli_obj.c
+++ b/src/object/cli_obj.c
@@ -2408,7 +2408,6 @@ obj_retry_csum_err(struct dc_object *obj, struct obj_auxi_args *obj_auxi,
 	unsigned int tgt_shard, shard_cnt, shard_idx;
 	int rc = 0;
 
-
 	rc = obj_dkey2grpmemb(obj, dkey_hash, map_ver,
 			      &shard_idx, &shard_cnt);
 	if (rc != 0)

--- a/src/object/cli_obj.c
+++ b/src/object/cli_obj.c
@@ -2014,7 +2014,6 @@ obj_req_fanout(struct dc_object *obj, struct obj_auxi_args *obj_auxi,
 
 	D_ASSERT(d_list_empty(task_list));
 
-
 	/* for multi-targets, schedule it by tse sub-shard-tasks */
 	for (i = 0; i < tgts_nr; i++) {
 		rc = tse_task_create(shard_io_task, tse_task2sched(obj_task),

--- a/src/object/obj_internal.h
+++ b/src/object/obj_internal.h
@@ -335,7 +335,8 @@ obj_retry_error(int err)
 {
 	return err == -DER_TIMEDOUT || err == -DER_STALE ||
 	       err == -DER_INPROGRESS || err == -DER_GRPVER ||
-	       err == -DER_EVICTED || daos_crt_network_error(err);
+	       err == -DER_EVICTED || err == -DER_CSUM ||
+	       daos_crt_network_error(err);
 }
 
 void obj_shard_decref(struct dc_obj_shard *shard);

--- a/src/tests/suite/daos_checksum.c
+++ b/src/tests/suite/daos_checksum.c
@@ -353,9 +353,11 @@ test_fetch_array(void **state)
 	assert_memory_equal(ctx.update_sgl.sg_iovs->iov_buf,
 			    ctx.fetch_sgl.sg_iovs->iov_buf,
 			    ctx.update_sgl.sg_iovs->iov_buf_len);
-
 	unset_csum_fi();
+	cleanup_data(&ctx);
 
+	/** 5. Replicated (complicated data) object with corruption */
+	set_fetch_csum_fi();
 	setup_multiple_extent_data(&ctx);
 	rc = daos_obj_update(ctx.oh, DAOS_TX_NONE, 0, &ctx.dkey, 1,
 			     &ctx.update_iod, &ctx.update_sgl, NULL);
@@ -370,7 +372,9 @@ test_fetch_array(void **state)
 			    ctx.update_sgl.sg_iovs->iov_buf_len);
 
 	/** Clean up */
+	unset_csum_fi();
 	cleanup_data(&ctx);
+	cleanup_cont_obj(&ctx);
 }
 
 /**

--- a/src/tests/suite/daos_checksum.c
+++ b/src/tests/suite/daos_checksum.c
@@ -37,7 +37,7 @@ set_update_csum_fi()
 static void
 set_fetch_csum_fi()
 {
-	daos_fail_loc_set(DAOS_CHECKSUM_FETCH_FAIL | DAOS_FAIL_ALWAYS);
+	daos_fail_loc_set(DAOS_CHECKSUM_FETCH_FAIL | DAOS_FAIL_ONCE);
 }
 static void
 unset_csum_fi()
@@ -76,7 +76,7 @@ setup_from_test_args(struct csum_test_ctx *ctx, test_arg_t *state)
  */
 static void
 setup_cont_obj(struct csum_test_ctx *ctx, int csum_prop_type, bool csum_sv,
-	       int chunksize)
+	       int chunksize, daos_oclass_id_t oclass)
 {
 	daos_prop_t	*props = daos_prop_alloc(3);
 	int		 rc;
@@ -100,7 +100,7 @@ setup_cont_obj(struct csum_test_ctx *ctx, int csum_prop_type, bool csum_sv,
 			    &ctx->coh, &ctx->info, NULL);
 	assert_int_equal(0, rc);
 
-	ctx->oid = dts_oid_gen(OC_SX, 0, 1);
+	ctx->oid = dts_oid_gen(oclass, 0, 1);
 	rc = daos_obj_open(ctx->coh, ctx->oid, 0, &ctx->oh, NULL);
 	assert_int_equal(0, rc);
 }
@@ -234,14 +234,14 @@ io_with_server_side_verify(void **state)
 	 *
 	 */
 	/** 1. Server verify disabled, no corruption */
-	setup_cont_obj(&ctx, DAOS_PROP_CO_CSUM_CRC64, false, 0);
+	setup_cont_obj(&ctx, DAOS_PROP_CO_CSUM_CRC64, false, 0, OC_SX);
 	rc = daos_obj_update(ctx.oh, DAOS_TX_NONE, 0, &ctx.dkey, 1,
 			     &ctx.update_iod, &ctx.update_sgl, NULL);
 	assert_int_equal(rc, 0);
 	cleanup_cont_obj(&ctx);
 
 	/** 2. Server verify enabled, no corruption */
-	setup_cont_obj(&ctx, DAOS_PROP_CO_CSUM_CRC64, true, 0);
+	setup_cont_obj(&ctx, DAOS_PROP_CO_CSUM_CRC64, true, 0, OC_SX);
 	rc = daos_obj_update(ctx.oh, DAOS_TX_NONE, 0, &ctx.dkey, 1,
 			     &ctx.update_iod, &ctx.update_sgl, NULL);
 	assert_int_equal(rc, 0);
@@ -249,14 +249,14 @@ io_with_server_side_verify(void **state)
 
 	/** 3. Server verify disabled, corruption occurs, update should work */
 	set_update_csum_fi();
-	setup_cont_obj(&ctx, DAOS_PROP_CO_CSUM_CRC64, false, 0);
+	setup_cont_obj(&ctx, DAOS_PROP_CO_CSUM_CRC64, false, 0, OC_SX);
 	rc = daos_obj_update(ctx.oh, DAOS_TX_NONE, 0, &ctx.dkey, 1,
 			     &ctx.update_iod, &ctx.update_sgl, NULL);
 	assert_int_equal(rc, 0);
 	cleanup_cont_obj(&ctx);
 
 	/** 4. Server verify enabled, corruption occurs, update should fail */
-	setup_cont_obj(&ctx, DAOS_PROP_CO_CSUM_CRC64, true, 0);
+	setup_cont_obj(&ctx, DAOS_PROP_CO_CSUM_CRC64, true, 0, OC_SX);
 	rc = daos_obj_update(ctx.oh, DAOS_TX_NONE, 0, &ctx.dkey, 1,
 			     &ctx.update_iod, &ctx.update_sgl, NULL);
 	assert_int_equal(rc, -DER_CSUM);
@@ -279,7 +279,7 @@ test_fetch_array(void **state)
 
 	setup_from_test_args(&ctx, (test_arg_t *) *state);
 
-	setup_cont_obj(&ctx, DAOS_PROP_CO_CSUM_CRC64, false, 1024*8);
+	setup_cont_obj(&ctx, DAOS_PROP_CO_CSUM_CRC64, false, 1024*8, OC_SX);
 	setup_simple_data(&ctx);
 
 	/**
@@ -294,6 +294,7 @@ test_fetch_array(void **state)
 	 * 3. Repeat case 1, but with a more complicated I/O: Larger data,
 	 *    multiple extents.
 	 * 4. Repeate case 2 but with the more complicated I/O from 3.
+	 * 5. Repeate cases 2 and 4, but with replica (2) object class.
 	 */
 
 	/** 1. Simple success case */
@@ -337,10 +338,39 @@ test_fetch_array(void **state)
 			    &ctx.fetch_iod, &ctx.fetch_sgl, NULL, NULL);
 	assert_int_equal(rc, -DER_CSUM);
 	unset_csum_fi();
+	cleanup_cont_obj(&ctx);
+
+	/** 5. Replicated object with corruption */
+	setup_cont_obj(&ctx, DAOS_PROP_CO_CSUM_CRC64, false, 1024*8, OC_RP_2GX);
+	rc = daos_obj_update(ctx.oh, DAOS_TX_NONE, 0, &ctx.dkey, 1,
+			     &ctx.update_iod, &ctx.update_sgl, NULL);
+	assert_int_equal(rc, 0);
+	set_fetch_csum_fi();
+	rc = daos_obj_fetch(ctx.oh, DAOS_TX_NONE, 0, &ctx.dkey, 1,
+			    &ctx.fetch_iod, &ctx.fetch_sgl, NULL, NULL);
+	assert_int_equal(rc, 0);
+	/** Update/Fetch data matches */
+	assert_memory_equal(ctx.update_sgl.sg_iovs->iov_buf,
+			    ctx.fetch_sgl.sg_iovs->iov_buf,
+			    ctx.update_sgl.sg_iovs->iov_buf_len);
+
+	unset_csum_fi();
+
+	setup_multiple_extent_data(&ctx);
+	rc = daos_obj_update(ctx.oh, DAOS_TX_NONE, 0, &ctx.dkey, 1,
+			     &ctx.update_iod, &ctx.update_sgl, NULL);
+	assert_int_equal(rc, 0);
+
+	rc = daos_obj_fetch(ctx.oh, DAOS_TX_NONE, 0, &ctx.dkey, 1,
+			    &ctx.fetch_iod, &ctx.fetch_sgl, NULL, NULL);
+	assert_int_equal(rc, 0);
+	/** Update/Fetch data matches */
+	assert_memory_equal(ctx.update_sgl.sg_iovs->iov_buf,
+			    ctx.fetch_sgl.sg_iovs->iov_buf,
+			    ctx.update_sgl.sg_iovs->iov_buf_len);
 
 	/** Clean up */
 	cleanup_data(&ctx);
-	cleanup_cont_obj(&ctx);
 }
 
 /**
@@ -462,7 +492,7 @@ array_update_fetch_testcase(char *file, int line, test_arg_t *test_arg,
 
 	setup_from_test_args(&ctx, test_arg);
 	setup_cont_obj(&ctx, args->csum_prop_type, args->server_verify,
-		       args->chunksize);
+		       args->chunksize, OC_SX);
 
 	for (i = 0; i < recx_count; i++) {
 		ctx.recx[0].rx_nr = args->recx_cfgs[i].nr;

--- a/src/tests/suite/daos_checksum.c
+++ b/src/tests/suite/daos_checksum.c
@@ -356,7 +356,7 @@ test_fetch_array(void **state)
 	unset_csum_fi();
 	cleanup_data(&ctx);
 
-	/** 5. Replicated (complicated data) object with corruption */
+	/** 6. Replicated (complicated data) object with corruption */
 	set_fetch_csum_fi();
 	setup_multiple_extent_data(&ctx);
 	rc = daos_obj_update(ctx.oh, DAOS_TX_NONE, 0, &ctx.dkey, 1,


### PR DESCRIPTION
Adds -DER_CSUM as a retry-able error.

Adds a flag to obj_auxi_args to indicate csum_retry.

Resends fetch requests incurring CSUM errors to the next replica in the redundancy group (for replica count > 1).

When a checksum mismatch occurs, fetch returns -DER_CSUM if single replica, if all replicas have been tried and return a CSUM error for the fetch, or if the fetch is for an EC object (this one will be addressed once EC degraded-mode read is in place).

This patch also adds tests to fetch from replicated data with fault injection.
