### PR TITLE
DAOS-4210 sec: Enforce ACL for create/del cont

### DIFF
--- a/src/container/cli.c
+++ b/src/container/cli.c
@@ -243,9 +243,6 @@ dc_cont_create(tse_task_t *task)
 	if (pool == NULL)
 		D_GOTO(err_task, rc = -DER_NO_HDL);
 
-	if (!(pool->dp_capas & DAOS_PC_RW) && !(pool->dp_capas & DAOS_PC_EX))
-		D_GOTO(err_pool, rc = -DER_NO_PERM);
-
 	rc = dup_with_default_ownership_props(&rpc_prop, args->prop);
 	if (rc != 0)
 		D_GOTO(err_pool, rc);
@@ -349,9 +346,6 @@ dc_cont_destroy(tse_task_t *task)
 	pool = dc_hdl2pool(args->poh);
 	if (pool == NULL)
 		D_GOTO(err, rc = -DER_NO_HDL);
-
-	if (!(pool->dp_capas & DAOS_PC_RW) && !(pool->dp_capas & DAOS_PC_EX))
-		D_GOTO(err_pool, rc = -DER_NO_PERM);
 
 	D_DEBUG(DF_DSMC, DF_UUID": destroying "DF_UUID": force=%d\n",
 		DP_UUID(pool->dp_pool), DP_UUID(args->uuid), args->force);
@@ -647,9 +641,6 @@ dc_cont_open(tse_task_t *task)
 	pool = dc_hdl2pool(args->poh);
 	if (pool == NULL)
 		D_GOTO(err, rc = -DER_NO_HDL);
-
-	if ((args->flags & DAOS_COO_RW) && (pool->dp_capas & DAOS_PC_RO))
-		D_GOTO(err_pool, rc = -DER_NO_PERM);
 
 	if (cont == NULL) {
 		cont = dc_cont_alloc(args->uuid);
@@ -1767,10 +1758,6 @@ dc_cont_g2l(daos_handle_t poh, struct dc_cont_glob *cont_glob,
 			DP_UUID(cont_glob->dcg_pool_hdl));
 		D_GOTO(out, rc = -DER_INVAL);
 	}
-
-	if ((cont_glob->dcg_capas & DAOS_COO_RW) &&
-	    (pool->dp_capas & DAOS_PC_RO))
-		D_GOTO(out_pool, rc = -DER_NO_PERM);
 
 	cont = dc_cont_alloc(cont_glob->dcg_uuid);
 	if (cont == NULL)

--- a/src/include/daos_srv/security.h
+++ b/src/include/daos_srv/security.h
@@ -118,6 +118,32 @@ bool
 ds_sec_pool_can_connect(uint64_t pool_capas);
 
 /**
+ * Determine if a pool handle with given security capabilities can create a
+ * container.
+ *
+ * \param	pool_capas	Capability bits acquired via
+ *				ds_sec_pool_get_capabilities
+ *
+ * \return	True		Operation allowed
+ *		False		Operation forbidden
+ */
+bool
+ds_sec_pool_can_create_cont(uint64_t pool_capas);
+
+/**
+ * Determine if a pool handle with given security capabilities can delete a
+ * container.
+ *
+ * \param	pool_capas	Capability bits acquired via
+ *				ds_sec_pool_get_capabilities
+ *
+ * \return	True		Operation allowed
+ *		False		Operation forbidden
+ */
+bool
+ds_sec_pool_can_delete_cont(uint64_t pool_capas);
+
+/**
  * Determine if the container can be opened based on the calculated set of
  * container capabilities.
  *
@@ -129,5 +155,21 @@ ds_sec_pool_can_connect(uint64_t pool_capas);
  */
 bool
 ds_sec_cont_can_open(uint64_t cont_capas);
