### PR TITLE
DAOS-2282 dfuse: Use common UNS xattrs for Lustre and dfuse

### DIFF
--- a/src/client/dfs/duns.c
+++ b/src/client/dfs/duns.c
@@ -46,7 +46,6 @@
 #include "daos_fs.h"
 #include "daos_uns.h"
 
-#define DUNS_XATTR_NAME		"user.daos"
 #define DUNS_MAX_XATTR_LEN	170
 #define DUNS_MIN_XATTR_LEN	85
 #define DUNS_XATTR_FMT		"DAOS.%s://%36s/%36s"
@@ -196,7 +195,7 @@ duns_resolve_lustre_path(const char *path, struct duns_attr_t *attr)
 			/** TODO - convert errno to rc */
 			return -DER_INVAL;
 		}
-	
+
 		lfm = (struct lmv_foreign_md *)buf;
 		/* sanity check */
 		if (lfm->lfm_magic != LMV_MAGIC_FOREIGN  ||
@@ -268,7 +267,6 @@ duns_resolve_path(const char *path, struct duns_attr_t *attr)
 {
 	ssize_t	s;
 	char	str[DUNS_MAX_XATTR_LEN];
-	char	*saveptr, *t;
 	struct statfs fs;
 	char	*dir, *dirp;
 	int	rc;
@@ -318,37 +316,67 @@ duns_resolve_path(const char *path, struct duns_attr_t *attr)
 		return -DER_INVAL;
 	}
 
-	t = strtok_r(str, ".", &saveptr);
+	return duns_parse_attr(&str[0], s, attr);
+}
+
+int
+duns_parse_attr(char *str, daos_size_t len, struct duns_attr_t *attr)
+{
+	char *local;
+	char	*saveptr, *t;
+	int rc;
+
+	D_STRNDUP(local, str, len);
+	if (!local)
+		return -DER_NOMEM;
+
+	t = strtok_r(local, ".", &saveptr);
 	if (t == NULL) {
 		D_ERROR("Invalid DAOS xattr format (%s).\n", str);
-		return -DER_INVAL;
+		D_GOTO(err, rc = -DER_INVAL);
 	}
 
 	t = strtok_r(NULL, ":", &saveptr);
+	if (t == NULL) {
+		D_ERROR("Invalid DAOS xattr format (%s).\n", str);
+		D_GOTO(err, rc = -DER_INVAL);
+	}
 	daos_parse_ctype(t, &attr->da_type);
 	if (attr->da_type == DAOS_PROP_CO_LAYOUT_UNKOWN) {
 		D_ERROR("Invalid DAOS xattr format: Container layout cannot be"
 			" unknown\n");
-		return -DER_INVAL;
+		D_GOTO(err, rc = -DER_INVAL);
 	}
 
 	t = strtok_r(NULL, "/", &saveptr);
+	if (t == NULL) {
+		D_ERROR("Invalid DAOS xattr format (%s).\n", str);
+		D_GOTO(err, rc = -DER_INVAL);
+	}
+
 	rc = uuid_parse(t, attr->da_puuid);
 	if (rc) {
 		D_ERROR("Invalid DAOS xattr format: pool UUID cannot be"
 			" parsed\n");
-		return -DER_INVAL;
+		D_GOTO(err, rc = -DER_INVAL);
 	}
 
 	t = strtok_r(NULL, "/", &saveptr);
+	if (t == NULL) {
+		D_ERROR("Invalid DAOS xattr format (%s).\n", str);
+		D_GOTO(err, rc = -DER_INVAL);
+	}
 	rc = uuid_parse(t, attr->da_cuuid);
 	if (rc) {
 		D_ERROR("Invalid DAOS xattr format: container UUID cannot be"
 			" parsed\n");
-		return -DER_INVAL;
+		D_GOTO(err, rc = -DER_INVAL);
 	}
 
 	return 0;
+err:
+	D_FREE(local);
+	return rc;
 }
 
 #ifdef LUSTRE_INCLUDE
@@ -565,7 +593,9 @@ duns_create_path(daos_handle_t poh, const char *path, struct duns_attr_t *attrp)
 
 		rc = lsetxattr(path, DUNS_XATTR_NAME, str, len + 1, 0);
 		if (rc) {
-			D_ERROR("Failed to set DAOS xattr (rc = %d).\n", rc);
+			int err = errno;
+
+			D_ERROR("Failed to set DAOS xattr (rc = %d).\n", err);
 			D_GOTO(err_link, rc = -DER_INVAL);
 		}
 
