### PR TITLE
DAOS-2603 doc: Update internal security docs

### DIFF
--- a/doc/admin/deployment.md
+++ b/doc/admin/deployment.md
@@ -265,6 +265,23 @@ The generated keys and certificates must then be securely distributed to all nod
 in the DAOS system (servers, clients, and admin nodes). Permissions for these files should
 be set to prevent unauthorized access to the keys and certificates.
 
+Client nodes require:
+- CA root cert
+- Agent cert
+- Agent key
+
+Administrative nodes require:
+- CA root cert
+- Admin cert
+- Admin key
+
+Server nodes require:
+- CA root cert
+- Server cert
+- Server key
+- All valid agent certs in the DAOS system (in the client cert directory, see
+  config file below)
+
 After the certificates have been securely distributed, the DAOS configuration files must be
 updated in order to enable authentication and secure communications. These examples assume
 that the configuration files have been installed under `/etc/daos`:

--- a/src/control/security/README.md
+++ b/src/control/security/README.md
@@ -76,7 +76,7 @@ used to protect the gRPC channel between the administrative node and the server,
 second, it protects the channel between DAOS servers, and finally, it provides
 signing functionality for data transfers between the server and compute nodes.
 
-DAOS provides a script and openssh configuration files for generating the
+DAOS provides a script and openssl configuration files for generating the
 various certificates needed by a DAOS installation. The script will craft a CA
 root certificate using the various configuration files found
 [in the DAOS source tree](/utils/certs).
@@ -99,7 +99,7 @@ Administration of a DAOS cluster will be performed by an administrator using the
 dmg utility and interfacing with the control plane service for the cluster. The
 control plane service is a distributed service provided by the DAOS cluster and
 resides on each node acting as a storage node. Even though the control plane
-service is present on every node, a subset of them is relegated as the
+service is present on every node, a subset of them is designated as the
 management nodes, and if you attempt to connect to a non-management node, it
 will attempt to redirect you to the entry point node for the cluster. The
 connections between dmg and the control plane processes are performed using

