### PR TITLE
DAOS-4295 dfuse: Check container and pool uuids better at start. (#2174)

### DIFF
--- a/src/client/dfuse/dfuse_main.c
+++ b/src/client/dfuse/dfuse_main.c
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2016-2019 Intel Corporation.
+ * (C) Copyright 2016-2020 Intel Corporation.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -125,6 +125,7 @@ main(int argc, char **argv)
 	struct dfuse_pool	*dfpn;
 	struct dfuse_dfs	*dfs = NULL;
 	struct dfuse_dfs	*dfsn;
+	uuid_t			tmp_uuid;
 	char			c;
 	int			ret = -DER_SUCCESS;
 	int			rc;
@@ -225,6 +226,20 @@ main(int argc, char **argv)
 		printf("Svcl is required\n");
 		show_help(argv[0]);
 		exit(1);
+	}
+
+	if (dfuse_info->di_pool) {
+		if (uuid_parse(dfuse_info->di_pool, tmp_uuid) < 0) {
+			printf("Invalid pool uuid\n");
+			exit(1);
+		}
+
+		if (dfuse_info->di_cont) {
+			if (uuid_parse(dfuse_info->di_cont, tmp_uuid) < 0) {
+				printf("Invalid container uuid");
+				exit(1);
+			}
+		}
 	}
 
 	if (!dfuse_info->di_foreground) {


### PR DESCRIPTION
dfuse has to go into the background before calling daos_init() for
daos to work properly, so there are lots of failure modes at start
that cannot be returned properly to the user.  Checking that uuids
passed for pools and containers however, can be checked so they
should be, as that allows us to give higher quality feedback
when they are incorrect.

Signed-off-by: Ashley Pittman <ashley.m.pittman@intel.com>