### PR TITLE
DAOS-4542 dtx: (3) re-org DTX CoS cache

### DIFF
--- a/src/dtx/dtx_common.c
+++ b/src/dtx/dtx_common.c
@@ -230,7 +230,7 @@ dtx_handle_init(struct dtx_id *dti, daos_unit_oid_t *oid, daos_handle_t coh,
 	dth->dth_leader = leader ? 1 : 0;
 	dth->dth_solo = solo ? 1 : 0;
 	dth->dth_dti_cos_done = 0;
-	dth->dth_has_ilog = 0;
+	dth->dth_modify_shared = 0;
 	dth->dth_actived = 0;
 
 	/* Operation sequence starts from 1 instead of 0. */
@@ -260,12 +260,11 @@ int
 dtx_leader_begin(struct dtx_id *dti, daos_unit_oid_t *oid, daos_handle_t coh,
 		 daos_epoch_t epoch, uint64_t dkey_hash, uint32_t pm_ver,
 		 uint32_t intent, struct daos_shard_tgt *tgts, int tgts_cnt,
-		 bool cond_check, struct dtx_leader_handle *dlh)
+		 struct dtx_leader_handle *dlh)
 {
 	struct dtx_handle	*dth = &dlh->dlh_handle;
 	struct dtx_id		*dti_cos = NULL;
 	int			 dti_cos_count = 0;
-	uint32_t		 type = DCLT_PUNCH;
 	int			 i;
 
 	/* Single replica case. */
@@ -291,34 +290,17 @@ dtx_leader_begin(struct dtx_id *dti, daos_unit_oid_t *oid, daos_handle_t coh,
 		return 0;
 	}
 
-	/* XXX: For leader case, we need to find out the potential
-	 *	conflict DTXs in the CoS cache, and append them to
-	 *	the dispatched RPC to non-leaders. Then non-leader
-	 *	replicas can commit them before real modifications
-	 *	to avoid availability trouble.
+	/* XXX: The leader needs to find out the DTXs in the CoS cache
+	 *	that modified potential shared items (object/dkey/akey),
+	 *	and append them to the dispatched RPC to non-leaders.
+	 *	Then non-leader replicas can commit them before real
+	 *	modifications to avoid availability trouble.
 	 */
-
-	if (intent == DAOS_INTENT_PUNCH || cond_check)
-		type |= DCLT_UPDATE;
-
-	dti_cos_count = vos_dtx_list_cos(coh, oid, dkey_hash, type,
+	dti_cos_count = vos_dtx_list_cos(coh, oid, dkey_hash,
 					 DTX_THRESHOLD_COUNT, &dti_cos);
 	if (dti_cos_count < 0) {
 		D_FREE(dlh->dlh_subs);
 		return dti_cos_count;
-	}
-
-	if (dti_cos_count > 0 && dti_cos == NULL) {
-		/* There are too many conflict DTXs to be committed,
-		 * as to cannot be taken via the normal IO RPC. The
-		 * background dedicated DTXs batched commit ULT has
-		 * not committed them in time. Let's retry later.
-		 */
-		D_DEBUG(DB_TRACE, "Too many pontential conflict DTXs"
-			" for the given "DF_DTI", let's retry later.\n",
-			DP_DTI(dti));
-		D_FREE(dlh->dlh_subs);
-		return -DER_INPROGRESS;
 	}
 
 init:
@@ -364,7 +346,7 @@ dtx_leader_end(struct dtx_leader_handle *dlh, struct ds_cont_child *cont,
 	       int result)
 {
 	struct dtx_handle		*dth = &dlh->dlh_handle;
-	int				 flags = 0;
+	daos_epoch_t			 epoch = dth->dth_epoch;
 	int				 rc = 0;
 
 	if (dlh->dlh_sub_cnt == 0)
@@ -381,15 +363,13 @@ dtx_leader_end(struct dtx_leader_handle *dlh, struct ds_cont_child *cont,
 	    daos_is_zero_dti(&dth->dth_xid))
 		D_GOTO(out, result = result < 0 ? result : rc);
 
-	if (dth->dth_intent == DAOS_INTENT_PUNCH)
-		flags |= DCF_FOR_PUNCH;
-	if (dth->dth_has_ilog)
-		flags |= DCF_HAS_ILOG;
-
 again:
-	rc = vos_dtx_add_cos(dth->dth_coh, &dth->dth_oid, &dth->dth_xid,
-			     dth->dth_dkey_hash, dth->dth_epoch, dth->dth_gen,
-			     flags);
+	rc = vos_dtx_check_sync(dth->dth_coh, dth->dth_oid, &epoch);
+	if (rc == 0)
+		rc = vos_dtx_add_cos(dth->dth_coh, &dth->dth_oid, &dth->dth_xid,
+				     dth->dth_dkey_hash, dth->dth_epoch,
+				     dth->dth_gen,
+				     dth->dth_modify_shared ? DCF_SHARED : 0);
 	if (rc == -DER_TX_RESTART) {
 		D_WARN(DF_UUID": Fail to add DTX "DF_DTI" to CoS "
 		       "because of using old epoch "DF_U64
@@ -413,7 +393,7 @@ again:
 		goto again;
 	}
 
-	if (rc != 0) {
+	if (rc != 0 && epoch < dth->dth_epoch) {
 		D_WARN(DF_UUID": Fail to add DTX "DF_DTI" to CoS cache: %d. "
 		       "Try to commit it sychronously.\n",
 		       DP_UUID(cont->sc_uuid), DP_DTI(&dth->dth_xid), rc);
@@ -626,7 +606,7 @@ dtx_batched_commit_deregister(struct ds_cont_child *cont)
 
 int
 dtx_handle_resend(daos_handle_t coh, daos_unit_oid_t *oid, struct dtx_id *dti,
-		  uint64_t dkey_hash, bool punch, daos_epoch_t *epoch)
+		  uint64_t dkey_hash, daos_epoch_t *epoch)
 {
 	int	rc;
 
@@ -644,7 +624,7 @@ dtx_handle_resend(daos_handle_t coh, daos_unit_oid_t *oid, struct dtx_id *dti,
 		return -DER_NONEXIST;
 
 again:
-	rc = vos_dtx_check_resend(coh, oid, dti, dkey_hash, punch, epoch);
+	rc = vos_dtx_check_resend(coh, oid, dti, dkey_hash, epoch);
 	switch (rc) {
 	case DTX_ST_PREPARED:
 		return 0;

--- a/src/dtx/dtx_resync.c
+++ b/src/dtx/dtx_resync.c
@@ -40,7 +40,6 @@ struct dtx_resync_entry {
 	struct dtx_entry	dre_dte;
 	daos_epoch_t		dre_epoch;
 	uint64_t		dre_hash;
-	uint32_t		dre_intent;
 	uint32_t		dre_in_cache:1;
 };
 
@@ -111,17 +110,14 @@ dtx_resync_commit(uuid_t po_uuid, struct ds_cont_child *cont,
 			goto commit;
 
 		rc = vos_dtx_lookup_cos(cont->sc_hdl, &dre->dre_oid,
-					&dre->dre_xid, dre->dre_hash,
-					dre->dre_intent == DAOS_INTENT_PUNCH ?
-					true : false);
+					&dre->dre_xid, dre->dre_hash);
 		if (rc == -DER_NONEXIST) {
-			int	flags = 0;
-
-			if (dre->dre_intent == DAOS_INTENT_PUNCH)
-				flags |= DCF_FOR_PUNCH;
+			/* Not sure about whether the DTX modified shared
+			 * items or not, then just assume it is.
+			 */
 			rc = vos_dtx_add_cos(cont->sc_hdl, &dre->dre_oid,
-				&dre->dre_xid, dre->dre_hash, dre->dre_epoch, 0,
-				flags);
+					     &dre->dre_xid, dre->dre_hash,
+					     dre->dre_epoch, 0, DCF_SHARED);
 			if (rc < 0)
 				D_WARN("Fail to add DTX "DF_DTI" to CoS cache: "
 				       "rc = %d\n",  DP_DTI(&dre->dre_xid), rc);
@@ -171,9 +167,7 @@ dtx_status_handle(struct dtx_resync_args *dra)
 		}
 
 		rc = vos_dtx_lookup_cos(cont->sc_hdl, &dre->dre_oid,
-					&dre->dre_xid, dre->dre_hash,
-					dre->dre_intent == DAOS_INTENT_PUNCH ?
-					true : false);
+					&dre->dre_xid, dre->dre_hash);
 		/* If it is in CoS cache, no need to check remote replicas. */
 		if (rc == 0) {
 			dre->dre_in_cache = 1;
@@ -240,9 +234,7 @@ dtx_status_handle(struct dtx_resync_args *dra)
 		}
 
 		rc = vos_dtx_lookup_cos(cont->sc_hdl, &dre->dre_oid,
-					&dre->dre_xid, dre->dre_hash,
-					dre->dre_intent == DAOS_INTENT_PUNCH ?
-					true : false);
+					&dre->dre_xid, dre->dre_hash);
 		if (rc == 0) {
 			dre->dre_in_cache = 1;
 			goto commit;
@@ -307,7 +299,6 @@ dtx_iter_cb(uuid_t co_uuid, vos_iter_entry_t *ent, void *args)
 	dre->dre_epoch = ent->ie_epoch;
 	dre->dre_xid = ent->ie_xid;
 	dre->dre_oid = ent->ie_oid;
-	dre->dre_intent = ent->ie_dtx_intent;
 	dre->dre_hash = ent->ie_dtx_hash;
 	d_list_add_tail(&dre->dre_link, &dra->tables.drh_list);
 	dra->tables.drh_count++;

--- a/src/include/daos_srv/dtx_srv.h
+++ b/src/include/daos_srv/dtx_srv.h
@@ -38,11 +38,6 @@ struct dtx_entry {
 	daos_unit_oid_t		dte_oid;
 };
 
-enum dtx_cos_list_types {
-	DCLT_UPDATE		= (1 << 0),
-	DCLT_PUNCH		= (1 << 1),
-};
-
 /**
  * DAOS two-phase commit transaction handle in DRAM.
  */
@@ -78,8 +73,8 @@ struct dtx_handle {
 					 dth_solo:1,
 					 /* dti_cos has been committed. */
 					 dth_dti_cos_done:1,
-					 /* XXX: touch ilog entry. */
-					 dth_has_ilog:1,
+					 /* Modified shared items: object/key */
+					 dth_modify_shared:1,
 					 /* The DTX entry is in active table. */
 					 dth_actived:1;
 	/* The count the DTXs in the dth_dti_cos array. */
@@ -141,7 +136,7 @@ int
 dtx_leader_begin(struct dtx_id *dti, daos_unit_oid_t *oid, daos_handle_t coh,
 		 daos_epoch_t epoch, uint64_t dkey_hash, uint32_t pm_ver,
 		 uint32_t intent, struct daos_shard_tgt *tgts, int tgts_cnt,
-		 bool cond_check, struct dtx_leader_handle *dlh);
+		 struct dtx_leader_handle *dlh);
 int
 dtx_leader_end(struct dtx_leader_handle *dlh, struct ds_cont_child *cont,
 	       int result);
@@ -179,7 +174,6 @@ int dtx_obj_sync(uuid_t po_uuid, uuid_t co_uuid, daos_handle_t coh,
  * \param oid		[IN]	Pointer to the object ID.
  * \param xid		[IN]	Pointer to the DTX identifier.
  * \param dkey_hash	[IN]	The hashed dkey.
- * \param punch		[IN]	For punch operation or not.
  * \param epoch		[IN,OUT] Pointer to current epoch, if it is zero and
  *				 if the DTX exists, then the DTX's epoch will
  *				 be saved in it.
@@ -195,7 +189,7 @@ int dtx_obj_sync(uuid_t po_uuid, uuid_t co_uuid, daos_handle_t coh,
  */
 int dtx_handle_resend(daos_handle_t coh, daos_unit_oid_t *oid,
 		      struct dtx_id *dti, uint64_t dkey_hash,
-		      bool punch, daos_epoch_t *epoch);
+		      daos_epoch_t *epoch);
 
 /* XXX: The higher 48 bits of HLC is the wall clock, the lower bits are for
  *	logic clock that will be hidden when divided by NSEC_PER_SEC.

--- a/src/include/daos_srv/vos.h
+++ b/src/include/daos_srv/vos.h
@@ -59,9 +59,7 @@ vos_dtx_update_resync_gen(daos_handle_t coh);
  * \param gen		[IN]	The DTX generation.
  * \param flags		[IN]	See dtx_cos_flags.
  *
- * \return		Zero on success.
- * \return		-DER_TX_RESTART	retry with newer epoch.
- * \return		Other negative value if error.
+ * \return		Zero on success, negative value if error.
  */
 int
 vos_dtx_add_cos(daos_handle_t coh, daos_unit_oid_t *oid, struct dtx_id *dti,
@@ -75,7 +73,6 @@ vos_dtx_add_cos(daos_handle_t coh, daos_unit_oid_t *oid, struct dtx_id *dti,
  * \param oid		[IN]	Pointer to the object ID.
  * \param xid		[IN]	Pointer to the DTX identifier.
  * \param dkey_hash	[IN]	The hashed dkey.
- * \param punch		[IN]	For punch DTX or not.
  *
  * \return	0 if the DTX exists in the CoS cache.
  * \return	-DER_NONEXIST if not in the CoS cache.
@@ -83,7 +80,7 @@ vos_dtx_add_cos(daos_handle_t coh, daos_unit_oid_t *oid, struct dtx_id *dti,
  */
 int
 vos_dtx_lookup_cos(daos_handle_t coh, daos_unit_oid_t *oid,
-		   struct dtx_id *xid, uint64_t dkey_hash, bool punch);
+		   struct dtx_id *xid, uint64_t dkey_hash);
 
 /**
  * Fetch the list of the DTXs to be committed because of (potential) share.
@@ -91,7 +88,6 @@ vos_dtx_lookup_cos(daos_handle_t coh, daos_unit_oid_t *oid,
  * \param coh		[IN]	Container open handle.
  * \param oid		[IN]	The target object (shard) ID.
  * \param dkey_hash	[IN]	The hashed dkey.
- * \param types		[IN]	The DTX types to be listed.
  * \param max		[IN]	The max size of the array for DTX entries.
  * \param dtis		[OUT]	The DTX IDs array to be committed for share.
  *
@@ -100,7 +96,7 @@ vos_dtx_lookup_cos(daos_handle_t coh, daos_unit_oid_t *oid,
  */
 int
 vos_dtx_list_cos(daos_handle_t coh, daos_unit_oid_t *oid, uint64_t dkey_hash,
-		 uint32_t types, int max, struct dtx_id **dtis);
+		 int max, struct dtx_id **dtis);
 
 /**
  * Fetch the list of the DTXs that can be committed.
@@ -128,7 +124,6 @@ vos_dtx_fetch_committable(daos_handle_t coh, uint32_t max_cnt,
  * \param oid		[IN]	Pointer to the object ID.
  * \param xid		[IN]	Pointer to the DTX identifier.
  * \param dkey_hash	[IN]	The hashed dkey.
- * \param punch		[IN]	For punch operation or not.
  * \param epoch		[IN,OUT] Pointer to current epoch, if it is zero and
  *				 if the DTX exists, then the DTX's epoch will
  *				 be saved in it.
@@ -144,7 +139,7 @@ vos_dtx_fetch_committable(daos_handle_t coh, uint32_t max_cnt,
 int
 vos_dtx_check_resend(daos_handle_t coh, daos_unit_oid_t *oid,
 		     struct dtx_id *dti, uint64_t dkey_hash,
-		     bool punch, daos_epoch_t *epoch);
+		     daos_epoch_t *epoch);
 
 /**
  * Check the specified DTX's persistent status.
@@ -210,6 +205,22 @@ vos_dtx_aggregate(daos_handle_t coh);
  */
 void
 vos_dtx_stat(daos_handle_t coh, struct dtx_stat *stat);
+
+/**
+ * Check the latest sync epoch against the specified object.
+ *
+ * \param coh	[IN]	Container open handle.
+ * \param oid	[IN]	The object ID.
+ * \param epoch	[IN,OUT] IN: the epoch to be compared with sync epoch.
+ *			OUT: the latest sync epoch against the object.
+ *
+ * \return		Zero on success.
+ * \return		-DER_AGAIN	object may be in-dying, retry locally.
+ * \return		-DER_TX_RESTART	restart related DTX with newer epoch.
+ * \return		Other negative value if error.
+ */
+int
+vos_dtx_check_sync(daos_handle_t coh, daos_unit_oid_t oid, daos_epoch_t *epoch);
 
 /**
  * Mark the object has been synced at the specified epoch.

--- a/src/include/daos_srv/vos_types.h
+++ b/src/include/daos_srv/vos_types.h
@@ -32,8 +32,7 @@
 #include <daos/checksum.h>
 
 enum dtx_cos_flags {
-	DCF_FOR_PUNCH	= (1 << 0),
-	DCF_HAS_ILOG	= (1 << 1),
+	DCF_SHARED	= (1 << 0),
 };
 
 enum vos_oi_attr {
@@ -308,8 +307,6 @@ typedef struct {
 					daos_unit_oid_t		ie_oid;
 					/* The dkey hash for DTX iteration. */
 					uint64_t		ie_dtx_hash;
-					/* The DTX intent for DTX iteration. */
-					uint32_t		ie_dtx_intent;
 				};
 			};
 		};

--- a/src/object/srv_obj.c
+++ b/src/object/srv_obj.c
@@ -1393,8 +1393,7 @@ ds_obj_tgt_update_handler(crt_rpc_t *rpc)
 	/* Handle resend. */
 	if (orw->orw_flags & ORF_RESEND) {
 		rc = dtx_handle_resend(ioc.ioc_vos_coh, &orw->orw_oid,
-				       &orw->orw_dti,
-				       orw->orw_dkey_hash, false,
+				       &orw->orw_dti, orw->orw_dkey_hash,
 				       &orw->orw_epoch);
 
 		/* Do nothing if 'prepared' or 'committed'. */
@@ -1553,8 +1552,7 @@ ds_obj_rw_handler(crt_rpc_t *rpc)
 		daos_epoch_t	tmp = 0;
 
 		rc = dtx_handle_resend(ioc.ioc_vos_coh, &orw->orw_oid,
-				       &orw->orw_dti, orw->orw_dkey_hash,
-				       false, &tmp);
+				       &orw->orw_dti, orw->orw_dkey_hash, &tmp);
 		if (rc == -DER_ALREADY)
 			D_GOTO(out, rc = 0);
 
@@ -1589,8 +1587,7 @@ renew:
 			      orw->orw_epoch, orw->orw_dkey_hash,
 			      orw->orw_map_ver, DAOS_INTENT_UPDATE,
 			      orw->orw_shard_tgts.ca_arrays,
-			      orw->orw_shard_tgts.ca_count,
-			      orw->orw_api_flags & VOS_COND_UPDATE_MASK, &dlh);
+			      orw->orw_shard_tgts.ca_count, &dlh);
 	if (rc != 0) {
 		D_ERROR(DF_UOID": Failed to start DTX for update "DF_RC".\n",
 			DP_UOID(orw->orw_oid), DP_RC(rc));
@@ -2031,7 +2028,7 @@ ds_obj_tgt_punch_handler(crt_rpc_t *rpc)
 	if (opi->opi_flags & ORF_RESEND) {
 		rc = dtx_handle_resend(ioc.ioc_vos_coh, &opi->opi_oid,
 				       &opi->opi_dti, opi->opi_dkey_hash,
-				       true, &opi->opi_epoch);
+				       &opi->opi_epoch);
 
 		/* Do nothing if 'prepared' or 'committed'. */
 		if (rc == -DER_ALREADY || rc == 0)
@@ -2170,8 +2167,7 @@ ds_obj_punch_handler(crt_rpc_t *rpc)
 		daos_epoch_t	tmp = 0;
 
 		rc = dtx_handle_resend(ioc.ioc_vos_coh, &opi->opi_oid,
-				       &opi->opi_dti, opi->opi_dkey_hash,
-				       true, &tmp);
+				       &opi->opi_dti, opi->opi_dkey_hash, &tmp);
 		if (rc == -DER_ALREADY)
 			D_GOTO(out, rc = 0);
 
@@ -2205,8 +2201,7 @@ renew:
 			      opi->opi_epoch, opi->opi_dkey_hash,
 			      opi->opi_map_ver, DAOS_INTENT_PUNCH,
 			      opi->opi_shard_tgts.ca_arrays,
-			      opi->opi_shard_tgts.ca_count,
-			      opi->opi_api_flags & VOS_OF_COND_PUNCH, &dlh);
+			      opi->opi_shard_tgts.ca_count, &dlh);
 	if (rc != 0) {
 		D_ERROR(DF_UOID": Failed to start DTX for punch "DF_RC".\n",
 			DP_UOID(opi->opi_oid), DP_RC(rc));

--- a/src/vos/vos_dtx.c
+++ b/src/vos/vos_dtx.c
@@ -582,8 +582,7 @@ vos_dtx_commit_one(struct vos_container *cont, struct dtx_id *dti,
 		goto out;
 
 	dtx_rec_release(cont, dae, false, &offset);
-	rc = vos_dtx_del_cos(cont, &DAE_OID(dae), dti, DAE_DKEY_HASH(dae),
-			DAE_INTENT(dae) == DAOS_INTENT_PUNCH ? true : false);
+	rc = vos_dtx_del_cos(cont, &DAE_OID(dae), dti, DAE_DKEY_HASH(dae));
 	if (rc != 0)
 		D_GOTO(out, rc);
 
@@ -739,7 +738,6 @@ vos_dtx_alloc(struct umem_instance *umm, struct dtx_handle *dth)
 	DAE_DKEY_HASH(dae) = dth->dth_dkey_hash;
 	DAE_EPOCH(dae) = dth->dth_epoch;
 	DAE_FLAGS(dae) = dth->dth_leader ? DTX_EF_LEADER : 0;
-	DAE_INTENT(dae) = dth->dth_intent;
 	DAE_SRV_GEN(dae) = dth->dth_gen;
 
 	/* Will be set as dbd::dbd_index via vos_dtx_prepared(). */
@@ -885,8 +883,7 @@ vos_dtx_check_availability(struct umem_instance *umm, daos_handle_t coh,
 	}
 
 	rc = vos_dtx_lookup_cos(coh, &DAE_OID(dae), &DAE_XID(dae),
-			DAE_DKEY_HASH(dae),
-			DAE_INTENT(dae) == DAOS_INTENT_PUNCH ? true : false);
+				DAE_DKEY_HASH(dae));
 	if (rc == 0)
 		return ALB_AVAILABLE_CLEAN;
 
@@ -995,14 +992,14 @@ vos_dtx_register_record(struct umem_instance *umm, umem_off_t record,
 		/* Incarnation log entry implies a share */
 		*tx_id = DAE_LID(dae);
 		if (type == DTX_RT_ILOG)
-			dth->dth_has_ilog = 1;
+			dth->dth_modify_shared = 1;
 	}
 
 	D_DEBUG(DB_TRACE, "Register DTX record for "DF_DTI
 		": lid=%d entry %p, type %d, %s ilog entry, rc %d\n",
 		DP_DTI(&dth->dth_xid),
 		DAE_LID((struct vos_dtx_act_ent *)dth->dth_ent), dth->dth_ent,
-		type, dth->dth_has_ilog ? "has" : "has not", rc);
+		type, dth->dth_modify_shared ? "has" : "has not", rc);
 
 	return rc;
 }
