### PR TITLE
DAOS-4521 tests: small fixes for daos_perf (#2516)

### DIFF
--- a/src/tests/daos_perf.c
+++ b/src/tests/daos_perf.c
@@ -391,6 +391,7 @@ objects_verify(void)
 			}
 		}
 	}
+	rc = dts_credit_drain(&ts_ctx);
 	return rc;
 }
 
@@ -401,9 +402,13 @@ objects_verify_close(void)
 	int rc = 0;
 
 	if (ts_verify_fetch) {
-		rc = objects_verify();
-		fprintf(stdout, "Fetch verification: %s\n", rc ? "Failed" :
-			"Success");
+		if (ts_single || ts_overwrite) {
+			fprintf(stdout, "Verification is unsupported\n");
+		} else {
+			rc = objects_verify();
+			fprintf(stdout, "Fetch verification: %s\n",
+				rc ? "Failed" : "Success");
+		}
 	}
 
 	for (i = 0; ts_mode == TS_MODE_DAOS && i < ts_obj_p_cont; i++) {
@@ -436,6 +441,7 @@ objects_fetch(d_rank_t rank)
 				return rc;
 		}
 	}
+	rc = dts_credit_drain(&ts_ctx);
 	return rc;
 }
 


### PR DESCRIPTION
- Disable verification for single value and overwrite
- fetch and verification tests should drain I/O credits
  before completing

Signed-off-by: Liang Zhen <liang.zhen@intel.com>