### PR TITLE
DAOS-5089 lru: Improve LRU/HASH implementation

### DIFF
--- a/src/cart/SConscript
+++ b/src/cart/SConscript
@@ -43,7 +43,7 @@ import daos_build
 Import('prereqs', 'env')
 
 # Keep versioned libs for now to avoid any conflict with 1.0
-CART_VERSION = "4.7.0"
+CART_VERSION = "4.8.0"
 
 def scons():
     """Scons function"""

--- a/src/cart/src/cart/crt_context.c
+++ b/src/cart/src/cart/crt_context.c
@@ -36,24 +36,14 @@ epi_link2ptr(d_list_t *rlink)
 	return container_of(rlink, struct crt_ep_inflight, epi_link);
 }
 
-static int
-epi_op_key_get(struct d_hash_table *hhtab, d_list_t *rlink, void **key_pp)
-{
-	struct crt_ep_inflight *epi = epi_link2ptr(rlink);
-
-	/* TODO: use global rank */
-	*key_pp = (void *)&epi->epi_ep.ep_rank;
-	return sizeof(epi->epi_ep.ep_rank);
-}
-
 static uint32_t
 epi_op_key_hash(struct d_hash_table *hhtab, const void *key,
 		unsigned int ksize)
 {
 	D_ASSERT(ksize == sizeof(d_rank_t));
 
-	return (unsigned int)(*(const uint32_t *)key %
-		(1U << CRT_EPI_TABLE_BITS));
+	return (uint32_t)(*(const uint32_t *)key
+			 & ((1U << CRT_EPI_TABLE_BITS) - 1));
 }
 
 static bool
@@ -66,6 +56,15 @@ epi_op_key_cmp(struct d_hash_table *hhtab, d_list_t *rlink,
 	/* TODO: use global rank */
 
 	return epi->epi_ep.ep_rank == *(d_rank_t *)key;
+}
+
+static uint32_t
+epi_op_rec_hash(struct d_hash_table *htable, d_list_t *link)
+{
+	struct crt_ep_inflight *epi = epi_link2ptr(link);
+
+	return (uint32_t)epi->epi_ep.ep_rank
+			& ((1U << CRT_EPI_TABLE_BITS) - 1);
 }
 
 static void
@@ -90,9 +89,9 @@ epi_op_rec_free(struct d_hash_table *hhtab, d_list_t *rlink)
 }
 
 static d_hash_table_ops_t epi_table_ops = {
-	.hop_key_get		= epi_op_key_get,
 	.hop_key_hash		= epi_op_key_hash,
 	.hop_key_cmp		= epi_op_key_cmp,
+	.hop_rec_hash		= epi_op_rec_hash,
 	.hop_rec_addref		= epi_op_rec_addref,
 	.hop_rec_decref		= epi_op_rec_decref,
 	.hop_rec_free		= epi_op_rec_free,

--- a/src/cart/src/cart/crt_group.c
+++ b/src/cart/src/cart/crt_group.c
@@ -62,22 +62,13 @@ crt_li_link2ptr(d_list_t *rlink)
 	return container_of(rlink, struct crt_lookup_item, li_link);
 }
 
-static int
-li_op_key_get(struct d_hash_table *hhtab, d_list_t *rlink, void **key_pp)
-{
-	struct crt_lookup_item *li = crt_li_link2ptr(rlink);
-
-	*key_pp = (void *)&li->li_rank;
-	return sizeof(li->li_rank);
-}
-
 static uint32_t
 li_op_key_hash(struct d_hash_table *hhtab, const void *key, unsigned int ksize)
 {
 	D_ASSERT(ksize == sizeof(d_rank_t));
 
-	return (unsigned int)(*(const uint32_t *)key %
-		(1U << CRT_LOOKUP_CACHE_BITS));
+	return (uint32_t)(*(const uint32_t *)key
+			  & ((1U << CRT_LOOKUP_CACHE_BITS) - 1));
 }
 
 static bool
@@ -89,6 +80,14 @@ li_op_key_cmp(struct d_hash_table *hhtab, d_list_t *rlink,
 	D_ASSERT(ksize == sizeof(d_rank_t));
 
 	return li->li_rank == *(d_rank_t *)key;
+}
+
+static uint32_t
+li_op_rec_hash(struct d_hash_table *htable, d_list_t *link)
+{
+	struct crt_lookup_item *li = crt_li_link2ptr(link);
+
+	return (uint32_t)li->li_rank & ((1U << CRT_LOOKUP_CACHE_BITS) - 1);
 }
 
 static void
@@ -116,9 +115,9 @@ li_op_rec_free(struct d_hash_table *hhtab, d_list_t *rlink)
 }
 
 static d_hash_table_ops_t lookup_table_ops = {
-	.hop_key_get		= li_op_key_get,
 	.hop_key_hash		= li_op_key_hash,
 	.hop_key_cmp		= li_op_key_cmp,
+	.hop_rec_hash		= li_op_rec_hash,
 	.hop_rec_addref		= li_op_rec_addref,
 	.hop_rec_decref		= li_op_rec_decref,
 	.hop_rec_free		= li_op_rec_free,
@@ -131,22 +130,13 @@ crt_rm_link2ptr(d_list_t *rlink)
 	return container_of(rlink, struct crt_rank_mapping, rm_link);
 }
 
-static int
-rm_op_key_get(struct d_hash_table *hhtab, d_list_t *rlink, void **key_pp)
-{
-	struct crt_rank_mapping *rm = crt_rm_link2ptr(rlink);
-
-	*key_pp = (void *)&rm->rm_key;
-	return sizeof(rm->rm_key);
-}
-
 static uint32_t
 rm_op_key_hash(struct d_hash_table *hhtab, const void *key, unsigned int ksize)
 {
 	D_ASSERT(ksize == sizeof(d_rank_t));
 
-	return (unsigned int)(*(const uint32_t *)key %
-		(1U << CRT_LOOKUP_CACHE_BITS));
+	return (uint32_t)(*(const uint32_t *)key
+			  & ((1U << CRT_LOOKUP_CACHE_BITS) - 1));
 }
 
 static bool
@@ -158,6 +148,14 @@ rm_op_key_cmp(struct d_hash_table *hhtab, d_list_t *rlink,
 	D_ASSERT(ksize == sizeof(d_rank_t));
 
 	return rm->rm_key == *(d_rank_t *)key;
+}
+
+static uint32_t
+rm_op_rec_hash(struct d_hash_table *htable, d_list_t *link)
+{
+	struct crt_rank_mapping *rm = crt_rm_link2ptr(link);
+
+	return (uint32_t)rm->rm_key & ((1U << CRT_LOOKUP_CACHE_BITS) - 1);
 }
 
 static void
@@ -201,22 +199,13 @@ crt_ui_link2ptr(d_list_t *rlink)
 	return container_of(rlink, struct crt_uri_item, ui_link);
 }
 
-static int
-ui_op_key_get(struct d_hash_table *hhtab, d_list_t *rlink, void **key_pp)
-{
-	struct crt_uri_item *ui = crt_ui_link2ptr(rlink);
-
-	*key_pp = (void *)&ui->ui_rank;
-	return sizeof(ui->ui_rank);
-}
-
 static uint32_t
 ui_op_key_hash(struct d_hash_table *hhtab, const void *key, unsigned int ksize)
 {
 	D_ASSERT(ksize == sizeof(d_rank_t));
 
-	return (unsigned int)(*(const uint32_t *)key %
-		(1U << CRT_LOOKUP_CACHE_BITS));
+	return (uint32_t)(*(const uint32_t *)key
+			  & ((1U << CRT_LOOKUP_CACHE_BITS) - 1));
 }
 
 static bool
@@ -228,6 +217,14 @@ ui_op_key_cmp(struct d_hash_table *hhtab, d_list_t *rlink,
 	D_ASSERT(ksize == sizeof(d_rank_t));
 
 	return ui->ui_rank == *(d_rank_t *)key;
+}
+
+static uint32_t
+ui_op_rec_hash(struct d_hash_table *htable, d_list_t *link)
+{
+	struct crt_uri_item *ui = crt_ui_link2ptr(link);
+
+	return (uint32_t)ui->ui_rank & ((1U << CRT_LOOKUP_CACHE_BITS) - 1);
 }
 
 static void
