### PR TITLE
DAOS-4248 tse: fix conflict usage of tse_task_set_priv (#2047)

### DIFF
--- a/src/common/tse.c
+++ b/src/common/tse.c
@@ -193,6 +193,24 @@ tse_task_set_priv(tse_task_t *task, void *priv)
 	return old;
 }
 
+void *
+tse_task_get_priv_internal(tse_task_t *task)
+{
+	struct tse_task_private *dtp = tse_task2priv(task);
+
+	return dtp->dtp_priv_internal;
+}
+
+void *
+tse_task_set_priv_internal(tse_task_t *task, void *priv)
+{
+	struct tse_task_private *dtp = tse_task2priv(task);
+	void			*old = dtp->dtp_priv_internal;
+
+	dtp->dtp_priv_internal = priv;
+	return old;
+}
+
 tse_sched_t *
 tse_task2sched(tse_task_t *task)
 {

--- a/src/common/tse_internal.h
+++ b/src/common/tse_internal.h
@@ -34,7 +34,7 @@
  */
 
 /* NB: tse_task_private is TSE_PRIV_SIZE = 1016 bytes for now */
-#define TSE_TASK_ARG_LEN		888
+#define TSE_TASK_ARG_LEN		880
 
 struct tse_task_private {
 	struct tse_sched_private	*dtp_sched;
@@ -80,6 +80,10 @@ struct tse_task_private {
 	 * fit in.
 	 */
 	void				*dtp_priv;
+	/**
+	 * DAOS internal task parameter pointer.
+	 */
+	void				*dtp_priv_internal;
 	/**
 	 * reserved buffer for user to assign embedded parameters, it also can
 	 * be used as task stack space that can push/pop parameters to

--- a/src/include/daos/event.h
+++ b/src/include/daos/event.h
@@ -32,6 +32,7 @@
 #include <gurt/list.h>
 #include <gurt/hash.h>
 #include <daos_task.h>
+#include <daos/task.h>
 
 enum daos_ev_flags {
 	/**
@@ -193,10 +194,10 @@ dc_task_get_opc(tse_task_t *task);
 	tse_task_decref(task)
 
 #define dc_task_set_priv(task, priv)				\
-	tse_task_set_priv(task, priv)
+	tse_task_set_priv_internal(task, priv)
 
 #define dc_task_get_priv(task)					\
-	tse_task_get_priv(task)
+	tse_task_get_priv_internal(task)
 
 #define dc_task_list_add(task, head)				\
 	tse_task_list_add(task, head)

--- a/src/include/daos/task.h
+++ b/src/include/daos/task.h
@@ -33,6 +33,63 @@
 #include <daos/common.h>
 #include <daos_task.h>
 
+/**
+ * Push to task stack space. This API only reserves space on the task stack, no
+ * data copy involved.
+ *
+ * \param task [in] task to push the buffer.
+ * \param size [in] buffer size.
+ *
+ * \return	pointer to the pushed buffer in task stack.
+ */
+void *
+tse_task_stack_push(tse_task_t *task, uint32_t size);
+
+/**
+ * Pop from task stack space. This API only reserves space on the task stack, no
+ * data copy involved.
+ *
+ * \param task [in] task to pop the buffer.
+ * \param size [in] buffer size.
+ *
+ * \return	pointer to the poped buffer in task stack.
+ */
+void *
+tse_task_stack_pop(tse_task_t *task, uint32_t size);
+
+/**
+ * Push data to task stack space, will copy the data to stack.
+ *
+ * \param task [in]	task to push the buffer.
+ * \param data [in]	pointer of data to push
+ * \param len  [in]	length of data
+ */
+void
+tse_task_stack_push_data(tse_task_t *task, void *data, uint32_t len);
+
+/**
+ * Pop data from task stack space, will copy the data from stack.
+ *
+ * \param task [in]	task to push the buffer.
+ * \param data [in/out]	pointer of value to store the poped data
+ * \param len  [in]	length of data
+ */
+void
+tse_task_stack_pop_data(tse_task_t *task, void *data, uint32_t len);
+
+/**
+ * Return the internal private data of the task.
+ */
+void *
+tse_task_get_priv_internal(tse_task_t *task);
+
+/**
+ * Set or change the internal private data of the task. The original internal
+ * private data will be returned.
+ */
+void *
+tse_task_set_priv_internal(tse_task_t *task, void *priv);
+
 struct daos_task_api {
 	tse_task_func_t		task_func;
 	daos_size_t		arg_size;

--- a/src/include/daos/tse.h
+++ b/src/include/daos/tse.h
@@ -258,50 +258,6 @@ void *
 tse_task_get_priv(tse_task_t *task);
 
 /**
- * Push to task stack space. This API only reserves space on the task stack, no
- * data copy involved.
- *
- * \param task [in] task to push the buffer.
- * \param size [in] buffer size.
- *
- * \return	pointer to the pushed buffer in task stack.
- */
-void *
-tse_task_stack_push(tse_task_t *task, uint32_t size);
-
-/**
- * Pop from task stack space. This API only reserves space on the task stack, no
- * data copy involved.
- *
- * \param task [in] task to pop the buffer.
- * \param size [in] buffer size.
- *
- * \return	pointer to the poped buffer in task stack.
- */
-void *
-tse_task_stack_pop(tse_task_t *task, uint32_t size);
-
-/**
- * Push data to task stack space, will copy the data to stack.
- *
- * \param task [in]	task to push the buffer.
- * \param data [in]	pointer of data to push
- * \param len  [in]	length of data
- */
-void
-tse_task_stack_push_data(tse_task_t *task, void *data, uint32_t len);
-
-/**
- * Pop data from task stack space, will copy the data from stack.
- *
- * \param task [in]	task to push the buffer.
- * \param data [in/out]	pointer of value to store the poped data
- * \param len  [in]	length of data
- */
-void
-tse_task_stack_pop_data(tse_task_t *task, void *data, uint32_t len);
-
-/**
  * Set or change the private data of the task. The original private data will
  * be returned.
  */

--- a/src/object/obj_internal.h
+++ b/src/object/obj_internal.h
@@ -33,6 +33,7 @@
 #include <daos/common.h>
 #include <daos/event.h>
 #include <daos/tse.h>
+#include <daos/task.h>
 #include <daos/placement.h>
 #include <daos/btree.h>
 #include <daos/btree_class.h>


### PR DESCRIPTION
tse_task_set_priv/_get_priv is public tse API, it will conflict if both
DAOS internal and DAOS user call it.
This patch keep two private pointers, one for DAOS internal and one for
user. tse_task_set_priv() is exported to user, and daos_task_set_priv()
is for DAOS internal usage.
Several tse API is not public exported anymore like
tse_task_stack_push/_pop/_push_data/_pop_data.

Signed-off-by: Xuezhao Liu <xuezhao.liu@intel.com>