### PR TITLE
DAOS-4766 evtree: Set entry list prev pointer to NULL after resize

### DIFF
--- a/src/cart/src/cart/crt_init.c
+++ b/src/cart/src/cart/crt_init.c
@@ -72,9 +72,6 @@ dump_envariables(void)
 static int
 mem_pin_workaround(void)
 {
-	D_DEBUG(DB_ALL, "Memory pinning workaround disabled\n");
-	return 0;
-#if 0
 	int crt_rc = 0;
 	int rc;
 
@@ -95,7 +92,6 @@ mem_pin_workaround(void)
 	D_DEBUG(DB_ALL, "Memory pinning workaround enabled\n");
 exit:
 	return crt_rc;
-#endif
 }
 
 

--- a/src/vos/evtree.c
+++ b/src/vos/evtree.c
@@ -238,9 +238,9 @@ ent_array_resize(struct evt_context *tcx, struct evt_entry_array *ent_array,
 		D_FREE(ent_array->ea_ents);
 	ent_array->ea_ents = ents;
 	ent_array->ea_size = new_size;
+
 	return 0;
 }
-
 static inline struct evt_list_entry *
 evt_array_entry2le(struct evt_entry *ent)
 {
@@ -594,6 +594,7 @@ evt_find_visible(struct evt_context *tcx, const struct evt_filter *filter,
 			continue;
 		}
 
+		evt_array_entry2le(this_ent)->le_prev = NULL;
 		d_list_add_tail(next, &covered);
 	}
 


### PR DESCRIPTION
After an array resize, le_prev points to memory that has been freed. Setting
it to NULL prevents accidental access to freed memory.

Signed-off-by: Ryon Jensen <ryon.jensen@intel.com>