### PR TITLE
DAOS-4211 sec: Check container capas for prop access

### DIFF
--- a/src/container/srv_epoch.c
+++ b/src/container/srv_epoch.c
@@ -27,6 +27,7 @@
 
 #include <daos_srv/pool.h>
 #include <daos_srv/rdb.h>
+#include <daos_srv/security.h>
 #include "rpc.h"
 #include "srv_internal.h"
 #include "srv_layout.h"
@@ -238,7 +239,7 @@ ds_cont_epoch_discard(struct rdb_tx *tx, struct ds_pool_hdl *pool_hdl,
 		DP_UUID(in->cei_op.ci_hdl), in->cei_epoch);
 
 	/* Verify the container handle capabilities. */
-	if (!(hdl->ch_flags & DAOS_COO_RW))
+	if (!ds_sec_cont_can_write_data(hdl->ch_sec_capas))
 		D_GOTO(out, rc = -DER_NO_PERM);
 
 	if (in->cei_epoch >= DAOS_EPOCH_MAX)
@@ -319,7 +320,7 @@ ds_cont_snap_create(struct rdb_tx *tx, struct ds_pool_hdl *pool_hdl,
 		in->cei_epoch);
 
 	/* Verify the container handle capabilities. */
-	if (!(hdl->ch_flags & DAOS_COO_RW)) {
+	if (!ds_sec_cont_can_write_data(hdl->ch_sec_capas)) {
 		rc = -DER_NO_PERM;
 		goto out;
 	}

--- a/src/include/daos_prop.h
+++ b/src/include/daos_prop.h
@@ -179,6 +179,11 @@ enum daos_cont_props {
 	DAOS_PROP_CO_MAX,
 };
 
+/**
+ * Number of container property types
+ */
+#define DAOS_PROP_CO_NUM	(DAOS_PROP_CO_MAX - DAOS_PROP_CO_MIN - 1)
+
 typedef uint16_t daos_cont_layout_t;
 
 /** container layout type */

--- a/src/include/daos_srv/security.h
+++ b/src/include/daos_srv/security.h
@@ -172,4 +172,82 @@ bool
 ds_sec_cont_can_delete(uint64_t pool_flags, d_iov_t *cred,
 		       struct ownership *ownership, struct daos_acl *acl);
 
+/**
+ * Determine if the container properties can be viewed based on the container
+ * security capabilities.
+ *
+ * \param	cont_capas	Capability bits acquired via
+ *				ds_sec_cont_get_capabilities
+ *
+ * \return	True		Access allowed
+ *		False		Access denied
+ */
+bool
+ds_sec_cont_can_get_props(uint64_t cont_capas);
+
+/**
+ * Determine if the container properties can be modified based on the container
+ * security capabilities.
+ *
+ * \param	cont_capas	Capability bits acquired via
+ *				ds_sec_cont_get_capabilities
+ *
+ * \return	True		Access allowed
+ *		False		Access denied
+ */
+bool
+ds_sec_cont_can_set_props(uint64_t cont_capas);
+
+/**
+ * Determine if the container Access Control List can be viewed based on the
+ * container security capabilities.
+ *
+ * \param	cont_capas	Capability bits acquired via
+ *				ds_sec_cont_get_capabilities
+ *
+ * \return	True		Access allowed
+ *		False		Access denied
+ */
+bool
+ds_sec_cont_can_get_acl(uint64_t cont_capas);
+
+/**
+ * Determine if the container Access Control List can be modified based on the
+ * container security capabilities.
+ *
+ * \param	cont_capas	Capability bits acquired via
+ *				ds_sec_cont_get_capabilities
+ *
+ * \return	True		Access allowed
+ *		False		Access denied
+ */
+bool
+ds_sec_cont_can_set_acl(uint64_t cont_capas);
+
+/**
+ * Determine if the container ownership can be modified based on the container
+ * security capabilities.
+ *
+ * \param	cont_capas	Capability bits acquired via
+ *				ds_sec_cont_get_capabilities
+ *
+ * \return	True		Access allowed
+ *		False		Access denied
+ */
+bool
+ds_sec_cont_can_set_owner(uint64_t cont_capas);
+
+/**
+ * Determine if the container can be written based on the container security
+ * capabilities.
+ *
+ * \param	cont_capas	Capability bits acquired via
+ *				ds_sec_cont_get_capabilities
+ *
+ * \return	True		Access allowed
+ *		False		Access denied
+ */
+bool
+ds_sec_cont_can_write_data(uint64_t cont_capas);
+
 #endif /* __DAOS_SRV_SECURITY_H__ */

--- a/src/object/srv_obj.c
+++ b/src/object/srv_obj.c
@@ -39,6 +39,7 @@
 #include <daos_srv/bio.h>
 #include <daos_srv/daos_server.h>
 #include <daos_srv/dtx_srv.h>
+#include <daos_srv/security.h>
 #include <daos/checksum.h>
 #include "daos_srv/srv_csum.h"
 #include "obj_rpc.h"
@@ -1044,10 +1045,11 @@ obj_ioc_init(uuid_t pool_uuid, uuid_t coh_uuid, uuid_t cont_uuid, int opc,
 		return rc;
 	}
 
-	if (obj_is_modification_opc(opc) && !(coh->sch_flags & DAOS_COO_RW)) {
-		D_ERROR("cont "DF_UUID" hdl "DF_UUID" sch_capas "DF_U64", "
+	if (obj_is_modification_opc(opc) &&
+	    !ds_sec_cont_can_write_data(coh->sch_sec_capas)) {
+		D_ERROR("cont "DF_UUID" hdl "DF_UUID" sec_capas "DF_U64", "
 			"NO_PERM to update.\n", DP_UUID(cont_uuid),
-			DP_UUID(coh_uuid), coh->sch_flags);
+			DP_UUID(coh_uuid), coh->sch_sec_capas);
 		D_GOTO(failed, rc = -DER_NO_PERM);
 	}
 

--- a/src/security/srv_acl.c
+++ b/src/security/srv_acl.c
@@ -715,3 +715,39 @@ ds_sec_cont_can_delete(uint64_t pool_flags, d_iov_t *cred,
 
 	return (capas & CONT_CAPA_DELETE) != 0;
 }
+
+bool
+ds_sec_cont_can_get_props(uint64_t cont_capas)
+{
+	return (cont_capas & CONT_CAPA_GET_PROP) != 0;
+}
+
+bool
+ds_sec_cont_can_set_props(uint64_t cont_capas)
+{
+	return (cont_capas & CONT_CAPA_SET_PROP) != 0;
+}
+
+bool
+ds_sec_cont_can_get_acl(uint64_t cont_capas)
+{
+	return (cont_capas & CONT_CAPA_GET_ACL) != 0;
+}
+
+bool
+ds_sec_cont_can_set_acl(uint64_t cont_capas)
+{
+	return (cont_capas & CONT_CAPA_SET_ACL) != 0;
+}
+
+bool
+ds_sec_cont_can_set_owner(uint64_t cont_capas)
+{
+	return (cont_capas & CONT_CAPA_SET_OWNER) != 0;
+}
+
+bool
+ds_sec_cont_can_write_data(uint64_t cont_capas)
+{
+	return (cont_capas & CONT_CAPA_WRITE_DATA) != 0;
+}

--- a/src/security/srv_internal.h
+++ b/src/security/srv_internal.h
@@ -45,6 +45,9 @@ extern char *ds_sec_server_socket_path;
 #define POOL_CAPA_DEL_CONT	(1U << 2)
 
 #define POOL_CAPAS_RO_MASK	(POOL_CAPA_READ)
+#define POOL_CAPAS_ALL		(POOL_CAPA_READ |			\
+				 POOL_CAPA_CREATE_CONT |		\
+				 POOL_CAPA_DEL_CONT)
 
 /*
  * Container capabilities bits. Derived from user-requested flags and user's
@@ -62,6 +65,14 @@ extern char *ds_sec_server_socket_path;
 #define CONT_CAPAS_RO_MASK	(CONT_CAPA_READ_DATA |			\
 				 CONT_CAPA_GET_PROP |			\
 				 CONT_CAPA_GET_ACL)
+#define CONT_CAPAS_ALL		(CONT_CAPA_READ_DATA |			\
+				 CONT_CAPA_WRITE_DATA |			\
+				 CONT_CAPA_GET_PROP |			\
+				 CONT_CAPA_SET_PROP |			\
+				 CONT_CAPA_GET_ACL |			\
+				 CONT_CAPA_SET_ACL |			\
+				 CONT_CAPA_SET_OWNER |			\
+				 CONT_CAPA_DELETE)
 
 int ds_sec_validate_credentials(d_iov_t *creds, Auth__Token **token);
 

--- a/src/security/tests/srv_acl_tests.c
+++ b/src/security/tests/srv_acl_tests.c
@@ -1750,19 +1750,10 @@ test_cont_get_capas_success(void **state)
 				     CONT_CAPA_DELETE);
 	expect_cont_capas_with_perms(DAOS_ACL_PERM_CONT_ALL,
 				     DAOS_COO_RW,
-				     CONT_CAPA_READ_DATA |
-				     CONT_CAPA_WRITE_DATA |
-				     CONT_CAPA_SET_PROP |
-				     CONT_CAPA_GET_PROP |
-				     CONT_CAPA_SET_ACL |
-				     CONT_CAPA_GET_ACL |
-				     CONT_CAPA_SET_OWNER |
-				     CONT_CAPA_DELETE);
+				     CONT_CAPAS_ALL);
 	expect_cont_capas_with_perms(DAOS_ACL_PERM_CONT_ALL,
 				     DAOS_COO_RO,
-				     CONT_CAPA_READ_DATA |
-				     CONT_CAPA_GET_PROP |
-				     CONT_CAPA_GET_ACL);
+				     CONT_CAPAS_RO_MASK);
 }
 
 static void
@@ -1790,9 +1781,8 @@ test_pool_can_connect(void **state)
 	assert_false(ds_sec_pool_can_connect(~POOL_CAPA_READ));
 
 	assert_true(ds_sec_pool_can_connect(POOL_CAPA_READ));
-	assert_true(ds_sec_pool_can_connect(POOL_CAPA_READ |
-					    POOL_CAPA_CREATE_CONT |
-					    POOL_CAPA_DEL_CONT));
+	assert_true(ds_sec_pool_can_connect(POOL_CAPAS_RO_MASK));
+	assert_true(ds_sec_pool_can_connect(POOL_CAPAS_ALL));
 }
 
 static void
@@ -1802,9 +1792,7 @@ test_pool_can_create_cont(void **state)
 	assert_false(ds_sec_pool_can_create_cont(~POOL_CAPA_CREATE_CONT));
 
 	assert_true(ds_sec_pool_can_create_cont(POOL_CAPA_CREATE_CONT));
-	assert_true(ds_sec_pool_can_create_cont(POOL_CAPA_READ |
-						POOL_CAPA_CREATE_CONT |
-						POOL_CAPA_DEL_CONT));
+	assert_true(ds_sec_pool_can_create_cont(POOL_CAPAS_ALL));
 }
 
 static void
@@ -1833,13 +1821,7 @@ test_cont_can_open(void **state)
 	assert_true(ds_sec_cont_can_open(CONT_CAPA_GET_PROP));
 	assert_true(ds_sec_cont_can_open(CONT_CAPA_GET_ACL));
 	assert_true(ds_sec_cont_can_open(CONT_CAPAS_RO_MASK));
-	assert_true(ds_sec_cont_can_open(CONT_CAPA_READ_DATA |
-					 CONT_CAPA_WRITE_DATA |
-					 CONT_CAPA_GET_PROP |
-					 CONT_CAPA_SET_PROP |
-					 CONT_CAPA_GET_ACL |
-					 CONT_CAPA_SET_ACL |
-					 CONT_CAPA_SET_OWNER));
+	assert_true(ds_sec_cont_can_open(CONT_CAPAS_ALL));
 }
 
 static void
@@ -1887,6 +1869,72 @@ test_cont_can_delete(void **state)
 	daos_acl_free(no_del_acl);
 	daos_acl_free(default_acl);
 	daos_iov_free(&cred);
+}
+
+static void
+test_cont_can_get_props(void **state)
+{
+	assert_false(ds_sec_cont_can_get_props(0));
+	assert_false(ds_sec_cont_can_get_props(~CONT_CAPA_GET_PROP));
+
+	assert_true(ds_sec_cont_can_get_props(CONT_CAPAS_RO_MASK));
+	assert_true(ds_sec_cont_can_get_props(CONT_CAPAS_ALL));
+	assert_true(ds_sec_cont_can_get_props(CONT_CAPA_GET_PROP));
+}
+
+static void
+test_cont_can_set_props(void **state)
+{
+	assert_false(ds_sec_cont_can_set_props(0));
+	assert_false(ds_sec_cont_can_set_props(~CONT_CAPA_SET_PROP));
+	assert_false(ds_sec_cont_can_set_props(CONT_CAPAS_RO_MASK));
+
+	assert_true(ds_sec_cont_can_set_props(CONT_CAPAS_ALL));
+	assert_true(ds_sec_cont_can_set_props(CONT_CAPA_SET_PROP));
+}
+
+static void
+test_cont_can_get_acl(void **state)
+{
+	assert_false(ds_sec_cont_can_get_acl(0));
+	assert_false(ds_sec_cont_can_get_acl(~CONT_CAPA_GET_ACL));
+
+	assert_true(ds_sec_cont_can_get_acl(CONT_CAPAS_RO_MASK));
+	assert_true(ds_sec_cont_can_get_acl(CONT_CAPAS_ALL));
+	assert_true(ds_sec_cont_can_get_acl(CONT_CAPA_GET_ACL));
+}
+
+static void
+test_cont_can_set_acl(void **state)
+{
+	assert_false(ds_sec_cont_can_set_acl(0));
+	assert_false(ds_sec_cont_can_set_acl(~CONT_CAPA_SET_ACL));
+	assert_false(ds_sec_cont_can_set_acl(CONT_CAPAS_RO_MASK));
+
+	assert_true(ds_sec_cont_can_set_acl(CONT_CAPAS_ALL));
+	assert_true(ds_sec_cont_can_set_acl(CONT_CAPA_SET_ACL));
+}
+
+static void
+test_cont_can_set_owner(void **state)
+{
+	assert_false(ds_sec_cont_can_set_owner(0));
+	assert_false(ds_sec_cont_can_set_owner(~CONT_CAPA_SET_OWNER));
+	assert_false(ds_sec_cont_can_set_owner(CONT_CAPAS_RO_MASK));
+
+	assert_true(ds_sec_cont_can_set_owner(CONT_CAPAS_ALL));
+	assert_true(ds_sec_cont_can_set_owner(CONT_CAPA_SET_OWNER));
+}
+
+static void
+test_cont_can_write_data(void **state)
+{
+	assert_false(ds_sec_cont_can_write_data(0));
+	assert_false(ds_sec_cont_can_write_data(~CONT_CAPA_WRITE_DATA));
+	assert_false(ds_sec_cont_can_write_data(CONT_CAPAS_RO_MASK));
+
+	assert_true(ds_sec_cont_can_write_data(CONT_CAPAS_ALL));
+	assert_true(ds_sec_cont_can_write_data(CONT_CAPA_WRITE_DATA));
 }
 
 /* Convenience macro for unit tests */
@@ -1954,6 +2002,12 @@ main(void)
 		cmocka_unit_test(test_pool_can_delete_cont),
 		cmocka_unit_test(test_cont_can_open),
 		cmocka_unit_test(test_cont_can_delete),
+		cmocka_unit_test(test_cont_can_get_props),
+		cmocka_unit_test(test_cont_can_set_props),
+		cmocka_unit_test(test_cont_can_get_acl),
+		cmocka_unit_test(test_cont_can_set_acl),
+		cmocka_unit_test(test_cont_can_set_owner),
+		cmocka_unit_test(test_cont_can_write_data),
 	};
 
 	return cmocka_run_group_tests(tests, NULL, NULL);

