### PR TITLE
DAOS-3449 test: Fix errors with and reenable IOR over 256B (#2642)

### DIFF
--- a/src/tests/ftest/io/ior_intercept_basic.yaml
+++ b/src/tests/ftest/io/ior_intercept_basic.yaml
@@ -7,6 +7,7 @@ timeout: 2400
 server_config:
     name: daos_server
     servers:
+        log_mask: INFO
         bdev_class: nvme
         bdev_list: ["0000:81:00.0","0000:da:00.0"]
         scm_class: dcpm
@@ -19,6 +20,9 @@ pool:
     nvme_size: 320000000000
     svcn: 1
     control_method: dmg
+container:
+    type: POSIX
+    control_method: daos
 ior:
     client_processes:
         np_16:

--- a/src/tests/ftest/io/ior_intercept_dfuse_mix.py
+++ b/src/tests/ftest/io/ior_intercept_dfuse_mix.py
@@ -36,14 +36,6 @@ class IorInterceptDfuseMix(IorTestBase):
     :avocado: recursive
     """
 
-    def setUp(self):
-        """Set up each test case."""
-        super(IorInterceptDfuseMix, self).setUp()
-        # Following line can be removed once the constraint
-        # in IorTestBase is removed. # DAOS-3320
-        self.hostlist_clients = self.params.get(
-            "test_clients", "/run/hosts/*")
-
     def test_ior_intercept_dfuse_mix(self):
         """Jira ID: DAOS-3500.
 

--- a/src/tests/ftest/io/ior_intercept_dfuse_mix.yaml
+++ b/src/tests/ftest/io/ior_intercept_dfuse_mix.yaml
@@ -10,6 +10,7 @@ timeout: 2400
 server_config:
     name: daos_server
     servers:
+        log_mask: INFO
         bdev_class: nvme
         bdev_list: ["0000:81:00.0","0000:da:00.0"]
         scm_class: dcpm
@@ -21,6 +22,9 @@ pool:
     nvme_size: 500000000000
     svcn: 1
     control_method: dmg
+container:
+    type: POSIX
+    control_method: daos
 ior:
     client_processes:
       np: 32

--- a/src/tests/ftest/io/ior_intercept_multi_client.py
+++ b/src/tests/ftest/io/ior_intercept_multi_client.py
@@ -37,17 +37,6 @@ class IorInterceptMultiClient(IorTestBase):
     :avocado: recursive
     """
 
-    def setUp(self):
-        """Set up each test case."""
-        super(IorInterceptMultiClient, self).setUp()
-        # This set up can be removed once the constraint
-        # in IorTestBase is removed. # DAOS-3320
-        self.hostlist_clients = self.params.get(
-            "test_clients", "/run/hosts/*")
-        self.hostfile_clients = write_host_file.write_host_file(
-            self.hostlist_clients, self.workdir,
-            self.hostfile_clients_slots)
-
     def test_ior_intercept_multi_client(self):
         """Jira ID: DAOS-3499.
 

--- a/src/tests/ftest/io/ior_intercept_multi_client.yaml
+++ b/src/tests/ftest/io/ior_intercept_multi_client.yaml
@@ -10,6 +10,7 @@ timeout: 8000
 server_config:
     name: daos_server
     servers:
+        log_mask: INFO
         bdev_class: nvme
         bdev_list: ["0000:81:00.0","0000:da:00.0"]
         scm_class: dcpm
@@ -21,6 +22,9 @@ pool:
     nvme_size: 400000000000
     svcn: 1
     control_method: dmg
+container:
+    type: POSIX
+    control_method: daos
 ior:
     client_processes:
       np: 16
@@ -34,17 +38,16 @@ ior:
           api: POSIX
           daos_oclass: "SX"
           transfersize_blocksize: !mux
-#         DAOS-3449
-#            512B:
-#              transfer_size: '512B'
-#              block_size: '128M'
-#              write_x: 1
-#              read_x: 1
-#            1K:
-#              transfer_size: '1K'
-#              block_size: '512M'
-#              write_x: 2
-#              read_x: 1
+            512B:
+              transfer_size: '512B'
+              block_size: '128M'
+              write_x: 1
+              read_x: 1
+            1K:
+              transfer_size: '1K'
+              block_size: '512M'
+              write_x: 2
+              read_x: 1
             4K:
               transfer_size: '4K'
               block_size: '512M'

--- a/src/tests/ftest/io/ior_intercept_verify_data_integrity.py
+++ b/src/tests/ftest/io/ior_intercept_verify_data_integrity.py
@@ -36,14 +36,6 @@ class IorInterceptVerifyDataIntegrity(IorTestBase):
     :avocado: recursive
     """
 
-    def setUp(self):
-        """Set up each test case."""
-        super(IorInterceptVerifyDataIntegrity, self).setUp()
-        # Following line can be removed once the constraint in the
-        # IorTestBase is resolved. #DAOS-3320
-        self.hostlist_clients = self.params.get(
-            "test_clients", "/run/hosts/*")
-
     def test_ior_intercept_verify_data(self):
         """Jira ID: DAOS-3502.
 

--- a/src/tests/ftest/io/ior_intercept_verify_data_integrity.yaml
+++ b/src/tests/ftest/io/ior_intercept_verify_data_integrity.yaml
@@ -13,6 +13,7 @@ timeout: 7200
 server_config:
     name: daos_server
     servers:
+        log_mask: INFO
         bdev_class: nvme
         bdev_list: ["0000:5e:00.0","0000:5f:00.0"]
         #scm_size needed for tmpfs
@@ -30,6 +31,9 @@ pool:
         nvme_size: 200000000000
     createsvc:
         svcn: 1
+container:
+    type: POSIX
+    control_method: daos
 ior:
     client_processes:
         np_24:

--- a/src/tests/ftest/io/ior_large.yaml
+++ b/src/tests/ftest/io/ior_large.yaml
@@ -32,6 +32,7 @@ timeout: 2400
 server_config:
   name: daos_server
   servers:
+    log_mask: INFO
     bdev_class: nvme
     bdev_list: ["0000:81:00.0","0000:da:00.0"]
     scm_class: dcpm
@@ -45,6 +46,7 @@ pool:
   control_method: dmg
 container:
   type: POSIX
+  control_method: daos
 ior:
   client_processes: !mux
     np_1:

--- a/src/tests/ftest/util/dfuse_utils.py
+++ b/src/tests/ftest/util/dfuse_utils.py
@@ -210,7 +210,10 @@ class Dfuse(DfuseCommand):
         if not self.check_running(fail_on_error=False):
             self.log.info('Waiting five seconds for dfuse to start')
             time.sleep(5)
-            self.check_running()
+            if not self.check_running(fail_on_error=False):
+                self.log.info('Waiting twenty five seconds for dfuse to start')
+                time.sleep(25)
+                self.check_running()
 
     def check_running(self, fail_on_error=True):
         """Check dfuse is running

--- a/src/tests/ftest/util/ior_test_base.py
+++ b/src/tests/ftest/util/ior_test_base.py
@@ -67,13 +67,6 @@ class IorTestBase(TestWithServers):
         self.ior_cmd.get_params(self)
         self.processes = self.params.get("np", '/run/ior/client_processes/*')
 
-        # Until DAOS-3320 is resolved run IOR for POSIX
-        # with single client node
-        if self.ior_cmd.api.value == "POSIX":
-            self.hostlist_clients = [self.hostlist_clients[0]]
-            self.hostfile_clients = write_host_file.write_host_file(
-                self.hostlist_clients, self.workdir,
-                self.hostfile_clients_slots)
         # lock is needed for run_multiple_ior method.
         self.lock = threading.Lock()
 
@@ -151,9 +144,6 @@ class IorTestBase(TestWithServers):
         # start dfuse if api is POSIX
         if self.ior_cmd.api.value == "POSIX":
             # Connect to the pool, create container and then start dfuse
-            # Uncomment below two lines once DAOS-3355 is resolved
-            if self.ior_cmd.transfer_size.value == "256B":
-                return "Skipping the case for transfer_size=256B"
             self._start_dfuse()
             test_file = os.path.join(self.dfuse.mount_dir.value, "testfile")
 

--- a/src/tests/ftest/util/mdtest_test_base.py
+++ b/src/tests/ftest/util/mdtest_test_base.py
@@ -69,15 +69,6 @@ class MdtestBase(TestWithServers):
         self.processes = self.params.get("np", '/run/mdtest/client_processes/*')
         self.manager = self.params.get("manager", '/run/mdtest/*', "MPICH")
 
-        # Until DAOS-3320 is resolved run IOR for POSIX
-        # with single client node
-        if self.mdtest_cmd.api.value == "POSIX":
-            self.log.info("Restricting mdtest to one node")
-            self.hostlist_clients = [self.hostlist_clients[0]]
-            self.hostfile_clients = write_host_file.write_host_file(
-                self.hostlist_clients, self.workdir,
-                self.hostfile_clients_slots)
-
         self.log.info('Clients %s', self.hostlist_clients)
         self.log.info('Servers %s', self.hostlist_servers)
 


### PR DESCRIPTION
Create containers with correct POSIX type.
Turn down server logs to avoid filling disk space.
Remove check for 256b message sizes
Do not modify hostlist_clients to be single-node.

Signed-off-by: Ashley Pittman <ashley.m.pittman@intel.com>