### PR TITLE
DAOS-4452 vos: minor epoch for incarnation log

### DIFF
--- a/src/dtx/dtx_common.c
+++ b/src/dtx/dtx_common.c
@@ -235,6 +235,10 @@ dtx_handle_init(struct dtx_id *dti, daos_unit_oid_t *oid, daos_handle_t coh,
 	dth->dth_has_ilog = 0;
 	dth->dth_renew = 0;
 	dth->dth_actived = 0;
+	dth->dth_local_tx_started = 0;
+
+	/* XXX: Change it when handle multiple modifications. */
+	dth->dth_last_modification = 1;
 }
 
 /**

--- a/src/dtx/dtx_common.c
+++ b/src/dtx/dtx_common.c
@@ -239,6 +239,9 @@ dtx_handle_init(struct dtx_id *dti, daos_unit_oid_t *oid, daos_handle_t coh,
 
 	/* XXX: Change it when handle multiple modifications. */
 	dth->dth_last_modification = 1;
+
+	/* Operation sequence starts from 1 instead of 0. */
+	dth->dth_op_seq = 1;
 }
 
 /**

--- a/src/include/daos_srv/dtx_srv.h
+++ b/src/include/daos_srv/dtx_srv.h
@@ -83,7 +83,11 @@ struct dtx_handle {
 					 /* epoch conflict, need to renew. */
 					 dth_renew:1,
 					 /* The DTX entry is in active table. */
-					 dth_actived:1;
+					 dth_actived:1,
+					 /* Local TX is started. */
+					 dth_local_tx_started:1,
+					 /* The last sub-modification for DTX */
+					 dth_last_modification:1;
 	/* The count the DTXs in the dth_dti_cos array. */
 	uint32_t			 dth_dti_cos_count;
 	/* The array of the DTXs for Commit on Share (conflcit). */

--- a/src/include/daos_srv/dtx_srv.h
+++ b/src/include/daos_srv/dtx_srv.h
@@ -98,6 +98,8 @@ struct dtx_handle {
 	void				*dth_ent;
 	/** The address (offset) of the (new) object to be modified. */
 	umem_off_t			 dth_obj;
+	/** Modification sequence in the distributed transaction. */
+	uint16_t			 dth_op_seq;
 };
 
 /* Each sub transaction handle to manage each sub thandle */

