### PR TITLE
DAOS-4280 test: skip consistency verification after racer if  out of space (debug)

### DIFF
--- a/src/dtx/dtx_common.c
+++ b/src/dtx/dtx_common.c
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2019 Intel Corporation.
+ * (C) Copyright 2019-2020 Intel Corporation.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -96,7 +96,6 @@ dtx_flush_on_deregister(struct dss_module_info *dmi,
 {
 	struct ds_cont_child	*cont = dbca->dbca_cont;
 	struct ds_pool_child	*pool = cont->sc_pool;
-	ABT_future		 future = dbca->dbca_deregistering;
 	int			 rc;
 
 	D_ASSERT(dbca->dbca_deregistering != NULL);
@@ -123,7 +122,7 @@ dtx_flush_on_deregister(struct dss_module_info *dmi,
 	 * flush done, then free the dbca.
 	 */
 	d_list_del_init(&dbca->dbca_link);
-	rc = ABT_future_set(future, NULL);
+	rc = ABT_future_set(dbca->dbca_deregistering, NULL);
 	D_ASSERTF(rc == ABT_SUCCESS, "ABT_future_set failed for DTX "
 		  "flush on "DF_UUID": rc = %d\n", DP_UUID(cont->sc_uuid), rc);
 }

--- a/src/dtx/dtx_rpc.c
+++ b/src/dtx/dtx_rpc.c
@@ -247,10 +247,12 @@ dtx_req_list_cb(void **args)
 				dra->dra_result = drr->drr_result;
 		}
 
+		drr = args[0];
 		D_CDEBUG(dra->dra_result < 0, DLOG_ERR, DB_TRACE,
-			 "DTX req for opc %x %s: rc = %d.\n", dra->dra_opc,
+			 "DTX req for opc %x ("DF_DTI") %s, count %d: %d.\n",
+			 dra->dra_opc, DP_DTI(drr->drr_dti),
 			 dra->dra_result < 0 ? "failed" : "succeed",
-			 dra->dra_result);
+			 dra->dra_length, dra->dra_result);
 	}
 }
 

