### PR TITLE
DAOS-2666 test: silence coverity warning in dfs_test

### DIFF
--- a/src/tests/suite/dfs_test.c
+++ b/src/tests/suite/dfs_test.c
@@ -562,7 +562,7 @@ dfs_test_syml(void **state)
 	char			*val = "SYMLINK VAL 1";
 	char			tmp_buf[64];
 	struct stat		stbuf;
-	daos_size_t		size;
+	daos_size_t		size = 0;
 	int			rc, op_rc;
 
 	op_rc = dfs_open(dfs_mt, NULL, filename, S_IFLNK | S_IWUSR | S_IRUSR,


### PR DESCRIPTION
it's a false positive, but need to silence the warning.

Skip-test: true

Signed-off-by: Mohamad Chaarawi <mohamad.chaarawi@intel.com>