### PR TITLE
DAOS-4444 vos: Split timestamp cache from underlying LRU array

### DIFF
--- a/src/vos/SConscript
+++ b/src/vos/SConscript
@@ -6,7 +6,8 @@ FILES = ["evt_iter.c", "vos_common.c", "vos_iterator.c", "vos_io.c",
          "vos_pool.c", "vos_aggregate.c", "vos_container.c", "vos_obj.c",
          "vos_obj_cache.c", "vos_obj_index.c", "vos_tree.c", "evtree.c",
          "vos_dtx.c", "vos_dtx_cos.c", "vos_query.c", "vos_overhead.c",
-         "vos_dtx_iter.c", "vos_gc.c", "vos_ilog.c", "ilog.c", "vos_ts.c"]
+         "vos_dtx_iter.c", "vos_gc.c", "vos_ilog.c", "ilog.c", "vos_ts.c",
+         "lru_array.c"]
 
 def build_vos(env, standalone):
     """build vos"""

--- a/src/vos/ilog.c
+++ b/src/vos/ilog.c
@@ -630,9 +630,6 @@ ilog_destroy(struct umem_instance *umm,
 fail:
 	rc = ilog_tx_end(&lctx, rc);
 
-	if (rc == 0)
-		vos_ts_evict(&lctx.ic_root->lr_ts_idx);
-
 	return rc;
 }
 

--- a/src/vos/lru_array.c
+++ b/src/vos/lru_array.c
@@ -1,0 +1,175 @@
+/**
+ * (C) Copyright 2020 Intel Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * GOVERNMENT LICENSE RIGHTS-OPEN SOURCE SOFTWARE
+ * The Government's rights to use, modify, reproduce, release, perform, display,
+ * or disclose this software are subject to the terms of the Apache License as
+ * provided in Contract No. B609815.
+ * Any reproduction of computer software, computer software documentation, or
+ * portions thereof marked with this legend must also reproduce the markings.
+ */
+/**
+ * LRU array implementation
+ * vos/lru_array.c
+ *
+ * Author: Jeff Olivier <jeffrey.v.olivier@intel.com>
+ */
+#include "lru_array.h"
+
+static void
+evict_cb(struct lru_array *array, struct lru_entry *entry, uint32_t idx)
+{
+	if (array->la_cbs.lru_on_evict == NULL)
+		return;
+
+	array->la_cbs.lru_on_evict(entry->le_payload, idx, array->la_arg);
+}
+
+static void
+init_cb(struct lru_array *array, struct lru_entry *entry, uint32_t idx)
+{
+	if (array->la_cbs.lru_on_init == NULL)
+		return;
+
+	array->la_cbs.lru_on_init(entry->le_payload, idx, array->la_arg);
+}
+
+static void
+fini_cb(struct lru_array *array, struct lru_entry *entry, uint32_t idx)
+{
+	if (array->la_cbs.lru_on_fini == NULL)
+		return;
+
+	array->la_cbs.lru_on_fini(entry->le_payload, idx, array->la_arg);
+}
+
+void
+lrua_evict_lru(struct lru_array *array, struct lru_entry **entryp,
+	       uint32_t *idx, bool evict_lru)
+{
+	struct lru_entry	*entry;
+
+	*entryp = NULL;
+
+	entry = &array->la_table[array->la_lru];
+
+	if (entry->le_record_idx != NULL) {
+		if (!evict_lru)
+			return; /* Caller has not set eviction flag */
+
+		evict_cb(array, entry, array->la_lru);
+	}
+
+	*idx = array->la_lru;
+	entry->le_record_idx = idx;
+	array->la_lru = entry->le_next_idx;
+	array->la_mru = *idx;
+
+	*entryp = entry;
+}
+
+void
+lrua_evict(struct lru_array *array, uint32_t *idx)
+{
+	struct lru_entry	*entry;
+	uint32_t		 tidx;
+
+	D_ASSERT(array != NULL);
+	D_ASSERT(idx != NULL && *idx < array->la_count);
+	tidx = *idx;
+
+	entry = &array->la_table[tidx];
+	if (idx != entry->le_record_idx)
+		return;
+
+	evict_cb(array, entry, tidx);
+
+	entry->le_record_idx = NULL;
+
+	if (array->la_mru == tidx)
+		array->la_mru = entry->le_prev_idx;
+
+	if (array->la_lru == tidx)
+		return;
+
+	/** Remove from current location */
+	lrua_remove_entry(&array->la_table[0], entry);
+
+	/** Add at the LRU */
+	lrua_insert_entry(&array->la_table[0], entry, tidx, array->la_mru,
+			  array->la_lru);
+
+	array->la_lru = tidx;
+}
+
+int
+lrua_array_alloc(struct lru_array **arrayp, uint32_t nr_ent,
+		 uint32_t record_size, const struct lru_callbacks *cbs,
+		 void *arg)
+{
+	struct lru_array	*array;
+	struct lru_entry	*current;
+	uint32_t		 aligned_size;
+	uint32_t		 cur_idx;
+	uint32_t		 next_idx;
+	uint32_t		 prev_idx;
+
+	aligned_size = (record_size + 7) & ~7;
+
+	*arrayp = NULL;
+
+	D_ALLOC(array, sizeof(*array) +
+		(sizeof(array->la_table[0]) + aligned_size) * nr_ent);
+	if (array == NULL)
+		return -DER_NOMEM;
+
+	prev_idx = array->la_mru = nr_ent - 1;
+	array->la_arg = arg;
+	array->la_lru = 0;
+	array->la_count = nr_ent;
+	array->la_record_size = aligned_size;
+	array->la_payload = &array->la_table[nr_ent];
+	if (cbs != NULL)
+		array->la_cbs = *cbs;
+	cur_idx = 0;
+	for (cur_idx = 0; cur_idx < nr_ent; cur_idx++) {
+		next_idx = (cur_idx + 1) % nr_ent;
+		current = &array->la_table[cur_idx];
+		current->le_payload = array->la_payload +
+			(aligned_size * cur_idx);
+		current->le_next_idx = next_idx;
+		current->le_prev_idx = prev_idx;
+		prev_idx = cur_idx;
+		init_cb(array, current, cur_idx);
+	}
+
+	*arrayp = array;
+
+	return 0;
+}
+
+void
+lrua_array_free(struct lru_array *array)
+{
+	int	i;
+
+	if (array == NULL)
+		return;
+
+	for (i = 0; i < array->la_count; i++)
+		fini_cb(array, &array->la_table[i], i);
+
+	D_FREE(array);
+}