@@ -594,43 +624,19 @@ duns_create_path(daos_handle_t poh, const char *path, struct duns_attr_t *attrp)
 		}
 
 		if (rc == -DER_SUCCESS && backend_dfuse) {
-			/* Setup the DFUSE entry points.  Do this after the
-			 * container has been created as the first access after
-			 * setting these will do a container attach and that
-			 * will fail if the container doesn't exist.
-			 *
-			 * Set both the extended attribures the DFUSE expects
-			 * as well as the Lustre version, which is used by
-			 * duns_resove_path() in container destroy.
-			 */
-
-			rc = lsetxattr(path, "user.uns.pool", pool,
-				       strlen(pool), XATTR_CREATE);
-			if (rc) {
-				D_ERROR("Failed to set DAOS xattr (rc = %d).\n",
-					rc);
-				D_GOTO(err_link, rc = -DER_IO);
-			}
-
-			rc = lsetxattr(path, "user.uns.container", cont,
-				       strlen(cont), XATTR_CREATE);
-			if (rc) {
-				D_ERROR("Failed to set DAOS xattr (rc = %d).\n",
-					rc);
-				D_GOTO(err_link, rc = -DER_IO);
-			}
-
 			/* This next setxattr will cause dfuse to lookup the
 			 * entry point and perform a container connect,
 			 * therefore this xattr will be set in the root of the
-			 * new container, not the directory
+			 * new container, not the directory.
 			 */
 
 			rc = lsetxattr(path, DUNS_XATTR_NAME, str,
 				       len + 1, XATTR_CREATE);
 			if (rc) {
+				int err = errno;
+
 				D_ERROR("Failed to set DAOS xattr (rc = %d).\n",
-					rc);
+					err);
 				D_GOTO(err_link, rc = -DER_IO);
 			}
 		}

--- a/src/client/dfuse/SConscript
+++ b/src/client/dfuse/SConscript
@@ -136,7 +136,7 @@ def scons():
     cenv.AppendUnique(CPPDEFINES=['-DFUSE_USE_VERSION=32'])
     cenv.AppendUnique(LIBPATH=["../dfs"])
 
-    cenv.AppendUnique(LIBS=['dfs'])
+    cenv.AppendUnique(LIBS=['dfs', 'duns'])
 
     prereqs.require(cenv, 'fuse')
 

--- a/src/client/dfuse/dfuse.h
+++ b/src/client/dfuse/dfuse.h
@@ -36,9 +36,6 @@
 
 #include "dfuse_common.h"
 
-#define DFUSE_UNS_POOL_ATTR "user.uns.pool"
-#define DFUSE_UNS_CONTAINER_ATTR "user.uns.container"
-
 struct dfuse_info {
 	struct fuse_session		*di_session;
 	struct dfuse_projection_info	*di_handle;

--- a/src/client/dfuse/dfuse_main.c
+++ b/src/client/dfuse/dfuse_main.c
@@ -111,7 +111,8 @@ show_help(char *name)
 		"	   --container=UUID	container UUID\n"
 		"	   --sys-name=STR	DAOS system name context for servers\n"
 		"	-S --singlethreaded	Single threaded\n"
-		"	-f --foreground		Run in foreground\n",
+		"	-f --foreground		Run in foreground\n"
+		"	   --enable-caching	Enable node-local caching (experimental)\n",
 		name);
 }
 

