### PR TITLE
DAOS-4244 container: fix ds_cont_local_open error handling

### DIFF
--- a/src/container/srv_target.c
+++ b/src/container/srv_target.c
@@ -1236,12 +1236,8 @@ ds_cont_local_open(uuid_t pool_uuid, uuid_t cont_hdl_uuid, uuid_t cont_uuid,
 
 csummer:
 		rc = cont_hdl_csummer_init(hdl);
-		if (rc != 0) {
-			ds_pool_child_put(hdl->sch_cont->sc_pool);
-			D_FREE(ddra);
+		if (rc != 0)
 			D_GOTO(err_register, rc);
-		}
-
 	}
 
 	if (cont_hdl != NULL) {


### PR DESCRIPTION
The ds_cont_local_open() will call cont_hdl_csummer_init() after
triggering dtx_resync ULT. If cont_hdl_csummer_init hit failure,
we should not release the parameter "ddra" that is used by above
dtx_resync ULT. Otherwise, it may cause segment fault during DTX
resync.

Signed-off-by: Fan Yong <fan.yong@intel.com>