### PR TITLE
DAOS-3947 control: Allow OFI_DOMAIN to be overridden

### DIFF
--- a/src/control/server/ioserver/config.go
+++ b/src/control/server/ioserver/config.go
@@ -1,5 +1,5 @@
 //
-// (C) Copyright 2019 Intel Corporation.
+// (C) Copyright 2019-2020 Intel Corporation.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -28,7 +28,6 @@ import (
 
 	"github.com/pkg/errors"
 
-	"github.com/daos-stack/daos/src/control/lib/netdetect"
 	"github.com/daos-stack/daos/src/control/server/storage"
 )
 
@@ -186,19 +185,18 @@ func (c *Config) CmdLineEnv() ([]string, error) {
 		return nil, err
 	}
 
-	// Provide special handling for the ofi+verbs provider.
-	// Mercury uses the interface name such as ib0, while OFI uses the device name such as hfi1_0
-	// CaRT and Mercury will now support the new OFI_DOMAIN environment variable so that we can
-	// specify the correct device for each.
-	if strings.Contains(c.Fabric.Provider, "ofi+verbs") {
-		deviceAlias, err := netdetect.GetDeviceAlias(c.Fabric.Interface)
-		if err != nil {
-			return nil, err
-		}
-		envVar := "OFI_DOMAIN=" + deviceAlias
-		tagEnv = append(tagEnv, envVar)
-	}
 	return mergeEnvVars(c.EnvVars, tagEnv), nil
+}
+
+// HasEnvVar returns true if the configuration contains
+// an environment variable with the given name.
+func (c *Config) HasEnvVar(name string) bool {
+	for _, keyPair := range c.EnvVars {
+		if strings.HasPrefix(keyPair, name+"=") {
+			return true
+		}
+	}
+	return false
 }
 
 // WithEnvVars applies the supplied list of environment


### PR DESCRIPTION
This commit addresses two issues:
  * Allow OFI_DOMAIN to be explicitly set in the server configuration -- if it's already set, the control plane will not attempt to resolve an interface alias for the ofi+verbs provider
  * Move the netdetect dependency up into the server package, which allows the ioserver package to be more widely imported without dragging in more baggage than necessary