### PR TITLE
DAOS-3219 utils: daos cmd per-resource/command help (#2307)

### DIFF
--- a/doc/man/man8/daos.8
+++ b/doc/man/man8/daos.8
@@ -41,7 +41,11 @@ The \fBRESOURCE\fRs, respective \fBCOMMAND\fRs and \fBOPTION\fRs supported by \f
 .br
 	  \fBobject \fR(\fBobj\fR)     object in a container
 .br
+	  \fBversion\fR          print command version
+.br
 	  \fBhelp\fR             print this message and exit
+.TP
+.I help \fR[\fBRESOURCE \fR[\fBCOMMAND\fR]] \h'4' per-resource/command help
 .TP
 .I pool \fBCOMMAND\fRs:
 	  \fBlist-containers\fR  list all containers in pool

--- a/doc/man/man8/daos.8
+++ b/doc/man/man8/daos.8
@@ -54,11 +54,13 @@ The \fBRESOURCE\fRs, respective \fBCOMMAND\fRs and \fBOPTION\fRs supported by \f
 .br
 	  \fBquery\fR            query a pool
 .br
-	  \fBstat\fR             get pool statistics
-.br
 	  \fBlist-attrs\fR       list pool user-defined attributes
 .br
 	  \fBget-attr\fR         get pool user-defined attribute
+.br
+	  \fBset-attr\fR         set pool user-defined attribute
+.br
+	  \fBget-prop\fR         get all pool's properties
 .br
 .TP
 .I pool \fBOPTION\fRs:
@@ -84,11 +86,13 @@ The \fBRESOURCE\fRs, respective \fBCOMMAND\fRs and \fBOPTION\fRs supported by \f
 .br
 	  \fBquery\fR            query a container
 .br
-	  \fBstat\fR             get container statistics
+	  \fBget-prop\fR         get all container's properties
+.br
+	  \fBset-prop\fR         set container's properties
+.br
+	  \fBget-acl\fR          get a container's ACL
 .br
 	  \fBlist-attrs\fR       list container user-defined attributes
-.br
-	  \fBdel-attr\fR         delete container user-defined attribute
 .br
 	  \fBget-attr\fR         get container user-defined attribute
 .br
@@ -103,8 +107,6 @@ The \fBRESOURCE\fRs, respective \fBCOMMAND\fRs and \fBOPTION\fRs supported by \f
 	  \fBdestroy-snap\fR     destroy container snapshots
 .br
 				    by name, epoch or range
-.br
-	  \fBrollback\fR         roll back container to specified snapshot
 .TP
 .I container \fBOPTION\fRs (create by UUID):
 	  <\fIpool\fR options>   (\fB--pool\fR, \fB--sys-name\fR, \fB--svc\fR)
@@ -115,7 +117,8 @@ The \fBRESOURCE\fRs, respective \fBCOMMAND\fRs and \fBOPTION\fRs supported by \f
 	  <\fIpool\fR/\fIcont\fR opts>   (\fB--pool\fR, \fB--sys-name\fR, \fB--svc\fR, \fB--cont\fR [optional])
 .br
 	  \fB--path=\fRPATHSTR     container namespace path to be created and provide a direct link to new DAOS container
-.br
+.TP
+.I container \fBOPTION\fRs (create common optional):
 	  \fB--type=\fRCTYPESTR    container type (HDF5, POSIX)
 .br
 	  \fB--oclass=\fROCLSSTR   container object class
@@ -125,6 +128,22 @@ The \fBRESOURCE\fRs, respective \fBCOMMAND\fRs and \fBOPTION\fRs supported by \f
 	  \fB--chunk_size=\fRBYTES chunk size of files created. Supports suffixes:
 .br
 				      K (KB), M (MB), G (GB), T (TB), P (PB), E (EB)
+.br
+	  \fB--properties=\fR<name>:<value>[,<name>:<value>,...]
+.br
+				      supported prop names are label, cksum,
+.br
+				           cksum_size, srv_cksum, rf
+.br
+				      label value can be any string
+.br
+				      cksum supported values are off, crc[16,32,64], sha1
+.br
+				      cksum_size can be any size
+.br
+				      srv_cksum values can be on, off
+.br
+				      rf supported values are [0-4]
 .TP
 .I container \fBOPTION\fRs (destroy):
 	  \fB--force\fR            destroy container regardless of state
@@ -141,23 +160,24 @@ The \fBRESOURCE\fRs, respective \fBCOMMAND\fRs and \fBOPTION\fRs supported by \f
                         namespace path must provide direct link to DAOS container
 .TP
 .I container \fBOPTION\fRs (attribute-related):
-	  \fB--attr=\fRNAME        container attribute name to set, get, del
+	  \fB--attr=\fRNAME        container attribute name to set, get
 .br
 	  \fB--value=\fRVALUESTR   container attribute value to set
 .TP
-.I container \fBOPTION\fRs (snapshot and rollback-related):
-	  \fB--snap=\fRNAME        container snapshot (create/destroy-snap, rollback)
+.I container \fBOPTION\fRs (snapshot-related):
+	  \fB--snap=\fRNAME        container snapshot (create/destroy-snap)
 .br
-	  \fB--epc=\fREPOCHNUM     container epoch (destroy-snap, rollback)
+	  \fB--epc=\fREPOCHNUM     container epoch (destroy-snap)
 .br
 	  \fB--eprange=\fRB-E      container epoch range (destroy-snap)
 .TP
+.I container \fBOPTION\fRs (ACL-related):
+	  \fB--verbose\fR          verbose mode (get-acl)
+.br
+	  \fB--outfile=\fRPATH     write ACL to file (get-acl)
+.TP
 .I object \fR(\fIobj\fR) \fBCOMMAND\fRs:
 	  \fBquery\fR            query an object's layout
-.br
-	  \fBlist-keys\fR        list an object's keys
-.br
-	  \fBdump\fR             dump an object's contents
 .TP
 .I object \fR(\fIobj\fR) \fBOPTION\fRs:
 	  <\fIpool\fR options>   (\fB--pool\fR, \fB--sys-name\fR, \fB--svc\fR)

--- a/src/utils/daos.c
+++ b/src/utils/daos.c
@@ -1042,21 +1042,14 @@ do { \
 	"	  get-prop         get all container's properties\n" \
 	"	  set-prop         set container's properties\n" \
 	"	  get-acl          get a container's ACL\n" \
-	"	  overwrite-acl    replace a container's ACL\n" \
-	"	  update-acl       add/modify entries in a container's ACL\n" \
-	"	  delete-acl       delete an entry from a container's ACL\n" \
-	"	  set-owner        change the user and/or group that own a container\n" \
-	"	  stat             get container statistics\n" \
 	"	  list-attrs       list container user-defined attributes\n" \
-	"	  del-attr         delete container user-defined attribute\n" \
 	"	  get-attr         get container user-defined attribute\n" \
 	"	  set-attr         set container user-defined attribute\n" \
 	"	  create-snap      create container snapshot (optional name)\n" \
 	"			   at most recent committed epoch\n" \
 	"	  list-snaps       list container snapshots taken\n" \
 	"	  destroy-snap     destroy container snapshots\n" \
-	"			   by name, epoch or range\n" \
-	"	  rollback         roll back container to specified snapshot\n"); \
+	"			   by name, epoch or range\n"); \
 	fprintf(stream, "\n"); \
 	fprintf(stream, "use 'daos help cont|container COMMAND' for command specific options\n"); \
 } while (0)
