### PR TITLE
DAOS-0000 cart: libgurt should use coarse time

### DIFF
--- a/src/cart/src/cart/crt_internal_fns.h
+++ b/src/cart/src/cart/crt_internal_fns.h
@@ -84,14 +84,6 @@ crt_is_service()
 	return crt_gdata.cg_server;
 }
 
-static inline void
-crt_bulk_desc_dup(struct crt_bulk_desc *bulk_desc_new,
-		  struct crt_bulk_desc *bulk_desc)
-{
-	D_ASSERT(bulk_desc_new != NULL && bulk_desc != NULL);
-	*bulk_desc_new = *bulk_desc;
-}
-
 void
 crt_hdlr_proto_query(crt_rpc_t *rpc_req);
 

--- a/src/cart/src/cart/crt_internal_types.h
+++ b/src/cart/src/cart/crt_internal_types.h
@@ -164,6 +164,10 @@ extern struct crt_plugin_gdata		crt_plugin_gdata;
 struct crt_context {
 	d_list_t		 cc_link; /* link to gdata.cg_ctx_list */
 	int			 cc_idx; /* context index */
+	/* timeout per-context */
+	uint32_t		 cc_timeout_sec;
+	/** last timeout check in micro-second */
+	uint64_t		 cc_last_toc;
 	struct crt_hg_context	 cc_hg_ctx; /* HG context */
 	void			*cc_rpc_cb_arg;
 	crt_rpc_task_t		 cc_rpc_cb; /* rpc callback */
@@ -173,8 +177,6 @@ struct crt_context {
 	struct d_binheap	 cc_bh_timeout;
 	/* mutex to protect cc_epi_table and timeout binheap */
 	pthread_mutex_t		 cc_mutex;
-	/* timeout per-context */
-	uint32_t		 cc_timeout_sec;
 };
 
 /* in-flight RPC req list, be tracked per endpoint for every crt_context */

--- a/src/cart/src/cart/crt_iv.c
+++ b/src/cart/src/cart/crt_iv.c
@@ -2839,8 +2839,7 @@ bulk_update_transfer_done(const struct crt_bulk_cb_info *info)
 		/* cb_info is inside of bci_arg */
 		info_dup->bci_arg = info->bci_arg;
 		info_dup->bci_rc = info->bci_rc;
-		crt_bulk_desc_dup(info_dup->bci_bulk_desc,
-				  info->bci_bulk_desc);
+		*info_dup->bci_bulk_desc = *info->bci_bulk_desc;
 		IV_DBG(&input->ivu_key, "Executing ivo_pre_update\n");
 
 		/* Note: cb_info free-ed by the aux_wrapper */

--- a/src/cart/src/include/gurt/common.h
+++ b/src/cart/src/include/gurt/common.h
@@ -80,7 +80,7 @@ extern "C" {
  * Get the current time using a monotonic timer
  * param[out] ts A timespec structure for the result
  */
-#define _gurt_gettime(ts) clock_gettime(CLOCK_MONOTONIC, ts)
+#define _gurt_gettime(ts) clock_gettime(CLOCK_MONOTONIC_COARSE, ts)
 
 /* memory allocating macros */
 


### PR DESCRIPTION
- _gurt_gettime is only used for timeout check, coarse time
  is good enough
- decrease the frequency of checking RPC timeout
- reduce a malloc in bulk transfer

Signed-off-by: Liang Zhen <liang.zhen@intel.com>