### PR TITLE
DAOS-4102 object: segfault in dtx_leader_end()

### DIFF
--- a/src/dtx/dtx_common.c
+++ b/src/dtx/dtx_common.c
@@ -525,15 +525,16 @@ int
 dtx_leader_end(struct dtx_leader_handle *dlh, struct ds_cont_child *cont,
 	       int result)
 {
-	struct dtx_handle		*dth = &dlh->dlh_handle;
+	struct dtx_handle		*dth;
 	struct dtx_conflict_entry	*dces = NULL;
 	int				*ptr = NULL;
 	int				 dces_cnt = 0;
 	int				 flags = 0;
 	int				 rc = 0;
 
-	if (dlh == NULL)
-		return result;
+	D_ASSERT(dlh != NULL);
+	dth = &dlh->dlh_handle;
+	D_ASSERT(dth != NULL);
 
 	if (dlh->dlh_sub_cnt == 0) {
 		if (daos_is_zero_dti(&dth->dth_xid))

--- a/src/object/srv_obj.c
+++ b/src/object/srv_obj.c
@@ -1456,7 +1456,7 @@ again:
 	exec_arg.flags	  = flags;
 	/* Execute the operation on all targets */
 	rc = dtx_leader_exec_ops(&dlh, obj_tgt_update, &exec_arg);
-out:
+
 	if (opc == DAOS_OBJ_RPC_UPDATE &&
 	    DAOS_FAIL_CHECK(DAOS_DTX_LEADER_ERROR))
 		rc = -DER_IO;
@@ -1475,7 +1475,7 @@ out:
 		flags |= ORF_RESEND;
 		D_GOTO(again, rc);
 	}
-
+out:
 	if (opc == DAOS_OBJ_RPC_UPDATE && !(orw->orw_flags & ORF_RESEND) &&
 	    DAOS_FAIL_CHECK(DAOS_DTX_LOST_RPC_REPLY))
 		goto cleanup;
@@ -2075,7 +2075,7 @@ again:
 	exec_arg.flags = flags;
 	/* Execute the operation on all shards */
 	rc = dtx_leader_exec_ops(&dlh, obj_tgt_punch, &exec_arg);
-out:
+
 	if (DAOS_FAIL_CHECK(DAOS_DTX_LEADER_ERROR))
 		rc = -DER_IO;
 
@@ -2093,7 +2093,7 @@ out:
 		flags |= ORF_RESEND;
 		D_GOTO(again, rc);
 	}
-
+out:
 	if (!(opi->opi_flags & ORF_RESEND) &&
 	    DAOS_FAIL_CHECK(DAOS_DTX_LOST_RPC_REPLY))
 		goto cleanup;


### PR DESCRIPTION
Improper error handling in object rw & punch handler could lead
to accessing NULL pointer in dtx_leader_end().

Signed-off-by: Niu Yawei <yawei.niu@intel.com>