### PR TITLE
DAOS-4341 tests: uninitialized var in rebuild_multiple_tgts

### DIFF
--- a/src/tests/suite/daos_rebuild.c
+++ b/src/tests/suite/daos_rebuild.c
@@ -1263,7 +1263,7 @@ rebuild_multiple_tgts(void **state)
 	daos_obj_id_t	oid;
 	struct daos_obj_layout *layout;
 	d_rank_t	leader;
-	d_rank_t	exclude_ranks[2];
+	d_rank_t	exclude_ranks[2] = { 0 };
 	int		i;
 
 	if (!test_runable(arg, 6))


### PR DESCRIPTION
Uninitialized var in rebuild_multiple_tgts.

Signed-off-by: Di Wang <di.wang@intel.com>