### PR TITLE
DAOS-4352 build: Force EL7 build to use fuse3 RPM

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,4 +18,4 @@ before_install:
 
 script:
  - docker build -f utils/docker/Dockerfile.$DOCKER_IMAGE -t daos/$DOCKER_IMAGE --build-arg NOBUILD=1 --build-arg UID=$UID .
- - docker run -v $PWD:/home/daos/daos:z daos/$DOCKER_IMAGE /bin/bash -c "scons --build-deps=yes install"
+ - docker run -v $PWD:/home/daos/daos:z daos/$DOCKER_IMAGE /bin/bash -c "scons --build-deps=yes USE_INSTALLED=fuse install"


### PR DESCRIPTION

In Docker builds.

Skip-checkpatch: true
Skip-run_test: true
Skip-coverity-test: true
Skip-func-test: true
Skip-scan-centos-rpms: true

Signed-off-by: Brian J. Murrell <brian.murrell@intel.com>