### PR TITLE
DAOS-3954 vos: use operation intent correctly

### DIFF
--- a/src/vos/vos_obj_index.c
+++ b/src/vos/vos_obj_index.c
@@ -217,6 +217,7 @@ int
 vos_oi_find_alloc(struct vos_container *cont, daos_unit_oid_t oid,
 		  daos_epoch_t epoch, bool log, struct vos_obj_df **obj_p)
 {
+	struct dtx_handle	*dth = vos_dth_get();
 	struct vos_obj_df	*obj = NULL;
 	d_iov_t			 key_iov;
 	d_iov_t			 val_iov;
@@ -240,7 +241,8 @@ vos_oi_find_alloc(struct vos_container *cont, daos_unit_oid_t oid,
 	d_iov_set(&val_iov, NULL, 0);
 	d_iov_set(&key_iov, &oid, sizeof(oid));
 
-	rc = dbtree_upsert(cont->vc_btr_hdl, BTR_PROBE_EQ, DAOS_INTENT_DEFAULT,
+	rc = dbtree_upsert(cont->vc_btr_hdl, BTR_PROBE_EQ,
+			   dth != NULL ? dth->dth_intent : DAOS_INTENT_UPDATE,
 			   &key_iov, &val_iov);
 	if (rc) {
 		D_ERROR("Failed to update Key for Object index\n");

--- a/src/vos/vos_tree.c
+++ b/src/vos/vos_tree.c
@@ -977,12 +977,12 @@ key_tree_punch(struct vos_object *obj, daos_handle_t toh, daos_epoch_t epoch,
 	daos_handle_t		 loh = DAOS_HDL_INVAL;
 	int			 rc;
 
-	rc = dbtree_fetch(toh, BTR_PROBE_EQ, DAOS_INTENT_UPDATE, key_iov, NULL,
+	rc = dbtree_fetch(toh, BTR_PROBE_EQ, DAOS_INTENT_PUNCH, key_iov, NULL,
 			  val_iov);
 	if (rc != 0) {
 		D_ASSERT(rc == -DER_NONEXIST);
 		/* use BTR_PROBE_BYPASS to avoid probe again */
-		rc = dbtree_upsert(toh, BTR_PROBE_BYPASS, DAOS_INTENT_UPDATE,
+		rc = dbtree_upsert(toh, BTR_PROBE_BYPASS, DAOS_INTENT_PUNCH,
 				   key_iov, val_iov);
 		if (rc) {
 			D_ERROR("Failed to add new punch, rc="DF_RC"\n",


### PR DESCRIPTION
For punch case, the intent should be "DAOS_INTENT_PUNCH".
If we have DTX handle, then the operation intent has been
specified via dtx_handle::dth_intent, just use it instead
of specifying other values.

Signed-off-by: Fan Yong <fan.yong@intel.com>