### PR TITLE
DAOS-4291 tools: Don't request ACL in get-prop

### DIFF
--- a/src/tests/suite/daos_container.c
+++ b/src/tests/suite/daos_container.c
@@ -1074,6 +1074,27 @@ co_query_access(void **state)
 			       ~DAOS_ACL_PERM_GET_ACL,
 			       -0);
 
+	print_message("Empty prop object (all props), but no get-prop\n");
+	prop = daos_prop_alloc(0);
+	expect_co_query_access(arg, prop,
+			       DAOS_ACL_PERM_CONT_ALL & ~DAOS_ACL_PERM_GET_PROP,
+			       -DER_NO_PERM);
+	daos_prop_free(prop);
+
+	print_message("Empty prop object (all props), but no get-ACL\n");
+	prop = daos_prop_alloc(0);
+	expect_co_query_access(arg, prop,
+			       DAOS_ACL_PERM_CONT_ALL & ~DAOS_ACL_PERM_GET_ACL,
+			       -DER_NO_PERM);
+	daos_prop_free(prop);
+
+	print_message("Empty prop object (all props), with access\n");
+	prop = daos_prop_alloc(0);
+	expect_co_query_access(arg, prop,
+			       DAOS_ACL_PERM_GET_PROP | DAOS_ACL_PERM_GET_ACL,
+			       0);
+	daos_prop_free(prop);
+
 	print_message("All props with no get-prop access\n");
 	prop = get_query_prop_all();
 	expect_co_query_access(arg, prop,

--- a/src/utils/daos_hdlr.c
+++ b/src/utils/daos_hdlr.c
@@ -738,10 +738,23 @@ cont_get_prop_hdlr(struct cmd_args_s *ap)
 	struct daos_prop_entry	*entry;
 	char			type[10] = {};
 	int			rc = 0;
+	uint32_t		i;
+	uint32_t		entry_type;
 
-	prop_query = daos_prop_alloc(0);
+	/*
+	 * Get all props except the ACL
+	 */
+	prop_query = daos_prop_alloc(DAOS_PROP_CO_NUM - 1);
 	if (prop_query == NULL)
 		return -DER_NOMEM;
+
+	entry_type = DAOS_PROP_CO_MIN + 1;
+	for (i = 0; i < prop_query->dpp_nr; entry_type++) {
+		if (entry_type == DAOS_PROP_CO_ACL)
+			continue; /* skip ACL */
+		prop_query->dpp_entries[i].dpe_type = entry_type;
+		i++;
+	}
 
 	rc = daos_cont_query(ap->cont, NULL, prop_query, NULL);
 	if (rc) {
@@ -815,15 +828,6 @@ cont_get_prop_hdlr(struct cmd_args_s *ap)
 		D_GOTO(err_out, rc = -DER_INVAL);
 	}
 	D_PRINT("max snapshots -> "DF_U64"\n", entry->dpe_val);
-
-	entry = daos_prop_entry_get(prop_query, DAOS_PROP_CO_ACL);
-	if (entry == NULL || entry->dpe_val_ptr == NULL) {
-		fprintf(stderr, "acl property not found\n");
-		/* not an error */
-	} else {
-		D_PRINT("acl ->\n");
-		daos_acl_dump(entry->dpe_val_ptr);
-	}
 
 	entry = daos_prop_entry_get(prop_query, DAOS_PROP_CO_COMPRESS);
 	if (entry == NULL) {


### PR DESCRIPTION
Explicitly do not request the ACL prop in daos cont get-prop.
The user may not actually have access to it, even if they
have access to other props.

- Also added a daos_test case to cover using an empty
  daos_prop_t to request all props.

Signed-off-by: Kris Jacque <kristin.jacque@intel.com>