### PR TITLE
DAOS-3128 tests: soak enhancements

### DIFF
--- a/src/tests/ftest/soak/soak.yaml
+++ b/src/tests/ftest/soak/soak.yaml
@@ -16,7 +16,7 @@ srun:
 srun_params:
     reservation:
 # This timeout must be longer than the test_timeout param (+15minutes)
-# 2 hour test
+# 2 hour test = time in seconds
 timeout: 8000
 logdir: /tmp/soak
 server_config:
@@ -43,17 +43,20 @@ pool_ior:
     scm_size: 40000000000
     nvme_size: 100000000000
     svcn: 1
+    control_method: dmg
 pool_fio:
     mode: 146
     name: daos_server
     scm_size: 40000000000
     nvme_size: 100000000000
     svcn: 1
+    control_method: dmg
 pool_reserved:
     mode: 511
     name: daos_server
     scm_size: 3000000000
     nvme_size: 50000000000
+    control_method: dmg
 container_reserved:
     akey_size: 5
     dkey_size: 5
@@ -65,8 +68,7 @@ container_reserved:
 # test_params - Defines the type of test to run and how long it runs
 #               It also defines how many pools and jobs to create
 #               name:                The name of the Avocado testcase
-#               test_timeout:        The overall timeout in secs; soak12 will be
-#                                    changed to 43200 once it is stable
+#               test_timeout:        The overall timeout in hours
 #               test_iteration:      values 1 or -1; -1 is used to cause the
 #                                    IOR -T x to end cmd.  i = 100000000
 #                                    (does not seem to work)
@@ -78,10 +80,11 @@ container_reserved:
 # smoke test_params
 smoke:
     name: soak_smoke
-    test_timeout: 1200
+    # smoke test timeout in hours
+    test_timeout: 0.3
     # maximum timeout for a single job in test in minutes
     job_timeout: 10
-    nodesperjob: 1
+    nodesperjob: -1
     taskspernode:
         - 1
     poollist:
@@ -91,10 +94,10 @@ smoke:
         - ior_smoke
         - fio_smoke
 # SOAK stress test params
-# Test will run for 120 minutes
 soak_stress:
     name: soak_stress
-    test_timeout: 7200
+    # stress test timeout in hours
+    test_timeout: 2
     # maximum timeout for a single job in test in minutes
     job_timeout: 20
     nodesperjob: -1
@@ -113,7 +116,8 @@ soak_stress:
       #- dfs
 soak_harassers:
     name: soak_harassers
-    test_timeout: 3600
+    # harasser test timeout in hours
+    test_timeout: 1
     harasser_timeout: 120
     # maximum timeout for a single job in test in minutes
     job_timeout: 20
@@ -189,8 +193,8 @@ ior_stress:
         - '512K'
         - '64k'
     daos_oclass:
-          - "SX"
-        # - "RP_2GX"
+        # - "SX"
+        - "RP_2GX"
         # - "RP_3GX"
         # - "RP_4GX"
 fio_stress:
@@ -206,10 +210,10 @@ fio_stress:
     verify: 'crc64'
     iodepth: 16
   test:
-    numjobs: 5
+    numjobs: 16
   soak:
     blocksize:
-        - '256B'
+        - '64K'
         - '1M'
     size:
         - '500M'
@@ -226,7 +230,7 @@ rebuild:
     svcl: 1
     daos_oclass:
         - "RP_2GX"
-        # - "RP_2GX"
+        # - "RP_3GX"
         # - "RP_2G1"
         # - "RP_3G1"
 dmg_create_destroy:

--- a/src/tests/ftest/util/apricot/apricot/test.py
+++ b/src/tests/ftest/util/apricot/apricot/test.py
@@ -116,6 +116,7 @@ class Test(avocadoTest):
         self.fault_file = None
         self.debug = False
         self.config = None
+        self.local_errors = []
 
     # pylint: disable=invalid-name
     def cancelForTicket(self, ticket):
@@ -296,8 +297,12 @@ class TestWithServers(TestWithoutServers):
 
     def tearDown(self):
         """Tear down after each test case."""
+        # Include test errors so that failure report includes these errors
+        # at the end of the test for ease of debug
+        errors = self.local_errors
+
         # Destroy any containers first
-        errors = self.destroy_containers(self.container)
+        errors.extend(self.destroy_containers(self.container))
 
         # Destroy any pools next
         errors.extend(self.destroy_pools(self.pool))

--- a/src/tests/ftest/util/slurm_utils.py
+++ b/src/tests/ftest/util/slurm_utils.py
@@ -120,6 +120,8 @@ def write_slurm_script(path, name, output, nodecount, cmds, sbatch=None):
             script_file.write("#SBATCH --output={}\n".format(output))
         if sbatch:
             for key, value in sbatch.items():
+                if key == "error":
+                    value = value + str(unique)
                 script_file.write("#SBATCH --{}={}\n".format(key, value))
         script_file.write("\n")
 
@@ -204,7 +206,7 @@ def watch_job(handle, maxwait, test_obj):
     wait_time = 0
     while True:
         state = check_slurm_job(handle)
-        if state == "PENDING" or state == "RUNNING" or state == "COMPLETING":
+        if state in ("PENDING", "RUNNING", "COMPLETING"):
             if wait_time > maxwait:
                 state = "MAXWAITREACHED"
                 print("Job {} has timedout after {} secs".format(handle,


### PR DESCRIPTION
Test-tag-hw-large: pr,hw,large soak_smoke

This is needed on 0.9 in order to cherry-pick
DAOS-2257

Updates:
1) create separate logs for failed jobs
2) enable dmg for pool create/destroy
3) enable soak to continue on error
4) change time format to allow hours in yaml

Signed-off-by: Maureen Jean <maureen.jean@intel.com>