### PR TITLE
DAOS-3409 SDL: Derefernce null issues (#1917)

### DIFF
--- a/src/client/dfs/dfs.c
+++ b/src/client/dfs/dfs.c
@@ -1514,14 +1514,14 @@ dfs_mkdir(dfs_t *dfs, dfs_obj_t *parent, const char *name, mode_t mode,
 	if (rc)
 		return rc;
 
+	D_ASSERT(parent != NULL);
 	rc = check_access(dfs, geteuid(), getegid(), parent->mode, W_OK | X_OK);
 	if (rc)
 		return rc;
 
 	strncpy(new_dir.name, name, DFS_MAX_PATH);
 	new_dir.name[DFS_MAX_PATH] = '\0';
-	rc = create_dir(dfs, th, (parent ? parent->oh : DAOS_HDL_INVAL), cid,
-			&new_dir);
+	rc = create_dir(dfs, th, parent->oh, cid, &new_dir);
 	if (rc)
 		D_GOTO(out, rc);
 

--- a/src/client/dfs/dfuse_hl.c
+++ b/src/client/dfs/dfuse_hl.c
@@ -157,6 +157,7 @@ dfuse_access(const char *path, int mask)
 	if (rc)
 		return rc;
 
+	D_ASSERT(dir_name != NULL);
 	if (strcmp(dir_name, "/") != 0) {
 		rc = dfs_lookup(dfs, dir_name, O_RDONLY, &parent, &pmode, NULL);
 		if (rc) {
@@ -178,8 +179,7 @@ dfuse_access(const char *path, int mask)
 out:
 	if (name)
 		free(name);
-	if (dir_name)
-		free(dir_name);
+	free(dir_name);
 	if (parent)
 		dfs_release(parent);
 	return rc;
@@ -210,6 +210,7 @@ dfuse_chmod(const char *path, mode_t mode, struct fuse_file_info *fi)
 	if (rc)
 		return rc;
 
+	D_ASSERT(dir_name != NULL);
 	if (strcmp(dir_name, "/") != 0) {
 		rc = dfs_lookup(dfs, dir_name, O_RDWR, &parent, &pmode, NULL);
 		if (rc) {
@@ -231,8 +232,7 @@ dfuse_chmod(const char *path, mode_t mode, struct fuse_file_info *fi)
 out:
 	if (name)
 		free(name);
-	if (dir_name)
-		free(dir_name);
+	free(dir_name);
 	if (parent)
 		dfs_release(parent);
 	return rc;

--- a/src/client/pydaos/pydaos_shim.c
+++ b/src/client/pydaos/pydaos_shim.c
@@ -924,7 +924,8 @@ out:
 	PyList_SetItem(return_list, 1, PyInt_FromLong(nr_req));
 	PyList_SetItem(return_list, 2, PyInt_FromLong(size));
 	if (rc || daos_anchor_is_eof(anchor)) {
-		Py_DECREF(anchor_cap);
+		if (anchor_cap != NULL)
+			Py_DECREF(anchor_cap);
 		Py_INCREF(Py_None);
 		PyList_SetItem(return_list, 3, Py_None);
 	} else {

--- a/src/common/acl_api.c
+++ b/src/common/acl_api.c
@@ -504,6 +504,7 @@ daos_acl_get_next_ace(struct daos_acl *acl, struct daos_ace *current_ace)
 	}
 
 	/* there is no next item */
+	D_ASSERT(current_ace != NULL);
 	offset = sizeof(struct daos_ace) + current_ace->dae_principal_len;
 	if (!is_in_ace_list((uint8_t *)current_ace + offset, acl)) {
 		return NULL;

--- a/src/common/acl_util.c
+++ b/src/common/acl_util.c
@@ -297,6 +297,7 @@ create_ace_from_mutable_str(char *str, struct daos_ace **ace)
 		D_GOTO(error, rc = -DER_INVAL);
 	}
 
+	D_ASSERT(new_ace != NULL);
 	new_ace->dae_access_flags = flags;
 	new_ace->dae_access_types = access_types;
 

--- a/src/common/pool_map.c
+++ b/src/common/pool_map.c
@@ -1120,6 +1120,7 @@ pool_map_compat(struct pool_map *map, uint32_t version,
 				if (!existed)
 					return -DER_INVAL;
 
+				D_ASSERT(parent != NULL);
 				if (parent->do_comp.co_status == PO_COMP_ST_NEW)
 					return -DER_INVAL;
 
@@ -1147,7 +1148,8 @@ pool_map_compat(struct pool_map *map, uint32_t version,
 			}
 
 			nr++;
-			if (parent != NULL && parent->do_child_nr == nr) {
+			D_ASSERT(parent != NULL);
+			if (parent->do_child_nr == nr) {
 				parent++;
 				nr = 0;
 			}

--- a/src/common/tests/btree.c
+++ b/src/common/tests/btree.c
@@ -177,7 +177,7 @@ ik_rec_fetch(struct btr_instance *tins, struct btr_record *rec,
 		if (val_iov->iov_buf == NULL)
 			val_iov->iov_buf = val;
 		else if (val_iov->iov_buf_len >= val_size)
-			memcpy(key_iov->iov_buf, val, val_size);
+			memcpy(val_iov->iov_buf, val, val_size);
 
 	}
 	return 0;

--- a/src/common/tests/btree_direct.c
+++ b/src/common/tests/btree_direct.c
@@ -214,7 +214,7 @@ sk_rec_fetch(struct btr_instance *tins, struct btr_record *rec,
 		if (val_iov->iov_buf == NULL)
 			val_iov->iov_buf = val;
 		else if (val_iov->iov_buf_len >= val_size)
-			memcpy(key_iov->iov_buf, val, val_size);
+			memcpy(val_iov->iov_buf, val, val_size);
 
 	}
 	return 0;

--- a/src/common/tests/lru.c
+++ b/src/common/tests/lru.c
@@ -171,8 +171,7 @@ main(int argc, char **argv)
 		keys[1]);
 exit:
 	daos_lru_cache_destroy(tcache);
-	if (keys)
-		D_FREE(keys);
+	D_FREE(keys);
 
 	daos_debug_fini();
 	return rc;

--- a/src/container/srv_target.c
+++ b/src/container/srv_target.c
@@ -1240,9 +1240,10 @@ err_register:
 	if (hdl->sch_cont->sc_open == 0)
 		dtx_batched_commit_deregister(hdl->sch_cont);
 err_cont:
-	cont_stop_dtx_reindex_ult(hdl->sch_cont);
-	if (hdl->sch_cont)
+	if (hdl->sch_cont) {
+		cont_stop_dtx_reindex_ult(hdl->sch_cont);
 		cont_child_put(tls->dt_cont_cache, hdl->sch_cont);
+	}
 
 	if (!daos_handle_is_inval(poh)) {
 		D_DEBUG(DF_DSMS, DF_CONT": destroying new vos container\n",

--- a/src/dtx/dtx_rpc.c
+++ b/src/dtx/dtx_rpc.c
@@ -452,6 +452,7 @@ dtx_dti_classify_one(struct ds_pool *pool, struct pl_map *map, uuid_t po_uuid,
 	if (rc != 0)
 		return rc;
 
+	D_ASSERT(layout != NULL);
 	tgt_cnt = dtx_get_tgt_cnt(oid, layout);
 	if (tgt_cnt < 0) {
 		rc = tgt_cnt;
@@ -500,8 +501,7 @@ dtx_dti_classify_one(struct ds_pool *pool, struct pl_map *map, uuid_t po_uuid,
 	}
 
 out:
-	if (layout != NULL)
-		pl_obj_layout_free(layout);
+	pl_obj_layout_free(layout);
 	return rc > 0 ? 0 : rc;
 }
 

--- a/src/object/cli_ec.c
+++ b/src/object/cli_ec.c
@@ -346,6 +346,7 @@ obj_ec_recx_scan(daos_iod_t *iod, d_sg_list_t *sgl,
 				return rc;
 			ec_recx = ec_recx_array->oer_recxs;
 		}
+		D_ASSERT(ec_recx != NULL);
 		ec_recx[idx].oer_idx = i;
 		rec_nr = end - start;
 		ec_recx[idx].oer_stripe_nr = rec_nr / stripe_rec_nr;

--- a/src/object/cli_obj.c
+++ b/src/object/cli_obj.c
@@ -1108,6 +1108,9 @@ dc_obj_layout_get(daos_handle_t oh, struct daos_obj_layout **p_layout)
 	int			k;
 
 	obj = obj_hdl2ptr(oh);
+	if (obj == NULL)
+		return -DER_NO_HDL;
+
 	oc_attr = daos_oclass_attr_find(obj->cob_md.omd_id);
 	D_ASSERT(oc_attr != NULL);
 	grp_size = daos_oclass_grp_size(oc_attr);
@@ -3285,13 +3288,16 @@ int
 dc_obj_verify(daos_handle_t oh, daos_epoch_t *epochs, unsigned int nr)
 {
 	struct dc_obj_verify_args		*dova = NULL;
-	struct dc_object			*obj = NULL;
+	struct dc_object			*obj;
 	struct daos_oclass_attr			*oc_attr;
 	unsigned int				 reps = 0;
 	int					 rc = 0;
 	int					 i;
 
 	obj = obj_hdl2ptr(oh);
+	if (obj == NULL)
+		return -DER_NO_HDL;
+
 	oc_attr = daos_oclass_attr_find(obj->cob_md.omd_id);
 	D_ASSERT(oc_attr != NULL);
 

--- a/src/object/obj_rpc.c
+++ b/src/object/obj_rpc.c
@@ -283,6 +283,7 @@ crt_proc_daos_iod_t(crt_proc_t proc, crt_proc_op_t proc_op, daos_iod_t *dvi,
 	}
 
 	if (existing_flags & IOD_REC_EXIST) {
+		D_ASSERT(dvi->iod_recxs != NULL || nr == 0);
 		for (i = start; i < start + nr; i++) {
 			rc = crt_proc_daos_recx_t(proc, &dvi->iod_recxs[i]);
 			if (rc != 0) {
@@ -347,6 +348,7 @@ crt_proc_struct_obj_iod_array(crt_proc_t proc, struct obj_iod_array *iod_array)
 			 iod_array->oia_iod_nr : 0;
 		if (crt_proc_uint32_t(proc, &off_nr) != 0)
 			return -DER_HG;
+		D_ASSERT(iod_array->oia_offs != NULL || off_nr == 0);
 		for (i = 0; i < off_nr; i++) {
 			if (crt_proc_uint64_t(proc, &iod_array->oia_offs[i]))
 				return -DER_HG;

--- a/src/object/srv_obj.c
+++ b/src/object/srv_obj.c
@@ -256,6 +256,11 @@ obj_bulk_transfer(crt_rpc_t *rpc, crt_bulk_op_t bulk_op, bool bulk_bind,
 	crt_bulk_perm_t		bulk_perm;
 	int			i, rc, *status, ret;
 
+	if (remote_bulks == NULL) {
+		D_ERROR("No remote bulks provided\n");
+		return -DER_INVAL;
+	}
+
 	bulk_perm = bulk_op == CRT_BULK_PUT ? CRT_BULK_RO : CRT_BULK_RW;
 	rc = ABT_eventual_create(sizeof(*status), &arg.eventual);
 	if (rc != 0)
@@ -1727,8 +1732,10 @@ ds_obj_enum_handler(crt_rpc_t *rpc)
 	rc = obj_enum_reply_bulk(rpc);
 out:
 	/* for KEY2BIG case, just reuse the oeo_size to reply the key len */
-	if (rc == -DER_KEY2BIG)
+	if (rc == -DER_KEY2BIG) {
+		D_ASSERT(enum_arg.kds != NULL);
 		oeo->oeo_size = enum_arg.kds[0].kd_key_len;
+	}
 	obj_enum_complete(rpc, rc, ioc.ioc_map_ver);
 	obj_ioc_end(&ioc, rc);
 }

--- a/src/object/tests/srv_checksum_tests.c
+++ b/src/object/tests/srv_checksum_tests.c
@@ -167,6 +167,7 @@ array_test_case_create(struct vos_fetch_test_context *ctx,
 
 	csum_len = daos_csummer_get_csum_len(ctx->csummer);
 	cs = daos_csummer_get_chunksize(ctx->csummer);
+	assert_true(cs != 0);
 	dummy_csums = (uint8_t *) "ABCDEFGHIJKLMNOPQRSTUVWXYZ";
 	rec_size = setup->rec_size;
 

--- a/src/placement/ring_map.c
+++ b/src/placement/ring_map.c
@@ -562,6 +562,7 @@ ring_map_build(struct pl_ring_map *rimap, struct pl_map_init_attr *mia)
 	if (rc != 0)
 		return rc;
 
+	D_ASSERT(buf != NULL);
 	rimap->rmp_domain_nr = buf->rb_domain_nr;
 	rimap->rmp_target_nr = buf->rb_target_nr;
 
@@ -574,8 +575,7 @@ ring_map_build(struct pl_ring_map *rimap, struct pl_map_init_attr *mia)
 	D_DEBUG(DB_PL, "Built %d rings for placement map\n",
 		rimap->rmp_ring_nr);
  out:
-	if (buf != NULL)
-		ring_buf_destroy(buf);
+	ring_buf_destroy(buf);
 	return rc;
 }
 

--- a/src/rebuild/srv.c
+++ b/src/rebuild/srv.c
@@ -740,8 +740,8 @@ rebuild_prepare(struct ds_pool *pool, uint32_t rebuild_ver,
 			if (ret <= 0)
 				continue;
 
-			if (target &&
-			    target->ta_comp.co_status == PO_COMP_ST_DOWN)
+			D_ASSERT(target != NULL);
+			if (target->ta_comp.co_status == PO_COMP_ST_DOWN)
 				excluded = true;
 
 			dom = pool_map_find_node_by_rank(pool->sp_map,
@@ -1903,6 +1903,7 @@ rebuild_tgt_prepare(crt_rpc_t *rpc, struct rebuild_tgt_pool_tracker **p_rpt)
 	D_DEBUG(DB_REBUILD, "rebuild coh/poh "DF_UUID"/"DF_UUID"\n",
 		DP_UUID(rpt->rt_coh_uuid), DP_UUID(rpt->rt_poh_uuid));
 
+	D_ASSERT(pool->sp_iv_ns != NULL);
 	ds_pool_iv_ns_update(pool, rsi->rsi_master_rank);
 
 	pool_tls = rebuild_pool_tls_create(rpt->rt_pool_uuid, rpt->rt_poh_uuid,

--- a/src/utils/daos.c
+++ b/src/utils/daos.c
@@ -161,9 +161,14 @@ tobytes(const char *str)
 	daos_size_t	 size;
 	char		*end;
 
+	if (str == NULL) {
+		fprintf(stderr, "passed NULL string\n");
+		return 0;
+	}
+
 	size = strtoull(str, &end, 0);
 	/* Prevent negative numbers from turning into unsigned */
-	if (str != NULL && str[0] == '-') {
+	if (str[0] == '-') {
 		fprintf(stderr, "WARNING bytes < 0 (string %s)"
 				"converted to "DF_U64" : using 0 instead\n",
 				str, size);

--- a/src/vos/evtree.c
+++ b/src/vos/evtree.c
@@ -1724,6 +1724,7 @@ evt_insert_entry(struct evt_context *tcx, const struct evt_entry_in *ent)
 				nm_dst = nm_cur;
 				nd_dst = nd_cur;
 			} else {
+				D_ASSERT(nd_dst != NULL);
 				nd_dst = evt_select_node(tcx, &ent->ei_rect,
 							 nd_dst, nd_cur);
 				if (nd_dst == nd_cur)

--- a/src/vos/tests/vts_container.c
+++ b/src/vos/tests/vts_container.c
@@ -202,13 +202,13 @@ teardown(void **state)
 	ret = vos_pool_close(test_arg->poh);
 	assert_int_equal(ret, 0);
 
+	D_ASSERT(test_arg->fname != NULL);
 	ret = vos_pool_destroy(test_arg->fname, test_arg->pool_uuid);
 	assert_int_equal(ret, 0);
 
 	if (vts_file_exists(test_arg->fname))
 		remove(test_arg->fname);
-	if (test_arg->fname)
-		D_FREE(test_arg->fname);
+	D_FREE(test_arg->fname);
 
 	D_FREE(test_arg);
 	return 0;

--- a/src/vos/vos_query.c
+++ b/src/vos/vos_query.c
@@ -345,6 +345,7 @@ vos_obj_query_key(daos_handle_t coh, daos_unit_oid_t oid, uint32_t flags,
 		return rc;
 	}
 
+	D_ASSERT(obj != NULL);
 	/* only integer keys supported */
 	obj_feats = daos_obj_id2feat(obj->obj_df->vo_id.id_pub);
 	if ((flags & DAOS_GET_DKEY) &&
@@ -428,7 +429,6 @@ vos_obj_query_key(daos_handle_t coh, daos_unit_oid_t oid, uint32_t flags,
 	if (!daos_handle_is_inval(query.qt_dkey_toh))
 		dbtree_close(query.qt_dkey_toh);
 out:
-	if (obj)
-		vos_obj_release(vos_obj_cache_current(), obj, false);
+	vos_obj_release(vos_obj_cache_current(), obj, false);
 	return rc;
 }

--- a/src/vos/vos_tree.c
+++ b/src/vos/vos_tree.c
@@ -937,8 +937,11 @@ key_tree_prepare(struct vos_object *obj, daos_handle_t toh,
 		break;
 	}
 
-	if (sub_toh)
+	if (sub_toh) {
+		D_ASSERT(krec != NULL);
 		rc = tree_open_create(obj, tclass, flags, krec, sub_toh);
+	}
+
 	if (rc)
 		goto out;
 


### PR DESCRIPTION
"Dereference before null check" and "Explicit null dereferenced"
issues raised by converity are fixed by:

- Added explicit non-null asserstion before dereferencing;
- Added non-null check before dereferencing;
- Fixed few real typo defects;

Signed-off-by: Niu Yawei <yawei.niu@intel.com>