### PR TITLE
DAOS-3835 control: Convert DAOS err codes to strings

### DIFF
--- a/src/control/SConscript
+++ b/src/control/SConscript
@@ -140,6 +140,8 @@ def scons():
     gosrc = Dir('.').srcnode().abspath
     cartpath = Dir('#/src/cart/src/include').srcnode().abspath
 
+    denv.AppendENVPath("CGO_LDFLAGS",
+                       denv.subst("-L$BUILD_DIR/src/cart/src/gurt"))
     denv.AppendENVPath("CGO_CFLAGS", "-I%s" % cartpath, sep=" ")
 
     agentbin = install_go_bin(denv, gosrc, None, "agent", "daos_agent")
@@ -154,6 +156,8 @@ def scons():
     prereqs.require(senv, 'pmdk', 'spdk', 'ofi', 'hwloc')
 
     cgolibdirs = senv.subst("-L$BUILD_DIR/src/control/lib/spdk "
+                            "-L$BUILD_DIR/src/cart/src/gurt "
+                            "-L$BUILD_DIR/src/cart/src/cart "
                             "-L$PREFIX/lib64 -L$SPDK_PREFIX/lib "
                             "-L$HWLOC_PREFIX/lib -L$OFI_PREFIX/lib "
                             "-L$ISAL_PREFIX/lib $_RPATH")

--- a/src/control/drpc/status.go
+++ b/src/control/drpc/status.go
@@ -1,5 +1,5 @@
 //
-// (C) Copyright 2019 Intel Corporation.
+// (C) Copyright 2019-2020 Intel Corporation.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -25,130 +25,145 @@
 
 package drpc
 
-// #include <gurt/errno.h>
+import "fmt"
+
+/*
+#cgo LDFLAGS: -lgurt
+
+#include <gurt/errno.h>
+*/
 import "C"
 
 // DaosStatus is a status code in the set defined by the DAOS data plane.
 type DaosStatus int32
 
