### PR TITLE
DAOS-4271 rebuild: Fix two ds_pool_child leaks (#2031)

### DIFF
--- a/src/rebuild/srv.c
+++ b/src/rebuild/srv.c
@@ -1553,6 +1553,8 @@ rebuild_fini_one(void *arg)
 			rpt->rt_rebuild_fence, dpc->spc_rebuild_fence);
 	}
 
+	ds_pool_child_put(dpc);
+
 	return 0;
 }
 
@@ -1803,6 +1805,9 @@ rebuild_prepare_one(void *data)
 	D_DEBUG(DB_REBUILD, "open local container "DF_UUID"/"DF_UUID
 		" rebuild eph "DF_U64" rc %d\n", DP_UUID(rpt->rt_pool_uuid),
 		DP_UUID(rpt->rt_coh_uuid), rpt->rt_rebuild_fence, rc);
+
+	ds_pool_child_put(dpc);
+
 	return rc;
 }
 


### PR DESCRIPTION
The extra reference to ds_pool_child in the rebuild code was causing an error
when trying to destroy SPDK blobs on NVMe SSDs (since they were remaining open).
This issue was first discovered while manually running the daos_nvme_recovery
tests (daos_test -N), but could also be reproduced by a simple rebuild test.

Signed-off-by: Sydney Vanda <sydney.m.vanda@intel.com>