### PR TITLE
DAOS-1449 object: daos_obj_fetch iod null causes segfault (#2221)

### DIFF
--- a/src/object/cli_obj.c
+++ b/src/object/cli_obj.c
@@ -1424,6 +1424,9 @@ obj_iod_sgl_valid(unsigned int nr, daos_iod_t *iods, d_sg_list_t *sgls,
 	int	i;
 	int	rc;
 
+	if (iods == NULL)
+		return -DER_INVAL;
+
 	for (i = 0; i < nr; i++) {
 		if (iods[i].iod_name.iov_buf == NULL)
 			/* XXX checksum & eprs should not be mandatory */


### PR DESCRIPTION
* DAOS-1449 client: daos_obj_fetch iod=null causes segfault

Check input parameter and return error if IOD is NULL

Change-Id: Ibfdc78fa82710dd3cb0d560e40801e30c682d729
Signed-off-by: Hua Kuang <hua.kuang@intel.com>