### PR TITLE
DAOS-4139 SDL: Fixes for Simple DAOS Issues Marked by Coverity (#1865)

### DIFF
--- a/src/client/dfuse/ops/getxattr.c
+++ b/src/client/dfuse/ops/getxattr.c
@@ -29,7 +29,7 @@ dfuse_cb_getxattr(fuse_req_t req, struct dfuse_inode_entry *inode,
 		  const char *name, size_t size)
 {
 	size_t out_size = 0;
-	char *value;
+	char *value = NULL;
 	int rc;
 
 	DFUSE_TRA_DEBUG(inode, "Attribute '%s'", name);
@@ -60,5 +60,6 @@ dfuse_cb_getxattr(fuse_req_t req, struct dfuse_inode_entry *inode,
 	D_FREE(value);
 	return;
 err:
+	D_FREE(value);
 	DFUSE_REPLY_ERR_RAW(inode, req, rc);
 }

--- a/src/common/tests/btree.c
+++ b/src/common/tests/btree.c
@@ -758,6 +758,7 @@ ik_btr_batch_oper(void **state)
 		}
 	}
 	ik_btr_query(NULL);
+	D_FREE(arr);
 }
 
 static void
@@ -872,6 +873,8 @@ ik_btr_drain(void **state)
 		if (empty)
 			break;
 	}
+
+	D_FREE(arr);
 }
 
 static int

--- a/src/common/tests/btree_direct.c
+++ b/src/common/tests/btree_direct.c
@@ -959,6 +959,7 @@ sk_btr_batch_oper(void **state)
 		}
 	}
 	sk_btr_query(NULL);
+	D_FREE(kv);
 }
 
 static void

--- a/src/common/tests/checksum_timing.c
+++ b/src/common/tests/checksum_timing.c
@@ -110,8 +110,10 @@ run_timings(struct csum_ft *fts[], const int types_count,
 			uint8_t			*csum_buf;
 
 			rc = daos_csummer_init(&csummer, ft, 0);
-			if (rc != 0)
+			if (rc != 0) {
+				free(buf);
 				return rc;
+			}
 
 			args.csummer = csummer;
 			args.buf = buf;

--- a/src/iosrv/module.c
+++ b/src/iosrv/module.c
@@ -132,14 +132,14 @@ dss_module_load(const char *modname, uint64_t *mod_facs)
 	if (strcmp(smod->sm_name, modname) != 0) {
 		D_ERROR("inconsistent module name %s != %s\n", modname,
 			smod->sm_name);
-		D_GOTO(err_hdl, rc = -DER_INVAL);
+		D_GOTO(err_lmod, rc = -DER_INVAL);
 	}
 
 	/* initialize the module */
 	rc = smod->sm_init();
 	if (rc) {
 		D_ERROR("failed to init %s: "DF_RC"\n", modname, DP_RC(rc));
-		D_GOTO(err_hdl, rc = -DER_INVAL);
+		D_GOTO(err_lmod, rc = -DER_INVAL);
 	}
 
 	if (smod->sm_key != NULL)

--- a/src/placement/ring_map.c
+++ b/src/placement/ring_map.c
@@ -410,7 +410,7 @@ ring_buf_shuffle(struct pl_ring_map *rimap, unsigned int seed,
 			&ring_domain_ver_sops);
 
 	ver = buf->rb_domains[0].rd_comp->co_ver;
-	merged = &scratch[buf->rb_domain_nr];
+	merged = scratch + buf->rb_domain_nr;
 
 	for (i = start = 0; i < buf->rb_domain_nr; i++) {
 		struct pool_component	 *comp;

--- a/src/tests/suite/daos_test_common.c
+++ b/src/tests/suite/daos_test_common.c
@@ -58,7 +58,7 @@ test_setup_pool_create(void **state, struct test_pool *ipool,
 {
 	test_arg_t		*arg = *state;
 	struct test_pool	*outpool;
-	int			 rc;
+	int			 rc = 0;
 
 	outpool = opool ? opool : &arg->pool;
 
@@ -198,7 +198,7 @@ static int
 test_setup_cont_create(void **state, daos_prop_t *co_prop)
 {
 	test_arg_t *arg = *state;
-	int rc;
+	int rc = 0;
 
 	if (arg->myrank == 0) {
 		uuid_generate(arg->co_uuid);
@@ -225,7 +225,7 @@ static int
 test_setup_cont_open(void **state)
 {
 	test_arg_t *arg = *state;
-	int rc;
+	int rc = 0;
 
 	if (arg->myrank == 0) {
 		print_message("setup: opening container\n");

--- a/src/vea/tests/vea_ut.c
+++ b/src/vea/tests/vea_ut.c
@@ -686,7 +686,7 @@ ut_inval_params_load(void **state)
 	uint32_t block_size = 0; /* use the default size */
 	uint32_t header_blocks = 1;
 	uint64_t capacity = ((VEA_LARGE_EXT_MB * 2) << 20); /* 128 MB */
-	struct vea_unmap_context unmap_ctxt;
+	struct vea_unmap_context unmap_ctxt = {0};
 	int rc;
 
 	ut_setup(&args);

--- a/src/vea/vea_api.c
+++ b/src/vea/vea_api.c
@@ -380,7 +380,7 @@ process_resrvd_list(struct vea_space_info *vsi, struct vea_hint_context *hint,
 		    d_list_t *resrvd_list, bool publish)
 {
 	struct vea_resrvd_ext	*resrvd, *tmp;
-	struct vea_free_extent	 vfe;
+	struct vea_free_extent vfe = {0};
 	uint64_t		 seq_max = 0, seq_min = 0;
 	uint64_t		 off_c = 0, off_p = 0;
 	uint64_t		 cur_time;

--- a/src/vos/tests/evt_ctl.c
+++ b/src/vos/tests/evt_ctl.c
@@ -1775,7 +1775,7 @@ test_evt_overlap_split_internal(void **state)
 		goto finish1;
 	D_ALLOC_ARRAY(actual_data, NUM_EPOCHS * record_size);
 	if (actual_data == NULL)
-		goto finish2;
+		goto finish1;
 
 	for (epoch = 1; epoch < NUM_EPOCHS; epoch++) {
 	/* Write a big extent at epoch 1.
@@ -1913,7 +1913,6 @@ finish:
 	D_FREE(actual_data);
 finish1:
 	D_FREE(data);
-finish2:
 	D_FREE(expected_data);
 	rc = evt_destroy(toh);
 	assert_int_equal(rc, 0);

--- a/src/vos/tests/vts_gc.c
+++ b/src/vos/tests/vts_gc.c
@@ -262,7 +262,7 @@ gc_obj_run(struct gc_test_args *args)
 
 	rc = gc_obj_prepare(args, args->gc_ctx.tsc_coh, oids);
 	if (rc)
-		return rc;
+		goto out;
 
 	gc_print_stat();
 
@@ -276,6 +276,8 @@ gc_obj_run(struct gc_test_args *args)
 	}
 
 	rc = gc_wait_check(args, false);
+out:
+	D_FREE(oids);
 	return rc;
 }
 


### PR DESCRIPTION
Second patch containing various simple fixes for issues marked as high priority in the Coverity scans that were too small to warrant their own ticket.

Signed-off-by: Peter Fetros <peter.fetros@intel.com>