### PR TITLE
DAOS-1781 api: check for invalid uuid in DAOS APIs

### DIFF
--- a/src/client/api/container.c
+++ b/src/client/api/container.c
@@ -48,6 +48,9 @@ daos_cont_create(daos_handle_t poh, const uuid_t uuid, daos_prop_t *cont_prop,
 	int			 rc;
 
 	DAOS_API_ARG_ASSERT(*args, CONT_CREATE);
+	if (!daos_uuid_valid(uuid))
+		return -DER_INVAL;
+
 	if (cont_prop != NULL && !daos_prop_valid(cont_prop, false, true)) {
 		D_ERROR("Invalid container properties.\n");
 		return -DER_INVAL;
@@ -74,6 +77,8 @@ daos_cont_open(daos_handle_t poh, const uuid_t uuid, unsigned int flags,
 	int			 rc;
 
 	DAOS_API_ARG_ASSERT(*args, CONT_OPEN);
+	if (!daos_uuid_valid(uuid))
+		return -DER_INVAL;
 
 	rc = dc_task_create(dc_cont_open, NULL, ev, &task);
 	if (rc)
@@ -117,6 +122,8 @@ daos_cont_destroy(daos_handle_t poh, const uuid_t uuid, int force,
 	int			 rc;
 
 	DAOS_API_ARG_ASSERT(*args, CONT_DESTROY);
+	if (!daos_uuid_valid(uuid))
+		return -DER_INVAL;
 
 	rc = dc_task_create(dc_cont_destroy, NULL, ev, &task);
 	if (rc)

--- a/src/client/api/mgmt.c
+++ b/src/client/api/mgmt.c
@@ -119,6 +119,9 @@ daos_pool_destroy(const uuid_t uuid, const char *grp, int force,
 	int			 rc;
 
 	DAOS_API_ARG_ASSERT(*args, POOL_DESTROY);
+	if (!daos_uuid_valid(uuid))
+		return -DER_INVAL;
+
 	rc = dc_task_create(dc_pool_destroy, NULL, ev, &task);
 	if (rc)
 		return rc;
@@ -140,6 +143,9 @@ daos_pool_evict(const uuid_t uuid, const char *grp, const d_rank_list_t *svc,
 	int			 rc;
 
 	DAOS_API_ARG_ASSERT(*args, POOL_EVICT);
+	if (!daos_uuid_valid(uuid))
+		return -DER_INVAL;
+
 	rc = dc_task_create(dc_pool_evict, NULL, ev, &task);
 	if (rc)
 		return rc;
@@ -160,6 +166,9 @@ daos_pool_add_tgt(const uuid_t uuid, const char *grp,
 	daos_pool_update_t	*args;
 	tse_task_t		*task;
 	int			 rc;
+
+	if (!daos_uuid_valid(uuid))
+		return -DER_INVAL;
 
 	rc = dc_task_create(dc_pool_add, NULL, ev, &task);
 	if (rc)
@@ -182,6 +191,9 @@ daos_pool_tgt_exclude_out(const uuid_t uuid, const char *grp,
 	daos_pool_update_t	*args;
 	tse_task_t		*task;
 	int			 rc;
+
+	if (!daos_uuid_valid(uuid))
+		return -DER_INVAL;
 
 	rc = dc_task_create(dc_pool_exclude_out, NULL, ev, &task);
 	if (rc)
@@ -206,6 +218,8 @@ daos_pool_tgt_exclude(const uuid_t uuid, const char *grp,
 	int			 rc;
 
 	DAOS_API_ARG_ASSERT(*args, POOL_EXCLUDE);
+	if (!daos_uuid_valid(uuid))
+		return -DER_INVAL;
 
 	rc = dc_task_create(dc_pool_exclude, NULL, ev, &task);
 	if (rc)
@@ -237,6 +251,8 @@ daos_pool_add_replicas(const uuid_t uuid, const char *group,
 	int			 rc;
 
 	DAOS_API_ARG_ASSERT(*args, POOL_ADD_REPLICAS);
+	if (!daos_uuid_valid(uuid))
+		return -DER_INVAL;
 
 	rc = dc_task_create(dc_pool_add_replicas, NULL, ev, &task);
 	if (rc)
@@ -262,6 +278,8 @@ daos_pool_remove_replicas(const uuid_t uuid, const char *group,
 	int			 rc;
 
 	DAOS_API_ARG_ASSERT(*args, POOL_REMOVE_REPLICAS);
+	if (!daos_uuid_valid(uuid))
+		return -DER_INVAL;
 
 	rc = dc_task_create(dc_pool_remove_replicas, NULL, ev, &task);
 	if (rc)

--- a/src/client/pydaos/raw/daos_api.py
+++ b/src/client/pydaos/raw/daos_api.py
@@ -1514,13 +1514,12 @@ class DaosContainer(object):
             else:
                 ret = func(self.poh, self.uuid, ctypes.byref(self.cont_prop),
                            None)
-                if ret != 0:
-                    self.uuid = (ctypes.c_ubyte * 1)(0)
-                    raise DaosApiError(
-                        "Container create returned non-zero. RC: {0}".format(
-                            ret))
-                else:
-                    self.attached = 1
+            if ret != 0:
+                self.uuid = (ctypes.c_ubyte * 1)(0)
+                raise DaosApiError(
+                    "Container create returned non-zero. RC: {0}".format(ret))
+            else:
+                self.attached = 1
         else:
             event = daos_cref.DaosEvent()
             if self.cont_prop is None:

--- a/src/tests/ftest/container/create.py
+++ b/src/tests/ftest/container/create.py
@@ -56,7 +56,6 @@ class CreateContainerTest(TestWithServers):
         if handleparam == 'VALID':
             poh = self.pool.pool.handle
         else:
-            self.cancel("skipping this test case until DAOS-4099 is fixed")
             poh = handleparam
             expected_results.append('FAIL')
 
@@ -64,11 +63,7 @@ class CreateContainerTest(TestWithServers):
         uuidparam = self.params.get("uuid", "/uuids/*")
         expected_results.append(uuidparam[1])
         if uuidparam[0] == 'NULLPTR':
-            self.cancel("skipping this test until DAOS-2043 is fixed")
-            # Commenting the line below as it will result in an
-            # AttributeError and never get to the DAOS API code.
-            # Should be further investigated as part of DAOS-3081
-            # contuuid = 'NULLPTR'
+            contuuid = 'NULLPTR'
         else:
             contuuid = uuid.UUID(uuidparam[0])
 


### PR DESCRIPTION
Several DAOS APIs accept a uuid_t parameter and perform a uuid_copy
involving that argument. A validity check is added on the argument
to protect against a segmentation fault that can occur in uuid_copy
if the argument is a NULL pointer.

A container create functional test is updated to no longer skip
negative test cases that supply a NULL pointer as the uuid
argument to container create.

Test-tag: pr,-hw containercreate

Signed-off-by: Ken Cain <kenneth.c.cain@intel.com>