### PR TITLE
DAOS-4132 iosrv: fix compiling issue with hwloc 2.x

### DIFF
--- a/src/iosrv/init.c
+++ b/src/iosrv/init.c
@@ -312,12 +312,12 @@ dss_topo_init()
 		corenode = hwloc_get_obj_by_depth(dss_topo, dss_core_depth, k);
 		if (corenode == NULL)
 			continue;
-		if (hwloc_bitmap_isincluded(corenode->allowed_cpuset,
-					    numa_obj->allowed_cpuset) != 0) {
+		if (hwloc_bitmap_isincluded(corenode->cpuset,
+					    numa_obj->cpuset) != 0) {
 			if (num_cores_visited++ >= dss_core_offset) {
 				hwloc_bitmap_set(core_allocation_bitmap, k);
 				hwloc_bitmap_asprintf(&cpuset,
-						      corenode->allowed_cpuset);
+						      corenode->cpuset);
 			}
 			dss_num_cores_numa_node++;
 		}

--- a/src/iosrv/srv.c
+++ b/src/iosrv/srv.c
@@ -801,7 +801,7 @@ dss_start_xs_id(int xs_id)
 			return -DER_INVAL;
 		}
 
-		hwloc_bitmap_asprintf(&cpuset, obj->allowed_cpuset);
+		hwloc_bitmap_asprintf(&cpuset, obj->cpuset);
 		D_DEBUG(DB_TRACE, "Using CPU set %s\n", cpuset);
 		free(cpuset);
 	} else {
@@ -824,7 +824,7 @@ dss_start_xs_id(int xs_id)
 		}
 	}
 
-	rc = dss_start_one_xstream(obj->allowed_cpuset, xs_id);
+	rc = dss_start_one_xstream(obj->cpuset, xs_id);
 	if (rc)
 		return rc;
 


### PR DESCRIPTION
In hwloc 2.x the allowed_cpuset is removed from hwloc_obj_t, and only
exports it by whole hwloc_topology and query it by
hwloc_topology_get_allowed_cpuset().

In DAOS usage, we don't set the HWLOC_TOPOLOGY_FLAG_WHOLE_SYSTEM for
hw_togology, so the allowed_cpuset is same as cpuset. So this patch just
replace the usage of allowed_cpuset by cpuset which is still exported.

Signed-off-by: Xuezhao Liu <xuezhao.liu@intel.com>