### PR TITLE
DAOS-3667 test: Modified pool tests to use dmg create and destroy

### DIFF
--- a/src/tests/ftest/container/open.py
+++ b/src/tests/ftest/container/open.py
@@ -36,6 +36,7 @@ RESULT_PASS = "PASS"
 RESULT_FAIL = "FAIL"
 RESULT_TO_NUM = {RESULT_PASS: 0, RESULT_FAIL: 1}
 
+
 class OpenContainerTest(TestWithServers):
     """
     Test Class Description:
@@ -131,7 +132,7 @@ class OpenContainerTest(TestWithServers):
             self.pool.append(TestPool(self.context, self.log))
             self.pool[-1].get_params(self)
             self.pool[-1].create()
-            self.pool[-1].connect(1)
+            self.pool[-1].connect()
             self.container.append(TestContainer(self.pool[-1]))
             self.container[-1].get_params(self)
             self.container[-1].create()

--- a/src/tests/ftest/container/open.py
+++ b/src/tests/ftest/container/open.py
@@ -23,7 +23,6 @@
 '''
 from __future__ import print_function
 
-import time
 import traceback
 import uuid
 
@@ -170,6 +169,3 @@ class OpenContainerTest(TestWithServers):
             print(traceback.format_exc())
             self.assertEqual(expected_result, RESULT_FAIL,
                              result_messages[test_case][3])
-
-if __name__ == "__main__":
-    main()

--- a/src/tests/ftest/pool/attribute.py
+++ b/src/tests/ftest/pool/attribute.py
@@ -91,7 +91,7 @@ class PoolAttributeTest(TestWithServers):
 
         self.large_data_set = {}
 
-        self.pool = TestPool(self.context, dmg_bin_path=self.bin)
+        self.pool = TestPool(self.context, dmg_command=self.get_dmg_command())
         self.pool.get_params(self)
         self.pool.create()
         self.pool.pool.connect(1 << 1)

--- a/src/tests/ftest/pool/attribute.py
+++ b/src/tests/ftest/pool/attribute.py
@@ -93,7 +93,7 @@ class PoolAttributeTest(TestWithServers):
         self.pool = TestPool(self.context, dmg_command=self.get_dmg_command())
         self.pool.get_params(self)
         self.pool.create()
-        self.pool.pool.connect(1 << 1)
+        self.pool.connect()
 
     def create_data_set(self):
         """

--- a/src/tests/ftest/pool/attribute.py
+++ b/src/tests/ftest/pool/attribute.py
@@ -90,7 +90,7 @@ class PoolAttributeTest(TestWithServers):
         super(PoolAttributeTest, self).setUp()
 
         self.large_data_set = {}
-        
+
         self.pool = TestPool(self.context, dmg_bin_path=self.bin)
         self.pool.get_params(self)
         self.pool.create()

--- a/src/tests/ftest/pool/attribute.py
+++ b/src/tests/ftest/pool/attribute.py
@@ -23,7 +23,6 @@
 '''
 from __future__ import print_function
 
-import os
 import traceback
 import threading
 import string

--- a/src/tests/ftest/pool/attribute.py
+++ b/src/tests/ftest/pool/attribute.py
@@ -90,32 +90,11 @@ class PoolAttributeTest(TestWithServers):
         super(PoolAttributeTest, self).setUp()
 
         self.large_data_set = {}
-
-        createmode = self.params.get("mode",
-                                     '/run/attrtests/createmode/')
-        createuid = os.geteuid()
-        creategid = os.getgid()
-        createsetid = self.params.get("setname",
-                                      '/run/attrtests/createset/')
-        createsize = self.params.get("size",
-                                     '/run/attrtests/createsize/')
-        try:
-            self.pool = TestPool(self.context,
-                                 dmg_bin_path=self.basepath + '/install/bin')
-            self.pool.get_params(self)
-            # Manually set TestPool members before calling create
-            self.pool.mode.value = createmode
-            self.pool.uid = createuid
-            self.pool.gid = creategid
-            self.pool.scm_size.value = createsize
-            self.pool.name.value = createsetid
-            self.pool.create()
-            self.pool.pool.connect(1 << 1)
-
-        except DaosApiError as excep:
-            print("In the setup exception handler\n")
-            print(excep)
-            print(traceback.format_exc())
+        
+        self.pool = TestPool(self.context, dmg_bin_path=self.bin)
+        self.pool.get_params(self)
+        self.pool.create()
+        self.pool.pool.connect(1 << 1)
 
     def create_data_set(self):
         """

--- a/src/tests/ftest/pool/attribute.yaml
+++ b/src/tests/ftest/pool/attribute.yaml
@@ -6,6 +6,8 @@ hosts:
 timeout: 120
 server_config:
   name: daos_server
+pool:
+  control_method: dmg
 attrtests:
   createmode:
     mode: 511

--- a/src/tests/ftest/pool/attribute.yaml
+++ b/src/tests/ftest/pool/attribute.yaml
@@ -8,13 +8,10 @@ server_config:
   name: daos_server
 pool:
   control_method: dmg
+  mode: 511
+  scm_size: 1073741824
+  name: daos_server
 attrtests:
-  createmode:
-    mode: 511
-  createset:
-    setname: daos_server
-  createsize:
-    size: 1073741824
   name_handles: !mux
     validlongname:
       name:

--- a/src/tests/ftest/pool/bad_connect.py
+++ b/src/tests/ftest/pool/bad_connect.py
@@ -25,7 +25,8 @@ from __future__ import print_function
 
 import traceback
 import ctypes
-from pydaos.raw import DaosApiError, RankList
+from pydaos.raw import RankList
+from avocado.core.exceptions import TestFail
 from apricot import TestWithServers, skipForTicket
 from test_utils_pool import TestPool
 
@@ -109,7 +110,7 @@ class BadConnectTest(TestWithServers):
             if expected_result in ['FAIL']:
                 self.fail("Test was expected to fail but it passed.\n")
 
-        except DaosApiError as excep:
+        except TestFail as excep:
             print(excep)
             print(traceback.format_exc())
             if expected_result in ['PASS']:

--- a/src/tests/ftest/pool/bad_connect.py
+++ b/src/tests/ftest/pool/bad_connect.py
@@ -118,7 +118,7 @@ class BadConnectTest(TestWithoutServers):
         pgroup = ctypes.create_string_buffer(0)
         # initialize a python pool object then create the underlying
         # daos storage
-        self.pool = TestPool(self.context, dmg_bin_path=self.bin)
+        self.pool = TestPool(self.context, dmg_command=self.get_dmg_command())
         self.pool.get_params(self)
         self.pool.create()
         # save this uuid since we might trash it as part of the test

--- a/src/tests/ftest/pool/bad_connect.py
+++ b/src/tests/ftest/pool/bad_connect.py
@@ -121,8 +121,14 @@ class BadConnectTest(TestWithoutServers):
             # initialize a python pool object then create the underlying
             # daos storage
             pool = TestPool(self.context,
-                                 dmg_bin_path=self.basepath + '/install/bin')
+                            dmg_bin_path=self.basepath + '/install/bin')
             pool.get_params(self)
+            pool.mode.value = createmode
+            pool.uid = createuid
+            pool.gid = creategid
+            pool.scm_size.value = createsize
+            pool.name.value = createsetid
+            pool.create()
             # save this uuid since we might trash it as part of the test
             ctypes.memmove(puuid, pool.pool.uuid, 16)
 

--- a/src/tests/ftest/pool/bad_connect.yaml
+++ b/src/tests/ftest/pool/bad_connect.yaml
@@ -6,6 +6,8 @@ hosts:
   test_servers:
     - server-A
 timeout: 700
+pool:
+  control_method: dmg
 connecttests:
    createmode:
      mode: 511

--- a/src/tests/ftest/pool/bad_connect.yaml
+++ b/src/tests/ftest/pool/bad_connect.yaml
@@ -8,9 +8,10 @@ hosts:
 timeout: 700
 pool:
   control_method: dmg
+  mode: 511
+  size: 1073741824
+  name: daos_server
 connecttests:
-   createmode:
-     mode: 511
    connectmode: !mux
      testmode1:
           mode:
@@ -59,16 +60,3 @@ connecttests:
           uuid:
              - JUNK
              - FAIL
-   uids:
-     createuid:
-         uid: 11374638
-   gids:
-     creategid:
-         gid: 11374638
-   setnames:
-     createset:
-          setname: scott_server
-   psize:
-     createsize:
-         size: 1073741824
-

--- a/src/tests/ftest/pool/bad_create.py
+++ b/src/tests/ftest/pool/bad_create.py
@@ -79,12 +79,13 @@ class BadCreateTest(TestWithServers):
             group = setidlist[0]
         expected_for_param.append(setidlist[1])
 
-        targetlist = self.params.get("rankptr", '/run/createtests/target/*')
-        if targetlist[0] == 'NULL':
-            targetptr = None
-        else:
-            targetptr = [0]
-        expected_for_param.append(targetlist[1])
+        # Uncomment this block when we test targetptr.
+        # targetlist = self.params.get("rankptr", '/run/createtests/target/*')
+        # if targetlist[0] == 'NULL':
+        #     targetptr = None
+        # else:
+        #     targetptr = [0]
+        # expected_for_param.append(targetlist[1])
 
         # not ready for this yet
         # devicelist = self.params.get("devptr", '/run/createtests/device/*')

--- a/src/tests/ftest/pool/bad_create.py
+++ b/src/tests/ftest/pool/bad_create.py
@@ -25,7 +25,6 @@ import os
 import traceback
 
 from apricot import TestWithServers
-from pydaos.raw import DaosApiError
 from test_utils_pool import TestPool
 from avocado.core.exceptions import TestFail
 

--- a/src/tests/ftest/pool/bad_create.py
+++ b/src/tests/ftest/pool/bad_create.py
@@ -117,7 +117,8 @@ class BadCreateTest(TestWithServers):
         try:
             # initialize a python pool object then create the underlying
             # daos storage
-            self.pool = TestPool(self.context, dmg_bin_path=self.bin)
+            self.pool = TestPool(self.context,
+                                 dmg_command=self.get_dmg_command())
             self.pool.get_params(self)
             # Manually set TestPool members before calling create
             self.pool.mode.value = mode

--- a/src/tests/ftest/pool/bad_create.py
+++ b/src/tests/ftest/pool/bad_create.py
@@ -115,18 +115,19 @@ class BadCreateTest(TestWithServers):
                 expected_result = 'FAIL'
                 break
 
+        # initialize a python pool object then create the underlying
+        # daos storage
+        self.pool = TestPool(self.context,
+                                dmg_command=self.get_dmg_command())
+        self.pool.get_params(self)
+        # Manually set TestPool members before calling create
+        self.pool.mode.value = mode
+        self.pool.uid = uid
+        self.pool.gid = gid
+        self.pool.scm_size.value = size
+        self.pool.name.value = group
+
         try:
-            # initialize a python pool object then create the underlying
-            # daos storage
-            self.pool = TestPool(self.context,
-                                 dmg_command=self.get_dmg_command())
-            self.pool.get_params(self)
-            # Manually set TestPool members before calling create
-            self.pool.mode.value = mode
-            self.pool.uid = uid
-            self.pool.gid = gid
-            self.pool.scm_size.value = size
-            self.pool.name.value = group
             self.pool.create()
 
             if expected_result in ['FAIL']:
@@ -139,5 +140,3 @@ class BadCreateTest(TestWithServers):
             self.log.error(traceback.format_exc())
             if expected_result == 'PASS':
                 self.fail("Test was expected to pass but it failed.\n")
-        finally:
-            self.destroy_pools(pool)

--- a/src/tests/ftest/pool/bad_create.py
+++ b/src/tests/ftest/pool/bad_create.py
@@ -117,8 +117,7 @@ class BadCreateTest(TestWithServers):
         try:
             # initialize a python pool object then create the underlying
             # daos storage
-            self.pool = TestPool(self.context,
-                                 dmg_bin_path=self.basepath + '/install/bin')
+            self.pool = TestPool(self.context, dmg_bin_path=self.bin)
             self.pool.get_params(self)
             # Manually set TestPool members before calling create
             self.pool.mode.value = mode

--- a/src/tests/ftest/pool/bad_create.py
+++ b/src/tests/ftest/pool/bad_create.py
@@ -51,8 +51,6 @@ class BadCreateTest(TestWithServers):
         # Accumulate a list of pass/fail indicators representing what is
         # expected for each parameter then "and" them to determine the
         # expected result of the test
-
-        pool = None
         expected_for_param = []
 
         modelist = self.params.get("mode", '/run/createtests/modes/*')
@@ -118,7 +116,7 @@ class BadCreateTest(TestWithServers):
         # initialize a python pool object then create the underlying
         # daos storage
         self.pool = TestPool(self.context,
-                                dmg_command=self.get_dmg_command())
+                             dmg_command=self.get_dmg_command())
         self.pool.get_params(self)
         # Manually set TestPool members before calling create
         self.pool.mode.value = mode

--- a/src/tests/ftest/pool/bad_create.yaml
+++ b/src/tests/ftest/pool/bad_create.yaml
@@ -6,6 +6,8 @@ hosts:
 server_config:
    name: daos_server
 timeout: 50
+pool:
+   control_method: dmg
 createtests:
    modes: !mux
       goodmode:

--- a/src/tests/ftest/pool/bad_query.py
+++ b/src/tests/ftest/pool/bad_query.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python
 '''
