### PR TITLE
DAOS-4849 build: -Werror inadvertently removed (#2182)

### DIFF
--- a/src/client/pydaos/SConscript
+++ b/src/client/pydaos/SConscript
@@ -21,6 +21,8 @@ def build_shim_module(env, lib_prefix, version):
     new_env.AppendUnique(LIBPATH=["../dfs"])
     new_env.AppendUnique(RPATH=[Literal(r'\$$ORIGIN/../../..')])
 
+    daos_build.clear_icc_env(new_env)
+
     obj = new_env.SharedObject(tgt_name, 'pydaos_shim.c',
                                CC='gcc -pthread',
                                SHLINKFLAGS=[],

--- a/src/container/cli.c
+++ b/src/container/cli.c
@@ -1843,7 +1843,7 @@ dc_cont_get_attr(tse_task_t *task)
 	D_ASSERTF(args != NULL, "Task Argument OPC does not match DC OPC\n");
 
 	rc = attr_check_input(args->n, args->names,
-			      (void const *const) args->values,
+			      (const void *const*) args->values,
 			      (size_t *)args->sizes, true);
 	if (rc != 0)
 		D_GOTO(out, rc);

--- a/src/pool/cli.c
+++ b/src/pool/cli.c
@@ -1968,7 +1968,7 @@ dc_pool_get_attr(tse_task_t *task)
 	D_ASSERTF(args != NULL, "Task Argument OPC does not match DC OPC\n");
 
 	rc = attr_check_input(args->n, args->names,
-			      (void const *const) args->values,
+			      (const void *const*) args->values,
 			      (size_t *)args->sizes, true);
 	if (rc != 0)
 		D_GOTO(out, rc);

--- a/src/rebuild/initiator.c
+++ b/src/rebuild/initiator.c
@@ -1265,7 +1265,7 @@ rebuild_scheduled_obj_insert_cb(struct rebuild_root *cont_root, uuid_t co_uuid,
 				unsigned int *cnt, int ref)
 {
 	struct rebuilt_oid	*roid;
-	struct rebuilt_oid	roid_tmp;
+	struct rebuilt_oid	roid_tmp = {0};
 	struct rebuild_obj_key	key = { 0 };
 	uint32_t		req_cnt;
 	d_iov_t		key_iov;

--- a/src/rebuild/srv.c
+++ b/src/rebuild/srv.c
@@ -723,7 +723,7 @@ rebuild_global_pool_tracker_create(struct ds_pool *pool, uint32_t ver,
 				   struct rebuild_global_pool_tracker **p_rgt)
 {
 	struct rebuild_global_pool_tracker *rgt;
-	unsigned int node_nr;
+	int node_nr;
 	struct pool_domain *doms;
 	int i;
 	int rc = 0;

--- a/src/tests/suite/SConscript
+++ b/src/tests/suite/SConscript
@@ -6,7 +6,7 @@ def scons():
     Import('denv')
 
     libraries = ['daos_common', 'daos', 'dfs', 'daos_tests', 'gurt', 'cart']
-    libraries += ['uuid', 'mpi', 'dfs', 'cmocka', 'pthread']
+    libraries += ['uuid', 'dfs', 'cmocka', 'pthread']
 
     denv.AppendUnique(LIBPATH=["$BUILD_DIR/src/client/dfs"])
 

--- a/src/tests/suite/io_conf/SConscript
+++ b/src/tests/suite/io_conf/SConscript
@@ -6,8 +6,7 @@ def scons():
     Import('denv')
 
     libraries = ['daos_common', 'daos', 'daos_tests', 'gurt', 'cart']
-    libraries += ['uuid', 'mpi']
-    libraries += ['cmocka']
+    libraries += ['uuid', 'cmocka']
 
     Import('daos_test_tgt')
     Import('daos_epoch_io')


### PR DESCRIPTION
This fixes the check for -Werror so as to restore it to the compiler
commands.
Also disables a few icc diagnostics so we can compile with icc

Co-authored-by: Ashley Pittman <ashley.m.pittman@intel.com>
Signed-off-by: Jeff Olivier <jeffrey.v.olivier@intel.com>