+func (ds DaosStatus) Error() string {
+	// NB: Currently, d_errstr() just returns a string of the status
+	// name, e.g. -1007 -> "DER_NOSPACE". This is better than nothing,
+	// but hopefully d_errstr() will be extended to provide better strings
+	// similar to perror().
+	dErrStr := C.GoString(C.d_errstr(C.int(ds)))
+	return fmt.Sprintf("DAOS error (%d): %s", ds, dErrStr)
+}
+
 const (
 	// DaosSuccess indicates no error
 	DaosSuccess DaosStatus = 0
 	// DaosNoPermission indicates that access to a resource was denied
-	DaosNoPermission = -C.DER_NO_PERM
+	DaosNoPermission DaosStatus = -C.DER_NO_PERM
 	// DaosNoHandle indicates the handle was invalid
-	DaosNoHandle = -C.DER_NO_HDL
+	DaosNoHandle DaosStatus = -C.DER_NO_HDL
 	// DaosInvalidInput indicates an input was invalid
-	DaosInvalidInput = -C.DER_INVAL
+	DaosInvalidInput DaosStatus = -C.DER_INVAL
 	// DaosExists indicates the entity already exists
-	DaosExists = -C.DER_EXIST
+	DaosExists DaosStatus = -C.DER_EXIST
 	// DaosNonexistant indicates the entity does not exist
-	DaosNonexistant = -C.DER_NONEXIST
+	DaosNonexistant DaosStatus = -C.DER_NONEXIST
 	// DaosUnreachable indicates a node was unreachable
-	DaosUnreachable = -C.DER_UNREACH
+	DaosUnreachable DaosStatus = -C.DER_UNREACH
 	// DaosNoSpace indicates there was not enough storage space
-	DaosNoSpace = -C.DER_NOSPACE
+	DaosNoSpace DaosStatus = -C.DER_NOSPACE
 	// DaosAlready indicates the operation was already done
-	DaosAlready = -C.DER_ALREADY
+	DaosAlready DaosStatus = -C.DER_ALREADY
 	// DaosNoMemory indicates the system ran out of memory
-	DaosNoMemory = -C.DER_NOMEM
+	DaosNoMemory DaosStatus = -C.DER_NOMEM
 	// DaosNotImpl indicates the requested functionality is not implemented
-	DaosNotImpl = -C.DER_NOSYS
+	DaosNotImpl DaosStatus = -C.DER_NOSYS
 	// DaosTimedOut indicates the operation timed out
-	DaosTimedOut = -C.DER_TIMEDOUT
+	DaosTimedOut DaosStatus = -C.DER_TIMEDOUT
 	// DaosBusy indicates the system was busy and didn't process the request
-	DaosBusy = -C.DER_BUSY
+	DaosBusy DaosStatus = -C.DER_BUSY
 	// DaosTryAgain indicates the operation failed, but should be tried again
-	DaosTryAgain = -C.DER_AGAIN
+	DaosTryAgain DaosStatus = -C.DER_AGAIN
 	// DaosProtocolError indicates incompatibility in communications protocols
-	DaosProtocolError = -C.DER_PROTO
+	DaosProtocolError DaosStatus = -C.DER_PROTO
 	// DaosNotInit indicates something in the system wasn't initialized
-	DaosNotInit = -C.DER_UNINIT
+	DaosNotInit DaosStatus = -C.DER_UNINIT
 	// DaosBufTooSmall indicates a provided buffer was too small
-	DaosBufTooSmall = -C.DER_TRUNC
+	DaosBufTooSmall DaosStatus = -C.DER_TRUNC
 	// DaosStructTooSmall indicates data could not fit in the provided structure
-	DaosStructTooSmall = -C.DER_OVERFLOW
+	DaosStructTooSmall DaosStatus = -C.DER_OVERFLOW
 	// DaosCanceled indicates the operation was canceled
-	DaosCanceled = -C.DER_CANCELED
+	DaosCanceled DaosStatus = -C.DER_CANCELED
 	// DaosOutOfGroup indicates that a rank wasn't found in the group
-	DaosOutOfGroup = -C.DER_OOG
+	DaosOutOfGroup DaosStatus = -C.DER_OOG
 	// DaosMercuryError indicates that there was an error in the Mercury transport layer
-	DaosMercuryError = -C.DER_HG
+	DaosMercuryError DaosStatus = -C.DER_HG
 	// DaosUnregistered indicates that a requested RPC was not registered
-	DaosUnregistered = -C.DER_UNREG
+	DaosUnregistered DaosStatus = -C.DER_UNREG
 	// DaosAddrStringFailed indicates that an address string couldn't be generated
-	DaosAddrStringFailed = -C.DER_ADDRSTR_GEN
+	DaosAddrStringFailed DaosStatus = -C.DER_ADDRSTR_GEN
 	// DaosPMIXError indicates an error in the PMIX layer
-	DaosPMIXError = -C.DER_PMIX
+	DaosPMIXError DaosStatus = -C.DER_PMIX
 	// DaosIVCallback indicates that the IV callback cannot be handled locally
-	DaosIVCallback = -C.DER_IVCB_FORWARD
+	DaosIVCallback DaosStatus = -C.DER_IVCB_FORWARD
 	// DaosMiscError indicates an unspecified error
-	DaosMiscError = -C.DER_MISC
+	DaosMiscError DaosStatus = -C.DER_MISC
 	// DaosBadPath indicates that a bad file or directory path was provided
-	DaosBadPath = -C.DER_BADPATH
+	DaosBadPath DaosStatus = -C.DER_BADPATH
 	// DaosNotDir indicates that the path is not to a directory
-	DaosNotDir = -C.DER_NOTDIR
+	DaosNotDir DaosStatus = -C.DER_NOTDIR
 	// DaosCorpcIncomplete indicates that corpc failed
-	DaosCorpcIncomplete = -C.DER_CORPC_INCOMPLETE
+	DaosCorpcIncomplete DaosStatus = -C.DER_CORPC_INCOMPLETE
 	// DaosNoRASRank indicates that no rank is subscribed to RAS
-	DaosNoRASRank = -C.DER_NO_RAS_RANK
+	DaosNoRASRank DaosStatus = -C.DER_NO_RAS_RANK
 	// DaosNotAttached indicates that a service group is not attached
-	DaosNotAttached = -C.DER_NOTATTACH
+	DaosNotAttached DaosStatus = -C.DER_NOTATTACH
 	// DaosMismatch indicates a version mismatch
-	DaosMismatch = -C.DER_MISMATCH
+	DaosMismatch DaosStatus = -C.DER_MISMATCH
 	// DaosEvicted indicates that the rank was evicted
-	DaosEvicted = -C.DER_EVICTED
+	DaosEvicted DaosStatus = -C.DER_EVICTED
 	// DaosNoReply indicates that there was no reply to an RPC
-	DaosNoReply = -C.DER_NOREPLY
+	DaosNoReply DaosStatus = -C.DER_NOREPLY
 	// DaosDenialOfService indicates that there was a denial of service
-	DaosDenialOfService = -C.DER_DOS
+	DaosDenialOfService DaosStatus = -C.DER_DOS
 	// DaosBadTarget indicates that the target was wrong for the RPC
-	DaosBadTarget = -C.DER_BAD_TARGET
+	DaosBadTarget DaosStatus = -C.DER_BAD_TARGET
 	// DaosGroupVersionMismatch indicates that group versions didn't match
-	DaosGroupVersionMismatch = -C.DER_GRPVER
+	DaosGroupVersionMismatch DaosStatus = -C.DER_GRPVER
 )
 
 const (
 	// DaosIOError indicates a generic IO error
 	DaosIOError DaosStatus = -C.DER_IO
 	// DaosFreeMemError indicates an error freeing memory
-	DaosFreeMemError = -C.DER_FREE_MEM
+	DaosFreeMemError DaosStatus = -C.DER_FREE_MEM
 	// DaosNoEntry indicates that the entry was not found
-	DaosNoEntry = -C.DER_ENOENT
+	DaosNoEntry DaosStatus = -C.DER_ENOENT
 	// DaosUnknownType indicates that the entity type was unknown
-	DaosUnknownType = -C.DER_NOTYPE
+	DaosUnknownType DaosStatus = -C.DER_NOTYPE
 	// DaosUnknownSchema indicates that the entity schema was unknown
-	DaosUnknownSchema = -C.DER_NOSCHEMA
+	DaosUnknownSchema DaosStatus = -C.DER_NOSCHEMA
 	// DaosNotLocal indicates that the entity was not local
-	DaosNotLocal = -C.DER_NOLOCAL
+	DaosNotLocal DaosStatus = -C.DER_NOLOCAL
 	// DaosStale indicates that a resource was stale
-	DaosStale = -C.DER_STALE
+	DaosStale DaosStatus = -C.DER_STALE
 	// DaosNotLeader indicates that the replica is not the service leader
-	DaosNotLeader = -C.DER_NOTLEADER
+	DaosNotLeader DaosStatus = -C.DER_NOTLEADER
 	// DaosTargetCreateError indicates that target creation failed
-	DaosTargetCreateError = -C.DER_TGT_CREATE
+	DaosTargetCreateError DaosStatus = -C.DER_TGT_CREATE
 	// DaosEpochReadOnly indicates that the epoch couldn't be modified
-	DaosEpochReadOnly = -C.DER_EP_RO
+	DaosEpochReadOnly DaosStatus = -C.DER_EP_RO
 	// DaosEpochRecycled indicates that the epoch was recycled due to age
-	DaosEpochRecycled = -C.DER_EP_OLD
+	DaosEpochRecycled DaosStatus = -C.DER_EP_OLD
 	// DaosKeyTooBig indicates that the key is too big
-	DaosKeyTooBig = -C.DER_KEY2BIG
+	DaosKeyTooBig DaosStatus = -C.DER_KEY2BIG
 	// DaosRecordTooBig indicates that the record is too big
-	DaosRecordTooBig = -C.DER_REC2BIG
+	DaosRecordTooBig DaosStatus = -C.DER_REC2BIG
 	// DaosIOInvalid indicates a mismatch between IO buffers and object extents
-	DaosIOInvalid = -C.DER_IO_INVAL
+	DaosIOInvalid DaosStatus = -C.DER_IO_INVAL
 	// DaosEventQueueBusy indicates that the event queue is busy
-	DaosEventQueueBusy = -C.DER_EQ_BUSY
+	DaosEventQueueBusy DaosStatus = -C.DER_EQ_BUSY
 	// DaosDomainMismatch indicates that there was a mismatch of domains in cluster components
-	DaosDomainMismatch = -C.DER_DOMAIN
+	DaosDomainMismatch DaosStatus = -C.DER_DOMAIN
 	// DaosShutdown indicates that the service should shut down
-	DaosShutdown = -C.DER_SHUTDOWN
+	DaosShutdown DaosStatus = -C.DER_SHUTDOWN
 	// DaosInProgress indicates that the operation is in progress
-	DaosInProgress = -C.DER_INPROGRESS
+	DaosInProgress DaosStatus = -C.DER_INPROGRESS
 	// DaosNotApplicable indicates that the operation is not applicable
-	DaosNotApplicable = -C.DER_NOTAPPLICABLE
+	DaosNotApplicable DaosStatus = -C.DER_NOTAPPLICABLE
 	// DaosNotReplica indicates that the requested component is not a service replica
-	DaosNotReplica = -C.DER_NOTREPLICA
+	DaosNotReplica DaosStatus = -C.DER_NOTREPLICA
 	// DaosChecksumError indicates a checksum error
-	DaosChecksumError = -C.DER_CSUM
+	DaosChecksumError DaosStatus = -C.DER_CSUM
 )

