### PR TITLE
DAOS-4190 tests: Fixing daos log clean and archive

### DIFF
--- a/src/tests/ftest/launch.py
+++ b/src/tests/ftest/launch.py
@@ -166,6 +166,7 @@ def set_test_environment(args):
                 # before ib1
                 if speed not in available_interfaces:
                     available_interfaces[speed] = device
+        print("Available interfaces: {}".format(available_interfaces))
         try:
             # Select the fastest active interface available by sorting the speed
             interface = available_interfaces[sorted(available_interfaces)[-1]]
@@ -174,9 +175,7 @@ def set_test_environment(args):
                 "Error obtaining a default interface from: {}".format(
                     os.listdir(net_path)))
             exit(1)
-    print(
-        "Using {} as the default interface from {}".format(
-            interface, available_interfaces))
+    print("Using {} as the default interface".format(interface))
 
     # Update env definitions
     os.environ["PATH"] = ":".join([bin_dir, sbin_dir, usr_sbin, path])
@@ -798,7 +797,6 @@ def find_yaml_hosts(test_yaml):
 
     """
     return find_values(
-        None,
         get_yaml_data(test_yaml),
         [YAML_KEYS["test_servers"], YAML_KEYS["test_clients"]])
 


### PR DESCRIPTION
Fixing a bug introduced by PR-1884 where the cleanup and archiving of
log files does not include the test_servers and test_clients hosts.

Also resolved a rasing of an exception when running manually with
OFI_INTERFACE set.

Signed-off-by: Phillip Henderson <phillip.henderson@intel.com>