### PR TITLE
DAOS-2448 vos: add shadow extend/epoch for EC degraded fetch

### DIFF
--- a/src/include/daos/object.h
+++ b/src/include/daos/object.h
@@ -169,9 +169,9 @@ struct daos_obj_shard {
 };
 
 struct daos_obj_layout {
-	uint32_t	ol_ver;
-	uint32_t	ol_class;
-	uint32_t	ol_nr;
+	uint32_t		 ol_ver;
+	uint32_t		 ol_class;
+	uint32_t		 ol_nr;
 	struct daos_obj_shard	*ol_shards[0];
 };
 
@@ -406,5 +406,75 @@ struct obj_enum_rec {
 	uint32_t		rec_version;
 	uint32_t		rec_flags;
 };
+
+enum daos_recx_type {
+	/** normal valid recx */
+	DRT_NORMAL	= 0,
+	/** hole recx */
+	DRT_HOLE	= 1,
+	/**
+	 * shadow valid recx, only used for EC degraded fetch to indicate
+	 * recx on shadow, i.e need-to-be-recovered recx.
+	 */
+	DRT_SHADOW	= 2,
+};
+
+struct daos_recx_ep {
+	daos_recx_t		re_recx;
+	daos_epoch_t		re_ep;
+	enum daos_recx_type	re_type;
+};
+
+struct daos_recx_ep_list {
+	/** #valid items in re_items array */
+	uint32_t		 re_nr;
+	/** #total items (capacity) in re_items array */
+	uint32_t		 re_total;
+	/** epoch valid flag, re_items' re_ep can be ignored when it is false */
+	uint32_t		 re_ep_valid:1;
+	struct daos_recx_ep	*re_items;
+};
+
+static inline void
+daos_recx_ep_free(struct daos_recx_ep_list *list)
+{
+	if (list->re_items != NULL)
+		D_FREE(list->re_items);
+	list->re_nr = 0;
+	list->re_total = 0;
+}
+
+static inline void
+daos_recx_ep_list_free(struct daos_recx_ep_list *list, unsigned int nr)
+{
+	unsigned int	i;
+
+	for (i = 0; i < nr; i++)
+		daos_recx_ep_free(&list[i]);
+	D_FREE(list);
+}
+
+static inline int
+daos_recx_ep_add(struct daos_recx_ep_list *list, struct daos_recx_ep *recx)
+{
+	struct daos_recx_ep	*new_items;
+	uint32_t		 nr;
+
+	if (list->re_total == list->re_nr) {
+		nr = (list->re_total == 0) ? 8 : (2 * list->re_total);
+		if (list->re_total == 0)
+			D_ALLOC_ARRAY(new_items, nr);
+		else
+			D_REALLOC_ARRAY(new_items, list->re_items, nr);
+		if (new_items == NULL)
+			return -DER_NOMEM;
+		list->re_items = new_items;
+		list->re_total = nr;
+	}
+
+	D_ASSERT(list->re_total > list->re_nr);
+	list->re_items[list->re_nr++] = *recx;
+	return 0;
+}
 
 #endif /* __DD_OBJ_H__ */

--- a/src/include/daos_srv/vos.h
+++ b/src/include/daos_srv/vos.h
@@ -468,6 +468,15 @@ vos_obj_delete(daos_handle_t coh, daos_unit_oid_t oid);
 /**
  * I/O APIs
  */
