### PR TITLE
DAOS-4657 test: convert full_regression tests to use medium,ib2 clusters

### DIFF
--- a/src/tests/ftest/io/unaligned_io.py
+++ b/src/tests/ftest/io/unaligned_io.py
@@ -44,6 +44,6 @@ class DaosRunIoConf(IoConfTestBase):
             Write data set, modified 1bytes in different offsets. Verify
             read through
 
-        :avocado: tags=all,full_regression,hw,large,unaligned_io
+        :avocado: tags=all,full_regression,hw,medium,ib2,unaligned_io
         """
         self.unaligned_io()

--- a/src/tests/ftest/io/unaligned_io.yaml
+++ b/src/tests/ftest/io/unaligned_io.yaml
@@ -4,19 +4,34 @@ hosts:
     - server-B
     - server-C
     - server-D
-    - server-E
-    - server-F
-    - server-G
-    - server-H
 timeout: 900
 server_config:
+  servers_per_host: 2
   name: daos_server
-  targets: 8
   servers:
-   bdev_class: nvme
-   bdev_list: ["0000:5e:00.0","0000:5f:00.0"]
-   scm_class: dcpm
-   scm_list: ["/dev/pmem0"]
+    0:
+      pinned_numa_node: 0
+      nr_xs_helpers: 1
+      fabric_iface: ib0
+      fabric_iface_port: 31416
+      log_file: daos_server0.log
+      bdev_class: nvme
+      bdev_list: ["0000:81:00.0"]
+      scm_class: dcpm
+      scm_list: ["/dev/pmem0"]
+      scm_mount: /mnt/daos0
+    1:
+      pinned_numa_node: 1
+      nr_xs_helpers: 1
+      fabric_iface: ib1
+      fabric_iface_port: 31417
+      log_file: daos_server1.log
+      bdev_class: nvme
+      bdev_list: ["0000:da:00.0"]
+      scm_class: dcpm
+      scm_list: ["/dev/pmem1"]
+      scm_mount: /mnt/daos1
+  targets: 8
 pool:
   scm_size: 12G
 datasize:


### PR DESCRIPTION
Test-tag: basictx
Test-tag-hw-small: ior_small
Test-tag-hw-medium: unaligned_io
Test-tag-hw-large: junk

  - Moving the following tests to run medium cluster
    by modifying the yaml to run two daos_io server per host
      1. io/unaligned_io.py

Signed-off-by: Logan Sundaram <logan.sundaram@intel.com>