### PR TITLE
DAOS-4467 tests: Support container properties in DaosCommand (#2312)

### DIFF
--- a/src/tests/ftest/io/ior_small.yaml
+++ b/src/tests/ftest/io/ior_small.yaml
@@ -28,6 +28,9 @@ pool:
     control_method: dmg
 container:
     type: POSIX
+    # Disabling checksum due to DAOS-4458
+    # properties: cksum:crc16,cksum_size:16384,srv_cksum:on
+    control_method: daos
 ior:
     client_processes:
         np_16:

--- a/src/tests/ftest/pool/rebuild_with_ior.py
+++ b/src/tests/ftest/pool/rebuild_with_ior.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python
-'''
-  (C) Copyright 2018-2019 Intel Corporation.
+"""
+  (C) Copyright 2018-2020 Intel Corporation.
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
@@ -20,24 +20,26 @@
   provided in Contract No. B609815.
   Any reproduction of computer software, computer software documentation, or
   portions thereof marked with this legend must also reproduce the markings.
-'''
+"""
 from __future__ import print_function
 
 from apricot import skipForTicket
 from ior_test_base import IorTestBase
 
-#pylint: disable=R0903
+
+# pylint: disable=too-few-public-methods,too-many-ancestors
 class RebuildWithIOR(IorTestBase):
-    """
+    """Rebuild test cases featuring IOR.
+
     This class contains tests for pool rebuild that feature I/O going on
     during the rebuild using IOR.
+
     :avocado: recursive
     """
 
     @skipForTicket("DAOS-2773")
     def test_rebuild_with_ior(self):
-        """
-        Jira ID: DAOS-951
+        """Jira ID: DAOS-951.
 
         Test Description: Trigger a rebuild while I/O is ongoing.
                           I/O performed using IOR.
@@ -48,7 +50,6 @@ class RebuildWithIOR(IorTestBase):
 
         :avocado: tags=all,pr,small,pool,rebuild,rebuildwithior
         """
-
         # set params
         targets = self.params.get("targets", "/run/server_config/*")
         rank = self.params.get("rank_to_kill", "/run/testparams/*")
@@ -79,8 +80,7 @@ class RebuildWithIOR(IorTestBase):
 
         # perform first set of io using IOR
         self.ior_cmd.flags.update(iorflags_write)
-        self.ior_cmd.test_file.update(file1)
-        self.run_ior_with_pool()
+        self.run_ior_with_pool(test_file=file1)
 
         # Kill the server
         self.pool.start_rebuild([rank], self.d_log)
@@ -102,14 +102,11 @@ class RebuildWithIOR(IorTestBase):
 
         # perform second set of io using IOR
         self.ior_cmd.flags.update(iorflags_write)
-        self.ior_cmd.test_file.update(file2)
-        self.run_ior_with_pool()
+        self.run_ior_with_pool(test_file=file2)
 
         # check data intergrity using ior for both ior runs
         self.ior_cmd.flags.update(iorflags_read)
-        self.ior_cmd.test_file.update(file1)
-        self.run_ior_with_pool()
+        self.run_ior_with_pool(test_file=file1)
 
         self.ior_cmd.flags.update(iorflags_read)
-        self.ior_cmd.test_file.update(file2)
-        self.run_ior_with_pool()
+        self.run_ior_with_pool(test_file=file2)

--- a/src/tests/ftest/util/ior_test_base.py
+++ b/src/tests/ftest/util/ior_test_base.py
@@ -30,6 +30,7 @@ from ClusterShell.NodeSet import NodeSet
 from apricot import TestWithServers, get_log_file
 from ior_utils import IorCommand
 from command_utils import Mpirun, CommandFailure
+from daos_utils import DaosCommand
 from mpio_utils import MpioUtils
 from test_utils_pool import TestPool
 from test_utils_container import TestContainer
@@ -52,7 +53,6 @@ class IorTestBase(TestWithServers):
         self.hostfile_clients_slots = None
         self.dfuse = None
         self.container = None
-        self.co_prop = None
         self.lock = None
 
     def setUp(self):
@@ -66,8 +66,7 @@ class IorTestBase(TestWithServers):
         self.ior_cmd = IorCommand()
         self.ior_cmd.get_params(self)
         self.processes = self.params.get("np", '/run/ior/client_processes/*')
-        self.co_prop = self.params.get("container_properties",
-                                       "/run/container/*")
+
         # Until DAOS-3320 is resolved run IOR for POSIX
         # with single client node
         if self.ior_cmd.api.value == "POSIX":
@@ -99,12 +98,13 @@ class IorTestBase(TestWithServers):
 
     def create_cont(self):
         """Create a TestContainer object to be used to create container."""
-        # Enable container using TestContainer object,
-        # Get Container params
-        self.container = TestContainer(self.pool)
+        # Get container params
+        self.container = TestContainer(
+            self.pool, daos_command=DaosCommand(self.bin))
         self.container.get_params(self)
+
         # create container
-        self.container.create(con_in=self.co_prop)
+        self.container.create()
 
     def _start_dfuse(self):
         """Create a DfuseCommand object to start dfuse."""
@@ -128,17 +128,24 @@ class IorTestBase(TestWithServers):
                            exc_info=error)
             self.fail("Test was expected to pass but it failed.\n")
 
-    def run_ior_with_pool(self, intercept=None, test_file_suffix=""):
+    def run_ior_with_pool(self, intercept=None, test_file_suffix="",
+                          test_file="daos:testFile"):
         """Execute ior with optional overrides for ior flags and object_class.
 
         If specified the ior flags and ior daos object class parameters will
         override the values read from the yaml file.
 
         Args:
-            intercept (str): path to the interception library. Shall be used
-                             only for POSIX through DFUSE.
-            ior_flags (str, optional): ior flags. Defaults to None.
-            object_class (str, optional): daos object class. Defaults to None.
+            intercept (str, optional): path to the interception library. Shall
+                    be used only for POSIX through DFUSE. Defaults to None.
+            test_file_suffix (str, optional): suffix to add to the end of the
+                test file name. Defaults to "".
+            test_file (str, optional): ior test file name. Defaults to
+                "daos:testFile". Is ignored when using POSIX through DFUSE.
+
+        Returns:
+            CmdResult: result of the ior command execution
+
         """
         self.update_ior_cmd_with_pool()
         # start dfuse if api is POSIX
@@ -148,10 +155,9 @@ class IorTestBase(TestWithServers):
             if self.ior_cmd.transfer_size.value == "256B":
                 return "Skipping the case for transfer_size=256B"
             self._start_dfuse()
-            testfile = os.path.join(self.dfuse.mount_dir.value,
-                                    "testfile{}".format(test_file_suffix))
+            test_file = os.path.join(self.dfuse.mount_dir.value, "testfile")
 
-            self.ior_cmd.test_file.update(testfile)
+        self.ior_cmd.test_file.update("".join([test_file, test_file_suffix]))
 
         out = self.run_ior(self.get_job_manager_command(), self.processes,
                            intercept)
@@ -162,8 +168,7 @@ class IorTestBase(TestWithServers):
         return out
 
     def update_ior_cmd_with_pool(self):
-        """Update ior_cmd with pool
-        """
+        """Update ior_cmd with pool."""
         # Create a pool if one does not already exist
         if self.pool is None:
             self.create_pool()
@@ -172,7 +177,7 @@ class IorTestBase(TestWithServers):
         # It will not enable checksum feature
         self.pool.connect()
         self.create_cont()
-         # Update IOR params with the pool and container params
+        # Update IOR params with the pool and container params
         self.ior_cmd.set_daos_params(self.server_group, self.pool,
                                      self.container.uuid)
 
@@ -253,7 +258,7 @@ class IorTestBase(TestWithServers):
         self.dfuse = None
 
     def get_new_job(self, clients, job_num, results, intercept=None):
-        """Create a new thread for ior run
+        """Create a new thread for ior run.
 
         Args:
             clients (lst): Number of clients the ior would run against.
@@ -269,7 +274,7 @@ class IorTestBase(TestWithServers):
 
     def run_multiple_ior(self, hostfile, num_clients,
                          results, job_num, intercept=None):
-        #pylint: disable=too-many-arguments
+        # pylint: disable=too-many-arguments
         """Run the IOR command.
 
         Args:

--- a/src/tests/ftest/util/test_utils_base.py
+++ b/src/tests/ftest/util/test_utils_base.py
@@ -77,6 +77,12 @@ class TestDaosApiBase(ObjectWithParameters):
     # pylint: disable=too-few-public-methods
     """A base class for functional testing of DaosPools objects."""
 
+    # Constants to define whether to use API or a command to create and destroy
+    # pools and containers.
+    USE_API = "API"
+    USE_DMG = "dmg"
+    USE_DAOS = "daos"
+
     def __init__(self, namespace, cb_handler=None):
         """Create a TestDaosApi object.
 
@@ -88,6 +94,12 @@ class TestDaosApiBase(ObjectWithParameters):
         super(TestDaosApiBase, self).__init__(namespace)
         self.cb_handler = cb_handler
         self.debug = BasicParameter(None, False)
+
+        # Test yaml parameter used to define the control method:
+        #   USE_API    - use the API methods to create/destroy pools/containers
+        #   USE_DMG    - use the dmg command to create/destroy pools/containers
+        #   USE_DAOS   - use the daos command to create/destroy pools/containers
+        self.control_method = BasicParameter(self.USE_API, self.USE_API)
 
     def _log_method(self, name, kwargs):
         """Log the method call with its arguments.

--- a/src/tests/ftest/util/test_utils_container.py
+++ b/src/tests/ftest/util/test_utils_container.py
@@ -29,7 +29,7 @@ from test_utils_base import TestDaosApiBase
 from avocado import fail_on
 from command_utils import BasicParameter
 from pydaos.raw import (DaosApiError, DaosContainer, DaosInputParams,
-                        c_uuid_to_str)
+                        c_uuid_to_str, str_to_c_uuid)
 from general_utils import get_random_string, DaosTestError
 
 
