### PR TITLE
CORCI-90[56] sdl: Disable bandit; limit files

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -270,7 +270,8 @@ pipeline {
                     when {
                       beforeAgent true
                       expression {
-                        ! commitPragma(pragma: 'Skip-python-bandit').contains('true')
+                        ! commitPragma(pragma: 'Skip-python-bandit',
+                                def_val: 'true').contains('true')
                       }
                     }
                     agent {
@@ -289,7 +290,8 @@ pipeline {
                                       status: "PENDING"
                         checkoutScm withSubmodules: true
                         catchError(stageResult: 'UNSTABLE', buildResult: 'SUCCESS') {
-                            runTest script: 'bandit -r . --format xml -o bandit.xml',
+                            runTest script: '''bandit --format xml -o bandit.xml \
+                                                      -r $(git ls-tree --name-only HEAD)''',
                                     junit_files: "bandit.xml",
                                     ignore_failure: true
                         }


### PR DESCRIPTION
Disable bandit checking by default, until the issues it is flagging are
fixed or accepted and ignored.
- can be run as needed with a "Skip-python-bandit: true" commit pragma

Limit the list of files to scan to only that which is in the git repo.

Signed-off-by: Brian J. Murrell <brian.murrell@intel.com>