### PR TITLE
DAOS-4181 sec: Add access capabilities for pools/conts

### DIFF
--- a/src/container/srv_container.c
+++ b/src/container/srv_container.c
@@ -548,8 +548,8 @@ cont_create(struct rdb_tx *tx, struct ds_pool_hdl *pool_hdl,
 		DP_CONT(pool_hdl->sph_pool->sp_uuid, in->cci_op.ci_uuid), rpc);
 
 	/* Verify the pool handle capabilities. */
-	if (!(pool_hdl->sph_capas & DAOS_PC_RW) &&
-	    !(pool_hdl->sph_capas & DAOS_PC_EX))
+	if (!(pool_hdl->sph_flags & DAOS_PC_RW) &&
+	    !(pool_hdl->sph_flags & DAOS_PC_EX))
 		D_GOTO(out, rc = -DER_NO_PERM);
 
 	/* Check if a container with this UUID already exists. */
@@ -688,8 +688,8 @@ cont_destroy(struct rdb_tx *tx, struct ds_pool_hdl *pool_hdl,
 		in->cdi_force);
 
 	/* Verify the pool handle capabilities. */
-	if (!(pool_hdl->sph_capas & DAOS_PC_RW) &&
-	    !(pool_hdl->sph_capas & DAOS_PC_EX))
+	if (!(pool_hdl->sph_flags & DAOS_PC_RW) &&
+	    !(pool_hdl->sph_flags & DAOS_PC_EX))
 		D_GOTO(out, rc = -DER_NO_PERM);
 
 	/* Check if the container attribute KVS exists. */
@@ -829,8 +829,8 @@ cont_open(struct rdb_tx *tx, struct ds_pool_hdl *pool_hdl, struct cont *cont,
 
 	/* Verify the pool handle capabilities. */
 	if ((in->coi_capas & DAOS_COO_RW) &&
-	    !(pool_hdl->sph_capas & DAOS_PC_RW) &&
-	    !(pool_hdl->sph_capas & DAOS_PC_EX))
+	    !(pool_hdl->sph_flags & DAOS_PC_RW) &&
+	    !(pool_hdl->sph_flags & DAOS_PC_EX))
 		D_GOTO(out, rc = -DER_NO_PERM);
 
 	/* See if this container handle already exists. */