@@ -253,7 +253,7 @@ class TestContainerData(object):
 class TestContainer(TestDaosApiBase):
     """A class for functional testing of DaosContainer objects."""
 
-    def __init__(self, pool, cb_handler=None):
+    def __init__(self, pool, cb_handler=None, daos_command=None):
         """Create a TeestContainer object.
 
         Args:
@@ -273,6 +273,17 @@ class TestContainer(TestDaosApiBase):
         # Provider access to get input params values
         # for enabling different container properties
         self.input_params = DaosInputParams()
+
+        # Optional daos command objec to use with the USE_DAOS control method
+        self.daos = daos_command
+
+        # Optional daos command argument values to use with the USE_DAOS control
+        # method when creating/destroying containers
+        self.path = BasicParameter(None)
+        self.type = BasicParameter(None)
+        self.oclass = BasicParameter(None)
+        self.chunk_size = BasicParameter(None)
+        self.properties = BasicParameter(None)
 
         self.container = None
         self.uuid = None
@@ -303,20 +314,53 @@ class TestContainer(TestDaosApiBase):
             "Creating a container with pool handle %s",
             self.pool.pool.handle.value)
         self.container = DaosContainer(self.pool.context)
-        kwargs = {"poh": self.pool.pool.handle}
-        if uuid is not None:
-            kwargs["con_uuid"] = uuid
-        # Refer daos_api for setting input params for DaosContainer.
-        if con_in is not None:
-            cop = self.input_params.get_con_create_params()
-            cop.type = con_in[0]
-            cop.enable_chksum = con_in[1]
-            cop.srv_verify = con_in[2]
-            cop.chksum_type = con_in[3]
-            cop.chunk_size = con_in[4]
-            kwargs["con_prop"] = cop
 
-        self._call_method(self.container.create, kwargs)
+        if self.control_method.value == self.USE_API:
+            # Create a container with the API method
+            kwargs = {"poh": self.pool.pool.handle}
+            if uuid is not None:
+                kwargs["con_uuid"] = uuid
+
+            # Refer daos_api for setting input params for DaosContainer.
+            if con_in is not None:
+                cop = self.input_params.get_con_create_params()
+                cop.type = con_in[0]
+                cop.enable_chksum = con_in[1]
+                cop.srv_verify = con_in[2]
+                cop.chksum_type = con_in[3]
+                cop.chunk_size = con_in[4]
+                kwargs["con_prop"] = cop
+
+            self._call_method(self.container.create, kwargs)
+
+        elif self.control_method.value == self.USE_DAOS and self.daos:
+            # Create a container with the daos command
+            kwargs = {
+                "pool": self.pool.uuid,
+                "sys_name": self.pool.name.value,
+                "svc": ",".join(str(rank) for rank in self.pool.svc_ranks),
+                "cont": uuid,
+                "path": self.path.value,
+                "cont_type": self.type.value,
+                "oclass": self.oclass.value,
+                "chunk_size": self.chunk_size.value,
+                "properties": self.properties.value,
+            }
+            self._log_method("daos.container_create", kwargs)
+            uuid = self.daos.get_output("container_create", **kwargs)[0]
+
+            # Populte the empty DaosContainer object with the properties of the
+            # container created with daos container create.
+            self.container.uuid = str_to_c_uuid(uuid)
+
+        elif self.control_method.value == self.USE_DAOS:
+            self.log.error("Error: Undefined daos command")
+
+        else:
+            self.log.error(
+                "Error: Undefined control_method: %s",
+                self.control_method.value)
+
         self.uuid = self.container.get_uuid_str()
         self.log.info("  Container created with uuid %s", self.uuid)
 
@@ -378,17 +422,42 @@ class TestContainer(TestDaosApiBase):
                 container does not exist.
 
         """
