### PR TITLE
DAOS-623 build: Fix SCons warning

### DIFF
--- a/src/common/tests/SConscript
+++ b/src/common/tests/SConscript
@@ -73,16 +73,18 @@ def scons():
     # The compiler decides this on its own, but let's force the issue.
     unit_env.Append(CCFLAGS="-U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=0")
 
+    acl_api = unit_env.Object('../acl_api.c')
+
     daos_build.test(unit_env, 'drpc_tests',
                     ['drpc_tests.c', '../drpc.c', '../drpc.pb-c.c',
                      common_test_utils],
                     LIBS=['protobuf-c', 'daos_common', 'gurt', 'cmocka'])
     daos_build.test(unit_env, 'acl_api_tests',
-                    source=['acl_api_tests.c', '../acl_api.c',
+                    source=['acl_api_tests.c', acl_api,
                             common_test_utils],
                     LIBS=['protobuf-c', 'daos_common', 'gurt', 'cmocka'])
     daos_build.test(unit_env, 'acl_valid_tests',
-                    source=['acl_valid_tests.c', '../acl_api.c',
+                    source=['acl_valid_tests.c', acl_api,
                             common_test_utils],
                     LIBS=['protobuf-c', 'daos_common', 'gurt', 'cmocka'])
     daos_build.test(unit_env, 'acl_util_tests',


### PR DESCRIPTION
A file was being built twice as parts of different unit
test binaries.

Signed-off-by: Kris Jacque <kristin.jacque@intel.com>