### PR TITLE
DAOS-4621 vos: Transaction conflict codes to DER_TX_RESTART

### DIFF
--- a/src/dtx/dtx_common.c
+++ b/src/dtx/dtx_common.c
@@ -538,7 +538,7 @@ dtx_leader_end(struct dtx_leader_handle *dlh, struct ds_cont_child *cont,
 		return result;
 
 	if (dlh->dlh_sub_cnt == 0) {
-		if (result == -DER_AGAIN)
+		if (result == -DER_TX_RESTART)
 			dth->dth_renew = 1;
 
 		if (daos_is_zero_dti(&dth->dth_xid))
@@ -584,7 +584,7 @@ dtx_leader_end(struct dtx_leader_handle *dlh, struct ds_cont_child *cont,
 				DP_DTI(&dth->dth_xid));
 			return -DER_AGAIN;
 		}
-	} else if (rc == -DER_AGAIN) {
+	} else if (rc == -DER_TX_RESTART) {
 		dth->dth_renew = 1;
 	}
 

--- a/src/object/srv_obj.c
+++ b/src/object/srv_obj.c
@@ -1534,14 +1534,15 @@ out:
 
 	/* Stop the distribute transaction */
 	rc = dtx_leader_end(&dlh, ioc.ioc_coc, rc);
