### PR TITLE
DAOS-2060 tools: Add daos cont get-acl command

### DIFF
--- a/src/client/api/container.c
+++ b/src/client/api/container.c
@@ -157,6 +157,30 @@ daos_cont_query(daos_handle_t coh, daos_cont_info_t *info,
 }
 
 int
+daos_cont_get_acl(daos_handle_t coh, daos_prop_t **acl_prop, daos_event_t *ev)
+{
+	daos_prop_t	*prop;
+	const size_t	nr_entries = 3;
+
+	if (acl_prop == NULL) {
+		D_ERROR("invalid acl_prop parameter\n");
+		return -DER_INVAL;
+	}
+
+	prop = daos_prop_alloc(nr_entries);
+	if (prop == NULL)
+		return -DER_NOMEM;
+
+	prop->dpp_entries[0].dpe_type = DAOS_PROP_CO_ACL;
+	prop->dpp_entries[1].dpe_type = DAOS_PROP_CO_OWNER;
+	prop->dpp_entries[2].dpe_type = DAOS_PROP_CO_OWNER_GROUP;
+
+	*acl_prop = prop;
+
+	return daos_cont_query(coh, NULL, prop, ev);
+}
+
+int
 daos_cont_aggregate(daos_handle_t coh, daos_epoch_t epoch, daos_event_t *ev)
 {
 	daos_cont_aggregate_t	*args;

--- a/src/client/api/container.c
+++ b/src/client/api/container.c
@@ -161,6 +161,7 @@ daos_cont_get_acl(daos_handle_t coh, daos_prop_t **acl_prop, daos_event_t *ev)
 {
 	daos_prop_t	*prop;
 	const size_t	nr_entries = 3;
+	int		rc;
 
 	if (acl_prop == NULL) {
 		D_ERROR("invalid acl_prop parameter\n");
@@ -175,9 +176,13 @@ daos_cont_get_acl(daos_handle_t coh, daos_prop_t **acl_prop, daos_event_t *ev)
 	prop->dpp_entries[1].dpe_type = DAOS_PROP_CO_OWNER;
 	prop->dpp_entries[2].dpe_type = DAOS_PROP_CO_OWNER_GROUP;
 
-	*acl_prop = prop;
+	rc = daos_cont_query(coh, NULL, prop, ev);
+	if (rc == 0)
+		*acl_prop = prop;
+	else
+		daos_prop_free(prop);
 
-	return daos_cont_query(coh, NULL, prop, ev);
+	return rc;
 }
 
 int

--- a/src/common/acl_api.c
+++ b/src/common/acl_api.c
@@ -1205,6 +1205,10 @@ daos_ace_is_valid(struct daos_ace *ace)
 	if (ace->dae_access_types & ~valid_types)
 		return false;
 
+	/* No access type defined */
+	if (ace->dae_access_types == 0)
+		return false;
+
 	if (ace->dae_access_flags & ~valid_flags)
 		return false;
 

--- a/src/common/acl_util.c
+++ b/src/common/acl_util.c
@@ -30,6 +30,8 @@
 #include <gurt/common.h>
 #include <gurt/debug.h>
 
+#define ACE_FIELD_DELIM		':'
+
 /*
  * Characters representing access flags
  */
@@ -39,11 +41,26 @@
 #define FLAG_POOL_INHERIT_CH	'P'
 
 /*
+ * Verbose strings representing access flags
+ */
+#define FLAG_GROUP_STR		"Group"
+#define FLAG_ACCESS_SUCCESS_STR	"Access-Success"
+#define FLAG_ACCESS_FAIL_STR	"Access-Failure"
+#define FLAG_POOL_INHERIT_STR	"Pool-Inherit"
+
+/*
  * Characters representing access types
  */
 #define ACCESS_ALLOW_CH		'A'
 #define ACCESS_AUDIT_CH		'U'
 #define ACCESS_ALARM_CH		'L'
+
+/*
+ * Verbose strings representing access types
+ */
+#define ACCESS_ALLOW_STR	"Allow"
+#define ACCESS_AUDIT_STR	"Audit"
+#define ACCESS_ALARM_STR	"Alarm"
 
 /*
  * Characters representing permissions
@@ -59,15 +76,32 @@
 #define PERM_SET_OWNER_CH	'o'
 
 /*
+ * Verbose strings representing permissions
+ */
+#define PERM_READ_STR		"Read"
+#define PERM_WRITE_STR		"Write"
+#define PERM_CREATE_CONT_STR	"Create-Container"
+#define PERM_DEL_CONT_STR	"Delete-Container"
+#define PERM_GET_PROP_STR	"Get-Prop"
+#define PERM_SET_PROP_STR	"Set-Prop"
+#define PERM_GET_ACL_STR	"Get-ACL"
+#define PERM_SET_ACL_STR	"Set-ACL"
+#define PERM_SET_OWNER_STR	"Set-Owner"
+
+/*
  * States used to parse a formatted ACE string
  */
 enum ace_str_state {
+	ACE_FIRST_ACCESS_TYPE,
 	ACE_ACCESS_TYPES,
+	ACE_FIRST_FLAG,
 	ACE_FLAGS,
 	ACE_IDENTITY,
+	ACE_FIRST_PERM,
 	ACE_PERMS,
 	ACE_DONE,
-	ACE_INVALID
+	ACE_INVALID,
+	ACE_TRUNC,
 };
 
 static enum ace_str_state
@@ -203,12 +237,15 @@ create_ace_from_mutable_str(char *str, struct daos_ace **ace)
 	struct daos_ace			*new_ace = NULL;
 	char				*pch;
 	char				*field;
-	char				delimiter[] = ":";
+	char				delimiter[2];
 	enum ace_str_state		state = ACE_ACCESS_TYPES;
 	uint16_t			flags = 0;
 	uint8_t				access_types = 0;
 	uint64_t			perms = 0;
 	int				rc = 0;
+
+	/* delimiter needs to be a string for strtok */
+	snprintf(delimiter, sizeof(delimiter), "%c", ACE_FIELD_DELIM);
 
 	pch = strpbrk(str, delimiter);
 	field = str;
@@ -341,7 +378,7 @@ daos_ace_get_principal_str(struct daos_ace *ace)
 }
 
 static int
-write_char(char **pen, char ch, ssize_t *remaining_len)
+write_char(char ch, char **pen, size_t *remaining_len)
 {
 	if (*remaining_len <= 1) /* leave a null termination char in buffer */
 		return -DER_TRUNC;
@@ -390,20 +427,42 @@ perms_unified(struct daos_ace *ace)
 	return true;
 }
 
-#define	WRITE_CH_FOR_BIT(bits, bit_name)				\
+#define	WRITE_BIT(bits, bit_name)					\
 	do {								\
 		if (bits & DAOS_ACL_ ## bit_name)			\
-			rc = write_char(&pen, bit_name ## _CH,		\
+			rc = write_char(bit_name ## _CH, &pen,		\
 					&remaining_len);		\
 	} while (0)
+
+#define	WRITE_DIVIDER(_pen, _remaining_len)				\
+	do {								\
+		rc = write_char(ACE_FIELD_DELIM, _pen, _remaining_len);	\
+	} while (0)
+
+
+static int
+write_str(const char *str, char **pen, size_t *remaining_len)
+{
+	int	written;
+
+	written = snprintf(*pen, *remaining_len, "%s", str);
+	if (written >= *remaining_len) {
+		*remaining_len = 0;
+		return -DER_TRUNC;
+	}
+
+	*pen += written;
+	*remaining_len -= written;
+
+	return 0;
+}
 
 int
 daos_ace_to_str(struct daos_ace *ace, char *buf, size_t buf_len)
 {
-	ssize_t		remaining_len = buf_len;
+	size_t		remaining_len = buf_len;
 	char		*pen = buf;
 	uint64_t	perms;
-	ssize_t		written;
 	int		rc = 0;
 
 	if (ace == NULL || buf == NULL || buf_len == 0) {
@@ -417,7 +476,6 @@ daos_ace_to_str(struct daos_ace *ace, char *buf, size_t buf_len)
 		return -DER_INVAL;
 	}
 
-
 	if (!perms_unified(ace)) {
 		D_INFO("Can't create string for ACE with different perms for "
 		       "different access types\n");
@@ -426,38 +484,294 @@ daos_ace_to_str(struct daos_ace *ace, char *buf, size_t buf_len)
 
 	memset(buf, 0, buf_len);
 
-	WRITE_CH_FOR_BIT(ace->dae_access_types, ACCESS_ALLOW);
-	WRITE_CH_FOR_BIT(ace->dae_access_types, ACCESS_AUDIT);
-	WRITE_CH_FOR_BIT(ace->dae_access_types, ACCESS_ALARM);
+	/* Access Type */
+	WRITE_BIT(ace->dae_access_types, ACCESS_ALLOW);
+	WRITE_BIT(ace->dae_access_types, ACCESS_AUDIT);
+	WRITE_BIT(ace->dae_access_types, ACCESS_ALARM);
 
-	rc = write_char(&pen, ':', &remaining_len);
+	WRITE_DIVIDER(&pen, &remaining_len);
 
-	WRITE_CH_FOR_BIT(ace->dae_access_flags, FLAG_GROUP);
-	WRITE_CH_FOR_BIT(ace->dae_access_flags, FLAG_ACCESS_SUCCESS);
-	WRITE_CH_FOR_BIT(ace->dae_access_flags, FLAG_ACCESS_FAIL);
-	WRITE_CH_FOR_BIT(ace->dae_access_flags, FLAG_POOL_INHERIT);
+	/* Flags */
+	WRITE_BIT(ace->dae_access_flags, FLAG_GROUP);
+	WRITE_BIT(ace->dae_access_flags, FLAG_ACCESS_SUCCESS);
+	WRITE_BIT(ace->dae_access_flags, FLAG_ACCESS_FAIL);
+	WRITE_BIT(ace->dae_access_flags, FLAG_POOL_INHERIT);
 
-	written = snprintf(pen, remaining_len, ":%s:",
-			   daos_ace_get_principal_str(ace));
-	if (written > remaining_len) {
-		remaining_len = 0;
-	} else {
-		pen += written;
-		remaining_len -= written;
-	}
+	WRITE_DIVIDER(&pen, &remaining_len);
 
+	/* Principal */
+	rc = write_str(daos_ace_get_principal_str(ace), &pen, &remaining_len);
+
+	WRITE_DIVIDER(&pen, &remaining_len);
+
+	/* Permissions */
 	perms = get_perms(ace);
-	WRITE_CH_FOR_BIT(perms, PERM_READ);
-	WRITE_CH_FOR_BIT(perms, PERM_WRITE);
-	WRITE_CH_FOR_BIT(perms, PERM_CREATE_CONT);
-	WRITE_CH_FOR_BIT(perms, PERM_DEL_CONT);
-	WRITE_CH_FOR_BIT(perms, PERM_GET_PROP);
-	WRITE_CH_FOR_BIT(perms, PERM_SET_PROP);
-	WRITE_CH_FOR_BIT(perms, PERM_GET_ACL);
-	WRITE_CH_FOR_BIT(perms, PERM_SET_ACL);
-	WRITE_CH_FOR_BIT(perms, PERM_SET_OWNER);
+	WRITE_BIT(perms, PERM_READ);
+	WRITE_BIT(perms, PERM_WRITE);
+	WRITE_BIT(perms, PERM_CREATE_CONT);
+	WRITE_BIT(perms, PERM_DEL_CONT);
+	WRITE_BIT(perms, PERM_GET_PROP);
+	WRITE_BIT(perms, PERM_SET_PROP);
+	WRITE_BIT(perms, PERM_GET_ACL);
+	WRITE_BIT(perms, PERM_SET_ACL);
+	WRITE_BIT(perms, PERM_SET_OWNER);
 
 	return rc;
+}
+
+static const char *
+get_verbose_principal_str(const char *name)
+{
+	if (strncmp(name, DAOS_ACL_PRINCIPAL_OWNER,
+		    DAOS_ACL_MAX_PRINCIPAL_BUF_LEN) == 0)
+		return "Owner";
+	if (strncmp(name, DAOS_ACL_PRINCIPAL_OWNER_GRP,
+		    DAOS_ACL_MAX_PRINCIPAL_BUF_LEN) == 0)
+		return "Owner-Group";
+	if (strncmp(name, DAOS_ACL_PRINCIPAL_EVERYONE,
+		    DAOS_ACL_MAX_PRINCIPAL_BUF_LEN) == 0)
+		return "Everyone";
+
+	return name;
+}
+
+static enum ace_str_state
+process_verbose_access_ch(const char ch, char **pen, size_t *remaining_len,
+			  bool first)
+{
+	const char	*str;
+	int		rc = 0;
+
+	switch (ch) {
+	case ACCESS_ALLOW_CH:
+		str = ACCESS_ALLOW_STR;
+		break;
+	case ACCESS_AUDIT_CH:
+		str = ACCESS_AUDIT_STR;
+		break;
+	case ACCESS_ALARM_CH:
+		str = ACCESS_ALARM_STR;
+		break;
+	case ACE_FIELD_DELIM:
+		if (first)
+			return ACE_INVALID;
+		WRITE_DIVIDER(pen, remaining_len);
+		if (rc == -DER_TRUNC)
+			return ACE_TRUNC;
+		return ACE_FIRST_FLAG;
+	case '\0':
+	default:
+		return ACE_INVALID;
+	}
+
+	if (!first)
+		write_char('/', pen, remaining_len);
+	rc = write_str(str, pen, remaining_len);
+	if (rc == -DER_TRUNC)
+		return ACE_TRUNC;
+
+	return ACE_ACCESS_TYPES;
+}
+
+static enum ace_str_state
+process_verbose_flag_ch(const char ch, char **pen, size_t *remaining_len,
+			bool first)
+{
+	const char	*str;
+	int		rc = 0;
+
+	switch (ch) {
+	case FLAG_GROUP_CH:
+		str = FLAG_GROUP_STR;
+		break;
+	case FLAG_ACCESS_FAIL_CH:
+		str = FLAG_ACCESS_FAIL_STR;
+		break;
+	case FLAG_ACCESS_SUCCESS_CH:
+		str = FLAG_ACCESS_SUCCESS_STR;
+		break;
+	case ACE_FIELD_DELIM:
+		WRITE_DIVIDER(pen, remaining_len);
+		if (rc == -DER_TRUNC)
+			return ACE_TRUNC;
+		return ACE_IDENTITY;
+	case '\0':
+	default:
+		return ACE_INVALID;
+	}
+
+	if (!first)
+		write_char('/', pen, remaining_len);
+	rc = write_str(str, pen, remaining_len);
+	if (rc == -DER_TRUNC)
+		return ACE_TRUNC;
+
+	return ACE_FLAGS;
+}
+
+static enum ace_str_state
+process_verbose_perms_ch(const char ch, char **pen, size_t *remaining_len,
+			 bool first)
+{
+	const char	*str;
+	int		rc = 0;
+
+	switch (ch) {
+	case PERM_READ_CH:
+		str = PERM_READ_STR;
+		break;
+	case PERM_WRITE_CH:
+		str = PERM_WRITE_STR;
+		break;
+	case PERM_CREATE_CONT_CH:
+		str = PERM_CREATE_CONT_STR;
+		break;
+	case PERM_DEL_CONT_CH:
+		str = PERM_DEL_CONT_STR;
+		break;
+	case PERM_GET_PROP_CH:
+		str = PERM_GET_PROP_STR;
+		break;
+	case PERM_SET_PROP_CH:
+		str = PERM_SET_PROP_STR;
+		break;
+	case PERM_GET_ACL_CH:
+		str = PERM_GET_ACL_STR;
+		break;
+	case PERM_SET_ACL_CH:
+		str = PERM_SET_ACL_STR;
+		break;
+	case PERM_SET_OWNER_CH:
+		str = PERM_SET_OWNER_STR;
+		break;
+	case '\0':
+		if (first) {
+			rc = write_str("No-Access", pen, remaining_len);
+			if (rc == -DER_TRUNC)
+				return ACE_TRUNC;
+		}
+		return ACE_DONE;
+	case ACE_FIELD_DELIM:
+	default:
+		return ACE_INVALID;
+	}
+
+	if (!first)
+		write_char('/', pen, remaining_len);
+	rc = write_str(str, pen, remaining_len);
+	if (rc == -DER_TRUNC)
+		return ACE_TRUNC;
+
+	return ACE_PERMS;
+}
+
+static enum ace_str_state
+process_verbose_identity(const char *pch, char **pen, size_t *remaining_len,
+			 const char **end)
+{
+	char	identity[DAOS_ACL_MAX_PRINCIPAL_BUF_LEN];
+	size_t	len;
+	char	delim[2];
+	int	rc;
+
+	snprintf(delim, sizeof(delim), "%c", ACE_FIELD_DELIM);
+
+	*end = strpbrk(pch, delim);
+	if (*end == NULL)
+		return ACE_INVALID;
+
+	len = *end - pch;
+	strncpy(identity, pch, len);
+	identity[len] = '\0';
+
+	if (!daos_acl_principal_is_valid(identity))
+		return ACE_INVALID;
+
+	rc = write_str(get_verbose_principal_str(identity), pen, remaining_len);
+	if (rc == -DER_TRUNC)
+		return ACE_TRUNC;
+
+	WRITE_DIVIDER(pen, remaining_len);
+	if (rc == -DER_TRUNC)
+		return ACE_TRUNC;
+
+	return ACE_FIRST_PERM;
+}
+
+int
+daos_ace_str_get_verbose(const char *ace_str, char *buf, size_t buf_len)
+{
+	const char		*pch = ace_str;
+	enum ace_str_state	state = ACE_FIRST_ACCESS_TYPE;
+	char			*pen = buf;
+	size_t			remaining_len = buf_len;
+	bool			first = false;
+
+
+	if (buf == NULL || buf_len == 0) {
+		D_ERROR("Empty or NULL buffer\n");
+		return -DER_INVAL;
+	}
+
+	if (ace_str == NULL) {
+		D_ERROR("NULL ACE string\n");
+		return -DER_INVAL;
+	}
+
+	memset(buf, 0, buf_len);
+
+	while (state != ACE_INVALID &&
+	       state != ACE_DONE &&
+	       state != ACE_TRUNC) {
+		switch (state) {
+		case ACE_FIRST_ACCESS_TYPE:
+			first = true;
+			/* fall through */
+		case ACE_ACCESS_TYPES:
+			state = process_verbose_access_ch(*pch, &pen,
+							  &remaining_len,
+							  first);
+			break;
+		case ACE_FIRST_FLAG:
+			first = true;
+			/* fall through */
+		case ACE_FLAGS:
+			state = process_verbose_flag_ch(*pch, &pen,
+							&remaining_len,
+							first);
+			break;
+		case ACE_IDENTITY:
+			state = process_verbose_identity(pch, &pen,
+							 &remaining_len, &pch);
+			break;
+		case ACE_FIRST_PERM:
+			first = true;
+			/* fall through */
+		case ACE_PERMS:
+			state = process_verbose_perms_ch(*pch,  &pen,
+							 &remaining_len,
+							 first);
+			break;
+		default:
+			D_INFO("Bad state: %u\n", state);
+			state = ACE_INVALID;
+		}
+
+		pch++;
+		first = false;
+	}
+
+	if (state == ACE_INVALID) {
+		D_INFO("Invalid ACE string\n");
+		return -DER_INVAL;
+	}
+
+	if (state == ACE_TRUNC) {
+		D_INFO("String was truncated\n");
+		return -DER_TRUNC;
+	}
+
+	return 0;
 }
 
 int

--- a/src/common/tests/acl_valid_tests.c
+++ b/src/common/tests/acl_valid_tests.c
@@ -48,6 +48,7 @@ expect_ace_valid(enum daos_acl_principal_type type, const char *principal)
 	struct daos_ace *ace;
 
 	ace = daos_ace_create(type, principal);
+	ace->dae_access_types = DAOS_ACL_ACCESS_ALLOW;
 
 	assert_true(daos_ace_is_valid(ace));
 
@@ -323,6 +324,19 @@ test_ace_is_valid_undefined_access_type(void **state)
 
 	ace = daos_ace_create(DAOS_ACL_OWNER, NULL);
 	ace->dae_access_types |= (1 << 7); /* nonexistent type */
+
+	assert_false(daos_ace_is_valid(ace));
+
+	daos_ace_free(ace);
+}
+
+static void
+test_ace_is_valid_no_access_type(void **state)
+{
+	struct daos_ace *ace;
+
+	ace = daos_ace_create(DAOS_ACL_OWNER, NULL);
+	ace->dae_access_types = 0;
 
 	assert_false(daos_ace_is_valid(ace));
 
@@ -897,6 +911,7 @@ main(void)
 		cmocka_unit_test(test_ace_is_valid_undefined_perms),
 		cmocka_unit_test(test_ace_is_valid_valid_perms),
 		cmocka_unit_test(test_ace_is_valid_undefined_access_type),
+		cmocka_unit_test(test_ace_is_valid_no_access_type),
 		cmocka_unit_test(test_ace_is_valid_valid_access_types),
 		cmocka_unit_test(test_ace_is_valid_perms_for_unset_type),
 		cmocka_unit_test(test_ace_is_valid_audit_flags_with_only_allow),

--- a/src/common/tests/test_utils.c
+++ b/src/common/tests/test_utils.c
@@ -126,6 +126,7 @@ fill_ace_list_with_users(struct daos_ace *ace[], size_t num_aces)
 
 		snprintf(name, sizeof(name), "user%d@", i + 1);
 		ace[i] = daos_ace_create(DAOS_ACL_USER, name);
+		ace[i]->dae_access_types = DAOS_ACL_ACCESS_ALLOW;
 	}
 }
 

--- a/src/container/container_iv.c
+++ b/src/container/container_iv.c
@@ -224,7 +224,8 @@ cont_iv_ent_copy(struct ds_iv_entry *entry, d_sg_list_t *dst_sgl,
 		break;
 	case IV_CONT_PROP:
 		memcpy(&dst->iv_prop, &src->iv_prop,
-		       cont_iv_prop_ent_size(src->iv_prop.cip_acl.dal_len));
+		       offsetof(struct cont_iv_prop,
+				cip_acl.dal_ace[src->iv_prop.cip_acl.dal_len]));
 		break;
 	default:
 		D_ERROR("bad iv_class_id %d.\n", entry->iv_class->iv_class_id);
@@ -919,7 +920,7 @@ cont_iv_prop_g2l(struct cont_iv_prop *iv_prop, daos_prop_t *prop)
 			break;
 		case DAOS_PROP_CO_ACL:
 			acl = &iv_prop->cip_acl;
-			if (acl->dal_len > 0) {
+			if (acl->dal_ver != 0) {
 				D_ASSERT(daos_acl_validate(acl) == 0);
 				acl_alloc = daos_acl_dup(acl);
 				if (acl_alloc != NULL)

--- a/src/include/daos_cont.h
+++ b/src/include/daos_cont.h
@@ -259,6 +259,29 @@ daos_cont_query(daos_handle_t container, daos_cont_info_t *info,
 		daos_prop_t *cont_prop, daos_event_t *ev);
 
 /**
+ * Query the container Access Control List and ownership properties.
+ *
+ * \param[in]	coh	Container open handle.
+
+ * \param[out]	acl_prop
+ *			Newly allocated daos_prop_t containing the ACL, owner,
+ *			and owner-group properties of the container.
+ *			Caller must free it with daos_prop_free().
+ * \param[in]	ev	Completion event, it is optional and can be NULL.
+ *			The function will run in blocking mode if \a ev is NULL.
+ *
+ * \return		These values will be returned by \a ev::ev_error in
+ *			non-blocking mode:
+ *			0		Success
+ *			-DER_INVAL	Invalid parameter
+ *			-DER_UNREACH	Network is unreachable
+ *			-DER_NO_HDL	Invalid container handle
+ */
+int
+daos_cont_get_acl(daos_handle_t container, daos_prop_t **acl_prop,
+		  daos_event_t *ev);
+
+/**
  * List the names of all user-defined container attributes.
  *
  * \param[in]	coh	Container handle.

--- a/src/include/daos_security.h
+++ b/src/include/daos_security.h
@@ -554,6 +554,20 @@ int
 daos_ace_to_str(struct daos_ace *ace, char *buf, size_t buf_len);
 
 /**
+ * Convert an Access Control Entry string to a verbose string.
+ *
+ * \param[in]	ace_str		ACE string
+ * \param[out]	buf		Output buffer
+ * \param[in]	buf_len		Length of output buffer
+ *
+ * \return	0		Success
+ *		-DER_INVAL	Invalid input string
+ *		-DER_TRUNC	Output didn't fit in buffer
+ */
+int
+daos_ace_str_get_verbose(const char *ace_str, char *buf, size_t buf_len);
+
+/**
  * Convert a list of Access Control Entries formatted as strings to a daos_acl
  * structure.
  *

--- a/src/pool/srv_iv.c
+++ b/src/pool/srv_iv.c
@@ -570,7 +570,7 @@ pool_iv_prop_g2l(struct pool_iv_prop *iv_prop, daos_prop_t *prop)
 			break;
 		case DAOS_PROP_PO_ACL:
 			acl = &iv_prop->pip_acl;
-			if (acl->dal_len > 0) {
+			if (acl->dal_ver != 0) {
 				D_ASSERT(daos_acl_validate(acl) == 0);
 				acl_alloc = daos_acl_dup(acl);
 				if (acl_alloc != NULL)

--- a/src/tests/suite/daos_container.c
+++ b/src/tests/suite/daos_container.c
@@ -465,6 +465,103 @@ co_op_retry(void **state)
 	print_message("success\n");
 }
 
+static void
+co_acl(void **state)
+{
+	test_arg_t		*arg0 = *state;
+	test_arg_t		*arg = NULL;
+	daos_prop_t		*prop_in;
+	daos_prop_t		*prop_out = NULL;
+	struct daos_prop_entry	*entry;
+	daos_pool_info_t	 info = {0};
+	int			 rc;
+	const char		*exp_owner = "fictionaluser@";
+	const char		*exp_owner_grp = "admins@";
+	struct daos_acl		*exp_acl, *actual_acl;
+
+	print_message("create container with access props, and verify.\n");
+	rc = test_setup((void **)&arg, SETUP_POOL_CONNECT, arg0->multi_rank,
+			DEFAULT_POOL_SIZE, NULL);
+	assert_int_equal(rc, 0);
+
+	/* Empty ACL is a weird case, but valid */
+	exp_acl = daos_acl_create(NULL, 0);
+	assert_non_null(exp_acl);
+	assert_int_equal(daos_acl_cont_validate(exp_acl), 0);
+
+	/*
+	 * Set up the container with non-default owner/group and ACL values
+	 */
+	prop_in = daos_prop_alloc(3);
+	assert_non_null(prop_in);
+	prop_in->dpp_entries[0].dpe_type = DAOS_PROP_CO_OWNER;
+	D_STRNDUP(prop_in->dpp_entries[0].dpe_str, exp_owner,
+		  DAOS_ACL_MAX_PRINCIPAL_BUF_LEN);
+	prop_in->dpp_entries[1].dpe_type = DAOS_PROP_CO_OWNER_GROUP;
+	D_STRNDUP(prop_in->dpp_entries[1].dpe_str, exp_owner_grp,
+		  DAOS_ACL_MAX_PRINCIPAL_BUF_LEN);
+	prop_in->dpp_entries[2].dpe_type = DAOS_PROP_CO_ACL;
+	prop_in->dpp_entries[2].dpe_val_ptr = daos_acl_dup(exp_acl);
+
+	while (!rc && arg->setup_state != SETUP_CONT_CONNECT)
+		rc = test_setup_next_step((void **)&arg, NULL, NULL, prop_in);
+	assert_int_equal(rc, 0);
+
+	if (arg->myrank == 0) {
+		rc = daos_pool_query(arg->pool.poh, NULL, &info, NULL, NULL);
+		assert_int_equal(rc, 0);
+		rc = daos_mgmt_set_params(arg->group, info.pi_leader,
+			DMG_KEY_FAIL_LOC, DAOS_FORCE_PROP_VERIFY, 0, NULL);
+		assert_int_equal(rc, 0);
+	}
+	MPI_Barrier(MPI_COMM_WORLD);
+
+	print_message("Getting the container ACL\n");
+	rc = daos_cont_get_acl(arg->coh, &prop_out, NULL);
+	assert_int_equal(rc, 0);
+
+	assert_non_null(prop_out);
+	assert_int_equal(prop_out->dpp_nr, 3);
+
+	print_message("Checking ACL\n");
+	entry = daos_prop_entry_get(prop_out, DAOS_PROP_CO_ACL);
+	if (entry == NULL || entry->dpe_val_ptr == NULL) {
+		print_message("ACL prop wasn't returned.\n");
+		assert_int_equal(rc, 1); /* fail the test */
+	}
+	actual_acl = entry->dpe_val_ptr;
+	assert_int_equal(actual_acl->dal_ver, exp_acl->dal_ver);
+	assert_int_equal(actual_acl->dal_len, exp_acl->dal_len);
+
+	print_message("Checking owner\n");
+	entry = daos_prop_entry_get(prop_out, DAOS_PROP_CO_OWNER);
+	if (entry == NULL || entry->dpe_str == NULL ||
+	    strncmp(entry->dpe_str, exp_owner,
+		    DAOS_ACL_MAX_PRINCIPAL_LEN)) {
+		print_message("Owner prop verification failed.\n");
+		assert_int_equal(rc, 1); /* fail the test */
+	}
+
+	print_message("Checking owner-group\n");
+	entry = daos_prop_entry_get(prop_out, DAOS_PROP_CO_OWNER_GROUP);
+	if (entry == NULL || entry->dpe_str == NULL ||
+	    strncmp(entry->dpe_str, exp_owner_grp,
+		    DAOS_ACL_MAX_PRINCIPAL_LEN)) {
+		print_message("Owner-group prop verification failed.\n");
+		assert_int_equal(rc, 1); /* fail the test */
+	}
+
+	if (arg->myrank == 0)
+		daos_mgmt_set_params(arg->group, -1, DMG_KEY_FAIL_LOC, 0,
+				     0, NULL);
+	MPI_Barrier(MPI_COMM_WORLD);
+
+	daos_prop_free(prop_in);
+	daos_prop_free(prop_out);
+	daos_acl_free(exp_acl);
+	test_teardown((void **)&arg);
+}
+
 static int
 co_setup_sync(void **state)
 {
@@ -502,7 +599,9 @@ static const struct CMUnitTest co_tests[] = {
 	{ "CONT6: create container with properties and query",
 	  co_properties, NULL, test_case_teardown},
 	{ "CONT7: retry CONT_{CLOSE,DESTROY,QUERY}",
-	  co_op_retry, NULL, test_case_teardown}
+	  co_op_retry, NULL, test_case_teardown},
+	{ "CONT8: container ACL",
+	  co_acl, NULL, test_case_teardown},
 };
 
 int

--- a/src/utils/daos_hdlr.c
+++ b/src/utils/daos_hdlr.c
@@ -999,6 +999,103 @@ cont_destroy_hdlr(struct cmd_args_s *ap)
 	return rc;
 }
 
+static int
+print_acl(FILE *outstream, daos_prop_t *acl_prop, bool verbose)
+{
+	int			rc = 0;
+	struct daos_prop_entry	*entry;
+	struct daos_acl		*acl = NULL;
+	char			**acl_str = NULL;
+	size_t			nr_acl_str;
+	char			verbose_str[DAOS_ACL_MAX_ACE_STR_LEN * 2];
+	size_t			i;
+
+	/*
+	 * Validate the ACL before we start printing anything out.
+	 */
+	entry = daos_prop_entry_get(acl_prop, DAOS_PROP_CO_ACL);
+	if (entry != NULL && entry->dpe_val_ptr != NULL) {
+		acl = entry->dpe_val_ptr;
+		rc = daos_acl_to_strs(acl, &acl_str, &nr_acl_str);
+		if (rc != 0) {
+			fprintf(stderr,
+				"Invalid ACL cannot be displayed\n");
+			return rc;
+		}
+	}
+
+	entry = daos_prop_entry_get(acl_prop, DAOS_PROP_CO_OWNER);
+	if (entry != NULL && entry->dpe_str != NULL)
+		fprintf(outstream, "# Owner: %s\n", entry->dpe_str);
+
+	entry = daos_prop_entry_get(acl_prop, DAOS_PROP_CO_OWNER_GROUP);
+	if (entry != NULL && entry->dpe_str != NULL)
+		fprintf(outstream, "# Owner-Group: %s\n", entry->dpe_str);
+
+	fprintf(outstream, "# Entries:\n");
+
+	if (acl == NULL || acl->dal_len == 0) {
+		fprintf(outstream, "#   None\n");
+		return 0;
+	}
+
+	for (i = 0; i < nr_acl_str; i++) {
+		if (verbose) {
+			rc = daos_ace_str_get_verbose(acl_str[i], verbose_str,
+						      sizeof(verbose_str));
+			/*
+			 * If the ACE is invalid, we'll still print it out -
+			 * we just can't parse it to any helpful verbose string.
+			 */
+			if (rc != -DER_INVAL)
+				fprintf(outstream, "# %s\n", verbose_str);
+		}
+		fprintf(outstream, "%s\n", acl_str[i]);
+	}
+
+	return 0;
+}
+
+int
+cont_get_acl_hdlr(struct cmd_args_s *ap)
+{
+	int		rc;
+	daos_prop_t	*prop = NULL;
+	struct stat	sb;
+	FILE		*outstream = stdout;
+
+	if (ap->outfile) {
+		if (!ap->force && (stat(ap->outfile, &sb) == 0)) {
+			fprintf(stderr,
+				"Unable to create output file: File already "
+				"exists\n");
+			return -DER_EXIST;
+		}
+
+		outstream = fopen(ap->outfile, "w");
+		if (outstream == NULL) {
+			fprintf(stderr, "Unable to create output file: %s\n",
+				strerror(errno));
+			return daos_errno2der(errno);
+		}
+	}
+
+	rc = daos_cont_get_acl(ap->cont, &prop, NULL);
+	if (rc != 0) {
+		fprintf(stderr, "failed to get ACL for container: %d\n", rc);
+	} else {
+		rc = print_acl(outstream, prop, ap->verbose);
+		if (ap->outfile)
+			fprintf(stdout, "Wrote ACL to output file: %s\n",
+				ap->outfile);
+	}
+
+	if (ap->outfile)
+		fclose(outstream);
+	daos_prop_free(prop);
+	return rc;
+}
+
 int
 obj_query_hdlr(struct cmd_args_s *ap)
 {

--- a/src/utils/daos_hdlr.h
+++ b/src/utils/daos_hdlr.h
@@ -37,6 +37,7 @@ enum cont_op {
 	CONT_LIST_SNAPS,
 	CONT_DESTROY_SNAP,
 	CONT_ROLLBACK,
+	CONT_GET_ACL,
 };
 
 enum pool_op {
@@ -70,7 +71,7 @@ struct cmd_args_s {
 	daos_handle_t		cont;
 	char			*mdsrv_str;	/* --svc */
 	d_rank_list_t		*mdsrv;
-	int			force_destroy;	/* --force (cont destroy) */
+	int			force;		/* --force */
 	char			*attrname_str;	/* --attr attribute name */
 	char			*value_str;	/* --value attribute value */
 
@@ -90,6 +91,8 @@ struct cmd_args_s {
 	daos_prop_t		*props;		/* --properties cont create */
 
 	FILE			*ostream;	/* help_hdlr() stream */
+	char			*outfile;	/* --outfile path */
+	bool			verbose;	/* --verbose mode */
 };
 
 #define ARGS_VERIFY_PUUID(ap, label, rcexpr)			\
@@ -190,6 +193,7 @@ int cont_get_attr_hdlr(struct cmd_args_s *ap);
 int cont_create_snap_hdlr(struct cmd_args_s *ap);
 int cont_list_snaps_hdlr(struct cmd_args_s *ap);
 int cont_destroy_snap_hdlr(struct cmd_args_s *ap);
+int cont_get_acl_hdlr(struct cmd_args_s *ap);
 
 /* TODO implement the following container op functions
  * all with signatures similar to this:


### PR DESCRIPTION
- Add daos cont get-acl command. This includes the input
  parameters --outfile, --force, and --verbose.
- Add client API endpoint for getting cont ACL.
- Add daos_ace_str_get_verbose() to expand an ACE
  for verbose mode.
- Fixed a bug where an ACE was allowed to have no
  access types.
- Fixed a bug where the ACL wouldn't be returned
  over IV if it was empty.

Signed-off-by: Kris Jacque <kristin.jacque@intel.com>