### PR TITLE
DAOS-4108 Pool: Nodes Not Marked Down on All Target Failure.

### DIFF
--- a/src/common/pool_map.c
+++ b/src/common/pool_map.c
@@ -1670,26 +1670,6 @@ pool_map_find_target_by_rank_idx(struct pool_map *map, uint32_t rank,
 	return 1;
 }
 
-/**
- * Check if all targets under one node matching the status.
- * \params [IN] dom	node domain to be checked.
- * \param [IN] status	status to be checked.
- *
- * \return		true if matches, otherwise false.
- */
-bool
-pool_map_node_status_match(struct pool_domain *dom, unsigned int status)
-{
-	int i;
-
-	for (i = 0; i < dom->do_target_nr; i++) {
-		if (!(dom->do_targets[i].ta_comp.co_status & status))
-			return false;
-	}
-
-	return true;
-}
-
 static void
 fseq_sort_op_swap(void *array, int a, int b)
 {

--- a/src/include/daos/pool_map.h
+++ b/src/include/daos/pool_map.h
@@ -210,8 +210,6 @@ int pool_map_find_target_by_rank_idx(struct pool_map *map, uint32_t rank,
 int pool_map_find_failed_tgts_by_rank(struct pool_map *map,
 				  struct pool_target ***tgt_ppp,
 				  unsigned int *tgt_cnt, d_rank_t rank);
-bool
-pool_map_node_status_match(struct pool_domain *dom, unsigned int status);
 
 struct pool_domain *
 pool_map_find_node_by_rank(struct pool_map *map, uint32_t rank);


### PR DESCRIPTION
During the exclusion or addition process for vos targets if all
vos targets for a given fault domain were marked down then the
parent would also be marked as down. This has been removed to
decouple the status of targets and nodes.

- Removed logic to mark nodes as DOWN or DOWNOUT.
- Removed status match helper function.

Signed-off-by: Peter Fetros <peter.fetros@intel.com>