### PR TITLE
DAOS-4493 test: pre-create POSIX container for all MPI-IO tests. (#2353)

### DIFF
--- a/src/tests/ftest/io/fio_small.yaml
+++ b/src/tests/ftest/io/fio_small.yaml
@@ -38,6 +38,8 @@ pool:
   nvme_size: 20000000000
   svcn: 1
   control_method: dmg
+container:
+  type: POSIX
 fio:
   names:
     - global

--- a/src/tests/ftest/io/hdf5.py
+++ b/src/tests/ftest/io/hdf5.py
@@ -21,11 +21,11 @@
   Any reproduction of computer software, computer software documentation, or
   portions thereof marked with this legend must also reproduce the markings.
 """
-from mpio_test_base import LlnlMpi4pyHdf5
+from mpio_test_base import MpiioTests
 
 
 # pylint: disable=too-many-ancestors
-class Hdf5(LlnlMpi4pyHdf5):
+class Hdf5(MpiioTests):
     """Runs HDF5 test suites.
 
     :avocado: recursive

--- a/src/tests/ftest/io/hdf5.yaml
+++ b/src/tests/ftest/io/hdf5.yaml
@@ -18,6 +18,8 @@ pool:
     nvme_size: 40000000000
     svcn: 1
     control_method: dmg
+container:
+    type: POSIX
 client_processes:
     np: 6
 test_repo:

--- a/src/tests/ftest/io/ior_large.yaml
+++ b/src/tests/ftest/io/ior_large.yaml
@@ -43,6 +43,8 @@ pool:
   nvme_size: 40000000000
   svcn: 1
   control_method: dmg
+container:
+  type: POSIX
 ior:
   client_processes: !mux
     np_1:

--- a/src/tests/ftest/io/ior_small.yaml
+++ b/src/tests/ftest/io/ior_small.yaml
@@ -26,6 +26,8 @@ pool:
     nvme_size: 9000000000
     svcn: 1
     control_method: dmg
+container:
+    type: POSIX
 ior:
     client_processes:
         np_16:

--- a/src/tests/ftest/io/llnl_mpi4py.py
+++ b/src/tests/ftest/io/llnl_mpi4py.py
@@ -22,11 +22,11 @@
   portions thereof marked with this legend must also reproduce the markings.
 """
 from __future__    import print_function
-from mpio_test_base import LlnlMpi4pyHdf5
+from mpio_test_base import MpiioTests
 
 
 # pylint: disable=too-many-ancestors
-class LlnlMpi4py(LlnlMpi4pyHdf5):
+class LlnlMpi4py(MpiioTests):
     """
     Runs LLNL and MPI4PY test suites.
     :avocado: recursive

--- a/src/tests/ftest/io/llnl_mpi4py.yaml
+++ b/src/tests/ftest/io/llnl_mpi4py.yaml
@@ -15,6 +15,8 @@ pool:
     scm_size: 1000000000
     svcn: 1
     control_method: dmg
+container:
+    type: POSIX
 client_processes:
     np: 8
 test_repo:

--- a/src/tests/ftest/io/mdtest_large.yaml
+++ b/src/tests/ftest/io/mdtest_large.yaml
@@ -43,6 +43,8 @@ pool:
   nvme_size: 30000000000
   svcn: 1
   control_method: dmg
+container:
+  type: POSIX
 mdtest:
   client_processes: !mux
     np_1:

--- a/src/tests/ftest/io/mdtest_small.yaml
+++ b/src/tests/ftest/io/mdtest_small.yaml
@@ -16,6 +16,8 @@ pool:
   scm_size: 6000000000
   svcn: 1
   control_method: dmg
+container:
+  type: POSIX
 mdtest:
   client_processes:
     np_8:

--- a/src/tests/ftest/io/romio.py
+++ b/src/tests/ftest/io/romio.py
@@ -21,24 +21,15 @@
   Any reproduction of computer software, computer software documentation, or
   portions thereof marked with this legend must also reproduce the markings.
 '''
-from __future__ import print_function
+from __future__    import print_function
+from mpio_test_base import MpiioTests
 
-from apricot import TestWithServers
-from mpio_utils import MpioUtils, MpioFailed
-
-class Romio(TestWithServers):
+# pylint: disable=too-many-ancestors
+class Romio(MpiioTests):
     """
     Runs Romio test.
-
     :avocado: recursive
     """
-
-    def __init__(self, *args, **kwargs):
-
-        super(Romio, self).__init__(*args, **kwargs)
-        # Initialize a TestWithServers object.
-        self.hostfile_clients_slots = None
-        self.mpio = None
 
     def test_romio(self):
         """
@@ -48,31 +39,5 @@ class Romio(TestWithServers):
         :avocado: tags=all,mpiio,pr,small,romio
         """
         # setting romio parameters
-        romio_test_repo = self.params.get("romio_repo", '/run/romio/')
-
-        # initialize MpioUtils
-        self.mpio = MpioUtils()
-        if self.mpio.mpich_installed(self.hostlist_clients) is False:
-            self.fail("Exiting Test: Mpich not installed")
-
-        try:
-            # running romio
-            self.mpio.run_romio(self.hostlist_clients, romio_test_repo)
-
-            # Parsing output to look for failures
-            # stderr directed to stdout
-            stdout = self.logdir + "/stdout"
-            searchfile = open(stdout, "r")
-            error_message = ["non-zero exit code", "MPI_Abort", "errors",
-                             "failed to create pool",
-                             "failed to parse pool UUID",
-                             "failed to destroy pool"]
-
-            for line in searchfile:
-                for i, _ in enumerate(error_message):
-                    if error_message[i] in line:
-                        self.fail("Romio Test Failed with error_message: "
-                                  "{}".format(error_message[i]))
-
-        except (MpioFailed) as excep:
-            self.fail("<Romio Test Failed> \n{}".format(excep))
+        test_repo = self.params.get("romio_repo", '/run/romio/')
+        self.run_test(test_repo, "romio")

--- a/src/tests/ftest/io/romio.yaml
+++ b/src/tests/ftest/io/romio.yaml
@@ -3,10 +3,18 @@ hosts:
     - server-A
   test_clients:
     - client-B
-timeout: 240
+timeout: 300
 # below mentioned path should be replaced by path of
 # romio test suite directory in CI nodes when available.
 server_config:
     name: daos_server
+pool:
+    mode: 146
+    name: daos_server
+    scm_size: 1000000000
+    svcn: 1
+    control_method: dmg
+container:
+    type: POSIX
 romio:
     romio_repo: "/usr/lib64/romio/test/"

--- a/src/tests/ftest/util/ior_utils.py
+++ b/src/tests/ftest/util/ior_utils.py
@@ -236,6 +236,7 @@ class IorCommand(ExecutableCommand):
         if "mpirun" in manager_cmd or "srun" in manager_cmd:
             env["DAOS_POOL"] = self.daos_pool.value
             env["DAOS_SVCL"] = self.daos_svcl.value
+            env["DAOS_CONT"] = self.daos_cont.value
             env["FI_PSM2_DISCONNECT"] = 1
             env["IOR_HINT__MPI__romio_daos_obj_class"] = self.daos_oclass.value
 

--- a/src/tests/ftest/util/mpio_test_base.py
+++ b/src/tests/ftest/util/mpio_test_base.py
@@ -24,32 +24,59 @@
 from __future__    import print_function
 
 import os
+import re
 
 from apricot import TestWithServers
 from mpio_utils import MpioUtils, MpioFailed
 from test_utils_pool import TestPool
+from daos_utils import DaosCommand
 
-
-class LlnlMpi4pyHdf5(TestWithServers):
+class MpiioTests(TestWithServers):
     """
-    Runs LLNL, MPI4PY and HDF5 test suites.
+    Runs ROMIO, LLNL, MPI4PY and HDF5 test suites.
     :avocado: recursive
     """
 
     def __init__(self, *args, **kwargs):
         """Initialize a TestWithServers object."""
-        super(LlnlMpi4pyHdf5, self).__init__(*args, **kwargs)
+        super(MpiioTests, self).__init__(*args, **kwargs)
         self.hostfile_clients_slots = None
         self.mpio = None
+        self.daos_cmd = None
+        self.cont_uuid = None
 
     def setUp(self):
-        super(LlnlMpi4pyHdf5, self).setUp()
+        super(MpiioTests, self).setUp()
+
+        # initialise daos_cmd
+        self.daos_cmd = DaosCommand(self.bin)
 
         # initialize a python pool object then create the underlying
         self.pool = TestPool(
             self.context, dmg_command=self.get_dmg_command())
         self.pool.get_params(self)
         self.pool.create()
+
+    def _create_cont(self):
+        """Create a container.
+
+        Returns:
+            str: UUID of the created container
+
+        """
+        cont_type = self.params.get("type", "/run/container/*")
+        result = self.daos_cmd.container_create(
+            pool=self.pool.uuid, svc=self.pool.svc_ranks,
+            cont_type=cont_type)
+
+        # Extract the container UUID from the daos container create output
+        cont_uuid = re.findall(
+            "created\s+container\s+([0-9a-f-]+)", result.stdout)
+        if not cont_uuid:
+            self.fail(
+                "Error obtaining the container uuid from: {}".format(
+                    result.stdout))
+        self.cont_uuid = cont_uuid[0]
 
     def run_test(self, test_repo, test_name):
         """
@@ -65,11 +92,14 @@ class LlnlMpi4pyHdf5(TestWithServers):
         # initialise test specific variables
         client_processes = self.params.get("np", '/run/client_processes/')
 
+        # create container
+        self._create_cont()
+
         try:
             # running tests
-            self.mpio.run_llnl_mpi4py_hdf5(
+            self.mpio.run_mpiio_tests(
                 self.hostfile_clients, self.pool.uuid, self.pool.svc_ranks,
-                test_repo, test_name, client_processes)
+                test_repo, test_name, client_processes, self.cont_uuid)
         except MpioFailed as excep:
             self.fail("<{0} Test Failed> \n{1}".format(test_name, excep))
 


### PR DESCRIPTION
Signed-off-by: Mohamad Chaarawi <mohamad.chaarawi@intel.com>
Conflicts:
	src/tests/ftest/util/mpio_test_base.py
	src/tests/ftest/util/mpio_utils.py