### PR TITLE
DAOS-4673 control: bindings to build with ipmctl v2

### DIFF
--- a/src/control/lib/ipmctl/nvm.go
+++ b/src/control/lib/ipmctl/nvm.go
@@ -1,5 +1,5 @@
 //
-// (C) Copyright 2018-2019 Intel Corporation.
+// (C) Copyright 2018-2020 Intel Corporation.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -90,41 +90,6 @@ func (n *NvmMgmt) Discover() (devices []DeviceDiscovery, err error) {
 	if len(devices) != int(count) {
 		err = fmt.Errorf("expected %d devices but got %d", len(devices), int(count))
 	}
-
-	return
-}
-
-// GetStatuses return status for each device in devices
-func (n *NvmMgmt) GetStatuses(devices []DeviceDiscovery) (
-	statuses []DeviceStatus, err error) {
-
-	// printing for debug
-	for i, d := range devices {
-		fmt.Printf("Device ID: %d, Memory type: %d, Fw Rev: %v, Capacity %d, ",
-			d.Device_id, d.Memory_type, d.Fw_revision, d.Capacity)
-		fmt.Printf("Channel Pos: %d, Channel ID: %d, Memory Ctrlr: %d, Socket ID: %d.\n",
-			d.Channel_pos, d.Channel_id, d.Memory_controller_id, d.Socket_id)
-
-		uidCharPtr := (*C.char)(unsafe.Pointer(&devices[0].Uid))
-		//uidCharPtr := (*C.char)(unsafe.Pointer(&devs[0].uid))
-
-		fmt.Printf("uid of device %d: %s\n", i, C.GoString(uidCharPtr))
-
-		status := C.struct_device_status{}
-		if err = Rc2err(
-			"get_device_status",
-			C.nvm_get_device_status(uidCharPtr, &status)); err != nil {
-			return
-		}
-		statuses = append(statuses, *(*DeviceStatus)(unsafe.Pointer(&status)))
-	}
-
-	// verify api call passing in uid as param
-	// dev := C.struct_device_discovery{}
-	// C.nvm_get_device_discovery(uidCharPtr, &dev)
-	// dd := (*DeviceDiscovery)(unsafe.Pointer(&dev))
-	// fmt.Printf("Device ID: %d, Memory type: %d, Fw Rev: %v, Capacity %d, ",
-	//    dd.Device_id, dd.Memory_type, dd.Fw_revision, dd.Capacity)
 
 	return
 }

--- a/src/control/lib/ipmctl/nvm_types.go
+++ b/src/control/lib/ipmctl/nvm_types.go
@@ -1,5 +1,5 @@
 //
-// (C) Copyright 2018-2019 Intel Corporation.
+// (C) Copyright 2018-2020 Intel Corporation.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -63,32 +63,4 @@ type DeviceDiscovery struct {
 	Controller_revision_id   uint16
 	Reserved                 [48]uint8
 	Pad_cgo_3                [6]byte
-}
-
-// DeviceStatus struct represents Go equivalent of C.struct_device_status
-// from nvm_management.h (NVM API) as reported by "go tool cgo -godefs nvm.go"
-type DeviceStatus struct {
-	Is_new                       uint8
-	Is_configured                uint8
-	Is_missing                   uint8
-	Package_spares_available     uint8
-	Pad_cgo_0                    [3]byte
-	Last_shutdown_status_details uint32
-	Config_status                uint32
-	Last_shutdown_time           uint64
-	Mixed_sku                    uint8
-	Sku_violation                uint8
-	Viral_state                  uint8
-	Pad_cgo_1                    [1]byte
-	Ars_status                   uint32
-	Overwritedimm_status         uint32
-	New_error_count              uint32
-	Newest_error_log_timestamp   uint64
-	Ait_dram_enabled             uint8
-	Pad_cgo_2                    [7]byte
-	Boot_status                  uint64
-	Injected_media_errors        uint32
-	Injected_non_media_errors    uint32
-	Error_log_status             _Ctype_struct_device_error_log_status
-	Reserved                     [56]uint8
 }


### PR DESCRIPTION
Remove unused stale DeviceStatus type and getter method from
control/lib/ipmctl to fix build on Ubuntu 20.04 (which ships with
ipmctl v2 as opposed to CentOS 7/8 which provides v1).

Signed-off-by: Tom Nabarro <tom.nabarro@intel.com>