### PR TITLE
DAOS-3388 build: Add scripts to assist with checks

### DIFF
--- a/utils/check/README.md
+++ b/utils/check/README.md
@@ -12,11 +12,11 @@ The three scripts in this section can be used to make a list of packages
 that the libraries installed by DAOS depend on, and then check the if
 RedHat has any CVEs listed for them.
 
-To use these scripts the following should be setup.
+To use these scripts the following should be set up.
 
-1. A test system with CentOS 7 installed with sudo.
+1. A test system with CentOS 7 installed including the `sudo` command.
 1. These three scripts need to be copied to that system.
-1. Recommend that you setup a working directory, as these scripts
+1. Recommend that you set up a working directory, as these scripts
    will put files and directories in it as they run.
 
 ### download_rpms.sh

--- a/utils/check/README.md
+++ b/utils/check/README.md
@@ -1,0 +1,51 @@
+# Check Utilities
+
+This directory has utilities to aid in doing some checks on the code
+in or produced by this package.
+
+The scripts in this directory may need to be modified to fit your build
+environment.
+
+## Scanning for CVEs for packages that DAOS depends on
+
+The three scripts in this section can be used to make a list of packages
+that the libraries installed by DAOS depend on, and then check the if
+RedHat has any CVEs listed for them.
+
+To use these scripts the following should be setup.
+
+1. A test system with CentOS 7 installed with sudo.
+1. These three scripts need to be copied to that system.
+1. Recommend that you setup a working directory, as these scripts
+   will put files and directories in it as they run.
+
+### download_rpms.sh
+
+This is the first script to run.
+
+This is a script used for downloading RPMs for testing from a local
+Jenkins system.
+
+This script takes 2 optional parameters.
+
+1. The branch name to download from.  Default is master.
+   You can also specify just the release number for release branches.
+1. The build number to download.  Default is the last successful build.
+
+### handle_rpms.sh
+
+This is the second script to run.
+
+This is a script that will do the following.
+
+1. Install the DAOS rpms that were previously downloaded.
+1. Find all the ELF executables and shared libaries that were installed.
+1. Find all the shared libraries from other packages that DAOS depends on.
+1. Find all the packages that provide those shared libraries.
+
+### scan_depends.sh
+
+This is the third script to run.
+
+This script will use a file created by the first script to list any CVEs
+that Red Hat knows about for the packages that DAOS depends on.

