### PR TITLE
DAOS-4213 sec: Add security capas to container handle

### DIFF
--- a/src/container/cli.c
+++ b/src/container/cli.c
@@ -678,7 +678,7 @@ dc_cont_open(tse_task_t *task)
 	uuid_copy(in->coi_op.ci_pool_hdl, pool->dp_pool_hdl);
 	uuid_copy(in->coi_op.ci_uuid, args->uuid);
 	uuid_copy(in->coi_op.ci_hdl, cont->dc_cont_hdl);
-	in->coi_capas = args->flags;
+	in->coi_flags = args->flags;
 	/** Determine which container properties need to be retrieved while
 	 * opening the contianer
 	 */

--- a/src/container/container_iv.c
+++ b/src/container/container_iv.c
@@ -220,7 +220,8 @@ cont_iv_ent_copy(struct ds_iv_entry *entry, d_sg_list_t *dst_sgl,
 		       src->iv_snap.snap_cnt * sizeof(src->iv_snap.snaps[0]));
 		break;
 	case IV_CONT_CAPA:
-		dst->iv_capa.capas = src->iv_capa.capas;
+		dst->iv_capa.flags = src->iv_capa.flags;
+		dst->iv_capa.sec_capas = src->iv_capa.sec_capas;
 		break;
 	case IV_CONT_PROP:
 		memcpy(&dst->iv_prop, &src->iv_prop,
@@ -341,7 +342,8 @@ cont_iv_capa_ent_update(struct ds_iv_entry *entry, struct ds_iv_key *key,
 	/* open the container locally */
 	rc = ds_cont_tgt_open(entry->ns->iv_pool_uuid,
 			      civ_key->cont_uuid, civ_ent->cont_uuid,
-			      civ_ent->iv_capa.capas);
+			      civ_ent->iv_capa.flags,
+			      civ_ent->iv_capa.sec_capas);
 	return rc;
 }
 
