### PR TITLE
DAOS-4567 control: Retry on certain pool create errors

### DIFF
--- a/src/control/server/mgmt_pool.go
+++ b/src/control/server/mgmt_pool.go
@@ -25,6 +25,7 @@ package server
 
 import (
 	"strings"
+	"time"
 
 	"github.com/golang/protobuf/proto"
 	"github.com/pkg/errors"
@@ -33,6 +34,13 @@ import (
 	mgmtpb "github.com/daos-stack/daos/src/control/common/proto/mgmt"
 	"github.com/daos-stack/daos/src/control/drpc"
 	"github.com/daos-stack/daos/src/control/server/ioserver"
+)
+
+const (
+	// poolCreateRetryDelay defines the amount of time between pool create retries.
+	// In the management service, the system map distribution code has a 3s backoff
+	// for distribution errors.
+	poolCreateRetryDelay = 1500 * time.Millisecond
 )
 
 // PoolCreate implements the method defined for the Management Service.
@@ -63,19 +71,42 @@ func (svc *mgmtSvc) PoolCreate(ctx context.Context, req *mgmtpb.PoolCreateReq) (
 		return nil, FaultPoolNvmeTooSmall(req.Nvmebytes, targetCount)
 	}
 
-	dresp, err := mi.CallDrpc(drpc.ModuleMgmt, drpc.MethodPoolCreate, req)
-	if err != nil {
-		return nil, err
+	try := 0
+	for {
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		default:
+		}
+
+		dresp, err := mi.CallDrpc(drpc.ModuleMgmt, drpc.MethodPoolCreate, req)
+		if err != nil {
+			return nil, err
+		}
+
+		resp := &mgmtpb.PoolCreateResp{}
+		if err = proto.Unmarshal(dresp.Body, resp); err != nil {
+			return nil, errors.Wrap(err, "unmarshal PoolCreate response")
+		}
+
+		svc.log.Debugf("MgmtSvc.PoolCreate dispatch, try %d, resp:%+v\n", try, *resp)
+
+		ds := drpc.DaosStatus(resp.GetStatus())
+		switch ds {
+		// retryable errors
+		case drpc.DaosGroupVersionMismatch:
+			svc.log.Infof("MgmtSvc.PoolCreate (try %d), retrying due to %s", try, ds)
+			try++
+			select {
+			case <-ctx.Done():
+				return nil, ctx.Err()
+			case <-time.After(poolCreateRetryDelay):
+				continue
+			}
+		default:
+			return resp, nil
+		}
 	}
-
-	resp := &mgmtpb.PoolCreateResp{}
-	if err = proto.Unmarshal(dresp.Body, resp); err != nil {
-		return nil, errors.Wrap(err, "unmarshal PoolCreate response")
-	}
-
-	svc.log.Debugf("MgmtSvc.PoolCreate dispatch, resp:%+v\n", *resp)
-
-	return resp, nil
 }
 
 // PoolDestroy implements the method defined for the Management Service.

--- a/src/control/server/mgmt_pool_test.go
+++ b/src/control/server/mgmt_pool_test.go
@@ -26,6 +26,7 @@ package server
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/dustin/go-humanize"
 	"github.com/golang/protobuf/proto"
@@ -104,6 +105,19 @@ func TestMgmtSvc_PoolCreate(t *testing.T) {
 			},
 			expErr: errors.New("unmarshal"),
 		},
+		"retries exceed context deadline": {
+			targetCount: 8,
+			req: &mgmtpb.PoolCreateReq{
+				Scmbytes:  100 * humanize.GiByte,
+				Nvmebytes: 10 * humanize.TByte,
+			},
+			setupMockDrpc: func(svc *mgmtSvc, err error) {
+				setupMockDrpcClient(svc, &mgmtpb.PoolCreateResp{
+					Status: int32(drpc.DaosGroupVersionMismatch),
+				}, nil)
+			},
+			expErr: context.DeadlineExceeded,
+		},
 		"successful creation": {
 			targetCount: 8,
 			req: &mgmtpb.PoolCreateReq{
@@ -170,7 +184,9 @@ func TestMgmtSvc_PoolCreate(t *testing.T) {
 				tc.setupMockDrpc(tc.mgmtSvc, tc.expErr)
 			}
 
-			gotResp, gotErr := tc.mgmtSvc.PoolCreate(context.TODO(), tc.req)
+			ctx, cancel := context.WithTimeout(context.Background(), poolCreateRetryDelay+10*time.Millisecond)
+			defer cancel()
+			gotResp, gotErr := tc.mgmtSvc.PoolCreate(ctx, tc.req)
 			common.CmpErr(t, tc.expErr, gotErr)
 			if tc.expErr != nil {
 				return


### PR DESCRIPTION
In particular, when the create results in a -DER_GRPVER,
we can assume that it's safe to retry the create in order
to deal with a race between the create and the pool map
distribution.

The create will be retried with a delay until the context
is canceled (cancelation criteria defined by the RPC invoker).