-  (C) Copyright 2018-2019 Intel Corporation.
+  (C) Copyright 2018-2020 Intel Corporation.
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
@@ -25,8 +25,8 @@ import os
 import traceback
 
 from apricot import TestWithServers
-from pydaos.raw import DaosContext, DaosPool, DaosApiError
-
+from pydaos.raw import DaosContext, DaosApiError
+from test_utils_pool import TestPool
 
 class BadQueryTest(TestWithServers):
     """Test pool query calls.
@@ -79,17 +79,24 @@ class BadQueryTest(TestWithServers):
         try:
             # initialize a python pool object then create the underlying
             # daos storage
-            pool = DaosPool(self.context)
-            pool.create(createmode, createuid, creategid,
-                        createsize, createsetid, None)
+            self.pool = TestPool(self.context,
+                                 dmg_bin_path=self.basepath + '/install/bin')
+            self.pool.get_params(self)
+            # Manually set TestPool members before calling create
+            self.pool.mode.value = createmode
+            self.pool.uid = createuid
+            self.pool.gid = creategid
+            self.pool.scm_size.value = createsize
+            self.pool.name.value = createsetid
+            self.pool.create()
 
-            pool.connect(connectmode)
+            self.pool.pool.connect(connectmode)
 
             # trash the pool handle value
             if not handle == 'VALID':
-                pool.handle = handle
+                self.pool.pool.handle = handle
 
-            pool.pool_query()
+            self.pool.pool.pool_query()
 
             if expected_result in ['FAIL']:
                 self.fail("Test was expected to fail but it passed.\n")

--- a/src/tests/ftest/pool/bad_query.py
+++ b/src/tests/ftest/pool/bad_query.py
@@ -21,7 +21,6 @@
   Any reproduction of computer software, computer software documentation, or
   portions thereof marked with this legend must also reproduce the markings.
 '''
-import os
 import traceback
 
 from apricot import TestWithServers

--- a/src/tests/ftest/pool/bad_query.py
+++ b/src/tests/ftest/pool/bad_query.py
@@ -24,7 +24,7 @@
 import traceback
 
 from apricot import TestWithServers
-from pydaos.raw import DaosApiError
+from avocado.core.exceptions import TestFail
 from test_utils_pool import TestPool
 
 class BadQueryTest(TestWithServers):
@@ -46,9 +46,6 @@ class BadQueryTest(TestWithServers):
 
         :avocado: tags=all,pool,full_regression,tiny,badquery
         """
-        # parameter used in pool create/connect
-        connectmode = self.params.get("mode", '/run/querytests/connectmode/')
-
         # Accumulate a list of pass/fail indicators representing what is
         # expected for each parameter then "and" them to determine the
         # expected result of the test
@@ -75,19 +72,19 @@ class BadQueryTest(TestWithServers):
         self.pool = TestPool(self.context, dmg_command=self.get_dmg_command())
         self.pool.get_params(self)
         self.pool.create()
-        self.pool.pool.connect(connectmode)
+        self.pool.connect()
 
         # trash the pool handle value
         if not handle == 'VALID':
             self.pool.pool.handle = handle
 
         try:
-            self.pool.pool.pool_query()
+            self.pool.get_info()
 
             if expected_result in ['FAIL']:
                 self.fail("Test was expected to fail but it passed.\n")
 
-        except DaosApiError as excep:
+        except TestFail as excep:
             self.log.error(str(excep))
             self.log.error(traceback.format_exc())
             if expected_result in ['PASS']:

--- a/src/tests/ftest/pool/bad_query.py
+++ b/src/tests/ftest/pool/bad_query.py
@@ -25,7 +25,7 @@ import os
 import traceback
 
 from apricot import TestWithServers
-from pydaos.raw import DaosContext, DaosApiError
+from pydaos.raw import DaosApiError
 from test_utils_pool import TestPool
 
 class BadQueryTest(TestWithServers):

--- a/src/tests/ftest/pool/bad_query.py
+++ b/src/tests/ftest/pool/bad_query.py
@@ -73,7 +73,7 @@ class BadQueryTest(TestWithServers):
 
         # initialize a python pool object then create the underlying
         # daos storage
-        self.pool = TestPool(self.context, dmg_bin_path=self.bin)
+        self.pool = TestPool(self.context, dmg_command=self.get_dmg_command())
         self.pool.get_params(self)
         self.pool.create()
         self.pool.pool.connect(connectmode)

--- a/src/tests/ftest/pool/bad_query.yaml
+++ b/src/tests/ftest/pool/bad_query.yaml
@@ -29,5 +29,3 @@ querytests:
           info:
              - NULL
              - PASS
-   connectmode:
-     mode: 2

--- a/src/tests/ftest/pool/bad_query.yaml
+++ b/src/tests/ftest/pool/bad_query.yaml
@@ -5,6 +5,8 @@ server_config:
 hosts:
   test_servers:
     - server-A