@@ -755,14 +757,15 @@ out_eventual:
 
 int
 cont_iv_capability_update(void *ns, uuid_t cont_hdl_uuid, uuid_t cont_uuid,
-			  uint64_t capas)
+			  uint64_t flags, uint64_t sec_capas)
 {
 	struct cont_iv_entry	iv_entry = { 0 };
 	int			rc;
 
 	/* Only happens on xstream 0 */
 	D_ASSERT(dss_get_module_info()->dmi_xs_id == 0);
-	iv_entry.iv_capa.capas = capas;
+	iv_entry.iv_capa.flags = flags;
+	iv_entry.iv_capa.sec_capas = sec_capas;
 	uuid_copy(iv_entry.cont_uuid, cont_uuid);
 
 	rc = cont_iv_update(ns, IV_CONT_CAPA, cont_hdl_uuid, &iv_entry,

--- a/src/container/rpc.h
+++ b/src/container/rpc.h
@@ -179,7 +179,8 @@ CRT_RPC_DECLARE(cont_destroy, DAOS_ISEQ_CONT_DESTROY, DAOS_OSEQ_CONT_DESTROY)
 
 #define DAOS_ISEQ_CONT_OPEN	/* input fields */		 \
 	((struct cont_op_in)	(coi_op)		CRT_VAR) \
-	((uint64_t)		(coi_capas)		CRT_VAR) \
+	((uint64_t)		(coi_flags)		CRT_VAR) \
+	((uint64_t)		(coi_sec_capas)		CRT_VAR) \
 	((uint64_t)		(coi_prop_bits)		CRT_VAR)
 
 #define DAOS_OSEQ_CONT_OPEN	/* output fields */		 \

--- a/src/container/srv_container.c
+++ b/src/container/srv_container.c
@@ -37,6 +37,7 @@
 #include <daos/rpc.h>
 #include <daos_srv/pool.h>
 #include <daos_srv/rdb.h>
+#include <daos_srv/security.h>
 #include "rpc.h"
 #include "srv_internal.h"
 #include "srv_layout.h"
@@ -817,28 +818,27 @@ cont_open(struct rdb_tx *tx, struct ds_pool_hdl *pool_hdl, struct cont *cont,
 	d_iov_t			key;
 	d_iov_t			value;
 	daos_prop_t	       *prop = NULL;
+	struct daos_prop_entry *acl_entry;
+	struct daos_prop_entry *owner_entry;
+	struct daos_prop_entry *owner_grp_entry;
 	struct container_hdl	chdl;
 	struct pool_map		*pmap;
 	struct cont_open_out   *out = crt_reply_get(rpc);
 	int			rc;
+	struct ownership	owner;
+	uint64_t		sec_capas = 0;
 
-	D_DEBUG(DF_DSMS, DF_CONT": processing rpc %p: hdl="DF_UUID" capas="
+	D_DEBUG(DF_DSMS, DF_CONT": processing rpc %p: hdl="DF_UUID" flags="
 		DF_X64"\n",
 		DP_CONT(pool_hdl->sph_pool->sp_uuid, in->coi_op.ci_uuid), rpc,
-		DP_UUID(in->coi_op.ci_hdl), in->coi_capas);
-
-	/* Verify the pool handle capabilities. */
-	if ((in->coi_capas & DAOS_COO_RW) &&
-	    !(pool_hdl->sph_flags & DAOS_PC_RW) &&
-	    !(pool_hdl->sph_flags & DAOS_PC_EX))
-		D_GOTO(out, rc = -DER_NO_PERM);
+		DP_UUID(in->coi_op.ci_hdl), in->coi_flags);
 
 	/* See if this container handle already exists. */
 	d_iov_set(&key, in->coi_op.ci_hdl, sizeof(uuid_t));
 	d_iov_set(&value, &chdl, sizeof(chdl));
 	rc = rdb_tx_lookup(tx, &cont->c_svc->cs_hdls, &key, &value);
 	if (rc != -DER_NONEXIST) {
-		if (rc == 0 && chdl.ch_capas != in->coi_capas) {
+		if (rc == 0 && chdl.ch_flags != in->coi_flags) {
 			D_ERROR(DF_CONT": found conflicting container handle\n",
 				DP_CONT(cont->c_svc->cs_pool_uuid,
 					cont->c_uuid));
@@ -854,7 +854,43 @@ cont_open(struct rdb_tx *tx, struct ds_pool_hdl *pool_hdl, struct cont *cont,
 	D_ASSERT(prop != NULL);
 	D_ASSERT(prop->dpp_nr == CONT_PROP_NUM);
 
-	if (!(in->coi_capas & DAOS_COO_FORCE)) {
+	acl_entry = daos_prop_entry_get(prop, DAOS_PROP_CO_ACL);
+	D_ASSERT(acl_entry != NULL);
+	D_ASSERT(acl_entry->dpe_val_ptr != NULL);
+
+	owner_entry = daos_prop_entry_get(prop, DAOS_PROP_CO_OWNER);
+	D_ASSERT(owner_entry != NULL);
+	D_ASSERT(owner_entry->dpe_str != NULL);
+
+	owner_grp_entry = daos_prop_entry_get(prop, DAOS_PROP_CO_OWNER_GROUP);
+	D_ASSERT(owner_grp_entry != NULL);
+	D_ASSERT(owner_grp_entry->dpe_str != NULL);
+
+	owner.user = owner_entry->dpe_str;
+	owner.group = owner_grp_entry->dpe_str;
+
+	rc = ds_sec_cont_get_capabilities(in->coi_flags, &pool_hdl->sph_cred,
+					  &owner, acl_entry->dpe_val_ptr,
+					  &sec_capas);
+	if (rc != 0) {
+		D_ERROR(DF_CONT": refusing attempt to open with flags "
+			DF_X64" error: "DF_RC"\n",
+			DP_CONT(cont->c_svc->cs_pool_uuid, cont->c_uuid),
+			in->coi_flags, DP_RC(rc));
+		daos_prop_free(prop);
+		D_GOTO(out, rc);
+	}
+
+	if (!ds_sec_cont_can_open(sec_capas)) {
+		D_ERROR(DF_CONT": permission denied opening with flags "
+			DF_X64"\n",
+			DP_CONT(cont->c_svc->cs_pool_uuid, cont->c_uuid),
+			in->coi_flags);
+		daos_prop_free(prop);
+		D_GOTO(out, rc = -DER_NO_PERM);
+	}
+
+	if (!(in->coi_flags & DAOS_COO_FORCE)) {
 		pmap = pool_hdl->sph_pool->sp_map;
 		rc = cont_verify_redun_req(pmap, prop);
 		if (rc != 0) {
@@ -882,7 +918,7 @@ cont_open(struct rdb_tx *tx, struct ds_pool_hdl *pool_hdl, struct cont *cont,
 	/* update container capa to IV */
 	rc = cont_iv_capability_update(pool_hdl->sph_pool->sp_iv_ns,
 				       in->coi_op.ci_hdl, in->coi_op.ci_uuid,
-				       in->coi_capas);
+				       in->coi_flags, sec_capas);
 	if (rc != 0) {
 		D_ERROR(DF_CONT": cont_iv_capability_update failed %d.\n",
 			DP_CONT(cont->c_svc->cs_pool_uuid, cont->c_uuid), rc);
@@ -893,7 +929,8 @@ cont_open(struct rdb_tx *tx, struct ds_pool_hdl *pool_hdl, struct cont *cont,
 
 	uuid_copy(chdl.ch_pool_hdl, pool_hdl->sph_uuid);
 	uuid_copy(chdl.ch_cont, cont->c_uuid);
-	chdl.ch_capas = in->coi_capas;
+	chdl.ch_flags = in->coi_flags;
+	chdl.ch_sec_capas = sec_capas;
 
 	rc = ds_cont_epoch_init_hdl(tx, cont, in->coi_op.ci_hdl, &chdl);
 	if (rc != 0)
@@ -1484,7 +1521,7 @@ set_prop(struct rdb_tx *tx, struct ds_pool_hdl *pool_hdl,
 	 * Can't modify the container props without RW perms to the container.
 	 * TODO DAOS-2063: Update check when set-prop and set-acl capas added.
 	 */
-	if (!(hdl->ch_capas & DAOS_COO_RW))
+	if (!(hdl->ch_flags & DAOS_COO_RW))
 		D_GOTO(out, rc = -DER_NO_PERM);
 
 	/* Read all props for prop IV update */

--- a/src/container/srv_container.c
+++ b/src/container/srv_container.c
@@ -847,7 +847,6 @@ cont_open(struct rdb_tx *tx, struct ds_pool_hdl *pool_hdl, struct cont *cont,
 		D_GOTO(out, rc);
 	}
 
-	/* Determine pool meets container redundancy factor requirments*/
 	rc = cont_prop_read(tx, cont, DAOS_CO_QUERY_PROP_ALL, &prop);
 	if (rc != 0)
 		D_GOTO(out, rc);
@@ -890,6 +889,7 @@ cont_open(struct rdb_tx *tx, struct ds_pool_hdl *pool_hdl, struct cont *cont,
 		D_GOTO(out, rc = -DER_NO_PERM);
 	}
 
+	/* Determine pool meets container redundancy factor requirements */
 	if (!(in->coi_flags & DAOS_COO_FORCE)) {
 		pmap = pool_hdl->sph_pool->sp_map;
 		rc = cont_verify_redun_req(pmap, prop);

--- a/src/container/srv_epoch.c
+++ b/src/container/srv_epoch.c
@@ -238,7 +238,7 @@ ds_cont_epoch_discard(struct rdb_tx *tx, struct ds_pool_hdl *pool_hdl,
 		DP_UUID(in->cei_op.ci_hdl), in->cei_epoch);
 
 	/* Verify the container handle capabilities. */
-	if (!(hdl->ch_capas & DAOS_COO_RW))
+	if (!(hdl->ch_flags & DAOS_COO_RW))
 		D_GOTO(out, rc = -DER_NO_PERM);
 
 	if (in->cei_epoch >= DAOS_EPOCH_MAX)
@@ -319,7 +319,7 @@ ds_cont_snap_create(struct rdb_tx *tx, struct ds_pool_hdl *pool_hdl,
 		in->cei_epoch);
 
 	/* Verify the container handle capabilities. */
-	if (!(hdl->ch_capas & DAOS_COO_RW)) {
+	if (!(hdl->ch_flags & DAOS_COO_RW)) {
 		rc = -DER_NO_PERM;
 		goto out;
 	}

--- a/src/container/srv_internal.h
+++ b/src/container/srv_internal.h
@@ -100,7 +100,8 @@ struct cont_iv_snapshot {
 };
 
 struct cont_iv_capa {
-	uint64_t	capas;
+	uint64_t	flags;
+	uint64_t	sec_capas;
 };
 
 /* flattened container properties */
@@ -220,7 +221,7 @@ void ds_cont_hdl_hash_destroy(struct d_hash_table *hash);
 void ds_cont_oid_alloc_handler(crt_rpc_t *rpc);
 
 int ds_cont_tgt_open(uuid_t pool_uuid, uuid_t cont_hdl_uuid,
-		     uuid_t cont_uuid, uint64_t capas);
+		     uuid_t cont_uuid, uint64_t flags, uint64_t sec_capas);
 int ds_cont_tgt_snapshots_update(uuid_t pool_uuid, uuid_t cont_uuid,
 				 uint64_t *snapshots, int snap_count);
 int ds_cont_tgt_snapshots_refresh(uuid_t pool_uuid, uuid_t cont_uuid);
@@ -237,7 +238,7 @@ int oid_iv_reserve(void *ns, uuid_t poh_uuid, uuid_t co_uuid, uuid_t coh_uuid,
 int ds_cont_iv_init(void);
 int ds_cont_iv_fini(void);
 int cont_iv_capability_update(void *ns, uuid_t cont_hdl_uuid, uuid_t cont_uuid,
-			      uint64_t capas);
+			      uint64_t flags, uint64_t sec_capas);
 int cont_iv_capability_invalidate(void *ns, uuid_t cont_hdl_uuid);
 int cont_iv_prop_update(void *ns, uuid_t cont_hdl_uuid, uuid_t cont_uuid,
 			daos_prop_t *prop);

--- a/src/container/srv_layout.h
+++ b/src/container/srv_layout.h
@@ -106,7 +106,8 @@ struct container_hdl {
 	uuid_t		ch_pool_hdl;
 	uuid_t		ch_cont;
 	uint64_t	ch_hce;
-	uint64_t	ch_capas;
+	uint64_t	ch_flags;
+	uint64_t	ch_sec_capas;
 };
 
 extern daos_prop_t cont_prop_default;

--- a/src/container/srv_target.c
+++ b/src/container/srv_target.c
@@ -1102,7 +1102,8 @@ ds_dtx_resync(void *arg)
 
 int
 ds_cont_local_open(uuid_t pool_uuid, uuid_t cont_hdl_uuid, uuid_t cont_uuid,
-		   uint64_t capas, struct ds_cont_hdl **cont_hdl)
+		   uint64_t flags, uint64_t sec_capas,
+		   struct ds_cont_hdl **cont_hdl)
 {
 	struct dsm_tls		*tls = dsm_tls_get();
 	struct ds_cont_hdl	*hdl;
@@ -1111,19 +1112,19 @@ ds_cont_local_open(uuid_t pool_uuid, uuid_t cont_hdl_uuid, uuid_t cont_uuid,
 
 	hdl = cont_hdl_lookup_internal(&tls->dt_cont_hdl_hash, cont_hdl_uuid);
 	if (hdl != NULL) {
-		if (capas != 0) {
-			if (hdl->sch_capas != capas) {
+		if (flags != 0) {
+			if (hdl->sch_flags != flags) {
 				D_ERROR(DF_CONT": conflicting container : hdl="
 					DF_UUID" capas="DF_U64"\n",
 					DP_CONT(pool_uuid, cont_uuid),
-					DP_UUID(cont_hdl_uuid), capas);
+					DP_UUID(cont_hdl_uuid), flags);
 				rc = -DER_EXIST;
 			} else {
 				D_DEBUG(DF_DSMS, DF_CONT": found compatible"
 					" container handle: hdl="DF_UUID
 					" capas="DF_U64"\n",
 				      DP_CONT(pool_uuid, cont_uuid),
-				      DP_UUID(cont_hdl_uuid), hdl->sch_capas);
+				      DP_UUID(cont_hdl_uuid), hdl->sch_flags);
 			}
 		}
 
@@ -1152,7 +1153,8 @@ ds_cont_local_open(uuid_t pool_uuid, uuid_t cont_hdl_uuid, uuid_t cont_uuid,
 	}
 
 	uuid_copy(hdl->sch_uuid, cont_hdl_uuid);
-	hdl->sch_capas = capas;
+	hdl->sch_flags = flags;
+	hdl->sch_sec_capas = sec_capas;
 
 	rc = cont_hdl_add(&tls->dt_cont_hdl_hash, hdl);
 	if (rc != 0)
@@ -1266,10 +1268,11 @@ err_hdl:
 }
 
 struct cont_tgt_open_arg {
-	uuid_t	pool_uuid;
-	uuid_t	cont_uuid;
-	uuid_t	cont_hdl_uuid;
-	uint64_t capas;
+	uuid_t		pool_uuid;
+	uuid_t		cont_uuid;
+	uuid_t		cont_hdl_uuid;
+	uint64_t	flags;
+	uint64_t	sec_capas;
 };
 
 /*
@@ -1282,12 +1285,13 @@ cont_open_one(void *vin)
 	struct cont_tgt_open_arg	*arg = vin;
 
 	return ds_cont_local_open(arg->pool_uuid, arg->cont_hdl_uuid,
-				  arg->cont_uuid, arg->capas, NULL);
+				  arg->cont_uuid, arg->flags, arg->sec_capas,
+				  NULL);
 }
 
 int
 ds_cont_tgt_open(uuid_t pool_uuid, uuid_t cont_hdl_uuid,
-		 uuid_t cont_uuid, uint64_t capas)
+		 uuid_t cont_uuid, uint64_t capas, uint64_t sec_capas)
 {
 	struct ds_pool		*pool = NULL;
 	struct cont_tgt_open_arg arg;
@@ -1298,7 +1302,8 @@ ds_cont_tgt_open(uuid_t pool_uuid, uuid_t cont_hdl_uuid,
 	uuid_copy(arg.pool_uuid, pool_uuid);
 	uuid_copy(arg.cont_hdl_uuid, cont_hdl_uuid);
 	uuid_copy(arg.cont_uuid, cont_uuid);
-	arg.capas = capas;
+	arg.flags = capas;
+	arg.sec_capas = sec_capas;
 
 	D_DEBUG(DB_TRACE, "open pool/cont/hdl "DF_UUID"/"DF_UUID"/"DF_UUID"\n",
 		DP_UUID(pool_uuid), DP_UUID(cont_uuid), DP_UUID(cont_hdl_uuid));

--- a/src/container/srv_target.c
+++ b/src/container/srv_target.c
@@ -1291,7 +1291,7 @@ cont_open_one(void *vin)
 
 int
 ds_cont_tgt_open(uuid_t pool_uuid, uuid_t cont_hdl_uuid,
-		 uuid_t cont_uuid, uint64_t capas, uint64_t sec_capas)
+		 uuid_t cont_uuid, uint64_t flags, uint64_t sec_capas)
 {
 	struct ds_pool		*pool = NULL;
 	struct cont_tgt_open_arg arg;
@@ -1302,7 +1302,7 @@ ds_cont_tgt_open(uuid_t pool_uuid, uuid_t cont_hdl_uuid,
 	uuid_copy(arg.pool_uuid, pool_uuid);
 	uuid_copy(arg.cont_hdl_uuid, cont_hdl_uuid);
 	uuid_copy(arg.cont_uuid, cont_uuid);
-	arg.flags = capas;
+	arg.flags = flags;
 	arg.sec_capas = sec_capas;
 
 	D_DEBUG(DB_TRACE, "open pool/cont/hdl "DF_UUID"/"DF_UUID"/"DF_UUID"\n",

--- a/src/include/daos_srv/container.h
+++ b/src/include/daos_srv/container.h
@@ -109,7 +109,8 @@ struct ds_cont_child {
 struct ds_cont_hdl {
 	d_list_t		sch_entry;
 	uuid_t			sch_uuid;	/* of the container handle */
-	uint64_t		sch_capas;
+	uint64_t		sch_flags;	/* user-supplied flags */
+	uint64_t		sch_sec_capas;	/* access control capas */
 	struct ds_cont_child	*sch_cont;
 	struct daos_csummer	*sch_csummer;
 	int			sch_ref;
@@ -123,7 +124,8 @@ int ds_cont_close_by_pool_hdls(uuid_t pool_uuid, uuid_t *pool_hdls,
 			       int n_pool_hdls, crt_context_t ctx);
 int
 ds_cont_local_open(uuid_t pool_uuid, uuid_t cont_hdl_uuid, uuid_t cont_uuid,
-		   uint64_t capas, struct ds_cont_hdl **cont_hdl);
+		   uint64_t flags, uint64_t sec_capas,
+		   struct ds_cont_hdl **cont_hdl);
 int
 ds_cont_local_close(uuid_t cont_hdl_uuid);
 

--- a/src/include/daos_srv/security.h
+++ b/src/include/daos_srv/security.h
@@ -117,4 +117,17 @@ ds_sec_cont_get_capabilities(uint64_t flags, d_iov_t *cred,
 bool
 ds_sec_pool_can_connect(uint64_t pool_capas);
 
+/**
+ * Determine if the container can be opened based on the calculated set of
+ * container capabilities.
+ *
+ * \param	cont_capas	Capability bits acquired via
+ *				ds_sec_cont_get_capabilities
+ *
+ * \return	True		Access allowed
+ *		False		Access denied
+ */
+bool
+ds_sec_cont_can_open(uint64_t cont_capas);
+
 #endif /* __DAOS_SRV_SECURITY_H__ */

--- a/src/object/srv_obj.c
+++ b/src/object/srv_obj.c
@@ -1044,10 +1044,10 @@ obj_ioc_init(uuid_t pool_uuid, uuid_t coh_uuid, uuid_t cont_uuid, int opc,
 		return rc;
 	}
 
-	if (obj_is_modification_opc(opc) && !(coh->sch_capas & DAOS_COO_RW)) {
+	if (obj_is_modification_opc(opc) && !(coh->sch_flags & DAOS_COO_RW)) {
 		D_ERROR("cont "DF_UUID" hdl "DF_UUID" sch_capas "DF_U64", "
 			"NO_PERM to update.\n", DP_UUID(cont_uuid),
-			DP_UUID(coh_uuid), coh->sch_capas);
+			DP_UUID(coh_uuid), coh->sch_flags);
 		D_GOTO(failed, rc = -DER_NO_PERM);
 	}
 

--- a/src/rebuild/srv.c
+++ b/src/rebuild/srv.c
@@ -1667,7 +1667,7 @@ rebuild_prepare_one(void *data)
 	D_ASSERT(dss_get_module_info()->dmi_xs_id != 0);
 	/* Create ds_container locally on main XS */
 	rc = ds_cont_local_open(rpt->rt_pool_uuid, rpt->rt_coh_uuid,
-				NULL, 0, NULL);
+				NULL, 0, 0, NULL);
 	if (rc)
 		pool_tls->rebuild_pool_status = rc;
 

--- a/src/security/srv_acl.c
+++ b/src/security/srv_acl.c
@@ -660,3 +660,12 @@ ds_sec_pool_can_connect(uint64_t pool_capas)
 {
 	return (pool_capas & POOL_CAPA_READ) != 0;
 }
+
+bool
+ds_sec_cont_can_open(uint64_t cont_capas)
+{
+	/*
+	 * Need to have some form of read access at minimum.
+	 */
+	return (cont_capas & CONT_CAPAS_RO_MASK) != 0;
+}

--- a/src/security/tests/srv_acl_tests.c
+++ b/src/security/tests/srv_acl_tests.c
@@ -1785,6 +1785,29 @@ test_pool_can_connect(void **state)
 					    POOL_CAPA_DEL_CONT));
 }
 
+/*
+ * Container access tests
+ */
+static void
+test_cont_can_open(void **state)
+{
+	assert_false(ds_sec_cont_can_open(0));
+	/* Need read access at minimum - write-only isn't allowed */
+	assert_false(ds_sec_cont_can_open(~CONT_CAPAS_RO_MASK));
+
+	assert_true(ds_sec_cont_can_open(CONT_CAPA_READ_DATA));
+	assert_true(ds_sec_cont_can_open(CONT_CAPA_GET_PROP));
+	assert_true(ds_sec_cont_can_open(CONT_CAPA_GET_ACL));
+	assert_true(ds_sec_cont_can_open(CONT_CAPAS_RO_MASK));
+	assert_true(ds_sec_cont_can_open(CONT_CAPA_READ_DATA |
+					 CONT_CAPA_WRITE_DATA |
+					 CONT_CAPA_GET_PROP |
+					 CONT_CAPA_SET_PROP |
+					 CONT_CAPA_GET_ACL |
+					 CONT_CAPA_SET_ACL |
+					 CONT_CAPA_SET_OWNER));
+}
+
 /* Convenience macro for unit tests */
 #define ACL_UTEST(X)	cmocka_unit_test_setup_teardown(X, srv_acl_setup, \
 							srv_acl_teardown)
@@ -1846,6 +1869,7 @@ main(void)
 		cmocka_unit_test(test_cont_get_capas_success),
 		cmocka_unit_test(test_cont_get_capas_denied),
 		cmocka_unit_test(test_pool_can_connect),
+		cmocka_unit_test(test_cont_can_open),
 	};
 
 	return cmocka_run_group_tests(tests, NULL, NULL);


### PR DESCRIPTION
This patch begins the enforcement of container ACLs.
The container ACL will be consulted during container
open, rather than using the pool handle's flags.

- Add security capabilities to server-side container
  handle structures and IV.
- Rename the old "capas" field to "flags" everywhere
  it's used, to better represent its updated function
  and avoid confusion.
- Derive the container security capas from the ACL
  and ownership props during container open, and use
  them as a basis for enforcement on container open.
- Add method ds_sec_cont_can_open to enforce container
  open.

Signed-off-by: Kris Jacque <kristin.jacque@intel.com>