### PR TITLE
DAOS-4916 Client: GetAttachInfo dRPC fails if no netdevs

### DIFF
--- a/src/control/cmd/daos_agent/infocache.go
+++ b/src/control/cmd/daos_agent/infocache.go
@@ -38,10 +38,10 @@ import (
 )
 
 const (
-	invalidIndex         = -1
-	verbsProvider        = "ofi+verbs"
+	invalidIndex  = -1
+	verbsProvider = "ofi+verbs"
 	defaultNetworkDevice = "lo"
-	defaultDomain        = "lo"
+	defaultDomain = "lo"
 )
 
 type attachInfoCache struct {
@@ -118,6 +118,8 @@ func (aic *attachInfoCache) initResponseCache(resp *mgmtpb.GetAttachInfoResp, sc
 	if len(aic.currentNumaDevIdx) == 0 {
 		aic.currentNumaDevIdx = make(map[int]int)
 	}
+
+	netdetect.SetLogger(aic.log)
 
 	var haveDefaultNuma bool
 

--- a/src/control/cmd/daos_agent/infocache.go
+++ b/src/control/cmd/daos_agent/infocache.go
@@ -38,8 +38,10 @@ import (
 )
 
 const (
-	invalidIndex  = -1
-	verbsProvider = "ofi+verbs"
+	invalidIndex         = -1
+	verbsProvider        = "ofi+verbs"
+	defaultNetworkDevice = "lo"
+	defaultDomain        = "lo"
 )
 
 type attachInfoCache struct {
@@ -117,8 +119,6 @@ func (aic *attachInfoCache) initResponseCache(resp *mgmtpb.GetAttachInfoResp, sc
 		aic.currentNumaDevIdx = make(map[int]int)
 	}
 
-	netdetect.SetLogger(aic.log)
-
 	var haveDefaultNuma bool
 
 	for _, fs := range scanResults {
@@ -167,6 +167,8 @@ func (aic *attachInfoCache) initResponseCache(resp *mgmtpb.GetAttachInfoResp, sc
 	if _, ok := aic.numaDeviceMarshResp[aic.defaultNumaNode]; !ok {
 		aic.log.Info("No network devices detected in fabric scan; default AttachInfo response may be incorrect\n")
 		aic.numaDeviceMarshResp[aic.defaultNumaNode] = make(map[int][]byte)
+		resp.Interface = defaultNetworkDevice
+		resp.Domain = defaultDomain
 		numaDeviceMarshResp, err := proto.Marshal(resp)
 		if err != nil {
 			return drpc.MarshalingFailure()

--- a/src/control/cmd/daos_agent/infocache.go
+++ b/src/control/cmd/daos_agent/infocache.go
@@ -38,10 +38,10 @@ import (
 )
 
 const (
-	invalidIndex  = -1
-	verbsProvider = "ofi+verbs"
+	invalidIndex         = -1
+	verbsProvider        = "ofi+verbs"
 	defaultNetworkDevice = "lo"
-	defaultDomain = "lo"
+	defaultDomain        = "lo"
 )
 
 type attachInfoCache struct {

--- a/src/control/cmd/daos_agent/infocache_test.go
+++ b/src/control/cmd/daos_agent/infocache_test.go
@@ -80,7 +80,8 @@ func TestInfoCacheInitNoScanResults(t *testing.T) {
 			if err = proto.Unmarshal(res, resp); err != nil {
 				t.Errorf("Expected error on proto.Unmarshal, got %+v", err)
 			}
-			common.AssertTrue(t, resp.GetInterface() == "", fmt.Sprintf("Expected empty interface name, got %s", resp.GetInterface()))
+			common.AssertTrue(t, resp.GetInterface() == defaultNetworkDevice, fmt.Sprintf("Expected default interface: %s, got %s", defaultNetworkDevice, resp.GetInterface()))
+			common.AssertTrue(t, resp.GetDomain() == defaultDomain, fmt.Sprintf("Expected default domain: %s, got %s", defaultDomain, resp.GetDomain()))
 		})
 	}
 }


### PR DESCRIPTION
    Sets the default network device and domain in the
    GetAttachInfo response to "lo" to avoid failing the
    dRPC when there is no network device or provider
    found.

    The default response is provided only if the client
    machine is configured in such a way that the network
    devices are not visible to the hwloc API.  This can
    happen on some virtual machine configurations.

    If the default "lo" is not what is desired, the client
    should override the default network device name by
    setting environment variables OFI_INTERFACE and
    OFI_DOMAIN as appropriate.

Signed-off-by: Joel Rosenzweig <joel.b.rosenzweig@intel.com>