@@ -1216,12 +1213,12 @@ do_vos_dtx_check(daos_handle_t coh, struct dtx_id *dti, daos_epoch_t *epoch)
 int
 vos_dtx_check_resend(daos_handle_t coh, daos_unit_oid_t *oid,
 		     struct dtx_id *xid, uint64_t dkey_hash,
-		     bool punch, daos_epoch_t *epoch)
+		     daos_epoch_t *epoch)
 {
 	struct vos_container	*cont;
 	int			 rc;
 
-	rc = vos_dtx_lookup_cos(coh, oid, xid, dkey_hash, punch);
+	rc = vos_dtx_lookup_cos(coh, oid, xid, dkey_hash);
 	if (rc == 0)
 		return DTX_ST_COMMITTED;
 
@@ -1565,6 +1562,35 @@ vos_dtx_stat(daos_handle_t coh, struct dtx_stat *stat)
 				   struct vos_dtx_cmt_ent, dce_committed_link);
 		stat->dtx_oldest_committed_time = DCE_EPOCH(dce);
 	}
+}
+
+int
+vos_dtx_check_sync(daos_handle_t coh, daos_unit_oid_t oid, daos_epoch_t *epoch)
+{
+	struct vos_container	*cont;
+	struct daos_lru_cache	*occ;
+	struct vos_object	*obj;
+	daos_epoch_range_t	 epr = {0, *epoch};
+	int			 rc;
+
+	cont = vos_hdl2cont(coh);
+	occ = vos_obj_cache_current();
+
+	/* Sync epoch check inside vos_obj_hold(). We do not
+	 * care about whether it is for punch or update, use
+	 * DAOS_INTENT_COS to bypass DTX conflict check.
+	 */
+	rc = vos_obj_hold(occ, cont, oid, &epr, true,
+			  DAOS_INTENT_COS, true, &obj, 0);
+	if (rc != 0) {
+		D_ERROR(DF_UOID" fail to check sync: rc = "DF_RC"\n",
+			DP_UOID(oid), DP_RC(rc));
+	} else {
+		*epoch = obj->obj_sync_epoch;
+		vos_obj_release(occ, obj, false);
+	}
+
+	return rc;
 }
 
 int

