### PR TITLE
DAOS-3890 target: check the sp_map (#1836)

### DIFF
--- a/src/pool/srv_target.c
+++ b/src/pool/srv_target.c
@@ -916,77 +916,72 @@ ds_pool_tgt_map_update(struct ds_pool *pool, struct pool_buf *buf,
 {
 	struct pool_map *map = NULL;
 	int		rc = 0;
-	bool		null_maps;
 
 	if (buf != NULL) {
 		rc = pool_map_create(buf, map_version, &map);
 		if (rc != 0) {
 			D_ERROR(DF_UUID" failed to create pool map: "DF_RC"\n",
 				DP_UUID(pool->sp_uuid), DP_RC(rc));
-			D_GOTO(out, rc);
+			return rc;
 		}
 	}
-
-	null_maps = (map == NULL || pool->sp_map == NULL);
 
 	ABT_rwlock_wrlock(pool->sp_lock);
-	if (pool->sp_map_version < map_version ||
-	   ((!null_maps) && (pool->sp_map_version == map_version ||
-	    pool_map_get_version(pool->sp_map) < map_version))) {
-		if (map != NULL) {
-			struct pool_map *tmp = pool->sp_map;
+	/* Check if the pool map needs to to update */
+	if (map != NULL &&
+	    (pool->sp_map == NULL ||
+	     pool_map_get_version(pool->sp_map) < map_version)) {
+		struct pool_map *tmp = pool->sp_map;
 
-			rc = update_pool_group(pool, map);
-			if (rc != 0) {
-				ABT_rwlock_unlock(pool->sp_lock);
-				goto out;
-			}
+		D_DEBUG(DB_MD, DF_UUID
+			": update pool_map version: %p/%d -> %p/%d\n",
+			DP_UUID(pool->sp_uuid), pool->sp_map,
+			pool->sp_map ? pool_map_get_version(pool->sp_map) : -1,
+			map, pool_map_get_version(map));
 
-			rc = pl_map_update(pool->sp_uuid, map,
-					   pool->sp_map != NULL ? false : true,
-					   DEFAULT_PL_TYPE);
-			if (rc != 0) {
-				ABT_rwlock_unlock(pool->sp_lock);
-				D_ERROR(DF_UUID": failed update pl_map: "
-					""DF_RC"\n", DP_UUID(pool->sp_uuid),
-					DP_RC(rc));
-				D_GOTO(out, rc);
-			}
-
-			rc = pool_map_update_failed_cnt(map);
-			if (rc != 0) {
-				ABT_rwlock_unlock(pool->sp_lock);
-				D_ERROR(DF_UUID": failed fail-cnt update pl_map"
-					": %d\n", DP_UUID(pool->sp_uuid), rc);
-				D_GOTO(out, rc);
-			}
-
-			/* drop the stale map */
-			pool->sp_map = map;
-			map = tmp;
+		rc = update_pool_group(pool, map);
+		if (rc != 0) {
+			D_ERROR(DF_UUID": Can not update pool group: "DF_RC"\n",
+				DP_UUID(pool->sp_uuid), DP_RC(rc));
+			D_GOTO(out, rc);
 		}
 
-		if (pool->sp_map_version < map_version ||
-		   (pool->sp_map_version == map_version && !null_maps)) {
-			D_DEBUG(DF_DSMS, DF_UUID
-				": changed cached map version: %u -> %u pool %p"
-				" map %p map_ver %u\n", DP_UUID(pool->sp_uuid),
-				pool->sp_map_version, map_version,
-				pool, pool->sp_map,
-				pool_map_get_version(pool->sp_map));
-
-			pool->sp_map_version = map_version;
-			rc = dss_task_collective(update_child_map, pool, 0,
-						 DSS_ULT_IO);
-			D_ASSERT(rc == 0);
+		rc = pl_map_update(pool->sp_uuid, map,
+				   pool->sp_map != NULL ? false : true,
+				   DEFAULT_PL_TYPE);
+		if (rc != 0) {
+			D_ERROR(DF_UUID": failed update pl_map: "
+				""DF_RC"\n", DP_UUID(pool->sp_uuid), DP_RC(rc));
+			D_GOTO(out, rc);
 		}
-	} else {
-		D_WARN("Ignore old map version: cur=%u, input=%u pool %p\n",
-		       pool->sp_map_version, map_version, pool);
+
+		rc = pool_map_update_failed_cnt(map);
+		if (rc != 0) {
+			D_ERROR(DF_UUID": failed fail-cnt update pl_map"
+				": %d\n", DP_UUID(pool->sp_uuid), rc);
+			D_GOTO(out, rc);
+		}
+
+		/* drop the stale map */
+		pool->sp_map = map;
+		map = tmp;
 	}
-	ABT_rwlock_unlock(pool->sp_lock);
+
+	/* Check if the pool map on each xstream needs to update */
+	if (pool->sp_map_version < map_version) {
+		D_DEBUG(DB_MD, DF_UUID
+			": changed cached map version: %u -> %u\n",
+			DP_UUID(pool->sp_uuid), pool->sp_map_version,
+			map_version);
+
+		pool->sp_map_version = map_version;
+		rc = dss_task_collective(update_child_map, pool, 0,
+					 DSS_ULT_IO);
+		D_ASSERT(rc == 0);
+	}
 
 out:
+	ABT_rwlock_unlock(pool->sp_lock);
 	if (map != NULL)
 		pool_map_decref(map);
 	return rc;


### PR DESCRIPTION
Cherry pick of PR #1836 from daos master to release/0.9 branch.
From that PR, including the improvement to ds_pool_tgt_map_update()
test to determine when to update the pool group. This is shown to
be important to scenarios like DAOS-4136 in which a pool connect
occurs immediately following pool create and before the initial
pool map distribution from the create has finished.

Check sp_map inside ds_tgt_pool_map_update().

sp_map_version and child map version are only used to
check the stale pool map during I/O.

sp_map is used to hold pool map on each server.

Signed-off-by: Di Wang <di.wang@intel.com>
Signed-off-by: Kenneth Cain <kenneth.c.cain@intel.com>