+        status = False
         if self.container:
             self.close()
             self.log.info("Destroying container %s", self.uuid)
             if self.container.attached:
-                self._call_method(self.container.destroy, {"force": force})
+                kwargs = {"force": force}
+
+                if self.control_method.value == self.USE_API:
+                    # Destroy the container with the API method
+                    self._call_method(self.container.destroy, kwargs)
+                    status = True
+
+                elif self.control_method.value == self.USE_DAOS and self.daos:
+                    # Destroy the container with the daos command
+                    kwargs["pool"] = self.pool.uuid
+                    kwargs["sys_name"] = self.pool.name.value
+                    kwargs["svc"] = ",".join(self.pool.svc_ranks)
+                    kwargs["cont"] = self.uuid
+                    self._log_method("daos.container_destroy", kwargs)
+                    self.daos.container_destroy(**kwargs)
+                    status = True
+
+                elif self.control_method.value == self.USE_DAOS:
+                    self.log.error("Error: Undefined daos command")
+
+                else:
+                    self.log.error(
+                        "Error: Undefined control_method: %s",
+                        self.control_method.value)
+
             self.container = None
             self.uuid = None
             self.info = None
             self.written_data = []
-            return True
-        return False
+
+        return status
 
     @fail_on(DaosApiError)
     def get_info(self, coh=None):

