### PR TITLE
DAOS-4557 iosrv: Load modules from relative path daos_srv

### DIFF
--- a/src/iosrv/module.c
+++ b/src/iosrv/module.c
@@ -99,7 +99,7 @@ dss_module_load(const char *modname, uint64_t *mod_facs)
 	}
 
 	/* load the dynamic library */
-	sprintf(name, "lib%s.so", modname);
+	sprintf(name, "daos_srv/lib%s.so", modname);
 	handle = dlopen(name, RTLD_LAZY | RTLD_GLOBAL);
 	if (handle == NULL) {
 		D_ERROR("cannot load %s: %s\n", name, dlerror());


### PR DESCRIPTION
Ideally, we would not have any direct dependencies on
daos_srv modules and could avoid adding it to the RPATH
but for now just change module load to load from relative
path daos_srv/lib[name].so

Signed-off-by: Jeff Olivier <jeffrey.v.olivier@intel.com>