### PR TITLE
DAOS-1946 md: fix initial solution for metadata full handling

### DIFF
--- a/src/rdb/rdb_raft.c
+++ b/src/rdb/rdb_raft.c
@@ -1731,10 +1731,8 @@ rdb_raft_check_state(struct rdb *db, const struct rdb_raft_state *state,
 	case -DER_NOMEM:
 	case -DER_NOSPACE:
 		if (leader) {
-			uint64_t cur_idx = raft_get_current_idx(db->d_raft);
-
-			/* No space / desperation: compact to current index */
-			(void) rdb_raft_compact_to_index(db, cur_idx);
+			/* No space / desperation: compact to committed idx */
+			rdb_raft_compact_to_index(db, committed);
 
 			raft_become_follower(db->d_raft);
 			leader = false;


### PR DESCRIPTION
The original solution for rdb_raft_state checking to handle
-DER_NOSPACE condition was to trigger log compaction and step down
as the service leader. A problem with this implementation in commit
a614cb1b64bf0855ea8c298b392d1149ea0cf72f is that it compacts to the
current index. With this fix, it compacts to the committed index.

Test-tag-hw-large: pr,hw,large metadatafill metadata_free_space

Signed-off-by: Ken Cain <kenneth.c.cain@intel.com>