### PR TITLE
DAOS-4305 sec: Check access capas for cont attr calls

### DIFF
--- a/src/container/srv_container.c
+++ b/src/container/srv_container.c
@@ -1996,6 +1996,14 @@ cont_attr_set(struct rdb_tx *tx, struct ds_pool_hdl *pool_hdl,
 	D_DEBUG(DF_DSMS, DF_CONT": processing rpc %p: hdl="DF_UUID"\n",
 		DP_CONT(pool_hdl->sph_pool->sp_uuid, in->casi_op.ci_uuid),
 		rpc, DP_UUID(in->casi_op.ci_hdl));
+
+	if (!ds_sec_cont_can_write_data(hdl->ch_sec_capas)) {
+		D_ERROR(DF_CONT": permission denied to set container attr\n",
+			DP_CONT(pool_hdl->sph_pool->sp_uuid,
+				in->casi_op.ci_uuid));
+		return -DER_NO_PERM;
+	}
+
 	return ds_rsvc_set_attr(cont->c_svc->cs_rsvc, tx, &cont->c_user,
 				in->casi_bulk, rpc, in->casi_count);
 }
@@ -2009,6 +2017,14 @@ cont_attr_get(struct rdb_tx *tx, struct ds_pool_hdl *pool_hdl,
 	D_DEBUG(DF_DSMS, DF_CONT": processing rpc %p: hdl="DF_UUID"\n",
 		DP_CONT(pool_hdl->sph_pool->sp_uuid, in->cagi_op.ci_uuid),
 		rpc, DP_UUID(in->cagi_op.ci_hdl));
+
+	if (!ds_sec_cont_can_read_data(hdl->ch_sec_capas)) {
+		D_ERROR(DF_CONT": permission denied to get container attr\n",
+			DP_CONT(pool_hdl->sph_pool->sp_uuid,
+				in->cagi_op.ci_uuid));
+		return -DER_NO_PERM;
+	}
+
 	return ds_rsvc_get_attr(cont->c_svc->cs_rsvc, tx, &cont->c_user,
 				in->cagi_bulk, rpc, in->cagi_count,
 				in->cagi_key_length);
@@ -2024,6 +2040,14 @@ cont_attr_list(struct rdb_tx *tx, struct ds_pool_hdl *pool_hdl,
 	D_DEBUG(DF_DSMS, DF_CONT": processing rpc %p: hdl="DF_UUID"\n",
 		DP_CONT(pool_hdl->sph_pool->sp_uuid, in->cali_op.ci_uuid),
 		rpc, DP_UUID(in->cali_op.ci_hdl));
+
+	if (!ds_sec_cont_can_read_data(hdl->ch_sec_capas)) {
+		D_ERROR(DF_CONT": permission denied to list container attr\n",
+			DP_CONT(pool_hdl->sph_pool->sp_uuid,
+				in->cali_op.ci_uuid));
+		return -DER_NO_PERM;
+	}
+
 	return ds_rsvc_list_attr(cont->c_svc->cs_rsvc, tx, &cont->c_user,
 				 in->cali_bulk, rpc, &out->calo_size);
 }

--- a/src/container/srv_epoch.c
+++ b/src/container/srv_epoch.c
@@ -140,14 +140,18 @@ ds_cont_epoch_aggregate(struct rdb_tx *tx, struct ds_pool_hdl *pool_hdl,
 	if (!ds_sec_cont_can_write_data(hdl->ch_sec_capas)) {
 		D_ERROR(DF_CONT": permission denied to aggregate\n",
 			DP_CONT(cont->c_svc->cs_pool_uuid, cont->c_uuid));
-		return -DER_NO_PERM;
+		rc = -DER_NO_PERM;
+		goto out;
 	}
 
-	if (epoch >= DAOS_EPOCH_MAX)
-		return -DER_INVAL;
-	else if (in->cei_epoch == 0)
+	if (epoch >= DAOS_EPOCH_MAX) {
+		rc = -DER_INVAL;
+		goto out;
+	} else if (in->cei_epoch == 0) {
 		epoch = crt_hlc_get();
+	}
 
+out:
 	D_DEBUG(DF_DSMS, DF_CONT": replying rpc %p: epoch="DF_U64", %d\n",
 		DP_CONT(pool_hdl->sph_pool->sp_uuid, in->cei_op.ci_uuid), rpc,
 		epoch, rc);

--- a/src/tests/suite/daos_container.c
+++ b/src/tests/suite/daos_container.c
@@ -28,6 +28,8 @@
 #define D_LOGFAC	DD_FAC(tests)
 #include "daos_test.h"
 
+#define TEST_MAX_ATTR_LEN	(128)
+
 /** create/destroy container */
 static void
 co_create(void **state)
@@ -1888,7 +1890,7 @@ expect_co_set_attr_access(test_arg_t *arg, uint64_t perms, int exp_result)
 	int		 rc = 0;
 	const char	*name = "AttrName";
 	const char	*value = "This is the value";
-	const size_t	 size = strnlen(value, 32);
+	const size_t	 size = strnlen(value, TEST_MAX_ATTR_LEN);
 
 	cont_prop = get_daos_prop_with_owner_acl_perms(perms,
 						       DAOS_PROP_CO_ACL);
@@ -1918,7 +1920,7 @@ expect_co_get_attr_access(test_arg_t *arg, uint64_t perms, int exp_result)
 	daos_prop_t	*cont_prop;
 	int		 rc = 0;
 	const char	*name = "AttrName";
-	size_t		 val_size = 64;
+	size_t		 val_size = TEST_MAX_ATTR_LEN;
 	char		 value[val_size];
 
 	cont_prop = get_daos_prop_with_owner_acl_perms(perms,
@@ -1949,7 +1951,7 @@ expect_co_list_attr_access(test_arg_t *arg, uint64_t perms, int exp_result)
 {
 	daos_prop_t	*cont_prop;
 	int		 rc = 0;
-	char		 buf[128];
+	char		 buf[TEST_MAX_ATTR_LEN];
 	size_t		 bufsize = sizeof(buf);
 
 	cont_prop = get_daos_prop_with_owner_acl_perms(perms,

--- a/src/tests/suite/daos_container.c
+++ b/src/tests/suite/daos_container.c
@@ -1881,6 +1881,157 @@ co_owner_implicit_access(void **state)
 	test_teardown((void **)&arg);
 }
 
+static void
+expect_co_set_attr_access(test_arg_t *arg, uint64_t perms, int exp_result)
+{
+	daos_prop_t	*cont_prop;
+	int		 rc = 0;
+	const char	*name = "AttrName";
+	const char	*value = "This is the value";
+	const size_t	 size = strnlen(value, 32);
+
+	cont_prop = get_daos_prop_with_owner_acl_perms(perms,
+						       DAOS_PROP_CO_ACL);
+
+	while (!rc && arg->setup_state != SETUP_CONT_CONNECT)
+		rc = test_setup_next_step((void **)&arg, NULL, NULL,
+					  cont_prop);
+	assert_int_equal(rc, 0);
+
+	if (arg->myrank == 0) {
+		/* Trivial case - just to see if we have access */
+		rc = daos_cont_set_attr(arg->coh, 1, &name,
+					(const void * const*)&value,
+					&size,
+					NULL);
+		assert_int_equal(rc, exp_result);
+	}
+
+	daos_prop_free(cont_prop);
+	test_teardown_cont_hdl(arg);
+	test_teardown_cont(arg);
+}
+
+static void
+expect_co_get_attr_access(test_arg_t *arg, uint64_t perms, int exp_result)
+{
+	daos_prop_t	*cont_prop;
+	int		 rc = 0;
+	const char	*name = "AttrName";
+	size_t		 val_size = 64;
+	char		 value[val_size];
+
+	cont_prop = get_daos_prop_with_owner_acl_perms(perms,
+						       DAOS_PROP_CO_ACL);
+
+	arg->cont_open_flags = DAOS_COO_RO;
+	while (!rc && arg->setup_state != SETUP_CONT_CONNECT)
+		rc = test_setup_next_step((void **)&arg, NULL, NULL,
+					  cont_prop);
+	assert_int_equal(rc, 0);
+
+	if (arg->myrank == 0) {
+		/* Trivial case - just to see if we have access */
+		rc = daos_cont_get_attr(arg->coh, 1, &name,
+					(void * const*)&value,
+					&val_size,
+					NULL);
+		assert_int_equal(rc, exp_result);
+	}
+
+	daos_prop_free(cont_prop);
+	test_teardown_cont_hdl(arg);
+	test_teardown_cont(arg);
+}
+
+static void
+expect_co_list_attr_access(test_arg_t *arg, uint64_t perms, int exp_result)
+{
+	daos_prop_t	*cont_prop;
+	int		 rc = 0;
+	char		 buf[128];
+	size_t		 bufsize = sizeof(buf);
+
+	cont_prop = get_daos_prop_with_owner_acl_perms(perms,
+						       DAOS_PROP_CO_ACL);
+
+	arg->cont_open_flags = DAOS_COO_RO;
+	while (!rc && arg->setup_state != SETUP_CONT_CONNECT)
+		rc = test_setup_next_step((void **)&arg, NULL, NULL,
+					  cont_prop);
+	assert_int_equal(rc, 0);
+
+	if (arg->myrank == 0) {
+		rc = daos_cont_list_attr(arg->coh, buf, &bufsize, NULL);
+		assert_int_equal(rc, exp_result);
+	}
+
+	daos_prop_free(cont_prop);
+	test_teardown_cont_hdl(arg);
+	test_teardown_cont(arg);
+}
+
+static void
+co_attribute_access(void **state)
+{
+	test_arg_t	*arg0 = *state;
+	test_arg_t	*arg = NULL;
+	int		 rc;
+
+	rc = test_setup((void **)&arg, SETUP_EQ, arg0->multi_rank,
+			DEFAULT_POOL_SIZE, NULL);
+	assert_int_equal(rc, 0);
+
+	print_message("Set attr denied with no write-data perms\n");
+	expect_co_set_attr_access(arg,
+				  DAOS_ACL_PERM_CONT_ALL &
+				  ~DAOS_ACL_PERM_WRITE,
+				  -DER_NO_PERM);
+
+	print_message("Set attr allowed with RW data access\n");
+	expect_co_set_attr_access(arg, DAOS_ACL_PERM_READ | DAOS_ACL_PERM_WRITE,
+				  0);
+
+	print_message("Set attr allowed with write-data access\n");
+	expect_co_set_attr_access(arg, DAOS_ACL_PERM_GET_PROP |
+				  DAOS_ACL_PERM_WRITE,
+				  0);
+
+	print_message("Get attr denied with no read-data perms\n");
+	expect_co_get_attr_access(arg,
+				  DAOS_ACL_PERM_CONT_ALL &
+				  ~DAOS_ACL_PERM_READ,
+				  -DER_NO_PERM);
+
+	print_message("Get attr allowed with RW access\n");
+	/* Attr isn't set, but we get past the permissions check */
+	expect_co_get_attr_access(arg,
+				  DAOS_ACL_PERM_READ | DAOS_ACL_PERM_WRITE,
+				  -DER_NONEXIST);
+
+	print_message("Get attr allowed with RO data access\n");
+	/* Attr isn't set, but we get past the permissions check */
+	expect_co_get_attr_access(arg, DAOS_ACL_PERM_READ,
+				  -DER_NONEXIST);
+
+	print_message("List attr denied with no read-data perms\n");
+	expect_co_list_attr_access(arg,
+				   DAOS_ACL_PERM_CONT_ALL &
+				   ~DAOS_ACL_PERM_READ,
+				   -DER_NO_PERM);
+
+	print_message("List attr allowed with RW access\n");
+	expect_co_list_attr_access(arg,
+				   DAOS_ACL_PERM_READ | DAOS_ACL_PERM_WRITE,
+				   0);
+
+	print_message("List attr allowed with RO data access\n");
+	expect_co_list_attr_access(arg, DAOS_ACL_PERM_READ,
+				   0);
+
+	test_teardown((void **)&arg);
+}
+
 static int
 co_setup_sync(void **state)
 {
@@ -1947,6 +2098,8 @@ static const struct CMUnitTest co_tests[] = {
 	  co_destroy_force, NULL, test_case_teardown},
 	{ "CONT21: container owner has implicit ACL access",
 	  co_owner_implicit_access, NULL, test_case_teardown},
+	{ "CONT22: container get/set attribute access by ACL",
+	  co_attribute_access, NULL, test_case_teardown},
 };
 
 int


### PR DESCRIPTION
- Add permission checks based on data access for API calls
  to get, set, and list user-settable attributes.
- Add daos_test test for attribute access.
- Add data access checks for snapshot access.

Signed-off-by: Kris Jacque <kristin.jacque@intel.com>