### PR TITLE
DAOS-4100 container: integer overflow on sleep time (#1954)

### DIFF
--- a/src/container/srv_target.c
+++ b/src/container/srv_target.c
@@ -75,6 +75,12 @@ cont_aggregate_runnable(struct ds_cont_child *cont)
 {
 	struct ds_pool	*pool = cont->sc_pool->spc_pool;
 
+	/* snapshot list isn't fetched yet */
+	if (cont->sc_aggregation_max == 0) {
+		D_DEBUG(DB_EPC, "No aggregation before snapshots fetched\n");
+		return false;
+	}
+
 	if ((pool->sp_reclaim == DAOS_RECLAIM_DISABLED) ||
 	    (pool->sp_reclaim == DAOS_RECLAIM_LAZY && dss_xstream_is_busy()))
 		return false;
@@ -96,14 +102,9 @@ cont_child_aggregate(struct ds_cont_child *cont, uint64_t *sleep)
 	int			tgt_id = dss_get_module_info()->dmi_tgt_id;
 	int			i, rc;
 
-	if (!cont_aggregate_runnable(cont)) {
-		*sleep = NSEC_PER_SEC << 2;
-		return 0;
-	}
-
-	*sleep = NSEC_PER_SEC;
-	/* snapshot list isn't fetched yet */
-	if (cont->sc_aggregation_max == 0)
+	/* Check if it's ok to start aggregation in every 2 seconds */
+	*sleep = 2ULL * NSEC_PER_SEC;
+	if (!cont_aggregate_runnable(cont))
 		return 0;
 
 	/*

--- a/src/include/daos_srv/daos_server.h
+++ b/src/include/daos_srv/daos_server.h
@@ -468,6 +468,8 @@ struct dss_rpc_cntr {
 	 * workload.
 	 */
 	uint64_t		rc_stime;
+	/* the time when processing last active RPC */
+	uint64_t		rc_active_time;
 	/** number of active RPCs */
 	uint64_t		rc_active;
 	/** total number of processed RPCs since \a rc_stime */

--- a/src/iosrv/init.c
+++ b/src/iosrv/init.c
@@ -124,7 +124,7 @@ register_dbtree_classes(void)
 	}
 
 	rc = dbtree_class_register(DBTREE_CLASS_IV,
-				   BTR_FEAT_UINT_KEY /* feats */,
+				   BTR_FEAT_UINT_KEY | BTR_FEAT_DIRECT_KEY,
 				   &dbtree_iv_ops);
 	if (rc != 0) {
 		D_ERROR("failed to register DBTREE_CLASS_IV: "DF_RC"\n",

--- a/src/iosrv/srv.c
+++ b/src/iosrv/srv.c
@@ -265,12 +265,13 @@ dss_rpc_cntr_enter(enum dss_rpc_cntr_id id)
 {
 	struct dss_rpc_cntr *cntr = dss_rpc_cntr_get(id);
 
-	/* TODO: add interface to calculate average workload and reset stime */
-	if (cntr->rc_stime == 0)
-		daos_gettime_coarse(&cntr->rc_stime);
-
+	daos_gettime_coarse(&cntr->rc_active_time);
 	cntr->rc_active++;
 	cntr->rc_total++;
+
+	/* TODO: add interface to calculate average workload and reset stime */
+	if (cntr->rc_stime == 0)
+		cntr->rc_stime = cntr->rc_active_time;
 }
 
 /**
@@ -502,12 +503,11 @@ dss_srv_handler(void *arg)
 			}
 		}
 
-		if (dss_xstream_exiting(dx)) {
-			check_sleep_list();
-			break;
-		}
-
 		check_sleep_list();
+
+		if (dss_xstream_exiting(dx))
+			break;
+
 		ABT_thread_yield();
 	}
 	D_ASSERT(d_list_empty(&dx->dx_sleep_ult_list));
@@ -768,9 +768,12 @@ dss_xstreams_empty(void)
 bool
 dss_xstream_is_busy(void)
 {
-	struct dss_rpc_cntr *cntr = dss_rpc_cntr_get(DSS_RC_OBJ);
+	struct dss_rpc_cntr	*cntr = dss_rpc_cntr_get(DSS_RC_OBJ);
+	uint64_t		 cur_sec = 0;
 
-	return cntr->rc_active != 0;
+	daos_gettime_coarse(&cur_sec);
+	/* No IO requests for more than 5 seconds */
+	return cur_sec < (cntr->rc_active_time + 5);
 }
 
 static int

--- a/src/vea/tests/vea_ut.c
+++ b/src/vea/tests/vea_ut.c
@@ -497,7 +497,7 @@ vea_ut_setup(void **state)
 		return rc;
 
 	rc = dbtree_class_register(DBTREE_CLASS_IV,
-				   BTR_FEAT_UINT_KEY,
+				   BTR_FEAT_UINT_KEY | BTR_FEAT_DIRECT_KEY,
 				   &dbtree_iv_ops);
 	if (rc != 0 && rc != -DER_EXIST) {
 		fprintf(stderr, "register DBTREE_CLASS_IV error %d\n", rc);

--- a/src/vea/vea_alloc.c
+++ b/src/vea/vea_alloc.c
@@ -438,19 +438,12 @@ persistent_alloc(struct vea_space_info *vsi, struct vea_free_extent *vfe)
 				return rc;
 		}
 	} else if (found_end > vfe_end) {
-		/* Adjust the in-tree integer key */
-		rc = umem_tx_add_ptr(vsi->vsi_umem, blk_off, sizeof(*blk_off));
-		if (rc)
-			return rc;
-
-		*blk_off = vfe->vfe_blk_off + vfe->vfe_blk_cnt;
-
-		/* Adjust the in-tree extent offset */
+		/* Adjust the in-tree extent offset & length */
 		rc = umem_tx_add_ptr(vsi->vsi_umem, found, sizeof(*found));
 		if (rc)
 			return rc;
 
-		found->vfe_blk_off = *blk_off;
+		found->vfe_blk_off = vfe->vfe_blk_off + vfe->vfe_blk_cnt;
 		found->vfe_blk_cnt = found_end - vfe_end;
 		rc = daos_gettime_coarse(&found->vfe_age);
 		if (rc)

--- a/src/vea/vea_api.c
+++ b/src/vea/vea_api.c
@@ -143,8 +143,9 @@ vea_format(struct umem_instance *umem, struct umem_tx_stage_data *txd,
 	/* Create free extent tree */
 	uma.uma_id = umem->umm_id;
 	uma.uma_pool = umem->umm_pool;
-	rc = dbtree_create_inplace(DBTREE_CLASS_IV, 0, VEA_TREE_ODR, &uma,
-				   &md->vsd_free_tree, &free_btr);
+	rc = dbtree_create_inplace(DBTREE_CLASS_IV, BTR_FEAT_DIRECT_KEY,
+				   VEA_TREE_ODR, &uma, &md->vsd_free_tree,
+				   &free_btr);
 	if (rc != 0)
 		goto out;
 
@@ -163,8 +164,9 @@ vea_format(struct umem_instance *umem, struct umem_tx_stage_data *txd,
 		goto out;
 
 	/* Create extent vector tree */
-	rc = dbtree_create_inplace(DBTREE_CLASS_IV, 0, VEA_TREE_ODR, &uma,
-				   &md->vsd_vec_tree, &vec_btr);
+	rc = dbtree_create_inplace(DBTREE_CLASS_IV, BTR_FEAT_DIRECT_KEY,
+				   VEA_TREE_ODR, &uma, &md->vsd_vec_tree,
+				   &vec_btr);
 	if (rc != 0)
 		goto out;
 
@@ -254,20 +256,20 @@ vea_load(struct umem_instance *umem, struct umem_tx_stage_data *txd,
 	memset(&uma, 0, sizeof(uma));
 	uma.uma_id = UMEM_CLASS_VMEM;
 	/* Create in-memory free extent tree */
-	rc = dbtree_create(DBTREE_CLASS_IV, 0, VEA_TREE_ODR, &uma,
-			   NULL, &vsi->vsi_free_btr);
+	rc = dbtree_create(DBTREE_CLASS_IV, BTR_FEAT_UINT_KEY, VEA_TREE_ODR,
+			   &uma, NULL, &vsi->vsi_free_btr);
 	if (rc != 0)
 		goto error;
 
 	/* Create in-memory extent vector tree */
-	rc = dbtree_create(DBTREE_CLASS_IV, 0, VEA_TREE_ODR, &uma,
-			   NULL, &vsi->vsi_vec_btr);
+	rc = dbtree_create(DBTREE_CLASS_IV, BTR_FEAT_UINT_KEY, VEA_TREE_ODR,
+			   &uma, NULL, &vsi->vsi_vec_btr);
 	if (rc != 0)
 		goto error;
 
 	/* Create in-memory aggregation tree */
-	rc = dbtree_create(DBTREE_CLASS_IV, 0, VEA_TREE_ODR, &uma,
-			   NULL, &vsi->vsi_agg_btr);
+	rc = dbtree_create(DBTREE_CLASS_IV, BTR_FEAT_UINT_KEY, VEA_TREE_ODR,
+			   &uma, NULL, &vsi->vsi_agg_btr);
 	if (rc != 0)
 		goto error;
 
@@ -562,6 +564,13 @@ done:
 	if (rc == 0)
 		migrate_free_exts(vsi);
 error:
+	/*
+	 * -DER_NONEXIST or -DER_ENOENT could be ignored by some caller,
+	 * let's convert them to more serious error here.
+	 */
+	if (rc == -DER_NONEXIST || rc == -DER_ENOENT)
+		rc = -DER_INVAL;
+
 	if (fca != NULL)
 		D_FREE(fca);
 	return rc;

--- a/src/vea/vea_free.c
+++ b/src/vea/vea_free.c
@@ -114,7 +114,7 @@ repeat:
 		else if (type == VEA_TYPE_AGGREGATE)
 			d_list_del_init(&entry->ve_link);
 
-		rc = dbtree_delete(btr_hdl, BTR_PROBE_EQ, &key_out, NULL);
+		rc = dbtree_delete(btr_hdl, BTR_PROBE_BYPASS, &key_out, NULL);
 		if (rc)
 			return rc;
 	}

--- a/src/vos/vos_common.c
+++ b/src/vos/vos_common.c
@@ -288,7 +288,7 @@ vos_nvme_init(void)
 
 	/* IV tree used by VEA */
 	rc = dbtree_class_register(DBTREE_CLASS_IV,
-				   BTR_FEAT_UINT_KEY,
+				   BTR_FEAT_UINT_KEY | BTR_FEAT_DIRECT_KEY,
 				   &dbtree_iv_ops);
 	if (rc != 0 && rc != -DER_EXIST)
 		return rc;


### PR DESCRIPTION
There is an integer overflow in cont aggregation code which leads
to the aggregation ULT being put to sleep for a very long time.

This patch also changed the criterion of dss_xstream_is_busy() to
"No IO requests in 5 seconds" instead of "No active requests in
this moment", because even if there is continuous IO flow from
client, the active request counter could be 0 at certain point,
that may result in the aggregation being triggered unexpectedly.

Signed-off-by: Niu Yawei <yawei.niu@intel.com>