+pool:
+  control_method: dmg
 querytests:
    handles: !mux
      goodhandle:

--- a/src/tests/ftest/pool/bad_query.yaml
+++ b/src/tests/ftest/pool/bad_query.yaml
@@ -7,6 +7,9 @@ hosts:
     - server-A
 pool:
   control_method: dmg
+  mode: 511
+  scm_size: 1073741824
+  name: daos_server
 querytests:
    handles: !mux
      goodhandle:
@@ -28,10 +31,3 @@ querytests:
              - PASS
    connectmode:
      mode: 2
-   createmode:
-     mode: 511
-   createset:
-     setname: scott_server
-   createsize:
-     size: 1073741824
-

--- a/src/tests/ftest/pool/destroy_rebuild.py
+++ b/src/tests/ftest/pool/destroy_rebuild.py
@@ -48,7 +48,8 @@ class DestroyRebuild(TestWithServers):
         :avocado: tags=all,pr,medium,pool,destroypoolrebuild
         """
         # Get the test parameters
-        self.pool = TestPool(self.context, self.log, dmg_bin_path=self.bin)
+        self.pool = TestPool(self.context, self.log,
+                             dmg_command=self.get_dmg_command())
         self.pool.get_params(self)
         targets = self.params.get("targets", "/run/server_config/*")
         rank = self.params.get("rank_to_kill", "/run/testparams/*")

--- a/src/tests/ftest/pool/destroy_rebuild.py
+++ b/src/tests/ftest/pool/destroy_rebuild.py
@@ -48,8 +48,7 @@ class DestroyRebuild(TestWithServers):
         :avocado: tags=all,pr,medium,pool,destroypoolrebuild
         """
         # Get the test parameters
-        self.pool = TestPool(self.context, self.log,
-                             dmg_bin_path=self.basepath + '/install/bin')
+        self.pool = TestPool(self.context, self.log, dmg_bin_path=self.bin)
         self.pool.get_params(self)
         targets = self.params.get("targets", "/run/server_config/*")
         rank = self.params.get("rank_to_kill", "/run/testparams/*")

--- a/src/tests/ftest/pool/destroy_rebuild.py
+++ b/src/tests/ftest/pool/destroy_rebuild.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python
 '''
-  (C) Copyright 2018-2019 Intel Corporation.
+  (C) Copyright 2018-2020 Intel Corporation.
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
@@ -22,7 +22,7 @@
   portions thereof marked with this legend must also reproduce the markings.
 '''
 from apricot import TestWithServers, skipForTicket
-from test_utils_pool import TestPool
+from test_utils import TestPool
 
 
 class DestroyRebuild(TestWithServers):
@@ -48,7 +48,8 @@ class DestroyRebuild(TestWithServers):
         :avocado: tags=all,pr,medium,pool,destroypoolrebuild
         """
         # Get the test parameters
-        self.pool = TestPool(self.context, self.log)
+        self.pool = TestPool(self.context, self.log,
+                             dmg_bin_path=self.basepath + '/install/bin')
         self.pool.get_params(self)
         targets = self.params.get("targets", "/run/server_config/*")
         rank = self.params.get("rank_to_kill", "/run/testparams/*")

--- a/src/tests/ftest/pool/destroy_rebuild.py
+++ b/src/tests/ftest/pool/destroy_rebuild.py
@@ -22,7 +22,7 @@
   portions thereof marked with this legend must also reproduce the markings.
 '''
 from apricot import TestWithServers, skipForTicket
-from test_utils import TestPool
+from test_utils_pool import TestPool
 
 
 class DestroyRebuild(TestWithServers):

--- a/src/tests/ftest/pool/destroy_rebuild.yaml
+++ b/src/tests/ftest/pool/destroy_rebuild.yaml
@@ -19,6 +19,7 @@ pool:
   mode: 511
   name: daos_server
   scm_size: 16428800
+  control_method: dmg
 testparams:
   rank_to_kill: 0
   # rank_to_kill: 1

--- a/src/tests/ftest/pool/destroy_tests.py
+++ b/src/tests/ftest/pool/destroy_tests.py
@@ -342,7 +342,7 @@ class DestroyTests(TestWithServers):
 
         # Connect to the pool
         self.assertTrue(
-            self.pool.connect(1), "Pool connect failed before destroy")
+            self.pool.connect(), "Pool connect failed before destroy")
 
         # Destroy pool with direct API call (no disconnect)
         self.log.info("Attempting to destroy a connected pool")
@@ -393,7 +393,7 @@ class DestroyTests(TestWithServers):
 
         # Connect to the pool
         self.assertTrue(
-            self.pool.connect(1), "Pool connect failed before destroy")
+            self.pool.connect(), "Pool connect failed before destroy")
 
         # Create a container
         self.container = TestContainer(self.pool)

--- a/src/tests/ftest/pool/destroy_tests.py
+++ b/src/tests/ftest/pool/destroy_tests.py
@@ -64,6 +64,7 @@ class DestroyTests(TestWithServers):
         self.validate_pool_destroy(hosts, case, exception_expected)
 
     def validate_pool_creation(self, hosts, group_name):
+        # pylint: disable=unused-argument
         """Validate the creation of a pool on the specified list of hosts.
 
         Args:
@@ -78,13 +79,14 @@ class DestroyTests(TestWithServers):
         self.pool.create()
         self.log.info("Pool UUID is %s", self.pool.uuid)
 
-        # Commented out due to DAOS-3836.
+        # Commented out due to DAOS-3836. Remove pylint disable when fixed.
         ## Check that the pool was created
         #self.assertTrue(
         #    self.pool.check_files(hosts),
         #    "Pool data not detected on servers before destroy")
 
     def validate_pool_destroy(self, hosts, case, exception_expected=False):
+        # pylint: disable=unused-argument
         """Validate a pool destroy.
 
         Args:
@@ -116,7 +118,7 @@ class DestroyTests(TestWithServers):
 
         # Restore the valid server group and check if valid pool still exists
         self.pool.uuid = saved_uuid
-        # Commented out due to DAOS-3836.
+        # Commented out due to DAOS-3836. Remove pylint disable when fixed.
         #if exception_detected:
         #    self.log.info(
         #        "Check pool data still exists after a failed pool destroy")

--- a/src/tests/ftest/pool/evict_test.py
+++ b/src/tests/ftest/pool/evict_test.py
@@ -49,7 +49,8 @@ class EvictTests(TestWithServers):
             TestPool (object)
 
         """
-        pool = TestPool(self.context, self.log, dmg_bin_path=self.bin)
+        pool = TestPool(self.context, self.log,
+                        dmg_command=self.get_dmg_command())
         pool.get_params(self)
         if targets is not None:
             pool.target_list.value = targets

--- a/src/tests/ftest/pool/evict_test.py
+++ b/src/tests/ftest/pool/evict_test.py
@@ -188,7 +188,7 @@ class EvictTests(TestWithServers):
         pool_tgt_ut = [num for num in range(int(len(self.hostlist_servers)/2))]
         tlist = [pool_tgt, pool_tgt, pool_tgt_ut]
         pool_servers = [self.hostlist_servers[:len(tgt)] for tgt in tlist]
-        non_pool_servers = [self.hostlist_servers[len(tgt):] for tgt in tlist]
+        #non_pool_servers = [self.hostlist_servers[len(tgt):] for tgt in tlist]
         # Create Connected TestPool
         for count, target_list in enumerate(tlist):
             pool.append(self.connected_pool(pool_servers[count], target_list))

--- a/src/tests/ftest/pool/evict_test.py
+++ b/src/tests/ftest/pool/evict_test.py
@@ -40,6 +40,7 @@ class EvictTests(TestWithServers):
     """
 
     def connected_pool(self, hostlist, targets=None):
+        # pylint: disable=unused-argument
         """Connect to pool.
 
         Args:
@@ -56,7 +57,8 @@ class EvictTests(TestWithServers):
             pool.target_list.value = targets
         # create pool
         pool.create()
-        # Commented out due to DAOS-3836.
+        # Commented out due to DAOS-3836. Remove the pylint disable at the top
+        # of this method when the following lines are uncommented.
         ## Check that the pool was created
         #status = pool.check_files(hostlist)
         #if not status:
@@ -179,7 +181,7 @@ class EvictTests(TestWithServers):
         """
         pool = []
         container = []
-        non_pool_servers = []
+        #non_pool_servers = []
         # Target list is configured so that the pools are across all servers
         # except the pool under test is created on half of the servers
         pool_tgt = [num for num in range(len(self.hostlist_servers))]

--- a/src/tests/ftest/pool/evict_test.py
+++ b/src/tests/ftest/pool/evict_test.py
@@ -49,8 +49,7 @@ class EvictTests(TestWithServers):
             TestPool (object)
 
         """
-        pool = TestPool(self.context, self.log,
-                        dmg_bin_path=self.basepath + '/install/bin')
+        pool = TestPool(self.context, self.log, dmg_bin_path=self.bin)
         pool.get_params(self)
         if targets is not None:
             pool.target_list.value = targets

