### PR TITLE
DAOS-1781 api: check for invalid uuid in DAOS APIs

### DIFF
--- a/src/client/api/container.c
+++ b/src/client/api/container.c
@@ -48,6 +48,9 @@ daos_cont_create(daos_handle_t poh, const uuid_t uuid, daos_prop_t *cont_prop,
 	int			 rc;
 
 	DAOS_API_ARG_ASSERT(*args, CONT_CREATE);
+	if (!daos_uuid_valid(uuid))
+		return -DER_INVAL;
+
 	if (cont_prop != NULL && !daos_prop_valid(cont_prop, false, true)) {
 		D_ERROR("Invalid container properties.\n");
 		return -DER_INVAL;
@@ -74,6 +77,8 @@ daos_cont_open(daos_handle_t poh, const uuid_t uuid, unsigned int flags,
 	int			 rc;
 
 	DAOS_API_ARG_ASSERT(*args, CONT_OPEN);
+	if (!daos_uuid_valid(uuid))
+		return -DER_INVAL;
 
 	rc = dc_task_create(dc_cont_open, NULL, ev, &task);
 	if (rc)
@@ -117,6 +122,8 @@ daos_cont_destroy(daos_handle_t poh, const uuid_t uuid, int force,
 	int			 rc;
 
 	DAOS_API_ARG_ASSERT(*args, CONT_DESTROY);
+	if (!daos_uuid_valid(uuid))
+		return -DER_INVAL;
 
 	rc = dc_task_create(dc_cont_destroy, NULL, ev, &task);
 	if (rc)

--- a/src/client/api/mgmt.c
+++ b/src/client/api/mgmt.c
@@ -119,6 +119,9 @@ daos_pool_destroy(const uuid_t uuid, const char *grp, int force,
 	int			 rc;
 
 	DAOS_API_ARG_ASSERT(*args, POOL_DESTROY);
+	if (!daos_uuid_valid(uuid))
+		return -DER_INVAL;
+
 	rc = dc_task_create(dc_pool_destroy, NULL, ev, &task);
 	if (rc)
 		return rc;
@@ -140,6 +143,9 @@ daos_pool_evict(const uuid_t uuid, const char *grp, const d_rank_list_t *svc,
 	int			 rc;
 
 	DAOS_API_ARG_ASSERT(*args, POOL_EVICT);
+	if (!daos_uuid_valid(uuid))
+		return -DER_INVAL;
+
 	rc = dc_task_create(dc_pool_evict, NULL, ev, &task);
 	if (rc)
 		return rc;
@@ -160,6 +166,9 @@ daos_pool_add_tgt(const uuid_t uuid, const char *grp,
 	daos_pool_update_t	*args;
 	tse_task_t		*task;
 	int			 rc;
+
+	if (!daos_uuid_valid(uuid))
+		return -DER_INVAL;
 
 	rc = dc_task_create(dc_pool_add, NULL, ev, &task);
 	if (rc)
@@ -182,6 +191,9 @@ daos_pool_tgt_exclude_out(const uuid_t uuid, const char *grp,
 	daos_pool_update_t	*args;
 	tse_task_t		*task;
 	int			 rc;
+
+	if (!daos_uuid_valid(uuid))
+		return -DER_INVAL;
 
 	rc = dc_task_create(dc_pool_exclude_out, NULL, ev, &task);
 	if (rc)
@@ -206,6 +218,8 @@ daos_pool_tgt_exclude(const uuid_t uuid, const char *grp,
 	int			 rc;
 
 	DAOS_API_ARG_ASSERT(*args, POOL_EXCLUDE);
+	if (!daos_uuid_valid(uuid))
+		return -DER_INVAL;
 
 	rc = dc_task_create(dc_pool_exclude, NULL, ev, &task);
 	if (rc)
@@ -237,6 +251,8 @@ daos_pool_add_replicas(const uuid_t uuid, const char *group,
 	int			 rc;
 
 	DAOS_API_ARG_ASSERT(*args, POOL_ADD_REPLICAS);
+	if (!daos_uuid_valid(uuid))
+		return -DER_INVAL;
 
 	rc = dc_task_create(dc_pool_add_replicas, NULL, ev, &task);
 	if (rc)
@@ -262,6 +278,8 @@ daos_pool_remove_replicas(const uuid_t uuid, const char *group,
 	int			 rc;
 
 	DAOS_API_ARG_ASSERT(*args, POOL_REMOVE_REPLICAS);
+	if (!daos_uuid_valid(uuid))
+		return -DER_INVAL;
 
 	rc = dc_task_create(dc_pool_remove_replicas, NULL, ev, &task);
 	if (rc)

--- a/src/tests/ftest/container/create.py
+++ b/src/tests/ftest/container/create.py
@@ -64,11 +64,7 @@ class CreateContainerTest(TestWithServers):
         uuidparam = self.params.get("uuid", "/uuids/*")
         expected_results.append(uuidparam[1])
         if uuidparam[0] == 'NULLPTR':
-            self.cancel("skipping this test until DAOS-2043 is fixed")
-            # Commenting the line below as it will result in an
-            # AttributeError and never get to the DAOS API code.
-            # Should be further investigated as part of DAOS-3081
-            # contuuid = 'NULLPTR'
+            contuuid = 'NULLPTR'
         else:
             contuuid = uuid.UUID(uuidparam[0])
 


### PR DESCRIPTION
Cherry picked commit cc28c2119727277ceff459409324cf0c43dcf287 PR #1934
from daos master branch to release/0.9 branch.

Several DAOS APIs accept a uuid_t parameter and perform a uuid_copy
involving that argument. A validity check is added on the argument
to protect against a segmentation fault that can occur in uuid_copy
if the argument is a NULL pointer.

A container create functional test is updated to no longer skip
negative test cases that supply a NULL pointer as the uuid
argument to container create.

Test-tag: pr,-hw containercreate

Signed-off-by: Ken Cain <kenneth.c.cain@intel.com>