### PR TITLE
DAOS-3945 tests: DaosCoreTest Failed to stop servers

### DIFF
--- a/src/tests/ftest/util/command_utils.py
+++ b/src/tests/ftest/util/command_utils.py
@@ -427,7 +427,8 @@ class ExecutableCommand(CommandWithParameters):
                     self._process.send_signal(signal_type)
                 if signal_list:
                     time.sleep(1)
-            if not signal_list:
+            # Do not consider a lingering orterun process to be a test error.
+            if not signal_list and self._command != "orterun":
                 # Indicate an error if the process required a SIGKILL
                 raise CommandFailure("Error stopping '{}'".format(self))
             self._process = None


### PR DESCRIPTION
Disabling the reporting of stopping an orterun process as test error in
tearDown().  The orterun process has been shown to pass the signals
through to the daos_server processes resulting in no daos_server or
daos_io_server processes running on the remote hosts.  At times the
stopping of the orterun process holds up the completion of the sub
process, which yields a test error.  Since the DAOS processes have been
terminated this is situation is not a test error.

Signed-off-by: Phillip Henderson <phillip.henderson@intel.com>