### PR TITLE
DAOS-3647 control: stop io_server through instance runner

### DIFF
--- a/src/control/server/instance.go
+++ b/src/control/server/instance.go
@@ -43,11 +43,12 @@ import (
 	"github.com/daos-stack/daos/src/control/system"
 )
 
-// IOServerStarter defines an interface for starting the actual
+// IOServerHandler defines an interface for starting and stopping the
 // daos_io_server.
-type IOServerStarter interface {
+type IOServerHandler interface {
 	Start(context.Context, chan<- error) error
 	IsStarted() bool
+	Stop() error
 	GetConfig() *ioserver.Config
 }
 
@@ -60,7 +61,7 @@ type IOServerStarter interface {
 // per node.
 type IOServerInstance struct {
 	log               logging.Logger
-	runner            IOServerStarter
+	runner            IOServerHandler
 	bdevClassProvider *bdev.ClassProvider
 	scmProvider       *scm.Provider
 	msClient          *mgmtSvcClient
@@ -80,7 +81,7 @@ type IOServerInstance struct {
 // its dependencies.
 func NewIOServerInstance(log logging.Logger,
 	bcp *bdev.ClassProvider, sp *scm.Provider,
-	msc *mgmtSvcClient, r IOServerStarter) *IOServerInstance {
+	msc *mgmtSvcClient, r IOServerHandler) *IOServerInstance {
 
 	return &IOServerInstance{
 		log:               log,
@@ -220,6 +221,10 @@ func (srv *IOServerInstance) Start(ctx context.Context, errChan chan<- error) er
 	}
 
 	return srv.runner.Start(ctx, errChan)
+}
+
+func (srv *IOServerInstance) Stop() error {
+	return srv.runner.Stop()
 }
 
 func (srv *IOServerInstance) IsStarted() bool {

--- a/src/control/server/ioserver/exec.go
+++ b/src/control/server/ioserver/exec.go
@@ -124,7 +124,7 @@ func (r *Runner) run(ctx context.Context, args, env []string) error {
 	r.setStarted()
 	defer r.setStopped()
 
-	return errors.Wrapf(exitStatus(r.cmd.Wait()), "%s (instance %d) exited", r.cmd.Path, r.Config.Index)
+	return errors.Wrapf(exitStatus(cmd.Wait()), "%s (instance %d) exited", binPath, r.Config.Index)
 }
 
 // Start asynchronously starts the IOServer instance and waits for exit after

--- a/src/control/server/ioserver/mocks.go
+++ b/src/control/server/ioserver/mocks.go
@@ -70,6 +70,8 @@ func (tr *TestRunner) Start(ctx context.Context, errChan chan<- error) error {
 	return tr.runnerCfg.StartErr
 }
 
+func (tr *TestRunner) Stop() error { return nil }
+
 func (tr *TestRunner) IsStarted() bool { return true }
 
 func (tr *TestRunner) GetConfig() *Config {


### PR DESCRIPTION
Enable daos_io_server processes to be stopped by the daos_server
harness through the instance runner interface. This create a
simple backup kill method in case inband shutdown fails.

Signed-off-by: Tom Nabarro <tom.nabarro@intel.com>