### PR TITLE
DAOS-3733 doc: Update admin guide for log collection

### DIFF
--- a/doc/admin/troubleshooting.md
+++ b/doc/admin/troubleshooting.md
@@ -26,6 +26,42 @@ to 2000).
 The function d_errstr() is provided in the API to convert an error
 number to an error message.
 
+## Log Files
+
+On the server side, there are three log files created as part of normal
+server operations:
+
+|Component|Config Parameter|Example Config Value|
+|-|-|-|
+|Control Plane|control_log_file|/tmp/daos_control.log|
+|Data Plane|log_file|/tmp/daos_server.log|
+|[Privileged Helper](https://daos-stack.github.io/admin/deployment/#elevated-privileges)|helper_log_file|/tmp/daos_admin.log|
+
+### Control Plane Log
+
+The default log level for the control plane is INFO. The following
+levels may be set using the `control_log_mask` config parameter:
+
+* DEBUG
+* INFO
+* ERROR
+
+### Data Plane Log
+
+Data Plane (`daos_io_server`) logging is configured on a per-instance
+basis. In other words, each section under the `servers:` section must
+have its own logging configuration. The `log_file` config parameter
+is converted to a D_LOG_FILE environment variable value. For more
+detail, please see the [Debugging System](#debugging-system)
+section of this document.
+
+### Privileged Helper Log
+
+By default, the privileged helper only emits ERROR-level logging which
+is captured by the control plane and included in that log. If the
+`helper_log_file` parameter is set in the server config, then
+DEBUG-level logging will be sent to the specified file.
+
 ## Debugging System
 
 DAOS uses the debug system defined in
@@ -160,7 +196,13 @@ This section to be updated in a future revision.
 ## Bug Report
 
 Bugs should be reported through our issue tracker[^1] with a test case
-to reproduce the issue (when applicable) and debug
-logs.
+to reproduce the issue (when applicable) and debug logs.
+
+After creating a ticket, logs should be gathered from the locations
+described in the [Log Files](#log-files) section of this document and
+attached to the ticket.
+
+To avoid problems with attaching large files, please attach the logs
+in a compressed container format, such as .zip or .tar.bz2.
 
 [^1]: https://jira.hpdd.intel.com

--- a/src/control/server/config_test.go
+++ b/src/control/server/config_test.go
@@ -36,6 +36,7 @@ import (
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/pkg/errors"
 
+	"github.com/daos-stack/daos/src/control/common"
 	. "github.com/daos-stack/daos/src/control/common"
 	"github.com/daos-stack/daos/src/control/lib/netdetect"
 	"github.com/daos-stack/daos/src/control/logging"
@@ -102,7 +103,7 @@ func mockConfigFromFile(t *testing.T, e External, path string) *Configuration {
 	return c
 }
 
-func TestConfig_MarshalUnmarshal(t *testing.T) {
+func TestServer_ConfigMarshalUnmarshal(t *testing.T) {
 	for name, tt := range map[string]struct {
 		inPath string
 		expErr error
@@ -182,12 +183,9 @@ func TestConfig_MarshalUnmarshal(t *testing.T) {
 	}
 }
 
-func TestConstructedConfig(t *testing.T) {
-	testDir, err := ioutil.TempDir("", strings.Replace(t.Name(), "/", "-", -1))
-	defer os.RemoveAll(testDir)
-	if err != nil {
-		t.Fatal(err)
-	}
+func TestServer_ConstructedConfig(t *testing.T) {
+	testDir, cleanup := common.CreateTestDir(t)
+	defer cleanup()
 
 	// First, load a config based on the server config with all options uncommented.
 	testFile := filepath.Join(testDir, sConfigUncomment)
@@ -206,6 +204,7 @@ func TestConstructedConfig(t *testing.T) {
 		WithNrHugePages(4096).
 		WithControlLogMask(ControlLogLevelError).
 		WithControlLogFile("/tmp/daos_control.log").
+		WithHelperLogFile("/tmp/daos_admin.log").
 		WithUserName("daosuser").
 		WithGroupName("daosgroup").
 		WithSystemName("daos").
@@ -266,7 +265,7 @@ func TestConstructedConfig(t *testing.T) {
 	}
 }
 
-func TestConfig_Validation(t *testing.T) {
+func TestServer_ConfigValidation(t *testing.T) {
 	noopExtra := func(c *Configuration) *Configuration { return c }
 
 	for name, tt := range map[string]struct {
@@ -338,7 +337,7 @@ func TestConfig_Validation(t *testing.T) {
 	}
 }
 
-func TestConfig_RelativeWorkingPath(t *testing.T) {
+func TestServer_ConfigRelativeWorkingPath(t *testing.T) {
 	for name, tt := range map[string]struct {
 		inPath    string
 		expErrMsg string

--- a/src/control/server/ioserver/config_test.go
+++ b/src/control/server/ioserver/config_test.go
@@ -184,7 +184,7 @@ func TestConstructedConfig(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if diff := cmp.Diff(constructed, fromDisk, cmpOpts()...); diff != "" {
+	if diff := cmp.Diff(fromDisk, constructed, cmpOpts()...); diff != "" {
 		t.Fatalf("(-want, +got):\n%s", diff)
 	}
 }
@@ -270,7 +270,7 @@ func TestConfigToCmdVals(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if diff := cmp.Diff(gotArgs, wantArgs, cmpOpts()...); diff != "" {
+	if diff := cmp.Diff(wantArgs, gotArgs, cmpOpts()...); diff != "" {
 		t.Fatalf("(-want, +got):\n%s", diff)
 	}
 
@@ -278,7 +278,7 @@ func TestConfigToCmdVals(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if diff := cmp.Diff(gotEnv, wantEnv, cmpOpts()...); diff != "" {
+	if diff := cmp.Diff(wantEnv, gotEnv, cmpOpts()...); diff != "" {
 		t.Fatalf("(-want, +got):\n%s", diff)
 	}
 }

--- a/utils/config/daos_server.yml
+++ b/utils/config/daos_server.yml
@@ -163,6 +163,12 @@
 #control_log_file: /tmp/daos_control.log
 #
 #
+## Enable daos_admin (privileged helper) logging.
+#
+## default: disabled (errors only to control plane log)
+#helper_log_file: /tmp/daos_admin.log
+#
+#
 ## Username used to lookup user uid/gid to drop privileges to if started
 ## as root. After control plane start-up and configuration, before starting
 ## data plane, process ownership will be dropped to those of supplied user.


### PR DESCRIPTION
Document the various server-side logs, their configuration
parameters, and default values. Add a section on collecting
said logs as part of a bug report.

Also adds missing documentation for daos_admin logging to
the example daos_server config.

Skip-func-test: true
Skip-func-hw-test: true