### PR TITLE
CART-892 rpc: remove additional RPC tracking

### DIFF
--- a/src/cart/src/cart/crt_hg.c
+++ b/src/cart/src/cart/crt_hg.c
@@ -1115,6 +1115,9 @@ crt_hg_req_send_cb(const struct hg_cb_info *hg_cbinfo)
 				     rpc_pub->cr_ep.ep_rank)) {
 			RPC_TRACE(DB_NET, rpc_priv, "request target evicted\n");
 			rc = -DER_EVICTED;
+		} else if (rpc_priv->crp_timeout_ts < d_timeus_secdiff(0)) {
+			RPC_TRACE(DB_NET, rpc_priv, "request timedout\n");
+			rc = -DER_TIMEDOUT;
 		} else {
 			RPC_TRACE(DB_NET, rpc_priv, "request canceled\n");
 			rc = -DER_CANCELED;

--- a/src/cart/src/cart/crt_hg.c
+++ b/src/cart/src/cart/crt_hg.c
@@ -1115,9 +1115,6 @@ crt_hg_req_send_cb(const struct hg_cb_info *hg_cbinfo)
 				     rpc_pub->cr_ep.ep_rank)) {
 			RPC_TRACE(DB_NET, rpc_priv, "request target evicted\n");
 			rc = -DER_EVICTED;
-		} else if (crt_req_timedout(rpc_priv)) {
-			RPC_TRACE(DB_NET, rpc_priv, "request timedout\n");
-			rc = -DER_TIMEDOUT;
 		} else {
 			RPC_TRACE(DB_NET, rpc_priv, "request canceled\n");
 			rc = -DER_CANCELED;
@@ -1213,12 +1210,7 @@ crt_hg_req_send(struct crt_rpc_priv *rpc_priv)
 	}
 
 	if (hg_ret == HG_NA_ERROR) {
-		if (!crt_req_timedout(rpc_priv)) {
-			/* error will be reported to the completion callback in
-			 * crt_req_timeout_hdlr()
-			 */
-			crt_req_force_timeout(rpc_priv);
-		}
+		rpc_priv->crp_timeout_ts = 0;
 		rpc_priv->crp_state = RPC_STATE_FWD_UNREACH;
 	} else if (hg_ret != HG_SUCCESS) {
 		rc = -DER_HG;

--- a/src/cart/src/cart/crt_internal_fns.h
+++ b/src/cart/src/cart/crt_internal_fns.h
@@ -72,9 +72,6 @@ void crt_context_req_untrack(struct crt_rpc_priv *rpc_priv);
 crt_context_t crt_context_lookup(int ctx_idx);
 crt_context_t crt_context_lookup_locked(int ctx_idx);
 void crt_rpc_complete(struct crt_rpc_priv *rpc_priv, int rc);
-int crt_req_timeout_track(struct crt_rpc_priv *rpc_priv);
-void crt_req_timeout_untrack(struct crt_rpc_priv *rpc_priv);
-void crt_req_force_timeout(struct crt_rpc_priv *rpc_priv);
 
 /** some simple helper functions */
 

--- a/src/cart/src/cart/crt_internal_types.h
+++ b/src/cart/src/cart/crt_internal_types.h
@@ -170,8 +170,6 @@ struct crt_context {
 	crt_rpc_task_t		 cc_iv_resp_cb;
 	/* in-flight endpoint tracking hash table */
 	struct d_hash_table	 cc_epi_table;
-	/* binheap for inflight RPC timeout tracking */
-	struct d_binheap	 cc_bh_timeout;
 	/* mutex to protect cc_epi_table and timeout binheap */
 	pthread_mutex_t		 cc_mutex;
 	/* timeout per-context */

--- a/src/cart/src/cart/crt_rpc.h
+++ b/src/cart/src/cart/crt_rpc.h
@@ -53,7 +53,6 @@
 /* uri lookup max retry times */
 #define CRT_URI_LOOKUP_RETRY_MAX	(8)
 
-extern struct d_binheap_ops crt_timeout_bh_ops;
 void crt_hdlr_rank_evict(crt_rpc_t *rpc_req);
 extern void crt_hdlr_memb_sample(crt_rpc_t *rpc_req);
 
@@ -159,8 +158,6 @@ struct crt_rpc_priv {
 	d_list_t		crp_tmp_link;
 	/* link to parent RPC crp_opc_info->co_child_rpcs/co_replied_rpcs */
 	d_list_t		crp_parent_link;
-	/* binheap node for timeout management, in crt_context::cc_bh_timeout */
-	struct d_binheap_node	crp_timeout_bp_node;
 	/* the timeout in seconds set by user */
 	uint32_t		crp_timeout_sec;
 	/* time stamp to be timeout, the key of timeout binheap */
@@ -192,8 +189,6 @@ struct crt_rpc_priv {
 				crp_uri_free:1,
 				/* flag of forwarded rpc for corpc */
 				crp_forward:1,
-				/* flag of in timeout binheap */
-				crp_in_binheap:1,
 				/* set if a call to crt_req_reply pending */
 				crp_reply_pending:1,
 				/* set to 1 if target ep is set */
@@ -615,17 +610,6 @@ int crt_req_create_internal(crt_context_t crt_ctx, crt_endpoint_t *tgt_ep,
 int crt_internal_rpc_register(void);
 int crt_rpc_common_hdlr(struct crt_rpc_priv *rpc_priv);
 int crt_req_send_internal(struct crt_rpc_priv *rpc_priv);
-
-static inline bool
-crt_req_timedout(struct crt_rpc_priv *rpc_priv)
-{
-	return (rpc_priv->crp_state == RPC_STATE_REQ_SENT ||
-		rpc_priv->crp_state == RPC_STATE_URI_LOOKUP ||
-		rpc_priv->crp_state == RPC_STATE_ADDR_LOOKUP ||
-		rpc_priv->crp_state == RPC_STATE_TIMEOUT ||
-		rpc_priv->crp_state == RPC_STATE_FWD_UNREACH) &&
-	       !rpc_priv->crp_in_binheap;
-}
 
 static inline uint64_t
 crt_set_timeout(struct crt_rpc_priv *rpc_priv)


### PR DESCRIPTION
Remove binheap usage from in-flight RPC's tracking.
Simplify implementation of expired by timeout RPC's.

The time we spend inside crt_context_req_track() function
was reduced in 46%. This function is on critical path for
send each RPC. So, this patch should significantly reduce
impact to total latency from CaRT stack.