### PR TITLE
DAOS-4766 evtree: Set entry list prev pointer to NULL after resize

### DIFF
--- a/src/vos/evtree.c
+++ b/src/vos/evtree.c
@@ -594,6 +594,7 @@ evt_find_visible(struct evt_context *tcx, const struct evt_filter *filter,
 			continue;
 		}
 
+		evt_array_entry2le(this_ent)->le_prev = NULL;
 		d_list_add_tail(next, &covered);
 	}
 


### PR DESCRIPTION
After an array resize, le_prev points to memory that has been freed. Setting
it to NULL prevents accidental access to freed memory. This issue became
more apparent with the memory pinning workaround in cart.

Signed-off-by: Ryon Jensen <ryon.jensen@intel.com>