### PR TITLE
DAOS-623 build: Prepend rather than Append mpicc path

### DIFF
--- a/utils/build.config
+++ b/utils/build.config
@@ -3,7 +3,7 @@ component=daos
 
 [commit_versions]
 ARGOBOTS = 89507c1f8cfec4e918e8b9861e41b4e9cef71461
-CART = 51549ea88405fa8f069aa8752525624e8d999d33
+CART = 14f63cf82262a46c85050df5b5b0fa00e85c94ac
 PMDK = 1.6
 ISAL = v2.26.0
 SPDK = v19.04.1

--- a/utils/daos_build.py
+++ b/utils/daos_build.py
@@ -1,5 +1,6 @@
 """Common DAOS build functions"""
 from SCons.Script import Literal
+from SCons.Script import GetOption
 from env_modules import load_mpi
 from distutils.spawn import find_executable
 import os
@@ -32,10 +33,12 @@ def load_mpi_path(env):
     """Load location of mpicc into path if MPI_PKG is set"""
     mpicc = find_executable("mpicc")
     if mpicc:
-        env.AppendENVPath("PATH", os.path.dirname(mpicc))
+        env.PrependENVPath("PATH", os.path.dirname(mpicc))
 
 def _configure_mpi_pkg(env, libs):
     """Configure MPI using pkg-config"""
+    if GetOption('help'):
+        return
     mpicc = find_executable("mpicc")
     if mpicc:
         env.Replace(CC="mpicc")


### PR DESCRIPTION
If another mpicc is in path, it can be picked instead
when MPI_PKG is used and that is wrong.
Also, check if help option is set before configuring mpi
Update cart to latest to get Prepend fix there too

Signed-off-by: Jeff Olivier <jeffrey.v.olivier@intel.com>