### PR TITLE
DAOS-3809 security: Set ACL max size to 64KB

### DIFF
--- a/doc/admin/pool_operations.md
+++ b/doc/admin/pool_operations.md
@@ -162,6 +162,18 @@ matching groups.
 
 By default, if a user matches no ACEs in the list, access will be denied.
 
+### Limitations
+
+The maximum length of the ACE list in a DAOS ACL structure is 64KiB.
+
+To calculate the actual length of an ACL, use the following formula for each
+ACE:
+
+* The base size of an ACE is 256B.
+* If the ACE principal is *not* one of the special principals:
+  * Add the length of the identity string + 1.
+  * If that value is not 64B aligned, round up to the nearest 64B boundary.
+
 ### Creating a pool with a custom ACL
 
 To create a pool with a custom ACL:

--- a/src/include/daos_security.h
+++ b/src/include/daos_security.h
@@ -60,7 +60,7 @@ extern "C" {
 /**
  * Maximum length of daos_acl::dal_ace (dal_len's value).
  */
-#define DAOS_ACL_MAX_ACE_LEN		(8192)
+#define DAOS_ACL_MAX_ACE_LEN		(65536)
 
 /**
  * Maximum length of an ACE provided in string format:


### PR DESCRIPTION
- Update the maximum length of the ACE list in the ACL
  structure to 65536 bytes.
- Update the ACL documentation to mention the max length
  and provide a formula for calculating the actual length
  of an ACL.

Signed-off-by: Kris Jacque <kristin.jacque@intel.com>