### PR TITLE
DAOS-623 object: Try a smaller inline count

### DIFF
--- a/src/object/cli_obj.c
+++ b/src/object/cli_obj.c
@@ -40,7 +40,7 @@
 #define CLI_OBJ_IO_PARMS	8
 #define NIL_BITMAP		(NULL)
 
-#define OBJ_TGT_INLINE_NR	(25)
+#define OBJ_TGT_INLINE_NR	(24)
 struct obj_req_tgts {
 	/* to save memory allocation if #targets <= OBJ_TGT_INLINE_NR */
 	struct daos_shard_tgt	 ort_tgts_inline[OBJ_TGT_INLINE_NR];


### PR DESCRIPTION
We are hitting an assertion on master because task struct isn't large
enough.  Try reducing space usage a little.

Signed-off-by: Jeff Olivier <jeffrey.v.olivier@intel.com>