### PR TITLE
DAOS-4416 client: rollback tse_task_private

### DIFF
--- a/src/common/tse_internal.h
+++ b/src/common/tse_internal.h
@@ -34,7 +34,7 @@
  */
 
 /* NB: tse_task_private is TSE_PRIV_SIZE = 1016 bytes for now */
-#define TSE_TASK_ARG_LEN		880
+#define TSE_TASK_ARG_LEN		888
 
 struct tse_task_private {
 	struct tse_sched_private	*dtp_sched;


### PR DESCRIPTION
Update TSE_TASK_ARG_LEN to 888, so rollback
tse_task_private size to 1016 to make sure
update object req can be pushed to the task
stack.

Signed-off-by: Di Wang <di.wang@intel.com>