### PR TITLE
DAOS-4687 test: Remove MPI dependence from daosctl (#2584)

### DIFF
--- a/src/control/SConscript
+++ b/src/control/SConscript
@@ -164,7 +164,8 @@ def scons():
 
     prereqs.require(denv, 'cart')
 
-    denv.AppendENVPath("CGO_CFLAGS", denv.subst("-I$CART_PREFIX/include"))
+    denv.AppendENVPath("CGO_CFLAGS", denv.subst("-I$CART_PREFIX/include"),
+                       sep=" ")
 
     install_go_bin(denv, gosrc, gopath, None, "agent", "daos_agent")
     install_go_bin(denv, gosrc, gopath, None, "dmg", "dmg")
@@ -194,7 +195,7 @@ def scons():
                        " -lspdk_blob -lspdk_nvme -lspdk_util -lspdk_json" + \
                        " -lspdk_jsonrpc -lspdk_rpc -lspdk_trace" + \
                        " -lspdk_sock -lspdk_log -lspdk_notify" + \
-                       " -lspdk_blob_bdev -lnuma -ldl -lisal")
+                       " -lspdk_blob_bdev -lnuma -ldl -lisal", sep=" ")
 
     senv.AppendENVPath("CGO_CFLAGS",
                        senv.subst("-I$SPDK_PREFIX/include "

--- a/src/tests/daosctl/SConscript
+++ b/src/tests/daosctl/SConscript
@@ -13,10 +13,6 @@ def scons():
 
     denv = env.Clone()
 
-    mpi = daos_build.configure_mpi(prereqs, denv, libs)
-    if mpi is None:
-        return
-
     denv.AppendUnique(CFLAGS=['-std=gnu99'])
     denv.AppendUnique(CPPDEFINES=['TEST'])
 

--- a/src/tests/daosctl/cont-cmds.c
+++ b/src/tests/daosctl/cont-cmds.c
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2018-2019 Intel Corporation.
+ * (C) Copyright 2018-2020 Intel Corporation.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -30,7 +30,6 @@
 #include <endian.h>
 #include <sys/types.h>
 #include <sys/stat.h>
-#include <mpi.h>
 #include <stdint.h>
 #include <inttypes.h>
 #include <argp.h>
@@ -132,7 +131,7 @@ cmd_create_container(int argc, const char **argv, void *ctx)
 	/* once the command is removed the remaining arguments conform
 	 * to GNU standards and can be parsed with argp
 	 */
-	argp_parse(&argp, argc, (char **restrict)argv, 0, 0, &cc_options);
+	argp_parse(&argp, argc, (char **)argv, 0, 0, &cc_options);
 
 	/* uuid needs extra parsing */
 	if (!cc_options.pool_uuid ||
@@ -218,7 +217,7 @@ cmd_destroy_container(int argc, const char **argv, void *ctx)
 	/* once the command is removed the remaining arguments conform
 	 * to GNU standards and can be parsed with argp
 	 */
-	argp_parse(&argp, argc, (char **restrict)argv, 0, 0, &cc_options);
+	argp_parse(&argp, argc, (char **)argv, 0, 0, &cc_options);
 
 	/* uuids needs extra parsing */
 	rc = uuid_parse(cc_options.pool_uuid, pool_uuid);
@@ -294,7 +293,7 @@ cmd_query_container(int argc, const char **argv, void *ctx)
 	/* once the command is removed the remaining arguments conform
 	 * to GNU standards and can be parsed with argp
 	 */
-	argp_parse(&argp, argc, (char **restrict)argv, 0, 0, &cc_options);
+	argp_parse(&argp, argc, (char **)argv, 0, 0, &cc_options);
 
 	/* uuids needs extra parsing */
 	rc = uuid_parse(cc_options.pool_uuid, pool_uuid);

--- a/src/tests/daosctl/daosctl.c
+++ b/src/tests/daosctl/daosctl.c
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2018 Intel Corporation.
+ * (C) Copyright 2018-2020 Intel Corporation.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,7 +21,9 @@
  * portions thereof marked with this legend must also reproduce the markings.
  */
 
+#ifdef USE_MPI
 #include <mpi.h>
+#endif
 #include <stdio.h>
 #include <errno.h>
 #include <string.h>
@@ -37,8 +39,6 @@
 #include <daos_api.h>
 #include <daos_mgmt.h>
 #include <daos/common.h>
-
-#define USE_MPI 0
 
 const char *program_bug_address = "scott.kirvan@intel.com";
 const char *program_version = "daosctl version 0.1";

--- a/src/tests/daosctl/io-cmds.c
+++ b/src/tests/daosctl/io-cmds.c
@@ -31,7 +31,6 @@
 #include <endian.h>
 #include <sys/types.h>
 #include <sys/stat.h>
-#include <mpi.h>
 #include <stdint.h>
 #include <inttypes.h>
 #include <argp.h>
@@ -435,7 +434,7 @@ cmd_write_pattern(int argc, const char **argv, void *ctx)
 	/* once the command is removed the remaining arguments conform
 	 * to GNU standards and can be parsed with argp
 	 */
-	argp_parse(&argp, argc, (char **restrict)argv, 0, 0, &io_options);
+	argp_parse(&argp, argc, (char **)argv, 0, 0, &io_options);
 
 	/* uuid needs extra parsing */
 	if (io_options.pool_uuid == NULL)
@@ -522,7 +521,7 @@ cmd_verify_pattern(int argc, const char **argv, void *ctx)
 	/* once the command is removed the remaining arguments conform
 	 * to GNU standards and can be parsed with argp
 	 */
-	argp_parse(&argp, argc, (char **restrict)argv, 0, 0, &io_options);
+	argp_parse(&argp, argc, (char **)argv, 0, 0, &io_options);
 
 	/* uuid needs extra parsing */
 	if (io_options.pool_uuid == NULL)

--- a/src/tests/daosctl/pool-cmds.c
+++ b/src/tests/daosctl/pool-cmds.c
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2018-2019 Intel Corporation.
+ * (C) Copyright 2018-2020 Intel Corporation.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -31,7 +31,6 @@
 #include <endian.h>
 #include <sys/types.h>
 #include <sys/stat.h>
-#include <mpi.h>
 #include <stdint.h>
 #include <inttypes.h>
 #include <argp.h>
@@ -167,7 +166,7 @@ cmd_create_pool(int argc, const char **argv, void *ctx)
 	/* once the command is removed the remaining arguments conform
 	 * to GNU standards and can be parsed with argp
 	 */
-	argp_parse(&argp, argc, (char **restrict)argv, 0, 0, &cp_options);
+	argp_parse(&argp, argc, (char **)argv, 0, 0, &cp_options);
 
 	svc.rl_nr = cp_options.replica_count;
 	D_ALLOC_ARRAY(svc.rl_ranks, svc.rl_nr);
@@ -235,7 +234,7 @@ cmd_destroy_pool(int argc, const char **argv, void *ctx)
 	/* once the command is removed the remaining arguments conform
 	 * to GNU standards and can be parsed with argp
 	 */
-	argp_parse(&argp, argc, (char **restrict)argv, 0, 0, &dp_options);
+	argp_parse(&argp, argc, (char **)argv, 0, 0, &dp_options);
 
 	printf("destroy_pool uuid:%s server:%s force:%i\n", dp_options.uuid,
 	       dp_options.server_group, dp_options.force);
@@ -290,7 +289,7 @@ cmd_exclude_target(int argc, const char **argv, void *ctx)
 	/* once the command is removed the remaining arguments conform
 	 * to GNU standards and can be parsed with argp
 	 */
-	argp_parse(&argp, argc, (char **restrict)argv, 0, 0, &et_options);
+	argp_parse(&argp, argc, (char **)argv, 0, 0, &et_options);
 
 	/* turn the uuid string, into a uuid byte array */
 	rc = uuid_parse(et_options.uuid, uuid);
@@ -366,7 +365,7 @@ cmd_evict_pool(int argc, const char **argv, void *ctx)
 	/* once the command is removed the remaining arguments
 	 * conform to GNU standards and can be parsed with argp
 	 */
-	argp_parse(&argp, argc, (char **restrict)argv, 0, 0, &ep_options);
+	argp_parse(&argp, argc, (char **)argv, 0, 0, &ep_options);
 
 	/* turn the UUID string into a uuid array */
 	rc = uuid_parse(ep_options.uuid, uuid);
@@ -426,7 +425,7 @@ cmd_query_pool_status(int argc, const char **argv, void *ctx)
 	/* once the command is removed the remaining arguments
 	 * conform to GNU standards and can be parsed with argp
 	 */
-	argp_parse(&argp, argc, (char **restrict)argv, 0, 0, &qp_options);
+	argp_parse(&argp, argc, (char **)argv, 0, 0, &qp_options);
 
 	rc = uuid_parse(qp_options.uuid, uuid);
 
@@ -492,7 +491,7 @@ cmd_kill_server(int argc, const char **argv, void *ctx)
 	/* once the command is removed the remaining arguments
 	 * conform to GNU standards and can be parsed with argp
 	 */
-	argp_parse(&argp, argc, (char **restrict)argv, 0, 0, &ep_options);
+	argp_parse(&argp, argc, (char **)argv, 0, 0, &ep_options);
 
 	rc = parse_rank_list(ep_options.server_list,
 			     &pool_service_list);
@@ -551,7 +550,7 @@ cmd_kill_pool_leader(int argc, const char **argv, void *ctx)
 	/* once the command is removed the remaining arguments
 	 * conform to GNU standards and can be parsed with argp
 	 */
-	argp_parse(&argp, argc, (char **restrict)argv, 0, 0, &killp_options);
+	argp_parse(&argp, argc, (char **)argv, 0, 0, &killp_options);
 
 	/* TODO once we have a way to serialize/deserialize this,
 	 * deserialize it here appropriately

--- a/src/tests/daosctl/test-pool.c
+++ b/src/tests/daosctl/test-pool.c
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2018-2019 Intel Corporation.
+ * (C) Copyright 2018-2020 Intel Corporation.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -30,7 +30,6 @@
 #include <endian.h>
 #include <sys/types.h>
 #include <sys/stat.h>
-#include <mpi.h>
 #include <stdint.h>
 #include <inttypes.h>
 #include <argp.h>
@@ -165,7 +164,7 @@ cmd_connect_pool(int argc, const char **argv, void *ctx)
 	/* once the command is removed the remaining arguments conform
 	 * to GNU standards and can be parsed with argp
 	 */
-	argp_parse(&argp, argc, (char **restrict)argv, 0, 0, &cp_options);
+	argp_parse(&argp, argc, (char **)argv, 0, 0, &cp_options);
 
 	if (cp_options.read)
 		flag = DAOS_PC_RO;
@@ -265,7 +264,7 @@ cmd_test_connect_pool(int argc, const char **argv, void *ctx)
 	/* once the command is removed the remaining arguments
 	 * conform to GNU standards and can be parsed with argp
 	 */
-	argp_parse(&argp, argc, (char **restrict)argv, 0, 0, &cp_options);
+	argp_parse(&argp, argc, (char **)argv, 0, 0, &cp_options);
 
 	/* finish parsing connect type */
 	/* TODO: not optimal parsing */
@@ -402,7 +401,7 @@ cmd_test_create_pool(int argc, const char **argv, void *ctx)
 	/* once the command is removed the remaining arguments
 	 * conform to GNU standards and can be parsed with argp
 	 */
-	argp_parse(&argp, argc, (char **restrict)argv, 0, 0, &cp_options);
+	argp_parse(&argp, argc, (char **)argv, 0, 0, &cp_options);
 
 	/* turn the list of pool service nodes into a rank list */
 	rc = parse_rank_list(cp_options.server_list,
@@ -477,7 +476,7 @@ cmd_test_evict_pool(int argc, const char **argv, void *ctx)
 	/* once the command is removed the remaining arguments
 	 * conform to GNU standards and can be parsed with argp
 	 */
-	argp_parse(&argp, argc, (char **restrict)argv, 0, 0, &ep_options);
+	argp_parse(&argp, argc, (char **)argv, 0, 0, &ep_options);
 
 	/* finish parsing connect type */
 	/* TODO: not optimal parsing */
@@ -592,7 +591,7 @@ cmd_test_query_pool(int argc, const char **argv, void *ctx)
 	/* once the command is removed the remaining arguments conform to
 	 * GNU standards and can be parsed with argp
 	 */
-	argp_parse(&argp, argc, (char **restrict)argv, 0, 0, &qp_options);
+	argp_parse(&argp, argc, (char **)argv, 0, 0, &qp_options);
 
 	/* a handle must be provided */
 	if (qp_options.handle == NULL)


### PR DESCRIPTION
This utility is deprecated but since we still use it but not
with MPI and since this issue is caused by a library MPI
uses, just disable MPI

Also fixes CGO_CFLAGS, CGO_LDFLAGS to use " " separator so
daos can be built on Fedora 31 with hwloc workaround

Signed-off-by: Jeff Olivier <jeffrey.v.olivier@intel.com>