### PR TITLE
DAOS-4542 dtx: DTX adjustment for cross RDGs modification

### DIFF
--- a/src/include/daos/dtx.h
+++ b/src/include/daos/dtx.h
@@ -48,11 +48,6 @@ struct dtx_id {
 	uint64_t		dti_hlc;
 };
 
-struct dtx_conflict_entry {
-	struct dtx_id		dce_xid;
-	uint64_t		dce_dkey;
-};
-
 void daos_dti_gen(struct dtx_id *dti, bool zero);
 
 static inline void

--- a/src/include/daos_srv/dtx_srv.h
+++ b/src/include/daos_srv/dtx_srv.h
@@ -31,75 +31,94 @@
 #include <daos_srv/pool.h>
 #include <daos_srv/container.h>
 
-struct dtx_entry {
-	/** The identifier of the DTX */
-	struct dtx_id		dte_xid;
-	/** The identifier of the modified object (shard). */
-	daos_unit_oid_t		dte_oid;
+struct dtx_rdg_unit {
+	/* The ID for one object that is in this redundancy group (RDG). */
+	daos_obj_id_t		dru_oid;
+	/* The count of shards within this RDG that participate in the DTX. */
+	uint16_t		dru_shard_cnt;
+	/* 32-bits alignment. */
+	uint16_t		dru_padding;
+	/*
+	 * The array of shards index. Cover 3-way replicas,
+	 * or partial EC obj update (1 shard + 2 parities).
+	 */
+	uint32_t		dru_shards[3];
 };
 
-enum dtx_cos_list_types {
-	DCLT_UPDATE		= (1 << 0),
-	DCLT_PUNCH		= (1 << 1),
+struct dtx_entry {
+	struct dtx_id		 dte_xid;
+	uint32_t		 dte_rdg_size;
+	uint16_t		 dte_rdg_cnt;
+	struct dtx_rdg_unit	*dte_rdgs;
+};
+
+enum dtx_flags {
+	/* The DTX is the leader */
+	DF_LEADER		= (1 << 0),
+	/* The DTX entry is invalid. */
+	DF_INVALID		= (1 << 1),
+	/*
+	 * Compounded DTX that may touch multiple dkeys
+	 * (in spite of whether in the same RDG or not).
+	 */
+	DF_CPD			= (1 << 2),
+	/* The RDG information is embedded inside DTX entry. */
+	DF_INLINE_RDG		= (1 << 3),
 };
 
 /**
  * DAOS two-phase commit transaction handle in DRAM.
  */
 struct dtx_handle {
-	union {
-		struct {
-			/** The identifier of the DTX */
-			struct dtx_id		dth_xid;
-			/** The identifier of the shard to be modified. */
-			daos_unit_oid_t		dth_oid;
-		};
-		struct dtx_entry		dth_dte;
-	};
+	/** Holds DTX identifier and related RDG information. */
+	struct dtx_entry		 dth_entry;
 	/** The container handle */
 	daos_handle_t			 dth_coh;
 	/** The epoch# for the DTX. */
 	daos_epoch_t			 dth_epoch;
-	/* The generation when the DTX is handled on the server. */
-	uint64_t			 dth_gen;
-	/** The {obj/dkey/akey}-tree records that are created
-	 * by other DTXs, but not ready for commit yet.
-	 */
-	d_list_t			 dth_shares;
-	/* The hash of the dkey to be modified if applicable */
-	uint64_t			 dth_dkey_hash;
 	/** Pool map version. */
 	uint32_t			 dth_ver;
-	/** The intent of related modification. */
-	uint32_t			 dth_intent;
+
 	uint32_t			 dth_sync:1, /* commit synchronously. */
 					 dth_leader:1, /* leader replica. */
 					 /* Only one participator in the DTX. */
 					 dth_solo:1,
+					 /* The DTX may cross multiple dkeys. */
+					 dth_compounded:1,
 					 /* dti_cos has been committed. */
 					 dth_dti_cos_done:1,
-					 /* XXX: touch ilog entry. */
-					 dth_has_ilog:1,
+					 /* May touch shared target. */
+					 dth_touch_shared:1,
 					 /* epoch conflict, need to renew. */
 					 dth_renew:1,
 					 /* The DTX entry is in active table. */
 					 dth_actived:1;
-	/* The count the DTXs in the dth_dti_cos array. */
-	uint32_t			 dth_dti_cos_count;
-	/* The array of the DTXs for Commit on Share (conflcit). */
-	struct dtx_id			*dth_dti_cos;
-	/* The identifier of the DTX that conflict with current one. */
-	struct dtx_conflict_entry	*dth_conflict;
+
+	/* The generation when the DTX is handled on the server. */
+	uint64_t			 dth_gen;
 	/** Pointer to the DTX entry in DRAM. */
 	void				*dth_ent;
-	/** The address (offset) of the (new) object to be modified. */
-	umem_off_t			 dth_obj;
+
+	/* The array of the DTXs for Commit on Share (conflcit). */
+	struct dtx_id			*dth_dti_cos;
+	/* The count the DTXs in the dth_dti_cos array. */
+	uint32_t			 dth_dti_cos_cnt;
+
+	/* The following fields are per modification based. */
+
+	/** The intent of related modification. */
+	uint16_t			 dth_intent;
+	/* Operation sequence starts from 1 instead of 0. */
+	uint16_t			 dth_op_seq;
+	/* The hash of the dkey to be modified if applicable */
+	uint64_t			 dth_dkey_hash;
+	/** The identifier of the shard to be modified. */
+	daos_unit_oid_t			 dth_oid;
 };
 
 /* Each sub transaction handle to manage each sub thandle */
 struct dtx_sub_status {
 	struct daos_shard_tgt		dss_tgt;
-	struct dtx_conflict_entry	dss_dce;
 	int				dss_result;
 };
 
@@ -140,11 +159,15 @@ enum dtx_status {
 	DTX_ST_COMMITTED	= 2,
 };
 
+void
+dtx_sub_init(struct dtx_handle *dth, daos_unit_oid_t *oid,
+	     uint64_t dkey_hash, uint16_t intent);
 int
-dtx_leader_begin(struct dtx_id *dti, daos_unit_oid_t *oid, daos_handle_t coh,
-		 daos_epoch_t epoch, uint64_t dkey_hash, uint32_t pm_ver,
-		 uint32_t intent, struct daos_shard_tgt *tgts, int tgts_cnt,
-		 bool cond_check, struct dtx_leader_handle *dlh);
+dtx_leader_begin(struct dtx_id *dti, daos_handle_t coh, daos_epoch_t epoch,
+		 uint32_t pm_ver, uint32_t rdg_size, uint16_t rdg_cnt,
+		 struct dtx_rdg_unit *rdgs, struct daos_shard_tgt *tgts,
+		 uint32_t tgt_cnt, uint32_t dti_cos_cnt,
+		 struct dtx_id *dti_cos, struct dtx_leader_handle *dlh);
 int
 dtx_leader_end(struct dtx_leader_handle *dlh, struct ds_cont_child *cont,
 	       int result);
@@ -157,11 +180,10 @@ typedef int (*dtx_sub_func_t)(struct dtx_leader_handle *dlh, void *arg, int idx,
 int dtx_resync(daos_handle_t po_hdl, uuid_t po_uuid, uuid_t co_uuid,
 	       uint32_t ver, bool block);
 int
-dtx_begin(struct dtx_id *dti, daos_unit_oid_t *oid, daos_handle_t coh,
-	  daos_epoch_t epoch, uint64_t dkey_hash,
-	  struct dtx_conflict_entry *conflict, struct dtx_id *dti_cos,
-	  int dti_cos_cnt, uint32_t pm_ver, uint32_t intent,
-	  struct dtx_handle *dth);
+dtx_begin(struct dtx_id *dti, daos_handle_t coh, daos_epoch_t epoch,
+	  uint32_t pm_ver, uint32_t rdg_size, uint16_t rdg_cnt,
+	  struct dtx_rdg_unit *rdgs, uint32_t dti_cos_cnt,
+	  struct dtx_id *dti_cos, struct dtx_handle *dth);
 int
 dtx_end(struct dtx_handle *dth, struct ds_cont_hdl *cont_hdl,
 	struct ds_cont_child *cont, int result);
@@ -183,7 +205,6 @@ int dtx_obj_sync(uuid_t po_uuid, uuid_t co_uuid, daos_handle_t coh,
  * \param oid		[IN]	Pointer to the object ID.
  * \param xid		[IN]	Pointer to the DTX identifier.
  * \param dkey_hash	[IN]	The hashed dkey.
- * \param punch		[IN]	For punch operation or not.
  * \param epoch		[IN,OUT] Pointer to current epoch, if it is zero and
  *				 if the DTX exists, then the DTX's epoch will
  *				 be saved in it.
@@ -197,9 +218,9 @@ int dtx_obj_sync(uuid_t po_uuid, uuid_t co_uuid, daos_handle_t coh,
  *					processed with different epoch.
  *			Other negative value if error.
  */
-int dtx_handle_resend(daos_handle_t coh, daos_unit_oid_t *oid,
+int dtx_handle_resend(daos_handle_t coh, daos_obj_id_t *oid,
 		      struct dtx_id *dti, uint64_t dkey_hash,
-		      bool punch, daos_epoch_t *epoch);
+		      daos_epoch_t *epoch);
 
 /* XXX: The higher 48 bits of HLC is the wall clock, the lower bits are for
  *	logic clock that will be hidden when divided by NSEC_PER_SEC.

--- a/src/include/daos_srv/vos_types.h
+++ b/src/include/daos_srv/vos_types.h
@@ -32,8 +32,8 @@
 #include <daos/checksum.h>
 
 enum dtx_cos_flags {
-	DCF_FOR_PUNCH	= (1 << 0),
-	DCF_HAS_ILOG	= (1 << 1),
+	/* Contains target (obj/dkey/akey) that can be shared by others. */
+	DCF_SHARED	= (1 << 0),
 };
 
 enum vos_oi_attr {
@@ -291,22 +291,10 @@ typedef struct {
 			/** Non-zero if punched */
 			daos_epoch_t		ie_punch;
 			union {
-				/** dkey or akey */
-				struct {
-					/** key value */
-					daos_key_t		ie_key;
-				};
-				/** object or DTX entry */
-				struct {
-					/** The DTX identifier. */
-					struct dtx_id		ie_xid;
-					/** oid */
-					daos_unit_oid_t		ie_oid;
-					/* The dkey hash for DTX iteration. */
-					uint64_t		ie_dtx_hash;
-					/* The DTX intent for DTX iteration. */
-					uint32_t		ie_dtx_intent;
-				};
+				/** key value */
+				daos_key_t	ie_key;
+				/** oid */
+				daos_unit_oid_t	ie_oid;
 			};
 		};
 		/** Array entry */
@@ -323,6 +311,16 @@ typedef struct {
 			struct dcs_csum_info	ie_csum;
 			/** pool map version */
 			uint32_t		ie_ver;
+		};
+		/** DTX entry */
+		struct {
+			struct dtx_id		ie_xid;
+			uint64_t		ie_dtx_epoch;
+			uint64_t		ie_dtx_hash;
+			uint16_t		ie_dtx_flags;
+			uint16_t		ie_rdg_cnt;
+			uint32_t		ie_rdg_size;
+			struct dtx_rdg_unit	*ie_rdgs;
 		};
 	};
 	/* Flags to describe the entry */

--- a/src/object/obj_rpc.c
+++ b/src/object/obj_rpc.c
@@ -698,30 +698,3 @@ obj_reply_map_version_get(crt_rpc_t *rpc)
 	}
 	return 0;
 }
-
-void
-obj_reply_dtx_conflict_set(crt_rpc_t *rpc, struct dtx_conflict_entry *dce)
-{
-	void *reply = crt_reply_get(rpc);
-
-	switch (opc_get(rpc->cr_opc)) {
-	case DAOS_OBJ_RPC_TGT_UPDATE: {
-		struct obj_rw_out	*orw = reply;
-
-		daos_dti_copy(&orw->orw_dti_conflict, &dce->dce_xid);
-		orw->orw_dkey_conflict = dce->dce_dkey;
-		break;
-	}
-	case DAOS_OBJ_RPC_TGT_PUNCH:
-	case DAOS_OBJ_RPC_TGT_PUNCH_DKEYS:
-	case DAOS_OBJ_RPC_TGT_PUNCH_AKEYS: {
-		struct obj_punch_out	*opo = reply;
-
-		daos_dti_copy(&opo->opo_dti_conflict, &dce->dce_xid);
-		opo->opo_dkey_conflict = dce->dce_dkey;
-		break;
-	}
-	default:
-		D_ASSERT(0);
-	}
-}

--- a/src/object/obj_rpc.h
+++ b/src/object/obj_rpc.h
@@ -164,6 +164,7 @@ struct obj_iod_array {
 	((uint32_t)		(orw_start_shard)	CRT_VAR) \
 	((uint32_t)		(orw_flags)		CRT_VAR) \
 	((daos_key_t)		(orw_dkey)		CRT_VAR) \
+	((d_iov_t)		(orw_rdgs)		CRT_VAR) \
 	((struct dcs_csum_info)	(orw_dkey_csum)		CRT_PTR) \
 	((struct obj_iod_array)	(orw_iod_array)		CRT_VAR) \
 	((struct dtx_id)	(orw_dti_cos)		CRT_ARRAY) \
@@ -174,8 +175,6 @@ struct obj_iod_array {
 #define DAOS_OSEQ_OBJ_RW	/* output fields */		 \
 	((int32_t)		(orw_ret)		CRT_VAR) \
 	((uint32_t)		(orw_map_version)	CRT_VAR) \
-	((uint64_t)		(orw_dkey_conflict)	CRT_VAR) \
-	((struct dtx_id)	(orw_dti_conflict)	CRT_VAR) \
 	((daos_size_t)		(orw_iod_sizes)		CRT_ARRAY) \
 	((daos_size_t)		(orw_data_sizes)	CRT_ARRAY) \
 	((d_sg_list_t)		(orw_sgls)		CRT_ARRAY) \
@@ -234,6 +233,7 @@ CRT_RPC_DECLARE(obj_key_enum, DAOS_ISEQ_OBJ_KEY_ENUM, DAOS_OSEQ_OBJ_KEY_ENUM)
 	((uint64_t)		(opi_dkey_hash)		CRT_VAR) \
 	((uint32_t)		(opi_map_ver)		CRT_VAR) \
 	((uint32_t)		(opi_flags)		CRT_VAR) \
+	((d_iov_t)		(opi_rdgs)		CRT_VAR) \
 	((struct dtx_id)	(opi_dti_cos)		CRT_ARRAY) \
 	((d_iov_t)		(opi_dkeys)		CRT_ARRAY) \
 	((d_iov_t)		(opi_akeys)		CRT_ARRAY) \
@@ -241,9 +241,7 @@ CRT_RPC_DECLARE(obj_key_enum, DAOS_ISEQ_OBJ_KEY_ENUM, DAOS_OSEQ_OBJ_KEY_ENUM)
 
 #define DAOS_OSEQ_OBJ_PUNCH	/* output fields */		 \
 	((int32_t)		(opo_ret)		CRT_VAR) \
-	((uint32_t)		(opo_map_version)	CRT_VAR) \
-	((uint64_t)		(opo_dkey_conflict)	CRT_VAR) \
-	((struct dtx_id)	(opo_dti_conflict)	CRT_VAR)
+	((uint32_t)		(opo_map_version)	CRT_VAR)
 
 CRT_RPC_DECLARE(obj_punch, DAOS_ISEQ_OBJ_PUNCH, DAOS_OSEQ_OBJ_PUNCH)
 
@@ -323,7 +321,6 @@ void obj_reply_set_status(crt_rpc_t *rpc, int status);
 int obj_reply_get_status(crt_rpc_t *rpc);
 void obj_reply_map_version_set(crt_rpc_t *rpc, uint32_t map_version);
 uint32_t obj_reply_map_version_get(crt_rpc_t *rpc);
-void obj_reply_dtx_conflict_set(crt_rpc_t *rpc, struct dtx_conflict_entry *dce);
 
 static inline bool
 obj_is_modification_opc(uint32_t opc)

--- a/src/placement/pl_map.c
+++ b/src/placement/pl_map.c
@@ -554,14 +554,25 @@ pl_select_leader(daos_obj_id_t oid, uint32_t shard_idx, uint32_t grp_size,
 
 	oc_attr = daos_oclass_attr_find(oid);
 	if (oc_attr->ca_resil != DAOS_RES_REPL) {
-		/* For EC object, elect last shard in the group (must to be
-		 * a parity node) as leader.
-		 */
-		shard = pl_get_shard(data, shard_idx + grp_size - 1);
-		if (for_tgt_id)
-			return shard->po_target;
+		D_ASSERT(oc_attr->ca_resil == DAOS_RES_EC);
 
-		return shard->po_shard;
+		/*
+		 * For EC object, elect the last non-rebuilding parity
+		 * shard in the group as the leader.
+		 */
+		for (i = 1; i <= oc_attr->u.ec.e_p; i++) {
+			shard = pl_get_shard(data, shard_idx + grp_size - i);
+			if (shard->po_target == -1 || shard->po_rebuilding)
+				continue;
+
+			if (for_tgt_id)
+				return shard->po_target;
+
+			return shard->po_shard;
+		}
+
+		/* Cannot find suitable parity shard as the leader. */
+		return -DER_IO;
 	}
 
 	replicas = oc_attr->u.rp.r_num;
@@ -574,7 +585,7 @@ pl_select_leader(daos_obj_id_t oid, uint32_t shard_idx, uint32_t grp_size,
 	if (replicas == 1) {
 		shard = pl_get_shard(data, shard_idx);
 		if (shard->po_target == -1)
-			return -DER_NONEXIST;
+			return -DER_IO;
 
 		/* Single replicated object will not rebuild. */
 		D_ASSERT(!shard->po_rebuilding);
@@ -619,8 +630,8 @@ pl_select_leader(daos_obj_id_t oid, uint32_t shard_idx, uint32_t grp_size,
 		return pl_get_shard(data, pos)->po_shard;
 	}
 
-	/* If all the replicas are failed or in-rebuilding, then NONEXIST. */
-	return -DER_NONEXIST;
+	/* If all the replicas are failed or in-rebuilding, then EIO. */
+	return -DER_IO;
 }
 
 #define PL_HTABLE_BITS 7

--- a/src/vos/vos_dtx_iter.c
+++ b/src/vos/vos_dtx_iter.c
@@ -174,10 +174,12 @@ dtx_iter_fetch(struct vos_iterator *iter, vos_iter_entry_t *it_entry,
 	dae = (struct vos_dtx_act_ent *)rec_iov.iov_buf;
 
 	it_entry->ie_xid = DAE_XID(dae);
-	it_entry->ie_oid = DAE_OID(dae);
-	it_entry->ie_epoch = DAE_EPOCH(dae);
-	it_entry->ie_dtx_intent = DAE_INTENT(dae);
+	it_entry->ie_dtx_epoch = DAE_EPOCH(dae);
 	it_entry->ie_dtx_hash = DAE_DKEY_HASH(dae);
+	it_entry->ie_dtx_flags = DAE_FLAGS(dae);
+	it_entry->ie_rdg_cnt = DAE_RDG_CNT(dae);
+	it_entry->ie_rdg_size = DAE_RDG_SIZE(dae);
+	it_entry->ie_rdgs = &DAE_RDG_INLINE(dae);
 
 	D_DEBUG(DB_IO, "DTX iterator fetch the one "DF_DTI"\n",
 		DP_DTI(&DAE_XID(dae)));

--- a/src/vos/vos_internal.h
+++ b/src/vos/vos_internal.h
@@ -171,6 +171,8 @@ struct vos_dtx_act_ent {
 	struct vos_dtx_act_ent_df	 dae_base;
 	umem_off_t			 dae_df_off;
 	struct vos_dtx_blob_df		*dae_dbd;
+	/* For DTX RDG information out of inline case. */
+	struct dtx_rdg_unit		*dae_rdgs;
 	/* More DTX records if out of the inlined buffer. */
 	struct vos_dtx_record_df	*dae_records;
 	/* The capacity of dae_records, NOT including the inlined buffer. */
@@ -178,14 +180,16 @@ struct vos_dtx_act_ent {
 };
 
 #define DAE_XID(dae)		((dae)->dae_base.dae_xid)
-#define DAE_OID(dae)		((dae)->dae_base.dae_oid)
-#define DAE_DKEY_HASH(dae)	((dae)->dae_base.dae_dkey_hash)
 #define DAE_EPOCH(dae)		((dae)->dae_base.dae_epoch)
+#define DAE_DKEY_HASH(dae)	((dae)->dae_base.dae_dkey_hash)
 #define DAE_SRV_GEN(dae)	((dae)->dae_base.dae_srv_gen)
 #define DAE_LAYOUT_GEN(dae)	((dae)->dae_base.dae_layout_gen)
-#define DAE_INTENT(dae)		((dae)->dae_base.dae_intent)
+#define DAE_RDG_INLINE(dae)	((dae)->dae_base.dae_rdg_inline)
+#define DAE_RDG_OFF(dae)	((dae)->dae_base.dae_rdg_off)
+#define DAE_RDG_SIZE(dae)	((dae)->dae_base.dae_rdg_size)
 #define DAE_INDEX(dae)		((dae)->dae_base.dae_index)
 #define DAE_REC_INLINE(dae)	((dae)->dae_base.dae_rec_inline)
+#define DAE_RDG_CNT(dae)	((dae)->dae_base.dae_rdg_cnt)
 #define DAE_FLAGS(dae)		((dae)->dae_base.dae_flags)
 #define DAE_REC_CNT(dae)	((dae)->dae_base.dae_rec_cnt)
 #define DAE_REC_OFF(dae)	((dae)->dae_base.dae_rec_off)
@@ -381,14 +385,13 @@ vos_dtx_cos_register(void);
  * \param oid		[IN]	Pointer to the object ID.
  * \param xid		[IN]	Pointer to the DTX identifier.
  * \param dkey_hash	[IN]	The hashed dkey.
- * \param punch		[IN]	For punch DTX or not.
  *
  * \return		Zero on success.
  * \return		Other negative value if error.
  */
 int
-vos_dtx_del_cos(struct vos_container *cont, daos_unit_oid_t *oid,
-		struct dtx_id *xid, uint64_t dkey_hash, bool punch);
+vos_dtx_del_cos(struct vos_container *cont, daos_obj_id_t *oid,
+		struct dtx_id *xid, uint64_t dkey_hash);
 
 /**
  * Query the oldest DTX's timestamp in the CoS cache.

--- a/src/vos/vos_io.c
+++ b/src/vos/vos_io.c
@@ -1571,10 +1571,10 @@ vos_update_end(daos_handle_t ioh, uint32_t pm_ver, daos_key_t *dkey, int err,
 		ioc->ic_read_conflict = true;
 
 	/* Commit the CoS DTXs via the IO PMDK transaction. */
-	if (dth != NULL && dth->dth_dti_cos_count > 0 &&
+	if (dth != NULL && dth->dth_dti_cos_cnt > 0 &&
 	    dth->dth_dti_cos_done == 0) {
 		vos_dtx_commit_internal(ioc->ic_obj->obj_cont, dth->dth_dti_cos,
-					dth->dth_dti_cos_count, 0);
+					dth->dth_dti_cos_cnt, 0);
 		dth->dth_dti_cos_done = 1;
 	}
 

--- a/src/vos/vos_obj.c
+++ b/src/vos/vos_obj.c
@@ -257,10 +257,10 @@ vos_obj_punch(daos_handle_t coh, daos_unit_oid_t oid, daos_epoch_t epoch,
 		goto reset;
 
 	/* Commit the CoS DTXs via the PUNCH PMDK transaction. */
-	if (dth != NULL && dth->dth_dti_cos_count > 0 &&
+	if (dth != NULL && dth->dth_dti_cos_cnt > 0 &&
 	    dth->dth_dti_cos_done == 0) {
 		vos_dtx_commit_internal(cont, dth->dth_dti_cos,
-					dth->dth_dti_cos_count, 0);
+					dth->dth_dti_cos_cnt, 0);
 		dth->dth_dti_cos_done = 1;
 	}
 

--- a/src/vos/vos_obj_cache.c
+++ b/src/vos/vos_obj_cache.c
@@ -344,7 +344,7 @@ out:
 		       " is not newer than the sync epoch "DF_U64"\n",
 		       intent == DAOS_INTENT_PUNCH ? "punch" : "update",
 		       DP_UOID(oid), epr->epr_hi, obj->obj_sync_epoch);
-		D_GOTO(failed, rc = -DER_INPROGRESS);
+		D_GOTO(failed, rc = -DER_AGAIN);
 	}
 
 	*obj_p = obj;


### PR DESCRIPTION
Adjust current server controlled single redundancy group (RDG)
based DTX logic to support the coming client driven distributed
transaction that may cross multiple RDGs, including the fixes:

1. Introduce RDG information to DTX logic. It helps the DTX
   logic to understand which RDGs participate in the DTX.

2. DTX entry on-disk layout adjustment:

2.1 Remove modification intent that was used for conflict
    detect by CoS logic and vos_dtx_check_availability().
    After introducing incarnation log logic, the conflict
    doesn't exist any more. On the other hand, the client
    driven DTX may contains multiple modifications with
    different intents. It is inconvenient to store them
    in the DTX entry.

2.2 Store RDG information in the DTX entry on-disk that
    will be used when DTX resync.

3. vos_dtx_check_availability() simplification. Remove
   useless logic for punch/update conflict check after
   introducing incarnation log logic.

4. Changes for DTX CoS logic:

4.1 Logic cleanup. Remove intent based classification. It
   is useless after introducing incarnation log that makes
   punch DTX and update DTX against the same object/key to
   be compatible with each other. On the other hand, keep
   related CoS logic for handling conditional modification.

4.2 CoS API adjustment. Remove @punch parameter. Replace
    daos_unit_oid_t with daos_obj_id_t for @oid parameter.
    We do not need the shard index for the CoS cache.
    vos_dtx_add_cos()
    vos_dtx_del_cos()
    vos_dtx_lookup_cos()
    vos_dtx_list_cos()

5. Adjust VOS DTX unit tests corresponding to the CoS API,
   logic and DTX entry layout changes.

6. DTX handle changes:

6.1 Hide incarnation log related logic inside VOS. Some of
    that were exposed by DTX handle, such as dth_has_ilog.

6.2 Remove useless members: dth_conflict and dth_obj.

6.3 New bit flag: dth_compounded, to indicate whether the
    DTX contains dkeys modifications.

6.4 Reference RDG information.

7. Adjust dtx_leader_begin/dtx_begin API to match above
   DTX handle changes.

8. Adjust the DTX RPC (commit/abort/check) to base on RDG
   information to avoid sending DTX RPC to the target that
   does not participate in the DTX. That is useful even if
   it is for server controlled DTX within single RDG, such
   as partially update of EC object, and the case of update
   replicated object under degrade mode.

8.1 RDG based Leader election for EC object.

9. Optimize DTX resync logic: only handle the DTX entry
   which leader (coordinator) has been changed to from
   the failed one to current daos target.

10. Remove DTX conflict logic that was used for detecting
    and handling incompatible non-committed punch DTX and
    update DTX in DTX module. With incarnation log, it is
    useless any longer.

Signed-off-by: Fan Yong <fan.yong@intel.com>