### PR TITLE
DAOS-4919 test: decrease io-small block size to 2M with 256B ts

### DIFF
--- a/src/tests/ftest/io/ior_small.yaml
+++ b/src/tests/ftest/io/ior_small.yaml
@@ -47,7 +47,7 @@ ior:
             - MPIIO
             - POSIX
           transfer_block_size:
-            - [256B, 4M]
+            - [256B, 2M]
             - [1M, 32M]
           obj_class:
             - "SX"


### PR DESCRIPTION
Signed-off-by: Mohamad Chaarawi <mohamad.chaarawi@intel.com>