### PR TITLE
DAOS-0000 ioserv: reuse RPC handler ULT

### DIFF
--- a/src/include/daos_srv/daos_server.h
+++ b/src/include/daos_srv/daos_server.h
@@ -392,6 +392,9 @@ struct dss_sleep_ult {
 	ABT_thread	dsu_thread;
 	uint64_t	dsu_expire_time;
 	d_list_t	dsu_list;
+	bool		dsu_idle;
+	void		*dsu_args;
+	void		(*dsu_func)(void *args);
 };
 
 struct dss_sleep_ult *dss_sleep_ult_create(void);


### PR DESCRIPTION
RPC handler ULT does not exist after handling RPC,
instead it suspect itself so it can process the
next incoming RPC.

Signed-off-by: Liang Zhen <liang.zhen@intel.com>