### PR TITLE
DAOS-0000 object: client round-robin RPC handling

### DIFF
--- a/src/include/daos/rpc.h
+++ b/src/include/daos/rpc.h
@@ -81,6 +81,8 @@ struct daos_rpc_handler {
 	crt_opcode_t		 dr_opc;
 	/* Request handler, only relevant on the server side */
 	crt_rpc_cb_t		 dr_hdlr;
+	/* Enqueue request */
+	crt_rpc_cb_t		 dr_enq;
 	/* CORPC operations (co_aggregate == NULL for point-to-point RPCs) */
 	struct crt_corpc_ops	*dr_corpc_ops;
 };
@@ -183,6 +185,8 @@ daos_rpc_register(struct crt_proto_format *proto_fmt, uint32_t cli_count,
 		for (i = 0; i < proto_fmt->cpf_count; i++) {
 			proto_fmt->cpf_prf[i].prf_hdlr =
 						handlers[i].dr_hdlr;
+			proto_fmt->cpf_prf[i].prf_enq =
+						handlers[i].dr_enq;
 			proto_fmt->cpf_prf[i].prf_co_ops =
 						handlers[i].dr_corpc_ops;
 		}

--- a/src/object/cli_mod.c
+++ b/src/object/cli_mod.c
@@ -33,6 +33,7 @@
 #include "obj_internal.h"
 
 unsigned int	srv_io_mode = DIM_DTX_FULL_ENABLED;
+uuid_t		obj_cli_uuid;
 
 /**
  * Initialize object interface
@@ -51,6 +52,7 @@ dc_obj_init(void)
 		srv_io_mode = DIM_DTX_FULL_ENABLED;
 		D_DEBUG(DB_IO, "Full dtx mode by default\n");
 	}
+	uuid_generate(obj_cli_uuid);
 
 	rc = obj_utils_init();
 	if (rc)

--- a/src/object/cli_shard.c
+++ b/src/object/cli_shard.c
@@ -410,6 +410,7 @@ dc_obj_shard_rw(struct dc_obj_shard *shard, enum obj_rpc_opc opc,
 	orw->orw_map_ver = args->auxi.map_ver;
 	orw->orw_start_shard = args->auxi.start_shard;
 	orw->orw_oid = shard->do_id;
+	uuid_copy(orw->orw_cli_id, obj_cli_uuid);
 	uuid_copy(orw->orw_pool_uuid, pool->dp_pool);
 	uuid_copy(orw->orw_co_hdl, cont_hdl_uuid);
 	uuid_copy(orw->orw_co_uuid, cont_uuid);

--- a/src/object/obj_internal.h
+++ b/src/object/obj_internal.h
@@ -363,6 +363,9 @@ int
 ds_obj_remote_punch(struct dtx_leader_handle *dth, void *arg, int idx,
 		    dtx_sub_comp_cb_t comp_cb);
 /* srv_obj.c */
+
+void ds_obj_rw_enq(crt_rpc_t *rpc);
+void ds_obj_tgt_wr_enq(crt_rpc_t *rpc);
 void ds_obj_rw_handler(crt_rpc_t *rpc);
 void ds_obj_tgt_update_handler(crt_rpc_t *rpc);
 void ds_obj_enum_handler(crt_rpc_t *rpc);
@@ -386,5 +389,8 @@ obj_dkey2hash(daos_key_t *dkey)
 int  obj_utils_init(void);
 void obj_utils_fini(void);
 
+extern uuid_t obj_cli_uuid;
+void obj_enq_init(void);
+void obj_enq_fini(void);
 
 #endif /* __DAOS_OBJ_INTENRAL_H__ */

--- a/src/object/obj_rpc.c
+++ b/src/object/obj_rpc.c
@@ -495,7 +495,7 @@ CRT_RPC_DEFINE(obj_sync, DAOS_ISEQ_OBJ_SYNC, DAOS_OSEQ_OBJ_SYNC)
 /* Define for cont_rpcs[] array population below.
  * See OBJ_PROTO_*_RPC_LIST macro definition
  */
-#define X(a, b, c, d, e)	\
+#define X(a, b, c, d, e, f)	\
 {				\
 	.prf_flags   = b,	\
 	.prf_req_fmt = c,	\

--- a/src/object/obj_rpc.h
+++ b/src/object/obj_rpc.h
@@ -60,52 +60,52 @@
 #define OBJ_PROTO_CLI_RPC_LIST						\
 	X(DAOS_OBJ_RPC_UPDATE,						\
 		0, &CQF_obj_update,					\
-		ds_obj_rw_handler, NULL),				\
+		ds_obj_rw_handler, ds_obj_rw_enq, NULL),		\
 	X(DAOS_OBJ_RPC_FETCH,						\
 		0, &CQF_obj_fetch,					\
-		ds_obj_rw_handler, NULL),				\
+		ds_obj_rw_handler, ds_obj_rw_enq, NULL),		\
 	X(DAOS_OBJ_DKEY_RPC_ENUMERATE,					\
 		0, &CQF_obj_key_enum,					\
-		ds_obj_enum_handler, NULL),				\
+		ds_obj_enum_handler, NULL, NULL),			\
 	X(DAOS_OBJ_AKEY_RPC_ENUMERATE,					\
 		0, &CQF_obj_key_enum,					\
-		ds_obj_enum_handler, NULL),				\
+		ds_obj_enum_handler, NULL, NULL),			\
 	X(DAOS_OBJ_RECX_RPC_ENUMERATE,					\
 		0, &CQF_obj_key_enum,					\
-		ds_obj_enum_handler, NULL),				\
+		ds_obj_enum_handler, NULL, NULL),			\
 	X(DAOS_OBJ_RPC_ENUMERATE,					\
 		0, &CQF_obj_key_enum,					\
-		ds_obj_enum_handler, NULL),				\
+		ds_obj_enum_handler, NULL, NULL),			\
 	X(DAOS_OBJ_RPC_PUNCH,						\
 		0, &CQF_obj_punch,					\
-		ds_obj_punch_handler, NULL),				\
+		ds_obj_punch_handler, NULL, NULL),			\
 	X(DAOS_OBJ_RPC_PUNCH_DKEYS,					\
 		0, &CQF_obj_punch,					\
-		ds_obj_punch_handler, NULL),				\
+		ds_obj_punch_handler, NULL, NULL),			\
 	X(DAOS_OBJ_RPC_PUNCH_AKEYS,					\
 		0, &CQF_obj_punch,					\
-		ds_obj_punch_handler, NULL),				\
+		ds_obj_punch_handler, NULL, NULL),			\
 	X(DAOS_OBJ_RPC_QUERY_KEY,					\
 		0, &CQF_obj_query_key,					\
-		ds_obj_query_key_handler, NULL),			\
+		ds_obj_query_key_handler, NULL, NULL),			\
 	X(DAOS_OBJ_RPC_SYNC,						\
 		0, &CQF_obj_sync,					\
-		ds_obj_sync_handler, NULL),				\
+		ds_obj_sync_handler, NULL, NULL),			\
 	X(DAOS_OBJ_RPC_TGT_UPDATE,					\
 		0, &CQF_obj_update,					\
-		ds_obj_tgt_update_handler, NULL),			\
+		ds_obj_tgt_update_handler, ds_obj_tgt_wr_enq, NULL),	\
 	X(DAOS_OBJ_RPC_TGT_PUNCH,					\
 		0, &CQF_obj_punch,					\
-		ds_obj_tgt_punch_handler, NULL),			\
+		ds_obj_tgt_punch_handler, NULL, NULL),			\
 	X(DAOS_OBJ_RPC_TGT_PUNCH_DKEYS,					\
 		0, &CQF_obj_punch,					\
-		ds_obj_tgt_punch_handler, NULL),			\
+		ds_obj_tgt_punch_handler, NULL, NULL),			\
 	X(DAOS_OBJ_RPC_TGT_PUNCH_AKEYS,					\
 		0, &CQF_obj_punch,					\
-		ds_obj_tgt_punch_handler, NULL)
+		ds_obj_tgt_punch_handler, NULL, NULL)
 
 /* Define for RPC enum population below */
