### PR TITLE
DAOS-4876 Client: Improve error handling for GetAttachInfo

### DIFF
--- a/src/client/api/init.c
+++ b/src/client/api/init.c
@@ -165,13 +165,13 @@ daos_init(void)
 	/** get CaRT configuration */
 	rc = dc_mgmt_net_cfg(NULL);
 	if (rc != 0)
-		D_GOTO(out_hhash, rc);
+		D_GOTO(out_agent, rc);
 
 	/** set up event queue */
 	rc = daos_eq_lib_init();
 	if (rc != 0) {
 		D_ERROR("failed to initialize eq_lib: "DF_RC"\n", DP_RC(rc));
-		D_GOTO(out_hhash, rc);
+		D_GOTO(out_agent, rc);
 	}
 
 	/** set up placement */
@@ -212,6 +212,8 @@ out_pl:
 	pl_fini();
 out_eq:
 	daos_eq_lib_fini();
+out_agent:
+	dc_agent_fini();
 out_hhash:
 	daos_hhash_fini();
 out_debug:


### PR DESCRIPTION
     Added call to dc_agent_fini() to clean up resources
     if there is a failure downstream.

Signed-off-by: Joel Rosenzweig <joel.b.rosenzweig@intel.com>