### PR TITLE
DAOS-WIP: Make number parsing helper more generic

### DIFF
--- a/src/control/cmd/dmg/pool.go
+++ b/src/control/cmd/dmg/pool.go
@@ -103,8 +103,8 @@ func (c *PoolCreateCmd) Execute(args []string) error {
 		return errors.WithMessage(err, "formatting user/group strings")
 	}
 
-	ranks, err := common.ParseInts(c.RankList)
-	if err != nil {
+	var ranks []uint32
+	if err := common.ParseNumberList(c.RankList, &ranks); err != nil {
 		return errors.WithMessage(err, "parsing rank list")
 	}
 

--- a/src/control/cmd/dmg/system.go
+++ b/src/control/cmd/dmg/system.go
@@ -148,8 +148,8 @@ type systemQueryCmd struct {
 
 // Execute is run when systemQueryCmd activates
 func (cmd *systemQueryCmd) Execute(_ []string) error {
-	ranks, err := common.ParseInts(cmd.Ranks)
-	if err != nil {
+	var ranks []uint32
+	if err := common.ParseNumberList(cmd.Ranks, &ranks); err != nil {
 		return errors.Wrap(err, "parsing input ranklist")
 	}
 

--- a/src/control/common/collection_utils.go
+++ b/src/control/common/collection_utils.go
@@ -27,6 +27,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"unicode"
+
+	"github.com/pkg/errors"
 )
 
 // Includes returns true if string target in slice.
@@ -102,8 +104,20 @@ func Pluralise(s string, n int) string {
 	return s + "s"
 }
 
-// ParseInts converts string of uint32s to uint32 array.
-func ParseInts(in string) (ints []uint32, err error) {
-	str := fmt.Sprintf("[%s]", in)
-	return ints, json.Unmarshal([]byte(str), &ints)
+// ParseNumberList converts a comma-separated string of numbers to a slice.
+func ParseNumberList(stringList string, output interface{}) error {
+	str := fmt.Sprintf("[%s]", stringList)
+	if err := json.Unmarshal([]byte(str), output); err != nil {
+		// return more user-friendly errors for malformed inputs
+		switch je := err.(type) {
+		case *json.SyntaxError:
+			return errors.Errorf("unable to parse %q: must be a comma-separated list of numbers", stringList)
+		case *json.UnmarshalTypeError:
+			return errors.Errorf("invalid input: %s can not be stored in %s", je.Value, je.Type)
+		default:
+			// other errors are more likely to be programmer-caused
+			return err
+		}
+	}
+	return nil
 }

--- a/src/control/common/collection_utils_test.go
+++ b/src/control/common/collection_utils_test.go
@@ -1,3 +1,26 @@
+//
+// (C) Copyright 2020 Intel Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// GOVERNMENT LICENSE RIGHTS-OPEN SOURCE SOFTWARE
+// The Government's rights to use, modify, reproduce, release, perform, display,
+// or disclose this software are subject to the terms of the Apache License as
+// provided in Contract No. 8F-30005.
+// Any reproduction of computer software, computer software documentation, or
+// portions thereof marked with this legend must also reproduce the markings.
+//
+
 package common
 
 import (
@@ -7,27 +30,88 @@ import (
 	"github.com/pkg/errors"
 )
 
-func TestCommon_ParseInts(t *testing.T) {
+func TestCommon_ParseNumberListUint32(t *testing.T) {
 	for name, tc := range map[string]struct {
-		ints    string
-		expInts []uint32
-		expErr  error
+		input     string
+		expOutput []uint32
+		expErr    error
 	}{
 		"empty":              {"", []uint32{}, nil},
 		"valid single":       {"0", []uint32{0}, nil},
 		"valid multiple":     {"0,1,2,3", []uint32{0, 1, 2, 3}, nil},
-		"invalid alphabetic": {"0,A,", nil, errors.New("invalid character 'A' looking for beginning of value")},
-		"invalid negative":   {"-1", nil, errors.New("json: cannot unmarshal number -1 into Go value of type uint32")},
+		"invalid alphabetic": {"0,A,", nil, errors.New("unable to parse")},
+		"invalid negative":   {"-1", nil, errors.New("invalid input")},
+		"invalid float":      {"5.5", nil, errors.New("invalid input")},
+		"overflows uint32":   {"4294967296", nil, errors.New("invalid input")},
 	} {
 		t.Run(name, func(t *testing.T) {
-			gotInts, gotErr := ParseInts(tc.ints)
+			var gotOutput []uint32
+			gotErr := ParseNumberList(tc.input, &gotOutput)
 			CmpErr(t, tc.expErr, gotErr)
 			if tc.expErr != nil {
 				return
 			}
-			if diff := cmp.Diff(tc.expInts, gotInts); diff != "" {
+			if diff := cmp.Diff(tc.expOutput, gotOutput); diff != "" {
 				t.Fatalf("unexpected integer list (-want, +got):\n%s\n", diff)
 			}
 		})
 	}
+}
+
+func TestCommon_ParseNumberListInt(t *testing.T) {
+	for name, tc := range map[string]struct {
+		input     string
+		expOutput []int
+		expErr    error
+	}{
+		"empty":              {"", []int{}, nil},
+		"valid single":       {"0", []int{0}, nil},
+		"valid multiple":     {"0,1,2,3", []int{0, 1, 2, 3}, nil},
+		"valid negative":     {"-1", []int{-1}, nil},
+		"invalid alphabetic": {"0,A,", nil, errors.New("unable to parse")},
+	} {
+		t.Run(name, func(t *testing.T) {
+			var gotOutput []int
+			gotErr := ParseNumberList(tc.input, &gotOutput)
+			CmpErr(t, tc.expErr, gotErr)
+			if tc.expErr != nil {
+				return
+			}
+			if diff := cmp.Diff(tc.expOutput, gotOutput); diff != "" {
+				t.Fatalf("unexpected integer list (-want, +got):\n%s\n", diff)
+			}
+		})
+	}
+}
+
+func TestCommon_ParseNumberListFloat64(t *testing.T) {
+	for name, tc := range map[string]struct {
+		input     string
+		expOutput []float64
+		expErr    error
+	}{
+		"empty":              {"", []float64{}, nil},
+		"valid single":       {"0", []float64{0}, nil},
+		"valid multiple":     {"0,1,2,3", []float64{0, 1, 2, 3}, nil},
+		"valid float":        {"5.5", []float64{5.5}, nil},
+		"valid negative":     {"-1", []float64{-1}, nil},
+		"invalid alphabetic": {"0,A,", nil, errors.New("unable to parse")},
+	} {
+		t.Run(name, func(t *testing.T) {
+			var gotOutput []float64
+			gotErr := ParseNumberList(tc.input, &gotOutput)
+			CmpErr(t, tc.expErr, gotErr)
+			if tc.expErr != nil {
+				return
+			}
+			if diff := cmp.Diff(tc.expOutput, gotOutput); diff != "" {
+				t.Fatalf("unexpected integer list (-want, +got):\n%s\n", diff)
+			}
+		})
+	}
+}
+
+func TestCommon_ParseNumberListBadReceiver(t *testing.T) {
+	gotErr := ParseNumberList("1,2,3", nil)
+	CmpErr(t, errors.New("json: Unmarshal"), gotErr)
 }


### PR DESCRIPTION
Rename common.ParseInts() -> common.ParseNumberList(). Receiver
slice type set by caller.