### PR TITLE
DAOS-5076 control: dont cache dmg storage scan scm result

### DIFF
--- a/src/control/server/ctl_storage_rpc.go
+++ b/src/control/server/ctl_storage_rpc.go
@@ -151,7 +151,7 @@ func (c *StorageControlService) StorageScan(ctx context.Context, req *ctlpb.Stor
 		}
 	}
 
-	ssr, err := c.scm.Scan(scm.ScanRequest{})
+	ssr, err := c.scm.Scan(scm.ScanRequest{Rescan: true})
 	if err != nil {
 		resp.Scm = &ctlpb.ScanScmResp{
 			State: newState(c.log, ctlpb.ResponseStatus_CTL_ERR_SCM, err.Error(), "", msg+"SCM"),


### PR DESCRIPTION
Set rescan to true to disable cache on SCM storage discovery so PMEM
(not DCPM) details are returned (from scan) after storage prepare.

Signed-off-by: Tom Nabarro <tom.nabarro@intel.com>