### PR TITLE
DAOS-3999 object: do not retry pool refresh

### DIFF
--- a/src/object/cli_obj.c
+++ b/src/object/cli_obj.c
@@ -1176,7 +1176,7 @@ dc_obj_layout_refresh(daos_handle_t oh)
 
 static int
 obj_retry_cb(tse_task_t *task, struct dc_object *obj,
-	     struct obj_auxi_args *obj_auxi)
+	     struct obj_auxi_args *obj_auxi, bool pmap_stale)
 {
 	tse_sched_t	 *sched = tse_task2sched(task);
 	tse_task_t	 *pool_task = NULL;
@@ -1184,19 +1184,7 @@ obj_retry_cb(tse_task_t *task, struct dc_object *obj,
 	int		  rc;
 	bool		  keep_result = false;
 
-	/* For the case of retry with leader, if it is for modification,
-	 * since we always send modification RPC to the leader, then no
-	 * need to refresh the pool map. Because if the client used old
-	 * pool map and sent the modification RPC to non-leader replica,
-	 * then the replied errno will be -DER_STALE (assume that there
-	 * will be at least one replica will have the latest pool map).
-	 *
-	 * For read-only RPC (fetch/list/query), retry with leader case
-	 * only can happen when the server to which we just sent the RPC
-	 * is not the leader. To guarantee the next retry can find the
-	 * right leader, we need to refresh the pool map before retry.
-	 */
-	if (!obj_auxi->to_leader || !obj_is_modification_opc(obj_auxi->opc)) {
+	if (pmap_stale) {
 		rc = obj_pool_query_task(sched, obj, &pool_task);
 		if (rc != 0)
 			D_GOTO(err, rc);
@@ -2259,11 +2247,17 @@ obj_comp_cb(tse_task_t *task, void *data)
 		daos_gettime_coarse(&obj->cob_time_fetch_leader[idx]);
 	}
 
-	if (obj_auxi->map_ver_reply > obj_auxi->map_ver_req) {
-		D_DEBUG(DB_IO, "map_ver stale (req %d, reply %d).\n",
-			obj_auxi->map_ver_req, obj_auxi->map_ver_reply);
+	/* Check if the pool map needs to refresh */
+	if (obj_auxi->map_ver_reply > obj_auxi->map_ver_req ||
+	    daos_crt_network_error(task->dt_result) ||
+	    task->dt_result == -DER_STALE || task->dt_result == -DER_TIMEDOUT ||
+	    task->dt_result == -DER_EVICTED) {
+		D_DEBUG(DB_IO, "map_ver stale (req %d, reply %d). result %d\n",
+			obj_auxi->map_ver_req, obj_auxi->map_ver_reply,
+			task->dt_result);
 		pm_stale = true;
 	}
+
 	if (obj_retry_error(task->dt_result)) {
 		/* If the RPC sponsor set the @spec_shard, then means it wants
 		 * to fetch data from the specified shard. If such shard isn't
@@ -2288,7 +2282,7 @@ obj_comp_cb(tse_task_t *task, void *data)
 	}
 
 	if (pm_stale || obj_auxi->io_retry)
-		obj_retry_cb(task, obj, obj_auxi);
+		obj_retry_cb(task, obj, obj_auxi, pm_stale);
 
 	if (!obj_auxi->io_retry) {
 

--- a/src/pool/srv_iv.c
+++ b/src/pool/srv_iv.c
@@ -350,7 +350,7 @@ pool_iv_update(void *ns, int class_id, struct pool_iv_entry *pool_iv,
 	memset(&key, 0, sizeof(key));
 	key.class_id = class_id;
 	rc = ds_iv_update(ns, &key, &sgl, shortcut, sync_mode, 0,
-			  false /* retry */);
+			  true /* retry */);
 	if (rc)
 		D_ERROR("iv update failed "DF_RC"\n", DP_RC(rc));
 

--- a/src/rebuild/rebuild_internal.h
+++ b/src/rebuild/rebuild_internal.h
@@ -279,6 +279,7 @@ struct rebuild_iv {
 	uint64_t	riv_size;
 	uint64_t	riv_leader_term;
 	uint64_t	riv_stable_epoch;
+	uint32_t	riv_seconds;
 	unsigned int	riv_rank;
 	unsigned int	riv_master_rank;
 	unsigned int	riv_ver;

--- a/src/rebuild/rebuild_iv.c
+++ b/src/rebuild/rebuild_iv.c
@@ -222,6 +222,7 @@ rebuild_iv_ent_refresh(struct ds_iv_entry *entry, struct ds_iv_key *key,
 			rs.rs_toberb_obj_nr	=
 				src_iv->riv_toberb_obj_count;
 			rs.rs_size	= src_iv->riv_size;
+			rs.rs_seconds   = src_iv->riv_seconds;
 
 			rc = rebuild_status_completed_update(
 					src_iv->riv_pool_uuid, &rs);

--- a/src/tests/ftest/daos_test/daos_core_test-rebuild.yaml
+++ b/src/tests/ftest/daos_test/daos_core_test-rebuild.yaml
@@ -26,11 +26,23 @@ daos_tests:
       test_name: rebuild tests 0-10
       args: -s3 -u subtests="0-10"
       test_timeout: 1500
-    test_r_12-18:
+    test_r_12-15:
       daos_test: r
-      test_name: rebuild tests 12-18
-      args: -s3 -u subtests="12-18"
+      test_name: rebuild tests 12-15
+      args: -s3 -u subtests="12-15"
       test_timeout: 1500
+    test_r_16:
+      daos_test: r
+      test_name: rebuild tests 16
+      args: -s3 -u subtests="16"
+    test_r_17:
+      daos_test: r
+      test_name: rebuild tests 17
+      args: -s3 -u subtests="17"
+    test_r_18:
+      daos_test: r
+      test_name: rebuild tests 18
+      args: -s3 -u subtests="18"
     test_r_19:
       daos_test: r
       test_name: rebuild tests 19

--- a/src/tests/suite/daos_rebuild.c
+++ b/src/tests/suite/daos_rebuild.c
@@ -1583,7 +1583,7 @@ multi_pools_rebuild_concurrently(void **state)
 #define CONT_PER_POOL		2
 #define OBJ_PER_CONT		8
 	test_arg_t		*arg = *state;
-	test_arg_t		*args[POOL_NUM * CONT_PER_POOL];
+	test_arg_t		*args[POOL_NUM * CONT_PER_POOL] = { 0 };
 	daos_obj_id_t		oids[OBJ_PER_CONT];
 	struct test_pool	*pool;
 	int			i;
@@ -1599,7 +1599,8 @@ multi_pools_rebuild_concurrently(void **state)
 		rc = rebuild_pool_create(&args[i], arg, SETUP_CONT_CONNECT,
 					 pool);
 		if (rc)
-			return;
+			goto out;
+
 		if (i % CONT_PER_POOL == 0)
 			assert_int_equal(args[i]->pool.slave, 0);
 		else
@@ -1616,10 +1617,12 @@ multi_pools_rebuild_concurrently(void **state)
 
 	rebuild_pools_ranks(args, POOL_NUM * CONT_PER_POOL, ranks_to_kill, 1);
 
-	for (i = POOL_NUM * CONT_PER_POOL - 1; i >= 0; i--) {
+	for (i = POOL_NUM * CONT_PER_POOL - 1; i >= 0; i--)
 		rebuild_io_validate(args[i], oids, OBJ_PER_CONT, true);
+
+out:
+	for (i = POOL_NUM * CONT_PER_POOL - 1; i >= 0; i--)
 		rebuild_pool_destroy(args[i]);
-	}
 }
 
 int


### PR DESCRIPTION
Do not need pool map refresh, if the pool map is not
stale.

Signed-off-by: Di Wang <di.wang@intel.com>