@@ -1090,9 +1083,10 @@ help_hdlr(int argc, char *argv[], struct cmd_args_s *ap)
 		"	  list-containers  list all containers in pool\n"
 		"	  list-cont\n"
 		"	  query            query a pool\n"
-		"	  stat             get pool statistics\n"
 		"	  list-attrs       list pool user-defined attributes\n"
-		"	  get-attr         get pool user-defined attribute\n");
+		"	  get-attr         get pool user-defined attribute\n"
+		"	  set-attr         set pool user-defined attribute\n"
+		"	  get-prop         get all pool's properties\n");
 
 		fprintf(stream,
 		"pool options:\n"
@@ -1131,72 +1125,35 @@ help_hdlr(int argc, char *argv[], struct cmd_args_s *ap)
 			"			   cksum supported values are off, crc[16,32,64], sha1\n"
 			"			   cksum_size can be any size\n"
 			"			   srv_cksum values can be on, off\n"
-			"			   rf supported values are [0-4]\n"
-			"	--acl-file=PATH    input file containing ACL\n"
-			"	--user=ID          user who will own the container.\n"
-			"			   format: username@[domain]\n"
-			"			   default is the effective user\n"
-			"	--group=ID         group who will own the container.\n"
-			"			   format: groupname@[domain]\n"
-			"			   default is the effective group\n");
+			"			   rf supported values are [0-4]\n");
 		} else if (strcmp(argv[3], "destroy") == 0) {
 			fprintf(stream,
 			"container options (destroy):\n"
 			"	--force            destroy container regardless of state\n");
 			ALL_BUT_CONT_CREATE_OPTS_HELP();
 		} else if (strcmp(argv[3], "get-attr") == 0 ||
-			   strcmp(argv[3], "set-attr") == 0 ||
-			   strcmp(argv[3], "del-attr") == 0) {
+			   strcmp(argv[3], "set-attr") == 0) {
 			fprintf(stream,
 			"container options (attribute-related):\n"
-			"	--attr=NAME        container attribute name to set, get, del\n"
+			"	--attr=NAME        container attribute name to set, get\n"
 			"	--value=VALUESTR   container attribute value to set\n");
 			ALL_BUT_CONT_CREATE_OPTS_HELP();
 		} else if (strcmp(argv[3], "create-snap") == 0 ||
-			   strcmp(argv[3], "destroy-snap") == 0 ||
-			   strcmp(argv[3], "rollback") == 0) {
+			   strcmp(argv[3], "destroy-snap") == 0) {
 			fprintf(stream,
-			"container options (snapshot and rollback-related):\n"
-			"	--snap=NAME        container snapshot (create/destroy-snap, rollback)\n"
-			"	--epc=EPOCHNUM     container epoch (destroy-snap, rollback)\n"
+			"container options (snapshot-related):\n"
+			"	--snap=NAME        container snapshot (create/destroy-snap)\n"
+			"	--epc=EPOCHNUM     container epoch (destroy-snap)\n"
 			"	--eprange=B-E      container epoch range (destroy-snap)\n");
 			ALL_BUT_CONT_CREATE_OPTS_HELP();
-		} else if (strcmp(argv[3], "set-prop") == 0) {
-			fprintf(stream,
-			"container options (set-prop):\n"
-			"	--properties=<name>:<value>[,<name>:<value>,...]\n"
-			"			   supported prop names: label\n"
-			"			   label value can be any string\n");
-			ALL_BUT_CONT_CREATE_OPTS_HELP();
-		} else if (strcmp(argv[3], "get-acl") == 0 ||
-			   strcmp(argv[3], "overwrite-acl") == 0 ||
-			   strcmp(argv[3], "update-acl") == 0 ||
-			   strcmp(argv[3], "delete-acl") == 0) {
+		} else if (strcmp(argv[3], "get-acl") == 0) {
 			fprintf(stream,
 			"container options (ACL-related):\n"
-			"	--acl-file=PATH    input file containing ACL (overwrite-acl, "
-			"			   update-acl)\n"
-			"	--entry=ACE        add or modify a single ACL entry (update-acl)\n"
-			"	--principal=ID     principal of entry (delete-acl)\n"
-			"			   for users: u:name@[domain]\n"
-			"			   for groups: g:name@[domain]\n"
-			"			   special principals: OWNER@, GROUP@, EVERYONE@\n"
 			"	--verbose          verbose mode (get-acl)\n"
 			"	--outfile=PATH     write ACL to file (get-acl)\n");
 			ALL_BUT_CONT_CREATE_OPTS_HELP();
-		} else if (strcmp(argv[3], "set-owner") == 0) {
-			fprintf(stream,
-			"container options (set-owner):\n"
-			"	--user=ID          user who will own the container.\n"
-			"			   format: username@[domain]\n"
-			"	--group=ID         group who will own the container.\n"
-			"			   format: groupname@[domain]\n");
-			ALL_BUT_CONT_CREATE_OPTS_HELP();
-		} else if (strcmp(argv[3], "list-objects") == 0 ||
-			   strcmp(argv[3], "list-obj") == 0 ||
-			   strcmp(argv[3], "query") == 0 ||
+		} else if (strcmp(argv[3], "query") == 0 ||
 			   strcmp(argv[3], "get-prop") == 0 ||
-			   strcmp(argv[3], "stat") == 0 ||
 			   strcmp(argv[3], "list-attrs") == 0 ||
 			   strcmp(argv[3], "list-snaps") == 0) {
 			ALL_BUT_CONT_CREATE_OPTS_HELP();
@@ -1207,9 +1164,7 @@ help_hdlr(int argc, char *argv[], struct cmd_args_s *ap)
 		   strcmp(argv[2], "object") == 0) {
 		fprintf(stream, "\n"
 		"object (obj) commands:\n"
-		"	  query            query an object's layout\n"
-		"	  list-keys        list an object's keys\n"
-		"	  dump             dump an object's contents\n");
+		"	  query            query an object's layout\n");
 
 		fprintf(stream,
 		"object (obj) options:\n"

--- a/src/utils/daos.c
+++ b/src/utils/daos.c
@@ -1016,8 +1016,63 @@ out:
 	free(str);
 }
 
