### PR TITLE
DAOS-1769 Test: Unit test to verify the record number after punch/enumerate

### DIFF
--- a/src/tests/suite/daos_obj.c
+++ b/src/tests/suite/daos_obj.c
@@ -3306,15 +3306,15 @@ punch_then_lookup(void **state)
 static void
 punch_enum_then_verify_record_count(void **state)
 {
-	daos_obj_id_t	 oid;
-	test_arg_t		*arg = *state;
+	daos_obj_id_t	oid;
+	test_arg_t	*arg = *state;
 	struct ioreq	req;
 	daos_anchor_t	anchor;
-	char			data_buf[100];
-	char			fetch_buf[100] = { 0 };
-	int				i;
-	int				total_rec = 0;
-	uint32_t		number;
+	char		data_buf[100];
+	char		fetch_buf[100] = { 0 };
+	int		i;
+	int		total_rec = 0;
+	uint32_t	number;
 
 	oid = dts_oid_gen(dts_obj_class, 0, arg->myrank);
 	ioreq_init(&req, arg->coh, oid, DAOS_IOD_ARRAY, arg);
@@ -3362,7 +3362,6 @@ punch_enum_then_verify_record_count(void **state)
 	/** Record count should be 2**/
 	assert_int_equal(total_rec, 2);
 	print_message("Number of record after Enumeration = %d\n", total_rec);
-
 }
 
 static void

--- a/src/tests/suite/daos_obj.c
+++ b/src/tests/suite/daos_obj.c
@@ -3300,6 +3300,71 @@ punch_then_lookup(void **state)
 	}
 }
 
+/**
+ * Verify the number of record after punch and enumeration.
+ */
+static void
+punch_enum_then_verify_record_count(void **state)
+{
+	daos_obj_id_t	 oid;
+	test_arg_t		*arg = *state;
+	struct ioreq	req;
+	daos_anchor_t	anchor;
+	char			data_buf[100];
+	char			fetch_buf[100] = { 0 };
+	int				i;
+	int				total_rec = 0;
+	uint32_t		number;
+
+	oid = dts_oid_gen(dts_obj_class, 0, arg->myrank);
+	ioreq_init(&req, arg->coh, oid, DAOS_IOD_ARRAY, arg);
+
+	memset(data_buf, 'a', 100);
+	/** Insert record with 100 extents **/
+	print_message("Insert single record with 100 extents\n");
+	insert_single_with_rxnr("dkey", "akey", 0, data_buf,
+		1, 100, DAOS_TX_NONE, &req);
+
+	/** Punch record extent from 50 to 60 **/
+	print_message("Punch record 50 to 60:\n");
+	punch_rec_with_rxnr("dkey", "akey", 50, 10, DAOS_TX_NONE, &req);
+
+	/** Lookup all the records **/
+	print_message("Lookup all the records:\n");
+	lookup_single_with_rxnr("dkey", "akey", 0, fetch_buf,
+		1, 100, DAOS_TX_NONE, &req);
+
+	print_message("Verify punch and non-punch data:\n");
+	for (i = 0; i < 100; i++) {
+		/** Verify the punch record extent from 50-59 are empty **/
+		if (i >= 50 && i <= 59)
+			assert_memory_equal(&fetch_buf[i], "", 1);
+		/** Verify the non-punch records extent data **/
+		else
+			assert_memory_equal(&fetch_buf[i], "a", 1);
+	}
+
+	/** Enumerate record */
+	print_message("Enumerating record extents...\n");
+	total_rec = 0;
+	memset(&anchor, 0, sizeof(anchor));
+	while (!daos_anchor_is_eof(&anchor)) {
+		daos_epoch_range_t	eprs[5];
+		daos_recx_t		recxs[5];
+		daos_size_t		size;
+
+		number = 5;
+		enumerate_rec(DAOS_TX_NONE, "dkey", "akey", &size,
+			      &number, recxs, eprs, &anchor, true, &req);
+		total_rec += number;
+	}
+
+	/** Record count should be 2**/
+	assert_int_equal(total_rec, 2);
+	print_message("Number of record after Enumeration = %d\n", total_rec);
+
+}
+
 static void
 split_sgl_internal(void **state, int size)
 {
@@ -3797,6 +3862,9 @@ static const struct CMUnitTest io_tests[] = {
 	  io_capa_iv_fetch, async_disable, test_case_teardown},
 	{ "IO39: Update with invalid sg and record",
 	  io_invalid, async_disable, test_case_teardown},
+	{ "IO40: Record count after punch/enumeration",
+	  punch_enum_then_verify_record_count, async_disable,
+	  test_case_teardown},
 };
 
 int


### PR DESCRIPTION
   This unit test will insert the 100 record with extent.
   Punch the 10 extent record [50, 60]
   Fetch all the record and verify the punch/non-punch record.
   Enumerate the record and verify the record count is 2.

Signed-off-by: Samir Raval <samir.raval@intel.com>