### PR TITLE
DAOS-4066 pydaos: Handle DER_REC2BIG from kv get correctly.

### DIFF
--- a/src/client/pydaos/daosdbm.py
+++ b/src/client/pydaos/daosdbm.py
@@ -45,9 +45,10 @@ class daos_named_kv():
         except Exception:
             pass
 
-        os.environ['CRT_PHY_ADDR_STR'] = transport
-        os.environ['OFI_INTERFACE'] = interface
-        os.environ['DAOS_SINGLETON_CLI'] = '1'
+        if 'CRT_PHY_ADDR_STR' not in os.environ:
+            os.environ['CRT_PHY_ADDR_STR'] = transport
+        if interface and 'OFI_INTERFACE' not in os.environ:
+            os.environ['OFI_INTERFACE'] = interface
 
         self.daos = __import__('pydaos')
 
@@ -70,6 +71,56 @@ class daos_named_kv():
         for kv in self.root_kv:
             yield kv
 
+LENGTH_KEY = '__length'
+
+def new_migrate(root):
+
+    batch_size = 200
+
+    files = sorted(daos_root.get_kv_list())
+
+    if 'root' in files:
+        files.remove('root')
+
+    target = root.get_kv_by_name('root')
+
+    target_offset = 0
+
+    for ifile in files:
+
+        index = 0
+
+        source = root.get_kv_by_name(ifile)
+
+        at_end = False
+
+        start_time = time.time()
+
+        while not at_end:
+            data = {}
+            for i in range(index, index + batch_size):
+
+                index += 1
+
+                data[str(i)] = None
+
+            source.bget(data)
+            tdata = {}
+
+            for key in data:
+                if data[key] is None:
+                    at_end = True
+                else:
+                    i = int(key)
+                    tdata[src(i+target_offset)] = data[key]
+
+            target.bput(tdata)
+            now = time.time()
+
+        target_offset += pickle.loads(source[LENGTH_KEY])
+
+        target[LENGTH_KEY] = pickle.dumps(target_offset)
+
 def main():
     """Migrate data from dbm file to named DAOS KV"""
 
@@ -85,6 +136,10 @@ def main():
                           CUID)
 
     print('Kvs are {}'.format(','.join(sorted(my_kv.get_kv_list()))))
+
+    if True:
+        new_migrate(my_kv)
+        return
 
     if len(sys.argv) != 5:
         print('Also need directory/file to import')
@@ -102,8 +157,6 @@ def main():
 
     kv = my_kv.get_kv_by_name(src_file)
 
-    LENGTH_KEY = '__length'
-
     count = pickle.loads(db[LENGTH_KEY])
 
     try:
@@ -111,8 +164,6 @@ def main():
         start_count += 1
     except KeyError:
         start_count = 0
-
-    start_count = 0
 
     print('Copying records from {} to {}'.format(start_count, count))
 
@@ -122,41 +173,48 @@ def main():
     last_report_time = start_time
     to_copy = count - start_count + 1
     # CHANGE THIS TO MODIFY REPORTING FREQUENCY
-    report_freq = 0.1
+    report_freq = 2
 
     bytes_total = 0
 
     try:
-        for idx in range(start_count, count + 1):
+        tdata = {}
+        idx = count
+        for idx in range(start_count, count):
             key = str(idx)
             value = db[key]
-            value_len = len(value)
-            bytes_total += value_len
-            kv[key] = value
-            kv[LENGTH_KEY] = pickle.dumps(idx)
+            tdata[key] = value
 
             copy_count += 1
             now = time.perf_counter()
+
+            if idx % 400 == 0:
+                tdata[LENGTH_KEY] = pickle.dumps(idx)
+                kv.bput(tdata)
+                tdata = {}
 
             if now - last_report_time > report_freq:
 
                 time_per_record = (now - start_time) / copy_count
 
                 # Make the remaining time in minutes so it's easier to parse
-                remaining_time = int((time_per_record * (to_copy - copy_count)/60))
+                remaining_time = int((time_per_record * (to_copy - copy_count)))
 
