### PR TITLE
DAOS-5127 vos: callbacks for pmem_memmove/memcpy

### DIFF
--- a/src/common/debug.c
+++ b/src/common/debug.c
@@ -96,6 +96,10 @@ struct io_bypass io_bypass_dict[] = {
 		.iob_str	= IOBP_ENV_PM_SNAP,
 	},
 	{
+		.iob_bit	= IOBP_PM_TX,
+		.iob_str	= IOBP_ENV_PM_TX,
+	},
+	{
 		.iob_bit	= IOBP_OFF,
 		.iob_str	= NULL,
 	},

--- a/src/common/mem.c
+++ b/src/common/mem.c
@@ -341,6 +341,32 @@ pmem_tx_add_callback(struct umem_instance *umm, struct umem_tx_stage_data *txd,
 	return 0;
 }
 
+/* NB: tx_add_range will flush all dirty ranges */
+void
+pmem_tx_memcpy(struct umem_instance *umem, void *dst, void *src, size_t nob)
+{
+	pmemobj_memcpy(umem->umm_pool, dst, src, nob,
+		       PMEMOBJ_F_MEM_NOFLUSH | PMEMOBJ_F_MEM_NODRAIN);
+}
+
+void
+pmem_tx_memmove(struct umem_instance *umem, void *dst, void *src, size_t nob)
+{
+	pmemobj_memmove(umem->umm_pool, dst, src, nob,
+			PMEMOBJ_F_MEM_NOFLUSH | PMEMOBJ_F_MEM_NODRAIN);
+}
+
+void
+pmem_tx_memset(struct umem_instance *umem, void *addr, int c, size_t nob)
+{
+#if 0 /* XXX: this is very slow and don't know the reason yet */
+	pmemobj_memset(umem->umm_pool, addr, c, nob,
+		       PMEMOBJ_F_MEM_NOFLUSH | PMEMOBJ_F_MEM_NODRAIN);
+#else
+	memset(addr, c, nob);
+#endif
+}
+
 static umem_ops_t	pmem_ops = {
 	.mo_tx_free		= pmem_tx_free,
 	.mo_tx_alloc		= pmem_tx_alloc,
@@ -353,6 +379,71 @@ static umem_ops_t	pmem_ops = {
 	.mo_cancel		= pmem_cancel,
 	.mo_tx_publish		= pmem_tx_publish,
 	.mo_tx_add_callback	= pmem_tx_add_callback,
+	.mo_tx_memcpy		= pmem_tx_memcpy,
+	.mo_tx_memmove		= pmem_tx_memmove,
+	.mo_tx_memset		= pmem_tx_memset,
+};
+
+/** Atomic allocator, no TX */
+static int
+pmem_aa_free(struct umem_instance *umm, umem_off_t umoff)
+{
+	if (!UMOFF_IS_NULL(umoff)) {
+		PMEMoid oid = umem_off2id(umm, umoff);
+		pmemobj_free(&oid);
+	}
+	return 0;
+}
+
+static umem_off_t
+pmem_aa_alloc(struct umem_instance *umm, size_t size, uint64_t flags,
+	      unsigned int type_num)
+{
+	PMEMoid	oid;
+	int	rc;
+
+	rc = pmemobj_xalloc(umm->umm_pool, &oid, size, type_num, flags,
+			    NULL, NULL);
+	return umem_id2off(umm, rc ? OID_NULL : oid);
+}
+
+static int
+pmem_aa_add_callback(struct umem_instance *umm, struct umem_tx_stage_data *txd,
+		     int stage, umem_tx_cb_t cb, void *data)
+{
+	if (cb == NULL)
+		return -DER_INVAL;
+
+	/*
+	 * vmem doesn't support transaction, so we just execute the commit
+	 * callback & end callback instantly and drop the abort callback.
+	 */
+	if (stage == TX_STAGE_ONCOMMIT || stage == TX_STAGE_NONE)
+		cb(data, false);
+	else if (stage == TX_STAGE_ONABORT)
+		cb(data, true);
+	else
+		return -DER_INVAL;
+
+	return 0;
+}
+
+/** Atomic allocator, it is for benchmark only */
+static umem_ops_t	pmem_aa_ops = {
+	.mo_tx_free		= pmem_aa_free,
+	.mo_tx_alloc		= pmem_aa_alloc,
+	.mo_tx_add		= NULL,
+	.mo_tx_add_ptr		= NULL,
+	.mo_tx_abort		= NULL,
+	.mo_tx_begin		= NULL,
+	.mo_tx_commit		= NULL,
+	.mo_reserve		= NULL,
+	.mo_cancel		= NULL,
+	.mo_tx_publish		= NULL,
+	.mo_tx_add_callback	= pmem_aa_add_callback,
+	.mo_tx_memcpy		= pmem_tx_memcpy,
+	.mo_tx_memmove		= pmem_tx_memmove,
+	.mo_tx_memset		= pmem_tx_memset,
 };
 
 int
@@ -477,6 +568,11 @@ static struct umem_class umem_class_defined[] = {
 		.umc_id		= UMEM_CLASS_PMEM_NO_SNAP,
 		.umc_ops	= &pmem_no_snap_ops,
 		.umc_name	= "pmem_no_snap",
+	},
+	{
+		.umc_id		= UMEM_CLASS_PMEM_AA,
+		.umc_ops	= &pmem_aa_ops,
+		.umc_name	= "pmem_no_tx",
 	},
 	{
 		.umc_id		= UMEM_CLASS_UNKNOWN,

--- a/src/include/daos/debug.h
+++ b/src/include/daos/debug.h
@@ -117,6 +117,8 @@ enum {
 	IOBP_PM			= (1 << 4),
 	/** no PMDK snapshot (PMDK transaction will be broken) */
 	IOBP_PM_SNAP		= (1 << 5),
+	/** no PMDK transaction */
+	IOBP_PM_TX		= (1 << 6),
 };
 
 /**
@@ -131,6 +133,7 @@ enum {
 #define IOBP_ENV_NVME		"nvme"
 #define IOBP_ENV_PM		"pm"
 #define IOBP_ENV_PM_SNAP	"pm_snap"
+#define IOBP_ENV_PM_TX		"pm_tx"
 
 extern unsigned int daos_io_bypass;
 

--- a/src/include/daos/mem.h
+++ b/src/include/daos/mem.h
@@ -126,6 +126,8 @@ typedef enum {
 	UMEM_CLASS_PMEM,
 	/** persistent memory but ignore PMDK snapshot */
 	UMEM_CLASS_PMEM_NO_SNAP,
+	/** atomic allocator */
+	UMEM_CLASS_PMEM_AA,
 	/** unknown */
 	UMEM_CLASS_UNKNOWN,
 } umem_class_id_t;
@@ -253,6 +255,16 @@ typedef struct {
 					       struct umem_tx_stage_data *txd,
 					       int stage, umem_tx_cb_t cb,
 					       void *data);
+
+	/* NB: only safe in TX */
+	void		 (*mo_tx_memcpy)(struct umem_instance *umm,
+					 void *dst, void *src, size_t nob);
+
+	void		 (*mo_tx_memmove)(struct umem_instance *umm,
+					  void *dst, void *src, size_t nob);
+
+	void		 (*mo_tx_memset)(struct umem_instance *umm,
+					 void *addr, int c, size_t nob);
 } umem_ops_t;
 
 
