### PR TITLE
DAOS-3821 test: pool update bad_evict yaml in pool create for CI regr…

### DIFF
--- a/src/tests/ftest/pool/bad_evict.py
+++ b/src/tests/ftest/pool/bad_evict.py
@@ -73,9 +73,6 @@ class BadEvictTest(TestWithServers):
         excludeuuid = uuidlist[0]
         expected_for_param.append(uuidlist[1])
 
-        if svc == 'VALID' and evictset is None and excludeuuid == 'VALID':
-            self.cancelForTicket("DAOS-3224")
-
         # if any parameter is FAIL then the test should FAIL, in this test
         # virtually everyone should FAIL since we are testing bad parameters
         expected_result = 'PASS'
@@ -140,5 +137,4 @@ class BadEvictTest(TestWithServers):
                         pool.uuid[item] = saveduuid[item]
                 if savedsvc is not None:
                     pool.svc = savedsvc
-                pool.disconnect()
-                pool.destroy(1)
+                pool.destroy(0)

--- a/src/tests/ftest/pool/bad_evict.py
+++ b/src/tests/ftest/pool/bad_evict.py
@@ -100,9 +100,11 @@ class BadEvictTest(TestWithServers):
                 pool.svc = RankList(rl_ranks, 1)
 
             # trash the pool group value
+            savedgroup = pool.group
             if evictset is None:
-                savedgroup = pool.group
                 pool.group = None
+            else:
+                pool.set_group(evictset)
 
             # trash the UUID value in various ways
             if excludeuuid is None:
@@ -130,8 +132,7 @@ class BadEvictTest(TestWithServers):
             if pool is not None:
                 # if the test trashed some pool parameter, put it back the
                 # way it was
-                if savedgroup is not None:
-                    pool.group = savedgroup
+                pool.group = savedgroup
                 if saveduuid is not None:
                     for item in range(0, len(saveduuid)):
                         pool.uuid[item] = saveduuid[item]

--- a/src/tests/ftest/pool/bad_evict.yaml
+++ b/src/tests/ftest/pool/bad_evict.yaml
@@ -1,9 +1,11 @@
 server_config:
-   name: scott_server
+   name: daos_server
 hosts:
   test_servers:
     - server-A
 timeout: 650
+server_manager:
+  recreate: true
 evicttests:
    svrlist: !mux
      goodlist:
@@ -22,7 +24,7 @@ evicttests:
      badname:
           setname:
              - NULL
-             - FAIL
+             - PASS
    UUID: !mux
      gooduuid:
           uuid:
@@ -39,6 +41,6 @@ evicttests:
    createmode:
      mode: 511
    createset:
-     setname: scott_server
+     setname: daos_server
    createsize:
      size: 1073741824

--- a/src/tests/ftest/pool/bad_evict.yaml
+++ b/src/tests/ftest/pool/bad_evict.yaml
@@ -19,9 +19,13 @@ evicttests:
    connectsetnames: !mux
      goodname:
           setname:
-             - scott_server
+             - daos_server
              - PASS
      badname:
+          setname:
+             - badname_server
+             - FAIL
+     nullname:
           setname:
              - NULL
              - PASS

--- a/src/tests/ftest/pool/bad_query.py
+++ b/src/tests/ftest/pool/bad_query.py
@@ -39,7 +39,7 @@ class BadQueryTest(TestWithServers):
     """
 
     def test_query(self):
-        """Test ID: DAOS-???.
+        """Test ID: DAOS-3821.
 
         Test Description:
             Pass bad parameters to pool query
@@ -76,6 +76,7 @@ class BadQueryTest(TestWithServers):
 
         # trash the pool handle value
         if not handle == 'VALID':
+            handle_sav = self.pool.pool.handle
             self.pool.pool.handle = handle
 
         try:
@@ -83,9 +84,13 @@ class BadQueryTest(TestWithServers):
 
             if expected_result in ['FAIL']:
                 self.fail("Test was expected to fail but it passed.\n")
+            self.log.info("===Pool query positive testcase Passed.")
 
         except TestFail as excep:
             self.log.error(str(excep))
             self.log.error(traceback.format_exc())
             if expected_result in ['PASS']:
                 self.fail("Test was expected to pass but it failed.\n")
+            self.log.info("===Pool query negative testcase Passed.")
+            # restore the valid handle for pool cleanup
+            self.pool.pool.handle = handle_sav

--- a/src/tests/ftest/pool/bad_query.yaml
+++ b/src/tests/ftest/pool/bad_query.yaml
@@ -32,11 +32,3 @@ querytests:
           info:
              - NULL
              - PASS
-   connectmode:
-     mode: 2
-   createmode:
-     mode: 511
-   createset:
-     setname: daos_server
-   createsize:
-     size: 1073741824

--- a/src/tests/ftest/pool/bad_query.yaml
+++ b/src/tests/ftest/pool/bad_query.yaml
@@ -1,10 +1,13 @@
 # Note that stuff that is commented out represents tests that presently
 # fail and will be uncommented as the daos code is fixed
 server_config:
-   name: scott_server
+   name: daos_server
 hosts:
   test_servers:
     - server-A
+timeout: 150
+server_manager:
+  recreate: true
 pool:
   control_method: dmg
   mode: 511
@@ -29,3 +32,11 @@ querytests:
           info:
              - NULL
              - PASS
+   connectmode:
+     mode: 2
+   createmode:
+     mode: 511
+   createset:
+     setname: daos_server
+   createsize:
+     size: 1073741824


### PR DESCRIPTION
…ession failures

updated file: daos/src/tests/ftest/pool/bad_evict.py
updated file: daos/src/tests/ftest/pool/bad_query.py
updated file: daos/src/tests/ftest/pool/bad_evict.yaml
updated file: daos/src/tests/ftest/pool/bad_query.yaml

Test-tags: pr,-hw pool,badevict,badquery
Signed-off-by: Ding Ho <ding-hwa.ho@intel.com>