### PR TITLE
DAOS-2063 sec: Support pool get-prop permission

### DIFF
--- a/src/common/tests/acl_valid_tests.c
+++ b/src/common/tests/acl_valid_tests.c
@@ -810,7 +810,6 @@ test_acl_is_valid_for_pool_invalid_perms(void **state)
 	expect_pool_acl_invalid_with_perms((uint64_t)-1);
 	expect_pool_acl_invalid_with_perms(DAOS_ACL_PERM_GET_ACL);
 	expect_pool_acl_invalid_with_perms(DAOS_ACL_PERM_SET_ACL);
-	expect_pool_acl_invalid_with_perms(DAOS_ACL_PERM_GET_PROP);
 	expect_pool_acl_invalid_with_perms(DAOS_ACL_PERM_SET_PROP);
 	expect_pool_acl_invalid_with_perms(DAOS_ACL_PERM_SET_OWNER);
 }
@@ -827,6 +826,7 @@ static void
 test_acl_is_valid_for_pool_good_perms(void **state)
 {
 	expect_pool_acl_valid_with_perms(DAOS_ACL_PERM_READ);
+	expect_pool_acl_valid_with_perms(DAOS_ACL_PERM_GET_PROP);
 	expect_pool_acl_valid_with_perms(DAOS_ACL_PERM_WRITE);
 	expect_pool_acl_valid_with_perms(DAOS_ACL_PERM_CREATE_CONT);
 	expect_pool_acl_valid_with_perms(DAOS_ACL_PERM_DEL_CONT);

--- a/src/include/daos_security.h
+++ b/src/include/daos_security.h
@@ -157,6 +157,7 @@ enum daos_acl_perm {
  * Mask of all valid permissions for DAOS pools
  */
 #define DAOS_ACL_PERM_POOL_ALL	(DAOS_ACL_PERM_READ |			\
+				 DAOS_ACL_PERM_GET_PROP |		\
 				 DAOS_ACL_PERM_WRITE |			\
 				 DAOS_ACL_PERM_CREATE_CONT |		\
 				 DAOS_ACL_PERM_DEL_CONT)

--- a/src/security/srv_acl.c
+++ b/src/security/srv_acl.c
@@ -287,7 +287,8 @@ pool_capas_from_perms(uint64_t perms)
 {
 	uint64_t capas = 0;
 
-	if (perms & DAOS_ACL_PERM_READ)
+	if ((perms & DAOS_ACL_PERM_READ) ||
+	    (perms & DAOS_ACL_PERM_GET_PROP))
 		capas |= POOL_CAPA_READ;
 	if ((perms & DAOS_ACL_PERM_WRITE) ||
 	    (perms & DAOS_ACL_PERM_CREATE_CONT))

--- a/src/security/tests/srv_acl_tests.c
+++ b/src/security/tests/srv_acl_tests.c
@@ -814,6 +814,13 @@ test_pool_get_capas_owner_success(void **state)
 	expect_owner_capas_with_perms(DAOS_ACL_PERM_READ, DAOS_PC_RO,
 				      POOL_CAPA_READ);
 	srv_acl_resetup(state);
+	expect_owner_capas_with_perms(DAOS_ACL_PERM_GET_PROP, DAOS_PC_RO,
+				      POOL_CAPA_READ);
+	srv_acl_resetup(state);
+	expect_owner_capas_with_perms(DAOS_ACL_PERM_READ |
+				      DAOS_ACL_PERM_GET_PROP, DAOS_PC_RO,
+				      POOL_CAPA_READ);
+	srv_acl_resetup(state);
 	expect_owner_capas_with_perms(DAOS_ACL_PERM_READ | DAOS_ACL_PERM_WRITE,
 				      DAOS_PC_RO, POOL_CAPA_READ);
 	srv_acl_resetup(state);
@@ -827,12 +834,12 @@ test_pool_get_capas_owner_success(void **state)
 				      POOL_CAPA_READ | POOL_CAPA_CREATE_CONT |
 				      POOL_CAPA_DEL_CONT);
 	srv_acl_resetup(state);
-	expect_owner_capas_with_perms(DAOS_ACL_PERM_READ |
+	expect_owner_capas_with_perms(DAOS_ACL_PERM_GET_PROP |
 				      DAOS_ACL_PERM_CREATE_CONT,
 				      DAOS_PC_RW,
 				      POOL_CAPA_READ | POOL_CAPA_CREATE_CONT);
 	srv_acl_resetup(state);
-	expect_owner_capas_with_perms(DAOS_ACL_PERM_READ |
+	expect_owner_capas_with_perms(DAOS_ACL_PERM_GET_PROP |
 				      DAOS_ACL_PERM_DEL_CONT,
 				      DAOS_PC_RW,
 				      POOL_CAPA_READ | POOL_CAPA_DEL_CONT);
@@ -861,6 +868,13 @@ test_pool_get_capas_group_success(void **state)
 	expect_group_capas_with_perms(DAOS_ACL_PERM_READ, DAOS_PC_RO,
 				      POOL_CAPA_READ);
 	srv_acl_resetup(state);
+	expect_group_capas_with_perms(DAOS_ACL_PERM_GET_PROP, DAOS_PC_RO,
+				      POOL_CAPA_READ);
+	srv_acl_resetup(state);
+	expect_group_capas_with_perms(DAOS_ACL_PERM_READ |
+				      DAOS_ACL_PERM_GET_PROP, DAOS_PC_RO,
+				      POOL_CAPA_READ);
+	srv_acl_resetup(state);
 	expect_group_capas_with_perms(DAOS_ACL_PERM_READ | DAOS_ACL_PERM_WRITE,
 				      DAOS_PC_RO, POOL_CAPA_READ);
 	srv_acl_resetup(state);
@@ -874,12 +888,12 @@ test_pool_get_capas_group_success(void **state)
 				      POOL_CAPA_CREATE_CONT |
 				      POOL_CAPA_DEL_CONT);
 	srv_acl_resetup(state);
-	expect_group_capas_with_perms(DAOS_ACL_PERM_READ |
+	expect_group_capas_with_perms(DAOS_ACL_PERM_GET_PROP |
 				      DAOS_ACL_PERM_CREATE_CONT,
 				      DAOS_PC_RW,
 				      POOL_CAPA_READ | POOL_CAPA_CREATE_CONT);
 	srv_acl_resetup(state);
-	expect_group_capas_with_perms(DAOS_ACL_PERM_READ |
+	expect_group_capas_with_perms(DAOS_ACL_PERM_GET_PROP |
 				      DAOS_ACL_PERM_DEL_CONT,
 				      DAOS_PC_RW,
 				      POOL_CAPA_READ | POOL_CAPA_DEL_CONT);


### PR DESCRIPTION
Get-prop and read mean the same thing for pools: The user
can connect to the pool and query it, and potentially open
containers.

Signed-off-by: Kris Jacque <kristin.jacque@intel.com>