@@ -445,6 +457,33 @@ umem_tx_end(struct umem_instance *umm, int err)
 		return umem_tx_abort(umm, err);
 	else
 		return umem_tx_commit(umm);
+}
+
+static inline void
+umem_tx_memcpy(struct umem_instance *umm, void *dst, void *src, size_t nob)
+{
+	if (umm->umm_ops->mo_tx_memcpy)
+		umm->umm_ops->mo_tx_memcpy(umm, dst, src, nob);
+	else
+		memcpy(dst, src, nob);
+}
+
+static inline void
+umem_tx_memmove(struct umem_instance *umm, void *dst, void *src, size_t nob)
+{
+	if (umm->umm_ops->mo_tx_memmove)
+		umm->umm_ops->mo_tx_memmove(umm, dst, src, nob);
+	else
+		memmove(dst, src, nob);
+}
+
+static inline void
+umem_tx_memset(struct umem_instance *umm, void *addr, int c, size_t nob)
+{
+	if (umm->umm_ops->mo_tx_memset)
+		umm->umm_ops->mo_tx_memset(umm, addr, c, nob);
+	else
+		memset(addr, c, nob);
 }
 
 static inline umem_off_t

--- a/src/vos/evt_priv.h
+++ b/src/vos/evt_priv.h
@@ -59,7 +59,10 @@ struct evt_iterator {
 	struct evt_entry_array		it_entries;
 };
 
