### PR TITLE
DAOS-3932 container: Fix CONT_CLOSE -DER_EVICTEDs

### DIFF
--- a/src/container/cli.c
+++ b/src/container/cli.c
@@ -1418,8 +1418,7 @@ cont_oid_alloc_complete(tse_task_t *task, void *data)
 	struct dc_cont *cont = arg->coaa_cont;
 	int rc = task->dt_result;
 
-	if (daos_rpc_retryable_rc(rc) || rc == -DER_STALE ||
-	    rc == -DER_EVICTED) {
+	if (daos_rpc_retryable_rc(rc) || rc == -DER_STALE) {
 		tse_sched_t *sched = tse_task2sched(task);
 		daos_pool_query_t *pargs;
 		tse_task_t *ptask;

--- a/src/include/daos/rpc.h
+++ b/src/include/daos/rpc.h
@@ -214,7 +214,7 @@ static inline bool
 daos_rpc_retryable_rc(int rc)
 {
 	return daos_crt_network_error(rc) || rc == -DER_TIMEDOUT ||
-	       rc == -DER_GRPVER;
+	       rc == -DER_GRPVER || rc == -DER_EVICTED;
 }
 
 /* Determine if the RPC is from a client. If not, it's from a server rank. */


### PR DESCRIPTION
A CONT_CLOSE may return -DER_EVICTED if during the CONT_TGT_CLOSE bcast
a pool server terminates and gets excluded from the pool map. This patch
adds -DER_EVICTED to daos_rpc_retryable_rc, so that all metadata RPCs
get the fix.

Signed-off-by: Li Wei <wei.g.li@intel.com>