### PR TITLE
DAOS-5105 dtx: not miss resent DTX when leader_end

### DIFF
--- a/src/dtx/dtx_common.c
+++ b/src/dtx/dtx_common.c
@@ -247,6 +247,7 @@ dtx_handle_init(struct dtx_id *dti, daos_handle_t coh,
 	dth->dth_ent = NULL;
 
 	dth->dth_sync = 0;
+	dth->dth_resent = 0;
 	dth->dth_solo = solo ? 1 : 0;
 	dth->dth_dti_cos_done = 0;
 	dth->dth_modify_shared = 0;
@@ -331,7 +332,7 @@ init:
 			dti_cos, dti_cos_count, true,
 			tgt_cnt == 0 ? true : false, dth);
 
-	D_DEBUG(DB_TRACE, "Start DTX "DF_DTI" for object "DF_OID
+	D_DEBUG(DB_IO, "Start DTX "DF_DTI" for object "DF_OID
 		" ver %u, dkey %llu, dti_cos_count %d, intent %s\n",
 		DP_DTI(&dth->dth_xid), DP_OID(oid->id_pub), dth->dth_ver,
 		(unsigned long long)dth->dth_dkey_hash, dti_cos_count,
@@ -349,7 +350,7 @@ dtx_leader_wait(struct dtx_leader_handle *dlh)
 	D_ASSERTF(rc == ABT_SUCCESS, "ABT_future_wait failed %d.\n", rc);
 
 	ABT_future_free(&dlh->dlh_future);
-	D_DEBUG(DB_TRACE, "dth "DF_DTI" rc "DF_RC"\n",
+	D_DEBUG(DB_IO, "dth "DF_DTI" rc "DF_RC"\n",
 		DP_DTI(&dlh->dlh_handle.dth_xid), DP_RC(dlh->dlh_result));
 
 	return dlh->dlh_result;
@@ -383,7 +384,7 @@ dtx_leader_end(struct dtx_leader_handle *dlh, struct ds_cont_child *cont,
 	 */
 
 	rc = dtx_leader_wait(dlh);
-	if (result < 0 || rc < 0 || !dth->dth_active ||
+	if (result < 0 || rc < 0 || (!dth->dth_active && !dth->dth_resent) ||
 	    daos_is_zero_dti(&dth->dth_xid))
 		D_GOTO(out, result = result < 0 ? result : rc);
 
@@ -425,11 +426,11 @@ again:
 	if (rc == 0) {
 		/* When we come here, the modification on all participants have
 		 * been done successfully. If 'dth->dth_active' is false, means
-		 * that it is for resent caseC. Under such case, we have no way
+		 * that it is for resent case. Under such case, we have no way
 		 * to mark it as committable, then commit it sychronously.
 		 */
 		if (!dth->dth_active) {
-			D_ASSERT(dth->dth_ent == NULL);
+			D_ASSERT(dth->dth_resent);
 
 			dth->dth_sync = 1;
 		}
@@ -497,7 +498,7 @@ out:
 				  dth->dth_epoch, &dth->dth_dte, 1,
 				  cont->sc_pool->spc_map_version);
 
-		D_DEBUG(DB_TRACE,
+		D_DEBUG(DB_IO,
 			"Stop the DTX "DF_DTI" ver %u, dkey %llu, intent %s, "
 			"%s, %s participator(s): rc "DF_RC"\n",
 			DP_DTI(&dth->dth_xid), dth->dth_ver,
@@ -575,7 +576,7 @@ dtx_begin(struct ds_cont_child *cont, struct dtx_id *dti,
 			oid, dkey_hash, intent,
 			dti_cos, dti_cos_cnt, false, false, dth);
 
-	D_DEBUG(DB_TRACE, "Start the DTX "DF_DTI" for object "DF_OID
+	D_DEBUG(DB_IO, "Start the DTX "DF_DTI" for object "DF_OID
 		" ver %u, dkey %llu, dti_cos_count %d, intent %s\n",
 		DP_DTI(&dth->dth_xid), DP_OID(oid->id_pub), dth->dth_ver,
 		(unsigned long long)dth->dth_dkey_hash, dti_cos_cnt,
@@ -613,7 +614,7 @@ dtx_end(struct dtx_handle *dth, struct ds_cont_child *cont, int result)
 		}
 	}
 
-	D_DEBUG(DB_TRACE,
+	D_DEBUG(DB_IO,
 		"Stop the DTX "DF_DTI" ver %u, dkey %llu, intent %s, rc = %d\n",
 		DP_DTI(&dth->dth_xid), dth->dth_ver,
 		(unsigned long long)dth->dth_dkey_hash,

--- a/src/dtx/dtx_resync.c
+++ b/src/dtx/dtx_resync.c
@@ -360,8 +360,8 @@ out:
 }
 
 struct dtx_container_scan_arg {
-	uuid_t			 co_uuid;
-	struct dtx_scan_args	*arg;
+	uuid_t			co_uuid;
+	struct dtx_scan_args	arg;
 };
 
 static int
@@ -370,7 +370,7 @@ container_scan_cb(daos_handle_t ih, vos_iter_entry_t *entry,
 		  void *data, unsigned *acts)
 {
 	struct dtx_container_scan_arg	*scan_arg = data;
-	struct dtx_scan_args		*arg = scan_arg->arg;
+	struct dtx_scan_args		*arg = &scan_arg->arg;
 	int				rc;
 
 	if (uuid_compare(scan_arg->co_uuid, entry->ie_couuid) == 0) {
@@ -406,7 +406,7 @@ dtx_resync_one(void *data)
 	if (child == NULL)
 		D_GOTO(out, rc = -DER_NONEXIST);
 
-	cb_arg.arg = arg;
+	cb_arg.arg = *arg;
 	param.ip_hdl = child->spc_hdl;
 	param.ip_flags = VOS_IT_FOR_REBUILD;
 	rc = vos_iterate(&param, VOS_ITER_COUUID, false, &anchor,

--- a/src/include/daos_srv/dtx_srv.h
+++ b/src/include/daos_srv/dtx_srv.h
@@ -56,6 +56,7 @@ struct dtx_handle {
 	uint32_t			 dth_intent;
 
 	uint32_t			 dth_sync:1, /* commit synchronously. */
+					 dth_resent:1, /* For resent case. */
 					 /* Only one participator in the DTX. */
 					 dth_solo:1,
 					 /* dti_cos has been committed. */

--- a/src/object/srv_obj.c
+++ b/src/object/srv_obj.c
@@ -1619,14 +1619,17 @@ renew:
 		D_GOTO(out, rc);
 	}
 
-	if (orw->orw_flags & ORF_DTX_SYNC)
-		dlh.dlh_handle.dth_sync = 1;
-
 	exec_arg.rpc	  = rpc;
 	exec_arg.cont_hdl = ioc.ioc_coh;
 	exec_arg.cont	  = ioc.ioc_coc;
 	exec_arg.args	  = split_req;
 again:
+	if (orw->orw_flags & ORF_DTX_SYNC)
+		dlh.dlh_handle.dth_sync = 1;
+
+	if (flags & ORF_RESEND)
+		dlh.dlh_handle.dth_resent = 1;
+
 	exec_arg.flags	  = flags;
 	/* Execute the operation on all targets */
 	rc = dtx_leader_exec_ops(&dlh, obj_tgt_update, &exec_arg);
@@ -2224,13 +2227,16 @@ renew:
 		D_GOTO(out, rc);
 	}
 
-	if (opi->opi_flags & ORF_DTX_SYNC)
-		dlh.dlh_handle.dth_sync = 1;
-
 	exec_arg.rpc = rpc;
 	exec_arg.cont_hdl = ioc.ioc_coh;
 	exec_arg.cont = ioc.ioc_coc;
 again:
+	if (opi->opi_flags & ORF_DTX_SYNC)
+		dlh.dlh_handle.dth_sync = 1;
+
+	if (flags & ORF_RESEND)
+		dlh.dlh_handle.dth_resent = 1;
+
 	exec_arg.flags = flags;
 	/* Execute the operation on all shards */
 	rc = dtx_leader_exec_ops(&dlh, obj_tgt_punch, &exec_arg);

--- a/src/vos/tests/vts_dtx.c
+++ b/src/vos/tests/vts_dtx.c
@@ -53,6 +53,7 @@ vts_dtx_begin(struct dtx_id *xid, daos_unit_oid_t *oid, daos_handle_t coh,
 	dth->dth_dti_cos_count = 0;
 	dth->dth_ent = NULL;
 	dth->dth_sync = 0;
+	dth->dth_resent = 0;
 	dth->dth_solo = 0;
 	dth->dth_dti_cos_done = 0;
 	dth->dth_modify_shared = 0;

--- a/src/vos/vos_dtx.c
+++ b/src/vos/vos_dtx.c
@@ -617,7 +617,7 @@ vos_dtx_commit_one(struct vos_container *cont, struct dtx_id *dti,
 		umem_free(vos_cont2umm(cont), offset);
 
 out:
-	D_CDEBUG(rc != 0 && rc != -DER_NONEXIST, DLOG_ERR, DB_TRACE,
+	D_CDEBUG(rc != 0 && rc != -DER_NONEXIST, DLOG_ERR, DB_IO,
 		 "Commit the DTX "DF_DTI": rc = "DF_RC"\n",
 		 DP_DTI(dti), DP_RC(rc));
 	if (rc != 0) {
@@ -765,7 +765,7 @@ vos_dtx_alloc(struct umem_instance *umm, struct dtx_handle *dth)
 			sizeof(struct vos_dtx_act_ent_df) * dbd->dbd_index;
 	dae->dae_dbd = dbd;
 	D_ASSERT(dbd->dbd_magic == DTX_ACT_BLOB_MAGIC);
-	D_DEBUG(DB_TRACE, "Allocated new lid DTX: "DF_DTI" lid=%d dae=%p"
+	D_DEBUG(DB_IO, "Allocated new lid DTX: "DF_DTI" lid=%d dae=%p"
 		" dae_dbd=%p\n", DP_DTI(&dth->dth_xid), DAE_LID(dae), dae, dbd);
 
 	d_iov_set(&kiov, &DAE_XID(dae), sizeof(DAE_XID(dae)));


### PR DESCRIPTION
For a resent modification, if it is prepared on the leader but it
is resent by the client, when handle such resend modification, the
leader will modify nothing on current vos target, then 'dth_active'
will not be set under such case. That may misguide the DTX logic in
dtx_leader_end() to handle it as noop operation, as to such DTX can
not be committed.

This patch add new flag 'dth_resent' on the DTX handle to indicate
such case.

The patch also fix an serious issue of accessing freed DRAM during
DTX resync. After changing DTX resync to be handled by a dedicated
asynchronous ULT, the buffer for the input parameters from the DTX
resync sponsor may be freed before DTX resync completed. That will
cause DTX resync logic to access invalid DRAM area.

Signed-off-by: Fan Yong <fan.yong@intel.com>