### PR TITLE
DAOS-4336 Security: Unify certificate naming

### DIFF
--- a/src/control/cmd/agent/main.go
+++ b/src/control/cmd/agent/main.go
@@ -49,7 +49,6 @@ var (
 const (
 	agentSockName        = "agent.sock"
 	daosAgentDrpcSockEnv = "DAOS_AGENT_DRPC_DIR"
-	defaultConfigFile    = "daos_agent.yml"
 )
 
 type cliOptions struct {
@@ -131,16 +130,9 @@ func agentMain(log *logging.LeveledLogger, opts *cliOptions) error {
 	ctx, shutdown := context.WithCancel(context.Background())
 	defer shutdown()
 
-	if opts.ConfigPath == "" {
-		defaultConfigPath := path.Join(configDir, defaultConfigFile)
-		if _, err := os.Stat(defaultConfigPath); err == nil {
-			opts.ConfigPath = defaultConfigPath
-		}
-	}
-
 	// Load the configuration file using the supplied path or the
 	// default path if none provided.
-	config, err := client.GetConfig(log, opts.ConfigPath)
+	config, err := client.GetAgentConfig(log, opts.ConfigPath)
 	if err != nil {
 		log.Errorf("An unrecoverable error occurred while processing the configuration file: %s", err)
 		return err

--- a/src/control/cmd/dmg/command_test.go
+++ b/src/control/cmd/dmg/command_test.go
@@ -63,7 +63,7 @@ type testConn struct {
 }
 
 func newTestConn(t *testing.T) *testConn {
-	cfg := client.NewConfiguration()
+	cfg := client.NewAdminConfiguration()
 	return &testConn{
 		clientConfig: cfg,
 		t:            t,
@@ -230,7 +230,7 @@ func testExpectedError(t *testing.T, expected, actual error) {
 func createTestConfig(t *testing.T, log logging.Logger, path string) (*os.File, func()) {
 	t.Helper()
 
-	defaultConfig := client.NewConfiguration()
+	defaultConfig := client.NewAdminConfiguration()
 	if err := defaultConfig.SetPath(path); err != nil {
 		t.Fatal(err)
 	}

--- a/src/control/cmd/dmg/main.go
+++ b/src/control/cmd/dmg/main.go
@@ -166,7 +166,7 @@ func parseOpts(args []string, opts *cliOptions, conns client.Connect, log *loggi
 			}
 		}
 
-		config, err := client.GetConfig(log, opts.ConfigPath)
+		config, err := client.GetAdminConfig(log, opts.ConfigPath)
 		if err != nil {
 			return errors.WithMessage(err, "processing config file")
 		}

--- a/src/control/security/config.go
+++ b/src/control/security/config.go
@@ -34,10 +34,12 @@ import (
 
 const (
 	defaultCACert        = ".daos/daosCA.crt"
-	defaultServerCert    = ".daos/daos_server.crt"
-	defaultServerKey     = ".daos/daos_server.key"
-	defaultClientCert    = ".daos/client.crt"
-	defaultClientKey     = ".daos/client.key"
+	defaultServerCert    = ".daos/server.crt"
+	defaultServerKey     = ".daos/server.key"
+	defaultAgentCert     = ".daos/agent.crt"
+	defaultAgentKey      = ".daos/agent.key"
+	defaultAdminCert     = ".daos/admin.crt"
+	defaultAdminKey      = ".daos/admin.key"
 	defaultServer        = "server"
 	defaultClientCertDir = ".daos/clients"
 	defaultInsecure      = false
@@ -50,8 +52,8 @@ type TransportConfig struct {
 	CertificateConfig `yaml:",inline"`
 }
 
-func (tc *TransportConfig) String() string {
-	return fmt.Sprintf("allow insecure: %v", tc.AllowInsecure)
+func (cfg *TransportConfig) String() string {
+	return fmt.Sprintf("allow insecure: %v", cfg.AllowInsecure)
 }
 
 //CertificateConfig contains the specific certificate information for the daos
@@ -67,19 +69,38 @@ type CertificateConfig struct {
 	caPool          *x509.CertPool   `yaml:"-"`
 }
 
-//DefaultClientTransportConfig provides a default transport config disabling
+//DefaultAgentTransportConfig provides a default transport config disabling
 //certificate usage and specifying certificates located under .daos. As this
 //credential is meant to be used as a client credential it specifies a default
 //ServerName as well.
-func DefaultClientTransportConfig() *TransportConfig {
+func DefaultAgentTransportConfig() *TransportConfig {
 	return &TransportConfig{
 		AllowInsecure: defaultInsecure,
 		CertificateConfig: CertificateConfig{
 			ServerName:      defaultServer,
 			ClientCertDir:   "",
 			CARootPath:      defaultCACert,
-			CertificatePath: defaultClientCert,
-			PrivateKeyPath:  defaultClientKey,
+			CertificatePath: defaultAgentCert,
+			PrivateKeyPath:  defaultAgentKey,
+			tlsKeypair:      nil,
+			caPool:          nil,
+		},
+	}
+}
+
+//DefaultAdminTransportConfig provides a default transport config disabling
+//certificate usage and specifying certificates located under .daos. As this
+//credential is meant to be used as a client credential it specifies a default
+//ServerName as well.
+func DefaultAdminTransportConfig() *TransportConfig {
+	return &TransportConfig{
+		AllowInsecure: defaultInsecure,
+		CertificateConfig: CertificateConfig{
+			ServerName:      defaultServer,
+			ClientCertDir:   "",
+			CARootPath:      defaultCACert,
+			CertificatePath: defaultAdminCert,
+			PrivateKeyPath:  defaultAdminKey,
 			tlsKeypair:      nil,
 			caPool:          nil,
 		},

--- a/src/control/server/testdata/expect_daos_server.yml
+++ b/src/control/server/testdata/expect_daos_server.yml
@@ -9,8 +9,8 @@ transport_config:
   allow_insecure: false
   client_cert_dir: .daos/clients
   ca_cert: .daos/daosCA.crt
-  cert: .daos/daos_server.crt
-  key: .daos/daos_server.key
+  cert: .daos/server.crt
+  key: .daos/server.key
 fault_path: ""
 fault_cb: ""
 fabric_ifaces: []

--- a/src/control/server/testdata/expect_daos_server_psm2.yml
+++ b/src/control/server/testdata/expect_daos_server_psm2.yml
@@ -33,8 +33,8 @@ transport_config:
   allow_insecure: false
   client_cert_dir: .daos/clients
   ca_cert: .daos/daosCA.crt
-  cert: .daos/daos_server.crt
-  key: .daos/daos_server.key
+  cert: .daos/server.crt
+  key: .daos/server.key
 fault_path: ""
 fault_cb: ""
 fabric_ifaces: []

--- a/src/control/server/testdata/expect_daos_server_sockets.yml
+++ b/src/control/server/testdata/expect_daos_server_sockets.yml
@@ -34,8 +34,8 @@ transport_config:
   allow_insecure: false
   client_cert_dir: .daos/clients
   ca_cert: .daos/daosCA.crt
-  cert: .daos/daos_server.crt
-  key: .daos/daos_server.key
+  cert: .daos/server.crt
+  key: .daos/server.key
 fault_path: ""
 fault_cb: ""
 fabric_ifaces: []

--- a/src/control/server/testdata/expect_daos_server_uncomment.yml
+++ b/src/control/server/testdata/expect_daos_server_uncomment.yml
@@ -57,8 +57,8 @@ transport_config:
   allow_insecure: false
   client_cert_dir: .daos/clients
   ca_cert: .daos/daosCA.crt
-  cert: .daos/daos_server.crt
-  key: .daos/daos_server.key
+  cert: .daos/server.crt
+  key: .daos/server.key
 fault_path: /vcdu0/rack1/hostname
 fault_cb: ./.daos/fd_callback
 fabric_ifaces:

--- a/utils/config/daos_server.yml
+++ b/utils/config/daos_server.yml
@@ -43,9 +43,9 @@
 #  # Custom CA Root certificate for generated certs
 #  ca_cert: .daos/daosCA.crt
 #  # Server certificate for use in TLS handshakes
-#  cert: .daos/daos_server.crt
+#  cert: .daos/server.crt
 #  # Key portion of Server Certificate
-#  key: .daos/daos_server.key
+#  key: .daos/server.key
 #
 #
 ## Fault domain path

--- a/utils/config/examples/daos_server_psm2.yml
+++ b/utils/config/examples/daos_server_psm2.yml
@@ -19,9 +19,9 @@ control_log_file: /tmp/daos_control.log
 #  # Custom CA Root certificate for generated certs
 #  ca_cert: .daos/daosCA.crt
 #  # Server certificate for use in TLS handshakes
-#  cert: .daos/daos_server.crt
+#  cert: .daos/server.crt
 #  # Key portion of Server Certificate
-#  key: .daos/daos_server.key
+#  key: .daos/server.key
 
 # single server instance per config file for now
 servers:

--- a/utils/config/examples/daos_server_sockets.yml
+++ b/utils/config/examples/daos_server_sockets.yml
@@ -19,9 +19,9 @@ control_log_file: /tmp/daos_control.log
 #  # Custom CA Root certificate for generated certs
 #  ca_cert: .daos/daosCA.crt
 #  # Server certificate for use in TLS handshakes
-#  cert: .daos/daos_server.crt
+#  cert: .daos/server.crt
 #  # Key portion of Server Certificate
-#  key: .daos/daos_server.key
+#  key: .daos/server.key
 
 # single server instance per config file for now
 servers:


### PR DESCRIPTION
The default values for certificates expected by each component do not line up
with the names that are generated by the certificate generation script.
Additionally dmg and daos_agent shared a single default configuration. This
splits those configurations to have component specific configuration defaults
in addition to unifying the default values of the certificate names.

Signed-off-by: David Quigley <david.quigley@intel.com>