### PR TITLE
DAOS-4477 test: NvmeIO nvme_io test fails in weekly run

### DIFF
--- a/src/tests/ftest/io/nvme_io.yaml
+++ b/src/tests/ftest/io/nvme_io.yaml
@@ -12,6 +12,9 @@ hosts:
 timeout: 28800
 server_config:
  name: daos_server
+ servers:
+   bdev_class: nvme
+   bdev_list: ["0000:81:00.0","0000:da:00.0"]
 pool:
  mode: 511
  name: daos_server


### PR DESCRIPTION
Test-tag: basictx
Test-tag-hw-small: iorsmall
Test-tag-hw-medium: fiosmall
Test-tag-hw-large: nvme_io

  - Added the missing bdev_list to the test yaml files
    for nvme testing.

Signed-off-by: Logan Sundaram <logan.sundaram@intel.com>