### PR TITLE
DAOS-3800 common: new DAOS errno DER_RESTART for DTX restart

### DIFF
--- a/src/include/daos_errno.h
+++ b/src/include/daos_errno.h
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2016-2019 Intel Corporation.
+ * (C) Copyright 2016-2020 Intel Corporation.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -92,7 +92,9 @@ extern "C" {
 	/** Incompatible durable format version */			\
 	ACTION(DER_DF_INCOMPT,		(DER_ERR_DAOS_BASE + 23))	\
 	/** Record size error */					\
-	ACTION(DER_REC_SIZE,		(DER_ERR_DAOS_BASE + 24))
+	ACTION(DER_REC_SIZE,		(DER_ERR_DAOS_BASE + 24))	\
+	/** XXX: Use it only when needs to restart the DTX */		\
+	ACTION(DER_RESTART,		(DER_ERR_DAOS_BASE + 25))
 
 #ifdef DAOS_USE_GURT_ERRNO
 	/* When new errno's added above, we need to define them here


### PR DESCRIPTION
Define new DAOS errno DER_RESTART. It is only used for the case
that related DTX needs to be restarted for some reason, such as
conflict with other DTX.

Signed-off-by: Fan Yong <fan.yong@intel.com>