### PR TITLE
DAOS-2282 dfuse: Hook into dfuse in the container create/destroy command.

### DIFF
--- a/src/client/dfs/dfs.c
+++ b/src/client/dfs/dfs.c
@@ -3088,7 +3088,7 @@ dfs_osetattr(dfs_t *dfs, dfs_obj_t *obj, struct stat *stbuf, int flags)
 
 	sgl.sg_nr	= i;
 	sgl.sg_nr_out	= 0;
-	sgl.sg_iovs	= &sg_iovs[i];
+	sgl.sg_iovs	= &sg_iovs[0];
 
 	rc = daos_obj_update(oh, th, 0, &dkey, 1, &iod, &sgl, NULL);
 	if (rc) {

--- a/src/client/dfs/duns.c
+++ b/src/client/dfs/duns.c
@@ -50,6 +50,11 @@
 #define DUNS_MAX_XATTR_LEN	170
 #define DUNS_MIN_XATTR_LEN	85
 #define DUNS_XATTR_FMT		"DAOS.%s://%36s/%36s"
+
+#ifndef FUSE_SUPER_MAGIC
+#define FUSE_SUPER_MAGIC	0x65735546
+#endif
+
 #ifdef LUSTRE_INCLUDE
 #define LIBLUSTRE		"liblustreapi.so"
 
@@ -455,6 +460,7 @@ duns_create_path(daos_handle_t poh, const char *path, struct duns_attr_t *attrp)
 	int			len;
 	int			try_multiple = 1;		/* boolean */
 	int			rc;
+	bool			backend_dfuse = false;
 
 	if (path == NULL) {
 		D_ERROR("Invalid path\n");
@@ -498,6 +504,10 @@ duns_create_path(daos_handle_t poh, const char *path, struct duns_attr_t *attrp)
 				dirp, strerror(errno));
 			/** TODO - convert errno to rc */
 			return -DER_INVAL;
+		}
+
+		if (fs.f_type == FUSE_SUPER_MAGIC) {
+			backend_dfuse = true;
 		}
 
 #ifdef LUSTRE_INCLUDE
@@ -582,6 +592,46 @@ duns_create_path(daos_handle_t poh, const char *path, struct duns_attr_t *attrp)
 			rc = daos_cont_create(poh, attrp->da_cuuid, prop, NULL);
 			daos_prop_free(prop);
 		}
+
+		if (rc == -DER_SUCCESS && backend_dfuse) {
+			/* Setup the DFUSE entry points.  Do this after the
+			 * container has been created as the first access after
+			 * setting these will do a container attach and that
+			 * will fail if the container doesn't exist.
+			 *
+			 * Set both the extended attribures the DFUSE expects
+			 * as well as the Lustre version, which is used by
+			 * duns_resove_path() in container destroy.
+			 */
+
+			rc = lsetxattr(path, "user.uns.pool", pool,
+				       strlen(pool), XATTR_CREATE);
+			if (rc) {
+				D_ERROR("Failed to set DAOS xattr (rc = %d).\n", rc);
+				D_GOTO(err_link, rc = -DER_IO);
+			}
+
+			rc = lsetxattr(path, "user.uns.container", cont,
+				       strlen(cont), XATTR_CREATE);
+			if (rc) {
+				D_ERROR("Failed to set DAOS xattr (rc = %d).\n", rc);
+				D_GOTO(err_link, rc = -DER_IO);
+			}
+
+			/* This next setxattr will cause dfuse to lookup the
+			 * entry point and perform a container connect,
+			 * therefore this xattr will be set in the root of the
+			 * new container, not the directory
+			 */
+
+			rc = lsetxattr(path, DUNS_XATTR_NAME, str,
+				       len + 1, XATTR_CREATE);
+			if (rc) {
+				D_ERROR("Failed to set DAOS xattr (rc = %d).\n", rc);
+				D_GOTO(err_link, rc = -DER_INVAL);
+			}
+		}
+
 	} while ((rc == -DER_EXIST) && try_multiple);
 	if (rc) {
 		D_ERROR("Failed to create container (%d)\n", rc);

--- a/src/client/dfs/duns.c
+++ b/src/client/dfs/duns.c
@@ -607,14 +607,16 @@ duns_create_path(daos_handle_t poh, const char *path, struct duns_attr_t *attrp)
 			rc = lsetxattr(path, "user.uns.pool", pool,
 				       strlen(pool), XATTR_CREATE);
 			if (rc) {
-				D_ERROR("Failed to set DAOS xattr (rc = %d).\n", rc);
+				D_ERROR("Failed to set DAOS xattr (rc = %d).\n",
+					rc);
 				D_GOTO(err_link, rc = -DER_IO);
 			}
 
 			rc = lsetxattr(path, "user.uns.container", cont,
 				       strlen(cont), XATTR_CREATE);
 			if (rc) {
-				D_ERROR("Failed to set DAOS xattr (rc = %d).\n", rc);
+				D_ERROR("Failed to set DAOS xattr (rc = %d).\n",
+					rc);
 				D_GOTO(err_link, rc = -DER_IO);
 			}
 
@@ -627,8 +629,9 @@ duns_create_path(daos_handle_t poh, const char *path, struct duns_attr_t *attrp)
 			rc = lsetxattr(path, DUNS_XATTR_NAME, str,
 				       len + 1, XATTR_CREATE);
 			if (rc) {
-				D_ERROR("Failed to set DAOS xattr (rc = %d).\n", rc);
-				D_GOTO(err_link, rc = -DER_INVAL);
+				D_ERROR("Failed to set DAOS xattr (rc = %d).\n",
+					rc);
+				D_GOTO(err_link, rc = -DER_IO);
 			}
 		}
 

--- a/src/client/dfuse/ops/lookup.c
+++ b/src/client/dfuse/ops/lookup.c
@@ -207,7 +207,7 @@ check_for_uns_ep(struct dfuse_projection_info *fs_handle,
 				       NULL);
 		if (rc != -DER_SUCCESS) {
 			DFUSE_LOG_ERROR("Failed to connect to pool (%d)", rc);
-			D_GOTO(out_err, ret = rc);
+			D_GOTO(out_err, ret = daos_der2errno(rc));
 		}
 
 	} else {
@@ -234,7 +234,7 @@ check_for_uns_ep(struct dfuse_projection_info *fs_handle,
 		if (rc) {
 			DFUSE_LOG_ERROR("Failed container open (%d)",
 					rc);
-			D_GOTO(out_pool, ret = rc);
+			D_GOTO(out_pool, ret = daos_der2errno(rc));
 		}
 
 		rc = dfs_mount(dfp->dfp_poh, dfs->dfs_coh, O_RDWR,


### PR DESCRIPTION
Add dfuse hooks in duns to allow container create to insert an entry
point in dfuse.
Fix a bug in setattr.
Return correct error codes if pool or container attach fail in dfuse.

This works correctly for creating a container, and the paths resolve
for container destroy however the destroy itself currently fails,
seemingly because the container is in use so further work is required here.