### PR TITLE
DAOS-4185 control: Handle large pbin payloads

### DIFF
--- a/src/control/cmd/daos_admin/handler.go
+++ b/src/control/cmd/daos_admin/handler.go
@@ -66,16 +66,14 @@ func sendSuccess(payloadSrc interface{}, res *pbin.Response, dest io.Writer) err
 	return err
 }
 
-func readRequest(log logging.Logger, rdr io.Reader) (*pbin.Request, error) {
-	buf := make([]byte, pbin.MaxMessageSize)
-
-	readLen, err := rdr.Read(buf)
+func readRequest(rdr io.Reader) (*pbin.Request, error) {
+	buf, err := pbin.ReadMessage(rdr)
 	if err != nil {
 		return nil, err
 	}
 
 	var req pbin.Request
-	if err := json.Unmarshal(buf[:readLen], &req); err != nil {
+	if err := json.Unmarshal(buf, &req); err != nil {
 		return nil, err
 	}
 

--- a/src/control/cmd/daos_admin/main.go
+++ b/src/control/cmd/daos_admin/main.go
@@ -109,7 +109,7 @@ func main() {
 		sendFailureAndExit(log, errors.Wrap(err, "unable to setuid(0)"), conn)
 	}
 
-	req, err := readRequest(log, conn)
+	req, err := readRequest(conn)
 	if err != nil {
 		exitWithError(log, err)
 	}

--- a/src/control/pbin/exec.go
+++ b/src/control/pbin/exec.go
@@ -36,7 +36,15 @@ import (
 	"github.com/daos-stack/daos/src/control/logging"
 )
 
-const MaxMessageSize = 4096
+const (
+	// MessageBufferSize is the starting size of the receive buffer. If
+	// the buffer must be grown to accommodate larger messages, it is
+	// expanded in increments of this value.
+	MessageBufferSize = 1024
+	// MaxMessageSize is the largest single message that can be written to
+	// or read from the privileged binary.
+	MaxMessageSize = MessageBufferSize * 1024
+)
 
 type (
 	// Request represents a request sent to the privileged binary. The
@@ -100,6 +108,36 @@ func decodeResponse(resBuf []byte) (*Response, error) {
 	return nil, errors.Wrapf(err, "pbin failed to decode response data(%q)", resBuf)
 }
 
+// ReadMessage attempts to read a message from the sender and
+// returns a buffer containing the message if successful. Relies
+// on the writer being closed so that the reader gets an io.EOF
+// to signal that the message is complete.
+func ReadMessage(conn io.Reader) ([]byte, error) {
+	readBuf := make([]byte, MessageBufferSize)
+
+	startIdx := 0
+	for {
+		readLen, err := conn.Read(readBuf[startIdx:])
+		startIdx += readLen
+		if err != nil {
+			if err == io.EOF && startIdx > 0 {
+				break
+			}
+			return nil, err
+		}
+
+		if len(readBuf)+MessageBufferSize > MaxMessageSize {
+			return nil, errors.New("max message size exceeded in ReadMessage()")
+		}
+
+		readBuf = append(readBuf, make([]byte, MessageBufferSize)...)
+	}
+
+	return readBuf[:startIdx], nil
+}
+
+// ExecReq executes the supplied Request by starting a child process
+// to service the request. Returns a Response if successful.
 func ExecReq(parent context.Context, log logging.Logger, binPath string, req *Request) (res *Response, err error) {
 	if req == nil {
 		return nil, errors.New("nil request")
@@ -150,25 +188,29 @@ func ExecReq(parent context.Context, log logging.Logger, binPath string, req *Re
 	if _, err := conn.Write(sendData); err != nil {
 		return nil, errors.Wrap(err, "pbin write failed")
 	}
+	// Signal to the receiver that we're finished.
+	if err := conn.CloseWrite(); err != nil {
+		return nil, errors.Wrap(err, "pbin CloseWrite failed")
+	}
 
-	maxReadAttempts := 5
 	readCount := 0
+	maxReadAttempts := 5
 	for {
-		recvData := make([]byte, MaxMessageSize)
-		recvLen, err := conn.Read(recvData)
+		recvData, err := ReadMessage(conn)
 		if err != nil {
-			return nil, errors.Wrap(err, "pbin read failed")
+			return nil, errors.Wrap(err, "failed to read message from sender")
 		}
 
-		res, err = decodeResponse(recvData[:recvLen])
+		res, err = decodeResponse(recvData)
 		if err != nil && err != io.EOF {
-			log.Debugf("discarding garbage response %q", recvData[:recvLen])
-			readCount++
+			log.Debugf("discarding garbage response %q", recvData)
 			if readCount < maxReadAttempts {
+				readCount++
 				continue
 			}
 			return nil, err
 		}
+
 		if res.Error != nil {
 			return nil, res.Error
 		}

--- a/src/control/pbin/exec_test.go
+++ b/src/control/pbin/exec_test.go
@@ -1,5 +1,5 @@
 //
-// (C) Copyright 2019 Intel Corporation.
+// (C) Copyright 2019-2020 Intel Corporation.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -26,6 +26,8 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"fmt"
+	"io/ioutil"
 	"os"
 	"testing"
 
@@ -38,35 +40,78 @@ import (
 
 func reqRes() {
 	conn := pbin.NewStdioConn("child", "parent", os.Stdin, os.Stdout)
-	readBuf := make([]byte, pbin.MaxMessageSize)
 
-	readLen, err := conn.Read(readBuf)
+	readBuf, err := pbin.ReadMessage(conn)
 	if err != nil {
 		childErrExit(err)
 	}
 
 	var req pbin.Request
-	err = json.Unmarshal(readBuf[:readLen], &req)
-	if err != nil {
+	if err = json.Unmarshal(readBuf, &req); err != nil {
 		childErrExit(err)
 	}
 
-	res := pbin.Response{
-		Payload: req.Payload,
+	var writeBuf []byte
+	switch req.Method {
+	case "garbage":
+		writeBuf = []byte(`junk`)
+	case "oversize":
+		writeBuf = generatePayload(pbin.MaxMessageSize + 1)
+	default:
+		res := pbin.Response{
+			Payload: req.Payload,
+		}
+
+		writeBuf, err = json.Marshal(&res)
+		if err != nil {
+			childErrExit(err)
+		}
 	}
 
-	writeBuf, err := json.Marshal(&res)
-	if err != nil {
+	if _, err = conn.Write(writeBuf); err != nil {
 		childErrExit(err)
 	}
 
-	_, err = conn.Write(writeBuf)
-	if err != nil {
+	if err = conn.CloseWrite(); err != nil {
 		childErrExit(err)
 	}
 }
 
-func TestPbinExec(t *testing.T) {
+func generatePayload(size int) []byte {
+	var buf bytes.Buffer
+	buf.WriteString(`{"reply":"`)
+	post := `"}`
+	adjSize := size - len(post)
+
+	for buf.Len() < adjSize {
+		buf.WriteString("0123456789abcdefghijklmnopqrstuvxyz")
+	}
+
+	ret := buf.Bytes()
+	if len(ret) > adjSize {
+		ret = ret[:len(ret)-(len(ret)-(adjSize))]
+	}
+	ret = append(ret[:adjSize], []byte(post)...)
+
+	return ret
+}
+
+func loadJSONPayload(t *testing.T, name string) []byte {
+	loadBuf, err := ioutil.ReadFile(fmt.Sprintf("testdata/%s.json", name))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// make sure that the expected payload is formatted the
+	// same as the test payload
+	var outBuf bytes.Buffer
+	if err := json.Compact(&outBuf, loadBuf); err != nil {
+		t.Fatal(err)
+	}
+	return outBuf.Bytes()
+}
+
+func TestPbin_Exec(t *testing.T) {
 	for name, tc := range map[string]struct {
 		req     *pbin.Request
 		binPath string
@@ -78,6 +123,36 @@ func TestPbinExec(t *testing.T) {
 				Payload: []byte(`{"reply":"pong"}`),
 			},
 			binPath: os.Args[0],
+		},
+		"giant payload": {
+			req: &pbin.Request{
+				Method:  "ping",
+				Payload: generatePayload((pbin.MessageBufferSize * 512) + 1),
+			},
+			binPath: os.Args[0],
+		},
+		"DAOS-4185 scan payload": {
+			req: &pbin.Request{
+				Method:  "scan",
+				Payload: loadJSONPayload(t, "boro-84-storage_scan"),
+			},
+			binPath: os.Args[0],
+		},
+		"oversize response payload": {
+			req: &pbin.Request{
+				Method:  "oversize",
+				Payload: []byte(`{"reply":"pong"}`),
+			},
+			binPath: os.Args[0],
+			expErr:  errors.New("size exceeded"),
+		},
+		"garbage response": {
+			req: &pbin.Request{
+				Method:  "garbage",
+				Payload: []byte(`{"reply":"garbage"}`),
+			},
+			binPath: os.Args[0],
+			expErr:  errors.New("EOF"),
 		},
 		"malformed payload (shouldn't hang)": {
 			req: &pbin.Request{

--- a/src/control/pbin/testdata/boro-84-storage_scan.json
+++ b/src/control/pbin/testdata/boro-84-storage_scan.json
@@ -1,0 +1,297 @@
+{
+    "Error": null,
+    "Payload": {
+        "Controllers": [
+            {
+                "Model": "INTEL SSDPE2KE016T8 ",
+                "Serial": "BTLN836301H11P6AGN  ",
+                "PciAddr": "0000:5e:00.0",
+                "FwRev": "VDV10170",
+                "SocketID": 0,
+                "HealthStats": {
+                    "Temp": 318,
+                    "TempWarnTime": 0,
+                    "TempCritTime": 0,
+                    "CtrlBusyTime": 188,
+                    "PowerCycles": 54,
+                    "PowerOnHours": 9056,
+                    "UnsafeShutdowns": 51,
+                    "MediaErrors": 0,
+                    "ErrorLogEntries": 0,
+                    "TempWarn": false,
+                    "AvailSpareWarn": false,
+                    "ReliabilityWarn": false,
+                    "ReadOnlyWarn": false,
+                    "VolatileWarn": false
+                },
+                "Namespaces": [
+                    {
+                        "ID": 1,
+                        "Size": 1600321314816
+                    }
+                ]
+            },
+            {
+                "Model": "INTEL SSDPE2KE016T8 ",
+                "Serial": "BTLN834500BC1P6AGN  ",
+                "PciAddr": "0000:8a:00.0",
+                "FwRev": "VDV10170",
+                "SocketID": 1,
+                "HealthStats": {
+                    "Temp": 319,
+                    "TempWarnTime": 0,
+                    "TempCritTime": 0,
+                    "CtrlBusyTime": 140,
+                    "PowerCycles": 54,
+                    "PowerOnHours": 9056,
+                    "UnsafeShutdowns": 51,
+                    "MediaErrors": 0,
+                    "ErrorLogEntries": 0,
+                    "TempWarn": false,
+                    "AvailSpareWarn": false,
+                    "ReliabilityWarn": false,
+                    "ReadOnlyWarn": false,
+                    "VolatileWarn": false
+                },
+                "Namespaces": [
+                    {
+                        "ID": 1,
+                        "Size": 1600321314816
+                    }
+                ]
+            },
+            {
+                "Model": "INTEL SSDPE2KE016T8 ",
+                "Serial": "BTLN841601AR1P6AGN  ",
+                "PciAddr": "0000:8b:00.0",
+                "FwRev": "VDV10170",
+                "SocketID": 1,
+                "HealthStats": {
+                    "Temp": 317,
+                    "TempWarnTime": 0,
+                    "TempCritTime": 0,
+                    "CtrlBusyTime": 143,
+                    "PowerCycles": 54,
+                    "PowerOnHours": 9056,
+                    "UnsafeShutdowns": 51,
+                    "MediaErrors": 0,
+                    "ErrorLogEntries": 0,
+                    "TempWarn": false,
+                    "AvailSpareWarn": false,
+                    "ReliabilityWarn": false,
+                    "ReadOnlyWarn": false,
+                    "VolatileWarn": false
+                },
+                "Namespaces": [
+                    {
+                        "ID": 1,
+                        "Size": 1600321314816
+                    }
+                ]
+            },
+            {
+                "Model": "INTEL SSDPE2KE016T8 ",
+                "Serial": "BTLN836301F81P6AGN  ",
+                "PciAddr": "0000:8c:00.0",
+                "FwRev": "VDV10170",
+                "SocketID": 1,
+                "HealthStats": {
+                    "Temp": 316,
+                    "TempWarnTime": 0,
+                    "TempCritTime": 0,
+                    "CtrlBusyTime": 68,
+                    "PowerCycles": 54,
+                    "PowerOnHours": 9056,
+                    "UnsafeShutdowns": 51,
+                    "MediaErrors": 0,
+                    "ErrorLogEntries": 0,
+                    "TempWarn": false,
+                    "AvailSpareWarn": false,
+                    "ReliabilityWarn": false,
+                    "ReadOnlyWarn": false,
+                    "VolatileWarn": false
+                },
+                "Namespaces": [
+                    {
+                        "ID": 1,
+                        "Size": 1600321314816
+                    }
+                ]
+            },
+            {
+                "Model": "INTEL SSDPE2KE016T8 ",
+                "Serial": "BTLN841601AV1P6AGN  ",
+                "PciAddr": "0000:8d:00.0",
+                "FwRev": "VDV10170",
+                "SocketID": 1,
+                "HealthStats": {
+                    "Temp": 315,
+                    "TempWarnTime": 0,
+                    "TempCritTime": 0,
+                    "CtrlBusyTime": 67,
+                    "PowerCycles": 54,
+                    "PowerOnHours": 9056,
+                    "UnsafeShutdowns": 51,
+                    "MediaErrors": 0,
+                    "ErrorLogEntries": 0,
+                    "TempWarn": false,
+                    "AvailSpareWarn": false,
+                    "ReliabilityWarn": false,
+                    "ReadOnlyWarn": false,
+                    "VolatileWarn": false
+                },
+                "Namespaces": [
+                    {
+                        "ID": 1,
+                        "Size": 1600321314816
+                    }
+                ]
+            },
+            {
+                "Model": "INTEL SSDPE2KE016T8 ",
+                "Serial": "BTLN836301MA1P6AGN  ",
+                "PciAddr": "0000:8e:00.0",
+                "FwRev": "VDV10170",
+                "SocketID": 1,
+                "HealthStats": {
+                    "Temp": 313,
+                    "TempWarnTime": 0,
+                    "TempCritTime": 0,
+                    "CtrlBusyTime": 67,
+                    "PowerCycles": 54,
+                    "PowerOnHours": 9056,
+                    "UnsafeShutdowns": 51,
+                    "MediaErrors": 0,
+                    "ErrorLogEntries": 0,
+                    "TempWarn": false,
+                    "AvailSpareWarn": false,
+                    "ReliabilityWarn": false,
+                    "ReadOnlyWarn": false,
+                    "VolatileWarn": false
+                },
+                "Namespaces": [
+                    {
+                        "ID": 1,
+                        "Size": 1600321314816
+                    }
+                ]
+            },
+            {
+                "Model": "INTEL SSDPE2KE016T8 ",
+                "Serial": "BTLN841601AK1P6AGN  ",
+                "PciAddr": "0000:8f:00.0",
+                "FwRev": "VDV10170",
+                "SocketID": 1,
+                "HealthStats": {
+                    "Temp": 312,
+                    "TempWarnTime": 0,
+                    "TempCritTime": 0,
+                    "CtrlBusyTime": 85,
+                    "PowerCycles": 54,
+                    "PowerOnHours": 9056,
+                    "UnsafeShutdowns": 49,
+                    "MediaErrors": 0,
+                    "ErrorLogEntries": 0,
+                    "TempWarn": false,
+                    "AvailSpareWarn": false,
+                    "ReliabilityWarn": false,
+                    "ReadOnlyWarn": false,
+                    "VolatileWarn": false
+                },
+                "Namespaces": [
+                    {
+                        "ID": 1,
+                        "Size": 1600321314816
+                    }
+                ]
+            },
+            {
+                "Model": "INTEL SSDPE2KE016T8 ",
+                "Serial": "BTLN834500BP1P6AGN  ",
+                "PciAddr": "0000:5f:00.0",
+                "FwRev": "VDV10170",
+                "SocketID": 0,
+                "HealthStats": {
+                    "Temp": 320,
+                    "TempWarnTime": 384,
+                    "TempCritTime": 0,
+                    "CtrlBusyTime": 149,
+                    "PowerCycles": 54,
+                    "PowerOnHours": 9056,
+                    "UnsafeShutdowns": 51,
+                    "MediaErrors": 0,
+                    "ErrorLogEntries": 0,
+                    "TempWarn": false,
+                    "AvailSpareWarn": false,
+                    "ReliabilityWarn": false,
+                    "ReadOnlyWarn": false,
+                    "VolatileWarn": false
+                },
+                "Namespaces": [
+                    {
+                        "ID": 1,
+                        "Size": 1600321314816
+                    }
+                ]
+            },
+            {
+                "Model": "INTEL SSDPED1K750GA ",
+                "Serial": "PHKS7505009A750BGN  ",
+                "PciAddr": "0000:da:00.0",
+                "FwRev": "E2010435",
+                "SocketID": 1,
+                "HealthStats": {
+                    "Temp": 309,
+                    "TempWarnTime": 0,
+                    "TempCritTime": 0,
+                    "CtrlBusyTime": 0,
+                    "PowerCycles": 35,
+                    "PowerOnHours": 5196,
+                    "UnsafeShutdowns": 25,
+                    "MediaErrors": 0,
+                    "ErrorLogEntries": 0,
+                    "TempWarn": false,
+                    "AvailSpareWarn": false,
+                    "ReliabilityWarn": false,
+                    "ReadOnlyWarn": false,
+                    "VolatileWarn": false
+                },
+                "Namespaces": [
+                    {
+                        "ID": 1,
+                        "Size": 750156374016
+                    }
+                ]
+            },
+            {
+                "Model": "INTEL SSDPED1K750GA ",
+                "Serial": "PHKS750500GU750BGN  ",
+                "PciAddr": "0000:81:00.0",
+                "FwRev": "E2010435",
+                "SocketID": 1,
+                "HealthStats": {
+                    "Temp": 309,
+                    "TempWarnTime": 0,
+                    "TempCritTime": 0,
+                    "CtrlBusyTime": 0,
+                    "PowerCycles": 35,
+                    "PowerOnHours": 5196,
+                    "UnsafeShutdowns": 29,
+                    "MediaErrors": 0,
+                    "ErrorLogEntries": 0,
+                    "TempWarn": false,
+                    "AvailSpareWarn": false,
+                    "ReliabilityWarn": false,
+                    "ReadOnlyWarn": false,
+                    "VolatileWarn": false
+                },
+                "Namespaces": [
+                    {
+                        "ID": 1,
+                        "Size": 750156374016
+                    }
+                ]
+            }
+        ]
+    }
+}


### PR DESCRIPTION
Adds pbin.ReadMessage() to handle payloads up to 1MiB in
size.