### PR TITLE
DAOS-4564 cont: refine cont_query operation

### DIFF
--- a/src/container/cli.c
+++ b/src/container/cli.c
@@ -1064,6 +1064,8 @@ dc_cont_query(tse_task_t *task)
 	uuid_copy(in->cqi_op.ci_uuid, cont->dc_uuid);
 	uuid_copy(in->cqi_op.ci_hdl, cont->dc_cont_hdl);
 	in->cqi_bits = cont_query_bits(args->prop);
+	if (args->info != NULL)
+		in->cqi_bits |= DAOS_CO_QUERY_TGT;
 
 	arg.cqa_pool = pool;
 	arg.cqa_cont = cont;

--- a/src/container/rpc.h
+++ b/src/container/rpc.h
@@ -217,6 +217,9 @@ CRT_RPC_DECLARE(cont_close, DAOS_ISEQ_CONT_CLOSE, DAOS_OSEQ_CONT_CLOSE)
 #define DAOS_CO_QUERY_PROP_ALL					\
 	((1ULL << DAOS_CO_QUERY_PROP_BITS_NR) - 1)
 
+/** container query target bit, to satisfy querying of daos_cont_info_t */
+#define DAOS_CO_QUERY_TGT		(1ULL << 31)
+
 #define DAOS_ISEQ_CONT_QUERY	/* input fields */		 \
 	((struct cont_op_in)	(cqi_op)		CRT_VAR) \
 	((uint64_t)		(cqi_bits)		CRT_VAR)

--- a/src/container/srv_container.c
+++ b/src/container/srv_container.c
@@ -1637,13 +1637,15 @@ cont_query(struct rdb_tx *tx, struct ds_pool_hdl *pool_hdl, struct cont *cont,
 	if (!hdl_has_query_access(hdl, cont, in->cqi_bits))
 		return -DER_NO_PERM;
 
-	rc = cont_query_bcast(rpc->cr_ctx, cont, in->cqi_op.ci_pool_hdl,
-			      in->cqi_op.ci_hdl, out);
-	if (rc)
-		return rc;
+	if (in->cqi_bits & DAOS_CO_QUERY_TGT) {
+		rc = cont_query_bcast(rpc->cr_ctx, cont, in->cqi_op.ci_pool_hdl,
+				      in->cqi_op.ci_hdl, out);
+		if (rc)
+			return rc;
+	}
 
 	/* Caller didn't actually ask for any props */
-	if (in->cqi_bits == 0)
+	if ((in->cqi_bits & DAOS_CO_QUERY_PROP_ALL) == 0)
 		return 0;
 
 	/* the allocated prop will be freed after rpc replied in


### PR DESCRIPTION
CONT_QUERY need not query each target (bcast+collective) for some cases.
It will make some usages for example dfs_mount() be simpler/faster.

Signed-off-by: Xuezhao Liu <xuezhao.liu@intel.com>