### PR TITLE
DAOS-623 build: -Werror inadvertently removed

### DIFF
--- a/src/client/pydaos/SConscript
+++ b/src/client/pydaos/SConscript
@@ -21,6 +21,8 @@ def build_shim_module(env, lib_prefix, version):
     new_env.AppendUnique(LIBPATH=["../dfs"])
     new_env.AppendUnique(RPATH=[Literal(r'\$$ORIGIN/../../..')])
 
+    daos_build.clear_icc_env(new_env)
+
     obj = new_env.SharedObject(tgt_name, 'pydaos_shim.c',
                                CC='gcc -pthread',
                                SHLINKFLAGS=[],

--- a/src/container/cli.c
+++ b/src/container/cli.c
@@ -2175,7 +2175,7 @@ dc_cont_get_attr(tse_task_t *task)
 	D_ASSERTF(args != NULL, "Task Argument OPC does not match DC OPC\n");
 
 	rc = attr_check_input(args->n, args->names,
-			      (void const *const) args->values,
+			      (const void *const*) args->values,
 			      (size_t *)args->sizes, true);
 	if (rc != 0)
 		D_GOTO(out, rc);

--- a/src/pool/cli.c
+++ b/src/pool/cli.c
@@ -1968,7 +1968,7 @@ dc_pool_get_attr(tse_task_t *task)
 	D_ASSERTF(args != NULL, "Task Argument OPC does not match DC OPC\n");
 
 	rc = attr_check_input(args->n, args->names,
-			      (void const *const) args->values,
+			      args->values,
 			      (size_t *)args->sizes, true);
 	if (rc != 0)
 		D_GOTO(out, rc);

--- a/src/pool/cli.c
+++ b/src/pool/cli.c
@@ -1968,7 +1968,7 @@ dc_pool_get_attr(tse_task_t *task)
 	D_ASSERTF(args != NULL, "Task Argument OPC does not match DC OPC\n");
 
 	rc = attr_check_input(args->n, args->names,
-			      args->values,
+			      (const void *const*) args->values,
 			      (size_t *)args->sizes, true);
 	if (rc != 0)
 		D_GOTO(out, rc);

--- a/src/tests/SConscript
+++ b/src/tests/SConscript
@@ -16,6 +16,9 @@ def scons():
         print("Install and load mpich or openmpi\n")
         return
 
+    # Clear out any compiler specific flags used, as mpicc might not support them.
+    denv.Replace(CCFLAGS="")
+
     # Add runtime paths for daos libraries
     denv.AppendUnique(RPATH=[Literal(r'\$$ORIGIN/../lib64/daos_srv')])
 

--- a/src/tests/SConscript
+++ b/src/tests/SConscript
@@ -16,9 +16,6 @@ def scons():
         print("Install and load mpich or openmpi\n")
         return
 
-    # Clear out any compiler specific flags used, as mpicc might not support them.
-    denv.Replace(CCFLAGS="")
-
     # Add runtime paths for daos libraries
     denv.AppendUnique(RPATH=[Literal(r'\$$ORIGIN/../lib64/daos_srv')])
 

--- a/utils/daos_build.py
+++ b/utils/daos_build.py
@@ -35,18 +35,32 @@ def load_mpi_path(env):
     if mpicc:
         env.PrependENVPath("PATH", os.path.dirname(mpicc))
 
+def clear_icc_env(env):
+    """Remove icc specific options from environment"""
+    if env.subst("$COMPILER") == "icc":
+        linkflags = str(env.get("LINKFLAGS")).split()
+        if '-static-intel' in linkflags:
+            linkflags.remove('-static-intel')
+        for flag_type in ['CCFLAGS', 'CXXFLAGS', 'CFLAGS']:
+            oldflags = str(env.get(flag_type)).split()
+            newflags = []
+            for flag in oldflags:
+                if 'diag-disable' in flag:
+                    continue
+                if '-Werror-all' == flag:
+                    newflags.append('-Werror')
+                    continue
+                newflags.append(flag)
+            env.Replace(**{flag_type : newflags})
+        env.Replace(LINKFLAGS=linkflags)
+
 def _find_mpicc(env):
     """find mpicc"""
     mpicc = find_executable("mpicc")
     if mpicc:
         env.Replace(CC="mpicc")
         env.Replace(LINK="mpicc")
-        if env.subst("$COMPILER") == "icc":
-            linkflags = str(env.get("LINKFLAGS")).split()
-            if '-static-intel' in linkflags:
-                linkflags.remove('-static-intel')
-            env.Replace(LINKFLAGS=linkflags)
-
+        clear_icc_env(env)
         load_mpi_path(env)
         return True
     return False

--- a/utils/sl/prereq_tools/base.py
+++ b/utils/sl/prereq_tools/base.py
@@ -821,7 +821,8 @@ class PreReqComponent():
         # disable the warning about Cilk since we don't use it
         self.__env.AppendUnique(LINKFLAGS=["-static-intel",
                                            "-diag-disable=10237"])
-
+        self.__env.AppendUnique(CCFLAGS=["-diag-disable:2282",
+                                         "-diag-disable:188"])
 
     def _setup_compiler(self, warning_level):
         """Setup the compiler to use"""

--- a/utils/sl/prereq_tools/base.py
+++ b/utils/sl/prereq_tools/base.py
@@ -843,15 +843,15 @@ class PreReqComponent():
         if compiler == 'icc':
             self._setup_intelc()
 
-        env = self.__env.Clone()
-        config = Configure(env)
-
         if warning_level == 'error':
             if compiler == 'icc':
                 warning_flag = '-Werror-all'
             else:
                 warning_flag = '-Werror'
             self.__env.AppendUnique(CCFLAGS=warning_flag)
+
+        env = self.__env.Clone()
+        config = Configure(env)
 
         if self.__check_only:
             # Have to temporarily turn off dry run to allow this check.

--- a/utils/sl/prereq_tools/base.py
+++ b/utils/sl/prereq_tools/base.py
@@ -843,15 +843,15 @@ class PreReqComponent():
         if compiler == 'icc':
             self._setup_intelc()
 
-        if warning_level == 'ERROR':
+        env = self.__env.Clone()
+        config = Configure(env)
+
+        if warning_level == 'error':
             if compiler == 'icc':
                 warning_flag = '-Werror-all'
             else:
                 warning_flag = '-Werror'
-            env.AppendUnique(CCFLAGS=warning_flag)
-
-        env = self.__env.Clone()
-        config = Configure(env)
+            self.__env.AppendUnique(CCFLAGS=warning_flag)
 
         if self.__check_only:
             # Have to temporarily turn off dry run to allow this check.

--- a/utils/sl/prereq_tools/base.py
+++ b/utils/sl/prereq_tools/base.py
@@ -823,6 +823,7 @@ class PreReqComponent():
                                            "-diag-disable=10237"])
         self.__env.AppendUnique(CCFLAGS=["-diag-disable:2282",
                                          "-diag-disable:188",
+                                         "-diag-disable:2405",
                                          "-diag-disable:1338"])
 
     def _setup_compiler(self, warning_level):

--- a/utils/sl/prereq_tools/base.py
+++ b/utils/sl/prereq_tools/base.py
@@ -822,7 +822,8 @@ class PreReqComponent():
         self.__env.AppendUnique(LINKFLAGS=["-static-intel",
                                            "-diag-disable=10237"])
         self.__env.AppendUnique(CCFLAGS=["-diag-disable:2282",
-                                         "-diag-disable:188"])
+                                         "-diag-disable:188",
+                                         "-diag-disable:1338"])
 
     def _setup_compiler(self, warning_level):
         """Setup the compiler to use"""


### PR DESCRIPTION
This fixes the check for -Werror so as to restore it to the compiler
commands.

Signed-off-by: Jeff Olivier <jeffrey.v.olivier@intel.com>