### PR TITLE
DAOS-4282 object: verify the specified shard for fetch

### DIFF
--- a/src/object/cli_obj.c
+++ b/src/object/cli_obj.c
@@ -1510,8 +1510,10 @@ obj_req_valid(void *args, int opc, daos_epoch_t *epoch)
 	case DAOS_OBJ_RPC_FETCH:
 		f_args = args;
 		if (f_args->dkey == NULL || f_args->dkey->iov_buf == NULL ||
-		    f_args->nr == 0)
+		    f_args->nr == 0) {
+			D_ERROR("Invalid fetch parameter.\n");
 			D_GOTO(out, rc = -DER_INVAL);
+		}
 
 		rc = obj_iod_sgl_valid(f_args->nr, f_args->iods, f_args->sgls,
 				       false);
@@ -1531,8 +1533,10 @@ obj_req_valid(void *args, int opc, daos_epoch_t *epoch)
 	case DAOS_OBJ_RPC_UPDATE:
 		u_args = args;
 		if (u_args->dkey == NULL || u_args->dkey->iov_buf == NULL ||
-		    u_args->nr == 0)
+		    u_args->nr == 0) {
+			D_ERROR("Invalid update parameter.\n");
 			D_GOTO(out, rc = -DER_INVAL);
+		}
 
 		rc = obj_iod_sgl_valid(u_args->nr, u_args->iods, u_args->sgls,
 				       true);
@@ -1575,7 +1579,7 @@ obj_req_valid(void *args, int opc, daos_epoch_t *epoch)
 			D_GOTO(out, rc = -DER_INVAL);
 		}
 		if (l_args->nr == NULL || *l_args->nr == 0) {
-			D_DEBUG(DB_IO, "Invalid API parameter.\n");
+			D_ERROR("Invalid API parameter.\n");
 			D_GOTO(out, rc = -DER_INVAL);
 		}
 
@@ -1602,8 +1606,9 @@ out:
 /* Query the obj request's targets */
 static int
 obj_req_get_tgts(struct dc_object *obj, enum obj_rpc_opc opc, int *shard,
-		 uint64_t dkey_hash, uint8_t *bit_map, uint32_t map_ver,
-		 bool to_leader, bool spec_shard, struct obj_req_tgts *req_tgts)
+		 daos_key_t *dkey, uint64_t dkey_hash, uint8_t *bit_map,
+		 uint32_t map_ver, bool to_leader, bool spec_shard,
+		 struct obj_req_tgts *req_tgts)
 {
 	int		rc;
 
@@ -1623,8 +1628,18 @@ obj_req_get_tgts(struct dc_object *obj, enum obj_rpc_opc opc, int *shard,
 
 				rc *= obj->cob_grp_size;
 				if (*shard < rc ||
-				    *shard >= rc + obj->cob_grp_size)
+				    *shard >= rc + obj->cob_grp_size) {
+					D_ERROR("Fetch from invalid shard, "
+						"grp size %u, shard cnt %u, "
+						"grp idx %u, given shard %u, "
+						"dkey hash %lu, dkey %s\n",
+						obj->cob_grp_size,
+						obj->cob_shards_nr,
+						rc / obj->cob_grp_size, *shard,
+						dkey_hash,
+						(char *)dkey->iov_buf);
 					D_GOTO(out, rc = -DER_INVAL);
+				}
 
 				rc = *shard;
 			} else {
@@ -2498,7 +2513,7 @@ do_dc_obj_fetch(tse_task_t *task, daos_obj_fetch_t *args,
 		tgt_bitmap = obj_auxi->reasb_req.tgt_bitmap;
 	}
 	rc = obj_req_get_tgts(obj, DAOS_OBJ_RPC_FETCH, (int *)&shard,
-			      dkey_hash, tgt_bitmap, map_ver,
+			      args->dkey, dkey_hash, tgt_bitmap, map_ver,
 			      obj_auxi->to_leader, obj_auxi->spec_shard,
 			      &obj_auxi->req_tgts);
 	if (rc != 0)
@@ -2578,9 +2593,9 @@ dc_obj_update(tse_task_t *task)
 	}
 
 	dkey_hash = obj_dkey2hash(args->dkey);
