### PR TITLE
DAOS-4278 vos: Fix bug preventing version update on ilog_abort

### DIFF
--- a/src/vos/ilog.h
+++ b/src/vos/ilog.h
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2019 Intel Corporation.
+ * (C) Copyright 2019-2020 Intel Corporation.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -260,5 +260,14 @@ ilog_fetch_finish(struct ilog_entries *entries);
 #define ilog_foreach_entry_reverse(ents, entry)				\
 	for (entry = &(ents)->ie_entries[(ents)->ie_num_entries - 1];	\
 	     entry != &(ents)->ie_entries[-1]; entry--)
+
+/** Retrieve the current version of the incarnation log
+ *
+ * \param	loh[in]	Open log handle
+ *
+ * Returns the version of the log or 0 if log handle is invalid
+ **/
+uint32_t
+ilog_version_get(daos_handle_t loh);
 
 #endif /* __ILOG_H__ */

--- a/src/vos/tests/vts_ilog.c
+++ b/src/vos/tests/vts_ilog.c
@@ -406,10 +406,10 @@ struct version_cache {
 };
 
 static void
-version_cache_init(struct version_cache *vcache, uint32_t initial_version)
+version_cache_init(struct version_cache *vcache)
 {
 	memset(vcache, 0, sizeof(*vcache));
-	vcache->vc_ver[1] = initial_version;
+	vcache->vc_ver[1] = 1;
 }
 
 static bool
@@ -418,11 +418,6 @@ version_cache_fetch_helper(struct version_cache *vcache, daos_handle_t loh,
 {
 	vcache->vc_ver[vcache->vc_idx] = ilog_version_get(loh);
 	if (expect_change) {
-		if (vcache->vc_ver[0] == vcache->vc_ver[1]) {
-			print_message("version unexpectedly matches: %d\n",
-				      vcache->vc_ver[0]);
-			return false;
-		}
 		if (vcache->vc_ver[vcache->vc_idx] <=
 		    vcache->vc_ver[1 - vcache->vc_idx]) {
 			print_message("version %d should be greater than %d\n",
@@ -460,7 +455,7 @@ ilog_test_update(void **state)
 	int			 rc;
 	int			 idx;
 
-	version_cache_init(&version_cache, 1);
+	version_cache_init(&version_cache);
 
 	assert_non_null(entries);
 
@@ -613,7 +608,7 @@ ilog_test_abort(void **state)
 	int			 iter;
 	int			 rc;
 
-	version_cache_init(&version_cache, 1);
+	version_cache_init(&version_cache);
 	assert_non_null(entries);
 
 	pool = vos_hdl2pool(args->ctx.tc_po_hdl);
@@ -760,7 +755,7 @@ ilog_test_persist(void **state)
 	assert_non_null(pool);
 	umm = vos_pool2umm(pool);
 
-	version_cache_init(&version_cache, 1);
+	version_cache_init(&version_cache);
 
 	ilog = ilog_alloc_root(umm);
 

--- a/src/vos/tests/vts_ilog.c
+++ b/src/vos/tests/vts_ilog.c
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2019 Intel Corporation.
+ * (C) Copyright 2019-2020 Intel Corporation.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -400,6 +400,49 @@ do_update(daos_handle_t loh, daos_epoch_t epoch,
 	return 0;
 }
 
+struct version_cache {
+	uint32_t	vc_ver[2];
+	int		vc_idx;
+};
+
+static void
+version_cache_init(struct version_cache *vcache, uint32_t initial_version)
+{
+	memset(vcache, 0, sizeof(*vcache));
+	vcache->vc_ver[1] = initial_version;
+}
+
+static bool
+version_cache_fetch_helper(struct version_cache *vcache, daos_handle_t loh,
+			   bool expect_change)
+{
+	vcache->vc_ver[vcache->vc_idx] = ilog_version_get(loh);
+	if (expect_change) {
+		if (vcache->vc_ver[0] == vcache->vc_ver[1]) {
+			print_message("version unexpectedly matches: %d\n",
+				      vcache->vc_ver[0]);
+			return false;
+		}
+		if (vcache->vc_ver[vcache->vc_idx] <=
+		    vcache->vc_ver[1 - vcache->vc_idx]) {
+			print_message("version %d should be greater than %d\n",
+				      vcache->vc_ver[vcache->vc_idx],
+				      vcache->vc_ver[1 - vcache->vc_idx]);
+			return false;
+		}
+	} else if (vcache->vc_ver[0] != vcache->vc_ver[1]) {
+		print_message("version unexpected mismatch: %d != %d\n",
+			      vcache->vc_ver[0], vcache->vc_ver[1]);
+		return false;
+	}
+	/* toggle to other entry */
+	vcache->vc_idx = 1 - vcache->vc_idx;
+	return true;
+}
+
+#define version_cache_fetch(vcache, loh, expect_change)			\
+	assert_true(version_cache_fetch_helper(vcache, loh, expect_change))
+
 #define NUM_REC 20
 static void
 ilog_test_update(void **state)
@@ -409,12 +452,15 @@ ilog_test_update(void **state)
 	struct umem_instance	*umm;
 	struct entries		*entries = args->custom;
 	struct ilog_df		*ilog;
+	struct version_cache	 version_cache;
 	daos_epoch_t		 epoch;
 	daos_handle_t		 loh;
 	int			 prior_status;
 	bool			 prior_punch;
 	int			 rc;
 	int			 idx;
+
+	version_cache_init(&version_cache, 1);
 
 	assert_non_null(entries);
 
@@ -438,6 +484,8 @@ ilog_test_update(void **state)
 		assert(0);
 	}
 
+	version_cache_fetch(&version_cache, loh, false);
+
 	epoch = 1;
 	current_status = COMMITTABLE;
 	rc = ilog_update(loh, NULL, epoch, false);
@@ -458,6 +506,8 @@ ilog_test_update(void **state)
 		assert(0);
 	}
 
+	version_cache_fetch(&version_cache, loh, true);
+
 	rc = entries_set(entries, ENTRY_REPLACE, 1, true, ENTRIES_END);
 	assert_int_equal(rc, 0);
 	rc = entries_check(umm, ilog, &ilog_callbacks, NULL, 0, entries);
@@ -473,6 +523,8 @@ ilog_test_update(void **state)
 		assert(0);
 	}
 
+	version_cache_fetch(&version_cache, loh, false);
+
 	/** no change */
 	rc = entries_check(umm, ilog, &ilog_callbacks, NULL, 0, entries);
 	assert_int_equal(rc, 0);
@@ -484,6 +536,7 @@ ilog_test_update(void **state)
 		print_message("Failed to insert log entry: %s\n", d_errstr(rc));
 		assert(0);
 	}
+	version_cache_fetch(&version_cache, loh, true);
 
 	rc = entries_set(entries, ENTRY_APPEND, 2, false, ENTRIES_END);
 	assert_int_equal(rc, 0);
@@ -496,6 +549,7 @@ ilog_test_update(void **state)
 		print_message("Failed to insert log entry: %s\n", d_errstr(rc));
 		assert(0);
 	}
