### PR TITLE
DAOS-4157 dfs: Remove env variable to turn off conditional updates.

### DIFF
--- a/src/client/api/init.c
+++ b/src/client/api/init.c
@@ -43,7 +43,6 @@
 
 static pthread_mutex_t	module_lock = PTHREAD_MUTEX_INITIALIZER;
 static bool		module_initialized;
-bool			dfs_no_cond_op;
 
 const struct daos_task_api dc_funcs[] = {
 	/** Managment */
@@ -193,8 +192,6 @@ daos_init(void)
 	rc = dc_agent_init();
 	if (rc != 0)
 		D_GOTO(out_obj, rc);
-
-	d_getenv_bool("DFS_NO_COND_OP", &dfs_no_cond_op);
 
 	module_initialized = true;
 	D_GOTO(unlock, rc = 0);

--- a/src/client/dfs/dfs.c
+++ b/src/client/dfs/dfs.c
@@ -358,15 +358,11 @@ out:
 
 static int
 remove_entry(dfs_t *dfs, daos_handle_t th, daos_handle_t parent_oh,
-	     const char *name, bool cond_check, struct dfs_entry entry)
+	     const char *name, struct dfs_entry entry)
 {
-	uint64_t	cond = 0;
 	daos_key_t	dkey;
 	daos_handle_t	oh;
 	int		rc;
-
-	if (cond_check && !dfs_no_cond_op)
-		cond = DAOS_COND_PUNCH;
 
 	if (S_ISLNK(entry.mode))
 		goto punch_entry;
@@ -387,7 +383,8 @@ remove_entry(dfs_t *dfs, daos_handle_t th, daos_handle_t parent_oh,
 
 punch_entry:
 	d_iov_set(&dkey, (void *)name, strlen(name));
-	rc = daos_obj_punch_dkeys(parent_oh, th, cond, 1, &dkey, NULL);
+	rc = daos_obj_punch_dkeys(parent_oh, th, DAOS_COND_PUNCH, 1, &dkey,
+				  NULL);
 	return daos_der2errno(rc);
 }
 
@@ -404,20 +401,8 @@ insert_entry(daos_handle_t oh, daos_handle_t th, const char *name,
 	unsigned int	i;
 	int		rc;
 
-	if (cond_check && !dfs_no_cond_op) {
+	if (cond_check)
 		cond = DAOS_COND_DKEY_INSERT;
-	} else if (cond_check) {
-		/** if cond_ops not enabled, fetch and check (non-atomically) */
-		struct dfs_entry	check_entry = {0};
-		bool			exists;
-
-		/* Check if parent has the dirname entry */
-		rc = fetch_entry(oh, th, name, true, &exists, &check_entry);
-		if (rc)
-			return rc;
-		if (exists)
-			return EEXIST;
-	}
 
 	d_iov_set(&dkey, (void *)name, strlen(name));
 	d_iov_set(&iod.iod_name, INODE_AKEY_NAME, strlen(INODE_AKEY_NAME));
@@ -923,8 +908,6 @@ open_sb(daos_handle_t coh, bool create, dfs_attr_t *attr, daos_handle_t *oh)
 
 	/** create the SB and exit */
 	if (create) {
-		uint64_t cond = 0;
-
 		iods[0].iod_size = sizeof(magic);
 		magic = DFS_SB_MAGIC;
 		iods[1].iod_size = sizeof(sb_ver);
@@ -942,11 +925,8 @@ open_sb(daos_handle_t coh, bool create, dfs_attr_t *attr, daos_handle_t *oh)
 		else
 			oclass = DFS_DEFAULT_OBJ_CLASS;
 
-		if (!dfs_no_cond_op)
-			cond = DAOS_COND_DKEY_INSERT;
-
-		rc = daos_obj_update(*oh, DAOS_TX_NONE, cond, &dkey, SB_AKEYS,
-				     iods, sgls, NULL);
+		rc = daos_obj_update(*oh, DAOS_TX_NONE, DAOS_COND_DKEY_INSERT,
+				     &dkey, SB_AKEYS, iods, sgls, NULL);
 		if (rc) {
 			D_ERROR("Failed to update SB info (%d)\n", rc);
 			D_GOTO(err, rc = daos_der2errno(rc));
@@ -1641,8 +1621,7 @@ remove_dir_contents(dfs_t *dfs, daos_handle_t th, struct dfs_entry entry)
 					D_GOTO(out, rc);
 			}
 
-			rc = remove_entry(dfs, th, oh, entry_name, true,
-					  child_entry);
+			rc = remove_entry(dfs, th, oh, entry_name, child_entry);
 			if (rc)
 				D_GOTO(out, rc);
 		}
@@ -1717,7 +1696,7 @@ dfs_remove(dfs_t *dfs, dfs_obj_t *parent, const char *name, bool force,
 		}
 	}
 
-	rc = remove_entry(dfs, th, parent->oh, name, true, entry);
+	rc = remove_entry(dfs, th, parent->oh, name, entry);
 	if (rc)
 		D_GOTO(out, rc);
 
@@ -3027,7 +3006,6 @@ dfs_chmod(dfs_t *dfs, dfs_obj_t *parent, const char *name, mode_t mode)
 	daos_iod_t		iod;
 	daos_recx_t		recx;
 	daos_key_t		dkey;
-	uint64_t		cond = 0;
 	int			rc;
 
 	if (dfs == NULL || !dfs->mounted)
@@ -3110,10 +3088,8 @@ dfs_chmod(dfs_t *dfs, dfs_obj_t *parent, const char *name, mode_t mode)
 	sgl.sg_nr_out	= 0;
 	sgl.sg_iovs	= &sg_iov;
 
-	if (!dfs_no_cond_op)
-		cond = DAOS_COND_DKEY_UPDATE;
-
-	rc = daos_obj_update(oh, th, cond, &dkey, 1, &iod, &sgl, NULL);
+	rc = daos_obj_update(oh, th, DAOS_COND_DKEY_UPDATE, &dkey, 1, &iod,
+			     &sgl, NULL);
 	if (rc) {
 		D_ERROR("Failed to update mode (rc = %d)\n", rc);
 		D_GOTO(out, rc = daos_der2errno(rc));
@@ -3139,7 +3115,6 @@ dfs_osetattr(dfs_t *dfs, dfs_obj_t *obj, struct stat *stbuf, int flags)
 	daos_recx_t		recx[3];
 	bool			set_size = false;
 	int			i = 0;
-	uint64_t		cond = 0;
 	int			rc;
 
 	if (dfs == NULL || !dfs->mounted)
@@ -3222,10 +3197,8 @@ dfs_osetattr(dfs_t *dfs, dfs_obj_t *obj, struct stat *stbuf, int flags)
 	sgl.sg_nr_out	= 0;
 	sgl.sg_iovs	= &sg_iovs[0];
 
-	if (!dfs_no_cond_op)
-		cond = DAOS_COND_DKEY_UPDATE;
-
-	rc = daos_obj_update(oh, th, cond, &dkey, 1, &iod, &sgl, NULL);
+	rc = daos_obj_update(oh, th, DAOS_COND_DKEY_UPDATE, &dkey, 1, &iod,
+			     &sgl, NULL);
 	if (rc) {
 		D_ERROR("Failed to update attr (rc = %d)\n", rc);
 		D_GOTO(out_obj, rc = daos_der2errno(rc));
@@ -3364,7 +3337,6 @@ dfs_move(dfs_t *dfs, dfs_obj_t *parent, char *name, dfs_obj_t *new_parent,
 	daos_handle_t		th = DAOS_TX_NONE;
 	bool			exists;
 	daos_key_t		dkey;
-	uint64_t		cond = 0;
 	int			rc;
 
 	if (dfs == NULL || !dfs->mounted)
@@ -3454,8 +3426,7 @@ dfs_move(dfs_t *dfs, dfs_obj_t *parent, char *name, dfs_obj_t *new_parent,
 			}
 		}
 
-		rc = remove_entry(dfs, th, new_parent->oh, new_name, true,
-				  new_entry);
+		rc = remove_entry(dfs, th, new_parent->oh, new_name, new_entry);
 		if (rc) {
 			D_ERROR("Failed to remove entry %s (%d)\n",
 				new_name, rc);
@@ -3468,7 +3439,7 @@ dfs_move(dfs_t *dfs, dfs_obj_t *parent, char *name, dfs_obj_t *new_parent,
 
 	/** rename symlink */
 	if (S_ISLNK(entry.mode)) {
-		rc = remove_entry(dfs, th, parent->oh, name, true, entry);
+		rc = remove_entry(dfs, th, parent->oh, name, entry);
 		if (rc) {
 			D_ERROR("Failed to remove entry %s (%d)\n",
 				name, rc);
@@ -3490,12 +3461,10 @@ dfs_move(dfs_t *dfs, dfs_obj_t *parent, char *name, dfs_obj_t *new_parent,
 		D_GOTO(out, rc);
 	}
 
-	if (!dfs_no_cond_op)
-		cond = DAOS_COND_PUNCH;
-
 	/** remove the old entry from the old parent (just the dkey) */
 	d_iov_set(&dkey, (void *)name, strlen(name));
-	rc = daos_obj_punch_dkeys(parent->oh, th, cond, 1, &dkey, NULL);
+	rc = daos_obj_punch_dkeys(parent->oh, th, DAOS_COND_PUNCH, 1, &dkey,
+				  NULL);
 	if (rc) {
 		D_ERROR("Punch entry %s failed (%d)\n", name, rc);
 		D_GOTO(out, rc = daos_der2errno(rc));
@@ -3586,7 +3555,7 @@ dfs_exchange(dfs_t *dfs, dfs_obj_t *parent1, char *name1, dfs_obj_t *parent2,
 
 	entry1.atime = entry1.mtime = entry1.ctime = time(NULL);
 	/** insert entry1 in parent2 object */
-	rc = insert_entry(parent2->oh, th, name1, false, entry1);
+	rc = insert_entry(parent2->oh, th, name1, true, entry1);
 	if (rc) {
 		D_ERROR("Inserting entry %s failed (%d)\n", name1, rc);
 		D_GOTO(out, rc);
@@ -3594,7 +3563,7 @@ dfs_exchange(dfs_t *dfs, dfs_obj_t *parent1, char *name1, dfs_obj_t *parent2,
 
 	entry2.atime = entry2.mtime = entry2.ctime = time(NULL);
 	/** insert entry2 in parent1 object */
-	rc = insert_entry(parent1->oh, th, name2, false, entry2);
+	rc = insert_entry(parent1->oh, th, name2, true, entry2);
 	if (rc) {
 		D_ERROR("Inserting entry %s failed (%d)\n", name2, rc);
 		D_GOTO(out, rc);
@@ -3683,33 +3652,10 @@ dfs_setxattr(dfs_t *dfs, dfs_obj_t *obj, const char *name,
 
 	/** if not default flag, check for xattr existence */
 	if (flags != 0) {
-		if (!dfs_no_cond_op) {
-			if (flags == XATTR_CREATE)
-				cond |= DAOS_COND_AKEY_INSERT;
-			if (flags == XATTR_REPLACE)
-				cond |= DAOS_COND_AKEY_UPDATE;
-		} else {
-			bool exists;
-
-			iod.iod_size	= DAOS_REC_ANY;
-			rc = daos_obj_fetch(oh, th, 0, &dkey, 1, &iod,
-					    NULL, NULL, NULL);
-			if (rc) {
-				D_ERROR("Failed to get extended attribute %s\n",
-					name);
-				D_GOTO(out, rc = daos_der2errno(rc));
-			}
-
-			if (iod.iod_size == 0)
-				exists = false;
-			else
-				exists = true;
-
-			if (flags == XATTR_CREATE && exists)
-				D_GOTO(out, rc = EEXIST);
-			if (flags == XATTR_REPLACE && !exists)
-				D_GOTO(out, rc = ENOENT);
-		}
+		if (flags == XATTR_CREATE)
+			cond |= DAOS_COND_AKEY_INSERT;
+		if (flags == XATTR_REPLACE)
+			cond |= DAOS_COND_AKEY_UPDATE;
 	}
 
 	/** set sgl for update */
@@ -3718,9 +3664,7 @@ dfs_setxattr(dfs_t *dfs, dfs_obj_t *obj, const char *name,
 	sgl.sg_nr_out	= 0;
 	sgl.sg_iovs	= &sg_iov;
 
-	if (!dfs_no_cond_op)
-		cond |= DAOS_COND_DKEY_UPDATE;
-
+	cond |= DAOS_COND_DKEY_UPDATE;
 	iod.iod_size	= size;
 	rc = daos_obj_update(oh, th, cond, &dkey, 1, &iod, &sgl, NULL);
 	if (rc) {
@@ -3844,9 +3788,7 @@ dfs_removexattr(dfs_t *dfs, dfs_obj_t *obj, const char *name)
 	/** set akey as the xattr name */
 	d_iov_set(&akey, xname, strlen(xname));
 
-	if (!dfs_no_cond_op)
-		cond = DAOS_COND_DKEY_UPDATE | DAOS_COND_PUNCH;
-
+	cond = DAOS_COND_DKEY_UPDATE | DAOS_COND_PUNCH;
 	rc = daos_obj_punch_akeys(oh, th, cond, &dkey, 1, &akey, NULL);
 	if (rc) {
 		D_ERROR("Failed to punch extended attribute %s\n", name);

--- a/src/include/daos/event.h
+++ b/src/include/daos/event.h
@@ -54,7 +54,6 @@ enum daos_ev_flags {
 struct tse_task_t;
 
 typedef int (*daos_event_comp_cb_t)(void *, daos_event_t *, int);
-extern bool dfs_no_cond_op;
 
 /**
  * Finish event queue library.


### PR DESCRIPTION
The environment variable DFS_NO_COND_OPS was just for benchmarking
purposes to test the effect of conditional operations. This was meant
only to be temporary to show the performance improvement with cond
operations and it will be removed now.

Signed-off-by: Mohamad Chaarawi <mohamad.chaarawi@intel.com>