--- a/src/vos/tests/vts_dtx.c
+++ b/src/vos/tests/vts_dtx.c
@@ -204,6 +204,14 @@ vts_dtx_begin(struct dtx_id *xid, daos_unit_oid_t *oid, daos_handle_t coh,
 	dth->dth_leader = 1;
 	dth->dth_ent = NULL;
 	dth->dth_obj = UMOFF_NULL;
+	dth->dth_sync = 0;
+	dth->dth_solo = 0;
+	dth->dth_dti_cos_done = 0;
+	dth->dth_has_ilog = 0;
+	dth->dth_renew = 0;
+	dth->dth_actived = 0;
+	dth->dth_local_tx_started = 0;
+	dth->dth_last_modification = 1;
 
 	*dthp = dth;
 

--- a/src/vos/tests/vts_dtx.c
+++ b/src/vos/tests/vts_dtx.c
@@ -212,6 +212,7 @@ vts_dtx_begin(struct dtx_id *xid, daos_unit_oid_t *oid, daos_handle_t coh,
 	dth->dth_actived = 0;
 	dth->dth_local_tx_started = 0;
 	dth->dth_last_modification = 1;
+	dth->dth_op_seq = 1;
 
 	*dthp = dth;
 

--- a/src/vos/vos_ilog.c
+++ b/src/vos/vos_ilog.c
@@ -127,13 +127,13 @@ vos_parse_ilog(struct vos_ilog_info *info, daos_epoch_t epoch,
 		}
 
 		if (entry->ie_id.id_epoch > epoch) {
-			if (entry->ie_punch &&
+			if (ilog_is_punch(entry) &&
 			    entry->ie_status == ILOG_COMMITTED)
 				info->ii_next_punch = entry->ie_id.id_epoch;
 			continue;
 		}
 
-		if (entry->ie_punch &&
+		if (ilog_is_punch(entry) &&
 		    info->ii_prior_any_punch < entry->ie_id.id_epoch)
 			info->ii_prior_any_punch = entry->ie_id.id_epoch;
 
@@ -156,7 +156,7 @@ vos_parse_ilog(struct vos_ilog_info *info, daos_epoch_t epoch,
 
 		D_ASSERT(entry->ie_status == ILOG_COMMITTED);
 
-		if (entry->ie_punch) {
+		if (ilog_is_punch(entry)) {
 			info->ii_prior_punch = entry->ie_id.id_epoch;
 			break;
 		}
@@ -270,6 +270,7 @@ int vos_ilog_update_(struct vos_container *cont, struct ilog_df *ilog,
 		     struct vos_ilog_info *parent, struct vos_ilog_info *info,
 		     uint32_t cond, struct vos_ts_set *ts_set)
 {
+	struct dtx_handle	*dth = vos_dth_get();
 	daos_epoch_range_t	 max_epr = *epr;
 	struct ilog_desc_cbs	 cbs;
 	daos_handle_t		 loh;
@@ -324,7 +325,8 @@ update:
 		return rc;
 	}
 
-	rc = ilog_update(loh, &max_epr, epr->epr_hi, false);
+	rc = ilog_update(loh, &max_epr, epr->epr_hi,
+			 dth != NULL ? dth->dth_op_seq : 1, false);
 
 	ilog_close(loh);
 
@@ -348,6 +350,7 @@ vos_ilog_punch_(struct vos_container *cont, struct ilog_df *ilog,
 		struct vos_ilog_info *info, struct vos_ts_set *ts_set,
 		bool leaf)
 {
+	struct dtx_handle	*dth = vos_dth_get();
 	daos_epoch_range_t	 max_epr = *epr;
 	struct ilog_desc_cbs	 cbs;
 	daos_handle_t		 loh;
@@ -408,7 +411,8 @@ punch_log:
 		return rc;
 	}
 
-	rc = ilog_update(loh, NULL, epr->epr_hi, true);
+	rc = ilog_update(loh, NULL, epr->epr_hi,
+			 dth != NULL ? dth->dth_op_seq : 1, true);
 
 	ilog_close(loh);
 

--- a/src/vos/vos_obj_index.c
+++ b/src/vos/vos_obj_index.c
@@ -233,6 +233,7 @@ vos_oi_find_alloc(struct vos_container *cont, daos_unit_oid_t oid,
 		  daos_epoch_t epoch, bool log, struct vos_obj_df **obj_p,
 		  struct vos_ts_set *ts_set)
 {
+	struct dtx_handle	*dth = vos_dth_get();
 	struct vos_obj_df	*obj = NULL;
 	d_iov_t			 key_iov;
 	d_iov_t			 val_iov;
@@ -273,7 +274,8 @@ do_log:
 	if (rc != 0)
 		return rc;
 
-	rc = ilog_update(loh, NULL, epoch, false);
+	rc = ilog_update(loh, NULL, epoch, dth != NULL ? dth->dth_op_seq : 1,
+			 false);
 
 	ilog_close(loh);
 skip_log:


### PR DESCRIPTION
Introduce 16-bits minor epoch for the modifications against the
same target (object/dkey/akey) via the same DTX that will share
the same incarnation log entry.

It is possible that a distributed transaction may contains both
punch and update against the same object/dkey/akey. So the ilog
entry may change between 'punch' and 'update' status frequently.

To support that, we add two minor epochs to an ilog entry, one
is for punch, another is for update. When the incarnation log
entry is created for the first time or re-created after punch,
its update minor epoch is set as current minor epoch (that is
controlled by the DTX handle); similarly, when it is punched,
its punch minor is set as current minor epoch. For a give ilog
entry, its minor epoch within the same DTX is increased only,
so by comparing the punch minor epoch and the update one, we
can know whether the ilog entry is a punched one or update.

The two minor epochs are stored inside btr_record::rec_hkey,
that is reserved space for the ilog entry record key, so not
consume additional space.

On the other hand, the minor epoch is only visible inside VOS,
it does not participate in ilog_hkey_cmp(), so will not affect
the ilog entry's visibility that is still controlled by main
epoch as original case does.

Signed-off-by: Fan Yong <fan.yong@intel.com>