### PR TITLE
DAOS-4120 md: pool create error cleanup on corpc send failure

### DIFF
--- a/src/mgmt/srv_pool.c
+++ b/src/mgmt/srv_pool.c
@@ -407,8 +407,11 @@ ds_mgmt_create_pool(uuid_t pool_uuid, const char *group, char *tgt_dev,
 	if (rc == 0 && DAOS_FAIL_CHECK(DAOS_POOL_CREATE_FAIL_CORPC))
 		rc = -DER_TIMEDOUT;
 	if (rc != 0) {
+		if (!DAOS_FAIL_CHECK(DAOS_POOL_CREATE_FAIL_CORPC))
+			D_ERROR(DF_UUID": dss_rpc_send MGMT_TGT_CREATE: %d\n",
+				DP_UUID(pool_uuid), rc);
 		crt_req_decref(tc_req);
-		goto out_preparation;
+		goto tgt_fail;
 	}
 
 	tc_out = crt_reply_get(tc_req);

--- a/src/mgmt/srv_pool.c
+++ b/src/mgmt/srv_pool.c
@@ -407,9 +407,8 @@ ds_mgmt_create_pool(uuid_t pool_uuid, const char *group, char *tgt_dev,
 	if (rc == 0 && DAOS_FAIL_CHECK(DAOS_POOL_CREATE_FAIL_CORPC))
 		rc = -DER_TIMEDOUT;
 	if (rc != 0) {
-		if (!DAOS_FAIL_CHECK(DAOS_POOL_CREATE_FAIL_CORPC))
-			D_ERROR(DF_UUID": dss_rpc_send MGMT_TGT_CREATE: %d\n",
-				DP_UUID(pool_uuid), rc);
+		D_ERROR(DF_UUID": dss_rpc_send MGMT_TGT_CREATE: %d\n",
+			DP_UUID(pool_uuid), rc);
 		crt_req_decref(tc_req);
 		goto tgt_fail;
 	}


### PR DESCRIPTION
With this change, when the management service while performing a pool
create fails to send the MGMT_TGT_CREATE corpc to the pool storage
target servers, the ds_mgmt_tgt_pool_destroy() function is called in
the error handling path. It prevents the following problem.

In rare cases when the dss_rpc_send() call fails (for example with
-DER_TIMEDOUT because the target servers are under heavy load), the
client will react to this timeout by retrying the pool create RPC with
the same UUID. Because target resources have not been destroyed in the
first attempt, this leads to a -DER_EXIST failure.
    
Signed-off-by: Ken Cain <kenneth.c.cain@intel.com>
