### PR TITLE
DAOS-4703 tests: remove extra tests in vos_test

### DIFF
--- a/src/vos/tests/vos_tests.c
+++ b/src/vos/tests/vos_tests.c
@@ -95,16 +95,27 @@ run_all_tests(int keys, bool nest_iterators)
 		sprintf(config_description+length, " bypass=%s", bypass);
 	else
 		sprintf(config_description+length, " bypass=none");
-	if (nest_iterators)
-		sprintf(cfg_desc_io,
-			"%s iterator=nested", config_description);
-	else
+
+	if (nest_iterators == false) {
+		failed += run_pm_tests(config_description);
+		failed += run_pool_test(config_description);
+		failed += run_co_test(config_description);
+		failed += run_discard_tests(config_description);
+		failed += run_aggregate_tests(false, config_description);
+		failed += run_gc_tests(config_description);
+		failed += run_dtx_tests(config_description);
+		failed += run_ilog_tests(config_description);
+		failed += run_csum_extent_tests(config_description);
+		failed += run_mvcc_tests(config_description);
+
 		sprintf(cfg_desc_io,
 			"%s iterator=standalone", config_description);
+	} else {
+		sprintf(cfg_desc_io,
+			"%s iterator=nested", config_description);
 
-	failed += run_pm_tests(config_description);
-	failed += run_pool_test(config_description);
-	failed += run_co_test(config_description);
+	}
+
 	for (i = 0; dkey_feats[i] >= 0; i++) {
 		for (j = 0; akey_feats[j] >= 0; j++) {
 			feats = dkey_feats[i] | akey_feats[j];
@@ -112,13 +123,7 @@ run_all_tests(int keys, bool nest_iterators)
 					      cfg_desc_io);
 		}
 	}
-	failed += run_discard_tests(config_description);
-	failed += run_aggregate_tests(false, config_description);
-	failed += run_gc_tests(config_description);
-	failed += run_dtx_tests(config_description);
-	failed += run_ilog_tests(config_description);
-	failed += run_csum_extent_tests(config_description);
-	failed += run_mvcc_tests(config_description);
+
 	return failed;
 }
 

--- a/src/vos/tests/vos_tests.c
+++ b/src/vos/tests/vos_tests.c
@@ -87,21 +87,20 @@ run_all_tests(int keys, bool nest_iterators)
 	int	j;
 	int	length = 0;
 	char	*bypass = getenv("DAOS_IO_BYPASS");
+	char	cfg_desc_io[50];
 
 	length += sprintf(config_description+length, "keys=%d", keys);
 
 	if (bypass)
-		length += sprintf(config_description+length,
-				  " bypass=%s", bypass);
+		sprintf(config_description+length, " bypass=%s", bypass);
 	else
-		length += sprintf(config_description+length,
-				  " bypass=none");
+		sprintf(config_description+length, " bypass=none");
 	if (nest_iterators)
-		length += sprintf(config_description+length,
-				  " iterator=nested");
+		sprintf(cfg_desc_io,
+			"%s iterator=nested", config_description);
 	else
-		length += sprintf(config_description+length,
-				  " iterator=standalone");
+		sprintf(cfg_desc_io,
+			"%s iterator=standalone", config_description);
 
 	failed += run_pm_tests(config_description);
 	failed += run_pool_test(config_description);
@@ -110,7 +109,7 @@ run_all_tests(int keys, bool nest_iterators)
 		for (j = 0; akey_feats[j] >= 0; j++) {
 			feats = dkey_feats[i] | akey_feats[j];
 			failed += run_io_test(feats, keys, nest_iterators,
-					      config_description);
+					      cfg_desc_io);
 		}
 	}
 	failed += run_discard_tests(config_description);


### PR DESCRIPTION
vos_test generates repeated tests results because not all tests
uses the nest_iteration variable. This commit removes the nest
iterator description from the tests that don't use it.

Signed-off-by: Marcela Rosales <marcela.a.rosales.jimenez@intel.com>