### PR TITLE
DAOS-4195 control: Check daos_admin version

### DIFF
--- a/src/control/SConscript
+++ b/src/control/SConscript
@@ -60,8 +60,8 @@ def install_go_bin(denv, gosrc, libs, name, install_name):
             return '0x' + buildid.decode()
     def go_ldflags():
         return ' '.join(['-ldflags',
-                         '"-X main.daosVersion=%s' % DAOS_VERSION,
-                         '-X main.configDir=%s' % CONF_DIR,
+                         '"-X github.com/daos-stack/daos/src/control/build.DaosVersion=%s' % DAOS_VERSION,
+                         '-X github.com/daos-stack/daos/src/control/build.ConfigDir=%s' % CONF_DIR,
                          '-B %s"' % gen_build_id()])
     # Must be run from the top of the source dir in order to
     # pick up the vendored modules.

--- a/src/control/build/variables.go
+++ b/src/control/build/variables.go
@@ -1,0 +1,31 @@
+//
+// (C) Copyright 2020 Intel Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// GOVERNMENT LICENSE RIGHTS-OPEN SOURCE SOFTWARE
+// The Government's rights to use, modify, reproduce, release, perform, display,
+// or disclose this software are subject to the terms of the Apache License as
+// provided in Contract No. 8F-30005.
+// Any reproduction of computer software, computer software documentation, or
+// portions thereof marked with this legend must also reproduce the markings.
+//
+// Package build provides an importable repository of variables set at build time.
+package build
+
+var (
+	// ConfigDir should be set via linker flag using the value of CONF_DIR.
+	ConfigDir string = "./"
+	// DaosVersion should be set via linker flag using the value of DAOS_VERSION.
+	DaosVersion string = "unset"
+)