--- a/src/include/daos_cont.h
+++ b/src/include/daos_cont.h
@@ -53,6 +53,9 @@ extern "C" {
 #define DAOS_COO_NOSLIP	(1U << 2)
 #define DAOS_COO_FORCE	(1U << 3)
 
+#define DAOS_COO_NBITS	(4)
+#define DAOS_COO_MASK	((1U << DAOS_COO_NBITS) - 1)
+
 /** Container information */
 typedef struct {
 	/** Container UUID */

--- a/src/include/daos_srv/pool.h
+++ b/src/include/daos_srv/pool.h
@@ -69,7 +69,8 @@ void ds_pool_put(struct ds_pool *pool);
 struct ds_pool_hdl {
 	d_list_t		sph_entry;
 	uuid_t			sph_uuid;	/* of the pool handle */
-	uint64_t		sph_capas;
+	uint64_t		sph_flags;	/* user-provided flags */
+	uint64_t		sph_sec_capas;	/* access capabilities */
 	struct ds_pool	       *sph_pool;
 	int			sph_ref;
 };

--- a/src/pool/cli.c
+++ b/src/pool/cli.c
@@ -549,7 +549,7 @@ dc_pool_connect(tse_task_t *task)
 
 	uuid_copy(pci->pci_op.pi_uuid, args->uuid);
 	uuid_copy(pci->pci_op.pi_hdl, pool->dp_pool_hdl);
-	pci->pci_capas = args->flags;
+	pci->pci_flags = args->flags;
 	pci->pci_query_bits = pool_query_bits(args->info, NULL);
 
 	rc = map_bulk_create(daos_task2ctx(task), &pci->pci_map_bulk, &map_buf,

--- a/src/pool/rpc.h
+++ b/src/pool/rpc.h
@@ -167,7 +167,7 @@ CRT_RPC_DECLARE(pool_create, DAOS_ISEQ_POOL_CREATE, DAOS_OSEQ_POOL_CREATE)
 #define DAOS_ISEQ_POOL_CONNECT	/* input fields */		 \
 	((struct pool_op_in)	(pci_op)		CRT_VAR) \
 	((d_iov_t)		(pci_cred)		CRT_VAR) \
-	((uint64_t)		(pci_capas)		CRT_VAR) \
+	((uint64_t)		(pci_flags)		CRT_VAR) \
 	((uint64_t)		(pci_query_bits)	CRT_VAR) \
 	((crt_bulk_t)		(pci_map_bulk)		CRT_VAR)
 
@@ -297,7 +297,8 @@ CRT_RPC_DECLARE(pool_svc_stop, DAOS_ISEQ_POOL_SVC_STOP, DAOS_OSEQ_POOL_SVC_STOP)
 #define DAOS_ISEQ_POOL_TGT_CONNECT /* input fields */		 \
 	((uuid_t)		(tci_uuid)		CRT_VAR) \
 	((uuid_t)		(tci_hdl)		CRT_VAR) \
-	((uint64_t)		(tci_capas)		CRT_VAR) \
+	((uint64_t)		(tci_flags)		CRT_VAR) \
+	((uint64_t)		(tci_sec_capas)		CRT_VAR) \
 	((uint32_t)		(tci_map_version)	CRT_VAR) \
 	((uint32_t)		(tci_iv_ns_id)		CRT_VAR) \
 	((uint32_t)		(tci_master_rank)	CRT_VAR) \

--- a/src/pool/srv_layout.h
+++ b/src/pool/srv_layout.h
@@ -77,7 +77,8 @@ extern d_iov_t ds_pool_attr_user;		/* pool user attributes KVS */
 
 /** value of key (handle uuid) in pool handle KVS (RDB_KVS_GENERIC) */
 struct pool_hdl {
-	uint64_t	ph_capas;
+	uint64_t	ph_flags;
+	uint64_t	ph_sec_capas;
 };
 
 extern daos_prop_t pool_prop_default;

--- a/src/pool/srv_pool.c
+++ b/src/pool/srv_pool.c
@@ -1703,7 +1703,7 @@ out:
 
 static int
 pool_connect_bcast(crt_context_t ctx, struct pool_svc *svc,
-		   const uuid_t pool_hdl, uint64_t capas,
+		   const uuid_t pool_hdl, uint64_t flags, uint64_t sec_capas,
 		   struct daos_pool_space *ps, crt_bulk_t map_buf_bulk)
 {
 	struct pool_tgt_connect_in     *in;
@@ -1725,7 +1725,8 @@ pool_connect_bcast(crt_context_t ctx, struct pool_svc *svc,
 	in = crt_req_get(rpc);
 	uuid_copy(in->tci_uuid, svc->ps_uuid);
 	uuid_copy(in->tci_hdl, pool_hdl);
-	in->tci_capas = capas;
+	in->tci_flags = flags;
+	in->tci_sec_capas = sec_capas;
 	in->tci_map_version = pool_map_get_version(svc->ps_pool->sp_map);
 	in->tci_iv_ns_id = ds_iv_ns_id_get(svc->ps_pool->sp_iv_ns);
 	in->tci_master_rank = rank;
@@ -1876,9 +1877,10 @@ ds_pool_connect_handler(crt_rpc_t *rpc)
 	daos_prop_t		       *prop = NULL;
 	uint64_t			prop_bits;
 	struct daos_prop_entry	       *acl_entry;
-	struct pool_owner		owner;
+	struct ownership		owner;
 	struct daos_prop_entry	       *owner_entry;
 	struct daos_prop_entry	       *owner_grp_entry;
+	uint64_t			sec_capas = 0;
 
 	D_DEBUG(DF_DSMS, DF_UUID": processing rpc %p: hdl="DF_UUID"\n",
 		DP_UUID(in->pci_op.pi_uuid), rpc, DP_UUID(in->pci_op.pi_hdl));
@@ -1919,7 +1921,7 @@ ds_pool_connect_handler(crt_rpc_t *rpc)
 	d_iov_set(&value, &hdl, sizeof(hdl));
 	rc = rdb_tx_lookup(&tx, &svc->ps_handles, &key, &value);
 	if (rc == 0) {
-		if (hdl.ph_capas == in->pci_capas) {
+		if (hdl.ph_flags == in->pci_flags) {
 			/*
 			 * The handle already exists; only do the pool map
 			 * transfer.
@@ -1962,12 +1964,24 @@ ds_pool_connect_handler(crt_rpc_t *rpc)
 	owner.user = owner_entry->dpe_str;
 	owner.group = owner_grp_entry->dpe_str;
 
-	rc = ds_sec_check_pool_access(acl_entry->dpe_val_ptr, &owner,
-			&in->pci_cred, in->pci_capas);
+	/*
+	 * Security capabilities determine the access control policy on this
+	 * pool handle.
+	 */
+	rc = ds_sec_pool_get_capabilities(in->pci_flags, &in->pci_cred, &owner,
+					  acl_entry->dpe_val_ptr,
+					  &sec_capas);
 	if (rc != 0) {
 		D_ERROR(DF_UUID": refusing connect attempt for "
 			DF_X64" error: "DF_RC"\n", DP_UUID(in->pci_op.pi_uuid),
-			in->pci_capas, DP_RC(rc));
+			in->pci_flags, DP_RC(rc));
+		D_GOTO(out_map_version, rc);
+	}
+
+	if (!ds_sec_pool_can_connect(sec_capas)) {
+		D_ERROR(DF_UUID": permission denied for connect attempt for "
+			DF_X64"\n", DP_UUID(in->pci_op.pi_uuid),
+			in->pci_flags);
 		D_GOTO(out_map_version, rc = -DER_NO_PERM);
 	}
 
@@ -2000,7 +2014,7 @@ ds_pool_connect_handler(crt_rpc_t *rpc)
 
 	/* Take care of exclusive handles. */
 	if (nhandles != 0) {
-		if (in->pci_capas & DAOS_PC_EX) {
+		if (in->pci_flags & DAOS_PC_EX) {
 			D_DEBUG(DF_DSMS, DF_UUID": others already connected\n",
 				DP_UUID(in->pci_op.pi_uuid));
 			D_GOTO(out_map_version, rc = -DER_BUSY);
@@ -2015,13 +2029,13 @@ ds_pool_connect_handler(crt_rpc_t *rpc)
 					  NULL /* key_out */, &value);
 			if (rc != 0)
 				D_GOTO(out_map_version, rc);
-			if (hdl.ph_capas & DAOS_PC_EX)
+			if (hdl.ph_flags & DAOS_PC_EX)
 				D_GOTO(out_map_version, rc = -DER_BUSY);
 		}
 	}
 
 	rc = pool_connect_bcast(rpc->cr_ctx, svc, in->pci_op.pi_hdl,
-				in->pci_capas,
+				in->pci_flags, sec_capas,
 				(in->pci_query_bits & DAOS_PO_QUERY_SPACE) ?
 				&out->pco_space : NULL, CRT_BULK_NULL);
 	if (rc != 0) {
@@ -2030,7 +2044,8 @@ ds_pool_connect_handler(crt_rpc_t *rpc)
 		D_GOTO(out_map_version, rc);
 	}
 
-	hdl.ph_capas = in->pci_capas;
+	hdl.ph_flags = in->pci_flags;
+	hdl.ph_sec_capas = sec_capas;
 	nhandles++;
 
 	d_iov_set(&value, &nhandles, sizeof(nhandles));

--- a/src/pool/srv_target.c
+++ b/src/pool/srv_target.c
@@ -735,17 +735,17 @@ ds_pool_tgt_connect_handler(crt_rpc_t *rpc)
 
 	hdl = ds_pool_hdl_lookup(in->tci_hdl);
 	if (hdl != NULL) {
-		if (hdl->sph_capas == in->tci_capas) {
+		if (hdl->sph_flags == in->tci_flags) {
 			D_DEBUG(DF_DSMS, DF_UUID": found compatible pool "
-				"handle: hdl="DF_UUID" capas="DF_U64"\n",
+				"handle: hdl="DF_UUID" flags="DF_U64"\n",
 				DP_UUID(in->tci_uuid), DP_UUID(in->tci_hdl),
-				hdl->sph_capas);
+				hdl->sph_flags);
 			rc = 0;
 		} else {
 			D_ERROR(DF_UUID": found conflicting pool handle: hdl="
-				DF_UUID" capas="DF_U64"\n",
+				DF_UUID" flags="DF_U64"\n",
 				DP_UUID(in->tci_uuid), DP_UUID(in->tci_hdl),
-				hdl->sph_capas);
+				hdl->sph_flags);
 			rc = -DER_EXIST;
 		}
 		ds_pool_hdl_put(hdl);
@@ -771,7 +771,8 @@ ds_pool_tgt_connect_handler(crt_rpc_t *rpc)
 	}
 
 	uuid_copy(hdl->sph_uuid, in->tci_hdl);
-	hdl->sph_capas = in->tci_capas;
+	hdl->sph_flags = in->tci_flags;
+	hdl->sph_sec_capas = in->tci_sec_capas;
 	hdl->sph_pool = pool;
 
 	rc = pool_hdl_add(hdl);

--- a/src/security/srv_acl.c
+++ b/src/security/srv_acl.c
@@ -277,55 +277,27 @@ ds_sec_validate_credentials(d_iov_t *creds, Auth__Token **token)
 	return rc;
 }
 
-static int
-get_auth_sys_payload(Auth__Token *token, Auth__Sys **payload)
+static uint64_t
+pool_capas_from_perms(uint64_t perms)
 {
-	if (token->flavor != AUTH__FLAVOR__AUTH_SYS) {
-		D_ERROR("Credential auth flavor not supported\n");
-		return -DER_PROTO;
-	}
+	uint64_t capas = 0;
 
-	*payload = auth__sys__unpack(NULL, token->data.len, token->data.data);
-	if (*payload == NULL) {
-		D_ERROR("Invalid auth_sys payload\n");
-		return -DER_PROTO;
-	}
+	if (perms & DAOS_ACL_PERM_READ)
+		capas |= POOL_CAPA_READ;
+	if ((perms & DAOS_ACL_PERM_WRITE) ||
+	    (perms & DAOS_ACL_PERM_CREATE_CONT))
+		capas |= POOL_CAPA_CREATE_CONT;
+	if ((perms & DAOS_ACL_PERM_WRITE) ||
+	    (perms & DAOS_ACL_PERM_DEL_CONT))
+		capas |= POOL_CAPA_DEL_CONT;
 
-	return 0;
-}
-
-static bool
-perms_have_access(uint64_t perms, uint64_t capas)
-{
-	D_DEBUG(DB_MGMT, "Allow Perms: 0x%lx\n", perms);
-
-	if ((capas & DAOS_PC_RO) &&
-	    (perms & DAOS_ACL_PERM_READ)) {
-		D_DEBUG(DB_MGMT, "Allowing read-only access\n");
-		return true;
-	}
-
-	if ((capas & (DAOS_PC_RW | DAOS_PC_EX)) &&
-	    (perms & DAOS_ACL_PERM_READ) &&
-	    (perms & DAOS_ACL_PERM_WRITE)) {
-		D_DEBUG(DB_MGMT, "Allowing RW access\n");
-		return true;
-	}
-
-	return false;
-}
-
-static bool
-ace_has_access(struct daos_ace *ace, uint64_t capas)
-{
-	return perms_have_access(ace->dae_allow_perms, capas);
+	return capas;
 }
 
 static int
-check_access_for_principal(struct daos_acl *acl,
-			   enum daos_acl_principal_type type,
-			   const char *name,
-			   uint64_t capas)
+get_capas_for_principal(struct daos_acl *acl, enum daos_acl_principal_type type,
+			const char *name, uint64_t (*convert_perms)(uint64_t),
+			uint64_t *capas)
 {
 	struct daos_ace *ace;
 	int		rc;
@@ -333,14 +305,11 @@ check_access_for_principal(struct daos_acl *acl,
 	D_DEBUG(DB_MGMT, "Checking ACE for principal type %d\n", type);
 
 	rc = daos_acl_get_ace_for_principal(acl, type, name, &ace);
-	if (rc == 0 && ace_has_access(ace, capas))
-		return 0;
-
-	/* ACE not found */
-	if (rc == -DER_NONEXIST)
+	if (rc != 0)
 		return rc;
 
-	return -DER_NO_PERM;
+	*capas = convert_perms(ace->dae_allow_perms);
+	return 0;
 }
 
 static bool
@@ -376,9 +345,10 @@ add_perms_for_principal(struct daos_acl *acl, enum daos_acl_principal_type type,
 }
 
 static int
-check_access_for_groups(struct daos_acl *acl,
-			struct pool_owner *ownership,
-			Auth__Sys *authsys, uint64_t capas)
+get_capas_for_groups(struct daos_acl *acl,
+		     struct ownership *ownership,
+		     Auth__Sys *authsys, uint64_t (*convert_perms)(uint64_t),
+		     uint64_t *capas)
 {
 	int		rc;
 	int		i;
@@ -409,60 +379,142 @@ check_access_for_groups(struct daos_acl *acl,
 	}
 
 	if (found) {
-		if (perms_have_access(grp_perms, capas))
-			return 0;
-
-		return -DER_NO_PERM;
+		*capas = convert_perms(grp_perms);
+		return 0;
 	}
 
 	return -DER_NONEXIST;
 }
 
 static int
-check_authsys_permissions(struct daos_acl *acl,
-			  struct pool_owner *ownership,
-			  Auth__Sys *authsys, uint64_t capas)
+get_authsys_capas(struct daos_acl *acl,
+		  struct ownership *ownership,
+		  Auth__Sys *authsys,
+		  uint64_t (*convert_perms)(uint64_t),
+		  uint64_t *capas)
 {
 	int rc;
 
 	/* If this is the owner, and there's an owner entry... */
 	if (strncmp(authsys->user, ownership->user,
 		    DAOS_ACL_MAX_PRINCIPAL_LEN) == 0) {
-		rc = check_access_for_principal(acl, DAOS_ACL_OWNER, NULL,
-						capas);
+		rc = get_capas_for_principal(acl, DAOS_ACL_OWNER, NULL,
+					     convert_perms,
+					     capas);
 		if (rc != -DER_NONEXIST)
 			return rc;
 	}
 
-	rc = check_access_for_principal(acl, DAOS_ACL_USER, authsys->user,
-					capas);
+	/* didn't match the owner entry, try the user by name */
+	rc = get_capas_for_principal(acl, DAOS_ACL_USER, authsys->user,
+				     convert_perms, capas);
 	if (rc != -DER_NONEXIST)
 		return rc;
 
-	return check_access_for_groups(acl, ownership, authsys, capas);
+	return get_capas_for_groups(acl, ownership, authsys, convert_perms,
+				    capas);
+}
+
+static int
+get_auth_sys_payload(Auth__Token *token, Auth__Sys **payload)
+{
+	if (token->flavor != AUTH__FLAVOR__AUTH_SYS) {
+		D_ERROR("Credential auth flavor not supported\n");
+		return -DER_PROTO;
+	}
+
+	*payload = auth__sys__unpack(NULL, token->data.len, token->data.data);
+	if (*payload == NULL) {
+		D_ERROR("Invalid auth_sys payload\n");
+		return -DER_PROTO;
+	}
+
+	return 0;
+}
+
+static void
+filter_pool_capas_based_on_flags(uint64_t flags, uint64_t *capas)
+{
+	if (flags & DAOS_PC_RO)
+		*capas &= POOL_CAPAS_RO_MASK;
+	else if (!(*capas & POOL_CAPAS_RO_MASK) ||
+		 !(*capas & ~POOL_CAPAS_RO_MASK))
+		/*
+		 * User requested RW - if they don't have permissions for both
+		 * read and write capas, we shouldn't grant them any.
+		 */
+		*capas = 0;
+}
+
+static bool
+is_ownership_valid(struct ownership *ownership)
+{
+	if (daos_acl_principal_is_valid(ownership->user) &&
+	    daos_acl_principal_is_valid(ownership->group))
+		return true;
+
+	return false;
+}
+
+static int
+get_sec_capas_for_token(Auth__Token *token, struct ownership *ownership,
+			struct daos_acl *acl,
+			uint64_t (*convert_perms)(uint64_t), uint64_t *capas)
+{
+	int		rc;
+	Auth__Sys	*authsys;
+
+	rc = get_auth_sys_payload(token, &authsys);
+	if (rc != 0)
+		return rc;
+
+	rc = get_authsys_capas(acl, ownership, authsys, convert_perms, capas);
+
+	/*
+	 * No match found to any specific entry. If there is an Everyone entry,
+	 * we can use the capas for that.
+	 */
+	if (rc == -DER_NONEXIST)
+		rc = get_capas_for_principal(acl, DAOS_ACL_EVERYONE, NULL,
+					     convert_perms, capas);
+
+	/* No match - default no capabilities */
+	if (rc == -DER_NONEXIST) {
+		*capas = 0;
+		rc = 0;
+	}
+
+	auth__sys__free_unpacked(authsys, NULL);
+	return rc;
 }
 
 int
-ds_sec_check_pool_access(struct daos_acl *acl, struct pool_owner *ownership,
-			 d_iov_t *cred, uint64_t capas)
+ds_sec_pool_get_capabilities(uint64_t flags, d_iov_t *cred,
+			     struct ownership *ownership,
+			     struct daos_acl *acl, uint64_t *capas)
 {
-	int		rc = 0;
-	Auth__Token	*token = NULL;
-	Auth__Sys	*authsys = NULL;
+	int		rc;
+	Auth__Token	*token;
 
-	if (acl == NULL || ownership == NULL || cred == NULL) {
-		D_ERROR("NULL input, acl=0x%p, ownership=0x%p, cred=0x%p\n",
-			acl, ownership, cred);
+	if (cred == NULL || ownership == NULL || acl == NULL || capas == NULL) {
+		D_ERROR("NULL input\n");
 		return -DER_INVAL;
 	}
 
-	if (ownership->user == NULL || ownership->group == NULL) {
-		D_ERROR("Invalid ownership structure\n");
+	if (!is_ownership_valid(ownership)) {
+		D_ERROR("Invalid ownership\n");
+		return -DER_INVAL;
+	}
+
+	/* Pool flags are mutually exclusive */
+	if ((flags != DAOS_PC_RO) && (flags != DAOS_PC_RW) &&
+	    (flags != DAOS_PC_EX)) {
+		D_ERROR("Invalid flags\n");
 		return -DER_INVAL;
 	}
 
 	if (daos_acl_validate(acl) != 0) {
-		D_ERROR("ACL content not valid\n");
+		D_ERROR("Invalid ACL\n");
 		return -DER_INVAL;
 	}
 
@@ -473,34 +525,138 @@ ds_sec_check_pool_access(struct daos_acl *acl, struct pool_owner *ownership,
 		return rc;
 	}
 
-	rc = get_auth_sys_payload(token, &authsys);
+	rc = get_sec_capas_for_token(token, ownership, acl,
+				     pool_capas_from_perms, capas);
+	if (rc == 0)
+		filter_pool_capas_based_on_flags(flags, capas);
+
 	auth__token__free_unpacked(token, NULL);
-	if (rc != 0)
-		return rc;
+	return rc;
+}
+
+static uint64_t
+cont_capas_from_perms(uint64_t perms)
+{
+	uint64_t capas = 0;
+
+	if (perms & DAOS_ACL_PERM_READ)
+		capas |= CONT_CAPA_READ_DATA;
+	if (perms & DAOS_ACL_PERM_WRITE)
+		capas |= CONT_CAPA_WRITE_DATA;
+	if (perms & DAOS_ACL_PERM_GET_PROP)
+		capas |= CONT_CAPA_GET_PROP;
+	if (perms & DAOS_ACL_PERM_SET_PROP)
+		capas |= CONT_CAPA_SET_PROP;
+	if (perms & DAOS_ACL_PERM_GET_ACL)
+		capas |= CONT_CAPA_GET_ACL;
+	if (perms & DAOS_ACL_PERM_SET_ACL)
+		capas |= CONT_CAPA_SET_ACL;
+	if (perms & DAOS_ACL_PERM_SET_OWNER)
+		capas |= CONT_CAPA_SET_OWNER;
+
+	return capas;
+}
+
+static void
+filter_cont_capas_based_on_flags(uint64_t flags, uint64_t *capas)
+{
+	if (flags & DAOS_COO_RO)
+		*capas &= CONT_CAPAS_RO_MASK;
+	else if (!(*capas & CONT_CAPAS_RO_MASK) ||
+		 !(*capas & ~CONT_CAPAS_RO_MASK))
+		/*
+		 * User requested RW - if they don't have permissions for both
+		 * read and write capas of some kind, we won't grant them any.
+		 */
+		*capas = 0;
+}
+
+static bool
+container_flags_valid(uint64_t flags)
+{
+	if (flags == 0 || (flags & ~DAOS_COO_MASK))
+		return false;
 
 	/*
-	 * Check ACL for permission via AUTH_SYS credentials
+	 * Read-only and read-write flags conflict
 	 */
-	rc = check_authsys_permissions(acl, ownership, authsys, capas);
-	if (rc == 0)
-		goto access_allowed;
-	else if (rc != -DER_NONEXIST)
-		goto access_denied;
+	if ((flags & DAOS_COO_RO) && (flags & DAOS_COO_RW))
+		return false;
+
+	return true;
+}
+
+static Auth__Token *
+unpack_token_from_cred(d_iov_t *cred)
+{
+	Auth__Credential	*unpacked;
+	Auth__Token		*token = NULL;
+
+	unpacked = auth__credential__unpack(NULL, cred->iov_buf_len,
+					    cred->iov_buf);
+	if (unpacked == NULL) {
+		D_ERROR("Couldn't unpack credential\n");
+		return NULL;
+	}
+
+	if (unpacked->token != NULL)
+		token = auth_token_dup(unpacked->token);
+
+	auth__credential__free_unpacked(unpacked, NULL);
+	return token;
+}
+
+int
+ds_sec_cont_get_capabilities(uint64_t flags, d_iov_t *cred,
+			     struct ownership *ownership,
+			     struct daos_acl *acl, uint64_t *capas)
+{
+	Auth__Token	*token;
+	int		rc;
+
+	if (cred == NULL || ownership == NULL || acl == NULL || capas == NULL) {
+		D_ERROR("NULL input\n");
+		return -DER_INVAL;
+	}
+
+	if (!is_ownership_valid(ownership)) {
+		D_ERROR("Invalid ownership\n");
+		return -DER_INVAL;
+	}
+
+	if (!container_flags_valid(flags)) {
+		D_ERROR("Invalid flags\n");
+		return -DER_INVAL;
+	}
+
+	if (daos_acl_validate(acl) != 0) {
+		D_ERROR("Invalid ACL\n");
+		return -DER_INVAL;
+	}
+
+	if (cred->iov_buf == NULL) {
+		D_ERROR("Credential data is NULL\n");
+		return -DER_INVAL;
+	}
 
 	/*
-	 * Last resort - if credentials don't match any ACEs
+	 * The credential has already been validated at pool connect.
 	 */
-	rc = check_access_for_principal(acl, DAOS_ACL_EVERYONE, NULL, capas);
+	token = unpack_token_from_cred(cred);
+	if (token == NULL)
+		return -DER_INVAL;
+
+	rc = get_sec_capas_for_token(token, ownership, acl,
+				     cont_capas_from_perms, capas);
 	if (rc == 0)
-		goto access_allowed;
+		filter_cont_capas_based_on_flags(flags, capas);
 
-access_denied:
-	D_INFO("Access denied\n");
-	auth__sys__free_unpacked(authsys, NULL);
-	return -DER_NO_PERM;
+	auth__token__free_unpacked(token, NULL);
+	return rc;
+}
 
-access_allowed:
-	D_INFO("Access allowed\n");
-	auth__sys__free_unpacked(authsys, NULL);
-	return 0;
+bool
+ds_sec_pool_can_connect(uint64_t pool_capas)
+{
+	return (pool_capas & POOL_CAPA_READ) != 0;
 }

--- a/src/security/srv_internal.h
+++ b/src/security/srv_internal.h
@@ -36,6 +36,32 @@
 
 extern char *ds_sec_server_socket_path;
 
+/*
+ * Pool capabilities bits, derived from user-requested flags and user access
+ * permissions.
+ */
+#define POOL_CAPA_READ		(1U << 0)
+#define POOL_CAPA_CREATE_CONT	(1U << 1)
+#define POOL_CAPA_DEL_CONT	(1U << 2)
+
+#define POOL_CAPAS_RO_MASK	(POOL_CAPA_READ)
+
+/*
+ * Container capabilities bits. Derived from user-requested flags and user's
+ * access permissions.
+ */
+#define CONT_CAPA_READ_DATA	(1U << 0)
+#define CONT_CAPA_WRITE_DATA	(1U << 1)
+#define CONT_CAPA_GET_PROP	(1U << 2)
+#define CONT_CAPA_SET_PROP	(1U << 3)
+#define CONT_CAPA_GET_ACL	(1U << 4)
+#define CONT_CAPA_SET_ACL	(1U << 5)
+#define CONT_CAPA_SET_OWNER	(1U << 6)
+
+#define CONT_CAPAS_RO_MASK	(CONT_CAPA_READ_DATA |			\
+				 CONT_CAPA_GET_PROP |			\
+				 CONT_CAPA_GET_ACL)
+
 int ds_sec_validate_credentials(d_iov_t *creds, Auth__Token **token);
 
 #endif /* __SECURITY_SRV_INTERNAL_H__ */

--- a/src/security/tests/srv_acl_tests.c
+++ b/src/security/tests/srv_acl_tests.c
@@ -128,7 +128,7 @@ init_default_cred(d_iov_t *cred)
 }
 
 static void
-init_default_ownership(struct pool_owner *owner)
+init_default_ownership(struct ownership *owner)
 {
 	owner->user = TEST_USER;
 	owner->group = TEST_GROUP;
@@ -154,6 +154,31 @@ free_ace_list(struct daos_ace **aces, size_t len)
 
 	for (i = 0; i < len; i++)
 		daos_ace_free(aces[i]);
+}
+
+static struct daos_acl *
+get_acl_with_perms(uint64_t owner_perms, uint64_t group_perms)
+{
+	struct daos_acl *acl;
+	size_t		num_aces = 2;
+	struct daos_ace *aces[num_aces];
+	size_t		i;
+
+	aces[0] = daos_ace_create(DAOS_ACL_OWNER, NULL);
+	aces[0]->dae_access_types = DAOS_ACL_ACCESS_ALLOW;
+	aces[0]->dae_allow_perms = owner_perms;
+
+	aces[1] = daos_ace_create(DAOS_ACL_OWNER_GROUP, NULL);
+	aces[1]->dae_access_types = DAOS_ACL_ACCESS_ALLOW;
+	aces[1]->dae_allow_perms = group_perms;
+
+	acl = daos_acl_create(aces, num_aces);
+
+	for (i = 0; i < num_aces; i++) {
+		daos_ace_free(aces[i]);
+	}
+
+	return acl;
 }
 
 /*
@@ -186,7 +211,7 @@ srv_acl_resetup(void **state)
 }
 
 /*
- * Unit tests
+ * Validate credential tests
  */
 
 static void
@@ -441,1010 +466,6 @@ test_validate_creds_success(void **state)
 	auth__token__free_unpacked(result, NULL);
 }
 
-static void
-test_check_pool_access_null_acl(void **state)
-{
-	d_iov_t			cred;
-	struct pool_owner	ownership;
-
-	init_default_cred(&cred);
-	init_default_ownership(&ownership);
-
-	assert_int_equal(ds_sec_check_pool_access(NULL, &ownership, &cred,
-						  DAOS_PC_RO),
-			 -DER_INVAL);
-
-	daos_iov_free(&cred);
-}
-
-static void
-test_check_pool_access_null_ownership(void **state)
-{
-	struct daos_acl		*acl;
-	d_iov_t			cred;
-
-	init_default_cred(&cred);
-	acl = daos_acl_create(NULL, 0);
-
-	assert_int_equal(ds_sec_check_pool_access(acl, NULL, &cred,
-						  DAOS_PC_RO),
-			 -DER_INVAL);
-
-	daos_iov_free(&cred);
-	daos_acl_free(acl);
-}
-
-static void
-test_check_pool_access_bad_owner_user(void **state)
-{
-	struct daos_acl		*acl;
-	d_iov_t			cred;
-	struct pool_owner	ownership;
-
-	init_default_cred(&cred);
-	acl = daos_acl_create(NULL, 0);
-
-	ownership.user = NULL;
-	ownership.group = TEST_GROUP;
-
-	assert_int_equal(ds_sec_check_pool_access(acl, &ownership, &cred,
-						  DAOS_PC_RO),
-			 -DER_INVAL);
-
-	daos_iov_free(&cred);
-	daos_acl_free(acl);
-}
-
-static void
-test_check_pool_access_bad_owner_group(void **state)
-{
-	struct daos_acl		*acl;
-	d_iov_t			cred;
-	struct pool_owner	ownership;
-
-	init_default_cred(&cred);
-	acl = daos_acl_create(NULL, 0);
-
-	ownership.user = TEST_USER;
-	ownership.group = NULL;
-
-	assert_int_equal(ds_sec_check_pool_access(acl, &ownership, &cred,
-						  DAOS_PC_RO),
-			 -DER_INVAL);
-
-	daos_iov_free(&cred);
-	daos_acl_free(acl);
-}
-
-static void
-test_check_pool_access_null_cred(void **state)
-{
-	struct daos_acl		*acl;
-	struct pool_owner	ownership;
-
-	acl = daos_acl_create(NULL, 0);
-	init_default_ownership(&ownership);
-
-	assert_int_equal(ds_sec_check_pool_access(acl, &ownership, NULL,
-						  DAOS_PC_RO),
-			 -DER_INVAL);
-
-	daos_acl_free(acl);
-}
-
-static void
-test_check_pool_access_bad_acl(void **state)
-{
-	struct daos_acl		*bad_acl;
-	d_iov_t			cred;
-	struct pool_owner	ownership;
-
-	init_default_cred(&cred);
-	init_default_ownership(&ownership);
-
-	/* zeroed out - not a valid ACL */
-	D_ALLOC(bad_acl, sizeof(struct daos_acl));
-	assert_non_null(bad_acl);
-
-	assert_int_equal(ds_sec_check_pool_access(bad_acl, &ownership, &cred,
-						  DAOS_PC_RO),
-			 -DER_INVAL);
-
-	D_FREE(bad_acl);
-	daos_iov_free(&cred);
-}
-
-static void
-test_check_pool_access_validate_cred_failed(void **state)
-{
-	struct daos_acl		*acl;
-	d_iov_t			cred;
-	struct pool_owner	ownership;
-
-	init_default_cred(&cred);
-	init_default_ownership(&ownership);
-	acl = daos_acl_create(NULL, 0);
-
-	/* drpc call failure will fail validation */
-	drpc_call_return = -DER_UNKNOWN;
-	drpc_call_resp_return_ptr = NULL;
-
-	assert_int_equal(ds_sec_check_pool_access(acl, &ownership, &cred,
-						  DAOS_PC_RO),
-			 drpc_call_return);
-
-	daos_acl_free(acl);
-	daos_iov_free(&cred);
-}
-
-static void
-expect_no_access_bad_authsys_payload(int auth_flavor)
-{
-	struct daos_acl		*acl;
-	d_iov_t			cred;
-	size_t			data_len = 8;
-	Auth__Token		token = AUTH__TOKEN__INIT;
-	Auth__ValidateCredResp	resp = AUTH__VALIDATE_CRED_RESP__INIT;
-	struct pool_owner	ownership;
-
-	init_default_cred(&cred);
-	init_default_ownership(&ownership);
-	acl = daos_acl_create(NULL, 0);
-
-	token.flavor = auth_flavor;
-
-	/* Put some junk in there */
-	D_ALLOC(token.data.data, data_len);
-	memset(token.data.data, 0xFF, data_len);
-	token.data.len = data_len;
-
-	resp.token = &token;
-
-	pack_validate_resp_in_drpc_call_resp_body(&resp);
-
-	assert_int_equal(ds_sec_check_pool_access(acl, &ownership, &cred,
-						  DAOS_PC_RO),
-			 -DER_PROTO);
-
-	daos_acl_free(acl);
-	daos_iov_free(&cred);
-	D_FREE(token.data.data);
-}
-
-static void
-test_check_pool_access_wrong_flavor(void **state)
-{
-	expect_no_access_bad_authsys_payload(AUTH__FLAVOR__AUTH_NONE);
-}
-
-static void
-test_check_pool_access_bad_payload(void **state)
-{
-	expect_no_access_bad_authsys_payload(AUTH__FLAVOR__AUTH_SYS);
-}
-
-static void
-test_check_pool_access_empty_acl(void **state)
-{
-	struct daos_acl		*acl;
-	d_iov_t			cred;
-	struct pool_owner	ownership;
-
-	init_default_cred(&cred);
-	init_default_ownership(&ownership);
-	acl = daos_acl_create(NULL, 0);
-
-	assert_int_equal(ds_sec_check_pool_access(acl, &ownership, &cred,
-						  DAOS_PC_RO),
-			 -DER_NO_PERM);
-
-	daos_acl_free(acl);
-	daos_iov_free(&cred);
-}
-
-static struct daos_acl *
-get_acl_with_perms(uint64_t owner_perms, uint64_t group_perms)
-{
-	struct daos_acl *acl;
-	size_t		num_aces = 2;
-	struct daos_ace *aces[num_aces];
-	size_t		i;
-
-	aces[0] = daos_ace_create(DAOS_ACL_OWNER, NULL);
-	aces[0]->dae_access_types = DAOS_ACL_ACCESS_ALLOW;
-	aces[0]->dae_allow_perms = owner_perms;
-
-	aces[1] = daos_ace_create(DAOS_ACL_OWNER_GROUP, NULL);
-	aces[1]->dae_access_types = DAOS_ACL_ACCESS_ALLOW;
-	aces[1]->dae_allow_perms = group_perms;
-
-	acl = daos_acl_create(aces, num_aces);
-
-	for (i = 0; i < num_aces; i++) {
-		daos_ace_free(aces[i]);
-	}
-
-	return acl;
-}
-
-static void
-expect_access_with_acl(struct daos_acl *acl, d_iov_t *cred,
-		       uint64_t requested_capas)
-{
-	struct pool_owner	ownership;
-
-	init_default_ownership(&ownership);
-
-	assert_int_equal(ds_sec_check_pool_access(acl, &ownership, cred,
-						      requested_capas),
-			 0);
-}
-
-static void
-expect_owner_access_with_perms(uint64_t acl_perms, uint64_t requested_capas)
-{
-	struct daos_acl	*acl;
-	d_iov_t		cred;
-
-	/* Only matches owner */
-	init_valid_cred(&cred, TEST_USER, "somerandomgroup@", NULL, 0);
-	acl = get_acl_with_perms(acl_perms, 0);
-
-	expect_access_with_acl(acl, &cred, requested_capas);
-
-	daos_acl_free(acl);
-	daos_iov_free(&cred);
-}
-
-static void
-test_check_pool_access_owner_success(void **state)
-{
-	expect_owner_access_with_perms(DAOS_ACL_PERM_READ, DAOS_PC_RO);
-	srv_acl_resetup(state);
-	expect_owner_access_with_perms(DAOS_ACL_PERM_READ | DAOS_ACL_PERM_WRITE,
-				       DAOS_PC_RO);
-	srv_acl_resetup(state);
-	expect_owner_access_with_perms(DAOS_ACL_PERM_READ | DAOS_ACL_PERM_WRITE,
-				       DAOS_PC_RW);
-	srv_acl_resetup(state);
-	expect_owner_access_with_perms(DAOS_ACL_PERM_READ | DAOS_ACL_PERM_WRITE,
-				       DAOS_PC_EX);
-}
-
-static void
-expect_group_access_with_perms(uint64_t acl_perms, uint64_t requested_capas)
-{
-	struct daos_acl	*acl;
-	d_iov_t		cred;
-
-	/* Only matches group */
-	init_valid_cred(&cred, "randomuser@", TEST_GROUP, NULL, 0);
-	acl = get_acl_with_perms(0, acl_perms);
-
-	expect_access_with_acl(acl, &cred, requested_capas);
-
-	daos_acl_free(acl);
-	daos_iov_free(&cred);
-}
-
-static void
-test_check_pool_access_group_success(void **state)
-{
-	expect_group_access_with_perms(DAOS_ACL_PERM_READ, DAOS_PC_RO);
-	srv_acl_resetup(state);
-	expect_group_access_with_perms(DAOS_ACL_PERM_READ | DAOS_ACL_PERM_WRITE,
-				       DAOS_PC_RO);
-	srv_acl_resetup(state);
-	expect_group_access_with_perms(DAOS_ACL_PERM_READ | DAOS_ACL_PERM_WRITE,
-				       DAOS_PC_RW);
-	srv_acl_resetup(state);
-	expect_group_access_with_perms(DAOS_ACL_PERM_READ | DAOS_ACL_PERM_WRITE,
-				       DAOS_PC_EX);
-}
-
-static void
-expect_list_access_with_perms(uint64_t acl_perms,
-			      uint64_t requested_capas)
-{
-	struct daos_acl		*acl;
-	d_iov_t			cred;
-	static const char	*grps[] = { "badgroup@",
-					    TEST_GROUP,
-					    "worsegroup@" };
-
-	/* Only matches group */
-	init_valid_cred(&cred, "fakeuser@", "fakegroup@", grps,
-			sizeof(grps) / sizeof(char *));
-	acl = get_acl_with_perms(0, acl_perms);
-
-	expect_access_with_acl(acl, &cred, requested_capas);
-
-	daos_acl_free(acl);
-	daos_iov_free(&cred);
-}
-
-static void
-test_check_pool_access_group_list_success(void **state)
-{
-	expect_list_access_with_perms(DAOS_ACL_PERM_READ, DAOS_PC_RO);
-	srv_acl_resetup(state);
-	expect_list_access_with_perms(DAOS_ACL_PERM_READ | DAOS_ACL_PERM_WRITE,
-				      DAOS_PC_RO);
-	srv_acl_resetup(state);
-	expect_list_access_with_perms(DAOS_ACL_PERM_READ | DAOS_ACL_PERM_WRITE,
-				      DAOS_PC_RW);
-	srv_acl_resetup(state);
-	expect_list_access_with_perms(DAOS_ACL_PERM_READ | DAOS_ACL_PERM_WRITE,
-				      DAOS_PC_EX);
-}
-
-static void
-test_check_pool_access_owner_overrides_group(void **state)
-{
-	struct daos_acl		*acl;
-	d_iov_t			cred;
-	struct pool_owner	ownership;
-
-	init_default_ownership(&ownership);
-	init_default_cred(&cred);
-	acl = get_acl_with_perms(DAOS_ACL_PERM_READ,
-				 DAOS_ACL_PERM_READ | DAOS_ACL_PERM_WRITE);
-
-	/* Owner-specific entry overrides group permissions */
-	assert_int_equal(ds_sec_check_pool_access(acl, &ownership, &cred,
-						  DAOS_PC_RW),
-			 -DER_NO_PERM);
-
-	daos_acl_free(acl);
-	daos_iov_free(&cred);
-}
-
-static void
-test_check_pool_access_no_match(void **state)
-{
-	struct daos_acl		*acl;
-	d_iov_t			cred;
-	struct pool_owner	ownership;
-
-	init_default_ownership(&ownership);
-
-	/* Cred is neither owner user nor owner group */
-	init_valid_cred(&cred, "fakeuser@", "fakegroup@", NULL, 0);
-	acl = get_acl_with_perms(DAOS_ACL_PERM_READ, DAOS_ACL_PERM_READ);
-
-	assert_int_equal(ds_sec_check_pool_access(acl, &ownership, &cred,
-						  DAOS_PC_RO),
-			 -DER_NO_PERM);
-
-	daos_acl_free(acl);
-	daos_iov_free(&cred);
-}
-
-static void
-expect_no_owner_access_with_perms(uint64_t acl_perms, uint64_t requested_capas)
-{
-	struct daos_acl		*acl;
-	d_iov_t			cred;
-	struct pool_owner	ownership;
-
-	init_default_ownership(&ownership);
-	init_default_cred(&cred);
-	acl = get_acl_with_perms(acl_perms,
-				 DAOS_ACL_PERM_READ | DAOS_ACL_PERM_WRITE);
-
-	assert_int_equal(ds_sec_check_pool_access(acl, &ownership, &cred,
-						  requested_capas),
-			 -DER_NO_PERM);
-
-	daos_acl_free(acl);
-	daos_iov_free(&cred);
-}
-
-static void
-test_check_pool_access_owner_forbidden(void **state)
-{
-	expect_no_owner_access_with_perms(0, DAOS_PC_RO);
-	srv_acl_resetup(state);
-	expect_no_owner_access_with_perms(DAOS_ACL_PERM_READ, DAOS_PC_RW);
-	srv_acl_resetup(state);
-	expect_no_owner_access_with_perms(DAOS_ACL_PERM_READ, DAOS_PC_EX);
-	srv_acl_resetup(state);
-	expect_no_owner_access_with_perms(DAOS_ACL_PERM_WRITE, DAOS_PC_RW);
-	srv_acl_resetup(state);
-	expect_no_owner_access_with_perms(DAOS_ACL_PERM_WRITE, DAOS_PC_EX);
-}
-
-static void
-expect_no_group_access_with_perms(uint64_t acl_perms, uint64_t requested_capas)
-{
-	struct daos_acl		*acl;
-	d_iov_t			cred;
-	struct pool_owner	ownership;
-
-	init_default_ownership(&ownership);
-	init_valid_cred(&cred, "wronguser@", "wronggroup@", NULL, 0);
-	acl = get_acl_with_perms(0, acl_perms);
-
-	assert_int_equal(ds_sec_check_pool_access(acl, &ownership, &cred,
-						  requested_capas),
-			 -DER_NO_PERM);
-
-	daos_acl_free(acl);
-	daos_iov_free(&cred);
-}
-
-static void
-test_check_pool_access_group_forbidden(void **state)
-{
-	expect_no_group_access_with_perms(0, DAOS_PC_RO);
-	srv_acl_resetup(state);
-	expect_no_group_access_with_perms(DAOS_ACL_PERM_READ, DAOS_PC_RW);
-	srv_acl_resetup(state);
-	expect_no_group_access_with_perms(DAOS_ACL_PERM_READ, DAOS_PC_EX);
-	srv_acl_resetup(state);
-	expect_no_group_access_with_perms(DAOS_ACL_PERM_WRITE, DAOS_PC_RW);
-	srv_acl_resetup(state);
-	expect_no_group_access_with_perms(DAOS_ACL_PERM_WRITE, DAOS_PC_EX);
-}
-
-static void
-expect_no_list_access_with_perms(uint64_t acl_perms, uint64_t requested_capas)
-{
-	struct daos_acl		*acl;
-	d_iov_t			cred;
-	struct pool_owner	ownership;
-	static const char	*grps[] = { "wronggroup@", TEST_GROUP };
-
-	/* owner group is in list only */
-	init_valid_cred(&cred, "wronguser@", "badgroup@", grps,
-			sizeof(grps) / sizeof(char *));
-
-	init_default_ownership(&ownership);
-	acl = get_acl_with_perms(DAOS_ACL_PERM_READ | DAOS_ACL_PERM_WRITE,
-				 acl_perms);
-
-	assert_int_equal(ds_sec_check_pool_access(acl, &ownership, &cred,
-						  requested_capas),
-			 -DER_NO_PERM);
-
-	daos_acl_free(acl);
-	daos_iov_free(&cred);
-}
-
-static void
-test_check_pool_access_list_forbidden(void **state)
-{
-	expect_no_list_access_with_perms(0, DAOS_PC_RO);
-	srv_acl_resetup(state);
-	expect_no_list_access_with_perms(DAOS_ACL_PERM_READ, DAOS_PC_RW);
-	srv_acl_resetup(state);
-	expect_no_list_access_with_perms(DAOS_ACL_PERM_READ, DAOS_PC_EX);
-	srv_acl_resetup(state);
-	expect_no_list_access_with_perms(DAOS_ACL_PERM_WRITE, DAOS_PC_RW);
-	srv_acl_resetup(state);
-	expect_no_list_access_with_perms(DAOS_ACL_PERM_WRITE, DAOS_PC_EX);
-}
-
-static void
-test_check_pool_access_no_owner_entry(void **state)
-{
-	struct daos_acl		*acl;
-	d_iov_t			cred;
-	struct pool_owner	ownership;
-
-	init_default_ownership(&ownership);
-	init_default_cred(&cred);
-	acl = get_acl_with_perms(0, DAOS_ACL_PERM_READ);
-	assert_int_equal(daos_acl_remove_ace(&acl, DAOS_ACL_OWNER, NULL), 0);
-
-	/*
-	 * Cred is owner and in owner group, but there's no entry for owner,
-	 * just owner group. Should still get access.
-	 */
-	assert_int_equal(ds_sec_check_pool_access(acl, &ownership, &cred,
-						  DAOS_PC_RO),
-			 0);
-
-	daos_acl_free(acl);
-	daos_iov_free(&cred);
-}
-
-static void
-test_check_pool_access_no_owner_group_entry(void **state)
-{
-	struct daos_acl		*acl;
-	d_iov_t			cred;
-	struct pool_owner	ownership;
-
-	init_default_ownership(&ownership);
-	init_valid_cred(&cred, "fakeuser@", TEST_GROUP, NULL, 0);
-	acl = get_acl_with_perms(DAOS_ACL_PERM_READ, DAOS_ACL_PERM_READ);
-	assert_int_equal(daos_acl_remove_ace(&acl, DAOS_ACL_OWNER_GROUP, NULL),
-			 0);
-
-	/*
-	 * Cred is in owner group, but there's no entry for owner group.
-	 */
-	assert_int_equal(ds_sec_check_pool_access(acl, &ownership, &cred,
-						      DAOS_PC_RO),
-			 -DER_NO_PERM);
-
-	daos_acl_free(acl);
-	daos_iov_free(&cred);
-}
-
-static void
-test_check_pool_access_no_owner_group_entry_list(void **state)
-{
-	struct daos_acl		*acl;
-	d_iov_t			cred;
-	struct pool_owner	ownership;
-	static const char	*grps[] = { TEST_GROUP };
-
-	init_default_ownership(&ownership);
-	init_valid_cred(&cred, "fakeuser@", "fakegroup@", grps, 1);
-	acl = get_acl_with_perms(DAOS_ACL_PERM_READ, DAOS_ACL_PERM_READ);
-	assert_int_equal(daos_acl_remove_ace(&acl, DAOS_ACL_OWNER_GROUP, NULL),
-			 0);
-
-	/*
-	 * Cred is in owner group, but there's no entry for owner group.
-	 */
-	assert_int_equal(ds_sec_check_pool_access(acl, &ownership, &cred,
-						      DAOS_PC_RO),
-			 -DER_NO_PERM);
-
-	daos_acl_free(acl);
-	daos_iov_free(&cred);
-}
-
-static void
-expect_everyone_gets_result_with_perms(uint64_t acl_perms,
-				       uint64_t requested_capas,
-				       int expected_result)
-{
-	struct daos_acl		*acl;
-	struct daos_ace		*ace;
-	d_iov_t			cred;
-	struct pool_owner	ownership;
-
-	init_default_ownership(&ownership);
-	init_valid_cred(&cred, TEST_USER, TEST_GROUP, NULL, 0);
-	ace = daos_ace_create(DAOS_ACL_EVERYONE, NULL);
-	ace->dae_access_types = DAOS_ACL_ACCESS_ALLOW;
-	ace->dae_allow_perms = acl_perms;
-	acl = daos_acl_create(&ace, 1);
-
-	/*
-	 * In owner and owner group... but no entries for them.
-	 * "Everyone" permissions should apply.
-	 */
-	assert_int_equal(ds_sec_check_pool_access(acl, &ownership, &cred,
-						  requested_capas),
-			 expected_result);
-
-	daos_acl_free(acl);
-	daos_ace_free(ace);
-	daos_iov_free(&cred);
-}
-
-static void
-expect_everyone_access_with_perms(uint64_t acl_perms, uint64_t requested_capas)
-{
-	expect_everyone_gets_result_with_perms(acl_perms, requested_capas, 0);
-}
-
-static void
-test_check_pool_access_everyone_success(void **state)
-{
-	expect_everyone_access_with_perms(DAOS_ACL_PERM_READ, DAOS_PC_RO);
-	srv_acl_resetup(state);
-	expect_everyone_access_with_perms(DAOS_ACL_PERM_READ |
-					  DAOS_ACL_PERM_WRITE,
-					  DAOS_PC_RO);
-	srv_acl_resetup(state);
-	expect_everyone_access_with_perms(DAOS_ACL_PERM_READ |
-					  DAOS_ACL_PERM_WRITE,
-					  DAOS_PC_RW);
-	srv_acl_resetup(state);
-	expect_everyone_access_with_perms(DAOS_ACL_PERM_READ |
-					  DAOS_ACL_PERM_WRITE,
-					  DAOS_PC_EX);
-}
-
-static void
-expect_everyone_no_access_with_perms(uint64_t acl_perms,
-				     uint64_t requested_capas)
-{
-	expect_everyone_gets_result_with_perms(acl_perms, requested_capas,
-					       -DER_NO_PERM);
-}
-
-static void
-test_check_pool_access_everyone_forbidden(void **state)
-{
-	expect_everyone_no_access_with_perms(0, DAOS_PC_RO);
-	srv_acl_resetup(state);
-	expect_everyone_no_access_with_perms(0, DAOS_PC_RW);
-	srv_acl_resetup(state);
-	expect_everyone_no_access_with_perms(0, DAOS_PC_EX);
-	srv_acl_resetup(state);
-	expect_everyone_no_access_with_perms(DAOS_ACL_PERM_READ, DAOS_PC_RW);
-	srv_acl_resetup(state);
-	expect_everyone_no_access_with_perms(DAOS_ACL_PERM_READ, DAOS_PC_EX);
-}
-
-static void
-test_check_pool_access_fall_thru_everyone(void **state)
-{
-	struct daos_acl		*acl;
-	struct daos_ace		*ace;
-	d_iov_t			cred;
-	struct pool_owner	ownership;
-	static const char	*grps[] = { "anotherbadgrp@" };
-
-	init_default_ownership(&ownership);
-	/* Cred doesn't match owner or group */
-	init_valid_cred(&cred, "baduser@", "badgrp@", grps, 1);
-	/* Owner/group entries exist with no perms */
-	acl = get_acl_with_perms(0, 0);
-
-	/* Everyone entry allowing RW access */
-	ace = daos_ace_create(DAOS_ACL_EVERYONE, NULL);
-	ace->dae_access_types = DAOS_ACL_ACCESS_ALLOW;
-	ace->dae_allow_perms = DAOS_ACL_PERM_READ | DAOS_ACL_PERM_WRITE;
-	assert_int_equal(daos_acl_add_ace(&acl, ace), 0);
-
-	/*
-	 * Cred doesn't match owner/group, falls thru to everyone
-	 */
-	assert_int_equal(ds_sec_check_pool_access(acl, &ownership, &cred,
-						  DAOS_PC_RW),
-			 0);
-
-	daos_acl_free(acl);
-	daos_ace_free(ace);
-	daos_iov_free(&cred);
-}
-
-static void
-test_check_pool_access_user_matches(void **state)
-{
-	struct daos_acl		*acl;
-	struct daos_ace		*ace;
-	d_iov_t			cred;
-	struct pool_owner	ownership;
-
-	/* Ownership won't match our creds */
-	ownership.user = "someuser@";
-	ownership.group = "somegroup@";
-
-	init_default_cred(&cred);
-
-	/* User entry matches our cred */
-	ace = daos_ace_create(DAOS_ACL_USER, TEST_USER);
-	ace->dae_access_types = DAOS_ACL_ACCESS_ALLOW;
-	ace->dae_allow_perms = DAOS_ACL_PERM_READ | DAOS_ACL_PERM_WRITE;
-	acl = daos_acl_create(&ace, 1);
-
-	assert_int_equal(ds_sec_check_pool_access(acl, &ownership, &cred,
-						  DAOS_PC_RW),
-			 0);
-
-	daos_acl_free(acl);
-	daos_ace_free(ace);
-	daos_iov_free(&cred);
-}
-
-static void
-test_check_pool_access_user_matches_second(void **state)
-{
-	struct daos_acl		*acl;
-	size_t			num_aces = 2;
-	struct daos_ace		*ace[num_aces];
-	d_iov_t			cred;
-	struct pool_owner	ownership;
-
-	/* Ownership won't match our creds */
-	ownership.user = "someuser@";
-	ownership.group = "somegroup@";
-
-	init_default_cred(&cred);
-
-	/* Match is not the first in the list */
-	ace[0] = daos_ace_create(DAOS_ACL_USER, "fakeuser@");
-	ace[0]->dae_access_types = DAOS_ACL_ACCESS_ALLOW;
-	ace[0]->dae_allow_perms = DAOS_ACL_PERM_READ;
-	ace[1] = daos_ace_create(DAOS_ACL_USER, TEST_USER);
-	ace[1]->dae_access_types = DAOS_ACL_ACCESS_ALLOW;
-	ace[1]->dae_allow_perms = DAOS_ACL_PERM_READ | DAOS_ACL_PERM_WRITE;
-	acl = daos_acl_create(ace, 2);
-
-	assert_int_equal(ds_sec_check_pool_access(acl, &ownership, &cred,
-						  DAOS_PC_RW),
-			 0);
-
-	daos_acl_free(acl);
-	free_ace_list(ace, num_aces);
-	daos_iov_free(&cred);
-}
-
-static void
-test_check_pool_access_owner_beats_user(void **state)
-{
-	struct daos_acl		*acl;
-	struct daos_ace		*ace;
-	d_iov_t			cred;
-	struct pool_owner	ownership;
-
-	/* Owner matches our creds */
-	ownership.user = TEST_USER;
-	ownership.group = "somegroup@";
-
-	init_default_cred(&cred);
-
-	acl = get_acl_with_perms(DAOS_ACL_PERM_READ, DAOS_ACL_PERM_READ);
-
-	/* User entry matches our cred */
-	ace = daos_ace_create(DAOS_ACL_USER, TEST_USER);
-	ace->dae_access_types = DAOS_ACL_ACCESS_ALLOW;
-	ace->dae_allow_perms = DAOS_ACL_PERM_READ | DAOS_ACL_PERM_WRITE;
-	assert_int_equal(daos_acl_add_ace(&acl, ace), 0);
-
-	/*
-	 * Requesting RW - but owner ACE has RO. Owner overrides named user
-	 * even though both match.
-	 */
-	assert_int_equal(ds_sec_check_pool_access(acl, &ownership, &cred,
-						  DAOS_PC_RW),
-			 -DER_NO_PERM);
-
-	daos_acl_free(acl);
-	daos_ace_free(ace);
-	daos_iov_free(&cred);
-}
-
-static void
-test_check_pool_access_user_beats_owner_grp(void **state)
-{
-	struct daos_acl		*acl;
-	struct daos_ace		*ace;
-	d_iov_t			cred;
-	struct pool_owner	ownership;
-
-	/* Owner group matches our creds */
-	ownership.user = "someuser@";
-	ownership.group = TEST_GROUP;
-
-	init_default_cred(&cred);
-
-	acl = get_acl_with_perms(DAOS_ACL_PERM_READ | DAOS_ACL_PERM_WRITE,
-				 DAOS_ACL_PERM_READ | DAOS_ACL_PERM_WRITE);
-
-	/* User entry matches our cred */
-	ace = daos_ace_create(DAOS_ACL_USER, TEST_USER);
-	ace->dae_access_types = DAOS_ACL_ACCESS_ALLOW;
-	ace->dae_allow_perms = DAOS_ACL_PERM_READ;
-	assert_int_equal(daos_acl_add_ace(&acl, ace), 0);
-
-	/*
-	 * Requesting RW - but user ACE has RO. User overrides owner-group
-	 * even though both match.
-	 * Owner-user doesn't match at all.
-	 */
-	assert_int_equal(ds_sec_check_pool_access(acl, &ownership, &cred,
-						  DAOS_PC_RW),
-			 -DER_NO_PERM);
-
-	daos_acl_free(acl);
-	daos_ace_free(ace);
-	daos_iov_free(&cred);
-}
-
-static void
-test_check_pool_access_grp_matches(void **state)
-{
-	struct daos_acl		*acl;
-	struct daos_ace		*ace;
-	d_iov_t			cred;
-	struct pool_owner	ownership;
-
-	/* Ownership won't match our creds */
-	ownership.user = "someuser@";
-	ownership.group = "somegroup@";
-
-	init_default_cred(&cred);
-
-	/* Group entry matches our cred */
-	ace = daos_ace_create(DAOS_ACL_GROUP, TEST_GROUP);
-	ace->dae_access_types = DAOS_ACL_ACCESS_ALLOW;
-	ace->dae_allow_perms = DAOS_ACL_PERM_READ | DAOS_ACL_PERM_WRITE;
-	acl = daos_acl_create(&ace, 1);
-
-	assert_int_equal(ds_sec_check_pool_access(acl, &ownership, &cred,
-						  DAOS_PC_RW),
-			 0);
-
-	daos_acl_free(acl);
-	daos_ace_free(ace);
-	daos_iov_free(&cred);
-}
-
-static void
-test_check_pool_access_grp_matches_second(void **state)
-{
-	struct daos_acl		*acl;
-	size_t			num_aces = 2;
-	struct daos_ace		*ace[num_aces];
-	d_iov_t			cred;
-	struct pool_owner	ownership;
-
-	/* Ownership won't match our creds */
-	ownership.user = "someuser@";
-	ownership.group = "somegroup@";
-
-	init_default_cred(&cred);
-
-	/* Match is not the first in the list */
-	ace[0] = daos_ace_create(DAOS_ACL_GROUP, "fakegrp@");
-	ace[0]->dae_access_types = DAOS_ACL_ACCESS_ALLOW;
-	ace[0]->dae_allow_perms = DAOS_ACL_PERM_READ;
-	ace[1] = daos_ace_create(DAOS_ACL_GROUP, TEST_GROUP);
-	ace[1]->dae_access_types = DAOS_ACL_ACCESS_ALLOW;
-	ace[1]->dae_allow_perms = DAOS_ACL_PERM_READ | DAOS_ACL_PERM_WRITE;
-	acl = daos_acl_create(ace, 2);
-
-	assert_int_equal(ds_sec_check_pool_access(acl, &ownership, &cred,
-						  DAOS_PC_RW),
-			 0);
-
-	daos_acl_free(acl);
-	free_ace_list(ace, num_aces);
-	daos_iov_free(&cred);
-}
-
-static void
-test_check_pool_access_grp_matches_multiple(void **state)
-{
-	struct daos_acl		*acl;
-	size_t			num_aces = 2;
-	struct daos_ace		*ace[num_aces];
-	d_iov_t			cred;
-	struct pool_owner	ownership;
-	static const char	*groups[] = { "group1@", "group2@" };
-
-	/* Ownership won't match our creds */
-	ownership.user = "someuser@";
-	ownership.group = "somegroup@";
-
-	init_valid_cred(&cred, TEST_USER, TEST_GROUP, groups, 2);
-
-	/* Both groups in the ACL with different perms - should be unioned */
-	ace[0] = daos_ace_create(DAOS_ACL_GROUP, groups[0]);
-	ace[0]->dae_access_types = DAOS_ACL_ACCESS_ALLOW;
-	ace[0]->dae_allow_perms = DAOS_ACL_PERM_READ;
-	ace[1] = daos_ace_create(DAOS_ACL_GROUP, groups[1]);
-	ace[1]->dae_access_types = DAOS_ACL_ACCESS_ALLOW;
-	ace[1]->dae_allow_perms = DAOS_ACL_PERM_WRITE;
-	acl = daos_acl_create(ace, 2);
-
-	assert_int_equal(ds_sec_check_pool_access(acl, &ownership, &cred,
-						  DAOS_PC_RW),
-			 0);
-
-	daos_acl_free(acl);
-	free_ace_list(ace, num_aces);
-	daos_iov_free(&cred);
-}
-
-static void
-test_check_pool_access_grp_no_match(void **state)
-{
-	struct daos_acl		*acl;
-	size_t			num_aces = 3;
-	struct daos_ace		*ace[num_aces];
-	d_iov_t			cred;
-	struct pool_owner	ownership;
-	static const char	*groups[] = { "group1@", "group2@" };
-
-	/* Ownership won't match our creds */
-	ownership.user = "someuser@";
-	ownership.group = "somegroup@";
-
-	init_valid_cred(&cred, TEST_USER, TEST_GROUP, groups, 2);
-
-	/* Shouldn't match any of them */
-	ace[0] = daos_ace_create(DAOS_ACL_GROUP, "fakegrp@");
-	ace[0]->dae_access_types = DAOS_ACL_ACCESS_ALLOW;
-	ace[0]->dae_allow_perms = DAOS_ACL_PERM_READ | DAOS_ACL_PERM_WRITE;
-	ace[1] = daos_ace_create(DAOS_ACL_GROUP, "fakegrp2@");
-	ace[1]->dae_access_types = DAOS_ACL_ACCESS_ALLOW;
-	ace[1]->dae_allow_perms = DAOS_ACL_PERM_READ;
-	ace[2] = daos_ace_create(DAOS_ACL_OWNER_GROUP, NULL);
-	ace[2]->dae_access_types = DAOS_ACL_ACCESS_ALLOW;
-	ace[2]->dae_allow_perms = DAOS_ACL_PERM_READ;
-	acl = daos_acl_create(ace, num_aces);
-
-	assert_int_equal(ds_sec_check_pool_access(acl, &ownership, &cred,
-						  DAOS_PC_RO),
-			 -DER_NO_PERM);
-
-	daos_acl_free(acl);
-	free_ace_list(ace, num_aces);
-	daos_iov_free(&cred);
-}
-
-static void
-test_check_pool_access_grp_check_includes_owner(void **state)
-{
-	struct daos_acl		*acl;
-	size_t			num_aces = 2;
-	struct daos_ace		*ace[num_aces];
-	d_iov_t			cred;
-	struct pool_owner	ownership;
-	static const char	*groups[] = { "group1@", "group2@" };
-
-	/* Ownership matches group */
-	ownership.user = "someuser@";
-	ownership.group = TEST_GROUP;
-
-	init_valid_cred(&cred, TEST_USER, TEST_GROUP, groups, 2);
-
-	/* Should get union of owner group and named groups */
-	ace[0] = daos_ace_create(DAOS_ACL_OWNER_GROUP, NULL);
-	ace[0]->dae_access_types = DAOS_ACL_ACCESS_ALLOW;
-	ace[0]->dae_allow_perms = DAOS_ACL_PERM_WRITE;
-	ace[1] = daos_ace_create(DAOS_ACL_GROUP, groups[1]);
-	ace[1]->dae_access_types = DAOS_ACL_ACCESS_ALLOW;
-	ace[1]->dae_allow_perms = DAOS_ACL_PERM_READ;
-	acl = daos_acl_create(ace, 2);
-
-	assert_int_equal(ds_sec_check_pool_access(acl, &ownership, &cred,
-						  DAOS_PC_RW),
-			 0);
-
-	daos_acl_free(acl);
-	free_ace_list(ace, num_aces);
-	daos_iov_free(&cred);
-}
-
-static void
-test_check_pool_access_grps_beat_everyone(void **state)
-{
-	struct daos_acl		*acl;
-	size_t			num_aces = 2;
-	struct daos_ace		*ace[num_aces];
-	d_iov_t			cred;
-	struct pool_owner	ownership;
-	static const char	*groups[] = { "group1@", "group2@" };
-
-	/* Ownership doesn't match */
-	ownership.user = "someuser@";
-	ownership.group = "somegroup@";
-
-	init_valid_cred(&cred, TEST_USER, TEST_GROUP, groups, 2);
-
-	/*
-	 * "Everyone" has more privs than the group, but the matching group
-	 * privileges take priority.
-	 */
-	ace[0] = daos_ace_create(DAOS_ACL_EVERYONE, NULL);
-	ace[0]->dae_access_types = DAOS_ACL_ACCESS_ALLOW;
-	ace[0]->dae_allow_perms = DAOS_ACL_PERM_READ | DAOS_ACL_PERM_WRITE;
-	ace[1] = daos_ace_create(DAOS_ACL_GROUP, groups[1]);
-	ace[1]->dae_access_types = DAOS_ACL_ACCESS_ALLOW;
-	ace[1]->dae_allow_perms = 0;
-	acl = daos_acl_create(ace, 2);
-
-	assert_int_equal(ds_sec_check_pool_access(acl, &ownership, &cred,
-						  DAOS_PC_RO),
-			 -DER_NO_PERM);
-
-	daos_acl_free(acl);
-	free_ace_list(ace, num_aces);
-	daos_iov_free(&cred);
-}
-
 /*
  * Default ACL tests
  */
@@ -1519,6 +540,1251 @@ test_default_cont_acl(void **state)
 	daos_acl_free(acl);
 }
 
+/*
+ * Pool get capabilities tests
+ */
+static void
+expect_pool_get_capas_flags_invalid(uint64_t invalid_flags)
+{
+	struct daos_acl		*valid_acl;
+	d_iov_t			valid_cred;
+	struct ownership	valid_owner;
+	uint64_t		result = 0;
+
+	valid_owner.user = "root@";
+	valid_owner.group = "admins@";
+
+	valid_acl = daos_acl_create(NULL, 0);
+	assert_non_null(valid_acl);
+	init_default_cred(&valid_cred);
+
+	printf("Expecting flags 0x%lx invalid\n", invalid_flags);
+	assert_int_equal(ds_sec_pool_get_capabilities(invalid_flags,
+						      &valid_cred,
+						      &valid_owner, valid_acl,
+						      &result),
+			 -DER_INVAL);
+
+	daos_acl_free(valid_acl);
+	daos_iov_free(&valid_cred);
+}
+
+static void
+test_pool_get_capas_invalid_flags(void **state)
+{
+	expect_pool_get_capas_flags_invalid(0);
+	expect_pool_get_capas_flags_invalid(1U << DAOS_PC_NBITS);
+	expect_pool_get_capas_flags_invalid(DAOS_PC_RO | DAOS_PC_RW);
+	expect_pool_get_capas_flags_invalid(DAOS_PC_RO | DAOS_PC_EX);
+	expect_pool_get_capas_flags_invalid(DAOS_PC_RW | DAOS_PC_EX);
+}
+
+static void
+test_pool_get_capas_null_input(void **state)
+{
+	struct daos_acl		*valid_acl;
+	d_iov_t			valid_cred;
+	struct ownership	valid_owner;
+	uint64_t		valid_flags = DAOS_PC_RO;
+	uint64_t		result = 0;
+
+	init_default_ownership(&valid_owner);
+	init_default_cred(&valid_cred);
+
+	valid_acl = daos_acl_create(NULL, 0);
+	assert_non_null(valid_acl);
+
+	assert_int_equal(ds_sec_pool_get_capabilities(valid_flags,
+						      NULL,
+						      &valid_owner, valid_acl,
+						      &result),
+			 -DER_INVAL);
+
+	assert_int_equal(ds_sec_pool_get_capabilities(valid_flags,
+						      &valid_cred,
+						      NULL, valid_acl,
+						      &result),
+			 -DER_INVAL);
+
+	assert_int_equal(ds_sec_pool_get_capabilities(valid_flags,
+						      &valid_cred,
+						      &valid_owner, NULL,
+						      &result),
+			 -DER_INVAL);
+
+	assert_int_equal(ds_sec_pool_get_capabilities(valid_flags,
+						      &valid_cred,
+						      &valid_owner, valid_acl,
+						      NULL),
+			 -DER_INVAL);
+
+	daos_acl_free(valid_acl);
+	daos_iov_free(&valid_cred);
+}
+
+static void
+expect_pool_get_capas_owner_invalid(char *user, char *group)
+{
+	struct daos_acl		*valid_acl;
+	d_iov_t			valid_cred;
+	struct ownership	invalid_owner;
+	uint64_t		valid_flags = DAOS_PC_RO;
+	uint64_t		result = 0;
+
+	init_default_cred(&valid_cred);
+
+	valid_acl = daos_acl_create(NULL, 0);
+	assert_non_null(valid_acl);
+
+	invalid_owner.user = user;
+	invalid_owner.group = group;
+	assert_int_equal(ds_sec_pool_get_capabilities(valid_flags,
+						      &valid_cred,
+						      &invalid_owner, valid_acl,
+						      &result),
+			 -DER_INVAL);
+
+	daos_acl_free(valid_acl);
+	daos_iov_free(&valid_cred);
+}
+
+static void
+test_pool_get_capas_bad_owner(void **state)
+{
+	expect_pool_get_capas_owner_invalid(NULL, NULL);
+	expect_pool_get_capas_owner_invalid(TEST_USER, NULL);
+	expect_pool_get_capas_owner_invalid(NULL, TEST_GROUP);
+	expect_pool_get_capas_owner_invalid("notavalidname", TEST_GROUP);
+	expect_pool_get_capas_owner_invalid(TEST_USER, "notavalidname");
+}
+
+static void
+test_pool_get_capas_bad_acl(void **state)
+{
+	struct daos_acl		*bad_acl;
+	d_iov_t			cred;
+	struct ownership	ownership;
+	uint64_t		result;
+
+	init_default_cred(&cred);
+	init_default_ownership(&ownership);
+
+	/* zeroed out - not a valid ACL */
+	D_ALLOC(bad_acl, sizeof(struct daos_acl));
+	assert_non_null(bad_acl);
+
+	assert_int_equal(ds_sec_pool_get_capabilities(DAOS_PC_RO, &cred,
+						      &ownership, bad_acl,
+						      &result),
+			 -DER_INVAL);
+
+	D_FREE(bad_acl);
+	daos_iov_free(&cred);
+}
+
+static void
+test_pool_get_capas_validate_cred_failed(void **state)
+{
+	struct daos_acl		*acl;
+	d_iov_t			cred;
+	struct ownership	ownership;
+	uint64_t		result;
+
+	init_default_cred(&cred);
+	init_default_ownership(&ownership);
+	acl = daos_acl_create(NULL, 0);
+
+	/* drpc call failure will fail validation */
+	drpc_call_return = -DER_UNKNOWN;
+	drpc_call_resp_return_ptr = NULL;
+
+	assert_int_equal(ds_sec_pool_get_capabilities(DAOS_PC_RO, &cred,
+						      &ownership, acl,
+						      &result),
+			 drpc_call_return);
+
+	daos_acl_free(acl);
+	daos_iov_free(&cred);
+}
+
+static void
+expect_pool_get_capas_bad_authsys_payload(int auth_flavor)
+{
+	struct daos_acl		*acl;
+	d_iov_t			cred;
+	size_t			data_len = 8;
+	Auth__Token		token = AUTH__TOKEN__INIT;
+	Auth__ValidateCredResp	resp = AUTH__VALIDATE_CRED_RESP__INIT;
+	struct ownership	ownership;
+	uint64_t		result;
+
+	init_default_cred(&cred);
+	init_default_ownership(&ownership);
+	acl = daos_acl_create(NULL, 0);
+
+	token.flavor = auth_flavor;
+
+	/* Put some junk in there */
+	D_ALLOC(token.data.data, data_len);
+	memset(token.data.data, 0xFF, data_len);
+	token.data.len = data_len;
+
+	resp.token = &token;
+
+	pack_validate_resp_in_drpc_call_resp_body(&resp);
+
+	assert_int_equal(ds_sec_pool_get_capabilities(DAOS_PC_RO, &cred,
+						      &ownership, acl,
+						      &result),
+			 -DER_PROTO);
+
+	daos_acl_free(acl);
+	daos_iov_free(&cred);
+	D_FREE(token.data.data);
+}
+
+static void
+test_pool_get_capas_wrong_flavor(void **state)
+{
+	expect_pool_get_capas_bad_authsys_payload(AUTH__FLAVOR__AUTH_NONE);
+}
+
+static void
+test_pool_get_capas_bad_payload(void **state)
+{
+	expect_pool_get_capas_bad_authsys_payload(AUTH__FLAVOR__AUTH_SYS);
+}
+
+static void
+expect_pool_capas_with_acl(struct daos_acl *acl, d_iov_t *cred,
+		      uint64_t flags, uint64_t exp_capas)
+{
+	struct ownership	ownership;
+	uint64_t		result = -1;
+
+	init_default_ownership(&ownership);
+
+	assert_int_equal(ds_sec_pool_get_capabilities(flags, cred, &ownership,
+						      acl, &result),
+			 0);
+
+	assert_int_equal(result, exp_capas);
+}
+
+static void
+test_pool_get_capas_empty_acl(void **state)
+{
+	struct daos_acl		*acl;
+	d_iov_t			cred;
+
+	init_default_cred(&cred);
+	acl = daos_acl_create(NULL, 0);
+
+	expect_pool_capas_with_acl(acl, &cred, DAOS_PC_RO, 0);
+	/* no capabilities allowed */
+
+	daos_acl_free(acl);
+	daos_iov_free(&cred);
+}
+
+static void
+expect_owner_capas_with_perms(uint64_t acl_perms, uint64_t flags,
+			      uint64_t exp_capas)
+{
+	struct daos_acl	*acl;
+	d_iov_t		cred;
+
+	/* Only matches owner */
+	init_valid_cred(&cred, TEST_USER, "somerandomgroup@", NULL, 0);
+	acl = get_acl_with_perms(acl_perms, 0);
+
+	expect_pool_capas_with_acl(acl, &cred, flags, exp_capas);
+
+	daos_acl_free(acl);
+	daos_iov_free(&cred);
+}
+
+static void
+test_pool_get_capas_owner_success(void **state)
+{
+	expect_owner_capas_with_perms(DAOS_ACL_PERM_READ, DAOS_PC_RO,
+				      POOL_CAPA_READ);
+	srv_acl_resetup(state);
+	expect_owner_capas_with_perms(DAOS_ACL_PERM_READ | DAOS_ACL_PERM_WRITE,
+				      DAOS_PC_RO, POOL_CAPA_READ);
+	srv_acl_resetup(state);
+	expect_owner_capas_with_perms(DAOS_ACL_PERM_READ | DAOS_ACL_PERM_WRITE,
+				      DAOS_PC_RW,
+				      POOL_CAPA_READ | POOL_CAPA_CREATE_CONT |
+				      POOL_CAPA_DEL_CONT);
+	srv_acl_resetup(state);
+	expect_owner_capas_with_perms(DAOS_ACL_PERM_READ | DAOS_ACL_PERM_WRITE,
+				      DAOS_PC_EX,
+				      POOL_CAPA_READ | POOL_CAPA_CREATE_CONT |
+				      POOL_CAPA_DEL_CONT);
+	srv_acl_resetup(state);
+	expect_owner_capas_with_perms(DAOS_ACL_PERM_READ |
+				      DAOS_ACL_PERM_CREATE_CONT,
+				      DAOS_PC_RW,
+				      POOL_CAPA_READ | POOL_CAPA_CREATE_CONT);
+	srv_acl_resetup(state);
+	expect_owner_capas_with_perms(DAOS_ACL_PERM_READ |
+				      DAOS_ACL_PERM_DEL_CONT,
+				      DAOS_PC_RW,
+				      POOL_CAPA_READ | POOL_CAPA_DEL_CONT);
+}
+
+static void
+expect_group_capas_with_perms(uint64_t acl_perms, uint64_t flags,
+			      uint64_t exp_capas)
+{
+	struct daos_acl	*acl;
+	d_iov_t		cred;
+
+	/* Only matches group */
+	init_valid_cred(&cred, "randomuser@", TEST_GROUP, NULL, 0);
+	acl = get_acl_with_perms(0, acl_perms);
+
+	expect_pool_capas_with_acl(acl, &cred, flags, exp_capas);
+
+	daos_acl_free(acl);
+	daos_iov_free(&cred);
+}
+
+static void
+test_pool_get_capas_group_success(void **state)
+{
+	expect_group_capas_with_perms(DAOS_ACL_PERM_READ, DAOS_PC_RO,
+				      POOL_CAPA_READ);
+	srv_acl_resetup(state);
+	expect_group_capas_with_perms(DAOS_ACL_PERM_READ | DAOS_ACL_PERM_WRITE,
+				      DAOS_PC_RO, POOL_CAPA_READ);
+	srv_acl_resetup(state);
+	expect_group_capas_with_perms(DAOS_ACL_PERM_READ | DAOS_ACL_PERM_WRITE,
+				      DAOS_PC_RW, POOL_CAPA_READ |
+				      POOL_CAPA_CREATE_CONT |
+				      POOL_CAPA_DEL_CONT);
+	srv_acl_resetup(state);
+	expect_group_capas_with_perms(DAOS_ACL_PERM_READ | DAOS_ACL_PERM_WRITE,
+				      DAOS_PC_EX, POOL_CAPA_READ |
+				      POOL_CAPA_CREATE_CONT |
+				      POOL_CAPA_DEL_CONT);
+	srv_acl_resetup(state);
+	expect_group_capas_with_perms(DAOS_ACL_PERM_READ |
+				      DAOS_ACL_PERM_CREATE_CONT,
+				      DAOS_PC_RW,
+				      POOL_CAPA_READ | POOL_CAPA_CREATE_CONT);
+	srv_acl_resetup(state);
+	expect_group_capas_with_perms(DAOS_ACL_PERM_READ |
+				      DAOS_ACL_PERM_DEL_CONT,
+				      DAOS_PC_RW,
+				      POOL_CAPA_READ | POOL_CAPA_DEL_CONT);
+}
+
+static void
+expect_list_capas_with_perms(uint64_t acl_perms,
+			     uint64_t flags, uint64_t exp_capas)
+{
+	struct daos_acl		*acl;
+	d_iov_t			cred;
+	static const char	*grps[] = { "badgroup@",
+					    TEST_GROUP,
+					    "worsegroup@" };
+
+	/* Only matches group */
+	init_valid_cred(&cred, "fakeuser@", "fakegroup@", grps,
+			sizeof(grps) / sizeof(char *));
+	acl = get_acl_with_perms(0, acl_perms);
+
+	expect_pool_capas_with_acl(acl, &cred, flags, exp_capas);
+
+	daos_acl_free(acl);
+	daos_iov_free(&cred);
+}
+
+static void
+test_pool_get_capas_group_list_success(void **state)
+{
+	expect_list_capas_with_perms(DAOS_ACL_PERM_READ, DAOS_PC_RO,
+				     POOL_CAPA_READ);
+	srv_acl_resetup(state);
+	expect_list_capas_with_perms(DAOS_ACL_PERM_READ | DAOS_ACL_PERM_WRITE,
+				     DAOS_PC_RO, POOL_CAPA_READ);
+	srv_acl_resetup(state);
+	expect_list_capas_with_perms(DAOS_ACL_PERM_READ | DAOS_ACL_PERM_WRITE,
+				     DAOS_PC_RW, POOL_CAPA_READ |
+				     POOL_CAPA_CREATE_CONT |
+				     POOL_CAPA_DEL_CONT);
+	srv_acl_resetup(state);
+	expect_list_capas_with_perms(DAOS_ACL_PERM_READ | DAOS_ACL_PERM_WRITE,
+				     DAOS_PC_EX, POOL_CAPA_READ |
+				     POOL_CAPA_CREATE_CONT |
+				     POOL_CAPA_DEL_CONT);
+	srv_acl_resetup(state);
+	expect_list_capas_with_perms(DAOS_ACL_PERM_READ |
+				     DAOS_ACL_PERM_CREATE_CONT,
+				     DAOS_PC_RW,
+				     POOL_CAPA_READ | POOL_CAPA_CREATE_CONT);
+	srv_acl_resetup(state);
+	expect_list_capas_with_perms(DAOS_ACL_PERM_READ |
+				     DAOS_ACL_PERM_DEL_CONT,
+				     DAOS_PC_RW,
+				     POOL_CAPA_READ | POOL_CAPA_DEL_CONT);
+}
+
+static void
+test_pool_get_capas_owner_overrides_group(void **state)
+{
+	struct daos_acl		*acl;
+	d_iov_t			cred;
+
+	init_default_cred(&cred);
+	acl = get_acl_with_perms(DAOS_ACL_PERM_READ,
+				 DAOS_ACL_PERM_READ | DAOS_ACL_PERM_WRITE);
+
+	/* Owner-specific entry overrides group permissions */
+	expect_pool_capas_with_acl(acl, &cred, DAOS_PC_RW, 0);
+
+	daos_acl_free(acl);
+	daos_iov_free(&cred);
+}
+
+static void
+test_pool_get_capas_no_match(void **state)
+{
+	struct daos_acl		*acl;
+	d_iov_t			cred;
+
+	/* Cred is neither owner user nor owner group */
+	init_valid_cred(&cred, "fakeuser@", "fakegroup@", NULL, 0);
+	acl = get_acl_with_perms(DAOS_ACL_PERM_READ, DAOS_ACL_PERM_READ);
+
+	expect_pool_capas_with_acl(acl, &cred, DAOS_PC_RO, 0);
+
+	daos_acl_free(acl);
+	daos_iov_free(&cred);
+}
+
+static void
+test_pool_get_capas_owner_forbidden(void **state)
+{
+	expect_owner_capas_with_perms(0, DAOS_PC_RO, 0);
+	srv_acl_resetup(state);
+	expect_owner_capas_with_perms(DAOS_ACL_PERM_WRITE, DAOS_PC_RO, 0);
+	srv_acl_resetup(state);
+	expect_owner_capas_with_perms(DAOS_ACL_PERM_READ, DAOS_PC_RW, 0);
+	srv_acl_resetup(state);
+	expect_owner_capas_with_perms(DAOS_ACL_PERM_READ, DAOS_PC_EX, 0);
+	srv_acl_resetup(state);
+	expect_owner_capas_with_perms(DAOS_ACL_PERM_WRITE, DAOS_PC_RW, 0);
+	srv_acl_resetup(state);
+	expect_owner_capas_with_perms(DAOS_ACL_PERM_WRITE, DAOS_PC_EX, 0);
+	srv_acl_resetup(state);
+	expect_owner_capas_with_perms(DAOS_ACL_PERM_CREATE_CONT, DAOS_PC_RW, 0);
+	srv_acl_resetup(state);
+	expect_owner_capas_with_perms(DAOS_ACL_PERM_CREATE_CONT, DAOS_PC_EX, 0);
+	srv_acl_resetup(state);
+	expect_owner_capas_with_perms(DAOS_ACL_PERM_DEL_CONT, DAOS_PC_RW, 0);
+	srv_acl_resetup(state);
+	expect_owner_capas_with_perms(DAOS_ACL_PERM_DEL_CONT, DAOS_PC_EX, 0);
+}
+
+static void
+test_pool_get_capas_group_forbidden(void **state)
+{
+	expect_group_capas_with_perms(0, DAOS_PC_RO, 0);
+	srv_acl_resetup(state);
+	expect_group_capas_with_perms(DAOS_ACL_PERM_WRITE, DAOS_PC_RO, 0);
+	srv_acl_resetup(state);
+	expect_group_capas_with_perms(DAOS_ACL_PERM_READ, DAOS_PC_RW, 0);
+	srv_acl_resetup(state);
+	expect_group_capas_with_perms(DAOS_ACL_PERM_READ, DAOS_PC_EX, 0);
+	srv_acl_resetup(state);
+	expect_group_capas_with_perms(DAOS_ACL_PERM_WRITE, DAOS_PC_RW, 0);
+	srv_acl_resetup(state);
+	expect_group_capas_with_perms(DAOS_ACL_PERM_WRITE, DAOS_PC_EX, 0);
+	srv_acl_resetup(state);
+	expect_group_capas_with_perms(DAOS_ACL_PERM_CREATE_CONT, DAOS_PC_RW, 0);
+	srv_acl_resetup(state);
+	expect_group_capas_with_perms(DAOS_ACL_PERM_CREATE_CONT, DAOS_PC_EX, 0);
+	srv_acl_resetup(state);
+	expect_group_capas_with_perms(DAOS_ACL_PERM_DEL_CONT, DAOS_PC_RW, 0);
+	srv_acl_resetup(state);
+	expect_group_capas_with_perms(DAOS_ACL_PERM_DEL_CONT, DAOS_PC_EX, 0);
+}
+
+static void
+test_pool_get_capas_list_forbidden(void **state)
+{
+	expect_list_capas_with_perms(0, DAOS_PC_RO, 0);
+	srv_acl_resetup(state);
+	expect_list_capas_with_perms(DAOS_ACL_PERM_WRITE, DAOS_PC_RO, 0);
+	srv_acl_resetup(state);
+	expect_list_capas_with_perms(DAOS_ACL_PERM_READ, DAOS_PC_RW, 0);
+	srv_acl_resetup(state);
+	expect_list_capas_with_perms(DAOS_ACL_PERM_READ, DAOS_PC_EX, 0);
+	srv_acl_resetup(state);
+	expect_list_capas_with_perms(DAOS_ACL_PERM_WRITE, DAOS_PC_RW, 0);
+	srv_acl_resetup(state);
+	expect_list_capas_with_perms(DAOS_ACL_PERM_WRITE, DAOS_PC_EX, 0);
+	srv_acl_resetup(state);
+	expect_list_capas_with_perms(DAOS_ACL_PERM_CREATE_CONT, DAOS_PC_RW, 0);
+	srv_acl_resetup(state);
+	expect_list_capas_with_perms(DAOS_ACL_PERM_CREATE_CONT, DAOS_PC_EX, 0);
+	srv_acl_resetup(state);
+	expect_list_capas_with_perms(DAOS_ACL_PERM_DEL_CONT, DAOS_PC_RW, 0);
+	srv_acl_resetup(state);
+	expect_list_capas_with_perms(DAOS_ACL_PERM_DEL_CONT, DAOS_PC_EX, 0);
+}
+
+static void
+test_pool_get_capas_no_owner_entry(void **state)
+{
+	struct daos_acl		*acl;
+	d_iov_t			cred;
+
+	init_default_cred(&cred);
+	acl = get_acl_with_perms(0, DAOS_ACL_PERM_READ);
+	assert_int_equal(daos_acl_remove_ace(&acl, DAOS_ACL_OWNER, NULL), 0);
+
+	/*
+	 * Cred is owner and in owner group, but there's no entry for owner,
+	 * just owner group. Should still get access.
+	 */
+	expect_pool_capas_with_acl(acl, &cred, DAOS_PC_RO, POOL_CAPA_READ);
+
+	daos_acl_free(acl);
+	daos_iov_free(&cred);
+}
+
+static void
+test_pool_get_capas_no_owner_group_entry(void **state)
+{
+	struct daos_acl		*acl;
+	d_iov_t			cred;
+
+	init_valid_cred(&cred, "fakeuser@", TEST_GROUP, NULL, 0);
+	acl = get_acl_with_perms(DAOS_ACL_PERM_READ, DAOS_ACL_PERM_READ);
+	assert_int_equal(daos_acl_remove_ace(&acl, DAOS_ACL_OWNER_GROUP, NULL),
+			 0);
+
+	/*
+	 * Cred is in owner group, but there's no entry for owner group.
+	 * So expecting no capas.
+	 */
+	expect_pool_capas_with_acl(acl, &cred, DAOS_PC_RO, 0);
+
+	daos_acl_free(acl);
+	daos_iov_free(&cred);
+}
+
+static void
+test_pool_get_capas_no_owner_group_entry_list(void **state)
+{
+	struct daos_acl		*acl;
+	d_iov_t			cred;
+	static const char	*grps[] = { TEST_GROUP };
+
+	init_valid_cred(&cred, "fakeuser@", "fakegroup@", grps, 1);
+	acl = get_acl_with_perms(DAOS_ACL_PERM_READ, DAOS_ACL_PERM_READ);
+	assert_int_equal(daos_acl_remove_ace(&acl, DAOS_ACL_OWNER_GROUP, NULL),
+			 0);
+
+	/*
+	 * Cred is in owner group, but there's no entry for owner group.
+	 * User should get no capas.
+	 */
+	expect_pool_capas_with_acl(acl, &cred, DAOS_PC_RO, 0);
+
+	daos_acl_free(acl);
+	daos_iov_free(&cred);
+}
+
+static void
+expect_everyone_capas_with_perms(uint64_t acl_perms,
+				 uint64_t flags,
+				 uint64_t exp_capas)
+{
+	struct daos_acl		*acl;
+	struct daos_ace		*ace;
+	d_iov_t			cred;
+
+	init_valid_cred(&cred, TEST_USER, TEST_GROUP, NULL, 0);
+	ace = daos_ace_create(DAOS_ACL_EVERYONE, NULL);
+	ace->dae_access_types = DAOS_ACL_ACCESS_ALLOW;
+	ace->dae_allow_perms = acl_perms;
+	acl = daos_acl_create(&ace, 1);
+
+	/*
+	 * In owner and owner group... but no entries for them.
+	 * "Everyone" permissions should apply.
+	 */
+	expect_pool_capas_with_acl(acl, &cred, flags, exp_capas);
+
+	daos_acl_free(acl);
+	daos_ace_free(ace);
+	daos_iov_free(&cred);
+}
+
+static void
+test_pool_get_capas_everyone_success(void **state)
+{
+	expect_everyone_capas_with_perms(DAOS_ACL_PERM_READ, DAOS_PC_RO,
+					 POOL_CAPA_READ);
+	srv_acl_resetup(state);
+	expect_everyone_capas_with_perms(DAOS_ACL_PERM_READ |
+					 DAOS_ACL_PERM_WRITE,
+					 DAOS_PC_RO,
+					 POOL_CAPA_READ);
+	srv_acl_resetup(state);
+	expect_everyone_capas_with_perms(DAOS_ACL_PERM_READ |
+					 DAOS_ACL_PERM_WRITE,
+					 DAOS_PC_RW,
+					 POOL_CAPA_READ |
+					 POOL_CAPA_CREATE_CONT |
+					 POOL_CAPA_DEL_CONT);
+	srv_acl_resetup(state);
+	expect_everyone_capas_with_perms(DAOS_ACL_PERM_READ |
+					 DAOS_ACL_PERM_WRITE,
+					 DAOS_PC_EX,
+					 POOL_CAPA_READ |
+					 POOL_CAPA_CREATE_CONT |
+					 POOL_CAPA_DEL_CONT);
+	srv_acl_resetup(state);
+	expect_everyone_capas_with_perms(DAOS_ACL_PERM_READ |
+					 DAOS_ACL_PERM_CREATE_CONT,
+					 DAOS_PC_RW,
+					 POOL_CAPA_READ |
+					 POOL_CAPA_CREATE_CONT);
+	srv_acl_resetup(state);
+	expect_everyone_capas_with_perms(DAOS_ACL_PERM_READ |
+					 DAOS_ACL_PERM_DEL_CONT,
+					 DAOS_PC_RW,
+					 POOL_CAPA_READ |
+					 POOL_CAPA_DEL_CONT);
+}
+
+static void
+test_pool_get_capas_everyone_forbidden(void **state)
+{
+	expect_everyone_capas_with_perms(0, DAOS_PC_RO, 0);
+	srv_acl_resetup(state);
+	expect_everyone_capas_with_perms(DAOS_ACL_PERM_WRITE, DAOS_PC_RO, 0);
+	srv_acl_resetup(state);
+	expect_everyone_capas_with_perms(DAOS_ACL_PERM_READ, DAOS_PC_RW, 0);
+	srv_acl_resetup(state);
+	expect_everyone_capas_with_perms(DAOS_ACL_PERM_READ, DAOS_PC_EX, 0);
+	srv_acl_resetup(state);
+	expect_everyone_capas_with_perms(DAOS_ACL_PERM_WRITE, DAOS_PC_RW, 0);
+	srv_acl_resetup(state);
+	expect_everyone_capas_with_perms(DAOS_ACL_PERM_WRITE, DAOS_PC_EX, 0);
+	srv_acl_resetup(state);
+	expect_everyone_capas_with_perms(DAOS_ACL_PERM_CREATE_CONT, DAOS_PC_RW,
+					 0);
+	srv_acl_resetup(state);
+	expect_everyone_capas_with_perms(DAOS_ACL_PERM_CREATE_CONT, DAOS_PC_EX,
+					 0);
+	srv_acl_resetup(state);
+	expect_everyone_capas_with_perms(DAOS_ACL_PERM_DEL_CONT, DAOS_PC_RW, 0);
+	srv_acl_resetup(state);
+	expect_everyone_capas_with_perms(DAOS_ACL_PERM_DEL_CONT, DAOS_PC_EX, 0);
+}
+
+static void
+test_pool_get_capas_fall_thru_everyone(void **state)
+{
+	struct daos_acl		*acl;
+	struct daos_ace		*ace;
+	d_iov_t			cred;
+	static const char	*grps[] = { "anotherbadgrp@" };
+
+	/* Cred doesn't match owner or group */
+	init_valid_cred(&cred, "baduser@", "badgrp@", grps, 1);
+	/* Owner/group entries exist with no perms */
+	acl = get_acl_with_perms(0, 0);
+
+	/* Everyone entry allowing RW access */
+	ace = daos_ace_create(DAOS_ACL_EVERYONE, NULL);
+	ace->dae_access_types = DAOS_ACL_ACCESS_ALLOW;
+	ace->dae_allow_perms = DAOS_ACL_PERM_READ | DAOS_ACL_PERM_WRITE;
+	assert_int_equal(daos_acl_add_ace(&acl, ace), 0);
+
+	/*
+	 * Cred doesn't match owner/group, falls thru to everyone
+	 */
+	expect_pool_capas_with_acl(acl, &cred, DAOS_PC_RW, POOL_CAPA_READ |
+			      POOL_CAPA_CREATE_CONT | POOL_CAPA_DEL_CONT);
+
+	daos_acl_free(acl);
+	daos_ace_free(ace);
+	daos_iov_free(&cred);
+}
+
+static void
+test_pool_get_capas_user_matches(void **state)
+{
+	struct daos_acl	*acl;
+	struct daos_ace	*ace;
+	d_iov_t		cred;
+	const char	*username = "pooluser@";
+
+	/* Ownership won't match the cred */
+	init_valid_cred(&cred, username, "somegroup@", NULL, 0);
+
+	/* User entry matches our cred */
+	ace = daos_ace_create(DAOS_ACL_USER, username);
+	ace->dae_access_types = DAOS_ACL_ACCESS_ALLOW;
+	ace->dae_allow_perms = DAOS_ACL_PERM_READ | DAOS_ACL_PERM_WRITE;
+	acl = daos_acl_create(&ace, 1);
+
+	expect_pool_capas_with_acl(acl, &cred, DAOS_PC_RW,
+			      POOL_CAPA_READ | POOL_CAPA_CREATE_CONT |
+			      POOL_CAPA_DEL_CONT);
+
+	daos_acl_free(acl);
+	daos_ace_free(ace);
+	daos_iov_free(&cred);
+}
+
+static void
+test_pool_get_capas_user_matches_second(void **state)
+{
+	struct daos_acl	*acl;
+	size_t		num_aces = 2;
+	struct daos_ace	*ace[num_aces];
+	d_iov_t		cred;
+	const char	*username = "pooluser@";
+
+	init_valid_cred(&cred, username, "somegroup@", NULL, 0);
+
+	/* Match is not the first in the list */
+	ace[0] = daos_ace_create(DAOS_ACL_USER, "fakeuser@");
+	ace[0]->dae_access_types = DAOS_ACL_ACCESS_ALLOW;
+	ace[0]->dae_allow_perms = DAOS_ACL_PERM_READ;
+	ace[1] = daos_ace_create(DAOS_ACL_USER, username);
+	ace[1]->dae_access_types = DAOS_ACL_ACCESS_ALLOW;
+	ace[1]->dae_allow_perms = DAOS_ACL_PERM_READ | DAOS_ACL_PERM_WRITE;
+	acl = daos_acl_create(ace, 2);
+
+	expect_pool_capas_with_acl(acl, &cred, DAOS_PC_RW,
+			      POOL_CAPA_READ | POOL_CAPA_CREATE_CONT |
+			      POOL_CAPA_DEL_CONT);
+
+	daos_acl_free(acl);
+	free_ace_list(ace, num_aces);
+	daos_iov_free(&cred);
+}
+
+static void
+test_pool_get_capas_owner_beats_user(void **state)
+{
+	struct daos_acl		*acl;
+	struct daos_ace		*ace;
+	d_iov_t			cred;
+
+	/* Cred user is the owner */
+	init_valid_cred(&cred, TEST_USER, "somegroup@", NULL, 0);
+
+	acl = get_acl_with_perms(DAOS_ACL_PERM_READ, DAOS_ACL_PERM_READ);
+
+	/* User entry matches our cred */
+	ace = daos_ace_create(DAOS_ACL_USER, TEST_USER);
+	ace->dae_access_types = DAOS_ACL_ACCESS_ALLOW;
+	ace->dae_allow_perms = DAOS_ACL_PERM_READ | DAOS_ACL_PERM_WRITE;
+	assert_int_equal(daos_acl_add_ace(&acl, ace), 0);
+
+	/*
+	 * Requesting RW - but owner ACE has RO. Owner overrides named user
+	 * even though both match.
+	 */
+	expect_pool_capas_with_acl(acl, &cred, DAOS_PC_RW, 0);
+
+	daos_acl_free(acl);
+	daos_ace_free(ace);
+	daos_iov_free(&cred);
+}
+
+static void
+test_pool_get_capas_user_beats_owner_grp(void **state)
+{
+	struct daos_acl		*acl;
+	struct daos_ace		*ace;
+	d_iov_t			cred;
+	const char		*username = "someuser@";
+
+	/* Cred group is the owner group */
+	init_valid_cred(&cred, username, TEST_GROUP, NULL, 0);
+
+	acl = get_acl_with_perms(DAOS_ACL_PERM_READ | DAOS_ACL_PERM_WRITE,
+				 DAOS_ACL_PERM_READ | DAOS_ACL_PERM_WRITE);
+
+	/* User entry matches our cred */
+	ace = daos_ace_create(DAOS_ACL_USER, username);
+	ace->dae_access_types = DAOS_ACL_ACCESS_ALLOW;
+	ace->dae_allow_perms = DAOS_ACL_PERM_READ;
+	assert_int_equal(daos_acl_add_ace(&acl, ace), 0);
+
+	/*
+	 * Requesting RW - but user ACE has RO. User overrides owner-group
+	 * even though both match.
+	 * Owner-user doesn't match at all.
+	 */
+	expect_pool_capas_with_acl(acl, &cred, DAOS_PC_RW, 0);
+
+	daos_acl_free(acl);
+	daos_ace_free(ace);
+	daos_iov_free(&cred);
+}
+
+static void
+test_pool_get_capas_grp_matches(void **state)
+{
+	struct daos_acl		*acl;
+	struct daos_ace		*ace;
+	d_iov_t			cred;
+	const char		*grpname = "wonderfulgroup@";
+
+	/* Ownership won't match our creds */
+	init_valid_cred(&cred, "someuser@", grpname, NULL, 0);
+
+	/* Group entry matches our cred */
+	ace = daos_ace_create(DAOS_ACL_GROUP, grpname);
+	ace->dae_access_types = DAOS_ACL_ACCESS_ALLOW;
+	ace->dae_allow_perms = DAOS_ACL_PERM_READ | DAOS_ACL_PERM_WRITE;
+	acl = daos_acl_create(&ace, 1);
+
+	expect_pool_capas_with_acl(acl, &cred, DAOS_PC_RW, POOL_CAPA_READ |
+			      POOL_CAPA_CREATE_CONT | POOL_CAPA_DEL_CONT);
+
+	daos_acl_free(acl);
+	daos_ace_free(ace);
+	daos_iov_free(&cred);
+}
+
+static void
+test_pool_get_capas_grp_matches_second(void **state)
+{
+	struct daos_acl		*acl;
+	size_t			num_aces = 2;
+	struct daos_ace		*ace[num_aces];
+	d_iov_t			cred;
+	const char		*grpname = "wonderfulgroup@";
+
+	/* Ownership won't match our creds */
+	init_valid_cred(&cred, "someuser@", grpname, NULL, 0);
+
+	/* Match is not the first in the list */
+	ace[0] = daos_ace_create(DAOS_ACL_GROUP, "fakegrp@");
+	ace[0]->dae_access_types = DAOS_ACL_ACCESS_ALLOW;
+	ace[0]->dae_allow_perms = DAOS_ACL_PERM_READ;
+	ace[1] = daos_ace_create(DAOS_ACL_GROUP, grpname);
+	ace[1]->dae_access_types = DAOS_ACL_ACCESS_ALLOW;
+	ace[1]->dae_allow_perms = DAOS_ACL_PERM_READ | DAOS_ACL_PERM_WRITE;
+	acl = daos_acl_create(ace, 2);
+
+	expect_pool_capas_with_acl(acl, &cred, DAOS_PC_RW, POOL_CAPA_READ |
+			      POOL_CAPA_CREATE_CONT | POOL_CAPA_DEL_CONT);
+
+	daos_acl_free(acl);
+	free_ace_list(ace, num_aces);
+	daos_iov_free(&cred);
+}
+
+static void
+test_pool_get_capas_grp_matches_multiple(void **state)
+{
+	struct daos_acl		*acl;
+	size_t			num_aces = 2;
+	struct daos_ace		*ace[num_aces];
+	d_iov_t			cred;
+	static const char	*groups[] = { "group1@", "group2@" };
+
+	/* Ownership won't match our creds */
+	init_valid_cred(&cred, "someuser@", "somegroup@", groups, 2);
+
+	/* Both groups in the ACL with different perms - should be unioned */
+	ace[0] = daos_ace_create(DAOS_ACL_GROUP, groups[0]);
+	ace[0]->dae_access_types = DAOS_ACL_ACCESS_ALLOW;
+	ace[0]->dae_allow_perms = DAOS_ACL_PERM_READ;
+	ace[1] = daos_ace_create(DAOS_ACL_GROUP, groups[1]);
+	ace[1]->dae_access_types = DAOS_ACL_ACCESS_ALLOW;
+	ace[1]->dae_allow_perms = DAOS_ACL_PERM_WRITE;
+	acl = daos_acl_create(ace, 2);
+
+	expect_pool_capas_with_acl(acl, &cred, DAOS_PC_RW, POOL_CAPA_READ |
+			      POOL_CAPA_CREATE_CONT | POOL_CAPA_DEL_CONT);
+
+	daos_acl_free(acl);
+	free_ace_list(ace, num_aces);
+	daos_iov_free(&cred);
+}
+
+static void
+test_pool_get_capas_grp_no_match(void **state)
+{
+	struct daos_acl		*acl;
+	size_t			num_aces = 3;
+	struct daos_ace		*ace[num_aces];
+	d_iov_t			cred;
+	static const char	*groups[] = { "group1@", "group2@" };
+
+	/* Not the owner */
+	init_valid_cred(&cred, "someuser@", "somegroup@", groups, 2);
+
+	/* Shouldn't match any of them */
+	ace[0] = daos_ace_create(DAOS_ACL_GROUP, "fakegrp@");
+	ace[0]->dae_access_types = DAOS_ACL_ACCESS_ALLOW;
+	ace[0]->dae_allow_perms = DAOS_ACL_PERM_READ | DAOS_ACL_PERM_WRITE;
+	ace[1] = daos_ace_create(DAOS_ACL_GROUP, "fakegrp2@");
+	ace[1]->dae_access_types = DAOS_ACL_ACCESS_ALLOW;
+	ace[1]->dae_allow_perms = DAOS_ACL_PERM_READ;
+	ace[2] = daos_ace_create(DAOS_ACL_OWNER_GROUP, NULL);
+	ace[2]->dae_access_types = DAOS_ACL_ACCESS_ALLOW;
+	ace[2]->dae_allow_perms = DAOS_ACL_PERM_READ;
+	acl = daos_acl_create(ace, num_aces);
+
+	expect_pool_capas_with_acl(acl, &cred, DAOS_PC_RW, 0);
+
+	daos_acl_free(acl);
+	free_ace_list(ace, num_aces);
+	daos_iov_free(&cred);
+}
+
+static void
+test_pool_get_capas_grp_check_includes_owner(void **state)
+{
+	struct daos_acl		*acl;
+	size_t			num_aces = 2;
+	struct daos_ace		*ace[num_aces];
+	d_iov_t			cred;
+	static const char	*groups[] = { "group1@", "group2@" };
+
+	/* Ownership matches group */
+	init_valid_cred(&cred, "someuser@", TEST_GROUP, groups, 2);
+
+	/* Should get union of owner group and named groups */
+	ace[0] = daos_ace_create(DAOS_ACL_OWNER_GROUP, NULL);
+	ace[0]->dae_access_types = DAOS_ACL_ACCESS_ALLOW;
+	ace[0]->dae_allow_perms = DAOS_ACL_PERM_WRITE;
+	ace[1] = daos_ace_create(DAOS_ACL_GROUP, groups[1]);
+	ace[1]->dae_access_types = DAOS_ACL_ACCESS_ALLOW;
+	ace[1]->dae_allow_perms = DAOS_ACL_PERM_READ;
+	acl = daos_acl_create(ace, 2);
+
+	expect_pool_capas_with_acl(acl, &cred, DAOS_PC_RW, POOL_CAPA_READ |
+			      POOL_CAPA_CREATE_CONT | POOL_CAPA_DEL_CONT);
+
+	daos_acl_free(acl);
+	free_ace_list(ace, num_aces);
+	daos_iov_free(&cred);
+}
+
+static void
+test_pool_get_capas_grps_beat_everyone(void **state)
+{
+	struct daos_acl		*acl;
+	size_t			num_aces = 2;
+	struct daos_ace		*ace[num_aces];
+	d_iov_t			cred;
+	static const char	*groups[] = { "group1@", "group2@" };
+
+	/* Ownership doesn't match */
+	init_valid_cred(&cred, "someuser@", "somegroup@", groups, 2);
+
+	/*
+	 * "Everyone" has more privs than the group, but the matching group
+	 * privileges take priority.
+	 */
+	ace[0] = daos_ace_create(DAOS_ACL_EVERYONE, NULL);
+	ace[0]->dae_access_types = DAOS_ACL_ACCESS_ALLOW;
+	ace[0]->dae_allow_perms = DAOS_ACL_PERM_READ | DAOS_ACL_PERM_WRITE;
+	ace[1] = daos_ace_create(DAOS_ACL_GROUP, groups[1]);
+	ace[1]->dae_access_types = DAOS_ACL_ACCESS_ALLOW;
+	ace[1]->dae_allow_perms = 0;
+	acl = daos_acl_create(ace, 2);
+
+	expect_pool_capas_with_acl(acl, &cred, DAOS_PC_RO, 0);
+
+	daos_acl_free(acl);
+	free_ace_list(ace, num_aces);
+	daos_iov_free(&cred);
+}
+
+/*
+ * Container get capas tests
+ */
+static void
+expect_cont_get_capas_flags_invalid(uint64_t invalid_flags)
+{
+	struct daos_acl		*valid_acl;
+	d_iov_t			valid_cred;
+	struct ownership	valid_owner;
+	uint64_t		result = 0;
+
+	init_default_ownership(&valid_owner);
+	valid_acl = daos_acl_create(NULL, 0);
+	assert_non_null(valid_acl);
+	init_default_cred(&valid_cred);
+
+	printf("Expecting flags 0x%lx invalid\n", invalid_flags);
+	assert_int_equal(ds_sec_cont_get_capabilities(invalid_flags,
+						      &valid_cred,
+						      &valid_owner, valid_acl,
+						      &result),
+			 -DER_INVAL);
+
+	daos_acl_free(valid_acl);
+	daos_iov_free(&valid_cred);
+}
+
+static void
+test_cont_get_capas_invalid_flags(void **state)
+{
+	expect_cont_get_capas_flags_invalid(0);
+	expect_cont_get_capas_flags_invalid(1U << DAOS_COO_NBITS);
+	expect_cont_get_capas_flags_invalid(DAOS_COO_RO | DAOS_COO_RW);
+}
+
+static void
+test_cont_get_capas_null_inputs(void **state)
+{
+	d_iov_t			cred;
+	struct ownership	ownership;
+	struct daos_acl		*acl;
+	uint64_t		result;
+
+	init_default_cred(&cred);
+	init_default_ownership(&ownership);
+	acl = daos_acl_create(NULL, 0);
+
+	assert_int_equal(ds_sec_cont_get_capabilities(DAOS_COO_RO, NULL,
+						      &ownership, acl, &result),
+			 -DER_INVAL);
+	assert_int_equal(ds_sec_cont_get_capabilities(DAOS_COO_RO, &cred,
+						      NULL, acl, &result),
+			 -DER_INVAL);
+	assert_int_equal(ds_sec_cont_get_capabilities(DAOS_COO_RO, &cred,
+						      &ownership, NULL,
+						      &result),
+			 -DER_INVAL);
+	assert_int_equal(ds_sec_cont_get_capabilities(DAOS_COO_RO, &cred,
+						      &ownership, acl, NULL),
+			 -DER_INVAL);
+
+	daos_acl_free(acl);
+	daos_iov_free(&cred);
+}
+
+static void
+expect_cont_get_capas_owner_invalid(char *user, char *group)
+{
+	struct daos_acl		*valid_acl;
+	d_iov_t			valid_cred;
+	struct ownership	invalid_owner;
+	uint64_t		valid_flags = DAOS_PC_RO;
+	uint64_t		result = 0;
+
+	init_default_cred(&valid_cred);
+
+	valid_acl = daos_acl_create(NULL, 0);
+	assert_non_null(valid_acl);
+
+	invalid_owner.user = user;
+	invalid_owner.group = group;
+	assert_int_equal(ds_sec_cont_get_capabilities(valid_flags,
+						      &valid_cred,
+						      &invalid_owner, valid_acl,
+						      &result),
+			 -DER_INVAL);
+
+	daos_acl_free(valid_acl);
+	daos_iov_free(&valid_cred);
+}
+
+static void
+test_cont_get_capas_bad_owner(void **state)
+{
+	expect_cont_get_capas_owner_invalid(NULL, NULL);
+	expect_cont_get_capas_owner_invalid(TEST_USER, NULL);
+	expect_cont_get_capas_owner_invalid(NULL, TEST_GROUP);
+	expect_cont_get_capas_owner_invalid("notavalidname", TEST_GROUP);
+	expect_cont_get_capas_owner_invalid(TEST_USER, "notavalidname");
+}
+
+static void
+test_cont_get_capas_bad_acl(void **state)
+{
+	struct daos_acl		*bad_acl;
+	d_iov_t			cred;
+	struct ownership	ownership;
+	uint64_t		result;
+
+	init_default_cred(&cred);
+	init_default_ownership(&ownership);
+
+	/* zeroed out - not a valid ACL */
+	D_ALLOC(bad_acl, sizeof(struct daos_acl));
+	assert_non_null(bad_acl);
+
+	assert_int_equal(ds_sec_cont_get_capabilities(DAOS_PC_RO, &cred,
+						      &ownership, bad_acl,
+						      &result),
+			 -DER_INVAL);
+
+	D_FREE(bad_acl);
+	daos_iov_free(&cred);
+}
+
+static void
+test_cont_get_capas_bad_cred(void **state)
+{
+	struct daos_acl		*acl;
+	d_iov_t			bad_cred;
+	struct ownership	ownership;
+	uint64_t		result;
+	uint8_t			bad_buf[32];
+	size_t			i;
+	Auth__Credential	cred = AUTH__CREDENTIAL__INIT;
+	Auth__Token		token = AUTH__TOKEN__INIT;
+	uint8_t			*buf;
+	size_t			bufsize;
+
+	init_default_ownership(&ownership);
+
+	acl = daos_acl_create(NULL, 0);
+	assert_non_null(acl);
+
+	/* some random bytes that won't translate to an auth credential */
+	for (i = 0; i < sizeof(bad_buf); i++)
+		bad_buf[i] = (uint8_t)i;
+	d_iov_set(&bad_cred, bad_buf, sizeof(bad_buf));
+
+	assert_int_equal(ds_sec_cont_get_capabilities(DAOS_PC_RO, &bad_cred,
+						      &ownership, acl,
+						      &result),
+			 -DER_INVAL);
+
+	/* null data */
+	d_iov_set(&bad_cred, NULL, 0);
+	assert_int_equal(ds_sec_cont_get_capabilities(DAOS_PC_RO, &bad_cred,
+						      &ownership, acl,
+						      &result),
+			 -DER_INVAL);
+
+	/* Junk in token data */
+	token.flavor = AUTH__FLAVOR__AUTH_SYS;
+	token.data.data = bad_buf;
+	token.data.len = sizeof(bad_buf);
+	cred.token = &token;
+	bufsize = auth__credential__get_packed_size(&cred);
+	D_ALLOC(buf, bufsize);
+	auth__credential__pack(&cred, buf);
+	d_iov_set(&bad_cred, buf, bufsize);
+	assert_int_equal(ds_sec_cont_get_capabilities(DAOS_PC_RO, &bad_cred,
+						      &ownership, acl,
+						      &result),
+			 -DER_PROTO);
+	D_FREE(buf);
+
+	daos_acl_free(acl);
+}
+
+static void
+expect_cont_capas_with_perms(uint64_t acl_perms, uint64_t flags,
+			     uint64_t exp_capas)
+{
+	struct daos_acl		*acl;
+	d_iov_t			cred;
+	struct ownership	ownership;
+	uint64_t		result = -1;
+
+	/* matches owner */
+	init_valid_cred(&cred, TEST_USER, TEST_GROUP, NULL, 0);
+	acl = get_acl_with_perms(acl_perms, 0);
+	init_default_ownership(&ownership);
+
+	printf("Perms: 0x%lx, Flags: 0x%lx\n", acl_perms, flags);
+	assert_int_equal(ds_sec_cont_get_capabilities(flags, &cred, &ownership,
+						      acl, &result),
+			 0);
+
+	assert_int_equal(result, exp_capas);
+
+	daos_acl_free(acl);
+	daos_iov_free(&cred);
+}
+
+static void
+test_cont_get_capas_success(void **state)
+{
+	expect_cont_capas_with_perms(DAOS_ACL_PERM_READ, DAOS_COO_RO,
+				     CONT_CAPA_READ_DATA);
+	expect_cont_capas_with_perms(DAOS_ACL_PERM_GET_PROP, DAOS_COO_RO,
+				     CONT_CAPA_GET_PROP);
+	expect_cont_capas_with_perms(DAOS_ACL_PERM_GET_ACL, DAOS_COO_RO,
+				     CONT_CAPA_GET_ACL);
+	expect_cont_capas_with_perms(DAOS_ACL_PERM_READ | DAOS_ACL_PERM_WRITE,
+				     DAOS_COO_RW,
+				     CONT_CAPA_READ_DATA |
+				     CONT_CAPA_WRITE_DATA);
+	expect_cont_capas_with_perms(DAOS_ACL_PERM_SET_PROP |
+				     DAOS_ACL_PERM_GET_PROP,
+				     DAOS_COO_RW,
+				     CONT_CAPA_SET_PROP |
+				     CONT_CAPA_GET_PROP);
+	expect_cont_capas_with_perms(DAOS_ACL_PERM_SET_ACL |
+				     DAOS_ACL_PERM_GET_ACL |
+				     DAOS_ACL_PERM_SET_OWNER,
+				     DAOS_COO_RW,
+				     CONT_CAPA_SET_ACL |
+				     CONT_CAPA_GET_ACL |
+				     CONT_CAPA_SET_OWNER);
+	expect_cont_capas_with_perms(DAOS_ACL_PERM_CONT_ALL,
+				     DAOS_COO_RW,
+				     CONT_CAPA_READ_DATA |
+				     CONT_CAPA_WRITE_DATA |
+				     CONT_CAPA_SET_PROP |
+				     CONT_CAPA_GET_PROP |
+				     CONT_CAPA_SET_ACL |
+				     CONT_CAPA_GET_ACL |
+				     CONT_CAPA_SET_OWNER);
+	expect_cont_capas_with_perms(DAOS_ACL_PERM_CONT_ALL,
+				     DAOS_COO_RO,
+				     CONT_CAPA_READ_DATA |
+				     CONT_CAPA_GET_PROP |
+				     CONT_CAPA_GET_ACL);
+}
+
+static void
+test_cont_get_capas_denied(void **state)
+{
+	expect_cont_capas_with_perms(0, DAOS_COO_RO, 0);
+	expect_cont_capas_with_perms(0, DAOS_COO_RW, 0);
+	expect_cont_capas_with_perms(DAOS_ACL_PERM_READ, DAOS_COO_RW, 0);
+	expect_cont_capas_with_perms(DAOS_ACL_PERM_GET_PROP, DAOS_COO_RW, 0);
+	expect_cont_capas_with_perms(DAOS_ACL_PERM_GET_ACL, DAOS_COO_RW, 0);
+	expect_cont_capas_with_perms(DAOS_ACL_PERM_WRITE, DAOS_COO_RW, 0);
+	expect_cont_capas_with_perms(DAOS_ACL_PERM_SET_PROP, DAOS_COO_RW, 0);
+	expect_cont_capas_with_perms(DAOS_ACL_PERM_SET_ACL, DAOS_COO_RW, 0);
+	expect_cont_capas_with_perms(DAOS_ACL_PERM_SET_OWNER, DAOS_COO_RW, 0);
+}
+
+/*
+ * Pool access tests
+ */
+static void
+test_pool_can_connect(void **state)
+{
+	assert_false(ds_sec_pool_can_connect(0));
+	assert_false(ds_sec_pool_can_connect(POOL_CAPA_CREATE_CONT |
+					     POOL_CAPA_DEL_CONT));
+
+	assert_true(ds_sec_pool_can_connect(POOL_CAPA_READ));
+	assert_true(ds_sec_pool_can_connect(POOL_CAPA_READ |
+					    POOL_CAPA_CREATE_CONT |
+					    POOL_CAPA_DEL_CONT));
+}
+
 /* Convenience macro for unit tests */
 #define ACL_UTEST(X)	cmocka_unit_test_setup_teardown(X, srv_acl_setup, \
 							srv_acl_teardown)
@@ -1538,42 +1804,48 @@ main(void)
 		ACL_UTEST(test_validate_creds_drpc_response_empty_token),
 		ACL_UTEST(test_validate_creds_drpc_response_bad_status),
 		ACL_UTEST(test_validate_creds_success),
-		ACL_UTEST(test_check_pool_access_null_acl),
-		ACL_UTEST(test_check_pool_access_null_ownership),
-		ACL_UTEST(test_check_pool_access_bad_owner_user),
-		ACL_UTEST(test_check_pool_access_bad_owner_group),
-		ACL_UTEST(test_check_pool_access_null_cred),
-		ACL_UTEST(test_check_pool_access_bad_acl),
-		ACL_UTEST(test_check_pool_access_validate_cred_failed),
-		ACL_UTEST(test_check_pool_access_wrong_flavor),
-		ACL_UTEST(test_check_pool_access_bad_payload),
-		ACL_UTEST(test_check_pool_access_empty_acl),
-		ACL_UTEST(test_check_pool_access_owner_success),
-		ACL_UTEST(test_check_pool_access_group_success),
-		ACL_UTEST(test_check_pool_access_group_list_success),
-		ACL_UTEST(test_check_pool_access_owner_overrides_group),
-		ACL_UTEST(test_check_pool_access_no_match),
-		ACL_UTEST(test_check_pool_access_owner_forbidden),
-		ACL_UTEST(test_check_pool_access_group_forbidden),
-		ACL_UTEST(test_check_pool_access_list_forbidden),
-		ACL_UTEST(test_check_pool_access_no_owner_entry),
-		ACL_UTEST(test_check_pool_access_no_owner_group_entry),
-		ACL_UTEST(test_check_pool_access_no_owner_group_entry_list),
-		ACL_UTEST(test_check_pool_access_everyone_success),
-		ACL_UTEST(test_check_pool_access_everyone_forbidden),
-		ACL_UTEST(test_check_pool_access_fall_thru_everyone),
-		ACL_UTEST(test_check_pool_access_user_matches),
-		ACL_UTEST(test_check_pool_access_user_matches_second),
-		ACL_UTEST(test_check_pool_access_owner_beats_user),
-		ACL_UTEST(test_check_pool_access_user_beats_owner_grp),
-		ACL_UTEST(test_check_pool_access_grp_matches),
-		ACL_UTEST(test_check_pool_access_grp_matches_second),
-		ACL_UTEST(test_check_pool_access_grp_matches_multiple),
-		ACL_UTEST(test_check_pool_access_grp_no_match),
-		ACL_UTEST(test_check_pool_access_grp_check_includes_owner),
-		ACL_UTEST(test_check_pool_access_grps_beat_everyone),
 		cmocka_unit_test(test_default_pool_acl),
 		cmocka_unit_test(test_default_cont_acl),
+		ACL_UTEST(test_pool_get_capas_invalid_flags),
+		ACL_UTEST(test_pool_get_capas_null_input),
+		ACL_UTEST(test_pool_get_capas_bad_owner),
+		ACL_UTEST(test_pool_get_capas_bad_acl),
+		ACL_UTEST(test_pool_get_capas_validate_cred_failed),
+		ACL_UTEST(test_pool_get_capas_wrong_flavor),
+		ACL_UTEST(test_pool_get_capas_bad_payload),
+		ACL_UTEST(test_pool_get_capas_empty_acl),
+		ACL_UTEST(test_pool_get_capas_owner_success),
+		ACL_UTEST(test_pool_get_capas_group_success),
+		ACL_UTEST(test_pool_get_capas_group_list_success),
+		ACL_UTEST(test_pool_get_capas_owner_overrides_group),
+		ACL_UTEST(test_pool_get_capas_no_match),
+		ACL_UTEST(test_pool_get_capas_owner_forbidden),
+		ACL_UTEST(test_pool_get_capas_group_forbidden),
+		ACL_UTEST(test_pool_get_capas_list_forbidden),
+		ACL_UTEST(test_pool_get_capas_no_owner_entry),
+		ACL_UTEST(test_pool_get_capas_no_owner_group_entry),
+		ACL_UTEST(test_pool_get_capas_no_owner_group_entry_list),
+		ACL_UTEST(test_pool_get_capas_everyone_success),
+		ACL_UTEST(test_pool_get_capas_everyone_forbidden),
+		ACL_UTEST(test_pool_get_capas_fall_thru_everyone),
+		ACL_UTEST(test_pool_get_capas_user_matches),
+		ACL_UTEST(test_pool_get_capas_user_matches_second),
+		ACL_UTEST(test_pool_get_capas_owner_beats_user),
+		ACL_UTEST(test_pool_get_capas_user_beats_owner_grp),
+		ACL_UTEST(test_pool_get_capas_grp_matches),
+		ACL_UTEST(test_pool_get_capas_grp_matches_second),
+		ACL_UTEST(test_pool_get_capas_grp_matches_multiple),
+		ACL_UTEST(test_pool_get_capas_grp_no_match),
+		ACL_UTEST(test_pool_get_capas_grp_check_includes_owner),
+		ACL_UTEST(test_pool_get_capas_grps_beat_everyone),
+		cmocka_unit_test(test_cont_get_capas_invalid_flags),
+		cmocka_unit_test(test_cont_get_capas_null_inputs),
+		cmocka_unit_test(test_cont_get_capas_bad_owner),
+		cmocka_unit_test(test_cont_get_capas_bad_acl),
+		cmocka_unit_test(test_cont_get_capas_bad_cred),
+		cmocka_unit_test(test_cont_get_capas_success),
+		cmocka_unit_test(test_cont_get_capas_denied),
+		cmocka_unit_test(test_pool_can_connect),
 	};
 
 	return cmocka_run_group_tests(tests, NULL, NULL);


### PR DESCRIPTION
This patch adds new functions to get access capabilities
for pools and containers based on their ACL, ownership,
the caller's user credential, and request flags.

- Add new bitmasks for pool and container security
  capabilities.
- Replace the previous pool access check with new method
  ds_sec_pool_get_capabilities.
- Save the pool security capabilities in the pool handle
  on the server side. They are not exposed to the client.
- Rename internal usages of the old "capas" to "flags" to
  better describe their function and differentiate from
  the security capas.
- Add ds_sec_cont_get_capabilities to allow similar
  functionality for containers in future, although it is
  not yet used.
- Add ds_sec_pool_can_connect to verify pool connections
  based on access capabilities.

Signed-off-by: Kris Jacque <kristin.jacque@intel.com>


Requesting exception as only test failures were due to a post provisioning bug in pipeline-lib https://github.com/daos-stack/pipeline-lib/commit/62633799c9795169a5806390ef443bfbcb238d65
