### PR TITLE
Prototype an inline script libarary

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -41,13 +41,10 @@
 //@Library(value="pipeline-lib@your_branch") _
 
 def doc_only_change() {
-    def rc = sh script: 'if [ "' + env.CHANGE_ID + '''" = "null" ]; then
-                              mb_modifier="^"
-                         fi
-                         git diff-tree --no-commit-id --name-only \
-                           $(git merge-base origin/''' + target_branch +
-                      '''$mb_modifier HEAD) HEAD | \
-                           grep -v -e "^doc$"''',
+    def rc = sh label: "Determine if doc-only change",
+                script: "CHANGE_ID=${env.CHANGE_ID} " +
+                        "target_branch=${target_branch} " +
+                        'ci/doc_only_change.sh',
                 returnStatus: true
 
     return rc == 1
@@ -362,9 +359,9 @@ pipeline {
                         checkoutScm withSubmodules: true
                         catchError(stageResult: 'UNSTABLE', buildResult: 'SUCCESS') {
                             sh label: env.STAGE_NAME,
-                               script: '''rm -rf artifacts/centos7/
-                                          mkdir -p artifacts/centos7/
-                                          make CHROOT_NAME="epel-7-x86_64" -C utils/rpms chrootbuild'''
+                               script: 'artdir=centos7 ' +
+                                       'chroot_name=epel-7-x86_64 ' +
+                                       'ci/rpm_build.sh'
                         }
                     }
                     post {
@@ -438,9 +435,9 @@ pipeline {
                         checkoutScm withSubmodules: true
                         catchError(stageResult: 'UNSTABLE', buildResult: 'SUCCESS') {
                             sh label: env.STAGE_NAME,
-                               script: '''rm -rf artifacts/leap15/
-                                  mkdir -p artifacts/leap15/
-                                  make CHROOT_NAME="opensuse-leap-15.1-x86_64" -C utils/rpms chrootbuild'''
+                               script: 'artdir=leap15 ' +
+                                       'chroot_name=opensuse-leap-15.1-x86_64 ' +
+                                       'ci/rpm_build.sh'
                         }
                     }
                     post {
@@ -991,42 +988,10 @@ pipeline {
                                                   'spdk-devel libfabric-devel pmix numactl-devel ' +
                                                   'libipmctl-devel' + qb_inst_rpms
                         runTest stashes: [ 'CentOS-tests', 'CentOS-install', 'CentOS-build-vars' ],
-                                script: '''# JENKINS-52781 tar function is breaking symlinks
-                                           rm -rf test_results
-                                           mkdir test_results
-                                           rm -f build/src/control/src/github.com/daos-stack/daos/src/control
-                                           mkdir -p build/src/control/src/github.com/daos-stack/daos/src/
-                                           ln -s ../../../../../../../../src/control build/src/control/src/github.com/daos-stack/daos/src/control
-                                           . ./.build_vars.sh
-                                           DAOS_BASE=${SL_PREFIX%/install*}
-                                           rm -f dnt.*.memcheck.xml test.out
-                                           NODE=${NODELIST%%,*}
-                                           ssh $SSH_KEY_ARGS jenkins@$NODE "set -x
-                                               set -e
-                                               sudo bash -c 'echo \"1\" > /proc/sys/kernel/sysrq'
-                                               if grep /mnt/daos\\  /proc/mounts; then
-                                                   sudo umount /mnt/daos
-                                               else
-                                                   sudo mkdir -p /mnt/daos
-                                               fi
-                                               sudo mkdir -p /mnt/daos
-                                               sudo mount -t tmpfs -o size=16G tmpfs /mnt/daos
-                                               sudo mkdir -p $DAOS_BASE
-                                               sudo mount -t nfs $HOSTNAME:$PWD $DAOS_BASE
-                                               sudo cp $DAOS_BASE/install/bin/daos_admin /usr/bin/daos_admin
-                                               sudo chown root /usr/bin/daos_admin
-                                               sudo chmod 4755 /usr/bin/daos_admin
-                                               /bin/rm $DAOS_BASE/install/bin/daos_admin
-                                               sudo ln -sf $SL_PREFIX/share/spdk/scripts/setup.sh /usr/share/spdk/scripts
-                                               sudo ln -sf $SL_PREFIX/share/spdk/scripts/common.sh /usr/share/spdk/scripts
-                                               sudo ln -s $SL_PREFIX/include  /usr/share/spdk/include
-                                               # set CMOCKA envs here
-                                               export CMOCKA_MESSAGE_OUTPUT="xml"
-                                               export CMOCKA_XML_FILE="$DAOS_BASE/test_results/%g.xml"
-                                               cd $DAOS_BASE
-                                               IS_CI=true OLD_CI=false utils/run_test.sh
-                                               ./utils/node_local_test.py all | tee test.out"''',
-                              junit_files: 'test_results/*.xml'
+                                script: "SSH_KEY_ARGS=${env.SSH_KEY_ARGS} " +
+                                        "NODELIST=${env.NODELIST} " +
+                                        'ci/run_test/main.sh',
+                                junit_files: 'test_results/*.xml'
                     }
                     post {
                         /* temporarily moved into runTest->stepResult due to JENKINS-39203

--- a/ci/doc_only_change.sh
+++ b/ci/doc_only_change.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+set -ex
+
+if [ "$CHANGE_ID" = "null" ]; then
+     mb_modifier=^
+fi
+git diff-tree --no-commit-id --name-only              \
+  "$(git merge-base origin/"${target_branch:?}"$mb_modifier HEAD)" HEAD | \
+  grep -v -e "^doc$"

--- a/ci/rpm_build.sh
+++ b/ci/rpm_build.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+set -ex
+
+rm -rf artifacts/"${artdir:?}"/
+mkdir -p artifacts/"${artdir:?}"/
+make CHROOT_NAME="${chroot_name:?}" -C utils/rpms chrootbuild

--- a/ci/run_test/core.sh
+++ b/ci/run_test/core.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+set -ex
+
+sudo bash -c 'echo 1 > /proc/sys/kernel/sysrq'
+if grep /mnt/daos\  /proc/mounts; then
+    sudo umount /mnt/daos
+else
+    sudo mkdir -p /mnt/daos
+fi
+sudo mount -t tmpfs -o size=16G tmpfs /mnt/daos
+sudo mkdir -p "$DAOS_BASE"
+sudo mount -t nfs "$HOSTNAME":"$PWD" "$DAOS_BASE"
+
+# copy daos_admin binary into $PATH and fix perms
+sudo cp "$DAOS_BASE"/install/bin/daos_admin /usr/bin/daos_admin && \
+  sudo chown root /usr/bin/daos_admin && \
+  sudo chmod 4755 /usr/bin/daos_admin && \
+  mv "$DAOS_BASE"/install/bin/daos_admin \
+     "$DAOS_BASE"/install/bin/orig_daos_admin
+
+# set CMOCKA envs here
+export CMOCKA_MESSAGE_OUTPUT=xml
+export CMOCKA_XML_FILE="$DAOS_BASE"/test_results/%g.xml
+cd "$DAOS_BASE"
+IS_CI=true OLD_CI=false utils/run_test.sh
+./utils/node_local_test.py all | tee test.out
+

--- a/ci/run_test/main.sh
+++ b/ci/run_test/main.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+set -ex
+
+# JENKINS-52781 tar function is breaking symlinks
+rm -rf test_results
+mkdir test_results
+rm -f build/src/control/src/github.com/daos-stack/daos/src/control
+mkdir -p build/src/control/src/github.com/daos-stack/daos/src/
+ln -s ../../../../../../../../src/control \
+      build/src/control/src/github.com/daos-stack/daos/src/control
+# shellcheck disable=SC1091
+. ./.build_vars.sh
+DAOS_BASE=${SL_PREFIX%/install*}
+NODE=${NODELIST%%,*}
+# shellcheck disable=SC2029
+ssh "$SSH_KEY_ARGS" jenkins@"$NODE" "DAOS_BASE=$DAOS_BASE      \
+                                     HOSTNAME=$HOSTNAME        \
+                                     PWD=$PWD                  \
+                                     $(cat ci/run_test/core.sh)"


### PR DESCRIPTION
Move inline scripts out into their own files so that they don't need heroic
escaping and can be linted with ShellCheck.

Signed-off-by: Brian J. Murrell <brian.murrell@intel.com>