+	version_cache_fetch(&version_cache, loh, true);
 
 	rc = entries_set(entries, ENTRY_REPLACE, 2, true, ENTRIES_END);
 	assert_int_equal(rc, 0);
@@ -551,6 +605,7 @@ ilog_test_abort(void **state)
 	struct umem_instance	*umm;
 	struct ilog_df		*ilog;
 	struct entries		*entries = args->custom;
+	struct version_cache	 version_cache;
 	struct ilog_id		 id;
 	daos_handle_t		 loh;
 	bool			 first;
@@ -558,6 +613,7 @@ ilog_test_abort(void **state)
 	int			 iter;
 	int			 rc;
 
+	version_cache_init(&version_cache, 1);
 	assert_non_null(entries);
 
 	pool = vos_hdl2pool(args->ctx.tc_po_hdl);
@@ -579,6 +635,7 @@ ilog_test_abort(void **state)
 			      d_errstr(rc));
 		assert(0);
 	}
+	version_cache_fetch(&version_cache, loh, false);
 
 	id.id_epoch = 1;
 	current_status = PREPARED;
@@ -587,6 +644,7 @@ ilog_test_abort(void **state)
 		print_message("Failed to insert log entry: %s\n", d_errstr(rc));
 		assert(0);
 	}
+	version_cache_fetch(&version_cache, loh, true);
 
 	rc = entries_set(entries, ENTRY_NEW, 1, false, ENTRIES_END);
 	assert_int_equal(rc, 0);
@@ -600,6 +658,7 @@ ilog_test_abort(void **state)
 		assert(0);
 	}
 	fake_tx_remove();
