### PR TITLE
DAOS-4016 test: check return of pool_destroy_safe()

### DIFF
--- a/src/tests/suite/daos_test_common.c
+++ b/src/tests/suite/daos_test_common.c
@@ -485,12 +485,16 @@ test_teardown(void **state)
 		if (arg->multi_rank)
 			MPI_Barrier(MPI_COMM_WORLD);
 		if (arg->myrank == 0)
-			pool_destroy_safe(arg, NULL);
+			rc = pool_destroy_safe(arg, NULL);
 
 		if (arg->multi_rank)
 			MPI_Bcast(&rc, 1, MPI_INT, 0, MPI_COMM_WORLD);
-		if (rc)
+		if (rc) {
+			print_message("failed to destroy pool "DF_UUIDF
+				      " rc: %d\n",
+				      DP_UUID(arg->pool.pool_uuid), rc);
 			return rc;
+		}
 	}
 
 	if (!daos_handle_is_inval(arg->eq)) {


### PR DESCRIPTION
With this change the daos_test common function test_teardown()
now examines the return code of pool_destroy_safe() and frees the
test state in an error scenario. Before the change he return code
was not examined. In rare error scenarios daos_test instability was
observed following a failure to destroy a DAOS pool in teardown.

Signed-off-by: Ken Cain <kenneth.c.cain@intel.com>