-#define X(a, b, c, d, e) a
+#define X(a, b, c, d, e, f) a
 
 enum obj_rpc_opc {
 	OBJ_PROTO_CLI_RPC_LIST,
@@ -148,6 +148,7 @@ struct obj_iod_array {
 #define DAOS_ISEQ_OBJ_RW	/* input fields */		 \
 	((struct dtx_id)	(orw_dti)		CRT_VAR) \
 	((daos_unit_oid_t)	(orw_oid)		CRT_VAR) \
+	((uuid_t)		(orw_cli_id)		CRT_VAR) \
 	((uuid_t)		(orw_pool_uuid)		CRT_VAR) \
 	((uuid_t)		(orw_co_hdl)		CRT_VAR) \
 	((uuid_t)		(orw_co_uuid)		CRT_VAR) \

--- a/src/object/srv_mod.c
+++ b/src/object/srv_mod.c
@@ -66,11 +66,12 @@ obj_mod_fini(void)
 /* Define for cont_rpcs[] array population below.
  * See OBJ_PROTO_*_RPC_LIST macro definition
  */
-#define X(a, b, c, d, e)	\
+#define X(a, b, c, d, e, f)	\
 {				\
 	.dr_opc       = a,	\
 	.dr_hdlr      = d,	\
-	.dr_corpc_ops = e,	\
+	.dr_enq       = e,	\
+	.dr_corpc_ops = f,	\
 }
 
 static struct daos_rpc_handler obj_handlers[] = {
@@ -85,6 +86,7 @@ obj_tls_init(const struct dss_thread_local_storage *dtls,
 {
 	struct obj_tls *tls;
 
+	obj_enq_init();
 	D_ALLOC_PTR(tls);
 	return tls;
 }
@@ -101,6 +103,7 @@ obj_tls_fini(const struct dss_thread_local_storage *dtls,
 	if (tls->ot_sp)
 		srv_profile_destroy(tls->ot_sp);
 
+	obj_enq_fini();
 	D_FREE(tls);
 }
 


### PR DESCRIPTION
- add client process uuid to update/fetch RPC

- I/O server handles update/fetch RPC in a round-robin
  maner based client uuid

- update & fetch use enqueue() instead of regular RPC handler

Signed-off-by: Liang Zhen <liang.zhen@intel.com>