### PR TITLE
DAOS-4278 vos: Fix bug preventing version update on ilog_abort (#2089)

### DIFF
--- a/src/vos/ilog.h
+++ b/src/vos/ilog.h
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2019 Intel Corporation.
+ * (C) Copyright 2019-2020 Intel Corporation.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -260,5 +260,14 @@ ilog_fetch_finish(struct ilog_entries *entries);
 #define ilog_foreach_entry_reverse(ents, entry)				\
 	for (entry = &(ents)->ie_entries[(ents)->ie_num_entries - 1];	\
 	     entry != &(ents)->ie_entries[-1]; entry--)
+
+/** Retrieve the current version of the incarnation log
+ *
+ * \param	loh[in]	Open log handle
+ *
+ * Returns the version of the log or 0 if log handle is invalid
+ **/
+uint32_t
+ilog_version_get(daos_handle_t loh);
 
 #endif /* __ILOG_H__ */


### PR DESCRIPTION
This causes cached ilog entries to not get updated resulting in
-DER_INPROGRESS in some cases even though transaction is aborted

Signed-off-by: Jeff Olivier <jeffrey.v.olivier@intel.com>