### PR TITLE
DAOS-4538 dtx: not free field in reuseable DTX handle

### DIFF
--- a/src/dtx/dtx_common.c
+++ b/src/dtx/dtx_common.c
@@ -211,9 +211,8 @@ check:
 static void
 dtx_handle_init(struct dtx_id *dti, daos_unit_oid_t *oid, daos_handle_t coh,
 		daos_epoch_t epoch, uint64_t dkey_hash, uint32_t pm_ver,
-		uint32_t intent, struct dtx_conflict_entry *conflict,
-		struct dtx_id *dti_cos, int dti_cos_count, bool leader,
-		bool solo, struct dtx_handle *dth)
+		uint32_t intent, struct dtx_id *dti_cos, int dti_cos_count,
+		bool leader, bool solo, struct dtx_handle *dth)
 {
 	dth->dth_xid = *dti;
 	dth->dth_oid = *oid;
@@ -225,7 +224,6 @@ dtx_handle_init(struct dtx_id *dti, daos_unit_oid_t *oid, daos_handle_t coh,
 	dth->dth_intent = intent;
 	dth->dth_dti_cos = dti_cos;
 	dth->dth_dti_cos_count = dti_cos_count;
-	dth->dth_conflict = conflict;
 	dth->dth_ent = NULL;
 	dth->dth_obj = UMOFF_NULL;
 	dth->dth_sync = 0;
@@ -233,7 +231,6 @@ dtx_handle_init(struct dtx_id *dti, daos_unit_oid_t *oid, daos_handle_t coh,
 	dth->dth_solo = solo ? 1 : 0;
 	dth->dth_dti_cos_done = 0;
 	dth->dth_has_ilog = 0;
-	dth->dth_renew = 0;
 	dth->dth_actived = 0;
 }
 
@@ -323,7 +320,7 @@ dtx_leader_begin(struct dtx_id *dti, daos_unit_oid_t *oid, daos_handle_t coh,
 
 init:
 	dtx_handle_init(dti, oid, coh, epoch, dkey_hash, pm_ver, intent,
-			NULL, dti_cos, dti_cos_count, true,
+			dti_cos, dti_cos_count, true,
 			tgts_cnt == 0 ? true : false, dth);
 
 	D_DEBUG(DB_TRACE, "Start DTX "DF_DTI" for object "DF_OID
@@ -336,183 +333,19 @@ init:
 }
 
 static int
-dtx_leader_wait(struct dtx_leader_handle *dlh, struct dtx_conflict_entry **dces,
-		int *dces_cnt)
+dtx_leader_wait(struct dtx_leader_handle *dlh)
 {
 	int	rc;
 
 	rc = ABT_future_wait(dlh->dlh_future);
 	D_ASSERTF(rc == ABT_SUCCESS, "ABT_future_wait failed %d.\n", rc);
-	rc = dlh->dlh_result;
-	if (rc == -DER_INPROGRESS && dces_cnt != NULL) {
-		struct dtx_conflict_entry	*conflict;
-		int				shard_cnt = dlh->dlh_sub_cnt;
-		int				i;
-		int				j;
 
-		D_ALLOC_ARRAY(conflict, shard_cnt);
-		if (conflict == NULL) {
-			rc = -DER_NOMEM;
-			goto out;
-		}
-
-		for (i = 0, j = 0; i < shard_cnt; i++) {
-			struct dtx_sub_status *dss;
-
-			dss = &dlh->dlh_subs[i];
-			if (!daos_is_zero_dti(&dss->dss_dce.dce_xid)) {
-				daos_dti_copy(&conflict[j].dce_xid,
-					      &dss->dss_dce.dce_xid);
-				conflict[j++].dce_dkey =
-					      dss->dss_dce.dce_dkey;
-			}
-		}
-
-		*dces_cnt = j;
-		if (j > 0) {
-			*dces = conflict;
-		} else {
-			D_FREE(conflict);
-			*dces = NULL;
-		}
-	}
-
-out:
 	ABT_future_free(&dlh->dlh_future);
-	D_DEBUG(DB_TRACE, "dth "DF_DTI" rc %d\n",
-		DP_DTI(&dlh->dlh_handle.dth_xid), rc);
-	return rc;
+	D_DEBUG(DB_TRACE, "dth "DF_DTI" rc "DF_RC"\n",
+		DP_DTI(&dlh->dlh_handle.dth_xid), DP_RC(dlh->dlh_result));
+
+	return dlh->dlh_result;
 };
-
-/**
- * Handle the conflict between current DTX and former uncommmitted DTXs.
- *
- * Current Commit on Share (CoS) mechanism cannot guarantee all related
- * DTXs to be handled in advance for current modification. If some confict
- * is detected after the RPC dispatching, the non-leader replica(s) will
- * return failures to the leader replica, then the leader needs to check
- * whether the conflict is caused by committable DTX(s) or not. if yes,
- * then commit them (via appending them to CoS list), otherwise, either
- * fail out (if leader also failed because of confilict) or abort them
- * if the leader replica executes related modification successfully.
- *
- * \param coh		[IN]	Container open handle.
- * \param dth		[IN]	The DTX handle.
- * \param po_uuid	[IN]	Pool UUID.
- * \param co_uuid	[IN]	Container UUID.
- * \param count		[IN]	The @dces array size.
- * \param version	[IN]	Current pool map version.
- *
- * \return			Zero on success, negative value if error.
- */
-static int
-dtx_conflict(daos_handle_t coh, struct dtx_leader_handle *dlh, uuid_t po_uuid,
-	     uuid_t co_uuid, struct dtx_conflict_entry *dces, int count,
-	     uint32_t version)
-{
-	struct dtx_handle	*dth = &dlh->dlh_handle;
-	daos_unit_oid_t		*oid = &dth->dth_oid;
-	struct dtx_id		*commit_ids = NULL;
-	struct dtx_entry	*abort_dtes = NULL;
-	int			 commit_cnt = 0;
-	int			 abort_cnt = 0;
-	int			 rc = 0;
-	int			 i;
-
-	D_ALLOC_ARRAY(commit_ids, count);
-	if (commit_ids == NULL)
-		D_GOTO(out, rc = -DER_NOMEM);
-
-	D_ALLOC_ARRAY(abort_dtes, count);
-	if (abort_dtes == NULL)
-		D_GOTO(out, rc = -DER_NOMEM);
-
-	for (i = 0; i < count; i++) {
-		int	j;
-		bool	skip = false;
-
-		for (j = 0; j < i; j++) {
-			if (daos_dti_equal(&dces[i].dce_xid,
-					   &dces[j].dce_xid)) {
-				skip = true;
-				break;
-			}
-		}
-
-		if (skip)
-			continue;
-
-		rc = vos_dtx_lookup_cos(coh, oid, &dces[i].dce_xid,
-					dces[i].dce_dkey, true);
-		if (rc != -DER_NONEXIST)
-			goto found;
-
-		rc = vos_dtx_lookup_cos(coh, oid, &dces[i].dce_xid,
-					dces[i].dce_dkey, false);
-		if (rc != -DER_NONEXIST)
-			goto found;
-
-		rc = vos_dtx_check(coh, &dces[i].dce_xid);
-		if (rc == DTX_ST_COMMITTED)
-			rc = 0;
-		else if (rc >= 0)
-			rc = -DER_NONEXIST;
-
-found:
-		if (rc == 0) {
-			daos_dti_copy(&commit_ids[commit_cnt++],
-				      &dces[i].dce_xid);
-			continue;
-		}
-
-		if (rc == -DER_NONEXIST) {
-			daos_dti_copy(&abort_dtes[abort_cnt].dte_xid,
-				      &dces[i].dce_xid);
-			abort_dtes[abort_cnt++].dte_oid = *oid;
-			continue;
-		}
-
-		goto out;
-	}
-
-	if (commit_cnt > 0) {
-		struct dtx_id	*dti_cos;
-		int		 dti_cos_count;
-
-		/* Append the committable DTXs' ID to the CoS list. */
-		dti_cos_count = dth->dth_dti_cos_count + commit_cnt;
-		D_ALLOC_ARRAY(dti_cos, dti_cos_count);
-		if (dti_cos == NULL)
-			D_GOTO(out, rc = -DER_NOMEM);
-
-		if (dth->dth_dti_cos != NULL) {
-			memcpy(dti_cos, dth->dth_dti_cos,
-			       sizeof(struct dtx_id) * dth->dth_dti_cos_count);
-
-			D_FREE(dth->dth_dti_cos);
-		}
-
-		memcpy(dti_cos + dth->dth_dti_cos_count, commit_ids,
-		       sizeof(struct dtx_id) * commit_cnt);
-		dth->dth_dti_cos_count = dti_cos_count;
-		dth->dth_dti_cos = dti_cos;
-	}
-
-	if (abort_cnt > 0) {
-		rc = dtx_abort(po_uuid, co_uuid, dth->dth_epoch,
-			       abort_dtes, abort_cnt, version);
-		if (rc == -DER_NONEXIST)
-			rc = 0;
-	}
-
-out:
-	D_FREE(commit_ids);
-	D_FREE(abort_dtes);
-
-	D_ASSERTF(rc <= 0, "unexpected return value "DF_RC"\n", DP_RC(rc));
-
-	return rc;
-}
 
 /**
  * Stop the leader thandle.
@@ -528,67 +361,21 @@ dtx_leader_end(struct dtx_leader_handle *dlh, struct ds_cont_child *cont,
 	       int result)
 {
 	struct dtx_handle		*dth = &dlh->dlh_handle;
-	struct dtx_conflict_entry	*dces = NULL;
-	int				*ptr = NULL;
-	int				 dces_cnt = 0;
 	int				 flags = 0;
 	int				 rc = 0;
 
-	if (dlh == NULL)
-		return result;
-
-	if (dlh->dlh_sub_cnt == 0) {
-		if (result == -DER_TX_RESTART)
-			dth->dth_renew = 1;
-
-		if (daos_is_zero_dti(&dth->dth_xid))
-			return result;
-
+	if (dlh->dlh_sub_cnt == 0)
 		goto out;
-	}
 
 	D_ASSERT(cont != NULL);
 
 	/* NB: even the local request failure, dth_ent == NULL, we
 	 * should still wait for remote object to finish the request.
 	 */
-	if (!daos_is_zero_dti(&dth->dth_xid) && result >= 0)
-		ptr = &dces_cnt;
 
-	rc = dtx_leader_wait(dlh, &dces, ptr);
-	if (daos_is_zero_dti(&dth->dth_xid)) {
-		D_FREE(dlh->dlh_subs);
-
-		return result < 0 ? result : rc;
-	}
-
-	if (rc == -DER_INPROGRESS && dces != NULL) {
-		/* XXX: The local modification has been done, but remote
-		 *	replica failed because of some uncommitted DTX,
-		 *	it may be caused by some garbage DTXs on remote
-		 *	replicas or leader has more information because
-		 *	of CoS cache. So handle (abort or commit) them
-		 *	firstly then retry.
-		 */
-		D_ASSERT(dth != NULL);
-		D_DEBUG(DB_TRACE, "Hit conflict DTX "DF_DTI" for "
-			DF_DTI", handle them and retry update.\n",
-			DP_DTI(&dces[0].dce_xid), DP_DTI(&dth->dth_xid));
-
-		rc = dtx_conflict(cont->sc_hdl, dlh, cont->sc_pool->spc_uuid,
-				  cont->sc_uuid, dces, dces_cnt,
-				  cont->sc_pool->spc_map_version);
-		D_FREE(dces);
-		if (rc >= 0) {
-			D_DEBUG(DB_TRACE, "retry DTX "DF_DTI"\n",
-				DP_DTI(&dth->dth_xid));
-			return -DER_AGAIN;
-		}
-	} else if (rc == -DER_TX_RESTART) {
-		dth->dth_renew = 1;
-	}
-
-	if (result < 0 || rc < 0 || !dth->dth_actived)
+	rc = dtx_leader_wait(dlh);
+	if (result < 0 || rc < 0 || !dth->dth_actived ||
+	    daos_is_zero_dti(&dth->dth_xid))
 		D_GOTO(out, result = result < 0 ? result : rc);
 
 	if (dth->dth_intent == DAOS_INTENT_PUNCH)
@@ -596,24 +383,31 @@ dtx_leader_end(struct dtx_leader_handle *dlh, struct ds_cont_child *cont,
 	if (dth->dth_has_ilog)
 		flags |= DCF_HAS_ILOG;
 
+again:
 	rc = vos_dtx_add_cos(dth->dth_coh, &dth->dth_oid, &dth->dth_xid,
 			     dth->dth_dkey_hash, dth->dth_epoch, dth->dth_gen,
 			     flags);
-	if (rc == -DER_INPROGRESS) {
+	if (rc == -DER_TX_RESTART) {
 		D_WARN(DF_UUID": Fail to add DTX "DF_DTI" to CoS "
-		       "because of using old epoch "DF_U64"\n",
+		       "because of using old epoch "DF_U64
+		       " or aborted by resync\n",
 		       DP_UUID(cont->sc_uuid), DP_DTI(&dth->dth_xid),
 		       dth->dth_epoch);
 		D_GOTO(out, result = rc);
 	}
 
-	/* The DTX has been aborted by resync ULT, ask the client to retry. */
 	if (rc == -DER_NONEXIST) {
-		D_WARN(DF_UUID": Fail to add DTX "DF_DTI" with eph "
-		       DF_U64" to CoS because it is aborted by resync.\n",
-		       DP_UUID(cont->sc_uuid), DP_DTI(&dth->dth_xid),
-		       dth->dth_epoch);
-		D_GOTO(out, result = -DER_INPROGRESS);
+		D_WARN(DF_UUID": Fail to add DTX "DF_DTI" to CoS "
+		       "because of target object disappeared unexpectedly.\n",
+		       DP_UUID(cont->sc_uuid), DP_DTI(&dth->dth_xid));
+		/* Handle it as IO failure. */
+		D_GOTO(out, result = -DER_IO);
+	}
+
+	if (rc == -DER_AGAIN) {
+		/* The object may be in-dying, let's yield and retry. */
+		ABT_thread_yield();
+		goto again;
 	}
 
 	if (rc != 0) {
@@ -636,24 +430,32 @@ dtx_leader_end(struct dtx_leader_handle *dlh, struct ds_cont_child *cont,
 	}
 
 out:
-	if (result < 0 && dlh->dlh_sub_cnt > 0)
-		dtx_abort(cont->sc_pool->spc_uuid, cont->sc_uuid,
-			  dth->dth_epoch, &dth->dth_dte, 1,
-			  cont->sc_pool->spc_map_version);
+	if (!daos_is_zero_dti(&dth->dth_xid) && rc != -DER_AGAIN) {
+		if (result < 0 && dlh->dlh_sub_cnt > 0)
+			dtx_abort(cont->sc_pool->spc_uuid, cont->sc_uuid,
+				  dth->dth_epoch, &dth->dth_dte, 1,
+				  cont->sc_pool->spc_map_version);
 
-	D_DEBUG(DB_TRACE,
-		"Stop the DTX "DF_DTI" ver %u, dkey %llu, intent %s, "
-		"%s, %s participator(s): rc = %d\n",
-		DP_DTI(&dth->dth_xid), dth->dth_ver,
-		(unsigned long long)dth->dth_dkey_hash,
-		dth->dth_intent == DAOS_INTENT_PUNCH ? "Punch" : "Update",
-		dth->dth_sync ? "sync" : "async",
-		dth->dth_solo ? "single" : "multiple", result);
+		D_DEBUG(DB_TRACE,
+			"Stop the DTX "DF_DTI" ver %u, dkey %llu, intent %s, "
+			"%s, %s participator(s): rc "DF_RC"\n",
+			DP_DTI(&dth->dth_xid), dth->dth_ver,
+			(unsigned long long)dth->dth_dkey_hash,
+			dth->dth_intent == DAOS_INTENT_PUNCH ?
+			"Punch" : "Update", dth->dth_sync ? "sync" : "async",
+			dth->dth_solo ? "single" : "multiple", DP_RC(result));
+	}
 
 	D_ASSERTF(result <= 0, "unexpected return value %d\n", result);
 
 	D_FREE(dth->dth_dti_cos);
-	D_FREE(dlh->dlh_subs);
+	dth->dth_dti_cos_count = 0;
+
+	/* Some remote replica(s) ask retry, keep the dlh_subs. */
+	if (result == -DER_AGAIN)
+		dlh->dlh_future = ABT_FUTURE_NULL;
+	else
+		D_FREE(dlh->dlh_subs);
 
 	return result;
 }
@@ -669,7 +471,6 @@ out:
  * \param coh		[IN]	Container open handle.
  * \param epoch		[IN]	Epoch for the DTX.
  * \param dkey_hash	[IN]	Hash of the dkey to be modified if applicable.
- * \param conflict	[IN]	The pointer to record conflict dtx
  * \param dti_cos	[IN,OUT]The DTX array to be committed because of shared.
  * \param dti_cos_count [IN,OUT]The @dti_cos array size.
  * \param pm_ver	[IN]	Pool map version for the DTX.
@@ -681,8 +482,7 @@ out:
  */
 int
 dtx_begin(struct dtx_id *dti, daos_unit_oid_t *oid, daos_handle_t coh,
-	  daos_epoch_t epoch, uint64_t dkey_hash,
-	  struct dtx_conflict_entry *conflict, struct dtx_id *dti_cos,
+	  daos_epoch_t epoch, uint64_t dkey_hash, struct dtx_id *dti_cos,
 	  int dti_cos_cnt, uint32_t pm_ver, uint32_t intent,
 	  struct dtx_handle *dth)
 {
@@ -690,7 +490,7 @@ dtx_begin(struct dtx_id *dti, daos_unit_oid_t *oid, daos_handle_t coh,
 		return 0;
 
 	dtx_handle_init(dti, oid, coh, epoch, dkey_hash, pm_ver, intent,
-			conflict, dti_cos, dti_cos_cnt, false, false, dth);
+			dti_cos, dti_cos_cnt, false, false, dth);
 
 	D_DEBUG(DB_TRACE, "Start the DTX "DF_DTI" for object "DF_OID
 		" ver %u, dkey %llu, dti_cos_count %d, intent %s\n",
@@ -930,7 +730,6 @@ dtx_leader_exec_ops_ult(void *arg)
 		struct dtx_sub_status *sub = &dlh->dlh_subs[i];
 
 		sub->dss_result = 0;
-		memset(&sub->dss_dce, 0, sizeof(sub->dss_dce));
 
 		if (sub->dss_tgt.st_rank == TGTS_IGNORE) {
 			int ret;
@@ -944,7 +743,7 @@ dtx_leader_exec_ops_ult(void *arg)
 		rc = ult_arg->func(dlh, ult_arg->func_arg, i,
 				   dtx_sub_comp_cb);
 		if (rc) {
-			dlh->dlh_subs[i].dss_result = rc;
+			sub->dss_result = rc;
 			break;
 		}
 	}

--- a/src/dtx/dtx_common.c
+++ b/src/dtx/dtx_common.c
@@ -913,6 +913,19 @@ dtx_leader_exec_ops_ult(void *arg)
 	int			  rc = 0;
 
 	D_ASSERT(future != ABT_FUTURE_NULL);
+
+	if (dlh->dlh_sub_cnt != 0) {
+		D_ASSERTF(ult_arg->func != NULL,
+			  "func is NULL, but sub_cnt is %d\n",
+			  dlh->dlh_sub_cnt);
+		D_ASSERTF(ult_arg->func_arg != NULL,
+			  "func_arg is NULL, but sub_cnt is %d\n",
+			  dlh->dlh_sub_cnt);
+		D_ASSERTF(dlh->dlh_subs != NULL,
+			  "dlh_subs is NULL, but sub_cnt is %d\n",
+			  dlh->dlh_sub_cnt);
+	}
+
 	for (i = 0; i < dlh->dlh_sub_cnt; i++) {
 		struct dtx_sub_status *sub = &dlh->dlh_subs[i];
 

--- a/src/include/daos/dtx.h
+++ b/src/include/daos/dtx.h
@@ -48,11 +48,6 @@ struct dtx_id {
 	uint64_t		dti_hlc;
 };
 
-struct dtx_conflict_entry {
-	struct dtx_id		dce_xid;
-	uint64_t		dce_dkey;
-};
-
 void daos_dti_gen(struct dtx_id *dti, bool zero);
 
 static inline void

--- a/src/include/daos_srv/dtx_srv.h
+++ b/src/include/daos_srv/dtx_srv.h
@@ -80,8 +80,6 @@ struct dtx_handle {
 					 dth_dti_cos_done:1,
 					 /* XXX: touch ilog entry. */
 					 dth_has_ilog:1,
-					 /* epoch conflict, need to renew. */
-					 dth_renew:1,
 					 /* The DTX entry is in active table. */
 					 dth_actived:1;
 	/* The count the DTXs in the dth_dti_cos array. */
@@ -99,7 +97,6 @@ struct dtx_handle {
 /* Each sub transaction handle to manage each sub thandle */
 struct dtx_sub_status {
 	struct daos_shard_tgt		dss_tgt;
-	struct dtx_conflict_entry	dss_dce;
 	int				dss_result;
 };
 
@@ -158,8 +155,7 @@ int dtx_resync(daos_handle_t po_hdl, uuid_t po_uuid, uuid_t co_uuid,
 	       uint32_t ver, bool block);
 int
 dtx_begin(struct dtx_id *dti, daos_unit_oid_t *oid, daos_handle_t coh,
-	  daos_epoch_t epoch, uint64_t dkey_hash,
-	  struct dtx_conflict_entry *conflict, struct dtx_id *dti_cos,
+	  daos_epoch_t epoch, uint64_t dkey_hash, struct dtx_id *dti_cos,
 	  int dti_cos_cnt, uint32_t pm_ver, uint32_t intent,
 	  struct dtx_handle *dth);
 int

--- a/src/include/daos_srv/vos.h
+++ b/src/include/daos_srv/vos.h
@@ -60,7 +60,7 @@ vos_dtx_update_resync_gen(daos_handle_t coh);
  * \param flags		[IN]	See dtx_cos_flags.
  *
  * \return		Zero on success.
- * \return		-DER_INPROGRESS	retry with newer epoch.
+ * \return		-DER_TX_RESTART	retry with newer epoch.
  * \return		Other negative value if error.
  */
 int

--- a/src/object/obj_rpc.c
+++ b/src/object/obj_rpc.c
@@ -698,30 +698,3 @@ obj_reply_map_version_get(crt_rpc_t *rpc)
 	}
 	return 0;
 }
-
-void
-obj_reply_dtx_conflict_set(crt_rpc_t *rpc, struct dtx_conflict_entry *dce)
-{
-	void *reply = crt_reply_get(rpc);
-
-	switch (opc_get(rpc->cr_opc)) {
-	case DAOS_OBJ_RPC_TGT_UPDATE: {
-		struct obj_rw_out	*orw = reply;
-
-		daos_dti_copy(&orw->orw_dti_conflict, &dce->dce_xid);
-		orw->orw_dkey_conflict = dce->dce_dkey;
-		break;
-	}
-	case DAOS_OBJ_RPC_TGT_PUNCH:
-	case DAOS_OBJ_RPC_TGT_PUNCH_DKEYS:
-	case DAOS_OBJ_RPC_TGT_PUNCH_AKEYS: {
-		struct obj_punch_out	*opo = reply;
-
-		daos_dti_copy(&opo->opo_dti_conflict, &dce->dce_xid);
-		opo->opo_dkey_conflict = dce->dce_dkey;
-		break;
-	}
-	default:
-		D_ASSERT(0);
-	}
-}

--- a/src/object/obj_rpc.h
+++ b/src/object/obj_rpc.h
@@ -174,8 +174,6 @@ struct obj_iod_array {
 #define DAOS_OSEQ_OBJ_RW	/* output fields */		 \
 	((int32_t)		(orw_ret)		CRT_VAR) \
 	((uint32_t)		(orw_map_version)	CRT_VAR) \
-	((uint64_t)		(orw_dkey_conflict)	CRT_VAR) \
-	((struct dtx_id)	(orw_dti_conflict)	CRT_VAR) \
 	((daos_size_t)		(orw_iod_sizes)		CRT_ARRAY) \
 	((daos_size_t)		(orw_data_sizes)	CRT_ARRAY) \
 	((d_sg_list_t)		(orw_sgls)		CRT_ARRAY) \
@@ -241,9 +239,7 @@ CRT_RPC_DECLARE(obj_key_enum, DAOS_ISEQ_OBJ_KEY_ENUM, DAOS_OSEQ_OBJ_KEY_ENUM)
 
 #define DAOS_OSEQ_OBJ_PUNCH	/* output fields */		 \
 	((int32_t)		(opo_ret)		CRT_VAR) \
-	((uint32_t)		(opo_map_version)	CRT_VAR) \
-	((uint64_t)		(opo_dkey_conflict)	CRT_VAR) \
-	((struct dtx_id)	(opo_dti_conflict)	CRT_VAR)
+	((uint32_t)		(opo_map_version)	CRT_VAR)
 
 CRT_RPC_DECLARE(obj_punch, DAOS_ISEQ_OBJ_PUNCH, DAOS_OSEQ_OBJ_PUNCH)
 
@@ -324,7 +320,6 @@ void obj_reply_set_status(crt_rpc_t *rpc, int status);
 int obj_reply_get_status(crt_rpc_t *rpc);
 void obj_reply_map_version_set(crt_rpc_t *rpc, uint32_t map_version);
 uint32_t obj_reply_map_version_get(crt_rpc_t *rpc);
-void obj_reply_dtx_conflict_set(crt_rpc_t *rpc, struct dtx_conflict_entry *dce);
 
 static inline bool
 obj_is_modification_opc(uint32_t opc)

--- a/src/object/srv_obj.c
+++ b/src/object/srv_obj.c
@@ -106,14 +106,12 @@ obj_rw_complete(crt_rpc_t *rpc, struct ds_cont_child *cont,
 
 static void
 obj_rw_reply(crt_rpc_t *rpc, int status, uint32_t map_version,
-	     struct dtx_conflict_entry *dce, struct ds_cont_hdl *cont_hdl)
+	     struct ds_cont_hdl *cont_hdl)
 {
 	int rc;
 
 	obj_reply_set_status(rpc, status);
 	obj_reply_map_version_set(rpc, map_version);
-	if (dce != NULL)
-		obj_reply_dtx_conflict_set(rpc, dce);
 
 	D_DEBUG(DB_TRACE, "rpc %p opc %d send reply, pmv %d, status %d.\n",
 		rpc, opc_get(rpc->cr_opc), map_version, status);
@@ -1274,7 +1272,6 @@ ds_obj_tgt_update_handler(crt_rpc_t *rpc)
 	daos_key_t			*dkey = &orw->orw_dkey;
 	struct obj_io_context		 ioc;
 	struct dtx_handle                dth = { 0 };
-	struct dtx_conflict_entry	 conflict = { 0 };
 	uint32_t			 opc = opc_get(rpc->cr_opc);
 	int				 rc;
 
@@ -1341,9 +1338,8 @@ ds_obj_tgt_update_handler(crt_rpc_t *rpc)
 
 	rc = dtx_begin(&orw->orw_dti, &orw->orw_oid, ioc.ioc_vos_coh,
 		       orw->orw_epoch, orw->orw_dkey_hash,
-		       &conflict, orw->orw_dti_cos.ca_arrays,
-		       orw->orw_dti_cos.ca_count, orw->orw_map_ver,
-		       DAOS_INTENT_UPDATE, &dth);
+		       orw->orw_dti_cos.ca_arrays, orw->orw_dti_cos.ca_count,
+		       orw->orw_map_ver, DAOS_INTENT_UPDATE, &dth);
 	if (rc != 0) {
 		D_ERROR(DF_UOID": Failed to start DTX for update "DF_RC".\n",
 			DP_UOID(orw->orw_oid), DP_RC(rc));
@@ -1363,7 +1359,7 @@ out:
 		rc = -DER_IO;
 
 	rc = dtx_end(&dth, ioc.ioc_coh, ioc.ioc_coc, rc);
-	obj_rw_reply(rpc, rc, ioc.ioc_map_ver, &conflict, ioc.ioc_coh);
+	obj_rw_reply(rpc, rc, ioc.ioc_map_ver, ioc.ioc_coh);
 	obj_ioc_end(&ioc, rc);
 }
 
@@ -1535,15 +1531,12 @@ out:
 	/* Stop the distribute transaction */
 	rc = dtx_leader_end(&dlh, ioc.ioc_coc, rc);
 	if (rc == -DER_TX_RESTART) {
-		D_ASSERT(dlh.dlh_handle.dth_renew);
-		/* epoch conflict, renew it and retry. */
+		/* Retry with newer epoch. */
 		orw->orw_epoch = crt_hlc_get();
 		flags &= ~ORF_RESEND;
 		memset(&dlh, 0, sizeof(dlh));
 		D_GOTO(renew, rc);
 	} else if (rc == -DER_AGAIN) {
-		D_ASSERT(!dlh.dlh_handle.dth_renew);
-
 		flags |= ORF_RESEND;
 		D_GOTO(again, rc);
 	}
@@ -1553,7 +1546,7 @@ out:
 		goto cleanup;
 
 reply:
-	obj_rw_reply(rpc, rc, ioc.ioc_map_ver, NULL, ioc.ioc_coh);
+	obj_rw_reply(rpc, rc, ioc.ioc_map_ver, ioc.ioc_coh);
 
 cleanup:
 	D_TIME_END(time_start, OBJ_PF_UPDATE);
@@ -1875,15 +1868,12 @@ out:
 }
 
 static void
-obj_punch_complete(crt_rpc_t *rpc, int status, uint32_t map_version,
-		   struct dtx_conflict_entry *dce)
+obj_punch_complete(crt_rpc_t *rpc, int status, uint32_t map_version)
 {
 	int rc;
 
 	obj_reply_set_status(rpc, status);
 	obj_reply_map_version_set(rpc, map_version);
-	if (dce != NULL)
-		obj_reply_dtx_conflict_set(rpc, dce);
 
 	rc = crt_reply_send(rpc);
 	if (rc != 0)
@@ -1940,7 +1930,6 @@ void
 ds_obj_tgt_punch_handler(crt_rpc_t *rpc)
 {
 	struct dtx_handle		 dth = { 0 };
-	struct dtx_conflict_entry	 conflict = { 0 };
 	struct obj_io_context		 ioc;
 	struct obj_punch_in		*opi;
 	int				 rc;
@@ -1980,9 +1969,8 @@ ds_obj_tgt_punch_handler(crt_rpc_t *rpc)
 	/* Start the local transaction */
 	rc = dtx_begin(&opi->opi_dti, &opi->opi_oid, ioc.ioc_vos_coh,
 		       opi->opi_epoch, opi->opi_dkey_hash,
-		       &conflict, opi->opi_dti_cos.ca_arrays,
-		       opi->opi_dti_cos.ca_count, opi->opi_map_ver,
-		       DAOS_INTENT_PUNCH, &dth);
+		       opi->opi_dti_cos.ca_arrays, opi->opi_dti_cos.ca_count,
+		       opi->opi_map_ver, DAOS_INTENT_PUNCH, &dth);
 	if (rc != 0) {
 		D_ERROR(DF_UOID": Failed to start DTX for punch "DF_RC".\n",
 			DP_UOID(opi->opi_oid), DP_RC(rc));
@@ -2003,7 +1991,7 @@ out:
 
 	/* Stop the local transaction */
 	rc = dtx_end(&dth, ioc.ioc_coh, ioc.ioc_coc, rc);
-	obj_punch_complete(rpc, rc, ioc.ioc_map_ver, &conflict);
+	obj_punch_complete(rpc, rc, ioc.ioc_map_ver);
 	obj_ioc_end(&ioc, rc);
 }
 
@@ -2158,15 +2146,12 @@ out:
 	/* Stop the distribute transaction */
 	rc = dtx_leader_end(&dlh, ioc.ioc_coc, rc);
 	if (rc == -DER_TX_RESTART) {
-		D_ASSERT(dlh.dlh_handle.dth_renew);
-		/* epoch conflict, renew it and retry. */
+		/* Retry with newer epoch. */
 		opi->opi_epoch = crt_hlc_get();
 		flags &= ~ORF_RESEND;
 		memset(&dlh, 0, sizeof(dlh));
 		D_GOTO(renew, rc);
 	} else if (rc == -DER_AGAIN) {
-		D_ASSERT(!dlh.dlh_handle.dth_renew);
-
 		flags |= ORF_RESEND;
 		D_GOTO(again, rc);
 	}
@@ -2175,7 +2160,7 @@ out:
 	    DAOS_FAIL_CHECK(DAOS_DTX_LOST_RPC_REPLY))
 		goto cleanup;
 
-	obj_punch_complete(rpc, rc, ioc.ioc_map_ver, NULL);
+	obj_punch_complete(rpc, rc, ioc.ioc_map_ver);
 cleanup:
 	obj_ioc_end(&ioc, rc);
 }

--- a/src/object/srv_obj_remote.c
+++ b/src/object/srv_obj_remote.c
@@ -57,7 +57,6 @@ shard_update_req_cb(const struct crt_cb_info *cb_info)
 	struct obj_rw_out		*orwo = crt_reply_get(req);
 	struct obj_rw_in		*orw_parent = crt_req_get(parent_req);
 	struct dtx_leader_handle	*dlh = arg->dlh;
-	struct dtx_sub_status		*sub = &dlh->dlh_subs[arg->idx];
 	int				rc = cb_info->cci_rc;
 	int				rc1 = 0;
 
@@ -68,11 +67,6 @@ shard_update_req_cb(const struct crt_cb_info *cb_info)
 		rc1 = -DER_STALE;
 	} else {
 		rc1 = orwo->orw_ret;
-		if (rc1 == -DER_INPROGRESS) {
-			daos_dti_copy(&sub->dss_dce.dce_xid,
-				      &orwo->orw_dti_conflict);
-			sub->dss_dce.dce_dkey = orwo->orw_dkey_conflict;
-		}
 	}
 
 	if (rc >= 0)
@@ -192,7 +186,6 @@ shard_punch_req_cb(const struct crt_cb_info *cb_info)
 	struct obj_punch_out		*opo = crt_reply_get(req);
 	struct obj_punch_in		*opi_parent = crt_req_get(req);
 	struct dtx_leader_handle	*dlh = arg->dlh;
-	struct dtx_sub_status		*sub = &dlh->dlh_subs[arg->idx];
 	int				rc = cb_info->cci_rc;
 	int				rc1 = 0;
 
@@ -203,11 +196,6 @@ shard_punch_req_cb(const struct crt_cb_info *cb_info)
 		rc1 = -DER_STALE;
 	} else {
 		rc1 = opo->opo_ret;
-		if (rc1 == -DER_INPROGRESS) {
-			daos_dti_copy(&sub->dss_dce.dce_xid,
-				      &opo->opo_dti_conflict);
-			sub->dss_dce.dce_dkey = opo->opo_dkey_conflict;
-		}
 	}
 
 	if (rc >= 0)

--- a/src/vos/tests/vts_dtx.c
+++ b/src/vos/tests/vts_dtx.c
@@ -180,8 +180,7 @@ dtx_4(void **state)
 
 static int
 vts_dtx_begin(struct dtx_id *xid, daos_unit_oid_t *oid, daos_handle_t coh,
-	      daos_epoch_t epoch, uint64_t dkey_hash,
-	      struct dtx_conflict_entry *conflict, uint32_t intent,
+	      daos_epoch_t epoch, uint64_t dkey_hash, uint32_t intent,
 	      struct dtx_handle **dthp)
 {
 	struct dtx_handle	*dth;
@@ -200,7 +199,6 @@ vts_dtx_begin(struct dtx_id *xid, daos_unit_oid_t *oid, daos_handle_t coh,
 	dth->dth_intent = intent;
 	dth->dth_dti_cos = NULL;
 	dth->dth_dti_cos_count = 0;
-	dth->dth_conflict = conflict;
 	dth->dth_leader = 1;
 	dth->dth_ent = NULL;
 	dth->dth_obj = UMOFF_NULL;
@@ -273,7 +271,6 @@ dtx_5(void **state)
 	struct io_test_args		*args = *state;
 	struct dtx_handle		*dth = NULL;
 	struct dtx_id			 xid;
-	struct dtx_conflict_entry	 conflict = { 0 };
 	struct dtx_stat			 stat = { 0 };
 	daos_iod_t			 iod = { 0 };
 	d_sg_list_t			 sgl = { 0 };
@@ -299,7 +296,7 @@ dtx_5(void **state)
 
 	/* Assume I am the leader. */
 	rc = vts_dtx_begin(&xid, &args->oid, args->ctx.tc_co_hdl, epoch,
-			   dkey_hash, &conflict, DAOS_INTENT_UPDATE, &dth);
+			   dkey_hash, DAOS_INTENT_UPDATE, &dth);
 	assert_int_equal(rc, 0);
 
 	rc = io_test_obj_update(args, epoch, &dkey, &iod, &sgl, dth, true);
@@ -331,7 +328,6 @@ vts_dtx_commit_visibility(struct io_test_args *args, bool ext, bool punch_obj)
 {
 	struct dtx_handle		*dth = NULL;
 	struct dtx_id			 xid;
-	struct dtx_conflict_entry	 conflict = { 0 };
 	daos_iod_t			 iod = { 0 };
 	d_sg_list_t			 sgl = { 0 };
 	daos_recx_t			 rex = { 0 };
@@ -354,7 +350,7 @@ vts_dtx_commit_visibility(struct io_test_args *args, bool ext, bool punch_obj)
 
 	/* Assume I am the leader. */
 	rc = vts_dtx_begin(&xid, &args->oid, args->ctx.tc_co_hdl, epoch,
-			   dkey_hash, &conflict, DAOS_INTENT_UPDATE, &dth);
+			   dkey_hash, DAOS_INTENT_UPDATE, &dth);
 	assert_int_equal(rc, 0);
 
 	rc = io_test_obj_update(args, epoch, &dkey, &iod, &sgl, dth, true);
@@ -392,7 +388,7 @@ vts_dtx_commit_visibility(struct io_test_args *args, bool ext, bool punch_obj)
 	daos_dti_gen(&xid, false);
 
 	rc = vts_dtx_begin(&xid, &args->oid, args->ctx.tc_co_hdl, ++epoch,
-			   dkey_hash, &conflict, DAOS_INTENT_PUNCH, &dth);
+			   dkey_hash, DAOS_INTENT_PUNCH, &dth);
 	assert_int_equal(rc, 0);
 
 	if (punch_obj)
@@ -465,7 +461,6 @@ vts_dtx_abort_visibility(struct io_test_args *args, bool ext, bool punch_obj)
 {
 	struct dtx_handle		*dth = NULL;
 	struct dtx_id			 xid;
-	struct dtx_conflict_entry	 conflict = { 0 };
 	daos_iod_t			 iod = { 0 };
 	d_sg_list_t			 sgl = { 0 };
 	daos_recx_t			 rex = { 0 };
@@ -496,7 +491,7 @@ vts_dtx_abort_visibility(struct io_test_args *args, bool ext, bool punch_obj)
 
 	/* Assume I am the leader. */
 	rc = vts_dtx_begin(&xid, &args->oid, args->ctx.tc_co_hdl, ++epoch,
-			   dkey_hash, &conflict, DAOS_INTENT_UPDATE, &dth);
+			   dkey_hash, DAOS_INTENT_UPDATE, &dth);
 	assert_int_equal(rc, 0);
 
 	rc = io_test_obj_update(args, epoch, &dkey, &iod, &sgl, dth, true);
@@ -524,7 +519,7 @@ vts_dtx_abort_visibility(struct io_test_args *args, bool ext, bool punch_obj)
 	daos_dti_gen(&xid, false);
 
 	rc = vts_dtx_begin(&xid, &args->oid, args->ctx.tc_co_hdl, ++epoch,
-			   dkey_hash, &conflict, DAOS_INTENT_PUNCH, &dth);
+			   dkey_hash, DAOS_INTENT_PUNCH, &dth);
 	assert_int_equal(rc, 0);
 
 	if (punch_obj)
@@ -588,7 +583,6 @@ dtx_14(void **state)
 	struct io_test_args		*args = *state;
 	struct dtx_handle		*dth = NULL;
 	struct dtx_id			 xid;
-	struct dtx_conflict_entry	 conflict = { 0 };
 	daos_iod_t			 iod = { 0 };
 	d_sg_list_t			 sgl = { 0 };
 	daos_recx_t			 rex = { 0 };
@@ -611,7 +605,7 @@ dtx_14(void **state)
 
 	/* Assume I am the leader. */
 	rc = vts_dtx_begin(&xid, &args->oid, args->ctx.tc_co_hdl, epoch,
-			   dkey_hash, &conflict, DAOS_INTENT_UPDATE, &dth);
+			   dkey_hash, DAOS_INTENT_UPDATE, &dth);
 	assert_int_equal(rc, 0);
 
 	rc = io_test_obj_update(args, epoch, &dkey, &iod, &sgl, dth, true);
@@ -661,7 +655,6 @@ dtx_15(void **state)
 	struct io_test_args		*args = *state;
 	struct dtx_handle		*dth = NULL;
 	struct dtx_id			 xid;
-	struct dtx_conflict_entry	 conflict = { 0 };
 	daos_iod_t			 iod = { 0 };
 	d_sg_list_t			 sgl = { 0 };
 	daos_recx_t			 rex = { 0 };
@@ -692,7 +685,7 @@ dtx_15(void **state)
 
 	/* Assume I am the leader. */
 	rc = vts_dtx_begin(&xid, &args->oid, args->ctx.tc_co_hdl, ++epoch,
-			   dkey_hash, &conflict, DAOS_INTENT_UPDATE, &dth);
+			   dkey_hash, DAOS_INTENT_UPDATE, &dth);
 	assert_int_equal(rc, 0);
 
 	rc = io_test_obj_update(args, epoch, &dkey, &iod, &sgl, dth, true);
@@ -741,7 +734,6 @@ dtx_16(void **state)
 	struct io_test_args		*args = *state;
 	struct dtx_handle		*dth = NULL;
 	struct dtx_id			 xid;
-	struct dtx_conflict_entry	 conflict = { 0 };
 	daos_iod_t			 iod = { 0 };
 	d_sg_list_t			 sgl = { 0 };
 	daos_recx_t			 rex = { 0 };
@@ -766,7 +758,7 @@ dtx_16(void **state)
 			    &epoch, false);
 
 	rc = vts_dtx_begin(&xid, &args->oid, args->ctx.tc_co_hdl, epoch,
-			   dkey_hash, &conflict, DAOS_INTENT_UPDATE, &dth);
+			   dkey_hash, DAOS_INTENT_UPDATE, &dth);
 	assert_int_equal(rc, 0);
 
 	rc = io_test_obj_update(args, epoch, &dkey, &iod, &sgl, dth, true);
