### PR TITLE
DAOS-4249 btree: Fix Coverity Unexpected Sign Extension

### DIFF
--- a/src/include/daos/btree.h
+++ b/src/include/daos/btree.h
@@ -88,7 +88,7 @@ struct btr_node {
 
 enum {
 	BTR_ORDER_MIN			= 3,
-	BTR_ORDER_MAX			= 255
+	BTR_ORDER_MAX			= 63
 };
 
 /**


### PR DESCRIPTION
Update BTR_ORDER_MAX from 255 to 63 to avoid potential overflow.
Currently there are no tress with order more than 23.

Signed-off-by: Sydney Vanda <sydney.m.vanda@intel.com>