### PR TITLE
DAOS-4644 test: Fix cmocka XML files issue for vos_test

### DIFF
--- a/src/vos/tests/vos_tests.c
+++ b/src/vos/tests/vos_tests.c
@@ -39,7 +39,7 @@
 #include <daos_srv/vos.h>
 #include <vos_internal.h>
 
-char	cfg[50];
+static char	config_description[50];
 
 static void
 print_usage()
@@ -88,33 +88,38 @@ run_all_tests(int keys, bool nest_iterators)
 	int	length = 0;
 	char	*bypass = getenv("DAOS_IO_BYPASS");
 
-	length += sprintf(cfg+length, "keys=%d", keys);
+	length += sprintf(config_description+length, "keys=%d", keys);
 
 	if (bypass)
-		length += sprintf(cfg+length, " bypass=%s", bypass);
+		length += sprintf(config_description+length,
+				  " bypass=%s", bypass);
 	else
-		length += sprintf(cfg+length, " bypass=none");
+		length += sprintf(config_description+length,
+				  " bypass=none");
 	if (nest_iterators)
-		length += sprintf(cfg+length, " iterator=nested");
+		length += sprintf(config_description+length,
+				  " iterator=nested");
 	else
-		length += sprintf(cfg+length, " iterator=standalone");
+		length += sprintf(config_description+length,
+				  " iterator=standalone");
 
-	failed += run_pm_tests(cfg);
-	failed += run_pool_test(cfg);
-	failed += run_co_test(cfg);
+	failed += run_pm_tests(config_description);
+	failed += run_pool_test(config_description);
+	failed += run_co_test(config_description);
 	for (i = 0; dkey_feats[i] >= 0; i++) {
 		for (j = 0; akey_feats[j] >= 0; j++) {
 			feats = dkey_feats[i] | akey_feats[j];
-			failed += run_io_test(feats, keys, nest_iterators, cfg);
+			failed += run_io_test(feats, keys, nest_iterators,
+					      config_description);
 		}
 	}
-	failed += run_discard_tests(cfg);
-	failed += run_aggregate_tests(false, cfg);
-	failed += run_gc_tests(cfg);
-	failed += run_dtx_tests(cfg);
-	failed += run_ilog_tests(cfg);
-	failed += run_csum_extent_tests(cfg);
-	failed += run_mvcc_tests(cfg);
+	failed += run_discard_tests(config_description);
+	failed += run_aggregate_tests(false, config_description);
+	failed += run_gc_tests(config_description);
+	failed += run_dtx_tests(config_description);
+	failed += run_ilog_tests(config_description);
+	failed += run_csum_extent_tests(config_description);
+	failed += run_mvcc_tests(config_description);
 	return failed;
 }
 