+#define FIRST_LEVEL_HELP() \
+do { \
+	fprintf(stream, \
+	"usage: daos RESOURCE COMMAND [OPTIONS]\n" \
+	"resources:\n" \
+	"	  pool             pool\n" \
+	"	  container (cont) container\n" \
+	"	  object (obj)     object\n" \
+	"	  version          print command version\n" \
+	"	  help             print this message and exit\n"); \
+	fprintf(stream, "\n"); \
+	fprintf(stream, "use 'daos help RESOURCE' for resource specifics\n"); \
+} while (0)
+
+#define ALL_CONT_CMDS_HELP() \
+do { \
+	fprintf(stream, "\n" \
+	"container (cont) commands:\n" \
+	"	  create           create a container\n" \
+	"	  destroy          destroy a container\n" \
+	"	  list-objects     list all objects in container\n" \
+	"	  list-obj\n" \
+	"	  query            query a container\n" \
+	"	  get-prop         get all container's properties\n" \
+	"	  set-prop         set container's properties\n" \
+	"	  get-acl          get a container's ACL\n" \
+	"	  overwrite-acl    replace a container's ACL\n" \
+	"	  update-acl       add/modify entries in a container's ACL\n" \
+	"	  delete-acl       delete an entry from a container's ACL\n" \
+	"	  set-owner        change the user and/or group that own a container\n" \
+	"	  stat             get container statistics\n" \
+	"	  list-attrs       list container user-defined attributes\n" \
+	"	  del-attr         delete container user-defined attribute\n" \
+	"	  get-attr         get container user-defined attribute\n" \
+	"	  set-attr         set container user-defined attribute\n" \
+	"	  create-snap      create container snapshot (optional name)\n" \
+	"			   at most recent committed epoch\n" \
+	"	  list-snaps       list container snapshots taken\n" \
+	"	  destroy-snap     destroy container snapshots\n" \
+	"			   by name, epoch or range\n" \
+	"	  rollback         roll back container to specified snapshot\n"); \
+	fprintf(stream, "\n"); \
+	fprintf(stream, "use 'daos help cont|container COMMAND' for command specific options\n"); \
+} while (0)
+
+#define ALL_BUT_CONT_CREATE_OPTS_HELP() \
+do { \
+	fprintf(stream, \
+	"container options (query, and all commands except create):\n" \
+	"	  <pool options>   with --cont use: (--pool, --sys-name, --svc)\n" \
+	"	  <pool options>   with --path use: (--sys-name, --svc)\n" \
+	"	--cont=UUID        (mandatory, or use --path)\n" \
+	"	--path=PATHSTR     (mandatory, or use --cont)\n"); \
+} while (0)
+
 static int
