### PR TITLE
DAOS-4818 dtx: Pass DTX to QUERY and ENUM

### DIFF
--- a/src/client/api/object.c
+++ b/src/client/api/object.c
@@ -131,8 +131,8 @@ daos_obj_punch_akeys(daos_handle_t oh, daos_handle_t th, uint64_t flags,
 }
 
 int
-daos_obj_query(daos_handle_t oh, daos_handle_t th, struct daos_obj_attr *oa,
-	       d_rank_list_t *ranks, daos_event_t *ev)
+daos_obj_query(daos_handle_t oh, struct daos_obj_attr *oa, d_rank_list_t *ranks,
+	       daos_event_t *ev)
 {
 	D_ERROR("Unsupported API\n");
 	return -DER_NOSYS;

--- a/src/container/srv_target.c
+++ b/src/container/srv_target.c
@@ -709,7 +709,7 @@ ds_cont_child_start_all(struct ds_pool_child *pool_child)
 	iter_param.ip_hdl = pool_child->spc_hdl;
 	/* The quantity of container is small, no need to yield */
 	rc = vos_iterate(&iter_param, VOS_ITER_COUUID, false, &anchors,
-			 cont_child_start_cb, NULL, (void *)pool_child);
+			 cont_child_start_cb, NULL, (void *)pool_child, NULL);
 	return rc;
 }
 
