### PR TITLE
DAOS-4019 control: Add unique codes for all faults

### DIFF
--- a/src/control/fault/code/codes.go
+++ b/src/control/fault/code/codes.go
@@ -1,5 +1,5 @@
 //
-// (C) Copyright 2018-2019 Intel Corporation.
+// (C) Copyright 2018-2020 Intel Corporation.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -39,14 +39,21 @@ const (
 	StorageAlreadyFormatted
 	StorageFilesystemAlreadyMounted
 	StorageDeviceAlreadyMounted
+	StorageTargetAlreadyMounted
 
 	// SCM fault codes
 	ScmUnknown Code = iota + 200
-	ScmFormatBadParam
+	ScmFormatInvalidSize
+	ScmFormatInvalidDeviceCount
+	ScmFormatMissingMountpoint
+	ScmFormatMissingDevice
+	ScmFormatMissingParam
+	ScmFormatConflictingParam
+	ScmDiscoveryFailed
 
 	// Bdev fault codes
 	BdevUnknown Code = iota + 300
-	BdevFormatBadParam
+	BdevFormatUnknownClass
 	BdevFormatFailure
 	BdevFormatBadPciAddress
 

--- a/src/control/server/storage/bdev/faults.go
+++ b/src/control/server/storage/bdev/faults.go
@@ -1,5 +1,5 @@
 //
-// (C) Copyright 2019 Intel Corporation.
+// (C) Copyright 2019-2020 Intel Corporation.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -43,7 +43,7 @@ func FaultFormatBadPciAddr(pciAddr string) *fault.Fault {
 
 func FaultFormatUnknownClass(class string) *fault.Fault {
 	return bdevFault(
-		code.BdevFormatBadParam,
+		code.BdevFormatUnknownClass,
 		fmt.Sprintf("format request contains unhandled block device class %q", class),
 		"check your configuration and restart the server",
 	)

--- a/src/control/server/storage/scm/faults.go
+++ b/src/control/server/storage/scm/faults.go
@@ -1,5 +1,5 @@
 //
-// (C) Copyright 2019 Intel Corporation.
+// (C) Copyright 2019-2020 Intel Corporation.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -32,22 +32,22 @@ var (
 		code.ScmUnknown, "unknown scm error", "",
 	)
 	FaultDiscoveryFailed = scmFault(
-		code.ScmUnknown, "module discovery failed", "",
+		code.ScmDiscoveryFailed, "module discovery failed", "",
 	)
 	FaultFormatInvalidSize = scmFault(
-		code.ScmFormatBadParam, "format request must specify a size greater than 0", "",
+		code.ScmFormatInvalidSize, "format request must specify a size greater than 0", "",
 	)
 	FaultFormatInvalidDeviceCount = scmFault(
-		code.ScmFormatBadParam, "format request must have exactly 1 dcpm device", "",
+		code.ScmFormatInvalidDeviceCount, "format request must have exactly 1 dcpm device", "",
 	)
 	FaultFormatMissingMountpoint = scmFault(
-		code.ScmFormatBadParam, "format request must specify mountpoint", "",
+		code.ScmFormatMissingMountpoint, "format request must specify mountpoint", "",
 	)
 	FaultFormatMissingParam = scmFault(
-		code.ScmFormatBadParam, "format request must have ramdisk or dcpm parameter", "",
+		code.ScmFormatMissingParam, "format request must have ramdisk or dcpm parameter", "",
 	)
 	FaultFormatConflictingParam = scmFault(
-		code.ScmFormatBadParam,
+		code.ScmFormatConflictingParam,
 		"format request must not have both ramdisk and dcpm parameters", "",
 	)
 	FaultFormatNoReformat = scmFault(
@@ -61,12 +61,12 @@ var (
 		"unmount the device and retry the operation",
 	)
 	FaultTargetAlreadyMounted = scmFault(
-		code.StorageDeviceAlreadyMounted,
+		code.StorageTargetAlreadyMounted,
 		"request included already-mounted mount target (cannot double-mount)",
 		"unmount the target and retry the operation",
 	)
 	FaultFormatMissingDevice = scmFault(
-		code.ScmFormatBadParam,
+		code.ScmFormatMissingDevice,
 		"configured SCM device does not exist",
 		"check the configured value and/or perform the SCM preparation procedure",
 	)


### PR DESCRIPTION
A number of the faults defined in the new storage providers were
added without unique codes. This commit fixes that problem.