### PR TITLE
CART-886 group: Use atomic operations for refcount

### DIFF
--- a/src/cart/src/cart/crt_ctl.c
+++ b/src/cart/src/cart/crt_ctl.c
@@ -79,11 +79,11 @@ out:
 static int
 crt_ctl_fill_buffer_cb(d_list_t *rlink, void *arg)
 {
-	struct crt_uri_item	*ui;
-	int			*idx;
-	struct crt_uri_cache	*uri_cache = arg;
 	crt_phy_addr_t		 uri;
-	int			 i;
+	struct crt_uri_cache	*uri_cache = arg;
+	struct crt_uri_item	*ui;
+	uint32_t		*idx;
+	uint32_t		 i;
 	int			 rc = 0;
 
 	D_ASSERT(rlink != NULL);
@@ -97,7 +97,7 @@ crt_ctl_fill_buffer_cb(d_list_t *rlink, void *arg)
 			continue;
 
 		if (*idx >= uri_cache->max_count) {
-			D_ERROR("grp_cache index %d out of range [0, %zu].\n",
+			D_ERROR("grp_cache index %u out of range [0, %u].\n",
 				*idx, uri_cache->max_count);
 			D_GOTO(out, rc = -DER_OVERFLOW);
 		}
@@ -116,9 +116,9 @@ out:
 void
 crt_hdlr_ctl_get_uri_cache(crt_rpc_t *rpc_req)
 {
+	struct crt_uri_cache			 uri_cache = {0};
 	struct crt_ctl_get_uri_cache_out	*out_args;
 	struct crt_grp_priv			*grp_priv = NULL;
-	struct crt_uri_cache			 uri_cache = {0};
 	int					 rc = 0;
 
 	D_ASSERTF(crt_is_service(), "Must be called in a service process\n");

--- a/src/cart/src/cart/crt_ctl.h
+++ b/src/cart/src/cart/crt_ctl.h
@@ -45,8 +45,8 @@
 /* crt uri lookup cache info */
 struct crt_uri_cache {
 	struct crt_grp_cache	*grp_cache;
-	size_t			 max_count;
-	int			 idx;
+	uint32_t		 max_count;
+	uint32_t		 idx;
 };
 
 void crt_hdlr_ctl_get_uri_cache(crt_rpc_t *rpc_req);

--- a/src/cart/src/cart/crt_ctl.h
+++ b/src/cart/src/cart/crt_ctl.h
@@ -45,6 +45,7 @@
 /* crt uri lookup cache info */
 struct crt_uri_cache {
 	struct crt_grp_cache	*grp_cache;
+	size_t			 max_count;
 	int			 idx;
 };
 

--- a/src/cart/src/cart/crt_group.c
+++ b/src/cart/src/cart/crt_group.c
@@ -112,24 +112,16 @@ li_op_rec_addref(struct d_hash_table *hhtab, d_list_t *rlink)
 	struct crt_lookup_item *li = crt_li_link2ptr(rlink);
 
 	D_ASSERT(li->li_initialized);
-	D_MUTEX_LOCK(&li->li_mutex);
-	li->li_ref++;
-	D_MUTEX_UNLOCK(&li->li_mutex);
+	atomic_fetch_add(&li->li_ref, 1);
 }
 
 static bool
 li_op_rec_decref(struct d_hash_table *hhtab, d_list_t *rlink)
 {
-	uint32_t			 ref;
-	struct crt_lookup_item		*li = crt_li_link2ptr(rlink);
+	struct crt_lookup_item *li = crt_li_link2ptr(rlink);
 
 	D_ASSERT(li->li_initialized);
-	D_MUTEX_LOCK(&li->li_mutex);
-	li->li_ref--;
-	ref = li->li_ref;
-	D_MUTEX_UNLOCK(&li->li_mutex);
-
-	return ref == 0;
+	return atomic_fetch_sub(&li->li_ref, 1) == 1;
 }
 
 static void
@@ -189,23 +181,16 @@ rm_op_rec_addref(struct d_hash_table *hhtab, d_list_t *rlink)
 	struct crt_rank_mapping *rm = crt_rm_link2ptr(rlink);
 
 	D_ASSERT(rm->rm_initialized);
-	D_MUTEX_LOCK(&rm->rm_mutex);
-	rm->rm_ref++;
-	D_MUTEX_UNLOCK(&rm->rm_mutex);
+	atomic_fetch_add(&rm->rm_ref, 1);
 }
 
 static bool
 rm_op_rec_decref(struct d_hash_table *hhtab, d_list_t *rlink)
 {
-	uint32_t		ref;
-	struct crt_rank_mapping	*rm = crt_rm_link2ptr(rlink);
+	struct crt_rank_mapping *rm = crt_rm_link2ptr(rlink);
 
 	D_ASSERT(rm->rm_initialized);
-	D_MUTEX_LOCK(&rm->rm_mutex);
-	ref = --rm->rm_ref;
-	D_MUTEX_UNLOCK(&rm->rm_mutex);
-
-	return ref == 0;
+	return atomic_fetch_sub(&rm->rm_ref, 1) == 1;
 }
 
 static void
@@ -215,7 +200,6 @@ crt_rm_destroy(struct crt_rank_mapping *rm)
 	D_ASSERT(rm->rm_ref == 0);
 	D_ASSERT(rm->rm_initialized == 1);
 
-	D_MUTEX_DESTROY(&rm->rm_mutex);
 	D_FREE(rm);
 }
 
