### PR TITLE
DAOS-3987 tools: Add daos cont update-acl command

### DIFF
--- a/src/client/api/container.c
+++ b/src/client/api/container.c
@@ -235,6 +235,30 @@ daos_cont_overwrite_acl(daos_handle_t coh, struct daos_acl *acl,
 }
 
 int
+daos_cont_update_acl(daos_handle_t coh, struct daos_acl *acl, daos_event_t *ev)
+{
+	daos_cont_update_acl_t	*args;
+	tse_task_t		*task;
+	int			 rc;
+
+	DAOS_API_ARG_ASSERT(*args, CONT_UPDATE_ACL);
+	if (daos_acl_validate(acl) != 0) {
+		D_ERROR("invalid acl parameter.\n");
+		return -DER_INVAL;
+	}
+
+	rc = dc_task_create(dc_cont_update_acl, NULL, ev, &task);
+	if (rc)
+		return rc;
+
+	args = dc_task_get_args(task);
+	args->coh	= coh;
+	args->acl	= acl;
+
+	return dc_task_schedule(task, true);
+}
+
+int
 daos_cont_aggregate(daos_handle_t coh, daos_epoch_t epoch, daos_event_t *ev)
 {
 	daos_cont_aggregate_t	*args;

--- a/src/client/api/init.c
+++ b/src/client/api/init.c
@@ -77,6 +77,7 @@ const struct daos_task_api dc_funcs[] = {
 	{dc_cont_destroy, sizeof(daos_cont_destroy_t)},
 	{dc_cont_query, sizeof(daos_cont_query_t)},
 	{dc_cont_set_prop, sizeof(daos_cont_set_prop_t)},
+	{dc_cont_update_acl, sizeof(daos_cont_update_acl_t)},
 	{dc_cont_aggregate, sizeof(daos_cont_aggregate_t)},
 	{dc_cont_rollback, sizeof(daos_cont_rollback_t)},
 	{dc_cont_subscribe, sizeof(daos_cont_subscribe_t)},

--- a/src/container/cli.c
+++ b/src/container/cli.c
@@ -1046,7 +1046,7 @@ dc_cont_set_prop(tse_task_t *task)
 	D_ASSERT(pool != NULL);
 
 	D_DEBUG(DF_DSMC, DF_CONT": setting props: hdl="DF_UUID"\n",
-		DP_CONT(pool->dp_pool_hdl, cont->dc_uuid),
+		DP_CONT(pool->dp_pool, cont->dc_uuid),
 		DP_UUID(cont->dc_cont_hdl));
 
 	ep.ep_grp  = pool->dp_sys->sy_group;
@@ -1092,8 +1092,8 @@ err:
 }
 
 struct cont_update_acl_args {
-	struct dc_pool		*cqa_pool;
-	struct dc_cont		*cqa_cont;
+	struct dc_pool		*cua_pool;
+	struct dc_cont		*cua_cont;
 	crt_rpc_t		*rpc;
 	daos_handle_t		hdl;
 };
@@ -1104,8 +1104,8 @@ cont_update_acl_complete(tse_task_t *task, void *data)
 	struct cont_update_acl_args	*arg = (struct cont_update_acl_args *)
 						data;
 	struct cont_acl_update_out	*out = crt_reply_get(arg->rpc);
-	struct dc_pool			*pool = arg->cqa_pool;
-	struct dc_cont			*cont = arg->cqa_cont;
+	struct dc_pool			*pool = arg->cua_pool;
+	struct dc_cont			*cont = arg->cua_cont;
 	int				 rc   = task->dt_result;
 
 	rc = cont_rsvc_client_complete_rpc(pool, &arg->rpc->cr_ep, rc,
@@ -1164,7 +1164,7 @@ dc_cont_update_acl(tse_task_t *task)
 	D_ASSERT(pool != NULL);
 
 	D_DEBUG(DF_DSMC, DF_CONT": updating ACL: hdl="DF_UUID"\n",
-		DP_CONT(pool->dp_pool_hdl, cont->dc_uuid),
+		DP_CONT(pool->dp_pool, cont->dc_uuid),
 		DP_UUID(cont->dc_cont_hdl));
 
 	ep.ep_grp  = pool->dp_sys->sy_group;
@@ -1183,8 +1183,8 @@ dc_cont_update_acl(tse_task_t *task)
 	uuid_copy(in->caui_op.ci_hdl, cont->dc_cont_hdl);
 	in->caui_acl = args->acl;
 
-	arg.cqa_pool = pool;
-	arg.cqa_cont = cont;
+	arg.cua_pool = pool;
+	arg.cua_cont = cont;
 	arg.rpc	     = rpc;
 	arg.hdl	     = args->coh;
 	crt_req_addref(rpc);

--- a/src/container/cli.c
+++ b/src/container/cli.c
@@ -1091,6 +1091,124 @@ err:
 	return rc;
 }
 
+struct cont_update_acl_args {
+	struct dc_pool		*cqa_pool;
+	struct dc_cont		*cqa_cont;
+	crt_rpc_t		*rpc;
+	daos_handle_t		hdl;
+};
+
+static int
+cont_update_acl_complete(tse_task_t *task, void *data)
+{
+	struct cont_update_acl_args	*arg = (struct cont_update_acl_args *)
+						data;
+	struct cont_acl_update_out	*out = crt_reply_get(arg->rpc);
+	struct dc_pool			*pool = arg->cqa_pool;
+	struct dc_cont			*cont = arg->cqa_cont;
+	int				 rc   = task->dt_result;
+
+	rc = cont_rsvc_client_complete_rpc(pool, &arg->rpc->cr_ep, rc,
+					   &out->cauo_op, task);
+	if (rc < 0)
+		D_GOTO(out, rc);
+	else if (rc == RSVC_CLIENT_RECHOOSE)
+		D_GOTO(out, rc = 0);
+
+	if (rc != 0) {
+		D_ERROR("RPC error while updating ACL on container: "DF_RC"\n",
+			DP_RC(rc));
+		D_GOTO(out, rc);
+	}
+
+	rc = out->cauo_op.co_rc;
+
+	if (rc != 0) {
+		D_DEBUG(DF_DSMC, DF_CONT": failed to update ACL on container: "
+			"%d\n",
+			DP_CONT(pool->dp_pool, cont->dc_uuid), rc);
+		D_GOTO(out, rc);
+	}
+
+	D_DEBUG(DF_DSMC, DF_CONT": Update ACL: using hdl="DF_UUID"\n",
+		DP_CONT(pool->dp_pool, cont->dc_uuid),
+		DP_UUID(cont->dc_cont_hdl));
+
+out:
+	crt_req_decref(arg->rpc);
+	dc_cont_put(cont);
+	dc_pool_put(pool);
+	return rc;
+}
+
+int
+dc_cont_update_acl(tse_task_t *task)
+{
+	daos_cont_update_acl_t		*args;
+	struct cont_acl_update_in	*in;
+	struct dc_pool			*pool;
+	struct dc_cont			*cont;
+	crt_endpoint_t			 ep;
+	crt_rpc_t			*rpc;
+	struct cont_update_acl_args	 arg;
+	int				 rc;
+
+	args = dc_task_get_args(task);
+	D_ASSERTF(args != NULL, "Task Argument OPC does not match DC OPC\n");
+
+	cont = dc_hdl2cont(args->coh);
+	if (cont == NULL)
+		D_GOTO(err, rc = -DER_NO_HDL);
+
+	pool = dc_hdl2pool(cont->dc_pool_hdl);
+	D_ASSERT(pool != NULL);
+
+	D_DEBUG(DF_DSMC, DF_CONT": updating ACL: hdl="DF_UUID"\n",
+		DP_CONT(pool->dp_pool_hdl, cont->dc_uuid),
+		DP_UUID(cont->dc_cont_hdl));
+
+	ep.ep_grp  = pool->dp_sys->sy_group;
+	D_MUTEX_LOCK(&pool->dp_client_lock);
+	rsvc_client_choose(&pool->dp_client, &ep);
+	D_MUTEX_UNLOCK(&pool->dp_client_lock);
+	rc = cont_req_create(daos_task2ctx(task), &ep, CONT_ACL_UPDATE, &rpc);
+	if (rc != 0) {
+		D_ERROR("failed to create rpc: "DF_RC"\n", DP_RC(rc));
+		D_GOTO(err_cont, rc);
+	}
+
+	in = crt_req_get(rpc);
+	uuid_copy(in->caui_op.ci_pool_hdl, pool->dp_pool_hdl);
+	uuid_copy(in->caui_op.ci_uuid, cont->dc_uuid);
+	uuid_copy(in->caui_op.ci_hdl, cont->dc_cont_hdl);
+	in->caui_acl = args->acl;
+
+	arg.cqa_pool = pool;
+	arg.cqa_cont = cont;
+	arg.rpc	     = rpc;
+	arg.hdl	     = args->coh;
+	crt_req_addref(rpc);
+
+	rc = tse_task_register_comp_cb(task, cont_update_acl_complete, &arg,
+				       sizeof(arg));
+	if (rc != 0)
+		D_GOTO(err_rpc, rc);
+
+	return daos_rpc_send(rpc, task);
+
+err_rpc:
+	crt_req_decref(rpc);
+	crt_req_decref(rpc);
+err_cont:
+	dc_cont_put(cont);
+	dc_pool_put(pool);
+err:
+	tse_task_complete(task, rc);
+	D_DEBUG(DF_DSMC, "Failed to update ACL on container: "DF_RC"\n",
+		DP_RC(rc));
+	return rc;
+}
+
 struct cont_oid_alloc_args {
 	struct dc_pool		*coaa_pool;
 	struct dc_cont		*coaa_cont;

--- a/src/container/rpc.c
+++ b/src/container/rpc.c
@@ -110,6 +110,8 @@ CRT_RPC_DEFINE(cont_tgt_epoch_aggregate, DAOS_ISEQ_CONT_TGT_EPOCH_AGGREGATE,
 CRT_RPC_DEFINE(cont_tgt_snapshot_notify, DAOS_ISEQ_CONT_TGT_SNAPSHOT_NOTIFY,
 		DAOS_OSEQ_CONT_TGT_SNAPSHOT_NOTIFY)
 CRT_RPC_DEFINE(cont_prop_set, DAOS_ISEQ_CONT_PROP_SET, DAOS_OSEQ_CONT_PROP_SET)
+CRT_RPC_DEFINE(cont_acl_update, DAOS_ISEQ_CONT_ACL_UPDATE,
+	       DAOS_OSEQ_CONT_ACL_UPDATE)
 
 /* Define for cont_rpcs[] array population below.
  * See CONT_PROTO_*_RPC_LIST macro definition

--- a/src/container/rpc.h
+++ b/src/container/rpc.h
@@ -90,6 +90,9 @@
 		ds_cont_op_handler, NULL),				\
 	X(CONT_PROP_SET,						\
 		0, &CQF_cont_prop_set,					\
+		ds_cont_op_handler, NULL),				\
+	X(CONT_ACL_UPDATE,						\
+		0, &CQF_cont_acl_update,				\
 		ds_cont_op_handler, NULL)
 
 #define CONT_PROTO_SRV_RPC_LIST						\
@@ -369,6 +372,16 @@ CRT_RPC_DECLARE(cont_tgt_snapshot_notify, DAOS_ISEQ_CONT_TGT_SNAPSHOT_NOTIFY,
 	((struct cont_op_out)	(cpso_op)		CRT_VAR)
 
 CRT_RPC_DECLARE(cont_prop_set, DAOS_ISEQ_CONT_PROP_SET, DAOS_OSEQ_CONT_PROP_SET)
+
+#define DAOS_ISEQ_CONT_ACL_UPDATE	/* input fields */	 \
+	((struct cont_op_in)	(caui_op)		CRT_VAR) \
+	((struct daos_acl)	(caui_acl)		CRT_PTR)
+
+#define DAOS_OSEQ_CONT_ACL_UPDATE	/* output fields */	 \
+	((struct cont_op_out)	(cauo_op)		CRT_VAR)
+
+CRT_RPC_DECLARE(cont_acl_update, DAOS_ISEQ_CONT_ACL_UPDATE,
+		DAOS_OSEQ_CONT_ACL_UPDATE)
 
 static inline int
 cont_req_create(crt_context_t crt_ctx, crt_endpoint_t *tgt_ep, crt_opcode_t opc,

--- a/src/container/srv_container.c
+++ b/src/container/srv_container.c
@@ -1468,20 +1468,14 @@ cont_query(struct rdb_tx *tx, struct ds_pool_hdl *pool_hdl, struct cont *cont,
 	return rc;
 }
 
-int
-ds_cont_prop_set(struct rdb_tx *tx, struct ds_pool_hdl *pool_hdl,
-		 struct cont *cont, struct container_hdl *hdl,
-		 crt_rpc_t *rpc)
+static int
+set_prop(struct rdb_tx *tx, struct ds_pool_hdl *pool_hdl,
+	 struct cont *cont, struct container_hdl *hdl, uuid_t hdl_uuid,
+	 daos_prop_t *prop_in)
 {
-	struct cont_prop_set_in		*in  = crt_req_get(rpc);
-	daos_prop_t			*prop_in = in->cpsi_prop;
-	daos_prop_t			*prop_old = NULL;
-	daos_prop_t			*prop_iv = NULL;
-	int				rc = 0;
-
-	D_DEBUG(DF_DSMS, DF_CONT": processing rpc %p: hdl="DF_UUID"\n",
-		DP_CONT(pool_hdl->sph_pool->sp_uuid, in->cpsi_op.ci_uuid), rpc,
-		DP_UUID(in->cpsi_op.ci_hdl));
+	int		rc;
+	daos_prop_t	*prop_old = NULL;
+	daos_prop_t	*prop_iv = NULL;
 
 	if (!daos_prop_valid(prop_in, false, true))
 		D_GOTO(out, rc = -DER_INVAL);
@@ -1511,7 +1505,7 @@ ds_cont_prop_set(struct rdb_tx *tx, struct ds_pool_hdl *pool_hdl,
 
 	/* Update prop IV with merged prop */
 	rc = cont_iv_prop_update(pool_hdl->sph_pool->sp_iv_ns,
-				 in->cpsi_op.ci_hdl, cont->c_uuid, prop_iv);
+				 hdl_uuid, cont->c_uuid, prop_iv);
 	if (rc)
 		D_ERROR(DF_UUID": failed to update prop IV for cont, "
 			"%d.\n", DP_UUID(cont->c_uuid), rc);
@@ -1519,6 +1513,93 @@ ds_cont_prop_set(struct rdb_tx *tx, struct ds_pool_hdl *pool_hdl,
 out:
 	daos_prop_free(prop_old);
 	daos_prop_free(prop_iv);
+	return rc;
+}
+
+int
+ds_cont_prop_set(struct rdb_tx *tx, struct ds_pool_hdl *pool_hdl,
+		 struct cont *cont, struct container_hdl *hdl,
+		 crt_rpc_t *rpc)
+{
+	struct cont_prop_set_in		*in  = crt_req_get(rpc);
+	daos_prop_t			*prop_in = in->cpsi_prop;
+
+	D_DEBUG(DF_DSMS, DF_CONT": processing rpc %p: hdl="DF_UUID"\n",
+		DP_CONT(pool_hdl->sph_pool->sp_uuid, in->cpsi_op.ci_uuid), rpc,
+		DP_UUID(in->cpsi_op.ci_hdl));
+
+	return set_prop(tx, pool_hdl, cont, hdl, in->cpsi_op.ci_hdl, prop_in);
+}
+
+int
+ds_cont_acl_update(struct rdb_tx *tx, struct ds_pool_hdl *pool_hdl,
+		   struct cont *cont, struct container_hdl *hdl,
+		   crt_rpc_t *rpc)
+{
+	struct cont_acl_update_in	*in  = crt_req_get(rpc);
+	int				rc = 0;
+	daos_prop_t			*acl_prop = NULL;
+	daos_prop_t			*prop_in = NULL;
+	struct daos_prop_entry		*entry;
+	struct daos_acl			*acl_in;
+	struct daos_acl			*acl = NULL;
+	struct daos_ace			*ace;
+
+	D_DEBUG(DF_DSMS, DF_CONT": processing rpc %p: hdl="DF_UUID"\n",
+		DP_CONT(pool_hdl->sph_pool->sp_uuid, in->caui_op.ci_uuid), rpc,
+		DP_UUID(in->caui_op.ci_hdl));
+
+	acl_in = in->caui_acl;
+	if (daos_acl_cont_validate(acl_in) != 0)
+		D_GOTO(out, rc = -DER_INVAL);
+
+	rc = cont_prop_read(tx, cont, DAOS_CO_QUERY_PROP_ACL, &acl_prop);
+	if (rc != 0) {
+		D_ERROR(DF_UUID": failed to read ACL prop for cont, rc=%d\n",
+			DP_UUID(cont->c_uuid), rc);
+		D_GOTO(out, rc);
+	}
+
+	entry = daos_prop_entry_get(acl_prop, DAOS_PROP_CO_ACL);
+	if (entry == NULL) {
+		D_ERROR(DF_UUID": cont prop read didn't return ACL property\n",
+			DP_UUID(cont->c_uuid));
+		D_GOTO(out_prop, rc = -DER_NONEXIST);
+	}
+
+	acl = daos_acl_dup(entry->dpe_val_ptr);
+	if (acl == NULL) {
+		D_ERROR(DF_UUID": couldn't copy container's ACL for "
+			"modification\n",
+			DP_UUID(cont->c_uuid));
+		D_GOTO(out_prop, rc = -DER_NOMEM);
+	}
+
+	ace = daos_acl_get_next_ace(acl_in, NULL);
+	while (ace != NULL) {
+		rc = daos_acl_add_ace(&acl, ace);
+		if (rc != 0) {
+			D_ERROR(DF_UUID": failed to add/update ACEs\n",
+				DP_UUID(cont->c_uuid));
+			daos_acl_free(acl);
+			D_GOTO(out_prop, rc);
+		}
+
+		ace = daos_acl_get_next_ace(acl_in, ace);
+	}
+
+	/* Just need to re-set the ACL prop with the merged ACL */
+	prop_in = daos_prop_alloc(1);
+	prop_in->dpp_entries[0].dpe_type = DAOS_PROP_CO_ACL;
+	prop_in->dpp_entries[0].dpe_val_ptr = acl;
+	acl = NULL; /* we'll free it with the prop now */
+
+	rc = set_prop(tx, pool_hdl, cont, hdl, in->caui_op.ci_hdl, prop_in);
+	daos_prop_free(prop_in);
+
+out_prop:
+	daos_prop_free(acl_prop);
+out:
 	return rc;
 }
 
@@ -1844,6 +1925,8 @@ cont_op_with_hdl(struct rdb_tx *tx, struct ds_pool_hdl *pool_hdl,
 		return ds_cont_snap_destroy(tx, pool_hdl, cont, hdl, rpc);
 	case CONT_PROP_SET:
 		return ds_cont_prop_set(tx, pool_hdl, cont, hdl, rpc);
+	case CONT_ACL_UPDATE:
+		return ds_cont_acl_update(tx, pool_hdl, cont, hdl, rpc);
 	default:
 		D_ASSERT(0);
 	}

--- a/src/container/srv_internal.h
+++ b/src/container/srv_internal.h
@@ -156,6 +156,9 @@ void cont_svc_put_leader(struct cont_svc *svc);
 int ds_cont_prop_set(struct rdb_tx *tx, struct ds_pool_hdl *pool_hdl,
 		     struct cont *cont, struct container_hdl *hdl,
 		     crt_rpc_t *rpc);
+int ds_cont_acl_update(struct rdb_tx *tx, struct ds_pool_hdl *pool_hdl,
+		       struct cont *cont, struct container_hdl *hdl,
+		       crt_rpc_t *rpc);
 
 /*
  * srv_epoch.c

--- a/src/include/daos/container.h
+++ b/src/include/daos/container.h
@@ -61,6 +61,7 @@ int dc_cont_close(tse_task_t *task);
 int dc_cont_destroy(tse_task_t *task);
 int dc_cont_query(tse_task_t *task);
 int dc_cont_set_prop(tse_task_t *task);
+int dc_cont_update_acl(tse_task_t *task);
 int dc_cont_aggregate(tse_task_t *task);
 int dc_cont_rollback(tse_task_t *task);
 int dc_cont_subscribe(tse_task_t *task);

--- a/src/include/daos_cont.h
+++ b/src/include/daos_cont.h
@@ -322,6 +322,29 @@ daos_cont_overwrite_acl(daos_handle_t coh, struct daos_acl *acl,
 			daos_event_t *ev);
 
 /**
+ * Add new entries and/or update existing entries in a container's ACL.
+ *
+ * If an entry already exists in the container's ACL for a principal in the
+ * passed-in ACL, the entry will be replaced with the new one. Otherwise, a
+ * new entry will be added.
+ *
+ * \param[in]	coh	Container handle
+ * \param[in]	acl	ACL containing new/updated entries
+ * \param[in]	ev	Completion event, it is optional and can be NULL.
+ *			The function will run in blocking mode if \a ev is NULL.
+ *
+ * \return		These values will be returned by \a ev::ev_error in
+ *			non-blocking mode:
+ *			0		Success
+ *			-DER_INVAL	Invalid parameter
+ *			-DER_NO_PERM	Permission denied
+ *			-DER_UNREACH	Network is unreachable
+ *			-DER_NO_HDL	Invalid container handle
+ */
+int
+daos_cont_update_acl(daos_handle_t coh, struct daos_acl *acl, daos_event_t *ev);
+
+/**
  * List the names of all user-defined container attributes.
  *
  * \param[in]	coh	Container handle.

--- a/src/include/daos_task.h
+++ b/src/include/daos_task.h
@@ -78,6 +78,7 @@ typedef enum {
 	DAOS_OPC_CONT_DESTROY,
 	DAOS_OPC_CONT_QUERY,
 	DAOS_OPC_CONT_SET_PROP,
+	DAOS_OPC_CONT_UPDATE_ACL,
 	DAOS_OPC_CONT_AGGREGATE,
 	DAOS_OPC_CONT_ROLLBACK,
 	DAOS_OPC_CONT_SUBSCRIBE,
@@ -297,6 +298,11 @@ typedef struct {
 	daos_handle_t		coh;
 	daos_prop_t		*prop;
 } daos_cont_set_prop_t;
+
+typedef struct {
+	daos_handle_t		coh;
+	struct daos_acl		*acl;
+} daos_cont_update_acl_t;
 
 typedef struct {
 	daos_handle_t		coh;

--- a/src/tests/suite/daos_container.c
+++ b/src/tests/suite/daos_container.c
@@ -543,6 +543,7 @@ co_acl(void **state)
 	const char		*exp_owner = "fictionaluser@";
 	const char		*exp_owner_grp = "admins@";
 	struct daos_acl		*exp_acl;
+	struct daos_acl		*update_acl;
 	struct daos_ace		*ace;
 	uid_t			uid;
 	char			*user;
@@ -629,6 +630,30 @@ co_acl(void **state)
 
 	co_acl_get(arg, exp_acl, exp_owner, exp_owner_grp);
 
+	print_message("Case 3: update ACL\n");
+
+	/* Add one new entry and update an entry already in our ACL */
+	update_acl = daos_acl_create(NULL, 0);
+	add_ace_with_perms(&update_acl, DAOS_ACL_USER, "friendlyuser@",
+			   DAOS_ACL_PERM_READ | DAOS_ACL_PERM_WRITE);
+	add_ace_with_perms(&update_acl, DAOS_ACL_GROUP, "testgroup2@",
+			   DAOS_ACL_PERM_READ);
+
+	assert_int_equal(daos_acl_cont_validate(update_acl), 0);
+
+	/* Update expected ACL to include changes */
+	ace = daos_acl_get_next_ace(update_acl, NULL);
+	while (ace != NULL) {
+		assert_int_equal(daos_acl_add_ace(&exp_acl, ace), 0);
+		ace = daos_acl_get_next_ace(update_acl, ace);
+	}
+
+	rc = daos_cont_update_acl(arg->coh, update_acl, NULL);
+	assert_int_equal(rc, 0);
+
+	co_acl_get(arg, exp_acl, exp_owner, exp_owner_grp);
+
+	/* Clean up */
 	if (arg->myrank == 0)
 		daos_mgmt_set_params(arg->group, -1, DMG_KEY_FAIL_LOC, 0,
 				     0, NULL);
@@ -636,6 +661,7 @@ co_acl(void **state)
 
 	daos_prop_free(prop_in);
 	daos_acl_free(exp_acl);
+	daos_acl_free(update_acl);
 	D_FREE(user);
 	test_teardown((void **)&arg);
 }

--- a/src/utils/daos.c
+++ b/src/utils/daos.c
@@ -84,6 +84,8 @@ cont_op_parse(const char *str)
 		return CONT_GET_ACL;
 	else if (strcmp(str, "overwrite-acl") == 0)
 		return CONT_OVERWRITE_ACL;
+	else if (strcmp(str, "update-acl") == 0)
+		return CONT_UPDATE_ACL;
 	return -1;
 }
 
@@ -468,6 +470,7 @@ common_op_parse_hdlr(int argc, char *argv[], struct cmd_args_s *ap)
 		{"outfile",	required_argument,	NULL,	'O'},
 		{"verbose",	no_argument,		NULL,	'V'},
 		{"acl-file",	required_argument,	NULL,	'A'},
+		{"entry",	required_argument,	NULL,	'E'},
 		{NULL,		0,			NULL,	0}
 	};
 	int			rc;
@@ -647,6 +650,11 @@ common_op_parse_hdlr(int argc, char *argv[], struct cmd_args_s *ap)
 			if (ap->aclfile == NULL)
 				D_GOTO(out_free, rc = RC_NO_HELP);
 			break;
+		case 'E':
+			D_STRNDUP(ap->entry, optarg, strlen(optarg));
+			if (ap->entry == NULL)
+				D_GOTO(out_free, rc = RC_NO_HELP);
+			break;
 		case DAOS_PROPERTIES_OPTION:
 			/* parse properties to be set at cont create time */
 			/* alloc max */
@@ -728,6 +736,8 @@ out_free:
 		D_FREE(ap->outfile);
 	if (ap->aclfile != NULL)
 		D_FREE(ap->aclfile);
+	if (ap->entry != NULL)
+		D_FREE(ap->entry);
 	D_FREE(cmdname);
 	return rc;
 }
@@ -904,6 +914,9 @@ cont_op_hdlr(struct cmd_args_s *ap)
 	case CONT_OVERWRITE_ACL:
 		rc = cont_overwrite_acl_hdlr(ap);
 		break;
+	case CONT_UPDATE_ACL:
+		rc = cont_update_acl_hdlr(ap);
+		break;
 	default:
 		break;
 	}
