### PR TITLE
DAOS-4653 control: Update control configuration

### DIFF
--- a/doc/admin/deployment.md
+++ b/doc/admin/deployment.md
@@ -318,7 +318,7 @@ transport_config:
 ```
 
 ```yaml
-# /etc/daos/daos.yml (dmg/admin)
+# /etc/daos/daos_control.yml (dmg/admin)
 
 transport_config:
   # Custom CA Root certificate for generated certs

--- a/src/control/client/config.go
+++ b/src/control/client/config.go
@@ -41,7 +41,7 @@ import (
 const (
 	defaultRuntimeDir  = "/var/run/daos_agent"
 	defaultLogFile     = "/tmp/daos_agent.log"
-	defaultConfigPath  = "../etc/daos.yml"
+	defaultConfigPath  = "../etc/daos_control.yml"
 	defaultSystemName  = "daos_server"
 	defaultControlPort = 10001
 )

--- a/src/control/cmd/dmg/README.md
+++ b/src/control/cmd/dmg/README.md
@@ -12,7 +12,7 @@ from a login node.
 ## Certificates
 
 Local certificate locations can be specified in the
-[client config file](/utils/config/daos.yml).
+[client config file](/utils/config/daos_control.yml).
 
 For more details on how certificates are used within DAOS, see the
 [Security documentation](/src/control/security/README.md#certificate-usage-in-daos).
@@ -26,7 +26,7 @@ running listening gRPC servers that host the control service.
 
 Communications take place over the management network and addresses of
 remote storage servers to connect to can be specified on the commandline
-or in the [client config file](/utils/config/daos.yml).
+or in the [client config file](/utils/config/daos_control.yml).
 
 For details on how gRPC communications are secured and authenticated, see the
 [Security documentation](/src/control/security/README.md#host-authentication-with-certificates).

--- a/src/control/cmd/dmg/cont.go
+++ b/src/control/cmd/dmg/cont.go
@@ -39,7 +39,7 @@ type ContCmd struct {
 // ContSetOwnerCmd is the struct representing the command to change the owner of a DAOS container.
 type ContSetOwnerCmd struct {
 	logCmd
-	ctlClientCmd
+	ctlInvokerCmd
 	GroupName string `short:"g" long:"group" description:"New owner-group for the container, format name@domain"`
 	UserName  string `short:"u" long:"user" description:"New owner-user for the container, format name@domain"`
 	ContUUID  string `short:"c" long:"cont" required:"1" description:"UUID of the DAOS container"`
@@ -57,7 +57,7 @@ func (c *ContSetOwnerCmd) Execute(args []string) error {
 	}
 
 	ctx := context.Background()
-	err := control.ContSetOwner(ctx, c.ctlClient, req)
+	err := control.ContSetOwner(ctx, c.ctlInvoker, req)
 	if err != nil {
 		msg = errors.WithMessage(err, "FAILED").Error()
 	}

--- a/src/control/cmd/dmg/main.go
+++ b/src/control/cmd/dmg/main.go
@@ -248,7 +248,7 @@ func parseOpts(args []string, opts *cliOptions, invoker control.Invoker, conns c
 				if hlCmd, ok := cmd.(hostListSetter); ok {
 					hlCmd.setHostList(strings.Split(opts.HostList, ","))
 				} else {
-					return errors.Errorf("MS commands do not accept a hostlist parameter (set it in %s or %s)",
+					return errors.Errorf("this command does not accept a hostlist parameter (set it in %s or %s)",
 						control.UserConfigPath(), control.SystemConfigPath())
 				}
 			}

--- a/src/control/cmd/dmg/main.go
+++ b/src/control/cmd/dmg/main.go
@@ -37,13 +37,10 @@ import (
 	"github.com/daos-stack/daos/src/control/build"
 	"github.com/daos-stack/daos/src/control/client"
 	"github.com/daos-stack/daos/src/control/common"
+	"github.com/daos-stack/daos/src/control/common/proto/convert"
 	"github.com/daos-stack/daos/src/control/fault"
 	"github.com/daos-stack/daos/src/control/lib/control"
 	"github.com/daos-stack/daos/src/control/logging"
-)
-
-const (
-	defaultConfigFile = "daos.yml"
 )
 
 type (
@@ -59,14 +56,20 @@ type (
 		conns client.Connect
 	}
 
-	ctlClientUser interface {
-		setClient(control.Invoker)
+	hostListSetter interface {
 		setHostList([]string)
 	}
 
-	ctlClientCmd struct {
-		hostlist  []string
-		ctlClient control.Invoker
+	hostListCmd struct {
+		hostlist []string
+	}
+
+	ctlInvoker interface {
+		setInvoker(control.Invoker)
+	}
+
+	ctlInvokerCmd struct {
+		ctlInvoker control.Invoker
 	}
 
 	jsonOutputter interface {
@@ -80,11 +83,11 @@ type (
 	}
 )
 
-func (cmd *ctlClientCmd) setClient(c control.Invoker) {
-	cmd.ctlClient = c
+func (cmd *ctlInvokerCmd) setInvoker(c control.Invoker) {
+	cmd.ctlInvoker = c
 }
 
-func (cmd *ctlClientCmd) setHostList(hl []string) {
+func (cmd *hostListCmd) setHostList(hl []string) {
 	cmd.hostlist = hl
 }
 
@@ -123,18 +126,18 @@ func (c *logCmd) setLog(log *logging.LeveledLogger) {
 	c.log = log
 }
 
-// cmdConfigSetter is an interface for setting the client config on a command
+// cmdConfigSetter is an interface for setting the control config on a command
 type cmdConfigSetter interface {
-	setConfig(*client.Configuration)
+	setConfig(*control.Config)
 }
 
-// cfgCmd is a structure that can be used by commands that need the client
+// cfgCmd is a structure that can be used by commands that need the control
 // config.
 type cfgCmd struct {
-	config *client.Configuration
+	config *control.Config
 }
 
-func (c *cfgCmd) setConfig(cfg *client.Configuration) {
+func (c *cfgCmd) setConfig(cfg *control.Config) {
 	c.config = cfg
 }
 
@@ -187,12 +190,16 @@ and access control settings, along with system wide operations.`
 	p.WriteManPage(wr)
 }
 
-func parseOpts(args []string, opts *cliOptions, ctlClient control.Invoker, conns client.Connect, log *logging.LeveledLogger) error {
+func parseOpts(args []string, opts *cliOptions, invoker control.Invoker, conns client.Connect, log *logging.LeveledLogger) error {
 	p := flags.NewParser(opts, flags.Default)
 	p.Options ^= flags.PrintErrors // Don't allow the library to print errors
 	p.CommandHandler = func(cmd flags.Commander, args []string) error {
 		if cmd == nil {
 			return nil
+		}
+
+		if opts.HostFile != "" {
+			return errors.New("hostfile option not implemented")
 		}
 
 		if !opts.AllowProxy {
@@ -216,24 +223,48 @@ func parseOpts(args []string, opts *cliOptions, ctlClient control.Invoker, conns
 			logCmd.setLog(log)
 		}
 
-		if opts.ConfigPath == "" {
-			defaultConfigPath := path.Join(build.ConfigDir, defaultConfigFile)
-			if _, err := os.Stat(defaultConfigPath); err == nil {
-				opts.ConfigPath = defaultConfigPath
-			}
-		}
-
-		config, err := client.GetConfig(log, opts.ConfigPath)
-		if err != nil {
-			return errors.WithMessage(err, "processing config file")
-		}
-
-		ctlClientCfg, err := control.LoadClientConfig(opts.ConfigPath)
+		ctlCfg, err := control.LoadConfig(opts.ConfigPath)
 		if err != nil {
 			if opts.ConfigPath != "" {
-				return errors.WithMessage(err, "failed to load client configuration")
+				return errors.WithMessage(err, "failed to load control configuration")
 			}
-			ctlClientCfg = control.DefaultClientConfig()
+			ctlCfg = control.DefaultConfig()
+		}
+		if opts.ConfigPath != "" {
+			log.Debugf("control config loaded from %s", opts.ConfigPath)
+		}
+
+		if opts.Insecure {
+			ctlCfg.TransportConfig.AllowInsecure = true
+		}
+		if err := ctlCfg.TransportConfig.PreLoadCertData(); err != nil {
+			return errors.Wrap(err, "Unable to load Certificate Data")
+		}
+
+		invoker.SetConfig(ctlCfg)
+		if ctlCmd, ok := cmd.(ctlInvoker); ok {
+			ctlCmd.setInvoker(invoker)
+			if opts.HostList != "" {
+				if hlCmd, ok := cmd.(hostListSetter); ok {
+					hlCmd.setHostList(strings.Split(opts.HostList, ","))
+				} else {
+					return errors.Errorf("MS commands do not accept a hostlist parameter (set it in %s or %s)",
+						control.UserConfigPath(), control.SystemConfigPath())
+				}
+			}
+		}
+
+		if cfgCmd, ok := cmd.(cmdConfigSetter); ok {
+			cfgCmd.setConfig(ctlCfg)
+		}
+
+		// BEGIN DEPRECATED CLIENT SETUP (DAOS-4632)
+		//
+		// Temporarily set up an old-style client config based on the control
+		// config.
+		config := new(client.Configuration)
+		if err := convert.Types(ctlCfg, config); err != nil {
+			return err
 		}
 
 		if opts.HostList != "" {
@@ -244,19 +275,9 @@ func parseOpts(args []string, opts *cliOptions, ctlClient control.Invoker, conns
 			config.HostList = hostlist
 		}
 
-		if opts.HostFile != "" {
-			return errors.New("hostfile option not implemented")
-		}
-
 		if opts.Insecure {
 			config.TransportConfig.AllowInsecure = true
-			ctlClientCfg.TransportConfig.AllowInsecure = true
 		}
-
-		if err := ctlClientCfg.TransportConfig.PreLoadCertData(); err != nil {
-			return errors.Wrap(err, "Unable to load Certificate Data")
-		}
-
 		err = config.TransportConfig.PreLoadCertData()
 		if err != nil {
 			return errors.Wrap(err, "Unable to load Certificate Data")
@@ -276,18 +297,7 @@ func parseOpts(args []string, opts *cliOptions, ctlClient control.Invoker, conns
 			log.Info(connStates.String())
 			wantsConn.setConns(conns)
 		}
-
-		ctlClient.SetClientConfig(ctlClientCfg)
-		if clientCmd, ok := cmd.(ctlClientUser); ok {
-			clientCmd.setClient(ctlClient)
-			if opts.HostList != "" {
-				clientCmd.setHostList(strings.Split(opts.HostList, ","))
-			}
-		}
-
-		if cfgCmd, ok := cmd.(cmdConfigSetter); ok {
-			cfgCmd.setConfig(config)
-		}
+		// END DEPRECATED CLIENT SETUP (DAOS-4632)
 
 		if err := cmd.Execute(args); err != nil {
 			return err
@@ -305,11 +315,11 @@ func main() {
 	log := logging.NewCommandLineLogger()
 
 	conns := client.NewConnect(log)
-	ctlClient := control.NewClient(
+	ctlInvoker := control.NewClient(
 		control.WithClientLogger(log),
 	)
 
-	if err := parseOpts(os.Args[1:], &opts, ctlClient, conns, log); err != nil {
+	if err := parseOpts(os.Args[1:], &opts, ctlInvoker, conns, log); err != nil {
 		exitWithError(log, err)
 	}
 }

--- a/src/control/cmd/dmg/network.go
+++ b/src/control/cmd/dmg/network.go
@@ -42,7 +42,8 @@ type NetCmd struct {
 // that match the given fabric provider.
 type networkScanCmd struct {
 	logCmd
-	ctlClientCmd
+	ctlInvokerCmd
+	hostListCmd
 	jsonOutputCmd
 	FabricProvider string `short:"p" long:"provider" description:"Filter device list to those that support the given OFI provider (default is the provider specified in daos_server.yml)"`
 	AllProviders   bool   `short:"a" long:"all" description:"Specify 'all' to see all devices on all providers.  Overrides --provider"`
@@ -57,7 +58,7 @@ func (cmd *networkScanCmd) Execute(_ []string) error {
 
 	cmd.log.Debugf("network scan req: %+v", req)
 
-	resp, err := control.NetworkScan(ctx, cmd.ctlClient, req)
+	resp, err := control.NetworkScan(ctx, cmd.ctlInvoker, req)
 	if err != nil {
 		return err
 	}
@@ -80,7 +81,8 @@ func (cmd *networkScanCmd) Execute(_ []string) error {
 
 type networkListCmd struct {
 	logCmd
-	ctlClientCmd
+	ctlInvokerCmd
+	hostListCmd
 	jsonOutputCmd
 }
 
@@ -92,7 +94,7 @@ func (cmd *networkListCmd) Execute(_ []string) error {
 
 	cmd.log.Debugf("network scan req: %+v", req)
 
-	resp, err := control.NetworkScan(ctx, cmd.ctlClient, req)
+	resp, err := control.NetworkScan(ctx, cmd.ctlInvoker, req)
 	if err != nil {
 		return err
 	}

--- a/src/control/cmd/dmg/pool.go
+++ b/src/control/cmd/dmg/pool.go
@@ -59,7 +59,7 @@ type PoolCmd struct {
 // PoolCreateCmd is the struct representing the command to create a DAOS pool.
 type PoolCreateCmd struct {
 	logCmd
-	ctlClientCmd
+	ctlInvokerCmd
 	jsonOutputCmd
 	GroupName  string `short:"g" long:"group" description:"DAOS pool to be owned by given group, format name@domain"`
 	UserName   string `short:"u" long:"user" description:"DAOS pool to be owned by given user, format name@domain"`
@@ -115,7 +115,7 @@ func (c *PoolCreateCmd) Execute(args []string) error {
 	}
 
 	ctx := context.Background()
-	resp, err := control.PoolCreate(ctx, c.ctlClient, req)
+	resp, err := control.PoolCreate(ctx, c.ctlInvoker, req)
 
 	if c.jsonOutputEnabled() {
 		return c.outputJSON(os.Stdout, resp)
@@ -136,7 +136,7 @@ func (c *PoolCreateCmd) Execute(args []string) error {
 // PoolDestroyCmd is the struct representing the command to destroy a DAOS pool.
 type PoolDestroyCmd struct {
 	logCmd
-	ctlClientCmd
+	ctlInvokerCmd
 	// TODO: implement --sys & --svc options (currently unsupported server side)
 	UUID  string `long:"pool" required:"1" description:"UUID of DAOS pool to destroy"`
 	Force bool   `short:"f" long:"force" description:"Force removal of DAOS pool"`
@@ -149,7 +149,7 @@ func (d *PoolDestroyCmd) Execute(args []string) error {
 	req := &control.PoolDestroyReq{UUID: d.UUID, Force: d.Force}
 
 	ctx := context.Background()
-	err := control.PoolDestroy(ctx, d.ctlClient, req)
+	err := control.PoolDestroy(ctx, d.ctlInvoker, req)
 	if err != nil {
 		msg = errors.WithMessage(err, "failed").Error()
 	}
@@ -162,7 +162,7 @@ func (d *PoolDestroyCmd) Execute(args []string) error {
 // PoolReintegrateCmd is the struct representing the command to Add a DAOS target.
 type PoolReintegrateCmd struct {
 	logCmd
-	ctlClientCmd
+	ctlInvokerCmd
 	UUID      string `long:"pool" required:"1" description:"UUID of the DAOS pool to start reintegration in"`
 	Rank      uint32 `long:"rank" required:"1" description:"Rank of the targets to be reintegrated"`
 	Targetidx string `long:"target-idx" required:"1" description:"Comma-seperated list of target idx(s) to be reintegrated into the rank"`
@@ -180,7 +180,7 @@ func (r *PoolReintegrateCmd) Execute(args []string) error {
 	req := &control.PoolReintegrateReq{UUID: r.UUID, Rank: r.Rank, Targetidx: idxlist}
 
 	ctx := context.Background()
-	err := control.PoolReintegrate(ctx, r.ctlClient, req)
+	err := control.PoolReintegrate(ctx, r.ctlInvoker, req)
 	if err != nil {
 		msg = errors.WithMessage(err, "failed").Error()
 	}
@@ -193,7 +193,7 @@ func (r *PoolReintegrateCmd) Execute(args []string) error {
 // PoolQueryCmd is the struct representing the command to query a DAOS pool.
 type PoolQueryCmd struct {
 	logCmd
-	ctlClientCmd
+	ctlInvokerCmd
 	jsonOutputCmd
 	UUID string `long:"pool" required:"1" description:"UUID of DAOS pool to query"`
 }
@@ -205,7 +205,7 @@ func (c *PoolQueryCmd) Execute(args []string) error {
 	}
 
 	ctx := context.Background()
-	resp, err := control.PoolQuery(ctx, c.ctlClient, req)
+	resp, err := control.PoolQuery(ctx, c.ctlInvoker, req)
 	if err != nil {
 		return errors.Wrap(err, "pool query failed")
 	}
@@ -225,7 +225,7 @@ func (c *PoolQueryCmd) Execute(args []string) error {
 // PoolSetPropCmd represents the command to set a property on a pool.
 type PoolSetPropCmd struct {
 	logCmd
-	ctlClientCmd
+	ctlInvokerCmd
 	jsonOutputCmd
 	UUID     string `long:"pool" required:"1" description:"UUID of DAOS pool"`
 	Property string `short:"n" long:"name" required:"1" description:"Name of property to be set"`
@@ -245,7 +245,7 @@ func (c *PoolSetPropCmd) Execute(_ []string) error {
 	}
 
 	ctx := context.Background()
-	resp, err := control.PoolSetProp(ctx, c.ctlClient, req)
+	resp, err := control.PoolSetProp(ctx, c.ctlInvoker, req)
 	if err != nil {
 		return errors.Wrap(err, "pool set-prop failed")
 	}
@@ -262,7 +262,7 @@ func (c *PoolSetPropCmd) Execute(_ []string) error {
 // DAOS pool.
 type PoolGetACLCmd struct {
 	logCmd
-	ctlClientCmd
+	ctlInvokerCmd
 	jsonOutputCmd
 	UUID    string `long:"pool" required:"1" description:"UUID of DAOS pool"`
 	File    string `short:"o" long:"outfile" required:"0" description:"Output ACL to file"`
@@ -275,7 +275,7 @@ func (d *PoolGetACLCmd) Execute(args []string) error {
 	req := &control.PoolGetACLReq{UUID: d.UUID}
 
 	ctx := context.Background()
-	resp, err := control.PoolGetACL(ctx, d.ctlClient, req)
+	resp, err := control.PoolGetACL(ctx, d.ctlInvoker, req)
 	if err != nil {
 		return errors.Wrap(err, "Pool-get-ACL command failed")
 	}
@@ -330,7 +330,7 @@ func (d *PoolGetACLCmd) writeACLToFile(acl string) error {
 // List of a DAOS pool.
 type PoolOverwriteACLCmd struct {
 	logCmd
-	ctlClientCmd
+	ctlInvokerCmd
 	jsonOutputCmd
 	UUID    string `long:"pool" required:"1" description:"UUID of DAOS pool"`
 	ACLFile string `short:"a" long:"acl-file" required:"1" description:"Path for new Access Control List file"`
@@ -349,7 +349,7 @@ func (d *PoolOverwriteACLCmd) Execute(args []string) error {
 	}
 
 	ctx := context.Background()
-	resp, err := control.PoolOverwriteACL(ctx, d.ctlClient, req)
+	resp, err := control.PoolOverwriteACL(ctx, d.ctlInvoker, req)
 	if err != nil {
 		return errors.Wrap(err, "Pool-overwrite-ACL command failed")
 	}
@@ -369,7 +369,7 @@ func (d *PoolOverwriteACLCmd) Execute(args []string) error {
 // a DAOS pool.
 type PoolUpdateACLCmd struct {
 	logCmd
-	ctlClientCmd
+	ctlInvokerCmd
 	jsonOutputCmd
 	UUID    string `long:"pool" required:"1" description:"UUID of DAOS pool"`
 	ACLFile string `short:"a" long:"acl-file" required:"0" description:"Path for new Access Control List file"`
@@ -401,7 +401,7 @@ func (d *PoolUpdateACLCmd) Execute(args []string) error {
 	}
 
 	ctx := context.Background()
-	resp, err := control.PoolUpdateACL(ctx, d.ctlClient, req)
+	resp, err := control.PoolUpdateACL(ctx, d.ctlInvoker, req)
 	if err != nil {
 		return errors.Wrap(err, "Pool-update-ACL command failed")
 	}
@@ -421,7 +421,7 @@ func (d *PoolUpdateACLCmd) Execute(args []string) error {
 // Control List of a DAOS pool.
 type PoolDeleteACLCmd struct {
 	logCmd
-	ctlClientCmd
+	ctlInvokerCmd
 	jsonOutputCmd
 	UUID      string `long:"pool" required:"1" description:"UUID of DAOS pool"`
 	Principal string `short:"p" long:"principal" required:"1" description:"Principal whose entry should be removed"`
@@ -435,7 +435,7 @@ func (d *PoolDeleteACLCmd) Execute(args []string) error {
 	}
 
 	ctx := context.Background()
-	resp, err := control.PoolDeleteACL(ctx, d.ctlClient, req)
+	resp, err := control.PoolDeleteACL(ctx, d.ctlInvoker, req)
 	if err != nil {
 		return errors.Wrap(err, "Pool-delete-ACL command failed")
 	}

--- a/src/control/cmd/dmg/storage.go
+++ b/src/control/cmd/dmg/storage.go
@@ -49,7 +49,8 @@ type storageCmd struct {
 // storagePrepareCmd is the struct representing the prep storage subcommand.
 type storagePrepareCmd struct {
 	logCmd
-	ctlClientCmd
+	ctlInvokerCmd
+	hostListCmd
 	jsonOutputCmd
 	types.StoragePrepareCmd
 }
@@ -86,7 +87,7 @@ func (cmd *storagePrepareCmd) Execute(args []string) error {
 		SCM:  sReq,
 	}
 	req.SetHostList(cmd.hostlist)
-	resp, err := control.StoragePrepare(ctx, cmd.ctlClient, req)
+	resp, err := control.StoragePrepare(ctx, cmd.ctlInvoker, req)
 	if err != nil {
 		return err
 	}
@@ -110,7 +111,8 @@ func (cmd *storagePrepareCmd) Execute(args []string) error {
 // storageScanCmd is the struct representing the scan storage subcommand.
 type storageScanCmd struct {
 	logCmd
-	ctlClientCmd
+	ctlInvokerCmd
+	hostListCmd
 	jsonOutputCmd
 	Verbose bool `short:"v" long:"verbose" description:"List SCM & NVMe device details"`
 }
@@ -122,7 +124,7 @@ func (cmd *storageScanCmd) Execute(_ []string) error {
 	ctx := context.Background()
 	req := &control.StorageScanReq{}
 	req.SetHostList(cmd.hostlist)
-	resp, err := control.StorageScan(ctx, cmd.ctlClient, req)
+	resp, err := control.StorageScan(ctx, cmd.ctlInvoker, req)
 	if err != nil {
 		return err
 	}
@@ -147,7 +149,8 @@ func (cmd *storageScanCmd) Execute(_ []string) error {
 // storageFormatCmd is the struct representing the format storage subcommand.
 type storageFormatCmd struct {
 	logCmd
-	ctlClientCmd
+	ctlInvokerCmd
+	hostListCmd
 	jsonOutputCmd
 	Verbose  bool `short:"v" long:"verbose" description:"Show results of each SCM & NVMe device format operation"`
 	Reformat bool `long:"reformat" description:"Always reformat storage (CAUTION: Potentially destructive)"`
@@ -162,7 +165,7 @@ func (cmd *storageFormatCmd) Execute(args []string) error {
 		Reformat: cmd.Reformat,
 	}
 	req.SetHostList(cmd.hostlist)
-	resp, err := control.StorageFormat(ctx, cmd.ctlClient, req)
+	resp, err := control.StorageFormat(ctx, cmd.ctlInvoker, req)
 	if err != nil {
 		return err
 	}

--- a/src/control/cmd/dmg/storage_query.go
+++ b/src/control/cmd/dmg/storage_query.go
@@ -49,7 +49,8 @@ type storageQueryCmd struct {
 // an alias for "storage scan").
 type nvmeHealthQueryCmd struct {
 	logCmd
-	ctlClientCmd
+	ctlInvokerCmd
+	hostListCmd
 	jsonOutputCmd
 }
 
@@ -59,7 +60,7 @@ func (cmd *nvmeHealthQueryCmd) Execute(args []string) error {
 	ctx := context.Background()
 	req := &control.StorageScanReq{}
 	req.SetHostList(cmd.hostlist)
-	resp, err := control.StorageScan(ctx, cmd.ctlClient, req)
+	resp, err := control.StorageScan(ctx, cmd.ctlInvoker, req)
 	if err != nil {
 		return err
 	}

--- a/src/control/cmd/dmg/system.go
+++ b/src/control/cmd/dmg/system.go
@@ -51,13 +51,13 @@ type SystemCmd struct {
 type leaderQueryCmd struct {
 	logCmd
 	cfgCmd
-	ctlClientCmd
+	ctlInvokerCmd
 	jsonOutputCmd
 }
 
 func (cmd *leaderQueryCmd) Execute(_ []string) error {
 	ctx := context.Background()
-	resp, err := control.LeaderQuery(ctx, cmd.ctlClient, &control.LeaderQueryReq{
+	resp, err := control.LeaderQuery(ctx, cmd.ctlInvoker, &control.LeaderQueryReq{
 		System: cmd.config.SystemName,
 	})
 	if err != nil {
@@ -149,7 +149,7 @@ func displaySystemQuerySingle(log logging.Logger, members system.Members) error 
 // systemQueryCmd is the struct representing the command to query system status.
 type systemQueryCmd struct {
 	logCmd
-	ctlClientCmd
+	ctlInvokerCmd
 	jsonOutputCmd
 	Verbose bool   `long:"verbose" short:"v" description:"Display more member details"`
 	Ranks   string `long:"ranks" short:"r" description:"Comma separated list of system ranks to query"`
@@ -163,7 +163,7 @@ func (cmd *systemQueryCmd) Execute(_ []string) error {
 	}
 
 	ctx := context.Background()
-	resp, err := control.SystemQuery(ctx, cmd.ctlClient, &control.SystemQueryReq{
+	resp, err := control.SystemQuery(ctx, cmd.ctlInvoker, &control.SystemQueryReq{
 		Ranks: system.RanksFromUint32(ranks),
 	})
 	if err != nil {
@@ -220,7 +220,7 @@ func displaySystemAction(log logging.Logger, results system.MemberResults) error
 // systemStopCmd is the struct representing the command to shutdown DAOS system.
 type systemStopCmd struct {
 	logCmd
-	ctlClientCmd
+	ctlInvokerCmd
 	jsonOutputCmd
 	Force bool   `long:"force" description:"Force stop DAOS system members"`
 	Ranks string `long:"ranks" short:"r" description:"Comma separated list of system ranks to query"`
@@ -236,7 +236,7 @@ func (cmd *systemStopCmd) Execute(_ []string) error {
 	}
 
 	ctx := context.Background()
-	resp, err := control.SystemStop(ctx, cmd.ctlClient, &control.SystemStopReq{
+	resp, err := control.SystemStop(ctx, cmd.ctlInvoker, &control.SystemStopReq{
 		Prep:  true,
 		Kill:  true,
 		Force: cmd.Force,
@@ -262,7 +262,7 @@ func (cmd *systemStopCmd) Execute(_ []string) error {
 // systemStartCmd is the struct representing the command to start system.
 type systemStartCmd struct {
 	logCmd
-	ctlClientCmd
+	ctlInvokerCmd
 	jsonOutputCmd
 	Ranks string `long:"ranks" short:"r" description:"Comma separated list of system ranks to query"`
 }
@@ -275,7 +275,7 @@ func (cmd *systemStartCmd) Execute(_ []string) error {
 	}
 
 	ctx := context.Background()
-	resp, err := control.SystemStart(ctx, cmd.ctlClient, &control.SystemStartReq{
+	resp, err := control.SystemStart(ctx, cmd.ctlInvoker, &control.SystemStartReq{
 		Ranks: system.RanksFromUint32(ranks),
 	})
 	if err != nil {
@@ -299,7 +299,7 @@ func (cmd *systemStartCmd) Execute(_ []string) error {
 type systemListPoolsCmd struct {
 	logCmd
 	cfgCmd
-	ctlClientCmd
+	ctlInvokerCmd
 	jsonOutputCmd
 }
 
@@ -322,7 +322,7 @@ func (cmd *systemListPoolsCmd) Execute(_ []string) error {
 	}
 
 	ctx := context.Background()
-	resp, err := control.ListPools(ctx, cmd.ctlClient, &control.ListPoolsReq{
+	resp, err := control.ListPools(ctx, cmd.ctlInvoker, &control.ListPoolsReq{
 		System: cmd.config.SystemName,
 	})
 	if err != nil {

--- a/src/control/lib/control/config.go
+++ b/src/control/lib/control/config.go
@@ -39,7 +39,7 @@ const (
 	defaultConfigFile = "daos_control.yml"
 )
 
-// Config defines the paramters used to connect to the control API server.
+// Config defines the parameters used to connect to a control API server.
 type Config struct {
 	SystemName      string                    `yaml:"name"`
 	ControlPort     int                       `yaml:"port"`

--- a/src/control/lib/control/config_test.go
+++ b/src/control/lib/control/config_test.go
@@ -1,0 +1,139 @@
+//
+// (C) Copyright 2020 Intel Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// GOVERNMENT LICENSE RIGHTS-OPEN SOURCE SOFTWARE
+// The Government's rights to use, modify, reproduce, release, perform, display,
+// or disclose this software are subject to the terms of the Apache License as
+// provided in Contract No. 8F-30005.
+// Any reproduction of computer software, computer software documentation, or
+// portions thereof marked with this legend must also reproduce the markings.
+//
+
+package control
+
+import (
+	"io/ioutil"
+	"os"
+	"path"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	"gopkg.in/yaml.v2"
+
+	"github.com/daos-stack/daos/src/control/build"
+	"github.com/daos-stack/daos/src/control/common"
+	"github.com/daos-stack/daos/src/control/security"
+)
+
+var testCfg = DefaultConfig()
+
+func saveConfig(t *testing.T, cfg *Config, cfgPath string) {
+	t.Helper()
+
+	data, err := yaml.Marshal(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := ioutil.WriteFile(cfgPath, data, 0644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func setDirs(t *testing.T, newHome, newSys string) func(t *testing.T) {
+	t.Helper()
+
+	// NB: This is safe because each package's tests are in
+	// their own binary, and tests within a package run sequentially.
+	curHome, err := os.UserHomeDir()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Setenv("HOME", newHome); err != nil {
+		t.Fatal(err)
+	}
+
+	curSys := build.ConfigDir
+	build.ConfigDir = newSys
+
+	return func(t *testing.T) {
+		_ = setDirs(t, curHome, curSys)
+	}
+}
+
+func TestControl_LoadSystemConfig(t *testing.T) {
+	tmpDir, cleanup := common.CreateTestDir(t)
+	defer cleanup()
+
+	restore := setDirs(t, "NONE", tmpDir)
+	defer restore(t)
+	saveConfig(t, testCfg, SystemConfigPath())
+
+	gotCfg, err := LoadConfig("")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	cmpOpts := []cmp.Option{
+		cmpopts.IgnoreUnexported(security.CertificateConfig{}),
+	}
+	if diff := cmp.Diff(testCfg, gotCfg, cmpOpts...); diff != "" {
+		t.Fatalf("loaded cfg doesn't match (-want, +got):\n%s\n", diff)
+	}
+}
+
+func TestControl_LoadUserConfig(t *testing.T) {
+	tmpDir, cleanup := common.CreateTestDir(t)
+	defer cleanup()
+
+	restore := setDirs(t, tmpDir, "NONE")
+	defer restore(t)
+	saveConfig(t, testCfg, UserConfigPath())
+
+	gotCfg, err := LoadConfig("")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	cmpOpts := []cmp.Option{
+		cmpopts.IgnoreUnexported(security.CertificateConfig{}),
+	}
+	if diff := cmp.Diff(testCfg, gotCfg, cmpOpts...); diff != "" {
+		t.Fatalf("loaded cfg doesn't match (-want, +got):\n%s\n", diff)
+	}
+}
+
+func TestControl_LoadSpecifiedConfig(t *testing.T) {
+	tmpDir, cleanup := common.CreateTestDir(t)
+	defer cleanup()
+
+	restore := setDirs(t, "NONE", "NONE")
+	defer restore(t)
+	testPath := path.Join(tmpDir, "test.yml")
+	saveConfig(t, testCfg, testPath)
+
+	gotCfg, err := LoadConfig(testPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	cmpOpts := []cmp.Option{
+		cmpopts.IgnoreUnexported(security.CertificateConfig{}),
+	}
+	if diff := cmp.Diff(testCfg, gotCfg, cmpOpts...); diff != "" {
+		t.Fatalf("loaded cfg doesn't match (-want, +got):\n%s\n", diff)
+	}
+}

--- a/src/control/lib/control/hostlist.go
+++ b/src/control/lib/control/hostlist.go
@@ -80,7 +80,7 @@ func ParseHostList(in []string, defaultPort int) (out []string, err error) {
 //     to the entire hostlist set in the configuration.
 //
 // Will always return at least 1 host, or an error.
-func getRequestHosts(cfg *ClientConfig, req targetChooser) (hosts []string, err error) {
+func getRequestHosts(cfg *Config, req targetChooser) (hosts []string, err error) {
 	hosts = req.getHostList()
 	if len(hosts) == 0 {
 		if len(cfg.HostList) == 0 {

--- a/src/control/lib/control/hostlist_test.go
+++ b/src/control/lib/control/hostlist_test.go
@@ -51,7 +51,7 @@ func mockHostList(hosts ...string) []string {
 }
 
 func TestControl_ParseHostList(t *testing.T) {
-	defaultCfg := DefaultClientConfig()
+	defaultCfg := DefaultConfig()
 
 	for name, tc := range map[string]struct {
 		in     []string
@@ -112,20 +112,20 @@ func TestControl_ParseHostList(t *testing.T) {
 }
 
 func TestControl_getRequestHosts(t *testing.T) {
-	defaultCfg := DefaultClientConfig()
+	defaultCfg := DefaultConfig()
 	defaultCfg.HostList = mockHostList("a", "b", "c")
 	for i, host := range defaultCfg.HostList {
 		defaultCfg.HostList[i] = fmt.Sprintf("%s:%d", host, defaultCfg.ControlPort)
 	}
 
 	for name, tc := range map[string]struct {
-		cfg    *ClientConfig
+		cfg    *Config
 		req    targetChooser
 		expOut []string
 		expErr error
 	}{
 		"bad hostname in config": {
-			cfg: &ClientConfig{
+			cfg: &Config{
 				ControlPort: 42,
 				HostList:    mockHostList("::"),
 			},
@@ -140,14 +140,14 @@ func TestControl_getRequestHosts(t *testing.T) {
 			expErr: errors.New("invalid host"),
 		},
 		"invalid config control port": {
-			cfg: &ClientConfig{
+			cfg: &Config{
 				HostList: mockHostList("foo"),
 			},
 			req:    &testTgtChooser{},
 			expErr: FaultConfigBadControlPort,
 		},
 		"empty config hostlist": {
-			cfg:    &ClientConfig{},
+			cfg:    &Config{},
 			req:    &testTgtChooser{},
 			expErr: FaultConfigEmptyHostList,
 		},

--- a/src/control/lib/control/mocks.go
+++ b/src/control/lib/control/mocks.go
@@ -103,7 +103,7 @@ func (mi *MockInvoker) InvokeUnaryRPCAsync(_ context.Context, _ UnaryRequest) (H
 	return mi.cfg.HostResponses, mi.cfg.UnaryError
 }
 
-func (mi *MockInvoker) SetClientConfig(_ *ClientConfig) {}
+func (mi *MockInvoker) SetConfig(_ *Config) {}
 
 // DefaultMockInvokerConfig returns the default MockInvoker
 // configuration.

--- a/src/control/lib/control/rpc.go
+++ b/src/control/lib/control/rpc.go
@@ -64,7 +64,7 @@ type (
 	Invoker interface {
 		UnaryInvoker
 		//TODO: StreamInvoker
-		SetClientConfig(*ClientConfig)
+		SetConfig(*Config)
 	}
 )
 
@@ -89,7 +89,7 @@ type (
 	// Client implements the Invoker interface and should be provided to
 	// API methods to invoke RPCs.
 	Client struct {
-		config *ClientConfig
+		config *Config
 		log    debugLogger
 	}
 
@@ -104,8 +104,8 @@ func WithClientLogger(log debugLogger) ClientOption {
 	}
 }
 
-// WithClientConfig sets the client's configuration.
-func WithClientConfig(cfg *ClientConfig) ClientOption {
+// WithConfig sets the client's configuration.
+func WithConfig(cfg *Config) ClientOption {
 	return func(c *Client) {
 		c.config = cfg
 	}
@@ -115,7 +115,7 @@ func WithClientConfig(cfg *ClientConfig) ClientOption {
 // parameters set by the provided ClientOption list.
 func NewClient(opts ...ClientOption) *Client {
 	c := &Client{
-		config: DefaultClientConfig(),
+		config: DefaultConfig(),
 	}
 
 	for _, opt := range opts {
@@ -133,14 +133,14 @@ func NewClient(opts ...ClientOption) *Client {
 // parameters set to default values.
 func DefaultClient() *Client {
 	return NewClient(
-		WithClientConfig(DefaultClientConfig()),
+		WithConfig(DefaultConfig()),
 		WithClientLogger(defaultLogger),
 	)
 }
 
-// SetClientConfig sets the client configuration for an
+// SetConfig sets the client configuration for an
 // existing Client.
-func (c *Client) SetClientConfig(cfg *ClientConfig) {
+func (c *Client) SetConfig(cfg *Config) {
 	c.config = cfg
 }
 

--- a/src/control/lib/control/rpc_test.go
+++ b/src/control/lib/control/rpc_test.go
@@ -78,7 +78,7 @@ type ctxCancel struct {
 }
 
 func TestControl_InvokeUnaryRPCAsync(t *testing.T) {
-	clientCfg := DefaultClientConfig()
+	clientCfg := DefaultConfig()
 	clientCfg.TransportConfig.AllowInsecure = true
 
 	for name, tc := range map[string]struct {
@@ -141,7 +141,7 @@ func TestControl_InvokeUnaryRPCAsync(t *testing.T) {
 			goRoutinesAtStart := runtime.NumGoroutine()
 
 			client := NewClient(
-				WithClientConfig(clientCfg),
+				WithConfig(clientCfg),
 				WithClientLogger(log),
 			)
 
@@ -201,7 +201,7 @@ func TestControl_InvokeUnaryRPCAsync(t *testing.T) {
 }
 
 func TestControl_InvokeUnaryRPC(t *testing.T) {
-	clientCfg := DefaultClientConfig()
+	clientCfg := DefaultConfig()
 	clientCfg.TransportConfig.AllowInsecure = true
 
 	for name, tc := range map[string]struct {
@@ -266,7 +266,7 @@ func TestControl_InvokeUnaryRPC(t *testing.T) {
 			defer common.ShowBufferOnFailure(t, buf)
 
 			client := NewClient(
-				WithClientConfig(clientCfg),
+				WithConfig(clientCfg),
 				WithClientLogger(log),
 			)
 

--- a/utils/config/SConscript
+++ b/utils/config/SConscript
@@ -5,7 +5,7 @@ def scons():
     """Execute build"""
     Import('env', 'CONF_DIR')
 
-    env.Install(CONF_DIR, ['daos_server.yml', 'daos.yml',
+    env.Install(CONF_DIR, ['daos_server.yml', 'daos_control.yml',
                            'daos_agent.yml'])
 
 if __name__ == "SCons.Script":

--- a/utils/config/daos_agent.yml
+++ b/utils/config/daos_agent.yml
@@ -1,10 +1,10 @@
 # DAOS client configuration file.
 #
 # Location of this configuration file is determined by first checking for the
-# path specified through the -o option of the daos_agent and DMG command line.
-# Otherwise, etc/daos.yml is used.
+# path specified through the -o option of the daos_agent command line.
+# Otherwise, etc/daos_agent.yml is used.
 #
-# Section describing the client configuration
+# Section describing the agent configuration
 #
 # Although not supported for now, one might want to connect to multiple
 # DAOS installations from the same node in the future.

--- a/utils/config/daos_control.yml
+++ b/utils/config/daos_control.yml
@@ -1,10 +1,10 @@
-# DAOS client configuration file.
+# DAOS control configuration file.
 #
 # Location of this configuration file is determined by first checking for the
-# path specified through the -o option of the daos_agent and DMG command line.
-# Otherwise, etc/daos.yml is used.
+# path specified through the -o option of the dmg command line.
+# Otherwise, etc/daos_control.yml is used.
 #
-# Section describing the client configuration
+# Section describing the control configuration
 #
 # Although not supported for now, one might want to connect to multiple
 # DAOS installations from the same node in the future.

--- a/utils/config/daos_server.yml
+++ b/utils/config/daos_server.yml
@@ -1,7 +1,7 @@
 ## DAOS server configuration file.
 #
 ## Location of this configuration file is determined by first checking for the
-## path specified through the -f option of the daos_server command line.
+## path specified through the -o option of the daos_server command line.
 ## Otherwise, /etc/daos_server.conf is used.
 #
 #

--- a/utils/rpms/daos.spec
+++ b/utils/rpms/daos.spec
@@ -6,7 +6,7 @@
 
 Name:          daos
 Version:       1.1.0
-Release:       12%{?relval}%{?dist}
+Release:       13%{?relval}%{?dist}
 Summary:       DAOS Storage Engine
 
 License:       Apache
@@ -314,7 +314,7 @@ getent group daos_admins >/dev/null || groupadd -r daos_admins
 %endif
 %{_datadir}/%{name}/ioil-ld-opts
 %config(noreplace) %{conf_dir}/daos_agent.yml
-%config(noreplace) %{conf_dir}/daos.yml
+%config(noreplace) %{conf_dir}/daos_control.yml
 %{_unitdir}/%{agent_svc_name}
 %{_mandir}/man8/daos.8*
 %{_mandir}/man8/dmg.8*
@@ -345,6 +345,9 @@ getent group daos_admins >/dev/null || groupadd -r daos_admins
 %{_libdir}/*.a
 
 %changelog
+* Mon Apr 27 2020 Michael MacDonald <mjmac.macdonald@intel.com> 1.1.0-13
+- Rename /etc/daos.yml -> /etc/daos_control.yml
+
 * Thu Apr 16 2020 Brian J. Murrell <brian.murrell@intel.com> - 1.1.0-12
 - Use distro fuse
 


### PR DESCRIPTION
As part of the move to the new Control API, the configuration file has been
renamed from daos.yml to daos_control.yml in order to better convey its
relationship to what's being configured.

In addition to this renaming and general code reorganization, a check has
been added to exit with an informative error when a hostlist is supplied
for a dmg command that connects to the Management Service (e.g. pool
operations). This is necessary to ensure that the correct AP is chosen when
the Replicated Management Service feature lands.