### PR TITLE
CORCI-812 release: Use raw_input() on Python 2

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -7,6 +7,11 @@ import time
 import errno
 from SCons.Script import BUILD_TARGETS
 
+try:
+    input = raw_input # pylint: disable=redefined-builtin
+except NameError:
+    pass
+
 sys.path.insert(0, os.path.join(Dir('#').abspath, 'utils'))
 import daos_build
 


### PR DESCRIPTION
Skip-build: true
Skip-test: true
Signed-off-by: Brian J. Murrell <brian.murrell@intel.com>