### PR TITLE
DAOS-3691 control: Adjust hugepage config/allocation

### DIFF
--- a/src/control/fault/code/codes.go
+++ b/src/control/fault/code/codes.go
@@ -93,6 +93,7 @@ const (
 	ServerIommuDisabled
 	ServerPoolScmTooSmall
 	ServerPoolNvmeTooSmall
+	ServerInsufficientFreeHugePages
 
 	// spdk library bindings codes
 	SpdkUnknown Code = iota + 700

--- a/src/control/server/faults.go
+++ b/src/control/server/faults.go
@@ -66,7 +66,7 @@ var (
 		"no DAOS IO Servers specified in configuration",
 		"specify at least one IO Server configuration ('servers' list parameter) and restart the control server",
 	)
-	FaultServerIommuDisabled = serverFault(
+	FaultIommuDisabled = serverFault(
 		code.ServerIommuDisabled,
 		"no IOMMU detected while running as non-root user with NVMe devices",
 		"enable IOMMU per the DAOS Admin Guide or run daos_server as root",
@@ -92,6 +92,14 @@ func FaultPoolScmTooSmall(reqBytes uint64, targetCount int) *fault.Fault {
 			humanize.IBytes(ioserver.ScmMinBytesPerTarget*uint64(targetCount))),
 		fmt.Sprintf("SCM capacity should be larger than %s",
 			humanize.IBytes(ioserver.ScmMinBytesPerTarget*uint64(targetCount))),
+	)
+}
+
+func FaultInsufficientFreeHugePages(free, requested int) *fault.Fault {
+	return serverFault(
+		code.ServerInsufficientFreeHugePages,
+		fmt.Sprintf("requested %d hugepages; got %d", requested, free),
+		"reboot the system or manually clear /dev/hugepages as appropriate",
 	)
 }
 

--- a/src/control/server/server.go
+++ b/src/control/server/server.go
@@ -57,7 +57,8 @@ const (
 	// define supported maximum number of I/O servers
 	maxIOServers = 2
 
-	iommuPath = "/sys/class/iommu"
+	iommuPath        = "/sys/class/iommu"
+	minHugePageCount = 128
 )
 
 func cfgHasBdev(cfg *Configuration) bool {
@@ -118,17 +119,20 @@ func Start(log *logging.LeveledLogger, cfg *Configuration) error {
 		return errors.Wrap(err, "unable to lookup current user")
 	}
 
-	if !cfgHasBdev(cfg) {
-		// If there are no bdevs in the config, use a minimal amount of hugepages.
-		cfg.NrHugepages = 128
-	}
-
 	// Perform an automatic prepare based on the values in the config file.
 	prepReq := bdev.PrepareRequest{
-		HugePageCount: cfg.NrHugepages,
+		// Default to minimum necessary for scan to work correctly.
+		HugePageCount: minHugePageCount,
 		TargetUser:    runningUser.Username,
 		PCIWhitelist:  strings.Join(cfg.BdevInclude, ","),
 	}
+
+	if cfgHasBdev(cfg) {
+		// The config value is intended to be per-ioserver, so we need to adjust
+		// based on the number of ioservers.
+		prepReq.HugePageCount = cfg.NrHugepages * len(cfg.Servers)
+	}
+
 	log.Debugf("automatic NVMe prepare req: %+v", prepReq)
 	if _, err := bdevProvider.Prepare(prepReq); err != nil {
 		log.Errorf("automatic NVMe prepare failed (check configuration?)\n%s", err)
@@ -141,20 +145,12 @@ func Start(log *logging.LeveledLogger, cfg *Configuration) error {
 
 	// Don't bother with these checks if there aren't any block devices configured.
 	if cfgHasBdev(cfg) {
-		if hugePages.Free != hugePages.Total {
-			// Not sure if this should be an error, per se, but I think we want to display it
-			// on the console to let the admin know that there might be something that needs
-			// to be cleaned up?
-			log.Errorf("free hugepages does not match total (%d != %d)", hugePages.Free, hugePages.Total)
-		}
-
-		if hugePages.FreeMB() == 0 {
-			// Is this appropriate? Or should we bomb out?
-			log.Error("no free hugepages -- NVMe performance may suffer")
+		if hugePages.Free < prepReq.HugePageCount {
+			return FaultInsufficientFreeHugePages(hugePages.Free, prepReq.HugePageCount)
 		}
 
 		if runningUser.Uid != "0" && !iommuDetected() {
-			return FaultServerIommuDisabled
+			return FaultIommuDisabled
 		}
 	}
 

--- a/src/control/server/storage/bdev/runner.go
+++ b/src/control/server/storage/bdev/runner.go
@@ -35,7 +35,7 @@ import (
 
 const (
 	spdkSetupPath      = "../share/daos/control/setup_spdk.sh"
-	defaultNrHugepages = 1024
+	defaultNrHugepages = 4096
 	nrHugepagesEnv     = "_NRHUGE"
 	targetUserEnv      = "_TARGET_USER"
 	pciWhiteListEnv    = "_PCI_WHITELIST"

--- a/utils/config/daos_server.yml
+++ b/utils/config/daos_server.yml
@@ -118,11 +118,11 @@
 ## Number of hugepages to allocate for use by NVMe SSDs
 #
 ## Specifies the number (not size) of hugepages to allocate for use by NVMe
-## through SPDK. This indicates the total number to be used by any spawned
-## servers. Default system hugepage size will be used and hugepages will be
-## evenly distributed between CPU nodes.
+## through SPDK. This indicates the number to be used for each spawned
+## I/O server, so the total will be this number * number of I/O servers.
+## Default system hugepage size will be used.
 #
-## default: 1024
+## default: 4096
 #nr_hugepages: 4096
 #
 #


### PR DESCRIPTION
This commit makes two changes:
  * Set the default value to 4096, as this seems to be the
    minimum required for proper operation by a single I/O
    server instance
  * Multiply the global nr_hugepages config value by the
    number of configured I/O server instances, to ensure
    that the system reserves enough hugepage memory for
    all instances