### PR TITLE
DAOS-4296: Checksum testing : ior-large

### DIFF
--- a/src/tests/ftest/io/ior_large.py
+++ b/src/tests/ftest/io/ior_large.py
@@ -41,7 +41,7 @@ class IorLarge(IorTestBase):
             Different combinations of 1/64/128 Clients and
             1K/4K/32K/128K/512K/1M transfersize.
 
-        :avocado: tags=all,daosio,iorlarge_sequential,pr,hw,iorlarge
+        :avocado: tags=all,daosio,iorlarge_sequential,iorlarge
         """
         ior_flags = self.params.get("F", "/run/ior/iorflags/sequential/")
         self.ior_cmd.flags.update(ior_flags)
@@ -57,7 +57,7 @@ class IorLarge(IorTestBase):
             Different combinations of 1/64/128 Clients and
             1K/4K/32K/128K/512K/1M transfersize.
 
-        :avocado: tags=all,daosio,iorlarge_random,pr,hw,iorlarge
+        :avocado: tags=all,daosio,iorlarge_random,iorlarge
         """
         ior_flags = self.params.get("F", "/run/ior/iorflags/random/")
         self.ior_cmd.flags.update(ior_flags)
@@ -73,7 +73,7 @@ class IorLarge(IorTestBase):
             Different combinations of 1/64/128 Clients and
             1K/4K/32K/128K/512K/1M transfersize.
 
-        :avocado: tags=all,daosio,iorlarge_fpp,pr,hw,iorlarge
+        :avocado: tags=all,daosio,iorlarge_fpp,iorlarge
         """
         ior_flags = self.params.get("F", "/run/ior/iorflags/fpp/")
         self.ior_cmd.flags.update(ior_flags)

--- a/src/tests/ftest/io/ior_large.py
+++ b/src/tests/ftest/io/ior_large.py
@@ -41,7 +41,7 @@ class IorLarge(IorTestBase):
             Different combinations of 1/64/128 Clients and
             1K/4K/32K/128K/512K/1M transfersize.
 
-        :avocado: tags=all,daosio,iorlarge_sequential,iorlarge
+        :avocado: tags=all,daosio,iorlarge_sequential,pr,hw,iorlarge
         """
         ior_flags = self.params.get("F", "/run/ior/iorflags/sequential/")
         self.ior_cmd.flags.update(ior_flags)
@@ -57,7 +57,7 @@ class IorLarge(IorTestBase):
             Different combinations of 1/64/128 Clients and
             1K/4K/32K/128K/512K/1M transfersize.
 
-        :avocado: tags=all,daosio,iorlarge_random,iorlarge
+        :avocado: tags=all,daosio,iorlarge_random,pr,hw,iorlarge
         """
         ior_flags = self.params.get("F", "/run/ior/iorflags/random/")
         self.ior_cmd.flags.update(ior_flags)
@@ -73,7 +73,7 @@ class IorLarge(IorTestBase):
             Different combinations of 1/64/128 Clients and
             1K/4K/32K/128K/512K/1M transfersize.
 
-        :avocado: tags=all,daosio,iorlarge_fpp,iorlarge
+        :avocado: tags=all,daosio,iorlarge_fpp,pr,hw,iorlarge
         """
         ior_flags = self.params.get("F", "/run/ior/iorflags/fpp/")
         self.ior_cmd.flags.update(ior_flags)

--- a/src/tests/ftest/io/ior_large.yaml
+++ b/src/tests/ftest/io/ior_large.yaml
@@ -43,6 +43,18 @@ pool:
   nvme_size: 40000000000
   svcn: 1
   control_method: dmg
+# Container Properties
+# 1. API used for creating container [POSIX]
+# 2. Checksum_Enable : True/False
+# 3. Server Verify : True/False
+# 4. Checksum Type : 100 (default).
+#                    1: CRC16, 2: CRC32
+#                    3: CRC64, 4: SHA1
+# 5. Chunk Size: 0 (default)
+#                16384: 16K
+# DAOS-4173: Improvement in this area required.
+container:
+    container_properties: [POSIX, True, True, 100, 0]
 ior:
   client_processes: !mux
     np_1:

--- a/src/tests/ftest/io/ior_large.yaml
+++ b/src/tests/ftest/io/ior_large.yaml
@@ -52,7 +52,6 @@ pool:
 #                    3: CRC64, 4: SHA1
 # 5. Chunk Size: 0 (default)
 #                16384: 16K
-# DAOS-4173: Improvement in this area required.
 container:
     container_properties: [POSIX, True, True, 100, 0]
 ior:


### PR DESCRIPTION
Summary: Enable checksum for ior-large testing.

Signed-off-by: Padmanabhan <ravindran.padmanabhan@intel.com>