### PR TITLE
DAOS-4724 iosrv: ignore membind failure and restore main thread name

### DIFF
--- a/src/iosrv/init.c
+++ b/src/iosrv/init.c
@@ -905,8 +905,6 @@ main(int argc, char **argv)
 	if (rc)
 		exit(EXIT_FAILURE);
 
-	(void)pthread_setname_np(pthread_self(), "daos_main");
-
 	/** block all possible signals but faults */
 	sigfillset(&set);
 	sigdelset(&set, SIGILL);

--- a/src/iosrv/srv.c
+++ b/src/iosrv/srv.c
@@ -382,19 +382,23 @@ dss_srv_handler(void *arg)
 	int				 rc;
 	bool				 signal_caller = true;
 
-	/** set affinity */
+	/**
+	 * Set cpu affinity
+	 */
 	rc = hwloc_set_cpubind(dss_topo, dx->dx_cpuset, HWLOC_CPUBIND_THREAD);
 	if (rc) {
 		D_ERROR("failed to set cpu affinity: %d\n", errno);
 		goto signal;
 	}
 
+	/**
+	 * Set memory affinity, but fail silently if it does not work since some
+	 * systems return ENOSYS.
+	 */
 	rc = hwloc_set_membind(dss_topo, dx->dx_cpuset, HWLOC_MEMBIND_BIND,
 			       HWLOC_MEMBIND_THREAD);
-	if (rc) {
-		D_ERROR("failed to set memory affinity: %d\n", errno);
-		goto signal;
-	}
+	if (rc)
+		D_DEBUG(DB_TRACE, "failed to set memory affinity: %d\n", errno);
 
 	/* initialize xstream-local storage */
 	dtc = dss_tls_init(DAOS_SERVER_TAG);


### PR DESCRIPTION
As reported on the mailing list, some systems still do not support
membind, so let's note make this error fatal.
Additionally, setting a pthread name on the main thread causes the
name in top to be changed as well. Restore the original behavior.

Signed-off-by: Johann Lombardi <johann.lombardi@intel.com>