### PR TITLE
DAOS-4246 srv: update to latest cart

### DIFF
--- a/src/iosrv/srv.c
+++ b/src/iosrv/srv.c
@@ -294,27 +294,17 @@ dss_rpc_cntr_exit(enum dss_rpc_cntr_id id, bool error)
 }
 
 static int
-dss_rpc_hdlr(crt_context_t *ctx, crt_rpc_t *rpc,
+dss_rpc_hdlr(crt_context_t *ctx, void *hdlr_arg,
 	     void (*real_rpc_hdlr)(void *), void *arg)
 {
-	unsigned int		 mod_id = opc_get_mod_id(rpc->cr_opc);
-	struct dss_module	*module = dss_module_get(mod_id);
 	ABT_pool		*pools = arg;
 	ABT_pool		 pool;
 	int			 rc;
 
-	/*
-	 * The mod_id for the RPC originated from CART is 0xfe, and 'module'
-	 * will be NULL for this case.
-	 */
-	if (module != NULL && module->sm_mod_ops != NULL &&
-	    module->sm_mod_ops->dms_abt_pool_choose_cb)
-		pool = module->sm_mod_ops->dms_abt_pool_choose_cb(rpc, pools);
-	else
-		pool = pools[DSS_POOL_IO];
+	pool = pools[DSS_POOL_IO];
+	rc = ABT_thread_create(pool, real_rpc_hdlr, hdlr_arg,
+			       ABT_THREAD_ATTR_NULL, NULL);
 
-	rc = ABT_thread_create(pool, real_rpc_hdlr, rpc, ABT_THREAD_ATTR_NULL,
-			       NULL);
 	return dss_abterr2der(rc);
 }
 

--- a/src/object/srv_obj.c
+++ b/src/object/srv_obj.c
@@ -308,6 +308,7 @@ obj_bulk_transfer(crt_rpc_t *rpc, crt_bulk_op_t bulk_op, bool bulk_bind,
 		while (idx < sgl->sg_nr_out) {
 			d_sg_list_t	sgl_sent;
 			daos_size_t	length = 0;
+			size_t		remote_bulk_size;
 			unsigned int	start;
 
 			/**
@@ -332,6 +333,17 @@ obj_bulk_transfer(crt_rpc_t *rpc, crt_bulk_op_t bulk_op, bool bulk_bind,
 				idx++;
 			}
 
+			rc = crt_bulk_get_len(remote_bulks[i],
+						&remote_bulk_size);
+			if (rc)
+				break;
+
+			if (length > remote_bulk_size) {
+				D_ERROR(DF_U64 "> %zu : %d\n", length,
+					remote_bulk_size, -DER_OVERFLOW);
+				rc = -DER_OVERFLOW;
+				break;
+			}
 			sgl_sent.sg_nr = idx - start;
 			sgl_sent.sg_nr_out = idx - start;
 
@@ -966,11 +978,13 @@ obj_local_rw(crt_rpc_t *rpc, struct ds_cont_hdl *cont_hdl,
 		rc = bio_iod_copy(biod, orw->orw_sgls.ca_arrays, orw->orw_nr);
 	}
 
-	if (rc == -DER_OVERFLOW) {
-		rc = -DER_REC2BIG;
-		D_ERROR(DF_UOID" bio_iod_copy failed, rc "DF_RC"",
-			DP_UOID(orw->orw_oid), DP_RC(rc));
-		goto post;
+	if (rc) {
+		if (rc == -DER_OVERFLOW)
+			rc = -DER_REC2BIG;
+
+		D_ERROR(DF_UOID" data transfer failed, dma %d rc "DF_RC"",
+			DP_UOID(orw->orw_oid), rma, DP_RC(rc));
+		D_GOTO(post, rc);
 	}
 
 	rc = obj_verify_bio_csum(rpc, biod, cont_hdl->sch_csummer);

--- a/utils/build.config
+++ b/utils/build.config
@@ -3,7 +3,7 @@ component=daos
 
 [commit_versions]
 ARGOBOTS = 89507c1f8cfec4e918e8b9861e41b4e9cef71461
-CART = 63fa727c055c2446f4f6f2d06d3aec8e84071c2b
+CART = 369b3686d68b784ecf6f66b675554b87c50dca56
 PMDK = 1.8
 ISAL = v2.26.0
 SPDK = v19.04.1


### PR DESCRIPTION
Update to latest cart and remove some unnecessary
ABT pool choose callback for 0.9 temporarily due
to the upgrade.

Signed-off-by: Di Wang <di.wang@intel.com>