--- a/src/tests/suite/daos_container.c
+++ b/src/tests/suite/daos_container.c
@@ -279,6 +279,24 @@ is_acl_prop_default(struct daos_acl *prop)
 	return true;
 }
 
+static daos_prop_t *
+get_query_prop_all(void)
+{
+	daos_prop_t	*prop;
+	const int	prop_count = DAOS_PROP_CO_NUM;
+	int		i;
+
+	prop = daos_prop_alloc(prop_count);
+	assert_non_null(prop);
+
+	for (i = 0; i < prop_count; i++) {
+		prop->dpp_entries[i].dpe_type = DAOS_PROP_CO_MIN + 1 + i;
+		assert_true(prop->dpp_entries[i].dpe_type < DAOS_PROP_CO_MAX);
+	}
+
+	return prop;
+}
+
 static void
 co_properties(void **state)
 {
@@ -318,22 +336,11 @@ co_properties(void **state)
 	}
 	MPI_Barrier(MPI_COMM_WORLD);
 
-	const int prop_count = 9;
-
-	prop_query = daos_prop_alloc(prop_count);
-	prop_query->dpp_entries[0].dpe_type = DAOS_PROP_CO_LABEL;
-	prop_query->dpp_entries[1].dpe_type = DAOS_PROP_CO_CSUM;
-	prop_query->dpp_entries[2].dpe_type = DAOS_PROP_CO_CSUM_CHUNK_SIZE;
-	prop_query->dpp_entries[3].dpe_type = DAOS_PROP_CO_CSUM_SERVER_VERIFY;
-	prop_query->dpp_entries[4].dpe_type = DAOS_PROP_CO_ENCRYPT;
-	prop_query->dpp_entries[5].dpe_type = DAOS_PROP_CO_SNAPSHOT_MAX;
-	prop_query->dpp_entries[6].dpe_type = DAOS_PROP_CO_ACL;
-	prop_query->dpp_entries[7].dpe_type = DAOS_PROP_CO_OWNER;
-	prop_query->dpp_entries[8].dpe_type = DAOS_PROP_CO_OWNER_GROUP;
+	prop_query = get_query_prop_all();
 	rc = daos_cont_query(arg->coh, NULL, prop_query, NULL);
 	assert_int_equal(rc, 0);
 
