### PR TITLE
DAOS-4760 duns: DUNS API should return positive errno instead of -DER

### DIFF
--- a/src/client/dfs/duns.c
+++ b/src/client/dfs/duns.c
@@ -76,7 +76,7 @@ bind_liblustre()
 		D_ERROR("unable to locate/bind %s, dlerror() says '%s', "
 			"reverting to non-lustre behaviour.\n",
 			LIBLUSTRE, dlerror());
-		return -DER_INVAL;
+		return EINVAL;
 	}
 
 	D_DEBUG(DB_TRACE, "%s has been found and dynamicaly binded !\n",
@@ -92,7 +92,7 @@ bind_liblustre()
 			"dlerror() says '%s', Lustre version do not seem to "
 			"support foreign LOV/LMV, reverting to non-lustre "
 			"behaviour.\n", dlerror());
-		return -DER_INVAL;
+		return EINVAL;
 	}
 
 	D_DEBUG(DB_TRACE, "llapi_dir_create_foreign() resolved at %p\n",
@@ -106,7 +106,7 @@ bind_liblustre()
 			"dlerror() says '%s', Lustre version do not seem to "
 			"support foreign daos type, reverting to non-lustre "
 			"behaviour.\n", dlerror());
-		return -DER_INVAL;
+		return EINVAL;
 	}
 
 	D_DEBUG(DB_TRACE, "llapi_unlink_foreign() resolved at %p\n",
@@ -137,15 +137,15 @@ duns_resolve_lustre_path(const char *path, struct duns_attr_t *attr)
 	if (liblustre_binded == false && liblustre_notfound == false) {
 		rc = bind_liblustre();
 		if (rc)
-			return -DER_INVAL;
+			return rc;
 	} else if (liblustre_notfound == true) {
 		/* no liblustreapi.so found, or incompatible */
-		return -DER_INVAL;
+		return EINVAL;
 	} else if (liblustre_binded == false) {
 		/* this should not happen */
 		D_ERROR("liblustre_notfound == false && liblustre_notfound == "
 			"false not expected after bind_liblustre()\n");
-		return -DER_INVAL;
+		return EINVAL;
 	}
 
 	D_DEBUG(DB_TRACE, "Trying to retrieve associated container's infos "
@@ -162,15 +162,15 @@ duns_resolve_lustre_path(const char *path, struct duns_attr_t *attr)
 		D_ERROR("unable to allocate XATTR_SIZE_MAX to get LOV/LMV "
 			"for '%s', errno %d(%s).\n", path, errno,
 			strerror(errno));
-		/** TODO - convert errno to rc */
-		return -DER_NOSPACE;
+		return ENOMEM;
 	}
 	fd = open(path, O_RDONLY | O_DIRECTORY | O_NOFOLLOW);
 	if (fd == -1 && errno != ENOTDIR) {
+		int err = errno;
+
 		D_ERROR("unable to open '%s' errno %d(%s).\n", path, errno,
 			strerror(errno));
-		/** TODO - convert errno to rc */
-		return -DER_INVAL;
+		return err;
 	} else if (errno == ENOTDIR) {
 		/* should we handle file/LOV case ?
 		 * for link to HDF5 container ?
@@ -190,10 +190,11 @@ duns_resolve_lustre_path(const char *path, struct duns_attr_t *attr)
 					sizeof(struct lmv_user_mds_data);
 		rc = ioctl(fd, LL_IOC_LMV_GETSTRIPE, buf);
 		if (rc != 0) {
+			int err = errno;
+
 			D_ERROR("ioctl(LL_IOC_LMV_GETSTRIPE) failed, rc: %d, "
 				"errno %d(%s).\n", rc, errno, strerror(errno));
-			/** TODO - convert errno to rc */
-			return -DER_INVAL;
+			return err;
 		}
 
 		lfm = (struct lmv_foreign_md *)buf;
@@ -204,53 +205,53 @@ duns_resolve_lustre_path(const char *path, struct duns_attr_t *attr)
 		    snprintf(str, DUNS_MAX_XATTR_LEN, "%s",
 			     lfm->lfm_value) > DUNS_MAX_XATTR_LEN) {
 			D_ERROR("Invalid DAOS LMV format (%s).\n", str);
-			return -DER_INVAL;
+			return EINVAL;
 		}
 	}
 
 	t = strtok_r(str, ".", &saveptr);
 	if (t == NULL) {
 		D_ERROR("Invalid DAOS LMV format (%s).\n", str);
-		return -DER_INVAL;
+		return EINVAL;
 	}
 
 	t = strtok_r(NULL, ":", &saveptr);
 	if (t == NULL) {
 		D_ERROR("Invalid DAOS LMV format (%s).\n", str);
-		return -DER_INVAL;
+		return EINVAL;
 	}
 
 	daos_parse_ctype(t, &attr->da_type);
 	if (attr->da_type == DAOS_PROP_CO_LAYOUT_UNKOWN) {
 		D_ERROR("Invalid DAOS LMV format: Container layout cannot be"
 			" unknown\n");
-		return -DER_INVAL;
+		return EINVAL;
 	}
 
 	t = strtok_r(NULL, "/", &saveptr);
 	if (t == NULL) {
 		D_ERROR("Invalid DAOS LMV format (%s).\n", str);
-		return -DER_INVAL;
+		return EINVAL;
 	}
 
 	rc = uuid_parse(t, attr->da_puuid);
 	if (rc) {
 		D_ERROR("Invalid DAOS LMV format: pool UUID cannot be"
 			" parsed\n");
-		return -DER_INVAL;
+		return EINVAL;
 	}
 
 	t = strtok_r(NULL, "/", &saveptr);
 	if (t == NULL) {
 		D_ERROR("Invalid DAOS LMV format (%s).\n", str);
-		return -DER_INVAL;
+		return EINVAL;
 	}
 
 	rc = uuid_parse(t, attr->da_cuuid);
 	if (rc) {
 		D_ERROR("Invalid DAOS LMV format: container UUID cannot be"
 			" parsed\n");
-		return -DER_INVAL;
+		return EINVAL;
 	}
 
 	/* path is DAOS-foreign and will need to be unlinked using
@@ -274,16 +275,17 @@ duns_resolve_path(const char *path, struct duns_attr_t *attr)
 	dir = strdup(path);
 	if (dir == NULL) {
 		D_ERROR("Failed to copy path\n");
-		return -DER_NOMEM;
+		return ENOMEM;
 	}
 
 	dirp = dirname(dir);
 	rc = statfs(dirp, &fs);
 	if (rc == -1) {
+		int err = errno;
+
 		D_ERROR("Failed to statfs %s: %s\n", path, strerror(errno));
-		/** TODO - convert errno to rc */
 		free(dir);
