### PR TITLE
DAOS-365 container: Slightly clean up srv_layout.h (#1960)

### DIFF
--- a/src/container/srv_internal.h
+++ b/src/container/srv_internal.h
@@ -82,9 +82,9 @@ struct cont_svc {
 struct cont {
 	uuid_t			c_uuid;
 	struct cont_svc	       *c_svc;
-	rdb_path_t		c_prop;		/* container properties KVS */
-	rdb_path_t		c_snaps;	/* Snapshots KVS */
-	rdb_path_t		c_user;		/* user attributes KVS */
+	rdb_path_t		c_prop;		/* container property KVS */
+	rdb_path_t		c_snaps;	/* snapshot KVS */
+	rdb_path_t		c_user;		/* user attribute KVS */
 };
 
 /* OID range for allocator */

--- a/src/container/srv_layout.h
+++ b/src/container/srv_layout.h
@@ -1,4 +1,4 @@
-/**
+/*
  * (C) Copyright 2016-2020 Intel Corporation.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -21,6 +21,8 @@
  * portions thereof marked with this legend must also reproduce the markings.
  */
 /**
+ * \file
+ *
  * ds_cont: Container Server Storage Layout
  *
  * This header assembles (hopefully) everything related to the persistent
@@ -31,13 +33,10 @@
  *
  *   Root KVS (GENERIC):
  *     Container KVS (GENERIC):
- *       Container properties KVS (GENERIC):
- *         HCE KVS (INTEGER)
- *         LRE KVS (INTEGER)
- *         LHE KVS (INTEGER)
+ *       Container property KVS (GENERIC):
  *         Snapshot KVS (INTEGER)
- *         User Attributes KVS (GENERIC)
- *       ... (more container properties KVSs)
+ *         User attribute KVS (GENERIC)
+ *       ... (more container property KVSs)
  *     Container handle KVS (GENERIC)
  */
 
@@ -46,28 +45,24 @@
 
 #include <daos_types.h>
 
-/* Root KVS (RDB_KVS_GENERIC) */
+/*
+ * Root KVS (RDB_KVS_GENERIC)
+ *
+ * All keys are strings. Value types are specified for each key below.
+ */
 extern d_iov_t ds_cont_prop_conts;		/* container KVS */
 extern d_iov_t ds_cont_prop_cont_handles;	/* container handle KVS */
 
 /*
  * Container KVS (RDB_KVS_GENERIC)
  *
- * This maps container UUIDs (uuid_t) to container properties KVSs.
+ * This maps container UUIDs (uuid_t) to container property KVSs.
  */
 
 /*
- * Container properties KVS (RDB_KVS_GENERIC)
+ * Container property KVS (RDB_KVS_GENERIC)
  *
- * 1-level KV pairs - ghce, max_oid and the optional properties (label,
- * layout type etc.).
- *
- * And KVS (with next level KV-pairs):
- * Snapshot KVS (RDB_KVS_INTEGER) -
- * This KVS stores an ordered list of snapshotted epochs. The values are
- * unused and empty.
- * User-defined attributes (RDB_KVS_GENERIC) -
- * To store container attributes of upper layers.
+ * All keys are strings. Value types are specified for each key below.
  */
 extern d_iov_t ds_cont_prop_ghce;		/* uint64_t */
 extern d_iov_t ds_cont_prop_max_oid;		/* uint64_t */
@@ -86,7 +81,21 @@ extern d_iov_t ds_cont_prop_acl;		/* struct daos_acl */
 extern d_iov_t ds_cont_prop_owner;		/* string */
 extern d_iov_t ds_cont_prop_owner_group;	/* string */
 extern d_iov_t ds_cont_prop_snapshots;		/* snapshot KVS */
-extern d_iov_t ds_cont_attr_user;		/* User attributes KVS */
+extern d_iov_t ds_cont_attr_user;		/* user attribute KVS */
+
+/*
+ * Snapshot KVS (RDB_KVS_INTEGER)
+ *
+ * A key is an epoch (daos_epoch_t). A value is an unused byte (char), as RDB
+ * values must be nonempty.
+ */
+
+/*
+ * User attribute KVS (RDB_KVS_GENERIC)
+ *
+ * A key is a user-specified byte array. A value is also a user-specified byte
+ * array.
+ */
 
 /*
  * Container handle KVS (RDB_KVS_GENERIC)


### PR DESCRIPTION
Slightly clean up the comments on the container metadata layout. No
functional changes.

Signed-off-by: Li Wei <wei.g.li@intel.com>