### PR TITLE
DAOS-4164 build: Restrict SPDK version

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -49,7 +49,7 @@ def el7_component_repos = ""
 def component_repos = ""
 def daos_repo = "daos@${env.BRANCH_NAME}:${env.BUILD_NUMBER}"
 def el7_daos_repos = el7_component_repos + ' ' + component_repos + ' ' + daos_repo
-def functional_rpms  = "--exclude openmpi openmpi3 hwloc ndctl spdk-tools " +
+def functional_rpms  = "--exclude openmpi openmpi3 hwloc ndctl " +
                        "ior-hpc-cart-4-daos-0 mpich-autoload-cart-4-daos-0 " +
                        "romio-tests-cart-4-daos-0 hdf5-tests-cart-4-daos-0 " +
                        "mpi4py-tests-cart-4-daos-0 testmpio-cart-4-daos-0"

--- a/utils/rpms/daos.spec
+++ b/utils/rpms/daos.spec
@@ -4,12 +4,11 @@
 
 %global mercury_version 2.0.0a1-0.7.git.41caa14%{?dist}
 
-# Unlimited maximum version
-%global spdk_max_version 1000
+%global spdk_version 19.04.1
 
 Name:          daos
 Version:       1.1.0
-Release:       8%{?relval}%{?dist}
+Release:       9%{?relval}%{?dist}
 Summary:       DAOS Storage Engine
 
 License:       Apache
@@ -34,7 +33,7 @@ BuildRequires: libabt-devel >= 1.0rc1
 BuildRequires: libpmem-devel, libpmemobj-devel
 BuildRequires: fuse-devel >= 3.4.2
 BuildRequires: protobuf-c-devel
-BuildRequires: spdk-devel <= %{spdk_max_version}, spdk-tools <= %{spdk_max_version}
+BuildRequires: spdk-devel = %{spdk_version}
 BuildRequires: fio < 3.4
 %if (0%{?rhel} >= 7)
 BuildRequires: libisa-l-devel
@@ -92,7 +91,7 @@ Requires: libpmem1, libpmemobj1
 %endif
 Requires: fuse >= 3.4.2
 Requires: protobuf-c
-Requires: spdk <= %{spdk_max_version}
+Requires: spdk >= %{spdk_version}, spdk < 20
 Requires: fio < 3.4
 Requires: openssl
 # This should only be temporary until we can get a stable upstream release
@@ -115,7 +114,7 @@ to optimize performance and cost.
 Summary: The DAOS server
 Requires: %{name} = %{version}-%{release}
 Requires: %{name}-client = %{version}-%{release}
-Requires: spdk-tools <= %{spdk_max_version}
+Requires: spdk-tools >= %{spdk_version}, spdk-tools < 20
 Requires: ndctl
 Requires: ipmctl
 Requires: hwloc
@@ -349,6 +348,9 @@ getent group daos_admins >/dev/null || groupadd -r daos_admins
 %{_libdir}/*.a
 
 %changelog
+* Thu Apr 02 2020 Tom Nabarro <tom.nabarro@intel.com> - 1.1.0-9
+- Pin version of spdk to 19.04.1 and restrict runtime version >=
+
 * Fri Mar 27 2020 David Quigley <david.quigley@intel.com> - 1.1.0-8
 - add daos and dmg man pages to the daos-client files list
 


### PR DESCRIPTION
Restrict runtime spdk version to < 20 so we can update packages in a
future commit.

Signed-off-by: Tom Nabarro <tom.nabarro@intel.com>
Co-authored-by: Brian J. Murrell <brian.murrell@intel.com>