### PR TITLE
DAOS-4348 pydaos: Make DaosClient a singleton and lazy init

### DIFF
--- a/src/client/pydaos/__init__.py
+++ b/src/client/pydaos/__init__.py
@@ -25,8 +25,6 @@ PyDAOS Module allowing global access to the DAOS containers and objects.
 import sys
 import atexit
 
-dc = None
-
 DAOS_MAGIC = 0x7A89
 
 # pylint: disable=import-error
@@ -55,12 +53,32 @@ class PyDError(Exception):
     def __str__(self):
         return self.message
 
-class DaosClient():
-    """DaosClient object"""
+class DaosClient(object):
+    # pylint: disable=too-few-public-methods
+    """
+    DaosClient is responsible for handling DAOS init/fini.
 
-    # Created automatically as module is imported, and the
-    # local ref is dropped when it's unloaded.
-    def __init__(self):
+    The class implements the Singleton pattern and only
+    allows a single instance to be instantiated during
+    the lifetime of a process.
+    """
+    _instance = None
+
+    @classmethod
+    def cleanup(cls):
+        """Trigger the instance cleanup process."""
+        if cls._instance is None:
+            return
+        cls._instance = None
+
+    def __new__(cls):
+        if cls._instance is None:
+            cls._instance = super(DaosClient, cls).__new__(cls)
+            # pylint: disable=protected-access
+            cls._instance._open()
+        return cls._instance
+
+    def _open(self):
         # Initialize DAOS
         self.connected = False
         _rc = pydaos_shim.daos_init(DAOS_MAGIC)
@@ -71,9 +89,9 @@ class DaosClient():
     def _close(self):
         if not self.connected:
             return
-        rc = pydaos_shim.daos_fini(DAOS_MAGIC)
-        if rc != pydaos_shim.DER_SUCCESS:
-            raise PyDError("Failed to cleanup DAOS", rc)
+        _rc = pydaos_shim.daos_fini(DAOS_MAGIC)
+        if _rc != pydaos_shim.DER_SUCCESS:
+            raise PyDError("Failed to cleanup DAOS", _rc)
         self.connected = False
 
     def __del__(self):
@@ -81,12 +99,9 @@ class DaosClient():
             return
         self._close()
 
-dc = DaosClient()
-
 @atexit.register
 def _cleanup():
-    global dc
-    dc = None
+    DaosClient.cleanup()
 
 from .pydaos_core import *
 

--- a/src/client/pydaos/dbm_daos.py
+++ b/src/client/pydaos/dbm_daos.py
@@ -31,6 +31,7 @@ class daosdm():
     """dbm.gnu() like interface to daos"""
 
     def __init__(self, kv):
+        self._dc = pydaos.DaosClient()
         self._kv = kv
         self._prevkey = None
         self._iter_obj = None

--- a/src/client/pydaos/pydaos_core.py
+++ b/src/client/pydaos/pydaos_core.py
@@ -35,7 +35,7 @@ else:
 
 from . import DAOS_MAGIC
 from . import PyDError
-from . import dc
+from . import DaosClient
 
 # Import Object class as an enumeration
 ObjClassID = enum.Enum(
@@ -102,6 +102,7 @@ class Cont(object):
         print pool and container UUIDs
     """
     def __init__(self, puuid=None, cuuid=None, path=None, svc='0'):
+        self._dc = DaosClient()
         self.coh = None
         if path is None and (puuid is None or cuuid is None):
             raise PyDError("invalid pool or container UUID",
@@ -120,7 +121,6 @@ class Cont(object):
             raise PyDError("failed to access container", ret)
         self.poh = poh
         self.coh = coh
-        self._dc = dc
 
     def __del__(self):
         if not self.coh:
@@ -161,6 +161,7 @@ class _Obj(object):
     oh = None
 
     def __init__(self, coh, oid, cont):
+        self._dc = DaosClient()
         self.oid = oid
         # Set self.oh to Null here so it's defined in __dell__ if there's
         # a problem with the obj_open() call.
@@ -193,6 +194,7 @@ class KVIter():
     """Iterator class for KVOjb"""
 
     def __init__(self, kv):
+        self._dc = DaosClient()
         self._entries = []
         self._nr = 256
         self._size = 4096 # optimized for 16-char strings


### PR DESCRIPTION
Currently, any python program that imports pydaos will effectively
call daos_init() on import. In conjuction with the new zero-config
client feature, this will result in the undesirable requirement to
have a DAOS agent and server running in order to import anything
from the package.

This commit changes the DaosClient class to create a singleton
instance to ensure that daos_init() is only called once during the
the lifetime of a process, and adjusts the various DAOS classes to
ensure that the singleton is created before making any DAOS API
calls.