### PR TITLE
DAOS-4062 build: Fixing Travis-CI pull access denied failures

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ berfore_install:
  - echo $DOCKER_IMAGE
  - git submodule init
  - git submodule update
- - docker pull $DOCKER_IMAGE
+ - docker pull ${DOCKER_IMAGE/./:}
 
 script:
  - docker build -f utils/docker/Dockerfile.$DOCKER_IMAGE -t daos/$DOCKER_IMAGE --build-arg NOBUILD=1 --build-arg UID=$UID .


### PR DESCRIPTION
Resolving travis CI failures reporting a 'pull access denied' failure
due to an incorrect name.  It appears the name now uses a colon instead
of a period to separate the name and version.

Skip-build: true
Skip-run_test: true
Skip-func-test: true
Skip-func-hw-test: true

Signed-off-by: Phillip Henderson <phillip.henderson@intel.com>