### PR TITLE
DAOS-3347 tests: invalid I/O sg & record update test

### DIFF
--- a/src/tests/suite/daos_obj.c
+++ b/src/tests/suite/daos_obj.c
@@ -3618,6 +3618,93 @@ io_capa_iv_fetch(void **state)
 	ioreq_fini(&req);
 }
 
+static void
+io_invalid(void **state)
+{
+	test_arg_t	*arg = *state;
+	daos_obj_id_t	 oid;
+	daos_handle_t	 oh;
+	d_iov_t	 dkey;
+	d_sg_list_t	 sgl;
+	d_iov_t	 sg_iov[2];
+	daos_iod_t	 iod;
+	daos_recx_t	 recx[10];
+	char		 buf[32];
+	char		 buf1[32];
+	char		 large_buf[8192];
+	char		 origin_buf[8192];
+	int		 rc;
+
+	/** open object */
+	oid = dts_oid_gen(dts_obj_class, 0, arg->myrank);
+	rc = daos_obj_open(arg->coh, oid, 0, &oh, NULL);
+	assert_int_equal(rc, 0);
+
+	/** init dkey */
+	d_iov_set(&dkey, "dkey", strlen("dkey"));
+	d_iov_set(&iod.iod_name, "akey", strlen("akey"));
+
+	/** smaller buffer */
+	d_iov_set(&sg_iov[0], buf, 12);
+	sgl.sg_nr		= 1;
+	sgl.sg_nr_out		= 0;
+	sgl.sg_iovs		= &sg_iov[0];
+	iod.iod_size	= 1;
+	iod.iod_recxs	= recx;
+	iod.iod_type	= DAOS_IOD_ARRAY;
+	recx[0].rx_idx	= 0;
+	recx[0].rx_nr	= 32;
+	iod.iod_nr	= 1;
+
+	rc = daos_obj_update(oh, DAOS_TX_NONE, 0, &dkey, 1, &iod, &sgl, NULL);
+	assert_int_equal(rc, -DER_REC2BIG);
+
+	/** more buffers */
+	memset(buf, 'a', 12);
+	memset(buf1, 'a', 12);
+	d_iov_set(&sg_iov[0], buf, 12);
+	d_iov_set(&sg_iov[1], buf1, 12);
+	sgl.sg_nr		= 2;
+	sgl.sg_nr_out		= 0;
+	sgl.sg_iovs		= sg_iov;
+	iod.iod_size	= 1;
+	iod.iod_recxs	= recx;
+	iod.iod_type	= DAOS_IOD_ARRAY;
+	recx[0].rx_idx	= 0;
+	recx[0].rx_nr	= 12;
+	iod.iod_nr	= 1;
+
+	rc = daos_obj_update(oh, DAOS_TX_NONE, 0, &dkey, 1, &iod, &sgl, NULL);
+	assert_int_equal(rc, 0);
+
+	rc = daos_obj_fetch(oh, DAOS_TX_NONE, 0, &dkey, 1, &iod, &sgl,
+			    NULL, NULL);
+	assert_int_equal(rc, 0);
+	assert_memory_equal(buf, buf1, 12);
+
+	/* larger buffer */
+	memset(large_buf, 'a', 8192);
+	memset(origin_buf, 'a', 8192);
+	d_iov_set(&sg_iov[0], large_buf, 8192);
+	sgl.sg_nr	= 1;
+	sgl.sg_nr_out	= 0;
+	sgl.sg_iovs	= &sg_iov[0];
+	iod.iod_size	= 1;
+	iod.iod_recxs	= recx;
+	iod.iod_type	= DAOS_IOD_ARRAY;
+	recx[0].rx_idx	= 0;
+	recx[0].rx_nr	= 12;
+	iod.iod_nr	= 1;
+
+	rc = daos_obj_update(oh, DAOS_TX_NONE, 0, &dkey, 1, &iod, &sgl, NULL);
+	assert_int_equal(rc, 0);
+
+	rc = daos_obj_fetch(oh, DAOS_TX_NONE, 0, &dkey, 1, &iod, &sgl,
+			    NULL, NULL);
+	assert_memory_equal(large_buf, origin_buf, 8192);
+	assert_int_equal(rc, 0);
+}
+
 static const struct CMUnitTest io_tests[] = {
 	{ "IO1: simple update/fetch/verify",
 	  io_simple, async_disable, test_case_teardown},
@@ -3694,6 +3781,9 @@ static const struct CMUnitTest io_tests[] = {
 	  fetch_mixed_keys, async_disable, test_case_teardown},
 	{ "IO38: force capablity IV fetch",
 	  io_capa_iv_fetch, async_disable, test_case_teardown},
+	{ "IO39: Update with invalid sg and record",
+	  io_invalid, async_disable, test_case_teardown},
+	
 };
 
 int


### PR DESCRIPTION
Add Invalid sg_list and iod record update test.

Signed-off-by: Di Wang <di.wang@intel.com>