### PR TITLE
DAOS-4293 dtx: skip aborted or invalid entry when reindex

### DIFF
--- a/src/vos/vos_dtx.c
+++ b/src/vos/vos_dtx.c
@@ -1568,6 +1568,14 @@ vos_dtx_act_reindex(struct vos_container *cont)
 			int				 count;
 
 			dae_df = &dbd->dbd_active_data[i];
+			if (dae_df->dae_flags & DTX_EF_INVALID)
+				continue;
+
+			if (daos_is_zero_dti(&dae_df->dae_xid)) {
+				D_WARN("Hit zero active DTX entry.\n");
+				continue;
+			}
+
 			D_ALLOC_PTR(dae);
 			if (dae == NULL)
 				D_GOTO(out, rc = -DER_NOMEM);


### PR DESCRIPTION
During reindex the active DTX entries, the aborted or invalid
ones (because of data corruption) should be skipped.

master-PR: 2084

Signed-off-by: Fan Yong <fan.yong@intel.com>