### PR TITLE
CART-872 swim: Provide ability to change SWIM parameters

### DIFF
--- a/src/cart/src/cart/crt_context.c
+++ b/src/cart/src/cart/crt_context.c
@@ -464,10 +464,10 @@ crt_context_destroy(crt_context_t crt_ctx, int force)
 			"d_hash_table_traverse failed rc: %d.\n",
 			ctx->cc_idx, force, rc);
 		/* Flush SWIM RPC already sent */
-		rc = crt_context_flush(crt_ctx, CRT_SWIM_RPC_TIMEOUT);
+		rc = crt_context_flush(crt_ctx, crt_swim_rpc_timeout);
 		if (rc)
 			/* give a chance to other threads to complete */
-			sleep(CRT_SWIM_RPC_TIMEOUT);
+			usleep(1000); /* 1ms */
 		D_MUTEX_LOCK(&ctx->cc_mutex);
 	}
 

--- a/src/cart/src/cart/crt_internal.h
+++ b/src/cart/src/cart/crt_internal.h
@@ -1,4 +1,4 @@
-/* Copyright (C) 2016-2019 Intel Corporation
+/* Copyright (C) 2016-2020 Intel Corporation
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -82,5 +82,7 @@
 			(rpc)->crp_pub.cr_ep.ep_tag,			\
 			## __VA_ARGS__);				\
 	} while (0)
+
+extern uint32_t crt_swim_rpc_timeout;
 
 #endif /* __CRT_INTERNAL_H__ */

--- a/src/cart/src/cart/crt_swim.c
+++ b/src/cart/src/cart/crt_swim.c
@@ -76,6 +76,17 @@ CRT_RPC_DEFINE(crt_rpc_swim,  CRT_ISEQ_RPC_SWIM, /* empty */)
 CRT_RPC_DECLARE(crt_rpc_swim_wack, CRT_ISEQ_RPC_SWIM, CRT_OSEQ_RPC_SWIM)
 CRT_RPC_DEFINE(crt_rpc_swim_wack,  CRT_ISEQ_RPC_SWIM, CRT_OSEQ_RPC_SWIM)
 
+uint32_t crt_swim_rpc_timeout;
+
+static inline uint32_t
+crt_swim_rpc_timeout_default(void)
+{
+	unsigned int val = CRT_SWIM_RPC_TIMEOUT;
+
+	d_getenv_int("CRT_SWIM_RPC_TIMEOUT", &val);
+	return val;
+}
+
 static void crt_swim_srv_cb(crt_rpc_t *rpc_req);
 
 static struct crt_proto_rpc_format crt_swim_proto_rpc_fmt[] = {
@@ -216,7 +227,7 @@ static int crt_swim_send_message(struct swim_context *ctx, swim_id_t to,
 	}
 
 	if (opc_idx == 0) { /* set timeout for one way RPC only */
-		rc = crt_req_set_timeout(rpc_req, CRT_SWIM_RPC_TIMEOUT);
+		rc = crt_req_set_timeout(rpc_req, crt_swim_rpc_timeout);
 		if (rc) {
 			D_TRACE_ERROR(rpc_req,
 				"crt_req_set_timeout() failed rc=%d\n", rc);
@@ -480,6 +491,8 @@ int crt_swim_init(int crt_ctx_idx)
 		}
 	}
 
+	crt_swim_rpc_timeout = crt_swim_rpc_timeout_default();
+
 	rc = crt_proto_register(&crt_swim_proto_fmt);
 	if (rc) {
 		D_ERROR("crt_proto_register() failed=%d\n", rc);
@@ -491,6 +504,7 @@ int crt_swim_init(int crt_ctx_idx)
 		D_ERROR("crt_register_progress_cb() failed=%d\n", rc);
 		D_GOTO(cleanup, rc);
 	}
+
 	D_GOTO(out, rc);
 
 cleanup:

--- a/src/cart/src/cart/crt_swim.h
+++ b/src/cart/src/cart/crt_swim.h
@@ -46,7 +46,7 @@
 #include "cart/swim.h"
 
 #define CRT_SWIM_RPC_TIMEOUT		1	/* 1 sec */
-#define CRT_SWIM_FLUSH_ATTEMPTS		10
+#define CRT_SWIM_FLUSH_ATTEMPTS		100
 #define CRT_SWIM_PROGRESS_TIMEOUT	0	/* minimal progressing time */
 #define CRT_DEFAULT_PROGRESS_CTX_IDX	0
 

--- a/src/cart/src/swim/swim_internal.h
+++ b/src/cart/src/swim/swim_internal.h
@@ -1,5 +1,5 @@
 /* Copyright (c) 2016 UChicago Argonne, LLC
- * Copyright (C) 2018-2019 Intel Corporation
+ * Copyright (C) 2018-2020 Intel Corporation
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -192,6 +192,54 @@ swim_state_set(struct swim_context *ctx, enum swim_context_state state)
 	if (ctx->sc_state != state)
 		ctx->sc_state = state;
 }
+
+/**
+ * Set the SWIM protocol period of pings in milliseconds.
+ *
+ * \note It should NOT be less than 3 * SWIM_PING_TIMEOUT
+ *
+ * \param[in] val	time in milliseconds
+ */
+void swim_period_set(uint64_t val);
+
+/**
+ * Get the current SWIM protocol period of pings in milliseconds.
+ *
+ * \return		time in milliseconds
+ */
+uint64_t swim_period_get(void);
+
+/**
+ * Set the "suspected" timeout in milliseconds. This is period of time
+ * are waiting for dping/iping response from other nodes. We assume the
+ * node is DEAD after this period of time.
+ *
+ * \param[in] val	timeout in milliseconds
+ */
+void swim_suspect_timeout_set(uint64_t val);
+
+/**
+ * Get the current "suspected" timeout in milliseconds.
+ *
+ * \return		timeout in milliseconds
+ */
+uint64_t swim_suspect_timeout_get(void);
+
+/**
+ * Set the direct ping (dping) timeout in milliseconds. This is period
+ * of time are waiting for dping response from other node. We try to
+ * indirectly ping a selected node after this period of time.
+ *
+ * \param[in] val	timeout in milliseconds
+ */
+void swim_ping_timeout_set(uint64_t val);
+
+/**
+ * Get the current "dping" timeout in milliseconds.
+ *
+ * \return		timeout in milliseconds
+ */
+uint64_t swim_ping_timeout_get(void);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
This patch allow to tune a SWIM algorithm by setting major SWIM
parameters in environment during runtime (without recompilation).