### PR TITLE
DAOS-4724 cart: progress improvements

### DIFF
--- a/src/cart/src/cart/crt_context.c
+++ b/src/cart/src/cart/crt_context.c
@@ -1276,7 +1276,7 @@ crt_progress_cond(crt_context_t crt_ctx, int64_t timeout,
 		crt_context_timeout_check(ctx);
 		crt_exec_progress_cb(ctx);
 
-		ret = crt_hg_progress (&ctx->cc_hg_ctx, hg_timeout);
+		ret = crt_hg_progress(&ctx->cc_hg_ctx, hg_timeout);
 		if (unlikely(ret && ret != -DER_TIMEDOUT)) {
 			D_ERROR("crt_hg_progress failed with %d\n", ret);
 			return ret;

--- a/src/cart/src/cart/crt_context.c
+++ b/src/cart/src/cart/crt_context.c
@@ -1270,7 +1270,7 @@ crt_progress_cond(crt_context_t crt_ctx, int64_t timeout,
 		 * in case any replies are pending in the queue
 		 */
 		rc = crt_hg_progress(&ctx->cc_hg_ctx, hg_timeout);
-		if (unlikely(rc && rc != -DER_TIMEDOUT)) {
+		if (unlikely(rc && rc != -DER_TIMEDOUT))
 			D_ERROR("crt_hg_progress failed with %d\n", rc);
 
 		crt_context_timeout_check(ctx);
@@ -1345,7 +1345,7 @@ crt_progress(crt_context_t crt_ctx, int64_t timeout)
 	if (timeout != 0 && (rc == 0 || rc == -DER_TIMEDOUT)) {
 		/** call progress once again with the real timeout */
 		rc = crt_hg_progress(&ctx->cc_hg_ctx, timeout);
-		if (rc && rc != -DER_TIMEDOUT)
+		if (unlikely(rc && rc != -DER_TIMEDOUT))
 			D_ERROR("crt_hg_progress failed, rc: %d.\n", rc);
 	}
 

--- a/src/cart/src/cart/crt_context.c
+++ b/src/cart/src/cart/crt_context.c
@@ -1279,7 +1279,7 @@ crt_progress_cond(crt_context_t crt_ctx, int64_t timeout,
 		rc = crt_hg_progress(&ctx->cc_hg_ctx, hg_timeout);
 		if (unlikely(rc && rc != -DER_TIMEDOUT)) {
 			D_ERROR("crt_hg_progress failed with %d\n", rc);
-			return ret;
+			return rc;
 		}
 
 		/** check for timeout */

--- a/src/cart/src/cart/crt_hg.c
+++ b/src/cart/src/cart/crt_hg.c
@@ -1369,8 +1369,10 @@ crt_hg_progress(struct crt_hg_context *hg_ctx, int64_t timeout)
 			/** nothing to trigger */
 			return rc;
 
-		/** continue network progress and callback processing, but w/o
-		 * waiting this time */
+		/**
+		 * continue network progress and callback processing, but w/o
+		 * waiting this time
+		 */
 		total -= count;
 		hg_timeout = 0;
 	} while (total > 0);

--- a/src/cart/src/cart/crt_hg.c
+++ b/src/cart/src/cart/crt_hg.c
@@ -520,7 +520,6 @@ crt_hg_init(crt_phy_addr_t *addr, bool server)
 		D_GOTO(out, rc);
 
 	init_info.na_init_info.progress_mode = 0;
-	init_info.na_init_info.max_contexts = 1;
 	if (crt_gdata.cg_share_na == false)
 		/* one context per NA class */
 		init_info.na_init_info.max_contexts = 1;
@@ -1325,41 +1324,14 @@ crt_hg_reply_error_send(struct crt_rpc_priv *rpc_priv, int error_code)
 	rpc_priv->crp_reply_pending = 0;
 }
 
-static int
-crt_hg_trigger(struct crt_hg_context *hg_ctx)
-{
-	hg_context_t		*hg_context;
-	hg_return_t		hg_ret = HG_SUCCESS;
-	unsigned int		count = 0;
-
-	D_ASSERT(hg_ctx != NULL);
-	hg_context = hg_ctx->chc_hgctx;
-
-	do {
-		hg_ret = HG_Trigger(hg_context, 0, UINT32_MAX, &count);
-	} while (hg_ret == HG_SUCCESS && count > 0);
-
-	if (hg_ret != HG_TIMEOUT) {
-		D_ERROR("HG_Trigger failed, hg_ret: %d.\n", hg_ret);
-		return -DER_HG;
-	}
-
-	return 0;
-}
-
 int
 crt_hg_progress(struct crt_hg_context *hg_ctx, int64_t timeout)
 {
 	hg_context_t		*hg_context;
-	hg_class_t		*hg_class;
-	hg_return_t		hg_ret = HG_SUCCESS;
 	unsigned int		hg_timeout;
-	int			rc;
+	unsigned int		total = 256;
 
-	D_ASSERT(hg_ctx != NULL);
 	hg_context = hg_ctx->chc_hgctx;
-	hg_class = hg_ctx->chc_hgcla;
-	D_ASSERT(hg_context != NULL && hg_class != NULL);
 
 	/**
 	 * Mercury only supports milli-second timeout and uses an unsigned int
@@ -1369,24 +1341,41 @@ crt_hg_progress(struct crt_hg_context *hg_ctx, int64_t timeout)
 	else
 		hg_timeout = timeout / 1000;
 
-	rc = crt_hg_trigger(hg_ctx);
-	if (rc != 0)
-		return rc;
+	do {
+		hg_return_t     hg_ret = HG_SUCCESS;
+		int             rc = 0;
+		unsigned int count = 0;
 
-	/** progress RPC execution */
-	hg_ret = HG_Progress(hg_context, hg_timeout);
-	if (hg_ret == HG_TIMEOUT)
-		D_GOTO(out, rc = -DER_TIMEDOUT);
-	if (hg_ret != HG_SUCCESS) {
-		D_ERROR("HG_Progress failed, hg_ret: %d.\n", hg_ret);
-		D_GOTO(out, rc = -DER_HG);
-	}
+		/** progress RPC execution */
+		hg_ret = HG_Progress(hg_context, hg_timeout);
+		if (hg_ret == HG_TIMEOUT) {
+			rc = -DER_TIMEDOUT;
+		} else if (hg_ret != HG_SUCCESS) {
+			D_ERROR("HG_Progress failed, hg_ret: %d.\n", hg_ret);
+			return -DER_HG;
+		}
 
-	/* some RPCs have progressed, call Trigger again */
-	rc = crt_hg_trigger(hg_ctx);
+		/** some RPCs have progressed, call Trigger */
+		hg_ret = HG_Trigger(hg_context, 0, total, &count);
+		if (hg_ret == HG_TIMEOUT) {
+			/** nothing to trigger */
+			return rc;
+		} else if (hg_ret != HG_SUCCESS) {
+			D_ERROR("HG_Trigger failed, hg_ret: %d.\n", hg_ret);
+			return -DER_HG;
+		}
 
-out:
-	return rc;
+		if (count == 0 || rc)
+			/** nothing to trigger */
+			return rc;
+
+		/** continue network progress and callback processing, but w/o
+		 * waiting this time */
+		total -= count;
+		hg_timeout = 0;
+	} while (total > 0);
+
+	return 0;
 }
 
 #define CRT_HG_IOVN_STACK	(8)

--- a/src/cart/src/include/cart/api.h
+++ b/src/cart/src/include/cart/api.h
@@ -218,25 +218,44 @@ int
 crt_finalize(void);
 
 /**
- * Progress CRT transport layer.
+ * Progress RPC execution on a cart context \a crt_ctx for at most \a timeout
+ * micro-seconds.
+ * The progress call returns when the timeout is reached or any completion has
+ * occurred.
  *
  * \param[in] crt_ctx          CRT transport context
  * \param[in] timeout          how long is caller going to wait (micro-second)
+ *			       at most for a completion to occur.
  *                             if \a timeout > 0 when there is no operation to
  *                             progress. Can return when one or more operation
  *                             progressed.
  *                             zero means no waiting and -1 waits indefinitely.
- * \param[in] cond_cb          optional progress condition callback.
- *                             CRT internally calls this function, when it
- *                             returns non-zero then stops the progressing or
- *                             waiting and returns.
- * \param[in] arg              argument to cond_cb.
  *
  * \return                     DER_SUCCESS on success, negative value if error
  */
 int
-crt_progress(crt_context_t crt_ctx, int64_t timeout,
-	     crt_progress_cond_cb_t cond_cb, void *arg);
+crt_progress(crt_context_t crt_ctx, int64_t timeout);
+
+/**
+ * Progress RPC execution on a cart context with a callback function.
+ * The callback function is regularly called internally. The progress call
+ * returns when the callback returns a non-zero value or when the timeout
+ * expires.
+ *
+ * \param[in] crt_ctx          CRT transport context
+ * \param[in] timeout          how long is caller going to wait (micro-second)
+ *                             zero means no waiting and -1 waits indefinitely.
+ * \param[in] cond_cb          progress condition callback.
+ *                             CRT internally calls this function, when it
+ *                             returns non-zero then stops the progressing or
+ *                             waiting and returns.
+ * \param[in] arg              optional argument to cond_cb.
+ *
+ * \return                     DER_SUCCESS on success, negative value if error
+ */
+int
+crt_progress_cond(crt_context_t crt_ctx, int64_t timeout,
+		  crt_progress_cond_cb_t cond_cb, void *arg);
 
 /**
  * Create an RPC request.

--- a/src/cart/src/include/cart/api.h
+++ b/src/cart/src/include/cart/api.h
@@ -223,15 +223,15 @@ crt_finalize(void);
  * The progress call returns when the timeout is reached or any completion has
  * occurred.
  *
- * \param[in] crt_ctx          CRT transport context
+ * \param[in] crt_ctx          cart context
  * \param[in] timeout          how long is caller going to wait (micro-second)
- *			       at most for a completion to occur.
- *                             if \a timeout > 0 when there is no operation to
- *                             progress. Can return when one or more operation
- *                             progressed.
- *                             zero means no waiting and -1 waits indefinitely.
+ *                             at most for a completion to occur.
+ *                             Can return when one or more operation progressed.
+ *                             zero means no waiting.
  *
- * \return                     DER_SUCCESS on success, negative value if error
+ * \return                     DER_SUCCESS on success
+ *                             -DER_TIMEDOUT if exited after timeout has expired
+ *                             negative value if other internal error
  */
 int
 crt_progress(crt_context_t crt_ctx, int64_t timeout);
@@ -242,16 +242,19 @@ crt_progress(crt_context_t crt_ctx, int64_t timeout);
  * returns when the callback returns a non-zero value or when the timeout
  * expires.
  *
- * \param[in] crt_ctx          CRT transport context
- * \param[in] timeout          how long is caller going to wait (micro-second)
+ * \param[in] crt_ctx          cart context
+ * \param[in] timeout          how long is the caller going to wait in
+ *                             micro-second.
  *                             zero means no waiting and -1 waits indefinitely.
  * \param[in] cond_cb          progress condition callback.
- *                             CRT internally calls this function, when it
+ *                             cart internally calls this function, when it
  *                             returns non-zero then stops the progressing or
  *                             waiting and returns.
  * \param[in] arg              optional argument to cond_cb.
  *
- * \return                     DER_SUCCESS on success, negative value if error
+ * \return                     DER_SUCCESS on success
+ *                             -DER_TIMEDOUT if exited after timeout has expired
+ *                             negative value if internal and \a conb_cb error
  */
 int
 crt_progress_cond(crt_context_t crt_ctx, int64_t timeout,

--- a/src/cart/src/include/gurt/common.h
+++ b/src/cart/src/include/gurt/common.h
@@ -72,6 +72,9 @@
 extern "C" {
 #endif
 
+#define likely(x)       __builtin_expect((x),1)
+#define unlikely(x)     __builtin_expect((x),0)
+
 /* Check if bit is set in passed val */
 #define D_BIT_IS_SET(val, bit) (((val) & bit) ? 1 : 0)
 

--- a/src/cart/src/include/gurt/common.h
+++ b/src/cart/src/include/gurt/common.h
@@ -72,8 +72,8 @@
 extern "C" {
 #endif
 
-#define likely(x)       __builtin_expect((x),1)
-#define unlikely(x)     __builtin_expect((x),0)
+#define likely(x)       __builtin_expect((x), 1)
+#define unlikely(x)     __builtin_expect((x), 0)
 
 /* Check if bit is set in passed val */
 #define D_BIT_IS_SET(val, bit) (((val) & bit) ? 1 : 0)

--- a/src/cart/src/self_test/self_test.c
+++ b/src/cart/src/self_test/self_test.c
@@ -98,7 +98,7 @@ static void *progress_fn(void *arg)
 	D_ASSERT(*crt_ctx != NULL);
 
 	while (!g_shutdown_flag) {
-		ret = crt_progress(*crt_ctx, 1, NULL, NULL);
+		ret = crt_progress(*crt_ctx, 1);
 		if (ret != 0 && ret != -DER_TIMEDOUT) {
 			D_ERROR("crt_progress failed; ret = %d\n", ret);
 			break;

--- a/src/cart/src/test/common.h
+++ b/src/cart/src/test/common.h
@@ -52,7 +52,7 @@ static inline int drain_queue(crt_context_t ctx)
 	 * a more robust method
 	 */
 	do {
-		rc = crt_progress(ctx, 1000000, NULL, NULL);
+		rc = crt_progress(ctx, 1000000);
 		if (rc != 0 && rc != -DER_TIMEDOUT) {
 			printf("crt_progress failed rc: %d.\n", rc);
 			return rc;

--- a/src/cart/src/test/iv_client.c
+++ b/src/cart/src/test/iv_client.c
@@ -393,7 +393,7 @@ progress_function(void *data)
 	crt_context_t *p_ctx = (crt_context_t *)data;
 
 	while (g_do_shutdown == 0)
-		crt_progress(*p_ctx, 1000, NULL, NULL);
+		crt_progress(*p_ctx, 1000);
 
 	crt_context_destroy(*p_ctx, 1);
 

--- a/src/cart/src/test/no_pmix_launcher_client.c
+++ b/src/cart/src/test/no_pmix_launcher_client.c
@@ -60,7 +60,7 @@ progress_function(void *data)
 	crt_context_t *p_ctx = (crt_context_t *)data;
 
 	while (g_do_shutdown == 0)
-		crt_progress(*p_ctx, 1000, NULL, NULL);
+		crt_progress(*p_ctx, 1000);
 
 	crt_context_destroy(*p_ctx, 1);
 

--- a/src/cart/src/test/rpc_test_cli.c
+++ b/src/cart/src/test/rpc_test_cli.c
@@ -149,7 +149,7 @@ static void
 	D_ASSERTF(p_ctx != NULL, "p_ctx:=%p\n", p_ctx);
 
 	while (rpc_cli.shutdown == 0) {
-		rc = crt_progress(*p_ctx, 1000, NULL, NULL);
+		rc = crt_progress(*p_ctx, 1000);
 		if (rc != 0 && rc != -DER_TIMEDOUT) {
 			D_ERROR("crt_progress failed %d", rc);
 			break;

--- a/src/cart/src/test/rpc_test_srv.c
+++ b/src/cart/src/test/rpc_test_srv.c
@@ -230,7 +230,7 @@ static void
 	D_ASSERTF(p_ctx != NULL, "p_ctx:=%p\n", p_ctx);
 
 	while (rpc_srv.shutdown == 0) {
-		rc = crt_progress(*p_ctx, 1000, NULL, NULL);
+		rc = crt_progress(*p_ctx, 1000);
 		if (rc != 0 && rc != -DER_TIMEDOUT) {
 			D_ERROR("crt_progress failed %d", rc);
 			break;

--- a/src/cart/src/test/rpc_test_srv2.c
+++ b/src/cart/src/test/rpc_test_srv2.c
@@ -144,7 +144,7 @@ static void
 	D_ASSERTF(p_ctx != NULL, "p_ctx:=%p\n", p_ctx);
 
 	while (rpc_srv.shutdown == 0) {
-		rc = crt_progress(*p_ctx, 1000, NULL, NULL);
+		rc = crt_progress(*p_ctx, 1000);
 		if (rc != 0 && rc != -DER_TIMEDOUT) {
 			D_ERROR("crt_progress failed %d", rc);
 			break;

--- a/src/cart/src/test/test_group.c
+++ b/src/cart/src/test/test_group.c
@@ -247,7 +247,7 @@ static void *progress_thread(void *arg)
 	ctx = (crt_context_t)test_g.t_crt_ctx[t_idx];
 	/* progress loop */
 	do {
-		rc = crt_progress(ctx, 0, NULL, NULL);
+		rc = crt_progress(ctx, 0);
 		if (rc != 0 && rc != -DER_TIMEDOUT) {
 			D_ERROR("crt_progress failed rc: %d.\n", rc);
 		}

--- a/src/cart/src/test/test_hlc_net.c
+++ b/src/cart/src/test/test_hlc_net.c
@@ -212,7 +212,7 @@ static void *srv_progress(void *data)
 	D_ASSERTF(ctx != NULL, "ctx=%p\n", ctx);
 
 	while (global_srv.shutdown == 0) {
-		rc = crt_progress(*ctx, 1000, NULL, NULL);
+		rc = crt_progress(*ctx, 1000);
 		if (rc != 0 && rc != -DER_TIMEDOUT) {
 			D_ERROR("crt_progress() failed rc=%d\n", rc);
 			break;

--- a/src/cart/src/test/test_rpc_error.c
+++ b/src/cart/src/test/test_rpc_error.c
@@ -144,7 +144,7 @@ static void *progress_thread(void *arg)
 
 	crt_ctx = (crt_context_t) arg;
 	do {
-		rc = crt_progress(crt_ctx, 1, NULL, NULL);
+		rc = crt_progress(crt_ctx, 1);
 		if (rc != 0 && rc != -DER_TIMEDOUT) {
 			D_ERROR("crt_progress failed rc: %d.\n", rc);
 			break;

--- a/src/cart/src/test/test_rpc_to_ghost_rank.c
+++ b/src/cart/src/test/test_rpc_to_ghost_rank.c
@@ -245,7 +245,7 @@ static void *progress_thread(void *arg)
 	ctx = (crt_context_t)test_g.t_crt_ctx[t_idx];
 	/* progress loop */
 	do {
-		rc = crt_progress(ctx, 0, NULL, NULL);
+		rc = crt_progress(ctx, 0);
 		if (rc != 0 && rc != -DER_TIMEDOUT)
 			D_ERROR("crt_progress failed rc: %d.\n", rc);
 		if (test_g.t_shutdown == 1)

--- a/src/cart/src/test/test_swim_net.c
+++ b/src/cart/src/test/test_swim_net.c
@@ -287,7 +287,7 @@ static void *srv_progress(void *data)
 	D_ASSERTF(ctx != NULL, "ctx=%p\n", ctx);
 
 	while (global_srv.shutdown == 0) {
-		rc = crt_progress(*ctx, 1, NULL, NULL);
+		rc = crt_progress(*ctx, 1);
 		if (rc != 0 && rc != -DER_TIMEDOUT) {
 			D_ERROR("crt_progress() failed rc=%d\n", rc);
 			break;

--- a/src/cart/src/test/tests_common.h
+++ b/src/cart/src/test/tests_common.h
@@ -92,13 +92,13 @@ tc_drain_queue(crt_context_t ctx)
 
 	/* TODO: Need better mechanism for tests to drain all queues */
 	for (i = 0; i < 1000; i++)
-		crt_progress(ctx, 1000, NULL, NULL);
+		crt_progress(ctx, 1000);
 
 	/* Drain the queue. Progress until 1 second timeout.  We need
 	 * a more robust method
 	 */
 	do {
-		rc = crt_progress(ctx, 1000000, NULL, NULL);
+		rc = crt_progress(ctx, 1000000);
 		if (rc != 0 && rc != -DER_TIMEDOUT) {
 			D_ERROR("crt_progress failed rc: %d.\n", rc);
 			return rc;
@@ -134,7 +134,7 @@ tc_progress_fn(void *data)
 	}
 
 	while (g_shutdown == 0)
-		crt_progress(*p_ctx, 1000, NULL, NULL);
+		crt_progress(*p_ctx, 1000);
 
 	if (idx == 0)
 		crt_swim_fini();

--- a/src/cart/src/test/threaded_client.c
+++ b/src/cart/src/test/threaded_client.c
@@ -68,7 +68,7 @@ static void *progress(void *arg)
 	__sync_fetch_and_add(status, 1);
 
 	do {
-		rc = crt_progress(crt_ctx, 1, check_status, status);
+		rc = crt_progress_cond(crt_ctx, 1, check_status, status);
 		if (rc == -DER_TIMEDOUT)
 			sched_yield();
 		else if (rc != 0)

--- a/src/cart/src/test/threaded_server.c
+++ b/src/cart/src/test/threaded_server.c
@@ -65,7 +65,8 @@ static void *progress(void *arg)
 	__sync_fetch_and_add(status, -1);
 
 	do {
-		rc = crt_progress(crt_ctx, 1000*1000, check_status, status);
+		rc = crt_progress_cond(crt_ctx, 1000*1000, check_status,
+				       status);
 		if (rc == -DER_TIMEDOUT)
 			sched_yield();
 		else if (rc != 0)

--- a/src/client/api/event.c
+++ b/src/client/api/event.c
@@ -45,22 +45,22 @@ static __thread bool		ev_thpriv_is_init;
 #define crt_finalize()			({0;})
 #define crt_context_create(a, b)	({0;})
 #define crt_context_destroy(a, b)	({0;})
-#define crt_progress(ctx, timeout, cb, args)	\
-({						\
-	int __rc = cb(args);			\
-						\
-	while ((timeout) != 0 && __rc == 0) {	\
-		sleep(1);			\
-		__rc = cb(args);		\
-		if ((timeout) < 0)		\
-			continue;		\
-		if ((timeout) < 1000000)	\
-			break;			\
-		(timeout) -= 1000000;		\
-	}					\
-	0;					\
+#define crt_context_progress(a, b)	({0;})
+#define crt_progress_cond(ctx, timeout, cb, args)	\
+({							\
+	int __rc = cb(args);				\
+							\
+	while ((timeout) != 0 && __rc == 0) {		\
+		sleep(1);				\
+		__rc = cb(args);			\
+		if ((timeout) < 0)			\
+			continue;			\
+		if ((timeout) < 1000000)		\
+			break;				\
+		(timeout) -= 1000000;			\
+	}						\
+	0;						\
 })
-
 #endif
 
 /*
@@ -585,7 +585,7 @@ daos_event_test(struct daos_event *ev, int64_t timeout, bool *flag)
 	}
 
 	/* pass the timeout to crt_progress() with a conditional callback */
-	rc = crt_progress(evx->evx_ctx, timeout, ev_progress_cb, &epa);
+	rc = crt_progress_cond(evx->evx_ctx, timeout, ev_progress_cb, &epa);
 
 	/** drop ref grabbed in daos_eq_lookup() */
 	if (epa.eqx)
@@ -722,7 +722,7 @@ daos_eq_poll(daos_handle_t eqh, int wait_running, int64_t timeout,
 	epa.count	= 0;
 
 	/* pass the timeout to crt_progress() with a conditional callback */
-	rc = crt_progress(epa.eqx->eqx_ctx, timeout, eq_progress_cb, &epa);
+	rc = crt_progress_cond(epa.eqx->eqx_ctx, timeout, eq_progress_cb, &epa);
 
 	/* drop ref grabbed in daos_eq_lookup() */
 	daos_eq_putref(epa.eqx);
@@ -1202,12 +1202,11 @@ daos_event_priv_wait()
 
 	/* Wait on the event to complete */
 	while (evx->evx_status != DAOS_EVS_READY) {
-		rc = crt_progress(evx->evx_ctx, DAOS_EQ_WAIT,
-				  ev_progress_cb, &epa);
+		rc = crt_progress_cond(evx->evx_ctx, 0, ev_progress_cb, &epa);
 		if (rc == 0)
 			rc = ev_thpriv.ev_error;
 
-		if (rc)
+		if (rc && rc != -DER_TIMEDOUT)
 			break;
 	}
 	return rc;

--- a/src/client/api/event.c
+++ b/src/client/api/event.c
@@ -45,7 +45,6 @@ static __thread bool		ev_thpriv_is_init;
 #define crt_finalize()			({0;})
 #define crt_context_create(a, b)	({0;})
 #define crt_context_destroy(a, b)	({0;})
-#define crt_context_progress(a, b)	({0;})
 #define crt_progress_cond(ctx, timeout, cb, args)	\
 ({							\
 	int __rc = cb(args);				\

--- a/src/client/api/rpc.c
+++ b/src/client/api/rpc.c
@@ -70,14 +70,6 @@ struct daos_rpc_status {
 	int status;
 };
 
-static int
-rpc_progress_cb(void *arg)
-{
-	struct daos_rpc_status *status = arg;
-
-	return status->completed;
-}
-
 static void
 daos_rpc_wait(crt_context_t *ctx, struct daos_rpc_status *status)
 {
@@ -85,10 +77,11 @@ daos_rpc_wait(crt_context_t *ctx, struct daos_rpc_status *status)
 	while (!status->completed) {
 		int rc = 0;
 
-		rc = crt_progress(ctx, DAOS_EQ_WAIT,
-				  rpc_progress_cb, status);
-		if (rc)
+		rc = crt_progress(ctx, 0);
+		if (rc && rc != -DER_TIMEDOUT) {
+			D_ERROR("failed to progress CART context: %d\n", rc);
 			break;
+		}
 	}
 }
 

--- a/src/client/api/task.c
+++ b/src/client/api/task.c
@@ -265,8 +265,8 @@ daos_progress(tse_sched_t *sched, int64_t timeout, bool *is_empty)
 	args.sched = sched;
 	args.is_empty = is_empty;
 
-	rc = crt_progress((crt_context_t *)sched->ds_udata, timeout,
-			  sched_progress_cb, &args);
+	rc = crt_progress_cond((crt_context_t *)sched->ds_udata, timeout,
+			       sched_progress_cb, &args);
 	if (rc != 0 && rc != -DER_TIMEDOUT)
 		D_ERROR("crt progress failed with "DF_RC"\n", DP_RC(rc));
 

--- a/src/iosrv/srv.c
+++ b/src/iosrv/srv.c
@@ -507,8 +507,7 @@ dss_srv_handler(void *arg)
 	/* main service progress loop */
 	for (;;) {
 		if (dx->dx_comm) {
-			rc = crt_progress(dmi->dmi_ctx, 0 /* no wait */, NULL,
-					  NULL);
+			rc = crt_progress(dmi->dmi_ctx, 0 /* no wait */);
 			if (rc != 0 && rc != -DER_TIMEDOUT) {
 				D_ERROR("failed to progress CART context: %d\n",
 					rc);

--- a/src/rdb/tests/rdbt.c
+++ b/src/rdb/tests/rdbt.c
@@ -99,7 +99,7 @@ invoke_rpc(crt_rpc_t *rpc)
 	D_ASSERTF(rc == 0, "%d\n", rc);
 	/* Sloppy... */
 	while (rpc_rc == rpc_rc_uninitialized)
-		crt_progress(context, 0, NULL, NULL);
+		crt_progress(context, 0);
 	return rpc_rc;
 }
 


### PR DESCRIPTION
First of all, this patch splits conditional and timeout-based
progress into two seperate calls with different semantic.
crt_progress() will return as soon some RPCs have been progressed.
If a non-zero timeout is passed, the call will wait for at most
timeout micro-seconds for something to progress.
On the other hand, conditional progress will block until the
callback (called on a regular basis internally) return a
non-zero value or if the timeout has expired.

Secondly, this patch changes how progress is driven over
mercury. Instead of passing an unlimited credits, the main
loop now calls HG_Progress() and HG_Trigger() multiple
times with a reduced credits. This showed substantial
performance improvements over infiniband.

Thirdly, crt_context_timeout_check() should be called after
(and not before as done currnetly) calling network progress
in case we have pending reply in the queue to process.

Finally, this patch introduced likely/unlikely macros
that can be used on the critical path to optimize
branching. A subsequant patch will be posted to use
those macros in many places.

Signed-off-by: Johann Lombardi <johann.lombardi@intel.com>