### PR TITLE
DAOS-xxx dedup: allow dedup to be used w/o cksum feature

### DIFF
--- a/src/common/SConscript
+++ b/src/common/SConscript
@@ -26,8 +26,8 @@ def scons():
                   'misc.c', 'pool_map.c', 'sort.c', 'btree.c', 'prop.c',
                   'btree_class.c', 'tse.c', 'rsvc.c', 'checksum.c',
                   'drpc.c', 'drpc.pb-c.c', 'proc.c',
-                  'acl_api.c', 'acl_util.c', 'acl_principal.c',
-                  'profile.c']
+                  'acl_api.c', 'acl_util.c', 'acl_principal.c', 'cont_props.c',
+                  'dedup.c', 'profile.c']
 
     common = daos_build.library(denv, 'libdaos_common', common_src)
     denv.Install('$PREFIX/lib64/', common)

--- a/src/common/checksum.c
+++ b/src/common/checksum.c
@@ -33,6 +33,7 @@
 #include <gurt/types.h>
 #include <daos/common.h>
 #include <daos/checksum.h>
+#include <daos/cont_props.h>
 
 #define C_TRACE(...) D_DEBUG(DB_CSUM, __VA_ARGS__)
 #define C_TRACE_ENABLED() true
@@ -48,81 +49,8 @@ is_array(const daos_iod_t *iod)
 }
 
 /** Container Property knowledge */
-uint32_t
-daos_cont_prop2csum(daos_prop_t *props)
-{
-	struct daos_prop_entry *prop =
-		daos_prop_entry_get(props, DAOS_PROP_CO_CSUM);
 
-	return prop == NULL ? DAOS_PROP_CO_CSUM_OFF : (uint32_t)prop->dpe_val;
-}
 
-uint64_t
-daos_cont_prop2chunksize(daos_prop_t *props)
-{
-	struct daos_prop_entry *prop =
-		daos_prop_entry_get(props, DAOS_PROP_CO_CSUM_CHUNK_SIZE);
-
-	return prop == NULL ? 0 : prop->dpe_val;
-}
-
-bool
-daos_cont_prop2serververify(daos_prop_t *props)
-{
-	struct daos_prop_entry *prop =
-		daos_prop_entry_get(props, DAOS_PROP_CO_CSUM_SERVER_VERIFY);
-
-	return prop == NULL ? false : prop->dpe_val == DAOS_PROP_CO_CSUM_SV_ON;
-}
-
-bool
-daos_cont_prop2dedup(daos_prop_t *props)
-{
-	struct daos_prop_entry *prop =
-		daos_prop_entry_get(props, DAOS_PROP_CO_DEDUP);
-
-	return prop == NULL ? false : prop->dpe_val != DAOS_PROP_CO_DEDUP_OFF;
-}
-
-bool
-daos_cont_prop2dedupverify(daos_prop_t *props)
-{
-	struct daos_prop_entry *prop =
-		daos_prop_entry_get(props, DAOS_PROP_CO_DEDUP);
-
-	return prop == NULL ? false
-			    : prop->dpe_val == DAOS_PROP_CO_DEDUP_MEMCMP;
-}
-
-uint64_t
-daos_cont_prop2dedupsize(daos_prop_t *props)
-{
-	struct daos_prop_entry *prop =
-		daos_prop_entry_get(props, DAOS_PROP_CO_DEDUP_THRESHOLD);
-
-	return prop == NULL ? 0 : prop->dpe_val;
-}
-
-bool
-daos_cont_csum_prop_is_valid(uint16_t val)
-{
-	if (daos_cont_csum_prop_is_enabled(val) || val == DAOS_PROP_CO_CSUM_OFF)
-		return true;
-	return false;
-}
-
-bool
-daos_cont_csum_prop_is_enabled(uint16_t val)
-{
-	if (val != DAOS_PROP_CO_CSUM_CRC16 &&
-	    val != DAOS_PROP_CO_CSUM_CRC32 &&
-	    val != DAOS_PROP_CO_CSUM_CRC64 &&
-	    val != DAOS_PROP_CO_CSUM_SHA1 &&
-	    val != DAOS_PROP_CO_CSUM_SHA256 &&
-	    val != DAOS_PROP_CO_CSUM_SHA512)
-		return false;
-	return true;
-}
 
 int
 daos_str2csumcontprop(const char *value)
@@ -501,14 +429,15 @@ daos_csum_type2algo(enum DAOS_CSUM_TYPE type)
 
 int
 daos_csummer_init(struct daos_csummer **obj, struct csum_ft *ft,
-		  size_t chunk_bytes, bool srv_verify, bool dedup,
-		  bool dedup_verify, size_t dedup_bytes)
+		  size_t chunk_bytes, bool srv_verify)
 {
 	struct daos_csummer	*result;
 	int			 rc = 0;
 
-	if (!ft)
+	if (!ft) {
+		D_ERROR("No function table");
 		return -DER_INVAL;
+	}
 
 	D_ALLOC(result, sizeof(*result));
 	if (result == NULL)
@@ -517,9 +446,6 @@ daos_csummer_init(struct daos_csummer **obj, struct csum_ft *ft,
 	result->dcs_algo = ft;
 	result->dcs_chunk_size = chunk_bytes;
 	result->dcs_srv_verify = srv_verify;
-	result->dcs_dedup = dedup;
-	result->dcs_dedup_verify = dedup_verify;
-	result->dcs_dedup_size = dedup_bytes;
 
 	if (result->dcs_algo->cf_init)
 		rc = result->dcs_algo->cf_init(result);
@@ -532,11 +458,10 @@ daos_csummer_init(struct daos_csummer **obj, struct csum_ft *ft,
 
 int
 daos_csummer_type_init(struct daos_csummer **obj, enum DAOS_CSUM_TYPE type,
-		       size_t chunk_bytes, bool srv_verify, bool dedup,
-		       bool dedup_verify, size_t dedup_bytes)
+		       size_t chunk_bytes, bool srv_verify)
 {
 	return daos_csummer_init(obj, daos_csum_type2algo(type), chunk_bytes,
-				 srv_verify, dedup, dedup_verify, dedup_bytes);
+				 srv_verify);
 }
 
 void daos_csummer_destroy(struct daos_csummer **obj)
@@ -588,30 +513,6 @@ daos_csummer_get_srv_verify(struct daos_csummer *obj)
 	if (daos_csummer_initialized(obj))
 		return obj->dcs_srv_verify;
 	return false;
-}
-
-bool
-daos_csummer_get_dedup(struct daos_csummer *obj)
-{
-	if (daos_csummer_initialized(obj))
-		return obj->dcs_dedup;
-	return false;
-}
-
-bool
-daos_csummer_get_dedupverify(struct daos_csummer *obj)
-{
-	if (daos_csummer_initialized(obj))
-		return obj->dcs_dedup_verify;
-	return false;
-}
-
-uint32_t
-daos_csummer_get_dedupsize(struct daos_csummer *obj)
-{
-	if (daos_csummer_initialized(obj))
-		return obj->dcs_dedup_size;
-	return 4096;
 }
 
 uint32_t