--- a/src/vos/lru_array.h
+++ b/src/vos/lru_array.h
@@ -1,0 +1,235 @@
+/**
+ * (C) Copyright 2020 Intel Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * GOVERNMENT LICENSE RIGHTS-OPEN SOURCE SOFTWARE
+ * The Government's rights to use, modify, reproduce, release, perform, display,
+ * or disclose this software are subject to the terms of the Apache License as
+ * provided in Contract No. B609815.
+ * Any reproduction of computer software, computer software documentation, or
+ * portions thereof marked with this legend must also reproduce the markings.
+ */
+/**
+ * Generic struct for allocating LRU entries in an array
+ * common/lru_array.h
+ *
+ * Author: Jeff Olivier <jeffrey.v.olivier@intel.com>
+ */
+
+#ifndef __LRU_ARRAY__
+#define __LRU_ARRAY__
+
+#include <daos/common.h>
+
+struct lru_callbacks {
+	/** Called when an entry is going to be evicted from cache */
+	void	(*lru_on_evict)(void *entry, uint32_t idx, void *arg);
+	/** Called on initialization of an entry */
+	void	(*lru_on_init)(void *entry, uint32_t idx, void *arg);
+	/** Called on finalization of an entry */
+	void	(*lru_on_fini)(void *entry, uint32_t idx, void *arg);
+};
+
+struct lru_entry {
+	/** The pointer to the index is unique identifier for the entry */
+	uint32_t	*le_record_idx;
+	/** Pointer to this entry */
+	void		*le_payload;
+	/** Next index in LRU array */
+	uint32_t	 le_next_idx;
+	/** Previous index in LRU array */
+	uint32_t	 le_prev_idx;
+};
+
+struct lru_array {
+	/** Least recently accessed index */
+	uint32_t		la_lru;
+	/** Most recently accessed index */
+	uint32_t		la_mru;
+	/** Number of indices */
+	uint32_t		la_count;
+	/** record size */
+	uint32_t		la_record_size;
+	/** Allocated payload entries */
+	void			*la_payload;
+	/** Callbacks for implementation */
+	struct lru_callbacks	 la_cbs;
+	/** User callback argument passed on init */
+	void			*la_arg;
+	/** Entries in the array */
+	struct lru_entry	 la_table[0];
+};
+
+/** Internal API: Evict the LRU, move it to MRU, invoke eviction callback,
+ *  and return the index
+ */
+void
+lrua_evict_lru(struct lru_array *array, struct lru_entry **entry,
+	       uint32_t *idx, bool evict_lru);
+
+/** Internal API: Remove an entry from the lru list */
+static inline void
+lrua_remove_entry(struct lru_entry *entries, struct lru_entry *entry)
+{
+	struct lru_entry	*prev = &entries[entry->le_prev_idx];
+	struct lru_entry	*next = &entries[entry->le_next_idx];
+
+	prev->le_next_idx = entry->le_next_idx;
+	next->le_prev_idx = entry->le_prev_idx;
+}
+
+/** Internal API: Insert an entry in the lru list */
+static inline void
+lrua_insert_entry(struct lru_entry *entries, struct lru_entry *entry,
+		  uint32_t idx, uint32_t prev_idx, uint32_t next_idx)
+{
+	struct lru_entry	*prev;
+	struct lru_entry	*next;
+
+	prev = &entries[prev_idx];
+	next = &entries[next_idx];
+	next->le_prev_idx = idx;
+	prev->le_next_idx = idx;
+	entry->le_prev_idx = prev_idx;
+	entry->le_next_idx = next_idx;
+}
+
+/** Internal API: Make the entry the mru */
+static inline void
+lrua_move_to_mru(struct lru_array *array, struct lru_entry *entry, uint32_t idx)
+{
+	if (array->la_mru == idx) {
+		/** Already the mru */
+		return;
+	}
+
+	if (array->la_lru == idx)
+		array->la_lru = entry->le_next_idx;
+
+	/** First remove */
+	lrua_remove_entry(&array->la_table[0], entry);
+
+	/** Now add */
+	lrua_insert_entry(&array->la_table[0], entry, idx,
+			  array->la_mru, array->la_lru);
+
+	array->la_mru = idx;
+}
+
+/** Internal API to lookup entry from index */
+static inline struct lru_entry *
+lrua_lookup_idx(struct lru_array *array, const uint32_t *idx)
+{
+	struct lru_entry	*entry;
+	uint32_t		 tindex = *idx;
+
+	if (tindex >= array->la_count)
+		return NULL;
+
+	entry = &array->la_table[tindex];
+	if (entry->le_record_idx == idx) {
+		lrua_move_to_mru(array, entry, tindex);
+		return entry;
+	}
+
+	return NULL;
+}
+
+/** Lookup an entry in the lru array.
+ *
+ * \param	array[in]	The lru array
+ * \param	idx[in,out]	Address of the record index.
+ * \param	entryp[in,out]	Valid only if function returns true.
+ *
+ * \return true if the entry is in the array and set \p entryp accordingly
+ */
+static inline bool
+lrua_lookup(struct lru_array *array, const uint32_t *idx,
+	    void **entryp)
+{
+	struct lru_entry	*entry;
+
+	D_ASSERT(array != NULL);
+
+	*entryp = NULL;
+
+	entry = lrua_lookup_idx(array, idx);
+	if (entry == NULL)
+		return false;
+
+	*entryp = entry->le_payload;
+	return true;
+}
+
+/** Allocate a new entry lru array.   Lookup should be called first and this
+ * should only be called if it returns false.  This will modify idx.  If
+ * called within a transaction and the value needs to persist, the old value
+ * should be logged before calling this function.
+ *
+ * \param	array[in]	The LRU array
+ * \param	idx[in,out]	Address of the entry index.
+ * \param	evict_lru[in]	True if LRU should be evicted
+ *
+ * \return	Returns a pointer to the entry or NULL if evict_lru is false
+ *		and the entry at the LRU is allocated
+ */
+static inline void *
+lrua_alloc(struct lru_array *array, uint32_t *idx, bool evict_lru)
+{
+	struct lru_entry	*new_entry;
+
+	D_ASSERT(array != NULL);
+
+	lrua_evict_lru(array, &new_entry, idx, evict_lru);
+
+	if (new_entry == NULL)
+		return NULL;
+
+	return new_entry->le_payload;
+}
+
+/** If an entry is still in the array, evict it and invoke eviction callback.
+ *  Move the evicted entry to the LRU and mark it as already evicted.
+ *
+ * \param	array[in]	Address of the LRU array.
+ * \param	idx[in]		Address of the entry index.
+ */
+void
+lrua_evict(struct lru_array *array, uint32_t *idx);
+
+/** Allocate an LRU array
+ *
+ * \param	array[in,out]	Pointer to LRU array
+ * \param	nr_ent[in]	Number of records in array
+ * \param	rec_size[in]	Size of each record
+ * \param	cbs[in]		Optional callbacks
+ * \param	arg[in]		Optional argument passed to all callbacks
+ *
+ * \return	-DER_NOMEM	Not enough memory available
+ *		0		Success
+ */
+int
+lrua_array_alloc(struct lru_array **array, uint32_t nr_ent,
+		 uint32_t record_size, const struct lru_callbacks *cbs,
+		 void *arg);
+
+
+/** Free an LRU array
+ *
+ * \param	array[in]	Pointer to LRU array
+ */
+void
+lrua_array_free(struct lru_array *array);
+
+#endif /* __LRU_ARRAY__ */

