### PR TITLE
DAOS-2062 cont: Add ACL and ownership props

### DIFF
--- a/src/client/pydaos/pydaos_shim.c
+++ b/src/client/pydaos/pydaos_shim.c
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2019 Intel Corporation.
+ * (C) Copyright 2019-2020 Intel Corporation.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -320,6 +320,8 @@ cont_prop_define(PyObject *module)
 	DEFINE_CONT(CO_ACL);
 	DEFINE_CONT(CO_COMPRESS);
 	DEFINE_CONT(CO_ENCRYPT);
+	DEFINE_CONT(CO_OWNER);
+	DEFINE_CONT(CO_OWNER_GROUP);
 	DEFINE_CONT(CO_MAX);
 	DEFINE_CONT(CO_LAYOUT_UNKOWN);
 	DEFINE_CONT(CO_LAYOUT_POSIX);

--- a/src/common/acl_api.c
+++ b/src/common/acl_api.c
@@ -807,27 +807,13 @@ validate_acl_with_special_perms(struct daos_acl *acl, uint64_t valid_perms)
 int
 daos_acl_pool_validate(struct daos_acl *acl)
 {
-	uint64_t	valid_perms =	DAOS_ACL_PERM_READ |
-					DAOS_ACL_PERM_WRITE |
-					DAOS_ACL_PERM_CREATE_CONT |
-					DAOS_ACL_PERM_DEL_CONT;
-
-	return validate_acl_with_special_perms(acl, valid_perms);
+	return validate_acl_with_special_perms(acl, DAOS_ACL_PERM_POOL_ALL);
 }
 
 int
 daos_acl_cont_validate(struct daos_acl *acl)
 {
-	uint64_t	valid_perms =	DAOS_ACL_PERM_READ |
-					DAOS_ACL_PERM_WRITE |
-					DAOS_ACL_PERM_DEL_CONT |
-					DAOS_ACL_PERM_GET_PROP |
-					DAOS_ACL_PERM_SET_PROP |
-					DAOS_ACL_PERM_GET_ACL |
-					DAOS_ACL_PERM_SET_ACL |
-					DAOS_ACL_PERM_SET_OWNER;
-
-	return validate_acl_with_special_perms(acl, valid_perms);
+	return validate_acl_with_special_perms(acl, DAOS_ACL_PERM_CONT_ALL);
 }
 
 static bool
@@ -1058,6 +1044,27 @@ get_perm_string(uint64_t perm)
 	case DAOS_ACL_PERM_WRITE:
 		return "Write";
 
+	case DAOS_ACL_PERM_CREATE_CONT:
+		return "Create Container";
+
+	case DAOS_ACL_PERM_DEL_CONT:
+		return "Delete Container";
+
+	case DAOS_ACL_PERM_GET_PROP:
+		return "Get Prop";
+
+	case DAOS_ACL_PERM_SET_PROP:
+		return "Set Prop";
+
+	case DAOS_ACL_PERM_GET_ACL:
+		return "Get ACL";
+
+	case DAOS_ACL_PERM_SET_ACL:
+		return "Set ACL";
+
+	case DAOS_ACL_PERM_SET_OWNER:
+		return "Set Owner";
+
 	default:
 		break;
 	}
@@ -1185,22 +1192,9 @@ access_matches_flags(struct daos_ace *ace)
 bool
 daos_ace_is_valid(struct daos_ace *ace)
 {
-	uint8_t		valid_types =	DAOS_ACL_ACCESS_ALLOW |
-					DAOS_ACL_ACCESS_AUDIT |
-					DAOS_ACL_ACCESS_ALARM;
-	uint16_t	valid_flags =	DAOS_ACL_FLAG_GROUP |
-					DAOS_ACL_FLAG_POOL_INHERIT |
-					DAOS_ACL_FLAG_ACCESS_FAIL |
-					DAOS_ACL_FLAG_ACCESS_SUCCESS;
-	uint64_t	valid_perms =	DAOS_ACL_PERM_READ |
-					DAOS_ACL_PERM_WRITE |
-					DAOS_ACL_PERM_CREATE_CONT |
-					DAOS_ACL_PERM_DEL_CONT |
-					DAOS_ACL_PERM_GET_PROP |
-					DAOS_ACL_PERM_SET_PROP |
-					DAOS_ACL_PERM_GET_ACL |
-					DAOS_ACL_PERM_SET_ACL |
-					DAOS_ACL_PERM_SET_OWNER;
+	uint8_t		valid_types = DAOS_ACL_ACCESS_ALL;
+	uint16_t	valid_flags = DAOS_ACL_FLAG_ALL;
+	uint64_t	valid_perms = DAOS_ACL_PERM_ALL;
 	bool		name_exists;
 	bool		flag_exists;
 

--- a/src/common/acl_util.c
+++ b/src/common/acl_util.c
@@ -395,7 +395,7 @@ perms_unified(struct daos_ace *ace)
 		if (bits & DAOS_ACL_ ## bit_name)			\
 			rc = write_char(&pen, bit_name ## _CH,		\
 					&remaining_len);		\
-	} while(0)
+	} while (0)
 
 int
 daos_ace_to_str(struct daos_ace *ace, char *buf, size_t buf_len)

--- a/src/common/acl_util.c
+++ b/src/common/acl_util.c
@@ -391,8 +391,11 @@ perms_unified(struct daos_ace *ace)
 }
 
 #define	WRITE_CH_FOR_BIT(bits, bit_name)				\
