### PR TITLE
DAOS-4258 vea: Use direct key for all VEA trees

### DIFF
--- a/src/vea/vea_api.c
+++ b/src/vea/vea_api.c
@@ -257,19 +257,19 @@ vea_load(struct umem_instance *umem, struct umem_tx_stage_data *txd,
 	memset(&uma, 0, sizeof(uma));
 	uma.uma_id = UMEM_CLASS_VMEM;
 	/* Create in-memory free extent tree */
-	rc = dbtree_create(DBTREE_CLASS_IV, BTR_FEAT_UINT_KEY, VEA_TREE_ODR,
+	rc = dbtree_create(DBTREE_CLASS_IV, BTR_FEAT_DIRECT_KEY, VEA_TREE_ODR,
 			   &uma, NULL, &vsi->vsi_free_btr);
 	if (rc != 0)
 		goto error;
 
 	/* Create in-memory extent vector tree */
-	rc = dbtree_create(DBTREE_CLASS_IV, BTR_FEAT_UINT_KEY, VEA_TREE_ODR,
+	rc = dbtree_create(DBTREE_CLASS_IV, BTR_FEAT_DIRECT_KEY, VEA_TREE_ODR,
 			   &uma, NULL, &vsi->vsi_vec_btr);
 	if (rc != 0)
 		goto error;
 
 	/* Create in-memory aggregation tree */
-	rc = dbtree_create(DBTREE_CLASS_IV, BTR_FEAT_UINT_KEY, VEA_TREE_ODR,
+	rc = dbtree_create(DBTREE_CLASS_IV, BTR_FEAT_DIRECT_KEY, VEA_TREE_ODR,
 			   &uma, NULL, &vsi->vsi_agg_btr);
 	if (rc != 0)
 		goto error;
@@ -379,15 +379,19 @@ static int
 process_resrvd_list(struct vea_space_info *vsi, struct vea_hint_context *hint,
 		    d_list_t *resrvd_list, bool publish)
 {
-	struct vea_resrvd_ext *resrvd, *tmp;
-	struct vea_free_extent vfe;
-	unsigned int flags = VEA_FL_GEN_AGE;
-	uint64_t seq_max = 0, seq_min = 0;
-	uint64_t off_c = 0, off_p = 0;
-	int rc = 0;
+	struct vea_resrvd_ext	*resrvd, *tmp;
+	struct vea_free_extent	 vfe;
+	uint64_t		 seq_max = 0, seq_min = 0;
+	uint64_t		 off_c = 0, off_p = 0;
+	uint64_t		 cur_time;
+	int			 rc = 0;
 
 	if (d_list_empty(resrvd_list))
 		return 0;
+
+	rc = daos_gettime_coarse(&cur_time);
+	if (rc)
+		return rc;
 
 	vfe.vfe_blk_off = 0;
 	vfe.vfe_blk_cnt = 0;
@@ -414,8 +418,9 @@ process_resrvd_list(struct vea_space_info *vsi, struct vea_hint_context *hint,
 		}
 
 		if (vfe.vfe_blk_cnt != 0) {
+			vfe.vfe_age = cur_time;
 			rc = publish ? persistent_alloc(vsi, &vfe) :
-				       compound_free(vsi, &vfe, flags);
+				       compound_free(vsi, &vfe, 0);
 			if (rc)
 				goto error;
 		}
@@ -425,8 +430,9 @@ process_resrvd_list(struct vea_space_info *vsi, struct vea_hint_context *hint,
 	}
 
 	if (vfe.vfe_blk_cnt != 0) {
+		vfe.vfe_age = cur_time;
 		rc = publish ? persistent_alloc(vsi, &vfe) :
-			       compound_free(vsi, &vfe, flags);
+			       compound_free(vsi, &vfe, 0);
 		if (rc)
 			goto error;
 	}

--- a/src/vea/vea_free.c
+++ b/src/vea/vea_free.c
@@ -32,101 +32,6 @@ enum vea_free_type {
 	VEA_TYPE_PERSIST,
 };
 
-/*
- * Make sure there is no overlapping or duplicated extents in the
- * free extent tree. The adjacent extents will be removed from the
- * btree and being combined with @ext_in to form @ext_out.
- */
-static int
-merge_free_ext(struct vea_space_info *vsi, struct vea_free_extent *ext_in,
-	       struct vea_free_extent *ext_out, unsigned int type,
-	       unsigned int flags)
-{
-	struct vea_free_extent *ext;
-	struct vea_entry *entry;
-	daos_handle_t btr_hdl;
-	d_iov_t key, key_out, val;
-	uint64_t off;
-	int rc, opc = BTR_PROBE_LE;
-
-	if (type == VEA_TYPE_COMPOUND)
-		btr_hdl = vsi->vsi_free_btr;
-	else if (type == VEA_TYPE_PERSIST)
-		btr_hdl = vsi->vsi_md_free_btr;
-	else if (type  == VEA_TYPE_AGGREGATE)
-		btr_hdl = vsi->vsi_agg_btr;
-	else
-		return -DER_INVAL;
-
-	D_ASSERT(!daos_handle_is_inval(btr_hdl));
-	d_iov_set(&key, &ext_in->vfe_blk_off, sizeof(ext_in->vfe_blk_off));
-	d_iov_set(&key_out, &off, sizeof(off));
-repeat:
-	d_iov_set(&val, NULL, 0);
-
-	rc = dbtree_fetch(btr_hdl, opc, DAOS_INTENT_DEFAULT, &key, &key_out,
-			  &val);
-	if (rc == -DER_NONEXIST && opc == BTR_PROBE_LE) {
-		opc = BTR_PROBE_GE;
-		goto repeat;
-	}
-
-	if (rc == -DER_NONEXIST)
-		return 0;	/* Merge done */
-	else if (rc)
-		return rc;	/* Error */
-
-	if (type == VEA_TYPE_PERSIST) {
-		entry = NULL;
-		ext = (struct vea_free_extent *)val.iov_buf;
-	} else {
-		entry = (struct vea_entry *)val.iov_buf;
-		ext = &entry->ve_ext;
-	}
-
-	rc = verify_free_entry(&off, ext);
-	if (rc != 0)
-		return rc;
-
-	/* This checks overlapping & duplicated extents as well. */
-	rc = (opc == BTR_PROBE_LE) ? ext_adjacent(ext, ext_out) :
-				     ext_adjacent(ext_out, ext);
-	if (rc < 0)
-		return rc;
-
-	if (rc > 0) {
-		if (flags & VEA_FL_NO_MERGE) {
-			D_ERROR("unexpected adjacent extents:"
-				" ["DF_U64", %u], ["DF_U64", %u]\n",
-				ext_out->vfe_blk_off, ext_out->vfe_blk_cnt,
-				ext->vfe_blk_off, ext->vfe_blk_cnt);
-			return -DER_INVAL;
-		}
-
-		if (opc == BTR_PROBE_LE) {
-			ext_out->vfe_blk_off = ext->vfe_blk_off;
-			ext_out->vfe_age = ext->vfe_age;
-		}
-		ext_out->vfe_blk_cnt += ext->vfe_blk_cnt;
-
-		if (type == VEA_TYPE_COMPOUND)
-			free_class_remove(&vsi->vsi_class, entry);
-		else if (type == VEA_TYPE_AGGREGATE)
-			d_list_del_init(&entry->ve_link);
-
-		rc = dbtree_delete(btr_hdl, BTR_PROBE_BYPASS, &key_out, NULL);
-		if (rc)
-			return rc;
-	}
-
-	if (opc == BTR_PROBE_LE) {
-		opc = BTR_PROBE_GE;
-		goto repeat;
-	}
-
-	return 0;
-}
-
 static d_list_t *
 blkcnt_to_lru(struct vea_free_class *vfc, uint32_t blkcnt)
 {
@@ -144,36 +49,253 @@ blkcnt_to_lru(struct vea_free_class *vfc, uint32_t blkcnt)
 	return &vfc->vfc_lrus[idx];
 }
 
+void
+free_class_remove(struct vea_free_class *vfc, struct vea_entry *entry)
+{
+	if (entry->ve_in_heap) {
+		D_ASSERTF(entry->ve_ext.vfe_blk_cnt > vfc->vfc_large_thresh,
+			  "%u <= %u", entry->ve_ext.vfe_blk_cnt,
+			  vfc->vfc_large_thresh);
+		d_binheap_remove(&vfc->vfc_heap, &entry->ve_node);
+		entry->ve_in_heap = 0;
+	}
+	d_list_del_init(&entry->ve_link);
+}
+
+int
+free_class_add(struct vea_free_class *vfc, struct vea_entry *entry)
+{
+	int rc;
+
+	D_ASSERT(entry->ve_in_heap == 0);
+	D_ASSERT(d_list_empty(&entry->ve_link));
+
+	/* Add to heap if it's a large free extent */
+	if (entry->ve_ext.vfe_blk_cnt > vfc->vfc_large_thresh) {
+		rc = d_binheap_insert(&vfc->vfc_heap, &entry->ve_node);
+		if (rc != 0) {
+			D_ERROR("Failed to insert heap: %d\n", rc);
+			return rc;
+		}
+
+		entry->ve_in_heap = 1;
+	} else { /* Otherwise add to one of size categarized LRU */
+		struct vea_entry *cur;
+		d_list_t *lru_head, *tmp;
+
+		lru_head = blkcnt_to_lru(vfc, entry->ve_ext.vfe_blk_cnt);
+
+		/* List is sorted by free extent age */
+		d_list_for_each_prev(tmp, lru_head) {
+			cur = d_list_entry(tmp, struct vea_entry, ve_link);
+
+			if (entry->ve_ext.vfe_age >= cur->ve_ext.vfe_age) {
+				d_list_add(&entry->ve_link, tmp);
+				break;
+			}
+		}
+		if (d_list_empty(&entry->ve_link))
+			d_list_add(&entry->ve_link, lru_head);
+	}
+
+	return 0;
+}
+
+static void
+undock_entry(struct vea_space_info *vsi, struct vea_entry *entry,
+	     unsigned int type)
+{
+	if (type == VEA_TYPE_PERSIST)
+		return;
+
+	D_ASSERT(entry != NULL);
+	if (type == VEA_TYPE_COMPOUND)
+		free_class_remove(&vsi->vsi_class, entry);
+	else
+		d_list_del_init(&entry->ve_link);
+}
+
+static int
+dock_entry(struct vea_space_info *vsi, struct vea_entry *entry,
+	   unsigned int type)
+{
+	int rc = 0;
+
+	if (type == VEA_TYPE_PERSIST)
+		return rc;
+
+	D_ASSERT(entry != NULL);
+	if (type == VEA_TYPE_COMPOUND) {
+		rc = free_class_add(&vsi->vsi_class, entry);
+	} else {
+		D_ASSERT(type == VEA_TYPE_AGGREGATE);
+		D_ASSERT(d_list_empty(&entry->ve_link));
+		d_list_add_tail(&entry->ve_link, &vsi->vsi_agg_lru);
+	}
+
+	return rc;
+}
+
+/*
+ * Make sure there is no overlapping or duplicated extents in the free
+ * extent tree. The passed in @ext_in will be merged with adjacent extents
+ * and being inserted in the tree.
+ *
+ * Return value:	0	- Not merged
+ *			1	- Merged in tree
+ *			-ve	- Error
+ */
+static int
+merge_free_ext(struct vea_space_info *vsi, struct vea_free_extent *ext_in,
+	       unsigned int type, unsigned int flags)
+{
+	struct vea_free_extent	*ext, *neighbor = NULL;
+	struct vea_free_extent	 merged = *ext_in;
+	struct vea_entry	*entry, *neighbor_entry = NULL;
+	daos_handle_t		 btr_hdl;
+	d_iov_t			 key, key_out, val;
+	uint64_t		*off;
+	int			 rc, opc = BTR_PROBE_LE;
+
+	if (type == VEA_TYPE_COMPOUND)
+		btr_hdl = vsi->vsi_free_btr;
+	else if (type == VEA_TYPE_PERSIST)
+		btr_hdl = vsi->vsi_md_free_btr;
+	else if (type  == VEA_TYPE_AGGREGATE)
+		btr_hdl = vsi->vsi_agg_btr;
+	else
+		return -DER_INVAL;
+
+	D_ASSERT(!daos_handle_is_inval(btr_hdl));
+	d_iov_set(&key, &ext_in->vfe_blk_off, sizeof(ext_in->vfe_blk_off));
+repeat:
+	d_iov_set(&key_out, NULL, 0);
+	d_iov_set(&val, NULL, 0);
+
+	rc = dbtree_fetch(btr_hdl, opc, DAOS_INTENT_DEFAULT, &key, &key_out,
+			  &val);
+	if (rc == -DER_NONEXIST && opc == BTR_PROBE_LE) {
+		opc = BTR_PROBE_GE;
+		goto repeat;
+	}
+
+	if (rc == -DER_NONEXIST)
+		goto done;	/* Merge done */
+	else if (rc)
+		return rc;	/* Error */
+
+	if (type == VEA_TYPE_PERSIST) {
+		entry = NULL;
+		ext = (struct vea_free_extent *)val.iov_buf;
+	} else {
+		entry = (struct vea_entry *)val.iov_buf;
+		ext = &entry->ve_ext;
+	}
+
+	off = (uint64_t *)key_out.iov_buf;
+	rc = verify_free_entry(off, ext);
+	if (rc != 0)
+		return rc;
+
+	/* This checks overlapping & duplicated extents as well. */
+	rc = (opc == BTR_PROBE_LE) ? ext_adjacent(ext, &merged) :
+				     ext_adjacent(&merged, ext);
+	if (rc < 0)
+		return rc;
+
+	if (rc > 0) {
+		if (flags & VEA_FL_NO_MERGE) {
+			D_ERROR("unexpected adjacent extents:"
+				" ["DF_U64", %u], ["DF_U64", %u]\n",
+				merged.vfe_blk_off, merged.vfe_blk_cnt,
+				ext->vfe_blk_off, ext->vfe_blk_cnt);
+			return -DER_INVAL;
+		}
+
+		if (opc == BTR_PROBE_LE) {
+			merged.vfe_blk_off = ext->vfe_blk_off;
+			merged.vfe_blk_cnt += ext->vfe_blk_cnt;
+
+			neighbor = ext;
+			neighbor_entry = entry;
+		} else {
+			merged.vfe_blk_cnt += ext->vfe_blk_cnt;
+
+			/*
+			 * Prev adjacent extent will be kept, remove the next
+			 * adjacent extent.
+			 */
+			if (neighbor != NULL) {
+				undock_entry(vsi, entry, type);
+				rc = dbtree_delete(btr_hdl, BTR_PROBE_BYPASS,
+						   &key_out, NULL);
+				if (rc) {
+					D_ERROR("Failed to delete: %d\n", rc);
+					return rc;
+				}
+			} else {
+				neighbor = ext;
+				neighbor_entry = entry;
+			}
+		}
+	}
+
+	if (opc == BTR_PROBE_LE) {
+		opc = BTR_PROBE_GE;
+		goto repeat;
+	}
+done:
+	if (neighbor == NULL)
+		return 0;
+
+	if (type == VEA_TYPE_PERSIST) {
+		rc = umem_tx_add_ptr(vsi->vsi_umem, neighbor,
+				     sizeof(*neighbor));
+		if (rc) {
+			D_ERROR("Failed add ptr into tx: %d\n", rc);
+			return rc;
+		}
+	} else {
+		undock_entry(vsi, neighbor_entry, type);
+	}
+
+	/* Adjust in-tree offset & length */
+	neighbor->vfe_blk_off = merged.vfe_blk_off;
+	neighbor->vfe_blk_cnt = merged.vfe_blk_cnt;
+	/* Only bump age for aging tree */
+	if (type == VEA_TYPE_AGGREGATE)
+		neighbor->vfe_age = merged.vfe_age;
+
+	rc = dock_entry(vsi, neighbor_entry, type);
+	if (rc < 0)
+		return rc;
+
+	return 1;
+}
+
 /* Free extent to in-memory compound index */
 int
 compound_free(struct vea_space_info *vsi, struct vea_free_extent *vfe,
 	      unsigned int flags)
 {
-	struct vea_entry *entry, dummy;
-	struct vea_free_class *vfc = &vsi->vsi_class;
-	d_iov_t key, val;
-	uint64_t cur_time = 0;
-	int rc;
+	struct vea_entry	*entry, dummy;
+	d_iov_t			 key, val;
+	int			 rc;
+
+	rc = merge_free_ext(vsi, vfe, VEA_TYPE_COMPOUND, flags);
+	if (rc < 0)
+		return rc;
+	else if (rc > 0)
+		return 0;	/* extent merged in tree */
 
 	memset(&dummy, 0, sizeof(dummy));
 	D_INIT_LIST_HEAD(&dummy.ve_link);
 	dummy.ve_ext = *vfe;
 
-	if (flags & VEA_FL_GEN_AGE) {
-		rc = daos_gettime_coarse(&cur_time);
-		if (rc)
-			return rc;
-		dummy.ve_ext.vfe_age = cur_time;
-	}
-
-	rc = merge_free_ext(vsi, vfe, &dummy.ve_ext, VEA_TYPE_COMPOUND, flags);
-	if (rc)
-		return rc;
-
 	/* Add to in-memory free extent tree */
 	D_ASSERT(!daos_handle_is_inval(vsi->vsi_free_btr));
 	d_iov_set(&key, &dummy.ve_ext.vfe_blk_off,
-		     sizeof(dummy.ve_ext.vfe_blk_off));
+		  sizeof(dummy.ve_ext.vfe_blk_off));
 	d_iov_set(&val, &dummy, sizeof(dummy));
 
 	rc = dbtree_update(vsi->vsi_free_btr, &key, &val);
@@ -182,7 +304,7 @@ compound_free(struct vea_space_info *vsi, struct vea_free_extent *vfe,
 
 	/* Fetch & operate on the in-tree record from now on */
 	d_iov_set(&key, &dummy.ve_ext.vfe_blk_off,
-		     sizeof(dummy.ve_ext.vfe_blk_off));
+		  sizeof(dummy.ve_ext.vfe_blk_off));
 	d_iov_set(&val, NULL, 0);
 
 	rc = dbtree_fetch(vsi->vsi_free_btr, BTR_PROBE_EQ, DAOS_INTENT_DEFAULT,
@@ -194,58 +316,28 @@ compound_free(struct vea_space_info *vsi, struct vea_free_extent *vfe,
 	entry = (struct vea_entry *)val.iov_buf;
 	D_INIT_LIST_HEAD(&entry->ve_link);
 
-	/* Add to heap if it's a large free extent */
-	if (entry->ve_ext.vfe_blk_cnt > vfc->vfc_large_thresh) {
-		rc = d_binheap_insert(&vfc->vfc_heap, &entry->ve_node);
-		if (rc != 0)
-			return rc;
-
-		entry->ve_in_heap = 1;
-	} else { /* Otherwise add to one of size categarized LRU */
-		struct vea_entry *cur;
-		d_list_t *lru_head, *tmp;
-
-		lru_head = blkcnt_to_lru(vfc, entry->ve_ext.vfe_blk_cnt);
-
-		if ((flags & VEA_FL_GEN_AGE) &&
-		    entry->ve_ext.vfe_age == cur_time) {
-			d_list_add_tail(&entry->ve_link, lru_head);
-		} else {
-			/* Sort by free extent age */
-			d_list_for_each_prev(tmp, lru_head) {
-				cur = d_list_entry(tmp, struct vea_entry,
-						   ve_link);
-
-				if (entry->ve_ext.vfe_age >=
-				    cur->ve_ext.vfe_age) {
-					d_list_add(&entry->ve_link, tmp);
-					break;
-				}
-			}
-			if (d_list_empty(&entry->ve_link))
-				d_list_add(&entry->ve_link, lru_head);
-		}
-	}
-
-	return 0;
+	rc = free_class_add(&vsi->vsi_class, entry);
+	return rc;
 }
 
 /* Free extent to persistent free tree */
 int
 persistent_free(struct vea_space_info *vsi, struct vea_free_extent *vfe)
 {
-	struct vea_free_extent dummy;
-	d_iov_t key, val;
-	daos_handle_t btr_hdl = vsi->vsi_md_free_btr;
-	int rc;
+	struct vea_free_extent	dummy;
+	d_iov_t			key, val;
+	daos_handle_t		btr_hdl = vsi->vsi_md_free_btr;
+	int			rc;
+
+	rc = merge_free_ext(vsi, vfe, VEA_TYPE_PERSIST, 0);
+	if (rc < 0)
+		return rc;
+	else if (rc > 0)
+		return 0;	/* extent merged in tree */
 
 	memset(&dummy, 0, sizeof(dummy));
 	dummy = *vfe;
 	dummy.vfe_age = VEA_EXT_AGE_MAX;
-
-	rc = merge_free_ext(vsi, vfe, &dummy, VEA_TYPE_PERSIST, 0);
-	if (rc)
-		return rc;
 
 	/* Add to persistent free extent tree */
 	D_ASSERT(!daos_handle_is_inval(btr_hdl));
@@ -260,26 +352,29 @@ persistent_free(struct vea_space_info *vsi, struct vea_free_extent *vfe)
 int
 aggregated_free(struct vea_space_info *vsi, struct vea_free_extent *vfe)
 {
-	struct vea_entry *entry, dummy;
-	d_iov_t key, val;
-	daos_handle_t btr_hdl = vsi->vsi_agg_btr;
-	int rc;
+	struct vea_entry	*entry, dummy;
+	d_iov_t			 key, val;
+	daos_handle_t		 btr_hdl = vsi->vsi_agg_btr;
+	int			 rc;
+
+	rc = daos_gettime_coarse(&vfe->vfe_age);
+	if (rc)
+		return rc;
+
+	rc = merge_free_ext(vsi, vfe, VEA_TYPE_AGGREGATE, 0);
+	if (rc < 0)
+		return rc;
+	else if (rc > 0)
+		return 0;	/* extent merged in tree */
 
 	memset(&dummy, 0, sizeof(dummy));
 	D_INIT_LIST_HEAD(&dummy.ve_link);
 	dummy.ve_ext = *vfe;
-	rc = daos_gettime_coarse(&dummy.ve_ext.vfe_age);
-	if (rc)
-		return rc;
-
-	rc = merge_free_ext(vsi, vfe, &dummy.ve_ext, VEA_TYPE_AGGREGATE, 0);
-	if (rc)
-		return rc;
 
 	/* Add to in-memory aggregate free extent tree */
 	D_ASSERT(!daos_handle_is_inval(btr_hdl));
 	d_iov_set(&key, &dummy.ve_ext.vfe_blk_off,
-		     sizeof(dummy.ve_ext.vfe_blk_off));
+		  sizeof(dummy.ve_ext.vfe_blk_off));
 	d_iov_set(&val, &dummy, sizeof(dummy));
 
 	rc = dbtree_update(btr_hdl, &key, &val);
@@ -288,7 +383,7 @@ aggregated_free(struct vea_space_info *vsi, struct vea_free_extent *vfe)
 
 	/* Fetch & operate on the in-tree record from now on */
 	d_iov_set(&key, &dummy.ve_ext.vfe_blk_off,
-		     sizeof(dummy.ve_ext.vfe_blk_off));
+		  sizeof(dummy.ve_ext.vfe_blk_off));
 	d_iov_set(&val, NULL, 0);
 
 	rc = dbtree_fetch(btr_hdl, BTR_PROBE_EQ, DAOS_INTENT_DEFAULT, &key,
@@ -376,7 +471,8 @@ migrate_end_cb(void *data, bool noop)
 			vue->vue_ext = vfe;
 			d_list_add_tail(&vue->vue_link, &unmap_list);
 		} else {
-			rc = compound_free(vsi, &vfe, VEA_FL_GEN_AGE);
+			vfe.vfe_age = cur_time;
+			rc = compound_free(vsi, &vfe, 0);
 			if (rc) {
 				D_ERROR("Compound free ["DF_U64", %u] error: "
 					"%d\n", vfe.vfe_blk_off,
@@ -412,7 +508,8 @@ migrate_end_cb(void *data, bool noop)
 			D_ERROR("Unmap ["DF_U64", "DF_U64"] error: %d\n",
 				off, cnt, rc);
 
-		rc = compound_free(vsi, &vue->vue_ext, VEA_FL_GEN_AGE);
+		vue->vue_ext.vfe_age = cur_time;
+		rc = compound_free(vsi, &vue->vue_ext, 0);
 		if (rc)
 			D_ERROR("Compund free ["DF_U64", %u] error: %d\n",
 				vue->vue_ext.vfe_blk_off,

--- a/src/vea/vea_internal.h
+++ b/src/vea/vea_internal.h
@@ -43,6 +43,10 @@ struct vea_hint_context {
 
 /* Free extent informat stored in the in-memory compound free extent index */
 struct vea_entry {
+	/*
+	 * Always keep it as first item, since vfe_blk_off is the direct key
+	 * of DBTREE_CLASS_IV
+	 */
 	struct vea_free_extent	ve_ext;
 	/* Link to vfc_heap */
 	struct d_binheap_node	ve_node;
@@ -144,7 +148,6 @@ static inline bool ext_is_idle(struct vea_free_extent *vfe)
 
 enum vea_free_flags {
 	VEA_FL_NO_MERGE		= (1 << 0),
-	VEA_FL_GEN_AGE		= (1 << 1),
 };
 
 /* vea_init.c */
@@ -163,7 +166,6 @@ int vea_verify_alloc(struct vea_space_info *vsi, bool transient,
 		     uint64_t off, uint32_t cnt);
 
 /* vea_alloc.c */
-void free_class_remove(struct vea_free_class *vfc, struct vea_entry *entry);
 int compound_vec_alloc(struct vea_space_info *vsi, struct vea_ext_vector *vec);
 int reserve_hint(struct vea_space_info *vsi, uint32_t blk_cnt,
 		 struct vea_resrvd_ext *resrvd);
@@ -176,6 +178,8 @@ int reserve_vector(struct vea_space_info *vsi, uint32_t blk_cnt,
 int persistent_alloc(struct vea_space_info *vsi, struct vea_free_extent *vfe);
 
 /* vea_free.c */
+void free_class_remove(struct vea_free_class *vfc, struct vea_entry *entry);
+int free_class_add(struct vea_free_class *vfc, struct vea_entry *entry);
 int compound_free(struct vea_space_info *vsi, struct vea_free_extent *vfe,
 		  unsigned int flags);
 int persistent_free(struct vea_space_info *vsi, struct vea_free_extent *vfe);


### PR DESCRIPTION
Using direct key for free extent tree can optimize free extent
insert operation, because merging extent into the tree can be
achieved by modify a in-tree value instead of a relative heavy
delete & re-insert precedure.

The persistent tree and persistent allocation is already being
accomodated to direct key in previous patch. This patch changed
the other two in-memory trees and all free/reserve related
operations into direct key mode.

This patch slightly improved NVMe small io performance (~5%),
it also reduced container destroy time from 39 secs to 29 secs(
~2.5 million disordered free calls are involved)

Signed-off-by: Niu Yawei <yawei.niu@intel.com>