### PR TITLE
DAOS-4475 test: Updated pool size and container UUID

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -1,2 +1,2 @@
 DAOS I/O Stack
-Copyright (c) 2015-2018, Intel Corporation
+Copyright (c) 2015-2020, Intel Corporation

--- a/src/tests/ftest/container/open_close.py
+++ b/src/tests/ftest/container/open_close.py
@@ -21,8 +21,6 @@
   Any reproduction of computer software, computer software documentation, or
   portions thereof marked with this legend must also reproduce the markings.
 '''
-from __future__ import print_function
-
 import traceback
 import uuid
 from apricot import TestWithServers
@@ -71,6 +69,8 @@ class OpenClose(TestWithServers):
                 # then close & destroy so handle is invalid
                 self.container.append(DaosContainer(self.context))
                 self.container[1].create(poh)
+                str_cuuid = self.container[1].get_uuid_str()
+                cuuid = uuid.UUID(str_cuuid)
                 self.container[1].open(poh, cuuid, 2, None)
                 coh = self.container[1].coh
                 self.container[1].close()

--- a/src/tests/ftest/container/open_close.yaml
+++ b/src/tests/ftest/container/open_close.yaml
@@ -7,15 +7,15 @@ server_config:
 pool:
     mode: 146
     name: daos_server
-    scm_size: 1073741
+    scm_size: 1G
     control_method: dmg
 container:
     container_handle: !mux
-        goodcoh:
+        good_coh:
             coh:
                 - GOOD
                 - 'PASS'
-        badcoh:
+        bad_coh:
             coh:
                 - BAD
                 - 'FAIL'


### PR DESCRIPTION
Use correct container UUID at open.

Increased SCM size.
Updated copyright year.

Test-tag: pr,-hw closehandle
Signed-off-by: Makito Kano <makito.kano@intel.com>