### PR TITLE
DAOS-4068 test: Increase info_tests.py timeout value

### DIFF
--- a/src/tests/ftest/pool/info_tests.yaml
+++ b/src/tests/ftest/pool/info_tests.yaml
@@ -2,7 +2,7 @@ hosts:
   test_servers:
     - server-A
 timeout: 120
-    server_config:
+server_config:
   name: daos_server
   servers:
     targets: 1

--- a/src/tests/ftest/pool/info_tests.yaml
+++ b/src/tests/ftest/pool/info_tests.yaml
@@ -1,7 +1,8 @@
 hosts:
   test_servers:
     - server-A
-server_config:
+timeout: 120
+    server_config:
   name: daos_server
   servers:
     targets: 1


### PR DESCRIPTION
Intermittent failures have been seen due to short timeout. Increasing timeout from 60 to 120 to give the test some room.

Signed-off-by: Justiniano-pagn <amanda.justiniano-pagn@intel.com>