### PR TITLE
DAOS-1965 md: re-enable metadata add/remove test

### DIFF
--- a/src/tests/ftest/server/metadata.py
+++ b/src/tests/ftest/server/metadata.py
@@ -163,7 +163,7 @@ class ObjectMetadata(TestWithServers):
         Use Cases:
             ?
 
-        :avocado: tags=metadata,metadata_free_space,nvme,small,hw
+        :avocado: tags=metadata,metadata_free_space,nvme,medium,hw
         :avocado: tags=full_regression
         """
         self.pool.pool.connect(2)

--- a/src/tests/ftest/server/metadata.py
+++ b/src/tests/ftest/server/metadata.py
@@ -153,7 +153,6 @@ class ObjectMetadata(TestWithServers):
 
         self.fail("Test was expected to fail but it passed.\n")
 
-    @skipForTicket("DAOS-1965")
     @avocado.fail_on(DaosApiError)
     def test_metadata_addremove(self):
         """JIRA ID: DAOS-1512.
@@ -164,18 +163,19 @@ class ObjectMetadata(TestWithServers):
         Use Cases:
             ?
 
-        :avocado: tags=metadata,metadata_free_space,nvme,small
+        :avocado: tags=metadata,metadata_free_space,nvme,small,hw
+        :avocado: tags=full_regression
         """
         self.pool.pool.connect(2)
         for k in range(10):
             container_array = []
-            self.d_log.debug("Container Create Iteration {}".format(k))
+            self.log.info("Container Create Iteration %d / 9", k)
             for cont in range(NO_OF_MAX_CONTAINER):
                 container = DaosContainer(self.context)
                 container.create(self.pool.pool.handle)
                 container_array.append(container)
 
-            self.d_log.debug("Container Remove Iteration {} ".format(k))
+            self.log.info("Container Remove Iteration %d / 9", k)
             for cont in container_array:
                 cont.destroy()
 

--- a/src/tests/ftest/server/metadata.yaml
+++ b/src/tests/ftest/server/metadata.yaml
@@ -9,7 +9,13 @@ hosts:
     - client-C
 timeout: 1800
 server_config:
-   name: daos_server
+  name: daos_server
+  servers_per_host: 1
+  servers:
+    0:
+      log_mask: ERR
+      env_vars:
+        - DAOS_MD_CAP=128
 pool:
   createmode:
     mode: 511


### PR DESCRIPTION
Cherry picked commit b8987a8dbee3cf00f32dacf96cd271a94c916898 PR #1887
from daos master branch to release/0.9 branch.

With this change the skipForTest decorator is removed from the server
metadata test function test_metadata_addremove(). Successful testing
is now possible due to PR #1635 that enabled rdb log compaction.

Skip-run_test: true
Skip-func-test: true
Skip-func-hw-test-medium: true
Skip-func-hw-test-large: true
Test-tag-hw-small: metadata_free_space

Signed-off-by: Ken Cain <kenneth.c.cain@intel.com>