### PR TITLE
DAOS-4167 build: daos-server Requires: daos-client

### DIFF
--- a/utils/rpms/daos.spec
+++ b/utils/rpms/daos.spec
@@ -5,7 +5,7 @@
 
 Name:          daos
 Version:       1.1.0
-Release:       1%{?relval}%{?dist}
+Release:       2%{?relval}%{?dist}
 Summary:       DAOS Storage Engine
 
 License:       Apache
@@ -109,6 +109,7 @@ to optimize performance and cost.
 %package server
 Summary: The DAOS server
 Requires: %{name} = %{version}-%{release}
+Requires: %{name}-client = %{version}-%{release}
 Requires: spdk-tools <= %{spdk_max_version}
 Requires: ndctl
 Requires: ipmctl
@@ -334,6 +335,9 @@ getent group daos_admins >/dev/null || groupadd -r daos_admins
 %{_libdir}/*.a
 
 %changelog
+* Thu Feb 20 2020 Brian J. Murrell <brian.murrell@intel.com> - 1.1.0-2
+- daos-server requires daos-client (same version)
+
 * Fri Feb 14 2020 Brian J. Murrell <brian.murrell@intel.com> - 1.1.0-1
 - Version bump up to 1.1.0
 


### PR DESCRIPTION

The client and server versions need to be tighly bound so that the
server Requires: the client of the same version.

Skip-func-hw-test: true
Signed-off-by: Brian J. Murrell <brian.murrell@intel.com>