--- a/src/control/security/README.md
+++ b/src/control/security/README.md
@@ -1,1 +1,151 @@
-# Certificate Management
+# Control Plane Security Package
+
+The control plane security package provides a centralized source for Control
+Plane functionality related to access control and identity. This functionality
+is used throughout the control plane, in the DAOS Agent, DAOS Control Server,
+and administrative tools.
+
+This package implements the following:
+
+- Load and validate DAOS certificates.
+- Generate user credentials for client processes.
+- Sign and validate a data token with a certificate.
+- Configure gRPC communications to use mutually-authenticated TLS with
+  certificates.
+- Define access for gRPC commands by DAOS component certificate type.
+
+## Credential Establishment
+
+To assure the identity of a client process, the DAOS Agent generates a token to
+assert the user's identity to the server, and signs this token using the agent
+certificate. Credentials are established at the time of pool connect, and are
+associated with the pool handle for its lifetime.
+
+Currently, the only authentication method available in DAOS is AUTH_SYS. The
+DAOS Agent gathers information about the effective UNIX user over the UNIX
+Domain Socket connection used to communicate from the client library to the
+DAOS Agent.
+
+The workflow is as follows:
+
+1.  A job application utilizing the DAOS client library requests to connect to
+    a pool.
+2.  The job application connects to the DAOS Agent requesting a security
+    credential (token representing identity information).
+3.  The DAOS Agent inspects the properties of the process (UID, GID, ACL,
+    SELinux context) and uses that information to build and sign a credential.
+4.  The DAOS Agent then passes this credential back to the DAOS client library,
+    where it is used in the pool connect request, passing the security
+    credential as an argument to the pool connect RPC.
+5.  The DAOS IO Server receives the pool connect RPC and passes the security
+    credential to the Control Plane component of the DAOS Server to validate the
+    authenticity of the credential. If the credential is not valid, the request
+    will be denied.
+6.  If the security credential is deemed valid, the IO Server will compare the
+    identity against the ACL for the pool, as described in the Access Control
+    Enforcement section. If the identity has access, a pool handle is returned.
+    Otherwise the error DER_NO_PERM is returned.
+
+The framework used to establish the credentials can be further expanded to
+handle additional properties and authentication methods.
+
+## Certificate Usage in DAOS
+
+Certificates are used in several locations to provide authentication and
+validation of user identity in a DAOS system.
+For information on how to set up the certificates in a DAOS system, see the
+[Admin Guide](/doc/admin/deployment.md#certificate-configuration).
+
+### Certificate Generation
+
+When generating certificates for a DAOS system, four types of certificates are
+generated.
+
+The first to be generated is the CA root certificate specific to this DAOS
+deployment. While it is advised to have per-system CA roots, there is no
+mechanism preventing reuse between DAOS deployments. The CA root is used to
+produce and validate the three remaining certificate types.
+
+The three remaining certificate types that are generated are the admin, agent,
+and server certificates. The admin certificate is used to protect the gRPC
+channel between the administrative node and also provide validation of the
+administrative user. The Agent certificate is used to ensure that the compute
+node belongs to the DAOS system and also provides validation of process identity
+credentials. The server certificate is used in three separate ways. First, it is
+used to protect the gRPC channel between the administrative node and the server,
+second, it protects the channel between DAOS servers, and finally, it provides
+signing functionality for data transfers between the server and compute nodes.
+
+DAOS provides a script and openssh configuration files for generating the
+various certificates needed by a DAOS installation. The script will craft a CA
+root certificate using the various configuration files found
+[in the DAOS source tree](/utils/certs).
+The config files contain the signing policies for the various other types of
+certificates as well, ensuring the cryptography used is as directed by current
+best practices for protecting TLS channels.
+
+For the remaining certificates, DAOS uses the common name to ensure that the
+correct certificates are used for the correct components. Initially, there will
+only be one class of administrative user, and the Common Name for the gRPC TLS
+channel will be admin, ensuring only admin certificates may be used to issue
+administrative commands to the control plane. This is to ensure that if a key
+and cert are obtained from a compute node that it cannot be used to connect to
+the administrative interface. Likewise, we ensure that the appropriate certs are
+used by the Agent and the Server by encoding their names into the Common Name.
+
+### Protecting Administrative Channels with Certificates
+
+Administration of a DAOS cluster will be performed by an administrator using the
+dmg utility and interfacing with the control plane service for the cluster. The
+control plane service is a distributed service provided by the DAOS cluster and
+resides on each node acting as a storage node. Even though the control plane
+service is present on every node, a subset of them is relegated as the
+management nodes, and if you attempt to connect to a non-management node, it
+will attempt to redirect you to the entry point node for the cluster. The
+connections between dmg and the control plane processes are performed using
+gRPC. gRPC is an http2 based microservice architecture. The data structure and
+service definitions for gRPC are written in protobuf and then translated into
+the various languages used by DAOS (golang and C).
+
+gRPC provides support for TLS authentication of the channel between the gRPC
+client and server. It provides the ability to authenticate both ends of the
+channel using both server and client-side validation. gRPC provides a mechanism
+to interpose additional checks on the TLS handshake to ensure certain properties
+of the connection are guaranteed. We use a server-side gRPC interceptor to
+ensure that the certificate that was used to negotiate the channel contains the
+appropriate Common Name.
+
+### Host Authentication with Certificates
+
+Every compute node in the cluster is assigned a certificate for its agent. The
+agent certificate is used to verify the host's authenticity and the validity of
+the data it is signing.  As part of the credential establishment process, an
+identity token is bound with a verifier consisting of a signed hash of the
+identity token along with the CommonName of the host signing the token. The
+agent will use the CommonName in the certificate in the token verifier. When
+the server receives the verifier, it will check for a certificate named with the
+CommonName for validation.
+
+Part of the setup of the DAOS cluster is that all nodes acting as a server must
+have the certificate of all Agents that will be present in the cluster. In the
+case of a single certificate shared by all agents in the cluster, which is
+expected to be the most common case, this means that all servers will have a
+single Agent certificate file. The requirement that agents must be known to
+servers ahead of time makes it so an agent cannot be placed into the cluster
+without a properly issued certificate.
+
+### Credential Validation with Certificates
+
+As mentioned in the previous sections, the Agents are responsible for generating
+identity tokens and signing them. This action is performed when a client
+application requests to connect to a pool. The Agent inspects the requesting
+process and generates a hashed verifier token and signs it with the private key
+file associated with the Agent's certificate. This token is packaged as part of
+the pool connect operation and is sent to the data plane using an RPC over the
+RDMA fabric channel. The data plane server sends a request to the control plane
+server to validate the identity token that has been provided.
+The control plane server inspects the verifier, extracts the name of the
+providing host, and checks for a certificate with that name. The server then
+validates the signature of the token using the certificate file associated with
+that host. If the identity token validates, then it is returned to the
+data plane server to make an access control check against the identity token.

--- a/src/security/README.md
+++ b/src/security/README.md
@@ -1,3 +1,82 @@
-# Security (TO BE UPDATED)
+# Data Plane Security Module
 
-Details on certificate management and process authentication by the agent are available [here](/src/control/security/README.md).
+The DAOS security module centralizes all access and security-related
+functionality in the DAOS data plane in a single module.
+
+The functionality in this module includes:
+
+- Client library requests to the DAOS Agent for a credential for authentication.
+- Server requests to the Control Plane to validate a signed client credential.
+- Generating default Access Control Lists for pools and containers.
+- Deriving pool and container capabilities from the combination of the Access
+  Control List and the client credential.
+- Access control checks for pool and container operations.
+
+## Credential Generation and Validation
+
+Details on the credential generation and validation process
+are outlined
+[in the Control Plane documentation](/src/control/security/README.md).
+
+## Access Control Internals
+
+This section covers the implementation details of pool and container access
+control.
+
+See the [ACL section of the User Guide](/doc/user/acl.md) for background on DAOS
+Access Control Lists.
+
+See the [Admin Guide](/doc/admin/pool_operations.md#pool-access-control-lists)
+for a higher-level view of pool access control.
+
+See the [User Guide](/doc/user/container.md#container-access-control-lists)
+for a higher-level view of container access control.
+
+### Pool Access
+
+When a client connects to a pool, the user credential that was used to make the
+connection is used, in combination with the pool ACL and the requested access
+type (RO or RW), to generate an internal set of security capabilities for the
+pool handle. These capabilities map to the valid permissions set for pools and
+are used for future access decisions for that pool handle, for pool-level
+operations such as container creation.
+
+These capabilities persist for the life of the handle, even if someone modifies
+the pool ACL or ownership. The modifications won't be used for access decisions
+until the user attempts to get a new handle for the pool. The pool handle cannot
+be revoked.
+
+In addition, the validated credential is saved in the handle data in the DAOS
+data plane during pool connect, and remains associated with the pool handle
+for its lifetime.
+This original credential is used for access decisions when the user
+interacts with existing containers. It is used both when the user attempts to
+open a container (acquire a container handle) and when the user attempts to
+delete a container, for which they may not be holding a handle.
+
+### Container Access
+
+The client process to open a container is similar to that for pool connection.
+A set of security capabilities is determined for the container handle based on
+the combination of the container ACL and the credential associated with the pool
+handle, along with the type of access requested (RO or RW). The security
+capabilities calculated at the time of the container open are used for container
+access decisions throughout the lifetime of the container handle. The container
+handle cannot be revoked.
+
+### Container Destroy
+
+Container deletion is a special operation in the context of access control.
+There are two levels of permission that may have been granted.
+
+At the pool level, a user may have been granted the administrator-like privilege
+of deleting any container, even those that they have no access to. This is the
+first and fastest check: this permission is included in the pool handle's
+security capabilities.
+
+If the user does not have the pool level delete privilege, we must determine the
+security capabilities of the pool handle's credential on the container before we
+know if the holder of the handle is permitted to delete it. This is the same
+process used during container open, wherein the credential and container ACL are
+used together. If the user has permission via the container ACL to delete that
+specific container, the operation is allowed to proceed.


### PR DESCRIPTION
This patch adds content to the internal design
documentation for both the control plane and
data plane security modules.

- Add control plane security design documentation on
  how certificates are used in DAOS, and on credential
  generation in the agent.
- Add data plane security design documentation on
  access control internals.

Signed-off-by: Kris Jacque <kristin.jacque@intel.com>