--- a/src/tests/ftest/pool/evict_test.py
+++ b/src/tests/ftest/pool/evict_test.py
@@ -64,7 +64,7 @@ class EvictTests(TestWithServers):
         #if not status:
         #    self.fail("Invalid pool - pool data not detected on servers")
         # Connect to the pool
-        status = pool.connect(1)
+        status = pool.connect()
         if not status:
             self.fail("Pool connect failed or already connected")
         # Return connected pool

--- a/src/tests/ftest/pool/evict_test.py
+++ b/src/tests/ftest/pool/evict_test.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python
 """
-  (C) Copyright 2018-2019 Intel Corporation.
+  (C) Copyright 2018-2020 Intel Corporation.
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
@@ -49,7 +49,8 @@ class EvictTests(TestWithServers):
             TestPool (object)
 
         """
-        pool = TestPool(self.context, self.log)
+        pool = TestPool(self.context, self.log,
+                        dmg_bin_path=self.basepath + '/install/bin')
         pool.get_params(self)
         if targets is not None:
             pool.target_list.value = targets

--- a/src/tests/ftest/pool/evict_test.yaml
+++ b/src/tests/ftest/pool/evict_test.yaml
@@ -11,6 +11,7 @@ pool:
    mode: 146
    name: daos_server
    scm_size: 1073741824
+   control_method: dmg
 container:
   akey_size: 5
   dkey_size: 5

--- a/src/tests/ftest/pool/global_handle.py
+++ b/src/tests/ftest/pool/global_handle.py
@@ -22,14 +22,11 @@
   portions thereof marked with this legend must also reproduce the markings.
 '''
 from __future__ import print_function
-
-import os
 import traceback
 
 from apricot import TestWithServers
-
 import check_for_pool
-from pydaos.raw import DaosContext, DaosPool, DaosContainer, DaosApiError
+from pydaos.raw import DaosPool, DaosContainer, DaosApiError
 from test_utils_pool import TestPool
 
 class GlobalHandle(TestWithServers):

--- a/src/tests/ftest/pool/global_handle.py
+++ b/src/tests/ftest/pool/global_handle.py
@@ -78,23 +78,23 @@ class GlobalHandle(TestWithServers):
         self.pool.get_params(self)
         self.pool.create()
 
-        self.pool.pool.connect(1 << 1)
+        self.pool.connect()
 
-        # create a container just to make sure handle is good
-        self.container = DaosContainer(self.context)
-        self.container.create(self.pool.pool.handle)
-
-        # create a global handle
-        iov_len, buf_len, buf = self.pool.pool.local2global()
-
-        # this should work in the future but need on-line server addition
-        #arg_list = (buf_len, iov_len, buf, pool.get_uuid_str(), 0)
-        #p = Process(target=check_handle, args=arg_list)
-        #p.start()
-        #p.join()
-        # for now verifying global handle in the same process which is not
-        # the intended use case
         try:
+            # create a container just to make sure handle is good
+            self.container = DaosContainer(self.context)
+            self.container.create(self.pool.pool.handle)
+
+            # create a global handle
+            iov_len, buf_len, buf = self.pool.pool.local2global()
+
+            # this should work in the future but need on-line server addition
+            #arg_list = (buf_len, iov_len, buf, pool.get_uuid_str(), 0)
+            #p = Process(target=check_handle, args=arg_list)
+            #p.start()
+            #p.join()
+            # for now verifying global handle in the same process which is not
+            # the intended use case
             self.check_handle(buf_len, iov_len, buf,
                               self.pool.pool.get_uuid_str(), 0)
 

--- a/src/tests/ftest/pool/global_handle.py
+++ b/src/tests/ftest/pool/global_handle.py
@@ -77,7 +77,7 @@ class GlobalHandle(TestWithServers):
         """
         # initialize a python pool object then create the underlying
         # daos storage
-        self.pool = TestPool(self.context, dmg_bin_path=self.bin)
+        self.pool = TestPool(self.context, dmg_command=self.get_dmg_command())
         self.pool.get_params(self)
         self.pool.create()
 

--- a/src/tests/ftest/pool/global_handle.yaml
+++ b/src/tests/ftest/pool/global_handle.yaml
@@ -8,10 +8,6 @@ server_config:
   name: daos_server
 pool:
   control_method: dmg
-testparams:
-  createmode:
-    mode: 511
-  createset:
-    setname: daos_server
-  createsize:
-    size: 1073741824
+  mode: 511
+  name: daos_server
+  scm_size: 1073741824

--- a/src/tests/ftest/pool/global_handle.yaml
+++ b/src/tests/ftest/pool/global_handle.yaml
@@ -6,6 +6,8 @@ hosts:
 timeout: 5000
 server_config:
   name: daos_server
+pool:
+  control_method: dmg
 testparams:
   createmode:
     mode: 511

--- a/src/tests/ftest/pool/info_tests.py
+++ b/src/tests/ftest/pool/info_tests.py
@@ -47,7 +47,8 @@ class InfoTests(TestWithServers):
         :avocado: tags=all,tiny,pr,pool,smoke,infotest
         """
         # Get the test params
-        self.pool = TestPool(self.context, self.log, dmg_bin_path=self.bin)
+        self.pool = TestPool(self.context, self.log,
+                             dmg_command=self.get_dmg_command())
         self.pool.get_params(self)
         permissions = self.params.get("permissions", "/run/test/*")
         targets = self.params.get("targets", "/run/server_config/*")

--- a/src/tests/ftest/pool/info_tests.py
+++ b/src/tests/ftest/pool/info_tests.py
@@ -52,7 +52,7 @@ class InfoTests(TestWithServers):
         self.pool.get_params(self)
         permissions = self.params.get("permissions", "/run/test/*")
         targets = self.params.get("targets", "/run/server_config/*")
-        pool_targets = len(self.hostlist_servers) * targets
+        #pool_targets = len(self.hostlist_servers) * targets
 
         # Create a pool
         self.pool.create()

--- a/src/tests/ftest/pool/info_tests.py
+++ b/src/tests/ftest/pool/info_tests.py
@@ -47,8 +47,7 @@ class InfoTests(TestWithServers):
         :avocado: tags=all,tiny,pr,pool,smoke,infotest
         """
         # Get the test params
-        self.pool = TestPool(self.context, self.log,
-                             dmg_bin_path=self.basepath + '/install/bin')
+        self.pool = TestPool(self.context, self.log, dmg_bin_path=self.bin)
         self.pool.get_params(self)
         permissions = self.params.get("permissions", "/run/test/*")
         targets = self.params.get("targets", "/run/server_config/*")

--- a/src/tests/ftest/pool/info_tests.py
+++ b/src/tests/ftest/pool/info_tests.py
@@ -58,7 +58,7 @@ class InfoTests(TestWithServers):
         self.pool.create()
 
         # Connect to the pool
-        self.pool.connect(permissions)
+        self.pool.connect(1 << permissions)
 
         # Verify the pool information
         checks = {

--- a/src/tests/ftest/pool/info_tests.py
+++ b/src/tests/ftest/pool/info_tests.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python
 """
-  (C) Copyright 2018-2019 Intel Corporation.
+  (C) Copyright 2018-2020 Intel Corporation.
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
@@ -47,7 +47,8 @@ class InfoTests(TestWithServers):
         :avocado: tags=all,tiny,pr,pool,smoke,infotest
         """
         # Get the test params
-        self.pool = TestPool(self.context, self.log)
+        self.pool = TestPool(self.context, self.log,
+                             dmg_bin_path=self.basepath + '/install/bin')
         self.pool.get_params(self)
         permissions = self.params.get("permissions", "/run/test/*")
         targets = self.params.get("targets", "/run/server_config/*")

--- a/src/tests/ftest/pool/info_tests.yaml
+++ b/src/tests/ftest/pool/info_tests.yaml
@@ -15,6 +15,7 @@ pool:
       mode: 146
   createset:
     name: daos_server
+  control_method: dmg
   createsize: !mux
     size1gb:
       scm_size: 1073741824

--- a/src/tests/ftest/pool/permission.py
+++ b/src/tests/ftest/pool/permission.py
@@ -45,14 +45,10 @@ class Permission(TestWithServers):
 
         :avocado: tags=pool,permission,connectpermission
         """
-        # parameters used in pool create
+        # parameter used in pool create
         createmode = self.params.get("mode", '/run/createtests/createmode/*/')
-        createuid = os.geteuid()
-        creategid = os.getegid()
-        createsetid = self.params.get("setname", '/run/createtests/createset/')
-        createsize = self.params.get("size", '/run/createtests/createsize/')
 
-        # parameters used for pool connect
+        # parameter used for pool connect
         permissions = self.params.get("perm", '/run/createtests/permissions/*')
 
         if createmode == 73 or \
@@ -71,21 +67,16 @@ class Permission(TestWithServers):
         else:
             expected_result = 'FAIL'
 
-        try:
-            # initialize a python pool object then create the underlying
-            # daos storage
-            self.pool = TestPool(self.context,
-                                 dmg_bin_path=self.basepath + '/install/bin')
-            self.multi_log("Pool initialisation successful", "debug")
-            self.pool.get_params(self)
-            self.pool.mode.value = createmode
-            self.pool.uid = createuid
-            self.pool.gid = creategid
-            self.pool.scm_size.value = createsize
-            self.pool.name.value = createsetid
-            self.pool.create()
-            self.multi_log("Pool Creation successful", "debug")
+        # initialize a python pool object then create the underlying
+        # daos storage
+        self.pool = TestPool(self.context, dmg_bin_path=self.bin)
+        self.multi_log("Pool initialisation successful", "debug")
+        self.pool.get_params(self)
+        self.pool.mode.value = createmode
+        self.pool.create()
+        self.multi_log("Pool Creation successful", "debug")
 
+        try:
             self.pool.connect(1 << permissions)
             self.multi_log("Pool Connect successful", "debug")
 
@@ -108,10 +99,6 @@ class Permission(TestWithServers):
         """
         # parameters used in pool create
         createmode = self.params.get("mode", '/run/createtests/createmode/*/')
-        createuid = self.params.get("uid", '/run/createtests/createuid/')
-        creategid = self.params.get("gid", '/run/createtests/creategid/')
-        createsetid = self.params.get("setname", '/run/createtests/createset/')
-        createsize = self.params.get("size", '/run/createtests/createsize/')
 
         if createmode == 73:
             expected_result = 'FAIL'
@@ -122,20 +109,15 @@ class Permission(TestWithServers):
             permissions = 2
             expected_result = 'PASS'
 
-        try:
-            # initialize a python pool object then create the underlying
-            # daos storage
-            self.pool = TestPool(self.context,
-                                 dmg_bin_path=self.basepath + '/install/bin')
-            self.multi_log("Pool initialisation successful", "debug")
-            self.pool.get_params(self)
-            self.pool.mode.value = createmode
-            self.pool.uid = createuid
-            self.pool.gid = creategid
-            self.pool.scm_size.value = createsize
-            self.pool.name.value = createsetid
-            self.multi_log("Pool Creation successful", "debug")
+        # initialize a python pool object then create the underlying
+        # daos storage
+        self.pool = TestPool(self.context, dmg_bin_path=self.bin)
+        self.multi_log("Pool initialisation successful", "debug")
+        self.pool.get_params(self)
+        self.pool.mode.value = createmode
+        self.multi_log("Pool Creation successful", "debug")
 
+        try:
             self.pool.connect(1 << permissions)
             self.multi_log("Pool Connect successful", "debug")
 

--- a/src/tests/ftest/pool/permission.py
+++ b/src/tests/ftest/pool/permission.py
@@ -133,7 +133,6 @@ class Permission(TestWithServers):
                     "passed.\n")
         except TestFail as excep:
             self.log.error(str(excep))
-            self.log.error(traceback.format_exc())
             if expected_result == RESULT_PASS:
                 self.fail(
                     "Test was expected to pass but it failed at " +

--- a/src/tests/ftest/pool/permission.py
+++ b/src/tests/ftest/pool/permission.py
@@ -83,6 +83,7 @@ class Permission(TestWithServers):
             self.pool.gid = creategid
             self.pool.scm_size.value = createsize
             self.pool.name.value = createsetid
+            self.pool.create()
             self.multi_log("Pool Creation successful", "debug")
 
             self.pool.connect(1 << permissions)

--- a/src/tests/ftest/pool/permission.py
+++ b/src/tests/ftest/pool/permission.py
@@ -69,7 +69,7 @@ class Permission(TestWithServers):
 
         # initialize a python pool object then create the underlying
         # daos storage
-        self.pool = TestPool(self.context, dmg_bin_path=self.bin)
+        self.pool = TestPool(self.context, dmg_command=self.get_dmg_command())
         self.multi_log("Pool initialisation successful", "debug")
         self.pool.get_params(self)
         self.pool.mode.value = createmode
@@ -111,7 +111,7 @@ class Permission(TestWithServers):
 
         # initialize a python pool object then create the underlying
         # daos storage
-        self.pool = TestPool(self.context, dmg_bin_path=self.bin)
+        self.pool = TestPool(self.context, dmg_command=self.get_dmg_command())
         self.multi_log("Pool initialisation successful", "debug")
         self.pool.get_params(self)
         self.pool.mode.value = createmode

--- a/src/tests/ftest/pool/permission.py
+++ b/src/tests/ftest/pool/permission.py
@@ -21,8 +21,6 @@
   Any reproduction of computer software, computer software documentation, or
   portions thereof marked with this legend must also reproduce the markings.
 '''
