### PR TITLE
DAOS-4275 dtx: move dtx resync to pool map

### DIFF
--- a/src/include/daos_srv/dtx_srv.h
+++ b/src/include/daos_srv/dtx_srv.h
@@ -210,4 +210,12 @@ dtx_hlc_age2sec(uint64_t hlc)
 	return (crt_hlc_get() - hlc) / NSEC_PER_SEC;
 }
 
+struct dtx_resync_arg {
+	uuid_t		pool_uuid;
+	uint32_t	version;
+};
+
+/* resync all dtx inside the pool */
+void
+dtx_resync_ult(void *arg);
 #endif /* __DAOS_DTX_SRV_H__ */

--- a/src/include/daos_srv/pool.h
+++ b/src/include/daos_srv/pool.h
@@ -55,6 +55,7 @@ struct ds_pool {
 	crt_group_t	       *sp_group;
 	ABT_mutex		sp_iv_refresh_lock;
 	struct ds_iv_ns	       *sp_iv_ns;
+	uint32_t		sp_dtx_resync_version;
 };
 
 struct ds_pool *ds_pool_lookup(const uuid_t uuid);

--- a/src/iosrv/init.c
+++ b/src/iosrv/init.c
@@ -45,7 +45,7 @@
 #include <daos.h> /* for daos_init() */
 
 #define MAX_MODULE_OPTIONS	64
-#define MODULE_LIST	"vos,rdb,rsvc,security,mgmt,pool,cont,dtx,obj,rebuild"
+#define MODULE_LIST	"vos,rdb,rsvc,security,mgmt,dtx,pool,cont,obj,rebuild"
 
 /** List of modules to load */
 static char		modules[MAX_MODULE_OPTIONS + 1];

--- a/src/pool/srv_pool.c
+++ b/src/pool/srv_pool.c
@@ -4468,3 +4468,4 @@ out_svc:
 	pool_svc_put_leader(svc);
 	return rc;
 }
+


### PR DESCRIPTION
Move dtx resync ourside of rebuild, so dtx resync
can be done sooner, instead of waitting until the
rebuild starts.

Dtx resync will be done once local pool map is updated.

Signed-off-by: Di Wang <di.wang@intel.com>