### PR TITLE
DAOS-4720 iosrv: wakeup progress ULTs on xstreams fini

### DIFF
--- a/src/iosrv/srv.c
+++ b/src/iosrv/srv.c
@@ -767,6 +767,7 @@ dss_xstreams_fini(bool force)
 	int			 rc;
 
 	D_DEBUG(DB_TRACE, "Stopping execution streams\n");
+	dss_xstreams_open_barrier();
 
 	/** Stop & free progress ULTs */
 	for (i = 0; i < xstream_data.xd_xs_nr; i++) {


### PR DESCRIPTION
We need to wakeup all the progress ULTs when finalizing xstreams,
otherwise, when latter xstreams failed to start, the prior started
xstreams will wait forever and io server won't exit properly.

Signed-off-by: Niu Yawei <yawei.niu@intel.com>