### PR TITLE
DAOS-623 rpms: Fix typo in rpm spec revision message

### DIFF
--- a/utils/rpms/daos.spec
+++ b/utils/rpms/daos.spec
@@ -8,7 +8,7 @@
 
 Name:          daos
 Version:       0.8.0
-Release:       2%{?relval}%{?dist}
+Release:       3%{?relval}%{?dist}
 Summary:       DAOS Storage Engine
 
 License:       Apache
@@ -229,7 +229,7 @@ getent group daos_admins >/dev/null || groupadd -r daos_admins
 %{_prefix}%{_sysconfdir}/vos_dfs_sample.yaml
 %{_prefix}%{_sysconfdir}/vos_size_input.yaml
 %{_libdir}/libdaos_common.so
-# TODO: this should move to %{_libdir}/daos/libplacement.so
+# TODO: this should move from daos_srv to daos
 %{_libdir}/daos_srv/libplacement.so
 # Certificate generation files
 %dir %{_libdir}/%{name}
@@ -336,7 +336,10 @@ getent group daos_admins >/dev/null || groupadd -r daos_admins
 %{_libdir}/*.a
 
 %changelog
-* Fri Dec 17 2019 Jeff Olivier <jeffrey.v.olivier@intel.com> - 0.8.0-2
+* Sat Jan 18 2020 Jeff Olivier <jeffrey.v.olivier@intel.com> - 0.8.0-3
+- Fixing a few warnings in the RPM spec file
+
+* Fri Dec 27 2019 Jeff Olivier <jeffrey.v.olivier@intel.com> - 0.8.0-2
 - Remove openmpi, pmix, and hwloc builds, use hwloc and openmpi packages
 
 * Tue Dec 17 2019 Johann Lombardi <johann.lombardi@intel.com> - 0.8.0-1


### PR DESCRIPTION
The date was the 27th, not the 17.  There is no Friday the 17th
Fix warning in comment

Skip-test: true

Signed-off-by: Jeff Olivier <jeffrey.v.olivier@intel.com>