### PR TITLE
DAOS-4266 DFS: revert SB and root oclass to OC_RP_XSF

### DIFF
--- a/src/client/dfs/README.md
+++ b/src/client/dfs/README.md
@@ -14,14 +14,15 @@ container handle where the namespace will be located.
 When the file system is created (i.e. when the DAOS container is initialized as
 an encapsulated namespace), a reserved object (with a predefined object ID) will
 be added to the container and will record superblock information about the
-namespace. The SB object is replicated and has the reserved OID 0.0.
+namespace. The SB object is replicated with object class OC_RP_XSF, and has the
+reserved OID 0.0.
 
 The SB object contains an entry with a magic value to indicate it's a POSIX
 filesystem. The SB object will contain also an entry to the root directory of
 the filesystem, which will be another reserved object with a predefined oid
-(1.0) and will have the same representation as a directory (see next
-section). The oid of the root id will be inserted as an entry in the superblock
-object.
+(1.0), replicated with object class OC_RP_XSF, and will have the same
+representation as a directory (see next section). The oid of the root id will be
+inserted as an entry in the superblock object.
 
 The SB will look like this:
 
@@ -31,10 +32,10 @@ A-key: "DFS_MAGIC"
 single-value (uint64_t): SB_MAGIC (0xda05df50da05df50)
 
 A-key: "DFS_SB_VERSION"
-single-value (uint64_t): Version number of the SB. This is used to determine the layout of the SB (the DKEYs and value sizes).
+single-value (uint16_t): Version number of the SB. This is used to determine the layout of the SB (the DKEYs and value sizes).
 
 A-key: "DFS_LAYOUT_VERSION"
-single-value (uint64_t): This is used to determine the format of the entries in the DFS namespace (DFS to DAOS mapping).
+single-value (uint16_t): This is used to determine the format of the entries in the DFS namespace (DFS to DAOS mapping).
 
 A-key: "DFS_SB_FEAT_COMPAT"
 single-value (uint64_t): flags to indicate feature set like extended attribute support, indexing
@@ -82,7 +83,7 @@ Directory Object
         mtime: modify time
         ctime: change time
         chunk_size: chunk_size of file (0 if default or not a file)
-        syml: symlink value (akey does not exist if not a symlink)
+        syml: symlink value (does not exist if not a symlink)
     A-key "x:xattr1"	// extended attribute name (if any)
     A-key "x:xattr2"	// extended attribute name (if any)
 ~~~~~~
@@ -172,8 +173,8 @@ depending on the type of access being requested (R, W, X) and the object mode,
 access permission is determined. In the source code, this is implemented in the
 function `check_access()`.
 
-setuid(), setgid() programs, supplementary groups, ACLs are not supported at the
-moment.
+setuid(), setgid() programs, supplementary groups, ACLs are not supported in the
+DFS namespace.
 
 ## DFUSE_HL
 

--- a/src/client/dfs/dfs.c
+++ b/src/client/dfs/dfs.c
@@ -878,7 +878,7 @@ open_sb(daos_handle_t coh, bool create, dfs_attr_t *attr, daos_handle_t *oh)
 	/** Open SB object */
 	super_oid.lo = RESERVED_LO;
 	super_oid.hi = SB_HI;
-	daos_obj_generate_id(&super_oid, 0, OC_SX, 0);
+	daos_obj_generate_id(&super_oid, 0, OC_RP_XSF, 0);
 
 	rc = daos_obj_open(coh, super_oid, create ? DAOS_OO_RW : DAOS_OO_RO,
 			   oh, NULL);
@@ -1197,7 +1197,7 @@ dfs_mount(daos_handle_t poh, daos_handle_t coh, int flags, dfs_t **_dfs)
 	strcpy(dfs->root.name, "/");
 	dfs->root.parent_oid.lo = RESERVED_LO;
 	dfs->root.parent_oid.hi = SB_HI;
-	daos_obj_generate_id(&dfs->root.parent_oid, 0, OC_SX, 0);
+	daos_obj_generate_id(&dfs->root.parent_oid, 0, OC_RP_XSF, 0);
 	rc = open_dir(dfs, DAOS_TX_NONE, dfs->super_oh, amode, 0, &dfs->root);
 	if (rc) {
 		D_ERROR("Failed to open root object\n");
@@ -1427,7 +1427,7 @@ dfs_global2local(daos_handle_t poh, daos_handle_t coh, int flags, d_iov_t glob,
 	/** Open SB object */
 	super_oid.lo = RESERVED_LO;
 	super_oid.hi = SB_HI;
-	daos_obj_generate_id(&super_oid, 0, OC_SX, 0);
+	daos_obj_generate_id(&super_oid, 0, OC_RP_XSF, 0);
 
 	rc = daos_obj_open(coh, super_oid, DAOS_OO_RO, &dfs->super_oh, NULL);
 	if (rc) {


### PR DESCRIPTION
- inadvertently switched in master to OC_SX
- minor Readme update

Signed-off-by: Mohamad Chaarawi <mohamad.chaarawi@intel.com>