### PR TITLE
DAOS-4134 build: Use /etc/daos for RPM config files

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -82,7 +82,7 @@ def rpm_test_daos_test = '''me=\\\$(whoami)
                             cat /etc/daos/daos_server.yml
                             cat /etc/daos/daos_agent.yml
                             module load mpi/openmpi3-x86_64
-                            coproc orterun -np 1 -H \\\$HOSTNAME --enable-recovery daos_server --debug --config /etc/daos/daos_server.yml start -t 1 -i --recreate-superblocks
+                            coproc orterun -np 1 -H \\\$HOSTNAME --enable-recovery daos_server --debug start -t 1 --recreate-superblocks
                             trap 'set -x; kill -INT \\\$COPROC_PID' EXIT
                             line=\"\"
                             while [[ \"\\\$line\" != *started\\\\ on\\\\ rank\\\\ 0* ]]; do
@@ -90,7 +90,7 @@ def rpm_test_daos_test = '''me=\\\$(whoami)
                                 echo \"Server stdout: \\\$line\"
                             done
                             echo \"Server started!\"
-                            daos_agent -o /etc/daos/daos_agent.yml -i &
+                            daos_agent &
                             AGENT_PID=\\\$!
                             trap 'set -x; kill -INT \\\$AGENT_PID \\\$COPROC_PID' EXIT
                             orterun -np 1 -x OFI_INTERFACE=eth0 daos_test -m'''

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1385,16 +1385,20 @@ pipeline {
                         label 'ci_vm1'
                     }
                     steps {
+                        unstash 'CentOS-rpm-version'
+                        script {
+                            daos_packages_version = readFile('centos7-rpm-version').trim()
+                        }
                         provisionNodes NODELIST: env.NODELIST,
                                        node_count: 1,
                                        snapshot: true,
                                        inst_repos: el7_daos_repos
                         catchError(stageResult: 'UNSTABLE', buildResult: 'SUCCESS') {
                             runTest script: "${rpm_test_pre}" +
-                                         '''sudo yum -y install daos-client
-                                            sudo yum -y history rollback last-1
-                                            sudo yum -y install daos-server
-                                            sudo yum -y install daos-tests\n''' +
+                                            "sudo yum -y install daos-client-${daos_packages_version}\n" +
+                                            "sudo yum -y history rollback last-1\n" +
+                                            "sudo yum -y install daos-server-${daos_packages_version}\n" +
+                                            "sudo yum -y install daos-tests-${daos_packages_version}\n" +
                                             "${rpm_test_daos_test}" + '"',
                                     junit_files: null,
                                     failure_artifacts: env.STAGE_NAME, ignore_failure: true

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -77,12 +77,12 @@ def rpm_test_daos_test = '''me=\\\$(whoami)
                             sudo mount -t tmpfs -o size=16777216k tmpfs /mnt/daos
                             sed -i -e \\\"/^access_points:/s/example/\\\$(hostname -s)/\\\" /tmp/daos_server_baseline.yaml
                             sed -i -e \\\"/^access_points:/s/example/\\\$(hostname -s)/\\\" /tmp/daos_agent_baseline.yaml
-                            sudo cp /tmp/daos_server_baseline.yaml /usr/etc/daos_server.yml
-                            sudo cp /tmp/daos_agent_baseline.yaml /usr/etc/daos_agent.yml
-                            cat /usr/etc/daos_server.yml
-                            cat /usr/etc/daos_agent.yml
+                            sudo cp /tmp/daos_server_baseline.yaml /etc/daos/daos_server.yml
+                            sudo cp /tmp/daos_agent_baseline.yaml /etc/daos/daos_agent.yml
+                            cat /etc/daos/daos_server.yml
+                            cat /etc/daos/daos_agent.yml
                             module load mpi/openmpi3-x86_64
