### PR TITLE
DAOS-4368 test: Add container create before mpi4py test runs

### DIFF
--- a/src/tests/ftest/io/llnl_mpi4py.yaml
+++ b/src/tests/ftest/io/llnl_mpi4py.yaml
@@ -17,6 +17,9 @@ pool:
     control_method: dmg
 client_processes:
     np: 8
+container:
+#                         [type: enable_chksum: srv_verify: chksum_type: chunk_size]
+    container_properties: [POSIX, False, False, 0, 1048576]
 test_repo:
     llnl: "/usr/lib64/testmpio"
     mpi4py: "/usr/lib64/python2.7/site-packages/mpi4py/tests"

--- a/src/tests/ftest/io/llnl_mpi4py.yaml
+++ b/src/tests/ftest/io/llnl_mpi4py.yaml
@@ -19,7 +19,7 @@ client_processes:
     np: 8
 container:
 #                         [type   enable_chksum]
-    container_properties: [POSIX, False]
+    container_properties: [posix, False]
 test_repo:
     llnl: "/usr/lib64/testmpio"
     mpi4py: "/usr/lib64/python2.7/site-packages/mpi4py/tests"

--- a/src/tests/ftest/io/llnl_mpi4py.yaml
+++ b/src/tests/ftest/io/llnl_mpi4py.yaml
@@ -18,8 +18,8 @@ pool:
 client_processes:
     np: 8
 container:
-#                         [type: enable_chksum: srv_verify: chksum_type: chunk_size]
-    container_properties: [POSIX, False, False, 0, 1048576]
+#                         [type   enable_chksum]
+    container_properties: [POSIX, False]
 test_repo:
     llnl: "/usr/lib64/testmpio"
     mpi4py: "/usr/lib64/python2.7/site-packages/mpi4py/tests"

--- a/src/tests/ftest/util/mpio_utils.py
+++ b/src/tests/ftest/util/mpio_utils.py
@@ -95,7 +95,7 @@ class MpioUtils():
                              .format(str(excep)))
     # pylint: disable=R0913
     def run_llnl_mpi4py_hdf5(self, hostfile, pool_uuid, test_repo,
-                             test_name, client_processes):
+                             test_name, client_processes, cont_uuid):
         """
             Running LLNL, MPI4PY and HDF5 testsuites
             Function Arguments:
@@ -103,6 +103,7 @@ class MpioUtils():
                 pool_uuid         --Pool UUID
                 test_repo         --test repo location
                 test_name         --name of test to be tested
+                cont_uuid         --Container UUID
         """
         print("self.mpichinstall: {}".format(self.mpichinstall))
         # environment variables only to be set on client node
@@ -126,6 +127,7 @@ class MpioUtils():
             cmd = " ".join(test_cmd)
         elif test_name == "mpi4py" and \
              os.path.isfile(os.path.join(test_repo, "test_io_daos.py")):
+            env["DAOS_CONT"] = "{}".format(cont_uuid)
             test_cmd = [env.get_export_str(),
                         mpirun,
                         '-np',

--- a/src/tests/ftest/util/test_utils_container.py
+++ b/src/tests/ftest/util/test_utils_container.py
@@ -310,9 +310,10 @@ class TestContainer(TestDaosApiBase):
         if con_in is not None:
             self.input_params.type = con_in[0]
             self.input_params.enable_chksum = con_in[1]
-            self.input_params.srv_verify = con_in[2]
-            self.input_params.chksum_type = con_in[3]
-            self.input_params.chunk_size = con_in[4]
+            if con_in[1] == True:
+                self.input_params.srv_verify = con_in[2]
+                self.input_params.chksum_type = con_in[3]
+                self.input_params.chunk_size = con_in[4]
             kwargs["con_prop"] = self.input_params
         self._call_method(self.container.create, kwargs)
         self.uuid = self.container.get_uuid_str()


### PR DESCRIPTION
Add container create of type POSIX before mpi4py test runs
and export the container uuid via DAOS_CONT

Signed-off-by: Saurabh Tandan <saurabh.tandan@intel.com>