--- a/src/control/drpc/status_test.go
+++ b/src/control/drpc/status_test.go
@@ -1,0 +1,56 @@
+//
+// (C) Copyright 2020 Intel Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// GOVERNMENT LICENSE RIGHTS-OPEN SOURCE SOFTWARE
+// The Government's rights to use, modify, reproduce, release, perform, display,
+// or disclose this software are subject to the terms of the Apache License as
+// provided in Contract No. 8F-30005.
+// Any reproduction of computer software, computer software documentation, or
+// portions thereof marked with this legend must also reproduce the markings.
+//
+package drpc_test
+
+import (
+	"testing"
+
+	"github.com/pkg/errors"
+
+	"github.com/daos-stack/daos/src/control/common"
+	"github.com/daos-stack/daos/src/control/drpc"
+)
+
+func TestDrpc_Status(t *testing.T) {
+	for name, tc := range map[string]struct {
+		in     int32
+		expErr error
+	}{
+		"rc 0": {
+			expErr: drpc.DaosSuccess,
+		},
+		"-1007": {
+			in:     -1007,
+			expErr: drpc.DaosNoSpace,
+		},
+		"-424242": {
+			in:     -424242,
+			expErr: errors.New("DER_UNKNOWN"),
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			ds := drpc.DaosStatus(tc.in)
+			common.CmpErr(t, tc.expErr, ds)
+		})
+	}
+}

