### PR TITLE
DAOS-4490 control: Quiet DPDK logging on stderr

### DIFF
--- a/src/bio/bio_xstream.c
+++ b/src/bio/bio_xstream.c
@@ -204,6 +204,9 @@ bio_spdk_env_init(void)
 	if (nvme_glb.bd_shm_id != DAOS_NVME_SHMID_NONE)
 		opts.shm_id = nvme_glb.bd_shm_id;
 
+	/* quiet DPDK logging by setting level to ERROR */
+	opts.env_context = "--log-level=lib.eal:4";
+
 	rc = spdk_env_init(&opts);
 	if (opts.pci_whitelist != NULL)
 		D_FREE(opts.pci_whitelist);

--- a/src/control/lib/spdk/spdk.go
+++ b/src/control/lib/spdk/spdk.go
@@ -1,5 +1,5 @@
 //
-// (C) Copyright 2018-2019 Intel Corporation.
+// (C) Copyright 2018-2020 Intel Corporation.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -31,14 +31,15 @@ package spdk
 #cgo LDFLAGS: -lspdk_env_dpdk -lrte_mempool -lrte_mempool_ring -lrte_bus_pci
 #cgo LDFLAGS: -lrte_pci -lrte_ring -lrte_mbuf -lrte_eal -lrte_kvargs -ldl -lnuma
 
-#include "stdlib.h"
-#include "spdk/stdinc.h"
-#include "spdk/env.h"
+#include <stdlib.h>
+#include <spdk/stdinc.h>
+#include <spdk/env.h>
 */
 import "C"
 
 import (
 	"fmt"
+	"unsafe"
 )
 
 // ENV is the interface that provides SPDK environment management.
@@ -79,6 +80,9 @@ func (e *Env) InitSPDKEnv(shmID int) (err error) {
 	if shmID > 0 {
 		opts.shm_id = C.int(shmID)
 	}
+
+	// quiet DPDK EAL logging by setting log level to ERROR
+	opts.env_context = unsafe.Pointer(C.CString("--log-level=lib.eal:4"))
 
 	rc := C.spdk_env_init(opts)
 	if err = Rc2err("spdk_env_opts_init", rc); err != nil {


### PR DESCRIPTION
SPDK allows for DPDK config options to be passed in
via the env_context field of spdk_env_opts. We can
leverage this to override the default EAL loglevel
and quiet the informational messages on stderr that
are incorrectly logged as errors by the control plane.