### PR TITLE
DAOS-2448 obj: add ISAL recovery helpers

### DIFF
--- a/src/common/checksum.c
+++ b/src/common/checksum.c
@@ -386,7 +386,7 @@ daos_csummer_csum_compare(struct daos_csummer *obj, uint8_t *a,
 }
 
 static uint32_t
-daos_singv_calc_chunks(struct dcs_singv_layout *singv_los, int idx)
+daos_singv_calc_chunks(struct dcs_layout *singv_los, int idx)
 {
 	if (singv_los == NULL || singv_los[idx].cs_even_dist == 0)
 		return 1;
@@ -398,7 +398,7 @@ daos_singv_calc_chunks(struct dcs_singv_layout *singv_los, int idx)
 uint64_t
 daos_csummer_allocation_size(struct daos_csummer *obj, daos_iod_t *iods,
 			     uint32_t nr, bool akey_only,
-			     struct dcs_singv_layout *singv_los)
+			     struct dcs_layout *singv_los)
 {
 	int		i, j;
 	uint64_t	result = 0;
@@ -447,7 +447,7 @@ daos_csummer_allocation_size(struct daos_csummer *obj, daos_iod_t *iods,
 int
 daos_csummer_alloc_iods_csums(struct daos_csummer *obj, daos_iod_t *iods,
 			      uint32_t nr, bool akey_only,
-			      struct dcs_singv_layout *singv_los,
+			      struct dcs_layout *singv_los,
 			      struct dcs_iod_csums **p_iods_csums)
 {
 	int			 i, j, rc = 0;
@@ -735,7 +735,7 @@ calc_csum_recx(struct daos_csummer *obj, d_sg_list_t *sgl, size_t rec_len,
 
 static int
 calc_csum_sv(struct daos_csummer *obj, d_sg_list_t *sgl, size_t rec_len,
-	     struct dcs_singv_layout *singv_lo, int singv_idx,
+	     struct dcs_layout *singv_lo, int singv_idx,
 	     struct dcs_csum_info *csums)
 {
 	size_t			 bytes_for_csum, csum_buf_len;
@@ -838,13 +838,13 @@ daos_csummer_calc_one(struct daos_csummer *obj, d_sg_list_t *sgl,
 int
 daos_csummer_calc_iods(struct daos_csummer *obj, d_sg_list_t *sgls,
 		       daos_iod_t *iods, daos_iom_t *maps, uint32_t nr,
-		       bool akey_only, struct dcs_singv_layout *singv_los,
+		       bool akey_only, struct dcs_layout *singv_los,
 		       int singv_idx, struct dcs_iod_csums **p_iods_csums)
 {
 	int			 rc = 0;
 	int			 i;
 	struct dcs_iod_csums	*iods_csums = NULL;
-	struct dcs_singv_layout	*singv_lo, *los;
+	struct dcs_layout	*singv_lo, *los;
 	uint32_t		 iods_csums_nr;
 	uint16_t		 csum_len = daos_csummer_get_csum_len(obj);
 
@@ -966,7 +966,7 @@ daos_csummer_free_ci(struct daos_csummer *obj, struct dcs_csum_info **p_cis)
 int
 daos_csummer_verify_iod(struct daos_csummer *obj, daos_iod_t *iod,
 			d_sg_list_t *sgl, struct dcs_iod_csums *iod_csum,
-			struct dcs_singv_layout *singv_lo, int singv_idx,
+			struct dcs_layout *singv_lo, int singv_idx,
 			daos_iom_t *map)
 {
 	struct dcs_iod_csums	*new_iod_csums;

--- a/src/include/daos/checksum.h
+++ b/src/include/daos/checksum.h
@@ -96,7 +96,7 @@ struct dcs_iod_csums {
 };
 
 /** Single value layout info for checksum */
-struct dcs_singv_layout {
+struct dcs_layout {
 	/** #bytes on evenly distributed targets */
 	uint64_t	cs_bytes;
 	/** targets number */
@@ -280,7 +280,7 @@ daos_csummer_calc_one(struct daos_csummer *obj, d_sg_list_t *sgl,
 int
 daos_csummer_calc_iods(struct daos_csummer *obj, d_sg_list_t *sgls,
 		       daos_iod_t *iods, daos_iom_t *maps, uint32_t nr,
-		       bool akey_only, struct dcs_singv_layout *singv_los,
+		       bool akey_only, struct dcs_layout *singv_los,
 		       int singv_idx, struct dcs_iod_csums **p_iods_csums);
 
 /**
@@ -324,7 +324,7 @@ daos_csummer_calc_key(struct daos_csummer *csummer, daos_key_t *key,
 int
 daos_csummer_verify_iod(struct daos_csummer *obj, daos_iod_t *iod,
 			d_sg_list_t *sgl, struct dcs_iod_csums *iod_csum,
-			struct dcs_singv_layout *singv_lo, int singv_idx,
+			struct dcs_layout *singv_lo, int singv_idx,
 			daos_iom_t *map);
 
 /**
@@ -361,7 +361,7 @@ daos_csummer_verify_key(struct daos_csummer *obj, daos_key_t *key,
 uint64_t
 daos_csummer_allocation_size(struct daos_csummer *obj, daos_iod_t *iods,
 			     uint32_t nr, bool akey_only,
-			     struct dcs_singv_layout *singv_los);
+			     struct dcs_layout *singv_los);
 
 /**
  * Allocate the checksum structures needed for the iods. This will also
@@ -385,7 +385,7 @@ daos_csummer_allocation_size(struct daos_csummer *obj, daos_iod_t *iods,
 int
 daos_csummer_alloc_iods_csums(struct daos_csummer *obj, daos_iod_t *iods,
 			      uint32_t nr, bool akey_only,
-			      struct dcs_singv_layout *singv_los,
+			      struct dcs_layout *singv_los,
 			      struct dcs_iod_csums **p_iods_csums);
 
 /** Destroy the iods csums */

--- a/src/mgmt/srv_pool.c
+++ b/src/mgmt/srv_pool.c
@@ -80,8 +80,8 @@ ds_mgmt_tgt_pool_destroy_ranks(uuid_t pool_uuid, d_rank_list_t *excluded)
 	td_out = crt_reply_get(td_req);
 	rc = td_out->td_rc;
 	if (rc != 0)
-		D_ERROR(DF_UUID": failed to update pool map on "DF_RC" "
-			"targets\n", DP_UUID(pool_uuid), DP_RC(rc));
+		D_ERROR(DF_UUID": failed to destroy pool targets "DF_RC"\n",
+			DP_UUID(pool_uuid), DP_RC(rc));
 out_rpc:
 	crt_req_decref(td_req);
 

--- a/src/object/cli_obj.c
+++ b/src/object/cli_obj.c
@@ -40,7 +40,7 @@
 #define CLI_OBJ_IO_PARMS	8
 #define NIL_BITMAP		(NULL)
 
-#define OBJ_TGT_INLINE_NR	(26)
+#define OBJ_TGT_INLINE_NR	(25)
 struct obj_req_tgts {
 	/* to save memory allocation if #targets <= OBJ_TGT_INLINE_NR */
 	struct daos_shard_tgt	 ort_tgts_inline[OBJ_TGT_INLINE_NR];
@@ -575,7 +575,7 @@ obj_reasb_req_init(struct obj_auxi_args *obj_auxi, daos_iod_t *iods,
 	size_oiod = roundup(sizeof(struct obj_io_desc) * iod_nr, 8);
 	size_recx = roundup(sizeof(struct obj_ec_recx_array) * iod_nr, 8);
 	size_sorter = roundup(sizeof(struct obj_ec_seg_sorter) * iod_nr, 8);
-	size_singv = roundup(sizeof(struct dcs_singv_layout) * iod_nr, 8);
+	size_singv = roundup(sizeof(struct dcs_layout) * iod_nr, 8);
 	/* for oer_tgt_recx_nrs/_idxs */
 	size_tgt_nr = roundup(sizeof(uint32_t) *
 			      (oca->u.ec.e_k + oca->u.ec.e_p), 8);
@@ -640,6 +640,7 @@ obj_reasb_req_fini(struct obj_auxi_args *obj_auxi)
 		obj_ec_tgt_oiod_fini(reasb_req->tgt_oiods);
 		reasb_req->tgt_oiods = NULL;
 	}
+	obj_ec_recov_free(reasb_req);
 	D_FREE(reasb_req->orr_iods);
 }
 

--- a/src/object/cli_shard.c
+++ b/src/object/cli_shard.c
@@ -122,11 +122,11 @@ struct rw_cb_args {
 	struct shard_rw_args	*shard_args;
 };
 
-static struct dcs_singv_layout *
+static struct dcs_layout *
 dc_rw_cb_singv_lo_get(daos_iod_t *iods, d_sg_list_t *sgls, uint32_t iod_nr,
 		      struct obj_reasb_req *reasb_req)
 {
-	struct dcs_singv_layout	*singv_lo, *singv_los;
+	struct dcs_layout	*singv_lo, *singv_los;
 	daos_iod_t		*iod;
 	d_sg_list_t		*sgl;
 	uint32_t		 i;
@@ -164,7 +164,7 @@ int dc_rw_cb_csum_verify(const struct rw_cb_args *rw_args)
 	daos_iod_t		*iods;
 	struct dcs_iod_csums	*iods_csums;
 	daos_iom_t		*maps;
-	struct dcs_singv_layout	*singv_lo, *singv_los;
+	struct dcs_layout	*singv_lo, *singv_los;
 	uint32_t		 shard_idx;
 	int			 i;
 	int			 rc = 0;

--- a/src/object/obj_ec.h
+++ b/src/object/obj_ec.h
@@ -197,6 +197,19 @@ struct obj_ec_seg_sorter {
 };
 #define OBJ_EC_SEG_NIL		 (-1)
 
+/** for EC data recovery */
+struct obj_ec_recov {
+	unsigned char		*er_gftbls;	/* GF tables */
+	unsigned char		*er_de_matrix;	/* decode matrix */
+	unsigned char		*er_inv_matrix;	/* invert matrix */
+	unsigned char		*er_b_matrix;	/* temporary b matrix */
+	uint32_t		*er_dec_idx;	/* decode index */
+	uint32_t		*er_err_list;	/* target idx list in error */
+	bool			*er_in_err;	/* boolean array for targets */
+	uint32_t		 er_nerrs;	/* #targets in error */
+	uint32_t		 er_data_nerrs; /* #data-targets in error */
+};
+
 struct obj_reasb_req;
 
 /** Query the number of records in EC full stripe */
@@ -370,6 +383,10 @@ struct obj_tgt_oiod *obj_ec_tgt_oiod_init(struct obj_io_desc *r_oiods,
 			uint32_t tgt_max_idx, uint32_t tgt_nr);
 struct obj_tgt_oiod *obj_ec_tgt_oiod_get(struct obj_tgt_oiod *tgt_oiods,
 			uint32_t tgt_nr, uint32_t tgt_idx);
+void obj_ec_recov_free(struct obj_reasb_req *reasb_req);
+int obj_ec_recov_prep(struct obj_reasb_req *reasb_req, daos_obj_id_t oid,
+		      struct daos_oclass_attr *oca, uint32_t nerrs,
+		      uint32_t *err_list);
 
 /* srv_ec.c */
 struct obj_rw_in;

--- a/src/object/obj_internal.h
+++ b/src/object/obj_internal.h
@@ -141,9 +141,11 @@ struct obj_reasb_req {
 	struct obj_io_desc		*orr_oiods;
 	struct obj_ec_recx_array	*orr_recxs;
 	struct obj_ec_seg_sorter	*orr_sorters;
-	struct dcs_singv_layout		*orr_singv_los;
+	struct dcs_layout		*orr_singv_los;
 	uint32_t			 orr_tgt_nr;
 	struct daos_oclass_attr		*orr_oca;
+	struct obj_ec_recov		*orr_recov;
+	struct obj_ec_codec		*orr_codec;
 	/* target bitmap, one bit for each target (from first data cell to last
 	 * parity cell.
 	 */

--- a/src/vos/vos_io.c
+++ b/src/vos/vos_io.c
@@ -300,12 +300,9 @@ iod_fetch(struct vos_io_context *ioc, struct bio_iov *biov)
 	if (iov_at == iov_nr - 1) {
 		struct bio_iov *biovs;
 
-		D_ALLOC_ARRAY(biovs, (iov_nr * 2));
+		D_REALLOC_ARRAY(biovs, bsgl->bs_iovs, (iov_nr * 2));
 		if (biovs == NULL)
 			return -DER_NOMEM;
-
-		memcpy(biovs, &bsgl->bs_iovs[0], iov_nr * sizeof(*biovs));
-		D_FREE(bsgl->bs_iovs);
 
 		bsgl->bs_iovs = biovs;
 		bsgl->bs_nr = iov_nr * 2;


### PR DESCRIPTION
Add several ISAL data recovery helpers.
Rename dcs_singv_layout to dcs_layout.

Signed-off-by: Xuezhao Liu <xuezhao.liu@intel.com>