### PR TITLE
DAOS-4262 tools: Add cont set-owner command

### DIFF
--- a/src/include/daos_cont.h
+++ b/src/include/daos_cont.h
@@ -372,6 +372,28 @@ daos_cont_delete_acl(daos_handle_t coh, enum daos_acl_principal_type type,
 		     d_string_t name, daos_event_t *ev);
 
 /**
+ * Update a container's owner user and/or owner group.
+ *
+ * \param[in]	coh	Container handle
+ * \param[in]	user	New owner user (NULL if not updating)
+ * \param[in]	group	New owner group (NULL if not updating)
+ * \param[in]	ev	Completion event, it is optional and can be NULL.
+ *			The function will run in blocking mode if \a ev is NULL.
+ *
+ * \return		These values will be returned by \a ev::ev_error in
+ *			non-blocking mode:
+ *			0		Success
+ *			-DER_INVAL	Invalid parameter
+ *			-DER_NO_PERM	Permission denied
+ *			-DER_UNREACH	Network is unreachable
+ *			-DER_NO_HDL	Invalid container handle
+ *			-DER_NOMEM	Out of memory
+ */
+int
+daos_cont_set_owner(daos_handle_t coh, d_string_t user, d_string_t group,
+		    daos_event_t *ev);
+
+/**
  * List the names of all user-defined container attributes.
  *
  * \param[in]	coh	Container handle.

--- a/src/tests/suite/daos_container.c
+++ b/src/tests/suite/daos_container.c
@@ -1596,6 +1596,165 @@ co_modify_acl_access(void **state)
 	test_teardown((void **)&arg);
 }
 
+static void
+expect_ownership(test_arg_t *arg, d_string_t user, d_string_t grp)
+{
+	int			 rc;
+	daos_prop_t		*prop;
+	struct daos_prop_entry	*entry;
+
+	prop = daos_prop_alloc(2);
+	assert_non_null(prop);
+
+	prop->dpp_entries[0].dpe_type = DAOS_PROP_CO_OWNER;
+	prop->dpp_entries[1].dpe_type = DAOS_PROP_CO_OWNER_GROUP;
+
+	rc = daos_cont_query(arg->coh, NULL, prop, NULL);
+	assert_int_equal(rc, 0);
+
+	entry = daos_prop_entry_get(prop, DAOS_PROP_CO_OWNER);
+	assert_non_null(entry);
+	assert_string_equal(entry->dpe_str, user);
+
+	entry = daos_prop_entry_get(prop, DAOS_PROP_CO_OWNER_GROUP);
+	assert_non_null(entry);
+	assert_string_equal(entry->dpe_str, grp);
+
+	daos_prop_free(prop);
+}
+
+static void
+co_set_owner(void **state)
+{
+	test_arg_t	*arg0 = *state;
+	test_arg_t	*arg = NULL;
+	d_string_t	 original_user;
+	d_string_t	 original_grp;
+	d_string_t	 new_user = "newuser@";
+	d_string_t	 new_grp = "newgrp@";
+	int		 rc;
+
+	rc = test_setup((void **)&arg, SETUP_EQ, arg0->multi_rank,
+			DEFAULT_POOL_SIZE, NULL);
+	assert_int_equal(rc, 0);
+
+	while (!rc && arg->setup_state != SETUP_CONT_CONNECT)
+		rc = test_setup_next_step((void **)&arg, NULL, NULL, NULL);
+	assert_int_equal(rc, 0);
+
+	/*
+	 * To start with, the euid/egid are the owner user/group.
+	 */
+	assert_int_equal(daos_acl_uid_to_principal(geteuid(), &original_user),
+			 0);
+	assert_int_equal(daos_acl_gid_to_principal(getegid(), &original_grp),
+			 0);
+
+	if (arg->myrank == 0) {
+		print_message("Set owner with null params\n");
+		rc = daos_cont_set_owner(arg->coh, NULL, NULL, NULL);
+		assert_int_equal(rc, -DER_INVAL);
+
+		print_message("Set owner with invalid user\n");
+		rc = daos_cont_set_owner(arg->coh, "not_a_valid_user", new_grp,
+					 NULL);
+		assert_int_equal(rc, -DER_INVAL);
+
+		print_message("Set owner with invalid grp\n");
+		rc = daos_cont_set_owner(arg->coh, new_user, "not_a_valid_grp",
+					 NULL);
+		assert_int_equal(rc, -DER_INVAL);
+
+		print_message("Set owner user\n");
+		rc = daos_cont_set_owner(arg->coh, new_user, NULL, NULL);
+		assert_int_equal(rc, 0);
+		expect_ownership(arg, new_user, original_grp);
+
+		print_message("Change owner user back\n");
+		rc = daos_cont_set_owner(arg->coh, original_user, NULL, NULL);
+		assert_int_equal(rc, 0);
+		expect_ownership(arg, original_user, original_grp);
+
+		print_message("Set owner group\n");
+		rc = daos_cont_set_owner(arg->coh, NULL, new_grp, NULL);
+		assert_int_equal(rc, 0);
+		expect_ownership(arg, original_user, new_grp);
+
+		print_message("Change owner group back\n");
+		rc = daos_cont_set_owner(arg->coh, NULL, original_grp, NULL);
+		assert_int_equal(rc, 0);
+		expect_ownership(arg, original_user, original_grp);
+
+		print_message("Set both owner user and group\n");
+		rc = daos_cont_set_owner(arg->coh, new_user, new_grp, NULL);
+		assert_int_equal(rc, 0);
+		expect_ownership(arg, new_user, new_grp);
+	}
+
+	D_FREE(original_user);
+	D_FREE(original_grp);
+	test_teardown((void **)&arg);
+}
+
+static void
+expect_co_set_owner_access(test_arg_t *arg, d_string_t user, d_string_t grp,
+			   uint64_t perms, int exp_result)
+{
+	daos_prop_t	*cont_prop;
+	int		 rc = 0;
+
+	cont_prop = get_daos_prop_with_owner_acl_perms(perms,
+						       DAOS_PROP_CO_ACL);
+
+	while (!rc && arg->setup_state != SETUP_CONT_CONNECT)
+		rc = test_setup_next_step((void **)&arg, NULL, NULL,
+					  cont_prop);
+	assert_int_equal(rc, 0);
+
+	if (arg->myrank == 0) {
+		rc = daos_cont_set_owner(arg->coh, user, grp, NULL);
+		assert_int_equal(rc, exp_result);
+	}
+
+	daos_prop_free(cont_prop);
+	test_teardown_cont_hdl(arg);
+	test_teardown_cont(arg);
+}
+
+static void
+co_set_owner_access(void **state)
+{
+	test_arg_t	*arg0 = *state;
+	test_arg_t	*arg = NULL;
+	int		 rc;
+	uint64_t	 no_perm = DAOS_ACL_PERM_CONT_ALL &
+				   ~DAOS_ACL_PERM_SET_OWNER;
+
+	rc = test_setup((void **)&arg, SETUP_EQ, arg0->multi_rank,
+			DEFAULT_POOL_SIZE, NULL);
+	assert_int_equal(rc, 0);
+
+	print_message("Set owner user denied with no set-owner perm\n");
+	expect_co_set_owner_access(arg, "user@", NULL, no_perm,
+				   -DER_NO_PERM);
+
+	print_message("Set owner group denied with no set-owner perm\n");
+	expect_co_set_owner_access(arg, NULL, "group@", no_perm,
+				   -DER_NO_PERM);
+
+	print_message("Set both owner and grp denied with no set-owner perm\n");
+	expect_co_set_owner_access(arg, "user@", "group@", no_perm,
+				   -DER_NO_PERM);
+
+	print_message("Set owner allowed with set-owner perm\n");
+	expect_co_set_owner_access(arg, "user@", "group@",
+				   DAOS_ACL_PERM_READ |
+				   DAOS_ACL_PERM_SET_OWNER,
+				   0);
+
+	test_teardown((void **)&arg);
+}
+
 static int
 co_setup_sync(void **state)
 {
@@ -1654,6 +1813,10 @@ static const struct CMUnitTest co_tests[] = {
 	  co_set_prop_access, NULL, test_case_teardown},
 	{ "CONT17: container overwrite/update/delete ACL access by ACL",
 	  co_modify_acl_access, NULL, test_case_teardown},
+	{ "CONT18: container set owner",
+	  co_set_owner, NULL, test_case_teardown},
+	{ "CONT19: container set-owner access by ACL",
+	  co_set_owner_access, NULL, test_case_teardown},
 };
 
 int

