### PR TITLE
DAOS-4569 build: Only build fuse on Ubuntu < 20

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,4 +18,4 @@ berfore_install:
 
 script:
  - docker build -f utils/docker/Dockerfile.$DOCKER_IMAGE -t daos/$DOCKER_IMAGE --build-arg NOBUILD=1 --build-arg UID=$UID .
- - docker run -v $PWD:/home/daos/daos:z daos/$DOCKER_IMAGE /bin/bash -c "scons --build-deps=yes USE_INSTALLED=fuse install"
+ - docker run -v $PWD:/home/daos/daos:z daos/$DOCKER_IMAGE /bin/bash -c "scons --build-deps=yes install"

--- a/doc/admin/installation.md
+++ b/doc/admin/installation.md
@@ -59,9 +59,9 @@ version of at least 1.10 is required.
 An exhaustive list of packages for each supported Linux distribution is
 maintained in the Docker files:
 
--    [CentOS](https://github.com/daos-stack/daos/blob/master/utils/docker/Dockerfile.centos.7#L53-L72)
--    [OpenSUSE](https://github.com/daos-stack/daos/blob/master/utils/docker/Dockerfile.leap.15#L16-L40)
--    [Ubuntu](https://github.com/daos-stack/daos/blob/master/utils/docker/Dockerfile.ubuntu.18.04#L21-L38)
+-    [CentOS](https://github.com/daos-stack/daos/blob/master/utils/docker/Dockerfile.centos.7#L53-L75)
+-    [OpenSUSE](https://github.com/daos-stack/daos/blob/master/utils/docker/Dockerfile.leap.15#L16-L42)
+-    [Ubuntu](https://github.com/daos-stack/daos/blob/master/utils/docker/Dockerfile.ubuntu.18.04#L21-L39)
 
 The command lines to install the required packages can be extracted from
 the Docker files by removing the "RUN" command, which is specific to Docker.

--- a/utils/docker/Dockerfile.centos.7
+++ b/utils/docker/Dockerfile.centos.7
@@ -61,7 +61,7 @@ RUN yum -y install epel-release; \
         pandoc patch python python-devel python36-devel python-magic   \
         python-pep8 python-pygit2 python2-pygithub python-requests     \
         readline-devel scons sg3_utils ShellCheck yasm pciutils        \
-        valgrind-devel python36-pylint man fuse3-devel
+        valgrind-devel python36-pylint man fuse3-devel python-distro
 
 # DAOS specific
 RUN yum -y install \

--- a/utils/docker/Dockerfile.leap.15
+++ b/utils/docker/Dockerfile.leap.15
@@ -28,7 +28,7 @@ RUN zypper --non-interactive --no-gpg-checks refresh; \
            make man meson nasm ninja pandoc patch python2-pip         \
            readline-devel sg3_utils which yasm                        \
            python-devel python3-devel valgrind-devel hwloc-devel      \
-           openmpi3-devel Modules man fuse3-devel python3-distro
+           openmpi3-devel Modules man fuse3-devel python-distro
 
 RUN update-ca-certificates;    \
     pip install --upgrade pip; \

--- a/utils/docker/Dockerfile.leap.15
+++ b/utils/docker/Dockerfile.leap.15
@@ -28,7 +28,7 @@ RUN zypper --non-interactive --no-gpg-checks refresh; \
            make man meson nasm ninja pandoc patch python2-pip         \
            readline-devel sg3_utils which yasm                        \
            python-devel python3-devel valgrind-devel hwloc-devel      \
-           openmpi3-devel Modules man fuse3-devel
+           openmpi3-devel Modules man fuse3-devel python3-distro
 
 RUN update-ca-certificates;    \
     pip install --upgrade pip; \

--- a/utils/docker/Dockerfile.ubuntu.18.04
+++ b/utils/docker/Dockerfile.ubuntu.18.04
@@ -28,7 +28,7 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y \
             libssl-dev libtool-bin libyaml-dev                          \
             locales make meson nasm ninja-build pandoc patch            \
             pylint python-dev python3-dev scons sg3-utils uuid-dev      \
-            yasm valgrind libhwloc-dev man
+            yasm valgrind libhwloc-dev man python-distro
 
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y \
                        software-properties-common &&                    \

--- a/utils/rpms/daos.spec
+++ b/utils/rpms/daos.spec
@@ -5,7 +5,7 @@
 
 Name:          daos
 Version:       0.9.1
-Release:       4%{?relval}%{?dist}
+Release:       5%{?relval}%{?dist}
 Summary:       DAOS Storage Engine
 
 License:       Apache
@@ -48,6 +48,7 @@ BuildRequires: CUnit-devel
 BuildRequires: golang-bin >= 1.12
 BuildRequires: libipmctl-devel
 BuildRequires: python-devel python36-devel
+BuildRequires: python-distro
 %else
 %if (0%{?suse_version} >= 1315)
 # see src/client/dfs/SConscript for why we need /etc/os-release
@@ -60,6 +61,7 @@ BuildRequires: go >= 1.12
 BuildRequires: ipmctl-devel
 BuildRequires: python-devel python3-devel
 BuildRequires: Modules
+BuildRequires: python3-distro
 %if 0%{?is_opensuse}
 # have choice for boost-devel needed by cart-devel: boost-devel boost_1_58_0-devel
 BuildRequires: boost-devel
@@ -315,6 +317,9 @@ getent group daos_admins >/dev/null || groupadd -r daos_admins
 %{_libdir}/*.a
 
 %changelog
+* Wed Apr 15 2020 Brian J. Murrell <brian.murrell@intel.com> - 0.9.1-5
+- Add BR: python-distro for scons_local
+
 * Sun Apr 11 2020 Brian J. Murrell <brian.murrell@intel.com> - 0.9.1-4
 - Use distro versions of fuse and fio
 - Use CaRT release 4.6.1


### PR DESCRIPTION

Since EL7 and Leap/SLES 15 have fuse3 in them, require fuse3-devel be
installed on those platforms.

Signed-off-by: Brian J. Murrell <brian.murrell@intel.com>