### PR TITLE
DAOS-4476 test: Increased NVMe size in test yaml

### DIFF
--- a/src/tests/ftest/io/nvme_io_verification.yaml
+++ b/src/tests/ftest/io/nvme_io_verification.yaml
@@ -1,6 +1,3 @@
-# change host names to your reserved nodes, the
-# required quantity is indicated by the placeholders
-
 hosts:
  test_servers:
    - boro-A
@@ -49,8 +46,8 @@ ior:
        - 60000000
  ior_sequence:
 #   - [scmsize, nvmesize]
-    - [500000000, 5000000000]        #[500M, 5G]
-    - [500000000, 50000000000]       #[500M, 50G]
-    - [3000000000, 500000000000]      #[3G, 500G]
+    - [500M, 10G]
+    - [500M, 50G]
+    - [3G, 500G]
 # Uncomment this once DAOS-3339 is resolved
 #    - [3000000000, 800000000000]     #[3G, 800G]


### PR DESCRIPTION
The new code has implemented minimum NVMe size at pool create.

Test-tag-hw-large: pr,hw,large nvme_io_verification
Signed-off-by: Makito Kano <makito.kano@intel.com>