-                            coproc orterun -np 1 -H \\\$HOSTNAME --enable-recovery daos_server --debug --config /usr/etc/daos_server.yml start -t 1 -i --recreate-superblocks
+                            coproc orterun -np 1 -H \\\$HOSTNAME --enable-recovery daos_server --debug --config /etc/daos/daos_server.yml start -t 1 -i --recreate-superblocks
                             trap 'set -x; kill -INT \\\$COPROC_PID' EXIT
                             line=\"\"
                             while [[ \"\\\$line\" != *started\\\\ on\\\\ rank\\\\ 0* ]]; do
@@ -90,7 +90,7 @@ def rpm_test_daos_test = '''me=\\\$(whoami)
                                 echo \"Server stdout: \\\$line\"
                             done
                             echo \"Server started!\"
-                            daos_agent -o /usr/etc/daos_agent.yml -i &
+                            daos_agent -o /etc/daos/daos_agent.yml -i &
                             AGENT_PID=\\\$!
                             trap 'set -x; kill -INT \\\$AGENT_PID \\\$COPROC_PID' EXIT
                             orterun -np 1 -x OFI_INTERFACE=eth0 daos_test -m'''

--- a/SConstruct
+++ b/SConstruct
@@ -351,9 +351,13 @@ def scons(): # pylint: disable=too-many-locals
         env.AppendUnique(CPPDEFINES=["DAOS_HAS_VALGRIND"])
     opts.Save(opts_file, env)
 
+    CONF_DIR = ARGUMENTS.get('CONF_DIR', '$PREFIX/etc')
+
     env.Alias('install', '$PREFIX')
     platform_arm = is_platform_arm()
-    Export('DAOS_VERSION', 'env', 'prereqs', 'platform_arm', 'API_VERSION')
+    Export('DAOS_VERSION', 'API_VERSION',
+           'env', 'prereqs', 'platform_arm',
+           'CONF_DIR')
 
     if env['PLATFORM'] == 'darwin':
         # generate .so on OSX instead of .dylib

--- a/src/control/SConscript
+++ b/src/control/SConscript
@@ -82,17 +82,17 @@ def install_go_bin(denv, gosrc, gopath, libs, name, install_name):
     def go_ldflags():
         return ' '.join(['-ldflags',
                          '"-X main.daosVersion=%s' % DAOS_VERSION,
-                         '-B %s"' % gen_build_id(),
-                         '-v'])
+                         '-X main.configDir=%s' % CONF_DIR,
+                         '-B %s"' % gen_build_id()])
     denv.Command(bin_path, src,
                  cmd_build(path, gosrc,
-                           'go install %s %s' % (go_ldflags(), install_src)))
+                           'go install -v %s %s' % (go_ldflags(), install_src)))
     denv.InstallAs(install_bin, bin_path)
 #pylint: enable=too-many-arguments
 
 def scons():
     """Execute build"""
-    Import('env', 'prereqs', 'DAOS_VERSION')
+    Import('env', 'prereqs', 'DAOS_VERSION', 'CONF_DIR')
 
     env.AppendUnique(LIBPATH=[Dir('.')])
 
@@ -203,9 +203,8 @@ def scons():
                        sep=" ")
 
     # Copy setup_spdk.sh script to be executed at daos_server runtime.
-    senv.Command(join("$PREFIX", "share", "daos", "control", "setup_spdk.sh"),
-                 join(gosrc, "server", "init", "setup_spdk.sh"),
-                 [Delete("$TARGET"), Copy("$TARGET", "$SOURCE")])
+    senv.Install(join('$PREFIX', 'share/daos/control'),
+                 join(gosrc, 'server/init/setup_spdk.sh'))
 
     install_go_bin(senv, gosrc, gopath, [denv.nvmecontrol], "daos_server",
                    "daos_server")

--- a/src/control/cmd/agent/main.go
+++ b/src/control/cmd/agent/main.go
@@ -1,5 +1,5 @@
 //
-// (C) Copyright 2018-2019 Intel Corporation.
+// (C) Copyright 2018-2020 Intel Corporation.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -41,11 +41,15 @@ import (
 	"github.com/daos-stack/daos/src/control/logging"
 )
 
