### PR TITLE
DAOS-4488 dtx: handle conditional modification in DTX

### DIFF
--- a/src/common/checksum.c
+++ b/src/common/checksum.c
@@ -1162,7 +1162,7 @@ daos_csummer_calc_iods(struct daos_csummer *obj, d_sg_list_t *sgls,
 	uint32_t		 iods_csums_nr;
 	uint16_t		 csum_len = daos_csummer_get_csum_len(obj);
 
-	if (!daos_csummer_initialized(obj))
+	if (!daos_csummer_initialized(obj) || nr == 0)
 		return 0;
 
 	*p_iods_csums = NULL;

--- a/src/include/daos/object.h
+++ b/src/include/daos/object.h
@@ -388,6 +388,8 @@ enum daos_io_flags {
 	DIOF_WITH_SPEC_EPOCH	= 0x4,
 	/* The operation is for EC recovering. */
 	DIOF_EC_RECOV		= 0x8,
+	/* The the key existence. */
+	DIOF_CHECK_EXISTENCE	= 0x10,
 };
 
 /**

--- a/src/object/cli_obj.c
+++ b/src/object/cli_obj.c
@@ -3062,7 +3062,8 @@ dc_obj_update_task(tse_task_t *task)
 	/* submit the update */
 	return dc_obj_update(task, &epoch, map_ver, args);
 comp:
-	tse_task_complete(task, rc);
+	if (rc <= 0)
+		tse_task_complete(task, rc);
 	return rc;
 }
 
@@ -3331,7 +3332,8 @@ obj_punch_common(tse_task_t *task, enum obj_rpc_opc opc, daos_obj_punch_t *args)
 	/* submit the punch */
 	return dc_obj_punch(task, &epoch, map_ver, opc, args);
 comp:
-	tse_task_complete(task, rc);
+	if (rc <= 0)
+		tse_task_complete(task, rc);
 	return rc;
 }
 

--- a/src/object/obj_internal.h
+++ b/src/object/obj_internal.h
@@ -512,5 +512,10 @@ int
 dc_tx_non_cpd_cb(daos_handle_t th, int result);
 
 int
-dc_tx_attach(daos_handle_t th, void *args, enum obj_rpc_opc opc);
+dc_tx_attach(daos_handle_t th, void *args, enum obj_rpc_opc opc,
+	     tse_task_t *task);
+
+void
+dc_tx_check_existence_cb(void *data, tse_task_t *task);
+
 #endif /* __DAOS_OBJ_INTENRAL_H__ */

--- a/src/object/obj_tx.c
+++ b/src/object/obj_tx.c
@@ -1326,7 +1326,12 @@ dc_tx_check_existence_task(enum obj_rpc_opc opc, daos_handle_t oh,
 		goto out;
 	}
 