-help_hdlr(struct cmd_args_s *ap)
+help_hdlr(int argc, char *argv[], struct cmd_args_s *ap)
 {
 	FILE *stream;
 
@@ -1027,119 +1082,145 @@ help_hdlr(struct cmd_args_s *ap)
 
 	fprintf(stream, "daos command (v%s)\n", DAOS_VERSION);
 
-	fprintf(stream,
-"usage: daos RESOURCE COMMAND [OPTIONS]\n"
-"resources:\n"
-"	  pool             pool\n"
-"	  container (cont) container\n"
-"	  version          print command version\n"
-"	  help             print this message and exit\n");
+	if (argc == 2) {
+		FIRST_LEVEL_HELP();
+	} else if (strcmp(argv[2], "pool") == 0) {
+		fprintf(stream, "\n"
+		"pool commands:\n"
+		"	  list-containers  list all containers in pool\n"
+		"	  list-cont\n"
+		"	  query            query a pool\n"
+		"	  stat             get pool statistics\n"
+		"	  list-attrs       list pool user-defined attributes\n"
+		"	  get-attr         get pool user-defined attribute\n");
 
-	fprintf(stream, "\n"
-"pool commands:\n"
-"	  list-containers  list all containers in pool\n"
-"	  list-cont\n"
-"	  query            query a pool\n"
-"	  stat             get pool statistics\n"
-"	  list-attrs       list pool user-defined attributes\n"
-"	  get-attr         get pool user-defined attribute\n");
+		fprintf(stream,
+		"pool options:\n"
+		"	--pool=UUID        pool UUID\n"
+		"	--sys-name=STR     DAOS system name context for servers (\"%s\")\n"
+		"	--sys=STR\n"
+		"	--svc=RANKS        pool service replicas like 1,2,3\n"
+		"	--attr=NAME        pool attribute name to get\n",
+			default_sysname);
 
-	fprintf(stream,
-"pool options:\n"
-"	--pool=UUID        pool UUID\n"
-"	--sys-name=STR     DAOS system name context for servers (\"%s\")\n"
-"	--sys=STR\n"
-"	--svc=RANKS        pool service replicas like 1,2,3\n"
-"	--attr=NAME        pool attribute name to get\n",
-	default_sysname);
+	} else if (strcmp(argv[2], "container") == 0 ||
+		   strcmp(argv[2], "cont") == 0) {
+		if (argc == 3) {
+			ALL_CONT_CMDS_HELP();
+		} else if (strcmp(argv[3], "create") == 0) {
+			fprintf(stream,
+			"container options (create by UUID):\n"
+			"	  <pool options>   (--pool, --sys-name, --svc)\n"
+			"	--cont=UUID        (optional) container UUID (or generated)\n"
+			"container options (create and link to namespace path):\n"
+			"	  <pool/cont opts> (--pool, --sys-name, --svc, --cont [optional])\n"
+			"	--path=PATHSTR     container namespace path\n"
+			"container create common optional options:\n"
+			"	--type=CTYPESTR    container type (HDF5, POSIX)\n"
+			"	--oclass=OCLSSTR   container object class\n"
+			"			   (");
+			/* vs hardcoded list like "tiny, small, large, R2, R2S, repl_max" */
+			print_oclass_names_list(stream);
+			fprintf(stream, ")\n"
+			"	--chunk_size=BYTES chunk size of files created. Supports suffixes:\n"
+			"			   K (KB), M (MB), G (GB), T (TB), P (PB), E (EB)\n"
+			"	--properties=<name>:<value>[,<name>:<value>,...]\n"
+			"			   supported prop names are label, cksum,\n"
+			"				cksum_size, srv_cksum, rf\n"
+			"			   label value can be any string\n"
+			"			   cksum supported values are off, crc[16,32,64], sha1\n"
+			"			   cksum_size can be any size\n"
+			"			   srv_cksum values can be on, off\n"
+			"			   rf supported values are [0-4]\n"
+			"	--acl-file=PATH    input file containing ACL\n"
+			"	--user=ID          user who will own the container.\n"
+			"			   format: username@[domain]\n"
+			"			   default is the effective user\n"
+			"	--group=ID         group who will own the container.\n"
+			"			   format: groupname@[domain]\n"
+			"			   default is the effective group\n");
+		} else if (strcmp(argv[3], "destroy") == 0) {
+			fprintf(stream,
+			"container options (destroy):\n"
+			"	--force            destroy container regardless of state\n");
+			ALL_BUT_CONT_CREATE_OPTS_HELP();
+		} else if (strcmp(argv[3], "get-attr") == 0 ||
+			   strcmp(argv[3], "set-attr") == 0 ||
+			   strcmp(argv[3], "del-attr") == 0) {
+			fprintf(stream,
+			"container options (attribute-related):\n"
+			"	--attr=NAME        container attribute name to set, get, del\n"
+			"	--value=VALUESTR   container attribute value to set\n");
+			ALL_BUT_CONT_CREATE_OPTS_HELP();
+		} else if (strcmp(argv[3], "create-snap") == 0 ||
+			   strcmp(argv[3], "destroy-snap") == 0 ||
+			   strcmp(argv[3], "rollback") == 0) {
+			fprintf(stream,
+			"container options (snapshot and rollback-related):\n"
+			"	--snap=NAME        container snapshot (create/destroy-snap, rollback)\n"
+			"	--epc=EPOCHNUM     container epoch (destroy-snap, rollback)\n"
+			"	--eprange=B-E      container epoch range (destroy-snap)\n");
+			ALL_BUT_CONT_CREATE_OPTS_HELP();
+		} else if (strcmp(argv[3], "set-prop") == 0) {
+			fprintf(stream,
+			"container options (set-prop):\n"
+			"	--properties=<name>:<value>[,<name>:<value>,...]\n"
+			"			   supported prop names: label\n"
+			"			   label value can be any string\n");
+			ALL_BUT_CONT_CREATE_OPTS_HELP();
+		} else if (strcmp(argv[3], "get-acl") == 0 ||
+			   strcmp(argv[3], "overwrite-acl") == 0 ||
+			   strcmp(argv[3], "update-acl") == 0 ||
+			   strcmp(argv[3], "delete-acl") == 0) {
+			fprintf(stream,
+			"container options (ACL-related):\n"
+			"	--acl-file=PATH    input file containing ACL (overwrite-acl, "
+			"			   update-acl)\n"
+			"	--entry=ACE        add or modify a single ACL entry (update-acl)\n"
+			"	--principal=ID     principal of entry (delete-acl)\n"
+			"			   for users: u:name@[domain]\n"
+			"			   for groups: g:name@[domain]\n"
+			"			   special principals: OWNER@, GROUP@, EVERYONE@\n"
+			"	--verbose          verbose mode (get-acl)\n"
+			"	--outfile=PATH     write ACL to file (get-acl)\n");
+			ALL_BUT_CONT_CREATE_OPTS_HELP();
+		} else if (strcmp(argv[3], "set-owner") == 0) {
+			fprintf(stream,
+			"container options (set-owner):\n"
+			"	--user=ID          user who will own the container.\n"
+			"			   format: username@[domain]\n"
+			"	--group=ID         group who will own the container.\n"
+			"			   format: groupname@[domain]\n");
+			ALL_BUT_CONT_CREATE_OPTS_HELP();
+		} else if (strcmp(argv[3], "list-objects") == 0 ||
+			   strcmp(argv[3], "list-obj") == 0 ||
+			   strcmp(argv[3], "query") == 0 ||
+			   strcmp(argv[3], "get-prop") == 0 ||
+			   strcmp(argv[3], "stat") == 0 ||
+			   strcmp(argv[3], "list-attrs") == 0 ||
+			   strcmp(argv[3], "list-snaps") == 0) {
+			ALL_BUT_CONT_CREATE_OPTS_HELP();
+		} else {
+			ALL_CONT_CMDS_HELP();
+		}
+	} else if (strcmp(argv[2], "obj") == 0 ||
+		   strcmp(argv[2], "object") == 0) {
+		fprintf(stream, "\n"
+		"object (obj) commands:\n"
+		"	  query            query an object's layout\n"
+		"	  list-keys        list an object's keys\n"
+		"	  dump             dump an object's contents\n");
 
-	fprintf(stream, "\n"
-"container (cont) commands:\n"
-"	  create           create a container\n"
-"	  destroy          destroy a container\n"
-"	  list-objects     list all objects in container\n"
-"	  list-obj\n"
-"	  query            query a container\n"
-"	  stat             get container statistics\n"
-"	  list-attrs       list container user-defined attributes\n"
-"	  del-attr         delete container user-defined attribute\n"
-"	  get-attr         get container user-defined attribute\n"
-"	  set-attr         set container user-defined attribute\n"
-"	  create-snap      create container snapshot (optional name)\n"
-"			   at most recent committed epoch\n"
-"	  list-snaps       list container snapshots taken\n"
-"	  destroy-snap     destroy container snapshots\n"
-"			   by name, epoch or range\n"
-"	  rollback         roll back container to specified snapshot\n");
+		fprintf(stream,
+		"object (obj) options:\n"
+		"	  <pool options>   (--pool, --sys-name, --svc)\n"
+		"	  <cont options>   (--cont)\n"
+		"	--oid=HI.LO        object ID\n");
 
-#if 0
-	fprintf(stream,
-"container (cont) options:\n"
-"	  <pool options>   (--pool, --sys-name, --svc)\n"
-"	--cont=UUID        container UUID\n"
-"	--attr=NAME        container attribute name to set, get, del\n"
-"	--value=VALUESTR   container attribute value to set\n"
-"	--path=PATHSTR     container namespace path\n"
-"	--type=CTYPESTR    container type (HDF5, POSIX)\n"
-"	--oclass=OCLSSTR   container object class\n"
-"			   (tiny, small, large, R2, R2S, repl_max)\n"
-"	--chunk_size=BYTES chunk size of files created. Supports suffixes:\n"
-"			   K (KB), M (MB), G (GB), T (TB), P (PB), E (EB)\n"
-"	--snap=NAME        container snapshot (create/destroy-snap, rollback)\n"
-"	--epc=EPOCHNUM     container epoch (destroy-snap, rollback)\n"
-"	--eprange=B-E      container epoch range (destroy-snap)\n"
-"	--force            destroy container regardless of state\n");
-#endif
+	} else {
+		FIRST_LEVEL_HELP();
+	}
 
-	fprintf(stream,
-"container options (create by UUID):\n"
-"	  <pool options>   (--pool, --sys-name, --svc)\n"
-"	--cont=UUID        (optional) container UUID (or generated)\n"
-"container options (create and link to namespace path):\n"
-"	  <pool/cont opts> (--pool, --sys-name, --svc, --cont [optional])\n"
-"	--path=PATHSTR     container namespace path\n"
-"	--type=CTYPESTR    container type (HDF5, POSIX)\n"
-"	--oclass=OCLSSTR   container object class\n"
-"			   (");
-	/* vs hardcoded list like "tiny, small, large, R2, R2S, repl_max" */
-	print_oclass_names_list(stream);
-	fprintf(stream, ")\n"
-"	--chunk_size=BYTES chunk size of files created. Supports suffixes:\n"
-"			   K (KB), M (MB), G (GB), T (TB), P (PB), E (EB)\n"
-"	--properties=<name>:<value>[,<name>:<value>,...]\n"
-"			   supported prop names are label, cksum,\n"
-"				cksum_size, srv_cksum, rf\n"
-"			   label value can be any string\n"
-"			   cksum supported values are off, crc[16,32,64], sha1\n"
-"			   cksum_size can be any size\n"
-"			   srv_cksum values can be on, off\n"
-"			   rf supported values are [0-4]\n"
-"container options (destroy):\n"
-"	--force            destroy container regardless of state\n"
-"container options (query, and all commands except create):\n"
-"	  <pool options>   with --cont use: (--pool, --sys-name, --svc)\n"
-"	  <pool options>   with --path use: (--sys-name, --svc)\n"
-"	--cont=UUID        (mandatory, or use --path)\n"
-"	--path=PATHSTR     (mandatory, or use --cont)\n"
-"container options (attribute-related):\n"
-"	--attr=NAME        container attribute name to set, get, del\n"
-"	--value=VALUESTR   container attribute value to set\n"
-"container options (snapshot and rollback-related):\n"
-"	--snap=NAME        container snapshot (create/destroy-snap, rollback)\n"
-"	--epc=EPOCHNUM     container epoch (destroy-snap, rollback)\n"
-"	--eprange=B-E      container epoch range (destroy-snap)\n");
-
-	fprintf(stream, "\n"
-"object (obj) commands:\n"
-"	  query            query an object's layout\n"
-"	  list-keys        list an object's keys\n"
-"	  dump             dump an object's contents\n");
-
-	fprintf(stream,
-"object (obj) options:\n"
-"	  <pool options>   (--pool, --sys-name, --svc)\n"
-"	  <cont options>   (--cont)\n"
-"	--oid=HI.LO        object ID\n");
 	return 0;
 }
 
