### PR TITLE
DAOS-623 build: Update to cart 354d616e01d2b0b76f327e4e4b58fadd2ce0e391

### DIFF
--- a/utils/build.config
+++ b/utils/build.config
@@ -1,4 +1,5 @@
 [component]
+
 component=daos
 
 [commit_versions]

--- a/utils/build.config
+++ b/utils/build.config
@@ -1,5 +1,4 @@
 [component]
-
 component=daos
 
 [commit_versions]

--- a/utils/build.config
+++ b/utils/build.config
@@ -3,7 +3,7 @@ component=daos
 
 [commit_versions]
 ARGOBOTS = 89507c1f8cfec4e918e8b9861e41b4e9cef71461
-CART = 63fa727c055c2446f4f6f2d06d3aec8e84071c2b
+CART = 354d616e01d2b0b76f327e4e4b58fadd2ce0e391
 PMDK = 1.8
 ISAL = v2.26.0
 SPDK = v19.04.1


### PR DESCRIPTION
Update to CaRT 354d616e01d2b0b76f327e4e4b58fadd2ce0e391 to include
psm2 nameserver changes.

Update to latest scons_local to pick up changes required for patching
mercury

Signed-off-by: Alexander Oganezov <alexander.a.oganezov@intel.com>