### PR TITLE
DAOS-4228 umem: race caused by yield in tx end callback

### DIFF
--- a/src/common/mem.c
+++ b/src/common/mem.c
@@ -145,11 +145,23 @@ static void
 pmem_process_cb_vec(struct umem_tx_stage_item *vec, unsigned int *cnt,
 		    bool noop)
 {
-	struct umem_tx_stage_item	*txi;
-	int				 i;
+	struct umem_tx_stage_item	*txi, *txi_arr;
+	unsigned int			 i, num = *cnt;
 
-	for (i = 0; i < *cnt; i++) {
-		txi = &vec[i];
+	/* @vec & @cnt could be changed by other ULT while txi_fn yielding */
+	if (num > 0) {
+		D_ALLOC_ARRAY(txi_arr, num);
+		if (txi_arr == NULL) {
+			D_ERROR("Failed to allocate txi array\n");
+			return;
+		}
+		memcpy(txi_arr, vec, sizeof(*txi) * num);
+		*cnt = 0;
+		memset(vec, 0, sizeof(*txi) * num);
+	}
+
+	for (i = 0; i < num; i++) {
+		txi = &txi_arr[i];
 
 		D_ASSERT(txi->txi_magic == UMEM_TX_DATA_MAGIC);
 		D_ASSERT(txi->txi_fn != NULL);
@@ -158,10 +170,8 @@ pmem_process_cb_vec(struct umem_tx_stage_item *vec, unsigned int *cnt,
 		txi->txi_fn(txi->txi_data, noop);
 	}
 
-	if (*cnt != 0) {
-		memset(vec, 0, sizeof(*txi) * (*cnt));
-		*cnt = 0;
-	}
+	if (num > 0)
+		D_FREE(txi_arr);
 }
 
 /*

--- a/src/container/srv_target.c
+++ b/src/container/srv_target.c
@@ -948,15 +948,20 @@ cont_child_destroy_one(void *vin)
 		 * the container has never been opened */
 		rc = 0;
 	}
+
+	/*
+	 * Pause flushing free extents in VEA aging buffer, otherwise,
+	 * there'll be way more fragments to be processed.
+	 */
+	vos_pool_ctl(pool->spc_hdl, VOS_PO_CTL_VEA_PLUG);
+
 	/* XXX there might be a race between GC and pool destroy, let's do
 	 * synchronous GC for now.
 	 */
 	dss_gc_run(pool->spc_hdl, -1);
-	/*
-	 * Force VEA to expire all the just freed extents and make them
-	 * available for allocation immediately.
-	 */
-	vos_pool_ctl(pool->spc_hdl, VOS_PO_CTL_VEA_FLUSH);
+
+	/* Unplug and make the freed extents available immediately. */
+	vos_pool_ctl(pool->spc_hdl, VOS_PO_CTL_VEA_UNPLUG);
 	if (rc) {
 		D_ERROR(DF_CONT": VEA flush failed. "DF_RC"\n",
 			DP_CONT(pool->spc_uuid, in->tdi_uuid), DP_RC(rc));

--- a/src/include/daos_srv/vea.h
+++ b/src/include/daos_srv/vea.h
@@ -317,11 +317,11 @@ int vea_query(struct vea_space_info *vsi, struct vea_attr *attr,
 	      struct vea_stat *stat);
 
 /**
- * Force flushing the free extents in aging buffer and make them available
- * for allocation immediately.
+ * Pause or resume flushing the free extents in aging buffer
  *
  * \param vsi       [IN]	In-memory compund index
+ * \param plug      [IN]	Plug or unplug
  */
-void vea_flush(struct vea_space_info *vsi);
+void vea_flush(struct vea_space_info *vsi, bool plug);
 
 #endif /* __VEA_API_H__ */

--- a/src/include/daos_srv/vos.h
+++ b/src/include/daos_srv/vos.h
@@ -922,10 +922,16 @@ int
 vos_pool_get_scm_cutoff(void);
 
 enum vos_pool_opc {
-	/** reset pool GC statistics */
+	/** Reset pool GC statistics */
 	VOS_PO_CTL_RESET_GC,
-	/** force VEA flush */
-	VOS_PO_CTL_VEA_FLUSH,
+	/**
+	 * Pause flushing the free extents in aging buffer. This is usually
+	 * called before container destroy where huge amount of extents could
+	 * be freed in a short period of time.
+	 */
+	VOS_PO_CTL_VEA_PLUG,
+	/** Pairing with PLUG, usually called after container destroy done. */
+	VOS_PO_CTL_VEA_UNPLUG,
 };
 
 /**

--- a/src/vea/vea_free.c
+++ b/src/vea/vea_free.c
@@ -329,8 +329,8 @@ migrate_end_cb(void *data, bool noop)
 	if (rc)
 		return;
 
-	D_ASSERT(cur_time >= vsi->vsi_agg_time);
-	if (cur_time < (vsi->vsi_agg_time + VEA_MIGRATE_INTVL))
+	if (vsi->vsi_agg_time == UINT64_MAX ||
+	    cur_time < (vsi->vsi_agg_time + VEA_MIGRATE_INTVL))
 		return;
 
 	D_ASSERT(pmemobj_tx_stage() == TX_STAGE_NONE);
@@ -388,6 +388,7 @@ migrate_end_cb(void *data, bool noop)
 
 	/* Update aggregation time before yield */
 	vsi->vsi_agg_time = cur_time;
+	vsi->vsi_agg_scheduled = false;
 
 	/*
 	 * According to NVMe spec, unmap isn't an expensive non-queue command
@@ -421,7 +422,7 @@ migrate_end_cb(void *data, bool noop)
 }
 
 void
-migrate_free_exts(struct vea_space_info *vsi)
+migrate_free_exts(struct vea_space_info *vsi, bool add_tx_cb)
 {
 	uint64_t	cur_time;
 	int		rc;
@@ -433,6 +434,13 @@ migrate_free_exts(struct vea_space_info *vsi)
 	}
 
 	/*
+	 * Skip this free extent migration if the transaction is started
+	 * without tx callback data provided, see umem_tx_begin().
+	 */
+	if (!add_tx_cb)
+		return;
+
+	/*
 	 * Check aggregation time in advance to avoid unnecessary
 	 * umem_tx_add_callback() calls.
 	 */
@@ -440,8 +448,12 @@ migrate_free_exts(struct vea_space_info *vsi)
 	if (rc)
 		return;
 
-	D_ASSERT(cur_time >= vsi->vsi_agg_time);
-	if (cur_time < (vsi->vsi_agg_time + VEA_MIGRATE_INTVL))
+	if (vsi->vsi_agg_time == UINT64_MAX ||
+	    cur_time < (vsi->vsi_agg_time + VEA_MIGRATE_INTVL))
+		return;
+
+	/* Schedule one migrate_end_cb() is enough */
+	if (vsi->vsi_agg_scheduled)
 		return;
 
 	/*
@@ -450,7 +462,10 @@ migrate_free_exts(struct vea_space_info *vsi)
 	 */
 	rc = umem_tx_add_callback(vsi->vsi_umem, vsi->vsi_txd, TX_STAGE_NONE,
 				  migrate_end_cb, vsi);
-	if (rc)
+	if (rc) {
 		D_ERROR("Add transaction end callback error "DF_RC"\n",
 			DP_RC(rc));
+		return;
+	}
+	vsi->vsi_agg_scheduled = true;
 }

--- a/src/vea/vea_internal.h
+++ b/src/vea/vea_internal.h
@@ -134,6 +134,7 @@ struct vea_space_info {
 	struct vea_unmap_context	 vsi_unmap_ctxt;
 	/* Statistics */
 	uint64_t			 vsi_stat[STAT_MAX];
+	bool				 vsi_agg_scheduled;
 };
 
 static inline bool ext_is_idle(struct vea_free_extent *vfe)
@@ -179,7 +180,7 @@ int compound_free(struct vea_space_info *vsi, struct vea_free_extent *vfe,
 		  unsigned int flags);
 int persistent_free(struct vea_space_info *vsi, struct vea_free_extent *vfe);
 int aggregated_free(struct vea_space_info *vsi, struct vea_free_extent *vfe);
-void migrate_free_exts(struct vea_space_info *vsi);
+void migrate_free_exts(struct vea_space_info *vsi, bool add_tx_cb);
 
 /* vea_hint.c */
 void hint_get(struct vea_hint_context *hint, uint64_t *off);

--- a/src/vos/vos_pool.c
+++ b/src/vos/vos_pool.c
@@ -744,10 +744,15 @@ vos_pool_ctl(daos_handle_t poh, enum vos_pool_opc opc)
 	case VOS_PO_CTL_RESET_GC:
 		memset(&pool->vp_gc_stat, 0, sizeof(pool->vp_gc_stat));
 		break;
-	case VOS_PO_CTL_VEA_FLUSH:
+	case VOS_PO_CTL_VEA_PLUG:
 		if (pool->vp_vea_info != NULL)
-			vea_flush(pool->vp_vea_info);
+			vea_flush(pool->vp_vea_info, true);
+		break;
+	case VOS_PO_CTL_VEA_UNPLUG:
+		if (pool->vp_vea_info != NULL)
+			vea_flush(pool->vp_vea_info, false);
 		break;
 	}
+
 	return 0;
 }


### PR DESCRIPTION
Some transaction end callback like the one from vea_free() could
yield on blob unmap, so we need to operate on a copy when processing
the tx callback vector.

This patch also introduced 'plug' & 'unplug" VEA calls. (through
the existing vea_flush()). The 'plug' will pause flushing free
extents in the aging buffer, it's usually being called before a
container destroy, otherwise, there'll be way more fragments being
processed separately. The 'unplug' will resume the flushing and do
a immediate flush.

The 'plug' & 'unplug' change can reduce a container destroy time
from 24 minutes to 39 seconds. (~ 2.5 million free calls for the
container)

This patch also improved VEA to:
- Avoid scheduling tx end callback when the transaction started w/o
  tx callback data;
- Avoid scheduling multiple tx end callback (which isn't necessary)
  when there are multiple vea_free() calls in one transaction;

Signed-off-by: Niu Yawei <yawei.niu@intel.com>