-	if (bits & DAOS_ACL_ ## bit_name)				\
-		rc = write_char(&pen, bit_name ## _CH, &remaining_len);
+	do {								\
+		if (bits & DAOS_ACL_ ## bit_name)			\
+			rc = write_char(&pen, bit_name ## _CH,		\
+					&remaining_len);		\
+	} while(0)
 
 int
 daos_ace_to_str(struct daos_ace *ace, char *buf, size_t buf_len)

--- a/src/common/acl_util.c
+++ b/src/common/acl_util.c
@@ -34,8 +34,8 @@
  * Characters representing access flags
  */
 #define FLAG_GROUP_CH		'G'
-#define FLAG_SUCCESS_CH		'S'
-#define FLAG_FAIL_CH		'F'
+#define FLAG_ACCESS_SUCCESS_CH	'S'
+#define FLAG_ACCESS_FAIL_CH	'F'
 #define FLAG_POOL_INHERIT_CH	'P'
 
 /*
@@ -109,10 +109,10 @@ process_flags(const char *str, uint16_t *flags)
 		case FLAG_GROUP_CH:
 			*flags |= DAOS_ACL_FLAG_GROUP;
 			break;
-		case FLAG_SUCCESS_CH:
+		case FLAG_ACCESS_SUCCESS_CH:
 			*flags |= DAOS_ACL_FLAG_ACCESS_SUCCESS;
 			break;
-		case FLAG_FAIL_CH:
+		case FLAG_ACCESS_FAIL_CH:
 			*flags |= DAOS_ACL_FLAG_ACCESS_FAIL;
 			break;
 		case FLAG_POOL_INHERIT_CH:
@@ -390,6 +390,10 @@ perms_unified(struct daos_ace *ace)
 	return true;
 }
 
+#define	WRITE_CH_FOR_BIT(bits, bit_name)				\
+	if (bits & DAOS_ACL_ ## bit_name)				\
+		rc = write_char(&pen, bit_name ## _CH, &remaining_len);
+
 int
 daos_ace_to_str(struct daos_ace *ace, char *buf, size_t buf_len)
 {
@@ -419,23 +423,16 @@ daos_ace_to_str(struct daos_ace *ace, char *buf, size_t buf_len)
 
 	memset(buf, 0, buf_len);
 
-	if (ace->dae_access_types & DAOS_ACL_ACCESS_ALLOW)
-		rc = write_char(&pen, ACCESS_ALLOW_CH, &remaining_len);
-	if (ace->dae_access_types & DAOS_ACL_ACCESS_AUDIT)
-		rc = write_char(&pen, ACCESS_AUDIT_CH, &remaining_len);
-	if (ace->dae_access_types & DAOS_ACL_ACCESS_ALARM)
-		rc = write_char(&pen, ACCESS_ALARM_CH, &remaining_len);
+	WRITE_CH_FOR_BIT(ace->dae_access_types, ACCESS_ALLOW);
+	WRITE_CH_FOR_BIT(ace->dae_access_types, ACCESS_AUDIT);
+	WRITE_CH_FOR_BIT(ace->dae_access_types, ACCESS_ALARM);
 
 	rc = write_char(&pen, ':', &remaining_len);
 
-	if (ace->dae_access_flags & DAOS_ACL_FLAG_GROUP)
-		rc = write_char(&pen, FLAG_GROUP_CH, &remaining_len);
-	if (ace->dae_access_flags & DAOS_ACL_FLAG_ACCESS_SUCCESS)
-		rc = write_char(&pen, FLAG_SUCCESS_CH, &remaining_len);
-	if (ace->dae_access_flags & DAOS_ACL_FLAG_ACCESS_FAIL)
-		rc = write_char(&pen, FLAG_FAIL_CH, &remaining_len);
-	if (ace->dae_access_flags & DAOS_ACL_FLAG_POOL_INHERIT)
-		rc = write_char(&pen, FLAG_POOL_INHERIT_CH, &remaining_len);
+	WRITE_CH_FOR_BIT(ace->dae_access_flags, FLAG_GROUP);
+	WRITE_CH_FOR_BIT(ace->dae_access_flags, FLAG_ACCESS_SUCCESS);
+	WRITE_CH_FOR_BIT(ace->dae_access_flags, FLAG_ACCESS_FAIL);
+	WRITE_CH_FOR_BIT(ace->dae_access_flags, FLAG_POOL_INHERIT);
 
 	written = snprintf(pen, remaining_len, ":%s:",
 			   daos_ace_get_principal_str(ace));
@@ -447,24 +444,15 @@ daos_ace_to_str(struct daos_ace *ace, char *buf, size_t buf_len)
 	}
 
 	perms = get_perms(ace);
-	if (perms & DAOS_ACL_PERM_READ)
-		rc = write_char(&pen, PERM_READ_CH, &remaining_len);
-	if (perms & DAOS_ACL_PERM_WRITE)
-		rc = write_char(&pen, PERM_WRITE_CH, &remaining_len);
-	if (perms & DAOS_ACL_PERM_CREATE_CONT)
-		rc = write_char(&pen, PERM_CREATE_CONT_CH, &remaining_len);
-	if (perms & DAOS_ACL_PERM_DEL_CONT)
-		rc = write_char(&pen, PERM_DEL_CONT_CH, &remaining_len);
-	if (perms & DAOS_ACL_PERM_GET_PROP)
-		rc = write_char(&pen, PERM_GET_PROP_CH, &remaining_len);
-	if (perms & DAOS_ACL_PERM_SET_PROP)
-		rc = write_char(&pen, PERM_SET_PROP_CH, &remaining_len);
-	if (perms & DAOS_ACL_PERM_GET_ACL)
-		rc = write_char(&pen, PERM_GET_ACL_CH, &remaining_len);
-	if (perms & DAOS_ACL_PERM_SET_ACL)
-		rc = write_char(&pen, PERM_SET_ACL_CH, &remaining_len);
-	if (perms & DAOS_ACL_PERM_SET_OWNER)
-		rc = write_char(&pen, PERM_SET_OWNER_CH, &remaining_len);
+	WRITE_CH_FOR_BIT(perms, PERM_READ);
+	WRITE_CH_FOR_BIT(perms, PERM_WRITE);
+	WRITE_CH_FOR_BIT(perms, PERM_CREATE_CONT);
+	WRITE_CH_FOR_BIT(perms, PERM_DEL_CONT);
+	WRITE_CH_FOR_BIT(perms, PERM_GET_PROP);
+	WRITE_CH_FOR_BIT(perms, PERM_SET_PROP);
+	WRITE_CH_FOR_BIT(perms, PERM_GET_ACL);
+	WRITE_CH_FOR_BIT(perms, PERM_SET_ACL);
+	WRITE_CH_FOR_BIT(perms, PERM_SET_OWNER);
 
 	return rc;
 }

--- a/src/common/proc.c
+++ b/src/common/proc.c
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2019 Intel Corporation.
+ * (C) Copyright 2019-2020 Intel Corporation.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -89,7 +89,9 @@ crt_proc_prop_entries(crt_proc_t proc, daos_prop_t *prop)
 		if (entry->dpe_type == DAOS_PROP_PO_LABEL ||
 		    entry->dpe_type == DAOS_PROP_CO_LABEL ||
 		    entry->dpe_type == DAOS_PROP_PO_OWNER ||
-		    entry->dpe_type == DAOS_PROP_PO_OWNER_GROUP)
+		    entry->dpe_type == DAOS_PROP_CO_OWNER ||
+		    entry->dpe_type == DAOS_PROP_PO_OWNER_GROUP ||
+		    entry->dpe_type == DAOS_PROP_CO_OWNER_GROUP)
 			rc = crt_proc_d_string_t(proc, &entry->dpe_str);
 		else if (entry->dpe_type == DAOS_PROP_PO_ACL ||
 			 entry->dpe_type == DAOS_PROP_CO_ACL)

--- a/src/common/prop.c
+++ b/src/common/prop.c
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2019 Intel Corporation.
+ * (C) Copyright 2019-2020 Intel Corporation.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -77,7 +77,9 @@ daos_prop_free(daos_prop_t *prop)
 		case DAOS_PROP_PO_LABEL:
 		case DAOS_PROP_CO_LABEL:
 		case DAOS_PROP_PO_OWNER:
+		case DAOS_PROP_CO_OWNER:
 		case DAOS_PROP_PO_OWNER_GROUP:
+		case DAOS_PROP_CO_OWNER_GROUP:
 			if (entry->dpe_str)
 				D_FREE(entry->dpe_str);
 			break;
@@ -192,17 +194,16 @@ daos_prop_valid(daos_prop_t *prop, bool pool, bool input)
 		switch (type) {
 		/* pool properties */
 		case DAOS_PROP_PO_LABEL:
+		case DAOS_PROP_CO_LABEL:
 			if (!daos_prop_label_valid(
 				prop->dpp_entries[i].dpe_str))
 				return false;
 			break;
 		case DAOS_PROP_PO_ACL:
+		case DAOS_PROP_CO_ACL:
 			acl_ptr = prop->dpp_entries[i].dpe_val_ptr;
 			if (daos_acl_validate(acl_ptr) != 0)
 				return false;
-			break;
-		case DAOS_PROP_CO_ACL:
-			/* TODO: Implement container ACL */
 			break;
 		case DAOS_PROP_PO_SPACE_RB:
 			val = prop->dpp_entries[i].dpe_val;
@@ -225,21 +226,18 @@ daos_prop_valid(daos_prop_t *prop, bool pool, bool input)
 			}
 			break;
 		case DAOS_PROP_PO_OWNER:
+		case DAOS_PROP_CO_OWNER:
 			if (!daos_prop_owner_valid(
 				prop->dpp_entries[i].dpe_str))
 				return false;
 			break;
 		case DAOS_PROP_PO_OWNER_GROUP:
+		case DAOS_PROP_CO_OWNER_GROUP:
 			if (!daos_prop_owner_group_valid(
 				prop->dpp_entries[i].dpe_str))
 				return false;
 			break;
-		/* container properties */
-		case DAOS_PROP_CO_LABEL:
-			if (!daos_prop_label_valid(
-				prop->dpp_entries[i].dpe_str))
-				return false;
-			break;
+		/* container-only properties */
 		case DAOS_PROP_CO_LAYOUT_TYPE:
 			val = prop->dpp_entries[i].dpe_val;
 			if (val != DAOS_PROP_CO_LAYOUT_UNKOWN &&
@@ -339,6 +337,7 @@ daos_prop_dup(daos_prop_t *prop, bool pool)
 			}
 			break;
 		case DAOS_PROP_PO_ACL:
+		case DAOS_PROP_CO_ACL:
 			acl_ptr = entry->dpe_val_ptr;
 			entry_dup->dpe_val_ptr = daos_acl_dup(acl_ptr);
 			if (entry_dup->dpe_val_ptr == NULL) {
@@ -347,11 +346,10 @@ daos_prop_dup(daos_prop_t *prop, bool pool)
 				return NULL;
 			}
 			break;
-		case DAOS_PROP_CO_ACL:
-			/* TODO: Implement container ACL */
-			break;
 		case DAOS_PROP_PO_OWNER:
+		case DAOS_PROP_CO_OWNER:
 		case DAOS_PROP_PO_OWNER_GROUP:
+		case DAOS_PROP_CO_OWNER_GROUP:
 			D_STRNDUP(entry_dup->dpe_str, entry->dpe_str,
 				  DAOS_ACL_MAX_PRINCIPAL_LEN);
 			if (entry_dup->dpe_str == NULL) {
@@ -385,6 +383,26 @@ daos_prop_entry_get(daos_prop_t *prop, uint32_t type)
 			return &prop->dpp_entries[i];
 	}
 	return NULL;
+}
+
+static void
+free_str_prop_entry(daos_prop_t *prop, uint32_t type)
+{
+	struct daos_prop_entry	*entry;
+
+	entry = daos_prop_entry_get(prop, type);
+	if (entry != NULL)
+		D_FREE(entry->dpe_str);
+}
+
+static void
+free_ptr_prop_entry(daos_prop_t *prop, uint32_t type)
+{
+	struct daos_prop_entry	*entry;
+
+	entry = daos_prop_entry_get(prop, type);
+	if (entry != NULL)
+		D_FREE(entry->dpe_val_ptr);
 }
 
 /**
@@ -441,22 +459,23 @@ daos_prop_copy(daos_prop_t *prop_req, daos_prop_t *prop_reply)
 			if (entry_req->dpe_str == NULL)
 				D_GOTO(out, rc = -DER_NOMEM);
 			label_alloc = true;
-		} else if (type == DAOS_PROP_PO_ACL) {
+		} else if (type == DAOS_PROP_PO_ACL ||
+			   type == DAOS_PROP_CO_ACL) {
 			acl = entry_reply->dpe_val_ptr;
 			entry_req->dpe_val_ptr = daos_acl_dup(acl);
 			if (entry_req->dpe_val_ptr == NULL)
 				D_GOTO(out, rc = -DER_NOMEM);
 			acl_alloc = true;
-		} else if (type == DAOS_PROP_CO_ACL) {
-			/* TODO: Implement container ACL */
-		} else if (type == DAOS_PROP_PO_OWNER) {
+		} else if (type == DAOS_PROP_PO_OWNER ||
+			   type == DAOS_PROP_CO_OWNER) {
 			D_STRNDUP(entry_req->dpe_str,
 				  entry_reply->dpe_str,
 				  DAOS_ACL_MAX_PRINCIPAL_LEN);
 			if (entry_req->dpe_str == NULL)
 				D_GOTO(out, rc = -DER_NOMEM);
 			owner_alloc = true;
-		} else if (type == DAOS_PROP_PO_OWNER_GROUP) {
+		} else if (type == DAOS_PROP_PO_OWNER_GROUP ||
+			   type == DAOS_PROP_CO_OWNER_GROUP) {
 			D_STRNDUP(entry_req->dpe_str,
 				  entry_reply->dpe_str,
 				  DAOS_ACL_MAX_PRINCIPAL_LEN);
@@ -471,28 +490,78 @@ daos_prop_copy(daos_prop_t *prop_req, daos_prop_t *prop_reply)
 out:
 	if (rc) {
 		if (label_alloc) {
-			entry_req = daos_prop_entry_get(prop_req,
-							DAOS_PROP_PO_LABEL);
-			D_FREE(entry_req->dpe_str);
+			free_str_prop_entry(prop_req, DAOS_PROP_PO_LABEL);
+			free_str_prop_entry(prop_req, DAOS_PROP_CO_LABEL);
 		}
 		if (acl_alloc) {
-			entry_req = daos_prop_entry_get(prop_req,
-							DAOS_PROP_PO_ACL);
-			D_FREE(entry_req->dpe_val_ptr);
+			free_ptr_prop_entry(prop_req, DAOS_PROP_PO_ACL);
+			free_ptr_prop_entry(prop_req, DAOS_PROP_CO_ACL);
 		}
 		if (owner_alloc) {
-			entry_req = daos_prop_entry_get(prop_req,
-							DAOS_PROP_PO_OWNER);
-			D_FREE(entry_req->dpe_str);
+			free_str_prop_entry(prop_req, DAOS_PROP_PO_OWNER);
+			free_str_prop_entry(prop_req, DAOS_PROP_CO_OWNER);
 		}
 		if (group_alloc) {
-			entry_req = daos_prop_entry_get(prop_req,
-						DAOS_PROP_PO_OWNER_GROUP);
-			D_FREE(entry_req->dpe_str);
+			free_str_prop_entry(prop_req, DAOS_PROP_PO_OWNER_GROUP);
+			free_str_prop_entry(prop_req, DAOS_PROP_CO_OWNER_GROUP);
 		}
 		if (entries_alloc) {
 			D_FREE(prop_req->dpp_entries);
 		}
 	}
 	return rc;
+}
+
+
+int
+daos_prop_entry_dup_ptr(struct daos_prop_entry *entry_dst,
+			struct daos_prop_entry *entry_src, size_t len)
+{
+	D_ASSERT(entry_src != NULL);
+	D_ASSERT(entry_dst != NULL);
+
+	D_ALLOC(entry_dst->dpe_val_ptr, len);
+	if (entry_dst->dpe_val_ptr == NULL)
+		return -DER_NOMEM;
+
+	memcpy(entry_dst->dpe_val_ptr, entry_src->dpe_val_ptr, len);
+	return 0;
+}
+
+int
+daos_prop_entry_cmp_acl(struct daos_prop_entry *entry1,
+			struct daos_prop_entry *entry2)
+{
+	struct daos_acl *acl1;
+	struct daos_acl *acl2;
+
+	/* Never call this with entries not known to be ACL types */
+	D_ASSERT(entry1->dpe_type == DAOS_PROP_PO_ACL ||
+		 entry1->dpe_type == DAOS_PROP_CO_ACL);
+	D_ASSERT(entry2->dpe_type == DAOS_PROP_PO_ACL ||
+		 entry2->dpe_type == DAOS_PROP_CO_ACL);
+
+	if (entry1->dpe_val_ptr == NULL && entry2->dpe_val_ptr == NULL)
+		return 0;
+
+	if (entry1->dpe_val_ptr == NULL || entry2->dpe_val_ptr == NULL) {
+		D_ERROR("ACL mismatch, NULL ptr\n");
+		return -DER_MISMATCH;
+	}
+
+	acl1 = entry1->dpe_val_ptr;
+	acl2 = entry2->dpe_val_ptr;
+
+	if (acl1->dal_len != acl2->dal_len) {
+		D_ERROR("ACL len mistmatch, %u != %u\n",
+			acl1->dal_len, acl2->dal_len);
+		return -DER_MISMATCH;
+	}
+
+	if (memcmp(acl1, acl2, daos_acl_get_size(acl1)) != 0) {
+		D_ERROR("ACL content mismatch\n");
+		return -DER_MISMATCH;
+	}
+
+	return 0;
 }

