### PR TITLE
DAOS-4682 test: Adding capability for different timeout

### DIFF
--- a/src/tests/ftest/io/nvme_object.yaml
+++ b/src/tests/ftest/io/nvme_object.yaml
@@ -1,6 +1,7 @@
 # change host names to your reserved nodes, the
 # required quantity is indicated by the placeholders
-
+server_manager:
+    srv_timeout: 500
 hosts:
  test_servers:
   - boro-A
@@ -12,7 +13,9 @@ hosts:
   - boro-G
  test_clients:
   - boro-H
-timeout: 16000
+timeouts:
+  test_nvme_object_single_pool: 900
+  test_nvme_object_multiple_pools: 16000
 server_config:
  name: daos_server
  servers:

--- a/src/tests/ftest/io/nvme_object.yaml
+++ b/src/tests/ftest/io/nvme_object.yaml
@@ -14,7 +14,7 @@ hosts:
  test_clients:
   - boro-H
 timeouts:
-  test_nvme_object_single_pool: 900
+  test_nvme_object_single_pool: 500
   test_nvme_object_multiple_pools: 16000
 server_config:
  name: daos_server

--- a/src/tests/ftest/util/apricot/apricot/test.py
+++ b/src/tests/ftest/util/apricot/apricot/test.py
@@ -106,11 +106,17 @@ class Test(avocadoTest):
                 if dhms[index] is not None:
                     self.timeout += multiplier * int(dhms[index])
 
+        # param to add multiple timeouts for different tests under
+        # same test class
+        self.timeouts = self.params.get(self.get_test_name(),
+                                        "/run/timeouts/*")
         # If not specified, set a default timeout of 1 minute.
         # Tests that require a longer timeout should set a "timeout: <int>"
         # entry in their yaml file.  All tests should have a timeout defined.
-        if not self.timeout:
+        if (not self.timeout) and (not self.timeouts):
             self.timeout = 60
+        elif self.timeouts:
+            self.timeout = self.timeouts
         self.log.info("self.timeout: %s", self.timeout)
 
         item_list = self.logdir.split('/')
@@ -128,6 +134,9 @@ class Test(avocadoTest):
         return self.cancel("Skipping until {} is fixed.".format(ticket))
     # pylint: enable=invalid-name
 
+    def get_test_name(self):
+        """Obtain test name from self.__str__() """
+        return (self.__str__().split(".", 4)[3]).split(";", 1)[0]
 
 class TestWithoutServers(Test):
     """Run tests without DAOS servers.


### PR DESCRIPTION
Adding capability to provide different timeout
for different tests under same test class for functional
test

Implementing the same for io/nvme_object.py

Signed-off-by: Saurabh Tandan <saurabh.tandan@intel.com>