### PR TITLE
CART-904 cart: differentiate rpc cb and iv response cb

### DIFF
--- a/src/cart/src/cart/crt_context.c
+++ b/src/cart/src/cart/crt_context.c
@@ -259,7 +259,7 @@ out:
 
 int
 crt_context_register_rpc_task(crt_context_t ctx, crt_rpc_task_t process_cb,
-			      void *arg)
+			      crt_rpc_task_t iv_resp_cb, void *arg)
 {
 	struct crt_context *crt_ctx = ctx;
 
@@ -270,6 +270,7 @@ crt_context_register_rpc_task(crt_context_t ctx, crt_rpc_task_t process_cb,
 	}
 
 	crt_ctx->cc_rpc_cb = process_cb;
+	crt_ctx->cc_iv_resp_cb = iv_resp_cb;
 	crt_ctx->cc_rpc_cb_arg = arg;
 	return 0;
 }

--- a/src/cart/src/cart/crt_internal_types.h
+++ b/src/cart/src/cart/crt_internal_types.h
@@ -167,6 +167,7 @@ struct crt_context {
 	struct crt_hg_context	 cc_hg_ctx; /* HG context */
 	void			*cc_rpc_cb_arg;
 	crt_rpc_task_t		 cc_rpc_cb; /* rpc callback */
+	crt_rpc_task_t		 cc_iv_resp_cb;
 	/* in-flight endpoint tracking hash table */
 	struct d_hash_table	 cc_epi_table;
 	/* binheap for inflight RPC timeout tracking */

--- a/src/cart/src/cart/crt_iv.c
+++ b/src/cart/src/cart/crt_iv.c
@@ -2623,7 +2623,7 @@ handle_response_cb(const struct crt_cb_info *cb_info)
 	D_ASSERT(rpc_priv != NULL);
 	crt_ctx = rpc_priv->crp_pub.cr_ctx;
 
-	if (crt_rpc_cb_customized(crt_ctx, &rpc_priv->crp_pub)) {
+	if (crt_ctx->cc_iv_resp_cb != NULL) {
 		int rc;
 		struct crt_cb_info *info;
 
@@ -2638,10 +2638,10 @@ handle_response_cb(const struct crt_cb_info *cb_info)
 		info->cci_rpc = cb_info->cci_rpc;
 		info->cci_rc = cb_info->cci_rc;
 		info->cci_arg = cb_info->cci_arg;
-		rc = crt_ctx->cc_rpc_cb((crt_context_t)crt_ctx,
-					 info,
-					 handle_response_cb_internal,
-					 crt_ctx->cc_rpc_cb_arg);
+		rc = crt_ctx->cc_iv_resp_cb((crt_context_t)crt_ctx,
+					    info,
+					    handle_response_cb_internal,
+					    crt_ctx->cc_rpc_cb_arg);
 		if (rc) {
 			D_WARN("rpc_cb failed %d, do cb directly\n", rc);
 			RPC_DECREF(rpc_priv);

--- a/src/cart/src/include/cart/api.h
+++ b/src/cart/src/include/cart/api.h
@@ -754,13 +754,14 @@ typedef int (*crt_rpc_task_t) (crt_context_t *ctx, void *rpc_hdlr_arg,
  *
  * \param[in] crt_ctx          The context to be registered.
  * \param[in] rpc_cb           The RPC process callback.
+ * \param[in] iv_reps_cb       The IV response callback.
  * \param[in] arg              The argument for RPC process callback.
  *
  * \return                     DER_SUCCESS on success, negative value if error.
  */
 int
-crt_context_register_rpc_task(crt_context_t crt_ctx,
-			      crt_rpc_task_t rpc_cb, void *arg);
+crt_context_register_rpc_task(crt_context_t crt_ctx, crt_rpc_task_t rpc_cb,
+			      crt_rpc_task_t iv_resp_cb, void *arg);
 
 /**
  * Dynamically register an RPC with features at server-side.

--- a/src/cart/src/test/no_pmix_corpc_errors.c
+++ b/src/cart/src/test/no_pmix_corpc_errors.c
@@ -342,7 +342,7 @@ int main(int argc, char **argv)
 		assert(rc == 0);
 
 		rc = crt_context_register_rpc_task(crt_ctx[i],
-				rpc_callback, NULL);
+				rpc_callback, NULL, NULL);
 		if (rc != 0) {
 			D_ERROR("register_rpc_task failed; rc=%d\n", rc);
 			assert(0);


### PR DESCRIPTION
RPC callback and IV response callback needs be differentiated becase
their logic will be quite different when the scheduler is improved to
prioritize various request ULTs differently.

Signed-off-by: Niu Yawei <yawei.niu@intel.com>