-		return -DER_INVAL;
+		return err;
 	}
 
 #ifdef LUSTRE_INCLUDE
@@ -314,7 +316,7 @@ duns_resolve_path(const char *path, struct duns_attr_t *attr)
 			D_ERROR("Invalid DAOS unified namespace xattr\n");
 
 		free(dir);
-		return -DER_INVAL;
+		return err;
 	}
 
 	free(dir);
@@ -330,49 +332,49 @@ duns_parse_attr(char *str, daos_size_t len, struct duns_attr_t *attr)
 
 	D_STRNDUP(local, str, len);
 	if (!local)
-		return -DER_NOMEM;
+		return ENOMEM;
 
 	t = strtok_r(local, ".", &saveptr);
 	if (t == NULL) {
 		D_ERROR("Invalid DAOS xattr format (%s).\n", str);
-		D_GOTO(err, rc = -DER_INVAL);
+		D_GOTO(err, rc = EINVAL);
 	}
 
 	t = strtok_r(NULL, ":", &saveptr);
 	if (t == NULL) {
 		D_ERROR("Invalid DAOS xattr format (%s).\n", str);
-		D_GOTO(err, rc = -DER_INVAL);
+		D_GOTO(err, rc = EINVAL);
 	}
 	daos_parse_ctype(t, &attr->da_type);
 	if (attr->da_type == DAOS_PROP_CO_LAYOUT_UNKOWN) {
 		D_ERROR("Invalid DAOS xattr format: Container layout cannot be"
 			" unknown\n");
-		D_GOTO(err, rc = -DER_INVAL);
+		D_GOTO(err, rc = EINVAL);
 	}
 
 	t = strtok_r(NULL, "/", &saveptr);
 	if (t == NULL) {
 		D_ERROR("Invalid DAOS xattr format (%s).\n", str);
-		D_GOTO(err, rc = -DER_INVAL);
+		D_GOTO(err, rc = EINVAL);
 	}
 
 	rc = uuid_parse(t, attr->da_puuid);
 	if (rc) {
 		D_ERROR("Invalid DAOS xattr format: pool UUID cannot be"
 			" parsed\n");
-		D_GOTO(err, rc = -DER_INVAL);
+		D_GOTO(err, rc = EINVAL);
 	}
 
 	t = strtok_r(NULL, "/", &saveptr);
 	if (t == NULL) {
 		D_ERROR("Invalid DAOS xattr format (%s).\n", str);
-		D_GOTO(err, rc = -DER_INVAL);
+		D_GOTO(err, rc = EINVAL);
 	}
 	rc = uuid_parse(t, attr->da_cuuid);
 	if (rc) {
 		D_ERROR("Invalid DAOS xattr format: container UUID cannot be"
 			" parsed\n");
-		D_GOTO(err, rc = -DER_INVAL);
+		D_GOTO(err, rc = EINVAL);
 	}
 
 	rc = 0;
