### PR TITLE
DAOS-2448 obj: disable DTX for echo test

### DIFF
--- a/src/object/cli_obj.c
+++ b/src/object/cli_obj.c
@@ -2364,7 +2364,8 @@ shard_rw_prep(struct shard_auxi_args *shard_auxi, struct dc_object *obj,
 	shard_arg->api_args		= obj_args;
 	if (obj_auxi->opc == DAOS_OBJ_RPC_UPDATE)
 		daos_dti_gen(&shard_arg->dti,
-			     srv_io_mode != DIM_DTX_FULL_ENABLED);
+			     (srv_io_mode != DIM_DTX_FULL_ENABLED) ||
+			     daos_obj_is_echo(obj->cob_md.omd_id));
 	shard_arg->dkey_hash		= dkey_hash;
 	shard_arg->bulks		= obj_auxi->bulks;
 	if (obj_auxi->req_reasbed) {

--- a/src/vos/vos_io.c
+++ b/src/vos/vos_io.c
@@ -367,8 +367,7 @@ save_csum(struct vos_io_context *ioc, struct dcs_csum_info *csum_info)
 /** Fetch the single value within the specified epoch range of an key */
 static int
 akey_fetch_single(daos_handle_t toh, const daos_epoch_range_t *epr,
-		  daos_size_t *rsize, daos_size_t *gsize,
-		  struct vos_io_context *ioc)
+		  daos_size_t *rsize, struct vos_io_context *ioc)
 {
 	struct vos_key_bundle	 kbund;
 	struct vos_rec_bundle	 rbund;
@@ -409,8 +408,7 @@ akey_fetch_single(daos_handle_t toh, const daos_epoch_range_t *epr,
 	if (rc != 0)
 		goto out;
 
-	*rsize = rbund.rb_rsize;
-	*gsize = rbund.rb_gsize;
+	*rsize = rbund.rb_gsize;
 out:
 	return rc;
 }
@@ -653,8 +651,7 @@ akey_fetch(struct vos_io_context *ioc, daos_handle_t ak_toh)
 	}
 
 	if (iod->iod_type == DAOS_IOD_SINGLE) {
-		rc = akey_fetch_single(toh, &val_epr, &iod->iod_size,
-				       &iod->iod_size, ioc);
+		rc = akey_fetch_single(toh, &val_epr, &iod->iod_size, ioc);
 		goto out;
 	}
 


### PR DESCRIPTION
1. disable DTX for echo test by zero the dti at client.
2. cleanup VOS akey_fetch_single()'s parameter.

Signed-off-by: Xuezhao Liu <xuezhao.liu@intel.com>