### PR TITLE
DAOS-5016 DMG: Extend dmg exclude & reintegrate to exclude an entire rank

### DIFF
--- a/doc/admin/pool_operations.md
+++ b/doc/admin/pool_operations.md
@@ -247,7 +247,8 @@ the management API and tool and will be documented here once available.
 ### Target Exclusion and Self-Healing
 
 An operator can exclude one or more targets from a specific DAOS pool using the rank
-the target resides on as well as the target idx on that rank. Excluding a target will
+the target resides on as well as the target idx on that rank. If a target idx list is
+not provided then all targets on the rank will be excluded. Excluding a target will
 automatically start the rebuild process.
 
 **To exclude a target from a pool:**
@@ -256,26 +257,28 @@ automatically start the rebuild process.
 $ dmg pool exclude --pool=${puuid} --rank=${rank} --target-idx=${idx1},${idx2},${idx3}
 ```
 
-The pool target exclude command accepts 3 required parameters:
+The pool target exclude command accepts 3 parameters:
 
 * The pool UUID of the pool that the targets will be excluded from.
 * The rank of the target(s) te be excluded.
-* The target Indices of the targets to be excluded from that rank.
+* The target Indices of the targets to be excluded from that rank (optional).
 
 ### Target Reintegration
 
 After a target failure an operator can fix the underlying issue and reintegrate the
-affected targets to restore the pool to its original state.
+affected targets to restore the pool to its original state. The operator can either
+reintegrate specific targets for a rank by supplying a target idx list, or reintegrate
+an entire rank by omitting the list.
 
 ```
 $ dmg pool reintegrate --pool=${puuid} --rank=${rank} --target-idx=${idx1},${idx2},${idx3}
 ```
 
-The pool reintegrate command accepts 3 required parameters:
+The pool reintegrate command accepts 3 parameters:
 
 * The pool UUID of the pool that the targets will be reintegrated into.
 * The rank of the affected targets.
-* The target Indices of the targets to be reintegrated on that rank.
+* The target Indices of the targets to be reintegrated on that rank (optional).
 
 When rebuild is triggered it will list the operations and their related targets by their rank ID
 and target index.

--- a/doc/man/man8/dmg.8
+++ b/doc/man/man8/dmg.8
@@ -1,4 +1,4 @@
-.TH dmg 1 "25 May 2020"
+.TH dmg 1 "1 June 2020"
 .SH NAME
 dmg \- Administrative tool for managing DAOS clusters
 .SH SYNOPSIS
@@ -145,7 +145,7 @@ UUID of DAOS pool to destroy
 \fB\fB\-f\fR, \fB\-\-force\fR\fP
 Force removal of DAOS pool
 .SS pool exclude
-Exclude a list of targets from a rank
+Exclude targets from a rank
 
 \fBUsage\fP: pool exclude [exclude-OPTIONS]
 .TP
@@ -159,7 +159,7 @@ UUID of the DAOS pool to exclude a target from
 \fB\fB\-\-rank\fR (\fIrequired\fR)\fP
 Rank of the targets to be excluded
 .TP
-\fB\fB\-\-target-idx\fR (\fIrequired\fR)\fP
+\fB\fB\-\-target-idx\fR\fP
 Comma-seperated list of target idx(s) to be excluded from the rank
 .SS pool get-acl
 Get a DAOS pool's Access Control List
@@ -212,7 +212,7 @@ Query a DAOS pool
 \fB\fB\-\-pool\fR (\fIrequired\fR)\fP
 UUID of DAOS pool to query
 .SS pool reintegrate
-Reintegrate a list of targets for a rank
+Reintegrate targets for a rank
 
 \fBUsage\fP: pool reintegrate [reintegrate-OPTIONS]
 .TP
@@ -226,7 +226,7 @@ UUID of the DAOS pool to start reintegration in
 \fB\fB\-\-rank\fR (\fIrequired\fR)\fP
 Rank of the targets to be reintegrated
 .TP
-\fB\fB\-\-target-idx\fR (\fIrequired\fR)\fP
+\fB\fB\-\-target-idx\fR\fP
 Comma-seperated list of target idx(s) to be reintegrated into the rank
 .SS pool set-prop
 Set pool property

--- a/src/control/cmd/dmg/pool.go
+++ b/src/control/cmd/dmg/pool.go
@@ -53,8 +53,8 @@ type PoolCmd struct {
 	Create       PoolCreateCmd       `command:"create" alias:"c" description:"Create a DAOS pool"`
 	Destroy      PoolDestroyCmd      `command:"destroy" alias:"d" description:"Destroy a DAOS pool"`
 	List         systemListPoolsCmd  `command:"list" alias:"l" description:"List DAOS pools"`
-	Exclude      PoolExcludeCmd      `command:"exclude" alias:"e" description:"Exclude a list of targets from a rank"`
-	Reintegrate  PoolReintegrateCmd  `command:"reintegrate" alias:"r" description:"Reintegrate a list of targets for a rank"`
+	Exclude      PoolExcludeCmd      `command:"exclude" alias:"e" description:"Exclude targets from a rank"`
+	Reintegrate  PoolReintegrateCmd  `command:"reintegrate" alias:"r" description:"Reintegrate targets for a rank"`
 	Query        PoolQueryCmd        `command:"query" alias:"q" description:"Query a DAOS pool"`
 	GetACL       PoolGetACLCmd       `command:"get-acl" alias:"ga" description:"Get a DAOS pool's Access Control List"`
 	OverwriteACL PoolOverwriteACLCmd `command:"overwrite-acl" alias:"oa" description:"Overwrite a DAOS pool's Access Control List"`
@@ -185,7 +185,7 @@ type PoolExcludeCmd struct {
 	ctlInvokerCmd
 	UUID      string `long:"pool" required:"1" description:"UUID of the DAOS pool to exclude a target from"`
 	Rank      uint32 `long:"rank" required:"1" description:"Rank of the targets to be excluded"`
-	Targetidx string `long:"target-idx" required:"1" description:"Comma-seperated list of target idx(s) to be excluded from the rank"`
+	Targetidx string `long:"target-idx" description:"Comma-separated list of target idx(s) to be excluded from the rank"`
 }
 
 // Execute is run when PoolExcludeCmd subcommand is activated
@@ -195,6 +195,10 @@ func (r *PoolExcludeCmd) Execute(args []string) error {
 	var idxlist []uint32
 	if err := common.ParseNumberList(r.Targetidx, &idxlist); err != nil {
 		return errors.WithMessage(err, "parsing rank list")
+	}
+
+	if len(idxlist) == 0 {
+		idxlist = append(idxlist, 0xFFFFFFFF)
 	}
 
 	req := &control.PoolExcludeReq{UUID: r.UUID, Rank: system.Rank(r.Rank), Targetidx: idxlist}
@@ -216,7 +220,7 @@ type PoolReintegrateCmd struct {
 	ctlInvokerCmd
 	UUID      string `long:"pool" required:"1" description:"UUID of the DAOS pool to start reintegration in"`
 	Rank      uint32 `long:"rank" required:"1" description:"Rank of the targets to be reintegrated"`
-	Targetidx string `long:"target-idx" required:"1" description:"Comma-seperated list of target idx(s) to be reintegrated into the rank"`
+	Targetidx string `long:"target-idx" description:"Comma-separated list of target idx(s) to be reintegrated into the rank"`
 }
 
 // Execute is run when PoolReintegrateCmd subcommand is activated
@@ -226,6 +230,10 @@ func (r *PoolReintegrateCmd) Execute(args []string) error {
 	var idxlist []uint32
 	if err := common.ParseNumberList(r.Targetidx, &idxlist); err != nil {
 		return errors.WithMessage(err, "parsing rank list")
+	}
+
+	if len(idxlist) == 0 {
+		idxlist = append(idxlist, 0xFFFFFFFF)
 	}
 
 	req := &control.PoolReintegrateReq{UUID: r.UUID, Rank: system.Rank(r.Rank), Targetidx: idxlist}

--- a/src/control/cmd/dmg/pool_test.go
+++ b/src/control/cmd/dmg/pool_test.go
@@ -255,6 +255,20 @@ func TestPoolCommands(t *testing.T) {
 			nil,
 		},
 		{
+			"Exclude a target with no idx given",
+			"pool exclude --pool 031bcaf8-f0f5-42ef-b3c5-ee048676dceb --rank 0",
+			strings.Join([]string{
+				"ConnectClients",
+				printRequest(t, &control.PoolExcludeReq{
+					UUID:      "031bcaf8-f0f5-42ef-b3c5-ee048676dceb",
+					Rank:      0,
+					Targetidx: []uint32{0xFFFFFFFF},
+				}),
+			}, " "),
+			nil,
+		},
+
+		{
 			"Reintegrate a target with single target idx",
 			"pool reintegrate --pool 031bcaf8-f0f5-42ef-b3c5-ee048676dceb --rank 0 --target-idx 1",
 			strings.Join([]string{
@@ -280,6 +294,20 @@ func TestPoolCommands(t *testing.T) {
 			}, " "),
 			nil,
 		},
+		{
+			"Reintegrate a target with no idx given",
+			"pool reintegrate --pool 031bcaf8-f0f5-42ef-b3c5-ee048676dceb --rank 0",
+			strings.Join([]string{
+				"ConnectClients",
+				printRequest(t, &control.PoolReintegrateReq{
+					UUID:      "031bcaf8-f0f5-42ef-b3c5-ee048676dceb",
+					Rank:      0,
+					Targetidx: []uint32{0xFFFFFFFF},
+				}),
+			}, " "),
+			nil,
+		},
+
 		{
 			"Destroy pool with force",
 			"pool destroy --pool 031bcaf8-f0f5-42ef-b3c5-ee048676dceb --force",

--- a/src/mgmt/srv_drpc.c
+++ b/src/mgmt/srv_drpc.c
@@ -576,7 +576,7 @@ pool_change_target_state(char *id, size_t n_targetidx, uint32_t *targetidx,
 			 uint32_t rank, pool_comp_state_t state)
 {
 	uuid_t				uuid;
-	struct pool_target_id_list	reint_list;
+	struct pool_target_id_list	target_id_list;
 	int				rc, i;
 
 	rc = uuid_parse(id, uuid);
@@ -586,20 +586,21 @@ pool_change_target_state(char *id, size_t n_targetidx, uint32_t *targetidx,
 		return -DER_INVAL;
 	}
 
-	rc = pool_target_id_list_alloc(n_targetidx, &reint_list);
+	rc = pool_target_id_list_alloc(n_targetidx, &target_id_list);
 	if (rc)
 		return rc;
 
 	for (i = 0; i < n_targetidx; ++i)
-		reint_list.pti_ids[i].pti_id = targetidx[i];
+		target_id_list.pti_ids[i].pti_id = targetidx[i];
 
-	rc = ds_mgmt_pool_target_update_state(uuid, rank, &reint_list, state);
+	rc = ds_mgmt_pool_target_update_state(uuid, rank, &target_id_list,
+					      state);
 	if (rc != 0) {
 		D_ERROR("Failed to set pool target up %s: "DF_RC"\n", uuid,
 			DP_RC(rc));
 	}
 
-	pool_target_id_list_free(&reint_list);
+	pool_target_id_list_free(&target_id_list);
 	return rc;
 }
 


### PR DESCRIPTION
Added functionality to dmg exclude and reintegrate to allow an operator
to exclude an entire rank by omitting the target index(s).

Signed-off-by: Peter Fetros <peter.fetros@intel.com>