### PR TITLE
DAOS-3945 rsvc: Fix lost s_refs in start

### DIFF
--- a/src/rsvc/srv.c
+++ b/src/rsvc/srv.c
@@ -673,6 +673,7 @@ start(enum ds_rsvc_class_id class, d_iov_t *id, uuid_t db_uuid, bool create,
 	rc = alloc_init(class, id, db_uuid, &svc);
 	if (rc != 0)
 		goto err;
+	svc->s_ref++;
 
 	if (create) {
 		rc = rdb_create(svc->s_db_path, svc->s_db_uuid, size, replicas);
@@ -692,7 +693,6 @@ start(enum ds_rsvc_class_id class, d_iov_t *id, uuid_t db_uuid, bool create,
 			goto err_db;
 	}
 
-	svc->s_ref = 1;
 	*svcp = svc;
 	return 0;
 
@@ -702,6 +702,7 @@ err_creation:
 	if (create)
 		rdb_destroy(svc->s_db_path, svc->s_db_uuid);
 err_svc:
+	svc->s_ref--;
 	fini_free(svc);
 err:
 	return rc;


### PR DESCRIPTION
Deadlocks like below are observed when stopping daos_io_servers not via
SIGKILL:

  ~ rdb_callbackd (waiting for map_distd, to return the leader ref):
      rsvc_step_down_cb
        ABT_cond_wait(s_leader_ref_cv)

  ~ map_distd (waiting for rdb_callbackd, to terminate):
      ds_rsvc_put
        rdb_stop
          rdb_raft_stop
            ABT_thread_join(d_callbackd)

In map_distd, the ds_rsvc reference count should never reach zero to
trigger the rdb_stop call. The root cause is in start called by
ds_rsvc_start. Before returning, start sets s_ref to 1, overwriting the
references taken by activities resulted from the rdb_start and the
bootstrap_self calls. For the MS, this effectively lost one reference
and led to the rdb_stop call made by map_distd. This patch fixes the
ds_rsvc reference count loss in start.

Signed-off-by: Li Wei <wei.g.li@intel.com>