### PR TITLE
DAOS-4269 bio: bump max ops per io channel to 4k (#2092)

### DIFF
--- a/src/bio/bio_buffer.c
+++ b/src/bio/bio_buffer.c
@@ -623,11 +623,17 @@ add_region:
 static void
 rw_completion(void *cb_arg, int err)
 {
+	struct bio_xs_context	*xs_ctxt;
 	struct bio_desc		*biod = cb_arg;
 	struct media_error_msg	*mem = NULL;
 
 	D_ASSERT(biod->bd_inflights > 0);
 	biod->bd_inflights--;
+
+	D_ASSERT(biod->bd_ctxt->bic_xs_ctxt);
+	xs_ctxt = biod->bd_ctxt->bic_xs_ctxt;
+	D_ASSERT(xs_ctxt->bxc_blob_rw > 0);
+	xs_ctxt->bxc_blob_rw--;
 
 	if (biod->bd_result == 0 && err != 0) {
 		biod->bd_result = daos_errno2der(-err);
@@ -635,8 +641,8 @@ rw_completion(void *cb_arg, int err)
 		if (mem == NULL)
 			goto skip_media_error;
 		mem->mem_update = biod->bd_update;
-		mem->mem_bs = biod->bd_ctxt->bic_xs_ctxt->bxc_blobstore;
-		mem->mem_tgt_id = biod->bd_ctxt->bic_xs_ctxt->bxc_tgt_id;
+		mem->mem_bs = xs_ctxt->bxc_blobstore;
+		mem->mem_tgt_id = xs_ctxt->bxc_tgt_id;
 		spdk_thread_send_msg(owner_thread(mem->mem_bs), bio_media_error,
 				     mem);
 	}
@@ -701,6 +707,10 @@ dma_rw(struct bio_desc *biod, bool prep)
 			pg_cnt -= pg_idx;
 
 			biod->bd_inflights++;
+			xs_ctxt->bxc_blob_rw++;
+			/* NVMe poll needs be scheduled */
+			if (bio_need_nvme_poll(xs_ctxt))
+				bio_yield();
 
 			D_DEBUG(DB_IO, "%s blob:%p payload:%p, "
 				"pg_idx:"DF_U64", pg_cnt:"DF_U64"\n",

--- a/src/bio/bio_internal.h
+++ b/src/bio/bio_internal.h
@@ -127,6 +127,7 @@ struct bio_blobstore {
 /* Per-xstream NVMe context */
 struct bio_xs_context {
 	int			 bxc_tgt_id;
+	unsigned int		 bxc_blob_rw;	/* inflight blob read/write */
 	struct spdk_thread	*bxc_thread;
 	struct bio_blobstore	*bxc_blobstore;
 	struct spdk_io_channel	*bxc_io_channel;

--- a/src/include/daos_srv/bio.h
+++ b/src/include/daos_srv/bio.h
@@ -588,4 +588,6 @@ int bio_get_dev_state(struct bio_dev_state *dev_state,
 int bio_dev_set_faulty(struct bio_xs_context *xs);
 
 
+/* Too many blob IO queued, need to schedule a NVMe poll? */
+bool bio_need_nvme_poll(struct bio_xs_context *xs);
 #endif /* __BIO_API_H__ */

--- a/src/iosrv/sched.c
+++ b/src/iosrv/sched.c
@@ -210,6 +210,8 @@ sched_pop_net_poll(struct sched_data *data, ABT_pool pool)
 static bool
 need_nvme_poll(struct sched_cycle *cycle)
 {
+	struct dss_module_info	*dmi;
+
 	/* Need net poll to start new cycle */
 	if (!cycle->sc_cycle_started) {
 		D_ASSERT(cycle->sc_ults_tot == 0);
@@ -220,16 +222,9 @@ need_nvme_poll(struct sched_cycle *cycle)
 	if (cycle->sc_ults_tot == 0)
 		return true;
 
-	/*
-	 * Need extra NVMe poll when too many ULTs are processed in
-	 * current cycle.
-	 */
-	if (cycle->sc_age_nvme > cycle->sc_age_nvme_bound[1])
-		return true;
-
-	/* TODO: Take NVMe I/O statistics into account */
-
-	return false;
+	dmi = dss_get_module_info();
+	D_ASSERT(dmi != NULL);
+	return bio_need_nvme_poll(dmi->dmi_nvme_ctxt);
 }
 
 static ABT_unit


### PR DESCRIPTION
The max blob read/write ops per io channel is 512 by default, it's
not enough for aggregation: Aggregation merge window size is 8MB,
let's assume an extreme case that the merge window consists of 4k
adjacent NVMe extents, then there will be 2k blob read ops on
window flush. There could be more blob reads on window flush when
the window consists of overlapped NVMe extents.

When there are multiple containers running aggregation in parallel
or many concurrent IO requests consists of many NVMe extents, the
512 limit could be exceeded easily.

This patch bumped the max ops to 4k in BIO, and schedule a NVMe
poll once queue blob IO exceeds a watermark (2k).

Signed-off-by: Niu Yawei <yawei.niu@intel.com>
Signed-off-by: Sydney Vanda <sydney.m.vanda@intel.com>