### PR TITLE
DAOS-3553 bio: SCM RDMA update over DRAM buffer

### DIFF
--- a/src/bio/bio_internal.h
+++ b/src/bio/bio_internal.h
@@ -160,6 +160,8 @@ struct bio_rsrvd_region {
 	uint64_t		 brr_off;
 	/* End (not included) in bytes */
 	uint64_t		 brr_end;
+	/* Media type */
+	uint16_t		 brr_media;
 };
 
 /* Reserved DMA buffer for certain io descriptor */
@@ -192,7 +194,8 @@ struct bio_desc {
 	unsigned int		 bd_buffer_prep:1,
 				 bd_update:1,
 				 bd_dma_issued:1,
-				 bd_retry:1;
+				 bd_retry:1,
+				 bd_bulk:1;
 	/* SG lists involved in this io descriptor */
 	unsigned int		 bd_sgl_cnt;
 	struct bio_sglist	 bd_sgls[0];
@@ -235,6 +238,7 @@ extern unsigned int	bio_chk_cnt_max;
 extern uint64_t		io_stat_period;
 void xs_poll_completion(struct bio_xs_context *ctxt, unsigned int *inflights);
 int get_bdev_type(struct spdk_bdev *bdev);
+extern bool bio_buffered_scm_rdma;
 
 /* bio_buffer.c */
 void dma_buffer_destroy(struct bio_dma_buffer *buf);

--- a/src/bio/bio_xstream.c
+++ b/src/bio/bio_xstream.c
@@ -61,6 +61,8 @@ unsigned int bio_chk_sz;
 unsigned int bio_chk_cnt_max;
 /* Per-xstream initial DMA buffer size (in chunk count) */
 static unsigned int bio_chk_cnt_init;
+/* When enabled, SCM RDMA update will go through DRAM buffer */
+bool bio_buffered_scm_rdma;
 
 struct bio_bdev {
 	d_list_t		 bb_link;
@@ -229,6 +231,12 @@ bio_spdk_env_init(void)
 	return rc;
 }
 
+bool
+bio_is_nvme_configured(void)
+{
+	return nvme_glb.bd_nvme_conf != NULL;
+}
+
 int
 bio_nvme_init(const char *storage_path, const char *nvme_conf, int shm_id,
 	      int mem_size)
@@ -259,6 +267,18 @@ bio_nvme_init(const char *storage_path, const char *nvme_conf, int shm_id,
 		goto free_mutex;
 	}
 
+	bio_chk_cnt_init = DAOS_DMA_CHUNK_CNT_INIT;
+	bio_chk_cnt_max = DAOS_DMA_CHUNK_CNT_MAX;
+	bio_chk_sz = (size_mb << 20) >> BIO_DMA_PAGE_SHIFT;
+
+	env = getenv("BIO_BUFFERED_SCM_RDMA");
+	if (env) {
+		D_WARN("Temp buffer will be used for SCM RDMA update\n");
+		bio_buffered_scm_rdma = true;
+	} else {
+		bio_buffered_scm_rdma = false;
+	}
+
 	fd = open(nvme_conf, O_RDONLY, 0600);
 	if (fd < 0) {
 		D_WARN("Open %s failed("DF_RC"), skip DAOS NVMe setup.\n",
@@ -286,9 +306,6 @@ bio_nvme_init(const char *storage_path, const char *nvme_conf, int shm_id,
 	nvme_glb.bd_bs_opts.cluster_sz = DAOS_BS_CLUSTER_SZ;
 	nvme_glb.bd_bs_opts.num_md_pages = DAOS_BS_MD_PAGES;
 	nvme_glb.bd_bs_opts.max_channel_ops = BIO_BS_MAX_CHANNEL_OPS;
-
-	bio_chk_cnt_init = DAOS_DMA_CHUNK_CNT_INIT;
-	bio_chk_cnt_max = DAOS_DMA_CHUNK_CNT_MAX;
 
 	env = getenv("VOS_BDEV_CLASS");
 	if (env && strcasecmp(env, "MALLOC") == 0) {
@@ -375,9 +392,10 @@ bio_nvme_poll(struct bio_xs_context *ctxt)
 	int rc;
 
 	/* NVMe context setup was skipped */
-	if (ctxt == NULL)
+	if (!bio_is_nvme_configured())
 		return 0;
 
+	D_ASSERT(ctxt != NULL && ctxt->bxc_thread != NULL);
 	rc = spdk_thread_poll(ctxt->bxc_thread, 0, 0);
 
 	/* Print SPDK I/O stats for each xstream */
@@ -974,7 +992,9 @@ bio_xsctxt_free(struct bio_xs_context *ctxt)
 	}
 
 	ABT_mutex_lock(nvme_glb.bd_mutex);
-	nvme_glb.bd_xstream_cnt--;
+
+	if (nvme_glb.bd_xstream_cnt > 0)
+		nvme_glb.bd_xstream_cnt--;
 
 	if (nvme_glb.bd_init_thread != NULL) {
 		if (nvme_glb.bd_init_thread == ctxt->bxc_thread) {
@@ -1028,18 +1048,24 @@ bio_xsctxt_alloc(struct bio_xs_context **pctxt, int tgt_id)
 	char			 th_name[32];
 	int			 rc;
 
-	/* Skip NVMe context setup if the daos_nvme.conf isn't present */
-	if (nvme_glb.bd_nvme_conf == NULL) {
-		*pctxt = NULL;
-		return 0;
-	}
-
 	D_ALLOC_PTR(ctxt);
 	if (ctxt == NULL)
 		return -DER_NOMEM;
 
 	D_INIT_LIST_HEAD(&ctxt->bxc_io_ctxts);
 	ctxt->bxc_tgt_id = tgt_id;
+
+	/* Skip NVMe context setup if the daos_nvme.conf isn't present */
+	if (!bio_is_nvme_configured()) {
+		ctxt->bxc_dma_buf = dma_buffer_create(bio_chk_cnt_init);
+		if (ctxt->bxc_dma_buf == NULL) {
+			D_FREE(ctxt);
+			*pctxt = NULL;
+			return -DER_NOMEM;
+		}
+		*pctxt = ctxt;
+		return 0;
+	}
 
 	ABT_mutex_lock(nvme_glb.bd_mutex);
 

--- a/src/include/daos_srv/bio.h
+++ b/src/include/daos_srv/bio.h
@@ -357,6 +357,11 @@ int bio_nvme_init(const char *storage_path, const char *nvme_conf, int shm_id,
  */
 void bio_nvme_fini(void);
 
+/**
+ * Check if NVMe is configured
+ */
+bool bio_is_nvme_configured(void);
+
 /*
  * Initialize SPDK env and per-xstream NVMe context.
  *
@@ -416,21 +421,23 @@ int bio_blob_delete(uuid_t uuid, struct bio_xs_context *xs_ctxt);
  * \param[IN] xs_ctxt	Per-xstream NVMe context
  * \param[IN] umem	umem instance
  * \param[IN] uuid	Pool UUID
+ * \param[IN] skip_blob	Skip blob open since no NVMe partition
  *
  * \returns		Zero on success, negative value on error
  */
 int bio_ioctxt_open(struct bio_io_context **pctxt,
 		    struct bio_xs_context *xs_ctxt,
-		    struct umem_instance *umem, uuid_t uuid);
+		    struct umem_instance *umem, uuid_t uuid, bool skip_blob);
 
 /*
  * Finalize per VOS instance I/O context.
  *
  * \param[IN] ctxt	I/O context
+ * \param[IN] skip_blob	Skip blob close since no NVMe partition
  *
  * \returns		Zero on success, negative value on error
  */
-int bio_ioctxt_close(struct bio_io_context *ctxt);
+int bio_ioctxt_close(struct bio_io_context *ctxt, bool skip_blob);
 
 /*
  * Unmap (TRIM) the extent being freed.
@@ -577,6 +584,14 @@ void bio_iod_flush(struct bio_desc *biod);
  * \return			SG list, or NULL on error
  */
 struct bio_sglist *bio_iod_sgl(struct bio_desc *biod, unsigned int idx);
+
+/*
+ * Mark the iod needing bulk transfer.
+ *
+ * \param biod       [IN]	io descriptor
+ * \param bulk       [IN]	true for false
+ */
+void bio_iod_set_bulk(struct bio_desc *biod, bool bulk);
 
 /*
  * Wrapper of ABT_thread_yield()

--- a/src/object/srv_obj.c
+++ b/src/object/srv_obj.c
@@ -1130,6 +1130,7 @@ obj_local_rw(crt_rpc_t *rpc, struct ds_cont_hdl *cont_hdl,
 	}
 
 	biod = vos_ioh2desc(ioh);
+	bio_iod_set_bulk(biod, rma);
 	rc = bio_iod_prep(biod);
 	if (rc) {
 		D_ERROR(DF_UOID" bio_iod_prep failed: "DF_RC".\n",

--- a/src/vos/vos_pool.c
+++ b/src/vos/vos_pool.c
@@ -119,7 +119,8 @@ pool_hop_free(struct d_ulink *hlink)
 	D_ASSERT(pool->vp_opened == 0);
 
 	if (pool->vp_io_ctxt != NULL) {
-		rc = bio_ioctxt_close(pool->vp_io_ctxt);
+		rc = bio_ioctxt_close(pool->vp_io_ctxt,
+				      pool->vp_pool_df->pd_nvme_sz == 0);
 		if (rc)
 			D_ERROR("Closing VOS I/O context:%p pool:"DF_UUID"\n",
 				pool->vp_io_ctxt, DP_UUID(pool->vp_id));
@@ -207,7 +208,7 @@ vos_blob_format_cb(void *cb_data, struct umem_instance *umem)
 	int			 rc;
 
 	/* Create a bio_io_context to get the blob */
-	rc = bio_ioctxt_open(&ioctxt, xs_ctxt, umem, blob_hdr->bbh_pool);
+	rc = bio_ioctxt_open(&ioctxt, xs_ctxt, umem, blob_hdr->bbh_pool, false);
 	if (rc) {
 		D_ERROR("Failed to create an ioctxt for writing blob header\n");
 		return rc;
@@ -219,7 +220,7 @@ vos_blob_format_cb(void *cb_data, struct umem_instance *umem)
 		D_ERROR("Failed to write header for blob:"DF_U64"\n",
 			blob_hdr->bbh_blob_id);
 
-	rc = bio_ioctxt_close(ioctxt);
+	rc = bio_ioctxt_close(ioctxt, false);
 	if (rc)
 		D_ERROR("Failed to free ioctxt\n");
 
@@ -349,7 +350,7 @@ end:
 	}
 
 	/* SCM only pool or NVMe device isn't configured */
-	if (nvme_sz == 0 || xs_ctxt == NULL)
+	if (nvme_sz == 0 || !bio_is_nvme_configured())
 		goto close;
 
 	/* Create SPDK blob on NVMe device */
@@ -429,7 +430,7 @@ vos_pool_kill(uuid_t uuid, bool force)
 	D_DEBUG(DB_MGMT, "No open handles, OK to delete\n");
 
 	/* NVMe device is configured */
-	if (xs_ctxt) {
+	if (bio_is_nvme_configured()) {
 		D_DEBUG(DB_MGMT, "Deleting blob for xs:%p pool:"DF_UUID"\n",
 			xs_ctxt, DP_UUID(uuid));
 		rc = bio_blob_delete(uuid, xs_ctxt);
@@ -675,11 +676,12 @@ vos_pool_open(const char *path, uuid_t uuid, daos_handle_t *poh)
 		D_GOTO(failed, rc);
 	}
 
-	xs_ctxt = pool_df->pd_nvme_sz == 0 ? NULL : vos_xsctxt_get();
+	xs_ctxt = vos_xsctxt_get();
 
 	D_DEBUG(DB_MGMT, "Opening VOS I/O context for xs:%p pool:"DF_UUID"\n",
 		xs_ctxt, DP_UUID(uuid));
-	rc = bio_ioctxt_open(&pool->vp_io_ctxt, xs_ctxt, &pool->vp_umm, uuid);
+	rc = bio_ioctxt_open(&pool->vp_io_ctxt, xs_ctxt, &pool->vp_umm, uuid,
+			     pool_df->pd_nvme_sz == 0);
 	if (rc) {
 		D_ERROR("Failed to open VOS I/O context for xs:%p "
 			"pool:"DF_UUID" rc="DF_RC"\n", xs_ctxt, DP_UUID(uuid),
@@ -687,7 +689,7 @@ vos_pool_open(const char *path, uuid_t uuid, daos_handle_t *poh)
 		goto failed;
 	}
 
-	if (xs_ctxt != NULL) {
+	if (bio_is_nvme_configured() && pool_df->pd_nvme_sz != 0) {
 		struct vea_unmap_context unmap_ctxt;
 
 		/* set unmap callback fp */


### PR DESCRIPTION
Implement SCM RDMA update over DRAM buffer since the AEP RDMA update
performance isn't good at this moment. This feature can be enabled
by setting env BIO_BUFFERED_SCM_RDMA=1 on server.

Signed-off-by: Niu Yawei <yawei.niu@intel.com>