### PR TITLE
CORCI-682 build: Publish on landing to $daos_branch

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -41,6 +41,7 @@
 //@Library(value="pipeline-lib@your_branch") _
 
 
+def daos_branch = "master"
 def arch = ""
 def sanitized_JOB_NAME = JOB_NAME.toLowerCase().replaceAll('/', '-').replaceAll('%2f', '-')
 
@@ -146,7 +147,6 @@ pipeline {
                 allOf {
                     not { branch 'weekly-testing' }
                     expression { env.CHANGE_TARGET != 'weekly-testing' }
-                    expression { return env.QUICKBUILD == '1' }
                 }
             }
             parallel {
@@ -261,6 +261,7 @@ pipeline {
                                                 format: 'yum',
                                                 maturity: 'stable',
                                                 tech: 'el-7',
+                                                publish_branch: daos_branch,
                                                 repo_dir: 'artifacts/centos7/'
                             stepResult name: env.STAGE_NAME, context: "build",
                                        result: "SUCCESS"
@@ -340,6 +341,7 @@ pipeline {
                                                 format: 'yum',
                                                 maturity: 'stable',
                                                 tech: 'leap-15',
+                                                publish_branch: daos_branch,
                                                 repo_dir: 'artifacts/leap15/'
                             stepResult name: env.STAGE_NAME, context: "build",
                                        result: "SUCCESS"
@@ -1380,7 +1382,9 @@ pipeline {
                         allOf {
                             not { branch 'weekly-testing' }
                             expression { env.CHANGE_TARGET != 'weekly-testing' }
-                            expression { return env.QUICKBUILD == '1' }
+                            expression {
+                                ! commitPragma(pragma: 'Skip-test-centos-rpms').contains('true')
+                            }
                         }
                     }
                     agent {
@@ -1408,7 +1412,7 @@ pipeline {
     }
     post {
         unsuccessful {
-            notifyBrokenBranch branches: "master"
+            notifyBrokenBranch branches: daos_branch
         }
     }
 }


### PR DESCRIPTION
Which is defined at the top of the Jenkinsfile for each branch when a
branch  is created.  Would be better to figure this out dynamically
somehow but I don't know if that is possible.

Add Skip-test-centos-rpms pragma and remove the skip of testing CentOS
RPMs when Quick-build is true.

Signed-off-by: Brian J. Murrell <brian.murrell@intel.com>