### PR TITLE
DAOS-4678 build: DAOS build with "COMPILER=covc" fails at GO build step

### DIFF
--- a/src/control/SConscript
+++ b/src/control/SConscript
@@ -122,6 +122,9 @@ def scons():
 
     denv = env.Clone()
 
+    if denv.get("COMPILER") == 'covc':
+        denv.Replace(CC='gcc', CXX='g++')
+
     # if SPDK_PREFIX differs from PREFIX, copy dir so files can be accessed at
     # runtime
     prefix = denv.subst("$PREFIX")


### PR DESCRIPTION
Excluded src/control from using Bullseye compiler covc.

Signed-off-by: Hua Kuang <hua.kuang@intel.com>