### PR TITLE
DAOS-2448 obj: add csum handling for EC obj

### DIFF
--- a/src/common/checksum.c
+++ b/src/common/checksum.c
@@ -342,7 +342,7 @@ daos_csummer_update(struct daos_csummer *obj, uint8_t *buf, size_t buf_len)
 	int rc = 0;
 
 	if (C_TRACE_ENABLED()) {
-		C_TRACE("Buffer (len=%lu) (type=%s): ", buf_len,
+		C_TRACE("Buffer (buf=%p len=%lu) (type=%s): ", buf, buf_len,
 			daos_csummer_get_name(obj));
 		trace_chars(buf, buf_len, 50);
 		C_TRACE("\n");
@@ -408,9 +408,20 @@ daos_csummer_csum_compare(struct daos_csummer *obj, uint8_t *a,
 	return memcmp(a, b, csum_len) == 0;
 }
 
+static uint32_t
+daos_singv_calc_chunks(struct dcs_singv_layout *singv_los, int idx)
+{
+	if (singv_los == NULL || singv_los[idx].cs_even_dist == 0)
+		return 1;
+
+	D_ASSERT(singv_los[idx].cs_nr > 1);
+	return singv_los[idx].cs_nr;
+}
+
 uint64_t
 daos_csummer_allocation_size(struct daos_csummer *obj, daos_iod_t *iods,
-			     uint32_t nr, bool akey_only)
+			     uint32_t nr, bool akey_only,
+			     struct dcs_singv_layout *singv_los)
 {
 	int		i, j;
 	uint64_t	result = 0;
@@ -435,10 +446,10 @@ daos_csummer_allocation_size(struct daos_csummer *obj, daos_iod_t *iods,
 			uint32_t	 csum_count;
 
 			csum_count = is_array(iod) ?
-				     daos_recx_calc_chunks(*recx,
-							   iod->iod_size,
+				     daos_recx_calc_chunks(*recx, iod->iod_size,
 							   chunksize) :
-				     1; /** sv only has 1 checksum */
+				     daos_singv_calc_chunks(singv_los, i);
+
 			result += sizeof(struct dcs_csum_info) +
 				  csum_count * csum_size;
 		}
@@ -456,6 +467,7 @@ daos_csummer_allocation_size(struct daos_csummer *obj, daos_iod_t *iods,
 int
 daos_csummer_alloc_iods_csums(struct daos_csummer *obj, daos_iod_t *iods,
 			      uint32_t nr, bool akey_only,
+			      struct dcs_singv_layout *singv_los,
 			      struct dcs_iod_csums **p_iods_csums)
 {
 	int			 i, j, rc = 0;
@@ -480,7 +492,8 @@ daos_csummer_alloc_iods_csums(struct daos_csummer *obj, daos_iod_t *iods,
 	 * allocate enough memory for all iod checksums at once, then update
 	 * pointers appropriately
 	 */
-	buf_len = daos_csummer_allocation_size(obj, iods, nr, akey_only);
+	buf_len = daos_csummer_allocation_size(obj, iods, nr, akey_only,
+					       singv_los);
 	D_ALLOC(buf, buf_len);
 	if (buf == NULL)
 		return -DER_NOMEM;
@@ -524,7 +537,8 @@ daos_csummer_alloc_iods_csums(struct daos_csummer *obj, daos_iod_t *iods,
 				       csum_size, csum_count,
 				       chunksize, csum_type);
 			} else { /** single value */
-				csum_count = 1;
+				csum_count = daos_singv_calc_chunks(singv_los,
+								    i);
 				ci_set(csum_info, NULL, csum_count * csum_size,
 				       csum_size, csum_count,
 				       CSUM_NO_CHUNK, csum_type);
@@ -597,25 +611,65 @@ calc_csum_recx(struct daos_csummer *obj, d_sg_list_t *sgl,
 
 static int
 calc_csum_sv(struct daos_csummer *obj, d_sg_list_t *sgl, size_t rec_len,
+	     struct dcs_singv_layout *singv_lo, int singv_idx,
 	     struct dcs_csum_info *csums)
 {
-	size_t			 bytes_for_csum;
-	struct daos_sgl_idx	 idx = {0};
+	size_t			 bytes_for_csum, csum_buf_len;
+	size_t			 skip_size, last_size = -1;
+	struct daos_sgl_idx	 sgl_idx = {0};
+	uint32_t		 idx, last_idx = -1;
+	uint8_t			*csum_buf;
 	int			 rc;
 
 	if (!(daos_csummer_initialized(obj)))
 		return 0;
 
-	daos_csummer_set_buffer(obj, csums->cs_csum, csums->cs_len);
-	daos_csummer_reset(obj);
+	if (singv_lo != NULL && singv_lo->cs_even_dist == 1) {
+		D_ASSERT(singv_lo->cs_bytes > 0 &&
+			 singv_lo->cs_bytes < rec_len);
+		D_ASSERT(singv_lo->cs_nr > 1);
+		last_idx = rec_len / singv_lo->cs_bytes;
+		D_ASSERT(last_idx >= 1);
+		if (singv_idx == -1) {
+			D_ASSERT(csums->cs_nr == singv_lo->cs_nr);
+			last_size = rec_len - last_idx * singv_lo->cs_bytes;
+		} else {
+			D_ASSERT(csums->cs_nr == 1);
+			/* skip to the sgl location of singv_idx, the last
+			 * data cell possibly with less valid bytes, and
+			 * followed by parity cells.
+			 */
+			if (singv_idx <= last_idx)
+				skip_size = singv_idx * singv_lo->cs_bytes;
+			else
+				skip_size = rec_len + (singv_idx - last_idx) *
+						      singv_lo->cs_bytes;
+			rc = daos_sgl_processor(sgl, &sgl_idx, skip_size,
+						NULL, NULL);
+			if (rc)
+				return rc;
+		}
+		bytes_for_csum = singv_lo->cs_bytes;
+	} else {
+		D_ASSERT(csums->cs_nr == 1);
+		bytes_for_csum = rec_len;
+	}
 
-	bytes_for_csum = rec_len;
-	rc = daos_sgl_processor(sgl, &idx, bytes_for_csum,
-				checksum_sgl_cb, obj);
-	if (rc)
-		return rc;
+	csum_buf_len = bytes_for_csum;
+	for (idx = 0; idx < csums->cs_nr; idx++) {
+		if (idx == last_idx)
+			csum_buf_len = last_size;
+		csum_buf = ci_idx2csum(&csums[0], idx);
+		daos_csummer_set_buffer(obj, csum_buf, csums->cs_len);
+		daos_csummer_reset(obj);
 
-	daos_csummer_finish(obj);
+		rc = daos_sgl_processor(sgl, &sgl_idx, csum_buf_len,
+					checksum_sgl_cb, obj);
+		if (rc)
+			return rc;
+
+		daos_csummer_finish(obj);
+	}
 
 	return 0;
 }
@@ -659,11 +713,13 @@ daos_csummer_calc_one(struct daos_csummer *obj, d_sg_list_t *sgl,
 int
 daos_csummer_calc_iods(struct daos_csummer *obj, d_sg_list_t *sgls,
 		       daos_iod_t *iods, uint32_t nr, bool akey_only,
+		       struct dcs_singv_layout *singv_los, int singv_idx,
 		       struct dcs_iod_csums **p_iods_csums)
 {
 	int			 rc = 0;
 	int			 i;
 	struct dcs_iod_csums	*iods_csums = NULL;
+	struct dcs_singv_layout	*singv_lo, *los;
 	uint32_t		 iods_csums_nr;
 	uint32_t		 chunksize = daos_csummer_get_chunksize(obj);
 	uint16_t		 csum_len = daos_csummer_get_csum_len(obj);
@@ -673,8 +729,12 @@ daos_csummer_calc_iods(struct daos_csummer *obj, d_sg_list_t *sgls,
 
 	*p_iods_csums = NULL;
 
+	if (singv_los == NULL || singv_idx != -1)
+		los = NULL;
+	else
+		los = singv_los;
 	rc = daos_csummer_alloc_iods_csums(obj, iods, nr, akey_only,
-					   &iods_csums);
+					   los, &iods_csums);
 	if (rc < 0) {
 		D_ERROR("daos_csummer_alloc_iods_csums error: %d", rc);
 		return rc;
@@ -701,12 +761,13 @@ daos_csummer_calc_iods(struct daos_csummer *obj, d_sg_list_t *sgls,
 			continue;
 
 		/** data */
+		singv_lo = (singv_los == NULL) ? NULL : &singv_los[i];
 		rc = is_array(iod) ?
 		     calc_csum_recx(obj, &sgls[i], iod->iod_size,
 				    iod->iod_recxs, iod->iod_nr,
 				    csums->ic_data) :
-		     calc_csum_sv(obj, &sgls[i], iod->iod_size,
-				  csums->ic_data);
+		     calc_csum_sv(obj, &sgls[i], iod->iod_size, singv_lo,
+				  singv_idx, csums->ic_data);
 		csums->ic_nr = iod->iod_nr;
 		/* Corrupt data after calculating checksum */
 		if (DAOS_FAIL_CHECK(DAOS_CHECKSUM_CDATA_CORRUPT))
@@ -781,7 +842,8 @@ daos_csummer_free_ci(struct daos_csummer *obj, struct dcs_csum_info **p_cis)
 
 int
 daos_csummer_verify_iod(struct daos_csummer *obj, daos_iod_t *iod,
-			d_sg_list_t *sgl, struct dcs_iod_csums *iod_csums)
+			d_sg_list_t *sgl, struct dcs_iod_csums *iod_csum,
+			struct dcs_singv_layout *singv_lo, int singv_idx)
 {
 	struct dcs_iod_csums	*new_iod_csums;
 	int			 i;
@@ -791,12 +853,13 @@ daos_csummer_verify_iod(struct daos_csummer *obj, daos_iod_t *iod,
 	if (!daos_csummer_initialized(obj))
 		return 0;
 
-	if (iod == NULL || sgl == NULL || iod_csums == NULL) {
+	if (iod == NULL || sgl == NULL || iod_csum == NULL) {
 		D_ERROR("Invalid params");
 		return -DER_INVAL;
 	}
 
-	rc = daos_csummer_calc_iods(obj, sgl, iod, 1, 0, &new_iod_csums);
+	rc = daos_csummer_calc_iods(obj, sgl, iod, 1, 0, singv_lo, singv_idx,
+				    &new_iod_csums);
 	if (rc != 0) {
 		D_ERROR("daos_csummer_calc_iods error: %d", rc);
 		return rc;
@@ -805,7 +868,7 @@ daos_csummer_verify_iod(struct daos_csummer *obj, daos_iod_t *iod,
 	for (i = 0; i < iod->iod_nr; i++) {
 		match = daos_csummer_compare_csum_info(obj,
 				&new_iod_csums->ic_data[i],
-				&iod_csums->ic_data[i]);
+				&iod_csum->ic_data[i]);
 		if (!match) {
 			D_ERROR("Data corruption found\n");
 			D_GOTO(done, rc = -DER_CSUM);

--- a/src/common/misc.c
+++ b/src/common/misc.c
@@ -292,7 +292,8 @@ daos_sgl_processor(d_sg_list_t *sgl, struct daos_sgl_idx *idx,
 	while (requested_bytes > 0 && !end && !rc) {
 		end = daos_sgl_get_bytes(sgl, idx, requested_bytes, &buf, &len);
 		requested_bytes -= len;
-		rc = process_cb(buf, len, cb_args);
+		if (process_cb != NULL)
+			rc = process_cb(buf, len, cb_args);
 	}
 
 	if (requested_bytes)

--- a/src/common/tests/checksum_tests.c
+++ b/src/common/tests/checksum_tests.c
@@ -229,7 +229,8 @@ test_daos_checksummer_with_single_iov_single_chunk(void **state)
 	iod.iod_size = 1;
 	iod.iod_type = DAOS_IOD_ARRAY;
 
-	rc = daos_csummer_calc_iods(csummer, &sgl, &iod, 1, 0, &actual);
+	rc = daos_csummer_calc_iods(csummer, &sgl, &iod, 1, 0, NULL, 0,
+				    &actual);
 
 	assert_int_equal(0, rc);
 
@@ -270,7 +271,8 @@ test_daos_checksummer_with_unaligned_recx(void **state)
 	iod.iod_type = DAOS_IOD_ARRAY;
 	d_iov_set(&iod.iod_name, "akey", strlen("akey"));
 
-	rc = daos_csummer_calc_iods(csummer, &sgl, &iod, 1, 0, &actual);
+	rc = daos_csummer_calc_iods(csummer, &sgl, &iod, 1, 0, NULL, 0,
+				    &actual);
 
 	assert_int_equal(0, rc);
 	assert_string_equal("akey|a|b", fake_update_buf_copy);
@@ -311,7 +313,8 @@ test_daos_checksummer_with_mult_iov_single_chunk(void **state)
 	iod.iod_type = DAOS_IOD_ARRAY;
 	fake_update_bytes_seen = 0;
 
-	rc = daos_csummer_calc_iods(csummer, &sgl, &iod, 1, 0, &actual);
+	rc = daos_csummer_calc_iods(csummer, &sgl, &iod, 1, 0, NULL, 0,
+				    &actual);
 
 	assert_int_equal(0, rc);
 	assert_int_equal(11, fake_update_bytes_seen);
@@ -359,7 +362,8 @@ test_daos_checksummer_with_multi_iov_multi_extents(void **state)
 	iod.iod_size = 1;
 	iod.iod_type = DAOS_IOD_ARRAY;
 
-	rc = daos_csummer_calc_iods(csummer, &sgl, &iod, 1, 0, &actual);
+	rc = daos_csummer_calc_iods(csummer, &sgl, &iod, 1, 0, NULL, 0,
+				    &actual);
 
 	assert_int_equal(0, rc);
 	/** fake checksum calc should have been called once for the first one,
@@ -408,7 +412,8 @@ test_daos_checksummer_with_multiple_chunks(void **state)
 	iod.iod_type = DAOS_IOD_ARRAY;
 	d_iov_set(&iod.iod_name, "akey", strlen("akey"));
 
-	rc = daos_csummer_calc_iods(csummer, &sgl, &iod, 1, 0, &actual);
+	rc = daos_csummer_calc_iods(csummer, &sgl, &iod, 1, 0, NULL, 0,
+				    &actual);
 
 	assert_int_equal(0, rc);
 	int csum_expected_count = 3; /** 11/4=3 */
@@ -498,9 +503,9 @@ test_compare_checksums(void **state)
 	iod.iod_size = 1;
 	iod.iod_type = DAOS_IOD_ARRAY;
 
-	rc = daos_csummer_calc_iods(csummer, &sgl, &iod, 1, 0, &one);
+	rc = daos_csummer_calc_iods(csummer, &sgl, &iod, 1, 0, NULL, 0, &one);
 	assert_int_equal(0, rc);
-	rc = daos_csummer_calc_iods(csummer, &sgl, &iod, 1, 0, &two);
+	rc = daos_csummer_calc_iods(csummer, &sgl, &iod, 1, 0, NULL, 0, &two);
 	assert_int_equal(0, rc);
 
 	assert_true(daos_csummer_compare_csum_info(csummer, one->ic_data,
@@ -536,7 +541,8 @@ test_get_iod_csum_allocation_size(void **state)
 			 csum_size + /** akey csum */
 			 sizeof(struct dcs_csum_info) + /** 1 data csum info */
 			 csum_size, /** 1 data csum */
-			 daos_csummer_allocation_size(csummer, &iods[0], 1, 0));
+			 daos_csummer_allocation_size(csummer, &iods[0],
+						      1, 0, NULL));
 
 	recxs[0].rx_idx = 0;
 	recxs[0].rx_nr = chunksize + 1; /** two checksums now */
@@ -544,7 +550,8 @@ test_get_iod_csum_allocation_size(void **state)
 				 csum_size + /** akey csum */
 				 sizeof(struct dcs_csum_info) +
 			 csum_size * 2,
-			 daos_csummer_allocation_size(csummer, &iods[0], 1, 0));
+			 daos_csummer_allocation_size(csummer, &iods[0],
+						      1, 0, NULL));
 
 	iods[0].iod_nr = 2;
 	recxs[1].rx_idx = 0;
@@ -553,7 +560,8 @@ test_get_iod_csum_allocation_size(void **state)
 				 csum_size + /** akey csum */
 			 sizeof(struct dcs_csum_info) * 2 +
 			 csum_size * 3,
-			 daos_csummer_allocation_size(csummer, &iods[0], 1, 0));
+			 daos_csummer_allocation_size(csummer, &iods[0],
+						      1, 0, NULL));
 	iods[0].iod_nr = 1;
 
 	iods[1].iod_nr = 1;
@@ -564,13 +572,14 @@ test_get_iod_csum_allocation_size(void **state)
 			 csum_size * 2 + /** akey csum (1 for each iod_csum */
 			 sizeof(struct dcs_csum_info) * 2 +
 			 csum_size * 3,
-			 daos_csummer_allocation_size(csummer, &iods[0], 2, 0));
+			 daos_csummer_allocation_size(csummer, &iods[0],
+						      2, 0, NULL));
 
 	/** skip data */
 	assert_int_equal(sizeof(struct dcs_iod_csums) * 2 +
 			 csum_size * 2, /** akey csum (1 for each iod_csum */
 			 daos_csummer_allocation_size(csummer, &iods[0], 2,
-						      true));
+						      true, NULL));
 }
 
 static void
@@ -638,7 +647,8 @@ test_all_checksum_types(void **state)
 		iod.iod_size = 1;
 		iod.iod_type = DAOS_IOD_ARRAY;
 
-		rc = daos_csummer_calc_iods(csummer, &sgl, &iod, 1, 0, &csums);
+		rc = daos_csummer_calc_iods(csummer, &sgl, &iod, 1, 0, NULL, 0,
+					    &csums);
 
 		assert_int_equal(0, rc);
 		assert_int_equal(csum_lens[type],
@@ -1074,7 +1084,8 @@ simple_sv(void **state)
 	iod.iod_size = 1; /* [todo-ryon]: this should be bigger than 1 */
 	iod.iod_type = DAOS_IOD_SINGLE;
 
-	rc = daos_csummer_calc_iods(csummer, &sgl, &iod, 1, 0, &actual);
+	rc = daos_csummer_calc_iods(csummer, &sgl, &iod, 1, 0, NULL, 0,
+				    &actual);
 
 	assert_int_equal(0, rc);
 
@@ -1111,9 +1122,9 @@ test_compare_sv_checksums(void **state)
 	iod.iod_size = daos_sgl_buf_size(&sgl);
 	iod.iod_type = DAOS_IOD_SINGLE;
 
-	rc = daos_csummer_calc_iods(csummer, &sgl, &iod, 1, 0, &one);
+	rc = daos_csummer_calc_iods(csummer, &sgl, &iod, 1, 0, NULL, 0, &one);
 	assert_int_equal(0, rc);
-	rc = daos_csummer_calc_iods(csummer, &sgl, &iod, 1, 0, &two);
+	rc = daos_csummer_calc_iods(csummer, &sgl, &iod, 1, 0, NULL, 0, &two);
 	assert_int_equal(0, rc);
 
 	assert_true(daos_csummer_compare_csum_info(csummer, one->ic_data,
@@ -1145,24 +1156,25 @@ test_verify_sv_data(void **state)
 	iod.iod_type = DAOS_IOD_SINGLE;
 
 	/** Checksum not set in iod_csums but csummer is set so should error */
-	rc = daos_csummer_verify_iod(csummer, &iod, &sgl, iod_csums);
+	rc = daos_csummer_verify_iod(csummer, &iod, &sgl, iod_csums, NULL, 0);
 	assert_int_equal(-DER_INVAL, rc);
 
-	rc = daos_csummer_calc_iods(csummer, &sgl, &iod, 1, 0, &iod_csums);
+	rc = daos_csummer_calc_iods(csummer, &sgl, &iod, 1, 0, NULL, 0,
+				    &iod_csums);
 	assert_int_equal(0, rc);
 
-	rc = daos_csummer_verify_iod(csummer, &iod, &sgl, iod_csums);
+	rc = daos_csummer_verify_iod(csummer, &iod, &sgl, iod_csums, NULL, 0);
 	assert_int_equal(0, rc);
 
 	((char *)sgl.sg_iovs[0].iov_buf)[0]++; /** Corrupt the data */
-	rc = daos_csummer_verify_iod(csummer, &iod, &sgl, iod_csums);
+	rc = daos_csummer_verify_iod(csummer, &iod, &sgl, iod_csums, NULL, 0);
 	assert_int_equal(-DER_CSUM, rc);
 
 	((char *)sgl.sg_iovs[0].iov_buf)[0]--; /** Un-corrupt the data */
 	/** Corrupt data elsewhere*/
 	sgl_buf_half = daos_sgl_buf_size(&sgl) / 2;
 	((char *)sgl.sg_iovs[0].iov_buf)[sgl_buf_half + 1]++;
-	rc = daos_csummer_verify_iod(csummer, &iod, &sgl, iod_csums);
+	rc = daos_csummer_verify_iod(csummer, &iod, &sgl, iod_csums, NULL, 0);
 	assert_int_equal(-DER_CSUM, rc);
 
 	/** Clean up */
@@ -1194,7 +1206,8 @@ test_akey_csum(void **state)
 	iod.iod_type = DAOS_IOD_ARRAY;
 	d_iov_set(&iod.iod_name, "akey", strlen("akey"));
 
-	rc = daos_csummer_calc_iods(csummer, &sgl, &iod, 1, 0, &actual);
+	rc = daos_csummer_calc_iods(csummer, &sgl, &iod, 1, 0, NULL, 0,
+				    &actual);
 	assert_int_equal(0, rc);
 
 	assert_int_equal(fake_get_size_result, actual->ic_akey.cs_buf_len);

--- a/src/include/daos/checksum.h
+++ b/src/include/daos/checksum.h
@@ -71,7 +71,7 @@ enum DAOS_CSUM_TYPE {
 struct dcs_csum_info {
 	/** buffer to store the checksums */
 	uint8_t		*cs_csum;
-	/** number of checksums stored in buffer. Only 1 for SV */
+	/** number of checksums stored in buffer */
 	uint32_t	 cs_nr;
 	/** type of checksum */
 	uint16_t	 cs_type;
@@ -93,6 +93,16 @@ struct dcs_iod_csums {
 	struct dcs_csum_info	*ic_data;
 	/** number of dcs_csum_info in ic_data. should be 1 for SV */
 	uint32_t		 ic_nr;
+};
+
+/** Single value layout info for checksum */
+struct dcs_singv_layout {
+	/** #bytes on evenly distributed targets */
+	uint64_t	cs_bytes;
+	/** targets number */
+	uint32_t	cs_nr;
+	/** even distribution flag */
+	uint32_t	cs_even_dist:1;
 };
 
 /** Lookup the appropriate CSUM_TYPE given daos container property */
@@ -244,6 +254,14 @@ daos_csummer_calc_one(struct daos_csummer *obj, d_sg_list_t *sgl,
  * @param[in]	nr		Number of iods and sgls as well as number of
  *				daos_iod_csums that will be created.
  * @param[in]	akey_only	Only calcualte the checksum for the iod name
+ * @param[in]	singv_los	Optional layout description for single values,
+ *				as for erasure-coding single value possibly
+ *				distributed to multiple targets. When it is NULL
+ *				it means replica object, or EC object located
+ *				in single target.
+ * @param[in]	singv_idx	single value target index, valid when singv_los
+ *				is non-NULL. -1 means calculating csum for all
+ *				shards.
  * @param[out]	p_iods_csums	Pointer that will reference the structures
  *				to hold the csums described by the iods. In case
  *				of error, memory will be freed internally to
@@ -254,6 +272,7 @@ daos_csummer_calc_one(struct daos_csummer *obj, d_sg_list_t *sgl,
 int
 daos_csummer_calc_iods(struct daos_csummer *obj, d_sg_list_t *sgls,
 		       daos_iod_t *iods, uint32_t nr, bool akey_only,
+		       struct dcs_singv_layout *singv_los, int singv_idx,
 		       struct dcs_iod_csums **p_iods_csums);
 
 /**
@@ -283,12 +302,21 @@ daos_csummer_calc_key(struct daos_csummer *csummer, daos_key_t *key,
  *			for the extents \a recxs. The total data
  *			length of the sgl should be the same as the sum
  *			of the lengths of all recxs
+ * @param singv_lo	Optional layout description for single value,
+ *			as for erasure-coding single value possibly
+ *			distributed to multiple targets. When it is NULL
+ *			it means replica object, or EC object located
+ *			in single target.
+ * @param singv_idx	single value target index, valid when singv_los
+ *			is non-NULL. -1 means verifing csum for all shards.
+ * @param iod_csum	checksum of the iod
  *
  * @return		0 for success, -DER_CSUM if corruption is detected
  */
 int
 daos_csummer_verify_iod(struct daos_csummer *obj, daos_iod_t *iod,
-			d_sg_list_t *sgl, struct dcs_iod_csums *iod_csums);
+			d_sg_list_t *sgl, struct dcs_iod_csums *iod_csum,
+			struct dcs_singv_layout *singv_lo, int singv_idx);
 
 /**
  * Verify a single buffer to a checksum
@@ -313,12 +341,18 @@ daos_csummer_verify_key(struct daos_csummer *obj, daos_key_t *key,
  * @param[in]	akey_only	if true, don't include the csums for the data
  *				(useful on client side fetch when only akey
  *				csum is needed)
+ * @param[in]	singv_los	Optional layout description for single values,
+ *				as for erasure-coding single value possibly
+ *				distributed to multiple targets. When it is NULL
+ *				it means replica object, or EC object located
+ *				in single target.
  *
  * @return			0 for success, or an error code
  */
 uint64_t
 daos_csummer_allocation_size(struct daos_csummer *obj, daos_iod_t *iods,
-			     uint32_t nr, bool akey_only);
+			     uint32_t nr, bool akey_only,
+			     struct dcs_singv_layout *singv_los);
 
 /**
  * Allocate the checksum structures needed for the iods. This will also
@@ -328,6 +362,12 @@ daos_csummer_allocation_size(struct daos_csummer *obj, daos_iod_t *iods,
  * @param[in]	obj		the daos_csummer obj
  * @param[in]	iods		list of iods
  * @param[in]	nr		number of iods
+ * @param[in]	akey_only	Only calcualte the checksum for the iod name
+ * @param[in]	singv_los	Optional layout description for single values,
+ *				as for erasure-coding single value possibly
+ *				distributed to multiple targets. When it is NULL
+ *				it means replica object, or EC object located
+ *				in single target.
  * @param[in]	p_iods_csums	pointer that will reference the
  *				the memory allocated
  * @return			number of iod_csums allocated, or
@@ -336,6 +376,7 @@ daos_csummer_allocation_size(struct daos_csummer *obj, daos_iod_t *iods,
 int
 daos_csummer_alloc_iods_csums(struct daos_csummer *obj, daos_iod_t *iods,
 			      uint32_t nr, bool akey_only,
+			      struct dcs_singv_layout *singv_los,
 			      struct dcs_iod_csums **p_iods_csums);
 
 /** Destroy the iods csums */

--- a/src/object/cli_ec.c
+++ b/src/object/cli_ec.c
@@ -1035,7 +1035,6 @@ obj_ec_recx_reasb(daos_iod_t *iod, d_sg_list_t *sgl,
 	}
 	punch = (update && iod->iod_size == DAOS_REC_ANY);
 
-	/* for array case */
 	for (i = 0; i < iod->iod_nr; i++) {
 		recx = &iod->iod_recxs[i];
 		with_full_stripe = recx_with_full_stripe(i, ec_recx_array,

--- a/src/object/cli_ec.c
+++ b/src/object/cli_ec.c
@@ -1188,15 +1188,24 @@ obj_ec_singv_req_reasb(daos_obj_id_t oid, daos_iod_t *iod, d_sg_list_t *sgl,
 				       obj_ec_tgt_nr(oca) - 1);
 		}
 	} else {
+		struct dcs_singv_layout	*singv_lo;
+
+		singv_lo = &reasb_req->orr_singv_los[iod_idx];
+		singv_lo->cs_even_dist = 1;
+		if (iod->iod_size != DAOS_REC_ANY)
+			singv_lo->cs_bytes =
+				obj_ec_singv_cell_bytes(iod->iod_size, oca);
 		/* large singv evenly distributed to all data targets */
 		if (update) {
 			tgt_nr = obj_ec_tgt_nr(oca);
+			singv_lo->cs_nr = tgt_nr;
 			obj_ec_set_tgt(tgt_bitmap, idx, 0,
 				       obj_ec_tgt_nr(oca) - 1);
 			if (!punch)
 				singv_parity = true;
 		} else {
 			tgt_nr = obj_ec_data_tgt_nr(oca);
+			singv_lo->cs_nr = tgt_nr;
 			obj_ec_set_tgt(tgt_bitmap, idx, 0,
 				       obj_ec_data_tgt_nr(oca) - 1);
 		}
@@ -1407,6 +1416,7 @@ obj_ec_tgt_oiod_init(struct obj_io_desc *r_oiods, uint32_t iod_nr,
 				oiod = &tgt_oiod->oto_oiods[i];
 				oiod->oiod_flags |= OBJ_SIOD_SINGV;
 				oiod->oiod_nr = 0;
+				oiod->oiod_tgt_idx = tgt_oiod->oto_tgt_idx;
 				oiod->oiod_siods = NULL;
 			}
 			continue;

--- a/src/object/cli_obj.c
+++ b/src/object/cli_obj.c
@@ -40,7 +40,7 @@
 #define CLI_OBJ_IO_PARMS	8
 #define NIL_BITMAP		(NULL)
 
-#define OBJ_TGT_INLINE_NR	(27)
+#define OBJ_TGT_INLINE_NR	(26)
 struct obj_req_tgts {
 	/* to save memory allocation if #targets <= OBJ_TGT_INLINE_NR */
 	struct daos_shard_tgt	 ort_tgts_inline[OBJ_TGT_INLINE_NR];

--- a/src/object/cli_obj.c
+++ b/src/object/cli_obj.c
@@ -40,7 +40,7 @@
 #define CLI_OBJ_IO_PARMS	8
 #define NIL_BITMAP		(NULL)
 
-#define OBJ_TGT_INLINE_NR	(28)
+#define OBJ_TGT_INLINE_NR	(27)
 struct obj_req_tgts {
 	/* to save memory allocation if #targets <= OBJ_TGT_INLINE_NR */
 	struct daos_shard_tgt	 ort_tgts_inline[OBJ_TGT_INLINE_NR];
@@ -569,7 +569,7 @@ obj_reasb_req_init(struct obj_auxi_args *obj_auxi, daos_iod_t *iods,
 {
 	struct obj_reasb_req		*reasb_req = &obj_auxi->reasb_req;
 	daos_size_t			 size_iod, size_sgl, size_oiod;
-	daos_size_t			 size_recx, size_tgt_nr;
+	daos_size_t			 size_recx, size_tgt_nr, size_singv;
 	daos_size_t			 size_sorter, buf_size;
 	daos_iod_t			*uiod, *riod;
 	struct obj_ec_recx_array	*ec_recx;
@@ -577,16 +577,18 @@ obj_reasb_req_init(struct obj_auxi_args *obj_auxi, daos_iod_t *iods,
 	uint8_t				*tmp_ptr;
 	int				 i;
 
+	reasb_req->orr_oca = oca;
 	size_iod = roundup(sizeof(daos_iod_t) * iod_nr, 8);
 	size_sgl = roundup(sizeof(d_sg_list_t) * iod_nr, 8);
 	size_oiod = roundup(sizeof(struct obj_io_desc) * iod_nr, 8);
 	size_recx = roundup(sizeof(struct obj_ec_recx_array) * iod_nr, 8);
 	size_sorter = roundup(sizeof(struct obj_ec_seg_sorter) * iod_nr, 8);
+	size_singv = roundup(sizeof(struct dcs_singv_layout) * iod_nr, 8);
 	/* for oer_tgt_recx_nrs/_idxs */
 	size_tgt_nr = roundup(sizeof(uint32_t) *
 			      (oca->u.ec.e_k + oca->u.ec.e_p), 8);
 	buf_size = size_iod + size_sgl + size_oiod + size_recx + size_sorter +
-		   size_tgt_nr * iod_nr * 2 + OBJ_TGT_BITMAP_LEN;
+		   size_singv + size_tgt_nr * iod_nr * 2 + OBJ_TGT_BITMAP_LEN;
 	D_ALLOC(buf, buf_size);
 	if (buf == NULL)
 		return -DER_NOMEM;
@@ -602,6 +604,8 @@ obj_reasb_req_init(struct obj_auxi_args *obj_auxi, daos_iod_t *iods,
 	tmp_ptr += size_recx;
 	reasb_req->orr_sorters = (void *)tmp_ptr;
 	tmp_ptr += size_sorter;
+	reasb_req->orr_singv_los = (void *)tmp_ptr;
+	tmp_ptr += size_singv;
 	reasb_req->tgt_bitmap = (void *)tmp_ptr;
 	tmp_ptr += OBJ_TGT_BITMAP_LEN;
 
@@ -2364,9 +2368,20 @@ shard_rw_prep(struct shard_auxi_args *shard_auxi, struct dc_object *obj,
 			shard_arg->oiods = reasb_req->orr_oiods;
 			shard_arg->offs = NULL;
 		}
+		if (obj_auxi->is_ec_obj)
+			shard_arg->reasb_req = reasb_req;
 	} else {
 		shard_arg->oiods = NULL;
 		shard_arg->offs = NULL;
+	}
+
+	/* csum_obj_update/_fetch set the dkey_csum/iod_csums to
+	 * obj_auxi->rw_args, but it is different than shard task's args
+	 * when there are multiple shard tasks (see obj_req_fanout).
+	 */
+	if (shard_arg != &obj_auxi->rw_args) {
+		shard_arg->dkey_csum = obj_auxi->rw_args.dkey_csum;
+		shard_arg->iod_csums = obj_auxi->rw_args.iod_csums;
 	}
 
 	return 0;
@@ -2390,11 +2405,12 @@ csum_obj_update(struct dc_object *obj, daos_obj_update_t *args,
 		return rc;
 
 	/** Calc 'a' key checksum and value checksum */
-	rc = daos_csummer_calc_iods(csummer, args->sgls, args->iods,
-				    args->nr, false, &iod_csums);
+	rc = daos_csummer_calc_iods(csummer, args->sgls, args->iods, args->nr,
+				    false, obj_auxi->reasb_req.orr_singv_los,
+				    -1, &iod_csums);
 	if (rc != 0) {
 		daos_csummer_free_ci(csummer, &dkey_csum);
-		D_ERROR("daos_csummer_calc_key error: %d", rc);
+		D_ERROR("daos_csummer_calc_iods error: %d", rc);
 		return rc;
 	}
 	/** fault injection */
@@ -2431,7 +2447,8 @@ csum_obj_fetch(const struct dc_object *obj, daos_obj_fetch_t *args,
 
 	/** akeys (1 for each iod) */
 	rc = daos_csummer_calc_iods(csummer, args->sgls, args->iods, args->nr,
-				    true, &iod_csums);
+				    true, obj_auxi->reasb_req.orr_singv_los,
+				    -1, &iod_csums);
 	if (rc != 0) {
 		D_ERROR("daos_csummer_calc_iods error: %d", rc);
 		daos_csummer_free_ci(csummer, &dkey_csum);

--- a/src/object/cli_obj.c
+++ b/src/object/cli_obj.c
@@ -2294,7 +2294,7 @@ obj_comp_cb(tse_task_t *task, void *data)
 			/** checksums sent and not retrying,
 			 * can destroy now
 			 */
-			obj_rw_csum_destroy(obj, dc_task_get_args(task));
+			obj_rw_csum_destroy(obj, obj_auxi);
 		if (obj_auxi->req_tgts.ort_shard_tgts !=
 		    obj_auxi->req_tgts.ort_tgts_inline)
 			D_FREE(obj_auxi->req_tgts.ort_shard_tgts);

--- a/src/object/cli_shard.c
+++ b/src/object/cli_shard.c
@@ -139,11 +139,11 @@ int dc_rw_cb_csum_verify(const struct rw_cb_args *rw_args)
 	orwo = crt_reply_get(rw_args->rpc);
 	sgls = rw_args->rwaa_sgls;
 	iods = orw->orw_iod_array.oia_iods;
-	iods_csums = orwo->orw_iod_csum.ca_arrays;
+	iods_csums = orwo->orw_iod_csums.ca_arrays;
 
 	if (DAOS_FAIL_CHECK(DAOS_CHECKSUM_FETCH_FAIL))
 		/** Got csum successfully from server. Now poison it!! */
-		orwo->orw_iod_csum.ca_arrays->ic_data->cs_csum[0]++;
+		orwo->orw_iod_csums.ca_arrays->ic_data->cs_csum[0]++;
 
 	for (i = 0; i < orw->orw_nr; i++) {
 		daos_iod_t		*iod = &iods[i];
@@ -428,13 +428,7 @@ dc_obj_shard_rw(struct dc_obj_shard *shard, enum obj_rpc_opc opc,
 		memset(&orw->orw_dkey_csum, 0, sizeof(orw->orw_dkey_csum));
 	orw->orw_iod_array.oia_iod_nr = nr;
 	orw->orw_iod_array.oia_iods = api_args->iods;
-	if (args->iod_csums != NULL) {
-		orw->orw_iod_csums.ca_arrays = args->iod_csums;
-		orw->orw_iod_csums.ca_count = api_args->nr;
-	} else {
-		orw->orw_iod_csums.ca_arrays = NULL;
-		orw->orw_iod_csums.ca_count = 0;
-	}
+	orw->orw_iod_array.oia_iod_csums = args->iod_csums;
 	orw->orw_iod_array.oia_oiods = args->oiods;
 	orw->orw_iod_array.oia_oiod_nr = (args->oiods == NULL) ?
 					 0 : nr;

--- a/src/object/cli_shard.c
+++ b/src/object/cli_shard.c
@@ -118,7 +118,41 @@ struct rw_cb_args {
 	d_sg_list_t		*rwaa_sgls;
 	struct dc_obj_shard	*dobj;
 	unsigned int		*map_ver;
+	struct shard_rw_args	*shard_args;
 };
+
+static struct dcs_singv_layout *
+dc_rw_cb_singv_lo_get(daos_iod_t *iods, d_sg_list_t *sgls, uint32_t iod_nr,
+		      struct obj_reasb_req *reasb_req)
+{
+	struct dcs_singv_layout	*singv_lo, *singv_los;
+	daos_iod_t		*iod;
+	d_sg_list_t		*sgl;
+	uint32_t		 i;
+
+	if (reasb_req == NULL)
+		return NULL;
+
+	singv_los = reasb_req->orr_singv_los;
+	for (i = 0; i < iod_nr; i++) {
+		singv_lo = &singv_los[i];
+		if (singv_lo->cs_even_dist == 0 || singv_lo->cs_bytes != 0)
+			continue;
+		/* the case of fetch singv with unknown rec size, now after the
+		 * fetch need to re-calculate the singv_lo again
+		 */
+		iod = &iods[i];
+		sgl = &sgls[i];
+		D_ASSERT(iod->iod_size != DAOS_REC_ANY);
+		if (obj_ec_singv_one_tgt(iod, sgl, reasb_req->orr_oca)) {
+			singv_lo->cs_even_dist = 0;
+			continue;
+		}
+		singv_lo->cs_bytes = obj_ec_singv_cell_bytes(iod->iod_size,
+						reasb_req->orr_oca);
+	}
+	return singv_los;
+}
 
 int dc_rw_cb_csum_verify(const struct rw_cb_args *rw_args)
 {
@@ -128,6 +162,8 @@ int dc_rw_cb_csum_verify(const struct rw_cb_args *rw_args)
 	struct obj_rw_out	*orwo;
 	daos_iod_t		*iods;
 	struct dcs_iod_csums	*iods_csums;
+	struct dcs_singv_layout	*singv_lo, *singv_los;
+	uint32_t		 shard_idx;
 	int			 i;
 	int			 rc = 0;
 
@@ -145,6 +181,10 @@ int dc_rw_cb_csum_verify(const struct rw_cb_args *rw_args)
 		/** Got csum successfully from server. Now poison it!! */
 		orwo->orw_iod_csums.ca_arrays->ic_data->cs_csum[0]++;
 
+	shard_idx = rw_args->shard_args->auxi.shard -
+		    rw_args->shard_args->auxi.start_shard;
+	singv_los = dc_rw_cb_singv_lo_get(iods, sgls, orw->orw_nr,
+					  rw_args->shard_args->reasb_req);
 	for (i = 0; i < orw->orw_nr; i++) {
 		daos_iod_t		*iod = &iods[i];
 		struct dcs_iod_csums	*iod_csum = &iods_csums[i];
@@ -152,7 +192,9 @@ int dc_rw_cb_csum_verify(const struct rw_cb_args *rw_args)
 		if (!csum_iod_is_supported(csummer->dcs_chunk_size, iod))
 			continue;
 
-		rc = daos_csummer_verify_iod(csummer, iod, &sgls[i], iod_csum);
+		singv_lo = (singv_los == NULL) ? NULL : &singv_los[i];
+		rc = daos_csummer_verify_iod(csummer, iod, &sgls[i], iod_csum,
+					     singv_lo, shard_idx);
 		if (rc != 0) {
 			D_ERROR("Verify failed: %d\n", rc);
 			break;
@@ -227,8 +269,14 @@ dc_rw_cb(tse_task_t *task, void *arg)
 	*rw_args->map_ver = obj_reply_map_version_get(rw_args->rpc);
 
 	if (opc == DAOS_OBJ_RPC_FETCH) {
+		bool	is_ec_obj = false;
+
 		iods = orw->orw_iod_array.oia_iods;
 		sizes = orwo->orw_iod_sizes.ca_arrays;
+
+		if (rw_args->shard_args->reasb_req != NULL &&
+		    DAOS_OC_IS_EC(rw_args->shard_args->reasb_req->orr_oca))
+			is_ec_obj = true;
 
 		if (orwo->orw_iod_sizes.ca_count != orw->orw_nr) {
 			D_ERROR("out:%u != in:%u for "DF_UOID" with eph "
@@ -249,7 +297,8 @@ dc_rw_cb(tse_task_t *task, void *arg)
 						     orw->orw_nr,
 						     orwo->orw_sgls.ca_arrays,
 						     orwo->orw_sgls.ca_count);
-		} else if (rw_args->rwaa_sgls != NULL) {
+		} else if (rw_args->rwaa_sgls != NULL && !is_ec_obj) {
+			/* XXX need some extra handling for EC obj */
 			/* for bulk transfer it needs to update sg_nr_out */
 			d_sg_list_t	*sgls = rw_args->rwaa_sgls;
 			d_iov_t		*iov;
@@ -422,10 +471,7 @@ dc_obj_shard_rw(struct dc_obj_shard *shard, enum obj_rpc_opc opc,
 	orw->orw_dkey_hash = args->dkey_hash;
 	orw->orw_nr = nr;
 	orw->orw_dkey = *dkey;
-	if (args->dkey_csum != NULL)
-		orw->orw_dkey_csum = args->dkey_csum;
-	else
-		memset(&orw->orw_dkey_csum, 0, sizeof(orw->orw_dkey_csum));
+	orw->orw_dkey_csum = args->dkey_csum;
 	orw->orw_iod_array.oia_iod_nr = nr;
 	orw->orw_iod_array.oia_iods = api_args->iods;
 	orw->orw_iod_array.oia_iod_csums = args->iod_csums;
@@ -462,6 +508,7 @@ dc_obj_shard_rw(struct dc_obj_shard *shard, enum obj_rpc_opc opc,
 	rw_args.hdlp = (daos_handle_t *)pool;
 	rw_args.map_ver = &args->auxi.map_ver;
 	rw_args.dobj = shard;
+	rw_args.shard_args = args;
 	/* remember the sgl to copyout the data inline for fetch */
 	rw_args.rwaa_sgls = (opc == DAOS_OBJ_RPC_FETCH) ? sgls : NULL;
 

--- a/src/object/obj_class.c
+++ b/src/object/obj_class.c
@@ -297,7 +297,7 @@ static struct daos_obj_class daos_obj_classes[] = {
 			.ca_grp_nr		= 1,
 			.ca_ec_k		= 2,
 			.ca_ec_p		= 2,
-			.ca_ec_cell		= 32,
+			.ca_ec_cell		= 1 << 15,
 		},
 	},
 	{
@@ -309,7 +309,19 @@ static struct daos_obj_class daos_obj_classes[] = {
 			.ca_grp_nr		= 1,
 			.ca_ec_k		= 8,
 			.ca_ec_p		= 2,
-			.ca_ec_cell		= 1 << 20,
+			.ca_ec_cell		= 1 << 15,
+		},
+	},
+	{
+		.oc_name	= "EC_16P2G1",
+		.oc_id		= OC_EC_16P2G1,
+		{
+			.ca_schema		= DAOS_OS_SINGLE,
+			.ca_resil		= DAOS_RES_EC,
+			.ca_grp_nr		= 1,
+			.ca_ec_k		= 16,
+			.ca_ec_p		= 2,
+			.ca_ec_cell		= 1 << 15,
 		},
 	},
 	{

--- a/src/object/obj_ec.h
+++ b/src/object/obj_ec.h
@@ -157,6 +157,8 @@ struct obj_ec_split_req {
 	daos_iod_t		*osr_iods;
 	/* leader shard's offsets (one for each iod) */
 	uint64_t		*osr_offs;
+	/* leader shard's iod_csums */
+	struct dcs_iod_csums	*osr_iod_csums;
 };
 
 /**

--- a/src/object/obj_ec.h
+++ b/src/object/obj_ec.h
@@ -80,7 +80,12 @@ struct obj_io_desc {
 	 * fetch targeted with only one shard, oiod_siods should be NULL as need
 	 * not carry extra info.
 	 */
-	uint32_t		 oiod_nr;
+	uint16_t		 oiod_nr;
+	/**
+	 * the target index [0, tgt_nr), only used for EC evenly distributed
+	 * single value.
+	 */
+	uint16_t		 oiod_tgt_idx;
 	/**
 	 * Flags, OBJ_SIOD_EVEN_DIST is for a special case that the extends
 	 * only cover full stripe(s), then each target has same number of
@@ -159,6 +164,8 @@ struct obj_ec_split_req {
 	uint64_t		*osr_offs;
 	/* leader shard's iod_csums */
 	struct dcs_iod_csums	*osr_iod_csums;
+	/* csum_info for singvs */
+	struct dcs_csum_info	*osr_singv_cis;
 };
 
 /**

--- a/src/object/obj_internal.h
+++ b/src/object/obj_internal.h
@@ -141,7 +141,9 @@ struct obj_reasb_req {
 	struct obj_io_desc		*orr_oiods;
 	struct obj_ec_recx_array	*orr_recxs;
 	struct obj_ec_seg_sorter	*orr_sorters;
+	struct dcs_singv_layout		*orr_singv_los;
 	uint32_t			 orr_tgt_nr;
+	struct daos_oclass_attr		*orr_oca;
 	/* target bitmap, one bit for each target (from first data cell to last
 	 * parity cell.
 	 */
@@ -271,6 +273,7 @@ struct shard_rw_args {
 	uint64_t		*offs;
 	struct dcs_csum_info	*dkey_csum;
 	struct dcs_iod_csums	*iod_csums;
+	struct obj_reasb_req	*reasb_req;
 };
 
 struct shard_punch_args {

--- a/src/object/obj_rpc.h
+++ b/src/object/obj_rpc.h
@@ -140,6 +140,7 @@ struct obj_iod_array {
 	/* number obj iods (oia_oiods) */
 	uint32_t		 oia_oiod_nr;
 	daos_iod_t		*oia_iods;
+	struct dcs_iod_csums	*oia_iod_csums;
 	struct obj_io_desc	*oia_oiods;
 	/* byte offset array for target, need this info after RPC dispatched
 	 * to specific target server as there is no oiod info already.
@@ -164,7 +165,6 @@ struct obj_iod_array {
 	((daos_key_t)		(orw_dkey)		CRT_VAR) \
 	((struct dcs_csum_info)	(orw_dkey_csum)		CRT_PTR) \
 	((struct obj_iod_array)	(orw_iod_array)		CRT_VAR) \
-	((struct dcs_iod_csums)	(orw_iod_csums)		CRT_ARRAY) \
 	((struct dtx_id)	(orw_dti_cos)		CRT_ARRAY) \
 	((d_sg_list_t)		(orw_sgls)		CRT_ARRAY) \
 	((crt_bulk_t)		(orw_bulks)		CRT_ARRAY) \
@@ -179,7 +179,7 @@ struct obj_iod_array {
 	((daos_size_t)		(orw_data_sizes)	CRT_ARRAY) \
 	((d_sg_list_t)		(orw_sgls)		CRT_ARRAY) \
 	((uint32_t)		(orw_nrs)		CRT_ARRAY) \
-	((struct dcs_iod_csums)	(orw_iod_csum)		CRT_ARRAY)
+	((struct dcs_iod_csums)	(orw_iod_csums)		CRT_ARRAY)
 
 CRT_RPC_DECLARE(obj_rw,		DAOS_ISEQ_OBJ_RW, DAOS_OSEQ_OBJ_RW)
 CRT_RPC_DECLARE(obj_update,	DAOS_ISEQ_OBJ_RW, DAOS_OSEQ_OBJ_RW)

--- a/src/object/rpc_csum.c
+++ b/src/object/rpc_csum.c
@@ -39,24 +39,33 @@
 				return -DER_HG; \
 		} while (0)
 
+/**
+ * advanced dcs_csum_info proc, can be used to proc partial data of the csum
+ * for EC single-value.
+ */
 static int
-proc_struct_dcs_csum_info(crt_proc_t proc, struct dcs_csum_info *csum)
+proc_struct_dcs_csum_info_adv(crt_proc_t proc, crt_proc_op_t proc_op,
+			      struct dcs_csum_info *csum, uint32_t idx,
+			      uint32_t nr)
 {
-	crt_proc_op_t		proc_op;
-	int			rc;
+	uint32_t	buf_len = 0;
+	int		rc;
 
 	if (csum == NULL)
 		return 0;
 
-	rc = crt_proc_get_op(proc, &proc_op);
-	if (rc != 0)
-		return -DER_HG;
-
-	PROC(uint32_t, &csum->cs_nr);
+	if (ENCODING(proc_op)) {
+		D_ASSERT(nr == csum->cs_nr || nr == 1);
+		PROC(uint32_t, &nr);
+		buf_len = nr * csum->cs_len;
+		PROC(uint32_t, &buf_len);
+	} else {
+		PROC(uint32_t, &csum->cs_nr);
+		PROC(uint32_t, &csum->cs_buf_len);
+	}
 	PROC(uint32_t, &csum->cs_chunksize);
 	PROC(uint16_t, &csum->cs_type);
 	PROC(uint16_t, &csum->cs_len);
-	PROC(uint32_t, &csum->cs_buf_len);
 
 	if (csum->cs_buf_len < csum->cs_len * csum->cs_nr) {
 		D_ERROR("invalid csum buf len %iu < csum len %hu\n",
@@ -68,7 +77,8 @@ proc_struct_dcs_csum_info(crt_proc_t proc, struct dcs_csum_info *csum)
 		return 0;
 
 	if (ENCODING(proc_op)) {
-		rc = crt_proc_memcpy(proc, csum->cs_csum, csum->cs_buf_len);
+		rc = crt_proc_memcpy(proc, csum->cs_csum + idx * csum->cs_len,
+				     buf_len);
 		if (rc != 0)
 			return -DER_HG;
 	}
@@ -89,6 +99,23 @@ proc_struct_dcs_csum_info(crt_proc_t proc, struct dcs_csum_info *csum)
 		D_FREE(csum->cs_csum);
 
 	return 0;
+}
+
+static int
+proc_struct_dcs_csum_info(crt_proc_t proc, struct dcs_csum_info *csum)
+{
+	crt_proc_op_t		proc_op;
+	int			rc;
+
+	if (csum == NULL)
+		return 0;
+
+	rc = crt_proc_get_op(proc, &proc_op);
+	if (rc != 0)
+		return -DER_HG;
+
+	return proc_struct_dcs_csum_info_adv(proc, proc_op, csum, 0,
+					     csum->cs_nr);
 }
 
 int
@@ -116,8 +143,10 @@ crt_proc_struct_dcs_csum_info(crt_proc_t proc, struct dcs_csum_info **p_csum)
 
 	if (DECODING(proc_op)) {
 		PROC(bool, &csum_enabled);
-		if (!csum_enabled)
+		if (!csum_enabled) {
+			*p_csum = NULL;
 			return 0;
+		}
 		D_ALLOC_PTR(*p_csum);
 		if (*p_csum == NULL)
 			return -DER_NOMEM;
@@ -136,13 +165,17 @@ crt_proc_struct_dcs_csum_info(crt_proc_t proc, struct dcs_csum_info **p_csum)
 	return rc;
 }
 
-/** advanced iod_csums proc */
+/**
+ * advanced iod_csums proc, can be used to proc partial data of the iod_csum
+ * for EC obj.
+ */
 int
 crt_proc_struct_dcs_iod_csums_adv(crt_proc_t proc, crt_proc_op_t proc_op,
-				  struct dcs_iod_csums *iod_csum,
+				  struct dcs_iod_csums *iod_csum, bool singv,
 				  uint32_t idx, uint32_t nr)
 {
-	int	rc, i;
+	struct dcs_csum_info	*singv_ci;
+	int			 rc, i;
 
 	rc = proc_struct_dcs_csum_info(proc, &iod_csum->ic_akey);
 	if (rc != 0)
@@ -151,18 +184,30 @@ crt_proc_struct_dcs_iod_csums_adv(crt_proc_t proc, crt_proc_op_t proc_op,
 	if (ENCODING(proc_op)) {
 		if (iod_csum->ic_nr != 0) {
 			D_ASSERT(nr <= iod_csum->ic_nr);
-			D_ASSERT(idx < iod_csum->ic_nr);
+			if (!singv)
+				D_ASSERT(idx < iod_csum->ic_nr);
 		} else {
 			/* only with akey csum */
 			idx = 0;
 			nr = 0;
 		}
 		PROC(uint32_t, &nr);
-		for (i = idx; i < idx + nr; i++) {
-			rc = proc_struct_dcs_csum_info(proc,
-				&iod_csum->ic_data[i]);
+		if (singv) {
+			D_ASSERT(nr == 1);
+			D_ASSERT(iod_csum->ic_nr == 1);
+			singv_ci = &iod_csum->ic_data[0];
+			D_ASSERT(idx < singv_ci->cs_nr);
+			rc = proc_struct_dcs_csum_info_adv(proc, proc_op,
+				singv_ci, idx, 1);
 			if (rc != 0)
 				return rc;
+		} else {
+			for (i = idx; i < idx + nr; i++) {
+				rc = proc_struct_dcs_csum_info(proc,
+					&iod_csum->ic_data[i]);
+				if (rc != 0)
+					return rc;
+			}
 		}
 	}
 
@@ -202,6 +247,6 @@ crt_proc_struct_dcs_iod_csums(crt_proc_t proc, struct dcs_iod_csums *iod_csum)
 	if (rc != 0)
 		return -DER_HG;
 
-	return crt_proc_struct_dcs_iod_csums_adv(proc, proc_op, iod_csum,
+	return crt_proc_struct_dcs_iod_csums_adv(proc, proc_op, iod_csum, false,
 						 0, iod_csum->ic_nr);
 }

--- a/src/object/rpc_csum.h
+++ b/src/object/rpc_csum.h
@@ -30,4 +30,9 @@ crt_proc_struct_dcs_csum_info(crt_proc_t proc, struct dcs_csum_info **csum);
 int
 crt_proc_struct_dcs_iod_csums(crt_proc_t proc, struct dcs_iod_csums *iod_csum);
 
+int
+crt_proc_struct_dcs_iod_csums_adv(crt_proc_t proc, crt_proc_op_t proc_op,
+				  struct dcs_iod_csums *iod_csum,
+				  uint32_t idx, uint32_t nr);
+
 #endif /** __DAOS_RPC_CSUM_H__ */

--- a/src/object/rpc_csum.h
+++ b/src/object/rpc_csum.h
@@ -32,7 +32,7 @@ crt_proc_struct_dcs_iod_csums(crt_proc_t proc, struct dcs_iod_csums *iod_csum);
 
 int
 crt_proc_struct_dcs_iod_csums_adv(crt_proc_t proc, crt_proc_op_t proc_op,
-				  struct dcs_iod_csums *iod_csum,
+				  struct dcs_iod_csums *iod_csum, bool singv,
 				  uint32_t idx, uint32_t nr);
 
 #endif /** __DAOS_RPC_CSUM_H__ */

--- a/src/object/srv_ec.c
+++ b/src/object/srv_ec.c
@@ -49,12 +49,17 @@ obj_ec_rw_req_split(struct obj_rw_in *orw, struct obj_ec_split_req **split_req)
 	daos_iod_t		*split_iod, *split_iods;
 	struct obj_shard_iod	*siod;
 	struct obj_tgt_oiod	*tgt_oiod, *tgt_oiods = NULL;
+	struct dcs_iod_csums	*iod_csum = NULL;
+	struct dcs_iod_csums	*iod_csums = orw->orw_iod_array.oia_iod_csums;
+	struct dcs_iod_csums	*split_iod_csum = NULL;
+	struct dcs_iod_csums	*split_iod_csums;
 	uint32_t		 tgt_nr = orw->orw_shard_tgts.ca_count;
 	uint32_t		 iod_nr = orw->orw_nr;
 	uint32_t		 start_shard = orw->orw_start_shard;
 	uint32_t		 i, tgt_idx, tgt_max_idx;
-	daos_size_t		 req_size, iods_size;
+	daos_size_t		 req_size, iods_size, csums_size = 0;
 	uint8_t			 tgt_bit_map[OBJ_TGT_BITMAP_LEN] = {0};
+	bool			 with_csums = (iod_csums != NULL);
 	void			*buf = NULL;
 	int			 rc = 0;
 
@@ -70,11 +75,15 @@ obj_ec_rw_req_split(struct obj_rw_in *orw, struct obj_ec_split_req **split_req)
 
 	req_size = roundup(sizeof(struct obj_ec_split_req), 8);
 	iods_size = roundup(sizeof(daos_iod_t) * iod_nr, 8);
-	D_ALLOC(buf, req_size + iods_size);
+	if (with_csums)
+		csums_size = roundup(sizeof(struct dcs_iod_csums) * iod_nr, 8);
+	D_ALLOC(buf, req_size + iods_size + csums_size);
 	if (buf == NULL)
 		return -DER_NOMEM;
 	req = buf;
 	req->osr_iods = buf + req_size;
+	if (with_csums)
+		req->osr_iod_csums = buf + req_size + iods_size;
 	req->osr_start_shard = start_shard;
 
 	for (i = 0; i < tgt_nr; i++) {
@@ -94,10 +103,17 @@ obj_ec_rw_req_split(struct obj_rw_in *orw, struct obj_ec_split_req **split_req)
 	req->osr_offs = tgt_oiod->oto_offs;
 
 	split_iods = req->osr_iods;
+	split_iod_csums = req->osr_iod_csums;
 	for (i = 0; i < iod_nr; i++) {
 		int	idx;
 
 		iod = &iods[i];
+		if (with_csums) {
+			D_ASSERT(split_iod_csums != NULL);
+			split_iod_csum = &split_iod_csums[i];
+			iod_csum = &iod_csums[i];
+			*split_iod_csum = *iod_csum;
+		}
 		split_iod = &split_iods[i];
 		split_iod->iod_name = iod->iod_name;
 		split_iod->iod_type = iod->iod_type;
@@ -106,10 +122,17 @@ obj_ec_rw_req_split(struct obj_rw_in *orw, struct obj_ec_split_req **split_req)
 			D_ASSERT(iod->iod_type == DAOS_IOD_SINGLE);
 			idx = 0;
 			split_iod->iod_nr = 1;
+			if (with_csums)
+				split_iod_csum->ic_nr = 1;
 		} else {
 			siod = &tgt_oiod->oto_oiods[i].oiod_siods[0];
 			split_iod->iod_nr = siod->siod_nr;
 			idx = siod->siod_idx;
+			if (with_csums) {
+				split_iod_csum->ic_data =
+					&iod_csum->ic_data[idx];
+				split_iod_csum->ic_nr = siod->siod_nr;
+			}
 		}
 		if (iod->iod_recxs != NULL)
 			split_iod->iod_recxs = &iod->iod_recxs[idx];

--- a/src/object/srv_obj.c
+++ b/src/object/srv_obj.c
@@ -763,7 +763,7 @@ obj_fetch_csum_init(struct ds_cont_hdl *cont_hdl,
 	rc = daos_csummer_alloc_iods_csums(cont_hdl->sch_csummer,
 					   orw->orw_iod_array.oia_iods,
 					   orw->orw_iod_array.oia_iod_nr,
-					   false,
+					   false, NULL,
 					   &orwo->orw_iod_csums.ca_arrays);
 
 	if (rc >= 0) {
@@ -2277,7 +2277,7 @@ obj_verify_bio_csum(crt_rpc_t *rpc, daos_iod_t *iods,
 
 		if (rc == 0)
 			rc = daos_csummer_verify_iod(csummer, iod, &sgl,
-						 &iod_csums[i]);
+						     &iod_csums[i], NULL, 0);
 
 		daos_sgl_fini(&sgl, false);
 

--- a/src/object/tests/srv_checksum_tests.c
+++ b/src/object/tests/srv_checksum_tests.c
@@ -231,7 +231,7 @@ array_test_case_create(struct vos_fetch_test_context *ctx,
 	ctx->iod.iod_recxs->rx_nr = setup->request_len;
 
 	daos_csummer_alloc_iods_csums(ctx->csummer, &ctx->iod, 1, false,
-				      &ctx->iod_csum);
+				      NULL, &ctx->iod_csum);
 }
 
 static void

--- a/src/tests/suite/daos_checksum.c
+++ b/src/tests/suite/daos_checksum.c
@@ -28,6 +28,36 @@
 #include <gurt/types.h>
 #include <daos_prop.h>
 
+/** by default for replica object test */
+static daos_oclass_id_t dts_csum_oc = OC_SX;
+
+/** enable EC obj csum test or replica obj csum test */
+static inline int
+csum_ec_enable(void **state)
+{
+	dts_csum_oc = OC_EC_2P2G1;
+	return 0;
+}
+
+static inline int
+csum_replia_enable(void **state)
+{
+	dts_csum_oc = OC_SX;
+	return 0;
+}
+
+static inline bool
+csum_ec_enabled()
+{
+	return dts_csum_oc == OC_EC_2P2G1;
+}
+
+static inline uint32_t
+csum_ec_grp_size()
+{
+	return 4;
+}
+
 /** fault injection helpers */
 static void
 set_fi(uint64_t flag)
@@ -242,14 +272,18 @@ static void
 checksum_disabled(void **state)
 {
 	struct csum_test_ctx	 ctx = {0};
+	daos_oclass_id_t	 oc = dts_csum_oc;
 	int			 rc;
+
+	if (csum_ec_enabled() && !test_runable(*state, csum_ec_grp_size()))
+		skip();
 
 	/**
 	 * Setup
 	 */
 	setup_from_test_args(&ctx, (test_arg_t *)*state);
 	setup_simple_data(&ctx);
-	setup_cont_obj(&ctx, DAOS_PROP_CO_CSUM_OFF, false, 0, OC_SX);
+	setup_cont_obj(&ctx, DAOS_PROP_CO_CSUM_OFF, false, 0, oc);
 
 	/**
 	 * Act
@@ -278,7 +312,11 @@ static void
 io_with_server_side_verify(void **state)
 {
 	struct csum_test_ctx	 ctx = {0};
+	daos_oclass_id_t	 oc = dts_csum_oc;
 	int			 rc;
+
+	if (csum_ec_enabled() && !test_runable(*state, csum_ec_grp_size()))
+		skip();
 
 	/**
 	 * Setup
@@ -302,14 +340,14 @@ io_with_server_side_verify(void **state)
 	 *
 	 */
 	/** 1. Server verify disabled, no corruption */
-	setup_cont_obj(&ctx, DAOS_PROP_CO_CSUM_CRC64, false, 0, OC_SX);
+	setup_cont_obj(&ctx, DAOS_PROP_CO_CSUM_CRC64, false, 0, oc);
 	rc = daos_obj_update(ctx.oh, DAOS_TX_NONE, 0, &ctx.dkey, 1,
 			     &ctx.update_iod, &ctx.update_sgl, NULL);
 	assert_int_equal(rc, 0);
 	cleanup_cont_obj(&ctx);
 
 	/** 2. Server verify enabled, no corruption */
-	setup_cont_obj(&ctx, DAOS_PROP_CO_CSUM_CRC64, true, 0, OC_SX);
+	setup_cont_obj(&ctx, DAOS_PROP_CO_CSUM_CRC64, true, 0, oc);
 	rc = daos_obj_update(ctx.oh, DAOS_TX_NONE, 0, &ctx.dkey, 1,
 			     &ctx.update_iod, &ctx.update_sgl, NULL);
 	assert_int_equal(rc, 0);
@@ -317,7 +355,7 @@ io_with_server_side_verify(void **state)
 
 	/** 3. Server verify disabled, corruption occurs, update should work */
 	set_update_csum_fi();
-	setup_cont_obj(&ctx, DAOS_PROP_CO_CSUM_CRC64, false, 0, OC_SX);
+	setup_cont_obj(&ctx, DAOS_PROP_CO_CSUM_CRC64, false, 0, oc);
 	rc = daos_obj_update(ctx.oh, DAOS_TX_NONE, 0, &ctx.dkey, 1,
 			     &ctx.update_iod, &ctx.update_sgl, NULL);
 	assert_int_equal(rc, 0);
@@ -326,7 +364,7 @@ io_with_server_side_verify(void **state)
 
 	/** 4. Server verify enabled, corruption occurs, update should fail */
 	set_update_csum_fi();
-	setup_cont_obj(&ctx, DAOS_PROP_CO_CSUM_CRC64, true, 0, OC_SX);
+	setup_cont_obj(&ctx, DAOS_PROP_CO_CSUM_CRC64, true, 0, oc);
 	rc = daos_obj_update(ctx.oh, DAOS_TX_NONE, 0, &ctx.dkey, 1,
 			     &ctx.update_iod, &ctx.update_sgl, NULL);
 	assert_int_equal(rc, -DER_CSUM);
@@ -335,13 +373,13 @@ io_with_server_side_verify(void **state)
 
 	/**5. Data corruption. Update should fail due CRC mismatch */
 	set_client_data_corrupt_fi();
-	setup_cont_obj(&ctx, DAOS_PROP_CO_CSUM_CRC64, false, 0, OC_SX);
+	setup_cont_obj(&ctx, DAOS_PROP_CO_CSUM_CRC64, false, 0, oc);
 	rc = daos_obj_update(ctx.oh, DAOS_TX_NONE, 0, &ctx.dkey, 1,
 			     &ctx.update_iod, &ctx.update_sgl, NULL);
 	assert_int_equal(rc, 0);
 	cleanup_cont_obj(&ctx);
 
-	setup_cont_obj(&ctx, DAOS_PROP_CO_CSUM_CRC64, true, 0, OC_SX);
+	setup_cont_obj(&ctx, DAOS_PROP_CO_CSUM_CRC64, true, 0, oc);
 	rc = daos_obj_update(ctx.oh, DAOS_TX_NONE, 0, &ctx.dkey, 1,
 			     &ctx.update_iod, &ctx.update_sgl, NULL);
 	assert_int_equal(rc, -DER_CSUM);
@@ -353,12 +391,13 @@ io_with_server_side_verify(void **state)
 static void
 test_server_data_corruption(void **state)
 {
-	test_arg_t	*arg = *state;
+	test_arg_t		*arg = *state;
 	struct csum_test_ctx	 ctx = {0};
+	daos_oclass_id_t	 oc = dts_csum_oc;
 	int			 rc;
 
 	setup_from_test_args(&ctx, *state);
-	setup_cont_obj(&ctx, DAOS_PROP_CO_CSUM_CRC64, false, 1024*8, OC_SX);
+	setup_cont_obj(&ctx, DAOS_PROP_CO_CSUM_CRC64, false, 1024*8, oc);
 
 	/**1. Simple server data corruption after RDMA */
 	setup_multiple_extent_data(&ctx);
@@ -387,15 +426,16 @@ test_server_data_corruption(void **state)
 static void
 test_fetch_array(void **state)
 {
-	int			rc;
 	struct csum_test_ctx	ctx = {0};
+	daos_oclass_id_t	oc = dts_csum_oc;
+	int			rc;
 
 	/**
 	 * Setup
 	 */
 	setup_from_test_args(&ctx, (test_arg_t *) *state);
 
-	setup_cont_obj(&ctx, DAOS_PROP_CO_CSUM_CRC64, false, 1024*8, OC_SX);
+	setup_cont_obj(&ctx, DAOS_PROP_CO_CSUM_CRC64, false, 1024*8, oc);
 
 	/**
 	 * Act
@@ -584,6 +624,7 @@ array_update_fetch_testcase(char *file, int line, test_arg_t *test_arg,
 			    struct partial_unaligned_fetch_testcase_args *args)
 {
 	struct csum_test_ctx	ctx = {0};
+	daos_oclass_id_t	oc = dts_csum_oc;
 	uint32_t		rec_size = args->rec_size;
 	int			recx_count = 0;
 	size_t			max_data_size = 0;
@@ -631,7 +672,7 @@ array_update_fetch_testcase(char *file, int line, test_arg_t *test_arg,
 
 	setup_from_test_args(&ctx, test_arg);
 	setup_cont_obj(&ctx, args->csum_prop_type, args->server_verify,
-		       args->chunksize, OC_SX);
+		       args->chunksize, oc);
 
 	for (i = 0; i < recx_count; i++) {
 		ctx.recx[0].rx_nr = args->recx_cfgs[i].nr;
@@ -750,11 +791,12 @@ static void
 single_value(void **state)
 {
 	struct csum_test_ctx	ctx = {0};
+	daos_oclass_id_t	oc = dts_csum_oc;
 	int			rc;
 
 	setup_from_test_args(&ctx, *state);
 
-	setup_cont_obj(&ctx, DAOS_PROP_CO_CSUM_CRC64, false, 4, OC_SX);
+	setup_cont_obj(&ctx, DAOS_PROP_CO_CSUM_CRC64, false, 4, oc);
 	setup_obj_data_for_sv(&ctx);
 
 	/** Base case ... no fault injection */
@@ -801,7 +843,7 @@ single_value(void **state)
 
 	/** Reset the container with server side verification enabled */
 	cleanup_cont_obj(&ctx);
-	setup_cont_obj(&ctx, DAOS_PROP_CO_CSUM_CRC64, true, 4, OC_SX);
+	setup_cont_obj(&ctx, DAOS_PROP_CO_CSUM_CRC64, true, 4, oc);
 
 	/**
 	 * fault injection on update
@@ -832,6 +874,7 @@ static void
 mix_test(void **state)
 {
 	struct csum_test_ctx	ctx = {0};
+	daos_oclass_id_t	oc = dts_csum_oc;
 	int			rc;
 	daos_key_t		 dkey;
 	daos_iod_t		 iods[2] = {0};
@@ -847,7 +890,7 @@ mix_test(void **state)
 
 	setup_from_test_args(&ctx, *state);
 
-	setup_cont_obj(&ctx, DAOS_PROP_CO_CSUM_CRC64, false, 4, OC_SX);
+	setup_cont_obj(&ctx, DAOS_PROP_CO_CSUM_CRC64, false, 4, oc);
 
 	iov_alloc_str(&dkey, "dkey");
 
@@ -917,7 +960,7 @@ mix_test(void **state)
 
 	/** Reset the container with server side verification enabled */
 	cleanup_cont_obj(&ctx);
-	setup_cont_obj(&ctx, DAOS_PROP_CO_CSUM_CRC64, true, 4, OC_SX);
+	setup_cont_obj(&ctx, DAOS_PROP_CO_CSUM_CRC64, true, 4, oc);
 
 	/**
 	 * fault injection on update
@@ -955,10 +998,11 @@ static void
 key_csum_fetch_update(void **state, int update_fi_flag, int fetch_fi_flag)
 {
 	struct csum_test_ctx	ctx;
+	daos_oclass_id_t	oc = dts_csum_oc;
 	int			rc;
 
 	setup_from_test_args(&ctx, *state);
-	setup_cont_obj(&ctx, DAOS_PROP_CO_CSUM_CRC16, false, 1024, OC_SX);
+	setup_cont_obj(&ctx, DAOS_PROP_CO_CSUM_CRC16, false, 1024, oc);
 	setup_simple_data(&ctx);
 
 	/**
@@ -1026,6 +1070,7 @@ static void
 test_enumerate_a_key(void **state)
 {
 	struct csum_test_ctx	ctx = {0};
+	daos_oclass_id_t	oc = dts_csum_oc;
 	int			rc;
 	uint32_t		i;
 	daos_anchor_t		anchor = {0};
@@ -1034,7 +1079,7 @@ test_enumerate_a_key(void **state)
 	uint32_t		nr = KDS_NR;
 
 	setup_from_test_args(&ctx, *state);
-	setup_cont_obj(&ctx, DAOS_PROP_CO_CSUM_CRC16, false, 1024, OC_SX);
+	setup_cont_obj(&ctx, DAOS_PROP_CO_CSUM_CRC16, false, 1024, oc);
 	setup_simple_data(&ctx);
 
 	/** insert multiple keys to enumerate */
@@ -1076,6 +1121,7 @@ static void
 test_enumerate_d_key(void **state)
 {
 	struct csum_test_ctx	ctx = {0};
+	daos_oclass_id_t	oc = dts_csum_oc;
 	int			rc = 0;
 	uint32_t		i;
 	daos_anchor_t		anchor = {0};
@@ -1085,7 +1131,7 @@ test_enumerate_d_key(void **state)
 	uint32_t		key_count = 0;
 
 	setup_from_test_args(&ctx, *state);
-	setup_cont_obj(&ctx, DAOS_PROP_CO_CSUM_CRC16, false, 1024, OC_SX);
+	setup_cont_obj(&ctx, DAOS_PROP_CO_CSUM_CRC16, false, 1024, oc);
 	setup_simple_data(&ctx);
 
 	/** insert multiple keys to enumerate */
@@ -1140,7 +1186,9 @@ setup(void **state)
 			  NULL);
 }
 
-#define CSUM_TEST(dsc, test) { dsc, test, async_disable, \
+#define CSUM_TEST(dsc, test) { dsc, test, csum_replia_enable, \
+				test_case_teardown }
+#define EC_CSUM_TEST(dsc, test) { dsc, test, csum_ec_enable, \
 				test_case_teardown }
 
 static const struct CMUnitTest csum_tests[] = {
@@ -1158,7 +1206,11 @@ static const struct CMUnitTest csum_tests[] = {
 	CSUM_TEST("DAOS_CSUM07: Update/Fetch A Key", test_update_fetch_a_key),
 	CSUM_TEST("DAOS_CSUM08: Update/Fetch D Key", test_update_fetch_d_key),
 	CSUM_TEST("DAOS_CSUM09: Enumerate A Keys", test_enumerate_a_key),
-	CSUM_TEST("DAOS_CSUM10: Enumerate D Keys", test_enumerate_d_key)
+	CSUM_TEST("DAOS_CSUM10: Enumerate D Keys", test_enumerate_d_key),
+
+	EC_CSUM_TEST("DAOS_EC_CSUM00: csum disabled", checksum_disabled),
+	EC_CSUM_TEST("DAOS_EC_CSUM01: simple update with server side verify",
+		     io_with_server_side_verify),
 };
 
 int

--- a/src/tests/suite/io_conf/daos_io_conf_3
+++ b/src/tests/suite/io_conf/daos_io_conf_3
@@ -59,7 +59,7 @@
 test_lvl daos
 dkey dkey_3
 akey akey_array_1
-iod_size 1024
+iod_size 10
 obj_class ec
 
 update --tx 1 -r "[0, 1]3, [33, 34]9"
@@ -75,9 +75,9 @@ update --tx 3 -r "[7, 9]23 [9, 20]34 [88, 123]55  [79, 82]11 [293, 549]8"
 fetch --tx 3 -r "[7, 9] [9, 20] [88, 123]  [79, 82] [293, 549]"
 fetch --tx 3 -r "[2, 100] [102, 134]"
 fetch --tx 3 -r "[1, 5]"
-update --tx 3 -r "[1, 2]6"
+update --tx 3 -r "[1, 132096]6"
 fetch --tx 3 -r "[0, 18]"
-fetch --tx 3 -r "[1, 15]"
+fetch --tx 3 -r "[1, 133096]"
 
 # single value on one target
 akey akey_single_1

--- a/src/vos/tests/vts_io.c
+++ b/src/vos/tests/vts_io.c
@@ -504,7 +504,7 @@ io_test_add_csums(daos_iod_t *iod, d_sg_list_t *sgl,
 	if (rc)
 		return rc;
 	rc = daos_csummer_calc_iods(*p_csummer, sgl, iod, 1, false,
-				    p_iod_csums);
+				    NULL, 0, p_iod_csums);
 	if (rc)
 		daos_csummer_destroy(p_csummer);
 	return rc;


### PR DESCRIPTION
1. For EC array, as we reassemble the iod/sgl at client, and split it at
    leader server for update, so need some extra handling for EC array
    csum handling.
2. For EC single value, it possibly distributed to all data targets, so
    define a dcs_singv_layout to describe layout info, and changed
    several csum APIs for it. And with some obj layer's changes.
3. bug fixes for csum handling (unrelated with EC)
    obj_rw_csum_destroy parameter, and dkey_csum/iod_csums
    possibly incorrectly set when obj req with multiple shard tasks.
4. Add csum test cases for both EC array and singv.
5. refine singv EC handling for padding case to fix a potential bug
6. Add OC_EC_16P2G1 obj class and change EC cell_size to be 32K.


Signed-off-by: Xuezhao Liu <xuezhao.liu@intel.com>