### PR TITLE
DAOS-4542 dtx: (1) remove dae_layout_gen from DTX entry

### DIFF
--- a/src/vos/vos_internal.h
+++ b/src/vos/vos_internal.h
@@ -233,7 +233,6 @@ struct vos_dtx_act_ent {
 #define DAE_DKEY_HASH(dae)	((dae)->dae_base.dae_dkey_hash)
 #define DAE_EPOCH(dae)		((dae)->dae_base.dae_epoch)
 #define DAE_SRV_GEN(dae)	((dae)->dae_base.dae_srv_gen)
-#define DAE_LAYOUT_GEN(dae)	((dae)->dae_base.dae_layout_gen)
 #define DAE_LID(dae)		((dae)->dae_base.dae_lid)
 #define DAE_INTENT(dae)		((dae)->dae_base.dae_intent)
 #define DAE_INDEX(dae)		((dae)->dae_base.dae_index)

--- a/src/vos/vos_layout.h
+++ b/src/vos/vos_layout.h
@@ -178,8 +178,6 @@ struct vos_dtx_act_ent_df {
 	daos_epoch_t			dae_epoch;
 	/** The server generation when handles the DTX. */
 	uint64_t			dae_srv_gen;
-	/** The active DTX entry on-disk layout generation. */
-	uint64_t			dae_layout_gen;
 	/** The allocated local id for the DTX entry */
 	uint32_t			dae_lid;
 	/** The intent of related modification. */


### PR DESCRIPTION
It was used for deregister DTX entry when container to be destroyed.
Under such case, the DTX entry in DRAM has been removed, the on-disk
DTX entry will be destroyed soon via vos_dtx_table_destroy(). So do
not need to care about the DTX entry layout generation changes.

Signed-off-by: Fan Yong <fan.yong@intel.com>