--- a/src/common/prop.c
+++ b/src/common/prop.c
@@ -533,7 +533,9 @@ daos_prop_entry_cmp_acl(struct daos_prop_entry *entry1,
 			struct daos_prop_entry *entry2)
 {
 	struct daos_acl *acl1;
+	size_t		acl1_size;
 	struct daos_acl *acl2;
+	size_t		acl2_size;
 
 	/* Never call this with entries not known to be ACL types */
 	D_ASSERT(entry1->dpe_type == DAOS_PROP_PO_ACL ||
@@ -552,13 +554,16 @@ daos_prop_entry_cmp_acl(struct daos_prop_entry *entry1,
 	acl1 = entry1->dpe_val_ptr;
 	acl2 = entry2->dpe_val_ptr;
 
-	if (acl1->dal_len != acl2->dal_len) {
-		D_ERROR("ACL len mistmatch, %u != %u\n",
-			acl1->dal_len, acl2->dal_len);
+	acl1_size = daos_acl_get_size(acl1);
+	acl2_size = daos_acl_get_size(acl2);
+
+	if (acl1_size != acl2_size) {
+		D_ERROR("ACL len mistmatch, %lu != %lu\n",
+			acl1_size, acl2_size);
 		return -DER_MISMATCH;
 	}
 
-	if (memcmp(acl1, acl2, daos_acl_get_size(acl1)) != 0) {
+	if (memcmp(acl1, acl2, acl1_size) != 0) {
 		D_ERROR("ACL content mismatch\n");
 		return -DER_MISMATCH;
 	}

--- a/src/container/cli.c
+++ b/src/container/cli.c
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2016-2019 Intel Corporation.
+ * (C) Copyright 2016-2020 Intel Corporation.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -889,6 +889,12 @@ cont_query_bits(daos_prop_t *prop)
 			break;
 		case DAOS_PROP_CO_ACL:
 			bits |= DAOS_CO_QUERY_PROP_ACL;
+			break;
+		case DAOS_PROP_CO_OWNER:
+			bits |= DAOS_CO_QUERY_PROP_OWNER;
+			break;
+		case DAOS_PROP_CO_OWNER_GROUP:
+			bits |= DAOS_CO_QUERY_PROP_OWNER_GROUP;
 			break;
 		default:
 			D_ERROR("ignore bad dpt_type %d.\n", entry->dpe_type);

--- a/src/container/rpc.h
+++ b/src/container/rpc.h
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2016-2019 Intel Corporation.
+ * (C) Copyright 2016-2020 Intel Corporation.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -200,8 +200,10 @@ CRT_RPC_DECLARE(cont_close, DAOS_ISEQ_CONT_CLOSE, DAOS_OSEQ_CONT_CLOSE)
 #define DAOS_CO_QUERY_PROP_COMPRESS	(1ULL << 9)
 #define DAOS_CO_QUERY_PROP_ENCRYPT	(1ULL << 10)
 #define DAOS_CO_QUERY_PROP_ACL		(1ULL << 11)
+#define DAOS_CO_QUERY_PROP_OWNER	(1ULL << 12)
+#define DAOS_CO_QUERY_PROP_OWNER_GROUP	(1ULL << 13)
 
-#define DAOS_CO_QUERY_PROP_BITS_NR	(12)
+#define DAOS_CO_QUERY_PROP_BITS_NR	(14)
 #define DAOS_CO_QUERY_PROP_ALL					\
 	((1ULL << DAOS_CO_QUERY_PROP_BITS_NR) - 1)
 

--- a/src/container/srv.c
+++ b/src/container/srv.c
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2016-2019 Intel Corporation.
+ * (C) Copyright 2016-2020 Intel Corporation.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -46,6 +46,10 @@ init(void)
 	if (rc)
 		D_GOTO(err, rc);
 
+	rc = ds_cont_prop_default_init();
+	if (rc)
+		D_GOTO(err, rc);
+
 	return 0;
 err:
 	ds_oid_iv_fini();
@@ -57,6 +61,8 @@ fini(void)
 {
 	ds_cont_iv_fini();
 	ds_oid_iv_fini();
+	ds_cont_prop_default_fini();
+
 	return 0;
 }
 

--- a/src/container/srv_container.c
+++ b/src/container/srv_container.c
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright 2016-2019 Intel Corporation.
+ * (C) Copyright 2016-2020 Intel Corporation.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -364,7 +364,22 @@ cont_prop_default_copy(daos_prop_t *prop_def, daos_prop_t *prop)
 			entry_def->dpe_val = entry->dpe_val;
 			break;
 		case DAOS_PROP_CO_ACL:
-			/* TODO: Implement container ACL */
+			if (entry->dpe_val_ptr != NULL) {
+				struct daos_acl *acl = entry->dpe_val_ptr;
+
+				daos_prop_entry_dup_ptr(entry_def, entry,
+							daos_acl_get_size(acl));
+				if (entry_def->dpe_val_ptr == NULL)
+					return -DER_NOMEM;
+			}
+			break;
+		case DAOS_PROP_CO_OWNER:
+		case DAOS_PROP_CO_OWNER_GROUP:
+			D_FREE(entry_def->dpe_str);
+			D_STRNDUP(entry_def->dpe_str, entry->dpe_str,
+				  DAOS_ACL_MAX_PRINCIPAL_LEN);
+			if (entry_def->dpe_str == NULL)
+				return -DER_NOMEM;
 			break;
 		default:
 			D_ASSERTF(0, "bad dpt_type %d.\n", entry->dpe_type);
@@ -475,8 +490,32 @@ cont_prop_write(struct rdb_tx *tx, const rdb_path_t *kvs, daos_prop_t *prop)
 			if (rc)
 				return rc;
 			break;
+		case DAOS_PROP_CO_OWNER:
+			d_iov_set(&value, entry->dpe_str,
+				     strlen(entry->dpe_str));
+			rc = rdb_tx_update(tx, kvs, &ds_cont_prop_owner,
+					   &value);
+			if (rc)
+				return rc;
+			break;
+		case DAOS_PROP_CO_OWNER_GROUP:
+			d_iov_set(&value, entry->dpe_str,
+				     strlen(entry->dpe_str));
+			rc = rdb_tx_update(tx, kvs, &ds_cont_prop_owner_group,
+					   &value);
+			if (rc)
+				return rc;
+			break;
 		case DAOS_PROP_CO_ACL:
-			/* TODO: Implement container ACL */
+			if (entry->dpe_val_ptr != NULL) {
+				struct daos_acl *acl = entry->dpe_val_ptr;
+
+				d_iov_set(&value, acl, daos_acl_get_size(acl));
+				rc = rdb_tx_update(tx, kvs, &ds_cont_prop_acl,
+						   &value);
+				if (rc)
+					return rc;
+			}
 			break;
 		default:
 			D_ERROR("bad dpe_type %d.\n", entry->dpe_type);
@@ -1257,9 +1296,58 @@ cont_prop_read(struct rdb_tx *tx, struct cont *cont, uint64_t bits,
 		idx++;
 	}
 	if (bits & DAOS_CO_QUERY_PROP_ACL) {
+		d_iov_set(&value, NULL, 0);
+		rc = rdb_tx_lookup(tx, &cont->c_prop, &ds_cont_prop_acl,
+				   &value);
+		if (rc != 0)
+			return rc;
 		D_ASSERT(idx < nr);
 		prop->dpp_entries[idx].dpe_type = DAOS_PROP_CO_ACL;
-		prop->dpp_entries[idx].dpe_val_ptr = NULL;
+		D_ALLOC(prop->dpp_entries[idx].dpe_val_ptr, value.iov_buf_len);
+		if (prop->dpp_entries[idx].dpe_val_ptr == NULL)
+			return -DER_NOMEM;
+		memcpy(prop->dpp_entries[idx].dpe_val_ptr, value.iov_buf,
+		       value.iov_buf_len);
+		idx++;
+	}
+	if (bits & DAOS_CO_QUERY_PROP_OWNER) {
+		d_iov_set(&value, NULL, 0);
+		rc = rdb_tx_lookup(tx, &cont->c_prop, &ds_cont_prop_owner,
+				   &value);
+		if (rc != 0)
+			return rc;
+		if (value.iov_len > DAOS_ACL_MAX_PRINCIPAL_LEN) {
+			D_ERROR("bad owner length %zu (> %d).\n", value.iov_len,
+				DAOS_ACL_MAX_PRINCIPAL_LEN);
+			return -DER_IO;
+		}
+		D_ASSERT(idx < nr);
+		prop->dpp_entries[idx].dpe_type = DAOS_PROP_CO_OWNER;
+		D_STRNDUP(prop->dpp_entries[idx].dpe_str, value.iov_buf,
+			  value.iov_len);
+		if (prop->dpp_entries[idx].dpe_str == NULL)
+			return -DER_NOMEM;
+		idx++;
+	}
+	if (bits & DAOS_CO_QUERY_PROP_OWNER_GROUP) {
+		d_iov_set(&value, NULL, 0);
+		rc = rdb_tx_lookup(tx, &cont->c_prop, &ds_cont_prop_owner_group,
+				   &value);
+		if (rc != 0)
+			return rc;
+		if (value.iov_len > DAOS_ACL_MAX_PRINCIPAL_LEN) {
+			D_ERROR("bad owner group length %zu (> %d).\n",
+				value.iov_len,
+				DAOS_ACL_MAX_PRINCIPAL_LEN);
+			return -DER_IO;
+		}
+		D_ASSERT(idx < nr);
+		prop->dpp_entries[idx].dpe_type = DAOS_PROP_CO_OWNER_GROUP;
+		D_STRNDUP(prop->dpp_entries[idx].dpe_str, value.iov_buf,
+			  value.iov_len);
+		if (prop->dpp_entries[idx].dpe_str == NULL)
+			return -DER_NOMEM;
+		idx++;
 	}
 
 out:
@@ -1347,7 +1435,22 @@ cont_query(struct rdb_tx *tx, struct ds_pool_hdl *pool_hdl, struct cont *cont,
 				}
 				break;
 			case DAOS_PROP_CO_ACL:
-				/* no container ACL now */
+				if (daos_prop_entry_cmp_acl(entry, iv_entry)
+				    != 0)
+					rc = -DER_IO;
+				break;
+			case DAOS_PROP_CO_OWNER:
+			case DAOS_PROP_CO_OWNER_GROUP:
+				D_ASSERT(strlen(entry->dpe_str) <=
+					 DAOS_ACL_MAX_PRINCIPAL_LEN);
+				if (strncmp(entry->dpe_str, iv_entry->dpe_str,
+					    DAOS_ACL_MAX_PRINCIPAL_BUF_LEN)
+				    != 0) {
+					D_ERROR("mismatch %s - %s.\n",
+						entry->dpe_str,
+						iv_entry->dpe_str);
+					rc = -DER_IO;
+				}
 				break;
 			default:
 				D_ASSERTF(0, "bad dpe_type %d\n",

--- a/src/container/srv_internal.h
+++ b/src/container/srv_internal.h
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright 2016-2019 Intel Corporation.
+ * (C) Copyright 2016-2020 Intel Corporation.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -106,6 +106,8 @@ struct cont_iv_capa {
 /* flattened container properties */
 struct cont_iv_prop {
 	char		cip_label[DAOS_PROP_LABEL_MAX_LEN];
+	char		cip_owner[DAOS_ACL_MAX_PRINCIPAL_BUF_LEN];
+	char		cip_owner_grp[DAOS_ACL_MAX_PRINCIPAL_BUF_LEN];
 	uint64_t	cip_layout_type;
 	uint64_t	cip_layout_ver;
 	uint64_t	cip_csum;
@@ -116,6 +118,7 @@ struct cont_iv_prop {
 	uint64_t	cip_snap_max;
 	uint64_t	cip_compress;
 	uint64_t	cip_encrypt;
+
 	struct daos_acl	cip_acl;
 };
 

--- a/src/container/srv_layout.h
+++ b/src/container/srv_layout.h
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2016-2019 Intel Corporation.
+ * (C) Copyright 2016-2020 Intel Corporation.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -71,17 +71,20 @@ extern d_iov_t ds_cont_prop_cont_handles;	/* container handle KVS */
  */
 extern d_iov_t ds_cont_prop_ghce;		/* uint64_t */
 extern d_iov_t ds_cont_prop_max_oid;		/* uint64_t */
-extern d_iov_t ds_cont_prop_label;		/* uint64_t */
+extern d_iov_t ds_cont_prop_label;		/* string */
 extern d_iov_t ds_cont_prop_layout_type;	/* uint64_t */
 extern d_iov_t ds_cont_prop_layout_ver;		/* uint64_t */
 extern d_iov_t ds_cont_prop_csum;		/* uint64_t */
 extern d_iov_t ds_cont_prop_csum_chunk_size;	/* uint64_t */
 extern d_iov_t ds_cont_prop_csum_server_verify;	/* uint64_t */
-extern d_iov_t ds_cont_prop_redun_fac;	/* uint64_t */
-extern d_iov_t ds_cont_prop_redun_lvl;	/* uint64_t */
+extern d_iov_t ds_cont_prop_redun_fac;		/* uint64_t */
+extern d_iov_t ds_cont_prop_redun_lvl;		/* uint64_t */
 extern d_iov_t ds_cont_prop_snapshot_max;	/* uint64_t */
 extern d_iov_t ds_cont_prop_compress;		/* uint64_t */
 extern d_iov_t ds_cont_prop_encrypt;		/* uint64_t */
+extern d_iov_t ds_cont_prop_acl;		/* struct daos_acl */
+extern d_iov_t ds_cont_prop_owner;		/* string */
+extern d_iov_t ds_cont_prop_owner_group;	/* string */
 extern d_iov_t ds_cont_prop_snapshots;		/* snapshot KVS */
 extern d_iov_t ds_cont_attr_user;		/* User attributes KVS */
 
@@ -100,5 +103,20 @@ struct container_hdl {
 extern daos_prop_t cont_prop_default;
 
 #define CONT_PROP_NUM	(DAOS_PROP_CO_MAX - DAOS_PROP_CO_MIN - 1)
+
+/**
+ * Initialize the default container properties.
+ *
+ * \return	0		Success
+ *		-DER_NOMEM	Out of memory
+ */
+int
+ds_cont_prop_default_init(void);
+
+/**
+ * Clean up the default container properties.
+ */
+void
+ds_cont_prop_default_fini(void);
 
 #endif /* __CONTAINER_SRV_LAYOUT_H__ */

--- a/src/include/daos_prop.h
+++ b/src/include/daos_prop.h
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2015-2019 Intel Corporation.
+ * (C) Copyright 2015-2020 Intel Corporation.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -151,12 +151,27 @@ enum daos_cont_props {
 	 * Maximum number of snapshots to retain.
 	 */
 	DAOS_PROP_CO_SNAPSHOT_MAX,
-	/** ACL: access control list for container */
+	/**
+	 * ACL: access control list for container
+	 * An ordered list of access control entries detailing user and group
+	 * access privileges.
+	 * Expected to be in the order: Owner, User(s), Group(s), Everyone
+	 */
 	DAOS_PROP_CO_ACL,
 	/** Compression on/off + compression type */
 	DAOS_PROP_CO_COMPRESS,
 	/** Encryption on/off + encryption type */
 	DAOS_PROP_CO_ENCRYPT,
+	/**
+	 * The user who acts as the owner of the container.
+	 * Format: user@[domain]
+	 */
+	DAOS_PROP_CO_OWNER,
+	/**
+	 * The group that acts as the owner of the container.
+	 * Format: group@[domain]
+	 */
+	DAOS_PROP_CO_OWNER_GROUP,
 	DAOS_PROP_CO_MAX,
 };
 
@@ -257,6 +272,34 @@ daos_prop_alloc(uint32_t entries_nr);
  */
 void
 daos_prop_free(daos_prop_t *prop);
+
+/**
+ * Duplicate a generic pointer value from one DAOS prop entry to another.
+ * Convenience function.
+ *
+ * \param[in][out]	entry_dst	Destination entry
+ * \param[in]		entry_src	Entry to be copied
+ * \param[in]		len		Length of the memory to be copied
+ *
+ * \return		0		Success
+ *			-DER_NOMEM	Out of memory
+ */
+int
+daos_prop_entry_dup_ptr(struct daos_prop_entry *entry_dst,
+			struct daos_prop_entry *entry_src, size_t len);
+
+/**
+ * Compare a pair of daos_prop_entry that contain ACLs.
+ *
+ * \param	entry1	DAOS prop entry for ACL
+ * \param	entry2	DAOS prop entry for ACL
+ *
+ * \return	0		Entries match
+ *		-DER_MISMATCH	Entries do NOT match
+ */
+int
+daos_prop_entry_cmp_acl(struct daos_prop_entry *entry1,
+			struct daos_prop_entry *entry2);
 
 #if defined(__cplusplus)
 }

--- a/src/include/daos_security.h
+++ b/src/include/daos_security.h
@@ -110,6 +110,13 @@ enum daos_acl_access_type {
 };
 
 /**
+ * Mask of all valid access bits
+ */
+#define DAOS_ACL_ACCESS_ALL	(DAOS_ACL_ACCESS_ALLOW |		\
+				 DAOS_ACL_ACCESS_AUDIT |		\
+				 DAOS_ACL_ACCESS_ALARM)
+
+/**
  * Bits representing access flags
  */
 enum daos_acl_flags {
@@ -122,6 +129,14 @@ enum daos_acl_flags {
 	/** Audit/alarm should occur on successful access */
 	DAOS_ACL_FLAG_ACCESS_SUCCESS	= (1U << 3)
 };
+
+/**
+ * Mask of all valid flag bits
+ */
+#define DAOS_ACL_FLAG_ALL	(DAOS_ACL_FLAG_GROUP |			\
+				 DAOS_ACL_FLAG_POOL_INHERIT |		\
+				 DAOS_ACL_FLAG_ACCESS_FAIL |		\
+				 DAOS_ACL_FLAG_ACCESS_SUCCESS)
 
 /**
  * Bits representing the specific permissions that may be set
@@ -137,6 +152,32 @@ enum daos_acl_perm {
 	DAOS_ACL_PERM_SET_ACL		= (1U << 7),
 	DAOS_ACL_PERM_SET_OWNER		= (1U << 8),
 };
+
+/**
+ * Mask of all valid permissions for DAOS pools
+ */
+#define DAOS_ACL_PERM_POOL_ALL	(DAOS_ACL_PERM_READ |			\
+				 DAOS_ACL_PERM_WRITE |			\
+				 DAOS_ACL_PERM_CREATE_CONT |		\
+				 DAOS_ACL_PERM_DEL_CONT)
+
+/**
+ * Mask of all valid permissions for DAOS containers
+ */
+#define DAOS_ACL_PERM_CONT_ALL	(DAOS_ACL_PERM_READ |			\
+				 DAOS_ACL_PERM_WRITE |			\
+				 DAOS_ACL_PERM_DEL_CONT |		\
+				 DAOS_ACL_PERM_GET_PROP |		\
+				 DAOS_ACL_PERM_SET_PROP |		\
+				 DAOS_ACL_PERM_GET_ACL |		\
+				 DAOS_ACL_PERM_SET_ACL |		\
+				 DAOS_ACL_PERM_SET_OWNER)
+
+/**
+ * Mask of all valid permission bits in DAOS
+ */
+#define DAOS_ACL_PERM_ALL	(DAOS_ACL_PERM_POOL_ALL |		\
+				 DAOS_ACL_PERM_CONT_ALL)
 
 /**
  * Access Control Entry for a given principal.

--- a/src/include/daos_srv/security.h
+++ b/src/include/daos_srv/security.h
@@ -41,6 +41,22 @@ struct pool_owner {
 };
 
 /**
+ * Allocate the default ACL for DAOS pools.
+ *
+ * \return	Newly allocated struct daos_acl
+ */
+struct daos_acl *
+ds_sec_alloc_default_daos_pool_acl(void);
+
+/**
+ * Allocate the default ACL for DAOS containers.
+ *
+ * \return	Newly allocated struct daos_acl
+ */
+struct daos_acl *
+ds_sec_alloc_default_daos_cont_acl(void);
+
+/**
  * Determine whether the provided credentials can access a pool.
  *
  * \param[in]	acl		Access Control List for pool

--- a/src/pool/srv_layout.c
+++ b/src/pool/srv_layout.c
@@ -26,10 +26,8 @@
 #define D_LOGFAC	DD_FAC(pool)
 
 #include <daos_srv/rdb.h>
+#include <daos_srv/security.h>
 #include "srv_layout.h"
-#include <daos_types.h>
-#include <daos_security.h>
-#include <gurt/debug.h>
 
 /** Root KVS */
 RDB_STRING_KEY(ds_pool_prop_, uid);
@@ -86,50 +84,6 @@ daos_prop_t pool_prop_default = {
 	.dpp_entries	= pool_prop_entries_default,
 };
 
-/**
- * The default ACL includes ACEs for owner and the assigned group allowing
- * read/write permissions. All others are denied by default.
- */
-static struct daos_ace *
-alloc_ace_with_rw_access(enum daos_acl_principal_type type)
-{
-	struct daos_ace *ace;
-
-	ace = daos_ace_create(type, NULL);
-	if (ace == NULL) {
-		D_ERROR("Failed to allocate default ACE type %d", type);
-		return NULL;
-	}
-
-	ace->dae_access_types = DAOS_ACL_ACCESS_ALLOW;
-	ace->dae_allow_perms = DAOS_ACL_PERM_READ | DAOS_ACL_PERM_WRITE;
-
-	return ace;
-}
-
-static struct daos_acl *
-get_default_daos_acl(void)
-{
-	int		num_aces = 2;
-	int		i;
-	struct daos_ace	*default_aces[num_aces];
-	struct daos_acl	*default_acl;
-
-	default_aces[0] = alloc_ace_with_rw_access(DAOS_ACL_OWNER);
-	default_aces[1] = alloc_ace_with_rw_access(DAOS_ACL_OWNER_GROUP);
-
-	default_acl = daos_acl_create(default_aces, num_aces);
-	if (default_acl == NULL) {
-		D_ERROR("Failed to allocate default ACL for pool properties");
-	}
-
-	for (i = 0; i < num_aces; i++) {
-		daos_ace_free(default_aces[i]);
-	}
-
-	return default_acl;
-}
-
 int
 ds_pool_prop_default_init(void)
 {
@@ -139,7 +93,7 @@ ds_pool_prop_default_init(void)
 	if (entry != NULL) {
 		D_DEBUG(DB_MGMT,
 			"Initializing default ACL pool prop\n");
-		entry->dpe_val_ptr = get_default_daos_acl();
+		entry->dpe_val_ptr = ds_sec_alloc_default_daos_pool_acl();
 		if (entry->dpe_val_ptr == NULL)
 			return -DER_NOMEM;
 	}

--- a/src/pool/srv_layout.c
+++ b/src/pool/srv_layout.c
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2017-2019 Intel Corporation.
+ * (C) Copyright 2017-2020 Intel Corporation.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -73,10 +73,10 @@ struct daos_prop_entry pool_prop_entries_default[DAOS_PROP_PO_NUM] = {
 		.dpe_val_ptr	= NULL, /* generated dynamically */
 	}, {
 		.dpe_type	= DAOS_PROP_PO_OWNER,
-		.dpe_str	= "nobody@",
+		.dpe_str	= "NOBODY@",
 	}, {
 		.dpe_type	= DAOS_PROP_PO_OWNER_GROUP,
-		.dpe_str	= "nobody@",
+		.dpe_str	= "NOBODY@",
 	}
 };
 

--- a/src/pool/srv_pool.c
+++ b/src/pool/srv_pool.c
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright 2016-2019 Intel Corporation.
+ * (C) Copyright 2016-2020 Intel Corporation.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -301,27 +301,6 @@ uuid_compare_cb(const void *a, const void *b)
 	return uuid_compare(*ua, *ub);
 }
 
-static void
-pool_prop_copy_ptr(struct daos_prop_entry *entry_def,
-		struct daos_prop_entry *entry, size_t len)
-{
-	D_ALLOC(entry_def->dpe_val_ptr, len);
-	if (entry_def->dpe_val_ptr != NULL) {
-		memcpy(entry_def->dpe_val_ptr, entry->dpe_val_ptr, len);
-	}
-}
-
-static uint32_t
-pool_prop_acl_get_length(struct daos_prop_entry *entry)
-{
-	if (entry->dpe_val_ptr == NULL) {
-		D_WARN("ACL pool property was NULL\n");
-		return 0;
-	}
-
-	return daos_acl_get_size((struct daos_acl *)entry->dpe_val_ptr);
-}
-
 /* copy \a prop to \a prop_def (duplicated default prop) */
 static int
 pool_prop_default_copy(daos_prop_t *prop_def, daos_prop_t *prop)
@@ -361,8 +340,10 @@ pool_prop_default_copy(daos_prop_t *prop_def, daos_prop_t *prop)
 			break;
 		case DAOS_PROP_PO_ACL:
 			if (entry->dpe_val_ptr != NULL) {
-				pool_prop_copy_ptr(entry_def, entry,
-					pool_prop_acl_get_length(entry));
+				struct daos_acl *acl = entry->dpe_val_ptr;
+
+				daos_prop_entry_dup_ptr(entry_def, entry,
+							daos_acl_get_size(acl));
 				if (entry_def->dpe_val_ptr == NULL)
 					return -DER_NOMEM;
 			}
@@ -416,8 +397,10 @@ pool_prop_write(struct rdb_tx *tx, const rdb_path_t *kvs, daos_prop_t *prop)
 			break;
 		case DAOS_PROP_PO_ACL:
 			if (entry->dpe_val_ptr != NULL) {
-				d_iov_set(&value, entry->dpe_val_ptr,
-					     pool_prop_acl_get_length(entry));
+				struct daos_acl *acl;
+
+				acl = entry->dpe_val_ptr;
+				d_iov_set(&value, acl, daos_acl_get_size(acl));
 				rc = rdb_tx_update(tx, kvs, &ds_pool_prop_acl,
 						   &value);
 				if (rc)
@@ -2624,12 +2607,23 @@ ds_pool_query_handler(crt_rpc_t *rpc)
 			D_ASSERT(iv_entry != NULL);
 			switch (entry->dpe_type) {
 			case DAOS_PROP_PO_LABEL:
-			case DAOS_PROP_PO_OWNER:
-			case DAOS_PROP_PO_OWNER_GROUP:
 				D_ASSERT(strlen(entry->dpe_str) <=
 					 DAOS_PROP_LABEL_MAX_LEN);
 				if (strncmp(entry->dpe_str, iv_entry->dpe_str,
 					    DAOS_PROP_LABEL_MAX_LEN) != 0) {
+					D_ERROR("mismatch %s - %s.\n",
+						entry->dpe_str,
+						iv_entry->dpe_str);
+					rc = -DER_IO;
+				}
+				break;
+			case DAOS_PROP_PO_OWNER:
+			case DAOS_PROP_PO_OWNER_GROUP:
+				D_ASSERT(strlen(entry->dpe_str) <=
+					 DAOS_ACL_MAX_PRINCIPAL_LEN);
+				if (strncmp(entry->dpe_str, iv_entry->dpe_str,
+					    DAOS_ACL_MAX_PRINCIPAL_BUF_LEN)
+				    != 0) {
 					D_ERROR("mismatch %s - %s.\n",
 						entry->dpe_str,
 						iv_entry->dpe_str);
@@ -2648,6 +2642,9 @@ ds_pool_query_handler(crt_rpc_t *rpc)
 				}
 				break;
 			case DAOS_PROP_PO_ACL:
+				if (daos_prop_entry_cmp_acl(entry, iv_entry)
+				    != 0)
+					rc = -DER_IO;
 				break;
 			default:
 				D_ASSERTF(0, "bad dpe_type %d\n",

--- a/src/tests/suite/daos_container.c
+++ b/src/tests/suite/daos_container.c
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2016 Intel Corporation.
+ * (C) Copyright 2016-2020 Intel Corporation.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -205,6 +205,80 @@ co_attribute(void **state)
 	}
 }
 
+static bool
+ace_has_permissions(struct daos_ace *ace, uint64_t exp_perms)
+{
+	if (ace->dae_access_types != DAOS_ACL_ACCESS_ALLOW) {
+		print_message("Expected access type allow for ACE\n");
+		daos_ace_dump(ace, 0);
+		return false;
+	}
+
+	if (ace->dae_allow_perms != exp_perms) {
+		print_message("ACE had perms: 0x%lx (expected: 0x%lx)\n",
+			      ace->dae_allow_perms, exp_perms);
+		daos_ace_dump(ace, 0);
+		return false;
+	}
+
+	return true;
+}
+
+static bool
+is_acl_prop_default(struct daos_acl *prop)
+{
+	struct daos_ace *ace;
+	ssize_t		acl_expected_len = 0;
+
+	if (daos_acl_validate(prop) != 0) {
+		print_message("ACL property not valid\n");
+		daos_acl_dump(prop);
+		return false;
+	}
+
+	if (daos_acl_get_ace_for_principal(prop, DAOS_ACL_OWNER,
+					   NULL, &ace) != 0) {
+		print_message("Owner ACE not found\n");
+		return false;
+	}
+
+	acl_expected_len += daos_ace_get_size(ace);
+
+	/* Owner should have full control of the container by default */
+	if (!ace_has_permissions(ace, DAOS_ACL_PERM_CONT_ALL)) {
+		print_message("Owner ACE was wrong\n");
+		return false;
+	}
+
+	if (daos_acl_get_ace_for_principal(prop, DAOS_ACL_OWNER_GROUP,
+					   NULL, &ace) != 0) {
+		print_message("Owner Group ACE not found\n");
+		return false;
+	}
+
+	acl_expected_len += daos_ace_get_size(ace);
+
+	/* Owner-group should have basic access */
+	if (!ace_has_permissions(ace,
+				 DAOS_ACL_PERM_READ |
+				 DAOS_ACL_PERM_WRITE |
+				 DAOS_ACL_PERM_GET_PROP |
+				 DAOS_ACL_PERM_SET_PROP)) {
+		print_message("Owner Group ACE was wrong\n");
+		return false;
+	}
+
+	if (prop->dal_len != acl_expected_len) {
+		print_message("More ACEs in list than expected, expected len = "
+			      "%ld, actual len = %u\n", acl_expected_len,
+			      prop->dal_len);
+		return false;
+	}
+
+	print_message("ACL prop matches expected defaults\n");
+	return true;
+}
+
 static void
 co_properties(void **state)
 {
@@ -242,7 +316,7 @@ co_properties(void **state)
 	}
 	MPI_Barrier(MPI_COMM_WORLD);
 
-	const int prop_count = 6;
+	const int prop_count = 9;
 
 	prop_query = daos_prop_alloc(prop_count);
 	prop_query->dpp_entries[0].dpe_type = DAOS_PROP_CO_LABEL;
@@ -251,6 +325,9 @@ co_properties(void **state)
 	prop_query->dpp_entries[3].dpe_type = DAOS_PROP_CO_CSUM_SERVER_VERIFY;
 	prop_query->dpp_entries[4].dpe_type = DAOS_PROP_CO_ENCRYPT;
 	prop_query->dpp_entries[5].dpe_type = DAOS_PROP_CO_SNAPSHOT_MAX;
+	prop_query->dpp_entries[6].dpe_type = DAOS_PROP_CO_ACL;
+	prop_query->dpp_entries[7].dpe_type = DAOS_PROP_CO_OWNER;
+	prop_query->dpp_entries[8].dpe_type = DAOS_PROP_CO_OWNER_GROUP;
 	rc = daos_cont_query(arg->coh, NULL, prop_query, NULL);
 	assert_int_equal(rc, 0);
 
@@ -286,6 +363,33 @@ co_properties(void **state)
 	entry = daos_prop_entry_get(prop_query, DAOS_PROP_CO_ENCRYPT);
 	if (entry == NULL || entry->dpe_val != DAOS_PROP_CO_ENCRYPT_OFF) {
 		print_message("encrypt verification failed.\n");
+		assert_int_equal(rc, 1); /* fail the test */
+	}
+
+	entry = daos_prop_entry_get(prop_query, DAOS_PROP_CO_ACL);
+	if (entry == NULL || entry->dpe_val_ptr == NULL ||
+	    !is_acl_prop_default((struct daos_acl *)entry->dpe_val_ptr)) {
+		print_message("ACL prop verification failed.\n");
+		assert_int_equal(rc, 1); /* fail the test */
+	}
+
+	/* default owner */
+	print_message("Checking owner set to default\n");
+	entry = daos_prop_entry_get(prop_query, DAOS_PROP_CO_OWNER);
+	if (entry == NULL || entry->dpe_str == NULL ||
+	    strncmp(entry->dpe_str, "NOBODY@",
+		    DAOS_ACL_MAX_PRINCIPAL_LEN)) {
+		print_message("Owner prop verification failed.\n");
+		assert_int_equal(rc, 1); /* fail the test */
+	}
+
+	/* default owner-group */
+	print_message("Checking owner-group set to default\n");
+	entry = daos_prop_entry_get(prop_query, DAOS_PROP_CO_OWNER_GROUP);
+	if (entry == NULL || entry->dpe_str == NULL ||
+	    strncmp(entry->dpe_str, "NOBODY@",
+		    DAOS_ACL_MAX_PRINCIPAL_LEN)) {
+		print_message("Owner-group prop verification failed.\n");
 		assert_int_equal(rc, 1); /* fail the test */
 	}
 


### PR DESCRIPTION
This patch updates the container metadata to support DAOS ACLs.
No enforcement occurs on the container ACL at this time.

- Implement container ACL prop.
- Add owner and owner-group props to containers.
- Initialize a default ACL for containers.
- Change default owner to a special string that doesn't
  match a real user (NOBODY@). Lowercase "nobody@" is
  used in some cases in UNIX systems.
- Add container-related permissions to daos_acl_dump().
- Clean up ACL validation logic and to/from str logic.
- Update container query test for default owner/group/ACL
  props in daos_test suite.
- Clean up some shared logic in pool and container
  props.

Signed-off-by: Kris Jacque <kristin.jacque@intel.com>