### PR TITLE
DAOS-5106 dtx: check PMDK operation return value

### DIFF
--- a/src/dtx/dtx_common.c
+++ b/src/dtx/dtx_common.c
@@ -275,7 +275,6 @@ dtx_handle_init(struct dtx_id *dti, daos_handle_t coh,
 	dth->dth_sync = 0;
 	dth->dth_resent = 0;
 	dth->dth_solo = solo ? 1 : 0;
-	dth->dth_dti_cos_done = 0;
 	dth->dth_modify_shared = 0;
 	dth->dth_active = 0;
 

--- a/src/dtx/dtx_rpc.c
+++ b/src/dtx/dtx_rpc.c
@@ -694,7 +694,7 @@ dtx_abort(uuid_t po_uuid, uuid_t co_uuid, daos_epoch_t epoch,
 
 	/* Local abort firstly. */
 	rc = vos_dtx_abort(cont->sc_hdl, epoch, dti, count);
-	if (rc == -DER_NONEXIST)
+	if (rc > 0 || rc == -DER_NONEXIST)
 		rc = 0;
 
 	if (rc == 0 && !d_list_empty(&head)) {

--- a/src/dtx/dtx_srv.c
+++ b/src/dtx/dtx_srv.c
@@ -79,7 +79,7 @@ dtx_handler(crt_rpc_t *rpc)
 			dtis = (struct dtx_id *)din->di_dtx_array.ca_arrays + i;
 			rc1 = vos_dtx_abort(cont->sc_hdl, din->di_epoch,
 					    dtis, count);
-			if (rc == 0 && rc1 != 0)
+			if (rc == 0 && rc1 < 0)
 				rc = rc1;
 
 			i += count;

--- a/src/include/daos_srv/dtx_srv.h
+++ b/src/include/daos_srv/dtx_srv.h
@@ -64,8 +64,6 @@ struct dtx_handle {
 					 dth_resent:1, /* For resent case. */
 					 /* Only one participator in the DTX. */
 					 dth_solo:1,
-					 /* dti_cos has been committed. */
-					 dth_dti_cos_done:1,
 					 /* Modified shared items: object/key */
 					 dth_modify_shared:1,
 					 /* The DTX entry is in active table. */

--- a/src/include/daos_srv/vos.h
+++ b/src/include/daos_srv/vos.h
@@ -88,7 +88,8 @@ vos_dtx_commit(daos_handle_t coh, struct dtx_id *dtis, int count,
  * \param dtis	[IN]	The array for DTX identifiers to be aborted.
  * \param count [IN]	The count of DTXs to be aborted.
  *
- * \return		Zero on success, negative value if error.
+ * \return		Negative value if error.
+ * \return		Others are for the count of aborted DTXs.
  */
 int
 vos_dtx_abort(daos_handle_t coh, daos_epoch_t epoch, struct dtx_id *dtis,

--- a/src/object/srv_obj.c
+++ b/src/object/srv_obj.c
@@ -1431,7 +1431,7 @@ ds_obj_tgt_update_handler(crt_rpc_t *rpc)
 			rc = vos_dtx_abort(ioc.ioc_vos_coh, DAOS_EPOCH_MAX,
 					   &orw->orw_dti, 1);
 
-		if (rc != 0 && rc != -DER_NONEXIST)
+		if (rc < 0 && rc != -DER_NONEXIST)
 			D_GOTO(out, rc);
 	}
 
@@ -2098,7 +2098,7 @@ ds_obj_tgt_punch_handler(crt_rpc_t *rpc)
 			rc = vos_dtx_abort(ioc.ioc_vos_coh, DAOS_EPOCH_MAX,
 					   &opi->opi_dti, 1);
 
-		if (rc != 0 && rc != -DER_NONEXIST)
+		if (rc < 0 && rc != -DER_NONEXIST)
 			D_GOTO(out, rc);
 	}
 

--- a/src/vos/tests/vts_dtx.c
+++ b/src/vos/tests/vts_dtx.c
@@ -55,7 +55,6 @@ vts_dtx_begin(struct dtx_id *xid, daos_unit_oid_t *oid, daos_handle_t coh,
 	dth->dth_sync = 0;
 	dth->dth_resent = 0;
 	dth->dth_solo = 0;
-	dth->dth_dti_cos_done = 0;
 	dth->dth_modify_shared = 0;
 	dth->dth_active = 0;
 	dth->dth_flags = DTE_LEADER;
@@ -301,7 +300,7 @@ vts_dtx_abort_visibility(struct io_test_args *args, bool ext, bool punch_obj)
 
 	/* Aborted the update DTX. */
 	rc = vos_dtx_abort(args->ctx.tc_co_hdl, epoch, &xid, 1);
-	assert_int_equal(rc, 0);
+	assert_int_equal(rc, 1);
 
 	memset(fetch_buf, 0, UPDATE_BUF_SIZE);
 	d_iov_set(&val_iov, fetch_buf, UPDATE_BUF_SIZE);
@@ -334,7 +333,7 @@ vts_dtx_abort_visibility(struct io_test_args *args, bool ext, bool punch_obj)
 
 	/* Aborted the punch DTX. */
 	rc = vos_dtx_abort(args->ctx.tc_co_hdl, epoch, &xid, 1);
-	assert_int_equal(rc, 0);
+	assert_int_equal(rc, 1);
 
 	memset(fetch_buf, 0, UPDATE_BUF_SIZE);
 	d_iov_set(&val_iov, fetch_buf, UPDATE_BUF_SIZE);
@@ -430,11 +429,9 @@ dtx_14(void **state)
 	/* Data record is not affected by double commit. */
 	assert_memory_equal(update_buf, fetch_buf, UPDATE_BUF_SIZE);
 
-	/* Committed DTX cannot be aborted.
-	 * But we cannot check "assert_int_not_equal(rc, 0)" that depends
-	 * on the umem_tx_abort() which may return 0 for vmem based case.
-	 */
-	vos_dtx_abort(args->ctx.tc_co_hdl, epoch, &xid, 1);
+	/* Committed DTX cannot be aborted. */
+	rc = vos_dtx_abort(args->ctx.tc_co_hdl, epoch, &xid, 1);
+	assert_int_not_equal(rc, 1);
 
 	memset(fetch_buf, 0, UPDATE_BUF_SIZE);
 	d_iov_set(&val_iov, fetch_buf, UPDATE_BUF_SIZE);
@@ -495,10 +492,11 @@ dtx_15(void **state)
 
 	/* Aborted the update DTX. */
 	rc = vos_dtx_abort(args->ctx.tc_co_hdl, epoch, &xid, 1);
-	assert_int_equal(rc, 0);
+	assert_int_equal(rc, 1);
 
 	/* Double aborted the DTX is harmless. */
-	vos_dtx_abort(args->ctx.tc_co_hdl, epoch, &xid, 1);
+	rc = vos_dtx_abort(args->ctx.tc_co_hdl, epoch, &xid, 1);
+	assert_int_not_equal(rc, 1);
 
 	memset(fetch_buf, 0, UPDATE_BUF_SIZE);
 	d_iov_set(&val_iov, fetch_buf, UPDATE_BUF_SIZE);

--- a/src/vos/vos_container.c
+++ b/src/vos/vos_container.c
@@ -120,6 +120,7 @@ cont_df_rec_alloc(struct btr_instance *tins, d_iov_t *key_iov,
 	rec->rec_off = offset;
 	return 0;
 failed:
+	/* Ignore umem_free failure. */
 	umem_free(&tins->ti_umm, offset);
 	return rc;
 }

--- a/src/vos/vos_dtx.c
+++ b/src/vos/vos_dtx.c
@@ -313,33 +313,40 @@ vos_dtx_table_register(void)
 	return rc;
 }
 
-void
+int
 vos_dtx_table_destroy(struct umem_instance *umm, struct vos_cont_df *cont_df)
 {
 	struct vos_dtx_blob_df		*dbd;
 	struct vos_dtx_act_ent_df	*dae_df;
 	umem_off_t			 dbd_off;
 	int				 i;
+	int				 rc;
 
 	/* cd_dtx_committed_tail is next to cd_dtx_committed_head */
-	umem_tx_add_ptr(umm, &cont_df->cd_dtx_committed_head,
-			sizeof(cont_df->cd_dtx_committed_head) +
-			sizeof(cont_df->cd_dtx_committed_tail));
+	rc = umem_tx_add_ptr(umm, &cont_df->cd_dtx_committed_head,
+			     sizeof(cont_df->cd_dtx_committed_head) +
+			     sizeof(cont_df->cd_dtx_committed_tail));
+	if (rc != 0)
+		return rc;
 
 	while (!umoff_is_null(cont_df->cd_dtx_committed_head)) {
 		dbd_off = cont_df->cd_dtx_committed_head;
 		dbd = umem_off2ptr(umm, dbd_off);
 		cont_df->cd_dtx_committed_head = dbd->dbd_next;
-		umem_free(umm, dbd_off);
+		rc = umem_free(umm, dbd_off);
+		if (rc != 0)
+			return rc;
 	}
 
 	cont_df->cd_dtx_committed_head = UMOFF_NULL;
 	cont_df->cd_dtx_committed_tail = UMOFF_NULL;
 
 	/* cd_dtx_active_tail is next to cd_dtx_active_head */
-	umem_tx_add_ptr(umm, &cont_df->cd_dtx_active_head,
-			sizeof(cont_df->cd_dtx_active_head) +
-			sizeof(cont_df->cd_dtx_active_tail));
+	rc = umem_tx_add_ptr(umm, &cont_df->cd_dtx_active_head,
+			     sizeof(cont_df->cd_dtx_active_head) +
+			     sizeof(cont_df->cd_dtx_active_tail));
+	if (rc != 0)
+		return rc;
 
 	while (!umoff_is_null(cont_df->cd_dtx_active_head)) {
 		dbd_off = cont_df->cd_dtx_active_head;
@@ -348,16 +355,23 @@ vos_dtx_table_destroy(struct umem_instance *umm, struct vos_cont_df *cont_df)
 		for (i = 0; i < dbd->dbd_index; i++) {
 			dae_df = &dbd->dbd_active_data[i];
 			if (!(dae_df->dae_flags & DTE_INVALID) &&
-			    !umoff_is_null(dae_df->dae_rec_off))
-				umem_free(umm, dae_df->dae_rec_off);
+			    !umoff_is_null(dae_df->dae_rec_off)) {
+				rc = umem_free(umm, dae_df->dae_rec_off);
+				if (rc != 0)
+					return rc;
+			}
 		}
 
 		cont_df->cd_dtx_active_head = dbd->dbd_next;
-		umem_free(umm, dbd_off);
+		rc = umem_free(umm, dbd_off);
+		if (rc != 0)
+			return rc;
 	}
 
 	cont_df->cd_dtx_active_head = UMOFF_NULL;
 	cont_df->cd_dtx_active_tail = UMOFF_NULL;
+
+	return 0;
 }
 
 static int
@@ -389,16 +403,18 @@ dtx_ilog_rec_release(struct umem_instance *umm, struct vos_container *cont,
 	return rc;
 }
 
-static void
+static int
 do_dtx_rec_release(struct umem_instance *umm, struct vos_container *cont,
 		   struct vos_dtx_act_ent *dae, umem_off_t rec, bool abort)
 {
+	int	rc = 0;
+
 	if (umoff_is_null(rec))
-		return;
+		return 0;
 
 	switch (dtx_umoff_flag2type(rec)) {
 	case DTX_RT_ILOG: {
-		dtx_ilog_rec_release(umm, cont, rec, dae, abort);
+		rc = dtx_ilog_rec_release(umm, cont, rec, dae, abort);
 		break;
 	}
 	case DTX_RT_SVT: {
@@ -406,12 +422,20 @@ do_dtx_rec_release(struct umem_instance *umm, struct vos_container *cont,
 
 		svt = umem_off2ptr(umm, umem_off2offset(rec));
 		if (abort) {
-			if (DAE_INDEX(dae) != -1)
-				umem_tx_add_ptr(umm, &svt->ir_dtx,
-						sizeof(svt->ir_dtx));
+			if (DAE_INDEX(dae) != -1) {
+				rc = umem_tx_add_ptr(umm, &svt->ir_dtx,
+						     sizeof(svt->ir_dtx));
+				if (rc != 0)
+					return rc;
+			}
+
 			dtx_set_aborted(&svt->ir_dtx);
 		} else {
-			umem_tx_add_ptr(umm, &svt->ir_dtx, sizeof(svt->ir_dtx));
+			rc = umem_tx_add_ptr(umm, &svt->ir_dtx,
+					     sizeof(svt->ir_dtx));
+			if (rc != 0)
+				return rc;
+
 			svt->ir_dtx = DTX_LID_COMMITTED;
 		}
 		break;
@@ -421,22 +445,34 @@ do_dtx_rec_release(struct umem_instance *umm, struct vos_container *cont,
 
 		evt = umem_off2ptr(umm, umem_off2offset(rec));
 		if (abort) {
-			if (DAE_INDEX(dae) != -1)
-				umem_tx_add_ptr(umm, &evt->dc_dtx,
-						sizeof(evt->dc_dtx));
+			if (DAE_INDEX(dae) != -1) {
+				rc = umem_tx_add_ptr(umm, &evt->dc_dtx,
+						     sizeof(evt->dc_dtx));
+				if (rc != 0)
+					return rc;
+			}
+
 			dtx_set_aborted(&evt->dc_dtx);
 		} else {
-			umem_tx_add_ptr(umm, &evt->dc_dtx, sizeof(evt->dc_dtx));
+			rc = umem_tx_add_ptr(umm, &evt->dc_dtx,
+					     sizeof(evt->dc_dtx));
+			if (rc != 0)
+				return rc;
+
 			evt->dc_dtx = DTX_LID_COMMITTED;
 		}
 		break;
 	}
 	default:
+		/* On-disk data corruption case. */
+		rc = -DER_IO;
 		D_ERROR(DF_UOID" unknown DTX "DF_DTI" type %u\n",
 			DP_UOID(DAE_OID(dae)), DP_DTI(&DAE_XID(dae)),
 			dtx_umoff_flag2type(rec));
 		break;
 	}
+
+	return rc;
 }
 
 #define dtx_evict_lid(cont, dae)					\
@@ -448,15 +484,16 @@ do_dtx_rec_release(struct umem_instance *umm, struct vos_container *cont,
 			    DAE_EPOCH(dae));				\
 	} while (0)
 
-static void
+static int
 dtx_rec_release(struct vos_container *cont, struct vos_dtx_act_ent *dae,
-		bool abort, umem_off_t *p_offset)
+		bool abort)
 {
 	struct umem_instance		*umm = vos_cont2umm(cont);
 	struct vos_dtx_act_ent_df	*dae_df;
 	struct vos_dtx_blob_df		*dbd;
 	int				 count;
 	int				 i;
+	int				 rc = 0;
 
 	D_ASSERT(DAE_INDEX(dae) >= 0);
 
@@ -469,12 +506,13 @@ dtx_rec_release(struct vos_container *cont, struct vos_dtx_act_ent *dae,
 	if (dae->dae_records != NULL) {
 		D_ASSERT(DAE_REC_CNT(dae) > DTX_INLINE_REC_CNT);
 
-		for (i = DAE_REC_CNT(dae) - DTX_INLINE_REC_CNT - 1; i >= 0; i--)
-			do_dtx_rec_release(umm, cont, dae, dae->dae_records[i],
-					   abort);
-
-		D_FREE(dae->dae_records);
-		dae->dae_rec_cap = 0;
+		for (i = DAE_REC_CNT(dae) - DTX_INLINE_REC_CNT - 1;
+		     i >= 0; i--) {
+			rc = do_dtx_rec_release(umm, cont, dae,
+						dae->dae_records[i], abort);
+			if (rc != 0)
+				return rc;
+		}
 	}
 
 	if (DAE_REC_CNT(dae) > DTX_INLINE_REC_CNT)
@@ -482,20 +520,33 @@ dtx_rec_release(struct vos_container *cont, struct vos_dtx_act_ent *dae,
 	else
 		count = DAE_REC_CNT(dae);
 
-	for (i = count - 1; i >= 0; i--)
-		do_dtx_rec_release(umm, cont, dae, DAE_REC_INLINE(dae)[i],
-				   abort);
+	for (i = count - 1; i >= 0; i--) {
+		rc = do_dtx_rec_release(umm, cont, dae, DAE_REC_INLINE(dae)[i],
+					abort);
+		if (rc != 0)
+			return rc;
+	}
 
-	if (!umoff_is_null(dae_df->dae_rec_off))
-		umem_free(umm, dae_df->dae_rec_off);
+	if (!umoff_is_null(dae_df->dae_rec_off)) {
+		rc = umem_free(umm, dae_df->dae_rec_off);
+		if (rc != 0)
+			return rc;
+	}
 
 	if (dbd->dbd_count > 1 || dbd->dbd_index < dbd->dbd_cap) {
-		umem_tx_add_ptr(umm, &dae_df->dae_flags,
+		rc = umem_tx_add_ptr(umm, &dae_df->dae_flags,
 				sizeof(dae_df->dae_flags));
+		if (rc != 0)
+			return rc;
+
 		/* Mark the DTX entry as invalid in SCM. */
 		dae_df->dae_flags = DTE_INVALID;
 
-		umem_tx_add_ptr(umm, &dbd->dbd_count, sizeof(dbd->dbd_count));
+		rc = umem_tx_add_ptr(umm, &dbd->dbd_count,
+				     sizeof(dbd->dbd_count));
+		if (rc != 0)
+			return rc;
+
 		dbd->dbd_count--;
 	} else {
 		struct vos_cont_df	*cont_df = cont->vc_cont_df;
@@ -505,50 +556,58 @@ dtx_rec_release(struct vos_container *cont, struct vos_dtx_act_ent *dae,
 		dbd_off = umem_ptr2off(umm, dbd);
 		tmp = umem_off2ptr(umm, dbd->dbd_prev);
 		if (tmp != NULL) {
-			umem_tx_add_ptr(umm, &tmp->dbd_next,
-					sizeof(tmp->dbd_next));
+			rc = umem_tx_add_ptr(umm, &tmp->dbd_next,
+					     sizeof(tmp->dbd_next));
+			if (rc != 0)
+				return rc;
+
 			tmp->dbd_next = dbd->dbd_next;
 		}
 
 		tmp = umem_off2ptr(umm, dbd->dbd_next);
 		if (tmp != NULL) {
-			umem_tx_add_ptr(umm, &tmp->dbd_prev,
-					sizeof(tmp->dbd_prev));
+			rc = umem_tx_add_ptr(umm, &tmp->dbd_prev,
+					     sizeof(tmp->dbd_prev));
+			if (rc != 0)
+				return rc;
+
 			tmp->dbd_prev = dbd->dbd_prev;
 		}
 
 		if (cont_df->cd_dtx_active_head == dbd_off) {
-			umem_tx_add_ptr(umm, &cont_df->cd_dtx_active_head,
+			rc = umem_tx_add_ptr(umm, &cont_df->cd_dtx_active_head,
 					sizeof(cont_df->cd_dtx_active_head));
+			if (rc != 0)
+				return rc;
+
 			cont_df->cd_dtx_active_head = dbd->dbd_next;
 		}
 
 		if (cont_df->cd_dtx_active_tail == dbd_off) {
-			umem_tx_add_ptr(umm, &cont_df->cd_dtx_active_tail,
+			rc = umem_tx_add_ptr(umm, &cont_df->cd_dtx_active_tail,
 					sizeof(cont_df->cd_dtx_active_tail));
+			if (rc != 0)
+				return rc;
+
 			cont_df->cd_dtx_active_tail = dbd->dbd_prev;
 		}
 
-		if (p_offset != NULL)
-			*p_offset = dbd_off;
-		else
-			umem_free(umm, dbd_off);
+		rc = umem_free(umm, dbd_off);
 	}
 
-	if (abort)
-		dtx_evict_lid(cont, dae);
+	return rc;
 }
 
 static int
 vos_dtx_commit_one(struct vos_container *cont, struct dtx_id *dti,
 		   daos_epoch_t epoch, struct vos_dtx_cmt_ent **dce_p,
-		   struct dtx_cos_key *dck)
+		   struct dtx_cos_key *dck, struct vos_dtx_act_ent **dae_p,
+		   bool *fatal)
 {
 	struct vos_dtx_act_ent		*dae = NULL;
 	struct vos_dtx_cmt_ent		*dce = NULL;
 	d_iov_t				 kiov;
 	d_iov_t				 riov;
-	umem_off_t			 offset = UMOFF_NULL;
 	int				 rc = 0;
 
 	d_iov_set(&kiov, dti, sizeof(*dti));
@@ -578,6 +637,29 @@ vos_dtx_commit_one(struct vos_container *cont, struct dtx_id *dti,
 			goto out;
 
 		dae = (struct vos_dtx_act_ent *)riov.iov_buf;
+
+		if (dae->dae_aborted) {
+			D_ERROR("NOT allow to commit an aborted DTX "DF_DTI"\n",
+				DP_DTI(dti));
+			D_GOTO(out, rc = -DER_NONEXIST);
+		}
+
+		/* It has been committed before, but failed to be removed
+		 * from the active table, just remove it again.
+		 */
+		if (dae->dae_committed) {
+			if (dck != NULL) {
+				dck->oid = DAE_OID(dae);
+				dck->dkey_hash = DAE_DKEY_HASH(dae);
+			}
+
+			rc = dbtree_delete(cont->vc_dtx_active_hdl,
+					   BTR_PROBE_BYPASS, &kiov, NULL);
+			if (rc == 0)
+				dtx_evict_lid(cont, dae);
+
+			goto out;
+		}
 	}
 
 	D_ALLOC_PTR(dce);
@@ -599,22 +681,19 @@ vos_dtx_commit_one(struct vos_container *cont, struct dtx_id *dti,
 	if (rc != 0 || epoch != 0)
 		goto out;
 
-	dtx_rec_release(cont, dae, false, &offset);
-
-	rc = dbtree_delete(cont->vc_dtx_active_hdl, BTR_PROBE_BYPASS, &kiov,
-			   &dae);
-
-	if (rc == 0) {
-		if (dck != NULL) {
-			dck->oid = DAE_OID(dae);
-			dck->dkey_hash = DAE_DKEY_HASH(dae);
-		}
-
-		dtx_evict_lid(cont, dae);
+	rc = dtx_rec_release(cont, dae, false);
+	if (rc != 0) {
+		*fatal = true;
+		goto out;
 	}
 
-	if (!umoff_is_null(offset))
-		umem_free(vos_cont2umm(cont), offset);
+	if (dck != NULL) {
+		dck->oid = DAE_OID(dae);
+		dck->dkey_hash = DAE_DKEY_HASH(dae);
+	}
+
+	D_ASSERT(dae_p != NULL);
+	*dae_p = dae;
 
 out:
 	D_CDEBUG(rc != 0 && rc != -DER_NONEXIST, DLOG_ERR, DB_IO,
@@ -632,7 +711,8 @@ out:
 
 static int
 vos_dtx_abort_one(struct vos_container *cont, daos_epoch_t epoch,
-		  struct dtx_id *dti)
+		  struct dtx_id *dti, struct vos_dtx_act_ent **dae_p,
+		  bool *fatal)
 {
 	struct vos_dtx_act_ent	*dae;
 	d_iov_t			 riov;
@@ -645,16 +725,37 @@ vos_dtx_abort_one(struct vos_container *cont, daos_epoch_t epoch,
 	if (rc != 0)
 		goto out;
 
-	if (epoch != 0) {
-		dae = (struct vos_dtx_act_ent *)riov.iov_buf;
-		if (DAE_EPOCH(dae) > epoch)
-			D_GOTO(out, rc = -DER_NONEXIST);
+	dae = (struct vos_dtx_act_ent *)riov.iov_buf;
+
+	if (dae->dae_committable || dae->dae_committed) {
+		D_ERROR("NOT allow to abort a committed DTX "DF_DTI"\n",
+			DP_DTI(dti));
+		D_GOTO(out, rc = -DER_NONEXIST);
 	}
 
-	rc = dbtree_delete(cont->vc_dtx_active_hdl, BTR_PROBE_BYPASS,
-			   &kiov, &dae);
-	if (rc == 0)
-		dtx_rec_release(cont, dae, true, NULL);
+	/* It has been committed before, but failed to be removed
+	 * from the active table, just remove it again.
+	 */
+	if (dae->dae_aborted) {
+		rc = dbtree_delete(cont->vc_dtx_active_hdl,
+				   BTR_PROBE_BYPASS, &kiov, NULL);
+		if (rc == 0)
+			dtx_evict_lid(cont, dae);
+
+		goto out;
+	}
+
+	if (epoch != 0 && DAE_EPOCH(dae) > epoch)
+		D_GOTO(out, rc = -DER_NONEXIST);
+
+	rc = dtx_rec_release(cont, dae, true);
+	if (rc != 0) {
+		*fatal = true;
+		goto out;
+	}
+
+	D_ASSERT(dae_p != NULL);
+	*dae_p = dae;
 
 out:
 	D_DEBUG(DB_IO, "Abort the DTX "DF_DTI": rc = "DF_RC"\n", DP_DTI(dti),
@@ -680,6 +781,7 @@ vos_dtx_extend_act_table(struct vos_container *cont)
 	struct vos_dtx_blob_df		*dbd;
 	struct vos_dtx_blob_df		*tmp;
 	umem_off_t			 dbd_off;
+	int				 rc;
 
 	dbd_off = umem_zalloc(umm, DTX_BLOB_SIZE);
 	if (umoff_is_null(dbd_off)) {
@@ -697,17 +799,26 @@ vos_dtx_extend_act_table(struct vos_container *cont)
 		D_ASSERT(umoff_is_null(cont_df->cd_dtx_active_head));
 
 		/* cd_dtx_active_tail is next to cd_dtx_active_head */
-		umem_tx_add_ptr(umm, &cont_df->cd_dtx_active_head,
-				sizeof(cont_df->cd_dtx_active_head) +
-				sizeof(cont_df->cd_dtx_active_tail));
+		rc = umem_tx_add_ptr(umm, &cont_df->cd_dtx_active_head,
+				     sizeof(cont_df->cd_dtx_active_head) +
+				     sizeof(cont_df->cd_dtx_active_tail));
+		if (rc != 0)
+			return rc;
+
 		cont_df->cd_dtx_active_head = dbd_off;
 	} else {
-		umem_tx_add_ptr(umm, &tmp->dbd_next, sizeof(tmp->dbd_next));
+		rc = umem_tx_add_ptr(umm, &tmp->dbd_next,
+				     sizeof(tmp->dbd_next));
+		if (rc != 0)
+			return rc;
+
 		tmp->dbd_next = dbd_off;
 
 		dbd->dbd_prev = cont_df->cd_dtx_active_tail;
-		umem_tx_add_ptr(umm, &cont_df->cd_dtx_active_tail,
-				sizeof(cont_df->cd_dtx_active_tail));
+		rc = umem_tx_add_ptr(umm, &cont_df->cd_dtx_active_tail,
+				     sizeof(cont_df->cd_dtx_active_tail));
+		if (rc != 0)
+			return rc;
 	}
 
 	cont_df->cd_dtx_active_tail = dbd_off;
@@ -897,8 +1008,11 @@ vos_dtx_check_availability(struct umem_instance *umm, daos_handle_t coh,
 		return ALB_AVAILABLE_CLEAN;
 	}
 
-	if (dae->dae_committable)
+	if (dae->dae_committable || dae->dae_committed)
 		return ALB_AVAILABLE_CLEAN;
+
+	if (dae->dae_aborted)
+		return ALB_UNAVAILABLE;
 
 	/* The followings are for non-committable cases. */
 
@@ -1107,6 +1221,7 @@ vos_dtx_prepared(struct dtx_handle *dth)
 	struct vos_container		*cont;
 	struct umem_instance		*umm;
 	struct vos_dtx_blob_df		*dbd;
+	int				 rc;
 
 	if (!dth->dth_active)
 		return 0;
@@ -1115,10 +1230,8 @@ vos_dtx_prepared(struct dtx_handle *dth)
 	D_ASSERT(cont != NULL);
 
 	if (dth->dth_solo) {
-		int	rc;
-
 		rc = vos_dtx_commit_internal(cont, &dth->dth_xid, 1,
-					     dth->dth_epoch, NULL);
+					     dth->dth_epoch, NULL, NULL);
 		dth->dth_active = 0;
 		if (rc >= 0)
 			dth->dth_sync = 1;
@@ -1167,9 +1280,11 @@ vos_dtx_prepared(struct dtx_handle *dth)
 				    &dae->dae_base,
 				    sizeof(struct vos_dtx_act_ent_df));
 		/* dbd_index is next to dbd_count */
-		umem_tx_add_ptr(umm, &dbd->dbd_count,
-				sizeof(dbd->dbd_count) +
-				sizeof(dbd->dbd_index));
+		rc = umem_tx_add_ptr(umm, &dbd->dbd_count,
+				     sizeof(dbd->dbd_count) +
+				     sizeof(dbd->dbd_index));
+		if (rc != 0)
+			return rc;
 	} else {
 		memcpy(umem_off2ptr(umm, dae->dae_df_off),
 		       &dae->dae_base, sizeof(struct vos_dtx_act_ent_df));
@@ -1199,8 +1314,11 @@ vos_dtx_check(daos_handle_t coh, struct dtx_id *dti, daos_epoch_t *epoch,
 	rc = dbtree_lookup(cont->vc_dtx_active_hdl, &kiov, &riov);
 	if (rc == 0) {
 		dae = (struct vos_dtx_act_ent *)riov.iov_buf;
-		if (dae->dae_committable)
+		if (dae->dae_committable || dae->dae_committed)
 			return DTX_ST_COMMITTED;
+
+		if (dae->dae_aborted)
+			return -DER_NONEXIST;
 
 		if (epoch != NULL) {
 			if (*epoch == 0)
@@ -1229,7 +1347,8 @@ vos_dtx_check(daos_handle_t coh, struct dtx_id *dti, daos_epoch_t *epoch,
 
 int
 vos_dtx_commit_internal(struct vos_container *cont, struct dtx_id *dtis,
-			int count, daos_epoch_t epoch, struct dtx_cos_key *dcks)
+			int count, daos_epoch_t epoch, struct dtx_cos_key *dcks,
+			struct vos_dtx_act_ent **daes)
 {
 	struct vos_cont_df		*cont_df = cont->vc_cont_df;
 	struct umem_instance		*umm = vos_cont2umm(cont);
@@ -1244,6 +1363,7 @@ vos_dtx_commit_internal(struct vos_container *cont, struct dtx_id *dtis,
 	int				 rc1 = 0;
 	int				 i;
 	int				 j;
+	bool				 fatal = false;
 
 	dbd = umem_off2ptr(umm, cont_df->cd_dtx_committed_tail);
 	if (dbd != NULL)
@@ -1252,7 +1372,9 @@ vos_dtx_commit_internal(struct vos_container *cont, struct dtx_id *dtis,
 	if (slots == 0)
 		goto new_blob;
 
-	umem_tx_add_ptr(umm, &dbd->dbd_count, sizeof(dbd->dbd_count));
+	rc = umem_tx_add_ptr(umm, &dbd->dbd_count, sizeof(dbd->dbd_count));
+	if (rc != 0)
+		return rc;
 
 again:
 	if (slots > count)
@@ -1266,13 +1388,7 @@ again:
 			D_ERROR("Not enough DRAM to commit "DF_DTI"\n",
 				DP_DTI(&dtis[cur]));
 
-			/* For the DTXs that have been committed we will not
-			 * re-insert them back into the active DTX table (in
-			 * DRAM) even if we abort the PMDK transaction, then
-			 * let's hide the error and commit former successful
-			 * DTXs. The left non-committed DTXs will be handled
-			 * next time.
-			 */
+			/* non-fatal, former handled ones can be committed. */
 			return committed > 0 ? committed : -DER_NOMEM;
 		}
 	} else {
@@ -1283,8 +1399,13 @@ again:
 		struct vos_dtx_cmt_ent	*dce = NULL;
 
 		rc = vos_dtx_commit_one(cont, &dtis[cur], epoch, &dce,
-					dcks != NULL ? &dcks[cur] : NULL);
-		if (rc == 0)
+					dcks != NULL ? &dcks[cur] : NULL,
+					daes != NULL ? &daes[cur] : NULL,
+					&fatal);
+		if (fatal)
+			return rc;
+
+		if (rc == 0 && (daes == NULL || daes[cur] != NULL))
 			committed++;
 
 		if (rc == -DER_NONEXIST)
@@ -1360,17 +1481,25 @@ new_blob:
 		D_ASSERT(umoff_is_null(cont_df->cd_dtx_committed_tail));
 
 		/* cd_dtx_committed_tail is next to cd_dtx_committed_head */
-		umem_tx_add_ptr(umm, &cont_df->cd_dtx_committed_head,
-				sizeof(cont_df->cd_dtx_committed_head) +
-				sizeof(cont_df->cd_dtx_committed_tail));
+		rc = umem_tx_add_ptr(umm, &cont_df->cd_dtx_committed_head,
+				     sizeof(cont_df->cd_dtx_committed_head) +
+				     sizeof(cont_df->cd_dtx_committed_tail));
+		if (rc != 0)
+			return rc;
+
 		cont_df->cd_dtx_committed_head = dbd_off;
 	} else {
-		umem_tx_add_ptr(umm, &dbd_prev->dbd_next,
-				sizeof(dbd_prev->dbd_next));
+		rc = umem_tx_add_ptr(umm, &dbd_prev->dbd_next,
+				     sizeof(dbd_prev->dbd_next));
+		if (rc != 0)
+			return rc;
+
 		dbd_prev->dbd_next = dbd_off;
 
-		umem_tx_add_ptr(umm, &cont_df->cd_dtx_committed_tail,
-				sizeof(cont_df->cd_dtx_committed_tail));
+		rc = umem_tx_add_ptr(umm, &cont_df->cd_dtx_committed_tail,
+				     sizeof(cont_df->cd_dtx_committed_tail));
+		if (rc != 0)
+			return rc;
 	}
 
 	cont_df->cd_dtx_committed_tail = dbd_off;
@@ -1379,8 +1508,13 @@ new_blob:
 		struct vos_dtx_cmt_ent	*dce = NULL;
 
 		rc = vos_dtx_commit_one(cont, &dtis[cur], epoch, &dce,
-					dcks != NULL ? &dcks[cur] : NULL);
-		if (rc == 0)
+					dcks != NULL ? &dcks[cur] : NULL,
+					daes != NULL ? &daes[cur] : NULL,
+					&fatal);
+		if (fatal)
+			return rc;
+
+		if (rc == 0 && (daes == NULL || daes[cur] != NULL))
 			committed++;
 
 		if (rc == -DER_NONEXIST)
@@ -1407,13 +1541,52 @@ new_blob:
 	return committed > 0 ? committed : rc1;
 }
 
+void
+vos_dtx_post_handle(struct vos_container *cont, struct vos_dtx_act_ent **daes,
+		    int count, bool abort)
+{
+	int	rc;
+	int	i;
+
+	for (i = 0; i < count; i++) {
+		d_iov_t		kiov;
+
+		if (daes[i] == NULL)
+			continue;
+
+		d_iov_set(&kiov, &DAE_XID(daes[i]), sizeof(DAE_XID(daes[i])));
+		rc = dbtree_delete(cont->vc_dtx_active_hdl, BTR_PROBE_EQ,
+				   &kiov, NULL);
+		if (rc == 0 || rc == -DER_NONEXIST) {
+			dtx_evict_lid(cont, daes[i]);
+		} else {
+			/* The DTX entry has been committed or aborted, but we
+			 * cannot remove it from the active table, can mark it
+			 * as 'committed' or 'aborted'. That will consume some
+			 * DRAM until server restart.
+			 */
+			if (abort)
+				daes[i]->dae_aborted = 1;
+			else
+				daes[i]->dae_committed = 1;
+		}
+	}
+}
+
 int
 vos_dtx_commit(daos_handle_t coh, struct dtx_id *dtis, int count,
 	       struct dtx_cos_key *dcks)
 {
-	struct vos_container	*cont;
-	int			 committed = 0;
-	int			 rc;
+	struct vos_dtx_act_ent	**daes = NULL;
+	struct vos_container	 *cont;
+	int			  committed = 0;
+	int			  rc;
+
+	D_ASSERT(count > 0);
+
+	D_ALLOC_ARRAY(daes, count);
+	if (daes == NULL)
+		return -DER_NOMEM;
 
 	cont = vos_hdl2cont(coh);
 	D_ASSERT(cont != NULL);
@@ -1421,10 +1594,15 @@ vos_dtx_commit(daos_handle_t coh, struct dtx_id *dtis, int count,
 	/* Commit multiple DTXs via single PMDK transaction. */
 	rc = umem_tx_begin(vos_cont2umm(cont), NULL);
 	if (rc == 0) {
-		committed = vos_dtx_commit_internal(cont, dtis, count, 0, dcks);
+		committed = vos_dtx_commit_internal(cont, dtis, count,
+						    0, dcks, daes);
 		rc = umem_tx_end(vos_cont2umm(cont),
 				 committed > 0 ? 0 : committed);
+		if (rc == 0)
+			vos_dtx_post_handle(cont, daes, count, false);
 	}
+
+	D_FREE(daes);
 
 	return rc < 0 ? rc : committed;
 }
@@ -1433,9 +1611,18 @@ int
 vos_dtx_abort(daos_handle_t coh, daos_epoch_t epoch, struct dtx_id *dtis,
 	      int count)
 {
-	struct vos_container	*cont;
-	int			 rc;
-	int			 i;
+	struct vos_dtx_act_ent	**daes = NULL;
+	struct vos_container	 *cont;
+	int			  aborted = 0;
+	int			  rc;
+	int			  i;
+	bool			  fatal = false;
+
+	D_ASSERT(count > 0);
+
+	D_ALLOC_ARRAY(daes, count);
+	if (daes == NULL)
+		return -DER_NOMEM;
 
 	cont = vos_hdl2cont(coh);
 	D_ASSERT(cont != NULL);
@@ -1443,26 +1630,26 @@ vos_dtx_abort(daos_handle_t coh, daos_epoch_t epoch, struct dtx_id *dtis,
 	/* Abort multiple DTXs via single PMDK transaction. */
 	rc = umem_tx_begin(vos_cont2umm(cont), NULL);
 	if (rc == 0) {
-		int	aborted = 0;
-
 		for (i = 0; i < count; i++) {
-			rc = vos_dtx_abort_one(cont, epoch, &dtis[i]);
-			if (rc == 0)
+			rc = vos_dtx_abort_one(cont, epoch, &dtis[i], &daes[i],
+					       &fatal);
+			if (fatal) {
+				aborted = rc;
+				break;
+			}
+
+			if (rc == 0 && daes[i] != NULL)
 				aborted++;
 		}
 
-		/* Some vos_dtx_abort_one may hit failure, for example, not
-		 * found related DTX entry in the active DTX table, that is
-		 * not important, go ahead. Because each DTX is independent
-		 * from the others. For the DTXs that have been aborted, we
-		 * cannot re-insert them back into the active DTX table (in
-		 * DRAM) even if we abort this PMDK transaction, then let's
-		 * commit the PMDK transaction anyway.
-		 */
 		rc = umem_tx_end(vos_cont2umm(cont), aborted > 0 ? 0 : rc);
+		if (rc == 0)
+			vos_dtx_post_handle(cont, daes, count, true);
 	}
 
-	return rc;
+	D_FREE(daes);
+
+	return rc < 0 ? rc : aborted;
 }
 
 int
@@ -1513,21 +1700,31 @@ vos_dtx_aggregate(daos_handle_t coh)
 		D_ASSERT(cont_df->cd_dtx_committed_tail ==
 			 cont_df->cd_dtx_committed_head);
 
-		umem_tx_add_ptr(umm, &cont_df->cd_dtx_committed_tail,
-				sizeof(cont_df->cd_dtx_committed_tail));
+		rc = umem_tx_add_ptr(umm, &cont_df->cd_dtx_committed_tail,
+				     sizeof(cont_df->cd_dtx_committed_tail));
+		if (rc != 0)
+			return rc;
+
 		cont_df->cd_dtx_committed_tail = UMOFF_NULL;
 	} else {
-		umem_tx_add_ptr(umm, &tmp->dbd_prev, sizeof(tmp->dbd_prev));
+		rc = umem_tx_add_ptr(umm, &tmp->dbd_prev,
+				     sizeof(tmp->dbd_prev));
+		if (rc != 0)
+			return rc;
+
 		tmp->dbd_prev = UMOFF_NULL;
 	}
 
-	umem_tx_add_ptr(umm, &cont_df->cd_dtx_committed_head,
-			sizeof(cont_df->cd_dtx_committed_head));
+	rc = umem_tx_add_ptr(umm, &cont_df->cd_dtx_committed_head,
+			     sizeof(cont_df->cd_dtx_committed_head));
+	if (rc != 0)
+		return rc;
+
 	cont_df->cd_dtx_committed_head = dbd->dbd_next;
 
-	umem_free(umm, dbd_off);
+	rc = umem_free(umm, dbd_off);
 
-	return umem_tx_end(umm, 0);
+	return umem_tx_end(umm, rc);
 }
 
 void

--- a/src/vos/vos_dtx_iter.c
+++ b/src/vos/vos_dtx_iter.c
@@ -141,8 +141,9 @@ dtx_iter_next(struct vos_iterator *iter)
 		D_ASSERT(rec_iov.iov_len == sizeof(struct vos_dtx_act_ent));
 		dae = (struct vos_dtx_act_ent *)rec_iov.iov_buf;
 
-		/* Skip committable ones. */
-		if (!dae->dae_committable)
+		/* Skip committable, committed, or aborted ones. */
+		if (!dae->dae_committable && !dae->dae_committed &&
+		    !dae->dae_aborted)
 			break;
 	}
 

--- a/src/vos/vos_gc.c
+++ b/src/vos/vos_gc.c
@@ -229,11 +229,14 @@ gc_drain_cont(struct vos_gc *gc, struct vos_pool *pool,
 static int
 gc_free_cont(struct vos_gc *gc, struct vos_pool *pool, struct vos_gc_item *item)
 {
-	vos_dtx_table_destroy(&pool->vp_umm,
-			      umem_off2ptr(&pool->vp_umm, item->it_addr));
-	umem_free(&pool->vp_umm, item->it_addr);
+	int	rc;
 
-	return 0;
+	rc = vos_dtx_table_destroy(&pool->vp_umm,
+				   umem_off2ptr(&pool->vp_umm, item->it_addr));
+	if (rc == 0)
+		rc = umem_free(&pool->vp_umm, item->it_addr);
+
+	return rc;
 }
 
 static struct vos_gc	gc_table[] = {
@@ -295,26 +298,33 @@ gc_bin_free_bag(struct umem_instance *umm, struct vos_gc_bin_df *bin,
 		umem_off_t bag_id)
 {
 	struct vos_gc_bag_df *bag = umem_off2ptr(umm, bag_id);
+	int		      rc;
 
 	D_ASSERT(bag_id == bin->bin_bag_first);
 	if (bag_id == bin->bin_bag_last) {
 		/* don't free the last bag, only reset it */
 		D_ASSERT(bin->bin_bag_nr == 1);
-		umem_tx_add_ptr(umm, bag, sizeof(*bag));
-		bag->bag_item_first = bag->bag_item_last = 0;
-		bag->bag_item_nr = 0;
-		return 0;
+		rc = umem_tx_add_ptr(umm, bag, sizeof(*bag));
+		if (rc == 0) {
+			bag->bag_item_first = bag->bag_item_last = 0;
+			bag->bag_item_nr = 0;
+		}
+
+		return rc;
 	}
 
 	D_ASSERT(bin->bin_bag_nr > 1);
 	D_ASSERT(bag->bag_next != UMOFF_NULL);
 
-	umem_tx_add_ptr(umm, bin, sizeof(*bin));
-	bin->bin_bag_first = bag->bag_next;
-	bin->bin_bag_nr--;
+	rc = umem_tx_add_ptr(umm, bin, sizeof(*bin));
+	if (rc == 0) {
+		bin->bin_bag_first = bag->bag_next;
+		bin->bin_bag_nr--;
 
-	umem_free(umm, bag_id);
-	return 0;
+		rc = umem_free(umm, bag_id);
+	}
+
+	return rc;
 }
 
 /**
@@ -327,6 +337,7 @@ gc_bin_find_bag(struct umem_instance *umm, struct vos_gc_bin_df *bin)
 	struct vos_gc_bag_df *bag = NULL;
 	umem_off_t	      bag_id;
 	int		      size;
+	int		      rc;
 
 	if (!UMOFF_IS_NULL(bin->bin_bag_last)) {
 		bag_id = bin->bin_bag_last;
@@ -341,16 +352,24 @@ gc_bin_find_bag(struct umem_instance *umm, struct vos_gc_bin_df *bin)
 	if (UMOFF_IS_NULL(bag_id))
 		return NULL;
 
-	umem_tx_add_ptr(umm, bin, sizeof(*bin));
-	bin->bin_bag_last = bag_id;
-	bin->bin_bag_nr++;
+	rc = umem_tx_add_ptr(umm, bin, sizeof(*bin));
+	if (rc != 0)
+		return NULL;
+
 	if (bag) { /* the original last bag */
-		umem_tx_add_ptr(umm, bag, sizeof(*bag));
+		rc = umem_tx_add_ptr(umm, bag, sizeof(*bag));
+		if (rc != 0)
+			return NULL;
+
 		bag->bag_next = bag_id;
 	} else {
 		/* this is a new bin */
 		bin->bin_bag_first = bag_id;
 	}
+
+	bin->bin_bag_last = bag_id;
+	bin->bin_bag_nr++;
+
 	return umem_off2ptr(umm, bag_id);
 }
 
@@ -361,6 +380,7 @@ gc_bin_add_item(struct umem_instance *umm, struct vos_gc_bin_df *bin,
 	struct vos_gc_bag_df *bag;
 	struct vos_gc_item   *it;
 	int		      last;
+	int		      rc;
 
 	bag = gc_bin_find_bag(umm, bin);
 	if (!bag)
@@ -377,10 +397,13 @@ gc_bin_add_item(struct umem_instance *umm, struct vos_gc_bin_df *bin,
 	if (last == bin->bin_bag_size)
 		last = 0;
 
-	umem_tx_add_ptr(umm, bag, sizeof(*bag));
-	bag->bag_item_last = last;
-	bag->bag_item_nr += 1;
-	return 0;
+	rc = umem_tx_add_ptr(umm, bag, sizeof(*bag));
+	if (rc == 0) {
+		bag->bag_item_last = last;
+		bag->bag_item_nr += 1;
+	}
+
+	return rc;
 }
 
 static struct vos_gc_item *
@@ -471,9 +494,12 @@ gc_free_item(struct vos_gc *gc, struct vos_pool *pool, struct vos_gc_item *item)
 	D_DEBUG(DB_TRACE, "GC released a %s\n", gc->gc_name);
 	/* this is the real container|object|dkey|akey free */
 	if (gc->gc_free)
-		gc->gc_free(gc, pool, item);
+		rc = gc->gc_free(gc, pool, item);
 	else
-		umem_free(&pool->vp_umm, item->it_addr);
+		rc = umem_free(&pool->vp_umm, item->it_addr);
+
+	if (rc != 0)
+		goto failed;
 
 	switch (gc->gc_type) {
 	default:

--- a/src/vos/vos_internal.h
+++ b/src/vos/vos_internal.h
@@ -237,7 +237,9 @@ struct vos_dtx_act_ent {
 	umem_off_t			*dae_records;
 	/* The capacity of dae_records, NOT including the inlined buffer. */
 	int				 dae_rec_cap;
-	unsigned int			 dae_committable:1;
+	unsigned int			 dae_committable:1,
+					 dae_committed:1,
+					 dae_aborted:1;
 };
 
 extern struct vos_tls	*standalone_tls;
@@ -371,8 +373,10 @@ vos_obj_tab_register();
  *
  * \param umm		[IN]	Instance of an unified memory class.
  * \param cont_df	[IN]	Pointer to the on-disk VOS container.
+ *
+ * \return		0 on success and negative on failure.
  */
-void
+int
 vos_dtx_table_destroy(struct umem_instance *umm, struct vos_cont_df *cont_df);
 
 /**
@@ -462,7 +466,11 @@ vos_dtx_prepared(struct dtx_handle *dth);
 int
 vos_dtx_commit_internal(struct vos_container *cont, struct dtx_id *dtis,
 			int counti, daos_epoch_t epoch,
-			struct dtx_cos_key *dcks);
+			struct dtx_cos_key *dcks,
+			struct vos_dtx_act_ent **daes);
+void
+vos_dtx_post_handle(struct vos_container *cont, struct vos_dtx_act_ent **daes,
+		    int count, bool abort);
 
 /**
  * Establish indexed active DTX table in DRAM.

--- a/src/vos/vos_tree.c
+++ b/src/vos/vos_tree.c
@@ -607,8 +607,8 @@ svt_rec_free(struct btr_instance *tins, struct btr_record *rec, void *args)
 		D_ASSERT(pool != NULL);
 		vos_bio_addr_free(pool, addr, irec->ir_size);
 	}
-	umem_free(&tins->ti_umm, rec->rec_off);
-	return 0;
+
+	return umem_free(&tins->ti_umm, rec->rec_off);
 }
 
 static int


### PR DESCRIPTION
DAOS-5106 dtx: check PMDK operation return value

If some PMDK operation hit error, the PMDK logic may abort
related PMDK transaction quietly. The caller needs to check
the PMDK operation return value before other PMDK operations
agasinst such PMDK transaction. Otherwise, we may trigger
asseration inside PMDK.

This patch also adjusts vos_dtx_commit() and vos_dtx_abort()
logic to avoid the trouble of recovery (or rollback) in-DRAM
DTX table if the PMDK transaction for DTX commit or abort is
failed and rollback.

Remove useless member 'dth_dti_cos_done' from DTX handle.

Signed-off-by: Fan Yong <fan.yong@intel.com>