### PR TITLE
DAOS-4292 csum: Fix for overlapping extents after first chunk

### DIFF
--- a/src/common/tests/checksum_tests.c
+++ b/src/common/tests/checksum_tests.c
@@ -1081,7 +1081,7 @@ simple_sv(void **state)
 
 	iod.iod_nr = 1;
 	iod.iod_recxs = NULL;
-	iod.iod_size = 1; /* [todo-ryon]: this should be bigger than 1 */
+	iod.iod_size = daos_sgl_buf_size(&sgl);
 	iod.iod_type = DAOS_IOD_SINGLE;
 
 	rc = daos_csummer_calc_iods(csummer, &sgl, &iod, 1, 0, NULL, 0,

--- a/src/object/srv_csum.c
+++ b/src/object/srv_csum.c
@@ -423,7 +423,8 @@ cc_add_csums_for_recx(struct csum_context *ctx, daos_recx_t *recx,
 	uint32_t		chunksize;
 	size_t			rec_size;
 	uint32_t		chunk_nr;
-	uint32_t		c;
+	uint32_t		c; /** recx chunk index */
+	uint32_t		sc; /** system chunk index */
 	int			rc = 0;
 
 	chunksize = daos_csummer_get_chunksize(ctx->cc_csummer);
@@ -437,11 +438,12 @@ cc_add_csums_for_recx(struct csum_context *ctx, daos_recx_t *recx,
 
 	cc_set_iov2ranges(ctx, cc2iov(ctx));
 
-	for (c = 0; c < chunk_nr; c++) { /** for each chunk/checksum */
+	sc = (recx->rx_idx * rec_size) / chunksize;
+	for (c = 0; c < chunk_nr; c++, sc++) { /** for each chunk/checksum */
 		ctx->cc_recx_chunk = csum_recx_chunkidx2range(recx, rec_size,
 							      chunksize, c);
 		ctx->cc_chunk = csum_chunkrange(chunksize / ctx->cc_rec_len,
-						c);
+						sc);
 		ctx->cc_chunk_bytes_left = ctx->cc_recx_chunk.dcr_nr *
 					   rec_size;
 

--- a/src/tests/suite/daos_checksum.c
+++ b/src/tests/suite/daos_checksum.c
@@ -593,7 +593,8 @@ setup_obj_data_for_sv(struct csum_test_ctx *ctx, bool large_buf)
 
 /** Fill an iov buf with data, using \data (duplicate if necessary)
  */
-static void iov_update_fill(d_iov_t *iov, char *data, uint64_t len_to_fill)
+static void
+iov_update_fill(d_iov_t *iov, char *data, uint64_t len_to_fill)
 {
 	iov->iov_len = len_to_fill;
 	const size_t data_len = strlen(data); /** don't include '\0' */
@@ -771,6 +772,19 @@ fetch_with_multiple_extents(void **state)
 			{.idx = 1500, .nr = 512, .data = "D"},
 		},
 		.fetch_recx = {.rx_idx = 2, .rx_nr = 800},
+	});
+
+	/** Overwrites after the first chunk */
+	ARRAY_UPDATE_FETCH_TESTCASE(state, {
+		.chunksize = 32,
+		.csum_prop_type = DAOS_PROP_CO_CSUM_CRC64,
+		.server_verify = false,
+		.rec_size = 4,
+		.recx_cfgs = {
+			{.idx = 8, .nr = 2, .data = "B"},
+			{.idx = 9, .nr = 2, .data = "C"},
+		},
+		.fetch_recx = {.rx_idx = 8, .rx_nr = 3},
 	});
 
 	/** Extents with holes */


### PR DESCRIPTION
Fixes a bug that caused errant checksum failures. The logic for choosing
checksums didn't take into account that chunk 0 of an extent isn't
chunk 0 of the system and so was using incorrect chunk dimensions.

Signed-off-by: Ryon Jensen <ryon.jensen@intel.com>