### PR TITLE
DAOS-4208 control: agent uses wrong config file by default

### DIFF
--- a/src/control/cmd/agent/main.go
+++ b/src/control/cmd/agent/main.go
@@ -46,6 +46,7 @@ var daosVersion string
 const (
 	agentSockName        = "agent.sock"
 	daosAgentDrpcSockEnv = "DAOS_AGENT_DRPC_DIR"
+	defaultConfigPath    = "../etc/daos_agent.yml"
 )
 
 type cliOptions struct {
@@ -126,6 +127,11 @@ func agentMain(log *logging.LeveledLogger, opts *cliOptions) error {
 
 	ctx, shutdown := context.WithCancel(context.Background())
 	defer shutdown()
+
+	// populate default agent config file path
+	if opts.ConfigPath == "" {
+		opts.ConfigPath = defaultConfigPath
+	}
 
 	// Load the configuration file using the supplied path or the
 	// default path if none provided.


### PR DESCRIPTION
Agent should by default parse daos_agent.yml, instead, daos.yml is
currently being used by default as specified in the imported client
package.

Set correct default in agent main() if no config file path is entered on
the commandline.

Signed-off-by: Tom Nabarro <tom.nabarro@intel.com>