### PR TITLE
DAOS-4877 control: fix storage prepare after ipmctl v2 upgrade

### DIFF
--- a/src/control/server/storage/scm/ipmctl.go
+++ b/src/control/server/storage/scm/ipmctl.go
@@ -20,6 +20,7 @@
 // Any reproduction of computer software, computer software documentation, or
 // portions thereof marked with this legend must also reproduce the markings.
 //
+
 package scm
 
 import (
@@ -28,6 +29,7 @@ import (
 	"os/exec"
 	"strings"
 
+	"github.com/dustin/go-humanize"
 	"github.com/pkg/errors"
 
 	"github.com/daos-stack/daos/src/control/lib/ipmctl"
@@ -134,11 +136,11 @@ func (r *cmdRunner) GetState() (storage.ScmState, error) {
 		return storage.ScmStateNoRegions, nil
 	}
 
-	ok, err := hasFreeCapacity(out)
+	bytes, err := freeCapacity(out)
 	if err != nil {
 		return storage.ScmStateUnknown, err
 	}
-	if ok {
+	if bytes > 0 {
 		return storage.ScmStateFreeCapacity, nil
 	}
 
@@ -250,7 +252,7 @@ func (r *cmdRunner) removeNamespace(devName string) (err error) {
 	return
 }
 
-// hasFreeCapacity takes output from ipmctl and checks for free capacity.
+// freeCapacity takes output from ipmctl and returns free capacity.
 //
 // external tool commands return:
 // $ ipmctl show -d PersistentMemoryType,FreeCapacity -region
@@ -263,13 +265,15 @@ func (r *cmdRunner) removeNamespace(devName string) (err error) {
 //    FreeCapacity=3012.0 GiB
 //
 // FIXME: implementation to be replaced by using libipmctl directly through bindings
-func hasFreeCapacity(text string) (hasCapacity bool, err error) {
+func freeCapacity(text string) (uint64, error) {
 	lines := strings.Split(text, "\n")
 	if len(lines) < 4 {
-		return false, errors.Errorf("expecting at least 4 lines, got %d",
+		return 0, errors.Errorf("expecting at least 4 lines, got %d",
 			len(lines))
 	}
 
+	var appDirect bool
+	var capacity uint64
 	for _, line := range lines {
 		entry := strings.TrimSpace(line)
 
@@ -278,23 +282,26 @@ func hasFreeCapacity(text string) (hasCapacity bool, err error) {
 			continue
 		}
 
-		if kv[0] == "PersistentMemoryType" && kv[1] == "AppDirect" {
-			hasCapacity = true
-			continue
+		switch kv[0] {
+		case "PersistentMemoryType":
+			if kv[1] == "AppDirect" {
+				appDirect = true
+				continue
+			}
+		case "FreeCapacity":
+			if !appDirect {
+				continue
+			}
+			c, err := humanize.ParseBytes(kv[1])
+			if err != nil {
+				return 0, err
+			}
+			capacity += c
 		}
-
-		if kv[0] != "FreeCapacity" {
-			continue
-		}
-
-		if hasCapacity && kv[1] != "0.0 GiB" {
-			return
-		}
-
-		hasCapacity = false
+		appDirect = false
 	}
 
-	return
+	return capacity, nil
 }
 
 // createstorage.ScmNamespaces runs create until no free capacity.

--- a/src/control/server/storage/scm/ipmctl_test.go
+++ b/src/control/server/storage/scm/ipmctl_test.go
@@ -157,8 +157,9 @@ func TestGetState(t *testing.T) {
 
 	tests := []struct {
 		desc              string
-		errMsg            string
 		showRegionOut     string
+		expGetStateErrMsg string
+		expErrMsg         string
 		expRebootRequired bool
 		expNamespaces     storage.ScmNamespaces
 		expCommands       []string
@@ -212,6 +213,25 @@ func TestGetState(t *testing.T) {
 			expCommands:   []string{cmdScmShowRegions, cmdScmListNamespaces},
 			expNamespaces: twoNs,
 		},
+		{
+			desc: "v2 regions with no capacity",
+			showRegionOut: "\n" +
+				"---ISetID=0x2aba7f4828ef2ccc---\n" +
+				"   PersistentMemoryType=AppDirect\n" +
+				"   FreeCapacity=0.000 GiB\n" +
+				"---ISetID=0x81187f4881f02ccb---\n" +
+				"   PersistentMemoryType=AppDirect\n" +
+				"   FreeCapacity=0.000 GiB\n" +
+				"\n",
+			expCommands:   []string{cmdScmShowRegions, cmdScmListNamespaces},
+			expNamespaces: twoNs,
+		},
+		{
+			desc: "unexpected output",
+			showRegionOut: "\n" +
+				"---ISetID=0x2aba7f4828ef2ccc---\n",
+			expGetStateErrMsg: "expecting at least 4 lines, got 3",
+		},
 	}
 
 	for _, tt := range tests {
@@ -237,13 +257,14 @@ func TestGetState(t *testing.T) {
 			commands = nil
 
 			scmState, err := cr.GetState()
-			if err != nil {
-				t.Fatal(tt.desc + ": GetState: " + err.Error())
+			ExpectError(t, err, tt.expGetStateErrMsg, tt.desc)
+			if tt.expGetStateErrMsg != "" {
+				return
 			}
 
 			needsReboot, namespaces, err := cr.Prep(scmState)
-			if tt.errMsg != "" {
-				ExpectError(t, err, tt.errMsg, tt.desc)
+			if tt.expErrMsg != "" {
+				ExpectError(t, err, tt.expErrMsg, tt.desc)
 				return
 			}
 			if err != nil {
@@ -351,7 +372,7 @@ func TestGetNamespaces(t *testing.T) {
 
 	tests := []struct {
 		desc           string
-		errMsg         string
+		expErrMsg      string
 		cmdOut         string
 		expNamespaces  storage.ScmNamespaces
 		expCommands    []string
@@ -378,7 +399,7 @@ func TestGetNamespaces(t *testing.T) {
 		{
 			desc:           "ndctl not installed",
 			lookPathErrMsg: FaultMissingNdctl.Error(),
-			errMsg:         FaultMissingNdctl.Error(),
+			expErrMsg:      FaultMissingNdctl.Error(),
 		},
 	}
 


### PR DESCRIPTION
daos_server storage prepare broken after distro upgraded ipmctl to
v2. Fix commandline output parsing to work with both v1 & v2.

Signed-off-by: Tom Nabarro <tom.nabarro@intel.com>