### PR TITLE
DAOS-4141 obj: fix bug of fetch csum retry

### DIFF
--- a/src/tests/suite/daos_checksum.c
+++ b/src/tests/suite/daos_checksum.c
@@ -1143,7 +1143,7 @@ setup(void **state)
 #define CSUM_TEST(dsc, test) { dsc, test, async_disable, \
 				test_case_teardown }
 
-static const struct CMUnitTest tests[] = {
+static const struct CMUnitTest csum_tests[] = {
 	CSUM_TEST("DAOS_CSUM00: csum disabled", checksum_disabled),
 	CSUM_TEST("DAOS_CSUM01: simple update with server side verify",
 		  io_with_server_side_verify),
@@ -1162,15 +1162,22 @@ static const struct CMUnitTest tests[] = {
 };
 
 int
-run_daos_checksum_test(int rank, int size)
+run_daos_checksum_test(int rank, int size, int *sub_tests, int sub_tests_size)
 {
 	int rc = 0;
 
-	if (rank == 0)
-		rc = cmocka_run_group_tests_name("DAOS Checksum Tests",
-			tests, setup, test_teardown);
+	if (rank == 0) {
+		if (sub_tests_size == 0) {
+			rc = cmocka_run_group_tests_name("DAOS Checksum Tests",
+				csum_tests, setup, test_teardown);
+		} else {
+			rc = run_daos_sub_tests(csum_tests,
+				ARRAY_SIZE(csum_tests), DEFAULT_POOL_SIZE,
+				sub_tests, sub_tests_size, setup,
+				test_teardown);
+		}
+	}
 
 	MPI_Barrier(MPI_COMM_WORLD);
 	return rc;
-
 }

--- a/src/tests/suite/daos_test.c
+++ b/src/tests/suite/daos_test.c
@@ -146,7 +146,8 @@ run_specified_tests(const char *tests, int rank, int size,
 			daos_test_print(rank, "\n\n=================");
 			daos_test_print(rank, "DAOS checksum tests..");
 			daos_test_print(rank, "=================");
-			nr_failed += run_daos_checksum_test(rank, size);
+			nr_failed += run_daos_checksum_test(rank, size,
+						sub_tests, sub_tests_size);
 			break;
 		case 'x':
 			daos_test_print(rank, "\n\n=================");

--- a/src/tests/suite/daos_test.h
+++ b/src/tests/suite/daos_test.h
@@ -283,7 +283,8 @@ int run_daos_degraded_test(int rank, int size);
 int run_daos_rebuild_test(int rank, int size, int *tests, int test_size);
 int run_daos_dtx_test(int rank, int size, int *tests, int test_size);
 int run_daos_vc_test(int rank, int size, int *tests, int test_size);
-int run_daos_checksum_test(int rank, int size);
+int run_daos_checksum_test(int rank, int size, int *sub_tests,
+			   int sub_tests_size);
 int run_daos_fs_test(int rank, int size, int *tests, int test_size);
 int run_daos_nvme_recov_test(int rank, int size, int *sub_tests,
 			     int sub_tests_size);


### PR DESCRIPTION
The original code use reasb_req.tgt_bitmap but that will not be
initialized for replica obj now. That cause initial_shard possibly
be incorrectly set and cause issue when retry for csum error.
This patch fixed some detailed handing, and add sub-test support for
csum test (for example ./daos_test -z -u sub_tests="2").

Fixed another bug that the csum report possibly send to incorrect target
and then further cause retry failure.

Signed-off-by: Xuezhao Liu <xuezhao.liu@intel.com>