### PR TITLE
DAOS-3610 control: Add `dmg pool list` command alias

### DIFF
--- a/src/control/cmd/dmg/pool.go
+++ b/src/control/cmd/dmg/pool.go
@@ -37,15 +37,14 @@ import (
 )
 
 const (
-	msgSizeNoNumber = "size string doesn't specify a number"
-	msgSizeZeroScm  = "non-zero scm size is required"
-	maxNumSvcReps   = 13
+	maxNumSvcReps = 13
 )
 
 // PoolCmd is the struct representing the top-level pool subcommand.
 type PoolCmd struct {
 	Create       PoolCreateCmd       `command:"create" alias:"c" description:"Create a DAOS pool"`
 	Destroy      PoolDestroyCmd      `command:"destroy" alias:"d" description:"Destroy a DAOS pool"`
+	List         systemListPoolsCmd  `command:"list" alias:"l" description:"List DAOS pools"`
 	Query        PoolQueryCmd        `command:"query" alias:"q" description:"Query a DAOS pool"`
 	GetACL       PoolGetACLCmd       `command:"get-acl" alias:"ga" description:"Get a DAOS pool's Access Control List"`
 	OverwriteACL PoolOverwriteACLCmd `command:"overwrite-acl" alias:"oa" description:"Overwrite a DAOS pool's Access Control List"`

--- a/src/control/cmd/dmg/pool_test.go
+++ b/src/control/cmd/dmg/pool_test.go
@@ -101,7 +101,9 @@ func TestPoolCommands(t *testing.T) {
 
 	// Subdirectory with no write perms
 	testNoPermDir := filepath.Join(tmpDir, "badpermsdir")
-	os.Mkdir(testNoPermDir, 0444)
+	if err := os.Mkdir(testNoPermDir, 0444); err != nil {
+		t.Fatal(err)
+	}
 
 	runCmdTests(t, []cmdTest{
 		{
@@ -226,6 +228,12 @@ func TestPoolCommands(t *testing.T) {
 					Force: true,
 				}),
 			}, " "),
+			nil,
+		},
+		{
+			"List pools",
+			"pool list",
+			"ConnectClients ListPools-{daos_server}",
 			nil,
 		},
 		{


### PR DESCRIPTION
Make the pool command group more intuitive by adding the list
subcommand.