--- a/src/tests/ftest/util/test_utils_pool.py
+++ b/src/tests/ftest/util/test_utils_pool.py
@@ -41,11 +41,6 @@ from dmg_utils import get_pool_uuid_service_replicas_from_stdout
 class TestPool(TestDaosApiBase):
     """A class for functional testing of DaosPools objects."""
 
-    # Constants to define whether to use API or dmg to create and destroy
-    # pool.
-    USE_API = "API"
-    USE_DMG = "dmg"
-
     def __init__(self, context, log=None, cb_handler=None, dmg_command=None):
         # pylint: disable=unused-argument
         """Initialize a TestPool object.
@@ -76,10 +71,6 @@ class TestPool(TestDaosApiBase):
         self.nvme_size = BasicParameter(None)
         self.prop_name = BasicParameter(None)      # name of property to be set
         self.prop_value = BasicParameter(None)     # value of property
-
-        # Set USE_API to use API or USE_DMG to use dmg. If it's not set, API is
-        # used.
-        self.control_method = BasicParameter(self.USE_API, self.USE_API)
 
         self.pool = None
         self.uuid = None


### PR DESCRIPTION
Adding support for the '--properties' command line argument for the daos
container create command.  Tests will be able to pass options for the
'--properties' comamnd line argument in their test yaml file or by
passing the argument to the DaosCommand.container_create() method.

Signed-off-by: Phillip Henderson <phillip.henderson@intel.com>