### PR TITLE
DAOS-3543 csum: Checksums for Single Values

### DIFF
--- a/src/common/checksum.c
+++ b/src/common/checksum.c
@@ -74,6 +74,13 @@ trace_chars(const uint8_t *buf, const size_t buf_len, const uint32_t max)
 	C_TRACE("%s", str);
 }
 
+static bool
+is_array(const daos_iod_t *iod)
+{
+	return iod->iod_type == DAOS_IOD_ARRAY;
+}
+
+
 static void
 daos_csummer_trace_csum(struct daos_csummer *obj, uint8_t *csum)
 {
@@ -424,9 +431,11 @@ daos_csummer_allocation_size(struct daos_csummer *obj, daos_iod_t *iods,
 			daos_recx_t	*recx = &iod->iod_recxs[j];
 			uint32_t	 csum_count;
 
-			csum_count = daos_recx_calc_chunks(*recx,
+			csum_count = is_array(iod) ?
+				     daos_recx_calc_chunks(*recx,
 							   iod->iod_size,
-							   chunksize);
+							   chunksize) :
+				     1; /** sv only has 1 checksum */
 			result += sizeof(struct dcs_csum_info) +
 				  csum_count * csum_size;
 		}
@@ -487,26 +496,36 @@ daos_csummer_alloc_iods_csums(struct daos_csummer *obj,
 		       used, buf_len);
 
 		for (j = 0; j < iod->iod_nr; j++) {
-			daos_recx_t		*recx;
-			struct dcs_csum_info	*recx_csum;
+			struct dcs_csum_info	*csum_info;
 			uint32_t		 csum_count;
 
-			recx = &iod->iod_recxs[j];
-			recx_csum = &iod_csum->ic_data[j];
-			csum_count = daos_recx_calc_chunks(*recx,
-							   iod->iod_size,
-							   chunksize);
+			csum_info = &iod_csum->ic_data[j];
+			if (is_array(iod)) {
+
+				daos_recx_t *recx;
+
+				recx = &iod->iod_recxs[j];
+				csum_count = daos_recx_calc_chunks(*recx,
+						iod->iod_size, chunksize);
+				ci_set(csum_info, NULL, csum_count * csum_size,
+				       csum_size, csum_count,
+				       chunksize, csum_type);
+			} else { /** single value */
+				csum_count = 1;
+				ci_set(csum_info, NULL, csum_count * csum_size,
+				       csum_size, csum_count,
+				       CSUM_NO_CHUNK, csum_type);
+			}
 
 			/**
-			 * set buffer to null first, then set it using
+			 * buffer set to null first by ci_set, now set it using
 			 * the setptr macro so that amount of memory
 			 * used from allocated buffer is tracked.
 			 */
-			ci_set(recx_csum, NULL, csum_count * csum_size,
-			       csum_size, csum_count, chunksize, csum_type);
-			setptr(recx_csum->cs_csum, buf, csum_count * csum_size,
+			setptr(csum_info->cs_csum, buf, csum_count * csum_size,
 			       used, buf_len);
 		}
+		iod_csum->ic_nr = iod->iod_nr;
 	}
 
 done:
@@ -518,9 +537,9 @@ done:
 
 
 static int
-calc_csum(struct daos_csummer *obj, d_sg_list_t *sgl,
-	  size_t rec_len, daos_recx_t *recxs, size_t nr,
-	  struct dcs_csum_info *csums)
+calc_csum_recx(struct daos_csummer *obj, d_sg_list_t *sgl,
+	       size_t rec_len, daos_recx_t *recxs, size_t nr,
+	       struct dcs_csum_info *csums)
 {
 	uint8_t			*buf;
 	size_t			 bytes_for_csum;
@@ -562,6 +581,31 @@ calc_csum(struct daos_csummer *obj, d_sg_list_t *sgl,
 	return 0;
 }
 
+static int
+calc_csum_sv(struct daos_csummer *obj, d_sg_list_t *sgl, size_t rec_len,
+	     struct dcs_csum_info *csums)
+{
+	size_t			 bytes_for_csum;
+	struct daos_sgl_idx	 idx = {0};
+	int			 rc;
+
+	if (!(daos_csummer_initialized(obj)))
+		return 0;
+
+	daos_csummer_set_buffer(obj, csums->cs_csum, csums->cs_len);
+	daos_csummer_reset(obj);
+
+	bytes_for_csum = rec_len;
+	rc = daos_sgl_processor(sgl, &idx, bytes_for_csum,
+				checksum_sgl_cb, obj);
+	if (rc)
+		return rc;
+
+	daos_csummer_finish(obj);
+
+	return 0;
+}
+
 int
 daos_csummer_calc_iods(struct daos_csummer *obj, d_sg_list_t *sgls,
 		  daos_iod_t *iods, uint32_t nr,
@@ -592,9 +636,12 @@ daos_csummer_calc_iods(struct daos_csummer *obj, d_sg_list_t *sgls,
 		if (!csum_iod_is_supported(chunksize, iod))
 			continue;
 
-		rc = calc_csum(obj, &sgls[i], iod->iod_size,
-			       iod->iod_recxs, iod->iod_nr,
-			       csums->ic_data);
+		rc = is_array(iod) ?
+		     calc_csum_recx(obj, &sgls[i], iod->iod_size,
+				    iod->iod_recxs, iod->iod_nr,
+				    csums->ic_data) :
+		     calc_csum_sv(obj, &sgls[i], iod->iod_size,
+				  csums->ic_data);
 		csums->ic_nr = iod->iod_nr;
 
 		if (rc != 0) {
@@ -605,7 +652,6 @@ daos_csummer_calc_iods(struct daos_csummer *obj, d_sg_list_t *sgls,
 	*p_iods_csums = iods_csums;
 
 	return 0;
-
 }
 
 void
@@ -625,6 +671,14 @@ daos_csummer_verify(struct daos_csummer *obj, daos_iod_t *iod, d_sg_list_t *sgl,
 	int			 i;
 	int			 rc;
 	bool			 match;
+
+	if (!daos_csummer_initialized(obj))
+		return 0;
+
+	if (iod == NULL || sgl == NULL || iod_csums == NULL) {
+		D_ERROR("Invalid params");
+		return -DER_INVAL;
+	}
 
 	rc = daos_csummer_calc_iods(obj, sgl, iod, 1, &new_iod_csums);
 	if (rc != 0)

--- a/src/common/tests/common_test.c
+++ b/src/common/tests/common_test.c
@@ -73,37 +73,45 @@ int main(int argc, char *argv[])
 {
 	if (show_help(argc, argv)) {
 		print_usage(argv[0]);
-	} else {
-		int opt;
-
-		while ((opt = getopt_long(argc, argv, s_opts, l_opts, &idx)) !=
-		       -1) {
-			switch (opt) {
-			case 'h':
-				/** already handled */
-				break;
-			case 'e':
-#if CMOCKA_FILTER_SUPPORTED == 1 /** requires cmocka 1.1.5 */
-				cmocka_set_skip_filter(optarg);
-#else
-				D_PRINT("filter not enabled");
-#endif
-
-				break;
-			case 'f':
-#if CMOCKA_FILTER_SUPPORTED == 1 /** requires cmocka 1.1.5 */
-				cmocka_set_test_filter(optarg);
-#else
-				D_PRINT("filter not enabled");
-#endif
-				break;
-			default:
-				break;
-		}
-		}
-		misc_tests_run();
-		daos_checksum_tests_run();
+		return 0;
 	}
+
+	int opt;
+
+	while ((opt = getopt_long(argc, argv, s_opts, l_opts, &idx)) !=
+	       -1) {
+		switch (opt) {
+		case 'h':
+			/** already handled */
+			break;
+		case 'e':
+#if CMOCKA_FILTER_SUPPORTED == 1 /** requires cmocka 1.1.5 */
+			cmocka_set_skip_filter(optarg);
+#else
+			D_PRINT("filter not enabled");
+#endif
+
+			break;
+		case 'f':
+#if CMOCKA_FILTER_SUPPORTED == 1 /** requires cmocka 1.1.5 */
+
+		{
+			/** Add wildcards for easier filtering */
+			char filter[sizeof(optarg) + 2];
+
+			sprintf(filter, "*%s*", optarg);
+			cmocka_set_test_filter(filter);
+		}
+#else
+			D_PRINT("filter not enabled");
+#endif
+			break;
+		default:
+			break;
+		}
+	}
+	misc_tests_run();
+	daos_checksum_tests_run();
 
 	return 0;
 }

--- a/src/include/daos/checksum.h
+++ b/src/include/daos/checksum.h
@@ -28,6 +28,8 @@
 #include <daos_obj.h>
 #include <daos_prop.h>
 
+#define CSUM_NO_CHUNK -1
+
 /**
  * -----------------------------------------------------------
  * Container Property Knowledge
@@ -376,10 +378,13 @@ csum_chunk_count(uint32_t chunk_size, uint64_t lo_idx, uint64_t hi_idx,
 static inline bool
 csum_iod_is_supported(uint64_t chunksize, daos_iod_t *iod)
 {
-	/** Only support ARRAY Type currently */
-	return iod->iod_type == DAOS_IOD_ARRAY &&
-	       iod->iod_size > 0 &&
-	       iod->iod_size <= chunksize;
+	/**
+	 * iod_size must be greater than 1 and chunksize must be larger
+	 * than iod size if it's an array type. Doesn't support very large
+	 * record size yet for array types
+	 */
+	return iod->iod_size > 0 &&
+	       (iod->iod_type == DAOS_IOD_SINGLE || iod->iod_size <= chunksize);
 }
 
 /**

--- a/src/object/cli_shard.c
+++ b/src/object/cli_shard.c
@@ -153,8 +153,10 @@ int dc_rw_cb_csum_verify(const struct rw_cb_args *rw_args)
 			continue;
 
 		rc = daos_csummer_verify(csummer, iod, &sgls[i], iod_csum);
-		if (rc != 0)
+		if (rc != 0) {
+			D_ERROR("Verify failed: %d\n", rc);
 			break;
+		}
 	}
 
 	return rc;

--- a/src/object/tests/srv_checksum_tests.c
+++ b/src/object/tests/srv_checksum_tests.c
@@ -140,7 +140,7 @@ struct extent_info {
 	struct evt_extent ful;
 };
 
-struct test_setup {
+struct array_test_case_args {
 	int request_idx;
 	int request_len;
 	uint64_t chunksize;
@@ -148,11 +148,12 @@ struct test_setup {
 	struct extent_info layout[24];
 };
 
-#define	TEST_CASE_CREATE(ctx, ...) test_case_create(ctx, \
-	&(struct test_setup)__VA_ARGS__)
+#define	ARRAY_TEST_CASE_CREATE(ctx, ...) array_test_case_create(ctx, \
+	&(struct array_test_case_args)__VA_ARGS__)
 
 static void
-test_case_create(struct vos_fetch_test_context *ctx, struct test_setup *setup)
+array_test_case_create(struct vos_fetch_test_context *ctx,
+		 struct array_test_case_args *setup)
 {
 	uint32_t	 csum_len;
 	uint64_t	 rec_size;
@@ -257,7 +258,7 @@ test_case_destroy(struct vos_fetch_test_context *ctx)
 }
 
 static int
-vos_fetch_csum_verify_bsgl_with_args(struct vos_fetch_test_context *ctx)
+fetch_csum_verify_bsgl_with_args(struct vos_fetch_test_context *ctx)
 {
 	return ds_csum_add2iod(
 		&ctx->iod, ctx->csummer, &ctx->bsgl, ctx->biov_csums, NULL,
@@ -451,7 +452,7 @@ with_extent_smaller_than_chunk(void **state)
 	struct vos_fetch_test_context ctx;
 
 	/** Setup */
-	TEST_CASE_CREATE(&ctx, {
+	ARRAY_TEST_CASE_CREATE(&ctx, {
 		.request_idx = 1,
 		.request_len = 3,
 		.chunksize = 8,
@@ -463,7 +464,7 @@ with_extent_smaller_than_chunk(void **state)
 	});
 
 	/** Act */
-	ASSERT_SUCCESS(vos_fetch_csum_verify_bsgl_with_args(&ctx));
+	ASSERT_SUCCESS(fetch_csum_verify_bsgl_with_args(&ctx));
 
 	/** Verify */
 	IOD_BIOV_CSUM_SAME(&ctx, { .biov_csum = {0, 0}, .iod_csum = {0, 0} });
@@ -489,7 +490,7 @@ with_aligned_chunks_csums_are_copied(void **state)
 	struct vos_fetch_test_context ctx;
 
 	/** Setup */
-	TEST_CASE_CREATE(&ctx, {
+	ARRAY_TEST_CASE_CREATE(&ctx, {
 		.request_idx = 0,
 		.request_len = 6,
 		.chunksize = 2,
@@ -502,7 +503,7 @@ with_aligned_chunks_csums_are_copied(void **state)
 	});
 
 	/** Act */
-	ASSERT_SUCCESS(vos_fetch_csum_verify_bsgl_with_args(&ctx));
+	ASSERT_SUCCESS(fetch_csum_verify_bsgl_with_args(&ctx));
 
 	/** Verify */
 	IOD_BIOV_CSUM_SAME(&ctx, { .biov_csum = {0, 0}, .iod_csum = {0, 0} });
@@ -530,7 +531,7 @@ with_unaligned_chunks_csums_new_csum_is_created(void **state)
 	struct vos_fetch_test_context ctx;
 
 	/** Setup */
-	TEST_CASE_CREATE(&ctx, {
+	ARRAY_TEST_CASE_CREATE(&ctx, {
 		.request_idx = 0,
 		.request_len = 4,
 		.chunksize = 2,
@@ -543,7 +544,7 @@ with_unaligned_chunks_csums_new_csum_is_created(void **state)
 	});
 
 	/** Act */
-	ASSERT_SUCCESS(vos_fetch_csum_verify_bsgl_with_args(&ctx));
+	ASSERT_SUCCESS(fetch_csum_verify_bsgl_with_args(&ctx));
 
 	/** Verify */
 	FAKE_UPDATE_SAW("1|A|12|A|");
@@ -574,7 +575,7 @@ with_extent_larger_than_request(void **state)
 	 * the whole chunk from the first.
 	 *
 	 */
-	TEST_CASE_CREATE(&ctx, {
+	ARRAY_TEST_CASE_CREATE(&ctx, {
 		.request_idx = 0,
 		.request_len = 4,
 		.chunksize = 8,
@@ -589,7 +590,7 @@ with_extent_larger_than_request(void **state)
 	});
 
 	/** Act */
-	ASSERT_SUCCESS(vos_fetch_csum_verify_bsgl_with_args(&ctx));
+	ASSERT_SUCCESS(fetch_csum_verify_bsgl_with_args(&ctx));
 
 	/** Verify */
 	FAKE_UPDATE_SAW("5|ABC|56\0|ABCDEFG|");
@@ -617,7 +618,7 @@ with_unaligned_first_chunk(void **state)
 	struct vos_fetch_test_context ctx;
 
 	/** Setup */
-	TEST_CASE_CREATE(&ctx, {
+	ARRAY_TEST_CASE_CREATE(&ctx, {
 		.request_idx = 1,
 		.request_len = 3,
 		.chunksize = 2,
@@ -630,7 +631,7 @@ with_unaligned_first_chunk(void **state)
 	});
 
 	/** Act */
-	ASSERT_SUCCESS(vos_fetch_csum_verify_bsgl_with_args(&ctx));
+	ASSERT_SUCCESS(fetch_csum_verify_bsgl_with_args(&ctx));
 
 	/** Verify */
 	FAKE_UPDATE_SAW("");
@@ -656,7 +657,7 @@ with_fetch_smaller_than_chunk(void **state)
 {
 	struct vos_fetch_test_context ctx;
 
-	TEST_CASE_CREATE(&ctx, {
+	ARRAY_TEST_CASE_CREATE(&ctx, {
 		.request_idx = 1,
 		.request_len = 6,
 		.chunksize = 8,
@@ -669,7 +670,7 @@ with_fetch_smaller_than_chunk(void **state)
 	});
 
 	/** Act */
-	ASSERT_SUCCESS(vos_fetch_csum_verify_bsgl_with_args(&ctx));
+	ASSERT_SUCCESS(fetch_csum_verify_bsgl_with_args(&ctx));
 
 	/** Verify */
 	FAKE_UPDATE_SAW("BCDEFG|ABCDEFGH|");
@@ -693,7 +694,7 @@ more_partial_extent_tests(void **state)
 {
 	struct vos_fetch_test_context ctx;
 
-	TEST_CASE_CREATE(&ctx, {
+	ARRAY_TEST_CASE_CREATE(&ctx, {
 		.request_idx = 0,
 		.request_len = 3,
 		.chunksize = 2,
@@ -708,7 +709,7 @@ more_partial_extent_tests(void **state)
 	});
 
 	/** Act */
-	ASSERT_SUCCESS(vos_fetch_csum_verify_bsgl_with_args(&ctx));
+	ASSERT_SUCCESS(fetch_csum_verify_bsgl_with_args(&ctx));
 
 	/** Verify */
 	FAKE_UPDATE_SAW("0|A|01|A|");
@@ -734,7 +735,7 @@ test_larger_records(void **state)
 		large_data02[i] = 'a' + i % ('z' + 1 - 'a');
 	}
 
-	TEST_CASE_CREATE(&ctx, {
+	ARRAY_TEST_CASE_CREATE(&ctx, {
 		.request_idx = 0,
 		.request_len = 8,
 		.chunksize = 12,
@@ -749,7 +750,7 @@ test_larger_records(void **state)
 	});
 
 	/** Act */
-	ASSERT_SUCCESS(vos_fetch_csum_verify_bsgl_with_args(&ctx));
+	ASSERT_SUCCESS(fetch_csum_verify_bsgl_with_args(&ctx));
 
 	/** Verify */
 	/** 1 record from 1st extent (mnop) and 2 records from 2nd extent
@@ -774,7 +775,7 @@ test_larger_records2(void **state)
 	memset(large_data01, 'A', 1024 * 16);
 	memset(large_data02, 'B', 1024 * 16);
 
-	TEST_CASE_CREATE(&ctx, {
+	ARRAY_TEST_CASE_CREATE(&ctx, {
 		.request_idx = 0,
 		.request_len = 12,
 		.chunksize = 1024*32,
@@ -789,7 +790,7 @@ test_larger_records2(void **state)
 	});
 
 	/** Act */
-	ASSERT_SUCCESS(vos_fetch_csum_verify_bsgl_with_args(&ctx));
+	ASSERT_SUCCESS(fetch_csum_verify_bsgl_with_args(&ctx));
 
 	/** Verify */
 	assert_int_equal(4, fake_update_called);
@@ -813,32 +814,100 @@ int teardown(void **state)
 }
 
 /* Convenience macros for unit tests */
-#define	T(desc, test_fn) \
-	{ "SRV_CSUM" desc, test_fn, setup, teardown}
+#define	TA(desc, test_fn) \
+	{ "SRV_CSUM_ARRAY" desc, test_fn, setup, teardown }
 
-static const struct CMUnitTest tests[] = {
-	T("01: Partial Extents, but chunks align",
+static const struct CMUnitTest array_tests[] = {
+	TA("01: Partial Extents, but chunks align",
 	  with_aligned_chunks_csums_are_copied),
-	T("02: Partial Extents, chunks don't align",
+	TA("02: Partial Extents, chunks don't align",
 	  with_unaligned_chunks_csums_new_csum_is_created),
-	T("03: Partial Extents, first extent isn't aligned",
+	TA("03: Partial Extents, first extent isn't aligned",
 	  with_unaligned_first_chunk),
-	T("04: Partial Extents, extent smaller than chunk",
+	TA("04: Partial Extents, extent smaller than chunk",
 	  with_extent_smaller_than_chunk),
-	T("05: Extent is larger than chunk", with_extent_larger_than_request),
-	T("06: Fetch smaller than chunk", with_fetch_smaller_than_chunk),
-	T("07: Partial extent/unaligned extent", more_partial_extent_tests),
-	T("08: Fetch with larger records", test_larger_records),
-	T("09: Fetch with larger records", test_larger_records2),
-	T("10: Determine if need new checksum", need_new_checksum_tests),
+	TA("05: Extent is larger than chunk", with_extent_larger_than_request),
+	TA("06: Fetch smaller than chunk", with_fetch_smaller_than_chunk),
+	TA("07: Partial extent/unaligned extent", more_partial_extent_tests),
+	TA("08: Fetch with larger records", test_larger_records),
+	TA("09: Fetch with larger records", test_larger_records2),
+	TA("10: Determine if need new checksum", need_new_checksum_tests),
+};
+
+/**
+ * ----------------------------------------------------------------------------
+ * Single Value Test
+ * ----------------------------------------------------------------------------
+ */
+static void
+update_fetch_sv(void **state)
+{
+	struct daos_csummer	*csummer;
+	struct bio_iov		 biov = {0};
+	struct bio_sglist	 bsgl = {0};
+	/** vos_update_begin will populate a list of csum_infos (one for each
+	 * biov 'extent'
+	 */
+	struct dcs_csum_info	 from_vos_begin = {0};
+	struct dcs_csum_info	 csum_info = {0};
+	struct dcs_iod_csums	 iod_csums = {0};
+
+	uint32_t		 iod_csum_value = 0;
+	daos_iod_t		 iod = {0};
+	char			*data = "abcd";
+	uint32_t		 csum = 0x12345678;
+
+	daos_csummer_init(&csummer, &fake_algo, 4);
+
+	iod.iod_type = DAOS_IOD_SINGLE;
+	iod.iod_size = strlen(data);
+	iod.iod_nr = 1;
+
+	ci_set(&csum_info, &iod_csum_value, sizeof(uint32_t), sizeof(uint32_t),
+	       1, CSUM_NO_CHUNK, 1);
+	iod_csums.ic_data = &csum_info;
+
+	biov.bi_buf = data;
+	biov.bi_data_len = strlen(data);
+
+	bsgl.bs_iovs = &biov;
+	bsgl.bs_nr_out = 1;
+	bsgl.bs_nr = 1;
+
+	ci_set(&from_vos_begin, &csum, sizeof(uint32_t), sizeof(uint32_t), 1,
+	       CSUM_NO_CHUNK, 1);
+
+	ds_csum_add2iod(&iod, csummer, &bsgl, &from_vos_begin, NULL,
+			&iod_csums);
+
+	assert_memory_equal(csum_info.cs_csum, from_vos_begin.cs_csum,
+			    from_vos_begin.cs_len);
+
+	daos_csummer_destroy(&csummer);
+}
+
+
+#define	TS(desc, test_fn) \
+	{ "SRV_CSUM_SV" desc, test_fn, setup, teardown }
+
+static const struct CMUnitTest sv_tests[] = {
+	TS("01: Various scenarios for update/fetch with fault injection",
+	   update_fetch_sv),
 };
 
 int
 main(void)
 {
+	int rc = 0;
 
-	return cmocka_run_group_tests_name(
+	rc += cmocka_run_group_tests_name(
 		"Storage and retrieval of checksums for Array Type",
-		tests, NULL, NULL);
+		array_tests, NULL, NULL);
+
+	rc += cmocka_run_group_tests_name(
+		"Storage and retrieval of checksums for Single Value Type",
+		sv_tests, NULL, NULL);
+
+	return rc;
 
 }

--- a/src/vos/vos_io.c
+++ b/src/vos/vos_io.c
@@ -104,14 +104,6 @@ vos_ioc2csum(struct vos_io_context *ioc)
 	return NULL;
 }
 
-static struct dcs_iod_csums*
-vos_ioc2iodcsum(struct vos_io_context *ioc)
-{
-	if (ioc->iod_csums != NULL)
-		return &ioc->iod_csums[ioc->ic_sgl_at];
-	return NULL;
-}
-
 static void
 iod_empty_sgl(struct vos_io_context *ioc, unsigned int sgl_at)
 {
@@ -337,6 +329,30 @@ bsgl_csums_resize(struct vos_io_context *ioc)
 	return 0;
 }
 
+/** Save the checksum to a list that can be retrieved later */
+static int
+save_csum(struct vos_io_context *ioc, struct dcs_csum_info *csum_info)
+{
+	int rc;
+
+	rc = bsgl_csums_resize(ioc);
+	if (rc != 0)
+		return rc;
+
+	/**
+	 * it's expected that the csum the csum_info points to is in memory
+	 * that will persist until fetch is complete ... so memcpy isn't needed
+	 */
+	ioc->ic_biov_csums[ioc->ic_biov_csums_at] = *csum_info;
+	if (DAOS_FAIL_CHECK(DAOS_CHECKSUM_FETCH_FAIL))
+		/* poison the checksum */
+		ioc->ic_biov_csums[ioc->ic_biov_csums_at].cs_csum[0] += 2;
+
+	ioc->ic_biov_csums_at++;
+
+	return 0;
+}
+
 /** Fetch the single value within the specified epoch range of an key */
 static int
 akey_fetch_single(daos_handle_t toh, const daos_epoch_range_t *epr,
@@ -349,9 +365,7 @@ akey_fetch_single(daos_handle_t toh, const daos_epoch_range_t *epr,
 	d_iov_t			 riov; /* iov to carry record bundle */
 	struct bio_iov		 biov; /* iov to return data buffer */
 	int			 rc;
-	struct dcs_iod_csums	*iod_csum;
-
-	iod_csum = vos_ioc2iodcsum(ioc);
+	struct dcs_csum_info	csum_info = {0};
 
 	tree_key_bundle2iov(&kbund, &kiov);
 	kbund.kb_epoch	= epr->epr_hi;
@@ -359,10 +373,7 @@ akey_fetch_single(daos_handle_t toh, const daos_epoch_range_t *epr,
 	tree_rec_bundle2iov(&rbund, &riov);
 	memset(&biov, 0, sizeof(biov));
 	rbund.rb_biov	= &biov;
-	if (iod_csum != NULL)
-		rbund.rb_csum	= &iod_csum->ic_data[0];
-	else
-		rbund.rb_csum = NULL;
+	rbund.rb_csum = &csum_info;
 
 	rc = dbtree_fetch(toh, BTR_PROBE_LE, DAOS_INTENT_DEFAULT, &kiov, &kiov,
 			  &riov);
@@ -380,11 +391,8 @@ akey_fetch_single(daos_handle_t toh, const daos_epoch_range_t *epr,
 		rbund.rb_rsize = 0;
 		bio_addr_set_hole(&biov.bi_addr, 1);
 	}
-	/* Get the iod_csum pointer and manipulate the checksum value
-	 * for fault injection.
-	 */
-	if (DAOS_FAIL_CHECK(DAOS_CHECKSUM_FETCH_FAIL))
-		rbund.rb_csum->cs_csum[0] += 2;
+	if (ci_is_valid(&csum_info))
+		save_csum(ioc, &csum_info);
 
 	rc = iod_fetch(ioc, &biov);
 	if (rc != 0)
@@ -402,26 +410,6 @@ biov_set_hole(struct bio_iov *biov, ssize_t len)
 	memset(biov, 0, sizeof(*biov));
 	bio_iov_set_len(biov, len);
 	bio_addr_set_hole(&biov->bi_addr, 1);
-}
-
-/** Save the entity checksum to a list that can be retrieved later */
-static int
-save_ent_csum(struct vos_io_context *ioc, struct evt_entry *ent)
-{
-	int rc;
-
-	rc = bsgl_csums_resize(ioc);
-	if (rc != 0)
-		return rc;
-
-	ioc->ic_biov_csums[ioc->ic_biov_csums_at] = ent->en_csum;
-	if (DAOS_FAIL_CHECK(DAOS_CHECKSUM_FETCH_FAIL))
-		/* poison the checksum */
-		ioc->ic_biov_csums[ioc->ic_biov_csums_at].cs_csum[0] += 2;
-
-	ioc->ic_biov_csums_at++;
-
-	return 0;
 }
 
 /**
@@ -514,7 +502,7 @@ akey_fetch_recx(daos_handle_t toh, const daos_epoch_range_t *epr,
 		bio_iov_set(&biov, ent->en_addr, nr * ent_array.ea_inob);
 
 		if (ci_is_valid(&ent->en_csum)) {
-			rc = save_ent_csum(ioc, ent);
+			rc = save_csum(ioc, &ent->en_csum);
 			if (rc != 0)
 				return rc;
 			biov_align_lens(&biov, ent, rsize);

--- a/src/vos/vos_tree.c
+++ b/src/vos/vos_tree.c
@@ -495,6 +495,8 @@ svt_rec_load(struct btr_instance *tins, struct btr_record *rec,
 		csum->cs_len		= irec->ir_cs_size;
 		csum->cs_buf_len	= irec->ir_cs_size;
 		csum->cs_type		= irec->ir_cs_type;
+		csum->cs_nr		= 1; /** sv only has 1 csum */
+		csum->cs_chunksize	= CSUM_NO_CHUNK;
 		if (csum->cs_csum)
 			memcpy(csum->cs_csum,
 			       vos_irec2csum(irec), csum->cs_len);


### PR DESCRIPTION
On update, checksums are calculated for single values on the client,
included in the I/O Descriptor and sent to the server which stores. On
fetch, the checksum is included in the I/O Descriptor back to the client
and the client verifies.

Signed-off-by: Ryon Jensen <ryon.jensen@intel.com>