### PR TITLE
CART-886 group: Use atomic operations for refcount

### DIFF
--- a/src/cart/src/cart/crt_group.h
+++ b/src/cart/src/cart/crt_group.h
@@ -213,10 +213,8 @@ struct crt_rank_mapping {
 	d_rank_t	rm_key;
 	d_rank_t	rm_value;
 
-	uint32_t	rm_ref;
-	uint32_t	rm_initialized;
-
-	pthread_mutex_t	rm_mutex;
+	ATOMIC uint32_t	rm_ref;
+	uint32_t	rm_initialized:1;
 };
 
 /* uri info for each remote rank */
@@ -235,10 +233,10 @@ struct crt_uri_item {
 	d_rank_t	ui_rank;
 
 	/* reference count */
-	uint32_t	ui_ref;
+	ATOMIC uint32_t	ui_ref;
 
 	/* flag indicating whether initialized */
-	uint32_t	ui_initialized;
+	uint32_t	ui_initialized:1;
 
 	/* mutex for protection of ui_ref */
 	pthread_mutex_t ui_mutex;
@@ -256,7 +254,7 @@ struct crt_lookup_item {
 	hg_addr_t		 li_tag_addr[CRT_SRV_CONTEXT_NUM];
 
 	/* reference count */
-	uint32_t		 li_ref;
+	ATOMIC uint32_t		 li_ref;
 	uint32_t		 li_initialized:1;
 	pthread_mutex_t		 li_mutex;
 };

--- a/src/cart/src/cart/crt_group.h
+++ b/src/cart/src/cart/crt_group.h
@@ -42,6 +42,7 @@
 #ifndef __CRT_GROUP_H__
 #define __CRT_GROUP_H__
 
+#include <gurt/atomic.h>
 #include "crt_swim.h"
 
 
@@ -224,7 +225,7 @@ struct crt_uri_item {
 
 	/* URI string for each remote tag */
 	/* TODO: in phase2 change this to hash table */
-	crt_phy_addr_t	ui_uri[CRT_SRV_CONTEXT_NUM];
+	ATOMIC crt_phy_addr_t ui_uri[CRT_SRV_CONTEXT_NUM];
 
 	/* Primary rank; for secondary groups only  */
 	d_rank_t	ui_pri_rank;
@@ -237,9 +238,6 @@ struct crt_uri_item {
 
 	/* flag indicating whether initialized */
 	uint32_t	ui_initialized:1;
-
-	/* mutex for protection of ui_ref */
-	pthread_mutex_t ui_mutex;
 };
 
 /* lookup cache item for one target */


### PR DESCRIPTION
Avoid mutexes usage for simple atomic operations like
reference counting.