-var daosVersion string
+var (
+	daosVersion string
+	configDir   string
+)
 
 const (
 	agentSockName        = "agent.sock"
 	daosAgentDrpcSockEnv = "DAOS_AGENT_DRPC_DIR"
+	defaultConfigFile    = "daos_agent.yml"
 )
 
 type cliOptions struct {
@@ -126,6 +130,13 @@ func agentMain(log *logging.LeveledLogger, opts *cliOptions) error {
 
 	ctx, shutdown := context.WithCancel(context.Background())
 	defer shutdown()
+
+	if opts.ConfigPath == "" {
+		defaultConfigPath := path.Join(configDir, defaultConfigFile)
+		if _, err := os.Stat(defaultConfigPath); err == nil {
+			opts.ConfigPath = defaultConfigPath
+		}
+	}
 
 	// Load the configuration file using the supplied path or the
 	// default path if none provided.

--- a/src/control/cmd/daos_server/main.go
+++ b/src/control/cmd/daos_server/main.go
@@ -27,6 +27,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"path"
 
 	"github.com/jessevdk/go-flags"
 	"github.com/pkg/errors"
@@ -39,7 +40,14 @@ import (
 	"github.com/daos-stack/daos/src/control/server"
 )
 
-var daosVersion string
+var (
+	daosVersion string
+	configDir   string
+)
+
+const (
+	defaultConfigFile = "daos_server.yml"
+)
 
 type mainOpts struct {
 	AllowProxy bool `long:"allow-proxy" description:"Allow proxy configuration via environment"`
@@ -104,6 +112,13 @@ func parseOpts(args []string, opts *mainOpts, log *logging.LeveledLogger) error 
 
 		if logCmd, ok := cmd.(cmdLogger); ok {
 			logCmd.setLog(log)
+		}
+
+		if opts.ConfigPath == "" {
+			defaultConfigPath := path.Join(configDir, defaultConfigFile)
+			if _, err := os.Stat(defaultConfigPath); err == nil {
+				opts.ConfigPath = defaultConfigPath
+			}
 		}
 
 		if cfgCmd, ok := cmd.(cfgLoader); ok {

--- a/src/control/cmd/dmg/main.go
+++ b/src/control/cmd/dmg/main.go
@@ -1,5 +1,5 @@
 //
-// (C) Copyright 2018-2019 Intel Corporation.
+// (C) Copyright 2018-2020 Intel Corporation.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -36,7 +36,14 @@ import (
 	"github.com/daos-stack/daos/src/control/logging"
 )
 
-var daosVersion string
+var (
+	daosVersion string
+	configDir   string
+)
+
+const (
+	defaultConfigFile = "daos.yml"
+)
 
 type (
 	// this interface decorates a command which
@@ -135,6 +142,13 @@ func parseOpts(args []string, opts *cliOptions, conns client.Connect, log *loggi
 
 		if logCmd, ok := cmd.(cmdLogger); ok {
 			logCmd.setLog(log)
+		}
+
+		if opts.ConfigPath == "" {
+			defaultConfigPath := path.Join(configDir, defaultConfigFile)
+			if _, err := os.Stat(defaultConfigPath); err == nil {
+				opts.ConfigPath = defaultConfigPath
+			}
 		}
 
 		config, err := client.GetConfig(log, opts.ConfigPath)

--- a/src/tests/ftest/data/daos_agent_baseline.yaml
+++ b/src/tests/ftest/data/daos_agent_baseline.yaml
@@ -1,3 +1,5 @@
 name: daos_server
 access_points: ['example:10001']
 port: 10001
+transport_config:
+  allow_insecure: true

--- a/src/tests/ftest/data/daos_server_baseline.yaml
+++ b/src/tests/ftest/data/daos_server_baseline.yaml
@@ -9,10 +9,9 @@ nr_hugepages: 4096
 control_log_mask: DEBUG
 control_log_file: /tmp/daos_control.log
 helper_log_file: /tmp/daos_admin.log
-## uncomment to drop privileges before starting data plane
-## (if started as root to perform hardware provisioning)
-# user_name: daosuser
-# group_name: daosgroup # (optional)
+
+transport_config:
+  allow_insecure: true
 
 # single server instance per config file for now
 servers:

--- a/src/tests/suite/SConscript
+++ b/src/tests/suite/SConscript
@@ -8,7 +8,7 @@ def scons():
     libraries = ['daos_common', 'daos', 'dfs', 'daos_tests', 'gurt', 'cart']
     libraries += ['uuid', 'mpi', 'dfs', 'cmocka', 'pthread']
 
-    denv.AppendUnique(LIBPATH=["$PREFIX/lib64/"])
+    denv.AppendUnique(LIBPATH=["$BUILD_DIR/src/client/dfs"])
 
     daos_test_tgt = denv.SharedObject(['daos_test_common.c'])
     Export('daos_test_tgt')

--- a/utils/config/SConscript
+++ b/utils/config/SConscript
@@ -3,10 +3,10 @@ import os
 
 def scons():
     """Execute build"""
-    Import('env')
+    Import('env', 'CONF_DIR')
 
-    env.Install("$PREFIX/etc", ['daos_server.yml', 'daos.yml',
-                                'daos_agent.yml'])
+    env.Install(CONF_DIR, ['daos_server.yml', 'daos.yml',
+                           'daos_agent.yml'])
 
 if __name__ == "SCons.Script":
     scons()

--- a/utils/rpms/daos.spec
+++ b/utils/rpms/daos.spec
@@ -182,20 +182,25 @@ rpath_files="utils/daos_build.py"
 rpath_files+=" $(find . -name SConscript)"
 sed -i -e '/AppendUnique(RPATH=.*)/d' $rpath_files
 
+%define conf_dir %{_sysconfdir}/daos
+
 scons %{?no_smp_mflags}    \
       --config=force       \
       USE_INSTALLED=all    \
+      CONF_DIR=%{conf_dir} \
       PREFIX=%{?buildroot}
 
 %install
-scons %{?no_smp_mflags}              \
-      --config=force                 \
-      install                        \
-      USE_INSTALLED=all              \
-      PREFIX=%{?buildroot}%{_prefix}
+scons %{?no_smp_mflags}               \
+      --config=force                  \
+      --install-sandbox=%{?buildroot} \
+      %{?buildroot}%{_prefix}         \
+      %{?buildroot}%{conf_dir}        \
+      USE_INSTALLED=all               \
+      CONF_DIR=%{conf_dir}            \
+      PREFIX=%{_prefix}
 BUILDROOT="%{?buildroot}"
 PREFIX="%{?_prefix}"
-sed -i -e s/${BUILDROOT//\//\\/}[^\"]\*/${PREFIX//\//\\/}/g %{?buildroot}%{_prefix}/lib/daos/.build_vars.*
 mkdir -p %{?buildroot}/%{_sysconfdir}/ld.so.conf.d/
 echo "%{_libdir}/daos_srv" > %{?buildroot}/%{_sysconfdir}/ld.so.conf.d/daos.conf
 mkdir -p %{?buildroot}/%{_unitdir}
@@ -236,7 +241,7 @@ getent group daos_admins >/dev/null || groupadd -r daos_admins
 %doc
 
 %files server
-%{_prefix}%{_sysconfdir}/daos_server.yml
+%config(noreplace) %{conf_dir}/daos_server.yml
 %{_sysconfdir}/ld.so.conf.d/daos.conf
 # set daos_admin to be setuid root in order to perform privileged tasks
 %attr(4750,root,daos_admins) %{_bindir}/daos_admin
@@ -307,8 +312,8 @@ getent group daos_admins >/dev/null || groupadd -r daos_admins
 %{_libdir}/python3/site-packages/pydaos/raw/*.pyo
 %endif
 %{_datadir}/%{name}/ioil-ld-opts
-%{_prefix}%{_sysconfdir}/daos.yml
-%{_prefix}%{_sysconfdir}/daos_agent.yml
+%config(noreplace) %{conf_dir}/daos_agent.yml
+%config(noreplace) %{conf_dir}/daos.yml
 %{_unitdir}/daos-agent.service
 
 %files tests


### PR DESCRIPTION
Set the path to control plane configuration files at build time
and adjust utilities to use absolute paths to the default locations.