### PR TITLE
DAOS-4679 test: Reset runable bool for test_runable() check

### DIFF
--- a/src/tests/suite/daos_test_common.c
+++ b/src/tests/suite/daos_test_common.c
@@ -575,7 +575,10 @@ bool
 test_runable(test_arg_t *arg, unsigned int required_nodes)
 {
 	int		 i;
-	static bool	 runable = true;
+	static bool	 runable;
+
+	/** reset runable for each new test runable check */
+	runable = true;
 
 	if (arg->myrank == 0) {
 		int			tgts_per_node;


### PR DESCRIPTION
When one check of test_runable() for daos_test returns false (ie not enough
servers to run test, etc), then the value is not reset to true at the beginning
of each new test case check. Instead the runable bool is just initially set to
true in the static declaration.

Signed-off-by: Sydney Vanda <sydney.m.vanda@intel.com>