### PR TITLE
DAOS-3717 control: Allow optional syslog logging

### DIFF
--- a/src/control/cmd/daos_server/main.go
+++ b/src/control/cmd/daos_server/main.go
@@ -55,8 +55,9 @@ type mainOpts struct {
 	ConfigPath string `short:"o" long:"config" description:"Server config file path"`
 	// TODO(DAOS-3129): This should be -d, but it conflicts with the start
 	// subcommand's -d flag when we default to running it.
-	Debug bool `short:"b" long:"debug" description:"Enable debug output"`
-	JSON  bool `short:"j" long:"json" description:"Enable JSON output"`
+	Debug  bool `short:"b" long:"debug" description:"Enable debug output"`
+	JSON   bool `short:"j" long:"json" description:"Enable JSON output"`
+	Syslog bool `long:"syslog" description:"Enable logging to syslog"`
 
 	// Define subcommands
 	Storage storageCmd `command:"storage" description:"Perform tasks related to locally-attached storage"`
@@ -108,6 +109,11 @@ func parseOpts(args []string, opts *mainOpts, log *logging.LeveledLogger) error 
 		}
 		if opts.JSON {
 			log.WithJSONOutput()
+		}
+		if opts.Syslog {
+			// Don't log debug stuff to syslog.
+			log.WithInfoLogger((&logging.DefaultInfoLogger{}).WithSyslogOutput())
+			log.WithErrorLogger((&logging.DefaultErrorLogger{}).WithSyslogOutput())
 		}
 
 		if logCmd, ok := cmd.(cmdLogger); ok {


### PR DESCRIPTION
When the logging system was designed, the expectation was that
server management would be done via systemd, which expects
log output on stdout and adds it to the journal. In some
cases it may be desirable to log to /var/log/messages instead,
so supplying the --syslog flag to daos_server start will
accomplish this.