### PR TITLE
DAOS-3909: client: change TX API - for test

### DIFF
--- a/src/client/api/init.c
+++ b/src/client/api/init.c
@@ -96,6 +96,7 @@ const struct daos_task_api dc_funcs[] = {
 	{dc_tx_abort, sizeof(daos_tx_abort_t)},
 	{dc_tx_open_snap, sizeof(daos_tx_open_snap_t)},
 	{dc_tx_close, sizeof(daos_tx_close_t)},
+	{dc_tx_restart, sizeof(daos_tx_restart_t)},
 
 	/** Object */
 	{dc_obj_register_class, sizeof(daos_obj_register_class_t)},

--- a/src/client/api/task_internal.h
+++ b/src/client/api/task_internal.h
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2017-2019 Intel Corporation.
+ * (C) Copyright 2017-2020 Intel Corporation.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -79,7 +79,9 @@ struct daos_task_args {
 		daos_tx_open_t		tx_open;
 		daos_tx_commit_t	tx_commit;
 		daos_tx_abort_t		tx_abort;
+		daos_tx_open_snap_t	tx_open_snap;
 		daos_tx_close_t		tx_close;
+		daos_tx_restart_t	tx_restart;
 
 		/** Object */
 		daos_obj_register_class_t obj_reg_class;

--- a/src/client/api/tx.c
+++ b/src/client/api/tx.c
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2018 Intel Corporation.
+ * (C) Copyright 2018-2020 Intel Corporation.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -28,7 +28,8 @@
 #include "task_internal.h"
 
 int
-daos_tx_open(daos_handle_t coh, daos_handle_t *th, daos_event_t *ev)
+daos_tx_open(daos_handle_t coh, daos_handle_t *th, uint64_t flags,
+	     daos_event_t *ev)
 {
 	daos_tx_open_t	*args;
 	tse_task_t	*task;
@@ -42,6 +43,7 @@ daos_tx_open(daos_handle_t coh, daos_handle_t *th, daos_event_t *ev)
 	args = dc_task_get_args(task);
 	args->coh	= coh;
 	args->th	= th;
+	args->flags	= flags;
 
 	return dc_task_schedule(task, true);
 }
@@ -116,6 +118,24 @@ daos_tx_open_snap(daos_handle_t coh, daos_epoch_t epoch, daos_handle_t *th,
 	args = dc_task_get_args(task);
 	args->coh	= coh;
 	args->epoch	= epoch;
+	args->th	= th;
+
+	return dc_task_schedule(task, true);
+}
+
+int
+daos_tx_restart(daos_handle_t th, daos_event_t *ev)
+{
+	daos_tx_restart_t	*args;
+	tse_task_t		*task;
+	int			 rc;
+
+	DAOS_API_ARG_ASSERT(*args, TX_RESTART);
+	rc = dc_task_create(dc_tx_restart, NULL, ev, &task);
+	if (rc)
+		return rc;
+
+	args = dc_task_get_args(task);
 	args->th	= th;
 
 	return dc_task_schedule(task, true);

--- a/src/client/pydaos/raw/daos_api.py
+++ b/src/client/pydaos/raw/daos_api.py
@@ -1669,7 +1669,7 @@ class DaosContainer(object):
         c_tx = ctypes.c_uint64(txn)
 
         func = self.context.get_function('open-tx')
-        ret = func(self.coh, ctypes.byref(c_tx), None)
+        ret = func(self.coh, ctypes.byref(c_tx), 0, None)
         if ret != 0:
             raise DaosApiError("tx open returned non-zero. RC: {0}"
                                .format(ret))
@@ -1714,6 +1714,20 @@ class DaosContainer(object):
         ret = func(c_tx, None)
         if ret != 0:
             raise DaosApiError("TX abort returned non-zero. RC: {0}"
+                               .format(ret))
+
+    def restart_tx(self, txn):
+        """Restart a transaction that is being modified."""
+        # container should be in open state
+        if self.coh == 0:
+            raise DaosApiError("Container needs to be opened.")
+
+        c_tx = ctypes.c_uint64(txn)
+
+        func = self.context.get_function('restart-tx')
+        ret = func(c_tx, None)
+        if ret != 0:
+            raise DaosApiError("TX restart returned non-zero. RC: {0}"
                                .format(ret))
 
     def write_an_array_value(self, datalist, dkey, akey, obj=None, rank=None,
@@ -2303,6 +2317,7 @@ class DaosContext(object):
             'query-obj':       self.libdaos.daos_obj_query,
             'query-pool':      self.libdaos.daos_pool_query,
             'query-target':    self.libdaos.daos_pool_query_target,
+            'restart-tx':      self.libdaos.daos_tx_restart,
             'set-cont-attr':   self.libdaos.daos_cont_set_attr,
             'set-pool-attr':   self.libdaos.daos_pool_set_attr,
             'stop-service':    self.libdaos.daos_pool_stop_svc,

--- a/src/container/cli_tx.c
+++ b/src/container/cli_tx.c
@@ -412,6 +412,13 @@ err_task:
 	return rc;
 }
 
+int
+dc_tx_restart(tse_task_t *task)
+{
+	/* TBD */
+	return 0;
+}
+
 /*
  * MSC - this is a temporary special TX for rebuild that needs to use the client
  * stack with a specific epoch.

--- a/src/include/daos/container.h
+++ b/src/include/daos/container.h
@@ -79,6 +79,7 @@ int dc_tx_commit(tse_task_t *task);
 int dc_tx_abort(tse_task_t *task);
 int dc_tx_open_snap(tse_task_t *task);
 int dc_tx_close(tse_task_t *task);
+int dc_tx_restart(tse_task_t *task);
 int dc_tx_local_open(daos_handle_t coh, daos_epoch_t epoch,
 		     daos_handle_t *th);
 int dc_tx_local_close(daos_handle_t th);

--- a/src/include/daos_api.h
+++ b/src/include/daos_api.h
@@ -33,6 +33,16 @@
 extern "C" {
 #endif
 
+enum {
+	/** The transaction is read only. */
+	DAOS_TF_RDONLY		= (1 << 0),
+	/**
+	 * Not copy application buffer (neither key buffer nor value buffer)
+	 * when cache modification on client for the distributed transaction.
+	 */
+	DAOS_TF_ZERO_COPY	= (1 << 1),
+};
+
 /**
  * Generate a rank list from a string with a seprator argument. This is a
  * convenience function to generate the rank list required by
@@ -58,13 +68,15 @@ d_rank_list_t *daos_rank_list_parse(const char *str, const char *sep);
  *
  * \param[in]	coh	Container handle.
  * \param[out]	th	Returned transaction handle.
+ * \param[in]	flags	Transaction flags.
  * \param[in]	ev	Completion event, it is optional and can be NULL.
  *			The function will run in blocking mode if \a ev is NULL.
  *
  * \return		0 if Success, negative if failed.
  */
 int
-daos_tx_open(daos_handle_t coh, daos_handle_t *th, daos_event_t *ev);
+daos_tx_open(daos_handle_t coh, daos_handle_t *th, uint64_t flags,
+	     daos_event_t *ev);
 
 /**
  * Commit the transaction on the container it was created with. The transaction
@@ -129,6 +141,19 @@ daos_tx_abort(daos_handle_t th, daos_event_t *ev);
  */
 int
 daos_tx_close(daos_handle_t th, daos_event_t *ev);
+
+/**
+ * Restart the transaction handle. It drops all the modifications that have
+ * been issued via the handle. This is a local operation, no RPC involved.
+ *
+ * \param[in]	th	Transaction handle to be restarted.
+ * \param[in]	ev	Completion event, it is optional and can be NULL.
+ *			The function will run in blocking mode if \a ev is NULL.
+ *
+ * \return		0 if Success, negative if failed.
+ */
+int
+daos_tx_restart(daos_handle_t th, daos_event_t *ev);
 
 /**
  * Return epoch associated with the transaction handle.

--- a/src/include/daos_task.h
+++ b/src/include/daos_task.h
@@ -97,6 +97,7 @@ typedef enum {
 	DAOS_OPC_TX_ABORT,
 	DAOS_OPC_TX_OPEN_SNAP,
 	DAOS_OPC_TX_CLOSE,
+	DAOS_OPC_TX_RESTART,
 
 	/** Object APIs */
 	DAOS_OPC_OBJ_REGISTER_CLASS,
@@ -548,6 +549,8 @@ typedef struct {
 	daos_handle_t		coh;
 	/** Returned transaction open handle. */
 	daos_handle_t		*th;
+	/** Transaction flags. */
+	uint64_t		flags;
 } daos_tx_open_t;
 
 /** Transaction commit args */
@@ -577,6 +580,12 @@ typedef struct {
 	/** Transaction open handle. */
 	daos_handle_t		th;
 } daos_tx_close_t;
+
+/** Transaction restart args */
+typedef struct {
+	/** Transaction open handle. */
+	daos_handle_t		th;
+} daos_tx_restart_t;
 
 /** Object class register args */
 typedef struct {

--- a/src/tests/suite/daos_epoch.c
+++ b/src/tests/suite/daos_epoch.c
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2016-2019 Intel Corporation.
+ * (C) Copyright 2016-2020 Intel Corporation.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -58,7 +58,7 @@ io_for_aggregation(test_arg_t *arg, daos_handle_t coh, daos_handle_t ths[],
 		for (i = 0, k = 0; i < gs_dkeys; i++) {
 			daos_size_t		rec_size;
 
-			daos_tx_open(coh, &ths[i], NULL);
+			daos_tx_open(coh, &ths[i], 0, NULL);
 			daos_tx_hdl2epoch(ths[i], &epoch);
 			memset(rec, 0, REC_MAX_LEN);
 			snprintf(rec, REC_MAX_LEN, VAL_FMT, epoch);


### PR DESCRIPTION
New TX restart API:
int daos_tx_restart(daos_handle_t th, daos_event_t *ev);

It allows the application to restart the transaction against
the same handle but with newer epoch. That will clean up its
former non-committed modifications. The transaction can only
be restarted when it is in open or failed status.

Extend TX open API with @flags
int daos_tx_open(daos_handle_t coh, daos_handle_t *th,
                 uint64_t flags, daos_event_t *ev)

The parameter @flags allows the application to restrict the
distributed transaction behavior. For example:

DAOS_TF_RDONLY: Claim the transaction as readonly.

DAOS_TF_ZERO_COPY: Ask the transaction logic to not copy
application buffer (neither key buffer nor value buffer)
when cache modification on client.

Signed-off-by: Fan Yong <fan.yong@intel.com>