### PR TITLE
DAOS-623 vos: Fix a compiler warning, minor reorg

### DIFF
--- a/src/vos/tests/vos_tests.c
+++ b/src/vos/tests/vos_tests.c
@@ -39,8 +39,6 @@
 #include <daos_srv/vos.h>
 #include <vos_internal.h>
 
-static char	config_description[50];
-
 static void
 print_usage()
 {
@@ -81,40 +79,40 @@ static int akey_feats[] = {
 static inline int
 run_all_tests(int keys, bool nest_iterators)
 {
-	int	failed = 0;
-	int	feats;
-	int	i;
-	int	j;
-	int	length = 0;
-	char	*bypass = getenv("DAOS_IO_BYPASS");
-	char	cfg_desc_io[50];
+	const char	*bypass = getenv("DAOS_IO_BYPASS");
+	const char	*it;
+	char		 cfg_desc_io[CFG_MAX];
+	int		 failed = 0;
+	int		 feats;
+	int		 i;
+	int		 j;
 
-	length += sprintf(config_description+length, "keys=%d", keys);
+	if (!bypass) {
+		create_config(cfg_desc_io, "keys=%d", keys);
+		failed += run_ts_tests(cfg_desc_io);
+		bypass = "none";
+	}
 
-	if (bypass)
-		sprintf(config_description+length, " bypass=%s", bypass);
-	else
-		sprintf(config_description+length, " bypass=none");
+	create_config(cfg_desc_io, "keys=%d bypass=%s", keys, bypass);
 
 	if (nest_iterators == false) {
-		failed += run_pm_tests(config_description);
-		failed += run_pool_test(config_description);
-		failed += run_co_test(config_description);
-		failed += run_discard_tests(config_description);
-		failed += run_aggregate_tests(false, config_description);
-		failed += run_gc_tests(config_description);
-		failed += run_dtx_tests(config_description);
-		failed += run_ilog_tests(config_description);
-		failed += run_csum_extent_tests(config_description);
-		failed += run_mvcc_tests(config_description);
+		failed += run_pm_tests(cfg_desc_io);
+		failed += run_pool_test(cfg_desc_io);
+		failed += run_co_test(cfg_desc_io);
+		failed += run_discard_tests(cfg_desc_io);
+		failed += run_aggregate_tests(false, cfg_desc_io);
+		failed += run_gc_tests(cfg_desc_io);
+		failed += run_dtx_tests(cfg_desc_io);
+		failed += run_ilog_tests(cfg_desc_io);
+		failed += run_csum_extent_tests(cfg_desc_io);
+		failed += run_mvcc_tests(cfg_desc_io);
 
-		sprintf(cfg_desc_io,
-			"%s iterator=standalone", config_description);
+		it = "standalone";
 	} else {
-		sprintf(cfg_desc_io,
-			"%s iterator=nested", config_description);
-
+		it = "nested";
 	}
+	create_config(cfg_desc_io, "keys=%d bypass=%s iterator=%s", keys,
+		      bypass, it);
 
 	for (i = 0; dkey_feats[i] >= 0; i++) {
 		for (j = 0; akey_feats[j] >= 0; j++) {
@@ -211,11 +209,11 @@ main(int argc, char **argv)
 				  long_options, &index)) != -1) {
 		switch (opt) {
 		case 'p':
-			nr_failed += run_pool_test(config_description);
+			nr_failed += run_pool_test("");
 			test_run = true;
 			break;
 		case 'c':
-			nr_failed += run_co_test(config_description);
+			nr_failed += run_co_test("");
 			test_run = true;
 			break;
 		case 'n':
@@ -225,28 +223,28 @@ main(int argc, char **argv)
 			ofeats = strtol(optarg, NULL, 16);
 			nr_failed += run_io_test(ofeats, 0,
 						 nest_iterators,
-						 config_description);
+						 "");
 			test_run = true;
 			break;
 		case 'a':
 			nr_failed += run_aggregate_tests(true,
-							 config_description);
+							 "");
 			test_run = true;
 			break;
 		case 'd':
-			nr_failed += run_discard_tests(config_description);
+			nr_failed += run_discard_tests("");
 			test_run = true;
 			break;
 		case 'g':
-			nr_failed += run_gc_tests(config_description);
+			nr_failed += run_gc_tests("");
 			test_run = true;
 			break;
 		case 'X':
-			nr_failed += run_dtx_tests(config_description);
+			nr_failed += run_dtx_tests("");
 			test_run = true;
 			break;
 		case 'm':
-			nr_failed += run_pm_tests(config_description);
+			nr_failed += run_pm_tests("");
 			test_run = true;
 			break;
 		case 'A':
@@ -255,19 +253,19 @@ main(int argc, char **argv)
 			test_run = true;
 			break;
 		case 'l':
-			nr_failed += run_ilog_tests(config_description);
+			nr_failed += run_ilog_tests("");
 			test_run = true;
 			break;
 		case 'z':
-			nr_failed += run_csum_extent_tests(config_description);
+			nr_failed += run_csum_extent_tests("");
 			test_run = true;
 			break;
 		case 't':
-			nr_failed += run_ts_tests();
+			nr_failed += run_ts_tests("");
 			test_run = true;
 			break;
 		case 'C':
-			nr_failed += run_mvcc_tests(config_description);
+			nr_failed += run_mvcc_tests("");
 			test_run = true;
 			break;
 		case 'f':

--- a/src/vos/tests/vos_tests.c
+++ b/src/vos/tests/vos_tests.c
@@ -87,11 +87,8 @@ run_all_tests(int keys, bool nest_iterators)
 	int		 i;
 	int		 j;
 
-	if (!bypass) {
-		create_config(cfg_desc_io, "keys=%d", keys);
-		failed += run_ts_tests(cfg_desc_io);
+	if (!bypass)
 		bypass = "none";
-	}
 
 	create_config(cfg_desc_io, "keys=%d bypass=%s", keys, bypass);
 

--- a/src/vos/tests/vts_aggregate.c
+++ b/src/vos/tests/vts_aggregate.c
@@ -2020,9 +2020,9 @@ static const struct CMUnitTest aggregate_tests[] = {
 int
 run_discard_tests(const char *cfg)
 {
-	char	test_name[100];
+	char	test_name[CFG_MAX];
 
-	sprintf(test_name, "VOS Discard Tests %s", cfg);
+	create_config(test_name, "VOS Discard Tests %s", cfg);
 	return cmocka_run_group_tests_name(test_name, discard_tests,
 					   setup_io, teardown_io);
 }
@@ -2030,9 +2030,10 @@ run_discard_tests(const char *cfg)
 int
 run_aggregate_tests(bool slow, const char *cfg)
 {
-	char	test_name[100];
+	char	test_name[CFG_MAX];
 
-	sprintf(test_name, "VOS Aggregate Tests %s", cfg);
+	create_config(test_name, "VOS Aggregate Tests %s", cfg);
+
 	slow_test = slow;
 	return cmocka_run_group_tests_name(test_name,
 					   aggregate_tests, setup_io,

--- a/src/vos/tests/vts_checksum.c
+++ b/src/vos/tests/vts_checksum.c
@@ -774,16 +774,16 @@ static const struct CMUnitTest evt_checksums_tests[] = {
 int run_csum_extent_tests(const char *cfg)
 {
 	int rc = 0;
-	char	test_name[130];
+	char	test_name[CFG_MAX];
 
-	sprintf(test_name,
+	create_config(test_name,
 		"Storage and retrieval of checksums for Array Type %s", cfg);
 
 	rc = cmocka_run_group_tests_name(
 		test_name,
 		update_fetch_checksums_for_array_types, setup_io, teardown_io);
 
-	sprintf(test_name,
+	create_config(test_name,
 		"evtreen helper functions for alignment, counting, etc for csum  %s",
 		cfg);
 

--- a/src/vos/tests/vts_common.h
+++ b/src/vos/tests/vts_common.h
@@ -111,6 +111,21 @@ void dts_ctx_fini(struct dts_context *tsc);
  */
 struct dts_io_credit *dts_credit_take(struct dts_context *tsc);
 
+#define CFG_MAX 128
+static inline void
+create_config(char buf[CFG_MAX], const char *format, ...)
+{
+	va_list	ap;
+	int	count;
+
+	va_start(ap, format);
+	count = vsnprintf(buf, CFG_MAX, format, ap);
+	va_end(ap);
+
+	if (count >= CFG_MAX)
+		buf[CFG_MAX - 1] = 0;
+}
+
 /**
  * VOS test suite run tests
  */
@@ -123,7 +138,7 @@ int run_gc_tests(const char *cfg);
 int run_pm_tests(const char *cfg);
 int run_io_test(daos_ofeat_t feats, int keys, bool nest_iterators,
 		const char *cfg);
-int run_ts_tests(void);
+int run_ts_tests(const char *cfg);
 
 int run_ilog_tests(const char *cfg);
 int run_csum_extent_tests(const char *cfg);

--- a/src/vos/tests/vts_container.c
+++ b/src/vos/tests/vts_container.c
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2016-2019 Intel Corporation.
+ * (C) Copyright 2016-2020 Intel Corporation.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -376,9 +376,9 @@ static const struct CMUnitTest vos_co_tests[] = {
 int
 run_co_test(const char *cfg)
 {
-	char	test_name[100];
+	char	test_name[CFG_MAX];
 
-	sprintf(test_name, "VOS container tests %s", cfg);
+	create_config(test_name, "VOS container tests %s", cfg);
 	return cmocka_run_group_tests_name(test_name,
 					   vos_co_tests,
 					   setup, teardown);

--- a/src/vos/tests/vts_dtx.c
+++ b/src/vos/tests/vts_dtx.c
@@ -1568,9 +1568,9 @@ static const struct CMUnitTest dtx_tests[] = {
 int
 run_dtx_tests(const char *cfg)
 {
-	char	test_name[100];
+	char	test_name[CFG_MAX];
 
-	sprintf(test_name, "VOS DTX Test %s", cfg);
+	create_config(test_name, "VOS DTX Test %s", cfg);
 	return cmocka_run_group_tests_name(test_name,
 					   dtx_tests, setup_io,
 					   teardown_io);

--- a/src/vos/tests/vts_gc.c
+++ b/src/vos/tests/vts_gc.c
@@ -431,9 +431,9 @@ static const struct CMUnitTest gc_tests[] = {
 int
 run_gc_tests(const char *cfg)
 {
-	char	test_name[100];
+	char	test_name[CFG_MAX];
 
-	sprintf(test_name, "Garbage collector %s", cfg);
+	create_config(test_name, "Garbage collector %s", cfg);
 	return cmocka_run_group_tests_name(test_name,
 					   gc_tests, gc_setup, gc_teardown);
 }

--- a/src/vos/tests/vts_ilog.c
+++ b/src/vos/tests/vts_ilog.c
@@ -1220,9 +1220,9 @@ teardown_ilog(void **state)
 int
 run_ilog_tests(const char *cfg)
 {
-	char	test_name[100];
+	char	test_name[CFG_MAX];
 
-	sprintf(test_name, "VOS Incarnation log tests %s", cfg);
+	create_config(test_name, "VOS Incarnation log tests %s", cfg);
 	return cmocka_run_group_tests_name(test_name,
 					   inc_tests, setup_ilog,
 					   teardown_ilog);

--- a/src/vos/tests/vts_mvcc.c
+++ b/src/vos/tests/vts_mvcc.c
@@ -655,9 +655,9 @@ teardown_mvcc(void **state)
 int
 run_mvcc_tests(const char *cfg)
 {
-	char	test_name[100];
+	char	test_name[CFG_MAX];
 
-	sprintf(test_name, "VOS MVCC Tests %s", cfg);
+	create_config(test_name, "VOS MVCC Tests %s", cfg);
 
 	if (getenv("DAOS_IO_BYPASS")) {
 		print_message("Skipping MVCC tests: DAOS_IO_BYPASS is set\n");

--- a/src/vos/tests/vts_pm.c
+++ b/src/vos/tests/vts_pm.c
@@ -1302,9 +1302,9 @@ static const struct CMUnitTest punch_model_tests[] = {
 int
 run_pm_tests(const char *cfg)
 {
-	char	test_name[100];
+	char	test_name[CFG_MAX];
 
-	sprintf(test_name, "VOS Punch Model tests %s", cfg);
+	create_config(test_name, "VOS Punch Model tests %s", cfg);
 	if (DAOS_ON_VALGRIND)
 		buf_size = 100;
 	return cmocka_run_group_tests_name(test_name,

--- a/src/vos/tests/vts_pool.c
+++ b/src/vos/tests/vts_pool.c
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2016-2019 Intel Corporation.
+ * (C) Copyright 2016-2020 Intel Corporation.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -421,9 +421,9 @@ static const struct CMUnitTest pool_tests[] = {
 int
 run_pool_test(const char *cfg)
 {
-	char	test_name[100];
+	char	test_name[CFG_MAX];
 
-	sprintf(test_name, "VOS Pool tests %s", cfg);
+	create_config(test_name, "VOS Pool tests %s", cfg);
 	return cmocka_run_group_tests_name(test_name, pool_tests,
 					   setup, teardown);
 }

--- a/src/vos/tests/vts_ts.c
+++ b/src/vos/tests/vts_ts.c
@@ -655,9 +655,12 @@ ts_test_fini(void **state)
 }
 
 int
-run_ts_tests(void)
+run_ts_tests(const char *cfg)
 {
-	return cmocka_run_group_tests_name("VOS Timestamp table tests",
-					   ts_tests, ts_test_init,
+	char	suite[CFG_MAX];
+
+	create_config(suite, "VOS Timestamp table tests %s", cfg);
+
+	return cmocka_run_group_tests_name(suite, ts_tests, ts_test_init,
 					   ts_test_fini);
 }

--- a/utils/run_test.sh
+++ b/utils/run_test.sh
@@ -83,6 +83,7 @@ if [ -d "/mnt/daos" ]; then
     run_test "${SL_BUILD_DIR}/src/cart/src/utest/test_gurt"
     run_test "${SL_BUILD_DIR}/src/cart/src/utest/utest_hlc"
     run_test "${SL_BUILD_DIR}/src/cart/src/utest/utest_swim"
+    run_test "${SL_PREFIX}/bin/vos_tests" -t
     run_test "${SL_PREFIX}/bin/vos_tests" -A 500
     run_test "${SL_PREFIX}/bin/vos_tests" -n -A 500
     export DAOS_IO_BYPASS=pm


### PR DESCRIPTION
Adds a create_config API in tests for consolidating possible
compiler warnings to a single location and using vsnprintf
rather than sprintf
Add timestamp tests to all
Avoid running timestamp when bypass is set

Signed-off-by: Jeff Olivier <jeffrey.v.olivier@intel.com>