@@ -267,25 +251,16 @@ ui_op_rec_addref(struct d_hash_table *hhtab, d_list_t *rlink)
 	struct crt_uri_item *ui = crt_ui_link2ptr(rlink);
 
 	D_ASSERT(ui->ui_initialized);
-	D_MUTEX_LOCK(&ui->ui_mutex);
-	ui->ui_ref++;
-	D_MUTEX_UNLOCK(&ui->ui_mutex);
+	atomic_fetch_add(&ui->ui_ref, 1);
 }
 
 static bool
 ui_op_rec_decref(struct d_hash_table *hhtab, d_list_t *rlink)
 {
-	uint32_t		ref;
-	struct crt_uri_item	*ui = crt_ui_link2ptr(rlink);
+	struct crt_uri_item *ui = crt_ui_link2ptr(rlink);
 
 	D_ASSERT(ui->ui_initialized);
-	D_MUTEX_LOCK(&ui->ui_mutex);
-	ui->ui_ref--;
-	ref = ui->ui_ref;
-
-	D_MUTEX_UNLOCK(&ui->ui_mutex);
-
-	return ref == 0;
+	return atomic_fetch_sub(&ui->ui_ref, 1) == 1;
 }
 
 static void
@@ -302,7 +277,6 @@ crt_ui_destroy(struct crt_uri_item *ui)
 			D_FREE(ui->ui_uri[i]);
 	}
 
-	D_MUTEX_DESTROY(&ui->ui_mutex);
 	D_FREE_PTR(ui);
 }
 
@@ -332,7 +306,7 @@ grp_li_uri_get(struct crt_lookup_item *li, int tag)
 	ui = crt_ui_link2ptr(rlink);
 	d_hash_rec_decref(&grp_priv->gp_uri_lookup_cache, rlink);
 
-	return ui->ui_uri[tag];
+	return atomic_load_consume(&ui->ui_uri[tag]);
 }
 
 static inline int
@@ -341,6 +315,8 @@ grp_li_uri_set(struct crt_lookup_item *li, int tag, const char *uri)
 	struct crt_uri_item	*ui;
 	d_list_t		*rlink;
 	struct crt_grp_priv	*grp_priv;
+	crt_phy_addr_t		nul_str = NULL;
+	crt_phy_addr_t		uri_dup;
 	d_rank_t		rank;
 	int			rc = 0;
 
