### PR TITLE
DAOS-4557 iosrv: Split dlopen from initialization for modules

### DIFF
--- a/src/iosrv/srv_internal.h
+++ b/src/iosrv/srv_internal.h
@@ -97,8 +97,8 @@ extern bool		dss_helper_pool;
 /* module.c */
 int dss_module_init(void);
 int dss_module_fini(bool force);
-int dss_module_load(const char *modname, void *arg);
-int dss_module_load_init(const char *modname, void *arg);
+int dss_module_load(const char *modname);
+int dss_module_init_all(uint64_t *mod_fac);
 int dss_module_unload(const char *modname);
 void dss_module_unload_all(void);
 int dss_module_setup_all(void);

--- a/src/iosrv/srv_internal.h
+++ b/src/iosrv/srv_internal.h
@@ -97,7 +97,8 @@ extern bool		dss_helper_pool;
 /* module.c */
 int dss_module_init(void);
 int dss_module_fini(bool force);
-int dss_module_load(const char *modname, uint64_t *mod_facs);
+int dss_module_load(const char *modname, void *arg);
+int dss_module_load_init(const char *modname, void *arg);
 int dss_module_unload(const char *modname);
 void dss_module_unload_all(void);
 int dss_module_setup_all(void);


### PR DESCRIPTION
We run into rpath problems on some platforms if dlopen is
first called from libfabric.   If we load our modules before
initializing cart, we can avoid this problem.  To do that,
this splits the load function so we call dlopen before
cart init and module init after.

Signed-off-by: Jeff Olivier <jeffrey.v.olivier@intel.com>