+
+/**
+ * Determine if the container can be deleted by the user with the given
+ * credential, based on the container ACL and ownership information.
+ *
+ * \param	pool_flags	Parent pool handle flags
+ * \param	cred		Pool's security credential
+ * \param	ownership	Container ownership information
+ * \param	acl		Container ACL
+ *
+ * \return	True		Operation allowed
+ *		False		Operation forbidden
+ */
+bool
+ds_sec_cont_can_delete(uint64_t pool_flags, d_iov_t *cred,
+		       struct ownership *ownership, struct daos_acl *acl);
 
 #endif /* __DAOS_SRV_SECURITY_H__ */

--- a/src/security/srv_acl.c
+++ b/src/security/srv_acl.c
@@ -105,7 +105,12 @@ ds_sec_alloc_default_daos_pool_acl(void)
 	uint64_t	owner_perms;
 	uint64_t	grp_perms;
 
-	/* pool owner and grp have full read/write access */
+	/*
+	 * TODO: modify default pool owner/group perms to the more granular
+	 * create_cont/del_cont
+	 */
+
+	/* pool owner and group have full read/write access */
 	owner_perms = DAOS_ACL_PERM_READ | DAOS_ACL_PERM_WRITE;
 	grp_perms = DAOS_ACL_PERM_READ | DAOS_ACL_PERM_WRITE;
 
@@ -553,6 +558,8 @@ cont_capas_from_perms(uint64_t perms)
 		capas |= CONT_CAPA_SET_ACL;
 	if (perms & DAOS_ACL_PERM_SET_OWNER)
 		capas |= CONT_CAPA_SET_OWNER;
+	if (perms & DAOS_ACL_PERM_DEL_CONT)
+		capas |= CONT_CAPA_DELETE;
 
 	return capas;
 }
@@ -662,10 +669,49 @@ ds_sec_pool_can_connect(uint64_t pool_capas)
 }
 
 bool
+ds_sec_pool_can_create_cont(uint64_t pool_capas)
+{
+	return (pool_capas & POOL_CAPA_CREATE_CONT) != 0;
+}
+bool
+ds_sec_pool_can_delete_cont(uint64_t pool_capas)
+{
+	return (pool_capas & POOL_CAPA_DEL_CONT) != 0;
+}
+
+bool
 ds_sec_cont_can_open(uint64_t cont_capas)
 {
 	/*
 	 * Need to have some form of read access at minimum.
 	 */
 	return (cont_capas & CONT_CAPAS_RO_MASK) != 0;
+}
+
+bool
+ds_sec_cont_can_delete(uint64_t pool_flags, d_iov_t *cred,
+		       struct ownership *ownership,
+		       struct daos_acl *acl)
+{
+	int		rc;
+	uint64_t	capas = 0;
+	uint64_t	cont_flags = 0;
+
+	/*
+	 * Translate the pool flags to allow us to properly filter RO/RW
+	 * permissions
+	 */
+	if (pool_flags & DAOS_PC_RO)
+		cont_flags |= DAOS_COO_RO;
+	if (pool_flags & DAOS_PC_RW)
+		cont_flags |= DAOS_COO_RW;
+
+	rc = ds_sec_cont_get_capabilities(cont_flags, cred, ownership, acl,
+					  &capas);
+	if (rc != 0) {
+		D_ERROR("failed to get container capabilities: %d\n", rc);
+		return false;
+	}
+
+	return (capas & CONT_CAPA_DELETE) != 0;
 }

--- a/src/security/srv_internal.h
+++ b/src/security/srv_internal.h
@@ -57,6 +57,7 @@ extern char *ds_sec_server_socket_path;
 #define CONT_CAPA_GET_ACL	(1U << 4)
 #define CONT_CAPA_SET_ACL	(1U << 5)
 #define CONT_CAPA_SET_OWNER	(1U << 6)
+#define CONT_CAPA_DELETE	(1U << 7)
 
 #define CONT_CAPAS_RO_MASK	(CONT_CAPA_READ_DATA |			\
 				 CONT_CAPA_GET_PROP |			\