@@ -874,7 +866,6 @@ dtx_17(void **state)
 	/* Assume I am the leader. */
 	for (i = 0; i < 10; i++) {
 		struct dtx_handle		*dth = NULL;
-		struct dtx_conflict_entry	 conflict = { 0 };
 		d_iov_t				 dkey_iov;
 		uint64_t			 dkey_hash;
 
@@ -888,7 +879,7 @@ dtx_17(void **state)
 				    false);
 
 		rc = vts_dtx_begin(&xid[i], &args->oid, args->ctx.tc_co_hdl,
-				   epoch[i], dkey_hash, &conflict,
+				   epoch[i], dkey_hash,
 				   DAOS_INTENT_UPDATE, &dth);
 		assert_int_equal(rc, 0);
 
@@ -966,7 +957,6 @@ dtx_18(void **state)
 	/* Assume I am the leader. */
 	for (i = 0; i < 10; i++) {
 		struct dtx_handle		*dth = NULL;
-		struct dtx_conflict_entry	 conflict = { 0 };
 		d_iov_t				 dkey_iov;
 		uint64_t			 dkey_hash;
 
@@ -976,7 +966,7 @@ dtx_18(void **state)
 				    UPDATE_REC_SIZE, &dkey_hash, &epoch, false);
 
 		rc = vts_dtx_begin(&xid[i], &args->oid, args->ctx.tc_co_hdl,
-				   epoch, dkey_hash, &conflict,
+				   epoch, dkey_hash,
 				   DAOS_INTENT_UPDATE, &dth);
 		assert_int_equal(rc, 0);
 
