### PR TITLE
CART-881 swim: delay the first ping until all will be initialized

### DIFF
--- a/src/cart/src/crt_launch/crt_launch.c
+++ b/src/cart/src/crt_launch/crt_launch.c
@@ -154,7 +154,7 @@ get_self_uri(struct host *h)
 	int		len;
 	int		rc;
 
-	rc = crt_init(0, CRT_FLAG_BIT_SERVER);
+	rc = crt_init(0, CRT_FLAG_BIT_SERVER | CRT_FLAG_BIT_AUTO_SWIM_DISABLE);
 	if (rc != 0) {
 		D_ERROR("crt_init() failed; rc=%d\n", rc);
 		D_GOTO(out, rc);

--- a/src/cart/src/swim/swim.c
+++ b/src/cart/src/swim/swim.c
@@ -516,6 +516,10 @@ swim_init(swim_id_t self_id, struct swim_ops *swim_ops, void *data)
 	ctx->sc_piggyback_tx_max = SWIM_PIGGYBACK_TX_COUNT;
 	/* force to choose next target first */
 	ctx->sc_target = SWIM_ID_INVALID;
+
+	/* delay the first ping until all things will be initialized */
+	ctx->sc_next_tick_time = swim_now_ms() + 10 * SWIM_PROTOCOL_PERIOD_LEN;
+
 out:
 	return ctx;
 }


### PR DESCRIPTION
- delay the first ping until all things will be initialized
- check about SWIM inited from few public API
- disable SWIM in crt_launch