### PR TITLE
DAOS-4569 build: Install python36-distro

### DIFF
--- a/utils/docker/Dockerfile.centos.7
+++ b/utils/docker/Dockerfile.centos.7
@@ -61,7 +61,7 @@ RUN yum -y install epel-release; \
         pandoc patch python python-devel python36-devel python-magic   \
         python-pep8 python-pygit2 python2-pygithub python-requests     \
         readline-devel scons sg3_utils ShellCheck yasm pciutils        \
-        valgrind-devel python36-pylint man fuse3-devel python-distro
+        valgrind-devel python36-pylint man
 
 # DAOS specific
 RUN yum -y install \
@@ -71,8 +71,9 @@ RUN yum -y install \
            ndctl ipmctl e2fsprogs                              \
            python2-clustershell python2-Cython python2-pip     \
            python36-clustershell python36-paramiko             \
-           python36-numpy python36-jira python3-pip;           \
-    yum -y install libipmctl-devel openmpi3-devel hwloc-devel
+           python36-numpy python36-jira python3-pip            \
+           fuse3-devel python{36,}-distro                      \
+           libipmctl-devel openmpi3-devel hwloc-devel
 
 # DAOS python 3 packages required for pylint
 #  - excluding mpi4py as it depends on CORCI-635


### PR DESCRIPTION
For linting at least, but also in case anyone is using scons-3 even
though we are only using scons-2 ourselves.

Signed-off-by: Brian J. Murrell <brian.murrell@intel.com>
Skip-test: true