--- a/utils/check/download_rpms.sh
+++ b/utils/check/download_rpms.sh
@@ -1,0 +1,70 @@
+#!/bin/bash
+
+set -uex
+
+# This is a script to download RPM artifacts of DAOS from a jenkins system.
+# It may need to be edited for other build systems.
+# $1 is the branch to build.  Default is master.
+#    Release x.y can be specified by x.y for convenience.
+
+: "${WORKSPACE:="${PWD}"}"
+
+: "${RPM_DIR:="${WORKSPACE}/rpm_dir"}"
+
+: "${JENKINS_URL:="https://build.hpdd.intel.com/"}"
+job_url="${JENKINS_URL}job/daos-stack/job"
+
+if [ $# -ge 1 ]; then
+  if [[ ${1} == [[:digit:]]* ]]; then
+    my_branch="release%252F${1}"
+  else
+    my_branch="${1}"
+  fi
+else
+  my_branch="master"
+fi
+
+if [ $# -ge 2 ]; then
+  my_build="$2"
+else
+  my_build="lastSuccessfulBuild"
+fi
+
+my_project="daos"
+
+my_art_dir="artifact/artifacts"
+my_distro="centos7"
+my_artifact="${my_distro}.zip"
+my_prefix="${my_branch}_"
+
+job_url+="/${my_project}/job/${my_branch}/${my_build}/${my_art_dir}/"
+job_url+="${my_distro}/*zip*/${my_artifact}"
+
+# Get the RPM Artifacts
+rm -f "${my_prefix}${my_project}_${my_artifact}"
+curl --silent --show-error "${job_url}" \
+     -o "${my_prefix}${my_project}_${my_artifact}"
+
+upload=0
+if [ -e "${my_prefix}${my_project}_${my_artifact}_last" ]; then
+  if ! cmp "${my_prefix}${my_project}_${my_artifact}" \
+           "${my_prefix}${my_project}_${my_artifact}_last"; then
+    upload=1
+  fi
+else
+  upload=1
+fi
+
+rm -rf "${RPM_DIR:?}"
+
+if [ $upload -ne 0 ]; then
+  rm -rf tmp_dir
+  mkdir -p tmp_dir
+  pushd tmp_dir
+    unzip "../${my_prefix}${my_project}_${my_artifact}"
+    mkdir -p "${RPM_DIR}"
+    mv "${my_distro}"/*.x86_64.rpm "${RPM_DIR}"
+  popd
+  rm -rf tmp_dir
+fi
+

--- a/utils/check/handle_rpms.sh
+++ b/utils/check/handle_rpms.sh
@@ -20,27 +20,21 @@ set -uex
 : "${SOFILES:="daos_depends_libraries"}"
 : "${PACKAGES:="daos_depends_packages"}"
 
-
-repo_file="/etc/yum.repos.d/"
-repo_file+="repo.dc.hpdd.intel.com_repository_daos-stack-"
-repo_file+="el-7-x86_64-stable-local.repo"
-
 repo_url="https://repo.dc.hpdd.intel.com/repository/"
 repo_url+="daos-stack-el-7-x86_64-stable-local"
 
+: "${DAOS_STACK_EL_7_LOCAL_REPO:="${repo_url}"}"
+
+repo_dir="/etc/yum.repos.d/"
+repo_base1="${DAOS_STACK_EL_7_LOCAL_REPO#*/*/*}"
+repo_file="${repo_dir}${repo_base1//\//_}.repo"
+
 if [ ! -e "${repo_file}" ]; then
-  cat << EOF > daos_repo_file
-
-[repo.dc.hpdd.intel.com_repository_daos-stack-el-7-x86_64-stable-local]
-name=added from: ${repo_url}
-baseurl=${repo_url}
-enabled=1
-
-gpgcheck = False
-
-EOF
-  sudo cp daos_repo_file "${repo_file}"
-  sudo yum -y makecache
+  sudo yum -y install yum-utils
+  sudo yum-config-manager --add-repo "${DAOS_STACK_EL_7_LOCAL_REPO}"
+fi
+if ! grep "gpgcheck = false" "${repo_file}"; then
+  echo "gpgcheck = false" | sudo tee -a "${repo_file}"
 fi
 
 sudo yum -y remove cart cart-debuginfo cart-devel cart-tests \

--- a/utils/check/handle_rpms.sh
+++ b/utils/check/handle_rpms.sh
@@ -1,0 +1,104 @@
+#!/bin/bash
+
+set -uex
+
+# This file does an install of the RPMs found in "${REPO_DIR}" and then
+# finds all the packages that the binaries installed reference.
+
+# The file ${PACKAGES} will contain a list of packages that the RPMs depend
+# on.
+
+# The file ${SOFILES} will contain a list of sharable images depended on by
+# the RPMs.  The default name for ${SOFILES} is "daos_depends_libries".
+
+# This will likely need to be edited for other build systems.
+
+: "${WORKSPACE:="${PWD}"}"
+
+: "${RPM_DIR:="${WORKSPACE}/rpm_dir"}"
+
+: "${SOFILES:="daos_depends_libraries"}"
+: "${PACKAGES:="daos_depends_packages"}"
+
+
+repo_file="/etc/yum.repos.d/"
+repo_file+="repo.dc.hpdd.intel.com_repository_daos-stack-"
+repo_file+="el-7-x86_64-stable-local.repo"
+
+repo_url="https://repo.dc.hpdd.intel.com/repository/"
+repo_url+="daos-stack-el-7-x86_64-stable-local"
+
+if [ ! -e "${repo_file}" ]; then
+  cat << EOF > daos_repo_file
+
+[repo.dc.hpdd.intel.com_repository_daos-stack-el-7-x86_64-stable-local]
+name=added from: ${repo_url}
+baseurl=${repo_url}
+enabled=1
+
+gpgcheck = False
+
+EOF
+  sudo cp daos_repo_file "${repo_file}"
+  sudo yum -y makecache
+fi
+
+sudo yum -y remove cart cart-debuginfo cart-devel cart-tests \
+                   daos daos-client daos-debuginfo daos-devel daos-server \
+                   daos-tests CUnit dpdk fio fuse fuse-lib hwloc \
+                   libabt0 libcmocka libfabric libfabric-devel libisa-l \
+                   libopa1 libpmem libpmemblk mercury ndctl\
+                   ompi openmpi3 openpa-devel \
+                   pexpect protobuf-c pmix \
+                   python-configshell python-urwid \
+                   raft raft-debuginfo raft-devel \
+                   spdk spdk-tools
+
+sudo yum -y install "${RPM_DIR}"/*.rpm
+
+set +x
+
+# Step 1. Get a list of all the files installed by the RPMs that
+#         we just installed.
+f_list=""
+
+for f in "${RPM_DIR}"/*.rpm; do
+  rpm_files="$(rpm -qlp "${f}")"
+  f_list+=" ${rpm_files}"
+done
+
+# Step 2. Identify which of the files are ELF executables and
+#         lookup what images that they depend on.
+rm -f raw_image_depends
+
+for f in ${f_list}; do
+  if [[ -x "${f}" ]]; then
+    if file "${f}" | grep ": ELF "; then
+      ldd "${f}" >> raw_lib_depends
+    fi
+  fi
+done
+
+# Step 3. Strip out just the filenames, sort removing duplicates
+awk '{print $1}' raw_lib_depends | sort -u > "${SOFILES}"
+
+# Step 4. Find the package that provided the dependent file.
+rm -rf raw_pkg_depends
+
+while read dp; do
+  if [ "${dp}" != linux-vdso.so.1 ]; then
+    if [[ ${dp} = /* ]]; then
+      #echo "Testing ${dp}"
+      rpm -qf "/usr/${dp}" >> raw_pkg_depends
+    else
+      #echo "testing ${dp}"
+      dp_found="$(sudo find /usr -name "${dp}")"
+      for dpf in ${dp_found}; do
+        rpm -qf "${dpf}" >> raw_pkg_depends
+      done
+    fi
+  fi
+done < "${SOFILES}"
+
+sort -u raw_pkg_depends > "${PACKAGES}"
+

--- a/utils/check/scan_depends.sh
+++ b/utils/check/scan_depends.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+
+# This script installs the Red Hat CVS API tool and then runs
+# it against a list of pakages in the file ${PACKAGES} and produces
+# a file ${CVE_LIST} with the CVE information found.
+#
+# Default for ${PACKAGES} is "daos_depends_packages"
+# Default for ${CVE_LIST} is "daos_depends_cve_list"
+
+set -uex
+
+: "${PACKAGES:="daos_depends_packages"}"
+: "${CVE_LIST:="daos_depends_cve_list"}"
+
+sudo yum -y install git
+if [ ! -e rhsecapi ]; then
+  git clone https://github.com/RedHatOfficial/rhsecapi.git
+else
+  pushd rhsecapi
+    git pull
+  popd
+fi
+
+# Need to add this file.
+if [ ! -e /etc/rhsecapi-no-argcomplete ]; then
+  sudo touch /etc/rhsecapi-no-argcomplete
+fi
+
+if [ -e "${CVE_LIST}" ]; then
+  rm "${CVE_LIST}"
+fi
+
+while read dp; do
+  echo "Checking package ${dp%-*-*}" >> "${CVE_LIST}"
+  rhsecapi/rhsecapi.py --q-package "${dp%-*-*}" \
+     --extract-cves --product 'linux 7' \
+     -f bugzilla,fix_states,severity,cvss &>> "${CVE_LIST}"
+done < "${PACKAGES}"
+
+cat "${CVE_LIST}"
+


### PR DESCRIPTION
Add scripts to assist in looking up what packages, shared libraries
that DAOS depends on, and looking up known CVEs on those packages.

Skip-test: true
Skip-build: true

Signed-off-by: John E Malmberg <john.e.malmberg@intel.com>