### PR TITLE
DAOS-4447 control: move mock mgmt svc client to common

### DIFF
--- a/src/control/client/connect_test.go
+++ b/src/control/client/connect_test.go
@@ -1,5 +1,5 @@
 //
-// (C) Copyright 2018-2019 Intel Corporation.
+// (C) Copyright 2018-2020 Intel Corporation.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -43,7 +43,7 @@ func connectSetupServers(
 	ctrlrResults NvmeControllerResults, modules ScmModules,
 	moduleResults ScmModuleResults, pmems ScmNamespaces, mountResults ScmMountResults,
 	scanRet error, formatRet error, killRet error, connectRet error,
-	ACLRet *mockACLResult, listPoolsRet *mockListPoolsResult) Connect {
+	ACLRet *MockACLResult, listPoolsRet *MockListPoolsResult) Connect {
 
 	connect := newMockConnect(
 		log, state, ctrlrs, ctrlrResults, modules,
@@ -60,8 +60,8 @@ func connectSetup(
 	state State, ctrlrs NvmeControllers, ctrlrResults NvmeControllerResults,
 	modules ScmModules, moduleResults ScmModuleResults, pmems ScmNamespaces,
 	mountResults ScmMountResults, scanRet error, formatRet error,
-	killRet error, connectRet error, ACLRet *mockACLResult,
-	listPoolsRet *mockListPoolsResult) Connect {
+	killRet error, connectRet error, ACLRet *MockACLResult,
+	listPoolsRet *MockListPoolsResult) Connect {
 
 	return connectSetupServers(MockServers, log, state, ctrlrs,
 		ctrlrResults, modules, moduleResults, pmems, mountResults, scanRet,
@@ -235,8 +235,8 @@ func TestPoolQuery(t *testing.T) {
 		"query fails": {
 			mc: &mockConnectConfig{
 				addresses: MockServers,
-				svcClientCfg: mockMgmtSvcClientConfig{
-					poolQueryErr: errors.New("query failed"),
+				svcClientCfg: MockMgmtSvcClientConfig{
+					PoolQueryErr: errors.New("query failed"),
 				},
 			},
 			expErr: errors.New("query failed"),
@@ -244,8 +244,8 @@ func TestPoolQuery(t *testing.T) {
 		"nonzero resp status": {
 			mc: &mockConnectConfig{
 				addresses: MockServers,
-				svcClientCfg: mockMgmtSvcClientConfig{
-					poolQueryResult: &mgmtpb.PoolQueryResp{
+				svcClientCfg: MockMgmtSvcClientConfig{
+					PoolQueryResult: &mgmtpb.PoolQueryResp{
 						Status: -42,
 					},
 				},
@@ -255,8 +255,8 @@ func TestPoolQuery(t *testing.T) {
 		"query succeeds": {
 			mc: &mockConnectConfig{
 				addresses: MockServers,
-				svcClientCfg: mockMgmtSvcClientConfig{
-					poolQueryResult: &mgmtpb.PoolQueryResp{
+				svcClientCfg: MockMgmtSvcClientConfig{
+					PoolQueryResult: &mgmtpb.PoolQueryResp{
 						Uuid:            MockUUID,
 						Totaltargets:    42,
 						Activetargets:   16,
@@ -368,10 +368,10 @@ func TestPoolGetACL(t *testing.T) {
 			if tt.expectedResp != nil {
 				expectedACL = tt.expectedResp.ACL.Entries
 			}
-			aclResult := &mockACLResult{
-				acl:    expectedACL,
-				status: tt.getACLRespStatus,
-				err:    tt.getACLErr,
+			aclResult := &MockACLResult{
+				Acl:    expectedACL,
+				Status: tt.getACLRespStatus,
+				Err:    tt.getACLErr,
 			}
 			cc := connectSetupServers(tt.addr, log, Ready,
 				MockCtrlrs, MockCtrlrResults, MockScmModules,
@@ -402,7 +402,7 @@ func TestPoolOverwriteACL(t *testing.T) {
 	defer ShowBufferOnFailure(t, buf)
 
 	testACL := &AccessControlList{
-		Entries: MockACL.acl,
+		Entries: MockACL.Acl,
 	}
 
 	for name, tt := range map[string]struct {
@@ -453,10 +453,10 @@ func TestPoolOverwriteACL(t *testing.T) {
 			if tt.expectedResp != nil {
 				expectedACL = tt.expectedResp.ACL.Entries
 			}
-			aclResult := &mockACLResult{
-				acl:    expectedACL,
-				status: tt.overwriteACLRespStatus,
-				err:    tt.overwriteACLErr,
+			aclResult := &MockACLResult{
+				Acl:    expectedACL,
+				Status: tt.overwriteACLRespStatus,
+				Err:    tt.overwriteACLErr,
 			}
 			cc := connectSetupServers(tt.addr, log, Ready,
 				MockCtrlrs, MockCtrlrResults, MockScmModules,
@@ -488,7 +488,7 @@ func TestPoolUpdateACL(t *testing.T) {
 	defer ShowBufferOnFailure(t, buf)
 
 	testACL := &AccessControlList{
-		Entries: MockACL.acl,
+		Entries: MockACL.Acl,
 	}
 
 	for name, tt := range map[string]struct {
@@ -544,10 +544,10 @@ func TestPoolUpdateACL(t *testing.T) {
 			if tt.expectedResp != nil {
 				expectedACL = tt.expectedResp.ACL.Entries
 			}
-			aclResult := &mockACLResult{
-				acl:    expectedACL,
-				status: tt.updateACLRespStatus,
-				err:    tt.updateACLErr,
+			aclResult := &MockACLResult{
+				Acl:    expectedACL,
+				Status: tt.updateACLRespStatus,
+				Err:    tt.updateACLErr,
 			}
 			cc := connectSetupServers(tt.addr, log, Ready,
 				MockCtrlrs, MockCtrlrResults, MockScmModules,
@@ -623,10 +623,10 @@ func TestPoolDeleteACL(t *testing.T) {
 			if tt.expectedResp != nil {
 				expectedACL = tt.expectedResp.ACL.Entries
 			}
-			aclResult := &mockACLResult{
-				acl:    expectedACL,
-				status: tt.deleteACLRespStatus,
-				err:    tt.deleteACLErr,
+			aclResult := &MockACLResult{
+				Acl:    expectedACL,
+				Status: tt.deleteACLRespStatus,
+				Err:    tt.deleteACLErr,
 			}
 			cc := connectSetupServers(tt.addr, log, Ready,
 				MockCtrlrs, MockCtrlrResults, MockScmModules,
@@ -684,7 +684,7 @@ func TestListPools(t *testing.T) {
 		"success": {
 			addr:                MockServers,
 			listPoolsRespStatus: 0,
-			expectedResp:        &ListPoolsResp{Pools: poolDiscoveriesFromPB(MockPoolList)},
+			expectedResp:        &ListPoolsResp{Pools: PoolDiscoveriesFromPB(MockPoolList)},
 			expectedErr:         "",
 		},
 	} {
@@ -694,9 +694,9 @@ func TestListPools(t *testing.T) {
 				MockCtrlrs, MockCtrlrResults, MockScmModules,
 				MockModuleResults, MockScmNamespaces, MockMountResults,
 				nil, nil, nil, nil, MockACL,
-				&mockListPoolsResult{
-					err:    tt.listPoolsErr,
-					status: tt.listPoolsRespStatus,
+				&MockListPoolsResult{
+					Err:    tt.listPoolsErr,
+					Status: tt.listPoolsRespStatus,
 				})
 
 			resp, err := cc.ListPools(ListPoolsReq{})
@@ -733,8 +733,8 @@ func TestPoolSetProp(t *testing.T) {
 		"set-prop fails": {
 			mc: &mockConnectConfig{
 				addresses: MockServers,
-				svcClientCfg: mockMgmtSvcClientConfig{
-					poolSetPropErr: errors.New("set-prop failed"),
+				svcClientCfg: MockMgmtSvcClientConfig{
+					PoolSetPropErr: errors.New("set-prop failed"),
 				},
 			},
 			req: PoolSetPropReq{
@@ -747,8 +747,8 @@ func TestPoolSetProp(t *testing.T) {
 		"nonzero resp status": {
 			mc: &mockConnectConfig{
 				addresses: MockServers,
-				svcClientCfg: mockMgmtSvcClientConfig{
-					poolSetPropResult: &mgmtpb.PoolSetPropResp{
+				svcClientCfg: MockMgmtSvcClientConfig{
+					PoolSetPropResult: &mgmtpb.PoolSetPropResp{
 						Status: -42,
 					},
 				},
@@ -783,8 +783,8 @@ func TestPoolSetProp(t *testing.T) {
 		"invalid response value": {
 			mc: &mockConnectConfig{
 				addresses: MockServers,
-				svcClientCfg: mockMgmtSvcClientConfig{
-					poolSetPropResult: &mgmtpb.PoolSetPropResp{},
+				svcClientCfg: MockMgmtSvcClientConfig{
+					PoolSetPropResult: &mgmtpb.PoolSetPropResp{},
 				},
 			},
 			req: PoolSetPropReq{
@@ -797,8 +797,8 @@ func TestPoolSetProp(t *testing.T) {
 		"successful string property": {
 			mc: &mockConnectConfig{
 				addresses: MockServers,
-				svcClientCfg: mockMgmtSvcClientConfig{
-					poolSetPropResult: &mgmtpb.PoolSetPropResp{
+				svcClientCfg: MockMgmtSvcClientConfig{
+					PoolSetPropResult: &mgmtpb.PoolSetPropResp{
 						Property: &mgmtpb.PoolSetPropResp_Name{
 							Name: testPropName,
 						},
@@ -822,8 +822,8 @@ func TestPoolSetProp(t *testing.T) {
 		"successful numeric property": {
 			mc: &mockConnectConfig{
 				addresses: MockServers,
-				svcClientCfg: mockMgmtSvcClientConfig{
-					poolSetPropResult: &mgmtpb.PoolSetPropResp{
+				svcClientCfg: MockMgmtSvcClientConfig{
+					PoolSetPropResult: &mgmtpb.PoolSetPropResp{
 						Property: &mgmtpb.PoolSetPropResp_Name{
 							Name: testPropName,
 						},

--- a/src/control/client/mocks.go
+++ b/src/control/client/mocks.go
@@ -32,6 +32,7 @@ import (
 	grpc "google.golang.org/grpc"
 	"google.golang.org/grpc/connectivity"
 
+	"github.com/daos-stack/daos/src/control/common"
 	. "github.com/daos-stack/daos/src/control/common/proto"
 	ctlpb "github.com/daos-stack/daos/src/control/common/proto/ctl"
 	mgmtpb "github.com/daos-stack/daos/src/control/common/proto/mgmt"
@@ -69,15 +70,11 @@ var (
 			State:    &MockState,
 		},
 	}
-	MockACL = &mockACLResult{
-		acl: []string{
+	MockACL = &common.MockACLResult{
+		Acl: []string{
 			"A::OWNER@:rw",
 			"A::GROUP@:r",
 		},
-	}
-	MockPoolList = []*mgmtpb.ListPoolsResp_Pool{
-		{Uuid: "12345678-1234-1234-1234-123456789abc", Svcreps: []uint32{1, 2}},
-		{Uuid: "12345678-1234-1234-1234-cba987654321", Svcreps: []uint32{0}},
 	}
 	MockErr = errors.New("unknown failure")
 )
@@ -180,164 +177,6 @@ func (m *mockMgmtCtlClient) SystemStart(ctx context.Context, req *ctlpb.SystemSt
 	return &ctlpb.SystemStartResp{}, nil
 }
 
-type mockACLResult struct {
-	acl    []string
-	status int32
-	err    error
-}
-
-// ACL returns a properly formed AccessControlList from the mock data
-func (m *mockACLResult) ACL() *AccessControlList {
-	return &AccessControlList{
-		Entries: m.acl,
-	}
-}
-
-type mockListPoolsResult struct {
-	status int32
-	err    error
-}
-
-type mockMgmtSvcClientConfig struct {
-	ACLRet            *mockACLResult
-	ListPoolsRet      *mockListPoolsResult
-	killErr           error
-	poolQueryResult   *mgmtpb.PoolQueryResp
-	poolQueryErr      error
-	poolSetPropResult *mgmtpb.PoolSetPropResp
-	poolSetPropErr    error
-}
-
-type mockMgmtSvcClient struct {
-	cfg mockMgmtSvcClientConfig
-}
-
-func (m *mockMgmtSvcClient) PoolCreate(ctx context.Context, req *mgmtpb.PoolCreateReq, o ...grpc.CallOption) (*mgmtpb.PoolCreateResp, error) {
-	// return successful pool creation results
-	// initialise with zero values indicating mgmt.CTL_SUCCESS
-	return &mgmtpb.PoolCreateResp{}, nil
-}
-
-func (m *mockMgmtSvcClient) PoolDestroy(ctx context.Context, req *mgmtpb.PoolDestroyReq, o ...grpc.CallOption) (*mgmtpb.PoolDestroyResp, error) {
-	// return successful pool destroy results
-	// initialise with zero values indicating mgmt.CTL_SUCCESS
-	return &mgmtpb.PoolDestroyResp{}, nil
-}
-
-func (m *mockMgmtSvcClient) PoolQuery(ctx context.Context, req *mgmtpb.PoolQueryReq, _ ...grpc.CallOption) (*mgmtpb.PoolQueryResp, error) {
-	if m.cfg.poolQueryErr != nil {
-		return nil, m.cfg.poolQueryErr
-	}
-	return m.cfg.poolQueryResult, nil
-}
-
-func (m *mockMgmtSvcClient) PoolSetProp(ctx context.Context, req *mgmtpb.PoolSetPropReq, _ ...grpc.CallOption) (*mgmtpb.PoolSetPropResp, error) {
-	if m.cfg.poolSetPropErr != nil {
-		return nil, m.cfg.poolSetPropErr
-	}
-	return m.cfg.poolSetPropResult, nil
-}
-
-// returnACLResult returns the mock ACL results - either an error or an ACLResp
-func (m *mockMgmtSvcClient) returnACLResult() (*mgmtpb.ACLResp, error) {
-	if m.cfg.ACLRet.err != nil {
-		return nil, m.cfg.ACLRet.err
-	}
-	return &mgmtpb.ACLResp{ACL: m.cfg.ACLRet.acl, Status: m.cfg.ACLRet.status}, nil
-}
-
-func (m *mockMgmtSvcClient) PoolGetACL(ctx context.Context, req *mgmtpb.GetACLReq, o ...grpc.CallOption) (*mgmtpb.ACLResp, error) {
-	return m.returnACLResult()
-}
-
-func (m *mockMgmtSvcClient) PoolOverwriteACL(ctx context.Context, req *mgmtpb.ModifyACLReq, o ...grpc.CallOption) (*mgmtpb.ACLResp, error) {
-	return m.returnACLResult()
-}
-
-func (m *mockMgmtSvcClient) PoolUpdateACL(ctx context.Context, req *mgmtpb.ModifyACLReq, o ...grpc.CallOption) (*mgmtpb.ACLResp, error) {
-	return m.returnACLResult()
-}
-
-func (m *mockMgmtSvcClient) PoolDeleteACL(ctx context.Context, req *mgmtpb.DeleteACLReq, o ...grpc.CallOption) (*mgmtpb.ACLResp, error) {
-	return m.returnACLResult()
-}
-
-func (m *mockMgmtSvcClient) BioHealthQuery(ctx context.Context, req *mgmtpb.BioHealthReq, o ...grpc.CallOption) (*mgmtpb.BioHealthResp, error) {
-
-	// return successful bio health results
-	// initialise with zero values indicating mgmt.CTL_SUCCESS
-	return &mgmtpb.BioHealthResp{}, nil
-}
-
-func (m *mockMgmtSvcClient) SmdListDevs(ctx context.Context, req *mgmtpb.SmdDevReq, o ...grpc.CallOption) (*mgmtpb.SmdDevResp, error) {
-
-	// return successful SMD device list
-	// initialise with zero values indicating mgmt.CTL_SUCCESS
-	return &mgmtpb.SmdDevResp{}, nil
-}
-
-func (m *mockMgmtSvcClient) SmdListPools(ctx context.Context, req *mgmtpb.SmdPoolReq, o ...grpc.CallOption) (*mgmtpb.SmdPoolResp, error) {
-
-	// return successful SMD pool list
-	// initialise with zero values indicating mgmt.CTL_SUCCESS
-	return &mgmtpb.SmdPoolResp{}, nil
-}
-
-func (m *mockMgmtSvcClient) DevStateQuery(ctx context.Context, req *mgmtpb.DevStateReq, o ...grpc.CallOption) (*mgmtpb.DevStateResp, error) {
-
-	// return successful device state
-	// initialise with zero values indicating mgmt.CTRL_SUCCESS
-	return &mgmtpb.DevStateResp{}, nil
-}
-
-func (m *mockMgmtSvcClient) StorageSetFaulty(ctx context.Context, req *mgmtpb.DevStateReq, o ...grpc.CallOption) (*mgmtpb.DevStateResp, error) {
-
-	// return suscessful FAULTY device state
-	// initialise with zero values indicating mgmt.CTRL_SUCCESS
-	return &mgmtpb.DevStateResp{}, nil
-}
-
-func (m *mockMgmtSvcClient) Join(ctx context.Context, req *mgmtpb.JoinReq, o ...grpc.CallOption) (*mgmtpb.JoinResp, error) {
-
-	return &mgmtpb.JoinResp{}, nil
-}
-
-func (m *mockMgmtSvcClient) GetAttachInfo(ctx context.Context, in *mgmtpb.GetAttachInfoReq, opts ...grpc.CallOption) (*mgmtpb.GetAttachInfoResp, error) {
-	return &mgmtpb.GetAttachInfoResp{}, nil
-}
-
-func (m *mockMgmtSvcClient) PrepShutdownRanks(ctx context.Context, req *mgmtpb.RanksReq, o ...grpc.CallOption) (*mgmtpb.RanksResp, error) {
-	return &mgmtpb.RanksResp{}, nil
-}
-
-func (m *mockMgmtSvcClient) StopRanks(ctx context.Context, req *mgmtpb.RanksReq, o ...grpc.CallOption) (*mgmtpb.RanksResp, error) {
-	return &mgmtpb.RanksResp{}, nil
-}
-
-func (m *mockMgmtSvcClient) PingRanks(ctx context.Context, req *mgmtpb.RanksReq, o ...grpc.CallOption) (*mgmtpb.RanksResp, error) {
-	return &mgmtpb.RanksResp{}, nil
-}
-
-func (m *mockMgmtSvcClient) StartRanks(ctx context.Context, req *mgmtpb.RanksReq, o ...grpc.CallOption) (*mgmtpb.RanksResp, error) {
-	return &mgmtpb.RanksResp{}, nil
-}
-
-func (m *mockMgmtSvcClient) ListPools(ctx context.Context, req *mgmtpb.ListPoolsReq, o ...grpc.CallOption) (*mgmtpb.ListPoolsResp, error) {
-	if m.cfg.ListPoolsRet.err != nil {
-		return nil, m.cfg.ListPoolsRet.err
-	}
-	return &mgmtpb.ListPoolsResp{Pools: MockPoolList, Status: m.cfg.ListPoolsRet.status}, nil
-}
-
-func (m *mockMgmtSvcClient) LeaderQuery(ctx context.Context, req *mgmtpb.LeaderQueryReq, _ ...grpc.CallOption) (*mgmtpb.LeaderQueryResp, error) {
-	return &mgmtpb.LeaderQueryResp{}, nil
-}
-
-func (m *mockMgmtSvcClient) ListContainers(ctx context.Context, req *mgmtpb.ListContReq, o ...grpc.CallOption) (*mgmtpb.ListContResp, error) {
-	// return successful list containers results
-	return &mgmtpb.ListContResp{}, nil
-}
-
 type mockControlConfig struct {
 	connectedState connectivity.State
 	connectErr     error
@@ -392,14 +231,14 @@ type mockControllerFactory struct {
 	log          logging.Logger
 	controlCfg   mockControlConfig
 	ctlClientCfg mockMgmtCtlClientConfig
-	svcClientCfg mockMgmtSvcClientConfig
+	svcClientCfg MockMgmtSvcClientConfig
 }
 
 func (m *mockControllerFactory) create(address string, cfg *security.TransportConfig) (Control, error) {
 	// returns controller with mock properties specified in constructor
 	cClient := &mockMgmtCtlClient{cfg: m.ctlClientCfg}
 
-	sClient := &mockMgmtSvcClient{cfg: m.svcClientCfg}
+	sClient := &MockMgmtSvcClient{Cfg: m.svcClientCfg}
 
 	controller := newMockControl(m.log, address, m.controlCfg, cClient, sClient)
 
@@ -413,7 +252,7 @@ type mockConnectConfig struct {
 	addresses     Addresses
 	controlConfig mockControlConfig
 	ctlClientCfg  mockMgmtCtlClientConfig
-	svcClientCfg  mockMgmtSvcClientConfig
+	svcClientCfg  MockMgmtSvcClientConfig
 }
 
 // newMockConnnectCfg is the config-based version of newMockConnect()
@@ -441,8 +280,8 @@ func newMockConnect(log logging.Logger,
 	state connectivity.State, ctrlrs NvmeControllers,
 	ctrlrResults NvmeControllerResults, modules ScmModules,
 	moduleResults ScmModuleResults, pmems ScmNamespaces, mountResults ScmMountResults,
-	scanRet error, formatRet error, killRet error, connectRet error, ACLRet *mockACLResult,
-	listPoolsRet *mockListPoolsResult) *connList {
+	scanRet error, formatRet error, killRet error, connectRet error, ACLRet *common.MockACLResult,
+	listPoolsRet *common.MockListPoolsResult) *connList {
 
 	return &connList{
 		log: log,
@@ -462,10 +301,10 @@ func newMockConnect(log logging.Logger,
 				scanRet:               scanRet,
 				formatRet:             formatRet,
 			},
-			svcClientCfg: mockMgmtSvcClientConfig{
+			svcClientCfg: MockMgmtSvcClientConfig{
 				ACLRet:       ACLRet,
 				ListPoolsRet: listPoolsRet,
-				killErr:      killRet,
+				KillErr:      killRet,
 			},
 		},
 	}

--- a/src/control/client/pool.go
+++ b/src/control/client/pool.go
@@ -1,5 +1,5 @@
 //
-// (C) Copyright 2019 Intel Corporation.
+// (C) Copyright 2019-2020 Intel Corporation.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -30,6 +30,8 @@ import (
 	"github.com/pkg/errors"
 	"golang.org/x/net/context"
 
+	"github.com/daos-stack/daos/src/control/common"
+	"github.com/daos-stack/daos/src/control/common/proto"
 	"github.com/daos-stack/daos/src/control/common/proto/convert"
 	mgmtpb "github.com/daos-stack/daos/src/control/common/proto/mgmt"
 )
@@ -43,7 +45,7 @@ type PoolCreateReq struct {
 	Sys        string
 	Usr        string
 	Grp        string
-	ACL        *AccessControlList
+	ACL        *common.AccessControlList
 	UUID       string
 }
 
@@ -319,7 +321,7 @@ type PoolGetACLReq struct {
 
 // PoolGetACLResp contains the output results for PoolGetACL
 type PoolGetACLResp struct {
-	ACL *AccessControlList
+	ACL *common.AccessControlList
 }
 
 // PoolGetACL gets the Access Control List for the pool.
@@ -346,19 +348,19 @@ func (c *connList) PoolGetACL(req PoolGetACLReq) (*PoolGetACLResp, error) {
 	}
 
 	return &PoolGetACLResp{
-		ACL: accessControlListFromPB(pbResp),
+		ACL: proto.AccessControlListFromPB(pbResp),
 	}, nil
 }
 
 // PoolOverwriteACLReq contains the input parameters for PoolOverwriteACL
 type PoolOverwriteACLReq struct {
-	UUID string             // pool UUID
-	ACL  *AccessControlList // new ACL for the pool
+	UUID string                    // pool UUID
+	ACL  *common.AccessControlList // new ACL for the pool
 }
 
 // PoolOverwriteACLResp returns the updated ACL for the pool
 type PoolOverwriteACLResp struct {
-	ACL *AccessControlList // actual ACL of the pool
+	ACL *common.AccessControlList // actual ACL of the pool
 }
 
 // PoolOverwriteACL sends a request to replace the pool's old Access Control List
@@ -390,19 +392,19 @@ func (c *connList) PoolOverwriteACL(req PoolOverwriteACLReq) (*PoolOverwriteACLR
 	}
 
 	return &PoolOverwriteACLResp{
-		ACL: accessControlListFromPB(pbResp),
+		ACL: proto.AccessControlListFromPB(pbResp),
 	}, nil
 }
 
 // PoolUpdateACLReq contains the input parameters for PoolUpdateACL
 type PoolUpdateACLReq struct {
-	UUID string             // pool UUID
-	ACL  *AccessControlList // ACL entries to add to the pool
+	UUID string                    // pool UUID
+	ACL  *common.AccessControlList // ACL entries to add to the pool
 }
 
 // PoolUpdateACLResp returns the updated ACL for the pool
 type PoolUpdateACLResp struct {
-	ACL *AccessControlList // actual ACL of the pool
+	ACL *common.AccessControlList // actual ACL of the pool
 }
 
 // PoolUpdateACL sends a request to add new entries and update existing entries
@@ -436,7 +438,7 @@ func (c *connList) PoolUpdateACL(req PoolUpdateACLReq) (*PoolUpdateACLResp, erro
 	}
 
 	return &PoolUpdateACLResp{
-		ACL: accessControlListFromPB(pbResp),
+		ACL: proto.AccessControlListFromPB(pbResp),
 	}, nil
 }
 
@@ -448,7 +450,7 @@ type PoolDeleteACLReq struct {
 
 // PoolDeleteACLResp returns the updated ACL for the pool.
 type PoolDeleteACLResp struct {
-	ACL *AccessControlList // actual ACL of the pool
+	ACL *common.AccessControlList // actual ACL of the pool
 }
 
 // PoolDeleteACL sends a request to delete an entry in a pool's Access Control
@@ -481,6 +483,6 @@ func (c *connList) PoolDeleteACL(req PoolDeleteACLReq) (*PoolDeleteACLResp, erro
 	}
 
 	return &PoolDeleteACLResp{
-		ACL: accessControlListFromPB(pbResp),
+		ACL: proto.AccessControlListFromPB(pbResp),
 	}, nil
 }

--- a/src/control/client/system.go
+++ b/src/control/client/system.go
@@ -27,6 +27,8 @@ import (
 	"github.com/pkg/errors"
 	"golang.org/x/net/context"
 
+	"github.com/daos-stack/daos/src/control/common"
+	"github.com/daos-stack/daos/src/control/common/proto"
 	"github.com/daos-stack/daos/src/control/common/proto/convert"
 	ctlpb "github.com/daos-stack/daos/src/control/common/proto/ctl"
 	mgmtpb "github.com/daos-stack/daos/src/control/common/proto/mgmt"
@@ -184,7 +186,7 @@ type ListPoolsReq struct {
 // of pools in the system.
 type ListPoolsResp struct {
 	Status int32
-	Pools  []*PoolDiscovery
+	Pools  []*common.PoolDiscovery
 }
 
 // ListPools fetches the list of all pools and their service replicas from the
@@ -212,6 +214,6 @@ func (c *connList) ListPools(req ListPoolsReq) (*ListPoolsResp, error) {
 	}
 
 	return &ListPoolsResp{
-		Pools: poolDiscoveriesFromPB(pbResp.Pools),
+		Pools: proto.PoolDiscoveriesFromPB(pbResp.Pools),
 	}, nil
 }

--- a/src/control/client/types.go
+++ b/src/control/client/types.go
@@ -1,5 +1,5 @@
 //
-// (C) Copyright 2018-2019 Intel Corporation.
+// (C) Copyright 2018-2020 Intel Corporation.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -414,89 +414,4 @@ func (sfr *StorageFormatResult) HasErrors() bool {
 		return true
 	}
 	return false
-}
-
-// AccessControlList is a structure for the access control list.
-type AccessControlList struct {
-	Entries    []string // Access Control Entries in short string format
-	Owner      string   // User that owns the resource
-	OwnerGroup string   // Group that owns the resource
-}
-
-// Empty checks whether there are any entries in the AccessControlList
-func (acl *AccessControlList) Empty() bool {
-	if acl == nil || len(acl.Entries) == 0 {
-		return true
-	}
-	return false
-}
-
-// HasOwner checks whether the AccessControlList has an owner user.
-func (acl *AccessControlList) HasOwner() bool {
-	if acl == nil {
-		return false
-	}
-
-	if acl.Owner != "" {
-		return true
-	}
-	return false
-}
-
-// HasOwnerGroup checks whether the AccessControlList has an owner group.
-func (acl *AccessControlList) HasOwnerGroup() bool {
-	if acl == nil {
-		return false
-	}
-
-	if acl.OwnerGroup != "" {
-		return true
-	}
-	return false
-}
-
-// String displays the AccessControlList in a basic string format.
-func (acl *AccessControlList) String() string {
-	if acl == nil {
-		return "nil"
-	}
-	return fmt.Sprintf("%+v", *acl)
-}
-
-// accessControlListFromPB converts from the protobuf ACLResp structure to an
-// AccessControlList structure.
-func accessControlListFromPB(pbACL *mgmtpb.ACLResp) *AccessControlList {
-	if pbACL == nil {
-		return &AccessControlList{}
-	}
-	return &AccessControlList{
-		Entries:    pbACL.ACL,
-		Owner:      pbACL.OwnerUser,
-		OwnerGroup: pbACL.OwnerGroup,
-	}
-}
-
-// PoolDiscovery represents the basic discovery information for a pool.
-type PoolDiscovery struct {
-	UUID        string   // Unique identifier
-	SvcReplicas []uint32 // Ranks of pool service replicas
-}
-
-// poolDiscoveriesFromPB converts the protobuf ListPoolsResp_Pool structures to
-// PoolDiscovery structures.
-func poolDiscoveriesFromPB(pbPools []*mgmtpb.ListPoolsResp_Pool) []*PoolDiscovery {
-	pools := make([]*PoolDiscovery, 0, len(pbPools))
-	for _, pbPool := range pbPools {
-		svcReps := make([]uint32, 0, len(pbPool.Svcreps))
-		for _, rep := range pbPool.Svcreps {
-			svcReps = append(svcReps, rep)
-		}
-
-		pools = append(pools, &PoolDiscovery{
-			UUID:        pbPool.Uuid,
-			SvcReplicas: svcReps,
-		})
-	}
-
-	return pools
 }

--- a/src/control/client/types_test.go
+++ b/src/control/client/types_test.go
@@ -1,5 +1,5 @@
 //
-// (C) Copyright 2019 Intel Corporation.
+// (C) Copyright 2019-2020 Intel Corporation.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -28,7 +28,8 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 
-	"github.com/daos-stack/daos/src/control/common"
+	. "github.com/daos-stack/daos/src/control/common"
+	"github.com/daos-stack/daos/src/control/common/proto"
 	mgmtpb "github.com/daos-stack/daos/src/control/common/proto/mgmt"
 )
 
@@ -71,7 +72,7 @@ func TestAccessControlList_Empty(t *testing.T) {
 		},
 	} {
 		t.Run(name, func(t *testing.T) {
-			common.AssertEqual(t, tc.acl.Empty(), tc.expResult, "result didn't match")
+			AssertEqual(t, tc.acl.Empty(), tc.expResult, "result didn't match")
 		})
 	}
 }
@@ -132,7 +133,7 @@ func TestAccessControlList_HasOwner(t *testing.T) {
 		},
 	} {
 		t.Run(name, func(t *testing.T) {
-			common.AssertEqual(t, tc.acl.HasOwner(), tc.expResult, "result didn't match")
+			AssertEqual(t, tc.acl.HasOwner(), tc.expResult, "result didn't match")
 		})
 	}
 }
@@ -193,7 +194,7 @@ func TestAccessControlList_HasOwnerGroup(t *testing.T) {
 		},
 	} {
 		t.Run(name, func(t *testing.T) {
-			common.AssertEqual(t, tc.acl.HasOwnerGroup(), tc.expResult, "result didn't match")
+			AssertEqual(t, tc.acl.HasOwnerGroup(), tc.expResult, "result didn't match")
 		})
 	}
 }
@@ -242,7 +243,7 @@ func TestAccessControlListFromPB(t *testing.T) {
 		},
 	} {
 		t.Run(name, func(t *testing.T) {
-			result := accessControlListFromPB(tc.pbACL)
+			result := proto.AccessControlListFromPB(tc.pbACL)
 
 			if diff := cmp.Diff(tc.expResult, result); diff != "" {
 				t.Fatalf("unexpected response (-want, +got):\n%s\n", diff)
@@ -317,7 +318,7 @@ func TestPoolDiscoveriesFromPB(t *testing.T) {
 		},
 	} {
 		t.Run(name, func(t *testing.T) {
-			result := poolDiscoveriesFromPB(tc.pbPools)
+			result := proto.PoolDiscoveriesFromPB(tc.pbPools)
 
 			if diff := cmp.Diff(tc.expResult, result); diff != "" {
 				t.Fatalf("unexpected response (-want, +got):\n%s\n", diff)

--- a/src/control/cmd/dmg/acl.go
+++ b/src/control/cmd/dmg/acl.go
@@ -1,5 +1,5 @@
 //
-// (C) Copyright 2019 Intel Corporation.
+// (C) Copyright 2019-2020 Intel Corporation.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -32,12 +32,12 @@ import (
 
 	"github.com/pkg/errors"
 
-	"github.com/daos-stack/daos/src/control/client"
+	"github.com/daos-stack/daos/src/control/common"
 )
 
 // readACLFile reads in a file representing an ACL, and translates it into an
 // AccessControlList structure
-func readACLFile(aclFile string) (*client.AccessControlList, error) {
+func readACLFile(aclFile string) (*common.AccessControlList, error) {
 	file, err := os.Open(aclFile)
 	if err != nil {
 		return nil, errors.WithMessage(err, "opening ACL file")
@@ -62,9 +62,9 @@ func isACLFileComment(line string) bool {
 }
 
 // parseACL reads the content from io.Reader and puts the results into a
-// client.AccessControlList structure.
+// common.AccessControlList structure.
 // Assumes that ACE strings are provided one per line.
-func parseACL(reader io.Reader) (*client.AccessControlList, error) {
+func parseACL(reader io.Reader) (*common.AccessControlList, error) {
 	aceList := make([]string, 0)
 	scanner := bufio.NewScanner(reader)
 	for scanner.Scan() {
@@ -78,11 +78,11 @@ func parseACL(reader io.Reader) (*client.AccessControlList, error) {
 		}
 	}
 
-	return &client.AccessControlList{Entries: aceList}, nil
+	return &common.AccessControlList{Entries: aceList}, nil
 }
 
 // formatACL converts the AccessControlList to a human-readable string.
-func formatACL(acl *client.AccessControlList, verbose bool) string {
+func formatACL(acl *common.AccessControlList, verbose bool) string {
 	var builder strings.Builder
 
 	if acl.HasOwner() {
@@ -110,7 +110,7 @@ func formatACL(acl *client.AccessControlList, verbose bool) string {
 }
 
 // formatACLDefault formats the AccessControlList in non-verbose mode.
-func formatACLDefault(acl *client.AccessControlList) string {
+func formatACLDefault(acl *common.AccessControlList) string {
 	return formatACL(acl, false)
 }
 

--- a/src/control/cmd/dmg/acl_test.go
+++ b/src/control/cmd/dmg/acl_test.go
@@ -1,5 +1,5 @@
 //
-// (C) Copyright 2019 Intel Corporation.
+// (C) Copyright 2019-2020 Intel Corporation.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -34,8 +34,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 
-	"github.com/daos-stack/daos/src/control/client"
-	"github.com/daos-stack/daos/src/control/common"
+	. "github.com/daos-stack/daos/src/control/common"
 )
 
 // mockReader is a mock used to represent a successful read of some text
@@ -130,7 +129,7 @@ func TestReadACLFile_Empty(t *testing.T) {
 		t.Errorf("expected no result, got: %+v", result)
 	}
 
-	common.ExpectError(t, err, fmt.Sprintf("ACL file '%s' contains no entries", path), "unexpected error")
+	ExpectError(t, err, fmt.Sprintf("ACL file '%s' contains no entries", path), "unexpected error")
 }
 
 func TestParseACL_EmptyFile(t *testing.T) {
@@ -153,7 +152,7 @@ func TestParseACL_EmptyFile(t *testing.T) {
 
 func TestParseACL_OneValidACE(t *testing.T) {
 	expectedACE := "A::OWNER@:rw"
-	expectedACL := &client.AccessControlList{Entries: []string{expectedACE}}
+	expectedACL := &AccessControlList{Entries: []string{expectedACE}}
 	mockFile := &mockReader{
 		text: expectedACE + "\n",
 	}
@@ -175,7 +174,7 @@ func TestParseACL_OneValidACE(t *testing.T) {
 
 func TestParseACL_WhitespaceExcluded(t *testing.T) {
 	expectedACE := "A::OWNER@:rw"
-	expectedACL := &client.AccessControlList{Entries: []string{expectedACE}}
+	expectedACL := &AccessControlList{Entries: []string{expectedACE}}
 	mockFile := &mockReader{
 		text: expectedACE + " \n\n",
 	}
@@ -203,7 +202,7 @@ func TestParseACL_MultiValidACE(t *testing.T) {
 		"L:f:baduser@:rw",
 		"U:f:EVERYONE@:rw",
 	}
-	expectedACL := &client.AccessControlList{
+	expectedACL := &AccessControlList{
 		Entries: expectedACEs,
 	}
 
@@ -254,7 +253,7 @@ func TestParseACL_MultiValidACEWithComment(t *testing.T) {
 		"L:f:baduser@:rw",
 		"U:f:EVERYONE@:rw",
 	}
-	expectedACL := &client.AccessControlList{
+	expectedACL := &AccessControlList{
 		Entries: expectedACEs,
 	}
 
@@ -285,7 +284,7 @@ func TestParseACL_MultiValidACEWithComment(t *testing.T) {
 
 func TestFormatACL(t *testing.T) {
 	for name, tc := range map[string]struct {
-		acl     *client.AccessControlList
+		acl     *AccessControlList
 		verbose bool
 		expStr  string
 	}{
@@ -293,16 +292,16 @@ func TestFormatACL(t *testing.T) {
 			expStr: "# Entries:\n#   None\n",
 		},
 		"empty": {
-			acl:    &client.AccessControlList{},
+			acl:    &AccessControlList{},
 			expStr: "# Entries:\n#   None\n",
 		},
 		"empty verbose": {
-			acl:     &client.AccessControlList{},
+			acl:     &AccessControlList{},
 			expStr:  "# Entries:\n#   None\n",
 			verbose: true,
 		},
 		"single": {
-			acl: &client.AccessControlList{
+			acl: &AccessControlList{
 				Entries: []string{
 					"A::user@:rw",
 				},
@@ -310,7 +309,7 @@ func TestFormatACL(t *testing.T) {
 			expStr: "# Entries:\nA::user@:rw\n",
 		},
 		"single verbose": {
-			acl: &client.AccessControlList{
+			acl: &AccessControlList{
 				Entries: []string{
 					"A::user@:rw",
 				},
@@ -319,7 +318,7 @@ func TestFormatACL(t *testing.T) {
 			verbose: true,
 		},
 		"multiple": {
-			acl: &client.AccessControlList{
+			acl: &AccessControlList{
 				Entries: []string{
 					"A::OWNER@:rw",
 					"A:G:GROUP@:rw",
@@ -329,7 +328,7 @@ func TestFormatACL(t *testing.T) {
 			expStr: "# Entries:\nA::OWNER@:rw\nA:G:GROUP@:rw\nA:G:readers@:r\n",
 		},
 		"multiple verbose": {
-			acl: &client.AccessControlList{
+			acl: &AccessControlList{
 				Entries: []string{
 					"A::OWNER@:rw",
 					"A:G:GROUP@:rw",
@@ -342,7 +341,7 @@ func TestFormatACL(t *testing.T) {
 			verbose: true,
 		},
 		"with owner user": {
-			acl: &client.AccessControlList{
+			acl: &AccessControlList{
 				Entries: []string{
 					"A::OWNER@:rw",
 				},
@@ -351,7 +350,7 @@ func TestFormatACL(t *testing.T) {
 			expStr: "# Owner: bob@\n# Entries:\nA::OWNER@:rw\n",
 		},
 		"with owner group": {
-			acl: &client.AccessControlList{
+			acl: &AccessControlList{
 				Entries: []string{
 					"A:G:GROUP@:rw",
 				},
@@ -361,13 +360,13 @@ func TestFormatACL(t *testing.T) {
 		},
 	} {
 		t.Run(name, func(t *testing.T) {
-			common.AssertEqual(t, formatACL(tc.acl, tc.verbose), tc.expStr, "string output didn't match")
+			AssertEqual(t, formatACL(tc.acl, tc.verbose), tc.expStr, "string output didn't match")
 		})
 	}
 }
 
 func TestFormatACLDefault(t *testing.T) {
-	acl := &client.AccessControlList{
+	acl := &AccessControlList{
 		Entries: []string{
 			"A::OWNER@:rw",
 			"A::someuser@:rw",
@@ -380,7 +379,7 @@ func TestFormatACLDefault(t *testing.T) {
 	// Just need to make sure it doesn't use verbose mode
 	expStr := formatACL(acl, false)
 
-	common.AssertEqual(t, formatACLDefault(acl), expStr, "output didn't match non-verbose mode")
+	AssertEqual(t, formatACLDefault(acl), expStr, "output didn't match non-verbose mode")
 }
 
 func TestGetVerboseACE(t *testing.T) {
@@ -461,7 +460,7 @@ func TestGetVerboseACE(t *testing.T) {
 		},
 	} {
 		t.Run(name, func(t *testing.T) {
-			common.AssertEqual(t, getVerboseACE(tc.shortACE), tc.expStr, "incorrect output")
+			AssertEqual(t, getVerboseACE(tc.shortACE), tc.expStr, "incorrect output")
 		})
 	}
 }

--- a/src/control/cmd/dmg/pool.go
+++ b/src/control/cmd/dmg/pool.go
@@ -86,7 +86,7 @@ func (c *PoolCreateCmd) Execute(args []string) error {
 		}
 	}
 
-	var acl *client.AccessControlList
+	var acl *common.AccessControlList
 	if c.ACLFile != "" {
 		acl, err = readACLFile(c.ACLFile)
 		if err != nil {
@@ -374,7 +374,7 @@ func (d *PoolUpdateACLCmd) Execute(args []string) error {
 		return errors.New("either ACL file or entry parameter is required")
 	}
 
-	var acl *client.AccessControlList
+	var acl *common.AccessControlList
 	if d.ACLFile != "" {
 		aclFileResult, err := readACLFile(d.ACLFile)
 		if err != nil {
@@ -382,7 +382,7 @@ func (d *PoolUpdateACLCmd) Execute(args []string) error {
 		}
 		acl = aclFileResult
 	} else {
-		acl = &client.AccessControlList{
+		acl = &common.AccessControlList{
 			Entries: []string{d.Entry},
 		}
 	}

--- a/src/control/cmd/dmg/pool_test.go
+++ b/src/control/cmd/dmg/pool_test.go
@@ -41,7 +41,7 @@ import (
 	"github.com/daos-stack/daos/src/control/logging"
 )
 
-func createACLFile(t *testing.T, path string, acl *client.AccessControlList) {
+func createACLFile(t *testing.T, path string, acl *AccessControlList) {
 	t.Helper()
 
 	file, err := os.Create(path)
@@ -75,7 +75,7 @@ func TestPoolCommands(t *testing.T) {
 
 	// Some tests need a valid ACL file
 	testACLFile := filepath.Join(tmpDir, "test_acl.txt")
-	testACL := &client.AccessControlList{
+	testACL := &AccessControlList{
 		Entries: []string{"A::OWNER@:rw", "A:G:GROUP@:rw"},
 	}
 	createACLFile(t, testACLFile, testACL)
@@ -412,7 +412,7 @@ func TestPoolCommands(t *testing.T) {
 				"ConnectClients",
 				fmt.Sprintf("PoolUpdateACL-%+v", client.PoolUpdateACLReq{
 					UUID: "12345678-1234-1234-1234-1234567890ab",
-					ACL:  &client.AccessControlList{Entries: []string{"A::user@:rw"}},
+					ACL:  &AccessControlList{Entries: []string{"A::user@:rw"}},
 				}),
 			}, " "),
 			nil,

--- a/src/control/common/mocks.go
+++ b/src/control/common/mocks.go
@@ -1,0 +1,42 @@
+//
+// (C) Copyright 2020 Intel Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// GOVERNMENT LICENSE RIGHTS-OPEN SOURCE SOFTWARE
+// The Government's rights to use, modify, reproduce, release, perform, display,
+// or disclose this software are subject to the terms of the Apache License as
+// provided in Contract No. 8F-30005.
+// Any reproduction of computer software, computer software documentation, or
+// portions thereof marked with this legend must also reproduce the markings.
+//
+
+package common
+
+type MockACLResult struct {
+	Acl    []string
+	Status int32
+	Err    error
+}
+
+// ACL returns a properly formed AccessControlList from the mock data
+func (m *MockACLResult) ACL() *AccessControlList {
+	return &AccessControlList{
+		Entries: m.Acl,
+	}
+}
+
+type MockListPoolsResult struct {
+	Status int32
+	Err    error
+}

--- a/src/control/common/proto/mocks.go
+++ b/src/control/common/proto/mocks.go
@@ -1,5 +1,5 @@
 //
-// (C) Copyright 2019 Intel Corporation.
+// (C) Copyright 2019-2020 Intel Corporation.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -20,10 +20,17 @@
 // Any reproduction of computer software, computer software documentation, or
 // portions thereof marked with this legend must also reproduce the markings.
 //
+
 package proto
 
 import (
+	"context"
+
+	"google.golang.org/grpc"
+
+	"github.com/daos-stack/daos/src/control/common"
 	ctlpb "github.com/daos-stack/daos/src/control/common/proto/ctl"
+	mgmtpb "github.com/daos-stack/daos/src/control/common/proto/mgmt"
 	"github.com/daos-stack/daos/src/control/server/storage"
 )
 
@@ -111,4 +118,153 @@ func MockScmNamespace(varIdx ...int32) *ctlpb.ScmNamespace {
 // multiple packages.
 func MockScmMount() *ctlpb.ScmMount {
 	return &ctlpb.ScmMount{Mntpoint: "/mnt/daos"}
+}
+
+var MockPoolList = []*mgmtpb.ListPoolsResp_Pool{
+	{Uuid: "12345678-1234-1234-1234-123456789abc", Svcreps: []uint32{1, 2}},
+	{Uuid: "12345678-1234-1234-1234-cba987654321", Svcreps: []uint32{0}},
+}
+
+type MockMgmtSvcClientConfig struct {
+	ACLRet            *common.MockACLResult
+	ListPoolsRet      *common.MockListPoolsResult
+	KillErr           error
+	PoolQueryResult   *mgmtpb.PoolQueryResp
+	PoolQueryErr      error
+	PoolSetPropResult *mgmtpb.PoolSetPropResp
+	PoolSetPropErr    error
+}
+
+type MockMgmtSvcClient struct {
+	Cfg MockMgmtSvcClientConfig
+}
+
+func NewMockMgmtSvcClient(cfg MockMgmtSvcClientConfig) mgmtpb.MgmtSvcClient {
+	return &MockMgmtSvcClient{cfg}
+}
+
+func (m *MockMgmtSvcClient) PoolCreate(ctx context.Context, req *mgmtpb.PoolCreateReq, o ...grpc.CallOption) (*mgmtpb.PoolCreateResp, error) {
+	// return successful pool creation results
+	// initialise with zero values indicating mgmt.CTL_SUCCESS
+	return &mgmtpb.PoolCreateResp{}, nil
+}
+
+func (m *MockMgmtSvcClient) PoolDestroy(ctx context.Context, req *mgmtpb.PoolDestroyReq, o ...grpc.CallOption) (*mgmtpb.PoolDestroyResp, error) {
+	// return successful pool destroy results
+	// initialise with zero values indicating mgmt.CTL_SUCCESS
+	return &mgmtpb.PoolDestroyResp{}, nil
+}
+
+func (m *MockMgmtSvcClient) PoolQuery(ctx context.Context, req *mgmtpb.PoolQueryReq, _ ...grpc.CallOption) (*mgmtpb.PoolQueryResp, error) {
+	if m.Cfg.PoolQueryErr != nil {
+		return nil, m.Cfg.PoolQueryErr
+	}
+	return m.Cfg.PoolQueryResult, nil
+}
+
+func (m *MockMgmtSvcClient) PoolSetProp(ctx context.Context, req *mgmtpb.PoolSetPropReq, _ ...grpc.CallOption) (*mgmtpb.PoolSetPropResp, error) {
+	if m.Cfg.PoolSetPropErr != nil {
+		return nil, m.Cfg.PoolSetPropErr
+	}
+	return m.Cfg.PoolSetPropResult, nil
+}
+
+// returnACLResult returns the mock ACL results - either an error or an ACLResp
+func (m *MockMgmtSvcClient) returnACLResult() (*mgmtpb.ACLResp, error) {
+	if m.Cfg.ACLRet.Err != nil {
+		return nil, m.Cfg.ACLRet.Err
+	}
+	return &mgmtpb.ACLResp{ACL: m.Cfg.ACLRet.Acl, Status: m.Cfg.ACLRet.Status}, nil
+}
+
+func (m *MockMgmtSvcClient) PoolGetACL(ctx context.Context, req *mgmtpb.GetACLReq, o ...grpc.CallOption) (*mgmtpb.ACLResp, error) {
+	return m.returnACLResult()
+}
+
+func (m *MockMgmtSvcClient) PoolOverwriteACL(ctx context.Context, req *mgmtpb.ModifyACLReq, o ...grpc.CallOption) (*mgmtpb.ACLResp, error) {
+	return m.returnACLResult()
+}
+
+func (m *MockMgmtSvcClient) PoolUpdateACL(ctx context.Context, req *mgmtpb.ModifyACLReq, o ...grpc.CallOption) (*mgmtpb.ACLResp, error) {
+	return m.returnACLResult()
+}
+
+func (m *MockMgmtSvcClient) PoolDeleteACL(ctx context.Context, req *mgmtpb.DeleteACLReq, o ...grpc.CallOption) (*mgmtpb.ACLResp, error) {
+	return m.returnACLResult()
+}
+
+func (m *MockMgmtSvcClient) BioHealthQuery(ctx context.Context, req *mgmtpb.BioHealthReq, o ...grpc.CallOption) (*mgmtpb.BioHealthResp, error) {
+
+	// return successful bio health results
+	// initialise with zero values indicating mgmt.CTL_SUCCESS
+	return &mgmtpb.BioHealthResp{}, nil
+}
+
+func (m *MockMgmtSvcClient) SmdListDevs(ctx context.Context, req *mgmtpb.SmdDevReq, o ...grpc.CallOption) (*mgmtpb.SmdDevResp, error) {
+
+	// return successful SMD device list
+	// initialise with zero values indicating mgmt.CTL_SUCCESS
+	return &mgmtpb.SmdDevResp{}, nil
+}
+
+func (m *MockMgmtSvcClient) SmdListPools(ctx context.Context, req *mgmtpb.SmdPoolReq, o ...grpc.CallOption) (*mgmtpb.SmdPoolResp, error) {
+
+	// return successful SMD pool list
+	// initialise with zero values indicating mgmt.CTL_SUCCESS
+	return &mgmtpb.SmdPoolResp{}, nil
+}
+
+func (m *MockMgmtSvcClient) DevStateQuery(ctx context.Context, req *mgmtpb.DevStateReq, o ...grpc.CallOption) (*mgmtpb.DevStateResp, error) {
+
+	// return successful device state
+	// initialise with zero values indicating mgmt.CTRL_SUCCESS
+	return &mgmtpb.DevStateResp{}, nil
+}
+
+func (m *MockMgmtSvcClient) StorageSetFaulty(ctx context.Context, req *mgmtpb.DevStateReq, o ...grpc.CallOption) (*mgmtpb.DevStateResp, error) {
+
+	// return suscessful FAULTY device state
+	// initialise with zero values indicating mgmt.CTRL_SUCCESS
+	return &mgmtpb.DevStateResp{}, nil
+}
+
+func (m *MockMgmtSvcClient) Join(ctx context.Context, req *mgmtpb.JoinReq, o ...grpc.CallOption) (*mgmtpb.JoinResp, error) {
+
+	return &mgmtpb.JoinResp{}, nil
+}
+
+func (m *MockMgmtSvcClient) GetAttachInfo(ctx context.Context, in *mgmtpb.GetAttachInfoReq, opts ...grpc.CallOption) (*mgmtpb.GetAttachInfoResp, error) {
+	return &mgmtpb.GetAttachInfoResp{}, nil
+}
+
+func (m *MockMgmtSvcClient) PrepShutdownRanks(ctx context.Context, req *mgmtpb.RanksReq, o ...grpc.CallOption) (*mgmtpb.RanksResp, error) {
+	return &mgmtpb.RanksResp{}, nil
+}
+
+func (m *MockMgmtSvcClient) StopRanks(ctx context.Context, req *mgmtpb.RanksReq, o ...grpc.CallOption) (*mgmtpb.RanksResp, error) {
+	return &mgmtpb.RanksResp{}, nil
+}
+
+func (m *MockMgmtSvcClient) PingRanks(ctx context.Context, req *mgmtpb.RanksReq, o ...grpc.CallOption) (*mgmtpb.RanksResp, error) {
+	return &mgmtpb.RanksResp{}, nil
+}
+
+func (m *MockMgmtSvcClient) StartRanks(ctx context.Context, req *mgmtpb.RanksReq, o ...grpc.CallOption) (*mgmtpb.RanksResp, error) {
+	return &mgmtpb.RanksResp{}, nil
+}
+
+func (m *MockMgmtSvcClient) ListPools(ctx context.Context, req *mgmtpb.ListPoolsReq, o ...grpc.CallOption) (*mgmtpb.ListPoolsResp, error) {
+	if m.Cfg.ListPoolsRet.Err != nil {
+		return nil, m.Cfg.ListPoolsRet.Err
+	}
+	return &mgmtpb.ListPoolsResp{Pools: MockPoolList, Status: m.Cfg.ListPoolsRet.Status}, nil
+}
+
+func (m *MockMgmtSvcClient) LeaderQuery(ctx context.Context, req *mgmtpb.LeaderQueryReq, _ ...grpc.CallOption) (*mgmtpb.LeaderQueryResp, error) {
+	return &mgmtpb.LeaderQueryResp{}, nil
+}
+
+func (m *MockMgmtSvcClient) ListContainers(ctx context.Context, req *mgmtpb.ListContReq, o ...grpc.CallOption) (*mgmtpb.ListContResp, error) {
+	// return successful list containers results
+	return &mgmtpb.ListContResp{}, nil
 }

--- a/src/control/common/proto/types.go
+++ b/src/control/common/proto/types.go
@@ -1,5 +1,5 @@
 //
-// (C) Copyright 2019 Intel Corporation.
+// (C) Copyright 2019-2020 Intel Corporation.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -20,6 +20,7 @@
 // Any reproduction of computer software, computer software documentation, or
 // portions thereof marked with this legend must also reproduce the markings.
 //
+
 package proto
 
 import (
@@ -33,6 +34,7 @@ import (
 	"github.com/daos-stack/daos/src/control/common"
 	"github.com/daos-stack/daos/src/control/common/proto/convert"
 	ctlpb "github.com/daos-stack/daos/src/control/common/proto/ctl"
+	mgmtpb "github.com/daos-stack/daos/src/control/common/proto/mgmt"
 	"github.com/daos-stack/daos/src/control/server/storage"
 )
 
@@ -325,3 +327,35 @@ func (smr ScmMountResults) HasErrors() bool {
 // ScmModuleResults is an alias for protobuf ScmModuleResult message slice
 // representing operation results on a number of SCM modules.
 type ScmModuleResults []*ctlpb.ScmModuleResult
+
+// AccessControlListFromPB converts from the protobuf ACLResp structure to an
+// AccessControlList structure.
+func AccessControlListFromPB(pbACL *mgmtpb.ACLResp) *common.AccessControlList {
+	if pbACL == nil {
+		return &common.AccessControlList{}
+	}
+	return &common.AccessControlList{
+		Entries:    pbACL.ACL,
+		Owner:      pbACL.OwnerUser,
+		OwnerGroup: pbACL.OwnerGroup,
+	}
+}
+
+// PoolDiscoveriesFromPB converts the protobuf ListPoolsResp_Pool structures to
+// PoolDiscovery structures.
+func PoolDiscoveriesFromPB(pbPools []*mgmtpb.ListPoolsResp_Pool) []*common.PoolDiscovery {
+	pools := make([]*common.PoolDiscovery, 0, len(pbPools))
+	for _, pbPool := range pbPools {
+		svcReps := make([]uint32, 0, len(pbPool.Svcreps))
+		for _, rep := range pbPool.Svcreps {
+			svcReps = append(svcReps, rep)
+		}
+
+		pools = append(pools, &common.PoolDiscovery{
+			UUID:        pbPool.Uuid,
+			SvcReplicas: svcReps,
+		})
+	}
+
+	return pools
+}

--- a/src/control/common/proto/types_test.go
+++ b/src/control/common/proto/types_test.go
@@ -20,6 +20,7 @@
 // Any reproduction of computer software, computer software documentation, or
 // portions thereof marked with this legend must also reproduce the markings.
 //
+
 package proto
 
 import (

--- a/src/control/common/types.go
+++ b/src/control/common/types.go
@@ -1,0 +1,79 @@
+//
+// (C) Copyright 2020 Intel Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// GOVERNMENT LICENSE RIGHTS-OPEN SOURCE SOFTWARE
+// The Government's rights to use, modify, reproduce, release, perform, display,
+// or disclose this software are subject to the terms of the Apache License as
+// provided in Contract No. 8F-30005.
+// Any reproduction of computer software, computer software documentation, or
+// portions thereof marked with this legend must also reproduce the markings.
+//
+
+package common
+
+import "fmt"
+
+// AccessControlList is a structure for the access control list.
+type AccessControlList struct {
+	Entries    []string // Access Control Entries in short string format
+	Owner      string   // User that owns the resource
+	OwnerGroup string   // Group that owns the resource
+}
+
+// Empty checks whether there are any entries in the AccessControlList
+func (acl *AccessControlList) Empty() bool {
+	if acl == nil || len(acl.Entries) == 0 {
+		return true
+	}
+	return false
+}
+
+// HasOwner checks whether the AccessControlList has an owner user.
+func (acl *AccessControlList) HasOwner() bool {
+	if acl == nil {
+		return false
+	}
+
+	if acl.Owner != "" {
+		return true
+	}
+	return false
+}
+
+// HasOwnerGroup checks whether the AccessControlList has an owner group.
+func (acl *AccessControlList) HasOwnerGroup() bool {
+	if acl == nil {
+		return false
+	}
+
+	if acl.OwnerGroup != "" {
+		return true
+	}
+	return false
+}
+
+// String displays the AccessControlList in a basic string format.
+func (acl *AccessControlList) String() string {
+	if acl == nil {
+		return "nil"
+	}
+	return fmt.Sprintf("%+v", *acl)
+}
+
+// PoolDiscovery represents the basic discovery information for a pool.
+type PoolDiscovery struct {
+	UUID        string   // Unique identifier
+	SvcReplicas []uint32 // Ranks of pool service replicas
+}

--- a/src/control/server/harness_test.go
+++ b/src/control/server/harness_test.go
@@ -38,8 +38,11 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/pkg/errors"
+	"google.golang.org/grpc"
 
 	"github.com/daos-stack/daos/src/control/common"
+	"github.com/daos-stack/daos/src/control/common/proto"
+	mgmtpb "github.com/daos-stack/daos/src/control/common/proto/mgmt"
 	"github.com/daos-stack/daos/src/control/drpc"
 	"github.com/daos-stack/daos/src/control/logging"
 	"github.com/daos-stack/daos/src/control/server/ioserver"
@@ -307,6 +310,14 @@ func TestServer_HarnessIOServerStart(t *testing.T) {
 					AccessPoints: []string{"localhost"},
 				}
 				msClient := newMgmtSvcClient(context.TODO(), log, msClientCfg)
+				mockMSClient := proto.NewMockMgmtSvcClient(
+					proto.MockMgmtSvcClientConfig{})
+
+				clientFn := func(*grpc.ClientConn) mgmtpb.MgmtSvcClient {
+					return mockMSClient
+				}
+				msClient.clientFn = clientFn
+
 				srv := NewIOServerInstance(log, bdevProvider, scmProvider, msClient, runner)
 				if err := harness.AddInstance(srv); err != nil {
 					t.Fatal(err)

--- a/src/control/server/mgmt_client.go
+++ b/src/control/server/mgmt_client.go
@@ -47,8 +47,9 @@ type (
 		TransportConfig *security.TransportConfig
 	}
 	mgmtSvcClient struct {
-		log logging.Logger
-		cfg mgmtSvcClientCfg
+		log      logging.Logger
+		cfg      mgmtSvcClientCfg
+		clientFn func(*grpc.ClientConn) mgmtpb.MgmtSvcClient
 	}
 )
 
@@ -56,6 +57,8 @@ func newMgmtSvcClient(ctx context.Context, log logging.Logger, cfg mgmtSvcClient
 	return &mgmtSvcClient{
 		log: log,
 		cfg: cfg,
+		// can be mocked with function that returns mgmtpb.MgmtSvcClient
+		clientFn: mgmtpb.NewMgmtSvcClient,
 	}
 }
 
@@ -84,7 +87,7 @@ func (msc *mgmtSvcClient) withConnection(ctx context.Context, ap string,
 	}
 	defer conn.Close()
 
-	return fn(ctx, mgmtpb.NewMgmtSvcClient(conn))
+	return fn(ctx, msc.clientFn(conn))
 }
 
 func (msc *mgmtSvcClient) withConnectionRetry(ctx context.Context, ap string,


### PR DESCRIPTION
Move MockMgmtSvcClient to common/mocks.go to reuse in server
and client packages, enabling greater test coverage.

Signed-off-by: Tom Nabarro <tom.nabarro@intel.com>