### PR TITLE
DAOS-4116 SDL: Fixing last Missed Coverity Issue.

### DIFF
--- a/src/vos/tests/vts_gc.c
+++ b/src/vos/tests/vts_gc.c
@@ -271,7 +271,7 @@ gc_obj_run(struct gc_test_args *args)
 		if (rc) {
 			print_error("failed to delete objects: %s\n",
 				    d_errstr(rc));
-			return rc;
+			goto out;
 		}
 	}
 


### PR DESCRIPTION
Fixing last Missed Coverity Issue.
Leaked memory in test.

Signed-off-by: Peter Fetros <peter.fetros@intel.com>