### PR TITLE
DAOS-3862 dfs: fetch symlink value in a separate RPC (#2313)

### DIFF
--- a/src/client/dfs/dfs.c
+++ b/src/client/dfs/dfs.c
@@ -312,16 +312,6 @@ fetch_entry(daos_handle_t oh, daos_handle_t th, const char *name,
 	d_iov_set(&sg_iovs[i++], &entry->ctime, sizeof(time_t));
 	d_iov_set(&sg_iovs[i++], &entry->chunk_size, sizeof(daos_size_t));
 
-	if (fetch_sym) {
-		D_ALLOC(value, PATH_MAX);
-		if (value == NULL)
-			return ENOMEM;
-
-		recx.rx_nr += PATH_MAX;
-		/** Set Akey for Symlink Value, will be empty if no symlink */
-		d_iov_set(&sg_iovs[i++], value, PATH_MAX);
-	}
-
 	sgl.sg_nr	= i;
 	sgl.sg_nr_out	= 0;
 	sgl.sg_iovs	= sg_iovs;
@@ -333,15 +323,34 @@ fetch_entry(daos_handle_t oh, daos_handle_t th, const char *name,
 	}
 
 	if (fetch_sym && S_ISLNK(entry->mode)) {
-		if (sgl.sg_nr_out == i) {
-			size_t sym_len = sg_iovs[i-1].iov_len;
+		size_t sym_len;
 
-			if (sym_len != 0) {
-				D_ASSERT(value);
-				D_STRNDUP(entry->value, value, PATH_MAX - 1);
-				if (entry->value == NULL)
-					D_GOTO(out, rc = ENOMEM);
-			}
+		D_ALLOC(value, PATH_MAX);
+		if (value == NULL)
+			return ENOMEM;
+
+		recx.rx_idx = sizeof(mode_t) + sizeof(time_t) * 3 +
+			sizeof(daos_obj_id_t) + sizeof(daos_size_t);
+		recx.rx_nr = PATH_MAX;
+
+		d_iov_set(&sg_iovs[0], value, PATH_MAX);
+		sgl.sg_nr	= 1;
+		sgl.sg_nr_out	= 0;
+		sgl.sg_iovs	= sg_iovs;
+
+		rc = daos_obj_fetch(oh, th, 0, &dkey, 1, &iod, &sgl, NULL,
+				    NULL);
+		if (rc) {
+			D_ERROR("Failed to fetch entry %s (%d)\n", name, rc);
+			D_GOTO(out, rc = daos_der2errno(rc));
+		}
+
+		sym_len = sg_iovs[0].iov_len;
+		if (sym_len != 0) {
+			D_ASSERT(value);
+			D_STRNDUP(entry->value, value, PATH_MAX - 1);
+			if (entry->value == NULL)
+				D_GOTO(out, rc = ENOMEM);
 		}
 	}
 
@@ -531,7 +540,7 @@ entry_stat(dfs_t *dfs, daos_handle_t th, daos_handle_t oh, const char *name,
 		break;
 	}
 	case S_IFLNK:
-		size = strlen(entry.value) + 1;
+		size = strlen(entry.value);
 		D_FREE(entry.value);
 		break;
 	default:

--- a/src/include/daos_fs.h
+++ b/src/include/daos_fs.h
@@ -561,7 +561,7 @@ dfs_get_chunk_size(dfs_obj_t *obj, daos_size_t *chunk_size);
 /**
  * Retrieve Symlink value of object if it's a symlink. If the buffer size passed
  * in is not large enough, we copy up to size of the buffer, and update the size
- * to actual value size.
+ * to actual value size. The size returned includes the null terminator.
  *
  * \param[in]	obj	Open object to query.
  * \param[in]	buf	user buffer to copy the symlink value in.

--- a/src/tests/suite/dfs_test.c
+++ b/src/tests/suite/dfs_test.c
@@ -466,6 +466,46 @@ dfs_test_short_read(void **state)
 	D_FREE(rsgl.sg_iovs);
 }
 
+
+static void
+dfs_test_syml(void **state)
+{
+	test_arg_t		*arg = *state;
+	dfs_obj_t		*sym;
+	char			*filename = "syml_file";
+	char			*val = "SYMLINK VAL 1";
+	char			tmp_buf[64];
+	struct stat		stbuf;
+	daos_size_t		size;
+	int			rc;
+
+	if (arg->myrank != 0)
+		goto syml_stat;
+
+	rc = dfs_open(dfs_mt, NULL, filename, S_IFLNK | S_IWUSR | S_IRUSR,
+		      O_RDWR | O_CREAT | O_EXCL, 0, 0, val, &sym);
+	assert_int_equal(rc, 0);
+
+	rc = dfs_get_symlink_value(sym, NULL, &size);
+	assert_int_equal(rc, 0);
+	assert_int_equal(size, strlen(val)+1);
+
+	rc = dfs_get_symlink_value(sym, tmp_buf, &size);
+	assert_int_equal(rc, 0);
+	assert_int_equal(size, strlen(val) + 1);
+	assert_string_equal(val, tmp_buf);
+
+	rc = dfs_release(sym);
+	assert_int_equal(rc, 0);
+
+syml_stat:
+	MPI_Barrier(MPI_COMM_WORLD);
+	rc = dfs_stat(dfs_mt, NULL, filename, &stbuf);
+	assert_int_equal(rc, 0);
+	assert_int_equal(stbuf.st_size, strlen(val));
+	MPI_Barrier(MPI_COMM_WORLD);
+}
+
 static const struct CMUnitTest dfs_tests[] = {
 	{ "DFS_TEST1: DFS mount / umount",
 	  dfs_test_mount, async_disable, test_case_teardown},
@@ -473,6 +513,8 @@ static const struct CMUnitTest dfs_tests[] = {
 	  dfs_test_short_read, async_disable, test_case_teardown},
 	{ "DFS_TEST3: multi-threads read shared file",
 	  dfs_test_read_shared_file, async_disable, test_case_teardown},
+	{ "DFS_TEST4: Simple Symlinks",
+	  dfs_test_syml, async_disable, test_case_teardown},
 };
 
 static int


### PR DESCRIPTION
Depending on the type of the entry being fetch, add a second fetch
to get the symlink value instead of doing it in the original fetch.
The original way was adding overhead to all entry types stats which
we can avoid by separating the symlin fetch because that needs a bulk.

Signed-off-by: Mohamad Chaarawi <mohamad.chaarawi@intel.com>
Conflicts:
	src/tests/suite/dfs_test.c