### PR TITLE
DAOS-4246 pool: disable evict in swim upcall

### DIFF
--- a/src/pool/srv_pool.c
+++ b/src/pool/srv_pool.c
@@ -63,7 +63,7 @@ struct pool_svc {
 	struct ds_pool	       *ps_pool;
 };
 
-static bool pool_disable_evict = false;
+static bool pool_disable_evict = true; /* Disable evict for 0.9/1.0 */
 
 static struct pool_svc *
 pool_svc_obj(struct ds_rsvc *rsvc)

--- a/src/tests/suite/daos_rebuild.c
+++ b/src/tests/suite/daos_rebuild.c
@@ -57,7 +57,6 @@ rebuild_exclude_tgt(test_arg_t **args, int arg_cnt, d_rank_t rank,
 		 * targets on this rank.
 		 **/
 		D_ASSERT(tgt_idx == -1);
-		return;
 	}
 
 	for (i = 0; i < arg_cnt; i++) {


### PR DESCRIPTION
Let's disable disable evict in SWIM event upcall
temporarily.

Signed-off-by: Di Wang <di.wang@intel.com>