-	return dc_task_schedule(task, true);
+	rc = dc_task_schedule(task, true);
+
+	/* Return positive value to notify the sponsor to not call
+	 * complete() the task until the checking existence callback.
+	 */
+	return rc == 0 ? 1 : rc;
 
 out:
 	if (iods != NULL && iods != iods_or_akeys) {

--- a/src/object/obj_tx.c
+++ b/src/object/obj_tx.c
@@ -583,7 +583,7 @@ dc_tx_commit_non_cpd(tse_task_t *task, struct dc_tx *tx)
 		daos_obj_update_t	*args = dc_task_get_args(task);
 
 		args->th = dc_tx_ptr2hdl(tx);
-		args->oh = obj_ptr2hdl(dtsr->dtsr_obj),
+		args->oh = obj_ptr2hdl(dtsr->dtsr_obj);
 		args->flags = dtsr->dtsr_flags;
 		args->dkey = dtsr->dtsr_dkey;
 		args->nr = dtsr->dtsr_nr;
@@ -596,7 +596,7 @@ dc_tx_commit_non_cpd(tse_task_t *task, struct dc_tx *tx)
 		daos_obj_punch_t	*args = dc_task_get_args(task);
 
 		args->th = dc_tx_ptr2hdl(tx);
-		args->oh = obj_ptr2hdl(dtsr->dtsr_obj),
+		args->oh = obj_ptr2hdl(dtsr->dtsr_obj);
 		args->dkey = dtsr->dtsr_dkey;
 		args->akeys = dtsr->dtsr_akeys;
 		args->flags = dtsr->dtsr_flags;
@@ -934,12 +934,14 @@ out_tx:
 
 static int
 dc_tx_add_update(struct dc_tx *tx, daos_handle_t oh, uint64_t flags,
-		 daos_key_t *dkey, unsigned int nr, daos_iod_t *iods,
+		 daos_key_t *dkey, uint32_t nr, daos_iod_t *iods,
 		 d_sg_list_t *sgls)
 {
 	struct dc_tx_sub_req	*dtsr;
 	int			 rc = 0;
 	int			 i;
+
+	D_ASSERT(nr != 0);
 
 	D_ALLOC_PTR(dtsr);
 	if (dtsr == NULL)
@@ -963,9 +965,6 @@ dc_tx_add_update(struct dc_tx *tx, daos_handle_t oh, uint64_t flags,
 		rc = daos_iov_copy(dtsr->dtsr_dkey, dkey);
 		if (rc != 0)
 			D_GOTO(fail, rc);
-
-		if (nr == 0)
-			goto link;
 
 		D_ALLOC_ARRAY(dtsr->dtsr_iods, nr);
 		if (dtsr->dtsr_iods == NULL)
@@ -1002,7 +1001,6 @@ dc_tx_add_update(struct dc_tx *tx, daos_handle_t oh, uint64_t flags,
 			D_GOTO(fail, rc);
 	}
 
-link:
 	d_list_add_tail(&dtsr->dtsr_link, &tx->tx_sub_reqs);
 	tx->tx_sub_count++;
 
@@ -1111,11 +1109,13 @@ fail:
 
 static int
 dc_tx_add_punch_akeys(struct dc_tx *tx, daos_handle_t oh, uint64_t flags,
-		      daos_key_t *dkey, unsigned int nr, daos_key_t *akeys)
+		      daos_key_t *dkey, uint32_t nr, daos_key_t *akeys)
 {
 	struct dc_tx_sub_req	*dtsr;
 	int			 rc = 0;
 	int			 i;
+
+	D_ASSERT(nr != 0);
 
 	D_ALLOC_PTR(dtsr);
 	if (dtsr == NULL)
@@ -1139,9 +1139,6 @@ dc_tx_add_punch_akeys(struct dc_tx *tx, daos_handle_t oh, uint64_t flags,
 		if (rc != 0)
 			D_GOTO(fail, rc);
 
-		if (nr == 0)
-			goto link;
-
 		D_ALLOC_ARRAY(dtsr->dtsr_akeys, nr);
 		if (dtsr->dtsr_akeys == NULL)
 			D_GOTO(fail, rc = -DER_NOMEM);
@@ -1153,7 +1150,6 @@ dc_tx_add_punch_akeys(struct dc_tx *tx, daos_handle_t oh, uint64_t flags,
 		}
 	}
 
-link:
 	d_list_add_tail(&dtsr->dtsr_link, &tx->tx_sub_reqs);
 	tx->tx_sub_count++;
 
@@ -1179,11 +1175,179 @@ fail:
 	return rc;
 }
 
+struct dc_tx_check_existence_cb_args {
+	enum obj_rpc_opc	opc;
+	struct dc_tx		*tx;
+	daos_handle_t		oh;
+	uint64_t		flags;
+	daos_key_t		*dkey;
+	uint64_t		nr;
+	void			*iods_or_akeys;
+	d_sg_list_t		*sgls;
+	daos_iod_t		*tmp_iods;
+};
+
+void
+dc_tx_check_existence_cb(void *data, tse_task_t *task)
+{
+	struct dc_tx_check_existence_cb_args	*args = data;
+	struct dc_tx				*tx = args->tx;
+	int					 rc = 0;
+
+	D_MUTEX_LOCK(&tx->tx_lock);
+
+	switch (args->opc) {
+	case DAOS_OBJ_RPC_UPDATE:
+		if (args->flags & (DAOS_COND_DKEY_INSERT |
+				   DAOS_COND_AKEY_INSERT)) {
+			if (task->dt_result == 0)
+				D_GOTO(out, rc = -DER_EXIST);
+
+			if (task->dt_result != -DER_NONEXIST)
+				D_GOTO(out, rc = task->dt_result);
+		} else if (args->flags & (DAOS_COND_DKEY_UPDATE |
+					  DAOS_COND_AKEY_UPDATE)) {
+			if (task->dt_result != 0)
+				D_GOTO(out, rc = task->dt_result);
+		}
+
+		rc = dc_tx_add_update(tx, args->oh, args->flags,
+				      args->dkey, args->nr,
+				      args->iods_or_akeys, args->sgls);
+		break;
+	case DAOS_OBJ_RPC_PUNCH_DKEYS:
+		D_ASSERT(args->flags & DAOS_COND_PUNCH);
+
+		if (task->dt_result != 0)
+			D_GOTO(out, rc = task->dt_result);
+
+		rc = dc_tx_add_punch_dkey(tx, args->oh, args->flags,
+					  args->dkey);
+		break;
+	case DAOS_OBJ_RPC_PUNCH_AKEYS:
+		D_ASSERT(args->flags & DAOS_COND_PUNCH);
+
+		if (task->dt_result != 0)
+			D_GOTO(out, rc = task->dt_result);
+
+		rc = dc_tx_add_punch_akeys(tx, args->oh, args->flags,
+					   args->dkey, args->nr,
+					   args->iods_or_akeys);
+		break;
+	default:
+		D_ASSERT(0);
+	}
+
+out:
+	D_MUTEX_UNLOCK(&tx->tx_lock);
+
+	/* Drop the reference that is held via dc_tx_attach(). */
+	dc_tx_decref(tx);
+	if (args->tmp_iods != NULL) {
+		int		i;
+
+		for (i = 0; i < args->nr; i++)
+			daos_iov_free(&args->tmp_iods[i].iod_name);
+
+		D_FREE(args->tmp_iods);
+	}
+
+	D_FREE(args);
+	/* The errno will be auto propagated to the dependent task. */
+	task->dt_result = rc;
+}
+
+static int
+dc_tx_check_existence_task(enum obj_rpc_opc opc, daos_handle_t oh,
+			   struct dc_tx *tx, uint64_t flags, daos_key_t *dkey,
+			   uint32_t nr, void *iods_or_akeys, d_sg_list_t *sgls,
+			   tse_task_t *parent)
+{
+	daos_iod_t				*iods = NULL;
+	struct dc_tx_check_existence_cb_args	*cb_args;
+	tse_task_t				*task;
+	uint64_t				 api_flags;
+	int					 rc;
+	int					 i;
+
+	D_ALLOC_PTR(cb_args);
+	if (cb_args == NULL)
+		return -DER_NOMEM;
+
+	cb_args->opc		= opc;
+	cb_args->tx		= tx;
+	cb_args->oh		= oh;
+	cb_args->flags		= flags;
+	cb_args->dkey		= dkey;
+	cb_args->nr		= nr;
+	cb_args->iods_or_akeys	= iods_or_akeys;
+	cb_args->sgls		= sgls;
+
+	if (nr != 0) {
+		D_ASSERT(iods_or_akeys != NULL);
+
+		if (opc != DAOS_OBJ_RPC_UPDATE) {
+			D_ALLOC_ARRAY(iods, nr);
+			if (iods == NULL)
+				D_GOTO(out, rc = -DER_NOMEM);
+
+			for (i = 0; i < nr; i++) {
+				rc = daos_iov_copy(&iods[i].iod_name,
+					&((daos_key_t *)iods_or_akeys)[i]);
+				if (rc != 0)
+					goto out;
+			}
+
+			api_flags = DAOS_COND_AKEY_FETCH;
+			cb_args->tmp_iods = iods;
+		} else if (flags & (DAOS_COND_AKEY_INSERT |
+				    DAOS_COND_AKEY_UPDATE)) {
+			iods = iods_or_akeys;
+			api_flags = DAOS_COND_AKEY_FETCH;
+		} else {
+			/* Only check dkey existence. */
+			api_flags = DAOS_COND_DKEY_FETCH;
+		}
+	} else {
+		api_flags = DAOS_COND_DKEY_FETCH;
+	}
+
+	rc = dc_obj_fetch_task_create(oh, dc_tx_ptr2hdl(tx), api_flags, dkey,
+			nr, DIOF_CHECK_EXISTENCE | DIOF_TO_LEADER, iods, sgls,
+			NULL, cb_args, NULL, tse_task2sched(parent), &task);
+	if (rc != 0)
+		goto out;
+
+	rc = dc_task_depend(parent, 1, &task);
+	if (rc != 0) {
+		D_ERROR("Fail to add dep on check existence task: "DF_RC"\n",
+			DP_RC(rc));
+		dc_task_decref(task);
+		goto out;
+	}
+
+	return dc_task_schedule(task, true);
+
+out:
+	if (iods != NULL && iods != iods_or_akeys) {
+		for (i = 0; i < nr; i++)
+			daos_iov_free(&iods[i].iod_name);
+
+		D_FREE(iods);
+	}
+
+	D_FREE(cb_args);
+
+	return rc;
+}
+
 int
-dc_tx_attach(daos_handle_t th, void *args, enum obj_rpc_opc opc)
+dc_tx_attach(daos_handle_t th, void *args, enum obj_rpc_opc opc,
+	     tse_task_t *task)
 {
 	struct dc_tx	*tx;
 	int		 rc;
+	bool		 locked = true;
 
 	rc = dc_tx_check(th, true, &tx);
 	if (rc != 0)
@@ -1193,12 +1357,28 @@ dc_tx_attach(daos_handle_t th, void *args, enum obj_rpc_opc opc)
 	case DAOS_OBJ_RPC_UPDATE: {
 		daos_obj_update_t	*up = args;
 
-		rc = dc_tx_add_update(tx, up->oh, up->flags, up->dkey,
-				      up->nr, up->iods, up->sgls);
+		if (up->flags & (DAOS_COND_DKEY_INSERT |
+				 DAOS_COND_DKEY_UPDATE |
+				 DAOS_COND_AKEY_INSERT |
+				 DAOS_COND_AKEY_UPDATE)) {
+			D_MUTEX_UNLOCK(&tx->tx_lock);
+			locked = false;
+			rc = dc_tx_check_existence_task(opc, up->oh, tx,
+							up->flags, up->dkey,
+							up->nr, up->iods,
+							up->sgls, task);
+		} else {
+			rc = dc_tx_add_update(tx, up->oh, up->flags, up->dkey,
+					      up->nr, up->iods, up->sgls);
+		}
 		break;
 	}
 	case DAOS_OBJ_RPC_PUNCH: {
 		daos_obj_punch_t	*pu = args;
+
+		D_ASSERTF(!(pu->flags & DAOS_COND_MASK),
+			  "Unexpected cond flag %lx for punch obj\n",
+			  pu->flags);
 
 		rc = dc_tx_add_punch_obj(tx, pu->oh, pu->flags);
 		break;
@@ -1206,14 +1386,33 @@ dc_tx_attach(daos_handle_t th, void *args, enum obj_rpc_opc opc)
 	case DAOS_OBJ_RPC_PUNCH_DKEYS: {
 		daos_obj_punch_t	*pu = args;
 
-		rc = dc_tx_add_punch_dkey(tx, pu->oh, pu->flags, pu->dkey);
+		if (pu->flags & DAOS_COND_PUNCH) {
+			D_MUTEX_UNLOCK(&tx->tx_lock);
+			locked = false;
+			rc = dc_tx_check_existence_task(opc, pu->oh, tx,
+							pu->flags, pu->dkey, 0,
+							NULL, NULL, task);
+		} else {
+			rc = dc_tx_add_punch_dkey(tx, pu->oh, pu->flags,
+						  pu->dkey);
+		}
 		break;
 	}
 	case DAOS_OBJ_RPC_PUNCH_AKEYS: {
 		daos_obj_punch_t	*pu = args;
 
-		rc = dc_tx_add_punch_akeys(tx, pu->oh, pu->flags, pu->dkey,
-					   pu->akey_nr, pu->akeys);
+		if (pu->flags & DAOS_COND_PUNCH) {
+			D_MUTEX_UNLOCK(&tx->tx_lock);
+			locked = false;
+			rc = dc_tx_check_existence_task(opc, pu->oh, tx,
+							pu->flags, pu->dkey,
+							pu->akey_nr, pu->akeys,
+							NULL, task);
+		} else {
+			rc = dc_tx_add_punch_akeys(tx, pu->oh, pu->flags,
+						   pu->dkey, pu->akey_nr,
+						   pu->akeys);
+		}
 		break;
 	}
 	default:
@@ -1222,7 +1421,8 @@ dc_tx_attach(daos_handle_t th, void *args, enum obj_rpc_opc opc)
 		break;
 	}
 
-	D_MUTEX_UNLOCK(&tx->tx_lock);
+	if (locked)
+		D_MUTEX_UNLOCK(&tx->tx_lock);
 	dc_tx_decref(tx);
 
 	return rc;


### PR DESCRIPTION
For distributed transaction, we caches modifications on client
before committing. Single conditional modification is equal to
atomic "fetch" + "update/punch". If such conditional operation
is inside distributed transaction, because cache non-committed
modifications, then we will not handle the "fetch" that is the
1st part of the conditional modification. So the result of the
left part modification may be different from the case of being
executed on the server. That further misguides the application
to make take more wrong actions in subsequent operations.

The solution is that:

DTX client side logic will interpret conditional modification
if it is inside DTX context, trigger conditional fetch RPC for
related dkey/akey to related server, according to conditional
fetch result to decide whether cache the left modification part
on client or return error to application.

Signed-off-by: Fan Yong <fan.yong@intel.com>