### PR TITLE
DAOS-4100 vea: Direct key for persistent free extent tree

### DIFF
--- a/src/iosrv/init.c
+++ b/src/iosrv/init.c
@@ -124,7 +124,7 @@ register_dbtree_classes(void)
 	}
 
 	rc = dbtree_class_register(DBTREE_CLASS_IV,
-				   BTR_FEAT_UINT_KEY /* feats */,
+				   BTR_FEAT_UINT_KEY | BTR_FEAT_DIRECT_KEY,
 				   &dbtree_iv_ops);
 	if (rc != 0) {
 		D_ERROR("failed to register DBTREE_CLASS_IV: "DF_RC"\n",

--- a/src/vea/tests/vea_ut.c
+++ b/src/vea/tests/vea_ut.c
@@ -497,7 +497,7 @@ vea_ut_setup(void **state)
 		return rc;
 
 	rc = dbtree_class_register(DBTREE_CLASS_IV,
-				   BTR_FEAT_UINT_KEY,
+				   BTR_FEAT_UINT_KEY | BTR_FEAT_DIRECT_KEY,
 				   &dbtree_iv_ops);
 	if (rc != 0 && rc != -DER_EXIST) {
 		fprintf(stderr, "register DBTREE_CLASS_IV error %d\n", rc);

--- a/src/vea/vea_alloc.c
+++ b/src/vea/vea_alloc.c
@@ -438,19 +438,12 @@ persistent_alloc(struct vea_space_info *vsi, struct vea_free_extent *vfe)
 				return rc;
 		}
 	} else if (found_end > vfe_end) {
-		/* Adjust the in-tree integer key */
-		rc = umem_tx_add_ptr(vsi->vsi_umem, blk_off, sizeof(*blk_off));
-		if (rc)
-			return rc;
-
-		*blk_off = vfe->vfe_blk_off + vfe->vfe_blk_cnt;
-
-		/* Adjust the in-tree extent offset */
+		/* Adjust the in-tree extent offset & length */
 		rc = umem_tx_add_ptr(vsi->vsi_umem, found, sizeof(*found));
 		if (rc)
 			return rc;
 
-		found->vfe_blk_off = *blk_off;
+		found->vfe_blk_off = vfe->vfe_blk_off + vfe->vfe_blk_cnt;
 		found->vfe_blk_cnt = found_end - vfe_end;
 		rc = daos_gettime_coarse(&found->vfe_age);
 		if (rc)

--- a/src/vea/vea_api.c
+++ b/src/vea/vea_api.c
@@ -143,8 +143,9 @@ vea_format(struct umem_instance *umem, struct umem_tx_stage_data *txd,
 	/* Create free extent tree */
 	uma.uma_id = umem->umm_id;
 	uma.uma_pool = umem->umm_pool;
-	rc = dbtree_create_inplace(DBTREE_CLASS_IV, 0, VEA_TREE_ODR, &uma,
-				   &md->vsd_free_tree, &free_btr);
+	rc = dbtree_create_inplace(DBTREE_CLASS_IV, BTR_FEAT_DIRECT_KEY,
+				   VEA_TREE_ODR, &uma, &md->vsd_free_tree,
+				   &free_btr);
 	if (rc != 0)
 		goto out;
 
@@ -163,8 +164,9 @@ vea_format(struct umem_instance *umem, struct umem_tx_stage_data *txd,
 		goto out;
 
 	/* Create extent vector tree */
-	rc = dbtree_create_inplace(DBTREE_CLASS_IV, 0, VEA_TREE_ODR, &uma,
-				   &md->vsd_vec_tree, &vec_btr);
+	rc = dbtree_create_inplace(DBTREE_CLASS_IV, BTR_FEAT_DIRECT_KEY,
+				   VEA_TREE_ODR, &uma, &md->vsd_vec_tree,
+				   &vec_btr);
 	if (rc != 0)
 		goto out;
 
@@ -254,20 +256,20 @@ vea_load(struct umem_instance *umem, struct umem_tx_stage_data *txd,
 	memset(&uma, 0, sizeof(uma));
 	uma.uma_id = UMEM_CLASS_VMEM;
 	/* Create in-memory free extent tree */
-	rc = dbtree_create(DBTREE_CLASS_IV, 0, VEA_TREE_ODR, &uma,
-			   NULL, &vsi->vsi_free_btr);
+	rc = dbtree_create(DBTREE_CLASS_IV, BTR_FEAT_UINT_KEY, VEA_TREE_ODR,
+			   &uma, NULL, &vsi->vsi_free_btr);
 	if (rc != 0)
 		goto error;
 
 	/* Create in-memory extent vector tree */
-	rc = dbtree_create(DBTREE_CLASS_IV, 0, VEA_TREE_ODR, &uma,
-			   NULL, &vsi->vsi_vec_btr);
+	rc = dbtree_create(DBTREE_CLASS_IV, BTR_FEAT_UINT_KEY, VEA_TREE_ODR,
+			   &uma, NULL, &vsi->vsi_vec_btr);
 	if (rc != 0)
 		goto error;
 
 	/* Create in-memory aggregation tree */
-	rc = dbtree_create(DBTREE_CLASS_IV, 0, VEA_TREE_ODR, &uma,
-			   NULL, &vsi->vsi_agg_btr);
+	rc = dbtree_create(DBTREE_CLASS_IV, BTR_FEAT_UINT_KEY, VEA_TREE_ODR,
+			   &uma, NULL, &vsi->vsi_agg_btr);
 	if (rc != 0)
 		goto error;
 
@@ -562,6 +564,13 @@ done:
 	if (rc == 0)
 		migrate_free_exts(vsi);
 error:
+	/*
+	 * -DER_NONEXIST or -DER_ENOENT could be ignored by some caller,
+	 * let's convert them to more serious error here.
+	 */
+	if (rc == -DER_NONEXIST || rc == -DER_ENOENT)
+		rc = -DER_INVAL;
+
 	if (fca != NULL)
 		D_FREE(fca);
 	return rc;

--- a/src/vea/vea_free.c
+++ b/src/vea/vea_free.c
@@ -114,7 +114,7 @@ repeat:
 		else if (type == VEA_TYPE_AGGREGATE)
 			d_list_del_init(&entry->ve_link);
 
-		rc = dbtree_delete(btr_hdl, BTR_PROBE_EQ, &key_out, NULL);
+		rc = dbtree_delete(btr_hdl, BTR_PROBE_BYPASS, &key_out, NULL);
 		if (rc)
 			return rc;
 	}

--- a/src/vos/vos_common.c
+++ b/src/vos/vos_common.c
@@ -288,7 +288,7 @@ vos_nvme_init(void)
 
 	/* IV tree used by VEA */
 	rc = dbtree_class_register(DBTREE_CLASS_IV,
-				   BTR_FEAT_UINT_KEY,
+				   BTR_FEAT_UINT_KEY | BTR_FEAT_DIRECT_KEY,
 				   &dbtree_iv_ops);
 	if (rc != 0 && rc != -DER_EXIST)
 		return rc;


### PR DESCRIPTION
The allocation optimization commit 33ed9655 modifies in-tree key
directly, that could corrupt the persistent free extent tree after
the tree re-balanced after insertions & deletions.

This patch changed DBTREE_CLASS_IV to make it support both integer
key and direct key, and used direct key for the VEA persistent
free extent tree, so that the in-tree modification will be safe.

vea_free() could error out for -DER_NONEXIST and abort transaction,
however, some vea_free() caller like evt_delete() sometimes may
want to ignore the -DER_NOEXIST error, this patch converted the
-DER_NONEXIST & -DER_ENOENT error from vea_free() into -DER_INVAL.

Signed-off-by: Niu Yawei <yawei.niu@intel.com>