### PR TITLE
DAOS-4353: Add Pool Query before and after ior/mdtest runs

### DIFF
--- a/src/tests/ftest/util/ior_test_base.py
+++ b/src/tests/ftest/util/ior_test_base.py
@@ -204,11 +204,14 @@ class IorTestBase(TestWithServers):
             env["LD_PRELOAD"] = intercept
         manager.setup_command(env, self.hostfile_clients, processes)
         try:
+            self.pool.display_pool_daos_space()
             out = manager.run()
             return out
         except CommandFailure as error:
             self.log.error("IOR Failed: %s", str(error))
             self.fail("Test was expected to pass but it failed.\n")
+        finally:
+            self.pool.display_pool_daos_space()
 
     def run_multiple_ior_with_pool(self, results, intercept=None):
         """Execute ior with optional overrides for ior flags and object_class.
@@ -287,6 +290,7 @@ class IorTestBase(TestWithServers):
         manager.setup_command(env, hostfile, procs)
         self.lock.release()
         try:
+            self.pool.display_pool_daos_space()
             out = manager.run()
             self.lock.acquire(True)
             results[job_num] = IorCommand.get_ior_metrics(out)
@@ -294,6 +298,8 @@ class IorTestBase(TestWithServers):
         except CommandFailure as error:
             self.log.error("IOR Failed: %s", str(error))
             self.fail("Test was expected to pass but it failed.\n")
+        finally:
+            self.pool.display_pool_daos_space()
 
     def verify_pool_size(self, original_pool_info, processes):
         """Validate the pool size.

--- a/src/tests/ftest/util/mdtest_test_base.py
+++ b/src/tests/ftest/util/mdtest_test_base.py
@@ -192,7 +192,10 @@ class MdtestBase(TestWithServers):
             str(manager), self.tmp, get_log_file(self.client_log))
         manager.setup_command(env, self.hostfile_clients, processes)
         try:
+            self.pool.display_pool_daos_space()
             manager.run()
         except CommandFailure as error:
             self.log.error("Mdtest Failed: %s", str(error))
             self.fail("Test was expected to pass but it failed.\n")
+        finally:
+            self.pool.display_pool_daos_space()


### PR DESCRIPTION
  - Added a pool space logging info before and after
    ior/mdtest runs to give more insight into pool space
    utilization.

Signed-off-by: Logan Sundaram <logan.sundaram@intel.com>