### PR TITLE
DAOS-2603 doc: Document container ACLs

### DIFF
--- a/doc/admin/pool_operations.md
+++ b/doc/admin/pool_operations.md
@@ -120,6 +120,9 @@ Access-controlled client pool accesses include:
 This is reflected in the set of supported 
 [pool permissions](/doc/user/acl.md#permissions).
 
+A user must be able to connect to the pool in order to access any containers
+inside, regardless of their permissions on those containers.
+
 ### Creating a pool with a custom ACL
 
 To create a pool with a custom ACL:

--- a/doc/admin/pool_operations.md
+++ b/doc/admin/pool_operations.md
@@ -106,77 +106,19 @@ be provided in a future release.
 
 ## Pool Access Control Lists
 
-User and group access for pools is controlled by Access Control Lists (ACLs).
-A DAOS ACL is a list of zero or more Access Control Entries (ACEs). ACEs are
-the individual rules applied to each access decision.
+Client user and group access for pools is controlled by 
+[Access Control Lists (ACLs)](/doc/user/acl.md). Most pool-related tasks are
+performed using the DMG administrative tool, which is authenticated by the
+administrative certificate rather than user-specific credentials.
 
-If no ACL is provided when creating the pool, the default ACL grants read and
-write access to the pool's owner-user and owner-group.
+Access-controlled client pool accesses include:
+* Connecting to the pool.
+* Querying the pool.
+* Creating containers in the pool.
+* Deleting containers in the pool.
 
-### Access Control Entries
-
-ACEs are designated by a colon-separated string format:
-`TYPE:FLAGS:IDENTITY:PERMISSIONS`
-
-Available values for these fields:
-
-* TYPE: Allow (A)
-* FLAGS: Group (G)
-* IDENTITY: See below
-* PERMISSIONS: Read (r), Write (w)
-
-#### Identity
-
-The identity (also called the principal) is specified in the name@domain format.
-The domain should be left off if the name is a user/group on the local domain.
-Currently, this is the only case supported by DAOS.
-
-There are three special identities, `OWNER@`, `GROUP@` and `EVERYONE@`,
-which align with User, Group, and Other from traditional POSIX permission bits.
-When providing them in the ACE string format, they must be spelled exactly as
-written here, in uppercase with no domain appended.
-
-#### Examples
-
-* `A::daos_user@:rw`
-  * Allow the UNIX user named daos_user to have read-write access
-* `A:G:project_users@:r`
-  * Allow anyone in the UNIX group project_users to have read-only access
-* `A::EVERYONE@:r`
-  * Allow any user not covered by other rules to have read-only access
-
-### Enforcement
-
-Access Control Entries (ACEs) will be enforced in the following order:
-
-* Owner-User
-* Named users
-* Owner-Group and named groups
-* Everyone
-
-In general, enforcement will be based on the first match, ignoring
-lower-priority entries. For example, if the user has an ACE for their user
-identity, they will not receive the permissions for any of their groups, even if
-those group entries have broader permissions than the user entry does. The user
-is expected to match at most one user entry.
-
-If no matching user entry is found, but entries match one or more of the user's
-groups, enforcement will be based on the union of the permissions of all
-matching groups.
-
-By default, if a user matches no ACEs in the list, access will be denied.
-
-### Limitations
-
-The maximum length of the ACE list in a DAOS ACL structure is 64KiB.
-
-To calculate the actual length of an ACL, use the following formula for each
-ACE:
-
-* The base size of an ACE is 256B.
-* If the ACE principal is *not* one of the special principals:
-  * Add the length of the identity string + 1.
-  * If that value is not 64B aligned, round up to the nearest 64B boundary.
+This is reflected in the set of supported 
+[pool permissions](/doc/user/acl.md#permissions).
 
 ### Creating a pool with a custom ACL
 
@@ -186,18 +128,7 @@ To create a pool with a custom ACL:
 $ dmg pool create --scm-size <size> --acl-file <path>
 ```
 
-The ACL file is expected to be a text file with one ACE listed on each line. For
-example:
-
-```bash
-# Entries:
-A::OWNER@:rw
-A:G:GROUP@:rw
-# Everyone should be allowed to read
-A::EVERYONE@:r
-```
-
-You may add comments to the ACL file by starting the line with `#`.
+The ACL file format is detailed in the [User Guide](/doc/user/acl.md#acl-file).
 
 ### Displaying a pool's ACL
 

--- a/doc/admin/pool_operations.md
+++ b/doc/admin/pool_operations.md
@@ -174,13 +174,13 @@ is replaced with the new one.
 
 #### Removing an entry from the ACL
 
-To delete an entry for a given principal, or identity, in an existing pool ACL:
+To delete an entry for a given principal in an existing pool ACL:
 
 ```bash
 $ dmg pool delete-acl --pool <UUID> --principal <principal>
 ```
 
-The principal corresponds to the principal/identity portion of an ACE that was
+The principal corresponds to the principal portion of an ACE that was
 set during pool creation or a previous pool ACL operation. For the delete
 operation, the principal argument must be formatted as follows:
 

--- a/doc/user/acl.md
+++ b/doc/user/acl.md
@@ -1,0 +1,150 @@
+# DAOS Access Control
+
+Client access to DAOS resources like pools and containers is controlled by
+Access Control Lists (ACLs). A DAOS ACL is a list of zero or more Access Control
+Entries (ACEs). ACEs are the individual rules applied to each access decision.
+
+## Access Control Entries
+
+In the input and output of DAOS tools, an ACE is defined using a colon-separated
+string format:\
+`TYPE:FLAGS:IDENTITY:PERMISSIONS`
+
+The contents of all the fields are case-sensitive.
+
+### Type
+
+The type of entry. Only one type of ACE is supported at this time.
+
+* A (Allow): Allow access to the specified identity for the given permissions.
+
+### Flags
+
+The flags provide additional information about how the ACE should be
+interpreted.
+
+* G (Group): The identity should be interpreted as a group.
+
+### Identity
+
+The identity (also called the principal) is specified in the name@domain format.
+The domain should be left off if the name is a UNIX user/group on the local
+domain. Currently, this is the only case supported by DAOS.
+
+There are three special identities, `OWNER@`, `GROUP@` and `EVERYONE@`,
+which align with User, Group, and Other from traditional POSIX permission bits.
+When providing them in the ACE string format, they must be spelled exactly as
+written here, in uppercase with no domain appended. The `GROUP@` entry must
+also have the `G` (group) flag.
+
+### Permissions
+
+The permissions in a resource's ACL permit a certain type of user access to
+the resource. Which types of permissions are valid depends on the resource
+type.
+
+| Permission	| Pool Meaning		| Container Meaning		|
+| ------------- | --------------------- | ----------------------------- |
+| r (Read)	| Alias for 't'		| Read data and attributes	|
+| w (Write)	| Alias for 'c' + 'd'	| Write data and attributes	|
+| c (Create)	| Create containers	| N/A				|
+| d (Delete)	| Delete any container	| Delete this container		|
+| t (Get-Prop)	| Connect/query		| Get container properties	|
+| T (Set-Prop)	| N/A			| Change container properties	|
+| a (Get-ACL)	| N/A			| Get container ACL		|
+| A (Set-ACL)	| N/A			| Change container ACL		|
+| o (Set-Owner)	| N/A			| Change owner user and group	|
+
+ACLs containing permissions not applicable to the given resource are considered
+invalid.
+
+In general a user/group's permissions must include at least some form of
+read access (for example, read or get-prop) before the user will be allowed to
+connect. A user with read-only *or* write-only permissions will be rejected when
+requesting RW access to a resource.
+
+### Denying Access
+
+Currently only "Allow" Access Control Entries are supported.
+
+However, it is possible to deny access to a specific user by creating an Allow
+entry for them with no permissions. This is fundamentally different from
+removing a user's ACE, which allows other ACEs in the ACL to determine their
+access.
+
+It is not possible to deny access to a specific group in this way, due to
+[the way group permissions are enforced](#enforcement).
+
+### ACE Examples
+
+* `A::daos_user@:rw`
+  * Allow the UNIX user named daos_user to have read-write access.
+* `A:G:project_users@:tc`
+  * Allow anyone in the UNIX group project_users to access a pool's contents and
+    create containers.
+* `A::OWNER@:rwdtTaAo`
+  * Allow the UNIX user who owns the container to have full control.
+* `A::EVERYONE@:r`
+  * Allow any user not covered by other rules to have read-only access.
+* `A::daos_user@:`
+  * Deny the UNIX user named daos_user any access to the resource.
+
+## Enforcement
+
+Access Control Entries (ACEs) will be enforced in the following order:
+
+* Owner-User
+* Named users
+* Owner-Group and named groups
+* Everyone
+
+In general, enforcement will be based on the first match, ignoring
+lower-priority entries. For example, if the user has an ACE for their user
+identity, they will not receive the permissions for any of their groups, even if
+those group entries have broader permissions than the user entry does. The user
+is expected to match at most one user entry.
+
+If no matching user entry is found, but entries match one or more of the user's
+groups, enforcement will be based on the union of the permissions of all
+matching groups.
+
+If no matching groups are found, the "Everyone" entry's permissions will be
+used, if it exists.
+
+By default, if a user matches no ACEs in the list, access will be denied.
+
+## ACL File
+
+Tools that accept an ACL file expect it to be a simple text file with one ACE
+on each line. A line may be marked as a comment by adding a `#` as the first
+non-whitespace character on the line.
+
+For example:
+
+```
+# ACL for my container
+# Owner can't touch data - just do admin-type things
+A::OWNER@:dtTaAo
+# My project's users can generate and access data
+A:G:my_great_project@:rw
+# Bob can use the data to generate a report
+A::bob@:r
+```
+
+That the permission bits and the ACEs themselves don't need to be in any
+specific order. However the order may be different when the resulting ACL is
+parsed and displayed by DAOS.
+
+## Limitations
+
+The maximum size of the ACE list in a DAOS ACL internal data structure is 64KiB.
+
+To calculate the internal data size of an ACL, use the following formula for
+each ACE:
+
+* The base size of an ACE is 256 bytes.
+* If the ACE principal is *not* one of the special principals:
+  * Add the length of the identity string + 1.
+  * If that value is not 64-byte aligned, round up to the nearest 64 byte 
+    boundary.
+ 

--- a/doc/user/acl.md
+++ b/doc/user/acl.md
@@ -8,7 +8,7 @@ Entries (ACEs). ACEs are the individual rules applied to each access decision.
 
 In the input and output of DAOS tools, an ACE is defined using a colon-separated
 string format:\
-`TYPE:FLAGS:IDENTITY:PERMISSIONS`
+`TYPE:FLAGS:PRINCIPAL:PERMISSIONS`
 
 The contents of all the fields are case-sensitive.
 
@@ -16,22 +16,22 @@ The contents of all the fields are case-sensitive.
 
 The type of entry. Only one type of ACE is supported at this time.
 
-* A (Allow): Allow access to the specified identity for the given permissions.
+* A (Allow): Allow access to the specified principal for the given permissions.
 
 ### Flags
 
 The flags provide additional information about how the ACE should be
 interpreted.
 
-* G (Group): The identity should be interpreted as a group.
+* G (Group): The principal should be interpreted as a group.
 
-### Identity
+### Principal
 
-The identity (also called the principal) is specified in the name@domain format.
+The principal (also called the identity) is specified in the name@domain format.
 The domain should be left off if the name is a UNIX user/group on the local
 domain. Currently, this is the only case supported by DAOS.
 
-There are three special identities, `OWNER@`, `GROUP@` and `EVERYONE@`,
+There are three special principals, `OWNER@`, `GROUP@` and `EVERYONE@`,
 which align with User, Group, and Other from traditional POSIX permission bits.
 When providing them in the ACE string format, they must be spelled exactly as
 written here, in uppercase with no domain appended. The `GROUP@` entry must
@@ -144,7 +144,7 @@ each ACE:
 
 * The base size of an ACE is 256 bytes.
 * If the ACE principal is *not* one of the special principals:
-  * Add the length of the identity string + 1.
+  * Add the length of the principal string + 1.
   * If that value is not 64-byte aligned, round up to the nearest 64 byte 
     boundary.
  

--- a/doc/user/container.md
+++ b/doc/user/container.md
@@ -190,14 +190,13 @@ is replaced with the new one.
 
 #### Removing an entry from the ACL
 
-To delete an entry for a given principal, or identity, in an existing container
-ACL:
+To delete an entry for a given principal in an existing container ACL:
 
 ```bash
 $ daos cont delete-acl --pool=<UUID> --svc=<rank> --cont=<UUID> --principal=<principal>
 ```
 
-The principal corresponds to the principal/identity portion of an ACE that was
+The principal corresponds to the principal portion of an ACE that was
 set during container creation or a previous container ACL operation. For the
 delete operation, the principal argument must be formatted as follows:
 
@@ -236,7 +235,7 @@ $ daos cont create --pool=<UUID> --svc=<rank> --user=<owner-user> --group=<owner
 ```
 
 The user and group names are case sensitive and must be formatted as
-[DAOS ACL user/group principals](/doc/user/acl.md#identity).
+[DAOS ACL user/group principals](/doc/user/acl.md#principal).
 
 #### Changing the ownership
 
@@ -253,7 +252,7 @@ $ daos cont set-owner --pool=<UUID> --svc=<rank> --cont=<UUID> --group=<owner-gr
 ```
 
 The user and group names are case sensitive and must be formatted as
-[DAOS ACL user/group principals](/doc/user/acl.md#identity).
+[DAOS ACL user/group principals](/doc/user/acl.md#principal).
 
 ## Compression & Encryption
 

--- a/doc/user/container.md
+++ b/doc/user/container.md
@@ -117,11 +117,143 @@ versions.
 Similar to POSIX extended attributes, users can attach some metadata to each
 container through the daos_cont_{list/get/set}_attr() API.
 
-## Container ACLs
+## Container Access Control Lists
 
-Support for per-container ACLs is scheduled for DAOS v1.2. Similar to pool ACLs,
-container ACLs will implement a subset of the NFSv4 ACL standard. This feature
-will be documented here once available.
+Client user and group access for containers is controlled by 
+[Access Control Lists (ACLs)](/doc/user/acl.md).
+
+Access-controlled container accesses include:
+* Opening the container for access.
+* Reading and writing data in the container.
+  * Reading and writing objects.
+  * Getting, setting, and listing user attributes.
+  * Getting, setting, and listing snapshots.
+* Deleting the container (if the pool does not grant the user permission).
+* Getting and setting container properties.
+* Getting and modifying the container ACL.
+* Modifying the container's owner.
+
+This is reflected in the set of supported 
+[container permissions](/doc/user/acl.md#permissions).
+
+### Creating a container with a custom ACL
+
+To create a container with a custom ACL:
+
+```bash
+$ daos cont create --pool=<UUID> --svc=<rank> --acl-file=<path>
+```
+
+The ACL file format is detailed in the [ACL section](/doc/user/acl.md#acl-file).
+
+### Displaying a container's ACL
+
+To view a container's ACL:
+
+```bash
+$ daos cont get-acl --pool=<UUID> --svc=<rank> --cont=<UUID>
+```
+
+The output is in the same string format used in the ACL file during creation,
+with one ACE per line.
+
+### Modifying a container's ACL
+
+For all of these commands using an ACL file, the ACL file must be in the format
+noted above for container creation.
+
+#### Overwriting the ACL
+
+To replace a container's ACL with a new ACL:
+
+```bash
+$ daos cont overwrite-acl --pool=<UUID> --svc=<rank> --cont=<UUID> --acl-file=<path>
+```
+
+#### Updating entries in an existing ACL
+
+To add or update multiple entries in an existing container ACL:
+
+```bash
+$ daos cont update-acl --pool=<UUID> --svc=<rank> --cont=<UUID> --acl-file=<path>
+```
+
+To add or update a single entry in an existing container ACL:
+
+```bash
+$ daos cont update-acl --pool=<UUID> --svc=<rank> --cont=<UUID> --entry <ACE>
+```
+
+If there is no existing entry for the principal in the ACL, the new entry is
+added to the ACL. If there is already an entry for the principal, that entry
+is replaced with the new one.
+
+#### Removing an entry from the ACL
+
+To delete an entry for a given principal, or identity, in an existing container
+ACL:
+
+```bash
+$ daos cont delete-acl --pool=<UUID> --svc=<rank> --cont=<UUID> --principal=<principal>
+```
+
+The principal corresponds to the principal/identity portion of an ACE that was
+set during container creation or a previous container ACL operation. For the
+delete operation, the principal argument must be formatted as follows:
+
+* Named user: `u:username@`
+* Named group: `g:groupname@`
+* Special principals:
+  * `OWNER@`
+  * `GROUP@`
+  * `EVERYONE@`
+
+The entry for that principal will be completely removed. This does not always
+mean that the principal will have no access. Rather, their access to the
+container will be decided based on the remaining ACL rules.
+
+### Ownership
+
+The ownership of the container corresponds to the special principals `OWNER@`
+and `GROUP@` in the ACL. These values are a part of the container properties.
+They may be set on container creation and changed later.
+
+The owner-user (`OWNER@`) always has set-ACL and get-ACL permissions, even if
+they are not explicitly granted by the ACL. This applies regardless of the other
+permissions they are granted by ACE(s) in the ACL.
+
+The owner-group (`GROUP@`) has no special permissions outside what they are
+granted by the ACL.
+
+#### Creating a container with a specific ownership
+
+The default owner user and group are the effective user and group of the user
+creating the container. However, a specific user and/or group may be specified
+at container creation time.
+
+```bash
+$ daos cont create --pool=<UUID> --svc=<rank> --user=<owner-user> --group=<owner-group>
+```
+
+The user and group names are case sensitive and must be formatted as
+[DAOS ACL user/group principals](/doc/user/acl.md#identity).
+
+#### Changing the ownership
+
+To change the owner user:
+
+```bash
+$ daos cont set-owner --pool=<UUID> --svc=<rank> --cont=<UUID> --user=<owner-user>
+```
+
+To change the owner group:
+
+```bash
+$ daos cont set-owner --pool=<UUID> --svc=<rank> --cont=<UUID> --group=<owner-group>
+```
+
+The user and group names are case sensitive and must be formatted as
+[DAOS ACL user/group principals](/doc/user/acl.md#identity).
 
 ## Compression & Encryption
 

--- a/doc/user/container.md
+++ b/doc/user/container.md
@@ -136,6 +136,25 @@ Access-controlled container accesses include:
 This is reflected in the set of supported 
 [container permissions](/doc/user/acl.md#permissions).
 
+### Pool Permissions vs. Container Permissions
+
+In general, pool permissions are separate from container permissions, and access
+to one does not guarantee access to the other. However, a user must have
+permission to connect to a container's pool before they can access the
+container in any way, regardless of their permissions on that container.
+Once the user has connected to a pool, container access decisions are based on
+the individual container ACL. A user need not have read/write access to a pool
+in order to open a container with read/write access, for example.
+
+There is one situation in which the pool can grant a container-level permission:
+Container deletion. If a user has Delete permission on a pool, this grants them
+the ability to delete *any* container in the pool, regardless of their
+permissions on that container.
+
+If the user does not have Delete permission on the pool, they will only be able
+to delete containers for which they have been explicitly granted Delete
+permission in the container's ACL.
+
 ### Creating a container with a custom ACL
 
 To create a container with a custom ACL:


### PR DESCRIPTION
- Move general ACL information to its own page in the user
  guide.
- Update user and admin guides to match current pool/cont
  ACL implementation.

Skip-build: true
Skip-test: true

Signed-off-by: Kris Jacque <kristin.jacque@intel.com>