### PR TITLE
DAOS-4036 control: Always forward privileged requests

### DIFF
--- a/src/control/cmd/daos_admin/handler_test.go
+++ b/src/control/cmd/daos_admin/handler_test.go
@@ -1,5 +1,5 @@
 //
-// (C) Copyright 2019 Intel Corporation.
+// (C) Copyright 2019-2020 Intel Corporation.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -28,6 +28,7 @@ import (
 	"io/ioutil"
 	"math/rand"
 	"os"
+	"strings"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -51,7 +52,7 @@ func parseResponse(t *testing.T, buf *bytes.Buffer) *pbin.Response {
 	return &res
 }
 
-func TestHandler(t *testing.T) {
+func TestDaosAdmin_Handler(t *testing.T) {
 	testTarget, err := ioutil.TempDir("", t.Name())
 	if err != nil {
 		t.Fatal(err)
@@ -59,7 +60,7 @@ func TestHandler(t *testing.T) {
 	defer os.RemoveAll(testTarget)
 
 	nilPayloadResp := &pbin.Response{
-		Error: &pbin.RequestFailure{Message: "unexpected end of JSON input"},
+		Error: pbin.PrivilegedHelperRequestFailed("unexpected end of JSON input"),
 	}
 	successResp := &pbin.Response{}
 	mountReqPayload, err := json.Marshal(scm.MountRequest{
@@ -142,8 +143,14 @@ func TestHandler(t *testing.T) {
 				Method: "OopsKaboom",
 			},
 			expRes: &pbin.Response{
-				Error: &pbin.RequestFailure{Message: `unhandled method "OopsKaboom"`},
+				Error: pbin.PrivilegedHelperRequestFailed(`unhandled method "OopsKaboom"`),
 			},
+		},
+		"Ping": {
+			req: &pbin.Request{
+				Method: "Ping",
+			},
+			expRes: successResp,
 		},
 		"ScmMount nil payload": {
 			req: &pbin.Request{
@@ -167,7 +174,7 @@ func TestHandler(t *testing.T) {
 				MountErr: errors.New("mount failed"),
 			},
 			expRes: &pbin.Response{
-				Error: &pbin.RequestFailure{Message: "mount failed"},
+				Error: pbin.PrivilegedHelperRequestFailed("mount failed"),
 			},
 		},
 		"ScmUnmount nil payload": {
@@ -192,7 +199,7 @@ func TestHandler(t *testing.T) {
 				UnmountErr: errors.New("unmount failed"),
 			},
 			expRes: &pbin.Response{
-				Error: &pbin.RequestFailure{Message: "unmount failed"},
+				Error: pbin.PrivilegedHelperRequestFailed("unmount failed"),
 			},
 		},
 		"ScmFormat nil payload": {
@@ -217,7 +224,7 @@ func TestHandler(t *testing.T) {
 				MountErr: errors.New("mount failed"),
 			},
 			expRes: &pbin.Response{
-				Error: &pbin.RequestFailure{Message: "mount failed"},
+				Error: pbin.PrivilegedHelperRequestFailed("mount failed"),
 			},
 		},
 		"ScmCheckFormat nil payload": {
@@ -242,7 +249,7 @@ func TestHandler(t *testing.T) {
 				DiscoverErr: errors.New("scan failed"),
 			},
 			expRes: &pbin.Response{
-				Error: &pbin.RequestFailure{Message: "scan failed"},
+				Error: pbin.PrivilegedHelperRequestFailed("scan failed"),
 			},
 		},
 		"ScmPrepare nil payload": {
@@ -267,7 +274,7 @@ func TestHandler(t *testing.T) {
 				DiscoverErr: errors.New("scan failed"),
 			},
 			expRes: &pbin.Response{
-				Error: &pbin.RequestFailure{Message: "scan failed"},
+				Error: pbin.PrivilegedHelperRequestFailed("scan failed"),
 			},
 		},
 		"ScmScan nil payload": {
@@ -292,7 +299,7 @@ func TestHandler(t *testing.T) {
 				DiscoverErr: errors.New("scan failed"),
 			},
 			expRes: &pbin.Response{
-				Error: &pbin.RequestFailure{Message: "scan failed"},
+				Error: pbin.PrivilegedHelperRequestFailed("scan failed"),
 			},
 		},
 		"BdevInit nil payload": {
@@ -317,7 +324,7 @@ func TestHandler(t *testing.T) {
 				InitErr: errors.New("init failed"),
 			},
 			expRes: &pbin.Response{
-				Error: &pbin.RequestFailure{Message: "init failed"},
+				Error: pbin.PrivilegedHelperRequestFailed("init failed"),
 			},
 		},
 		"BdevScan nil payload": {
@@ -342,7 +349,7 @@ func TestHandler(t *testing.T) {
 				ScanErr: errors.New("scan failed"),
 			},
 			expRes: &pbin.Response{
-				Error: &pbin.RequestFailure{Message: "scan failed"},
+				Error: pbin.PrivilegedHelperRequestFailed("scan failed"),
 			},
 		},
 		"BdevPrepare nil payload": {
@@ -367,7 +374,7 @@ func TestHandler(t *testing.T) {
 				PrepareErr: errors.New("prepare failed"),
 			},
 			expRes: &pbin.Response{
-				Error: &pbin.RequestFailure{Message: "prepare failed"},
+				Error: pbin.PrivilegedHelperRequestFailed("prepare failed"),
 			},
 		},
 		"BdevFormat nil payload": {
@@ -411,13 +418,21 @@ func TestHandler(t *testing.T) {
 				// We don't need to check the payload details here; we just
 				// want to check that a response came back and that the Error
 				// field was what we expected.
-				common.CmpErr(t, tc.expRes.Error, gotRes.Error)
+				wantErr := tc.expRes.Error
+				gotErr := gotRes.Error
+				if gotErr == wantErr {
+					return
+				}
+				if (gotErr == nil || wantErr == nil) ||
+					!strings.Contains(gotErr.Description, wantErr.Description) {
+					t.Fatalf("unexpected error: wanted %s, got %s", wantErr, gotErr)
+				}
 			}
 		})
 	}
 }
 
-func TestReadRequest(t *testing.T) {
+func TestDaosAdmin_ReadRequest(t *testing.T) {
 	alnum := []byte("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789")
 	giantPayload := make([]byte, pbin.MaxMessageSize)
 	for i := 0; i < len(giantPayload); i++ {

--- a/src/control/cmd/daos_admin/main.go
+++ b/src/control/cmd/daos_admin/main.go
@@ -1,5 +1,5 @@
 //
-// (C) Copyright 2019 Intel Corporation.
+// (C) Copyright 2019-2020 Intel Corporation.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -25,6 +25,7 @@ package main
 
 import (
 	"fmt"
+	"io"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -41,12 +42,24 @@ import (
 
 var daosVersion string
 
+// exitWithError logs the error to stderr and exits.
 func exitWithError(log logging.Logger, err error) {
 	if err == nil {
 		err = errors.New("Unknown error")
 	}
 	log.Error(err.Error())
 	os.Exit(1)
+}
+
+// sendFailureAndExit attempts to send the failure back
+// to the parent and then exits.
+func sendFailureAndExit(log logging.Logger, err error, dest io.Writer) {
+	res := &pbin.Response{}
+	sendErr := sendFailure(err, res, dest)
+	if sendErr != nil {
+		exitWithError(log, errors.Wrap(sendErr, fmt.Sprintf("failed to send %s", err)))
+	}
+	exitWithError(log, err)
 }
 
 func configureLogging(binName string) logging.Logger {
@@ -84,16 +97,18 @@ func main() {
 
 	checkParentName(log)
 
+	// set up the r/w pipe from the parent process
+	conn := pbin.NewStdioConn(binName, "daos_server", os.Stdin, os.Stdout)
+
 	if os.Geteuid() != 0 {
-		exitWithError(log, errors.Errorf("%s not setuid root", binName))
+		sendFailureAndExit(log, pbin.PrivilegedHelperNotPrivileged(os.Args[0]), conn)
 	}
 
 	// hack for stuff that doesn't use geteuid() (e.g. ipmctl)
 	if err := setuid(0); err != nil {
-		exitWithError(log, errors.Wrap(err, "unable to setuid(0)"))
+		sendFailureAndExit(log, errors.Wrap(err, "unable to setuid(0)"), conn)
 	}
 
-	conn := pbin.NewStdioConn(binName, "daos_server", os.Stdin, os.Stdout)
 	req, err := readRequest(log, conn)
 	if err != nil {
 		exitWithError(log, err)

--- a/src/control/cmd/daos_server/main.go
+++ b/src/control/cmd/daos_server/main.go
@@ -1,5 +1,5 @@
 //
-// (C) Copyright 2019 Intel Corporation.
+// (C) Copyright 2019-2020 Intel Corporation.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -35,6 +35,7 @@ import (
 	"github.com/daos-stack/daos/src/control/fault"
 	"github.com/daos-stack/daos/src/control/lib/netdetect"
 	"github.com/daos-stack/daos/src/control/logging"
+	"github.com/daos-stack/daos/src/control/pbin"
 	"github.com/daos-stack/daos/src/control/server"
 )
 
@@ -137,6 +138,11 @@ func parseOpts(args []string, opts *mainOpts, log *logging.LeveledLogger) error 
 func main() {
 	log := logging.NewCommandLineLogger()
 	var opts mainOpts
+
+	// Check this right away to avoid lots of annoying failures later.
+	if err := pbin.CheckHelper(log, pbin.DaosAdminName); err != nil {
+		exitWithError(log, err)
+	}
 
 	if err := parseOpts(os.Args[1:], &opts, log); err != nil {
 		if errors.Cause(err) == context.Canceled {

--- a/src/control/fault/code/codes.go
+++ b/src/control/fault/code/codes.go
@@ -33,6 +33,9 @@ const (
 	// general fault codes
 	Unknown Code = iota
 	MissingSoftwareDependency
+	PrivilegedHelperNotPrivileged
+	PrivilegedHelperNotAvailable
+	PrivilegedHelperRequestFailed
 
 	// generic storage fault codes
 	StorageUnknown Code = iota + 100

--- a/src/control/fault/fault.go
+++ b/src/control/fault/fault.go
@@ -1,5 +1,5 @@
 //
-// (C) Copyright 2018-2019 Intel Corporation.
+// (C) Copyright 2018-2020 Intel Corporation.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -109,10 +109,10 @@ func (f *Fault) Error() string {
 // resolve to the same fault code, then they are considered equivalent.
 func (f *Fault) Equals(raw error) bool {
 	other, ok := errors.Cause(raw).(*Fault)
-	if !ok {
+	if !ok || other == nil {
 		return false
 	}
-	return f.Code == other.Code && f.Description == other.Description
+	return f.Code == other.Code
 }
 
 // ShowResolutionFor attempts to return the resolution string for the
@@ -123,7 +123,7 @@ func ShowResolutionFor(raw error) string {
 	fmtStr := "%s: code = %d resolution = %q"
 
 	f, ok := errors.Cause(raw).(*Fault)
-	if !ok {
+	if !ok || f == nil {
 		return fmt.Sprintf(fmtStr, UnknownDomainStr, code.Unknown, ResolutionUnknown)
 	}
 	if f.Resolution == ResolutionEmpty {
@@ -136,8 +136,14 @@ func ShowResolutionFor(raw error) string {
 // defined.
 func HasResolution(raw error) bool {
 	f, ok := errors.Cause(raw).(*Fault)
-	if !ok || f.Resolution == ResolutionEmpty {
+	if !ok || f == nil || f.Resolution == ResolutionEmpty {
 		return false
 	}
 	return true
+}
+
+// IsFault indicates whether or not the error is a Fault
+func IsFault(raw error) bool {
+	_, ok := errors.Cause(raw).(*Fault)
+	return ok
 }

--- a/src/control/fault/fault_test.go
+++ b/src/control/fault/fault_test.go
@@ -1,5 +1,5 @@
 //
-// (C) Copyright 2018-2019 Intel Corporation.
+// (C) Copyright 2018-2020 Intel Corporation.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -39,6 +39,7 @@ func TestFaults(t *testing.T) {
 		testErr     error
 		expFaultStr string
 		expFaultRes string
+		expNotFault bool
 	}{
 		{
 			name:        "nil error",
@@ -49,6 +50,7 @@ func TestFaults(t *testing.T) {
 			name:        "normal error",
 			testErr:     fmt.Errorf("not a fault"),
 			expFaultStr: "not a fault",
+			expNotFault: true,
 			expFaultRes: "unknown: code = 0 resolution = \"no known resolution\"",
 		},
 		{
@@ -96,6 +98,12 @@ func TestFaults(t *testing.T) {
 					t.Fatalf("expected %q, got %q", tc.expFaultStr, tc.testErr)
 				}
 			}
+
+			isFault := fault.IsFault(tc.testErr)
+			if tc.expNotFault && isFault {
+				t.Fatalf("expected %+v to not be a fault", tc.testErr)
+			}
+
 			actual := fault.ShowResolutionFor(tc.testErr)
 			if actual != tc.expFaultRes {
 				t.Fatalf("expected %q, got %q", tc.expFaultRes, actual)
@@ -145,11 +153,6 @@ func TestFaultComparison(t *testing.T) {
 		{
 			name:          "comparison with other different code",
 			other:         &fault.Fault{Code: testErr.Code + 1, Description: testErr.Description},
-			expComparison: false,
-		},
-		{
-			name:          "comparison with other different description",
-			other:         &fault.Fault{Code: testErr.Code, Description: testErr.Description + "A"},
 			expComparison: false,
 		},
 		{

--- a/src/control/pbin/exec.go
+++ b/src/control/pbin/exec.go
@@ -1,5 +1,5 @@
 //
-// (C) Copyright 2019 Intel Corporation.
+// (C) Copyright 2019-2020 Intel Corporation.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -32,6 +32,7 @@ import (
 
 	"github.com/pkg/errors"
 
+	"github.com/daos-stack/daos/src/control/fault"
 	"github.com/daos-stack/daos/src/control/logging"
 )
 
@@ -46,16 +47,10 @@ type (
 		Payload json.RawMessage
 	}
 
-	// RequestFailure represents a failed request. The error message
-	// (if available) is stored as a string in the Message field.
-	RequestFailure struct {
-		Message string
-	}
-
 	// Response represents a response received from the privileged binary. The
 	// payload field contains a JSON-encoded representation of the wrapped response.
 	Response struct {
-		Error   *RequestFailure
+		Error   *fault.Fault
 		Payload json.RawMessage
 	}
 
@@ -64,18 +59,6 @@ type (
 		prefix string
 	}
 )
-
-func IsFailedRequest(err error) bool {
-	_, ok := err.(*RequestFailure)
-	return ok
-}
-
-func (rf *RequestFailure) Error() string {
-	if rf == nil {
-		return "nil *RequestFailure"
-	}
-	return rf.Message
-}
 
 func (cl *cmdLogger) Write(data []byte) (int, error) {
 	if cl.logFn == nil {

--- a/src/control/pbin/faults.go
+++ b/src/control/pbin/faults.go
@@ -1,0 +1,62 @@
+//
+// (C) Copyright 2020 Intel Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// GOVERNMENT LICENSE RIGHTS-OPEN SOURCE SOFTWARE
+// The Government's rights to use, modify, reproduce, release, perform, display,
+// or disclose this software are subject to the terms of the Apache License as
+// provided in Contract No. 8F-30005.
+// Any reproduction of computer software, computer software documentation, or
+// portions thereof marked with this legend must also reproduce the markings.
+//
+package pbin
+
+import (
+	"fmt"
+
+	"github.com/daos-stack/daos/src/control/fault"
+	"github.com/daos-stack/daos/src/control/fault/code"
+)
+
+func PrivilegedHelperNotAvailable(helperName string) *fault.Fault {
+	return pbinFault(
+		code.PrivilegedHelperNotAvailable,
+		fmt.Sprintf("the privileged helper (%s) was not found or is not executable", helperName),
+		"check the DAOS admin guide for details on privileged helper setup",
+	)
+}
+
+func PrivilegedHelperNotPrivileged(helperName string) *fault.Fault {
+	return pbinFault(
+		code.PrivilegedHelperNotPrivileged,
+		fmt.Sprintf("the privileged helper (%s) does not have root permissions", helperName),
+		"check the DAOS admin guide for details on privileged helper setup",
+	)
+}
+
+func PrivilegedHelperRequestFailed(message string) *fault.Fault {
+	return pbinFault(
+		code.PrivilegedHelperRequestFailed,
+		message, "",
+	)
+}
+
+func pbinFault(code code.Code, message, resolution string) *fault.Fault {
+	return &fault.Fault{
+		Domain:      "pbin",
+		Code:        code,
+		Description: message,
+		Resolution:  resolution,
+	}
+}

--- a/src/control/pbin/stdio_test.go
+++ b/src/control/pbin/stdio_test.go
@@ -1,5 +1,5 @@
 //
-// (C) Copyright 2019 Intel Corporation.
+// (C) Copyright 2019-2020 Intel Corporation.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -59,7 +59,7 @@ func echo() {
 	}
 }
 
-func TestStdioSimpleParentChild(t *testing.T) {
+func TestPbin_StdioSimpleParentChild(t *testing.T) {
 	var errBuf bytes.Buffer
 	defer func() {
 		if t.Failed() {

--- a/src/control/server/storage/scm/faults.go
+++ b/src/control/server/storage/scm/faults.go
@@ -23,6 +23,8 @@
 package scm
 
 import (
+	"fmt"
+
 	"github.com/daos-stack/daos/src/control/fault"
 	"github.com/daos-stack/daos/src/control/fault/code"
 )
@@ -65,16 +67,19 @@ var (
 		"request included already-mounted mount target (cannot double-mount)",
 		"unmount the target and retry the operation",
 	)
-	FaultFormatMissingDevice = scmFault(
-		code.ScmFormatMissingDevice,
-		"configured SCM device does not exist",
-		"check the configured value and/or perform the SCM preparation procedure",
-	)
 	FaultMissingNdctl = scmFault(
 		code.MissingSoftwareDependency,
 		"ndctl utility not found", "install the ndctl software for your OS",
 	)
 )
+
+func FaultFormatMissingDevice(device string) *fault.Fault {
+	return scmFault(
+		code.ScmFormatMissingDevice,
+		fmt.Sprintf("configured SCM device %s does not exist", device),
+		"check the configured value and/or perform the SCM preparation procedure",
+	)
+}
 
 func scmFault(code code.Code, desc, res string) *fault.Fault {
 	return &fault.Fault{

--- a/src/control/server/storage/scm/provider.go
+++ b/src/control/server/storage/scm/provider.go
@@ -1,5 +1,5 @@
 //
-// (C) Copyright 2019 Intel Corporation.
+// (C) Copyright 2019-2020 Intel Corporation.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -550,7 +550,7 @@ func (p *Provider) CheckFormat(req FormatRequest) (*FormatResponse, error) {
 	fsType, err := p.sys.Getfs(req.Dcpm.Device)
 	if err != nil {
 		if os.IsNotExist(errors.Cause(err)) {
-			return nil, errors.Wrap(FaultFormatMissingDevice, req.Dcpm.Device)
+			return nil, FaultFormatMissingDevice(req.Dcpm.Device)
 		}
 		return nil, errors.Wrapf(err, "failed to check if %s is formatted", req.Dcpm.Device)
 	}

--- a/src/control/server/storage/scm/provider_test.go
+++ b/src/control/server/storage/scm/provider_test.go
@@ -1,5 +1,5 @@
 //
-// (C) Copyright 2019 Intel Corporation.
+// (C) Copyright 2019-2020 Intel Corporation.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -764,7 +764,7 @@ func TestProviderFormat(t *testing.T) {
 				Path: "/bad/device",
 				Err:  os.ErrNotExist,
 			},
-			expErr: FaultFormatMissingDevice,
+			expErr: FaultFormatMissingDevice("/bad/device"),
 		},
 	} {
 		t.Run(name, func(t *testing.T) {


### PR DESCRIPTION
Removes the ability to disable request forwarding to the
privileged helper, as this is not a supportable configuration.

Modifies the daos_server<->daos_admin plumbing to represent
daos_admin errors as Faults for better error reporting and
resolution display.

Adds pbin.CheckHelper() to allow early identification of
installation problems with clear resolution messages.