### PR TITLE
DAOS-3965 vos: reindex active DTX before into container hash

### DIFF
--- a/src/vos/vos_container.c
+++ b/src/vos/vos_container.c
@@ -436,22 +436,21 @@ vos_cont_open(daos_handle_t poh, uuid_t co_uuid, daos_handle_t *coh)
 		}
 	}
 
+	rc = vos_dtx_act_reindex(cont);
+	if (rc != 0) {
+		D_ERROR("Fail to reindex active DTX entries: %d\n", rc);
+		goto exit;
+	}
+
 	rc = cont_insert(cont, &ukey, &pkey, coh);
 	if (rc != 0) {
 		D_ERROR("Error inserting vos container handle to uuid hash\n");
 		goto exit;
 	}
 
-	rc = vos_dtx_act_reindex(cont);
-	if (rc != 0) {
-		D_ERROR("Fail to reindex active DTX entries: %d\n", rc);
-	} else {
-		cont->vc_open_count = 1;
-
-		D_DEBUG(DB_TRACE, "Inert cont "DF_UUID" into hash table.\n",
-			DP_UUID(cont->vc_id));
-
-	}
+	cont->vc_open_count = 1;
+	D_DEBUG(DB_TRACE, "Inert cont "DF_UUID" into hash table.\n",
+		DP_UUID(cont->vc_id));
 
 exit:
 	if (rc != 0 && cont)


### PR DESCRIPTION
Re-establish the active DTX index in DRAM is part of initializing
vos container. We should do that before inserting the vos container
into the hash table.

Signed-off-by: Fan Yong <fan.yong@intel.com>