### PR TITLE
DAOS-4354 test: Disable daos_test IO38: Force capability IV fetch (#2…

### DIFF
--- a/src/tests/suite/daos_obj.c
+++ b/src/tests/suite/daos_obj.c
@@ -3603,6 +3603,15 @@ io_capa_iv_fetch(void **state)
 	struct ioreq	req;
 	d_rank_t	leader;
 
+	/*
+	 * Currently causing "Failed to destroy container" error resulting from
+	 * an additional container open from DAOS_FORCE_CAPA_FETCH w/o
+	 * corresponding container close.
+	 * FIXME: DAOS-4560 - Fix binding of container open w/ cont capa IV
+	 * refresh
+	 */
+	skip();
+
 	/* needs at lest 2 targets */
 	if (!test_runable(arg, 2))
 		skip();


### PR DESCRIPTION
…426)

IO38: Force Capability IV Fetch is currently resulting in a "Failed to destroy
container" error when running daos I/O tests. This patch will temporarily
disable this test for CI until DAOS-4560 is resolved. DAOS-4560 will address the
additional container open resulting from a force container capa IV refresh,
without corresponding container close.

Signed-off-by: Sydney Vanda <sydney.m.vanda@intel.com>