### PR TITLE
DAOS-4827 vos: Ensure we don't remove key trees for empty value

### DIFF
--- a/src/vos/tests/vts_aggregate.c
+++ b/src/vos/tests/vts_aggregate.c
@@ -41,8 +41,8 @@ static bool slow_test;
 
 static void
 update_value(struct io_test_args *arg, daos_unit_oid_t oid, daos_epoch_t epoch,
-	     char *dkey, char *akey, daos_iod_type_t type, daos_size_t iod_size,
-	     daos_recx_t *recx, char *buf)
+	     uint64_t flags, char *dkey, char *akey, daos_iod_type_t type,
+	     daos_size_t iod_size, daos_recx_t *recx, char *buf)
 {
 	daos_iod_t	iod = { 0 };
 	d_sg_list_t	sgl = { 0 };
@@ -86,7 +86,8 @@ update_value(struct io_test_args *arg, daos_unit_oid_t oid, daos_epoch_t epoch,
 			arg->ta_flags |= TF_ZERO_COPY;
 	}
 
-	rc = io_test_obj_update(arg, epoch, &dkey_iov, &iod, &sgl, NULL, true);
+	rc = io_test_obj_update(arg, epoch, 0, &dkey_iov, &iod, &sgl, NULL,
+				true);
 	assert_int_equal(rc, 0);
 
 	daos_sgl_fini(&sgl, false);
@@ -95,8 +96,8 @@ update_value(struct io_test_args *arg, daos_unit_oid_t oid, daos_epoch_t epoch,
 
 static void
 fetch_value(struct io_test_args *arg, daos_unit_oid_t oid, daos_epoch_t epoch,
-	    char *dkey, char *akey, daos_iod_type_t type, daos_size_t iod_size,
-	    daos_recx_t *recx, char *buf)
+	    uint64_t flags, char *dkey, char *akey, daos_iod_type_t type,
+	    daos_size_t iod_size, daos_recx_t *recx, char *buf)
 {
 	daos_iod_t	iod = { 0 };
 	d_sg_list_t	sgl = { 0 };
@@ -135,7 +136,7 @@ fetch_value(struct io_test_args *arg, daos_unit_oid_t oid, daos_epoch_t epoch,
 	if (rand() % 2 == 0)
 		arg->ta_flags |= TF_ZERO_COPY;
 
-	rc = io_test_obj_fetch(arg, epoch, &dkey_iov, &iod, &sgl, true);
+	rc = io_test_obj_fetch(arg, epoch, flags, &dkey_iov, &iod, &sgl, true);
 	assert_int_equal(rc, 0);
 	assert_true(iod.iod_size == 0 || iod.iod_size == iod_size);
 
@@ -291,7 +292,7 @@ generate_view(struct io_test_args *arg, daos_unit_oid_t oid, char *dkey,
 
 	view_epoch = ds->td_discard ? (epr_a->epr_lo - 1) : epr_a->epr_hi;
 
-	fetch_value(arg, oid, view_epoch, dkey, akey, ds->td_type,
+	fetch_value(arg, oid, view_epoch, 0, dkey, akey, ds->td_type,
 		    ds->td_iod_size, &recx, ds->td_expected_view);
 }
 
@@ -321,7 +322,7 @@ verify_view(struct io_test_args *arg, daos_unit_oid_t oid, char *dkey,
 	D_ALLOC(buf_f, view_len);
 	assert_non_null(buf_f);
 
-	fetch_value(arg, oid, epr_a->epr_hi, dkey, akey, ds->td_type,
+	fetch_value(arg, oid, epr_a->epr_hi, 0, dkey, akey, ds->td_type,
 		    ds->td_iod_size, &recx, buf_f);
 
 	assert_memory_equal(buf_f, ds->td_expected_view, view_len);
@@ -355,7 +356,7 @@ generate_akeys(struct io_test_args *arg, daos_unit_oid_t oid, int nr)
 	dts_key_gen(dkey, UPDATE_DKEY_SIZE, UPDATE_DKEY);
 	for (i = 0; i < nr; i++) {
 		dts_key_gen(akey, UPDATE_AKEY_SIZE, UPDATE_AKEY);
-		update_value(arg, oid, 1, dkey, akey, DAOS_IOD_SINGLE,
+		update_value(arg, oid, 1, 0, dkey, akey, DAOS_IOD_SINGLE,
 			     10, NULL, buf_u);
 	}
 	D_FREE(buf_u);
@@ -408,7 +409,7 @@ aggregate_basic(struct io_test_args *arg, struct agg_tst_dataset *ds,
 			recx_idx++;
 		}
 
-		update_value(arg, oid, epoch, dkey, akey, ds->td_type,
+		update_value(arg, oid, epoch, 0, dkey, akey, ds->td_type,
 			     ds->td_iod_size, recx_p, buf_u);
 		arg->ta_flags &= ~TF_PUNCH;
 	}
@@ -579,7 +580,7 @@ aggregate_multi(struct io_test_args *arg, struct agg_tst_dataset *ds_sample)
 			ds->td_upd_epr.epr_lo = epoch;
 		ds->td_upd_epr.epr_hi = epoch;
 
-		update_value(arg, oid, epoch, dkey, akey, ds->td_type,
+		update_value(arg, oid, epoch, 0, dkey, akey, ds->td_type,
 			     ds->td_iod_size, recx_p, buf_u);
 		arg->ta_flags &= ~TF_PUNCH;
 
@@ -1084,7 +1085,7 @@ agg_punches_test_helper(void **state, int record_type, int type, bool discard,
 	arg->ta_flags = TF_USE_VAL;
 
 	if (first != AGG_NONE) {
-		update_value(arg, oid, epr.epr_lo++, dkey, akey,
+		update_value(arg, oid, epr.epr_lo++, 0, dkey, akey,
 			     record_type, sizeof(first_val), &recx,
 			     &first_val);
 		if (first == AGG_PUNCH) {
@@ -1103,14 +1104,14 @@ agg_punches_test_helper(void **state, int record_type, int type, bool discard,
 			do_punch(arg, type, oid, epoch++, dkey, akey);
 			continue;
 		}
-		update_value(arg, oid, epoch++, dkey, akey,
+		update_value(arg, oid, epoch++, 0, dkey, akey,
 			     record_type, sizeof(middle_val), &recx,
 			     &middle_val);
 		middle_epoch = epoch;
 	}
 
 	if (last == AGG_UPDATE) {
-		update_value(arg, oid, epoch++, dkey, akey, record_type,
+		update_value(arg, oid, epoch++, 0, dkey, akey, record_type,
 			     sizeof(last_val), &recx, &last_val);
 	}
 
@@ -1130,14 +1131,14 @@ agg_punches_test_helper(void **state, int record_type, int type, bool discard,
 			 * should exist because it's outside of the epr.
 			 */
 			fetch_val = 0;
-			fetch_value(arg, oid, 1, dkey, akey, record_type,
+			fetch_value(arg, oid, 1, 0, dkey, akey, record_type,
 				    sizeof(first_val), &recx, &fetch_val);
 			assert_int_equal(fetch_val, first_val);
 			/* Reading at "snapshot" should also work except for
 			 * punch, it will be gone.
 			 */
 			fetch_val = 0;
-			fetch_value(arg, oid, epr.epr_lo, dkey, akey,
+			fetch_value(arg, oid, epr.epr_lo, 0, dkey, akey,
 				    record_type, sizeof(first_val), &recx,
 				    &fetch_val);
 			assert_int_equal(fetch_val,
@@ -1151,7 +1152,7 @@ agg_punches_test_helper(void **state, int record_type, int type, bool discard,
 		fetch_val = 0;
 		if (first == AGG_UPDATE && discard)
 			expected = first_val;
-		fetch_value(arg, oid, middle_epoch, dkey, akey, record_type,
+		fetch_value(arg, oid, middle_epoch, 0, dkey, akey, record_type,
 			    sizeof(middle_val), &recx, &fetch_val);
 		assert_int_equal(fetch_val, expected);
 
@@ -1159,7 +1160,7 @@ agg_punches_test_helper(void **state, int record_type, int type, bool discard,
 		 * discard
 		 */
 		fetch_val = 0;
-		fetch_value(arg, oid, epr.epr_hi, dkey, akey, record_type,
+		fetch_value(arg, oid, epr.epr_hi, 0, dkey, akey, record_type,
 			    sizeof(last_val), &recx, &fetch_val);
 		expected = last_val;
 		if (discard) {
@@ -1743,7 +1744,7 @@ fill_cont(struct io_test_args *arg, daos_unit_oid_t oid, char *dkey,
 		if ((rand() % 10) > 7 && written != 0)
 			arg->ta_flags |= TF_PUNCH;
 
-		update_value(arg, oid, *epc_hi, dkey, akey, DAOS_IOD_ARRAY,
+		update_value(arg, oid, *epc_hi, 0, dkey, akey, DAOS_IOD_ARRAY,
 			     iod_size, &recx, buf_u);
 		(*epc_hi)++;
 		if (arg->ta_flags & TF_PUNCH)
@@ -1931,6 +1932,102 @@ aggregate_21(void **state)
 	daos_fail_loc_set(0);
 }
 
+static void
+aggregate_22(void **state)
+{
+	struct io_test_args	*arg = *state;
+	daos_unit_oid_t		 oid;
+	char			 dkey[UPDATE_DKEY_SIZE] = { 0 };
+	char			 akey[UPDATE_AKEY_SIZE] = { 0 };
+	char			 akey2[UPDATE_AKEY_SIZE] = { 0 };
+	char			 akey3[UPDATE_AKEY_SIZE] = { 0 };
+	char			 akey4[UPDATE_AKEY_SIZE] = { 0 };
+	daos_recx_t		 recx;
+	daos_epoch_range_t	 epr;
+	daos_epoch_t		 epoch = 100;
+	char			 buf_u[16];
+	int			 rc;
+
+	oid = dts_unit_oid_gen(0, 0, 0);
+
+	dts_key_gen(dkey, UPDATE_DKEY_SIZE, UPDATE_DKEY);
+	dts_key_gen(akey, UPDATE_AKEY_SIZE, UPDATE_AKEY);
+	dts_key_gen(akey2, UPDATE_AKEY_SIZE, UPDATE_AKEY);
+	dts_key_gen(akey3, UPDATE_AKEY_SIZE, UPDATE_AKEY);
+	dts_key_gen(akey4, UPDATE_AKEY_SIZE, UPDATE_AKEY);
+	recx.rx_idx = 0;
+	recx.rx_nr = 1;
+
+	epr.epr_lo = 0;
+
+	memset(buf_u, 'x', sizeof(buf_u));
+
+	update_value(arg, oid, epoch++, 0, dkey, akey, DAOS_IOD_ARRAY,
+		     sizeof(buf_u), &recx, buf_u);
+	update_value(arg, oid, epoch++, 0, dkey, akey2, DAOS_IOD_SINGLE,
+		     sizeof(buf_u), &recx, buf_u);
+	arg->ta_flags |= TF_PUNCH;
+	update_value(arg, oid, epoch++, 0, dkey, akey3, DAOS_IOD_ARRAY,
+		     sizeof(buf_u), &recx, buf_u);
+	update_value(arg, oid, epoch++, 0, dkey, akey4, DAOS_IOD_SINGLE,
+		     sizeof(buf_u), &recx, buf_u);
+
+	fetch_value(arg, oid, epoch++,
+		    VOS_OF_USE_TIMESTAMPS | VOS_OF_COND_AKEY_FETCH, dkey, akey,
+		    DAOS_IOD_ARRAY, sizeof(buf_u), &recx, buf_u);
+	fetch_value(arg, oid, epoch++,
+		    VOS_OF_USE_TIMESTAMPS | VOS_OF_COND_AKEY_FETCH, dkey, akey2,
+		    DAOS_IOD_SINGLE, sizeof(buf_u), &recx, buf_u);
+	memset(buf_u, 0, sizeof(buf_u));
+	fetch_value(arg, oid, epoch++,
+		    VOS_OF_USE_TIMESTAMPS | VOS_OF_COND_AKEY_FETCH, dkey, akey3,
+		    DAOS_IOD_ARRAY, sizeof(buf_u), &recx, buf_u);
+	fetch_value(arg, oid, epoch++,
+		    VOS_OF_USE_TIMESTAMPS | VOS_OF_COND_AKEY_FETCH, dkey, akey4,
+		    DAOS_IOD_SINGLE, sizeof(buf_u), &recx, buf_u);
+
+	update_value(arg, oid, epoch++, 0, dkey, akey, DAOS_IOD_ARRAY,
+		     sizeof(buf_u), &recx, buf_u);
+	update_value(arg, oid, epoch++, 0, dkey, akey2, DAOS_IOD_SINGLE,
+		     sizeof(buf_u), &recx, buf_u);
+
+	epr.epr_hi = epoch++;
+
+	rc = vos_aggregate(arg->ctx.tc_co_hdl, &epr, NULL);
+	assert_int_equal(rc, 0);
+
+	fetch_value(arg, oid, epoch++,
+		    VOS_OF_USE_TIMESTAMPS | VOS_OF_COND_AKEY_FETCH, dkey, akey,
+		    DAOS_IOD_ARRAY, sizeof(buf_u), &recx, buf_u);
+	fetch_value(arg, oid, epoch++,
+		    VOS_OF_USE_TIMESTAMPS | VOS_OF_COND_AKEY_FETCH, dkey, akey2,
+		    DAOS_IOD_SINGLE, sizeof(buf_u), &recx, buf_u);
+	fetch_value(arg, oid, epoch++,
+		    VOS_OF_USE_TIMESTAMPS | VOS_OF_COND_AKEY_FETCH, dkey, akey3,
+		    DAOS_IOD_ARRAY, sizeof(buf_u), &recx, buf_u);
+	fetch_value(arg, oid, epoch++,
+		    VOS_OF_USE_TIMESTAMPS | VOS_OF_COND_AKEY_FETCH, dkey, akey4,
+		    DAOS_IOD_SINGLE, sizeof(buf_u), &recx, buf_u);
+
+	arg->ta_flags &= TF_PUNCH;
+
+	memset(buf_u, 'x', sizeof(buf_u));
+
+	/* Also check conditional updates still work */
+	update_value(arg, oid, epoch++,
+		     VOS_OF_USE_TIMESTAMPS | VOS_OF_COND_DKEY_UPDATE, dkey,
+		     akey, DAOS_IOD_ARRAY, sizeof(buf_u), &recx, buf_u);
+	update_value(arg, oid, epoch++,
+		     VOS_OF_USE_TIMESTAMPS | VOS_OF_COND_AKEY_UPDATE, dkey,
+		     akey2, DAOS_IOD_SINGLE, sizeof(buf_u), &recx, buf_u);
+	update_value(arg, oid, epoch++,
+		     VOS_OF_USE_TIMESTAMPS | VOS_OF_COND_AKEY_UPDATE, dkey,
+		     akey3, DAOS_IOD_ARRAY, sizeof(buf_u), &recx, buf_u);
+	update_value(arg, oid, epoch++,
+		     VOS_OF_USE_TIMESTAMPS | VOS_OF_COND_DKEY_UPDATE, dkey,
+		     akey4, DAOS_IOD_SINGLE, sizeof(buf_u), &recx, buf_u);
+}
+
 
 static int
 agg_tst_teardown(void **state)
@@ -2015,6 +2112,8 @@ static const struct CMUnitTest aggregate_tests[] = {
 	  aggregate_20, NULL, agg_tst_teardown },
 	{ "VOS421: Aggregate EV with random punch, small flush threshold, csum",
 	  aggregate_21, NULL, agg_tst_teardown },
+	{ "VOS422: Conditional fetch before and after aggregation is same",
+	  aggregate_22, NULL, agg_tst_teardown },
 };
 
 int

--- a/src/vos/tests/vts_aggregate.c
+++ b/src/vos/tests/vts_aggregate.c
@@ -86,7 +86,7 @@ update_value(struct io_test_args *arg, daos_unit_oid_t oid, daos_epoch_t epoch,
 			arg->ta_flags |= TF_ZERO_COPY;
 	}
 
-	rc = io_test_obj_update(arg, epoch, 0, &dkey_iov, &iod, &sgl, NULL,
+	rc = io_test_obj_update(arg, epoch, flags, &dkey_iov, &iod, &sgl, NULL,
 				true);
 	assert_int_equal(rc, 0);
 

--- a/src/vos/tests/vts_dtx.c
+++ b/src/vos/tests/vts_dtx.c
@@ -299,7 +299,7 @@ dtx_5(void **state)
 			   dkey_hash, DAOS_INTENT_UPDATE, &dth);
 	assert_int_equal(rc, 0);
 
-	rc = io_test_obj_update(args, epoch, &dkey, &iod, &sgl, dth, true);
+	rc = io_test_obj_update(args, epoch, 0, &dkey, &iod, &sgl, dth, true);
 	assert_int_equal(rc, 0);
 
 	/* The DTX is 'prepared'. */
@@ -353,7 +353,7 @@ vts_dtx_commit_visibility(struct io_test_args *args, bool ext, bool punch_obj)
 			   dkey_hash, DAOS_INTENT_UPDATE, &dth);
 	assert_int_equal(rc, 0);
 
-	rc = io_test_obj_update(args, epoch, &dkey, &iod, &sgl, dth, true);
+	rc = io_test_obj_update(args, epoch, 0, &dkey, &iod, &sgl, dth, true);
 	assert_int_equal(rc, 0);
 
 	/* The update DTX is 'prepared'. */
@@ -363,7 +363,7 @@ vts_dtx_commit_visibility(struct io_test_args *args, bool ext, bool punch_obj)
 	d_iov_set(&val_iov, fetch_buf, UPDATE_BUF_SIZE);
 	iod.iod_size = DAOS_REC_ANY;
 
-	rc = io_test_obj_fetch(args, epoch, &dkey, &iod, &sgl, true);
+	rc = io_test_obj_fetch(args, epoch, 0, &dkey, &iod, &sgl, true);
 	assert_int_equal(rc, 0);
 
 	/* Data record with update DTX is invisible before commit. */
@@ -378,7 +378,7 @@ vts_dtx_commit_visibility(struct io_test_args *args, bool ext, bool punch_obj)
 	iod.iod_size = DAOS_REC_ANY;
 
 	/* Fetch again. */
-	rc = io_test_obj_fetch(args, epoch, &dkey, &iod, &sgl, true);
+	rc = io_test_obj_fetch(args, epoch, 0, &dkey, &iod, &sgl, true);
 	assert_int_equal(rc, 0);
 
 	/* Data record with update DTX is readable after commit. */
@@ -406,7 +406,7 @@ vts_dtx_commit_visibility(struct io_test_args *args, bool ext, bool punch_obj)
 	d_iov_set(&val_iov, fetch_buf, UPDATE_BUF_SIZE);
 	iod.iod_size = DAOS_REC_ANY;
 
-	rc = io_test_obj_fetch(args, ++epoch, &dkey, &iod, &sgl, true);
+	rc = io_test_obj_fetch(args, ++epoch, 0, &dkey, &iod, &sgl, true);
 	/* Punch is not yet visible */
 	assert_int_equal(rc, 0);
 
@@ -421,7 +421,7 @@ vts_dtx_commit_visibility(struct io_test_args *args, bool ext, bool punch_obj)
 	iod.iod_size = DAOS_REC_ANY;
 
 	/* Fetch again. */
-	rc = io_test_obj_fetch(args, ++epoch, &dkey, &iod, &sgl, true);
+	rc = io_test_obj_fetch(args, ++epoch, 0, &dkey, &iod, &sgl, true);
 	assert_int_equal(rc, 0);
 
 	/* Data record with punch DTX is invisible after commit. */
@@ -483,7 +483,7 @@ vts_dtx_abort_visibility(struct io_test_args *args, bool ext, bool punch_obj)
 			    &epoch, ext);
 
 	/* initial update. */
-	rc = io_test_obj_update(args, epoch, &dkey, &iod, &sgl, dth, true);
+	rc = io_test_obj_update(args, epoch, 0, &dkey, &iod, &sgl, dth, true);
 	assert_int_equal(rc, 0);
 
 	dts_buf_render(update_buf2, UPDATE_BUF_SIZE);
@@ -494,7 +494,7 @@ vts_dtx_abort_visibility(struct io_test_args *args, bool ext, bool punch_obj)
 			   dkey_hash, DAOS_INTENT_UPDATE, &dth);
 	assert_int_equal(rc, 0);
 
-	rc = io_test_obj_update(args, epoch, &dkey, &iod, &sgl, dth, true);
+	rc = io_test_obj_update(args, epoch, 0, &dkey, &iod, &sgl, dth, true);
 	assert_int_equal(rc, 0);
 
 	/* The update DTX is 'prepared'. */
@@ -508,7 +508,7 @@ vts_dtx_abort_visibility(struct io_test_args *args, bool ext, bool punch_obj)
 	d_iov_set(&val_iov, fetch_buf, UPDATE_BUF_SIZE);
 	iod.iod_size = DAOS_REC_ANY;
 
-	rc = io_test_obj_fetch(args, epoch, &dkey, &iod, &sgl, true);
+	rc = io_test_obj_fetch(args, epoch, 0, &dkey, &iod, &sgl, true);
 	assert_int_equal(rc, 0);
 
 	assert_memory_not_equal(update_buf2, fetch_buf, UPDATE_BUF_SIZE);
@@ -541,7 +541,7 @@ vts_dtx_abort_visibility(struct io_test_args *args, bool ext, bool punch_obj)
 	d_iov_set(&val_iov, fetch_buf, UPDATE_BUF_SIZE);
 	iod.iod_size = DAOS_REC_ANY;
 
-	rc = io_test_obj_fetch(args, ++epoch, &dkey, &iod, &sgl, true);
+	rc = io_test_obj_fetch(args, ++epoch, 0, &dkey, &iod, &sgl, true);
 	assert_int_equal(rc, 0);
 
 	/* The fetched result is the data written via the initial update. */
@@ -608,7 +608,7 @@ dtx_14(void **state)
 			   dkey_hash, DAOS_INTENT_UPDATE, &dth);
 	assert_int_equal(rc, 0);
 
-	rc = io_test_obj_update(args, epoch, &dkey, &iod, &sgl, dth, true);
+	rc = io_test_obj_update(args, epoch, 0, &dkey, &iod, &sgl, dth, true);
 	assert_int_equal(rc, 0);
 
 	/* The DTX is 'prepared'. */
@@ -625,7 +625,7 @@ dtx_14(void **state)
 	d_iov_set(&val_iov, fetch_buf, UPDATE_BUF_SIZE);
 	iod.iod_size = DAOS_REC_ANY;
 
-	rc = io_test_obj_fetch(args, epoch, &dkey, &iod, &sgl, true);
+	rc = io_test_obj_fetch(args, epoch, 0, &dkey, &iod, &sgl, true);
 	assert_int_equal(rc, 0);
 
 	/* Data record is not affected by double commit. */
@@ -641,7 +641,7 @@ dtx_14(void **state)
 	d_iov_set(&val_iov, fetch_buf, UPDATE_BUF_SIZE);
 	iod.iod_size = DAOS_REC_ANY;
 
-	rc = io_test_obj_fetch(args, epoch, &dkey, &iod, &sgl, true);
+	rc = io_test_obj_fetch(args, epoch, 0, &dkey, &iod, &sgl, true);
 	assert_int_equal(rc, 0);
 
 	/* Data record is not affected by failed abort. */
@@ -677,7 +677,7 @@ dtx_15(void **state)
 			    &epoch, false);
 
 	/* initial update. */
-	rc = io_test_obj_update(args, epoch, &dkey, &iod, &sgl, dth, true);
+	rc = io_test_obj_update(args, epoch, 0, &dkey, &iod, &sgl, dth, true);
 	assert_int_equal(rc, 0);
 
 	dts_buf_render(update_buf2, UPDATE_BUF_SIZE);
@@ -688,7 +688,7 @@ dtx_15(void **state)
 			   dkey_hash, DAOS_INTENT_UPDATE, &dth);
 	assert_int_equal(rc, 0);
 
-	rc = io_test_obj_update(args, epoch, &dkey, &iod, &sgl, dth, true);
+	rc = io_test_obj_update(args, epoch, 0, &dkey, &iod, &sgl, dth, true);
 	assert_int_equal(rc, 0);
 
 	/* The update DTX is 'prepared'. */
@@ -705,7 +705,7 @@ dtx_15(void **state)
 	d_iov_set(&val_iov, fetch_buf, UPDATE_BUF_SIZE);
 	iod.iod_size = DAOS_REC_ANY;
 
-	rc = io_test_obj_fetch(args, epoch, &dkey, &iod, &sgl, true);
+	rc = io_test_obj_fetch(args, epoch, 0, &dkey, &iod, &sgl, true);
 	assert_int_equal(rc, 0);
 
 	assert_memory_not_equal(update_buf2, fetch_buf, UPDATE_BUF_SIZE);
@@ -719,7 +719,7 @@ dtx_15(void **state)
 	d_iov_set(&val_iov, fetch_buf, UPDATE_BUF_SIZE);
 	iod.iod_size = DAOS_REC_ANY;
 
-	rc = io_test_obj_fetch(args, epoch, &dkey, &iod, &sgl, true);
+	rc = io_test_obj_fetch(args, epoch, 0, &dkey, &iod, &sgl, true);
 	assert_int_equal(rc, 0);
 
 	assert_memory_not_equal(update_buf2, fetch_buf, UPDATE_BUF_SIZE);
@@ -761,7 +761,7 @@ dtx_16(void **state)
 			   dkey_hash, DAOS_INTENT_UPDATE, &dth);
 	assert_int_equal(rc, 0);
 
-	rc = io_test_obj_update(args, epoch, &dkey, &iod, &sgl, dth, true);
+	rc = io_test_obj_update(args, epoch, 0, &dkey, &iod, &sgl, dth, true);
 	assert_int_equal(rc, 0);
 
 	/* The DTX is 'prepared'. */
@@ -780,7 +780,7 @@ dtx_16(void **state)
 
 	daos_fail_loc_reset();
 
-	rc = io_test_obj_fetch(args, epoch, &dkey, &iod, &sgl, true);
+	rc = io_test_obj_fetch(args, epoch, 0, &dkey, &iod, &sgl, true);
 	assert_int_equal(rc, 0);
 
 	/* Former DTX is not committed, so nothing can be fetched. */
@@ -792,7 +792,7 @@ dtx_16(void **state)
 	assert_int_equal(rc, 0);
 
 	/* Fetch again. */
-	rc = io_test_obj_fetch(args, epoch, &dkey, &iod, &sgl, true);
+	rc = io_test_obj_fetch(args, epoch, 0, &dkey, &iod, &sgl, true);
 	assert_int_equal(rc, 0);
 
 	/* The DTX in CoS cache will make related data record as readable. */
@@ -883,7 +883,7 @@ dtx_17(void **state)
 				   DAOS_INTENT_UPDATE, &dth);
 		assert_int_equal(rc, 0);
 
-		rc = io_test_obj_update(args, epoch[i], &dkey, &iod, &sgl,
+		rc = io_test_obj_update(args, epoch[i], 0, &dkey, &iod, &sgl,
 					dth, true);
 		assert_int_equal(rc, 0);
 
@@ -970,7 +970,7 @@ dtx_18(void **state)
 				   DAOS_INTENT_UPDATE, &dth);
 		assert_int_equal(rc, 0);
 
-		rc = io_test_obj_update(args, epoch, &dkey, &iod, &sgl,
+		rc = io_test_obj_update(args, epoch, 0, &dkey, &iod, &sgl,
 					dth, true);
 		assert_int_equal(rc, 0);
 
@@ -1001,7 +1001,7 @@ dtx_18(void **state)
 	d_iov_set(&val_iov, fetch_buf, UPDATE_BUF_SIZE);
 	iod.iod_size = DAOS_REC_ANY;
 
-	rc = io_test_obj_fetch(args, epoch, &dkey, &iod, &sgl, true);
+	rc = io_test_obj_fetch(args, epoch, 0, &dkey, &iod, &sgl, true);
 	assert_int_equal(rc, 0);
 
 	/* Related data record is still readable after DTX aggregation. */
@@ -1050,7 +1050,7 @@ vts_dtx_shares(struct io_test_args *args, int *commit_list, int commit_count,
 			   dkey_hash, DAOS_INTENT_UPDATE, &dth);
 	assert_int_equal(rc, 0);
 
-	rc = io_test_obj_update(args, epoch[0], &dkey, &iod[0], &sgl[0],
+	rc = io_test_obj_update(args, epoch[0], 0, &dkey, &iod[0], &sgl[0],
 				dth, true);
 	assert_int_equal(rc, 0);
 
@@ -1095,8 +1095,8 @@ vts_dtx_shares(struct io_test_args *args, int *commit_list, int commit_count,
 				   DAOS_INTENT_UPDATE, &dth);
 		assert_int_equal(rc, 0);
 
-		rc = io_test_obj_update(args, epoch[i], &dkey, &iod[i], &sgl[i],
-					dth, true);
+		rc = io_test_obj_update(args, epoch[i], 0, &dkey, &iod[i],
+					&sgl[i], dth, true);
 		assert_int_equal(rc, 0);
 
 		vts_dtx_end(dth);
@@ -1135,7 +1135,7 @@ vts_dtx_shares(struct io_test_args *args, int *commit_list, int commit_count,
 		d_iov_set(&val_iov, fetch_buf, UPDATE_BUF_SIZE);
 		iod[commit_list[i]].iod_size = DAOS_REC_ANY;
 
-		rc = io_test_obj_fetch(args, epoch[commit_list[i]], &dkey,
+		rc = io_test_obj_fetch(args, epoch[commit_list[i]], 0, &dkey,
 				       &iod[commit_list[i]],
 				       &sgl[commit_list[i]], true);
 		assert_int_equal(rc, 0);
@@ -1149,7 +1149,7 @@ vts_dtx_shares(struct io_test_args *args, int *commit_list, int commit_count,
 		d_iov_set(&val_iov, fetch_buf, UPDATE_BUF_SIZE);
 		iod[abort_list[i]].iod_size = DAOS_REC_ANY;
 
-		rc = io_test_obj_fetch(args, epoch[abort_list[i]], &dkey,
+		rc = io_test_obj_fetch(args, epoch[abort_list[i]], 0, &dkey,
 				       &iod[abort_list[i]],
 				       &sgl[abort_list[i]], true);
 		assert_int_equal(rc, 0);
@@ -1306,7 +1306,7 @@ vts_dtx_shares_with_punch(struct io_test_args *args, bool punch_obj, bool abort)
 			   dkey_hash, DAOS_INTENT_UPDATE, &dth);
 	assert_int_equal(rc, 0);
 
-	rc = io_test_obj_update(args, epoch[0], &dkey, &iod[0], &sgl[0],
+	rc = io_test_obj_update(args, epoch[0], 0, &dkey, &iod[0], &sgl[0],
 				dth, true);
 	assert_int_equal(rc, 0);
 
@@ -1351,8 +1351,8 @@ vts_dtx_shares_with_punch(struct io_test_args *args, bool punch_obj, bool abort)
 				   DAOS_INTENT_UPDATE, &dth);
 		assert_int_equal(rc, 0);
 
-		rc = io_test_obj_update(args, epoch[i], &dkey, &iod[i], &sgl[i],
-					dth, true);
+		rc = io_test_obj_update(args, epoch[i], 0, &dkey, &iod[i],
+					&sgl[i], dth, true);
 		assert_int_equal(rc, 0);
 
 		vts_dtx_end(dth);
@@ -1400,7 +1400,8 @@ vts_dtx_shares_with_punch(struct io_test_args *args, bool punch_obj, bool abort)
 	iod[0].iod_size = DAOS_REC_ANY;
 
 	/* DTX[0] is aborted, so cannot be read even if against epoch[0] */
-	rc = io_test_obj_fetch(args, epoch[0], &dkey, &iod[0], &sgl[0], true);
+	rc = io_test_obj_fetch(args, epoch[0], 0, &dkey, &iod[0], &sgl[0],
+			       true);
 	assert_int_equal(rc, 0);
 
 	assert_memory_not_equal(update_buf[0], fetch_buf, UPDATE_BUF_SIZE);
@@ -1411,7 +1412,7 @@ vts_dtx_shares_with_punch(struct io_test_args *args, bool punch_obj, bool abort)
 		iod[i].iod_size = DAOS_REC_ANY;
 
 		/* DTX[i] is committed, so readable against its epoch[i] */
-		rc = io_test_obj_fetch(args, epoch[i], &dkey, &iod[i],
+		rc = io_test_obj_fetch(args, epoch[i], 0, &dkey, &iod[i],
 				       &sgl[i], true);
 		assert_int_equal(rc, 0);
 
@@ -1423,7 +1424,7 @@ vts_dtx_shares_with_punch(struct io_test_args *args, bool punch_obj, bool abort)
 		d_iov_set(&val_iov, fetch_buf, UPDATE_BUF_SIZE);
 		iod[0].iod_size = DAOS_REC_ANY;
 
-		rc = io_test_obj_fetch(args, ++epoch[3], &dkey, &iod[0],
+		rc = io_test_obj_fetch(args, ++epoch[3], 0, &dkey, &iod[0],
 				       &sgl[0], true);
 		assert_int_equal(rc, 0);
 
@@ -1435,8 +1436,8 @@ vts_dtx_shares_with_punch(struct io_test_args *args, bool punch_obj, bool abort)
 			d_iov_set(&val_iov, fetch_buf, UPDATE_BUF_SIZE);
 			iod[i].iod_size = DAOS_REC_ANY;
 
-			rc = io_test_obj_fetch(args, ++epoch[3], &dkey, &iod[i],
-					       &sgl[i], true);
+			rc = io_test_obj_fetch(args, ++epoch[3], 0, &dkey,
+					       &iod[i], &sgl[i], true);
 			assert_int_equal(rc, 0);
 
 			assert_memory_equal(update_buf[i], fetch_buf,
@@ -1448,8 +1449,8 @@ vts_dtx_shares_with_punch(struct io_test_args *args, bool punch_obj, bool abort)
 			d_iov_set(&val_iov, fetch_buf, UPDATE_BUF_SIZE);
 			iod[i].iod_size = DAOS_REC_ANY;
 
-			rc = io_test_obj_fetch(args, ++epoch[3], &dkey, &iod[i],
-					       &sgl[i], true);
+			rc = io_test_obj_fetch(args, ++epoch[3], 0, &dkey,
+					       &iod[i], &sgl[i], true);
 			assert_int_equal(rc, 0);
 
 			assert_memory_not_equal(update_buf[i], fetch_buf,

--- a/src/vos/tests/vts_io.c
+++ b/src/vos/tests/vts_io.c
@@ -546,7 +546,7 @@ io_test_obj_update(struct io_test_args *arg, daos_epoch_t epoch, uint64_t flags,
 	}
 
 	if (!(arg->ta_flags & TF_ZERO_COPY)) {
-		rc = vos_obj_update(arg->ctx.tc_co_hdl, arg->oid, epoch, flags,
+		rc = vos_obj_update(arg->ctx.tc_co_hdl, arg->oid, epoch, 0,
 				    flags, dkey, 1, iod, iod_csums, sgl);
 		if (rc != 0 && verbose)
 			print_error("Failed to update: "DF_RC"\n", DP_RC(rc));

--- a/src/vos/tests/vts_io.c
+++ b/src/vos/tests/vts_io.c
@@ -546,7 +546,7 @@ io_test_obj_update(struct io_test_args *arg, daos_epoch_t epoch, uint64_t flags,
 	}
 
 	if (!(arg->ta_flags & TF_ZERO_COPY)) {
-		rc = vos_obj_update(arg->ctx.tc_co_hdl, arg->oid, epoch, 0,
+		rc = vos_obj_update(arg->ctx.tc_co_hdl, arg->oid, epoch, flags,
 				    flags, dkey, 1, iod, iod_csums, sgl);
 		if (rc != 0 && verbose)
 			print_error("Failed to update: "DF_RC"\n", DP_RC(rc));
@@ -555,8 +555,8 @@ io_test_obj_update(struct io_test_args *arg, daos_epoch_t epoch, uint64_t flags,
 	/* Punch can't be zero copy */
 	assert_true(iod->iod_size > 0);
 
-	rc = vos_update_begin(arg->ctx.tc_co_hdl, arg->oid, epoch, 0, dkey, 1,
-			      iod, iod_csums, &ioh, dth);
+	rc = vos_update_begin(arg->ctx.tc_co_hdl, arg->oid, epoch, flags, dkey,
+			      1, iod, iod_csums, &ioh, dth);
 	if (rc != 0) {
 		if (verbose && rc != -DER_INPROGRESS)
 			print_error("Failed to prepare ZC update: "DF_RC"\n",

--- a/src/vos/tests/vts_io.c
+++ b/src/vos/tests/vts_io.c
@@ -526,7 +526,7 @@ io_test_add_csums(daos_iod_t *iod, d_sg_list_t *sgl,
 }
 
 int
-io_test_obj_update(struct io_test_args *arg, daos_epoch_t epoch,
+io_test_obj_update(struct io_test_args *arg, daos_epoch_t epoch, uint64_t flags,
 		   daos_key_t *dkey, daos_iod_t *iod, d_sg_list_t *sgl,
 		   struct dtx_handle *dth, bool verbose)
 {
@@ -547,7 +547,7 @@ io_test_obj_update(struct io_test_args *arg, daos_epoch_t epoch,
 
 	if (!(arg->ta_flags & TF_ZERO_COPY)) {
 		rc = vos_obj_update(arg->ctx.tc_co_hdl, arg->oid, epoch, 0,
-				    0, dkey, 1, iod, iod_csums, sgl);
+				    flags, dkey, 1, iod, iod_csums, sgl);
 		if (rc != 0 && verbose)
 			print_error("Failed to update: "DF_RC"\n", DP_RC(rc));
 		goto end;
@@ -596,7 +596,7 @@ end:
 }
 
 int
-io_test_obj_fetch(struct io_test_args *arg, daos_epoch_t epoch,
+io_test_obj_fetch(struct io_test_args *arg, daos_epoch_t epoch, uint64_t flags,
 		  daos_key_t *dkey, daos_iod_t *iod, d_sg_list_t *sgl,
 		  bool verbose)
 {
@@ -617,7 +617,7 @@ io_test_obj_fetch(struct io_test_args *arg, daos_epoch_t epoch,
 		return rc;
 	}
 
-	rc = vos_fetch_begin(arg->ctx.tc_co_hdl, arg->oid, epoch, 0, dkey,
+	rc = vos_fetch_begin(arg->ctx.tc_co_hdl, arg->oid, epoch, flags, dkey,
 			     1, iod, false, &ioh);
 	if (rc != 0) {
 		if (verbose && rc != -DER_INPROGRESS)
@@ -647,9 +647,12 @@ io_test_obj_fetch(struct io_test_args *arg, daos_epoch_t epoch,
 	rc = bio_iod_post(vos_ioh2desc(ioh));
 end:
 	rc = vos_fetch_end(ioh, rc);
-	if (rc != 0 && verbose && rc != -DER_INPROGRESS)
+	if (((flags & VOS_COND_FETCH_MASK) && rc == -DER_NONEXIST) ||
+	    rc == -DER_INPROGRESS)
+		goto skip;
+	if (rc != 0 && verbose)
 		print_error("Failed to submit ZC update: "DF_RC"\n", DP_RC(rc));
-
+skip:
 	return rc;
 }
 
@@ -725,7 +728,7 @@ io_update_and_fetch_dkey(struct io_test_args *arg, daos_epoch_t update_epoch,
 	iod.iod_nr	= 1;
 
 	/* Act */
-	rc = io_test_obj_update(arg, update_epoch, &dkey, &iod, &sgl,
+	rc = io_test_obj_update(arg, update_epoch, 0, &dkey, &iod, &sgl,
 				NULL, true);
 	if (rc)
 		goto exit;
@@ -739,7 +742,7 @@ io_update_and_fetch_dkey(struct io_test_args *arg, daos_epoch_t update_epoch,
 	iod.iod_size = DAOS_REC_ANY;
 
 	/* Act again */
-	rc = io_test_obj_fetch(arg, fetch_epoch, &dkey, &iod, &sgl, true);
+	rc = io_test_obj_fetch(arg, fetch_epoch, 0, &dkey, &iod, &sgl, true);
 	if (rc)
 		goto exit;
 
@@ -1202,7 +1205,7 @@ io_update_and_fetch_incorrect_dkey(struct io_test_args *arg,
 	iod.iod_nr	= 1;
 	iod.iod_type	= DAOS_IOD_ARRAY;
 
-	rc = io_test_obj_update(arg, update_epoch, &dkey, &iod, &sgl,
+	rc = io_test_obj_update(arg, update_epoch, 0, &dkey, &iod, &sgl,
 				NULL, true);
 	if (rc)
 		goto exit;
@@ -1218,7 +1221,7 @@ io_update_and_fetch_incorrect_dkey(struct io_test_args *arg,
 	/* Injecting an incorrect dkey for fetch! */
 	vts_key_gen(&dkey_buf[0], arg->dkey_size, true, arg);
 
-	rc = io_test_obj_fetch(arg, fetch_epoch, &dkey, &iod, &sgl, true);
+	rc = io_test_obj_fetch(arg, fetch_epoch, 0, &dkey, &iod, &sgl, true);
 	assert_int_equal(rc, 0);
 	assert_int_equal(iod.iod_size, 0);
 exit:
@@ -1267,7 +1270,7 @@ io_fetch_wo_object(void **state)
 	iod.iod_size = -1;
 	arg->oid = gen_oid(arg->ofeat);
 
-	rc = io_test_obj_fetch(arg, 1, &dkey, &iod, &sgl, true);
+	rc = io_test_obj_fetch(arg, 1, 0, &dkey, &iod, &sgl, true);
 	assert_int_equal(rc, 0);
 	assert_int_equal(iod.iod_size, 0);
 }

--- a/src/vos/tests/vts_io.c
+++ b/src/vos/tests/vts_io.c
@@ -610,7 +610,7 @@ io_test_obj_fetch(struct io_test_args *arg, daos_epoch_t epoch, uint64_t flags,
 
 	if (!(arg->ta_flags & TF_ZERO_COPY)) {
 		rc = vos_obj_fetch(arg->ctx.tc_co_hdl,
-				   arg->oid, epoch, 0, dkey, 1, iod,
+				   arg->oid, epoch, flags, dkey, 1, iod,
 				   sgl);
 		if (rc != 0 && verbose)
 			print_error("Failed to fetch: "DF_RC"\n", DP_RC(rc));

--- a/src/vos/tests/vts_io.h
+++ b/src/vos/tests/vts_io.h
@@ -110,13 +110,14 @@ void			inc_cntr(unsigned long op_flags);
 void			test_args_reset(struct io_test_args *args,
 					uint64_t pool_size);
 int			io_test_obj_update(struct io_test_args *arg,
-					   daos_epoch_t epoch, daos_key_t *dkey,
-					   daos_iod_t *iod,
+					   daos_epoch_t epoch, uint64_t flags,
+					   daos_key_t *dkey, daos_iod_t *iod,
 					   d_sg_list_t *sgl,
 					   struct dtx_handle *dth,
 					   bool verbose);
 int			io_test_obj_fetch(struct io_test_args *arg,
-					  daos_epoch_t epoch, daos_key_t *dkey,
+					  daos_epoch_t epoch, uint64_t flags,
+					  daos_key_t *dkey,
 					  daos_iod_t *iod,
 					  d_sg_list_t *sgl,
 					  bool verbose);


### PR DESCRIPTION
Adds a test to aggregation to ensure we don't remove key trees.
This appears to already be the case.   Added flags to the test
io routines so I could check this with conditional operations
that would fail otherwise.

Also shuts off the error message in aggregation associated with
evtrees with only holes.  Instead, it assumes a record size of
1.   Since it is all holes, it shouldn't matter what size is
used.

Signed-off-by: Jeff Olivier <jeffrey.v.olivier@intel.com>