-	rc = obj_req_get_tgts(obj, DAOS_OBJ_RPC_UPDATE, NULL, dkey_hash,
-			      obj_auxi->reasb_req.tgt_bitmap, map_ver, false,
-			      false, &obj_auxi->req_tgts);
+	rc = obj_req_get_tgts(obj, DAOS_OBJ_RPC_UPDATE, NULL, args->dkey,
+			      dkey_hash, obj_auxi->reasb_req.tgt_bitmap,
+			      map_ver, false, false, &obj_auxi->req_tgts);
 
 	if (!obj_auxi->io_retry)
 		obj_update_csums(obj, args, obj_auxi);
@@ -2679,13 +2694,16 @@ dc_obj_list_internal(tse_task_t *task, int opc, daos_obj_list_t *args)
 	    (daos_anchor_get_flags(args->dkey_anchor) & DIOF_TO_SPEC_SHARD)) {
 		shard = dc_obj_anchor2shard(args->dkey_anchor);
 		obj_auxi->spec_shard = 1;
+	} else if (DAOS_FAIL_CHECK(DAOS_OBJ_SPECIAL_SHARD)) {
+		shard = daos_fail_value_get();
+		obj_auxi->spec_shard = 1;
 	} else {
 		obj_auxi->spec_shard = 0;
 	}
 
-	rc = obj_req_get_tgts(obj, opc, &shard, dkey_hash, NIL_BITMAP, map_ver,
-			      obj_auxi->to_leader, obj_auxi->spec_shard,
-			      &obj_auxi->req_tgts);
+	rc = obj_req_get_tgts(obj, opc, &shard, args->dkey, dkey_hash,
+			      NIL_BITMAP, map_ver, obj_auxi->to_leader,
+			      obj_auxi->spec_shard, &obj_auxi->req_tgts);
 	if (rc != 0)
 		goto out_task;
 	if (args->dkey == NULL)
@@ -2813,8 +2831,9 @@ obj_punch_internal(tse_task_t *task, enum obj_rpc_opc opc,
 	}
 
 	dkey_hash = obj_dkey2hash(api_args->dkey);
-	rc = obj_req_get_tgts(obj, opc, NULL, dkey_hash, NIL_BITMAP, map_ver,
-			      false, false, &obj_auxi->req_tgts);
+	rc = obj_req_get_tgts(obj, opc, NULL, api_args->dkey, dkey_hash,
+			      NIL_BITMAP, map_ver, false, false,
+			      &obj_auxi->req_tgts);
 	if (rc != 0)
 		goto out_task;
 
@@ -3267,7 +3286,7 @@ dc_obj_sync(tse_task_t *task)
 			*args->epochs_p[i] = 0;
 	}
 
