### PR TITLE
DAOS-4668 distro: remove python-distro package

### DIFF
--- a/utils/docker/Dockerfile.centos.7
+++ b/utils/docker/Dockerfile.centos.7
@@ -72,8 +72,8 @@ RUN yum -y install \
            python2-clustershell python2-Cython python2-pip     \
            python36-clustershell python36-paramiko             \
            python36-numpy python36-jira python3-pip            \
-           fuse3-devel python{36,}-distro                      \
-           libipmctl-devel openmpi3-devel hwloc-devel
+           fuse3-devel libipmctl-devel openmpi3-devel          \
+           hwloc-devel
 
 # DAOS python 3 packages required for pylint
 #  - excluding mpi4py as it depends on CORCI-635

--- a/utils/docker/Dockerfile.leap.15
+++ b/utils/docker/Dockerfile.leap.15
@@ -28,7 +28,7 @@ RUN zypper --non-interactive --no-gpg-checks refresh; \
            make man meson nasm ninja pandoc patch python2-pip         \
            readline-devel sg3_utils which yasm                        \
            python-devel python3-devel valgrind-devel hwloc-devel      \
-           openmpi3-devel Modules man fuse3-devel python-distro
+           openmpi3-devel Modules man fuse3-devel
 
 RUN update-ca-certificates;    \
     pip install --upgrade pip; \

--- a/utils/rpms/daos.spec
+++ b/utils/rpms/daos.spec
@@ -52,7 +52,6 @@ BuildRequires: CUnit-devel
 BuildRequires: golang-bin >= 1.12
 BuildRequires: libipmctl-devel
 BuildRequires: python-devel python36-devel
-BuildRequires: python-distro
 %else
 %if (0%{?suse_version} >= 1315)
 # see src/client/dfs/SConscript for why we need /etc/os-release
@@ -70,7 +69,6 @@ BuildRequires: ipmctl-devel
 BuildRequires: python-devel python3-devel
 BuildRequires: Modules
 BuildRequires: systemd-rpm-macros
-BuildRequires: python3-distro
 %if 0%{?is_opensuse}
 %else
 # have choice for libcurl.so.4()(64bit) needed by systemd: libcurl4 libcurl4-mini


### PR DESCRIPTION
Remove python-distro package from CentOS and Leap
since it is not required any longer after ubuntu
20.04 migration.

Skip-test: true

Signed-off-by: Johann Lombardi <johann.lombardi@intel.com>