-import os
-
 from apricot import TestWithServers
 from pydaos.raw import DaosContainer, DaosApiError
 from test_utils_pool import TestPool

--- a/src/tests/ftest/pool/permission.py
+++ b/src/tests/ftest/pool/permission.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python
 '''
-  (C) Copyright 2018-2019 Intel Corporation.
+  (C) Copyright 2018-2020 Intel Corporation.
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
@@ -24,8 +24,8 @@
 import os
 
 from apricot import TestWithServers
-from pydaos.raw import DaosPool, DaosContainer, DaosApiError
-
+from pydaos.raw import DaosContainer, DaosApiError
+from test_utils_pool import TestPool
 
 class Permission(TestWithServers):
     """Test pool permissions.
@@ -74,11 +74,15 @@ class Permission(TestWithServers):
         try:
             # initialize a python pool object then create the underlying
             # daos storage
-            self.pool = DaosPool(self.context)
+            self.pool = TestPool(self.context,
+                                 dmg_bin_path=self.basepath + '/install/bin')
             self.multi_log("Pool initialisation successful", "debug")
-
-            self.pool.create(createmode, createuid, creategid,
-                             createsize, createsetid, None)
+            self.pool.get_params(self)
+            self.pool.mode.value = createmode
+            self.pool.uid = createuid
+            self.pool.gid = creategid
+            self.pool.scm_size.value = createsize
+            self.pool.name.value = createsetid
             self.multi_log("Pool Creation successful", "debug")
 
             self.pool.connect(1 << permissions)
@@ -120,14 +124,15 @@ class Permission(TestWithServers):
         try:
             # initialize a python pool object then create the underlying
             # daos storage
-            self.pool = DaosPool(self.context)
+            self.pool = TestPool(self.context,
+                                 dmg_bin_path=self.basepath + '/install/bin')
             self.multi_log("Pool initialisation successful", "debug")
-            self.pool.create(createmode,
-                             createuid,
-                             creategid,
-                             createsize,
-                             createsetid,
-                             None)
+            self.pool.get_params(self)
+            self.pool.mode.value = createmode
+            self.pool.uid = createuid
+            self.pool.gid = creategid
+            self.pool.scm_size.value = createsize
+            self.pool.name.value = createsetid
             self.multi_log("Pool Creation successful", "debug")
 
             self.pool.connect(1 << permissions)
@@ -136,7 +141,7 @@ class Permission(TestWithServers):
             self.container = DaosContainer(self.context)
             self.multi_log("Contianer initialisation successful", "debug")
 
-            self.container.create(self.pool.handle)
+            self.container.create(self.pool.pool.handle)
             self.multi_log("Container create successful", "debug")
 
             # now open it

--- a/src/tests/ftest/pool/permission.yaml
+++ b/src/tests/ftest/pool/permission.yaml
@@ -13,7 +13,8 @@ hosts:
 timeout: 300
 server_config:
     name: daos_server
-
+pool:
+    control_method: dmg
 createtests:
     createmode: !mux
         mode_RO:

--- a/src/tests/ftest/pool/permission.yaml
+++ b/src/tests/ftest/pool/permission.yaml
@@ -15,6 +15,8 @@ server_config:
     name: daos_server
 pool:
     control_method: dmg
+    scm_size: 1000000000
+    name: daos_server
 createtests:
     createmode: !mux
         mode_RO:
@@ -25,10 +27,6 @@ createtests:
             mode: 292
         mode_ALL:
             mode: 511
-    createset:
-        setname: daos_server
-    createsize:
-        size: 1000000000
     permissions: !mux
         perm_RO:
             perm: 0

--- a/src/tests/ftest/pool/pool_svc.py
+++ b/src/tests/ftest/pool/pool_svc.py
@@ -69,7 +69,7 @@ class PoolSvc(TestWithServers):
         # FAIL case should fail at above pool create, so do below only for
         # PASS case
         if expected_result == RESULT_PASS:
-            self.log.debug("self.pool.svc_ranks = %s" % self.pool.svc_ranks)
+            self.log.debug("self.pool.svc_ranks = %s", self.pool.svc_ranks)
             self.assertTrue(999999 not in self.pool.svc_ranks,
                             "999999 is in the pool's service ranks.")
             self.assertEqual(len(self.pool.svc_ranks), self.pool.svcn.value,

--- a/src/tests/ftest/pool/pool_svc.py
+++ b/src/tests/ftest/pool/pool_svc.py
@@ -88,7 +88,7 @@ class PoolSvc(TestWithServers):
                 if createsvc[0] == 3:
                     # kill pool leader and exclude it
                     self.pool.pool.pool_svc_stop()
-                    self.pool.exclude([leader])
+                    self.pool.exclude([leader], self.d_log)
                     # perform pool disconnect, try connect again and disconnect
                     self.pool.disconnect()
                     self.pool.connect(1)

--- a/src/tests/ftest/pool/pool_svc.py
+++ b/src/tests/ftest/pool/pool_svc.py
@@ -28,7 +28,7 @@ import traceback
 
 from apricot import TestWithServers
 
-from pydaos.raw import DaosServer, DaosApiError
+from pydaos.raw import DaosServer
 from test_utils_pool import TestPool
 from avocado.core.exceptions import TestFail
 
@@ -72,14 +72,14 @@ class PoolSvc(TestWithServers):
             # checking returned rank list for server more than 1
             iterator = 0
             while (
-                    int(self.pool.pool.svc.rl_ranks[iterator]) > 0 and
-                    int(self.pool.pool.svc.rl_ranks[iterator]) <= createsvc[0] and
-                    int(self.pool.pool.svc.rl_ranks[iterator]) != 999999
+                int(self.pool.pool.svc.rl_ranks[iterator]) > 0 and
+                int(self.pool.pool.svc.rl_ranks[iterator]) <= createsvc[0] and
+                int(self.pool.pool.svc.rl_ranks[iterator]) != 999999
             ):
                 iterator += 1
             if iterator != createsvc[0]:
                 self.fail("Length of Returned Rank list is not equal to "
-                        "the number of Pool Service members.\n")
+                          "the number of Pool Service members.\n")
             rank_list = []
             for iterator in range(createsvc[0]):
                 rank_list.append(int(self.pool.pool.svc.rl_ranks[iterator]))

--- a/src/tests/ftest/pool/pool_svc.py
+++ b/src/tests/ftest/pool/pool_svc.py
@@ -72,15 +72,15 @@ class PoolSvc(TestWithServers):
             #self.log.debug("## self.pool.svc_ranks = %s" %
             #               self.pool.svc_ranks)
             self.assertTrue(999999 not in self.pool.svc_ranks,
-                "999999 is in the pool's service ranks.")
+                            "999999 is in the pool's service ranks.")
             self.assertEqual(len(self.pool.svc_ranks), self.pool.svcn.value,
-                "Length of Returned Rank list is not equal to the number of " + 
-                "Pool Service members.")
+                             "Length of Returned Rank list is not equal to " +
+                             "the number of Pool Service members.")
 
             # Verify there are no duplicate ranks in the rank list
             self.assertEqual(len(self.pool.svc_ranks),
-                            len(set(self.pool.svc_ranks)),
-                            "Duplicate values in returned rank list")
+                             len(set(self.pool.svc_ranks)),
+                             "Duplicate values in returned rank list")
 
             try:
                 self.pool.get_info()
@@ -96,7 +96,7 @@ class PoolSvc(TestWithServers):
                     # kill another server which is not a leader and exclude it
                     server = DaosServer(self.context, self.server_group, 3)
                     server.kill(1)
-                    self.pool.exclude([3])
+                    self.pool.exclude([3], self.d_log)
                     # perform pool connect
                     self.pool.connect(1)
 

--- a/src/tests/ftest/pool/pool_svc.py
+++ b/src/tests/ftest/pool/pool_svc.py
@@ -54,7 +54,7 @@ class PoolSvc(TestWithServers):
 
         # initialize a python pool object then create the underlying
         # daos storage
-        self.pool = TestPool(self.context, dmg_bin_path=self.bin)
+        self.pool = TestPool(self.context, dmg_command=self.get_dmg_command())
         self.pool.get_params(self)
         self.pool.svcn.update(createsvc[0])
         try:

--- a/src/tests/ftest/pool/pool_svc.py
+++ b/src/tests/ftest/pool/pool_svc.py
@@ -32,6 +32,7 @@ from avocado.core.exceptions import TestFail
 RESULT_PASS = "PASS"
 RESULT_FAIL = "FAIL"
 
+
 class PoolSvc(TestWithServers):
     """
     Tests svc argument while pool create.
@@ -56,6 +57,8 @@ class PoolSvc(TestWithServers):
         self.pool.svcn.update(createsvc[0])
         try:
             self.pool.create()
+            if expected_result == RESULT_FAIL:
+                self.fail("Test was expected to fail, but it passed.\n")
         except TestFail as excep:
             print("## TestFail exception is caught at pool create!")
             print(excep)
@@ -66,8 +69,7 @@ class PoolSvc(TestWithServers):
         # FAIL case should fail at above pool create, so do below only for
         # PASS case
         if expected_result == RESULT_PASS:
-            #self.log.debug("## self.pool.svc_ranks = %s" %
-            #               self.pool.svc_ranks)
+            self.log.debug("self.pool.svc_ranks = %s" % self.pool.svc_ranks)
             self.assertTrue(999999 not in self.pool.svc_ranks,
                             "999999 is in the pool's service ranks.")
             self.assertEqual(len(self.pool.svc_ranks), self.pool.svcn.value,
@@ -88,23 +90,18 @@ class PoolSvc(TestWithServers):
                     self.pool.exclude([leader], self.d_log)
                     # perform pool disconnect, try connect again and disconnect
                     self.pool.disconnect()
-                    self.pool.connect(1)
+                    self.pool.connect()
                     self.pool.disconnect()
                     # kill another server which is not a leader and exclude it
                     server = DaosServer(self.context, self.server_group, 3)
                     server.kill(1)
                     self.pool.exclude([3], self.d_log)
                     # perform pool connect
-                    self.pool.connect(1)
-
-                if expected_result == RESULT_FAIL:
-                    self.fail("Test was expected to fail but it passed.\n")
-
+                    self.pool.connect()
             # Use TestFail instead of DaosApiError because create method has
             # @fail_on
             except TestFail as excep:
                 print("## TestFail exception caught")
                 print(excep)
                 print(traceback.format_exc())
-                if expected_result == RESULT_PASS:
-                    self.fail("Test was expected to pass but it failed.\n")
+                self.fail("Test was expected to pass but it failed.\n")

--- a/src/tests/ftest/pool/pool_svc.py
+++ b/src/tests/ftest/pool/pool_svc.py
@@ -22,12 +22,9 @@
   portions thereof marked with this legend must also reproduce the markings.
 '''
 from __future__ import print_function