--- a/src/security/tests/srv_acl_tests.c
+++ b/src/security/tests/srv_acl_tests.c
@@ -486,7 +486,10 @@ test_default_pool_acl(void **state)
 {
 	struct daos_acl	*acl;
 	struct daos_ace	*current = NULL;
-	uint64_t	exp_perms = DAOS_ACL_PERM_READ | DAOS_ACL_PERM_WRITE;
+	uint64_t	exp_owner_perms = DAOS_ACL_PERM_READ |
+					  DAOS_ACL_PERM_WRITE;
+	uint64_t	exp_grp_perms = DAOS_ACL_PERM_READ |
+					DAOS_ACL_PERM_WRITE;
 
 	acl = ds_sec_alloc_default_daos_pool_acl();
 
@@ -495,12 +498,13 @@ test_default_pool_acl(void **state)
 
 	current = daos_acl_get_next_ace(acl, NULL);
 	assert_non_null(current);
-	expect_ace_is_type_with_perms(current, DAOS_ACL_OWNER, 0, exp_perms);
+	expect_ace_is_type_with_perms(current, DAOS_ACL_OWNER, 0,
+				      exp_owner_perms);
 
 	current = daos_acl_get_next_ace(acl, current);
 	assert_non_null(current);
 	expect_ace_is_type_with_perms(current, DAOS_ACL_OWNER_GROUP,
-				      DAOS_ACL_FLAG_GROUP, exp_perms);
+				      DAOS_ACL_FLAG_GROUP, exp_grp_perms);
 
 	current = daos_acl_get_next_ace(acl, current);
 	assert_null(current); /* shouldn't be any more ACEs */
@@ -1739,6 +1743,11 @@ test_cont_get_capas_success(void **state)
 				     CONT_CAPA_SET_ACL |
 				     CONT_CAPA_GET_ACL |
 				     CONT_CAPA_SET_OWNER);
