### PR TITLE
DAOS-4087 control: Allow storage prepare without SCM

### DIFF
--- a/src/control/cmd/daos_server/storage.go
+++ b/src/control/cmd/daos_server/storage.go
@@ -1,5 +1,5 @@
 //
-// (C) Copyright 2019 Intel Corporation.
+// (C) Copyright 2019-2020 Intel Corporation.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -40,6 +40,7 @@ type storageCmd struct {
 }
 
 type storagePrepareCmd struct {
+	scs *server.StorageControlService
 	logCmd
 	commands.StoragePrepareCmd
 }
@@ -63,10 +64,17 @@ func (cmd *storagePrepareCmd) Execute(args []string) error {
 		return err
 	}
 
-	cfg := server.NewConfiguration()
-	svc, err := server.DefaultStorageControlService(cmd.log, cfg)
-	if err != nil {
-		return errors.WithMessage(err, "init control service")
+	// This is a little ugly, but allows for easier unit testing.
+	// FIXME: With the benefit of hindsight, it seems apparent
+	// that we should have made these Execute() methods thin
+	// wrappers around more easily-testable functions.
+	if cmd.scs == nil {
+		cfg := server.NewConfiguration()
+		svc, err := server.DefaultStorageControlService(cmd.log, cfg)
+		if err != nil {
+			return errors.WithMessage(err, "init control service")
+		}
+		cmd.scs = svc
 	}
 
 	op := "Preparing"
@@ -80,7 +88,7 @@ func (cmd *storagePrepareCmd) Execute(args []string) error {
 		cmd.log.Info(op + " locally-attached NVMe storage...")
 
 		// Prepare NVMe access through SPDK
-		if _, err := svc.NvmePrepare(bdev.PrepareRequest{
+		if _, err := cmd.scs.NvmePrepare(bdev.PrepareRequest{
 			HugePageCount: cmd.NrHugepages,
 			TargetUser:    cmd.TargetUser,
 			PCIWhitelist:  cmd.PCIWhiteList,
@@ -90,21 +98,21 @@ func (cmd *storagePrepareCmd) Execute(args []string) error {
 		}
 	}
 
-	if prepScm {
+	scmScan, err := cmd.scs.ScmScan()
+	if err != nil {
+		return concatErrors(scanErrors, err)
+	}
+
+	if prepScm && len(scmScan.Modules) > 0 {
 		cmd.log.Info(op + " locally-attached SCM...")
 
-		state, err := svc.GetScmState()
-		if err != nil {
-			return concatErrors(scanErrors, err)
-		}
-
-		if err := cmd.CheckWarn(cmd.log, state); err != nil {
+		if err := cmd.CheckWarn(cmd.log, scmScan.State); err != nil {
 			return concatErrors(scanErrors, err)
 		}
 
 		// Prepare SCM modules to be presented as pmem device files.
 		// Pass evaluated state to avoid running GetScmState() twice.
-		resp, err := svc.ScmPrepare(scm.PrepareRequest{Reset: cmd.Reset})
+		resp, err := cmd.scs.ScmPrepare(scm.PrepareRequest{Reset: cmd.Reset})
 		if err != nil {
 			return concatErrors(scanErrors, err)
 		}
@@ -115,6 +123,8 @@ func (cmd *storagePrepareCmd) Execute(args []string) error {
 		} else {
 			cmd.log.Info("no SCM namespaces")
 		}
+	} else if prepScm {
+		cmd.log.Info("No SCM modules detected; skipping operation")
 	}
 
 	if len(scanErrors) > 0 {

--- a/src/control/cmd/daos_server/storage_test.go
+++ b/src/control/cmd/daos_server/storage_test.go
@@ -1,0 +1,158 @@
+//
+// (C) Copyright 2020 Intel Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// GOVERNMENT LICENSE RIGHTS-OPEN SOURCE SOFTWARE
+// The Government's rights to use, modify, reproduce, release, perform, display,
+// or disclose this software are subject to the terms of the Apache License as
+// provided in Contract No. 8F-30005.
+// Any reproduction of computer software, computer software documentation, or
+// portions thereof marked with this legend must also reproduce the markings.
+//
+package main
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/pkg/errors"
+
+	"github.com/daos-stack/daos/src/control/common"
+	commands "github.com/daos-stack/daos/src/control/common/storage"
+	"github.com/daos-stack/daos/src/control/logging"
+	"github.com/daos-stack/daos/src/control/server"
+	"github.com/daos-stack/daos/src/control/server/storage"
+	"github.com/daos-stack/daos/src/control/server/storage/bdev"
+	"github.com/daos-stack/daos/src/control/server/storage/scm"
+)
+
+func TestDaosServer_StoragePrepare(t *testing.T) {
+	failedErr := errors.New("it failed")
+
+	for name, tc := range map[string]struct {
+		nvmeOnly  bool
+		scmOnly   bool
+		reset     bool
+		force     bool
+		bmbc      *bdev.MockBackendConfig
+		smbc      *scm.MockBackendConfig
+		expLogMsg string
+		expErr    error
+	}{
+		"default no devices; success": {},
+		"nvme-only no devices; success": {
+			nvmeOnly: true,
+		},
+		"scm-only no devices; success": {
+			scmOnly: true,
+		},
+		"setting nvme-only and scm-only should fail": {
+			nvmeOnly: true,
+			scmOnly:  true,
+			expErr:   errors.New("should not be set"),
+		},
+		"prepared scm; success": {
+			smbc: &scm.MockBackendConfig{
+				DiscoverRes:     storage.ScmModules{*storage.MockScmModule()},
+				GetNamespaceRes: storage.ScmNamespaces{*storage.MockScmNamespace()},
+				StartingState:   storage.ScmStateNoCapacity,
+			},
+		},
+		"unprepared scm; warn": {
+			smbc: &scm.MockBackendConfig{
+				DiscoverRes:   storage.ScmModules{*storage.MockScmModule()},
+				StartingState: storage.ScmStateNoRegions,
+			},
+			expErr: errors.New("consent not given"), // prompts for confirmation and gets EOF
+		},
+		"unprepared scm; force": {
+			force: true,
+			smbc: &scm.MockBackendConfig{
+				DiscoverRes:     storage.ScmModules{*storage.MockScmModule()},
+				StartingState:   storage.ScmStateNoRegions,
+				PrepNeedsReboot: true,
+			},
+			expLogMsg: scm.MsgScmRebootRequired,
+		},
+		"prepare scm; create namespaces": {
+			smbc: &scm.MockBackendConfig{
+				DiscoverRes:      storage.ScmModules{*storage.MockScmModule()},
+				PrepNamespaceRes: storage.ScmNamespaces{*storage.MockScmNamespace()},
+				StartingState:    storage.ScmStateFreeCapacity,
+			},
+			expLogMsg: storage.MockScmNamespace().String(),
+		},
+		"reset scm": {
+			reset: true,
+			smbc: &scm.MockBackendConfig{
+				DiscoverRes:      storage.ScmModules{*storage.MockScmModule()},
+				PrepNamespaceRes: storage.ScmNamespaces{*storage.MockScmNamespace()},
+				StartingState:    storage.ScmStateNoCapacity,
+			},
+			expErr: errors.New("consent not given"), // prompts for confirmation and gets EOF
+		},
+		"scm scan fails": {
+			smbc: &scm.MockBackendConfig{
+				DiscoverErr: failedErr,
+			},
+			expErr: failedErr,
+		},
+		"scm prepare fails": {
+			smbc: &scm.MockBackendConfig{
+				DiscoverRes:   storage.ScmModules{*storage.MockScmModule()},
+				StartingState: storage.ScmStateFreeCapacity,
+				PrepErr:       failedErr,
+			},
+			expErr: failedErr,
+		},
+		"nvme prep fails": {
+			bmbc: &bdev.MockBackendConfig{
+				PrepareErr: failedErr,
+			},
+			expErr: failedErr,
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			log, buf := logging.NewTestLogger(name)
+			defer common.ShowBufferOnFailure(t, buf)
+
+			bdevProvider := bdev.NewMockProvider(log, tc.bmbc)
+			scmProvider := scm.NewMockProvider(log, tc.smbc, nil)
+			cmd := &storagePrepareCmd{
+				StoragePrepareCmd: commands.StoragePrepareCmd{
+					NvmeOnly: tc.nvmeOnly,
+					ScmOnly:  tc.scmOnly,
+					Reset:    tc.reset,
+					Force:    tc.force,
+				},
+				logCmd: logCmd{
+					log: log,
+				},
+				scs: server.NewStorageControlService(log, bdevProvider, scmProvider, nil),
+			}
+
+			gotErr := cmd.Execute(nil)
+			common.CmpErr(t, tc.expErr, gotErr)
+			if tc.expErr != nil {
+				return
+			}
+
+			if tc.expLogMsg != "" {
+				if !strings.Contains(buf.String(), tc.expLogMsg) {
+					t.Fatalf("expected to see %q in log, but didn't", tc.expLogMsg)
+				}
+			}
+		})
+	}
+}

--- a/src/control/server/storage/mocks.go
+++ b/src/control/server/storage/mocks.go
@@ -1,5 +1,5 @@
 //
-// (C) Copyright 2019 Intel Corporation.
+// (C) Copyright 2019-2020 Intel Corporation.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -22,7 +22,11 @@
 //
 package storage
 
-import "fmt"
+import (
+	"fmt"
+	"strconv"
+	"strings"
+)
 
 func concat(base string, idx int32) string {
 	return fmt.Sprintf("%s-%d", base, idx)
@@ -68,4 +72,42 @@ func MockNvmeController(varIdx ...int32) *NvmeController {
 		HealthStats: MockNvmeDeviceHealth(idx),
 		Namespaces:  []*NvmeNamespace{MockNvmeNamespace(idx)},
 	}
+}
+
+func MockScmModule(varIdx ...int32) *ScmModule {
+	idx := uint32(getIndex(varIdx...))
+
+	return &ScmModule{
+		ChannelID:       idx,
+		ChannelPosition: idx,
+		ControllerID:    idx,
+		SocketID:        idx,
+		PhysicalID:      idx,
+		Capacity:        uint64(idx),
+	}
+}
+
+func MockScmNamespace(varIdx ...int32) *ScmNamespace {
+	idx := getIndex(varIdx...)
+
+	return &ScmNamespace{
+		UUID:        MockUUID(varIdx...),
+		BlockDevice: fmt.Sprintf("/dev/pmem%d", idx),
+		Name:        fmt.Sprintf("pmem%d", idx),
+		NumaNode:    uint32(idx),
+		Size:        uint64(idx),
+	}
+}
+
+func MockUUID(varIdx ...int32) string {
+	idx := getIndex(varIdx...)
+	idxStr := strconv.Itoa(int(idx))
+
+	return fmt.Sprintf("%s-%s-%s-%s-%s",
+		strings.Repeat(idxStr, 8),
+		strings.Repeat(idxStr, 4),
+		strings.Repeat(idxStr, 4),
+		strings.Repeat(idxStr, 4),
+		strings.Repeat(idxStr, 12),
+	)
 }


### PR DESCRIPTION
When `daos_server storage prepare` is run, skip trying
to prepare SCM if no modules are detected.