-
-import os
 import traceback
 
 from apricot import TestWithServers
-
 from pydaos.raw import DaosServer
 from test_utils_pool import TestPool
 from avocado.core.exceptions import TestFail

--- a/src/tests/ftest/pool/pool_svc.py
+++ b/src/tests/ftest/pool/pool_svc.py
@@ -32,6 +32,9 @@ from pydaos.raw import DaosServer
 from test_utils_pool import TestPool
 from avocado.core.exceptions import TestFail
 
+RESULT_PASS = "PASS"
+RESULT_FAIL = "FAIL"
+
 class PoolSvc(TestWithServers):
     """
     Tests svc argument while pool create.
@@ -44,73 +47,67 @@ class PoolSvc(TestWithServers):
 
         :avocado: tags=all,pool,pr,medium,svc
         """
-
-        # parameters used in pool create
-        createmode = self.params.get("mode", '/run/createtests/createmode/*/')
-        createuid = os.geteuid()
-        creategid = os.getegid()
-        createsetid = self.params.get("setname", '/run/createtests/createset/')
-        createsize = self.params.get("size", '/run/createtests/createsize/')
+        # parameter used in pool create
         createsvc = self.params.get("svc", '/run/createtests/createsvc/*/')
 
         expected_result = createsvc[1]
 
+        # initialize a python pool object then create the underlying
+        # daos storage
+        self.pool = TestPool(self.context, dmg_bin_path=self.bin)
+        self.pool.get_params(self)
+        self.pool.svcn.update(createsvc[0])
         try:
-            # initialize a python pool object then create the underlying
-            # daos storage
-            self.pool = TestPool(self.context,
-                                 dmg_bin_path=self.basepath + '/install/bin')
-            self.pool.get_params(self)
-            # Manually set TestPool members before calling create
-            self.pool.mode.value = createmode
-            self.pool.scm_size.value = createsize
-            self.pool.name.update(createsetid)
-            self.pool.svcn.update(createsvc[0])
             self.pool.create()
-
-            self.pool.pool.connect(1 << 1)
-            # checking returned rank list for server more than 1
-            iterator = 0
-            while (
-                int(self.pool.pool.svc.rl_ranks[iterator]) > 0 and
-                int(self.pool.pool.svc.rl_ranks[iterator]) <= createsvc[0] and
-                int(self.pool.pool.svc.rl_ranks[iterator]) != 999999
-            ):
-                iterator += 1
-            if iterator != createsvc[0]:
-                self.fail("Length of Returned Rank list is not equal to "
-                          "the number of Pool Service members.\n")
-            rank_list = []
-            for iterator in range(createsvc[0]):
-                rank_list.append(int(self.pool.pool.svc.rl_ranks[iterator]))
-                if len(rank_list) != len(set(rank_list)):
-                    self.fail("Duplicate values in returned rank list")
-
-            self.pool.pool.pool_query()
-            leader = self.pool.pool.pool_info.pi_leader
-            if createsvc[0] == 3:
-                # kill pool leader and exclude it
-                self.pool.pool.pool_svc_stop()
-                self.pool.pool.exclude([leader])
-                # perform pool disconnect, try connect again and disconnect
-                self.pool.pool.disconnect()
-                self.pool.pool.connect(1 << 1)
-                self.pool.pool.disconnect()
-                # kill another server which is not a leader and exclude it
-                server = DaosServer(self.context, self.server_group, 3)
-                server.kill(1)
-                self.pool.pool.exclude([3])
-                # perform pool connect
-                self.pool.pool.connect(1 << 1)
-
-            if expected_result in ['FAIL']:
-                self.fail("Test was expected to fail but it passed.\n")
-
-        # Use TestFail instead of DaosApiError because create method has
-        # @fail_on
         except TestFail as excep:
