### PR TITLE
DAOS-4246 srv: Assign SWIM a separate core

### DIFF
--- a/src/cart/crt_context.c
+++ b/src/cart/crt_context.c
@@ -172,8 +172,8 @@ out:
 	return rc;
 }
 
-int
-crt_context_provider_create(crt_context_t *crt_ctx, int provider)
+static int
+crt_context_provider_create(crt_context_t *crt_ctx, int provider, uint32_t swim_idx)
 {
 	struct crt_context	*ctx = NULL;
 	int			rc = 0;
@@ -275,7 +275,7 @@ crt_context_provider_create(crt_context_t *crt_ctx, int provider)
 	if (crt_is_service() &&
 	    crt_gdata.cg_auto_swim_disable == 0 &&
 	    ctx->cc_idx == CRT_DEFAULT_PROGRESS_CTX_IDX) {
-		rc = crt_swim_init(CRT_DEFAULT_PROGRESS_CTX_IDX);
+		rc = crt_swim_init(swim_idx);
 		if (rc) {
 			D_ERROR("crt_swim_init() failed rc: %d.\n", rc);
 			crt_context_destroy(ctx, true);
@@ -293,7 +293,8 @@ out:
 int
 crt_context_create(crt_context_t *crt_ctx)
 {
-	return crt_context_provider_create(crt_ctx, crt_gdata.cg_init_prov);
+	return crt_context_provider_create(crt_ctx, crt_gdata.cg_init_prov,
+					   crt_gdata.cg_swim_crt_idx);
 }
 
 int

--- a/src/cart/crt_init.c
+++ b/src/cart/crt_init.c
@@ -163,6 +163,13 @@ static int data_init(int server, crt_init_options_t *opt)
 	D_DEBUG(DB_ALL, "set the global timeout value as %d second.\n",
 		crt_gdata.cg_timeout);
 
+	if (opt && opt->cio_swim_crt_idx)
+		crt_gdata.cg_swim_crt_idx = opt->cio_swim_crt_idx;
+	else
+		crt_gdata.cg_swim_crt_idx = CRT_DEFAULT_PROGRESS_CTX_IDX;
+
+	D_DEBUG(DB_ALL, "SWIM index is %d\n", crt_gdata.cg_swim_crt_idx);
+
 	/* Override defaults and environment if option is set */
 	if (opt && opt->cio_use_credits) {
 		credits = opt->cio_ep_credits;
@@ -537,7 +544,6 @@ do_init:
 		D_ASSERT(crt_gdata.cg_opc_map != NULL);
 
 		crt_gdata.cg_inited = 1;
-
 	} else {
 		if (crt_gdata.cg_server == false && server == true) {
 			D_ERROR("CRT initialized as client, cannot set as "

--- a/src/cart/crt_internal_types.h
+++ b/src/cart/crt_internal_types.h
@@ -71,6 +71,9 @@ struct crt_gdata {
 	/** global timeout value (second) for all RPCs */
 	uint32_t		cg_timeout;
 
+	/** global swim index for all servers */
+	uint32_t		cg_swim_crt_idx;
+
 	/** credits limitation for #inflight RPCs per target EP CTX */
 	uint32_t		cg_credit_ep_ctx;
 

--- a/src/client/api/event.c
+++ b/src/client/api/event.c
@@ -70,7 +70,7 @@ daos_eq_lib_init()
 		D_GOTO(unlock, rc = 0);
 	}
 
-	rc = crt_init_opt(NULL, 0, daos_crt_init_opt_get(false, 1));
+	rc = crt_init_opt(NULL, 0, daos_crt_init_opt_get(false, 1, 0));
 	if (rc != 0) {
 		D_ERROR("failed to initialize crt: "DF_RC"\n", DP_RC(rc));
 		D_GOTO(unlock, rc);

--- a/src/common/misc.c
+++ b/src/common/misc.c
@@ -644,12 +644,13 @@ daos_hhash_link_delete(struct d_hlink *hlink)
  *
  * \param server [IN]	true for server
  * \param ctx_nr [IN]	number of contexts
+ * \param swim_ctx [IN]	swim ctx index
  *
  * \return		the pointer to crt_init_options_t (NULL if not needed)
  */
 crt_init_options_t daos_crt_init_opt;
 crt_init_options_t *
-daos_crt_init_opt_get(bool server, int ctx_nr)
+daos_crt_init_opt_get(bool server, int ctx_nr, int swim_ctx)
 {
 	crt_phy_addr_t	addr_env;
 	bool		sep = false;
@@ -657,6 +658,7 @@ daos_crt_init_opt_get(bool server, int ctx_nr)
 	/** enable statistics on the server side */
 	daos_crt_init_opt.cio_use_sensors = server;
 
+	daos_crt_init_opt.cio_swim_crt_idx = swim_ctx;
 	/** Scalable EndPoint-related settings */
 	d_getenv_bool("CRT_CTX_SHARE_ADDR", &sep);
 	if (!sep)

--- a/src/engine/srv_internal.h
+++ b/src/engine/srv_internal.h
@@ -112,6 +112,9 @@ extern unsigned int	dss_tgt_offload_xs_nr;
 extern unsigned int	dss_sys_xs_nr;
 /** Flag of helper XS as a pool */
 extern bool		dss_helper_pool;
+/** SWIM cart indext */
+extern unsigned int	dss_swim_idx;
+
 /** Shadow dss_get_module_info */
 struct dss_module_info *get_module_info(void);
 
@@ -136,6 +139,7 @@ void dss_dump_ABT_state(FILE *fp);
 void dss_xstreams_open_barrier(void);
 struct dss_xstream *dss_get_xstream(int stream_id);
 int dss_xstream_cnt(void);
+unsigned int dss_ctx_get_swim_ctx();
 
 /* srv_metrics.c */
 int dss_engine_metrics_init(void);
@@ -261,17 +265,19 @@ void ds_iv_fini(void);
 
 /** Total number of XS */
 #define DSS_XS_NR_TOTAL						\
-	(dss_sys_xs_nr + dss_tgt_nr + dss_tgt_offload_xs_nr)
+	(dss_sys_xs_nr + dss_tgt_nr + dss_tgt_offload_xs_nr +	\
+	 (dss_swim_idx == 0 ? 0 : 1))
 /** Total number of cart contexts created */
 #define DSS_CTX_NR_TOTAL					\
 	(DAOS_TGT0_OFFSET + dss_tgt_nr +			\
 	 (dss_tgt_offload_xs_nr > dss_tgt_nr ? dss_tgt_nr :	\
-	  dss_tgt_offload_xs_nr))
+	  dss_tgt_offload_xs_nr) + (dss_swim_idx == 0 ? 0 : 1))
 /** main XS id of (vos) tgt_id */
 #define DSS_MAIN_XS_ID(tgt_id)						\
 	(dss_helper_pool ? ((tgt_id) + dss_sys_xs_nr) :			\
 			   ((tgt_id) * ((dss_tgt_offload_xs_nr /	\
 			      dss_tgt_nr) + 1) + dss_sys_xs_nr))
+
 
 /**
  * get the VOS target ID of xstream.

--- a/src/engine/tests/drpc_client_tests.c
+++ b/src/engine/tests/drpc_client_tests.c
@@ -35,6 +35,7 @@ uint32_t	dss_tgt_offload_xs_nr = 3;
 uint32_t	dss_tgt_nr = 4;
 uint32_t	dss_sys_xs_nr = 2;
 uint32_t	dss_instance_idx = 5;
+uint32_t	dss_swim_idx = 0;
 
 static int		 crt_self_uri_get_return;
 static const char	*crt_self_uri_get_uri = "/cart/test/uri";

--- a/src/include/cart/types.h
+++ b/src/include/cart/types.h
@@ -71,6 +71,8 @@ typedef struct crt_init_options {
 	 */
 	uint32_t	cio_max_expected_size;
 	uint32_t	cio_max_unexpected_size;
+			/** swim crt index */
+	int		cio_swim_crt_idx;
 } crt_init_options_t;
 
 typedef int		crt_status_t;

--- a/src/include/daos/common.h
+++ b/src/include/daos/common.h
@@ -856,7 +856,8 @@ daos_recx_merge(daos_recx_t *src, daos_recx_t *dst)
 #define DAOS_NVME_SHMID_NONE	-1
 #define DAOS_NVME_MEM_PRIMARY	0
 
-crt_init_options_t *daos_crt_init_opt_get(bool server, int crt_nr);
+crt_init_options_t *daos_crt_init_opt_get(bool server, int crt_nr,
+					  int swim_idx);
 
 int crt_proc_struct_dtx_id(crt_proc_t proc, crt_proc_op_t proc_op,
 			   struct dtx_id *dti);


### PR DESCRIPTION
Let's assign SWIM to an independent xstream to avoid timeout,
if there are extra cores avabile.

Signed-off-by: Di Wang <di.wang@intel.com>