### PR TITLE
DAOS-4989 test: Detect failing IOR runs by scanning output.

### DIFF
--- a/src/tests/ftest/io/ior_small.yaml
+++ b/src/tests/ftest/io/ior_small.yaml
@@ -11,7 +11,7 @@ hosts:
     - client-F
     - client-G
     - client-H
-timeout: 1800
+timeout: 9000
 server_config:
     name: daos_server
     servers:
@@ -36,7 +36,7 @@ ior:
         np_16:
             np: 16
     test_file: daos:testFile
-    repetitions: 2
+    repetitions: 10
     daos_destroy: False
     iorflags:
           ior_flags:

--- a/src/tests/ftest/io/ior_small.yaml
+++ b/src/tests/ftest/io/ior_small.yaml
@@ -11,7 +11,7 @@ hosts:
     - client-F
     - client-G
     - client-H
-timeout: 9000
+timeout: 1800
 server_config:
     name: daos_server
     servers:
@@ -36,7 +36,7 @@ ior:
         np_16:
             np: 16
     test_file: daos:testFile
-    repetitions: 10
+    repetitions: 2
     daos_destroy: False
     iorflags:
           ior_flags:

--- a/src/tests/ftest/util/ior_test_base.py
+++ b/src/tests/ftest/util/ior_test_base.py
@@ -206,6 +206,10 @@ class IorTestBase(TestWithServers):
         try:
             self.pool.display_pool_daos_space()
             out = manager.run()
+
+            for line in out.stdout.splitlines():
+                if 'WARNING' in line:
+                    self.fail("IOR command issued warnings.\n")
             return out
         except CommandFailure as error:
             self.log.error("IOR Failed: %s", str(error))


### PR DESCRIPTION
Due to an IOR bug it sometimes exits zero even in the presence of errors, so scan the output
for error messages as well until the IOR fix is landed.

Signed-off-by: Ashley Pittman <ashley.m.pittman@intel.com>