### PR TITLE
DAOS-4067 pydaos: Make svc configurable and fix open_by_path

### DIFF
--- a/src/client/pydaos/pydaos_core.py
+++ b/src/client/pydaos/pydaos_core.py
@@ -107,6 +107,8 @@ class Cont(object):
             raise PyDError("invalid pool or container UUID",
                            -pydaos_shim.DER_INVAL)
         if path != None:
+            self.puuid = None
+            self.cuuid = None
             (ret, poh, coh) = pydaos_shim.cont_open_by_path(DAOS_MAGIC, path,
                                                             svc, 0)
         else:
@@ -153,7 +155,7 @@ class Cont(object):
         return KVObj(self.coh, oid, self)
 
     def __str__(self):
-        return str(self.cuuid) + "@" + str(self.puuid)
+        return '{}@{}'.format(self.cuuid, self.puuid)
 
 class _Obj(object):
     oh = None

--- a/src/client/pydaos/pydaos_core.py
+++ b/src/client/pydaos/pydaos_core.py
@@ -101,18 +101,19 @@ class Cont(object):
     __str__
         print pool and container UUIDs
     """
-    def __init__(self, puuid=None, cuuid=None, path=None):
+    def __init__(self, puuid=None, cuuid=None, path=None, svc='0'):
         self.coh = None
         if path is None and (puuid is None or cuuid is None):
             raise PyDError("invalid pool or container UUID",
                            -pydaos_shim.DER_INVAL)
         if path != None:
-            (ret, poh, coh) = pydaos_shim.cont_open_by_path(DAOS_MAGIC, path),
+            (ret, poh, coh) = pydaos_shim.cont_open_by_path(DAOS_MAGIC, path,
+                                                            svc, 0)
         else:
             self.puuid = uuid.UUID(puuid)
             self.cuuid = uuid.UUID(cuuid)
             (ret, poh, coh) = pydaos_shim.cont_open(DAOS_MAGIC, str(puuid),
-                                                    str(cuuid), 0)
+                                                    str(cuuid), svc, 0)
         if ret != pydaos_shim.DER_SUCCESS:
             raise PyDError("failed to access container", ret)
         self.poh = poh

--- a/src/client/pydaos/pydaos_shim.c
+++ b/src/client/pydaos/pydaos_shim.c
@@ -133,10 +133,10 @@ __shim_handle__err_to_str(PyObject *self, PyObject *args)
  */
 
 static PyObject *
-cont_open(int ret, uuid_t puuid, uuid_t cuuid, int flags)
+cont_open(int ret, uuid_t puuid, uuid_t cuuid, char *svc_str, int flags)
 {
 	PyObject	*return_list;
-	daos_handle_t	 coh;
+	daos_handle_t	 coh = {0};
 	daos_handle_t	 poh = {0};
 	d_rank_list_t	*svcl = NULL;
 	int		 rc;
@@ -146,7 +146,7 @@ cont_open(int ret, uuid_t puuid, uuid_t cuuid, int flags)
 		goto out;
 	}
 
-	svcl = daos_rank_list_parse("0", ":");
+	svcl = daos_rank_list_parse(svc_str, ":");
 	if (svcl == NULL) {
 		rc = -DER_NOMEM;
 		goto out;
@@ -179,33 +179,35 @@ __shim_handle__cont_open(PyObject *self, PyObject *args)
 {
 	const char	*puuid_str;
 	const char	*cuuid_str;
+	char		*svc_str;
 	uuid_t		 puuid;
 	uuid_t		 cuuid;
 	int		 flags;
 
 	/** Parse arguments, flags not used for now */
-	RETURN_NULL_IF_FAILED_TO_PARSE(args, "ssi", &puuid_str, &cuuid_str,
-				       &flags);
+	RETURN_NULL_IF_FAILED_TO_PARSE(args, "sssi", &puuid_str, &cuuid_str,
+				       &svc_str, &flags);
 	uuid_parse(puuid_str, puuid);
 	uuid_parse(cuuid_str, cuuid);
 
-	return cont_open(DER_SUCCESS, puuid, cuuid, flags);
+	return cont_open(DER_SUCCESS, puuid, cuuid, svc_str, flags);
 }
 
 static PyObject *
 __shim_handle__cont_open_by_path(PyObject *self, PyObject *args)
 {
 	const char		*path;
+	char			*svc_str;
 	int			 flags;
 	struct duns_attr_t	 attr;
 	int			 rc;
 
 	/** Parse arguments, flags not used for now */
-	RETURN_NULL_IF_FAILED_TO_PARSE(args, "si", &path, &flags);
+	RETURN_NULL_IF_FAILED_TO_PARSE(args, "ssi", &path, &svc_str, &flags);
 
 	rc = duns_resolve_path(path, &attr);
 
-	return cont_open(rc, attr.da_puuid, attr.da_cuuid, flags);
+	return cont_open(rc, attr.da_puuid, attr.da_cuuid, svc_str, flags);
 }
 
 static PyObject *


### PR DESCRIPTION
Add a python option for svc to allow non-standard values.
Fix the return code of open_by_path() and correctly pass
in flags value to avoid issues at connect time.