### PR TITLE
DAOS-5108 duns: post PR-2557 fix for Lustre support

### DIFF
--- a/src/client/dfs/duns.c
+++ b/src/client/dfs/duns.c
@@ -281,10 +281,9 @@ duns_resolve_path(const char *path, struct duns_attr_t *attr)
 #ifdef LUSTRE_INCLUDE
 	if (fs.f_type == LL_SUPER_MAGIC) {
 		rc = duns_resolve_lustre_path(path, attr);
-		if (rc == 0) {
-			free(dir);
+		if (rc == 0)
 			return 0;
-		}
+
 		/* if Lustre specific method fails, fallback to try
 		 * the normal way...
 		 */


### PR DESCRIPTION
Commit 203e22ef6cf808f84f8f97965fe12f376c819daf
(DAOS-4690 dfuse: Check for UNS ep at startup. (#2557))
has introduced a regression causing duns to fail compiling
with Lustre support enabled.
This has been possible due to current CI builds are not
Lustre aware.

Change-Id: Id6a0346f942fa6d9329a55def412ecc2720a3cef
Signed-off-by: Bruno Faccini <bruno.faccini@intel.com>