### PR TITLE
DAOS-4392 control: Fix missing agent defaults

### DIFF
--- a/src/control/cmd/daos_agent/config.go
+++ b/src/control/cmd/daos_agent/config.go
@@ -35,6 +35,8 @@ import (
 
 const (
 	defaultConfigFile = "daos_agent.yml"
+	defaultRuntimeDir = "/var/run/daos_agent"
+	defaultLogFile    = "/tmp/daos_agent.log"
 )
 
 // Config defines the agent configuration.
@@ -66,6 +68,8 @@ func DefaultConfig() *Config {
 		SystemName:      build.DefaultSystemName,
 		ControlPort:     build.DefaultControlPort,
 		AccessPoints:    []string{localServer},
+		RuntimeDir:      defaultRuntimeDir,
+		LogFile:         defaultLogFile,
 		TransportConfig: security.DefaultAgentTransportConfig(),
 	}
 }


### PR DESCRIPTION
In the move to isolate the agent config, default values for
the socket directory and log file were accidentally dropped.