@@ -202,11 +207,11 @@ main(int argc, char **argv)
 				  long_options, &index)) != -1) {
 		switch (opt) {
 		case 'p':
-			nr_failed += run_pool_test(cfg);
+			nr_failed += run_pool_test(config_description);
 			test_run = true;
 			break;
 		case 'c':
-			nr_failed += run_co_test(cfg);
+			nr_failed += run_co_test(config_description);
 			test_run = true;
 			break;
 		case 'n':
@@ -215,27 +220,29 @@ main(int argc, char **argv)
 		case 'i':
 			ofeats = strtol(optarg, NULL, 16);
 			nr_failed += run_io_test(ofeats, 0,
-						 nest_iterators, cfg);
+						 nest_iterators,
+						 config_description);
 			test_run = true;
 			break;
 		case 'a':
-			nr_failed += run_aggregate_tests(true, cfg);
+			nr_failed += run_aggregate_tests(true,
+							 config_description);
 			test_run = true;
 			break;
 		case 'd':
-			nr_failed += run_discard_tests(cfg);
+			nr_failed += run_discard_tests(config_description);
 			test_run = true;
 			break;
 		case 'g':
-			nr_failed += run_gc_tests(cfg);
+			nr_failed += run_gc_tests(config_description);
 			test_run = true;
 			break;
 		case 'X':
-			nr_failed += run_dtx_tests(cfg);
+			nr_failed += run_dtx_tests(config_description);
 			test_run = true;
 			break;
 		case 'm':
-			nr_failed += run_pm_tests(cfg);
+			nr_failed += run_pm_tests(config_description);
 			test_run = true;
 			break;
 		case 'A':
@@ -244,11 +251,11 @@ main(int argc, char **argv)
 			test_run = true;
 			break;
 		case 'l':
-			nr_failed += run_ilog_tests(cfg);
+			nr_failed += run_ilog_tests(config_description);
 			test_run = true;
 			break;
 		case 'z':
-			nr_failed += run_csum_extent_tests(cfg);
+			nr_failed += run_csum_extent_tests(config_description);
 			test_run = true;
 			break;
 		case 't':
@@ -256,7 +263,7 @@ main(int argc, char **argv)
 			test_run = true;
 			break;
 		case 'C':
-			nr_failed += run_mvcc_tests(cfg);
+			nr_failed += run_mvcc_tests(config_description);
 			test_run = true;
 			break;
 		case 'f':

--- a/src/vos/tests/vos_tests.c
+++ b/src/vos/tests/vos_tests.c
@@ -39,6 +39,8 @@
 #include <daos_srv/vos.h>
 #include <vos_internal.h>
 
+char	cfg[50];
+
 static void
 print_usage()
 {
@@ -83,23 +85,36 @@ run_all_tests(int keys, bool nest_iterators)
 	int	feats;
 	int	i;
 	int	j;
+	int	length = 0;
+	char	*bypass = getenv("DAOS_IO_BYPASS");
 
-	failed += run_pm_tests();
-	failed += run_pool_test();
-	failed += run_co_test();
+	length += sprintf(cfg+length, "keys=%d", keys);
+
+	if (bypass)
+		length += sprintf(cfg+length, " bypass=%s", bypass);
+	else
+		length += sprintf(cfg+length, " bypass=none");
+	if (nest_iterators)
+		length += sprintf(cfg+length, " iterator=nested");
+	else
+		length += sprintf(cfg+length, " iterator=standalone");
+
+	failed += run_pm_tests(cfg);
+	failed += run_pool_test(cfg);
+	failed += run_co_test(cfg);
 	for (i = 0; dkey_feats[i] >= 0; i++) {
 		for (j = 0; akey_feats[j] >= 0; j++) {
 			feats = dkey_feats[i] | akey_feats[j];
-			failed += run_io_test(feats, keys, nest_iterators);
+			failed += run_io_test(feats, keys, nest_iterators, cfg);
 		}
 	}
-	failed += run_discard_tests();
-	failed += run_aggregate_tests(false);
-	failed += run_gc_tests();
-	failed += run_dtx_tests();
-	failed += run_ilog_tests();
-	failed += run_csum_extent_tests();
-	failed += run_mvcc_tests();
+	failed += run_discard_tests(cfg);
+	failed += run_aggregate_tests(false, cfg);
+	failed += run_gc_tests(cfg);
+	failed += run_dtx_tests(cfg);
+	failed += run_ilog_tests(cfg);
+	failed += run_csum_extent_tests(cfg);
+	failed += run_mvcc_tests(cfg);
 	return failed;
 }
 
@@ -187,11 +202,11 @@ main(int argc, char **argv)
 				  long_options, &index)) != -1) {
 		switch (opt) {
 		case 'p':
-			nr_failed += run_pool_test();
+			nr_failed += run_pool_test(cfg);
 			test_run = true;
 			break;
 		case 'c':
-			nr_failed += run_co_test();
+			nr_failed += run_co_test(cfg);
 			test_run = true;
 			break;
 		case 'n':
@@ -200,27 +215,27 @@ main(int argc, char **argv)
 		case 'i':
 			ofeats = strtol(optarg, NULL, 16);
 			nr_failed += run_io_test(ofeats, 0,
-						 nest_iterators);
+						 nest_iterators, cfg);
 			test_run = true;
 			break;
 		case 'a':
-			nr_failed += run_aggregate_tests(true);
+			nr_failed += run_aggregate_tests(true, cfg);
 			test_run = true;
 			break;
 		case 'd':
-			nr_failed += run_discard_tests();
+			nr_failed += run_discard_tests(cfg);
 			test_run = true;
 			break;
 		case 'g':
-			nr_failed += run_gc_tests();
+			nr_failed += run_gc_tests(cfg);
 			test_run = true;
 			break;
 		case 'X':
-			nr_failed += run_dtx_tests();
+			nr_failed += run_dtx_tests(cfg);
 			test_run = true;
 			break;
 		case 'm':
-			nr_failed += run_pm_tests();
+			nr_failed += run_pm_tests(cfg);
 			test_run = true;
 			break;
 		case 'A':
@@ -229,11 +244,11 @@ main(int argc, char **argv)
 			test_run = true;
 			break;
 		case 'l':
-			nr_failed += run_ilog_tests();
+			nr_failed += run_ilog_tests(cfg);
 			test_run = true;
 			break;
 		case 'z':
-			nr_failed += run_csum_extent_tests();
+			nr_failed += run_csum_extent_tests(cfg);
 			test_run = true;
 			break;
 		case 't':
@@ -241,7 +256,7 @@ main(int argc, char **argv)
 			test_run = true;
 			break;
 		case 'C':
-			nr_failed += run_mvcc_tests();
+			nr_failed += run_mvcc_tests(cfg);
 			test_run = true;
 			break;
 		case 'f':

--- a/src/vos/tests/vts_aggregate.c
+++ b/src/vos/tests/vts_aggregate.c
@@ -2018,7 +2018,7 @@ static const struct CMUnitTest aggregate_tests[] = {
 };
 
 int
-run_discard_tests(char *cfg)
+run_discard_tests(const char *cfg)
 {
 	char	test_name[100];
 
@@ -2028,7 +2028,7 @@ run_discard_tests(char *cfg)
 }
 
 int
-run_aggregate_tests(bool slow, char *cfg)
+run_aggregate_tests(bool slow, const char *cfg)
 {
 	char	test_name[100];
 

--- a/src/vos/tests/vts_aggregate.c
+++ b/src/vos/tests/vts_aggregate.c
@@ -2018,17 +2018,23 @@ static const struct CMUnitTest aggregate_tests[] = {
 };
 
 int
-run_discard_tests(void)
+run_discard_tests(char *cfg)
 {
-	return cmocka_run_group_tests_name("VOS Discard Test", discard_tests,
+	char	test_name[100];
+
+	sprintf(test_name, "VOS Discard Tests %s", cfg);
+	return cmocka_run_group_tests_name(test_name, discard_tests,
 					   setup_io, teardown_io);
 }
 
 int
-run_aggregate_tests(bool slow)
+run_aggregate_tests(bool slow, char *cfg)
 {
+	char	test_name[100];
+
+	sprintf(test_name, "VOS Aggregate Tests %s", cfg);
 	slow_test = slow;
-	return cmocka_run_group_tests_name("VOS Aggregate Test",
+	return cmocka_run_group_tests_name(test_name,
 					   aggregate_tests, setup_io,
 					   teardown_io);
 }

--- a/src/vos/tests/vts_checksum.c
+++ b/src/vos/tests/vts_checksum.c
@@ -771,16 +771,24 @@ static const struct CMUnitTest evt_checksums_tests[] = {
 	EVT("03: Test the alignment of entries", test_evt_entry_csum_update),
 };
 
-int run_csum_extent_tests(void)
+int run_csum_extent_tests(char *cfg)
 {
 	int rc = 0;
+	char	test_name[130];
+
+	sprintf(test_name,
+		"Storage and retrieval of checksums for Array Type %s", cfg);
 
 	rc = cmocka_run_group_tests_name(
-		"Storage and retrieval of checksums for Array Type",
+		test_name,
 		update_fetch_checksums_for_array_types, setup_io, teardown_io);
 
+	sprintf(test_name,
+		"evtreen helper functions for alignment, counting, etc for csum  %s",
+		cfg);
+
 	rc += cmocka_run_group_tests_name(
-		"evtree helper functions for alignment, counting, etc for csum",
+		test_name,
 		evt_checksums_tests, setup_io, teardown_io);
 
 	return rc;

--- a/src/vos/tests/vts_checksum.c
+++ b/src/vos/tests/vts_checksum.c
@@ -771,7 +771,7 @@ static const struct CMUnitTest evt_checksums_tests[] = {
 	EVT("03: Test the alignment of entries", test_evt_entry_csum_update),
 };
 
-int run_csum_extent_tests(char *cfg)
+int run_csum_extent_tests(const char *cfg)
 {
 	int rc = 0;
 	char	test_name[130];

--- a/src/vos/tests/vts_common.h
+++ b/src/vos/tests/vts_common.h
@@ -114,18 +114,18 @@ struct dts_io_credit *dts_credit_take(struct dts_context *tsc);
 /**
  * VOS test suite run tests
  */
-int run_pool_test(void);
-int run_co_test(void);
-int run_discard_tests(void);
-int run_aggregate_tests(bool slow);
-int run_dtx_tests(void);
-int run_gc_tests(void);
-int run_pm_tests(void);
-int run_io_test(daos_ofeat_t feats, int keys, bool nest_iterators);
+int run_pool_test(char *cfg);
+int run_co_test(char *cfg);
+int run_discard_tests(char *cfg);
+int run_aggregate_tests(bool slow, char *cfg);
+int run_dtx_tests(char *cfg);
+int run_gc_tests(char *cfg);
+int run_pm_tests(char *cfg);
+int run_io_test(daos_ofeat_t feats, int keys, bool nest_iterators, char *cfg);
 int run_ts_tests(void);
 
-int run_ilog_tests(void);
-int run_csum_extent_tests(void);
-int run_mvcc_tests(void);
+int run_ilog_tests(char *cfg);
+int run_csum_extent_tests(char *cfg);
+int run_mvcc_tests(char *cfg);
 
 #endif

--- a/src/vos/tests/vts_common.h
+++ b/src/vos/tests/vts_common.h
@@ -114,18 +114,19 @@ struct dts_io_credit *dts_credit_take(struct dts_context *tsc);
 /**
  * VOS test suite run tests
  */
-int run_pool_test(char *cfg);
-int run_co_test(char *cfg);
-int run_discard_tests(char *cfg);
-int run_aggregate_tests(bool slow, char *cfg);
-int run_dtx_tests(char *cfg);
-int run_gc_tests(char *cfg);
-int run_pm_tests(char *cfg);
-int run_io_test(daos_ofeat_t feats, int keys, bool nest_iterators, char *cfg);
+int run_pool_test(const char *cfg);
+int run_co_test(const char *cfg);
+int run_discard_tests(const char *cfg);
+int run_aggregate_tests(bool slow, const char *cfg);
+int run_dtx_tests(const char *cfg);
+int run_gc_tests(const char *cfg);
+int run_pm_tests(const char *cfg);
+int run_io_test(daos_ofeat_t feats, int keys, bool nest_iterators,
+		const char *cfg);
 int run_ts_tests(void);
 
-int run_ilog_tests(char *cfg);
-int run_csum_extent_tests(char *cfg);
-int run_mvcc_tests(char *cfg);
+int run_ilog_tests(const char *cfg);
+int run_csum_extent_tests(const char *cfg);
+int run_mvcc_tests(const char *cfg);
 
 #endif

--- a/src/vos/tests/vts_container.c
+++ b/src/vos/tests/vts_container.c
@@ -374,9 +374,12 @@ static const struct CMUnitTest vos_co_tests[] = {
 };
 
 int
-run_co_test(void)
+run_co_test(char *cfg)
 {
-	return cmocka_run_group_tests_name("VOS container tests",
+	char	test_name[100];
+
+	sprintf(test_name, "VOS container tests %s", cfg);
+	return cmocka_run_group_tests_name(test_name,
 					   vos_co_tests,
 					   setup, teardown);
 }

--- a/src/vos/tests/vts_container.c
+++ b/src/vos/tests/vts_container.c
@@ -374,7 +374,7 @@ static const struct CMUnitTest vos_co_tests[] = {
 };
 
 int
-run_co_test(char *cfg)
+run_co_test(const char *cfg)
 {
 	char	test_name[100];
 

--- a/src/vos/tests/vts_dtx.c
+++ b/src/vos/tests/vts_dtx.c
@@ -1566,9 +1566,12 @@ static const struct CMUnitTest dtx_tests[] = {
 };
 
 int
-run_dtx_tests(void)
+run_dtx_tests(char *cfg)
 {
-	return cmocka_run_group_tests_name("VOS DTX Test",
+	char	test_name[100];
+
+	sprintf(test_name, "VOS DTX Test %s", cfg);
+	return cmocka_run_group_tests_name(test_name,
 					   dtx_tests, setup_io,
 					   teardown_io);
 }

--- a/src/vos/tests/vts_dtx.c
+++ b/src/vos/tests/vts_dtx.c
@@ -1566,7 +1566,7 @@ static const struct CMUnitTest dtx_tests[] = {
 };
 
 int
-run_dtx_tests(char *cfg)
+run_dtx_tests(const char *cfg)
 {
 	char	test_name[100];
 

--- a/src/vos/tests/vts_gc.c
+++ b/src/vos/tests/vts_gc.c
@@ -429,8 +429,11 @@ static const struct CMUnitTest gc_tests[] = {
 };
 
 int
-run_gc_tests(void)
+run_gc_tests(char *cfg)
 {
-	return cmocka_run_group_tests_name("Garbage collector",
+	char	test_name[100];
+
+	sprintf(test_name, "Garbage collector %s", cfg);
+	return cmocka_run_group_tests_name(test_name,
 					   gc_tests, gc_setup, gc_teardown);
 }

--- a/src/vos/tests/vts_gc.c
+++ b/src/vos/tests/vts_gc.c
@@ -429,7 +429,7 @@ static const struct CMUnitTest gc_tests[] = {
 };
 
 int
-run_gc_tests(char *cfg)
+run_gc_tests(const char *cfg)
 {
 	char	test_name[100];
 

--- a/src/vos/tests/vts_ilog.c
+++ b/src/vos/tests/vts_ilog.c
@@ -1218,9 +1218,12 @@ teardown_ilog(void **state)
 }
 
 int
-run_ilog_tests(void)
+run_ilog_tests(char *cfg)
 {
-	return cmocka_run_group_tests_name("VOS Incarnation log tests",
+	char	test_name[100];
+
+	sprintf(test_name, "VOS Incarnation log tests %s", cfg);
+	return cmocka_run_group_tests_name(test_name,
 					   inc_tests, setup_ilog,
 					   teardown_ilog);
 }

--- a/src/vos/tests/vts_ilog.c
+++ b/src/vos/tests/vts_ilog.c
@@ -1218,7 +1218,7 @@ teardown_ilog(void **state)
 }
 
 int
-run_ilog_tests(char *cfg)
+run_ilog_tests(const char *cfg)
 {
 	char	test_name[100];
 

--- a/src/vos/tests/vts_io.c
+++ b/src/vos/tests/vts_io.c
@@ -2445,7 +2445,7 @@ static const struct CMUnitTest int_tests[] = {
 };
 
 int
-run_io_test(daos_ofeat_t feats, int keys, bool nest_iterators, char *cfg)
+run_io_test(daos_ofeat_t feats, int keys, bool nest_iterators, const char *cfg)
 {
 	char buf[VTS_BUF_SIZE];
 	const char *akey = "hashed";

--- a/src/vos/tests/vts_io.c
+++ b/src/vos/tests/vts_io.c
@@ -2445,7 +2445,7 @@ static const struct CMUnitTest int_tests[] = {
 };
 
 int
-run_io_test(daos_ofeat_t feats, int keys, bool nest_iterators)
+run_io_test(daos_ofeat_t feats, int keys, bool nest_iterators, char *cfg)
 {
 	char buf[VTS_BUF_SIZE];
 	const char *akey = "hashed";
@@ -2474,8 +2474,8 @@ run_io_test(daos_ofeat_t feats, int keys, bool nest_iterators)
 	if (feats & DAOS_OF_AKEY_LEXICAL)
 		akey = "lex";
 
-	snprintf(buf, VTS_BUF_SIZE, "#. VOS IO tests (dkey=%-6s akey=%s)",
-		 dkey, akey);
+	snprintf(buf, VTS_BUF_SIZE, "#. VOS IO tests (dkey=%-6s akey=%s) %s",
+		 dkey, akey, cfg);
 	init_ofeats = feats;
 	if (keys)
 		init_num_keys = keys;

--- a/src/vos/tests/vts_mvcc.c
+++ b/src/vos/tests/vts_mvcc.c
@@ -653,7 +653,7 @@ teardown_mvcc(void **state)
 }
 
 int
-run_mvcc_tests(char *cfg)
+run_mvcc_tests(const char *cfg)
 {
 	char	test_name[100];
 

--- a/src/vos/tests/vts_mvcc.c
+++ b/src/vos/tests/vts_mvcc.c
@@ -653,12 +653,17 @@ teardown_mvcc(void **state)
 }
 
 int
-run_mvcc_tests(void)
+run_mvcc_tests(char *cfg)
 {
+	char	test_name[100];
+
+	sprintf(test_name, "VOS MVCC Tests %s", cfg);
+
 	if (getenv("DAOS_IO_BYPASS")) {
 		print_message("Skipping MVCC tests: DAOS_IO_BYPASS is set\n");
 		return 0;
 	}
-	return cmocka_run_group_tests_name("VOS MVCC Tests", mvcc_tests,
+
+	return cmocka_run_group_tests_name(test_name, mvcc_tests,
 					   setup_mvcc, teardown_mvcc);
 }

--- a/src/vos/tests/vts_pm.c
+++ b/src/vos/tests/vts_pm.c
@@ -1300,7 +1300,7 @@ static const struct CMUnitTest punch_model_tests[] = {
 };
 
 int
-run_pm_tests(char *cfg)
+run_pm_tests(const char *cfg)
 {
 	char	test_name[100];
 

--- a/src/vos/tests/vts_pm.c
+++ b/src/vos/tests/vts_pm.c
@@ -1300,11 +1300,14 @@ static const struct CMUnitTest punch_model_tests[] = {
 };
 
 int
-run_pm_tests(void)
+run_pm_tests(char *cfg)
 {
+	char	test_name[100];
+
+	sprintf(test_name, "VOS Punch Model tests %s", cfg);
 	if (DAOS_ON_VALGRIND)
 		buf_size = 100;
-	return cmocka_run_group_tests_name("VOS Punch Model tests",
+	return cmocka_run_group_tests_name(test_name,
 					   punch_model_tests, setup_io,
 					   teardown_io);
 }

--- a/src/vos/tests/vts_pool.c
+++ b/src/vos/tests/vts_pool.c
@@ -419,7 +419,7 @@ static const struct CMUnitTest pool_tests[] = {
 
 
 int
-run_pool_test(char *cfg)
+run_pool_test(const char *cfg)
 {
 	char	test_name[100];
 

--- a/src/vos/tests/vts_pool.c
+++ b/src/vos/tests/vts_pool.c
@@ -419,8 +419,11 @@ static const struct CMUnitTest pool_tests[] = {
 
 
 int
-run_pool_test(void)
+run_pool_test(char *cfg)
 {
-	return cmocka_run_group_tests_name("VOS Pool tests", pool_tests,
+	char	test_name[100];
+
+	sprintf(test_name, "VOS Pool tests %s", cfg);
+	return cmocka_run_group_tests_name(test_name, pool_tests,
 					   setup, teardown);
 }


### PR DESCRIPTION
vos_test did not generate complete cmocka XML results because the
execution instances were named the same. This commit adds the specific
configuration to the test name.

Signed-off-by: Marcela Rosales <marcela.a.rosales.jimenez@intel.com>