--- a/src/client/dfuse/ops/lookup.c
+++ b/src/client/dfuse/ops/lookup.c
@@ -284,7 +284,8 @@ out_pool:
 	if (new_pool) {
 		rc = daos_pool_disconnect(dfp->dfp_poh, NULL);
 		if (rc)
-			DFUSE_TRA_ERROR(dfs, "daos_pool_disconnect() failed %d", rc);
+			DFUSE_TRA_ERROR(dfs,
+					"daos_pool_disconnect() failed %d", rc);
 	}
 out_err:
 	if (new_cont) {

--- a/src/client/dfuse/ops/lookup.c
+++ b/src/client/dfuse/ops/lookup.c
@@ -24,6 +24,8 @@
 #include "dfuse_common.h"
 #include "dfuse.h"
 
+#include "daos_uns.h"
+
 void
 dfuse_reply_entry(struct dfuse_projection_info *fs_handle,
 		  struct dfuse_inode_entry *ie,
@@ -123,61 +125,32 @@ check_for_uns_ep(struct dfuse_projection_info *fs_handle,
 {
 	daos_obj_id_t		oid;
 	int			rc;
-	char			pool[40] = {};
-	size_t			pool_size = 40;
-	char			cont[40] = {};
-	size_t			cont_size = 40;
+	char			str[DUNS_MAX_XATTR_LEN];
+	daos_size_t		str_len = DUNS_MAX_XATTR_LEN;
+	struct duns_attr_t	dattr = {};
 	struct dfuse_dfs	*dfs = NULL;
 	struct dfuse_dfs	*dfsi;
 	struct dfuse_pool	*dfp = NULL;
 	struct dfuse_pool	*dfpi;
+	int			new_pool = false;
+	int			new_cont = false;
 	int ret;
 
-	rc = dfs_getxattr(ie->ie_dfs->dfs_ns, ie->ie_obj, DFUSE_UNS_POOL_ATTR,
-			  &pool, &pool_size);
+	rc = dfs_getxattr(ie->ie_dfs->dfs_ns, ie->ie_obj, DUNS_XATTR_NAME,
+			  &str, &str_len);
 
 	if (rc == ENODATA)
 		return 0;
 	if (rc)
 		return rc;
 
-	if (pool_size != 36)
-		return EINVAL;
+	rc = duns_parse_attr(&str[0], str_len, &dattr);
+	if (rc != -DER_SUCCESS)
+		return daos_der2errno(rc);
 
-	rc = dfs_getxattr(ie->ie_dfs->dfs_ns, ie->ie_obj,
-			  DFUSE_UNS_CONTAINER_ATTR, &cont, &cont_size);
-	if (rc == ENODATA)
-		return 0;
-	if (rc)
-		return rc;
+	if (dattr.da_type != DAOS_PROP_CO_LAYOUT_POSIX)
+		return ENOTSUP;
 
-	if (cont_size != 36)
-		return EINVAL;
-
-	DFUSE_TRA_DEBUG(ie, "'%s' '%s'", pool, cont);
-
-	D_ALLOC_PTR(dfs);
-	if (dfs == NULL) {
-		return ENOMEM;
-	}
-
-	D_ALLOC_PTR(dfp);
-	if (dfp == NULL) {
-		D_FREE(dfs);
-		return ENOMEM;
-	}
-
-	if (uuid_parse(pool, dfp->dfp_pool) < 0) {
-		DFUSE_LOG_ERROR("Invalid pool uuid");
-		D_GOTO(out_err, ret = EINVAL);
-	}
-
-	if (uuid_parse(cont, dfs->dfs_cont) < 0) {
-		DFUSE_LOG_ERROR("Invalid container uuid");
-		D_GOTO(out_err, ret = EINVAL);
-	}
-
-	dfs->dfs_attr_timeout = ie->ie_dfs->dfs_attr_timeout;
 	D_MUTEX_LOCK(&fs_handle->dpi_info->di_lock);
 
 	/* Search the currently connect dfp list, if one matches then use that
@@ -189,19 +162,24 @@ check_for_uns_ep(struct dfuse_projection_info *fs_handle,
 
 		DFUSE_TRA_DEBUG(ie, "Checking dfp %p", dfpi);
 
-		if (uuid_compare(dfp->dfp_pool, dfpi->dfp_pool) != 0) {
+		if (uuid_compare(dattr.da_puuid, dfpi->dfp_pool) != 0) {
 			continue;
 		}
 
 		DFUSE_TRA_DEBUG(ie, "Reusing dfp %p", dfpi);
-		D_FREE(dfp);
+		dfp = dfpi;
 		break;
 	}
 
-	if (dfp) {
+	if (!dfp) {
+		D_ALLOC_PTR(dfp);
+		if (dfp == NULL)
+			D_GOTO(out_err, ret = ENOMEM);
+
 		DFUSE_TRA_UP(dfp, ie->ie_dfs->dfs_dfp, "dfp");
 		D_INIT_LIST_HEAD(&dfp->dfp_dfs_list);
 		d_list_add(&dfp->dfp_list, &fs_handle->dpi_info->di_dfp_list);
+		uuid_copy(dfp->dfp_pool, dattr.da_puuid);
 
 		/* Connect to DAOS pool */
 		rc = daos_pool_connect(dfp->dfp_pool,
@@ -213,24 +191,30 @@ check_for_uns_ep(struct dfuse_projection_info *fs_handle,
 			DFUSE_LOG_ERROR("Failed to connect to pool (%d)", rc);
 			D_GOTO(out_err, ret = daos_der2errno(rc));
 		}
-
-	} else {
-		dfp = dfpi;
+		new_pool = true;
 	}
 
 	d_list_for_each_entry(dfsi, &dfp->dfp_dfs_list,	dfs_list) {
 
-		if (uuid_compare(dfsi->dfs_cont, dfs->dfs_cont) != 0)
+		if (uuid_compare(dattr.da_cuuid, dfsi->dfs_cont) != 0)
 			continue;
 
 		DFUSE_TRA_DEBUG(ie, "Reusing dfs %p", dfsi);
-		D_FREE(dfs);
+		dfs = dfsi;
 		break;
 	}
 
-	if (dfs) {
+	if (!dfs) {
+		D_ALLOC_PTR(dfs);
+		if (dfs == NULL)
+			D_GOTO(out_pool, ret = ENOMEM);
+
 		dfs->dfs_ops = ie->ie_dfs->dfs_ops;
 		DFUSE_TRA_UP(dfs, dfp, "dfs");
+		d_list_add(&dfs->dfs_list, &dfp->dfp_dfs_list);
+		uuid_copy(dfs->dfs_cont, dattr.da_cuuid);
+		dfs->dfs_attr_timeout = ie->ie_dfs->dfs_attr_timeout;
+
 		/* Try to open the DAOS container (the mountpoint) */
 		rc = daos_cont_open(dfp->dfp_poh, dfs->dfs_cont, DAOS_COO_RW,
 				    &dfs->dfs_coh, &dfs->dfs_co_info,
@@ -247,11 +231,7 @@ check_for_uns_ep(struct dfuse_projection_info *fs_handle,
 			DFUSE_LOG_ERROR("dfs_mount failed (%d)", rc);
 			D_GOTO(out_cont, ret = rc);
 		}
-		d_list_add(&dfs->dfs_list, &dfp->dfp_dfs_list);
 		ie->ie_root = true;
-	} else {
-
-		dfs = dfsi;
 	}
 
 	rc = dfs_release(ie->ie_obj);
@@ -289,22 +269,33 @@ check_for_uns_ep(struct dfuse_projection_info *fs_handle,
 	D_MUTEX_UNLOCK(&fs_handle->dpi_info->di_lock);
 	return 0;
 out_umount:
-	rc = dfs_umount(dfs->dfs_ns);
-	if (rc)
-		DFUSE_TRA_ERROR(dfs, "dfs_umount() failed %d", rc);
+	if (new_cont) {
+		rc = dfs_umount(dfs->dfs_ns);
+		if (rc)
+			DFUSE_TRA_ERROR(dfs, "dfs_umount() failed %d", rc);
+	}
 out_cont:
-	rc = daos_cont_close(dfs->dfs_coh, NULL);
-	if (rc)
-		DFUSE_TRA_ERROR(dfs, "daos_cont_close() failed %d", rc);
+	if (new_cont) {
+		rc = daos_cont_close(dfs->dfs_coh, NULL);
+		if (rc)
+			DFUSE_TRA_ERROR(dfs, "daos_cont_close() failed %d", rc);
+	}
 out_pool:
-	rc = daos_pool_disconnect(dfp->dfp_poh, NULL);
-	if (rc)
-		DFUSE_TRA_ERROR(dfs, "daos_pool_disconnect() failed %d", rc);
+	if (new_pool) {
+		rc = daos_pool_disconnect(dfp->dfp_poh, NULL);
+		if (rc)
+			DFUSE_TRA_ERROR(dfs, "daos_pool_disconnect() failed %d", rc);
+	}
 out_err:
-	d_list_del(&dfp->dfp_list);
+	if (new_cont) {
+		d_list_del(&dfs->dfs_list);
+		D_FREE(dfs);
+	}
+	if (new_pool) {
+		d_list_del(&dfp->dfp_list);
+		D_FREE(dfp);
+	}
 	D_MUTEX_UNLOCK(&fs_handle->dpi_info->di_lock);
-	D_FREE(dfs);
-	D_FREE(dfp);
 	return ret;
 }
 

--- a/src/client/dfuse/ops/setxattr.c
+++ b/src/client/dfuse/ops/setxattr.c
@@ -24,55 +24,7 @@
 #include "dfuse_common.h"
 #include "dfuse.h"
 
-/* Check if buffer contains a UUID
- */
-static bool
-check_uuid(void *arg, const char *value, size_t size)
-{
-	char uuid_str[40] = {};
-	uuid_t uuid;
-
-	if (size != 36)
-		return false;
-
-	/* Make a copy of the string so it's NULL terminated otherwise
-	 * uuid_parse will throw an error because of the missing \0
-	 */
-	strncpy(uuid_str, value, size);
-
-	DFUSE_TRA_DEBUG(arg, "%zi '%s'", size, uuid_str);
-
-	if (uuid_parse(uuid_str, uuid) < 0)
-		return false;
-
-	return true;
-}
-
-/* Check if pool uuid is set correctly
- *
- * To do this check the size of the pool attr, then check
- * it's a valid uuid.
- */
-static bool
-check_uns_attr(struct dfuse_inode_entry *inode)
-{
-	char uuid_str[40] = {};
-	size_t size = 40;
-	int rc;
-
-	rc = dfs_getxattr(inode->ie_dfs->dfs_ns, inode->ie_obj,
-			  DFUSE_UNS_POOL_ATTR, &uuid_str, &size);
-
-	if (rc || size != 36)
-		return false;
-
-	if (!check_uuid(inode, uuid_str, size)) {
-		DFUSE_TRA_DEBUG(inode, "pool attr failed check");
-		return false;
-	}
-
-	return true;
-}
+#include "daos_uns.h"
 
 void
 dfuse_cb_setxattr(fuse_req_t req, struct dfuse_inode_entry *inode,
@@ -83,17 +35,15 @@ dfuse_cb_setxattr(fuse_req_t req, struct dfuse_inode_entry *inode,
 
 	DFUSE_TRA_DEBUG(inode, "Attribute '%s'", name);
 
-	if (strcmp(name, DFUSE_UNS_POOL_ATTR) == 0) {
-		if (!check_uuid(inode, value, size))
-			D_GOTO(err, rc = EINVAL);
-	}
+	if (strcmp(name, DUNS_XATTR_NAME) == 0) {
+		struct duns_attr_t	dattr = {};
 
-	if (strcmp(name, DFUSE_UNS_CONTAINER_ATTR) == 0) {
-		if (!check_uuid(inode, value, size))
-			D_GOTO(err, rc = EINVAL);
+		rc = duns_parse_attr((char *)value, size, &dattr);
+		if (rc != -DER_SUCCESS)
+			D_GOTO(err, rc = daos_der2errno(rc));
 
-		if (!check_uns_attr(inode))
-			D_GOTO(err, rc = EINVAL);
+		if (dattr.da_type != DAOS_PROP_CO_LAYOUT_POSIX)
+			D_GOTO(err, rc = ENOTSUP);
 	}
 
 	rc = dfs_setxattr(inode->ie_dfs->dfs_ns, inode->ie_obj, name, value,
@@ -103,6 +53,5 @@ dfuse_cb_setxattr(fuse_req_t req, struct dfuse_inode_entry *inode,
 		return;
 	}
 err:
-
 	DFUSE_REPLY_ERR_RAW(inode, req, rc);
 }

--- a/src/include/daos_uns.h
+++ b/src/include/daos_uns.h
@@ -52,6 +52,9 @@ struct duns_attr_t {
 	bool			da_on_lustre;
 };
 
+#define DUNS_XATTR_NAME		"user.daos"
+#define DUNS_MAX_XATTR_LEN	170
+
 /**
  * Create a special directory (POSIX) or file (HDF5) depending on the container
  * type, and create a new DAOS container in the pool that is passed in \a
@@ -95,6 +98,18 @@ duns_resolve_path(const char *path, struct duns_attr_t *attr);
  */
 int
 duns_destroy_path(daos_handle_t poh, const char *path);
+
+/**
+ * Convert a string into duns_attr_t.
+ *
+ * \param[in]	str	Input string
+ * \param[in]	len	Length of input string
+ * \param[out]	attr	Struct containing the xattrs on the path.
+ *
+ * \return		0 on Success. Negative on Failure.
+ */
+int
+duns_parse_attr(char *str, daos_size_t len, struct duns_attr_t *attr);
 
 #if defined(__cplusplus)
 }

--- a/src/utils/daos.c
+++ b/src/utils/daos.c
@@ -80,8 +80,6 @@ cont_op_parse(const char *str)
 		return CONT_DESTROY_SNAP;
 	else if (strcmp(str, "rollback") == 0)
 		return CONT_ROLLBACK;
-	else if (strcmp(str, "uns-insert") == 0)
-		return CONT_UNS_INSERT;
 	return -1;
 }
 
@@ -585,8 +583,7 @@ cont_op_hdlr(struct cmd_args_s *ap)
 	/* All container operations require a pool handle, connect here.
 	 * Take specified pool UUID or look up through unified namespace.
 	 */
-	if ((op != CONT_CREATE) && (op != CONT_UNS_INSERT) &&
-	    (ap->path != NULL)) {
+	if ((op != CONT_CREATE) && (ap->path != NULL)) {
 		struct duns_attr_t dattr = {0};
 
 		ARGS_VERIFY_PATH_NON_CREATE(ap, out, rc = RC_PRINT_HELP);
@@ -689,9 +686,6 @@ cont_op_hdlr(struct cmd_args_s *ap)
 		break;
 	case CONT_ROLLBACK:
 		/* rc = cont_rollback_hdlr(ap); */
-		break;
-	case CONT_UNS_INSERT:
-		rc = cont_uns_insert_hdlr(ap);
 		break;
 	default:
 		break;
@@ -867,8 +861,7 @@ help_hdlr(struct cmd_args_s *ap)
 "	  list-snaps       list container snapshots taken\n"
 "	  destroy-snap     destroy container snapshots\n"
 "			   by name, epoch or range\n"
-"	  rollback         roll back container to specified snapshot\n"
-"	  uns-insert       insert container into UNS\n");
+"	  rollback         roll back container to specified snapshot\n");
 
 #if 0
 	fprintf(stream,

--- a/src/utils/daos_hdlr.c
+++ b/src/utils/daos_hdlr.c
@@ -32,9 +32,7 @@
 #include <sys/xattr.h>
 #include <sys/types.h>
 #include <sys/stat.h>
-#include <sys/vfs.h>
 #include <fcntl.h>
-#include <libgen.h>
 #include <daos.h>
 #include <daos/common.h>
 #include <daos/rpc.h>
@@ -47,10 +45,6 @@
 #include "daos_uns.h"
 
 #include "daos_hdlr.h"
-
-#define DUNS_XATTR_NAME		"user.daos"
-#define DUNS_MAX_XATTR_LEN	170
-#define DUNS_XATTR_FMT		"DAOS.%s://%36s/%36s/%s/%zu"
 
 /* TODO: implement these pool op functions
  * int pool_stat_hdlr(struct cmd_args_s *ap);
@@ -281,114 +275,6 @@ cont_create_uns_hdlr(struct cmd_args_s *ap)
 
 	return 0;
 
-err_rc:
-	return rc;
-}
-
-int
-cont_uns_insert_hdlr(struct cmd_args_s *ap)
-{
-	struct statfs	stsf;
-	int		rc;
-	char		*dir;
-	char		*base;
-	char		*pool;
-	char		*cont;
-	int		fd;
-	int		nfd;
-	int		err;
-
-	if (!ap->path) {
-		fprintf(stderr,
-			"Path not set\n");
-		D_GOTO(err_rc, rc = -DER_INVAL);
-	}
-
-	base = basename(ap->path);
-
-	/* This function modifies ap->path by inserting a \0 in place of the
-	 * last '/' character, so it's important to call basename() before
-	 * dirname() or basename will return the name of the parent directory
-	 * not the bottom level entry.
-	 */
-	dir = dirname(ap->path);
-
-	fd = open(dir, O_PATH | O_DIRECTORY);
-	if (fd < 0) {
-		err = errno;
-		fprintf(stderr,
-			"Failed to open parent directory %s\n", strerror(err));
-		D_GOTO(err_rc, rc = -DER_INVAL);
-	}
-
-	rc = fstatfs(fd, &stsf);
-	if (rc < 0) {
-		err = errno;
-		fprintf(stderr,
-			"Failed to statfs parent directory %s\n",
-			strerror(err));
-		D_GOTO(close, rc = -DER_IO);
-	}
-
-	/* This should read FUSE_SUPER_MAGIC however this is not exported from
-	 * the kernel headers so hard-code the value
-	 */
-	if (stsf.f_type != 0x65735546) {
-		fprintf(stderr,
-			"Wrong filesystem type for path\n");
-		D_GOTO(close, rc = -DER_INVAL);
-	}
-
-	rc = mkdirat(fd, base, 0700);
-	if (rc < 0) {
-		err = errno;
-		fprintf(stderr,
-			"Failed to make new directory %s\n", strerror(err));
-		D_GOTO(close, rc = daos_errno2der(rc));
-	}
-
-	nfd = openat(fd, base, O_RDONLY, O_DIRECTORY);
-	if (nfd < 0) {
-		err = errno;
-		fprintf(stderr,
-			"Failed to open new directory %s\n", strerror(err));
-		D_GOTO(unlink, rc = -DER_IO);
-	}
-
-	pool = DP_UUID(ap->p_uuid);
-
-	rc = fsetxattr(nfd, "user.uns.pool", pool, strlen(pool), XATTR_CREATE);
-	if (rc < 0) {
-		err = errno;
-		fprintf(stderr,
-			"Failed to set pool attribute %s\n", strerror(err));
-		D_GOTO(close_two, rc = -DER_IO);
-
-	}
-
-	cont = DP_UUID(ap->c_uuid);
-
-	rc = fsetxattr(nfd, "user.uns.container", cont, strlen(cont),
-		       XATTR_CREATE);
-	if (rc < 0) {
-		err = errno;
-		fprintf(stderr,
-			"Failed to set cont attribute %s\n", strerror(err));
-		D_GOTO(close_two, rc = -DER_IO);
-
-	}
-
-	printf("Setup UNS entry point\n");
-	close(nfd);
-	close(fd);
-	return 0;
-
-close_two:
-	close(nfd);
-unlink:
-	unlinkat(fd, base, AT_REMOVEDIR);
-close:
-	close(fd);
 err_rc:
 	return rc;
 }

--- a/src/utils/daos_hdlr.h
+++ b/src/utils/daos_hdlr.h
@@ -37,7 +37,6 @@ enum cont_op {
 	CONT_LIST_SNAPS,
 	CONT_DESTROY_SNAP,
 	CONT_ROLLBACK,
-	CONT_UNS_INSERT,
 };
 
 enum pool_op {
@@ -180,7 +179,6 @@ int pool_list_containers_hdlr(struct cmd_args_s *ap);
 /* Container operations */
 int cont_create_hdlr(struct cmd_args_s *ap);
 int cont_create_uns_hdlr(struct cmd_args_s *ap);
-int cont_uns_insert_hdlr(struct cmd_args_s *ap);
 int cont_query_hdlr(struct cmd_args_s *ap);
 int cont_destroy_hdlr(struct cmd_args_s *ap);
 

--- a/src/vos/vos_aggregate.c
+++ b/src/vos/vos_aggregate.c
@@ -1388,10 +1388,9 @@ vos_agg_ev(daos_handle_t ih, vos_iter_entry_t *entry,
 	}
 
 	/* Aggregation */
-	D_DEBUG(DB_EPC, "oid:"DF_UOID", dkey:%s, akye:%s, lgc_ext:"DF_EXT", "
+	D_DEBUG(DB_EPC, "oid:"DF_UOID", lgc_ext:"DF_EXT", "
 		"phy_ext:"DF_EXT", epoch:"DF_U64", flags: %x\n",
-		DP_UOID(agg_param->ap_oid), (char *)agg_param->ap_dkey.iov_buf,
-		(char *)agg_param->ap_akey.iov_buf, DP_EXT(&lgc_ext),
+		DP_UOID(agg_param->ap_oid), DP_EXT(&lgc_ext),
 		DP_EXT(&phy_ext), entry->ie_epoch, entry->ie_vis_flags);
 
 	rc = set_window_size(mw, entry->ie_rsize);


### PR DESCRIPTION
Change dfuse to use the same xattr names as lustre.
Create and export a new function for parsing the xattr.
Add command line help for dfuse
Remove akey/dkey from kernel logging.