### PR TITLE
Daos 4252 test: Error pool/bad_exclude.yaml while parsing a block map…

### DIFF
--- a/src/tests/ftest/pool/bad_exclude.yaml
+++ b/src/tests/ftest/pool/bad_exclude.yaml
@@ -32,25 +32,29 @@ testparams:
    connectsetnames: !mux
       goodname:
          setname:
-            - test_server
+            - daos_server
             - PASS
       badname:
          setname:
-            - NULLPTR
+            - bad_name_server
             - FAIL
+      defaultname:
+         setname:
+            - NULLPTR
+            - PASS
    UUID: !mux
       gooduuid:
          uuid:
             - VALID
             - PASS
-     nulluuid:
-          uuid:
-             - NULLPTR
-             - FAIL
-     baduuid:
-          uuid:
-             - CRAP
-             - FAIL
+      nulluuid:
+         uuid:
+            - NULLPTR
+            - FAIL
+      baduuid:
+         uuid:
+            - CRAP
+            - FAIL
 pool:
    mode: 511
    name: daos_server


### PR DESCRIPTION
…ping (#2010)

* DAOS-4252 test: Error pool/bad_exclude.yaml while parsing a block mapping

Signed-off-by: Ding Ho <ding-hwa.ho@intel.com>