### PR TITLE
DAOS-4455 doc: fix admin guide link to developer information

### DIFF
--- a/doc/admin/installation.md
+++ b/doc/admin/installation.md
@@ -101,7 +101,7 @@ $ scons --config=force install
 ```
 
 If you are a developer of DAOS, we recommend following the instructions in the
-[DAOS for Development](https://daos-stack.github.io/admin/installation/#daos-for-development) section.
+[DAOS for Development](https://daos-stack.github.io/dev/development/#building-daos-for-development) section.
 
 Otherwise, the missing dependencies can be built automatically by invoking scons
 with the following parameters:


### PR DESCRIPTION
Fix a URL that has changed, to point to the correct information
that documents how to build DAOS for developers.

Skip-build: true
Skip-test: true

Signed-off-by: Kenneth Cain <kenneth.c.cain@intel.com>