### PR TITLE
DAOS-3634 doc: Fix dmg manpage generator

### DIFF
--- a/doc/man/man8/dmg.8
+++ b/doc/man/man8/dmg.8
@@ -1,4 +1,4 @@
-.TH dmg 1 "30 March 2020"
+.TH dmg 1 "1 April 2020"
 .SH NAME
 dmg \- Administrative tool for managing DAOS clusters
 .SH SYNOPSIS
@@ -352,4 +352,22 @@ Query DAOS system status
 Display more member details
 .TP
 \fB\fB\-r\fR, \fB\-\-ranks\fR\fP
-Comma separated list of system ra
+Comma separated list of system ranks to query
+.SS system start
+Perform start of stopped DAOS system
+
+\fBAliases\fP: r
+
+.SS system stop
+Perform controlled shutdown of DAOS system
+
+\fBUsage\fP: system stop [stop-OPTIONS]
+.TP
+
+\fBAliases\fP: s
+
+.TP
+\fB\fB\-\-force\fR\fP
+Force stop DAOS system members
+.SS version
+Print dmg version

--- a/src/control/cmd/dmg/man_test.go
+++ b/src/control/cmd/dmg/man_test.go
@@ -23,7 +23,6 @@
 package main
 
 import (
-	"bufio"
 	"bytes"
 	"flag"
 	"fmt"
@@ -50,7 +49,7 @@ func TestDmg_ManPageIsCurrent(t *testing.T) {
 		return out.Bytes()
 	}
 
-	writeManPage(bufio.NewWriter(&manBytes))
+	writeManPage(&manBytes)
 	if *update {
 		err := ioutil.WriteFile(goldenPath, manBytes.Bytes(), 0644)
 		if err != nil {


### PR DESCRIPTION
It's not necessary to wrap the output buffer in a buffered
writer.