--- a/src/vos/vos_dtx_iter.c
+++ b/src/vos/vos_dtx_iter.c
@@ -176,7 +176,6 @@ dtx_iter_fetch(struct vos_iterator *iter, vos_iter_entry_t *it_entry,
 	it_entry->ie_xid = DAE_XID(dae);
 	it_entry->ie_oid = DAE_OID(dae);
 	it_entry->ie_epoch = DAE_EPOCH(dae);
-	it_entry->ie_dtx_intent = DAE_INTENT(dae);
 	it_entry->ie_dtx_hash = DAE_DKEY_HASH(dae);
 
 	D_DEBUG(DB_IO, "DTX iterator fetch the one "DF_DTI"\n",

--- a/src/vos/vos_internal.h
+++ b/src/vos/vos_internal.h
@@ -234,7 +234,6 @@ struct vos_dtx_act_ent {
 #define DAE_EPOCH(dae)		((dae)->dae_base.dae_epoch)
 #define DAE_SRV_GEN(dae)	((dae)->dae_base.dae_srv_gen)
 #define DAE_LID(dae)		((dae)->dae_base.dae_lid)
-#define DAE_INTENT(dae)		((dae)->dae_base.dae_intent)
 #define DAE_INDEX(dae)		((dae)->dae_base.dae_index)
 #define DAE_REC_INLINE(dae)	((dae)->dae_base.dae_rec_inline)
 #define DAE_FLAGS(dae)		((dae)->dae_base.dae_flags)
@@ -436,14 +435,13 @@ vos_dtx_cos_register(void);
  * \param oid		[IN]	Pointer to the object ID.
  * \param xid		[IN]	Pointer to the DTX identifier.
  * \param dkey_hash	[IN]	The hashed dkey.
- * \param punch		[IN]	For punch DTX or not.
  *
  * \return		Zero on success.
  * \return		Other negative value if error.
  */
 int
 vos_dtx_del_cos(struct vos_container *cont, daos_unit_oid_t *oid,
-		struct dtx_id *xid, uint64_t dkey_hash, bool punch);
+		struct dtx_id *xid, uint64_t dkey_hash);
 
 /**
  * Query the oldest DTX's timestamp in the CoS cache.

--- a/src/vos/vos_layout.h
+++ b/src/vos/vos_layout.h
@@ -169,8 +169,8 @@ struct vos_dtx_act_ent_df {
 	uint64_t			dae_srv_gen;
 	/** The allocated local id for the DTX entry */
 	uint32_t			dae_lid;
-	/** The intent of related modification. */
-	uint16_t			dae_intent;
+	/** For 32-bits alignment. */
+	uint16_t			dae_padding;
 	/** The index in the current vos_dtx_blob_df. */
 	int16_t				dae_index;
 	/** The inlined dtx records. */
@@ -182,16 +182,6 @@ struct vos_dtx_act_ent_df {
 	/** The offset for the list of dtx records if out of inline. */
 	umem_off_t			dae_rec_off;
 };
-
-/* Assume dae_rec_cnt is next to dae_flags. */
-D_CASSERT(offsetof(struct vos_dtx_act_ent_df, dae_rec_cnt) ==
-	  offsetof(struct vos_dtx_act_ent_df, dae_flags) +
-	  sizeof(((struct vos_dtx_act_ent_df *)0)->dae_flags));
-
-/* Assume dae_rec_off is next to dae_rec_cnt. */
-D_CASSERT(offsetof(struct vos_dtx_act_ent_df, dae_rec_off) ==
-	  offsetof(struct vos_dtx_act_ent_df, dae_rec_cnt) +
-	  sizeof(((struct vos_dtx_act_ent_df *)0)->dae_rec_cnt));
 
 /** Committed DTX entry on-disk layout in both SCM and DRAM. */
 struct vos_dtx_cmt_ent_df {


### PR DESCRIPTION
Before introducing incarnation log into VOS, the DTX with update
intent is conflict with the punch one. Then the DTX CoS cache was
organized by the DTX intent at that time. Such classification is
out of date. The new CoS logic splits the DTXs into two lists:

prio_list: the DTXs in this list modify some object/dkey that
	   can be shared by other modifications, so they need
	   to be committed with priority.

reg_list: for the DTXs only modify SV value or EV value that
	  will not be shared by others.

The patch also further cleanup DTX entry by removing 'dae_intent'
from the DTX entry on-disk layout,

Signed-off-by: Fan Yong <fan.yong@intel.com>