### PR TITLE
DAOS-3868 build: Update scons_local for build changes

### DIFF
--- a/src/control/SConscript
+++ b/src/control/SConscript
@@ -84,7 +84,7 @@ def scons():
     # runtime
     prefix = denv.subst("$PREFIX")
     sprefix = denv.subst("$SPDK_PREFIX")
-    if sprefix not in ["/usr", prefix]:
+    if sprefix not in ["", prefix]:
         for _dir in [join("share", "spdk", "scripts"), join("include", "spdk")]:
             target = join(prefix, _dir)
             if not check_dir_exists(target):


### PR DESCRIPTION
Fixes to USE_INSTALLED
  - checks in components/__init__.py were always false
  - After fixing checks, changed it so they actually
    only return true if a component is installed
  - If a component is installed, no PREFIX variables
    are defined for said component.

Fixes to psm2
  - Adds header file check to reduce probability of
    picking up system installed library
  - Allow EXCLUDE=psm2 to avoid building psm2

Signed-off-by: Jeff Olivier <jeffrey.v.olivier@intel.com>