### PR TITLE
DAOS-4188 control: no error on nvme format skip

### DIFF
--- a/src/control/fault/code/codes.go
+++ b/src/control/fault/code/codes.go
@@ -81,7 +81,6 @@ const (
 	ServerConfigNoServers
 	ServerScmUnmanaged
 	ServerBdevNotFound
-	ServerBdevFormatSkipped
 	ServerConfigDuplicateFabric
 	ServerConfigDuplicateLogFile
 	ServerConfigDuplicateScmMount

--- a/src/control/server/ctl_storage_rpc_test.go
+++ b/src/control/server/ctl_storage_rpc_test.go
@@ -25,6 +25,7 @@ package server
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -507,9 +508,8 @@ func TestStorageFormat(t *testing.T) {
 						{
 							Pciaddr: "<nil>",
 							State: &ResponseState{
-								Status: ResponseStatus_CTL_ERR_NVME,
-								Error:  FaultBdevFormatSkipped(0).Error(),
-								Info:   FaultBdevFormatSkipped(0).Resolution,
+								Status: ResponseStatus_CTL_SUCCESS,
+								Info:   fmt.Sprintf(msgNvmeFormatSkip, 0),
 							},
 						},
 					},
@@ -571,9 +571,8 @@ func TestStorageFormat(t *testing.T) {
 						{
 							Pciaddr: "<nil>",
 							State: &ResponseState{
-								Status: ResponseStatus_CTL_ERR_NVME,
-								Error:  FaultBdevFormatSkipped(0).Error(),
-								Info:   FaultBdevFormatSkipped(0).Resolution,
+								Status: ResponseStatus_CTL_SUCCESS,
+								Info:   fmt.Sprintf(msgNvmeFormatSkip, 0),
 							},
 						},
 					},

--- a/src/control/server/faults.go
+++ b/src/control/server/faults.go
@@ -87,14 +87,6 @@ func FaultBdevNotFound(bdevs []string) *fault.Fault {
 	)
 }
 
-func FaultBdevFormatSkipped(instanceIdx uint32) *fault.Fault {
-	return serverFault(
-		code.ServerBdevFormatSkipped,
-		fmt.Sprintf("NVMe format skipped on instance %d as SCM format did not complete", instanceIdx),
-		fmt.Sprintf("resolve SCM formatting issues on instance %d", instanceIdx),
-	)
-}
-
 func FaultConfigDuplicateFabric(curIdx, seenIdx int) *fault.Fault {
 	return serverFault(
 		code.ServerConfigDuplicateFabric,

--- a/src/control/server/server.go
+++ b/src/control/server/server.go
@@ -104,9 +104,8 @@ func Start(log *logging.LeveledLogger, cfg *Configuration) error {
 	}
 
 	if !cfgHasBdev(cfg) {
-		// If there are no bdevs in the config, don't waste memory on configuring
-		// hugepages (1 is minimum to avoid default).
-		cfg.NrHugepages = 1
+		// If there are no bdevs in the config, use a minimal amount of hugepages.
+		cfg.NrHugepages = 128
 	}
 
 	// Perform an automatic prepare based on the values in the config file.


### PR DESCRIPTION
Remove error being printed to standard out when SCM format cannot
complete and NVMe format is skipped. Also increase hugepage
allocation when no devices are specified in config so that scan can
be performed without error.

Signed-off-by: Tom Nabarro <tom.nabarro@intel.com>