--- a/src/control/cmd/agent/main.go
+++ b/src/control/cmd/agent/main.go
@@ -35,15 +35,11 @@ import (
 	flags "github.com/jessevdk/go-flags"
 	"github.com/pkg/errors"
 
+	"github.com/daos-stack/daos/src/control/build"
 	"github.com/daos-stack/daos/src/control/client"
 	"github.com/daos-stack/daos/src/control/common"
 	"github.com/daos-stack/daos/src/control/drpc"
 	"github.com/daos-stack/daos/src/control/logging"
-)
-
-var (
-	daosVersion string
-	configDir   string
 )
 
 const (
@@ -66,7 +62,7 @@ type cliOptions struct {
 type versionCmd struct{}
 
 func (cmd *versionCmd) Execute(_ []string) error {
-	fmt.Printf("daos_agent version %s\n", daosVersion)
+	fmt.Printf("daos_agent version %s\n", build.DaosVersion)
 	os.Exit(0)
 	return nil
 }
@@ -132,7 +128,7 @@ func agentMain(log *logging.LeveledLogger, opts *cliOptions) error {
 	defer shutdown()
 
 	if opts.ConfigPath == "" {
-		defaultConfigPath := path.Join(configDir, defaultConfigFile)
+		defaultConfigPath := path.Join(build.ConfigDir, defaultConfigFile)
 		if _, err := os.Stat(defaultConfigPath); err == nil {
 			opts.ConfigPath = defaultConfigPath
 		}

--- a/src/control/cmd/daos_admin/handler.go
+++ b/src/control/cmd/daos_admin/handler.go
@@ -28,6 +28,7 @@ import (
 
 	"github.com/pkg/errors"
 
+	"github.com/daos-stack/daos/src/control/build"
 	"github.com/daos-stack/daos/src/control/fault"
 	"github.com/daos-stack/daos/src/control/logging"
 	"github.com/daos-stack/daos/src/control/pbin"
@@ -88,7 +89,7 @@ func handleRequest(log logging.Logger, scmProvider *scm.Provider, bdevProvider *
 
 	switch req.Method {
 	case "Ping":
-		return sendSuccess(struct{}{}, &res, resDest)
+		return sendSuccess(&pbin.PingResp{Version: build.DaosVersion}, &res, resDest)
 	case "ScmMount", "ScmUnmount":
 		var mReq scm.MountRequest
 		if err := json.Unmarshal(req.Payload, &mReq); err != nil {

--- a/src/control/cmd/daos_admin/main.go
+++ b/src/control/cmd/daos_admin/main.go
@@ -33,14 +33,13 @@ import (
 
 	"github.com/pkg/errors"
 
+	"github.com/daos-stack/daos/src/control/build"
 	"github.com/daos-stack/daos/src/control/common"
 	"github.com/daos-stack/daos/src/control/logging"
 	"github.com/daos-stack/daos/src/control/pbin"
 	"github.com/daos-stack/daos/src/control/server/storage/bdev"
 	"github.com/daos-stack/daos/src/control/server/storage/scm"
 )
-
-var daosVersion string
 
 // exitWithError logs the error to stderr and exits.
 func exitWithError(log logging.Logger, err error) {
@@ -87,7 +86,7 @@ func checkParentName(log logging.Logger) {
 	daosServer := "daos_server"
 	if !strings.HasSuffix(pPath, daosServer) {
 		exitWithError(log, errors.Errorf("%s (version %s) may only be invoked by %s",
-			os.Args[0], daosVersion, daosServer))
+			os.Args[0], build.DaosVersion, daosServer))
 	}
 }
 

--- a/src/control/cmd/daos_server/main.go
+++ b/src/control/cmd/daos_server/main.go
@@ -32,17 +32,13 @@ import (
 	"github.com/jessevdk/go-flags"
 	"github.com/pkg/errors"
 
+	"github.com/daos-stack/daos/src/control/build"
 	"github.com/daos-stack/daos/src/control/common"
 	"github.com/daos-stack/daos/src/control/fault"
 	"github.com/daos-stack/daos/src/control/lib/netdetect"
 	"github.com/daos-stack/daos/src/control/logging"
 	"github.com/daos-stack/daos/src/control/pbin"
 	"github.com/daos-stack/daos/src/control/server"
-)
-
-var (
-	daosVersion string
-	configDir   string
 )
 
 const (
@@ -68,7 +64,7 @@ type mainOpts struct {
 type versionCmd struct{}
 
 func (cmd *versionCmd) Execute(_ []string) error {
-	fmt.Printf("daos_server version %s\n", daosVersion)
+	fmt.Printf("daos_server version %s\n", build.DaosVersion)
 	os.Exit(0)
 	return nil
 }
@@ -115,7 +111,7 @@ func parseOpts(args []string, opts *mainOpts, log *logging.LeveledLogger) error 
 		}
 
 		if opts.ConfigPath == "" {
-			defaultConfigPath := path.Join(configDir, defaultConfigFile)
+			defaultConfigPath := path.Join(build.ConfigDir, defaultConfigFile)
 			if _, err := os.Stat(defaultConfigPath); err == nil {
 				opts.ConfigPath = defaultConfigPath
 			}

--- a/src/control/cmd/dmg/main.go
+++ b/src/control/cmd/dmg/main.go
@@ -31,14 +31,10 @@ import (
 	flags "github.com/jessevdk/go-flags"
 	"github.com/pkg/errors"
 
+	"github.com/daos-stack/daos/src/control/build"
 	"github.com/daos-stack/daos/src/control/client"
 	"github.com/daos-stack/daos/src/control/common"
 	"github.com/daos-stack/daos/src/control/logging"
-)
-
-var (
-	daosVersion string
-	configDir   string
 )
 
 const (
@@ -110,7 +106,7 @@ type cliOptions struct {
 type versionCmd struct{}
 
 func (cmd *versionCmd) Execute(_ []string) error {
-	fmt.Printf("dmg version %s\n", daosVersion)
+	fmt.Printf("dmg version %s\n", build.DaosVersion)
 	os.Exit(0)
 	return nil
 }
@@ -145,7 +141,7 @@ func parseOpts(args []string, opts *cliOptions, conns client.Connect, log *loggi
 		}
 
 		if opts.ConfigPath == "" {
-			defaultConfigPath := path.Join(configDir, defaultConfigFile)
+			defaultConfigPath := path.Join(build.ConfigDir, defaultConfigFile)
 			if _, err := os.Stat(defaultConfigPath); err == nil {
 				opts.ConfigPath = defaultConfigPath
 			}

--- a/src/control/pbin/exec_test.go
+++ b/src/control/pbin/exec_test.go
@@ -62,6 +62,14 @@ func reqRes() {
 			Payload: req.Payload,
 		}
 
+		if req.Method == "Ping" {
+			childVersion := os.Getenv(childVersionEnvVar)
+			res.Payload, err = json.Marshal(pbin.PingResp{Version: childVersion})
+			if err != nil {
+				childErrExit(err)
+			}
+		}
+
 		writeBuf, err = json.Marshal(&res)
 		if err != nil {
 			childErrExit(err)


### PR DESCRIPTION
Expand the verification in pbin.CheckHelper() to include comparing the
returned helper version against the server version.

Also adds a new build package to be an importable repository of variables
set at build time.