### PR TITLE
DAOS-4145 tests: Run Functional HW tests on different cluster sizes (#1896)

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1327,7 +1327,7 @@ pipeline {
                                            export DAOS_TARGET_OVERSUBSCRIBE=1
                                            rm -rf install/lib/daos/TESTING/ftest/avocado ./*_results.xml
                                            mkdir -p install/lib/daos/TESTING/ftest/avocado/job-results
-                                           ./ftest.sh "$test_tag" $tnodes''',
+                                           ./ftest.sh "$test_tag" $tnodes "auto:Optane"''',
                                 junit_files: "install/lib/daos/TESTING/ftest/avocado/*/*/*.xml install/lib/daos/TESTING/ftest/*_results.xml",
                                 failure_artifacts: 'Functional'
                     }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1065,7 +1065,7 @@ pipeline {
                                            mkdir -p install/lib/daos/TESTING/ftest/avocado/job-results
                                            ./ftest.sh "$test_tag" $tnodes''',
                                 junit_files: "install/lib/daos/TESTING/ftest/avocado/*/*/*.xml install/lib/daos/TESTING/ftest/*_results.xml",
-                                failure_artifacts: env.STAGE_NAME
+                                failure_artifacts: 'Functional'
                     }
                     post {
                         always {
@@ -1073,25 +1073,20 @@ pipeline {
                                   # Remove the latest avocado symlink directory to avoid inclusion in the
                                   # jenkins build artifacts
                                   unlink install/lib/daos/TESTING/ftest/avocado/job-results/latest
-                                  if [ -n "$STAGE_NAME" ]; then
-                                      rm -rf "$STAGE_NAME/"
-                                      mkdir "$STAGE_NAME/"
-                                      # compress those potentially huge DAOS logs
-                                      if daos_logs=$(ls install/lib/daos/TESTING/ftest/avocado/job-results/*/daos_logs/*); then
-                                          lbzip2 $daos_logs
-                                      fi
-                                      arts="$arts$(ls *daos{,_agent}.log* 2>/dev/null)" && arts="$arts"$'\n'
-                                      arts="$arts$(ls -d install/lib/daos/TESTING/ftest/avocado/job-results/* 2>/dev/null)" && arts="$arts"$'\n'
-                                      arts="$arts$(ls install/lib/daos/TESTING/ftest/*.stacktrace 2>/dev/null || true)"
-                                      if [ -n "$arts" ]; then
-                                          mv $(echo $arts | tr '\n' ' ') "$STAGE_NAME/"
-                                      fi
-                                  else
-                                      echo "The STAGE_NAME environment variable is missing!"
-                                      false
+                                  rm -rf "Functional/"
+                                  mkdir "Functional/"
+                                  # compress those potentially huge DAOS logs
+                                  if daos_logs=$(ls install/lib/daos/TESTING/ftest/avocado/job-results/*/daos_logs/*); then
+                                      lbzip2 $daos_logs
+                                  fi
+                                  arts="$arts$(ls *daos{,_agent}.log* 2>/dev/null)" && arts="$arts"$'\n'
+                                  arts="$arts$(ls -d install/lib/daos/TESTING/ftest/avocado/job-results/* 2>/dev/null)" && arts="$arts"$'\n'
+                                  arts="$arts$(ls install/lib/daos/TESTING/ftest/*.stacktrace 2>/dev/null || true)"
+                                  if [ -n "$arts" ]; then
+                                      mv $(echo $arts | tr '\n' ' ') "Functional/"
                                   fi'''
-                            archiveArtifacts artifacts: env.STAGE_NAME + '/**'
-                            junit env.STAGE_NAME + '/*/results.xml, install/lib/daos/TESTING/ftest/*_results.xml'
+                            archiveArtifacts artifacts: 'Functional/**'
+                            junit 'Functional/*/results.xml, install/lib/daos/TESTING/ftest/*_results.xml'
                         }
                         /* temporarily moved into runTest->stepResult due to JENKINS-39203
                         success {
@@ -1115,17 +1110,197 @@ pipeline {
                         */
                     }
                 }
