### PR TITLE
DAOS-4223 snapshot: Propagate snap IV after commit

### DIFF
--- a/src/container/srv_container.c
+++ b/src/container/srv_container.c
@@ -800,7 +800,7 @@ err:
 	return rc;
 }
 
-static void
+void
 cont_put(struct cont *cont)
 {
 	rdb_path_fini(&cont->c_prop);
@@ -2094,7 +2094,7 @@ out_lock:
 out:
 	/* Propagate new snapshot list by IV */
 	if (rc == 0 && (opc == CONT_SNAP_CREATE || opc == CONT_SNAP_DESTROY))
-		ds_cont_update_snap_iv(pool_hdl->sph_pool, in->ci_uuid);
+		ds_cont_update_snap_iv(svc, in->ci_uuid);
 
 	return rc;
 }

--- a/src/container/srv_container.c
+++ b/src/container/srv_container.c
@@ -2092,6 +2092,10 @@ out_lock:
 	ABT_rwlock_unlock(svc->cs_lock);
 	rdb_tx_end(&tx);
 out:
+	/* Propagate new snapshot list by IV */
+	if (rc == 0 && (opc == CONT_SNAP_CREATE || opc == CONT_SNAP_DESTROY))
+		ds_cont_update_snap_iv(pool_hdl->sph_pool, in->ci_uuid);
+
 	return rc;
 }
 

--- a/src/container/srv_epoch.c
+++ b/src/container/srv_epoch.c
@@ -109,41 +109,6 @@ read_snap_list(struct rdb_tx *tx, struct cont *cont,
 }
 
 int
-update_snap_iv(struct rdb_tx *tx, struct cont *cont)
-{
-	struct ds_pool	*pool;
-	uint64_t	*snapshots = NULL;
-	int		 snap_count = -1, rc;
-
-	/* Only happens on xstream 0 */
-	D_ASSERT(dss_get_module_info()->dmi_xs_id == 0);
-
-	rc = read_snap_list(tx, cont, &snapshots, &snap_count);
-	if (rc != 0) {
-		D_ERROR(DF_CONT": failed to update snapshots IV: %d\n",
-			DP_CONT(cont->c_svc->cs_pool_uuid, cont->c_uuid), rc);
-		return rc;
-	}
-
-	pool = ds_pool_lookup(cont->c_svc->cs_pool_uuid);
-	if (pool == NULL) {
-		rc = -DER_INVAL;
-		goto out;
-	}
-
-	rc = cont_iv_snapshots_update(pool->sp_iv_ns, cont->c_uuid, snapshots,
-				      snap_count);
-	ds_pool_put(pool);
-out:
-	if (rc != 0)
-		D_ERROR(DF_UUID": failed to update snapshots IV: rc %d\n",
-			DP_UUID(cont->c_uuid), rc);
-
-	D_FREE(snapshots);
-	return rc;
-}
-
-int
 ds_cont_epoch_init_hdl(struct rdb_tx *tx, struct cont *cont, uuid_t c_hdl,
 		       struct container_hdl *hdl)
 {
@@ -297,7 +262,6 @@ snap_create_bcast(struct rdb_tx *tx, struct cont *cont, crt_context_t *ctx,
 	}
 	D_DEBUG(DF_DSMS, DF_CONT": created snapshot "DF_U64"\n",
 		DP_CONT(cont->c_svc->cs_pool_uuid, cont->c_uuid), *epoch);
-	update_snap_iv(tx, cont);
 out_rpc:
 	crt_req_decref(rpc);
 out:
@@ -363,7 +327,6 @@ ds_cont_snap_destroy(struct rdb_tx *tx, struct ds_pool_hdl *pool_hdl,
 	D_DEBUG(DF_DSMS, DF_CONT": deleted snapshot [%lu]\n",
 		DP_CONT(pool_hdl->sph_pool->sp_uuid, in->cei_op.ci_uuid),
 		in->cei_epoch);
-	update_snap_iv(tx, cont);
 out:
 	return rc;
 }
@@ -505,4 +468,62 @@ out_put:
 		DP_UUID(pool_uuid), DP_UUID(cont_uuid), *snap_count, rc);
 
 	return rc;
