### PR TITLE
DAOS-4692 doc: container destroy-snap --eprange typo

### DIFF
--- a/doc/man/man8/daos.8
+++ b/doc/man/man8/daos.8
@@ -182,7 +182,7 @@ The \fBRESOURCE\fRs, respective \fBCOMMAND\fRs and \fBOPTION\fRs supported by \f
 .br
 	  \fB--epc=\fREPOCHNUM     container epoch (destroy-snap, rollback)
 .br
-	  \fB--eprange=\fRB-E      container epoch range (destroy-snap)
+	  \fB--epcrange=\fRB-E     container epoch range (destroy-snap)
 .TP
 .I object \fR(\fIobj\fR) \fBCOMMAND\fRs:
 	  \fBquery\fR            query an object's layout

--- a/src/tests/ftest/util/daos_utils.py
+++ b/src/tests/ftest/util/daos_utils.py
@@ -439,7 +439,7 @@ class DaosCommand(CommandWithSubCommand):
                     self).__init__("destroy-snap")
                 self.snap = FormattedParameter("--snap={}")
                 self.epc = FormattedParameter("--epc={}")
-                self.eprange = FormattedParameter("--eprange={}")
+                self.epcrange = FormattedParameter("--epcrange={}")
 
         class RollbackSubCommand(CommonContainerSubCommand):
             """Defines an object for the daos container rollback command."""

--- a/src/utils/daos.c
+++ b/src/utils/daos.c
@@ -1266,7 +1266,7 @@ help_hdlr(int argc, char *argv[], struct cmd_args_s *ap)
 			"container options (snapshot and rollback-related):\n"
 			"	--snap=NAME        container snapshot (create/destroy-snap, rollback)\n"
 			"	--epc=EPOCHNUM     container epoch (destroy-snap, rollback)\n"
-			"	--eprange=B-E      container epoch range (destroy-snap)\n");
+			"	--epcrange=B-E     container epoch range (destroy-snap)\n");
 			ALL_BUT_CONT_CREATE_OPTS_HELP();
 		} else if (strcmp(argv[3], "set-prop") == 0) {
 			fprintf(stream,


### PR DESCRIPTION
'eprange' typo changed to 'epcrange' in man page and daos help
command.

Signed-off-by: David Maldonado Moreno <david.maldonado.moreno@intel.com>