### PR TITLE
CART-89 init: Ignore fastbin mallopt errors

### DIFF
--- a/src/cart/src/cart/crt_init.c
+++ b/src/cart/src/cart/crt_init.c
@@ -73,7 +73,7 @@ static int
 mem_pin_workaround(void)
 {
 	int crt_rc = 0;
-	int rc;
+	int rc = 0;
 
 	/* Prevent malloc from releasing memory via sbrk syscall */
 	rc = mallopt(M_TRIM_THRESHOLD, -1);

--- a/src/cart/src/cart/crt_init.c
+++ b/src/cart/src/cart/crt_init.c
@@ -85,7 +85,8 @@ mem_pin_workaround(void)
 	/* Disable fastbins; this option is not available on all systems */
 	rc = mallopt(M_MXFAST, 0);
 	if (rc != 1)
-		D_ERROR("Failed to disable malloc fastbins: %d\n", errno);
+		D_WARN("Failed to disable malloc fastbins: %d (%s)\n",
+			errno, strerror(errno));
 
 	D_DEBUG(DB_ALL, "Memory pinning workaround enabled\n");
 exit:

--- a/src/cart/src/cart/crt_init.c
+++ b/src/cart/src/cart/crt_init.c
@@ -82,12 +82,10 @@ mem_pin_workaround(void)
 		D_GOTO(exit, crt_rc = -DER_MISC);
 	}
 
-	/** Disable fastbins */
+	/* Disable fastbins -- this option is not available on all systems */
 	rc = mallopt(M_MXFAST, 0);
-	if (rc != 1) {
+	if (rc != 1)
 		D_ERROR("Failed to disable malloc fastbins: %d\n", errno);
-		D_GOTO(exit, crt_rc = -DER_MISC);
-	}
 
 	D_DEBUG(DB_ALL, "Memory pinning workaround enabled\n");
 exit:

--- a/src/cart/src/cart/crt_init.c
+++ b/src/cart/src/cart/crt_init.c
@@ -82,7 +82,7 @@ mem_pin_workaround(void)
 		D_GOTO(exit, crt_rc = -DER_MISC);
 	}
 
-	/* Disable fastbins -- this option is not available on all systems */
+	/* Disable fastbins; this option is not available on all systems */
 	rc = mallopt(M_MXFAST, 0);
 	if (rc != 1)
 		D_ERROR("Failed to disable malloc fastbins: %d\n", errno);


### PR DESCRIPTION
- Ignore mallopt errors for fastbins as it is not available on
all systems.

Signed-off-by: Alexander Oganezov <alexander.a.oganezov@intel.com>