--- a/src/vos/tests/vts_ts.c
+++ b/src/vos/tests/vts_ts.c
@@ -34,11 +34,12 @@
 #include <vos_internal.h>
 #include <vos_ts.h>
 
+#define VOS_TS_SIZE (8 * 1024 * 1024)
+
 #define NUM_EXTRA	4
 struct ts_test_arg {
-	uint32_t		*ta_records[VOS_TS_TYPE_COUNT];
+	uint32_t		 ta_records[VOS_TS_TYPE_COUNT][VOS_TS_SIZE];
 	struct vos_ts_set	*ta_ts_set;
-	uint32_t		 ta_real_records[VOS_TS_SIZE];
 	uint32_t		 ta_counts[VOS_TS_TYPE_COUNT];
 	uint32_t		 ta_extra_records[NUM_EXTRA];
 };
@@ -169,7 +170,7 @@ run_positive_entry_test(struct ts_test_arg *ts_arg, uint32_t type)
 
 	/** Now evict the extra records to reset the array for child tests */
 	for (idx = 0; idx < NUM_EXTRA; idx++)
-		vos_ts_evict(&ts_arg->ta_extra_records[idx]);
+		vos_ts_evict(&ts_arg->ta_extra_records[idx], type);
 
 	/** evicting an entry should move it to lru */
 	vos_ts_set_reset(ts_arg->ta_ts_set, type, 0);
@@ -177,7 +178,7 @@ run_positive_entry_test(struct ts_test_arg *ts_arg, uint32_t type)
 			      false, &same);
 	assert_true(found);
 	assert_int_equal(same->te_info->ti_type, type);
-	vos_ts_evict(&ts_arg->ta_records[type][20]);
+	vos_ts_evict(&ts_arg->ta_records[type][20], type);
 	found = vos_ts_lookup(ts_arg->ta_ts_set, &ts_arg->ta_records[type][20],
 			      true, &entry);
 	assert_false(found);
@@ -221,7 +222,7 @@ ilog_test_ts_get(void **state)
 	}
 
 	for (type = VOS_TS_TYPE_AKEY;; type -= 2) {
-		vos_ts_evict(&ts_arg->ta_records[type][0]);
+		vos_ts_evict(&ts_arg->ta_records[type][0], type);
 		found = vos_ts_lookup(ts_arg->ta_ts_set,
 				      &ts_arg->ta_records[type][0], true,
 				      &entry);
@@ -261,9 +262,186 @@ alloc_ts_cache(void **state)
 	return 0;
 }
 
+struct index_record {
+	uint32_t idx;
+	uint32_t value;
+};
+
+#define LRU_ARRAY_SIZE	32
+#define NUM_INDEXES	128
+struct lru_arg {
+	struct lru_array	*array;
+	struct index_record	 indexes[NUM_INDEXES];
+};
+
+struct lru_record {
+	uint64_t		 magic1;
+	struct index_record	*record;
+	uint32_t		 idx;
+	uint32_t		 custom;
+	uint64_t		 magic2;
+};
+
+#define MAGIC1	0xdeadbeef
+#define MAGIC2	0xbaadf00d
+
+static void
+on_entry_evict(void *payload, uint32_t idx, void *arg)
+{
+	struct lru_record	*record = payload;
+
+	record->record->value = 0xdeadbeef;
+}
+
+static void
+on_entry_init(void *payload, uint32_t idx, void *arg)
+{
+	struct lru_record	*record = payload;
+
+	record->idx = idx;
+	record->magic1 = MAGIC1;
+	record->magic2 = MAGIC2;
+}
+
+static void
+on_entry_fini(void *payload, uint32_t idx, void *arg)
+{
+	struct lru_record	*record = payload;
+
+	if (record->record)
+		record->record->value = 0xdeadbeef;
+}
+
+static const struct lru_callbacks lru_cbs = {
+	.lru_on_evict	= on_entry_evict,
+	.lru_on_init	= on_entry_init,
+	.lru_on_fini	= on_entry_fini,
+};
+
+static void
+lru_array_test(void **state)
+{
+	struct lru_arg		*ts_arg = *state;
+	struct lru_record	*entry;
+	int			 i;
+	bool			 found;
+	int			 lru_idx;
+
+
+	for (i = 0; i < NUM_INDEXES; i++) {
+		found = lrua_lookup(ts_arg->array, &ts_arg->indexes[i].idx,
+				    (void **)&entry);
+		assert_false(found);
+	}
+
+	for (i = 0; i < NUM_INDEXES; i++) {
+		entry = lrua_alloc(ts_arg->array, &ts_arg->indexes[i].idx,
+				   true);
+		assert_non_null(entry);
+
+		entry->record = &ts_arg->indexes[i];
+		ts_arg->indexes[i].value = i;
+	}
+
+	for (i = NUM_INDEXES - 1; i >= 0; i--) {
+		found = lrua_lookup(ts_arg->array, &ts_arg->indexes[i].idx,
+				    (void **)&entry);
+		if (found) {
+			assert_true(i >= (NUM_INDEXES - LRU_ARRAY_SIZE));
+			assert_non_null(entry);
+			assert_true(entry->magic1 == MAGIC1);
+			assert_true(entry->magic2 == MAGIC2);
+			assert_true(i == ts_arg->indexes[i].value);
+			assert_true(entry->idx == ts_arg->indexes[i].idx);
+		} else {
+			assert_false(i >= (NUM_INDEXES - LRU_ARRAY_SIZE));
+			assert_null(entry);
+			assert_true(ts_arg->indexes[i].value == 0xdeadbeef);
+		}
+	}
+
+	lru_idx = NUM_INDEXES - 3;
+	found = lrua_lookup(ts_arg->array,
+			    &ts_arg->indexes[lru_idx].idx, (void **)&entry);
+	assert_true(found);
+	assert_non_null(entry);
+	assert_true(entry->record->value == lru_idx);
+
+	/* cache all but one new entry */
+	for (i = 0; i <  LRU_ARRAY_SIZE - 1; i++) {
+		found = lrua_lookup(ts_arg->array, &ts_arg->indexes[i].idx,
+				    (void **)&entry);
+		assert_false(found);
+		entry = lrua_alloc(ts_arg->array, &ts_arg->indexes[i].idx,
+				   true);
+		assert_non_null(entry);
+
+		entry->record = &ts_arg->indexes[i];
+		ts_arg->indexes[i].value = i;
+
+		found = lrua_lookup(ts_arg->array, &ts_arg->indexes[i].idx,
+				    (void *)&entry);
+		assert_non_null(entry);
+		assert_true(entry->magic1 == MAGIC1);
+		assert_true(entry->magic2 == MAGIC2);
+		assert_true(i == ts_arg->indexes[i].value);
+		assert_true(entry->idx == ts_arg->indexes[i].idx);
+	}
+
+	/** lru_idx should still be there */
+	found = lrua_lookup(ts_arg->array,
+			    &ts_arg->indexes[lru_idx].idx, (void *)&entry);
+	assert_true(found);
+	assert_non_null(entry);
+	assert_true(entry->record->value == lru_idx);
+
+	lrua_evict(ts_arg->array, &ts_arg->indexes[lru_idx].idx);
+
+	found = lrua_lookup(ts_arg->array,
+			    &ts_arg->indexes[lru_idx].idx, (void *)&entry);
+	assert_false(found);
+}
+
+static int
+init_lru_test(void **state)
+{
+	struct lru_arg		*ts_arg;
+	int			 rc;
+
+	D_ALLOC_PTR(ts_arg);
+	if (ts_arg == NULL)
+		return 1;
+
+	rc = lrua_array_alloc(&ts_arg->array, LRU_ARRAY_SIZE,
+			      sizeof(struct lru_record), &lru_cbs,
+			      ts_arg);
+
+	*state = ts_arg;
+	return rc;
+}
+
+static int
+finalize_lru_test(void **state)
+{
+	struct lru_arg		*ts_arg = *state;
+
+	if (ts_arg == NULL)
+		return 0;
+
+	if (ts_arg->array == NULL)
+		return 0;
+
+	lrua_array_free(ts_arg->array);
+
+	return 0;
+}
+
+
 static const struct CMUnitTest ts_tests[] = {
 	{ "VOS600.1: VOS timestamp allocation test", ilog_test_ts_get,
 		alloc_ts_cache, NULL},
+	{ "VOS600.2: LRU array test", lru_array_test, init_lru_test,
+		finalize_lru_test},
 };
 
 static int
