### PR TITLE
Move mdtest_small to weekly run for master

### DIFF
--- a/src/tests/ftest/io/mdtest_small.py
+++ b/src/tests/ftest/io/mdtest_small.py
@@ -48,7 +48,7 @@ class MdtestSmall(MdtestBase):
             read bytes: 0|4K
             depth of hierarchical directory structure: 0|5
 
-        :avocado: tags=all,pr,hw,large,mdtest,mdtestsmall
+        :avocado: tags=all,hw,large,mdtest,mdtestsmall,full_regression
         """
         # local params
         mdtest_params = self.params.get("mdtest_params", "/run/mdtest/*")


### PR DESCRIPTION
Removing the tag 'pr' and adding 'full_regression' in order
to move mdtest_small to weekly run in master branch.

Signed-off-by: Saurabh Tandan <saurabh.tandan@intel.com>