@@ -362,18 +359,18 @@ ui_op_rec_free(struct d_hash_table *hhtab, d_list_t *rlink)
 }
 
 static d_hash_table_ops_t uri_lookup_table_ops = {
-	.hop_key_get		= ui_op_key_get,
 	.hop_key_hash		= ui_op_key_hash,
 	.hop_key_cmp		= ui_op_key_cmp,
+	.hop_rec_hash		= ui_op_rec_hash,
 	.hop_rec_addref		= ui_op_rec_addref,
 	.hop_rec_decref		= ui_op_rec_decref,
 	.hop_rec_free		= ui_op_rec_free,
 };
 
 static d_hash_table_ops_t rank_mapping_ops = {
-	.hop_key_get		= rm_op_key_get,
 	.hop_key_hash		= rm_op_key_hash,
 	.hop_key_cmp		= rm_op_key_cmp,
+	.hop_rec_hash		= rm_op_rec_hash,
 	.hop_rec_addref		= rm_op_rec_addref,
 	.hop_rec_decref		= rm_op_rec_decref,
 	.hop_rec_free		= rm_op_rec_free,

--- a/src/cart/src/gurt/fault_inject.c
+++ b/src/cart/src/gurt/fault_inject.c
@@ -55,6 +55,15 @@ fa_op_key_cmp(struct d_hash_table *htab, d_list_t *rlink, const void *key,
 	return fa_ptr->fa_attr.fa_id == *(uint32_t *)key;
 }
 
+static uint32_t
+fa_op_rec_hash(struct d_hash_table *htab, d_list_t *link)
+{
+	struct d_fault_attr *fa_ptr = fa_link2ptr(link);
+
+	return d_hash_string_u32((const char *)&fa_ptr->fa_attr.fa_id,
+				 sizeof(fa_ptr->fa_attr.fa_id));
+}
+
 static void
 fa_op_rec_free(struct d_hash_table *htab, d_list_t *rlink)
 {
@@ -82,6 +91,7 @@ fa_op_rec_decref(struct d_hash_table *htab, d_list_t *rlink)
 
 static d_hash_table_ops_t fa_table_ops = {
 	.hop_key_cmp	= fa_op_key_cmp,
+	.hop_rec_hash	= fa_op_rec_hash,
 	.hop_rec_decref	= fa_op_rec_decref,
 	.hop_rec_free	= fa_op_rec_free,
 };

--- a/src/cart/src/gurt/hash.c
+++ b/src/cart/src/gurt/hash.c
@@ -30,6 +30,12 @@
 #include <gurt/list.h>
 #include <gurt/hash.h>
 
+enum d_hash_lru {
+	D_HASH_LRU_TAIL = -1,
+	D_HASH_LRU_NONE =  0,
+	D_HASH_LRU_HEAD =  1,
+};
+
 /******************************************************************************
  * Hash functions / supporting routines
  ******************************************************************************/
@@ -113,7 +119,7 @@ d_hash_srch_u64(uint64_t *hashes, unsigned int nhashes, uint64_t value)
 {
 	int	high = nhashes - 1;
 	int	low = 0;
-	int     i;
+	int	i;
 
 	for (i = high / 2; high - low > 1; i = (low + high) / 2) {
 		if (value >= hashes[i])
@@ -149,7 +155,7 @@ d_hash_string_u32(const char *string, unsigned int len)
 
 uint64_t
 d_hash_murmur64(const unsigned char *key, unsigned int key_len,
-		   unsigned int seed)
+		unsigned int seed)
 {
 	const uint64_t	*addr	= (const uint64_t *)key;
 	int		 loop	= key_len >> 3; /* divided by sizeof uint64 */
@@ -200,34 +206,6 @@ d_hash_murmur64(const unsigned char *key, unsigned int key_len,
  * Generic Hash Table functions / data structures
  ******************************************************************************/
 
-static int
-ch_lock_init(struct d_hash_table *htable)
-{
-	if (htable->ht_feats & D_HASH_FT_NOLOCK)
-		return 0;
-
-	if (htable->ht_feats & D_HASH_FT_MUTEX)
-		return D_MUTEX_INIT(&htable->ht_mutex, NULL);
-	else if (htable->ht_feats & D_HASH_FT_RWLOCK)
-		return D_RWLOCK_INIT(&htable->ht_rwlock, NULL);
-	else
-		return D_SPIN_INIT(&htable->ht_spin, PTHREAD_PROCESS_PRIVATE);
-}
-
-static void
-ch_lock_fini(struct d_hash_table *htable)
-{
-	if (htable->ht_feats & D_HASH_FT_NOLOCK)
-		return;
-
-	if (htable->ht_feats & D_HASH_FT_MUTEX)
-		D_MUTEX_DESTROY(&htable->ht_mutex);
-	else if (htable->ht_feats & D_HASH_FT_RWLOCK)
-		D_RWLOCK_DESTROY(&htable->ht_rwlock);
-	else
-		D_SPIN_DESTROY(&htable->ht_spin);
-}
-
 /**
  * Lock the hash table
  *
@@ -236,53 +214,72 @@ ch_lock_fini(struct d_hash_table *htable)
  * see D_HASH_FT_RWLOCK for the details.
  */
 static inline void
-ch_lock(struct d_hash_table *htable, bool read_only)
+ch_bucket_lock(struct d_hash_table *htable, uint32_t idx, bool read_only)
 {
+	union d_hash_lock *lock;
 
 	if (htable->ht_feats & D_HASH_FT_NOLOCK)
 		return;
 
+	lock = (htable->ht_feats & D_HASH_FT_GLOCK)
+		? &htable->ht_lock : &htable->ht_locks[idx];
 	if (htable->ht_feats & D_HASH_FT_MUTEX) {
-		D_MUTEX_LOCK(&htable->ht_mutex);
+		D_MUTEX_LOCK(&lock->mutex);
 	} else if (htable->ht_feats & D_HASH_FT_RWLOCK) {
 		if (read_only)
-			D_RWLOCK_RDLOCK(&htable->ht_rwlock);
+			D_RWLOCK_RDLOCK(&lock->rwlock);
 		else
-			D_RWLOCK_WRLOCK(&htable->ht_rwlock);
-
+			D_RWLOCK_WRLOCK(&lock->rwlock);
 	} else {
-		D_SPIN_LOCK(&htable->ht_spin);
+		D_SPIN_LOCK(&lock->spin);
 	}
 }
 
 /** unlock the hash table */
 static inline void
-ch_unlock(struct d_hash_table *htable, bool read_only)
+ch_bucket_unlock(struct d_hash_table *htable, uint32_t idx, bool read_only)
 {
+	union d_hash_lock *lock;
+
 	if (htable->ht_feats & D_HASH_FT_NOLOCK)
 		return;
 
+	lock = (htable->ht_feats & D_HASH_FT_GLOCK)
+		? &htable->ht_lock : &htable->ht_locks[idx];
 	if (htable->ht_feats & D_HASH_FT_MUTEX)
-		D_MUTEX_UNLOCK(&htable->ht_mutex);
+		D_MUTEX_UNLOCK(&lock->mutex);
 	else if (htable->ht_feats & D_HASH_FT_RWLOCK)
-		D_RWLOCK_UNLOCK(&htable->ht_rwlock);
+		D_RWLOCK_UNLOCK(&lock->rwlock);
 	else
-		D_SPIN_UNLOCK(&htable->ht_spin);
+		D_SPIN_UNLOCK(&lock->spin);
 }
 
 /**
  * wrappers for member functions.
  */
 
+static inline bool
+ch_key_cmp(struct d_hash_table *htable, d_list_t *link,
+	   const void *key, unsigned int ksize)
+{
+	return htable->ht_ops->hop_key_cmp(htable, link, key, ksize);
+}
+
+static inline void
+ch_key_init(struct d_hash_table *htable, d_list_t *link, void *arg)
+{
+	htable->ht_ops->hop_key_init(htable, link, arg);
+}
+
 /**
  * Convert key to hash bucket id.
  *
  * It calls DJB2 hash if no customized hash function is provided.
  */
-static inline unsigned int
+static inline uint32_t
 ch_key_hash(struct d_hash_table *htable, const void *key, unsigned int ksize)
 {
-	unsigned int idx;
+	uint32_t idx;
 
 	if (htable->ht_ops->hop_key_hash)
 		idx = htable->ht_ops->hop_key_hash(htable, key, ksize);
@@ -292,40 +289,52 @@ ch_key_hash(struct d_hash_table *htable, const void *key, unsigned int ksize)
 	return idx & ((1U << htable->ht_bits) - 1);
 }
 
-static inline void
-ch_key_init(struct d_hash_table *htable, d_list_t *rlink, void *arg)
+static inline uint32_t
+ch_rec_hash(struct d_hash_table *htable, d_list_t *link)
 {
-	D_ASSERT(htable->ht_ops->hop_key_init);
-	htable->ht_ops->hop_key_init(htable, rlink, arg);
+	uint32_t idx = 0;
+
+	if (htable->ht_ops->hop_rec_hash)
+		idx = htable->ht_ops->hop_rec_hash(htable, link);
+	else
+		D_ASSERT(htable->ht_feats &
+			 (D_HASH_FT_NOLOCK | D_HASH_FT_GLOCK));
+
+	return idx & ((1U << htable->ht_bits) - 1);
+}
+
+static inline void
+ch_rec_addref(struct d_hash_table *htable, d_list_t *link)
+{
+	if (htable->ht_ops->hop_rec_addref)
+		htable->ht_ops->hop_rec_addref(htable, link);
 }
 
 static inline bool
-ch_key_cmp(struct d_hash_table *htable, d_list_t *rlink,
-	   const void *key, unsigned int ksize)
+ch_rec_decref(struct d_hash_table *htable, d_list_t *link)
 {
-	D_ASSERT(htable->ht_ops->hop_key_cmp);
-	return htable->ht_ops->hop_key_cmp(htable, rlink, key, ksize);
-}
-
-static inline unsigned int
-ch_key_get(struct d_hash_table *htable, d_list_t *rlink, void **key_pp)
-{
-	D_ASSERT(htable->ht_ops->hop_key_get);
-	return htable->ht_ops->hop_key_get(htable, rlink, key_pp);
+	return htable->ht_ops->hop_rec_decref ?
+	       htable->ht_ops->hop_rec_decref(htable, link) : false;
 }
 
 static inline void
-ch_rec_insert(struct d_hash_table *htable, unsigned idx, d_list_t *rlink)
+ch_rec_free(struct d_hash_table *htable, d_list_t *link)
 {
-	struct d_hash_bucket *bucket = &htable->ht_buckets[idx];
+	if (htable->ht_ops->hop_rec_free)
+		htable->ht_ops->hop_rec_free(htable, link);
+}
 
-	d_list_add(rlink, &bucket->hb_head);
+static inline void
+ch_rec_insert(struct d_hash_table *htable, struct d_hash_bucket *bucket,
+	      d_list_t *link)
+{
+	d_list_add(link, &bucket->hb_head);
 #if D_HASH_DEBUG
 	htable->ht_nr++;
 	if (htable->ht_nr > htable->ht_nr_max)
 		htable->ht_nr_max = htable->ht_nr;
 
-	if (htable->ht_ops->hop_key_get) {
+	if (htable->ht_ops->hop_rec_hash) {
 		bucket->hb_dep++;
 		if (bucket->hb_dep > htable->ht_dep_max) {
 			htable->ht_dep_max = bucket->hb_dep;
@@ -337,71 +346,33 @@ ch_rec_insert(struct d_hash_table *htable, unsigned idx, d_list_t *rlink)
 #endif
 }
 
-static inline void
-ch_rec_delete(struct d_hash_table *htable, d_list_t *rlink)
-{
-	d_list_del_init(rlink);
-#if D_HASH_DEBUG
-	htable->ht_nr--;
-	if (htable->ht_ops->hop_key_get) {
-		struct d_hash_bucket *bucket;
-		void		    *key;
-		unsigned int	     size;
-
-		size = htable->ht_ops->hop_key_get(htable, rlink, &key);
-		bucket = &htable->ht_buckets[ch_key_hash(htable, key, size)];
-		bucket->hb_dep--;
-	}
-#endif
-}
-
-static inline d_list_t *
-ch_rec_find(struct d_hash_table *htable, unsigned idx, const void *key,
-	    unsigned int ksize)
-{
-	struct d_hash_bucket	*bucket = &htable->ht_buckets[idx];
-	d_list_t		*rlink;
-
-	d_list_for_each(rlink, &bucket->hb_head) {
-		if (ch_key_cmp(htable, rlink, key, ksize))
-			return rlink;
-	}
-	return NULL;
-}
-
-static inline void
-ch_rec_addref(struct d_hash_table *htable, d_list_t *rlink)
-{
-	if (htable->ht_ops->hop_rec_addref)
-		htable->ht_ops->hop_rec_addref(htable, rlink);
-}
-
-static inline bool
-ch_rec_decref(struct d_hash_table *htable, d_list_t *rlink)
-{
-	return htable->ht_ops->hop_rec_decref ?
-	       htable->ht_ops->hop_rec_decref(htable, rlink) : false;
-}
-
-static inline void
-ch_rec_free(struct d_hash_table *htable, d_list_t *rlink)
-{
-	if (htable->ht_ops->hop_rec_free)
-		htable->ht_ops->hop_rec_free(htable, rlink);
-}
-
 /**
  * Insert the record into the hash table and take refcount on it if
  * "ephemeral" is not set.
  */
 static inline void
-ch_rec_insert_addref(struct d_hash_table *htable, int bucket_idx,
-		     d_list_t *rlink)
+ch_rec_insert_addref(struct d_hash_table *htable, struct d_hash_bucket *bucket,
+		     d_list_t *link)
 {
 	if (!(htable->ht_feats & D_HASH_FT_EPHEMERAL))
-		ch_rec_addref(htable, rlink);
+		ch_rec_addref(htable, link);
 
-	ch_rec_insert(htable, bucket_idx, rlink);
+	ch_rec_insert(htable, bucket, link);
+}
+
+static inline void
+ch_rec_delete(struct d_hash_table *htable, d_list_t *link)
+{
+	d_list_del_init(link);
+#if D_HASH_DEBUG
+	htable->ht_nr--;
+	if (htable->ht_ops->hop_rec_hash) {
+		struct d_hash_bucket *bucket;
+
+		bucket = &htable->ht_buckets[ch_rec_hash(htable, link)];
+		bucket->hb_dep--;
+	}
+#endif
 }
 
 /**
@@ -409,105 +380,161 @@ ch_rec_insert_addref(struct d_hash_table *htable, int bucket_idx,
  * "ephemeral" is not set.
  */
 static inline bool
-ch_rec_del_decref(struct d_hash_table *htable, d_list_t *rlink)
+ch_rec_del_decref(struct d_hash_table *htable, d_list_t *link)
 {
 	bool zombie = false;
 
-	ch_rec_delete(htable, rlink);
+	ch_rec_delete(htable, link);
 	if (!(htable->ht_feats & D_HASH_FT_EPHEMERAL))
-		zombie = ch_rec_decref(htable, rlink);
+		zombie = ch_rec_decref(htable, link);
 
 	return zombie;
+}
+
+static inline d_list_t *
+ch_rec_find(struct d_hash_table *htable, struct d_hash_bucket *bucket,
+	    const void *key, unsigned int ksize, enum d_hash_lru lru)
+{
+	d_list_t *link;
+	bool lru_enabled = (htable->ht_feats & D_HASH_FT_LRU) &&
+			   (lru != D_HASH_LRU_NONE);
+
+	d_list_for_each(link, &bucket->hb_head) {
+		if (ch_key_cmp(htable, link, key, ksize)) {
+			if (lru_enabled) {
+				if (lru == D_HASH_LRU_HEAD &&
+				    link != bucket->hb_head.next)
+					d_list_move(link, &bucket->hb_head);
+				else if (lru == D_HASH_LRU_TAIL &&
+					 link != bucket->hb_head.prev)
+					d_list_move_tail(link,
+							 &bucket->hb_head);
+			}
+			return link;
+		}
+	}
+
+	return NULL;
+}
+
+bool
+d_hash_rec_unlinked(d_list_t *link)
+{
+	return d_list_empty(link);
 }
 
 d_list_t *
 d_hash_rec_find(struct d_hash_table *htable, const void *key,
 		unsigned int ksize)
 {
-	d_list_t	*rlink;
-	int		 idx;
+	struct d_hash_bucket	*bucket;
+	d_list_t		*link;
+	uint32_t		 idx;
+	bool			 is_lru = (htable->ht_feats & D_HASH_FT_LRU);
 
-	D_ASSERT(key != NULL);
-
+	D_ASSERT(key != NULL && ksize != 0);
 	idx = ch_key_hash(htable, key, ksize);
-	ch_lock(htable, true);
+	bucket = &htable->ht_buckets[idx];
 
-	rlink = ch_rec_find(htable, idx, key, ksize);
-	if (rlink != NULL)
-		ch_rec_addref(htable, rlink);
+	ch_bucket_lock(htable, idx, !is_lru);
 
-	ch_unlock(htable, true);
-	return rlink;
+	link = ch_rec_find(htable, bucket, key, ksize, D_HASH_LRU_HEAD);
+	if (link != NULL)
+		ch_rec_addref(htable, link);
+
+	ch_bucket_unlock(htable, idx, !is_lru);
+	return link;
 }
 
 int
 d_hash_rec_insert(struct d_hash_table *htable, const void *key,
-		  unsigned int ksize, d_list_t *rlink, bool exclusive)
+		  unsigned int ksize, d_list_t *link, bool exclusive)
 {
-	int	idx;
-	int	rc = 0;
+	struct d_hash_bucket	*bucket;
+	d_list_t		*tmp;
+	uint32_t		 idx;
+	int			 rc = 0;
 
 	D_ASSERT(key != NULL && ksize != 0);
 	idx = ch_key_hash(htable, key, ksize);
+	bucket = &htable->ht_buckets[idx];
 
-	ch_lock(htable, false);
+	ch_bucket_lock(htable, idx, false);
+
 	if (exclusive) {
-		d_list_t *tmp;
-
-		tmp = ch_rec_find(htable, idx, key, ksize);
+		tmp = ch_rec_find(htable, bucket, key, ksize, D_HASH_LRU_NONE);
 		if (tmp)
-			D_GOTO(out, rc = -DER_EXIST);
+			D_GOTO(out_unlock, rc = -DER_EXIST);
 	}
-	ch_rec_insert_addref(htable, idx, rlink);
-out:
-	ch_unlock(htable, false);
+	ch_rec_insert_addref(htable, bucket, link);
+
+out_unlock:
+	ch_bucket_unlock(htable, idx, false);
 	return rc;
 }
 
 d_list_t *
 d_hash_rec_find_insert(struct d_hash_table *htable, const void *key,
-		       unsigned int ksize, d_list_t *rlink)
+		       unsigned int ksize, d_list_t *link)
 {
-	d_list_t *tmp;
-	int	  idx;
+	struct d_hash_bucket	*bucket;
+	d_list_t		*tmp;
+	uint32_t		 idx;
 
 	D_ASSERT(key != NULL && ksize != 0);
 	idx = ch_key_hash(htable, key, ksize);
+	bucket = &htable->ht_buckets[idx];
 
-	ch_lock(htable, false);
-	tmp = ch_rec_find(htable, idx, key, ksize);
+	ch_bucket_lock(htable, idx, false);
+
+	tmp = ch_rec_find(htable, bucket, key, ksize, D_HASH_LRU_HEAD);
 	if (tmp) {
 		ch_rec_addref(htable, tmp);
-		rlink = tmp;
-		D_GOTO(out, 0);
+		link = tmp;
+		D_GOTO(out_unlock, 0);
 	}
-	ch_rec_insert_addref(htable, idx, rlink);
-out:
-	ch_unlock(htable, false);
-	return rlink;
+	ch_rec_insert_addref(htable, bucket, link);
+
+out_unlock:
+	ch_bucket_unlock(htable, idx, false);
+	return link;
 }
 
 int
-d_hash_rec_insert_anonym(struct d_hash_table *htable, d_list_t *rlink,
+d_hash_rec_insert_anonym(struct d_hash_table *htable, d_list_t *link,
 			 void *arg)
 {
-	void	*key;
-	int	 idx;
-	int	 ksize;
+	struct d_hash_bucket	*bucket;
+	uint32_t	 idx;
+	uint32_t	 nr = 1U << htable->ht_bits;
+	bool		 need_lock = !(htable->ht_feats & D_HASH_FT_NOLOCK);
 
-	if (htable->ht_ops->hop_key_init == NULL ||
-	    htable->ht_ops->hop_key_get == NULL)
-		return -DER_NO_PERM;
+	if (htable->ht_ops->hop_key_init == NULL)
+		return -DER_INVAL;
 
-	ch_lock(htable, false);
+	if (need_lock) {
+		/* Lock all buckets because of unknown key yet */
+		for (idx = 0; idx < nr; idx++) {
+			ch_bucket_lock(htable, idx, false);
+			if (htable->ht_feats & D_HASH_FT_GLOCK)
+				break;
+		}
+	}
+
 	/* has no key, hash table should have provided key generator */
-	ch_key_init(htable, rlink, arg);
+	ch_key_init(htable, link, arg);
 
-	ksize = ch_key_get(htable, rlink, &key);
-	idx = ch_key_hash(htable, key, ksize);
-	ch_rec_insert_addref(htable, idx, rlink);
+	idx = ch_rec_hash(htable, link);
+	bucket = &htable->ht_buckets[idx];
+	ch_rec_insert_addref(htable, bucket, link);
 
-	ch_unlock(htable, false);
+	if (need_lock) {
+		for (idx = 0; idx < nr; idx++) {
+			ch_bucket_unlock(htable, idx, false);
+			if (htable->ht_feats & D_HASH_FT_GLOCK)
+				break;
+		}
+	}
 	return 0;
 }
 
@@ -515,94 +542,170 @@ bool
 d_hash_rec_delete(struct d_hash_table *htable, const void *key,
 		  unsigned int ksize)
 {
-	d_list_t	*rlink;
-	int		 idx;
-	bool		 deleted = false;
-	bool		 zombie  = false;
+	struct d_hash_bucket	*bucket;
+	d_list_t		*link;
+	uint32_t		 idx;
+	bool			 deleted = false;
+	bool			 zombie  = false;
 
-	D_ASSERT(key != NULL);
-
+	D_ASSERT(key != NULL && ksize != 0);
 	idx = ch_key_hash(htable, key, ksize);
-	ch_lock(htable, false);
+	bucket = &htable->ht_buckets[idx];
 
-	rlink = ch_rec_find(htable, idx, key, ksize);
-	if (rlink != NULL) {
-		zombie = ch_rec_del_decref(htable, rlink);
+	ch_bucket_lock(htable, idx, false);
+
+	link = ch_rec_find(htable, bucket, key, ksize, D_HASH_LRU_NONE);
+	if (link != NULL) {
+		zombie  = ch_rec_del_decref(htable, link);
 		deleted = true;
 	}
 
-	ch_unlock(htable, false);
-	if (zombie)
-		ch_rec_free(htable, rlink);
+	ch_bucket_unlock(htable, idx, false);
 
+	if (zombie)
+		ch_rec_free(htable, link);
 	return deleted;
 }
 
 bool
-d_hash_rec_delete_at(struct d_hash_table *htable, d_list_t *rlink)
+d_hash_rec_delete_at(struct d_hash_table *htable, d_list_t *link)
 {
-	bool	deleted = false;
-	bool	zombie  = false;
+	uint32_t idx = 0;
+	bool	 deleted = false;
+	bool	 zombie  = false;
+	bool	 need_lock = !(htable->ht_feats & D_HASH_FT_NOLOCK);
 
-	ch_lock(htable, false);
+	if (need_lock) {
+		idx = ch_rec_hash(htable, link);
+		ch_bucket_lock(htable, idx, false);
+	}
 
-	if (!d_list_empty(rlink)) {
-		zombie = ch_rec_del_decref(htable, rlink);
+	if (!d_list_empty(link)) {
+		zombie  = ch_rec_del_decref(htable, link);
 		deleted = true;
 	}
-	ch_unlock(htable, false);
+
+	if (need_lock)
+		ch_bucket_unlock(htable, idx, false);
 
 	if (zombie)
-		ch_rec_free(htable, rlink);
-
+		ch_rec_free(htable, link);
 	return deleted;
 }
 
-void
-d_hash_rec_addref(struct d_hash_table *htable, d_list_t *rlink)
+bool
+d_hash_rec_evict(struct d_hash_table *htable, const void *key,
+		 unsigned int ksize)
 {
-	ch_lock(htable, true);
-	ch_rec_addref(htable, rlink);
-	ch_unlock(htable, true);
+	struct d_hash_bucket	*bucket;
+	d_list_t		*link;
+	uint32_t		 idx;
+
+	if (!(htable->ht_feats & D_HASH_FT_LRU))
+		return false;
+
+	D_ASSERT(key != NULL && ksize != 0);
+	idx = ch_key_hash(htable, key, ksize);
+	bucket = &htable->ht_buckets[idx];
+
+	ch_bucket_lock(htable, idx, false);
+
+	link = ch_rec_find(htable, bucket, key, ksize, D_HASH_LRU_TAIL);
+
+	ch_bucket_unlock(htable, idx, false);
+	return link != NULL;
+}
+
+bool
+d_hash_rec_evict_at(struct d_hash_table *htable, d_list_t *link)
+{
+	struct d_hash_bucket	*bucket;
+	uint32_t		 idx;
+	bool			 evicted = false;
+
+	if (!(htable->ht_feats & D_HASH_FT_LRU))
+		return false;
+
+	idx = ch_rec_hash(htable, link);
+	bucket = &htable->ht_buckets[idx];
+
+	ch_bucket_lock(htable, idx, false);
+
+	if (link != bucket->hb_head.prev) {
+		d_list_move_tail(link, &bucket->hb_head);
+		evicted = true;
+	}
+
+	ch_bucket_unlock(htable, idx, false);
+	return evicted;
 }
 
 void
-d_hash_rec_decref(struct d_hash_table *htable, d_list_t *rlink)
+d_hash_rec_addref(struct d_hash_table *htable, d_list_t *link)
 {
-	bool ephemeral = (htable->ht_feats & D_HASH_FT_EPHEMERAL);
-	bool zombie;
+	uint32_t idx = 0;
+	bool	 need_lock = !(htable->ht_feats & D_HASH_FT_NOLOCK);
 
-	ch_lock(htable, !ephemeral);
-	zombie = ch_rec_decref(htable, rlink);
+	if (need_lock) {
+		idx = ch_rec_hash(htable, link);
+		ch_bucket_lock(htable, idx, true);
+	}
 
-	if (zombie && ephemeral && !d_list_empty(rlink))
-		ch_rec_delete(htable, rlink);
+	ch_rec_addref(htable, link);
 
-	D_ASSERT(!zombie || d_list_empty(rlink));
+	if (need_lock)
+		ch_bucket_unlock(htable, idx, true);
+}
 
-	ch_unlock(htable, !ephemeral);
+void
+d_hash_rec_decref(struct d_hash_table *htable, d_list_t *link)
+{
+	uint32_t idx = 0;
+	bool	 need_lock = !(htable->ht_feats & D_HASH_FT_NOLOCK);
+	bool	 ephemeral = (htable->ht_feats & D_HASH_FT_EPHEMERAL);
+	bool	 zombie;
+
+	if (need_lock) {
+		idx = ch_rec_hash(htable, link);
+		ch_bucket_lock(htable, idx, !ephemeral);
+	}
+
+	zombie = ch_rec_decref(htable, link);
+	if (zombie && ephemeral && !d_list_empty(link))
+		ch_rec_delete(htable, link);
+
+	D_ASSERT(!zombie || d_list_empty(link));
+
+	if (need_lock)
+		ch_bucket_unlock(htable, idx, !ephemeral);
+
 	if (zombie)
-		ch_rec_free(htable, rlink);
+		ch_rec_free(htable, link);
 }
 
 int
-d_hash_rec_ndecref(struct d_hash_table *htable, int count, d_list_t *rlink)
+d_hash_rec_ndecref(struct d_hash_table *htable, int count, d_list_t *link)
 {
-	bool ephemeral = (htable->ht_feats & D_HASH_FT_EPHEMERAL);
-	bool zombie = false;
-	int rc = 0;
+	uint32_t idx = 0;
+	bool	 need_lock = !(htable->ht_feats & D_HASH_FT_NOLOCK);
+	bool	 ephemeral = (htable->ht_feats & D_HASH_FT_EPHEMERAL);
+	bool	 zombie = false;
+	int	 rc = 0;
 
-	ch_lock(htable, !ephemeral);
+	if (need_lock) {
+		idx = ch_rec_hash(htable, link);
+		ch_bucket_lock(htable, idx, !ephemeral);
+	}
 
 	if (htable->ht_ops->hop_rec_ndecref) {
-		rc = htable->ht_ops->hop_rec_ndecref(htable, rlink, count);
+		rc = htable->ht_ops->hop_rec_ndecref(htable, link, count);
 		if (rc >= 1) {
 			zombie = true;
 			rc = 0;
 		}
 	} else {
 		do {
-			zombie = ch_rec_decref(htable, rlink);
+			zombie = ch_rec_decref(htable, link);
 		} while (--count && !zombie);
 
 		if (count != 0)
@@ -610,23 +713,18 @@ d_hash_rec_ndecref(struct d_hash_table *htable, int count, d_list_t *rlink)
 	}
 
 	if (rc == 0) {
-		if (zombie && ephemeral && !d_list_empty(rlink))
-			ch_rec_delete(htable, rlink);
+		if (zombie && ephemeral && !d_list_empty(link))
+			ch_rec_delete(htable, link);
 
-		D_ASSERT(!zombie || d_list_empty(rlink));
+		D_ASSERT(!zombie || d_list_empty(link));
 	}
 
-	ch_unlock(htable, !ephemeral);
+	if (need_lock)
+		ch_bucket_unlock(htable, idx, !ephemeral);
+
 	if (zombie)
-		ch_rec_free(htable, rlink);
-
+		ch_rec_free(htable, link);
 	return rc;
-}
-
-bool
-d_hash_rec_unlinked(d_list_t *rlink)
-{
-	return d_list_empty(rlink);
 }
 
 /* Find an entry in the hash table.
@@ -637,36 +735,36 @@ d_hash_rec_unlinked(d_list_t *rlink)
  * one.
  */
 static inline int
-d_hash_find_single(d_list_t *rlink, void *arg)
+d_hash_find_single(d_list_t *link, void *arg)
 {
 	d_list_t **p = arg;
 
-	*p = rlink;
+	*p = link;
 	return 1;
 }
 
 d_list_t *
 d_hash_rec_first(struct d_hash_table *htable)
 {
-	d_list_t *rlink = NULL;
-	int rc;
+	d_list_t	*link = NULL;
+	int		 rc;
 
-	rc = d_hash_table_traverse(htable, d_hash_find_single, &rlink);
+	rc = d_hash_table_traverse(htable, d_hash_find_single, &link);
 	if (rc < 0)
 		return NULL;
 
-	return rlink;
+	return link;
 }
 
 int
-d_hash_table_create_inplace(uint32_t feats, unsigned int bits, void *priv,
+d_hash_table_create_inplace(uint32_t feats, uint32_t bits, void *priv,
 			    d_hash_table_ops_t *hops,
 			    struct d_hash_table *htable)
 {
-	struct d_hash_bucket	*buckets;
-	int			nr = (1 << bits);
-	int			i;
-	int			rc;
+	uint32_t nr = (1 << bits);
+	uint32_t i;
+	int	 rc = 0;
+
 	D_ASSERT(hops != NULL);
 	D_ASSERT(hops->hop_key_cmp != NULL);
 
@@ -675,43 +773,91 @@ d_hash_table_create_inplace(uint32_t feats, unsigned int bits, void *priv,
 	htable->ht_ops	 = hops;
 	htable->ht_priv	 = priv;
 
-	D_ALLOC_ARRAY(buckets, nr);
-	if (buckets == NULL)
-		return -DER_NOMEM;
-
-	for (i = 0; i < nr; i++)
-		D_INIT_LIST_HEAD(&buckets[i].hb_head);
-
-	htable->ht_buckets = buckets;
-	rc = ch_lock_init(htable);
-	if (rc != 0) {
-		D_FREE(buckets);
-		return rc;
+	if (hops->hop_rec_hash == NULL && !(feats & D_HASH_FT_NOLOCK)) {
+		htable->ht_feats |= D_HASH_FT_GLOCK;
+		D_WARN("The d_hash_table_ops_t->hop_rec_hash() callback is "
+			"not provided!\nTherefore the whole hash table locking "
+			"will be used for backward compatibility.\n");
 	}
 
-	return 0;
+	D_ALLOC_ARRAY(htable->ht_buckets, nr);
+	if (htable->ht_buckets == NULL)
+		D_GOTO(out, rc = -DER_NOMEM);
+
+	for (i = 0; i < nr; i++)
+		D_INIT_LIST_HEAD(&htable->ht_buckets[i].hb_head);
+
+	if (htable->ht_feats & D_HASH_FT_NOLOCK)
+		D_GOTO(out, rc = 0);
+
+	if (htable->ht_feats & D_HASH_FT_GLOCK) {
+		if (htable->ht_feats & D_HASH_FT_MUTEX)
+			rc = D_MUTEX_INIT(&htable->ht_lock.mutex, NULL);
+		else if (htable->ht_feats & D_HASH_FT_RWLOCK)
+			rc = D_RWLOCK_INIT(&htable->ht_lock.rwlock, NULL);
+		else
+			rc = D_SPIN_INIT(&htable->ht_lock.spin,
+					 PTHREAD_PROCESS_PRIVATE);
+		if (rc)
+			D_GOTO(free_buckets, rc);
+	} else {
+		D_ALLOC_ARRAY(htable->ht_locks, nr);
+		if (htable->ht_locks == NULL)
+			D_GOTO(free_buckets, rc = -DER_NOMEM);
+
+		for (i = 0; i < nr; i++) {
+			if (htable->ht_feats & D_HASH_FT_MUTEX)
+				rc = D_MUTEX_INIT(&htable->ht_locks[i].mutex,
+						  NULL);
+			else if (htable->ht_feats & D_HASH_FT_RWLOCK)
+				rc = D_RWLOCK_INIT(&htable->ht_locks[i].rwlock,
+						   NULL);
+			else
+				rc = D_SPIN_INIT(&htable->ht_locks[i].spin,
+						 PTHREAD_PROCESS_PRIVATE);
+			if (rc)
+				D_GOTO(free_locks, rc);
+		}
+	}
+
+	D_GOTO(out, rc = 0);
+
+free_locks:
+	while (i > 0) {
+		i--; /* last successful */
+		if (htable->ht_feats & D_HASH_FT_MUTEX)
+			D_MUTEX_DESTROY(&htable->ht_locks[i].mutex);
+		else if (htable->ht_feats & D_HASH_FT_RWLOCK)
+			D_RWLOCK_DESTROY(&htable->ht_locks[i].rwlock);
+		else
+			D_SPIN_DESTROY(&htable->ht_locks[i].spin);
+	}
+	D_FREE(htable->ht_locks);
+free_buckets:
+	D_FREE(htable->ht_buckets);
+out:
+	return rc;
 }
 
 int
-d_hash_table_create(uint32_t feats, unsigned int bits, void *priv,
+d_hash_table_create(uint32_t feats, uint32_t bits, void *priv,
 		    d_hash_table_ops_t *hops,
 		    struct d_hash_table **htable_pp)
 {
-	struct d_hash_table *htable;
-	int		    rc;
+	struct d_hash_table	*htable;
+	int			 rc;
 
 	D_ALLOC_PTR(htable);
 	if (htable == NULL)
-		return -DER_NOMEM;
+		D_GOTO(out, rc = -DER_NOMEM);
 
 	rc = d_hash_table_create_inplace(feats, bits, priv, hops, htable);
-	if (rc != 0)
-		goto failed;
-
+	if (rc) {
+		D_FREE_PTR(htable);
+		htable = NULL;
+	}
+out:
 	*htable_pp = htable;
-	return 0;
- failed:
-	D_FREE_PTR(htable);
 	return rc;
 }
 
@@ -719,14 +865,13 @@ int
 d_hash_table_traverse(struct d_hash_table *htable, d_hash_traverse_cb_t cb,
 		      void *arg)
 {
-	struct d_hash_bucket	*buckets = htable->ht_buckets;
-	d_list_t		*rlink;
-
-	int			 nr;
-	int			 i;
+	struct d_hash_bucket	*bucket;
+	d_list_t		*link;
+	uint32_t		 nr = 1U << htable->ht_bits;
+	uint32_t		 idx;
 	int			 rc = 0;
 
-	if (buckets == NULL) {
+	if (htable->ht_buckets == NULL) {
 		D_ERROR("d_hash_table %p not initialized (NULL buckets).\n",
 			htable);
 		D_GOTO(out, rc = -DER_UNINIT);
@@ -736,19 +881,16 @@ d_hash_table_traverse(struct d_hash_table *htable, d_hash_traverse_cb_t cb,
 		D_GOTO(out, rc = -DER_INVAL);
 	}
 
-	ch_lock(htable, true);
-
-	nr = 1U << htable->ht_bits;
-	for (i = 0; i < nr; i++) {
-		d_list_for_each(rlink, &buckets[i].hb_head) {
-			rc = cb(rlink, arg);
-			if (rc != 0)
-				D_GOTO(unlock, 0);
+	for (idx = 0; idx < nr && !rc; idx++) {
+		bucket = &htable->ht_buckets[idx];
+		ch_bucket_lock(htable, idx, true);
+		d_list_for_each(link, &bucket->hb_head) {
+			rc = cb(link, arg);
+			if (rc)
+				break;
 		}
+		ch_bucket_unlock(htable, idx, true);
 	}
-
-unlock:
-	ch_unlock(htable, true);
 out:
 	return rc;
 }
@@ -756,56 +898,72 @@ out:
 static bool
 d_hash_table_is_empty(struct d_hash_table *htable)
 {
-	struct d_hash_bucket    *buckets = htable->ht_buckets;
-	int			 nr;
-	int			 i;
-	bool			 res = true;
+	uint32_t	 nr = 1U << htable->ht_bits;
+	uint32_t	 idx;
+	bool		 is_empty = true;
 
-	if (buckets == NULL) {
+	if (htable->ht_buckets == NULL) {
 		D_ERROR("d_hash_table %p not initialized (NULL buckets).\n",
 			htable);
-		return true;
+		D_GOTO(out, 0);
 	}
 
-	ch_lock(htable, true);
+	for (idx = 0; idx < nr && is_empty; idx++) {
+		ch_bucket_lock(htable, idx, true);
+		is_empty = d_list_empty(&htable->ht_buckets[idx].hb_head);
+		ch_bucket_unlock(htable, idx, true);
+	}
 
-	nr = 1U << htable->ht_bits;
-	for (i = 0; i < nr; i++)
-		if (!d_list_empty(&buckets[i].hb_head)) {
-			res = false;
-			break;
-		}
-
-	ch_unlock(htable, true);
-
-	return res;
+out:
+	return is_empty;
 }
 
 int
 d_hash_table_destroy_inplace(struct d_hash_table *htable, bool force)
 {
-	struct d_hash_bucket	*buckets = htable->ht_buckets;
-	int			 nr;
-	int			 i;
+	struct d_hash_bucket	*bucket;
+	uint32_t		 nr = 1U << htable->ht_bits;
+	uint32_t		 i;
+	int			 rc = 0;
 
-	if (buckets == NULL)
-		goto out;
-
-	nr = 1U << htable->ht_bits;
 	for (i = 0; i < nr; i++) {
-		while (!d_list_empty(&buckets[i].hb_head)) {
+		bucket = &htable->ht_buckets[i];
+		while (!d_list_empty(&bucket->hb_head)) {
 			if (!force) {
 				D_DEBUG(DB_TRACE, "Warning, non-empty hash\n");
-				return -DER_BUSY;
+				D_GOTO(out, rc = -DER_BUSY);
 			}
-			d_hash_rec_delete_at(htable, buckets[i].hb_head.next);
+			d_hash_rec_delete_at(htable, bucket->hb_head.next);
 		}
 	}
-	D_FREE(buckets);
-	ch_lock_fini(htable);
- out:
+
+	if (htable->ht_feats & D_HASH_FT_NOLOCK)
+		D_GOTO(free_buckets, rc = 0);
+
+	if (htable->ht_feats & D_HASH_FT_GLOCK) {
+		if (htable->ht_feats & D_HASH_FT_MUTEX)
+			D_MUTEX_DESTROY(&htable->ht_lock.mutex);
+		else if (htable->ht_feats & D_HASH_FT_RWLOCK)
+			D_RWLOCK_DESTROY(&htable->ht_lock.rwlock);
+		else
+			D_SPIN_DESTROY(&htable->ht_lock.spin);
+	} else {
+		for (i = 0; i < nr; i++) {
+			if (htable->ht_feats & D_HASH_FT_MUTEX)
+				D_MUTEX_DESTROY(&htable->ht_locks[i].mutex);
+			else if (htable->ht_feats & D_HASH_FT_RWLOCK)
+				D_RWLOCK_DESTROY(&htable->ht_locks[i].rwlock);
+			else
+				D_SPIN_DESTROY(&htable->ht_locks[i].spin);
+		}
+		D_FREE(htable->ht_locks);
+	}
+
+free_buckets:
+	D_FREE(htable->ht_buckets);
 	memset(htable, 0, sizeof(*htable));
-	return 0;
+out:
+	return rc;
 }
 
 int
@@ -813,11 +971,9 @@ d_hash_table_destroy(struct d_hash_table *htable, bool force)
 {
 	int rc = d_hash_table_destroy_inplace(htable, force);
 
-	if (rc != 0)
-		return rc;
-
-	D_FREE_PTR(htable);
-	return 0;
+	if (!rc)
+		D_FREE_PTR(htable);
+	return rc;
 }
 
 void
@@ -852,100 +1008,103 @@ link2rlink(d_list_t *link)
 }
 
 static void
-rlink_op_addref(struct d_rlink *rlink)
+rl_op_addref(struct d_rlink *rlink)
 {
 	rlink->rl_ref++;
 }
 
 static bool
-rlink_op_decref(struct d_rlink *rlink)
+rl_op_decref(struct d_rlink *rlink)
 {
 	D_ASSERT(rlink->rl_ref > 0);
 	rlink->rl_ref--;
-
 	return rlink->rl_ref == 0;
 }
 
 static void
-rlink_op_init(struct d_rlink *rlink)
+rl_op_init(struct d_rlink *rlink)
 {
 	D_INIT_LIST_HEAD(&rlink->rl_link);
 	rlink->rl_initialized	= 1;
 	rlink->rl_ref		= 1; /* for caller */
 }
 
-
 static bool
-rlink_op_empty(struct d_rlink *rlink)
+rl_op_empty(struct d_rlink *rlink)
 {
+	bool is_unlinked;
+
 	if (!rlink->rl_initialized)
-		return 1;
-	D_ASSERT(rlink->rl_ref != 0 || d_hash_rec_unlinked(&rlink->rl_link));
-	return d_hash_rec_unlinked(&rlink->rl_link);
+		return true;
+
+	is_unlinked = d_hash_rec_unlinked(&rlink->rl_link);
+	D_ASSERT(rlink->rl_ref != 0 || is_unlinked);
+	return is_unlinked;
 }
 
 static inline struct d_hlink *
-hh_link2ptr(d_list_t *link)
+link2hlink(d_list_t *link)
 {
 	struct d_rlink	*rlink = link2rlink(link);
 
-	return	container_of(rlink, struct d_hlink, hl_link);
+	return container_of(rlink, struct d_hlink, hl_link);
 }
 
 static void
-hh_op_key_init(struct d_hash_table *hhtab, d_list_t *rlink, void *arg)
+hh_op_key_init(struct d_hash_table *htable, d_list_t *link, void *arg)
 {
-	struct d_hhash	*dht;
-	struct d_hlink	*hlink = hh_link2ptr(rlink);
+	struct d_hhash	*hhash;
+	struct d_hlink	*hlink = link2hlink(link);
 	int		 type  = *(int *)arg;
 
-	dht = container_of(hhtab, struct d_hhash, ch_htable);
-	hlink->hl_key = ((dht->ch_cookie++) << D_HTYPE_BITS) | type;
-}
-
-static int
-hh_op_key_get(struct d_hash_table *hhtab, d_list_t *rlink, void **key_pp)
-{
-	struct d_hlink	*hlink = hh_link2ptr(rlink);
-
-	*key_pp = (void *)&hlink->hl_key;
-	return sizeof(hlink->hl_key);
+	hhash = container_of(htable, struct d_hhash, ch_htable);
+	hlink->hl_key = ((hhash->ch_cookie++) << D_HTYPE_BITS)
+			| (type & D_HTYPE_MASK);
 }
 
 static uint32_t
-hh_op_key_hash(struct d_hash_table *hhtab, const void *key, unsigned int ksize)
+hh_op_key_hash(struct d_hash_table *htable, const void *key, unsigned int ksize)
 {
 	D_ASSERT(ksize == sizeof(uint64_t));
 
-	return (unsigned int)(*(const uint64_t *)key >> D_HTYPE_BITS);
+	return (uint32_t)(*(const uint64_t *)key >> D_HTYPE_BITS);
 }
 
 static bool
-hh_op_key_cmp(struct d_hash_table *hhtab, d_list_t *link,
+hh_op_key_cmp(struct d_hash_table *htable, d_list_t *link,
 	      const void *key, unsigned int ksize)
 {
-	struct d_hlink	*hlink = hh_link2ptr(link);
+	struct d_hlink	*hlink = link2hlink(link);
 
 	D_ASSERT(ksize == sizeof(uint64_t));
+
 	return hlink->hl_key == *(uint64_t *)key;
 }
 
-static void
-hh_op_rec_addref(struct d_hash_table *hhtab, d_list_t *link)
+static uint32_t
+hh_op_rec_hash(struct d_hash_table *htable, d_list_t *link)
 {
-	rlink_op_addref(link2rlink(link));
+	struct d_hlink	*hlink = link2hlink(link);
+
+	return (uint32_t)(hlink->hl_key >> D_HTYPE_BITS);
+}
+
+static void
+hh_op_rec_addref(struct d_hash_table *htable, d_list_t *link)
+{
+	rl_op_addref(link2rlink(link));
 }
 
 static bool
-hh_op_rec_decref(struct d_hash_table *hhtab, d_list_t *link)
+hh_op_rec_decref(struct d_hash_table *htable, d_list_t *link)
 {
-	return rlink_op_decref(link2rlink(link));
+	return rl_op_decref(link2rlink(link));
 }
 
 static void
-hh_op_rec_free(struct d_hash_table *hhtab, d_list_t *link)
+hh_op_rec_free(struct d_hash_table *htable, d_list_t *link)
 {
-	struct d_hlink	*hlink = hh_link2ptr(link);
+	struct d_hlink	*hlink = link2hlink(link);
 
 	if (hlink->hl_ops != NULL && hlink->hl_ops->hop_free != NULL)
 		hlink->hl_ops->hop_free(hlink);
@@ -953,82 +1112,85 @@ hh_op_rec_free(struct d_hash_table *hhtab, d_list_t *link)
 
 static d_hash_table_ops_t hh_ops = {
 	.hop_key_init		= hh_op_key_init,
-	.hop_key_get		= hh_op_key_get,
 	.hop_key_hash		= hh_op_key_hash,
 	.hop_key_cmp		= hh_op_key_cmp,
+	.hop_rec_hash		= hh_op_rec_hash,
 	.hop_rec_addref		= hh_op_rec_addref,
 	.hop_rec_decref		= hh_op_rec_decref,
 	.hop_rec_free		= hh_op_rec_free,
 };
 
 int
-d_hhash_create(uint32_t feats, unsigned int bits, struct d_hhash **htable_pp)
+d_hhash_create(uint32_t feats, uint32_t bits, struct d_hhash **hhash_pp)
 {
-	struct d_hhash	*hhtab;
-	int		 rc;
+	struct d_hhash	*hhash;
+	int		 rc = 0;
 
-	D_ALLOC_PTR(hhtab);
-	if (hhtab == NULL)
-		return -DER_NOMEM;
+	D_ALLOC_PTR(hhash);
+	if (hhash == NULL)
+		D_GOTO(out, rc = -DER_NOMEM);
 
 	rc = d_hash_table_create_inplace(feats, bits, NULL, &hh_ops,
-					 &hhtab->ch_htable);
-	if (rc != 0)
-		goto failed;
+					 &hhash->ch_htable);
+	if (rc) {
+		D_FREE_PTR(hhash);
+		hhash = NULL;
+		D_GOTO(out, rc);
+	}
 
-	hhtab->ch_cookie  = 1;
-	hhtab->ch_ptrtype = false;
-	*htable_pp = hhtab;
-	return 0;
- failed:
-	D_FREE_PTR(hhtab);
+	hhash->ch_cookie  = 1ULL;
+	hhash->ch_ptrtype = false;
+out:
+	*hhash_pp = hhash;
 	return rc;
 }
 
 void
-d_hhash_destroy(struct d_hhash *hhtab)
+d_hhash_destroy(struct d_hhash *hhash)
 {
-	d_hash_table_debug(&hhtab->ch_htable);
-	d_hash_table_destroy_inplace(&hhtab->ch_htable, true);
-	D_FREE_PTR(hhtab);
+	d_hash_table_debug(&hhash->ch_htable);
+	d_hash_table_destroy_inplace(&hhash->ch_htable, true);
+	D_FREE_PTR(hhash);
 }
 
 int
-d_hhash_set_ptrtype(struct d_hhash *hhtab)
+d_hhash_set_ptrtype(struct d_hhash *hhash)
 {
-	if (!d_hash_table_is_empty(&hhtab->ch_htable) &&
-	    hhtab->ch_ptrtype == false) {
+	if (!d_hash_table_is_empty(&hhash->ch_htable) &&
+	    hhash->ch_ptrtype == false) {
 		D_ERROR("d_hash_table %p not empty with non-ptr objects.\n",
-			&hhtab->ch_htable);
+			&hhash->ch_htable);
 		return -DER_ALREADY;
 	}
 
-	hhtab->ch_ptrtype = true;
+	hhash->ch_ptrtype = true;
 	return 0;
 }
 
 bool
-d_hhash_is_ptrtype(struct d_hhash *hhtab)
+d_hhash_is_ptrtype(struct d_hhash *hhash)
 {
-	return hhtab->ch_ptrtype;
+	return hhash->ch_ptrtype;
 }
 
 void
-d_hhash_hlink_init(struct d_hlink *hlink, struct d_hlink_ops *ops)
+d_hhash_hlink_init(struct d_hlink *hlink, struct d_hlink_ops *hl_ops)
 {
-	hlink->hl_ops = ops;
-	rlink_op_init(&hlink->hl_link);
+	hlink->hl_ops = hl_ops;
+	rl_op_init(&hlink->hl_link);
 }
 
 bool
 d_uhash_link_empty(struct d_ulink *ulink)
 {
-	return rlink_op_empty(&ulink->ul_link);
+	return rl_op_empty(&ulink->ul_link);
 }
 
 void
-d_hhash_link_insert(struct d_hhash *hhtab, struct d_hlink *hlink, int type)
+d_hhash_link_insert(struct d_hhash *hhash, struct d_hlink *hlink, int type)
 {
+	bool need_lock = !(hhash->ch_htable.ht_feats & D_HASH_FT_NOLOCK);
+
 	D_ASSERT(hlink->hl_link.rl_initialized);
 
 	/* check if handle type fits in allocated bits */
@@ -1036,34 +1198,50 @@ d_hhash_link_insert(struct d_hhash *hhtab, struct d_hlink *hlink, int type)
 		  "Type (%d) does not fit in D_HTYPE_BITS (%d)\n",
 		  type, D_HTYPE_BITS);
 
-	if (d_hhash_is_ptrtype(hhtab)) {
+	if (d_hhash_is_ptrtype(hhash)) {
 		uint64_t ptr_key = (uintptr_t)hlink;
+		uint32_t nr = 1U << hhash->ch_htable.ht_bits;
+		uint32_t idx = 0;
 
 		D_ASSERTF(type == D_HTYPE_PTR, "direct/ptr-based htable can "
 			  "only contain D_HTYPE_PTR type entries");
 		D_ASSERTF(d_hhash_key_isptr(ptr_key), "hlink ptr %p is invalid "
 			  "D_HTYPE_PTR type", hlink);
 
-		ch_lock(&hhtab->ch_htable, false);
-		ch_rec_addref(&hhtab->ch_htable, &hlink->hl_link.rl_link);
+		if (need_lock) {
+			/* Lock all buckets to emulate proper hlink lock */
+			for (idx = 0; idx < nr; idx++) {
+				ch_bucket_lock(&hhash->ch_htable, idx, false);
+				if (hhash->ch_htable.ht_feats & D_HASH_FT_GLOCK)
+					break;
+			}
+		}
+
+		ch_rec_addref(&hhash->ch_htable, &hlink->hl_link.rl_link);
 		hlink->hl_key = ptr_key;
-		ch_unlock(&hhtab->ch_htable, false);
+
+		if (need_lock) {
+			for (idx = 0; idx < nr; idx++) {
+				ch_bucket_unlock(&hhash->ch_htable, idx, false);
+				if (hhash->ch_htable.ht_feats & D_HASH_FT_GLOCK)
+					break;
+			}
+		}
 	} else {
 		D_ASSERTF(type != D_HTYPE_PTR, "PTR type key being inserted "
 			  "in a non ptr-based htable.\n");
 
-		d_hash_rec_insert_anonym(&hhtab->ch_htable,
+		d_hash_rec_insert_anonym(&hhash->ch_htable,
 			&hlink->hl_link.rl_link, (void *)&type);
 	}
 }
 
 static inline struct d_hlink*
-d_hlink_find(struct d_hash_table *htable, void *key, size_t size)
+d_hlink_find(struct d_hash_table *htable, const void *key, unsigned int ksize)
 {
-	d_list_t	*link;
+	d_list_t *link = d_hash_rec_find(htable, key, ksize);
 
-	link = d_hash_rec_find(htable, key, size);
-	return link == NULL ? NULL : hh_link2ptr(link);
+	return link ? link2hlink(link) : NULL;
 }
 
 bool
@@ -1073,66 +1251,63 @@ d_hhash_key_isptr(uint64_t key)
 }
 
 struct d_hlink *
-d_hhash_link_lookup(struct d_hhash *hhtab, uint64_t key)
+d_hhash_link_lookup(struct d_hhash *hhash, uint64_t key)
 {
 	if (d_hhash_key_isptr(key)) {
-		struct d_hlink *hlink;
+		struct d_hlink *hlink = (struct d_hlink *)key;
 
-		if (!d_hhash_is_ptrtype(hhtab)) {
+		if (!d_hhash_is_ptrtype(hhash)) {
 			D_ERROR("invalid PTR type key being lookup in a "
 				"non ptr-based htable.\n");
 			return NULL;
 		}
-		hlink = (struct d_hlink *)key;
 		if (hlink->hl_key != key) {
 			D_ERROR("invalid PTR type key.\n");
 			return NULL;
 		}
 
-		ch_lock(&hhtab->ch_htable, true);
-		ch_rec_addref(&hhtab->ch_htable, &hlink->hl_link.rl_link);
-		ch_unlock(&hhtab->ch_htable, true);
-
+		d_hash_rec_addref(&hhash->ch_htable, &hlink->hl_link.rl_link);
 		return hlink;
 	} else {
-		return d_hlink_find(&hhtab->ch_htable, (void *)&key,
+		return d_hlink_find(&hhash->ch_htable, (void *)&key,
 				    sizeof(key));
 	}
 }
 
 bool
-d_hhash_link_delete(struct d_hhash *hhtab, struct d_hlink *hlink)
+d_hhash_link_delete(struct d_hhash *hhash, struct d_hlink *hlink)
 {
 	if (d_hhash_key_isptr(hlink->hl_key)) {
-		if (!d_hhash_is_ptrtype(hhtab)) {
+		if (!d_hhash_is_ptrtype(hhash)) {
 			D_ERROR("invalid PTR type key being lookup in a "
 				"non ptr-based htable.\n");
 			return false;
 		}
-		d_hhash_link_putref(hhtab, hlink);
+
+		d_hhash_link_putref(hhash, hlink);
 		return true;
 	} else {
-		return d_hash_rec_delete_at(&hhtab->ch_htable,
+		return d_hash_rec_delete_at(&hhash->ch_htable,
 					    &hlink->hl_link.rl_link);
 	}
 }
 
 void
-d_hhash_link_getref(struct d_hhash *hhtab, struct d_hlink *hlink)
+d_hhash_link_getref(struct d_hhash *hhash, struct d_hlink *hlink)
 {
-	d_hash_rec_addref(&hhtab->ch_htable, &hlink->hl_link.rl_link);
+	d_hash_rec_addref(&hhash->ch_htable, &hlink->hl_link.rl_link);
 }
 
 void
-d_hhash_link_putref(struct d_hhash *hhtab, struct d_hlink *hlink)
+d_hhash_link_putref(struct d_hhash *hhash, struct d_hlink *hlink)
 {
-	d_hash_rec_decref(&hhtab->ch_htable, &hlink->hl_link.rl_link);
+	d_hash_rec_decref(&hhash->ch_htable, &hlink->hl_link.rl_link);
 }
 
 bool
 d_hhash_link_empty(struct d_hlink *hlink)
 {
-	return rlink_op_empty(&hlink->hl_link);
+	return rl_op_empty(&hlink->hl_link);
 }
 
 void
@@ -1141,12 +1316,10 @@ d_hhash_link_key(struct d_hlink *hlink, uint64_t *key)
 	*key = hlink->hl_key;
 }
 
-int d_hhash_key_type(uint64_t key)
+int
+d_hhash_key_type(uint64_t key)
 {
-	if (d_hhash_key_isptr(key))
-		return D_HTYPE_PTR;
-	else
-		return key & D_HTYPE_MASK;
+	return d_hhash_key_isptr(key) ? D_HTYPE_PTR : key & D_HTYPE_MASK;
 }
 
 /******************************************************************************
@@ -1166,15 +1339,31 @@ struct d_uhash_bundle {
 };
 
 static inline struct d_ulink *
-uh_link2ptr(d_list_t *link)
+link2ulink(d_list_t *link)
 {
 	struct d_rlink	*rlink = link2rlink(link);
 
 	return container_of(rlink, struct d_ulink, ul_link);
 }
 
-static unsigned int
-uh_op_key_hash(struct d_hash_table *uhtab, const void *key, unsigned int ksize)
+static void
+uh_op_rec_addref(struct d_hash_table *htable, d_list_t *link)
+{
+	struct d_ulink		*ulink	= link2ulink(link);
+
+	rl_op_addref(&ulink->ul_link);
+}
+
+static bool
+uh_op_rec_decref(struct d_hash_table *htable, d_list_t *link)
+{
+	struct d_ulink		*ulink	= link2ulink(link);
+
+	return rl_op_decref(&ulink->ul_link);
+}
+
+static uint32_t
+uh_op_key_hash(struct d_hash_table *htable, const void *key, unsigned int ksize)
 {
 	struct d_uhash_bundle	*uhbund	= (struct d_uhash_bundle *)key;
 	struct d_uuid		*lkey	= uhbund->key;
@@ -1182,18 +1371,26 @@ uh_op_key_hash(struct d_hash_table *uhtab, const void *key, unsigned int ksize)
 	D_ASSERT(ksize == sizeof(struct d_uhash_bundle));
 	D_DEBUG(DB_TRACE, "uuid_key: "CF_UUID"\n", CP_UUID(lkey->uuid));
 
-	return (unsigned int)(d_hash_string_u32((const char *)lkey->uuid,
-						sizeof(uuid_t)));
+	return d_hash_string_u32((const char *)lkey->uuid, sizeof(uuid_t));
+}
+
+static uint32_t
+uh_op_rec_hash(struct d_hash_table *htable, d_list_t *link)
+{
+	struct d_ulink		*ulink	= link2ulink(link);
+
+	return d_hash_string_u32((const char *)ulink->ul_uuid.uuid,
+				 sizeof(uuid_t));
 }
 
 static bool
-uh_op_key_cmp(struct d_hash_table *uhtab, d_list_t *link, const void *key,
+uh_op_key_cmp(struct d_hash_table *htable, d_list_t *link, const void *key,
 	      unsigned int ksize)
 {
-	struct d_ulink		*ulink	= uh_link2ptr(link);
+	struct d_ulink		*ulink	= link2ulink(link);
 	struct d_uhash_bundle	*uhbund	= (struct d_uhash_bundle *)key;
 	struct d_uuid		*lkey	= (struct d_uuid *)uhbund->key;
-	bool			res	= true;
+	bool			 res;
 
 	D_ASSERT(ksize == sizeof(struct d_uhash_bundle));
 	D_DEBUG(DB_TRACE, "Link key, Key:"CF_UUID","CF_UUID"\n",
@@ -1208,93 +1405,81 @@ uh_op_key_cmp(struct d_hash_table *uhtab, d_list_t *link, const void *key,
 }
 
 static void
-uh_op_rec_free(struct d_hash_table *hhtab, d_list_t *link)
+uh_op_rec_free(struct d_hash_table *htable, d_list_t *link)
 {
-	struct d_ulink	*ulink = uh_link2ptr(link);
+	struct d_ulink	*ulink = link2ulink(link);
 
 	if (ulink->ul_ops != NULL && ulink->ul_ops->uop_free != NULL)
 		ulink->ul_ops->uop_free(ulink);
 }
 
 static d_hash_table_ops_t uh_ops = {
-	.hop_key_hash	= uh_op_key_hash,
-	.hop_key_cmp	= uh_op_key_cmp,
-	.hop_rec_addref	= hh_op_rec_addref, /* Reuse hh_op_add/decref */
-	.hop_rec_decref	= hh_op_rec_decref,
-	.hop_rec_free	= uh_op_rec_free,
+	.hop_key_hash		= uh_op_key_hash,
+	.hop_key_cmp		= uh_op_key_cmp,
+	.hop_rec_hash		= uh_op_rec_hash,
+	.hop_rec_addref		= uh_op_rec_addref,
+	.hop_rec_decref		= uh_op_rec_decref,
+	.hop_rec_free		= uh_op_rec_free,
 };
 
 int
-d_uhash_create(uint32_t feats, unsigned int bits,
-	       struct d_hash_table **htable_pp)
+d_uhash_create(uint32_t feats, uint32_t bits, struct d_hash_table **htable_pp)
 {
-	struct d_hash_table	*uhtab;
-	int			rc;
-
-	rc = d_hash_table_create(feats, bits, NULL, &uh_ops, &uhtab);
-	if (rc != 0)
-		goto failed;
-
-	*htable_pp = uhtab;
-	return 0;
-
-failed:
-	return -DER_NOMEM;
+	return d_hash_table_create(feats, bits, NULL, &uh_ops, htable_pp);
 }
 
 void
-d_uhash_destroy(struct d_hash_table *uhtab)
+d_uhash_destroy(struct d_hash_table *htable)
 {
-	d_hash_table_debug(uhtab);
-	d_hash_table_destroy(uhtab, true);
+	d_hash_table_debug(htable);
+	d_hash_table_destroy(htable, true);
 }
 
 void
-d_uhash_ulink_init(struct d_ulink *ulink, struct d_ulink_ops *ops)
+d_uhash_ulink_init(struct d_ulink *ulink, struct d_ulink_ops *ul_ops)
 {
-	ulink->ul_ops = ops;
-	rlink_op_init(&ulink->ul_link);
+	ulink->ul_ops = ul_ops;
+	rl_op_init(&ulink->ul_link);
 }
 
 static inline struct d_ulink*
-d_ulink_find(struct d_hash_table *htable, void *key, size_t size)
+d_ulink_find(struct d_hash_table *htable, void *key, unsigned int ksize)
 {
-	d_list_t	*link;
+	d_list_t *link = d_hash_rec_find(htable, key, ksize);
 
-	link = d_hash_rec_find(htable, key, size);
-	return link == NULL ? NULL : uh_link2ptr(link);
+	return link ? link2ulink(link) : NULL;
 }
 
 struct d_ulink*
-d_uhash_link_lookup(struct d_hash_table *uhtab, struct d_uuid *key,
+d_uhash_link_lookup(struct d_hash_table *htable, struct d_uuid *key,
 		    void *cmp_args)
 {
-	struct d_uhash_bundle	uhbund;
+	struct d_uhash_bundle uhbund;
 
 	uhbund.key	= key;
 	uhbund.cmp_args	= cmp_args;
-	return d_ulink_find(uhtab, (void *)(&uhbund),
-			    sizeof(struct d_uhash_bundle));
+
+	return d_ulink_find(htable, (void *)&uhbund, sizeof(uhbund));
 }
 
 void
-d_uhash_link_addref(struct d_hash_table *uhtab, struct d_ulink *ulink)
+d_uhash_link_addref(struct d_hash_table *htable, struct d_ulink *ulink)
 {
-	d_hash_rec_addref(uhtab, &ulink->ul_link.rl_link);
+	d_hash_rec_addref(htable, &ulink->ul_link.rl_link);
 }
 
 void
-d_uhash_link_putref(struct d_hash_table *uhtab, struct d_ulink *ulink)
+d_uhash_link_putref(struct d_hash_table *htable, struct d_ulink *ulink)
 {
-	d_hash_rec_decref(uhtab, &ulink->ul_link.rl_link);
+	d_hash_rec_decref(htable, &ulink->ul_link.rl_link);
 }
 
 int
-d_uhash_link_insert(struct d_hash_table *uhtab, struct d_uuid *key,
+d_uhash_link_insert(struct d_hash_table *htable, struct d_uuid *key,
 		    void *cmp_args, struct d_ulink *ulink)
 {
-	int			rc = 0;
 	struct d_uhash_bundle	uhbund;
+	int			rc = 0;
 
 	D_ASSERT(ulink->ul_link.rl_initialized);
 
@@ -1302,8 +1487,7 @@ d_uhash_link_insert(struct d_hash_table *uhtab, struct d_uuid *key,
 	uhbund.key	= key;
 	uhbund.cmp_args = cmp_args;
 
-	rc = d_hash_rec_insert(uhtab, (void *)(&uhbund),
-			       sizeof(struct d_uhash_bundle),
+	rc = d_hash_rec_insert(htable, (void *)&uhbund, sizeof(uhbund),
 			       &ulink->ul_link.rl_link, true);
 	if (rc)
 		D_ERROR("Error Inserting handle in UUID in-memory hash\n");
@@ -1318,7 +1502,7 @@ d_uhash_link_last_ref(struct d_ulink *ulink)
 }
 
 void
-d_uhash_link_delete(struct d_hash_table *uhtab, struct d_ulink *ulink)
+d_uhash_link_delete(struct d_hash_table *htable, struct d_ulink *ulink)
 {
-	d_hash_rec_delete_at(uhtab, &ulink->ul_link.rl_link);
+	d_hash_rec_delete_at(htable, &ulink->ul_link.rl_link);
 }

--- a/src/cart/src/gurt/hash.c
+++ b/src/cart/src/gurt/hash.c
@@ -852,10 +852,8 @@ d_hash_table_create(uint32_t feats, uint32_t bits, void *priv,
 		D_GOTO(out, rc = -DER_NOMEM);
 
 	rc = d_hash_table_create_inplace(feats, bits, priv, hops, htable);
-	if (rc) {
-		D_FREE_PTR(htable);
-		htable = NULL;
-	}
+	if (rc)
+		D_FREE(htable);
 out:
 	*htable_pp = htable;
 	return rc;
@@ -972,7 +970,7 @@ d_hash_table_destroy(struct d_hash_table *htable, bool force)
 	int rc = d_hash_table_destroy_inplace(htable, force);
 
 	if (!rc)
-		D_FREE_PTR(htable);
+		D_FREE(htable);
 	return rc;
 }
 
@@ -1133,8 +1131,7 @@ d_hhash_create(uint32_t feats, uint32_t bits, struct d_hhash **hhash_pp)
 	rc = d_hash_table_create_inplace(feats, bits, NULL, &hh_ops,
 					 &hhash->ch_htable);
 	if (rc) {
-		D_FREE_PTR(hhash);
-		hhash = NULL;
+		D_FREE(hhash);
 		D_GOTO(out, rc);
 	}
 
@@ -1150,7 +1147,7 @@ d_hhash_destroy(struct d_hhash *hhash)
 {
 	d_hash_table_debug(&hhash->ch_htable);
 	d_hash_table_destroy_inplace(&hhash->ch_htable, true);
-	D_FREE_PTR(hhash);
+	D_FREE(hhash);
 }
 
 int

--- a/src/cart/src/include/gurt/hash.h
+++ b/src/cart/src/include/gurt/hash.h
@@ -34,7 +34,7 @@
 #include <stdbool.h>
 
 #include <gurt/list.h>
-#include <gurt/types.h> /* for d_uuid */
+#include <gurt/types.h>
 
 /**
  * Hash table keeps and prints extra debugging information
@@ -56,67 +56,64 @@ extern "C" {
 
 typedef struct {
 	/**
-	 * Compare \p key with the key of the record \p rlink
+	 * Compare \p key with the key of the record \p link
 	 * This member function is mandatory.
 	 *
-	 * \param[in] htable	hash table
-	 * \param[in] rlink	The link chain of the record
-	 * \param[in] key	Key to compare
-	 * \param[in] ksize	Size of the key
+	 * \param[in]	htable	hash table
+	 * \param[in]	link	The link chain of the record
+	 * \param[in]	key	Key to compare
+	 * \param[in]	ksize	Size of the key
 	 *
 	 * \retval	true	The key of the record equals to \p key.
 	 * \retval	false	No match
 	 */
-	bool	 (*hop_key_cmp)(struct d_hash_table *htable, d_list_t *rlink,
+	bool	 (*hop_key_cmp)(struct d_hash_table *htable, d_list_t *link,
 				const void *key, unsigned int ksize);
 	/**
-	 * Optional, generate a key for the record \p rlink.
+	 * Optional, generate a key for the record \p link.
 	 *
 	 * This function is called before inserting a record w/o key into a
 	 * hash table.
 	 *
-	 * \param[in] htable	hash table
-	 * \param[in] rlink	The link chain of the record to generate key.
-	 * \param[in] arg	Input arguments for the key generating.
+	 * \param[in]	htable	hash table
+	 * \param[in]	link	The link chain of the record to generate key.
+	 * \param[in]	arg	Input arguments for the key generating.
 	 */
-	void	 (*hop_key_init)(struct d_hash_table *htable,
-				 d_list_t *rlink, void *arg);
-	/**
-	 * Optional, return the key of record \p rlink to \p key_pp, and size of
-	 * the key as the returned value.
-	 *
-	 * \param[in] htable	hash table
-	 * \param[in] rlink	The link chain of the record being queried.
-	 * \param[out] key_pp	The returned key.
-	 *
-	 * \return		size of the key.
-	 */
-	int	 (*hop_key_get)(struct d_hash_table *htable, d_list_t *rlink,
-				void **key_pp);
+	void	 (*hop_key_init)(struct d_hash_table *htable, d_list_t *link,
+				 void *arg);
 	/**
 	 * Optional, hash \p key to a 32-bit value.
 	 * DJB2 hash is used when this function is abscent.
 	 *
-	 * \param[in] htable	hash table
-	 * \param[in] key	Key to hash
-	 * \param[in] ksize	Key size
+	 * \param[in]	htable	hash table
+	 * \param[in]	key	Key to hash
+	 * \param[in]	ksize	Key size
 	 *
 	 * \return		hash of the key
 	 */
 	uint32_t (*hop_key_hash)(struct d_hash_table *htable, const void *key,
 				 unsigned int ksize);
 	/**
-	 * Optional, increase refcount on the record \p rlink
+	 * Get the hash of recorded key.
+	 *
+	 * \param[in]	htable	hash table
+	 * \param[in]	link	the link to record.
+	 *
+	 * \return		hash of recorded key
+	 */
+	uint32_t (*hop_rec_hash)(struct d_hash_table *htable, d_list_t *link);
+
+	/**
+	 * Optional, increase refcount on the record \p link
 	 * If this function is provided, it will be called for successfully
 	 * inserted record.
 	 *
-	 * \param[in] htable	hash table
-	 * \param[in] rlink	The record being referenced.
+	 * \param[in]	htable	hash table
+	 * \param[in]	link	The record being referenced.
 	 */
-	void	 (*hop_rec_addref)(struct d_hash_table *htable,
-				   d_list_t *rlink);
+	void	 (*hop_rec_addref)(struct d_hash_table *htable, d_list_t *link);
 	/**
-	 * Optional, release refcount on the record \p rlink
+	 * Optional, release refcount on the record \p link
 	 *
 	 * If this function is provided, it is called while deleting a record
 	 * from the hash table.
@@ -126,27 +123,26 @@ typedef struct {
 	 * If the record should not be automatically freed by the hash table
 	 * despite of refcount, then this function should never return true.
 	 *
-	 * \param[in] htable	hash table
-	 * \param[in] rlink	The rlink being released.
+	 * \param[in]	htable	hash table
+	 * \param[in]	link	The link being released.
 	 *
 	 * \retval	false	Do nothing
 	 * \retval	true	Only if refcount is zero and the hash item
 	 *			can be freed. If this function can return
 	 *			true, then hop_rec_free() should be defined.
 	 */
-	bool	 (*hop_rec_decref)(struct d_hash_table *htable,
-				   d_list_t *rlink);
+	bool	 (*hop_rec_decref)(struct d_hash_table *htable, d_list_t *link);
 
 	/**
-	 * Optional, release multiple refcount on the record \p rlink
+	 * Optional, release multiple refcount on the record \p link
 	 *
 	 * This function expands on hop_rec_decref() so the notes from that
 	 * function apply here.  If hop_rec_decref() is not provided then
 	 * hop_rec_ndecref() shouldn't be either.
 	 *
-	 * \param[in] htable	hash table
-	 * \param[in] rlink	The rlink being released.
-	 * \param[in] count	The number of refs to be dropped.
+	 * \param[in]	htable	hash table
+	 * \param[in]	link	The link being released.
+	 * \param[in]	count	The number of refcounts to be dropped.
 	 *
 	 * \retval	0	Do nothing
 	 * \retval	1	Only if refcount is zero and the hash item
@@ -155,17 +151,16 @@ typedef struct {
 	 *		negative value on error.
 	 */
 	int	 (*hop_rec_ndecref)(struct d_hash_table *htable,
-				    d_list_t *rlink,
-				    int count);
+				    d_list_t *link, int count);
 
 	/**
-	 * Optional, free the record \p rlink
+	 * Optional, free the record \p link
 	 * It is called if hop_decref() returns zero.
 	 *
-	 * \param[in] htable	hash table
-	 * \param[in] rlink	The record being freed.
+	 * \param[in]	htable	hash table
+	 * \param[in]	link	The record being freed.
 	 */
-	void	 (*hop_rec_free)(struct d_hash_table *htable, d_list_t *rlink);
+	void	 (*hop_rec_free)(struct d_hash_table *htable, d_list_t *link);
 } d_hash_table_ops_t;
 
 enum d_hash_feats {
@@ -210,6 +205,25 @@ enum d_hash_feats {
 	 * Note that if addref/decref are not provided this bit has no effect
 	 */
 	D_HASH_FT_EPHEMERAL	= (1 << 3),
+
+	/**
+	 * If the LRU bit is set:
+	 * The found in bucket item is moved on top of the list.
+	 * So, next search for it will be much faster.
+	 */
+	D_HASH_FT_LRU		= (1 << 4),
+
+	/**
+	 * Use Global Table Lock instead of per bucket locking.
+	 * TODO: should be removed when all will use per bucket locking.
+	 */
+	D_HASH_FT_GLOCK		= (1 << 15),
+};
+
+union d_hash_lock {
+	pthread_spinlock_t	spin;
+	pthread_mutex_t		mutex;
+	pthread_rwlock_t	rwlock;
 };
 
 struct d_hash_bucket {
@@ -221,13 +235,9 @@ struct d_hash_bucket {
 
 struct d_hash_table {
 	/** different type of locks based on ht_feats */
-	union {
-		pthread_spinlock_t	ht_spin;
-		pthread_mutex_t		ht_mutex;
-		pthread_rwlock_t	ht_rwlock;
-	};
+	union d_hash_lock	 ht_lock;
 	/** bits to generate number of buckets */
-	unsigned int		 ht_bits;
+	uint32_t		 ht_bits;
 	/** feature bits */
 	uint32_t		 ht_feats;
 #if D_HASH_DEBUG
@@ -244,8 +254,9 @@ struct d_hash_table {
 	d_hash_table_ops_t	*ht_ops;
 	/** array of buckets */
 	struct d_hash_bucket	*ht_buckets;
+	/** different type of locks based on ht_feats */
+	union d_hash_lock	*ht_locks;
 };
-
 
 /**
  * Create a new hash table.
@@ -261,8 +272,8 @@ struct d_hash_table {
  *
  * \return			0 on success, negative value on error
  */
-int  d_hash_table_create(uint32_t feats, unsigned int bits,
-			 void *priv, d_hash_table_ops_t *hops,
+int  d_hash_table_create(uint32_t feats, uint32_t bits, void *priv,
+			 d_hash_table_ops_t *hops,
 			 struct d_hash_table **htable_pp);
 
 /**
@@ -281,11 +292,11 @@ int  d_hash_table_create(uint32_t feats, unsigned int bits,
  *
  * \return			0 on success, negative value on error
  */
-int  d_hash_table_create_inplace(uint32_t feats, unsigned int bits,
-				 void *priv, d_hash_table_ops_t *hops,
+int  d_hash_table_create_inplace(uint32_t feats, uint32_t bits, void *priv,
+				 d_hash_table_ops_t *hops,
 				 struct d_hash_table *htable);
 
-typedef int (*d_hash_traverse_cb_t)(d_list_t *rlink, void *arg);
+typedef int (*d_hash_traverse_cb_t)(d_list_t *link, void *arg);
 
 /**
  * Traverse a hash table, call the traverse callback function on every item.
@@ -299,8 +310,8 @@ typedef int (*d_hash_traverse_cb_t)(d_list_t *rlink, void *arg);
  *
  * \return			zero on success, negative value if error.
  */
-int d_hash_table_traverse(struct d_hash_table *htable,
-			  d_hash_traverse_cb_t cb, void *arg);
+int  d_hash_table_traverse(struct d_hash_table *htable,
+			   d_hash_traverse_cb_t cb, void *arg);
 
 /**
  * Destroy a hash table.
@@ -335,36 +346,36 @@ int  d_hash_table_destroy(struct d_hash_table *htable, bool force);
 int  d_hash_table_destroy_inplace(struct d_hash_table *htable, bool force);
 
 /**
- * lookup \p key in the hash table, the found chain rlink is returned on
+ * lookup \p key in the hash table, the found chain link is returned on
  * success.
  *
  * \param[in] htable		Pointer to the hash table
  * \param[in] key		The key to search
  * \param[in] ksize		Size of the key
  *
- * \return			found chain rlink
+ * \return			found chain link
  */
 d_list_t *d_hash_rec_find(struct d_hash_table *htable, const void *key,
 			  unsigned int ksize);
 
 /**
  * Lookup \p key in the hash table, if there is a matched record, it should be
- * returned, otherwise \p rlink will be inserted into the hash table. In the
- * later case, the returned link chain is the input \p rlink.
+ * returned, otherwise \p link will be inserted into the hash table. In the
+ * later case, the returned link chain is the input \p link.
  *
  * \param[in] htable		Pointer to the hash table
  * \param[in] key		The key to be inserted
  * \param[in] ksize		Size of the key
- * \param[in] rlink		The link chain of the record being inserted
+ * \param[in] link		The link chain of the record being inserted
  *
  * \return			matched record
  */
 d_list_t *d_hash_rec_find_insert(struct d_hash_table *htable,
 				 const void *key, unsigned int ksize,
-				 d_list_t *rlink);
+				 d_list_t *link);
 
 /**
- * Insert a new key and its record chain \p rlink into the hash table. The hash
+ * Insert a new key and its record chain \p link into the hash table. The hash
  * table holds a refcount on the successfully inserted record, it releases the
  * refcount while deleting the record.
  *
@@ -374,28 +385,28 @@ d_list_t *d_hash_rec_find_insert(struct d_hash_table *htable,
  * \param[in] htable		Pointer to the hash table
  * \param[in] key		The key to be inserted
  * \param[in] ksize		Size of the key
- * \param[in] rlink		The link chain of the record being inserted
+ * \param[in] link		The link chain of the record being inserted
  * \param[in] exclusive		The key has to be unique if it is true.
  *
  * \return			0 on success, negative value on error
  */
 int  d_hash_rec_insert(struct d_hash_table *htable, const void *key,
-		       unsigned int ksize, d_list_t *rlink,
+		       unsigned int ksize, d_list_t *link,
 		       bool exclusive);
 
 /**
  * Insert an anonymous record (w/o key) into the hash table.
- * This function calls hop_key_init() to generate a key for the new rlink
+ * This function calls hop_key_init() to generate a key for the new link
  * under the protection of the hash table lock.
  *
  * \param[in] htable		Pointer to the hash table
- * \param[in] rlink		The link chain of the hash record
+ * \param[in] link		The link chain of the hash record
  * \param[in] arg		Arguments for key generating
  *
  * \return			0 on success, negative value on error
  */
-int  d_hash_rec_insert_anonym(struct d_hash_table *htable, d_list_t *rlink,
-			       void *arg);
+int  d_hash_rec_insert_anonym(struct d_hash_table *htable, d_list_t *link,
+			      void *arg);
 
 /**
  * Delete the record identified by \p key from the hash table.
@@ -411,26 +422,50 @@ bool d_hash_rec_delete(struct d_hash_table *htable, const void *key,
 		       unsigned int ksize);
 
 /**
- * Delete the record linked by the chain \p rlink.
+ * Delete the record linked by the chain \p link.
  * This record will be freed if hop_rec_free() is defined and the hash table
  * holds the last refcount.
  *
  * \param[in] htable		Pointer to the hash table
- * \param[in] rlink		The link chain of the record
+ * \param[in] link		The link chain of the record
  *
  * \retval			true	Successfully deleted the record
  * \retval			false	The record has already been unlinked
  *					from the hash table
  */
-bool d_hash_rec_delete_at(struct d_hash_table *htable, d_list_t *rlink);
+bool d_hash_rec_delete_at(struct d_hash_table *htable, d_list_t *link);
+
+/**
+ * Evict the record identified by \p key from the hash table.
+ *
+ * \param[in] htable		Pointer to the hash table
+ * \param[in] key		The key of the record being evicted
+ * \param[in] ksize		Size of the key
+ *
+ * \retval			true	Item with \p key has been evicted
+ * \retval			false	Can't find the record by \p key
+ */
+bool d_hash_rec_evict(struct d_hash_table *htable, const void *key,
+		      unsigned int ksize);
+
+/**
+ * Evict the record linked by the chain \p link.
+ *
+ * \param[in] htable		Pointer to the hash table
+ * \param[in] link		The link chain of the record
+ *
+ * \retval			true	Item has been evicted
+ * \retval			false	Not LRU feature
+ */
+bool d_hash_rec_evict_at(struct d_hash_table *htable, d_list_t *link);
 
 /**
  * Increase the refcount of the record.
  *
  * \param[in] htable		Pointer to the hash table
- * \param[in] rlink		The link chain of the record
+ * \param[in] link		The link chain of the record
  */
-void d_hash_rec_addref(struct d_hash_table *htable, d_list_t *rlink);
+void d_hash_rec_addref(struct d_hash_table *htable, d_list_t *link);
 
 /**
  * Decrease the refcount of the record.
@@ -438,9 +473,9 @@ void d_hash_rec_addref(struct d_hash_table *htable, d_list_t *rlink);
  * is set.
  *
  * \param[in] htable		Pointer to the hash table
- * \param[in] rlink		Chain rlink of the hash record
+ * \param[in] link		Chain link of the hash record
  */
-void d_hash_rec_decref(struct d_hash_table *htable, d_list_t *rlink);
+void d_hash_rec_decref(struct d_hash_table *htable, d_list_t *link);
 
 /**
  * Decrease the refcount of the record by count.
@@ -448,28 +483,27 @@ void d_hash_rec_decref(struct d_hash_table *htable, d_list_t *rlink);
  *
  * \param[in] htable		Pointer to the hash table
  * \param[in] count		Number of references to drop
- * \param[in] rlink		Chain rlink of the hash record
+ * \param[in] link		Chain link of the hash record
  *
  * \retval			0		Success
  * \retval			-DER_INVAL	Not enough references were held.
  */
-int d_hash_rec_ndecref(struct d_hash_table *htable, int count,
-		       d_list_t *rlink);
+int  d_hash_rec_ndecref(struct d_hash_table *htable, int count, d_list_t *link);
 
 /**
  * Check if the link chain has already been unlinked from the hash table.
  *
- * \param[in] rlink		The link chain of the record
+ * \param[in] link		The link chain of the record
  *
  * \retval			true	Yes
  * \retval			false	No
  */
-bool d_hash_rec_unlinked(d_list_t *rlink);
+bool d_hash_rec_unlinked(d_list_t *link);
 
 /**
- * Return the first entry in a hash table.  Do this by traversing the table, and
- * returning the first rlink value provided to the callback.
- * Returns rlink on success, or NULL on error or if the hash table is empty.
+ * Return the first entry in a hash table.  Do this by traversing the table,
+ * and returning the first link value provided to the callback.
+ * Returns link on success, or NULL on error or if the hash table is empty.
  *
  * Note this does not take a reference on the returned entry and has no ordering
  * semantics.  It's main use is for draining a hash table before calling
@@ -477,7 +511,7 @@ bool d_hash_rec_unlinked(d_list_t *rlink);
  *
  * \param[in] htable		Pointer to the hash table
  *
- * \retval			rlink	Pointer to first element in hash table
+ * \retval			link	Pointer to first element in hash table
  * \retval			NULL	Hash table is empty or error occurred
  */
 d_list_t *d_hash_rec_first(struct d_hash_table *htable);
@@ -508,20 +542,20 @@ void d_hash_table_debug(struct d_hash_table *htable);
  * set bit 0 to 1.
  */
 enum {
-	D_HTYPE_PTR		= 0, /**< pointer type handle */
+	D_HTYPE_PTR		= 0,	/**< pointer type handle */
 	/* Must enlarge D_HTYPE_BITS to add more types */
 };
 
 struct d_hlink;
 struct d_hlink_ops {
 	/** free callback */
-	void	(*hop_free)(struct d_hlink *rlink);
+	void	(*hop_free)(struct d_hlink *hlink);
 };
 
 struct d_rlink {
 	d_list_t		rl_link;
-	unsigned int		rl_ref;
-	unsigned int		rl_initialized:1;
+	uint32_t		rl_ref:30,
+				rl_initialized:1;
 };
 
 struct d_hlink {
@@ -530,11 +564,11 @@ struct d_hlink {
 	struct d_hlink_ops	*hl_ops;
 };
 
-struct d_hhash;
+struct d_hhash;			/**< internal definition */
 
-int  d_hhash_create(uint32_t feats, unsigned int bits, struct d_hhash **hhash);
-void d_hhash_destroy(struct d_hhash *hh);
-void d_hhash_hlink_init(struct d_hlink *hlink, struct d_hlink_ops *ops);
+int  d_hhash_create(uint32_t feats, uint32_t bits, struct d_hhash **hhash);
+void d_hhash_destroy(struct d_hhash *hhash);
+void d_hhash_hlink_init(struct d_hlink *hlink, struct d_hlink_ops *hl_ops);
 /**
  * Insert to handle hash table.
  * If \a type is D_HTYPE_PTR, user MUST ensure the bit 0 of \a hlink pointer is
@@ -543,7 +577,7 @@ void d_hhash_hlink_init(struct d_hlink *hlink, struct d_hlink_ops *ops);
  * type.
  */
 void d_hhash_link_insert(struct d_hhash *hhash, struct d_hlink *hlink,
-		         int type);
+			 int type);
 struct d_hlink *d_hhash_link_lookup(struct d_hhash *hhash, uint64_t key);
 void d_hhash_link_getref(struct d_hhash *hhash, struct d_hlink *hlink);
 void d_hhash_link_putref(struct d_hhash *hhash, struct d_hlink *hlink);
@@ -552,8 +586,8 @@ bool d_hhash_link_empty(struct d_hlink *hlink);
 void d_hhash_link_key(struct d_hlink *hlink, uint64_t *key);
 int  d_hhash_key_type(uint64_t key);
 bool d_hhash_key_isptr(uint64_t key);
-int  d_hhash_set_ptrtype(struct d_hhash *hhtab);
-bool d_hhash_is_ptrtype(struct d_hhash *hhtab);
+int  d_hhash_set_ptrtype(struct d_hhash *hhash);
+bool d_hhash_is_ptrtype(struct d_hhash *hhash);
 
 /******************************************************************************
  * UUID Hash Table Wrapper
@@ -577,23 +611,21 @@ struct d_ulink_ops {
 struct d_ulink {
 	struct d_rlink		 ul_link;
 	struct d_uuid		 ul_uuid;
-	/** optional argument for compare callback */
-	void			*ul_cmp_args;
 	struct d_ulink_ops	*ul_ops;
 };
 
-int  d_uhash_create(uint32_t feats, unsigned int bits,
-		    struct d_hash_table **uhtab);
-void d_uhash_destroy(struct d_hash_table *uhtab);
-void d_uhash_ulink_init(struct d_ulink *ulink, struct d_ulink_ops *rl_ops);
+int  d_uhash_create(uint32_t feats, uint32_t bits,
+		    struct d_hash_table **htable);
+void d_uhash_destroy(struct d_hash_table *htable);
+void d_uhash_ulink_init(struct d_ulink *ulink, struct d_ulink_ops *ul_ops);
 bool d_uhash_link_empty(struct d_ulink *ulink);
 bool d_uhash_link_last_ref(struct d_ulink *ulink);
-void d_uhash_link_addref(struct d_hash_table *uhtab, struct d_ulink *hlink);
-void d_uhash_link_putref(struct d_hash_table *uhtab, struct d_ulink *hlink);
-void d_uhash_link_delete(struct d_hash_table *uhtab, struct d_ulink *hlink);
-int  d_uhash_link_insert(struct d_hash_table *uhtab, struct d_uuid *key,
-			 void *cmp_args, struct d_ulink *hlink);
-struct d_ulink *d_uhash_link_lookup(struct d_hash_table *uhtab,
+void d_uhash_link_addref(struct d_hash_table *htable, struct d_ulink *ulink);
+void d_uhash_link_putref(struct d_hash_table *htable, struct d_ulink *ulink);
+void d_uhash_link_delete(struct d_hash_table *htable, struct d_ulink *ulink);
+int  d_uhash_link_insert(struct d_hash_table *htable, struct d_uuid *key,
+			 void *cmp_args, struct d_ulink *ulink);
+struct d_ulink *d_uhash_link_lookup(struct d_hash_table *htable,
 				    struct d_uuid *key, void *cmp_args);
 
 #if defined(__cplusplus)

--- a/src/cart/src/include/gurt/hash.h
+++ b/src/cart/src/include/gurt/hash.h
@@ -94,7 +94,8 @@ typedef struct {
 	uint32_t (*hop_key_hash)(struct d_hash_table *htable, const void *key,
 				 unsigned int ksize);
 	/**
-	 * Get the hash of recorded key.
+	 * Mandatory for per bucket locking. Get the hash of recorded key.
+	 * It should return the same hash as hop_key_hash().
 	 *
 	 * \param[in]	htable	hash table
 	 * \param[in]	link	the link to record.
@@ -554,8 +555,8 @@ struct d_hlink_ops {
 
 struct d_rlink {
 	d_list_t		rl_link;
-	uint32_t		rl_ref:30,
-				rl_initialized:1;
+	uint32_t		rl_ref;
+	uint32_t		rl_initialized:1;
 };
 
 struct d_hlink {

--- a/src/cart/src/utest/test_gurt.c
+++ b/src/cart/src/utest/test_gurt.c
@@ -822,6 +822,15 @@ test_gurt_hash_op_key_cmp(struct d_hash_table *thtab, d_list_t *link,
 	return !memcmp(tlink->tl_key, key, ksize);
 }
 
+static uint32_t
+test_gurt_hash_op_rec_hash(struct d_hash_table *thtab, d_list_t *link)
+{
+	struct test_hash_entry *tlink = test_gurt_hash_link2ptr(link);
+
+	return d_hash_string_u32((const char *)tlink->tl_key,
+				 TEST_GURT_HASH_KEY_LEN);
+}
+
 static void
 test_gurt_hash_op_rec_addref(struct d_hash_table *thtab, d_list_t *link)
 {
@@ -863,7 +872,8 @@ test_gurt_hash_op_rec_free(struct d_hash_table *thtab, d_list_t *link)
 }
 
 static d_hash_table_ops_t th_ops = {
-	.hop_key_cmp    = test_gurt_hash_op_key_cmp,
+	.hop_key_cmp	= test_gurt_hash_op_key_cmp,
+	.hop_rec_hash	= test_gurt_hash_op_rec_hash,
 };
 
 /**
@@ -981,6 +991,7 @@ test_gurt_hash_empty(void **state)
 
 static d_hash_table_ops_t th_ops_ref = {
 	.hop_key_cmp		= test_gurt_hash_op_key_cmp,
+	.hop_rec_hash		= test_gurt_hash_op_rec_hash,
 	.hop_rec_addref		= test_gurt_hash_op_rec_addref,
 	.hop_rec_decref		= test_gurt_hash_op_rec_decref,
 	.hop_rec_ndecref	= test_gurt_hash_op_rec_ndecref,
@@ -1635,6 +1646,7 @@ test_gurt_hash_op_rec_decref_locked(struct d_hash_table *thtab, d_list_t *link)
 
 static d_hash_table_ops_t th_ref_ops = {
 	.hop_key_cmp    = test_gurt_hash_op_key_cmp,
+	.hop_rec_hash	= test_gurt_hash_op_rec_hash,
 	.hop_rec_addref	= test_gurt_hash_op_rec_addref_locked,
 	.hop_rec_decref	= test_gurt_hash_op_rec_decref_locked,
 };
@@ -1754,6 +1766,7 @@ test_gurt_hash_parallel_same_operations(void **state)
 	test_gurt_hash_threaded_same_operations(D_HASH_FT_RWLOCK);
 	test_gurt_hash_threaded_same_operations(D_HASH_FT_RWLOCK
 						| D_HASH_FT_EPHEMERAL);
+	test_gurt_hash_threaded_same_operations(D_HASH_FT_LRU);
 }
 
 static void
@@ -1764,6 +1777,7 @@ test_gurt_hash_parallel_different_operations(void **state)
 	test_gurt_hash_threaded_concurrent_operations(D_HASH_FT_RWLOCK);
 	test_gurt_hash_threaded_concurrent_operations(D_HASH_FT_RWLOCK
 						      | D_HASH_FT_EPHEMERAL);
+	test_gurt_hash_threaded_concurrent_operations(D_HASH_FT_LRU);
 }
 
 static void
@@ -1774,6 +1788,7 @@ test_gurt_hash_parallel_refcounting(void **state)
 	_test_gurt_hash_parallel_refcounting(D_HASH_FT_RWLOCK);
 	_test_gurt_hash_parallel_refcounting(D_HASH_FT_RWLOCK
 					     | D_HASH_FT_EPHEMERAL);
+	_test_gurt_hash_parallel_refcounting(D_HASH_FT_LRU);
 }
 
 struct circular_item {

--- a/src/cart/src/utest/test_linkage.cpp
+++ b/src/cart/src/utest/test_linkage.cpp
@@ -115,8 +115,17 @@ key_cmp(struct d_hash_table *htable, d_list_t *rlink,
 	return true;
 }
 
+static uint32_t
+hop_rec_hash(struct d_hash_table *htable, d_list_t *link)
+{
+	return 0;
+}
+
 static d_hash_table_ops_t hash_ops = {
-	hop_key_cmp : key_cmp,
+	hop_key_cmp  : key_cmp,
+	hop_key_init : NULL,
+	hop_key_hash : NULL,
+	hop_rec_hash : hop_rec_hash
 };
 
 static void

--- a/src/client/dfuse/dfuse_core.c
+++ b/src/client/dfuse/dfuse_core.c
@@ -65,11 +65,11 @@ ir_key_cmp(struct d_hash_table *htable, d_list_t *rlink,
 }
 
 static uint32_t
-ir_rec_hash(struct d_hash_table *htable, d_list_t *link)
+ir_rec_hash(struct d_hash_table *htable, d_list_t *rlink)
 {
 	const struct dfuse_inode_record		*ir;
 
-	ir = container_of(link, struct dfuse_inode_record, ir_htl);
+	ir = container_of(rlink, struct dfuse_inode_record, ir_htl);
 
 	return (uint32_t)ir->ir_id.irid_oid.hi;
 
@@ -88,14 +88,12 @@ ir_free(struct d_hash_table *htable, d_list_t *rlink)
 /* Inode entry hash table operations */
 
 static uint32_t
-ih_rec_hash(struct d_hash_table *htable, d_list_t *link)
+ih_key_hash(struct d_hash_table *htable, const void *key,
+	    unsigned int ksize)
 {
-	const struct dfuse_inode_entry	*ie;
+	const ino_t *ino = key;
 
-	ie = container_of(link, struct dfuse_inode_entry, ie_htl);
-
-	return d_hash_string_u32((const char *)&ie->ie_stat.st_ino,
-				 sizeof(ie->ie_stat.st_ino));
+	return (uint32_t)(*ino);
 }
 
 static bool
@@ -108,6 +106,16 @@ ih_key_cmp(struct d_hash_table *htable, d_list_t *rlink,
 	ie = container_of(rlink, struct dfuse_inode_entry, ie_htl);
 
 	return *ino == ie->ie_stat.st_ino;
+}
+
+static uint32_t
+ih_rec_hash(struct d_hash_table *htable, d_list_t *rlink)
+{
+	const struct dfuse_inode_entry	*ie;
+
+	ie = container_of(rlink, struct dfuse_inode_entry, ie_htl);
+
+	return (uint32_t)ie->ie_stat.st_ino;
 }
 
 static void
@@ -178,6 +186,7 @@ ih_free(struct d_hash_table *htable, d_list_t *rlink)
 
 static d_hash_table_ops_t ie_hops = {
 	.hop_key_cmp		= ih_key_cmp,
+	.hop_key_hash		= ih_key_hash,
 	.hop_rec_hash		= ih_rec_hash,
 	.hop_rec_addref		= ih_addref,
 	.hop_rec_decref		= ih_decref,

--- a/src/client/dfuse/dfuse_core.c
+++ b/src/client/dfuse/dfuse_core.c
@@ -64,6 +64,17 @@ ir_key_cmp(struct d_hash_table *htable, d_list_t *rlink,
 	return true;
 }
 
+static uint32_t
+ir_rec_hash(struct d_hash_table *htable, d_list_t *link)
+{
+	const struct dfuse_inode_record		*ir;
+
+	ir = container_of(link, struct dfuse_inode_record, ir_htl);
+
+	return (uint32_t)ir->ir_id.irid_oid.hi;
+
+}
+
 static void
 ir_free(struct d_hash_table *htable, d_list_t *rlink)
 {
@@ -75,6 +86,17 @@ ir_free(struct d_hash_table *htable, d_list_t *rlink)
 }
 
 /* Inode entry hash table operations */
+
+static uint32_t
+ih_rec_hash(struct d_hash_table *htable, d_list_t *link)
+{
+	const struct dfuse_inode_entry	*ie;
+
+	ie = container_of(link, struct dfuse_inode_entry, ie_htl);
+
+	return d_hash_string_u32((const char *)&ie->ie_stat.st_ino,
+				 sizeof(ie->ie_stat.st_ino));
+}
 
 static bool
 ih_key_cmp(struct d_hash_table *htable, d_list_t *rlink,
@@ -156,6 +178,7 @@ ih_free(struct d_hash_table *htable, d_list_t *rlink)
 
 static d_hash_table_ops_t ie_hops = {
 	.hop_key_cmp		= ih_key_cmp,
+	.hop_rec_hash		= ih_rec_hash,
 	.hop_rec_addref		= ih_addref,
 	.hop_rec_decref		= ih_decref,
 	.hop_rec_ndecref	= ih_ndecref,
@@ -163,9 +186,10 @@ static d_hash_table_ops_t ie_hops = {
 };
 
 static d_hash_table_ops_t ir_hops = {
-	.hop_key_cmp	= ir_key_cmp,
-	.hop_key_hash   = ir_key_hash,
-	.hop_rec_free	= ir_free,
+	.hop_key_cmp		= ir_key_cmp,
+	.hop_key_hash		= ir_key_hash,
+	.hop_rec_hash		= ir_rec_hash,
+	.hop_rec_free		= ir_free,
 
 };
 

--- a/src/common/lru.c
+++ b/src/common/lru.c
@@ -1,31 +1,42 @@
-/**
- * (C) Copyright 2016-2019 Intel Corporation.
+/* Copyright (C) 2016-2020 Intel Corporation
+ * All rights reserved.
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted for any purpose (including commercial purposes)
+ * provided that the following conditions are met:
  *
- *    http://www.apache.org/licenses/LICENSE-2.0
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions, and the following disclaimer.
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions, and the following disclaimer in the
+ *    documentation and/or materials provided with the distribution.
  *
- * GOVERNMENT LICENSE RIGHTS-OPEN SOURCE SOFTWARE
- * The Government's rights to use, modify, reproduce, release, perform, display,
- * or disclose this software are subject to the terms of the Apache License as
- * provided in Contract No. B609815.
- * Any reproduction of computer software, computer software documentation, or
- * portions thereof marked with this legend must also reproduce the markings.
+ * 3. In addition, redistributions of modified forms of the source or binary
+ *    code must carry prominent notices stating that the original code was
+ *    changed and the date of the change.
+ *
+ * 4. All publications or advertising materials mentioning features or use of
+ *    this software are asked, but not required, to acknowledge that it was
+ *    developed by Intel Corporation and credit the contributors.
+ *
+ * 5. Neither the name of Intel Corporation, nor the name of any Contributor
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 /*
- * This file is part of DAOSM
- *
- * common/lru.c
- *
- * Author: Vishwanath Venkatesan <vishwanath.venkatesan@intel.com>
+ * This file is part of DAOS
  */
 #define D_LOGFAC	DD_FAC(common)
 
@@ -35,35 +46,37 @@
 #include <gurt/hash.h>
 #include <daos/lru.h>
 
-static struct daos_llink*
-hash2lru_link(d_list_t *blink)
+static inline struct daos_llink*
+link2llink(d_list_t *link)
 {
-	return container_of(blink, struct daos_llink, ll_hlink);
+	return container_of(link, struct daos_llink, ll_link);
 }
 
 static void
-lru_hop_rec_addref(struct d_hash_table *lr_htab, d_list_t *rlink)
+lru_hop_rec_addref(struct d_hash_table *htable, d_list_t *link)
 {
-	hash2lru_link(rlink)->ll_ref++;
+	struct daos_llink *llink = link2llink(link);
+
+	llink->ll_ref++;
 }
 
 static bool
-lru_hop_rec_decref(struct d_hash_table *lr_htab, d_list_t *rlink)
+lru_hop_rec_decref(struct d_hash_table *htable, d_list_t *link)
 {
 
-       struct daos_llink *llink = hash2lru_link(rlink);
+	struct daos_llink *llink = link2llink(link);
 
-       D_ASSERT(llink->ll_ref > 0);
-       llink->ll_ref--;
-       /* Delete from hash only if no more references */
-       return llink->ll_ref == 0;
+	D_ASSERT(llink->ll_ref > 0);
+	llink->ll_ref--;
+	/* Delete from hash only if no more references */
+	return llink->ll_ref == 0;
 }
 
 static bool
-lru_hop_key_cmp(struct d_hash_table *lr_htab, d_list_t *rlink,
+lru_hop_key_cmp(struct d_hash_table *htable, d_list_t *link,
 		const void *key, unsigned int ksize)
 {
-	struct daos_llink *llink = hash2lru_link(rlink);
+	struct daos_llink *llink = link2llink(link);
 
 	if (llink->ll_evicted)
 		return false; /* nobody should use it */
@@ -71,268 +84,212 @@ lru_hop_key_cmp(struct d_hash_table *lr_htab, d_list_t *rlink,
 		return llink->ll_ops->lop_cmp_keys(key, ksize, llink);
 }
 
-static void
-lru_hop_rec_free(struct d_hash_table *lr_htab, d_list_t *rlink)
+static uint32_t
+lru_hop_rec_hash(struct d_hash_table *htable, d_list_t *link)
 {
-	struct daos_llink *llink = hash2lru_link(rlink);
+	struct daos_llink *llink = link2llink(link);
+
+	return llink->ll_ops->lop_rec_hash(llink);
+}
+
+static void
+lru_hop_rec_free(struct d_hash_table *htable, d_list_t *link)
+{
+	struct daos_llink *llink = link2llink(link);
 
 	llink->ll_ops->lop_free_ref(llink);
 }
 
 static d_hash_table_ops_t lru_ops = {
 	.hop_key_cmp		= lru_hop_key_cmp,
+	.hop_rec_hash		= lru_hop_rec_hash,
 	.hop_rec_addref		= lru_hop_rec_addref,
 	.hop_rec_decref		= lru_hop_rec_decref,
 	.hop_rec_free		= lru_hop_rec_free,
 };
 
-
 int
 daos_lru_cache_create(int bits, uint32_t feats,
 		      struct daos_llink_ops *ops,
-		      struct daos_lru_cache **lcache)
+		      struct daos_lru_cache **lcache_pp)
 {
-	struct daos_lru_cache	*lru_cache = NULL;
-	int			rc = 0;
+	struct daos_lru_cache	*lcache = NULL;
+	int			 rc = 0;
 
-	D_DEBUG(DB_TRACE, "Creating a new LRU cache of size (2^%d)\n",
-		bits);
+	D_DEBUG(DB_TRACE, "Creating a new LRU cache of size (2^%d)\n", bits);
 
 	if (ops == NULL ||
-	    ops->lop_cmp_keys == NULL ||
+	    ops->lop_cmp_keys  == NULL ||
+	    ops->lop_rec_hash  == NULL ||
 	    ops->lop_alloc_ref == NULL ||
-	    ops->lop_free_ref == NULL) {
+	    ops->lop_free_ref  == NULL) {
 		D_ERROR("Error missing ops/mandatory-ops for LRU cache\n");
-		return -DER_INVAL;
+		D_GOTO(out, rc = -DER_INVAL);
 	}
 
-	D_ALLOC_PTR(lru_cache);
-	if (lru_cache == NULL)
-		return -DER_NOMEM;
+	D_ALLOC_PTR(lcache);
+	if (lcache == NULL)
+		D_GOTO(out, rc = -DER_NOMEM);
 
-	rc = d_hash_table_create_inplace(feats, max(4, bits - 3),
-					 NULL, &lru_ops,
-					 &lru_cache->dlc_htable);
+	rc = d_hash_table_create_inplace(feats | D_HASH_FT_LRU,
+					 (uint32_t)max_t(int, 4, bits - 3),
+					 NULL, &lru_ops, &lcache->dlc_htable);
 	if (rc)
-		D_GOTO(exit, rc = -DER_NOMEM);
+		D_GOTO(out, rc);
 
 	if (bits >= 0)
-		lru_cache->dlc_csize = (1 << bits);
+		lcache->dlc_csize = (1U << bits);
 	else /* disable LRU */
-		lru_cache->dlc_csize = 0;
+		lcache->dlc_csize = 0;
 
-	lru_cache->dlc_ops = ops;
+	lcache->dlc_count = 0;
+	lcache->dlc_ops = ops;
 
-	D_INIT_LIST_HEAD(&lru_cache->dlc_idle_list);
-	D_INIT_LIST_HEAD(&lru_cache->dlc_busy_list);
-
-	*lcache = lru_cache;
-exit:
-	if (rc != 0)
-		D_FREE(lru_cache);
-
+	*lcache_pp = lcache;
+	lcache = NULL;
+out:
+	if (lcache != NULL)
+		D_FREE(lcache);
 	return rc;
 }
 
 void
 daos_lru_cache_destroy(struct daos_lru_cache *lcache)
 {
+	if (lcache == NULL)
+		return;
 
 	D_DEBUG(DB_TRACE, "Destroying LRU cache\n");
-	/**
-	 * Cannot destroy if either lcache is NULL or
-	 * if there are busy references.
-	 */
-	D_DEBUG(DB_TRACE, "refs_held :%u\n", lcache->dlc_busy_nr);
-	D_ASSERTF(lcache->dlc_busy_nr == 0, "busy=%d", lcache->dlc_busy_nr);
-
 	d_hash_table_debug(&lcache->dlc_htable);
 	d_hash_table_destroy_inplace(&lcache->dlc_htable, true);
 	D_FREE(lcache);
 }
 
+struct lru_evict_arg {
+	daos_lru_cond_cb_t	 cb;
+	void			*arg;
+	d_list_t		 list;
+};
+
+static int
+lru_evict_cb(d_list_t *link, void *arg)
+{
+	struct daos_llink *llink = link2llink(link);
+	struct lru_evict_arg *cb_arg = arg;
+
+	if (llink->ll_evicted || cb_arg->cb == NULL ||
+	    cb_arg->cb(llink, cb_arg->arg)) {
+		llink->ll_evicted = 1;
+		if (d_list_empty(&llink->ll_qlink))
+			d_list_add(&llink->ll_qlink, &cb_arg->list);
+	}
+
+	return 0;
+}
+
 void
 daos_lru_cache_evict(struct daos_lru_cache *lcache,
-		     daos_lru_cond_cb_t cond, void *args)
+		     daos_lru_cond_cb_t cond, void *arg)
 {
-	struct daos_llink *llink;
-	struct daos_llink *tmp;
-	unsigned int	   cntr;
+	struct lru_evict_arg	 cb_arg = { .cb = cond, .arg = arg };
+	struct daos_llink	*llink;
+	struct daos_llink	*tmp;
+	unsigned int		 count = 0;
+	int			 rc;
 
-	cntr = 0;
-	d_list_for_each_entry(llink, &lcache->dlc_busy_list, ll_qlink) {
-		if (cond == NULL || cond(llink, args)) {
-			/* will be evicted later in daos_lru_ref_release */
-			daos_lru_ref_evict(llink);
-			cntr++;
-		}
-	}
-	D_DEBUG(DB_TRACE, "Marked %d busy items as evicted\n", cntr);
+	D_INIT_LIST_HEAD(&cb_arg.list);
+	rc = d_hash_table_traverse(&lcache->dlc_htable, lru_evict_cb, &cb_arg);
+	D_ASSERT(rc == 0);
 
-	cntr = 0;
-	d_list_for_each_entry_safe(llink, tmp, &lcache->dlc_idle_list,
-				   ll_qlink) {
-		if (cond == NULL || cond(llink, args)) {
-			d_list_del_init(&llink->ll_qlink);
+	d_list_for_each_entry_safe(llink, tmp, &cb_arg.list, ll_qlink) {
+		d_list_del_init(&llink->ll_qlink);
+		if (llink->ll_ref == 1) { /* the last refcount */
+			D_DEBUG(DB_TRACE, "Remove %p from LRU cache\n",
+				llink);
 			d_hash_rec_delete_at(&lcache->dlc_htable,
-					     &llink->ll_hlink);
-			lcache->dlc_idle_nr--;
-			cntr++;
+					     &llink->ll_link);
+			lcache->dlc_count--;
+			count++;
 		}
 	}
-	D_DEBUG(DB_TRACE, "Evicted %d items from idle list\n", cntr);
-}
-
-static struct daos_llink *
-lru_fast_search(struct daos_lru_cache *lcache, d_list_t *head,
-		void *key, unsigned int key_size)
-{
-	struct daos_llink *llink;
-
-	if (d_list_empty(head))
-		return NULL;
-
-	llink = d_list_entry(head->next, struct daos_llink, ll_qlink);
-	if (llink->ll_evicted)
-		return NULL;
-
-	if (llink->ll_ops->lop_cmp_keys(key, key_size, llink)) {
-		D_DEBUG(DB_TRACE, "Found item on the %s list.\n",
-			head == &lcache->dlc_busy_list ? "busy" : "idle");
-
-		llink->ll_ref++; /* +1 for caller */
-		return llink;
-	}
-	return NULL;
-}
-
-struct daos_llink *
-lru_hash_search(struct daos_lru_cache *lcache, void *key,
-		unsigned int key_size)
-{
-	d_list_t	*hlink;
-
-	hlink = d_hash_rec_find(&lcache->dlc_htable, key, key_size);
-	if (hlink == NULL)
-		return NULL;
-
-	D_DEBUG(DB_TRACE, "Found in the cache hash table\n");
-	return hash2lru_link(hlink);
-}
-
-static inline void
-lru_mark_busy(struct daos_lru_cache *lcache, struct daos_llink *llink)
-{
-	/**
-	 * This reference is about to get busy, lets move it from the idle
-	 * list to busy list, and change counters for the cache.
-	 */
-	D_DEBUG(DB_TRACE, "Ref to get busy held: %u, filled :%u\n",
-		lcache->dlc_busy_nr, lcache->dlc_idle_nr);
-
-	if (d_list_empty(&llink->ll_qlink)) { /* new item */
-		d_list_add(&llink->ll_qlink, &lcache->dlc_busy_list);
-	} else {
-		lcache->dlc_idle_nr--;
-		d_list_move(&llink->ll_qlink, &lcache->dlc_busy_list);
-	}
-	lcache->dlc_busy_nr++;
+	D_DEBUG(DB_TRACE, "Evicted %u items, total count %u of %u\n",
+		count, lcache->dlc_count, lcache->dlc_csize);
 }
 
 int
 daos_lru_ref_hold(struct daos_lru_cache *lcache, void *key,
 		  unsigned int key_size, void *create_args,
-		  struct daos_llink **rlink)
+		  struct daos_llink **llink_pp)
 {
-	struct daos_llink *llink;
-	int		   rc;
+	struct daos_llink	*llink;
+	d_list_t		*link;
+	int			 rc = 0;
 
 	D_ASSERT(lcache != NULL && key != NULL && key_size > 0);
 	if (lcache->dlc_ops->lop_print_key)
 		lcache->dlc_ops->lop_print_key(key, key_size);
 
-	llink = lru_fast_search(lcache, &lcache->dlc_busy_list, key, key_size);
-	if (llink)
+	link = d_hash_rec_find(&lcache->dlc_htable, key, key_size);
+	if (link != NULL) {
+		llink = link2llink(link);
 		D_GOTO(found, rc = 0);
+	}
 
-	llink = lru_fast_search(lcache, &lcache->dlc_idle_list, key, key_size);
-	if (llink)
-		D_GOTO(found, rc = 0);
-
-	llink = lru_hash_search(lcache, key, key_size);
-	if (llink)
-		D_GOTO(found, rc = 0);
-
-	if (!create_args)
+	if (create_args == NULL)
 		D_GOTO(out, rc = -DER_NONEXIST);
 
-	D_DEBUG(DB_TRACE, "Entry not found adding it to LRU\n");
 	/* llink does not exist create one */
 	rc = lcache->dlc_ops->lop_alloc_ref(key, key_size, create_args, &llink);
 	if (rc)
 		D_GOTO(out, rc);
 
-	D_DEBUG(DB_TRACE, "Inserting into LRU Hash table\n");
+	D_DEBUG(DB_TRACE, "Inserting %p item into LRU Hash table\n", llink);
 	llink->ll_evicted = 0;
 	llink->ll_ref	  = 1; /* 1 for caller */
 	llink->ll_ops	  = lcache->dlc_ops;
-	D_INIT_LIST_HEAD(&llink->ll_qlink);
 
 	rc = d_hash_rec_insert(&lcache->dlc_htable, key, key_size,
-			       &llink->ll_hlink, true);
+			       &llink->ll_link, true);
 	D_ASSERT(rc == 0);
+	lcache->dlc_count++;
 found:
-	if (llink->ll_ref == 2) /* 1 for hash, 1 for the first holder */
-		lru_mark_busy(lcache, llink);
-
-	*rlink = llink;
+	*llink_pp = llink;
 out:
 	return rc;
+}
+
+static bool
+lru_flush_cond(struct daos_llink *llink, void *arg)
+{
+	if (llink->ll_ref == 1) /* the last refcount */
+		llink->ll_evicted = 1;
+
+	return llink->ll_evicted;
+}
+
+void
+daos_lru_ref_flush(struct daos_lru_cache *lcache)
+{
+	D_DEBUG(DB_TRACE, "Flush LRU cache: %d > %d\n",
+		lcache->dlc_count, lcache->dlc_csize);
+	daos_lru_cache_evict(lcache, lru_flush_cond, NULL);
 }
 
 void
 daos_lru_ref_release(struct daos_lru_cache *lcache, struct daos_llink *llink)
 {
 	D_ASSERT(lcache != NULL && llink != NULL && llink->ll_ref > 1);
-	D_DEBUG(DB_TRACE, "Releasing item %p, ref=%d\n", llink, llink->ll_ref);
 
 	llink->ll_ref--;
 	if (llink->ll_ref == 1) { /* the last refcount */
-		D_DEBUG(DB_TRACE, "busy: %u, idle: %u\n",
-			lcache->dlc_busy_nr, lcache->dlc_idle_nr);
-
-		D_ASSERT(lcache->dlc_busy_nr > 0);
-		lcache->dlc_busy_nr--;
-
-		if (llink->ll_evicted) {
-			D_DEBUG(DB_TRACE, "Evict %p from LRU cache\n", llink);
-			d_list_del_init(&llink->ll_qlink);
+		if (llink->ll_evicted || lcache->dlc_csize == 0) {
+			D_DEBUG(DB_TRACE, "Remove %p from LRU cache\n", llink);
 			/* be freed within hash callback */
 			d_hash_rec_delete_at(&lcache->dlc_htable,
-					     &llink->ll_hlink);
-		} else {
-			D_DEBUG(DB_TRACE,
-				"Moving %p to the idle list\n", llink);
-			lcache->dlc_idle_nr++;
-			d_list_move(&llink->ll_qlink, &lcache->dlc_idle_list);
+					     &llink->ll_link);
+			lcache->dlc_count--;
 		}
 	}
-
-	while (lcache->dlc_idle_nr != 0 &&
-	       (lcache->dlc_busy_nr + lcache->dlc_idle_nr >=
-		lcache->dlc_csize)) {
-		D_DEBUG(DB_TRACE, "Evicting from object cache :%d, %d\n",
-			lcache->dlc_idle_nr, lcache->dlc_busy_nr);
-
-		/** evict from the tail of the list */
-		D_ASSERT(!d_list_empty(&lcache->dlc_idle_list));
-		llink = container_of(lcache->dlc_idle_list.prev,
-				     struct daos_llink, ll_qlink);
-
-		d_list_del_init(&llink->ll_qlink);
-		lcache->dlc_idle_nr--;
-		/* NB. hash entry free could yield */
-		d_hash_rec_delete_at(&lcache->dlc_htable, &llink->ll_hlink);
-	}
-	D_DEBUG(DB_TRACE, "Done releasing reference\n");
+	if (lcache->dlc_csize && lcache->dlc_count > lcache->dlc_csize)
+		daos_lru_ref_flush(lcache);
 }

--- a/src/common/misc.c
+++ b/src/common/misc.c
@@ -495,7 +495,8 @@ daos_hhash_init(void)
 		D_GOTO(unlock, rc = 0);
 	}
 
-	rc = d_hhash_create(D_HASH_FT_LRU, D_HHASH_BITS, &daos_ht.dht_hhash);
+	rc = d_hhash_create(D_HASH_FT_GLOCK | D_HASH_FT_LRU, D_HHASH_BITS,
+			    &daos_ht.dht_hhash);
 	if (rc == 0) {
 		D_ASSERT(daos_ht.dht_hhash != NULL);
 		daos_ht_ref = 1;

--- a/src/common/misc.c
+++ b/src/common/misc.c
@@ -495,7 +495,7 @@ daos_hhash_init(void)
 		D_GOTO(unlock, rc = 0);
 	}
 
-	rc = d_hhash_create(0, D_HHASH_BITS, &daos_ht.dht_hhash);
+	rc = d_hhash_create(D_HASH_FT_LRU, D_HHASH_BITS, &daos_ht.dht_hhash);
 	if (rc == 0) {
 		D_ASSERT(daos_ht.dht_hhash != NULL);
 		daos_ht_ref = 1;

--- a/src/common/tests/lru.c
+++ b/src/common/tests/lru.c
@@ -71,16 +71,27 @@ bool
 uint_ref_lru_cmp(const void *key, unsigned int ksize,
 		 struct daos_llink *llink)
 {
-	struct uint_ref	*ref = NULL;
+	struct uint_ref	*ref = container_of(llink, struct uint_ref, ur_llink);
 
-	ref = container_of(llink, struct uint_ref, ur_llink);
+	D_ASSERT(ksize == sizeof(uint64_t));
+
 	return (ref->ur_key == *(uint64_t *)key);
+}
+
+uint32_t
+uint_ref_lru_hash(struct daos_llink *llink)
+{
+	struct uint_ref	*ref = container_of(llink, struct uint_ref, ur_llink);
+
+	return d_hash_string_u32((const char *)&ref->ur_key,
+				 sizeof(ref->ur_key));
 }
 
 struct daos_llink_ops uint_ref_llink_ops = {
 	.lop_free_ref	= uint_ref_lru_free,
 	.lop_alloc_ref	= uint_ref_lru_alloc,
 	.lop_cmp_keys	= uint_ref_lru_cmp,
+	.lop_rec_hash	= uint_ref_lru_hash,
 };
 
 static inline int

--- a/src/container/srv_target.c
+++ b/src/container/srv_target.c
@@ -526,10 +526,19 @@ cont_child_cmp_keys(const void *key, unsigned int ksize,
 	return uuid_compare(key, cont->sc_uuid) == 0;
 }
 
+static uint32_t
+cont_child_rec_hash(struct daos_llink *llink)
+{
+	struct ds_cont_child *cont = cont_child_obj(llink);
+
+	return d_hash_string_u32((const char *)cont->sc_uuid, sizeof(uuid_t));
+}
+
 static struct daos_llink_ops cont_child_cache_ops = {
 	.lop_alloc_ref	= cont_child_alloc_ref,
 	.lop_free_ref	= cont_child_free_ref,
-	.lop_cmp_keys	= cont_child_cmp_keys
+	.lop_cmp_keys	= cont_child_cmp_keys,
+	.lop_rec_hash	= cont_child_rec_hash,
 };
 
 int

--- a/src/include/daos/lru.h
+++ b/src/include/daos/lru.h
@@ -1,27 +1,42 @@
-/**
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the GNU Lesser General Public License
- * (LGPL) version 2.1 which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/lgpl-2.1.html
+/* Copyright (C) 2016-2020 Intel Corporation
+ * All rights reserved.
  *
- * This library is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
- * Lesser General Public License for more details.
- * GOVERNMENT LICENSE RIGHTS-OPEN SOURCE SOFTWARE
- * The Government's rights to use, modify, reproduce, release, perform, display,
- * or disclose this software are subject to the terms of the LGPL License as
- * provided in Contract No. B609815.
- * Any reproduction of computer software, computer software documentation, or
- * portions thereof marked with this legend must also reproduce the markings.
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted for any purpose (including commercial purposes)
+ * provided that the following conditions are met:
  *
- * (C) Copyright 2016 Intel Corporation.
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions, and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions, and the following disclaimer in the
+ *    documentation and/or materials provided with the distribution.
+ *
+ * 3. In addition, redistributions of modified forms of the source or binary
+ *    code must carry prominent notices stating that the original code was
+ *    changed and the date of the change.
+ *
+ * 4. All publications or advertising materials mentioning features or use of
+ *    this software are asked, but not required, to acknowledge that it was
+ *    developed by Intel Corporation and credit the contributors.
+ *
+ * 5. Neither the name of Intel Corporation, nor the name of any Contributor
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 /**
  * In-memory LRU cache for DAOS
- * daos/lru.h
- *
- * Author: Vishwanath Venkatesan <vishwanath.venkatesan@intel.com>
  */
 #ifndef __DAOS_LRU_H__
 #define __DAOS_LRU_H__
@@ -32,66 +47,47 @@
 struct daos_llink;
 struct daos_llink_ops {
 	/** Mandatory: lru reference free callback */
-	void	(*lop_free_ref)(struct daos_llink *llink);
+	void	 (*lop_free_ref)(struct daos_llink *llink);
 	/** Mandatory: If ref not found, allocate and return ref */
-	int	(*lop_alloc_ref)(void *key, unsigned int ksize,
-				 void *args, struct daos_llink **link);
+	int	 (*lop_alloc_ref)(void *key, unsigned int ksize,
+				  void *args, struct daos_llink **link);
 	/** Mandatory: Compare keys callback for LRU */
-	bool	(*lop_cmp_keys)(const void *key, unsigned int ksize,
-				struct daos_llink *link);
+	bool	 (*lop_cmp_keys)(const void *key, unsigned int ksize,
+				 struct daos_llink *link);
+	/** Mandatory: Get key's hash callback for LRU */
+	uint32_t (*lop_rec_hash)(struct daos_llink *link);
 	/** Optional print_key function for debugging */
-	void	(*lop_print_key)(void *key, unsigned int ksize);
+	void	 (*lop_print_key)(void *key, unsigned int ksize);
 };
 
 struct daos_llink {
-	/* LRU hash link */
-	d_list_t		ll_hlink;
-	/* LRU queue link */
-	d_list_t		ll_qlink;
-	/* Ref count for this reference */
-	unsigned int		ll_ref:30;
-	/** has been evicted */
-	unsigned int		ll_evicted:1;
-	/**
-	 * ops to allocate and free reference
-	 * for this llink.
-	 */
-	struct daos_llink_ops	*ll_ops;
+	d_list_t		 ll_link;	/**< LRU hash link */
+	d_list_t		 ll_qlink;	/**< Temp link for traverse */
+	unsigned int		 ll_ref:30,	/**< refcount for this ref */
+				 ll_evicted:1;	/**< has been evicted */
+	struct daos_llink_ops	*ll_ops;	/**< ops to maintain refs */
 };
 
 /**
- * LRU cache implementation using d_hash_table
- * and d_list_t
+ * LRU cache implementation using d_hash_table and d_list_t
  */
 struct daos_lru_cache {
-	/* Provided cache size */
-	uint32_t		dlc_csize;
-	/* # idle items in the LRU */
-	uint32_t		dlc_idle_nr;
-	/* # busy items in the LRU (referenced by caller) */
-	uint32_t		dlc_busy_nr;
-	/* Queue head, holds idle refs (no refcnt) */
-	d_list_t		dlc_idle_list;
-	/** list head of busy items in the LRU */
-	d_list_t		dlc_busy_list;
-	/* Holds all refs but needs lookup */
-	struct d_hash_table	dlc_htable;
-	/* ops to allocate and free reference */
-	struct daos_llink_ops	*dlc_ops;
+	uint32_t		 dlc_csize;	/**< Provided cache size */
+	uint32_t		 dlc_count;	/**< count of refs in cache */
+	struct d_hash_table	 dlc_htable;	/**< Hash table for all refs */
+	struct daos_llink_ops	*dlc_ops;	/**< ops to maintain refs */
 };
 
 /**
  * Create a DAOS LRU cache
  * This function creates an LRU cache in DRAM
  *
- * \param bits		[IN]	power2(bits) is the size
- *				of the LRU cache
+ * \param bits		[IN]	power2(bits) is the size of the LRU cache
  * \feats feats		[IN]	Feature bits for DHASH, see DHASH_FT_*
  * \param ops		[IN]	DAOS LRU callbacks
  * \param lcache	[OUT]	Newly created LRU cache
  *
- * \return			0 on success and negative
- *				on failure.
+ * \return			0 on success and negative on failure.
  */
 int
 daos_lru_cache_create(int bits, uint32_t feats,
@@ -107,19 +103,19 @@ daos_lru_cache_create(int bits, uint32_t feats,
 void
 daos_lru_cache_destroy(struct daos_lru_cache *lcache);
 
-typedef bool (*daos_lru_cond_cb_t)(struct daos_llink *llink, void *args);
+typedef bool (*daos_lru_cond_cb_t)(struct daos_llink *llink, void *arg);
 
 /**
- * Evit LRU items that can match the condition @cond. All items will be evicted
- * if @cond is NULL.
+ * Evit LRU items that can match the condition @cond.
+ * All items will be evicted if @cond is NULL.
  *
  * \param lcache	[IN]	DAOS LRU cache
  * \param cond		[IN]	the condition callback
- * \param args		[IN]	arguments for the @cond
+ * \param arg		[IN]	arguments for the @cond
  */
 void
 daos_lru_cache_evict(struct daos_lru_cache *lcache,
-		     daos_lru_cond_cb_t cond, void *args);
+		     daos_lru_cond_cb_t cond, void *arg);
 
 /**
  * Find a ref in the cache \a lcache and take its reference.
@@ -138,10 +134,10 @@ daos_lru_cache_evict(struct daos_lru_cache *lcache,
  */
 int
 daos_lru_ref_hold(struct daos_lru_cache *lcache, void *key, unsigned int ksize,
-		  void *create_args, struct daos_llink **rlink);
+		  void *create_args, struct daos_llink **llink);
 
 /**
- * Release a reference from the cache and maintain a idle LRU list
+ * Release a reference from the cache
  *
  * \param lcache	[IN]	DAOS LRU cache
  * \param llink		[IN]	DAOS LRU link
@@ -150,14 +146,24 @@ void
 daos_lru_ref_release(struct daos_lru_cache *lcache, struct daos_llink *llink);
 
 /**
+ * Flush old items from LRU.
+ *
+ * \param lcache	[IN]	DAOS LRU cache
+ */
+void
+daos_lru_ref_flush(struct daos_lru_cache *lcache);
+
+/**
  * Evict the item from LRU after releasing the last refcount on it.
  *
+ * \param lcache	[IN]	DAOS LRU cache
  * \param llink		[IN]	DAOS LRU item to be evicted.
  */
 static inline void
-daos_lru_ref_evict(struct daos_llink *llink)
+daos_lru_ref_evict(struct daos_lru_cache *lcache, struct daos_llink *llink)
 {
 	llink->ll_evicted = 1;
+	d_hash_rec_evict_at(&lcache->dlc_htable, &llink->ll_link);
 }
 
 /**

--- a/src/placement/pl_map.c
+++ b/src/placement/pl_map.c
@@ -328,7 +328,7 @@ pl_link2map(d_list_t *link)
 	return container_of(link, struct pl_map, pl_link);
 }
 
-static unsigned int
+static uint32_t
 pl_hop_key_hash(struct d_hash_table *htab, const void *key,
 		unsigned int ksize)
 {

--- a/src/pool/srv_target.c
+++ b/src/pool/srv_target.c
@@ -420,10 +420,19 @@ pool_cmp_keys(const void *key, unsigned int ksize, struct daos_llink *llink)
 	return uuid_compare(key, pool->sp_uuid) == 0;
 }
 
+static uint32_t
+pool_rec_hash(struct daos_llink *llink)
+{
+	struct ds_pool *pool = pool_obj(llink);
+
+	return d_hash_string_u32((const char *)pool->sp_uuid, sizeof(uuid_t));
+}
+
 static struct daos_llink_ops pool_cache_ops = {
 	.lop_alloc_ref	= pool_alloc_ref,
 	.lop_free_ref	= pool_free_ref,
-	.lop_cmp_keys	= pool_cmp_keys
+	.lop_cmp_keys	= pool_cmp_keys,
+	.lop_rec_hash	= pool_rec_hash,
 };
 
 int
@@ -575,6 +584,14 @@ pool_hdl_key_cmp(struct d_hash_table *htable, d_list_t *rlink,
 	return uuid_compare(hdl->sph_uuid, key) == 0;
 }
 
+static uint32_t
+pool_hdl_rec_hash(struct d_hash_table *htable, d_list_t *link)
+{
+	struct ds_pool_hdl *hdl = pool_hdl_obj(link);
+
+	return d_hash_string_u32((const char *)hdl->sph_uuid, sizeof(uuid_t));
+}
+
 static void
 pool_hdl_rec_addref(struct d_hash_table *htable, d_list_t *rlink)
 {
@@ -607,6 +624,7 @@ pool_hdl_rec_free(struct d_hash_table *htable, d_list_t *rlink)
 
 static d_hash_table_ops_t pool_hdl_hash_ops = {
 	.hop_key_cmp	= pool_hdl_key_cmp,
+	.hop_rec_hash	= pool_hdl_rec_hash,
 	.hop_rec_addref	= pool_hdl_rec_addref,
 	.hop_rec_decref	= pool_hdl_rec_decref,
 	.hop_rec_free	= pool_hdl_rec_free

--- a/src/rdb/rdb_kvs.c
+++ b/src/rdb/rdb_kvs.c
@@ -173,10 +173,20 @@ rdb_kvs_cmp_keys(const void *key, unsigned int ksize, struct daos_llink *llink)
 	return true;
 }
 
+static uint32_t
+rdb_kvs_rec_hash(struct daos_llink *llink)
+{
+	struct rdb_kvs *kvs = rdb_kvs_obj(llink);
+
+	return d_hash_string_u32((const char *)kvs->de_path.iov_buf,
+				 kvs->de_path.iov_len);
+}
+
 static struct daos_llink_ops rdb_kvs_cache_ops = {
 	.lop_alloc_ref	= rdb_kvs_alloc_ref,
 	.lop_free_ref	= rdb_kvs_free_ref,
-	.lop_cmp_keys	= rdb_kvs_cmp_keys
+	.lop_cmp_keys	= rdb_kvs_cmp_keys,
+	.lop_rec_hash	= rdb_kvs_rec_hash,
 };
 
 int
@@ -230,5 +240,5 @@ rdb_kvs_put(struct rdb *db, struct rdb_kvs *kvs)
 void
 rdb_kvs_evict(struct rdb *db, struct rdb_kvs *kvs)
 {
-	daos_lru_ref_evict(&kvs->de_entry);
+	daos_lru_ref_evict(db->d_kvss, &kvs->de_entry);
 }

--- a/src/vos/vos_obj.c
+++ b/src/vos/vos_obj.c
@@ -147,6 +147,7 @@ static int
 obj_punch(daos_handle_t coh, struct vos_object *obj, daos_epoch_t epoch,
 	  uint64_t flags, struct vos_ts_set *ts_set)
 {
+	struct daos_lru_cache	*occ  = vos_obj_cache_current();
 	struct vos_container	*cont;
 	struct vos_ilog_info	 info;
 	int			 rc;
@@ -161,7 +162,7 @@ obj_punch(daos_handle_t coh, struct vos_object *obj, daos_epoch_t epoch,
 	/* evict it from catch, because future fetch should only see empty
 	 * object (without obj_df)
 	 */
-	vos_obj_evict(obj);
+	vos_obj_evict(occ, obj);
 failed:
 	vos_ilog_fetch_finish(&info);
 	return rc;

--- a/src/vos/vos_obj.h
+++ b/src/vos/vos_obj.h
@@ -118,7 +118,7 @@ vos_obj_refcount(struct vos_object *obj)
 }
 
 /** Evict an object reference from the cache */
-void vos_obj_evict(struct vos_object *obj);
+void vos_obj_evict(struct daos_lru_cache *occ, struct vos_object *obj);
 
 int vos_obj_evict_by_oid(struct daos_lru_cache *occ, struct vos_container *cont,
 			 daos_unit_oid_t oid);

--- a/utils/node_local_test.py
+++ b/utils/node_local_test.py
@@ -63,7 +63,7 @@ class WarningsFactory():
     # Error levels supported by the reporint are LOW, NORMAL, HIGH, ERROR.
     # Errors from this list of functions are known to happen during shutdown
     # for the time being, so are downgraded to LOW.
-    FLAKY_FUNCTIONS = ('daos_lru_cache_destroy', 'rdb_timerd')
+    FLAKY_FUNCTIONS = ('ds_pool_child_purge')
 
     def __init__(self, filename):
         self._fd = open(filename, 'w')


### PR DESCRIPTION
The Hash Table implementation was redesigned to make the locking
per bucket. It led to a change in the API. The new function
hop_rec_hash was introduced.

uint32_t (*hop_rec_hash)(struct d_hash_table *htable, d_list_t *link);

It should return the hash value of key which was used to store it
into the hash table.

New LRU feature was add into Hash Table implementation. The idea of
this feature is to popup the last found item into head of per bucket
list. This cause next search for this item much faster.

Basing on this LRU feature the DAOS LRU code was changed to make it
more scalable to maintain many hot items.

Performance testing of new implementations show the following results:

New Hash Table implementation.

Parallel execution of the same operations into several threads:

current master version (the time in processor tiks):
Operation (count)  | min time | avg time | max time
------------ | ---------- | --------- | -----------
insert(122880) | 200,407,811  | 301,821,520  |  390,762,741
traverse(122880) | 26,457,490 | 142,478,282 | 251,781,644
lookup(122880) | 3,091,640,839 | 3,180,550,249 | 3,231,423,491
delete(122880) | 289,866,694 | 320,578,773 | 330,955,234

this patch version (the time in processor tiks):
Operation (count)  | min time | avg time | max time
------------ | ---------- | --------- | -----------
insert(122880) |  20,992,422 |  33,196,314 | 55,259,780
traverse(122880) |  25,937,342 |  30,285,950 | 31,452,028
lookup(122880) | 324,108,436 | 325,161,848 | 325,536,972
delete(122880) | 23,429,403 | 28,689,445 | 30,819,230

The performance improvements is about 10 times.

Concurrent execution of the different operations in parallel into
several threads:

current master | this patch
---------------- | -----------
1,864,564,804 | 237,032,281

The performance improvements again is about 10 times.

New LRU implementation.

The test just store and the release a random values into LRU with
different size.

lru_test <size of LRU in 2^n> <count of elements>

$ time ./lru_test 4 100000000

time | current master | this patch
----- | ---------------- | -----------
real | 0m17.729s | 0m20.490s
user | 0m17.570s | 0m20.299s
sys | 0m0.059s | 0m0.091s

$ time ./lru_test 6 100000000

time | current master | this patch
----- | ---------------- | -----------
real | 0m21.342s | 0m19.487s
user | 0m21.192s | 0m19.336s
sys | 0m0.048s | 0m0.050s

$ time ./lru_test 8 100000000

time | current master | this patch
----- | ---------------- | -----------
real | 0m22.481s | 0m21.606s
user | 0m22.270s | 0m21.445s
sys | 0m0.109s | 0m0.060s

$ time ./lru_test 12 100000000

time | current master | this patch
----- | ---------------- | -----------
real | 0m26.401s | 0m23.433s
user | 0m26.235s | 0m23.274s
sys | 0m0.064s | 0m0.057s

$ time ./lru_test 16 100000000

time | current master | this patch
----- | ---------------- | -----------
real | 0m51.480s | 0m48.181s
user | 0m51.309s | 0m48.019s
sys | 0m0.062s | 0m0.053s

The new implementation has better scaling with LRU size.