### PR TITLE
DAOS-4115 control: Check for IOMMU on startup

### DIFF
--- a/doc/admin/deployment.md
+++ b/doc/admin/deployment.md
@@ -43,6 +43,31 @@ Before getting started, please make sure to review and complete the
 This section covers the preliminary setup required on the compute and
 storage nodes before deploying DAOS.
 
+### (Optional) Enable IOMMU
+
+In order to run DAOS server as a non-root user with NVMe devices, the hardware
+must support virtualized device access, and it must be enabled in the system BIOS.
+On Intel® systems, this capability is named Intel® Virtualization Technology for
+Directed I/O (VT-d). Once enabled in BIOS, IOMMU support must also be enabled in
+the Linux kernel. Exact details depend on the distribution, but the following
+example should be illustrative:
+
+```bash
+# Enable IOMMU on CentOS 7
+# All commands must be run as root/sudo!
+
+$ sudo vi /etc/default/grub # add the following line:
+GRUB_CMDLINE_LINUX_DEFAULT="intel_iommu=on"
+
+# after saving the file, run the following to reconfigure
+# the bootloader:
+$ sudo grub2-mkconfig --output=/boot/grub2/grub.cfg
+
+# if the command completed with no errors, reboot the system
+# in order to make the changes take effect
+$ sudo reboot
+```
+
 ### Time Synchronization
 
 The DAOS transaction model relies on timestamps and requires time to be

--- a/src/control/fault/code/codes.go
+++ b/src/control/fault/code/codes.go
@@ -20,13 +20,17 @@
 // Any reproduction of computer software, computer software documentation, or
 // portions thereof marked with this legend must also reproduce the markings.
 //
-
+// Package code is a central repository for all control plane fault codes.
 package code
 
 // Code represents a stable fault code.
 //
 // NB: All control plane errors should register their codes in the
 // following block in order to avoid conflicts.
+//
+// Also note that new codes should always be added at the bottom of
+// their respective blocks. This ensures stability of fault codes
+// over time.
 type Code int
 
 const (
@@ -86,6 +90,7 @@ const (
 	ServerConfigDuplicateScmMount
 	ServerConfigDuplicateScmDeviceList
 	ServerConfigOverlappingBdevDeviceList
+	ServerIommuDisabled
 
 	// spdk library bindings codes
 	SpdkUnknown Code = iota + 700

--- a/src/control/server/faults.go
+++ b/src/control/server/faults.go
@@ -63,6 +63,11 @@ var (
 		"no DAOS IO Servers specified in configuration",
 		"specify at least one IO Server configuration ('servers' list parameter) and restart the control server",
 	)
+	FaultServerIommuDisabled = serverFault(
+		code.ServerIommuDisabled,
+		"no IOMMU detected while running as non-root user with NVMe devices",
+		"enable IOMMU per the DAOS Admin Guide or run daos_server as root",
+	)
 )
 
 func FaultScmUnmanaged(mntPoint string) *fault.Fault {


### PR DESCRIPTION
When running as a non-root user with NVMe devices in the
server configuration, check for the presence of an enabled
IOMMU in the system. If no IOMMU is detected, exit with
a clear error message and resolution.