### PR TITLE
DAOS-4758 rsvc: Fix some RSVC_START DER_HGs

### DIFF
--- a/src/cart/src/cart/crt_rpc.h
+++ b/src/cart/src/cart/crt_rpc.h
@@ -1,4 +1,4 @@
-/* Copyright (C) 2016-2019 Intel Corporation
+/* Copyright (C) 2016-2020 Intel Corporation
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/cart/src/cart/crt_rpc.h
+++ b/src/cart/src/cart/crt_rpc.h
@@ -72,7 +72,7 @@ struct crt_corpc_hdr {
 	d_string_t		 coh_grpid;
 	/* collective bulk handle */
 	crt_bulk_t		 coh_bulk_hdl;
-	/* optional excluded or exclusive ranks */
+	/* optional filter ranks (see crt_corpc_req_create) */
 	d_rank_list_t		*coh_filter_ranks;
 	/* optional inline ranks, for example piggyback the group members */
 	d_rank_list_t		*coh_inline_ranks;
@@ -119,7 +119,7 @@ typedef enum {
 /* corpc info to track the tree topo and child RPCs info */
 struct crt_corpc_info {
 	struct crt_grp_priv	*co_grp_priv;
-	/* excluded or exclusive ranks */
+	/* filter ranks (see crt_corpc_req_create) */
 	d_rank_list_t		*co_filter_ranks;
 	uint32_t		 co_grp_ver;
 	uint32_t		 co_tree_topo;

--- a/src/cart/src/cart/crt_tree.c
+++ b/src/cart/src/cart/crt_tree.c
@@ -45,7 +45,7 @@
 
 static int
 crt_get_filtered_grp_rank_list(struct crt_grp_priv *grp_priv, uint32_t grp_ver,
-			       bool exclusive, d_rank_list_t *filter_ranks,
+			       bool filter_invert, d_rank_list_t *filter_ranks,
 			       d_rank_t root, d_rank_t self, d_rank_t *grp_size,
 			       uint32_t *grp_root, d_rank_t *grp_self,
 			       d_rank_list_t **result_grp_rank_list,
@@ -65,11 +65,11 @@ crt_get_filtered_grp_rank_list(struct crt_grp_priv *grp_priv, uint32_t grp_ver,
 	D_ASSERT(grp_rank_list != NULL);
 	*allocated = true;
 
-	if (exclusive) {
+	if (filter_invert) {
 		d_rank_list_filter(filter_ranks, grp_rank_list,
 				   false /* exclude */);
 		if (grp_rank_list->rl_nr != filter_ranks->rl_nr) {
-			D_ERROR("%u/%u exclusive ranks out of group\n",
+			D_ERROR("%u/%u filter ranks (inverted) out of group\n",
 				filter_ranks->rl_nr - grp_rank_list->rl_nr,
 				filter_ranks->rl_nr);
 			d_rank_list_free(grp_rank_list);
@@ -162,7 +162,7 @@ crt_tree_get_nchildren(struct crt_grp_priv *grp_priv, uint32_t grp_ver,
 	 * for building the tree, rank number in it is for primary group.
 	 */
 	rc = crt_get_filtered_grp_rank_list(grp_priv, grp_ver,
-					    false /* exclusive */,
+					    false /* filter_invert */,
 					    exclude_ranks, root, self,
 					    &grp_size, &grp_root, &grp_self,
 					    &grp_rank_list, &allocated);
@@ -202,7 +202,7 @@ out:
  */
 int
 crt_tree_get_children(struct crt_grp_priv *grp_priv, uint32_t grp_ver,
-		      bool exclusive, d_rank_list_t *filter_ranks,
+		      bool filter_invert, d_rank_list_t *filter_ranks,
 		      int tree_topo, d_rank_t root, d_rank_t self,
 		      d_rank_list_t **children_rank_list, bool *ver_match)
 {
@@ -238,7 +238,7 @@ crt_tree_get_children(struct crt_grp_priv *grp_priv, uint32_t grp_ver,
 	 * grp_rank_list is the target group (after applying filter_ranks)
 	 * for building the tree, rank number in it is for primary group.
 	 */
-	rc = crt_get_filtered_grp_rank_list(grp_priv, grp_ver, exclusive,
+	rc = crt_get_filtered_grp_rank_list(grp_priv, grp_ver, filter_invert,
 					    filter_ranks, root, self, &grp_size,
 					    &grp_root, &grp_self,
 					    &grp_rank_list, &allocated);
@@ -330,7 +330,7 @@ crt_tree_get_parent(struct crt_grp_priv *grp_priv, uint32_t grp_ver,
 	 * for building the tree, rank number in it is for primary group.
 	 */
 	rc = crt_get_filtered_grp_rank_list(grp_priv, grp_ver,
-					    false /* exclusive */,
+					    false /* filter_invert */,
 					    exclude_ranks, root, self,
 					    &grp_size, &grp_root, &grp_self,
 					    &grp_rank_list, &allocated);

--- a/src/cart/src/cart/crt_tree.h
+++ b/src/cart/src/cart/crt_tree.h
@@ -52,7 +52,7 @@ int crt_tree_get_nchildren(struct crt_grp_priv *grp_priv, uint32_t grp_ver,
 			   d_rank_t grp_root, d_rank_t grp_self,
 			   uint32_t *nchildren);
 int crt_tree_get_children(struct crt_grp_priv *grp_priv, uint32_t grp_ver,
-			  bool exclusive, d_rank_list_t *filter_ranks,
+			  bool filter_invert, d_rank_list_t *filter_ranks,
 			  int tree_topo, d_rank_t grp_root, d_rank_t grp_self,
 			  d_rank_list_t **children_rank_list, bool *ver_match);
 int crt_tree_get_parent(struct crt_grp_priv *grp_priv, uint32_t grp_ver,

--- a/src/cart/src/cart/crt_tree.h
+++ b/src/cart/src/cart/crt_tree.h
@@ -1,4 +1,4 @@
-/* Copyright (C) 2016-2017 Intel Corporation
+/* Copyright (C) 2016-2020 Intel Corporation
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/cart/src/include/cart/api.h
+++ b/src/cart/src/include/cart/api.h
@@ -1194,17 +1194,19 @@ crt_group_rank_s2p(crt_group_t *subgrp, d_rank_t rank_in, d_rank_t *rank_out);
  *
  * \param[in] crt_ctx          CRT context
  * \param[in] grp              CRT group for the collective RPC
- * \param[in] filter_ranks     optional excluded or exclusive ranks. the RPC
+ * \param[in] filter_ranks     optional filter ranks. By default, the RPC
  *                             will be delivered to all members in the group
- *                             except or exclusively to those in ranks.
- *                             the ranks are numbered in primary group.
+ *                             except those in \a filter_ranks. If \a flags
+ *                             includes CRT_RPC_FLAG_FILTER_INVERT, the RPC
+ *                             will be delivered to \a filter_ranks only.
+ *                             The ranks are numbered in primary group.
  * \param[in] opc              unique opcode for the RPC
  * \param[in] co_bulk_hdl      collective bulk handle
  * \param[in] priv             A private pointer associated with the request
  *                             will be passed to crt_corpc_ops::co_aggregate as
  *                             2nd parameter.
  * \param[in] flags            collective RPC flags:
- *                             CRT_RPC_FLAG_EXCLUSIVE to send exclusively to
+ *                             CRT_RPC_FLAG_FILTER_INVERT to send only to
  *                             \a filter_ranks.
  * \param[in] tree_topo        tree topology for the collective propagation,
  *                             can be calculated by crt_tree_topo().

--- a/src/cart/src/include/cart/types.h
+++ b/src/cart/src/include/cart/types.h
@@ -171,8 +171,8 @@ typedef void *crt_bulk_array_t; /**< abstract bulk array handle */
 
 /** RPC flags enumeration */
 enum crt_rpc_flags {
-	/** send CORPC exclusively to a specified set of ranks */
-	CRT_RPC_FLAG_EXCLUSIVE		= (1U << 1)
+	/** send CORPC to filter_ranks only */
+	CRT_RPC_FLAG_FILTER_INVERT	= (1U << 1)
 };
 
 struct crt_rpc;

--- a/src/cart/src/test/test_corpc_exclusive.c
+++ b/src/cart/src/test/test_corpc_exclusive.c
@@ -36,7 +36,8 @@
  * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 /**
- * Basic CORPC test to check CRT_FLAG_RPC_EXCLUSIVE flag. Test assumes 5 ranks.
+ * Basic CORPC test to check CRT_FLAG_RPC_FILTER_INVERT flag. Test assumes 5
+ * ranks.
  * CORPC with 'shutdown' is sent to 3 ranks, 1,2 and 4.
  * Ranks0 and 3 are expected to not receive this call.
  */
@@ -219,7 +220,7 @@ int main(void)
 		rc = crt_corpc_req_create(g_main_ctx, NULL, &membs,
 			CRT_PROTO_OPC(TEST_CORPC_PREFWD_BASE,
 				TEST_CORPC_PREFWD_VER, 0), NULL, 0,
-			CRT_RPC_FLAG_EXCLUSIVE,
+			CRT_RPC_FLAG_FILTER_INVERT,
 			crt_tree_topo(CRT_TREE_KNOMIAL, 4), &rpc);
 		assert(rc == 0);
 

--- a/src/mgmt/srv_pool.c
+++ b/src/mgmt/srv_pool.c
@@ -394,7 +394,7 @@ ds_mgmt_create_pool(uuid_t pool_uuid, const char *group, char *tgt_dev,
 			      DAOS_MGMT_VERSION);
 	rc = crt_corpc_req_create(dss_get_module_info()->dmi_ctx, NULL,
 				  rank_list, opc, NULL, NULL,
-				  CRT_RPC_FLAG_EXCLUSIVE, topo, &tc_req);
+				  CRT_RPC_FLAG_FILTER_INVERT, topo, &tc_req);
 	if (rc)
 		goto out_preparation;
 

--- a/src/mgmt/srv_pool.c
+++ b/src/mgmt/srv_pool.c
@@ -1,5 +1,5 @@
-/**
- * (C) Copyright 2016-2019 Intel Corporation.
+/*
+ * (C) Copyright 2016-2020 Intel Corporation.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,9 +20,12 @@
  * Any reproduction of computer software, computer software documentation, or
  * portions thereof marked with this legend must also reproduce the markings.
  */
-/*
+/**
+ * \file
+ *
  * ds_mgmt: Pool Methods
  */
+
 #define D_LOGFAC	DD_FAC(mgmt)
 
 #include <daos_srv/pool.h>

--- a/src/rsvc/rpc.h
+++ b/src/rsvc/rpc.h
@@ -1,5 +1,5 @@
-/**
- * (C) Copyright 2016-2019 Intel Corporation.
+/*
+ * (C) Copyright 2016-2020 Intel Corporation.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,6 +21,8 @@
  * portions thereof marked with this legend must also reproduce the markings.
  */
 /**
+ * \file
+ *
  * ds_rsvc: RPC Protocol Definitions
  */
 

--- a/src/rsvc/rpc.h
+++ b/src/rsvc/rpc.h
@@ -81,8 +81,7 @@ CRT_RPC_DECLARE(rsvc_start, DAOS_ISEQ_RSVC_START, DAOS_OSEQ_RSVC_START)
 #define DAOS_ISEQ_RSVC_STOP /* input fields */			 \
 	((d_iov_t)		(soi_svc_id)		CRT_VAR) \
 	((uint32_t)		(soi_class)		CRT_VAR) \
-	((uint32_t)		(soi_flags)		CRT_VAR) \
-	((d_rank_list_t)	(soi_ranks)		CRT_PTR)
+	((uint32_t)		(soi_flags)		CRT_VAR)
 
 #define DAOS_OSEQ_RSVC_STOP /* output fields */			 \
 	((int32_t)		(soo_rc)		CRT_VAR)

--- a/src/rsvc/srv.c
+++ b/src/rsvc/srv.c
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright 2019 Intel Corporation.
+ * (C) Copyright 2019-2020 Intel Corporation.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/rsvc/srv.c
+++ b/src/rsvc/srv.c
@@ -1026,18 +1026,25 @@ enum rdb_stop_flag {
 	RDB_OF_DESTROY		= 0x1
 };
 
+/*
+ * Create a bcast in the primary group. If filter_invert is false, bcast to the
+ * whole primary group filtering out filter_ranks; otherwise, bcast to
+ * filter_ranks only.
+ */
 static int
-bcast_create(crt_opcode_t opc, crt_group_t *group, d_rank_list_t *excluded,
+bcast_create(crt_opcode_t opc, bool filter_invert, d_rank_list_t *filter_ranks,
 	     crt_rpc_t **rpc)
 {
 	struct dss_module_info *info = dss_get_module_info();
 	crt_opcode_t		opc_full;
 
+	D_ASSERT(!filter_invert || filter_ranks != NULL);
 	opc_full = DAOS_RPC_OPCODE(opc, DAOS_RSVC_MODULE, DAOS_RSVC_VERSION);
-	return crt_corpc_req_create(info->dmi_ctx, group,
-				    excluded /* excluded_ranks */, opc_full,
+	return crt_corpc_req_create(info->dmi_ctx, NULL /* grp */,
+				    filter_ranks, opc_full,
 				    NULL /* co_bulk_hdl */, NULL /* priv */,
-				    0 /* flags */,
+				    filter_invert ?
+				    CRT_RPC_FLAG_FILTER_INVERT : 0,
 				    crt_tree_topo(CRT_TREE_FLAT, 0), rpc);
 }
 
@@ -1055,24 +1062,21 @@ bcast_create(crt_opcode_t opc, crt_group_t *group, d_rank_list_t *excluded,
  * \param[in]	size		size of each replica in bytes if \a create
  */
 int
-ds_rsvc_dist_start(enum ds_rsvc_class_id class, d_iov_t *id,
-		   const uuid_t dbid, const d_rank_list_t *ranks, bool create,
-		   bool bootstrap, size_t size)
+ds_rsvc_dist_start(enum ds_rsvc_class_id class, d_iov_t *id, const uuid_t dbid,
+		   const d_rank_list_t *ranks, bool create, bool bootstrap,
+		   size_t size)
 {
 	crt_rpc_t		*rpc;
 	struct rsvc_start_in	*in;
 	struct rsvc_start_out	*out;
 	int			 rc;
 
-	D_ASSERT(!create || ranks != NULL);
+	D_ASSERT(!bootstrap || ranks != NULL);
 	D_DEBUG(DB_MD, DF_UUID": %s DB\n",
 		DP_UUID(dbid), create ? "creating" : "starting");
 
-	/*
-	 * If ranks doesn't include myself, creating a group with ranks will
-	 * fail; bcast to the primary group instead.
-	 */
-	rc = bcast_create(RSVC_START, NULL /* group */, NULL, &rpc);
+	rc = bcast_create(RSVC_START, ranks != NULL /* filter_invert */,
+			  (d_rank_list_t *)ranks, &rpc);
 	if (rc != 0)
 		goto out;
 	in = crt_req_get(rpc);
@@ -1116,28 +1120,18 @@ ds_rsvc_start_handler(crt_rpc_t *rpc)
 	struct rsvc_start_in	*in = crt_req_get(rpc);
 	struct rsvc_start_out	*out = crt_reply_get(rpc);
 	bool			 create = in->sai_flags & RDB_AF_CREATE;
+	bool			 bootstrap = in->sai_flags & RDB_AF_BOOTSTRAP;
 	int			 rc;
 
-	if (create && in->sai_ranks == NULL) {
+	if (bootstrap && in->sai_ranks == NULL) {
 		rc = -DER_PROTO;
 		goto out;
 	}
 
-	if (in->sai_ranks != NULL) {
-		d_rank_t	rank;
-		int		i;
-
-		/* Do nothing if I'm not one of the replicas. */
-		rc = crt_group_rank(NULL /* grp */, &rank);
-		D_ASSERTF(rc == 0, ""DF_RC"\n", DP_RC(rc));
-		if (!daos_rank_list_find(in->sai_ranks, rank, &i))
-			goto out;
-	}
-
 	rc = ds_rsvc_start(in->sai_class, &in->sai_svc_id, in->sai_db_uuid,
 			   create, in->sai_size,
-			   (in->sai_flags & RDB_AF_BOOTSTRAP) ?
-			   in->sai_ranks : NULL, NULL /* arg */);
+			   bootstrap ? in->sai_ranks : NULL, NULL /* arg */);
+
 out:
 	out->sao_rc_errval = rc;
 	out->sao_rc = (rc == 0 ? 0 : 1);
@@ -1189,11 +1183,12 @@ ds_rsvc_dist_stop(enum ds_rsvc_class_id class, d_iov_t *id,
 	struct rsvc_stop_out	*out;
 	int			 rc;
 
-	/*
-	 * If ranks doesn't include myself, creating a group with ranks will
-	 * fail; bcast to the primary group instead.
-	 */
-	rc = bcast_create(RSVC_STOP, NULL /* group */, excluded, &rpc);
+	/* No "ranks != NULL && excluded != NULL" use case currently. */
+	D_ASSERT(ranks == NULL || excluded == NULL);
+
+	rc = bcast_create(RSVC_STOP, ranks != NULL /* filter_invert */,
+			  ranks != NULL ? (d_rank_list_t *)ranks : excluded,
+			  &rpc);
 	if (rc != 0)
 		goto out;
 	in = crt_req_get(rpc);
@@ -1203,7 +1198,6 @@ ds_rsvc_dist_stop(enum ds_rsvc_class_id class, d_iov_t *id,
 		goto out_rpc;
 	if (destroy)
 		in->soi_flags |= RDB_OF_DESTROY;
-	in->soi_ranks = (d_rank_list_t *)ranks;
 
 	rc = dss_rpc_send(rpc);
 	if (rc != 0)
@@ -1232,20 +1226,8 @@ ds_rsvc_stop_handler(crt_rpc_t *rpc)
 	struct rsvc_stop_out	*out = crt_reply_get(rpc);
 	int			 rc = 0;
 
-	if (in->soi_ranks != NULL) {
-		d_rank_t	rank;
-		int		i;
-
-		/* Do nothing if I'm not one of the replicas. */
-		rc = crt_group_rank(NULL /* grp */, &rank);
-		D_ASSERTF(rc == 0, ""DF_RC"\n", DP_RC(rc));
-		if (!daos_rank_list_find(in->soi_ranks, rank, &i))
-			goto out;
-	}
-
 	rc = ds_rsvc_stop(in->soi_class, &in->soi_svc_id,
 			  in->soi_flags & RDB_OF_DESTROY);
-out:
 	out->soo_rc = (rc == 0 || rc == -DER_ALREADY ? 0 : 1);
 	crt_reply_send(rpc);
 }


### PR DESCRIPTION
ds_rsvc_dist_start bcasts to the whole primary group, relying on
recipients who don't belong to the ranks parameter to ignore the bcast.
If the ranks parameter is {0, 1}, but rank 2 is unavailable, then
ds_rsvc_dist_start will return -DER_HG unnecessarily. This patch adopts
the new CRT_RPC_FLAG_EXCLUSIVE flag to create CoRPCs targeting
exclusively at {0, 1} in the example, so that they won't be affected by
other ranks:

  - RSVC_START no longer needs to check whether a recipient belongs to
    sai_ranks.
  - RSVC_STOP no longer needs soi_ranks in the request.

Also:

  - RSVC_START should assert that sai_ranks must not be NULL, if
    bootstrap, rather than create, is true.
  - Rename CRT_RPC_FLAG_EXCLUSIVE, which turns out to be confusing, to
    CRT_RPC_FLAG_FILTER_INVERT.

Signed-off-by: Li Wei <wei.g.li@intel.com>