### PR TITLE
DAOS-4288 control: dmg system stop send kill default

### DIFF
--- a/src/control/cmd/dmg/system.go
+++ b/src/control/cmd/dmg/system.go
@@ -214,7 +214,8 @@ type systemStopCmd struct {
 //
 // Perform prep and kill stages with stop command.
 func (cmd *systemStopCmd) Execute(_ []string) error {
-	req := client.SystemStopReq{Prep: true, Kill: true, Force: cmd.Force}
+	// always force stop while daos_io_server shutdown is broken.
+	req := client.SystemStopReq{Prep: true, Kill: true, Force: true}
 	resp, err := cmd.conns.SystemStop(req)
 	if err != nil {
 		return errors.Wrap(err, "System-Stop command failed")

--- a/src/control/cmd/dmg/system_test.go
+++ b/src/control/cmd/dmg/system_test.go
@@ -65,7 +65,7 @@ func TestSystemCommands(t *testing.T) {
 		{
 			"system stop with no arguments",
 			"system stop",
-			"ConnectClients SystemStop-{true true [] false}",
+			"ConnectClients SystemStop-{true true [] true}",
 			nil,
 		},
 		{


### PR DESCRIPTION
Send SIGKILL by default to I/O servers on "dmg system stop" as iosrv
does not exit cleanly on SIGINT.

Signed-off-by: Tom Nabarro <tom.nabarro@intel.com>