@@ -272,7 +450,6 @@ ts_test_init(void **state)
 	int			 i;
 	struct vos_ts_table	*ts_table;
 	struct ts_test_arg	*ts_arg;
-	uint32_t		*cursor;
 	int			 rc;
 
 	D_ALLOC_PTR(ts_arg);
@@ -285,12 +462,8 @@ ts_test_init(void **state)
 
 	ts_table = vos_ts_table_get();
 
-	cursor = &ts_arg->ta_real_records[0];
-	for (i = 0; i < VOS_TS_TYPE_COUNT; i++) {
+	for (i = 0; i < VOS_TS_TYPE_COUNT; i++)
 		ts_arg->ta_counts[i] = ts_table->tt_type_info[i].ti_count;
-		ts_arg->ta_records[i] = cursor;
-		cursor += ts_arg->ta_counts[i];
-	}
 
 	rc = vos_ts_set_allocate(&ts_arg->ta_ts_set, VOS_OF_USE_TIMESTAMPS, 1);
 	if (rc != 0) {

--- a/src/vos/vos_container.c
+++ b/src/vos/vos_container.c
@@ -77,7 +77,7 @@ cont_df_rec_free(struct btr_instance *tins, struct btr_record *rec, void *args)
 		return -DER_NONEXIST;
 
 	cont_df = umem_off2ptr(&tins->ti_umm, rec->rec_off);
-	vos_ts_evict(&cont_df->cd_ts_idx);
+	vos_ts_evict(&cont_df->cd_ts_idx, VOS_TS_TYPE_CONT);
 
 	return gc_add_item(tins->ti_priv, GC_CONT, rec->rec_off, 0);
 }

--- a/src/vos/vos_ilog.c
+++ b/src/vos/vos_ilog.c
@@ -520,11 +520,11 @@ vos_ilog_ts_mark(struct vos_ts_set *ts_set, struct ilog_df *ilog)
 }
 
 void
-vos_ilog_ts_evict(struct ilog_df *ilog)
+vos_ilog_ts_evict(struct ilog_df *ilog, uint32_t type)
 {
 	uint32_t	*idx;
 
 	idx = ilog_ts_idx_get(ilog);
 
-	return vos_ts_evict(idx);
+	return vos_ts_evict(idx, type);
 }

--- a/src/vos/vos_ilog.h
+++ b/src/vos/vos_ilog.h
@@ -311,8 +311,9 @@ vos_ilog_ts_mark(struct vos_ts_set *ts_set, struct ilog_df *ilog);
 /** Evict the cached timestamp entry, if present
  *
  *  \param	ilog[in]	The incarnation log
+ *  \param	type[in]	The timestamp type
  */
 void
-vos_ilog_ts_evict(struct ilog_df *ilog);
+vos_ilog_ts_evict(struct ilog_df *ilog, uint32_t type);
 
 #endif /* __VOS_ILOG_H__ */

--- a/src/vos/vos_obj_index.c
+++ b/src/vos/vos_obj_index.c
@@ -145,6 +145,8 @@ oi_rec_free(struct btr_instance *tins, struct btr_record *rec, void *args)
 		return rc;
 	}
 
+	vos_ilog_ts_evict(&obj->vo_ilog, VOS_TS_TYPE_OBJ);
+
 	D_ASSERT(tins->ti_priv);
 	return gc_add_item((struct vos_pool *)tins->ti_priv, GC_OBJ,
 			   rec->rec_off, 0);

--- a/src/vos/vos_tree.c
+++ b/src/vos/vos_tree.c
@@ -361,6 +361,9 @@ ktr_rec_free(struct btr_instance *tins, struct btr_record *rec, void *args)
 	if (rc != 0)
 		return rc;
 
