### PR TITLE
DAOS-0000 vos: deduped update

### DIFF
--- a/src/include/daos_srv/bio.h
+++ b/src/include/daos_srv/bio.h
@@ -43,7 +43,8 @@ typedef struct {
 	uint16_t	ba_type;
 	/* Is the address a hole ? */
 	uint16_t	ba_hole;
-	uint32_t	ba_padding;
+	uint16_t	ba_dedup;
+	uint16_t	ba_padding;
 } bio_addr_t;
 
 /** Ensure this remains compatible */
@@ -279,7 +280,11 @@ bio_sgl_convert(struct bio_sglist *bsgl, d_sg_list_t *sgl)
 		struct bio_iov	*biov = &bsgl->bs_iovs[i];
 		d_iov_t	*iov = &sgl->sg_iovs[i];
 
-		iov->iov_buf = bio_iov2req_buf(biov);
+		/* Skip bulk transfer for deduped extent */
+		if (biov->bi_addr.ba_dedup)
+			iov->iov_buf = NULL;
+		else
+			iov->iov_buf = bio_iov2req_buf(biov);
 		iov->iov_len = bio_iov2req_len(biov);
 		iov->iov_buf_len = bio_iov2req_len(biov);
 	}

--- a/src/vos/vos_container.c
+++ b/src/vos/vos_container.c
@@ -587,6 +587,8 @@ vos_cont_destroy(daos_handle_t poh, uuid_t co_uuid)
 	}
 	uuid_copy(pkey.uuid, pool->vp_id);
 
+	vos_dedup_invalidate(pool);
+
 	rc = cont_lookup(&key, &pkey, &cont);
 	if (rc != -DER_NONEXIST) {
 		D_ASSERT(rc == 0);

--- a/src/vos/vos_internal.h
+++ b/src/vos/vos_internal.h
@@ -161,6 +161,8 @@ struct vos_pool {
 	struct bio_io_context	*vp_io_ctxt;
 	/** In-memory free space tracking for NVMe device */
 	struct vea_space_info	*vp_vea_info;
+	/** Dedup hash */
+	struct d_hash_table	*vp_dedup_hash;
 };
 
 /**
@@ -973,6 +975,15 @@ key_tree_punch(struct vos_object *obj, daos_handle_t toh, daos_epoch_t epoch,
 	       struct vos_ilog_info *info);
 
 /* vos_io.c */
+int
+vos_dedup_init(struct vos_pool *pool);
+
+void
+vos_dedup_fini(struct vos_pool *pool);
+
+void
+vos_dedup_invalidate(struct vos_pool *pool);
+
 uint16_t
 vos_media_select(struct vos_container *cont, daos_iod_type_t type,
 		 daos_size_t size);

--- a/src/vos/vos_pool.c
+++ b/src/vos/vos_pool.c
@@ -138,6 +138,8 @@ pool_hop_free(struct d_ulink *hlink)
 	if (pool->vp_uma.uma_pool)
 		vos_pmemobj_close(pool->vp_uma.uma_pool);
 
+	vos_dedup_fini(pool);
+
 	D_FREE(pool);
 }
 
@@ -695,6 +697,10 @@ vos_pool_open(const char *path, uuid_t uuid, daos_handle_t *poh)
 			goto failed;
 		}
 	}
+
+	rc = vos_dedup_init(pool);
+	if (rc)
+		goto failed;
 
 	/* Insert the opened pool to the uuid hash table */
 	rc = pool_link(pool, &ukey, poh);


### PR DESCRIPTION
Maintain a per VOS pool hash table to keep the recx csum and address
for all updates, and all updates will first search this dedup hash
to find identical recx, if any identical recx is found, just reuse
the old recx address and skip space allocation and data transfer.

This deduped update needs to enable checksum and disable aggregation.

Signed-off-by: Niu Yawei <yawei.niu@intel.com>