### PR TITLE
DAOS-3819 api: check pool connect uuid for NULL

### DIFF
--- a/src/client/api/pool.c
+++ b/src/client/api/pool.c
@@ -38,6 +38,9 @@ daos_pool_connect(const uuid_t uuid, const char *grp,
 	int			 rc;
 
 	DAOS_API_ARG_ASSERT(*args, POOL_CONNECT);
+	if (!daos_uuid_valid(uuid))
+		return -DER_INVAL;
+
 	rc = dc_task_create(dc_pool_connect, NULL, ev, &task);
 	if (rc)
 		return rc;

--- a/src/tests/ftest/pool/bad_connect.py
+++ b/src/tests/ftest/pool/bad_connect.py
@@ -36,7 +36,6 @@ class BadConnectTest(TestWithServers):
     parameters.  This can't be done with daosctl, need to use the python API.
     :avocado: recursive
     """
-    @skipForTicket("DAOS-3819")
     def test_connect(self):
         """
         Pass bad parameters to pool connect
@@ -63,8 +62,6 @@ class BadConnectTest(TestWithServers):
 
         uuidlist = self.params.get("uuid", '/run/connecttests/UUID/*/')
         connectuuid = uuidlist[0]
-        if connectuuid == 'NULLPTR':
-            self.cancel("skipping null pointer test until DAOS-1781 is fixed")
         expected_for_param.append(uuidlist[1])
 
         # if any parameter is FAIL then the test should FAIL, in this test
@@ -105,7 +102,7 @@ class BadConnectTest(TestWithServers):
             self.pool.pool.uuid[4] = 244
 
         try:
-            self.pool.connect(connectmode)
+            self.pool.connect(1 << connectmode)
 
             if expected_result in ['FAIL']:
                 self.fail("Test was expected to fail but it passed.\n")
@@ -123,6 +120,8 @@ class BadConnectTest(TestWithServers):
                 self.pool.pool.svc.rl_ranks = psvc.rl_ranks
                 self.pool.pool.svc.rl_nr = psvc.rl_nr
                 self.pool.pool.group = pgroup
+                if self.pool.pool.uuid is None:
+                    self.pool.pool.uuid = (ctypes.c_ubyte * 16)()
                 ctypes.memmove(self.pool.pool.uuid, puuid, 16)
                 print("pool uuid after restore {}".format(
                     self.pool.pool.get_uuid_str()))

--- a/src/tests/ftest/pool/bad_connect.yaml
+++ b/src/tests/ftest/pool/bad_connect.yaml
@@ -5,11 +5,13 @@ server_config:
 hosts:
   test_servers:
     - server-A
+server_manager:
+   recreate: true
 timeout: 700
 pool:
   control_method: dmg
   mode: 511
-  size: 1073741824
+  scm_size: 1073741824
   name: daos_server
 connecttests:
    connectmode: !mux


### PR DESCRIPTION
Cherry picked commit 0d58d4725611cd041ad8984b4a0706dbeb47dc32 PR #1842
from daos master branch to release/0.9 branch.

With this change, daos_pool_connect() returns -DER_INVAL if the uuid
argument is invalid (preventing a segmentation fault when uuid=NULL).

Also with this change the functional test bad_connect.py is
re-enabled (skip decorator removed).

Some text fixes were also required: the config file (scm_size),
cleanup code for the NULL uuid test cases, and the flags argument
supplied to daos_pool_connect (1 << mode required).

Test-tag: pr,-hw badconnect

Signed-off-by: Ken Cain <kenneth.c.cain@intel.com>