### PR TITLE
DAOS-2061 api: Add daos_cont_set_prop() to client API

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -400,6 +400,7 @@ pipeline {
                                                  build/src/common/tests/acl_util_tests,
                                                  build/src/common/tests/acl_principal_tests,
                                                  build/src/common/tests/acl_real_tests,
+                                                 build/src/common/tests/prop_tests,
                                                  build/src/iosrv/tests/drpc_progress_tests,
                                                  build/src/control/src/github.com/daos-stack/daos/src/control/mgmt,
                                                  build/src/client/api/tests/eq_tests,

--- a/src/client/api/container.c
+++ b/src/client/api/container.c
@@ -186,6 +186,30 @@ daos_cont_get_acl(daos_handle_t coh, daos_prop_t **acl_prop, daos_event_t *ev)
 }
 
 int
+daos_cont_set_prop(daos_handle_t coh, daos_prop_t *prop, daos_event_t *ev)
+{
+	daos_cont_set_prop_t	*args;
+	tse_task_t		*task;
+	int			 rc;
+
+	DAOS_API_ARG_ASSERT(*args, CONT_SET_PROP);
+	if (prop != NULL && !daos_prop_valid(prop, false, true)) {
+		D_ERROR("invalid prop parameter.\n");
+		return -DER_INVAL;
+	}
+
+	rc = dc_task_create(dc_cont_set_prop, NULL, ev, &task);
+	if (rc)
+		return rc;
+
+	args = dc_task_get_args(task);
+	args->coh	= coh;
+	args->prop	= prop;
+
+	return dc_task_schedule(task, true);
+}
+
+int
 daos_cont_aggregate(daos_handle_t coh, daos_epoch_t epoch, daos_event_t *ev)
 {
 	daos_cont_aggregate_t	*args;

--- a/src/client/api/init.c
+++ b/src/client/api/init.c
@@ -76,6 +76,7 @@ const struct daos_task_api dc_funcs[] = {
 	{dc_cont_close, sizeof(daos_cont_close_t)},
 	{dc_cont_destroy, sizeof(daos_cont_destroy_t)},
 	{dc_cont_query, sizeof(daos_cont_query_t)},
+	{dc_cont_set_prop, sizeof(daos_cont_set_prop_t)},
 	{dc_cont_aggregate, sizeof(daos_cont_aggregate_t)},
 	{dc_cont_rollback, sizeof(daos_cont_rollback_t)},
 	{dc_cont_subscribe, sizeof(daos_cont_subscribe_t)},

--- a/src/common/prop.c
+++ b/src/common/prop.c
@@ -57,6 +57,29 @@ daos_prop_alloc(uint32_t entries_nr)
 	return prop;
 }
 
+static void
+daos_prop_entry_free_value(struct daos_prop_entry *entry)
+{
+	switch (entry->dpe_type) {
+	case DAOS_PROP_PO_LABEL:
+	case DAOS_PROP_CO_LABEL:
+	case DAOS_PROP_PO_OWNER:
+	case DAOS_PROP_CO_OWNER:
+	case DAOS_PROP_PO_OWNER_GROUP:
+	case DAOS_PROP_CO_OWNER_GROUP:
+		if (entry->dpe_str)
+			D_FREE(entry->dpe_str);
+		break;
+	case DAOS_PROP_PO_ACL:
+	case DAOS_PROP_CO_ACL:
+		if (entry->dpe_val_ptr)
+			D_FREE(entry->dpe_val_ptr);
+		break;
+	default:
+		break;
+	};
+}
+
 void
 daos_prop_free(daos_prop_t *prop)
 {
@@ -73,28 +96,75 @@ daos_prop_free(daos_prop_t *prop)
 		struct daos_prop_entry *entry;
 
 		entry = &prop->dpp_entries[i];
-		switch (entry->dpe_type) {
-		case DAOS_PROP_PO_LABEL:
-		case DAOS_PROP_CO_LABEL:
-		case DAOS_PROP_PO_OWNER:
-		case DAOS_PROP_CO_OWNER:
-		case DAOS_PROP_PO_OWNER_GROUP:
-		case DAOS_PROP_CO_OWNER_GROUP:
-			if (entry->dpe_str)
-				D_FREE(entry->dpe_str);
-			break;
-		case DAOS_PROP_PO_ACL:
-		case DAOS_PROP_CO_ACL:
-			if (entry->dpe_val_ptr)
-				D_FREE(entry->dpe_val_ptr);
-			break;
-		default:
-			break;
-		};
+		daos_prop_entry_free_value(entry);
 	}
 
 	D_FREE(prop->dpp_entries);
 	D_FREE_PTR(prop);
+}
+
+daos_prop_t *
+daos_prop_merge(daos_prop_t* old_prop, daos_prop_t *new_prop)
+{
+	daos_prop_t		*result;
+	int			rc;
+	uint32_t		result_nr;
+	uint32_t		i, result_i;
+	struct daos_prop_entry	*entry;
+
+	if (old_prop == NULL || new_prop == NULL) {
+		D_ERROR("NULL input\n");
+		return NULL;
+	}
+
+	/*
+	 * We might override some values in the old prop. Need to account for
+	 * that in the final prop count.
+	 */
+	result_nr = old_prop->dpp_nr;
+	for (i = 0; i < new_prop->dpp_nr; i++) {
+		entry = daos_prop_entry_get(old_prop,
+					    new_prop->dpp_entries[i].dpe_type);
+		if (entry == NULL) /* New entry isn't a duplicate of old */
+			result_nr++;
+	}
+
+	result = daos_prop_alloc(result_nr);
+	if (result == NULL)
+		return NULL;
+
+	if (result->dpp_nr == 0) /* Nothing more to do */
+		return result;
+
+	result_i = 0;
+	for (i = 0; i < old_prop->dpp_nr; i++, result_i++) {
+		rc = daos_prop_entry_copy(&old_prop->dpp_entries[i],
+					  &result->dpp_entries[result_i]);
+		if (rc != 0)
+			goto err;
+	}
+
+	/*
+	 * Either add or update based on the values of the new prop entries
+	 */
+	for (i = 0; i < new_prop->dpp_nr; i++) {
+		entry = daos_prop_entry_get(result,
+					    new_prop->dpp_entries[i].dpe_type);
+		if (entry == NULL) {
+			D_ASSERT(result_i < result_nr);
+			entry = &result->dpp_entries[result_i];
+			result_i++;
+		}
+		daos_prop_entry_copy(&new_prop->dpp_entries[i], entry);
+		if (rc != 0)
+			goto err;
+	}
+
+	return result;
+
+err:
+	daos_prop_free(result);
+	return NULL;
 }
 
 static bool
