### PR TITLE
DAOS-4743 test: VOS IO test fix

### DIFF
--- a/src/vos/tests/vts_io.c
+++ b/src/vos/tests/vts_io.c
@@ -2474,7 +2474,7 @@ run_io_test(daos_ofeat_t feats, int keys, bool nest_iterators, const char *cfg)
 	if (feats & DAOS_OF_AKEY_LEXICAL)
 		akey = "lex";
 
-	snprintf(buf, VTS_BUF_SIZE, "#. VOS IO tests (dkey=%-6s akey=%s) %s",
+	snprintf(buf, VTS_BUF_SIZE, "# VOS IO tests (dkey=%-6s akey=%s) %s",
 		 dkey, akey, cfg);
 	init_ofeats = feats;
 	if (keys)


### PR DESCRIPTION
VOS IO test results were missing from Jenkins results. This was because
of how Jenkins parses the junit xmls. To solve this problem the dot
in the VOS IO test name was removed.

Signed-off-by: Marcela Rosales <marcela.a.rosales.jimenez@intel.com>