### PR TITLE
DAOS-2448 obj: fix a bug in pl_select_leader for EC

### DIFF
--- a/src/object/srv_ec.c
+++ b/src/object/srv_ec.c
@@ -64,8 +64,8 @@ obj_ec_rw_req_split(struct obj_rw_in *orw, struct obj_ec_split_req **split_req)
 	void			*buf = NULL;
 	int			 rc = 0;
 
-	/* minimal K/P is 2/1, so at least 2 forward targets */
-	D_ASSERT(tgt_nr >= 2);
+	/* minimal K/P is 2/1, so at least 1 forward targets */
+	D_ASSERT(tgt_nr >= 1);
 	D_ASSERT(oiods != NULL);
 	/* as we select the last parity node as leader, and for any update
 	 * there must be a siod (the last siod) for leader except for singv.

--- a/src/placement/pl_map.c
+++ b/src/placement/pl_map.c
@@ -557,7 +557,8 @@ pl_select_leader(daos_obj_id_t oid, uint32_t shard_idx, uint32_t grp_size,
 		/* For EC object, elect last shard in the group (must to be
 		 * a parity node) as leader.
 		 */
-		shard = pl_get_shard(data, shard_idx + grp_size - 1);
+		shard = pl_get_shard(data,
+				rounddown(shard_idx, grp_size) + grp_size - 1);
 		if (for_tgt_id)
 			return shard->po_target;
 


### PR DESCRIPTION
Original code possibly cause shard idx overflow.

Signed-off-by: Xuezhao Liu <xuezhao.liu@intel.com>