### PR TITLE
DAOS-4929 control: Control API cleanups

### DIFF
--- a/src/control/lib/control/network_test.go
+++ b/src/control/lib/control/network_test.go
@@ -33,7 +33,6 @@ import (
 	"github.com/daos-stack/daos/src/control/common"
 	ctlpb "github.com/daos-stack/daos/src/control/common/proto/ctl"
 	mgmtpb "github.com/daos-stack/daos/src/control/common/proto/mgmt"
-	"github.com/daos-stack/daos/src/control/lib/hostlist"
 	"github.com/daos-stack/daos/src/control/logging"
 )
 
@@ -287,13 +286,7 @@ func TestControl_NetworkScan(t *testing.T) {
 				return
 			}
 
-			cmpOpts := []cmp.Option{
-				cmp.Comparer(func(x, y *hostlist.HostSet) bool {
-					return x.RangedString() == y.RangedString()
-				}),
-			}
-
-			if diff := cmp.Diff(tc.expResp, gotResp, cmpOpts...); diff != "" {
+			if diff := cmp.Diff(tc.expResp, gotResp, defResCmpOpts()...); diff != "" {
 				t.Fatalf("unexpected response (-want, +got):\n%s\n", diff)
 			}
 		})

--- a/src/control/lib/control/response.go
+++ b/src/control/lib/control/response.go
@@ -74,8 +74,8 @@ func (her *HostErrorsResp) getHostErrors() HostErrorsMap {
 func (her *HostErrorsResp) Errors() error {
 	if len(her.HostErrors) > 0 {
 		errCount := 0
-		for _, set := range her.HostErrors {
-			errCount += set.Count()
+		for _, hes := range her.HostErrors {
+			errCount += hes.HostSet.Count()
 		}
 
 		return errors.Errorf("%s had errors",
@@ -84,16 +84,27 @@ func (her *HostErrorsResp) Errors() error {
 	return nil
 }
 
+// HostErrorSet preserves the original hostError used
+// to create the map key.
+type HostErrorSet struct {
+	HostSet   *hostlist.HostSet
+	HostError error
+}
+
 // HostErrorsMap provides a mapping from error strings to a set of
 // hosts to which the error applies.
-type HostErrorsMap map[string]*hostlist.HostSet
+type HostErrorsMap map[string]*HostErrorSet
 
 // MarshalJSON implements a custom marshaller to include
 // the hostset as a ranged string.
 func (hem HostErrorsMap) MarshalJSON() ([]byte, error) {
 	out := make(map[string]string)
-	for k, v := range hem {
-		out[k] = v.RangedString()
+	for k, hes := range hem {
+		// quick sanity check to prevent panics
+		if hes == nil || hes.HostSet == nil {
+			return nil, errors.New("nil hostErrorSet or hostSet")
+		}
+		out[k] = hes.HostSet.RangedString()
 	}
 	return json.Marshal(out)
 }
@@ -106,18 +117,24 @@ func (hem HostErrorsMap) Add(hostAddr string, hostErr error) (err error) {
 
 	errStr := hostErr.Error() // stringify the error as map key
 	if _, exists := hem[errStr]; !exists {
-		hem[errStr], err = hostlist.CreateSet(hostAddr)
+		hes := &HostErrorSet{
+			HostError: hostErr,
+		}
+		hes.HostSet, err = hostlist.CreateSet(hostAddr)
+		if err == nil {
+			hem[errStr] = hes
+		}
 		return
 	}
-	_, err = hem[errStr].Insert(hostAddr)
+	_, err = hem[errStr].HostSet.Insert(hostAddr)
 	return
 }
 
 // Keys returns a stable sorted slice of the errors map keys.
 func (hem HostErrorsMap) Keys() []string {
 	setToKeys := make(map[string]map[string]struct{})
-	for errStr, set := range hem {
-		rs := set.RangedString()
+	for errStr, hes := range hem {
+		rs := hes.HostSet.RangedString()
 		if _, exists := setToKeys[rs]; !exists {
 			setToKeys[rs] = make(map[string]struct{})
 		}

--- a/src/control/lib/control/response_test.go
+++ b/src/control/lib/control/response_test.go
@@ -24,15 +24,78 @@
 package control
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/golang/protobuf/proto"
 	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/pkg/errors"
 
 	"github.com/daos-stack/daos/src/control/common"
 	"github.com/daos-stack/daos/src/control/lib/hostlist"
 )
+
+type mockHostError struct {
+	Hosts string
+	Error string
+}
+
+func mockHostErrorsMap(t *testing.T, hostErrors ...*mockHostError) HostErrorsMap {
+	hem := make(HostErrorsMap)
+
+	for _, he := range hostErrors {
+		if hes, found := hem[he.Error]; found {
+			if _, err := hes.HostSet.Insert(he.Hosts); err != nil {
+				t.Fatal(err)
+			}
+			continue
+		}
+		hem[he.Error] = &HostErrorSet{
+			HostError: errors.New(he.Error),
+			HostSet:   mockHostSet(t, he.Hosts),
+		}
+	}
+
+	return hem
+}
+
+func mockHostErrorsResp(t *testing.T, hostErrors ...*mockHostError) HostErrorsResp {
+	if len(hostErrors) == 0 {
+		return HostErrorsResp{}
+	}
+	return HostErrorsResp{
+		HostErrors: mockHostErrorsMap(t, hostErrors...),
+	}
+}
+
+func mockHostSet(t *testing.T, hosts string) *hostlist.HostSet {
+	hs, err := hostlist.CreateSet(hosts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return hs
+}
+
+func mockHostResponses(t *testing.T, count int, fmtStr string, respMsg proto.Message) []*HostResponse {
+	hrs := make([]*HostResponse, count)
+	for i := 0; i < count; i++ {
+		hrs[i] = &HostResponse{
+			Addr:    fmt.Sprintf(fmtStr, i),
+			Message: respMsg,
+		}
+	}
+	return hrs
+}
+
+func defResCmpOpts() []cmp.Option {
+	return []cmp.Option{
+		cmp.Comparer(func(x, y *hostlist.HostSet) bool {
+			return x.RangedString() == y.RangedString()
+		}),
+		cmpopts.IgnoreFields(HostErrorSet{}, "HostError"),
+	}
+}
 
 func TestControl_HostErrorsMap(t *testing.T) {
 	makeHosts := func(hosts ...string) []string {
@@ -57,40 +120,41 @@ func TestControl_HostErrorsMap(t *testing.T) {
 			expErrMap: HostErrorsMap{},
 		},
 		"one host one error": {
-			hosts:  makeHosts("host1"),
-			errors: makeErrors("whoops"),
-			expErrMap: HostErrorsMap{
-				"whoops": mockHostSet(t, "host1"),
-			},
+			hosts:     makeHosts("host1"),
+			errors:    makeErrors("whoops"),
+			expErrMap: mockHostErrorsMap(t, &mockHostError{"host1", "whoops"}),
 		},
 		"two hosts one error": {
 			hosts:  makeHosts("host1", "host2"),
 			errors: makeErrors("whoops", "whoops"),
-			expErrMap: HostErrorsMap{
-				"whoops": mockHostSet(t, "host1,host2"),
-			},
+			expErrMap: mockHostErrorsMap(t,
+				&mockHostError{"host1", "whoops"},
+				&mockHostError{"host2", "whoops"},
+			),
 		},
 		"two hosts two errors": {
 			hosts:  makeHosts("host1", "host2"),
 			errors: makeErrors("whoops", "oops"),
-			expErrMap: HostErrorsMap{
-				"whoops": mockHostSet(t, "host1"),
-				"oops":   mockHostSet(t, "host2"),
-			},
+			expErrMap: mockHostErrorsMap(t,
+				&mockHostError{"host1", "whoops"},
+				&mockHostError{"host2", "oops"},
+			),
 		},
 		"two hosts same port one error": {
 			hosts:  makeHosts("host1:1", "host2:1"),
 			errors: makeErrors("whoops", "whoops"),
-			expErrMap: HostErrorsMap{
-				"whoops": mockHostSet(t, "host[1-2]:1"),
-			},
+			expErrMap: mockHostErrorsMap(t,
+				&mockHostError{"host1:1", "whoops"},
+				&mockHostError{"host2:1", "whoops"},
+			),
 		},
 		"two hosts different port one error": {
 			hosts:  makeHosts("host1:1", "host2:2"),
 			errors: makeErrors("whoops", "whoops"),
-			expErrMap: HostErrorsMap{
-				"whoops": mockHostSet(t, "host1:1,host2:2"),
-			},
+			expErrMap: mockHostErrorsMap(t,
+				&mockHostError{"host1:1", "whoops"},
+				&mockHostError{"host2:2", "whoops"},
+			),
 		},
 	} {
 		t.Run(name, func(t *testing.T) {
@@ -103,13 +167,7 @@ func TestControl_HostErrorsMap(t *testing.T) {
 				}
 			}
 
-			cmpOpts := []cmp.Option{
-				cmp.Comparer(func(x, y *hostlist.HostSet) bool {
-					return x.RangedString() == y.RangedString()
-				}),
-			}
-
-			if diff := cmp.Diff(tc.expErrMap, hem, cmpOpts...); diff != "" {
+			if diff := cmp.Diff(tc.expErrMap, hem, defResCmpOpts()...); diff != "" {
 				t.Fatalf("unexpected map (-want, +got):\n%s\n", diff)
 			}
 		})

--- a/src/control/lib/control/system.go
+++ b/src/control/lib/control/system.go
@@ -35,7 +35,6 @@ import (
 	"github.com/daos-stack/daos/src/control/common/proto/convert"
 	ctlpb "github.com/daos-stack/daos/src/control/common/proto/ctl"
 	mgmtpb "github.com/daos-stack/daos/src/control/common/proto/mgmt"
-	"github.com/daos-stack/daos/src/control/fault"
 	"github.com/daos-stack/daos/src/control/system"
 )
 
@@ -382,13 +381,8 @@ func rpcToRanks(ctx context.Context, rpcClient UnaryInvoker, req *RanksReq) (*Ra
 
 	rr := new(RanksResp)
 	for _, hostResp := range ur.Responses {
-		hostErr := hostResp.Error
-		if hostErr != nil {
-			f, ok := errors.Cause(hostErr).(*fault.Fault)
-			if ok && f != nil {
-				hostErr = errors.New(f.Description)
-			}
-			if err := rr.addHostError(hostResp.Addr, hostErr); err != nil {
+		if hostResp.Error != nil {
+			if err := rr.addHostError(hostResp.Addr, hostResp.Error); err != nil {
 				return nil, err
 			}
 			continue

--- a/src/control/lib/control/system_test.go
+++ b/src/control/lib/control/system_test.go
@@ -33,7 +33,6 @@ import (
 	"github.com/daos-stack/daos/src/control/common"
 	ctlpb "github.com/daos-stack/daos/src/control/common/proto/ctl"
 	mgmtpb "github.com/daos-stack/daos/src/control/common/proto/mgmt"
-	"github.com/daos-stack/daos/src/control/lib/hostlist"
 	"github.com/daos-stack/daos/src/control/logging"
 	"github.com/daos-stack/daos/src/control/system"
 	. "github.com/daos-stack/daos/src/control/system"
@@ -134,13 +133,7 @@ func TestControl_StartRanks(t *testing.T) {
 				return
 			}
 
-			cmpOpts := []cmp.Option{
-				cmp.Comparer(func(x, y *hostlist.HostSet) bool {
-					return x.RangedString() == y.RangedString()
-				}),
-			}
-
-			if diff := cmp.Diff(tc.expResp, gotResp, cmpOpts...); diff != "" {
+			if diff := cmp.Diff(tc.expResp, gotResp, defResCmpOpts()...); diff != "" {
 				t.Fatalf("unexpected results (-want, +got)\n%s\n", diff)
 			}
 		})
@@ -242,13 +235,7 @@ func TestControl_PrepShutdownRanks(t *testing.T) {
 				return
 			}
 
-			cmpOpts := []cmp.Option{
-				cmp.Comparer(func(x, y *hostlist.HostSet) bool {
-					return x.RangedString() == y.RangedString()
-				}),
-			}
-
-			if diff := cmp.Diff(tc.expResp, gotResp, cmpOpts...); diff != "" {
+			if diff := cmp.Diff(tc.expResp, gotResp, defResCmpOpts()...); diff != "" {
 				t.Fatalf("unexpected results (-want, +got)\n%s\n", diff)
 			}
 		})
@@ -350,13 +337,7 @@ func TestControl_StopRanks(t *testing.T) {
 				return
 			}
 
-			cmpOpts := []cmp.Option{
-				cmp.Comparer(func(x, y *hostlist.HostSet) bool {
-					return x.RangedString() == y.RangedString()
-				}),
-			}
-
-			if diff := cmp.Diff(tc.expResp, gotResp, cmpOpts...); diff != "" {
+			if diff := cmp.Diff(tc.expResp, gotResp, defResCmpOpts()...); diff != "" {
 				t.Fatalf("unexpected results (-want, +got)\n%s\n", diff)
 			}
 		})
@@ -458,13 +439,7 @@ func TestControl_PingRanks(t *testing.T) {
 				return
 			}
 
-			cmpOpts := []cmp.Option{
-				cmp.Comparer(func(x, y *hostlist.HostSet) bool {
-					return x.RangedString() == y.RangedString()
-				}),
-			}
-
-			if diff := cmp.Diff(tc.expResp, gotResp, cmpOpts...); diff != "" {
+			if diff := cmp.Diff(tc.expResp, gotResp, defResCmpOpts()...); diff != "" {
 				t.Fatalf("unexpected results (-want, +got)\n%s\n", diff)
 			}
 		})
@@ -631,11 +606,9 @@ func TestControl_SystemReformat(t *testing.T) {
 			),
 			expResp: &StorageFormatResp{
 				HostErrorsResp: HostErrorsResp{
-					HostErrors: HostErrorsMap{
-						"1 rank failed: didn't start": mockHostSet(
-							t, "10.0.0.1:10001",
-						),
-					},
+					HostErrors: mockHostErrorsMap(t, &mockHostError{
+						"10.0.0.1:10001", "1 rank failed: didn't start",
+					}),
 				},
 			},
 		},
@@ -693,17 +666,11 @@ func TestControl_SystemReformat(t *testing.T) {
 			),
 			expResp: &StorageFormatResp{
 				HostErrorsResp: HostErrorsResp{
-					HostErrors: HostErrorsMap{
-						"2 ranks failed: didn't start": mockHostSet(
-							t, "10.0.0.4:10001",
-						),
-						"1 rank failed: didn't start": mockHostSet(
-							t, "10.0.0.[1,3]:10001",
-						),
-						"1 rank failed: something bad": mockHostSet(
-							t, "10.0.0.3:10001",
-						),
-					},
+					HostErrors: mockHostErrorsMap(t,
+						&mockHostError{"10.0.0.4:10001", "2 ranks failed: didn't start"},
+						&mockHostError{"10.0.0.[1,3]:10001", "1 rank failed: didn't start"},
+						&mockHostError{"10.0.0.3:10001", "1 rank failed: something bad"},
+					),
 				},
 			},
 		},
@@ -723,17 +690,9 @@ func TestControl_SystemReformat(t *testing.T) {
 				return
 			}
 
-			cmpOpts := []cmp.Option{
-				cmp.Comparer(func(x, y *hostlist.HostSet) bool {
-					return x.RangedString() == y.RangedString()
-				}),
+			if diff := cmp.Diff(tc.expResp, gotResp, defResCmpOpts()...); diff != "" {
+				t.Fatalf("unexpected response (-want, +got):\n%s\n", diff)
 			}
-			if diff := cmp.Diff(tc.expResp, gotResp, cmpOpts...); diff != "" {
-				// only printed for convenience when the below assert fails
-				t.Logf("unexpected response (-want, +got):\n%s\n", diff)
-			}
-
-			common.AssertEqual(t, tc.expResp, gotResp, name+" response")
 		})
 	}
 }

--- a/src/control/server/ctl_system.go
+++ b/src/control/server/ctl_system.go
@@ -97,17 +97,17 @@ func (svc *ControlService) rpcToRanks(ctx context.Context, req *control.RanksReq
 
 	// synthesise "Stopped" rank results for any harness host errors
 	hostRanks := svc.membership.HostRanks(req.Ranks...)
-	for errMsg, hostSet := range resp.HostErrors {
-		for _, addr := range strings.Split(hostSet.DerangedString(), ",") {
+	for _, hes := range resp.HostErrors {
+		for _, addr := range strings.Split(hes.HostSet.DerangedString(), ",") {
 			for _, rank := range hostRanks[addr] {
 				results = append(results,
 					&system.MemberResult{
-						Rank: rank, Msg: errMsg,
+						Rank: rank, Msg: hes.HostError.Error(),
 						State: system.MemberStateUnresponsive,
 					})
 			}
 			svc.log.Debugf("harness %s (ranks %v) host error: %s",
-				addr, hostRanks[addr], errMsg)
+				addr, hostRanks[addr], hes.HostError)
 		}
 	}
 


### PR DESCRIPTION
Now that we are starting to build new things into
the Control API, it's apparent that a bit of refactoring
is needed to clean up a few rough edges:

  * DRYing up the cmp options supplied to tests that are
    comparing expected vs actual responses
  * Preserving the original Error in the HostErrorsMap in
    order to retain implementation functionality (fault.Fault,
    errors.Cause, etc)
  * Fix up some older tests to use the new mock helpers for
    creating HostErrorsMaps
  * Move the response test helpers into response_test.go