### PR TITLE
DAOS-4614 tests: Fixing bandit check subprocess errors

### DIFF
--- a/ftest.sh
+++ b/ftest.sh
@@ -404,7 +404,7 @@ enabled=0
 EOF\"
 
 # now run it!
-if ! ./launch.py -crispav -ts ${TEST_NODES} ${NVME_ARG} ${TEST_TAG_ARR[*]}; then
+if ! ./launch.py -crispa -ts ${TEST_NODES} ${NVME_ARG} ${TEST_TAG_ARR[*]}; then
     rc=\${PIPESTATUS[0]}
 else
     rc=0

--- a/ftest.sh
+++ b/ftest.sh
@@ -404,7 +404,7 @@ enabled=0
 EOF\"
 
 # now run it!
-if ! ./launch.py -crispa -ts ${TEST_NODES} ${NVME_ARG} ${TEST_TAG_ARR[*]}; then
+if ! ./launch.py -crispav -ts ${TEST_NODES} ${NVME_ARG} ${TEST_TAG_ARR[*]}; then
     rc=\${PIPESTATUS[0]}
 else
     rc=0

--- a/src/rdb/raft_tests/raft_tests.py
+++ b/src/rdb/raft_tests/raft_tests.py
@@ -44,13 +44,13 @@ def number_of_failures():
     successes = 0
     if not os.path.isfile(os.path.join("build", DIR, "src", "tests_main")):
         try:
-            res = subprocess.check_output(['make', '-C', DIR, 'tests'])
+            res = subprocess.check_output(['/usr/bin/make', '-C', DIR, 'tests'])
         except Exception as e:
             print("Building Raft Tests failed due to\n{}".format(e))
             return TEST_NOT_RUN
     else:
         os.chdir(os.path.join("build", DIR, "src"))
-        res = subprocess.check_output("./tests_main", shell=True)
+        res = subprocess.check_output(["./tests_main"])
 
     for line in res.split('\n'):
         if line.startswith("not ok"):

--- a/src/tests/ftest/launch.py
+++ b/src/tests/ftest/launch.py
@@ -445,7 +445,7 @@ def get_test_list(tags):
             test_list.append(tag)
         else:
             # Otherwise it is assumed that this is a tag
-            test_tags.extend([" --filter-by-tags", str(tag)])
+            test_tags.extend(["--filter-by-tags", str(tag)])
 
     # Add to the list of tests any test that matches the specified tags.  If no
     # tags and no specific tests have been specified then all of the functional

--- a/src/tests/ftest/launch.py
+++ b/src/tests/ftest/launch.py
@@ -395,7 +395,7 @@ def find_values(obj, keys, key=None, val_type=list):
             [A, B, C]   [A, B, C, D]    [A, B, C, D]
 
         Args:
-            found (list): list of matches found
+            found (dict): dictionary of matches found for each key
         """
         for found_key in found:
             if found_key not in matches:
@@ -408,9 +408,9 @@ def find_values(obj, keys, key=None, val_type=list):
                     matches[found_key] = [matches[found_key]]
                 if isinstance(found[found_key], list):
                     for found_item in found[found_key]:
-                        if found_key not in matches:
+                        if found_item not in matches[found_key]:
                             matches[found_key].append(found_item)
-                elif found_key not in matches:
+                elif found[found_key] not in matches[found_key]:
                     matches[found_key].append(found[found_key])
 
                 if not is_list and len(matches[found_key]) == 1:

--- a/src/tests/ftest/launch.py
+++ b/src/tests/ftest/launch.py
@@ -227,20 +227,20 @@ def get_output(cmd):
     """Get the output of given command executed on this host.
 
     Args:
-        cmd (str): command from which to obtain the output
+        cmd (list): command from which to obtain the output
 
     Returns:
         str: command output
 
     """
     try:
-        print("Running {}".format(cmd))
-        return subprocess.check_output(
-            cmd, stderr=subprocess.STDOUT, shell=True)
+        print("Running {}".format(" ".join(cmd)))
+        return subprocess.check_output(cmd, stderr=subprocess.STDOUT)
 
     except subprocess.CalledProcessError as err:
-        print("Error executing '{}':\n\t{}\n\tOutput:\n{}".format(cmd, err,
-                                                                  err.output))
+        print(
+            "Error executing '{}':\n\t{}\n\tOutput:\n{}".format(
+                " ".join(cmd), err, err.output))
         exit(1)
 
 
@@ -248,15 +248,15 @@ def time_command(cmd):
     """Execute the command on this host and display its duration.
 
     Args:
-        cmd (str): command to time
+        cmd (list): command to time
 
     Returns:
         int: return code of the command
 
     """
-    print("Running {}".format(cmd))
+    print("Running {}".format(" ".join(cmd)))
     start_time = int(time.time())
-    return_code = subprocess.call(cmd, shell=True)
+    return_code = subprocess.call(cmd)
     end_time = int(time.time())
     print("Total test time: {}s".format(end_time - start_time))
     return return_code
@@ -424,7 +424,7 @@ def get_test_list(tags):
         tags (list): a list of tag or test file names
 
     Returns:
-        (str, list): a tuple of the avacado tag filter and lists of tests
+        (list, list): a tuple of an avacado tag filter list and lists of tests
 
     """
     test_tags = []
@@ -435,19 +435,20 @@ def get_test_list(tags):
             test_list.append(tag)
         else:
             # Otherwise it is assumed that this is a tag
-            test_tags.append(" --filter-by-tags={}".format(tag))
+            test_tags.extend([" --filter-by-tags", str(tag)])
 
     # Add to the list of tests any test that matches the specified tags.  If no
     # tags and no specific tests have been specified then all of the functional
     # tests will be added.
     if test_tags or not test_list:
-        command = " | ".join([
-            "avocado list --paginator off{} ./".format(" ".join(test_tags)),
-            r"sed -ne '/INSTRUMENTED/s/.* \([^:]*\):.*/\1/p'",
-            "uniq"])
-        test_list.extend(get_output(command).splitlines())
+        command = ["avocado", "list", "--paginator=off"]
+        for test_tag in test_tags:
+            command.append(str(test_tag))
+        command.append("./")
+        tagged_tests = re.findall(r"INSTRUMENTED\s+(.*):", get_output(command))
+        test_list.extend(list(set(tagged_tests)))
 
