### PR TITLE
Revert "CART-886 group: Use atomic operations for refcount"

### DIFF
--- a/src/cart/src/cart/crt_ctl.c
+++ b/src/cart/src/cart/crt_ctl.c
@@ -41,7 +41,6 @@
  */
 
 #include "crt_internal.h"
-#include <gurt/atomic.h>
 
 #define MAX_HOSTNAME_SIZE 1024
 
@@ -82,7 +81,6 @@ crt_ctl_fill_buffer_cb(d_list_t *rlink, void *arg)
 	struct crt_uri_item	*ui;
 	int			*idx;
 	struct crt_uri_cache	*uri_cache = arg;
-	crt_phy_addr_t		 uri;
 	int			 i;
 	int			 rc = 0;
 
@@ -90,18 +88,23 @@ crt_ctl_fill_buffer_cb(d_list_t *rlink, void *arg)
 	D_ASSERT(arg != NULL);
 
 	ui = crt_ui_link2ptr(rlink);
+
+	D_MUTEX_LOCK(&ui->ui_mutex);
+
 	idx = &uri_cache->idx;
+
 	for (i = 0; i < CRT_SRV_CONTEXT_NUM; i++) {
-		uri = atomic_load_consume(&ui->ui_uri[i]);
-		if (uri == NULL)
+		if (ui->ui_uri[i] == NULL)
 			continue;
 
 		uri_cache->grp_cache[*idx].gc_rank = ui->ui_rank;
 		uri_cache->grp_cache[*idx].gc_tag = i;
-		uri_cache->grp_cache[*idx].gc_uri = uri;
+		uri_cache->grp_cache[*idx].gc_uri = ui->ui_uri[i];
 
 		*idx += 1;
 	}
+
+	D_MUTEX_UNLOCK(&ui->ui_mutex);
 
 	return rc;
 }
@@ -118,12 +121,15 @@ crt_ctl_get_uri_cache_size_cb(d_list_t *rlink, void *arg)
 	D_ASSERT(arg != NULL);
 
 	ui = crt_ui_link2ptr(rlink);
+
+	D_MUTEX_LOCK(&ui->ui_mutex);
 	for (i = 0; i < CRT_SRV_CONTEXT_NUM; i++) {
-		if (atomic_load_consume(&ui->ui_uri[i]) == NULL)
+		if (ui->ui_uri[i] == NULL)
 			continue;
 
 		*nuri += 1;
 	}
+	D_MUTEX_UNLOCK(&ui->ui_mutex);
 
 	return rc;
 }

--- a/src/cart/src/cart/crt_group.h
+++ b/src/cart/src/cart/crt_group.h
@@ -42,7 +42,6 @@
 #ifndef __CRT_GROUP_H__
 #define __CRT_GROUP_H__
 
-#include <gurt/atomic.h>
 #include "crt_swim.h"
 
 
@@ -214,8 +213,10 @@ struct crt_rank_mapping {
 	d_rank_t	rm_key;
 	d_rank_t	rm_value;
 
-	ATOMIC uint32_t	rm_ref;
-	uint32_t	rm_initialized:1;
+	uint32_t	rm_ref;
+	uint32_t	rm_initialized;
+
+	pthread_mutex_t	rm_mutex;
 };
 
 /* uri info for each remote rank */
@@ -225,7 +226,7 @@ struct crt_uri_item {
 
 	/* URI string for each remote tag */
 	/* TODO: in phase2 change this to hash table */
-	ATOMIC crt_phy_addr_t ui_uri[CRT_SRV_CONTEXT_NUM];
+	crt_phy_addr_t	ui_uri[CRT_SRV_CONTEXT_NUM];
 
 	/* Primary rank; for secondary groups only  */
 	d_rank_t	ui_pri_rank;
@@ -234,10 +235,13 @@ struct crt_uri_item {
 	d_rank_t	ui_rank;
 
 	/* reference count */
-	ATOMIC uint32_t	ui_ref;
+	uint32_t	ui_ref;
 
 	/* flag indicating whether initialized */
-	uint32_t	ui_initialized:1;
+	uint32_t	ui_initialized;
+
+	/* mutex for protection of ui_ref */
+	pthread_mutex_t ui_mutex;
 };
 
 /* lookup cache item for one target */
@@ -252,7 +256,7 @@ struct crt_lookup_item {
 	hg_addr_t		 li_tag_addr[CRT_SRV_CONTEXT_NUM];
 
 	/* reference count */
-	ATOMIC uint32_t		 li_ref;
+	uint32_t		 li_ref;
 	uint32_t		 li_initialized:1;
 	pthread_mutex_t		 li_mutex;
 };


### PR DESCRIPTION
Seems to be causing memory leaks.
Reverts daos-stack/daos#2538