### PR TITLE
DAOS-3626 md: fix NVMe SPDK blob leak on pool create failure

### DIFF
--- a/src/mgmt/srv_target.c
+++ b/src/mgmt/srv_target.c
@@ -420,6 +420,8 @@ tgt_vos_create(uuid_t uuid, daos_size_t tgt_scm_size, daos_size_t tgt_nvme_size)
 	return rc;
 }
 
+static int tgt_destroy(uuid_t pool_uuid, char *path);
+
 static int
 tgt_create(uuid_t pool_uuid, uuid_t tgt_uuid, daos_size_t scm_size,
 	   daos_size_t nvme_size, char *path)
@@ -466,8 +468,8 @@ tgt_create(uuid_t pool_uuid, uuid_t tgt_uuid, daos_size_t scm_size,
 
 out_tree:
 	/** cleanup will be re-executed on several occasions */
-	(void)subtree_destroy(newborn);
-	(void)rmdir(newborn);
+	/* Ensure partially created resources (e.g., SPDK blobs) not leaked */
+	(void)tgt_destroy(pool_uuid, newborn);
 out:
 	D_FREE(newborn);
 	return rc;


### PR DESCRIPTION
Before this change a pool create specifying an NVMe size greater
than the available space remaining would result in a failure
correctly reported to the client with -DER_NOSPACE (-1007). However,
a side effect is that it would leave behind some of the SPDK blobs
created in the attempt to satisfy the pool create NVMe size.
tgt_create() cleanup only included SCM subtree destroy.

With this change, the error cleanup for tgt_create() is made
more complete by invoking the tgt_destroy() function that also
includes removal of SPDK blobs.

Signed-off-by: Ken Cain <kenneth.c.cain@intel.com>