-#define EVT_TRACE_MAX                   32
+/* backtrace depth, evtree(order=8, depth=16) can store 4 billion rectangles,
+ * giving the actual order used by VOS is 23, this value is more than enough.
+ */
+#define EVT_TRACE_MAX                   16
 
 struct evt_trace {
 	/** the current node offset */

--- a/src/vos/ilog.c
+++ b/src/vos/ilog.c
@@ -459,9 +459,12 @@ ilog_hdl2lctx(daos_handle_t hdl)
 
 static int
 ilog_ptr_set_full(struct ilog_context *lctx, void *dest, const void *src,
-		  size_t len)
+		  size_t len, bool created)
 {
 	int	rc = 0;
+
+	if (created)
+		goto copy;
 
 	rc = ilog_tx_begin(lctx);
 	if (rc != 0) {
@@ -475,19 +478,19 @@ ilog_ptr_set_full(struct ilog_context *lctx, void *dest, const void *src,
 		D_ERROR("Failed to add to undo log\n");
 		goto done;
 	}
-
+copy:
 	memcpy(dest, src, len);
 done:
 	return rc;
 }
 
 #define ilog_ptr_set(lctx, dest, src)	\
-	ilog_ptr_set_full(lctx, dest, src, sizeof(*(src)))
+	ilog_ptr_set_full(lctx, dest, src, sizeof(*(src)), false)
 
 int
 ilog_create(struct umem_instance *umm, struct ilog_df *root)
 {
-	struct ilog_context	lctx = {
+	struct ilog_context     lctx = {
 		.ic_root = (struct ilog_root *)root,
 		.ic_root_off = umem_ptr2off(umm, root),
 		.ic_umm = *umm,
@@ -495,15 +498,10 @@ ilog_create(struct umem_instance *umm, struct ilog_df *root)
 		.ic_in_txn = 0,
 	};
 	struct ilog_root	tmp = {0};
-	int			rc = 0;
 
 	tmp.lr_magic = ILOG_MAGIC + ILOG_VERSION_INC;
-
-	rc = ilog_ptr_set(&lctx, root, &tmp);
-	lctx.ic_ver_inc = false;
-
-	rc = ilog_tx_end(&lctx, rc);
-	return rc;
+	ilog_ptr_set_full(&lctx, root, &tmp, sizeof(tmp), true);
+	return 0;
 }
 
 #define ILOG_ASSERT_VALID(root_df)				\
@@ -1021,7 +1019,7 @@ ilog_modify(daos_handle_t loh, const struct ilog_id *id_in,
 		tmp.lr_magic = ilog_ver_inc(lctx);
 		tmp.lr_ts_idx = root->lr_ts_idx;
 		tmp.lr_id = *id_in;
-		rc = ilog_ptr_set(lctx, root, &tmp);
+		rc = ilog_ptr_set_full(lctx, root, &tmp, sizeof(tmp), true);
 		if (rc != 0)
 			goto done;
 		rc = ilog_log_add(lctx, &root->lr_id);

--- a/src/vos/vos_pool.c
+++ b/src/vos/vos_pool.c
@@ -98,6 +98,10 @@ umem_get_type(void)
 		D_PRINT("Ignore PMDK snapshot, data can be lost on failure.\n");
 		return UMEM_CLASS_PMEM_NO_SNAP;
 
+	} else if (daos_io_bypass & IOBP_PM_TX) {
+		D_PRINT("Ignore PMDK tx, data can be lost on failure.\n");
+		return UMEM_CLASS_PMEM_AA;
+
 	} else {
 		return UMEM_CLASS_PMEM;
 	}


### PR DESCRIPTION
A few changes in this patch:
- calls pmem_memmove/memcpy for persistent memory
- no snapshot for newly allocated ilog root
- decrease snapshot size of dbtree and evtree

Signed-off-by: Liang Zhen <liang.zhen@intel.com>