### PR TITLE
DAOS-4153 control: attempt graceful io_server shutdown on exit

### DIFF
--- a/src/control/common/collection_utils.go
+++ b/src/control/common/collection_utils.go
@@ -27,6 +27,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"unicode"
+
+	"github.com/pkg/errors"
 )
 
 // Includes returns true if string target in slice.
@@ -106,4 +108,18 @@ func Pluralise(s string, n int) string {
 func ParseInts(in string) (ints []uint32, err error) {
 	str := fmt.Sprintf("[%s]", in)
 	return ints, json.Unmarshal([]byte(str), &ints)
+}
+
+// ConcatErrors builds single error from error slice.
+func ConcatErrors(scanErrors []error, err error) error {
+	if err != nil {
+		scanErrors = append(scanErrors, err)
+	}
+
+	errStr := "scan error(s):\n"
+	for _, err := range scanErrors {
+		errStr += fmt.Sprintf("  %s\n", err.Error())
+	}
+
+	return errors.New(errStr)
 }

--- a/src/control/server/ctl_system.go
+++ b/src/control/server/ctl_system.go
@@ -89,7 +89,7 @@ func (svc *ControlService) updateMemberStatus(ctx context.Context) error {
 	// Update either:
 	// - members unresponsive to ping
 	// - members with stopped processes
-	// TODO: update members with ping errors
+	// - members returning error from dRPC ping
 	badRanks := make(map[uint32]system.MemberState)
 	for addr, ranks := range hostRanks {
 		hResults, err := svc.harnessClient.Query(ctx, addr)

--- a/src/control/server/faults.go
+++ b/src/control/server/faults.go
@@ -25,6 +25,7 @@ package server
 import (
 	"fmt"
 
+	"github.com/daos-stack/daos/src/control/common"
 	"github.com/daos-stack/daos/src/control/fault"
 	"github.com/daos-stack/daos/src/control/fault/code"
 )
@@ -79,16 +80,10 @@ func FaultScmUnmanaged(mntPoint string) *fault.Fault {
 }
 
 func FaultBdevNotFound(bdevs []string) *fault.Fault {
-	plural := ""
-	if len(bdevs) > 1 {
-		plural = "s"
-	}
-
 	return serverFault(
 		code.ServerBdevNotFound,
-		fmt.Sprintf("NVMe SSD%s %v not found", plural, bdevs),
-		fmt.Sprintf("check SSD%s %v that are specified in server config "+
-			"exist and are accessible by SPDK", plural, bdevs),
+		fmt.Sprintf("NVMe SSD%s %v not found", common.Pluralise("", len(bdevs)), bdevs),
+		fmt.Sprintf("check SSD%s %v that are specified in server config exist", common.Pluralise("", len(bdevs)), bdevs),
 	)
 }
 

--- a/src/control/server/instance.go
+++ b/src/control/server/instance.go
@@ -48,7 +48,7 @@ import (
 type IOServerRunner interface {
 	Start(context.Context, chan<- error) error
 	IsRunning() bool
-	Stop(bool) error
+	Signal(os.Signal) error
 	GetConfig() *ioserver.Config
 }
 
@@ -223,10 +223,12 @@ func (srv *IOServerInstance) Start(ctx context.Context, errChan chan<- error) er
 	return srv.runner.Start(ctx, errChan)
 }
 
-func (srv *IOServerInstance) Stop(force bool) error {
-	return srv.runner.Stop(force)
+// Signal sends signal to IOServerInstance runner.
+func (srv *IOServerInstance) Signal(signal os.Signal) error {
+	return srv.runner.Signal(signal)
 }
 
+// IsStarted indicates whether IOServerInstance is in a running state.
 func (srv *IOServerInstance) IsStarted() bool {
 	return srv.runner.IsRunning()
 }
@@ -330,6 +332,27 @@ func (srv *IOServerInstance) callSetRank(rank ioserver.Rank) error {
 	}
 
 	return nil
+}
+
+// GetRank returns a valid instance rank or error.
+func (srv *IOServerInstance) GetRank() (*ioserver.Rank, error) {
+	var err error
+	sb := srv.getSuperblock()
+
+	switch {
+	case sb == nil:
+		err = errors.New("nil superblock")
+	case sb.Rank == nil:
+		err = errors.New("nil rank in superblock")
+	case *sb.Rank == ioserver.NilRank:
+		err = errors.New("NilRank in superblock")
+	}
+
+	if err != nil {
+		return nil, err
+	}
+
+	return sb.Rank, nil
 }
 
 // StartManagementService starts the DAOS management service replica associated
@@ -460,6 +483,7 @@ func (srv *IOServerInstance) CallDrpc(module, method int32, body proto.Message) 
 	return makeDrpcCall(dc, module, method, body)
 }
 
+// BioErrorNotify logs a blob I/O error.
 func (srv *IOServerInstance) BioErrorNotify(bio *srvpb.BioErrorReq) {
 
 	srv.log.Errorf("I/O server instance %d (target %d) has detected blob I/O error! %v",

--- a/src/control/server/ioserver/exec.go
+++ b/src/control/server/ioserver/exec.go
@@ -158,17 +158,13 @@ func (r *Runner) IsRunning() bool {
 	return atomic.LoadUint32(&r.running) != 0
 }
 
-// Stop sends relevant shutdown signal to the Runner process (idempotent).
-func (r *Runner) Stop(force bool) error {
+// Signal sends relevant signal to the Runner process (idempotent).
+func (r *Runner) Signal(signal os.Signal) error {
 	if !r.IsRunning() {
 		return nil
 	}
 
-	signal := syscall.SIGTERM
-	if force {
-		signal = syscall.SIGKILL
-	}
-	r.log.Debugf("Stopping I/O server instance %d (%s)", r.Config.Index, signal)
+	r.log.Debugf("Signalling I/O server instance %d (%s)", r.Config.Index, signal)
 
 	return r.cmd.Process.Signal(signal)
 }

--- a/src/control/server/ioserver/mocks.go
+++ b/src/control/server/ioserver/mocks.go
@@ -22,12 +22,17 @@
 //
 package ioserver
 
-import "context"
+import (
+	"context"
+	"os"
+)
 
 type (
 	TestRunnerConfig struct {
 		StartCb    func()
 		StartErr   error
+		SignalCb   func(uint32, os.Signal)
+		SignalErr  error
 		ErrChanCb  func() error
 		ErrChanErr error
 	}
@@ -70,7 +75,12 @@ func (tr *TestRunner) Start(ctx context.Context, errChan chan<- error) error {
 	return tr.runnerCfg.StartErr
 }
 
-func (tr *TestRunner) Stop(bool) error { return nil }
+func (tr *TestRunner) Signal(sig os.Signal) error {
+	if tr.runnerCfg.SignalCb != nil {
+		tr.runnerCfg.SignalCb(tr.serverCfg.Index, sig)
+	}
+	return tr.runnerCfg.SignalErr
+}
 
 func (tr *TestRunner) IsRunning() bool { return true }
 

--- a/src/control/server/mgmt_svc.go
+++ b/src/control/server/mgmt_svc.go
@@ -28,6 +28,7 @@ import (
 	"os/exec"
 	"strconv"
 	"strings"
+	"syscall"
 	"time"
 
 	"github.com/golang/protobuf/proto"
@@ -36,18 +37,20 @@ import (
 	"google.golang.org/grpc/peer"
 
 	"github.com/daos-stack/daos/src/control/common"
+	"github.com/daos-stack/daos/src/control/common/proto/convert"
 	mgmtpb "github.com/daos-stack/daos/src/control/common/proto/mgmt"
 	"github.com/daos-stack/daos/src/control/drpc"
 	"github.com/daos-stack/daos/src/control/logging"
+	"github.com/daos-stack/daos/src/control/server/ioserver"
 	"github.com/daos-stack/daos/src/control/system"
 )
 
 const instanceUpdateDelay = 500 * time.Millisecond
 
 // NewRankResult returns a reference to a new member result struct.
-func NewRankResult(rank uint32, action string, state system.MemberState, err error) *mgmtpb.RanksResp_RankResult {
+func NewRankResult(rank *ioserver.Rank, action string, state system.MemberState, err error) *mgmtpb.RanksResp_RankResult {
 	result := mgmtpb.RanksResp_RankResult{
-		Rank: rank, Action: action, State: uint32(state),
+		Rank: rank.Uint32(), Action: action, State: uint32(state),
 	}
 	if err != nil {
 		result.Errored = true
@@ -61,19 +64,19 @@ func NewRankResult(rank uint32, action string, state system.MemberState, err err
 //
 // RankResult is populated with rank, state and error dependent on processing
 // dRPC response. Target state param is populated on success, Errored otherwise.
-func drespToRankResult(rank uint32, action string, dresp *drpc.Response, err error, tState system.MemberState) *mgmtpb.RanksResp_RankResult {
+func drespToRankResult(rank *ioserver.Rank, action string, dresp *drpc.Response, err error, tState system.MemberState) *mgmtpb.RanksResp_RankResult {
 	var outErr error
 	state := system.MemberStateErrored
 
 	if err != nil {
-		outErr = errors.WithMessagef(err, "rank %d dRPC failed", rank)
+		outErr = errors.WithMessagef(err, "rank %s dRPC failed", rank)
 	} else {
 		resp := &mgmtpb.DaosResp{}
 		if err = proto.Unmarshal(dresp.Body, resp); err != nil {
-			outErr = errors.WithMessagef(err, "rank %d dRPC unmarshal failed",
+			outErr = errors.WithMessagef(err, "rank %s dRPC unmarshal failed",
 				rank)
 		} else if resp.GetStatus() != 0 {
-			outErr = errors.Errorf("rank %d dRPC returned DER %d",
+			outErr = errors.Errorf("rank %s dRPC returned DER %d",
 				rank, resp.GetStatus())
 		}
 	}
@@ -706,22 +709,15 @@ func (svc *mgmtSvc) StorageSetFaulty(ctx context.Context, req *mgmtpb.DevStateRe
 	return nil, errors.Errorf("no rank matched request for %q", req.DevUuid)
 }
 
-// validateInstanceRank checks instance rank in superblock matches supplied list.
-func validateInstanceRank(log logging.Logger, i *IOServerInstance, ranks []uint32) (*uint32, bool) {
-	rank := i.getSuperblock().Rank.Uint32()
-
-	if len(ranks) == 0 {
-		return &rank, true // no ranks to filter, allow all
-	}
+// checkRankList checks rank is present in rank list.
+func checkRankList(rank ioserver.Rank, ranks []*ioserver.Rank) bool {
 	for _, r := range ranks {
-		if r == rank {
-			return &rank, true
+		if rank.Equals(r) {
+			return true
 		}
 	}
 
-	log.Debugf("validateInstanceRank() skipping rank %d", rank)
-
-	return &rank, false
+	return false
 }
 
 // PrepShutdown implements the method defined for the Management Service.
@@ -740,19 +736,24 @@ func (svc *mgmtSvc) PrepShutdownRanks(ctx context.Context, req *mgmtpb.RanksReq)
 
 	resp := &mgmtpb.RanksResp{}
 
-	for _, i := range svc.harness.instances {
-		if !i.hasSuperblock() { // critical error
-			return nil, errors.Errorf("instance %d has no superblock", i.Index())
+	var rankList []*ioserver.Rank
+	if err := convert.Types(req.Ranks, &rankList); err != nil {
+		return nil, errors.Wrap(err, "parsing request rank list")
+	}
+
+	for _, i := range svc.harness.Instances() {
+		rank, err := i.GetRank()
+		if err != nil {
+			return nil, err
 		}
 
-		rank, ok := validateInstanceRank(svc.log, i, req.Ranks)
-		if !ok { // filtered out, no result expected
-			continue
+		if !checkRankList(*rank, rankList) {
+			continue // filtered out, no result expected
 		}
 
 		if !i.IsStarted() {
 			resp.Results = append(resp.Results,
-				NewRankResult(*rank, "prep shutdown",
+				NewRankResult(rank, "prep shutdown",
 					system.MemberStateStopped, nil))
 			continue
 		}
@@ -760,7 +761,7 @@ func (svc *mgmtSvc) PrepShutdownRanks(ctx context.Context, req *mgmtpb.RanksReq)
 		dresp, err := i.CallDrpc(drpc.ModuleMgmt, drpc.MethodPrepShutdown, nil)
 
 		resp.Results = append(resp.Results,
-			drespToRankResult(*rank, "prep shutdown", dresp, err,
+			drespToRankResult(rank, "prep shutdown", dresp, err,
 				system.MemberStateStopping))
 	}
 
@@ -772,14 +773,10 @@ func (svc *mgmtSvc) PrepShutdownRanks(ctx context.Context, req *mgmtpb.RanksReq)
 // StopRanks implements the method defined for the Management Service.
 //
 // Stop data-plane instance managed by control-plane identified by unique rank.
-//
-// Iterate over instances issuing kill rank requests, wait until either all instances are
-// stopped or timeout occurs and then populate response results based on instance started state.
-// Return error if any instances are still running in order to enable retries at the sender.
-//
-// TODO: Enable "force" if number of retries fail, issuing a different signal/mechanism for
-//       terminating the process.
-func (svc *mgmtSvc) StopRanks(ctx context.Context, req *mgmtpb.RanksReq) (*mgmtpb.RanksResp, error) {
+// After attempting to stop instances through harness (when either all instances
+// are stopped or timeout has occurred, populate response results based on
+// instance started state.
+func (svc *mgmtSvc) StopRanks(parent context.Context, req *mgmtpb.RanksReq) (*mgmtpb.RanksResp, error) {
 	if req == nil {
 		return nil, errors.New("nil request")
 	}
@@ -787,64 +784,39 @@ func (svc *mgmtSvc) StopRanks(ctx context.Context, req *mgmtpb.RanksReq) (*mgmtp
 
 	resp := &mgmtpb.RanksResp{}
 
-	for _, i := range svc.harness.instances {
-		if !i.hasSuperblock() { // critical error
-			return nil, errors.Errorf("instance %d has no superblock", i.Index())
-		}
-
-		rank, ok := validateInstanceRank(svc.log, i, req.Ranks)
-		if !ok { // filtered out, no result expected
-			continue
-		}
-
-		if !i.IsStarted() { // skip as already stopped
-			svc.log.Debugf("rank %d already stopped", *rank)
-			continue
-		}
-
-		if err := i.Stop(req.Force); err != nil {
-			var msg string
-			if req.Force {
-				msg = " (forced)"
-			}
-			svc.log.Error(errors.Wrapf(err,
-				"rank %d stop%s", *rank, msg).Error())
-		}
+	signal := syscall.SIGINT
+	if req.Force {
+		signal = syscall.SIGKILL
+	}
+	if err := svc.harness.SignalInstances(ctx, svc.log, signal, req.Ranks...); err != nil {
+		return nil, errors.Wrap(err, "signalling instances to stop")
 	}
 
-	stopped := make(chan struct{})
-	// select until instances stop or timeout occurs (at which point get results of each instance)
-	go func() {
-		for {
-			if len(svc.harness.StartedRanks()) > 0 {
-				time.Sleep(instanceUpdateDelay)
-				continue
-			}
-			close(stopped)
-			break
-		}
-	}()
-
-	select {
-	case <-stopped:
-	case <-time.After(svc.harness.rankReqTimeout * 2):
+	var rankList []*ioserver.Rank
+	if err := convert.Types(req.Ranks, &rankList); err != nil {
+		return nil, errors.Wrap(err, "parsing request rank list")
 	}
 
 	// either all instances stopped or timeout occurred
-	for _, i := range svc.harness.instances {
+	for _, i := range svc.harness.Instances() {
+		rank, err := i.GetRank()
+		if err != nil {
+			return nil, err
+		}
+
+		if !checkRankList(*rank, rankList) {
+			continue // filtered out, no result expected
+		}
+
 		state := system.MemberStateStarted
 		rrErr := errors.Errorf("want %s, got %s", system.MemberStateStopped, state)
-
-		if !i.hasSuperblock() {
-			return nil, errors.Errorf("instance %d has no superblock", i.Index())
-		}
 
 		if !i.IsStarted() {
 			state = system.MemberStateStopped
 			rrErr = nil
 		}
 		resp.Results = append(resp.Results,
-			NewRankResult(i.getSuperblock().Rank.Uint32(), "stop", state, rrErr))
+			NewRankResult(rank, "stop", state, rrErr))
 	}
 
 	svc.log.Debugf("MgmtSvc.StopRanks dispatch, resp:%+v\n", *resp)
@@ -852,7 +824,7 @@ func (svc *mgmtSvc) StopRanks(ctx context.Context, req *mgmtpb.RanksReq) (*mgmtp
 	return resp, nil
 }
 
-func ping(i *IOServerInstance, rank uint32, timeout time.Duration) *mgmtpb.RanksResp_RankResult {
+func ping(i *IOServerInstance, rank *ioserver.Rank, timeout time.Duration) *mgmtpb.RanksResp_RankResult {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
@@ -878,8 +850,6 @@ func ping(i *IOServerInstance, rank uint32, timeout time.Duration) *mgmtpb.Ranks
 		return NewRankResult(rank, "ping", system.MemberStateUnresponsive,
 			errors.New("timeout occurred"))
 	}
-
-	return nil
 }
 
 // PingRanks implements the method defined for the Management Service.
@@ -899,23 +869,29 @@ func (svc *mgmtSvc) PingRanks(ctx context.Context, req *mgmtpb.RanksReq) (*mgmtp
 
 	resp := &mgmtpb.RanksResp{}
 
+	var rankList []*ioserver.Rank
+	if err := convert.Types(req.Ranks, &rankList); err != nil {
+		return nil, errors.Wrap(err, "parsing request rank list")
+	}
+
 	for _, i := range svc.harness.Instances() {
-		if !i.hasSuperblock() { // critical error
-			return nil, errors.Errorf("instance %d has no superblock", i.Index())
+		rank, err := i.GetRank()
+		if err != nil {
+			return nil, err
 		}
 
-		rank, ok := validateInstanceRank(svc.log, i, req.Ranks)
-		if !ok { // filtered out, no result expected
-			continue
+		if !checkRankList(*rank, rankList) {
+			continue // filtered out, no result expected
 		}
 
 		if !i.IsStarted() {
 			resp.Results = append(resp.Results,
-				NewRankResult(*rank, "ping", system.MemberStateStopped, nil))
+				NewRankResult(rank, "ping",
+					system.MemberStateStopped, nil))
 			continue
 		}
 
-		resp.Results = append(resp.Results, ping(i, *rank, svc.harness.rankReqTimeout))
+		resp.Results = append(resp.Results, ping(i, rank, svc.harness.rankReqTimeout))
 	}
 
 	svc.log.Debugf("MgmtSvc.PingRanks dispatch, resp:%+v\n", *resp)
@@ -939,8 +915,7 @@ func (svc *mgmtSvc) StartRanks(ctx context.Context, req *mgmtpb.RanksReq) (*mgmt
 
 	resp := &mgmtpb.RanksResp{}
 
-	// perform controlled restart of I/O Server harness
-	if err := svc.harness.RestartInstances(); err != nil {
+	if err := svc.harness.StartInstances(); err != nil {
 		return nil, err
 	}
 
@@ -962,22 +937,30 @@ func (svc *mgmtSvc) StartRanks(ctx context.Context, req *mgmtpb.RanksReq) (*mgmt
 	case <-time.After(svc.harness.rankReqTimeout):
 	}
 
+	var rankList []*ioserver.Rank
+	if err := convert.Types(req.Ranks, &rankList); err != nil {
+		return nil, errors.Wrap(err, "parsing request rank list")
+	}
+
 	// either all instances started or timeout occurred
-	for _, i := range svc.harness.instances {
+	for _, i := range svc.harness.Instances() {
+		rank, err := i.GetRank()
+		if err != nil {
+			return nil, err
+		}
+
+		if !checkRankList(*rank, rankList) {
+			continue // filtered out, no result expected
+		}
+
 		state := system.MemberStateStopped
 		rrErr := errors.Errorf("want %s, got %s", system.MemberStateStarted, state)
-
-		if !i.hasSuperblock() {
-			return nil, errors.Errorf("instance %d has no superblock", i.Index())
-		}
 
 		if i.IsStarted() {
 			state = system.MemberStateStarted
 			rrErr = nil
 		}
-		resp.Results = append(resp.Results,
-			NewRankResult(i.getSuperblock().Rank.Uint32(), "start",
-				state, rrErr))
+		resp.Results = append(resp.Results, NewRankResult(rank, "start", state, rrErr))
 	}
 
 	svc.log.Debugf("MgmtSvc.StartRanks dispatch, resp:%+v\n", *resp)


### PR DESCRIPTION
When daos_server receives SIG{INT,TERM,QUIT}, attempt to shutdown
child daos_io_server processes gracefully with the same signal before
falling back to SIGKILL on timeout. Fetch timeout value from server
config file.

Signed-off-by: Tom Nabarro <tom.nabarro@intel.com>