### PR TITLE
DAOS-3966 security: Address server_name missing from server client co…

### DIFF
--- a/src/control/security/config.go
+++ b/src/control/security/config.go
@@ -92,6 +92,7 @@ func DefaultServerTransportConfig() *TransportConfig {
 	return &TransportConfig{
 		AllowInsecure: defaultInsecure,
 		CertificateConfig: CertificateConfig{
+			ServerName:      defaultServer,
 			CARootPath:      defaultCACert,
 			ClientCertDir:   defaultClientCertDir,
 			CertificatePath: defaultServerCert,


### PR DESCRIPTION
…nfig (#1691)

daos_server acts both as a grpc server and client. Without the server name
being specified in the client config used by the server, TLS negotiation will
fail when a non-access point server attempts to join the cluster.

Backport of commit from master

Signed-off-by: David Quigley <david.quigley@intel.com>