### PR TITLE
DAOS-3627 md: pool destroy: resume destroy/connected testing

### DIFF
--- a/src/tests/ftest/pool/destroy_tests.py
+++ b/src/tests/ftest/pool/destroy_tests.py
@@ -324,7 +324,6 @@ class DestroyTests(TestWithServers):
                 self.pool.uuid, group_names[0]),
             False)
 
-    @skipForTicket("DAOS-2741")
     def test_destroy_connected(self):
         """Destroy pool with connected client.
 
@@ -375,7 +374,6 @@ class DestroyTests(TestWithServers):
         self.assertTrue(
             exception_detected, "No exception when deleting a connected pool")
 
-    @skipForTicket("DAOS-2741")
     def test_destroy_withdata(self):
         """Destroy Pool with data.
 


### PR DESCRIPTION
Cherry picked commit a3ec11ddb517ac31d7620f0486937b4935b5efd2 PR #1670
from daos master branch to release/0.9 branch.

Pool destroy tests test_destroy_connected and test_destroy_withdata
are re-introduced with this change. The tests had previously been
skipped in the testing flow due to bugs with pool destroy that have
now been been resolved in a prior commit for DAOS-3627.

Signed-off-by: Ken Cain <kenneth.c.cain@intel.com>