### PR TITLE
DAOS-3672 rebuild: Do not use bit to track rebuild

### DIFF
--- a/src/rebuild/rebuild_internal.h
+++ b/src/rebuild/rebuild_internal.h
@@ -131,6 +131,12 @@ struct rebuild_tgt_pool_tracker {
 				rt_global_done:1;
 };
 
+struct rebuild_server_status {
+	d_rank_t	rank;
+	uint32_t	scan_done:1,
+			pull_done:1;
+};
+
 /* Track the rebuild status globally */
 struct rebuild_global_pool_tracker {
 	/* rebuild status */
@@ -150,16 +156,11 @@ struct rebuild_global_pool_tracker {
 	/** the current version being rebuilt */
 	uint32_t	rgt_rebuild_ver;
 
-	/* bits to track scan status for all targets */
-	uint8_t		*rgt_scan_bits;
+	/** rebuild status for each server */
+	struct rebuild_server_status *rgt_servers;
 
-	/* bits to track pull status for all targets */
-	uint8_t		*rgt_pull_bits;
-
-	/* The size of rgt_scan_bits and
-	 * rgt_pull_bits in bit
-	 */
-	uint32_t	rgt_bits_size;
+	/** number of rgt_server_status */
+	uint32_t	rgt_servers_number;
 
 	/* The term of the current rebuild leader */
 	uint64_t	rgt_leader_term;
@@ -319,26 +320,6 @@ int rebuild_iv_update(void *ns, struct rebuild_iv *rebuild_iv,
 int rebuild_iv_ns_create(struct ds_pool *pool, uint32_t map_ver,
 			 d_rank_list_t *exclude_tgts,
 			 unsigned int master_rank);
-
-static inline bool
-is_rebuild_global_pull_done(struct rebuild_global_pool_tracker *rgt)
-{
-	return isset_range(rgt->rgt_pull_bits, 0, rgt->rgt_bits_size - 1);
-}
-
-static inline bool
-is_rebuild_global_scan_done(struct rebuild_global_pool_tracker *rgt)
-{
-	return isset_range(rgt->rgt_scan_bits, 0, rgt->rgt_bits_size - 1);
-}
-
-static inline bool
-is_rebuild_global_done(struct rebuild_global_pool_tracker *rgt)
-{
-	return is_rebuild_global_scan_done(rgt) &&
-	       is_rebuild_global_pull_done(rgt);
-
-}
 
 int rebuild_iv_init(void);
 int rebuild_iv_fini(void);

--- a/src/rebuild/srv.c
+++ b/src/rebuild/srv.c
@@ -138,6 +138,67 @@ rebuild_tls_init(const struct dss_thread_local_storage *dtls,
 	return tls;
 }
 
+static bool
+is_rebuild_global_pull_done(struct rebuild_global_pool_tracker *rgt)
+{
+	int i;
+
+	D_ASSERT(rgt->rgt_servers_number > 0);
+	D_ASSERT(rgt->rgt_servers != NULL);
+
+	for (i = 0; i < rgt->rgt_servers_number; i++)
+		if (!rgt->rgt_servers[i].pull_done)
+			return false;
+	return true;
+}
+
+static bool
+is_rebuild_global_scan_done(struct rebuild_global_pool_tracker *rgt)
+{
+	int i;
+
+	D_ASSERT(rgt->rgt_servers_number > 0);
+	D_ASSERT(rgt->rgt_servers != NULL);
+
+	for (i = 0; i < rgt->rgt_servers_number; i++)
+		if (!rgt->rgt_servers[i].scan_done)
+			return false;
+	return true;
+}
+
+static bool
+is_rebuild_global_done(struct rebuild_global_pool_tracker *rgt)
+{
+	return is_rebuild_global_scan_done(rgt) &&
+	       is_rebuild_global_pull_done(rgt);
+
+}
+
+#define SCAN_DONE	0x1
+#define PULL_DONE	0x2
+static void
+rebuild_leader_set_status(struct rebuild_global_pool_tracker *rgt,
+			  d_rank_t rank, unsigned flags)
+{
+	struct rebuild_server_status	*status = NULL;
+	int				i;
+
+	D_ASSERT(rgt->rgt_servers_number > 0);
+	D_ASSERT(rgt->rgt_servers != NULL);
+	for (i = 0; i < rgt->rgt_servers_number; i++) {
+		if (rgt->rgt_servers[i].rank == rank) {
+			status = &rgt->rgt_servers[i];
+			break;
+		}
+	}
+
+	D_ASSERTF(status != NULL, "Can not find rank %u\n", rank);
+	if (flags & SCAN_DONE)
+		status->scan_done = 1;
+	if (flags & PULL_DONE)
+		status->pull_done = 1;
+}
+
 struct rebuild_tgt_pool_tracker *
 rpt_lookup(uuid_t pool_uuid, unsigned int ver)
 {
@@ -188,10 +249,9 @@ rebuild_global_status_update(struct rebuild_global_pool_tracker *rgt,
 		return 0;
 
 	if (!is_rebuild_global_scan_done(rgt)) {
-		setbit(rgt->rgt_scan_bits, iv->riv_rank);
-		D_DEBUG(DB_REBUILD, "rebuild ver %d tgt %d scan"
-			" done bits %x\n", rgt->rgt_rebuild_ver,
-			iv->riv_rank, rgt->rgt_scan_bits[0]);
+		rebuild_leader_set_status(rgt, iv->riv_rank, SCAN_DONE);
+		D_DEBUG(DB_REBUILD, "rebuild ver %d tgt %d scan done\n",
+			rgt->rgt_rebuild_ver, iv->riv_rank);
 		/* If global scan is not done, then you can not trust
 		 * pull status. But if the rebuild on that target is
 		 * failed(riv_status != 0), then the target will report
@@ -204,10 +264,9 @@ rebuild_global_status_update(struct rebuild_global_pool_tracker *rgt,
 
 	/* Only trust pull done if scan is done globally */
 	if (iv->riv_pull_done) {
-		setbit(rgt->rgt_pull_bits, iv->riv_rank);
-		D_DEBUG(DB_REBUILD, "rebuild ver %d tgt %d pull"
-			" done bits %x\n", rgt->rgt_rebuild_ver,
-			iv->riv_rank, rgt->rgt_pull_bits[0]);
+		rebuild_leader_set_status(rgt, iv->riv_rank, PULL_DONE);
+		D_DEBUG(DB_REBUILD, "rebuild ver %d tgt %d pull done\n",
+			rgt->rgt_rebuild_ver, iv->riv_rank);
 	}
 
 	return 0;
@@ -563,10 +622,9 @@ rebuild_leader_status_check(struct ds_pool *pool, uint32_t map_ver,
 					dom->do_comp.co_rank);
 				if (pool_component_unavail(&dom->do_comp,
 							false)) {
-					setbit(rgt->rgt_scan_bits,
-					       dom->do_comp.co_rank);
-					setbit(rgt->rgt_pull_bits,
-					       dom->do_comp.co_rank);
+					rebuild_leader_set_status(rgt,
+						dom->do_comp.co_rank,
+						SCAN_DONE|PULL_DONE);
 				}
 			}
 			D_FREE(targets);
@@ -654,11 +712,8 @@ static void
 rebuild_global_pool_tracker_destroy(struct rebuild_global_pool_tracker *rgt)
 {
 	d_list_del(&rgt->rgt_list);
-	if (rgt->rgt_scan_bits)
-		D_FREE(rgt->rgt_scan_bits);
-
-	if (rgt->rgt_pull_bits)
-		D_FREE(rgt->rgt_pull_bits);
+	if (rgt->rgt_servers)
+		D_FREE(rgt->rgt_servers);
 
 	D_FREE(rgt);
 }
@@ -669,25 +724,26 @@ rebuild_global_pool_tracker_create(struct ds_pool *pool, uint32_t ver,
 {
 	struct rebuild_global_pool_tracker *rgt;
 	unsigned int node_nr;
-	unsigned int array_size;
+	struct pool_domain *doms;
+	int i;
 	int rc = 0;
 
 	D_ALLOC_PTR(rgt);
 	if (rgt == NULL)
 		return -DER_NOMEM;
+
 	D_INIT_LIST_HEAD(&rgt->rgt_list);
+	node_nr = pool_map_find_nodes(pool->sp_map, PO_COMP_ID_ALL, &doms);
+	if (node_nr < 0)
+		D_GOTO(out, rc = node_nr);
 
-	node_nr = pool_map_node_nr(pool->sp_map);
-	array_size = roundup(node_nr, NBBY) / NBBY;
-	rgt->rgt_bits_size = node_nr;
-
-	D_ALLOC_ARRAY(rgt->rgt_scan_bits, array_size);
-	if (rgt->rgt_scan_bits == NULL)
+	D_ALLOC_ARRAY(rgt->rgt_servers, node_nr);
+	if (rgt->rgt_servers == NULL)
 		D_GOTO(out, rc = -DER_NOMEM);
 
-	D_ALLOC_ARRAY(rgt->rgt_pull_bits, array_size);
-	if (rgt->rgt_pull_bits == NULL)
-		D_GOTO(out, rc = -DER_NOMEM);
+	for (i = 0; i < node_nr; i++)
+		rgt->rgt_servers[i].rank = doms[i].do_comp.co_rank;
+	rgt->rgt_servers_number = node_nr;
 
 	uuid_copy(rgt->rgt_pool_uuid, pool->sp_uuid);
 	rgt->rgt_rebuild_ver = ver;
@@ -696,7 +752,7 @@ rebuild_global_pool_tracker_create(struct ds_pool *pool, uint32_t ver,
 out:
 	if (rc)
 		rebuild_global_pool_tracker_destroy(rgt);
-	return 0;
+	return rc;
 }
 
 /* To notify all targets to prepare the rebuild */
@@ -728,7 +784,7 @@ rebuild_prepare(struct ds_pool *pool, uint32_t rebuild_ver,
 		bool excluded = false;
 		int i;
 
-		/* Set failed(being rebuilt) targets scan/pull bits.*/
+		/* Set failed(being rebuilt) targets scan/pull status.*/
 		for (i = 0; i < exclude_tgts->pti_number; i++) {
 			struct pool_target *target;
 			struct pool_domain *dom;
@@ -747,18 +803,11 @@ rebuild_prepare(struct ds_pool *pool, uint32_t rebuild_ver,
 			dom = pool_map_find_node_by_rank(pool->sp_map,
 						target->ta_comp.co_rank);
 			if (dom && dom->do_comp.co_status == PO_COMP_ST_DOWN) {
-				D_ASSERT(dom->do_comp.co_rank <
-					  (*rgt)->rgt_bits_size);
-				setbit((*rgt)->rgt_scan_bits,
-					dom->do_comp.co_rank);
-				setbit((*rgt)->rgt_pull_bits,
-					dom->do_comp.co_rank);
-				D_DEBUG(DB_REBUILD, "exclude target fail with"
-					"%u/%u scan bits 0x%x pull bits 0x%x\n",
-					target->ta_comp.co_rank,
-					target->ta_comp.co_id,
-					*(*rgt)->rgt_scan_bits,
-					*(*rgt)->rgt_pull_bits);
+				rebuild_leader_set_status(*rgt,
+							  dom->do_comp.co_rank,
+							  SCAN_DONE|PULL_DONE);
+				D_DEBUG(DB_REBUILD, "exclude target %u\n",
+					target->ta_comp.co_rank);
 			}
 		}
 		/* Sigh these failed targets does not exist in the pool


### PR DESCRIPTION
Because the pool might be created on selected servers,
let's not use single bit to track single server rebuild
status.

master-PR:2122

Signed-off-by: Di Wang <di.wang@intel.com>