### PR TITLE
DAOS-4197 reenable HDF5 over MPIIO testing

### DIFF
--- a/src/tests/ftest/io/hdf5.py
+++ b/src/tests/ftest/io/hdf5.py
@@ -21,7 +21,6 @@
   Any reproduction of computer software, computer software documentation, or
   portions thereof marked with this legend must also reproduce the markings.
 """
-from apricot import skipForTicket
 from mpio_test_base import LlnlMpi4pyHdf5
 
 
@@ -32,7 +31,6 @@ class Hdf5(LlnlMpi4pyHdf5):
     :avocado: recursive
     """
 
-    @skipForTicket("DAOS-4197")
     def test_hdf5(self):
         """Jira ID: DAOS-2252.
 

--- a/src/tests/ftest/io/hdf5.yaml
+++ b/src/tests/ftest/io/hdf5.yaml
@@ -14,10 +14,11 @@ server_config:
 pool:
     mode: 146
     name: daos_server
-    scm_size: 25000000000
+    scm_size: 30000000000
+    nvme_size: 40000000000
     svcn: 1
     control_method: dmg
 client_processes:
-    np: 8
+    np: 6
 test_repo:
     hdf5: "/usr/lib64/hdf5/tests"

--- a/src/tests/ftest/util/mpio_test_base.py
+++ b/src/tests/ftest/util/mpio_test_base.py
@@ -68,8 +68,8 @@ class LlnlMpi4pyHdf5(TestWithServers):
         try:
             # running tests
             self.mpio.run_llnl_mpi4py_hdf5(
-                self.hostfile_clients, self.pool.uuid, test_repo, test_name,
-                client_processes)
+                self.hostfile_clients, self.pool.uuid, self.pool.svc_ranks,
+                test_repo, test_name, client_processes)
         except MpioFailed as excep:
             self.fail("<{0} Test Failed> \n{1}".format(test_name, excep))
 

--- a/src/tests/ftest/util/mpio_utils.py
+++ b/src/tests/ftest/util/mpio_utils.py
@@ -94,27 +94,27 @@ class MpioUtils():
             raise MpioFailed("<ROMIO Test FAILED> \nException occurred: {}"
                              .format(str(excep)))
     # pylint: disable=R0913
-    def run_llnl_mpi4py_hdf5(self, hostfile, pool_uuid, test_repo,
+    def run_llnl_mpi4py_hdf5(self, hostfile, pool_uuid, svcl, test_repo,
                              test_name, client_processes):
         """
             Running LLNL, MPI4PY and HDF5 testsuites
             Function Arguments:
                 hostfile          --client hostfile
                 pool_uuid         --Pool UUID
+                svcl              --Pool SVCL
                 test_repo         --test repo location
                 test_name         --name of test to be tested
         """
         print("self.mpichinstall: {}".format(self.mpichinstall))
         # environment variables only to be set on client node
         env = EnvironmentVariables()
-        env["MPIO_USER_PATH"] = "daos:"
         env["DAOS_POOL"] = "{}".format(pool_uuid)
-        env["DAOS_SVCL"] = "{}".format(0)
-        env["HDF5_PARAPREFIX"] = "daos:"
+        env["DAOS_SVCL"] = "{}".format(":".join([str(item) for item in svcl]))
         mpirun = os.path.join(self.mpichinstall, "bin", "mpirun")
         # running 8 client processes
         if test_name == "llnl" and os.path.isfile(
                 os.path.join(test_repo, "testmpio_daos")):
+            env["MPIO_USER_PATH"] = "daos:"
             test_cmd = [env.get_export_str(),
                         mpirun,
                         '-np',
@@ -138,6 +138,7 @@ class MpioUtils():
         elif test_name == "hdf5" and \
              (os.path.isfile(os.path.join(test_repo, "testphdf5")) and
               os.path.isfile(os.path.join(test_repo, "t_shapesame"))):
+            env["HDF5_PARAPREFIX"] = "daos:"
             cmd = ''
             for test in ["testphdf5", "t_shapesame"]:
                 fqtp = os.path.join(test_repo, test)


### PR DESCRIPTION
Reduce the number of client ranks to 6, which makes the test to run much faster.
Will need to explore why when going to 8 or more ranks causes the slowdown in CI.

Signed-off-by: Mohamad Chaarawi <mohamad.chaarawi@intel.com>