### PR TITLE
DAOS-4818 dtx: Pass DTX ID & uncertainty to obj_rw

### DIFF
--- a/src/dtx/dtx_common.c
+++ b/src/dtx/dtx_common.c
@@ -223,12 +223,36 @@ check:
 	}
 }
 
+/* Return the epoch uncertainty upper bound. */
+static daos_epoch_t
+dtx_epoch_bound(daos_epoch_t epoch, daos_epoch_t epoch_orig, bool uncertain)
+{
+	daos_epoch_t limit;
+
+	if (!uncertain)
+		/*
+		 * We are told that the epoch has no uncertainty, even if it's
+		 * still within the potential uncertainty window.
+		 */
+		return epoch;
+
+	limit = epoch_orig + crt_hlc_epsilon_get();
+	if (epoch >= limit)
+		/*
+		 * The epoch is already out of the potential uncertainty
+		 * window.
+		 */
+		return epoch;
+
+	return limit;
+}
+
 /**
  * Init local dth handle.
  */
 static void
 dtx_handle_init(struct dtx_id *dti, daos_handle_t coh,
-		daos_epoch_t epoch,  uint32_t pm_ver,
+		daos_epoch_t epoch,  bool epoch_uncertain, uint32_t pm_ver,
 		daos_unit_oid_t *oid, uint64_t dkey_hash, uint32_t intent,
 		struct dtx_id *dti_cos, int dti_cos_count,
 		bool leader, bool solo, struct dtx_handle *dth)
