### PR TITLE
DAOS-4423 mgmt: Fix map_update_bcast -DER_NONEXIST (#2551)

### DIFF
--- a/src/mgmt/srv_system.c
+++ b/src/mgmt/srv_system.c
@@ -453,14 +453,17 @@ mgmt_svc_map_dist_cb(struct ds_rsvc *rsvc)
 {
 	struct mgmt_svc	       *svc = mgmt_svc_obj(rsvc);
 	struct rdb_tx		tx;
+	uint32_t		map_version;
 	struct enum_server_arg	arg;
 	struct dss_module_info *info = dss_get_module_info();
 	int			rc;
 
+	/* Retrieve map_version (from the cache) and arg (from the DB). */
 	rc = rdb_tx_begin(svc->ms_rsvc.s_db, svc->ms_rsvc.s_term, &tx);
 	if (rc != 0)
 		return rc;
 	ABT_rwlock_rdlock(svc->ms_lock);
+	map_version = svc->ms_map_version;
 	enum_server_arg_init(&arg);
 	rc = rdb_tx_iterate(&tx, &svc->ms_servers, false /* !backward */,
 			    enum_server_cb, &arg);
@@ -471,7 +474,7 @@ mgmt_svc_map_dist_cb(struct ds_rsvc *rsvc)
 		return rc;
 	}
 
-	rc = map_update_bcast(info->dmi_ctx, svc, svc->ms_map_version,
+	rc = map_update_bcast(info->dmi_ctx, svc, map_version,
 			      arg.esa_servers_len, arg.esa_servers);
 
 	enum_server_arg_fini(&arg);


### PR DESCRIPTION
map_update_bcast was observed to return -DER_NONEXIST:

  map_update_bcast() enter: version=2 nservers=1
  map_update_bcast() leave: version=2 nservers=1: DER_NONEXIST(-1005)
  ...
  map_update_bcast() enter: version=2 nservers=2
  map_update_bcast() leave: version=2 nservers=2: DER_NONEXIST(-1005)

The first call was broadcasting system map version 2 with 1 server,
whereas the second call was broadcasting system version 2 with 2
servers. Same version, but different number of servers!

The surrounding log messages suggested that the first
mgmt_svc_map_dist_cb call, which made the first map_update_bcast call
above, very likely retrieved the server list before a new server joined
and the system map version after the new server joined.
mgmt_svc_map_dist_cb should retrieve both under svc->ms_lock.

(The first -DER_NONEXIST was generated on a remote server, who accepted
system map version 1 as version 2. Later correct version 2 broadcasts
were then ignored.)

Signed-off-by: Li Wei <wei.g.li@intel.com>