### PR TITLE
DAOS-4979 object: flush after RDMA update

### DIFF
--- a/src/bio/bio_buffer.c
+++ b/src/bio/bio_buffer.c
@@ -781,9 +781,12 @@ bio_memcpy(struct bio_desc *biod, uint16_t media, void *media_addr,
 	struct umem_instance *umem = biod->bd_ctxt->bic_umem;
 
 	if (biod->bd_update && media == DAOS_MEDIA_SCM) {
-		/* NB: pmemobj_tx_commit will drain HW buffer */
-		pmemobj_memcpy(umem->umm_pool, media_addr, addr, n,
-			       PMEMOBJ_F_MEM_NODRAIN);
+		/*
+		 * We could do no_drain copy and rely on the tx commit to
+		 * drain controller, however, test shows calling a persistent
+		 * copy and drain controller here is faster.
+		 */
+		pmemobj_memcpy_persist(umem->umm_pool, media_addr, addr, n);
 	} else {
 		if (biod->bd_update)
 			memcpy(media_addr, addr, n);
@@ -980,6 +983,36 @@ bio_iod_copy(struct bio_desc *biod, d_sg_list_t *sgls, unsigned int nr_sgl)
 	arg.ca_sgl_cnt = nr_sgl;
 
 	return iterate_biov(biod, copy_one, &arg);
+}
+
+static int
+flush_one(struct bio_desc *biod, struct bio_iov *biov,
+	  struct bio_copy_args *arg)
+{
+	struct umem_instance *umem = biod->bd_ctxt->bic_umem;
+
+	D_ASSERT(arg == NULL);
+	D_ASSERT(biov);
+
+	if (bio_addr_is_hole(&biov->bi_addr))
+		return 0;
+
+	if (biov->bi_addr.ba_type != DAOS_MEDIA_SCM)
+		return 0;
+
+	D_ASSERT(bio_iov2raw_buf(biov) != NULL);
+	D_ASSERT(bio_iov2req_len(biov) != 0);
+	pmemobj_flush(umem->umm_pool, bio_iov2req_buf(biov),
+		      bio_iov2req_len(biov));
+	return 0;
+}
+
+void
+bio_iod_flush(struct bio_desc *biod)
+{
+	D_ASSERT(biod->bd_buffer_prep);
+	if (biod->bd_update)
+		iterate_biov(biod, flush_one, NULL);
 }
 
 static int

--- a/src/include/daos_srv/bio.h
+++ b/src/include/daos_srv/bio.h
@@ -560,6 +560,15 @@ int bio_iod_post(struct bio_desc *biod);
 int bio_iod_copy(struct bio_desc *biod, d_sg_list_t *sgls, unsigned int nr_sgl);
 
 /*
+ * Helper function to flush memory vectors in SG lists of io descriptor
+ *
+ * \param biod       [IN]	io descriptor
+ *
+ * \return			N/A
+ */
+void bio_iod_flush(struct bio_desc *biod);
+
+/*
  * Helper function to get the specified SG list of an io descriptor
  *
  * \param biod       [IN]	io descriptor

--- a/src/object/srv_obj.c
+++ b/src/object/srv_obj.c
@@ -1146,6 +1146,8 @@ obj_local_rw(crt_rpc_t *rpc, struct ds_cont_hdl *cont_hdl,
 		rc = obj_bulk_transfer(rpc, bulk_op, bulk_bind,
 				       orw->orw_bulks.ca_arrays, offs,
 				       ioh, NULL, orw->orw_nr);
+		if (!rc)
+			bio_iod_flush(biod);
 	} else if (orw->orw_sgls.ca_arrays != NULL) {
 		rc = bio_iod_copy(biod, orw->orw_sgls.ca_arrays, orw->orw_nr);
 	}


### PR DESCRIPTION
To ensure data persistency, pmemobj_flush() needs be called to the
pmemobj_reserve() reserved region after RDMA update done.

Signed-off-by: Niu Yawei <yawei.niu@intel.com>