### PR TITLE
DAOS-4317 tests: Update daos_utils.py and dmg_utils.py (#2073)

### DIFF
--- a/src/tests/ftest/control/dmg_nvme_scan_test.yaml
+++ b/src/tests/ftest/control/dmg_nvme_scan_test.yaml
@@ -7,6 +7,7 @@ server_config:
   name: daos_server
   port: 10001
 dmg:
-  request: storage
-  action: scan
+  dmg_sub_command: storage
+  storage:
+    storage_sub_command: scan
   insecure: True

--- a/src/tests/ftest/pool/multi_server_create_delete_test.py
+++ b/src/tests/ftest/pool/multi_server_create_delete_test.py
@@ -24,8 +24,7 @@
 import os
 from apricot import TestWithServers
 import check_for_pool
-from dmg_utils import (pool_create, pool_destroy,
-                       get_pool_uuid_service_replicas_from_stdout)
+from dmg_utils import DmgCommand, get_pool_uuid_service_replicas_from_stdout
 
 RESULT_PASS = "PASS"
 RESULT_FAIL = "FAIL"
@@ -49,6 +48,16 @@ class MultiServerCreateDeleteTest(TestWithServers):
 
         :avocado: tags=all,pool,full_regression,small,multitarget
         """
+        # Create a dmg command object
+        dmg = DmgCommand(self.bin)
+        dmg.get_params(self)
+        dmg.hostlist.update(
+            self.server_managers[0].runner.job.yaml_params.access_points.value,
+            "dmg.hostlist")
+
+        # Disable raising an exception if the dmg command fails
+        dmg.exit_status_exception = False
+
         # Accumulate a list of pass/fail indicators representing what is
         # expected for each parameter then "and" them to determine the
         # expected result of the test
@@ -79,18 +88,14 @@ class MultiServerCreateDeleteTest(TestWithServers):
         host1 = self.hostlist_servers[0]
         host2 = self.hostlist_servers[1]
         test_destroy = True
-        # Get the access point and pass it in to dmg -l
-        access_points = self.server_managers[0].runner.job.\
-            yaml_params.access_points.value
-        create_result = pool_create(
-            path=self.bin, scm_size="1GB", host_port=access_points,
-            group=group, user=user, ranks=tgtlist, sys=system_name)
-        if create_result is not None:
+        create_result = dmg.pool_create(
+            "1GB", user, group, None, tgtlist, None, system_name)
+        if create_result.exit_status == 0:
+            if expected_result == RESULT_FAIL:
+                self.fail(
+                    "Test was expected to fail but it passed at pool create.")
             uuid, _ = get_pool_uuid_service_replicas_from_stdout(
                 create_result.stdout)
-            if expected_result == RESULT_FAIL:
-                self.fail("Test was expected to fail but it passed at pool " +
-                          "create.")
             if '0' in tgtlist:
                 # check_for_pool checks if the uuid directory exists in host1
                 exists = check_for_pool.check_for_pool(host1, uuid)
@@ -109,9 +114,8 @@ class MultiServerCreateDeleteTest(TestWithServers):
                           "create.")
 
         if test_destroy:
-            destroy_result = pool_destroy(
-                path=self.bin, pool_uuid=uuid, host_port=access_points)
-            if destroy_result is not None:
+            destroy_result = dmg.pool_destroy(uuid)
+            if destroy_result.exit_status == 0:
                 if expected_result == RESULT_FAIL:
                     self.fail("Test was expected to fail but it passed at " +
                               "pool create.")

--- a/src/tests/ftest/pool/multi_server_create_delete_test.yaml
+++ b/src/tests/ftest/pool/multi_server_create_delete_test.yaml
@@ -47,13 +47,13 @@ tests:
   tgtlist: !mux
     firsttgt:
       tgt:
-        - "0"
+        - [0]
         - PASS
     bothtgt:
       tgt:
-        - "0,1"
+        - [0, 1]
         - PASS
     badtgt:
       tgt:
-        - "0,1,2"
+        - [0, 1, 2]
         - FAIL

--- a/src/tests/ftest/security/pool_security_acl.py
+++ b/src/tests/ftest/security/pool_security_acl.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python
 '''
-  (C) Copyright 2018-2019 Intel Corporation.
+  (C) Copyright 2020 Intel Corporation.
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
@@ -24,294 +24,18 @@
 from __future__ import print_function
 
 import os
-from apricot import TestWithServers
-from daos_utils import DaosCommand
-from dmg_utils import DmgCommand
-import dmg_utils
-import random
 import pwd
 import grp
-import re
-from general_utils import pcmd
+import pool_security_test_base as poolSec
+from pool_security_test_base import PoolSecurityTestBase
 
-
-PERMISSIONS = ["", "r", "w", "rw"]
-
-def acl_entry(usergroup, name, permission):
-    '''
-    Deascription:
-        Create a daos acl entry on the specified user or groups
-        with specified or random permission.
-    Args:
-        usergroup: user or group.
-        name: user or group name to be created.
-        permission: permission to be created.
-    Return:
-        entry: daos acl entry.
-    '''
-    if permission == "random":
-        permission = random.choice(PERMISSIONS)
-    if permission == "nonexist":
-        return ""
-    if "group" in usergroup:
-        entry = "A:G:" + name + "@:" + permission
-    else:
-        entry = "A::" + name + "@:" + permission
-    return entry
-
-def add_del_user(hosts, ba_cmd, user):
-    '''
-    Deascription:
-        Add or delete the daos user and group on host by sudo command.
-    Args:
-        hosts: list of host.
-        ba_cmd: linux bash command to create user or group.
-        user: user or group name to be created or cleaned.
-    Return:
-        none.
-    '''
-    bash_cmd = os.path.join("/usr/sbin", ba_cmd)
-    homedir = ""
-    if "user" in ba_cmd:
-        homedir = "-r"
-    cmd = " ".join(("sudo", bash_cmd, homedir, user))
-    pcmd(hosts, cmd, False)
-
-class PoolSecurityTest(TestWithServers):
-    '''
-    Test Class Description:
-    Tests to verify the Pool security with dmg and daos tools on daos_server.
+class DaosRunPoolSecurityTest(PoolSecurityTestBase):
+    """Test daos_pool acl for primary and secondary groups.
     :avocado: recursive
-    '''
+    """
+    # pylint: disable=too-many-ancestors
 
-    def get_pool_acl_list(self, uuid):
-        '''
-        Deascription:
-            Get daos pool acl list by dmg get-acl.
-        Args:
-            uuid: pool uuid number.
-        Return:
-            pool_permission_list: daos pool acl list.
-        '''
-        dmg = DmgCommand(os.path.join(self.prefix, "bin"))
-        dmg.request.value = "pool"
-        dmg.action.value = "get-acl --pool " + uuid
-        port = self.params.get("port", "/run/server_config/*")
-        servers_with_ports = [
-            "{}:{}".format(host, port) for host in self.hostlist_servers]
-        dmg.hostlist.update(",".join(servers_with_ports), "dmg.hostlist")
-        result = dmg.run()
-
-        pool_permission_list = []
-        for line in result.stdout.splitlines():
-            if not line.startswith("A:"):
-                continue
-            elif line.startswith("A::"):
-                found_user = re.search(r"A::(.+)@:(.*)", line)
-                if found_user:
-                    pool_permission_list.append(line)
-            elif line.startswith("A:G:"):
-                found_group = re.search(r"A:G:(.+)@:(.*)", line)
-                if found_group:
-                    pool_permission_list.append(line)
-        return pool_permission_list
-
-    def verify_daos_pool_result(self, result, action, expect, err_code):
-        '''
-        Deascription:
-            To verify the daos pool read or write action result.
-        Args:
-            result: handle for daos pool action.
-            action: daos pool read or write.
-            expect: expecting pass or deny.
-            err_code: expecting deny of RC code.
-        Return:
-            none.
-        '''
-        if expect.lower() == 'pass':
-            if result.exit_status != 0 or result.stderr != "":
-                self.fail("##Test Fail on verify_daos_pool %s, "
-                          "expected Pass, but Failed.", action)
-            else:
-                self.log.info(" =Test Passed on verify_daos_pool %s, "
-                              "Succeed.\n", action)
-        elif err_code not in result.stderr:
-            self.fail("##Test Fail on verify_daos_pool %s,"
-                      " expected Failure of %s, but Passed.",
-                      action, expect)
-        else:
-            self.log.info(" =Test Passed on verify_daos_pool %s"
-                          " expected error of %s.\n", action, expect)
-
-    def verify_pool_readwrite(self, svc, uuid, action, expect='Pass'):
-        '''
-        Deascription:
-            To verify client is able to perform read or write on a pool.
-        Args:
-            svc:  pool svc number.
-            uuid: pool uuid number.
-            action: read or write on pool.
-            expect: expecting behavior pass or deny with RC -1001.
-        Return:
-            pass or fail.
-        '''
-        deny_access = '-1001'
-        daos_cmd = DaosCommand(os.path.join(self.prefix, "bin"))
-        if action.lower() == "write":
-            daos_cmd.request.value = "container"
-            daos_cmd.action.value = "create --svc={} --pool={}".format(
-                svc, uuid)
-        elif action.lower() == "read":
-            daos_cmd.request.value = "pool"
-            daos_cmd.action.value = "query --svc={} --pool={}".format(
-                svc, uuid)
-        else:
-            self.fail("##In verify_pool_readwrite, invalid action: "
-                      "%s", action)
-        daos_cmd.exit_status_exception = False
-        result = daos_cmd.run()
-        self.log.info("  In verify_pool_readwrite %s.\n =daos_cmd.run()"
-                      " result:\n%s", action, result)
-        self.verify_daos_pool_result(result, action, expect, deny_access)
-
-    def create_pool_acl(self, num_user, num_group, current_user_acl, acl_file):
-        '''
-        Deascription:
-            Create pool get-acl file with specified number of users and groups
-            with random permission.
-        Args:
-            num_user:  number of user with random permission to be created.
-            num_group: number of group with random permission to be created.
-            current_user_acl: acl entries on current user to be created.
-            acl_file: acl file to be created.
-        Return:
-            permission_list: acl permission list on the acl_file.
-        '''
-        user_prefix = self.params.get("user_prefix", "/run/pool_acl/*")
-        user_list = []
-        group_list = []
-        for uid in range(num_user):
-            username = user_prefix + "_tester_" + str(uid + 1)
-            new_user = "A::" + username + "@:" + PERMISSIONS[uid % 4]
-            add_del_user(self.hostlist_clients, "useradd", username)
-            user_list.append(new_user)
-        for gid in range(num_group):
-            groupname = user_prefix + "_testGrp_" + str(gid + 1)
-            new_group = "A:G:" + groupname + "@:" + PERMISSIONS[(gid + 2) % 4]
-            add_del_user(self.hostlist_clients, "groupadd", groupname)
-            group_list.append(new_group)
-        permission_list = group_list + user_list + current_user_acl
-        random.shuffle(permission_list)
-        with open(acl_file, "w") as test_file:
-            test_file.write("\n".join(permission_list))
-        return permission_list
-
-    def cleanup_user_group(self, num_user, num_group):
-        '''
-        Deascription:
-            Remove the daos acl user and group on host.
-        Args:
-            num_user: number of user to be cleaned.
-            num_group: number of group name to be cleaned.
-        Return:
-            none.
-        '''
-        user_prefix = self.params.get("user_prefix", "/run/pool_acl/*")
-        for uid in range(num_user):
-            username = user_prefix + "_tester_" + str(uid + 1)
-            add_del_user(self.hostlist_clients, "userdel", username)
-        for gid in range(num_group):
-            groupname = user_prefix + "_testGrp_" + str(gid + 1)
-            add_del_user(self.hostlist_clients, "groupdel", groupname)
-
-    def pool_acl_verification(self, current_user_acl, read, write):
-        '''
-        Deascription:
-            Daos pool security verification with acl file.
-            Steps:
-                (1)Setup dmg tool for creating a pool
-                (2)Generate acl file with permissions
-                (3)Create a pool with acl
-                (4)Verify the pool create status
-                (5)Get the pool's acl list
-                (6)Verify pool read operation
-                (7)Verify pool write operation
-                (8)Cleanup user and destroy pool
-        Args:
-            current_user_acl: acl with read write access credential.
-            read: expecting read permission.
-            write: expecting write permission.
-        Return:
-            pass to continue.
-            fail to report the testlog and stop.
-        '''
-
-        # (1)Create daos_shell command
-        dmg = DmgCommand(os.path.join(self.prefix, "bin"))
-        dmg.get_params(self)
-        port = self.params.get("port", "/run/server_config/*", 10001)
-        get_acl_file = self.params.get("acl_file", "/run/pool_acl/*",
-                                       "acl_test.txt")
-        acl_file = os.path.join(self.tmp, get_acl_file)
-        num_user = self.params.get("num_user", "/run/pool_acl/*")
-        num_group = self.params.get("num_group", "/run/pool_acl/*")
-        servers_with_ports = [
-            "{}:{}".format(host, port) for host in self.hostlist_servers]
-        dmg.hostlist.update(",".join(servers_with_ports), "dmg.hostlist")
-        self.log.info("  (1)dmg= %s", dmg)
-
-        # (2)Generate acl file with permissions
-        self.log.info("  (2)Generate acl file with user/group permissions")
-        permission_list = self.create_pool_acl(num_user,
-                                               num_group,
-                                               current_user_acl,
-                                               acl_file)
-
-        # (3)Create a pool with acl
-        self.log.info("  (3)Create a pool with acl")
-        dmg.action_command.acl_file.value = acl_file
-        dmg.exit_status_exception = False
-        result = dmg.run()
-
-        # (4)Verify the pool create status
-        self.log.info("  (4)dmg.run() result=\n%s", result)
-        if result.stderr == "":
-            uuid, svc = dmg_utils.get_pool_uuid_service_replicas_from_stdout(
-                result.stdout)
-        else:
-            self.fail("##(4)Unable to parse pool uuid and svc.")
-
-        # (5)Get the pool's acl list
-        #    dmg pool get-acl --pool <UUID>
-        self.log.info("  (5)Get a pool's acl list by: "
-                      "dmg pool get-acl --pool --hostlist")
-        pool_acl_list = self.get_pool_acl_list(uuid)
-        self.log.info(
-            "   pool original permission_list: %s", permission_list)
-        self.log.info(
-            "   pool get_acl  permission_list: %s", pool_acl_list)
-
-        # (6)Verify pool read operation
-        #    daos pool query --pool <uuid>
-        self.log.info("  (6)Verify pool read by: daos pool query --pool")
-        self.verify_pool_readwrite(svc, uuid, "read", expect=read)
-
-        # (7)Verify pool write operation
-        #    daos continer create --pool <uuid>
-        self.log.info("  (7)Verify pool write by: daos continer create --pool")
-        self.verify_pool_readwrite(svc, uuid, "write", expect=write)
-
-        # (8)Cleanup user and destroy pool
-        self.log.info("  (8)Cleanup user and destroy pool")
-        self.cleanup_user_group(num_user, num_group)
-        dmg = DmgCommand(os.path.join(self.prefix, "bin"))
-        dmg.request.value = "pool"
-        dmg.action.value = "destroy --pool={}".format(uuid)
-        dmg.hostlist.update(",".join(servers_with_ports), "dmg.hostlist")
-        result = dmg.run()
-        return
-
-    def test_pool_acl_enforcement(self):
+    def test_daos_pool_acl_enforcement(self):
         '''
         Epic:
             DAOS-1961: Testing related to DAOS security features.
@@ -323,6 +47,8 @@ class PoolSecurityTest(TestWithServers):
             DAOS-3611: Pool ACL verification after user removed from a
                        granted group.
             DAOS-3612: ACL update to remove/grant user/group access pool
+            DAOS-3546: Test ACL access when user/group management isn't
+                       synced between client and server nodes
         Description:
             Create pool with pass-in user and group acl permission,
             verify pool user and group read, write, read-write and none
@@ -339,20 +65,22 @@ class PoolSecurityTest(TestWithServers):
 
         user_types = ["owner", "user", "ownergroup", "group", "everyone"]
         default_acl_entries = ["A::OWNER@:",
-                               acl_entry("user", current_user, ""),
+                               poolSec.acl_entry("user", current_user, ""),
                                "A:G:GROUP@:",
-                               acl_entry("group", current_group, ""),
+                               poolSec.acl_entry("group", current_group, ""),
                                "A::EVERYONE@:"]
         test_acl_entries = ["", "", "", "", ""]
 
         if permission.lower() == "none":
             permission = ""
-        if permission not in PERMISSIONS:
-            self.fail("##permission %s is invalid, valid permissions are:"
-                      "'none', 'r', w', 'rw'", permission)
+        if permission not in poolSec.PERMISSIONS:
+            self.fail(
+                "##permission {} is invalid, valid permissions are: "
+                "'none', 'r', w', 'rw'".format(permission))
         if user_type not in user_types:
-            self.fail("##user_type %s is invalid, valid user_types are: "
-                      "%s", user_type, user_types)
+            self.fail(
+                "##user_type {} is invalid, valid user_types are: {}".format(
+                    user_type, user_types))
         user_type_ind = user_types.index(user_type)
         self.log.info("===>Start DAOS pool acl enforcement order Testcase: "
                       " user_type: %s, permission: %s, expect_read: %s,"
@@ -377,7 +105,6 @@ class PoolSecurityTest(TestWithServers):
                     test_permission = ""
                 if user_types[ind] == "group":
                     group_acl = test_permission
-            #"A::OWNER@:" + permission
             test_acl_entries[ind] = default_acl_entries[ind] + test_permission
         #union of ownergroup and group permission
         if user_type == "ownergroup":

--- a/src/tests/ftest/security/pool_security_acl.yaml
+++ b/src/tests/ftest/security/pool_security_acl.yaml
@@ -18,12 +18,8 @@ server_config:
 daos_server:
   start:
      insecure: False
-dmg:
-  request: pool
-  action: create
-  create:
-    scm_size: 16777216
 pool_acl:
+  scm_size: 16777216
   user_prefix: daos_ci
   num_user: 5
   num_group: 5

--- a/src/tests/ftest/util/command_utils.py
+++ b/src/tests/ftest/util/command_utils.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python
 """
-  (C) Copyright 2018-2019 Intel Corporation.
+  (C) Copyright 2018-2020 Intel Corporation.
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
@@ -100,6 +100,37 @@ class BasicParameter(object):
             self.log.debug("Updated param %s => %s", name, self.value)
 
 
+class NamedParameter(BasicParameter):
+    # pylint: disable=too-few-public-methods
+    """A class for test parameters whose values are read from a yaml file.
+
+    This is essentially a BasicParameter object whose yaml value is obtained
+    with a different name than the one assigned to the object.
+    """
+
+    def __init__(self, name, value, default=None):
+        """Create a NamedParameter  object.
+
+        Args:
+            name (str): yaml key name
+            value (object): intial value for the parameter
+            default (object): default value for the param
+        """
+        super(NamedParameter, self).__init__(value, default)
+        self._name = name
+
+    def get_yaml_value(self, name, test, path):
+        """Get the value for the parameter from the test case's yaml file.
+
+        Args:
+            name (str): name of the value in the yaml file - not used
+            test (Test): avocado Test object to use to read the yaml file
+            path (str): yaml path where the name is to be found
+        """
+        return super(NamedParameter, self).get_yaml_value(
+            self._name, test, path)
+
+
 class FormattedParameter(BasicParameter):
     # pylint: disable=too-few-public-methods
     """A class for test parameters whose values are read from a yaml file."""
@@ -122,19 +153,21 @@ class FormattedParameter(BasicParameter):
             str: if defined, the parameter, otherwise an empty string
 
         """
+        parameter = ""
         if isinstance(self._default, bool) and self.value:
-            return self._str_format
+            parameter = self._str_format
         elif not isinstance(self._default, bool) and self.value is not None:
             if isinstance(self.value, dict):
-                return " ".join([self._str_format.format("{} \"{}\"".format(
-                    key, self.value[key])) for key in self.value])
+                parameter = " ".join([
+                    self._str_format.format(
+                        "{} \"{}\"".format(key, self.value[key]))
+                    for key in self.value])
             elif isinstance(self.value, (list, tuple)):
-                return " ".join(
+                parameter = " ".join(
                     [self._str_format.format(value) for value in self.value])
             else:
-                return self._str_format.format(self.value)
-        else:
-            return ""
+                parameter = self._str_format.format(self.value)
+        return parameter
 
 
 class ObjectWithParameters(object):
@@ -398,6 +431,115 @@ class ExecutableCommand(CommandWithParameters):
                 # Indicate an error if the process required a SIGKILL
                 raise CommandFailure("Error stopping '{}'".format(self))
             self._process = None
+
+
+class CommandWithSubCommand(ExecutableCommand):
+    """A class for a command with a sub command."""
+
+    def __init__(self, namespace, command, path="", subprocess=False):
+        """Create a CommandWithSubCommand object.
+
+        Args:
+            namespace (str): yaml namespace (path to parameters)
+            command (str): string of the command to be executed.
+            path (str, optional): path to location of command binary file.
+                Defaults to "".
+            subprocess (bool, optional): whether the command is run as a
+                subprocess. Defaults to False.
+        """
+        super(CommandWithSubCommand, self).__init__(namespace, command, path)
+
+        # Define the sub-command parameter whose value is used to assign the
+        # sub-command's CommandWithParameters-based class.  Use the command to
+        # create uniquely named yaml parameter names.
+        #
+        # This parameter can be specified in the test yaml like so:
+        #   <command>:
+        #       <command>_sub_command: <sub_command>
+        #       <sub_command>:
+        #           <sub_command>_sub_command: <sub_command_sub_command>
+        #
+        self.sub_command = NamedParameter(
+            "{}_sub_command".format(self._command), None)
+
+        # Define the class to represent the active sub-command and it's specific
+        # parameters.  Multiple sub-commands may be available, but only one can
+        # be active at a given time.
+        #
+        # The self.get_sub_command_class() method is called after obtaining the
+        # main command's parameter values, in self.get_params(), to assign the
+        # sub-command's class.  This is typically a class based upon the
+        # CommandWithParameters class, but can be any object with a __str__()
+        # method (including a simple str object).
+        #
+        self.sub_command_class = None
+
+    def get_param_names(self):
+        """Get a sorted list of the names of the BasicParameter attributes.
+
+        Ensure the sub command appears at the end of the list
+
+        Returns:
+            list: a list of class attribute names used to define parameters
+
+        """
+        names = self.get_attribute_names(BasicParameter)
+        names.append(names.pop(names.index("sub_command")))
+        return names
+
+    def get_params(self, test):
+        """Get values for all of the command params from the yaml file.
+
+        Calls self.get_sub_command_class() to assign the self.sub_command_class
+        after obtaining the latest self.sub_command definition.  If the
+        self.sub_command_class is assigned to an ObjectWithParameters-based
+        class its get_params() method is also called.
+
+        Args:
+            test (Test): avocado Test object
+        """
+        super(CommandWithSubCommand, self).get_params(test)
+        self.get_sub_command_class()
+        if isinstance(self.sub_command_class, ObjectWithParameters):
+            self.sub_command_class.get_params(test)
+
+    def get_sub_command_class(self):
+        """Get the class assignment for the sub command.
+
+        Should be overridden to assign the self.sub_command_class using the
+        latest self.sub_command definition.
+
+        Override this method with sub_command_class assignment that maps to the
+        expected sub_command value.
+        """
+        self.sub_command_class = None
+
+    def get_str_param_names(self):
+        """Get a sorted list of the names of the command attributes.
+
+        If the sub-command parameter yields a sub-command class, replace the
+        sub-command value with the resulting string from the sub-command class
+        when assembling that command string.
+
+        Returns:
+            list: a list of class attribute names used to define parameters
+                for the command.
+
+        """
+        names = self.get_param_names()
+        if self.sub_command_class is not None:
+            index = names.index("sub_command")
+            names[index] = "sub_command_class"
+        return names
+
+    def set_sub_command(self, value):
+        """Set the command's sub-command value and update the sub-command class.
+
+        Args:
+            value (str): sub-command value
+        """
+        self.sub_command.value = value
+        self.get_sub_command_class()
 
 
 class DaosCommand(ExecutableCommand):

--- a/src/tests/ftest/util/daos_utils.py
+++ b/src/tests/ftest/util/daos_utils.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python
 """
-  (C) Copyright 2018-2019 Intel Corporation.
+  (C) Copyright 2018-2020 Intel Corporation.
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
@@ -21,30 +21,513 @@
   Any reproduction of computer software, computer software documentation, or
   portions thereof marked with this legend must also reproduce the markings.
 """
-from __future__ import print_function
+from command_utils import \
+    CommandWithParameters, FormattedParameter, CommandFailure, \
+    CommandWithSubCommand
 
-from command_utils import CommandWithParameters
-from command_utils import DaosCommand as CommandWithSubCommand
 
 class DaosCommand(CommandWithSubCommand):
     """Defines a object representing a daos command."""
 
     def __init__(self, path):
-        """Create a daos Command object."""
+        """Create a daos Command object.
+
+        Args:
+            path (str): path to the daos command
+        """
         super(DaosCommand, self).__init__("/run/daos/*", "daos", path)
 
-    def get_action_command(self):
-        """Assign a command object for the specified request and action."""
+    def get_sub_command_class(self):
         # pylint: disable=redefined-variable-type
-        if self.action.value == "create":
-            self.action_command = self.DaosCreateSubCommand()
+        """Get the dmg sub command object based upon the sub-command."""
+        if self.sub_command.value == "pool":
+            self.sub_command_class = self.PoolSubCommand()
+        elif self.sub_command.value == "container":
+            self.sub_command_class = self.ContainerSubCommand()
+        elif self.sub_command.value == "object":
+            self.sub_command_class = self.ObjectSubCommand()
         else:
-            self.action_command = None
+            self.sub_command_class = None
 
-    class DaosCreateSubCommand(CommandWithParameters):
-        """Defines a object representing a create sub daos command."""
+    class PoolSubCommand(CommandWithSubCommand):
+        """Defines an object for the daos pool sub command."""
 
         def __init__(self):
-            """Create a daos Command object."""
-            super(DaosCommand.DaosCreateSubCommand, self).__init__(
-                "/run/daos/create/*", "create")
+            """Create a daos pool subcommand object."""
+            super(DaosCommand.PoolSubCommand, self).__init__(
+                "/run/daos/pool/*", "pool")
+
+        def get_sub_command_class(self):
+            # pylint: disable=redefined-variable-type
+            """Get the dmg network sub command object."""
+            if self.sub_command.value == "list-containers":
+                self.sub_command_class = self.ListContainersSubCommand()
+            elif self.sub_command.value == "query":
+                self.sub_command_class = self.QuerySubCommand()
+            elif self.sub_command.value == "stat":
+                self.sub_command_class = self.StatSubCommand()
+            elif self.sub_command.value == "list-attrs":
+                self.sub_command_class = self.ListAttrsSubCommand()
+            elif self.sub_command.value == "get-attr":
+                self.sub_command_class = self.GetAttrSubCommand()
+            else:
+                self.sub_command_class = None
+
+        class CommonPoolSubCommand(CommandWithParameters):
+            """Defines an object for the common daos pool sub-command."""
+
+            def __init__(self, sub_command):
+                """Create a common daos pool sub-command object.
+
+                Args:
+                    sub_command (str): sub-command name
+                """
+                super(
+                    DaosCommand.PoolSubCommand.CommonPoolSubCommand,
+                    self).__init__(
+                        "/run/daos/pool/{}/*".format(sub_command), sub_command)
+                self.pool = FormattedParameter("--pool={}")
+                self.sys_name = FormattedParameter("--sys-name={}")
+                self.svc = FormattedParameter("--svc={}")
+                self.sys = FormattedParameter("--sys={}")
+
+        class ListContainersSubCommand(CommonPoolSubCommand):
+            """Defines an object for the daos pool list-containers command."""
+
+            def __init__(self):
+                """Create a daos pool list-containers command object."""
+                super(
+                    DaosCommand.PoolSubCommand.ListContainersSubCommand,
+                    self).__init__("list-containers")
+
+        class QuerySubCommand(CommonPoolSubCommand):
+            """Defines an object for the daos pool query command."""
+
+            def __init__(self):
+                """Create a daos pool query command object."""
+                super(
+                    DaosCommand.PoolSubCommand.QuerySubCommand, self).__init__(
+                        "query")
+
+        class StatSubCommand(CommonPoolSubCommand):
+            """Defines an object for the daos pool stat command."""
+
+            def __init__(self):
+                """Create a daos pool stat command object."""
+                super(
+                    DaosCommand.PoolSubCommand.StatSubCommand, self).__init__(
+                        "stat")
+
+        class ListAttrsSubCommand(CommonPoolSubCommand):
+            """Defines an object for the daos pool list-attr command."""
+
+            def __init__(self):
+                """Create a daos pool list-attr command object."""
+                super(
+                    DaosCommand.PoolSubCommand.ListAttrsSubCommand,
+                    self).__init__("list-attrs")
+
+        class GetAttrSubCommand(CommonPoolSubCommand):
+            """Defines an object for the daos pool get-attr command."""
+
+            def __init__(self):
+                """Create a daos pool get-attr command object."""
+                super(
+                    DaosCommand.PoolSubCommand.GetAttrSubCommand,
+                    self).__init__("get-attr")
+                self.attr = FormattedParameter("--attr={}")
+
+    class ContainerSubCommand(CommandWithSubCommand):
+        """Defines an object for the daos container sub command."""
+
+        def __init__(self):
+            """Create a daos container subcommand object."""
+            super(DaosCommand.ContainerSubCommand, self).__init__(
+                "/run/daos/container/*", "container")
+
+        def get_sub_command_class(self):
+            # pylint: disable=redefined-variable-type
+            """Get the dmg network sub command object."""
+            if self.sub_command.value == "create":
+                self.sub_command_class = self.CreateSubCommand()
+            elif self.sub_command.value == "destroy":
+                self.sub_command_class = self.DestroySubCommand()
+            elif self.sub_command.value == "list-objects":
+                self.sub_command_class = self.ListObjectsSubCommand()
+            elif self.sub_command.value == "query":
+                self.sub_command_class = self.QuerySubCommand()
+            elif self.sub_command.value == "get-acl":
+                self.sub_command_class = self.GetAclSubCommand()
+            elif self.sub_command.value == "overwrite-acl":
+                self.sub_command_class = self.OverwriteAclSubCommand()
+            elif self.sub_command.value == "update-acl":
+                self.sub_command_class = self.UpdateAclSubCommand()
+            elif self.sub_command.value == "delete-acl":
+                self.sub_command_class = self.DeleteAclSubCommand()
+            elif self.sub_command.value == "stat":
+                self.sub_command_class = self.StatSubCommand()
+            elif self.sub_command.value == "list-attrs":
+                self.sub_command_class = self.ListAttrsSubCommand()
+            elif self.sub_command.value == "del-attrs":
+                self.sub_command_class = self.DelAttrSubCommand()
+            elif self.sub_command.value == "get-attr":
+                self.sub_command_class = self.GetAttrSubCommand()
+            elif self.sub_command.value == "set-attr":
+                self.sub_command_class = self.SetAttrSubCommand()
+            elif self.sub_command.value == "create-snap":
+                self.sub_command_class = self.CreateSnapSubCommand()
+            elif self.sub_command.value == "list-snaps":
+                self.sub_command_class = self.ListSnapsSubCommand()
+            elif self.sub_command.value == "destroy-snap":
+                self.sub_command_class = self.DestroySnapSubCommand()
+            elif self.sub_command.value == "rollback":
+                self.sub_command_class = self.RollbackSubCommand()
+            else:
+                self.sub_command_class = None
+
+        class CommonContainerSubCommand(CommandWithParameters):
+            """Defines an object for the common daos container sub-command."""
+
+            def __init__(self, sub_command):
+                """Create a common daos container sub-command object.
+
+                Args:
+                    sub_command (str): sub-command name
+                """
+                super(
+                    DaosCommand.ContainerSubCommand.CommonContainerSubCommand,
+                    self).__init__(
+                        "/run/daos/container/{}/*".format(sub_command),
+                        sub_command)
+                self.pool = FormattedParameter("--pool={}")
+                self.sys_name = FormattedParameter("--sys-name={}")
+                self.svc = FormattedParameter("--svc={}")
+                self.cont = FormattedParameter("--cont={}")
+                self.path = FormattedParameter("--path={}")
+
+        class CreateSubCommand(CommonContainerSubCommand):
+            """Defines an object for the daos container create command."""
+
+            def __init__(self):
+                """Create a daos container create command object."""
+                super(
+                    DaosCommand.ContainerSubCommand.CreateSubCommand,
+                    self).__init__("create")
+                self.type = FormattedParameter("--type={}")
+                self.oclass = FormattedParameter("--oclass={}")
+                self.chunk_size = FormattedParameter("--chunk_size={}")
+
+        class DestroySubCommand(CommonContainerSubCommand):
+            """Defines an object for the daos container destroy command."""
+
+            def __init__(self):
+                """Create a daos container destroy command object."""
+                super(
+                    DaosCommand.ContainerSubCommand.DestroySubCommand,
+                    self).__init__("destroy")
+                self.force = FormattedParameter("--force", False)
+
+        class ListObjectsSubCommand(CommonContainerSubCommand):
+            """Defines an object for the daos container list-objects command."""
+
+            def __init__(self):
+                """Create a daos container list-objects command object."""
+                super(
+                    DaosCommand.ContainerSubCommand.ListObjectsSubCommand,
+                    self).__init__("list-objects")
+
+        class QuerySubCommand(CommonContainerSubCommand):
+            """Defines an object for the daos container query command."""
+
+            def __init__(self):
+                """Create a daos container query command object."""
+                super(
+                    DaosCommand.ContainerSubCommand.QuerySubCommand,
+                    self).__init__("query")
+
+        class GetAclSubCommand(CommonContainerSubCommand):
+            """Defines an object for the daos container get-acl command."""
+
+            def __init__(self):
+                """Create a daos container get-acl command object."""
+                super(
+                    DaosCommand.ContainerSubCommand.GetAclSubCommand,
+                    self).__init__("get-acl")
+                self.outfile = FormattedParameter("--outfile={}")
+                self.verbose = FormattedParameter("--verbose", False)
+
+        class OverwriteAclSubCommand(CommonContainerSubCommand):
+            """Defines an object for the daos container overwrite-acl cmd."""
+
+            def __init__(self):
+                """Create a daos container overwrite-acl command object."""
+                super(
+                    DaosCommand.ContainerSubCommand.OverwriteAclSubCommand,
+                    self).__init__("overwrite-acl")
+                self.acl_file = FormattedParameter("--acl-file={}")
+
+        class UpdateAclSubCommand(CommonContainerSubCommand):
+            """Defines an object for the daos container update-acl command."""
+
+            def __init__(self):
+                """Create a daos container update-acl command object."""
+                super(
+                    DaosCommand.ContainerSubCommand.UpdateAclSubCommand,
+                    self).__init__("update-acl")
+                self.acl_file = FormattedParameter("--acl-file={}")
+                self.entry = FormattedParameter("--entry={}")
+
+        class DeleteAclSubCommand(CommonContainerSubCommand):
+            """Defines an object for the daos container delete-acl command."""
+
+            def __init__(self):
+                """Create a daos container delete-acl command object."""
+                super(
+                    DaosCommand.ContainerSubCommand.DeleteAclSubCommand,
+                    self).__init__("delete-acl")
+                self.principal = FormattedParameter("--principal={}")
+
+        class StatSubCommand(CommonContainerSubCommand):
+            """Defines an object for the daos container stat command."""
+
+            def __init__(self):
+                """Create a daos container stat command object."""
+                super(
+                    DaosCommand.ContainerSubCommand.StatSubCommand,
+                    self).__init__("stat")
+
+        class ListAttrsSubCommand(CommonContainerSubCommand):
+            """Defines an object for the daos container list-attrs command."""
+
+            def __init__(self):
+                """Create a daos container list-attrs command object."""
+                super(
+                    DaosCommand.ContainerSubCommand.ListAttrsSubCommand,
+                    self).__init__("list-attrs")
+
+        class DelAttrSubCommand(CommonContainerSubCommand):
+            """Defines an object for the daos container del-attrs command."""
+
+            def __init__(self):
+                """Create a daos container del-attrs command object."""
+                super(
+                    DaosCommand.ContainerSubCommand.DelAttrSubCommand,
+                    self).__init__("del-attrs")
+                self.attr = FormattedParameter("--attr={}")
+
+        class GetAttrSubCommand(CommonContainerSubCommand):
+            """Defines an object for the daos container get-attr command."""
+
+            def __init__(self):
+                """Create a daos container get-attr command object."""
+                super(
+                    DaosCommand.ContainerSubCommand.GetAttrSubCommand,
+                    self).__init__("get-attr")
+                self.attr = FormattedParameter("--attr={}")
+
+        class SetAttrSubCommand(CommonContainerSubCommand):
+            """Defines an object for the daos container set-attr command."""
+
+            def __init__(self):
+                """Create a daos container set-attr command object."""
+                super(
+                    DaosCommand.ContainerSubCommand.SetAttrSubCommand,
+                    self).__init__("set-attr")
+                self.attr = FormattedParameter("--attr={}")
+                self.value = FormattedParameter("--value={}")
+
+        class CreateSnapSubCommand(CommonContainerSubCommand):
+            """Defines an object for the daos container create-snap command."""
+
+            def __init__(self):
+                """Create a daos container create-snap command object."""
+                super(
+                    DaosCommand.ContainerSubCommand.CreateSnapSubCommand,
+                    self).__init__("create-snap")
+                self.snap = FormattedParameter("--snap={}")
+
+        class ListSnapsSubCommand(CommonContainerSubCommand):
+            """Defines an object for the daos container list-snaps command."""
+
+            def __init__(self):
+                """Create a daos container list-snaps command object."""
+                super(
+                    DaosCommand.ContainerSubCommand.ListSnapsSubCommand,
+                    self).__init__("list-snaps")
+
+        class DestroySnapSubCommand(CommonContainerSubCommand):
+            """Defines an object for the daos container destroy-snap command."""
+
+            def __init__(self):
+                """Create a daos container destroy-snap command object."""
+                super(
+                    DaosCommand.ContainerSubCommand.DestroySnapSubCommand,
+                    self).__init__("destroy-snap")
+                self.snap = FormattedParameter("--snap={}")
+                self.epc = FormattedParameter("--epc={}")
+                self.eprange = FormattedParameter("--eprange={}")
+
+        class RollbackSubCommand(CommonContainerSubCommand):
+            """Defines an object for the daos container rollback command."""
+
+            def __init__(self):
+                """Create a daos container rollback command object."""
+                super(
+                    DaosCommand.ContainerSubCommand.RollbackSubCommand,
+                    self).__init__("rollback")
+                self.snap = FormattedParameter("--snap={}")
+                self.epc = FormattedParameter("--epc={}")
+
+    class ObjectSubCommand(CommandWithSubCommand):
+        """Defines an object for the daos object sub command."""
+
+        def __init__(self):
+            """Create a daos object subcommand object."""
+            super(DaosCommand.ObjectSubCommand, self).__init__(
+                "/run/daos/object/*", "object")
+
+        def get_sub_command_class(self):
+            # pylint: disable=redefined-variable-type
+            """Get the dmg network sub command object."""
+            if self.sub_command.value == "query":
+                self.sub_command_class = self.QuerySubCommand()
+            elif self.sub_command.value == "list-keys":
+                self.sub_command_class = self.ListKeysSubCommand()
+            elif self.sub_command.value == "dump":
+                self.sub_command_class = self.DumpSubCommand()
+            else:
+                self.sub_command_class = None
+
+        class CommonObjectSubCommand(CommandWithParameters):
+            """Defines an object for the common daos object sub-command."""
+
+            def __init__(self, sub_command):
+                """Create a common daos object sub-command object.
+
+                Args:
+                    sub_command (str): sub-command name
+                """
+                super(
+                    DaosCommand.ObjectSubCommand.CommonObjectSubCommand,
+                    self).__init__(
+                        "/run/daos/object/{}/*".format(sub_command),
+                        sub_command)
+                self.pool = FormattedParameter("--pool={}")
+                self.sys_name = FormattedParameter("--sys-name={}")
+                self.svc = FormattedParameter("--svc={}")
+                self.cont = FormattedParameter("--cont={}")
+                self.oid = FormattedParameter("--oid={}")
+
+        class QuerySubCommand(CommonObjectSubCommand):
+            """Defines an object for the daos object query command."""
+
+            def __init__(self):
+                """Create a daos object query command object."""
+                super(
+                    DaosCommand.ObjectSubCommand.QuerySubCommand,
+                    self).__init__("query")
+
+        class ListKeysSubCommand(CommonObjectSubCommand):
+            """Defines an object for the daos object list-keys command."""
+
+            def __init__(self):
+                """Create a daos object list-keys command object."""
+                super(
+                    DaosCommand.ObjectSubCommand.ListKeysSubCommand,
+                    self).__init__("list-keys")
+
+        class DumpSubCommand(CommonObjectSubCommand):
+            """Defines an object for the daos object dump command."""
+
+            def __init__(self):
+                """Create a daos object dump command object."""
+                super(
+                    DaosCommand.ObjectSubCommand.DumpSubCommand,
+                    self).__init__("dump")
+
+    def _get_result(self):
+        """Get the result from running the configured daos command.
+
+        Returns:
+            CmdResult: an avocado CmdResult object containing the daos command
+                information, e.g. exit status, stdout, stderr, etc.
+
+        Raises:
+            CommandFailure: if the daos command fails.
+
+        """
+        result = None
+        try:
+            result = self.run()
+        except CommandFailure as error:
+            raise CommandFailure("<daos> command failed: {}".format(error))
+
+        return result
+
+    def pool_query(self, pool, sys_name=None, svc=None, sys=None, env=None):
+        """Query a pool.
+
+        Args:
+            pool ([type]): [description]
+            sys_name ([type], optional): [description]. Defaults to None.
+            svc ([type], optional): [description]. Defaults to None.
+            sys ([type], optional): [description]. Defaults to None.
+            env (dict, optional): dictionary of environment variable names and
+                values (EnvironmentVariables). Defaults to None.
+
+        Returns:
+            CmdResult: Object that contains exit status, stdout, and other
+                information.
+
+        Raises:
+            CommandFailure: if the doas pool query command fails.
+
+        """
+        self.set_sub_command("pool")
+        self.sub_command_class.set_sub_command("query")
+        self.sub_command_class.sub_command_class.pool.value = pool
+        self.sub_command_class.sub_command_class.sys_name.value = sys_name
+        self.sub_command_class.sub_command_class.svc.value = svc
+        self.sub_command_class.sub_command_class.sys.value = sys
+        self.env = env
+        return self._get_result()
+
+    def container_create(self, pool, sys_name=None, svc=None, cont=None,
+                         path=None, cont_type=None, oclass=None,
+                         chunk_size=None, env=None):
+        """Create a container.
+
+        Args:
+            pool (str): UUID of the pool in which to create the container
+            sys_name (str, optional): [description]. Defaults to None.
+            svc (str, optional): the pool service replicas, e.g. '1,2,3'.
+                Defaults to None.
+            cont (str, optional): [description]. Defaults to None.
+            path (str, optional): [description]. Defaults to None.
+            cont_type (str, optional): the type of container to create. Defaults
+                to None.
+            oclass (str, optional): object class. Defaults to None.
+            chunk_size ([type], optional): [description]. Defaults to None.
+            env (dict, optional): dictionary of environment variable names and
+                values (EnvironmentVariables). Defaults to None.
+
+        Returns:
+            CmdResult: Object that contains exit status, stdout, and other
+                information.
+
+        Raises:
+            CommandFailure: if the doas container create command fails.
+
+        """
+        self.set_sub_command("container")
+        self.sub_command_class.set_sub_command("create")
+        self.sub_command_class.sub_command_class.pool.value = pool
+        self.sub_command_class.sub_command_class.sys_name.value = sys_name
+        self.sub_command_class.sub_command_class.svc.value = svc
+        self.sub_command_class.sub_command_class.cont.value = cont
+        self.sub_command_class.sub_command_class.path.value = path
+        self.sub_command_class.sub_command_class.type.value = cont_type
+        self.sub_command_class.sub_command_class.oclass.value = oclass
+        self.sub_command_class.sub_command_class.chunk_size.value = chunk_size
+        self.env = env
+        return self._get_result()

--- a/src/tests/ftest/util/dmg_utils.py
+++ b/src/tests/ftest/util/dmg_utils.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python
 """
-  (C) Copyright 2018-2019 Intel Corporation.
+  (C) Copyright 2018-2020 Intel Corporation.
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
@@ -23,18 +23,25 @@
 """
 from __future__ import print_function
 
-import getpass
+from getpass import getuser
+from grp import getgrgid
+from pwd import getpwuid
 import re
 
-from command_utils import DaosCommand, CommandWithParameters, CommandFailure
-from command_utils import FormattedParameter
+from command_utils import \
+    CommandWithParameters, FormattedParameter, CommandFailure, \
+    CommandWithSubCommand
 
 
-class DmgCommand(DaosCommand):
+class DmgCommand(CommandWithSubCommand):
     """Defines a object representing a dmg command."""
 
     def __init__(self, path):
-        """Create a dmg Command object."""
+        """Create a dmg Command object.
+
+        Args:
+            path (str): path to the dmg command
+        """
         super(DmgCommand, self).__init__("/run/dmg/*", "dmg", path)
 
         self.hostlist = FormattedParameter("-l {}")
@@ -44,101 +51,662 @@ class DmgCommand(DaosCommand):
         self.debug = FormattedParameter("-d", False)
         self.json = FormattedParameter("-j", False)
 
-    def get_action_command(self):
-        """Get the action command object based on the yaml provided value."""
+    def set_hostlist(self, manager):
+        """Set the dmg hostlist parameter with the daos server/agent info.
+
+        Use the daos server/agent access points port and list of hosts to define
+        the dmg --hostlist command line parameter.
+
+        Args:
+            manager (SubprocessManager): daos server/agent process manager
+        """
+        self.hostlist.update(
+            manager.get_config_value("access_points"), "dmg.hostlist")
+
+    def get_sub_command_class(self):
         # pylint: disable=redefined-variable-type
-        if self.action.value == "format":
-            self.action_command = self.DmgFormatSubCommand()
-        elif self.action.value == "prepare":
-            self.action_command = self.DmgPrepareSubCommand()
-        elif self.action.value == "create":
-            self.action_command = self.DmgCreateSubCommand()
-        elif self.action.value == "destroy":
-            self.action_command = self.DmgDestroySubCommand()
+        """Get the dmg sub command object based upon the sub-command."""
+        if self.sub_command.value == "network":
+            self.sub_command_class = self.NetworkSubCommand()
+        elif self.sub_command.value == "pool":
+            self.sub_command_class = self.PoolSubCommand()
+        elif self.sub_command.value == "storage":
+            self.sub_command_class = self.StorageSubCommand()
+        elif self.sub_command.value == "system":
+            self.sub_command_class = self.SystemSubCommand()
         else:
-            self.action_command = None
+            self.sub_command_class = None
 
-    class DmgFormatSubCommand(CommandWithParameters):
-        """Defines an object representing a format sub dmg command."""
-
-        def __init__(self):
-            """Create a dmg Command object."""
-            super(DmgCommand.DmgFormatSubCommand, self).__init__(
-                "/run/dmg/format/*", "format")
-            self.reformat = FormattedParameter("--reformat", False)
-
-    class DmgPrepareSubCommand(CommandWithParameters):
-        """Defines a object representing a prepare sub dmg command."""
+    class NetworkSubCommand(CommandWithSubCommand):
+        """Defines an object for the dmg network sub command."""
 
         def __init__(self):
-            """Create a dmg Command object."""
-            super(DmgCommand.DmgPrepareSubCommand, self).__init__(
-                "/run/dmg/prepare/*", "prepare")
-            self.pci_wl = FormattedParameter("-w {}")
-            self.hugepages = FormattedParameter("-p {}")
-            self.targetuser = FormattedParameter("-u {}")
-            self.nvmeonly = FormattedParameter("-n", False)
-            self.scmonly = FormattedParameter("-s", False)
-            self.force = FormattedParameter("-f", False)
-            self.reset = FormattedParameter("--reset", False)
+            """Create a dmg network subcommand object."""
+            super(DmgCommand.NetworkSubCommand, self).__init__(
+                "/run/dmg/network/*", "network")
 
-    class DmgCreateSubCommand(CommandWithParameters):
-        """Defines a object representing a create sub dmg command."""
+        def get_sub_command_class(self):
+            # pylint: disable=redefined-variable-type
+            """Get the dmg network sub command object."""
+            if self.sub_command.value == "scan":
+                self.sub_command_class = self.ScanSubCommand()
+            else:
+                self.sub_command_class = None
 
-        def __init__(self):
-            """Create a dmg Command object."""
-            super(DmgCommand.DmgCreateSubCommand, self).__init__(
-                "/run/dmg/create/*", "create")
-            self.group = FormattedParameter("-g {}")
-            self.user = FormattedParameter("-u {}")
-            self.acl_file = FormattedParameter("-a {}")
-            self.scm_size = FormattedParameter("-s {}")
-            self.nvme_size = FormattedParameter("-n {}")
-            self.ranks = FormattedParameter("-r {}")
-            self.nsvc = FormattedParameter("-v {}")
-            self.sys = FormattedParameter("-S {}")
+        class ScanSubCommand(CommandWithParameters):
+            """Defines an object for the dmg network scan command."""
 
-    class DmgDestroySubCommand(CommandWithParameters):
-        """Defines an object representing a destroy sub dmg command."""
+            def __init__(self):
+                """Create a dmg network scan command object."""
+                super(
+                    DmgCommand.NetworkSubCommand.ScanSubCommand, self).__init__(
+                        "/run/dmg/network/scan/*", "scan")
+                self.provider = FormattedParameter("-p {}", None)
+                self.all = FormattedParameter("-a", False)
+
+    class PoolSubCommand(CommandWithSubCommand):
+        """Defines an object for the dmg pool sub command."""
 
         def __init__(self):
-            """Create a dmg Command object."""
-            super(DmgCommand.DmgDestroySubCommand, self).__init__(
-                "/run/dmg/destroy/*", "destroy")
-            self.pool = FormattedParameter("--pool {}")
-            self.force = FormattedParameter("-f", False)
+            """Create a dmg pool subcommand object."""
+            super(DmgCommand.PoolSubCommand, self).__init__(
+                "/run/dmg/pool/*", "pool")
+
+        def get_sub_command_class(self):
+            # pylint: disable=redefined-variable-type
+            """Get the dmg pool sub command object."""
+            if self.sub_command.value == "create":
+                self.sub_command_class = self.CreateSubCommand()
+            elif self.sub_command.value == "delete-acl":
+                self.sub_command_class = self.DeleteAclSubCommand()
+            elif self.sub_command.value == "destroy":
+                self.sub_command_class = self.DestroySubCommand()
+            elif self.sub_command.value == "get-acl":
+                self.sub_command_class = self.GetAclSubCommand()
+            elif self.sub_command.value == "list":
+                self.sub_command_class = self.ListSubCommand()
+            elif self.sub_command.value == "overwrite-acl":
+                self.sub_command_class = self.OverwriteAclSubCommand()
+            elif self.sub_command.value == "query":
+                self.sub_command_class = self.QuerySubCommand()
+            elif self.sub_command.value == "set-prop":
+                self.sub_command_class = self.SetPropSubCommand()
+            elif self.sub_command.value == "update-acl":
+                self.sub_command_class = self.UpdateAclSubCommand()
+            else:
+                self.sub_command_class = None
+
+        class CreateSubCommand(CommandWithParameters):
+            """Defines an object for the dmg pool create command."""
+
+            def __init__(self):
+                """Create a dmg pool create command object."""
+                super(
+                    DmgCommand.PoolSubCommand.CreateSubCommand,
+                    self).__init__(
+                        "/run/dmg/pool/create/*", "create")
+                self.group = FormattedParameter("--group={}", None)
+                self.user = FormattedParameter("--user={}", None)
+                self.acl_file = FormattedParameter("--acl-file={}", None)
+                self.scm_size = FormattedParameter("--scm-size={}", None)
+                self.nvme_size = FormattedParameter("--nvme-size={}", None)
+                self.ranks = FormattedParameter("--ranks={}", None)
+                self.nsvc = FormattedParameter("--nsvc={}", None)
+                self.sys = FormattedParameter("--sys={}", None)
+
+        class DeleteAclSubCommand(CommandWithParameters):
+            """Defines an object for the dmg pool delete-acl command."""
+
+            def __init__(self):
+                """Create a dmg pool delete-acl command object."""
+                super(
+                    DmgCommand.PoolSubCommand.DeleteAclSubCommand,
+                    self).__init__(
+                        "/run/dmg/pool/delete-acl/*", "delete-acl")
+                self.pool = FormattedParameter("--pool={}", None)
+                self.principal = FormattedParameter("-p {}", None)
+
+        class DestroySubCommand(CommandWithParameters):
+            """Defines an object for the dmg pool destroy command."""
+
+            def __init__(self):
+                """Create a dmg pool destroy command object."""
+                super(
+                    DmgCommand.PoolSubCommand.DestroySubCommand,
+                    self).__init__(
+                        "/run/dmg/pool/destroy/*", "destroy")
+                self.pool = FormattedParameter("--pool={}", None)
+                self.sys_name = FormattedParameter("--sys-name={}", None)
+                self.force = FormattedParameter("--force", False)
+
+        class GetAclSubCommand(CommandWithParameters):
+            """Defines an object for the dmg pool get-acl command."""
+
+            def __init__(self):
+                """Create a dmg pool get-acl command object."""
+                super(
+                    DmgCommand.PoolSubCommand.GetAclSubCommand,
+                    self).__init__(
+                        "/run/dmg/pool/get-acl/*", "get-acl")
+                self.pool = FormattedParameter("--pool={}", None)
+
+        class ListSubCommand(CommandWithParameters):
+            """Defines an object for the dmg pool list command."""
+
+            def __init__(self):
+                """Create a dmg pool list command object."""
+                super(
+                    DmgCommand.PoolSubCommand.ListSubCommand,
+                    self).__init__(
+                        "/run/dmg/pool/list/*", "list")
+
+        class OverwriteAclSubCommand(CommandWithParameters):
+            """Defines an object for the dmg pool overwrite-acl command."""
+
+            def __init__(self):
+                """Create a dmg pool overwrite-acl command object."""
+                super(
+                    DmgCommand.PoolSubCommand.OverwriteAclSubCommand,
+                    self).__init__(
+                        "/run/dmg/pool/overwrite-acl/*", "overwrite-acl")
+                self.pool = FormattedParameter("--pool={}", None)
+                self.acl_file = FormattedParameter("-a {}", None)
+
+        class QuerySubCommand(CommandWithParameters):
+            """Defines an object for the dmg pool query command."""
+
+            def __init__(self):
+                """Create a dmg pool query command object."""
+                super(
+                    DmgCommand.PoolSubCommand.QuerySubCommand,
+                    self).__init__(
+                        "/run/dmg/pool/query/*", "query")
+                self.pool = FormattedParameter("--pool={}", None)
+
+        class SetPropSubCommand(CommandWithParameters):
+            """Defines an object for the dmg pool set-prop command."""
+
+            def __init__(self):
+                """Create a dmg pool set-prop command object."""
+                super(
+                    DmgCommand.PoolSubCommand.SetPropSubCommand,
+                    self).__init__(
+                        "/run/dmg/pool/set-prop/*", "set-prop")
+                self.pool = FormattedParameter("--pool={}", None)
+                self.name = FormattedParameter("--name={}", None)
+                self.value = FormattedParameter("--value={}", None)
+
+        class UpdateAclSubCommand(CommandWithParameters):
+            """Defines an object for the dmg pool update-acl command."""
+
+            def __init__(self):
+                """Create a dmg pool update-acl command object."""
+                super(
+                    DmgCommand.PoolSubCommand.UpdateAclSubCommand,
+                    self).__init__(
+                        "/run/dmg/pool/update-acl/*", "update-acl")
+                self.pool = FormattedParameter("--pool={}", None)
+                self.acl_file = FormattedParameter("-a {}", None)
+                self.entry = FormattedParameter("-e {}", None)
+
+    class StorageSubCommand(CommandWithSubCommand):
+        """Defines an object for the dmg storage sub command."""
+
+        def __init__(self):
+            """Create a dmg storage subcommand object."""
+            super(DmgCommand.StorageSubCommand, self).__init__(
+                "/run/dmg/storage/*", "storage")
+
+        def get_sub_command_class(self):
+            # pylint: disable=redefined-variable-type
+            """Get the dmg storage sub command object."""
+            if self.sub_command.value == "format":
+                self.sub_command_class = self.FormatSubCommand()
+            elif self.sub_command.value == "prepare":
+                self.sub_command_class = self.PrepareSubCommand()
+            elif self.sub_command.value == "query":
+                self.sub_command_class = self.QuerySubCommand()
+            elif self.sub_command.value == "scan":
+                self.sub_command_class = self.ScanSubCommand()
+            elif self.sub_command.value == "set":
+                self.sub_command_class = self.SetSubCommand()
+            else:
+                self.sub_command_class = None
+
+        class FormatSubCommand(CommandWithParameters):
+            """Defines an object for the dmg storage format command."""
+
+            def __init__(self):
+                """Create a dmg storage format command object."""
+                super(
+                    DmgCommand.StorageSubCommand.FormatSubCommand,
+                    self).__init__(
+                        "/run/dmg/storage/format/*", "format")
+                self.reformat = FormattedParameter("--reformat", False)
+
+        class PrepareSubCommand(CommandWithParameters):
+            """Defines an object for the dmg storage format command."""
+
+            def __init__(self):
+                """Create a dmg storage prepare command object."""
+                super(
+                    DmgCommand.StorageSubCommand.PrepareSubCommand,
+                    self).__init__(
+                        "/run/dmg/storage/prepare/*", "prepare")
+                self.pci_whitelist = FormattedParameter("-w {}", None)
+                self.hugepages = FormattedParameter("-p {}", None)
+                self.target_user = FormattedParameter("-u {}", None)
+                self.nvme_only = FormattedParameter("-n", False)
+                self.scm_only = FormattedParameter("-s", False)
+                self.reset = FormattedParameter("--reset", False)
+                self.force = FormattedParameter("-f", False)
+
+        class QuerySubCommand(CommandWithSubCommand):
+            """Defines an object for the dmg query format command."""
+
+            def __init__(self):
+                """Create a dmg storage query command object."""
+                super(
+                    DmgCommand.StorageSubCommand.QuerySubCommand,
+                    self).__init__(
+                        "/run/dmg/storage/query/*", "query")
+
+            def get_sub_command_class(self):
+                # pylint: disable=redefined-variable-type
+                """Get the dmg pool sub command object."""
+                if self.sub_command.value == "blobstore-health":
+                    self.sub_command_class = self.BlobstoreHealthSubCommand()
+                elif self.sub_command.value == "smd":
+                    self.sub_command_class = self.SmdSubCommand()
+                else:
+                    self.sub_command_class = None
+
+            class BlobstoreHealthSubCommand(CommandWithParameters):
+                """Defines a dmg storage query blobstore-health object."""
+
+                def __init__(self):
+                    """Create a dmg storage query blobstore-health object."""
+                    super(
+                        DmgCommand.StorageSubCommand.QuerySubCommand.
+                        BlobstoreHealthSubCommand,
+                        self).__init__(
+                            "/run/dmg/storage/query/blobstore-health/*",
+                            "blobstore-health")
+                    self.devuuid = FormattedParameter("-u {}", None)
+                    self.tgtid = FormattedParameter("-t {}", None)
+
+            class SmdSubCommand(CommandWithParameters):
+                """Defines a dmg storage query smd object."""
+
+                def __init__(self):
+                    """Create a dmg storage query smd object."""
+                    super(
+                        DmgCommand.StorageSubCommand.QuerySubCommand.
+                        SmdSubCommand,
+                        self).__init__(
+                            "/run/dmg/storage/query/nvme-health/*",
+                            "nvme-health")
+                    self.devices = FormattedParameter("-d", False)
+                    self.pools = FormattedParameter("-p", False)
+
+        class ScanSubCommand(CommandWithParameters):
+            """Defines an object for the dmg storage scan command."""
+
+            def __init__(self):
+                """Create a dmg storage scan command object."""
+                super(
+                    DmgCommand.StorageSubCommand.ScanSubCommand,
+                    self).__init__(
+                        "/run/dmg/storage/scan/*", "scan")
+                self.summary = FormattedParameter("-m", False)
+
+        class SetSubCommand(CommandWithParameters):
+            """Defines an object for the dmg storage set command."""
+
+            def __init__(self):
+                """Create a dmg storage set command object."""
+                super(
+                    DmgCommand.StorageSubCommand.SetSubCommand,
+                    self).__init__(
+                        "/run/dmg/storage/set/*", "set")
+                self.nvme_faulty = FormattedParameter("nvme-faulty", False)
+
+    class SystemSubCommand(CommandWithSubCommand):
+        """Defines an object for the dmg system sub command."""
+
+        def __init__(self):
+            """Create a dmg system subcommand object."""
+            super(DmgCommand.SystemSubCommand, self).__init__(
+                "/run/dmg/system/*", "system")
+
+        def get_sub_command_class(self):
+            # pylint: disable=redefined-variable-type
+            """Get the dmg system sub command object."""
+            if self.sub_command.value == "leader-query":
+                self.sub_command_class = self.LeaderQuerySubCommand()
+            elif self.sub_command.value == "list-pools":
+                self.sub_command_class = self.ListPoolsSubCommand()
+            elif self.sub_command.value == "query":
+                self.sub_command_class = self.QuerySubCommand()
+            elif self.sub_command.value == "start":
+                self.sub_command_class = self.StartSubCommand()
+            elif self.sub_command.value == "stop":
+                self.sub_command_class = self.StopSubCommand()
+            else:
+                self.sub_command_class = None
+
+        class LeaderQuerySubCommand(CommandWithParameters):
+            """Defines an object for the dmg system leader-query command."""
+
+            def __init__(self):
+                """Create a dmg system leader-query command object."""
+                super(
+                    DmgCommand.SystemSubCommand.LeaderQuerySubCommand,
+                    self).__init__(
+                        "/run/dmg/system/leader-query/*", "leader-query")
+
+        class ListPoolsSubCommand(CommandWithParameters):
+            """Defines an object for the dmg system list-pools command."""
+
+            def __init__(self):
+                """Create a dmg system list-pools command object."""
+                super(
+                    DmgCommand.SystemSubCommand.ListPoolsSubCommand,
+                    self).__init__(
+                        "/run/dmg/system/list-pools/*", "list-pools")
+
+        class QuerySubCommand(CommandWithParameters):
+            """Defines an object for the dmg system query command."""
+
+            def __init__(self):
+                """Create a dmg system query command object."""
+                super(
+                    DmgCommand.SystemSubCommand.QuerySubCommand,
+                    self).__init__(
+                        "/run/dmg/system/query/*", "query")
+                self.rank = FormattedParameter("--rank={}")
+                self.verbose = FormattedParameter("--verbose", False)
+
+        class StartSubCommand(CommandWithParameters):
+            """Defines an object for the dmg system start command."""
+
+            def __init__(self):
+                """Create a dmg system start command object."""
+                super(
+                    DmgCommand.SystemSubCommand.StartSubCommand,
+                    self).__init__(
+                        "/run/dmg/system/start/*", "start")
+
+        class StopSubCommand(CommandWithParameters):
+            """Defines an object for the dmg system stop command."""
+
+            def __init__(self):
+                """Create a dmg system stop command object."""
+                super(
+                    DmgCommand.SystemSubCommand.StopSubCommand,
+                    self).__init__(
+                        "/run/dmg/system/stop/*", "stop")
+                self.force = FormattedParameter("--force", False)
+
+    def _get_result(self):
+        """Get the result from running the configured dmg command.
+
+        Returns:
+            CmdResult: an avocado CmdResult object containing the dmg command
+                information, e.g. exit status, stdout, stderr, etc.
+
+        Raises:
+            CommandFailure: if the dmg command fails.
+
+        """
+        result = None
+        try:
+            result = self.run()
+        except CommandFailure as error:
+            raise CommandFailure("<dmg> command failed: {}".format(error))
+
+        return result
+
+    def storage_scan(self):
+        """Get the result of the dmg storage scan command.
+
+        Returns:
+            CmdResult: an avocado CmdResult object containing the dmg command
+                information, e.g. exit status, stdout, stderr, etc.
+
+        Raises:
+            CommandFailure: if the dmg storage scan command fails.
+
+        """
+        self.set_sub_command("storage")
+        self.sub_command_class.set_sub_command("scan")
+        return self._get_result()
+
+    def storage_format(self):
+        """Get the result of the dmg storage format command.
+
+        Returns:
+            CmdResult: an avocado CmdResult object containing the dmg command
+                information, e.g. exit status, stdout, stderr, etc.
+
+        Raises:
+            CommandFailure: if the dmg storage format command fails.
+
+        """
+        self.set_sub_command("storage")
+        self.sub_command_class.set_sub_command("format")
+        return self._get_result()
+
+    def storage_prepare(self, user=None, hugepages="4096", nvme=False,
+                        scm=False, reset=False, force=True):
+        """Get the result of the dmg storage format command.
+
+        Returns:
+            CmdResult: an avocado CmdResult object containing the dmg command
+                information, e.g. exit status, stdout, stderr, etc.
+
+        Raises:
+            CommandFailure: if the dmg storage prepare command fails.
+
+        """
+        self.set_sub_command("storage")
+        self.sub_command_class.set_sub_command("prepare")
+        self.sub_command_class.sub_command_class.nvme_only.value = nvme
+        self.sub_command_class.sub_command_class.scm_only.value = scm
+        self.sub_command_class.sub_command_class.target_user.value = \
+            getuser() if user is None else user
+        self.sub_command_class.sub_command_class.hugepages.value = hugepages
+        self.sub_command_class.sub_command_class.reset.value = reset
+        self.sub_command_class.sub_command_class.force.value = force
+        return self._get_result()
+
+    def pool_create(self, scm_size, uid=None, gid=None, nvme_size=None,
+                    target_list=None, svcn=None, group=None, acl_file=None):
+        """Create a pool with the dmg command.
+
+        The uid and gid method arguments can be specified as either an integer
+        or a string.  If an integer value is specified it will be converted into
+        the corresponding user/group name string.
+
+        Args:
+            scm_size (int): SCM pool size to create.
+            uid (object, optional): User ID with privileges. Defaults to None.
+            gid (object, otional): Group ID with privileges. Defaults to None.
+            nvme_size (str, optional): NVMe size. Defaults to None.
+            target_list (list, optional): a list of storage server unique
+                identifiers (ranks) for the DAOS pool
+            svcn (str, optional): Number of pool service replicas. Defaults to
+                None, in which case 1 is used by the dmg binary in default.
+            group (str, optional): DAOS system group name in which to create the
+                pool. Defaults to None, in which case "daos_server" is used by
+                default.
+            acl_file (str, optional): ACL file. Defaults to None.
+
+        Returns:
+            CmdResult: an avocado CmdResult object containing the dmg command
+                information, e.g. exit status, stdout, stderr, etc.
+
+        Raises:
+            CommandFailure: if the dmg pool create command fails.
+
+        """
+        self.set_sub_command("pool")
+        self.sub_command_class.set_sub_command("create")
+        self.sub_command_class.sub_command_class.user.value = \
+            getpwuid(uid).pw_name if isinstance(uid, int) else uid
+        self.sub_command_class.sub_command_class.group.value = \
+            getgrgid(gid).gr_name if isinstance(gid, int) else gid
+        self.sub_command_class.sub_command_class.scm_size.value = scm_size
+        self.sub_command_class.sub_command_class.nvme_size.value = nvme_size
+        if target_list is not None:
+            self.sub_command_class.sub_command_class.ranks.value = ",".join(
+                [str(target) for target in target_list])
+        self.sub_command_class.sub_command_class.nsvc.value = svcn
+        self.sub_command_class.sub_command_class.sys.value = group
+        self.sub_command_class.sub_command_class.acl_file.value = acl_file
+        return self._get_result()
+
+    def pool_destroy(self, pool, force=True):
+        """Destroy a pool with the dmg command.
+
+        Args:
+            pool (str): Pool UUID to destroy.
+            force (bool, optional): Force removal of pool. Defaults to True.
+
+        Returns:
+            CmdResult: Object that contains exit status, stdout, and other
+                information.
+
+        Raises:
+            CommandFailure: if the dmg pool destroy command fails.
+
+        """
+        self.set_sub_command("pool")
+        self.sub_command_class.set_sub_command("destroy")
+        self.sub_command_class.sub_command_class.pool.value = pool
+        self.sub_command_class.sub_command_class.force.value = force
+        return self._get_result()
+
+    def pool_get_acl(self, pool):
+        """Get the ACL for a given pool.
+
+        Args:
+            pool (str): Pool for which to get the ACL.
+
+        Returns:
+            CmdResult: Object that contains exit status, stdout, and other
+                information.
+
+        Raises:
+            CommandFailure: if the dmg pool get-acl command fails.
+
+        """
+        self.set_sub_command("pool")
+        self.sub_command_class.set_sub_command("get-acl")
+        self.sub_command_class.sub_command_class.pool.value = pool
+        return self._get_result()
+
+    def pool_update_acl(self, pool, acl_file, entry):
+        """Update the acl for a given pool.
+
+        Args:
+            pool (str): Pool for which to update the ACL.
+            acl_file (str): ACL file to update
+            entry (str): entry to be updated
+
+        Returns:
+            CmdResult: Object that contains exit status, stdout, and other
+                information.
+
+        Raises:
+            CommandFailure: if the dmg pool update-acl command fails.
+
+        """
+        self.set_sub_command("pool")
+        self.sub_command_class.set_sub_command("update-acl")
+        self.sub_command_class.sub_command_class.pool.value = pool
+        self.sub_command_class.sub_command_class.acl_file.value = acl_file
+        self.sub_command_class.sub_command_class.entry.value = entry
+        return self._get_result()
+
+    def pool_overwrite_acl(self, pool, acl_file):
+        """Overwrite the acl for a given pool.
+
+        Args:
+            pool (str): Pool for which to overwrite the ACL.
+            acl_file (str): ACL file to update
+
+        Returns:
+            CmdResult: Object that contains exit status, stdout, and other
+                information.
+
+        Raises:
+            CommandFailure: if the dmg pool overwrite-acl command fails.
+
+        """
+        self.set_sub_command("pool")
+        self.sub_command_class.set_sub_command("overwrite-acl")
+        self.sub_command_class.sub_command_class.pool.value = pool
+        self.sub_command_class.sub_command_class.acl_file.value = acl_file
+        return self._get_result()
+
+    def pool_delete_acl(self, pool, principal):
+        """Delete the acl for a given pool.
+
+        Args:
+            pool (str): Pool for which to delete the ACL.
+            principal (str): principal to be deleted
+
+        Returns:
+            CmdResult: Object that contains exit status, stdout, and other
+                information.
+
+        Raises:
+            CommandFailure: if the dmg pool delete-acl command fails.
+
+        """
+        self.set_sub_command("pool")
+        self.sub_command_class.set_sub_command("delete-acl")
+        self.sub_command_class.sub_command_class.pool.value = pool
+        self.sub_command_class.sub_command_class.principal.value = principal
+        return self._get_result()
 
 
-def storage_scan(path, hosts, insecure=True):
-    """ Execute scan command through dmg tool to servers provided.
+def get_pool_uuid_service_replicas_from_stdout(stdout_str):
+    """Get Pool UUID and Service replicas from stdout.
+
+    stdout_str is something like:
+    Active connections: [wolf-3:10001]
+    Creating DAOS pool with 100MB SCM and 0B NvMe storage (1.000 ratio)
+    Pool-create command SUCCEEDED: UUID: 9cf5be2d-083d-4f6b-9f3e-38d771ee313f,
+    Service replicas: 0
+    This method makes it easy to create a test.
 
     Args:
-        path (str): path to tool's binary
-        hosts (list): list of servers to run scan on.
-        insecure (bool): toggle insecure mode
+        stdout_str (str): Output of pool create command.
 
     Returns:
-        Avocado CmdResult object that contains exit status, stdout information.
+        Tuple (str, str): Tuple that contains two items; Pool UUID and Service
+            replicas if found. If not found, the tuple contains None.
 
     """
-    # Create and setup the command
-    dmg = DmgCommand(path)
-    dmg.request.value = "storage"
-    dmg.action.value = "scan"
-    dmg.insecure.value = insecure
-    dmg.hostlist.value = hosts
-
-    try:
-        result = dmg.run()
-    except CommandFailure as details:
-        print("<dmg> command failed: {}".format(details))
-        return None
-
-    return result
+    # Find the following with regex. One or more of whitespace after "UUID:"
+    # followed by one of more of number, alphabets, or -. Use parenthesis to
+    # get the returned value.
+    uuid = None
+    svc = None
+    match = re.search(r" UUID: (.+), Service replicas: (.+)", stdout_str)
+    if match:
+        uuid = match.group(1)
+        svc = match.group(2)
+    return uuid, svc
 
 
+# ************************************************************************
+# *** External usage should be replaced by DmgCommand.storage_format() ***
+# ************************************************************************
 def storage_format(path, hosts, insecure=True):
-    """ Execute format command through dmg tool to servers provided.
+    """Execute format command through dmg tool to servers provided.
 
     Args:
         path (str): path to tool's binary
@@ -153,216 +721,11 @@ def storage_format(path, hosts, insecure=True):
     dmg = DmgCommand(path)
     dmg.insecure.value = insecure
     dmg.hostlist.value = hosts
-    dmg.request.value = "storage"
-    dmg.action.value = "format"
-    dmg.get_action_command()
 
     try:
-        result = dmg.run()
+        result = dmg.storage_format()
     except CommandFailure as details:
         print("<dmg> command failed: {}".format(details))
         return None
 
     return result
-
-
-def storage_prep(path, hosts, user=None, hugepages="4096", nvme=False,
-                 scm=False, insecure=True):
-    """Execute prepare command through dmg tool to servers provided.
-
-    Args:
-        path (str): path to tool's binary
-        hosts (list): list of servers to run prepare on.
-        user (str, optional): User with privileges. Defaults to False.
-        hugepages (str, optional): Hugepages to allocate. Defaults to "4096".
-        nvme (bool, optional): Perform prep on nvme. Defaults to False.
-        scm (bool, optional): Perform prep on scm. Defaults to False.
-        insecure (bool): toggle insecure mode
-
-    Returns:
-        Avocado CmdResult object that contains exit status, stdout information.
-
-    """
-    # Create and setup the command
-    dmg = DmgCommand(path)
-    dmg.insecure.value = insecure
-    dmg.hostlist.value = hosts
-    dmg.request.value = "storage"
-    dmg.action.value = "prepare"
-    dmg.get_action_command()
-    dmg.action_command.nvmeonly.value = nvme
-    dmg.action_command.scmonly.value = scm
-    dmg.action_command.targetuser.value = getpass.getuser() \
-        if user is None else user
-    dmg.action_command.hugepages.value = hugepages
-    dmg.action_command.force.value = True
-
-    try:
-        result = dmg.run()
-    except CommandFailure as details:
-        print("<dmg> command failed: {}".format(details))
-        return None
-
-    return result
-
-
-def storage_reset(path, hosts, nvme=False, scm=False, user=None,
-                  hugepages="4096", insecure=True):
-    """Execute prepare reset command through dmg tool to servers provided.
-
-    Args:
-        path (str): path to tool's binary.
-        hosts (list): list of servers to run prepare on.
-        nvme (bool): if true, nvme flag will be appended to command.
-        scm (bool): if true, scm flag will be appended to command.
-        user (str, optional): User with privileges. Defaults to False.
-        hugepages (str, optional): Hugepages to allocate. Defaults to "4096".
-        insecure (bool): toggle insecure mode
-
-    Returns:
-        Avocado CmdResult object that contains exit status, stdout information.
-
-    """
-    # Create and setup the command
-    dmg = DmgCommand(path)
-    dmg.insecure.value = insecure
-    dmg.hostlist.value = hosts
-    dmg.request.value = "storage"
-    dmg.action.value = "prepare"
-    dmg.get_action_command()
-    dmg.action_command.nvmeonly.value = nvme
-    dmg.action_command.scmonly.value = scm
-    dmg.action_command.targetuser.value = user
-    dmg.action_command.hugepages.value = hugepages
-    dmg.action_command.reset.value = True
-    dmg.action_command.force.value = True
-
-    try:
-        result = dmg.run()
-    except CommandFailure as details:
-        print("<dmg> command failed: {}".format(details))
-        return None
-
-    return result
-
-
-def pool_create(path, scm_size, host_port=None, insecure=True, group=None,
-                user=None, acl_file=None, nvme_size=None, ranks=None,
-                nsvc=None, sys=None):
-    # pylint: disable=too-many-arguments
-    """Execute pool create command through dmg tool to servers provided.
-
-    Args:
-        path (str): Path to the directory of dmg binary.
-        host_port (str, optional): Comma separated list of Host:Port where
-            daos_server runs. e.g., wolf-31:10001,wolf-32:10001. Use 10001 for
-            the default port number. This number is defined in
-            daos_avocado_test.yaml
-        scm_size (str): SCM size value passed into the command.
-        insecure (bool, optional): Insecure mode. Defaults to True.
-        group (str, otional): Group with privileges. Defaults to None.
-        user (str, optional): User with privileges. Defaults to None.
-        acl_file (str, optional): Access Control List file path for DAOS pool.
-            Defaults to None.
-        nvme_size (str, optional): NVMe size. Defaults to None.
-        ranks (str, optional): Storage server unique identifiers (ranks) for
-            DAOS pool
-        nsvc (str, optional): Number of pool service replicas. Defaults to
-            None, in which case 1 is used by the dmg binary in default.
-        sys (str, optional): DAOS system that pool is to be a part of. Defaults
-            to None, in which case daos_server is used by the dmg binary in
-            default.
-
-    Returns:
-        CmdResult: Object that contains exit status, stdout, and other
-            information.
-    """
-    # Create and setup the command
-    dmg = DmgCommand(path)
-    dmg.insecure.value = insecure
-    dmg.hostlist.value = host_port
-    dmg.request.value = "pool"
-    dmg.action.value = "create"
-    dmg.get_action_command()
-    dmg.action_command.group.value = group
-    dmg.action_command.user.value = user
-    dmg.action_command.acl_file.value = acl_file
-    dmg.action_command.scm_size.value = scm_size
-    dmg.action_command.nvme_size.value = nvme_size
-    dmg.action_command.ranks.value = ranks
-    dmg.action_command.nsvc.value = nsvc
-    dmg.action_command.sys.value = sys
-
-    try:
-        result = dmg.run()
-    except CommandFailure as details:
-        print("Pool create command failed: {}".format(details))
-        return None
-
-    return result
-
-
-def pool_destroy(path, pool_uuid, host_port=None, insecure=True, force=True):
-    """ Execute pool destroy command through dmg tool to servers provided.
-
-    Args:
-        path (str): Path to the directory of dmg binary.
-        host_port (str, optional): Comma separated list of Host:Port where
-            daos_server runs. e.g., wolf-31:10001,wolf-32:10001. Use 10001 for
-            the default port number. This number is defined in
-            daos_avocado_test.yaml
-        pool_uuid (str): Pool UUID to destroy.
-        insecure (bool, optional): Insecure mode. Defaults to True.
-        foce (bool, optional): Force removal of DAOS pool. Defaults to True.
-
-    Returns:
-        CmdResult: Object that contains exit status, stdout, and other
-            information.
-    """
-    # Create and setup the command
-    dmg = DmgCommand(path)
-    dmg.insecure.value = insecure
-    dmg.hostlist.value = host_port
-    dmg.request.value = "pool"
-    dmg.action.value = "destroy"
-    dmg.get_action_command()
-    dmg.action_command.pool.value = pool_uuid
-    dmg.action_command.force.value = force
-
-    try:
-        result = dmg.run()
-    except CommandFailure as details:
-        print("Pool destroy command failed: {}".format(details))
-        return None
-
-    return result
-
-
-def get_pool_uuid_service_replicas_from_stdout(stdout_str):
-    """Get Pool UUID and Service replicas from stdout.
-
-    stdout_str is something like:
-    Active connections: [wolf-3:10001]
-    Creating DAOS pool with 100MB SCM and 0B NvMe storage (1.000 ratio)
-    Pool-create command SUCCEEDED: UUID: 9cf5be2d-083d-4f6b-9f3e-38d771ee313f,
-    Service replicas: 0
-
-    This method makes it easy to create a test.
-
-    Args:
-        stdout_str (str): Output of pool create command.
-
-    Returns:
-        Tuple (str, str): Tuple that contains two items; Pool UUID and Service
-            replicas if found. If not found, the tuple contains None.
-    """
-    # Find the following with regex. One or more of whitespace after "UUID:"
-    # followed by one of more of number, alphabets, or -. Use parenthesis to
-    # get the returned value.
-    uuid = None
-    svc = None
-    match = re.search(r" UUID: (.+), Service replicas: (.+)", stdout_str)
-    if match:
-        uuid = match.group(1)
-        svc = match.group(2)
-    return uuid, svc

--- a/src/tests/ftest/util/pool_security_test_base.py
+++ b/src/tests/ftest/util/pool_security_test_base.py
@@ -1,0 +1,495 @@
+#!/usr/bin/python
+"""
+  (C) Copyright 2020 Intel Corporation.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+  GOVERNMENT LICENSE RIGHTS-OPEN SOURCE SOFTWARE
+  The Government's rights to use, modify, reproduce, release, perform, display,
+  or disclose this software are subject to the terms of the Apache License as
+  provided in Contract No. B609815.
+  Any reproduction of computer software, computer software documentation, or
+  portions thereof marked with this legend must also reproduce the markings.
+"""
+from __future__ import print_function
+
+import os
+from apricot import TestWithServers
+from daos_utils import DaosCommand
+import dmg_utils
+import random
+import grp
+import re
+from general_utils import pcmd
+
+PERMISSIONS = ["", "r", "w", "rw"]
+
+
+def acl_entry(usergroup, name, permission):
+    """Create a daos acl entry for the specified user or group and permission.
+
+    Args:
+        usergroup (str): user or group.
+        name (str): user or group name to be created.
+        permission (str): permission to be created.
+
+    Return:
+        str: daos pool acl entry.
+
+    """
+    if permission == "random":
+        permission = random.choice(PERMISSIONS)
+    if permission == "nonexist":
+        return ""
+    if "group" in usergroup:
+        entry = "A:G:" + name + "@:" + permission
+    else:
+        entry = "A::" + name + "@:" + permission
+    return entry
+
+
+def acl_principal(usergroup, name):
+    """Create a daos ace principal for the specified user or group.
+
+    Args:
+        usergroup (str): user or group.
+        name (str): user or group name to be created.
+
+    Return:
+        str: daos pool acl entry.
+
+    """
+    if "group" in usergroup:
+        entry = "g:" + name + "@"
+    else:
+        entry = "u:" + name + "@"
+    return entry
+
+
+def add_del_user(hosts, ba_cmd, user):
+    """Add or delete the daos user and group on host by sudo command.
+
+    Args:
+        hosts (list): list of host.
+        ba_cmd (str): linux bash command to create user or group.
+        user (str): user or group name to be created or cleaned.
+
+    Return:
+        none.
+
+    """
+    bash_cmd = os.path.join("/usr/sbin", ba_cmd)
+    homedir = ""
+    if "usermod" not in ba_cmd and "user" in ba_cmd:
+        homedir = "-r"
+    cmd = " ".join(("sudo", bash_cmd, homedir, user))
+    print("     =Clients/hosts {0}, exec cmd: {1}".format(hosts, cmd))
+    pcmd(hosts, cmd, False)
+
+
+def create_acl_file(file_name, permissions):
+    """Create a acl_file with permissions.
+
+    Args:
+        file_name (str): file name.
+        permissions (str): daos acl permission list.
+
+    Return:
+        none.
+
+    """
+    acl_file = open(file_name, "w")
+    acl_file.write("\n".join(permissions))
+    acl_file.close()
+
+
+class PoolSecurityTestBase(TestWithServers):
+    """Pool security test cases.
+
+    Test Class Description:
+        Test methods to verify the Pool security with acl by dmg
+        and daos tools.
+
+    :avocado: recursive
+    """
+
+    def __init__(self, *args, **kwargs):
+        """Initialize a PoolSecurityTestBase object."""
+        super(PoolSecurityTestBase, self).__init__(*args, **kwargs)
+        self.dmg = None
+
+    def setUp(self):
+        """Set up each test case."""
+        super(PoolSecurityTestBase, self).setUp()
+
+        # Setup the dmg command object - requires a server to be started
+        self.dmg = self.get_dmg_command()
+
+    def modify_acl_file_entry(self, file_name, entry, new_entry):
+        """Modify the acl_file acl list entry.
+
+        Args:
+            file_name (str): file name.
+            entry (str): acl entry to be modified.
+            new_entry (str): new acl entry.
+
+        Return:
+            none.
+
+        """
+        acl_file = open(file_name, "r+")
+        new_permissions = ""
+        for line in acl_file.readlines():
+            line = line.split("\n")[0]
+            if line == entry:
+                line = new_entry
+                self.log.info(
+                    "==>replaceing \n %s  with\n %s", entry, new_entry)
+            new_permissions = new_permissions + line + "\n"
+        if entry is None:
+            new_permissions = new_permissions + new_entry + "\n"
+        acl_file.close()
+        acl_file = open(file_name, "w")
+        acl_file.write(new_permissions)
+        acl_file.close()
+
+    def get_pool_acl_list(self, uuid):
+        """Get daos pool acl list by dmg get-acl.
+
+        Args:
+            uuid (str): pool uuid.
+
+        Return:
+            list: daos pool acl list.
+
+        """
+        result = self.dmg.pool_get_acl(uuid)
+
+        pool_permission_list = []
+        for line in result.stdout.splitlines():
+            if not line.startswith("A:"):
+                continue
+            elif line.startswith("A::"):
+                found_user = re.search(r"A::(.+)@:(.*)", line)
+                if found_user:
+                    pool_permission_list.append(line)
+            elif line.startswith("A:G:"):
+                found_group = re.search(r"A:G:(.+)@:(.*)", line)
+                if found_group:
+                    pool_permission_list.append(line)
+        return pool_permission_list
+
+    def update_pool_acl_entry(self, uuid, action, entry):
+        """Update daos pool acl list by dmg tool.
+
+        Args:
+            uuid (str): pool uuid.
+            action (str): update-acl or delete-acl.
+            entry (str): pool acl entry or principal to be updated.
+
+        Return:
+            none.
+
+        """
+        if action == "delete":
+            result = self.dmg.pool_delete_acl(uuid, entry)
+        elif action == "update":
+            result = self.dmg.pool_update_acl(uuid, None, entry)
+        else:
+            self.fail("##update_pool_acl_entry, action: {} is not supported."
+                      "\n  supported action: update, delete.".format(action))
+        self.log.info(" At update_pool_acl_entry, dmg.run result=\n %s", result)
+
+    def verify_daos_pool_result(self, result, action, expect, err_code):
+        """Verify the daos pool read or write action result.
+
+        Args:
+            result (CmdResult): handle for daos pool action.
+            action (str): daos pool read or write.
+            expect (str): expecting pass or deny.
+            err_code (str): expecting deny of RC code.
+
+        Return:
+            none.
+
+        """
+        if expect.lower() == 'pass':
+            if result.exit_status != 0 or result.stderr != "":
+                self.fail(
+                    "##Test Fail on verify_daos_pool {}, expected Pass, but "
+                    "Failed.".format(action))
+            else:
+                self.log.info(
+                    " =Test Passed on verify_daos_pool %s, Succeed.\n", action)
+        elif err_code not in result.stderr:
+            self.fail(
+                "##Test Fail on verify_daos_pool {}, expected Failure of {}, "
+                "but Passed.".format(action, expect))
+        else:
+            self.log.info(
+                " =Test Passed on verify_daos_pool %s expected error of %s.\n",
+                action, expect)
+
+    def verify_pool_readwrite(self, svc, uuid, action, expect='Pass'):
+        """Verify client is able to perform read or write on a pool.
+
+        Args:
+            svc (int):  pool svc number.
+            uuid (str): pool uuid number.
+            action (str): read or write on pool.
+            expect (str): expecting behavior pass or deny with RC -1001.
+
+        Return:
+            bool: pass or fail.
+
+        """
+        deny_access = '-1001'
+        daos_cmd = DaosCommand(self.bin)
+        daos_cmd.exit_status_exception = False
+        if action.lower() == "write":
+            result = daos_cmd.container_create(pool=uuid, svc=svc)
+        elif action.lower() == "read":
+            result = daos_cmd.pool_query(pool=uuid, svc=svc)
+        else:
+            self.fail(
+                "##In verify_pool_readwrite, invalid action: {}".format(action))
+        self.log.info(
+            "  In verify_pool_readwrite %s.\n =daos_cmd.run() result:\n%s",
+            action, result)
+        self.verify_daos_pool_result(result, action, expect, deny_access)
+
+    def create_pool_acl(self, num_user, num_group, current_user_acl, acl_file):
+        """Create pool get-acl file.
+
+        Create the pool acl file with specified number of users and groups with
+        random permission.
+
+        Args:
+            num_user (int):  number of users to be created.
+            num_group (int): number of groups to be created.
+            current_user_acl (list): acl entries on current user to be created.
+            acl_file (str): acl file to be created.
+
+        Return:
+            list: acl permission list on the acl_file.
+
+        """
+        user_prefix = self.params.get("user_prefix", "/run/pool_acl/*")
+        user_list = []
+        group_list = []
+        for uid in range(num_user):
+            username = user_prefix + "_tester_" + str(uid + 1)
+            new_user = "A::" + username + "@:" + PERMISSIONS[uid % 4]
+            add_del_user(self.hostlist_clients, "useradd", username)
+            user_list.append(new_user)
+        for gid in range(num_group):
+            groupname = user_prefix + "_testGrp_" + str(gid + 1)
+            new_group = "A:G:" + groupname + "@:" + PERMISSIONS[(gid + 2) % 4]
+            add_del_user(self.hostlist_clients, "groupadd", groupname)
+            group_list.append(new_group)
+        permission_list = group_list + user_list + current_user_acl
+        random.shuffle(permission_list)
+        with open(acl_file, "w") as test_file:
+            test_file.write("\n".join(permission_list))
+        return permission_list
+
+    def cleanup_user_group(self, num_user, num_group):
+        """Remove the daos acl user and group on host.
+
+        Args:
+            num_user (int): number of user to be cleaned.
+            num_group (int): number of group name to be cleaned.
+
+        Return:
+            none.
+
+        """
+        user_prefix = self.params.get("user_prefix", "/run/pool_acl/*")
+        for uid in range(num_user):
+            username = user_prefix + "_tester_" + str(uid + 1)
+            add_del_user(self.hostlist_clients, "userdel", username)
+        for gid in range(num_group):
+            groupname = user_prefix + "_testGrp_" + str(gid + 1)
+            add_del_user(self.hostlist_clients, "groupdel", groupname)
+
+    def verify_pool_acl_prim_sec_groups(self, pool_acl_list, acl_file, uuid,
+                                        svc):
+        """Verify daos pool acl access.
+
+        Verify access with primary and secondary groups access permission.
+
+        Args:
+            pool_acl_list (list): pool acl entry list.
+            acl_file (str): acl file to be used.
+            uuid (str): daos pool uuid.
+            svc (int):  daos pool svc.
+
+        Return:
+            None.
+
+        """
+        sec_group = self.params.get("secondary_group_name", "/run/pool_acl/*")
+        sec_group_perm = self.params.get("sg_permission", "/run/pool_acl/*")
+        sec_group_rw = self.params.get("sg_read_write", "/run/pool_acl/*")
+        user_gid = os.getegid()
+        current_group = grp.getgrgid(user_gid)[0]
+        primary_grp_perm = self.params.get(
+            "pg_permission", "/run/pool_acl/primary_secondary_group_test/*")[0]
+        sec_group = self.params.get(
+            "secondary_group_name",
+            "/run/pool_acl/primary_secondary_group_test/*")
+        sec_group_perm = self.params.get(
+            "sg_permission", "/run/pool_acl/primary_secondary_group_test/*")
+        sec_group_rw = self.params.get(
+            "sg_read_write", "/run/pool_acl/primary_secondary_group_test/*")
+        l_group = grp.getgrgid(os.getegid())[0]
+        for group in sec_group:
+            add_del_user(self.hostlist_clients, "groupadd", group)
+        cmd = "usermod -G " + ",".join(sec_group)
+        self.log.info("  (8-1)verify_pool_acl_prim_sec_groups, cmd= %s", cmd)
+        add_del_user(self.hostlist_clients, cmd, l_group)
+
+        self.log.info(
+            "  (8-2)Before update sec_group permission, pool_acl_list= %s",
+            pool_acl_list)
+        for group, permission in zip(sec_group, sec_group_perm):
+            if permission == "none":
+                permission = ""
+            n_acl = acl_entry("group", group, permission)
+            pool_acl_list.append(n_acl)
+
+        self.log.info(
+            "  (8-3)After update sec_group permission, pool_acl_list= %s",
+            pool_acl_list)
+        self.log.info("      pool acl_file= %s", acl_file)
+        create_acl_file(acl_file, pool_acl_list)
+
+        # modify primary-group permission for secondary-group test
+        grp_entry = acl_entry("group", current_group, primary_grp_perm)
+        new_grp_entry = acl_entry("group", current_group, "")
+        self.modify_acl_file_entry(acl_file, grp_entry, new_grp_entry)
+
+        # dmg pool overwrite-acl --pool <uuid> --acl-file <file>
+        result = self.dmg.pool_overwrite_acl(uuid, acl_file)
+        self.log.info("  (8-4)dmg= %s", self.dmg)
+        self.log.info("  (8-5)dmg.run() result=\n %s", result)
+
+        # Verify pool read operation
+        # daos pool query --pool <uuid>
+        self.log.info("  (8-6)Verify pool read by: daos pool query --pool")
+        exp_read = sec_group_rw[0]
+        self.verify_pool_readwrite(svc, uuid, "read", expect=exp_read)
+
+        # Verify pool write operation
+        # daos continer create --pool <uuid>
+        self.log.info("  (8-7)Verify pool write by: daos continer create pool")
+        exp_write = sec_group_rw[1]
+        self.verify_pool_readwrite(svc, uuid, "write", expect=exp_write)
+
+        for group in sec_group:
+            add_del_user(self.hostlist_clients, "groupdel", group)
+
+    def pool_acl_verification(self, current_user_acl, read, write,
+                              secondary_grp_test=False):
+        """Verify the daos pool security with an acl file.
+
+        Steps:
+            (1)Setup dmg tool for creating a pool
+            (2)Generate acl file with permissions
+            (3)Create a pool with acl
+            (4)Verify the pool create status
+            (5)Get the pool's acl list
+            (6)Verify pool's ace entry update and delete
+            (7)Verify pool read operation
+            (8)Verify pool write operation
+            (9)Cleanup user and destroy pool
+
+        Args:
+            current_user_acl (str): acl with read write access credential.
+            read (str): expecting read permission.
+            write (str): expecting write permission.
+
+        Return:
+            None: pass to continue; fail to report the testlog and stop.
+
+        """
+        # (1)Create dmg command
+        scm_size = self.params.get("scm_size", "/run/pool_acl/*")
+        get_acl_file = self.params.get(
+            "acl_file", "/run/pool_acl/*", "acl_test.txt")
+        acl_file = os.path.join(self.tmp, get_acl_file)
+        num_user = self.params.get("num_user", "/run/pool_acl/*")
+        num_group = self.params.get("num_group", "/run/pool_acl/*")
+
+        # (2)Generate acl file with permissions
+        self.log.info("  (1)Generate acl file with user/group permissions")
+        permission_list = self.create_pool_acl(num_user,
+                                               num_group,
+                                               current_user_acl,
+                                               acl_file)
+
+        # (3)Create a pool with acl
+        self.dmg.exit_status_exception = False
+        result = self.dmg.pool_create(scm_size, acl_file=acl_file)
+        self.dmg.exit_status_exception = True
+        self.log.info("  (2)dmg= %s", self.dmg)
+        self.log.info("  (3)Create a pool with acl")
+
+        # (4)Verify the pool create status
+        self.log.info("  (4)dmg.run() result=\n%s", result)
+        if "ERR" not in result.stderr:
+            uuid, svc = \
+                dmg_utils.get_pool_uuid_service_replicas_from_stdout(
+                    result.stdout)
+        else:
+            self.fail("##(4)Unable to parse pool uuid and svc.")
+
+        # (5)Get the pool's acl list
+        #    dmg pool get-acl --pool <UUID>
+        self.log.info("  (5)Get a pool's acl list by: "
+                      "dmg pool get-acl --pool --hostlist")
+        pool_acl_list = self.get_pool_acl_list(uuid)
+        self.log.info(
+            "   pool original permission_list: %s", permission_list)
+        self.log.info(
+            "   pool get_acl  permission_list: %s", pool_acl_list)
+
+        # (6)Verify pool acl ace update and delete
+        self.log.info("  (6)Verify update and delete of pool's acl entry.")
+        tmp_ace = "daos_ci_test_new"
+        new_entrys = [acl_entry("user", tmp_ace, ""),
+                      acl_entry("group", tmp_ace, "")]
+        acl_principals = [acl_principal("user", tmp_ace),
+                          acl_principal("group", tmp_ace)]
+        for new_entry in new_entrys:
+            self.update_pool_acl_entry(uuid, "update", new_entry)
+        for principal in acl_principals:
+            self.update_pool_acl_entry(uuid, "delete", principal)
+
+        # (7)Verify pool read operation
+        #    daos pool query --pool <uuid>
+        self.log.info("  (7)Verify pool read by: daos pool query --pool")
+        self.verify_pool_readwrite(svc, uuid, "read", expect=read)
+
+        # (8)Verify pool write operation
+        #    daos continer create --pool <uuid>
+        self.log.info("  (8)Verify pool write by: daos continer create --pool")
+        self.verify_pool_readwrite(svc, uuid, "write", expect=write)
+        if secondary_grp_test:
+            self.log.info("  (8-0)Verifying verify_pool_acl_prim_sec_groups")
+            self.verify_pool_acl_prim_sec_groups(
+                pool_acl_list, acl_file, uuid, svc)
+
+        # (9)Cleanup user and destroy pool
+        self.log.info("  (9)Cleanup users and groups")
+        self.cleanup_user_group(num_user, num_group)

--- a/src/tests/ftest/util/test_utils_pool.py
+++ b/src/tests/ftest/util/test_utils_pool.py
@@ -24,8 +24,6 @@
 import os
 from time import sleep
 import ctypes
-import getpass
-import grp
 
 from test_utils_base import TestDaosApiBase
 
@@ -76,13 +74,10 @@ class TestPool(TestDaosApiBase):
         self.target_list = BasicParameter(None)
         self.scm_size = BasicParameter(None)
         self.nvme_size = BasicParameter(None)
+
         # Set USE_API to use API or USE_DMG to use dmg. If it's not set, API is
         # used.
         self.control_method = BasicParameter(self.USE_API, self.USE_API)
-        uname = getpass.getuser()
-        gname = grp.getgrgid(self.gid)[0]
-        self.username = BasicParameter(uname, uname)
-        self.groupname = BasicParameter(gname, gname)
 
         self.pool = None
         self.uuid = None
@@ -100,14 +95,14 @@ class TestPool(TestDaosApiBase):
         prior to calling this method. The recommended way is to specify the
         pool block in yaml. For example,
 
-        pool:
-            control_method: dmg
+            pool:
+                control_method: dmg
 
         This tells this method to use dmg. The test also needs to set
         dmg_bin_path through the constructor if dmg is used. For example,
 
-        self.pool = TestPool(self.context,
-                             dmg_bin_path=self.basepath + '/install/bin')
+            self.pool = TestPool(
+                self.context, dmg_bin_path=self.basepath + '/install/bin')
 
         If it wants to use --nsvc option, it needs to set the value to
         svcn.value. Otherwise, 1 is used. If it wants to use --group, it needs
@@ -127,90 +122,57 @@ class TestPool(TestDaosApiBase):
                 "Creating a pool on targets %s", self.target_list.value)
         else:
             self.log.info("Creating a pool")
-        self.pool = DaosPool(self.context)
-        if self.control_method.value == self.USE_API:
-            kwargs = {
-                "mode": self.mode.value, "uid": self.uid, "gid": self.gid,
-                "scm_size": self.scm_size.value, "group": self.name.value}
-            for key in ("target_list", "svcn", "nvme_size"):
-                value = getattr(self, key).value
-                if value is not None:
-                    kwargs[key] = value
-            self._call_method(self.pool.create, kwargs)
-        else:
-            if self.dmg is None:
-                raise DaosTestError(
-                    "self.dmg is None. dmg_command needs to be set through "
-                    "the constructor of TestPool to create pool with dmg.")
-            self.dmg.request.value = "pool"
-            # Currently, there is one test that creates the pool over the
-            # subset of the server hosts; pool/evict_test. To do so, the test
-            # needs to set the rank(s) to target_list.value starting from 0.
-            # e.g., if you're using 4 server hosts; wolf-1, wolf-2, wolf-3, and
-            # wolf-4, and want to create a pool over the first two hosts;
-            # wolf-1 and 2, then set the list [0, 1] to target_list.value.
-            # We'll convert it to the comma separated string and set it to dmg.
-            # For instance, [0, 1] will result in dmg pool create -r 0,1. If
-            # you don't set target_list.value, -r won't be used, in which case
-            # the pool is created over all the server hosts.
-            if self.target_list.value is None:
-                ranks_comma_separated = None
-            else:
-                ranks_comma_separated = ""
-                for i in range(len(self.target_list.value)):
-                    ranks_comma_separated += str(self.target_list.value[i])
-                    # If this element is not the last one, append comma
-                    if i < len(self.target_list.value) - 1:
-                        ranks_comma_separated += ","
-            # Call the dmg pool create command
-            self.dmg.action.value = "create"
-            self.dmg.get_action_command()
-            # uid/gid used in API correspond to --user and --group in dmg.
-            # group, or self.name.value, used in API is called server group and
-            # it's different from the group name passed in to --group. Server
-            # group isn't used in dmg. We don't pass it into the command, but
-            # we'll still use it to set self.pool.group
-            self.dmg.action_command.group.value = self.groupname.value
-            self.dmg.action_command.user.value = self.username.value
-            self.dmg.action_command.scm_size.value = self.scm_size.value
-            self.dmg.action_command.ranks.value = ranks_comma_separated
-            self.dmg.action_command.nsvc.value = self.svcn.value
-            create_result = self.dmg.run()
-            self.log.info("Result stdout = %s", create_result.stdout)
-            self.log.info("Result exit status = %s", create_result.exit_status)
-            # Get UUID and service replica from the output
-            uuid_svc = get_pool_uuid_service_replicas_from_stdout(
-                create_result.stdout)
-            new_uuid = uuid_svc[0]
-            service_replica = uuid_svc[1]
 
-            # 3. Create DaosPool object. The process is similar to the one in
-            # DaosPool.create, but there are some modifications
-            if self.name.value is None:
-                self.pool.group = None
-            else:
+        self.pool = DaosPool(self.context)
+        kwargs = {
+            "uid": self.uid,
+            "gid": self.gid,
+            "scm_size": self.scm_size.value,
+            "group": self.name.value}
+        for key in ("target_list", "svcn", "nvme_size"):
+            value = getattr(self, key).value
+            if value is not None:
+                kwargs[key] = value
+
+        if self.control_method.value == self.USE_API:
+            # Create a pool with the API method
+            kwargs["mode"] = self.mode.value
+            self._call_method(self.pool.create, kwargs)
+
+        elif self.control_method.value == self.USE_DMG and self.dmg:
+            # Create a pool with the dmg command
+            self._log_method("dmg.pool_create", kwargs)
+            result = self.dmg.pool_create(**kwargs)
+            uuid, svc = get_pool_uuid_service_replicas_from_stdout(
+                result.stdout)
+
+            # Populte the empty DaosPool object with the properties of the pool
+            # created with dmg pool create.
+            if self.name.value:
                 self.pool.group = ctypes.create_string_buffer(self.name.value)
-            # Modification 1: Use the length of service_replica returned by dmg
-            # to calculate rank_t. Note that we assume we always get a single
-            # number. I'm not sure if we ever get multiple numbers, but in that
-            # case, we need to modify this implementation to create a list out
-            # of the multiple numbers possibly separated by comma
-            service_replicas = [int(service_replica)]
+
+            # Convert the string of service replicas from the dmg command output
+            # into an ctype array for the DaosPool object using the same
+            # technique used in DaosPool.create().
+            service_replicas = [int(value) for value in svc.split(",")]
             rank_t = ctypes.c_uint * len(service_replicas)
-            # Modification 2: Use the service_replicas list to generate rank.
-            # In DaosPool, we first use some garbage 999999 values and let DAOS
-            # set the correct values, but we can't do that here, so we need to
-            # set the correct rank value by ourself
             rank = rank_t(*list([svc for svc in service_replicas]))
             rl_ranks = ctypes.POINTER(ctypes.c_uint)(rank)
-            # Modification 3: Similar to 1. Use the length of service_replicas
-            # list instead of self.svcn.value
             self.pool.svc = daos_cref.RankList(rl_ranks, len(service_replicas))
 
-            # 4. Set UUID and attached to the DaosPool object
-            self.pool.set_uuid_str(new_uuid)
+            # Set UUID and attached to the DaosPool object
+            self.pool.set_uuid_str(uuid)
             self.pool.attached = 1
 
+        elif self.control_method.value == self.USE_DMG:
+            self.log.error("Error: Undefined dmg command")
+
+        else:
+            self.log.error(
+                "Error: Undefined control_method: %s",
+                self.control_method.value)
+
+        # Set the TestPool attributes for the created pool
         self.svc_ranks = [
             int(self.pool.svc.rl_ranks[index])
             for index in range(self.pool.svc.rl_nr)]
@@ -270,28 +232,36 @@ class TestPool(TestDaosApiBase):
                 defined.
 
         """
+        status = False
         if self.pool:
             self.disconnect()
-            self.log.info("Destroying pool %s", self.uuid)
-            if self.control_method.value == self.USE_API:
-                if self.pool.attached:
+            if self.pool.attached:
+                self.log.info("Destroying pool %s", self.uuid)
+
+                if self.control_method.value == self.USE_API:
+                    # Destroy the pool with the API method
                     self._call_method(self.pool.destroy, {"force": force})
-            elif self.control_method.value == self.USE_DMG:
-                if self.pool.attached:
-                    self.dmg.action.value = "destroy"
-                    self.dmg.get_action_command()
-                    self.dmg.action_command.pool.value = self.uuid
-                    self.dmg.action_command.force.value = force
-                    self.dmg.run()
-            else:
-                self.log.error("Cannot destroy pool! Use USE_API or USE_DMG")
-                return False
+                    status = True
+
+                elif self.control_method.value == self.USE_DMG and self.dmg:
+                    # Destroy the pool with the dmg command
+                    self.dmg.pool_destroy(pool=self.uuid, force=force)
+                    status = True
+
+                elif self.control_method.value == self.USE_DMG:
+                    self.log.error("Error: Undefined dmg command")
+
+                else:
+                    self.log.error(
+                        "Error: Undefined control_method: %s",
+                        self.control_method.value)
+
             self.pool = None
             self.uuid = None
             self.info = None
             self.svc_ranks = None
-            return True
-        return False
+
+        return status
 
     @fail_on(DaosApiError)
     def get_info(self):


### PR DESCRIPTION
Extend daos_utils.py and dmg_utils.py command line options to include
the latest options to enable current and future functional tests.

Test-tag: pr,-hw sec_basic pool_acl multitarget

Signed-off-by: Phillip Henderson <phillip.henderson@intel.com>