### PR TITLE
DAOS-3170 control: spdk quick format by wiping lba-0

### DIFF
--- a/src/control/lib/spdk/include/nvme_control.h
+++ b/src/control/lib/spdk/include/nvme_control.h
@@ -25,6 +25,18 @@
 #define NVMECONTROL_H
 
 /**
+ * \brief Details of write sequence for quick format.
+ */
+struct format_sequence {
+	struct spdk_nvme_ctrlr	*ctrlr;
+	struct spdk_nvme_qpair	*qpair;
+	struct spdk_nvme_ns	*ns;
+	char			*buf;
+	unsigned		 using_cmb_io;
+	int			 is_completed;
+};
+
+/**
  * Discover NVMe controllers and namespaces, as well as return device health
  * information.
  *
@@ -32,6 +44,18 @@
  */
 struct ret_t *
 nvme_discover(void);
+
+/**
+ * Wipe NVMe controller namespace LBA-0.
+ *
+ * Removes any data container structures e.g. blobstore.
+ *
+ * \param ctrlr_pci_addr PCI address of NVMe controller.
+ *
+ * \return a pointer to a return struct (ret_t).
+ */
+struct ret_t *
+nvme_wipe_first_ns(char *ctrlr_pci_addr);
 
 /**
  * Format NVMe controller namespace.

--- a/src/control/lib/spdk/include/nvme_control_common.h
+++ b/src/control/lib/spdk/include/nvme_control_common.h
@@ -1,5 +1,5 @@
 /**
-* (C) Copyright 2019 Intel Corporation.
+* (C) Copyright 2019-2020 Intel Corporation.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -41,6 +41,12 @@ enum NvmeControlStatusCode {
 	NVMEC_ERR_NS_NOT_FOUND		= 6,
 	NVMEC_ERR_NOT_SUPPORTED		= 7,
 	NVMEC_ERR_BAD_LBA		= 8,
+	NVMEC_ERR_ALLOC_IO_QPAIR	= 9,
+	NVMEC_ERR_NS_ID_UNEXPECTED	= 10,
+	NVMEC_ERR_NS_WRITE_FAIL		= 11,
+	NVMEC_ERR_MULTIPLE_ACTIVE_NS	= 12,
+	NVMEC_ERR_NULL_NS		= 13,
+	NVMEC_ERR_ALLOC_SEQUENCE_BUF	= 14,
 	NVMEC_LAST_STATUS_VALUE
 };
 

--- a/src/control/server/storage/bdev/backend.go
+++ b/src/control/server/storage/bdev/backend.go
@@ -217,7 +217,7 @@ func (b *spdkBackend) Format(pciAddr string) (*storage.NvmeController, error) {
 		return nil, FaultFormatBadPciAddr(pciAddr)
 	}
 
-	if err := b.binding.Format(pciAddr); err != nil {
+	if err := b.binding.Format(b.log, pciAddr); err != nil {
 		return nil, err
 	}
 


### PR DESCRIPTION
Instead of performing a device format through SPDK each time, which can
take up to fifteen minutes on an Optane device, write zeroes to the
first LBA sector on the device (4k LBA-0) which effectively erases the
user visible contents of the device (no blobs will be visible after).

If this fails because there is an unexpected first active namespace ID
or namespace information cannot be retrieved from the controller,
fallback to performing a device format as before.

"formatting" NVMe devices now takes in the region of 3 seconds.

Signed-off-by: Tom Nabarro <tom.nabarro@intel.com>