-            print("### TestFail exception caught")
+            print("## TestFail exception is caught at pool create!")
             print(excep)
             print(traceback.format_exc())
-            if expected_result == 'PASS':
+            if expected_result == RESULT_PASS:
                 self.fail("Test was expected to pass but it failed.\n")
+
+        # FAIL case should fail at above pool create, so do below only for
+        # PASS case
+        if expected_result == RESULT_PASS:
+            #self.log.debug("## self.pool.svc_ranks = %s" %
+            #               self.pool.svc_ranks)
+            self.assertTrue(999999 not in self.pool.svc_ranks,
+                "999999 is in the pool's service ranks.")
+            self.assertEqual(len(self.pool.svc_ranks), self.pool.svcn.value,
+                "Length of Returned Rank list is not equal to the number of " + 
+                "Pool Service members.")
+
+            # Verify there are no duplicate ranks in the rank list
+            self.assertEqual(len(self.pool.svc_ranks),
+                            len(set(self.pool.svc_ranks)),
+                            "Duplicate values in returned rank list")
+
+            try:
+                self.pool.get_info()
+                leader = self.pool.info.pi_leader
+                if createsvc[0] == 3:
+                    # kill pool leader and exclude it
+                    self.pool.pool.pool_svc_stop()
+                    self.pool.exclude([leader])
+                    # perform pool disconnect, try connect again and disconnect
+                    self.pool.disconnect()
+                    self.pool.connect(1)
+                    self.pool.disconnect()
+                    # kill another server which is not a leader and exclude it
+                    server = DaosServer(self.context, self.server_group, 3)
+                    server.kill(1)
+                    self.pool.exclude([3])
+                    # perform pool connect
+                    self.pool.connect(1)
+
+                if expected_result == RESULT_FAIL:
+                    self.fail("Test was expected to fail but it passed.\n")
+
+            # Use TestFail instead of DaosApiError because create method has
+            # @fail_on
+            except TestFail as excep:
+                print("## TestFail exception caught")
+                print(excep)
+                print(traceback.format_exc())
+                if expected_result == RESULT_PASS:
+                    self.fail("Test was expected to pass but it failed.\n")

--- a/src/tests/ftest/pool/pool_svc.yaml
+++ b/src/tests/ftest/pool/pool_svc.yaml
@@ -9,14 +9,10 @@ server_config:
 timeout: 180
 pool:
     control_method: dmg
+    mode: 146
+    name: daos_server
+    scm_size: 1073741
 createtests:
-    createmode:
-        mode_RW:
-             mode: 146
-    createset:
-        setname: daos_server
-    createsize:
-        size: 1073741
     createsvc: !mux
         svc0:
             svc:

--- a/src/tests/ftest/pool/pool_svc.yaml
+++ b/src/tests/ftest/pool/pool_svc.yaml
@@ -7,6 +7,8 @@ hosts:
 server_config:
     name: daos_server
 timeout: 180
+pool:
+    control_method: dmg
 createtests:
     createmode:
         mode_RW:

--- a/src/tests/ftest/pool/rebuild_no_cap.py
+++ b/src/tests/ftest/pool/rebuild_no_cap.py
@@ -48,8 +48,7 @@ class RebuildNoCap(TestWithServers):
         :avocado: tags=all,medium,pr,pool,rebuild,nocap
         """
         # Get the test params
-        self.pool = TestPool(self.context, self.log,
-                             dmg_bin_path=self.basepath + '/install/bin')
+        self.pool = TestPool(self.context, self.log, dmg_bin_path=self.bin)
         self.pool.get_params(self)
         targets = self.params.get("targets", "/run/server_config/*")
         rank = self.params.get("rank_to_kill", "/run/testparams/*")

--- a/src/tests/ftest/pool/rebuild_no_cap.py
+++ b/src/tests/ftest/pool/rebuild_no_cap.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python
 '''
-  (C) Copyright 2018-2019 Intel Corporation.
+  (C) Copyright 2018-2020 Intel Corporation.
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
@@ -48,7 +48,8 @@ class RebuildNoCap(TestWithServers):
         :avocado: tags=all,medium,pr,pool,rebuild,nocap
         """
         # Get the test params
-        self.pool = TestPool(self.context, self.log)
+        self.pool = TestPool(self.context, self.log,
+                             dmg_bin_path=self.basepath + '/install/bin')
         self.pool.get_params(self)
         targets = self.params.get("targets", "/run/server_config/*")
         rank = self.params.get("rank_to_kill", "/run/testparams/*")

--- a/src/tests/ftest/pool/rebuild_no_cap.py
+++ b/src/tests/ftest/pool/rebuild_no_cap.py
@@ -48,7 +48,8 @@ class RebuildNoCap(TestWithServers):
         :avocado: tags=all,medium,pr,pool,rebuild,nocap
         """
         # Get the test params
-        self.pool = TestPool(self.context, self.log, dmg_bin_path=self.bin)
+        self.pool = TestPool(self.context, self.log,
+                             dmg_command=self.get_dmg_command())
         self.pool.get_params(self)
         targets = self.params.get("targets", "/run/server_config/*")
         rank = self.params.get("rank_to_kill", "/run/testparams/*")

--- a/src/tests/ftest/pool/rebuild_no_cap.yaml
+++ b/src/tests/ftest/pool/rebuild_no_cap.yaml
@@ -22,6 +22,7 @@ pool:
     name: daos_server
   createsize:
     scm_size: 16777216
+  control_method: dmg
 testparams:
   ranks:
     rank_to_kill: 0

--- a/src/tests/ftest/pool/rebuild_tests.py
+++ b/src/tests/ftest/pool/rebuild_tests.py
@@ -46,7 +46,7 @@ class RebuildTests(TestWithServers):
         containers = []
         for index in range(pool_quantity):
             pools.append(TestPool(self.context, self.log,
-                                  dmg_bin_path=self.basepath + '/install/bin'))
+                                  dmg_bin_path=self.bin))
             pools[index].get_params(self)
             containers.append(TestContainer(pools[index]))
             containers[index].get_params(self)

--- a/src/tests/ftest/pool/rebuild_tests.py
+++ b/src/tests/ftest/pool/rebuild_tests.py
@@ -46,7 +46,7 @@ class RebuildTests(TestWithServers):
         containers = []
         for index in range(pool_quantity):
             pools.append(TestPool(self.context, self.log,
-                                  dmg_bin_path=self.bin))
+                                  dmg_command=self.get_dmg_command()))
             pools[index].get_params(self)
             containers.append(TestContainer(pools[index]))
             containers[index].get_params(self)

--- a/src/tests/ftest/pool/rebuild_tests.py
+++ b/src/tests/ftest/pool/rebuild_tests.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python
 """
-  (C) Copyright 2018-2019 Intel Corporation.
+  (C) Copyright 2018-2020 Intel Corporation.
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
@@ -45,7 +45,8 @@ class RebuildTests(TestWithServers):
         pools = []
         containers = []
         for index in range(pool_quantity):
-            pools.append(TestPool(self.context, self.log))
+            pools.append(TestPool(self.context, self.log,
+                                  dmg_bin_path=self.basepath + '/install/bin'))
             pools[index].get_params(self)
             containers.append(TestContainer(pools[index]))
             containers[index].get_params(self)

--- a/src/tests/ftest/pool/rebuild_tests.yaml
+++ b/src/tests/ftest/pool/rebuild_tests.yaml
@@ -17,6 +17,7 @@ pool:
   mode: 511
   name: daos_server
   scm_size: 1073741824
+  control_method: dmg
 container:
   akey_size: 5
   dkey_size: 5

--- a/src/tests/ftest/pool/rebuild_with_io.py
+++ b/src/tests/ftest/pool/rebuild_with_io.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python
 """
-  (C) Copyright 2018-2019 Intel Corporation.
+  (C) Copyright 2018-2020 Intel Corporation.
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
@@ -50,7 +50,8 @@ class RebuildWithIO(TestWithServers):
         :avocado: tags=all,pool,rebuild,pr,medium,rebuildwithio
         """
         # Get the test params
-        pool = TestPool(self.context, self.log)
+        pool = TestPool(self.context, self.log,
+                        dmg_bin_path=self.basepath + '/install/bin')
         pool.get_params(self)
         container = TestContainer(pool)
         container.get_params(self)

