### PR TITLE
DAOS-2167 api: add a force destroy pool test

### DIFF
--- a/src/tests/ftest/pool/destroy_tests.py
+++ b/src/tests/ftest/pool/destroy_tests.py
@@ -374,6 +374,45 @@ class DestroyTests(TestWithServers):
         self.assertTrue(
             exception_detected, "No exception when deleting a connected pool")
 
+    def test_forcedestroy_connected(self):
+        """Forcibly destroy pool with connected client.
+
+        Test destroying a pool that has a connected client with force == true.
+        Should pass.
+
+        :avocado: tags=all,medium,pr
+        :avocado: tags=pool,destroy,forcedestroyconnected
+        """
+        hostlist_servers = self.hostlist_servers[:1]
+
+        # Start servers
+        self.start_servers({self.server_group: hostlist_servers})
+
+        # Create the pool
+        self.validate_pool_creation(hostlist_servers, self.server_group)
+
+        # Connect to the pool
+        self.assertTrue(
+            self.pool.connect(), "Pool connect failed before destroy")
+
+        # Destroy pool with direct API call (no disconnect)
+        self.log.info("Attempting to forcibly destroy a connected pool")
+        exception_detected = False
+        try:
+            self.pool.pool.destroy(1)
+
+        except DaosApiError as result:
+            exception_detected = True
+            self.log.info(
+                "Unexpected exception - destroying connected pool: %s",
+                str(result))
+
+        finally:
+            # Prevent attempting to delete the pool in tearDown()
+            self.pool.pool = None
+            if exception_detected:
+                self.fail("Force destroying connected pool failed")
+
     def test_destroy_withdata(self):
         """Destroy Pool with data.
 


### PR DESCRIPTION
Cherry picked PR #2009
from daos master branch to release/0.9 branch.

With this change a new pool destroy test is added that invokes the
DAOS pool destroy API with force=1 on a connected pool. Before recent
changes to the pool destroy implementation, this scenario was observed
to result in segmentation faults. This does not occur with the latest
implementation. So now a test is needed to explicitly verify.

Skip-run_test: true
Skip-func-hw-test: true
Test-tag: destroyconnected forcedestroyconnected

Signed-off-by: Ken Cain <kenneth.c.cain@intel.com>