### PR TITLE
DAOS-4028 vea: optimize allocation

### DIFF
--- a/src/vea/vea_alloc.c
+++ b/src/vea/vea_alloc.c
@@ -455,6 +455,11 @@ persistent_alloc(struct vea_space_info *vsi, struct vea_free_extent *vfe)
 		rc = daos_gettime_coarse(&found->vfe_age);
 		if (rc)
 			return rc;
+	} else {
+		/* Remove the original free extent from persistent tree */
+		rc = dbtree_delete(btr_hdl, BTR_PROBE_BYPASS, &key_out, NULL);
+		if (rc)
+			return rc;
 	}
 
 	return 0;

--- a/src/vea/vea_api.c
+++ b/src/vea/vea_api.c
@@ -458,7 +458,8 @@ int
 vea_tx_publish(struct vea_space_info *vsi, struct vea_hint_context *hint,
 	       d_list_t *resrvd_list)
 {
-	D_ASSERT(pmemobj_tx_stage() == TX_STAGE_WORK);
+	D_ASSERT(pmemobj_tx_stage() == TX_STAGE_WORK ||
+		 vsi->vsi_umem->umm_id == UMEM_CLASS_VMEM);
 	D_ASSERT(vsi != NULL);
 	D_ASSERT(resrvd_list != NULL);
 	/*

--- a/src/vea/vea_hint.c
+++ b/src/vea/vea_hint.c
@@ -90,7 +90,8 @@ hint_tx_publish(struct umem_instance *umm, struct vea_hint_context *hint,
 {
 	int	rc;
 
-	D_ASSERT(pmemobj_tx_stage() == TX_STAGE_WORK);
+	D_ASSERT(pmemobj_tx_stage() == TX_STAGE_WORK ||
+		 umm->umm_id == UMEM_CLASS_VMEM);
 
 	if (hint == NULL)
 		return 0;


### PR DESCRIPTION
VEA tracks all free extents in an integer btree (key is the free
extent start, value is the free extent) on SCM, and there is no
overlapping or adjacent free extent (adjacent free extent will
always be merged into one), so on persistent allocation, instead
of deleting & re-inserting free extent from/to the persistent
tree, we can just directly modify the in-tree key & value, that
could save lot of PMDK snapshots operations.

DAOS perf shows that can reduce 20% latency of small NVMe I/Os
(4096 bytes I/O), and DAOS FIO over single xstream server shows
13~20% throughput improvement for 16k NVMe I/O in various QDs.

Signed-off-by: Niu Yawei <yawei.niu@intel.com>