### PR TITLE
DAOS-3409 SDL: integer overflows reported by coverity (#2068)

### DIFF
--- a/src/client/api/event.c
+++ b/src/client/api/event.c
@@ -537,7 +537,7 @@ ev_progress_cb(void *arg)
 	if (eqx->eqx_finalizing) {
 		evx->evx_status = DAOS_EVS_READY;
 		D_ASSERT(d_list_empty(&evx->evx_link));
-		D_MUTEX_UNLOCK(&epa->eqx->eqx_lock);
+		D_MUTEX_UNLOCK(&eqx->eqx_lock);
 		return 1;
 	}
 

--- a/src/common/pool_map.c
+++ b/src/common/pool_map.c
@@ -1897,7 +1897,7 @@ pool_map_update_failed_cnt(struct pool_map *map)
 	struct pool_domain *root;
 	struct pool_fail_comp *fail_cnts = map->po_comp_fail_cnts;
 
-	memset(fail_cnts, 0, sizeof(fail_cnts) * map->po_domain_layers);
+	memset(fail_cnts, 0, sizeof(*fail_cnts) * map->po_domain_layers);
 
 	rc = pool_map_find_domain(map, PO_COMP_TP_ROOT, PO_COMP_ID_ALL, &root);
 	if (rc == 0)

--- a/src/common/tests/abt_perf.c
+++ b/src/common/tests/abt_perf.c
@@ -93,7 +93,7 @@ abt_ult_create_rate(void)
 	while (1) {
 		if (!abt_exiting) {
 			now = abt_current_ms();
-			if (now - then >= opt_secs * 1000)
+			if (now - then >= (uint64_t)opt_secs * 1000)
 				abt_exiting = true;
 		}
 
@@ -167,7 +167,7 @@ abt_sched_rate(void)
 	while (1) {
 		if (then && !abt_exiting) {
 			now = abt_current_ms();
-			if (now - then >= opt_secs * 1000)
+			if (now - then >= (uint64_t)opt_secs * 1000)
 				abt_exiting = true;
 		}
 
@@ -232,7 +232,7 @@ abt_lock_create_rate(void *arg)
 	while (1) {
 		if (!abt_exiting) {
 			now = abt_current_ms();
-			if (now - then >= opt_secs * 1000)
+			if (now - then >= (uint64_t)opt_secs * 1000)
 				abt_exiting = true;
 		}
 

--- a/src/mgmt/srv_target.c
+++ b/src/mgmt/srv_target.c
@@ -856,7 +856,7 @@ tgt_profile_task(void *arg)
 	int rc = 0;
 
 	for (mod_id = 0; mod_id < (sizeof(uint64_t) * NBBY); mod_id++) {
-		uint64_t mask = 1 << mod_id;
+		uint64_t mask = 1ULL << mod_id;
 		struct dss_module *module;
 
 		if (!(in->p_module & mask))

--- a/src/object/cli_ec.c
+++ b/src/object/cli_ec.c
@@ -1610,7 +1610,7 @@ ec_array_encode(struct ec_params *params, daos_obj_id_t oid, daos_iod_t *iod,
 	unsigned int	 len = oca->u.ec.e_len;
 	unsigned int	 k = oca->u.ec.e_k;
 	daos_recx_t     *this_recx = &iod->iod_recxs[recx_idx];
-	uint64_t	 ss = len * k;
+	uint64_t	 ss = (uint64_t)len * k;
 	uint64_t	 recx_start_offset = this_recx->rx_idx * iod->iod_size;
 	uint64_t	 recx_end_offset = (this_recx->rx_nr * iod->iod_size) +
 					   recx_start_offset;
@@ -1879,11 +1879,11 @@ ec_get_tgt_set(daos_iod_t *iods, unsigned int nr, struct daos_oclass_attr *oca,
 				 * first in the the recx array.
 				 */
 				D_ASSERT(!parity_include);
-				ss = p * len;
+				ss = (uint64_t)p * len;
 				p_offset = 0;
 
 			} else {
-				ss = k * len;
+				ss = (uint64_t)k * len;
 				p_offset = p;
 			}
 			/* Walk from start to end by len, except for the last
@@ -1991,7 +1991,7 @@ ec_update_fetch_params(struct ec_fetch_params *params, daos_iod_t *iod,
 		/* can't have more than one stripe in a recx entry */
 		D_ASSERT(rem > 0);
 		while (rem) {
-			if (rem <= len * k) {
+			if (rem <= (uint64_t)len * k) {
 				params->niod.iod_recxs[params->niod.iod_nr].
 				rx_nr = rem/iod->iod_size;
 				params->niod.iod_recxs[params->niod.iod_nr++].

--- a/src/object/srv_ec.c
+++ b/src/object/srv_ec.c
@@ -246,7 +246,8 @@ ec_data_target(unsigned int dtgt_idx, unsigned int nr, daos_iod_t *iods,
 							 true, sl_idx++,
 							 &skip_list[i]);
 				}
-			} else if ((dtgt_idx + 1) * oca->u.ec.e_len <= so) {
+			} else if ((uint64_t)(dtgt_idx + 1) * oca->u.ec.e_len
+					<= so) {
 				/* this recx doesn't map to this target
 				 * so we need to remove the recx
 				 */

--- a/src/tests/suite/daos_obj.c
+++ b/src/tests/suite/daos_obj.c
@@ -578,7 +578,7 @@ io_overwrite_small(void **state, daos_obj_id_t oid)
 #endif
 }
 
-#define OW_IOD_SIZE	1024 /* used for mixed record overwrite */
+#define OW_IOD_SIZE	1024ULL /* used for mixed record overwrite */
 /**
  * Test mixed SCM & NVMe overwrites in different transactions with a large
  * record size. Iod size is needed for insert/lookup since the same akey is
@@ -1956,7 +1956,7 @@ next_step:
 	print_message("validating data ... sg_nr_out %d, iod_size %d.\n",
 		      sgl.sg_nr_out, (int)iod.iod_size);
 	assert_int_equal(sgl.sg_nr_out, 2);
-	assert_memory_equal(buf, buf_out, sizeof(buf));
+	assert_memory_equal(buf, buf_out, buf_len);
 
 	print_message("short read should get iov_len with tail hole trimmed\n");
 	memset(buf_out, 0, buf_len);

--- a/src/utils/daos_hdlr.c
+++ b/src/utils/daos_hdlr.c
@@ -507,8 +507,8 @@ cont_list_snaps_hdlr(struct cmd_args_s *ap)
 	}
 
 	D_PRINT("Container's snapshots :\n");
-	if (daos_anchor_is_eof < 0) {
-		fprintf(stderr, "invalid number of snapshots returned\n");
+	if (!daos_anchor_is_eof(&anchor)) {
+		fprintf(stderr, "too many snapshots returned\n");
 		D_GOTO(out, rc = -DER_INVAL);
 	}
 	if (snaps_count == 0) {

--- a/src/vos/tests/vts_checksum.c
+++ b/src/vos/tests/vts_checksum.c
@@ -150,7 +150,8 @@ csum_for_arrays_test_case(void *const *state, struct test_case_args test)
 	for (i = 0; i < update_recx_nr; i++) {
 		uint64_t csum_buf_len;
 
-		csum_buf_len = csum_size * test.update_recxs[i].csum_count;
+		csum_buf_len = (uint64_t)csum_size *
+				test.update_recxs[i].csum_count;
 		csum_infos[i].cs_type = 1;
 		csum_infos[i].cs_nr = test.update_recxs[i].csum_count;
 		csum_infos[i].cs_chunksize = test.chunksize;

--- a/src/vos/tests/vts_pm.c
+++ b/src/vos/tests/vts_pm.c
@@ -864,7 +864,7 @@ object_punch_and_fetch(void **state)
 
 		iod.iod_type = DAOS_IOD_SINGLE;
 		iod.iod_size = 0;
-		d_iov_set(&sgl.sg_iovs[0], (void *)value, sizeof(value));
+		d_iov_set(&sgl.sg_iovs[0], (void *)value, strlen(value) + 1);
 		iod.iod_nr = 1;
 		iod.iod_recxs = NULL;
 


### PR DESCRIPTION
Fixed several issues reported by coverity:
- Several integer overflow issues;
- 3 wrong sizeof() issues;
- 1 function address comparison issue;

Signed-off-by: Niu Yawei <yawei.niu@intel.com>