### PR TITLE
DAOS-3743 test: Modify object, rebuild, pool tests to use dmg (#1914)

### DIFF
--- a/src/tests/ftest/object/array_obj_test.py
+++ b/src/tests/ftest/object/array_obj_test.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python
 '''
-  (C) Copyright 2017-2019 Intel Corporation.
+  (C) Copyright 2017-2020 Intel Corporation.
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
@@ -23,15 +23,13 @@
 '''
 from __future__ import print_function
 
-import os
 import time
 import traceback
 import logging
-from avocado import main
+
 from apricot import TestWithServers
+from pydaos.raw import DaosContainer, DaosApiError, c_uuid_to_str
 
-
-from pydaos.raw import DaosPool, DaosContainer, DaosApiError, c_uuid_to_str
 
 class ArrayObjTest(TestWithServers):
     """
@@ -52,28 +50,12 @@ class ArrayObjTest(TestWithServers):
 
         :avocado: tags=all,smoke,pr,object,tiny,basicobject
         """
+        self.prepare_pool()
+
         try:
-            # parameters used in pool create
-            createmode = self.params.get("mode", '/run/pool_params/createmode/')
-            createsetid = self.params.get("setname",
-                                          '/run/pool_params/createset/')
-            createsize = self.params.get("size", '/run/pool_params/createsize/')
-            createuid = os.geteuid()
-            creategid = os.getegid()
-
-            # initialize a python pool object then create the underlying
-            # daos storage
-            self.pool = DaosPool(self.context)
-            self.pool.create(createmode, createuid, creategid,
-                             createsize, createsetid, None)
-            self.plog.info("Pool %s created.", self.pool.get_uuid_str())
-
-            # need a connection to create container
-            self.pool.connect(1 << 1)
-
             # create a container
             container = DaosContainer(self.context)
-            container.create(self.pool.handle)
+            container.create(self.pool.pool.handle)
             self.plog.info("Container %s created.", container.get_uuid_str())
 
             # now open it
@@ -128,6 +110,3 @@ class ArrayObjTest(TestWithServers):
             print(excep)
             print(traceback.format_exc())
             self.fail("Test was expected to pass but it failed.\n")
-
-if __name__ == "__main__":
-    main()

--- a/src/tests/ftest/object/array_obj_test.yaml
+++ b/src/tests/ftest/object/array_obj_test.yaml
@@ -1,15 +1,13 @@
 # change host names to your reserved nodes, the
 # required quantity is indicated by the placeholders
 hosts:
- test_servers:
-   - server-A
+     test_servers:
+          - server-A
 timeout: 100
 server_config:
-   name: daos_server
-pool_params:
-   createmode:
-        mode: 511
-   createset:
-        setname: daos_server
-   createsize:
-        size: 1073741824
+     name: daos_server
+pool:
+     control_method: dmg
+     mode: 511
+     name: daos_server
+     scm_size: 1073741824

--- a/src/tests/ftest/object/create_many_dkeys.py
+++ b/src/tests/ftest/object/create_many_dkeys.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python
 '''
-  (C) Copyright 2018-2019 Intel Corporation.
+  (C) Copyright 2018-2020 Intel Corporation.
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
@@ -23,13 +23,13 @@
 '''
 from __future__ import print_function
 
-import os
 import sys
 import ctypes
 import avocado
-from apricot import TestWithServers
 
-from pydaos.raw import DaosPool, DaosContainer, IORequest, DaosApiError
+from apricot import TestWithServers
+from pydaos.raw import DaosContainer, IORequest, DaosApiError
+
 
 class CreateManyDkeys(TestWithServers):
     """
@@ -39,24 +39,6 @@ class CreateManyDkeys(TestWithServers):
 
     :avocado: recursive
     """
-    def setUp(self):
-        super(CreateManyDkeys, self).setUp()
-        self.pool = DaosPool(self.context)
-        self.pool.create(self.params.get("mode", '/run/pool/createmode/*'),
-                         os.geteuid(),
-                         os.getegid(),
-                         self.params.get("size", '/run/pool/createsize/*'),
-                         self.params.get("setname", '/run/pool/createset/*'),
-                         None)
-        self.pool.connect(1 << 1)
-
-    def tearDown(self):
-        try:
-            if self.pool:
-                self.pool.disconnect()
-                self.pool.destroy(1)
-        finally:
-            super(CreateManyDkeys, self).tearDown()
 
     def write_a_bunch_of_values(self, how_many):
         """
@@ -65,7 +47,7 @@ class CreateManyDkeys(TestWithServers):
         """
 
         self.container = DaosContainer(self.context)
-        self.container.create(self.pool.handle)
+        self.container.create(self.pool.pool.handle)
         self.container.open()
 
         ioreq = IORequest(self.context, self.container, None)
@@ -127,7 +109,7 @@ class CreateManyDkeys(TestWithServers):
         :avocado: tags=all,full,small,object,many_dkeys
 
         """
-
+        self.prepare_pool()
         no_of_dkeys = self.params.get("number_of_dkeys", '/run/dkeys/')
 
         # write a lot of individual data items, verify them, then destroy

--- a/src/tests/ftest/object/create_many_dkeys.yaml
+++ b/src/tests/ftest/object/create_many_dkeys.yaml
@@ -8,11 +8,9 @@ timeout: 8000
 server_config:
   name: daos_server
 pool:
-  createmode:
-    mode: 511
-  createset:
-    setname: daos_server
-  createsize:
-    size: 2000000000
+  mode: 511
+  name: daos_server
+  scm_size: 2000000000
+  control_method: dmg
 dkeys:
   number_of_dkeys: 1000000

--- a/src/tests/ftest/object/obj_fetch_bad_param.py
+++ b/src/tests/ftest/object/obj_fetch_bad_param.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python
 '''
-  (C) Copyright 2018-2019 Intel Corporation.
+  (C) Copyright 2018-2020 Intel Corporation.
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
@@ -23,14 +23,12 @@
 '''
 from __future__ import print_function
 
-import os
 import time
 import traceback
-from avocado import main
+
 from apricot import TestWithServers
+from pydaos.raw import DaosContainer, DaosApiError
 
-
-from pydaos.raw import DaosPool, DaosContainer, DaosApiError
 
 class ObjFetchBadParam(TestWithServers):
     """
@@ -42,26 +40,12 @@ class ObjFetchBadParam(TestWithServers):
         super(ObjFetchBadParam, self).setUp()
         time.sleep(5)
 
+        self.prepare_pool()
+
         try:
-            # parameters used in pool create
-            createmode = self.params.get("mode", '/run/pool/createmode/')
-            createsetid = self.params.get("setname", '/run/pool/createset/')
-            createsize = self.params.get("size", '/run/pool/createsize/')
-            createuid = os.geteuid()
-            creategid = os.getegid()
-
-            # initialize a python pool object then create the underlying
-            # daos storage
-            self.pool = DaosPool(self.context)
-            self.pool.create(createmode, createuid, creategid, createsize,
-                             createsetid, None)
-
-            # need a connection to create container
-            self.pool.connect(1 << 1)
-
             # create a container
             self.container = DaosContainer(self.context)
-            self.container.create(self.pool.handle)
+            self.container.create(self.pool.pool.handle)
 
             # now open it
             self.container.open()
@@ -134,7 +118,6 @@ class ObjFetchBadParam(TestWithServers):
 
             self.container.close()
             self.container.destroy()
-            self.pool.disconnect()
             self.pool.destroy(1)
             self.fail("Test was expected to return a -1003 but it has not.\n")
 
@@ -177,7 +160,3 @@ class ObjFetchBadParam(TestWithServers):
                 print(excep)
                 print(traceback.format_exc())
                 self.fail("Test was expected to get -1003 but it has not.\n")
-
-
-if __name__ == "__main__":
-    main()

--- a/src/tests/ftest/object/obj_fetch_bad_param.yaml
+++ b/src/tests/ftest/object/obj_fetch_bad_param.yaml
@@ -1,15 +1,11 @@
-# change host names to your reserved nodes, the
-# required quantity is indicated by the placeholders
 hosts:
-  test_servers:
-    - server-A
-    - server-B
+   test_servers:
+      - server-A
+      - server-B
 server_config:
    name: daos_server
 pool:
-   createmode:
-     mode: 511
-   createset:
-     setname: daos_server
-   createsize:
-     size: 1073741824
+   mode: 511
+   name: daos_server
+   scm_size: 1073741824
+   control_method: dmg

--- a/src/tests/ftest/object/obj_open_bad_param.py
+++ b/src/tests/ftest/object/obj_open_bad_param.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python
 """
-  (C) Copyright 2018-2019 Intel Corporation.
+  (C) Copyright 2018-2020 Intel Corporation.
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
@@ -23,11 +23,11 @@
 """
 from __future__ import print_function
 
-import os
 import traceback
-from apricot import TestWithServers
 
-from pydaos.raw import DaosPool, DaosContainer, DaosApiError, DaosObjId
+from apricot import TestWithServers
+from pydaos.raw import DaosContainer, DaosApiError, DaosObjId
+
 
 class ObjOpenBadParam(TestWithServers):
     """
@@ -38,26 +38,12 @@ class ObjOpenBadParam(TestWithServers):
     """
     def setUp(self):
         super(ObjOpenBadParam, self).setUp()
+        self.prepare_pool()
+
         try:
-            # parameters used in pool create
-            createmode = self.params.get("mode", '/run/pool/createmode/')
-            createsetid = self.params.get("setname", '/run/pool/createset/')
-            createsize = self.params.get("size", '/run/pool/createsize/')
-            createuid = os.geteuid()
-            creategid = os.getegid()
-
-            # initialize a python pool object then create the underlying
-            # daos storage
-            self.pool = DaosPool(self.context)
-            self.pool.create(createmode, createuid, creategid,
-                             createsize, createsetid, None)
-
-            # need a connection to create container
-            self.pool.connect(1 << 1)
-
             # create a container
             self.container = DaosContainer(self.context)
-            self.container.create(self.pool.handle)
+            self.container.create(self.pool.pool.handle)
 
             # now open it
             self.container.open()
@@ -166,7 +152,7 @@ class ObjOpenBadParam(TestWithServers):
         :avocado: tags=all,object,full_regression,tiny,objopenbadpool
         """
         saved_oh = self.obj.obj_handle
-        self.obj.obj_handle = self.pool.handle
+        self.obj.obj_handle = self.pool.pool.handle
 
         try:
             dummy_obj = self.obj.open()

--- a/src/tests/ftest/object/obj_open_bad_param.yaml
+++ b/src/tests/ftest/object/obj_open_bad_param.yaml
@@ -1,14 +1,10 @@
-# change host names to your reserved nodes, the
-# required quantity is indicated by the placeholders
 hosts:
   test_servers:
     - server-A
 server_config:
-   name: daos_server
+  name: daos_server
 pool:
-   createmode:
-     mode: 511
-   createset:
-     setname: daos_server
-   createsize:
-     size: 1073741824
+  mode: 511
+  name: daos_server
+  scm_size: 1073741824
+  control_method: dmg

--- a/src/tests/ftest/object/obj_update_bad_param.yaml
+++ b/src/tests/ftest/object/obj_update_bad_param.yaml
@@ -1,15 +1,11 @@
-# change host names to your reserved nodes, the
-# required quantity is indicated by the placeholders
 hosts:
   test_servers:
     - server-A
     - server-B
 server_config:
-   name: daos_server
-conttests:
-   createmode:
-     mode: 511
-   createset:
-     setname: daos_server
-   createsize:
-     size: 1073741824
+  name: daos_server
+pool:
+  mode: 511
+  name: daos_server
+  scm_size: 1073741824
+  control_method: dmg

--- a/src/tests/ftest/object/object_integrity.py
+++ b/src/tests/ftest/object/object_integrity.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python
 """
-  (C) Copyright 2019 Intel Corporation.
+  (C) Copyright 2020 Intel Corporation.
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
@@ -21,21 +21,16 @@
   Any reproduction of computer software, computer software documentation, or
   portions thereof marked with this legend must also reproduce the markings.
 """
-
-import os
 import ctypes
 import time
 import avocado
 import random
-import agent_utils
-import server_utils
-import write_host_file
 
-from pydaos.raw import (DaosPool, DaosContainer, IORequest,
-                        DaosObj, DaosApiError)
-from apricot import skipForTicket, TestWithoutServers
+from pydaos.raw import (DaosContainer, IORequest, DaosObj, DaosApiError)
+from apricot import TestWithServers
 
-class ObjectDataValidation(TestWithoutServers):
+
+class ObjectDataValidation(TestWithServers):
     """
     Test Class Description:
         Tests that create Different length records,
@@ -47,42 +42,21 @@ class ObjectDataValidation(TestWithoutServers):
     # pylint: disable=too-many-instance-attributes
     def setUp(self):
         super(ObjectDataValidation, self).setUp()
-        self.agent_sessions = None
-        self.pool = None
-        self.container = None
         self.obj = None
         self.ioreq = None
-        self.hostlist = None
-        self.hostfile = None
         self.no_of_dkeys = None
         self.no_of_akeys = None
         self.array_size = None
         self.record_length = None
-        server_group = self.params.get("name",
-                                       '/server_config/',
-                                       'daos_server')
-        self.hostlist = self.params.get("test_servers", '/run/hosts/*')
-        self.hostfile = write_host_file.write_host_file(self.hostlist,
-                                                        self.workdir)
         self.no_of_dkeys = self.params.get("no_of_dkeys", '/run/dkeys/*')[0]
         self.no_of_akeys = self.params.get("no_of_akeys", '/run/akeys/*')[0]
         self.array_size = self.params.get("size", '/array_size/')
         self.record_length = self.params.get("length", '/run/record/*')
-        self.agent_sessions = agent_utils.run_agent(
-            self, self.hostlist)
-        server_utils.run_server(self, self.hostfile, server_group)
 
-        self.pool = DaosPool(self.context)
-        self.pool.create(self.params.get("mode", '/run/pool/createmode/*'),
-                         os.geteuid(),
-                         os.getegid(),
-                         self.params.get("size", '/run/pool/createsize/*'),
-                         self.params.get("setname", '/run/pool/createset/*'),
-                         None)
-        self.pool.connect(2)
+        self.prepare_pool()
 
         self.container = DaosContainer(self.context)
-        self.container.create(self.pool.handle)
+        self.container.create(self.pool.pool.handle)
         self.container.open()
 
         self.obj = DaosObj(self.context, self.container)
@@ -91,19 +65,6 @@ class ObjectDataValidation(TestWithoutServers):
         self.ioreq = IORequest(self.context,
                                self.container,
                                self.obj, objtype=4)
-
-    def tearDown(self):
-        try:
-            if self.container:
-                self.container.close()
-                self.container.destroy()
-            if self.pool:
-                self.pool.disconnect()
-                self.pool.destroy(1)
-        finally:
-            if self.agent_sessions:
-                agent_utils.stop_agent(self.agent_sessions)
-            server_utils.stop_server(hosts=self.hostlist)
 
     def reconnect(self):
         '''
@@ -232,9 +193,7 @@ class ObjectDataValidation(TestWithoutServers):
             self.log.info(str(excep))
             self.fail("##(6.2)Failed on abort_tx.")
 
-
     @avocado.fail_on(DaosApiError)
-    @skipForTicket("DAOS-3208")
     def test_single_object_validation(self):
         """
         Test ID: DAOS-707
@@ -288,7 +247,6 @@ class ObjectDataValidation(TestWithoutServers):
                     record_index = 0
 
     @avocado.fail_on(DaosApiError)
-    @skipForTicket("DAOS-3208")
     def test_array_object_validation(self):
         """
         Test ID: DAOS-707

--- a/src/tests/ftest/object/object_integrity.yaml
+++ b/src/tests/ftest/object/object_integrity.yaml
@@ -1,6 +1,3 @@
-# change host names to your reserved nodes, the
-# required quantity is indicated by the placeholders
-
 hosts:
   test_servers:
     - server-A
@@ -10,12 +7,10 @@ timeout: 4800
 server_config:
    name: daos_server
 pool:
-  createmode:
-    mode: 511
-  createset:
-    setname: daos_server
-  createsize:
-    size: 8000000000
+  mode: 511
+  name: daos_server
+  scm_size: 8000000000
+  control_method: dmg
 array_size:
   size: 10
 dkeys: !mux

--- a/src/tests/ftest/object/punch_test.py
+++ b/src/tests/ftest/object/punch_test.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python
 '''
-  (C) Copyright 2018-2019 Intel Corporation.
+  (C) Copyright 2018-2020 Intel Corporation.
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
@@ -23,11 +23,11 @@
 '''
 from __future__ import print_function
 
-import os
 import traceback
 
 from apricot import TestWithServers
-from pydaos.raw import DaosPool, DaosContainer, DaosApiError
+from pydaos.raw import DaosContainer, DaosApiError
+
 
 class PunchTest(TestWithServers):
     """
@@ -35,27 +35,13 @@ class PunchTest(TestWithServers):
     :avocado: recursive
     """
     def setUp(self):
+        super(PunchTest, self).setUp()
+        self.prepare_pool()
+
         try:
-            super(PunchTest, self).setUp()
-
-            # parameters used in pool create
-            createmode = self.params.get("mode", '/run/pool/createmode/')
-            createsetid = self.params.get("setname", '/run/pool/createset/')
-            createsize = self.params.get("size", '/run/pool/createsize/')
-
-            createuid = os.geteuid()
-            creategid = os.getegid()
-
-            # initialize a python pool object then create the underlying
-            # daos storage
-            self.pool = DaosPool(self.context)
-            self.pool.create(createmode, createuid, creategid,
-                             createsize, createsetid, None)
-            self.pool.connect(1 << 1)
-
             # create a container
             self.container = DaosContainer(self.context)
-            self.container.create(self.pool.handle)
+            self.container.create(self.pool.pool.handle)
 
             # now open it
             self.container.open()

--- a/src/tests/ftest/object/punch_test.yaml
+++ b/src/tests/ftest/object/punch_test.yaml
@@ -1,16 +1,12 @@
-# change host names to your reserved nodes, the
-# required quantity is indicated by the placeholders
 hosts:
   test_servers:
     - server-A
     - server-B
 timeout: 100
 server_config:
-   name: daos_server
+  name: daos_server
 pool:
-   createmode:
-     mode: 511
-   createset:
-     setname: daos_server
-   createsize:
-     size: 1073741824
+  mode: 511
+  name: daos_server
+  scm_size: 1073741824
+  control_method: dmg

--- a/src/tests/ftest/object/same_key_different_value.py
+++ b/src/tests/ftest/object/same_key_different_value.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python
 '''
-  (C) Copyright 2019 Intel Corporation.
+  (C) Copyright 2020 Intel Corporation.
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
@@ -23,11 +23,11 @@
 '''
 from __future__ import print_function
 
-import os
 import traceback
-from apricot import TestWithServers
 
-from pydaos.raw import DaosPool, DaosContainer, DaosApiError
+from apricot import TestWithServers
+from pydaos.raw import DaosContainer, DaosApiError
+
 
 class SameKeyDifferentValue(TestWithServers):
     """
@@ -36,26 +36,13 @@ class SameKeyDifferentValue(TestWithServers):
     :avocado: recursive
     """
     def setUp(self):
+        super(SameKeyDifferentValue, self).setUp()
+        self.prepare_pool()
+
         try:
-            super(SameKeyDifferentValue, self).setUp()
-
-            # parameters used in pool create
-            createmode = self.params.get("mode", '/run/pool/createmode/')
-            createsetid = self.params.get("setname", '/run/pool/createset/')
-            createsize = self.params.get("size", '/run/pool/createsize/')
-            createuid = os.geteuid()
-            creategid = os.getegid()
-
-            # initialize a python pool object then create the underlying
-            # daos storage
-            self.pool = DaosPool(self.context)
-            self.pool.create(createmode, createuid, creategid,
-                             createsize, createsetid, None)
-            self.pool.connect(1 << 1)
-
             # create a container
             self.container = DaosContainer(self.context)
-            self.container.create(self.pool.handle)
+            self.container.create(self.pool.pool.handle)
 
             # now open it
             self.container.open()

--- a/src/tests/ftest/object/same_key_different_value.yaml
+++ b/src/tests/ftest/object/same_key_different_value.yaml
@@ -1,15 +1,11 @@
-# change host names to your reserved nodes, the
-# required quantity is indicated by the placeholders
 hosts:
   test_servers:
     - server-A
 timeout: 180
 server_config:
-   name: daos_server
+  name: daos_server
 pool:
-   createmode:
-     mode: 511
-   createset:
-     setname: daos_server
-   createsize:
-     size: 10000000
+  mode: 511
+  name: daos_server
+  scm_size: 10000000
+  control_method: dmg

--- a/src/tests/ftest/pool/bad_exclude.py
+++ b/src/tests/ftest/pool/bad_exclude.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python
 '''
-  (C) Copyright 2018-2019 Intel Corporation.
+  (C) Copyright 2018-2020 Intel Corporation.
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
@@ -23,16 +23,14 @@
 '''
 from __future__ import print_function
 
-import os
 import traceback
 import ctypes
-import agent_utils
-import server_utils
-import write_host_file
-from apricot import TestWithoutServers
-from pydaos.raw import DaosPool, DaosApiError, RankList
 
-class BadExcludeTest(TestWithoutServers):
+from apricot import TestWithServers
+from pydaos.raw import DaosApiError, RankList
+
+
+class BadExcludeTest(TestWithServers):
     """
     Tests target exclude calls passing NULL and otherwise inappropriate
     parameters.  This can't be done with daosctl, need to use the python API.
@@ -40,40 +38,12 @@ class BadExcludeTest(TestWithoutServers):
     :avocado: recursive
     """
 
-    def setUp(self):
-        super(BadExcludeTest, self).setUp()
-        self.agent_sessions = None
-        self.hostlist_servers = self.params.get("test_servers", '/run/hosts/')
-
-        self.hostfile_servers = write_host_file.write_host_file(
-            self.hostlist_servers, self.workdir)
-
-        server_group = self.params.get("name",
-                                       '/server_config/',
-                                       'daos_server')
-        self.agent_sessions = agent_utils.run_agent(self,
-                                                    self.hostlist_servers)
-        server_utils.run_server(self, self.hostfile_servers, server_group)
-
-    def tearDown(self):
-        if self.agent_sessions:
-            agent_utils.stop_agent(self.agent_sessions)
-        server_utils.stop_server(hosts=self.hostlist_servers)
-
     def test_exclude(self):
         """
         Pass bad parameters to pool connect
 
         :avocado: tags=all,pool,full_regression,tiny,badexclude
         """
-        # parameters used in pool create
-        createmode = self.params.get("mode", '/run/pool/createmode/')
-        createsetid = self.params.get("setname", '/run/pool/createset/')
-        createsize = self.params.get("size", '/run/pool/createsize/')
-
-        createuid = os.geteuid()
-        creategid = os.getegid()
-
         # Accumulate a list of pass/fail indicators representing what is
         # expected for each parameter then "and" them to determine the
         # expected result of the test
@@ -113,52 +83,47 @@ class BadExcludeTest(TestWithoutServers):
         saved_svc = None
         saved_grp = None
         saved_uuid = None
-        pool = None
-        try:
-            # initialize a python pool object then create the underlying
-            # daos storage
-            pool = DaosPool(self.context)
-            pool.create(createmode, createuid, creategid,
-                        createsize, createsetid, None)
+        self.prepare_pool()
 
-            # trash the the pool service rank list
-            if not svc == 'VALID':
-                self.cancel("skipping this test until DAOS-1931 is fixed")
-                saved_svc = RankList(pool.svc.rl_ranks, pool.svc.rl_nr)
-                pool.svc = None
+        # trash the the pool service rank list
+        if not svc == 'VALID':
+            self.cancel("skipping this test until DAOS-1931 is fixed")
+            saved_svc = RankList(
+                self.pool.pool.svc.rl_ranks, self.pool.pool.svc.rl_nr)
+            self.pool.pool.svc = None
 
+        saved_grp = self.pool.pool.group
+        if connectset == 'NULLPTR':
             # trash the pool group value
-            if connectset == 'NULLPTR':
-                saved_grp = pool.group
-                pool.group = None
+            self.pool.pool.group = None
+        else:
+            self.pool.pool.set_group(connectset)
 
-            # trash the UUID value in various ways
-            if excludeuuid == 'NULLPTR':
-                self.cancel("skipping this test until DAOS-1932 is fixed")
-                ctypes.memmove(saved_uuid, pool.uuid, 16)
-                pool.uuid = 0
-            if excludeuuid == 'CRAP':
-                self.cancel("skipping this test until DAOS-1932 is fixed")
-                ctypes.memmove(saved_uuid, pool.uuid, 16)
-                pool.uuid[4] = 244
+        # trash the UUID value in various ways
+        if excludeuuid == 'NULLPTR':
+            self.cancel("skipping this test until DAOS-1932 is fixed")
+            ctypes.memmove(saved_uuid, self.pool.pool.uuid, 16)
+            self.pool.pool.uuid = 0
+        if excludeuuid == 'CRAP':
+            self.cancel("skipping this test until DAOS-1932 is fixed")
+            ctypes.memmove(saved_uuid, self.pool.pool.uuid, 16)
+            self.pool.pool.uuid[4] = 244
 
-            pool.exclude(targets)
+        try:
+            self.pool.pool.exclude(targets)
 
-            if expected_result in ['FAIL']:
+            if expected_result == 'FAIL':
                 self.fail("Test was expected to fail but it passed.\n")
 
         except DaosApiError as excep:
             print(excep)
             print(traceback.format_exc())
-            if expected_result in ['PASS']:
+            if expected_result == 'PASS':
                 self.fail("Test was expected to pass but it failed.\n")
         finally:
-            if pool is not None:
-                if saved_svc is not None:
-                    pool.svc = saved_svc
-                if saved_grp is not None:
-                    pool.group = saved_grp
-                if saved_uuid is not None:
-                    ctypes.memmove(pool.uuid, saved_uuid, 16)
-                pool.disconnect()
-                pool.destroy(1)
+            if saved_svc is not None:
+                self.pool.pool.svc = saved_svc
+            if saved_grp is not None:
+                self.pool.pool.group = saved_grp
+            if saved_uuid is not None:
+                ctypes.memmove(self.pool.pool.uuid, saved_uuid, 16)

--- a/src/tests/ftest/pool/bad_exclude.yaml
+++ b/src/tests/ftest/pool/bad_exclude.yaml
@@ -1,48 +1,48 @@
 server_config:
    name: test_server
 hosts:
-  test_servers:
-    - server-A
-    - server-B
-    - server-C
+   test_servers:
+      - server-A
+      - server-B
+      - server-C
 timeout: 200
 testparams:
    tgtlist: !mux
-     goodlist:
-          ranklist:
-             - 2
-             - PASS
-     badlist:
-          ranklist:
-             - 44
-             - FAIL
-     nulllist:
-          ranklist:
-             - NULLPTR
-             - FAIL
+      goodlist:
+         ranklist:
+            - 2
+            - PASS
+      badlist:
+         ranklist:
+            - 44
+            - FAIL
+      nulllist:
+         ranklist:
+            - NULLPTR
+            - FAIL
    svrlist: !mux
-     goodlist:
-          ranklist:
-             - VALID
-             - PASS
-     badlist:
-          ranklist:
-             - NULLPTR
-             - FAIL
+      goodlist:
+         ranklist:
+            - VALID
+            - PASS
+      badlist:
+         ranklist:
+            - NULLPTR
+            - FAIL
    connectsetnames: !mux
-     goodname:
-          setname:
-             - test_server
-             - PASS
-     badname:
-          setname:
-             - NULLPTR
-             - FAIL
+      goodname:
+         setname:
+            - test_server
+            - PASS
+      badname:
+         setname:
+            - NULLPTR
+            - FAIL
    UUID: !mux
-     gooduuid:
-          uuid:
-             - VALID
-             - PASS
+      gooduuid:
+         uuid:
+            - VALID
+            - PASS
      nulluuid:
           uuid:
              - NULLPTR
@@ -52,10 +52,7 @@ testparams:
              - CRAP
              - FAIL
 pool:
-   createmode:
-     mode: 511
-   createset:
-     setname: test_server
-   createsize:
-     size: 1073741824
-
+   mode: 511
+   name: daos_server
+   scm_size: 1073741824
+   control_method: dmg

--- a/src/tests/ftest/pool/simple_create_delete_test.yaml
+++ b/src/tests/ftest/pool/simple_create_delete_test.yaml
@@ -1,16 +1,13 @@
-# change host names to your reserved nodes, the
-# required quantity is indicated by the placeholders
 hosts:
  test_servers:
   - server-A
 server_config:
  name: daos_server
+pool:
+ control_method: dmg
+ mode: 511
+ scm_size: 1073741824
 tests:
- modes:
-  modeall:
-   mode:
-    - 511
-    - PASS
  uids: !mux
   validuid:
    uid:
@@ -38,4 +35,3 @@ tests:
    setname:
     - complete_rubbish
     - FAIL
-

--- a/src/tests/ftest/rebuild/cascading_failures.yaml
+++ b/src/tests/ftest/rebuild/cascading_failures.yaml
@@ -18,6 +18,7 @@ pool:
   name: daos_server
   scm_size: 1073741824
   svcn: 2
+  control_method: dmg
 container:
   akey_size: 5
   dkey_size: 5

--- a/src/tests/ftest/rebuild/container_create.py
+++ b/src/tests/ftest/rebuild/container_create.py
@@ -1,5 +1,5 @@
 """
-  (C) Copyright 2019 Intel Corporation.
+  (C) Copyright 2020 Intel Corporation.
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
@@ -23,7 +23,6 @@
 import os
 
 from avocado.core.exceptions import TestFail
-
 from apricot import TestWithServers, skipForTicket
 from command_utils import CommandFailure, Mpirun
 from ior_utils import IorCommand
@@ -150,7 +149,8 @@ class ContainerCreate(TestWithServers):
         # Get pool params
         self.pool = []
         for index in range(pool_qty):
-            self.pool.append(TestPool(self.context, self.log))
+            self.pool.append(
+                TestPool(self.context, dmg_command=self.get_dmg_command()))
             self.pool[-1].get_params(self)
 
         if use_ior:
@@ -291,7 +291,6 @@ class ContainerCreate(TestWithServers):
 
             # Destroy the pools
             for pool in self.pool:
-                pool.disconnect()
                 pool.destroy(1)
 
             self.log.info(

--- a/src/tests/ftest/rebuild/container_create.yaml
+++ b/src/tests/ftest/rebuild/container_create.yaml
@@ -15,6 +15,7 @@ pool:
   name: daos_server
   scm_size: 8589934592
   svcn: 3
+  control_method: dmg
 container:
   object_qty: 1
   record_qty: 1

--- a/src/tests/ftest/rebuild/delete_objects.yaml
+++ b/src/tests/ftest/rebuild/delete_objects.yaml
@@ -19,6 +19,7 @@ pool:
   scm_size: 1073741824
   svcn: 2
   debug: True
+  control_method: dmg
 container:
   akey_size: 5
   dkey_size: 5

--- a/src/tests/ftest/rebuild/io_conf_run.yaml
+++ b/src/tests/ftest/rebuild/io_conf_run.yaml
@@ -16,6 +16,7 @@ server_config:
     bdev_list: ["0000:5e:00.0","0000:5f:00.0"]
 pool:
   scm_size: 14G
+  control_method: dmg
 gen_io_conf:
   no_of_ranks: !mux
     default_single_rank:

--- a/src/tests/ftest/rebuild/read_array.yaml
+++ b/src/tests/ftest/rebuild/read_array.yaml
@@ -17,6 +17,7 @@ pool:
   name: daos_server
   scm_size: 1073741824
   svcn: 2
+  control_method: dmg
 container:
   object_qty: 10
   record_qty: 10

--- a/src/tests/ftest/security/pool_connect_init.py
+++ b/src/tests/ftest/security/pool_connect_init.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python
 '''
-  (C) Copyright 2019 Intel Corporation.
+  (C) Copyright 2020 Intel Corporation.
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
@@ -24,10 +24,11 @@
 from __future__ import print_function
 import os
 import traceback
+
 from apricot import TestWithServers
 from avocado.core.exceptions import TestFail
-from pydaos.raw import DaosApiError
 from test_utils_pool import TestPool
+
 
 class PoolSecurityTest(TestWithServers):
     """
@@ -54,7 +55,7 @@ class PoolSecurityTest(TestWithServers):
         user_uid = os.geteuid()
         user_gid = os.getegid()
 
-        self.pool = TestPool(self.context, self.log)
+        self.pool = TestPool(self.context, dmg_command=self.get_dmg_command())
         self.pool.get_params(self)
 
         uid, gid, expected = self.params.get("ids", "/run/pool/tests/*")

--- a/src/tests/ftest/security/pool_connect_init.yaml
+++ b/src/tests/ftest/security/pool_connect_init.yaml
@@ -1,5 +1,3 @@
-# change host names to your reserved nodes, the
-# required quantity is indicated by the placeholders
 hosts:
  test_servers:
   - server-A
@@ -10,6 +8,7 @@ pool:
   mode: 511
   name: daos_server
   scm_size: 16777216
+  control_method: dmg
   tests: !mux
       user_root:
         ids:

--- a/src/tests/ftest/util/daos_io_conf.py
+++ b/src/tests/ftest/util/daos_io_conf.py
@@ -30,6 +30,7 @@ from command_utils import ExecutableCommand, CommandFailure, FormattedParameter
 from command_utils import BasicParameter
 from test_utils import TestPool
 
+
 class IoConfGen(ExecutableCommand):
     """Defines an object for the daos_gen_io_conf and daos_run_io_conf commands.
 
@@ -129,7 +130,7 @@ class IoConfTestBase(TestWithServers):
 
     def setup_test_pool(self):
         """Define a TestPool object."""
-        self.pool = TestPool(self.context, self.log)
+        self.pool = TestPool(self.context, dmg_command=self.get_dmg_command())
         self.pool.get_params(self)
 
     def execute_io_conf_run_test(self):

--- a/src/tests/ftest/util/rebuild_test_base.py
+++ b/src/tests/ftest/util/rebuild_test_base.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python
 """
-  (C) Copyright 2019 Intel Corporation.
+  (C) Copyright 2020 Intel Corporation.
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
@@ -67,7 +67,7 @@ class RebuildTestBase(TestWithServers):
 
     def setup_test_pool(self):
         """Define a TestPool object."""
-        self.pool = TestPool(self.context)
+        self.pool = TestPool(self.context, dmg_command=self.get_dmg_command())
         self.pool.get_params(self)
 
     def setup_test_container(self):

--- a/src/tests/ftest/util/test_utils_pool.py
+++ b/src/tests/ftest/util/test_utils_pool.py
@@ -190,12 +190,9 @@ class TestPool(TestDaosApiBase):
                 self.pool.group = None
             else:
                 self.pool.group = ctypes.create_string_buffer(self.name.value)
-            # Modification 1: Use the length of service_replica returned by dmg
-            # to calculate rank_t. Note that we assume we always get a single
-            # number. I'm not sure if we ever get multiple numbers, but in that
-            # case, we need to modify this implementation to create a list out
-            # of the multiple numbers possibly separated by comma
-            service_replicas = [int(service_replica)]
+            # Modification 1: Use the list of service replicas returned from
+            # dmg pool create.
+            service_replicas = [int(num) for num in service_replica.split(",")]
             rank_t = ctypes.c_uint * len(service_replicas)
             # Modification 2: Use the service_replicas list to generate rank.
             # In DaosPool, we first use some garbage 999999 values and let DAOS

--- a/utils/docker/Dockerfile.leap.15
+++ b/utils/docker/Dockerfile.leap.15
@@ -1,5 +1,5 @@
 #
-# Copyright 2019, Intel Corporation
+# Copyright 2020, Intel Corporation
 #
 # 'recipe' for Docker to build an image of Leap-based
 # environment for building the DAOS project.
@@ -30,9 +30,10 @@ RUN zypper --non-interactive --no-gpg-checks refresh; \
            python-devel python3-devel valgrind-devel hwloc-devel      \
            openmpi3-devel Modules man
 
-RUN pip install --upgrade pip; \
+RUN update-ca-certificates; \
+    pip install --upgrade pip; \
     pip install -U setuptools; \
-    pip install -U wheel;      \
+    pip install -U wheel; \
     pip install scons==3.0.1
 
 RUN curl -fsSL -o /tmp/jhli.key https://download.opensuse.org/repositories/home:/jhli/SLE_15/repodata/repomd.xml.key

--- a/utils/docker/Dockerfile.leap.15
+++ b/utils/docker/Dockerfile.leap.15
@@ -1,5 +1,5 @@
 #
-# Copyright 2020, Intel Corporation
+# Copyright 2019-2020, Intel Corporation
 #
 # 'recipe' for Docker to build an image of Leap-based
 # environment for building the DAOS project.
@@ -30,10 +30,10 @@ RUN zypper --non-interactive --no-gpg-checks refresh; \
            python-devel python3-devel valgrind-devel hwloc-devel      \
            openmpi3-devel Modules man
 
-RUN update-ca-certificates; \
+RUN update-ca-certificates;    \
     pip install --upgrade pip; \
     pip install -U setuptools; \
-    pip install -U wheel; \
+    pip install -U wheel;      \
     pip install scons==3.0.1
 
 RUN curl -fsSL -o /tmp/jhli.key https://download.opensuse.org/repositories/home:/jhli/SLE_15/repodata/repomd.xml.key


### PR DESCRIPTION
* DAOS-3743 test: Modify object, rebuild, pool tests to use dmg

Updated the tests to use dmg pool create.

Made a lot of refactoring; mainly obtaining the pool-related
data from yaml using get_params method.

Also removed SkipForTicket tags from a test since the
issue was resolved.

Updated TestPool.create method to support multiple service
replicas.

Signed-off-by: Makito Kano <makito.kano@intel.com>