### PR TITLE
DAOS-4368 test: pre-create POSIX container for mpi4py mpi-io test

### DIFF
--- a/src/tests/ftest/util/mpio_utils.py
+++ b/src/tests/ftest/util/mpio_utils.py
@@ -126,6 +126,20 @@ class MpioUtils():
             cmd = " ".join(test_cmd)
         elif test_name == "mpi4py" and \
              os.path.isfile(os.path.join(test_repo, "test_io_daos.py")):
+            cmd = "daos cont create --pool={} --svc={} --type=POSIX".format(
+                pool_uuid, 0)
+            try:
+                container = subprocess.Popen(cmd, stdout=subprocess.PIPE,
+                                             shell=True)
+                (output, err) = container.communicate()
+
+                print("Container created: {}".format(output.split()[3]))
+                env["DAOS_CONT"] = "{}".format(output.split()[3])
+
+            except subprocess.CalledProcessError as err:
+                raise MpioFailed("<Container Create FAILED> \nException occurred: {}"
+                                 .format(err))
+
             test_cmd = [env.get_export_str(),
                         mpirun,
                         '-np',


### PR DESCRIPTION
Since Conditional Ops landed and are used in DFS, we cannot assume that several dfs_cont_create() of the same container will succeed. Se we  need to change the mpi4py test that does that to pre-create the container for the test using the daos tool and export it to DAOS_CONT for the test to use.

Signed-off-by: Mohamad Chaarawi <mohamad.chaarawi@intel.com>