### PR TITLE
DAOS-3809 security: Check ACL string validity

### DIFF
--- a/src/common/acl_util.c
+++ b/src/common/acl_util.c
@@ -506,6 +506,13 @@ daos_acl_from_strs(const char **ace_strs, size_t ace_nr, struct daos_acl **acl)
 		D_GOTO(out, rc = -DER_NOMEM);
 	}
 
+	rc = daos_acl_validate(tmp_acl);
+	if (rc != 0) {
+		D_ERROR("Resulting ACL was invalid\n");
+		daos_acl_free(tmp_acl);
+		D_GOTO(out, rc);
+	}
+
 	*acl = tmp_acl;
 	rc = 0;
 

--- a/src/common/tests/acl_util_tests.c
+++ b/src/common/tests/acl_util_tests.c
@@ -700,6 +700,9 @@ test_acl_from_strs_bad_input(void **state)
 	struct daos_acl		*acl = NULL;
 	static const char	*valid_aces[] = {"A::OWNER@:rw"};
 	static const char	*garbage[] = {"ABCD:E:FGH:IJ"};
+	/* duplicate entries aren't valid */
+	static const char	*invalid_aces[2] = {"A::OWNER@:rw",
+						    "A::OWNER@:rw"};
 
 	assert_int_equal(daos_acl_from_strs(NULL, 1, &acl), -DER_INVAL);
 	assert_int_equal(daos_acl_from_strs(valid_aces, 0, &acl),
@@ -707,6 +710,7 @@ test_acl_from_strs_bad_input(void **state)
 	assert_int_equal(daos_acl_from_strs(valid_aces, 1, NULL),
 			 -DER_INVAL);
 	assert_int_equal(daos_acl_from_strs(garbage, 1, &acl), -DER_INVAL);
+	assert_int_equal(daos_acl_from_strs(invalid_aces, 2, &acl), -DER_INVAL);
 }
 
 static void

--- a/src/mgmt/srv_drpc.c
+++ b/src/mgmt/srv_drpc.c
@@ -352,10 +352,6 @@ create_pool_props(daos_prop_t **out_prop, char *owner, char *owner_grp,
 		if (rc != 0)
 			D_GOTO(err_out, rc);
 
-		rc = daos_acl_validate(out_acl);
-		if (rc != 0)
-			D_GOTO(err_out, rc);
-
 		entries++;
 	}
 


### PR DESCRIPTION
When translating an ACL from a string list, we weren't
checking the overall ACL validity when complete. This
was letting a few types of invalid ACL slip through
during update/overwrite ACL.

Signed-off-by: Kris Jacque <kristin.jacque@intel.com>