### PR TITLE
DAOS-4154 build: Set an explicit API version

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -34,6 +34,7 @@ def get_version():
         return version_file.read().rstrip()
 
 DAOS_VERSION = get_version()
+API_VERSION = "0.9.0"
 
 def update_rpm_version(version, tag):
     """ Update the version (and release) in the RPM specfile """
@@ -104,6 +105,7 @@ def set_defaults(env):
     env.Append(CCFLAGS=['-g', '-Wshadow', '-Wall', '-Wno-missing-braces',
                         '-fpic', '-D_GNU_SOURCE', '-DD_LOG_V2'])
     env.Append(CCFLAGS=['-O2', '-DDAOS_VERSION=\\"' + DAOS_VERSION + '\\"'])
+    env.Append(CCFLAGS=['-DAPI_VERSION=\\"' + API_VERSION + '\\"'])
     env.Append(CCFLAGS=['-DCMOCKA_FILTER_SUPPORTED=0'])
     env.Append(CCFLAGS=['-D_FORTIFY_SOURCE=2'])
     env.AppendIfSupported(CCFLAGS=DESIRED_FLAGS)
@@ -340,7 +342,7 @@ def scons():
 
     env.Alias('install', '$PREFIX')
     platform_arm = is_platform_arm()
-    Export('DAOS_VERSION', 'env', 'prereqs', 'platform_arm')
+    Export('DAOS_VERSION', 'env', 'prereqs', 'platform_arm', 'API_VERSION')
 
     if env['PLATFORM'] == 'darwin':
         # generate .so on OSX instead of .dylib

--- a/src/client/api/SConscript
+++ b/src/client/api/SConscript
@@ -3,7 +3,7 @@ import daos_build
 
 def scons():
     """Execute build"""
-    Import('env', 'DAOS_VERSION', 'prereqs')
+    Import('env', 'API_VERSION', 'prereqs')
 
     env.AppendUnique(LIBPATH=[Dir('.')])
     denv = env.Clone()
@@ -17,11 +17,11 @@ def scons():
     dc_tgts += dc_pool_tgts + dc_co_tgts + dc_placement_tgts + dc_obj_tgts
     dc_tgts += dc_mgmt_tgts + dc_array_tgts + dc_kv_tgts + dc_security_tgts
     libdaos = daos_build.library(env, 'daos', dc_tgts,
-                                 SHLIBVERSION=DAOS_VERSION,
+                                 SHLIBVERSION=API_VERSION,
                                  LIBS=['daos_common'])
     if hasattr(env, 'InstallVersionedLib'):
         env.InstallVersionedLib('$PREFIX/lib64/', libdaos,
-                                SHLIBVERSION=DAOS_VERSION)
+                                SHLIBVERSION=API_VERSION)
     else:
         env.Install('$PREFIX/lib64/', libdaos)
 


### PR DESCRIPTION
Set the libdaos.so SOVERSION to the API_VERSION, not DAOS_VERSION.

Signed-off-by: Brian J. Murrell <brian.murrell@intel.com>