### PR TITLE
DAOS-2265 build: Add GO build-ids

### DIFF
--- a/src/control/SConscript
+++ b/src/control/SConscript
@@ -71,7 +71,7 @@ def install_go_bin(denv, gosrc, gopath, libs, name, install_name):
     def gen_build_id():
         from os import urandom
         from binascii import b2a_hex
-        return str('0x%s' % b2a_hex(urandom(20)))
+        return '0x' + b2a_hex(urandom(20)).decode()
     def go_ldflags():
         return ' '.join(['-ldflags',
                          '"-X main.daosVersion=%s' % DAOS_VERSION,

--- a/src/control/SConscript
+++ b/src/control/SConscript
@@ -66,9 +66,20 @@ def install_go_bin(denv, gosrc, gopath, libs, name, install_name):
     src = [mod_src]
     if libs is not None:
         src.extend(libs)
+    # generate a unique build id per binary for use by RPM
+    # https://fedoraproject.org/wiki/PackagingDrafts/Go#Build_ID
+    def gen_build_id():
+        from os import urandom
+        from binascii import b2a_hex
+        return '0x' + b2a_hex(urandom(20)).decode()
+    def go_ldflags():
+        return ' '.join(['-ldflags',
+                         '"-X main.daosVersion=%s' % DAOS_VERSION,
+                         '-B %s"' % gen_build_id(),
+                         '-v'])
     denv.Command(bin_path, src,
                  cmd_build(path, gosrc,
-                           'go install -ldflags "-X main.daosVersion=%s" %s' % (DAOS_VERSION, install_src)))
+                           'go install %s %s' % (go_ldflags(), install_src)))
     denv.InstallAs(install_bin, bin_path)
 #pylint: enable=too-many-arguments
 

--- a/src/control/SConscript
+++ b/src/control/SConscript
@@ -71,7 +71,13 @@ def install_go_bin(denv, gosrc, gopath, libs, name, install_name):
     def gen_build_id():
         from os import urandom
         from binascii import b2a_hex
-        return '0x' + b2a_hex(urandom(20)).decode()
+        ret = '0x' + b2a_hex(urandom(20))
+        if isinstance(ret, str):
+            # Python 2 is a str already
+            return ret
+        else:
+            # Python 3 is a bytes, decode() it to a str
+            return ret.decode()
     def go_ldflags():
         return ' '.join(['-ldflags',
                          '"-X main.daosVersion=%s' % DAOS_VERSION,

--- a/src/control/SConscript
+++ b/src/control/SConscript
@@ -71,7 +71,7 @@ def install_go_bin(denv, gosrc, gopath, libs, name, install_name):
     def gen_build_id():
         from os import urandom
         from binascii import b2a_hex
-        return '0x' + b2a_hex(urandom(20)).decode()
+        return str('0x%s' % b2a_hex(urandom(20)))
     def go_ldflags():
         return ' '.join(['-ldflags',
                          '"-X main.daosVersion=%s' % DAOS_VERSION,

--- a/src/control/SConscript
+++ b/src/control/SConscript
@@ -71,13 +71,14 @@ def install_go_bin(denv, gosrc, gopath, libs, name, install_name):
     def gen_build_id():
         from os import urandom
         from binascii import b2a_hex
-        ret = '0x' + b2a_hex(urandom(20))
-        if isinstance(ret, str):
-            # Python 2 is a str already
-            return ret
+        buildid = b2a_hex(urandom(20))
+        if isinstance(buildid, str):
+            # Python 2 is a str already, using decode() here transforms it
+            # into a 'unicode' type
+            return '0x' + buildid
         else:
             # Python 3 is a bytes, decode() it to a str
-            return ret.decode()
+            return '0x' + buildid.decode()
     def go_ldflags():
         return ' '.join(['-ldflags',
                          '"-X main.daosVersion=%s' % DAOS_VERSION,

--- a/utils/rpms/daos.spec
+++ b/utils/rpms/daos.spec
@@ -1,6 +1,3 @@
-# Needed because of the GO binaries
-%undefine _missing_build_ids_terminate_build
-
 %define daoshome %{_exec_prefix}/lib/%{name}
 
 # Unlimited maximum version
@@ -8,7 +5,7 @@
 
 Name:          daos
 Version:       0.9.0
-Release:       1%{?relval}%{?dist}
+Release:       2%{?relval}%{?dist}
 Summary:       DAOS Storage Engine
 
 License:       Apache
@@ -336,6 +333,9 @@ getent group daos_admins >/dev/null || groupadd -r daos_admins
 %{_libdir}/*.a
 
 %changelog
+* Wed Feb 12 2020 Brian J. Murrell <brian.murrell@intel.com> - 0.9.0-2
+- Remove undefine _missing_build_ids_terminate_build
+
 * Thu Feb 06 2020 Johann Lombardi <johann.lombardi@intel.com> - 0.9.0-1
 - Version bump up to 0.9.0
 


### PR DESCRIPTION

Thanks to a hack by Michael MacDonald, we can now give GO binaries a
build-id.

Signed-off-by: Brian J. Murrell <brian.murrell@intel.com>