### PR TITLE
DAOS-3821: Pool update bad_evict yaml in pool create for CI regressio…

### DIFF
--- a/src/tests/ftest/pool/bad_evict.py
+++ b/src/tests/ftest/pool/bad_evict.py
@@ -140,4 +140,4 @@ class BadEvictTest(TestWithServers):
                         pool.uuid[item] = saveduuid[item]
                 if savedsvc is not None:
                     pool.svc = savedsvc
-                pool.destroy(1)
+                pool.destroy(0)

--- a/src/tests/ftest/pool/bad_evict.py
+++ b/src/tests/ftest/pool/bad_evict.py
@@ -140,5 +140,4 @@ class BadEvictTest(TestWithServers):
                         pool.uuid[item] = saveduuid[item]
                 if savedsvc is not None:
                     pool.svc = savedsvc
-                pool.disconnect()
                 pool.destroy(1)

--- a/src/tests/ftest/pool/bad_evict.yaml
+++ b/src/tests/ftest/pool/bad_evict.yaml
@@ -1,5 +1,5 @@
 server_config:
-   name: scott_server
+   name: daos_server
 hosts:
   test_servers:
     - server-A
@@ -17,7 +17,7 @@ evicttests:
    connectsetnames: !mux
      goodname:
           setname:
-             - scott_server
+             - daos_server
              - PASS
      badname:
           setname:
@@ -39,6 +39,6 @@ evicttests:
    createmode:
      mode: 511
    createset:
-     setname: scott_server
+     setname: daos_server
    createsize:
      size: 1073741824

--- a/src/tests/ftest/pool/bad_query.yaml
+++ b/src/tests/ftest/pool/bad_query.yaml
@@ -1,7 +1,7 @@
 # Note that stuff that is commented out represents tests that presently
 # fail and will be uncommented as the daos code is fixed
 server_config:
-   name: scott_server
+   name: daos_server
 hosts:
   test_servers:
     - server-A
@@ -29,7 +29,7 @@ querytests:
    createmode:
      mode: 511
    createset:
-     setname: scott_server
+     setname: daos_server
    createsize:
      size: 1073741824
 


### PR DESCRIPTION
…n failures

updated file: daos/src/tests/ftest/pool/bad_evict.py
updated file: daos/src/tests/ftest/pool/bad_query.yaml
updated file: daos/src/tests/ftest/pool/bad_evict.yaml

Test-tag: pr,-hw pool,badevict,badquery
Signed-off-by: Ding Ho <ding-hwa.ho@intel.com>