-                stage('Functional_Hardware') {
+                stage('Functional_Hardware_Small') {
                     when {
                         beforeAgent true
                         allOf {
                             expression { env.DAOS_STACK_CI_HARDWARE_SKIP != 'true' }
                             expression {
-                              ! commitPragma(pragma: 'Skip-func-hw-test').contains('true')
+                                ! commitPragma(pragma: 'Skip-func-hw-test').contains('true')
+                            }
+                            expression {
+                                ! commitPragma(pragma: 'Skip-func-hw-test-small').contains('true')
                             }
                         }
                     }
                     agent {
+                        // 2 node cluster with 1 IB/node + 1 test control node
+                        label 'ci_nvme3'
+                    }
+                    steps {
+                        unstash 'CentOS-rpm-version'
+                        script {
+                            daos_packages_version = readFile('centos7-rpm-version').trim()
+                        }
+                        // Just reboot the physical nodes
+                        provisionNodes NODELIST: env.NODELIST,
+                                       node_count: 3,
+                                       power_only: true,
+                                       inst_repos: el7_daos_repos,
+                                       inst_rpms: 'daos-' + daos_packages_version +
+                                                  ' daos-client-' + daos_packages_version +
+                                                  ' cart-' + env.CART_COMMIT + ' ' +
+                                                  functional_rpms
+                        runTest stashes: [ 'CentOS-install', 'CentOS-build-vars' ],
+                                script: '''test_tag=$(git show -s --format=%B | sed -ne "/^Test-tag-hw-small:/s/^.*: *//p")
+                                           if [ -z "$test_tag" ]; then
+                                               test_tag=pr,hw,small
+                                           fi
+                                           tnodes=$(echo $NODELIST | cut -d ',' -f 1-3)
+                                           # set DAOS_TARGET_OVERSUBSCRIBE env here
+                                           export DAOS_TARGET_OVERSUBSCRIBE=1
+                                           rm -rf install/lib/daos/TESTING/ftest/avocado ./*_results.xml
+                                           mkdir -p install/lib/daos/TESTING/ftest/avocado/job-results
+                                           ./ftest.sh "$test_tag" $tnodes "auto:Optane"''',
+                                junit_files: "install/lib/daos/TESTING/ftest/avocado/*/*/*.xml install/lib/daos/TESTING/ftest/*_results.xml",
+                                failure_artifacts: 'Functional'
+                    }
+                    post {
+                        always {
+                            sh '''rm -rf install/lib/daos/TESTING/ftest/avocado/*/*/html/
+                                  # Remove the latest avocado symlink directory to avoid inclusion in the
+                                  # jenkins build artifacts
+                                  unlink install/lib/daos/TESTING/ftest/avocado/job-results/latest
+                                  rm -rf "Functional/"
+                                  mkdir "Functional/"
+                                  # compress those potentially huge DAOS logs
+                                  if daos_logs=$(ls install/lib/daos/TESTING/ftest/avocado/job-results/*/daos_logs/*); then
+                                      lbzip2 $daos_logs
+                                  fi
+                                  arts="$arts$(ls *daos{,_agent}.log* 2>/dev/null)" && arts="$arts"$'\n'
+                                  arts="$arts$(ls -d install/lib/daos/TESTING/ftest/avocado/job-results/* 2>/dev/null)" && arts="$arts"$'\n'
+                                  arts="$arts$(ls install/lib/daos/TESTING/ftest/*.stacktrace 2>/dev/null || true)"
+                                  if [ -n "$arts" ]; then
+                                      mv $(echo $arts | tr '\n' ' ') "Functional/"
+                                  fi'''
+                            archiveArtifacts artifacts: 'Functional/**'
+                            junit 'Functional/*/results.xml, install/lib/daos/TESTING/ftest/*_results.xml'
+                        }
+                        /* temporarily moved into runTest->stepResult due to JENKINS-39203
+                        success {
+                            githubNotify credentialsId: 'daos-jenkins-commit-status',
+                                         description: env.STAGE_NAME,
+                                         context: 'test/' + env.STAGE_NAME,
+                                         status: 'SUCCESS'
+                        }
+                        unstable {
+                            githubNotify credentialsId: 'daos-jenkins-commit-status',
+                                         description: env.STAGE_NAME,
+                                         context: 'test/' + env.STAGE_NAME,
+                                         status: 'FAILURE'
+                        }
+                        failure {
+                            githubNotify credentialsId: 'daos-jenkins-commit-status',
+                                         description: env.STAGE_NAME,
+                                         context: 'test/' + env.STAGE_NAME,
+                                         status: 'ERROR'
+                        }
+                        */
+                    }
+                }
+                stage('Functional_Hardware_Medium') {
+                    when {
+                        beforeAgent true
+                        allOf {
+                            expression { env.DAOS_STACK_CI_HARDWARE_SKIP != 'true' }
+                            expression {
+                                ! commitPragma(pragma: 'Skip-func-hw-test').contains('true')
+                            }
+                            expression {
+                                ! commitPragma(pragma: 'Skip-func-hw-test-medium').contains('true')
+                            }
+                        }
+                    }
+                    agent {
+                        // 4 node cluster with 2 IB/node + 1 test control node
+                        label 'ci_nvme5'
+                    }
+                    steps {
+                        unstash 'CentOS-rpm-version'
+                        script {
+                            daos_packages_version = readFile('centos7-rpm-version').trim()
+                        }
+                        // Just reboot the physical nodes
+                        provisionNodes NODELIST: env.NODELIST,
+                                       node_count: 5,
+                                       power_only: true,
+                                       inst_repos: el7_daos_repos,
+                                       inst_rpms: 'daos-' + daos_packages_version +
+                                                  ' daos-client-' + daos_packages_version +
+                                                  ' cart-' + env.CART_COMMIT + ' ' +
+                                                  functional_rpms
+                        runTest stashes: [ 'CentOS-install', 'CentOS-build-vars' ],
+                                script: '''test_tag=$(git show -s --format=%B | sed -ne "/^Test-tag-hw-medium:/s/^.*: *//p")
+                                           if [ -z "$test_tag" ]; then
+                                               test_tag=pr,hw,medium,ib2
+                                           fi
+                                           tnodes=$(echo $NODELIST | cut -d ',' -f 1-5)
+                                           # set DAOS_TARGET_OVERSUBSCRIBE env here
+                                           export DAOS_TARGET_OVERSUBSCRIBE=1
+                                           rm -rf install/lib/daos/TESTING/ftest/avocado ./*_results.xml
+                                           mkdir -p install/lib/daos/TESTING/ftest/avocado/job-results
+                                           ./ftest.sh "$test_tag" $tnodes "auto:Optane"''',
+                                junit_files: "install/lib/daos/TESTING/ftest/avocado/*/*/*.xml install/lib/daos/TESTING/ftest/*_results.xml",
+                                failure_artifacts: 'Functional'
+                    }
+                    post {
+                        always {
+                            sh '''rm -rf install/lib/daos/TESTING/ftest/avocado/*/*/html/
+                                  # Remove the latest avocado symlink directory to avoid inclusion in the
+                                  # jenkins build artifacts
+                                  unlink install/lib/daos/TESTING/ftest/avocado/job-results/latest
+                                  rm -rf "Functional/"
+                                  mkdir "Functional/"
+                                  # compress those potentially huge DAOS logs
+                                  if daos_logs=$(ls install/lib/daos/TESTING/ftest/avocado/job-results/*/daos_logs/*); then
+                                      lbzip2 $daos_logs
+                                  fi
+                                  arts="$arts$(ls *daos{,_agent}.log* 2>/dev/null)" && arts="$arts"$'\n'
+                                  arts="$arts$(ls -d install/lib/daos/TESTING/ftest/avocado/job-results/* 2>/dev/null)" && arts="$arts"$'\n'
+                                  arts="$arts$(ls install/lib/daos/TESTING/ftest/*.stacktrace 2>/dev/null || true)"
+                                  if [ -n "$arts" ]; then
+                                      mv $(echo $arts | tr '\n' ' ') "Functional/"
+                                  fi'''
+                            archiveArtifacts artifacts: 'Functional/**'
+                            junit 'Functional/*/results.xml, install/lib/daos/TESTING/ftest/*_results.xml'
+                        }
+                        /* temporarily moved into runTest->stepResult due to JENKINS-39203
+                        success {
+                            githubNotify credentialsId: 'daos-jenkins-commit-status',
+                                         description: env.STAGE_NAME,
+                                         context: 'test/' + env.STAGE_NAME,
+                                         status: 'SUCCESS'
+                        }
+                        unstable {
+                            githubNotify credentialsId: 'daos-jenkins-commit-status',
+                                         description: env.STAGE_NAME,
+                                         context: 'test/' + env.STAGE_NAME,
+                                         status: 'FAILURE'
+                        }
+                        failure {
+                            githubNotify credentialsId: 'daos-jenkins-commit-status',
+                                         description: env.STAGE_NAME,
+                                         context: 'test/' + env.STAGE_NAME,
+                                         status: 'ERROR'
+                        }
+                        */
+                    }
+                }
+                stage('Functional_Hardware_Large') {
+                    when {
+                        beforeAgent true
+                        allOf {
+                            expression { env.DAOS_STACK_CI_HARDWARE_SKIP != 'true' }
+                            expression {
+                                ! commitPragma(pragma: 'Skip-func-hw-test').contains('true')
+                            }
+                            expression {
+                                ! commitPragma(pragma: 'Skip-func-hw-test-large').contains('true')
+                            }
+                        }
+                    }
+                    agent {
+                        // 8+ node cluster with 1 IB/node + 1 test control node
                         label 'ci_nvme9'
                     }
                     steps {
@@ -1133,16 +1308,7 @@ pipeline {
                         script {
                             daos_packages_version = readFile('centos7-rpm-version').trim()
                         }
-                        // First snapshot provision the VM at beginning of list
-                        provisionNodes NODELIST: env.NODELIST,
-                                       node_count: 1,
-                                       snapshot: true,
-                                       inst_repos: el7_daos_repos,
-                                       inst_rpms: 'daos-' + daos_packages_version +
-                                                  ' daos-client-' + daos_packages_version +
-                                                  ' cart-' + env.CART_COMMIT + ' ' +
-                                                  functional_rpms
-                        // Then just reboot the physical nodes
+                        // Just reboot the physical nodes
                         provisionNodes NODELIST: env.NODELIST,
                                        node_count: 9,
                                        power_only: true,
@@ -1152,9 +1318,9 @@ pipeline {
                                                   ' cart-' + env.CART_COMMIT + ' ' +
                                                   functional_rpms
                         runTest stashes: [ 'CentOS-install', 'CentOS-build-vars' ],
-                                script: '''test_tag=$(git show -s --format=%B | sed -ne "/^Test-tag-hw:/s/^.*: *//p")
+                                script: '''test_tag=$(git show -s --format=%B | sed -ne "/^Test-tag-hw-large:/s/^.*: *//p")
                                            if [ -z "$test_tag" ]; then
-                                               test_tag=pr,hw
+                                               test_tag=pr,hw,large
                                            fi
                                            tnodes=$(echo $NODELIST | cut -d ',' -f 1-9)
                                            # set DAOS_TARGET_OVERSUBSCRIBE env here
@@ -1163,7 +1329,7 @@ pipeline {
                                            mkdir -p install/lib/daos/TESTING/ftest/avocado/job-results
                                            ./ftest.sh "$test_tag" $tnodes''',
                                 junit_files: "install/lib/daos/TESTING/ftest/avocado/*/*/*.xml install/lib/daos/TESTING/ftest/*_results.xml",
-                                failure_artifacts: env.STAGE_NAME
+                                failure_artifacts: 'Functional'
                     }
                     post {
                         always {
@@ -1171,25 +1337,20 @@ pipeline {
                                   # Remove the latest avocado symlink directory to avoid inclusion in the
                                   # jenkins build artifacts
                                   unlink install/lib/daos/TESTING/ftest/avocado/job-results/latest
-                                  if [ -n "$STAGE_NAME" ]; then
-                                      rm -rf "$STAGE_NAME/"
-                                      mkdir "$STAGE_NAME/"
-                                      # compress those potentially huge DAOS logs
-                                      if daos_logs=$(ls install/lib/daos/TESTING/ftest/avocado/job-results/*/daos_logs/*); then
-                                          lbzip2 $daos_logs
-                                      fi
-                                      arts="$arts$(ls *daos{,_agent}.log* 2>/dev/null)" && arts="$arts"$'\n'
-                                      arts="$arts$(ls -d install/lib/daos/TESTING/ftest/avocado/job-results/* 2>/dev/null)" && arts="$arts"$'\n'
-                                      arts="$arts$(ls install/lib/daos/TESTING/ftest/*.stacktrace 2>/dev/null || true)"
-                                      if [ -n "$arts" ]; then
-                                          mv $(echo $arts | tr '\n' ' ') "$STAGE_NAME/"
-                                      fi
-                                  else
-                                      echo "The STAGE_NAME environment variable is missing!"
-                                      false
+                                  rm -rf "Functional/"
+                                  mkdir "Functional/"
+                                  # compress those potentially huge DAOS logs
+                                  if daos_logs=$(ls install/lib/daos/TESTING/ftest/avocado/job-results/*/daos_logs/*); then
+                                      lbzip2 $daos_logs
+                                  fi
+                                  arts="$arts$(ls *daos{,_agent}.log* 2>/dev/null)" && arts="$arts"$'\n'
+                                  arts="$arts$(ls -d install/lib/daos/TESTING/ftest/avocado/job-results/* 2>/dev/null)" && arts="$arts"$'\n'
+                                  arts="$arts$(ls install/lib/daos/TESTING/ftest/*.stacktrace 2>/dev/null || true)"
+                                  if [ -n "$arts" ]; then
+                                      mv $(echo $arts | tr '\n' ' ') "Functional/"
                                   fi'''
-                            archiveArtifacts artifacts: env.STAGE_NAME + '/**'
-                            junit env.STAGE_NAME + '/*/results.xml, install/lib/daos/TESTING/ftest/*_results.xml'
+                            archiveArtifacts artifacts: 'Functional/**'
+                            junit 'Functional/*/results.xml, install/lib/daos/TESTING/ftest/*_results.xml'
                         }
                         /* temporarily moved into runTest->stepResult due to JENKINS-39203
                         success {

--- a/ftest.sh
+++ b/ftest.sh
@@ -55,6 +55,12 @@ trap 'echo "encountered an unchecked return code, exiting with error"' ERR
 IFS=" " read -r -a nodes <<< "${2//,/ }"
 TEST_NODES=$(IFS=","; echo "${nodes[*]:1:8}")
 
+# Optional --nvme argument for launch.py
+NVME_ARG=""
+if [ -n "${3}" ]; then
+    NVME_ARG="-n ${3}"
+fi
+
 # For nodes that are only rebooted between CI nodes left over mounts
 # need to be cleaned up.
 pre_clean () {
@@ -351,7 +357,7 @@ if [[ \"${TEST_TAG_ARG}\" =~ soak ]]; then
 fi
 
 # now run it!
-if ! ./launch.py -c -a -r -i -s -ts ${TEST_NODES} ${TEST_TAG_ARR[*]}; then
+if ! ./launch.py -caris -ts ${TEST_NODES} ${NVME_ARG} ${TEST_TAG_ARR[*]}; then
     rc=\${PIPESTATUS[0]}
 else
     rc=0

--- a/src/tests/ftest/control/daos_admin_privileged.py
+++ b/src/tests/ftest/control/daos_admin_privileged.py
@@ -50,7 +50,7 @@ class DaosAdminPrivTest(TestWithServers):
         JIRA ID: DAOS-2895
         Test Description: Test daso_admin functionality to perform format
         privileged operations while daos_server is run as normal user.
-        :avocado: tags=all,tiny,pr,hw,daos_admin,basic
+        :avocado: tags=all,pr,hw,small,daos_admin,basic
         """
         # Verify that daos_admin has the correct permissions
         self.log.info("Checking daos_admin binary permissions")

--- a/src/tests/ftest/control/daos_admin_privileged.yaml
+++ b/src/tests/ftest/control/daos_admin_privileged.yaml
@@ -9,6 +9,6 @@ server_config:
   port: 10001
   servers:
     bdev_class: nvme
-    bdev_list: ["0000:81:00.0","0000:da:00.0"]
+    bdev_list: ["aaaa:aa:aa.a","bbbb:bb:bb.b"]
     scm_class: dcpm
     scm_list: ["/dev/pmem0"]

--- a/src/tests/ftest/daos_test/daos_core_test-rebuild.py
+++ b/src/tests/ftest/daos_test/daos_core_test-rebuild.py
@@ -41,6 +41,6 @@ class DaosCoreTestRebuild(DaosCoreBase):
         Use case:
             Balance testing load betweeen hardware and VM clusters.
 
-        :avocado: tags=all,pr,hw,small,unittest,daos_test_rebuild
+        :avocado: tags=all,pr,hw,medium,ib2,unittest,daos_test_rebuild
         """
         DaosCoreBase.run_subtest(self)

--- a/src/tests/ftest/io/fio_small.py
+++ b/src/tests/ftest/io/fio_small.py
@@ -51,6 +51,6 @@ class FioSmall(FioBase):
             read_write: rw|randrw
             numjobs: 1
 
-        :avocado: tags=all,pr,hw,small,fio,fiosmall
+        :avocado: tags=all,pr,hw,medium,ib2,fio,fiosmall
         """
         self.execute_fio()

--- a/src/tests/ftest/io/hdf5.py
+++ b/src/tests/ftest/io/hdf5.py
@@ -21,6 +21,7 @@
   Any reproduction of computer software, computer software documentation, or
   portions thereof marked with this legend must also reproduce the markings.
 """
+from apricot import skipForTicket
 from mpio_test_base import LlnlMpi4pyHdf5
 
 
@@ -31,6 +32,7 @@ class Hdf5(LlnlMpi4pyHdf5):
     :avocado: recursive
     """
 
+    @skipForTicket("DAOS-4197")
     def test_hdf5(self):
         """Jira ID: DAOS-2252.
 
@@ -79,7 +81,7 @@ class Hdf5(LlnlMpi4pyHdf5):
                 test_dense_attr
                 test_partial_no_selection_coll_md_read
 
-        :avocado: tags=all,pr,hw,tiny,mpio,llnlmpi4pyhdf5,hdf5
+        :avocado: tags=all,pr,hw,small,mpio,llnlmpi4pyhdf5,hdf5
         """
         test_repo = self.params.get("hdf5", '/run/test_repo/')
         self.run_test(test_repo, "hdf5")

--- a/src/tests/ftest/io/ior_intercept_basic.py
+++ b/src/tests/ftest/io/ior_intercept_basic.py
@@ -55,7 +55,7 @@ class IorIntercept(IorTestBase):
             Compare the results and check whether using interception
                 library provides better performance.
 
-        :avocado: tags=all,daosio,medium,hw,full_regression,iorinterceptbasic
+        :avocado: tags=all,full_regression,hw,small,daosio,iorinterceptbasic
         """
         out = self.run_ior_with_pool()
         without_intercept = IorCommand.get_ior_metrics(out)

--- a/src/tests/ftest/io/ior_intercept_dfuse_mix.py
+++ b/src/tests/ftest/io/ior_intercept_dfuse_mix.py
@@ -67,7 +67,7 @@ class IorInterceptDfuseMix(IorTestBase):
                 library provides better performance and not using it
                 does not change the performance.
 
-        :avocado: tags=all,daosio,hw,full_regression,iorinterceptmix
+        :avocado: tags=all,full_regression,hw,large,daosio,iorinterceptmix
         """
         without_intercept = dict()
         self.run_multiple_ior_with_pool(without_intercept)

--- a/src/tests/ftest/io/ior_intercept_multi_client.py
+++ b/src/tests/ftest/io/ior_intercept_multi_client.py
@@ -65,7 +65,8 @@ class IorInterceptMultiClient(IorTestBase):
             Compare the results and check whether using interception
                 library provides better performance.
 
-        :avocado: tags=all,daosio,hw,full_regression,iorinterceptmulticlient
+        :avocado: tags=all,full_regression,hw,large
+        :avocado: tags=daosio,iorinterceptmulticlient
         """
         suffix = self.ior_cmd.transfer_size.value
         out = self.run_ior_with_pool(test_file_suffix=suffix)

--- a/src/tests/ftest/io/ior_intercept_verify_data_integrity.py
+++ b/src/tests/ftest/io/ior_intercept_verify_data_integrity.py
@@ -60,7 +60,8 @@ class IorInterceptVerifyDataIntegrity(IorTestBase):
             Run ior with read, write, read verify
             write verify for 30 minutes
 
-        :avocado: tags=all,daosio,hw,full_regression,iorinterceptverifydata
+        :avocado: tags=all,full_regression,hw,large
+        :avocado: tags=daosio,iorinterceptverifydata
         """
         intercept = os.path.join(self.prefix, 'lib64', 'libioil.so')
         with_intercept = dict()

--- a/src/tests/ftest/io/ior_small.py
+++ b/src/tests/ftest/io/ior_small.py
@@ -47,7 +47,7 @@ class IorSmall(IorTestBase):
             All above three cases to be run with single client and
                 multiple client processes in two separate nodes.
 
-        :avocado: tags=all,pr,hw,medium,daosio,iorsmall
+        :avocado: tags=all,pr,hw,large,daosio,iorsmall
         """
         flags = self.params.get("ior_flags", '/run/ior/iorflags/*')
         apis = self.params.get("ior_api", '/run/ior/iorflags/*')

--- a/src/tests/ftest/io/mdtest_small.py
+++ b/src/tests/ftest/io/mdtest_small.py
@@ -48,7 +48,7 @@ class MdtestSmall(MdtestBase):
             read bytes: 0|4K
             depth of hierarchical directory structure: 0|5
 
-        :avocado: tags=all,pr,hw,medium,mdtest,mdtestsmall
+        :avocado: tags=all,pr,hw,large,mdtest,mdtestsmall
         """
         # local params
         mdtest_params = self.params.get("mdtest_params", "/run/mdtest/*")

--- a/src/tests/ftest/io/nvme_io.py
+++ b/src/tests/ftest/io/nvme_io.py
@@ -48,7 +48,7 @@ class NvmeIo(IorTestBase):
         Use Cases:
             Running multiple IOR on same server start instance.
 
-        :avocado: tags=all,daosio,full_regression,hw,nvme_io
+        :avocado: tags=all,full_regression,hw,large,daosio,nvme_io
         """
         # Test params
         tests = self.params.get("ior_sequence", '/run/ior/*')

--- a/src/tests/ftest/io/nvme_io_verification.py
+++ b/src/tests/ftest/io/nvme_io_verification.py
@@ -61,7 +61,7 @@ class NvmeIoVerification(IorTestBase):
             as transfer size is > 4096.
             (4) Repeat the case(3) with maximum nvme pool size that can be
             created.
-        :avocado: tags=all,daosio,full_regression,hw,nvme_io_verification
+        :avocado: tags=all,full_regression,hw,large,daosio,nvme_io_verification
         """
         # Test params
         tests = self.params.get("ior_sequence", '/run/ior/*')

--- a/src/tests/ftest/io/nvme_object.py
+++ b/src/tests/ftest/io/nvme_object.py
@@ -184,7 +184,7 @@ class NvmeObject(TestWithServers):
             Verify the objects are being created and the data is not
             corrupted.
 
-        :avocado: tags=all,pr,hw,medium,nvme_object_single_pool,nvme_object
+        :avocado: tags=all,pr,hw,large,nvme_object_single_pool,nvme_object
         """
         # perform multiple object writes to a single pool
         test_runner(self, self.pool_size[0], self.record_size[:-1], 0,
@@ -203,7 +203,7 @@ class NvmeObject(TestWithServers):
             Verify the objects are being created and the data is not
             corrupted.
 
-        :avocado: tags=all,full_regression,hw,medium,nvme_object_multiple_pools
+        :avocado: tags=all,full_regression,hw,large,nvme_object_multiple_pools
         :avocado: tags=nvme_object
         """
         # thread to perform simulatneous object writes to multiple pools

--- a/src/tests/ftest/io/unaligned_io.py
+++ b/src/tests/ftest/io/unaligned_io.py
@@ -44,6 +44,6 @@ class DaosRunIoConf(IoConfTestBase):
             Write data set, modified 1bytes in different offsets. Verify
             read through
 
-        :avocado: tags=all,small,hw,unaligned_io,full_regression
+        :avocado: tags=all,full_regression,hw,large,unaligned_io
         """
         self.unaligned_io()

--- a/src/tests/ftest/launch.py
+++ b/src/tests/ftest/launch.py
@@ -1,4 +1,5 @@
 #!/usr/bin/python2
+# pylint: disable=too-many-lines
 """
   (C) Copyright 2018-2019 Intel Corporation.
 
@@ -62,8 +63,23 @@ except ImportError:
             rmtree(self.name)
 
 DEFAULT_DAOS_TEST_LOG_DIR = "/var/tmp/daos_testing"
-SERVER_KEYS = ("test_servers")
-CLIENT_KEYS = ("test_clients")
+YAML_KEYS = {
+    "test_servers": "test_servers",
+    "test_clients": "test_clients",
+    "bdev_list": "nvme",
+}
+YAML_KEY_ORDER = ("test_servers", "test_clients", "bdev_list")
+
+
+def display(args, message):
+    """Display the message if verbosity is set.
+
+    Args:
+        args (argparse.Namespace): command line arguments for this program
+        message (str): message to display if verbosity is set
+    """
+    if args.verbose:
+        print(message)
 
 
 def get_build_environment():
@@ -150,6 +166,7 @@ def set_test_environment(args):
                 # before ib1
                 if speed not in available_interfaces:
                     available_interfaces[speed] = device
+        print("Available interfaces: {}".format(available_interfaces))
         try:
             # Select the fastest active interface available by sorting the speed
             interface = available_interfaces[sorted(available_interfaces)[-1]]
@@ -158,9 +175,7 @@ def set_test_environment(args):
                 "Error obtaining a default interface from: {}".format(
                     os.listdir(net_path)))
             exit(1)
-    print(
-        "Using {} as the default interface from {}".format(
-            interface, available_interfaces))
+    print("Using {} as the default interface".format(interface))
 
     # Update env definitions
     os.environ["PATH"] = ":".join([bin_dir, sbin_dir, usr_sbin, path])
@@ -246,17 +261,18 @@ def time_command(cmd):
     return return_code
 
 
-def spawn_commands(host_list, command, timeout=120):
+def get_remote_output(host_list, command, timeout=120):
     """Run the command on each specified host in parallel.
 
     Args:
         host_list (list): list of hosts
         command (str): command to run on each host
-        timeout (int): number of seconds to wait for all jobs to complete
+        timeout (int, optional): number of seconds to wait for all jobs to
+            complete. Defaults to 120 seconds.
 
     Returns:
-        bool: True if the command completed successfully (rc=0) on each
-            specified host; False otherwise
+        Task: a Task object containing the result of the running the command on
+            the specified hosts
 
     """
     # Create a ClusterShell Task to run the command in parallel on the hosts
@@ -270,7 +286,21 @@ def spawn_commands(host_list, command, timeout=120):
     task.set_info("ssh_options", "-oForwardAgent=yes")
     print("Running on {}: {}".format(nodes, command))
     task.run(command=command, nodes=nodes, timeout=timeout)
+    return task
 
+
+def check_remote_output(task, command):
+    """Check if a remote command completed successfully on all hosts.
+
+    Args:
+        task (Task): a Task object containing the command result
+        command (str): command run by the task
+
+    Returns:
+        bool: True if the command completed successfully (rc=0) on each
+            specified host; False otherwise
+
+    """
     # Create a dictionary of hosts for each unique return code
     results = {code: hosts for code, hosts in task.iter_retcodes()}
 
@@ -282,7 +312,7 @@ def spawn_commands(host_list, command, timeout=120):
     # Display the command output
     for code in sorted(results):
         output_data = list(task.iter_buffers(results[code]))
-        if len(output_data) == 0:
+        if not output_data:
             err_nodes = NodeSet.fromlist(results[code])
             print("    {}: rc={}, output: <NONE>".format(err_nodes, code))
         else:
@@ -301,6 +331,27 @@ def spawn_commands(host_list, command, timeout=120):
     return status
 
 
+def spawn_commands(host_list, command, timeout=120):
+    """Run the command on each specified host in parallel.
+
+    Args:
+        host_list (list): list of hosts
+        command (str): command to run on each host
+        timeout (int, optional): number of seconds to wait for all jobs to
+            complete. Defaults to 120 seconds.
+
+    Returns:
+        bool: True if the command completed successfully (rc=0) on each
+            specified host; False otherwise
+
+    """
+    # Create a dictionary of hosts for each unique return code
+    task = get_remote_output(host_list, command, timeout)
+
+    # Determine if the command completed successfully across all the hosts
+    return check_remote_output(task, command)
+
+
 def find_values(obj, keys, key=None, val_type=list):
     """Find dictionary values of a certain type specified with certain keys.
 
@@ -313,18 +364,55 @@ def find_values(obj, keys, key=None, val_type=list):
         dict: a dictionary of each matching key and its value
 
     """
+    def add_matches(found):
+        """Add found matches to the match dictionary entry of the same key.
+
+        If a match does not already exist for this key add all the found values.
+        When a match already exists for a key, append the existing match with
+        any new found values.
+
+        For example:
+            Match       Found           Updated Match
+            ---------   ------------    -------------
+            None        [A, B]          [A, B]
+            [A, B]      [C]             [A, B, C]
+            [A, B, C]   [A, B, C, D]    [A, B, C, D]
+
+        Args:
+            found (list): list of matches found
+        """
+        for found_key in found:
+            if found_key not in matches:
+                # Simply add the new value found for this key
+                matches[found_key] = found[found_key]
+
+            else:
+                is_list = isinstance(matches[found_key], list)
+                if not is_list:
+                    matches[found_key] = [matches[found_key]]
+                if isinstance(found[found_key], list):
+                    for found_item in found[found_key]:
+                        if found_key not in matches:
+                            matches[found_key].append(found_item)
+                elif found_key not in matches:
+                    matches[found_key].append(found[found_key])
+
+                if not is_list and len(matches[found_key]) == 1:
+                    matches[found_key] = matches[found_key][0]
+
     matches = {}
     if isinstance(obj, val_type) and isinstance(key, str) and key in keys:
         # Match found
         matches[key] = obj
     elif isinstance(obj, dict):
         # Recursively look for matches in each dictionary entry
-        for key, val in obj.items():
-            matches.update(find_values(val, keys, key, val_type))
+        for obj_key, obj_val in obj.items():
+            add_matches(find_values(obj_val, keys, obj_key, val_type))
     elif isinstance(obj, list):
         # Recursively look for matches in each list entry
         for item in obj:
-            matches.update(find_values(item, keys, None, val_type))
+            add_matches(find_values(item, keys, None, val_type))
+
     return matches
 
 
@@ -385,13 +473,105 @@ def get_test_files(test_list, args, tmp_dir):
     return test_files
 
 
-def replace_yaml_file(yaml_file, args, tmp_dir):
-    """Replace the server/client yaml file placeholders.
+def get_nvme_replacement(args):
+    """Determine the value to use for the '--nvme' command line argument.
 
-    Replace any server or client yaml file placeholder names with the host
-    names provided by the command line arguments in a copy of the original
-    test yaml file.  If no replacements are specified return the original
-    test yaml file.
+    Parse the lspci output for any NMVe devices, e.g.
+        $ lspci | grep 'Non-Volatile memory controller:'
+        5e:00.0 Non-Volatile memory controller:
+            Intel Corporation NVMe Datacenter SSD [3DNAND, Beta Rock Controller]
+        5f:00.0 Non-Volatile memory controller:
+            Intel Corporation NVMe Datacenter SSD [3DNAND, Beta Rock Controller]
+        81:00.0 Non-Volatile memory controller:
+            Intel Corporation NVMe Datacenter SSD [Optane]
+        da:00.0 Non-Volatile memory controller:
+            Intel Corporation NVMe Datacenter SSD [Optane]
+
+    Optionally filter the above output even further with a specified search
+    string (e.g. '--nvme=auto:Optane'):
+        $ lspci | grep 'Non-Volatile memory controller:' | grep 'Optane'
+        81:00.0 Non-Volatile memory controller:
+            Intel Corporation NVMe Datacenter SSD [Optane]
+        da:00.0 Non-Volatile memory controller:
+            Intel Corporation NVMe Datacenter SSD [Optane]
+
+    Args:
+        args (argparse.Namespace): command line arguments for this program
+
+    Returns:
+        str: a comma-separated list of nvme device pci addresses available on
+            all of the specified test servers
+
+    """
+    # A list of server host is required to able to auto-detect NVMe devices
+    if not args.test_servers:
+        print("ERROR: Missing a test_servers list to auto-detect NVMe devices")
+        exit(1)
+
+    # Get a list of NVMe devices from each specified server host
+    host_list = args.test_servers.split(",")
+    command_list = [
+        "/usr/sbin/lspci -D", "grep 'Non-Volatile memory controller:'"]
+    if ":" in args.nvme:
+        command_list.append("grep '{}'".format(args.nvme.split(":")[1]))
+    command = " | ".join(command_list)
+    task = get_remote_output(host_list, command)
+
+    # Verify the command was successful on each server host
+    if not check_remote_output(task, command):
+        print("ERROR: Issuing commands to detect NVMe PCI addresses.")
+        exit(1)
+
+    # Verify each server host has the same NVMe PCI addresses
+    output_data = list(task.iter_buffers())
+    if len(output_data) > 1:
+        print("ERROR: Non-homogeneous NVMe PCI addresses.")
+        exit(1)
+
+    # Get the list of NVMe PCI addresses found in the output
+    devices = find_pci_address(output_data[0][0])
+    print("Auto-detected NVMe devices on {}: {}".format(host_list, devices))
+    return ",".join(devices)
+
+
+def find_pci_address(value):
+    """Find PCI addresses in the specified string.
+
+    Args:
+        value (str): string to search for PCI addresses
+
+    Returns:
+        list: a list of all the PCI addresses found in the string
+
+    """
+    pattern = r"[{0}]{{4}}:[{0}]{{2}}:[{0}]{{2}}\.[{0}]".format("0-9a-fA-F")
+    return re.findall(pattern, str(value))
+
+
+def replace_yaml_file(yaml_file, args, tmp_dir):
+    """Create a temporary test yaml file with any requested values replaced.
+
+    Optionally replace the following test yaml file values if specified by the
+    user via the command line arguments:
+
+        test_servers:   Use the list sepecified by the --test_servers (-ts)
+                        argument to replace any host name placeholders listed
+                        under "test_servers:"
+
+        test_clients    Use the list sepecified by the --test_clients (-tc)
+                        argument (or any remaining names in the --test_servers
+                        list argument, if --test_clients is not specified) to
+                        replace any host name placeholders listed under
+                        "test_clients:".
+
+        bdev_list       Use the list specified by the --nvme (-n) argument to
+                        replace the string specified by the "bdev_list:" yaml
+                        parameter.  If multiple "bdev_list:" entries exist in
+                        the yaml file, evenly divide the list when making the
+                        replacements.
+
+    Any replacements are made in a copy of the original test yaml file.  If no
+    replacements are specified return the original test yaml file.
 
     Args:
         yaml_file (str): test yaml file
@@ -404,45 +584,91 @@ def replace_yaml_file(yaml_file, args, tmp_dir):
             w/o replacements
 
     """
-    if args.test_servers:
-        # Determine which placeholder names need to be replaced in this yaml by
-        # getting the lists of hosts specified in the yaml file
-        unique_hosts = {"servers": set(), "clients": set()}
-        for key, placeholders in find_yaml_hosts(yaml_file).items():
-            if key in SERVER_KEYS:
-                unique_hosts["servers"].update(placeholders)
-            elif key in CLIENT_KEYS:
-                # If no specific clients are specified use a specified server
-                key = "clients" if args.test_clients else "servers"
-                unique_hosts[key].update(placeholders)
+    replacements = {}
 
-        # Map the placeholder names to values provided by the user
-        mapping_pairings = [("servers", args.test_servers.split(","))]
-        if args.test_clients:
-            mapping_pairings.append(("clients", args.test_clients.split(",")))
-        mapping = {
-            tmp: node_list[index] if index < len(node_list) else None
-            for key, node_list in mapping_pairings
-            for index, tmp in enumerate(sorted(unique_hosts[key]))}
+    if args.test_servers or args.nvme:
+        # Find the test yaml keys and values that match the replacable fields
+        yaml_data = get_yaml_data(yaml_file)
+        yaml_keys = list(YAML_KEYS.keys())
+        yaml_find = find_values(yaml_data, yaml_keys)
 
+        # Generate a list
+        new_values = {
+            key: getattr(args, value).split(",") if getattr(args, value) else []
+            for key, value in YAML_KEYS.items()}
+
+        # Assign replacement values for the test yaml entries to be replaced
+        display(args, "Detecting replacements for {} in {}".format(
+            yaml_keys, yaml_file))
+        display(args, "  Found values: {}".format(yaml_find))
+        display(args, "  New values:   {}".format(new_values))
+
+        for key in YAML_KEY_ORDER:
+            # If the user did not provide a specific list of replacement
+            # test_clients values, use the remaining test_servers values to
+            # replace test_clients placeholder values
+            if key == "test_clients" and not new_values[key]:
+                new_values[key] = new_values["test_servers"]
+
+            # Replace test yaml keys that were:
+            #   - found in the test yaml
+            #   - have a user-specified replacement
+            if key in yaml_find and new_values[key]:
+                if key.startswith("test_"):
+                    # The entire server/client test yaml list entry is replaced
+                    # by a new test yaml list entry, e.g.
+                    #   '- serverA' --> '- wolf-1'
+                    value_format = "- {}"
+                    values_to_replace = [
+                        value_format.format(item) for item in yaml_find[key]]
+
+                else:
+                    # Individual bdev_list NVMe PCI addresses in the test yaml
+                    # file are replaced with the new NVMe PCI addresses in the
+                    # order they are found, e.g.
+                    #   0000:81:00.0 --> 0000:12:00.0
+                    value_format = "\"{}\""
+                    values_to_replace = [
+                        value_format.format(item)
+                        for item in find_pci_address(yaml_find[key])]
+
+                # Add the next user-specified value as a replacement for the key
+                for value in values_to_replace:
+                    if value in replacements:
+                        continue
+                    try:
+                        replacements[value] = value_format.format(
+                            new_values[key].pop(0))
+                    except IndexError:
+                        replacements[value] = None
+                    display(
+                        args,
+                        "  - Replacement: {} -> {}".format(
+                            value, replacements[value]))
+
+    if replacements:
         # Read in the contents of the yaml file to retain the !mux entries
         print("Reading {}".format(yaml_file))
         with open(yaml_file) as yaml_buffer:
-            file_str = yaml_buffer.read()
+            yaml_data = yaml_buffer.read()
 
         # Apply the placeholder replacements
         missing_replacements = []
-        for placeholder, host in mapping.items():
-            if host:
+        display(args, "Modifying contents: {}".format(yaml_file))
+        for key in sorted(replacements):
+            value = replacements[key]
+            if value:
                 # Replace the host entries with their mapped values
-                file_str = re.sub(
-                    "- {}".format(placeholder), "- {}".format(host), file_str)
+                display(args, "  - Replacing: {} --> {}".format(key, value))
+                yaml_data = re.sub(key, value, yaml_data)
             elif args.discard:
                 # Discard any host entries without a replacement value
-                file_str = re.sub(r"\s+- {}".format(placeholder), "", file_str)
+                display(args, "  - Removing:  {}".format(key))
+                yaml_data = re.sub(r"\s*[,]?{}".format(key), "", yaml_data)
             else:
                 # Keep track of any placeholders without a replacement value
-                missing_replacements.append(placeholder)
+                display(args, "  - Missing:   {}".format(key))
+                missing_replacements.append(key)
 
         if missing_replacements:
             # Report an error for all of the placeholders w/o a replacement
@@ -453,11 +679,18 @@ def replace_yaml_file(yaml_file, args, tmp_dir):
 
         # Write the modified yaml file into a temporary file.  Use the path to
         # ensure unique yaml files for tests with the same filename.
+        orig_yaml_file = yaml_file
         yaml_name = get_test_category(yaml_file)
         yaml_file = os.path.join(tmp_dir.name, "{}.yaml".format(yaml_name))
-        print("Creating {}".format(yaml_file))
+        print("Creating copy: {}".format(yaml_file))
         with open(yaml_file, "w") as yaml_buffer:
-            yaml_buffer.write(file_str)
+            yaml_buffer.write(yaml_data)
+
+        # Optionally display the file
+        if args.verbose:
+            print(
+                get_output(
+                    "diff -y {} {}; exit 0".format(orig_yaml_file, yaml_file)))
 
     # Return the untouched or modified yaml file
     return yaml_file
@@ -515,6 +748,7 @@ def run_tests(test_files, tag_filter, args):
             # along with the test results
             if args.archive:
                 archive_logs(avocado_logs_dir, test_file["yaml"], args)
+                archive_config_files(avocado_logs_dir)
 
             # Optionally rename the test results directory for this test
             if args.rename:
@@ -562,7 +796,9 @@ def find_yaml_hosts(test_yaml):
         dict: a dictionary of each host key and its host values
 
     """
-    return find_values(get_yaml_data(test_yaml), SERVER_KEYS + CLIENT_KEYS)
+    return find_values(
+        get_yaml_data(test_yaml),
+        [YAML_KEYS["test_servers"], YAML_KEYS["test_clients"]])
 
 
 def get_hosts_from_yaml(test_yaml, args):
@@ -585,7 +821,7 @@ def get_hosts_from_yaml(test_yaml, args):
     found_client_key = False
     for key, value in find_yaml_hosts(test_yaml).items():
         host_set.update(value)
-        if key in CLIENT_KEYS:
+        if key in YAML_KEYS["test_clients"]:
             found_client_key = True
 
     # Include this host as a client if no clients are specified
@@ -807,6 +1043,19 @@ def main():
         action="store_true",
         help="list the python scripts that match the specified tags")
     parser.add_argument(
+        "-m", "--modify",
+        action="store_true",
+        help="modify the test yaml files but do not run the tests")
+    parser.add_argument(
+        "-n", "--nvme",
+        action="store",
+        help="comma-separated list of NVMe device PCI addresses to use as "
+             "replacement values for the bdev_list in each test's yaml file.  "
+             "Using the 'auto[:<filter>]' keyword will auto-detect the NVMe "
+             "PCI address list on each of the '--test_servers' hosts - the "
+             "optonal '<filter>' can be used to limit auto-detected addresses, "
+             "e.g. 'auto:Optane' for Intel Optane NVMe devices.")
+    parser.add_argument(
         "-r", "--rename",
         action="store_true",
         help="rename the avocado test logs directory to include the test name")
@@ -831,17 +1080,25 @@ def main():
              "server placeholders in each test's yaml file.  If the "
              "'--test_clients' argument is not specified, this list of hosts "
              "will also be used to replace client placeholders.")
+    parser.add_argument(
+        "-v", "--verbose",
+        action="store_true",
+        help="verbose output")
     args = parser.parse_args()
     print("Arguments: {}".format(args))
 
     # Setup the user environment
     set_test_environment(args)
 
+    # Auto-detect nvme test yaml replacement values if requested
+    if args.nvme and args.nvme.startswith("auto"):
+        args.nvme = get_nvme_replacement(args)
+
     # Process the tags argument to determine which tests to run
     tag_filter, test_list = get_test_list(args.tags)
 
     # Verify at least one test was requested
-    if len(test_list) == 0:
+    if not test_list:
         print("ERROR: No tests or tags found via {}".format(args.tags))
         exit(1)
 
@@ -855,6 +1112,8 @@ def main():
 
     # Create a dictionary of test and their yaml files
     test_files = get_test_files(test_list, args, tmp_dir)
+    if args.modify:
+        exit(0)
 
     # Run all the tests
     status = run_tests(test_files, tag_filter, args)

--- a/src/tests/ftest/launch.py
+++ b/src/tests/ftest/launch.py
@@ -653,7 +653,7 @@ def archive_logs(avocado_logs_dir, test_yaml, args):
         "echo Copied ${copied[@]:-no files}",
         "exit $rc",
     ]
-    spawn_commands(host_list, "; ".join(commands))
+    spawn_commands(host_list, "; ".join(commands), 900)
 
 
 def archive_config_files(avocado_logs_dir):

--- a/src/tests/ftest/rebuild/io_conf_run.py
+++ b/src/tests/ftest/rebuild/io_conf_run.py
@@ -47,6 +47,6 @@ class DaosRunIoConf(IoConfTestBase):
         Use Cases:
             Verify rebuild with data verification.
 
-        :avocado: tags=all,medium,hw,rebuild,iorebuild,full_regression
+        :avocado: tags=all,full_regression,hw,large,rebuild,iorebuild
         """
         self.execute_io_conf_run_test()

--- a/src/tests/ftest/util/agent_utils.py
+++ b/src/tests/ftest/util/agent_utils.py
@@ -177,7 +177,7 @@ def run_agent(test, server_list, client_list=None):
 
     # Create the DAOS Agent configuration yaml file to pass
     # with daos_agent -o <FILE_NAME>
-    agent_yaml = os.path.join(test.tmp, "daos_agent.yml")
+    agent_yaml = os.path.join(test.tmp, "daos_agent.yaml")
     agent_config = DaosAgentConfig()
     agent_config.get_params(test)
     agent_config.hostlist.value = client_list


### PR DESCRIPTION
Split the Functional_Hardware stage into three different stages to
divide running Functional HW testsexecution by cluster sizes.  Tests
requiring 2 nodes to run will now execute in the
Functional_Hardware_Small phase, tests requiring 4 nodes with dual IB
adapters will run in the Functional_Hardware_Medium stage, and all other
tests will run in the Functional_Hardware_Large stage.

Also includes the changes in these master branch commits:

DAOS-3266 tests: Include daos configuration files in archive. (#1835)

As part of the launch.py --archive option, include the collection of the
daos_agent and daos_server configuration files used with the commands
during testing.

DAOS-4143 tests: Enable replacing bdev_list test yaml entries (#1884)

A '--nvme <value>' option has been added to launch.py to enbale
replacing NVMe device specifications in the functional tests it
executes.  Similar to the '--test_servers' and '--test_clients'
command line options, used to replace the hosts specified in the
test yaml file, this new option replaces any NVMe Bus:Device.Function
notations in the test yaml with each comma-separated BDF in the <value>
string, in corresponding order.
The special "auto[:<filter>]" keywoard can also be specifed as the
<value> string, which will result in the <value> string being assigned
to the BDF notations detected on the '--test_servers' hosts.  This
enables running the functional tests on clusters with different hardware
configurations - eliminating the need for changes to test yaml files
when hardware configurations are changed.
In addition, the DAOS-4069 bug has also been resolved by this change.

DAOS-4190 tests: Fixing daos log clean and archive (#1923)

Fixing a bug introduced by PR-1884 where the cleanup and archiving of
log files does not include the test_servers and test_clients hosts.
Also resolved a rasing of an exception when running manually with
OFI_INTERFACE set.

Signed-off-by: Phillip Henderson <phillip.henderson@intel.com>