### PR TITLE
DAOS-3899 pool: leaked ds_pool in pool query handler

### DIFF
--- a/src/pool/srv_target.c
+++ b/src/pool/srv_target.c
@@ -1003,7 +1003,7 @@ ds_pool_tgt_query_handler(crt_rpc_t *rpc)
 	}
 
 	rc = pool_tgt_query(pool, &out->tqo_space);
-
+	ds_pool_put(pool);
 out:
 	out->tqo_rc = (rc == 0 ? 0 : 1);
 	crt_reply_send(rpc);


### PR DESCRIPTION
Missed ds_pool_put() in pool query handler.

Signed-off-by: Niu Yawei <yawei.niu@intel.com>