### PR TITLE
DAOS-4199 api: fix error code check in python container create

### DIFF
--- a/src/client/pydaos/raw/daos_api.py
+++ b/src/client/pydaos/raw/daos_api.py
@@ -1514,13 +1514,12 @@ class DaosContainer(object):
             else:
                 ret = func(self.poh, self.uuid, ctypes.byref(self.cont_prop),
                            None)
-                if ret != 0:
-                    self.uuid = (ctypes.c_ubyte * 1)(0)
-                    raise DaosApiError(
-                        "Container create returned non-zero. RC: {0}".format(
-                            ret))
-                else:
-                    self.attached = 1
+            if ret != 0:
+                self.uuid = (ctypes.c_ubyte * 1)(0)
+                raise DaosApiError(
+                    "Container create returned non-zero. RC: {0}".format(ret))
+            else:
+                self.attached = 1
         else:
             event = daos_cref.DaosEvent()
             if self.cont_prop is None:

--- a/src/tests/ftest/container/create.py
+++ b/src/tests/ftest/container/create.py
@@ -56,7 +56,6 @@ class CreateContainerTest(TestWithServers):
         if handleparam == 'VALID':
             poh = self.pool.pool.handle
         else:
-            self.cancel("skipping this test case until DAOS-4099 is fixed")
             poh = handleparam
             expected_results.append('FAIL')
 


### PR DESCRIPTION
Cherry picked commit a04525e5923e77c86f1710712265760fde51e24 PR #1933
from daos master branch to release/0.9 branch.

In python class DaosContainer method create, the error return code
check was indented such that it would only be executed for only some
container create C API calls (those providing properties argument).
So DaosApiError exceptions are not raised in some cases.
Reduce indent of the check so it happens for all container creates.

Also, the container/create.py test is updated to not cancel negative
test cases that supply a bad pool handle argument. These cases failed
initially because the DaosApiError was not raised by the python API.

This commit also resolves DAOS-4099 that is specific to the
container/create.py functional test issue.

Skip-run_test: true
Test-tag: pr,-hw,container containercreate
Test-tag-hw-small: pr,hw,small,container
Test-tag-hw-medium: pr,hw,medium,container
Test-tag-hw-large: pr,hw,large,container

Signed-off-by: Ken Cain <kenneth.c.cain@intel.com>