### PR TITLE
DAOS-5053 csum: Checksum Bug Fixes

### DIFF
--- a/src/common/checksum.c
+++ b/src/common/checksum.c
@@ -40,51 +40,10 @@
 static int
 checksum_sgl_cb(uint8_t *buf, size_t len, void *args);
 
-/** helper function to trace bytes */
-static void
-trace_bytes(const uint8_t *buf, const size_t len, const size_t max)
-{
-	size_t	char_buf_len = max == 0 ? len : min(max, len);
-	char	char_buf[char_buf_len * 2 + 1];
-	int	i;
-
-	if (buf == NULL)
-		return;
-
-	for (i = 0; i <  len && (i < max || max == 0); i++)
-		sprintf(char_buf + i * 2, "%x", buf[i]);
-	char_buf[i] = '\0';
-	C_TRACE("%s", char_buf);
-}
-
-/** helper function to trace chars */
-static void
-trace_chars(const uint8_t *buf, const size_t buf_len, const uint32_t max)
-{
-	int	i;
-	size_t	len = max == 0 ? buf_len : min(buf_len, max);
-	char	str[len + 1];
-
-	if (buf == NULL)
-		return;
-
-	for (i = 0; i <  len ; i++)
-		str[i] = buf[i] == '\0' ? '_' : buf[i];
-	str[i] = '\0';
-	C_TRACE("%s", str);
-}
-
 static bool
 is_array(const daos_iod_t *iod)
 {
 	return iod->iod_type == DAOS_IOD_ARRAY;
-}
-
-
-static void
-daos_csummer_trace_csum(struct daos_csummer *obj, uint8_t *csum)
-{
-	trace_bytes(csum, daos_csummer_get_csum_len(obj), 0);
 }
 
 /** Container Property knowledge */
