### PR TITLE
DAOS-4512 test: Correction in avocado DaosCore rebuild test

### DIFF
--- a/src/tests/ftest/daos_test/daos_core_test-rebuild.yaml
+++ b/src/tests/ftest/daos_test/daos_core_test-rebuild.yaml
@@ -70,7 +70,7 @@ daos_tests:
     test_r_20:
       daos_test: r
       test_name: rebuild tests 20
-      args: -s3 -u subtests="27"
+      args: -s3 -u subtests="20"
     test_r_21:
       daos_test: r
       test_name: rebuild tests 21


### PR DESCRIPTION
Rebuild test #20 is supposed to run subtest 20 but it is
running #27. Correcting it to run #20 inside
daos_test/daos_core_test-rebuild.yaml

Signed-off-by: Saurabh Tandan <saurabh.tandan@intel.com>