### PR TITLE
DAOS-3947 control: Demonstrate alternative approach

### DIFF
--- a/src/control/server/ioserver/config.go
+++ b/src/control/server/ioserver/config.go
@@ -1,5 +1,5 @@
 //
-// (C) Copyright 2019 Intel Corporation.
+// (C) Copyright 2019-2020 Intel Corporation.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -28,7 +28,6 @@ import (
 
 	"github.com/pkg/errors"
 
-	"github.com/daos-stack/daos/src/control/lib/netdetect"
 	"github.com/daos-stack/daos/src/control/server/storage"
 )
 
@@ -186,19 +185,18 @@ func (c *Config) CmdLineEnv() ([]string, error) {
 		return nil, err
 	}
 
-	// Provide special handling for the ofi+verbs provider.
-	// Mercury uses the interface name such as ib0, while OFI uses the device name such as hfi1_0
-	// CaRT and Mercury will now support the new OFI_DOMAIN environment variable so that we can
-	// specify the correct device for each.
-	if strings.Contains(c.Fabric.Provider, "ofi+verbs") {
-		deviceAlias, err := netdetect.GetDeviceAlias(c.Fabric.Interface)
-		if err != nil {
-			return nil, err
-		}
-		envVar := "OFI_DOMAIN=" + deviceAlias
-		tagEnv = append(tagEnv, envVar)
-	}
 	return mergeEnvVars(c.EnvVars, tagEnv), nil
+}
+
+// HasEnvVar returns true if the configuration contains
+// an environment variable with the given name.
+func (c *Config) HasEnvVar(name string) bool {
+	for _, keyPair := range c.EnvVars {
+		if strings.HasPrefix(keyPair, name) {
+			return true
+		}
+	}
+	return false
 }
 
 // WithEnvVars applies the supplied list of environment

--- a/src/control/server/server.go
+++ b/src/control/server/server.go
@@ -1,5 +1,5 @@
 //
-// (C) Copyright 2018-2019 Intel Corporation.
+// (C) Copyright 2018-2020 Intel Corporation.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -38,6 +38,7 @@ import (
 
 	ctlpb "github.com/daos-stack/daos/src/control/common/proto/ctl"
 	mgmtpb "github.com/daos-stack/daos/src/control/common/proto/mgmt"
+	"github.com/daos-stack/daos/src/control/lib/netdetect"
 	"github.com/daos-stack/daos/src/control/logging"
 	"github.com/daos-stack/daos/src/control/pbin"
 	"github.com/daos-stack/daos/src/control/security"
@@ -147,6 +148,19 @@ func Start(log *logging.LeveledLogger, cfg *Configuration) error {
 	for i, srvCfg := range cfg.Servers {
 		if i+1 > maxIoServers {
 			break
+		}
+
+		// Provide special handling for the ofi+verbs provider.
+		// Mercury uses the interface name such as ib0, while OFI uses the device name such as hfi1_0
+		// CaRT and Mercury will now support the new OFI_DOMAIN environment variable so that we can
+		// specify the correct device for each.
+		if strings.Contains(srvCfg.Fabric.Provider, "ofi+verbs") && !srvCfg.HasEnvVar("OFI_DOMAIN") {
+			deviceAlias, err := netdetect.GetDeviceAlias(srvCfg.Fabric.Interface)
+			if err != nil {
+				return errors.Wrapf(err, "failed to resolve alias for %s", srvCfg.Fabric.Interface)
+			}
+			envVar := "OFI_DOMAIN=" + deviceAlias
+			srvCfg.WithEnvVars(envVar)
 		}
 
 		// If the configuration specifies that we should explicitly set hugepage values


### PR DESCRIPTION
Remove netdetect dependency from ioserver package while
allowing OFI_DOMAIN to be overridden by user environment.