### PR TITLE
DAOS-623 iosrv: Modify module code so it never holds lock

### DIFF
--- a/src/include/daos_srv/daos_server.h
+++ b/src/include/daos_srv/daos_server.h
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2016-2019 Intel Corporation.
+ * (C) Copyright 2016-2020 Intel Corporation.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -483,7 +483,6 @@ dss_thread_collective_reduce(struct dss_coll_ops *ops,
 int dss_task_collective(int (*func)(void *), void *arg, int flag, int ult_type);
 int dss_thread_collective(int (*func)(void *), void *arg, int flag,
 			  int ult_type);
-struct dss_module *dss_module_get(int mod_id);
 /* Convert Argobots errno to DAOS ones. */
 static inline int
 dss_abterr2der(int abt_errno)

--- a/src/iosrv/srv_internal.h
+++ b/src/iosrv/srv_internal.h
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright 2016-2019 Intel Corporation.
+ * (C) Copyright 2016-2020 Intel Corporation.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -99,7 +99,6 @@ int dss_module_init(void);
 int dss_module_fini(bool force);
 int dss_module_load(const char *modname);
 int dss_module_init_all(uint64_t *mod_fac);
-int dss_module_unload(const char *modname);
 void dss_module_unload_all(void);
 int dss_module_setup_all(void);
 int dss_module_cleanup_all(void);


### PR DESCRIPTION
Avoid holding the module list lock during callbacks that may
invoke things like dlclose.   This is done by "checking out"
the entire list to a local variable such that any conflicting
calls will see an empty list.  This ensures only one thread
can invoke any of these routines at any one time.

Remove some unused functions

Signed-off-by: Jeff Olivier <jeffrey.v.olivier@intel.com>