### PR TITLE
DAOS-4627 control: format instance storage in parallel

### DIFF
--- a/src/control/server/ctl_storage_rpc.go
+++ b/src/control/server/ctl_storage_rpc.go
@@ -40,7 +40,7 @@ import (
 )
 
 const (
-	msgFormatErr      = "failure formatting storage, check RPC response for details"
+	msgFormatErr      = "failure formatting instance %d storage, check RPC response for details"
 	msgNvmeFormatSkip = "NVMe format skipped on instance %d as SCM format did not complete"
 )
 

--- a/src/control/server/ctl_storage_rpc.go
+++ b/src/control/server/ctl_storage_rpc.go
@@ -242,68 +242,80 @@ func (c *ControlService) scmFormat(scmCfg storage.ScmConfig, reformat bool) (*ct
 
 // doFormat performs format on storage subsystems, populates response results
 // in storage subsystem routines and broadcasts (closes channel) if successful.
-func (c *ControlService) doFormat(i *IOServerInstance, reformat bool, resp *ctlpb.StorageFormatResp) error {
+func (c *ControlService) doFormat(srv *IOServerInstance, reformat bool) (resp *ctlpb.StorageFormatResp) {
+	resp = new(ctlpb.StorageFormatResp)
+	resp.Mrets = proto.ScmMountResults{}
+	resp.Crets = proto.NvmeControllerResults{}
+
+	srvIdx := srv.Index()
 	needsSuperblock := true
 	needsScmFormat := reformat
 	skipNvmeResult := newCret(c.log, "format", "", ctlpb.ResponseStatus_CTL_SUCCESS, "",
-		fmt.Sprintf(msgNvmeFormatSkip, i.Index()))
+		fmt.Sprintf(msgNvmeFormatSkip, srv.Index()))
 
 	c.log.Infof("formatting storage for %s instance %d (reformat: %t)",
-		DataPlaneName, i.Index(), reformat)
+		DataPlaneName, srv.Index(), reformat)
 
-	scmConfig := i.scmConfig()
+	scmConfig := srv.scmConfig()
 
-	// If not reformatting, check if SCM is already formatted.
-	if !reformat {
+	scmErrored := false
+	scmErr := func(err error) *ctlpb.ScmMountResult {
+		scmErrored = true
+		return newMntRet(c.log, "format", scmConfig.MountPoint,
+			ctlpb.ResponseStatus_CTL_ERR_SCM, err.Error(),
+			fault.ShowResolutionFor(err))
+	}
+
+	if srv.IsStarted() {
+		resp.Mrets = append(resp.Mrets, scmErr(errors.Errorf(
+			"instance %d: can't format storage of running instance", srvIdx)))
+	} else if !reformat {
+		// If not reformatting, check if SCM is already formatted.
 		var err error
-		needsScmFormat, err = i.NeedsScmFormat()
+		needsScmFormat, err = srv.NeedsScmFormat()
 		if err != nil {
-			return errors.Wrap(err, "unable to check storage formatting")
+			resp.Mrets = append(resp.Mrets, scmErr(err))
+		} else if !needsScmFormat {
+			resp.Mrets = append(resp.Mrets, scmErr(scm.FaultFormatNoReformat))
 		}
-		if !needsScmFormat {
-			err = scm.FaultFormatNoReformat
-			resp.Mrets = append(resp.Mrets,
-				newMntRet(c.log, "format", scmConfig.MountPoint,
-					ctlpb.ResponseStatus_CTL_ERR_SCM, err.Error(),
-					fault.ShowResolutionFor(err)))
+	}
 
-			if len(i.bdevConfig().DeviceList) > 0 {
-				resp.Crets = append(resp.Crets, skipNvmeResult)
-			}
-
-			return nil // don't continue if formatted and no reformat opt
+	if scmErrored {
+		if len(srv.bdevConfig().DeviceList) > 0 {
+			resp.Crets = append(resp.Crets, skipNvmeResult)
 		}
+		return // don't continue if we can't format SCM
 	}
 
 	// When SCM format is required, format and append to response results.
 	if needsScmFormat {
 		result, err := c.scmFormat(scmConfig, true)
 		if err != nil {
-			return errors.Wrap(err, "scm format") // return unexpected errors
-		}
-		resp.Mrets = append(resp.Mrets, result)
-
-		if result.State.Status != ctlpb.ResponseStatus_CTL_SUCCESS {
-			c.log.Error(msgFormatErr)
-			if len(i.bdevConfig().DeviceList) > 0 {
-				resp.Crets = append(resp.Crets, skipNvmeResult)
-			}
-
-			return nil // don't continue if we can't format SCM
+			resp.Mrets = append(resp.Mrets, scmErr(err))
+		} else {
+			resp.Mrets = append(resp.Mrets, result)
 		}
 	} else {
 		var err error
 		// If SCM was already formatted, verify if superblock exists.
-		needsSuperblock, err = i.NeedsSuperblock()
+		needsSuperblock, err = srv.NeedsSuperblock()
 		if err != nil {
-			return errors.Wrap(err, "unable to check instance superblock")
+			resp.Mrets = append(resp.Mrets, scmErr(err))
 		}
+	}
+
+	if scmErrored {
+		c.log.Errorf(msgFormatErr, srvIdx)
+		if len(srv.bdevConfig().DeviceList) > 0 {
+			resp.Crets = append(resp.Crets, skipNvmeResult)
+		}
+		return // don't continue if we can't format SCM
 	}
 
 	// If no superblock exists, format NVMe and populate response with results.
 	if needsSuperblock {
 		nvmeResults := proto.NvmeControllerResults{}
-		bdevConfig := i.bdevConfig()
+		bdevConfig := srv.bdevConfig()
 
 		// A config with SCM and no block devices is valid.
 		if len(bdevConfig.DeviceList) > 0 {
@@ -315,7 +327,10 @@ func (c *ControlService) doFormat(i *IOServerInstance, reformat bool, resp *ctlp
 				DeviceList: bdevConfig.DeviceList,
 			})
 			if err != nil {
-				return err
+				nvmeResults = append(nvmeResults,
+					newCret(c.log, "format", "", ctlpb.ResponseStatus_CTL_ERR_NVME,
+						err.Error(), fault.ShowResolutionFor(err)))
+				return
 			}
 
 			for dev, status := range res.DeviceResponses {
@@ -339,14 +354,14 @@ func (c *ControlService) doFormat(i *IOServerInstance, reformat bool, resp *ctlp
 		resp.Crets = append(resp.Crets, nvmeResults...) // append this instance's results
 
 		if nvmeResults.HasErrors() {
-			c.log.Error(msgFormatErr)
-			return nil // don't continue if we can't format NVMe
+			c.log.Errorf(msgFormatErr, srvIdx)
+			return // don't continue if we can't format NVMe
 		}
 	}
 
-	i.NotifyStorageReady()
+	srv.NotifyStorageReady()
 
-	return nil
+	return
 }
 
 // StorageFormat delegates to Storage implementation's Format methods to prepare
@@ -358,25 +373,35 @@ func (c *ControlService) doFormat(i *IOServerInstance, reformat bool, resp *ctlp
 // Send response containing multiple results of format operations on scm mounts
 // and nvme controllers.
 func (c *ControlService) StorageFormat(ctx context.Context, req *ctlpb.StorageFormatReq) (*ctlpb.StorageFormatResp, error) {
-	resp := new(ctlpb.StorageFormatResp)
-	resp.Mrets = proto.ScmMountResults{}
-	resp.Crets = proto.NvmeControllerResults{}
+	var resp *ctlpb.StorageFormatResp
+	respChan := make(chan *ctlpb.StorageFormatResp)
 
 	c.log.Debugf("received StorageFormat RPC %v; proceeding to instance storage format", req)
 
-	// TODO: We may want to ease this restriction at some point, but having this
-	// here for now should help to cut down on shenanigans which might result
-	// in data loss.
-	if c.harness.IsStarted() {
-		return nil, errors.New("cannot format storage with running I/O server instances")
+	// TODO: enable per-instance formatting
+	formatting := 0
+	for _, srv := range c.harness.Instances() {
+		formatting++
+		go func(s *IOServerInstance) {
+			respChan <- c.doFormat(s, req.Reformat)
+		}(srv)
 	}
 
-	// temporary scaffolding
-	for _, i := range c.harness.Instances() {
-		if err := c.doFormat(i, req.Reformat, resp); err != nil {
-			return nil, errors.WithMessage(err, "formatting storage")
+	for {
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		case newResp := <-respChan:
+			formatting--
+			if resp == nil {
+				resp = newResp
+			} else {
+				resp.Mrets = append(resp.Mrets, newResp.Mrets...)
+				resp.Crets = append(resp.Crets, newResp.Crets...)
+			}
+			if formatting == 0 {
+				return resp, nil
+			}
 		}
 	}
-
-	return resp, nil
 }

--- a/src/control/server/ctl_storage_rpc_test.go
+++ b/src/control/server/ctl_storage_rpc_test.go
@@ -386,7 +386,7 @@ func TestStoragePrepare(t *testing.T) {
 
 func TestStorageFormat(t *testing.T) {
 	var (
-		mockNvmeController0 = storage.MockNvmeController()
+		mockNvmeController0 = storage.MockNvmeController(0)
 		mockNvmeController1 = storage.MockNvmeController(1)
 	)
 
@@ -404,7 +404,7 @@ func TestStorageFormat(t *testing.T) {
 		bDevs            [][]string
 		expNvmeFormatted bool
 		bmbc             *bdev.MockBackendConfig
-		expResults       []*StorageFormatResp
+		expResp          *StorageFormatResp
 		isRoot           bool
 		reformat         bool
 	}{
@@ -413,14 +413,12 @@ func TestStorageFormat(t *testing.T) {
 			sClass:           storage.ScmClassRAM,
 			sSize:            6,
 			expNvmeFormatted: true,
-			expResults: []*StorageFormatResp{
-				{
-					Crets: []*NvmeControllerResult{},
-					Mrets: []*ScmMountResult{
-						{
-							Mntpoint: "/mnt/daos",
-							State:    new(ResponseState),
-						},
+			expResp: &StorageFormatResp{
+				Crets: []*NvmeControllerResult{},
+				Mrets: []*ScmMountResult{
+					{
+						Mntpoint: "/mnt/daos",
+						State:    new(ResponseState),
 					},
 				},
 			},
@@ -430,14 +428,12 @@ func TestStorageFormat(t *testing.T) {
 			sClass:           storage.ScmClassDCPM,
 			sDevs:            []string{"/dev/pmem1"},
 			expNvmeFormatted: true,
-			expResults: []*StorageFormatResp{
-				{
-					Crets: []*NvmeControllerResult{},
-					Mrets: []*ScmMountResult{
-						{
-							Mntpoint: "/mnt/daos",
-							State:    new(ResponseState),
-						},
+			expResp: &StorageFormatResp{
+				Crets: []*NvmeControllerResult{},
+				Mrets: []*ScmMountResult{
+					{
+						Mntpoint: "/mnt/daos",
+						State:    new(ResponseState),
 					},
 				},
 			},
@@ -453,19 +449,17 @@ func TestStorageFormat(t *testing.T) {
 			bmbc: &bdev.MockBackendConfig{
 				ScanRes: storage.NvmeControllers{mockNvmeController0},
 			},
-			expResults: []*StorageFormatResp{
-				{
-					Crets: []*NvmeControllerResult{
-						{
-							Pciaddr: mockNvmeController0.PciAddr,
-							State:   new(ResponseState),
-						},
+			expResp: &StorageFormatResp{
+				Crets: []*NvmeControllerResult{
+					{
+						Pciaddr: mockNvmeController0.PciAddr,
+						State:   new(ResponseState),
 					},
-					Mrets: []*ScmMountResult{
-						{
-							Mntpoint: "/mnt/daos",
-							State:    new(ResponseState),
-						},
+				},
+				Mrets: []*ScmMountResult{
+					{
+						Mntpoint: "/mnt/daos",
+						State:    new(ResponseState),
 					},
 				},
 			},
@@ -480,19 +474,17 @@ func TestStorageFormat(t *testing.T) {
 			bmbc: &bdev.MockBackendConfig{
 				ScanRes: storage.NvmeControllers{mockNvmeController0},
 			},
-			expResults: []*StorageFormatResp{
-				{
-					Crets: []*NvmeControllerResult{
-						{
-							Pciaddr: mockNvmeController0.PciAddr,
-							State:   new(ResponseState),
-						},
+			expResp: &StorageFormatResp{
+				Crets: []*NvmeControllerResult{
+					{
+						Pciaddr: mockNvmeController0.PciAddr,
+						State:   new(ResponseState),
 					},
-					Mrets: []*ScmMountResult{
-						{
-							Mntpoint: "/mnt/daos",
-							State:    new(ResponseState),
-						},
+				},
+				Mrets: []*ScmMountResult{
+					{
+						Mntpoint: "/mnt/daos",
+						State:    new(ResponseState),
 					},
 				},
 			},
@@ -507,25 +499,23 @@ func TestStorageFormat(t *testing.T) {
 			bmbc: &bdev.MockBackendConfig{
 				ScanRes: storage.NvmeControllers{mockNvmeController0},
 			},
-			expResults: []*StorageFormatResp{
-				{
-					Crets: []*NvmeControllerResult{
-						{
-							Pciaddr: "<nil>",
-							State: &ResponseState{
-								Status: ResponseStatus_CTL_SUCCESS,
-								Info:   fmt.Sprintf(msgNvmeFormatSkip, 0),
-							},
+			expResp: &StorageFormatResp{
+				Crets: []*NvmeControllerResult{
+					{
+						Pciaddr: "<nil>",
+						State: &ResponseState{
+							Status: ResponseStatus_CTL_SUCCESS,
+							Info:   fmt.Sprintf(msgNvmeFormatSkip, 0),
 						},
 					},
-					Mrets: []*ScmMountResult{
-						{
-							Mntpoint: "/mnt/daos",
-							State: &ResponseState{
-								Status: ResponseStatus_CTL_ERR_SCM,
-								Error:  scm.FaultFormatNoReformat.Error(),
-								Info:   fault.ShowResolutionFor(scm.FaultFormatNoReformat),
-							},
+				},
+				Mrets: []*ScmMountResult{
+					{
+						Mntpoint: "/mnt/daos",
+						State: &ResponseState{
+							Status: ResponseStatus_CTL_ERR_SCM,
+							Error:  scm.FaultFormatNoReformat.Error(),
+							Info:   fault.ShowResolutionFor(scm.FaultFormatNoReformat),
 						},
 					},
 				},
@@ -543,19 +533,17 @@ func TestStorageFormat(t *testing.T) {
 				ScanRes: storage.NvmeControllers{mockNvmeController0},
 			},
 			expNvmeFormatted: true,
-			expResults: []*StorageFormatResp{
-				{
-					Crets: []*NvmeControllerResult{
-						{
-							Pciaddr: mockNvmeController0.PciAddr,
-							State:   new(ResponseState),
-						},
+			expResp: &StorageFormatResp{
+				Crets: []*NvmeControllerResult{
+					{
+						Pciaddr: mockNvmeController0.PciAddr,
+						State:   new(ResponseState),
 					},
-					Mrets: []*ScmMountResult{
-						{
-							Mntpoint: "/mnt/daos",
-							State:    new(ResponseState),
-						},
+				},
+				Mrets: []*ScmMountResult{
+					{
+						Mntpoint: "/mnt/daos",
+						State:    new(ResponseState),
 					},
 				},
 			},
@@ -570,25 +558,23 @@ func TestStorageFormat(t *testing.T) {
 			bmbc: &bdev.MockBackendConfig{
 				ScanRes: storage.NvmeControllers{mockNvmeController0},
 			},
-			expResults: []*StorageFormatResp{
-				{
-					Crets: []*NvmeControllerResult{
-						{
-							Pciaddr: "<nil>",
-							State: &ResponseState{
-								Status: ResponseStatus_CTL_SUCCESS,
-								Info:   fmt.Sprintf(msgNvmeFormatSkip, 0),
-							},
+			expResp: &StorageFormatResp{
+				Crets: []*NvmeControllerResult{
+					{
+						Pciaddr: "<nil>",
+						State: &ResponseState{
+							Status: ResponseStatus_CTL_SUCCESS,
+							Info:   fmt.Sprintf(msgNvmeFormatSkip, 0),
 						},
 					},
-					Mrets: []*ScmMountResult{
-						{
-							Mntpoint: "/mnt/daos",
-							State: &ResponseState{
-								Status: ResponseStatus_CTL_ERR_SCM,
-								Error:  scm.FaultFormatNoReformat.Error(),
-								Info:   fault.ShowResolutionFor(scm.FaultFormatNoReformat),
-							},
+				},
+				Mrets: []*ScmMountResult{
+					{
+						Mntpoint: "/mnt/daos",
+						State: &ResponseState{
+							Status: ResponseStatus_CTL_ERR_SCM,
+							Error:  scm.FaultFormatNoReformat.Error(),
+							Info:   fault.ShowResolutionFor(scm.FaultFormatNoReformat),
 						},
 					},
 				},
@@ -606,19 +592,17 @@ func TestStorageFormat(t *testing.T) {
 				ScanRes: storage.NvmeControllers{mockNvmeController0},
 			},
 			expNvmeFormatted: true,
-			expResults: []*StorageFormatResp{
-				{
-					Crets: []*NvmeControllerResult{
-						{
-							Pciaddr: mockNvmeController0.PciAddr,
-							State:   new(ResponseState),
-						},
+			expResp: &StorageFormatResp{
+				Crets: []*NvmeControllerResult{
+					{
+						Pciaddr: mockNvmeController0.PciAddr,
+						State:   new(ResponseState),
 					},
-					Mrets: []*ScmMountResult{
-						{
-							Mntpoint: "/mnt/daos",
-							State:    new(ResponseState),
-						},
+				},
+				Mrets: []*ScmMountResult{
+					{
+						Mntpoint: "/mnt/daos",
+						State:    new(ResponseState),
 					},
 				},
 			},
@@ -636,27 +620,25 @@ func TestStorageFormat(t *testing.T) {
 			bmbc: &bdev.MockBackendConfig{
 				ScanRes: storage.NvmeControllers{mockNvmeController0, mockNvmeController1},
 			},
-			expResults: []*StorageFormatResp{
-				{
-					Crets: []*NvmeControllerResult{
-						{
-							Pciaddr: mockNvmeController0.PciAddr,
-							State:   new(ResponseState),
-						},
-						{
-							Pciaddr: mockNvmeController1.PciAddr,
-							State:   new(ResponseState),
-						},
+			expResp: &StorageFormatResp{
+				Crets: []*NvmeControllerResult{
+					{
+						Pciaddr: mockNvmeController0.PciAddr,
+						State:   new(ResponseState),
 					},
-					Mrets: []*ScmMountResult{
-						{
-							Mntpoint: "/mnt/daos0",
-							State:    new(ResponseState),
-						},
-						{
-							Mntpoint: "/mnt/daos1",
-							State:    new(ResponseState),
-						},
+					{
+						Pciaddr: mockNvmeController1.PciAddr,
+						State:   new(ResponseState),
+					},
+				},
+				Mrets: []*ScmMountResult{
+					{
+						Mntpoint: "/mnt/daos0",
+						State:    new(ResponseState),
+					},
+					{
+						Mntpoint: "/mnt/daos1",
+						State:    new(ResponseState),
 					},
 				},
 			},
@@ -669,14 +651,14 @@ func TestStorageFormat(t *testing.T) {
 			testDir, cleanup := common.CreateTestDir(t)
 			defer cleanup()
 
-			common.AssertEqual(t, len(tc.sMounts), len(tc.expResults[0].Mrets), name)
-			for i, _ := range tc.sMounts {
+			common.AssertEqual(t, len(tc.sMounts), len(tc.expResp.Mrets), name)
+			for i := range tc.sMounts {
 				// Hack to deal with creating the mountpoint in test.
 				// FIXME (DAOS-3471): The tests in this layer really shouldn't be
 				// reaching down far enough to actually interact with the filesystem.
 				tc.sMounts[i] = filepath.Join(testDir, tc.sMounts[i])
-				if len(tc.expResults) == 1 && len(tc.expResults[0].Mrets) > 0 {
-					mp := &(tc.expResults[0].Mrets[i].Mntpoint)
+				if len(tc.expResp.Mrets) > 0 {
+					mp := &(tc.expResp.Mrets[i].Mntpoint)
 					if *mp != "" {
 						if strings.HasSuffix(tc.sMounts[i], *mp) {
 							*mp = tc.sMounts[i]
@@ -706,6 +688,7 @@ func TestStorageFormat(t *testing.T) {
 			for idx, scmMount := range tc.sMounts {
 				if tc.sClass == storage.ScmClassDCPM {
 					devToMount[tc.sDevs[idx]] = scmMount
+					t.Logf("sDevs[%d]= %v, value= %v", idx, tc.sDevs[idx], scmMount)
 				}
 				iosrv := ioserver.NewConfig().
 					WithScmMountPoint(scmMount).
@@ -777,9 +760,33 @@ func TestStorageFormat(t *testing.T) {
 				t.Fatal(fmtErr)
 			}
 
-			results := []*StorageFormatResp{resp}
-			if diff := cmp.Diff(tc.expResults, results); diff != "" {
-				t.Fatalf("unexpected results: (-want, +got):\n%s\n", diff)
+			common.AssertEqual(t, len(tc.expResp.Crets), len(resp.Crets),
+				"number of controller results")
+			common.AssertEqual(t, len(tc.expResp.Mrets), len(resp.Mrets),
+				"number of mount results")
+			for _, exp := range tc.expResp.Crets {
+				match := false
+				for _, got := range resp.Crets {
+					if diff := cmp.Diff(exp, got); diff == "" {
+						match = true
+					}
+				}
+				if !match {
+					t.Fatalf("unexpected results: (\nwant: %+v\ngot: %+v)",
+						tc.expResp.Crets, resp.Crets)
+				}
+			}
+			for _, exp := range tc.expResp.Mrets {
+				match := false
+				for _, got := range resp.Mrets {
+					if diff := cmp.Diff(exp, got); diff == "" {
+						match = true
+					}
+				}
+				if !match {
+					t.Fatalf("unexpected results: (\nwant: %+v\ngot: %+v)",
+						tc.expResp.Mrets, resp.Mrets)
+				}
 			}
 		})
 	}

--- a/src/control/server/storage/bdev/backend.go
+++ b/src/control/server/storage/bdev/backend.go
@@ -20,11 +20,13 @@
 // Any reproduction of computer software, computer software documentation, or
 // portions thereof marked with this legend must also reproduce the markings.
 //
+
 package bdev
 
 import (
 	"encoding/json"
 	"os"
+	"sync"
 	"syscall"
 
 	"github.com/pkg/errors"
@@ -47,6 +49,8 @@ type (
 		log     logging.Logger
 		binding *spdkWrapper
 		script  *spdkSetupScript
+
+		sync.RWMutex
 	}
 )
 
@@ -199,6 +203,9 @@ func (b *spdkBackend) Format(pciAddr string) (*storage.NvmeController, error) {
 	if pciAddr == "" {
 		return nil, FaultFormatBadPciAddr("")
 	}
+
+	b.Lock()
+	defer b.Unlock()
 
 	controllers, err := b.Scan()
 	if err != nil {

--- a/src/control/server/storage/bdev/backend.go
+++ b/src/control/server/storage/bdev/backend.go
@@ -20,13 +20,11 @@
 // Any reproduction of computer software, computer software documentation, or
 // portions thereof marked with this legend must also reproduce the markings.
 //
-
 package bdev
 
 import (
 	"encoding/json"
 	"os"
-	"sync"
 	"syscall"
 
 	"github.com/pkg/errors"
@@ -49,8 +47,6 @@ type (
 		log     logging.Logger
 		binding *spdkWrapper
 		script  *spdkSetupScript
-
-		sync.RWMutex
 	}
 )
 
@@ -203,9 +199,6 @@ func (b *spdkBackend) Format(pciAddr string) (*storage.NvmeController, error) {
 	if pciAddr == "" {
 		return nil, FaultFormatBadPciAddr("")
 	}
-
-	b.Lock()
-	defer b.Unlock()
 
 	if !b.binding.initialized {
 		return nil, errors.New("spdk not initialised, please run scan")


### PR DESCRIPTION
When `dmg storage format` gets called, in a multi-io configuration,
format storage (server side) on both IO server instances in parallel.

Signed-off-by: Tom Nabarro <tom.nabarro@intel.com>