+
+/**
+ * VOS fetch flags
+ * VOS_FETCH_SIZE_ONLY - only query iod_size
+ * VOS_FETCH_RECX_LIST - query recx list
+ */
+#define VOS_FETCH_SIZE_ONLY	(0x1UL << 0)
+#define VOS_FETCH_RECX_LIST	(0x1UL << 1)
+
 /**
  *
  * Find and return I/O source buffers for the data of the specified
@@ -483,14 +492,19 @@ vos_obj_delete(daos_handle_t coh, daos_unit_oid_t oid);
  * \param oid	[IN]	Object ID
  * \param epoch	[IN]	Epoch for the fetch. It will be ignored if epoch range
  *			is provided by \a iods.
- * \param flags [IN]	conditional flags
+ * \param cond_flags [IN]
+ *			conditional flags
  * \param dkey	[IN]	Distribution key.
  * \param nr	[IN]	Number of I/O descriptors in \a ios.
  * \param iods	[IN/OUT]
  *			Array of I/O descriptors. The returned record
  *			sizes are also restored in this parameter.
- * \param size_fetch[IN]
- *			Fetch size only
+ * \param fetch_flags [IN]
+ *			VOS fetch flags, VOS_FETCH_SIZE_ONLY or
+ *			VOS_FETCH_RECX_LIST.
+ * \param shadows [IN]	Optional shadow recx/epoch lists, one for each iod.
+ *			data of extents covered by these should not be returned
+ *			by fetch function. Only used for EC obj degraded fetch.
  * \param ioh	[OUT]	The returned handle for the I/O.
  * \param dth	[IN]	Pointer to the DTX handle.
  *
@@ -498,8 +512,9 @@ vos_obj_delete(daos_handle_t coh, daos_unit_oid_t oid);
  */
 int
 vos_fetch_begin(daos_handle_t coh, daos_unit_oid_t oid, daos_epoch_t epoch,
-		uint64_t flags, daos_key_t *dkey, unsigned int nr,
-		daos_iod_t *iods, bool size_fetch, daos_handle_t *ioh,
+		uint64_t cond_flags, daos_key_t *dkey, unsigned int nr,
+		daos_iod_t *iods, uint32_t fetch_flags,
+		struct daos_recx_ep_list *shadows, daos_handle_t *ioh,
 		struct dtx_handle *dth);
 
 /**
@@ -559,6 +574,16 @@ vos_update_begin(daos_handle_t coh, daos_unit_oid_t oid, daos_epoch_t epoch,
 int
 vos_update_end(daos_handle_t ioh, uint32_t pm_ver, daos_key_t *dkey, int err,
 	       struct dtx_handle *dth);
+
+/**
+ * Get the recx/epoch list.
+ *
+ * \param ioh	[IN]	The I/O handle.
+ *
+ * \return		recx/epoch list.
+ */
+struct daos_recx_ep_list *
+vos_ioh2recx_list(daos_handle_t ioh);
 
 /**
  * Get the I/O descriptor.

--- a/src/object/cli_obj.c
+++ b/src/object/cli_obj.c
@@ -1351,8 +1351,7 @@ obj_recx_valid(unsigned int nr, daos_recx_t *recxs, bool update)
 
 	if (nr == 0 || recxs == NULL)
 		return false;
-	/* only check recx overlap for update */
-	if (!update || nr == 1)
+	if (nr == 1)
 		return true;
 
 	switch (nr) {

--- a/src/object/srv_obj.c
+++ b/src/object/srv_obj.c
@@ -1096,13 +1096,16 @@ obj_local_rw(crt_rpc_t *rpc, struct ds_cont_hdl *cont_hdl,
 			goto out;
 		}
 	} else {
+		uint32_t	fetch_flags;
+
 		size_fetch = (!rma && orw->orw_sgls.ca_arrays == NULL);
+		fetch_flags = size_fetch ? VOS_FETCH_SIZE_ONLY : 0;
 		bulk_op = CRT_BULK_PUT;
 
 		rc = vos_fetch_begin(cont->sc_hdl, orw->orw_oid, orw->orw_epoch,
 				     orw->orw_api_flags | VOS_OF_USE_TIMESTAMPS,
-				     dkey, orw->orw_nr, iods, size_fetch, &ioh,
-				     dth);
+				     dkey, orw->orw_nr, iods, fetch_flags, NULL,
+				     &ioh, dth);
 		if (rc) {
 			D_CDEBUG(rc == -DER_INPROGRESS, DB_IO, DLOG_ERR,
 				 "Fetch begin for "DF_UOID" failed: "DF_RC"\n",

--- a/src/rdb/rdb_util.c
+++ b/src/rdb/rdb_util.c
@@ -334,7 +334,7 @@ rdb_vos_fetch_addr(daos_handle_t cont, daos_epoch_t epoch, rdb_oid_t oid,
 	rdb_oid_to_uoid(oid, &uoid);
 	rdb_vos_set_iods(RDB_VOS_QUERY, 1 /* n */, akey, value, &iod);
 	rc = vos_fetch_begin(cont, uoid, epoch, 0 /* flags */, &rdb_dkey,
-			     1 /* n */, &iod, false /* size_fetch */, &io,
+			     1 /* n */, &iod, 0 /* fetch_flags */, NULL, &io,
 			     NULL /* dth */);
 	if (rc != 0)
 		return rc;

--- a/src/tests/daos_perf.c
+++ b/src/tests/daos_perf.c
@@ -200,7 +200,7 @@ _vos_update_or_fetch(enum ts_op_type op_type, struct dts_io_credit *cred,
 			rc = vos_fetch_begin(ts_ctx.tsc_coh, ts_uoid, epoch,
 					     VOS_OF_USE_TIMESTAMPS,
 					     &cred->tc_dkey, 1, &cred->tc_iod,
-					     false, &ioh, NULL);
+					     0, NULL, &ioh, NULL);
 		if (rc)
 			return rc;
 

--- a/src/vos/tests/vts_checksum.c
+++ b/src/vos/tests/vts_checksum.c
@@ -189,7 +189,7 @@ csum_for_arrays_test_case(void *const *state, struct test_case_args test)
 	 * how the server object layer already interfaces with VOS)
 	 */
 	vos_fetch_begin(k.container_hdl, k.object_id, 1, 0, &k.dkey, 1, &iod,
-			false, &ioh, NULL);
+			0, NULL, &ioh, NULL);
 
 	biod = vos_ioh2desc(ioh);
 	bsgl = bio_iod_sgl(biod, 0);

--- a/src/vos/tests/vts_dtx.c
+++ b/src/vos/tests/vts_dtx.c
@@ -568,7 +568,7 @@ dtx_16(void **state)
 	iod.iod_size = DAOS_REC_ANY;
 
 	rc = vos_fetch_begin(args->ctx.tc_co_hdl, args->oid, epoch,
-			     0, &dkey_iov, 1, &iod, false, &ioh, NULL);
+			     0, &dkey_iov, 1, &iod, 0, NULL, &ioh, NULL);
 	/* The former DTX is not committed, so need to retry with leader. */
 	assert_int_equal(rc, -DER_INPROGRESS);
 

