### PR TITLE
DAOS-4214 test: weekly test error in obj_update_bad_param.py (#2255)

### DIFF
--- a/src/object/cli_obj.c
+++ b/src/object/cli_obj.c
@@ -1427,7 +1427,7 @@ obj_iod_sgl_valid(unsigned int nr, daos_iod_t *iods, d_sg_list_t *sgls,
 	for (i = 0; i < nr; i++) {
 		if (iods[i].iod_name.iov_buf == NULL)
 			/* XXX checksum & eprs should not be mandatory */
-			return false;
+			return -DER_INVAL;
 
 		switch (iods[i].iod_type) {
 		default:


### PR DESCRIPTION
  - Cherry picked from master to release/0.9
  - Changed the client code to return -DER_INVAL when akey is NULL
    in iod as opposed to return false.
  - Improved the test code to have container creation in setUp and
    destroy in tearDown.

Signed-off-by: Logan Sundaram <logan.sundaram@intel.com>