### PR TITLE
DAOS-4285 test: Fix issues with dfuse setup in testing (#2205)

### DIFF
--- a/src/client/dfs/dfs.c
+++ b/src/client/dfs/dfs.c
@@ -1133,6 +1133,7 @@ dfs_mount(daos_handle_t poh, daos_handle_t coh, int flags, dfs_t **_dfs)
 
 	entry = daos_prop_entry_get(prop, DAOS_PROP_CO_LAYOUT_TYPE);
 	if (entry == NULL || entry->dpe_val != DAOS_PROP_CO_LAYOUT_POSIX) {
+		D_ERROR("container is not of type POSIX\n");
 		daos_prop_free(prop);
 		return EINVAL;
 	}

--- a/src/client/pydaos/raw/daos_api.py
+++ b/src/client/pydaos/raw/daos_api.py
@@ -1371,7 +1371,6 @@ class DaosContProperties(ctypes.Structure):
         self.chksum_type = ctypes.c_uint64(100)
         self.chunk_size = ctypes.c_uint64(0)
 
-
 class DaosInputParams(object):
     # pylint: disable=too-few-public-methods
     """ This is a helper python method
@@ -1396,7 +1395,6 @@ class DaosInputParams(object):
         create container method.
         """
         return self.co_prop
-
 
 class DaosContainer(object):
     """A python object representing a DAOS container."""
@@ -1468,13 +1466,14 @@ class DaosContainer(object):
         if self.cont_input_values.type != "Unknown":
             self.cont_prop.dpp_entries[idx].dpe_type = ctypes.c_uint32(
                 DaosContPropEnum.DAOS_PROP_CO_LAYOUT_TYPE.value)
-            if self.cont_input_values.type == "posix":
+            if self.cont_input_values.type in ("posix", "POSIX"):
                 self.cont_prop.dpp_entries[idx].dpe_val = ctypes.c_uint64(
                     DaosContPropEnum.DAOS_PROP_CO_LAYOUT_POSIX.value)
             elif self.cont_input_values.type == "hdf5":
                 self.cont_prop.dpp_entries[idx].dpe_val = ctypes.c_uint64(
                     DaosContPropEnum.DAOS_PROP_CO_LAYOUT_HDF5.value)
             else:
+                # TODO: This should ideally fail.
                 self.cont_prop.dpp_entries[idx].dpe_val = ctypes.c_uint64(
                     DaosContPropEnum.DAOS_PROP_CO_LAYOUT_UNKOWN.value)
             idx = idx + 1

--- a/src/tests/ftest/util/fio_test_base.py
+++ b/src/tests/ftest/util/fio_test_base.py
@@ -71,7 +71,8 @@ class FioBase(TestWithServers):
     def tearDown(self):
         """Tear down each test case."""
         try:
-            self.dfuse = None
+            if self.dfuse:
+                self.dfuse.stop()
         finally:
             # Stop the servers and agents
             super(FioBase, self).tearDown()
@@ -153,3 +154,7 @@ class FioBase(TestWithServers):
         # Run Fio
         self.fio_cmd.hosts = self.hostlist_clients
         self.fio_cmd.run()
+
+        if self.dfuse:
+            self.dfuse.stop()
+            self.dfuse = None

--- a/src/tests/ftest/util/ior_test_base.py
+++ b/src/tests/ftest/util/ior_test_base.py
@@ -81,7 +81,8 @@ class IorTestBase(TestWithServers):
     def tearDown(self):
         """Tear down each test case."""
         try:
-            self.dfuse = None
+            if self.dfuse:
+                self.dfuse.stop()
         finally:
             # Stop the servers and agents
             super(IorTestBase, self).tearDown()
@@ -105,7 +106,7 @@ class IorTestBase(TestWithServers):
         # create container
         self.container.create(con_in=self.co_prop)
 
-    def start_dfuse(self):
+    def _start_dfuse(self):
         """Create a DfuseCommand object to start dfuse."""
         # Get Dfuse params
         self.dfuse = Dfuse(self.hostlist_clients, self.tmp,
@@ -146,7 +147,7 @@ class IorTestBase(TestWithServers):
             # Uncomment below two lines once DAOS-3355 is resolved
             if self.ior_cmd.transfer_size.value == "256B":
                 return "Skipping the case for transfer_size=256B"
-            self.start_dfuse()
+            self._start_dfuse()
             testfile = os.path.join(self.dfuse.mount_dir.value,
                                     "testfile{}".format(test_file_suffix))
 
@@ -155,6 +156,9 @@ class IorTestBase(TestWithServers):
         out = self.run_ior(self.get_job_manager_command(), self.processes,
                            intercept)
 
+        if self.dfuse:
+            self.dfuse.stop()
+            self.dfuse = None
         return out
 
     def update_ior_cmd_with_pool(self):
@@ -226,7 +230,7 @@ class IorTestBase(TestWithServers):
 
         # start dfuse for POSIX api. This is specific to interception
         # library test requirements.
-        self.start_dfuse()
+        self._start_dfuse()
 
         # Create two jobs and run in parallel.
         # Job1 will have 3 client set up to use dfuse + interception
@@ -245,6 +249,8 @@ class IorTestBase(TestWithServers):
         job2.start()
         job1.join()
         job2.join()
+        self.dfuse.stop()
+        self.dfuse = None
 
     def get_new_job(self, clients, job_num, results, intercept=None):
         """Create a new thread for ior run

--- a/src/tests/ftest/util/mdtest_test_base.py
+++ b/src/tests/ftest/util/mdtest_test_base.py
@@ -84,7 +84,8 @@ class MdtestBase(TestWithServers):
     def tearDown(self):
         """Tear down each test case."""
         try:
-            self.dfuse = None
+            if self.dfuse:
+                self.dfuse.stop()
         finally:
             # Stop the servers and agents
             super(MdtestBase, self).tearDown()
@@ -126,6 +127,7 @@ class MdtestBase(TestWithServers):
     def _start_dfuse(self):
         """Create a DfuseCommand object to start dfuse."""
         # Get Dfuse params
+
         self.dfuse = Dfuse(self.hostlist_clients,
                            self.tmp,
                            log_file=get_log_file(self.client_log),
@@ -141,10 +143,9 @@ class MdtestBase(TestWithServers):
             self.dfuse.run()
         except CommandFailure as error:
             self.log.error("Dfuse command %s failed on hosts %s",
-                           str(self.dfuse), str(NodeSet(self.dfuse.hosts)),
+                           str(self.dfuse), self.dfuse.hosts,
                            exc_info=error)
             self.fail("Unable to launch Dfuse.\n")
-
 
     def execute_mdtest(self):
         """Runner method for Mdtest."""
@@ -167,6 +168,9 @@ class MdtestBase(TestWithServers):
        # Run Mdtest
         self.run_mdtest(self.get_job_manager_command(self.manager),
                         self.processes)
+        if self.dfuse:
+            self.dfuse.stop()
+            self.dfuse = None
 
     def get_job_manager_command(self, manager):
         """Get the MPI job manager command for Mdtest.

--- a/src/tests/ftest/util/test_utils_container.py
+++ b/src/tests/ftest/util/test_utils_container.py
@@ -308,12 +308,14 @@ class TestContainer(TestDaosApiBase):
             kwargs["con_uuid"] = uuid
         # Refer daos_api for setting input params for DaosContainer.
         if con_in is not None:
-            self.input_params.type = con_in[0]
-            self.input_params.enable_chksum = con_in[1]
-            self.input_params.srv_verify = con_in[2]
-            self.input_params.chksum_type = con_in[3]
-            self.input_params.chunk_size = con_in[4]
-            kwargs["con_prop"] = self.input_params
+            cop = self.input_params.get_con_create_params()
+            cop.type = con_in[0]
+            cop.enable_chksum = con_in[1]
+            cop.srv_verify = con_in[2]
+            cop.chksum_type = con_in[3]
+            cop.chunk_size = con_in[4]
+            kwargs["con_prop"] = cop
+
         self._call_method(self.container.create, kwargs)
         self.uuid = self.container.get_uuid_str()
         self.log.info("  Container created with uuid %s", self.uuid)


### PR DESCRIPTION
Overhaul dfuse_utils.py:
Check dfuse has started after launch, waiting up to five seconds as required
Only attempt to stop on nodes where dfuse was launched
Check dfuse is running before shutdown
Do not use del handler in object, as this doesn't allow exceptions to propagate into test failures.
Log invalid container types in dfs_mount()
Support 'POSIX' and 'posix' container types in pydaos.raw
Fix bug in test_utils_container where it was setting values in DaosInputParams, not DaosContParams

Signed-off-by: Ashley Pittman <ashley.m.pittman@intel.com>
Co-authored-by: Logan Sundaram <logan.sundaram@intel.com>