### PR TITLE
CART-877 swim: disable SWIM for DAOS server

### DIFF
--- a/src/iosrv/init.c
+++ b/src/iosrv/init.c
@@ -528,7 +528,7 @@ server_init(int argc, char *argv[])
 
 	/* initialize the network layer */
 	rc = crt_init_opt(daos_sysname,
-			  CRT_FLAG_BIT_SERVER,
+			  CRT_FLAG_BIT_SERVER | CRT_FLAG_BIT_AUTO_SWIM_DISABLE,
 			  daos_crt_init_opt_get(true, DSS_CTX_NR_TOTAL));
 	if (rc)
 		D_GOTO(exit_mod_init, rc);


### PR DESCRIPTION
Since in commit 680b09aa2 it disabled SWIM upcall, it make SWIM
no effect. This patch further disables SWIM, as in IOR test we still
can see such err logs -
swim ERR  src/swim/swim.c:739 swim_progress() SWIM shutdown.
So disables it for 1.0, but keep it enabled for master branch.

Signed-off-by: Xuezhao Liu <xuezhao.liu@intel.com>