### PR TITLE
DAOS-3954 vos: not create punch target for non-rebuild case

### DIFF
--- a/src/common/btree.c
+++ b/src/common/btree.c
@@ -1985,7 +1985,7 @@ dbtree_update(daos_handle_t toh, d_iov_t *key, d_iov_t *val)
  *			-ve	error code
  */
 int
-dbtree_upsert(daos_handle_t toh, dbtree_probe_opc_t opc, uint32_t intent,
+dbtree_upsert(daos_handle_t toh, dbtree_probe_opc_t opc,
 	      d_iov_t *key, d_iov_t *val)
 {
 	struct btr_context *tcx;
@@ -1998,7 +1998,9 @@ dbtree_upsert(daos_handle_t toh, dbtree_probe_opc_t opc, uint32_t intent,
 	rc = btr_tx_begin(tcx);
 	if (rc != 0)
 		return rc;
-	rc = btr_upsert(tcx, opc, intent, key, val);
+
+	/* For rebuild-punch, the intent will be ignored by lower layer. */
+	rc = btr_upsert(tcx, opc, DAOS_INTENT_UPDATE, key, val);
 
 	return btr_tx_end(tcx, rc);
 }

--- a/src/dtx/dtx_common.c
+++ b/src/dtx/dtx_common.c
@@ -586,6 +586,9 @@ dtx_leader_end(struct dtx_leader_handle *dlh, struct ds_cont_child *cont,
 	if (result < 0 || rc < 0)
 		D_GOTO(out, result = result < 0 ? result : rc);
 
+	if (!dth->dth_actived)
+		D_GOTO(out, result = 0);
+
 	if (dth->dth_intent == DAOS_INTENT_PUNCH)
 		flags |= DCF_FOR_PUNCH;
 	if (dth->dth_has_ilog)
@@ -638,12 +641,13 @@ out:
 
 	D_DEBUG(DB_TRACE,
 		"Stop the DTX "DF_DTI" ver %u, dkey %llu, intent %s, "
-		"%s, %s participator(s): rc = %d\n",
+		"%s, %s participator(s), modified %s: rc = %d\n",
 		DP_DTI(&dth->dth_xid), dth->dth_ver,
 		(unsigned long long)dth->dth_dkey_hash,
 		dth->dth_intent == DAOS_INTENT_PUNCH ? "Punch" : "Update",
 		dth->dth_sync ? "sync" : "async",
-		dth->dth_solo ? "single" : "multiple", result);
+		dth->dth_solo ? "single" : "multiple",
+		dth->dth_actived ? "something" : "nothing", result);
 
 	D_ASSERTF(result <= 0, "unexpected return value %d\n", result);
 

--- a/src/dtx/dtx_rpc.c
+++ b/src/dtx/dtx_rpc.c
@@ -495,8 +495,7 @@ dtx_dti_classify_one(struct ds_pool *pool, struct pl_map *map, uuid_t po_uuid,
 
 		d_iov_set(&riov, &dcrb, sizeof(dcrb));
 		d_iov_set(&kiov, &dcrb.dcrb_key, sizeof(dcrb.dcrb_key));
-		rc = dbtree_upsert(tree, BTR_PROBE_EQ, DAOS_INTENT_UPDATE,
-				   &kiov, &riov);
+		rc = dbtree_upsert(tree, BTR_PROBE_EQ, &kiov, &riov);
 	}
 
 out:

--- a/src/include/daos/btree.h
+++ b/src/include/daos/btree.h
@@ -499,7 +499,7 @@ int  dbtree_lookup(daos_handle_t toh, d_iov_t *key, d_iov_t *val_out);
 int  dbtree_update(daos_handle_t toh, d_iov_t *key, d_iov_t *val);
 int  dbtree_fetch(daos_handle_t toh, dbtree_probe_opc_t opc, uint32_t intent,
 		  d_iov_t *key, d_iov_t *key_out, d_iov_t *val_out);
-int  dbtree_upsert(daos_handle_t toh, dbtree_probe_opc_t opc, uint32_t intent,
+int  dbtree_upsert(daos_handle_t toh, dbtree_probe_opc_t opc,
 		   d_iov_t *key, d_iov_t *val);
 int  dbtree_delete(daos_handle_t toh, dbtree_probe_opc_t opc,
 		   d_iov_t *key, void *args);

--- a/src/vos/vos_dtx_cos.c
+++ b/src/vos/vos_dtx_cos.c
@@ -436,8 +436,7 @@ add:
 	rbund.flags = flags;
 	d_iov_set(&riov, &rbund, sizeof(rbund));
 
-	rc = dbtree_upsert(cont->vc_dtx_cos_hdl, BTR_PROBE_EQ,
-			   DAOS_INTENT_UPDATE, &kiov, &riov);
+	rc = dbtree_upsert(cont->vc_dtx_cos_hdl, BTR_PROBE_EQ, &kiov, &riov);
 
 	D_DEBUG(DB_TRACE, "Insert DTX "DF_DTI" to CoS cache, key %llu, "
 		"intent %s, %s ilog entry: rc = "DF_RC"\n",

--- a/src/vos/vos_obj.c
+++ b/src/vos/vos_obj.c
@@ -74,17 +74,22 @@ key_punch(struct vos_object *obj, daos_epoch_t epoch, uint32_t pm_ver,
 				    flags);
 		if (rc != 0)
 			D_GOTO(out, rc);
-
 	} else {
 		daos_handle_t		 toh;
 		int			 i;
 
-		rc = key_tree_prepare(obj, obj->obj_toh, VOS_BTR_DKEY,
-				      dkey, SUBTR_CREATE, DAOS_INTENT_PUNCH,
-				      &krec, &toh);
+		/* For non-rebuild case, if the key does not exist,
+		 * don't create it.
+		 */
+		rc = key_tree_prepare(obj, obj->obj_toh, VOS_BTR_DKEY, dkey,
+				flags & VOS_OF_REPLAY_PC ? SUBTR_CREATE : 0,
+				DAOS_INTENT_PUNCH, &krec, &toh);
 		if (rc) {
-			D_ERROR("Error preparing dkey: rc="DF_RC"\n",
-				DP_RC(rc));
+			if (rc == -DER_NONEXIST && !(flags & VOS_OF_REPLAY_PC))
+				rc = 0;
+			else
+				D_ERROR("Error preparing dkey: rc="DF_RC"\n",
+					DP_RC(rc));
 			D_GOTO(out, rc);
 		}
 
@@ -161,15 +166,21 @@ vos_obj_punch(daos_handle_t coh, daos_unit_oid_t oid, daos_epoch_t epoch,
 		dth->dth_dti_cos_done = 1;
 	}
 
-	/* NB: punch always generate a new incarnation of the object */
+	/* NB: punch always generate a new incarnation of the object.
+	 *
+	 * For non-rebuild case, if the object does not exist, don't create it.
+	 */
 	rc = vos_obj_hold(vos_obj_cache_current(), vos_hdl2cont(coh), oid, &epr,
-			  false, DAOS_INTENT_PUNCH, true, &obj);
+			  flags & VOS_OF_REPLAY_PC ? false : true,
+			  DAOS_INTENT_PUNCH, true, &obj);
 	if (rc == 0) {
 		if (dkey) /* key punch */
 			rc = key_punch(obj, epoch, pm_ver, dkey,
 				       akey_nr, akeys, flags);
 		else /* object punch */
 			rc = obj_punch(coh, obj, epoch, flags);
+	} else if (rc == -DER_NONEXIST && !(flags & VOS_OF_REPLAY_PC)) {
+		rc = 0;
 	}
 
 	if (dth != NULL && rc == 0)

--- a/src/vos/vos_obj_index.c
+++ b/src/vos/vos_obj_index.c
@@ -240,8 +240,7 @@ vos_oi_find_alloc(struct vos_container *cont, daos_unit_oid_t oid,
 	d_iov_set(&val_iov, NULL, 0);
 	d_iov_set(&key_iov, &oid, sizeof(oid));
 
-	rc = dbtree_upsert(cont->vc_btr_hdl, BTR_PROBE_EQ, DAOS_INTENT_DEFAULT,
-			   &key_iov, &val_iov);
+	rc = dbtree_upsert(cont->vc_btr_hdl, BTR_PROBE_EQ, &key_iov, &val_iov);
 	if (rc) {
 		D_ERROR("Failed to update Key for Object index\n");
 		return rc;


### PR DESCRIPTION
For non-rebuild case, if the target (to be punched) does not exist,
it is not necessary to create the target before punch it, instead,
just return success directly; otherwise, it will leave useless
information in related tree and cause additional incarnation log
and DTX operations.

For DTX logic, if nothing is modified, then do not add it into CoS
cache, instead, release the DTX directly.

Signed-off-by: Fan Yong <fan.yong@intel.com>