### PR TITLE
DAOS-2666 test: silence coverity warning in dfs_test (#2345)

### DIFF
--- a/src/tests/suite/dfs_test.c
+++ b/src/tests/suite/dfs_test.c
@@ -476,7 +476,7 @@ dfs_test_syml(void **state)
 	char			*val = "SYMLINK VAL 1";
 	char			tmp_buf[64];
 	struct stat		stbuf;
-	daos_size_t		size;
+	daos_size_t		size = 0;
 	int			rc;
 
 	if (arg->myrank != 0)


### PR DESCRIPTION
Signed-off-by: Mohamad Chaarawi <mohamad.chaarawi@intel.com>
Conflicts:
	src/tests/suite/dfs_test.c