+	expect_cont_capas_with_perms(DAOS_ACL_PERM_READ |
+				     DAOS_ACL_PERM_DEL_CONT,
+				     DAOS_COO_RW,
+				     CONT_CAPA_READ_DATA |
+				     CONT_CAPA_DELETE);
 	expect_cont_capas_with_perms(DAOS_ACL_PERM_CONT_ALL,
 				     DAOS_COO_RW,
 				     CONT_CAPA_READ_DATA |
@@ -1747,7 +1756,8 @@ test_cont_get_capas_success(void **state)
 				     CONT_CAPA_GET_PROP |
 				     CONT_CAPA_SET_ACL |
 				     CONT_CAPA_GET_ACL |
-				     CONT_CAPA_SET_OWNER);
+				     CONT_CAPA_SET_OWNER |
+				     CONT_CAPA_DELETE);
 	expect_cont_capas_with_perms(DAOS_ACL_PERM_CONT_ALL,
 				     DAOS_COO_RO,
 				     CONT_CAPA_READ_DATA |
@@ -1764,6 +1774,7 @@ test_cont_get_capas_denied(void **state)
 	expect_cont_capas_with_perms(DAOS_ACL_PERM_GET_PROP, DAOS_COO_RW, 0);
 	expect_cont_capas_with_perms(DAOS_ACL_PERM_GET_ACL, DAOS_COO_RW, 0);
 	expect_cont_capas_with_perms(DAOS_ACL_PERM_WRITE, DAOS_COO_RW, 0);
+	expect_cont_capas_with_perms(DAOS_ACL_PERM_DEL_CONT, DAOS_COO_RW, 0);
 	expect_cont_capas_with_perms(DAOS_ACL_PERM_SET_PROP, DAOS_COO_RW, 0);
 	expect_cont_capas_with_perms(DAOS_ACL_PERM_SET_ACL, DAOS_COO_RW, 0);
 	expect_cont_capas_with_perms(DAOS_ACL_PERM_SET_OWNER, DAOS_COO_RW, 0);
@@ -1776,13 +1787,36 @@ static void
 test_pool_can_connect(void **state)
 {
 	assert_false(ds_sec_pool_can_connect(0));
-	assert_false(ds_sec_pool_can_connect(POOL_CAPA_CREATE_CONT |
-					     POOL_CAPA_DEL_CONT));
+	assert_false(ds_sec_pool_can_connect(~POOL_CAPA_READ));
 
 	assert_true(ds_sec_pool_can_connect(POOL_CAPA_READ));
 	assert_true(ds_sec_pool_can_connect(POOL_CAPA_READ |
 					    POOL_CAPA_CREATE_CONT |
 					    POOL_CAPA_DEL_CONT));
+}
+
+static void
+test_pool_can_create_cont(void **state)
+{
+	assert_false(ds_sec_pool_can_create_cont(0));
+	assert_false(ds_sec_pool_can_create_cont(~POOL_CAPA_CREATE_CONT));
+
+	assert_true(ds_sec_pool_can_create_cont(POOL_CAPA_CREATE_CONT));
+	assert_true(ds_sec_pool_can_create_cont(POOL_CAPA_READ |
+						POOL_CAPA_CREATE_CONT |
+						POOL_CAPA_DEL_CONT));
+}
+
+static void
+test_pool_can_delete_cont(void **state)
+{
+	assert_false(ds_sec_pool_can_delete_cont(0));
+	assert_false(ds_sec_pool_can_delete_cont(~POOL_CAPA_DEL_CONT));
+
+	assert_true(ds_sec_pool_can_delete_cont(POOL_CAPA_DEL_CONT));
+	assert_true(ds_sec_pool_can_delete_cont(POOL_CAPA_READ |
+						POOL_CAPA_CREATE_CONT |
+						POOL_CAPA_DEL_CONT));
 }
 
 /*
@@ -1806,6 +1840,53 @@ test_cont_can_open(void **state)
 					 CONT_CAPA_GET_ACL |
 					 CONT_CAPA_SET_ACL |
 					 CONT_CAPA_SET_OWNER));
+}
+
+static void
+test_cont_can_delete(void **state)
+{
+	d_iov_t			cred;
+	struct ownership	owner;
+	struct daos_acl		*default_acl;
+	struct daos_acl		*no_del_acl;
+	struct daos_acl		*min_acl;
+
+	init_default_cred(&cred);
+	init_default_ownership(&owner);
+
+	/* minimal good container ACL that allows delete */
+	min_acl = get_acl_with_perms(DAOS_ACL_PERM_READ |
+				     DAOS_ACL_PERM_DEL_CONT, 0);
+
+	/* all container perms except delete */
+	no_del_acl = get_acl_with_perms(DAOS_ACL_PERM_CONT_ALL &
+					~DAOS_ACL_PERM_DEL_CONT, 0);
+
+	/* default container ACL */
+	default_acl = ds_sec_alloc_default_daos_cont_acl();
+
+	/* Default ACL allows owner to delete it */
+	assert_true(ds_sec_cont_can_delete(DAOS_PC_RW, &cred, &owner,
+					   default_acl));
+
+	/* Minimal ACL with RW access allowing delete */
+	assert_true(ds_sec_cont_can_delete(DAOS_PC_RW, &cred, &owner, min_acl));
+
+	/* Read-only pool flags will prevent deletion */
+	assert_false(ds_sec_cont_can_delete(DAOS_PC_RO, &cred, &owner,
+					    min_acl));
+
+	/* Invalid inputs don't get any perms */
+	assert_false(ds_sec_cont_can_delete(DAOS_PC_RW, NULL, NULL, NULL));
+
+	/* doesn't have delete perms */
+	assert_false(ds_sec_cont_can_delete(DAOS_PC_RW, &cred, &owner,
+					    no_del_acl));
+
+	daos_acl_free(min_acl);
+	daos_acl_free(no_del_acl);
+	daos_acl_free(default_acl);
+	daos_iov_free(&cred);
 }
 
 /* Convenience macro for unit tests */
@@ -1869,7 +1950,10 @@ main(void)
 		cmocka_unit_test(test_cont_get_capas_success),
 		cmocka_unit_test(test_cont_get_capas_denied),
 		cmocka_unit_test(test_pool_can_connect),
+		cmocka_unit_test(test_pool_can_create_cont),
+		cmocka_unit_test(test_pool_can_delete_cont),
 		cmocka_unit_test(test_cont_can_open),
