### PR TITLE
DAOS-4147 control: Handle config with empty server

### DIFF
--- a/src/control/server/config_test.go
+++ b/src/control/server/config_test.go
@@ -117,11 +117,8 @@ func TestServer_ConfigMarshalUnmarshal(t *testing.T) {
 			log, buf := logging.NewTestLogger(t.Name())
 			defer ShowBufferOnFailure(t, buf)
 
-			testDir, err := ioutil.TempDir("", strings.Replace(t.Name(), "/", "-", -1))
-			defer os.RemoveAll(testDir)
-			if err != nil {
-				t.Fatal(err)
-			}
+			testDir, cleanup := CreateTestDir(t)
+			defer cleanup()
 			testFile := filepath.Join(testDir, "test.yml")
 
 			if tt.inPath == "uncommentedDefault" {
@@ -133,7 +130,7 @@ func TestServer_ConfigMarshalUnmarshal(t *testing.T) {
 				WithProviderValidator(netdetect.ValidateProviderStub).
 				WithNUMAValidator(netdetect.ValidateNUMAStub)
 			configA.Path = tt.inPath
-			err = configA.Load()
+			err := configA.Load()
 			if err == nil {
 				err = configA.Validate(log)
 			}
@@ -267,6 +264,13 @@ func TestServer_ConfigValidation(t *testing.T) {
 			noopExtra,
 			nil,
 		},
+		"nil server entry": {
+			func(c *Configuration) *Configuration {
+				var nilIOServerConfig *ioserver.Config
+				return c.WithServers(nilIOServerConfig)
+			},
+			errors.New("validation"),
+		},
 		"single access point": {
 			func(c *Configuration) *Configuration {
 				return c.WithAccessPoints("1.2.3.4:1234")
@@ -309,11 +313,8 @@ func TestServer_ConfigValidation(t *testing.T) {
 			log, buf := logging.NewTestLogger(t.Name())
 			defer ShowBufferOnFailure(t, buf)
 
-			testDir, err := ioutil.TempDir("", strings.Replace(t.Name(), "/", "-", -1))
-			defer os.RemoveAll(testDir)
-			if err != nil {
-				t.Fatal(err)
-			}
+			testDir, cleanup := CreateTestDir(t)
+			defer cleanup()
 
 			// First, load a config based on the server config with all options uncommented.
 			testFile := filepath.Join(testDir, sConfigUncomment)
@@ -337,11 +338,8 @@ func TestServer_ConfigRelativeWorkingPath(t *testing.T) {
 		"path doesnt exist": {expErrMsg: "no such file or directory"},
 	} {
 		t.Run(name, func(t *testing.T) {
-			testDir, err := ioutil.TempDir("", strings.Replace(t.Name(), "/", "-", -1))
-			defer os.RemoveAll(testDir)
-			if err != nil {
-				t.Fatal(err)
-			}
+			testDir, cleanup := CreateTestDir(t)
+			defer cleanup()
 			testFile := filepath.Join(testDir, "test.yml")
 
 			if tt.inPath == "uncommentedDefault" {
@@ -380,6 +378,30 @@ func TestServer_ConfigRelativeWorkingPath(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+func TestServer_WithServersInheritsMainConfig(t *testing.T) {
+	testFabric := "test-fabric"
+	testModules := "a,b,c"
+	testSystemName := "test-system"
+	testSocketDir := "test-sockets"
+
+	wantCfg := ioserver.NewConfig().
+		WithFabricProvider(testFabric).
+		WithModules(testModules).
+		WithSocketDir(testSocketDir).
+		WithSystemName(testSystemName)
+
+	config := NewConfiguration().
+		WithFabricProvider(testFabric).
+		WithModules(testModules).
+		WithSocketDir(testSocketDir).
+		WithSystemName(testSystemName).
+		WithServers(ioserver.NewConfig())
+
+	if diff := cmp.Diff(wantCfg, config.Servers[0]); diff != "" {
+		t.Fatalf("unexpected server config (-want, +got):\n%s\n", diff)
 	}
 }
 


### PR DESCRIPTION
A configuration with an empty ioserver config entry is
valid yaml, but results in a nil *ioserver.Config entry
which will cause a panic unless we handle it.