### PR TITLE
DAOS-4058 doc: add properties related stuff in daos manpage

### DIFF
--- a/doc/man/man8/daos.8
+++ b/doc/man/man8/daos.8
@@ -56,6 +56,8 @@ The \fBRESOURCE\fRs, respective \fBCOMMAND\fRs and \fBOPTION\fRs supported by \f
 .br
 	  \fBget-attr\fR         get pool user-defined attribute
 .br
+	  \fBget-prop\fR         get pool properties
+.br
 .TP
 .I pool \fBOPTION\fRs:
 	  \fB--pool=\fRUUID        pool UUID
@@ -90,6 +92,8 @@ The \fBRESOURCE\fRs, respective \fBCOMMAND\fRs and \fBOPTION\fRs supported by \f
 .br
 	  \fBset-attr\fR         set container user-defined attribute
 .br
+	  \fBget-prop\fR         get container properties
+.br
 	  \fBcreate-snap\fR      create container snapshot (optional name)
 .br
 				    at most recent committed epoch
@@ -121,6 +125,21 @@ The \fBRESOURCE\fRs, respective \fBCOMMAND\fRs and \fBOPTION\fRs supported by \f
 	  \fB--chunk_size=\fRBYTES chunk size of files created. Supports suffixes:
 .br
 				      K (KB), M (MB), G (GB), T (TB), P (PB), E (EB)
+.TP
+.I container \fBOPTION\fRs (create):
+	  \fB--properties=\fR<name>:<value>[,<name>:<value>,...]      (optional) container properties
+.br
+				      Supported properties names:
+.br
+				      \fBlabel\fR (can be any string)
+.br
+				      \fBcksum\fR checksum type (can be {off,crc{16,32,64}})
+.br
+				      \fBcksum_size\fR checksum chunk size (can be any value)
+.br
+				      \fBsrv_cksum\fR checksum server verify (can be {on,off})
+.br
+				      \fBrf\fR redundancy factor (can be {0,1,2,3,4})
 .TP
 .I container \fBOPTION\fRs (destroy):
 	  \fB--force\fR            destroy container regardless of state

--- a/doc/man/man8/daos.8
+++ b/doc/man/man8/daos.8
@@ -133,7 +133,7 @@ The \fBRESOURCE\fRs, respective \fBCOMMAND\fRs and \fBOPTION\fRs supported by \f
 .br
 				      \fBlabel\fR (can be any string)
 .br
-				      \fBcksum\fR checksum type (can be {off,crc{16,32,64}})
+				      \fBcksum\fR checksum type (can be {off,crc{16,32,64},sha1})
 .br
 				      \fBcksum_size\fR checksum chunk size (can be any value)
 .br


### PR DESCRIPTION
This is a follow-on to DAOS-3741 changes, to add missing
pool/container "get properties" sub-cmd description, along with
container properties specification during "container create", in
daos command manpage.

Signed-off-by: Bruno Faccini <bruno.faccini@intel.com>

Change-Id: I4f822f57f1725aec26830c3b6ff2c6e247e91e40