### PR TITLE
DAOS-4567 control: Retry on certain pool create errors

### DIFF
--- a/src/control/server/mgmt_svc.go
+++ b/src/control/server/mgmt_svc.go
@@ -313,6 +313,13 @@ func checkIsMSReplica(mi *IOServerInstance) error {
 	return nil
 }
 
+const (
+	// poolCreateRetryDelay defines the amount of time between pool create retries.
+	// In the management service, the system map distribution code has a 3s backoff
+	// for distribution errors.
+	poolCreateRetryDelay = 1500 * time.Millisecond
+)
+
 // PoolCreate implements the method defined for the Management Service.
 //
 // Validate minimum SCM/NVMe pool size per VOS target, pool size request params
@@ -341,19 +348,43 @@ func (svc *mgmtSvc) PoolCreate(ctx context.Context, req *mgmtpb.PoolCreateReq) (
 		return nil, FaultPoolNvmeTooSmall(req.Nvmebytes, targetCount)
 	}
 
-	dresp, err := mi.CallDrpc(drpc.ModuleMgmt, drpc.MethodPoolCreate, req)
-	if err != nil {
-		return nil, err
+	try := 0
+	for {
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		default:
+		}
+
+		dresp, err := mi.CallDrpc(drpc.ModuleMgmt, drpc.MethodPoolCreate, req)
+		if err != nil {
+			return nil, err
+		}
+
+		resp := &mgmtpb.PoolCreateResp{}
+		if err = proto.Unmarshal(dresp.Body, resp); err != nil {
+			return nil, errors.Wrap(err, "unmarshal PoolCreate response")
+		}
+
+		svc.log.Debugf("MgmtSvc.PoolCreate dispatch, try %d, resp:%+v\n", try, *resp)
+
+		ds := drpc.DaosStatus(resp.GetStatus())
+		switch ds {
+		// retryable errors
+		case drpc.DaosGroupVersionMismatch:
+			svc.log.Infof("MgmtSvc.PoolCreate (try %d), retrying due to %s", try, ds)
+			try++
+			select {
+			case <-ctx.Done():
+				return nil, ctx.Err()
+			case <-time.After(poolCreateRetryDelay):
+				continue
+			}
+		default:
+			return resp, nil
+		}
+
 	}
-
-	resp := &mgmtpb.PoolCreateResp{}
-	if err = proto.Unmarshal(dresp.Body, resp); err != nil {
-		return nil, errors.Wrap(err, "unmarshal PoolCreate response")
-	}
-
-	svc.log.Debugf("MgmtSvc.PoolCreate dispatch, resp:%+v\n", *resp)
-
-	return resp, nil
 }
 
 // PoolDestroy implements the method defined for the Management Service.


### PR DESCRIPTION
In particular, when the create results in a DER_GRPVER,
we can assume that it's safe to retry the create in order
to deal with a race between the create and the pool map
distribution.

The create will be retried with a delay until the context
is canceled (cancelation criteria defined by the RPC invoker).