### PR TITLE
DAOS-4393 test: Fault injection via daos_test

### DIFF
--- a/src/tests/ftest/util/apricot/apricot/test.py
+++ b/src/tests/ftest/util/apricot/apricot/test.py
@@ -35,7 +35,7 @@ from avocado import skip, TestFail
 from avocado.utils import process
 from ClusterShell.NodeSet import NodeSet, NodeSetParseError
 
-import fault_config_utils
+# import fault_config_utils
 import agent_utils
 import write_host_file
 
@@ -46,6 +46,7 @@ from env_modules import load_mpi
 from distutils.spawn import find_executable
 from dmg_utils import DmgCommand
 from test_utils_pool import TestPool
+from command_utils import FaultInjection
 
 
 # pylint: disable=invalid-name
@@ -165,14 +166,17 @@ class TestWithoutServers(Test):
             os.makedirs(self.tmp)
 
         # setup fault injection, this MUST be before API setup
-        fault_list = self.params.get("fault_list", '/run/faults/*/')
-        if fault_list:
+        # fault_list = self.params.get("fault_list", '/run/faults/*/')
+        # if fault_list:
             # not using workdir because the huge path was messing up
             # orterun or something, could re-evaluate this later
-            self.fault_file = fault_config_utils.write_fault_file(self.tmp,
-                                                                  fault_list,
-                                                                  None)
-            os.environ["D_FI_CONFIG"] = self.fault_file
+        #    self.fault_file = fault_config_utils.write_fault_file(self.tmp,
+        #                                                          fault_list,
+        #                                                          None)
+        #    os.environ["D_FI_CONFIG"] = self.fault_file
+
+        self.fault_injection = FaultInjection(os.path.join(self.tmp))
+        self.fault_injection.activate(self)
 
         self.context = DaosContext(self.prefix + '/lib64/')
         self.d_log = DaosLog(self.context)

--- a/src/tests/suite/daos_fault_inject.c
+++ b/src/tests/suite/daos_fault_inject.c
@@ -1,0 +1,48 @@
+#define D_LOGFAC	DD_FAC(tests)
+#include "daos_test.h"
+
+#include <daos/checksum.h>
+#include <gurt/types.h>
+#include <daos_prop.h>
+
+/** fault injection helpers */
+static void
+update_csum_fi()
+{
+	sleep(10);
+	daos_fail_loc_set(dt_inject_fault | DAOS_FAIL_ALWAYS);
+	sleep(dt_fi_sleep);
+}
+
+/*
+static void
+update_csum_fi()
+{
+	daos_fail_loc_set(dt_inject_fault | DAOS_FAIL_ALWAYS);
+}
+*/
+
+static int
+setup(void **state)
+{
+	return test_setup(state, SETUP_POOL_CONNECT, true, DEFAULT_POOL_SIZE,
+			  NULL);
+}
+
+static const struct CMUnitTest tests[] = {
+	{ "DAOS_FAULT: Set Fault Injection",
+		update_csum_fi, async_disable, test_case_teardown}
+};
+
+int
+run_daos_fault_injection(int rank, int size)
+{
+	int rc = 0;
+
+	if (rank == 0)
+		rc = cmocka_run_group_tests_name("DAOS Set fault injection",
+			tests, setup, test_teardown);
+	MPI_Barrier(MPI_COMM_WORLD);
+	return rc;
+
+}

--- a/src/tests/suite/daos_test.h
+++ b/src/tests/suite/daos_test.h
@@ -77,6 +77,10 @@ extern unsigned int dt_csum_type;
 extern unsigned int dt_csum_chunksize;
 extern bool dt_csum_server_verify;
 
+/** Fault injection value */
+extern uint64_t dt_inject_fault;
+extern unsigned int dt_fi_sleep;
+
 /* the temporary IO dir*/
 extern char *test_io_dir;
 /* the IO conf file*/
@@ -295,6 +299,7 @@ int run_daos_fs_test(int rank, int size, int *tests, int test_size);
 int run_daos_nvme_recov_test(int rank, int size, int *sub_tests,
 			     int sub_tests_size);
 int run_daos_rebuild_simple_test(int rank, int size, int *tests, int test_size);
+int run_daos_fault_injection(int rank, int size);
 
 void daos_kill_server(test_arg_t *arg, const uuid_t pool_uuid, const char *grp,
 		      d_rank_list_t *svc, d_rank_t rank);

--- a/src/tests/suite/daos_test_common.c
+++ b/src/tests/suite/daos_test_common.c
@@ -43,6 +43,10 @@ unsigned int	dt_csum_type;
 unsigned int	dt_csum_chunksize;
 bool		dt_csum_server_verify;
 
+/** Fault injection value */
+uint64_t dt_inject_fault;
+unsigned int dt_fi_sleep;
+
 /* Create or import a single pool with option to store info in arg->pool
  * or an alternate caller-specified test_pool structure.
  * ipool (optional): import pool: store info for an existing pool to arg->pool.


### PR DESCRIPTION
Summary: This PR tries enabled fault injection via the daos_test utility.
daos_test -I --enable_fault <DAOS_fault> eg: daos_test -I --enable_fault 65539  [this will enable DAOS_SHARD_OBJ_FAIL defined under daos/src/include/daos/common.h ]

Signed-off-by: Padmanabhan <ravindran.padmanabhan@intel.com>