### PR TITLE
WIP Fork DMG storage query commands from daos_test

### DIFF
--- a/src/include/daos/tests_lib.h
+++ b/src/include/daos/tests_lib.h
@@ -190,4 +190,20 @@ void
 dts_sgl_init_with_strings_repeat(d_sg_list_t *sgl, uint32_t repeat,
 	uint32_t count, char *d, ...);
 
+struct dmg_storage_query_output {
+	char	device_uuid[36];
+	int	read_errs;
+	int	write_errs;
+	int	unmap_errs;
+	int	cs_errs;
+};
+
+/** dmg cmg for listing per-server metadata (device and pool list) */
+int
+exec_dmg_storage_query_smd(bool device, struct dmg_storage_query_output *out);
+
+/** dmg storage query blobstore-health --device_uuid=DEVUUID */
+int
+exec_dmg_storage_query_blobstore_health(struct dmg_storage_query_output *out);
+
 #endif /* __DAOS_TESTS_LIB_H__ */


### PR DESCRIPTION
(DAOS-4658 & DAOS-4659)

Currently adds functions for running
dmg storage query smd --devices
&
dmg storage query blobstore-health --devuuid=UUID

Necessary output from the commands such as the device uuids as well as
the I/O error counters in the blobstore health data are parsed and
returned.
A daos_nvme_recovery test was added to demonstrate using these
forking functions.

Signed-off-by: Sydney Vanda <sydney.m.vanda@intel.com>