### PR TITLE
CORCI-27 test: Install the codespell package to enable CI checks.

### DIFF
--- a/src/client/dfs/dfs.c
+++ b/src/client/dfs/dfs.c
@@ -85,11 +85,6 @@
 #define SB_HI		0
 #define ROOT_HI		1
 
-enum {
-	DFS_WRITE,
-	DFS_READ
-};
-
 /** object struct that is instantiated for a DFS open object */
 struct dfs_obj {
 	/** DAOS object ID */

--- a/src/client/dfuse/SConscript
+++ b/src/client/dfuse/SConscript
@@ -3,7 +3,8 @@ import os
 import daos_build
 
 HEADERS = ['ioil_io.h', 'ioil_defines.h',
-           'ioil_api.h', 'ioil_preload.h']
+           'ioil_api.h', 'ioil_preload.h',
+           'ioil.h']
 COMMON_SRC = ['dfuse_da.c',
               'dfuse_obj_da.c',
               'dfuse_vector.c']
@@ -55,6 +56,8 @@ def build_client_libs_shared(env):
     ilenv = env.Clone()
     ilenv.AppendUnique(CFLAGS=['-fPIC'])
     ilenv.AppendUnique(CPPDEFINES=['IOIL_PRELOAD'])
+    ilenv.AppendUnique(LIBPATH=["../dfs"])
+    ilenv.AppendUnique(LIBS=['dfs'])
     penv = ilenv.Clone()
     penv.AppendUnique(CPPDEFINES=['_FILE_OFFSET_BITS=64'])
 

--- a/src/client/dfuse/dfuse_ioctl.h
+++ b/src/client/dfuse/dfuse_ioctl.h
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2017-2019 Intel Corporation.
+ * (C) Copyright 2017-2020 Intel Corporation.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -31,9 +31,16 @@
 #define DFUSE_IOCTL_VERSION 4       /* Version of ioctl protocol */
 
 #define DFUSE_IOCTL_REPLY_CORE (DFUSE_IOCTL_REPLY_BASE)
-#define DFUSE_IOCTL_REPLY_SIZE (DFUSE_IOCTL_REPLY_BASE + 1)
+
+/* (DFUSE_IOCTL_REPLY_BASE + 5) is reserverd by an older version of
+ * IOCTL_REPLY_SIZE
+ */
 #define DFUSE_IOCTL_REPLY_POH (DFUSE_IOCTL_REPLY_BASE + 2)
 #define DFUSE_IOCTL_REPLY_COH (DFUSE_IOCTL_REPLY_BASE + 3)
