### PR TITLE
DAOS-4287: Change to remove nvme devices from test to mitigate IOMMU issue(#2053)

### DIFF
--- a/src/tests/ftest/control/daos_admin_privileged.py
+++ b/src/tests/ftest/control/daos_admin_privileged.py
@@ -89,9 +89,9 @@ class DaosAdminPrivTest(TestWithServers):
         # Prep server for format, run command under non-root user
         # self.log.info("Performing NVMe storage prepare")
         # try:
-        #     server.storage_prepare(user, "nvme")
+        #    server.storage_prepare(user, "nvme")
         # except ServerFailed as err:
-        #     self.fail("Failed preparing nvme as non-root user: {}".format(err))
+        #    self.fail("Failed preparing nvme as non-root user: {}".format(err))
 
         # Start server
         try:

--- a/src/tests/ftest/control/daos_admin_privileged.py
+++ b/src/tests/ftest/control/daos_admin_privileged.py
@@ -85,12 +85,13 @@ class DaosAdminPrivTest(TestWithServers):
         except ServerFailed as err:
             self.fail("Failed preparing SCM as non-root user: {}".format(err))
 
+        # Uncomment the below line after DAOS-4287 is resolved
         # Prep server for format, run command under non-root user
-        self.log.info("Performing NVMe storage prepare")
-        try:
-            server.storage_prepare(user, "nvme")
-        except ServerFailed as err:
-            self.fail("Failed preparing nvme as non-root user: {}".format(err))
+        # self.log.info("Performing NVMe storage prepare")
+        # try:
+        #     server.storage_prepare(user, "nvme")
+        # except ServerFailed as err:
+        #     self.fail("Failed preparing nvme as non-root user: {}".format(err))
 
         # Start server
         try:

--- a/src/tests/ftest/control/daos_admin_privileged.yaml
+++ b/src/tests/ftest/control/daos_admin_privileged.yaml
@@ -8,7 +8,8 @@ server_config:
   name: daos_server
   port: 10001
   servers:
-    bdev_class: nvme
-    bdev_list: ["aaaa:aa:aa.a","bbbb:bb:bb.b"]
+    # Uncommment once DAOS-4287 has been closed.
+    # bdev_class: nvme
+    # bdev_list: ["aaaa:aa:aa.a","bbbb:bb:bb.b"]
     scm_class: dcpm
     scm_list: ["/dev/pmem0"]


### PR DESCRIPTION
To mitigate IOMMU failures in CI, removing the nvme devices until our systems have been configured to enable IOMMU.

Signed-off-by: Justiniano-pagn <amanda.justiniano-pagn@intel.com>