### PR TITLE
DAOS-4968 gurt: modify hash table implementation

### DIFF
--- a/src/cart/src/include/gurt/hash.h
+++ b/src/cart/src/include/gurt/hash.h
@@ -1,4 +1,4 @@
-/* Copyright (C) 2016-2019 Intel Corporation
+/* Copyright (C) 2016-2020 Intel Corporation
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -163,14 +163,19 @@ typedef struct {
 
 enum d_hash_feats {
 	/**
-	 * By default, the hash table is protected by pthread_mutex.
+	 * By default, the hash table is protected by pthread_spinlock_t.
 	 */
 
 	/**
 	 * The hash table has no lock, it means the hash table is protected
 	 * by external lock, or only accessed by a single thread.
 	 */
-	D_HASH_FT_NOLOCK		= (1 << 0),
+	D_HASH_FT_NOLOCK	= (1 << 0),
+
+	/**
+	 * The hash table is protected by pthread_mutex_t.
+	 */
+	D_HASH_FT_MUTEX		= (1 << 1),
 
 	/**
 	 * It is a read-mostly hash table, so it is protected by RW lock.
@@ -179,7 +184,7 @@ enum d_hash_feats {
 	 * then he should guarantee refcount changes are atomic or protected
 	 * within hop_addref/decref, because RW lock can't protect refcount.
 	 */
-	D_HASH_FT_RWLOCK		= (1 << 1),
+	D_HASH_FT_RWLOCK	= (1 << 2),
 
 	/**
 	 * If the EPHEMERAL bit is zero:
@@ -197,7 +202,7 @@ enum d_hash_feats {
 	 *
 	 * Note that if addref/decref are not provided this bit has no effect
 	 */
-	D_HASH_FT_EPHEMERAL		= (1 << 2),
+	D_HASH_FT_EPHEMERAL	= (1 << 3),
 };
 
 struct d_hash_bucket {
@@ -210,13 +215,14 @@ struct d_hash_bucket {
 struct d_hash_table {
 	/** different type of locks based on ht_feats */
 	union {
-		pthread_mutex_t		ht_lock;
+		pthread_spinlock_t	ht_spin;
+		pthread_mutex_t		ht_mutex;
 		pthread_rwlock_t	ht_rwlock;
 	};
 	/** bits to generate number of buckets */
 	unsigned int		 ht_bits;
 	/** feature bits */
-	unsigned int		 ht_feats;
+	uint32_t		 ht_feats;
 #if D_HASH_DEBUG
 	/** maximum search depth ever */
 	unsigned int		 ht_dep_max;
@@ -249,8 +255,8 @@ struct d_hash_table {
  * \return			0 on success, negative value on error
  */
 int  d_hash_table_create(uint32_t feats, unsigned int bits,
-			  void *priv, d_hash_table_ops_t *hops,
-			  struct d_hash_table **htable_pp);
+			 void *priv, d_hash_table_ops_t *hops,
+			 struct d_hash_table **htable_pp);
 
 /**
  * Initialise an inplace hash table.
@@ -519,7 +525,7 @@ struct d_hlink {
 
 struct d_hhash;
 
-int  d_hhash_create(unsigned int bits, struct d_hhash **hhash);
+int  d_hhash_create(uint32_t feats, unsigned int bits, struct d_hhash **hhash);
 void d_hhash_destroy(struct d_hhash *hh);
 void d_hhash_hlink_init(struct d_hlink *hlink, struct d_hlink_ops *ops);
 /**
@@ -569,7 +575,8 @@ struct d_ulink {
 	struct d_ulink_ops	*ul_ops;
 };
 
-int d_uhash_create(int feats, unsigned int bits, struct d_hash_table **uhtab);
+int  d_uhash_create(uint32_t feats, unsigned int bits,
+		    struct d_hash_table **uhtab);
 void d_uhash_destroy(struct d_hash_table *uhtab);
 void d_uhash_ulink_init(struct d_ulink *ulink, struct d_ulink_ops *rl_ops);
 bool d_uhash_link_empty(struct d_ulink *ulink);

--- a/src/common/misc.c
+++ b/src/common/misc.c
@@ -462,7 +462,7 @@ daos_hhash_init(void)
 		D_GOTO(unlock, rc = 0);
 	}
 
-	rc = d_hhash_create(D_HHASH_BITS, &daos_ht.dht_hhash);
+	rc = d_hhash_create(0, D_HHASH_BITS, &daos_ht.dht_hhash);
 	if (rc == 0) {
 		D_ASSERT(daos_ht.dht_hhash != NULL);
 		daos_ht_ref = 1;

--- a/src/container/srv_target.c
+++ b/src/container/srv_target.c
@@ -753,7 +753,8 @@ static d_hash_table_ops_t cont_hdl_hash_ops = {
 int
 ds_cont_hdl_hash_create(struct d_hash_table *hash)
 {
-	return d_hash_table_create_inplace(0 /* feats */, 8 /* bits */,
+	return d_hash_table_create_inplace(D_HASH_FT_NOLOCK /* feats */,
+					   8 /* bits */,
 					   NULL /* priv */,
 					   &cont_hdl_hash_ops, hash);
 }

--- a/src/vos/vos_common.c
+++ b/src/vos/vos_common.c
@@ -131,7 +131,7 @@ vos_imem_strts_create(struct vos_imem_strts *imem_inst)
 		return rc;
 	}
 
-	rc = d_uhash_create(0 /* no locking */, VOS_POOL_HHASH_BITS,
+	rc = d_uhash_create(D_HASH_FT_NOLOCK, VOS_POOL_HHASH_BITS,
 			    &imem_inst->vis_pool_hhash);
 	if (rc) {
 		D_ERROR("Error in creating POOL ref hash: "DF_RC"\n",
@@ -139,8 +139,8 @@ vos_imem_strts_create(struct vos_imem_strts *imem_inst)
 		goto failed;
 	}
 
-	rc = d_uhash_create(D_HASH_FT_EPHEMERAL, VOS_CONT_HHASH_BITS,
-			    &imem_inst->vis_cont_hhash);
+	rc = d_uhash_create(D_HASH_FT_NOLOCK | D_HASH_FT_EPHEMERAL,
+			    VOS_CONT_HHASH_BITS, &imem_inst->vis_cont_hhash);
 	if (rc) {
 		D_ERROR("Error in creating CONT ref hash: "DF_RC"\n",
 			DP_RC(rc));


### PR DESCRIPTION
- Changed default hash table protection from mutex to spinlock.
  This improved performance of parallel insert/delete in 4 times.
  The performance of parallel lookup improved in 2.5 times.
  It's used in daos_hhash now.
- Made API more consistent by always passing "feats" argument
  for create hhash. Also made type of it the same.
- Made few style fixes and add more compiler hits "inline".
- Removed locking of thread-local POOL/CONT hash tables in VOS.
- Removed locking of thread-local container handle cache.