### PR TITLE
DAOS-4512 rebuild: do not retry for rebuild IV

### DIFF
--- a/src/iosrv/server_iv.c
+++ b/src/iosrv/server_iv.c
@@ -868,7 +868,7 @@ iv_op_internal(struct ds_iv_ns *ns, struct ds_iv_key *key_iv,
 	key_iv->rank = ns->iv_master_rank;
 	class = iv_class_lookup(key_iv->class_id);
 	D_ASSERT(class != NULL);
-	D_DEBUG(DB_TRACE, "class_id %d crt class id %d opc %d\n",
+	D_DEBUG(DB_MD, "class_id %d crt class id %d opc %d\n",
 		key_iv->class_id, class->iv_cart_class_id, opc);
 
 	iv_key_pack(&key_iov, key_iv);
@@ -904,8 +904,7 @@ iv_op_internal(struct ds_iv_ns *ns, struct ds_iv_key *key_iv,
 
 	ABT_future_wait(future);
 	rc = cb_info.result;
-	D_DEBUG(DB_TRACE, "class_id %d opc %d rc %d\n", key_iv->class_id, opc,
-		rc);
+	D_DEBUG(DB_MD, "class_id %d opc %d rc %d\n", key_iv->class_id, opc, rc);
 out:
 	ABT_future_free(&future);
 	return rc;
@@ -924,7 +923,8 @@ retry:
 		 * in the mean time, it will rely on others to update the
 		 * ns for it.
 		 */
-		D_WARN("retry upon %d\n", rc);
+		D_WARN("retry upon %d for class %d opc %d\n", rc,
+		       key->class_id, opc);
 		goto retry;
 	}
 	return rc;

--- a/src/pool/srv_iv.c
+++ b/src/pool/srv_iv.c
@@ -563,7 +563,7 @@ ds_pool_iv_map_update(struct ds_pool *pool, struct pool_buf *buf,
 	uint32_t		 size;
 	int			 rc;
 
-	D_DEBUG(DB_TRACE, DF_UUID": map_ver=%u\n", DP_UUID(pool->sp_uuid),
+	D_DEBUG(DB_MD, DF_UUID": map_ver=%u\n", DP_UUID(pool->sp_uuid),
 		map_ver);
 
 	size = pool_iv_map_ent_size(buf->pb_nr);
@@ -583,7 +583,7 @@ ds_pool_iv_map_update(struct ds_pool *pool, struct pool_buf *buf,
 	rc = pool_iv_update(pool->sp_iv_ns, IV_POOL_MAP, iv_entry, size,
 			    CRT_IV_SHORTCUT_NONE, CRT_IV_SYNC_EAGER, false);
 	if (rc != 0)
-		D_DEBUG(DB_TRACE, DF_UUID": map_ver=%u: %d\n",
+		D_DEBUG(DB_MD, DF_UUID": map_ver=%u: %d\n",
 			DP_UUID(pool->sp_uuid), map_ver, rc);
 
 	D_FREE(iv_entry);
@@ -691,7 +691,7 @@ ds_pool_iv_prop_update(struct ds_pool *pool, daos_prop_t *prop)
 	pool_iv_prop_l2g(prop, &iv_entry->piv_prop);
 
 	rc = pool_iv_update(pool->sp_iv_ns, IV_POOL_PROP, iv_entry, size,
-			    CRT_IV_SHORTCUT_NONE, CRT_IV_SYNC_EAGER, true);
+			    CRT_IV_SHORTCUT_NONE, CRT_IV_SYNC_EAGER, false);
 	if (rc)
 		D_ERROR("pool_iv_update failed "DF_RC"\n", DP_RC(rc));
 	D_FREE(iv_entry);

--- a/src/rebuild/rebuild_iv.c
+++ b/src/rebuild/rebuild_iv.c
@@ -320,7 +320,7 @@ rebuild_iv_update(void *ns, struct rebuild_iv *iv,
 	memset(&key, 0, sizeof(key));
 	key.class_id = IV_REBUILD;
 	rc = ds_iv_update(ns, &key, &sgl, shortcut, sync_mode, 0,
-			  true /* retry */);
+			  false /* retry */);
 	if (rc)
 		D_ERROR("iv update failed "DF_RC"\n", DP_RC(rc));
 

--- a/src/rebuild/srv.c
+++ b/src/rebuild/srv.c
@@ -1111,6 +1111,7 @@ re_dist:
 		} else {
 			D_ERROR("pool map broadcast failed: rc "DF_RC"\n",
 				DP_RC(rc));
+			D_GOTO(out, rc);
 		}
 	}
 

--- a/src/tests/ftest/daos_test/daos_core_test-rebuild.py
+++ b/src/tests/ftest/daos_test/daos_core_test-rebuild.py
@@ -43,6 +43,4 @@ class DaosCoreTestRebuild(DaosCoreBase):
 
         :avocado: tags=all,pr,hw,medium,ib2,unittest,daos_test_rebuild
         """
-        if self.subtest_name == "rebuild_tests_27":
-            self.cancelForTicket("DAOS-4512")
         DaosCoreBase.run_subtest(self)


### PR DESCRIPTION
Let's not retry for rebuild IV and pool prop IV
propagate for the moment. Because once retry,
it may cause rebuild in endless loop, unless
the pool map is properly updated, which should
be explicitly by the caller. I will do that
in another patch.

Signed-off-by: Di Wang <di.wang@intel.com>