@@ -1871,7 +1871,7 @@ ds_cont_iter(daos_handle_t ph, uuid_t co_uuid, cont_iter_cb_t callback,
 	param.ip_epr.epr_hi = DAOS_EPOCH_MAX;
 	param.ip_flags = VOS_IT_FOR_REBUILD;
 
-	rc = vos_iter_prepare(type, &param, &iter_h);
+	rc = vos_iter_prepare(type, &param, &iter_h, NULL);
 	if (rc != 0) {
 		D_ERROR("prepare obj iterator failed "DF_RC"\n", DP_RC(rc));
 		D_GOTO(close, rc);

--- a/src/dtx/dtx_resync.c
+++ b/src/dtx/dtx_resync.c
@@ -436,7 +436,7 @@ dtx_resync_one(void *data)
 	param.ip_hdl = child->spc_hdl;
 	param.ip_flags = VOS_IT_FOR_REBUILD;
 	rc = vos_iterate(&param, VOS_ITER_COUUID, false, &anchor,
-			 container_scan_cb, NULL, &cb_arg);
+			 container_scan_cb, NULL, &cb_arg, NULL);
 
 	ds_pool_child_put(child);
 out:

--- a/src/include/daos_obj.h
+++ b/src/include/daos_obj.h
@@ -745,8 +745,9 @@ daos_obj_list_akey(daos_handle_t oh, daos_handle_t th, daos_key_t *dkey,
  *			records.
  *
  * \param[in,out]
- *		eprs	[in]: preallocated array of \nr epoch ranges. [out]:
- *			returned epoch ranges.
+ *		eprs	[in]: optional preallocated array of \nr epoch ranges.
+ *			[out]: if eprs is not NULL, returned epoch ranges. This
+ *			parameter shall only be passed if th is DAOS_TX_NONE.
  *
  * \param[in,out]
  *		anchor	Hash anchor for the next call, it should be set to

--- a/src/include/daos_obj.h
+++ b/src/include/daos_obj.h
@@ -517,9 +517,7 @@ daos_obj_query(daos_handle_t oh, struct daos_obj_attr *oa, d_rank_list_t *ranks,
  *		iods	[in]: Array of I/O descriptors. Each descriptor is
  *			associated with a given akey and describes the list of
  *			record extents to fetch from the array.
- *			A different epoch can be passed for each extent via
- *			\a iods[]::iod_eprs[] and in this case, \a epoch will be
- *			ignored. [out]: Checksum of each extent is returned via
+ *			[out]: Checksum of each extent is returned via
  *			\a iods[]::iod_csums[]. If the record size of an
  *			extent is unknown (i.e. set to DAOS_REC_ANY as input),
  *			then the actual record size will be returned in
@@ -581,9 +579,6 @@ daos_obj_fetch(daos_handle_t oh, daos_handle_t th, uint64_t flags,
  * \param[in]	iods	Array of I/O descriptor. Each descriptor is associated
  *			with an array identified by its akey and describes the
  *			list of record extent to update.
- *			A different epoch can be passed for each extent via
- *			\a iods[]::iod_eprs[] and in this case, \a epoch will be
- *			ignored.
  *			Checksum of each record extent is stored in
  *			\a iods[]::iod_csums[]. If the record size of an extent
  *			is zero, then it is effectively a punch for the
@@ -743,9 +738,8 @@ daos_obj_list_akey(daos_handle_t oh, daos_handle_t th, daos_key_t *dkey,
  *			records.
  *
  * \param[in,out]
- *		eprs	[in]: optional preallocated array of \nr epoch ranges.
- *			[out]: if eprs is not NULL, returned epoch ranges. This
- *			parameter shall only be passed if th is DAOS_TX_NONE.
+ *		eprs	[in]: preallocated array of \nr epoch ranges. [out]:
+ *			returned epoch ranges.
  *
  * \param[in,out]
  *		anchor	Hash anchor for the next call, it should be set to

--- a/src/include/daos_obj.h
+++ b/src/include/daos_obj.h
@@ -478,8 +478,6 @@ daos_obj_punch_akeys(daos_handle_t oh, daos_handle_t th, uint64_t flags,
  * Caller should provide at least one of the output parameters.
  *
  * \param[in]	oh	Object open handle.
- * \param[in]	th	Optional transaction handle to query with.
- *			Use DAOS_TX_NONE for an independent transaction.
  * \param[out]	oa	Returned object attributes.
  * \param[out]	ranks	Ordered list of ranks where the object is stored.
  * \param[in]	ev	Completion event, it is optional and can be NULL.
@@ -493,8 +491,8 @@ daos_obj_punch_akeys(daos_handle_t oh, daos_handle_t th, uint64_t flags,
  *			-DER_UNREACH	Network is unreachable
  */
 int
-daos_obj_query(daos_handle_t oh, daos_handle_t th, struct daos_obj_attr *oa,
-	       d_rank_list_t *ranks, daos_event_t *ev);
+daos_obj_query(daos_handle_t oh, struct daos_obj_attr *oa, d_rank_list_t *ranks,
+	       daos_event_t *ev);
 
 /*
  * Object I/O API

--- a/src/include/daos_srv/daos_server.h
+++ b/src/include/daos_srv/daos_server.h
@@ -693,9 +693,10 @@ struct dss_enum_arg {
 	daos_unit_oid_t		oid;		/* for unpack */
 };
 
-int
-dss_enum_pack(vos_iter_param_t *param, vos_iter_type_t type, bool recursive,
-	      struct vos_iter_anchors *anchors, struct dss_enum_arg *arg);
+struct dtx_handle;
+int dss_enum_pack(vos_iter_param_t *param, vos_iter_type_t type, bool recursive,
+		  struct vos_iter_anchors *anchors, struct dss_enum_arg *arg,
+		  struct dtx_handle *dth);
 
 /** Maximal number of iods (i.e., akeys) in dss_enum_unpack_io.ui_iods */
 #define DSS_ENUM_UNPACK_MAX_IODS 16

--- a/src/include/daos_srv/vos.h
+++ b/src/include/daos_srv/vos.h
@@ -681,12 +681,13 @@ vos_iod_sgl_at(daos_handle_t ioh, unsigned int idx);
  *			is inherited from that entry.
  *
  * \param ih	[OUT]	Returned iterator handle
+ * \param dth	[IN]	Pointer to the DTX handle.
  *
  * \return		Zero on success, negative value if error
  */
 int
 vos_iter_prepare(vos_iter_type_t type, vos_iter_param_t *param,
-		 daos_handle_t *ih);
+		 daos_handle_t *ih, struct dtx_handle *dth);
 
 /**
  * Release a iterator
@@ -805,6 +806,7 @@ vos_iter_empty(daos_handle_t ih);
  * \param[in]		pre_cb		pre subtree iteration callback
  * \param[in]		post_cb		post subtree iteration callback
  * \param[in]		arg		callback argument
+ * \param[in]		dth		DTX handle
  *
  * \retval		0	iteration complete
  * \retval		> 0	callback return value
@@ -813,7 +815,7 @@ vos_iter_empty(daos_handle_t ih);
 int
 vos_iterate(vos_iter_param_t *param, vos_iter_type_t type, bool recursive,
 	    struct vos_iter_anchors *anchors, vos_iter_cb_t pre_cb,
-	    vos_iter_cb_t post_cb, void *arg);
+	    vos_iter_cb_t post_cb, void *arg, struct dtx_handle *dth);
 
 /**
  * Retrieve the largest or smallest integer DKEY, AKEY, and array offset from an
@@ -853,6 +855,7 @@ vos_iterate(vos_iter_param_t *param, vos_iter_type_t type, bool recursive,
  * \param[out]	recx	max or min offset in dkey/akey, and the size of the
  *			extent at the offset. If there are no visible array
  *			records, the size in the recx returned will be 0.
+ * \param[in]	dth	Pointer to the DTX handle.
  *
  * \return
  *			0		Success
@@ -863,7 +866,7 @@ vos_iterate(vos_iter_param_t *param, vos_iter_type_t type, bool recursive,
 int
 vos_obj_query_key(daos_handle_t coh, daos_unit_oid_t oid, uint32_t flags,
 		  daos_epoch_t epoch, daos_key_t *dkey, daos_key_t *akey,
-		  daos_recx_t *recx);
+		  daos_recx_t *recx, struct dtx_handle *dth);
 
 /** Return constants that can be used to estimate the metadata overhead
  *  in persistent memory on-disk format.

--- a/src/iosrv/vos.c
+++ b/src/iosrv/vos.c
@@ -423,6 +423,7 @@ enum_pack_cb(daos_handle_t ih, vos_iter_entry_t *entry, vos_iter_type_t type,
  * \param[in]		recursive	iterate to next level recursively
  * \param[in]		anchors		iteration anchors
  * \param[in,out]	arg		enumeration argument
+ * \param[in]		dth		DTX handle
  *
  * \retval		0	enumeration complete
  * \retval		1	buffer(s) full
@@ -430,7 +431,8 @@ enum_pack_cb(daos_handle_t ih, vos_iter_entry_t *entry, vos_iter_type_t type,
  */
 int
 dss_enum_pack(vos_iter_param_t *param, vos_iter_type_t type, bool recursive,
-	      struct vos_iter_anchors *anchors, struct dss_enum_arg *arg)
+	      struct vos_iter_anchors *anchors, struct dss_enum_arg *arg,
+	      struct dtx_handle *dth)
 {
 	int	rc;
 
@@ -438,7 +440,7 @@ dss_enum_pack(vos_iter_param_t *param, vos_iter_type_t type, bool recursive,
 		 type == VOS_ITER_SINGLE || type == VOS_ITER_RECX);
 
 	rc = vos_iterate(param, type, recursive, anchors, enum_pack_cb, NULL,
-			 arg);
+			 arg, dth);
 
 	D_DEBUG(DB_IO, "enum type %d tag %d rc "DF_RC"\n", type,
 		dss_get_module_info()->dmi_tgt_id, DP_RC(rc));

--- a/src/object/cli_obj.c
+++ b/src/object/cli_obj.c
@@ -1755,12 +1755,6 @@ obj_req_valid(tse_task_t *task, void *args, int opc, struct dc_obj_epoch *epoch,
 			}
 		}
 
-		if (daos_handle_is_valid(l_args->th) && l_args->eprs != NULL) {
-			D_ERROR("epoch range is not allowed for transactional "
-				"listing\n");
-			D_GOTO(out, rc = -DER_INVAL);
-		}
-
 		rc = dc_tx_hdl2epoch_and_pmv(l_args->th, epoch, pm_ver);
 		if (rc != 0) {
 			if (rc != -DER_INVAL)

--- a/src/object/cli_obj.c
+++ b/src/object/cli_obj.c
@@ -1755,6 +1755,12 @@ obj_req_valid(tse_task_t *task, void *args, int opc, struct dc_obj_epoch *epoch,
 			}
 		}
 
+		if (daos_handle_is_valid(l_args->th) && l_args->eprs != NULL) {
+			D_ERROR("epoch range is not allowed for transactional "
+				"listing\n");
+			D_GOTO(out, rc = -DER_INVAL);
+		}
+
 		rc = dc_tx_hdl2epoch_and_pmv(l_args->th, epoch, pm_ver);
 		if (rc != 0) {
 			if (rc != -DER_INVAL)
@@ -3097,6 +3103,17 @@ obj_list_common(tse_task_t *task, int opc, daos_obj_list_t *args)
 	if (args->dkey == NULL)
 		dc_obj_shard2anchor(args->dkey_anchor, shard);
 
+	if (daos_handle_is_valid(args->th)) {
+		rc = dc_tx_get_dti(args->th, &obj_auxi->l_args.la_dti);
+		/*
+		 * The obj_req_valid call above has already verified this
+		 * transaction handle.
+		 */
+		D_ASSERTF(rc == 0, "%d\n", rc);
+	} else {
+		daos_dti_gen(&obj_auxi->l_args.la_dti, true /* zero */);
+	}
+
 	D_DEBUG(DB_IO, "list opc %d "DF_OID" dkey %llu\n", opc,
 		DP_OID(obj->cob_md.omd_id), (unsigned long long)dkey_hash);
 
@@ -3390,7 +3407,7 @@ struct shard_query_key_args {
 	uuid_t			 kqa_cont_uuid;
 	daos_obj_query_key_t	*kqa_api_args;
 	uint64_t		 kqa_dkey_hash;
-	daos_epoch_t		 kqa_epoch;
+	struct dtx_id		 kqa_dti;
 };
 
 static int
@@ -3419,10 +3436,11 @@ shard_query_key_task(tse_task_t *task)
 	tse_task_stack_push_data(task, &args->kqa_dkey_hash,
 				 sizeof(args->kqa_dkey_hash));
 	api_args = args->kqa_api_args;
-	rc = dc_obj_shard_query_key(obj_shard, args->kqa_epoch, api_args->flags,
-				    obj, api_args->dkey, api_args->akey,
-				    api_args->recx, args->kqa_coh_uuid,
-				    args->kqa_cont_uuid,
+	rc = dc_obj_shard_query_key(obj_shard, &args->kqa_auxi.epoch,
+				    api_args->flags, obj, api_args->dkey,
+				    api_args->akey, api_args->recx,
+				    args->kqa_coh_uuid, args->kqa_cont_uuid,
+				    &args->kqa_dti,
 				    &args->kqa_auxi.obj_auxi->map_ver_reply,
 				    task);
 
@@ -3471,6 +3489,7 @@ dc_obj_query_key(tse_task_t *api_task)
 	unsigned int		map_ver = 0;
 	uint64_t		dkey_hash;
 	struct dc_obj_epoch	epoch;
+	struct dtx_id		dti;
 	int			i = 0;
 	int			rc;
 
@@ -3485,6 +3504,17 @@ dc_obj_query_key(tse_task_t *api_task)
 
 		dc_io_epoch_set(&epoch);
 		D_DEBUG(DB_IO, "set query epoch "DF_U64"\n", epoch.oe_value);
+	}
+
+	if (daos_handle_is_valid(api_args->th)) {
+		rc = dc_tx_get_dti(api_args->th, &dti);
+		/*
+		 * The dc_tx_hdl2epoch_and_pmv call above has already verified
+		 * this transaction handle.
+		 */
+		D_ASSERTF(rc == 0, "%d\n", rc);
+	} else {
+		daos_dti_gen(&dti, true /* zero */);
 	}
 
 	obj = obj_hdl2ptr(api_args->oh);
@@ -3601,13 +3631,14 @@ dc_obj_query_key(tse_task_t *api_task)
 
 		args = tse_task_buf_embedded(task, sizeof(*args));
 		args->kqa_api_args	= api_args;
-		args->kqa_epoch		= epoch.oe_value;
+		args->kqa_auxi.epoch	= epoch;
 		args->kqa_auxi.shard	= shard;
 		args->kqa_auxi.target	= obj_shard2tgtid(obj, shard);
 		args->kqa_auxi.map_ver	= map_ver;
 		args->kqa_auxi.obj	= obj;
 		args->kqa_auxi.obj_auxi	= obj_auxi;
 		args->kqa_dkey_hash	= dkey_hash;
+		args->kqa_dti		= dti;
 		uuid_copy(args->kqa_coh_uuid, coh_uuid);
 		uuid_copy(args->kqa_cont_uuid, cont_uuid);
 

--- a/src/object/cli_shard.c
+++ b/src/object/cli_shard.c
@@ -994,6 +994,12 @@ dc_obj_shard_list(struct dc_obj_shard *obj_shard, enum obj_rpc_opc opc,
 		oei->oei_akey = *obj_args->akey;
 	oei->oei_oid		= obj_shard->do_id;
 	oei->oei_map_ver	= args->la_auxi.map_ver;
+	/*
+	 * If an epoch range is specified, we shall not assume any epoch
+	 * uncertainty.
+	 */
+	if (args->la_auxi.epoch.oe_uncertain && obj_args->eprs != NULL)
+		oei->oei_flags |= ORF_EPOCH_UNCERTAIN;
 	if (obj_args->eprs != NULL && opc == DAOS_OBJ_RPC_ENUMERATE) {
 		oei->oei_epr = *obj_args->eprs;
 	} else {
@@ -1006,6 +1012,7 @@ dc_obj_shard_list(struct dc_obj_shard *obj_shard, enum obj_rpc_opc opc,
 	uuid_copy(oei->oei_pool_uuid, pool->dp_pool);
 	uuid_copy(oei->oei_co_hdl, cont_hdl_uuid);
 	uuid_copy(oei->oei_co_uuid, cont_uuid);
+	daos_dti_copy(&oei->oei_dti, &args->la_dti);
 
 	if (obj_args->anchor != NULL)
 		enum_anchor_copy(&oei->oei_anchor, obj_args->anchor);
@@ -1090,7 +1097,6 @@ struct obj_query_key_cb_args {
 	crt_rpc_t		*rpc;
 	unsigned int		*map_ver;
 	daos_unit_oid_t		oid;
-	uint32_t		flags;
 	daos_key_t		*dkey;
 	daos_key_t		*akey;
 	daos_recx_t		*recx;
@@ -1115,7 +1121,7 @@ obj_shard_query_key_cb(tse_task_t *task, void *data)
 	okqi = crt_req_get(cb_args->rpc);
 	D_ASSERT(okqi != NULL);
 
-	flags = okqi->okqi_flags;
+	flags = okqi->okqi_api_flags;
 	opc = opc_get(cb_args->rpc->cr_opc);
 
 	if (ret != 0) {
@@ -1212,11 +1218,12 @@ out:
 }
 
 int
-dc_obj_shard_query_key(struct dc_obj_shard *shard, daos_epoch_t epoch,
+dc_obj_shard_query_key(struct dc_obj_shard *shard, struct dc_obj_epoch *epoch,
 		       uint32_t flags, struct dc_object *obj, daos_key_t *dkey,
 		       daos_key_t *akey, daos_recx_t *recx,
 		       const uuid_t coh_uuid, const uuid_t cont_uuid,
-		       unsigned int *map_ver, tse_task_t *task)
+		       struct dtx_id *dti, unsigned int *map_ver,
+		       tse_task_t *task)
 {
 	struct dc_pool			*pool = NULL;
 	struct obj_query_key_in		*okqi;
@@ -1252,7 +1259,6 @@ dc_obj_shard_query_key(struct dc_obj_shard *shard, daos_epoch_t epoch,
 	cb_args.rpc	= req;
 	cb_args.map_ver = map_ver;
 	cb_args.oid	= shard->do_id;
-	cb_args.flags	= flags;
 	cb_args.dkey	= dkey;
 	cb_args.akey	= akey;
 	cb_args.recx	= recx;
@@ -1267,16 +1273,19 @@ dc_obj_shard_query_key(struct dc_obj_shard *shard, daos_epoch_t epoch,
 	D_ASSERT(okqi != NULL);
 
 	okqi->okqi_map_ver		= *map_ver;
-	okqi->okqi_epoch		= epoch;
-	okqi->okqi_flags		= flags;
+	okqi->okqi_epoch		= epoch->oe_value;
+	okqi->okqi_api_flags		= flags;
 	okqi->okqi_oid			= oid;
 	if (dkey != NULL)
 		okqi->okqi_dkey		= *dkey;
 	if (akey != NULL)
 		okqi->okqi_akey		= *akey;
+	if (epoch->oe_uncertain)
+		okqi->okqi_flags	= ORF_EPOCH_UNCERTAIN;
 	uuid_copy(okqi->okqi_pool_uuid, pool->dp_pool);
 	uuid_copy(okqi->okqi_co_hdl, coh_uuid);
 	uuid_copy(okqi->okqi_co_uuid, cont_uuid);
+	daos_dti_copy(&okqi->okqi_dti, dti);
 
 	rc = daos_rpc_send(req, task);
 	if (rc != 0) {

--- a/src/object/cli_shard.c
+++ b/src/object/cli_shard.c
@@ -994,14 +994,15 @@ dc_obj_shard_list(struct dc_obj_shard *obj_shard, enum obj_rpc_opc opc,
 		oei->oei_akey = *obj_args->akey;
 	oei->oei_oid		= obj_shard->do_id;
 	oei->oei_map_ver	= args->la_auxi.map_ver;
-	/*
-	 * If an epoch range is specified, we shall not assume any epoch
-	 * uncertainty.
-	 */
-	if (args->la_auxi.epoch.oe_uncertain && obj_args->eprs != NULL)
+	if (args->la_auxi.epoch.oe_uncertain)
 		oei->oei_flags |= ORF_EPOCH_UNCERTAIN;
 	if (obj_args->eprs != NULL && opc == DAOS_OBJ_RPC_ENUMERATE) {
 		oei->oei_epr = *obj_args->eprs;
+		/*
+		 * If an epoch range is specified, we shall not assume any
+		 * epoch uncertainty.
+		 */
+		oei->oei_flags &= ~ORF_EPOCH_UNCERTAIN;
 	} else {
 		oei->oei_epr.epr_lo = 0;
 		oei->oei_epr.epr_hi = args->la_auxi.epoch.oe_value;

--- a/src/object/obj_internal.h
+++ b/src/object/obj_internal.h
@@ -297,6 +297,7 @@ struct shard_punch_args {
 struct shard_list_args {
 	struct shard_auxi_args	 la_auxi;
 	daos_obj_list_t		*la_api_args;
+	struct dtx_id		 la_dti;
 };
 
 struct ec_bulk_spec {
@@ -387,11 +388,12 @@ int dc_obj_shard_list(struct dc_obj_shard *shard, enum obj_rpc_opc opc,
 		      void *shard_args, struct daos_shard_tgt *fw_shard_tgts,
 		      uint32_t fw_cnt, tse_task_t *task);
 
-int dc_obj_shard_query_key(struct dc_obj_shard *shard, daos_epoch_t epoch,
-			   uint32_t flags, struct dc_object *obj,
-			   daos_key_t *dkey, daos_key_t *akey,
-			   daos_recx_t *recx, const uuid_t coh_uuid,
-			   const uuid_t cont_uuid, unsigned int *map_ver,
+int dc_obj_shard_query_key(struct dc_obj_shard *shard,
+			   struct dc_obj_epoch *epoch, uint32_t flags,
+			   struct dc_object *obj, daos_key_t *dkey,
+			   daos_key_t *akey, daos_recx_t *recx,
+			   const uuid_t coh_uuid, const uuid_t cont_uuid,
+			   struct dtx_id *dti, unsigned int *map_ver,
 			   tse_task_t *task);
 
 int dc_obj_shard_sync(struct dc_obj_shard *shard, enum obj_rpc_opc opc,

--- a/src/object/obj_rpc.h
+++ b/src/object/obj_rpc.h
@@ -200,6 +200,7 @@ CRT_RPC_DECLARE(obj_rw,		DAOS_ISEQ_OBJ_RW, DAOS_OSEQ_OBJ_RW)
 
 /* object Enumerate in/out */
 #define DAOS_ISEQ_OBJ_KEY_ENUM	/* input fields */		 \
+	((struct dtx_id)	(oei_dti)		CRT_VAR) \
 	((daos_unit_oid_t)	(oei_oid)		CRT_VAR) \
 	((uuid_t)		(oei_pool_uuid)		CRT_VAR) \
 	((uuid_t)		(oei_co_hdl)		CRT_VAR) \
@@ -208,7 +209,7 @@ CRT_RPC_DECLARE(obj_rw,		DAOS_ISEQ_OBJ_RW, DAOS_OSEQ_OBJ_RW)
 	((uint32_t)		(oei_map_ver)		CRT_VAR) \
 	((uint32_t)		(oei_nr)		CRT_VAR) \
 	((uint32_t)		(oei_rec_type)		CRT_VAR) \
-	((uint32_t)		(oei_pad)		CRT_VAR) \
+	((uint32_t)		(oei_flags)		CRT_VAR) \
 	((daos_key_t)		(oei_dkey)		CRT_VAR) \
 	((daos_key_t)		(oei_akey)		CRT_VAR) \
 	((daos_anchor_t)	(oei_anchor)		CRT_VAR) \
@@ -258,13 +259,16 @@ CRT_RPC_DECLARE(obj_key_enum, DAOS_ISEQ_OBJ_KEY_ENUM, DAOS_OSEQ_OBJ_KEY_ENUM)
 CRT_RPC_DECLARE(obj_punch, DAOS_ISEQ_OBJ_PUNCH, DAOS_OSEQ_OBJ_PUNCH)
 
 #define DAOS_ISEQ_OBJ_QUERY_KEY	/* input fields */		 \
+	((struct dtx_id)	(okqi_dti)		CRT_VAR) \
 	((uuid_t)		(okqi_co_hdl)		CRT_VAR) \
 	((uuid_t)		(okqi_pool_uuid)	CRT_VAR) \
 	((uuid_t)		(okqi_co_uuid)		CRT_VAR) \
 	((daos_unit_oid_t)	(okqi_oid)		CRT_VAR) \
 	((uint64_t)		(okqi_epoch)		CRT_VAR) \
 	((uint32_t)		(okqi_map_ver)		CRT_VAR) \
+	((uint32_t)		(okqi_api_flags)	CRT_VAR) \
 	((uint32_t)		(okqi_flags)		CRT_VAR) \
+	((uint32_t)		(okqi_padding)		CRT_VAR) \
 	((daos_key_t)		(okqi_dkey)		CRT_VAR) \
 	((daos_key_t)		(okqi_akey)		CRT_VAR) \
 	((daos_recx_t)		(okqi_recx)		CRT_VAR)

--- a/src/object/obj_rpc.h
+++ b/src/object/obj_rpc.h
@@ -266,9 +266,8 @@ CRT_RPC_DECLARE(obj_punch, DAOS_ISEQ_OBJ_PUNCH, DAOS_OSEQ_OBJ_PUNCH)
 	((daos_unit_oid_t)	(okqi_oid)		CRT_VAR) \
 	((uint64_t)		(okqi_epoch)		CRT_VAR) \
 	((uint32_t)		(okqi_map_ver)		CRT_VAR) \
-	((uint32_t)		(okqi_api_flags)	CRT_VAR) \
 	((uint32_t)		(okqi_flags)		CRT_VAR) \
-	((uint32_t)		(okqi_padding)		CRT_VAR) \
+	((uint64_t)		(okqi_api_flags)	CRT_VAR) \
 	((daos_key_t)		(okqi_dkey)		CRT_VAR) \
 	((daos_key_t)		(okqi_akey)		CRT_VAR) \
 	((daos_recx_t)		(okqi_recx)		CRT_VAR)

--- a/src/object/srv_obj.c
+++ b/src/object/srv_obj.c
@@ -1780,9 +1780,8 @@ cleanup:
 static void
 obj_enum_complete(crt_rpc_t *rpc, int status, int map_version)
 {
-	struct obj_key_enum_out *oeo;
-	struct obj_key_enum_in *oei;
-	int rc;
+	struct obj_key_enum_out	*oeo;
+	int			 rc;
 
 	obj_reply_set_status(rpc, status);
 	obj_reply_map_version_set(rpc, map_version);
@@ -1790,8 +1789,6 @@ obj_enum_complete(crt_rpc_t *rpc, int status, int map_version)
 	if (rc != 0)
 		D_ERROR("send reply failed: "DF_RC"\n", DP_RC(rc));
 
-	oei = crt_req_get(rpc);
-	D_ASSERT(oei != NULL);
 	oeo = crt_reply_get(rpc);
 	D_ASSERT(oeo != NULL);
 
@@ -1820,7 +1817,9 @@ obj_local_enum(struct obj_io_context *ioc, crt_rpc_t *rpc,
 	int			opc = opc_get(rpc->cr_opc);
 	int			type;
 	int			rc;
+	int			rc_tmp;
 	bool			recursive = false;
+	struct dtx_handle	dth = {0};
 
 	enum_arg->csummer = ioc->ioc_coh->sch_csummer;
 	/* prepare enumeration parameters */
@@ -1885,7 +1884,22 @@ obj_local_enum(struct obj_io_context *ioc, crt_rpc_t *rpc,
 		DAOS_FAIL_CHECK(DAOS_VC_LOST_REPLICA))
 		D_GOTO(failed, rc =  -DER_NONEXIST);
 
-	rc = dss_enum_pack(&param, type, recursive, anchors, enum_arg);
+	/*
+	 * If oei->oei_dti is not zero, an epoch range is not specified by the
+	 * user. (See obj_list_common and obj_req_valid.) oei->oei_epr.epr_hi
+	 * is our epoch. (See dc_obj_shard_list.)
+	 */
+	rc = dtx_begin(ioc->ioc_coc, &oei->oei_dti, oei->oei_epr.epr_hi,
+		       oei->oei_flags & ORF_EPOCH_UNCERTAIN, oei->oei_map_ver,
+		       &oei->oei_oid, 0, DAOS_INTENT_DEFAULT, NULL, 0, &dth);
+	D_ASSERTF(rc == 0, "%d\n", rc);
+
+	rc = dss_enum_pack(&param, type, recursive, anchors, enum_arg, &dth);
+
+	/* dss_enum_pack may return 1. */
+	rc_tmp = dtx_end(&dth, ioc->ioc_coc, rc > 0 ? 0 : rc);
+	if (rc_tmp != 0)
+		rc = rc_tmp;
 
 	if (type == VOS_ITER_SINGLE)
 		anchors->ia_ev = anchors->ia_sv;
@@ -2417,6 +2431,7 @@ ds_obj_query_key_handler(crt_rpc_t *rpc)
 	daos_key_t			*dkey;
 	daos_key_t			*akey;
 	struct obj_io_context		 ioc;
+	struct dtx_handle		 dth = {0};
 	int				 rc;
 
 	okqi = crt_req_get(rpc);
@@ -2424,10 +2439,11 @@ ds_obj_query_key_handler(crt_rpc_t *rpc)
 	okqo = crt_reply_get(rpc);
 	D_ASSERT(okqo != NULL);
 
-	D_DEBUG(DB_IO, "flags = %d\n", okqi->okqi_flags);
+	D_DEBUG(DB_IO, "flags = %d\n", okqi->okqi_api_flags);
 
 	if (okqi->okqi_epoch == DAOS_EPOCH_MAX || okqi->okqi_epoch == 0) {
 		okqi->okqi_epoch = crt_hlc_get();
+		okqi->okqi_flags &= ~ORF_EPOCH_UNCERTAIN;
 		D_DEBUG(DB_IO, "overwrite epoch "DF_U64"\n", okqi->okqi_epoch);
 	}
 
@@ -2441,14 +2457,24 @@ ds_obj_query_key_handler(crt_rpc_t *rpc)
 	akey = &okqi->okqi_akey;
 	d_iov_set(&okqo->okqo_akey, NULL, 0);
 	d_iov_set(&okqo->okqo_dkey, NULL, 0);
-	if (okqi->okqi_flags & DAOS_GET_DKEY)
+	if (okqi->okqi_api_flags & DAOS_GET_DKEY)
 		dkey = &okqo->okqo_dkey;
-	if (okqi->okqi_flags & DAOS_GET_AKEY)
+	if (okqi->okqi_api_flags & DAOS_GET_AKEY)
 		akey = &okqo->okqo_akey;
 
+	rc = dtx_begin(ioc.ioc_coc, &okqi->okqi_dti, okqi->okqi_epoch,
+		       okqi->okqi_flags & ORF_EPOCH_UNCERTAIN,
+		       okqi->okqi_map_ver, &okqi->okqi_oid, 0,
+		       DAOS_INTENT_DEFAULT, NULL, 0, &dth);
+	D_ASSERTF(rc == 0, "%d\n", rc);
+
 	rc = vos_obj_query_key(ioc.ioc_vos_coh, okqi->okqi_oid,
-			       VOS_USE_TIMESTAMPS | okqi->okqi_flags,
-			       okqi->okqi_epoch, dkey, akey, &okqo->okqo_recx);
+			       VOS_USE_TIMESTAMPS | okqi->okqi_api_flags,
+			       okqi->okqi_epoch, dkey, akey, &okqo->okqo_recx,
+			       &dth);
+
+	rc = dtx_end(&dth, ioc.ioc_coc, rc);
+
 out:
 	obj_reply_set_status(rpc, rc);
 	obj_reply_map_version_set(rpc, ioc.ioc_map_ver);

--- a/src/object/srv_obj.c
+++ b/src/object/srv_obj.c
@@ -1891,7 +1891,8 @@ obj_local_enum(struct obj_io_context *ioc, crt_rpc_t *rpc,
 	 */
 	rc = dtx_begin(ioc->ioc_coc, &oei->oei_dti, oei->oei_epr.epr_hi,
 		       oei->oei_flags & ORF_EPOCH_UNCERTAIN, oei->oei_map_ver,
-		       &oei->oei_oid, 0, DAOS_INTENT_DEFAULT, NULL, 0, &dth);
+		       &oei->oei_oid, 0, DAOS_INTENT_DEFAULT, NULL, 0, NULL,
+		       &dth);
 	D_ASSERTF(rc == 0, "%d\n", rc);
 
 	rc = dss_enum_pack(&param, type, recursive, anchors, enum_arg, &dth);
@@ -2439,7 +2440,7 @@ ds_obj_query_key_handler(crt_rpc_t *rpc)
 	okqo = crt_reply_get(rpc);
 	D_ASSERT(okqo != NULL);
 
-	D_DEBUG(DB_IO, "flags = %d\n", okqi->okqi_api_flags);
+	D_DEBUG(DB_IO, "flags = "DF_U64"\n", okqi->okqi_api_flags);
 
 	if (okqi->okqi_epoch == DAOS_EPOCH_MAX || okqi->okqi_epoch == 0) {
 		okqi->okqi_epoch = crt_hlc_get();
@@ -2465,7 +2466,7 @@ ds_obj_query_key_handler(crt_rpc_t *rpc)
 	rc = dtx_begin(ioc.ioc_coc, &okqi->okqi_dti, okqi->okqi_epoch,
 		       okqi->okqi_flags & ORF_EPOCH_UNCERTAIN,
 		       okqi->okqi_map_ver, &okqi->okqi_oid, 0,
-		       DAOS_INTENT_DEFAULT, NULL, 0, &dth);
+		       DAOS_INTENT_DEFAULT, NULL, 0, NULL, &dth);
 	D_ASSERTF(rc == 0, "%d\n", rc);
 
 	rc = vos_obj_query_key(ioc.ioc_vos_coh, okqi->okqi_oid,

--- a/src/rdb/rdb_raft.c
+++ b/src/rdb/rdb_raft.c
@@ -407,7 +407,8 @@ rdb_raft_pack_chunk(daos_handle_t lc, struct rdb_raft_is *is, d_iov_t *kds,
 	arg.inline_thres = 1 * 1024 * 1024;
 
 	/* Enumerate from the object level. */
-	rc = dss_enum_pack(&param, VOS_ITER_OBJ, true, &anchors, &arg);
+	rc = dss_enum_pack(&param, VOS_ITER_OBJ, true, &anchors, &arg,
+			   NULL /* dth */);
 	if (rc < 0)
 		return rc;
 

--- a/src/rdb/rdb_util.c
+++ b/src/rdb/rdb_util.c
@@ -395,7 +395,7 @@ rdb_vos_iter_fetch(daos_handle_t cont, daos_epoch_t epoch, rdb_oid_t oid,
 	param.ip_dkey = rdb_dkey;
 	param.ip_epr.epr_lo = epoch;
 	param.ip_epr.epr_hi = epoch;
-	rc = vos_iter_prepare(VOS_ITER_AKEY, &param, &iter);
+	rc = vos_iter_prepare(VOS_ITER_AKEY, &param, &iter, NULL);
 	if (rc != 0)
 		goto out;
 	rc = vos_iter_probe(iter, NULL /* anchor */);
@@ -450,7 +450,7 @@ rdb_vos_iterate(daos_handle_t cont, daos_epoch_t epoch, rdb_oid_t oid,
 	param.ip_dkey = rdb_dkey;
 	param.ip_epr.epr_lo = epoch;
 	param.ip_epr.epr_hi = epoch;
-	rc = vos_iter_prepare(VOS_ITER_AKEY, &param, &iter);
+	rc = vos_iter_prepare(VOS_ITER_AKEY, &param, &iter, NULL);
 	if (rc != 0) {
 		if (rc == -DER_NONEXIST)
 			/* No a-keys. */

--- a/src/rebuild/scan.c
+++ b/src/rebuild/scan.c
@@ -465,7 +465,7 @@ rebuild_container_scan_cb(daos_handle_t ih, vos_iter_entry_t *entry,
 	param.ip_flags = VOS_IT_FOR_REBUILD;
 	uuid_copy(arg->co_uuid, entry->ie_couuid);
 	rc = vos_iterate(&param, VOS_ITER_OBJ, false, &anchor,
-			 rebuild_obj_scan_cb, NULL, arg);
+			 rebuild_obj_scan_cb, NULL, arg, NULL);
 	vos_cont_close(coh);
 
 	*acts |= VOS_ITER_CB_YIELD;
@@ -529,7 +529,7 @@ rebuild_scanner(void *data)
 	arg.yield_freq = DEFAULT_YIELD_FREQ;
 	if (!rebuild_status_match(rpt, PO_COMP_ST_UP)) {
 		rc = vos_iterate(&param, VOS_ITER_COUUID, false, &anchor,
-				 rebuild_container_scan_cb, NULL, &arg);
+				 rebuild_container_scan_cb, NULL, &arg, NULL);
 	}
 
 	ds_pool_child_put(child);

--- a/src/tests/daos_perf.c
+++ b/src/tests/daos_perf.c
@@ -597,7 +597,7 @@ ts_iterate_internal(uint32_t type, vos_iter_param_t *param,
 	daos_handle_t		ih;
 	int			rc;
 
-	rc = vos_iter_prepare(type, param, &ih);
+	rc = vos_iter_prepare(type, param, &ih, NULL);
 	if (rc != 0) {
 		if (rc == -DER_NONEXIST)
 			rc = 0;

--- a/src/tests/obj_ctl.c
+++ b/src/tests/obj_ctl.c
@@ -171,7 +171,7 @@ ctl_vos_list(struct dts_io_credit *cred)
 	else
 		type = VOS_ITER_AKEY;
 
-	rc = vos_iter_prepare(type, &param, &ih);
+	rc = vos_iter_prepare(type, &param, &ih, NULL);
 	if (rc == -DER_NONEXIST) {
 		D_PRINT("No matched object or key\n");
 		D_GOTO(out, rc = 0);

--- a/src/vos/tests/vts_aggregate.c
+++ b/src/vos/tests/vts_aggregate.c
@@ -196,7 +196,7 @@ phy_recs_nr(struct io_test_args *arg, daos_unit_oid_t oid,
 		VOS_ITER_SINGLE : VOS_ITER_RECX;
 
 	rc = vos_iterate(&iter_param, iter_type, false, &anchors,
-			 counting_cb, NULL, &nr);
+			 counting_cb, NULL, &nr, NULL);
 	assert_int_equal(rc, 0);
 
 	return nr;

--- a/src/vos/tests/vts_array.c
+++ b/src/vos/tests/vts_array.c
@@ -430,7 +430,7 @@ vts_array_get_size(daos_handle_t aoh, daos_epoch_t epoch, daos_size_t *size)
 	rc = vos_obj_query_key(array->va_coh, array->va_oid,
 			       DAOS_GET_DKEY | DAOS_GET_RECX | DAOS_GET_MAX,
 			       epoch, &dkey, &array->va_iod.iod_name,
-			       &recx);
+			       &recx, NULL);
 
 	if (rc == -DER_NONEXIST) {
 		*size = 0;

--- a/src/vos/tests/vts_container.c
+++ b/src/vos/tests/vts_container.c
@@ -246,7 +246,7 @@ co_uuid_iter_test(struct vc_test_args *arg)
 	memset(&param, 0, sizeof(param));
 	param.ip_hdl = arg->poh;
 
-	rc = vos_iter_prepare(VOS_ITER_COUUID, &param, &ih);
+	rc = vos_iter_prepare(VOS_ITER_COUUID, &param, &ih, NULL);
 	if (rc != 0) {
 		print_error("Failed to prepare co iterator\n");
 		return rc;

--- a/src/vos/tests/vts_dtx.c
+++ b/src/vos/tests/vts_dtx.c
@@ -720,7 +720,7 @@ dtx_17(void **state)
 	vdid.count = 4;
 
 	rc = vos_iterate(&param, VOS_ITER_DKEY, false, &anchors,
-			 vts_dtx_iter_cb, NULL, &vdid);
+			 vts_dtx_iter_cb, NULL, &vdid, NULL);
 	assert_int_equal(rc, 0);
 
 	for (i = 0; i < 4; i++) {
@@ -736,7 +736,7 @@ dtx_17(void **state)
 	vdid.count = 10;
 
 	rc = vos_iterate(&param, VOS_ITER_DKEY, false, &anchors,
-			 vts_dtx_iter_cb, NULL, &vdid);
+			 vts_dtx_iter_cb, NULL, &vdid, NULL);
 	assert_int_equal(rc, 0);
 
 	for (i = 0; i < 10; i++) {

--- a/src/vos/tests/vts_io.c
+++ b/src/vos/tests/vts_io.c
@@ -260,7 +260,7 @@ io_recx_iterate(struct io_test_args *arg, vos_iter_param_t *param,
 	else
 		itype = VOS_ITER_SINGLE;
 
-	rc = vos_iter_prepare(itype, param, &ih);
+	rc = vos_iter_prepare(itype, param, &ih, NULL);
 	if (rc != 0) {
 		if (rc == -DER_NONEXIST)
 			rc = 0;
@@ -342,7 +342,7 @@ io_akey_iterate(struct io_test_args *arg, vos_iter_param_t *param,
 	int		rc;
 
 	param->ip_dkey = *dkey;
-	rc = vos_iter_prepare(VOS_ITER_AKEY, param, &ih);
+	rc = vos_iter_prepare(VOS_ITER_AKEY, param, &ih, NULL);
 	if (rc != 0) {
 		print_error("Failed to create akey iterator: "DF_RC"\n",
 			DP_RC(rc));
@@ -429,7 +429,7 @@ io_obj_iter_test(struct io_test_args *arg, daos_epoch_range_t *epr,
 			arg->ofeat & DAOS_OF_AKEY_UINT64);
 	}
 
-	rc = vos_iter_prepare(VOS_ITER_DKEY, &param, &ih);
+	rc = vos_iter_prepare(VOS_ITER_DKEY, &param, &ih, NULL);
 	if (rc != 0) {
 		print_error("Failed to prepare d-key iterator\n");
 		return rc;
@@ -1288,7 +1288,7 @@ io_oid_iter_test(struct io_test_args *arg)
 	param.ip_epr.epr_lo = vts_epoch_gen + 10;
 	param.ip_epr.epr_hi = DAOS_EPOCH_MAX;
 
-	rc = vos_iter_prepare(VOS_ITER_OBJ, &param, &ih);
+	rc = vos_iter_prepare(VOS_ITER_OBJ, &param, &ih, NULL);
 	if (rc != 0) {
 		print_error("Failed to prepare obj iterator\n");
 		return rc;
@@ -2105,7 +2105,7 @@ io_query_key(void **state)
 			rc = vos_obj_query_key(arg->ctx.tc_co_hdl, oid,
 					       DAOS_GET_MAX | DAOS_GET_RECX,
 					       epoch + 3, &dkey, &akey,
-					       &recx_read);
+					       &recx_read, NULL);
 			assert_int_equal(rc, 0);
 			assert_int_equal(recx_read.rx_idx, 0);
 			assert_int_equal(recx_read.rx_nr, 1);
@@ -2114,7 +2114,7 @@ io_query_key(void **state)
 			rc = vos_obj_query_key(arg->ctx.tc_co_hdl, oid,
 					       DAOS_GET_MAX | DAOS_GET_RECX,
 					       epoch + 2, &dkey, &akey,
-					       &recx_read);
+					       &recx_read, NULL);
 			assert_int_equal(rc, 0);
 			assert_int_equal(recx_read.rx_idx, 2);
 			assert_int_equal(recx_read.rx_nr, 1);
@@ -2123,7 +2123,7 @@ io_query_key(void **state)
 					       DAOS_GET_DKEY | DAOS_GET_AKEY |
 					       DAOS_GET_MAX | DAOS_GET_RECX,
 					       epoch + 3, &dkey_read,
-					       &akey_read, &recx_read);
+					       &akey_read, &recx_read, NULL);
 			assert_int_equal(rc, 0);
 			assert_int_equal(recx_read.rx_idx, 0);
 			assert_int_equal(recx_read.rx_nr, 1);
@@ -2137,7 +2137,7 @@ io_query_key(void **state)
 					       DAOS_GET_DKEY | DAOS_GET_AKEY |
 					       DAOS_GET_MAX | DAOS_GET_RECX,
 					       epoch + 2, &dkey_read,
-					       &akey_read, &recx_read);
+					       &akey_read, &recx_read, NULL);
 			assert_int_equal(rc, 0);
 			assert_int_equal(recx_read.rx_idx, 2);
 			assert_int_equal(recx_read.rx_nr, 1);
@@ -2149,7 +2149,7 @@ io_query_key(void **state)
 			rc = vos_obj_query_key(arg->ctx.tc_co_hdl, oid,
 					       DAOS_GET_MIN | DAOS_GET_RECX,
 					       epoch + 3, &dkey, &akey,
-					       &recx_read);
+					       &recx_read, NULL);
 			assert_int_equal(rc, 0);
 			assert_int_equal(recx_read.rx_idx, 0);
 			assert_int_equal(recx_read.rx_nr, 1);
@@ -2158,7 +2158,7 @@ io_query_key(void **state)
 			rc = vos_obj_query_key(arg->ctx.tc_co_hdl, oid,
 					       DAOS_GET_MIN | DAOS_GET_RECX,
 					       epoch + 2, &dkey, &akey,
-					       &recx_read);
+					       &recx_read, NULL);
 			assert_int_equal(rc, 0);
 			assert_int_equal(recx_read.rx_idx, 0);
 			assert_int_equal(recx_read.rx_nr, 1);
@@ -2167,7 +2167,7 @@ io_query_key(void **state)
 					       DAOS_GET_DKEY | DAOS_GET_AKEY |
 					       DAOS_GET_MIN | DAOS_GET_RECX,
 					       epoch + 3, &dkey_read,
-					       &akey_read, &recx_read);
+					       &akey_read, &recx_read, NULL);
 			assert_int_equal(rc, 0);
 			assert_int_equal(recx_read.rx_idx, 0);
 			assert_int_equal(recx_read.rx_nr, 1);
@@ -2181,7 +2181,7 @@ io_query_key(void **state)
 					       DAOS_GET_DKEY | DAOS_GET_AKEY |
 					       DAOS_GET_MIN | DAOS_GET_RECX,
 					       epoch + 2, &dkey_read,
-					       &akey_read, &recx_read);
+					       &akey_read, &recx_read, NULL);
 			assert_int_equal(rc, 0);
 			assert_int_equal(recx_read.rx_idx, 0);
 			assert_int_equal(recx_read.rx_nr, 1);
@@ -2209,12 +2209,14 @@ io_query_key(void **state)
 	assert_int_equal(rc, 0);
 
 	rc = vos_obj_query_key(arg->ctx.tc_co_hdl, oid, DAOS_GET_AKEY |
-			       DAOS_GET_MIN, epoch++, &dkey, &akey_read, NULL);
+			       DAOS_GET_MIN, epoch++, &dkey, &akey_read, NULL,
+			       NULL);
 	assert_int_equal(rc, 0);
 	assert_int_equal(*(uint64_t *)akey_read.iov_buf, KEY_INC * 2);
 
 	rc = vos_obj_query_key(arg->ctx.tc_co_hdl, oid, DAOS_GET_AKEY |
-			       DAOS_GET_MAX, epoch++, &dkey, &akey_read, NULL);
+			       DAOS_GET_MAX, epoch++, &dkey, &akey_read, NULL,
+			       NULL);
 	assert_int_equal(rc, 0);
 	assert_int_equal(*(uint64_t *)akey_read.iov_buf, MAX_INT_KEY - KEY_INC);
 
@@ -2226,12 +2228,13 @@ io_query_key(void **state)
 		assert_int_equal(rc, 0);
 	}
 	rc = vos_obj_query_key(arg->ctx.tc_co_hdl, oid, DAOS_GET_AKEY |
-			       DAOS_GET_MAX, epoch++, &dkey, &akey_read, NULL);
+			       DAOS_GET_MAX, epoch++, &dkey, &akey_read, NULL,
+			       NULL);
 	assert_int_equal(rc, -DER_NONEXIST);
 
 	rc = vos_obj_query_key(arg->ctx.tc_co_hdl, oid, DAOS_GET_AKEY |
 			       DAOS_GET_DKEY | DAOS_GET_MAX, epoch++,
-			       &dkey_read, &akey_read, NULL);
+			       &dkey_read, &akey_read, NULL, NULL);
 	assert_int_equal(rc, 0);
 	assert_int_equal(*(uint64_t *)akey_read.iov_buf, MAX_INT_KEY);
 	assert_int_equal(*(uint64_t *)dkey_read.iov_buf, MAX_INT_KEY - KEY_INC);
@@ -2240,7 +2243,7 @@ io_query_key(void **state)
 	rc = vos_obj_query_key(arg->ctx.tc_co_hdl, oid, DAOS_GET_AKEY |
 			       DAOS_GET_DKEY | DAOS_GET_RECX | DAOS_GET_MAX,
 			       epoch++, &dkey_read, &akey_read,
-			       &recx_read);
+			       &recx_read, NULL);
 	assert_int_equal(rc, 0);
 	assert_int_equal(*(uint64_t *)akey_read.iov_buf, MAX_INT_KEY - KEY_INC);
 	assert_int_equal(*(uint64_t *)dkey_read.iov_buf, MAX_INT_KEY - KEY_INC);
@@ -2259,12 +2262,14 @@ io_query_key(void **state)
 	assert_int_equal(rc, 0);
 
 	rc = vos_obj_query_key(arg->ctx.tc_co_hdl, oid, DAOS_GET_DKEY |
-			       DAOS_GET_MIN, epoch++, &dkey_read, NULL, NULL);
+			       DAOS_GET_MIN, epoch++, &dkey_read, NULL, NULL,
+			       NULL);
 	assert_int_equal(rc, 0);
 	assert_int_equal(*(uint64_t *)dkey_read.iov_buf, KEY_INC * 2);
 
 	rc = vos_obj_query_key(arg->ctx.tc_co_hdl, oid, DAOS_GET_DKEY |
-			       DAOS_GET_MAX, epoch++, &dkey_read, NULL, NULL);
+			       DAOS_GET_MAX, epoch++, &dkey_read, NULL, NULL,
+			       NULL);
 	assert_int_equal(rc, 0);
 	assert_int_equal(*(uint64_t *)dkey_read.iov_buf, MAX_INT_KEY - KEY_INC);
 
@@ -2274,7 +2279,8 @@ io_query_key(void **state)
 	assert_int_equal(rc, 0);
 
 	rc = vos_obj_query_key(arg->ctx.tc_co_hdl, oid, DAOS_GET_DKEY |
-			       DAOS_GET_MAX, epoch++, &dkey_read, NULL, NULL);
+			       DAOS_GET_MAX, epoch++, &dkey_read, NULL, NULL,
+			       NULL);
 	assert_int_equal(rc, -DER_NONEXIST);
 }
 
@@ -2337,7 +2343,7 @@ io_query_key_punch_update(void **state)
 
 	rc = vos_obj_query_key(arg->ctx.tc_co_hdl, oid,
 			       DAOS_GET_MAX | DAOS_GET_DKEY | DAOS_GET_RECX,
-			       epoch++, &dkey, &akey, &recx_read);
+			       epoch++, &dkey, &akey, &recx_read, NULL);
 	assert_int_equal(rc, 0);
 	assert_int_equal(recx_read.rx_idx, 0);
 	assert_int_equal(recx_read.rx_nr, sizeof("Goodbye"));
@@ -2352,7 +2358,7 @@ io_query_key_punch_update(void **state)
 
 	rc = vos_obj_query_key(arg->ctx.tc_co_hdl, oid,
 			       DAOS_GET_MAX | DAOS_GET_DKEY | DAOS_GET_RECX,
-			       epoch++, &dkey, &akey, &recx_read);
+			       epoch++, &dkey, &akey, &recx_read, NULL);
 	assert_int_equal(rc, 0);
 	assert_int_equal(recx_read.rx_idx, 0);
 	assert_int_equal(recx_read.rx_nr, sizeof("World"));
@@ -2363,7 +2369,7 @@ io_query_key_punch_update(void **state)
 
 	rc = vos_obj_query_key(arg->ctx.tc_co_hdl, oid,
 			       DAOS_GET_MAX | DAOS_GET_DKEY | DAOS_GET_RECX,
-			       epoch++, &dkey, &akey, &recx_read);
+			       epoch++, &dkey, &akey, &recx_read, NULL);
 	assert_int_equal(rc, 0);
 	assert_int_equal(recx_read.rx_nr, sizeof("Hello"));
 	assert_int_equal(recx_read.rx_idx, 0);
@@ -2386,21 +2392,21 @@ io_query_key_negative(void **state)
 			       DAOS_GET_DKEY | DAOS_GET_AKEY |
 			       DAOS_GET_MAX | DAOS_GET_RECX, 4,
 			       &dkey_read, &akey_read,
-			       &recx_read);
+			       &recx_read, NULL);
 	assert_int_equal(rc, -DER_NONEXIST);
 
 	rc = vos_obj_query_key(arg->ctx.tc_co_hdl, oid,
 			       DAOS_GET_DKEY | DAOS_GET_AKEY |
 			       DAOS_GET_MIN | DAOS_GET_RECX, 4,
 			       &dkey_read, &akey_read,
-			       &recx_read);
+			       &recx_read, NULL);
 	assert_int_equal(rc, -DER_NONEXIST);
 
 	gen_query_tree(arg, oid);
 
 	rc = vos_obj_query_key(arg->ctx.tc_co_hdl, arg->oid,
 			       DAOS_GET_DKEY | DAOS_GET_MAX, 4,
-			       NULL, NULL, NULL);
+			       NULL, NULL, NULL, NULL);
 	assert_int_equal(rc, -DER_INVAL);
 }
 

--- a/src/vos/tests/vts_pm.c
+++ b/src/vos/tests/vts_pm.c
@@ -144,7 +144,8 @@ vos_check(void **state, vos_iter_param_t *param, vos_iter_type_t type,
 	struct vos_iter_anchors	 anchors = {0};
 	int			 rc;
 
-	rc = vos_iterate(param, type, true, &anchors, count_cb, NULL, &counts);
+	rc = vos_iterate(param, type, true, &anchors, count_cb, NULL, &counts,
+			 NULL);
 	assert_int_equal(rc, 0);
 	assert_int_equal(expected->num_objs, counts.num_objs);
 	assert_int_equal(expected->num_dkeys, counts.num_dkeys);
@@ -733,7 +734,7 @@ punch_model_test(void **state)
 
 	rc = vos_obj_query_key(arg->ctx.tc_co_hdl, oid,
 			       DAOS_GET_RECX | DAOS_GET_MAX,
-			       11, &dkey, &akey, &rex);
+			       11, &dkey, &akey, &rex, NULL);
 	assert_int_equal(rc, 0);
 	assert_int_equal(rex.rx_idx, 0);
 	assert_int_equal(rex.rx_nr, strlen(latest));

--- a/src/vos/vos_aggregate.c
+++ b/src/vos/vos_aggregate.c
@@ -1967,7 +1967,7 @@ vos_aggregate(daos_handle_t coh, daos_epoch_range_t *epr,
 	iter_param.ip_flags |= VOS_IT_FOR_PURGE;
 	rc = vos_iterate(&iter_param, VOS_ITER_OBJ, true, &anchors,
 			 vos_aggregate_pre_cb, vos_aggregate_post_cb,
-			 &agg_param);
+			 &agg_param, NULL);
 	if (rc != 0) {
 		close_merge_window(&agg_param.ap_window, rc);
 		goto exit;
@@ -2038,7 +2038,7 @@ vos_discard(daos_handle_t coh, daos_epoch_range_t *epr,
 	iter_param.ip_flags |= VOS_IT_FOR_PURGE;
 	rc = vos_iterate(&iter_param, VOS_ITER_OBJ, true, &anchors,
 			 vos_aggregate_pre_cb, vos_aggregate_post_cb,
-			 &agg_param);
+			 &agg_param, NULL);
 
 	aggregate_exit(cont, true);
 	return rc;

--- a/src/vos/vos_iterator.c
+++ b/src/vos/vos_iterator.c
@@ -165,7 +165,7 @@ nested_prepare(vos_iter_type_t type, struct vos_iter_dict *dict,
 
 int
 vos_iter_prepare(vos_iter_type_t type, vos_iter_param_t *param,
-		 daos_handle_t *ih)
+		 daos_handle_t *ih, struct dtx_handle *dth)
 {
 	struct vos_iter_dict	*dict;
 	struct vos_iterator	*iter;
@@ -532,7 +532,7 @@ need_reprobe(vos_iter_type_t type, struct vos_iter_anchors *anchors)
 int
 vos_iterate(vos_iter_param_t *param, vos_iter_type_t type, bool recursive,
 	    struct vos_iter_anchors *anchors, vos_iter_cb_t pre_cb,
-	    vos_iter_cb_t post_cb, void *arg)
+	    vos_iter_cb_t post_cb, void *arg, struct dtx_handle *dth)
 {
 	daos_anchor_t		*anchor, *probe_anchor = NULL;
 	vos_iter_entry_t	iter_ent;
@@ -547,7 +547,7 @@ vos_iterate(vos_iter_param_t *param, vos_iter_type_t type, bool recursive,
 
 	anchor = type2anchor(type, anchors);
 
-	rc = vos_iter_prepare(type, param, &ih);
+	rc = vos_iter_prepare(type, param, &ih, dth);
 	if (rc != 0) {
 		if (rc == -DER_NONEXIST) {
 			daos_anchor_set_eof(anchor);
@@ -627,7 +627,7 @@ probe:
 
 			rc = vos_iterate(&child_param, iter_ent.ie_child_type,
 					 recursive, anchors, pre_cb, post_cb,
-					 arg);
+					 arg, dth);
 			if (rc != 0)
 				D_GOTO(out, rc);
 

--- a/src/vos/vos_query.c
+++ b/src/vos/vos_query.c
@@ -290,7 +290,7 @@ open_and_query_key(struct open_query *query, daos_key_t *key,
 int
 vos_obj_query_key(daos_handle_t coh, daos_unit_oid_t oid, uint32_t flags,
 		  daos_epoch_t epoch, daos_key_t *dkey, daos_key_t *akey,
-		  daos_recx_t *recx)
+		  daos_recx_t *recx, struct dtx_handle *dth)
 {
 	struct vos_object	*obj;
 	struct open_query	 query;


### PR DESCRIPTION
As a follow-on change to #2776, this patch addresses QUERY_KEY and ENUM
operations. It also makes these cleanups:

  - Remove parameter th from daos_obj_query.
  - Replace shard_query_key_args.kqa_epoch with
    shard_query_key_args.kqa_auxi.epoch.
  - Remove the unused obj_query_key_cb_args.flags.

Signed-off-by: Li Wei <wei.g.li@intel.com>