### PR TITLE
DAOS-4391 vos: Fix issue with duplicate akeys in single update

### DIFF
--- a/src/vos/tests/vts_pm.c
+++ b/src/vos/tests/vts_pm.c
@@ -1245,6 +1245,16 @@ cond_test(void **state)
 			VOS_OF_COND_DKEY_INSERT | VOS_OF_USE_TIMESTAMPS,
 			0, sgl, 5, "a", "foo", "b", "bar", "c",
 			"foobar", "d", "value", "e", "abc");
+
+	oid = gen_oid(0);
+	/** Test duplicate akey */
+	cond_updaten_op(state, arg->ctx.tc_co_hdl, oid, 17, "a",
+			VOS_OF_USE_TIMESTAMPS, -DER_NO_PERM, sgl, 5, "c", "foo",
+			"c", "bar", "d", "val", "e", "flag", "f", "temp");
+	cond_updaten_op(state, arg->ctx.tc_co_hdl, oid, 17, "a",
+			VOS_OF_USE_TIMESTAMPS, -DER_NO_PERM, sgl, 5, "new",
+			"foo", "f", "bar", "d", "val", "e", "flag", "new",
+			"temp");
 }
 
 static const struct CMUnitTest punch_model_tests[] = {

--- a/src/vos/vos_ilog.c
+++ b/src/vos/vos_ilog.c
@@ -487,23 +487,28 @@ vos_ilog_ts_lookup(struct vos_ts_set *ts_set, struct ilog_df *ilog)
 	return vos_ts_lookup(ts_set, idx, false, &entry);
 }
 
-void
+int
 vos_ilog_ts_cache(struct vos_ts_set *ts_set, struct ilog_df *ilog,
 		  void *record, daos_size_t rec_size)
 {
+	struct vos_ts_entry	*entry;
 	uint32_t		*idx;
 	uint64_t		 hash;
 
 	if (ts_set == NULL)
-		return;
+		return 0;
 
 	hash = vos_hash_get(record, rec_size);
 	if (ilog) {
 		idx = ilog_ts_idx_get(ilog);
-		vos_ts_alloc(ts_set, idx, hash);
+		entry = vos_ts_alloc(ts_set, idx, hash);
+		if (entry == NULL)
+			return -DER_NO_PERM;
 	} else {
 		vos_ts_get_negative(ts_set, hash, false);
 	}
+
+	return 0;
 }
 
 void

--- a/src/vos/vos_ilog.h
+++ b/src/vos/vos_ilog.h
@@ -295,9 +295,9 @@ vos_ilog_ts_lookup(struct vos_ts_set *ts_set, struct ilog_df *ilog);
  *  \param	record[in]	The record to hash
  *  \param	rec_size[in]	The size of the record to hash
  *
- *  \return the existing or new entry
+ *  \return 0 on success or an error
  */
-void
+int
 vos_ilog_ts_cache(struct vos_ts_set *ts_set, struct ilog_df *ilog,
 		  void *record, daos_size_t rec_size);
 

--- a/src/vos/vos_obj_cache.c
+++ b/src/vos/vos_obj_cache.c
@@ -248,10 +248,15 @@ vos_obj_hold(struct daos_lru_cache *occ, struct vos_container *cont,
 	}
 
 	if (obj->obj_df) {
+		D_DEBUG(DB_TRACE, "looking up object ilog");
 		found = vos_ilog_ts_lookup(ts_set, &obj->obj_df->vo_ilog);
-		if (!found)
-			vos_ilog_ts_cache(ts_set, &obj->obj_df->vo_ilog,
-					  &oid, sizeof(oid));
+		if (!found) {
+			int	tmprc;
+
+			tmprc = vos_ilog_ts_cache(ts_set, &obj->obj_df->vo_ilog,
+						  &oid, sizeof(oid));
+			D_ASSERT(tmprc == 0); /* Non-zero only valid for akey */
+		}
 		goto check_object;
 	}
 

--- a/src/vos/vos_obj_index.c
+++ b/src/vos/vos_obj_index.c
@@ -195,6 +195,7 @@ vos_oi_find(struct vos_container *cont, daos_unit_oid_t oid,
 	d_iov_t			 key_iov;
 	d_iov_t			 val_iov;
 	int			 rc;
+	int			 tmprc;
 	bool			 found = false;
 
 	*obj_p = NULL;
@@ -215,7 +216,9 @@ vos_oi_find(struct vos_container *cont, daos_unit_oid_t oid,
 			goto out;
 	}
 
-	vos_ilog_ts_cache(ts_set, ilog, &oid, sizeof(oid));
+	tmprc = vos_ilog_ts_cache(ts_set, ilog, &oid, sizeof(oid));
+
+	D_ASSERT(tmprc == 0); /* Non-zero return for akey only */
 out:
 	return rc;
 }

--- a/src/vos/vos_tree.c
+++ b/src/vos/vos_tree.c
@@ -893,6 +893,7 @@ key_tree_prepare(struct vos_object *obj, daos_handle_t toh,
 	d_iov_t			 riov;
 	bool			 found;
 	int			 rc;
+	int			 tmprc;
 
 	/** reset the saved hash */
 	vos_kh_set(0);
@@ -936,7 +937,13 @@ key_tree_prepare(struct vos_object *obj, daos_handle_t toh,
 		/** Key hash already be calculated by dbtree_fetch so no need
 		 *  to pass in the key here.
 		 */
-		vos_ilog_ts_cache(ts_set, ilog, NULL, 0);
+		tmprc = vos_ilog_ts_cache(ts_set, ilog, NULL, 0);
+		if (tmprc != 0) {
+			rc = tmprc;
+			D_ASSERT(tmprc == -DER_NO_PERM);
+			D_ASSERT(tclass == VOS_BTR_AKEY);
+			goto out;
+		}
 		break;
 	}
 
@@ -952,7 +959,6 @@ key_tree_prepare(struct vos_object *obj, daos_handle_t toh,
 			goto out;
 		}
 		krec = rbund.rb_krec;
-
 		vos_ilog_ts_mark(ts_set, &krec->kr_ilog);
 	}
 


### PR DESCRIPTION
If an I/O does an update with same akey specified multiple times,
we were triggering an assertion in the new timestamp cache code.
Rather than trigger an assertion, return -DER_NO_PERM as this
has undefined behavior.

Signed-off-by: Jeff Olivier <jeffrey.v.olivier@intel.com>