+	version_cache_fetch(&version_cache, loh, true);
 
 	rc = entries_set(entries, ENTRY_NEW, ENTRIES_END);
 	assert_int_equal(rc, 0);
@@ -612,6 +671,7 @@ ilog_test_abort(void **state)
 		print_message("Failed to insert log entry: %s\n", d_errstr(rc));
 		assert(0);
 	}
+	version_cache_fetch(&version_cache, loh, true);
 
 	for (iter = 0; iter < 5; iter++) {
 		rc = entries_set(entries, ENTRY_NEW, 1, false, ENTRIES_END);
@@ -632,6 +692,7 @@ ilog_test_abort(void **state)
 					      d_errstr(rc));
 				assert(0);
 			}
+			version_cache_fetch(&version_cache, loh, true);
 			rc = entries_set(entries, ENTRY_APPEND, id.id_epoch,
 					 punch, ENTRIES_END);
 			if (rc != 0) {
@@ -661,6 +722,7 @@ ilog_test_abort(void **state)
 					      d_errstr(rc));
 				assert(0);
 			}
+			version_cache_fetch(&version_cache, loh, true);
 			current_tx_id = id.id_tx_id;
 			fake_tx_remove();
 		}
@@ -687,6 +749,7 @@ ilog_test_persist(void **state)
 	struct umem_instance	*umm;
 	struct ilog_df		*ilog;
 	struct entries		*entries = args->custom;
+	struct version_cache	 version_cache;
 	struct ilog_id		 id;
 	daos_handle_t		 loh;
 	umem_off_t		 saved_tx_id1, saved_tx_id2;
@@ -696,6 +759,8 @@ ilog_test_persist(void **state)
 	pool = vos_hdl2pool(args->ctx.tc_po_hdl);
 	assert_non_null(pool);
 	umm = vos_pool2umm(pool);
+
+	version_cache_init(&version_cache, 1);
 
 	ilog = ilog_alloc_root(umm);
 
@@ -712,6 +777,7 @@ ilog_test_persist(void **state)
 			      d_errstr(rc));
 		assert(0);
 	}
+	version_cache_fetch(&version_cache, loh, false);
 
 	id.id_epoch = 1;
 	current_status = PREPARED;
@@ -721,6 +787,7 @@ ilog_test_persist(void **state)
 		assert(0);
 	}
 	saved_tx_id1 = current_tx_id;
+	version_cache_fetch(&version_cache, loh, true);
 
 	id.id_epoch = 2;
 	rc = ilog_update(loh, NULL, id.id_epoch, false);
@@ -729,6 +796,7 @@ ilog_test_persist(void **state)
 		assert(0);
 	}
 	saved_tx_id2 = current_tx_id;
+	version_cache_fetch(&version_cache, loh, true);
 
 	id.id_epoch = 3;
 	rc = ilog_update(loh, NULL, id.id_epoch, false);
@@ -736,6 +804,7 @@ ilog_test_persist(void **state)
 		print_message("Failed to insert log entry: %s\n", d_errstr(rc));
 		assert(0);
 	}
+	version_cache_fetch(&version_cache, loh, true);
 
 	id.id_epoch = 4;
 	rc = ilog_update(loh, NULL, id.id_epoch, true);
@@ -743,6 +812,7 @@ ilog_test_persist(void **state)
 		print_message("Failed to insert log entry: %s\n", d_errstr(rc));
 		assert(0);
 	}
+	version_cache_fetch(&version_cache, loh, true);
 
 	id.id_epoch = 2;
 	id.id_tx_id = saved_tx_id2;
@@ -753,6 +823,7 @@ ilog_test_persist(void **state)
 	}
 	current_tx_id = saved_tx_id2;
 	fake_tx_remove();
+	version_cache_fetch(&version_cache, loh, true);
 
 	rc = entries_set(entries, ENTRY_NEW, 1, false, 2, false, 3, false,
 			 4, true, ENTRIES_END);
@@ -767,6 +838,7 @@ ilog_test_persist(void **state)
 		print_message("Failed to insert log entry: %s\n", d_errstr(rc));
 		assert(0);
 	}
+	version_cache_fetch(&version_cache, loh, true);
 	current_tx_id = saved_tx_id1;
 	fake_tx_remove();
 


### PR DESCRIPTION
This causes cached ilog entries to not get updated resulting in
-DER_INPROGRESS in some cases even though transaction is aborted

Signed-off-by: Jeff Olivier <jeffrey.v.olivier@intel.com>