@@ -302,6 +372,57 @@ daos_prop_valid(daos_prop_t *prop, bool pool, bool input)
 	return true;
 }
 
+int
+daos_prop_entry_copy(struct daos_prop_entry *entry,
+		     struct daos_prop_entry *entry_dup)
+{
+	struct daos_acl		*acl_ptr;
+
+	D_ASSERT(entry != NULL);
+	D_ASSERT(entry_dup != NULL);
+
+	/* Clean up the entry we're copying to, first */
+	daos_prop_entry_free_value(entry_dup);
+
+	entry_dup->dpe_type = entry->dpe_type;
+	switch (entry->dpe_type) {
+	case DAOS_PROP_PO_LABEL:
+	case DAOS_PROP_CO_LABEL:
+		D_STRNDUP(entry_dup->dpe_str, entry->dpe_str,
+			  DAOS_PROP_LABEL_MAX_LEN);
+		if (entry_dup->dpe_str == NULL) {
+			D_ERROR("failed to dup label.\n");
+			return -DER_NOMEM;
+		}
+		break;
+	case DAOS_PROP_PO_ACL:
+	case DAOS_PROP_CO_ACL:
+		acl_ptr = entry->dpe_val_ptr;
+		entry_dup->dpe_val_ptr = daos_acl_dup(acl_ptr);
+		if (entry_dup->dpe_val_ptr == NULL) {
+			D_ERROR("failed to dup ACL\n");
+			return -DER_NOMEM;
+		}
+		break;
+	case DAOS_PROP_PO_OWNER:
+	case DAOS_PROP_CO_OWNER:
+	case DAOS_PROP_PO_OWNER_GROUP:
+	case DAOS_PROP_CO_OWNER_GROUP:
+		D_STRNDUP(entry_dup->dpe_str, entry->dpe_str,
+			  DAOS_ACL_MAX_PRINCIPAL_LEN);
+		if (entry_dup->dpe_str == NULL) {
+			D_ERROR("failed to dup ownership info.\n");
+			return -DER_NOMEM;
+		}
+		break;
+	default:
+		entry_dup->dpe_val = entry->dpe_val;
+		break;
+	}
+
+	return 0;
+}
+
 /**
  * duplicate the properties
  * \a pool true for pool properties, false for container properties.
@@ -312,7 +433,7 @@ daos_prop_dup(daos_prop_t *prop, bool pool)
 	daos_prop_t		*prop_dup;
 	struct daos_prop_entry	*entry, *entry_dup;
 	int			 i;
-	struct daos_acl		*acl_ptr;
+	int			 rc;
 
 	if (!daos_prop_valid(prop, pool, true))
 		return NULL;
@@ -324,43 +445,10 @@ daos_prop_dup(daos_prop_t *prop, bool pool)
 	for (i = 0; i < prop->dpp_nr; i++) {
 		entry = &prop->dpp_entries[i];
 		entry_dup = &prop_dup->dpp_entries[i];
-		entry_dup->dpe_type = entry->dpe_type;
-		switch (entry->dpe_type) {
-		case DAOS_PROP_PO_LABEL:
-		case DAOS_PROP_CO_LABEL:
-			D_STRNDUP(entry_dup->dpe_str, entry->dpe_str,
-				  DAOS_PROP_LABEL_MAX_LEN);
-			if (entry_dup->dpe_str == NULL) {
-				D_ERROR("failed to dup label.\n");
-				daos_prop_free(prop_dup);
-				return NULL;
-			}
-			break;
-		case DAOS_PROP_PO_ACL:
-		case DAOS_PROP_CO_ACL:
-			acl_ptr = entry->dpe_val_ptr;
-			entry_dup->dpe_val_ptr = daos_acl_dup(acl_ptr);
-			if (entry_dup->dpe_val_ptr == NULL) {
-				D_ERROR("failed to dup ACL\n");
-				daos_prop_free(prop_dup);
-				return NULL;
-			}
-			break;
-		case DAOS_PROP_PO_OWNER:
-		case DAOS_PROP_CO_OWNER:
-		case DAOS_PROP_PO_OWNER_GROUP:
-		case DAOS_PROP_CO_OWNER_GROUP:
-			D_STRNDUP(entry_dup->dpe_str, entry->dpe_str,
-				  DAOS_ACL_MAX_PRINCIPAL_LEN);
-			if (entry_dup->dpe_str == NULL) {
-				D_ERROR("failed to dup ownership info.\n");
-				daos_prop_free(prop_dup);
-				return NULL;
-			}
-			break;
-		default:
-			entry_dup->dpe_val = entry->dpe_val;
-			break;
+		rc = daos_prop_entry_copy(entry, entry_dup);
+		if (rc != 0) {
+			daos_prop_free(prop_dup);
+			return NULL;
 		}
 	}
 

--- a/src/common/prop.c
+++ b/src/common/prop.c
@@ -104,7 +104,7 @@ daos_prop_free(daos_prop_t *prop)
 }
 
 daos_prop_t *
-daos_prop_merge(daos_prop_t* old_prop, daos_prop_t *new_prop)
+daos_prop_merge(daos_prop_t *old_prop, daos_prop_t *new_prop)
 {
 	daos_prop_t		*result;
 	int			rc;

--- a/src/common/tests/SConscript
+++ b/src/common/tests/SConscript
@@ -65,6 +65,8 @@ def scons():
                     LIBS=['daos_common', 'gurt', 'abt'])
     daos_build.test(tenv, 'acl_real_tests', 'acl_util_real_tests.c',
                     LIBS=['daos_common', 'gurt', 'cmocka'])
+    daos_build.test(tenv, 'prop_tests', 'prop_tests.c',
+                    LIBS=['daos_common', 'gurt', 'cmocka'])
     define_checksum_timing(daos_build, tenv, prereqs)
 
     unit_env = tenv.Clone()

--- a/src/common/tests/prop_tests.c
+++ b/src/common/tests/prop_tests.c
@@ -1,0 +1,293 @@
+/*
+ * (C) Copyright 2020 Intel Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * GOVERNMENT LICENSE RIGHTS-OPEN SOURCE SOFTWARE
+ * The Government's rights to use, modify, reproduce, release, perform, display,
+ * or disclose this software are subject to the terms of the Apache License as
+ * provided in Contract No. 8F-30005.
+ * Any reproduction of computer software, computer software documentation, or
+ * portions thereof marked with this legend must also reproduce the markings.
+ */
+
+/**
+ * Unit tests for the DAOS property API
+ */
+
+#include <stdarg.h>
+#include <stdlib.h>
+#include <setjmp.h>
+#include <cmocka.h>
+
+#include <daos_prop.h>
+#include <daos/common.h>
+
+static void
+test_daos_prop_merge_null(void **state)
+{
+	daos_prop_t	*prop;
+
+	prop = daos_prop_alloc(0);
+
+	assert_null(daos_prop_merge(prop, NULL));
+	assert_null(daos_prop_merge(NULL, prop));
+
+	daos_prop_free(prop);
+}
+
+static void
+expect_merge_result(daos_prop_t *old, daos_prop_t *new, daos_prop_t *exp_result)
+{
+	daos_prop_t		*result;
+	struct daos_prop_entry	*entry;
+	struct daos_prop_entry	*exp_entry;
+	uint32_t		i;
+
+	result = daos_prop_merge(old, new);
+	assert_non_null(result);
+	assert_int_equal(result->dpp_nr, exp_result->dpp_nr);
+	for (i = 0; i < exp_result->dpp_nr; i++) {
+		/*
+		 * This check is agnostic to the order of the properties.
+		 */
+		exp_entry = &exp_result->dpp_entries[i];
+		printf("- Checking for property type %u\n",
+		       exp_entry->dpe_type);
+		entry = daos_prop_entry_get(result, exp_entry->dpe_type);
+		assert_non_null(entry);
+
+		switch (entry->dpe_type) {
+		case DAOS_PROP_PO_LABEL:
+		case DAOS_PROP_CO_LABEL:
+		case DAOS_PROP_PO_OWNER:
+		case DAOS_PROP_CO_OWNER:
+		case DAOS_PROP_PO_OWNER_GROUP:
+		case DAOS_PROP_CO_OWNER_GROUP:
+			assert_string_equal(entry->dpe_str, exp_entry->dpe_str);
+			break;
+		case DAOS_PROP_PO_ACL:
+		case DAOS_PROP_CO_ACL:
+			assert_int_equal(daos_prop_entry_cmp_acl(entry,
+								 exp_entry),
+					 0);
+			break;
+		default:
+			assert_int_equal(entry->dpe_val, exp_entry->dpe_val);
+			break;
+		};
+	}
+
+	daos_prop_free(result);
+}
+
+static void
+test_daos_prop_merge_empty(void **state)
+{
+	daos_prop_t	*prop_empty;
+	daos_prop_t	*prop;
+
+	prop_empty = daos_prop_alloc(0);
+	prop = daos_prop_alloc(2);
+	prop->dpp_entries[0].dpe_type = DAOS_PROP_PO_LABEL;
+	D_STRNDUP(prop->dpp_entries[0].dpe_str, "Test",
+		  DAOS_PROP_LABEL_MAX_LEN);
+	prop->dpp_entries[1].dpe_type = DAOS_PROP_PO_RECLAIM;
+	prop->dpp_entries[1].dpe_val = DAOS_RECLAIM_LAZY;
+
+	printf("Case: Two empty props\n");
+	expect_merge_result(prop_empty, prop_empty, prop_empty);
+
+	printf("Case: Add empty to non-empty\n");
+	expect_merge_result(prop, prop_empty, prop);
+
+	printf("Case: Add non-empty to empty\n");
+	expect_merge_result(prop_empty, prop, prop);
+
+	daos_prop_free(prop_empty);
+	daos_prop_free(prop);
+}
+
+static void
+test_daos_prop_merge_add_only(void **state)
+{
+	daos_prop_t	*prop1;
+	daos_prop_t	*prop2;
+	uint32_t	exp_nr, i, result_i;
+	daos_prop_t	*exp_result;
+
+	prop1 = daos_prop_alloc(2);
+	prop1->dpp_entries[0].dpe_type = DAOS_PROP_CO_LABEL;
+	D_STRNDUP(prop1->dpp_entries[0].dpe_str, "Test",
+		  DAOS_PROP_LABEL_MAX_LEN);
+	prop1->dpp_entries[1].dpe_type = DAOS_PROP_CO_COMPRESS;
+	prop1->dpp_entries[1].dpe_val = 1;
+
+	prop2 = daos_prop_alloc(3);
+	prop2->dpp_entries[0].dpe_type = DAOS_PROP_CO_OWNER;
+	D_STRNDUP(prop2->dpp_entries[0].dpe_str, "test@",
+		  DAOS_ACL_MAX_PRINCIPAL_LEN);
+	prop2->dpp_entries[1].dpe_type = DAOS_PROP_CO_CSUM;
+	prop2->dpp_entries[1].dpe_val = DAOS_PROP_CO_CSUM_CRC32;
+	prop2->dpp_entries[2].dpe_type = DAOS_PROP_CO_ENCRYPT;
+	prop2->dpp_entries[2].dpe_val = 1;
+
+	/* Should be set of all the prop entries, no conflicts */
+	exp_nr = prop1->dpp_nr + prop2->dpp_nr;
+	exp_result = daos_prop_alloc(exp_nr);
+	result_i = 0;
+	for (i = 0; i < prop1->dpp_nr; i++, result_i++)
+		daos_prop_entry_copy(&prop1->dpp_entries[i],
+				     &exp_result->dpp_entries[result_i]);
+	for (i = 0; i < prop2->dpp_nr; i++, result_i++)
+		daos_prop_entry_copy(&prop2->dpp_entries[i],
+				     &exp_result->dpp_entries[result_i]);
+
+	expect_merge_result(prop1, prop2, exp_result);
+
+	daos_prop_free(prop1);
+	daos_prop_free(prop2);
+	daos_prop_free(exp_result);
+}
+
+static void
+test_daos_prop_merge_total_update(void **state)
+{
+	daos_prop_t	*prop1;
+	daos_prop_t	*prop2;
+
+	prop1 = daos_prop_alloc(2);
+	prop1->dpp_entries[0].dpe_type = DAOS_PROP_CO_LABEL;
+	D_STRNDUP(prop1->dpp_entries[0].dpe_str, "Test",
+		  DAOS_PROP_LABEL_MAX_LEN);
+	prop1->dpp_entries[1].dpe_type = DAOS_PROP_CO_COMPRESS;
+	prop1->dpp_entries[1].dpe_val = 1;
+
+	prop2 = daos_prop_alloc(2);
+	prop2->dpp_entries[0].dpe_type = DAOS_PROP_CO_LABEL;
+	D_STRNDUP(prop2->dpp_entries[0].dpe_str, "Updated",
+		  DAOS_PROP_LABEL_MAX_LEN);
+	prop2->dpp_entries[1].dpe_type = DAOS_PROP_CO_COMPRESS;
+	prop2->dpp_entries[1].dpe_val = 0;
+
+	/* Expecting all props to be overwritten */
+	expect_merge_result(prop1, prop2, prop2);
+
+	daos_prop_free(prop1);
+	daos_prop_free(prop2);
+}
+
+static void
+test_daos_prop_merge_subset_update(void **state)
+{
+	daos_prop_t		*prop1;
+	daos_prop_t		*prop2;
+	daos_prop_t		*exp_result;
+	struct daos_prop_entry	*entry;
+
+	prop1 = daos_prop_alloc(2);
+	prop1->dpp_entries[0].dpe_type = DAOS_PROP_CO_LABEL;
+	D_STRNDUP(prop1->dpp_entries[0].dpe_str, "Test",
+		  DAOS_PROP_LABEL_MAX_LEN);
+	prop1->dpp_entries[1].dpe_type = DAOS_PROP_CO_COMPRESS;
+	prop1->dpp_entries[1].dpe_val = 1;
+
+	prop2 = daos_prop_alloc(1);
+	prop2->dpp_entries[0].dpe_type = DAOS_PROP_CO_LABEL;
+	D_STRNDUP(prop2->dpp_entries[0].dpe_str, "Updated",
+		  DAOS_PROP_LABEL_MAX_LEN);
+
+	/* Expecting only one prop to be overwritten */
+	exp_result = daos_prop_dup(prop1, false);
+	entry = daos_prop_entry_get(exp_result, prop2->dpp_entries[0].dpe_type);
+	assert_int_equal(daos_prop_entry_copy(&prop2->dpp_entries[0], entry),
+			 0);
+
+	expect_merge_result(prop1, prop2, exp_result);
+
+	daos_prop_free(prop1);
+	daos_prop_free(prop2);
+	daos_prop_free(exp_result);
+}
+
+static void
+test_daos_prop_merge_add_and_update(void **state)
+{
+	daos_prop_t		*prop1;
+	daos_prop_t		*prop2;
+	uint32_t		exp_nr;
+	uint32_t		i, result_i;
+	uint32_t		new_idx, dup_idx;
+	daos_prop_t		*exp_result;
+	struct daos_prop_entry	*entry;
+
+	prop1 = daos_prop_alloc(2);
+	prop1->dpp_entries[0].dpe_type = DAOS_PROP_CO_LABEL;
+	D_STRNDUP(prop1->dpp_entries[0].dpe_str, "Test",
+		  DAOS_PROP_LABEL_MAX_LEN);
+	prop1->dpp_entries[1].dpe_type = DAOS_PROP_CO_COMPRESS;
+	prop1->dpp_entries[1].dpe_val = 1;
+
+	prop2 = daos_prop_alloc(2);
+	dup_idx = 0; /* duplicate type to what's in prop1 */
+	prop2->dpp_entries[dup_idx].dpe_type = DAOS_PROP_CO_LABEL;
+	D_STRNDUP(prop2->dpp_entries[dup_idx].dpe_str, "Updated",
+		  DAOS_PROP_LABEL_MAX_LEN);
+	new_idx = 1; /* type that isn't in prop1 */
+	prop2->dpp_entries[1].dpe_type = DAOS_PROP_CO_CSUM;
+	prop2->dpp_entries[1].dpe_val = DAOS_PROP_CO_CSUM_CRC32;
+
+	/* Expecting duplicate prop to be overwritten, and new to be added */
+	exp_nr = prop1->dpp_nr + prop2->dpp_nr - 1;
+	exp_result = daos_prop_alloc(exp_nr);
+	result_i = 0;
+	for (i = 0; i < prop1->dpp_nr; i++, result_i++) {
+		entry = &exp_result->dpp_entries[result_i];
+		assert_int_equal(daos_prop_entry_copy(&prop1->dpp_entries[i],
+						      entry), 0);
+	}
+
+	entry = &exp_result->dpp_entries[result_i];
+	assert_int_equal(daos_prop_entry_copy(&prop2->dpp_entries[new_idx],
+					      entry), 0);
+	result_i++;
+	assert_int_equal(result_i, exp_nr);
+
+	/* Overwrite the entry prop2 is duplicating */
+	entry = daos_prop_entry_get(exp_result,
+				    prop2->dpp_entries[dup_idx].dpe_type);
+	assert_int_equal(daos_prop_entry_copy(&prop2->dpp_entries[dup_idx],
+					      entry),
+			 0);
+
+	expect_merge_result(prop1, prop2, exp_result);
+
+	daos_prop_free(prop1);
+	daos_prop_free(prop2);
+	daos_prop_free(exp_result);
+}
+
+int
+main(void)
+{
+	const struct CMUnitTest tests[] = {
+		cmocka_unit_test(test_daos_prop_merge_null),
+		cmocka_unit_test(test_daos_prop_merge_empty),
+		cmocka_unit_test(test_daos_prop_merge_add_only),
+		cmocka_unit_test(test_daos_prop_merge_total_update),
+		cmocka_unit_test(test_daos_prop_merge_subset_update),
+		cmocka_unit_test(test_daos_prop_merge_add_and_update),
+	};
+
+	return cmocka_run_group_tests(tests, NULL, NULL);
+}

