### PR TITLE
DAOS-623 test: Add a filter to run_test.sh

### DIFF
--- a/utils/run_test.sh
+++ b/utils/run_test.sh
@@ -43,6 +43,13 @@ run_test()
     local in="$*"
     local a="${in// /-}"
     local b="${a////-}"
+
+    if [ -n "${RUN_TEST_FILTER}" ]; then
+        if ! [[ "$*" =~ ${RUN_TEST_FILTER} ]]; then
+            echo "Skipping test: $in"
+            return
+        fi
+    fi
     export D_LOG_FILE="/tmp/daos_${b}-${log_num}.log"
     echo "Running $* with log file: ${D_LOG_FILE}"
 


### PR DESCRIPTION
RUN_TEST_FILTER=evt ./utils/run_test.sh

This variable will be checked using a bash regular expression
and run only tests that match.   It is just for convenience
so one can run all tests of a specific type using the
script.

Skip-func-test: true

Signed-off-by: Jeff Olivier <jeffrey.v.olivier@intel.com>