+	vos_ilog_ts_evict(&krec->kr_ilog, (krec->kr_bmap & KREC_BF_DKEY) ?
+			  VOS_TS_TYPE_DKEY : VOS_TS_TYPE_AKEY);
+
 	D_ASSERT(tins->ti_priv);
 	gc = (krec->kr_bmap & KREC_BF_DKEY) ? GC_DKEY : GC_AKEY;
 	return gc_add_item((struct vos_pool *)tins->ti_priv, gc,

--- a/src/vos/vos_ts.c
+++ b/src/vos/vos_ts.c
@@ -30,14 +30,14 @@
 
 #include "vos_internal.h"
 
-#define DEFINE_TS_STR(type, desc, count, child_count)	desc, desc "_nochild",
+#define DEFINE_TS_STR(type, desc, count)	desc,
 
 /** Strings corresponding to timestamp types */
 static const char * const type_strs[] = {
 	D_FOREACH_TS_TYPE(DEFINE_TS_STR)
 };
 
-#define DEFINE_TS_COUNT(type, desc, count, child_count)	count, child_count,
+#define DEFINE_TS_COUNT(type, desc, count)	count,
 static const uint32_t type_counts[] = {
 	D_FOREACH_TS_TYPE(DEFINE_TS_COUNT)
 };
@@ -46,110 +46,11 @@ static const uint32_t type_counts[] = {
 #define DKEY_MISS_SIZE (1 << 5)
 #define AKEY_MISS_SIZE (1 << 4)
 
-int
-vos_ts_table_alloc(struct vos_ts_table **ts_tablep)
-{
-	struct vos_ts_table	*ts_table;
-	struct vos_ts_info	*info;
-	struct vos_ts_entry	*current;
-	uint32_t		 sofar = 0;
-	uint32_t		 cur_idx;
-	uint32_t		 next_idx;
-	uint32_t		 prev_idx;
-	uint32_t		 i, count, offset;
-	uint32_t		 miss_size;
-	uint32_t		*misses;
-	uint32_t		*miss_cursor;
-
-	*ts_tablep = NULL;
-
-	D_ALLOC_PTR(ts_table);
-	if (ts_table == NULL)
-		return -DER_NOMEM;
-
-	D_ALLOC_ARRAY(misses, (type_counts[VOS_TS_TYPE_CONT] * OBJ_MISS_SIZE) +
-			      (type_counts[VOS_TS_TYPE_OBJ] * DKEY_MISS_SIZE) +
-			      (type_counts[VOS_TS_TYPE_DKEY] * AKEY_MISS_SIZE));
-	if (misses == NULL) {
-		D_FREE(ts_table);
-		return -DER_NOMEM;
-	}
-
-	ts_table->tt_ts_rl = vos_start_epoch;
-	ts_table->tt_ts_rh = vos_start_epoch;
-	ts_table->tt_ts_w = vos_start_epoch;
-	miss_cursor = misses;
-	cur_idx = 0;
-	for (i = 0; i < VOS_TS_TYPE_COUNT; i++) {
-		info = &ts_table->tt_type_info[i];
-		count = type_counts[i];
-
-		if (count == 0) {
-			D_ASSERT(i == VOS_TS_TYPE_AKEY);
-			count = VOS_TS_SIZE - sofar;
-			/** More akeys than missing akeys */
-			D_ASSERT(count > type_counts[VOS_TS_TYPE_DKEY_CHILD]);
-			/** Make sure it doesn't overflow */
-			D_ASSERT(count < VOS_TS_SIZE);
-		} else {
-			sofar += count;
-		}
-
-		info->ti_count = count;
-		info->ti_type = i;
-
-		offset = cur_idx;
-		switch (i) {
-		case VOS_TS_TYPE_CONT:
-			miss_size = OBJ_MISS_SIZE;
-			break;
-		case VOS_TS_TYPE_OBJ:
-			miss_size = DKEY_MISS_SIZE;
-			break;
-		case VOS_TS_TYPE_DKEY:
-			miss_size = AKEY_MISS_SIZE;
-			break;
-		case VOS_TS_TYPE_AKEY:
-		default:
-			miss_size = 0;
-			break;
-		}
-
-		if (miss_size != 0)
-			info->ti_cache_mask = miss_size - 1;
-		info->ti_lru = cur_idx;
-		prev_idx = info->ti_mru = offset + count - 1;
-		while (cur_idx < (offset + count)) {
-			next_idx = offset + ((cur_idx + 1 - offset) % count);
-			current = &ts_table->tt_table[cur_idx];
-			current->te_info = info;
-			current->te_next_idx = next_idx;
-			current->te_prev_idx = prev_idx;
-			prev_idx = cur_idx;
-			cur_idx++;
-			if (miss_size == 0)
-				continue;
-			current->te_miss_idx = miss_cursor;
-			miss_cursor += miss_size;
-		}
-	}
-
-	*ts_tablep = ts_table;
-
-	return 0;
-}
-
-void
-vos_ts_table_free(struct vos_ts_table **ts_tablep)
-{
-	struct vos_ts_table	*ts_table = *ts_tablep;
-
-	/** entry 0 points to start of allocated space */
-	D_FREE(ts_table->tt_table[0].te_miss_idx);
-	D_FREE(ts_table);
-
-	*ts_tablep = NULL;
-}
+#define TS_TRACE(action, entry, idx, type)				\
+	D_DEBUG(DB_TRACE, "%s %s at idx %d(%p), read.hi="DF_U64		\
+		" read.lo="DF_U64" write="DF_U64"\n", action,		\
+		type_strs[type], idx, (entry)->te_record_ptr,		\
+		(entry)->te_ts_rh, (entry)->te_ts_rl, (entry)->te_ts_w)
 
 /** This probably needs more thought */
 static bool
@@ -158,18 +59,27 @@ ts_update_on_evict(struct vos_ts_table *ts_table, struct vos_ts_entry *entry)
 	struct vos_ts_entry	*parent = NULL;
 	struct vos_ts_entry	*other = NULL;
 	struct vos_ts_info	*info = entry->te_info;
+	struct vos_ts_info	*parent_info;
+	struct vos_ts_info	*neg_info = NULL;
 	uint32_t		*idx;
 
 	if (entry->te_record_ptr == NULL)
 		return false;
 
 	if (entry->te_parent_ptr != NULL) {
-		parent = vos_ts_lookup_idx(ts_table, entry->te_parent_ptr);
 		if (info->ti_type & 1) { /* negative entry */
+			parent_info = info - 1;
+		} else {
+			parent_info = info - 2;
+			neg_info = info - 1;
+		}
+		lrua_lookup(parent_info->ti_array, entry->te_parent_ptr,
+			    (void **)&parent);
+		if (neg_info == NULL) {
 			other = parent;
 		} else if (parent != NULL) {
 			idx = &parent->te_miss_idx[entry->te_hash_idx];
-			other = vos_ts_lookup_idx(ts_table, idx);
+			lrua_lookup(neg_info->ti_array, idx, (void **)&other);
 		}
 	}
 
@@ -187,47 +97,11 @@ ts_update_on_evict(struct vos_ts_table *ts_table, struct vos_ts_entry *entry)
 	return true;
 }
 
-#define TS_TRACE(action, entry, idx, type)				\
-	D_DEBUG(DB_TRACE, "%s %s at idx %d(%p), read.hi="DF_U64		\
-		" read.lo="DF_U64" write="DF_U64"\n", action,		\
-		type_strs[type], idx, (entry)->te_record_ptr,		\
-		(entry)->te_ts_rh, (entry)->te_ts_rl, (entry)->te_ts_w)
-
 static inline void
-evict_one(struct vos_ts_table *ts_table, struct vos_ts_entry *entry,
-	  uint32_t idx, struct vos_ts_info *info, bool removed)
+evict_children(struct vos_ts_info *info, struct vos_ts_entry *entry)
 {
-	if (ts_update_on_evict(ts_table, entry)) {
-		TS_TRACE("Evicted", entry, idx, info->ti_type);
-		entry->te_record_ptr = NULL;
-	}
-
-	if (removed)
-		return;
-
-	if (info->ti_mru == idx)
-		info->ti_mru = entry->te_prev_idx;
-
-	if (info->ti_lru == idx)
-		return;
-
-	/** Remove the entry from it's current location */
-	remove_ts_entry(&ts_table->tt_table[0], entry);
-
-	/** insert the entry at the LRU */
-	insert_ts_entry(&ts_table->tt_table[0], entry, idx, info->ti_mru,
-			info->ti_lru);
-
-	info->ti_lru = idx;
-}
-
-static inline void
-evict_children(struct vos_ts_table *ts_table, struct vos_ts_info *info,
-	       struct vos_ts_entry *entry)
-{
-	struct vos_ts_entry	*child;
 	int			 i;
-	uint32_t		 idx;
+	uint32_t		*idx;
 	uint32_t		 cache_num;
 
 	info = entry->te_info;
@@ -239,13 +113,136 @@ evict_children(struct vos_ts_table *ts_table, struct vos_ts_info *info,
 	info++;
 	for (i = 0; i < cache_num; i++) {
 		/* Also evict the children, if present */
-		idx = entry->te_miss_idx[i] & VOS_TS_MASK;
-		child = &ts_table->tt_table[idx];
-		if (child->te_record_ptr != &entry->te_miss_idx[i])
-			continue;
-
-		evict_one(ts_table, child, idx, info, false);
+		idx = &entry->te_miss_idx[i];
+		lrua_evict(info->ti_array, idx);
 	}
+}
+
+
+static void evict_entry(void *payload, uint32_t idx, void *arg)
+{
+	struct vos_ts_info	*info = arg;
+	struct vos_ts_entry	*entry = payload;
+
+	evict_children(info, entry);
+
+	if (ts_update_on_evict(info->ti_table, entry)) {
+		TS_TRACE("Evicted", entry, idx, info->ti_type);
+		entry->te_record_ptr = NULL;
+	}
+}
+
+static void init_entry(void *payload, uint32_t idx, void *arg)
+{
+	struct vos_ts_info	*info = arg;
+	struct vos_ts_entry	*entry = payload;
+	uint32_t		 count;
+
+	entry->te_info = info;
+	if (info->ti_misses) {
+		D_ASSERT((info->ti_type & 1) == 0 &&
+			 info->ti_type != VOS_TS_TYPE_AKEY &&
+			 info->ti_cache_mask != 0);
+		count = info->ti_cache_mask + 1;
+		entry->te_miss_idx = &info->ti_misses[idx * count];
+	}
+}
+
+static const struct lru_callbacks lru_cbs = {
+	.lru_on_evict = evict_entry,
+	.lru_on_init = init_entry,
+};
+
+int
+vos_ts_table_alloc(struct vos_ts_table **ts_tablep)
+{
+	struct vos_ts_table	*ts_table;
+	struct vos_ts_info	*info;
+	int			 rc;
+	uint32_t		 i;
+	uint32_t		 miss_size;
+	uint32_t		*miss_cursor;
+
+	*ts_tablep = NULL;
+
+	D_ALLOC_PTR(ts_table);
+	if (ts_table == NULL)
+		return -DER_NOMEM;
+
+	D_ALLOC_ARRAY(ts_table->tt_misses,
+		      (type_counts[VOS_TS_TYPE_CONT] * OBJ_MISS_SIZE) +
+		      (type_counts[VOS_TS_TYPE_OBJ] * DKEY_MISS_SIZE) +
+		      (type_counts[VOS_TS_TYPE_DKEY] * AKEY_MISS_SIZE));
+	if (ts_table->tt_misses == NULL) {
+		rc = -DER_NOMEM;
+		goto free_table;
+	}
+
+	ts_table->tt_ts_rl = vos_start_epoch;
+	ts_table->tt_ts_rh = vos_start_epoch;
+	ts_table->tt_ts_w = vos_start_epoch;
+	miss_cursor = ts_table->tt_misses;
+	for (i = 0; i < VOS_TS_TYPE_COUNT; i++) {
+		info = &ts_table->tt_type_info[i];
+
+		info->ti_type = i;
+		info->ti_count = type_counts[i];
+		info->ti_table = ts_table;
+		switch (i) {
+		case VOS_TS_TYPE_CONT:
+			miss_size = OBJ_MISS_SIZE;
+			break;
+		case VOS_TS_TYPE_OBJ:
+			miss_size = DKEY_MISS_SIZE;
+			break;
+		case VOS_TS_TYPE_DKEY:
+			miss_size = AKEY_MISS_SIZE;
+			break;
+		case VOS_TS_TYPE_AKEY:
+		default:
+			miss_size = 0;
+			break;
+		}
+		if (miss_size) {
+			info->ti_cache_mask = miss_size - 1;
+			info->ti_misses = miss_cursor;
+			miss_cursor += info->ti_count * miss_size;
+		}
+
+		rc = lrua_array_alloc(&info->ti_array, info->ti_count,
+				      sizeof(struct vos_ts_entry), &lru_cbs,
+				      info);
+		if (rc != 0)
+			goto cleanup;
+	}
+
+	*ts_tablep = ts_table;
+
+	return 0;
+
+cleanup:
+	for (i = 0; i < VOS_TS_TYPE_COUNT; i++)
+		lrua_array_free(ts_table->tt_type_info[i].ti_array);
+	D_FREE(ts_table->tt_misses);
+free_table:
+	D_FREE(ts_table);
+
+	return rc;
+}
+
+void
+vos_ts_table_free(struct vos_ts_table **ts_tablep)
+{
+	struct vos_ts_table	*ts_table = *ts_tablep;
+	int			 i;
+
+	for (i = 0; i < VOS_TS_TYPE_COUNT; i++)
+		lrua_array_free(ts_table->tt_type_info[i].ti_array);
+
+	D_FREE(ts_table->tt_misses);
+	D_FREE(ts_table);
+
+	*ts_tablep = NULL;
 }
 
 void
@@ -258,16 +255,8 @@ vos_ts_evict_lru(struct vos_ts_table *ts_table, struct vos_ts_entry *parent,
 	struct vos_ts_info	*info = &ts_table->tt_type_info[type];
 	uint32_t		*neg_idx;
 
-	/** Ok, grab and evict the LRU */
-	*idx = info->ti_lru;
-	entry = &ts_table->tt_table[*idx];
-	info->ti_lru = entry->te_next_idx;
-	info->ti_mru = *idx;
-
-	if (entry->te_record_ptr != NULL) {
-		evict_children(ts_table, info, entry);
-		evict_one(ts_table, entry, *idx, info, true);
-	}
+	entry = lrua_alloc(ts_table->tt_type_info[type].ti_array, idx,
+			   true);
 
 	if (parent == NULL) {
 		/** Use global timestamps for the type to initialize it */
@@ -279,7 +268,8 @@ vos_ts_evict_lru(struct vos_ts_table *ts_table, struct vos_ts_entry *parent,
 		entry->te_parent_ptr = parent->te_record_ptr;
 		if ((type & 1) == 0) { /* positive entry */
 			neg_idx = &parent->te_miss_idx[hash_idx];
-			ts_source = vos_ts_lookup_idx(ts_table, neg_idx);
+			lrua_lookup(parent->te_info->ti_array, neg_idx,
+				    (void **)&ts_source);
 		}
 		if (ts_source == NULL) /* for negative and uncached entries */
 			ts_source = parent;
@@ -300,17 +290,6 @@ vos_ts_evict_lru(struct vos_ts_table *ts_table, struct vos_ts_entry *parent,
 	D_ASSERT(type == info->ti_type);
 
 	*entryp = entry;
-}
-
-void
-vos_ts_evict_entry(struct vos_ts_table *ts_table, struct vos_ts_entry *entry,
-		   uint32_t idx)
-{
-	struct vos_ts_info	*info = entry->te_info;
-
-	evict_children(ts_table, info, entry);
-
-	evict_one(ts_table, entry, idx, info, false);
 }
 
 int

--- a/src/vos/vos_ts.h
+++ b/src/vos/vos_ts.h
@@ -30,13 +30,18 @@
 #ifndef __VOS_TS__
 #define __VOS_TS__
 
+#include <lru_array.h>
 #include <vos_tls.h>
 
+struct vos_ts_table;
+
 struct vos_ts_info {
-	/** Least recently accessed index */
-	uint32_t		ti_lru;
-	/** Most recently accessed index */
-	uint32_t		ti_mru;
+	/** The LRU array */
+	struct lru_array	*ti_array;
+	/** Back pointer to table */
+	struct vos_ts_table	*ti_table;
+	/** Miss indexes for the type */
+	uint32_t		*ti_misses;
 	/** Type identifier */
 	uint32_t		ti_type;
 	/** mask for hash of negative entries */
@@ -47,8 +52,8 @@ struct vos_ts_info {
 
 struct vos_ts_entry {
 	struct vos_ts_info	*te_info;
-	/** Uniquely identifies the record */
-	void			*te_record_ptr;
+	/** Key for current occupant */
+	uint32_t		*te_record_ptr;
 	/** Uniquely identifies the parent record */
 	uint32_t		*te_parent_ptr;
 	/** negative entry cache */
@@ -69,10 +74,6 @@ struct vos_ts_entry {
 	uuid_t			 te_tx_rh;
 	/** write tx */
 	uuid_t			 te_tx_w;
-	/** Next most recently used */
-	uint32_t		 te_next_idx;
-	/** Previous most recently used */
-	uint32_t		 te_prev_idx;
 	/** Hash index in parent */
 	uint32_t		 te_hash_idx;
 };
@@ -98,24 +99,22 @@ struct vos_ts_set {
 	struct vos_ts_set_entry	 ts_entries[0];
 };
 
-/** Table will be per xstream */
-#define VOS_TS_BITS	23
-#define VOS_TS_SIZE	(1 << VOS_TS_BITS)
-#define VOS_TS_MASK	(VOS_TS_SIZE - 1)
-
-/** Timestamp types */
+/** Timestamp types (should all be powers of 2) */
 #define D_FOREACH_TS_TYPE(ACTION)					\
-	ACTION(VOS_TS_TYPE_CONT, "container", 1024,       32 * 1024)	\
-	ACTION(VOS_TS_TYPE_OBJ,  "object",    96 * 1024,  128 * 1024)	\
-	ACTION(VOS_TS_TYPE_DKEY, "dkey",      896 * 1024, 1024 * 1024)	\
-	ACTION(VOS_TS_TYPE_AKEY, "akey",      0,          0)		\
+	ACTION(VOS_TS_TYPE_CONT,	"container",	1024)		\
+	ACTION(VOS_TS_TYPE_OBJ_MISS,	"object miss",	32 * 1024)	\
+	ACTION(VOS_TS_TYPE_OBJ,		"object",	64 * 1024)	\
+	ACTION(VOS_TS_TYPE_DKEY_MISS,	"dkey miss",	128 * 1024)	\
+	ACTION(VOS_TS_TYPE_DKEY,	"dkey",		512 * 1024)	\
+	ACTION(VOS_TS_TYPE_AKEY_MISS,	"akey miss",	1024 * 1024)	\
+	ACTION(VOS_TS_TYPE_AKEY,	"akey",		4 * 1024 * 1024)
 
-#define DEFINE_TS_TYPE(type, desc, count, child_count)	type, type##_CHILD,
+#define DEFINE_TS_TYPE(type, desc, count)	type,
 
 enum {
 	D_FOREACH_TS_TYPE(DEFINE_TS_TYPE)
 	/** Number of timestamp types */
-	VOS_TS_TYPE_COUNT = VOS_TS_TYPE_AKEY_CHILD,
+	VOS_TS_TYPE_COUNT,
 };
 
 struct vos_ts_table {
@@ -125,78 +124,11 @@ struct vos_ts_table {
 	daos_epoch_t		tt_ts_rh;
 	/** Global write timestamp for type */
 	daos_epoch_t		tt_ts_w;
+	/** Miss index table */
+	uint32_t		*tt_misses;
 	/** Timestamp table pointers for a type */
 	struct vos_ts_info	tt_type_info[VOS_TS_TYPE_COUNT];
-	/** The table entries */
-	struct vos_ts_entry	tt_table[VOS_TS_SIZE];
 };
-
-/** Internal API: Evict the LRU, move it to MRU, update relevant time stamps,
- *  and return the index
- */
-void
-vos_ts_evict_lru(struct vos_ts_table *ts_table, struct vos_ts_entry *parent,
-		 struct vos_ts_entry **entryp, uint32_t *idx, uint32_t hash_idx,
-		 uint32_t type);
-
-/** Internal API: Evict selected entry from the cache, update global
- *  timestamps
- */
-void
-vos_ts_evict_entry(struct vos_ts_table *ts_table, struct vos_ts_entry *entry,
-		   uint32_t idx);
-
-/** Internal API: Remove an entry from the lru list */
-static inline void
-remove_ts_entry(struct vos_ts_entry *entries, struct vos_ts_entry *entry)
-{
-	struct vos_ts_entry	*prev = &entries[entry->te_prev_idx];
-	struct vos_ts_entry	*next = &entries[entry->te_next_idx];
-
-	prev->te_next_idx = entry->te_next_idx;
-	next->te_prev_idx = entry->te_prev_idx;
-}
-
-/** Internal API: Insert an entry in the lru list */
-static inline void
-insert_ts_entry(struct vos_ts_entry *entries, struct vos_ts_entry *entry,
-		uint32_t idx, uint32_t prev_idx, uint32_t next_idx)
-{
-	struct vos_ts_entry	*prev;
-	struct vos_ts_entry	*next;
-
-	prev = &entries[prev_idx];
-	next = &entries[next_idx];
-	next->te_prev_idx = idx;
-	prev->te_next_idx = idx;
-	entry->te_prev_idx = prev_idx;
-	entry->te_next_idx = next_idx;
-}
-
-/** Internal API: Make the entry the mru */
-static inline void
-move_lru(struct vos_ts_table *ts_table, struct vos_ts_entry *entry,
-	 uint32_t idx)
-{
-	struct vos_ts_info	*info = entry->te_info;
-
-	if (info->ti_mru == idx) {
-		/** Already the mru */
-		return;
-	}
-
-	if (info->ti_lru == idx)
-		info->ti_lru = entry->te_next_idx;
-
-	/** First remove */
-	remove_ts_entry(&ts_table->tt_table[0], entry);
-
-	/** Now add */
-	insert_ts_entry(&ts_table->tt_table[0], entry, idx, info->ti_mru,
-			info->ti_lru);
-
-	info->ti_mru = idx;
-}
 
 /** Internal API: Grab the parent entry from the set */
 static inline struct vos_ts_entry *
@@ -216,22 +148,6 @@ ts_set_get_parent(struct vos_ts_set *ts_set)
 
 	return parent;
 
-}
-
-/** Internal API to lookup entry from index */
-static inline struct vos_ts_entry *
-vos_ts_lookup_idx(struct vos_ts_table *ts_table, uint32_t *idx)
-{
-	struct vos_ts_entry	*entry;
-	uint32_t		 tindex = *idx & VOS_TS_MASK;
-
-	entry = &ts_table->tt_table[tindex];
-	if (entry->te_record_ptr == idx) {
-		move_lru(ts_table, entry, tindex);
-		return entry;
-	}
-
-	return NULL;
 }
 
 /** Reset the index in the set so an entry can be replaced
@@ -255,6 +171,30 @@ vos_ts_set_reset(struct vos_ts_set *ts_set, uint32_t type, uint32_t akey_nr)
 	ts_set->ts_init_count = idx;
 }
 
+static inline bool
+vos_ts_lookup_internal(struct vos_ts_set *ts_set, uint32_t type, uint32_t *idx,
+		       struct vos_ts_entry **entryp)
+{
+	struct vos_ts_table	*ts_table = vos_ts_table_get();
+	struct vos_ts_info	*info = &ts_table->tt_type_info[type];
+	void			*entry;
+	struct vos_ts_set_entry	 set_entry = {0};
+	bool found;
+
+	ts_table = vos_ts_table_get();
+
+	found = lrua_lookup(info->ti_array, idx, &entry);
+	if (found) {
+		D_ASSERT(ts_set->ts_set_size != ts_set->ts_init_count);
+		set_entry.se_entry = entry;
+		ts_set->ts_entries[ts_set->ts_init_count++] = set_entry;
+		*entryp = entry;
+		return true;
+	}
+
+	return false;
+}
+
 /** Lookup an entry in the timestamp cache and save it to the set.
  *
  * \param	ts_set[in]	The timestamp set
@@ -269,9 +209,7 @@ static inline bool
 vos_ts_lookup(struct vos_ts_set *ts_set, uint32_t *idx, bool reset,
 	      struct vos_ts_entry **entryp)
 {
-	struct vos_ts_table	*ts_table = vos_ts_table_get();
-	struct vos_ts_entry	*entry;
-	struct vos_ts_set_entry	 set_entry = {0};
+	uint32_t		 type;
 
 	*entryp = NULL;
 
@@ -281,19 +219,16 @@ vos_ts_lookup(struct vos_ts_set *ts_set, uint32_t *idx, bool reset,
 	if (reset)
 		ts_set->ts_init_count--;
 
-	ts_table = vos_ts_table_get();
+	type = MIN(ts_set->ts_init_count * 2, VOS_TS_TYPE_AKEY);
 
-	entry = vos_ts_lookup_idx(ts_table, idx);
-	if (entry != NULL) {
-		D_ASSERT(ts_set->ts_set_size != ts_set->ts_init_count);
-		set_entry.se_entry = entry;
-		ts_set->ts_entries[ts_set->ts_init_count++] = set_entry;
-		*entryp = entry;
-		return true;
-	}
-
-	return false;
+	return vos_ts_lookup_internal(ts_set, type, idx, entryp);
 }
+
+/** Internal function to evict LRU and initialize an entry */
+void
+vos_ts_evict_lru(struct vos_ts_table *ts_table, struct vos_ts_entry *parent,
+		 struct vos_ts_entry **new_entry, uint32_t *idx,
+		 uint32_t hash_idx, uint32_t new_type);
 
 /** Allocate a new entry in the set.   Lookup should be called first and this
  * should only be called if it returns false.
@@ -318,6 +253,7 @@ vos_ts_alloc(struct vos_ts_set *ts_set, uint32_t *idx, uint64_t hash)
 
 	if (ts_set == NULL)
 		return NULL;
+
 
 	ts_table = vos_ts_table_get();
 
@@ -444,8 +380,6 @@ vos_ts_get_negative(struct vos_ts_set *ts_set, uint64_t hash, bool reset)
 
 	D_ASSERT(parent != NULL);
 
-	ts_table = vos_ts_table_get();
-
 	info = parent->te_info;
 	if (info->ti_type & 1) {
 		/** Parent is a negative entry, just reuse it
@@ -455,12 +389,18 @@ vos_ts_get_negative(struct vos_ts_set *ts_set, uint64_t hash, bool reset)
 		goto add_to_set;
 	}
 
+	ts_table = vos_ts_table_get();
+
 	idx = hash & info->ti_cache_mask;
-	if (vos_ts_lookup(ts_set, &parent->te_miss_idx[idx], false, &neg_entry))
+	if (vos_ts_lookup_internal(ts_set, info->ti_type + 1,
+				   &parent->te_miss_idx[idx], &neg_entry)) {
+		D_ASSERT(idx == neg_entry->te_hash_idx);
 		goto out;
+	}
 
 	vos_ts_evict_lru(ts_table, parent, &neg_entry,
 			 &parent->te_miss_idx[idx], idx, info->ti_type + 1);
+	D_ASSERT(idx == neg_entry->te_hash_idx);
 add_to_set:
 	set_entry.se_entry = neg_entry;
 	ts_set->ts_entries[ts_set->ts_init_count++] = set_entry;
@@ -478,17 +418,11 @@ out:
  * \param	type[in]	Type of the object
  */
 static inline void
-vos_ts_evict(uint32_t *idx)
+vos_ts_evict(uint32_t *idx, uint32_t type)
 {
 	struct vos_ts_table	*ts_table = vos_ts_table_get();
-	struct vos_ts_entry	*entry;
-	uint32_t		 tindex = *idx & VOS_TS_MASK;
 
-	entry = &ts_table->tt_table[tindex];
-	if (entry->te_record_ptr != idx)
-		return;
-
-	vos_ts_evict_entry(ts_table, entry, *idx);
+	lrua_evict(ts_table->tt_type_info[type].ti_array, idx);
 }
 
 /** Allocate thread local timestamp cache.   Set the initial global times


### PR DESCRIPTION
The LRU array could be generically useful, in particular to
allocate a unique local transaction identifier which is a
combination of a unique 16 bit id and an epoch.

Signed-off-by: Jeff Olivier <jeffrey.v.olivier@intel.com>