### PR TITLE
DAOS-623 test: Disable Avocado TAP result output

### DIFF
--- a/src/tests/ftest/launch.py
+++ b/src/tests/ftest/launch.py
@@ -725,6 +725,7 @@ def run_tests(test_files, tag_filter, args):
         "--ignore-missing-references on",
         "--show-job-log" if not args.sparse else "",
         "--html-job-result on",
+        "--tap-job-result=off",
         tag_filter
     ]
 


### PR DESCRIPTION

Since this is a copy of the stdout/stderr from the test and it can be
copious and take a long time to write.

Signed-off-by: Brian J. Murrell <brian.murrell@intel.com>
Quick-build: true
Skip-func-hw-test: true