+#define DFUSE_IOCTL_REPLY_DOH (DFUSE_IOCTL_REPLY_BASE + 4)
+#define DFUSE_IOCTL_REPLY_DOOH (DFUSE_IOCTL_REPLY_BASE + 5)
+#define DFUSE_IOCTL_REPLY_SIZE (DFUSE_IOCTL_REPLY_BASE + 6)
+
 
 /* Core IOCTL reply */
 struct dfuse_il_reply {
@@ -48,6 +55,8 @@ struct dfuse_hs_reply {
 	int		fsr_version;
 	size_t		fsr_pool_size;
 	size_t		fsr_cont_size;
+	size_t		fsr_dfs_size;
+	size_t		fsr_dobj_size;
 };
 
 /* Defines the IOCTL command to get the object ID for a open file */

--- a/src/client/dfuse/il/int_posix.c
+++ b/src/client/dfuse/il/int_posix.c
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2017-2019 Intel Corporation.
+ * (C) Copyright 2017-2020 Intel Corporation.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -29,13 +29,13 @@
 #include <string.h>
 #include <errno.h>
 #include <fcntl.h>
-#include <sys/stat.h>
-#include <sys/types.h>
+
 #include <sys/time.h>
 #include <sys/resource.h>
 #include <stdio.h>
 #include <sys/ioctl.h>
 #include <string.h>
+
 #include "dfuse_log.h"
 #include <gurt/list.h>
 #include "intercept.h"
@@ -43,7 +43,7 @@
 #include "dfuse_vector.h"
 #include "dfuse_common.h"
 
-#include "daos.h"
+#include "ioil.h"
 
 FOREACH_INTERCEPT(IOIL_FORWARD_DECL)
 
@@ -53,6 +53,7 @@ struct ioil_common {
 	uuid_t		ioc_cont;
 	daos_handle_t	ioc_poh;
 	daos_handle_t	ioc_coh;
+	dfs_t		*ioc_dfs;
 	int		ioc_open_fd_count;
 	bool		ioc_initialized;
 };
@@ -104,14 +105,28 @@ static const char * const bypass_status[] = {
 static void
 entry_array_close(void *arg) {
 	struct fd_entry *entry = arg;
+	int rc;
 
 	DFUSE_LOG_INFO("entry %p closing array fd_count %d",
 		       entry, ioil_ioc.ioc_open_fd_count);
-	daos_array_close(entry->fd_aoh, NULL);
+
+	if (entry->fd_dfsoh) {
+		dfs_release(entry->fd_dfsoh);
+	} else {
+		daos_array_close(entry->fd_aoh, NULL);
+	}
 
 	ioil_ioc.ioc_open_fd_count -= 1;
 
 	if (ioil_ioc.ioc_open_fd_count == 0) {
+		if (ioil_ioc.ioc_dfs) {
+			rc = dfs_umount(ioil_ioc.ioc_dfs);
+			if (rc != 0) {
+				DFUSE_LOG_ERROR("Could not close dfs rc = %d",
+						rc);
+			}
+		}
+
 		CONT_CLOSE(ioil_ioc);
 		POOL_DISCONNECT(ioil_ioc);
 	}
@@ -239,8 +254,18 @@ static __attribute__((destructor)) void
 ioil_fini(void)
 {
 	ioil_ioc.ioc_initialized = false;
+	int rc;
 
 	if (ioil_ioc.ioc_open_fd_count > 0) {
+
+		if (ioil_ioc.ioc_dfs) {
+			rc = dfs_umount(ioil_ioc.ioc_dfs);
+			if (rc != 0) {
+				DFUSE_LOG_ERROR("Could not close dfs rc = %d",
+						rc);
+			}
+		}
+
 		CONT_CLOSE(ioil_ioc);
 		POOL_DISCONNECT(ioil_ioc);
 	}
@@ -250,7 +275,61 @@ ioil_fini(void)
 }
 
 static int
-fetch_daos_handles(int fd)
+_fetch_dfs_obj(int fd,
+	struct dfuse_hs_reply *hs_reply,
+	struct fd_entry *entry)
+{
+	d_iov_t			iov = {};
+	int			cmd;
+	int			rc;
+
+	D_ALLOC(iov.iov_buf, hs_reply->fsr_dobj_size);
+	cmd = _IOC(_IOC_READ, DFUSE_IOCTL_TYPE,
+		   DFUSE_IOCTL_REPLY_DOOH, hs_reply->fsr_dobj_size);
+
+	rc = ioctl(fd, cmd, iov.iov_buf);
+	if (rc != 0) {
+		D_FREE(iov.iov_buf);
+		return rc;
+	}
+
+	iov.iov_buf_len = hs_reply->fsr_dobj_size;
+	iov.iov_len = iov.iov_buf_len;
+
+	rc = dfs_obj_global2local(ioil_ioc.ioc_dfs,
+				  0,
+				  iov,
+				  &entry->fd_dfsoh);
+	if (rc) {
+		DFUSE_LOG_INFO("Failed to use dfs object handle %d", rc);
+		D_FREE(iov.iov_buf);
+		return rc;
+	}
+
+	D_FREE(iov.iov_buf);
+
+	return 0;
+}
+
+static int
+fetch_dfs_obj_handle(int fd, struct fd_entry *entry)
+{
+	struct dfuse_hs_reply hs_reply;
+	int rc;
+
+	rc = ioctl(fd, DFUSE_IOCTL_IL_SIZE, &hs_reply);
+	if (rc != 0) {
+		int err = errno;
+
+		DFUSE_LOG_INFO("ioctl returned %d err %d", rc, err);
+		return rc;
+	}
+
+	return _fetch_dfs_obj(fd, &hs_reply, entry);
+}
+
+static int
+fetch_daos_handles(int fd, struct fd_entry *entry)
 {
 	struct dfuse_hs_reply	hs_reply;
 	d_iov_t			iov = {};
@@ -265,9 +344,11 @@ fetch_daos_handles(int fd)
 		return rc;
 	}
 
-	DFUSE_LOG_INFO("ioctl returned %zi %zi",
+	DFUSE_LOG_INFO("ioctl returned %zi %zi %zi %zi",
 		       hs_reply.fsr_pool_size,
-		       hs_reply.fsr_cont_size);
+		       hs_reply.fsr_cont_size,
+		       hs_reply.fsr_dfs_size,
+		       hs_reply.fsr_dobj_size);
 
 	D_ALLOC(iov.iov_buf, hs_reply.fsr_pool_size);
 	if (!iov.iov_buf)
@@ -319,7 +400,32 @@ fetch_daos_handles(int fd)
 
 	D_FREE(iov.iov_buf);
 
-	return 0;
+	D_ALLOC(iov.iov_buf, hs_reply.fsr_dfs_size);
+	cmd = _IOC(_IOC_READ, DFUSE_IOCTL_TYPE,
+		   DFUSE_IOCTL_REPLY_DOH, hs_reply.fsr_dfs_size);
+
+	rc = ioctl(fd, cmd, iov.iov_buf);
+	if (rc != 0) {
+		D_FREE(iov.iov_buf);
+		return rc;
+	}
+
+	iov.iov_buf_len = hs_reply.fsr_dfs_size;
+	iov.iov_len = iov.iov_buf_len;
+
+	rc = dfs_global2local(ioil_ioc.ioc_poh,
+			      ioil_ioc.ioc_coh,
+			      0,
+			      iov, &ioil_ioc.ioc_dfs);
+	if (rc) {
+		DFUSE_LOG_INFO("Failed to use dfs handle %d", rc);
+		D_FREE(iov.iov_buf);
+		return rc;
+	}
+
+	D_FREE(iov.iov_buf);
+
+	return _fetch_dfs_obj(fd, &hs_reply, entry);
 }
 
 static int
@@ -377,7 +483,7 @@ check_ioctl_on_open(int fd, struct fd_entry *entry, int flags, int status)
 
 	if (ioil_ioc.ioc_open_fd_count == 0) {
 
-		rc = fetch_daos_handles(fd);
+		rc = fetch_daos_handles(fd, entry);
 		if (rc) {
 			DFUSE_LOG_INFO("fetch handles failed");
 
@@ -399,18 +505,27 @@ check_ioctl_on_open(int fd, struct fd_entry *entry, int flags, int status)
 			pthread_mutex_unlock(&ioil_ioc.ioc_lock);
 			return false;
 		}
+		rc = fetch_dfs_obj_handle(fd, entry);
+		if (rc)
+			D_GOTO(drop_lock, 0);
 	}
 
 	entry->fd_pos = 0;
 	entry->fd_flags = flags;
 	entry->fd_status = DFUSE_IO_BYPASS;
 
-	rc = daos_array_open_with_attr(ioil_ioc.ioc_coh, il_reply.fir_oid,
-				       DAOS_TX_NONE, DAOS_OO_RW,
-				       cell_size, chunk_size,
-				       &entry->fd_aoh, NULL);
-	if (rc)
-		D_GOTO(cont_close, 0);
+	if (entry->fd_dfsoh) {
+		entry->fd_dfs = ioil_ioc.ioc_dfs;
+	} else {
+		rc = daos_array_open_with_attr(ioil_ioc.ioc_coh,
+					       il_reply.fir_oid,
+					       DAOS_TX_NONE, DAOS_OO_RW,
+					       cell_size, chunk_size,
+					       &entry->fd_aoh, NULL);
+		if (rc)
+			D_GOTO(cont_close, 0);
+
+	}
 
 	rc = vector_set(&fd_table, fd, entry);
 	if (rc != 0) {
@@ -420,6 +535,9 @@ check_ioctl_on_open(int fd, struct fd_entry *entry, int flags, int status)
 		entry->fd_status = DFUSE_IO_DIS_RSRC;
 		D_GOTO(array_close, 0);
 	}
+
+	DFUSE_LOG_INFO("Added entry for new fd %d", fd);
+
 	ioil_ioc.ioc_open_fd_count += 1;
 
 	pthread_mutex_unlock(&ioil_ioc.ioc_lock);

--- a/src/client/dfuse/il/int_read.c
+++ b/src/client/dfuse/il/int_read.c
@@ -27,6 +27,8 @@
 #include "daos.h"
 #include "daos_array.h"
 
+#include "ioil.h"
+
 static ssize_t
 read_bulk(char *buff, size_t len, off_t position,
 	  struct fd_entry *entry, int *errcode)
@@ -40,6 +42,26 @@ read_bulk(char *buff, size_t len, off_t position,
 	int rc;
 
 	DFUSE_TRA_INFO(entry, "%#zx-%#zx ", position, position + len - 1);
+
+	if (entry->fd_dfsoh) {
+		daos_size_t read_size = 0;
+
+		sgl.sg_nr = 1;
+		d_iov_set(&iov, (void *)buff, len);
+		sgl.sg_iovs = &iov;
+		rc = dfs_read(entry->fd_dfs,
+			      entry->fd_dfsoh,
+			      &sgl,
+			      position,
+			      &read_size,
+			      NULL);
+		if (rc) {
+			DFUSE_TRA_INFO(entry, "dfs_read() failed: %d", rc);
+			*errcode = rc;
+			return -1;
+		}
+		return read_size;
+	}
 
 	rc = daos_array_get_size(entry->fd_aoh, DAOS_TX_NONE, &array_size,
 				 NULL);

--- a/src/client/dfuse/il/intercept.h
+++ b/src/client/dfuse/il/intercept.h
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2017-2019 Intel Corporation.
+ * (C) Copyright 2017-2020 Intel Corporation.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -117,25 +117,5 @@
 		__attribute__((weak, alias("__wrap_" #name)));
 
 #endif /* IOIL_PRELOAD */
-
-struct fd_entry {
-	daos_handle_t	fd_aoh;
-	off_t		fd_pos;
-	int		fd_flags;
-	int		fd_status;
-};
-
-ssize_t
-ioil_do_pread(char *buff, size_t len, off_t position,
-	      struct fd_entry *entry, int *errcode);
-ssize_t
-ioil_do_preadv(const struct iovec *iov, int count, off_t position,
-	       struct fd_entry *entry, int *errcode);
-ssize_t
-ioil_do_writex(const char *buff, size_t len, off_t position,
-	       struct fd_entry *entry, int *errcode);
-ssize_t
-ioil_do_pwritev(const struct iovec *iov, int count, off_t position,
-		struct fd_entry *entry, int *errcode);
 
 #endif /* __INTERCEPT_H__ */

--- a/src/client/dfuse/il/ioil.h
+++ b/src/client/dfuse/il/ioil.h
@@ -1,0 +1,55 @@
+/**
+ * (C) Copyright 2017-2020 Intel Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * GOVERNMENT LICENSE RIGHTS-OPEN SOURCE SOFTWARE
+ * The Government's rights to use, modify, reproduce, release, perform, display,
+ * or disclose this software are subject to the terms of the Apache License as
+ * provided in Contract No. B609815.
+ * Any reproduction of computer software, computer software documentation, or
+ * portions thereof marked with this legend must also reproduce the markings.
+ */
+
+#ifndef __IOIL_H__
+#define __IOIL_H__
+
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <unistd.h>
+
+#include "daos_fs.h"
+
+struct fd_entry {
+	daos_handle_t	fd_aoh;
+	dfs_obj_t	*fd_dfsoh;
+	dfs_t		*fd_dfs;
+	off_t		fd_pos;
+	int		fd_flags;
+	int		fd_status;
+};
+
+ssize_t
+ioil_do_pread(char *buff, size_t len, off_t position,
+	      struct fd_entry *entry, int *errcode);
+ssize_t
+ioil_do_preadv(const struct iovec *iov, int count, off_t position,
+	       struct fd_entry *entry, int *errcode);
+ssize_t
+ioil_do_writex(const char *buff, size_t len, off_t position,
+	       struct fd_entry *entry, int *errcode);
+ssize_t
+ioil_do_pwritev(const struct iovec *iov, int count, off_t position,
+		struct fd_entry *entry, int *errcode);
+
+#endif /* __IOIL_H__ */

--- a/utils/node_local_test.py
+++ b/utils/node_local_test.py
@@ -853,12 +853,22 @@ def run_il_test(server, conf):
                 pass
             dirs.append(d)
 
+    # Create a file natively.
     f = os.path.join(dirs[0], 'file')
     fd = open(f, 'w')
     fd.write('Hello')
     fd.close()
+    # Copy it across containers.
     il_cmd(dfuse, ['cp', f, dirs[-1]])
+
+    # Copy it within the container.
+    child_dir = os.path.join(dirs[0], 'new_dir')
+    os.mkdir(child_dir)
+    il_cmd(dfuse, ['cp', f, child_dir])
+
+    # Copy something into a container
     il_cmd(dfuse, ['cp', '/bin/bash', dirs[-1]])
+    # Read it from within a container
     il_cmd(dfuse, ['md5sum', os.path.join(dirs[-1], 'bash')])
     dfuse.stop()
 


### PR DESCRIPTION
Install the python codespell package so the recent change
to code-review can report on spelling mistakes in PRs.