### PR TITLE
DAOS-4358 test: Disable POSIX mdtest cases

### DIFF
--- a/src/tests/ftest/io/mdtest_small.yaml
+++ b/src/tests/ftest/io/mdtest_small.yaml
@@ -25,15 +25,17 @@ mdtest:
   dfs_destroy: True
   manager: "MPICH"
   mdtest_params:
+# Commenting out all POSIX mdtest cases until DAOS-4285 is resolved
+# Re-enable them once DAOS-4285 is completed.
 #     [api, write, read, branching_factor, num_of_dir_files, depth, flags]
     - [DFS, 4096, 4096, 1, 1000, 0, ' ']
     - [DFS, 4096, 4096, 1, 1000, 20, ' ']
-    - [POSIX, 0, 0, 1, 1000, 0, ' ']
-    - [POSIX, 0, 0, 1, 1000, 20, ' ']
+#    - [POSIX, 0, 0, 1, 1000, 0, ' ']
+#    - [POSIX, 0, 0, 1, 1000, 20, ' ']
     - [DFS, 4096, 4096, 2, 10, 5, ' ']
-    - [POSIX, 4096, 4096, 2, 10, 5, ' ']
+#    - [POSIX, 4096, 4096, 2, 10, 5, ' ']
     - [DFS, 4096, 4096, 1, 1000, 20, '-u']
-    - [POSIX, 0, 0, 2, 10, 5, '-u']
+#    - [POSIX, 0, 0, 2, 10, 5, '-u']
 
 dfuse:
   mount_dir: "/tmp/daos_dfuse"


### PR DESCRIPTION
Temporarily disable all test cases involving
dfuse for mdtest_small until DAOS-4285 is resolved.
    
Signed-off-by: Saurabh Tandan <saurabh.tandan@intel.com>