### PR TITLE
DAOS-2257 tests: enabled fault injection with soak (#2395)

### DIFF
--- a/src/tests/ftest/soak/soak_faults.py
+++ b/src/tests/ftest/soak/soak_faults.py
@@ -1,0 +1,47 @@
+#!/usr/bin/python
+"""
+(C) Copyright 2018-2019 Intel Corporation.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+GOVERNMENT LICENSE RIGHTS-OPEN SOURCE SOFTWARE
+The Government's rights to use, modify, reproduce, release, perform, display,
+or disclose this software are subject to the terms of the Apache License as
+provided in Contract No. B609815.
+Any reproduction of computer software, computer software documentation, or
+portions thereof marked with this legend must also reproduce the markings.
+"""
+
+from soak import SoakTestBase
+
+
+class SoakFaultInject(SoakTestBase):
+    # pylint: disable=too-many-ancestors
+    """Test class Description: Runs soak with fault injectors.
+
+    :avocado: recursive
+    """
+
+    def test_soak_faults(self):
+        """Run all soak tests with fault injectors.
+
+        Test ID: DAOS-2511
+        Test Description: This will create a soak job that runs
+        various fault injectors  defined in the soak yaml
+        This test will run for the time specified by test_timeout in
+        the soak_faults config file.
+
+        :avocado: tags=soak,soak_faults
+        """
+        test_param = "/run/soak_faults/"
+        self.run_soak(test_param)

--- a/src/tests/ftest/soak/soak_faults.yaml
+++ b/src/tests/ftest/soak/soak_faults.yaml
@@ -1,0 +1,123 @@
+hosts:
+# servers if no server partition is defined
+    test_servers:
+        - server-A
+        - server-B
+        - server-C
+        - server-D
+# servers if a server partition is defined
+    # server_partition: daos_server
+    client_partition: daos_client
+orterun:
+    allow_run_as_root: True
+# include Cluster specific slurm params
+srun:
+    reservation:
+srun_params:
+    reservation:
+# This timeout must be longer than the test_timeout param (+15minutes)
+# 1 hour test
+timeout: 1H15M
+logdir: /tmp/soak
+server_config:
+    name: daos_server
+    provider: ofi+sockets
+    control_log_mask: INFO
+    control_log_file: /tmp/daos_control0.log
+    servers:
+        log_mask: INFO
+        fabric_iface: ib0
+        fabric_iface_port: 31416
+        log_file: /tmp/daos_io0.log
+        # Storage definitions for AEP and NVMe
+        scm_mount: /mnt/daos0
+        scm_class: dcpm
+        scm_list: [/dev/pmem0]
+        bdev_class: nvme
+        bdev_list: ["0000:81:00.0","0000:da:00.0"]
+# pool_params - attributes of the pools to create; Currently only create one
+pool_ior:
+    mode: 146
+    name: daos_server
+    scm_size: 40000000000
+    nvme_size: 100000000000
+    svcn: 1
+    control_method: dmg
+pool_reserved:
+    mode: 511
+    name: daos_server
+    scm_size: 3000000000
+    nvme_size: 50000000000
+    control_method: dmg
+container_reserved:
+    akey_size: 5
+    dkey_size: 5
+    data_size: 4096
+    object_qty: 20
+    record_qty: 1
+    record_size: 100
+    array_size: 1
+faults:
+    fault_list:
+    #    - DAOS_DTX_LOST_RPC_REQUEST
+    #    - DAOS_DTX_LOST_RPC_REPLY
+    #    - DAOS_DTX_LONG_TIME_RESEND
+       - DAOS_SHARD_OBJ_UPDATE_TIMEOUT
+    #    - DAOS_SHARD_OBJ_FETCH_TIMEOUT
+    #    - DAOS_SHARD_OBJ_FAIL
+    #    - DAOS_OBJ_UPDATE_NOSPACE
+    #    - DAOS_SHARD_OBJ_RW_CRT_ERROR
+    #    - DAOS_OBJ_REQ_CREATE_TIMEOUT
+    #    - DAOS_SHARD_OBJ_UPDATE_TIMEOUT_SINGLE
+    #    - DAOS_OBJ_SPECIAL_SHARD
+    #    - DAOS_OBJ_TGT_IDX_CHANGE
+
+# test_params - Defines the type of test to run and how long it runs
+#               It also defines how many pools and jobs to create
+#               name:                The name of the Avocado testcase
+#               test_timeout:        The overall timeout in hours
+#               test_iteration:      values 1 or -1; -1 is used to cause the
+#                                    IOR -T x to end cmd.  i = 100000000
+#                                    (does not seem to work)
+#               nodesperjob:         slurm -N param; -1 indicates all nodes
+#                                    in -partition
+#               poollist:            defines pools to create for jobs
+#               joblist:             defines workload per slurm scripts
+#               harasserlist:        defines the harassers to run in test
+soak_faults:
+    name: soak_faults
+    # harasser test timeout in hours
+    test_timeout: 1
+    # maximum timeout for a single job in test in minutes
+    job_timeout: 20
+    nodesperjob:
+        - -1
+    # used for perfomance benchmarks
+    taskspernode:
+        - 16
+    poollist:
+        - pool_ior
+    joblist:
+        - ior_faults
+# Commandline parameters
+# Benchmark and application params
+# IOR params -a DAOS and -a MPIIO
+# sequential
+ior_faults:
+    api:
+        - DAOS
+        - MPIIO
+    test_file: daos:testFile
+    flags: -v -w -W -r -R -q
+    block_size:
+        - '64M'
+    repetitions: 1
+    transfer_size:
+        - '4k'
+        - '128k'
+        - '1m'
+    segment_count: 1
+    daos_oclass:
+        - 'SX'
+
+

--- a/src/tests/ftest/soak/soak_harassers.py
+++ b/src/tests/ftest/soak/soak_harassers.py
@@ -1,0 +1,47 @@
+#!/usr/bin/python
+"""
+(C) Copyright 2018-2019 Intel Corporation.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+GOVERNMENT LICENSE RIGHTS-OPEN SOURCE SOFTWARE
+The Government's rights to use, modify, reproduce, release, perform, display,
+or disclose this software are subject to the terms of the Apache License as
+provided in Contract No. B609815.
+Any reproduction of computer software, computer software documentation, or
+portions thereof marked with this legend must also reproduce the markings.
+"""
+
+from soak import SoakTestBase
+
+
+class SoakHarassers(SoakTestBase):
+    # pylint: disable=too-many-ancestors
+    """Test class Description: Runs soak with harassers.
+
+    :avocado: recursive
+    """
+
+    def test_soak_harassers(self):
+        """Run all soak tests with harassers.
+
+        Test ID: DAOS-2511
+        Test Description: This will create a soak job that runs
+        various harassers  defined in the soak yaml
+        This test will run for the time specififed in
+        /run/test_timeout.
+
+        :avocado: tags=soak,soak_harassers
+        """
+        test_param = "/run/soak_harassers/"
+        self.run_soak(test_param)

--- a/src/tests/ftest/soak/soak_harassers.yaml
+++ b/src/tests/ftest/soak/soak_harassers.yaml
@@ -1,0 +1,126 @@
+hosts:
+# servers if no server partition is defined
+    test_servers:
+        - server-A
+        - server-B
+        - server-C
+        - server-D
+# servers if a server partition is defined
+    # server_partition: daos_server
+    client_partition: daos_client
+orterun:
+    allow_run_as_root: True
+# include Cluster specific slurm params
+srun:
+    reservation:
+srun_params:
+    reservation:
+# This timeout must be longer than the test_timeout param (+15minutes)
+# 1 hour test
+timeout: 1H15M
+logdir: /tmp/soak
+server_config:
+    name: daos_server
+    provider: ofi+sockets
+    control_log_mask: INFO
+    control_log_file: /tmp/daos_control0.log
+    servers:
+        log_mask: ERR
+        fabric_iface: ib0
+        fabric_iface_port: 31416
+        log_mask: ERR
+        log_file: /tmp/daos_io0.log
+        # Storage definitions for AEP and NVMe
+        scm_mount: /mnt/daos0
+        scm_class: dcpm
+        scm_list: [/dev/pmem0]
+        bdev_class: nvme
+        bdev_list: ["0000:81:00.0","0000:da:00.0"]
+# pool_params - attributes of the pools to create; Currently only create one
+pool_ior:
+    mode: 146
+    name: daos_server
+    scm_size: 40000000000
+    nvme_size: 100000000000
+    svcn: 1
+    control_method: dmg
+pool_reserved:
+    mode: 511
+    name: daos_server
+    scm_size: 3000000000
+    nvme_size: 50000000000
+    control_method: dmg
+container_reserved:
+    akey_size: 5
+    dkey_size: 5
+    data_size: 4096
+    object_qty: 20
+    record_qty: 1
+    record_size: 100
+    array_size: 1
+# test_params - Defines the type of test to run and how long it runs
+#               It also defines how many pools and jobs to create
+#               name:                The name of the Avocado testcase
+#               test_timeout:        The overall timeout in hours
+#               test_iteration:      values 1 or -1; -1 is used to cause the
+#                                    IOR -T x to end cmd.  i = 100000000
+#                                    (does not seem to work)
+#               nodesperjob:         slurm -N param; -1 indicates all nodes
+#                                    in -partition
+#               poollist:            defines pools to create for jobs
+#               joblist:             defines workload per slurm scripts
+#               harasserlist:        defines the harassers to run in test
+soak_harassers:
+    name: soak_harassers
+    # harasser test timeout in hours
+    test_timeout: 1
+    harasser_timeout: 120
+    # maximum timeout for a single job in test in minutes
+    job_timeout: 10
+    nodesperjob:
+        - -1
+    # used for perfomance benchmarks
+    taskspernode:
+        - 16
+    poollist:
+        - pool_ior
+    joblist:
+        - ior_harasser
+    harasserlist:
+        - snapshot
+        #- rebuild
+# Commandline parameters
+# Benchmark and application params
+# IOR params -a DAOS and -a MPIIO
+# sequential
+ior_harasser:
+    api:
+        - DAOS
+        - MPIIO
+    test_file: daos:testFile
+    flags: -v -w -W -r -R -q
+    block_size:
+        - '64M'
+    repetitions: 1
+    transfer_size:
+        - '4k'
+        - '128k'
+        - '1m'
+    segment_count: 1
+    daos_oclass:
+        - 'SX'
+rebuild:
+    rebuild_timeout: 30
+    ranks_to_kill:
+        - 2
+    svcl: 1
+    daos_oclass:
+        - "RP_2GX"
+dmg_create_destroy:
+    size:
+      - 8M
+      - 16M
+      - 64M
+      - 512M
+      - 1G
+      - 30G

--- a/src/tests/ftest/soak/soak_smoke.py
+++ b/src/tests/ftest/soak/soak_smoke.py
@@ -1,0 +1,47 @@
+#!/usr/bin/python
+"""
+(C) Copyright 2018-2019 Intel Corporation.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+GOVERNMENT LICENSE RIGHTS-OPEN SOURCE SOFTWARE
+The Government's rights to use, modify, reproduce, release, perform, display,
+or disclose this software are subject to the terms of the Apache License as
+provided in Contract No. B609815.
+Any reproduction of computer software, computer software documentation, or
+portions thereof marked with this legend must also reproduce the markings.
+"""
+
+from soak import SoakTestBase
+
+
+class SoakSmoke(SoakTestBase):
+    # pylint: disable=too-many-ancestors
+    """Test class Description: Runs soak smoke.
+
+    :avocado: recursive
+    """
+
+    def test_soak_smoke(self):
+        """Run soak smoke.
+
+        Test ID: DAOS-2192
+
+        Test Description:  This will create a slurm batch job that runs
+        various jobs defined in the soak yaml.  It will run for no more than
+        20 min
+
+        :avocado: tags=soak_smoke
+        """
+        test_param = "/run/smoke/"
+        self.run_soak(test_param)

--- a/src/tests/ftest/soak/soak_smoke.yaml
+++ b/src/tests/ftest/soak/soak_smoke.yaml
@@ -1,0 +1,141 @@
+hosts:
+# servers if no server partition is defined
+    test_servers:
+        - server-A
+        - server-B
+        - server-C
+        - server-D
+# servers if a server partition is defined
+    # server_partition: daos_server
+    client_partition: daos_client
+orterun:
+    allow_run_as_root: True
+# include Cluster specific slurm params
+srun:
+    reservation:
+srun_params:
+    reservation:
+# This timeout must be longer than the test_timeout param (+15minutes)
+# 24 Min test
+timeout: 30M
+logdir: /tmp/soak
+server_config:
+    name: daos_server
+    provider: ofi+sockets
+    control_log_mask: INFO
+    control_log_file: /tmp/daos_control0.log
+    servers:
+        log_mask: ERR
+        fabric_iface: ib0
+        fabric_iface_port: 31416
+        log_mask: ERR
+        log_file: /tmp/daos_io0.log
+        # Storage definitions for AEP and NVMe
+        scm_mount: /mnt/daos0
+        scm_class: dcpm
+        scm_list: [/dev/pmem0]
+        bdev_class: nvme
+        bdev_list: ["0000:81:00.0","0000:da:00.0"]
+# pool_params - attributes of the pools to create; Currently only create one
+pool_ior:
+    mode: 146
+    name: daos_server
+    scm_size: 40000000000
+    nvme_size: 100000000000
+    svcn: 1
+    control_method: dmg
+pool_fio:
+    mode: 146
+    name: daos_server
+    scm_size: 40000000000
+    nvme_size: 100000000000
+    svcn: 1
+    control_method: dmg
+pool_reserved:
+    mode: 511
+    name: daos_server
+    scm_size: 3000000000
+    nvme_size: 50000000000
+    control_method: dmg
+container_reserved:
+    akey_size: 5
+    dkey_size: 5
+    data_size: 4096
+    object_qty: 20
+    record_qty: 1
+    record_size: 100
+    array_size: 1
+# test_params - Defines the type of test to run and how long it runs
+#               It also defines how many pools and jobs to create
+#               name:                The name of the Avocado testcase
+#               test_timeout:        The overall timeout in hours
+#               test_iteration:      values 1 or -1; -1 is used to cause the
+#                                    IOR -T x to end cmd.  i = 100000000
+#                                    (does not seem to work)
+#               nodesperjob:         slurm -N param; -1 indicates all nodes
+#                                    in -partition
+#               poollist:            defines pools to create for jobs
+#               joblist:             defines workload per slurm scripts
+#               harasserlist:        defines the harassers to run in test
+# smoke test_params
+smoke:
+    name: soak_smoke
+    # smoke test timeout in hours
+    test_timeout: 0.4
+    # maximum timeout for a single job in test in minutes
+    job_timeout: 10
+    nodesperjob:
+        - -1
+    taskspernode:
+        - 1
+    poollist:
+        - pool_ior
+        - pool_fio
+    joblist:
+        - ior_smoke
+        - fio_smoke
+# Commandline parameters
+# Benchmark and application params
+# IOR params -a DAOS and -a MPIIO
+# sequential
+ior_smoke:
+    api:
+        - DAOS
+        - MPIIO
+    test_file: daos:testFile
+    flags: -v -w -W -r -R -q
+    block_size:
+        - '64M'
+    repetitions: 1
+    transfer_size:
+        - '4k'
+        - '128k'
+        - '1m'
+    segment_count: 1
+    daos_oclass:
+        - 'SX'
+fio_smoke:
+  names:
+      - global
+      - test
+  global:
+    directory: "/tmp/daos_dfuse"
+    ioengine: 'libaio'
+    thread: 1
+    group_reporting: 1
+    direct: 1
+    verify: 'crc64'
+    iodepth: 16
+  test:
+    numjobs: 1
+  soak:
+    blocksize:
+        - '1M'
+    size:
+        - '1G'
+    rw:
+        - 'rw'
+        - 'randrw'
+dfuse:
+  mount_dir: "/tmp/daos_dfuse"
+

--- a/src/tests/ftest/soak/soak_stress_2h.py
+++ b/src/tests/ftest/soak/soak_stress_2h.py
@@ -1,0 +1,47 @@
+#!/usr/bin/python
+"""
+(C) Copyright 2018-2019 Intel Corporation.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+GOVERNMENT LICENSE RIGHTS-OPEN SOURCE SOFTWARE
+The Government's rights to use, modify, reproduce, release, perform, display,
+or disclose this software are subject to the terms of the Apache License as
+provided in Contract No. B609815.
+Any reproduction of computer software, computer software documentation, or
+portions thereof marked with this legend must also reproduce the markings.
+"""
+
+from soak import SoakTestBase
+
+
+class SoakStress(SoakTestBase):
+    # pylint: disable=too-many-ancestors
+    """Test class Description: Runs soak smoke.
+
+    :avocado: recursive
+    """
+
+    def test_soak_stress(self):
+        """Run all soak tests .
+
+        Test ID: DAOS-2256
+        Test ID: DAOS-2509
+        Test Description: This will create a slurm batch job that runs
+        various jobs defined in the soak yaml
+        This test will run soak_stress for 2 hours.
+
+        :avocado: tags=soak,soak_stress_2h
+        """
+        test_param = "/run/soak_stress/"
+        self.run_soak(test_param)

--- a/src/tests/ftest/soak/soak_stress_2h.yaml
+++ b/src/tests/ftest/soak/soak_stress_2h.yaml
@@ -1,0 +1,148 @@
+hosts:
+# servers if no server partition is defined
+    test_servers:
+        - server-A
+        - server-B
+        - server-C
+        - server-D
+# servers if a server partition is defined
+    # server_partition: daos_server
+    client_partition: daos_client
+orterun:
+    allow_run_as_root: True
+# include Cluster specific slurm params
+srun:
+    reservation:
+srun_params:
+    reservation:
+# This timeout must be longer than the test_timeout param (+15minutes)
+# 2 hour test
+timeout: 2H15M
+logdir: /tmp/soak
+server_config:
+    name: daos_server
+    provider: ofi+sockets
+    control_log_mask: INFO
+    control_log_file: /tmp/daos_control0.log
+    servers:
+        log_mask: ERR
+        fabric_iface: ib0
+        fabric_iface_port: 31416
+        log_mask: ERR
+        log_file: /tmp/daos_io0.log
+        # Storage definitions for AEP and NVMe
+        scm_mount: /mnt/daos0
+        scm_class: dcpm
+        scm_list: [/dev/pmem0]
+        bdev_class: nvme
+        bdev_list: ["0000:81:00.0","0000:da:00.0"]
+# pool_params - attributes of the pools to create; Currently only create one
+pool_ior:
+    mode: 146
+    name: daos_server
+    scm_size: 40000000000
+    nvme_size: 100000000000
+    svcn: 1
+    control_method: dmg
+pool_fio:
+    mode: 146
+    name: daos_server
+    scm_size: 40000000000
+    nvme_size: 100000000000
+    svcn: 1
+    control_method: dmg
+pool_reserved:
+    mode: 511
+    name: daos_server
+    scm_size: 3000000000
+    nvme_size: 50000000000
+    control_method: dmg
+container_reserved:
+    akey_size: 5
+    dkey_size: 5
+    data_size: 4096
+    object_qty: 20
+    record_qty: 1
+    record_size: 100
+    array_size: 1
+# test_params - Defines the type of test to run and how long it runs
+#               It also defines how many pools and jobs to create
+#               name:                The name of the Avocado testcase
+#               test_timeout:        The overall timeout in hours
+#               test_iteration:      values 1 or -1; -1 is used to cause the
+#                                    IOR -T x to end cmd.  i = 100000000
+#                                    (does not seem to work)
+#               nodesperjob:         slurm -N param; -1 indicates all nodes
+#                                    in -partition
+#               poollist:            defines pools to create for jobs
+#               joblist:             defines workload per slurm scripts
+#               harasserlist:        defines the harassers to run in test
+soak_stress:
+    name: soak_stress
+    # stress test timeout in hours
+    test_timeout: 2
+    # maximum timeout for a single job in test in minutes
+    job_timeout: 20
+    nodesperjob:
+        - -1
+    # used for perfomance benchmarks
+    taskspernode:
+        - 1
+        - 16
+        - 32
+    poollist:
+        - pool_ior
+        - pool_fio
+    joblist:
+        - ior_stress
+        - fio_stress
+# Commandline parameters
+# Benchmark and application params
+# IOR params -a DAOS and -a MPIIO
+# sequential
+ior_stress:
+    api:
+        - DAOS
+        - MPIIO
+    test_file: daos:testFile
+    flags: -v -w -W -r -R -q
+    block_size:
+        - '64M'
+        - '4M'
+        - '32M'
+    repetitions: 5
+    transfer_size:
+        - '4k'
+        - '128k'
+        - '1m'
+        - '512K'
+        - '64k'
+    daos_oclass:
+        - "SX"
+fio_stress:
+  names:
+    - global
+    - test
+  global:
+    directory: "/tmp/daos_dfuse"
+    ioengine: 'libaio'
+    thread: 1
+    group_reporting: 1
+    direct: 1
+    verify: 'crc64'
+    iodepth: 16
+  test:
+    numjobs: 16
+  soak:
+    blocksize:
+        - '64K'
+        - '1M'
+    size:
+        - '500M'
+        - '1G'
+    rw:
+        - 'rw'
+        - 'randrw'
+dfuse:
+  mount_dir: "/tmp/daos_dfuse"
+

--- a/src/tests/ftest/util/apricot/apricot/test.py
+++ b/src/tests/ftest/util/apricot/apricot/test.py
@@ -182,7 +182,7 @@ class TestWithoutServers(Test):
             os.makedirs(self.tmp)
 
         # setup fault injection, this MUST be before API setup
-        fault_list = self.params.get("fault_list", '/run/faults/*/')
+        fault_list = self.params.get("fault_list", '/run/faults/*')
         if fault_list:
             # not using workdir because the huge path was messing up
             # orterun or something, could re-evaluate this later
@@ -484,6 +484,11 @@ class TestWithServers(TestWithoutServers):
                         self.server_managers[-1].runner.export.value = []
                     self.server_managers[-1].runner.export.value.extend(
                         ["PATH"])
+                if os.getenv("D_FI_CONFIG") is not None:
+                    if self.server_managers[-1].runner.export.value is None:
+                        self.server_managers[-1].runner.export.value = []
+                    self.server_managers[-1].runner.export.value.extend(
+                        ["D_FI_CONFIG"])
                 load_mpi("orterun")
                 yamlfile = os.path.join(self.tmp, "daos_avocado_test.yaml")
 

--- a/src/tests/ftest/util/fault_config_utils.py
+++ b/src/tests/ftest/util/fault_config_utils.py
@@ -28,26 +28,90 @@ import yaml
 
 # a lookup table of predefined faults
 FAULTS = {
-    # this causes an object update to time out 17 times after
-    # which it will start succeeding
-    'obj_update_timeout': {
-        'id': '50',
+    'DAOS_CHECKSUM_UPDATE_FAIL': {
+        'id': '65568',
         'probability_x': '100',
         'probability_y': '100',
         'interval': '1',
-        'max_faults': '17'},
-    # this doesn't exist in the code, remove later when we
-    # have more actual faults
-    'bogus_2nd_fault': {
-        'id': '51',
+        'max_faults': '1'},
+    'DAOS_DTX_LOST_RPC_REQUEST': {
+        'id': '65587',
+        'probability_x': '100',
+        'probability_y': '100',
+        'interval': '1',
+        'max_faults': '1'},
+    'DAOS_DTX_LOST_RPC_REPLY': {
+        'id': '65588',
+        'probability_x': '100',
+        'probability_y': '100',
+        'interval': '1',
+        'max_faults': '1'},
+    'DAOS_DTX_LONG_TIME_RESEND': {
+        'id': '65589',
+        'probability_x': '100',
+        'probability_y': '100',
+        'interval': '1',
+        'max_faults': '1'},
+    'DAOS_SHARD_OBJ_UPDATE_TIMEOUT': {
+        'id': '65537',
+        'probability_x': '100',
+        'probability_y': '100',
+        'interval': '1',
+        'max_faults': '1'},
+    'DAOS_SHARD_OBJ_FETCH_TIMEOUT': {
+        'id': '65538',
+        'probability_x': '100',
+        'probability_y': '100',
+        'interval': '1',
+        'max_faults': '1'},
+    'DAOS_SHARD_OBJ_FAIL': {
+        'id': '65539',
+        'probability_x': '100',
+        'probability_y': '100',
+        'interval': '1',
+        'max_faults': '1'},
+    'DAOS_OBJ_UPDATE_NOSPACE': {
+        'id': '65540',
+        'probability_x': '100',
+        'probability_y': '100',
+        'interval': '1',
+        'max_faults': '1'},
+    'DAOS_SHARD_OBJ_RW_CRT_ERROR': {
+        'id': '65541',
+        'probability_x': '100',
+        'probability_y': '100',
+        'interval': '1',
+        'max_faults': '1'},
+    'DAOS_OBJ_REQ_CREATE_TIMEOUT': {
+        'id': '65542',
+        'probability_x': '100',
+        'probability_y': '100',
+        'interval': '1',
+        'max_faults': '1'},
+    'DAOS_SHARD_OBJ_UPDATE_TIMEOUT_SINGLE': {
+        'id': '65543',
+        'probability_x': '100',
+        'probability_y': '100',
+        'interval': '1',
+        'max_faults': '1'},
+    'DAOS_OBJ_SPECIAL_SHARD': {
+        'id': '65544',
+        'probability_x': '100',
+        'probability_y': '100',
+        'interval': '1',
+        'max_faults': '1'},
+    'DAOS_OBJ_TGT_IDX_CHANGE': {
+        'id': '65545',
         'probability_x': '100',
         'probability_y': '100',
         'interval': '1',
         'max_faults': '1'}
 }
 
+
 class FaultInjectionFailed(Exception):
-    """Raise if FI failed"""
+    """Raise if FI failed."""
+
 
 def write_fault_file(path, fault_list=None, on_the_fly_fault=None):
     """ Write out a fault injection config file.
@@ -59,7 +123,6 @@ def write_fault_file(path, fault_list=None, on_the_fly_fault=None):
 
         Returns the name of the file.
     """
-
     if fault_list is None and on_the_fly_fault is None:
         raise FaultInjectionFailed("bad parameters")
 
@@ -77,7 +140,7 @@ def write_fault_file(path, fault_list=None, on_the_fly_fault=None):
                 fault_config.append(FAULTS[fault])
         if on_the_fly_fault is not None:
             fault_config.append(on_the_fly_fault)
-        yaml.dump({'fault_config':fault_config}, outfile,
+        yaml.dump({'fault_config': fault_config}, outfile,
                   default_flow_style=False, allow_unicode=True)
 
     return fi_config


### PR DESCRIPTION
* DAOS-2257 tests: enabled fault injection with soak

Test-tag-hw-large: pr,hw,large soak_faults

The following changes are included in theis PR:
1) enable fault injection in soak
2) create SoakTestbase class
3) create separate tests/yaml for soak

Signed-off-by: Maureen Jean <maureen.jean@intel.com>