### PR TITLE
DAOS-4696 tests: Removing test control host from client hostlist

### DIFF
--- a/src/tests/ftest/soak/soak.py
+++ b/src/tests/ftest/soak/soak.py
@@ -40,6 +40,7 @@ import threading
 from avocado.utils import process
 from avocado.core.exceptions import TestFail
 from pydaos.raw import DaosSnapshot, DaosApiError
+from agent_utils import include_local_host
 
 H_LOCK = threading.Lock()
 
@@ -133,17 +134,18 @@ class SoakTestBase(TestWithServers):
                 self.exclude_slurm_nodes.append(host_server)
         self.log.info(
             "<<Updated hostlist_clients %s >>", self.hostlist_clients)
-        # include test node for log cleanup; remove from client list
-        self.exclude_slurm_nodes.append(self.hostlist_clients.pop(-1))
-        self.log.info("<<Updated hostlist_clients %s >>", self.hostlist_clients)
         if not self.hostlist_clients:
             self.fail("There are no nodes that are client only;"
                       "check if the partition also contains server nodes")
 
+        # Include test node for log cleanup; remove from client list
+        local_host_list = include_local_host(None)
+        self.exclude_slurm_nodes.extend(local_host_list)
+
         # Start an agent on the test control host to enable API calls for
         # reserved pool and containers.  The test control host should be the
         # last host in the hostlist_clients list.
-        agent_groups = {self.server_group: self.exclude_slurm_nodes[-1:]}
+        agent_groups = {self.server_group: local_host_list}
         self.start_agents(agent_groups)
 
     def pre_tear_down(self):

--- a/src/tests/ftest/util/apricot/apricot/test.py
+++ b/src/tests/ftest/util/apricot/apricot/test.py
@@ -293,9 +293,6 @@ class TestWithServers(TestWithoutServers):
                     "Specifying both a {} partition name and a list of hosts "
                     "is not supported!".format(name))
 
-        # For API calls include running the agent on the local host
-        self.hostlist_clients = include_local_host(self.hostlist_clients)
-
         # # Find a configuration that meets the test requirements
         # self.config = Configuration(
         #     self.params, self.hostlist_servers, debug=self.debug)
@@ -364,7 +361,10 @@ class TestWithServers(TestWithoutServers):
 
         """
         if agent_groups is None:
-            agent_groups = {self.server_group: self.hostlist_clients}
+            # Include running the daos_agent on the test control host for API
+            # calls and calling the daos command from this host.
+            agent_groups = {
+                self.server_group: include_local_host(self.hostlist_clients)}
 
         self.log.debug("--- STARTING AGENT GROUPS: %s ---", agent_groups)
 


### PR DESCRIPTION
After a recent change as part of DAOS-3730, the test control host
(local host) is being left in the self.hostlist_clients list after
starting the daos_agents and resulting in extra hosts being included
in various commands, e.g. ior.

Test-tag-hw-large: pr,hw,large soak_smoke

Signed-off-by: Phillip Henderson <phillip.henderson@intel.com>