### PR TITLE
DAOS-4457 tests: fix parsing of "daos pool list-cont" output

### DIFF
--- a/utils/node_local_test.py
+++ b/utils/node_local_test.py
@@ -1070,7 +1070,7 @@ def test_pydaos_kv(server, conf):
     container = show_cont(conf, pool)
 
     print(container)
-    c_uuid = container.decode().split(' ')[-1]
+    c_uuid = container.decode().split()[-1]
     kvg = dbm.daos_named_kv(pool, c_uuid)
 
     kv = kvg.get_kv_by_name('Dave')


### PR DESCRIPTION
After D_PRINT() change to no longer print date/time/host as a
prefix of each line (like "06/04-14:12:46.39 wolf-80 "),
space/' ' could not be used as the only separator possible to parse
"daos pool list-cont" command output.

Skip-func-test: true
Change-Id: I44aa6f24bf0a6213433dc6989cec9e2d572efa1e
Signed-off-by: Bruno Faccini <bruno.faccini@intel.com>