### PR TITLE
DAOS-4148 Updating the new test_utils_pools change in util/daos_io_co…

### DIFF
--- a/src/tests/ftest/io/unaligned_io.yaml
+++ b/src/tests/ftest/io/unaligned_io.yaml
@@ -25,4 +25,5 @@ datasize:
     - 300
     - 16000
     - 1048599
-    - 1073741824
+    # Skip this large size until DAOS-2164 resolved.
+    #- 1073741824

--- a/src/tests/ftest/util/daos_io_conf.py
+++ b/src/tests/ftest/util/daos_io_conf.py
@@ -28,7 +28,7 @@ from avocado.utils import process
 from apricot import TestWithServers
 from command_utils import ExecutableCommand, CommandFailure, FormattedParameter
 from command_utils import BasicParameter
-from test_utils import TestPool
+from test_utils_pool import TestPool
 
 
 class IoConfGen(ExecutableCommand):
@@ -96,7 +96,7 @@ def gen_unaligned_io_conf(record_size, filename="testfile"):
         filename (string): Filename (with/without path) for
                            creating the data set.
     """
-    rand_ofs_end = random.randint(1, record_size)
+    rand_ofs_end = random.randint(1, record_size - 1)
     rand_ofs_start = rand_ofs_end - 1
     file_data = (
         "test_lvl daos",


### PR DESCRIPTION
…nf.py (#1869)

Test-tag-hw-large: iorebuild

* Updating the new test_utils_pools change in util/daos_io_conf.py

Signed-off-by: Samir Raval <samir.raval@intel.com>
Signed-off-by: Logan Sundaram <logan.sundaram@intel.com>