### PR TITLE
CART-871 fi: Set FI_UNIVERSE_SIZE to 2048 if not set

### DIFF
--- a/src/cart/src/cart/crt_init.c
+++ b/src/cart/src/cart/crt_init.c
@@ -55,7 +55,8 @@ dump_envariables(void)
 		"D_LOG_FILE_APPEND_PID", "D_LOG_MASK", "DD_MASK",
 		"DD_STDERR", "DD_SUBSYS", "CRT_TIMEOUT", "CRT_ATTACH_INFO_PATH",
 		"OFI_PORT", "OFI_INTERFACE", "OFI_DOMAIN", "CRT_CREDIT_EP_CTX",
-		"CRT_CTX_SHARE_ADDR", "CRT_CTX_NUM", "D_FI_CONFIG"};
+		"CRT_CTX_SHARE_ADDR", "CRT_CTX_NUM", "D_FI_CONFIG",
+		"FI_UNIVERSE_SIZE"};
 
 	D_DEBUG(DB_ALL, "-- ENVARS: --\n");
 	for (i = 0; i < ARRAY_SIZE(envars); i++) {
@@ -71,6 +72,7 @@ static int data_init(crt_init_options_t *opt)
 	uint32_t	credits;
 	bool		share_addr = false;
 	uint32_t	ctx_num = 1;
+	uint32_t	fi_univ_size = 0;
 	int		rc = 0;
 
 	D_DEBUG(DB_ALL, "initializing crt_gdata...\n");
@@ -119,6 +121,13 @@ static int data_init(crt_init_options_t *opt)
 	} else {
 		credits = CRT_DEFAULT_CREDITS_PER_EP_CTX;
 		d_getenv_int("CRT_CREDIT_EP_CTX", &credits);
+	}
+
+	/* This is a workaround for CART-871 if universe size is not set */
+	d_getenv_int("FI_UNIVERSE_SIZE", &fi_univ_size);
+	if (fi_univ_size == 0) {
+		D_WARN("FI_UNIVERSE_SIZE was not set; setting to 2048\n");
+		setenv("FI_UNIVERSE_SIZE", "2048", 1);
 	}
 
 	if (credits == 0) {


### PR DESCRIPTION
As a workaround, if IF_UNIVERSE_SIZE is not set, force set it
to 2048

Signed-off-by: Alexander Oganezov <alexander.a.oganezov@intel.com>