### PR TITLE
DAOS-4280 test: skip RPC retry is server out of space (debug)

### DIFF
--- a/src/object/srv_obj.c
+++ b/src/object/srv_obj.c
@@ -2230,7 +2230,7 @@ ds_obj_sync_handler(crt_rpc_t *rpc)
 	else
 		oso->oso_epoch = min(epoch, osi->osi_epoch);
 
-	D_DEBUG(DB_IO, "start: "DF_UOID", epc "DF_U64"\n",
+	D_DEBUG(DB_IO, "obj_sync start: "DF_UOID", epc "DF_U64"\n",
 		DP_UOID(osi->osi_oid), oso->oso_epoch);
 
 	rc = obj_ioc_begin(osi->osi_oid, osi->osi_map_ver,
@@ -2247,7 +2247,7 @@ out:
 	obj_reply_set_status(rpc, rc);
 	obj_ioc_end(&ioc, rc);
 
-	D_DEBUG(DB_IO, "stop: "DF_UOID", epc "DF_U64", rd = %d\n",
+	D_DEBUG(DB_IO, "obj_sync stop: "DF_UOID", epc "DF_U64", rd = %d\n",
 		DP_UOID(osi->osi_oid), oso->oso_epoch, rc);
 
 	rc = crt_reply_send(rpc);

--- a/src/tests/ftest/io/daos_racer.yaml
+++ b/src/tests/ftest/io/daos_racer.yaml
@@ -18,4 +18,4 @@ server_config:
         scm_list: ["/dev/pmem0"]
 daos_racer:
   runtime: 600
-  clush_timeout: 1500
+  clush_timeout: 900

--- a/src/vos/tests/vts_pm.c
+++ b/src/vos/tests/vts_pm.c
@@ -1245,6 +1245,16 @@ cond_test(void **state)
 			VOS_OF_COND_DKEY_INSERT | VOS_OF_USE_TIMESTAMPS,
 			0, sgl, 5, "a", "foo", "b", "bar", "c",
 			"foobar", "d", "value", "e", "abc");
+
+	oid = gen_oid(0);
+	/** Test duplicate akey */
+	cond_updaten_op(state, arg->ctx.tc_co_hdl, oid, 17, "a",
+			VOS_OF_USE_TIMESTAMPS, -DER_NO_PERM, sgl, 5, "c", "foo",
+			"c", "bar", "d", "val", "e", "flag", "f", "temp");
+	cond_updaten_op(state, arg->ctx.tc_co_hdl, oid, 17, "a",
+			VOS_OF_USE_TIMESTAMPS, -DER_NO_PERM, sgl, 5, "new",
+			"foo", "f", "bar", "d", "val", "e", "flag", "new",
+			"temp");
 }
 
 static const struct CMUnitTest punch_model_tests[] = {

--- a/src/vos/vos_ilog.c
+++ b/src/vos/vos_ilog.c
@@ -487,23 +487,28 @@ vos_ilog_ts_lookup(struct vos_ts_set *ts_set, struct ilog_df *ilog)
 	return vos_ts_lookup(ts_set, idx, false, &entry);
 }
 
-void
+int
 vos_ilog_ts_cache(struct vos_ts_set *ts_set, struct ilog_df *ilog,
 		  void *record, daos_size_t rec_size)
 {
+	struct vos_ts_entry	*entry;
 	uint32_t		*idx;
 	uint64_t		 hash;
 
 	if (ts_set == NULL)
-		return;
+		return 0;
 
 	hash = vos_hash_get(record, rec_size);
 	if (ilog) {
 		idx = ilog_ts_idx_get(ilog);
-		vos_ts_alloc(ts_set, idx, hash);
+		entry = vos_ts_alloc(ts_set, idx, hash);
+		if (entry == NULL)
+			return -DER_NO_PERM;
 	} else {
 		vos_ts_get_negative(ts_set, hash, false);
 	}
+
+	return 0;
 }
 
 void

--- a/src/vos/vos_ilog.h
+++ b/src/vos/vos_ilog.h
@@ -295,9 +295,9 @@ vos_ilog_ts_lookup(struct vos_ts_set *ts_set, struct ilog_df *ilog);
  *  \param	record[in]	The record to hash
  *  \param	rec_size[in]	The size of the record to hash
  *
- *  \return the existing or new entry
+ *  \return 0 on success or an error
  */
-void
+int
 vos_ilog_ts_cache(struct vos_ts_set *ts_set, struct ilog_df *ilog,
 		  void *record, daos_size_t rec_size);
 

--- a/src/vos/vos_obj_cache.c
+++ b/src/vos/vos_obj_cache.c
@@ -248,10 +248,15 @@ vos_obj_hold(struct daos_lru_cache *occ, struct vos_container *cont,
 	}
 
 	if (obj->obj_df) {
+		D_DEBUG(DB_TRACE, "looking up object ilog");
 		found = vos_ilog_ts_lookup(ts_set, &obj->obj_df->vo_ilog);
-		if (!found)
-			vos_ilog_ts_cache(ts_set, &obj->obj_df->vo_ilog,
-					  &oid, sizeof(oid));
+		if (!found) {
+			int	tmprc;
+
+			tmprc = vos_ilog_ts_cache(ts_set, &obj->obj_df->vo_ilog,
+						  &oid, sizeof(oid));
+			D_ASSERT(tmprc == 0); /* Non-zero only valid for akey */
+		}
 		goto check_object;
 	}
 

--- a/src/vos/vos_obj_index.c
+++ b/src/vos/vos_obj_index.c
@@ -195,6 +195,7 @@ vos_oi_find(struct vos_container *cont, daos_unit_oid_t oid,
 	d_iov_t			 key_iov;
 	d_iov_t			 val_iov;
 	int			 rc;
+	int			 tmprc;
 	bool			 found = false;
 
 	*obj_p = NULL;
@@ -215,7 +216,9 @@ vos_oi_find(struct vos_container *cont, daos_unit_oid_t oid,
 			goto out;
 	}
 
-	vos_ilog_ts_cache(ts_set, ilog, &oid, sizeof(oid));
+	tmprc = vos_ilog_ts_cache(ts_set, ilog, &oid, sizeof(oid));
+
+	D_ASSERT(tmprc == 0); /* Non-zero return for akey only */
 out:
 	return rc;
 }

--- a/src/vos/vos_tree.c
+++ b/src/vos/vos_tree.c
@@ -893,6 +893,7 @@ key_tree_prepare(struct vos_object *obj, daos_handle_t toh,
 	d_iov_t			 riov;
 	bool			 found;
 	int			 rc;
+	int			 tmprc;
 
 	/** reset the saved hash */
 	vos_kh_set(0);
@@ -936,7 +937,13 @@ key_tree_prepare(struct vos_object *obj, daos_handle_t toh,
 		/** Key hash already be calculated by dbtree_fetch so no need
 		 *  to pass in the key here.
 		 */
-		vos_ilog_ts_cache(ts_set, ilog, NULL, 0);
+		tmprc = vos_ilog_ts_cache(ts_set, ilog, NULL, 0);
+		if (tmprc != 0) {
+			rc = tmprc;
+			D_ASSERT(tmprc == -DER_NO_PERM);
+			D_ASSERT(tclass == VOS_BTR_AKEY);
+			goto out;
+		}
 		break;
 	}
 
@@ -952,7 +959,6 @@ key_tree_prepare(struct vos_object *obj, daos_handle_t toh,
 			goto out;
 		}
 		krec = rbund.rb_krec;
-
 		vos_ilog_ts_mark(ts_set, &krec->kr_ilog);
 	}
 


### PR DESCRIPTION
Including the fixes from DAOS-4391 with the following commit:
6eb31c20a474bb26ceb6141a54515b75d8d6f434.

Signed-off-by: Fan Yong <fan.yong@intel.com>