### PR TITLE
DAOS-723 Fault: Allow Fault Injection framework to be compiled out

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -586,6 +586,7 @@ pipeline {
                     }
                     steps {
                         sconsBuild clean: "_build.external${arch}",
+                                   scons_args: "BUILD_TYPE=dev",
                                    failure_artifacts: 'config.log-centos7-gcc'
                         stash name: 'CentOS-install', includes: 'install/**'
                         stash name: 'CentOS-build-vars', includes: ".build_vars${arch}.*"
@@ -678,6 +679,7 @@ pipeline {
                     }
                     steps {
                         sconsBuild clean: "_build.external${arch}", COMPILER: "clang",
+                                   scons_args: "BUILD_TYPE=dev",
                                    failure_artifacts: 'config.log-centos7-clang'
                     }
                     post {
@@ -739,6 +741,7 @@ pipeline {
                     }
                     steps {
                         sconsBuild clean: "_build.external${arch}",
+                                   scons_args: "BUILD_TYPE=dev",
                                    failure_artifacts: 'config.log-ubuntu18.04-gcc'
                     }
                     post {
@@ -801,6 +804,7 @@ pipeline {
                     }
                     steps {
                         sconsBuild clean: "_build.external${arch}", COMPILER: "clang",
+                                   scons_args: "BUILD_TYPE=dev",
                                    failure_artifacts: 'config.log-ubuntu18.04-clag'
                     }
                     post {
@@ -862,6 +866,7 @@ pipeline {
                     }
                     steps {
                         sconsBuild clean: "_build.external${arch}",
+                                   scons_args: "BUILD_TYPE=dev",
                                    failure_artifacts: 'config.log-leap15-gcc'
                     }
                     post {
@@ -923,6 +928,7 @@ pipeline {
                     }
                     steps {
                         sconsBuild clean: "_build.external${arch}", COMPILER: "clang",
+                                   scons_args: "BUILD_TYPE=dev",
                                    failure_artifacts: 'config.log-leap15-clang'
                     }
                     post {
@@ -986,6 +992,7 @@ pipeline {
                     }
                     steps {
                         sconsBuild clean: "_build.external${arch}", COMPILER: "icc",
+                                   scons_args: "BUILD_TYPE=dev",
                                    TARGET_PREFIX: 'install/opt', failure_artifacts: 'config.log-leap15-icc'
                     }
                     post {

--- a/SConstruct
+++ b/SConstruct
@@ -115,6 +115,9 @@ def set_defaults(env):
     env.Append(CCFLAGS=['-D_FORTIFY_SOURCE=2'])
     env.AppendIfSupported(CCFLAGS=DESIRED_FLAGS)
 
+    if env.get('BUILT_TYPE') != 'release':
+        env.Append(CCFLAGS=['-DFAULT_INJECTION=1'])
+
     if GetOption("preprocess"):
         #could refine this but for now, just assume these warnings are ok
         env.AppendIfSupported(CCFLAGS=PP_ONLY_FLAGS)

--- a/SConstruct
+++ b/SConstruct
@@ -115,7 +115,7 @@ def set_defaults(env):
     env.Append(CCFLAGS=['-D_FORTIFY_SOURCE=2'])
     env.AppendIfSupported(CCFLAGS=DESIRED_FLAGS)
 
-    if env.get('BUILT_TYPE') != 'release':
+    if env.get('BUILD_TYPE') != 'release':
         env.Append(CCFLAGS=['-DFAULT_INJECTION=1'])
 
     if GetOption("preprocess"):

--- a/src/common/fail_loc.c
+++ b/src/common/fail_loc.c
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2016 Intel Corporation.
+ * (C) Copyright 2016-2020 Intel Corporation.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -141,18 +141,13 @@ daos_fail_init(void)
 	int rc;
 
 	rc = d_fault_inject_init();
-	if (rc == -DER_NOSYS) {
-		D_GOTO(out, rc = -DER_SUCCESS);
-	} else if (rc) {
+	if (rc != 0 && rc != -DER_NOSYS)
 		return rc;
-	}
 
 	rc = d_fault_attr_set(DAOS_FAIL_UNIT_TEST_GROUP, attr);
 	if (rc)
 		d_fault_inject_fini();
 
-
-out:
 	return rc;
 }
 

--- a/src/tests/suite/daos_checksum.c
+++ b/src/tests/suite/daos_checksum.c
@@ -249,6 +249,8 @@ io_with_server_side_verify(void **state)
 	struct csum_test_ctx	 ctx = {0};
 	int			 rc;
 
+	FAULT_INJECTION_REQUIRED();
+
 	/**
 	 * Setup
 	 */
@@ -326,6 +328,8 @@ test_server_data_corruption(void **state)
 	struct csum_test_ctx	 ctx = {0};
 	int			 rc;
 
+	FAULT_INJECTION_REQUIRED();
+
 	setup_from_test_args(&ctx, *state);
 	setup_cont_obj(&ctx, DAOS_PROP_CO_CSUM_CRC64, false, 1024*8, OC_SX);
 
@@ -358,6 +362,8 @@ test_fetch_array(void **state)
 {
 	int			rc;
 	struct csum_test_ctx	ctx = {0};
+
+	FAULT_INJECTION_REQUIRED();
 
 	/**
 	 * Setup
@@ -740,6 +746,8 @@ single_value(void **state)
 {
 	struct csum_test_ctx	ctx = {0};
 	int			rc;
+
+	FAULT_INJECTION_REQUIRED();
 
 	setup_from_test_args(&ctx, *state);
 

--- a/src/tests/suite/daos_mgmt.c
+++ b/src/tests/suite/daos_mgmt.c
@@ -394,6 +394,8 @@ pool_create_and_destroy_retry(void **state)
 	uuid_t		 uuid;
 	int		 rc;
 
+	FAULT_INJECTION_REQUIRED();
+
 	if (arg->myrank != 0)
 		return;
 

--- a/src/tests/suite/daos_obj.c
+++ b/src/tests/suite/daos_obj.c
@@ -2649,6 +2649,8 @@ io_nospace(void **state)
 	char		key[10];
 	int		i;
 
+	FAULT_INJECTION_REQUIRED();
+
 	/** choose random object */
 	oid = dts_oid_gen(dts_obj_class, 0, arg->myrank);
 

--- a/src/tests/suite/daos_test.h
+++ b/src/tests/suite/daos_test.h
@@ -55,6 +55,16 @@
 		return; \
 	} while  (0)
 
+#if FAULT_INJECTION
+#define FAULT_INJECTION_REQUIRED() do { } while (0)
+#else
+#define FAULT_INJECTION_REQUIRED() \
+	do { \
+		print_message("Fault injection required for test, skipping...\n"); \
+		skip();\
+	} while (0)
+#endif /* FAULT_INJECTION */
+
 #include <mpi.h>
 #include <daos/debug.h>
 #include <daos/common.h>

--- a/src/vos/tests/vts_common.h
+++ b/src/vos/tests/vts_common.h
@@ -40,6 +40,16 @@
 	#pragma GCC diagnostic ignored "-Wframe-larger-than="
 #endif
 
+#if FAULT_INJECTION
+#define FAULT_INJECTION_REQUIRED() do { } while (0)
+#else
+#define FAULT_INJECTION_REQUIRED() \
+	do { \
+		print_message("Fault injection required for test, skipping...\n"); \
+		skip();\
+	} while (0)
+#endif /* FAULT_INJECTION */
+
 #define VPOOL_16M	(16ULL << 20)
 #define VPOOL_1G	(1ULL << 30)
 #define VPOOL_2G	(2ULL << 30)

--- a/src/vos/tests/vts_pool.c
+++ b/src/vos/tests/vts_pool.c
@@ -124,6 +124,8 @@ pool_interop(void **state)
 	daos_handle_t		poh;
 	int			ret;
 
+	FAULT_INJECTION_REQUIRED();
+
 	uuid_generate(uuid);
 
 	daos_fail_loc_set(FLC_POOL_DF_VER | DAOS_FAIL_ONCE);

--- a/utils/build.config
+++ b/utils/build.config
@@ -3,7 +3,7 @@ component=daos
 
 [commit_versions]
 ARGOBOTS = 89507c1f8cfec4e918e8b9861e41b4e9cef71461
-CART = v4.7.0
+CART = 4cd401d159b14f431f4a77e94ae0e0eebce5f0e3
 PMDK = 1.8
 ISAL = v2.26.0
 SPDK = v19.04.1


### PR DESCRIPTION
The fault injection framework in in DAOS is a developer/test focused feature.
The feature should not be present in production systems so it is not built in
by default. It can be enabled by specifying BUILT_TYPE= dev or debug on the
scons build line.

Signed-off-by: David Quigley <david.quigley@intel.com>
Signed-off-by: Maureen Jean <maureen.jean@intel.com>