### PR TITLE
DAOS-623 build: Pin mock on version 1.4.x

### DIFF
--- a/utils/rpms/packaging/Dockerfile.mockbuild
+++ b/utils/rpms/packaging/Dockerfile.mockbuild
@@ -12,14 +12,10 @@ MAINTAINER daos-stack <daos@daos.groups.io>
 ARG UID=1000
 
 # Install basic tools
-RUN yum install -y mock make rpm-build curl createrepo rpmlint redhat-lsb-core \
-                   git python-srpm-macros
+RUN dnf -y install mock\ \<\ 2 mock-core-configs\ \<\ 32 make \
+                   rpm-build curl createrepo rpmlint redhat-lsb-core git \
+                   python-srpm-macros rpmdevtools
 
-# Temporary fix for https://github.com/rpm-software-management/mock/issues/484
-RUN if [ ! -f /etc/mock/opensuse-leap-15.1-x86_64.cfg ]; then  \
-        ln /etc/mock/templates/opensuse-leap-15.1.tpl          \
-           /etc/mock/opensuse-leap-15.1-x86_64.cfg;            \
-    fi
 # Add build user (to keep rpmbuild happy)
 ENV USER build
 ENV PASSWD build


### PR DESCRIPTION
To fix the Leap 15 RPM build failure.  The mock 2.0 release was a
completely failure for Leap 15 building.

Signed-off-by: Brian J. Murrell <brian.murrell@intel.com>
Skip-checkpatch: true
Quick-build: true
Skip-test: true