### PR TITLE
DAOS-4666 test: Adjust skipForTicket tag for resolved tickets and failing tests

### DIFF
--- a/src/tests/ftest/pool/destroy_rebuild.py
+++ b/src/tests/ftest/pool/destroy_rebuild.py
@@ -34,7 +34,6 @@ class DestroyRebuild(TestWithServers):
     :avocado: recursive
     """
 
-    @skipForTicket("DAOS-2723")
     def test_destroy_while_rebuilding(self):
         """Jira ID: DAOS-xxxx.
 

--- a/src/tests/ftest/pool/destroy_tests.py
+++ b/src/tests/ftest/pool/destroy_tests.py
@@ -208,7 +208,6 @@ class DestroyTests(TestWithServers):
                 hostlist_servers,
                 "with multiple servers - pass {}".format(counter))
 
-    @skipForTicket("DAOS-2739")
     def test_destroy_invalid_uuid(self):
         """Test destroying a pool uuid that doesn't exist.
 

--- a/src/tests/ftest/pool/rebuild_tests.py
+++ b/src/tests/ftest/pool/rebuild_tests.py
@@ -21,7 +21,7 @@
   Any reproduction of computer software, computer software documentation, or
   portions thereof marked with this legend must also reproduce the markings.
 """
-from apricot import TestWithServers, skipForTicket
+from apricot import TestWithServers
 from test_utils_pool import TestPool
 from test_utils_container import TestContainer
 
@@ -130,7 +130,6 @@ class RebuildTests(TestWithServers):
                 "Data verifiaction error after rebuild")
         self.log.info("Test Passed")
 
-    @skipForTicket("DAOS-2922")
     def test_simple_rebuild(self):
         """JIRA ID: DAOS-XXXX Rebuild-001.
 
@@ -144,7 +143,6 @@ class RebuildTests(TestWithServers):
         """
         self.run_rebuild_test(1)
 
-    @skipForTicket("DAOS-2922")
     def test_multipool_rebuild(self):
         """JIRA ID: DAOS-XXXX (Rebuild-002).
 

--- a/src/tests/ftest/pool/rebuild_with_io.py
+++ b/src/tests/ftest/pool/rebuild_with_io.py
@@ -21,7 +21,7 @@
   Any reproduction of computer software, computer software documentation, or
   portions thereof marked with this legend must also reproduce the markings.
 """
-from apricot import TestWithServers, skipForTicket
+from apricot import TestWithServers
 from test_utils_pool import TestPool
 from test_utils_container import TestContainer
 
@@ -36,7 +36,6 @@ class RebuildWithIO(TestWithServers):
     :avocado: recursive
     """
 
-    @skipForTicket("DAOS-2922")
     def test_rebuild_with_io(self):
         """JIRA ID: Rebuild-003.
 

--- a/src/tests/ftest/pool/rebuild_with_ior.py
+++ b/src/tests/ftest/pool/rebuild_with_ior.py
@@ -23,7 +23,6 @@
 """
 from __future__ import print_function
 
-from apricot import skipForTicket
 from ior_test_base import IorTestBase
 
 
@@ -37,7 +36,6 @@ class RebuildWithIOR(IorTestBase):
     :avocado: recursive
     """
 
-    @skipForTicket("DAOS-2773")
     def test_rebuild_with_ior(self):
         """Jira ID: DAOS-951.
 

--- a/src/tests/ftest/rebuild/cascading_failures.py
+++ b/src/tests/ftest/rebuild/cascading_failures.py
@@ -110,7 +110,6 @@ class CascadingFailures(RebuildTestBase):
         self.mode = "simultaneous"
         self.execute_rebuild_test()
 
-    @skipForTicket("DAOS-2469")
     def test_sequential_failures(self):
         """Jira ID: DAOS-843.
 
@@ -131,7 +130,6 @@ class CascadingFailures(RebuildTestBase):
         self.mode = "sequential"
         self.execute_rebuild_test()
 
-    @skipForTicket("DAOS-3172")
     def test_cascading_failures(self):
         """Jira ID: DAOS-844.
 

--- a/src/tests/ftest/rebuild/read_array.py
+++ b/src/tests/ftest/rebuild/read_array.py
@@ -21,7 +21,6 @@
   Any reproduction of computer software, computer software documentation, or
   portions thereof marked with this legend must also reproduce the markings.
 """
-from apricot import skipForTicket
 from rebuild_test_base import RebuildTestBase
 
 
@@ -40,7 +39,6 @@ class ReadArrayTest(RebuildTestBase):
             self.pool.read_data_during_rebuild(self.container),
             "Error reading data during rebuild")
 
-    @skipForTicket("DAOS-2676")
     def test_read_array_during_rebuild(self):
         """Jira ID: DAOS-691.
 

--- a/src/tests/ftest/server/metadata.py
+++ b/src/tests/ftest/server/metadata.py
@@ -35,7 +35,7 @@ except ImportError:
     # python 2.7
     import Queue as queue
 
-from apricot import TestWithServers, skipForTicket
+from apricot import TestWithServers
 from pydaos.raw import DaosContainer, DaosApiError
 from ior_utils import IorCommand
 from command_utils import CommandFailure
@@ -119,7 +119,6 @@ class ObjectMetadata(TestWithServers):
         self.d_log.debug("IOR {0} Threads Finished -----".format(operation))
         return "PASS"
 
-    @skipForTicket("DAOS-1936/DAOS-1946")
     def test_metadata_fillup(self):
         """JIRA ID: DAOS-1512.
 


### PR DESCRIPTION
Test-tag: rebuildsimple rebuildmulti rebuildwithio
Test-tag: destroyinvaliduuid destroypoolrebuild
Test-tag: rebuildwithior sequential cascading rebuildreadarray
Test-tag-hw-large: pr,hw,large,metadatafill

  - Removed the skipForTicket for the following resolved tickets
  - DAOS-2922
  - DAOS-2739
  - DAOS-2723
  - DAOS-2773
  - DAOS-2469
  - DAOS-3172
  - DAOS-2676
  - DAOS-1936
  - DAOS-1763

Signed-off-by: Logan Sundaram <logan.sundaram@intel.com>