-    return " ".join(test_tags), test_list
+    return test_tags, test_list
 
 
 def get_test_files(test_list, args, tmp_dir):
@@ -702,7 +703,7 @@ def run_tests(test_files, tag_filter, args):
 
     Args:
         test_files (dict): a list of dictionaries of each test script/yaml file
-        tag_filter (str): the avocado tag filter command line argument
+        tag_filter (list): the avocado tag filter command line argument
         args (argparse.Namespace): command line arguments for this program
 
     Returns:
@@ -714,21 +715,23 @@ def run_tests(test_files, tag_filter, args):
     # Determine the location of the avocado logs for archiving or renaming
     avocado_logs_dir = None
     if args.archive or args.rename:
-        avocado_logs_dir = get_output(
-            "avocado config | sed -ne '/logs_dir/s/.*  *//p'").strip()
-        avocado_logs_dir = os.path.expanduser(avocado_logs_dir)
+        data = get_output(["avocado", "config"]).strip()
+        avocado_logs_dir = re.findall(r"datadir\.paths\.logs_dir\s+(.*)", data)
+        avocado_logs_dir = os.path.expanduser(avocado_logs_dir[0])
         print("Avocado logs stored in {}".format(avocado_logs_dir))
 
     # Create the base avocado run command
     command_list = [
         "avocado",
         "run",
-        "--ignore-missing-references on",
-        "--show-job-log" if not args.sparse else "",
-        "--html-job-result on",
-        "--tap-job-result=off",
-        tag_filter
+        "--ignore-missing-references", "on",
+        "--html-job-result", "on",
+        "--tap-job-result", "off",
     ]
+    if not args.sparse:
+        command_list.append("--show-job-log")
+    if tag_filter:
+        command_list.extend(tag_filter)
 
     # Run each test
     for test_file in test_files:
@@ -741,12 +744,11 @@ def run_tests(test_files, tag_filter, args):
 
             # Execute this test
             test_command_list = list(command_list)
-            test_command_list.append("--mux-yaml {}".format(test_file["yaml"]))
-            test_command_list.append("-- {}".format(test_file["py"]))
-            return_code |= time_command(
-                " ".join([item for item in test_command_list if item != ""]))
+            test_command_list.extend([
+                "--mux-yaml", test_file["yaml"], "--", test_file["py"]])
+            return_code |= time_command(test_command_list)
 
-            # Optionally store all of the doas server and client log files
+            # Optionally store all of the daos server and client log files
             # along with the test results
             if args.archive:
                 archive_logs(avocado_logs_dir, test_file["yaml"], args)
@@ -872,7 +874,7 @@ def archive_logs(avocado_logs_dir, test_yaml, args):
     # Create a subdirectory in the avocado logs directory for this test
     daos_logs_dir = os.path.join(avocado_logs_dir, "latest", "daos_logs")
     print("Archiving host logs from {} in {}".format(host_list, daos_logs_dir))
-    get_output("mkdir {}".format(daos_logs_dir))
+    get_output(["/usr/bin/mkdir", daos_logs_dir])
 
     # Copy any log files that exist on the test hosts and remove them from the
     # test host if the copy is successful.  Attempt all of the commands and
@@ -916,7 +918,7 @@ def archive_config_files(avocado_logs_dir):
     daos_logs_dir = os.path.join(avocado_logs_dir, "latest", "daos_configs")
     print(
         "Archiving config files from {} in {}".format(host_list, daos_logs_dir))
-    get_output("mkdir {}".format(daos_logs_dir))
+    get_output(["/usr/bin/mkdir", daos_logs_dir])
 
     # Archive any yaml configuration files.  Currently these are always written
     # to a shared directory for all of hosts.
@@ -961,17 +963,17 @@ def rename_logs(avocado_logs_dir, test_file):
 
 USE_DEBUGINFO_INSTALL = True
 
-def install_debuginfos():
-    """Install debuginfo packages"""
 
+def install_debuginfos():
+    """Install debuginfo packages."""
     install_pkgs = [{'name': 'gdb'}, {'name': 'python-magic'}]
     cmds = []
 
     if USE_DEBUGINFO_INSTALL:
-        cmds.append("sudo debuginfo-install -y "                   \
-                    "--exclude ompi-debuginfo,gcc-debuginfo,"      \
-                               "gcc-base-debuginfo "               \
-                    "daos-server cart libpmemobj python openmpi3")
+        cmds.extend([
+            "sudo", "debuginfo-install", "-y",
+            "--exclude", "ompi-debuginfo,gcc-debuginfo,gcc-base-debuginfo",
+            "daos-server", "cart", "libpmemobj", "python", "openmpi3"])
     else:
         import yum
 
@@ -985,8 +987,8 @@ def install_debuginfos():
 
         # We're not using the yum API to install packages
         # See the comments below.
-        #kwarg = {'name': 'gdb'}
-        #yum_base.install(**kwarg)
+        # kwarg = {'name': 'gdb'}
+        # yum_base.install(**kwarg)
 
         for pkg in ['python', 'glibc', 'daos', 'systemd', 'ndctl', 'libpmem',
                     'mercury', 'cart', 'libfabric', 'argobots']:
@@ -1005,10 +1007,10 @@ def install_debuginfos():
                     raise
             # This is how you actually use the API to add a package
             # But since we need sudo to do it, we need to call out to yum
-            #kwarg = {'name': debug_pkg,
+            # kwarg = {'name': debug_pkg,
             #         'version': pkg_data['version'],
             #         'release': pkg_data['release']}
