### PR TITLE
DAOS-3945 iosrv: properly account for ULT in flight (#2627)

### DIFF
--- a/src/iosrv/srv.c
+++ b/src/iosrv/srv.c
@@ -332,12 +332,14 @@ dss_nvme_poll_ult(void *args)
 static void
 wait_all_exited(struct dss_xstream *dx)
 {
-	size_t	total_size = 0, pool_size;
-	int	rc, i;
-
 	D_DEBUG(DB_TRACE, "XS(%d) draining ULTs.\n", dx->dx_xs_id);
 	while (1) {
+		size_t	total_size = 0;
+		int	i;
+
 		for (i = 0; i < DSS_POOL_CNT; i++) {
+			size_t	pool_size;
+			int	rc;
 			rc = ABT_pool_get_total_size(dx->dx_pools[i],
 						     &pool_size);
 			D_ASSERTF(rc == ABT_SUCCESS, "%d\n", rc);


### PR DESCRIPTION
During shutdown, the main ULT calls wait_all_exited() to wait for all
pending ULTs to complete, but total_size isn't properly calculated.
It should be reset to 0 at each iteration of the loop otherwise we
will never exit ...

Signed-off-by: Johann Lombardi <johann.lombardi@intel.com>