### PR TITLE
DAOS-4168 security: Add PoolQuery to grpc authorization table

### DIFF
--- a/src/control/security/grpc_authorization.go
+++ b/src/control/security/grpc_authorization.go
@@ -51,6 +51,7 @@ var methodAuthorizations = map[string]Component{
 	"/mgmt.MgmtSvc/PoolDestroy":         ComponentAdmin,
 	"/mgmt.MgmtSvc/PoolGetACL":          ComponentAdmin,
 	"/mgmt.MgmtSvc/PoolOverwriteACL":    ComponentAdmin,
+	"/mgmt.MgmtSvc/PoolQuery":           ComponentAdmin,
 	"/mgmt.MgmtSvc/GetAttachInfo":       ComponentAgent,
 	"/mgmt.MgmtSvc/BioHealthQuery":      ComponentAdmin,
 	"/mgmt.MgmtSvc/SmdListDevs":         ComponentAdmin,

--- a/src/control/security/grpc_authorization_test.go
+++ b/src/control/security/grpc_authorization_test.go
@@ -72,6 +72,7 @@ func TestHasAccess(t *testing.T) {
 		{"PoolDestroy", ComponentAdmin, "/mgmt.MgmtSvc/PoolDestroy"},
 		{"PoolGetACL", ComponentAdmin, "/mgmt.MgmtSvc/PoolGetACL"},
 		{"PoolOverwriteACL", ComponentAdmin, "/mgmt.MgmtSvc/PoolOverwriteACL"},
+		{"PoolQuery", ComponentAdmin, "/mgmt.MgmtSvc/PoolQuery"},
 		{"GetAttachInfo", ComponentAgent, "/mgmt.MgmtSvc/GetAttachInfo"},
 		{"BioHealthQuery", ComponentAdmin, "/mgmt.MgmtSvc/BioHealthQuery"},
 		{"SmdListDevs", ComponentAdmin, "/mgmt.MgmtSvc/SmdListDevs"},


### PR DESCRIPTION
PoolQuery gRPC is missing an entry in the authorization table causing it to
fail if certificates are enabled. This adds the entry to the authorization
table and the corresponding tests.

Signed-off-by: David Quigley <david.quigley@intel.com>

This is a backport of a fix that is merged into master.