--- a/src/vos/tests/vts_io.c
+++ b/src/vos/tests/vts_io.c
@@ -618,7 +618,7 @@ io_test_obj_fetch(struct io_test_args *arg, daos_epoch_t epoch, uint64_t flags,
 	}
 
 	rc = vos_fetch_begin(arg->ctx.tc_co_hdl, arg->oid, epoch, flags, dkey,
-			     1, iod, false, &ioh, NULL);
+			     1, iod, 0, NULL, &ioh, NULL);
 	if (rc != 0) {
 		if (verbose && rc != -DER_INPROGRESS)
 			print_error("Failed to prepare ZC update: "DF_RC"\n",

--- a/src/vos/vos_io.c
+++ b/src/vos/vos_io.c
@@ -74,7 +74,19 @@ struct vos_io_context {
 	bool			 ic_read_conflict;
 	/** flags */
 	unsigned int		 ic_update:1,
-				 ic_size_fetch:1;
+				 ic_size_fetch:1,
+				 ic_save_recx:1;
+	/**
+	 * Input shadow recx lists, one for each iod. Now only used for degraded
+	 * mode EC obj fetch handling.
+	 */
+	struct daos_recx_ep_list *ic_shadows;
+	/**
+	 * Output recx/epoch lists, one for each iod. To save the recx list when
+	 * vos_fetch_begin() with VOS_FETCH_RECX_LIST flag. User can get it by
+	 * vos_ioh2recx_list() and should free it by daos_recx_ep_list_free().
+	 */
+	struct daos_recx_ep_list *ic_recx_lists;
 };
 
 static inline struct umem_instance *
@@ -189,9 +201,10 @@ vos_ioc_destroy(struct vos_io_context *ioc, bool evict)
 
 static int
 vos_ioc_create(daos_handle_t coh, daos_unit_oid_t oid, bool read_only,
-	       daos_epoch_t epoch, uint64_t flags, unsigned int iod_nr,
+	       daos_epoch_t epoch, uint64_t cond_flags, unsigned int iod_nr,
 	       daos_iod_t *iods, struct dcs_iod_csums *iod_csums,
-	       bool size_fetch, struct vos_io_context **ioc_pp)
+	       uint32_t fetch_flags, struct daos_recx_ep_list *shadows,
+	       struct vos_io_context **ioc_pp)
 {
 	struct vos_container *cont;
 	struct vos_io_context *ioc = NULL;
@@ -216,19 +229,21 @@ vos_ioc_create(daos_handle_t coh, daos_unit_oid_t oid, bool read_only,
 	ioc->ic_cont = vos_hdl2cont(coh);
 	vos_cont_addref(ioc->ic_cont);
 	ioc->ic_update = !read_only;
-	ioc->ic_size_fetch = size_fetch;
+	ioc->ic_size_fetch = fetch_flags & VOS_FETCH_SIZE_ONLY;
+	ioc->ic_save_recx = fetch_flags & VOS_FETCH_RECX_LIST;
 	ioc->ic_read_conflict = false;
 	ioc->ic_umoffs_cnt = ioc->ic_umoffs_at = 0;
 	ioc->iod_csums = iod_csums;
 	vos_ilog_fetch_init(&ioc->ic_dkey_info);
 	vos_ilog_fetch_init(&ioc->ic_akey_info);
 	D_INIT_LIST_HEAD(&ioc->ic_blk_exts);
+	ioc->ic_shadows = shadows;
 
 	rc = vos_ioc_reserve_init(ioc);
 	if (rc != 0)
 		goto error;
 
-	rc = vos_ts_set_allocate(&ioc->ic_ts_set, flags, iod_nr);
+	rc = vos_ts_set_allocate(&ioc->ic_ts_set, cond_flags, iod_nr);
 	if (rc != 0)
 		goto error;
 
@@ -445,10 +460,36 @@ biov_align_lens(struct bio_iov *biov, struct evt_entry *ent, daos_size_t rsize)
 			  rsize);
 }
 
+/**
+ * Save to recx/ep list, user can get it by vos_ioh2recx_list() and then free
+ * the memory.
+ */
+static int
+save_recx(struct vos_io_context *ioc, uint64_t rx_idx, uint64_t rx_nr,
+	  daos_epoch_t ep, int type)
+{
+	struct daos_recx_ep_list	*recx_list;
+	struct daos_recx_ep		 recx_ep;
+
+	if (ioc->ic_recx_lists == NULL) {
+		D_ALLOC_ARRAY(ioc->ic_recx_lists, ioc->ic_iod_nr);
+		if (ioc->ic_recx_lists == NULL)
+			return -DER_NOMEM;
+	}
+
+	recx_list = &ioc->ic_recx_lists[ioc->ic_sgl_at];
+	recx_ep.re_recx.rx_idx = rx_idx;
+	recx_ep.re_recx.rx_nr = rx_nr;
+	recx_ep.re_ep = ep;
+	recx_ep.re_type = type;
+
+	return daos_recx_ep_add(recx_list, &recx_ep);
+}
+
 /** Fetch an extent from an akey */
 static int
 akey_fetch_recx(daos_handle_t toh, const daos_epoch_range_t *epr,
-		daos_recx_t *recx, daos_size_t *rsize_p,
+		daos_recx_t *recx, daos_epoch_t shadow_ep, daos_size_t *rsize_p,
 		struct vos_io_context *ioc)
 {
 	struct evt_entry	*ent;
@@ -463,6 +504,7 @@ akey_fetch_recx(daos_handle_t toh, const daos_epoch_range_t *epr,
 	daos_off_t		 index;
 	daos_off_t		 end;
 	bool			 csum_enabled = false;
+	bool			 with_shadow = (shadow_ep != DAOS_EPOCH_MAX);
 	int			 rc;
 
 	index = recx->rx_idx;
@@ -494,13 +536,21 @@ akey_fetch_recx(daos_handle_t toh, const daos_epoch_range_t *epr,
 			holes += lo - index;
 		}
 
-		if (bio_addr_is_hole(&ent->en_addr)) { /* hole extent */
+		/* Hole extent, with_shadow case only used for EC obj */
+		if (bio_addr_is_hole(&ent->en_addr) ||
+		    (with_shadow && (ent->en_epoch < shadow_ep))) {
 			index = lo + nr;
 			holes += nr;
 			continue;
 		}
 
 		if (holes != 0) {
+			if (with_shadow) {
+				rc = save_recx(ioc, lo - holes, holes,
+					       shadow_ep, DRT_SHADOW);
+				if (rc != 0)
+					goto failed;
+			}
 			biov_set_hole(&biov, holes * ent_array.ea_inob);
 			/* skip the hole */
 			rc = iod_fetch(ioc, &biov);
@@ -513,6 +563,11 @@ akey_fetch_recx(daos_handle_t toh, const daos_epoch_range_t *epr,
 			rsize = ent_array.ea_inob;
 		D_ASSERT(rsize == ent_array.ea_inob);
 
+		if (ioc->ic_save_recx) {
+			rc = save_recx(ioc, lo, nr, ent->en_epoch, DRT_NORMAL);
+			if (rc != 0)
+				goto failed;
+		}
 		bio_iov_set(&biov, ent->en_addr, nr * ent_array.ea_inob);
 
 		if (ci_is_valid(&ent->en_csum)) {
@@ -540,12 +595,18 @@ akey_fetch_recx(daos_handle_t toh, const daos_epoch_range_t *epr,
 		holes += end - index;
 
 	if (holes != 0) { /* trailing holes */
+		if (with_shadow) {
+			rc = save_recx(ioc, end - holes, holes, shadow_ep,
+				       DRT_SHADOW);
+			if (rc != 0)
+				goto failed;
+		}
 		biov_set_hole(&biov, holes * ent_array.ea_inob);
 		rc = iod_fetch(ioc, &biov);
 		if (rc != 0)
 			goto failed;
 	}
-	if (rsize_p)
+	if (rsize_p && *rsize_p == 0)
 		*rsize_p = rsize;
 failed:
 	evt_ent_array_fini(&ent_array);
@@ -602,6 +663,42 @@ out:
 	return rc;
 }
 
+static void
+akey_fetch_recx_get(daos_recx_t *iod_recx, struct daos_recx_ep_list *shadow,
+		    daos_recx_t *fetch_recx, daos_epoch_t *shadow_ep)
+{
+	struct daos_recx_ep	*recx_ep;
+	daos_recx_t		*recx;
+	uint32_t		 i;
+
+	if (shadow == NULL)
+		goto no_shadow;
+
+	for (i = 0; i < shadow->re_nr; i++) {
+		recx_ep = &shadow->re_items[i];
+		recx = &recx_ep->re_recx;
+		if (!DAOS_RECX_PTR_OVERLAP(iod_recx, recx))
+			continue;
+
+		fetch_recx->rx_idx = iod_recx->rx_idx;
+		fetch_recx->rx_nr = min((iod_recx->rx_idx + iod_recx->rx_nr),
+					(recx->rx_idx + recx->rx_nr)) -
+				    iod_recx->rx_idx;
+		iod_recx->rx_idx += fetch_recx->rx_nr;
+		iod_recx->rx_nr -= fetch_recx->rx_nr;
+		*shadow_ep = recx_ep->re_ep;
+		D_ASSERT(fetch_recx->rx_nr > 0 &&
+			 fetch_recx->rx_nr <= iod_recx->rx_nr);
+		return;
+	}
+
+no_shadow:
+	*fetch_recx = *iod_recx;
+	iod_recx->rx_idx += fetch_recx->rx_nr;
+	iod_recx->rx_nr -= fetch_recx->rx_nr;
+	*shadow_ep = DAOS_EPOCH_MAX;
+}
+
 static int
 akey_fetch(struct vos_io_context *ioc, daos_handle_t ak_toh)
 {
@@ -612,6 +709,7 @@ akey_fetch(struct vos_io_context *ioc, daos_handle_t ak_toh)
 	int			 i, rc;
 	int			 flags = 0;
 	bool			 is_array = (iod->iod_type == DAOS_IOD_ARRAY);
+	struct daos_recx_ep_list *shadow;
 
 	D_DEBUG(DB_IO, "akey "DF_KEY" fetch %s epr "DF_X64"-"DF_X64"\n",
 		DP_KEY(&iod->iod_name),
@@ -667,8 +765,13 @@ akey_fetch(struct vos_io_context *ioc, daos_handle_t ak_toh)
 	}
 
 	iod->iod_size = 0;
+	shadow = (ioc->ic_shadows == NULL) ? NULL :
+					     &ioc->ic_shadows[ioc->ic_sgl_at];
 	for (i = 0; i < iod->iod_nr; i++) {
-		daos_size_t rsize;
+		daos_recx_t	iod_recx;
+		daos_recx_t	fetch_recx;
+		daos_epoch_t	shadow_ep;
+		daos_size_t	rsize = 0;
 
 		if (iod->iod_recxs[i].rx_nr == 0) {
 			D_DEBUG(DB_IO,
@@ -678,12 +781,17 @@ akey_fetch(struct vos_io_context *ioc, daos_handle_t ak_toh)
 			continue;
 		}
 
-		rc = akey_fetch_recx(toh, &val_epr, &iod->iod_recxs[i], &rsize,
-				     ioc);
-		if (rc != 0) {
-			D_DEBUG(DB_IO, "Failed to fetch index %d: "DF_RC"\n", i,
-				DP_RC(rc));
-			goto out;
+		iod_recx = iod->iod_recxs[i];
+		while (iod_recx.rx_nr > 0) {
+			akey_fetch_recx_get(&iod_recx, shadow, &fetch_recx,
+					    &shadow_ep);
+			rc = akey_fetch_recx(toh, &val_epr, &fetch_recx,
+					     shadow_ep, &rsize, ioc);
+			if (rc != 0) {
+				D_DEBUG(DB_IO, "Failed to fetch index %d: "
+					DF_RC"\n", i, DP_RC(rc));
+				goto out;
+			}
 		}
 
 		/*
@@ -852,19 +960,20 @@ update_prev:
 
 int
 vos_fetch_begin(daos_handle_t coh, daos_unit_oid_t oid, daos_epoch_t epoch,
-		uint64_t flags, daos_key_t *dkey, unsigned int iod_nr,
-		daos_iod_t *iods, bool size_fetch, daos_handle_t *ioh,
+		uint64_t cond_flags, daos_key_t *dkey, unsigned int iod_nr,
+		daos_iod_t *iods, uint32_t fetch_flags,
+		struct daos_recx_ep_list *shadows, daos_handle_t *ioh,
 		struct dtx_handle *dth)
 {
 	struct vos_io_context	*ioc;
 	struct vos_ts_entry	*entry;
-	int i, rc;
+	int			 i, rc;
 
 	D_DEBUG(DB_TRACE, "Fetch "DF_UOID", desc_nr %d, epoch "DF_X64"\n",
 		DP_UOID(oid), iod_nr, epoch);
 
-	rc = vos_ioc_create(coh, oid, true, epoch, flags, iod_nr, iods, NULL,
-			    size_fetch, &ioc);
+	rc = vos_ioc_create(coh, oid, true, epoch, cond_flags, iod_nr, iods,
+			    NULL, fetch_flags, shadows, &ioc);
 	if (rc != 0)
 		return rc;
 
@@ -1691,7 +1800,7 @@ vos_update_begin(daos_handle_t coh, daos_unit_oid_t oid, daos_epoch_t epoch,
 		"\n", DP_UOID(oid), iod_nr, dth ? dth->dth_epoch :  epoch);
 
 	rc = vos_ioc_create(coh, oid, false, dth ? dth->dth_epoch : epoch,
-			    flags, iod_nr, iods, iods_csums, false, &ioc);
+			    flags, iod_nr, iods, iods_csums, 0, NULL, &ioc);
 	if (rc != 0)
 		return rc;
 
@@ -1714,6 +1823,12 @@ vos_update_begin(daos_handle_t coh, daos_unit_oid_t oid, daos_epoch_t epoch,
 error:
 	vos_update_end(vos_ioc2ioh(ioc), 0, dkey, rc, dth);
 	return rc;
+}
+
+struct daos_recx_ep_list *
+vos_ioh2recx_list(daos_handle_t ioh)
+{
+	return vos_ioh2ioc(ioh)->ic_recx_lists;
 }
 
 struct bio_desc *
@@ -1816,12 +1931,13 @@ vos_obj_fetch(daos_handle_t coh, daos_unit_oid_t oid, daos_epoch_t epoch,
 	      uint64_t flags, daos_key_t *dkey, unsigned int iod_nr,
 	      daos_iod_t *iods, d_sg_list_t *sgls)
 {
-	daos_handle_t ioh;
-	bool size_fetch = (sgls == NULL);
-	int rc;
+	daos_handle_t	ioh;
+	bool		size_fetch = (sgls == NULL);
+	uint32_t	fetch_flags = size_fetch ? VOS_FETCH_SIZE_ONLY : 0;
+	int		rc;
 
 	rc = vos_fetch_begin(coh, oid, epoch, flags, dkey, iod_nr, iods,
-			     size_fetch, &ioh, NULL);
+			     fetch_flags, NULL, &ioh, NULL);
 	if (rc) {
 		if (rc == -DER_INPROGRESS)
 			D_DEBUG(DB_TRACE, "Cannot fetch "DF_UOID" because of "


### PR DESCRIPTION
Add VOS level shadow related handing for EC degraded fetch, it will be
used as -
1. client send degraded fetch request to parity target.
2. on parity server -
   2.1 query parity space the exist parity extend, by using the added
       VOS_FETCH_RECX_LIST.
   2.2 fetch the data space, with the shadow list got at step 2.1
   2.3 transfer back the data above shadow, and reply the
       recx_list@shadow.
3. if recx_list@shadow is non-empty, client need to reconstruct the
   missed data.

Signed-off-by: Xuezhao Liu <xuezhao.liu@intel.com>