### PR TITLE
DAOS-4947 tests: Timeout not honored in YamlCommand initialization

### DIFF
--- a/src/tests/ftest/util/command_utils.py
+++ b/src/tests/ftest/util/command_utils.py
@@ -575,7 +575,7 @@ class YamlCommand(SubProcessCommand):
             timeout (int, optional): number of seconds to wait for patterns to
                 appear in the subprocess output. Defaults to 60 seconds.
         """
-        super(YamlCommand, self).__init__(namespace, command, path)
+        super(YamlCommand, self).__init__(namespace, command, path, timeout)
 
         # Command configuration yaml file
         self.yaml = yaml_cfg


### PR DESCRIPTION
Providing the optional 'timeout' value in the YamlCommand initialization
to the inherited SubProcessCommand._init_().  This enables setting the
intended default for the self.pattern_timeout.value.

This resolvess the issue where the 90 second default pattern timeout
defined in the DaosServerCommand was not being honored and resulting in
potentenial timeouts detecting of the "SCM format required" messages by
a few seconds.

Signed-off-by: Phillip Henderson <phillip.henderson@intel.com>