### PR TITLE
DAOS-4223 container: fix slipped merge conflict

### DIFF
--- a/src/container/srv_container.c
+++ b/src/container/srv_container.c
@@ -790,8 +790,6 @@ out:
 	return rc;
 }
 
-static void cont_put(struct cont *cont);
-
 static int
 cont_destroy(struct rdb_tx *tx, struct ds_pool_hdl *pool_hdl,
 	     struct cont_svc *svc, crt_rpc_t *rpc)


### PR DESCRIPTION
cont_put() was made to public in 20a06cd9 which is based on ealier
0.9, however, a newly landed patch added 'static cont_put()' which
doesn't generate explicit conflict with 20a06cd9.

Signed-off-by: Niu Yawei <yawei.niu@intel.com>