### PR TITLE
DAOS-623 vos: Fix issues with timestamp tests

### DIFF
--- a/src/vos/tests/vos_tests.c
+++ b/src/vos/tests/vos_tests.c
@@ -89,7 +89,7 @@ run_all_tests(int keys, bool nest_iterators)
 
 	if (!bypass) {
 		if (!nest_iterators) {
-			create_config(cfg_desc_io, "keys=%d", keys, bypass);
+			create_config(cfg_desc_io, "keys=%d", keys);
 			failed += run_ts_tests(cfg_desc_io);
 			failed += run_mvcc_tests(cfg_desc_io);
 		}

--- a/src/vos/tests/vos_tests.c
+++ b/src/vos/tests/vos_tests.c
@@ -87,8 +87,14 @@ run_all_tests(int keys, bool nest_iterators)
 	int		 i;
 	int		 j;
 
-	if (!bypass)
+	if (!bypass) {
+		if (!nest_iterators) {
+			create_config(cfg_desc_io, "keys=%d", keys, bypass);
+			failed += run_ts_tests(cfg_desc_io);
+			failed += run_mvcc_tests(cfg_desc_io);
+		}
 		bypass = "none";
+	}
 
 	create_config(cfg_desc_io, "keys=%d bypass=%s", keys, bypass);
 
@@ -102,7 +108,6 @@ run_all_tests(int keys, bool nest_iterators)
 		failed += run_dtx_tests(cfg_desc_io);
 		failed += run_ilog_tests(cfg_desc_io);
 		failed += run_csum_extent_tests(cfg_desc_io);
-		failed += run_mvcc_tests(cfg_desc_io);
 
 		it = "standalone";
 	} else {

--- a/src/vos/tests/vts_common.h
+++ b/src/vos/tests/vts_common.h
@@ -112,6 +112,7 @@ void dts_ctx_fini(struct dts_context *tsc);
 struct dts_io_credit *dts_credit_take(struct dts_context *tsc);
 
 #define CFG_MAX 128
+__attribute__ ((__format__(__printf__, 2, 3)))
 static inline void
 create_config(char buf[CFG_MAX], const char *format, ...)
 {

--- a/utils/run_test.sh
+++ b/utils/run_test.sh
@@ -83,7 +83,6 @@ if [ -d "/mnt/daos" ]; then
     run_test "${SL_BUILD_DIR}/src/cart/src/utest/test_gurt"
     run_test "${SL_BUILD_DIR}/src/cart/src/utest/utest_hlc"
     run_test "${SL_BUILD_DIR}/src/cart/src/utest/utest_swim"
-    run_test "${SL_PREFIX}/bin/vos_tests" -t
     run_test "${SL_PREFIX}/bin/vos_tests" -A 500
     run_test "${SL_PREFIX}/bin/vos_tests" -n -A 500
     export DAOS_IO_BYPASS=pm


### PR DESCRIPTION
1. Timestamp tests should not delete the vos timestamp cache
2. We should reset the timestamp cache between tests to mimic
   a clean state.  Otherwise, different orders of tests give
   different results

Signed-off-by: Jeff Olivier <jeffrey.v.olivier@intel.com>