### PR TITLE
DAOS-4282 tests: generate different dkeys on different replicas

### DIFF
--- a/src/object/srv_obj.c
+++ b/src/object/srv_obj.c
@@ -1187,7 +1187,7 @@ ds_obj_tgt_update_handler(crt_rpc_t *rpc)
 	if (DAOS_FAIL_CHECK(DAOS_VC_DIFF_DKEY)) {
 		unsigned char	*buf = dkey->iov_buf;
 
-		buf[0] += 1;
+		buf[0] += orw->orw_oid.id_shard + 1;
 		orw->orw_dkey_hash = obj_dkey2hash(dkey);
 	}
 


### PR DESCRIPTION
We inject failure to simulate corrupted dkey for replicas
consistency verification. It is expected that different
replicas have different corrupted dkeys.

master-PR: 2155

Signed-off-by: Fan Yong <fan.yong@intel.com>