--- a/src/container/cli.c
+++ b/src/container/cli.c
@@ -973,6 +973,124 @@ err:
 	return rc;
 }
 
+struct cont_set_prop_args {
+	struct dc_pool		*cqa_pool;
+	struct dc_cont		*cqa_cont;
+	crt_rpc_t		*rpc;
+	daos_handle_t		hdl;
+};
+
+static int
+cont_set_prop_complete(tse_task_t *task, void *data)
+{
+	struct cont_set_prop_args	*arg = (struct cont_set_prop_args *)
+						data;
+	struct cont_prop_set_out	*out = crt_reply_get(arg->rpc);
+	struct dc_pool			*pool = arg->cqa_pool;
+	struct dc_cont			*cont = arg->cqa_cont;
+	int				 rc   = task->dt_result;
+
+	rc = cont_rsvc_client_complete_rpc(pool, &arg->rpc->cr_ep, rc,
+					   &out->cpso_op, task);
+	if (rc < 0)
+		D_GOTO(out, rc);
+	else if (rc == RSVC_CLIENT_RECHOOSE)
+		D_GOTO(out, rc = 0);
+
+	if (rc != 0) {
+		D_ERROR("RPC error while setting prop on container: "DF_RC"\n",
+			DP_RC(rc));
+		D_GOTO(out, rc);
+	}
+
+	rc = out->cpso_op.co_rc;
+
+	if (rc != 0) {
+		D_DEBUG(DF_DSMC, DF_CONT": failed to set prop on container: "
+			"%d\n",
+			DP_CONT(pool->dp_pool, cont->dc_uuid), rc);
+		D_GOTO(out, rc);
+	}
+
+	D_DEBUG(DF_DSMC, DF_CONT": Set prop: using hdl="DF_UUID"\n",
+		DP_CONT(pool->dp_pool, cont->dc_uuid),
+		DP_UUID(cont->dc_cont_hdl));
+
+out:
+	crt_req_decref(arg->rpc);
+	dc_cont_put(cont);
+	dc_pool_put(pool);
+	return rc;
+}
+
+int
+dc_cont_set_prop(tse_task_t *task)
+{
+	daos_cont_set_prop_t		*args;
+	struct cont_prop_set_in		*in;
+	struct dc_pool			*pool;
+	struct dc_cont			*cont;
+	crt_endpoint_t			 ep;
+	crt_rpc_t			*rpc;
+	struct cont_set_prop_args	 arg;
+	int				 rc;
+
+	args = dc_task_get_args(task);
+	D_ASSERTF(args != NULL, "Task Argument OPC does not match DC OPC\n");
+
+	cont = dc_hdl2cont(args->coh);
+	if (cont == NULL)
+		D_GOTO(err, rc = -DER_NO_HDL);
+
+	pool = dc_hdl2pool(cont->dc_pool_hdl);
+	D_ASSERT(pool != NULL);
+
+	D_DEBUG(DF_DSMC, DF_CONT": setting props: hdl="DF_UUID"\n",
+		DP_CONT(pool->dp_pool_hdl, cont->dc_uuid),
+		DP_UUID(cont->dc_cont_hdl));
+
+	ep.ep_grp  = pool->dp_sys->sy_group;
+	D_MUTEX_LOCK(&pool->dp_client_lock);
+	rsvc_client_choose(&pool->dp_client, &ep);
+	D_MUTEX_UNLOCK(&pool->dp_client_lock);
+	rc = cont_req_create(daos_task2ctx(task), &ep, CONT_PROP_SET, &rpc);
+	if (rc != 0) {
+		D_ERROR("failed to create rpc: "DF_RC"\n", DP_RC(rc));
+		D_GOTO(err_cont, rc);
+	}
+
+	in = crt_req_get(rpc);
+	uuid_copy(in->cpsi_op.ci_pool_hdl, pool->dp_pool_hdl);
+	uuid_copy(in->cpsi_op.ci_uuid, cont->dc_uuid);
+	uuid_copy(in->cpsi_op.ci_hdl, cont->dc_cont_hdl);
+	in->cpsi_prop = args->prop;
+
+	arg.cqa_pool = pool;
+	arg.cqa_cont = cont;
+	arg.rpc	     = rpc;
+	arg.hdl	     = args->coh;
+	crt_req_addref(rpc);
+
+	rc = tse_task_register_comp_cb(task, cont_set_prop_complete, &arg,
+				       sizeof(arg));
+	if (rc != 0)
+		D_GOTO(err_rpc, rc);
+
+	return daos_rpc_send(rpc, task);
+
+err_rpc:
+	crt_req_decref(rpc);
+	crt_req_decref(rpc);
+err_cont:
+	dc_cont_put(cont);
+	dc_pool_put(pool);
+err:
+	tse_task_complete(task, rc);
+	D_DEBUG(DF_DSMC, "Failed to set prop on container: "DF_RC"\n",
+		DP_RC(rc));
+	return rc;
+}
+
 struct cont_oid_alloc_args {
 	struct dc_pool		*coaa_pool;
 	struct dc_cont		*coaa_cont;

--- a/src/container/rpc.c
+++ b/src/container/rpc.c
@@ -109,6 +109,7 @@ CRT_RPC_DEFINE(cont_tgt_epoch_aggregate, DAOS_ISEQ_CONT_TGT_EPOCH_AGGREGATE,
 		DAOS_OSEQ_CONT_TGT_EPOCH_AGGREGATE)
 CRT_RPC_DEFINE(cont_tgt_snapshot_notify, DAOS_ISEQ_CONT_TGT_SNAPSHOT_NOTIFY,
 		DAOS_OSEQ_CONT_TGT_SNAPSHOT_NOTIFY)
+CRT_RPC_DEFINE(cont_prop_set, DAOS_ISEQ_CONT_PROP_SET, DAOS_OSEQ_CONT_PROP_SET)
 
 /* Define for cont_rpcs[] array population below.
  * See CONT_PROTO_*_RPC_LIST macro definition

--- a/src/container/rpc.h
+++ b/src/container/rpc.h
@@ -87,6 +87,9 @@
 		ds_cont_op_handler, NULL),				\
 	X(CONT_SNAP_DESTROY,						\
 		0, &CQF_cont_snap_destroy,				\
+		ds_cont_op_handler, NULL),				\
+	X(CONT_PROP_SET,						\
+		0, &CQF_cont_prop_set,					\
 		ds_cont_op_handler, NULL)
 
 #define CONT_PROTO_SRV_RPC_LIST						\
@@ -357,6 +360,15 @@ CRT_RPC_DECLARE(cont_tgt_epoch_aggregate, DAOS_ISEQ_CONT_TGT_EPOCH_AGGREGATE,
 
 CRT_RPC_DECLARE(cont_tgt_snapshot_notify, DAOS_ISEQ_CONT_TGT_SNAPSHOT_NOTIFY,
 		DAOS_OSEQ_CONT_TGT_SNAPSHOT_NOTIFY)
+
+#define DAOS_ISEQ_CONT_PROP_SET	/* input fields */		 \
+	((struct cont_op_in)	(cpsi_op)		CRT_VAR) \
+	((daos_prop_t)		(cpsi_prop)		CRT_PTR)
+
+#define DAOS_OSEQ_CONT_PROP_SET	/* output fields */		 \
+	((struct cont_op_out)	(cpso_op)		CRT_VAR)
+
+CRT_RPC_DECLARE(cont_prop_set, DAOS_ISEQ_CONT_PROP_SET, DAOS_OSEQ_CONT_PROP_SET)
 
 static inline int
 cont_req_create(crt_context_t crt_ctx, crt_endpoint_t *tgt_ep, crt_opcode_t opc,

--- a/src/container/srv_container.c
+++ b/src/container/srv_container.c
@@ -1468,6 +1468,59 @@ cont_query(struct rdb_tx *tx, struct ds_pool_hdl *pool_hdl, struct cont *cont,
 	return rc;
 }
 
+int
+ds_cont_prop_set(struct rdb_tx *tx, struct ds_pool_hdl *pool_hdl,
+		 struct cont *cont, struct container_hdl *hdl,
+		 crt_rpc_t *rpc)
+{
+	struct cont_prop_set_in		*in  = crt_req_get(rpc);
+	daos_prop_t			*prop_in = in->cpsi_prop;
+	daos_prop_t			*prop_out = NULL;
+	int				rc = 0;
+
+	D_DEBUG(DF_DSMS, DF_CONT": processing rpc %p: hdl="DF_UUID"\n",
+		DP_CONT(pool_hdl->sph_pool->sp_uuid, in->cpsi_op.ci_uuid), rpc,
+		DP_UUID(in->cpsi_op.ci_hdl));
+
+	if (!daos_prop_valid(prop_in, false, true))
+		D_GOTO(out, rc = -DER_INVAL);
+
+	/*
+	 * Can't modify the container props without RW perms to the container.
+	 * TODO DAOS-2063: Update check when set-prop and set-acl capas added.
+	 */
+	if (!(hdl->ch_capas & DAOS_COO_RW))
+		D_GOTO(out, rc = -DER_NO_PERM);
+
+	rc = cont_prop_write(tx, &cont->c_prop, prop_in);
+	if (rc != 0)
+		D_GOTO(out, rc);
+
+	rc = rdb_tx_commit(tx);
+	if (rc != 0)
+		D_GOTO(out, rc);
+
+	/* Read all props & update prop IV */
+	rc = cont_prop_read(tx, cont, DAOS_CO_QUERY_PROP_ALL, &prop_out);
+	if (rc != 0) {
+		D_ERROR(DF_UUID": failed to read prop for cont, rc=%d\n",
+			DP_UUID(cont->c_uuid), rc);
+		D_GOTO(out, rc);
+	}
+	D_ASSERT(prop_out != NULL);
+
+	rc = cont_iv_prop_update(pool_hdl->sph_pool->sp_iv_ns,
+				 in->cpsi_op.ci_hdl, cont->c_uuid, prop_out);
+	if (rc)
+		D_ERROR(DF_UUID": failed to update prop IV for cont, "
+			"%d.\n", DP_UUID(cont->c_uuid), rc);
+
+	daos_prop_free(prop_out);
+
+out:
+	return rc;
+}
+
 static int
 cont_attr_set(struct rdb_tx *tx, struct ds_pool_hdl *pool_hdl,
 	      struct cont *cont, struct container_hdl *hdl, crt_rpc_t *rpc)
@@ -1788,6 +1841,8 @@ cont_op_with_hdl(struct rdb_tx *tx, struct ds_pool_hdl *pool_hdl,
 		return ds_cont_snap_create(tx, pool_hdl, cont, hdl, rpc);
 	case CONT_SNAP_DESTROY:
 		return ds_cont_snap_destroy(tx, pool_hdl, cont, hdl, rpc);
+	case CONT_PROP_SET:
+		return ds_cont_prop_set(tx, pool_hdl, cont, hdl, rpc);
 	default:
 		D_ASSERT(0);
 	}

--- a/src/container/srv_internal.h
+++ b/src/container/srv_internal.h
@@ -153,6 +153,9 @@ int cont_svc_lookup_leader(uuid_t pool_uuid, uint64_t id,
 int cont_lookup(struct rdb_tx *tx, const struct cont_svc *svc,
 		const uuid_t uuid, struct cont **cont);
 void cont_svc_put_leader(struct cont_svc *svc);
+int ds_cont_prop_set(struct rdb_tx *tx, struct ds_pool_hdl *pool_hdl,
+		     struct cont *cont, struct container_hdl *hdl,
+		     crt_rpc_t *rpc);
 
 /*
  * srv_epoch.c

--- a/src/include/daos/common.h
+++ b/src/include/daos/common.h
@@ -645,6 +645,8 @@ bool daos_prop_valid(daos_prop_t *prop, bool pool, bool input);
 daos_prop_t *daos_prop_dup(daos_prop_t *prop, bool pool);
 struct daos_prop_entry *daos_prop_entry_get(daos_prop_t *prop, uint32_t type);
 int daos_prop_copy(daos_prop_t *prop_req, daos_prop_t *prop_reply);
+int daos_prop_entry_copy(struct daos_prop_entry *entry,
+			 struct daos_prop_entry *entry_dup);
 
 static inline void
 daos_parse_ctype(const char *string, daos_cont_layout_t *type)

--- a/src/include/daos/container.h
+++ b/src/include/daos/container.h
@@ -60,6 +60,7 @@ int dc_cont_open(tse_task_t *task);
 int dc_cont_close(tse_task_t *task);
 int dc_cont_destroy(tse_task_t *task);
 int dc_cont_query(tse_task_t *task);
+int dc_cont_set_prop(tse_task_t *task);
 int dc_cont_aggregate(tse_task_t *task);
 int dc_cont_rollback(tse_task_t *task);
 int dc_cont_subscribe(tse_task_t *task);

--- a/src/include/daos_cont.h
+++ b/src/include/daos_cont.h
@@ -280,6 +280,24 @@ daos_cont_query(daos_handle_t container, daos_cont_info_t *info,
 int
 daos_cont_get_acl(daos_handle_t container, daos_prop_t **acl_prop,
 		  daos_event_t *ev);
+/**
+ * Sets the container properties.
+ *
+ * \param[in]	coh	Container handle
+ * \param[in]	prop	Property entries to update
+ * \param[in]	ev	Completion event, it is optional and can be NULL.
+ *			The function will run in blocking mode if \a ev is NULL.
+ *
+ * \return		These values will be returned by \a ev::ev_error in
+ *			non-blocking mode:
+ *			0		Success
+ *			-DER_INVAL	Invalid parameter
+ *			-DER_NO_PERM	Permission denied
+ *			-DER_UNREACH	Network is unreachable
+ *			-DER_NO_HDL	Invalid container handle
+ */
+int
+daos_cont_set_prop(daos_handle_t coh, daos_prop_t *prop, daos_event_t *ev);
 
 /**
  * List the names of all user-defined container attributes.

--- a/src/include/daos_prop.h
+++ b/src/include/daos_prop.h
@@ -274,6 +274,17 @@ void
 daos_prop_free(daos_prop_t *prop);
 
 /**
+ * Merge a set of new DAOS properties into a set of existing DAOS properties.
+ *
+ * \param[in]	old_prop	Existing set of properties
+ * \param[in]	new_prop	New properties - may override old entries
+ *
+ * \return	Newly allocated merged property
+ */
+daos_prop_t *
+daos_prop_merge(daos_prop_t* old_prop, daos_prop_t *new_prop);
+
+/**
  * Duplicate a generic pointer value from one DAOS prop entry to another.
  * Convenience function.
  *

--- a/src/include/daos_prop.h
+++ b/src/include/daos_prop.h
@@ -282,7 +282,7 @@ daos_prop_free(daos_prop_t *prop);
  * \return	Newly allocated merged property
  */
 daos_prop_t *
-daos_prop_merge(daos_prop_t* old_prop, daos_prop_t *new_prop);
+daos_prop_merge(daos_prop_t *old_prop, daos_prop_t *new_prop);
 
 /**
  * Duplicate a generic pointer value from one DAOS prop entry to another.

--- a/src/include/daos_task.h
+++ b/src/include/daos_task.h
@@ -77,6 +77,7 @@ typedef enum {
 	DAOS_OPC_CONT_CLOSE,
 	DAOS_OPC_CONT_DESTROY,
 	DAOS_OPC_CONT_QUERY,
+	DAOS_OPC_CONT_SET_PROP,
 	DAOS_OPC_CONT_AGGREGATE,
 	DAOS_OPC_CONT_ROLLBACK,
 	DAOS_OPC_CONT_SUBSCRIBE,
@@ -291,6 +292,11 @@ typedef struct {
 	daos_cont_info_t	*info;
 	daos_prop_t		*prop;
 } daos_cont_query_t;
+
+typedef struct {
+	daos_handle_t		coh;
+	daos_prop_t		*prop;
+} daos_cont_set_prop_t;
 
 typedef struct {
 	daos_handle_t		coh;

--- a/src/tests/suite/daos_container.c
+++ b/src/tests/suite/daos_container.c
@@ -605,6 +605,7 @@ co_set_prop(void **state)
 	prop_out = daos_prop_alloc(0);
 	assert_non_null(prop_out);
 	rc = daos_cont_query(arg->coh, NULL, prop_out, NULL);
+	assert_int_equal(rc, 0);
 
 	assert_non_null(prop_out->dpp_entries);
 	assert_true(prop_out->dpp_nr >= prop_in->dpp_nr);

--- a/utils/run_test.sh
+++ b/utils/run_test.sh
@@ -112,6 +112,7 @@ if [ -d "/mnt/daos" ]; then
     run_test build/src/common/tests/acl_util_tests
     run_test build/src/common/tests/acl_principal_tests
     run_test build/src/common/tests/acl_real_tests
+    run_test build/src/common/tests/prop_tests
     run_test build/src/iosrv/tests/drpc_progress_tests
     run_test build/src/iosrv/tests/drpc_handler_tests
     run_test build/src/iosrv/tests/drpc_listener_tests


### PR DESCRIPTION
The caller must have a container handle with RW capabilities
to set the container properties.

Signed-off-by: Kris Jacque <kristin.jacque@intel.com>