+}
+
+/*
+ * Propagate new snapshot list to all servers through snapshot IV, errors
+ * are ignored.
+ */
+void
+ds_cont_update_snap_iv(struct ds_pool *pool, uuid_t cont_uuid)
+{
+	struct cont_svc	*svc;
+	struct rdb_tx	 tx;
+	struct cont	*cont = NULL;
+	uint64_t	*snapshots = NULL;
+	int		 snap_count = -1, rc;
+
+	/* Only happens on xstream 0 */
+	D_ASSERT(dss_get_module_info()->dmi_xs_id == 0);
+	rc = cont_svc_lookup_leader(pool->sp_uuid, 0, &svc, NULL);
+	if (rc != 0) {
+		D_ERROR(DF_UUID": Failed to lookup leader: %d\n",
+			DP_UUID(pool->sp_uuid), rc);
+		return;
+	}
+
+	rc = rdb_tx_begin(svc->cs_rsvc->s_db, svc->cs_rsvc->s_term, &tx);
+	if (rc != 0) {
+		D_ERROR(DF_UUID": Failed to start rdb tx: %d\n",
+			DP_UUID(pool->sp_uuid), rc);
+		goto out_put;
+	}
+
+	ABT_rwlock_rdlock(svc->cs_lock);
+	rc = cont_lookup(&tx, svc, cont_uuid, &cont);
+	if (rc != 0) {
+		D_ERROR(DF_CONT": Failed to look container: %d\n",
+			DP_CONT(pool->sp_uuid, cont_uuid), rc);
+		goto out_lock;
+	}
+
+	rc = read_snap_list(&tx, cont, &snapshots, &snap_count);
+	if (rc != 0) {
+		D_ERROR(DF_CONT": Failed to read snap list: %d\n",
+			DP_CONT(pool->sp_uuid, cont_uuid), rc);
+		goto out_lock;
+	}
+
+	rc = cont_iv_snapshots_update(pool->sp_iv_ns, cont_uuid, snapshots,
+				      snap_count);
+	if (rc != 0)
+		D_ERROR(DF_CONT": Failed to update snapshots IV: %d\n",
+			DP_CONT(pool->sp_uuid, cont_uuid), rc);
+
+	D_FREE(snapshots);
+out_lock:
+	ABT_rwlock_unlock(svc->cs_lock);
+	rdb_tx_end(&tx);
+out_put:
+	cont_svc_put_leader(svc);
 }