-	if (rc == -DER_AGAIN) {
-		if (dlh.dlh_handle.dth_renew) {
-			/* epoch conflict, renew it and retry. */
-			orw->orw_epoch = crt_hlc_get();
-			flags &= ~ORF_RESEND;
-			memset(&dlh, 0, sizeof(dlh));
-			D_GOTO(renew, rc);
-		}
+	if (rc == -DER_TX_RESTART) {
+		D_ASSERT(dlh.dlh_handle.dth_renew);
+		/* epoch conflict, renew it and retry. */
+		orw->orw_epoch = crt_hlc_get();
+		flags &= ~ORF_RESEND;
+		memset(&dlh, 0, sizeof(dlh));
+		D_GOTO(renew, rc);
+	} else if (rc == -DER_AGAIN) {
+		D_ASSERT(!dlh.dlh_handle.dth_renew);
 
 		flags |= ORF_RESEND;
 		D_GOTO(again, rc);
@@ -2156,14 +2157,15 @@ out:
 
 	/* Stop the distribute transaction */
 	rc = dtx_leader_end(&dlh, ioc.ioc_coc, rc);
-	if (rc == -DER_AGAIN) {
-		if (dlh.dlh_handle.dth_renew) {
-			/* epoch conflict, renew it and retry. */
-			opi->opi_epoch = crt_hlc_get();
-			flags &= ~ORF_RESEND;
-			memset(&dlh, 0, sizeof(dlh));
-			D_GOTO(renew, rc);
-		}
+	if (rc == -DER_TX_RESTART) {
+		D_ASSERT(dlh.dlh_handle.dth_renew);
+		/* epoch conflict, renew it and retry. */
+		opi->opi_epoch = crt_hlc_get();
+		flags &= ~ORF_RESEND;
+		memset(&dlh, 0, sizeof(dlh));
+		D_GOTO(renew, rc);
+	} else if (rc == -DER_AGAIN) {
+		D_ASSERT(!dlh.dlh_handle.dth_renew);
 
 		flags |= ORF_RESEND;
 		D_GOTO(again, rc);

--- a/src/vos/ilog.c
+++ b/src/vos/ilog.c
@@ -734,8 +734,8 @@ check_equal(struct ilog_context *lctx, struct ilog_id *id_out,
 			return 0;
 		}
 		D_DEBUG(DB_IO, "Access of incarnation log from multiple DTX"
-			" at same time is not allowed: rc=DER_AGAIN\n");
-		return -DER_AGAIN;
+			" at same time is not allowed: rc=DER_TX_RESTART\n");
+		return -DER_TX_RESTART;
 	}
 
 	return 0;

--- a/src/vos/tests/vts_ilog.c
+++ b/src/vos/tests/vts_ilog.c
@@ -522,9 +522,10 @@ ilog_test_update(void **state)
 	/** Same epoch, different DTX */
 	fake_tx_reset();
 	rc = ilog_update(loh, NULL, epoch, true);
-	if (rc != -DER_AGAIN) {
+	if (rc != -DER_TX_RESTART) {
 		print_message("Epoch entry already exists.  Replacing with"
-			      " different DTX should get -DER_AGAIN: rc=%s\n",
+			      " different DTX should get -DER_TX_RESTART:"
+			      " rc=%s\n",
 			      d_errstr(rc));
 		assert(0);
 	}

--- a/src/vos/tests/vts_mvcc.c
+++ b/src/vos/tests/vts_mvcc.c
@@ -492,7 +492,7 @@ conflicting_rw_exec_one(struct io_test_args *arg, int i, int j, bool empty,
 	}
 
 	if (re >= we)
-		expected_wrc = -DER_AGAIN;
+		expected_wrc = -DER_TX_RESTART;
 	if (is_rw(w)) {
 		bool e;
 

--- a/src/vos/tests/vts_pm.c
+++ b/src/vos/tests/vts_pm.c
@@ -1199,7 +1199,7 @@ cond_test(void **state)
 		       -DER_NONEXIST, sgl, "foo");
 	/** Non conditional update should fail due to later read */
 	cond_update_op(state, arg->ctx.tc_co_hdl, oid, epoch - 3, "a", "b",
-		       VOS_OF_USE_TIMESTAMPS, -DER_AGAIN, sgl, "foo");
+		       VOS_OF_USE_TIMESTAMPS, -DER_TX_RESTART, sgl, "foo");
 	/** Conditional insert should succeed */
 	cond_update_op(state, arg->ctx.tc_co_hdl, oid, epoch++, "a", "b",
 		       VOS_OF_USE_TIMESTAMPS | VOS_OF_COND_DKEY_INSERT, 0, sgl,
@@ -1240,7 +1240,7 @@ cond_test(void **state)
 			"foobar", "d", "value", "e", "abc");
 	cond_updaten_op(state, arg->ctx.tc_co_hdl, oid, epoch - 2, "z",
 			VOS_OF_COND_DKEY_INSERT | VOS_OF_USE_TIMESTAMPS,
-			-DER_AGAIN, sgl, 5, "a", "foo", "b", "bar", "c",
+			-DER_TX_RESTART, sgl, 5, "a", "foo", "b", "bar", "c",
 			"foobar", "d", "value", "e", "abc");
 	cond_updaten_op(state, arg->ctx.tc_co_hdl, oid, epoch++, "z",
 			VOS_OF_COND_DKEY_INSERT | VOS_OF_USE_TIMESTAMPS,
@@ -1253,13 +1253,13 @@ cond_test(void **state)
 		      VOS_OF_COND_AKEY_FETCH | VOS_OF_USE_TIMESTAMPS,
 		      -DER_NONEXIST, sgl, "xxx", 'x');
 	cond_update_op(state, arg->ctx.tc_co_hdl, oid, epoch - 2, "a",
-		       "nonexist", VOS_OF_USE_TIMESTAMPS, -DER_AGAIN, sgl,
+		       "nonexist", VOS_OF_USE_TIMESTAMPS, -DER_TX_RESTART, sgl,
 		       "foo");
 	cond_fetch_op(state, arg->ctx.tc_co_hdl, oid, epoch++, "nonexist", "a",
 		      VOS_OF_COND_DKEY_FETCH | VOS_OF_USE_TIMESTAMPS,
 		      -DER_NONEXIST, sgl, "xxx", 'x');
 	cond_update_op(state, arg->ctx.tc_co_hdl, oid, epoch - 2, "nonexist",
-		       "a", VOS_OF_USE_TIMESTAMPS, -DER_AGAIN, sgl,
+		       "a", VOS_OF_USE_TIMESTAMPS, -DER_TX_RESTART, sgl,
 		       "foo");
 	cond_update_op(state, arg->ctx.tc_co_hdl, oid, epoch++, "nonexist",
 		       "a", VOS_OF_USE_TIMESTAMPS, 0, sgl, "foo");

--- a/src/vos/vos_ilog.c
+++ b/src/vos/vos_ilog.c
@@ -294,7 +294,7 @@ int vos_ilog_update_(struct vos_container *cont, struct ilog_df *ilog,
 	 *  is conditional update and sharing.
 	 */
 	if (cond == VOS_ILOG_COND_UPDATE && info->ii_uncommitted != 0)
-		return -DER_AGAIN;
+		return -DER_INPROGRESS;
 	if (rc == -DER_NONEXIST)
 		goto update;
 	if (rc != 0) {
@@ -381,7 +381,7 @@ vos_ilog_punch_(struct vos_container *cont, struct ilog_df *ilog,
 	 *  is conditional update and sharing.
 	 */
 	if (info->ii_uncommitted != 0)
-		return -DER_AGAIN;
+		return -DER_INPROGRESS;
 	if (rc == -DER_NONEXIST)
 		return -DER_NONEXIST;
 	if (rc != 0) {

--- a/src/vos/vos_io.c
+++ b/src/vos/vos_io.c
@@ -1601,7 +1601,7 @@ vos_update_end(daos_handle_t ioh, uint32_t pm_ver, daos_key_t *dkey, int err,
 	 * read conflict
 	 */
 	if (ioc->ic_read_conflict) {
-		err = -DER_AGAIN;
+		err = -DER_TX_RESTART;
 		goto abort;
 	}
 

--- a/src/vos/vos_obj.c
+++ b/src/vos/vos_obj.c
@@ -138,7 +138,7 @@ key_punch(struct vos_object *obj, daos_epoch_t epoch, uint32_t pm_ver,
 	}
 
 	if (rc == 0 && read_conflict)
-		rc = -DER_AGAIN;
+		rc = -DER_TX_RESTART;
 
 	return rc;
 }
@@ -280,7 +280,7 @@ vos_obj_punch(daos_handle_t coh, daos_unit_oid_t oid, daos_epoch_t epoch,
 	}
 
 	if (rc == 0 && read_conflict)
-		rc = -DER_AGAIN;
+		rc = -DER_TX_RESTART;
 
 	if (dth != NULL && rc == 0)
 		rc = vos_dtx_prepared(dth);

--- a/src/vos/vos_obj_index.c
+++ b/src/vos/vos_obj_index.c
@@ -302,7 +302,7 @@ vos_oi_punch(struct vos_container *cont, daos_unit_oid_t oid,
 			    info, ts_set, true);
 
 	if (rc == 0 && vos_ts_check_rh_conflict(ts_set, epoch))
-		rc = -DER_AGAIN;
+		rc = -DER_TX_RESTART;
 
 	if (rc != 0)
 		D_CDEBUG(rc == -DER_NONEXIST, DB_IO, DLOG_ERR,

--- a/src/vos/vos_tree.c
+++ b/src/vos/vos_tree.c
@@ -1034,7 +1034,7 @@ key_tree_punch(struct vos_object *obj, daos_handle_t toh, daos_epoch_t epoch,
 			    info, ts_set, true);
 
 	if (rc == 0 && vos_ts_check_rh_conflict(ts_set, epoch))
-		rc = -DER_AGAIN;
+		rc = -DER_TX_RESTART;
 done:
 	if (rc != 0)
 		D_CDEBUG(rc == -DER_NONEXIST, DB_IO, DLOG_ERR,


### PR DESCRIPTION
Modifies DER_AGAIN return codes in vos for transactional conflicts
to DER_TX_RESTART
Returns DER_INPROGRESS if there are uncommitted entries in the
history rather than DER_AGAIN.

Signed-off-by: Jeff Olivier <jeffrey.v.olivier@intel.com>