### PR TITLE
A few simple changes related to alignment

### DIFF
--- a/src/control/SConscript
+++ b/src/control/SConscript
@@ -164,7 +164,8 @@ def scons():
 
     prereqs.require(denv, 'cart')
 
-    denv.AppendENVPath("CGO_CFLAGS", denv.subst("-I$CART_PREFIX/include"))
+    denv.AppendENVPath("CGO_CFLAGS", denv.subst("-I$CART_PREFIX/include"),
+                       sep=" ")
 
     install_go_bin(denv, gosrc, gopath, None, "agent", "daos_agent")
     install_go_bin(denv, gosrc, gopath, None, "dmg", "dmg")
@@ -194,7 +195,7 @@ def scons():
                        " -lspdk_blob -lspdk_nvme -lspdk_util -lspdk_json" + \
                        " -lspdk_jsonrpc -lspdk_rpc -lspdk_trace" + \
                        " -lspdk_sock -lspdk_log -lspdk_notify" + \
-                       " -lspdk_blob_bdev -lnuma -ldl -lisal")
+                       " -lspdk_blob_bdev -lnuma -ldl -lisal", sep=" ")
 
     senv.AppendENVPath("CGO_CFLAGS",
                        senv.subst("-I$SPDK_PREFIX/include "

--- a/src/include/daos/mem.h
+++ b/src/include/daos/mem.h
@@ -331,6 +331,13 @@ umem_has_tx(struct umem_instance *umm)
 	return umm->umm_ops->mo_tx_add != NULL;
 }
 
+/** align an address to 256 bytes */
+#define UMEM_ALIGN_PAD ((1 << 8) - 1)
+#define UMEM_ALIGN_MASK (~UMEM_ALIGN_PAD)
+#define UMEM_ALIGN(off) ((__typeof__(off))((uintptr_t)(off) & UMEM_ALIGN_MASK))
+/** pad a size to 256 bytes */
+#define UMEM_PAD(size) UMEM_ALIGN((size) + UMEM_ALIGN_PAD)
+
 #define umem_alloc_verb(umm, flags, size)				\
 ({									\
 	umem_off_t	__umoff;					\

--- a/src/vos/vos_internal.h
+++ b/src/vos/vos_internal.h
@@ -42,9 +42,9 @@
 #include <vos_obj.h>
 
 #define VOS_CONT_ORDER		20	/* Order of container tree */
-#define VOS_OBJ_ORDER		20	/* Order of object tree */
-#define VOS_KTR_ORDER		23	/* order of d/a-key tree */
-#define VOS_SVT_ORDER		5	/* order of single value tree */
+#define VOS_OBJ_ORDER		15	/* Order of object tree */
+#define VOS_KTR_ORDER		20	/* order of d/a-key tree */
+#define VOS_SVT_ORDER		14	/* order of single value tree */
 #define VOS_EVT_ORDER		23	/* evtree order */
 #define DTX_BTREE_ORDER		23	/* Order for DTX tree */
 

--- a/src/vos/vos_tree.c
+++ b/src/vos/vos_tree.c
@@ -78,8 +78,6 @@ iov2rec_bundle(d_iov_t *val_iov)
 struct ktr_hkey {
 	/** murmur64 hash */
 	uint64_t		kh_hash[2];
-	/** cacheline alignment */
-	uint64_t		kh_pad_64;
 };
 
 /**


### PR DESCRIPTION
1. Pad allocations to 256 byte boundaries
2. Align and pad tx_add_range
3. Modify tree order to fit better in padded
   sizes
4. Modify dynamic tree ordering to fit better
   in padded sizes
5. Minor fix to SConscript to support compiling
   on my box.
6. Remove the extra 8 bytes from the akey/dkey hash

Signed-off-by: Jeff Olivier <jeffrey.v.olivier@intel.com>