@@ -1153,9 +1234,11 @@ main(int argc, char *argv[])
 	/* argv[1] is RESOURCE or "help" or "version";
 	 * argv[2] if provided is a resource-specific command
 	 */
-	if (argc < 2 || strcmp(argv[1], "help") == 0)
-		hdlr = help_hdlr;
-	else if (strcmp(argv[1], "version") == 0) {
+	if (argc < 2 || strcmp(argv[1], "help") == 0) {
+		dargs.ostream = stdout;
+		help_hdlr(argc, argv, &dargs);
+		return 0;
+	} else if (strcmp(argv[1], "version") == 0) {
 		fprintf(stdout, "daos version %s\n", DAOS_VERSION);
 		return 0;
 	} else if ((strcmp(argv[1], "container") == 0) ||
@@ -1169,14 +1252,8 @@ main(int argc, char *argv[])
 
 	if (hdlr == NULL) {
 		dargs.ostream = stderr;
-		help_hdlr(&dargs);
+		help_hdlr(argc, argv, &dargs);
 		return 2;
-	}
-
-	if (hdlr == help_hdlr) {
-		dargs.ostream = stdout;
-		help_hdlr(&dargs);
-		return 0;
 	}
 
 	rc = daos_init();
@@ -1191,7 +1268,7 @@ main(int argc, char *argv[])
 		fprintf(stderr, "error parsing command line arguments\n");
 		if (rc > 0) {
 			dargs.ostream = stderr;
-			help_hdlr(&dargs);
+			help_hdlr(argc, argv, &dargs);
 		}
 		daos_fini();
 		return -1;
@@ -1210,7 +1287,7 @@ main(int argc, char *argv[])
 	else if (rc > 0) {
 		printf("rc: %d\n", rc);
 		dargs.ostream = stderr;
-		help_hdlr(&dargs);
+		help_hdlr(argc, argv, &dargs);
 		return 2;
 	}
 


### PR DESCRIPTION
Changes daos command online help to become
per-resource/command for better clarity.
Also document this in daos command man page.

Change-Id: Ib54e79924be1250c34164906cadd86b4958f10e0
Signed-off-by: Bruno Faccini <bruno.faccini@intel.com>