-            #yum_base.install(**kwarg)
+            # yum_base.install(**kwarg)
             install_pkgs.append({'name': debug_pkg,
                                  'version': pkg_data['version'],
                                  'release': pkg_data['release'],
@@ -1016,19 +1018,19 @@ def install_debuginfos():
 
     # This is how you normally finish up a yum transaction, but
     # again, we need to employ sudo
-    #yum_base.resolveDeps()
-    #yum_base.buildTransaction()
-    #yum_base.processTransaction(rpmDisplay=yum.rpmtrans.NoOutputCallBack())
-    cmd = "sudo yum -y --enablerepo=\\*debug\\* install"
+    # yum_base.resolveDeps()
+    # yum_base.buildTransaction()
+    # yum_base.processTransaction(rpmDisplay=yum.rpmtrans.NoOutputCallBack())
+    cmds.extend(["sudo", "yum", "-y", "--enablerepo=\\*debug\\*", "install"])
     for pkg in install_pkgs:
         try:
-            cmd += " {}-{}-{}".format(pkg['name'], pkg['version'],
-                                      pkg['release'])
+            cmds.append(
+                "{}-{}-{}".format(pkg['name'], pkg['version'], pkg['release']))
         except KeyError:
             cmd += " {}".format(pkg['name'])
     cmds.append(cmd)
 
-    print(get_output(';'.join(cmds)))
+    print(get_output(cmds))
 
 
 def process_the_cores(avocado_logs_dir, test_yaml, args):
@@ -1047,7 +1049,7 @@ def process_the_cores(avocado_logs_dir, test_yaml, args):
 
     # Create a subdirectory in the avocado logs directory for this test
     print("Processing cores from {} in {}".format(host_list, daos_cores_dir))
-    get_output("mkdir {}".format(daos_cores_dir))
+    get_output(["/usr/bin/mkdir", daos_cores_dir])
 
     # Copy any core files that exist on the test hosts and remove them from the
     # test host if the copy is successful.  Attempt all of the commands and
@@ -1102,12 +1104,18 @@ def process_the_cores(avocado_logs_dir, test_yaml, args):
             exe_name_start = exe_type.find("execfn: '") + 9
             exe_name_end = exe_type.find("', platform:")
             exe_name = exe_type[exe_name_start:exe_name_end]
-            get_output('cd {0} && gdb -ex "set pagination off" \
-                            -ex "thread apply all bt full"     \
-                            -ex "detach"                       \
-                            -ex "quit"                         \
-                        {1} {2} > {2}.stacktrace'.format(
-                            daos_cores_dir, exe_name, corefile))
+            cmd = [
+                "gdb", "-cd={}".format(daos_cores_dir),
+                "-ex", "\"set pagination off\"",
+                "-ex", "\"thread apply all bt full\"",
+                "-ex", "\"detach\"",
+                "-ex", "\"quit\"",
+                exe_name, corefile
+            ]
+            stack_trace_file = os.path.join(
+                daos_cores_dir, "{}.stacktrace".format(corefile))
+            with open(stack_trace_file, "w") as stack_trace:
+                stack_trace.writelines(get_output(cmd))
             print("Removing {}".format(corefile_fqpn))
             os.unlink(corefile_fqpn)
 

--- a/src/tests/ftest/metrics.py
+++ b/src/tests/ftest/metrics.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python2
-'''
-  (C) Copyright 2018-2019 Intel Corporation.
+"""
+  (C) Copyright 2018-2020 Intel Corporation.
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
@@ -20,7 +20,7 @@
   provided in Contract No. B609815.
   Any reproduction of computer software, computer software documentation, or
   portions thereof marked with this legend must also reproduce the markings.
-'''
+"""
 from __future__ import print_function
 
 import os
@@ -32,13 +32,19 @@ from jira import JIRA
 
 
 def filelist(directory):
-    """
-    Create a list of test files contained in the provided path.
+    """Create a list of test files contained in the provided path.
+
     This is meant to deal primarily with the structure of tests
     in the daos repo and would need to be changed to deal with
     random directory trees of tests.
-    """
 
+    Args:
+        directory (str): directory from which to create a list of files
+
+    Returns:
+        list: list of files in the directory
+
+    """
     local_test_files = []
     test_pattern = "*.py"
 
@@ -49,12 +55,12 @@ def filelist(directory):
                     local_test_files.append(os.path.join(path, test_file))
     return local_test_files
 
+
 def yamlforpy(path):
-    """
-    Create the name of the yaml file for a given test file.
-    """
+    """Create the name of the yaml file for a given test file."""
     (base, _ext) = os.path.splitext(path)
     return base + ".yaml"
+
 
 if __name__ == "__main__":
 
@@ -68,13 +74,15 @@ if __name__ == "__main__":
     variants = 0
     print("working ")
     for _file in test_files:
-        cmd1 = "avocado list {}".format(_file)
-        output = subprocess.check_output(cmd1, shell=True)
+        cmd1 = ["avocado", "list", _file]
+        output = subprocess.check_output(cmd1)
         tests += len(output.splitlines())
         yamlfile = yamlforpy(_file)
-        cmd2 = (
-            "avocado variants -m {} --summary 0 --variants 1".format(yamlfile))
-        output = subprocess.check_output(cmd2, shell=True)
+        cmd2 = [
+            "avocado", "variants", "-m", yamlfile, "--summary", "0",
+            "--variants", "1"
+        ]
+        output = subprocess.check_output(cmd2)
         variants += len(output.splitlines())
         print(".")
         sys.stdout.flush()

--- a/src/tests/ftest/unittest/unittest.py
+++ b/src/tests/ftest/unittest/unittest.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python
-'''
-  (C) Copyright 2018-2019 Intel Corporation.
+"""
+  (C) Copyright 2018-2020 Intel Corporation.
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
@@ -20,37 +20,34 @@
   provided in Contract No. B609815.
   Any reproduction of computer software, computer software documentation, or
   portions thereof marked with this legend must also reproduce the markings.
-'''
-from avocado.utils import process
-from general_utils import get_file_path
-from apricot import Test, TestWithServers, skipForTicket
+"""
+from general_utils import get_file_path, run_command
+from apricot import Test, skipForTicket
+
 
 def unittest_runner(self, unit_testname):
-    """
-    Common unitetest runner function.
+    """Run a unit test.
 
     Unit tests needs to be run on local machine incase of server start required
     For other unit tests, which does not required to start server,it needs to be
     run on server where /mnt/daos mounted.
 
     Args:
-        unit_testname: unittest name.
-    return:
-        None
+        unit_testname (str): unittest name.
     """
     name = self.params.get("testname", '/run/UnitTest/{0}/'
                            .format(unit_testname))
     server = self.params.get("test_servers", "/run/hosts/*")
     bin_path = get_file_path(name, "install/bin")
 
-    cmd = ("ssh {} {}".format(server[0], bin_path[0]))
+    cmd = ("/usr/bin/ssh {} {}".format(server[0], bin_path[0]))
 
-    return_code = process.system(cmd, ignore_status=True,
-                                 allow_output_check="both")
+    result = run_command(cmd, raise_exception=False, output_check="both")
 
-    if return_code != 0:
+    if result.exit_status != 0:
         self.fail("{0} unittest failed with return code={1}.\n"
-                  .format(unit_testname, return_code))
+                  .format(unit_testname, result.exit_status))
+
 
 class UnitTestWithoutServers(Test):
     """

--- a/src/tests/ftest/util/agent_utils.py
+++ b/src/tests/ftest/util/agent_utils.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python
-'''
-  (C) Copyright 2019 Intel Corporation.
+"""
+  (C) Copyright 2019-2020 Intel Corporation.
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
@@ -20,7 +20,7 @@
   provided in Contract No. B609815.
   Any reproduction of computer software, computer software documentation, or
   portions thereof marked with this legend must also reproduce the markings.
-'''
+"""
 from __future__ import print_function
 
 import os
@@ -208,7 +208,7 @@ def run_agent(test, server_list, client_list=None):
 
     for client in client_list:
         sessions[client] = subprocess.Popen(
-            ["ssh", client, "-o ConnectTimeout=10",
+            ["/usr/bin/ssh", client, "-o ConnectTimeout=10",
              "{} -i".format(daos_agent_cmd)],
             stdout=subprocess.PIPE,
             stderr=subprocess.STDOUT

--- a/src/tests/ftest/util/apricot/apricot/test.py
+++ b/src/tests/ftest/util/apricot/apricot/test.py
@@ -32,7 +32,6 @@ import re
 
 from avocado import Test as avocadoTest
 from avocado import skip, TestFail
-from avocado.utils import process
 from ClusterShell.NodeSet import NodeSet, NodeSetParseError
 
 import fault_config_utils
@@ -45,6 +44,7 @@ from pydaos.raw import DaosContext, DaosLog, DaosApiError
 from env_modules import load_mpi
 from distutils.spawn import find_executable
 from dmg_utils import DmgCommand
+from general_utils import DaosTestError, run_command
 from test_utils_pool import TestPool
 
 
@@ -513,10 +513,9 @@ class TestWithServers(TestWithoutServers):
         partiton_name = self.params.get(partition_key, "/run/hosts/*")
         if partiton_name is not None:
             cmd = "scontrol show partition {}".format(partiton_name)
-
             try:
-                result = process.run(cmd, shell=True, timeout=10)
-            except process.CmdError as error:
+                result = run_command(cmd, timeout=10)
+            except DaosTestError as error:
                 self.log.warning(
                     "Unable to obtain hosts from the {} slurm "
                     "partition: {}".format(partiton_name, error))

--- a/src/tests/ftest/util/check_for_pool.py
+++ b/src/tests/ftest/util/check_for_pool.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python
-'''
-  (C) Copyright 2017-2019 Intel Corporation.
+"""
+  (C) Copyright 2017-2020 Intel Corporation.
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
@@ -20,36 +20,39 @@
   provided in Contract No. B609815.
   Any reproduction of computer software, computer software documentation, or
   portions thereof marked with this legend must also reproduce the markings.
-'''
+"""
 from __future__ import print_function
 
-import subprocess
+from general_utils import run_command
+
 
 def check_for_pool(host, uuid):
-    """
-    Function to check if pool folder exist on server
+    """Check if pool folder exist on server.
+
     Args:
-        host: Server host name
-        uuid: Pool uuid to check if exists
-    return:
-        resp: subprocess return code
+        host (str): Server host name
+        uuid (str): Pool uuid to check if exists
+
+    Returns:
+        int: subprocess return code
+
     """
-    cmd = "test -e /mnt/daos/" + uuid
-    resp = subprocess.call(["ssh", host, cmd])
-    if resp == 0:
-        print ('%s exists' %uuid)
+    cmd = "/usr/bin/ssh {} test -e /mnt/daos/{}".format(host, uuid)
+    result = run_command(cmd, raise_exception=False)
+    if result.exit_status == 0:
+        print("{} exists".format(uuid))
     else:
-        print ('%s does not exist' %uuid)
-    return resp
+        print("{} does not exist".format(uuid))
+    return result.exit_status
+
 
 def cleanup_pools(hosts):
-    """
-    To cleanup the pool and content from /mnt/daps/
+    """Cleanup the pool and content from /mnt/daos/.
+
     Args:
         hosts[list]: Lists of servers name
     return"
         None
     """
     for host in hosts:
-        cmd = "rm -rf /mnt/daos/*"
-        subprocess.call(["ssh", host, cmd])
+        run_command("/usr/bin/ssh {} rm -rf /mnt/daos/*".format(host))

--- a/src/tests/ftest/util/daos_io_conf.py
+++ b/src/tests/ftest/util/daos_io_conf.py
@@ -23,11 +23,11 @@
 """
 import os
 import random
-from avocado.utils import process
 
 from apricot import TestWithServers
 from command_utils import ExecutableCommand, CommandFailure, FormattedParameter
 from command_utils import BasicParameter
+from general_utils import DaosTestError, run_command
 from test_utils_pool import TestPool
 
 
@@ -36,6 +36,7 @@ class IoConfGen(ExecutableCommand):
 
     :avocado: recursive
     """
+
     def __init__(self, path="", env=None):
         """Create a ExecutableCommand object.
 
@@ -68,28 +69,15 @@ class IoConfGen(ExecutableCommand):
         """
         command = " ".join([os.path.join(self._path, "daos_run_io_conf"),
                             self.filename.value])
-        kwargs = {
-            "cmd": command,
-            "timeout": self.timeout,
-            "verbose": self.verbose,
-            "allow_output_check": "combined",
-            "shell": True,
-            "env": self.env,
-            "sudo": self.sudo,
-        }
         try:
-            # Block until the command is complete or times out
-            return process.run(**kwargs)
+            run_command(command, self.timeout, self.verbose, env=self.env)
 
-        except process.CmdError as error:
-            # Command failed or possibly timed out
-            msg = "Error occurred running '{}': {}".format(command, error)
-            self.log.error(msg)
-            raise CommandFailure(msg)
+        except DaosTestError as error:
+            raise CommandFailure(error)
+
 
 def gen_unaligned_io_conf(record_size, filename="testfile"):
-    """
-    Generate the data-set file based on record size.
+    """Generate the data-set file based on record size.
 
     Args:
         record_size(Number): Record Size to fill the data.
@@ -122,6 +110,7 @@ def gen_unaligned_io_conf(record_size, filename="testfile"):
     except Exception as error:
         raise error
 
+
 class IoConfTestBase(TestWithServers):
     """Base rebuild test class.
 
@@ -134,30 +123,26 @@ class IoConfTestBase(TestWithServers):
         self.pool.get_params(self)
 
     def execute_io_conf_run_test(self):
-        """
-        Execute the rebuild test steps.
-        """
+        """Execute the rebuild test steps."""
         self.setup_test_pool()
         pool_env = {"POOL_SCM_SIZE": "{}".format(self.pool.scm_size)}
         io_conf = IoConfGen(os.path.join(self.prefix, "bin"), env=pool_env)
         io_conf.get_params(self)
         io_conf.run()
-        #Run test file using daos_run_io_conf
+        # Run test file using daos_run_io_conf
         io_conf.run_conf()
 
     def unaligned_io(self):
-        """
-        Execute the unaligned IO test steps.
-        """
+        """Execute the unaligned IO test steps."""
         total_sizes = self.params.get("sizes", "/run/datasize/*")
-        #Setup the pool
+        # Setup the pool
         self.setup_test_pool()
         pool_env = {"POOL_SCM_SIZE": "{}".format(self.pool.scm_size)}
         io_conf = IoConfGen(os.path.join(self.prefix, "bin"), env=pool_env)
         io_conf.get_params(self)
         for record_size in total_sizes:
             print("Start test for record size = {}".format(record_size))
-            #create unaligned test data set
+            # Create unaligned test data set
             gen_unaligned_io_conf(record_size)
-            #Run test file using daos_run_io_conf
+            # Run test file using daos_run_io_conf
             io_conf.run_conf()

--- a/src/tests/ftest/util/daos_utils.py
+++ b/src/tests/ftest/util/daos_utils.py
@@ -508,7 +508,7 @@ class DaosCommand(CommandWithSubCommand):
                 information.
 
         Raises:
-            CommandFailure: if the doas pool query command fails.
+            CommandFailure: if the daos pool query command fails.
 
         """
         self.set_sub_command("pool")
@@ -546,7 +546,7 @@ class DaosCommand(CommandWithSubCommand):
                 information.
 
         Raises:
-            CommandFailure: if the doas container create command fails.
+            CommandFailure: if the daos container create command fails.
 
         """
         self.set_sub_command("container")
@@ -579,7 +579,7 @@ class DaosCommand(CommandWithSubCommand):
                 information.
 
         Raises:
-            CommandFailure: if the doas container destroy command fails.
+            CommandFailure: if the daos container destroy command fails.
 
         """
         self.set_sub_command("container")

--- a/src/tests/ftest/util/fio_test_base.py
+++ b/src/tests/ftest/util/fio_test_base.py
@@ -91,7 +91,7 @@ class FioBase(TestWithServers):
         """Create a container.
 
         Args:
-            daos_cmd (DaosCommand): doas command to issue the container
+            daos_cmd (DaosCommand): daos command to issue the container
                 create
 
         Returns:

--- a/src/tests/ftest/util/general_utils.py
+++ b/src/tests/ftest/util/general_utils.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python
 """
-  (C) Copyright 2018-2019 Intel Corporation.
+  (C) Copyright 2018-2020 Intel Corporation.
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
@@ -32,10 +32,88 @@ from pathlib import Path
 from errno import ENOENT
 from ClusterShell.Task import task_self
 from ClusterShell.NodeSet import NodeSet
+from avocado.utils import process
 
 
 class DaosTestError(Exception):
     """DAOS API exception class."""
+
+
+def run_command(command, timeout=60, verbose=True, raise_exception=True,
+                output_check="combined", env=None):
+    """Run the command on the local host.
+
+    This method uses the avocado.utils.process.run() method to run the specified
+    command string on the local host using subprocess.Popen(). Even though the
+    command is specified as a string, since shell=False is passed to process.run
+    it will use shlex.spit() to break up the command into a list before it is
+    passed to subprocess.Popen. The shell=False is forced for security. As a
+    result typically any command containing ";", "|", "&&", etc. will fail.
+
+    Args:
+        command (str): command to run.
+        timeout (int, optional): command timeout. Defaults to 60 seconds.
+        verbose (bool, optional): whether to log the command run and
+            stdout/stderr. Defaults to True.
+        raise_exception (bool, optional): whether to raise an exception if the
+            command returns a non-zero exit status. Defaults to True.
+        output_check (str, optional): whether to record the output from the
+            command (from stdout and stderr) in the test output record files.
+            Valid values:
+                "stdout"    - standard output *only*
+                "stderr"    - standard error *only*
+                "both"      - both standard output and error in separate files
+                "combined"  - standard output and error in a single file
+                "none"      - disable all recording
+            Defaults to "combined".
+        env (dict, optional): dictionary of environment variable names and
+            values to set when running the command. Defaults to None.
+
+    Raises:
+        DaosTestError: if there is an error running the command
+
+    Returns:
+        CmdResult: an avocado.utils.process CmdResult object containing the
+            result of the command execution.  A CmdResult object has the
+            following properties:
+                command         - command string
+                exit_status     - exit_status of the command
+                stdout          - the stdout
+                stderr          - the stderr
+                duration        - command execution time
+                interrupted     - whether the command completed within timeout
+                pid             - command's pid
+
+    """
+    msg = None
+    kwargs = {
+        "cmd": command,
+        "timeout": timeout,
+        "verbose": verbose,
+        "ignore_status": not raise_exception,
+        "allow_output_check": output_check,
+        "shell": False,
+        "env": env,
+    }
+    try:
+        # Block until the command is complete or times out
+        return process.run(**kwargs)
+
+    except TypeError as error:
+        # Can occur if using env with a non-string dictionary values
+        msg = "Error running '{}': {}".format(command, error)
+        if env is not None:
+            msg = "\n".join([
+                msg,
+                "Verify env values are defined as strings: {}".format(env)])
+
+    except process.CmdError as error:
+        # Command failed or possibly timed out
+        msg = "Error occurred running '{}': {}".format(command, error)
+
+    if msg is not None:
+        print(msg)
+        raise DaosTestError(msg)
 
 
 def run_task(hosts, command, timeout=None):

--- a/src/tests/ftest/util/mdtest_test_base.py
+++ b/src/tests/ftest/util/mdtest_test_base.py
@@ -103,7 +103,7 @@ class MdtestBase(TestWithServers):
         """Create a container.
 
         Args:
-            daos_cmd (DaosCommand): doas command to issue the container
+            daos_cmd (DaosCommand): daos command to issue the container
                 create
 
         Returns:

--- a/src/tests/ftest/util/mpio_utils.py
+++ b/src/tests/ftest/util/mpio_utils.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python
-'''
-  (C) Copyright 2019 Intel Corporation.
+"""
+  (C) Copyright 2019-2020 Intel Corporation.
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
@@ -20,55 +20,70 @@
   provided in Contract No. B609815.
   Any reproduction of computer software, computer software documentation, or
   portions thereof marked with this legend must also reproduce the markings.
-'''
+"""
 from __future__ import print_function
 
 import os
-import subprocess
+
 from env_modules import load_mpi
 from command_utils import EnvironmentVariables
+from general_utils import run_command, DaosTestError
 
 
 class MpioFailed(Exception):
-    """Raise if MPIO failed"""
+    """Raise if MPIO failed."""
+
 
 class MpioUtils():
-    """MpioUtils Class"""
+    """MpioUtils Class."""
 
     def __init__(self):
-
+        """Initialize a MpioUtils object."""
         self.mpichinstall = None
 
     def mpich_installed(self, hostlist):
-        """Check if mpich is installed"""
+        """Check if mpich is installed.
 
+        Args:
+            hostlist (list): list of hosts
+
+        Returns:
+            bool: whether mpich is installed on the first host in the list
+
+        """
         load_mpi('mpich')
-
         try:
             # checking mpich install
-            self.mpichinstall = subprocess.check_output(
-                ["ssh", hostlist[0],
-                 "command -v mpichversion"]).rstrip()[:-len('bin/mpichversion')]
-
+            cmd = "/usr/bin/ssh {} command -v mpichversion".format(hostlist[0])
+            result = run_command(cmd)
+            self.mpichinstall = \
+                result.stdout.rstrip()[:-len('bin/mpichversion')]
             return True
 
-        except subprocess.CalledProcessError as excep:
+        except DaosTestError as excep:
             print("Mpich not installed \n {}".format(excep))
             return False
 
     # pylint: disable=R0913
     def run_mpiio_tests(self, hostfile, pool_uuid, svcl, test_repo,
                         test_name, client_processes, cont_uuid):
-        """
-            Running LLNL, MPI4PY and HDF5 testsuites
-            Function Arguments:
-                hostfile          --client hostfile
-                pool_uuid         --Pool UUID
-                svcl              --Pool SVCL
-                test_repo         --test repo location
-                test_name         --name of test to be tested
+        """Run the LLNL, MPI4PY, and HDF5 testsuites.
+
+        Args:
+            hostfile (str): client hostfile
+            pool_uuid (str): pool UUID
+            svcl (list): pool SVCL
+            test_repo (str): test repo location
+            test_name (str): name of test to be tested
+            client_processes (int): number of client processes
+            cont_uuid (str): container UUID
+
+        Raises:
+            MpioFailed: for an invalid test name or test execution failure
+
         """
         print("self.mpichinstall: {}".format(self.mpichinstall))
+
         # environment variables only to be set on client node
         env = EnvironmentVariables()
         env["DAOS_POOL"] = "{}".format(pool_uuid)
@@ -76,72 +91,57 @@ class MpioUtils():
         env["DAOS_CONT"] = "{}".format(cont_uuid)
         mpirun = os.path.join(self.mpichinstall, "bin", "mpirun")
 
-        if test_name == "romio" and os.path.isfile(
-                os.path.join(test_repo, "runtests")):
-            test_cmd = [env.get_export_str(),
-                        os.path.join(test_repo, 'runtests'),
-                        '-fname=daos:test1',
-                        '-subset']
-            cmd = " ".join(test_cmd)
-        elif test_name == "llnl" and os.path.isfile(
-                os.path.join(test_repo, "testmpio_daos")):
+        executables = {
+            "romio": [os.path.join(test_repo, "runtests")],
+            "llnl": [os.path.join(test_repo, "testmpio_daos")],
+            "mpi4py": [os.path.join(test_repo, "test_io_daos.py")],
+            "hdf5": [
+                os.path.join(test_repo, "testphdf5"),
+                os.path.join(test_repo, "t_shapesame")
+            ]
+        }
+
+        # Verify the test name is valid
+        if test_name not in executables:
+            raise MpioFailed(
+                "Invalid test name: {} not supported".format(test_name))
+
+        # Verify the executables exist for the valid test name
+        if not all([os.path.join(exe) for exe in executables[test_name]]):
+            raise MpioFailed(
+                "Missing test name: {} missing executables {}".format(
+                    test_name, ", ".join(executables[test_name])))
+
+        # Setup the commands to run for this test name
+        commands = []
+        if test_name == "romio":
+            env = None
+            commands.append(
+                "{} -fname=daos:test1 -subset".format(
+                    executables[test_name][0]))
+        elif test_name == "llnl":
             env["MPIO_USER_PATH"] = "daos:"
-            test_cmd = [env.get_export_str(),
-                        mpirun,
-                        '-np',
-                        str(client_processes),
-                        '--hostfile',
-                        hostfile,
-                        os.path.join(test_repo, 'testmpio_daos'),
-                        '1']
-            cmd = " ".join(test_cmd)
-        elif test_name == "mpi4py" and \
-             os.path.isfile(os.path.join(test_repo, "test_io_daos.py")):
-            test_cmd = [env.get_export_str(),
-                        mpirun,
-                        '-np',
-                        str(client_processes),
-                        '--hostfile',
-                        hostfile,
-                        'python',
-                        os.path.join(test_repo, 'test_io_daos.py')]
-            cmd = " ".join(test_cmd)
-        elif test_name == "hdf5" and \
-             (os.path.isfile(os.path.join(test_repo, "testphdf5")) and
-              os.path.isfile(os.path.join(test_repo, "t_shapesame"))):
+            for exe in executables[test_name]:
+                commands.append(
+                    "{} -np {} --hostfile {} {} 1".format(
+                        mpirun, client_processes, hostfile, exe))
+        elif test_name == "mpi4py":
+            for exe in executables[test_name]:
+                commands.append(
+                    "{} -np {} --hostfile {} python {}".format(
+                        mpirun, client_processes, hostfile, exe))
+        elif test_name == "hdf5":
             env["HDF5_PARAPREFIX"] = "daos:"
-            cmd = ''
-            for test in ["testphdf5", "t_shapesame"]:
-                fqtp = os.path.join(test_repo, test)
-                test_cmd = [env.get_export_str(),
-                            'echo ***Running {}*** ;'.format(fqtp),
-                            mpirun,
-                            '-np',
-                            str(client_processes),
-                            '--hostfile',
-                            hostfile,
-                            fqtp + ';']
-                cmd += " ".join(test_cmd)
-        else:
-            raise MpioFailed("Wrong test name ({}) or test repo location ({}) "
-                             "specified".format(test_name, test_repo))
+            for exe in executables[test_name]:
+                commands.append(
+                    "{} -np {} --hostfile {} {}".format(
+                        mpirun, client_processes, hostfile, exe))
 
-        print("run command: {}".format(cmd))
+        for command in commands:
+            print("run command: {}".format(command))
+            try:
+                run_command(command, timeout=None, verbose=True, env=env)
 
-        try:
-            process = subprocess.Popen(cmd, stdout=subprocess.PIPE,
-                                       stderr=subprocess.STDOUT, shell=True)
-            while True:
-                output = process.stdout.readline()
-                if output == '' and process.poll() is not None:
-                    break
-                if output:
-                    print(output.strip())
-            if process.poll() != 0:
-                raise MpioFailed("{} Run process".format(test_name)
-                                 + " Failed with non zero exit"
-                                 + " code:{}".format(process.poll()))
-
-        except (ValueError, OSError) as excep:
-            raise MpioFailed("<Test FAILED> \nException occurred: {}"\
-                                 .format(str(excep)))
+            except DaosTestError as excep:
+                raise MpioFailed(
+                    "<Test FAILED> \nException occurred: {}".format(str(excep)))

--- a/src/tests/ftest/util/server_utils.py
+++ b/src/tests/ftest/util/server_utils.py
@@ -666,7 +666,7 @@ class ServerManager(ExecutableCommand):
 
     def server_clean(self):
         """Prepare the hosts before starting daos server."""
-        # Kill any doas servers running on the hosts
+        # Kill any daos servers running on the hosts
         self.kill()
         # Clean up any files that exist on the hosts
         self.clean_files()

--- a/src/tests/ftest/util/server_utils.py
+++ b/src/tests/ftest/util/server_utils.py
@@ -993,7 +993,7 @@ def stop_server(setname=None, hosts=None):
     # we can also have orphaned ssh processes that started an orted on a
     # remote node but never get cleaned up when that remote node spontaneiously
     # reboots
-    subprocess.call(["pkill", "^ssh$"])
+    subprocess.call(["/usr/bin/pkill", "^ssh$"])
 
 
 def kill_server(hosts):

--- a/src/tests/ftest/util/slurm_utils.py
+++ b/src/tests/ftest/util/slurm_utils.py
@@ -26,10 +26,10 @@ from __future__ import print_function
 import os
 import random
 import time
-import subprocess
 import threading
 import re
-from avocado.utils import process
+
+from general_utils import run_command, DaosTestError
 
 W_LOCK = threading.Lock()
 
@@ -41,50 +41,57 @@ class SlurmFailed(Exception):
 def cancel_jobs(job_id):
     """Cancel slurms jobs.
 
-    :param job_id: slurm job id
-    :type job_id: int
-    :return: status
-    :rtype: bool
+    Args:
+        job_id (int): slurm job id
+
+    Returns:
+        int: return status from scancel command
 
     """
-    status = process.system("scancel {}".format(job_id))
-    if status > 0:
+    result = run_command("scancel {}".format(job_id), raise_exception=False)
+    if result.exit_status > 0:
         raise SlurmFailed(
             "Slurm: scancel failed to kill job {}".format(job_id))
-    return status
+    return result.exit_status
 
 
 def create_slurm_partition(nodelist, name):
     """Create a slurm partion for soak jobs.
 
-    client nodes will be allocated for this partiton
+    Client nodes will be allocated for this partiton.
+
     Args:
         nodelist (list): list of nodes for job allocation
         name (str): partition name
-    Returns: status bool
+
+    Returns:
+        int: return status from scontrol command
+
     """
     # If the partition exists; delete it because if may have wrong nodes
-    status = process.system(
-        "scontrol delete PartitionName={}".format(name))
-    if status == 0:
-        status = process.system(
-            "scontrol create PartitionName={} Nodes={}".format(
-                name, ",".join(nodelist)))
-    return status
+    command = "scontrol delete PartitionName={}".format(name)
+    result = run_command(command, raise_exception=False)
+    if result.exit_status == 0:
+        command = "scontrol create PartitionName={} Nodes={}".format(
+            name, ",".join(nodelist))
+        result = run_command(command, raise_exception=False)
+    return result.exit_status
 
 
 def delete_slurm_partition(name):
-    """Create a slurm partion for soak jobs.
+    """Remove the partition from slurm.
 
-    Remove the partition from slurm
     Args:
         name (str): partition name
-    Returns: status bool
+
+    Returns:
+        int: return status from scontrol command
+
     """
     # If the partition exists; delete it because if may have wrong nodes
-    status = process.system(
-        "scontrol delete PartitionName={}".format(name))
-    return status
+    command = "scontrol delete PartitionName={}".format(name)
+    result = run_command(command, raise_exception=False)
+    return result.exit_status
 
 
 def write_slurm_script(path, name, output, nodecount, cmds, uniq, sbatch=None):
@@ -139,39 +146,48 @@ def write_slurm_script(path, name, output, nodecount, cmds, uniq, sbatch=None):
 def run_slurm_script(script, logfile=None):
     """Run slurm script.
 
-    script(str) -- script file suitable to by run by slurm
-    logfile(str) -- add -o param and generate logfile
-    returns --the job ID, which is used as a handle for other functions
+    Args:
+        script (str): script file suitable to by run by slurm
+        logfile (str, optional): logfile to generate. Defaults to None.
+
+    Raises:
+        SlurmFailed: if there is an error obtaining the slurm job id
+
+    Returns:
+        str: the job ID, which is used as a handle for other functions
+
     """
+    job_id = None
     if logfile is not None:
         script = " -o " + logfile + " " + script
     cmd = "sbatch " + script
     try:
-        result = process.run(cmd, shell=True, timeout=10)
-    except process.CmdError as error:
+        result = run_command(cmd, timeout=10)
+    except DaosTestError as error:
         result = None
         raise SlurmFailed("job failed : {}".format(error))
     if result:
         output = result.stdout
         match = re.search(r"Submitted\s+batch\s+job\s+(\d+)", str(output))
         if match is not None:
-            return match.group(1)
-    else:
-        return None
+            job_id = match.group(1)
+    return job_id
 
 
 def check_slurm_job(handle):
     """Get the state of a job initiated via slurm.
 
-    handle   --slurm job id
+    Args:
+        handle (str): slurm job id
 
-    returns  --one of the slurm defined JOB_STATE_CODES strings plus
-                one extra UNKNOWN if the handle doesn't match a known
-                slurm job.
+    Returns:
+        str: one of the slurm defined JOB_STATE_CODES strings plus one extra
+            UNKNOWN if the handle doesn't match a known slurm job.
+
     """
     cmd = "scontrol show job {}".format(handle)
-    output = subprocess.check_output(cmd, stderr=subprocess.STDOUT, shell=True)
-    match = re.search(r"JobState=([a-zA-Z]+)", str(output))
+    result = run_command(cmd, raise_exception=False)
+    match = re.search(r"JobState=([a-zA-Z]+)", result.stdout)
     if match is not None:
         state = match.group(1)
     else:
@@ -230,12 +246,13 @@ def srun(nodes, cmd, srun_params=None):
     """Run srun cmd on slurm partition.
 
     Args:
-        hosts (str): hosts to allocate
+        nodes (str): hosts to allocate
         cmd (str): cmdline to execute
-        srun_params(dict):  additional params for srun
+        srun_params(dict): additional params for srun
 
     Returns:
-        exit status: int
+        CmdResult: object containing the result (exit status, stdout, etc.) of
+            the srun command
 
     """
     params_list = []
@@ -246,8 +263,8 @@ def srun(nodes, cmd, srun_params=None):
             params = " ".join(params_list)
     cmd = "srun --nodelist={} {} {}".format(nodes, params, cmd)
     try:
-        result = process.run(cmd, shell=True, timeout=30)
-    except process.CmdError as error:
+        result = run_command(cmd, timeout=30)
+    except DaosTestError as error:
         result = None
         raise SlurmFailed("srun failed : {}".format(error))
     return result

--- a/src/tests/ftest/util/test_utils_pool.py
+++ b/src/tests/ftest/util/test_utils_pool.py
@@ -28,17 +28,17 @@ import ctypes
 from test_utils_base import TestDaosApiBase
 
 from avocado import fail_on
-from avocado.utils import process
 from command_utils import BasicParameter, CommandFailure
 from pydaos.raw import (DaosApiError, DaosServer, DaosPool, c_uuid_to_str,
                         daos_cref)
-from general_utils import check_pool_files, DaosTestError
+from general_utils import check_pool_files, DaosTestError, run_command
 from env_modules import load_mpi
 
 from dmg_utils import get_pool_uuid_service_replicas_from_stdout
 
 
 class TestPool(TestDaosApiBase):
+    # pylint: disable=too-many-public-methods
     """A class for functional testing of DaosPools objects."""
 
     def __init__(self, context, log=None, cb_handler=None, dmg_command=None):
@@ -553,7 +553,7 @@ class TestPool(TestDaosApiBase):
                 command. Defaults to 60 seconds.
 
         Returns:
-            process.CmdResult: command execution result
+            CmdResult: command execution result
 
         """
         self.log.info("Writing %s bytes to pool %s", size, self.uuid)
@@ -568,7 +568,7 @@ class TestPool(TestDaosApiBase):
         command = "{} --np {} --hostfile {} {} {} testfile".format(
             orterun, processes, hostfile,
             os.path.join(current_path, "write_some_data.py"), size)
-        return process.run(command, timeout, True, False, "both", True, env)
+        return run_command(command, timeout, True, env=env)
 
     def get_pool_daos_space(self):
         """Get the pool info daos space attributes as a dictionary.


### PR DESCRIPTION
Resolving python Bandit B602, B604, & B607 errors detected in the code
by removing the use of shell=True in subprocess.Popen() calls and
including full paths to executables.

Skip-python-bandit: false
Test-tag: pr,-hw unittest
Test-tag-hw-large: pr,hw,large soak_smoke

Signed-off-by: Phillip Henderson <phillip.henderson@intel.com>