### PR TITLE
CORCI-835 build: Get quickbuild deps from caller (#1578)

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -50,7 +50,7 @@ def el7_component_repos = ""
 def component_repos = ""
 def daos_repo = "daos@${env.BRANCH_NAME}:${env.BUILD_NUMBER}"
 def el7_daos_repos = el7_component_repos + ' ' + component_repos + ' ' + daos_repo
-def functional_rpms  = "--exclude openmpi openmpi3 hwloc ndctl " +
+def functional_rpms  = "--exclude openmpi openmpi3 hwloc ndctl spdk-tools " +
                        "ior-hpc-cart-4-daos-0 mpich-autoload-cart-4-daos-0 " +
                        "romio-tests-cart-4-daos-0 hdf5-tests-cart-4-daos-0 " +
                        "mpi4py-tests-cart-4-daos-0 testmpio-cart-4-daos-0"
@@ -122,11 +122,13 @@ pipeline {
                     "--build-arg NOBUILD=1 --build-arg UID=$env.UID "         +
                     "--build-arg JENKINS_URL=$env.JENKINS_URL "               +
                     "--build-arg CACHEBUST=${currentBuild.startTimeInMillis}"
-        QUICKBUILD = sh(script: "git show -s --format=%B | grep \"^Quick-build: true\"",
-                        returnStatus: true)
+       QUICKBUILD = commitPragma(pragma: 'Quick-build').contains('true')
         SSH_KEY_ARGS = "-ici_key"
         CLUSH_ARGS = "-o$SSH_KEY_ARGS"
-        CART_COMMIT = sh(script: "sed -ne 's/CART *= *\\(.*\\)/\\1/p' utils/build.config", returnStdout: true).trim()
+        CART_COMMIT = sh(script: "sed -ne 's/CART *= *\\(.*\\)/\\1/p' utils/build.config",
+                         returnStdout: true).trim()
+        QUICKBUILD_DEPS = sh(script: "rpmspec -q --define cart_sha1\\ ${env.CART_COMMIT} --srpm --requires utils/rpms/daos.spec 2>/dev/null",
+                             returnStdout: true)
     }
 
     options {
@@ -217,13 +219,6 @@ pipeline {
             }
             parallel {
                 stage('Build RPM on CentOS 7') {
-                    when {
-                        beforeAgent true
-                        allOf {
-                            not { branch 'weekly-testing' }
-                            expression { env.CHANGE_TARGET != 'weekly-testing' }
-                        }
-                    }
                     agent {
                         dockerfile {
                             filename 'Dockerfile.mockbuild'
@@ -381,7 +376,8 @@ pipeline {
                             additionalBuildArgs "-t ${sanitized_JOB_NAME}-centos7 " +
                                                 '$BUILDARGS ' +
                                                 '--build-arg QUICKBUILD=' + env.QUICKBUILD +
-                                                ' --build-arg CART_COMMIT=-' + env.CART_COMMIT +
+                                                ' --build-arg QUICKBUILD_DEPS="' + env.QUICKBUILD_DEPS +
+                                                '" --build-arg CART_COMMIT=-' + env.CART_COMMIT +
                                                 ' --build-arg REPOS="' + component_repos + '"'
                         }
                     }
@@ -466,7 +462,7 @@ pipeline {
                         beforeAgent true
                         allOf {
                             branch 'master'
-                            expression { return env.QUICKBUILD == '1' }
+                            expression { env.QUICKBUILD != 'true' }
                         }
                     }
                     agent {
@@ -527,7 +523,7 @@ pipeline {
                         beforeAgent true
                         allOf {
                             branch 'master'
-                            expression { return env.QUICKBUILD == '1' }
+                            expression { env.QUICKBUILD != 'true' }
                         }
                     }
                     agent {
@@ -589,7 +585,7 @@ pipeline {
                         allOf {
                             not { branch 'weekly-testing' }
                             expression { env.CHANGE_TARGET != 'weekly-testing' }
-                            expression { return env.QUICKBUILD == '1' }
+                            expression { env.QUICKBUILD != 'true' }
                         }
                     }
                     agent {
@@ -650,7 +646,7 @@ pipeline {
                         beforeAgent true
                         allOf {
                             branch 'master'
-                            expression { return env.QUICKBUILD == '1' }
+                            expression { env.QUICKBUILD != 'true' }
                         }
                     }
                     agent {
@@ -711,7 +707,7 @@ pipeline {
                         beforeAgent true
                         allOf {
                             branch 'master'
-                            expression { return env.QUICKBUILD == '1' }
+                            expression { env.QUICKBUILD != 'true' }
                         }
                     }
                     agent {
@@ -773,7 +769,7 @@ pipeline {
                         allOf {
                             not { branch 'weekly-testing' }
                             expression { env.CHANGE_TARGET != 'weekly-testing' }
-                            expression { return env.QUICKBUILD == '1' }
+                            expression { env.QUICKBUILD != 'true' }
                         }
                     }
                     agent {
@@ -856,7 +852,7 @@ pipeline {
                                        snapshot: true,
                                        inst_repos: el7_component_repos + ' ' + component_repos,
                                        inst_rpms: 'openmpi3 hwloc-devel argobots ' +
-                                                  "cart-${env.CART_COMMIT} fuse3-libs " +
+                                                  "cart-devel-${env.CART_COMMIT} fuse3-libs " +
                                                   'libisa-l-devel libpmem libpmemobj protobuf-c ' +
                                                   'spdk-devel libfabric-devel pmix numactl-devel'
                         runTest stashes: [ 'CentOS-tests', 'CentOS-install', 'CentOS-build-vars' ],
@@ -995,8 +991,9 @@ pipeline {
                             label 'docker_runner'
                             additionalBuildArgs "-t ${sanitized_JOB_NAME}-centos7 " +
                                                 '$BUILDARGS ' +
-                                                '--build-arg QUICKBUILD=0' +
-                                                ' --build-arg CART_COMMIT=-' + env.CART_COMMIT +
+                                                '--build-arg QUICKBUILD=true' +
+                                                ' --build-arg QUICKBUILD_DEPS="' + env.QUICKBUILD_DEPS +
+                                                '" --build-arg CART_COMMIT=-' + env.CART_COMMIT +
                                                 ' --build-arg REPOS="' + component_repos + '"'
                         }
                     }

--- a/ftest.sh
+++ b/ftest.sh
@@ -206,13 +206,19 @@ sudo mkdir -p /usr/share/daos/control
 sudo ln -sf $SL_PREFIX/share/daos/control/setup_spdk.sh \
            /usr/share/daos/control
 sudo mkdir -p /usr/share/spdk/scripts
-sudo ln -sf $SL_PREFIX/share/spdk/scripts/setup.sh \
-           /usr/share/spdk/scripts
-sudo ln -sf $SL_PREFIX/share/spdk/scripts/common.sh \
-           /usr/share/spdk/scripts
-sudo rm -f /usr/share/spdk/include
-sudo ln -s $SL_PREFIX/include \
-           /usr/share/spdk/include
+if [ ! -f /usr/share/spdk/scripts/setup.sh ]; then
+    sudo ln -sf $SL_PREFIX/share/spdk/scripts/setup.sh \
+               /usr/share/spdk/scripts
+fi
+if [ ! -f /usr/share/spdk/scripts/common.sh ]; then
+    sudo ln -sf $SL_PREFIX/share/spdk/scripts/common.sh \
+               /usr/share/spdk/scripts
+fi
+if [ ! -f /usr/share/spdk/include/spdk/pci_ids.h ]; then
+    sudo rm -f /usr/share/spdk/include
+    sudo ln -s $SL_PREFIX/include \
+               /usr/share/spdk/include
+fi
 
 # first, strip the execute bit from the in-tree binary,
 # then copy daos_admin binary into \$PATH and fix perms

--- a/src/client/setup.py
+++ b/src/client/setup.py
@@ -25,7 +25,7 @@ def load_conf():
             return conf
 
         file_self = os.path.dirname(file_self)
-    return none
+    return None
 
 from setuptools import setup, find_packages, Extension
 
@@ -35,8 +35,10 @@ args = {'sources': ['pydaos/pydaos_shim.c'],
         'libraries': ['daos', 'duns']}
 
 if conf:
-    args['include_dirs'] = [os.path.join(conf['PREFIX'], 'include'),
-                                      os.path.join(conf['CART_PREFIX'], 'include')]
+    args['include_dirs'] = [os.path.join(conf['PREFIX'], 'include')]
+    if conf.get('CART_PREFIX', None):
+        args['include_dirs'].extend(os.path.join(
+            conf['CART_PREFIX'], 'include'))
     args['library_dirs'] = [os.path.join(conf['PREFIX'], 'lib64')]
     args['runtime_library_dirs'] = args['library_dirs']
 

--- a/src/control/run_go_tests.sh
+++ b/src/control/run_go_tests.sh
@@ -45,19 +45,19 @@ function setup_environment()
 	source "${build_source}"
 
 	# allow cgo to find and link to third-party libs
-	LD_LIBRARY_PATH=${SL_PREFIX}/lib64
-	LD_LIBRARY_PATH+=":${SL_SPDK_PREFIX}/lib"
-	LD_LIBRARY_PATH+=":${SL_OFI_PREFIX}/lib"
-	LD_LIBRARY_PATH+=":${SL_ISAL_PREFIX}/lib"
-	CGO_LDFLAGS=-L${SL_PREFIX}/lib64
-	CGO_LDFLAGS+=" -L${SL_SPDK_PREFIX}/lib"
-	CGO_LDFLAGS+=" -L${SL_OFI_PREFIX}/lib"
-	CGO_LDFLAGS+=" -L${SL_ISAL_PREFIX}/lib"
+	LD_LIBRARY_PATH=${SL_PREFIX+${SL_PREFIX}/lib64}
+	LD_LIBRARY_PATH+="${SL_SPDK_PREFIX+:${SL_SPDK_PREFIX}/lib}"
+	LD_LIBRARY_PATH+="${SL_OFI_PREFIX+:${SL_OFI_PREFIX}/lib}"
+	LD_LIBRARY_PATH+="${SL_ISAL_PREFIX+:${SL_ISAL_PREFIX}/lib}"
+	CGO_LDFLAGS=${SL_PREFIX+-L${SL_PREFIX}/lib64}
+	CGO_LDFLAGS+="${SL_SPDK_PREFIX+ -L${SL_SPDK_PREFIX}/lib}"
+	CGO_LDFLAGS+="${SL_OFI_PREFIX+ -L${SL_OFI_PREFIX}/lib}"
+	CGO_LDFLAGS+="${SL_ISAL_PREFIX+ -L${SL_ISAL_PREFIX}/lib}"
 	CGO_LDFLAGS+=" -lisal"
-	CGO_CFLAGS=-I${SL_PREFIX}/include
-	CGO_CFLAGS+=" -I${SL_SPDK_PREFIX}/include"
-	CGO_CFLAGS+=" -I${SL_OFI_PREFIX}/include"
-	CGO_CFLAGS+=" -I${SL_ISAL_PREFIX}/include"
+	CGO_CFLAGS=${SL_PREFIX+-I${SL_PREFIX}/include}
+	CGO_CFLAGS+="${SL_SPDK_PREFIX+ -I${SL_SPDK_PREFIX}/include}"
+	CGO_CFLAGS+="${SL_OFI_PREFIX+ -I${SL_OFI_PREFIX}/include}"
+	CGO_CFLAGS+="${SL_ISAL_PREFIX+ -I${SL_ISAL_PREFIX}/include}"
 }
 
 function check_formatting()

--- a/src/control/server/init/setup_spdk.sh
+++ b/src/control/server/init/setup_spdk.sh
@@ -63,6 +63,14 @@ echo "start of script: $thisscriptpath/$thisscriptname"
 
 rootdir="$(readlink -f "$(dirname "$0")")"/../..
 scriptpath="$rootdir/spdk/scripts/setup.sh"
+if [ ! -f "$scriptpath" ]; then
+    if [ -f /usr/share/spdk/scripts/setup.sh ]; then
+        scriptpath=/usr/share/spdk/scripts/setup.sh
+	else
+	    echo "Could not find the SPDK setup.sh script" >&2
+		exit 1
+	fi
+fi
 
 echo "calling into script: $scriptpath"
 

--- a/utils/docker/Dockerfile.centos.7
+++ b/utils/docker/Dockerfile.centos.7
@@ -96,10 +96,11 @@ RUN chown daos.daos /mnt/daos
 # Packages for NVML exist in CentOS, but are
 # unfortunately outdated. The DAOS build system will rebuild those packages.
 ARG JENKINS_URL=""
-ARG QUICKBUILD=1
+ARG QUICKBUILD=false
+ARG QUICKBUILD_DEPS=""
 ARG CART_COMMIT=""
 ARG REPOS=""
-RUN if [ $QUICKBUILD -eq 0 ]; then                                               \
+RUN if $QUICKBUILD; then                                                         \
         echo -e "[repo.dc.hpdd.intel.com_repository_daos-stack-el-7-x86_64-stable-local]\n\
 name=created by dnf config-manager from https://repo.dc.hpdd.intel.com/repository/daos-stack-el-7-x86_64-stable-local\n\
 baseurl=https://repo.dc.hpdd.intel.com/repository/daos-stack-el-7-x86_64-stable-local\n\
@@ -122,13 +123,8 @@ baseurl=${JENKINS_URL}job/daos-stack/job/$repo/job/$branch/$build_number/artifac
 enabled=1\n\
 gpgcheck=False\n" >> /etc/yum.repos.d/$repo:$branch:$build_number.repo;          \
         done;                                                                    \
-        pkgs="cart-devel$CART_COMMIT argobots-devel libpmem-devel                \
-              libpmemobj-devel fuse-devel protobuf-c-devel spdk-devel            \
-              fio-3.3-5.el7 libisa-l-devel mercury-devel-1.0.1-21.el7            \
-              openpa-devel libfabric-devel                                       \
-              dpdk-devel";                     \
-        echo "Installing: $pkgs";                                                \
-        yum -y install $pkgs;                                                    \
+        echo "Installing: $QUICKBUILD_DEPS";                                     \
+        echo "$QUICKBUILD_DEPS" | tr '\n' '\0' | xargs -0 yum -y install;        \
     fi
 
 # force an upgrade to get any newly built RPMs


### PR DESCRIPTION
Currently we have to maintain the proper versions of dependencies in the
Dockerfile.centos.7 file when used with Quick-build: true.  It gets out
of date often.

Instead, the list of packages to install for Quick-build: true should be
given to the Dockerfile by Jenkins after it queries the daos.spec to get
the list of dependencies.

Make RPM build log step more obvious.

Signed-off-by: Brian J. Murrell <brian.murrell@intel.com>