--- a/src/container/srv_internal.h
+++ b/src/container/srv_internal.h
@@ -188,10 +188,12 @@ int ds_cont_snap_list(struct rdb_tx *tx, struct ds_pool_hdl *pool_hdl,
 int ds_cont_snap_destroy(struct rdb_tx *tx, struct ds_pool_hdl *pool_hdl,
 			 struct cont *cont, struct container_hdl *hdl,
 			 crt_rpc_t *rpc);
-
 int
 ds_cont_get_snapshots(uuid_t pool_uuid, uuid_t cont_uuid,
 		      daos_epoch_t **snapshots, int *snap_count);
+void
+ds_cont_update_snap_iv(struct ds_pool *pool, uuid_t cont_uuid);
+
 /**
  * srv_target.c
  */

--- a/src/container/srv_internal.h
+++ b/src/container/srv_internal.h
@@ -152,6 +152,7 @@ int cont_svc_lookup_leader(uuid_t pool_uuid, uint64_t id,
 			   struct cont_svc **svcp, struct rsvc_hint *hint);
 int cont_lookup(struct rdb_tx *tx, const struct cont_svc *svc,
 		const uuid_t uuid, struct cont **cont);
+void cont_put(struct cont *cont);
 void cont_svc_put_leader(struct cont_svc *svc);
 int ds_cont_prop_set(struct rdb_tx *tx, struct ds_pool_hdl *pool_hdl,
 		     struct cont *cont, struct container_hdl *hdl,
@@ -192,7 +193,7 @@ int
 ds_cont_get_snapshots(uuid_t pool_uuid, uuid_t cont_uuid,
 		      daos_epoch_t **snapshots, int *snap_count);
 void
-ds_cont_update_snap_iv(struct ds_pool *pool, uuid_t cont_uuid);
+ds_cont_update_snap_iv(struct cont_svc *svc, uuid_t cont_uuid);
 
 /**
  * srv_target.c

--- a/src/container/srv_target.c
+++ b/src/container/srv_target.c
@@ -122,7 +122,7 @@ cont_child_aggregate(struct ds_cont_child *cont, uint64_t *sleep)
 		 * aggregation, let's restart from 0.
 		 */
 		epoch_min = 0;
-		D_DEBUG(DB_TRACE, "change hlc "DF_U64" > full "DF_U64"\n",
+		D_DEBUG(DB_EPC, "change hlc "DF_U64" > full "DF_U64"\n",
 			change_hlc, cont->sc_aggregation_full_scan_hlc);
 	} else {
 		epoch_min = cinfo.ci_hae;
@@ -153,7 +153,7 @@ cont_child_aggregate(struct ds_cont_child *cont, uint64_t *sleep)
 		int	j;
 		int	k;
 
-		D_DEBUG(DB_TRACE, "rebuild fence "DF_U64"\n", rebuild_fence);
+		D_DEBUG(DB_EPC, "rebuild fence "DF_U64"\n", rebuild_fence);
 		/* Insert the rebuild_epoch into snapshots */
 		D_ALLOC(snapshots, (cont->sc_snapshots_nr + 1) *
 			sizeof(daos_epoch_t));
@@ -175,18 +175,17 @@ cont_child_aggregate(struct ds_cont_child *cont, uint64_t *sleep)
 		 * always copy here.
 		 */
 		snapshots_nr = cont->sc_snapshots_nr;
-		D_ALLOC(snapshots, snapshots_nr * sizeof(daos_epoch_t));
-		if (snapshots == NULL)
-			return -DER_NOMEM;
+		if (snapshots_nr > 0) {
+			D_ALLOC(snapshots, snapshots_nr * sizeof(daos_epoch_t));
+			if (snapshots == NULL)
+				return -DER_NOMEM;
 
-		memcpy(snapshots, cont->sc_snapshots,
-		       snapshots_nr * sizeof(daos_epoch_t));
+			memcpy(snapshots, cont->sc_snapshots,
+					snapshots_nr * sizeof(daos_epoch_t));
+		}
 	}
 
-	/*
-	 * Find highest snapshot less than last aggregated epoch.
-	 * TODO: Rebuild epoch needs be taken into account as well.
-	 */
+	/* Find highest snapshot less than last aggregated epoch. */
 	for (i = 0; i < snapshots_nr && snapshots[i] < epoch_min; ++i)
 		;
 
@@ -1699,7 +1698,7 @@ cont_snap_update_one(void *vin)
 	/* Snapshot deleted, reset aggregation lower bound epoch */
 	if (cont->sc_snapshots_nr > args->snap_count) {
 		cont->sc_snapshot_delete_hlc = crt_hlc_get();
-		D_DEBUG(DF_DSMS, DF_CONT": Reset aggregation lower bound\n",
+		D_DEBUG(DB_EPC, DF_CONT": Reset aggregation lower bound\n",
 			DP_CONT(args->pool_uuid, args->cont_uuid));
 	}
 	cont->sc_snapshots_nr = args->snap_count;
@@ -1787,7 +1786,7 @@ ds_cont_tgt_snapshot_notify_handler(crt_rpc_t *rpc)
 	struct cont_tgt_snapshot_notify_out	*out	= crt_reply_get(rpc);
 	struct cont_snap_args			 args	= { 0 };
 
-	D_DEBUG(DF_DSMS, DF_CONT": handling rpc %p\n",
+	D_DEBUG(DB_EPC, DF_CONT": handling rpc %p\n",
 		DP_CONT(in->tsi_pool_uuid, in->tsi_cont_uuid), rpc);
 
 	uuid_copy(args.pool_uuid, in->tsi_pool_uuid);


### PR DESCRIPTION
On create/destroy snapshots, the snapshot IV update needs be called
after rdb tx commit, otherwise, new change to the snapshots won't
be fetched and aggregation won't be informed with uptodate snapshot
information.

Changed some aggregation related debug messages to use DB_EPC (which
are widely used for aggregation code).

Signed-off-by: Niu Yawei <yawei.niu@intel.com>