### PR TITLE
DAOS-4084 control: Enforce resource isolation

### DIFF
--- a/src/control/fault/code/codes.go
+++ b/src/control/fault/code/codes.go
@@ -80,7 +80,7 @@ const (
 	ServerConfigDuplicateLogFile
 	ServerConfigDuplicateScmMount
 	ServerConfigDuplicateScmDeviceList
-	ServerConfigDuplicateBdevDeviceList
+	ServerConfigOverlappingBdevDeviceList
 
 	// security fault codes
 	SecurityUnknown Code = iota + 900

--- a/src/control/fault/code/codes.go
+++ b/src/control/fault/code/codes.go
@@ -76,6 +76,11 @@ const (
 	ServerConfigBadAccessPoints
 	ServerConfigBadProvider
 	ServerConfigNoServers
+	ServerConfigDuplicateFabric
+	ServerConfigDuplicateLogFile
+	ServerConfigDuplicateScmMount
+	ServerConfigDuplicateScmDeviceList
+	ServerConfigDuplicateBdevDeviceList
 
 	// security fault codes
 	SecurityUnknown Code = iota + 900

--- a/src/control/server/config.go
+++ b/src/control/server/config.go
@@ -508,8 +508,8 @@ func validateMultiServerConfig(log logging.Logger, c *Configuration) error {
 		bdevConf := srv.Storage.Bdev
 		for _, dev := range bdevConf.DeviceList {
 			if seenIn, exists := seenBdevSet[dev]; exists {
-				log.Debugf("bdev_list entry %s in %d duplicates %d", dev, idx, seenIn)
-				return FaultConfigDuplicateBdevDeviceList(idx, seenIn)
+				log.Debugf("bdev_list entry %s in %d overlaps %d", dev, idx, seenIn)
+				return FaultConfigOverlappingBdevDeviceList(idx, seenIn)
 			}
 			seenBdevSet[dev] = idx
 		}

--- a/src/control/server/config.go
+++ b/src/control/server/config.go
@@ -499,7 +499,7 @@ func validateMultiServerConfig(log logging.Logger, c *Configuration) error {
 
 		for _, dev := range scmConf.DeviceList {
 			if seenIn, exists := seenScmSet[dev]; exists {
-				log.Debugf("scm device %s in %d duplicates %d", dev, idx, seenIn)
+				log.Debugf("scm_list entry %s in %d duplicates %d", dev, idx, seenIn)
 				return FaultConfigDuplicateScmDeviceList(idx, seenIn)
 			}
 			seenScmSet[dev] = idx
@@ -508,7 +508,7 @@ func validateMultiServerConfig(log logging.Logger, c *Configuration) error {
 		bdevConf := srv.Storage.Bdev
 		for _, dev := range bdevConf.DeviceList {
 			if seenIn, exists := seenBdevSet[dev]; exists {
-				log.Debugf("bdev device %s in %d duplicates %d", dev, idx, seenIn)
+				log.Debugf("bdev_list entry %s in %d duplicates %d", dev, idx, seenIn)
 				return FaultConfigDuplicateBdevDeviceList(idx, seenIn)
 			}
 			seenBdevSet[dev] = idx

--- a/src/control/server/config_test.go
+++ b/src/control/server/config_test.go
@@ -245,7 +245,7 @@ func TestServer_ConstructedConfig(t *testing.T) {
 				WithBdevDeviceList("/dev/sdc", "/dev/sdd").
 				WithBdevDeviceCount(1).
 				WithBdevFileSize(16).
-				WithFabricInterface("qib0").
+				WithFabricInterface("qib1").
 				WithFabricInterfacePort(20000).
 				WithPinnedNumaNode(&numaNode1).
 				WithEnvVars("CRT_TIMEOUT=100").
@@ -388,6 +388,84 @@ func TestServer_ConfigRelativeWorkingPath(t *testing.T) {
 					t.Fatalf("want contains: %s, got %s", tt.expErrMsg, err)
 				}
 			}
+		})
+	}
+}
+
+func TestServer_ConfigDuplicateValues(t *testing.T) {
+	configA := func() *ioserver.Config {
+		return ioserver.NewConfig().
+			WithLogFile("a").
+			WithFabricInterface("a").
+			WithScmClass("ram").
+			WithScmRamdiskSize(1).
+			WithScmMountPoint("a")
+	}
+	configB := func() *ioserver.Config {
+		return ioserver.NewConfig().
+			WithLogFile("b").
+			WithFabricInterface("b").
+			WithScmClass("ram").
+			WithScmRamdiskSize(1).
+			WithScmMountPoint("b")
+	}
+
+	for name, tc := range map[string]struct {
+		configA *ioserver.Config
+		configB *ioserver.Config
+		expErr  error
+	}{
+		"successful validation": {
+			configA: configA(),
+			configB: configB(),
+		},
+		"duplicate fabric config": {
+			configA: configA(),
+			configB: configB().
+				WithFabricInterface(configA().Fabric.Interface),
+			expErr: FaultConfigDuplicateFabric(1, 0),
+		},
+		"duplicate log_file": {
+			configA: configA(),
+			configB: configB().
+				WithLogFile(configA().LogFile),
+			expErr: FaultConfigDuplicateLogFile(1, 0),
+		},
+		"duplicate scm_mount": {
+			configA: configA(),
+			configB: configB().
+				WithScmMountPoint(configA().Storage.SCM.MountPoint),
+			expErr: FaultConfigDuplicateScmMount(1, 0),
+		},
+		"duplicate scm_list": {
+			configA: configA().
+				WithScmClass("dcpm").
+				WithScmRamdiskSize(0).
+				WithScmDeviceList("a"),
+			configB: configB().
+				WithScmClass("dcpm").
+				WithScmRamdiskSize(0).
+				WithScmDeviceList("a"),
+			expErr: FaultConfigDuplicateScmDeviceList(1, 0),
+		},
+		"duplicate bdev_list": {
+			configA: configA().
+				WithBdevDeviceList("a", "b"),
+			configB: configB().
+				WithBdevDeviceList("b", "a"),
+			expErr: FaultConfigDuplicateBdevDeviceList(1, 0),
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			log, buf := logging.NewTestLogger(t.Name())
+			defer ShowBufferOnFailure(t, buf)
+
+			conf := NewConfiguration().
+				WithFabricProvider("test").
+				WithServers(tc.configA, tc.configB)
+
+			gotErr := conf.Validate(log)
+			common.CmpErr(t, tc.expErr, gotErr)
 		})
 	}
 }

--- a/src/control/server/config_test.go
+++ b/src/control/server/config_test.go
@@ -448,9 +448,9 @@ func TestServer_ConfigDuplicateValues(t *testing.T) {
 				WithScmDeviceList("a"),
 			expErr: FaultConfigDuplicateScmDeviceList(1, 0),
 		},
-		"duplicate bdev_list": {
+		"overlapping bdev_list": {
 			configA: configA().
-				WithBdevDeviceList("a", "b"),
+				WithBdevDeviceList("a"),
 			configB: configB().
 				WithBdevDeviceList("b", "a"),
 			expErr: FaultConfigDuplicateBdevDeviceList(1, 0),

--- a/src/control/server/config_test.go
+++ b/src/control/server/config_test.go
@@ -453,7 +453,7 @@ func TestServer_ConfigDuplicateValues(t *testing.T) {
 				WithBdevDeviceList("a"),
 			configB: configB().
 				WithBdevDeviceList("b", "a"),
-			expErr: FaultConfigDuplicateBdevDeviceList(1, 0),
+			expErr: FaultConfigOverlappingBdevDeviceList(1, 0),
 		},
 	} {
 		t.Run(name, func(t *testing.T) {

--- a/src/control/server/faults.go
+++ b/src/control/server/faults.go
@@ -23,6 +23,8 @@
 package server
 
 import (
+	"fmt"
+
 	"github.com/daos-stack/daos/src/control/fault"
 	"github.com/daos-stack/daos/src/control/fault/code"
 )
@@ -62,6 +64,45 @@ var (
 		"specify at least one IO Server configuration ('servers' list parameter) and restart the control server",
 	)
 )
+
+func FaultConfigDuplicateFabric(curIdx, seenIdx int) *fault.Fault {
+	return serverFault(
+		code.ServerConfigDuplicateFabric,
+		fmt.Sprintf("the fabric configuration in IO server %d is a duplicate of server %d", curIdx, seenIdx),
+		"ensure that each IO server has a unique combination of provider,fabric_iface,fabric_iface_port and restart",
+	)
+}
+
+func FaultConfigDuplicateLogFile(curIdx, seenIdx int) *fault.Fault {
+	return dupeValue(
+		code.ServerConfigDuplicateLogFile, "log_file", curIdx, seenIdx,
+	)
+}
+
+func FaultConfigDuplicateScmMount(curIdx, seenIdx int) *fault.Fault {
+	return dupeValue(
+		code.ServerConfigDuplicateScmMount, "scm_mount", curIdx, seenIdx,
+	)
+}
+
+func FaultConfigDuplicateScmDeviceList(curIdx, seenIdx int) *fault.Fault {
+	return dupeValue(
+		code.ServerConfigDuplicateScmDeviceList, "scm_list", curIdx, seenIdx,
+	)
+}
+
+func FaultConfigDuplicateBdevDeviceList(curIdx, seenIdx int) *fault.Fault {
+	return dupeValue(
+		code.ServerConfigDuplicateBdevDeviceList, "bdev_list", curIdx, seenIdx,
+	)
+}
+
+func dupeValue(code code.Code, name string, curIdx, seenIdx int) *fault.Fault {
+	return serverFault(code,
+		fmt.Sprintf("the %s value in IO server %d is a duplicate of server %d", name, curIdx, seenIdx),
+		fmt.Sprintf("ensure that each IO server has a unique %s value and restart", name),
+	)
+}
 
 func serverFault(code code.Code, desc, res string) *fault.Fault {
 	return &fault.Fault{

--- a/src/control/server/faults.go
+++ b/src/control/server/faults.go
@@ -91,9 +91,11 @@ func FaultConfigDuplicateScmDeviceList(curIdx, seenIdx int) *fault.Fault {
 	)
 }
 
-func FaultConfigDuplicateBdevDeviceList(curIdx, seenIdx int) *fault.Fault {
-	return dupeValue(
-		code.ServerConfigDuplicateBdevDeviceList, "bdev_list", curIdx, seenIdx,
+func FaultConfigOverlappingBdevDeviceList(curIdx, seenIdx int) *fault.Fault {
+	return serverFault(
+		code.ServerConfigOverlappingBdevDeviceList,
+		fmt.Sprintf("the bdev_list value in IO server %d overlaps with entries in server %d", curIdx, seenIdx),
+		"ensure that each IO server has a unique set of bdev_list entries and restart",
 	)
 }
 

--- a/utils/config/daos_server.yml
+++ b/utils/config/daos_server.yml
@@ -316,7 +316,7 @@
 #  # by this server but please only if you have a specific need, this will
 #  # normally be chosen automatically.
 #
-#  fabric_iface: qib0
+#  fabric_iface: qib1
 #  fabric_iface_port: 20000
 #  pinned_numa_node: 1
 #


### PR DESCRIPTION
Expand the configuration validation logic to check for
duplicate resource assignments when running with
multiple I/O server configurations.