### PR TITLE
DAOS-4742 build: Add dependence on libgurt to go builders

### DIFF
--- a/src/control/SConscript
+++ b/src/control/SConscript
@@ -7,7 +7,7 @@ from os.path import join, isdir
 from os import urandom
 from binascii import b2a_hex
 
-Import('env', 'prereqs', 'DAOS_VERSION', 'CONF_DIR')
+Import('env', 'prereqs', 'DAOS_VERSION', 'CONF_DIR', 'gurt_lib')
 
 GO_COMPILER = 'go'
 MIN_GO_VERSION = '1.12.0'
@@ -68,7 +68,7 @@ def install_go_bin(denv, gosrc, libs, name, install_name):
                          '-B %s"' % gen_build_id()])
     # Must be run from the top of the source dir in order to
     # pick up the vendored modules.
-    denv.Command(build_bin, src,
+    denv.Command(build_bin, src + gurt_lib,
                  'cd %s; %s build -mod vendor -v %s -o %s %s' %
                  (gosrc, GO_BIN, go_ldflags(), build_bin, install_src))
     # Use the intermediate build location in order to play nicely


### PR DESCRIPTION
Parallel builds can fail because the Command builder used
by the control plane build doens't know there is a
dependence on libgurt.

Add an explicit dependence on the library.   Other library
dependencies should be handled by prerequisite checks

Signed-off-by: Jeff Olivier <jeffrey.v.olivier@intel.com>