--- a/src/tests/suite/daos_container.c
+++ b/src/tests/suite/daos_container.c
@@ -1634,12 +1634,8 @@ co_set_owner(void **state)
 	d_string_t	 new_grp = "newgrp@";
 	int		 rc;
 
-	rc = test_setup((void **)&arg, SETUP_EQ, arg0->multi_rank,
+	rc = test_setup((void **)&arg, SETUP_CONT_CONNECT, arg0->multi_rank,
 			DEFAULT_POOL_SIZE, NULL);
-	assert_int_equal(rc, 0);
-
-	while (!rc && arg->setup_state != SETUP_CONT_CONNECT)
-		rc = test_setup_next_step((void **)&arg, NULL, NULL, NULL);
 	assert_int_equal(rc, 0);
 
 	/*

--- a/src/utils/daos.c
+++ b/src/utils/daos.c
@@ -1115,6 +1115,7 @@ help_hdlr(struct cmd_args_s *ap)
 "	  overwrite-acl    replace a container's ACL\n"
 "	  update-acl       add/modify entries in a container's ACL\n"
 "	  delete-acl       delete an entry from a container's ACL\n"
+"	  set-owner        change the user and/or group that own a container\n"
 "	  stat             get container statistics\n"
 "	  list-attrs       list container user-defined attributes\n"
 "	  del-attr         delete container user-defined attribute\n"
@@ -1199,7 +1200,12 @@ help_hdlr(struct cmd_args_s *ap)
 "			   for groups: g:name@[domain]\n"
 "			   special principals: OWNER@, GROUP@, EVERYONE@\n"
 "	--verbose          verbose mode (get-acl)\n"
-"	--outfile=PATH     write ACL to file (get-acl)\n");
+"	--outfile=PATH     write ACL to file (get-acl)\n"
+"container options (set-owner):\n"
+"	--user=ID          user who will own the container.\n"
+"			   format: username@[domain]\n"
+"	--group=ID         group who will own the container.\n"
+"			   format: groupname@[domain]\n");
 
 	fprintf(stream, "\n"
 "object (obj) commands:\n"

--- a/src/utils/daos.c
+++ b/src/utils/daos.c
@@ -88,6 +88,8 @@ cont_op_parse(const char *str)
 		return CONT_UPDATE_ACL;
 	else if (strcmp(str, "delete-acl") == 0)
 		return CONT_DELETE_ACL;
+	else if (strcmp(str, "set-owner") == 0)
+		return CONT_SET_OWNER;
 	return -1;
 }
 
@@ -941,6 +943,9 @@ cont_op_hdlr(struct cmd_args_s *ap)
 		break;
 	case CONT_DELETE_ACL:
 		rc = cont_delete_acl_hdlr(ap);
+		break;
+	case CONT_SET_OWNER:
+		rc = cont_set_owner_hdlr(ap);
 		break;
 	default:
 		break;

--- a/src/utils/daos_hdlr.c
+++ b/src/utils/daos_hdlr.c
@@ -1466,6 +1466,28 @@ cont_delete_acl_hdlr(struct cmd_args_s *ap)
 }
 
 int
+cont_set_owner_hdlr(struct cmd_args_s *ap)
+{
+	int	rc;
+
+	if (!ap->user && !ap->group) {
+		fprintf(stderr,
+			"parameter --user or --group is required\n");
+		return -DER_INVAL;
+	}
+
+	rc = daos_cont_set_owner(ap->cont, ap->user, ap->group, NULL);
+	if (rc != 0) {
+		fprintf(stderr,
+			"failed to set owner for container: %d\n", rc);
+		return rc;
+	}
+
+	fprintf(stdout, "successfully updated owner for container\n");
+	return rc;
+}
+
+int
 obj_query_hdlr(struct cmd_args_s *ap)
 {
 	struct daos_obj_layout *layout;

--- a/src/utils/daos_hdlr.h
+++ b/src/utils/daos_hdlr.h
@@ -41,6 +41,7 @@ enum cont_op {
 	CONT_OVERWRITE_ACL,
 	CONT_UPDATE_ACL,
 	CONT_DELETE_ACL,
+	CONT_SET_OWNER,
 };
 
 enum pool_op {
@@ -205,6 +206,7 @@ int cont_get_acl_hdlr(struct cmd_args_s *ap);
 int cont_overwrite_acl_hdlr(struct cmd_args_s *ap);
 int cont_update_acl_hdlr(struct cmd_args_s *ap);
 int cont_delete_acl_hdlr(struct cmd_args_s *ap);
+int cont_set_owner_hdlr(struct cmd_args_s *ap);
 
 /* TODO implement the following container op functions
  * all with signatures similar to this:


### PR DESCRIPTION
- Add the cont set-owner command to the daos user tool.
- Add the daos_cont_set_owner API endpoint.
- Add functional test cases in daos_test for the API
  endpoint.
- Add access control test cases in daos_test for the
  API endpoint.

Signed-off-by: Kris Jacque <kristin.jacque@intel.com>