--- a/src/vos/vos_dtx.c
+++ b/src/vos/vos_dtx.c
@@ -63,18 +63,18 @@ static inline int
 dtx_inprogress(struct dtx_handle *dth, struct vos_dtx_act_ent *dae, int pos)
 {
 	if (dae != NULL) {
-		D_DEBUG(DB_TRACE, "Hit uncommitted DTX "DF_DTI" at %d\n",
+		D_DEBUG(DB_IO, "Hit uncommitted DTX "DF_DTI" at %d\n",
 			DP_DTI(&DAE_XID(dae)), pos);
 
 		if (dth != NULL && dth->dth_conflict != NULL) {
-			D_DEBUG(DB_TRACE, "Record conflict DTX "DF_DTI"\n",
+			D_DEBUG(DB_IO, "Record conflict DTX "DF_DTI"\n",
 				DP_DTI(&DAE_XID(dae)));
 			daos_dti_copy(&dth->dth_conflict->dce_xid,
 				      &DAE_XID(dae));
 			dth->dth_conflict->dce_dkey = DAE_DKEY_HASH(dae);
 		}
 	} else {
-		D_DEBUG(DB_TRACE, "Hit uncommitted (unknown) DTX at %d\n", pos);
+		D_DEBUG(DB_IO, "Hit uncommitted (unknown) DTX at %d\n", pos);
 	}
 
 	return -DER_INPROGRESS;
@@ -539,8 +539,10 @@ vos_dtx_commit_one(struct vos_container *cont, struct dtx_id *dti,
 		goto out;
 
 	dtx_rec_release(cont, dae, false, &offset);
-	vos_dtx_del_cos(cont, &DAE_OID(dae), dti, DAE_DKEY_HASH(dae),
+	rc = vos_dtx_del_cos(cont, &DAE_OID(dae), dti, DAE_DKEY_HASH(dae),
 			DAE_INTENT(dae) == DAOS_INTENT_PUNCH ? true : false);
+	if (rc != 0)
+		D_GOTO(out, rc);
 
 	/* If dbtree_delete() failed, the @dae will be left in the active DTX
 	 * table until close the container. It is harmless but waste some DRAM.
@@ -551,8 +553,9 @@ vos_dtx_commit_one(struct vos_container *cont, struct dtx_id *dti,
 		umem_free(vos_cont2umm(cont), offset);
 
 out:
-	D_DEBUG(DB_TRACE, "Commit the DTX "DF_DTI": rc = "DF_RC"\n",
-		DP_DTI(dti), DP_RC(rc));
+	D_CDEBUG(rc != 0 && rc != DER_NONEXIST, DLOG_ERR, DB_IO,
+		 "Commit the DTX "DF_DTI": rc = "DF_RC"\n",
+		 DP_DTI(dti), DP_RC(rc));
 	if (rc != 0) {
 		if (dce != NULL)
 			D_FREE_PTR(dce);
@@ -590,7 +593,7 @@ vos_dtx_abort_one(struct vos_container *cont, daos_epoch_t epoch,
 		dtx_rec_release(cont, dae, true, NULL);
 
 out:
-	D_DEBUG(DB_TRACE, "Abort the DTX "DF_DTI": rc = "DF_RC"\n", DP_DTI(dti),
+	D_DEBUG(DB_IO, "Abort the DTX "DF_DTI": rc = "DF_RC"\n", DP_DTI(dti),
 		DP_RC(rc));
 
 	return rc;
@@ -952,7 +955,7 @@ vos_dtx_register_record(struct umem_instance *umm, umem_off_t record,
 			dth->dth_has_ilog = 1;
 	}
 
-	D_DEBUG(DB_TRACE, "Register DTX record for "DF_DTI
+	D_DEBUG(DB_IO, "Register DTX record for "DF_DTI
 		": entry %p, type %d, %s ilog entry, rc %d\n",
 		DP_DTI(&dth->dth_xid), dth->dth_ent, type,
 		dth->dth_has_ilog ? "has" : "has not", rc);
@@ -1250,12 +1253,15 @@ again:
 		dce_df = &dbd->dbd_commmitted_data[dbd->dbd_count];
 	}
 
-	for (i = 0, j = 0; i < slots; i++, cur++) {
+	for (i = 0, j = 0; i < slots && rc1 == 0; i++, cur++) {
 		struct vos_dtx_cmt_ent	*dce = NULL;
 
 		rc = vos_dtx_commit_one(cont, &dtis[cur], epoch, &dce);
 		if (rc == 0 && dce != NULL)
 			committed++;
+
+		if (rc == -DER_NONEXIST)
+			rc = 0;
 
 		if (rc1 == 0)
 			rc1 = rc;
@@ -1282,7 +1288,7 @@ again:
 	if (j > 0)
 		dbd->dbd_count += j;
 
-	if (count == 0)
+	if (count == 0 || rc1 != 0)
 		return committed > 0 ? 0 : rc1;
 
 	if (j < slots) {
@@ -1342,12 +1348,15 @@ new_blob:
 
 	cont_df->cd_dtx_committed_tail = dbd_off;
 
-	for (i = 0, j = 0; i < count; i++, cur++) {
+	for (i = 0, j = 0; i < count && rc1 == 0; i++, cur++) {
 		struct vos_dtx_cmt_ent	*dce = NULL;
 
 		rc = vos_dtx_commit_one(cont, &dtis[cur], epoch, &dce);
 		if (rc == 0 && dce != NULL)
 			committed++;
+
+		if (rc == -DER_NONEXIST)
+			rc = 0;
 
 		if (rc1 == 0)
 			rc1 = rc;

--- a/src/vos/vos_dtx_cos.c
+++ b/src/vos/vos_dtx_cos.c
@@ -545,13 +545,13 @@ vos_dtx_fetch_committable(daos_handle_t coh, uint32_t max_cnt,
 	return min(count, i);
 }
 
-void
+int
 vos_dtx_del_cos(struct vos_container *cont, daos_unit_oid_t *oid,
 		struct dtx_id *xid, uint64_t dkey_hash, bool punch)
 {
 	struct dtx_cos_key		 key;
-	d_iov_t			 kiov;
-	d_iov_t			 riov;
+	d_iov_t				 kiov;
+	d_iov_t				 riov;
 	struct dtx_cos_rec		*dcr;
 	struct dtx_cos_rec_child	*dcrc;
 	d_list_t			*head;
@@ -563,8 +563,15 @@ vos_dtx_del_cos(struct vos_container *cont, daos_unit_oid_t *oid,
 	d_iov_set(&riov, NULL, 0);
 
 	rc = dbtree_lookup(cont->vc_dtx_cos_hdl, &kiov, &riov);
-	if (rc != 0)
-		return;
+	if (rc != 0) {
+		if (rc == -DER_NONEXIST)
+			return 0;
+
+		D_ERROR("Fail to remove "DF_DTI" from CoS cache: %d\n",
+			DP_DTI(xid), rc);
+
+		return rc;
+	}
 
 	dcr = (struct dtx_cos_rec *)riov.iov_buf;
 	if (punch)
@@ -575,11 +582,6 @@ vos_dtx_del_cos(struct vos_container *cont, daos_unit_oid_t *oid,
 	d_list_for_each_entry(dcrc, head, dcrc_link) {
 		if (memcmp(&dcrc->dcrc_dti, xid, sizeof(*xid)) != 0)
 			continue;
-
-		D_DEBUG(DB_TRACE, "Remove DTX "DF_DTI" from CoS cache, "
-			"key %llu, intent %s, has ilog entry\n",
-			DP_DTI(&dcrc->dcrc_dti), (unsigned long long)dkey_hash,
-			punch ? "Punch" : "Update");
 
 		d_list_del(&dcrc->dcrc_committable);
 		d_list_del(&dcrc->dcrc_link);
@@ -593,23 +595,24 @@ vos_dtx_del_cos(struct vos_container *cont, daos_unit_oid_t *oid,
 
 		if (dcr->dcr_punch_count == 0 && dcr->dcr_update_count == 0 &&
 		    dcr->dcr_ilog_count == 0)
-			dbtree_delete(cont->vc_dtx_cos_hdl, BTR_PROBE_EQ,
-				      &kiov, NULL);
+			rc = dbtree_delete(cont->vc_dtx_cos_hdl, BTR_PROBE_EQ,
+					   &kiov, NULL);
 
-		return;
+		D_CDEBUG(rc != 0, DLOG_ERR, DB_IO, "Remove DTX "DF_DTI" from "
+			 "CoS cache, key %llu, intent %s, has ilog entry: %d\n",
+			 DP_DTI(xid), (unsigned long long)dkey_hash,
+			 punch ? "Punch" : "Update", rc);
+
+		return rc;
 	}
 
 	if (punch)
-		return;
+		return 0;
 
 	/* For UPDATE DTX, the DTX entry can be in {update,ilog}_list */
 	d_list_for_each_entry(dcrc, &dcr->dcr_update_list, dcrc_link) {
 		if (memcmp(&dcrc->dcrc_dti, xid, sizeof(*xid)) != 0)
 			continue;
-
-		D_DEBUG(DB_TRACE, "Remove DTX "DF_DTI" from CoS cache, "
-			"key %llu, intent Update, has not ilog entry\n",
-			DP_DTI(&dcrc->dcrc_dti), (unsigned long long)dkey_hash);
 
 		d_list_del(&dcrc->dcrc_committable);
 		d_list_del(&dcrc->dcrc_link);
@@ -620,11 +623,18 @@ vos_dtx_del_cos(struct vos_container *cont, daos_unit_oid_t *oid,
 
 		if (dcr->dcr_punch_count == 0 && dcr->dcr_update_count == 0 &&
 		    dcr->dcr_ilog_count == 0)
-			dbtree_delete(cont->vc_dtx_cos_hdl, BTR_PROBE_EQ,
-				      &kiov, NULL);
+			rc = dbtree_delete(cont->vc_dtx_cos_hdl, BTR_PROBE_EQ,
+					   &kiov, NULL);
 
-		return;
+		D_CDEBUG(rc != 0, DLOG_ERR, DB_IO, "Remove DTX "DF_DTI" from "
+			 "CoS cache, key %llu, intent Update, has not ilog "
+			 "entry: %d\n",
+			 DP_DTI(xid), (unsigned long long)dkey_hash, rc);
+
+		break;
 	}
+
+	return rc;
 }
 
 uint64_t

--- a/src/vos/vos_internal.h
+++ b/src/vos/vos_internal.h
@@ -457,8 +457,11 @@ vos_dtx_cos_register(void);
  * \param xid		[IN]	Pointer to the DTX identifier.
  * \param dkey_hash	[IN]	The hashed dkey.
  * \param punch		[IN]	For punch DTX or not.
+ *
+ * \return		Zero on success.
+ * \return		Other negative value if error.
  */
-void
+int
 vos_dtx_del_cos(struct vos_container *cont, daos_unit_oid_t *oid,
 		struct dtx_id *xid, uint64_t dkey_hash, bool punch);
 


### PR DESCRIPTION
Return DTX commit failure to the caller, then dtx_obj_sync will not fall
into dead loop if out of space. The upper layer user (such as daos racer)
should skip consistency verification if server out of space.

Another fix is that trace vos_dtx_del_cos() failure, that may cause
DTX entry has been committed but still be kept in the CoS cache, as
to related commit ULT (such as batched commit) fall into dead loop.

The pach also increase debug level to DLOG_ERR for DTX RPC failure.

Signed-off-by: Fan Yong <fan.yong@intel.com>