### PR TITLE
DAOS-2746 test: Use junit-capable go test runner

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -855,7 +855,7 @@ pipeline {
                                        node_count: 1,
                                        snapshot: true,
                                        inst_repos: el7_component_repos + ' ' + component_repos,
-                                       inst_rpms: 'openmpi3 hwloc-devel argobots ' +
+                                       inst_rpms: 'gotestsum openmpi3 hwloc-devel argobots ' +
                                                   "cart-${env.CART_COMMIT} fuse3-libs " +
                                                   'libisa-l-devel libpmem libpmemobj protobuf-c ' +
                                                   'spdk-devel libfabric-devel pmix numactl-devel'
@@ -892,7 +892,7 @@ pipeline {
                                                export CMOCKA_MESSAGE_OUTPUT="xml"
                                                export CMOCKA_XML_FILE="$DAOS_BASE/test_results/%g.xml"
                                                cd $DAOS_BASE
-                                               OLD_CI=false utils/run_test.sh"''',
+                                               IS_CI=true OLD_CI=false utils/run_test.sh"''',
                               junit_files: 'test_results/*.xml'
                     }
                     post {

--- a/src/control/run_go_tests.sh
+++ b/src/control/run_go_tests.sh
@@ -76,11 +76,35 @@ function check_formatting()
 	fi
 }
 
+function get_test_runner()
+{
+	test_args="-race -cover -v ./..."
+	test_runner="go test"
+
+	if which gotestsum >/dev/null; then
+		mkdir -p "$(dirname "$GO_TEST_XML")"
+		test_runner="gotestsum --format short "
+		test_runner+="--junitfile-testcase-classname relative "
+		test_runner+="--junitfile-testsuite-name relative "
+		if [ -n "${IS_CI:-}" ]; then
+			test_runner+="--no-color "
+		fi
+		test_runner+="--junitfile $GO_TEST_XML --"
+	fi
+
+	echo "$test_runner $test_args"
+}
+
 check=$(check_environment)
 
 if [ "$check" == "false" ]; then
 	setup_environment
 fi
+
+DAOS_BASE=${DAOS_BASE:-${SL_PREFIX%/install*}}
+export PATH=$SL_PREFIX/bin:$PATH
+GO_TEST_XML="$DAOS_BASE/test_results/run_go_tests.xml"
+GO_TEST_RUNNER=$(get_test_runner)
 
 DIR="$(readlink -f "$(dirname "${BASH_SOURCE[0]}")")"
 GOPATH="$(readlink -f "$DIR/../../build/src/control")"
@@ -90,6 +114,7 @@ controldir="$GOPATH/src/$repopath/src/control"
 check_formatting "$controldir"
 
 echo "Environment:"
+echo "  GO VERSION: $(go version | awk '{print $3" "$4}')"
 echo "  LD_LIBRARY_PATH: $LD_LIBRARY_PATH"
 echo "  CGO_LDFLAGS: $CGO_LDFLAGS"
 echo "  CGO_CFLAGS: $CGO_CFLAGS"
@@ -104,9 +129,14 @@ LD_LIBRARY_PATH="$LD_LIBRARY_PATH" \
 CGO_LDFLAGS="$CGO_LDFLAGS" \
 CGO_CFLAGS="$CGO_CFLAGS" \
 GOPATH="$GOPATH" \
-	go test -race -cover -v ./...
+	$GO_TEST_RUNNER
 testrc=$?
 popd >/dev/null
+
+if [ -f "$GO_TEST_XML" ]; then
+	# add a newline to make the XML parser happy
+	echo >> "$GO_TEST_XML"
+fi
 
 echo "Tests completed with rc: $testrc"
 exit $testrc


### PR DESCRIPTION
The gotestsum runner has a --junitfile option that will
convert the native runner's JSON output into JUnit for
consumption by Jenkins.

When gotestsum is available, the run_go_tests.sh script will
prefer it; otherwise it will fall back to the native `go test` runner.