### PR TITLE
DAOS-5052 IV: increate pool map IV buffer size.

### DIFF
--- a/src/common/misc.c
+++ b/src/common/misc.c
@@ -223,6 +223,28 @@ daos_sgls_buf_size(d_sg_list_t *sgls, int nr)
 	return size;
 }
 
+int
+daos_sgl_buf_extend(d_sg_list_t *sgl, int idx, size_t new_size)
+{
+	char	*new_buf;
+
+	if (sgl == NULL || sgl->sg_iovs == NULL)
+		return 0;
+
+	D_ASSERT(sgl->sg_nr > idx);
+	if (sgl->sg_iovs[idx].iov_buf_len >= new_size)
+		return 0;
+
+	D_REALLOC(new_buf, sgl->sg_iovs[idx].iov_buf, new_size);
+	if (new_buf == NULL)
+		return -DER_NOMEM;
+
+	sgl->sg_iovs[idx].iov_buf = new_buf;
+	sgl->sg_iovs[idx].iov_buf_len = new_size;
+
+	return 0;
+}
+
 /**
  * Query the size of packed sgls, if the \a buf_size != NULL then will set its
  * value as buffer size as well.

--- a/src/include/daos/common.h
+++ b/src/include/daos/common.h
@@ -247,6 +247,8 @@ daos_size_t daos_sgl_buf_size(d_sg_list_t *sgl);
 daos_size_t daos_sgls_buf_size(d_sg_list_t *sgls, int nr);
 daos_size_t daos_sgls_packed_size(d_sg_list_t *sgls, int nr,
 				  daos_size_t *buf_size);
+int
+daos_sgl_buf_extend(d_sg_list_t *sgl, int idx, size_t new_size);
 
 /** Move to next iov, it's caller's responsibility to ensure the idx boundary */
 #define daos_sgl_next_iov(iov_idx, iov_off)				\

--- a/src/pool/srv_iv.c
+++ b/src/pool/srv_iv.c
@@ -396,12 +396,32 @@ pool_iv_ent_update(struct ds_iv_entry *entry, struct ds_iv_key *key,
 		src_iv->piv_master_rank);
 
 	/* Update pool map version or pool map */
-	if (entry->iv_class->iv_class_id == IV_POOL_MAP)
+	if (entry->iv_class->iv_class_id == IV_POOL_MAP) {
+		int dst_len = entry->iv_value.sg_iovs[0].iov_buf_len -
+			      sizeof(struct pool_iv_entry) +
+			      sizeof(struct pool_buf);
+		int src_len = pool_buf_size(
+			src_iv->piv_map.piv_pool_buf.pb_nr);
+
 		rc = ds_pool_tgt_map_update(pool,
 			src_iv->piv_map.piv_pool_buf.pb_nr > 0 ?
 			&src_iv->piv_map.piv_pool_buf : NULL,
 			src_iv->piv_pool_map_ver);
-	else if (entry->iv_class->iv_class_id == IV_POOL_PROP)
+		if (rc)
+			return rc;
+
+		/* realloc the pool iv buffer if the size is not enough */
+		if (dst_len < src_len) {
+			int new_alloc_size = src_len + sizeof(*src_iv) -
+					     sizeof(struct pool_buf);
+
+			rc = daos_sgl_buf_extend(&entry->iv_value, 0,
+						 new_alloc_size);
+			if (rc)
+				return rc;
+		}
+
+	} else if (entry->iv_class->iv_class_id == IV_POOL_PROP)
 		rc = ds_pool_tgt_prop_update(pool, &src_iv->piv_prop);
 
 	ds_pool_put(pool);


### PR DESCRIPTION
During reintegration, the pool map buffer size
might need to be increased, since new rank will
be added to pool map.

Signed-off-by: Di Wang <di.wang@intel.com>