### PR TITLE
DAOS-3855 tests: Automate daos_racer/consistency checker test (#1990)

### DIFF
--- a/src/tests/ftest/io/daos_racer.py
+++ b/src/tests/ftest/io/daos_racer.py
@@ -1,0 +1,58 @@
+#!/usr/bin/python
+"""
+  (C) Copyright 2020 Intel Corporation.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+  GOVERNMENT LICENSE RIGHTS-OPEN SOURCE SOFTWARE
+  The Government's rights to use, modify, reproduce, release, perform, display,
+  or disclose this software are subject to the terms of the Apache License as
+  provided in Contract No. B609815.
+  Any reproduction of computer software, computer software documentation, or
+  portions thereof marked with this legend must also reproduce the markings.
+"""
+
+from apricot import TestWithServers
+from daos_racer_utils import DaosRacerCommand
+
+
+class DaosRacerTest(TestWithServers):
+    """Test cases that utilize the daos_racer tool.
+
+    :avocado: recursive
+    """
+
+    def test_daos_racer(self):
+        """JIRA-3855: daos_racer/consistency checker test.
+
+        Test Description:
+            The daos_racer test tool generates a bunch of simultaneous,
+            conflicting I/O requests. After it is run it will verify that all
+            the replicas of a given object are consistent.
+
+            Run daos_racer for 5-10 minutes or so on 3-way replicated object
+            data (at least 6 servers) and verify the object replicas.
+
+        Use Cases:
+            Running simultaneous, conflicting I/O requests.
+
+        :avocado: tags=all,full_regression,hw,large,io,daosracer
+        """
+        self.assertGreater(
+            len(self.hostlist_clients), 0,
+            "This test requires one client: {}".format(self.hostlist_clients))
+        daos_racer = DaosRacerCommand(self.bin, self.hostlist_clients[0])
+        daos_racer.get_params(self)
+        daos_racer.set_environment(
+            daos_racer.get_environment(self.server_managers[0]))
+        daos_racer.run()

--- a/src/tests/ftest/io/daos_racer.yaml
+++ b/src/tests/ftest/io/daos_racer.yaml
@@ -1,0 +1,21 @@
+hosts:
+  test_servers:
+    - server-A
+    - server-B
+    - server-C
+    - server-D
+    - server-E
+    - server-F
+  test_clients:
+    - client-G
+timeout: 1800
+server_config:
+    name: daos_server
+    servers:
+        bdev_class: nvme
+        bdev_list: ["aaaa:aa:aa.a","bbbb:bb:bb.b"]
+        scm_class: dcpm
+        scm_list: ["/dev/pmem0"]
+daos_racer:
+  runtime: 600
+  clush_timeout: 1500

--- a/src/tests/ftest/util/daos_racer_utils.py
+++ b/src/tests/ftest/util/daos_racer_utils.py
@@ -1,0 +1,135 @@
+#!/usr/bin/python
+"""
+  (C) Copyright 2020 Intel Corporation.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+  GOVERNMENT LICENSE RIGHTS-OPEN SOURCE SOFTWARE
+  The Government's rights to use, modify, reproduce, release, perform, display,
+  or disclose this software are subject to the terms of the Apache License as
+  provided in Contract No. B609815.
+  Any reproduction of computer software, computer software documentation, or
+  portions thereof marked with this legend must also reproduce the markings.
+"""
+
+from apricot import get_log_file
+from command_utils import \
+    CommandFailure, BasicParameter, FormattedParameter, ExecutableCommand, \
+    EnvironmentVariables
+from general_utils import pcmd
+
+
+class DaosRacerCommand(ExecutableCommand):
+    """Defines a object representing a daos_racer command."""
+
+    def __init__(self, path, host):
+        """Create a daos_racer command object.
+
+        Args:
+            path (str): path of the daos_racer command
+            host (str): host on which to run the daos_racer command
+        """
+        super(DaosRacerCommand, self).__init__(
+            "/run/daos_racer", "daos_racer", path)
+        self.host = host
+
+        # Number of seconds to run
+        self.runtime = FormattedParameter("-t {}", 60)
+
+        # Optional timeout for the clush command running the daos_racer command.
+        # This should be set greater than the 'runtime' value but less than the
+        # avocado test timeout value to allow for proper cleanup.  Using a value
+        # of None will result in no timeout being used.
+        self.clush_timeout = BasicParameter(None)
+
+        # Environment variable names required to be set when running the
+        # daos_racer command.  The values for these names are populated by the
+        # get_environment() method and added to command line by the
+        # set_environment() method.
+        self._env_names = ["OFI_INTERFACE", "CRT_PHY_ADDR_STR", "D_LOG_FILE"]
+
+    def get_str_param_names(self):
+        """Get a sorted list of the names of the command attributes.
+
+        Only include FormattedParameter class parameter values when building the
+        command string, e.g. 'runtime'.
+
+        Returns:
+            list: a list of class attribute names used to define parameters
+                for the command.
+
+        """
+        return self.get_attribute_names(FormattedParameter)
+
+    def get_environment(self, manager):
+        """Get the environment variables to export for the daos_racer command.
+
+        Args:
+            manager (ServerManager): the job manager used to start daos_server
+                from which the server config values can be obtained to set the
+                required environment variables.
+
+        Returns:
+            EnvironmentVariables: a dictionary of environment variable names and
+                values to export prior to running daos_racer
+
+        """
+        env = EnvironmentVariables()
+        env["OMPI_MCA_btl_openib_warn_default_gid_prefix"] = "0"
+        env["OMPI_MCA_btl"] = "tcp,self"
+        env["OMPI_MCA_oob"] = "tcp"
+        env["OMPI_MCA_pml"] = "ob1"
+        for name in self._env_names:
+            if name == "D_LOG_FILE":
+                value = get_log_file("daos.log")
+            else:
+                value = manager.get_environment_value(name)
+            env[name] = value
+
+        return env
+
+    def set_environment(self, env):
+        """Set the environment variables to export prior to running daos_racer.
+
+        Args:
+            env (EnvironmentVariables): a dictionary of environment variable
+                names and values to export prior to running daos_racer
+        """
+        # Include exports prior to the daos_racer command
+        self._pre_command = env.get_export_str()
+
+    def run(self):
+        """Run the daos_racer command remotely.
+
+        Raises:
+            CommandFailure: if there is an error running the command
+
+        """
+        # Run daos_racer on the specified host
+        self.log.info(
+            "Running %s on %s with %s timeout",
+            self.__str__(), self.host,
+            "no" if self.clush_timeout.value is None else
+            "a {}s".format(self.clush_timeout.value))
+        return_codes = pcmd(
+            [self.host], self.__str__(), True, self.clush_timeout.value)
+        if 0 not in return_codes or len(return_codes) > 1:
+            # Kill the daos_racer process if the remote command timed out
+            if 255 in return_codes:
+                self.log.info(
+                    "Stopping timed out daos_racer process on %s", self.host)
+                pcmd([self.host], "pkill daos_racer", True)
+
+            raise CommandFailure("Error running '{}'".format(self._command))
+
+        self.log.info("Test passed!")

--- a/src/tests/ftest/util/general_utils.py
+++ b/src/tests/ftest/util/general_utils.py
@@ -112,9 +112,9 @@ def pcmd(hosts, command, verbose=True, timeout=None, expect_rc=0):
     if timeout and task.num_timeout() > 0:
         nodes = task.iter_keys_timeout()
         print(
-            "{}: timeout detected running '{}' on {}/{} hosts".format(
+            "{}: timeout detected running '{}' on {}/{} hosts after {}s".format(
                 NodeSet.fromlist(nodes),
-                command, task.num_timeout(), len(hosts)))
+                command, task.num_timeout(), len(hosts), timeout))
         retcode = 255
         if retcode not in retcode_dict:
             retcode_dict[retcode] = NodeSet()

