### PR TITLE
DAOS-4113 test: Unknown 37s "time gap" in server startup

### DIFF
--- a/src/tests/ftest/pool/connect_test.yaml
+++ b/src/tests/ftest/pool/connect_test.yaml
@@ -4,6 +4,7 @@ hosts:
   test_servers:
     - server-A
     - server-B
+timeout: 120
 server_manager:
   recreate: true
 server_config:


### PR DESCRIPTION
Summary: Increasing timeout for connect_test
since there is a 37s server startup time
during PR run. This is causing test timeout of
60 seconds to be low. A new ticket will be
created to address 37s server startup issue.

Signed-off-by: Padmanabhan <ravindran.padmanabhan@intel.com>