-	rc = obj_req_get_tgts(obj, DAOS_OBJ_RPC_SYNC, NULL, 0, NIL_BITMAP,
+	rc = obj_req_get_tgts(obj, DAOS_OBJ_RPC_SYNC, NULL, NULL, 0, NIL_BITMAP,
 			      map_ver, true, false, &obj_auxi->req_tgts);
 	if (rc != 0)
 		D_GOTO(out_task, rc);

--- a/src/object/obj_verify.c
+++ b/src/object/obj_verify.c
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2019 Intel Corporation.
+ * (C) Copyright 2019-2020 Intel Corporation.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -55,9 +55,6 @@ dc_obj_verify_list(struct dc_obj_verify_args *dova)
 
 	dova->size = 0;
 	dova->num = DOVA_NUM;
-
-	daos_anchor_set_flags(&dova->dkey_anchor,
-			      DIOF_TO_SPEC_SHARD | DIOF_WITH_SPEC_EPOCH);
 
 again:
 	dova->list_iov.iov_len = 0;
@@ -527,26 +524,44 @@ dc_obj_verify_cmp(struct dc_obj_verify_args *dova_a,
 		return -DER_MISMATCH;
 	}
 
-	switch (cur_a->type) {
-	case OBJ_ITER_NONE:
-		/* The end. */
-		break;
-	case OBJ_ITER_DKEY_EPOCH:
-	case OBJ_ITER_DKEY:
-		/* Punched dkey, do nothing. */
-		break;
-	case OBJ_ITER_AKEY_EPOCH:
-	case OBJ_ITER_AKEY:
-		/* Punched akey, do nothing. */
-		break;
-	case OBJ_ITER_RECX:
+	/* The end. */
+	if (cur_a->type == OBJ_ITER_NONE)
+		return 0;
+
+	if (!daos_key_match(&cur_a->dkey, &cur_b->dkey)) {
+		D_INFO(DF_OID" (reps %u, inconsistent) "
+		       "shard %u has dkey %s, but shard %u has dkey %s.\n",
+		       DP_OID(oid), reps,
+		       shard_a, (char *)cur_a->dkey.iov_buf,
+		       shard_b, (char *)cur_b->dkey.iov_buf);
+		return -DER_MISMATCH;
+	}
+
+	/* Punched dkey. */
+	if (cur_a->type == OBJ_ITER_DKEY_EPOCH || cur_a->type == OBJ_ITER_DKEY)
+		return 0;
+
+	if (!daos_key_match(&cur_a->iod.iod_name, &cur_b->iod.iod_name)) {
+		D_INFO(DF_OID" (reps %u, inconsistent) "
+		       "shard %u has akey %s, but shard %u has akey %s.\n",
+		       DP_OID(oid), reps,
+		       shard_a, (char *)cur_a->iod.iod_name.iov_buf,
+		       shard_b, (char *)cur_b->iod.iod_name.iov_buf);
+		return -DER_MISMATCH;
+	}
+
+	/* Punched akey. */
+	if (cur_a->type == OBJ_ITER_AKEY_EPOCH || cur_a->type == OBJ_ITER_AKEY)
+		return 0;
+
+	if (cur_a->type == OBJ_ITER_RECX) {
 		if (cur_a->iod.iod_recxs->rx_idx !=
 		    cur_b->iod.iod_recxs->rx_idx) {
 			D_INFO(DF_OID" (reps %u, inconsistent) "
 			       "shard %u has EV rec start %lu, "
 			       "but shard %u has EV rec start %lu.\n",
-			       DP_OID(oid), reps, shard_a,
-			       cur_a->iod.iod_recxs->rx_idx,
+			       DP_OID(oid), reps,
+			       shard_a, cur_a->iod.iod_recxs->rx_idx,
 			       shard_b, cur_b->iod.iod_recxs->rx_idx);
 			return -DER_MISMATCH;
 		}
@@ -556,64 +571,57 @@ dc_obj_verify_cmp(struct dc_obj_verify_args *dova_a,
 			D_INFO(DF_OID" (reps %u, inconsistent) "
 			       "shard %u has EV rec len %lu, "
 			       "but shard %u has EV rec len %lu.\n",
-			       DP_OID(oid), reps, shard_a,
-			       cur_a->iod.iod_recxs->rx_nr,
+			       DP_OID(oid), reps,
+			       shard_a, cur_a->iod.iod_recxs->rx_nr,
 			       shard_b, cur_b->iod.iod_recxs->rx_nr);
 			return -DER_MISMATCH;
 		}
+	}
 
-		/* Fall through. */
-	case OBJ_ITER_SINGLE:
-		if (cur_a->iod.iod_size != cur_b->iod.iod_size) {
-			D_INFO(DF_OID" (reps %u, inconsistent) "
-			       "type %u, shard %u has rec size %lu, "
-			       "but shard %u has rec size %lu.\n",
-			       DP_OID(oid), reps, cur_a->type, shard_a,
-			       cur_a->iod.iod_size, shard_b,
-			       cur_b->iod.iod_size);
-			return -DER_MISMATCH;
-		}
+	if (cur_a->iod.iod_size != cur_b->iod.iod_size) {
+		D_INFO(DF_OID" (reps %u, inconsistent) "
+		       "type %u, shard %u has rec size %lu, "
+		       "but shard %u has rec size %lu.\n",
+		       DP_OID(oid), reps, cur_a->type, shard_a,
+		       cur_a->iod.iod_size, shard_b, cur_b->iod.iod_size);
+		return -DER_MISMATCH;
+	}
 
-		/* Punched record, do nothing. */
-		if (cur_a->iod.iod_size == 0)
-			break;
+	/* Punched record, do nothing. */
+	if (cur_a->iod.iod_size == 0)
+		return 0;
 
-		D_ASSERT(cur_a->iod.iod_size != DAOS_SIZE_MAX);
+	D_ASSERT(cur_a->iod.iod_size != DAOS_SIZE_MAX);
 
-		rc = dc_obj_verify_fetch(dova_a);
-		if (rc != 0)
-			return rc;
+	rc = dc_obj_verify_fetch(dova_a);
+	if (rc != 0)
+		return rc;
 
-		rc = dc_obj_verify_fetch(dova_b);
-		if (rc != 0)
-			return rc;
+	rc = dc_obj_verify_fetch(dova_b);
+	if (rc != 0)
+		return rc;
 
-		D_ASSERT(dova_a->fetch_iov.iov_buf == dova_a->fetch_buf);
-		D_ASSERT(dova_b->fetch_iov.iov_buf == dova_b->fetch_buf);
+	D_ASSERT(dova_a->fetch_iov.iov_buf == dova_a->fetch_buf);
+	D_ASSERT(dova_b->fetch_iov.iov_buf == dova_b->fetch_buf);
 
-		if (dova_a->fetch_iov.iov_len != dova_b->fetch_iov.iov_len) {
-			D_INFO(DF_OID" (reps %u, inconsistent) "
-			       "type %u, fetched %ld bytes from shard %u, "
-			       "but fetched %ld bytes from shard %u.\n",
-			       DP_OID(oid), reps, cur_a->type,
-			       dova_a->fetch_iov.iov_len, shard_a,
-			       dova_b->fetch_iov.iov_len, shard_b);
-			return -DER_MISMATCH;
-		}
+	if (dova_a->fetch_iov.iov_len != dova_b->fetch_iov.iov_len) {
+		D_INFO(DF_OID" (reps %u, inconsistent) "
+		       "type %u, fetched %ld bytes from shard %u, "
+		       "but fetched %ld bytes from shard %u.\n",
+		       DP_OID(oid), reps, cur_a->type,
+		       dova_a->fetch_iov.iov_len, shard_a,
+		       dova_b->fetch_iov.iov_len, shard_b);
+		return -DER_MISMATCH;
+	}
 
-		if (memcmp(dova_a->fetch_iov.iov_buf, dova_b->fetch_iov.iov_buf,
-			   dova_a->fetch_iov.iov_len) != 0) {
-			D_INFO(DF_OID" (reps %u, inconsistent) "
-			       "type %u, shard %u and shard %u have "
-			       "different data, size %lu.\n",
-			       DP_OID(oid), reps, cur_a->type, shard_a, shard_b,
-			       dova_a->fetch_iov.iov_len);
-			return -DER_MISMATCH;
-		}
-
-		break;
-	default:
-		D_ASSERT(0);
+	if (memcmp(dova_a->fetch_iov.iov_buf, dova_b->fetch_iov.iov_buf,
+		   dova_a->fetch_iov.iov_len) != 0) {
+		D_INFO(DF_OID" (reps %u, inconsistent) "
+		       "type %u, shard %u and shard %u have "
+		       "different data, size %lu.\n",
+		       DP_OID(oid), reps, cur_a->type, shard_a, shard_b,
+		       dova_a->fetch_iov.iov_len);
+		return -DER_MISMATCH;
 	}
 
 	return 0;
@@ -640,6 +648,8 @@ dc_obj_verify_rdg(struct dc_object *obj, struct dc_obj_verify_args *dova,
 		memset(&dova[i].dkey_anchor, 0, sizeof(dova[i].dkey_anchor));
 		memset(&dova[i].akey_anchor, 0, sizeof(dova[i].akey_anchor));
 		dc_obj_shard2anchor(&dova[i].dkey_anchor, start + i);
+		daos_anchor_set_flags(&dova[i].dkey_anchor,
+				DIOF_TO_SPEC_SHARD | DIOF_WITH_SPEC_EPOCH);
 
 		dova[i].th = th;
 		dova[i].eof = 0;


### PR DESCRIPTION
Sometimes, we need to fetch data from specified shard, such as
for verifying replicas consistency. Under such case, the shard
corresponding to the dkey_hash should match the given shard.

Add dkey and akey consistency verification.

master-PR: 2086

Signed-off-by: Fan Yong <fan.yong@intel.com>