@@ -236,6 +260,8 @@ dtx_handle_init(struct dtx_id *dti, daos_handle_t coh,
 	dth->dth_xid = *dti;
 	dth->dth_coh = coh;
 	dth->dth_epoch = epoch;
+	dth->dth_epoch_bound = dtx_epoch_bound(epoch, dti->dti_hlc,
+					       epoch_uncertain);
 	dth->dth_ver = pm_ver;
 
 	dth->dth_oid = *oid;
@@ -267,6 +293,8 @@ dtx_handle_init(struct dtx_id *dti, daos_handle_t coh,
  * \param cont		[IN]	Pointer to the container.
  * \param dti		[IN]	The DTX identifier.
  * \param epoch		[IN]	Epoch for the DTX.
+ * \param epoch_uncertain
+ *			[IN]	Epoch is uncertain.
  * \param pm_ver	[IN]	Pool map version for the DTX.
  * \param oid		[IN]	The target object (shard) ID.
  * \param dkey_hash	[IN]	Hash of the dkey to be modified if applicable.
@@ -279,7 +307,7 @@ dtx_handle_init(struct dtx_id *dti, daos_handle_t coh,
  */
 int
 dtx_leader_begin(struct ds_cont_child *cont, struct dtx_id *dti,
-		 daos_epoch_t epoch, uint32_t pm_ver,
+		 daos_epoch_t epoch, bool epoch_uncertain, uint32_t pm_ver,
 		 daos_unit_oid_t *oid, uint64_t dkey_hash, uint32_t intent,
 		 struct daos_shard_tgt *tgts, int tgt_cnt,
 		 struct dtx_leader_handle *dlh)
@@ -326,7 +354,7 @@ dtx_leader_begin(struct ds_cont_child *cont, struct dtx_id *dti,
 	}
 
 init:
-	dtx_handle_init(dti, cont->sc_hdl, epoch, pm_ver,
+	dtx_handle_init(dti, cont->sc_hdl, epoch, epoch_uncertain, pm_ver,
 			oid, dkey_hash, intent,
 			dti_cos, dti_cos_count, true,
 			tgt_cnt == 0 ? true : false, dth);
@@ -548,10 +576,12 @@ out:
  * \param cont		[IN]	Pointer to the container.
  * \param dti		[IN]	The DTX identifier.
  * \param epoch		[IN]	Epoch for the DTX.
+ * \param epoch_uncertain
+ *			[IN]	Epoch is uncertain.
  * \param pm_ver	[IN]	Pool map version for the DTX.
  * \param oid		[IN]	The target object (shard) ID.
  * \param dkey_hash	[IN]	Hash of the dkey to be modified if applicable.
- * \param intent	[IN]	The intent of related modification.
+ * \param intent	[IN]	The intent of related operations.
  * \param dti_cos	[IN]	The DTX array to be committed because of shared.
  * \param dti_cos_count [IN]	The @dti_cos array size.
  * \param dth		[OUT]	Pointer to the DTX handle.
@@ -560,7 +590,7 @@ out:
  */
 int
 dtx_begin(struct ds_cont_child *cont, struct dtx_id *dti,
-	  daos_epoch_t epoch, uint32_t pm_ver,
+	  daos_epoch_t epoch, bool epoch_uncertain, uint32_t pm_ver,
 	  daos_unit_oid_t *oid, uint64_t dkey_hash, uint32_t intent,
 	  struct dtx_id *dti_cos, int dti_cos_cnt, struct dtx_handle *dth)
 {
@@ -571,7 +601,7 @@ dtx_begin(struct ds_cont_child *cont, struct dtx_id *dti,
 		return 0;
 	}
 
-	dtx_handle_init(dti, cont->sc_hdl, epoch, pm_ver,
+	dtx_handle_init(dti, cont->sc_hdl, epoch, epoch_uncertain, pm_ver,
 			oid, dkey_hash, intent,
 			dti_cos, dti_cos_cnt, false, false, dth);
 

--- a/src/include/daos_api.h
+++ b/src/include/daos_api.h
@@ -68,7 +68,7 @@ d_rank_list_t *daos_rank_list_parse(const char *str, const char *sep);
  *
  * \param[in]	coh	Container handle.
  * \param[out]	th	Returned transaction handle.
- * \param[in]	flags	Transaction flags.
+ * \param[in]	flags	Transaction flags (DAOS_TF_RDONLY, etc.).
  * \param[in]	ev	Completion event, it is optional and can be NULL.
  *			The function will run in blocking mode if \a ev is NULL.
  *

--- a/src/include/daos_srv/dtx_srv.h
+++ b/src/include/daos_srv/dtx_srv.h
@@ -48,6 +48,11 @@ struct dtx_handle {
 	daos_handle_t			 dth_coh;
 	/** The epoch# for the DTX. */
 	daos_epoch_t			 dth_epoch;
+	/**
+	 * The upper bound of the epoch uncertainty. dth_epoch_bound ==
+	 * dth_epoch means that dth_epoch has no uncertainty.
+	 */
+	daos_epoch_t			 dth_epoch_bound;
 	/* The hash of the dkey to be modified if applicable */
 	uint64_t			 dth_dkey_hash;
 	/** Pool map version. */
@@ -122,7 +127,7 @@ enum dtx_status {
 
 int
 dtx_leader_begin(struct ds_cont_child *cont, struct dtx_id *dti,
-		 daos_epoch_t epoch, uint32_t pm_ver,
+		 daos_epoch_t epoch, bool epoch_uncertain, uint32_t pm_ver,
 		 daos_unit_oid_t *oid, uint64_t dkey_hash, uint32_t intent,
 		 struct daos_shard_tgt *tgts, int tgt_cnt,
 		 struct dtx_leader_handle *dlh);
@@ -137,7 +142,7 @@ typedef int (*dtx_sub_func_t)(struct dtx_leader_handle *dlh, void *arg, int idx,
 
 int
 dtx_begin(struct ds_cont_child *cont, struct dtx_id *dti,
-	  daos_epoch_t epoch, uint32_t pm_ver,
+	  daos_epoch_t epoch, bool epoch_uncertain, uint32_t pm_ver,
 	  daos_unit_oid_t *oid, uint64_t dkey_hash, uint32_t intent,
 	  struct dtx_id *dti_cos, int dti_cos_cnt, struct dtx_handle *dth);
 int

--- a/src/include/daos_srv/vos.h
+++ b/src/include/daos_srv/vos.h
@@ -325,17 +325,6 @@ int
 vos_cont_query(daos_handle_t coh, vos_cont_info_t *cinfo);
 
 /**
- * Flush changes in the specified epoch to storage
- *
- * \param coh	[IN]	Container open handle
- * \param epoch	[IN]	Epoch to flush
- *
- * \return		Zero on success, negative value if error
- */
-int
-vos_epoch_flush(daos_handle_t coh, daos_epoch_t epoch);
-
-/**
  * Aggregates all epochs within the epoch range \a epr.
  * Data in all these epochs will be aggregated to the last epoch
  * \a epr::epr_hi, aggregated epochs will be discarded except the last one,
@@ -503,14 +492,15 @@ vos_obj_delete(daos_handle_t coh, daos_unit_oid_t oid);
  * \param size_fetch[IN]
  *			Fetch size only
  * \param ioh	[OUT]	The returned handle for the I/O.
+ * \param dth	[IN]	Pointer to the DTX handle.
  *
  * \return		Zero on success, negative value if error
  */
 int
 vos_fetch_begin(daos_handle_t coh, daos_unit_oid_t oid, daos_epoch_t epoch,
 		uint64_t flags, daos_key_t *dkey, unsigned int nr,
-		daos_iod_t *iods,
-		bool size_fetch, daos_handle_t *ioh);
+		daos_iod_t *iods, bool size_fetch, daos_handle_t *ioh,
+		struct dtx_handle *dth);
 
 /**
  * Finish the fetch operation and release the responding resources.

--- a/src/object/cli_obj.c
+++ b/src/object/cli_obj.c
@@ -40,7 +40,7 @@
 #define CLI_OBJ_IO_PARMS	8
 #define NIL_BITMAP		(NULL)
 
-#define OBJ_TGT_INLINE_NR	(26)
+#define OBJ_TGT_INLINE_NR	(25)
 struct obj_req_tgts {
 	/* to save memory allocation if #targets <= OBJ_TGT_INLINE_NR */
 	struct daos_shard_tgt	 ort_tgts_inline[OBJ_TGT_INLINE_NR];
@@ -1482,7 +1482,7 @@ obj_iod_sgl_valid(unsigned int nr, daos_iod_t *iods, d_sg_list_t *sgls,
 
 /* check if the obj request is valid */
 static int
-obj_req_valid(void *args, int opc, daos_epoch_t *epoch, uint32_t *pm_ver)
+obj_req_valid(void *args, int opc, struct dc_obj_epoch *epoch, uint32_t *pm_ver)
 {
 	int	rc = 0;
 
@@ -1506,8 +1506,9 @@ obj_req_valid(void *args, int opc, daos_epoch_t *epoch, uint32_t *pm_ver)
 			if (rc != -DER_INVAL)
 				D_GOTO(out, rc);
 
-			*epoch = dc_io_epoch();
-			D_DEBUG(DB_IO, "set fetch epoch "DF_U64"\n", *epoch);
+			dc_io_epoch_set(epoch);
+			D_DEBUG(DB_IO, "set fetch epoch "DF_U64"\n",
+				epoch->oe_value);
 			rc = 0;
 		}
 		break;
@@ -1525,8 +1526,9 @@ obj_req_valid(void *args, int opc, daos_epoch_t *epoch, uint32_t *pm_ver)
 				       true);
 		/* !daos_handle_is_inval case will be handled by the caller. */
 		if (rc == 0 && daos_handle_is_inval(u_args->th)) {
-			*epoch = dc_io_epoch();
-			D_DEBUG(DB_IO, "set update epoch "DF_U64"\n", *epoch);
+			dc_io_epoch_set(epoch);
+			D_DEBUG(DB_IO, "set update epoch "DF_U64"\n",
+				epoch->oe_value);
 		}
 		break;
 	}
@@ -1537,8 +1539,9 @@ obj_req_valid(void *args, int opc, daos_epoch_t *epoch, uint32_t *pm_ver)
 
 		/* !daos_handle_is_inval case will be handled by the caller. */
 		if (daos_handle_is_inval(p_args->th)) {
-			*epoch = dc_io_epoch();
-			D_DEBUG(DB_IO, "set punch epoch "DF_U64"\n", *epoch);
+			dc_io_epoch_set(epoch);
+			D_DEBUG(DB_IO, "set punch epoch "DF_U64"\n",
+				epoch->oe_value);
 		}
 		break;
 	}
@@ -1565,8 +1568,9 @@ obj_req_valid(void *args, int opc, daos_epoch_t *epoch, uint32_t *pm_ver)
 			if (rc != -DER_INVAL)
 				D_GOTO(out, rc);
 
-			*epoch = dc_io_epoch();
-			D_DEBUG(DB_IO, "set enum epoch "DF_U64"\n", *epoch);
+			dc_io_epoch_set(epoch);
+			D_DEBUG(DB_IO, "set enum epoch "DF_U64"\n",
+				epoch->oe_value);
 			rc = 0;
 		}
 		break;
@@ -1736,17 +1740,18 @@ shard_task_abort(tse_task_t *task, void *arg)
 
 static void
 shard_auxi_set_param(struct shard_auxi_args *shard_arg, uint32_t map_ver,
-		     uint32_t shard, uint32_t tgt_id, uint64_t epoch)
+		     uint32_t shard, uint32_t tgt_id,
+		     struct dc_obj_epoch *epoch)
 {
-	shard_arg->epoch = epoch;
+	shard_arg->epoch = *epoch;
 	shard_arg->shard = shard;
 	shard_arg->target = tgt_id;
 	shard_arg->map_ver = map_ver;
 }
 
 struct shard_task_sched_args {
-	uint64_t	tsa_epoch;
-	bool		tsa_scheded;
+	struct dc_obj_epoch	tsa_epoch;
+	bool			tsa_scheded;
 };
 
 static int
@@ -1774,7 +1779,8 @@ shard_task_sched(tse_task_t *task, void *arg)
 		target = obj_shard2tgtid(shard_auxi->obj, shard_auxi->shard);
 		if (obj_auxi->req_tgts.ort_srv_disp ||
 		    obj_retry_error(task->dt_result) ||
-		    sched_arg->tsa_epoch != shard_auxi->epoch ||
+		    sched_arg->tsa_epoch.oe_value !=
+		    shard_auxi->epoch.oe_value ||
 		    target != shard_auxi->target) {
 			D_DEBUG(DB_IO, "shard %d, dt_result %d, target %d @ "
 				"map_ver %d, target %d @ last_map_ver %d, "
@@ -1793,7 +1799,7 @@ shard_task_sched(tse_task_t *task, void *arg)
 			if (!obj_auxi->req_tgts.ort_srv_disp)
 				shard_auxi_set_param(shard_auxi, map_ver,
 					shard_auxi->shard, target,
-					sched_arg->tsa_epoch);
+					&sched_arg->tsa_epoch);
 			sched_arg->tsa_scheded = true;
 		}
 	} else {
@@ -1808,13 +1814,13 @@ out:
 }
 
 static void
-obj_shard_task_sched(struct obj_auxi_args *obj_auxi, uint64_t epoch)
+obj_shard_task_sched(struct obj_auxi_args *obj_auxi, struct dc_obj_epoch *epoch)
 {
 	struct shard_task_sched_args	sched_arg;
 
 	D_ASSERT(!d_list_empty(&obj_auxi->shard_task_head));
 	sched_arg.tsa_scheded = false;
-	sched_arg.tsa_epoch = epoch;
+	sched_arg.tsa_epoch = *epoch;
 	tse_task_list_traverse(&obj_auxi->shard_task_head, shard_task_sched,
 			       &sched_arg);
 	/* It is possible that the IO retried by stale pm version found, but
@@ -1904,7 +1910,7 @@ typedef int (*shard_io_prep_cb_t)(struct shard_auxi_args *shard_auxi,
 
 struct shard_task_reset_arg {
 	struct obj_req_tgts	*req_tgts;
-	uint64_t		 epoch;
+	struct dc_obj_epoch	 epoch;
 };
 
 static int
@@ -1923,13 +1929,13 @@ shard_task_reset_param(tse_task_t *shard_task, void *arg)
 		     shard_arg->grp_idx * req_tgts->ort_grp_size;
 	shard_auxi_set_param(shard_arg, obj_auxi->map_ver_req,
 			     leader_tgt->st_shard, leader_tgt->st_tgt_id,
-			     reset_arg->epoch);
+			     &reset_arg->epoch);
 	return 0;
 }
 
 static int
 obj_req_fanout(struct dc_object *obj, struct obj_auxi_args *obj_auxi,
-	       uint64_t dkey_hash, uint32_t map_ver, daos_epoch_t epoch,
+	       uint64_t dkey_hash, uint32_t map_ver, struct dc_obj_epoch *epoch,
 	       shard_io_prep_cb_t io_prep_cb, shard_io_cb_t io_cb,
 	       tse_task_t *obj_task)
 {
@@ -1985,7 +1991,7 @@ obj_req_fanout(struct dc_object *obj, struct obj_auxi_args *obj_auxi,
 			struct shard_task_reset_arg reset_arg;
 
 			reset_arg.req_tgts = req_tgts;
-			reset_arg.epoch = epoch;
+			reset_arg.epoch = *epoch;
 			/* For srv dispatch, the task_list non-empty is only for
 			 * obj punch that with multiple RDG that each with a
 			 * leader. Here reset the header for the shard task.
@@ -2383,14 +2389,13 @@ shard_rw_prep(struct shard_auxi_args *shard_auxi, struct dc_object *obj,
 	obj_args = dc_task_get_args(obj_auxi->obj_task);
 	shard_arg = container_of(shard_auxi, struct shard_rw_args, auxi);
 
-	if (obj_auxi->opc == DAOS_OBJ_RPC_UPDATE) {
-		if (daos_handle_is_inval(obj_auxi->th))
-			daos_dti_gen(&shard_arg->dti,
-				     (srv_io_mode != DIM_DTX_FULL_ENABLED) ||
-				     daos_obj_is_echo(obj->cob_md.omd_id));
-		else
-			dc_tx_get_dti(obj_auxi->th, &shard_arg->dti);
-	}
+	if (daos_handle_is_inval(obj_auxi->th))
+		daos_dti_gen(&shard_arg->dti,
+			     obj_auxi->opc == DAOS_OBJ_RPC_FETCH ||
+			     srv_io_mode != DIM_DTX_FULL_ENABLED ||
+			     daos_obj_is_echo(obj->cob_md.omd_id));
+	else
+		dc_tx_get_dti(obj_auxi->th, &shard_arg->dti);
 
 	shard_arg->api_args		= obj_args;
 	shard_arg->dkey_hash		= dkey_hash;
@@ -2565,7 +2570,7 @@ dc_obj_fetch(tse_task_t *task, daos_obj_fetch_t *args, uint32_t flags,
 	uint8_t                 *tgt_bitmap = NIL_BITMAP;
 	unsigned int		 map_ver = 0;
 	uint64_t		 dkey_hash;
-	daos_epoch_t		 epoch;
+	struct dc_obj_epoch	 epoch;
 	int			 rc;
 	uint8_t                  csum_bitmap = 0;
 
@@ -2657,7 +2662,7 @@ dc_obj_fetch(tse_task_t *task, daos_obj_fetch_t *args, uint32_t flags,
 		goto out_task;
 	}
 
-	rc = obj_req_fanout(obj, obj_auxi, dkey_hash, map_ver, epoch,
+	rc = obj_req_fanout(obj, obj_auxi, dkey_hash, map_ver, &epoch,
 			    shard_rw_prep, dc_obj_shard_rw, task);
 	return rc;
 
@@ -2681,7 +2686,7 @@ dc_obj_fetch_task(tse_task_t *task)
 }
 
 int
-dc_obj_update(tse_task_t *task, daos_epoch_t epoch, uint32_t map_ver,
+dc_obj_update(tse_task_t *task, struct dc_obj_epoch *epoch, uint32_t map_ver,
 	      daos_obj_update_t *args)
 {
 	struct obj_auxi_args	*obj_auxi;
@@ -2760,7 +2765,7 @@ int
 dc_obj_update_task(tse_task_t *task)
 {
 	daos_obj_update_t	*args = dc_task_get_args(task);
-	daos_epoch_t		 epoch = 0;
+	struct dc_obj_epoch	 epoch = {0};
 	unsigned int		 map_ver = 0;
 	int			 rc;
 
@@ -2774,7 +2779,7 @@ dc_obj_update_task(tse_task_t *task)
 		goto comp;
 	}
 	/* submit the update */
-	return dc_obj_update(task, epoch, map_ver, args);
+	return dc_obj_update(task, &epoch, map_ver, args);
 comp:
 	tse_task_complete(task, rc);
 	return rc;
@@ -2803,7 +2808,7 @@ obj_list_common(tse_task_t *task, int opc, daos_obj_list_t *args)
 	unsigned int		 map_ver = 0;
 	struct obj_list_arg	 list_args;
 	uint64_t		 dkey_hash;
-	daos_epoch_t		 epoch;
+	struct dc_obj_epoch	 epoch;
 	int			 shard = -1;
 	int			 rc;
 
@@ -2868,7 +2873,7 @@ obj_list_common(tse_task_t *task, int opc, daos_obj_list_t *args)
 	D_DEBUG(DB_IO, "list opc %d "DF_OID" dkey %llu\n", opc,
 		DP_OID(obj->cob_md.omd_id), (unsigned long long)dkey_hash);
 
-	rc = obj_req_fanout(obj, obj_auxi, dkey_hash, map_ver, epoch,
+	rc = obj_req_fanout(obj, obj_auxi, dkey_hash, map_ver, &epoch,
 			    shard_list_prep, dc_obj_shard_list, task);
 	return rc;
 
@@ -2959,7 +2964,7 @@ shard_punch_prep(struct shard_auxi_args *shard_auxi, struct dc_object *obj,
 }
 
 int
-dc_obj_punch(tse_task_t *task, daos_epoch_t epoch, uint32_t map_ver,
+dc_obj_punch(tse_task_t *task, struct dc_obj_epoch *epoch, uint32_t map_ver,
 	     enum obj_rpc_opc opc, daos_obj_punch_t *api_args)
 {
 	struct obj_auxi_args	*obj_auxi;
@@ -3014,7 +3019,7 @@ out_task:
 static int
 obj_punch_common(tse_task_t *task, enum obj_rpc_opc opc, daos_obj_punch_t *args)
 {
-	daos_epoch_t		 epoch = 0;
+	struct dc_obj_epoch	 epoch = {0};
 	unsigned int		 map_ver = 0;
 	int			 rc;
 
@@ -3028,7 +3033,7 @@ obj_punch_common(tse_task_t *task, enum obj_rpc_opc opc, daos_obj_punch_t *args)
 		goto comp;
 	}
 	/* submit the punch */
-	return dc_obj_punch(task, epoch, map_ver, opc, args);
+	return dc_obj_punch(task, &epoch, map_ver, opc, args);
 comp:
 	tse_task_complete(task, rc);
 	return rc;
@@ -3239,7 +3244,7 @@ dc_obj_query_key(tse_task_t *api_task)
 	unsigned int		replicas;
 	unsigned int		map_ver = 0;
 	uint64_t		dkey_hash;
-	daos_epoch_t            epoch;
+	struct dc_obj_epoch	epoch;
 	int			i = 0;
 	int			rc;
 
@@ -3252,8 +3257,8 @@ dc_obj_query_key(tse_task_t *api_task)
 		if (rc != -DER_INVAL)
 			goto out_task;
 
-		epoch = dc_io_epoch();
-		D_DEBUG(DB_IO, "set query epoch "DF_U64"\n", epoch);
+		dc_io_epoch_set(&epoch);
+		D_DEBUG(DB_IO, "set query epoch "DF_U64"\n", epoch.oe_value);
 	}
 
 	obj = obj_hdl2ptr(api_args->oh);
@@ -3370,7 +3375,7 @@ dc_obj_query_key(tse_task_t *api_task)
 
 		args = tse_task_buf_embedded(task, sizeof(*args));
 		args->kqa_api_args	= api_args;
-		args->kqa_epoch		= epoch;
+		args->kqa_epoch		= epoch.oe_value;
 		args->kqa_auxi.shard	= shard;
 		args->kqa_auxi.target	= obj_shard2tgtid(obj, shard);
 		args->kqa_auxi.map_ver	= map_ver;
@@ -3394,7 +3399,7 @@ dc_obj_query_key(tse_task_t *api_task)
 	obj_auxi->args_initialized = 1;
 
 task_sched:
-	obj_shard_task_sched(obj_auxi, epoch);
+	obj_shard_task_sched(obj_auxi, &epoch);
 	return rc;
 
 out_task:
@@ -3431,6 +3436,7 @@ dc_obj_sync(tse_task_t *task)
 	struct daos_obj_sync_args	*args;
 	struct obj_auxi_args		*obj_auxi = NULL;
 	struct dc_object		*obj = NULL;
+	struct dc_obj_epoch		 epoch;
 	uint32_t			 map_ver;
 	int				 rc;
 	int				 i;
@@ -3445,6 +3451,9 @@ dc_obj_sync(tse_task_t *task)
 	obj = obj_hdl2ptr(args->oh);
 	if (obj == NULL)
 		D_GOTO(out_task, rc = -DER_NO_HDL);
+
+	epoch.oe_value = args->epoch;
+	epoch.oe_uncertain = false;
 
 	rc = obj_ptr2pm_ver(obj, &map_ver);
 	if (rc != 0) {
@@ -3486,8 +3495,8 @@ dc_obj_sync(tse_task_t *task)
 	D_DEBUG(DB_IO, "sync "DF_OID", reps %d\n",
 		DP_OID(obj->cob_md.omd_id), obj_get_replicas(obj));
 
-	rc = obj_req_fanout(obj, obj_auxi, 0, map_ver, args->epoch,
-			    shard_sync_prep, dc_obj_shard_sync, task);
+	rc = obj_req_fanout(obj, obj_auxi, 0, map_ver, &epoch, shard_sync_prep,
+			    dc_obj_shard_sync, task);
 	return rc;
 
 out_task:

--- a/src/object/cli_shard.c
+++ b/src/object/cli_shard.c
@@ -483,6 +483,9 @@ dc_obj_shard_rw(struct dc_obj_shard *shard, enum obj_rpc_opc opc,
 		}
 	}
 
+	if (args->auxi.epoch.oe_uncertain)
+		flags |= ORF_EPOCH_UNCERTAIN;
+
 	rc = dc_cont_hdl2uuid(shard->do_co_hdl, &cont_hdl_uuid, &cont_uuid);
 	if (rc != 0)
 		D_GOTO(out_obj, rc);
@@ -501,7 +504,7 @@ dc_obj_shard_rw(struct dc_obj_shard *shard, enum obj_rpc_opc opc,
 	D_DEBUG(DB_TRACE, "rpc %p opc:%d "DF_UOID" %d %s rank:%d tag:%d eph "
 		DF_U64"\n", req, opc, DP_UOID(shard->do_id), (int)dkey->iov_len,
 		(char *)dkey->iov_buf, tgt_ep.ep_rank, tgt_ep.ep_tag,
-		args->auxi.epoch);
+		args->auxi.epoch.oe_value);
 	if (rc != 0)
 		D_GOTO(out_pool, rc);
 
@@ -531,7 +534,7 @@ dc_obj_shard_rw(struct dc_obj_shard *shard, enum obj_rpc_opc opc,
 	orw->orw_dti_cos.ca_arrays = NULL;
 
 	orw->orw_api_flags = api_args->flags;
-	orw->orw_epoch = args->auxi.epoch;
+	orw->orw_epoch = args->auxi.epoch.oe_value;
 	orw->orw_dkey_hash = args->dkey_hash;
 	orw->orw_nr = nr;
 	orw->orw_dkey = *dkey;
@@ -547,7 +550,8 @@ dc_obj_shard_rw(struct dc_obj_shard *shard, enum obj_rpc_opc opc,
 	D_DEBUG(DB_TRACE, "opc %d "DF_UOID" %d %s rank %d tag %d eph "
 		DF_U64", DTI = "DF_DTI"\n", opc, DP_UOID(shard->do_id),
 		(int)dkey->iov_len, (char *)dkey->iov_buf, tgt_ep.ep_rank,
-		tgt_ep.ep_tag, args->auxi.epoch, DP_DTI(&orw->orw_dti));
+		tgt_ep.ep_tag, args->auxi.epoch.oe_value,
+		DP_DTI(&orw->orw_dti));
 
 	if (args->bulks != NULL) {
 		orw->orw_sgls.ca_count = 0;
@@ -664,7 +668,8 @@ dc_obj_shard_punch(struct dc_obj_shard *shard, enum obj_rpc_opc opc,
 		D_GOTO(out, rc = (int)tgt_ep.ep_rank);
 
 	D_DEBUG(DB_IO, "opc=%d, rank=%d tag=%d epoch "DF_U64".\n",
-		 opc, tgt_ep.ep_rank, tgt_ep.ep_tag, args->pa_auxi.epoch);
+		 opc, tgt_ep.ep_rank, tgt_ep.ep_tag,
+		 args->pa_auxi.epoch.oe_value);
 
 	rc = obj_req_create(daos_task2ctx(task), &tgt_ep, opc, &req);
 	if (rc != 0)
@@ -683,7 +688,7 @@ dc_obj_shard_punch(struct dc_obj_shard *shard, enum obj_rpc_opc opc,
 
 	opi->opi_map_ver	 = args->pa_auxi.map_ver;
 	opi->opi_api_flags	 = obj_args->flags;
-	opi->opi_epoch		 = args->pa_auxi.epoch;
+	opi->opi_epoch		 = args->pa_auxi.epoch.oe_value;
 	opi->opi_dkey_hash	 = args->pa_dkey_hash;
 	opi->opi_oid		 = oid;
 	opi->opi_dkeys.ca_count  = (dkey == NULL) ? 0 : 1;
@@ -703,6 +708,8 @@ dc_obj_shard_punch(struct dc_obj_shard *shard, enum obj_rpc_opc opc,
 	uuid_copy(opi->opi_co_uuid, args->pa_cont_uuid);
 	daos_dti_copy(&opi->opi_dti, &args->pa_dti);
 	opi->opi_flags = args->pa_auxi.flags;
+	if (args->pa_auxi.epoch.oe_uncertain)
+		opi->opi_flags |= ORF_EPOCH_UNCERTAIN;
 	opi->opi_dti_cos.ca_count = 0;
 	opi->opi_dti_cos.ca_arrays = NULL;
 
@@ -973,7 +980,7 @@ dc_obj_shard_list(struct dc_obj_shard *obj_shard, enum obj_rpc_opc opc,
 		oei->oei_epr = *obj_args->eprs;
 	} else {
 		oei->oei_epr.epr_lo = 0;
-		oei->oei_epr.epr_hi = args->la_auxi.epoch;
+		oei->oei_epr.epr_hi = args->la_auxi.epoch.oe_value;
 	}
 
 	oei->oei_nr		= *obj_args->nr;
@@ -1376,7 +1383,7 @@ dc_obj_shard_sync(struct dc_obj_shard *shard, enum obj_rpc_opc opc,
 	uuid_copy(osi->osi_pool_uuid, pool->dp_pool);
 	uuid_copy(osi->osi_co_uuid, cont_uuid);
 	osi->osi_oid		= shard->do_id;
-	osi->osi_epoch		= args->sa_auxi.epoch;
+	osi->osi_epoch		= args->sa_auxi.epoch.oe_value;
 	osi->osi_map_ver	= args->sa_auxi.map_ver;
 
 	rc = daos_rpc_send(req, task);

--- a/src/object/obj_internal.h
+++ b/src/object/obj_internal.h
@@ -246,6 +246,11 @@ typedef int (*shard_io_cb_t)(struct dc_obj_shard *shard, enum obj_rpc_opc opc,
 			     struct daos_shard_tgt *fw_shard_tgts,
 			     uint32_t fw_cnt, tse_task_t *task);
 
+struct dc_obj_epoch {
+	daos_epoch_t	oe_value;
+	bool		oe_uncertain;
+};
+
 /* shard update/punch auxiliary args, must be the first field of
  * shard_rw_args and shard_punch_args.
  */
@@ -253,7 +258,7 @@ struct shard_auxi_args {
 	struct dc_object	*obj;
 	struct obj_auxi_args	*obj_auxi;
 	shard_io_cb_t		 shard_io_cb;
-	uint64_t		 epoch;
+	struct dc_obj_epoch	 epoch;
 	uint32_t		 shard;
 	uint32_t		 target;
 	uint32_t		 map_ver;
@@ -412,11 +417,17 @@ obj_ptr2hdl(struct dc_object *obj)
 	return oh;
 }
 
-static inline daos_epoch_t
-dc_io_epoch(void)
+static inline void
+dc_io_epoch_set(struct dc_obj_epoch *epoch)
 {
-	return (srv_io_mode != DIM_CLIENT_DISPATCH) ?
-			DAOS_EPOCH_MAX : crt_hlc_get();
+	if (srv_io_mode == DIM_CLIENT_DISPATCH) {
+		epoch->oe_value = crt_hlc_get();
+		/* DIM_CLIENT_DISPATCH doesn't promise consistency. */
+		epoch->oe_uncertain = false;
+	} else {
+		epoch->oe_value = DAOS_EPOCH_MAX;
+		epoch->oe_uncertain = false; /* not applicable */
+	}
 }
 
 void obj_shard_decref(struct dc_obj_shard *shard);
@@ -425,9 +436,9 @@ void obj_addref(struct dc_object *obj);
 void obj_decref(struct dc_object *obj);
 int obj_get_grp_size(struct dc_object *obj);
 struct dc_object *obj_hdl2ptr(daos_handle_t oh);
-int dc_obj_update(tse_task_t *task, daos_epoch_t epoch, uint32_t map_ver,
-		  daos_obj_update_t *args);
-int dc_obj_punch(tse_task_t *task, daos_epoch_t epoch, uint32_t map_ver,
+int dc_obj_update(tse_task_t *task, struct dc_obj_epoch *epoch,
+		  uint32_t map_ver, daos_obj_update_t *args);
+int dc_obj_punch(tse_task_t *task, struct dc_obj_epoch *epoch, uint32_t map_ver,
 		 enum obj_rpc_opc opc, daos_obj_punch_t *api_args);
 
 struct ds_obj_exec_arg {
@@ -474,7 +485,8 @@ int
 dc_tx_check_pmv(daos_handle_t th);
 
 int
-dc_tx_hdl2epoch_and_pmv(daos_handle_t th, daos_epoch_t *epoch, uint32_t *pmv);
+dc_tx_hdl2epoch_and_pmv(daos_handle_t th, struct dc_obj_epoch *epoch,
+			uint32_t *pmv);
 
 int
 dc_tx_set_epoch(daos_handle_t th, daos_epoch_t epoch);

--- a/src/object/obj_rpc.h
+++ b/src/object/obj_rpc.h
@@ -141,6 +141,8 @@ enum obj_rpc_flags {
 	ORF_EC			= (1 << 4),
 	/** Include the map on fetch (daos_iom_t) */
 	ORF_CREATE_MAP		= (1 << 5),
+	/** The epoch (e.g., orw_epoch for OBJ_RW) is uncertain. */
+	ORF_EPOCH_UNCERTAIN	= (1 << 6),
 };
 
 struct obj_iod_array {

--- a/src/object/obj_tx.c
+++ b/src/object/obj_tx.c
@@ -87,10 +87,10 @@ struct dc_tx {
 	/** Container open handle */
 	daos_handle_t		 tx_coh;
 	/** The TX epoch. */
-	daos_epoch_t		 tx_epoch;
+	struct dc_obj_epoch	 tx_epoch;
 	/** The list of dc_tx_sub_req. */
 	d_list_t		 tx_sub_reqs;
-	/** Transaction flags (RDONLY, ZERO_COPY, etc.) */
+	/** Transaction flags (DAOS_TF_RDONLY, DAOS_TF_ZERO_COPY, etc.) */
 	uint64_t		 tx_flags;
 	/** The sub requests count */
 	uint32_t		 tx_sub_count;
@@ -192,9 +192,11 @@ dc_tx_alloc(daos_handle_t coh, daos_epoch_t epoch, uint64_t flags,
 	 *	  It will be replaced by dc_tx_set_epoch when server side HLC
 	 *	  based solution ready.
 	 */
-	tx->tx_epoch = epoch;
-	if (tx->tx_epoch == 0)
-		tx->tx_epoch = daos_dti2epoch(&tx->tx_id);
+	tx->tx_epoch.oe_value = epoch;
+	if (tx->tx_epoch.oe_value == 0) {
+		tx->tx_epoch.oe_value = daos_dti2epoch(&tx->tx_id);
+		tx->tx_epoch.oe_uncertain = true;
+	}
 
 	tx->tx_coh = coh;
 	tx->tx_flags = flags;
@@ -281,7 +283,7 @@ dc_tx_set_epoch(daos_handle_t th, daos_epoch_t epoch)
 		D_ERROR("Can't repeated set epoch on TX unless restart it\n");
 		rc = -DER_NO_PERM;
 	} else {
-		tx->tx_epoch = epoch;
+		tx->tx_epoch.oe_value = epoch;
 	}
 
 	dc_tx_decref(tx);
@@ -404,7 +406,8 @@ out:
 }
 
 int
-dc_tx_hdl2epoch_and_pmv(daos_handle_t th, daos_epoch_t *epoch, uint32_t *pm_ver)
+dc_tx_hdl2epoch_and_pmv(daos_handle_t th, struct dc_obj_epoch *epoch,
+			uint32_t *pm_ver)
 {
 	struct dc_tx	*tx = NULL;
 	int		 rc;
@@ -441,8 +444,8 @@ dc_tx_hdl2epoch(daos_handle_t th, daos_epoch_t *epoch)
 	 *	that. The caller can re-call hdl2epoch after some fetch or
 	 *	TX commit.
 	 */
-	if (tx->tx_epoch != 0)
-		*epoch = tx->tx_epoch;
+	if (tx->tx_epoch.oe_value != 0)
+		*epoch = tx->tx_epoch.oe_value;
 	else
 		rc = -DER_UNINIT;
 	dc_tx_decref(tx);
@@ -557,7 +560,7 @@ dc_tx_commit_non_cpd(tse_task_t *task, struct dc_tx *tx)
 		args->sgls = dtsr->dtsr_sgls;
 		args->maps = NULL;
 
-		rc = dc_obj_update(task, tx->tx_epoch, tx->tx_pm_ver, args);
+		rc = dc_obj_update(task, &tx->tx_epoch, tx->tx_pm_ver, args);
 	} else {
 		daos_obj_punch_t	*args = dc_task_get_args(task);
 
@@ -568,7 +571,7 @@ dc_tx_commit_non_cpd(tse_task_t *task, struct dc_tx *tx)
 		args->flags = dtsr->dtsr_flags;
 		args->akey_nr = dtsr->dtsr_nr;
 
-		rc = dc_obj_punch(task, tx->tx_epoch, tx->tx_pm_ver,
+		rc = dc_obj_punch(task, &tx->tx_epoch, tx->tx_pm_ver,
 				  dtsr->dtsr_opc, args);
 	}
 
@@ -793,6 +796,11 @@ out_task:
 	return rc;
 }
 
+/**
+ * Restart a transaction that has encountered a -DER_TX_RESTART. This shall not
+ * be used to restart a transaction created by dc_tx_open_snap or
+ * dc_tx_local_open, either of which shall not encounter -DER_TX_RESTART.
+ */
 int
 dc_tx_restart(tse_task_t *task)
 {
@@ -816,13 +824,17 @@ dc_tx_restart(tse_task_t *task)
 		dc_tx_cleanup(tx);
 		tx->tx_status = TX_OPEN;
 
-		/* FIXME: The tx_epoch should be reset as zero, but before
+		/*
+		 * Increasing the epoch doesn't change our knowledge of its
+		 * uncertainty on the client side.
+		 *
+		 * FIXME: The tx_epoch should be reset as zero, but before
 		 *	  server side HLC based solution ready, we temporarily
 		 *	  set it as client side HLC.
 		 *
 		 *	tx->tx_epoch = 0;
 		 */
-		tx->tx_epoch = crt_hlc_get();
+		tx->tx_epoch.oe_value = crt_hlc_get();
 	}
 
 	/* -1 for hdl2ptr */

--- a/src/object/srv_obj.c
+++ b/src/object/srv_obj.c
@@ -1101,7 +1101,8 @@ obj_local_rw(crt_rpc_t *rpc, struct ds_cont_hdl *cont_hdl,
 
 		rc = vos_fetch_begin(cont->sc_hdl, orw->orw_oid, orw->orw_epoch,
 				     orw->orw_api_flags | VOS_OF_USE_TIMESTAMPS,
-				     dkey, orw->orw_nr, iods, size_fetch, &ioh);
+				     dkey, orw->orw_nr, iods, size_fetch, &ioh,
+				     dth);
 		if (rc) {
 			D_CDEBUG(rc == -DER_INPROGRESS, DB_IO, DLOG_ERR,
 				 "Fetch begin for "DF_UOID" failed: "DF_RC"\n",
@@ -1446,8 +1447,8 @@ ds_obj_tgt_update_handler(crt_rpc_t *rpc)
 		D_GOTO(out, rc = 0);
 	}
 
-	rc = dtx_begin(ioc.ioc_coc, &orw->orw_dti,
-		       orw->orw_epoch, orw->orw_map_ver,
+	rc = dtx_begin(ioc.ioc_coc, &orw->orw_dti, orw->orw_epoch,
+		       orw->orw_flags & ORF_EPOCH_UNCERTAIN, orw->orw_map_ver,
 		       &orw->orw_oid, orw->orw_dkey_hash, DAOS_INTENT_UPDATE,
 		       orw->orw_dti_cos.ca_arrays, orw->orw_dti_cos.ca_count,
 		       &dth);
@@ -1548,17 +1549,30 @@ ds_obj_rw_handler(crt_rpc_t *rpc)
 
 	if (orw->orw_epoch == DAOS_EPOCH_MAX || orw->orw_epoch == 0) {
 		orw->orw_epoch = crt_hlc_get();
+		orw->orw_flags &= ~ORF_EPOCH_UNCERTAIN;
 		D_DEBUG(DB_IO, "overwrite epoch "DF_U64"\n", orw->orw_epoch);
 	}
 
 	if (obj_rpc_is_fetch(rpc)) {
+		struct dtx_handle dth = {0};
+
 		if (orw->orw_flags & ORF_CSUM_REPORT) {
 			obj_log_csum_err();
 			D_GOTO(out, rc = -DER_CSUM);
 		}
 
-		rc = obj_local_rw(rpc, ioc.ioc_coh, ioc.ioc_coc,
-				  NULL, NULL, NULL, NULL);
+		rc = dtx_begin(ioc.ioc_coc, &orw->orw_dti, orw->orw_epoch,
+			       orw->orw_flags & ORF_EPOCH_UNCERTAIN,
+			       orw->orw_map_ver, &orw->orw_oid,
+			       orw->orw_dkey_hash, DAOS_INTENT_DEFAULT,
+			       orw->orw_dti_cos.ca_arrays,
+			       orw->orw_dti_cos.ca_count, &dth);
+		D_ASSERTF(rc == 0, "%d\n", rc);
+
+		rc = obj_local_rw(rpc, ioc.ioc_coh, ioc.ioc_coc, NULL, NULL,
+				  NULL, &dth);
+
+		rc = dtx_end(&dth, ioc.ioc_coc, rc);
 		D_GOTO(out, rc);
 	} else if (orw->orw_iod_array.oia_oiods != NULL) {
 		rc = obj_ec_rw_req_split(orw, &split_req);
@@ -1583,6 +1597,7 @@ ds_obj_rw_handler(crt_rpc_t *rpc)
 		if (rc == 0) {
 			flags |= ORF_RESEND;
 			orw->orw_epoch = epoch;
+			/* TODO: Also recover the epoch uncertainty. */
 		} else if (rc == -DER_NONEXIST) {
 			rc = 0;
 		} else {
@@ -1607,11 +1622,10 @@ renew:
 	 * modification or not, so still need to dispatch
 	 * the RPC to other replicas.
 	 */
-	rc = dtx_leader_begin(ioc.ioc_coc, &orw->orw_dti,
-			      orw->orw_epoch, version,
+	rc = dtx_leader_begin(ioc.ioc_coc, &orw->orw_dti, orw->orw_epoch,
+			      orw->orw_flags & ORF_EPOCH_UNCERTAIN, version,
 			      &orw->orw_oid, orw->orw_dkey_hash,
-			      DAOS_INTENT_UPDATE,
-			      orw->orw_shard_tgts.ca_arrays,
+			      DAOS_INTENT_UPDATE, orw->orw_shard_tgts.ca_arrays,
 			      orw->orw_shard_tgts.ca_count, &dlh);
 	if (rc != 0) {
 		D_ERROR(DF_UOID": Failed to start DTX for update "DF_RC".\n",
@@ -1638,11 +1652,24 @@ out:
 	/* Stop the distribute transaction */
 	rc = dtx_leader_end(&dlh, ioc.ioc_coc, rc);
 	if (rc == -DER_TX_RESTART) {
-		/* Retry with newer epoch. */
-		orw->orw_epoch = crt_hlc_get();
-		flags &= ~ORF_RESEND;
-		memset(&dlh, 0, sizeof(dlh));
-		D_GOTO(renew, rc);
+		/*
+		 * If this is a standalone operation, we can restart the
+		 * internal transaction right here. Otherwise, we have to defer
+		 * the restart to the RPC client.
+		 */
+		if (opc == DAOS_OBJ_RPC_UPDATE) {
+			/*
+			 * Only standalone updates use this RPC. Retry with
+			 * newer epoch.
+			 */
+			orw->orw_epoch = crt_hlc_get();
+			flags &= ~ORF_RESEND;
+			memset(&dlh, 0, sizeof(dlh));
+			D_GOTO(renew, rc);
+		} else {
+			/* Standalone fetches do not get -DER_TX_RESTART. */
+			D_ASSERT(!daos_is_zero_dti(&orw->orw_dti));
+		}
 	} else if (rc == -DER_AGAIN) {
 		flags |= ORF_RESEND;
 		D_GOTO(again, rc);
@@ -2073,8 +2100,8 @@ ds_obj_tgt_punch_handler(crt_rpc_t *rpc)
 	}
 
 	/* Start the local transaction */
-	rc = dtx_begin(ioc.ioc_coc, &opi->opi_dti,
-		       opi->opi_epoch, opi->opi_map_ver,
+	rc = dtx_begin(ioc.ioc_coc, &opi->opi_dti, opi->opi_epoch,
+		       opi->opi_flags & ORF_EPOCH_UNCERTAIN, opi->opi_map_ver,
 		       &opi->opi_oid, opi->opi_dkey_hash, DAOS_INTENT_PUNCH,
 		       opi->opi_dti_cos.ca_arrays, opi->opi_dti_cos.ca_count,
 		       &dth);
@@ -2172,6 +2199,7 @@ ds_obj_punch_handler(crt_rpc_t *rpc)
 
 	if (opi->opi_epoch == DAOS_EPOCH_MAX || opi->opi_epoch == 0) {
 		opi->opi_epoch = crt_hlc_get();
+		opi->opi_flags &= ~ORF_EPOCH_UNCERTAIN;
 		D_DEBUG(DB_IO, "overwrite epoch "DF_U64"\n", opi->opi_epoch);
 	}
 
@@ -2188,6 +2216,7 @@ ds_obj_punch_handler(crt_rpc_t *rpc)
 
 		if (rc == 0) {
 			opi->opi_epoch = epoch;
+			/* TODO: Also recovery the epoch uncertainty. */
 			flags |= ORF_RESEND;
 		} else if (rc == -DER_NONEXIST) {
 			rc = 0;
@@ -2212,11 +2241,10 @@ renew:
 	 * modification or not, so still need to dispatch
 	 * the RPC to other replicas.
 	 */
-	rc = dtx_leader_begin(ioc.ioc_coc, &opi->opi_dti,
-			      opi->opi_epoch, version,
+	rc = dtx_leader_begin(ioc.ioc_coc, &opi->opi_dti, opi->opi_epoch,
+			      opi->opi_flags & ORF_EPOCH_UNCERTAIN, version,
 			      &opi->opi_oid, opi->opi_dkey_hash,
-			      DAOS_INTENT_PUNCH,
-			      opi->opi_shard_tgts.ca_arrays,
+			      DAOS_INTENT_PUNCH, opi->opi_shard_tgts.ca_arrays,
 			      opi->opi_shard_tgts.ca_count, &dlh);
 	if (rc != 0) {
 		D_ERROR(DF_UOID": Failed to start DTX for punch "DF_RC".\n",
@@ -2241,7 +2269,10 @@ out:
 	/* Stop the distribute transaction */
 	rc = dtx_leader_end(&dlh, ioc.ioc_coc, rc);
 	if (rc == -DER_TX_RESTART) {
-		/* Retry with newer epoch. */
+		/*
+		 * Only standalone punches use this RPC. Retry with newer
+		 * epoch.
+		 */
 		opi->opi_epoch = crt_hlc_get();
 		flags &= ~ORF_RESEND;
 		memset(&dlh, 0, sizeof(dlh));

--- a/src/rdb/rdb_util.c
+++ b/src/rdb/rdb_util.c
@@ -334,7 +334,8 @@ rdb_vos_fetch_addr(daos_handle_t cont, daos_epoch_t epoch, rdb_oid_t oid,
 	rdb_oid_to_uoid(oid, &uoid);
 	rdb_vos_set_iods(RDB_VOS_QUERY, 1 /* n */, akey, value, &iod);
 	rc = vos_fetch_begin(cont, uoid, epoch, 0 /* flags */, &rdb_dkey,
-			     1 /* n */, &iod, false /* size_fetch */, &io);
+			     1 /* n */, &iod, false /* size_fetch */, &io,
+			     NULL /* dth */);
 	if (rc != 0)
 		return rc;
 

--- a/src/tests/daos_perf.c
+++ b/src/tests/daos_perf.c
@@ -200,7 +200,7 @@ _vos_update_or_fetch(enum ts_op_type op_type, struct dts_io_credit *cred,
 			rc = vos_fetch_begin(ts_ctx.tsc_coh, ts_uoid, epoch,
 					     VOS_OF_USE_TIMESTAMPS,
 					     &cred->tc_dkey, 1, &cred->tc_iod,
-					     false, &ioh);
+					     false, &ioh, NULL);
 		if (rc)
 			return rc;
 

--- a/src/vos/README.md
+++ b/src/vos/README.md
@@ -483,7 +483,7 @@ performs all operations using its epoch.
 
 The MVCC rules ensure that transactions execute as if they are serialized in
 their epoch order while complying with external consistency, as long as the
-system clock offsets are always within the expected maximal system clock offset
+system clock offsets are always within the expected maximum system clock offset
 (epsilon). For convenience, the rules classify the I/O operations into reads
 and writes:
 
@@ -513,7 +513,7 @@ A read at epoch e follows these rules:
 
     // Epoch uncertainty check
     if e is uncertain
-        if there is any overlapping, unaborted write in (e, e + epsilon]
+        if there is any overlapping, unaborted write in (e, e_orig + epsilon]
             reject
 
     find the highest overlapping, unaborted write in [0, e]
@@ -531,7 +531,7 @@ A write at epoch e follows these rules:
 
     // Epoch uncertainty check
     if e is uncertain
-        if there is any overlapping, unaborted write in (e, e + epsilon]
+        if there is any overlapping, unaborted write in (e, e_orig + epsilon]
             reject
 
     // Read timestamp check
@@ -546,9 +546,10 @@ A write at epoch e follows these rules:
         reject
 
 A transaction involving both reads and writes must follow both sets of rules.
-As an optimization, read-only transactions do not need to update read
-timestamps. Snapshot creations, however, must update the read timestamps as if
-it is a transaction reading the whole container.
+As optimizations, single-read transactions and snapshot (read) transactions
+do not need to update read timestamps. Snapshot creations, however, must
+update the read timestamps as if it is a transaction reading the whole
+container.
 
 When a transaction is rejected, it restarts with the same transaction ID but a
 higher epoch. If the epoch becomes higher than the original epoch plus epsilon,

--- a/src/vos/tests/vts_checksum.c
+++ b/src/vos/tests/vts_checksum.c
@@ -189,7 +189,7 @@ csum_for_arrays_test_case(void *const *state, struct test_case_args test)
 	 * how the server object layer already interfaces with VOS)
 	 */
 	vos_fetch_begin(k.container_hdl, k.object_id, 1, 0, &k.dkey, 1, &iod,
-			false, &ioh);
+			false, &ioh, NULL);
 
 	biod = vos_ioh2desc(ioh);
 	bsgl = bio_iod_sgl(biod, 0);

--- a/src/vos/tests/vts_dtx.c
+++ b/src/vos/tests/vts_dtx.c
@@ -567,7 +567,7 @@ dtx_16(void **state)
 	iod.iod_size = DAOS_REC_ANY;
 
 	rc = vos_fetch_begin(args->ctx.tc_co_hdl, args->oid, epoch,
-			     0, &dkey_iov, 1, &iod, false, &ioh);
+			     0, &dkey_iov, 1, &iod, false, &ioh, NULL);
 	/* The former DTX is not committed, so need to retry with leader. */
 	assert_int_equal(rc, -DER_INPROGRESS);
 

--- a/src/vos/tests/vts_io.c
+++ b/src/vos/tests/vts_io.c
@@ -618,7 +618,7 @@ io_test_obj_fetch(struct io_test_args *arg, daos_epoch_t epoch, uint64_t flags,
 	}
 
 	rc = vos_fetch_begin(arg->ctx.tc_co_hdl, arg->oid, epoch, flags, dkey,
-			     1, iod, false, &ioh);
+			     1, iod, false, &ioh, NULL);
 	if (rc != 0) {
 		if (verbose && rc != -DER_INPROGRESS)
 			print_error("Failed to prepare ZC update: "DF_RC"\n",

--- a/src/vos/vos_io.c
+++ b/src/vos/vos_io.c
@@ -856,7 +856,8 @@ update_prev:
 int
 vos_fetch_begin(daos_handle_t coh, daos_unit_oid_t oid, daos_epoch_t epoch,
 		uint64_t flags, daos_key_t *dkey, unsigned int iod_nr,
-		daos_iod_t *iods, bool size_fetch, daos_handle_t *ioh)
+		daos_iod_t *iods, bool size_fetch, daos_handle_t *ioh,
+		struct dtx_handle *dth)
 {
 	struct vos_io_context	*ioc;
 	struct vos_ts_entry	*entry;
@@ -1823,7 +1824,7 @@ vos_obj_fetch(daos_handle_t coh, daos_unit_oid_t oid, daos_epoch_t epoch,
 	int rc;
 
 	rc = vos_fetch_begin(coh, oid, epoch, flags, dkey, iod_nr, iods,
-			     size_fetch, &ioh);
+			     size_fetch, &ioh, NULL);
 	if (rc) {
 		if (rc == -DER_INPROGRESS)
 			D_DEBUG(DB_TRACE, "Cannot fetch "DF_UOID" because of "


### PR DESCRIPTION
To fully implement read timestamp updates and epoch uncertainty checks,
vos needs to know a read operation's DTX ID and epoch uncertainty. Write
and read-write operations already have dtx_handle, which contains the
former. This patch extends dtx_handle to include the epoch uncertainty
upper bound and passes it to vos_fetch_begin. Some related changes are
also included:

  - Determine the epoch uncertainty for each obj_rw (i.e., FETCH or
    UPDATE) RPC.
  - Remove the obsolete vos_epoch_flush.
  - Fix a few typos in the MVCC section of src/vos/README.md.

Left to future patches are:

  - Other operations, like query and enumeration methods.
  - Recovery of epoch uncertainty for resent obj_rw RPCs.
  - Optimizations for finer cases where epochs have no uncertainty.

Signed-off-by: Li Wei <wei.g.li@intel.com>