### PR TITLE
DAOS-4264 tests printout return error in daos_fio_cleanup()

### DIFF
--- a/src/tests/dfio/daos_fio.c
+++ b/src/tests/dfio/daos_fio.c
@@ -187,11 +187,20 @@ static void
 daos_fio_cleanup(struct thread_data *td)
 {
 	struct daos_data *dd = td->io_ops_data;
+	int rc;
 
-	dfs_umount(dd->dfs);
-	daos_cont_close(dd->coh, NULL);
-	daos_pool_disconnect(dd->poh, NULL);
-	daos_fini();
+	rc = dfs_umount(dd->dfs);
+	if (rc)
+		D_ERROR("failed to umount dfs: rc = %d\n", rc);
+	rc = daos_cont_close(dd->coh, NULL);
+	if (rc)
+		D_ERROR("failed to close container: "DF_RC"\n", DP_RC(rc));
+	rc = daos_pool_disconnect(dd->poh, NULL);
+	if (rc)
+		D_ERROR("failed to disconnect pool: "DF_RC"\n", DP_RC(rc));
+	rc = daos_fini();
+	if (rc)
+		D_ERROR("failed to finalize daos: "DF_RC"\n", DP_RC(rc));
 
 	free(dd->io_us);
 	free(dd);


### PR DESCRIPTION
While daos_fio_cleanup() doesn't return rc to upper stack, print out
errors in this function.

Change-Id: Ice1330a15d0e43a1eec46a62af7d7dfb8a5dca30
Signed-off-by: Hua Kuang <hua.kuang@intel.com>