### PR TITLE
DAOS-4848 object: Fix a log message (and compiler warning)

### DIFF
--- a/src/object/srv_obj.c
+++ b/src/object/srv_obj.c
@@ -924,7 +924,7 @@ obj_local_rw(crt_rpc_t *rpc, struct ds_cont_hdl *cont_hdl,
 
 		if (rc) {
 			D_CDEBUG(rc == -DER_INPROGRESS, DB_IO, DLOG_ERR,
-				 " Fetch begin failed: "DF_RC"\n",
+				 " Fetch begin for "DF_UOID" failed: "DF_RC"\n",
 				 DP_UOID(orw->orw_oid), DP_RC(rc));
 			goto out;
 		}


### PR DESCRIPTION
For some reason, -Werror got disabled so this wasn't caught
but the log message was missing a format entry

Signed-off-by: Jeff Olivier <jeffrey.v.olivier@intel.com>