### PR TITLE
DAOS-5109 test: Add a reproducer for crash on container uuid reuse.

### DIFF
--- a/src/cart/test/util/cart_logparse.py
+++ b/src/cart/test/util/cart_logparse.py
@@ -414,7 +414,7 @@ class LogIter():
             self._fd = open(fname, 'r', encoding='utf-8')
             self._fd.read()
         except UnicodeDecodeError as err:
-            print('ERROR: Invalid data in server.log on following line')
+            print('ERROR: Invalid data in {} on following line'.format(fname))
             self._fd = open(fname, 'r', encoding='latin-1')
             self._fd.read(err.start - 200)
             data = self._fd.read(199)


### PR DESCRIPTION
Add a new test to node local testing that creates a container with
the same name in two pools.  This test should fail so run this first,
then shutdown the server and restart.

Change the interception library test slightly so that it also creates
two contatainers with the same name, this will also fail for the same
reason but triggers a double-free in the server.

Signed-off-by: Ashley Pittman <ashley.m.pittman@intel.com>