### PR TITLE
DAOS-4269 bio: bump max ops per io channel to 4k

### DIFF
--- a/src/bio/bio_internal.h
+++ b/src/bio/bio_internal.h
@@ -127,6 +127,7 @@ struct bio_blobstore {
 /* Per-xstream NVMe context */
 struct bio_xs_context {
 	int			 bxc_tgt_id;
+	unsigned int		 bxc_blob_rw;	/* inflight blob read/write */
 	struct spdk_thread	*bxc_thread;
 	struct bio_blobstore	*bxc_blobstore;
 	struct spdk_io_channel	*bxc_io_channel;

--- a/src/include/daos_srv/bio.h
+++ b/src/include/daos_srv/bio.h
@@ -589,4 +589,6 @@ int bio_dev_set_faulty(struct bio_xs_context *xs);
 /* Function to increment CSUM media error. */
 void bio_log_csum_err(struct bio_xs_context *b, int tgt_id);
 
+/* Too many blob IO queued, need to schedule a NVMe poll? */
+bool bio_need_nvme_poll(struct bio_xs_context *xs);
 #endif /* __BIO_API_H__ */

--- a/src/iosrv/sched.c
+++ b/src/iosrv/sched.c
@@ -210,6 +210,8 @@ sched_pop_net_poll(struct sched_data *data, ABT_pool pool)
 static bool
 need_nvme_poll(struct sched_cycle *cycle)
 {
+	struct dss_module_info	*dmi;
+
 	/* Need net poll to start new cycle */
 	if (!cycle->sc_cycle_started) {
 		D_ASSERT(cycle->sc_ults_tot == 0);
@@ -220,16 +222,9 @@ need_nvme_poll(struct sched_cycle *cycle)
 	if (cycle->sc_ults_tot == 0)
 		return true;
 
-	/*
-	 * Need extra NVMe poll when too many ULTs are processed in
-	 * current cycle.
-	 */
-	if (cycle->sc_age_nvme > cycle->sc_age_nvme_bound[1])
-		return true;
-
-	/* TODO: Take NVMe I/O statistics into account */
-
-	return false;
+	dmi = dss_get_module_info();
+	D_ASSERT(dmi != NULL);
+	return bio_need_nvme_poll(dmi->dmi_nvme_ctxt);
 }
 
 static ABT_unit


### PR DESCRIPTION
The max blob read/write ops per io channel is 512 by default, it's
not enough for aggregation: Aggregation merge window size is 8MB,
let's assume an extreme case that the merge window consists of 4k
adjacent NVMe extents, then there will be 2k blob read ops on
window flush. There could be more blob reads on window flush when
the window consists of overlapped NVMe extents.

When there are multiple containers running aggregation in parallel
or many concurrent IO requests consists of many NVMe extents, the
512 limit could be exceeded easily.

This patch bumped the max ops to 4k in BIO, and schedule a NVMe
poll once queue blob IO exceeds a watermark (2k).

Signed-off-by: Niu Yawei <yawei.niu@intel.com>