@@ -755,7 +656,8 @@ daos_csummer_allocation_size(struct daos_csummer *obj, daos_iod_t *iods,
 		if (!csum_iod_is_supported(iod))
 			continue;
 
-		result += csum_size; /** akey csum */
+		if (!obj->dcs_skip_key_calc)
+			result += csum_size; /** akey csum */
 
 		if (akey_only)
 			continue;
@@ -831,10 +733,12 @@ daos_csummer_alloc_iods_csums(struct daos_csummer *obj, daos_iod_t *iods,
 			continue;
 
 		/** setup akey csum  */
-		ci_set(&iod_csum->ic_akey, NULL, csum_size, csum_size, 1,
-		       CSUM_NO_CHUNK, csum_type);
-		setptr(iod_csum->ic_akey.cs_csum, buf, csum_size, used,
-		       buf_len);
+		if (!obj->dcs_skip_key_calc) {
+			ci_set(&iod_csum->ic_akey, NULL, csum_size, csum_size, 1,
+			       CSUM_NO_CHUNK, csum_type);
+			setptr(iod_csum->ic_akey.cs_csum, buf, csum_size, used,
+			       buf_len);
+		}
 
 		if (akey_only)
 			continue;
@@ -1219,11 +1123,14 @@ daos_csummer_calc_iods(struct daos_csummer *obj, d_sg_list_t *sgls,
 			continue;
 
 		/** akey */
-		rc = calc_for_iov(obj, &iod->iod_name,
-			     csums->ic_akey.cs_csum, csum_len);
-		if (rc != 0) {
-			D_ERROR("calc_for_iov error: %d\n", rc);
-			goto error;
+		if (!obj->dcs_skip_key_calc) {
+			rc = calc_for_iov(obj, &iod->iod_name,
+					  csums->ic_akey.cs_csum, csum_len);
+			if (rc != 0) {
+				D_ERROR("calc_for_iov error: %d\n", rc);
+				goto error;
+			}
+
 		}
 
 		if (akey_only)
@@ -1267,7 +1174,7 @@ daos_csummer_calc_key(struct daos_csummer *csummer, daos_key_t *key,
 	uint16_t		 type = daos_csummer_get_type(csummer);
 	int			 rc;
 
-	if (!daos_csummer_initialized(csummer))
+	if (!daos_csummer_initialized(csummer) || csummer->dcs_skip_key_calc)
 		return 0;
 
 	D_ALLOC(csum_info, sizeof(*csum_info) + size);
@@ -1319,7 +1226,7 @@ daos_csummer_verify_iod(struct daos_csummer *obj, daos_iod_t *iod,
 	int			 rc;
 	bool			 match;
 
-	if (!daos_csummer_initialized(obj))
+	if (!daos_csummer_initialized(obj) || obj->dcs_skip_data_verify)
 		return 0;
 
 	if (iod == NULL || sgl == NULL || iod_csum == NULL) {

--- a/src/common/cont_props.c
+++ b/src/common/cont_props.c
@@ -1,0 +1,118 @@
+/**
+ * (C) Copyright 2020 Intel Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * GOVERNMENT LICENSE RIGHTS-OPEN SOURCE SOFTWARE
+ * The Government's rights to use, modify, reproduce, release, perform, display,
+ * or disclose this software are subject to the terms of the Apache License as
+ * provided in Contract No. B609815.
+ * Any reproduction of computer software, computer software documentation, or
+ * portions thereof marked with this legend must also reproduce the markings.
+ */
+
+#include <daos/cont_props.h>
+#include <common.h>
+
+void
+daos_props_2cont_props(daos_prop_t *props, struct cont_props *cont_prop)
+{
+	if (props == NULL || cont_prop == NULL)
+		return;
+
+	cont_prop->dcp_dedup = daos_cont_prop2dedup(props);
+	cont_prop->dcp_dedup_size = daos_cont_prop2dedupsize(props);
+	cont_prop->dcp_dedup_verify = daos_cont_prop2dedupverify(props);
+	cont_prop->dcp_srv_verify = daos_cont_prop2serververify(props);
+	cont_prop->dcp_csum_type = daos_cont_prop2csum(props);
+	cont_prop->dcp_csum_enabled =
+		daos_cont_csum_prop_is_enabled(cont_prop->dcp_csum_type);
+	cont_prop->dcp_chunksize = daos_cont_prop2chunksize(props);
+}
+
+
+uint32_t
+daos_cont_prop2csum(daos_prop_t *props)
+{
+	struct daos_prop_entry *prop =
+		daos_prop_entry_get(props, DAOS_PROP_CO_CSUM);
+
+	return prop == NULL ? DAOS_PROP_CO_CSUM_OFF : (uint32_t)prop->dpe_val;
+}
+
+uint64_t
+daos_cont_prop2chunksize(daos_prop_t *props)
+{
+	struct daos_prop_entry *prop =
+		daos_prop_entry_get(props, DAOS_PROP_CO_CSUM_CHUNK_SIZE);
+
+	return prop == NULL ? 0 : prop->dpe_val;
+}
+
+bool
+daos_cont_prop2serververify(daos_prop_t *props)
+{
+	struct daos_prop_entry *prop =
+		daos_prop_entry_get(props, DAOS_PROP_CO_CSUM_SERVER_VERIFY);
+
+	return prop == NULL ? false : prop->dpe_val == DAOS_PROP_CO_CSUM_SV_ON;
+}
+
+bool
+daos_cont_csum_prop_is_valid(uint16_t val)
+{
+	if (daos_cont_csum_prop_is_enabled(val) || val == DAOS_PROP_CO_CSUM_OFF)
+		return true;
+	return false;
+}
+
+bool
+daos_cont_csum_prop_is_enabled(uint16_t val)
+{
+	if (val != DAOS_PROP_CO_CSUM_CRC16 &&
+	    val != DAOS_PROP_CO_CSUM_CRC32 &&
+	    val != DAOS_PROP_CO_CSUM_CRC64 &&
+	    val != DAOS_PROP_CO_CSUM_SHA1 &&
+	    val != DAOS_PROP_CO_CSUM_SHA256 &&
+	    val != DAOS_PROP_CO_CSUM_SHA512)
+		return false;
+	return true;
+}
+
+bool
+daos_cont_prop2dedup(daos_prop_t *props)
+{
+	struct daos_prop_entry *prop =
+		daos_prop_entry_get(props, DAOS_PROP_CO_DEDUP);
+
+	return prop == NULL ? false : prop->dpe_val != DAOS_PROP_CO_DEDUP_OFF;
+}
+
+bool
+daos_cont_prop2dedupverify(daos_prop_t *props)
+{
+	struct daos_prop_entry *prop =
+		daos_prop_entry_get(props, DAOS_PROP_CO_DEDUP);
+
+	return prop == NULL ? false
+			    : prop->dpe_val == DAOS_PROP_CO_DEDUP_MEMCMP;
+}
+
+uint64_t
+daos_cont_prop2dedupsize(daos_prop_t *props)
+{
+	struct daos_prop_entry *prop =
+		daos_prop_entry_get(props, DAOS_PROP_CO_DEDUP_THRESHOLD);
+
+	return prop == NULL ? 0 : prop->dpe_val;
+}

--- a/src/common/dedup.c
+++ b/src/common/dedup.c
@@ -1,0 +1,52 @@
+/**
+ * (C) Copyright 2020 Intel Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * GOVERNMENT LICENSE RIGHTS-OPEN SOURCE SOFTWARE
+ * The Government's rights to use, modify, reproduce, release, perform, display,
+ * or disclose this software are subject to the terms of the Apache License as
+ * provided in Contract No. B609815.
+ * Any reproduction of computer software, computer software documentation, or
+ * portions thereof marked with this legend must also reproduce the markings.
+ */
+
+#include <daos/checksum.h>
+#include <daos/dedup.h>
+
+int
+dedup_get_csum_algo(struct cont_props *cont_props)
+{
+	if (cont_props->dcp_dedup && cont_props->dcp_dedup_verify)
+		return DAOS_PROP_CO_CSUM_CRC64;
+	if (cont_props->dcp_dedup)
+		return  DAOS_PROP_CO_CSUM_SHA256;
+
+	return DAOS_PROP_CO_CSUM_OFF;
+}
+
+void
+dedup_configure_csummer(struct daos_csummer *csummer,
+			struct cont_props *cont_props)
+{
+	if (!cont_props->dcp_csum_enabled && cont_props->dcp_dedup) {
+		csummer->dcs_skip_data_verify = true;
+		csummer->dcs_skip_key_calc = true;
+		csummer->dcs_skip_key_verify = true;
+
+		if (csummer->dcs_chunk_size == 0)
+			csummer->dcs_chunk_size = 32 * 1024;
+		else if (csummer->dcs_chunk_size < cont_props->dcp_dedup_size)
+			csummer->dcs_chunk_size = cont_props->dcp_dedup_size;
+	}
+}

--- a/src/common/prop.c
+++ b/src/common/prop.c
@@ -29,7 +29,7 @@
 #include <daos/common.h>
 #include <daos/dtx.h>
 #include <daos_security.h>
-#include <daos/checksum.h>
+#include <daos/cont_props.h>
 
 daos_prop_t *
 daos_prop_alloc(uint32_t entries_nr)

--- a/src/common/tests/checksum_timing.c
+++ b/src/common/tests/checksum_timing.c
@@ -159,7 +159,7 @@ run_timings(struct csum_ft *fts[], const int types_count, const size_t *sizes,
 			size_t			 csum_size;
 			uint8_t			*csum_buf;
 
-			rc = daos_csummer_init(&csummer, ft, 0, 0, 0, 0, 0);
+			rc = daos_csummer_init(&csummer, ft, 0, 0);
 			if (rc != 0) {
 				free(buf);
 				return rc;

--- a/src/container/cli.c
+++ b/src/container/cli.c
@@ -29,6 +29,8 @@
 #define D_LOGFAC	DD_FAC(container)
 
 #include <daos/container.h>
+#include <daos/cont_props.h>
+#include <daos/dedup.h>
 #include <daos/event.h>
 #include <daos/mgmt.h>
 #include <daos/pool.h>
@@ -450,23 +452,25 @@ dc_cont_alloc(const uuid_t uuid)
 }
 
 static void
-dc_cont_csum_init(struct dc_cont *cont, daos_prop_t *props)
+dc_cont_csum_init(struct dc_cont *cont, struct cont_props cont_props)
 {
-	uint32_t		csum_type_prop;
-	enum DAOS_CSUM_TYPE	csum_type;
-	uint64_t		chunksize;
+	uint32_t csum_type = cont_props.dcp_csum_type;
+	bool dedup_only = false;
 
-	csum_type_prop = daos_cont_prop2csum(props);
-	if (csum_type_prop == DAOS_PROP_CO_CSUM_OFF) {
-		cont->dc_csummer = NULL;
-		return;
+	if (csum_type == DAOS_PROP_CO_CSUM_OFF) {
+		dedup_only = true;
+		csum_type = dedup_get_csum_algo(&cont_props);
 	}
 
-	csum_type = daos_contprop2csumtype(csum_type_prop);
-	chunksize = daos_cont_prop2chunksize(props);
-	daos_csummer_init(&cont->dc_csummer,
-			  daos_csum_type2algo(csum_type),
-			  chunksize, 0, 0, 0, 0);
+	if (!daos_cont_csum_prop_is_enabled(csum_type))
+		return;
+
+	daos_csummer_type_init(&cont->dc_csummer,
+			       csum_type,
+			       cont_props.dcp_chunksize, 0);
+
+	if (dedup_only)
+		dedup_configure_csummer(cont->dc_csummer, &cont_props);
 }
 
 struct cont_open_args {
@@ -524,7 +528,9 @@ cont_open_complete(tse_task_t *task, void *data)
 	d_list_add(&cont->dc_po_list, &pool->dp_co_list);
 	cont->dc_pool_hdl = arg->hdl;
 
-	dc_cont_csum_init(cont, out->coo_prop);
+	daos_props_2cont_props(out->coo_prop, &cont->dc_props);
+
+	dc_cont_csum_init(cont, cont->dc_props);
 
 	D_RWLOCK_UNLOCK(&pool->dp_co_list_lock);
 
@@ -612,7 +618,9 @@ dc_cont_open(tse_task_t *task)
 	 * opening the contianer
 	 */
 	in->coi_prop_bits	= DAOS_CO_QUERY_PROP_CSUM |
-				  DAOS_CO_QUERY_PROP_CSUM_CHUNK;
+				  DAOS_CO_QUERY_PROP_CSUM_CHUNK |
+				  DAOS_CO_QUERY_PROP_DEDUP |
+				  DAOS_CO_QUERY_PROP_DEDUP_THRESHOLD;
 	arg.coa_pool		= pool;
 	arg.coa_info		= args->info;
 	arg.rpc			= rpc;
@@ -1604,6 +1612,9 @@ struct dc_cont_glob {
 	uint16_t	dcg_csum_type;
 	uint32_t	dcg_csum_chunksize;
 	bool		dcg_csum_srv_verify;
+	bool		dcg_dedup;
+	bool		dcg_dedup_verify;
+	uint32_t        dcg_dedup_th;
 };
 
 static inline daos_size_t
@@ -1665,11 +1676,13 @@ dc_cont_l2g(daos_handle_t coh, d_iov_t *glob)
 	uuid_copy(cont_glob->dcg_uuid, cont->dc_uuid);
 	uuid_copy(cont_glob->dcg_cont_hdl, cont->dc_cont_hdl);
 	cont_glob->dcg_capas = cont->dc_capas;
-	cont_glob->dcg_csum_type = daos_csummer_get_type(cont->dc_csummer);
-	cont_glob->dcg_csum_chunksize =
-		daos_csummer_get_chunksize(cont->dc_csummer);
-	cont_glob->dcg_csum_srv_verify =
-		daos_csummer_get_srv_verify(cont->dc_csummer);
+
+	cont_glob->dcg_csum_type = cont->dc_props.dcp_csum_type;
+	cont_glob->dcg_csum_chunksize = cont->dc_props.dcp_chunksize;
+	cont_glob->dcg_csum_srv_verify = cont->dc_props.dcp_srv_verify;
+	cont_glob->dcg_dedup = cont->dc_props.dcp_dedup;
+	cont_glob->dcg_dedup_verify = cont->dc_props.dcp_dedup_verify;
+	cont_glob->dcg_dedup_th = cont->dc_props.dcp_dedup_size;
 
 	dc_pool_put(pool);
 out_cont:
@@ -1709,12 +1722,9 @@ csum_cont_g2l(const struct dc_cont_glob *cont_glob, struct dc_cont *cont)
 	struct csum_ft *csum_algo;
 
 	csum_algo = daos_csum_type2algo(cont_glob->dcg_csum_type);
-	if (csum_algo != NULL)
-		daos_csummer_init(&cont->dc_csummer, csum_algo,
-				  cont_glob->dcg_csum_chunksize,
-				  cont_glob->dcg_csum_srv_verify, 0, 0, 0);
-	else
-		cont->dc_csummer = NULL;
+	daos_csummer_init(&cont->dc_csummer, csum_algo,
+			  cont_glob->dcg_csum_chunksize,
+			  cont_glob->dcg_csum_srv_verify);
 }
 
 static int
@@ -1758,6 +1768,12 @@ dc_cont_g2l(daos_handle_t poh, struct dc_cont_glob *cont_glob,
 	cont->dc_pool_hdl = poh;
 	D_RWLOCK_UNLOCK(&pool->dp_co_list_lock);
 
+	cont->dc_props.dcp_dedup = cont_glob->dcg_dedup;
+	cont->dc_props.dcp_csum_type = cont_glob->dcg_csum_type;
+	cont->dc_props.dcp_srv_verify = cont_glob->dcg_csum_srv_verify;
+	cont->dc_props.dcp_chunksize = cont_glob->dcg_csum_chunksize;
+	cont->dc_props.dcp_dedup_size = cont_glob->dcg_dedup_th;
+	cont->dc_props.dcp_dedup_verify = cont_glob->dcg_dedup_verify;
 	csum_cont_g2l(cont_glob, cont);
 
 	dc_cont_hdl_link(cont);
@@ -2580,5 +2596,22 @@ dc_cont_hdl2csummer(daos_handle_t coh)
 	dc_cont_put(dc);
 
 	return csum;
+
+}
+
+struct cont_props
+dc_cont_hdl2props(daos_handle_t coh)
+{
+	struct dc_cont	*dc = NULL;
+	struct cont_props result = {0};
+
+	dc = dc_hdl2cont(coh);
+	if (dc == NULL)
+		return result;
+
+	result = dc->dc_props;
+	dc_cont_put(dc);
+
+	return result;
 
 }

--- a/src/container/cli_internal.h
+++ b/src/container/cli_internal.h
@@ -45,6 +45,7 @@ struct dc_cont {
 	/* pool handler of the container */
 	daos_handle_t		dc_pool_hdl;
 	struct daos_csummer    *dc_csummer;
+	struct cont_props	dc_props;
 	uint32_t		dc_closing:1,
 				dc_slave:1; /* generated via g2l */
 };

--- a/src/container/srv_cli.c
+++ b/src/container/srv_cli.c
@@ -27,6 +27,7 @@
 
 #include <daos/pool.h>
 #include <daos/container.h>
+#include <daos/cont_props.h>
 #include <daos/event.h>
 #include <daos/task.h>
 #include <daos_types.h>

--- a/src/container/srv_csum_recalc.c
+++ b/src/container/srv_csum_recalc.c
@@ -215,7 +215,7 @@ ds_csum_agg_recalc(void *recalc_args)
 		return;
 	}
 	daos_csummer_type_init(&csummer, csum_info.cs_type,
-			       csum_info.cs_chunksize, 0, 0, 0, 0);
+			       csum_info.cs_chunksize, 0);
 	for (i = 0; i < args->cra_seg_cnt; i++) {
 		bool		is_valid = false;
 		unsigned int	this_buf_nr, this_buf_idx;

--- a/src/include/daos/checksum.h
+++ b/src/include/daos/checksum.h
@@ -35,29 +35,6 @@
  * Container Property Knowledge
  * -----------------------------------------------------------
  */
-uint32_t
-daos_cont_prop2csum(daos_prop_t *props);
-
-uint64_t
-daos_cont_prop2chunksize(daos_prop_t *props);
-
-bool
-daos_cont_prop2serververify(daos_prop_t *props);
-
-bool
-daos_cont_prop2dedup(daos_prop_t *props);
-
-bool
-daos_cont_prop2dedupverify(daos_prop_t *props);
-
-uint64_t
-daos_cont_prop2dedupsize(daos_prop_t *props);
-
-bool
-daos_cont_csum_prop_is_valid(uint16_t val);
-
-bool
-daos_cont_csum_prop_is_enabled(uint16_t val);
 
 /** Convert a string into a property value for csum property */
 int
@@ -104,7 +81,6 @@ struct dcs_csum_info {
 	uint32_t	 cs_chunksize;
 };
 
-
 struct dcs_iod_csums {
 	/** akey checksum */
 	struct dcs_csum_info	 ic_akey;
@@ -139,10 +115,12 @@ struct daos_csummer {
 	void		*dcs_ctx;
 	/** Points to the buffer where the  calculated csum is to be written */
 	uint8_t		*dcs_csum_buf;
+	/** Whether or not to verify on the server on an update */
 	bool		 dcs_srv_verify;
-	bool		 dcs_dedup;
-	bool		 dcs_dedup_verify;
-	uint32_t	 dcs_dedup_size;
+	/** Disable aspects of the checksum process */
+	bool		 dcs_skip_key_calc;
+	bool		 dcs_skip_key_verify;
+	bool		 dcs_skip_data_verify;
 };
 
 struct csum_ft {
@@ -190,8 +168,7 @@ daos_csum_type2algo(enum DAOS_CSUM_TYPE type);
  */
 int
 daos_csummer_init(struct daos_csummer **obj, struct csum_ft *ft,
-		  size_t chunk_bytes, bool srv_verify, bool dedup,
-		  bool dedup_verify, size_t dedup_bytes);
+		  size_t chunk_bytes, bool srv_verify);
 
 /**
  * Initialize the daos_csummer with a known DAOS_CSUM_TYPE
@@ -209,8 +186,7 @@ daos_csummer_init(struct daos_csummer **obj, struct csum_ft *ft,
  */
 int
 daos_csummer_type_init(struct daos_csummer **obj, enum DAOS_CSUM_TYPE type,
-		       size_t chunk_bytes, bool srv_verify, bool dedup,
-		       bool dedup_verify, size_t dedup_bytes);
+		       size_t chunk_bytes, bool srv_verify);
 
 /** Destroy the daos_csummer */
 void
@@ -237,15 +213,6 @@ daos_csummer_get_rec_chunksize(struct daos_csummer *obj, uint64_t rec_size);
 
 bool
 daos_csummer_get_srv_verify(struct daos_csummer *obj);
-
-bool
-daos_csummer_get_dedup(struct daos_csummer *obj);
-
-bool
-daos_csummer_get_dedupverify(struct daos_csummer *obj);
-
-uint32_t
-daos_csummer_get_dedupsize(struct daos_csummer *obj);
 
 /** Get a string representing the csum the csummer is configured with */
 char *

--- a/src/include/daos/cont_props.h
+++ b/src/include/daos/cont_props.h
@@ -1,0 +1,74 @@
+/**
+ * (C) Copyright 2020 Intel Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * GOVERNMENT LICENSE RIGHTS-OPEN SOURCE SOFTWARE
+ * The Government's rights to use, modify, reproduce, release, perform, display,
+ * or disclose this software are subject to the terms of the Apache License as
+ * provided in Contract No. B609815.
+ * Any reproduction of computer software, computer software documentation, or
+ * portions thereof marked with this legend must also reproduce the markings.
+ */
+
+#ifndef __DAOS_M_CONT_PROPS_H
+#define __DAOS_M_CONT_PROPS_H
+
+
+#include <daos_prop.h>
+
+struct cont_props {
+	uint64_t	 dcp_chunksize;
+	uint32_t	 dcp_dedup_size;
+	uint32_t	 dcp_csum_type;
+	bool		 dcp_csum_enabled;
+	bool		 dcp_srv_verify;
+	bool		 dcp_dedup;
+	bool		 dcp_dedup_verify;
+};
+
+void
+daos_props_2cont_props(daos_prop_t *props,
+			    struct cont_props* cont_prop);
+
+/**
+ * Checksum Properties
+ */
+uint32_t
+daos_cont_prop2csum(daos_prop_t *props);
+
+uint64_t
+daos_cont_prop2chunksize(daos_prop_t *props);
+
+bool
+daos_cont_prop2serververify(daos_prop_t *props);
+
+bool
+daos_cont_csum_prop_is_valid(uint16_t val);
+
+bool
+daos_cont_csum_prop_is_enabled(uint16_t val);
+
+/**
+ * Dedup Properties
+ */
+bool
+daos_cont_prop2dedup(daos_prop_t *props);
+
+bool
+daos_cont_prop2dedupverify(daos_prop_t *props);
+
+uint64_t
+daos_cont_prop2dedupsize(daos_prop_t *props);
+
+#endif //__DAOS_M_CONT_PROPS_H__

--- a/src/include/daos/container.h
+++ b/src/include/daos/container.h
@@ -43,6 +43,7 @@ int dc_cont_node_id2ptr(daos_handle_t coh, uint32_t node_id,
 int dc_cont_hdl2uuid(daos_handle_t coh, uuid_t *hdl_uuid, uuid_t *con_uuid);
 daos_handle_t dc_cont_hdl2pool_hdl(daos_handle_t coh);
 struct daos_csummer *dc_cont_hdl2csummer(daos_handle_t coh);
+struct cont_props dc_cont_hdl2props(daos_handle_t coh);
 
 int dc_cont_local2global(daos_handle_t coh, d_iov_t *glob);
 int dc_cont_global2local(daos_handle_t poh, d_iov_t glob,

--- a/src/include/daos/dedup.h
+++ b/src/include/daos/dedup.h
@@ -1,0 +1,38 @@
+/**
+ * (C) Copyright 2020 Intel Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * GOVERNMENT LICENSE RIGHTS-OPEN SOURCE SOFTWARE
+ * The Government's rights to use, modify, reproduce, release, perform, display,
+ * or disclose this software are subject to the terms of the Apache License as
+ * provided in Contract No. B609815.
+ * Any reproduction of computer software, computer software documentation, or
+ * portions thereof marked with this legend must also reproduce the markings.
+ */
+
+#ifndef __DAOS_DEDUP_H
+#define __DAOS_DEDUP_H
+
+#include <cont_props.h>
+
+int
+dedup_get_csum_algo(struct cont_props *cont_props);
+
+void
+dedup_configure_csummer(struct daos_csummer *csummer,
+			struct cont_props *cont_props);
+
+
+#endif /** __DAOS_DEDUP_H */
+

--- a/src/include/daos_srv/container.h
+++ b/src/include/daos_srv/container.h
@@ -36,6 +36,8 @@
 #include <daos_srv/rsvc.h>
 #include <daos_srv/vos_types.h>
 #include <daos_srv/evtree.h>
+#include <daos/container.h>
+#include <daos/cont_props.h>
 
 void ds_cont_wrlock_metadata(struct cont_svc *svc);
 void ds_cont_rdlock_metadata(struct cont_svc *svc);
@@ -117,6 +119,7 @@ struct ds_cont_hdl {
 	uint64_t		sch_sec_capas;	/* access control capas */
 	struct ds_cont_child	*sch_cont;
 	struct daos_csummer	*sch_csummer;
+	struct cont_props	sch_props;
 	int			sch_ref;
 };
 

--- a/src/object/cli_obj.c
+++ b/src/object/cli_obj.c
@@ -29,6 +29,7 @@
 
 #include <daos/object.h>
 #include <daos/container.h>
+#include <daos/cont_props.h>
 #include <daos/pool.h>
 #include <daos/task.h>
 #include <daos_task.h>
@@ -2435,12 +2436,43 @@ obj_csum_update(struct dc_object *obj, daos_obj_update_t *args,
 		struct obj_auxi_args *obj_auxi)
 {
 	struct daos_csummer	*csummer = dc_cont_hdl2csummer(obj->cob_coh);
+	struct cont_props	 cont_props = dc_cont_hdl2props(obj->cob_coh);
 	struct dcs_csum_info	*dkey_csum = NULL;
 	struct dcs_iod_csums	*iod_csums = NULL;
 	int			 rc;
 
 	if (!daos_csummer_initialized(csummer)) /** Not configured */
 		return 0;
+
+	if (!cont_props.dcp_csum_enabled && cont_props.dcp_dedup) {
+		uint32_t	dedup_th = cont_props.dcp_dedup_size;
+		int		i;
+		bool		candidate = false;
+
+		/**
+		 * Checksums are only enabled for dedup purpose.
+		 * Verify whether the I/O is a candidate for dedup.
+		 * If not, then no need to provide a checksum to the server
+		 */
+
+		for (i = 0; i < args->nr; i++) {
+			daos_iod_t	*iod = &args->iods[i];
+			int		 j = 0;
+
+			if (iod->iod_type == DAOS_IOD_SINGLE)
+				/** dedup does not support single value yet */
+				return 0;
+
+			for (j = 0; j < iod->iod_nr; j++) {
+				daos_recx_t	*recx = &iod->iod_recxs[j];
+				if (recx->rx_nr * iod->iod_size >= dedup_th)
+					candidate = true;
+			}
+		}
+		if (!candidate)
+			/** not a candidate for dedup, don't compute checksum */
+			return 0;
+	}
 
 	/** Calc 'd' key checksum */
 	rc = daos_csummer_calc_key(csummer, args->dkey, &dkey_csum);
@@ -2479,11 +2511,15 @@ obj_csum_fetch(const struct dc_object *obj, daos_obj_fetch_t *args,
 	       struct obj_auxi_args *obj_auxi)
 {
 	struct daos_csummer	*csummer = dc_cont_hdl2csummer(obj->cob_coh);
+	struct cont_props	cont_props = dc_cont_hdl2props(obj->cob_coh);
 	struct dcs_csum_info	*dkey_csum = NULL;
 	struct dcs_iod_csums	*iod_csums = NULL;
 	int			 rc;
 
-	if (!daos_csummer_initialized(csummer)) /** Not configured */
+	if (!daos_csummer_initialized(csummer) || !cont_props.dcp_csum_enabled)
+		/** csummer might be initialized by dedup, but checksum
+		 * feature is turned off ...
+		 */
 		return 0;
 
 	/** dkey */

--- a/src/object/cli_shard.c
+++ b/src/object/cli_shard.c
@@ -170,7 +170,7 @@ int dc_rw_cb_csum_verify(const struct rw_cb_args *rw_args)
 	int			 rc = 0;
 
 	csummer = dc_cont_hdl2csummer(rw_args->dobj->do_co_hdl);
-	if (!daos_csummer_initialized(csummer))
+	if (!daos_csummer_initialized(csummer) || csummer->dcs_skip_data_verify)
 		return 0;
 
 	orw = crt_req_get(rw_args->rpc);
@@ -755,7 +755,7 @@ int csum_enum_verify_keys(const struct obj_enum_args *enum_args,
 		return 0; /** no keys to verify */
 
 	csummer = dc_cont_hdl2csummer(enum_args->eaa_obj->do_co_hdl);
-	if (!daos_csummer_initialized(csummer))
+	if (!daos_csummer_initialized(csummer) || csummer->dcs_skip_key_verify)
 		return 0; /** csums not enabled */
 
 	csum_ptr = oeo->oeo_csum_iov.iov_buf;

--- a/src/object/srv_csum.c
+++ b/src/object/srv_csum.c
@@ -509,7 +509,7 @@ ds_csum_add2iod(daos_iod_t *iod, struct daos_csummer *csummer,
 	if (biov_csums_used != NULL)
 		*biov_csums_used = 0;
 
-	if (!(daos_csummer_initialized(csummer) && bsgl))
+	if (!daos_csummer_initialized(csummer) || !bsgl)
 		return 0;
 
 	if (!csum_iod_is_supported(iod))

--- a/src/object/tests/srv_checksum_tests.c
+++ b/src/object/tests/srv_checksum_tests.c
@@ -163,8 +163,7 @@ array_test_case_create(struct vos_fetch_test_context *ctx,
 	size_t		 nr;
 	uint8_t		*dummy_csums;
 
-	daos_csummer_init(&ctx->csummer, &fake_algo, setup->chunksize, 0, 0, 0,
-			  0);
+	daos_csummer_init(&ctx->csummer, &fake_algo, setup->chunksize, 0);
 
 	csum_len = daos_csummer_get_csum_len(ctx->csummer);
 	cs = daos_csummer_get_chunksize(ctx->csummer);
@@ -859,7 +858,7 @@ update_fetch_sv(void **state)
 	char			*data = "abcd";
 	uint32_t		 csum = 0x12345678;
 
-	daos_csummer_init(&csummer, &fake_algo, 4, 0, 0, 0, 0);
+	daos_csummer_init(&csummer, &fake_algo, 4, 0);
 
 	iod.iod_type = DAOS_IOD_SINGLE;
 	iod.iod_size = strlen(data);

--- a/src/tests/suite/daos_dedup.c
+++ b/src/tests/suite/daos_dedup.c
@@ -1,0 +1,361 @@
+/**
+ * (C) Copyright 2020 Intel Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * GOVERNMENT LICENSE RIGHTS-OPEN SOURCE SOFTWARE
+ * The Government's rights to use, modify, reproduce, release, perform, display,
+ * or disclose this software are subject to the terms of the Apache License as
+ * provided in Contract No. B609815.
+ * Any reproduction of computer software, computer software documentation, or
+ * portions thereof marked with this legend must also reproduce the markings.
+ */
+
+#define D_LOGFAC	DD_FAC(tests)
+#include "daos_test.h"
+
+#include <daos/checksum.h>
+#include <gurt/types.h>
+#include <daos_prop.h>
+
+#define assert_success(r) do {\
+	int __rc = (r); \
+	if (__rc != 0) \
+		fail_msg("Not successful!! Error code: " DF_RC, DP_RC(__rc)); \
+	} while (0)
+
+struct dedup_test_ctx {
+	/** Pool */
+	daos_handle_t		poh;
+	/** Container */
+	daos_handle_t		coh;
+	daos_cont_info_t	info;
+	uuid_t			uuid;
+	/** Object */
+	daos_handle_t		oh;
+	daos_obj_id_t		oid;
+	daos_key_t		dkey;
+	daos_iod_t		update_iod;
+	d_sg_list_t		update_sgl;
+	daos_iod_t		fetch_iod;
+	d_sg_list_t		fetch_sgl;
+	daos_recx_t		recx[4];
+};
+
+enum THRESHOLD_SETTING {
+	THRESHOLD_GREATER_THAN_DATA = 1,
+	THRESHOLD_LESS_THAN_DATA,
+};
+
+/** easily setup an iov and allocate */
+static void
+iov_alloc(d_iov_t *iov, size_t len)
+{
+	D_ALLOC(iov->iov_buf, len);
+	iov->iov_buf_len = iov->iov_len = len;
+}
+
+static void
+iov_alloc_str(d_iov_t *iov, const char *str)
+{
+	iov_alloc(iov, strlen(str) + 1);
+	strcpy(iov->iov_buf, str);
+}
+
+static void
+setup_from_test_args(struct dedup_test_ctx *ctx, test_arg_t *state)
+{
+	ctx->poh = state->pool.poh;
+}
+
+static void
+setup_sgl(struct dedup_test_ctx *ctx)
+{
+	dts_sgl_init_with_strings_repeat(&ctx->update_sgl, 1000, 1,
+					 "Lorem ipsum dolor sit "
+					 "amet, consectetur adipiscing elit,"
+					 " sed do eiusmod tempor incididunt ut"
+					 " labore et dolore magna aliqua.");
+
+	daos_sgl_init(&ctx->fetch_sgl, 1);
+	iov_alloc(&ctx->fetch_sgl.sg_iovs[0],
+		daos_sgl_buf_size(&ctx->update_sgl));
+}
+
+static void
+setup_keys(struct dedup_test_ctx *ctx)
+{
+	iov_alloc_str(&ctx->dkey, "dkey");
+	iov_alloc_str(&ctx->update_iod.iod_name, "akey");
+}
+
+static void
+setup_as_array(struct dedup_test_ctx *ctx)
+{
+	ctx->recx[0].rx_idx = 0;
+	ctx->recx[0].rx_nr = daos_sgl_buf_size(&ctx->update_sgl);
+	ctx->update_iod.iod_size = 1;
+	ctx->update_iod.iod_nr	= 1;
+	ctx->update_iod.iod_recxs = &ctx->recx[0];
+	ctx->update_iod.iod_type  = DAOS_IOD_ARRAY;
+}
+
+static void
+setup_as_single_value(struct dedup_test_ctx *ctx)
+{
+	ctx->update_iod.iod_nr	= 1;
+	ctx->update_iod.iod_size = daos_sgl_buf_size(&ctx->update_sgl);
+	ctx->update_iod.iod_recxs = NULL;
+	ctx->update_iod.iod_type  = DAOS_IOD_SINGLE;
+}
+
+static void
+setup_fetch_iod(struct dedup_test_ctx *ctx)
+{
+	ctx->fetch_iod.iod_name = ctx->update_iod.iod_name;
+	ctx->fetch_iod.iod_size = ctx->update_iod.iod_size;
+	ctx->fetch_iod.iod_recxs = ctx->update_iod.iod_recxs;
+	ctx->fetch_iod.iod_nr = ctx->update_iod.iod_nr;
+	ctx->fetch_iod.iod_type = ctx->update_iod.iod_type;
+}
+
+static void
+setup_cont_obj(struct dedup_test_ctx *ctx,
+	       uint32_t csum_prop_type,
+	       daos_oclass_id_t oclass,
+	       uint32_t dedup_type,
+	       uint32_t dedup_threshold_setting)
+{
+	daos_prop_t *props = NULL;
+	int		 rc;
+	daos_size_t	 data_len;
+	daos_size_t	 dedup_threshold;
+
+
+	/** calc threshold based on data size and setting */
+	data_len = daos_sgl_buf_size(&ctx->update_sgl);
+	dedup_threshold = dedup_threshold_setting == THRESHOLD_GREATER_THAN_DATA
+			  ? data_len + 10 : data_len - 10;
+
+	uuid_generate(ctx->uuid);
+
+	props = daos_prop_alloc(3);
+	assert_non_null(props);
+	props->dpp_entries[0].dpe_type = DAOS_PROP_CO_CSUM;
+	props->dpp_entries[0].dpe_val = csum_prop_type;
+	props->dpp_entries[1].dpe_type = DAOS_PROP_CO_DEDUP;
+	props->dpp_entries[1].dpe_val = dedup_type;
+	props->dpp_entries[2].dpe_type = DAOS_PROP_CO_DEDUP_THRESHOLD;
+	props->dpp_entries[2].dpe_val = dedup_threshold;
+
+	rc = daos_cont_create(ctx->poh, ctx->uuid, props, NULL);
+	assert_int_equal(0, rc);
+	daos_prop_free(props);
+
+	rc = daos_cont_open(ctx->poh, ctx->uuid, DAOS_COO_RW,
+			    &ctx->coh, &ctx->info, NULL);
+	assert_int_equal(0, rc);
+
+	ctx->oid = dts_oid_gen(oclass, 0, 1);
+	rc = daos_obj_open(ctx->coh, ctx->oid, 0, &ctx->oh, NULL);
+	assert_int_equal(0, rc);
+}
+
+static void
+setup_context(struct dedup_test_ctx *ctx, test_arg_t *state,
+	      uint32_t iod_type,
+	      uint32_t csum_prop_type,
+	      daos_oclass_id_t oclass,
+	      uint32_t dedup_type,
+	      enum THRESHOLD_SETTING dedup_threshold_setting)
+{
+	setup_from_test_args(ctx, state);
+	setup_keys(ctx);
+	setup_sgl(ctx);
+
+	if (iod_type == DAOS_IOD_ARRAY)
+		setup_as_array(ctx);
+	else if (iod_type == DAOS_IOD_SINGLE)
+		setup_as_single_value(ctx);
+	else
+		fail_msg("Invalid iod_type: %d\n", iod_type);
+
+	setup_fetch_iod(ctx);
+
+	setup_cont_obj(ctx, csum_prop_type, oclass,
+		       dedup_type, dedup_threshold_setting);
+}
+
+static daos_size_t
+get_size(struct dedup_test_ctx *ctx)
+{
+	daos_pool_info_t	info;
+	int			rc;
+
+	info.pi_bits = DPI_SPACE;
+	rc = daos_pool_query((*ctx).poh, NULL, &info, NULL, NULL);
+	assert_success(rc);
+	return info.pi_space.ps_space.s_free[0];
+}
+
+static int ctx_update(struct dedup_test_ctx *ctx)
+{
+	return daos_obj_update(ctx->oh, DAOS_TX_NONE, 0,
+			       &ctx->dkey,
+			       1, &ctx->update_iod, &ctx->update_sgl,
+			       NULL);
+}
+
+static void
+with_identical_updates(void *const *state, uint32_t iod_type, int csum_type,
+		       daos_oclass_id_t oc, int dedup_type,
+		       enum THRESHOLD_SETTING dedup_threshold_setting)
+{
+	struct dedup_test_ctx	ctx;
+	/** acceptable size increase when dedup identifies identical data
+	 * being inserted
+	 */
+	const daos_size_t	dedup_size_increase = 256;
+	daos_size_t		after_first_update;
+	daos_size_t		after_second_update;
+	daos_size_t		delta;
+	int			rc;
+
+	setup_context(&ctx, *state, iod_type, csum_type, oc, dedup_type,
+		      dedup_threshold_setting);
+
+	rc = ctx_update(&ctx);
+	assert_success(rc);
+	after_first_update = get_size(&ctx);
+
+	/** update again with same data */
+	rc = ctx_update(&ctx);
+	assert_success(rc);
+
+	/** if threshold is less than data size, dedup should prevent the extra
+	 * update and therefor the data used from the pool is much less.
+	 * Otherwise, the data used from the pool will be larger.
+	 */
+	after_second_update = get_size(&ctx);
+	delta = after_first_update - after_second_update;
+	if (dedup_threshold_setting == THRESHOLD_LESS_THAN_DATA &&
+	    delta > dedup_size_increase)
+		fail_msg("Pool used size increased by %lu, which is larger "
+			 "than expected size increase of less than or equal "
+			 "to %lu", delta, dedup_size_increase);
+	else if (dedup_threshold_setting == THRESHOLD_GREATER_THAN_DATA &&
+	    delta < dedup_size_increase)
+		fail_msg("Pool used size increased by %lu, which is less "
+			 "than expected size increase of greater than or equal "
+			 "to %lu", delta, dedup_size_increase);
+}
+
+static void
+array_csumoff_deduphash(void **state)
+{
+	with_identical_updates(state,
+			       DAOS_IOD_ARRAY,
+			       DAOS_PROP_CO_CSUM_OFF,
+			       OC_SX,
+			       DAOS_PROP_CO_DEDUP_HASH,
+			       THRESHOLD_LESS_THAN_DATA);
+}
+static void
+array_csumoff_dedupmemcmp(void **state)
+{
+	with_identical_updates(state,
+			       DAOS_IOD_ARRAY,
+			       DAOS_PROP_CO_CSUM_OFF,
+			       OC_SX,
+			       DAOS_PROP_CO_DEDUP_MEMCMP,
+			       THRESHOLD_LESS_THAN_DATA);
+}
+
+static void
+array_csumcrc64_deduphash(void **state)
+{
+	with_identical_updates(state,
+			       DAOS_IOD_ARRAY,
+			       DAOS_PROP_CO_CSUM_CRC64,
+			       OC_SX,
+			       DAOS_PROP_CO_DEDUP_HASH,
+			       THRESHOLD_LESS_THAN_DATA);
+}
+
+static void
+array_csumcrc64_dedupmemcmp(void **state)
+{
+	with_identical_updates(state,
+			       DAOS_IOD_ARRAY,
+			       DAOS_PROP_CO_CSUM_CRC64,
+			       OC_SX,
+			       DAOS_PROP_CO_DEDUP_MEMCMP,
+			       THRESHOLD_LESS_THAN_DATA);
+}
+
+static void
+array_above_threshold(void **state)
+{
+	with_identical_updates(state,
+			       DAOS_IOD_ARRAY,
+			       DAOS_PROP_CO_CSUM_CRC64,
+			       OC_SX,
+			       DAOS_PROP_CO_DEDUP_MEMCMP,
+			       THRESHOLD_GREATER_THAN_DATA);
+}
+
+static int
+setup(void **state)
+{
+	return test_setup(state, SETUP_POOL_CONNECT, true, DEFAULT_POOL_SIZE,
+			  NULL);
+}
+
+#define DEDUP_TEST(dsc, test) { dsc, test, NULL, test_case_teardown }
+static const struct CMUnitTest dedup_tests[] = {
+	DEDUP_TEST("DAOS_DEDUP01: With array type, csums disabled, hash dedup",
+		array_csumoff_deduphash),
+	DEDUP_TEST("DAOS_DEDUP02: With array type, csums disabled, hash memcmp",
+		   array_csumoff_dedupmemcmp),
+	DEDUP_TEST("DAOS_DEDUP03: With array type, csums crc64, hash dedup",
+		   array_csumcrc64_deduphash),
+	DEDUP_TEST("DAOS_DEDUP04: With array type, csums crc64, hash memcmp",
+		   array_csumcrc64_dedupmemcmp),
+	DEDUP_TEST("DAOS_DEDUP05: With array type, threshold greater than data "
+		   "should still update",
+		   array_above_threshold),
+};
+
+int
+run_daos_dedup_test(int rank, int size, int *sub_tests, int sub_tests_size)
+{
+	int rc = 0;
+
+	if (rank == 0) {
+		if (sub_tests_size == 0) {
+			rc = cmocka_run_group_tests_name("DAOS Checksum Tests",
+							 dedup_tests, setup,
+							 test_teardown);
+		} else {
+			rc = run_daos_sub_tests("DAOS Checksum Tests",
+						dedup_tests,
+						ARRAY_SIZE(dedup_tests),
+						sub_tests,
+						sub_tests_size, setup,
+						test_teardown);
+		}
+	}
+
+	MPI_Barrier(MPI_COMM_WORLD);
+	return rc;
+}

--- a/src/tests/suite/daos_test.c
+++ b/src/tests/suite/daos_test.c
@@ -34,7 +34,7 @@
  * all will be run if no test is specified. Tests will be run in order
  * so tests that kill nodes must be last.
  */
-#define TESTS "mpceXVizADKCoROdrFNv"
+#define TESTS "mpceXVizuADKCoROdrFNv"
 /**
  * These tests will only be run if explicity specified. They don't get
  * run if no test is specified.
@@ -62,6 +62,8 @@ print_usage(int rank)
 	print_message("daos_test -p|--daos_pool_tests\n");
 	print_message("daos_test -c|--daos_container_tests\n");
 	print_message("daos_test -C|--capa\n");
+	print_message("daos_test -u|--dedup\n");
+	print_message("daos_test -z|--checksum\n");
 	print_message("daos_test -X|--dtx\n");
 	print_message("daos_test -i|--daos_io_tests\n");
 	print_message("daos_test -x|--epoch_io\n");
@@ -147,6 +149,13 @@ run_specified_tests(const char *tests, int rank, int size,
 			daos_test_print(rank, "DAOS checksum tests..");
 			daos_test_print(rank, "=================");
 			nr_failed += run_daos_checksum_test(rank, size,
+						sub_tests, sub_tests_size);
+			break;
+		case 'u':
+			daos_test_print(rank, "\n\n=================");
+			daos_test_print(rank, "DAOS dedup tests..");
+			daos_test_print(rank, "=================");
+			nr_failed += run_daos_dedup_test(rank, size,
 						sub_tests, sub_tests_size);
 			break;
 		case 'x':
@@ -286,6 +295,7 @@ main(int argc, char **argv)
 		{"verify",	no_argument,		NULL,	'V'},
 		{"io",		no_argument,		NULL,	'i'},
 		{"checksum",	no_argument,		NULL,	'z'},
+		{"dedup",	no_argument,		NULL,	'u'},
 		{"epoch_io",	no_argument,		NULL,	'x'},
 		{"obj_array",	no_argument,		NULL,	'A'},
 		{"array",	no_argument,		NULL,	'D'},
@@ -325,7 +335,7 @@ main(int argc, char **argv)
 	memset(tests, 0, sizeof(tests));
 
 	while ((opt = getopt_long(argc, argv,
-				  "ampcCdXVizxADKeoROg:s:u:E:f:Fw:W:hrNv",
+				  "ampcCdXVizuxADKeoROg:s:u:E:f:Fw:W:hrNv",
 				  long_options, &index)) != -1) {
 		if (strchr(all_tests_defined, opt) != NULL) {
 			tests[ntests] = opt;

--- a/src/tests/suite/daos_test.h
+++ b/src/tests/suite/daos_test.h
@@ -295,6 +295,8 @@ int run_daos_dtx_test(int rank, int size, int *tests, int test_size);
 int run_daos_vc_test(int rank, int size, int *tests, int test_size);
 int run_daos_checksum_test(int rank, int size, int *sub_tests,
 			   int sub_tests_size);
+int run_daos_dedup_test(int rank, int size, int *sub_tests,
+			   int sub_tests_size);
 unsigned int daos_checksum_test_arg2type(char *optarg);
 int run_daos_fs_test(int rank, int size, int *tests, int test_size);
 int run_daos_nvme_recov_test(int rank, int size, int *sub_tests,

--- a/src/vos/tests/vts_io.c
+++ b/src/vos/tests/vts_io.c
@@ -515,7 +515,7 @@ io_test_add_csums(daos_iod_t *iod, d_sg_list_t *sgl,
 	size_t			 chunk_size = 1 << 12;
 	int			 rc = 0;
 
-	rc = daos_csummer_type_init(p_csummer, type, chunk_size, 0, 0, 0, 0);
+	rc = daos_csummer_type_init(p_csummer, type, chunk_size, 0);
 	if (rc)
 		return rc;
 	rc = daos_csummer_calc_iods(*p_csummer, sgl, iod, NULL, 1, false,


### PR DESCRIPTION
Let server know about dedup threshold and compute SHA256 hash only
for extents that are candidate to deduplication.

Signed-off-by: Johann Lombardi <johann.lombardi@intel.com>