-                print('Copied {}/{} records in {:.2f} seconds {} minutes remaining.'.format(copy_count,
-                                                                                            to_copy,
-                                                                                            now - start_time,
-                                                                                            remaining_time))
+                print('Copied {}/{} records in {:.2f} seconds ({:.0f}) {} seconds remaining.'.format(copy_count,
+                                                                                                    to_copy,
+                                                                                                    now - start_time,
+                                                                                                    copy_count / (now - start_time),
+                                                                                                    remaining_time))
                 last_report_time = now
+        tdata[LENGTH_KEY] = pickle.dumps(idx)
+        kv.bput(tdata)
+
     except KeyboardInterrupt:
         pass
 
     now = time.perf_counter()
     print('Completed, Copied {} records in {:.2f} seconds.'.format(copy_count,
                                                                    now - start_time))
-    print('Copied {} bytes'.format(bytes_total))
 
 if __name__ == '__main__':
     main()

--- a/src/client/pydaos/daosdbm.py
+++ b/src/client/pydaos/daosdbm.py
@@ -74,10 +74,11 @@ class daos_named_kv():
 LENGTH_KEY = '__length'
 
 def new_migrate(root):
+    """Migrate data from multiple KVs to a single KV"""
 
     batch_size = 200
 
-    files = sorted(daos_root.get_kv_list())
+    files = sorted(root.get_kv_list())
 
     if 'root' in files:
         files.remove('root')
@@ -93,8 +94,6 @@ def new_migrate(root):
         source = root.get_kv_by_name(ifile)
 
         at_end = False
-
-        start_time = time.time()
 
         while not at_end:
             data = {}
@@ -112,10 +111,9 @@ def new_migrate(root):
                     at_end = True
                 else:
                     i = int(key)
-                    tdata[src(i+target_offset)] = data[key]
+                    tdata[str(i+target_offset)] = data[key]
 
             target.bput(tdata)
-            now = time.time()
 
         target_offset += pickle.loads(source[LENGTH_KEY])
 
@@ -201,10 +199,10 @@ def main():
                 remaining_time = int((time_per_record * (to_copy - copy_count)))
 
                 print('Copied {}/{} records in {:.2f} seconds ({:.0f}) {} seconds remaining.'.format(copy_count,
-                                                                                                    to_copy,
-                                                                                                    now - start_time,
-                                                                                                    copy_count / (now - start_time),
-                                                                                                    remaining_time))
+                                                                                                     to_copy,
+                                                                                                     now - start_time,
+                                                                                                     copy_count / (now - start_time),
+                                                                                                     remaining_time))
                 last_report_time = now
         tdata[LENGTH_KEY] = pickle.dumps(idx)
         kv.bput(tdata)

--- a/src/client/pydaos/pydaos_core.py
+++ b/src/client/pydaos/pydaos_core.py
@@ -304,9 +304,9 @@ class KVObj(_Obj):
     def __delitem__(self, key):
         self.put(key, None)
 
-    def bget(self, ddict):
+    def bget(self, ddict, value_size=4096):
         """Bulk get value for all the keys of the input python dictionary."""
-        ret = pydaos_shim.kv_get(DAOS_MAGIC, self.oh, ddict)
+        ret = pydaos_shim.kv_get(DAOS_MAGIC, self.oh, ddict, value_size)
         if ret != pydaos_shim.DER_SUCCESS:
             raise PyDError("failed to retrieve KV value", ret)
 