-	assert_int_equal(prop_query->dpp_nr, prop_count);
+	assert_int_equal(prop_query->dpp_nr, DAOS_PROP_CO_NUM);
 	/* set properties should get the value user set */
 	entry = daos_prop_entry_get(prop_query, DAOS_PROP_CO_LABEL);
 	if (entry == NULL || strcmp(entry->dpe_str, label) != 0) {
@@ -538,6 +545,21 @@ add_ace_with_perms(struct daos_acl **acl, enum daos_acl_principal_type type,
 	daos_ace_free(ace);
 }
 
+static char *
+get_current_user_name(void)
+{
+	uid_t	uid;
+	int	rc;
+	char	*user = NULL;
+
+	uid = geteuid();
+	rc = daos_acl_uid_to_principal(uid, &user);
+	assert_int_equal(rc, 0);
+	assert_non_null(user);
+
+	return user;
+}
+
 static void
 co_acl(void **state)
 {
@@ -551,7 +573,6 @@ co_acl(void **state)
 	struct daos_acl		*exp_acl;
 	struct daos_acl		*update_acl;
 	struct daos_ace		*ace;
-	uid_t			 uid;
 	char			*user;
 	d_string_t		 name_to_remove = "friendlyuser@";
 	uint8_t			 type_to_remove = DAOS_ACL_USER;
@@ -567,10 +588,9 @@ co_acl(void **state)
 	 * This ACL gives the effective user permissions to interact
 	 * with the ACL. This is the bare minimum required to run the tests.
 	 */
-	uid = geteuid();
-	rc = daos_acl_uid_to_principal(uid, &user);
-	assert_int_equal(rc, 0);
-	assert_non_null(user);
+	user = get_current_user_name();
+
+	print_message("Creating ACL with entry for user %s\n", user);
 
 	exp_acl = daos_acl_create(NULL, 0);
 	assert_non_null(exp_acl);
@@ -806,6 +826,8 @@ co_create_access_denied(void **state)
 		uuid_clear(arg->co_uuid);
 	}
 
+	uuid_clear(arg->co_uuid); /* wasn't actually created */
+
 	daos_prop_free(prop);
 	test_teardown((void **)&arg);
 }
