### PR TITLE
DAOS-4478 test: security 2nd group failed on Jenkins

### DIFF
--- a/src/tests/ftest/util/pool_security_test_base.py
+++ b/src/tests/ftest/util/pool_security_test_base.py
@@ -28,6 +28,7 @@ from apricot import TestWithServers
 from daos_utils import DaosCommand
 from dmg_utils import DmgCommand
 import dmg_utils
+import agent_utils as agu
 import random
 import grp
 import re
@@ -431,6 +432,7 @@ class PoolSecurityTestBase(TestWithServers):
         acl_file = os.path.join(self.tmp, get_acl_file)
         num_user = self.params.get("num_user", "/run/pool_acl/*")
         num_group = self.params.get("num_group", "/run/pool_acl/*")
+        self.hostlist_clients = agu.include_local_host(self.hostlist_clients)
 
         # (2)Generate acl file with permissions
         self.log.info("  (1)Generate acl file with user/group permissions")


### PR DESCRIPTION
DAOS-4478 test: security 2nd group failed on Jenkins due to the daos command to verify the r/w priviledge was executed on the running-host instead of the client-host.
modified:   util/pool_security_test_base.py 

Test-tag: pr,-hw sec_acl_groups
Signed-off-by: Ding Ho <ding-hwa.ho@intel.com>