### PR TITLE
DAOS-4628 dtx: not print error msg if read hit non-committed DTX

### DIFF
--- a/src/object/srv_obj.c
+++ b/src/object/srv_obj.c
@@ -923,8 +923,9 @@ obj_local_rw(crt_rpc_t *rpc, struct ds_cont_hdl *cont_hdl,
 				     dkey, orw->orw_nr, iods, size_fetch, &ioh);
 
 		if (rc) {
-			D_ERROR(DF_UOID" Fetch begin failed: "DF_RC"\n",
-				DP_UOID(orw->orw_oid), DP_RC(rc));
+			D_CDEBUG(rc == -DER_INPROGRESS, DB_IO, DLOG_ERR,
+				 " Fetch begin failed: "DF_RC"\n",
+				 DP_UOID(orw->orw_oid), DP_RC(rc));
 			goto out;
 		}
 
@@ -1339,11 +1340,6 @@ ds_obj_rw_handler(crt_rpc_t *rpc)
 	if (obj_rpc_is_fetch(rpc)) {
 		rc = obj_local_rw(rpc, ioc.ioc_coh, ioc.ioc_coc,
 				  NULL, NULL, NULL);
-		if (rc != 0) {
-			D_ERROR(DF_UOID": error="DF_RC".\n",
-				DP_UOID(orw->orw_oid), DP_RC(rc));
-			D_GOTO(out, rc);
-		}
 		D_GOTO(out, rc);
 	} else if (orw->orw_iod_array.oia_oiods != NULL) {
 		rc = obj_ec_rw_req_split(orw, &split_req);


### PR DESCRIPTION
It is normal that the fetch RPC is sent to some non-leader replica
and hits some DTX with 'prepare' status. In such case, the replica
will reply -2018 to the client to notify the client to resend such
fetch request to leader replica. Such event should not be reported
as error message that is some misguided and noisy. Instead, we can
log it with 'DB_IO' if required.

master-PR: 2486

Signed-off-by: Fan Yong <fan.yong@intel.com>