### PR TITLE
CART-890 mem: disable memory pinning (#2560)

### DIFF
--- a/src/cart/src/cart/crt_init.c
+++ b/src/cart/src/cart/crt_init.c
@@ -72,6 +72,9 @@ dump_envariables(void)
 static int
 mem_pin_workaround(void)
 {
+	D_DEBUG(DB_ALL, "Memory pinning workaround disabled\n");
+	return 0;
+#if 0
 	int crt_rc = 0;
 	int rc;
 
@@ -92,6 +95,7 @@ mem_pin_workaround(void)
 	D_DEBUG(DB_ALL, "Memory pinning workaround enabled\n");
 exit:
 	return crt_rc;
+#endif
 }
 
 


### PR DESCRIPTION
Temporarily disable memory pinning workaround from PR #2560 since it
is causing some failure in the IO tests.

Signed-off-by: Johann Lombardi <johann.lombardi@intel.com>