### PR TITLE
TACC: Allow forwarding to be disabled

### DIFF
--- a/src/control/pbin/forwarding.go
+++ b/src/control/pbin/forwarding.go
@@ -25,6 +25,8 @@ package pbin
 import (
 	"context"
 	"encoding/json"
+	"os"
+	"strconv"
 
 	"github.com/pkg/errors"
 
@@ -66,6 +68,16 @@ func NewForwarder(log logging.Logger, pbinName string) *Forwarder {
 	fwd := &Forwarder{
 		log:      log,
 		pbinName: pbinName,
+	}
+
+	if val, set := os.LookupEnv(DisableReqFwdEnvVar); set {
+		disabled, err := strconv.ParseBool(val)
+		if err != nil {
+			log.Errorf("%s was set to non-boolean value (%q); not disabling",
+				DisableReqFwdEnvVar, val)
+			return fwd
+		}
+		fwd.Disabled = disabled
 	}
 
 	return fwd

--- a/src/control/pbin/pbin.go
+++ b/src/control/pbin/pbin.go
@@ -35,6 +35,10 @@ const (
 	// DaosAdminName is the name of the daos_admin privileged helper.
 	DaosAdminName = "daos_admin"
 
+	// DisableReqFwdEnvVar is the name of the environment variable which
+	// can be set to disable forwarding requests to the privileged binary.
+	DisableReqFwdEnvVar = "DAOS_DISABLE_REQ_FWD"
+
 	// DaosAdminLogFileEnvVar is the name of the environment variable which
 	// can be set to enable non-ERROR logging in the privileged binary.
 	DaosAdminLogFileEnvVar = "DAOS_ADMIN_LOG_FILE"
@@ -46,6 +50,10 @@ const (
 func CheckHelper(log logging.Logger, helperName string) error {
 	fwd := NewForwarder(log, helperName)
 	dummy := struct{}{}
+
+	if fwd.Disabled {
+		return nil
+	}
 
 	if err := fwd.SendReq("Ping", dummy, &dummy); err != nil {
 		err = errors.Cause(err)


### PR DESCRIPTION
Apply this patch against release/0.9 (may work with master, untested)
in order to remove a hard requirement on forwarding requests to
daos_admin. As before, DAOS_DISABLE_REQ_FWD=true will disable forwarding
to daos_admin.

Please note that this is an unsupported configuration, and future work
will likely remove all ability for daos_server to operate independently
of daos_admin.

Signed-off-by: Saurabh Tandan <saurabh.tandan@intel.com>