### PR TITLE
DAOS-4184 control: Enable strict config parsing

### DIFF
--- a/src/control/client/config.go
+++ b/src/control/client/config.go
@@ -1,5 +1,5 @@
 //
-// (C) Copyright 2019 Intel Corporation.
+// (C) Copyright 2019-2020 Intel Corporation.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -183,7 +183,7 @@ func (c *Configuration) Validate(log logging.Logger) (err error) {
 
 // decodes YAML representation of Configuration struct
 func (c *Configuration) parse(data []byte) error {
-	return yaml.Unmarshal(data, c)
+	return yaml.UnmarshalStrict(data, c)
 }
 
 // NewConfiguration creates a new instance of the Configuration struct

--- a/src/control/server/config.go
+++ b/src/control/server/config.go
@@ -274,11 +274,6 @@ func (c *Configuration) WithHelperLogFile(filePath string) *Configuration {
 	return c
 }
 
-// parse decodes YAML representation of configuration
-func (c *Configuration) parse(data []byte) error {
-	return yaml.Unmarshal(data, c)
-}
-
 // newDefaultConfiguration creates a new instance of configuration struct
 // populated with defaults.
 func newDefaultConfiguration(ext External) *Configuration {
@@ -314,7 +309,7 @@ func (c *Configuration) Load() error {
 		return errors.WithMessage(err, "reading file")
 	}
 
-	if err = c.parse(bytes); err != nil {
+	if err = yaml.UnmarshalStrict(bytes, c); err != nil {
 		return errors.WithMessage(err, "parse failed; config contains invalid "+
 			"parameters and may be out of date, see server config examples")
 	}

--- a/utils/config/daos_server.yml
+++ b/utils/config/daos_server.yml
@@ -62,17 +62,6 @@
 #fault_cb: ./.daos/fd_callback
 #
 #
-## Use specific OFI interfaces
-#
-## Specify either a single fabric interface that will be used by all
-## spawned servers or a comma-seperated list of fabric interfaces to be
-## assigned individually.
-## By default, the DAOS server will auto-detect and use all fabric
-## interfaces if any and fall back to socket on the first eth card
-## otherwise.
-#
-#fabric_ifaces: [qib0,qib1]
-#
 #
 ## Use specific OFI provider
 #
@@ -83,19 +72,6 @@
 #
 #provider: ofi+verbs;ofi_rxm
 #
-#
-## Storage mount directory
-#
-## TODO: If no pre-configured mountpoints are specified, DAOS will auto-detect
-## NVDIMMs, configure them in interleave mode, format with ext4 and
-## mount with the DAX extension creating a subdirectory within scm_mount_path.
-#
-## This option allows to specify a preferred path where the mountpoints will
-## be created. Either the specified directory or its parent must be a mount
-## point.
-#
-## default: /mnt/daos
-#scm_mount_path: /mnt/daosa
 #
 #
 ## NVMe SSD whitelist


### PR DESCRIPTION
Use yaml.UnmarshalStrict() to catch config validation
errors more quickly.