### PR TITLE
DAOS-5062 pool: Avoid IV retries under ps_lock

### DIFF
--- a/src/pool/srv_iv.c
+++ b/src/pool/srv_iv.c
@@ -632,7 +632,7 @@ ds_pool_iv_hdl_update(struct ds_pool *pool, uuid_t hdl_uuid, uint64_t flags,
 	memcpy(&pic->pic_creds[0], cred->iov_buf, cred->iov_len);
 
 	rc = pool_iv_update(pool->sp_iv_ns, IV_POOL_CONN, iv_entry, size,
-			    CRT_IV_SHORTCUT_NONE, CRT_IV_SYNC_EAGER, true);
+			    CRT_IV_SHORTCUT_NONE, CRT_IV_SYNC_EAGER, false);
 	D_DEBUG(DB_MD, DF_UUID" distribute hdl "DF_UUID" capas "DF_U64" %d\n",
 		DP_UUID(pool->sp_uuid), DP_UUID(hdl_uuid), sec_capas, rc);
 	D_FREE(iv_entry);

--- a/src/pool/srv_pool.c
+++ b/src/pool/srv_pool.c
@@ -2023,6 +2023,8 @@ ds_pool_connect_handler(crt_rpc_t *rpc)
 
 	rc = pool_connect_iv_dist(svc, in->pci_op.pi_hdl, in->pci_flags,
 				  sec_capas, &in->pci_cred);
+	if (rc == 0 && DAOS_FAIL_CHECK(DAOS_POOL_CONNECT_FAIL_CORPC))
+		rc = -DER_TIMEDOUT;
 	if (rc != 0) {
 		D_ERROR(DF_UUID": failed to connect to targets: "DF_RC"\n",
 			DP_UUID(in->pci_op.pi_uuid), DP_RC(rc));


### PR DESCRIPTION
ds_pool_iv_hdl_update, called from ds_pool_connect_handler holding
pool_svc.ps_lock, asks ds_iv to retry the IV update operation
automatically. If a server crashes, the pool map update can't obtain the
lock, while the IV update operation can't pick up a new pool map that
excludes the crashed server---a deadlock. This patch changes
ds_pool_iv_hdl_update to avoid retrying the IV update operation, so that
ds_pool_connect_handler will release the lock and leave the retry to the
client side. Also, this patch fixes the DAOS_POOL_CONNECT_FAIL_CORPC
fault injection used by the regressed pool_op_retry test.

Signed-off-by: Li Wei <wei.g.li@intel.com>