### PR TITLE
CART-903 ctl: Ability to inject custom log messages on remote server

### DIFF
--- a/src/cart/src/cart/crt_rpc.c
+++ b/src/cart/src/cart/crt_rpc.c
@@ -77,16 +77,10 @@ crt_hdlr_ctl_log_add_msg(crt_rpc_t *rpc_req)
 	if (in_args->log_msg == NULL) {
 		D_ERROR("Empty log message\n");
 		rc = -DER_INVAL;
+	} else {
+		D_INFO("%.*s\n", CRT_CTL_MAX_LOG_MSG_SIZE,
+			in_args->log_msg);
 	}
-
-	if (strlen(in_args->log_msg) > CRT_CTL_MAX_LOG_MSG_SIZE) {
-		D_ERROR("Log message exceeded %d chars\n",
-			CRT_CTL_MAX_LOG_MSG_SIZE);
-		rc = -DER_OVERFLOW;
-	}
-
-	if (rc == 0)
-		D_INFO("%s\n", in_args->log_msg);
 
 	out_args->rc = rc;
 	rc = crt_reply_send(rpc_req);

--- a/src/cart/src/cart/crt_rpc.h
+++ b/src/cart/src/cart/crt_rpc.h
@@ -284,7 +284,10 @@ struct crt_rpc_priv {
 		crt_hdlr_ctl_fi_attr_set, NULL),			\
 	X(CRT_OPC_CTL_LOG_SET,						\
 		0, &CQF_crt_ctl_log_set,				\
-		crt_hdlr_ctl_log_set, NULL)
+		crt_hdlr_ctl_log_set, NULL),				\
+	X(CRT_OPC_CTL_LOG_ADD_MSG,					\
+		0, &CQF_crt_ctl_log_add_msg,				\
+		crt_hdlr_ctl_log_add_msg, NULL)
 
 /* Define for RPC enum population below */
 #define X(a, b, c, d, e) a
@@ -525,6 +528,15 @@ CRT_RPC_DECLARE(crt_ctl_fi_toggle,
 	((int32_t)		(rc)		CRT_VAR)
 
 CRT_RPC_DECLARE(crt_ctl_log_set, CRT_ISEQ_CTL_LOG_SET, CRT_OSEQ_CTL_LOG_SET)
+
+#define CRT_ISEQ_CTL_LOG_ADD_MSG	/* input fields */	\
+	((d_string_t)		(log_msg)	CRT_VAR)
+
+#define CRT_OSEQ_CTL_LOG_ADD_MSG	/* output fields */	\
+	((int32_t)		(rc)		CRT_VAR)
+
+CRT_RPC_DECLARE(crt_ctl_log_add_msg, CRT_ISEQ_CTL_LOG_ADD_MSG,
+		CRT_OSEQ_CTL_LOG_ADD_MSG)
 
 /* Internal macros for crt_req_(add|dec)ref from within cart.  These take
  * a crt_internal_rpc pointer and provide better logging than the public


### PR DESCRIPTION
- new 'add_log_msg' command added to cart_ctl. This comand sends
  custom log message (specified via -m 'msg') to the remote server
  Custom logs are printed as 'info' (D_INFO macro), and are limited
  to 256 characters.

- ability to specify 'all' for --ranks argument. When 'all' is
  used, every rank from group attach info file is contacted with
  this rpc.

Signed-off-by: Alexander Oganezov <alexander.a.oganezov@intel.com>