### PR TITLE
DAOS-4512 test: Skipping rebuild test 27

### DIFF
--- a/src/tests/ftest/daos_test/daos_core_test-rebuild.py
+++ b/src/tests/ftest/daos_test/daos_core_test-rebuild.py
@@ -43,4 +43,6 @@ class DaosCoreTestRebuild(DaosCoreBase):
 
         :avocado: tags=all,pr,hw,medium,ib2,unittest,daos_test_rebuild
         """
+        if self.subtest_name == "rebuild_tests_27":
+            self.cancelForTicket("DAOS-4512")
         DaosCoreBase.run_subtest(self)


### PR DESCRIPTION
Skip rebuild test 27 until there is a fix
for DAOS-4512. This should be re-enabled with the fix.

Signed-off-by: Saurabh Tandan <saurabh.tandan@intel.com>