### PR TITLE
DAOS-4100 container: integer overflow on sleep time

### DIFF
--- a/src/container/srv_target.c
+++ b/src/container/srv_target.c
@@ -75,6 +75,12 @@ cont_aggregate_runnable(struct ds_cont_child *cont)
 {
 	struct ds_pool	*pool = cont->sc_pool->spc_pool;
 
+	/* snapshot list isn't fetched yet */
+	if (cont->sc_aggregation_max == 0) {
+		D_DEBUG(DB_EPC, "No aggregation before snapshots fetched\n");
+		return false;
+	}
+
 	if ((pool->sp_reclaim == DAOS_RECLAIM_DISABLED) ||
 	    (pool->sp_reclaim == DAOS_RECLAIM_LAZY && dss_xstream_is_busy()))
 		return false;
@@ -96,14 +102,9 @@ cont_child_aggregate(struct ds_cont_child *cont, uint64_t *sleep)
 	int			tgt_id = dss_get_module_info()->dmi_tgt_id;
 	int			i, rc;
 
-	if (!cont_aggregate_runnable(cont)) {
-		*sleep = NSEC_PER_SEC << 2;
-		return 0;
-	}
-
-	*sleep = NSEC_PER_SEC;
-	/* snapshot list isn't fetched yet */
-	if (cont->sc_aggregation_max == 0)
+	/* Check if it's ok to start aggregation in every 2 seconds */
+	*sleep = 2ULL * NSEC_PER_SEC;
+	if (!cont_aggregate_runnable(cont))
 		return 0;
 
 	/*

--- a/src/include/daos_srv/daos_server.h
+++ b/src/include/daos_srv/daos_server.h
@@ -470,6 +470,8 @@ struct dss_rpc_cntr {
 	 * workload.
 	 */
 	uint64_t		rc_stime;
+	/* the time when processing last active RPC */
+	uint64_t		rc_active_time;
 	/** number of active RPCs */
 	uint64_t		rc_active;
 	/** total number of processed RPCs since \a rc_stime */


### PR DESCRIPTION
There is an integer overflow in cont aggregation code which leads
to the aggregation ULT being put to sleep for a very long time.

This patch also changed the criterion of dss_xstream_is_busy() to
"No IO requests in 5 seconds" instead of "No active requests in
this moment", because even if there is continuous IO flow from
client, the active request counter could be 0 at certain point,
that may result in the aggregation being triggered unexpectedly.

Signed-off-by: Niu Yawei <yawei.niu@intel.com>