### PR TITLE
DAOS-4295: test: Restructuring cont_create for base classes

### DIFF
--- a/src/tests/ftest/io/fio_small.py
+++ b/src/tests/ftest/io/fio_small.py
@@ -51,6 +51,6 @@ class FioSmall(FioBase):
             read_write: rw|randrw
             numjobs: 1
 
-        :avocado: tags=all,hw,medium,ib2,fio,fiosmall,full_regression
+        :avocado: tags=all,pr,hw,medium,ib2,fio,fiosmall
         """
         self.execute_fio()

--- a/src/tests/ftest/io/fio_small.yaml
+++ b/src/tests/ftest/io/fio_small.yaml
@@ -38,6 +38,8 @@ pool:
   nvme_size: 20000000000
   svcn: 1
   control_method: dmg
+container:
+  type: POSIX
 fio:
   names:
     - global

--- a/src/tests/ftest/io/mdtest_small.yaml
+++ b/src/tests/ftest/io/mdtest_small.yaml
@@ -16,6 +16,8 @@ pool:
   scm_size: 6000000000
   svcn: 1
   control_method: dmg
+container:
+  type: POSIX
 mdtest:
   client_processes:
     np_8:

--- a/src/tests/ftest/util/fio_test_base.py
+++ b/src/tests/ftest/util/fio_test_base.py
@@ -53,6 +53,7 @@ class FioBase(TestWithServers):
 
     def setUp(self):
         """Set up each test case."""
+        # obtain separate logs
         self.update_log_file_names()
 
         # Start the servers and agents

--- a/src/tests/ftest/util/fio_test_base.py
+++ b/src/tests/ftest/util/fio_test_base.py
@@ -53,8 +53,6 @@ class FioBase(TestWithServers):
 
     def setUp(self):
         """Set up each test case."""
-
-        # obtain separate logs
         self.update_log_file_names()
 
         # Start the servers and agents

--- a/src/tests/ftest/util/fio_test_base.py
+++ b/src/tests/ftest/util/fio_test_base.py
@@ -24,6 +24,8 @@
 from __future__ import print_function
 
 import subprocess
+import os
+import re
 
 from ClusterShell.NodeSet import NodeSet
 from apricot import TestWithServers, get_log_file
@@ -31,6 +33,7 @@ from test_utils_pool import TestPool
 from fio_utils import FioCommand
 from command_utils import CommandFailure
 from dfuse_utils import Dfuse
+from daos_utils import DaosCommand
 
 
 class FioBase(TestWithServers):
@@ -46,11 +49,19 @@ class FioBase(TestWithServers):
         self.processes = None
         self.manager = None
         self.dfuse = None
+        self.daos_cmd = None
 
     def setUp(self):
         """Set up each test case."""
+
         # obtain separate logs
         self.update_log_file_names()
+
+        # Start the servers and agents
+        super(FioBase, self).setUp()
+
+        # initialise daos_cmd
+        self.daos_cmd = DaosCommand(self.bin)
 
         # Start the servers and agents
         super(FioBase, self).setUp()
@@ -79,31 +90,30 @@ class FioBase(TestWithServers):
         # Create a pool
         self.pool.create()
 
-    def _create_cont(self):
-        """Create a TestContainer object to be used to create container."""
-        # TO-DO: Enable container using TestContainer object,
-        # once DAOS-3355 is resolved.
-        # Get Container params
-        # self.container = TestContainer(self.pool)
-        # self.container.get_params(self)
+    def _create_cont(self, doas_cmd):
+        """Create a container.
 
-        # create container
-        # self.container.create()
-        env = Dfuse(self.hostlist_clients, self.tmp).get_default_env()
-        # command to create container of posix type
-        cmd = env + "daos cont create --pool={} --svc={} --type=POSIX".format(
-            self.pool.uuid, ":".join(
-                [str(item) for item in self.pool.svc_ranks]))
-        try:
-            container = subprocess.Popen(cmd, stdout=subprocess.PIPE,
-                                         shell=True)
-            (output, err) = container.communicate()
-            self.log.info("Container created with UUID %s", output.split()[3])
+        Args:
+            daos_cmd (DaosCommand): doas command to issue the container
+                create
 
-        except subprocess.CalledProcessError as err:
-            self.fail("Container create failed:{}".format(err))
+        Returns:
+            str: UUID of the created container
 
-        return output.split()[3]
+        """
+        cont_type = self.params.get("type", "/run/container/*")
+        result = self.daos_cmd.container_create(
+            pool=self.pool.uuid, svc=self.pool.svc_ranks,
+            cont_type=cont_type)
+
+        # Extract the container UUID from the daos container create output
+        cont_uuid = re.findall(
+            "created\s+container\s+([0-9a-f-]+)", result.stdout)
+        if not cont_uuid:
+            self.fail(
+                "Error obtaining the container uuid from: {}".format(
+                    result.stdout))
+        return cont_uuid[0]
 
     def _start_dfuse(self):
         """Create a DfuseCommand object to start dfuse."""
@@ -115,7 +125,7 @@ class FioBase(TestWithServers):
 
         # update dfuse params
         self.dfuse.set_dfuse_params(self.pool)
-        self.dfuse.set_dfuse_cont_param(self._create_cont())
+        self.dfuse.set_dfuse_cont_param(self._create_cont(self.daos_cmd))
 
         try:
             # start dfuse

--- a/src/tests/ftest/util/fio_test_base.py
+++ b/src/tests/ftest/util/fio_test_base.py
@@ -63,9 +63,6 @@ class FioBase(TestWithServers):
         # initialise daos_cmd
         self.daos_cmd = DaosCommand(self.bin)
 
-        # Start the servers and agents
-        super(FioBase, self).setUp()
-
         # Get the parameters for Fio
         self.fio_cmd = FioCommand()
         self.fio_cmd.get_params(self)


### PR DESCRIPTION
Re-structuring cont_create() for base classes
of mdtest and fio to use DaosCommand class
implemented in daos_utils.py

Also moving fio_small back to PR run from
weekly run.

Signed-off-by: Saurabh Tandan <saurabh.tandan@intel.com>