### PR TITLE
DAOS-4310 srv: bump ULTs stack-size to 32K

### DIFF
--- a/src/vos/vos_common.c
+++ b/src/vos/vos_common.c
@@ -386,6 +386,7 @@ vos_init(void)
 		rc = set_abt_thread_stacksize(32768);
 		if (rc != 0) {
 			D_ERROR("failed to set ABT_THREAD_STACKSIZE: %d\n", rc);
+			D_MUTEX_UNLOCK(&mutex);
 			return rc;
 		}
 	}


### PR DESCRIPTION
To prevent cases where old PMDK RPMs (previous to
DAOS-4183 fix) we build, or PMDK local build done
without "NDCTL_DISABLE=y", are used. This is because
ndctl-based PMDK version will inconditionnally try
to check for bad blocks and thus call udev_new()
routine which allocates a 16K buffer on stack leading
to a stack overflow finaly causing corruption in
adjacent ULT stack.
This is the only known case of ULT stack overflow in
DAOS presently, and this patch is only an empirical
way to fix it by bumping ULT stack size, but a more
generic mechanism is required to at least detect any
cases in Argobots.

Change-Id: Ief8da1597afded1edc898f847a7bfdf47b59458f
Signed-off-by: Bruno Faccini <bruno.faccini@intel.com>