@@ -351,21 +327,18 @@ grp_li_uri_set(struct crt_lookup_item *li, int tag, const char *uri)
 				(void *)&rank, sizeof(rank));
 	if (rlink == NULL) {
 		D_ALLOC_PTR(ui);
-		if (!ui) {
+		if (!ui)
 			D_GOTO(exit, rc = -DER_NOMEM);
-		}
 
 		D_INIT_LIST_HEAD(&ui->ui_link);
 		ui->ui_ref = 0;
 		ui->ui_initialized = 1;
-
-		rc = D_MUTEX_INIT(&ui->ui_mutex, NULL);
-		if (rc != 0) {
-			D_FREE_PTR(ui);
-			D_GOTO(exit, rc);
-		}
-
 		ui->ui_rank = li->li_rank;
+		D_STRNDUP(ui->ui_uri[tag], uri, CRT_ADDR_STR_MAX_LEN);
+		if (!ui->ui_uri[tag]) {
+			D_FREE_PTR(ui);
+			D_GOTO(exit, rc = -DER_NOMEM);
+		}
 
 		rc = d_hash_rec_insert(&grp_priv->gp_uri_lookup_cache,
 				&rank, sizeof(rank),
@@ -373,25 +346,21 @@ grp_li_uri_set(struct crt_lookup_item *li, int tag, const char *uri)
 				true /* exclusive */);
 		if (rc != 0) {
 			D_ERROR("Entry already present\n");
-			D_MUTEX_DESTROY(&ui->ui_mutex);
+			D_FREE(ui->ui_uri[tag]);
 			D_FREE_PTR(ui);
 			D_GOTO(exit, rc);
 		}
-		D_STRNDUP(ui->ui_uri[tag], uri, CRT_ADDR_STR_MAX_LEN);
-
-		if (!ui->ui_uri[tag]) {
-			d_hash_rec_delete(&grp_priv->gp_uri_lookup_cache,
-					&rank, sizeof(d_rank_t));
-			D_GOTO(exit, rc = -DER_NOMEM);
-		}
 	} else {
 		ui = crt_ui_link2ptr(rlink);
-		if (!ui->ui_uri[tag]) {
-			D_STRNDUP(ui->ui_uri[tag], uri, CRT_ADDR_STR_MAX_LEN);
-		}
-
-		if (!ui->ui_uri[tag]) {
-			rc = -DER_NOMEM;
+		if (ui->ui_uri[tag] == NULL) {
+			D_STRNDUP(uri_dup, uri, CRT_ADDR_STR_MAX_LEN);
+			if (uri_dup) {
+				if (!atomic_compare_exchange(&ui->ui_uri[tag],
+							     nul_str, uri_dup))
+					D_FREE(uri_dup);
+			} else {
+				rc = -DER_NOMEM;
+			}
 		}
 
 		d_hash_rec_decref(&grp_priv->gp_uri_lookup_cache, rlink);
@@ -3132,7 +3101,6 @@ static struct crt_rank_mapping *
 crt_rank_mapping_init(d_rank_t key, d_rank_t value)
 {
 	struct crt_rank_mapping *rm;
-	int			rc;
 
 	D_ALLOC_PTR(rm);
 	if (!rm) {
@@ -3141,17 +3109,10 @@ crt_rank_mapping_init(d_rank_t key, d_rank_t value)
 	}
 
 	D_INIT_LIST_HEAD(&rm->rm_link);
-	rm->rm_ref = 0;
-	rm->rm_initialized = 1;
-
-	rc = D_MUTEX_INIT(&rm->rm_mutex, NULL);
-	if (rc != 0) {
-		D_FREE_PTR(rm);
-		D_GOTO(out, rm = NULL);
-	}
-
 	rm->rm_key = key;
 	rm->rm_value = value;
+	rm->rm_ref = 0;
+	rm->rm_initialized = 1;
 
 out:
 	return rm;

--- a/src/cart/src/cart/crt_group.h
+++ b/src/cart/src/cart/crt_group.h
@@ -42,6 +42,7 @@
 #ifndef __CRT_GROUP_H__
 #define __CRT_GROUP_H__
 
+#include <gurt/atomic.h>
 #include "crt_swim.h"
 
 
@@ -218,10 +219,8 @@ struct crt_rank_mapping {
 	d_rank_t	rm_key;
 	d_rank_t	rm_value;
 
-	uint32_t	rm_ref;
-	uint32_t	rm_initialized;
-
-	pthread_mutex_t	rm_mutex;
+	ATOMIC uint32_t	rm_ref;
+	uint32_t	rm_initialized:1;
 };
 
 /* uri info for each remote rank */
@@ -231,7 +230,7 @@ struct crt_uri_item {
 
 	/* URI string for each remote tag */
 	/* TODO: in phase2 change this to hash table */
-	crt_phy_addr_t	ui_uri[CRT_SRV_CONTEXT_NUM];
+	ATOMIC crt_phy_addr_t ui_uri[CRT_SRV_CONTEXT_NUM];
 
 	/* Primary rank; for secondary groups only  */
 	d_rank_t	ui_pri_rank;
@@ -240,13 +239,10 @@ struct crt_uri_item {
 	d_rank_t	ui_rank;
 
 	/* reference count */
-	uint32_t	ui_ref;
+	ATOMIC uint32_t	ui_ref;
 
 	/* flag indicating whether initialized */
-	uint32_t	ui_initialized;
-
-	/* mutex for protection of ui_ref */
-	pthread_mutex_t ui_mutex;
+	uint32_t	ui_initialized:1;
 };
 
 /* lookup cache item for one target */
@@ -261,7 +257,7 @@ struct crt_lookup_item {
 	hg_addr_t		 li_tag_addr[CRT_SRV_CONTEXT_NUM];
 
 	/* reference count */
-	uint32_t		 li_ref;
+	ATOMIC uint32_t		 li_ref;
 	uint32_t		 li_initialized:1;
 	pthread_mutex_t		 li_mutex;
 };

--- a/src/cart/src/include/gurt/atomic.h
+++ b/src/cart/src/include/gurt/atomic.h
@@ -63,6 +63,9 @@
 #define atomic_load_consume(ptr) \
 	atomic_load_explicit(ptr, memory_order_consume)
 
+#define atomic_load_relaxed(ptr) \
+	atomic_load_explicit(ptr, memory_order_relaxed)
+
 #define atomic_dec_release(ptr) \
 	atomic_fetch_sub_explicit(ptr, 1, memory_order_release)
 
@@ -83,6 +86,7 @@
  * required.
  */
 #define atomic_load_consume(ptr) atomic_fetch_add(ptr, 0)
+#define atomic_load_relaxed(ptr) atomic_fetch_add(ptr, 0)
 #define atomic_dec_release(ptr) __sync_fetch_and_sub(ptr, 1)
 #define ATOMIC
 


### PR DESCRIPTION
Avoid mutexes usage for simple atomic operations like
reference counting.