@@ -401,7 +403,7 @@ duns_create_lustre_path(daos_handle_t poh, const char *path,
 	if (liblustre_binded == false && liblustre_notfound == false) {
 		rc = bind_liblustre();
 		if (rc)
-			return -DER_INVAL;
+			return EINVAL;
 	}
 
 	uuid_unparse(attrp->da_puuid, pool);
@@ -444,7 +446,7 @@ duns_create_lustre_path(daos_handle_t poh, const char *path,
 			prop = daos_prop_alloc(nr);
 			if (prop == NULL) {
 				D_ERROR("Failed to allocate container prop.");
-				D_GOTO(err, rc = -DER_NOMEM);
+				D_GOTO(err, rc = ENOMEM);
 			}
 			if (attrp->da_props != NULL) {
 				rc = daos_prop_copy(prop, attrp->da_props);
@@ -475,7 +477,7 @@ duns_create_lustre_path(daos_handle_t poh, const char *path,
 	len = sprintf(str, DUNS_XATTR_FMT, type, pool, cont);
 	if (len < DUNS_MIN_XATTR_LEN) {
 		D_ERROR("Failed to create LMV value\n");
-		D_GOTO(err_cont, rc = -DER_INVAL);
+		D_GOTO(err_cont, rc = EINVAL);
 	}
 
 	rc = (*dir_create_foreign)(path, S_IRWXU | S_IRWXG | S_IROTH | S_IWOTH,
@@ -483,7 +485,7 @@ duns_create_lustre_path(daos_handle_t poh, const char *path,
 	if (rc) {
 		D_ERROR("Failed to create Lustre dir '%s' with foreign "
 			"LMV '%s' (rc = %d).\n", path, str, rc);
-		D_GOTO(err_cont, rc = -DER_INVAL);
+		D_GOTO(err_cont, rc = EINVAL);
 	}
 
 	return rc;
@@ -508,7 +510,7 @@ duns_create_path(daos_handle_t poh, const char *path, struct duns_attr_t *attrp)
 
 	if (path == NULL) {
 		D_ERROR("Invalid path\n");
-		return -DER_INVAL;
+		return EINVAL;
 	}
 
 	if (attrp->da_type == DAOS_PROP_CO_LAYOUT_HDF5) {
@@ -518,10 +520,11 @@ duns_create_path(daos_handle_t poh, const char *path, struct duns_attr_t *attrp)
 		fd = open(path, O_CREAT | O_EXCL,
 			  S_IRUSR | S_IWUSR | S_IRGRP | S_IWGRP | S_IROTH);
 		if (fd == -1) {
+			int err = errno;
+
 			D_ERROR("Failed to create file %s: %s\n", path,
 				strerror(errno));
-			/** TODO - convert errno to rc */
-			return -DER_INVAL;
+			return err;
 		}
 		close(fd);
 	} else if (attrp->da_type == DAOS_PROP_CO_LAYOUT_POSIX) {
@@ -532,8 +535,7 @@ duns_create_path(daos_handle_t poh, const char *path, struct duns_attr_t *attrp)
 		if (dir == NULL) {
 			D_ERROR("Failed copy path %s: %s\n", path,
 				strerror(errno));
-			/** TODO - convert errno to rc */
-			return -DER_NOMEM;
+			return ENOMEM;
 		}
 
 		/* dirname() may modify dir content or not, so use an
@@ -542,11 +544,12 @@ duns_create_path(daos_handle_t poh, const char *path, struct duns_attr_t *attrp)
 		dirp = dirname(dir);
 		rc = statfs(dirp, &fs);
 		if (rc == -1) {
+			int err = errno;
+
 			D_ERROR("Failed to statfs dir %s: %s\n",
 				dirp, strerror(errno));
-			/** TODO - convert errno to rc */
 			free(dir);
-			return -DER_INVAL;
+			return err;
 		}
 		free(dir);
 
@@ -568,14 +571,15 @@ duns_create_path(daos_handle_t poh, const char *path, struct duns_attr_t *attrp)
 		/** create a new directory if POSIX/MPI-IO container */
 		rc = mkdir(path, S_IRWXU | S_IRWXG | S_IROTH | S_IXOTH);
 		if (rc == -1) {
+			int err = errno;
+
 			D_ERROR("Failed to create dir %s: %s\n",
 				path, strerror(errno));
-			/** TODO - convert errno to rc */
-			return -DER_INVAL;
+			return err;
 		}
 	} else {
 		D_ERROR("Invalid container layout.\n");
-		return -DER_INVAL;
+		return EINVAL;
 	}
 
 	uuid_unparse(attrp->da_puuid, pool);
@@ -604,7 +608,7 @@ duns_create_path(daos_handle_t poh, const char *path, struct duns_attr_t *attrp)
 		len = sprintf(str, DUNS_XATTR_FMT, type, pool, cont);
 		if (len < DUNS_MIN_XATTR_LEN) {
 			D_ERROR("Failed to create xattr value\n");
-			D_GOTO(err_link, rc = -DER_INVAL);
+			D_GOTO(err_link, rc = EINVAL);
 		}
 
 		rc = lsetxattr(path, DUNS_XATTR_NAME, str, len + 1, 0);
@@ -612,7 +616,7 @@ duns_create_path(daos_handle_t poh, const char *path, struct duns_attr_t *attrp)
 			int err = errno;
 
 			D_ERROR("Failed to set DAOS xattr (rc = %d).\n", err);
-			D_GOTO(err_link, rc = -DER_INVAL);
+			D_GOTO(err_link, rc = err);
 		}
 
 		if (attrp->da_type == DAOS_PROP_CO_LAYOUT_POSIX) {
@@ -635,7 +639,7 @@ duns_create_path(daos_handle_t poh, const char *path, struct duns_attr_t *attrp)
 			prop = daos_prop_alloc(nr);
 			if (prop == NULL) {
 				D_ERROR("Failed to allocate container prop.");
-				D_GOTO(err_link, rc = -DER_NOMEM);
+				D_GOTO(err_link, rc = ENOMEM);
 			}
 			if (attrp->da_props != NULL) {
 				rc = daos_prop_copy(prop, attrp->da_props);
@@ -667,14 +671,14 @@ duns_create_path(daos_handle_t poh, const char *path, struct duns_attr_t *attrp)
 
 				D_ERROR("Failed to set DAOS xattr (rc = %d).\n",
 					err);
-				D_GOTO(err_link, rc = -DER_IO);
+				D_GOTO(err_link, rc = err);
 			}
 		}
 
 	} while ((rc == -DER_EXIST) && try_multiple);
 	if (rc) {
 		D_ERROR("Failed to create container (%d)\n", rc);
-		D_GOTO(err_link, rc);
+		D_GOTO(err_link, rc = daos_der2errno(rc));
 	}
 
 	return rc;
@@ -705,7 +709,7 @@ duns_destroy_path(daos_handle_t poh, const char *path)
 	if (rc) {
 		D_ERROR("Failed to destroy container (%d)\n", rc);
 		/** recreate the link ? */
-		return rc;
+		return daos_der2errno(rc);
 	}
 
 	if (dattr.da_type == DAOS_PROP_CO_LAYOUT_HDF5) {
@@ -716,10 +720,12 @@ duns_destroy_path(daos_handle_t poh, const char *path)
 #endif
 			rc = unlink(path);
 		if (rc) {
+			int err = errno;
+
 			D_ERROR("Failed to unlink %sfile %s: %s\n",
 				dattr.da_on_lustre ? "Lustre " : " ", path,
 				strerror(errno));
-			return -DER_INVAL;
+			return err;
 		}
 	} else if (dattr.da_type == DAOS_PROP_CO_LAYOUT_POSIX) {
 #ifdef LUSTRE_INCLUDE
@@ -729,10 +735,12 @@ duns_destroy_path(daos_handle_t poh, const char *path)
 #endif
 			rc = rmdir(path);
 		if (rc) {
+			int err = errno;
+
 			D_ERROR("Failed to remove %sdir %s: %s\n",
 				dattr.da_on_lustre ? "Lustre " : " ", path,
 				strerror(errno));
-			return -DER_INVAL;
+			return err;
 		}
 	}
 

--- a/src/client/dfuse/ops/lookup.c
+++ b/src/client/dfuse/ops/lookup.c
@@ -145,8 +145,8 @@ check_for_uns_ep(struct dfuse_projection_info *fs_handle,
 		return rc;
 
 	rc = duns_parse_attr(&str[0], str_len, &dattr);
-	if (rc != -DER_SUCCESS)
-		return daos_der2errno(rc);
+	if (rc)
+		return rc;
 
 	if (dattr.da_type != DAOS_PROP_CO_LAYOUT_POSIX)
 		return ENOTSUP;

--- a/src/client/dfuse/ops/setxattr.c
+++ b/src/client/dfuse/ops/setxattr.c
@@ -39,8 +39,8 @@ dfuse_cb_setxattr(fuse_req_t req, struct dfuse_inode_entry *inode,
 		struct duns_attr_t	dattr = {};
 
 		rc = duns_parse_attr((char *)value, size, &dattr);
-		if (rc != -DER_SUCCESS)
-			D_GOTO(err, rc = daos_der2errno(rc));
+		if (rc)
+			D_GOTO(err, rc);
 
 		if (dattr.da_type != DAOS_PROP_CO_LAYOUT_POSIX)
 			D_GOTO(err, rc = ENOTSUP);

--- a/src/include/daos_uns.h
+++ b/src/include/daos_uns.h
@@ -74,7 +74,7 @@ struct duns_attr_t {
  *		attrp	Struct containing the attributes. The uuid of the
  *			container created is returned in da_cuuid.
  *
- * \return		0 on Success. Negative on Failure.
+ * \return		0 on Success. errno code on failure.
  */
 int
 duns_create_path(daos_handle_t poh, const char *path,
@@ -88,7 +88,7 @@ duns_create_path(daos_handle_t poh, const char *path,
  * \param[in]	path	Valid path in an existing namespace.
  * \param[out]	attr	Struct containing the xattrs on the path.
  *
- * \return		0 on Success. Negative on Failure.
+ * \return		0 on Success. errno code on failure.
  */
 int
 duns_resolve_path(const char *path, struct duns_attr_t *attr);
@@ -99,7 +99,7 @@ duns_resolve_path(const char *path, struct duns_attr_t *attr);
  * \param[in]	poh	Pool handle
  * \param[in]	path	Valid path in an existing namespace.
  *
- * \return		0 on Success. Negative on Failure.
+ * \return		0 on Success. errno code on failure.
  */
 int
 duns_destroy_path(daos_handle_t poh, const char *path);
@@ -111,7 +111,7 @@ duns_destroy_path(daos_handle_t poh, const char *path);
  * \param[in]	len	Length of input string
  * \param[out]	attr	Struct containing the xattrs on the path.
  *
- * \return		0 on Success. Negative on Failure.
+ * \return		0 on Success. errno code on failure.
  */
 int
 duns_parse_attr(char *str, daos_size_t len, struct duns_attr_t *attr);

--- a/src/utils/daos_hdlr.c
+++ b/src/utils/daos_hdlr.c
@@ -1072,7 +1072,7 @@ cont_create_uns_hdlr(struct cmd_args_s *ap)
 
 	rc = duns_create_path(ap->pool, ap->path, &dattr);
 	if (rc) {
-		fprintf(stderr, "duns_create_path() error: rc=%d\n", rc);
+		fprintf(stderr, "duns_create_path() error: %s\n", strerror(rc));
 		D_GOTO(err_rc, rc);
 	}
 
@@ -1156,8 +1156,8 @@ cont_destroy_hdlr(struct cmd_args_s *ap)
 	if (ap->path) {
 		rc = duns_destroy_path(ap->pool, ap->path);
 		if (rc)
-			fprintf(stderr, "duns_destroy_path() failed %s (%d)\n",
-				ap->path, rc);
+			fprintf(stderr, "duns_destroy_path() failed %s (%s)\n",
+				ap->path, strerror(rc));
 		else
 			fprintf(stdout, "Successfully destroyed path %s\n",
 				ap->path);


### PR DESCRIPTION
To better align with middleware using the duns, return positive errno
which matches what DFS does and what dfuse expects too.

Signed-off-by: Mohamad Chaarawi <mohamad.chaarawi@intel.com>