### PR TITLE
DAOS-4226 test: Added nvme_size to dmg pool create method

### DIFF
--- a/src/tests/ftest/util/test_utils_pool.py
+++ b/src/tests/ftest/util/test_utils_pool.py
@@ -173,6 +173,7 @@ class TestPool(TestDaosApiBase):
             self.dmg.action_command.group.value = self.groupname.value
             self.dmg.action_command.user.value = self.username.value
             self.dmg.action_command.scm_size.value = self.scm_size.value
+            self.dmg.action_command.nvme_size.value = self.nvme_size.value
             self.dmg.action_command.ranks.value = ranks_comma_separated
             self.dmg.action_command.nsvc.value = self.svcn.value
             create_result = self.dmg.run()


### PR DESCRIPTION
Added the following line so that we can use --nvme-size
from the test.
self.dmg.action_command.nvme_size.value = self.nvme_size.value

NVMe was initially forgotten and was added to master, but it didn't
make it to 0.9.

Signed-off-by: Makito Kano <makito.kano@intel.com>