### PR TITLE
DAOS-4411 test: Move fio_small to weekly runs

### DIFF
--- a/src/tests/ftest/io/fio_small.py
+++ b/src/tests/ftest/io/fio_small.py
@@ -51,6 +51,6 @@ class FioSmall(FioBase):
             read_write: rw|randrw
             numjobs: 1
 
-        :avocado: tags=all,pr,hw,medium,ib2,fio,fiosmall
+        :avocado: tags=all,hw,medium,ib2,fio,fiosmall,full_regression
         """
         self.execute_fio()


### PR DESCRIPTION
Moving fio_small test from PR runs to weekly runs
temporarily until below mentioned issue is resolved.
https://jira.hpdd.intel.com/browse/DAOS-4295

Signed-off-by: Saurabh Tandan <saurabh.tandan@intel.com>