### PR TITLE
DAOS-4724 iosrv: name & membind xstreams

### DIFF
--- a/src/include/daos_srv/daos_server.h
+++ b/src/include/daos_srv/daos_server.h
@@ -140,7 +140,8 @@ dss_module_key_get(struct dss_thread_local_storage *dtls,
 void dss_register_key(struct dss_module_key *key);
 void dss_unregister_key(struct dss_module_key *key);
 
-#define DSS_XS_NAME_LEN		64
+/** pthread names are limited to 16 chars */
+#define DSS_XS_NAME_LEN		16
 
 struct srv_profile_chunk {
 	d_list_t	spc_chunk_list;

--- a/src/iosrv/init.c
+++ b/src/iosrv/init.c
@@ -905,6 +905,8 @@ main(int argc, char **argv)
 	if (rc)
 		exit(EXIT_FAILURE);
 
+	(void)pthread_setname_np(pthread_self(), "daos_main");
+
 	/** block all possible signals but faults */
 	sigfillset(&set);
 	sigdelset(&set, SIGILL);

--- a/src/iosrv/srv.c
+++ b/src/iosrv/srv.c
@@ -115,7 +115,8 @@ dss_ctx_nr_get(void)
 static void dss_gc_ult(void *args);
 
 #define DSS_SYS_XS_NAME_FMT	"daos_sys_%d"
-#define DSS_TGT_XS_NAME_FMT	"daos_tgt_%d_xs_%d"
+#define DSS_IO_XS_NAME_FMT	"daos_io_%d"
+#define DSS_OFFLOAD_XS_NAME_FMT	"daos_off_%d"
 
 struct dss_xstream_data {
 	/** Initializing step, it is for cleanup of global states */
@@ -384,7 +385,14 @@ dss_srv_handler(void *arg)
 	/** set affinity */
 	rc = hwloc_set_cpubind(dss_topo, dx->dx_cpuset, HWLOC_CPUBIND_THREAD);
 	if (rc) {
-		D_ERROR("failed to set affinity: %d\n", errno);
+		D_ERROR("failed to set cpu affinity: %d\n", errno);
+		goto signal;
+	}
+
+	rc = hwloc_set_membind(dss_topo, dx->dx_cpuset, HWLOC_MEMBIND_BIND,
+			       HWLOC_CPUBIND_THREAD);
+	if (rc) {
+		D_ERROR("failed to set memory affinity: %d\n", errno);
 		goto signal;
 	}
 
@@ -401,6 +409,8 @@ dss_srv_handler(void *arg)
 	dmi->dmi_tgt_id	= dx->dx_tgt_id;
 	dmi->dmi_ctx_id	= -1;
 	D_INIT_LIST_HEAD(&dmi->dmi_dtx_batched_list);
+
+	(void)pthread_setname_np(pthread_self(), dx->dx_name);
 
 	if (dx->dx_comm) {
 		/* create private transport context */
@@ -644,14 +654,6 @@ dss_start_one_xstream(hwloc_cpuset_t cpus, int xs_id)
 				 (helper_per_tgt + 1));
 		comm = (xs_id == 0) || xs_offset == 0 || xs_offset == 1;
 	}
-	dx->dx_tgt_id	= dss_xs2tgt(xs_id);
-	if (xs_id < dss_sys_xs_nr) {
-		snprintf(dx->dx_name, DSS_XS_NAME_LEN, DSS_SYS_XS_NAME_FMT,
-			 xs_id);
-	} else {
-		snprintf(dx->dx_name, DSS_XS_NAME_LEN, DSS_TGT_XS_NAME_FMT,
-			 dx->dx_tgt_id, xs_id);
-	}
 	dx->dx_xs_id	= xs_id;
 	dx->dx_ctx_id	= -1;
 	dx->dx_comm	= comm;
@@ -664,6 +666,26 @@ dss_start_one_xstream(hwloc_cpuset_t cpus, int xs_id)
 	dx->dx_dsc_started = false;
 	D_INIT_LIST_HEAD(&dx->dx_sleep_ult_list);
 
+	/**
+	 * Generate name for each xstreams so that they can be easily identified
+	 * and monitored independently (e.g. via ps(1))
+	 */
+	dx->dx_tgt_id	= dss_xs2tgt(xs_id);
+	if (xs_id < dss_sys_xs_nr) {
+		/** system xtreams are named daos_sys_$num */
+		snprintf(dx->dx_name, DSS_XS_NAME_LEN, DSS_SYS_XS_NAME_FMT,
+			 xs_id);
+	} else if (dx->dx_main_xs) {
+		/** primary I/O xstreams are named daos_io_$tgtid */
+		snprintf(dx->dx_name, DSS_XS_NAME_LEN, DSS_IO_XS_NAME_FMT,
+			 dx->dx_tgt_id);
+	} else {
+		/** offload xstreams are named daos_off_$num */
+		snprintf(dx->dx_name, DSS_XS_NAME_LEN, DSS_OFFLOAD_XS_NAME_FMT,
+			 xs_id);
+	}
+
+	/** create ABT scheduler in charge of this xstream */
 	rc = dss_sched_init(dx);
 	if (rc != 0) {
 		D_ERROR("create scheduler fails: "DF_RC"\n", DP_RC(rc));

--- a/src/iosrv/srv.c
+++ b/src/iosrv/srv.c
@@ -390,7 +390,7 @@ dss_srv_handler(void *arg)
 	}
 
 	rc = hwloc_set_membind(dss_topo, dx->dx_cpuset, HWLOC_MEMBIND_BIND,
-			       HWLOC_CPUBIND_THREAD);
+			       HWLOC_MEMBIND_THREAD);
 	if (rc) {
 		D_ERROR("failed to set memory affinity: %d\n", errno);
 		goto signal;


### PR DESCRIPTION
Use hwloc membind to force memory allocation to be on the
local NUMA node.
Use meaningful name for each pthread so that they can be
recognized with ps(1) and other tools.

e.g. with ps -To pid,tid,tgid,tty,time,tid,comm -p 204238
   PID    TID   TGID TT           TIME    TID COMMAND
204238 204238 204238 pts/1    00:00:06 204238 daos_main
204238 204254 204238 pts/1    00:00:00 204254 eal-intr-thread
204238 204255 204238 pts/1    00:00:00 204255 rte_mp_handle
204238 204256 204238 pts/1    00:00:11 204256 daos_sys_0
204238 204257 204238 pts/1    00:00:06 204257 daos_sys_1
204238 204258 204238 pts/1    00:00:11 204258 daos_io_0
204238 204274 204238 pts/1    00:00:06 204274 daos_io_1
204238 204280 204238 pts/1    00:00:06 204280 daos_io_2
204238 204286 204238 pts/1    00:00:06 204286 daos_io_3
204238 204292 204238 pts/1    00:00:06 204292 daos_io_4
204238 204298 204238 pts/1    00:00:06 204298 daos_io_5
204238 204304 204238 pts/1    00:00:06 204304 daos_io_6
204238 204310 204238 pts/1    00:00:06 204310 daos_io_7
204238 204316 204238 pts/1    00:00:05 204316 daos_io_8
204238 204322 204238 pts/1    00:00:05 204322 daos_io_9
204238 204328 204238 pts/1    00:00:05 204328 daos_io_10
204238 204334 204238 pts/1    00:00:05 204334 daos_io_11
204238 204340 204238 pts/1    00:00:05 204340 daos_io_12
204238 204346 204238 pts/1    00:00:05 204346 daos_io_13
204238 204352 204238 pts/1    00:00:05 204352 daos_io_14
204238 204358 204238 pts/1    00:00:05 204358 daos_io_15

Signed-off-by: Johann Lombardi <johann.lombardi@intel.com>