### PR TITLE
DAOS-4280 test: skip consistency verification after racer if out of space (debug)

### DIFF
--- a/src/dtx/dtx_common.c
+++ b/src/dtx/dtx_common.c
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2019 Intel Corporation.
+ * (C) Copyright 2019-2020 Intel Corporation.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -96,7 +96,7 @@ dtx_flush_on_deregister(struct dss_module_info *dmi,
 {
 	struct ds_cont_child	*cont = dbca->dbca_cont;
 	struct ds_pool_child	*pool = cont->sc_pool;
-	ABT_future		 future = dbca->dbca_deregistering;
+	struct dtx_id		 saved_dtx = { 0 };
 	int			 rc;
 
 	D_ASSERT(dbca->dbca_deregistering != NULL);
@@ -109,6 +109,15 @@ dtx_flush_on_deregister(struct dss_module_info *dmi,
 		if (rc <= 0)
 			break;
 
+		if (daos_dti_equal(&saved_dtx, &dtes[0].dte_xid)) {
+			dtx_free_committable(dtes);
+			D_ERROR("dtx_flush fall into loop, "DF_DTI"\n",
+				DP_DTI(&saved_dtx));
+			rc = -DER_NOSPACE;
+			break;
+		}
+
+		daos_dti_copy(&saved_dtx, &dtes[0].dte_xid);
 		rc = dtx_commit(pool->spc_uuid, cont->sc_uuid,
 				dtes, rc, pool->spc_map_version);
 		dtx_free_committable(dtes);
@@ -123,7 +132,7 @@ dtx_flush_on_deregister(struct dss_module_info *dmi,
 	 * flush done, then free the dbca.
 	 */
 	d_list_del_init(&dbca->dbca_link);
-	rc = ABT_future_set(future, NULL);
+	rc = ABT_future_set(dbca->dbca_deregistering, NULL);
 	D_ASSERTF(rc == ABT_SUCCESS, "ABT_future_set failed for DTX "
 		  "flush on "DF_UUID": rc = %d\n", DP_UUID(cont->sc_uuid), rc);
 }
@@ -583,7 +592,7 @@ dtx_leader_end(struct dtx_leader_handle *dlh, struct ds_cont_child *cont,
 		dth->dth_renew = 1;
 	}
 
-	if (result < 0 || rc < 0)
+	if (result < 0 || rc < 0 || !dth->dth_actived)
 		D_GOTO(out, result = result < 0 ? result : rc);
 
 	if (dth->dth_intent == DAOS_INTENT_PUNCH)
@@ -997,7 +1006,8 @@ int
 dtx_obj_sync(uuid_t po_uuid, uuid_t co_uuid, daos_handle_t coh,
 	     daos_unit_oid_t oid, daos_epoch_t epoch, uint32_t map_ver)
 {
-	int	rc = 0;
+	struct dtx_id	saved_dtx = { 0 };
+	int		rc = 0;
 
 	while (1) {
 		struct dtx_entry	*dtes = NULL;
@@ -1013,6 +1023,14 @@ dtx_obj_sync(uuid_t po_uuid, uuid_t co_uuid, daos_handle_t coh,
 		if (rc == 0)
 			break;
 
+		if (daos_dti_equal(&saved_dtx, &dtes[0].dte_xid)) {
+			D_ERROR("obj_sync "DF_UOID" fall into loop, "DF_DTI"\n",
+				DP_UOID(oid), DP_DTI(&saved_dtx));
+			dtx_free_committable(dtes);
+			return -DER_NOSPACE;
+		}
+
+		daos_dti_copy(&saved_dtx, &dtes[0].dte_xid);
 		rc = dtx_commit(po_uuid, co_uuid, dtes, rc, map_ver);
 		dtx_free_committable(dtes);
 		if (rc < 0) {

--- a/src/dtx/dtx_rpc.c
+++ b/src/dtx/dtx_rpc.c
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2019 Intel Corporation.
+ * (C) Copyright 2019-2020 Intel Corporation.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -241,18 +241,18 @@ dtx_req_list_cb(void **args)
 	} else {
 		for (i = 0; i < dra->dra_length; i++) {
 			drr = args[i];
-			if (dra->dra_result == 0)
+			if ((drr->drr_result < 0) &&
+			    (dra->dra_result == 0 ||
+			     dra->dra_result == -DER_NONEXIST))
 				dra->dra_result = drr->drr_result;
-
-			if (dra->dra_result != 0) {
-				D_ERROR("DTX req for opc %x failed: rc = %d.\n",
-					dra->dra_opc, dra->dra_result);
-				return;
-			}
 		}
 
-		D_DEBUG(DB_TRACE, "DTX req for opc %x succeed.\n",
-			dra->dra_opc);
+		drr = args[0];
+		D_CDEBUG(dra->dra_result < 0, DLOG_ERR, DB_TRACE,
+			 "DTX req for opc %x ("DF_DTI") %s, count %d: %d.\n",
+			 dra->dra_opc, DP_DTI(drr->drr_dti),
+			 dra->dra_result < 0 ? "failed" : "succeed",
+			 dra->dra_length, dra->dra_result);
 	}
 }
 
@@ -611,13 +611,20 @@ dtx_commit(uuid_t po_uuid, uuid_t co_uuid, struct dtx_entry *dtes,
 	}
 
 	rc1 = vos_dtx_commit(cont->sc_hdl, dti, count);
+	/* -DER_NONEXIST may be caused by race or repeated commit, ignore it. */
+	if (rc1 == -DER_NONEXIST)
+		rc1 = 0;
 
-	if (dra.dra_future != ABT_FUTURE_NULL)
+	if (dra.dra_future != ABT_FUTURE_NULL) {
 		rc2 = dtx_req_wait(&dra);
+		if (rc2 == -DER_NONEXIST)
+			rc2 = 0;
+	}
 
 out:
-	D_DEBUG(DB_TRACE, "Commit DTXs "DF_DTI", count %d: rc %d %d %d\n",
-		DP_DTI(&dtes[0].dte_xid), count, rc, rc1, rc2);
+	D_CDEBUG(rc != 0 || rc1 != 0 || rc2 != 0, DLOG_ERR, DB_TRACE,
+		 "Commit DTXs "DF_DTI", count %d: rc %d %d %d\n",
+		 DP_DTI(&dtes[0].dte_xid), count, rc, rc1, rc2);
 
 	if (dti != NULL)
 		D_FREE(dti);
@@ -630,7 +637,7 @@ out:
 	if (cont != NULL)
 		ds_cont_child_put(cont);
 
-	return rc > 0 ? 0 : rc;
+	return rc < 0 ? rc : (rc1 < 0 ? rc1 : (rc2 < 0 ? rc2 : 0));
 }
 
 int
@@ -680,12 +687,16 @@ dtx_abort(uuid_t po_uuid, uuid_t co_uuid, daos_epoch_t epoch,
 	if (rc1 == -DER_NONEXIST)
 		rc1 = 0;
 
-	if (dra.dra_future != ABT_FUTURE_NULL)
+	if (dra.dra_future != ABT_FUTURE_NULL) {
 		rc2 = dtx_req_wait(&dra);
+		if (rc2 == -DER_NONEXIST)
+			rc2 = 0;
+	}
 
 out:
-	D_DEBUG(DB_TRACE, "Abort DTXs "DF_DTI", count %d: rc %d %d %d\n",
-		DP_DTI(&dtes[0].dte_xid), count, rc, rc1, rc2);
+	D_CDEBUG(rc != 0 || rc1 != 0 || rc2 != 0, DLOG_ERR, DB_TRACE,
+		 "Abort DTXs "DF_DTI", count %d: rc %d %d %d\n",
+		 DP_DTI(&dtes[0].dte_xid), count, rc, rc1, rc2);
 
 	if (dti != NULL)
 		D_FREE(dti);
@@ -698,7 +709,7 @@ out:
 	if (cont != NULL)
 		ds_cont_child_put(cont);
 
-	return rc > 0 ? 0 : rc;
+	return rc < 0 ? rc : (rc1 < 0 ? rc1 : (rc2 < 0 ? rc2 : 0));
 }
 
 int

--- a/src/object/cli_obj.c
+++ b/src/object/cli_obj.c
@@ -81,6 +81,7 @@ struct obj_auxi_args {
 					 to_leader:1,
 					 spec_shard:1,
 					 req_reasbed:1,
+					 check_pm_ver:1,
 					 csum_retry:1;
 	/* request flags, now only with ORF_RESEND */
 	uint32_t			 flags;
@@ -2303,6 +2304,9 @@ obj_comp_cb(tse_task_t *task, void *data)
 		}
 		if (!obj_auxi->spec_shard && task->dt_result == -DER_INPROGRESS)
 			obj_auxi->to_leader = 1;
+
+		if (task->dt_result == -DER_EVICTED)
+			obj_auxi->check_pm_ver = 1;
 	}
 
 	if (pm_stale || obj_auxi->io_retry)
@@ -2351,9 +2355,23 @@ obj_reg_comp_cb(tse_task_t *task, int opc, uint32_t map_ver,
 	struct obj_auxi_args	*obj_auxi;
 
 	obj_auxi = tse_task_stack_push(task, sizeof(*obj_auxi));
+
+	/* XXX: It is used for RPC retry case: if I was told that the pool
+	 *	map version has been updated, but I still use the old pool
+	 *	map to retry the RPC, then either the client failed to fetch
+	 *	the pool map from server or the server is out of space as to
+	 *	the pool map cannot be refreshed properly. For the 1st case,
+	 *	related RPC will not be retried, so it is the 2nd case.
+	 */
+	if (obj_auxi->check_pm_ver && obj_auxi->map_ver_req == map_ver) {
+		D_ERROR("Fail to refresh pm version because of out of space\n");
+		return -DER_NOSPACE;
+	}
+
 	obj_auxi->opc = opc;
 	obj_auxi->map_ver_req = map_ver;
 	obj_auxi->obj_task = task;
+	obj_auxi->check_pm_ver = 0;
 	shard_task_list_init(obj_auxi);
 	*auxi = obj_auxi;
 	return tse_task_register_comp_cb(task, obj_comp_cb, cb_arg, arg_sz);

--- a/src/object/srv_obj.c
+++ b/src/object/srv_obj.c
@@ -2128,7 +2128,7 @@ ds_obj_sync_handler(crt_rpc_t *rpc)
 	else
 		oso->oso_epoch = min(epoch, osi->osi_epoch);
 
-	D_DEBUG(DB_IO, "start: "DF_UOID", epc "DF_U64"\n",
+	D_DEBUG(DB_IO, "obj_sync start: "DF_UOID", epc "DF_U64"\n",
 		DP_UOID(osi->osi_oid), oso->oso_epoch);
 
 	rc = obj_ioc_begin(osi->osi_oid, osi->osi_map_ver,
@@ -2145,7 +2145,7 @@ out:
 	obj_reply_set_status(rpc, rc);
 	obj_ioc_end(&ioc, rc);
 
-	D_DEBUG(DB_IO, "stop: "DF_UOID", epc "DF_U64", rd = %d\n",
+	D_DEBUG(DB_IO, "obj_sync stop: "DF_UOID", epc "DF_U64", rd = %d\n",
 		DP_UOID(osi->osi_oid), oso->oso_epoch, rc);
 
 	rc = crt_reply_send(rpc);

--- a/src/tests/daos_racer.c
+++ b/src/tests/daos_racer.c
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2019 Intel Corporation.
+ * (C) Copyright 2019-2020 Intel Corporation.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -525,6 +525,22 @@ main(int argc, char **argv)
 			if (rc == -DER_NONEXIST) {
 				rc = 0;
 				continue;
+			}
+
+			if (rc == -DER_NOSPACE) {
+				/* XXX: There is not enough space to sync the
+				 *	object, that may cause some committable
+				 *	DTX entries cannot be committed on some
+				 *	replica(s), then subsequent fetch from
+				 *	related replica(s) for verification
+				 *	against those DTX entries will not get
+				 *	the right data as to the verification
+				 *	logic may report fake inconsistency.
+				 *
+				 *	So let's stop the verification.
+				 */
+				rc = 0;
+				break;
 			}
 
 			if (rc == -DER_MISMATCH) {

--- a/src/tests/ftest/io/daos_racer.yaml
+++ b/src/tests/ftest/io/daos_racer.yaml
@@ -8,7 +8,7 @@ hosts:
     - server-F
   test_clients:
     - client-G
-timeout: 1800
+timeout: 1200
 server_config:
     name: daos_server
     servers:
@@ -18,4 +18,4 @@ server_config:
         scm_list: ["/dev/pmem0"]
 daos_racer:
   runtime: 600
-  clush_timeout: 1500
+  clush_timeout: 900

--- a/src/vos/vos_dtx.c
+++ b/src/vos/vos_dtx.c
@@ -63,18 +63,18 @@ static inline int
 dtx_inprogress(struct dtx_handle *dth, struct vos_dtx_act_ent *dae, int pos)
 {
 	if (dae != NULL) {
-		D_DEBUG(DB_TRACE, "Hit uncommitted DTX "DF_DTI" at %d\n",
+		D_DEBUG(DB_IO, "Hit uncommitted DTX "DF_DTI" at %d\n",
 			DP_DTI(&DAE_XID(dae)), pos);
 
 		if (dth != NULL && dth->dth_conflict != NULL) {
-			D_DEBUG(DB_TRACE, "Record conflict DTX "DF_DTI"\n",
+			D_DEBUG(DB_IO, "Record conflict DTX "DF_DTI"\n",
 				DP_DTI(&DAE_XID(dae)));
 			daos_dti_copy(&dth->dth_conflict->dce_xid,
 				      &DAE_XID(dae));
 			dth->dth_conflict->dce_dkey = DAE_DKEY_HASH(dae);
 		}
 	} else {
-		D_DEBUG(DB_TRACE, "Hit uncommitted (unknown) DTX at %d\n", pos);
+		D_DEBUG(DB_IO, "Hit uncommitted (unknown) DTX at %d\n", pos);
 	}
 
 	return -DER_INPROGRESS;
@@ -539,8 +539,10 @@ vos_dtx_commit_one(struct vos_container *cont, struct dtx_id *dti,
 		goto out;
 
 	dtx_rec_release(cont, dae, false, &offset);
-	vos_dtx_del_cos(cont, &DAE_OID(dae), dti, DAE_DKEY_HASH(dae),
+	rc = vos_dtx_del_cos(cont, &DAE_OID(dae), dti, DAE_DKEY_HASH(dae),
 			DAE_INTENT(dae) == DAOS_INTENT_PUNCH ? true : false);
+	if (rc != 0)
+		D_GOTO(out, rc);
 
 	/* If dbtree_delete() failed, the @dae will be left in the active DTX
 	 * table until close the container. It is harmless but waste some DRAM.
@@ -551,8 +553,9 @@ vos_dtx_commit_one(struct vos_container *cont, struct dtx_id *dti,
 		umem_free(vos_cont2umm(cont), offset);
 
 out:
-	D_DEBUG(DB_TRACE, "Commit the DTX "DF_DTI": rc = "DF_RC"\n",
-		DP_DTI(dti), DP_RC(rc));
+	D_CDEBUG(rc != 0 && rc != DER_NONEXIST, DLOG_ERR, DB_IO,
+		 "Commit the DTX "DF_DTI": rc = "DF_RC"\n",
+		 DP_DTI(dti), DP_RC(rc));
 	if (rc != 0) {
 		if (dce != NULL)
 			D_FREE_PTR(dce);
@@ -590,7 +593,7 @@ vos_dtx_abort_one(struct vos_container *cont, daos_epoch_t epoch,
 		dtx_rec_release(cont, dae, true, NULL);
 
 out:
-	D_DEBUG(DB_TRACE, "Abort the DTX "DF_DTI": rc = "DF_RC"\n", DP_DTI(dti),
+	D_DEBUG(DB_IO, "Abort the DTX "DF_DTI": rc = "DF_RC"\n", DP_DTI(dti),
 		DP_RC(rc));
 
 	return rc;
@@ -952,7 +955,7 @@ vos_dtx_register_record(struct umem_instance *umm, umem_off_t record,
 			dth->dth_has_ilog = 1;
 	}
 
-	D_DEBUG(DB_TRACE, "Register DTX record for "DF_DTI
+	D_DEBUG(DB_IO, "Register DTX record for "DF_DTI
 		": entry %p, type %d, %s ilog entry, rc %d\n",
 		DP_DTI(&dth->dth_xid), dth->dth_ent, type,
 		dth->dth_has_ilog ? "has" : "has not", rc);
@@ -1250,12 +1253,15 @@ again:
 		dce_df = &dbd->dbd_commmitted_data[dbd->dbd_count];
 	}
 
-	for (i = 0, j = 0; i < slots; i++, cur++) {
+	for (i = 0, j = 0; i < slots && rc1 == 0; i++, cur++) {
 		struct vos_dtx_cmt_ent	*dce = NULL;
 
 		rc = vos_dtx_commit_one(cont, &dtis[cur], epoch, &dce);
 		if (rc == 0 && dce != NULL)
 			committed++;
+
+		if (rc == -DER_NONEXIST)
+			rc = 0;
 
 		if (rc1 == 0)
 			rc1 = rc;
@@ -1282,7 +1288,7 @@ again:
 	if (j > 0)
 		dbd->dbd_count += j;
 
-	if (count == 0)
+	if (count == 0 || rc1 != 0)
 		return committed > 0 ? 0 : rc1;
 
 	if (j < slots) {
@@ -1342,12 +1348,15 @@ new_blob:
 
 	cont_df->cd_dtx_committed_tail = dbd_off;
 
-	for (i = 0, j = 0; i < count; i++, cur++) {
+	for (i = 0, j = 0; i < count && rc1 == 0; i++, cur++) {
 		struct vos_dtx_cmt_ent	*dce = NULL;
 
 		rc = vos_dtx_commit_one(cont, &dtis[cur], epoch, &dce);
 		if (rc == 0 && dce != NULL)
 			committed++;
+
+		if (rc == -DER_NONEXIST)
+			rc = 0;
 
 		if (rc1 == 0)
 			rc1 = rc;

--- a/src/vos/vos_dtx_cos.c
+++ b/src/vos/vos_dtx_cos.c
@@ -439,7 +439,7 @@ add:
 	rc = dbtree_upsert(cont->vc_dtx_cos_hdl, BTR_PROBE_EQ,
 			   DAOS_INTENT_UPDATE, &kiov, &riov);
 
-	D_DEBUG(DB_TRACE, "Insert DTX "DF_DTI" to CoS cache, key %llu, "
+	D_DEBUG(DB_IO, "Insert DTX "DF_DTI" to CoS cache, key %llu, "
 		"intent %s, %s ilog entry: rc = "DF_RC"\n",
 		DP_DTI(dti), (unsigned long long)dkey_hash,
 		flags & DCF_FOR_PUNCH ? "Punch" : "Update",
@@ -545,13 +545,13 @@ vos_dtx_fetch_committable(daos_handle_t coh, uint32_t max_cnt,
 	return min(count, i);
 }
 
-void
+int
 vos_dtx_del_cos(struct vos_container *cont, daos_unit_oid_t *oid,
 		struct dtx_id *xid, uint64_t dkey_hash, bool punch)
 {
 	struct dtx_cos_key		 key;
-	d_iov_t			 kiov;
-	d_iov_t			 riov;
+	d_iov_t				 kiov;
+	d_iov_t				 riov;
 	struct dtx_cos_rec		*dcr;
 	struct dtx_cos_rec_child	*dcrc;
 	d_list_t			*head;
@@ -563,8 +563,15 @@ vos_dtx_del_cos(struct vos_container *cont, daos_unit_oid_t *oid,
 	d_iov_set(&riov, NULL, 0);
 
 	rc = dbtree_lookup(cont->vc_dtx_cos_hdl, &kiov, &riov);
-	if (rc != 0)
-		return;
+	if (rc != 0) {
+		if (rc == -DER_NONEXIST)
+			return 0;
+
+		D_ERROR("Fail to remove "DF_DTI" from CoS cache: %d\n",
+			DP_DTI(xid), rc);
+
+		return rc;
+	}
 
 	dcr = (struct dtx_cos_rec *)riov.iov_buf;
 	if (punch)
@@ -575,11 +582,6 @@ vos_dtx_del_cos(struct vos_container *cont, daos_unit_oid_t *oid,
 	d_list_for_each_entry(dcrc, head, dcrc_link) {
 		if (memcmp(&dcrc->dcrc_dti, xid, sizeof(*xid)) != 0)
 			continue;
-
-		D_DEBUG(DB_TRACE, "Remove DTX "DF_DTI" from CoS cache, "
-			"key %llu, intent %s, has ilog entry\n",
-			DP_DTI(&dcrc->dcrc_dti), (unsigned long long)dkey_hash,
-			punch ? "Punch" : "Update");
 
 		d_list_del(&dcrc->dcrc_committable);
 		d_list_del(&dcrc->dcrc_link);
@@ -593,23 +595,24 @@ vos_dtx_del_cos(struct vos_container *cont, daos_unit_oid_t *oid,
 
 		if (dcr->dcr_punch_count == 0 && dcr->dcr_update_count == 0 &&
 		    dcr->dcr_ilog_count == 0)
-			dbtree_delete(cont->vc_dtx_cos_hdl, BTR_PROBE_EQ,
-				      &kiov, NULL);
+			rc = dbtree_delete(cont->vc_dtx_cos_hdl, BTR_PROBE_EQ,
+					   &kiov, NULL);
 
-		return;
+		D_CDEBUG(rc != 0, DLOG_ERR, DB_IO, "Remove DTX "DF_DTI" from "
+			 "CoS cache, key %llu, intent %s, has ilog entry: %d\n",
+			 DP_DTI(xid), (unsigned long long)dkey_hash,
+			 punch ? "Punch" : "Update", rc);
+
+		return rc;
 	}
 
 	if (punch)
-		return;
+		return 0;
 
 	/* For UPDATE DTX, the DTX entry can be in {update,ilog}_list */
 	d_list_for_each_entry(dcrc, &dcr->dcr_update_list, dcrc_link) {
 		if (memcmp(&dcrc->dcrc_dti, xid, sizeof(*xid)) != 0)
 			continue;
-
-		D_DEBUG(DB_TRACE, "Remove DTX "DF_DTI" from CoS cache, "
-			"key %llu, intent Update, has not ilog entry\n",
-			DP_DTI(&dcrc->dcrc_dti), (unsigned long long)dkey_hash);
 
 		d_list_del(&dcrc->dcrc_committable);
 		d_list_del(&dcrc->dcrc_link);
@@ -620,11 +623,18 @@ vos_dtx_del_cos(struct vos_container *cont, daos_unit_oid_t *oid,
 
 		if (dcr->dcr_punch_count == 0 && dcr->dcr_update_count == 0 &&
 		    dcr->dcr_ilog_count == 0)
-			dbtree_delete(cont->vc_dtx_cos_hdl, BTR_PROBE_EQ,
-				      &kiov, NULL);
+			rc = dbtree_delete(cont->vc_dtx_cos_hdl, BTR_PROBE_EQ,
+					   &kiov, NULL);
 
-		return;
+		D_CDEBUG(rc != 0, DLOG_ERR, DB_IO, "Remove DTX "DF_DTI" from "
+			 "CoS cache, key %llu, intent Update, has not ilog "
+			 "entry: %d\n",
+			 DP_DTI(xid), (unsigned long long)dkey_hash, rc);
+
+		break;
 	}
+
+	return rc;
 }
 
 uint64_t

--- a/src/vos/vos_dtx_iter.c
+++ b/src/vos/vos_dtx_iter.c
@@ -179,7 +179,7 @@ dtx_iter_fetch(struct vos_iterator *iter, vos_iter_entry_t *it_entry,
 	it_entry->ie_dtx_intent = DAE_INTENT(dae);
 	it_entry->ie_dtx_hash = DAE_DKEY_HASH(dae);
 
-	D_DEBUG(DB_TRACE, "DTX iterator fetch the one "DF_DTI"\n",
+	D_DEBUG(DB_IO, "DTX iterator fetch the one "DF_DTI"\n",
 		DP_DTI(&DAE_XID(dae)));
 
 	return 0;

--- a/src/vos/vos_internal.h
+++ b/src/vos/vos_internal.h
@@ -457,8 +457,11 @@ vos_dtx_cos_register(void);
  * \param xid		[IN]	Pointer to the DTX identifier.
  * \param dkey_hash	[IN]	The hashed dkey.
  * \param punch		[IN]	For punch DTX or not.
+ *
+ * \return		Zero on success.
+ * \return		Other negative value if error.
  */
-void
+int
 vos_dtx_del_cos(struct vos_container *cont, daos_unit_oid_t *oid,
 		struct dtx_id *xid, uint64_t dkey_hash, bool punch);
 


### PR DESCRIPTION
Return DTX commit failure to the caller, then dtx_obj_sync will not fall
into dead loop if out of space. The upper layer user (such as daos racer)
should skip consistency verification if server out of space.

Another fix is that trace vos_dtx_del_cos() failure, that may cause
DTX entry has been committed but still be kept in the CoS cache, as
to related commit ULT (such as batched commit) fall into dead loop.

The pach also increase debug level to DLOG_ERR for DTX RPC failure.

Skip-func-test: true
Skip-func-hw-test-small: true
Skip-func-hw-test-medium: true
Test-tag-hw-large: daosracer

Signed-off-by: Fan Yong <fan.yong@intel.com>