### PR TITLE
DAOS-4489 iosrv: move profile to dss_module_info

### DIFF
--- a/src/include/daos/mgmt.h
+++ b/src/include/daos/mgmt.h
@@ -42,7 +42,7 @@ int dc_pool_evict(tse_task_t *task);
 int dc_pool_extend(tse_task_t *task);
 int dc_mgmt_set_params(tse_task_t *task);
 int dc_mgmt_list_pools(tse_task_t *task);
-int dc_mgmt_profile(uint64_t modules, char *path, int avg, bool start);
+int dc_mgmt_profile(char *path, int avg, bool start);
 int dc_mgmt_add_mark(const char *mark);
 
 /** GetAttachInfo system info */

--- a/src/include/daos_srv/daos_server.h
+++ b/src/include/daos_srv/daos_server.h
@@ -114,22 +114,6 @@ dss_tls_get()
 		pthread_getspecific(dss_tls_key);
 }
 
-#define D_TIME_START(sp, start, op)		\
-do {						\
-	if ((sp) == NULL)			\
-		break;				\
-	start = daos_get_ntime();		\
-} while (0)
-
-#define D_TIME_END(sp, start, op)		\
-do {						\
-	int time_msec;				\
-	if ((sp) == NULL || start == 0)		\
-		break;				\
-	time_msec = (daos_get_ntime() - start)/1000; \
-	srv_profile_count(sp, op, time_msec);	\
-} while (0)
-
 /**
  * Get value from context by the key
  *
@@ -158,6 +142,87 @@ void dss_unregister_key(struct dss_module_key *key);
 
 #define DSS_XS_NAME_LEN		64
 
+struct srv_profile_chunk {
+	d_list_t	spc_chunk_list;
+	uint32_t	spc_chunk_offset;
+	uint32_t	spc_chunk_size;
+	uint64_t	*spc_chunks;
+};
+
+/* The profile structure to record single operation */
+struct srv_profile_op {
+	int		pro_op;			/* operation */
+	char		*pro_op_name;		/* name of the op */
+	int		pro_acc_cnt;		/* total number of val */
+	int		pro_acc_val;		/* current total val */
+	d_list_t	pro_chunk_list;		/* list of all chunks */
+	d_list_t	pro_chunk_idle_list;	/* idle list of profile chunk */
+	int		pro_chunk_total_cnt;	/* Count in idle list & list */
+	int		pro_chunk_cnt;		/* count in list */
+	struct srv_profile_chunk *pro_current_chunk; /* current chunk */
+};
+
+/* Holding the total trunk list for a specific profiling module */
+struct srv_profile {
+	struct srv_profile_op *sp_ops;
+	int		sp_ops_cnt;
+	int		sp_avg;
+	int		sp_id;
+	char		*sp_dir_path;	/* Where to dump the profiling */
+	char		**sp_names;	/* profile name */
+	ABT_thread	sp_dump_thread;	/* dump thread for profile */
+	unsigned int	sp_stop:1,
+			sp_empty:1;
+};
+
+enum profile_op {
+	OBJ_PF_UPDATE_PREP = 0,
+	OBJ_PF_UPDATE_DISPATCH,
+	OBJ_PF_UPDATE_LOCAL,
+	OBJ_PF_UPDATE_END,
+	OBJ_PF_UPDATE_WAIT,
+	OBJ_PF_UPDATE_REPLY,
+	OBJ_PF_UPDATE,
+	VOS_UPDATE_END,
+	PF_MAX_CNT,
+};
+
+#ifndef VOS_STANDALONE
+#define D_TIME_START(start, op)			\
+do {						\
+	struct srv_profile *sp;			\
+						\
+	sp = dss_get_module_info()->dmi_sp;	\
+	if ((sp) == NULL)			\
+		break;				\
+	start = daos_get_ntime();		\
+} while (0)
+
+#define D_TIME_END(start, op)			\
+do {						\
+	struct srv_profile *sp;			\
+						\
+	sp = dss_get_module_info()->dmi_sp;	\
+	int time_msec;				\
+	if ((sp) == NULL || start == 0)		\
+		break;				\
+	time_msec = (daos_get_ntime() - start)/1000; \
+	srv_profile_count(sp, op, time_msec);	\
+} while (0)
+
+#else
+unsigned int tmp_count;
+#define D_TIME_START(start, op)			\
+do {						\
+	start = 1;				\
+} while(0)
+
+#define D_TIME_END(start, op)			\
+do {						\
+	tmp_count += start;			\
+} while(0)
+
+#endif
 /* Opaque xstream configuration data */
 struct dss_xstream;
 
