### PR TITLE
DAOS-722 logging: Remove key names from logging

### DIFF
--- a/src/common/debug.c
+++ b/src/common/debug.c
@@ -242,37 +242,3 @@ DP_UUID(const void *uuid)
 #define DF_KEY_MAX		8
 #define DF_KEY_STR_SIZE		64
 
-static __thread int thread_key_buf_idx;
-static __thread char thread_key_buf[DF_KEY_MAX][DF_KEY_STR_SIZE];
-
-char *
-daos_key2str(daos_key_t *key)
-{
-	char *buf = thread_key_buf[thread_key_buf_idx];
-
-	if (!key->iov_buf || key->iov_len == 0) {
-		strcpy(buf, "<NULL>");
-	} else {
-		int len = min(key->iov_len, DF_KEY_STR_SIZE - 1);
-		int i;
-		char *akey = key->iov_buf;
-		bool can_print = true;
-
-		for (i = 0 ; i < len ; i++) {
-			if (akey[i] == '\0')
-				break;
-			if (!isprint(akey[i])) {
-				can_print = false;
-				break;
-			}
-		}
-		if (can_print) {
-			strncpy(buf, key->iov_buf, len);
-			buf[len] = 0;
-		} else {
-			strcpy(buf, "????");
-		}
-	}
-	thread_key_buf_idx = (thread_key_buf_idx + 1) % DF_KEY_MAX;
-	return buf;
-}

--- a/src/common/debug.c
+++ b/src/common/debug.c
@@ -239,6 +239,3 @@ DP_UUID(const void *uuid)
 	return buf;
 }
 
-#define DF_KEY_MAX		8
-#define DF_KEY_STR_SIZE		64
-

--- a/src/include/daos/common.h
+++ b/src/include/daos/common.h
@@ -104,7 +104,7 @@ char *DP_UUID(const void *uuid);
 #define DF_CONTF		DF_UUIDF"/"DF_UUIDF
 
 #define DF_KEY			"[%d]"
-#define DP_KEY(key)		(int)(key)->iov_len
+#define DP_KEY(key)		(int)((key)->iov_len)
 
 static inline uint64_t
 daos_u64_hash(uint64_t val, unsigned int bits)

--- a/src/include/daos/common.h
+++ b/src/include/daos/common.h
@@ -105,10 +105,8 @@ char *DP_UUID(const void *uuid);
 
 char *daos_key2str(daos_key_t *key);
 
-#define DF_KEY			"[%d] %.*s"
-#define DP_KEY(key)		(int)(key)->iov_len,	\
-		                (int)(key)->iov_len,	\
-		                daos_key2str(key)
+#define DF_KEY			"[%d]"
+#define DP_KEY(key)		(int)(key)->iov_len
 
 static inline uint64_t
 daos_u64_hash(uint64_t val, unsigned int bits)

--- a/src/include/daos/common.h
+++ b/src/include/daos/common.h
@@ -103,8 +103,6 @@ char *DP_UUID(const void *uuid);
 #define DP_CONT(puuid, cuuid)	DP_UUID(puuid), DP_UUID(cuuid)
 #define DF_CONTF		DF_UUIDF"/"DF_UUIDF
 
-char *daos_key2str(daos_key_t *key);
-
 #define DF_KEY			"[%d]"
 #define DP_KEY(key)		(int)(key)->iov_len
 


### PR DESCRIPTION
To avoid logging sensitive information key names are being removed from logging statements on the server side.

Signed-off-by: David Quigley <david.quigley@intel.com>
Signed-off-by: Ashley Pittman <ashley.m.pittman@intel.com>