### PR TITLE
DAOS-1965 md: Fix regression on metadata_add_remove test

### DIFF
--- a/src/tests/ftest/server/metadata.py
+++ b/src/tests/ftest/server/metadata.py
@@ -45,7 +45,7 @@ from server_utils import run_server, stop_server
 from write_host_file import write_host_file
 from test_utils_pool import TestPool
 
-NO_OF_MAX_CONTAINER = 14286
+NO_OF_MAX_CONTAINER = 13034
 
 def ior_runner_thread(manager, uuids, results):
     """IOR run thread method.


### PR DESCRIPTION
The maximum number of containers created before which metadata space
becomes exhausted has changed (lower) due to changes in DAOS both on
the master branch and release/0.9 branches. This has led to CI test
regressions. Lower the value of the constant in the test to 98% of
the lowest observed number of containers, factoring in differences
in behavior across the two branches.

Skip-run_test: true
Skip-func-test: true
Skip-func-hw-test-small: true
Skip-func-hw-test-medium: true
Test-tag-hw-large: metadata_free_space

Signed-off-by: Ken Cain <kenneth.c.cain@intel.com>