### PR TITLE
DAOS-2585 dtx: move CoS logic from VOS to DTX

### DIFF
--- a/src/container/srv_target.c
+++ b/src/container/srv_target.c
@@ -1109,7 +1109,8 @@ ds_dtx_resync(void *arg)
 	int				 rc;
 
 	rc = dtx_resync(ddra->pool->spc_hdl, ddra->pool->spc_uuid,
-			ddra->co_uuid, ddra->pool->spc_map_version, false);
+			ddra->co_uuid, ddra->pool->spc_map_version,
+			false, true);
 	if (rc != 0)
 		D_WARN("Fail to resync some DTX(s) for the pool/cont "
 		       DF_UUID"/"DF_UUID" that may affect subsequent "

--- a/src/dtx/SConscript
+++ b/src/dtx/SConscript
@@ -13,7 +13,7 @@ def scons():
     # dtx
     dtx = daos_build.library(denv, 'dtx',
                              ['dtx_srv.c', 'dtx_rpc.c', 'dtx_resync.c',
-                              'dtx_common.c'])
+                              'dtx_common.c', 'dtx_cos.c'])
     denv.Install('$PREFIX/lib64/daos_srv', dtx)
 
 if __name__ == "SCons.Script":

--- a/src/dtx/dtx_common.c
+++ b/src/dtx/dtx_common.c
@@ -27,6 +27,7 @@
 
 #include <abt.h>
 #include <uuid/uuid.h>
+#include <daos/btree_class.h>
 #include <daos_srv/pool.h>
 #include <daos_srv/container.h>
 #include <daos_srv/vos.h>
@@ -39,6 +40,15 @@ struct dtx_batched_commit_args {
 	struct ds_cont_child	*dbca_cont;
 	void			*dbca_deregistering;
 };
+
+static void
+dtx_stat(struct ds_cont_child *cont, struct dtx_stat *stat)
+{
+	vos_dtx_stat(cont->sc_hdl, stat);
+
+	stat->dtx_committable_count = cont->sc_dtx_committable_count;
+	stat->dtx_oldest_committable_time = dtx_cos_oldest(cont);
+}
 
 void
 dtx_aggregate(void *arg)
@@ -58,7 +68,7 @@ dtx_aggregate(void *arg)
 		if (cont->sc_open == 0)
 			break;
 
-		vos_dtx_stat(cont->sc_hdl, &stat);
+		dtx_stat(cont, &stat);
 
 		if (stat.dtx_committed_count <= DTX_AGG_THRESHOLD_CNT_LOWER)
 			break;
@@ -85,8 +95,18 @@ dtx_free_committable(struct dtx_entry *dtes)
 static inline void
 dtx_free_dbca(struct dtx_batched_commit_args *dbca)
 {
+	struct ds_cont_child	*cont = dbca->dbca_cont;
+
+	if (!daos_handle_is_inval(cont->sc_dtx_cos_hdl)) {
+		dbtree_destroy(cont->sc_dtx_cos_hdl, NULL);
+		cont->sc_dtx_cos_hdl = DAOS_HDL_INVAL;
+	}
+
+	D_ASSERT(cont->sc_dtx_committable_count == 0);
+	D_ASSERT(d_list_empty(&cont->sc_dtx_cos_list));
+
 	d_list_del(&dbca->dbca_link);
-	ds_cont_child_put(dbca->dbca_cont);
+	ds_cont_child_put(cont);
 	D_FREE_PTR(dbca);
 }
 
@@ -102,14 +122,13 @@ dtx_flush_on_deregister(struct dss_module_info *dmi,
 	do {
 		struct dtx_entry	*dtes = NULL;
 
-		rc = vos_dtx_fetch_committable(cont->sc_hdl,
-					       DTX_THRESHOLD_COUNT, NULL,
-					       DAOS_EPOCH_MAX, &dtes);
+		rc = dtx_fetch_committable(cont, DTX_THRESHOLD_COUNT,
+					   NULL, DAOS_EPOCH_MAX, &dtes);
 		if (rc <= 0)
 			break;
 
 		rc = dtx_commit(pool->spc_uuid, cont->sc_uuid,
-				dtes, rc, pool->spc_map_version);
+				dtes, rc, pool->spc_map_version, true);
 		dtx_free_committable(dtes);
 	} while (rc >= 0);
 
@@ -151,19 +170,18 @@ dtx_batched_commit(void *arg)
 		}
 
 		d_list_move_tail(&dbca->dbca_link, &dmi->dmi_dtx_batched_list);
-		vos_dtx_stat(cont->sc_hdl, &stat);
+		dtx_stat(cont, &stat);
 
 		if ((stat.dtx_committable_count > DTX_THRESHOLD_COUNT) ||
 		    (stat.dtx_oldest_committable_time != 0 &&
 		     dtx_hlc_age2sec(stat.dtx_oldest_committable_time) >
 		     DTX_COMMIT_THRESHOLD_AGE)) {
-			rc = vos_dtx_fetch_committable(cont->sc_hdl,
-						DTX_THRESHOLD_COUNT, NULL,
-						DAOS_EPOCH_MAX, &dtes);
+			rc = dtx_fetch_committable(cont, DTX_THRESHOLD_COUNT,
+						   NULL, DAOS_EPOCH_MAX, &dtes);
 			if (rc > 0) {
 				rc = dtx_commit(cont->sc_pool->spc_uuid,
 					cont->sc_uuid, dtes, rc,
-					cont->sc_pool->spc_map_version);
+					cont->sc_pool->spc_map_version, true);
 				dtx_free_committable(dtes);
 
 				if (dbca->dbca_deregistering) {
@@ -172,7 +190,7 @@ dtx_batched_commit(void *arg)
 				}
 
 				if (!cont->sc_dtx_aggregating)
-					vos_dtx_stat(cont->sc_hdl, &stat);
+					dtx_stat(cont, &stat);
 			}
 		}
 
@@ -209,29 +227,32 @@ check:
  * Init local dth handle.
  */
 static void