@@ -175,6 +240,8 @@ struct dss_module_info {
 	/* the cart context id */
 	int			dmi_ctx_id;
 	d_list_t		dmi_dtx_batched_list;
+	/* the profile information */
+	struct srv_profile	*dmi_sp;
 };
 
 extern struct dss_module_key	daos_srv_modkey;
@@ -216,39 +283,6 @@ struct dss_drpc_handler {
 	drpc_handler_t	handler;	/** dRPC handler for the module */
 };
 
-struct srv_profile_chunk {
-	d_list_t	spc_chunk_list;
-	uint32_t	spc_chunk_offset;
-	uint32_t	spc_chunk_size;
-	uint64_t	*spc_chunks;
-};
-
-/* The profile structure to record single operation */
-struct srv_profile_op {
-	int		pro_op;			/* operation */
-	char		*pro_op_name;		/* name of the op */
-	int		pro_acc_cnt;		/* total number of val */
-	int		pro_acc_val;		/* current total val */
-	d_list_t	pro_chunk_list;		/* list of all chunks */
-	d_list_t	pro_chunk_idle_list;	/* idle list of profile chunk */
-	int		pro_chunk_total_cnt;	/* Count in idle list & list */
-	int		pro_chunk_cnt;		/* count in list */
-	struct srv_profile_chunk *pro_current_chunk; /* current chunk */
-};
-
-/* Holding the total trunk list for a specific profiling module */
-struct srv_profile {
-	struct srv_profile_op *sp_ops;
-	int		sp_ops_cnt;
-	int		sp_avg;
-	int		sp_id;
-	char		*sp_dir_path;	/* Where to dump the profiling */
-	char		**sp_names;	/* profile name */
-	ABT_thread	sp_dump_thread;	/* dump thread for profile */
-	unsigned int	sp_stop:1,
-			sp_empty:1;
-};
-
 struct dss_module_ops {
 	/* The callback for each module will choose ABT pool to handle RPC */
 	ABT_pool (*dms_abt_pool_choose_cb)(crt_rpc_t *rpc, ABT_pool *pools);
@@ -258,10 +292,9 @@ struct dss_module_ops {
 	int	(*dms_profile_stop)(void);
 };
 
-int srv_profile_stop(struct srv_profile *sp);
+int srv_profile_stop();
 int srv_profile_count(struct srv_profile *sp, int id, int time);
-int srv_profile_start(struct srv_profile **sp_p, char *path, int avg,
-		      int op_cnt, char **names);
+int srv_profile_start(char *path, int avg);
 void srv_profile_destroy(struct srv_profile *sp);
 
 /**

--- a/src/iosrv/srv.c
+++ b/src/iosrv/srv.c
@@ -525,6 +525,10 @@ dss_srv_handler(void *arg)
 	D_ASSERT(d_list_empty(&dx->dx_sleep_ult_list));
 
 	wait_all_exited(dx);
+	if (dmi->dmi_sp) {
+		srv_profile_destroy(dmi->dmi_sp);
+		dmi->dmi_sp = NULL;
+	}
 nvme_fini:
 	if (dx->dx_main_xs)
 		bio_xsctxt_free(dmi->dmi_nvme_ctxt);

--- a/src/mgmt/cli_mgmt.c
+++ b/src/mgmt/cli_mgmt.c
@@ -185,7 +185,7 @@ out_task:
 }
 
 int
-dc_mgmt_profile(uint64_t modules, char *path, int avg, bool start)
+dc_mgmt_profile(char *path, int avg, bool start)
 {
 	struct dc_mgmt_sys	*sys;
 	struct mgmt_profile_in	*in;
@@ -213,7 +213,6 @@ dc_mgmt_profile(uint64_t modules, char *path, int avg, bool start)
 
 	D_ASSERT(rpc != NULL);
 	in = crt_req_get(rpc);
-	in->p_module = modules;
 	in->p_path = path;
 	in->p_avg = avg;
 	in->p_op = start ? MGMT_PROFILE_START : MGMT_PROFILE_STOP;

--- a/src/mgmt/rpc.h
+++ b/src/mgmt/rpc.h
@@ -152,7 +152,6 @@ CRT_RPC_DECLARE(mgmt_params_set, DAOS_ISEQ_MGMT_PARAMS_SET,
 		DAOS_OSEQ_MGMT_PARAMS_SET)
 
 #define DAOS_ISEQ_MGMT_PROFILE /* input fields */		 \
-	((uint64_t)		(p_module)		CRT_VAR) \
 	((d_string_t)		(p_path)		CRT_VAR) \
 	((int32_t)		(p_avg)			CRT_VAR) \
 	((int32_t)		(p_op)			CRT_VAR)

--- a/src/mgmt/srv.c
+++ b/src/mgmt/srv.c
@@ -256,7 +256,6 @@ ds_mgmt_profile_hdlr(crt_rpc_t *rpc)
 	tc_in = crt_req_get(tc_req);
 	D_ASSERT(tc_in != NULL);
 
-	tc_in->p_module = in->p_module;
 	tc_in->p_path = in->p_path;
 	tc_in->p_op = in->p_op;
 	tc_in->p_avg = in->p_avg;

--- a/src/mgmt/srv_target.c
+++ b/src/mgmt/srv_target.c
@@ -852,30 +852,12 @@ static int
 tgt_profile_task(void *arg)
 {
 	struct mgmt_profile_in *in = arg;
-	int mod_id = 0;
 	int rc = 0;
 
-	for (mod_id = 0; mod_id < (sizeof(uint64_t) * NBBY); mod_id++) {
-		uint64_t mask = 1ULL << mod_id;
-		struct dss_module *module;
-
-		if (!(in->p_module & mask))
-			continue;
-
-		module = dss_module_get(mod_id);
-		if (module == NULL || module->sm_mod_ops == NULL) {
-			D_ERROR("no module sm_mod_ops %d\n", mod_id);
-			continue;
-		}
-
-		if (in->p_op == MGMT_PROFILE_START)
-			rc = module->sm_mod_ops->dms_profile_start(in->p_path,
-								   in->p_avg);
-		else
-			rc = module->sm_mod_ops->dms_profile_stop();
-		if (rc)
-			break;
-	}
+	if (in->p_op == MGMT_PROFILE_START)
+		rc = srv_profile_start(in->p_path, in->p_avg);
+	else
+		rc = srv_profile_stop();
 
 	D_DEBUG(DB_MGMT, "profile task: rc "DF_RC"\n", DP_RC(rc));
 	return rc;

--- a/src/object/obj_internal.h
+++ b/src/object/obj_internal.h
@@ -158,16 +158,6 @@ enum_anchor_copy(daos_anchor_t *dst, daos_anchor_t *src)
 }
 
 extern struct dss_module_key obj_module_key;
-enum obj_profile_op {
-	OBJ_PF_UPDATE_PREP = 0,
-	OBJ_PF_UPDATE_DISPATCH,
-	OBJ_PF_UPDATE_LOCAL,
-	OBJ_PF_UPDATE_END,
-	OBJ_PF_UPDATE_WAIT,
-	OBJ_PF_UPDATE_REPLY,
-	OBJ_PF_UPDATE,
-	OBJ_PF_MAX,
-};
 
 /* Per pool attached to the migrate tls(per xstream) */
 struct migrate_pool_tls {
@@ -226,7 +216,6 @@ migrate_pool_tls_destroy(struct migrate_pool_tls *tls);
 
 struct obj_tls {
 	d_sg_list_t		ot_echo_sgl;
-	struct srv_profile	*ot_sp;
 	d_list_t		ot_pool_list;
 };
 

--- a/src/object/srv_mod.c
+++ b/src/object/srv_mod.c
@@ -108,51 +108,7 @@ obj_tls_fini(const struct dss_thread_local_storage *dtls,
 	if (tls->ot_echo_sgl.sg_iovs != NULL)
 		daos_sgl_fini(&tls->ot_echo_sgl, true);
 
-	if (tls->ot_sp)
-		srv_profile_destroy(tls->ot_sp);
-
 	D_FREE(tls);
-}
-
-char *profile_op_names[] = {
-	[OBJ_PF_UPDATE_PREP] = "update_prep",
-	[OBJ_PF_UPDATE_DISPATCH] = "update_dispatch",
-	[OBJ_PF_UPDATE_LOCAL] = "update_local",
-	[OBJ_PF_UPDATE_END] = "update_end",
-	[OBJ_PF_UPDATE_WAIT] = "update_end",
-	[OBJ_PF_UPDATE_REPLY] = "update_repl",
-	[OBJ_PF_UPDATE] = "update",
-};
-
-static int
-ds_obj_profile_start(char *path, int avg)
-{
-	struct obj_tls *tls = obj_tls_get();
-	int rc;
-
-	if (tls->ot_sp)
-		return 0;
-
-	rc = srv_profile_start(&tls->ot_sp, path, avg, OBJ_PF_MAX,
-			       profile_op_names);
-	D_DEBUG(DB_MGMT, "object profile start: "DF_RC"\n", DP_RC(rc));
-	return rc;
-}
-
-static int
-ds_obj_profile_stop(void)
-{
-	struct obj_tls *tls = obj_tls_get();
-	int	rc;
-
-	if (tls->ot_sp == NULL)
-		return 0;
-
-	rc = srv_profile_stop(tls->ot_sp);
-
-	D_DEBUG(DB_MGMT, "object profile stop: "DF_RC"\n", DP_RC(rc));
-	tls->ot_sp = NULL;
-	return rc;
 }
 
 struct dss_module_key obj_module_key = {
@@ -164,8 +120,6 @@ struct dss_module_key obj_module_key = {
 
 static struct dss_module_ops ds_obj_mod_ops = {
 	.dms_abt_pool_choose_cb = NULL,
-	.dms_profile_start = ds_obj_profile_start,
-	.dms_profile_stop = ds_obj_profile_stop,
 };
 
 struct dss_module obj_module =  {

--- a/src/object/srv_obj.c
+++ b/src/object/srv_obj.c
@@ -926,7 +926,6 @@ obj_local_rw(crt_rpc_t *rpc, struct ds_cont_hdl *cont_hdl,
 	uint32_t		tag = dss_get_module_info()->dmi_tgt_id;
 	daos_handle_t		ioh = DAOS_HDL_INVAL;
 	uint64_t		time_start = 0;
-	struct obj_tls		*tls = obj_tls_get();
 	struct bio_desc		*biod;
 	daos_key_t		*dkey;
 	crt_bulk_op_t		bulk_op;
@@ -937,7 +936,7 @@ obj_local_rw(crt_rpc_t *rpc, struct ds_cont_hdl *cont_hdl,
 	uint64_t		*offs;
 	int			err, rc = 0;
 
-	D_TIME_START(tls->ot_sp, time_start, OBJ_PF_UPDATE_LOCAL);
+	D_TIME_START(time_start, OBJ_PF_UPDATE_LOCAL);
 
 	if (daos_is_zero_dti(&orw->orw_dti)) {
 		D_DEBUG(DB_TRACE, "disable dtx\n");
@@ -1072,7 +1071,7 @@ post:
 	rc = rc ? : err;
 out:
 	rc = obj_rw_complete(rpc, cont, ioh, rc, dth);
-	D_TIME_END(tls->ot_sp, time_start, OBJ_PF_UPDATE_LOCAL);
+	D_TIME_END(time_start, OBJ_PF_UPDATE_LOCAL);
 	return rc;
 }
 
@@ -1390,7 +1389,6 @@ ds_obj_rw_handler(crt_rpc_t *rpc)
 {
 	struct obj_rw_in		*orw = crt_req_get(rpc);
 	struct obj_rw_out		*orwo = crt_reply_get(rpc);
-	struct obj_tls			*tls = obj_tls_get();
 	struct dtx_leader_handle	dlh = { 0 };
 	struct ds_obj_exec_arg		exec_arg = { 0 };
 	struct obj_io_context		ioc;
@@ -1470,7 +1468,7 @@ ds_obj_rw_handler(crt_rpc_t *rpc)
 		goto cleanup;
 	}
 
-	D_TIME_START(tls->ot_sp, time_start, OBJ_PF_UPDATE);
+	D_TIME_START(time_start, OBJ_PF_UPDATE);
 
 renew:
 	/*
@@ -1536,7 +1534,7 @@ reply:
 	obj_rw_reply(rpc, rc, ioc.ioc_map_ver, NULL, ioc.ioc_coh);
 
 cleanup:
-	D_TIME_END(tls->ot_sp, time_start, OBJ_PF_UPDATE);
+	D_TIME_END(time_start, OBJ_PF_UPDATE);
 	obj_ec_split_req_fini(split_req);
 	obj_ioc_end(&ioc, rc);
 }

--- a/src/utils/dmg.c
+++ b/src/utils/dmg.c
@@ -785,63 +785,6 @@ disconnect:
 }
 
 static int
-module_str2id(const char *name, int name_len)
-{
-	if (strncmp(name, "object", name_len) == 0)
-		return DAOS_OBJ_MODULE;
-	else if (strncmp(name, "rebuild", name_len) == 0)
-		return DAOS_REBUILD_MODULE;
-	else if (strncmp(name, "vos", name_len) == 0)
-		return DAOS_VOS_MODULE;
-	else if (strncmp(name, "pool", name_len) == 0)
-		return DAOS_VOS_MODULE;
-	else
-		return -DER_INVAL;
-}
-
-static int
-module_opt_parse(char *opt_str, uint64_t *module_p)
-{
-	char *ptr = opt_str;
-	uint64_t module = 0;
-	int rc = 0;
-
-	while (1) {
-		char *end;
-		int mod_id;
-
-		/* skip the space & , to locate the start */
-		while (*ptr && (*ptr == ' ' || *ptr == ','))
-			ptr++;
-
-		if (!*ptr)
-			break;
-
-		/* find the word end */
-		end = ptr;
-		while (*end && *end != ' ' && *end != ',')
-			end++;
-
-		mod_id = module_str2id(ptr, end - ptr);
-		if (mod_id < 0)
-			return mod_id;
-
-		if (mod_id > 64) {
-			fprintf(stderr, "wrong module %s id %d\n", ptr, mod_id);
-			return -DER_INVAL;
-		}
-		module |= 1 << mod_id;
-
-		ptr = end;
-	}
-
-	if (module > 0)
-		*module_p = module;
-
-	return rc;
-}
-
-int
 file_path_copy(char *opt_str, char **path)
 {
 	int len = strlen(opt_str) + 1;
@@ -857,7 +800,6 @@ file_path_copy(char *opt_str, char **path)
 static int
 profile_op_hdlr(int argc, char *argv[])
 {
-	uint64_t		modules = -1;
 	char			*path = NULL;
 	bool			start = false;
 	bool			stop = false;
@@ -868,7 +810,6 @@ profile_op_hdlr(int argc, char *argv[])
 		{"start",	no_argument,		NULL,	's'},
 		{"end",		no_argument,		NULL,	'e'},
 		{"path",	required_argument,	NULL,	'p'},
-		{"module",	required_argument,	NULL,	'm'},
 		{NULL,		0,			NULL,	0}
 	};
 
@@ -877,15 +818,6 @@ profile_op_hdlr(int argc, char *argv[])
 		switch (rc) {
 		case 'a':
 			average = atoi(optarg);
-			break;
-		case 'm':
-			rc = module_opt_parse(optarg, &modules);
-			if (rc != 0) {
-				fprintf(stderr, "failed to parse module: %s\n",
-					optarg);
-				goto out;
-			}
-
 			break;
 		case 'p':
 			rc = file_path_copy(optarg, &path);
@@ -913,13 +845,7 @@ profile_op_hdlr(int argc, char *argv[])
 		goto out;
 	}
 
-	if (start && (modules == (uint64_t)(-1))) {
-		fprintf(stderr, "module option and path are needed\n");
-		rc = -DER_INVAL;
-		goto out;
-	}
-
-	rc = dc_mgmt_profile(modules, path, average, start);
+	rc = dc_mgmt_profile(path, average, start);
 out:
 	if (path)
 		free(path);

--- a/src/vos/vos_io.c
+++ b/src/vos/vos_io.c
@@ -1468,7 +1468,9 @@ vos_update_end(daos_handle_t ioh, uint32_t pm_ver, daos_key_t *dkey, int err,
 	struct vos_io_context	*ioc = vos_ioh2ioc(ioh);
 	struct umem_instance	*umem;
 	struct vos_ts_entry	*entry;
+	uint64_t		time = 0;
 
+	D_TIME_START(time, VOS_UPDATE_END);
 	D_ASSERT(ioc->ic_update);
 
 	if (err != 0)
@@ -1553,6 +1555,7 @@ out:
 
 	update_read_timestamps(ioc, err);
 
+	D_TIME_END(time, VOS_UPDATE_END);
 	vos_ioc_destroy(ioc, err != 0);
 	vos_dth_set(NULL);
 


### PR DESCRIPTION
Move profile from each module tls to dss_module_info
so each module can profiled simplied. And it only need

1. Define profile id and name in src/iosrv/profile.c
2. Add D_TIME_START/END in the corresponding function.

And also move module option for profile start.

Signed-off-by: Di Wang <di.wang@intel.com>