--- a/src/control/server/interceptors.go
+++ b/src/control/server/interceptors.go
@@ -147,7 +147,7 @@ func dErrFromStatus(sg statusGetter) error {
 		return nil
 	}
 
-	return drpc.DaosStatus(-dStatus)
+	return drpc.DaosStatus(dStatus)
 }
 
 func unaryStatusInterceptor(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (interface{}, error) {

--- a/src/control/server/interceptors.go
+++ b/src/control/server/interceptors.go
@@ -35,6 +35,7 @@ import (
 	"google.golang.org/grpc/status"
 
 	"github.com/daos-stack/daos/src/control/common/proto"
+	"github.com/daos-stack/daos/src/control/drpc"
 	"github.com/daos-stack/daos/src/control/security"
 )
 
@@ -132,4 +133,32 @@ func unaryErrorInterceptor(ctx context.Context, req interface{}, info *grpc.Unar
 func streamErrorInterceptor(srv interface{}, ss grpc.ServerStream, info *grpc.StreamServerInfo, handler grpc.StreamHandler) error {
 	err := handler(srv, ss)
 	return proto.AnnotateError(err)
+}
+
+type statusGetter interface {
+	GetStatus() int32
+}
+
+// dErrFromStatus converts a numeric DAOS return status code
+// into an error.
+func dErrFromStatus(sg statusGetter) error {
+	dStatus := sg.GetStatus()
+	if dStatus == 0 {
+		return nil
+	}
+
+	return drpc.DaosStatus(-dStatus)
+}
+
+func unaryStatusInterceptor(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (interface{}, error) {
+	res, err := handler(ctx, req)
+	if err != nil {
+		return res, err
+	}
+
+	if sg, ok := res.(statusGetter); ok {
+		return res, dErrFromStatus(sg)
+	}
+
+	return res, err
 }

--- a/src/control/server/interceptors_test.go
+++ b/src/control/server/interceptors_test.go
@@ -1,0 +1,83 @@
+//
+// (C) Copyright 2020 Intel Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// GOVERNMENT LICENSE RIGHTS-OPEN SOURCE SOFTWARE
+// The Government's rights to use, modify, reproduce, release, perform, display,
+// or disclose this software are subject to the terms of the Apache License as
+// provided in Contract No. 8F-30005.
+// Any reproduction of computer software, computer software documentation, or
+// portions thereof marked with this legend must also reproduce the markings.
+//
+
+package server
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/pkg/errors"
+
+	"github.com/daos-stack/daos/src/control/common"
+	"github.com/daos-stack/daos/src/control/drpc"
+)
+
+type testStatus struct {
+	Status int32
+}
+
+func (ts *testStatus) GetStatus() int32 {
+	return ts.Status
+}
+
+func TestServer_unaryStatusInterceptor(t *testing.T) {
+	for name, tc := range map[string]struct {
+		handlerResp interface{}
+		handlerErr  error
+		expErr      error
+	}{
+		"handler error": {
+			handlerErr: errors.New("whoops"),
+			expErr:     errors.New("whoops"),
+		},
+		"DAOS status 0": {
+			handlerResp: &testStatus{},
+		},
+		"DAOS status -1005": {
+			handlerResp: &testStatus{
+				Status: -1005,
+			},
+			expErr: drpc.DaosNonexistant,
+		},
+		"non-status resp": {
+			handlerResp: 42,
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+				return tc.handlerResp, tc.handlerErr
+			}
+			gotResp, gotErr := unaryStatusInterceptor(context.TODO(), nil, nil, handler)
+			common.CmpErr(t, tc.expErr, gotErr)
+			if tc.expErr != nil {
+				return
+			}
+
+			if diff := cmp.Diff(tc.handlerResp, gotResp); diff != "" {
+				t.Fatalf("unexpected response (-want, +got):\n%s\n", diff)
+			}
+		})
+	}
+}

--- a/src/control/server/server.go
+++ b/src/control/server/server.go
@@ -230,6 +230,7 @@ func Start(log *logging.LeveledLogger, cfg *Configuration) error {
 	// Create new grpc server, register services and start serving.
 	unaryInterceptors := []grpc.UnaryServerInterceptor{
 		unaryErrorInterceptor,
+		unaryStatusInterceptor,
 	}
 	streamInterceptors := []grpc.StreamServerInterceptor{
 		streamErrorInterceptor,


### PR DESCRIPTION
Use the d_errstr() function in libgurt to provide
somewhat-more comprehensible error messages to control
API callers. Uses a server-side gRPC interceptor to
handle the conversion before sending the response.