-dtx_handle_init(struct dtx_id *dti, daos_unit_oid_t *oid, daos_handle_t coh,
-		daos_epoch_t epoch, uint64_t dkey_hash, uint32_t pm_ver,
-		uint32_t intent, struct dtx_id *dti_cos, int dti_cos_count,
+dtx_handle_init(struct dtx_id *dti, daos_handle_t coh,
+		daos_epoch_t epoch,  uint32_t pm_ver,
+		daos_unit_oid_t *oid, uint64_t dkey_hash, uint32_t intent,
+		struct dtx_id *dti_cos, int dti_cos_count,
 		bool leader, bool solo, struct dtx_handle *dth)
 {
 	dth->dth_xid = *dti;
-	dth->dth_oid = *oid;
 	dth->dth_coh = coh;
 	dth->dth_epoch = epoch;
-	D_INIT_LIST_HEAD(&dth->dth_shares);
-	dth->dth_dkey_hash = dkey_hash;
 	dth->dth_ver = pm_ver;
+
+	dth->dth_oid = *oid;
+	dth->dth_dkey_hash = dkey_hash;
 	dth->dth_intent = intent;
+
 	dth->dth_dti_cos = dti_cos;
 	dth->dth_dti_cos_count = dti_cos_count;
 	dth->dth_ent = NULL;
-	dth->dth_obj = UMOFF_NULL;
+
 	dth->dth_sync = 0;
-	dth->dth_leader = leader ? 1 : 0;
 	dth->dth_solo = solo ? 1 : 0;
 	dth->dth_dti_cos_done = 0;
 	dth->dth_modify_shared = 0;
-	dth->dth_actived = 0;
+	dth->dth_active = 0;
+
+	dth->dth_flags = leader ? DTE_LEADER : 0;
 
 	/* Operation sequence starts from 1 instead of 0. */
 	dth->dth_op_seq = 1;
@@ -243,23 +264,24 @@ dtx_handle_init(struct dtx_id *dti, daos_unit_oid_t *oid, daos_handle_t coh,
  * XXX: Currently, we only support to prepare the DTX against single DAOS
  *	object and single dkey.
  *
+ * \param cont		[IN]	Pointer to the container.
  * \param dti		[IN]	The DTX identifier.
- * \param oid		[IN]	The target object (shard) ID.
- * \param coh		[IN]	Container open handle.
  * \param epoch		[IN]	Epoch for the DTX.
- * \param dkey_hash	[IN]	Hash of the dkey to be modified if applicable.
- * \param tgts		[IN]	targets for distribute transaction.
- * \param tgts_cnt	[IN]	number of targets.
  * \param pm_ver	[IN]	Pool map version for the DTX.
+ * \param oid		[IN]	The target object (shard) ID.
+ * \param dkey_hash	[IN]	Hash of the dkey to be modified if applicable.
  * \param intent	[IN]	The intent of related modification.
+ * \param tgts		[IN]	targets for distribute transaction.
+ * \param tgt_cnt	[IN]	number of targets.
  * \param dth		[OUT]	Pointer to the DTX handle.
  *
  * \return			Zero on success, negative value if error.
  */
 int
-dtx_leader_begin(struct dtx_id *dti, daos_unit_oid_t *oid, daos_handle_t coh,
-		 daos_epoch_t epoch, uint64_t dkey_hash, uint32_t pm_ver,
-		 uint32_t intent, struct daos_shard_tgt *tgts, int tgts_cnt,
+dtx_leader_begin(struct ds_cont_child *cont, struct dtx_id *dti,
+		 daos_epoch_t epoch, uint32_t pm_ver,
+		 daos_unit_oid_t *oid, uint64_t dkey_hash, uint32_t intent,
+		 struct daos_shard_tgt *tgts, int tgt_cnt,
 		 struct dtx_leader_handle *dlh)
 {
 	struct dtx_handle	*dth = &dlh->dlh_handle;
@@ -268,7 +290,7 @@ dtx_leader_begin(struct dtx_id *dti, daos_unit_oid_t *oid, daos_handle_t coh,
 	int			 i;
 
 	/* Single replica case. */
-	if (tgts_cnt == 0) {
+	if (tgt_cnt == 0) {
 		if (!daos_is_zero_dti(dti))
 			goto init;
 
@@ -277,13 +299,13 @@ dtx_leader_begin(struct dtx_id *dti, daos_unit_oid_t *oid, daos_handle_t coh,
 	}
 
 	dlh->dlh_future = ABT_FUTURE_NULL;
-	D_ALLOC_ARRAY(dlh->dlh_subs, tgts_cnt);
+	D_ALLOC_ARRAY(dlh->dlh_subs, tgt_cnt);
 	if (dlh->dlh_subs == NULL)
 		return -DER_NOMEM;
 
-	for (i = 0; i < tgts_cnt; i++)
+	for (i = 0; i < tgt_cnt; i++)
 		dlh->dlh_subs[i].dss_tgt = tgts[i];
-	dlh->dlh_sub_cnt = tgts_cnt;
+	dlh->dlh_sub_cnt = tgt_cnt;
 
 	if (daos_is_zero_dti(dti)) {
 		daos_dti_gen(&dth->dth_xid, true); /* zero it */
@@ -296,17 +318,18 @@ dtx_leader_begin(struct dtx_id *dti, daos_unit_oid_t *oid, daos_handle_t coh,
 	 *	Then non-leader replicas can commit them before real
 	 *	modifications to avoid availability trouble.
 	 */
-	dti_cos_count = vos_dtx_list_cos(coh, oid, dkey_hash,
-					 DTX_THRESHOLD_COUNT, &dti_cos);
+	dti_cos_count = dtx_list_cos(cont, oid, dkey_hash,
+				     DTX_THRESHOLD_COUNT, &dti_cos);
 	if (dti_cos_count < 0) {
 		D_FREE(dlh->dlh_subs);
 		return dti_cos_count;
 	}
 
 init:
-	dtx_handle_init(dti, oid, coh, epoch, dkey_hash, pm_ver, intent,
+	dtx_handle_init(dti, cont->sc_hdl, epoch, pm_ver,
+			oid, dkey_hash, intent,
 			dti_cos, dti_cos_count, true,
-			tgts_cnt == 0 ? true : false, dth);
+			tgt_cnt == 0 ? true : false, dth);
 
 	D_DEBUG(DB_TRACE, "Start DTX "DF_DTI" for object "DF_OID
 		" ver %u, dkey %llu, dti_cos_count %d, intent %s\n",
@@ -347,6 +370,7 @@ dtx_leader_end(struct dtx_leader_handle *dlh, struct ds_cont_child *cont,
 {
 	struct dtx_handle		*dth = &dlh->dlh_handle;
 	daos_epoch_t			 epoch = dth->dth_epoch;
+	int				 saved = result;
 	int				 rc = 0;
 
 	if (dlh->dlh_sub_cnt == 0)
@@ -359,21 +383,73 @@ dtx_leader_end(struct dtx_leader_handle *dlh, struct ds_cont_child *cont,
 	 */
 
 	rc = dtx_leader_wait(dlh);
-	if (result < 0 || rc < 0 || !dth->dth_actived ||
+	if (result < 0 || rc < 0 || !dth->dth_active ||
 	    daos_is_zero_dti(&dth->dth_xid))
 		D_GOTO(out, result = result < 0 ? result : rc);
 
 again:
+	/* If the DTX is started befoe DTX resync (for rebuild), then it is
+	 * possbile that the DTX resync ULT may have aborted or committed
+	 * the DTX during current ULT waiting for other non-leaders' reply.
+	 * Let's check DTX status locally before marking as 'committable'.
+	 */
+	if (dth->dth_ver < cont->sc_dtx_resync_ver) {
+		rc = vos_dtx_check(cont->sc_hdl, &dth->dth_xid,
+				   NULL, NULL, false);
+		/* Committed by race, do nothing. */
+		if (rc == DTX_ST_COMMITTED)
+			D_GOTO(out, result = 0);
+
+		/* Aborted by race, restart it. */
+		if (rc == -DER_NONEXIST) {
+			D_WARN(DF_UUID": DTX "DF_DTI" is aborted with "
+			       "old epoch "DF_U64" by resync\n",
+			       DP_UUID(cont->sc_uuid), DP_DTI(&dth->dth_xid),
+			       dth->dth_epoch);
+			D_GOTO(out, result = -DER_TX_RESTART);
+		}
+
+		if (rc != DTX_ST_PREPARED) {
+			D_ASSERT(rc < 0);
+
+			D_WARN(DF_UUID": Failed to check local DTX "DF_DTI
+			       "status: "DF_RC"\n",
+			       DP_UUID(cont->sc_uuid), DP_DTI(&dth->dth_xid),
+			       DP_RC(rc));
+			D_GOTO(out, result = rc);
+		}
+	}
+
 	rc = vos_dtx_check_sync(dth->dth_coh, dth->dth_oid, &epoch);
-	if (rc == 0)
-		rc = vos_dtx_add_cos(dth->dth_coh, &dth->dth_oid, &dth->dth_xid,
-				     dth->dth_dkey_hash, dth->dth_epoch,
-				     dth->dth_gen,
-				     dth->dth_modify_shared ? DCF_SHARED : 0);
+	/* Only add async DTX into the CoS cache. */
+	if (rc == 0) {
+		/* When we come here, the modification on all participants have
+		 * been done successfully. If 'dth->dth_active' is false, means
+		 * that it is for resent caseC. Under such case, we have no way
+		 * to mark it as committable, then commit it sychronously.
+		 */
+		if (!dth->dth_active) {
+			D_ASSERT(dth->dth_ent == NULL);
+
+			dth->dth_sync = 1;
+		}
+
+		/* For synchronous DTX, do not add it into CoS cache, otherwise,
+		 * we may have no way to remove it from the cache.
+		 */
+		if (dth->dth_sync)
+			goto sync;
+
+		rc = dtx_add_cos(cont, &dth->dth_xid, &dth->dth_oid,
+				 dth->dth_dkey_hash, dth->dth_epoch,
+				 dth->dth_modify_shared ? DCF_SHARED : 0);
+		if (rc == 0)
+			vos_dtx_mark_committable(dth);
+	}
+
 	if (rc == -DER_TX_RESTART) {
 		D_WARN(DF_UUID": Fail to add DTX "DF_DTI" to CoS "
-		       "because of using old epoch "DF_U64
-		       " or aborted by resync\n",
+		       "because of using old epoch "DF_U64"\n",
 		       DP_UUID(cont->sc_uuid), DP_DTI(&dth->dth_xid),
 		       dth->dth_epoch);
 		D_GOTO(out, result = rc);
@@ -394,20 +470,22 @@ again:
 	}
 
 	if (rc != 0 && epoch < dth->dth_epoch) {
-		D_WARN(DF_UUID": Fail to add DTX "DF_DTI" to CoS cache: %d. "
-		       "Try to commit it sychronously.\n",
-		       DP_UUID(cont->sc_uuid), DP_DTI(&dth->dth_xid), rc);
+		D_WARN(DF_UUID": Fail to add DTX "DF_DTI" to CoS cache: "
+		       DF_RC". Try to commit it sychronously.\n",
+		       DP_UUID(cont->sc_uuid), DP_DTI(&dth->dth_xid),
+		       DP_RC(rc));
 		dth->dth_sync = 1;
 	}
 
+sync:
 	if (dth->dth_sync) {
 		rc = dtx_commit(cont->sc_pool->spc_uuid, cont->sc_uuid,
 				&dth->dth_dte, 1,
-				cont->sc_pool->spc_map_version);
+				cont->sc_pool->spc_map_version, false);
 		if (rc != 0) {
 			D_ERROR(DF_UUID": Fail to sync commit DTX "DF_DTI
-				": rc = %d\n", DP_UUID(cont->sc_uuid),
-				DP_DTI(&dth->dth_xid), rc);
+				": "DF_RC"\n", DP_UUID(cont->sc_uuid),
+				DP_DTI(&dth->dth_xid), DP_RC(rc));
 			D_GOTO(out, result = rc);
 		}
 	}
@@ -431,13 +509,27 @@ out:
 
 	D_ASSERTF(result <= 0, "unexpected return value %d\n", result);
 
+	/* Local modification is done, then need to handle CoS cache. */
+	if (saved >= 0) {
+		int	i;
+
+		for (i = 0; i < dth->dth_dti_cos_count; i++)
+			dtx_del_cos(cont, &dth->dth_dti_cos[i],
+				    &dth->dth_oid, dth->dth_dkey_hash);
+	}
+
 	D_FREE(dth->dth_dti_cos);
 	dth->dth_dti_cos_count = 0;
 
 	/* Some remote replica(s) ask retry. We do not make such replica
 	 * to locally retry for avoiding RPC timeout. The leader replica
 	 * will trigger retry globally without aborting 'prepared' ones.
-	 * Reuse the DTX handle for that, so keep the 'dlh_subs'.
+	 * Reuse the DTX handle for that, so keep the 'dlh_subs'. It is
+	 * not necessary to keep the 'dth_dti_cos' because that we will
+	 * not re-init the transaction handle, then will not assign new
+	 * 'dth_dti_cos'. On the other hand, even if some replicas have
+	 * not executed related modification, the piggyback dth_dti_cos
+	 * still has been committed when dtx_end().
 	 */
 	if (result == -DER_AGAIN)
 		dlh->dlh_future = ABT_FUTURE_NULL;
@@ -453,30 +545,34 @@ out:
  * XXX: Currently, we only support to prepare the DTX against single DAOS
  *	object and single dkey.
  *
+ * \param cont		[IN]	Pointer to the container.
  * \param dti		[IN]	The DTX identifier.
- * \param oid		[IN]	The target object (shard) ID.
- * \param coh		[IN]	Container open handle.
  * \param epoch		[IN]	Epoch for the DTX.
- * \param dkey_hash	[IN]	Hash of the dkey to be modified if applicable.
- * \param dti_cos	[IN,OUT]The DTX array to be committed because of shared.
- * \param dti_cos_count [IN,OUT]The @dti_cos array size.
  * \param pm_ver	[IN]	Pool map version for the DTX.
+ * \param oid		[IN]	The target object (shard) ID.
+ * \param dkey_hash	[IN]	Hash of the dkey to be modified if applicable.
  * \param intent	[IN]	The intent of related modification.
- * \param leader	[IN]	The target (to be modified) is leader or not.
+ * \param dti_cos	[IN]	The DTX array to be committed because of shared.
+ * \param dti_cos_count [IN]	The @dti_cos array size.
  * \param dth		[OUT]	Pointer to the DTX handle.
  *
  * \return			Zero on success, negative value if error.
  */
 int
-dtx_begin(struct dtx_id *dti, daos_unit_oid_t *oid, daos_handle_t coh,
-	  daos_epoch_t epoch, uint64_t dkey_hash, struct dtx_id *dti_cos,
-	  int dti_cos_cnt, uint32_t pm_ver, uint32_t intent,
-	  struct dtx_handle *dth)
+dtx_begin(struct ds_cont_child *cont, struct dtx_id *dti,
+	  daos_epoch_t epoch, uint32_t pm_ver,
+	  daos_unit_oid_t *oid, uint64_t dkey_hash, uint32_t intent,
+	  struct dtx_id *dti_cos, int dti_cos_cnt, struct dtx_handle *dth)
 {
-	if (dth == NULL || daos_is_zero_dti(dti))
-		return 0;
+	D_ASSERT(dth != NULL);
 
-	dtx_handle_init(dti, oid, coh, epoch, dkey_hash, pm_ver, intent,
+	if (daos_is_zero_dti(dti)) {
+		daos_dti_gen(&dth->dth_xid, true);
+		return 0;
+	}
+
+	dtx_handle_init(dti, cont->sc_hdl, epoch, pm_ver,
+			oid, dkey_hash, intent,
 			dti_cos, dti_cos_cnt, false, false, dth);
 
 	D_DEBUG(DB_TRACE, "Start the DTX "DF_DTI" for object "DF_OID
@@ -489,13 +585,14 @@ dtx_begin(struct dtx_id *dti, daos_unit_oid_t *oid, daos_handle_t coh,
 }
 
 int
-dtx_end(struct dtx_handle *dth, struct ds_cont_hdl *cont_hdl,
-	struct ds_cont_child *cont, int result)
+dtx_end(struct dtx_handle *dth, struct ds_cont_child *cont, int result)
 {
-	int rc = 0;
+	int	rc;
 
-	if (dth == NULL || daos_is_zero_dti(&dth->dth_xid))
-		goto out;
+	D_ASSERT(dth != NULL);
+
+	if (daos_is_zero_dti(&dth->dth_xid))
+		return result;
 
 	if (result < 0) {
 		if (dth->dth_dti_cos_count > 0) {
@@ -509,8 +606,8 @@ dtx_end(struct dtx_handle *dth, struct ds_cont_hdl *cont_hdl,
 			 *	CoS cache, and can be committed next time.
 			 */
 			rc = vos_dtx_commit(cont->sc_hdl, dth->dth_dti_cos,
-					    dth->dth_dti_cos_count);
-			if (rc != 0)
+					    dth->dth_dti_cos_count, NULL);
+			if (rc < 0)
 				D_ERROR(DF_UUID": Fail to DTX CoS commit: %d\n",
 					DP_UUID(cont->sc_uuid), rc);
 		}
@@ -525,16 +622,18 @@ dtx_end(struct dtx_handle *dth, struct ds_cont_hdl *cont_hdl,
 
 	D_ASSERTF(result <= 0, "unexpected return value %d\n", result);
 
-out:
 	return result;
 }
 
+#define DTX_COS_BTREE_ORDER		23
 
 int
 dtx_batched_commit_register(struct ds_cont_child *cont)
 {
 	struct dtx_batched_commit_args	*dbca;
 	d_list_t			*head;
+	struct umem_attr		 uma;
+	int				 rc;
 
 	D_ASSERT(cont != NULL);
 
@@ -552,9 +651,28 @@ dtx_batched_commit_register(struct ds_cont_child *cont)
 	if (dbca == NULL)
 		return -DER_NOMEM;
 
+	memset(&uma, 0, sizeof(uma));
+	uma.uma_id = UMEM_CLASS_VMEM;
+	rc = dbtree_create_inplace_ex(DBTREE_CLASS_DTX_COS, 0,
+				      DTX_COS_BTREE_ORDER, &uma,
+				      &cont->sc_dtx_cos_btr,
+				      DAOS_HDL_INVAL, cont,
+				      &cont->sc_dtx_cos_hdl);
+	if (rc != 0) {
+		D_ERROR("Failed to create DTX CoS btree: "DF_RC"\n",
+			DP_RC(rc));
+		D_FREE(dbca);
+		return rc;
+	}
+
+	cont->sc_dtx_committable_count = 0;
+	D_INIT_LIST_HEAD(&cont->sc_dtx_cos_list);
+	cont->sc_dtx_resync_ver = 1;
+
 	ds_cont_child_get(cont);
 	dbca->dbca_cont = cont;
 	d_list_add_tail(&dbca->dbca_link, head);
+
 	return 0;
 }
 
@@ -605,8 +723,8 @@ dtx_batched_commit_deregister(struct ds_cont_child *cont)
 }
 
 int
-dtx_handle_resend(daos_handle_t coh, daos_unit_oid_t *oid, struct dtx_id *dti,
-		  uint64_t dkey_hash, daos_epoch_t *epoch)
+dtx_handle_resend(daos_handle_t coh,  struct dtx_id *dti,
+		  daos_epoch_t *epoch, uint32_t *pm_ver)
 {
 	int	rc;
 
@@ -624,7 +742,7 @@ dtx_handle_resend(daos_handle_t coh, daos_unit_oid_t *oid, struct dtx_id *dti,
 		return -DER_NONEXIST;
 
 again:
-	rc = vos_dtx_check_resend(coh, oid, dti, dkey_hash, epoch);
+	rc = vos_dtx_check(coh, dti, epoch, pm_ver, true);
 	switch (rc) {
 	case DTX_ST_PREPARED:
 		return 0;
@@ -785,36 +903,34 @@ out:
 }
 
 int
-dtx_obj_sync(uuid_t po_uuid, uuid_t co_uuid, daos_handle_t coh,
-	     daos_unit_oid_t oid, daos_epoch_t epoch, uint32_t map_ver)
+dtx_obj_sync(uuid_t po_uuid, uuid_t co_uuid, struct ds_cont_child *cont,
+	     daos_unit_oid_t *oid, daos_epoch_t epoch, uint32_t map_ver)
 {
 	int	rc = 0;
 
 	while (1) {
 		struct dtx_entry	*dtes = NULL;
 
-		rc = vos_dtx_fetch_committable(coh, DTX_THRESHOLD_COUNT, &oid,
-					       epoch, &dtes);
+		rc = dtx_fetch_committable(cont, DTX_THRESHOLD_COUNT, oid,
+					   epoch, &dtes);
 		if (rc < 0) {
-			D_ERROR(DF_UOID" fail to fetch dtx: rc = %d\n",
-				DP_UOID(oid), rc);
+			D_ERROR("Failed to fetch dtx: "DF_RC"\n", DP_RC(rc));
 			break;
 		}
 
 		if (rc == 0)
 			break;
 
-		rc = dtx_commit(po_uuid, co_uuid, dtes, rc, map_ver);
+		rc = dtx_commit(po_uuid, co_uuid, dtes, rc, map_ver, true);
 		dtx_free_committable(dtes);
 		if (rc < 0) {
-			D_ERROR(DF_UOID" fail to commit dtx: rc = %d\n",
-				DP_UOID(oid), rc);
+			D_ERROR("Fail to commit dtx: "DF_RC"\n", DP_RC(rc));
 			break;
 		}
 	}
 
-	if (rc == 0)
-		rc = vos_dtx_mark_sync(coh, oid, epoch);
+	if (rc == 0 && oid != NULL)
+		rc = vos_dtx_mark_sync(cont->sc_hdl, *oid, epoch);
 
 	return rc;
 }

--- a/src/dtx/dtx_internal.h
+++ b/src/dtx/dtx_internal.h
@@ -91,11 +91,30 @@ CRT_RPC_DECLARE(dtx, DAOS_ISEQ_DTX, DAOS_OSEQ_DTX);
 
 extern struct crt_proto_format dtx_proto_fmt;
 extern btr_ops_t dbtree_dtx_cf_ops;
+extern btr_ops_t dtx_btr_cos_ops;
 
+/* dtx_common.c */
 void dtx_aggregate(void *arg);
 void dtx_batched_commit(void *arg);
-int dtx_commit(uuid_t po_uuid, uuid_t co_uuid,
-	       struct dtx_entry *dtes, int count, uint32_t version);
+
+/* dtx_cos.c */
+int dtx_fetch_committable(struct ds_cont_child *cont, uint32_t max_cnt,
+			  daos_unit_oid_t *oid, daos_epoch_t epoch,
+			  struct dtx_entry **dtes);
+int dtx_list_cos(struct ds_cont_child *cont, daos_unit_oid_t *oid,
+		 uint64_t dkey_hash, int max, struct dtx_id **dtis);
+int dtx_lookup_cos(struct ds_cont_child *cont, struct dtx_id *xid,
+		   daos_unit_oid_t *oid, uint64_t dkey_hash);
+int dtx_add_cos(struct ds_cont_child *cont, struct dtx_id *dti,
+		daos_unit_oid_t *oid, uint64_t dkey_hash,
+		daos_epoch_t epoch, uint32_t flags);
+int dtx_del_cos(struct ds_cont_child *cont, struct dtx_id *xid,
+		daos_unit_oid_t *oid, uint64_t dkey_hash);
+uint64_t dtx_cos_oldest(struct ds_cont_child *cont);
+
+/* dtx_rpc.c */
+int dtx_commit(uuid_t po_uuid, uuid_t co_uuid, struct dtx_entry *dtes,
+	       int count, uint32_t version, bool drop_cos);
 int dtx_abort(uuid_t po_uuid, uuid_t co_uuid, daos_epoch_t epoch,
 	      struct dtx_entry *dtes, int count, uint32_t version);
 int dtx_check(uuid_t po_uuid, uuid_t co_uuid,

--- a/src/dtx/dtx_resync.c
+++ b/src/dtx/dtx_resync.c
@@ -39,8 +39,6 @@ struct dtx_resync_entry {
 	d_list_t		dre_link;
 	struct dtx_entry	dre_dte;
 	daos_epoch_t		dre_epoch;
-	uint64_t		dre_hash;
-	uint32_t		dre_in_cache:1;
 };
 
 #define dre_oid		dre_dte.dte_oid
@@ -55,7 +53,9 @@ struct dtx_resync_args {
 	struct ds_cont_child	*cont;
 	uuid_t			 po_uuid;
 	struct dtx_resync_head	 tables;
+	daos_epoch_t		 epoch;
 	uint32_t		 version;
+	uint32_t		 resync_all:1;
 };
 
 static inline void
@@ -85,45 +85,22 @@ dtx_resync_commit(uuid_t po_uuid, struct ds_cont_child *cont,
 	for (i = 0; i < count; i++) {
 		dre = d_list_entry(drh->drh_list.next,
 				   struct dtx_resync_entry, dre_link);
+
 		/* Someone (the DTX owner or batched commit ULT) may have
 		 * committed or aborted the DTX during we handling other
-		 * DTXs. So double check the on-disk status before current
-		 * commit.
+		 * DTXs. So double check the status before current commit.
 		 */
-		rc = vos_dtx_check(cont->sc_hdl, &dre->dre_xid);
+		rc = vos_dtx_check(cont->sc_hdl, &dre->dre_xid,
+				   NULL, NULL, false);
 
 		/* Skip this DTX since it has been committed or aggregated. */
 		if (rc == DTX_ST_COMMITTED || rc == -DER_NONEXIST)
 			goto next;
 
-		if (rc != DTX_ST_PREPARED) {
-			/* If we failed to check the on-disk status, commit
-			 * it again, that is harmless. But we cannot add it
-			 * to CoS cache.
-			 */
-			D_WARN("Fail to check DTX "DF_DTI" status: %d.\n",
-			       DP_DTI(&dre->dre_xid), rc);
-			goto commit;
-		}
+		/* If we failed to check the status, then assume that it is
+		 * not committed, then commit it (again), that is harmless.
+		 */
 
-		if (dre->dre_in_cache)
-			goto commit;
-
-		rc = vos_dtx_lookup_cos(cont->sc_hdl, &dre->dre_oid,
-					&dre->dre_xid, dre->dre_hash);
-		if (rc == -DER_NONEXIST) {
-			/* Not sure about whether the DTX modified shared
-			 * items or not, then just assume it is.
-			 */
-			rc = vos_dtx_add_cos(cont->sc_hdl, &dre->dre_oid,
-					     &dre->dre_xid, dre->dre_hash,
-					     dre->dre_epoch, 0, DCF_SHARED);
-			if (rc < 0)
-				D_WARN("Fail to add DTX "DF_DTI" to CoS cache: "
-				       "rc = %d\n",  DP_DTI(&dre->dre_xid), rc);
-		}
-
-commit:
 		dte[j].dte_xid = dre->dre_xid;
 		dte[j].dte_oid = dre->dre_oid;
 		++j;
@@ -133,7 +110,7 @@ next:
 	}
 
 	if (j > 0) {
-		rc = dtx_commit(po_uuid, cont->sc_uuid, dte, j, version);
+		rc = dtx_commit(po_uuid, cont->sc_uuid, dte, j, version, false);
 		if (rc < 0)
 			D_ERROR("Failed to commit the DTXs: rc = "DF_RC"\n",
 				DP_RC(rc));
@@ -158,7 +135,7 @@ dtx_status_handle(struct dtx_resync_args *dra)
 	int				 rc;
 
 	if (drh->drh_count == 0)
-		return 0;
+		goto out;
 
 	d_list_for_each_entry_safe(dre, next, &drh->drh_list, dre_link) {
 		if (layout != NULL) {
@@ -166,27 +143,16 @@ dtx_status_handle(struct dtx_resync_args *dra)
 			layout = NULL;
 		}
 
-		rc = vos_dtx_lookup_cos(cont->sc_hdl, &dre->dre_oid,
-					&dre->dre_xid, dre->dre_hash);
-		/* If it is in CoS cache, no need to check remote replicas. */
-		if (rc == 0) {
-			dre->dre_in_cache = 1;
-			goto commit;
-		}
-
 		rc = ds_pool_check_leader(dra->po_uuid, &dre->dre_oid,
 					  dra->version, &layout);
 		if (rc <= 0) {
 			if (rc < 0)
 				D_WARN("Not sure about the leader for the DTX "
-				       DF_UOID"/"DF_DTI" (ver = %u): rc = %d, "
-				       "skip it.\n",
-				       DP_UOID(dre->dre_oid),
+				       DF_DTI" (ver = %u): rc = %d, skip it.\n",
 				       DP_DTI(&dre->dre_xid), dra->version, rc);
 			else
 				D_DEBUG(DB_TRACE, "Not the leader for the DTX "
-					DF_UOID"/"DF_DTI" (ver = %u) skip it\n",
-					DP_UOID(dre->dre_oid),
+					DF_DTI" (ver = %u) skip it.\n",
 					DP_DTI(&dre->dre_xid), dra->version);
 			dtx_dre_release(drh, dre);
 			continue;
@@ -195,19 +161,15 @@ dtx_status_handle(struct dtx_resync_args *dra)
 		rc = dtx_check(dra->po_uuid, cont->sc_uuid,
 			       &dre->dre_dte, layout);
 
-		/* The DTX has been committed (or) ready to be committed on
-		 * some remote replica(s), let's commit the it globally.
+		/* The DTX has been committed or ready to be committed on
+		 * some remote replica(s), let's commit the DTX globally.
 		 */
 		if (rc == DTX_ST_COMMITTED || rc == DTX_ST_PREPARED)
 			goto commit;
 
 		if (rc != -DER_NONEXIST) {
-			/* We are not sure about whether the DTX can be
-			 * committed or not, then we have to skip it.
-			 */
-			D_WARN("Not sure about whether the DTX "DF_UOID
-			       "/"DF_DTI" can be committed or not: %d\n",
-			       DP_UOID(dre->dre_oid),
+			D_WARN("Not sure about whether the DTX "DF_DTI
+			       " can be committed or not: %d, skip it.\n",
 			       DP_DTI(&dre->dre_xid), rc);
 			dtx_dre_release(drh, dre);
 			continue;
@@ -215,43 +177,43 @@ dtx_status_handle(struct dtx_resync_args *dra)
 
 		/* Someone (the DTX owner or batched commit ULT) may have
 		 * committed or aborted the DTX during we handling other
-		 * DTXs. So double check the on-disk status before current
-		 * commit.
+		 * DTXs. So double check the status before next action.
 		 */
-		rc = vos_dtx_check(cont->sc_hdl, &dre->dre_xid);
+		rc = vos_dtx_check(cont->sc_hdl, &dre->dre_xid,
+				   NULL, NULL, false);
 
-		/* Skip this DTX since it has been committed or aborted or
-		 * fail to get the status.
-		 */
-		if (rc != DTX_ST_PREPARED) {
-			if (rc < 0 && rc != -DER_NONEXIST)
-				D_WARN("Not sure about whether the DTX "DF_UOID
-				       "/"DF_DTI" can be abort or not: %d\n",
-				       DP_UOID(dre->dre_oid),
-				       DP_DTI(&dre->dre_xid), rc);
+		/* Skip this DTX that it may has been committed or aborted. */
+		if (rc == DTX_ST_COMMITTED || rc == -DER_NONEXIST) {
 			dtx_dre_release(drh, dre);
 			continue;
 		}
 
-		rc = vos_dtx_lookup_cos(cont->sc_hdl, &dre->dre_oid,
-					&dre->dre_xid, dre->dre_hash);
-		if (rc == 0) {
-			dre->dre_in_cache = 1;
-			goto commit;
+		/* Skip this DTX if failed to get the status. */
+		if (rc != DTX_ST_PREPARED) {
+			D_WARN("Not sure about whether the DTX "DF_DTI
+			       " can be abort or not: %d, skip it.\n",
+			       DP_DTI(&dre->dre_xid), rc);
+			dtx_dre_release(drh, dre);
+			continue;
 		}
 
-		if (rc == -DER_NONEXIST) {
-			/* If we abort multiple non-ready DTXs together, then
-			 * there is race that one DTX may become committable
-			 * when we abort some other DTX(s). To avoid complex
-			 * rollback logic, let's abort the DTXs one by one.
-			 */
-			rc = dtx_abort(dra->po_uuid, cont->sc_uuid,
-				       dre->dre_epoch, &dre->dre_dte, 1,
-				       dra->version);
-			if (rc < 0)
-				err = rc;
-		}
+		/* To be aborted. It is possible that the client has resent
+		 * related RPC to the new leader, but such DTX is still not
+		 * committable yet. Here, the resync logic will abort it by
+		 * race during the new leader waiting for other replica(s).
+		 * The dtx_abort() logic will abort the local DTX firstly.
+		 * When the leader get replies from other replicas, it will
+		 * check whether local DTX is still valid or not.
+		 *
+		 * If we abort multiple non-ready DTXs together, then there
+		 * is race that one DTX may become committable when we abort
+		 * some other DTX(s). To avoid complex rollback logic, let's
+		 * abort the DTXs one by one, not batched.
+		 */
+		rc = dtx_abort(dra->po_uuid, cont->sc_uuid, dre->dre_epoch,
+			       &dre->dre_dte, 1, dra->version);
+		if (rc < 0)
+			err = rc;
 
 		dtx_dre_release(drh, dre);
 		continue;
@@ -276,6 +238,12 @@ commit:
 	if (layout != NULL)
 		pl_obj_layout_free(layout);
 
+out:
+	if (err >= 0)
+		/* Drain old committable DTX to help subsequent rebuild. */
+		err = dtx_obj_sync(dra->po_uuid, cont->sc_uuid, cont,
+				   NULL, dra->epoch, dra->version);
+
 	return err;
 }
 
@@ -292,14 +260,22 @@ dtx_iter_cb(uuid_t co_uuid, vos_iter_entry_t *ent, void *args)
 	 * (or abort) the DTXs (that will change the active-DTX tree).
 	 */
 
+	D_ASSERT(!(ent->ie_dtx_flags & DTE_INVALID));
+
+	if (ent->ie_dtx_flags & DTE_LEADER && !dra->resync_all)
+		return 0;
+
+	/* Only handle the DTX that happened before the DTX resync. */
+	if (ent->ie_dtx_ver >= dra->version)
+		return 0;
+
 	D_ALLOC_PTR(dre);
 	if (dre == NULL)
 		return -DER_NOMEM;
 
 	dre->dre_epoch = ent->ie_epoch;
-	dre->dre_xid = ent->ie_xid;
-	dre->dre_oid = ent->ie_oid;
-	dre->dre_hash = ent->ie_dtx_hash;
+	dre->dre_xid = ent->ie_dtx_xid;
+	dre->dre_oid = ent->ie_dtx_oid;
 	d_list_add_tail(&dre->dre_link, &dra->tables.drh_list);
 	dra->tables.drh_count++;
 
@@ -308,7 +284,7 @@ dtx_iter_cb(uuid_t co_uuid, vos_iter_entry_t *ent, void *args)
 
 int
 dtx_resync(daos_handle_t po_hdl, uuid_t po_uuid, uuid_t co_uuid, uint32_t ver,
-	   bool block)
+	   bool block, bool resync_all)
 {
 	struct ds_cont_child		*cont = NULL;
 	struct dtx_resync_args		 dra = { 0 };
@@ -341,15 +317,17 @@ dtx_resync(daos_handle_t po_hdl, uuid_t po_uuid, uuid_t co_uuid, uint32_t ver,
 		goto out;
 	}
 	cont->sc_dtx_resyncing = 1;
+	cont->sc_dtx_resync_ver = ver;
 	ABT_mutex_unlock(cont->sc_mutex);
-
-	rc = vos_dtx_update_resync_gen(cont->sc_hdl);
-	if (rc != 0)
-		goto fail;
 
 	dra.cont = cont;
 	uuid_copy(dra.po_uuid, po_uuid);
 	dra.version = ver;
+	dra.epoch = crt_hlc_get();
+	if (resync_all)
+		dra.resync_all = 1;
+	else
+		dra.resync_all = 0;
 	D_INIT_LIST_HEAD(&dra.tables.drh_list);
 	dra.tables.drh_count = 0;
 
@@ -368,7 +346,6 @@ dtx_resync(daos_handle_t po_hdl, uuid_t po_uuid, uuid_t co_uuid, uint32_t ver,
 	if (rc >= 0)
 		rc = rc1;
 
-fail:
 	D_DEBUG(DB_TRACE, "resync DTX scan "DF_UUID"/"DF_UUID" stop: rc = %d\n",
 		DP_UUID(po_uuid), DP_UUID(co_uuid), rc);
 
@@ -382,9 +359,9 @@ out:
 	return rc;
 }
 
-struct container_scan_arg {
-	uuid_t	co_uuid;
-	struct dtx_resync_arg *arg;
+struct dtx_container_scan_arg {
+	uuid_t			 co_uuid;
+	struct dtx_scan_args	*arg;
 };
 
 static int
@@ -392,8 +369,8 @@ container_scan_cb(daos_handle_t ih, vos_iter_entry_t *entry,
 		  vos_iter_type_t type, vos_iter_param_t *iter_param,
 		  void *data, unsigned *acts)
 {
-	struct container_scan_arg	*scan_arg = data;
-	struct dtx_resync_arg		*arg = scan_arg->arg;
+	struct dtx_container_scan_arg	*scan_arg = data;
+	struct dtx_scan_args		*arg = scan_arg->arg;
 	int				rc;
 
 	if (uuid_compare(scan_arg->co_uuid, entry->ie_couuid) == 0) {
@@ -404,7 +381,7 @@ container_scan_cb(daos_handle_t ih, vos_iter_entry_t *entry,
 
 	uuid_copy(scan_arg->co_uuid, entry->ie_couuid);
 	rc = dtx_resync(iter_param->ip_hdl, arg->pool_uuid, entry->ie_couuid,
-			arg->version, true);
+			arg->version, true, false);
 	if (rc)
 		D_ERROR(DF_UUID" dtx resync failed: rc %d\n",
 			DP_UUID(arg->pool_uuid), rc);
@@ -418,12 +395,12 @@ container_scan_cb(daos_handle_t ih, vos_iter_entry_t *entry,
 static int
 dtx_resync_one(void *data)
 {
-	struct dtx_resync_arg	*arg = data;
-	struct ds_pool_child	*child;
-	vos_iter_param_t	param = { 0 };
-	struct vos_iter_anchors	anchor = { 0 };
-	struct container_scan_arg cb_arg = { 0 };
-	int			rc;
+	struct dtx_scan_args		*arg = data;
+	struct ds_pool_child		*child;
+	vos_iter_param_t		 param = { 0 };
+	struct vos_iter_anchors		 anchor = { 0 };
+	struct dtx_container_scan_arg	 cb_arg = { 0 };
+	int				 rc;
 
 	child = ds_pool_child_lookup(arg->pool_uuid);
 	if (child == NULL)
@@ -446,7 +423,7 @@ out:
 void
 dtx_resync_ult(void *data)
 {
-	struct dtx_resync_arg	*arg = data;
+	struct dtx_scan_args	*arg = data;
 	struct ds_pool		*pool;
 	int			rc = 0;
 

--- a/src/dtx/dtx_rpc.c
+++ b/src/dtx/dtx_rpc.c
@@ -567,15 +567,16 @@ out:
  * then call DTX commit locally. For a DTX, it is possible that some targets
  * have committed successfully, but others failed. That is no matter. As long
  * as one target has committed, then the DTX logic can re-sync those failed
- * targets when dtx_resync() is triggered next time
+ * targets when dtx_resync() is triggered next time.
  */
 int
 dtx_commit(uuid_t po_uuid, uuid_t co_uuid, struct dtx_entry *dtes,
-	   int count, uint32_t version)
+	   int count, uint32_t version, bool drop_cos)
 {
 	struct dtx_req_args	 dra;
 	struct ds_cont_child	*cont = NULL;
 	struct dtx_id		*dti = NULL;
+	struct dtx_cos_key	*dcks = NULL;
 	struct umem_attr	 uma;
 	struct btr_root		 tree_root = { 0 };
 	daos_handle_t		 tree_hdl = DAOS_HDL_INVAL;
@@ -610,10 +611,29 @@ dtx_commit(uuid_t po_uuid, uuid_t co_uuid, struct dtx_entry *dtes,
 			goto out;
 	}
 
-	rc1 = vos_dtx_commit(cont->sc_hdl, dti, count);
+	if (drop_cos) {
+		D_ALLOC_ARRAY(dcks, count);
+		if (dcks == NULL)
+			D_GOTO(out, rc1 = -DER_NOMEM);
+	}
+
+	rc1 = vos_dtx_commit(cont->sc_hdl, dti, count, dcks);
+
 	/* -DER_NONEXIST may be caused by race or repeated commit, ignore it. */
 	if (rc1 == -DER_NONEXIST)
 		rc1 = 0;
+
+	if (rc1 > 0 && drop_cos) {
+		int	i;
+
+		for (i = 0; i < rc1; i++) {
+			if (!daos_oid_is_null(dcks[i].oid.id_pub))
+				dtx_del_cos(cont, &dti[i], &dcks[i].oid,
+					    dcks[i].dkey_hash);
+		}
+	}
+
+	D_FREE(dcks);
 
 	if (dra.dra_future != ABT_FUTURE_NULL) {
 		rc2 = dtx_req_wait(&dra);
@@ -622,12 +642,11 @@ dtx_commit(uuid_t po_uuid, uuid_t co_uuid, struct dtx_entry *dtes,
 	}
 
 out:
-	D_CDEBUG(rc != 0 || rc1 != 0 || rc2 != 0, DLOG_ERR, DB_TRACE,
+	D_CDEBUG(rc < 0 || rc1 < 0 || rc2 < 0, DLOG_ERR, DB_TRACE,
 		 "Commit DTXs "DF_DTI", count %d: rc %d %d %d\n",
 		 DP_DTI(&dtes[0].dte_xid), count, rc, rc1, rc2);
 
-	if (dti != NULL)
-		D_FREE(dti);
+	D_FREE(dti);
 
 	if (!daos_handle_is_inval(tree_hdl))
 		dbtree_destroy(tree_hdl, NULL);
@@ -653,8 +672,6 @@ dtx_abort(uuid_t po_uuid, uuid_t co_uuid, daos_epoch_t epoch,
 	d_list_t		 head;
 	int			 length;
 	int			 rc;
-	int			 rc1 = 0;
-	int			 rc2 = 0;
 
 	rc = ds_cont_child_lookup(po_uuid, co_uuid, &cont);
 	if (rc != 0)
@@ -675,31 +692,28 @@ dtx_abort(uuid_t po_uuid, uuid_t co_uuid, daos_epoch_t epoch,
 
 	D_ASSERT(dti != NULL);
 
-	dra.dra_future = ABT_FUTURE_NULL;
-	if (!d_list_empty(&head)) {
+	/* Local abort firstly. */
+	rc = vos_dtx_abort(cont->sc_hdl, epoch, dti, count);
+	if (rc == -DER_NONEXIST)
+		rc = 0;
+
+	if (rc == 0 && !d_list_empty(&head)) {
 		rc = dtx_req_list_send(&dra, DTX_ABORT, &head, length, po_uuid,
 				       co_uuid, epoch);
 		if (rc != 0)
 			goto out;
-	}
 
-	rc1 = vos_dtx_abort(cont->sc_hdl, epoch, dti, count);
-	if (rc1 == -DER_NONEXIST)
-		rc1 = 0;
-
-	if (dra.dra_future != ABT_FUTURE_NULL) {
-		rc2 = dtx_req_wait(&dra);
-		if (rc2 == -DER_NONEXIST)
-			rc2 = 0;
+		rc = dtx_req_wait(&dra);
+		if (rc == -DER_NONEXIST)
+			rc = 0;
 	}
 
 out:
-	D_CDEBUG(rc != 0 || rc1 != 0 || rc2 != 0, DLOG_ERR, DB_TRACE,
-		 "Abort DTXs "DF_DTI", count %d: rc %d %d %d\n",
-		 DP_DTI(&dtes[0].dte_xid), count, rc, rc1, rc2);
+	D_CDEBUG(rc != 0, DLOG_ERR, DB_TRACE,
+		 "Abort DTXs "DF_DTI", count %d: rc %d\n",
+		 DP_DTI(&dtes[0].dte_xid), count, rc);
 
-	if (dti != NULL)
-		D_FREE(dti);
+	D_FREE(dti);
 
 	if (!daos_handle_is_inval(tree_hdl))
 		dbtree_destroy(tree_hdl, NULL);
@@ -709,7 +723,7 @@ out:
 	if (cont != NULL)
 		ds_cont_child_put(cont);
 
-	return rc < 0 ? rc : (rc1 < 0 ? rc1 : (rc2 < 0 ? rc2 : 0));
+	return rc < 0 ? rc : 0;
 }
 
 int

--- a/src/dtx/dtx_srv.c
+++ b/src/dtx/dtx_srv.c
@@ -64,8 +64,8 @@ dtx_handler(crt_rpc_t *rpc)
 				count = din->di_dtx_array.ca_count - i;
 
 			dtis = (struct dtx_id *)din->di_dtx_array.ca_arrays + i;
-			rc1 = vos_dtx_commit(cont->sc_hdl, dtis, count);
-			if (rc == 0 && rc1 != 0)
+			rc1 = vos_dtx_commit(cont->sc_hdl, dtis, count, NULL);
+			if (rc == 0 && rc1 < 0)
 				rc = rc1;
 
 			i += count;
@@ -91,7 +91,8 @@ dtx_handler(crt_rpc_t *rpc)
 			rc = -DER_PROTO;
 		else
 			rc = vos_dtx_check(cont->sc_hdl,
-					   din->di_dtx_array.ca_arrays);
+					   din->di_dtx_array.ca_arrays,
+					   NULL, NULL, false);
 		break;
 	default:
 		rc = -DER_INVAL;
@@ -119,8 +120,13 @@ dtx_init(void)
 {
 	int	rc;
 
-	rc = dbtree_class_register(DBTREE_CLASS_DTX_CF, BTR_FEAT_UINT_KEY,
+	rc = dbtree_class_register(DBTREE_CLASS_DTX_CF,
+				   BTR_FEAT_UINT_KEY | BTR_FEAT_DYNAMIC_ROOT,
 				   &dbtree_dtx_cf_ops);
+	if (rc == 0)
+		rc = dbtree_class_register(DBTREE_CLASS_DTX_COS, 0,
+					   &dtx_btr_cos_ops);
+
 	return rc;
 }
 

--- a/src/include/daos/btree_class.h
+++ b/src/include/daos/btree_class.h
@@ -110,4 +110,9 @@ extern btr_ops_t dbtree_recx_ops;
  */
 #define DBTREE_CLASS_DTX_CF (DBTREE_DSM_BEGIN + 6)
 
+/**
+ * The key is dtx_cos_key: oid + dkey_hash
+ */
+#define DBTREE_CLASS_DTX_COS (DBTREE_DSM_BEGIN + 7)
+
 #endif /* __DAOS_SRV_BTREE_CLASS_H__ */

--- a/src/include/daos_srv/container.h
+++ b/src/include/daos_srv/container.h
@@ -102,6 +102,16 @@ struct ds_cont_child {
 	uint64_t		*sc_snapshots;
 	uint32_t		 sc_snapshots_nr;
 	uint32_t		 sc_open;
+
+	uint64_t		 sc_dtx_committable_count;
+	/* The objects with committable DTXs in DRAM. */
+	daos_handle_t		 sc_dtx_cos_hdl;
+	/* The DTX COS-btree. */
+	struct btr_root		 sc_dtx_cos_btr;
+	/* The global list for committable DTXs. */
+	d_list_t		 sc_dtx_cos_list;
+	/* The pool map version for the latest DTX resync on the container. */
+	uint32_t		 sc_dtx_resync_ver;
 };
 
 /*

--- a/src/include/daos_srv/dtx_srv.h
+++ b/src/include/daos_srv/dtx_srv.h
@@ -31,13 +31,6 @@
 #include <daos_srv/pool.h>
 #include <daos_srv/container.h>
 
-struct dtx_entry {
-	/** The identifier of the DTX */
-	struct dtx_id		dte_xid;
-	/** The identifier of the modified object (shard). */
-	daos_unit_oid_t		dte_oid;
-};
-
 /**
  * DAOS two-phase commit transaction handle in DRAM.
  */
@@ -55,20 +48,14 @@ struct dtx_handle {
 	daos_handle_t			 dth_coh;
 	/** The epoch# for the DTX. */
 	daos_epoch_t			 dth_epoch;
-	/* The generation when the DTX is handled on the server. */
-	uint64_t			 dth_gen;
-	/** The {obj/dkey/akey}-tree records that are created
-	 * by other DTXs, but not ready for commit yet.
-	 */
-	d_list_t			 dth_shares;
 	/* The hash of the dkey to be modified if applicable */
 	uint64_t			 dth_dkey_hash;
 	/** Pool map version. */
 	uint32_t			 dth_ver;
 	/** The intent of related modification. */
 	uint32_t			 dth_intent;
+
 	uint32_t			 dth_sync:1, /* commit synchronously. */
-					 dth_leader:1, /* leader replica. */
 					 /* Only one participator in the DTX. */
 					 dth_solo:1,
 					 /* dti_cos has been committed. */
@@ -76,15 +63,16 @@ struct dtx_handle {
 					 /* Modified shared items: object/key */
 					 dth_modify_shared:1,
 					 /* The DTX entry is in active table. */
-					 dth_actived:1;
+					 dth_active:1;
+
 	/* The count the DTXs in the dth_dti_cos array. */
 	uint32_t			 dth_dti_cos_count;
 	/* The array of the DTXs for Commit on Share (conflcit). */
 	struct dtx_id			*dth_dti_cos;
 	/** Pointer to the DTX entry in DRAM. */
 	void				*dth_ent;
-	/** The address (offset) of the (new) object to be modified. */
-	umem_off_t			 dth_obj;
+	/** The flags, see dtx_entry_flags. */
+	uint16_t			 dth_flags;
 	/** Modification sequence in the distributed transaction. */
 	uint16_t			 dth_op_seq;
 };
@@ -133,9 +121,10 @@ enum dtx_status {
 };
 
 int
-dtx_leader_begin(struct dtx_id *dti, daos_unit_oid_t *oid, daos_handle_t coh,
-		 daos_epoch_t epoch, uint64_t dkey_hash, uint32_t pm_ver,
-		 uint32_t intent, struct daos_shard_tgt *tgts, int tgts_cnt,
+dtx_leader_begin(struct ds_cont_child *cont, struct dtx_id *dti,
+		 daos_epoch_t epoch, uint32_t pm_ver,
+		 daos_unit_oid_t *oid, uint64_t dkey_hash, uint32_t intent,
+		 struct daos_shard_tgt *tgts, int tgt_cnt,
 		 struct dtx_leader_handle *dlh);
 int
 dtx_leader_end(struct dtx_leader_handle *dlh, struct ds_cont_child *cont,
@@ -146,16 +135,13 @@ typedef void (*dtx_sub_comp_cb_t)(struct dtx_leader_handle *dlh, int idx,
 typedef int (*dtx_sub_func_t)(struct dtx_leader_handle *dlh, void *arg, int idx,
 			      dtx_sub_comp_cb_t comp_cb);
 
-int dtx_resync(daos_handle_t po_hdl, uuid_t po_uuid, uuid_t co_uuid,
-	       uint32_t ver, bool block);
 int
-dtx_begin(struct dtx_id *dti, daos_unit_oid_t *oid, daos_handle_t coh,
-	  daos_epoch_t epoch, uint64_t dkey_hash, struct dtx_id *dti_cos,
-	  int dti_cos_cnt, uint32_t pm_ver, uint32_t intent,
-	  struct dtx_handle *dth);
+dtx_begin(struct ds_cont_child *cont, struct dtx_id *dti,
+	  daos_epoch_t epoch, uint32_t pm_ver,
+	  daos_unit_oid_t *oid, uint64_t dkey_hash, uint32_t intent,
+	  struct dtx_id *dti_cos, int dti_cos_cnt, struct dtx_handle *dth);
 int
-dtx_end(struct dtx_handle *dth, struct ds_cont_hdl *cont_hdl,
-	struct ds_cont_child *cont, int result);
+dtx_end(struct dtx_handle *dth, struct ds_cont_child *cont, int result);
 
 int dtx_leader_exec_ops(struct dtx_leader_handle *dth, dtx_sub_func_t exec_func,
 			void *func_arg);
@@ -164,19 +150,18 @@ int dtx_batched_commit_register(struct ds_cont_child *cont);
 
 void dtx_batched_commit_deregister(struct ds_cont_child *cont);
 
-int dtx_obj_sync(uuid_t po_uuid, uuid_t co_uuid, daos_handle_t coh,
-		 daos_unit_oid_t oid, daos_epoch_t epoch, uint32_t map_ver);
+int dtx_obj_sync(uuid_t po_uuid, uuid_t co_uuid, struct ds_cont_child *cont,
+		 daos_unit_oid_t *oid, daos_epoch_t epoch, uint32_t map_ver);
 
 /**
  * Check whether the given DTX is resent one or not.
  *
  * \param coh		[IN]	Container open handle.
- * \param oid		[IN]	Pointer to the object ID.
  * \param xid		[IN]	Pointer to the DTX identifier.
- * \param dkey_hash	[IN]	The hashed dkey.
  * \param epoch		[IN,OUT] Pointer to current epoch, if it is zero and
  *				 if the DTX exists, then the DTX's epoch will
  *				 be saved in it.
+ * \param mp_ver	[OUT]	Hold the DTX pool map version.
  *
  * \return		0		means that the DTX has been 'prepared',
  *					so the local modification has been done
@@ -187,9 +172,8 @@ int dtx_obj_sync(uuid_t po_uuid, uuid_t co_uuid, daos_handle_t coh,
  *					processed with different epoch.
  *			Other negative value if error.
  */
-int dtx_handle_resend(daos_handle_t coh, daos_unit_oid_t *oid,
-		      struct dtx_id *dti, uint64_t dkey_hash,
-		      daos_epoch_t *epoch);
+int dtx_handle_resend(daos_handle_t coh, struct dtx_id *dti,
+		      daos_epoch_t *epoch, uint32_t *pm_ver);
 
 /* XXX: The higher 48 bits of HLC is the wall clock, the lower bits are for
  *	logic clock that will be hidden when divided by NSEC_PER_SEC.
@@ -200,12 +184,13 @@ dtx_hlc_age2sec(uint64_t hlc)
 	return (crt_hlc_get() - hlc) / NSEC_PER_SEC;
 }
 
-struct dtx_resync_arg {
+struct dtx_scan_args {
 	uuid_t		pool_uuid;
 	uint32_t	version;
 };
 
-/* resync all dtx inside the pool */
-void
-dtx_resync_ult(void *arg);
+int dtx_resync(daos_handle_t po_hdl, uuid_t po_uuid, uuid_t co_uuid,
+	       uint32_t ver, bool block, bool resync_all);
+void dtx_resync_ult(void *arg);
+
 #endif /* __DAOS_DTX_SRV_H__ */

--- a/src/include/daos_srv/vos.h
+++ b/src/include/daos_srv/vos.h
@@ -38,95 +38,16 @@
 #include <daos_srv/vos_types.h>
 
 /**
- * Refresh the DTX resync generation.
- *
- * \param coh	[IN]	Container open handle.
- *
- * \return		Zero on success.
- * \return		Negative value if error.
- */
-int
-vos_dtx_update_resync_gen(daos_handle_t coh);
-
-/**
- * Add the given DTX to the Commit-on-Share (CoS) cache (in DRAM).
+ * Check the specified DTX's status, and related epoch, pool map version
+ * information if required.
  *
  * \param coh		[IN]	Container open handle.
- * \param oid		[IN]	The target object (shard) ID.
- * \param dti		[IN]	The DTX identifier.
- * \param dkey_hash	[IN]	The hashed dkey.
- * \param epoch		[IN]	The DTX epoch.
- * \param gen		[IN]	The DTX generation.
- * \param flags		[IN]	See dtx_cos_flags.
- *
- * \return		Zero on success, negative value if error.
- */
-int
-vos_dtx_add_cos(daos_handle_t coh, daos_unit_oid_t *oid, struct dtx_id *dti,
-		uint64_t dkey_hash, daos_epoch_t epoch, uint64_t gen,
-		uint32_t flags);
-
-/**
- * Search the specified DTX is in the CoS cache or not.
- *
- * \param coh		[IN]	Container open handle.
- * \param oid		[IN]	Pointer to the object ID.
  * \param xid		[IN]	Pointer to the DTX identifier.
- * \param dkey_hash	[IN]	The hashed dkey.
- *
- * \return	0 if the DTX exists in the CoS cache.
- * \return	-DER_NONEXIST if not in the CoS cache.
- * \return	Other negative values on error.
- */
-int
-vos_dtx_lookup_cos(daos_handle_t coh, daos_unit_oid_t *oid,
-		   struct dtx_id *xid, uint64_t dkey_hash);
-
-/**
- * Fetch the list of the DTXs to be committed because of (potential) share.
- *
- * \param coh		[IN]	Container open handle.
- * \param oid		[IN]	The target object (shard) ID.
- * \param dkey_hash	[IN]	The hashed dkey.
- * \param max		[IN]	The max size of the array for DTX entries.
- * \param dtis		[OUT]	The DTX IDs array to be committed for share.
- *
- * \return			The count of DTXs to be committed for share
- *				on success, negative value if error.
- */
-int
-vos_dtx_list_cos(daos_handle_t coh, daos_unit_oid_t *oid, uint64_t dkey_hash,
-		 int max, struct dtx_id **dtis);
-
-/**
- * Fetch the list of the DTXs that can be committed.
- *
- * \param coh		[IN]	Container open handle.
- * \param max_cnt	[IN]	The max size of the array for DTX entries.
- * \param oid		[IN]	Only return the DTXs belong to the specified
- *				object if it is non-NULL.
- * \param epoch		[IN]	Only return the DTXs that is not newer than
- *				the specified epoch.
- * \param dtes		[OUT]	The array for DTX entries can be committed.
- *
- * \return		Positve value for the @dtes array size.
- *			Negative value on failure.
- */
-int
-vos_dtx_fetch_committable(daos_handle_t coh, uint32_t max_cnt,
-			  daos_unit_oid_t *oid, daos_epoch_t epoch,
-			  struct dtx_entry **dtes);
-
-/**
- * Check whether the given DTX is resent one or not.
- *
- * \param coh		[IN]	Container open handle.
- * \param oid		[IN]	Pointer to the object ID.
- * \param xid		[IN]	Pointer to the DTX identifier.
- * \param dkey_hash	[IN]	The hashed dkey.
  * \param epoch		[IN,OUT] Pointer to current epoch, if it is zero and
  *				 if the DTX exists, then the DTX's epoch will
  *				 be saved in it.
+ * \param pm_ver	[OUT]	Hold the DTX's pool map version.
+ * \param for_resent	[IN]	The check is for check resent or not.
  *
  * \return		DTX_ST_PREPARED	means that the DTX has been 'prepared',
  *					so the local modification has been done
@@ -134,29 +55,14 @@ vos_dtx_fetch_committable(daos_handle_t coh, uint32_t max_cnt,
  *			DTX_ST_COMMITTED means the DTX has been committed.
  *			-DER_MISMATCH	means that the DTX has ever been
  *					processed with different epoch.
+ *			-DER_AGAIN means DTX re-index is in processing, not sure
+ *				   about the existence of the DTX entry, need to
+ *				   retry sometime later.
  *			Other negative value if error.
  */
 int
-vos_dtx_check_resend(daos_handle_t coh, daos_unit_oid_t *oid,
-		     struct dtx_id *dti, uint64_t dkey_hash,
-		     daos_epoch_t *epoch);
-
-/**
- * Check the specified DTX's persistent status.
- *
- * \param coh		[IN]	Container open handle.
- * \param xid		[IN]	Pointer to the DTX identifier.
- *
- * \return		DTX_ST_PREPARED	means that the DTX has been 'prepared',
- *					so the local modification has been done
- *					on related replica(s). If all replicas
- *					have 'prepared', then the whole DTX is
- *					committable.
- *			DTX_ST_COMMITTED means the DTX has been committed.
- *			Negative value if error.
- */
-int
-vos_dtx_check(daos_handle_t coh, struct dtx_id *dti);
+vos_dtx_check(daos_handle_t coh, struct dtx_id *dti, daos_epoch_t *epoch,
+	      uint32_t *pm_ver, bool for_resent);
 
 /**
  * Commit the specified DTXs.
@@ -164,14 +70,15 @@ vos_dtx_check(daos_handle_t coh, struct dtx_id *dti);
  * \param coh	[IN]	Container open handle.
  * \param dtis	[IN]	The array for DTX identifiers to be committed.
  * \param count [IN]	The count of DTXs to be committed.
+ * \param dcks	[OUT]	The array to hold the OID and dkey hash corresponding to
+ *			the committed DTXs array for subsequent CoS handling.
  *
- * \return		Positive value to ask the caller to aggregate
- *			some old DTXs.
- * \return		Zero on success (no additional action required).
  * \return		Negative value if error.
+ * \return		Others are for the count of committed DTXs.
  */
 int
-vos_dtx_commit(daos_handle_t coh, struct dtx_id *dtis, int count);
+vos_dtx_commit(daos_handle_t coh, struct dtx_id *dtis, int count,
+	       struct dtx_cos_key *dcks);
 
 /**
  * Abort the specified DTXs.
@@ -198,13 +105,21 @@ int
 vos_dtx_aggregate(daos_handle_t coh);
 
 /**
- * Query the container's DTXs information.
+ * Query the container's DTXs statistics information.
  *
  * \param coh	[IN]	Container open handle.
  * \param stat	[OUT]	The structure to hold the DTXs information.
  */
 void
 vos_dtx_stat(daos_handle_t coh, struct dtx_stat *stat);
+
+/**
+ * Set the DTX committable as committable.
+ *
+ * \param dth	[IN]	Pointer to the DTX handle.
+ */
+void
+vos_dtx_mark_committable(struct dtx_handle *dth);
 
 /**
  * Check the latest sync epoch against the specified object.

--- a/src/include/daos_srv/vos_types.h
+++ b/src/include/daos_srv/vos_types.h
@@ -35,6 +35,25 @@ enum dtx_cos_flags {
 	DCF_SHARED	= (1 << 0),
 };
 
+struct dtx_cos_key {
+	daos_unit_oid_t		oid;
+	uint64_t		dkey_hash;
+};
+
+enum dtx_entry_flags {
+	/* The DTX is the leader */
+	DTE_LEADER		= (1 << 0),
+	/* The DTX entry is invalid. */
+	DTE_INVALID		= (1 << 1),
+};
+
+struct dtx_entry {
+	/** The identifier of the DTX */
+	struct dtx_id		dte_xid;
+	/** The identifier of the modified object (shard). */
+	daos_unit_oid_t		dte_oid;
+};
+
 enum vos_oi_attr {
 	/** Marks object as failed */
 	VOS_OI_FAILED		= (1U << 0),
@@ -294,20 +313,10 @@ typedef struct {
 			/** Non-zero if punched */
 			daos_epoch_t		ie_punch;
 			union {
-				/** dkey or akey */
-				struct {
-					/** key value */
-					daos_key_t		ie_key;
-				};
-				/** object or DTX entry */
-				struct {
-					/** The DTX identifier. */
-					struct dtx_id		ie_xid;
-					/** oid */
-					daos_unit_oid_t		ie_oid;
-					/* The dkey hash for DTX iteration. */
-					uint64_t		ie_dtx_hash;
-				};
+				/** key value */
+				daos_key_t	ie_key;
+				/** oid */
+				daos_unit_oid_t	ie_oid;
 			};
 		};
 		/** Array entry */
@@ -324,6 +333,17 @@ typedef struct {
 			struct dcs_csum_info	ie_csum;
 			/** pool map version */
 			uint32_t		ie_ver;
+		};
+		/** Active DTX entry. */
+		struct {
+			/** The DTX identifier. */
+			struct dtx_id		ie_dtx_xid;
+			/** The OID. */
+			daos_unit_oid_t		ie_dtx_oid;
+			/** The pool map version when handling DTX on server. */
+			uint32_t		ie_dtx_ver;
+			/* The dkey hash for DTX iteration. */
+			uint16_t		ie_dtx_flags;
 		};
 	};
 	/* Flags to describe the entry */

--- a/src/pool/srv_target.c
+++ b/src/pool/srv_target.c
@@ -978,7 +978,7 @@ ds_pool_tgt_map_update(struct ds_pool *pool, struct pool_buf *buf,
 	}
 
 	if (update_map) {
-		struct dtx_resync_arg *arg;
+		struct dtx_scan_args	*arg;
 		int ret;
 
 		/* Since the map has been updated successfully, so let's

--- a/src/vos/SConscript
+++ b/src/vos/SConscript
@@ -5,7 +5,7 @@ import daos_build
 FILES = ["evt_iter.c", "vos_common.c", "vos_iterator.c", "vos_io.c",
          "vos_pool.c", "vos_aggregate.c", "vos_container.c", "vos_obj.c",
          "vos_obj_cache.c", "vos_obj_index.c", "vos_tree.c", "evtree.c",
-         "vos_dtx.c", "vos_dtx_cos.c", "vos_query.c", "vos_overhead.c",
+         "vos_dtx.c", "vos_query.c", "vos_overhead.c",
          "vos_dtx_iter.c", "vos_gc.c", "vos_ilog.c", "ilog.c", "vos_ts.c",
          "lru_array.c"]
 

--- a/src/vos/tests/vts_dtx.c
+++ b/src/vos/tests/vts_dtx.c
@@ -31,134 +31,6 @@
 #include <daos_srv/dtx_srv.h>
 #include "vts_io.h"
 
-static void
-vts_dtx_cos(void **state, bool shared)
-{
-	struct io_test_args	*args = *state;
-	struct vos_container	*cont;
-	struct dtx_id		 xid;
-	uint64_t		 dkey_hash = lrand48();
-	int			 rc;
-
-	daos_dti_gen(&xid, false);
-
-	/* Insert a DTX into CoS cache. */
-	rc = vos_dtx_add_cos(args->ctx.tc_co_hdl, &args->oid, &xid,
-			     dkey_hash, DAOS_EPOCH_MAX - 1, 0,
-			     shared ? DCF_SHARED : 0);
-	assert_int_equal(rc, 0);
-
-	/* Query the DTX different dkey hash will find nothing. */
-	rc = vos_dtx_lookup_cos(args->ctx.tc_co_hdl, &args->oid, &xid,
-				dkey_hash + 1);
-	assert_int_equal(rc, -DER_NONEXIST);
-
-	rc = vos_dtx_lookup_cos(args->ctx.tc_co_hdl, &args->oid, &xid,
-				dkey_hash);
-	assert_int_equal(rc, 0);
-
-	cont = vos_hdl2cont(args->ctx.tc_co_hdl);
-	/* Remove the DTX from CoS cache. */
-	vos_dtx_del_cos(cont, &args->oid, &xid, dkey_hash);
-	rc = vos_dtx_lookup_cos(args->ctx.tc_co_hdl, &args->oid, &xid,
-				dkey_hash);
-	assert_int_equal(rc, -DER_NONEXIST);
-}
-
-/* DTX CoS cache insert/delete/query without shared items. */
-static void
-dtx_1(void **state)
-{
-	vts_dtx_cos(state, false);
-}
-
-/* DTX CoS cache insert/delete/query with shared items. */
-static void
-dtx_2(void **state)
-{
-	vts_dtx_cos(state, true);
-}
-
-/* DTX CoS cache list */
-static void
-dtx_3(void **state)
-{
-	struct io_test_args	*args = *state;
-	struct dtx_id		*dti_cos = NULL;
-	struct dtx_id		 xid;
-	struct dtx_stat		 stat = { 0 };
-	uint64_t		 dkey_hash = lrand48();
-	int			 flags[2];
-	int			 rc;
-	int			 i;
-
-	flags[0] = 0;
-	flags[1] = DCF_SHARED;
-
-	for (i = 0; i < 11; i++) {
-		daos_dti_gen(&xid, false);
-
-		rc = vos_dtx_add_cos(args->ctx.tc_co_hdl, &args->oid, &xid,
-				     dkey_hash, DAOS_EPOCH_MAX - 1, 0,
-				     flags[i % 2]);
-		assert_int_equal(rc, 0);
-	}
-
-	rc = vos_dtx_list_cos(args->ctx.tc_co_hdl, &args->oid, dkey_hash,
-			      100, &dti_cos);
-	/* xid[1,3,5,7,9] */
-	assert_int_equal(rc, 5);
-	D_FREE(dti_cos);
-
-	vos_dtx_stat(args->ctx.tc_co_hdl, &stat);
-	assert_int_equal(stat.dtx_committable_count, 11);
-}
-
-/* DTX CoS cache fetch committable */
-static void
-dtx_4(void **state)
-{
-	struct io_test_args	*args = *state;
-	struct dtx_entry	*dtes = NULL;
-	struct dtx_id		 xid[10];
-	uint64_t		 dkey_hash;
-	int			 flags[2];
-	int			 rc;
-	int			 i;
-
-	flags[0] = 0;
-	flags[1] = DCF_SHARED;
-
-	for (i = 0; i < 10; i++) {
-		daos_dti_gen(&xid[i], false);
-		dkey_hash = lrand48();
-
-		rc = vos_dtx_add_cos(args->ctx.tc_co_hdl, &args->oid, &xid[i],
-				     dkey_hash, DAOS_EPOCH_MAX - 1, 0,
-				     flags[i % 2]);
-		assert_int_equal(rc, 0);
-	}
-
-	rc = vos_dtx_fetch_committable(args->ctx.tc_co_hdl, 100, NULL,
-				       DAOS_EPOCH_MAX, &dtes);
-	assert_int_equal(rc, 10);
-
-	for (i = 0; i < 10; i++) {
-		int	j;
-
-		for (j = 0; j < 10; j++) {
-			if (daos_dti_equal(&xid[j], &dtes[i].dte_xid)) {
-				daos_dti_gen(&xid[j], true);
-				break;
-			}
-		}
-
-		assert_true(j < 10);
-	}
-
-	D_FREE(dtes);
-}
-
 static int
 vts_dtx_begin(struct dtx_id *xid, daos_unit_oid_t *oid, daos_handle_t coh,
 	      daos_epoch_t epoch, uint64_t dkey_hash, uint32_t intent,
@@ -174,20 +46,18 @@ vts_dtx_begin(struct dtx_id *xid, daos_unit_oid_t *oid, daos_handle_t coh,
 	dth->dth_oid = *oid;
 	dth->dth_coh = coh;
 	dth->dth_epoch = epoch;
-	D_INIT_LIST_HEAD(&dth->dth_shares);
 	dth->dth_dkey_hash = dkey_hash;
 	dth->dth_ver = 1; /* init version */
 	dth->dth_intent = intent;
 	dth->dth_dti_cos = NULL;
 	dth->dth_dti_cos_count = 0;
-	dth->dth_leader = 1;
 	dth->dth_ent = NULL;
-	dth->dth_obj = UMOFF_NULL;
 	dth->dth_sync = 0;
 	dth->dth_solo = 0;
 	dth->dth_dti_cos_done = 0;
 	dth->dth_modify_shared = 0;
-	dth->dth_actived = 0;
+	dth->dth_active = 0;
+	dth->dth_flags = DTE_LEADER;
 	dth->dth_op_seq = 1;
 
 	*dthp = dth;
@@ -251,65 +121,6 @@ vts_dtx_prep_update(struct io_test_args *args, struct dtx_id *xid,
 	iod->iod_nr = 1;
 }
 
-/* remove DTX from CoS cache after commit */
-static void
-dtx_5(void **state)
-{
-	struct io_test_args		*args = *state;
-	struct dtx_handle		*dth = NULL;
-	struct dtx_id			 xid;
-	struct dtx_stat			 stat = { 0 };
-	daos_iod_t			 iod = { 0 };
-	d_sg_list_t			 sgl = { 0 };
-	daos_recx_t			 rex = { 0 };
-	daos_key_t			 dkey;
-	daos_key_t			 akey;
-	d_iov_t				 dkey_iov;
-	d_iov_t				 val_iov;
-	uint64_t			 epoch;
-	uint64_t			 dkey_hash;
-	uint64_t			 saved_committable;
-	uint64_t			 saved_committed;
-	char				 dkey_buf[UPDATE_DKEY_SIZE];
-	char				 akey_buf[UPDATE_AKEY_SIZE];
-	char				 update_buf[UPDATE_BUF_SIZE];
-	int				 rc;
-
-
-	vts_dtx_prep_update(args, &xid, &val_iov, &dkey_iov, &dkey, dkey_buf,
-			    &akey, akey_buf, &iod, &sgl, &rex, update_buf,
-			    UPDATE_BUF_SIZE, UPDATE_REC_SIZE, &dkey_hash,
-			    &epoch, false);
-
-	/* Assume I am the leader. */
-	rc = vts_dtx_begin(&xid, &args->oid, args->ctx.tc_co_hdl, epoch,
-			   dkey_hash, DAOS_INTENT_UPDATE, &dth);
-	assert_int_equal(rc, 0);
-
-	rc = io_test_obj_update(args, epoch, 0, &dkey, &iod, &sgl, dth, true);
-	assert_int_equal(rc, 0);
-
-	/* The DTX is 'prepared'. */
-	vts_dtx_end(dth);
-
-	/* Add former DTX into CoS cache. */
-	rc = vos_dtx_add_cos(args->ctx.tc_co_hdl, &args->oid, &xid,
-			     dkey_hash, epoch, 0, 0);
-	assert_int_equal(rc, 0);
-
-	vos_dtx_stat(args->ctx.tc_co_hdl, &stat);
-	saved_committable = stat.dtx_committable_count;
-	saved_committed = stat.dtx_committed_count;
-
-	/* Commit former DTX that will be removed from the CoS cache. */
-	rc = vos_dtx_commit(args->ctx.tc_co_hdl, &xid, 1);
-	assert_int_equal(rc, 0);
-
-	vos_dtx_stat(args->ctx.tc_co_hdl, &stat);
-	assert_true(saved_committable == stat.dtx_committable_count + 1);
-	assert_true(saved_committed == stat.dtx_committed_count - 1);
-}
-
 static void
 vts_dtx_commit_visibility(struct io_test_args *args, bool ext, bool punch_obj)
 {
@@ -357,8 +168,8 @@ vts_dtx_commit_visibility(struct io_test_args *args, bool ext, bool punch_obj)
 	assert_memory_not_equal(update_buf, fetch_buf, UPDATE_BUF_SIZE);
 
 	/* Commit the update DTX. */
-	rc = vos_dtx_commit(args->ctx.tc_co_hdl, &xid, 1);
-	assert_int_equal(rc, 0);
+	rc = vos_dtx_commit(args->ctx.tc_co_hdl, &xid, 1, NULL);
+	assert_int_equal(rc, 1);
 
 	memset(fetch_buf, 0, UPDATE_BUF_SIZE);
 	d_iov_set(&val_iov, fetch_buf, UPDATE_BUF_SIZE);
@@ -400,8 +211,8 @@ vts_dtx_commit_visibility(struct io_test_args *args, bool ext, bool punch_obj)
 	assert_memory_equal(update_buf, fetch_buf, UPDATE_BUF_SIZE);
 
 	/* Commit the punch DTX. */
-	rc = vos_dtx_commit(args->ctx.tc_co_hdl, &xid, 1);
-	assert_int_equal(rc, 0);
+	rc = vos_dtx_commit(args->ctx.tc_co_hdl, &xid, 1, NULL);
+	assert_int_equal(rc, 1);
 
 	memset(fetch_buf, 0, UPDATE_BUF_SIZE);
 	d_iov_set(&val_iov, fetch_buf, UPDATE_BUF_SIZE);
@@ -602,11 +413,11 @@ dtx_14(void **state)
 	vts_dtx_end(dth);
 
 	/* Commit the DTX. */
-	rc = vos_dtx_commit(args->ctx.tc_co_hdl, &xid, 1);
-	assert_int_equal(rc, 0);
+	rc = vos_dtx_commit(args->ctx.tc_co_hdl, &xid, 1, NULL);
+	assert_int_equal(rc, 1);
 
 	/* Double commit the DTX is harmless. */
-	vos_dtx_commit(args->ctx.tc_co_hdl, &xid, 1);
+	vos_dtx_commit(args->ctx.tc_co_hdl, &xid, 1, NULL);
 
 	memset(fetch_buf, 0, UPDATE_BUF_SIZE);
 	d_iov_set(&val_iov, fetch_buf, UPDATE_BUF_SIZE);
@@ -700,7 +511,7 @@ dtx_15(void **state)
 	assert_memory_equal(update_buf1, fetch_buf, UPDATE_BUF_SIZE);
 
 	/* Aborted DTX cannot be committed. */
-	vos_dtx_commit(args->ctx.tc_co_hdl, &xid, 1);
+	vos_dtx_commit(args->ctx.tc_co_hdl, &xid, 1, NULL);
 
 	memset(fetch_buf, 0, UPDATE_BUF_SIZE);
 	d_iov_set(&val_iov, fetch_buf, UPDATE_BUF_SIZE);
@@ -737,8 +548,6 @@ dtx_16(void **state)
 	char				 fetch_buf[UPDATE_BUF_SIZE];
 	int				 rc;
 
-	skip();
-
 	vts_dtx_prep_update(args, &xid, &val_iov, &dkey_iov, &dkey, dkey_buf,
 			    &akey, akey_buf, &iod, &sgl, &rex, update_buf,
 			    UPDATE_BUF_SIZE, UPDATE_REC_SIZE, &dkey_hash,
@@ -750,9 +559,6 @@ dtx_16(void **state)
 
 	rc = io_test_obj_update(args, epoch, 0, &dkey, &iod, &sgl, dth, true);
 	assert_int_equal(rc, 0);
-
-	/* The DTX is 'prepared'. */
-	vts_dtx_end(dth);
 
 	daos_fail_loc_set(DAOS_VOS_NON_LEADER | DAOS_FAIL_ALWAYS);
 
@@ -773,10 +579,11 @@ dtx_16(void **state)
 	/* Former DTX is not committed, so nothing can be fetched. */
 	assert_memory_not_equal(update_buf, fetch_buf, UPDATE_BUF_SIZE);
 
-	/* Insert a DTX into CoS cache. */
-	rc = vos_dtx_add_cos(args->ctx.tc_co_hdl, &args->oid, &xid,
-			     dkey_hash, epoch, 0, 0);
-	assert_int_equal(rc, 0);
+	/* Mark the DTX as committable. */
+	vos_dtx_mark_committable(dth);
+
+	/* The DTX is 'prepared'. */
+	vts_dtx_end(dth);
 
 	/* Fetch again. */
 	rc = io_test_obj_fetch(args, epoch, 0, &dkey, &iod, &sgl, true);
@@ -785,9 +592,9 @@ dtx_16(void **state)
 	/* The DTX in CoS cache will make related data record as readable. */
 	assert_memory_equal(update_buf, fetch_buf, UPDATE_BUF_SIZE);
 
-	/* Commit the fisrt 4 DTXs. */
-	rc = vos_dtx_commit(args->ctx.tc_co_hdl, &xid, 1);
-	assert_int_equal(rc, 0);
+	/* Commit the DTX. */
+	rc = vos_dtx_commit(args->ctx.tc_co_hdl, &xid, 1, NULL);
+	assert_int_equal(rc, 1);
 
 }
 
@@ -848,8 +655,6 @@ dtx_17(void **state)
 	int				 rc;
 	int				 i;
 
-	skip();
-
 	/* Assume I am the leader. */
 	for (i = 0; i < 10; i++) {
 		struct dtx_handle		*dth = NULL;
@@ -878,8 +683,8 @@ dtx_17(void **state)
 	}
 
 	/* Commit the fisrt 4 DTXs. */
-	rc = vos_dtx_commit(args->ctx.tc_co_hdl, xid, 4);
-	assert_int_equal(rc, 0);
+	rc = vos_dtx_commit(args->ctx.tc_co_hdl, xid, 4, NULL);
+	assert_int_equal(rc, 4);
 
 	param.ip_hdl = args->ctx.tc_co_hdl;
 	param.ip_ih = DAOS_HDL_INVAL;
@@ -905,8 +710,8 @@ dtx_17(void **state)
 	}
 
 	/* Commit the others. */
-	rc = vos_dtx_commit(args->ctx.tc_co_hdl, &xid[4], 6);
-	assert_int_equal(rc, 0);
+	rc = vos_dtx_commit(args->ctx.tc_co_hdl, &xid[4], 6, NULL);
+	assert_int_equal(rc, 6);
 
 	memset(&anchors, 0, sizeof(anchors));
 	vdid.count = 10;
@@ -965,11 +770,12 @@ dtx_18(void **state)
 	}
 
 	/* Commit all DTXs. */
-	rc = vos_dtx_commit(args->ctx.tc_co_hdl, xid, 10);
-	assert_int_equal(rc, 0);
+	rc = vos_dtx_commit(args->ctx.tc_co_hdl, xid, 10, NULL);
+	assert_int_equal(rc, 10);
 
 	for (i = 0; i < 10; i++) {
-		rc = vos_dtx_check(args->ctx.tc_co_hdl, &xid[i]);
+		rc = vos_dtx_check(args->ctx.tc_co_hdl, &xid[i],
+				   NULL, NULL, false);
 		assert_int_equal(rc, DTX_ST_COMMITTED);
 	}
 
@@ -980,7 +786,8 @@ dtx_18(void **state)
 	assert_int_equal(rc, 0);
 
 	for (i = 0; i < 10; i++) {
-		rc = vos_dtx_check(args->ctx.tc_co_hdl, &xid[i]);
+		rc = vos_dtx_check(args->ctx.tc_co_hdl, &xid[i],
+				   NULL, NULL, false);
 		assert_int_equal(rc, -DER_NONEXIST);
 	}
 
@@ -995,490 +802,6 @@ dtx_18(void **state)
 	assert_memory_equal(update_buf, fetch_buf, UPDATE_BUF_SIZE);
 }
 
-static void
-vts_dtx_shares(struct io_test_args *args, int *commit_list, int commit_count,
-	       int *abort_list, int abort_count, bool commit_first)
-{
-	struct dtx_handle		*dth = NULL;
-	struct dtx_id			 xid[5];
-	daos_iod_t			 iod[5];
-	d_sg_list_t			 sgl[5];
-	daos_recx_t			 rex[5];
-	daos_key_t			 dkey;
-	daos_key_t			 akey[5];
-	d_iov_t				 val_iov;
-	d_iov_t				 dkey_iov;
-	uint64_t			 epoch[5];
-	uint64_t			 dkey_hash;
-	char				 dkey_buf[UPDATE_DKEY_SIZE];
-	char				*akey_buf[5];
-	char				*update_buf[5];
-	char				 fetch_buf[UPDATE_BUF_SIZE];
-	int				 rc;
-	int				 i;
-
-	skip();
-
-	assert_true(commit_count + abort_count == 5);
-
-	akey_buf[0] = malloc(UPDATE_AKEY_SIZE);
-	assert_true(akey_buf[0] != NULL);
-
-	update_buf[0] = malloc(UPDATE_BUF_SIZE);
-	assert_true(update_buf[0] != NULL);
-
-	vts_dtx_prep_update(args, &xid[0], &val_iov, &dkey_iov, &dkey, dkey_buf,
-			    &akey[0], akey_buf[0], &iod[0], &sgl[0], &rex[0],
-			    update_buf[0], UPDATE_BUF_SIZE, UPDATE_REC_SIZE,
-			    &dkey_hash, &epoch[0], false);
-
-	/* Assume I am the leader. */
-	rc = vts_dtx_begin(&xid[0], &args->oid, args->ctx.tc_co_hdl, epoch[0],
-			   dkey_hash, DAOS_INTENT_UPDATE, &dth);
-	assert_int_equal(rc, 0);
-
-	rc = io_test_obj_update(args, epoch[0], 0, &dkey, &iod[0], &sgl[0],
-				dth, true);
-	assert_int_equal(rc, 0);
-
-	vts_dtx_end(dth);
-
-	for (i = 1; i < 5; i++) {
-		akey_buf[i] = malloc(UPDATE_AKEY_SIZE);
-		assert_true(akey_buf[i] != NULL);
-
-		update_buf[i] = malloc(UPDATE_BUF_SIZE);
-		assert_true(update_buf[i] != NULL);
-
-		memset(&iod[i], 0, sizeof(iod[i]));
-		memset(&sgl[i], 0, sizeof(sgl[i]));
-		memset(&rex[i], 0, sizeof(rex[i]));
-
-		daos_dti_gen(&xid[i], false);
-		epoch[i] = crt_hlc_get();
-
-		dts_buf_render(update_buf[i], UPDATE_BUF_SIZE);
-		d_iov_set(&val_iov, update_buf[i], UPDATE_BUF_SIZE);
-
-		sgl[i].sg_iovs = &val_iov;
-		sgl[i].sg_nr = 1;
-
-		rex[i].rx_idx = hash_key(&dkey_iov,
-					 args->ofeat & DAOS_OF_DKEY_UINT64);
-		rex[i].rx_nr = 1;
-
-		vts_key_gen(akey_buf[i], args->akey_size, false, args);
-		set_iov(&akey[i], akey_buf[i],
-			args->ofeat & DAOS_OF_AKEY_UINT64);
-
-		iod[i].iod_name = akey[i];
-		iod[i].iod_type = DAOS_IOD_SINGLE;
-		iod[i].iod_size = UPDATE_BUF_SIZE;
-		iod[i].iod_recxs = &rex[i];
-		iod[i].iod_nr = 1;
-
-		rc = vts_dtx_begin(&xid[i], &args->oid, args->ctx.tc_co_hdl,
-				   epoch[i], dkey_hash,
-				   DAOS_INTENT_UPDATE, &dth);
-		assert_int_equal(rc, 0);
-
-		rc = io_test_obj_update(args, epoch[i], 0, &dkey, &iod[i],
-					&sgl[i], dth, true);
-		assert_int_equal(rc, 0);
-
-		vts_dtx_end(dth);
-	}
-
-	if (commit_first) {
-		for (i = 0; i < commit_count; i++) {
-			rc = vos_dtx_commit(args->ctx.tc_co_hdl,
-					    &xid[commit_list[i]], 1);
-			assert_int_equal(rc, 0);
-		}
-
-		for (i = 0; i < abort_count; i++) {
-			rc = vos_dtx_abort(args->ctx.tc_co_hdl,
-					   epoch[abort_list[i]],
-					   &xid[abort_list[i]], 1);
-			assert_int_equal(rc, 0);
-		}
-	} else {
-		for (i = 0; i < abort_count; i++) {
-			rc = vos_dtx_abort(args->ctx.tc_co_hdl,
-					   epoch[abort_list[i]],
-					   &xid[abort_list[i]], 1);
-			assert_int_equal(rc, 0);
-		}
-
-		for (i = 0; i < commit_count; i++) {
-			rc = vos_dtx_commit(args->ctx.tc_co_hdl,
-					    &xid[commit_list[i]], 1);
-			assert_int_equal(rc, 0);
-		}
-	}
-
-	for (i = 0; i < commit_count; i++) {
-		memset(fetch_buf, 0, UPDATE_BUF_SIZE);
-		d_iov_set(&val_iov, fetch_buf, UPDATE_BUF_SIZE);
-		iod[commit_list[i]].iod_size = DAOS_REC_ANY;
-
-		rc = io_test_obj_fetch(args, epoch[commit_list[i]], 0, &dkey,
-				       &iod[commit_list[i]],
-				       &sgl[commit_list[i]], true);
-		assert_int_equal(rc, 0);
-
-		assert_memory_equal(update_buf[commit_list[i]], fetch_buf,
-				    UPDATE_BUF_SIZE);
-	}
-
-	for (i = 0; i < abort_count; i++) {
-		memset(fetch_buf, 0, UPDATE_BUF_SIZE);
-		d_iov_set(&val_iov, fetch_buf, UPDATE_BUF_SIZE);
-		iod[abort_list[i]].iod_size = DAOS_REC_ANY;
-
-		rc = io_test_obj_fetch(args, epoch[abort_list[i]], 0, &dkey,
-				       &iod[abort_list[i]],
-				       &sgl[abort_list[i]], true);
-		assert_int_equal(rc, 0);
-
-		assert_memory_not_equal(update_buf[abort_list[i]], fetch_buf,
-					UPDATE_BUF_SIZE);
-	}
-
-	if (abort_count == 5) {
-		vos_iter_param_t		 param = { 0 };
-		struct vos_iter_anchors		 anchors = { 0 };
-		struct vts_dtx_iter_data	 vdid = { 0 };
-		bool				 found = false;
-
-		param.ip_hdl = args->ctx.tc_co_hdl;
-		param.ip_ih = DAOS_HDL_INVAL;
-		param.ip_oid = args->oid;
-		param.ip_epr.epr_lo = epoch[0];
-		param.ip_epr.epr_hi = epoch[4];
-		param.ip_epc_expr = VOS_IT_EPC_RE;
-
-		vdid.dkeys = (void **)&dkey_buf;
-		vdid.found = &found;
-		vdid.count = 1;
-
-		rc = vos_iterate(&param, VOS_ITER_DKEY, false, &anchors,
-				 vts_dtx_iter_cb, NULL, &vdid);
-		assert_int_equal(rc, 0);
-		assert_true(!found);
-	}
-
-	for (i = 0; i < 5; i++) {
-		free(akey_buf[i]);
-		free(update_buf[i]);
-	}
-}
-
-/* share DTX, all committed, commit the first DTX firstly */
-static void
-dtx_19(void **state)
-{
-	int	commit_list[5] = { 0, 1, 2, 3, 4 };
-
-	vts_dtx_shares(*state, commit_list, 5, NULL, 0, true);
-}
-
-/* share DTX, all committed, commit the first DTX lastly */
-static void
-dtx_20(void **state)
-{
-	int	commit_list[5] = { 1, 4, 2, 3, 0 };
-
-	vts_dtx_shares(*state, commit_list, 5, NULL, 0, true);
-}
-
-/* share DTX, all aborted, abort the first DTX firstly */
-static void
-dtx_21(void **state)
-{
-	int	abort_list[5] = { 0, 1, 2, 3, 4 };
-
-	vts_dtx_shares(*state, NULL, 0, abort_list, 5, false);
-}
-
-/* share DTX, all aborted, abort the first DTX lastly */
-static void
-dtx_22(void **state)
-{
-	int	abort_list[5] = { 1, 4, 2, 3, 0 };
-
-	vts_dtx_shares(*state, NULL, 0, abort_list, 5, false);
-}
-
-/* share DTX, some committed, the first DTX is committed firstly */
-static void
-dtx_23(void **state)
-{
-	int	commit_list[3] = { 0, 4, 2 };
-	int	abort_list[2] = { 1, 3 };
-
-	vts_dtx_shares(*state, commit_list, 3, abort_list, 2, true);
-}
-
-/* share DTX, some committed, the first DTX is committed,
- * but some DTX is aborted firstly
- */
-static void
-dtx_24(void **state)
-{
-	int	commit_list[3] = { 0, 4, 2 };
-	int	abort_list[2] = { 1, 3 };
-
-	vts_dtx_shares(*state, commit_list, 3, abort_list, 2, false);
-}
-
-/* share DTX, some committed, the first DTX is aborted firstly */
-static void
-dtx_25(void **state)
-{
-	int	commit_list[3] = { 1, 4, 2 };
-	int	abort_list[2] = { 0, 3 };
-
-	vts_dtx_shares(*state, commit_list, 3, abort_list, 2, false);
-}
-
-/* share DTX, some committed, the first DTX is aborted,
- * but some DTX is committed firstly
- */
-static void
-dtx_26(void **state)
-{
-	int	commit_list[3] = { 1, 4, 2 };
-	int	abort_list[2] = { 0, 3 };
-
-	vts_dtx_shares(*state, commit_list, 3, abort_list, 2, true);
-}
-
-static void
-vts_dtx_shares_with_punch(struct io_test_args *args, bool punch_obj, bool abort)
-{
-	struct dtx_handle		*dth = NULL;
-	struct dtx_id			 xid[4];
-	daos_iod_t			 iod[3];
-	d_sg_list_t			 sgl[3];
-	daos_recx_t			 rex[3];
-	daos_key_t			 dkey;
-	daos_key_t			 akey[3];
-	d_iov_t				 val_iov;
-	d_iov_t				 dkey_iov;
-	uint64_t			 epoch[4];
-	uint64_t			 dkey_hash;
-	char				 dkey_buf[UPDATE_DKEY_SIZE];
-	char				*akey_buf[3];
-	char				*update_buf[3];
-	char				 fetch_buf[UPDATE_BUF_SIZE];
-	int				 rc;
-	int				 i;
-
-	skip();
-
-	akey_buf[0] = malloc(UPDATE_AKEY_SIZE);
-	assert_true(akey_buf[0] != NULL);
-
-	update_buf[0] = malloc(UPDATE_BUF_SIZE);
-	assert_true(update_buf[0] != NULL);
-
-	vts_dtx_prep_update(args, &xid[0], &val_iov, &dkey_iov, &dkey, dkey_buf,
-			    &akey[0], akey_buf[0], &iod[0], &sgl[0], &rex[0],
-			    update_buf[0], UPDATE_BUF_SIZE, UPDATE_REC_SIZE,
-			    &dkey_hash, &epoch[0], false);
-
-	/* Assume I am the leader. */
-	rc = vts_dtx_begin(&xid[0], &args->oid, args->ctx.tc_co_hdl, epoch[0],
-			   dkey_hash, DAOS_INTENT_UPDATE, &dth);
-	assert_int_equal(rc, 0);
-
-	rc = io_test_obj_update(args, epoch[0], 0, &dkey, &iod[0], &sgl[0],
-				dth, true);
-	assert_int_equal(rc, 0);
-
-	vts_dtx_end(dth);
-
-	for (i = 1; i < 3; i++) {
-		akey_buf[i] = malloc(UPDATE_AKEY_SIZE);
-		assert_true(akey_buf[i] != NULL);
-
-		update_buf[i] = malloc(UPDATE_BUF_SIZE);
-		assert_true(update_buf[i] != NULL);
-
-		memset(&iod[i], 0, sizeof(iod[i]));
-		memset(&sgl[i], 0, sizeof(sgl[i]));
-		memset(&rex[i], 0, sizeof(rex[i]));
-
-		daos_dti_gen(&xid[i], false);
-		epoch[i] = crt_hlc_get();
-
-		dts_buf_render(update_buf[i], UPDATE_BUF_SIZE);
-		d_iov_set(&val_iov, update_buf[i], UPDATE_BUF_SIZE);
-
-		sgl[i].sg_iovs = &val_iov;
-		sgl[i].sg_nr = 1;
-
-		rex[i].rx_idx = hash_key(&dkey_iov,
-					 args->ofeat & DAOS_OF_DKEY_UINT64);
-		rex[i].rx_nr = 1;
-
-		vts_key_gen(akey_buf[i], args->akey_size, false, args);
-		set_iov(&akey[i], akey_buf[i],
-			args->ofeat & DAOS_OF_AKEY_UINT64);
-
-		iod[i].iod_name = akey[i];
-		iod[i].iod_type = DAOS_IOD_SINGLE;
-		iod[i].iod_size = UPDATE_BUF_SIZE;
-		iod[i].iod_recxs = &rex[i];
-		iod[i].iod_nr = 1;
-
-		rc = vts_dtx_begin(&xid[i], &args->oid, args->ctx.tc_co_hdl,
-				   epoch[i], dkey_hash,
-				   DAOS_INTENT_UPDATE, &dth);
-		assert_int_equal(rc, 0);
-
-		rc = io_test_obj_update(args, epoch[i], 0, &dkey, &iod[i],
-					&sgl[i], dth, true);
-		assert_int_equal(rc, 0);
-
-		vts_dtx_end(dth);
-	}
-
-	/* Commit the second update DTX firstly. */
-	rc = vos_dtx_commit(args->ctx.tc_co_hdl, &xid[1], 1);
-	assert_int_equal(rc, 0);
-
-	daos_dti_gen(&xid[3], false);
-	epoch[3] = crt_hlc_get();
-
-	rc = vts_dtx_begin(&xid[3], &args->oid, args->ctx.tc_co_hdl, epoch[3],
-			   dkey_hash, DAOS_INTENT_PUNCH, &dth);
-	assert_int_equal(rc, 0);
-
-	/* Punch the object or dkey. */
-	if (punch_obj)
-		rc = vos_obj_punch(args->ctx.tc_co_hdl, args->oid, epoch[3],
-				   1, 0, NULL, 0, NULL, dth);
-	else
-		rc = vos_obj_punch(args->ctx.tc_co_hdl, args->oid, epoch[3],
-				   1, 0, &dkey, 0, NULL, dth);
-	assert_int_equal(rc, 0);
-
-	vts_dtx_end(dth);
-
-	/* Abort or commit the punch DTX. */
-	if (abort)
-		rc = vos_dtx_abort(args->ctx.tc_co_hdl, epoch[3], &xid[3], 1);
-	else
-		rc = vos_dtx_commit(args->ctx.tc_co_hdl, &xid[3], 1);
-	assert_int_equal(rc, 0);
-
-	/* Abort the first update DTX. */
-	rc = vos_dtx_abort(args->ctx.tc_co_hdl, epoch[0], &xid[0], 1);
-	assert_int_equal(rc, 0);
-
-	/* Commit the third update DTX. */
-	rc = vos_dtx_commit(args->ctx.tc_co_hdl, &xid[2], 1);
-	assert_int_equal(rc, 0);
-
-	memset(fetch_buf, 0, UPDATE_BUF_SIZE);
-	d_iov_set(&val_iov, fetch_buf, UPDATE_BUF_SIZE);
-	iod[0].iod_size = DAOS_REC_ANY;
-
-	/* DTX[0] is aborted, so cannot be read even if against epoch[0] */
-	rc = io_test_obj_fetch(args, epoch[0], 0, &dkey, &iod[0], &sgl[0],
-			       true);
-	assert_int_equal(rc, 0);
-
-	assert_memory_not_equal(update_buf[0], fetch_buf, UPDATE_BUF_SIZE);
-
-	for (i = 1; i < 3; i++) {
-		memset(fetch_buf, 0, UPDATE_BUF_SIZE);
-		d_iov_set(&val_iov, fetch_buf, UPDATE_BUF_SIZE);
-		iod[i].iod_size = DAOS_REC_ANY;
-
-		/* DTX[i] is committed, so readable against its epoch[i] */
-		rc = io_test_obj_fetch(args, epoch[i], 0, &dkey, &iod[i],
-				       &sgl[i], true);
-		assert_int_equal(rc, 0);
-
-		assert_memory_equal(update_buf[i], fetch_buf, UPDATE_BUF_SIZE);
-	}
-
-	if (abort) {
-		memset(fetch_buf, 0, UPDATE_BUF_SIZE);
-		d_iov_set(&val_iov, fetch_buf, UPDATE_BUF_SIZE);
-		iod[0].iod_size = DAOS_REC_ANY;
-
-		rc = io_test_obj_fetch(args, ++epoch[3], 0, &dkey, &iod[0],
-				       &sgl[0], true);
-		assert_int_equal(rc, 0);
-
-		assert_memory_not_equal(update_buf[0], fetch_buf,
-					UPDATE_BUF_SIZE);
-
-		for (i = 1; i < 3; i++) {
-			memset(fetch_buf, 0, UPDATE_BUF_SIZE);
-			d_iov_set(&val_iov, fetch_buf, UPDATE_BUF_SIZE);
-			iod[i].iod_size = DAOS_REC_ANY;
-
-			rc = io_test_obj_fetch(args, ++epoch[3], 0, &dkey,
-					       &iod[i], &sgl[i], true);
-			assert_int_equal(rc, 0);
-
-			assert_memory_equal(update_buf[i], fetch_buf,
-					    UPDATE_BUF_SIZE);
-		}
-	} else {
-		for (i = 0; i < 3; i++) {
-			memset(fetch_buf, 0, UPDATE_BUF_SIZE);
-			d_iov_set(&val_iov, fetch_buf, UPDATE_BUF_SIZE);
-			iod[i].iod_size = DAOS_REC_ANY;
-
-			rc = io_test_obj_fetch(args, ++epoch[3], 0, &dkey,
-					       &iod[i], &sgl[i], true);
-			assert_int_equal(rc, 0);
-
-			assert_memory_not_equal(update_buf[i], fetch_buf,
-						UPDATE_BUF_SIZE);
-		}
-	}
-
-	for (i = 0; i < 3; i++) {
-		free(akey_buf[i]);
-		free(update_buf[i]);
-	}
-}
-
-/* punch obj during some shared DTXs, the punch is committed */
-static void
-dtx_27(void **state)
-{
-	vts_dtx_shares_with_punch(*state, true, false);
-}
-
-/* punch obj during some shared DTXs, the punch is aborted */
-static void
-dtx_28(void **state)
-{
-	vts_dtx_shares_with_punch(*state, true, true);
-}
-
-/* punch key during some shared DTXs, the punch is committed */
-static void
-dtx_29(void **state)
-{
-	vts_dtx_shares_with_punch(*state, false, false);
-}
-
-/* punch key during some shared DTXs, the punch is aborted */
-static void
-dtx_30(void **state)
-{
-	vts_dtx_shares_with_punch(*state, false, true);
-}
-
 static int
 dtx_tst_teardown(void **state)
 {
@@ -1487,16 +810,6 @@ dtx_tst_teardown(void **state)
 }
 
 static const struct CMUnitTest dtx_tests[] = {
-	{ "VOS501: update-DTX CoS cache insert/delete/query",
-	  dtx_1, NULL, dtx_tst_teardown },
-	{ "VOS502: punch-DTX CoS cache insert/delete/query",
-	  dtx_2, NULL, dtx_tst_teardown },
-	{ "VOS503: DTX CoS cache list",
-	  dtx_3, NULL, dtx_tst_teardown },
-	{ "VOS504: DTX CoS cache fetch committable",
-	  dtx_4, NULL, dtx_tst_teardown },
-	{ "VOS505: remove DTX from CoS cache after commit",
-	  dtx_5, NULL, dtx_tst_teardown },
 	{ "VOS506: DTX commit visibility (single value, punch key)",
 	  dtx_6, NULL, dtx_tst_teardown },
 	{ "VOS507: DTX commit visibility (extent value, punch key)",
@@ -1523,34 +836,6 @@ static const struct CMUnitTest dtx_tests[] = {
 	  dtx_17, NULL, dtx_tst_teardown },
 	{ "VOS518: DTX aggregation",
 	  dtx_18, NULL, dtx_tst_teardown },
-	{ "VOS519: share DTX, all committed, commit the first one firstly",
-	  dtx_19, NULL, dtx_tst_teardown },
-	{ "VOS520: share DTX, all committed, commit the first one lastly",
-	  dtx_20, NULL, dtx_tst_teardown },
-	{ "VOS521: share DTX, all aborted, abort the first DTX firstly",
-	  dtx_21, NULL, dtx_tst_teardown },
-	{ "VOS522: share DTX, all aborted, abort the first DTX lastly",
-	  dtx_22, NULL, dtx_tst_teardown },
-	{ "VOS523: share DTX, some committed, "
-		"the first DTX is committed firstly",
-	  dtx_23, NULL, dtx_tst_teardown },
-	{ "VOS524: share DTX, some committed, the first DTX is committed, "
-		"but some DTX is aborted firstly",
-	  dtx_24, NULL, dtx_tst_teardown },
-	{ "VOS525: share DTX, some committed, "
-		"the first DTX is aborted firstly",
-	  dtx_25, NULL, dtx_tst_teardown },
-	{ "VOS526: share DTX, some committed, the first DTX is aborted, "
-		"but some DTX is committed firstly",
-	  dtx_26, NULL, dtx_tst_teardown },
-	{ "VOS527: punch obj during some shared DTXs, the punch is committed",
-	  dtx_27, NULL, dtx_tst_teardown },
-	{ "VOS528: punch obj during some shared DTXs, the punch is aborted",
-	  dtx_28, NULL, dtx_tst_teardown },
-	{ "VOS529: punch key during some shared DTXs, the punch is committed",
-	  dtx_29, NULL, dtx_tst_teardown },
-	{ "VOS530: punch key during some shared DTXs, the punch is aborted",
-	  dtx_30, NULL, dtx_tst_teardown },
 };
 
 int

--- a/src/vos/vos_common.c
+++ b/src/vos/vos_common.c
@@ -265,12 +265,6 @@ vos_mod_init(void)
 		return rc;
 	}
 
-	rc = vos_dtx_cos_register();
-	if (rc != 0) {
-		D_ERROR("DTX CoS btree initialization error\n");
-		return rc;
-	}
-
 	/**
 	 * Registering the class for OI btree
 	 * and KV btree

--- a/src/vos/vos_container.c
+++ b/src/vos/vos_container.c
@@ -106,7 +106,6 @@ cont_df_rec_alloc(struct btr_instance *tins, d_iov_t *key_iov,
 
 	cont_df = umem_off2ptr(&tins->ti_umm, offset);
 	uuid_copy(cont_df->cd_id, ukey->uuid);
-	cont_df->cd_dtx_resync_gen = 1;
 
 	rc = dbtree_create_inplace_ex(VOS_BTR_OBJ_TABLE, 0, VOS_OBJ_ORDER,
 				      &pool->vp_uma, &cont_df->cd_obj_root,
@@ -191,8 +190,6 @@ cont_free_internal(struct vos_container *cont)
 
 	D_ASSERT(cont->vc_open_count == 0);
 
-	if (!daos_handle_is_inval(cont->vc_dtx_cos_hdl))
-		dbtree_destroy(cont->vc_dtx_cos_hdl, NULL);
 	if (!daos_handle_is_inval(cont->vc_dtx_active_hdl))
 		dbtree_destroy(cont->vc_dtx_active_hdl, NULL);
 	if (!daos_handle_is_inval(cont->vc_dtx_committed_hdl))
@@ -201,7 +198,6 @@ cont_free_internal(struct vos_container *cont)
 	if (cont->vc_dtx_array)
 		lrua_array_free(cont->vc_dtx_array);
 
-	D_ASSERT(d_list_empty(&cont->vc_dtx_committable_list));
 	D_ASSERT(d_list_empty(&cont->vc_dtx_committed_list));
 	D_ASSERT(d_list_empty(&cont->vc_dtx_committed_tmp_list));
 
@@ -383,14 +379,10 @@ vos_cont_open(daos_handle_t poh, uuid_t co_uuid, daos_handle_t *coh)
 	cont->vc_ts_idx = &cont->vc_cont_df->cd_ts_idx;
 	cont->vc_dtx_active_hdl = DAOS_HDL_INVAL;
 	cont->vc_dtx_committed_hdl = DAOS_HDL_INVAL;
-	cont->vc_dtx_cos_hdl = DAOS_HDL_INVAL;
-	D_INIT_LIST_HEAD(&cont->vc_dtx_committable_list);
 	D_INIT_LIST_HEAD(&cont->vc_dtx_committed_list);
 	D_INIT_LIST_HEAD(&cont->vc_dtx_committed_tmp_list);
-	cont->vc_dtx_committable_count = 0;
 	cont->vc_dtx_committed_count = 0;
 	cont->vc_dtx_committed_tmp_count = 0;
-	cont->vc_dtx_resync_gen = cont->vc_cont_df->cd_dtx_resync_gen;
 
 	/* Cache this btr object ID in container handle */
 	rc = dbtree_open_inplace_ex(&cont->vc_cont_df->cd_obj_root,
@@ -432,17 +424,6 @@ vos_cont_open(daos_handle_t poh, uuid_t co_uuid, daos_handle_t *coh)
 				      &cont->vc_dtx_committed_hdl);
 	if (rc != 0) {
 		D_ERROR("Failed to create DTX committed btree: rc = "DF_RC"\n",
-			DP_RC(rc));
-		D_GOTO(exit, rc);
-	}
-
-	rc = dbtree_create_inplace_ex(VOS_BTR_DTX_COS, 0,
-				      DTX_BTREE_ORDER, &uma,
-				      &cont->vc_dtx_cos_btr,
-				      DAOS_HDL_INVAL, cont,
-				      &cont->vc_dtx_cos_hdl);
-	if (rc != 0) {
-		D_ERROR("Failed to create DTX CoS btree: rc = "DF_RC"\n",
 			DP_RC(rc));
 		D_GOTO(exit, rc);
 	}
@@ -663,24 +644,6 @@ vos_cont_tab_register()
 	if (rc)
 		D_ERROR("dbtree create failed\n");
 	return rc;
-}
-
-int
-vos_dtx_update_resync_gen(daos_handle_t coh)
-{
-	struct vos_container	*cont;
-	struct vos_cont_df	*cont_df;
-
-	cont = vos_hdl2cont(coh);
-	D_ASSERT(cont != NULL);
-
-	cont_df = cont->vc_cont_df;
-	cont->vc_dtx_resync_gen = cont_df->cd_dtx_resync_gen + 1;
-	pmemobj_memcpy_persist(vos_cont2umm(cont)->umm_pool,
-			       &cont_df->cd_dtx_resync_gen,
-			       &cont->vc_dtx_resync_gen,
-			       sizeof(cont_df->cd_dtx_resync_gen));
-	return 0;
 }
 
 /** iterator for co_uuid */

--- a/src/vos/vos_dtx.c
+++ b/src/vos/vos_dtx.c
@@ -168,8 +168,7 @@ dtx_act_ent_free(struct btr_instance *tins, struct btr_record *rec,
 		D_ASSERT(dae != NULL);
 		*(struct vos_dtx_act_ent **)args = dae;
 	} else if (dae != NULL) {
-		if (dae->dae_records != NULL)
-			D_FREE(dae->dae_records);
+		D_FREE(dae->dae_records);
 		/** Only happens on destroy and the dae will be freed as part of
 		 *  destroying the lru array.
 		 */
@@ -196,7 +195,14 @@ static int
 dtx_act_ent_update(struct btr_instance *tins, struct btr_record *rec,
 		   d_iov_t *key, d_iov_t *val)
 {
-	D_ASSERTF(0, "Should never been called\n");
+	/* It is possible that when commit the DTX for the first time,
+	 * it failed at removing the DTX entry from active table, but
+	 * at that time the DTX entry has already been added into the
+	 * committed table that is in DRAM. Currently, we do not have
+	 * efficient way to recover such DRAM based btree structure,
+	 * so just keep it there. Then when we re-commit such DTX, we
+	 * may come here.
+	 */
 	return 0;
 }
 
@@ -341,7 +347,7 @@ vos_dtx_table_destroy(struct umem_instance *umm, struct vos_cont_df *cont_df)
 
 		for (i = 0; i < dbd->dbd_index; i++) {
 			dae_df = &dbd->dbd_active_data[i];
-			if (!(dae_df->dae_flags & DTX_EF_INVALID) &&
+			if (!(dae_df->dae_flags & DTE_INVALID) &&
 			    !umoff_is_null(dae_df->dae_rec_off))
 				umem_free(umm, dae_df->dae_rec_off);
 		}
@@ -468,7 +474,6 @@ dtx_rec_release(struct vos_container *cont, struct vos_dtx_act_ent *dae,
 					   abort);
 
 		D_FREE(dae->dae_records);
-		dae->dae_records = NULL;
 		dae->dae_rec_cap = 0;
 	}
 
@@ -488,7 +493,7 @@ dtx_rec_release(struct vos_container *cont, struct vos_dtx_act_ent *dae,
 		umem_tx_add_ptr(umm, &dae_df->dae_flags,
 				sizeof(dae_df->dae_flags));
 		/* Mark the DTX entry as invalid in SCM. */
-		dae_df->dae_flags = DTX_EF_INVALID;
+		dae_df->dae_flags = DTE_INVALID;
 
 		umem_tx_add_ptr(umm, &dbd->dbd_count, sizeof(dbd->dbd_count));
 		dbd->dbd_count--;
@@ -536,7 +541,8 @@ dtx_rec_release(struct vos_container *cont, struct vos_dtx_act_ent *dae,
 
 static int
 vos_dtx_commit_one(struct vos_container *cont, struct dtx_id *dti,
-		   daos_epoch_t epoch, struct vos_dtx_cmt_ent **dce_p)
+		   daos_epoch_t epoch, struct vos_dtx_cmt_ent **dce_p,
+		   struct dtx_cos_key *dck)
 {
 	struct vos_dtx_act_ent		*dae = NULL;
 	struct vos_dtx_cmt_ent		*dce = NULL;
@@ -557,7 +563,14 @@ vos_dtx_commit_one(struct vos_container *cont, struct dtx_id *dti,
 		rc = dbtree_lookup(cont->vc_dtx_active_hdl, &kiov, &riov);
 		if (rc == -DER_NONEXIST) {
 			rc = dbtree_lookup(cont->vc_dtx_committed_hdl,
-					   &kiov, NULL);
+					   &kiov, &riov);
+			if (rc == 0 && dck != NULL) {
+				dce = (struct vos_dtx_cmt_ent *)riov.iov_buf;
+				dck->oid = DCE_OID(dce);
+				dck->dkey_hash = DCE_DKEY_HASH(dce);
+				dce = NULL;
+			}
+
 			goto out;
 		}
 
@@ -571,8 +584,13 @@ vos_dtx_commit_one(struct vos_container *cont, struct dtx_id *dti,
 	if (dce == NULL)
 		D_GOTO(out, rc = -DER_NOMEM);
 
-	DCE_XID(dce) = *dti;
-	DCE_EPOCH(dce) = epoch != 0 ? epoch : DAE_EPOCH(dae);
+	if (dae != NULL) {
+		memcpy(&dce->dce_base.dce_common, &dae->dae_base.dae_common,
+		       sizeof(dce->dce_base.dce_common));
+	} else {
+		DCE_XID(dce) = *dti;
+		DCE_EPOCH(dce) = epoch;
+	}
 	dce->dce_reindex = 0;
 
 	d_iov_set(&riov, dce, sizeof(*dce));
@@ -582,18 +600,18 @@ vos_dtx_commit_one(struct vos_container *cont, struct dtx_id *dti,
 		goto out;
 
 	dtx_rec_release(cont, dae, false, &offset);
-	rc = vos_dtx_del_cos(cont, &DAE_OID(dae), dti, DAE_DKEY_HASH(dae));
-	if (rc != 0)
-		D_GOTO(out, rc);
 
-	/* If dbtree_delete() failed, the @dae will be left in the active DTX
-	 * table until close the container. It is harmless but waste some DRAM.
-	 */
 	rc = dbtree_delete(cont->vc_dtx_active_hdl, BTR_PROBE_BYPASS, &kiov,
 			   &dae);
 
-	if (rc == 0)
+	if (rc == 0) {
+		if (dck != NULL) {
+			dck->oid = DAE_OID(dae);
+			dck->dkey_hash = DAE_DKEY_HASH(dae);
+		}
+
 		dtx_evict_lid(cont, dae);
+	}
 
 	if (!umoff_is_null(offset))
 		umem_free(vos_cont2umm(cont), offset);
@@ -713,7 +731,6 @@ vos_dtx_alloc(struct umem_instance *umm, struct dtx_handle *dth)
 	D_ASSERT(cont != NULL);
 
 	cont_df = cont->vc_cont_df;
-	dth->dth_gen = cont->vc_dtx_resync_gen;
 
 	rc = lrua_allocx(cont->vc_dtx_array, &idx, dth->dth_epoch, &dae);
 	if (rc != 0) {
@@ -737,8 +754,8 @@ vos_dtx_alloc(struct umem_instance *umm, struct dtx_handle *dth)
 	DAE_OID(dae) = dth->dth_oid;
 	DAE_DKEY_HASH(dae) = dth->dth_dkey_hash;
 	DAE_EPOCH(dae) = dth->dth_epoch;
-	DAE_FLAGS(dae) = dth->dth_leader ? DTX_EF_LEADER : 0;
-	DAE_SRV_GEN(dae) = dth->dth_gen;
+	DAE_FLAGS(dae) = dth->dth_flags;
+	DAE_VER(dae) = dth->dth_ver;
 
 	/* Will be set as dbd::dbd_index via vos_dtx_prepared(). */
 	DAE_INDEX(dae) = -1;
@@ -757,7 +774,7 @@ vos_dtx_alloc(struct umem_instance *umm, struct dtx_handle *dth)
 			   DAOS_INTENT_UPDATE, &kiov, &riov);
 	if (rc == 0) {
 		dth->dth_ent = dae;
-		dth->dth_actived = 1;
+		dth->dth_active = 1;
 	}
 
 out:
@@ -821,8 +838,6 @@ vos_dtx_check_availability(struct umem_instance *umm, daos_handle_t coh,
 	struct dtx_handle		*dth = vos_dth_get();
 	struct vos_container		*cont;
 	struct vos_dtx_act_ent		*dae = NULL;
-	struct vos_dtx_act_ent_df	*dae_df = NULL;
-	int				 rc;
 	bool				 found;
 
 	switch (type) {
@@ -882,21 +897,13 @@ vos_dtx_check_availability(struct umem_instance *umm, daos_handle_t coh,
 		return ALB_AVAILABLE_CLEAN;
 	}
 
-	rc = vos_dtx_lookup_cos(coh, &DAE_OID(dae), &DAE_XID(dae),
-				DAE_DKEY_HASH(dae));
-	if (rc == 0)
+	if (dae->dae_committable)
 		return ALB_AVAILABLE_CLEAN;
-
-	if (rc != -DER_NONEXIST) {
-		D_ERROR("Failed to check CoS for DTX entry "DF_DTI"\n",
-			DP_DTI(&dae_df->dae_xid));
-		return rc;
-	}
 
 	/* The followings are for non-committable cases. */
 
 	if (intent == DAOS_INTENT_DEFAULT || intent == DAOS_INTENT_REBUILD) {
-		if (!(DAE_FLAGS(dae) & DTX_EF_LEADER) ||
+		if (!(DAE_FLAGS(dae) & DTE_LEADER) ||
 		    DAOS_FAIL_CHECK(DAOS_VOS_NON_LEADER)) {
 			/* Inavailable for rebuild case. */
 			if (intent == DAOS_INTENT_REBUILD)
@@ -974,7 +981,7 @@ vos_dtx_register_record(struct umem_instance *umm, umem_off_t record,
 	 * entry for handling resend case, nothing for active table.
 	 */
 	if (dth->dth_solo) {
-		dth->dth_actived = 1;
+		dth->dth_active = 1;
 		*tx_id = DTX_LID_COMMITTED;
 		return 0;
 	}
@@ -1040,7 +1047,7 @@ vos_dtx_deregister_record(struct umem_instance *umm, daos_handle_t coh,
 
 	dae_df = umem_off2ptr(umm, dae->dae_df_off);
 	if (daos_is_zero_dti(&dae_df->dae_xid) ||
-	    dae_df->dae_flags & DTX_EF_INVALID)
+	    dae_df->dae_flags & DTE_INVALID)
 		return;
 
 	if (DAE_REC_CNT(dae) > DTX_INLINE_REC_CNT)
@@ -1101,7 +1108,7 @@ vos_dtx_prepared(struct dtx_handle *dth)
 	struct umem_instance		*umm;
 	struct vos_dtx_blob_df		*dbd;
 
-	if (!dth->dth_actived)
+	if (!dth->dth_active)
 		return 0;
 
 	cont = vos_hdl2cont(dth->dth_coh);
@@ -1111,12 +1118,12 @@ vos_dtx_prepared(struct dtx_handle *dth)
 		int	rc;
 
 		rc = vos_dtx_commit_internal(cont, &dth->dth_xid, 1,
-					     dth->dth_epoch);
-		dth->dth_actived = 0;
-		if (rc == 0)
+					     dth->dth_epoch, NULL);
+		dth->dth_active = 0;
+		if (rc >= 0)
 			dth->dth_sync = 1;
 
-		return rc;
+		return rc > 0 ? 0 : rc;
 	}
 
 	dae = dth->dth_ent;
@@ -1174,8 +1181,9 @@ vos_dtx_prepared(struct dtx_handle *dth)
 	return 0;
 }
 
-static int
-do_vos_dtx_check(daos_handle_t coh, struct dtx_id *dti, daos_epoch_t *epoch)
+int
+vos_dtx_check(daos_handle_t coh, struct dtx_id *dti, daos_epoch_t *epoch,
+	      uint32_t *pm_ver, bool for_resent)
 {
 	struct vos_container	*cont;
 	struct vos_dtx_act_ent	*dae;
@@ -1191,12 +1199,18 @@ do_vos_dtx_check(daos_handle_t coh, struct dtx_id *dti, daos_epoch_t *epoch)
 	rc = dbtree_lookup(cont->vc_dtx_active_hdl, &kiov, &riov);
 	if (rc == 0) {
 		dae = (struct vos_dtx_act_ent *)riov.iov_buf;
+		if (dae->dae_committable)
+			return DTX_ST_COMMITTED;
+
 		if (epoch != NULL) {
 			if (*epoch == 0)
 				*epoch = DAE_EPOCH(dae);
 			else if (*epoch != DAE_EPOCH(dae))
 				return -DER_MISMATCH;
 		}
+
+		if (pm_ver != NULL)
+			*pm_ver = DAE_VER(dae);
 
 		return DTX_ST_PREPARED;
 	}
@@ -1207,46 +1221,15 @@ do_vos_dtx_check(daos_handle_t coh, struct dtx_id *dti, daos_epoch_t *epoch)
 			return DTX_ST_COMMITTED;
 	}
 
-	return rc;
-}
-
-int
-vos_dtx_check_resend(daos_handle_t coh, daos_unit_oid_t *oid,
-		     struct dtx_id *xid, uint64_t dkey_hash,
-		     daos_epoch_t *epoch)
-{
-	struct vos_container	*cont;
-	int			 rc;
-
-	rc = vos_dtx_lookup_cos(coh, oid, xid, dkey_hash);
-	if (rc == 0)
-		return DTX_ST_COMMITTED;
-
-	if (rc != -DER_NONEXIST)
-		return rc;
-
-	rc = do_vos_dtx_check(coh, xid, epoch);
-	if (rc != -DER_NONEXIST)
-		return rc;
-
-	cont = vos_hdl2cont(coh);
-	D_ASSERT(cont != NULL);
-
-	if (cont->vc_reindex_cmt_dtx)
+	if (rc == -DER_NONEXIST && for_resent && cont->vc_reindex_cmt_dtx)
 		rc = -DER_AGAIN;
 
 	return rc;
 }
 
 int
-vos_dtx_check(daos_handle_t coh, struct dtx_id *dti)
-{
-	return do_vos_dtx_check(coh, dti, NULL);
-}
-
-int
 vos_dtx_commit_internal(struct vos_container *cont, struct dtx_id *dtis,
-			int count, daos_epoch_t epoch)
+			int count, daos_epoch_t epoch, struct dtx_cos_key *dcks)
 {
 	struct vos_cont_df		*cont_df = cont->vc_cont_df;
 	struct umem_instance		*umm = vos_cont2umm(cont);
@@ -1290,7 +1273,7 @@ again:
 			 * DTXs. The left non-committed DTXs will be handled
 			 * next time.
 			 */
-			return committed > 0 ? 0 : -DER_NOMEM;
+			return committed > 0 ? committed : -DER_NOMEM;
 		}
 	} else {
 		dce_df = &dbd->dbd_commmitted_data[dbd->dbd_count];
@@ -1299,8 +1282,9 @@ again:
 	for (i = 0, j = 0; i < slots && rc1 == 0; i++, cur++) {
 		struct vos_dtx_cmt_ent	*dce = NULL;
 
-		rc = vos_dtx_commit_one(cont, &dtis[cur], epoch, &dce);
-		if (rc == 0 && dce != NULL)
+		rc = vos_dtx_commit_one(cont, &dtis[cur], epoch, &dce,
+					dcks != NULL ? &dcks[cur] : NULL);
+		if (rc == 0)
 			committed++;
 
 		if (rc == -DER_NONEXIST)
@@ -1332,7 +1316,7 @@ again:
 		dbd->dbd_count += j;
 
 	if (count == 0 || rc1 != 0)
-		return committed > 0 ? 0 : rc1;
+		return committed > 0 ? committed : rc1;
 
 	if (j < slots) {
 		slots -= j;
@@ -1347,7 +1331,7 @@ new_blob:
 	if (umoff_is_null(dbd_off)) {
 		D_ERROR("No space to store committed DTX %d "DF_DTI"\n",
 			count, DP_DTI(&dtis[cur]));
-		return committed > 0 ? 0 : -DER_NOSPACE;
+		return committed > 0 ? committed : -DER_NOSPACE;
 	}
 
 	dbd = umem_off2ptr(umm, dbd_off);
@@ -1365,7 +1349,7 @@ new_blob:
 		if (dce_df == NULL) {
 			D_ERROR("Not enough DRAM to commit "DF_DTI"\n",
 				DP_DTI(&dtis[cur]));
-			return committed > 0 ? 0 : -DER_NOMEM;
+			return committed > 0 ? committed : -DER_NOMEM;
 		}
 	} else {
 		dce_df = &dbd->dbd_commmitted_data[0];
@@ -1394,8 +1378,9 @@ new_blob:
 	for (i = 0, j = 0; i < count && rc1 == 0; i++, cur++) {
 		struct vos_dtx_cmt_ent	*dce = NULL;
 
-		rc = vos_dtx_commit_one(cont, &dtis[cur], epoch, &dce);
-		if (rc == 0 && dce != NULL)
+		rc = vos_dtx_commit_one(cont, &dtis[cur], epoch, &dce,
+					dcks != NULL ? &dcks[cur] : NULL);
+		if (rc == 0)
 			committed++;
 
 		if (rc == -DER_NONEXIST)
@@ -1419,13 +1404,15 @@ new_blob:
 
 	dbd->dbd_count = j;
 
-	return committed > 0 ? 0 : rc1;
+	return committed > 0 ? committed : rc1;
 }
 
 int
-vos_dtx_commit(daos_handle_t coh, struct dtx_id *dtis, int count)
+vos_dtx_commit(daos_handle_t coh, struct dtx_id *dtis, int count,
+	       struct dtx_cos_key *dcks)
 {
 	struct vos_container	*cont;
+	int			 committed = 0;
 	int			 rc;
 
 	cont = vos_hdl2cont(coh);
@@ -1434,11 +1421,12 @@ vos_dtx_commit(daos_handle_t coh, struct dtx_id *dtis, int count)
 	/* Commit multiple DTXs via single PMDK transaction. */
 	rc = umem_tx_begin(vos_cont2umm(cont), NULL);
 	if (rc == 0) {
-		rc = vos_dtx_commit_internal(cont, dtis, count, 0);
-		rc = umem_tx_end(vos_cont2umm(cont), rc);
+		committed = vos_dtx_commit_internal(cont, dtis, count, 0, dcks);
+		rc = umem_tx_end(vos_cont2umm(cont),
+				 committed > 0 ? 0 : committed);
 	}
 
-	return rc;
+	return rc < 0 ? rc : committed;
 }
 
 int
@@ -1550,8 +1538,6 @@ vos_dtx_stat(daos_handle_t coh, struct dtx_stat *stat)
 	cont = vos_hdl2cont(coh);
 	D_ASSERT(cont != NULL);
 
-	stat->dtx_committable_count = cont->vc_dtx_committable_count;
-	stat->dtx_oldest_committable_time = vos_dtx_cos_oldest(cont);
 	stat->dtx_committed_count = cont->vc_dtx_committed_count;
 	if (d_list_empty(&cont->vc_dtx_committed_list)) {
 		stat->dtx_oldest_committed_time = 0;
@@ -1561,6 +1547,18 @@ vos_dtx_stat(daos_handle_t coh, struct dtx_stat *stat)
 		dce = d_list_entry(cont->vc_dtx_committed_list.next,
 				   struct vos_dtx_cmt_ent, dce_committed_link);
 		stat->dtx_oldest_committed_time = DCE_EPOCH(dce);
+	}
+}
+
+void
+vos_dtx_mark_committable(struct dtx_handle *dth)
+{
+	struct vos_dtx_act_ent	*dae = dth->dth_ent;
+
+	if (dth->dth_active) {
+		D_ASSERT(dae != NULL);
+
+		dae->dae_committable = 1;
 	}
 }
 
@@ -1652,7 +1650,7 @@ vos_dtx_act_reindex(struct vos_container *cont)
 			int				 count;
 
 			dae_df = &dbd->dbd_active_data[i];
-			if (dae_df->dae_flags & DTX_EF_INVALID)
+			if (dae_df->dae_flags & DTE_INVALID)
 				continue;
 
 			if (daos_is_zero_dti(&dae_df->dae_xid)) {
@@ -1714,8 +1712,7 @@ insert:
 					   BTR_PROBE_EQ, DAOS_INTENT_UPDATE,
 					   &kiov, &riov);
 			if (rc != 0) {
-				if (dae->dae_records != NULL)
-					D_FREE(dae->dae_records);
+				D_FREE(dae->dae_records);
 				dtx_evict_lid(cont, dae);
 				goto out;
 			}
@@ -1815,7 +1812,7 @@ vos_dtx_cleanup_dth(struct dtx_handle *dth)
 	d_iov_t			 kiov;
 	int			 rc;
 
-	if (dth == NULL || !dth->dth_actived)
+	if (dth == NULL || !dth->dth_active)
 		return;
 
 	cont = vos_hdl2cont(dth->dth_coh);
@@ -1832,5 +1829,5 @@ vos_dtx_cleanup_dth(struct dtx_handle *dth)
 			dtx_evict_lid(cont, dae);
 	}
 
-	dth->dth_actived = 0;
+	dth->dth_active = 0;
 }

--- a/src/vos/vos_dtx_iter.c
+++ b/src/vos/vos_dtx_iter.c
@@ -141,10 +141,8 @@ dtx_iter_next(struct vos_iterator *iter)
 		D_ASSERT(rec_iov.iov_len == sizeof(struct vos_dtx_act_ent));
 		dae = (struct vos_dtx_act_ent *)rec_iov.iov_buf;
 
-		/* Only need to return the DTX that was handled before the
-		 * latest DTX resync.
-		 */
-		if (DAE_SRV_GEN(dae) < oiter->oit_cont->vc_dtx_resync_gen)
+		/* Skip committable ones. */
+		if (!dae->dae_committable)
 			break;
 	}
 
@@ -173,10 +171,11 @@ dtx_iter_fetch(struct vos_iterator *iter, vos_iter_entry_t *it_entry,
 	D_ASSERT(rec_iov.iov_len == sizeof(struct vos_dtx_act_ent));
 	dae = (struct vos_dtx_act_ent *)rec_iov.iov_buf;
 
-	it_entry->ie_xid = DAE_XID(dae);
-	it_entry->ie_oid = DAE_OID(dae);
 	it_entry->ie_epoch = DAE_EPOCH(dae);
-	it_entry->ie_dtx_hash = DAE_DKEY_HASH(dae);
+	it_entry->ie_dtx_xid = DAE_XID(dae);
+	it_entry->ie_dtx_oid = DAE_OID(dae);
+	it_entry->ie_dtx_ver = DAE_VER(dae);
+	it_entry->ie_dtx_flags = DAE_FLAGS(dae);
 
 	D_DEBUG(DB_IO, "DTX iterator fetch the one "DF_DTI"\n",
 		DP_DTI(&DAE_XID(dae)));

--- a/src/vos/vos_io.c
+++ b/src/vos/vos_io.c
@@ -1583,7 +1583,7 @@ vos_update_end(daos_handle_t ioh, uint32_t pm_ver, daos_key_t *dkey, int err,
 	if (dth != NULL && dth->dth_dti_cos_count > 0 &&
 	    dth->dth_dti_cos_done == 0) {
 		vos_dtx_commit_internal(ioc->ic_obj->obj_cont, dth->dth_dti_cos,
-					dth->dth_dti_cos_count, 0);
+					dth->dth_dti_cos_count, 0, NULL);
 		dth->dth_dti_cos_done = 1;
 	}
 

--- a/src/vos/vos_layout.h
+++ b/src/vos/vos_layout.h
@@ -145,49 +145,53 @@ enum vos_dtx_record_types {
 	DTX_RT_EVT	= 3,
 };
 
-enum vos_dtx_entry_flags {
-	/* The DTX is the leader */
-	DTX_EF_LEADER			= (1 << 0),
-	/* The DTX entry is invalid. */
-	DTX_EF_INVALID			= (1 << 1),
-};
-
 #define DTX_INLINE_REC_CNT	4
 #define DTX_REC_CAP_DEFAULT	4
 
-/** Active DTX entry on-disk layout in both SCM and DRAM. */
-struct vos_dtx_act_ent_df {
+struct vos_dtx_ent_common {
 	/** The DTX identifier. */
-	struct dtx_id			dae_xid;
-	/** The identifier of the modified object (shard). */
-	daos_unit_oid_t			dae_oid;
-	/** The hashed dkey if applicable. */
-	uint64_t			dae_dkey_hash;
+	struct dtx_id			dec_xid;
 	/** The epoch# for the DTX. */
-	daos_epoch_t			dae_epoch;
-	/** The server generation when handles the DTX. */
-	uint64_t			dae_srv_gen;
-	/** The allocated local id for the DTX entry */
-	uint32_t			dae_lid;
-	/** For 32-bits alignment. */
-	uint16_t			dae_padding;
-	/** The index in the current vos_dtx_blob_df. */
-	int16_t				dae_index;
-	/** The inlined dtx records. */
-	umem_off_t			dae_rec_inline[DTX_INLINE_REC_CNT];
-	/** DTX flags, see enum vos_dtx_entry_flags. */
-	uint32_t			dae_flags;
-	/** The DTX records count, including inline case. */
-	uint32_t			dae_rec_cnt;
-	/** The offset for the list of dtx records if out of inline. */
-	umem_off_t			dae_rec_off;
+	daos_epoch_t			dec_epoch;
+	/** The identifier of the modified object (shard). */
+	daos_unit_oid_t			dec_oid;
+	/** The hashed dkey if applicable. */
+	uint64_t			dec_dkey_hash;
 };
 
 /** Committed DTX entry on-disk layout in both SCM and DRAM. */
 struct vos_dtx_cmt_ent_df {
-	struct dtx_id			dce_xid;
-	daos_epoch_t			dce_epoch;
+	struct vos_dtx_ent_common	dce_common;
 };
+
+#define dce_xid		dce_common.dec_xid
+#define dce_epoch	dce_common.dec_epoch
+#define dce_oid		dce_common.dec_oid
+#define dce_dkey_hash	dce_common.dec_dkey_hash
+
+/** Active DTX entry on-disk layout in both SCM and DRAM. */
+struct vos_dtx_act_ent_df {
+	struct vos_dtx_ent_common	dae_common;
+	/** The allocated local id for the DTX entry */
+	uint32_t			dae_lid;
+	/** DTX flags, see enum dtx_entry_flags. */
+	uint16_t			dae_flags;
+	/** The index in the current vos_dtx_blob_df. */
+	int16_t				dae_index;
+	/** The inlined dtx records. */
+	umem_off_t			dae_rec_inline[DTX_INLINE_REC_CNT];
+	/** The DTX records count, including inline case. */
+	uint32_t			dae_rec_cnt;
+	/** For 64-bits alignment. */
+	uint32_t			dae_ver;
+	/** The offset for the list of dtx records if out of inline. */
+	umem_off_t			dae_rec_off;
+};
+
+#define dae_xid		dae_common.dec_xid
+#define dae_epoch	dae_common.dec_epoch
+#define dae_oid		dae_common.dec_oid
+#define dae_dkey_hash	dae_common.dec_dkey_hash
 
 struct vos_dtx_blob_df {
 	/** Magic number, can be used to distinguish active or committed DTX. */
@@ -229,7 +233,6 @@ enum vos_io_stream {
 struct vos_cont_df {
 	uuid_t				cd_id;
 	uint64_t			cd_nobjs;
-	uint64_t			cd_dtx_resync_gen;
 	uint32_t			cd_ts_idx;
 	uint32_t			cd_pad;
 	daos_size_t			cd_used;

--- a/src/vos/vos_obj.c
+++ b/src/vos/vos_obj.c
@@ -260,7 +260,7 @@ vos_obj_punch(daos_handle_t coh, daos_unit_oid_t oid, daos_epoch_t epoch,
 	if (dth != NULL && dth->dth_dti_cos_count > 0 &&
 	    dth->dth_dti_cos_done == 0) {
 		vos_dtx_commit_internal(cont, dth->dth_dti_cos,
-					dth->dth_dti_cos_count, 0);
+					dth->dth_dti_cos_count, 0, NULL);
 		dth->dth_dti_cos_done = 1;
 	}
 

--- a/src/vos/vos_tree.c
+++ b/src/vos/vos_tree.c
@@ -447,7 +447,7 @@ svt_rec_store(struct btr_instance *tins, struct btr_record *rec,
 	/** at this point, it's assumed that enough was allocated for the irec
 	 *  to hold a checksum of length csum->cs_len
 	 */
-	if (dth != NULL && dth->dth_leader &&
+	if (dth != NULL && dth->dth_flags & DTE_LEADER &&
 	    irec->ir_ex_addr.ba_type == DAOS_MEDIA_SCM &&
 	    DAOS_FAIL_CHECK(DAOS_VC_DIFF_REC)) {
 		void	*addr;


### PR DESCRIPTION
The Commit-on-Share (CoS) logic is special for DTX. Originally,
it was implemented inside VOS for the convenience of using it to
check modification visibility in VOS. But it makes the VOS logic
more complex. On the other hand, we will support the distributed
transaction soon, that may need more complex CoS handling. So we
decide move the CoS logic from VOS to DTX. That will simplify VOS
logic, and make the relationships among VOS, DTX and object to be
more clear.

After splitting the CoS cache from VOS, we use new mechanism to
resolve the modification visibility issue in VOS: the DTX leader
will mark 'committable' (via VOS API: vos_dtx_mark_committable)
on the DTX in-DRAM entry after inserting the DTX into CoS cache.
Such action is driven by DTX logic, from object layer perspective,
it is transparent. That is very lightweight operation, almost no
overhead comparing with original case of CoS cache in VOS.

Other changes:

1. Currently, not add sync mode DTX (such as DTX for updating
   EC object) in the CoS cache.

2. For the DTX that was started before DTX resync, the leader
   needs to check its local DTX statue before making the DTX
   as 'committable'. Becuase the DTX resync logic may aborted
   such DTX by race.

3. Optimize DTX resync logic to skip CoS cache check that can
   be replaced by the already called vos_dtx_check().

4. Remove stale DTX test cases from VOS local test set.

Signed-off-by: Fan Yong <fan.yong@intel.com>