@@ -1070,6 +1083,7 @@ help_hdlr(struct cmd_args_s *ap)
 "	  query            query a container\n"
 "	  get-acl          get a container's ACL\n"
 "	  overwrite-acl    replace a container's ACL\n"
+"	  update-acl       add/modify entries in a container's ACL\n"
 "	  stat             get container statistics\n"
 "	  list-attrs       list container user-defined attributes\n"
 "	  del-attr         delete container user-defined attribute\n"
@@ -1139,7 +1153,9 @@ help_hdlr(struct cmd_args_s *ap)
 "	--epc=EPOCHNUM     container epoch (destroy-snap, rollback)\n"
 "	--eprange=B-E      container epoch range (destroy-snap)\n"
 "container options (ACL-related):\n"
-"	--acl-file=PATH    input file containing ACL (overwrite-acl)\n"
+"	--acl-file=PATH    input file containing ACL (overwrite-acl, "
+"			   update-acl)\n"
+"	--entry=ACE        add or modify a single ACL entry (update-acl)\n"
 "	--verbose          verbose mode (get-acl)\n"
 "	--outfile=PATH     write ACL to file (get-acl)\n");
 

--- a/src/utils/daos_hdlr.h
+++ b/src/utils/daos_hdlr.h
@@ -39,6 +39,7 @@ enum cont_op {
 	CONT_ROLLBACK,
 	CONT_GET_ACL,
 	CONT_OVERWRITE_ACL,
+	CONT_UPDATE_ACL,
 };
 
 enum pool_op {
@@ -95,6 +96,7 @@ struct cmd_args_s {
 	char			*outfile;	/* --outfile path */
 	char			*aclfile;	/* --acl-file path */
 	bool			verbose;	/* --verbose mode */
+	char			*entry;		/* --entry for ACL */
 };
 
 #define ARGS_VERIFY_PUUID(ap, label, rcexpr)			\
@@ -197,6 +199,7 @@ int cont_list_snaps_hdlr(struct cmd_args_s *ap);
 int cont_destroy_snap_hdlr(struct cmd_args_s *ap);
 int cont_get_acl_hdlr(struct cmd_args_s *ap);
 int cont_overwrite_acl_hdlr(struct cmd_args_s *ap);
+int cont_update_acl_hdlr(struct cmd_args_s *ap);
 
 /* TODO implement the following container op functions
  * all with signatures similar to this:


### PR DESCRIPTION
This new command and client API function allow a user
to add or update individual entries in a container's
ACL.

- Add container update ACL API endpoint.
- Add update case to daos_test container ACL tests.
- Add cont update-acl command to the daos user tool.

Signed-off-by: Kris Jacque <kristin.jacque@intel.com>