@@ -931,16 +953,11 @@ co_destroy_allowed_by_pool(void **state)
 }
 
 static void
-expect_cont_open_access(test_arg_t *arg0, uint64_t perms, uint64_t flags,
+expect_cont_open_access(test_arg_t *arg, uint64_t perms, uint64_t flags,
 			int exp_result)
 {
-	test_arg_t	*arg = NULL;
 	daos_prop_t	*prop;
-	int		 rc;
-
-	rc = test_setup((void **)&arg, SETUP_EQ, arg0->multi_rank,
-			DEFAULT_POOL_SIZE, NULL);
-	assert_int_equal(rc, 0);
+	int		 rc = 0;
 
 	arg->cont_open_flags = flags;
 	prop = get_daos_prop_with_owner_acl_perms(perms,
@@ -955,37 +972,628 @@ expect_cont_open_access(test_arg_t *arg0, uint64_t perms, uint64_t flags,
 		assert_int_equal(rc, exp_result);
 	}
 
+	/* Cleanup */
+	test_teardown_cont_hdl(arg);
+	test_teardown_cont(arg);
 	daos_prop_free(prop);
-	test_teardown((void **)&arg);
 }
 
 static void
 co_open_access(void **state)
 {
 	test_arg_t	*arg0 = *state;
+	test_arg_t	*arg = NULL;
+	int		rc;
+
+	rc = test_setup((void **)&arg, SETUP_EQ, arg0->multi_rank,
+			DEFAULT_POOL_SIZE, NULL);
+	assert_int_equal(rc, 0);
 
 	print_message("cont ACL gives the owner no permissions\n");
-	expect_cont_open_access(arg0, 0, DAOS_COO_RO, -DER_NO_PERM);
+	expect_cont_open_access(arg, 0, DAOS_COO_RO, -DER_NO_PERM);
 
 	print_message("cont ACL gives the owner RO, they want RW\n");
-	expect_cont_open_access(arg0, DAOS_ACL_PERM_READ, DAOS_COO_RW,
+	expect_cont_open_access(arg, DAOS_ACL_PERM_READ, DAOS_COO_RW,
 				   -DER_NO_PERM);
 
 	print_message("cont ACL gives the owner RO, they want RO\n");
-	expect_cont_open_access(arg0, DAOS_ACL_PERM_READ, DAOS_COO_RO,
+	expect_cont_open_access(arg, DAOS_ACL_PERM_READ, DAOS_COO_RO,
 				   0);
 
 	print_message("cont ACL gives the owner RW, they want RO\n");
-	expect_cont_open_access(arg0,
+	expect_cont_open_access(arg,
 				   DAOS_ACL_PERM_READ | DAOS_ACL_PERM_WRITE,
 				   DAOS_COO_RO,
 				   0);
 
 	print_message("cont ACL gives the owner RW, they want RW\n");
-	expect_cont_open_access(arg0,
+	expect_cont_open_access(arg,
 				   DAOS_ACL_PERM_READ | DAOS_ACL_PERM_WRITE,
 				   DAOS_COO_RW,
 				   0);
+
+	test_teardown((void **)&arg);
+}
+
+static void
+expect_co_query_access(test_arg_t *arg, daos_prop_t *query_prop,
+		       uint64_t perms, int exp_result)
+{
+	daos_prop_t		*cont_prop;
+	daos_cont_info_t	 info;
+	int			 rc = 0;
+
+	cont_prop = get_daos_prop_with_owner_acl_perms(perms,
+						       DAOS_PROP_CO_ACL);
+
+	arg->cont_open_flags = DAOS_COO_RO;
+	while (!rc && arg->setup_state != SETUP_CONT_CONNECT)
+		rc = test_setup_next_step((void **)&arg, NULL, NULL,
+					  cont_prop);
+	assert_int_equal(rc, 0);
+
+	if (arg->myrank == 0) {
+		rc = daos_cont_query(arg->coh, &info, query_prop, NULL);
+		assert_int_equal(rc, exp_result);
+	}
+
+	daos_prop_free(cont_prop);
+	test_teardown_cont_hdl(arg);
+	test_teardown_cont(arg);
+}
+
+static daos_prop_t *
+get_single_query_prop(uint32_t type)
+{
+	daos_prop_t	*prop;
+
+	prop = daos_prop_alloc(1);
+	assert_non_null(prop);
+
+	prop->dpp_entries[0].dpe_type = type;
+
+	return prop;
+}
+
+static void
+co_query_access(void **state)
+{
+	test_arg_t	*arg0 = *state;
+	test_arg_t	*arg = NULL;
+	daos_prop_t	*prop;
+	int		rc;
+
+	rc = test_setup((void **)&arg, SETUP_EQ, arg0->multi_rank,
+			DEFAULT_POOL_SIZE, NULL);
+	assert_int_equal(rc, 0);
+
+	print_message("Not asking for any props\n");
+	expect_co_query_access(arg, NULL,
+			       DAOS_ACL_PERM_CONT_ALL &
+			       ~DAOS_ACL_PERM_GET_PROP &
+			       ~DAOS_ACL_PERM_GET_ACL,
+			       -0);
+
+	print_message("All props with no get-prop access\n");
+	prop = get_query_prop_all();
+	expect_co_query_access(arg, prop,
+			       DAOS_ACL_PERM_CONT_ALL & ~DAOS_ACL_PERM_GET_PROP,
+			       -DER_NO_PERM);
+	daos_prop_free(prop);
+
+	print_message("All props with no get-ACL access\n");
+	prop = get_query_prop_all();
+	expect_co_query_access(arg, prop,
+			       DAOS_ACL_PERM_CONT_ALL & ~DAOS_ACL_PERM_GET_ACL,
+			       -DER_NO_PERM);
+	daos_prop_free(prop);
+
+	print_message("All props with only prop and ACL access\n");
+	prop = get_query_prop_all();
+	expect_co_query_access(arg, prop,
+			       DAOS_ACL_PERM_GET_PROP | DAOS_ACL_PERM_GET_ACL,
+			       0);
+	daos_prop_free(prop);
+
+	/*
+	 * ACL props can only be accessed by users with get-ACL permission
+	 */
+	print_message("ACL prop with no get-ACL access\n");
+	prop = get_single_query_prop(DAOS_PROP_CO_ACL);
+	expect_co_query_access(arg, prop,
+			       DAOS_ACL_PERM_CONT_ALL & ~DAOS_ACL_PERM_GET_ACL,
+			       -DER_NO_PERM);
+	daos_prop_free(prop);
+
+	print_message("ACL prop with only get-ACL access\n");
+	prop = get_single_query_prop(DAOS_PROP_CO_ACL);
+	expect_co_query_access(arg, prop,
+			       DAOS_ACL_PERM_GET_ACL,
+			       0);
+	daos_prop_free(prop);
+
+	/*
+	 * Props unrelated to access/ACLs can only be accessed by users with
+	 * the get-prop permission
+	 */
+	print_message("Non-access-related prop with no get-prop access\n");
+	prop = get_single_query_prop(DAOS_PROP_CO_LABEL);
+	expect_co_query_access(arg, prop,
+			       DAOS_ACL_PERM_CONT_ALL & ~DAOS_ACL_PERM_GET_PROP,
+			       -DER_NO_PERM);
+	daos_prop_free(prop);
+
+	print_message("Non-access-related prop with only prop access\n");
+	prop = get_single_query_prop(DAOS_PROP_CO_LABEL);
+	expect_co_query_access(arg, prop,
+			       DAOS_ACL_PERM_GET_PROP,
+			       0);
+	daos_prop_free(prop);
+
+	/*
+	 * Ownership props can be accessed by users with either get-prop or
+	 * get-acl access
+	 */
+	print_message("Owner with only prop access\n");
+	prop = get_single_query_prop(DAOS_PROP_CO_OWNER);
+	expect_co_query_access(arg, prop,
+			       DAOS_ACL_PERM_GET_PROP,
+			       0);
+	daos_prop_free(prop);
+
+	print_message("Owner with only ACL access\n");
+	prop = get_single_query_prop(DAOS_PROP_CO_OWNER);
+	expect_co_query_access(arg, prop,
+			       DAOS_ACL_PERM_GET_ACL,
+			       0);
+	daos_prop_free(prop);
+
+	print_message("Owner with neither get-prop nor get-acl access\n");
+	prop = get_single_query_prop(DAOS_PROP_CO_OWNER);
+	expect_co_query_access(arg, prop,
+			       DAOS_ACL_PERM_CONT_ALL &
+			       ~(DAOS_ACL_PERM_GET_PROP |
+				 DAOS_ACL_PERM_GET_ACL),
+			       -DER_NO_PERM);
+	daos_prop_free(prop);
+
+	print_message("Owner-group with only prop access\n");
+	prop = get_single_query_prop(DAOS_PROP_CO_OWNER_GROUP);
+	expect_co_query_access(arg, prop,
+			       DAOS_ACL_PERM_GET_PROP,
+			       0);
+	daos_prop_free(prop);
+
+	print_message("Owner-group with only ACL access\n");
+	prop = get_single_query_prop(DAOS_PROP_CO_OWNER_GROUP);
+	expect_co_query_access(arg, prop,
+			       DAOS_ACL_PERM_GET_ACL,
+			       0);
+	daos_prop_free(prop);
+
+	print_message("Owner-group with no get-prop or get-acl access\n");
+	prop = get_single_query_prop(DAOS_PROP_CO_OWNER_GROUP);
+	expect_co_query_access(arg, prop,
+			       DAOS_ACL_PERM_CONT_ALL &
+			       ~(DAOS_ACL_PERM_GET_PROP |
+				 DAOS_ACL_PERM_GET_ACL),
+			       -DER_NO_PERM);
+	daos_prop_free(prop);
+
+	test_teardown((void **)&arg);
+}
+
+static void
+expect_co_get_acl_access(test_arg_t *arg, uint64_t perms, int exp_result)
+{
+	daos_prop_t		*cont_prop;
+	daos_prop_t		*acl_prop;
+	int			 rc = 0;
+
+	cont_prop = get_daos_prop_with_owner_acl_perms(perms,
+						       DAOS_PROP_CO_ACL);
+
+	arg->cont_open_flags = DAOS_COO_RO;
+	while (!rc && arg->setup_state != SETUP_CONT_CONNECT)
+		rc = test_setup_next_step((void **)&arg, NULL, NULL,
+					  cont_prop);
+	assert_int_equal(rc, 0);
+
+	if (arg->myrank == 0) {
+		rc = daos_cont_get_acl(arg->coh, &acl_prop, NULL);
+		assert_int_equal(rc, exp_result);
+
+		if (rc == 0)
+			daos_prop_free(acl_prop);
+	}
+
+	daos_prop_free(cont_prop);
+	test_teardown_cont_hdl(arg);
+	test_teardown_cont(arg);
+}
+
+static void
+co_get_acl_access(void **state)
+{
+	test_arg_t	*arg0 = *state;
+	test_arg_t	*arg = NULL;
+	int		rc;
+
+	rc = test_setup((void **)&arg, SETUP_EQ, arg0->multi_rank,
+			DEFAULT_POOL_SIZE, NULL);
+	assert_int_equal(rc, 0);
+
+	print_message("No get-ACL permissions\n");
+	expect_co_get_acl_access(arg,
+				 DAOS_ACL_PERM_CONT_ALL &
+				 ~DAOS_ACL_PERM_GET_ACL,
+				 -DER_NO_PERM);
+
+	print_message("Only get-ACL permissions\n");
+	expect_co_get_acl_access(arg, DAOS_ACL_PERM_GET_ACL, 0);
+
+	test_teardown((void **)&arg);
+}
+
+static void
+expect_co_set_prop_access(test_arg_t *arg, daos_prop_t *prop, uint64_t perms,
+			  int exp_result)
+{
+	daos_prop_t	*cont_prop;
+	int		 rc = 0;
+
+	cont_prop = get_daos_prop_with_owner_acl_perms(perms,
+						       DAOS_PROP_CO_ACL);
+
+	while (!rc && arg->setup_state != SETUP_CONT_CONNECT)
+		rc = test_setup_next_step((void **)&arg, NULL, NULL,
+					  cont_prop);
+	assert_int_equal(rc, 0);
+
+	if (arg->myrank == 0) {
+		rc = daos_cont_set_prop(arg->coh, prop, NULL);
+		assert_int_equal(rc, exp_result);
+	}
+
+	daos_prop_free(cont_prop);
+	test_teardown_cont_hdl(arg);
+	test_teardown_cont(arg);
+}
+
+static void
+setup_str_prop_entry(struct daos_prop_entry *entry, uint32_t type,
+		     const char *val)
+{
+	entry->dpe_type = type;
+	D_STRNDUP(entry->dpe_str, val, DAOS_ACL_MAX_PRINCIPAL_LEN);
+}
+
+static daos_prop_t *
+get_daos_prop_with_owner(const char *user, const char *group)
+{
+	uint32_t	nr = 0;
+	uint32_t	i = 0;
+	daos_prop_t	*prop;
+
+	if (user != NULL)
+		nr++;
+	if (group != NULL)
+		nr++;
+
+	assert_true(nr > 0); /* test error! */
+
+	prop = daos_prop_alloc(nr);
+	assert_non_null(prop);
+
+	if (user != NULL) {
+		setup_str_prop_entry(&prop->dpp_entries[i], DAOS_PROP_CO_OWNER,
+				     user);
+		i++;
+	}
+
+	if (group != NULL) {
+		setup_str_prop_entry(&prop->dpp_entries[i],
+				     DAOS_PROP_CO_OWNER_GROUP, group);
+		i++;
+	}
+
+	return prop;
+}
+
+static daos_prop_t *
+get_daos_prop_with_label(void)
+{
+	daos_prop_t	*prop;
+
+	prop = daos_prop_alloc(1);
+	assert_non_null(prop);
+
+	setup_str_prop_entry(&prop->dpp_entries[0], DAOS_PROP_CO_LABEL,
+			     "My container");
+
+	return prop;
+}
+
+static daos_prop_t *
+get_daos_prop_with_all_prop_categories(void)
+{
+	daos_prop_t	*prop;
+	struct daos_acl	*acl;
+
+	prop = daos_prop_alloc(4);
+	assert_non_null(prop);
+
+	setup_str_prop_entry(&prop->dpp_entries[0], DAOS_PROP_CO_LABEL,
+			     "Container 1");
+	setup_str_prop_entry(&prop->dpp_entries[1], DAOS_PROP_CO_OWNER,
+			     "niceuser@");
+	setup_str_prop_entry(&prop->dpp_entries[2], DAOS_PROP_CO_OWNER_GROUP,
+			     "nicegroup@");
+
+	acl = get_daos_acl_with_owner_perms(DAOS_ACL_PERM_CONT_ALL);
+	prop->dpp_entries[3].dpe_type = DAOS_PROP_CO_ACL;
+	prop->dpp_entries[3].dpe_val_ptr = acl;
+
+	return prop;
+}
+
+static void
+co_set_prop_access(void **state)
+{
+	test_arg_t	*arg0 = *state;
+	daos_prop_t	*prop;
+	test_arg_t	*arg = NULL;
+	int		 rc;
+
+	rc = test_setup((void **)&arg, SETUP_EQ, arg0->multi_rank,
+			DEFAULT_POOL_SIZE, NULL);
+	assert_int_equal(rc, 0);
+
+	/*
+	 * ACL modification through set-prop only works if you have set-ACL
+	 * permissions
+	 */
+	print_message("No set-ACL permissions\n");
+	prop = get_daos_prop_with_owner_acl_perms(DAOS_ACL_PERM_CONT_ALL,
+						  DAOS_PROP_CO_ACL);
+	expect_co_set_prop_access(arg, prop,
+				  DAOS_ACL_PERM_CONT_ALL &
+				  ~DAOS_ACL_PERM_SET_ACL,
+				  -DER_NO_PERM);
+	daos_prop_free(prop);
+
+	print_message("Has set-ACL permissions\n");
+	prop = get_daos_prop_with_owner_acl_perms(DAOS_ACL_PERM_CONT_ALL,
+						  DAOS_PROP_CO_ACL);
+	expect_co_set_prop_access(arg, prop,
+				  DAOS_ACL_PERM_READ |
+				  DAOS_ACL_PERM_SET_ACL,
+				  0);
+	daos_prop_free(prop);
+
+	/*
+	 * Owner modification through set-prop only works if you have set-owner
+	 * permissions
+	 */
+	print_message("Set owner only, with no set-owner perms\n");
+	prop = get_daos_prop_with_owner("someuser@", NULL);
+	expect_co_set_prop_access(arg, prop,
+				  DAOS_ACL_PERM_CONT_ALL &
+				  ~DAOS_ACL_PERM_SET_OWNER,
+				  -DER_NO_PERM);
+	daos_prop_free(prop);
+
+	print_message("Set owner-group only, with no set-owner perms\n");
+	prop = get_daos_prop_with_owner(NULL, "somegroup@");
+	expect_co_set_prop_access(arg, prop,
+				  DAOS_ACL_PERM_CONT_ALL &
+				  ~DAOS_ACL_PERM_SET_OWNER,
+				  -DER_NO_PERM);
+	daos_prop_free(prop);
+
+	print_message("Set both owner and group, with no set-owner perms\n");
+	prop = get_daos_prop_with_owner("someuser@", "somegroup@");
+	expect_co_set_prop_access(arg, prop,
+				  DAOS_ACL_PERM_CONT_ALL &
+				  ~DAOS_ACL_PERM_SET_OWNER,
+				  -DER_NO_PERM);
+	daos_prop_free(prop);
+
+	print_message("Set both owner and group, with set-owner perms\n");
+	prop = get_daos_prop_with_owner("someuser@", "somegroup@");
+	expect_co_set_prop_access(arg, prop,
+				  DAOS_ACL_PERM_READ | DAOS_ACL_PERM_SET_OWNER,
+				  0);
+	daos_prop_free(prop);
+
+	/*
+	 * Setting regular props requires set-prop permission
+	 */
+	print_message("Set label, with no set-prop perms\n");
+	prop = get_daos_prop_with_label();
+	expect_co_set_prop_access(arg, prop,
+				  DAOS_ACL_PERM_CONT_ALL &
+				  ~DAOS_ACL_PERM_SET_PROP,
+				  -DER_NO_PERM);
+	daos_prop_free(prop);
+
+	print_message("Set label, with set-prop perms\n");
+	prop = get_daos_prop_with_label();
+	expect_co_set_prop_access(arg, prop,
+				  DAOS_ACL_PERM_READ | DAOS_ACL_PERM_SET_PROP,
+				  0);
+	daos_prop_free(prop);
+
+	/*
+	 * Set all three categories requires all three permissions
+	 */
+	print_message("Set multiple, with no set-prop perms\n");
+	prop = get_daos_prop_with_all_prop_categories();
+	expect_co_set_prop_access(arg, prop,
+				  DAOS_ACL_PERM_CONT_ALL &
+				  ~DAOS_ACL_PERM_SET_PROP,
+				  -DER_NO_PERM);
+	daos_prop_free(prop);
+
+	print_message("Set multiple, with no set-owner perms\n");
+	prop = get_daos_prop_with_all_prop_categories();
+	expect_co_set_prop_access(arg, prop,
+				  DAOS_ACL_PERM_CONT_ALL &
+				  ~DAOS_ACL_PERM_SET_OWNER,
+				  -DER_NO_PERM);
+	daos_prop_free(prop);
+
+	print_message("Set multiple, with no set-ACL perms\n");
+	prop = get_daos_prop_with_all_prop_categories();
+	expect_co_set_prop_access(arg, prop,
+				  DAOS_ACL_PERM_CONT_ALL &
+				  ~DAOS_ACL_PERM_SET_OWNER,
+				  -DER_NO_PERM);
+	daos_prop_free(prop);
+
+	print_message("Set multiple, with all required perms\n");
+	prop = get_daos_prop_with_all_prop_categories();
+	expect_co_set_prop_access(arg, prop,
+				  DAOS_ACL_PERM_READ |
+				  DAOS_ACL_PERM_SET_PROP |
+				  DAOS_ACL_PERM_SET_OWNER |
+				  DAOS_ACL_PERM_SET_ACL,
+				  0);
+	daos_prop_free(prop);
+
+	test_teardown((void **)&arg);
+}
+
+static void
+expect_co_overwrite_acl_access(test_arg_t *arg, uint64_t perms, int exp_result)
+{
+	daos_prop_t	*cont_prop;
+	struct daos_acl	*acl = NULL;
+	int		 rc = 0;
+
+	cont_prop = get_daos_prop_with_owner_acl_perms(perms,
+						       DAOS_PROP_CO_ACL);
+
+	while (!rc && arg->setup_state != SETUP_CONT_CONNECT)
+		rc = test_setup_next_step((void **)&arg, NULL, NULL,
+					  cont_prop);
+	assert_int_equal(rc, 0);
+
+	if (arg->myrank == 0) {
+		acl = get_daos_acl_with_owner_perms(DAOS_ACL_PERM_CONT_ALL);
+
+		rc = daos_cont_overwrite_acl(arg->coh, acl, NULL);
+		assert_int_equal(rc, exp_result);
+
+		daos_acl_free(acl);
+	}
+
+	daos_prop_free(cont_prop);
+	test_teardown_cont_hdl(arg);
+	test_teardown_cont(arg);
+}
+
+static void
+expect_co_update_acl_access(test_arg_t *arg, uint64_t perms, int exp_result)
+{
+	daos_prop_t	*cont_prop;
+	struct daos_acl	*acl = NULL;
+	int		 rc = 0;
+
+	cont_prop = get_daos_prop_with_owner_acl_perms(perms,
+						       DAOS_PROP_CO_ACL);
+
+	while (!rc && arg->setup_state != SETUP_CONT_CONNECT)
+		rc = test_setup_next_step((void **)&arg, NULL, NULL,
+					  cont_prop);
+	assert_int_equal(rc, 0);
+
+	if (arg->myrank == 0) {
+		acl = get_daos_acl_with_owner_perms(DAOS_ACL_PERM_CONT_ALL);
+
+		rc = daos_cont_update_acl(arg->coh, acl, NULL);
+		assert_int_equal(rc, exp_result);
+
+		daos_acl_free(acl);
+	}
+
+	daos_prop_free(cont_prop);
+	test_teardown_cont_hdl(arg);
+	test_teardown_cont(arg);
+}
+
+static void
+expect_co_delete_acl_access(test_arg_t *arg, uint64_t perms, int exp_result)
+{
+	daos_prop_t	*cont_prop;
+	int		 rc = 0;
+
+	cont_prop = get_daos_prop_with_owner_acl_perms(perms,
+						       DAOS_PROP_CO_ACL);
+
+	while (!rc && arg->setup_state != SETUP_CONT_CONNECT)
+		rc = test_setup_next_step((void **)&arg, NULL, NULL,
+					  cont_prop);
+	assert_int_equal(rc, 0);
+
+	if (arg->myrank == 0) {
+		rc = daos_cont_delete_acl(arg->coh, DAOS_ACL_OWNER, NULL, NULL);
+		assert_int_equal(rc, exp_result);
+	}
+
+	daos_prop_free(cont_prop);
+	test_teardown_cont_hdl(arg);
+	test_teardown_cont(arg);
+}
+
+static void
+co_modify_acl_access(void **state)
+{
+	test_arg_t	*arg0 = *state;
+	test_arg_t	*arg = NULL;
+	int		 rc;
+	uint64_t	 no_set_acl_perm = DAOS_ACL_PERM_CONT_ALL &
+					   ~DAOS_ACL_PERM_SET_ACL;
+	uint64_t	 min_set_acl_perm = DAOS_ACL_PERM_READ |
+					    DAOS_ACL_PERM_SET_ACL;
+
+	rc = test_setup((void **)&arg, SETUP_EQ, arg0->multi_rank,
+			DEFAULT_POOL_SIZE, NULL);
+	assert_int_equal(rc, 0);
+
+	print_message("Overwrite ACL denied with no set-ACL perm\n");
+	expect_co_overwrite_acl_access(arg, no_set_acl_perm,
+				       -DER_NO_PERM);
+
+	print_message("Overwrite ACL allowed with set-ACL perm\n");
+	expect_co_overwrite_acl_access(arg, min_set_acl_perm,
+				       0);
+
+	print_message("Update ACL denied with no set-ACL perm\n");
+	expect_co_update_acl_access(arg,
+				    DAOS_ACL_PERM_CONT_ALL &
+				    ~DAOS_ACL_PERM_SET_ACL,
+				    -DER_NO_PERM);
+
+	print_message("Update ACL allowed with set-ACL perm\n");
+	expect_co_update_acl_access(arg,
+				    DAOS_ACL_PERM_READ |
+				    DAOS_ACL_PERM_SET_ACL,
+				    0);
+
+	print_message("Delete ACL denied with no set-ACL perm\n");
+	expect_co_delete_acl_access(arg,
+				    DAOS_ACL_PERM_CONT_ALL &
+				    ~DAOS_ACL_PERM_SET_ACL,
+				    -DER_NO_PERM);
+
+	print_message("Delete ACL allowed with set-ACL perm\n");
+	expect_co_delete_acl_access(arg,
+				    DAOS_ACL_PERM_READ |
+				    DAOS_ACL_PERM_SET_ACL,
+				    0);
+
+	test_teardown((void **)&arg);
 }
 
 static int
@@ -1038,6 +1646,14 @@ static const struct CMUnitTest co_tests[] = {
 	  co_destroy_allowed_by_pool, NULL, test_case_teardown},
 	{ "CONT13: container open access by ACL",
 	  co_open_access, NULL, test_case_teardown},
+	{ "CONT14: container query access by ACL",
+	  co_query_access, NULL, test_case_teardown},
+	{ "CONT15: container get-acl access by ACL",
+	  co_get_acl_access, NULL, test_case_teardown},
+	{ "CONT16: container set-prop access by ACL",
+	  co_set_prop_access, NULL, test_case_teardown},
+	{ "CONT17: container overwrite/update/delete ACL access by ACL",
+	  co_modify_acl_access, NULL, test_case_teardown},
 };
 
 int

--- a/src/tests/suite/daos_test.h
+++ b/src/tests/suite/daos_test.h
@@ -205,6 +205,10 @@ enum {
 int
 test_teardown(void **state);
 int
+test_teardown_cont_hdl(test_arg_t *arg);
+int
+test_teardown_cont(test_arg_t *arg);
+int
 test_setup(void **state, unsigned int step, bool multi_rank,
 	   daos_size_t pool_size, struct test_pool *pool);
 int
@@ -295,6 +299,7 @@ void daos_kill_server(test_arg_t *arg, const uuid_t pool_uuid, const char *grp,
 		      d_rank_list_t *svc, d_rank_t rank);
 void daos_kill_exclude_server(test_arg_t *arg, const uuid_t pool_uuid,
 			      const char *grp, d_rank_list_t *svc);
+struct daos_acl *get_daos_acl_with_owner_perms(uint64_t perms);
 daos_prop_t *get_daos_prop_with_owner_acl_perms(uint64_t perms,
 						uint32_t prop_type);
 typedef int (*test_setup_cb_t)(void **state);


### PR DESCRIPTION
This patch adds enforcement for container access for props
and for data reading.

- Check access for get-prop and get-ACL. Fetching the ACL
  requires get-ACL permission. Owner and owner-group can
  be accessed with either get-prop or get-ACL permission.
  All other props require get-prop permission.
- Check access for set-prop, set-ACL, and set-owner. Setting
  the ACL requires set-ACL, setting the owner or owner-group
  requires set-owner, and setting other props requires set-
  prop.
- Check write access for object updates, snapshot create,
  and epoch discard.
- Add daos_test cases for endpoints that get and update
  props.
- Refactor some daos_test container tests to run faster
  by running multiple test cases on the same pool.

Signed-off-by: Kris Jacque <kristin.jacque@intel.com>