### PR TITLE
CORCI-843 buid: Skip build and test for doc-only

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -40,7 +40,24 @@
 // I.e. for testing library changes
 //@Library(value="pipeline-lib@your_branch") _
 
-def daos_branch = "master"
+def doc_only_change() {
+    def rc = sh script: 'if [ "' + env.CHANGE_ID + '''" = "null" ]; then
+                              mb_modifier="^"
+                         fi
+                         git diff-tree --no-commit-id --name-only \
+                           $(git merge-base origin/''' + target_branch +
+                      '''$mb_modifier HEAD) HEAD | \
+                           grep -v -e "^doc$"''',
+                returnStatus: true
+
+    return rc == 1
+}
+
+def skip_stage(String stage) {
+    return commitPragma(pragma: 'Skip-' + stage).contains('true')
+}
+
+target_branch = env.CHANGE_TARGET ? env.CHANGE_TARGET : env.BRANCH_NAME
 def arch = ""
 def sanitized_JOB_NAME = JOB_NAME.toLowerCase().replaceAll('/', '-').replaceAll('%2f', '-')
 
@@ -65,10 +82,7 @@ if (quickbuild) {
     functional_rpms += " spdk-tools"
 }
 
-def rpm_test_pre = '''if git show -s --format=%B | grep "^Skip-test: true"; then
-                          exit 0
-                      fi
-                      nodelist=(${NODELIST//,/ })
+def rpm_test_pre = '''nodelist=(${NODELIST//,/ })
                       scp -i ci_key src/tests/ftest/data/daos_server_baseline.yaml \
                                     jenkins@${nodelist[0]}:/tmp
                       scp -i ci_key src/tests/ftest/data/daos_agent_baseline.yaml \
@@ -170,7 +184,7 @@ def rpm_scan_post = '''rm -f ${WORKSPACE}/maldetect.xml
 
 // bail out of branch builds that are not on a whitelist
 if (!env.CHANGE_ID &&
-    (env.BRANCH_NAME != "weekly-testing" &&
+    (!env.BRANCH_NAME.startsWith("weekly-testing") &&
      !env.BRANCH_NAME.startsWith("release/") &&
      env.BRANCH_NAME != "master")) {
    currentBuild.result = 'SUCCESS'
@@ -217,16 +231,17 @@ pipeline {
                 beforeAgent true
                 allOf {
                     not { branch 'weekly-testing' }
-                    expression { env.CHANGE_TARGET != 'weekly-testing' }
+                    not { environment name: 'CHANGE_TARGET', value: 'weekly-testing' }
                 }
             }
             parallel {
                 stage('checkpatch') {
                     when {
-                      beforeAgent true
-                      expression {
-                        ! commitPragma(pragma: 'Skip-checkpatch').contains('true')
-                      }
+                        beforeAgent true
+                        allOf {
+                            expression { ! skip_stage('checkpatch') }
+                            expression { ! doc_only_change() }
+                        }
                     }
                     agent {
                         dockerfile {
@@ -319,8 +334,15 @@ pipeline {
             //failFast true
             when {
                 beforeAgent true
-                // expression { skipTest != true }
-                expression { ! commitPragma(pragma: 'Skip-build').contains('true') }
+                anyOf {
+                    // always build branch landings as we depend on lastSuccessfulBuild
+                    // always having RPMs in it
+                    branch target_branch
+                    allOf {
+                        expression { ! skip_stage('build') }
+                        expression { ! doc_only_change() }
+                    }
+                }
             }
             parallel {
                 stage('Build RPM on CentOS 7') {
@@ -361,7 +383,6 @@ pipeline {
                                                 format: 'yum',
                                                 maturity: 'stable',
                                                 tech: 'el-7',
-                                                publish_branch: daos_branch,
                                                 repo_dir: 'artifacts/centos7/'
                             stepResult name: env.STAGE_NAME, context: "build",
                                        result: "SUCCESS"
@@ -397,7 +418,7 @@ pipeline {
                         beforeAgent true
                         allOf {
                             not { branch 'weekly-testing' }
-                            expression { env.CHANGE_TARGET != 'weekly-testing' }
+                            not { environment name: 'CHANGE_TARGET', value: 'weekly-testing' }
                         }
                     }
                     agent {
@@ -421,9 +442,6 @@ pipeline {
                             sh label: env.STAGE_NAME,
                                script: '''rm -rf artifacts/leap15/
                                   mkdir -p artifacts/leap15/
-                                  if git show -s --format=%B | grep "^Skip-build: true"; then
-                                      exit 0
-                                  fi
                                   make CHROOT_NAME="opensuse-leap-15.1-x86_64" -C utils/rpms chrootbuild'''
                         }
                     }
@@ -441,7 +459,6 @@ pipeline {
                                                 format: 'yum',
                                                 maturity: 'stable',
                                                 tech: 'leap-15',
-                                                publish_branch: daos_branch,
                                                 repo_dir: 'artifacts/leap15/'
                             stepResult name: env.STAGE_NAME, context: "build",
                                        result: "SUCCESS"
@@ -569,7 +586,7 @@ pipeline {
                     when {
                         beforeAgent true
                         allOf {
-                            branch 'master'
+                            branch target_branch
                             expression { quickbuild != 'true' }
                         }
                     }
@@ -630,7 +647,7 @@ pipeline {
                     when {
                         beforeAgent true
                         allOf {
-                            branch 'master'
+                            branch target_branch
                             expression { quickbuild != 'true' }
                         }
                     }
@@ -692,7 +709,7 @@ pipeline {
                         beforeAgent true
                         allOf {
                             not { branch 'weekly-testing' }
-                            expression { env.CHANGE_TARGET != 'weekly-testing' }
+                            not { environment name: 'CHANGE_TARGET', value: 'weekly-testing' }
                             expression { quickbuild != 'true' }
                         }
                     }
@@ -753,7 +770,7 @@ pipeline {
                     when {
                         beforeAgent true
                         allOf {
-                            branch 'master'
+                            branch target_branch
                             expression { quickbuild != 'true' }
                         }
                     }
@@ -814,7 +831,7 @@ pipeline {
                     when {
                         beforeAgent true
                         allOf {
-                            branch 'master'
+                            branch target_branch
                             expression { quickbuild != 'true' }
                         }
                     }
@@ -876,7 +893,7 @@ pipeline {
                         beforeAgent true
                         allOf {
                             not { branch 'weekly-testing' }
-                            expression { env.CHANGE_TARGET != 'weekly-testing' }
+                            not { environment name: 'CHANGE_TARGET', value: 'weekly-testing' }
                             expression { quickbuild != 'true' }
                         }
                     }
@@ -939,17 +956,20 @@ pipeline {
         stage('Unit Test') {
             when {
                 beforeAgent true
-                // expression { skipTest != true }
-                expression { env.NO_CI_TESTING != 'true' }
-                expression { ! commitPragma(pragma: 'Skip-test').contains('true') }
+                allOf {
+                    not { environment name: 'NO_CI_TESTING', value: 'true' }
+                    // nothing to test if build was skipped
+                    expression { ! skip_stage('build') }
+                    // or it's a doc-only change
+                    expression { ! doc_only_change() }
+                    expression { ! skip_stage('test') }
+                }
             }
             parallel {
                 stage('run_test.sh') {
                     when {
                       beforeAgent true
-                      expression {
-                        ! commitPragma(pragma: 'Skip-run_test').contains('true')
-                      }
+                      expression { ! skip_stage('run_test') }
                     }
                     agent {
                         label 'ci_vm1'
@@ -1070,9 +1090,12 @@ pipeline {
             when {
                 beforeAgent true
                 allOf {
-                    // expression { skipTest != true }
-                    expression { env.NO_CI_TESTING != 'true' }
-                    expression { ! commitPragma(pragma: 'Skip-test').contains('true') }
+                    not { environment name: 'NO_CI_TESTING', value: 'true' }
+                    // nothing to test if build was skipped
+                    expression { ! skip_stage('build') }
+                    // or it's a doc-only change
+                    expression { ! doc_only_change() }
+                    expression { ! skip_stage('test') }
                 }
             }
             parallel {
@@ -1130,9 +1153,7 @@ pipeline {
                 stage('Functional') {
                     when {
                         beforeAgent true
-                        expression {
-                            ! commitPragma(pragma: 'Skip-func-test').contains('true')
-                        }
+                        expression { ! skip_stage('func-test') }
                     }
                     agent {
                         label 'ci_vm9'
@@ -1211,13 +1232,9 @@ pipeline {
                     when {
                         beforeAgent true
                         allOf {
-                            expression { env.DAOS_STACK_CI_HARDWARE_SKIP != 'true' }
-                            expression {
-                                ! commitPragma(pragma: 'Skip-func-hw-test').contains('true')
-                            }
-                            expression {
-                                ! commitPragma(pragma: 'Skip-func-hw-test-small').contains('true')
-                            }
+                            not { environment name: 'DAOS_STACK_CI_HARDWARE_SKIP', value: 'true' }
+                            expression { ! skip_stage('func-hw-test') }
+                            expression { ! skip_stage('func-hw-test-small') }
                         }
                     }
                     agent {
@@ -1314,13 +1331,9 @@ pipeline {
                     when {
                         beforeAgent true
                         allOf {
-                            expression { env.DAOS_STACK_CI_HARDWARE_SKIP != 'true' }
-                            expression {
-                                ! commitPragma(pragma: 'Skip-func-hw-test').contains('true')
-                            }
-                            expression {
-                                ! commitPragma(pragma: 'Skip-func-hw-test-medium').contains('true')
-                            }
+                            not { environment name: 'DAOS_STACK_CI_HARDWARE_SKIP', value: 'true' }
+                            expression { ! skip_stage('func-hw-test') }
+                            expression { ! skip_stage('func-hw-test-medium') }
                         }
                     }
                     agent {
@@ -1417,13 +1430,9 @@ pipeline {
                     when {
                         beforeAgent true
                         allOf {
-                            expression { env.DAOS_STACK_CI_HARDWARE_SKIP != 'true' }
-                            expression {
-                                ! commitPragma(pragma: 'Skip-func-hw-test').contains('true')
-                            }
-                            expression {
-                                ! commitPragma(pragma: 'Skip-func-hw-test-large').contains('true')
-                            }
+                            not { environment name: 'DAOS_STACK_CI_HARDWARE_SKIP', value: 'true' }
+                            expression { ! skip_stage('func-hw-test') }
+                            expression { ! skip_stage('func-hw-test-large') }
                         }
                     }
                     agent {
@@ -1521,10 +1530,8 @@ pipeline {
                         beforeAgent true
                         allOf {
                             not { branch 'weekly-testing' }
-                            expression { env.CHANGE_TARGET != 'weekly-testing' }
-                            expression {
-                                ! commitPragma(pragma: 'Skip-test-centos-rpms').contains('true')
-                            }
+                            not { environment name: 'CHANGE_TARGET', value: 'weekly-testing' }
+                            expression { ! skip_stage('test-centos-rpms') }
                         }
                     }
                     agent {
@@ -1604,7 +1611,7 @@ pipeline {
     }
     post {
         unsuccessful {
-            notifyBrokenBranch branches: daos_branch
+            notifyBrokenBranch branches: target_branch
         }
     }
 }


### PR DESCRIPTION
Also skip checkpatch.

A few other enhancements while we're in here:
- Skip-build: true implies Skip-test: true
- make a generic skip() test function
- remove unused/obsoleted inline Skip-* checks
- use Jenkinsfile idoms such as environment instead of expression {
  env.<variable> ... }
- take advantage of env.CHANGE_TARGET instead of hardcoding the target
  into the Jenkinsfile
- don't skip build on landing to branch even if Skip-build: true is in
  the commit message
  - every lastSuccessfulBuild of a branch needs to have build artifacts
    in it

Signed-off-by: Brian J. Murrell <brian.murrell@intel.com>