@@ -358,21 +317,21 @@ daos_csummer_update(struct daos_csummer *obj, uint8_t *buf, size_t buf_len)
 {
 	int rc = 0;
 
-	if (C_TRACE_ENABLED()) {
-		C_TRACE("Buffer (buf=%p len=%zu) (type=%s): ", buf, buf_len,
+	if (C_TRACE_ENABLED())
+		C_TRACE("Buffer (buf=%p len=%zu) (type=%s)\n", buf, buf_len,
 			daos_csummer_get_name(obj));
-		trace_chars(buf, buf_len, 50);
-		C_TRACE("\n");
-	}
 
-	if (obj->dcs_csum_buf && obj->dcs_csum_buf_size > 0) {
+	if (obj->dcs_csum_buf && obj->dcs_csum_buf_size > 0)
 		rc = obj->dcs_algo->cf_update(obj, buf, buf_len);
-	}
 
 	if (C_TRACE_ENABLED()) {
-		C_TRACE("CSUM: ...");
-		daos_csummer_trace_csum(obj, obj->dcs_csum_buf);
-		C_TRACE("\n");
+		d_iov_t tmp;
+
+		d_iov_set(&tmp, buf, buf_len);
+		C_TRACE("Updated csum(type=%s) for '"DF_KEY"'->"DF_CI_BUF"\n",
+			daos_csummer_get_name(obj),
+			DP_KEY(&tmp),
+			DP_CI_BUF(obj->dcs_csum_buf, obj->dcs_csum_buf_size));
 	}
 
 	return rc;
@@ -415,11 +374,9 @@ daos_csummer_csum_compare(struct daos_csummer *obj, uint8_t *a,
 			  uint8_t *b, uint32_t csum_len)
 {
 	if (C_TRACE_ENABLED()) {
-		C_TRACE("Comparing: ");
-		daos_csummer_trace_csum(obj, a);
-		C_TRACE("\nWith: ");
-		daos_csummer_trace_csum(obj, b);
-		C_TRACE("\n: ");
+		C_TRACE("Comparing: "DF_CI_BUF" with "DF_CI_BUF"\n",
+			DP_CI_BUF(a, csum_len),
+			DP_CI_BUF(b, csum_len));
 	}
 
 	if (obj->dcs_algo->cf_compare)
@@ -663,6 +620,12 @@ recx_hi(daos_recx_t *r)
 }
 
 static int
+sgl_process_nop_cb(uint8_t *buf, size_t len, void *args)
+{
+	return 0;
+}
+
+static int
 calc_csum_recx_with_map(struct daos_csummer *obj, size_t csum_nr,
 			daos_recx_t *recx,
 			struct dcs_csum_info *csum_info,
@@ -677,8 +640,9 @@ calc_csum_recx_with_map(struct daos_csummer *obj, size_t csum_nr,
 	uint32_t		 i, j;
 	daos_size_t		 bytes_for_csum;
 	daos_size_t		 bytes_to_skip;
-	uint32_t		 prev_idx = recx->rx_idx;
+	uint64_t		 prev_idx = recx->rx_idx;
 	struct daos_csum_range	 maps_in_chunk;
+	daos_size_t		 consumed_bytes = 0;
 
 	for (i = 0; i < csum_nr; i++) {
 		buf = ci_idx2csum(csum_info, i);
@@ -699,13 +663,15 @@ calc_csum_recx_with_map(struct daos_csummer *obj, size_t csum_nr,
 			if (mapped_chunk.dcr_lo > prev_idx) {
 				bytes_to_skip = (mapped_chunk.dcr_lo - prev_idx)
 						* rec_len;
-				daos_sgl_get_bytes(sgl, idx,
+				daos_sgl_processor(sgl, idx,
 						   bytes_to_skip,
-						   NULL, NULL);
+						   sgl_process_nop_cb, NULL);
+				consumed_bytes += bytes_to_skip;
 			}
 			bytes_for_csum = mapped_chunk.dcr_nr * rec_len;
 			rc = daos_sgl_processor(sgl, idx, bytes_for_csum,
 						checksum_sgl_cb, obj);
+			consumed_bytes += bytes_for_csum;
 			if (rc != 0) {
 				D_ERROR("daos_sgl_processor error: %d\n", rc);
 				return rc;
@@ -715,6 +681,18 @@ calc_csum_recx_with_map(struct daos_csummer *obj, size_t csum_nr,
 
 		daos_csummer_finish(obj);
 	}
+
+	if (consumed_bytes < recx->rx_nr * rec_len) {
+		/** Nothing mapped for recx or tail unmapped */
+		bytes_to_skip = (recx->rx_nr * rec_len) - consumed_bytes;
+		daos_sgl_processor(sgl, idx, bytes_to_skip,
+				   sgl_process_nop_cb, NULL);
+		consumed_bytes += bytes_to_skip;
+	}
+
+	D_ASSERTF(consumed_bytes == recx->rx_nr * rec_len,
+		"consumed_bytes(%lu) == recx->rx_nr * rec_len(%lu)",
+		  consumed_bytes, recx->rx_nr * rec_len);
 	return 0;
 }
 
@@ -1017,7 +995,11 @@ daos_csummer_verify_iod(struct daos_csummer *obj, daos_iod_t *iod,
 				&new_iod_csums->ic_data[i],
 				&iod_csum->ic_data[i]);
 		if (!match) {
-			D_ERROR("Data corruption found\n");
+			D_ERROR("Data corruption found. "
+				"Calculated "DF_CI" != "
+				"received "DF_CI"\n",
+				DP_CI(new_iod_csums->ic_data[i]),
+				DP_CI(iod_csum->ic_data[i]));
 			D_GOTO(done, rc = -DER_CSUM);
 		}
 	}
@@ -1149,6 +1131,29 @@ ci_off2csum(struct dcs_csum_info *csum_buf, uint32_t offset)
 {
 	return ci_idx2csum(csum_buf,
 			   ci_off2idx(csum_buf, offset));
+}
+
+uint64_t
+ci_buf2uint64(const uint8_t *buf, uint16_t len)
+{
+	switch (len) {
+	/** for csum_buffers should only be these lengths */
+	case 2:
+		return *(uint16_t *) buf;
+	case 4:
+		return *(uint32_t *) buf;
+	case 8:
+		return *(uint64_t *) buf;
+	default:
+		return 0;
+	}
+}
+
+/** helper for printing csum as a 64bit value */
+uint64_t
+ci2csum(struct dcs_csum_info ci)
+{
+	return ci_buf2uint64(ci.cs_csum, ci.cs_len);
 }
 
 /** Other Functions */
@@ -1283,6 +1288,8 @@ csum_chunk_count(uint32_t chunk_size, uint64_t lo_idx, uint64_t hi_idx,
 
 	if (rec_size == 0)
 		return 0;
+	if (lo_idx == hi_idx) /** if lo == hi, always just 1 chunk */
+		return 1;
 	chunk = csum_align_boundaries(lo_idx, hi_idx, 0, UINT64_MAX,
 				      rec_size, chunk_size);
 	daos_size_t result = chunk.dcr_nr / (chunk_size / rec_size);

--- a/src/common/tests/checksum_tests.c
+++ b/src/common/tests/checksum_tests.c
@@ -1495,6 +1495,32 @@ test_calc_rec_chunksize(void **state)
 		csum_record_chunksize(UINT_MAX, UINT_MAX - 1));
 }
 
+uint64_t
+ci2csum(struct dcs_csum_info ci)
+{
+	uint16_t len = ci.cs_len;
+	uint8_t *buf = ci.cs_csum;
+
+	return ci_buf2uint64(buf, len);
+}
+
+static void
+test_formatter(void **state)
+{
+	uint64_t csum_buf = 1234567890123456789;
+	char result[1024];
+	struct dcs_csum_info ci = {
+		.cs_csum = (uint8_t *)&csum_buf,
+		.cs_nr = 1,
+		.cs_chunksize = 1024,
+		.cs_buf_len = sizeof(csum_buf),
+		.cs_len = sizeof(csum_buf)
+		};
+
+	sprintf(result, DF_CI, DP_CI(ci));
+	assert_string_equal("{nr: 1, len: 8, first_csum: 1234567890123456789}",
+			    result);
+}
 
 static int test_setup(void **state)
 {
@@ -1567,6 +1593,8 @@ static const struct CMUnitTest tests[] = {
 		test_akey_csum),
 	TEST("CSUM27: Calc record chunk size",
 		test_calc_rec_chunksize),
+	TEST("CSUM28: Formatter",
+		test_formatter),
 	TEST("CSUM28: Get the recxes from a map", get_map_test),
 	TEST("CSUM_HOLES01: With 2 mapped extents that leave a hole "
 	     "at the beginning, in between and "

--- a/src/include/daos/checksum.h
+++ b/src/include/daos/checksum.h
@@ -450,6 +450,17 @@ ci_idx2csum(struct dcs_csum_info *csum_buf, uint32_t idx);
 uint8_t *
 ci_off2csum(struct dcs_csum_info *csum_buf, uint32_t offset);
 
+uint64_t
+ci_buf2uint64(const uint8_t *buf, uint16_t len);
+
+uint64_t
+ci2csum(struct dcs_csum_info ci);
+
+#define	DF_CI_BUF "%"PRIu64
+#define	DP_CI_BUF(buf, len) ci_buf2uint64(buf, len)
+#define	DF_CI "{nr: %d, len: %d, first_csum: %lu}"
+#define	DP_CI(ci) (ci).cs_nr, (ci).cs_len, ci2csum(ci)
+
 /**
  * -----------------------------------------------------------------------------
  * Helper Functions

--- a/src/object/cli_shard.c
+++ b/src/object/cli_shard.c
@@ -180,7 +180,15 @@ int dc_rw_cb_csum_verify(const struct rw_cb_args *rw_args)
 	iods_csums = orwo->orw_iod_csums.ca_arrays;
 	maps = orwo->orw_maps.ca_arrays;
 
-	D_ASSERT(orwo->orw_maps.ca_count == orw->orw_iod_array.oia_iod_nr);
+	if (daos_obj_is_echo(orw->orw_oid.id_pub))
+		return 0; /** currently don't verify echo classes */
+
+	if (sgls == NULL)
+		return 0; /** no data to verify ... size only */
+	D_ASSERTF(orwo->orw_maps.ca_count == orw->orw_iod_array.oia_iod_nr,
+		  "orwo->orw_maps.ca_count(%lu) == "
+		  "orw->orw_iod_array.oia_iod_nr(%d)",
+		  orwo->orw_maps.ca_count, orw->orw_iod_array.oia_iod_nr);
 
 	/** fault injection - corrupt data after getting from server and before
 	 * verifying on client - simulates corruption over network
@@ -741,7 +749,9 @@ int csum_enum_verify_keys(const struct obj_enum_args *enum_args,
 	struct daos_sgl_idx	 sgl_idx = {0};
 	d_sg_list_t		 sgl = oeo->oeo_sgl;
 
-	if (enum_args->eaa_nr == NULL || *enum_args->eaa_nr == 0)
+	if (enum_args->eaa_nr == NULL ||
+	    *enum_args->eaa_nr == 0 ||
+	    sgl.sg_nr_out == 0)
 		return 0; /** no keys to verify */
 
 	csummer = dc_cont_hdl2csummer(enum_args->eaa_obj->do_co_hdl);

--- a/src/object/srv_csum.c
+++ b/src/object/srv_csum.c
@@ -291,8 +291,10 @@ static void
 cc_insert_remembered_csums(struct csum_context *ctx)
 {
 	if (ctx->cc_csums_to_copy_to != NULL) {
-		C_TRACE("Inserting csum (len=%lu)\n",
-			ctx->cc_csum_buf_to_copy_len);
+		C_TRACE("Inserting csum (len=%"PRIu64"): "DF_CI_BUF"\n",
+			ctx->cc_csum_buf_to_copy_len,
+			DP_CI_BUF(ctx->cc_csum_buf_to_copy,
+				  ctx->cc_csum_buf_to_copy_len));
 		ci_insert(ctx->cc_csums_to_copy_to,
 			  ctx->cc_csums_to_copy_to_csum_idx,
 			  ctx->cc_csum_buf_to_copy,
@@ -484,7 +486,7 @@ cc_add_csums_for_recx(struct csum_context *ctx, daos_recx_t *recx,
 static uint64_t
 cc2biov_csums_nr(struct csum_context *ctx)
 {
-	return ctx->cc_biov_csum_idx;
+	return ctx->cc_biov_csum_idx + 1;
 }
 
 int
@@ -496,6 +498,9 @@ ds_csum_add2iod(daos_iod_t *iod, struct daos_csummer *csummer,
 	struct daos_sgl_idx	bsgl_idx = {0};
 	int			rc = 0;
 	uint32_t		i, j;
+
+	if (biov_csums_used != NULL)
+		*biov_csums_used = 0;
 
 	if (!(daos_csummer_initialized(csummer) && bsgl))
 		return 0;

--- a/src/object/srv_obj.c
+++ b/src/object/srv_obj.c
@@ -813,8 +813,12 @@ csum_add2iods(daos_handle_t ioh, daos_iod_t *iods, uint32_t iods_nr,
 
 	struct bio_desc *biod = vos_ioh2desc(ioh);
 	struct dcs_csum_info *csum_infos = vos_ioh2ci(ioh);
+	uint32_t csum_info_nr = vos_ioh2ci_nr(ioh);
 
 	for (i = 0; i < iods_nr; i++) {
+		if (biov_csums_idx >= csum_info_nr)
+			break; /** no more csums to add */
+
 		rc = ds_csum_add2iod(
 			&iods[i], csummer,
 			bio_iod_sgl(biod, i),
@@ -924,9 +928,9 @@ obj_log_csum_err(void)
 }
 
 static void
-map_add_recx(daos_iom_t *map, const struct bio_iov *biov, uint64_t byte_idx)
+map_add_recx(daos_iom_t *map, const struct bio_iov *biov, uint64_t rec_idx)
 {
-	map->iom_recxs[map->iom_nr_out].rx_idx = byte_idx / map->iom_size;
+	map->iom_recxs[map->iom_nr_out].rx_idx = rec_idx;
 	map->iom_recxs[map->iom_nr_out].rx_nr = bio_iov2req_len(biov)
 						/ map->iom_size;
 	map->iom_nr_out++;
@@ -944,8 +948,9 @@ obj_fetch_create_maps(crt_rpc_t *rpc, struct bio_desc *biod)
 	daos_iod_t		*iod;
 	struct bio_iov		*biov;
 	uint32_t		 iods_nr;
-	uint32_t		 i, j;
-	uint64_t		 byte_idx;
+	uint32_t		 i, r;
+	uint64_t		 rec_idx;
+	uint32_t		 bsgl_iov_idx;
 
 	/**
 	 * Allocate memory for the maps. There will be 1 per iod
@@ -975,21 +980,30 @@ obj_fetch_create_maps(crt_rpc_t *rpc, struct bio_desc *biod)
 			bsgl->bs_nr_out == 0)
 			continue;
 
-		/** start byte_idx at first record of iod.recxs */
-		byte_idx = iod->iod_recxs[0].rx_idx;
-		for (i = 0; i < iods_nr; i++)
-			byte_idx = min(byte_idx, iod->iod_recxs[i].rx_idx);
-		byte_idx *= map->iom_size;
+		/** start rec_idx at first record of iod.recxs */
+		bsgl_iov_idx = 0;
+		for (r = 0; r < iod->iod_nr; r++) {
+			daos_recx_t recx = iod->iod_recxs[r];
 
-		for (j = 0; j < bsgl->bs_nr_out; j++) {
-			biov = bio_sgl_iov(bsgl, j);
-			if (!bio_addr_is_hole(&biov->bi_addr))
-				map_add_recx(map, biov, byte_idx);
+			rec_idx = recx.rx_idx;
 
-			byte_idx += bio_iov2req_len(biov);
+			while (rec_idx <= recx.rx_idx + recx.rx_nr - 1) {
+				biov = bio_sgl_iov(bsgl, bsgl_iov_idx);
+				if (biov == NULL) /** reached end of bsgl */
+					break;
+				if (!bio_addr_is_hole(&biov->bi_addr))
+					map_add_recx(map, biov, rec_idx);
+
+				rec_idx += (bio_iov2req_len(biov) /
+					    map->iom_size);
+				bsgl_iov_idx++;
+			}
 		}
+
 		/** allocated and used should be the same */
-		D_ASSERT(map->iom_nr == map->iom_nr_out);
+		D_ASSERTF(map->iom_nr == map->iom_nr_out,
+			  "map->iom_nr(%d) == map->iom_nr_out(%d)",
+			  map->iom_nr, map->iom_nr_out);
 		map->iom_recx_lo = map->iom_recxs[0];
 		map->iom_recx_hi = map->iom_recxs[map->iom_nr - 1];
 	}

--- a/src/vos/vos_io.c
+++ b/src/vos/vos_io.c
@@ -348,6 +348,9 @@ save_csum(struct vos_io_context *ioc, struct dcs_csum_info *csum_info,
 	struct dcs_csum_info	*saved_csum_info;
 	int			 rc;
 
+	if (ioc->ic_size_fetch)
+		return 0;
+
 	rc = bsgl_csums_resize(ioc);
 	if (rc != 0)
 		return rc;


### PR DESCRIPTION
Several bug fixes discovered when I/O tests run with checksums.

- Many are related to I/O mapping and accounting for holes correctly
while processing SG lists.
- Some issues related to UINT64_MAX and int overflow.
- Don't verify checksums with echo object classes.
- Don't process more biov_csums than available.
- Don't save a csum while fetching in VOS if size_fetch

Added better checksum tracing functionality.

Signed-off-by: Ryon Jensen <ryon.jensen@intel.com>