@@ -1024,7 +1014,6 @@ vts_dtx_shares(struct io_test_args *args, int *commit_list, int commit_count,
 {
 	struct dtx_handle		*dth = NULL;
 	struct dtx_id			 xid[5];
-	struct dtx_conflict_entry	 conflict = { 0 };
 	daos_iod_t			 iod[5];
 	d_sg_list_t			 sgl[5];
 	daos_recx_t			 rex[5];
@@ -1058,7 +1047,7 @@ vts_dtx_shares(struct io_test_args *args, int *commit_list, int commit_count,
 
 	/* Assume I am the leader. */
 	rc = vts_dtx_begin(&xid[0], &args->oid, args->ctx.tc_co_hdl, epoch[0],
-			   dkey_hash, &conflict, DAOS_INTENT_UPDATE, &dth);
+			   dkey_hash, DAOS_INTENT_UPDATE, &dth);
 	assert_int_equal(rc, 0);
 
 	rc = io_test_obj_update(args, epoch[0], &dkey, &iod[0], &sgl[0],
@@ -1102,7 +1091,7 @@ vts_dtx_shares(struct io_test_args *args, int *commit_list, int commit_count,
 		iod[i].iod_nr = 1;
 
 		rc = vts_dtx_begin(&xid[i], &args->oid, args->ctx.tc_co_hdl,
-				   epoch[i], dkey_hash, &conflict,
+				   epoch[i], dkey_hash,
 				   DAOS_INTENT_UPDATE, &dth);
 		assert_int_equal(rc, 0);
 
@@ -1283,7 +1272,6 @@ vts_dtx_shares_with_punch(struct io_test_args *args, bool punch_obj, bool abort)
 {
 	struct dtx_handle		*dth = NULL;
 	struct dtx_id			 xid[4];
-	struct dtx_conflict_entry	 conflict = { 0 };
 	daos_iod_t			 iod[3];
 	d_sg_list_t			 sgl[3];
 	daos_recx_t			 rex[3];
@@ -1315,7 +1303,7 @@ vts_dtx_shares_with_punch(struct io_test_args *args, bool punch_obj, bool abort)
 
 	/* Assume I am the leader. */
 	rc = vts_dtx_begin(&xid[0], &args->oid, args->ctx.tc_co_hdl, epoch[0],
-			   dkey_hash, &conflict, DAOS_INTENT_UPDATE, &dth);
+			   dkey_hash, DAOS_INTENT_UPDATE, &dth);
 	assert_int_equal(rc, 0);
 
 	rc = io_test_obj_update(args, epoch[0], &dkey, &iod[0], &sgl[0],
@@ -1359,7 +1347,7 @@ vts_dtx_shares_with_punch(struct io_test_args *args, bool punch_obj, bool abort)
 		iod[i].iod_nr = 1;
 
 		rc = vts_dtx_begin(&xid[i], &args->oid, args->ctx.tc_co_hdl,
-				   epoch[i], dkey_hash, &conflict,
+				   epoch[i], dkey_hash,
 				   DAOS_INTENT_UPDATE, &dth);
 		assert_int_equal(rc, 0);
 
@@ -1378,7 +1366,7 @@ vts_dtx_shares_with_punch(struct io_test_args *args, bool punch_obj, bool abort)
 	epoch[3] = crt_hlc_get();
 
 	rc = vts_dtx_begin(&xid[3], &args->oid, args->ctx.tc_co_hdl, epoch[3],
-			   dkey_hash, &conflict, DAOS_INTENT_PUNCH, &dth);
+			   dkey_hash, DAOS_INTENT_PUNCH, &dth);
 	assert_int_equal(rc, 0);
 
 	/* Punch the object or dkey. */

--- a/src/vos/vos_dtx_cos.c
+++ b/src/vos/vos_dtx_cos.c
@@ -407,7 +407,7 @@ vos_dtx_add_cos(daos_handle_t coh, daos_unit_oid_t *oid, struct dtx_id *dti,
 			/* The DTX has been aborted by resync ULT, ask the
 			 * client to retry.
 			 */
-			return -DER_NONEXIST;
+			return -DER_TX_RESTART;
 		default:
 			return rc >= 0 ? -DER_INVAL : rc;
 		}

--- a/src/vos/vos_obj_cache.c
+++ b/src/vos/vos_obj_cache.c
@@ -344,7 +344,7 @@ out:
 		       " is not newer than the sync epoch "DF_U64"\n",
 		       intent == DAOS_INTENT_PUNCH ? "punch" : "update",
 		       DP_UOID(oid), epr->epr_hi, obj->obj_sync_epoch);
-		D_GOTO(failed, rc = -DER_INPROGRESS);
+		D_GOTO(failed, rc = -DER_TX_RESTART);
 	}
 
 	*obj_p = obj;


### PR DESCRIPTION
The original dtx_leader_end() logic is some chaotic as to
the DTX handle may be reused but with some released field,
such as dtx_leader_handle::dlh_subs.

The patch clean related logic with the following changes:

1. Remove DTX conflict logic that was used for detecting
   and handling incompatible non-committed punch DTX and
   update DTX in DTX module. With introduced incarnation
   log, it is useless any longer.

2. vos_dtx_check_availability() simplification. Remove
   useless logic for punch/update conflict check after
   introduced incarnation log logic.

3. More sanity check and handling for vos_dtx_add_cos().

4. Drop redundant dtx_leader_handle::dth_renew.

Signed-off-by: Fan Yong <fan.yong@intel.com>