### PR TITLE
DAOS-3170 control: format without user data erase

### DIFF
--- a/src/control/lib/spdk/src/nvme_control.c
+++ b/src/control/lib/spdk/src/nvme_control.c
@@ -113,7 +113,7 @@ nvme_format(char *ctrlr_pci_addr)
 	format.ms	= 0; /* metadata xfer as part of separate buffer */
 	format.pi	= 0; /* protection information is not enabled */
 	format.pil	= 0; /* protection information location N/A */
-	format.ses	= 1; /* secure erase operation set user data erase */
+	format.ses	= 0; /* secure erase operation set user data erase */
 
 	ret->rc = spdk_nvme_ctrlr_format(ctrlr_entry->ctrlr, ns_id, &format);
 	if (ret->rc != 0) {


### PR DESCRIPTION
NVMe SSD "low-level format" involves erasing media which wear out the
device.  Eventually after enough low level formats the drive sets
itself in "read-only" mode to protect the data from corruption.

"User Data Erase" option triggers the LLF flow and the SPDK
equivalent term is "Secure Erase" triggered by the flag
"spdk_nvme_format.ses".

Without this set, format via SPDK should be low-impact (but still
take a long time with Optane drives).

Signed-off-by: Tom Nabarro <tom.nabarro@intel.com>