### PR TITLE
DAOS-3512 md: improve error aggregation/return for rsvc start

### DIFF
--- a/src/rsvc/rpc.h
+++ b/src/rsvc/rpc.h
@@ -71,8 +71,10 @@ extern struct crt_proto_format rsvc_proto_fmt;
 	((uint64_t)		(sai_size)		CRT_VAR) \
 	((d_rank_list_t)	(sai_ranks)		CRT_PTR)
 
-#define DAOS_OSEQ_RSVC_START /* output fields */		 \
-	((int32_t)		(sao_rc)		CRT_VAR)
+#define DAOS_OSEQ_RSVC_START /* output fields (rc: err count) */ \
+	((int32_t)		(sao_rc)		CRT_VAR) \
+	((int32_t)		(sao_rc_errval)		CRT_VAR)
+
 
 CRT_RPC_DECLARE(rsvc_start, DAOS_ISEQ_RSVC_START, DAOS_OSEQ_RSVC_START)
 

--- a/src/rsvc/srv.c
+++ b/src/rsvc/srv.c
@@ -1095,10 +1095,11 @@ ds_rsvc_dist_start(enum ds_rsvc_class_id class, d_iov_t *id,
 	out = crt_reply_get(rpc);
 	rc = out->sao_rc;
 	if (rc != 0) {
-		D_ERROR(DF_UUID": failed to start%s replicas: "DF_RC"\n",
-			DP_UUID(dbid), create ? "/create" : "", DP_RC(rc));
+		D_ERROR(DF_UUID": failed to start%s %d replicas: "DF_RC"\n",
+			DP_UUID(dbid), create ? "/create" : "", rc,
+			DP_RC(out->sao_rc_errval));
 		ds_rsvc_dist_stop(class, id, ranks, NULL, create);
-		rc = -DER_IO;
+		rc = out->sao_rc_errval;
 	}
 
 out_mem:
@@ -1138,6 +1139,7 @@ ds_rsvc_start_handler(crt_rpc_t *rpc)
 			   (in->sai_flags & RDB_AF_BOOTSTRAP) ?
 			   in->sai_ranks : NULL, NULL /* arg */);
 out:
+	out->sao_rc_errval = rc;
 	out->sao_rc = (rc == 0 ? 0 : 1);
 	crt_reply_send(rpc);
 }
@@ -1150,7 +1152,12 @@ ds_rsvc_start_aggregator(crt_rpc_t *source, crt_rpc_t *result, void *priv)
 
 	out_source = crt_reply_get(source);
 	out_result = crt_reply_get(result);
+	/* rc is error count, rc_errval an aggregation of values. */
 	out_result->sao_rc += out_source->sao_rc;
+
+	D_DEBUG(DB_MD, "\n");
+	out_result->sao_rc_errval = MIN(out_result->sao_rc_errval,
+					out_source->sao_rc_errval);
 	return 0;
 }
 

--- a/src/rsvc/srv.c
+++ b/src/rsvc/srv.c
@@ -1155,7 +1155,6 @@ ds_rsvc_start_aggregator(crt_rpc_t *source, crt_rpc_t *result, void *priv)
 	/* rc is error count, rc_errval an aggregation of values. */
 	out_result->sao_rc += out_source->sao_rc;
 
-	D_DEBUG(DB_MD, "\n");
 	out_result->sao_rc_errval = MIN(out_result->sao_rc_errval,
 					out_source->sao_rc_errval);
 	return 0;

--- a/src/rsvc/srv.c
+++ b/src/rsvc/srv.c
@@ -1152,11 +1152,14 @@ ds_rsvc_start_aggregator(crt_rpc_t *source, crt_rpc_t *result, void *priv)
 
 	out_source = crt_reply_get(source);
 	out_result = crt_reply_get(result);
-	/* rc is error count, rc_errval an aggregation of values. */
+	/* rc is error count, rc_errval first error value */
 	out_result->sao_rc += out_source->sao_rc;
 
-	out_result->sao_rc_errval = MIN(out_result->sao_rc_errval,
-					out_source->sao_rc_errval);
+	if (out_result->sao_rc_errval == 0) {
+		if (out_source->sao_rc_errval != 0)
+			out_result->sao_rc_errval = out_source->sao_rc_errval;
+	}
+
 	return 0;
 }
 


### PR DESCRIPTION
Cherry picked PR #2305 from daos master to release/0.9 branch.

Before this change when certain operations such as pool create
encounter -DER_NOSPACE during the replicated service startup phase,
a generic -DER_IO is returned to the client. The collective RPC
broadcast issued by the management service gets returned only a count
of errors by broadcast tree children nodes, rather than an aggregation
of the specific errors.

With this change, the collective RPC for RSVC_START maintains both
a count of nodes that returned an error and the first error code value
among the specific errors that individual nodes may have encountered.
The management service function that issues RSVC_START returns
the specific error rather than generic -DER_IO.

Signed-off-by: Kenneth Cain <kenneth.c.cain@intel.com>