--- a/src/client/pydaos/pydaos_shim.c
+++ b/src/client/pydaos/pydaos_shim.c
@@ -629,9 +629,10 @@ rewait:
 		if (ret == 1) {
 			int rc2;
 
+			op = container_of(evp, struct kv_op, ev);
+
 			/** check result of completed operation */
 			if (evp->ev_error == DER_SUCCESS) {
-				op = container_of(evp, struct kv_op, ev);
 				rc2 = kv_get_comp(op, daos_dict);
 				if (rc == DER_SUCCESS && rc2 != DER_SUCCESS)
 					D_GOTO(err, rc = rc2);
@@ -642,7 +643,6 @@ rewait:
 				daos_event_fini(evp);
 				rc2 = daos_event_init(evp, eq, NULL);
 
-				op = container_of(evp, struct kv_op, ev);
 				op->size *= 2;
 				D_REALLOC(new_buff, op->buf, op->size);
 				if (new_buff == NULL)

--- a/src/client/pydaos/pydaos_shim.c
+++ b/src/client/pydaos/pydaos_shim.c
@@ -23,7 +23,6 @@
 #ifdef __USE_PYTHON3__
 /* Those are gone from python3, replaced with new functions */
 #define PyInt_FromLong		PyLong_FromLong
-#define PyInt_AsLong		PyLong_AsLong
 #define PyString_FromString	PyUnicode_FromString
 #define PyString_FromStringAndSize PyUnicode_FromStringAndSize
 #define PyString_AsString	PyBytes_AsString
@@ -502,6 +501,8 @@ kv_get_comp(struct kv_op *op, PyObject *daos_dict)
 	else
 		rc = DER_SUCCESS;
 
+	Py_DECREF(val);
+
 	return rc;
 }
 
@@ -704,7 +705,8 @@ __shim_handle__kv_put(PyObject *self, PyObject *args)
 	int		 ret;
 
 	/* Parse arguments */
-	RETURN_NULL_IF_FAILED_TO_PARSE(args, "LO", &oh.cookie, &daos_dict);
+	RETURN_NULL_IF_FAILED_TO_PARSE(args, "LO!", &oh.cookie,
+				&PyDict_Type, &daos_dict);
 
 	rc = daos_eq_create(&eq);
 	if (rc)

--- a/src/client/pydaos/pydaos_shim.c
+++ b/src/client/pydaos/pydaos_shim.c
@@ -653,7 +653,7 @@ rewait:
 				rc2 = daos_kv_get(oh, DAOS_TX_NONE, 0, op->key,
 						&op->size, op->buf, evp);
 				if (rc2 != -DER_SUCCESS)
-					D_GOTO(out, 0);
+					D_GOTO(out, rc = rc2);
 			} else {
 				if (rc == DER_SUCCESS)
 					rc = evp->ev_error;

--- a/src/include/daos_kv.h
+++ b/src/include/daos_kv.h
@@ -79,7 +79,7 @@ daos_kv_put(daos_handle_t oh, daos_handle_t th, uint64_t flags, const char *key,
  * \param[in,out]
  *		size	[in]: Size of the user buf. if the size is unknown, set
  *			to DAOS_REC_ANY). [out]: The actual size of the value.
- * \param[in]	buf	Pointer to user buffer. If NULL, only size is returned.
+ * \param[out]	buf	Pointer to user buffer. If NULL, only size is returned.
  * \param[in]	ev	Completion event, it is optional and can be NULL.
  *			Function will run in blocking mode if \a ev is NULL.
  *
@@ -90,6 +90,7 @@ daos_kv_put(daos_handle_t oh, daos_handle_t th, uint64_t flags, const char *key,
  *			-DER_INVAL	Invalid parameter
  *			-DER_NO_PERM	Permission denied
  *			-DER_UNREACH	Network is unreachable
+ *			-DER_REC2BIG	Record does not fit in buffer
  *			-DER_EP_RO	Epoch is read-only
  */
 int


### PR DESCRIPTION
Handle REC2BIG in kvget by using the size supplied from daos to reallocate the buffer and retry.  This allows an initial get to be attempted with a default buffer, and if the size is insufficient then a second get is all that is needed to fetch the data.
Track buffer sizes properly, so once a buffer has grown it is reused as the new size for subsequent gets in the same call.
Allow the python code to provide an initial buffer size.
Fix a bug in get where a reference was kept on the data after adding it to the dict, which resulted in a memory leak.