### PR TITLE
DAOS-3409 SDL: few minor issues raised by coverity (#1889)

### DIFF
--- a/src/bio/bio_monitor.c
+++ b/src/bio/bio_monitor.c
@@ -81,19 +81,21 @@ bio_get_dev_state(struct bio_dev_state *dev_state, struct bio_xs_context *xs)
 
 	rc = ABT_eventual_create(0, &dsm.eventual);
 	if (rc != ABT_SUCCESS)
-		return rc;
+		return dss_abterr2der(rc);
 
 	dsm.xs = xs;
 
 	spdk_thread_send_msg(owner_thread(xs->bxc_blobstore),
 			     bio_get_dev_state_internal, &dsm);
-	ABT_eventual_wait(dsm.eventual, NULL);
+	rc = ABT_eventual_wait(dsm.eventual, NULL);
+	if (rc != ABT_SUCCESS)
+		return dss_abterr2der(rc);
 
 	*dev_state = dsm.devstate;
 
 	rc = ABT_eventual_free(&dsm.eventual);
 	if (rc != ABT_SUCCESS)
-		D_ERROR("BIO get device state ABT future not freed\n");
+		rc = dss_abterr2der(rc);
 
 	return rc;
 }
@@ -111,7 +113,7 @@ bio_dev_set_faulty(struct bio_xs_context *xs)
 
 	rc = ABT_eventual_create(sizeof(*dsm_rc), &dsm.eventual);
 	if (rc != ABT_SUCCESS)
-		return rc;
+		return dss_abterr2der(rc);
 
 	dsm.xs = xs;
 
@@ -124,7 +126,7 @@ bio_dev_set_faulty(struct bio_xs_context *xs)
 		rc = dss_abterr2der(rc);
 
 	if (ABT_eventual_free(&dsm.eventual) != ABT_SUCCESS)
-		D_ERROR("BIO set device state ABT future not freed\n");
+		rc = dss_abterr2der(rc);
 
 	return rc;
 }

--- a/src/tests/obj_ctl.c
+++ b/src/tests/obj_ctl.c
@@ -312,7 +312,8 @@ ctl_cmd_run(char opc, char *args)
 	bool			 opened = false;
 
 	if (args) {
-		strcpy(buf, args);
+		strncpy(buf, args, CTL_BUF_LEN);
+		buf[CTL_BUF_LEN - 1] = '\0';
 		str = daos_str_trimwhite(buf);
 	} else {
 		str = NULL;
@@ -371,14 +372,16 @@ ctl_cmd_run(char opc, char *args)
 		}
 	}
 
-	if (ctl_abits & CTL_ARG_DKEY) {
-		strcpy(cred->tc_dbuf, dkey);
+	if ((ctl_abits & CTL_ARG_DKEY) && dkey != NULL) {
+		strncpy(cred->tc_dbuf, dkey, DTS_KEY_LEN);
+		cred->tc_dbuf[DTS_KEY_LEN - 1] = '\0';
 		d_iov_set(&cred->tc_dkey, cred->tc_dbuf,
 			     strlen(cred->tc_dbuf) + 1);
 	}
 
-	if (ctl_abits & CTL_ARG_AKEY) {
-		strcpy(cred->tc_abuf, akey);
+	if ((ctl_abits & CTL_ARG_AKEY) && akey != NULL) {
+		strncpy(cred->tc_abuf, akey, DTS_KEY_LEN);
+		cred->tc_abuf[DTS_KEY_LEN - 1] = '\0';
 		d_iov_set(&cred->tc_iod.iod_name, cred->tc_abuf,
 			     strlen(cred->tc_abuf) + 1);
 
@@ -389,9 +392,10 @@ ctl_cmd_run(char opc, char *args)
 		cred->tc_recx.rx_nr	= 1;
 	}
 
-	if (ctl_abits & CTL_ARG_VAL) {
+	if ((ctl_abits & CTL_ARG_VAL) && val != NULL) {
 		cred->tc_iod.iod_size = strlen(val) + 1;
-		strcpy(cred->tc_vbuf, val);
+		strncpy(cred->tc_vbuf, val, ctl_ctx.tsc_cred_vsize);
+		cred->tc_vbuf[ctl_ctx.tsc_cred_vsize - 1] = '\0';
 		d_iov_set(&cred->tc_val, cred->tc_vbuf,
 			     strlen(cred->tc_vbuf) + 1);
 	} else {

--- a/src/vos/tests/vts_container.c
+++ b/src/vos/tests/vts_container.c
@@ -78,14 +78,12 @@ co_ops_run(void **state)
 				break;
 			case QUERY:
 				ret = vos_cont_query(arg->coh[i], &cinfo);
-				assert_int_equal(ret, 0);
 				assert_int_equal(cinfo.ci_nobjs, 0);
 				assert_int_equal(cinfo.ci_used, 0);
 				break;
 			case DESTROY:
 				ret = vos_cont_destroy(arg->poh,
 						     arg->uuid[i].uuid);
-				assert_int_equal(ret, 0);
 				uuid_clear(arg->uuid[i].uuid);
 				if (!uuid_is_null(arg->uuid[i].uuid))
 					printf("UUID clear did not work\n");
@@ -94,9 +92,7 @@ co_ops_run(void **state)
 				fail_msg("Unkown Ops!\n");
 				break;
 			}
-			if (arg->ops_seq[i][j] != QUERY ||
-			    arg->ops_seq[i][j] != DESTROY)
-				assert_int_equal(ret, 0);
+			assert_int_equal(ret, 0);
 		}
 	}
 	D_PRINT("Finished all create and discards\n");


### PR DESCRIPTION
- Replaced strcpy() to strncpy() in obj_ctl.c
- Checked ABT return value in bio_monitor.c
- Removed unused code in vts_container.c

Signed-off-by: Niu Yawei <yawei.niu@intel.com>