### PR TITLE
DAOS-623 build: Update to stable 1.8 PMDK

### DIFF
--- a/utils/build.config
+++ b/utils/build.config
@@ -4,7 +4,7 @@ component=daos
 [commit_versions]
 ARGOBOTS = 89507c1f8cfec4e918e8b9861e41b4e9cef71461
 CART = fbd25ce7274c649bc72a652ed21db54f7613f2f0
-PMDK = 1.8-rc1
+PMDK = 1.8
 ISAL = v2.26.0
 SPDK = v19.04.1
 FUSE = 7bf25b6987d84c816aebd5325b95cfa0d311b1e6


### PR DESCRIPTION
Updates to stable release.
Fixes parallel build issue with PMDK

Signed-off-by: Jeff Olivier <jeffrey.v.olivier@intel.com>