### PR TITLE
DAOS-3626: md: on startup, cleanup newborn pool SPDK blobs

### DIFF
--- a/src/bio/bio_context.c
+++ b/src/bio/bio_context.c
@@ -429,7 +429,7 @@ bio_blob_create(uuid_t uuid, struct bio_xs_context *xs_ctxt, uint64_t blob_sz)
 					""DF_U64" for xs:%p pool:"DF_UUID"\n",
 					ba->bca_id, xs_ctxt, DP_UUID(uuid));
 		} else {
-			D_DEBUG(DB_MGMT, "Successfully assgin blob:"DF_U64" "
+			D_DEBUG(DB_MGMT, "Successfully assign blob:"DF_U64" "
 				"to pool:"DF_UUID":%d\n", ba->bca_id,
 				DP_UUID(uuid), xs_ctxt->bxc_tgt_id);
 		}

--- a/src/mgmt/srv.c
+++ b/src/mgmt/srv.c
@@ -366,15 +366,9 @@ ds_mgmt_init()
 {
 	int rc;
 
-	rc = ds_mgmt_tgt_init();
-	if (rc)
-		return rc;
-
 	rc = ds_mgmt_system_module_init();
-	if (rc != 0) {
-		ds_mgmt_tgt_fini();
+	if (rc != 0)
 		return rc;
-	}
 
 	D_DEBUG(DB_MGMT, "successfull init call\n");
 	return 0;
@@ -384,14 +378,21 @@ static int
 ds_mgmt_fini()
 {
 	ds_mgmt_system_module_fini();
-	ds_mgmt_tgt_fini();
-	D_DEBUG(DB_MGMT, "successfull fini call\n");
+
+	D_DEBUG(DB_MGMT, "successful fini call\n");
 	return 0;
+}
+
+static int
+ds_mgmt_setup()
+{
+	return ds_mgmt_tgt_setup();
 }
 
 static int
 ds_mgmt_cleanup()
 {
+	ds_mgmt_tgt_cleanup();
 	return ds_mgmt_svc_stop();
 }
 
@@ -401,6 +402,7 @@ struct dss_module mgmt_module = {
 	.sm_ver			= DAOS_MGMT_VERSION,
 	.sm_init		= ds_mgmt_init,
 	.sm_fini		= ds_mgmt_fini,
+	.sm_setup		= ds_mgmt_setup,
 	.sm_cleanup		= ds_mgmt_cleanup,
 	.sm_proto_fmt		= &mgmt_proto_fmt,
 	.sm_cli_count		= MGMT_PROTO_CLI_COUNT,

--- a/src/mgmt/srv_internal.h
+++ b/src/mgmt/srv_internal.h
@@ -128,8 +128,8 @@ int ds_mgmt_dev_state_query(uuid_t uuid, Mgmt__DevStateResp *resp);
 int ds_mgmt_dev_set_faulty(uuid_t uuid, Mgmt__DevStateResp *resp);
 
 /** srv_target.c */
-int ds_mgmt_tgt_init(void);
-void ds_mgmt_tgt_fini(void);
+int ds_mgmt_tgt_setup(void);
+void ds_mgmt_tgt_cleanup(void);
 void ds_mgmt_hdlr_tgt_create(crt_rpc_t *rpc_req);
 void ds_mgmt_hdlr_tgt_destroy(crt_rpc_t *rpc_req);
 int ds_mgmt_tgt_create_aggregator(crt_rpc_t *source, crt_rpc_t *result,

--- a/src/mgmt/srv_target.c
+++ b/src/mgmt/srv_target.c
@@ -99,111 +99,16 @@ subtree_destroy(const char *path)
 }
 
 int
-ds_mgmt_tgt_init(void)
+tgt_kill_pool(void *args)
 {
-	mode_t	stored_mode, mode;
-	int	rc;
+	struct d_uuid	*id = args;
 
-	/** create the path string */
-	rc = asprintf(&newborns_path, "%s/NEWBORNS", dss_storage_path);
-	if (rc < 0)
-		D_GOTO(err, rc = -DER_NOMEM);
-	rc = asprintf(&zombies_path, "%s/ZOMBIES", dss_storage_path);
-	if (rc < 0)
-		D_GOTO(err_newborns, rc = -DER_NOMEM);
-
-	stored_mode = umask(0);
-	mode = S_IRWXU | S_IRWXG | S_IRWXO;
-	/** create NEWBORNS directory if it does not exist already */
-	rc = mkdir(newborns_path, mode);
-	if (rc < 0 && errno != EEXIST) {
-		D_ERROR("failed to create NEWBORNS dir: %d\n", errno);
-		umask(stored_mode);
-		D_GOTO(err_zombies, rc = daos_errno2der(errno));
-	}
-
-	/** create ZOMBIES directory if it does not exist already */
-	rc = mkdir(zombies_path, mode);
-	if (rc < 0 && errno != EEXIST) {
-		D_ERROR("failed to create ZOMBIES dir: %d\n", errno);
-		umask(stored_mode);
-		D_GOTO(err_zombies, rc = daos_errno2der(errno));
-	}
-	umask(stored_mode);
-
-	/** remove leftover from previous runs */
-	rc = subtree_destroy(newborns_path);
-	if (rc)
-		/** only log error, will try again next time */
-		D_ERROR("failed to cleanup NEWBORNS dir: %d, will try again\n",
-			rc);
-	rc = subtree_destroy(zombies_path);
-	if (rc)
-		/** only log error, will try again next time */
-		D_ERROR("failed to cleanup ZOMBIES dir: %d, will try again\n",
-			rc);
-	return 0;
-
-err_zombies:
-	D_FREE(zombies_path);
-err_newborns:
-	D_FREE(newborns_path);
-err:
-	return rc;
-}
-
-void
-ds_mgmt_tgt_fini(void)
-{
-	D_FREE(zombies_path);
-	D_FREE(newborns_path);
-}
-
-static int
-path_gen(const uuid_t pool_uuid, const char *dir, const char *fname, int *idx,
-	 char **fpath)
-{
-	int	 size;
-	int	 off;
-
-	/** *fpath = dir + "/" + pool_uuid + "/" + fname + idx */
-
-	/** DAOS_UUID_STR_SIZE includes the trailing '\0' */
-	size = strlen(dir) + 1 /* "/" */ + DAOS_UUID_STR_SIZE;
-	if (fname != NULL || idx != NULL)
-		size += 1 /* "/" */;
-	if (fname)
-		size += strlen(fname);
-	if (idx)
-		size += snprintf(NULL, 0, "%d", *idx);
-
-	D_ALLOC(*fpath, size);
-	if (*fpath == NULL)
-		return -DER_NOMEM;
-
-	off = sprintf(*fpath, "%s", dir);
-	off += sprintf(*fpath + off, "/");
-	uuid_unparse_lower(pool_uuid, *fpath + off);
-	off += DAOS_UUID_STR_SIZE - 1;
-	if (fname != NULL || idx != NULL)
-		off += sprintf(*fpath + off, "/");
-	if (fname)
-		off += sprintf(*fpath + off, "%s", fname);
-	if (idx)
-		sprintf(*fpath + off, "%d", *idx);
-
-	return 0;
-}
-
-/**
- * Generate path to a target file for pool \a pool_uuid with a filename set to
- * \a fname and suffixed by \a idx. \a idx can be NULL.
- */
-int
-ds_mgmt_tgt_file(const uuid_t pool_uuid, const char *fname, int *idx,
-		 char **fpath)
-{
-	return path_gen(pool_uuid, dss_storage_path, fname, idx, fpath);
+	/* XXX: there are a few test cases that leak pool close
+	 * before destroying pool, we have to force the kill to pass
+	 * those tests, but we should try to disable "force" and
+	 * fix those issues in the future.
+	 */
+	return vos_pool_kill(id->uuid, true);
 }
 
 /**
@@ -267,6 +172,210 @@ ds_mgmt_tgt_pool_iterate(int (*cb)(uuid_t uuid, void *arg), void *arg)
 
 	return rc == 0 ? rc_tmp : rc;
 }
+
+/**
+ * Iterate pools left in the newborns path that have targets on this node
+ * The function \a cb will be called with the UUID of each pool. When \a cb
+ * returns an rc,
+ *
+ *   - if rc == 0, the iteration continues;
+ *   - otherwise, the iteration stops and returns rc.
+ *
+ * \param[in]	cb	callback called for each pool
+ * \param[in]	arg	argument passed to each \a cb call
+ */
+static int
+newborn_pool_iterate(int (*cb)(uuid_t uuid, void *arg), void *arg)
+{
+	DIR    *storage;
+	int	rc;
+	int	rc_tmp;
+
+	storage = opendir(newborns_path);
+	if (storage == NULL) {
+		D_ERROR("failed to open %s: %d\n", newborns_path, errno);
+		return daos_errno2der(errno);
+	}
+
+	for (;;) {
+		struct dirent  *entry;
+		uuid_t		uuid;
+
+		rc = 0;
+		errno = 0;
+		entry = readdir(storage);
+		if (entry == NULL) {
+			if (errno != 0) {
+				D_ERROR("failed to read %s: %d\n",
+					newborns_path, errno);
+				rc = daos_errno2der(errno);
+			}
+			break;
+		}
+
+		/* A pool directory must have a valid UUID as its name. */
+		rc = uuid_parse(entry->d_name, uuid);
+		if (rc != 0)
+			continue;
+
+		rc = cb(uuid, arg);
+		if (rc != 0) {
+			break;
+		}
+	}
+
+	rc_tmp = closedir(storage);
+	if (rc_tmp != 0) {
+		D_ERROR("failed to close %s: %d\n", newborns_path, errno);
+		rc_tmp = daos_errno2der(errno);
+	}
+
+	return rc == 0 ? rc_tmp : rc;
+}
+
+/* During init, remove leftover SPDK resources from pools not fully created */
+static int
+cleanup_newborn_pool(uuid_t uuid, void *arg)
+{
+	int		rc;
+	struct d_uuid	id;
+
+	/* destroy blobIDs */
+	D_DEBUG(DB_MGMT, "Clear SPDK blobs for NEWBORN pool "DF_UUID"\n",
+		DP_UUID(uuid));
+	uuid_copy(id.uuid, uuid);
+	rc = dss_thread_collective(tgt_kill_pool, &id, 0, DSS_ULT_IO);
+	if (rc != 0) {
+		if (rc > 0)
+			D_ERROR("%d xstreams failed tgt_kill_pool()\n", rc);
+		else
+			D_ERROR("tgt_kill_pool, rc: "DF_RC"\n", DP_RC(rc));
+	}
+
+	return rc;
+}
+
+static int
+cleanup_newborn_pools(void)
+{
+	return newborn_pool_iterate(cleanup_newborn_pool, NULL);
+}
+
+int
+ds_mgmt_tgt_setup(void)
+{
+	mode_t	stored_mode, mode;
+	int	rc;
+
+	/** create the path string */
+	rc = asprintf(&newborns_path, "%s/NEWBORNS", dss_storage_path);
+	if (rc < 0)
+		D_GOTO(err, rc = -DER_NOMEM);
+	rc = asprintf(&zombies_path, "%s/ZOMBIES", dss_storage_path);
+	if (rc < 0)
+		D_GOTO(err_newborns, rc = -DER_NOMEM);
+
+	stored_mode = umask(0);
+	mode = S_IRWXU | S_IRWXG | S_IRWXO;
+	/** create NEWBORNS directory if it does not exist already */
+	rc = mkdir(newborns_path, mode);
+	if (rc < 0 && errno != EEXIST) {
+		D_ERROR("failed to create NEWBORNS dir: %d\n", errno);
+		umask(stored_mode);
+		D_GOTO(err_zombies, rc = daos_errno2der(errno));
+	}
+
+	/** create ZOMBIES directory if it does not exist already */
+	rc = mkdir(zombies_path, mode);
+	if (rc < 0 && errno != EEXIST) {
+		D_ERROR("failed to create ZOMBIES dir: %d\n", errno);
+		umask(stored_mode);
+		D_GOTO(err_zombies, rc = daos_errno2der(errno));
+	}
+	umask(stored_mode);
+
+	/** remove leftover from previous runs */
+	rc = cleanup_newborn_pools();
+	if (rc)
+		/** only log error, will try again next time */
+		D_ERROR("failed to delete SPDK blobs for NEWBORNS pools: "
+			"%d, will try again\n", rc);
+
+	rc = subtree_destroy(newborns_path);
+	if (rc)
+		/** only log error, will try again next time */
+		D_ERROR("failed to cleanup NEWBORNS dir: %d, will try again\n",
+			rc);
+	rc = subtree_destroy(zombies_path);
+	if (rc)
+		/** only log error, will try again next time */
+		D_ERROR("failed to cleanup ZOMBIES dir: %d, will try again\n",
+			rc);
+	return 0;
+
+err_zombies:
+	D_FREE(zombies_path);
+err_newborns:
+	D_FREE(newborns_path);
+err:
+	return rc;
+}
+
+void
+ds_mgmt_tgt_cleanup(void)
+{
+	D_FREE(zombies_path);
+	D_FREE(newborns_path);
+}
+
+static int
+path_gen(const uuid_t pool_uuid, const char *dir, const char *fname, int *idx,
+	 char **fpath)
+{
+	int	 size;
+	int	 off;
+
+	/** *fpath = dir + "/" + pool_uuid + "/" + fname + idx */
+
+	/** DAOS_UUID_STR_SIZE includes the trailing '\0' */
+	size = strlen(dir) + 1 /* "/" */ + DAOS_UUID_STR_SIZE;
+	if (fname != NULL || idx != NULL)
+		size += 1 /* "/" */;
+	if (fname)
+		size += strlen(fname);
+	if (idx)
+		size += snprintf(NULL, 0, "%d", *idx);
+
+	D_ALLOC(*fpath, size);
+	if (*fpath == NULL)
+		return -DER_NOMEM;
+
+	off = sprintf(*fpath, "%s", dir);
+	off += sprintf(*fpath + off, "/");
+	uuid_unparse_lower(pool_uuid, *fpath + off);
+	off += DAOS_UUID_STR_SIZE - 1;
+	if (fname != NULL || idx != NULL)
+		off += sprintf(*fpath + off, "/");
+	if (fname)
+		off += sprintf(*fpath + off, "%s", fname);
+	if (idx)
+		sprintf(*fpath + off, "%d", *idx);
+
+	return 0;
+}
+
+/**
+ * Generate path to a target file for pool \a pool_uuid with a filename set to
+ * \a fname and suffixed by \a idx. \a idx can be NULL.
+ */
+int
+ds_mgmt_tgt_file(const uuid_t pool_uuid, const char *fname, int *idx,
+		 char **fpath)
+{
+	return path_gen(pool_uuid, dss_storage_path, fname, idx, fpath);
+}
+
+
 
 struct vos_pool_arg {
 	uuid_t		vpa_uuid;
@@ -615,19 +724,6 @@ free:
 out:
 	tc_out->tc_rc = rc;
 	crt_reply_send(tc_req);
-}
-
-int
-tgt_kill_pool(void *args)
-{
-	struct d_uuid	*id = args;
-
-	/* XXX: there are a few test cases that leak pool close
-	 * before destroying pool, we have to force the kill to pass
-	 * those tests, but we should try to disable "force" and
-	 * fix those issues in the future.
-	 */
-	return vos_pool_kill(id->uuid, true);
 }
 
 static int


### PR DESCRIPTION
With this change, on daos_io_server startup, any newborn pools in
the process of being created (but not fully created) during a previous
server run will have any SPDK blobs removed. Before this change,
only the pool folder in the SCM mountpoint newborns path was cleaned.
Depending on when the previous server run stopped, the possibility
exists that SPDK blobs created for this pool were left in NVMe storage.

Newborn pool cleanup also now is performed later in mgmt module setup
instead of init because SPDK blob cleanup is done as a per-target
xstream collective operation (xstreams need to be started first).

Signed-off-by: Ken Cain <kenneth.c.cain@intel.com>