### PR TITLE
DAOS-4878 DFS: fix bug in dfs_global2local

### DIFF
--- a/src/client/dfs/dfs.c
+++ b/src/client/dfs/dfs.c
@@ -1414,7 +1414,7 @@ dfs_global2local(daos_handle_t poh, daos_handle_t coh, int flags, d_iov_t glob,
 	dfs->coh = coh;
 	dfs->amode = (flags == 0) ? dfs_params->amode : (flags & O_ACCMODE);
 	dfs->uid = dfs_params->uid;
-	dfs->uid = dfs_params->gid;
+	dfs->gid = dfs_params->gid;
 	dfs->attr.da_id = dfs_params->id;
 	dfs->attr.da_chunk_size = dfs_params->chunk_size;
 	dfs->attr.da_oclass_id = dfs_params->oclass;


### PR DESCRIPTION
typo where uid is overwritten by the gid and gid is not set.

Signed-off-by: Mohamad Chaarawi <mohamad.chaarawi@intel.com>