--- a/src/tests/ftest/pool/rebuild_with_io.py
+++ b/src/tests/ftest/pool/rebuild_with_io.py
@@ -50,7 +50,8 @@ class RebuildWithIO(TestWithServers):
         :avocado: tags=all,pool,rebuild,pr,medium,rebuildwithio
         """
         # Get the test params
-        pool = TestPool(self.context, self.log, dmg_bin_path=self.bin)
+        pool = TestPool(self.context, self.log,
+                        dmg_command=self.get_dmg_command())
         pool.get_params(self)
         container = TestContainer(pool)
         container.get_params(self)

--- a/src/tests/ftest/pool/rebuild_with_io.py
+++ b/src/tests/ftest/pool/rebuild_with_io.py
@@ -50,8 +50,7 @@ class RebuildWithIO(TestWithServers):
         :avocado: tags=all,pool,rebuild,pr,medium,rebuildwithio
         """
         # Get the test params
-        pool = TestPool(self.context, self.log,
-                        dmg_bin_path=self.basepath + '/install/bin')
+        pool = TestPool(self.context, self.log, dmg_bin_path=self.bin)
         pool.get_params(self)
         container = TestContainer(pool)
         container.get_params(self)

--- a/src/tests/ftest/pool/rebuild_with_io.yaml
+++ b/src/tests/ftest/pool/rebuild_with_io.yaml
@@ -17,6 +17,7 @@ pool:
   mode: 511
   name: daos_server
   scm_size: 1073741824
+  control_method: dmg
 container:
   akey_size: 5
   dkey_size: 5

--- a/src/tests/ftest/pool/rebuild_with_ior.yaml
+++ b/src/tests/ftest/pool/rebuild_with_ior.yaml
@@ -26,6 +26,7 @@ pool:
     scm_size: 30000000000
   createsvc:
     svcn: 1
+  control_method: dmg
 ior:
     client_processes:
         np_8:

--- a/src/tests/ftest/util/apricot/apricot/test.py
+++ b/src/tests/ftest/util/apricot/apricot/test.py
@@ -44,6 +44,7 @@ from configuration_utils import Configuration
 from pydaos.raw import DaosContext, DaosLog, DaosApiError
 from env_modules import load_mpi
 from distutils.spawn import find_executable
+from dmg_utils import DmgCommand
 
 
 # pylint: disable=invalid-name
@@ -499,3 +500,26 @@ class TestWithServers(TestWithoutServers):
             self.log_dir, "{}_server_daos.log".format(self.test_id))
         self.client_log = os.path.join(
             self.log_dir, "{}_client_daos.log".format(self.test_id))
+
+    def get_dmg_command(self, index=0):
+        """Create a DmgCommand object, set the access point's host:port to -l
+        parameter, set False to -i (in default), and return the object.
+
+        This method is intended to be used by tests that wants to use dmg to
+        create and destroy pool. Pass in the object to TestPool constructor.
+
+        Access point should be passed in to -l regardless of the number of
+        servers.
+
+        Args:
+            index (int, optional): Server index. Defaults to 0.
+
+        Returns:
+            DmgCommand: New DmgCommand object.
+        """
+        dmg = DmgCommand(self.bin)
+        dmg.hostlist.value = self.server_managers[index].runner.job.\
+            yaml_params.access_points.value
+        dmg.insecure.value = \
+            self.server_managers[index].insecure.value
+        return dmg

--- a/src/tests/ftest/util/ior_test_base.py
+++ b/src/tests/ftest/util/ior_test_base.py
@@ -83,7 +83,8 @@ class IorTestBase(TestWithServers):
     def create_pool(self):
         """Create a TestPool object to use with ior."""
         # Get the pool params
-        self.pool = TestPool(self.context, self.log, dmg_bin_path=self.bin)
+        self.pool = TestPool(self.context, self.log,
+                             dmg_command=self.get_dmg_command())
         self.pool.get_params(self)
 
         # Create a pool

--- a/src/tests/ftest/util/ior_test_base.py
+++ b/src/tests/ftest/util/ior_test_base.py
@@ -83,7 +83,7 @@ class IorTestBase(TestWithServers):
     def create_pool(self):
         """Create a TestPool object to use with ior."""
         # Get the pool params
-        self.pool = TestPool(self.context, self.log)
+        self.pool = TestPool(self.context, self.log, dmg_bin_path=self.bin)
         self.pool.get_params(self)
 
         # Create a pool

--- a/src/tests/ftest/util/test_utils_pool.py
+++ b/src/tests/ftest/util/test_utils_pool.py
@@ -37,7 +37,7 @@ from pydaos.raw import (DaosApiError, DaosServer, DaosPool, c_uuid_to_str,
 from general_utils import check_pool_files, DaosTestError
 from env_modules import load_mpi
 
-from dmg_utils import (get_pool_uuid_service_replicas_from_stdout, DmgCommand)
+from dmg_utils import get_pool_uuid_service_replicas_from_stdout
 
 
 class TestPool(TestDaosApiBase):

--- a/src/tests/ftest/util/test_utils_pool.py
+++ b/src/tests/ftest/util/test_utils_pool.py
@@ -58,6 +58,11 @@ class TestPool(TestDaosApiBase):
             log (logging): logging object used to report the pool status
             cb_handler (CallbackHandler, optional): callback object to use with
                 the API methods. Defaults to None.
+            dmg_command (DmgCommand): DmgCommand used to call dmg command. If
+                control_method is set to dmg, this value needs to be set. It
+                can be obtained by calling self.get_dmg_command() from a test.
+                It'll return the object with -l <Access Point host:port> and
+                --insecure.
         """
         super(TestPool, self).__init__("/run/pool/*", cb_handler)
         self.context = context
@@ -211,11 +216,11 @@ class TestPool(TestDaosApiBase):
         self.uuid = self.pool.get_uuid_str()
 
     @fail_on(DaosApiError)
-    def connect(self, permission=1):
+    def connect(self, permission=2):
         """Connect to the pool.
 
         Args:
-            permission (int, optional): connect permission. Defaults to 1.
+            permission (int, optional): connect permission. Defaults to 2.
 
         Returns:
             bool: True if the pool has been connected; False if the pool was
@@ -223,7 +228,7 @@ class TestPool(TestDaosApiBase):
 
         """
         if self.pool and not self.connected:
-            kwargs = {"flags": 1 << permission}
+            kwargs = {"flags": permission}
             self.log.info(
                 "Connecting to pool %s with permission %s (flag: %s)",
                 self.uuid, permission, kwargs["flags"])

--- a/src/tests/ftest/util/test_utils_pool.py
+++ b/src/tests/ftest/util/test_utils_pool.py
@@ -47,7 +47,7 @@ class TestPool(TestDaosApiBase):
     USE_API = "API"
     USE_DMG = "dmg"
 
-    def __init__(self, context, log=None, cb_handler=None, dmg_bin_path=None):
+    def __init__(self, context, log=None, cb_handler=None, dmg_command=None):
         # pylint: disable=unused-argument
         """Initialize a TestPool object.
 
@@ -83,16 +83,7 @@ class TestPool(TestDaosApiBase):
         self.info = None
         self.svc_ranks = None
         self.connected = False
-        self.dmg = None
-        # Required to use dmg. It defined the directory where dmg is installed.
-        # Use self.basepath + '/install/bin' in the test
-        self.dmg_bin_path = dmg_bin_path
-        if dmg_bin_path is not None:
-            # We make dmg as the member of this class because the test would
-            # have more flexibility over the usage of the command.
-            self.dmg = DmgCommand(self.dmg_bin_path)
-            self.dmg.insecure.value = True
-            self.dmg.request.value = "pool"
+        self.dmg = dmg_command
 
     @fail_on(CommandFailure)
     @fail_on(DaosApiError)
@@ -143,8 +134,9 @@ class TestPool(TestDaosApiBase):
         else:
             if self.dmg is None:
                 raise DaosTestError(
-                    "self.dmg is None. dmg_bin_path needs to be set through "
+                    "self.dmg is None. dmg_command needs to be set through "
                     "the constructor of TestPool to create pool with dmg.")
+            self.dmg.request.value = "pool"
             # Currently, there is one test that creates the pool over the
             # subset of the server hosts; pool/evict_test. To do so, the test
             # needs to set the rank(s) to target_list.value starting from 0.

--- a/src/tests/ftest/util/test_utils_pool.py
+++ b/src/tests/ftest/util/test_utils_pool.py
@@ -140,10 +140,6 @@ class TestPool(TestDaosApiBase):
                 if value is not None:
                     kwargs[key] = value
             self._call_method(self.pool.create, kwargs)
-
-            self.svc_ranks = [
-                int(self.pool.svc.rl_ranks[index])
-                for index in range(self.pool.svc.rl_nr)]
         else:
             if self.dmg is None:
                 raise DaosTestError(
@@ -217,6 +213,9 @@ class TestPool(TestDaosApiBase):
             self.pool.set_uuid_str(new_uuid)
             self.pool.attached = 1
 
+        self.svc_ranks = [
+            int(self.pool.svc.rl_ranks[index])
+            for index in range(self.pool.svc.rl_nr)]
         self.uuid = self.pool.get_uuid_str()
 
     @fail_on(DaosApiError)


### PR DESCRIPTION
For the tests that use TestPool, added dmg_bin_path parameter to
the TestPool constructor. For the tests that use DmgPool,
modified them to use TestPool.create method.

Added control_method: dmg to the yaml files.

Most of the tests were tested in my environment.

Signed-off-by: Makito Kano <makito.kano@intel.com>