### PR TITLE
DAOS-1037 md: test: enable container destroy testing

### DIFF
--- a/src/container/srv_container.c
+++ b/src/container/srv_container.c
@@ -810,11 +810,8 @@ cont_destroy(struct rdb_tx *tx, struct ds_pool_hdl *pool_hdl,
 
 	/* Check if the container attribute KVS exists. */
 	rc = cont_lookup(tx, svc, in->cdi_op.ci_uuid, &cont);
-	if (rc != 0) {
-		if (rc == -DER_NONEXIST)
-			rc = 0;
+	if (rc != 0)
 		goto out;
-	}
 
 	rc = evict_hdls(tx, cont, in->cdi_force, rpc->cr_ctx);
 	if (rc != 0)

--- a/src/tests/ftest/container/delete.py
+++ b/src/tests/ftest/container/delete.py
@@ -39,7 +39,7 @@ class DeleteContainerTest(TestWithServers):
         """
         Test basic container delete
 
-        :avocado: tags=all,container,tiny,smoke,pr,contdelete
+        :avocado: tags=all,container,tiny,smoke,full_regression,contdelete
         """
         expected_for_param = []
         uuidlist = self.params.get("uuid",
@@ -58,15 +58,16 @@ class DeleteContainerTest(TestWithServers):
 
         forcelist = self.params.get("force", "/run/createtests/ForceDestroy/*/")
         force = forcelist[0]
-        expected_for_param.append(forcelist[1])
 
-        if force >= 1:
-            self.cancel("Force >= 1 blocked by issue described in "
-                        "https://jira.hpdd.intel.com/browse/DAOS-689")
+        # force=0 in .yaml file specifies FAIL, however:
+        # if not opened and force=0 expect pass
+        if force == 0 and not opened:
+            expected_for_param.append('PASS')
+        else:
+            expected_for_param.append(forcelist[1])
 
-        if force == 0:
-            self.cancel("Force = 0 blocked by "
-                        "https://jira.hpdd.intel.com/browse/DAOS-1935")
+        # opened=True in .yaml file specifies PASS, however
+        # if it is also the case force=0, then FAIL is expected
 
         expected_result = 'PASS'
         for result in expected_for_param:
@@ -78,15 +79,18 @@ class DeleteContainerTest(TestWithServers):
         # daos storage and connect to it
         self.prepare_pool()
 
+        passed = False
         try:
             self.container = DaosContainer(self.context)
 
             # create should always work (testing destroy)
             if not cont_uuid == 'INVALID':
                 cont_uuid = uuid.UUID(uuidlist[0])
+                save_cont_uuid = cont_uuid
                 self.container.create(self.pool.pool.handle, cont_uuid)
             else:
                 self.container.create(self.pool.pool.handle)
+                save_cont_uuid = uuid.UUID(self.container.get_uuid_str())
 
             # Opens the container if required
             if opened:
@@ -102,13 +106,23 @@ class DeleteContainerTest(TestWithServers):
                 cont_uuid = uuid.uuid4()
 
             self.container.destroy(force=force, poh=poh, con_uuid=cont_uuid)
-            self.container = None
 
-            if expected_result in ['FAIL']:
-                self.fail("Test was expected to fail but it passed.\n")
+            passed = True
 
         except DaosApiError as excep:
-            self.d_log.error(excep)
-            self.d_log.error(traceback.format_exc())
-            if expected_result == 'PASS':
+            self.log.info(excep, traceback.format_exc())
+            self.container.destroy(force=1, poh=self.pool.pool.handle,
+                                   con_uuid=save_cont_uuid)
+
+        finally:
+            # close container handle, release a reference on pool in client lib
+            # Otherwise test will ERROR in tearDown (pool disconnect -DER_BUSY)
+            if opened:
+                self.container.close()
+
+            self.container = None
+
+            if expected_result == 'PASS' and not passed:
                 self.fail("Test was expected to pass but it failed.\n")
+            if expected_result == 'FAIL' and passed:
+                self.fail("Test was expected to fail but it passed.\n")

--- a/src/tests/ftest/container/delete.yaml
+++ b/src/tests/ftest/container/delete.yaml
@@ -3,12 +3,12 @@
 hosts:
   test_servers:
     - server-A
-timeout: 50
+timeout: 60
 server_config:
   name: daos_server
 pool:
   mode: 511
-  scm_size: 16777216
+  scm_size: 1073741824
   name: daos_server
   control_method: dmg
 createtests:
@@ -20,31 +20,31 @@ createtests:
     nonexistingUUID:
       uuid:
         - INVALID
-        - PASS
-  # pass for opened should probably be fail when force works, DAOS-1935
+        - FAIL
   ConnectionOpened: !mux
-    #CTopened:
-    #  opened:
-    #    - TRUE
-    #    - PASS
+    # opened=TRUE and force=0 should FAIL (noForce below causes FAIL)
+    CTopened:
+      opened:
+        - TRUE
+        - PASS
     CTclosed:
       opened:
         - FALSE
         - PASS
-  # does not work at the moment, DAOS bug DAOS-1935
   ForceDestroy: !mux
-    #noForce:
-    #  force:
-    #    - 0
-    #    - FAIL
-        validForce:
-          force:
-            - 1
-            - PASS
-    #    randomForce:
-    #      force:
-    #        - 99999999
-    #        - PASS
+    # force=0 and opened=FALSE expected to PASS (delete.py overrides this FAIL)
+    noForce:
+      force:
+        - 0
+        - FAIL
+    validForce:
+      force:
+        - 1
+        - PASS
+    randomForce:
+      force:
+        - 99999999
+        - PASS
   PoolHandles: !mux
     validPH:
       poh:


### PR DESCRIPTION
Cherry picked commit PR #2147 from daos master release/0.9 branch.
Also with this change, to match a recent change on master,
container destroy when presented with a nonexising UUID returns the
error -DER_NONEXIST rather than translating to success (rc=0).

Recently (in PR #1949) DAOS container destroy was enhanced to take into
account the status of any open handles and the force argument.

With this change, the container destroy functional test is re-enabled
and expanded into several more test cases that were either cancelled at
runtime, or commented out in the configuration mux. The container
handle opened by the test is also closed even after a container destroy
with force. This avoids an ERROR during test tearDown, with pool
disconnect failing (container is still referenced by pool in libdaos).

Test-tag: pr,-hw contdelete

Signed-off-by: Ken Cain <kenneth.c.cain@intel.com>