--- a/src/tests/ftest/util/server_utils.py
+++ b/src/tests/ftest/util/server_utils.py
@@ -21,6 +21,7 @@
   Any reproduction of computer software, computer software documentation, or
   portions thereof marked with this legend must also reproduce the markings.
 """
+# pylint: disable=too-many-lines
 from __future__ import print_function
 
 import traceback
@@ -143,6 +144,21 @@ class DaosServer(DaosCommand):
             self.log.info("Server startup detected - %s", msg)
 
         return complete
+
+    def get_config_value(self, name):
+        """Get the value associated with a daos_server configuration value name.
+
+        Args:
+            name (str): configuration value name
+
+        Raises:
+            ServerFailure: if the configuration value name does not exist
+
+        Returns:
+            str: value of the provided configuration name
+
+        """
+        return self.yaml_params.get_value(name)
 
     class ServerStartSubCommand(CommandWithParameters):
         """Defines an object representing a daos_server start sub command."""
@@ -407,9 +423,49 @@ class DaosServerConfig(ObjectWithParameters):
                     filename, error))
         return filename
 
+    def get_value(self, name):
+        """Get the value associated with the configuration name.
+
+        Configuration names will first match any general configuration settings,
+        followed by any single server configuration entries.
+
+        Args:
+            name (str): configuration name
+
+        Raises:
+            ServerFailed: a configuration setting matching the specified name
+                was not found.
+
+        Returns:
+            [type]: [description]
+
+        """
+        found = False
+        for obj in [self] + self.server_params:
+            setting = getattr(obj, name, "setting-not-found")
+            if isinstance(setting, BasicParameter):
+                value = setting.value
+                found = True
+                break
+            elif setting != "setting-not-found":
+                value = setting
+                found = True
+                break
+        if not found:
+            raise ServerFailed(
+                "No daos_server configuration value for {}".format(name))
+        return value
+
 
 class ServerManager(ExecutableCommand):
     """Defines object to manage server functions and launch server command."""
+
+    # Mapping of environment variable names to daos_server config param names
+    ENVIRONMENT_VARIABLE_MAPPING = {
+        "CRT_PHY_ADDR_STR": "provider",
+        "OFI_INTERFACE": "fabric_iface",
+        "OFI_PORT": "fabric_iface_port",
+    }
 
     def __init__(self, daosbinpath, runnerpath, timeout=300):
         """Create a ServerManager object.
@@ -498,6 +554,33 @@ class ServerManager(ExecutableCommand):
             getattr(test, "helper_log"),
             getattr(test, "server_log")
         )
+
+    def get_environment_value(self, name):
+        """Get the server config value associated with the env variable name.
+
+        Args:
+            name (str): environment variable name for which to get a daos_server
+                configuration value
+
+        Raises:
+            ServerFailed: Unable to find a daos_server configuration value for
+                the specified environment variable name
+
+        Returns:
+            str: the daos_server configuration value for the specified
+                environment variable name
+
+        """
+        try:
+            setting = self.ENVIRONMENT_VARIABLE_MAPPING[name]
+            value = self.runner.job.get_config_value(setting)
+
+        except IndexError:
+            raise ServerFailed(
+                "Unknown server config setting mapping for the {} environment "
+                "variable!".format(name))
+
+        return value
 
     def run(self):
         """Execute the runner subprocess."""


### PR DESCRIPTION
Adding a new test to execute the daos_racer tool that generates a bunch
of simultaneous, conflicting I/O requests. After it is run it will
verify that all the replicas of a given object are consistent.

Test-tag-hw-large: pr,hw,large daosracer

Signed-off-by: Phillip Henderson <phillip.henderson@intel.com>