### PR TITLE
DAOS-3449 object: make the key query shard cb threadsafe

### DIFF
--- a/src/object/cli_obj.c
+++ b/src/object/cli_obj.c
@@ -3116,7 +3116,7 @@ shard_query_key_task(tse_task_t *task)
 				 sizeof(args->kqa_dkey_hash));
 	api_args = args->kqa_api_args;
 	rc = dc_obj_shard_query_key(obj_shard, args->kqa_epoch, api_args->flags,
-				    api_args->dkey, api_args->akey,
+				    obj, api_args->dkey, api_args->akey,
 				    api_args->recx, args->kqa_coh_uuid,
 				    args->kqa_cont_uuid,
 				    &args->kqa_auxi.obj_auxi->map_ver_reply,

--- a/src/object/obj_internal.h
+++ b/src/object/obj_internal.h
@@ -380,7 +380,8 @@ int dc_obj_shard_list(struct dc_obj_shard *shard, enum obj_rpc_opc opc,
 		      uint32_t fw_cnt, tse_task_t *task);
 
 int dc_obj_shard_query_key(struct dc_obj_shard *shard, daos_epoch_t epoch,
-			   uint32_t flags, daos_key_t *dkey, daos_key_t *akey,
+			   uint32_t flags, struct dc_object *obj,
+			   daos_key_t *dkey, daos_key_t *akey,
 			   daos_recx_t *recx, const uuid_t coh_uuid,
 			   const uuid_t cont_uuid, unsigned int *map_ver,
 			   tse_task_t *task);


### PR DESCRIPTION
In multithreaded access, it's possible that multiple threads complete
different shard query tasks for the same API task. In current handling
of the query cb, the access to the key pointer is not threadsafe, so
add a lock around the key & recx processing.

Signed-off-by: Mohamad Chaarawi <mohamad.chaarawi@intel.com>