### PR TITLE
DAOS-4431 client: hide internal symbols

### DIFF
--- a/src/client/api/SConscript
+++ b/src/client/api/SConscript
@@ -7,6 +7,7 @@ def scons():
 
     env.AppendUnique(LIBPATH=[Dir('.')])
     denv = env.Clone()
+    denv.AppendIfSupported(CCFLAGS='-fvisibility=hidden')
 
     prereqs.require(denv, 'protobufc')
 

--- a/src/client/dfs/SConscript
+++ b/src/client/dfs/SConscript
@@ -6,6 +6,7 @@ def scons():
     Import('env', 'prereqs')
 
     denv = env.Clone()
+    denv.AppendIfSupported(CCFLAGS='-fvisibility=hidden')
 
     """ If Lustre installed build a Lustre-aware libduns """
     conf = Configure(denv)

--- a/src/include/daos_api.h
+++ b/src/include/daos_api.h
@@ -45,7 +45,8 @@ extern "C" {
  * \return		allocated rank list that user is responsible to free
  *			with d_rank_list_free().
  */
-d_rank_list_t *daos_rank_list_parse(const char *str, const char *sep);
+DAOS_API d_rank_list_t *
+daos_rank_list_parse(const char *str, const char *sep);
 
 /*
  * Transaction API
@@ -63,7 +64,7 @@ d_rank_list_t *daos_rank_list_parse(const char *str, const char *sep);
  *
  * \return		0 if Success, negative if failed.
  */
-int
+DAOS_API int
 daos_tx_open(daos_handle_t coh, daos_handle_t *th, daos_event_t *ev);
 
 /**
@@ -82,7 +83,7 @@ daos_tx_open(daos_handle_t coh, daos_handle_t *th, daos_event_t *ev);
  *			-DER_INVAL      Invalid parameter
  *			-DER_RESTART	transaction conflict detected.
  */
-int
+DAOS_API int
 daos_tx_commit(daos_handle_t th, daos_event_t *ev);
 
 /**
@@ -100,7 +101,7 @@ daos_tx_commit(daos_handle_t th, daos_event_t *ev);
  *
  * \return		0 if Success, negative if failed.
  */
-int
+DAOS_API int
 daos_tx_open_snap(daos_handle_t coh, daos_epoch_t epoch, daos_handle_t *th,
 		  daos_event_t *ev);
 
@@ -114,7 +115,7 @@ daos_tx_open_snap(daos_handle_t coh, daos_epoch_t epoch, daos_handle_t *th,
  *
  * \return		0 if Success, negative if failed.
  */
-int
+DAOS_API int
 daos_tx_abort(daos_handle_t th, daos_event_t *ev);
 
 /**
@@ -125,7 +126,7 @@ daos_tx_abort(daos_handle_t th, daos_event_t *ev);
  *
  * \return		0 if Success, negative if failed.
  */
-int
+DAOS_API int
 daos_tx_close(daos_handle_t th, daos_event_t *ev);
 
 /**
@@ -136,7 +137,7 @@ daos_tx_close(daos_handle_t th, daos_event_t *ev);
  *
  * \return		0 if Success, negative if failed.
  */
-int
+DAOS_API int
 daos_tx_hdl2epoch(daos_handle_t th, daos_epoch_t *epoch);
 
 #if defined(__cplusplus)

--- a/src/include/daos_array.h
+++ b/src/include/daos_array.h
@@ -152,7 +152,7 @@ daos_array_generate_id(daos_obj_id_t *oid, daos_oclass_id_t cid, bool add_attr,
  *			-DER_EP_OLD	Epoch is too old and has no data for
  *					this object
  */
-int
+DAOS_API int
 daos_array_create(daos_handle_t coh, daos_obj_id_t oid, daos_handle_t th,
 		  daos_size_t cell_size, daos_size_t chunk_size,
 		  daos_handle_t *oh, daos_event_t *ev);
@@ -186,7 +186,7 @@ daos_array_create(daos_handle_t coh, daos_obj_id_t oid, daos_handle_t th,
  *			-DER_EP_OLD	Epoch is too old and has no data for
  *					this object
  */
-int
+DAOS_API int
 daos_array_open(daos_handle_t coh, daos_obj_id_t oid, daos_handle_t th,
 		unsigned int mode, daos_size_t *cell_size,
 		daos_size_t *chunk_size, daos_handle_t *oh, daos_event_t *ev);
@@ -223,7 +223,7 @@ daos_array_open(daos_handle_t coh, daos_obj_id_t oid, daos_handle_t th,
  *			-DER_EP_OLD	Epoch is too old and has no data for
  *					this object
  */
-int
+DAOS_API int
 daos_array_open_with_attr(daos_handle_t coh, daos_obj_id_t oid,
 			  daos_handle_t th, unsigned int mode,
 			  daos_size_t cell_size, daos_size_t chunk_size,
@@ -249,7 +249,7 @@ daos_array_open_with_attr(daos_handle_t coh, daos_obj_id_t oid,
  *					required buffer size is returned through
  *					glob->iov_buf_len.
  */
-int
+DAOS_API int
 daos_array_local2global(daos_handle_t oh, d_iov_t *glob);
 
 /**
@@ -269,7 +269,7 @@ daos_array_local2global(daos_handle_t oh, d_iov_t *glob);
  *			-DER_INVAL	Invalid parameter
  *			-DER_NO_HDL	Container handle is nonexistent
  */
-int
+DAOS_API int
 daos_array_global2local(daos_handle_t coh, d_iov_t glob, unsigned int mode,
 			daos_handle_t *oh);
 
@@ -285,7 +285,7 @@ daos_array_global2local(daos_handle_t coh, d_iov_t glob, unsigned int mode,
  *			0		Success
  *			-DER_NO_HDL	Invalid object open handle
  */
-int
+DAOS_API int
 daos_array_close(daos_handle_t oh, daos_event_t *ev);
 
 /**
@@ -311,7 +311,7 @@ daos_array_close(daos_handle_t oh, daos_event_t *ev);
  *					fit into output buffer
  *			-DER_EP_OLD	Epoch is too old and has no data
  */
-int
+DAOS_API int
 daos_array_read(daos_handle_t oh, daos_handle_t th, daos_array_iod_t *iod,
 		d_sg_list_t *sgl, daos_event_t *ev);
 
@@ -337,7 +337,7 @@ daos_array_read(daos_handle_t oh, daos_handle_t th, daos_array_iod_t *iod,
  *					fit into output buffer
  *			-DER_EP_OLD	Epoch is too old and has no data
  */
-int
+DAOS_API int
 daos_array_write(daos_handle_t oh, daos_handle_t th, daos_array_iod_t *iod,
 		 d_sg_list_t *sgl, daos_event_t *ev);
 
@@ -352,7 +352,7 @@ daos_array_write(daos_handle_t oh, daos_handle_t th, daos_array_iod_t *iod,
  *
  * \return		0 on Success, negative on failure.
  */
-int
+DAOS_API int
 daos_array_get_size(daos_handle_t oh, daos_handle_t th, daos_size_t *size,
 		    daos_event_t *ev);
 
@@ -370,7 +370,7 @@ daos_array_get_size(daos_handle_t oh, daos_handle_t th, daos_size_t *size,
  *
  * \return		0 on Success, negative on failure.
  */
-int
+DAOS_API int
 daos_array_set_size(daos_handle_t oh, daos_handle_t th, daos_size_t size,
 		    daos_event_t *ev);
 
@@ -390,7 +390,7 @@ daos_array_set_size(daos_handle_t oh, daos_handle_t th, daos_size_t size,
  *
  * \return		0 on Success, negative on failure.
  */
-int
+DAOS_API int
 daos_array_destroy(daos_handle_t oh, daos_handle_t th, daos_event_t *ev);
 
 /**
@@ -404,7 +404,7 @@ daos_array_destroy(daos_handle_t oh, daos_handle_t th, daos_event_t *ev);
  *
  * \return		0 on Success, negative on failure.
  */
-int
+DAOS_API int
 daos_array_punch(daos_handle_t oh, daos_handle_t th, daos_array_iod_t *iod,
 		 daos_event_t *ev);
 
@@ -419,7 +419,7 @@ daos_array_punch(daos_handle_t oh, daos_handle_t th, daos_array_iod_t *iod,
  *
  * \return		0 on Success, negative on failure.
  */
-int
+DAOS_API int
 daos_array_get_attr(daos_handle_t oh, daos_size_t *chunk_size,
 		    daos_size_t *cell_size);
 

--- a/src/include/daos_cont.h
+++ b/src/include/daos_cont.h
@@ -33,6 +33,7 @@
 extern "C" {
 #endif
 
+#include <daos_types.h>
 #include <daos_security.h>
 
 /**

--- a/src/include/daos_cont.h
+++ b/src/include/daos_cont.h
@@ -84,7 +84,8 @@ typedef struct {
  * \return		allocated rank list that user is responsible to free
  *			with d_rank_list_free().
  */
-d_rank_list_t *daos_rank_list_parse(const char *str, const char *sep);
+DAOS_API d_rank_list_t *
+daos_rank_list_parse(const char *str, const char *sep);
 
 /**
  * Convert a local container handle to global representation data which can be
@@ -106,7 +107,7 @@ d_rank_list_t *daos_rank_list_parse(const char *str, const char *sep);
  *					required buffer size is returned through
  *					glob->iov_buf_len.
  */
-int
+DAOS_API int
 daos_cont_local2global(daos_handle_t coh, d_iov_t *glob);
 
 /**
@@ -123,7 +124,7 @@ daos_cont_local2global(daos_handle_t coh, d_iov_t *glob);
  *			-DER_INVAL	Invalid parameter
  *			-DER_NO_HDL	Pool handle is nonexistent
  */
-int
+DAOS_API int
 daos_cont_global2local(daos_handle_t poh, d_iov_t glob, daos_handle_t *coh);
 
 /*
@@ -149,7 +150,7 @@ daos_cont_global2local(daos_handle_t poh, d_iov_t glob, daos_handle_t *coh);
  *			-DER_NO_PERM	Permission denied
  *			-DER_UNREACH	network is unreachable
  */
-int
+DAOS_API int
 daos_cont_create(daos_handle_t poh, const uuid_t uuid, daos_prop_t *cont_prop,
 		 daos_event_t *ev);
 
@@ -176,7 +177,7 @@ daos_cont_create(daos_handle_t poh, const uuid_t uuid, daos_prop_t *cont_prop,
  *			-DER_NO_PERM	Permission denied
  *			-DER_NONEXIST	Container is nonexistent
  */
-int
+DAOS_API int
 daos_cont_open(daos_handle_t poh, const uuid_t uuid, unsigned int flags,
 	       daos_handle_t *coh, daos_cont_info_t *info, daos_event_t *ev);
 
@@ -195,7 +196,7 @@ daos_cont_open(daos_handle_t poh, const uuid_t uuid, unsigned int flags,
  *			-DER_UNREACH	Network is unreachable
  *			-DER_NO_HDL	Invalid container handle
  */
-int
+DAOS_API int
 daos_cont_close(daos_handle_t coh, daos_event_t *ev);
 
 /**
@@ -222,7 +223,7 @@ daos_cont_close(daos_handle_t coh, daos_event_t *ev);
  *			-DER_NONEXIST	Container is nonexistent
  *			-DER_BUSY	Pool is busy
  */
-int
+DAOS_API int
 daos_cont_destroy(daos_handle_t poh, const uuid_t uuid, int force,
 		  daos_event_t *ev);
 
@@ -259,7 +260,7 @@ daos_cont_destroy(daos_handle_t poh, const uuid_t uuid, int force,
  *			-DER_UNREACH	Network is unreachable
  *			-DER_NO_HDL	Invalid container handle
  */
-int
+DAOS_API int
 daos_cont_query(daos_handle_t container, daos_cont_info_t *info,
 		daos_prop_t *cont_prop, daos_event_t *ev);
 
@@ -282,7 +283,7 @@ daos_cont_query(daos_handle_t container, daos_cont_info_t *info,
  *			-DER_UNREACH	Network is unreachable
  *			-DER_NO_HDL	Invalid container handle
  */
-int
+DAOS_API int
 daos_cont_get_acl(daos_handle_t container, daos_prop_t **acl_prop,
 		  daos_event_t *ev);
 /**
@@ -301,7 +302,7 @@ daos_cont_get_acl(daos_handle_t container, daos_prop_t **acl_prop,
  *			-DER_UNREACH	Network is unreachable
  *			-DER_NO_HDL	Invalid container handle
  */
-int
+DAOS_API int
 daos_cont_set_prop(daos_handle_t coh, daos_prop_t *prop, daos_event_t *ev);
 
 /**
@@ -320,7 +321,7 @@ daos_cont_set_prop(daos_handle_t coh, daos_prop_t *prop, daos_event_t *ev);
  *			-DER_UNREACH	Network is unreachable
  *			-DER_NO_HDL	Invalid container handle
  */
-int
+DAOS_API int
 daos_cont_overwrite_acl(daos_handle_t coh, struct daos_acl *acl,
 			daos_event_t *ev);
 
@@ -344,7 +345,7 @@ daos_cont_overwrite_acl(daos_handle_t coh, struct daos_acl *acl,
  *			-DER_UNREACH	Network is unreachable
  *			-DER_NO_HDL	Invalid container handle
  */
-int
+DAOS_API int
 daos_cont_update_acl(daos_handle_t coh, struct daos_acl *acl, daos_event_t *ev);
 
 /**
@@ -367,7 +368,7 @@ daos_cont_update_acl(daos_handle_t coh, struct daos_acl *acl, daos_event_t *ev);
  *			-DER_NOMEM	Out of memory
  *			-DER_NONEXIST	Principal is not in the ACL
  */
-int
+DAOS_API int
 daos_cont_delete_acl(daos_handle_t coh, enum daos_acl_principal_type type,
 		     d_string_t name, daos_event_t *ev);
 
@@ -389,7 +390,7 @@ daos_cont_delete_acl(daos_handle_t coh, enum daos_acl_principal_type type,
  *			-DER_NO_HDL	Invalid container handle
  *			-DER_NOMEM	Out of memory
  */
-int
+DAOS_API int
 daos_cont_set_owner(daos_handle_t coh, d_string_t user, d_string_t group,
 		    daos_event_t *ev);
 
@@ -409,7 +410,7 @@ daos_cont_set_owner(daos_handle_t coh, d_string_t user, d_string_t group,
  * \param[in]	ev	Completion event, it is optional and can be NULL.
  *			The function will run in blocking mode if \a ev is NULL.
  */
-int
+DAOS_API int
 daos_cont_list_attr(daos_handle_t coh, char *buffer, size_t *size,
 		    daos_event_t *ev);
 
@@ -431,7 +432,7 @@ daos_cont_list_attr(daos_handle_t coh, char *buffer, size_t *size,
  * \param[in]	ev	Completion event, it is optional and can be NULL.
  *			The function will run in blocking mode if \a ev is NULL.
  */
-int
+DAOS_API int
 daos_cont_get_attr(daos_handle_t coh, int n, char const *const names[],
 		   void *const buffers[], size_t sizes[], daos_event_t *ev);
 
@@ -447,7 +448,7 @@ daos_cont_get_attr(daos_handle_t coh, int n, char const *const names[],
  * \param[in]	ev	Completion event, it is optional and can be NULL.
  *			The function will run in blocking mode if \a ev is NULL.
  */
-int
+DAOS_API int
 daos_cont_set_attr(daos_handle_t coh, int n, char const *const names[],
 		   void const *const values[], size_t const sizes[],
 		   daos_event_t *ev);
@@ -474,7 +475,7 @@ daos_cont_set_attr(daos_handle_t coh, int n, char const *const names[],
  *			-DER_NO_HDL	Invalid container open handle
  *			-DER_UNREACH	Network is unreachable
  */
-int
+DAOS_API int
 daos_cont_alloc_oids(daos_handle_t coh, daos_size_t num_oids, uint64_t *oid,
 		     daos_event_t *ev);
 
@@ -487,7 +488,7 @@ daos_cont_alloc_oids(daos_handle_t coh, daos_size_t num_oids, uint64_t *oid,
  * \param[in]	ev	Completion event, it is optional and can be NULL.
  *			The function will run in blocking mode if \a ev is NULL.
  */
-int
+DAOS_API int
 daos_cont_aggregate(daos_handle_t coh, daos_epoch_t epoch, daos_event_t *ev);
 
 /**
@@ -498,7 +499,7 @@ daos_cont_aggregate(daos_handle_t coh, daos_epoch_t epoch, daos_event_t *ev);
  * \param[in]	ev	Completion event, it is optional and can be NULL.
  *			The function will run in blocking mode if \a ev is NULL.
  */
-int
+DAOS_API int
 daos_cont_rollback(daos_handle_t coh, daos_epoch_t epoch, daos_event_t *ev);
 
 /**
@@ -517,7 +518,7 @@ daos_cont_rollback(daos_handle_t coh, daos_epoch_t epoch, daos_event_t *ev);
  * \param[in]	ev	Completion event, it is optional and can be NULL.
  *			The function will run in blocking mode if \a ev is NULL.
  */
-int
+DAOS_API int
 daos_cont_subscribe(daos_handle_t coh, daos_epoch_t *epoch, daos_event_t *ev);
 
 #define DAOS_SNAPSHOT_MAX_LEN 128
@@ -535,7 +536,7 @@ daos_cont_subscribe(daos_handle_t coh, daos_epoch_t *epoch, daos_event_t *ev);
  * \param[in]	ev	Completion event, it is optional and can be NULL.
  *			The function will run in blocking mode if \a ev is NULL.
  */
-int
+DAOS_API int
 daos_cont_create_snap(daos_handle_t coh, daos_epoch_t *epoch, char *name,
 		      daos_event_t *ev);
 
@@ -558,7 +559,7 @@ daos_cont_create_snap(daos_handle_t coh, daos_epoch_t *epoch, char *name,
  * \param[in]	ev	Completion event, it is optional and can be NULL.
  *			The function will run in blocking mode if \a ev is NULL.
  */
-int
+DAOS_API int
 daos_cont_list_snap(daos_handle_t coh, int *nr, daos_epoch_t *epochs,
 		    char **names, daos_anchor_t *anchor, daos_event_t *ev);
 
@@ -575,7 +576,7 @@ daos_cont_list_snap(daos_handle_t coh, int *nr, daos_epoch_t *epochs,
  * \param[in]	ev	Completion event, it is optional and can be NULL.
  *			The function will run in blocking mode if \a ev is NULL.
  */
-int
+DAOS_API int
 daos_cont_destroy_snap(daos_handle_t coh, daos_epoch_range_t epr,
 		       daos_event_t *ev);
 

--- a/src/include/daos_event.h
+++ b/src/include/daos_event.h
@@ -66,7 +66,7 @@ extern "C" {
  *
  * \return		Zero on success, negative value if error
  */
-int
+DAOS_API int
 daos_eq_create(daos_handle_t *eqh);
 
 #define DAOS_EQ_DESTROY_FORCE	1
@@ -79,7 +79,7 @@ daos_eq_create(daos_handle_t *eqh);
  *
  * \return		Zero on success, EBUSY if there is any launched event
  */
-int
+DAOS_API int
 daos_eq_destroy(daos_handle_t eqh, int flags);
 
 /**
@@ -99,7 +99,7 @@ daos_eq_destroy(daos_handle_t eqh, int flags);
  * \return		>= 0	Returned number of events
  *			< 0	negative value if error
  */
-int
+DAOS_API int
 daos_eq_poll(daos_handle_t eqh, int wait_running,
 	     int64_t timeout, unsigned int nevents, daos_event_t **events);
 
@@ -123,7 +123,7 @@ daos_eq_poll(daos_handle_t eqh, int wait_running,
  * \return		>= 0	Returned number of events
  *			 < 0	negative value if error
  */
-int
+DAOS_API int
 daos_eq_query(daos_handle_t eqh, daos_eq_query_t query,
 	      unsigned int nevents, daos_event_t **events);
 
@@ -145,7 +145,7 @@ daos_eq_query(daos_handle_t eqh, daos_eq_query_t query,
  *
  * \return		Zero on success, negative value if error
  */
-int
+DAOS_API int
 daos_event_init(daos_event_t *ev, daos_handle_t eqh, daos_event_t *parent);
 
 /**
@@ -160,7 +160,7 @@ daos_event_init(daos_event_t *ev, daos_handle_t eqh, daos_event_t *parent);
  *
  * \return		Zero on success, negative value if error
  */
-int
+DAOS_API int
 daos_event_fini(daos_event_t *ev);
 
 /**
@@ -173,7 +173,7 @@ daos_event_fini(daos_event_t *ev);
  * \return		The next child event after \a child, or NULL if it's
  *			the last one.
  */
-daos_event_t *
+DAOS_API daos_event_t *
 daos_event_next(daos_event_t *parent, daos_event_t *child);
 
 /**
@@ -190,7 +190,7 @@ daos_event_next(daos_event_t *parent, daos_event_t *child);
  *
  * \return		Zero on success, negative value if error
  */
-int
+DAOS_API int
 daos_event_test(struct daos_event *ev, int64_t timeout, bool *flag);
 
 /**
@@ -210,7 +210,7 @@ daos_event_test(struct daos_event *ev, int64_t timeout, bool *flag);
  *
  * \return		Zero on success, negative value if error
  */
-int
+DAOS_API int
 daos_event_parent_barrier(struct daos_event *ev);
 
 /**
@@ -221,7 +221,7 @@ daos_event_parent_barrier(struct daos_event *ev);
  *
  * \return		Zero on success, negative value if error
  */
-int
+DAOS_API int
 daos_event_abort(daos_event_t *ev);
 
 #if defined(__cplusplus)

--- a/src/include/daos_fs.h
+++ b/src/include/daos_fs.h
@@ -79,7 +79,7 @@ typedef struct {
  *
  * \return              0 on success, errno code on failure.
  */
-int
+DAOS_API int
 dfs_cont_create(daos_handle_t poh, uuid_t co_uuid, dfs_attr_t *attr,
 		daos_handle_t *coh, dfs_t **dfs);
 
@@ -98,7 +98,7 @@ dfs_cont_create(daos_handle_t poh, uuid_t co_uuid, dfs_attr_t *attr,
  *
  * \return		0 on success, errno code on failure.
  */
-int
+DAOS_API int
 dfs_mount(daos_handle_t poh, daos_handle_t coh, int flags, dfs_t **dfs);
 
 /**
@@ -110,7 +110,7 @@ dfs_mount(daos_handle_t poh, daos_handle_t coh, int flags, dfs_t **dfs);
  *
  * \return		0 on success, errno code on failure.
  */
-int
+DAOS_API int
 dfs_umount(dfs_t *dfs);
 
 /**
@@ -121,7 +121,7 @@ dfs_umount(dfs_t *dfs);
  *
  * \return              0 on success, errno code on failure.
  */
-int
+DAOS_API int
 dfs_query(dfs_t *dfs, dfs_attr_t *attr);
 
 /**
@@ -136,7 +136,7 @@ dfs_query(dfs_t *dfs, dfs_attr_t *attr);
  *
  * \return		0 on success, errno code on failure.
  */
-int
+DAOS_API int
 dfs_local2global(dfs_t *dfs, d_iov_t *glob);
 
 /**
@@ -153,7 +153,7 @@ dfs_local2global(dfs_t *dfs, d_iov_t *glob);
  *
  * \return		0 on success, errno code on failure.
  */
-int
+DAOS_API int
 dfs_global2local(daos_handle_t poh, daos_handle_t coh, int flags, d_iov_t glob,
 		 dfs_t **dfs);
 
@@ -169,7 +169,7 @@ dfs_global2local(daos_handle_t poh, daos_handle_t coh, int flags, d_iov_t glob,
  *
  * \return		0 on success, errno code on failure.
  */
-int
+DAOS_API int
 dfs_set_prefix(dfs_t *dfs, const char *prefix);
 
 /**
@@ -180,7 +180,7 @@ dfs_set_prefix(dfs_t *dfs, const char *prefix);
  *
  * \return		0 on success, errno code on failure.
  */
-int
+DAOS_API int
 dfs_obj2id(dfs_obj_t *obj, daos_obj_id_t *oid);
 
 /**
@@ -196,7 +196,7 @@ dfs_obj2id(dfs_obj_t *obj, daos_obj_id_t *oid);
  *
  * \return		0 on success, errno code on failure.
  */
-int
+DAOS_API int
 dfs_lookup(dfs_t *dfs, const char *path, int flags, dfs_obj_t **obj,
 	   mode_t *mode, struct stat *stbuf);
 
@@ -219,7 +219,7 @@ dfs_lookup(dfs_t *dfs, const char *path, int flags, dfs_obj_t **obj,
  *
  * \return		0 on success, errno code on failure.
  */
-int
+DAOS_API int
 dfs_lookup_rel(dfs_t *dfs, dfs_obj_t *parent, const char *name, int flags,
 	       dfs_obj_t **_obj, mode_t *mode, struct stat *stbuf);
 
@@ -246,7 +246,7 @@ dfs_lookup_rel(dfs_t *dfs, dfs_obj_t *parent, const char *name, int flags,
  *
  * \return		0 on success, errno code on failure.
  */
-int
+DAOS_API int
 dfs_open(dfs_t *dfs, dfs_obj_t *parent, const char *name, mode_t mode,
 	 int flags, daos_oclass_id_t cid, daos_size_t chunk_size,
 	 const char *value, dfs_obj_t **obj);
@@ -263,7 +263,7 @@ dfs_open(dfs_t *dfs, dfs_obj_t *parent, const char *name, mode_t mode,
  *
  * \return		0 on success, errno code on failure.
  */
-int
+DAOS_API int
 dfs_dup(dfs_t *dfs, dfs_obj_t *obj, int flags, dfs_obj_t **new_obj);
 
 /**
@@ -279,7 +279,7 @@ dfs_dup(dfs_t *dfs, dfs_obj_t *obj, int flags, dfs_obj_t **new_obj);
  *
  * \return		0 on success, errno code on failure.
  */
-int
+DAOS_API int
 dfs_obj_local2global(dfs_t *dfs, dfs_obj_t *obj, d_iov_t *glob);
 
 /**
@@ -295,7 +295,7 @@ dfs_obj_local2global(dfs_t *dfs, dfs_obj_t *obj, d_iov_t *glob);
  *
  * \return		0 on success, errno code on failure.
  */
-int
+DAOS_API int
 dfs_obj_global2local(dfs_t *dfs, int flags, d_iov_t glob, dfs_obj_t **obj);
 
 /**
@@ -305,7 +305,7 @@ dfs_obj_global2local(dfs_t *dfs, int flags, d_iov_t glob, dfs_obj_t **obj);
  *
  * \return		0 on success, errno code on failure.
  */
-int
+DAOS_API int
 dfs_release(dfs_obj_t *obj);
 
 /**
@@ -322,7 +322,7 @@ dfs_release(dfs_obj_t *obj);
  *
  * \return		0 on success, errno code on failure.
  */
-int
+DAOS_API int
 dfs_read(dfs_t *dfs, dfs_obj_t *obj, d_sg_list_t *sgl, daos_off_t off,
 	 daos_size_t *read_size, daos_event_t *ev);
 
@@ -340,7 +340,7 @@ dfs_read(dfs_t *dfs, dfs_obj_t *obj, d_sg_list_t *sgl, daos_off_t off,
  *
  * \return		0 on success, errno code on failure.
  */
-int
+DAOS_API int
 dfs_readx(dfs_t *dfs, dfs_obj_t *obj, dfs_iod_t *iod, d_sg_list_t *sgl,
 	  daos_size_t *read_size, daos_event_t *ev);
 
@@ -356,7 +356,7 @@ dfs_readx(dfs_t *dfs, dfs_obj_t *obj, dfs_iod_t *iod, d_sg_list_t *sgl,
  *
  * \return		0 on success, errno code on failure.
  */
-int
+DAOS_API int
 dfs_write(dfs_t *dfs, dfs_obj_t *obj, d_sg_list_t *sgl, daos_off_t off,
 	  daos_event_t *ev);
 
@@ -372,7 +372,7 @@ dfs_write(dfs_t *dfs, dfs_obj_t *obj, d_sg_list_t *sgl, daos_off_t off,
  *
  * \return		0 on success, errno code on failure.
  */
-int
+DAOS_API int
 dfs_writex(dfs_t *dfs, dfs_obj_t *obj, dfs_iod_t *iod, d_sg_list_t *sgl,
 	   daos_event_t *ev);
 
@@ -385,7 +385,7 @@ dfs_writex(dfs_t *dfs, dfs_obj_t *obj, dfs_iod_t *iod, d_sg_list_t *sgl,
  *
  * \return		0 on success, errno code on failure.
  */
-int
+DAOS_API int
 dfs_get_size(dfs_t *dfs, dfs_obj_t *obj, daos_size_t *size);
 
 /**
@@ -401,7 +401,7 @@ dfs_get_size(dfs_t *dfs, dfs_obj_t *obj, daos_size_t *size);
  *
  * \return		0 on success, errno code on failure.
  */
-int
+DAOS_API int
 dfs_punch(dfs_t *dfs, dfs_obj_t *obj, daos_off_t offset, daos_size_t len);
 
 /**
@@ -422,7 +422,7 @@ dfs_punch(dfs_t *dfs, dfs_obj_t *obj, daos_off_t offset, daos_size_t len);
  *
  * \return		0 on success, errno code on failure.
  */
-int
+DAOS_API int
 dfs_readdir(dfs_t *dfs, dfs_obj_t *obj, daos_anchor_t *anchor,
 	    uint32_t *nr, struct dirent *dirs);
 
@@ -452,7 +452,7 @@ typedef int (*dfs_filler_cb_t)(dfs_t *dfs, dfs_obj_t *obj, const char name[],
  *
  * \return		0 on success, errno code on failure.
  */
-int
+DAOS_API int
 dfs_iterate(dfs_t *dfs, dfs_obj_t *obj, daos_anchor_t *anchor,
 	    uint32_t *nr, size_t size, dfs_filler_cb_t op, void *udata);
 
@@ -467,7 +467,7 @@ dfs_iterate(dfs_t *dfs, dfs_obj_t *obj, daos_anchor_t *anchor,
  *
  * \return		0 on success, errno code on failure.
  */
-int
+DAOS_API int
 dfs_mkdir(dfs_t *dfs, dfs_obj_t *parent, const char *name, mode_t mode,
 	  daos_oclass_id_t cid);
 
@@ -484,7 +484,7 @@ dfs_mkdir(dfs_t *dfs, dfs_obj_t *parent, const char *name, mode_t mode,
  *
  * \return		0 on success, errno code on failure.
  */
-int
+DAOS_API int
 dfs_remove(dfs_t *dfs, dfs_obj_t *parent, const char *name, bool force,
 	   daos_obj_id_t *oid);
 
@@ -502,7 +502,7 @@ dfs_remove(dfs_t *dfs, dfs_obj_t *parent, const char *name, bool force,
  *
  * \return		0 on success, errno code on failure.
  */
-int
+DAOS_API int
 dfs_move(dfs_t *dfs, dfs_obj_t *parent, char *name, dfs_obj_t *new_parent,
 	 char *new_name, daos_obj_id_t *oid);
 
@@ -517,7 +517,7 @@ dfs_move(dfs_t *dfs, dfs_obj_t *parent, char *name, dfs_obj_t *new_parent,
  *
  * \return		0 on success, errno code on failure.
  */
-int
+DAOS_API int
 dfs_exchange(dfs_t *dfs, dfs_obj_t *parent1, char *name1,
 	     dfs_obj_t *parent2, char *name2);
 
@@ -529,7 +529,7 @@ dfs_exchange(dfs_t *dfs, dfs_obj_t *parent1, char *name1,
  *
  * \return		0 on success, errno code on failure.
  */
-int
+DAOS_API int
 dfs_get_mode(dfs_obj_t *obj, mode_t *mode);
 
 /**
@@ -543,7 +543,7 @@ dfs_get_mode(dfs_obj_t *obj, mode_t *mode);
  *
  * \return		0 on success, errno code on failure.
  */
-int
+DAOS_API int
 dfs_get_file_oh(dfs_obj_t *obj, daos_handle_t *oh);
 
 /**
@@ -555,7 +555,7 @@ dfs_get_file_oh(dfs_obj_t *obj, daos_handle_t *oh);
  *
  * \return		0 on success, errno code on failure.
  */
-int
+DAOS_API int
 dfs_get_chunk_size(dfs_obj_t *obj, daos_size_t *chunk_size);
 
 /**
@@ -571,7 +571,7 @@ dfs_get_chunk_size(dfs_obj_t *obj, daos_size_t *chunk_size);
  *
  * \return		0 on success, errno code on failure.
  */
-int
+DAOS_API int
 dfs_get_symlink_value(dfs_obj_t *obj, char *buf, daos_size_t *size);
 
 /**
@@ -589,7 +589,7 @@ dfs_get_symlink_value(dfs_obj_t *obj, char *buf, daos_size_t *size);
  *
  * \return		0 on Success. errno code on Failure.
  */
-int
+DAOS_API int
 dfs_update_parent(dfs_obj_t *obj, dfs_obj_t *parent_obj, const char *name);
 
 /**
@@ -613,7 +613,7 @@ dfs_update_parent(dfs_obj_t *obj, dfs_obj_t *parent_obj, const char *name);
  *
  * \return		0 on success, errno code on failure.
  */
-int
+DAOS_API int
 dfs_stat(dfs_t *dfs, dfs_obj_t *parent, const char *name,
 	 struct stat *stbuf);
 
@@ -626,7 +626,7 @@ dfs_stat(dfs_t *dfs, dfs_obj_t *parent, const char *name,
  *
  * \return		0 on success, errno code on failure.
  */
-int
+DAOS_API int
 dfs_ostat(dfs_t *dfs, dfs_obj_t *obj, struct stat *stbuf);
 
 #define DFS_SET_ATTR_MODE	(1 << 0)
@@ -648,7 +648,7 @@ dfs_ostat(dfs_t *dfs, dfs_obj_t *obj, struct stat *stbuf);
  *
  * \return		0 on Success. errno code on Failure.
  */
-int
+DAOS_API int
 dfs_osetattr(dfs_t *dfs, dfs_obj_t *obj, struct stat *stbuf, int flags);
 
 /**
@@ -665,7 +665,7 @@ dfs_osetattr(dfs_t *dfs, dfs_obj_t *obj, struct stat *stbuf, int flags);
  *
  * \return		0 on success, errno code on failure.
  */
-int
+DAOS_API int
 dfs_access(dfs_t *dfs, dfs_obj_t *parent, const char *name, int mask);
 
 /**
@@ -680,7 +680,7 @@ dfs_access(dfs_t *dfs, dfs_obj_t *parent, const char *name, int mask);
  *
  * \return		0 on success, errno code on failure.
  */
-int
+DAOS_API int
 dfs_chmod(dfs_t *dfs, dfs_obj_t *parent, const char *name, mode_t mode);
 
 /**
@@ -693,7 +693,7 @@ dfs_chmod(dfs_t *dfs, dfs_obj_t *parent, const char *name, mode_t mode);
  *
  * \return		0 on success, errno code on failure.
  */
-int
+DAOS_API int
 dfs_sync(dfs_t *dfs);
 
 /**
@@ -711,7 +711,7 @@ dfs_sync(dfs_t *dfs);
  *
  * \return		0 on success, errno code on failure.
  */
-int
+DAOS_API int
 dfs_setxattr(dfs_t *dfs, dfs_obj_t *obj, const char *name,
 	     const void *value, daos_size_t size, int flags);
 
@@ -728,7 +728,7 @@ dfs_setxattr(dfs_t *dfs, dfs_obj_t *obj, const char *name,
  *
  * \return		0 on success, errno code on failure.
  */
-int
+DAOS_API int
 dfs_getxattr(dfs_t *dfs, dfs_obj_t *obj, const char *name, void *value,
 	     daos_size_t *size);
 
@@ -742,7 +742,7 @@ dfs_getxattr(dfs_t *dfs, dfs_obj_t *obj, const char *name, void *value,
  *
  * \return		0 on success, errno code on failure.
  */
-int
+DAOS_API int
 dfs_removexattr(dfs_t *dfs, dfs_obj_t *obj, const char *name);
 
 /**
@@ -760,7 +760,7 @@ dfs_removexattr(dfs_t *dfs, dfs_obj_t *obj, const char *name);
  *
  * \return		0 on success, errno code on failure.
  */
-int
+DAOS_API int
 dfs_listxattr(dfs_t *dfs, dfs_obj_t *obj, char *list, daos_size_t *size);
 
 /**
@@ -772,7 +772,7 @@ dfs_listxattr(dfs_t *dfs, dfs_obj_t *obj, char *list, daos_size_t *size);
  *
  * \return              0 on success, errno code on failure.
  */
-int
+DAOS_API int
 dfs_mount_root_cont(daos_handle_t poh, dfs_t **dfs);
 
 /**
@@ -782,7 +782,7 @@ dfs_mount_root_cont(daos_handle_t poh, dfs_t **dfs);
  *
  * \return		0 on success, errno code on failure.
  */
-int
+DAOS_API int
 dfs_umount_root_cont(dfs_t *dfs);
 
 #if defined(__cplusplus)

--- a/src/include/daos_kv.h
+++ b/src/include/daos_kv.h
@@ -65,7 +65,7 @@ extern "C" {
  *			-DER_UNREACH	Network is unreachable
  *			-DER_EP_RO	Epoch is read-only
  */
-int
+DAOS_API int
 daos_kv_put(daos_handle_t oh, daos_handle_t th, uint64_t flags, const char *key,
 	    daos_size_t size, const void *buf, daos_event_t *ev);
 
@@ -93,7 +93,7 @@ daos_kv_put(daos_handle_t oh, daos_handle_t th, uint64_t flags, const char *key,
  *			-DER_REC2BIG	Record does not fit in buffer
  *			-DER_EP_RO	Epoch is read-only
  */
-int
+DAOS_API int
 daos_kv_get(daos_handle_t oh, daos_handle_t th, uint64_t flags, const char *key,
 	    daos_size_t *size, void *buf, daos_event_t *ev);
 
@@ -116,7 +116,7 @@ daos_kv_get(daos_handle_t oh, daos_handle_t th, uint64_t flags, const char *key,
  *			-DER_UNREACH	Network is unreachable
  *			-DER_EP_RO	Epoch is read-only
  */
-int
+DAOS_API int
 daos_kv_remove(daos_handle_t oh, daos_handle_t th, uint64_t flags,
 	       const char *key, daos_event_t *ev);
 
@@ -150,7 +150,7 @@ daos_kv_remove(daos_handle_t oh, daos_handle_t th, uint64_t flags,
  *			-DER_UNREACH	Network is unreachable
  *			-DER_EP_RO	Epoch is read-only
  */
-int
+DAOS_API int
 daos_kv_list(daos_handle_t oh, daos_handle_t th, uint32_t *nr,
 	     daos_key_desc_t *kds, d_sg_list_t *sgl, daos_anchor_t *anchor,
 	     daos_event_t *ev);

--- a/src/include/daos_obj.h
+++ b/src/include/daos_obj.h
@@ -365,7 +365,7 @@ daos_obj_generate_id(daos_obj_id_t *oid, daos_ofeat_t ofeats,
  *			-DER_EP_OLD	Epoch is too old and has no data for
  *					this object
  */
-int
+DAOS_API int
 daos_obj_open(daos_handle_t coh, daos_obj_id_t oid, unsigned int mode,
 	      daos_handle_t *oh, daos_event_t *ev);
 
@@ -381,7 +381,7 @@ daos_obj_open(daos_handle_t coh, daos_obj_id_t oid, unsigned int mode,
  *			0		Success
  *			-DER_NO_HDL	Invalid object open handle
  */
-int
+DAOS_API int
 daos_obj_close(daos_handle_t oh, daos_event_t *ev);
 
 /**
@@ -405,7 +405,7 @@ daos_obj_close(daos_handle_t oh, daos_event_t *ev);
  *					related resent history may have been
  *					aggregated. Punch result is undefined.
  */
-int
+DAOS_API int
 daos_obj_punch(daos_handle_t oh, daos_handle_t th, uint64_t flags,
 	       daos_event_t *ev);
 
@@ -432,7 +432,7 @@ daos_obj_punch(daos_handle_t oh, daos_handle_t th, uint64_t flags,
  *					related resent history may have been
  *					aggregated. Punch result is undefined.
  */
-int
+DAOS_API int
 daos_obj_punch_dkeys(daos_handle_t oh, daos_handle_t th, uint64_t flags,
 		     unsigned int nr, daos_key_t *dkeys, daos_event_t *ev);
 
@@ -460,7 +460,7 @@ daos_obj_punch_dkeys(daos_handle_t oh, daos_handle_t th, uint64_t flags,
  *					related resent history may have been
  *					aggregated. Punch result is undefined.
  */
-int
+DAOS_API int
 daos_obj_punch_akeys(daos_handle_t oh, daos_handle_t th, uint64_t flags,
 		     daos_key_t *dkey, unsigned int nr, daos_key_t *akeys,
 		     daos_event_t *ev);
@@ -484,7 +484,7 @@ daos_obj_punch_akeys(daos_handle_t oh, daos_handle_t th, uint64_t flags,
  *			-DER_INVAL	Invalid parameter
  *			-DER_UNREACH	Network is unreachable
  */
-int
+DAOS_API int
 daos_obj_query(daos_handle_t oh, daos_handle_t th, struct daos_obj_attr *oa,
 	       d_rank_list_t *ranks, daos_event_t *ev);
 
@@ -552,7 +552,7 @@ daos_obj_query(daos_handle_t oh, daos_handle_t th, struct daos_obj_attr *oa,
  *					fit into output buffer
  *			-DER_EP_OLD	Epoch is too old and has no data
  */
-int
+DAOS_API int
 daos_obj_fetch(daos_handle_t oh, daos_handle_t th, uint64_t flags,
 	       daos_key_t *dkey, unsigned int nr, daos_iod_t *iods,
 	       d_sg_list_t *sgls, daos_iom_t *maps, daos_event_t *ev);
@@ -608,7 +608,7 @@ daos_obj_fetch(daos_handle_t oh, daos_handle_t th, uint64_t flags,
  *					related resent history may have been
  *					aggregated. Update result is undefined.
  */
-int
+DAOS_API int
 daos_obj_update(daos_handle_t oh, daos_handle_t th, uint64_t flags,
 		daos_key_t *dkey, unsigned int nr, daos_iod_t *iods,
 		d_sg_list_t *sgls, daos_event_t *ev);
@@ -658,7 +658,7 @@ daos_obj_update(daos_handle_t oh, daos_handle_t th, uint64_t flags,
  *					times \a kds[0].kd_key_len) and do the
  *					enumerate again.
  */
-int
+DAOS_API int
 daos_obj_list_dkey(daos_handle_t oh, daos_handle_t th, uint32_t *nr,
 		   daos_key_desc_t *kds, d_sg_list_t *sgl,
 		   daos_anchor_t *anchor, daos_event_t *ev);
@@ -709,7 +709,7 @@ daos_obj_list_dkey(daos_handle_t oh, daos_handle_t th, uint32_t *nr,
  *					times \a kds[0].kd_key_len) and do the
  *					enumerate again.
  */
-int
+DAOS_API int
 daos_obj_list_akey(daos_handle_t oh, daos_handle_t th, daos_key_t *dkey,
 		   uint32_t *nr, daos_key_desc_t *kds, d_sg_list_t *sgl,
 		   daos_anchor_t *anchor, daos_event_t *ev);
@@ -762,7 +762,7 @@ daos_obj_list_akey(daos_handle_t oh, daos_handle_t th, daos_key_t *dkey,
  *			-DER_INVAL	Invalid parameter
  *			-DER_UNREACH	Network is unreachable
  */
-int
+DAOS_API int
 daos_obj_list_recx(daos_handle_t oh, daos_handle_t th, daos_key_t *dkey,
 		   daos_key_t *akey, daos_size_t *size, uint32_t *nr,
 		   daos_recx_t *recxs, daos_epoch_range_t *eprs,
@@ -812,7 +812,7 @@ daos_obj_list_recx(daos_handle_t oh, daos_handle_t th, daos_key_t *dkey,
  *			-DER_INVAL	Invalid parameter
  *			-DER_UNREACH	Network is unreachable
  */
-int
+DAOS_API int
 daos_obj_query_key(daos_handle_t oh, daos_handle_t th, uint64_t flags,
 		   daos_key_t *dkey, daos_key_t *akey, daos_recx_t *recx,
 		   daos_event_t *ev);
@@ -830,7 +830,7 @@ daos_obj_query_key(daos_handle_t oh, daos_handle_t th, uint64_t flags,
  *			-DER_NO_HDL	Invalid object open handle
  *			-DER_MISMATCH	Found data inconsistency
  */
-int
+DAOS_API int
 daos_obj_verify(daos_handle_t coh, daos_obj_id_t oid, daos_epoch_t epoch);
 
 #if defined(__cplusplus)

--- a/src/include/daos_obj_class.h
+++ b/src/include/daos_obj_class.h
@@ -27,6 +27,8 @@
 extern "C" {
 #endif
 
+#include <daos_types.h>
+
 /**
  * Predefined object classes
  * It describes schema of data distribution & protection.

--- a/src/include/daos_obj_class.h
+++ b/src/include/daos_obj_class.h
@@ -464,7 +464,7 @@ struct daos_oclass_list {
  *
  * \return		The Object class ID, 0 / OC_UNKNOWN if unknown.
  */
-int
+DAOS_API int
 daos_oclass_name2id(const char *name);
 
 /**
@@ -475,7 +475,7 @@ daos_oclass_name2id(const char *name);
  *
  * \return		>= 0 on success and required length of str, -1 if error.
  */
-size_t
+DAOS_API size_t
 daos_oclass_names_list(size_t size, char *str);
 
 /**
@@ -487,7 +487,7 @@ daos_oclass_names_list(size_t size, char *str);
  *
  * \return		0 on success, -1 if invalid class.
  */
-int
+DAOS_API int
 daos_oclass_id2name(daos_oclass_id_t oc_id, char *name);
 
 /**
@@ -509,7 +509,7 @@ daos_oclass_id2name(daos_oclass_id_t oc_id, char *name);
  *			-DER_UNREACH	Network is unreachable
  *			-DER_EXIST	Object class ID already existed
  */
-int
+DAOS_API int
 daos_obj_register_class(daos_handle_t coh, daos_oclass_id_t cid,
 			struct daos_oclass_attr *attr, daos_event_t *ev);
 
@@ -530,7 +530,7 @@ daos_obj_register_class(daos_handle_t coh, daos_oclass_id_t cid,
  *			-DER_UNREACH	Network is unreachable
  *			-DER_NONEXIST	Nonexistent class ID
  */
-int
+DAOS_API int
 daos_obj_query_class(daos_handle_t coh, daos_oclass_id_t cid,
 		     struct daos_oclass_attr *attr, daos_event_t *ev);
 
@@ -553,7 +553,7 @@ daos_obj_query_class(daos_handle_t coh, daos_oclass_id_t cid,
  *			-DER_INVAL	Invalid parameter
  *			-DER_UNREACH	Network is unreachable
  */
-int
+DAOS_API int
 daos_obj_list_class(daos_handle_t coh, struct daos_oclass_list *list,
 		    daos_anchor_t *anchor, daos_event_t *ev);
 

--- a/src/include/daos_pool.h
+++ b/src/include/daos_pool.h
@@ -200,7 +200,7 @@ struct daos_pool_cont_info {
  *			-DER_NO_PERM	Permission denied
  *			-DER_NONEXIST	Pool is nonexistent
  */
-int
+DAOS_API int
 daos_pool_connect(const uuid_t uuid, const char *grp,
 		  const d_rank_list_t *svc, unsigned int flags,
 		  daos_handle_t *poh, daos_pool_info_t *info, daos_event_t *ev);
@@ -219,7 +219,7 @@ daos_pool_connect(const uuid_t uuid, const char *grp,
  *			-DER_UNREACH	Network is unreachable
  *			-DER_NO_HDL	Invalid pool handle
  */
-int
+DAOS_API int
 daos_pool_disconnect(daos_handle_t poh, daos_event_t *ev);
 
 /*
@@ -246,7 +246,7 @@ daos_pool_disconnect(daos_handle_t poh, daos_event_t *ev);
  *					required buffer size is returned through
  *					glob->iov_buf_len.
  */
-int
+DAOS_API int
 daos_pool_local2global(daos_handle_t poh, d_iov_t *glob);
 
 /**
@@ -261,7 +261,7 @@ daos_pool_local2global(daos_handle_t poh, d_iov_t *glob);
  *			0		Success
  *			-DER_INVAL	Invalid parameter
  */
-int
+DAOS_API int
 daos_pool_global2local(d_iov_t glob, daos_handle_t *poh);
 
 /**
@@ -297,7 +297,7 @@ daos_pool_global2local(d_iov_t glob, daos_handle_t *poh);
  *			-DER_UNREACH	Network is unreachable
  *			-DER_NO_HDL	Invalid pool handle
  */
-int
+DAOS_API int
 daos_pool_query(daos_handle_t poh, d_rank_list_t *tgts, daos_pool_info_t *info,
 		daos_prop_t *pool_prop, daos_event_t *ev);
 
@@ -321,7 +321,7 @@ daos_pool_query(daos_handle_t poh, d_rank_list_t *tgts, daos_pool_info_t *info,
  *			-DER_UNREACH	Network is unreachable
  *			-DER_NONEXIST	No pool on specified targets
  */
-int
+DAOS_API int
 daos_pool_query_target(daos_handle_t poh, d_rank_list_t *tgts,
 		       d_rank_list_t *failed, daos_target_info_t *info_list,
 		       daos_event_t *ev);
@@ -343,7 +343,7 @@ daos_pool_query_target(daos_handle_t poh, d_rank_list_t *tgts,
  * \param[in]	ev	Completion event, it is optional and can be NULL.
  *			The function will run in blocking mode if \a ev is NULL.
  */
-int
+DAOS_API int
 daos_pool_list_attr(daos_handle_t poh, char *buffer, size_t *size,
 		    daos_event_t *ev);
 
@@ -365,7 +365,7 @@ daos_pool_list_attr(daos_handle_t poh, char *buffer, size_t *size,
  * \param[in]	ev	Completion event, it is optional and can be NULL.
  *			The function will run in blocking mode if \a ev is NULL.
  */
-int
+DAOS_API int
 daos_pool_get_attr(daos_handle_t poh, int n, char const *const names[],
 		   void *const buffers[], size_t sizes[], daos_event_t *ev);
 
@@ -381,7 +381,7 @@ daos_pool_get_attr(daos_handle_t poh, int n, char const *const names[],
  * \param[in]	ev	Completion event, it is optional and can be NULL.
  *			The function will run in blocking mode if \a ev is NULL.
  */
-int
+DAOS_API int
 daos_pool_set_attr(daos_handle_t poh, int n, char const *const names[],
 		   void const *const values[], size_t const sizes[],
 		   daos_event_t *ev);
@@ -403,7 +403,7 @@ daos_pool_set_attr(daos_handle_t poh, int n, char const *const names[],
  * \return		0		Success
  *			-DER_TRUNC	\a cbuf cannot hold \a ncont items
  */
-int
+DAOS_API int
 daos_pool_list_cont(daos_handle_t poh, daos_size_t *ncont,
 		    struct daos_pool_cont_info *cbuf, daos_event_t *ev);
 

--- a/src/include/daos_pool.h
+++ b/src/include/daos_pool.h
@@ -30,6 +30,8 @@
 extern "C" {
 #endif
 
+#include <daos_types.h>
+
 /** Type of storage target */
 typedef enum {
 	DAOS_TP_UNKNOWN,

--- a/src/include/daos_prop.h
+++ b/src/include/daos_prop.h
@@ -271,7 +271,7 @@ typedef struct {
  *
  * \return	allocated daos_prop_t pointer, NULL if failed.
  */
-daos_prop_t *
+DAOS_API daos_prop_t *
 daos_prop_alloc(uint32_t entries_nr);
 
 /**
@@ -279,7 +279,7 @@ daos_prop_alloc(uint32_t entries_nr);
  *
  * \param[in]	prop	properties to be freed.
  */
-void
+DAOS_API void
 daos_prop_free(daos_prop_t *prop);
 
 /**
@@ -290,7 +290,7 @@ daos_prop_free(daos_prop_t *prop);
  *
  * \return	Newly allocated merged property
  */
-daos_prop_t *
+DAOS_API daos_prop_t *
 daos_prop_merge(daos_prop_t *old_prop, daos_prop_t *new_prop);
 
 /**
@@ -304,7 +304,7 @@ daos_prop_merge(daos_prop_t *old_prop, daos_prop_t *new_prop);
  * \return		0		Success
  *			-DER_NOMEM	Out of memory
  */
-int
+DAOS_API int
 daos_prop_entry_dup_ptr(struct daos_prop_entry *entry_dst,
 			struct daos_prop_entry *entry_src, size_t len);
 
@@ -317,7 +317,7 @@ daos_prop_entry_dup_ptr(struct daos_prop_entry *entry_dst,
  * \return	0		Entries match
  *		-DER_MISMATCH	Entries do NOT match
  */
-int
+DAOS_API int
 daos_prop_entry_cmp_acl(struct daos_prop_entry *entry1,
 			struct daos_prop_entry *entry2);
 

--- a/src/include/daos_security.h
+++ b/src/include/daos_security.h
@@ -34,6 +34,8 @@
 extern "C" {
 #endif
 
+#include <daos_types.h>
+
 #include <stdint.h>
 #include <stdbool.h>
 #include <sys/types.h>

--- a/src/include/daos_security.h
+++ b/src/include/daos_security.h
@@ -219,7 +219,7 @@ struct daos_ace {
  *
  * \return	allocated daos_acl pointer, NULL if failed
  */
-struct daos_acl *
+DAOS_API struct daos_acl *
 daos_acl_create(struct daos_ace *aces[], uint16_t num_aces);
 
 /**
@@ -230,7 +230,7 @@ daos_acl_create(struct daos_ace *aces[], uint16_t num_aces);
  * \return	Newly allocated copy of the ACL, or NULL if the ACL can't be
  *		allocated
  */
-struct daos_acl *
+DAOS_API struct daos_acl *
 daos_acl_dup(struct daos_acl *acl);
 
 /**
@@ -238,7 +238,7 @@ daos_acl_dup(struct daos_acl *acl);
  *
  * \param[in]	acl	ACL pointer to be freed
  */
-void
+DAOS_API void
 daos_acl_free(struct daos_acl *acl);
 
 /**
@@ -250,7 +250,7 @@ daos_acl_free(struct daos_acl *acl);
  * \return	Size of ACL in bytes
  *		-DER_INVAL		Invalid input
  */
-ssize_t
+DAOS_API ssize_t
 daos_acl_get_size(struct daos_acl *acl);
 
 /**
@@ -263,7 +263,7 @@ daos_acl_get_size(struct daos_acl *acl);
  *
  * \return	Pointer to the next ACE in the ACL, or NULL if at the end
  */
-struct daos_ace *
+DAOS_API struct daos_ace *
 daos_acl_get_next_ace(struct daos_acl *acl, struct daos_ace *current_ace);
 
 /**
@@ -280,7 +280,7 @@ daos_acl_get_next_ace(struct daos_acl *acl, struct daos_ace *current_ace);
  *		-DER_INVAL	Invalid input
  *		-DER_NONEXIST	Matching ACE not found
  */
-int
+DAOS_API int
 daos_acl_get_ace_for_principal(struct daos_acl *acl,
 			       enum daos_acl_principal_type type,
 			       const char *principal, struct daos_ace **ace);
@@ -302,7 +302,7 @@ daos_acl_get_ace_for_principal(struct daos_acl *acl,
  *		-DER_INVAL	Invalid input
  *		-DER_NOMEM	Failed to allocate required memory
  */
-int
+DAOS_API int
 daos_acl_add_ace(struct daos_acl **acl, struct daos_ace *new_ace);
 
 /**
@@ -323,7 +323,7 @@ daos_acl_add_ace(struct daos_acl **acl, struct daos_ace *new_ace);
  *		-DER_NOMEM	Failed to allocate required memory
  *		-DER_NONEXIST	Requested ACE was not in the ACL
  */
-int
+DAOS_API int
 daos_acl_remove_ace(struct daos_acl **acl,
 		    enum daos_acl_principal_type type,
 		    const char *principal_name);
@@ -333,7 +333,7 @@ daos_acl_remove_ace(struct daos_acl **acl,
  *
  * \param	acl	Access Control List to print
  */
-void
+DAOS_API void
 daos_acl_dump(struct daos_acl *acl);
 
 /**
@@ -346,7 +346,7 @@ daos_acl_dump(struct daos_acl *acl);
  *		-DER_INVAL	ACL is not valid
  *		-DER_NOMEM	Ran out of memory while checking
  */
-int
+DAOS_API int
 daos_acl_validate(struct daos_acl *acl);
 
 /**
@@ -360,7 +360,7 @@ daos_acl_validate(struct daos_acl *acl);
  *		-DER_INVAL	ACL is not valid
  *		-DER_NOMEM	Ran out of memory while checking
  */
-int
+DAOS_API int
 daos_acl_pool_validate(struct daos_acl *acl);
 
 /**
@@ -374,7 +374,7 @@ daos_acl_pool_validate(struct daos_acl *acl);
  *		-DER_INVAL	ACL is not valid
  *		-DER_NOMEM	Ran out of memory while checking
  */
-int
+DAOS_API int
 daos_acl_cont_validate(struct daos_acl *acl);
 
 /**
@@ -391,7 +391,7 @@ daos_acl_cont_validate(struct daos_acl *acl);
  * \return	New ACE structure with an appropriately packed principal name,
  *			length, and type set.
  */
-struct daos_ace *
+DAOS_API struct daos_ace *
 daos_ace_create(enum daos_acl_principal_type type, const char *principal_name);
 
 /**
@@ -399,7 +399,7 @@ daos_ace_create(enum daos_acl_principal_type type, const char *principal_name);
  *
  * \param[in]	ace	ACE to be freed
  */
-void
+DAOS_API void
 daos_ace_free(struct daos_ace *ace);
 
 /**
@@ -411,7 +411,7 @@ daos_ace_free(struct daos_ace *ace);
  * \return	Size of ACE in bytes
  *		-DER_INVAL		Invalid input
  */
-ssize_t
+DAOS_API ssize_t
 daos_ace_get_size(struct daos_ace *ace);
 
 /**
@@ -420,7 +420,7 @@ daos_ace_get_size(struct daos_ace *ace);
  * \param	ace	Access Control Entry to print
  * \param	tabs	Number of tabs to indent at top level
  */
-void
+DAOS_API void
 daos_ace_dump(struct daos_ace *ace, uint32_t tabs);
 
 /**
@@ -431,7 +431,7 @@ daos_ace_dump(struct daos_ace *ace, uint32_t tabs);
  *
  * \return	True if the ACE is valid, false otherwise
  */
-bool
+DAOS_API bool
 daos_ace_is_valid(struct daos_ace *ace);
 
 /**
@@ -447,7 +447,7 @@ daos_ace_is_valid(struct daos_ace *ace);
  * \return	true if the name is properly formatted
  *		false otherwise
  */
-bool
+DAOS_API bool
 daos_acl_principal_is_valid(const char *name);
 
 /**
@@ -463,7 +463,7 @@ daos_acl_principal_is_valid(const char *name);
  *		-DER_NONEXIST	UID not found
  *		-DER_NOMEM	Could not allocate memory
  */
-int
+DAOS_API int
 daos_acl_uid_to_principal(uid_t uid, char **name);
 
 /**
@@ -479,7 +479,7 @@ daos_acl_uid_to_principal(uid_t uid, char **name);
  *		-DER_NONEXIST	GID not found
  *		-DER_NOMEM	Could not allocate memory
  */
-int
+DAOS_API int
 daos_acl_gid_to_principal(gid_t gid, char **name);
 
 /**
@@ -494,7 +494,7 @@ daos_acl_gid_to_principal(gid_t gid, char **name);
  *		-DER_NONEXIST	User not found
  *		-DER_NOMEM	Could not allocate memory
  */
-int
+DAOS_API int
 daos_acl_principal_to_uid(const char *principal, uid_t *uid);
 
 /**
@@ -509,7 +509,7 @@ daos_acl_principal_to_uid(const char *principal, uid_t *uid);
  *		-DER_NONEXIST	Group not found
  *		-DER_NOMEM	Could not allocate memory
  */
-int
+DAOS_API int
 daos_acl_principal_to_gid(const char *principal, gid_t *gid);
 
 /**
@@ -520,7 +520,7 @@ daos_acl_principal_to_gid(const char *principal, gid_t *gid);
  * \return	Either the string from the principal name field, or one of the
  *		special principal names: OWNER@, GROUP@, EVERYONE@
  */
-const char *
+DAOS_API const char *
 daos_ace_get_principal_str(struct daos_ace *ace);
 
 /**
@@ -534,7 +534,7 @@ daos_ace_get_principal_str(struct daos_ace *ace);
  *		-DER_INVAL	Invalid input
  *		-DER_NOMEM	Could not allocate memory
  */
-int
+DAOS_API int
 daos_ace_from_str(const char *str, struct daos_ace **ace);
 
 /**
@@ -551,7 +551,7 @@ daos_ace_from_str(const char *str, struct daos_ace **ace);
  * \return	0		Success
  *		-DER_INVAL	Invalid input
  */
-int
+DAOS_API int
 daos_ace_to_str(struct daos_ace *ace, char *buf, size_t buf_len);
 
 /**
@@ -565,7 +565,7 @@ daos_ace_to_str(struct daos_ace *ace, char *buf, size_t buf_len);
  *		-DER_INVAL	Invalid input string
  *		-DER_TRUNC	Output didn't fit in buffer
  */
-int
+DAOS_API int
 daos_ace_str_get_verbose(const char *ace_str, char *buf, size_t buf_len);
 
 /**
@@ -580,7 +580,7 @@ daos_ace_str_get_verbose(const char *ace_str, char *buf, size_t buf_len);
  *		-DER_INVAL	Invalid input
  *		-DER_NOMEM	Could not allocate memory
  */
-int
+DAOS_API int
 daos_acl_from_strs(const char **ace_strs, size_t ace_nr, struct daos_acl **acl);
 
 /**
@@ -598,7 +598,7 @@ daos_acl_from_strs(const char **ace_strs, size_t ace_nr, struct daos_acl **acl);
  *		-DER_INVAL	Invalid input
  *		-DER_NOMEM	Could not allocate memory
  */
-int
+DAOS_API int
 daos_acl_to_strs(struct daos_acl *acl, char ***ace_strs, size_t *ace_nr);
 
 /**
@@ -621,7 +621,7 @@ daos_acl_to_strs(struct daos_acl *acl, char ***ace_strs, size_t *ace_nr);
  *		-DER_INVAL	Invalid input
  *		-DER_NOMEM	Could not allocate memory
  */
-int
+DAOS_API int
 daos_acl_principal_from_str(const char *principal_str,
 			    enum daos_acl_principal_type *type,
 			    char **name);

--- a/src/include/daos_task.h
+++ b/src/include/daos_task.h
@@ -675,7 +675,7 @@ typedef struct {
  * \return		0 if task creation succeeds.
  *			negative errno if it fails.
  */
-int
+DAOS_API int
 daos_task_create(daos_opc_t opc, tse_sched_t *sched,
 		 unsigned int num_deps, tse_task_t *dep_tasks[],
 		 tse_task_t **taskp);
@@ -690,7 +690,7 @@ daos_task_create(daos_opc_t opc, tse_sched_t *sched,
  *
  * \return		Success: Pointer to arguments for the DAOS task
  */
-void *
+DAOS_API void *
 daos_task_get_args(tse_task_t *task);
 
 /**
@@ -701,7 +701,7 @@ daos_task_get_args(tse_task_t *task);
  *
  * \return		Pointer to the private state
  */
-void *
+DAOS_API void *
 daos_task_get_priv(tse_task_t *task);
 
 /**
@@ -712,7 +712,7 @@ daos_task_get_priv(tse_task_t *task);
  *
  * \return		private state set by the previous call
  */
-void *
+DAOS_API void *
 daos_task_set_priv(tse_task_t *task, void *priv);
 
 /**
@@ -728,7 +728,7 @@ daos_task_set_priv(tse_task_t *task, void *priv);
  *
  * \return		0 if Success, errno if failed.
  */
-int
+DAOS_API int
 daos_progress(tse_sched_t *sched, int64_t timeout, bool *is_empty);
 
 #if defined(__cplusplus)

--- a/src/include/daos_types.h
+++ b/src/include/daos_types.h
@@ -31,6 +31,12 @@
 extern "C" {
 #endif
 
+#if __GNUC__ >= 4
+	#define DAOS_API __attribute__ ((visibility ("default")))
+#else
+	#define DAOS_API
+#endif
+
 #include <stdint.h>
 #include <stdio.h>
 #include <string.h>

--- a/src/include/daos_uns.h
+++ b/src/include/daos_uns.h
@@ -73,7 +73,7 @@ struct duns_attr_t {
  *
  * \return		0 on Success. Negative on Failure.
  */
-int
+DAOS_API int
 duns_create_path(daos_handle_t poh, const char *path,
 		 struct duns_attr_t *attrp);
 
@@ -87,7 +87,7 @@ duns_create_path(daos_handle_t poh, const char *path,
  *
  * \return		0 on Success. Negative on Failure.
  */
-int
+DAOS_API int
 duns_resolve_path(const char *path, struct duns_attr_t *attr);
 
 /**
@@ -98,7 +98,7 @@ duns_resolve_path(const char *path, struct duns_attr_t *attr);
  *
  * \return		0 on Success. Negative on Failure.
  */
-int
+DAOS_API int
 duns_destroy_path(daos_handle_t poh, const char *path);
 
 /**
@@ -110,7 +110,7 @@ duns_destroy_path(daos_handle_t poh, const char *path);
  *
  * \return		0 on Success. Negative on Failure.
  */
-int
+DAOS_API int
 duns_parse_attr(char *str, daos_size_t len, struct duns_attr_t *attr);
 
 #if defined(__cplusplus)


### PR DESCRIPTION
Compile with -fvisibility=hidden to hide internal symbols of libdaos
and libdfs. Public symbols are exposed via
__attribute__ ((visibility ("default"))).

Signed-off-by: Johann Lombardi <johann.lombardi@intel.com>