### PR TITLE
DAOS-4542 dtx: (2) replace vos_dtx_record_df with umem_off_t

### DIFF
--- a/src/vos/vos_internal.h
+++ b/src/vos/vos_internal.h
@@ -223,7 +223,7 @@ struct vos_dtx_act_ent {
 	umem_off_t			 dae_df_off;
 	struct vos_dtx_blob_df		*dae_dbd;
 	/* More DTX records if out of the inlined buffer. */
-	struct vos_dtx_record_df	*dae_records;
+	umem_off_t			*dae_records;
 	/* The capacity of dae_records, NOT including the inlined buffer. */
 	int				 dae_rec_cap;
 };

--- a/src/vos/vos_layout.h
+++ b/src/vos/vos_layout.h
@@ -152,19 +152,8 @@ enum vos_dtx_entry_flags {
 	DTX_EF_INVALID			= (1 << 1),
 };
 
-/** The agent of the record being modified via the DTX in both SCM and DRAM. */
-struct vos_dtx_record_df {
-	/** The DTX record type, see enum vos_dtx_record_types. */
-	uint32_t			dr_type;
-	/** The 64-bits alignment. */
-	uint32_t			dr_padding;
-	/** The modified record in the related tree in SCM. */
-	umem_off_t			dr_record;
-};
-
 #define DTX_INLINE_REC_CNT	4
 #define DTX_REC_CAP_DEFAULT	4
-
 
 /** Active DTX entry on-disk layout in both SCM and DRAM. */
 struct vos_dtx_act_ent_df {
@@ -185,12 +174,12 @@ struct vos_dtx_act_ent_df {
 	/** The index in the current vos_dtx_blob_df. */
 	int16_t				dae_index;
 	/** The inlined dtx records. */
-	struct vos_dtx_record_df	dae_rec_inline[DTX_INLINE_REC_CNT];
+	umem_off_t			dae_rec_inline[DTX_INLINE_REC_CNT];
 	/** DTX flags, see enum vos_dtx_entry_flags. */
 	uint32_t			dae_flags;
 	/** The DTX records count, including inline case. */
 	uint32_t			dae_rec_cnt;
-	/** The offset for the list of vos_dtx_record_df if out of inline. */
+	/** The offset for the list of dtx records if out of inline. */
 	umem_off_t			dae_rec_off;
 };
 


### PR DESCRIPTION
'vos_dtx_record_df' is the agent of the record being modified via
the DTX in both SCM and DRAM, as following:

struct vos_dtx_record_df {
       /** The DTX record type, see enum vos_dtx_record_types. */
       uint32_t                        dr_type;
       /** The 64-bits alignment. */
       uint32_t                        dr_padding;
       /** The modified record in the related tree in SCM. */
       umem_off_t                      dr_record;
};

We only support 3 types of DTX record: ilog, svt, evt. They can
be embedded into the 'dr_records' as the high 8 bits flags. Then
the whole 'vos_dtx_record_df' can be replaced by 'umem_off_t'.

Signed-off-by: Fan Yong <fan.yong@intel.com>