### PR TITLE
DAOS-4523 control: only start MS node ranks once

### DIFF
--- a/src/control/server/ctl_system.go
+++ b/src/control/server/ctl_system.go
@@ -434,11 +434,12 @@ func (svc *ControlService) start(ctx context.Context, rankList []system.Rank) (s
 		results = append(results, hResults...)
 	}
 
-	// in the case of start, don't manually update member states, members
-	// are updated as they join or bootstrap, only update state on errors
+	// in the case of start, don't manually update member state to "started",
+	// only to "ready". Member state will transition to "sarted" during
+	// join or bootstrap
 	filteredResults := make(system.MemberResults, 0, len(results))
 	for _, r := range results {
-		if r.Errored {
+		if r.Errored || r.State == system.MemberStateReady {
 			filteredResults = append(filteredResults, r)
 		}
 	}

--- a/src/control/server/ctl_system.go
+++ b/src/control/server/ctl_system.go
@@ -339,15 +339,14 @@ func (svc *ControlService) SystemStop(parent context.Context, req *ctlpb.SystemS
 // If all are present return true, else false.
 func (svc *ControlService) allRanksOnHostInList(addr string, rankList []system.Rank) ([]system.Rank, bool) {
 	var rank system.Rank
-	var ok bool
 	addrRanks := svc.membership.HostRanks()[addr]
 
+	ok := true
 	for _, rank = range addrRanks {
-		if rank.InList(rankList) {
-			ok = true
-			continue
+		if !rank.InList(rankList) {
+			ok = false
+			break
 		}
-		ok = false
 	}
 	if !ok {
 		svc.log.Debugf("skip host %s: rank %d not in rank list %v",
@@ -397,7 +396,7 @@ func (svc *ControlService) start(ctx context.Context, rankList []system.Rank) (s
 	for addr, ranks := range hostRanks {
 		// All ranks configured at addr will be started, therefore if
 		// any of the harness ranks are not in rankList then don't start
-		// harness and indicate why.
+		// harness.
 		//
 		// TODO: when DAOS-4456 lands and ranks can be started, remove
 		//       below mitigation/code block

--- a/src/control/server/harness.go
+++ b/src/control/server/harness.go
@@ -38,30 +38,35 @@ import (
 	"github.com/daos-stack/daos/src/control/system"
 )
 
-const defaultRequestTimeout = 3 * time.Second
+const (
+	defaultRequestTimeout = 3 * time.Second
+	defaultStartTimeout   = 10 * defaultRequestTimeout
+)
 
 // IOServerHarness is responsible for managing IOServer instances.
 type IOServerHarness struct {
 	sync.RWMutex
-	log            logging.Logger
-	instances      []*IOServerInstance
-	started        atm.Bool
-	startable      atm.Bool
-	restart        chan struct{}
-	errChan        chan ioserver.InstanceError
-	rankReqTimeout time.Duration
+	log              logging.Logger
+	instances        []*IOServerInstance
+	started          atm.Bool
+	startable        atm.Bool
+	restart          chan struct{}
+	errChan          chan ioserver.InstanceError
+	rankReqTimeout   time.Duration
+	rankStartTimeout time.Duration
 }
 
 // NewIOServerHarness returns an initialized *IOServerHarness.
 func NewIOServerHarness(log logging.Logger) *IOServerHarness {
 	return &IOServerHarness{
-		log:            log,
-		instances:      make([]*IOServerInstance, 0, maxIOServers),
-		started:        atm.NewBool(false),
-		startable:      atm.NewBool(false),
-		restart:        make(chan struct{}, 1),
-		errChan:        make(chan ioserver.InstanceError, maxIOServers),
-		rankReqTimeout: defaultRequestTimeout,
+		log:              log,
+		instances:        make([]*IOServerInstance, 0, maxIOServers),
+		started:          atm.NewBool(false),
+		startable:        atm.NewBool(false),
+		restart:          make(chan struct{}, 1),
+		errChan:          make(chan ioserver.InstanceError, maxIOServers),
+		rankReqTimeout:   defaultRequestTimeout,
+		rankStartTimeout: defaultStartTimeout,
 	}
 }
 

--- a/src/control/server/mgmt_system.go
+++ b/src/control/server/mgmt_system.go
@@ -392,7 +392,7 @@ func (svc *mgmtSvc) StartRanks(ctx context.Context, req *mgmtpb.RanksReq) (*mgmt
 	// select until instances start or timeout occurs (at which point get results of each instance)
 	go func() {
 		for {
-			if len(svc.harness.StartedRanks()) != len(svc.harness.instances) {
+			if len(svc.harness.ReadyRanks()) != len(svc.harness.instances) {
 				time.Sleep(instanceUpdateDelay)
 				continue
 			}
@@ -403,7 +403,7 @@ func (svc *mgmtSvc) StartRanks(ctx context.Context, req *mgmtpb.RanksReq) (*mgmt
 
 	select {
 	case <-started:
-	case <-time.After(svc.harness.rankReqTimeout):
+	case <-time.After(svc.harness.rankStartTimeout):
 	}
 
 	results, err := svc.getStartedResults(system.RanksFromUint32(req.GetRanks()),

--- a/src/control/system/member.go
+++ b/src/control/system/member.go
@@ -41,6 +41,8 @@ type MemberState int
 const (
 	// MemberStateUnknown is the default invalid state.
 	MemberStateUnknown MemberState = iota
+	// MemberStateReady indicates the member has setup successfully.
+	MemberStateReady
 	// MemberStateStarted indicates the member has joined the system.
 	MemberStateStarted
 	// MemberStateStopping indicates prep-shutdown successfully run.
@@ -58,6 +60,7 @@ const (
 func (ms MemberState) String() string {
 	return [...]string{
 		"Unknown",
+		"Ready",
 		"Started",
 		"Stopping",
 		"Stopped",


### PR DESCRIPTION
Starting one rank on a harness will implicitly start any other ranks
configured on the same harness. Only one start request should be sent
to each harness until ranks can be started independently.

Signed-off-by: Tom Nabarro <tom.nabarro@intel.com>