+		cmocka_unit_test(test_cont_can_delete),
 	};
 
 	return cmocka_run_group_tests(tests, NULL, NULL);

--- a/src/tests/suite/daos_capa.c
+++ b/src/tests/suite/daos_capa.c
@@ -252,10 +252,15 @@ open(void **state)
 			       NULL /* ev */);
 	assert_int_equal(rc, 0);
 
-	/** open container in read/write mode */
+	/** open container in read/write mode - this is OK, RW on pool handle
+	 * only applies to creating/deleting containers.
+	 */
 	print_message("opening container RW with RO pool handle ...\n");
 	rc = daos_cont_open(poh, arg->co_uuid, DAOS_COO_RW, &coh, NULL, NULL);
-	assert_int_equal(rc, -DER_NO_PERM);
+	assert_int_equal(rc, 0);
+
+	rc = daos_cont_close(coh, NULL);
+	assert_int_equal(rc, 0);
 
 	/** invalidate pool handle */
 	poh_invalidate_local(&poh);

--- a/src/tests/suite/daos_pool.c
+++ b/src/tests/suite/daos_pool.c
@@ -386,7 +386,7 @@ init_fini_conn(void **state)
 }
 
 static bool
-ace_has_default_permissions(struct daos_ace *ace)
+ace_has_permissions(struct daos_ace *ace, uint64_t perms)
 {
 	if (ace->dae_access_types != DAOS_ACL_ACCESS_ALLOW) {
 		print_message("Expected access type allow for ACE\n");
@@ -394,9 +394,8 @@ ace_has_default_permissions(struct daos_ace *ace)
 		return false;
 	}
 
-	if (ace->dae_allow_perms != (uint64_t)(DAOS_ACL_PERM_READ |
-					       DAOS_ACL_PERM_WRITE)) {
-		print_message("Expected allow RW perms for ACE\n");
+	if (ace->dae_allow_perms != perms) {
+		print_message("Expected allow perms 0x%lx for ACE\n", perms);
 		daos_ace_dump(ace, 0);
 		return false;
 	}
@@ -424,7 +423,8 @@ is_acl_prop_default(struct daos_acl *prop)
 
 	acl_expected_len += daos_ace_get_size(ace);
 
-	if (!ace_has_default_permissions(ace)) {
+	if (!ace_has_permissions(ace, DAOS_ACL_PERM_READ |
+				      DAOS_ACL_PERM_WRITE)) {
 		print_message("Owner ACE was wrong\n");
 		return false;
 	}
@@ -437,7 +437,8 @@ is_acl_prop_default(struct daos_acl *prop)
 
 	acl_expected_len += daos_ace_get_size(ace);
 
-	if (!ace_has_default_permissions(ace)) {
+	if (!ace_has_permissions(ace, DAOS_ACL_PERM_READ |
+				      DAOS_ACL_PERM_WRITE)) {
 		print_message("Owner Group ACE was wrong\n");
 		return false;
 	}
@@ -1005,6 +1006,62 @@ list_containers_test(void **state)
 	print_message("success\n");
 }
 
+static void
+expect_pool_connect_access(test_arg_t *arg0, uint64_t perms,
+			   uint64_t flags, int exp_result)
+{
+	test_arg_t	*arg = NULL;
+	daos_prop_t	*prop;
+	int		 rc;
+
+	rc = test_setup((void **)&arg, SETUP_EQ, arg0->multi_rank,
+			DEFAULT_POOL_SIZE, NULL);
+	assert_int_equal(rc, 0);
+
+	arg->pool.pool_connect_flags = flags;
+	prop = get_daos_prop_with_owner_acl_perms(perms,
+						  DAOS_PROP_PO_ACL);
+
+	while (!rc && arg->setup_state != SETUP_POOL_CONNECT)
+		rc = test_setup_next_step((void **)&arg, NULL, prop, NULL);
+
+	/* Make sure we actually got to pool connect */
+	assert_int_equal(arg->setup_state, SETUP_POOL_CONNECT);
+	assert_int_equal(rc, exp_result);
+
+	daos_prop_free(prop);
+	test_teardown((void **)&arg);
+}
+
+static void
+pool_connect_access(void **state)
+{
+	test_arg_t	*arg0 = *state;
+
+	print_message("pool ACL gives the owner no permissions\n");
+	expect_pool_connect_access(arg0, 0, DAOS_PC_RO, -DER_NO_PERM);
+
+	print_message("pool ACL gives the owner RO, they want RW\n");
+	expect_pool_connect_access(arg0, DAOS_ACL_PERM_READ, DAOS_PC_RW,
+				   -DER_NO_PERM);
+
+	print_message("pool ACL gives the owner RO, they want RO\n");
+	expect_pool_connect_access(arg0, DAOS_ACL_PERM_READ, DAOS_PC_RO,
+				   0);
+
+	print_message("pool ACL gives the owner RW, they want RO\n");
+	expect_pool_connect_access(arg0,
+				   DAOS_ACL_PERM_READ | DAOS_ACL_PERM_WRITE,
+				   DAOS_PC_RO,
+				   0);
+
+	print_message("pool ACL gives the owner RW, they want RW\n");
+	expect_pool_connect_access(arg0,
+				   DAOS_ACL_PERM_READ | DAOS_ACL_PERM_WRITE,
+				   DAOS_PC_RW,
+				   0);
+}
+
 static const struct CMUnitTest pool_tests[] = {
 	{ "POOL1: connect to non-existing pool",
 	  pool_connect_nonexist, NULL, test_case_teardown},
@@ -1032,7 +1089,9 @@ static const struct CMUnitTest pool_tests[] = {
 	{ "POOL12: pool list containers (many)",
 	  list_containers_test, setup_manycontainers, teardown_containers},
 	{ "POOL13: retry POOL_{CONNECT,DISCONNECT,QUERY}",
-	  pool_op_retry, NULL, test_case_teardown}
+	  pool_op_retry, NULL, test_case_teardown},
+	{ "POOL14: pool connect access based on ACL",
+	  pool_connect_access, NULL, test_case_teardown},
 };
 
 int

--- a/src/tests/suite/daos_test.h
+++ b/src/tests/suite/daos_test.h
@@ -92,6 +92,7 @@ struct test_pool {
 	daos_handle_t		poh;
 	daos_pool_info_t	pool_info;
 	daos_size_t		pool_size;
+	uint64_t		pool_connect_flags;
 	/* Updated if some ranks are killed during degraged or rebuild
 	 * test, so we know whether some tests is allowed to be run.
 	 */
@@ -126,11 +127,11 @@ typedef struct {
 	const char	       *group;
 	struct test_pool	pool;
 	uuid_t			co_uuid;
-	unsigned int		mode;
 	unsigned int		uid;
 	unsigned int		gid;
 	daos_handle_t		eq;
 	daos_handle_t		coh;
+	uint64_t		cont_open_flags;
 	daos_cont_info_t	co_info;
 	int			setup_state;
 	bool			async;
@@ -294,6 +295,8 @@ void daos_kill_server(test_arg_t *arg, const uuid_t pool_uuid, const char *grp,
 		      d_rank_list_t *svc, d_rank_t rank);
 void daos_kill_exclude_server(test_arg_t *arg, const uuid_t pool_uuid,
 			      const char *grp, d_rank_list_t *svc);
+daos_prop_t *get_daos_prop_with_owner_acl_perms(uint64_t perms,
+						uint32_t prop_type);
 typedef int (*test_setup_cb_t)(void **state);
 typedef int (*test_teardown_cb_t)(void **state);
 

--- a/src/tests/suite/daos_test_common.c
+++ b/src/tests/suite/daos_test_common.c
@@ -106,7 +106,7 @@ test_setup_pool_create(void **state, struct test_pool *ipool,
 		print_message("setup: creating pool, SCM size="DF_U64" GB, "
 			      "NVMe size="DF_U64" GB\n",
 			      (outpool->pool_size >> 30), nvme_size >> 30);
-		rc = daos_pool_create(arg->mode, arg->uid, arg->gid, arg->group,
+		rc = daos_pool_create(0, arg->uid, arg->gid, arg->group,
 				      NULL, "pmem", outpool->pool_size,
 				      nvme_size, prop, &outpool->svc,
 				      outpool->pool_uuid, NULL);
@@ -157,7 +157,8 @@ test_setup_pool_connect(void **state, struct test_pool *pool)
 
 		print_message("setup: connecting to pool\n");
 		rc = daos_pool_connect(arg->pool.pool_uuid, arg->group,
-				       &arg->pool.svc, DAOS_PC_RW,
+				       &arg->pool.svc,
+				       arg->pool.pool_connect_flags,
 				       &arg->pool.poh, &arg->pool.pool_info,
 				       NULL /* ev */);
 		if (rc)
@@ -229,7 +230,8 @@ test_setup_cont_open(void **state)
 
 	if (arg->myrank == 0) {
 		print_message("setup: opening container\n");
-		rc = daos_cont_open(arg->pool.poh, arg->co_uuid, DAOS_COO_RW,
+		rc = daos_cont_open(arg->pool.poh, arg->co_uuid,
+				    arg->cont_open_flags,
 				    &arg->coh, &arg->co_info, NULL);
 		if (rc)
 			print_message("daos_cont_open failed, rc: %d\n", rc);
@@ -307,7 +309,6 @@ test_setup(void **state, unsigned int step, bool multi_rank,
 		arg->pool.svc.rl_ranks = arg->pool.ranks;
 		arg->pool.slave = false;
 
-		arg->mode = 0731;
 		arg->uid = geteuid();
 		arg->gid = getegid();
 
@@ -317,7 +318,9 @@ test_setup(void **state, unsigned int step, bool multi_rank,
 
 		arg->hdl_share = false;
 		arg->pool.poh = DAOS_HDL_INVAL;
+		arg->pool.pool_connect_flags = DAOS_PC_RW;
 		arg->coh = DAOS_HDL_INVAL;
+		arg->cont_open_flags = DAOS_COO_RW;
 
 		arg->pool.destroyed = false;
 	}
@@ -864,4 +867,28 @@ daos_kill_exclude_server(test_arg_t *arg, const uuid_t pool_uuid,
 
 	daos_kill_server(arg, pool_uuid, grp, svc, rank);
 	daos_exclude_server(pool_uuid, grp, svc, rank);
+}
+
+
+daos_prop_t *
+get_daos_prop_with_owner_acl_perms(uint64_t perms, uint32_t type)
+{
+	daos_prop_t	*prop;
+	struct daos_acl	*acl;
+	struct daos_ace	*owner_ace;
+
+	owner_ace = daos_ace_create(DAOS_ACL_OWNER, NULL);
+	owner_ace->dae_access_types = DAOS_ACL_ACCESS_ALLOW;
+	owner_ace->dae_allow_perms = perms;
+	assert_true(daos_ace_is_valid(owner_ace));
+
+	acl = daos_acl_create(&owner_ace, 1);
+	assert_non_null(acl);
+
+	prop = daos_prop_alloc(1);
+	prop->dpp_entries[0].dpe_type = type;
+	prop->dpp_entries[0].dpe_val_ptr = acl;
+
+	daos_ace_free(owner_ace);
+	return prop;
 }


### PR DESCRIPTION
This patch adds ACL-based access enforcement for container
create and delete.

- Check pool capas to determine access for container
  create.
- Determine access for container delete based on pool
  capas first. If no delete privileges on the pool handle,
  check the container ACL to see if the user has delete
  privs for that container.
- Add CONT_CAPA_DELETE to container capabilities mask and
  update container capabilities translation.
- Remove defunct client-side permission checks.
- Add pool and container access check tests to daos_test.
- Fix pool capa open test. The meaning of the pool RO
  flag has changed now that container access is controlled
  by container ACLs.
- Removed mode from test_arg struct - it's been defunct
  for a while.

Signed-off-by: Kris Jacque <kristin.jacque@intel.com>