### PR TITLE
DAOS-2448 obj: add EC degraded fetch test and bug fixes

### DIFF
--- a/src/common/fail_loc.c
+++ b/src/common/fail_loc.c
@@ -116,6 +116,37 @@ daos_fail_loc_set(uint64_t fail_loc)
 	D_DEBUG(DB_ANY, "*** fail_loc="DF_X64"\n", daos_fail_loc);
 }
 
+/* set #nr shards as failure (nr within [1, 4]) */
+uint64_t
+daos_shard_fail_value(uint16_t *shards, int nr)
+{
+	int		i;
+	uint64_t	fail_val = 0;
+
+	if (nr == 0 || nr > 4) {
+		D_ERROR("ignore nr %d, should within [1, 4].\n", nr);
+		return fail_val;
+	}
+	for (i = 0; i < nr; i++)
+		fail_val |= ((uint64_t)shards[i] << (16 * i));
+	return fail_val;
+}
+
+bool
+daos_shard_in_fail_value(uint16_t shard)
+{
+	int		i;
+	uint64_t	mask = 0xFFFF;
+	uint64_t	fail_val = daos_fail_value_get();
+
+	for (i = 0; i < 4; i++) {
+		if (shard == ((fail_val & (mask << (i * 16))) >> (i * 16)))
+			return true;
+	}
+
+	return false;
+}
+
 void
 daos_fail_num_set(uint64_t value)
 {

--- a/src/include/daos/common.h
+++ b/src/include/daos/common.h
@@ -511,7 +511,10 @@ void
 daos_fail_value_set(uint64_t val);
 void
 daos_fail_num_set(uint64_t num);
-
+uint64_t
+daos_shard_fail_value(uint16_t *shards, int nr);
+bool
+daos_shard_in_fail_value(uint16_t shard);
 int
 daos_fail_check(uint64_t id);
 
@@ -604,8 +607,13 @@ enum {
 #define DAOS_CSUM_CORRUPT_UPDATE_DKEY	(DAOS_FAIL_UNIT_TEST_GROUP_LOC | 0x24)
 #define DAOS_CSUM_CORRUPT_FETCH_DKEY	(DAOS_FAIL_UNIT_TEST_GROUP_LOC | 0x25)
 
- /** This fault simulates corruption on disk. Must be set on server side. */
+/** This fault simulates corruption on disk. Must be set on server side. */
 #define DAOS_CSUM_CORRUPT_DISK		(DAOS_FAIL_UNIT_TEST_GROUP_LOC | 0x26)
+/**
+ * This fault simulates shard fetch failure. Can be used to test EC degraded
+ * fetch.
+ */
+#define DAOS_FAIL_SHARD_FETCH		(DAOS_FAIL_UNIT_TEST_GROUP_LOC | 0x27)
 
 #define DAOS_DTX_COMMIT_SYNC		(DAOS_FAIL_UNIT_TEST_GROUP_LOC | 0x30)
 #define DAOS_DTX_LEADER_ERROR		(DAOS_FAIL_UNIT_TEST_GROUP_LOC | 0x31)

--- a/src/object/cli_ec.c
+++ b/src/object/cli_ec.c
@@ -1907,16 +1907,21 @@ obj_ec_recov_prep(struct obj_reasb_req *reasb_req, daos_obj_id_t oid,
 	int			 rc;
 
 	D_ASSERT(iod_nr == fail_info->efi_nrecx_lists);
-	rc = obj_ec_stripe_list_init(fail_info->efi_recx_lists,
-				    fail_info->efi_nrecx_lists,
-				    reasb_req->orr_oca,
-				   &fail_info->efi_stripe_lists);
-	if (rc)
-		goto out;
+	/* when new target failed in recovery, the efi_stripe_lists and
+	 * efi_recov_tasks already initialized.
+	 */
+	if (fail_info->efi_stripe_lists == NULL) {
+		rc = obj_ec_stripe_list_init(fail_info->efi_recx_lists,
+					    fail_info->efi_nrecx_lists,
+					    reasb_req->orr_oca,
+					   &fail_info->efi_stripe_lists);
+		if (rc)
+			goto out;
 
-	rc = obj_ec_recov_task_init(reasb_req, oid, iods, iod_nr);
-	if (rc)
-		goto out;
+		rc = obj_ec_recov_task_init(reasb_req, oid, iods, iod_nr);
+		if (rc)
+			goto out;
+	}
 
 	rc = obj_ec_recov_codec_init(reasb_req, oid, fail_info->efi_ntgts,
 				     fail_info->efi_tgt_list);

--- a/src/object/cli_ec.c
+++ b/src/object/cli_ec.c
@@ -1984,61 +1984,92 @@ obj_ec_sgl_copy(d_sg_list_t *sgl, uint64_t off, void *buf, uint64_t size)
 	D_ASSERT(rc == 0);
 }
 
+/* copy the recovered data back to missed (to be recovered) recx list */
 static void
 obj_ec_recov_fill_back(daos_iod_t *iod, d_sg_list_t *sgl,
+		       struct daos_recx_ep_list *recov_list,
 		       struct daos_recx_ep_list *stripe_list,
 		       d_sg_list_t *stripe_sgl, uint64_t stripe_total_sz,
 		       uint64_t stripe_rec_nr)
 {
 	void		*stripe_buf;
-	daos_recx_t	 recx, stripe_recx, ovl;
-	uint64_t	 stripe_off, off, recx_nr, stripe_total_nr, stripe_nr;
+	daos_recx_t	 recov_recx, stripe_recx, iod_recx, ovl = {0};
+	uint64_t	 stripe_off, iod_off, tmp_off, rec_nr;
+	uint64_t	 stripe_total_nr, stripe_nr;
 	uint64_t	 iod_size = iod->iod_size;
+	bool		 overlapped;
 	uint32_t	 i, j, k;
 
-	recx_nr = 0;
-	for (i = 0; i < iod->iod_nr; i++) {
-		recx = iod->iod_recxs[i];
-		off = recx_nr * iod_size;
+	for (i = 0; i < recov_list->re_nr; i++) {
+		recov_recx = recov_list->re_items[i].re_recx;
+again:
+		/* calculate the offset of to-be-recovered recx in original
+		 * user iod/sgl.
+		 */
+		rec_nr = 0;
+		overlapped = false;
+		for (j = 0; j < iod->iod_nr; j++) {
+			iod_recx = iod->iod_recxs[j];
+			if (!DAOS_RECX_PTR_OVERLAP(&recov_recx, &iod_recx)) {
+				rec_nr += iod_recx.rx_nr;
+				continue;
+			}
+			overlapped = true;
+			D_ASSERT(recov_recx.rx_idx >= iod_recx.rx_idx);
+			ovl.rx_idx = recov_recx.rx_idx;
+			ovl.rx_nr = min(recov_recx.rx_idx + recov_recx.rx_nr,
+					iod_recx.rx_idx + iod_recx.rx_nr) -
+				    ovl.rx_idx;
+			rec_nr += recov_recx.rx_idx - iod_recx.rx_idx;
+		}
+		D_ASSERT(overlapped);
+		iod_off = rec_nr * iod_size;
+
+		/* break the to-be-recovered recx per stripe, can copy
+		 * corresponding data in recovered full stripe to original
+		 * user sgl.
+		 */
 		stripe_total_nr = 0;
-		stripe_nr = 0;
 		for (j = 0; j < stripe_list->re_nr; j++) {
 			stripe_recx = stripe_list->re_items[j].re_recx;
-			stripe_recx.rx_nr = stripe_rec_nr;
+			D_ASSERT(stripe_recx.rx_nr % stripe_rec_nr == 0);
 			stripe_nr = stripe_recx.rx_nr / stripe_rec_nr;
+			stripe_recx.rx_nr = stripe_rec_nr;
 			for (k = 0; k < stripe_nr; k++) {
 				stripe_off = stripe_total_nr * stripe_total_sz;
 				stripe_buf = stripe_sgl->sg_iovs[0].iov_buf +
 					     stripe_off;
-				if (DAOS_RECX_PTR_OVERLAP(&recx,
-							  &stripe_recx)) {
-					ovl.rx_idx =
-						max(recx.rx_idx,
-						    stripe_recx.rx_idx);
-					ovl.rx_nr =
-						min(recx.rx_idx + recx.rx_nr,
-						    stripe_recx.rx_idx +
-						    stripe_recx.rx_nr) -
-						ovl.rx_idx;
-					off += (ovl.rx_idx - recx.rx_idx) *
-					       iod_size;
-					stripe_off +=
-					    (ovl.rx_idx - stripe_recx.rx_idx) *
-					    iod_size;
-					obj_ec_sgl_copy(sgl, off,
-							stripe_buf + stripe_off,
-							ovl.rx_nr * iod_size);
-					recx.rx_idx += ovl.rx_nr;
-					recx.rx_nr -= ovl.rx_nr;
-					if (recx.rx_nr == 0)
+				if (DAOS_RECX_PTR_OVERLAP(&ovl, &stripe_recx)) {
+					D_ASSERT(ovl.rx_idx >=
+						 stripe_recx.rx_idx);
+					rec_nr = min(ovl.rx_idx + ovl.rx_nr,
+						     stripe_recx.rx_idx +
+						     stripe_recx.rx_nr) -
+						 ovl.rx_idx;
+					tmp_off = iod_size *
+					    (ovl.rx_idx - stripe_recx.rx_idx);
+					obj_ec_sgl_copy(sgl, iod_off,
+							stripe_buf + tmp_off,
+							rec_nr * iod_size);
+					ovl.rx_idx += rec_nr;
+					ovl.rx_nr -= rec_nr;
+					if (ovl.rx_nr == 0)
 						goto next;
 				}
 				stripe_recx.rx_idx += stripe_rec_nr;
 				stripe_total_nr++;
 			}
 		}
+
 next:
-		recx_nr += iod->iod_recxs[i].rx_nr;
+		D_ASSERT(ovl.rx_nr == 0);
+		D_ASSERT(ovl.rx_idx <= recov_recx.rx_idx + recov_recx.rx_nr);
+		if (ovl.rx_idx < recov_recx.rx_idx + recov_recx.rx_nr) {
+			recov_recx.rx_nr = recov_recx.rx_idx + recov_recx.rx_nr
+					   - ovl.rx_idx;
+			recov_recx.rx_idx = ovl.rx_idx;
+			goto again;
+		}
 	}
 }
 
@@ -2051,14 +2082,16 @@ obj_ec_recov_data(struct obj_reasb_req *reasb_req, daos_obj_id_t oid,
 	struct obj_ec_fail_info		*fail_info = reasb_req->orr_fail;
 	struct obj_ec_recov_codec	*codec = fail_info->efi_recov_codec;
 	struct daos_oclass_attr		*oca = reasb_req->orr_oca;
-	struct daos_recx_ep_list	*stripe_list;
+	struct daos_recx_ep_list	*stripe_list, *recov_list;
 	struct daos_recx_ep_list	*stripe_lists =
 						fail_info->efi_stripe_lists;
+	struct daos_recx_ep_list	*recov_lists =
+						fail_info->efi_recx_lists;
 	d_sg_list_t			*stripe_sgls =
 						fail_info->efi_stripe_sgls;
 	d_sg_list_t			*stripe_sgl, *sgl;
 	daos_iod_t			*iod;
-	void				*buf_rsgl, *buf_stripe;
+	void				*buf_stripe;
 	uint32_t			 i, j, sidx, stripe_nr;
 	uint64_t			 cell_sz, stripe_total_sz;
 	uint64_t			 stripe_rec_nr =
@@ -2067,16 +2100,19 @@ obj_ec_recov_data(struct obj_reasb_req *reasb_req, daos_obj_id_t oid,
 
 	for (i = 0; i < iod_nr; i++) {
 		stripe_list = &stripe_lists[i];
-		if (stripe_list->re_nr == 0)
+		recov_list = &recov_lists[i];
+		if (recov_list->re_nr == 0 || stripe_list->re_nr == 0) {
+			D_ASSERT(recov_list->re_nr == 0 &&
+				 stripe_list->re_nr == 0);
 			continue;
+		}
 
 		iod = &iods[i];
 		sgl = &sgls[i];
 		stripe_sgl = &stripe_sgls[i];
 		cell_sz = obj_ec_cell_rec_nr(oca) * iod->iod_size;
 		stripe_total_sz = cell_sz * obj_ec_tgt_nr(oca);
-		buf_rsgl = stripe_sgl->sg_iovs[0].iov_buf;
-		buf_stripe = buf_rsgl;
+		buf_stripe = stripe_sgl->sg_iovs[0].iov_buf;
 		for (j = 0; j < stripe_list->re_nr; j++) {
 			recx_ep = &stripe_list->re_items[j];
 			stripe_nr = recx_ep->re_recx.rx_nr / stripe_rec_nr;
@@ -2086,8 +2122,9 @@ obj_ec_recov_data(struct obj_reasb_req *reasb_req, daos_obj_id_t oid,
 				buf_stripe += stripe_total_sz;
 			}
 		}
-		obj_ec_recov_fill_back(iod, sgl, stripe_list, stripe_sgl,
-				       stripe_total_sz, stripe_rec_nr);
+		obj_ec_recov_fill_back(iod, sgl, recov_list, stripe_list,
+				       stripe_sgl, stripe_total_sz,
+				       stripe_rec_nr);
 	}
 }
 

--- a/src/object/obj_ec.h
+++ b/src/object/obj_ec.h
@@ -408,7 +408,7 @@ obj_io_desc_fini(struct obj_io_desc *oiod)
 
 static inline void
 obj_recx_ep_list_idx_parity2daos(uint32_t nr, struct daos_recx_ep_list *lists,
-				 uint32_t tgt_idx, struct daos_oclass_attr *oca)
+				 struct daos_oclass_attr *oca)
 {
 	struct daos_recx_ep_list	*list;
 	daos_recx_t			*recx;
@@ -416,7 +416,7 @@ obj_recx_ep_list_idx_parity2daos(uint32_t nr, struct daos_recx_ep_list *lists,
 						obj_ec_stripe_rec_nr(oca);
 	uint64_t			 cell_rec_nr =
 						obj_ec_cell_rec_nr(oca);
-	uint32_t			 i, j;
+	uint32_t			 i, j, stripe_nr;
 
 	if (lists == NULL)
 		return;
@@ -424,16 +424,73 @@ obj_recx_ep_list_idx_parity2daos(uint32_t nr, struct daos_recx_ep_list *lists,
 		list = &lists[i];
 		for (j = 0; j < list->re_nr; j++) {
 			recx = &list->re_items[j].re_recx;
+			D_ASSERT(recx->rx_idx % cell_rec_nr == 0);
+			stripe_nr = recx->rx_nr / cell_rec_nr;
 			D_ASSERT((recx->rx_idx & PARITY_INDICATOR) != 0);
 			recx->rx_idx &= ~PARITY_INDICATOR;
 			recx->rx_idx = obj_ec_idx_vos2daos(recx->rx_idx,
 						stripe_rec_nr, cell_rec_nr,
-						tgt_idx);
+						0);
+			recx->rx_nr = stripe_rec_nr * stripe_nr;
 		}
 	}
 }
 
-static inline void
+/* Break iod's recxs on cell_size boundary, for the use case that translate
+ * mapped VOS extend to original daos extent - one mapped VOS extend possibly
+ * corresponds to multiple original dis-continuous daos extents.
+ */
+static inline int
+obj_iod_break(daos_iod_t *iod, struct daos_oclass_attr *oca)
+{
+	daos_recx_t	*recx, *new_recx;
+	uint64_t	 cell_size = obj_ec_cell_rec_nr(oca);
+	uint64_t	 rec_nr;
+	uint32_t	 i, j, stripe_nr;
+
+	for (i = 0; i < iod->iod_nr; i++) {
+		recx = &iod->iod_recxs[i];
+		stripe_nr = obj_ec_recx_cell_nr(recx, oca);
+		D_ASSERT(stripe_nr >= 1);
+		if (stripe_nr == 1)
+			continue;
+		D_ALLOC_ARRAY(new_recx, stripe_nr);
+		if (new_recx == NULL)
+			return -DER_NOMEM;
+		for (j = 0; j < i; j++)
+			new_recx[j] = iod->iod_recxs[j];
+		rec_nr = recx->rx_nr;
+		for (j = 0; j < stripe_nr; j++) {
+			if (j == 0) {
+				new_recx[i].rx_idx = recx->rx_idx;
+				new_recx[i].rx_nr = cell_size - recx->rx_idx;
+				rec_nr -= new_recx[i].rx_nr;
+			} else {
+				new_recx[i + j].rx_idx =
+					new_recx[i + j - 1].rx_idx +
+					new_recx[i + j - 1].rx_nr;
+				D_ASSERT(new_recx[i + j].rx_idx % cell_size ==
+					 0);
+				if (j == stripe_nr - 1) {
+					new_recx[i + j].rx_nr = rec_nr;
+				} else {
+					new_recx[i + j].rx_nr = cell_size;
+					rec_nr -= cell_size;
+				}
+			}
+		}
+		for (j = i + 1; j < iod->iod_nr; j++)
+			new_recx[j + stripe_nr] = iod->iod_recxs[j];
+		i += (stripe_nr - 1);
+		iod->iod_nr += (stripe_nr - 1);
+		D_FREE(iod->iod_recxs);
+		iod->iod_recxs = new_recx;
+	}
+
+	return 0;
+}
+
+static inline int
 obj_iod_idx_vos2daos(uint32_t iod_nr, daos_iod_t *iods, uint32_t tgt_idx,
 		     struct daos_oclass_attr *oca)
 {
@@ -442,9 +499,16 @@ obj_iod_idx_vos2daos(uint32_t iod_nr, daos_iod_t *iods, uint32_t tgt_idx,
 	uint64_t	 stripe_rec_nr = obj_ec_stripe_rec_nr(oca);
 	uint64_t	 cell_rec_nr = obj_ec_cell_rec_nr(oca);
 	uint32_t	 i, j;
+	int		 rc;
 
 	for (i = 0; i < iod_nr; i++) {
 		iod = &iods[i];
+
+		rc = obj_iod_break(iod, oca);
+		if (rc != 0) {
+			D_ERROR("obj_iod_break failed, "DF_RC"\n", DP_RC(rc));
+			return rc;
+		}
 		for (j = 0; j < iod->iod_nr; j++) {
 			recx = &iod->iod_recxs[j];
 			D_ASSERT((recx->rx_idx & PARITY_INDICATOR) == 0);
@@ -453,6 +517,8 @@ obj_iod_idx_vos2daos(uint32_t iod_nr, daos_iod_t *iods, uint32_t tgt_idx,
 						tgt_idx);
 		}
 	}
+
+	return 0;
 }
 
 static inline void

--- a/src/object/obj_internal.h
+++ b/src/object/obj_internal.h
@@ -459,6 +459,7 @@ ds_obj_remote_update(struct dtx_leader_handle *dth, void *arg, int idx,
 int
 ds_obj_remote_punch(struct dtx_leader_handle *dth, void *arg, int idx,
 		    dtx_sub_comp_cb_t comp_cb);
+
 /* srv_obj.c */
 void ds_obj_rw_handler(crt_rpc_t *rpc);
 void ds_obj_tgt_update_handler(crt_rpc_t *rpc);

--- a/src/object/srv_obj.c
+++ b/src/object/srv_obj.c
@@ -1050,9 +1050,8 @@ obj_fetch_shadow(daos_handle_t coh, daos_unit_oid_t oid, daos_epoch_t epoch,
 out:
 	obj_iod_idx_parity2vos(iod_nr, iods);
 	if (rc == 0) {
-		obj_iod_idx_vos2daos(iod_nr, iods, tgt_idx, oca);
-		obj_recx_ep_list_idx_parity2daos(iod_nr, *pshadows, tgt_idx,
-						 oca);
+		obj_recx_ep_list_idx_parity2daos(iod_nr, *pshadows, oca);
+		rc = obj_iod_idx_vos2daos(iod_nr, iods, tgt_idx, oca);
 	}
 	return rc;
 }

--- a/src/object/srv_obj.c
+++ b/src/object/srv_obj.c
@@ -1050,8 +1050,8 @@ obj_fetch_shadow(daos_handle_t coh, daos_unit_oid_t oid, daos_epoch_t epoch,
 out:
 	obj_iod_idx_parity2vos(iod_nr, iods);
 	if (rc == 0) {
-		obj_recx_ep_list_idx_parity2daos(iod_nr, *pshadows, oca);
-		rc = obj_iod_idx_vos2daos(iod_nr, iods, tgt_idx, oca);
+		obj_shadow_list_vos2daos(iod_nr, *pshadows, oca);
+		rc = obj_iod_recx_vos2daos(iod_nr, iods, tgt_idx, oca);
 	}
 	return rc;
 }

--- a/src/tests/suite/SConscript
+++ b/src/tests/suite/SConscript
@@ -95,6 +95,8 @@ def scons():
     denv.Install('$PREFIX/bin/io_conf', Glob('io_conf/daos_io_conf_1'))
     denv.Install('$PREFIX/bin/io_conf', Glob('io_conf/daos_io_conf_2'))
     denv.Install('$PREFIX/bin/io_conf', Glob('io_conf/daos_io_conf_3'))
+    denv.Install('$PREFIX/bin/io_conf', Glob('io_conf/daos_io_conf_4'))
+    denv.Install('$PREFIX/bin/io_conf', Glob('io_conf/daos_io_conf_5'))
     SConscript('io_conf/SConscript', exports='denv')
 
 if __name__ == "SCons.Script":

--- a/src/tests/suite/daos_epoch_io.c
+++ b/src/tests/suite/daos_epoch_io.c
@@ -1242,10 +1242,24 @@ cmd_line_parse(test_arg_t *arg, const char *cmd_line,
 		arg->eio_args.op_iod_size = atoi(argv[1]);
 	} else if (strcmp(argv[0], "obj_class") == 0) {
 		if (strcmp(argv[1], "ec") == 0) {
+			print_message("the test is for EC object.\n");
 			arg->eio_args.op_ec = 1;
+			if ((argc == 3 && strcmp(argv[2], "OC_EC_2P2G1") == 0)
+			    || argc == 2) {
+				print_message("EC obj class OC_EC_2P2G1\n");
+				dts_ec_obj_class = OC_EC_2P2G1;
+				dts_ec_grp_size = 4;
+			} else if (argc == 3 &&
+				   strcmp(argv[2], "OC_EC_4P2G1") == 0) {
+				print_message("EC obj class OC_EC_4P2G1\n");
+				dts_ec_obj_class = OC_EC_4P2G1;
+				dts_ec_grp_size = 6;
+			} else {
+				print_message("bad parameter");
+				D_GOTO(out, rc = -DER_INVAL);
+			}
 			arg->eio_args.op_oid = dts_oid_gen(dts_ec_obj_class, 0,
 							   arg->myrank);
-			print_message("the test is for EC object.\n");
 		} else if (strcmp(argv[1], "replica") == 0) {
 			arg->eio_args.op_ec = 0;
 			arg->eio_args.op_oid = dts_oid_gen(dts_obj_class, 0,
@@ -1254,6 +1268,32 @@ cmd_line_parse(test_arg_t *arg, const char *cmd_line,
 		} else {
 			print_message("bad obj_class %s.\n", argv[1]);
 			rc = -DER_INVAL;
+		}
+	} else if (strcmp(argv[0], "fail_shard_fetch") == 0) {
+		uint16_t	shard[4] = {0};
+		uint64_t	fail_val;
+		int		i;
+
+		if (argc < 2 || argc > 6) {
+			print_message("bad parameter");
+			D_GOTO(out, rc = -DER_INVAL);
+		}
+		if (strcmp(argv[1], "set") == 0) {
+			for (i = 0; i < argc - 2; i++) {
+				shard[i] = atoi(argv[i + 2]) + 1;
+				print_message("will fail fetch from shard %d\n",
+					      shard[i]);
+			}
+			fail_val = daos_shard_fail_value(shard, argc - 2);
+			arg->fail_loc = DAOS_FAIL_SHARD_FETCH |
+					DAOS_FAIL_ALWAYS;
+			arg->fail_value = fail_val;
+		} else if (strcmp(argv[1], "clear") == 0) {
+			arg->fail_loc = 0;
+			arg->fail_value = 0;
+		} else {
+			print_message("bad parameter");
+			D_GOTO(out, rc = -DER_INVAL);
 		}
 	} else if (strcmp(argv[0], "oid") == 0) {
 		rc = cmd_parse_oid(arg, argc, argv);

--- a/src/tests/suite/io_conf/daos_io_conf_4
+++ b/src/tests/suite/io_conf/daos_io_conf_4
@@ -1,0 +1,76 @@
+#/*
+## * (C) Copyright 2018-2019 Intel Corporation.
+## *
+## * Licensed under the Apache License, Version 2.0 (the "License");
+## * you may not use this file except in compliance with the License.
+## * You may obtain a copy of the License at
+## *
+## *    http://www.apache.org/licenses/LICENSE-2.0
+## *
+## * Unless required by applicable law or agreed to in writing, software
+## * distributed under the License is distributed on an "AS IS" BASIS,
+## * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+## * See the License for the specific language governing permissions and
+## * limitations under the License.
+## *
+## * GOVERNMENT LICENSE RIGHTS-OPEN SOURCE SOFTWARE
+## * The Government's rights to use, modify, reproduce, release, perform, display,
+## * or disclose this software are subject to the terms of the Apache License as
+## * provided in Contract No. B609815.
+## * Any reproduction of computer software, computer software documentation, or
+## * portions thereof marked with this legend must also reproduce the markings.
+## */
+##/**
+## * An example daos EPOCH IO test conf file.
+## */
+#
+# io conf file format:
+# 1) some setting:
+# test_lvl xxx (daos or vos, default is daos)
+# dkey xxx
+# akey xxx
+# iod_size xxx (default is 1)
+# obj_class xxx(ec or replica, default is replica)
+#
+# 2) update
+# 2.1) update array and take snapshot
+# update --tx x --snap --recx "[idx_start1, idx_end1] [idx_start2, idx_end2] ..."
+# The max number of recxs is 5 (IOREQ_IOD_NR).
+# 2.2) update single type record and take snapshot
+# update --tx x --snap --single
+#
+# If no --epoch specified, then use default epoch 1.
+# Other two options: --dkey xxx --akey xxx. If not specified then use the last
+# dkey/akey set at above 1).
+# for the option name:
+# --single      == -s
+# --recx        == -r
+# --dkey        == -d
+# --akey        == -a
+#
+# 3) fetch and verify based on snapshot teaken after update.
+# same parameter usage as above 2)
+#
+# 4) discard
+#
+# 5) punch
+#
+
+# 2+2 (OC_EC_2P2G1) EC obj degraded-fetch testing
+# with full-stripe update plus partial overwrite
+
+test_lvl daos
+dkey dkey_4
+akey akey_array_1
+iod_size 1
+obj_class ec OC_EC_2P2G1
+
+update --tx 1 -r "[0, 131072]3"
+
+update --tx 2 -r "[32812, 45777]7"
+
+update --tx 5 -r "[131072, 2621444]9"
+update --tx 6 -r "[65540, 130000]11"
+fail_shard_fetch set 0 1
+fetch --tx 7 -r "[0, 262144]"
+fail_shard_fetch clear

--- a/src/tests/suite/io_conf/daos_io_conf_5
+++ b/src/tests/suite/io_conf/daos_io_conf_5
@@ -1,0 +1,76 @@
+#/*
+## * (C) Copyright 2018-2019 Intel Corporation.
+## *
+## * Licensed under the Apache License, Version 2.0 (the "License");
+## * you may not use this file except in compliance with the License.
+## * You may obtain a copy of the License at
+## *
+## *    http://www.apache.org/licenses/LICENSE-2.0
+## *
+## * Unless required by applicable law or agreed to in writing, software
+## * distributed under the License is distributed on an "AS IS" BASIS,
+## * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+## * See the License for the specific language governing permissions and
+## * limitations under the License.
+## *
+## * GOVERNMENT LICENSE RIGHTS-OPEN SOURCE SOFTWARE
+## * The Government's rights to use, modify, reproduce, release, perform, display,
+## * or disclose this software are subject to the terms of the Apache License as
+## * provided in Contract No. B609815.
+## * Any reproduction of computer software, computer software documentation, or
+## * portions thereof marked with this legend must also reproduce the markings.
+## */
+##/**
+## * An example daos EPOCH IO test conf file.
+## */
+#
+# io conf file format:
+# 1) some setting:
+# test_lvl xxx (daos or vos, default is daos)
+# dkey xxx
+# akey xxx
+# iod_size xxx (default is 1)
+# obj_class xxx(ec or replica, default is replica)
+#
+# 2) update
+# 2.1) update array and take snapshot
+# update --tx x --snap --recx "[idx_start1, idx_end1] [idx_start2, idx_end2] ..."
+# The max number of recxs is 5 (IOREQ_IOD_NR).
+# 2.2) update single type record and take snapshot
+# update --tx x --snap --single
+#
+# If no --epoch specified, then use default epoch 1.
+# Other two options: --dkey xxx --akey xxx. If not specified then use the last
+# dkey/akey set at above 1).
+# for the option name:
+# --single      == -s
+# --recx        == -r
+# --dkey        == -d
+# --akey        == -a
+#
+# 3) fetch and verify based on snapshot teaken after update.
+# same parameter usage as above 2)
+#
+# 4) discard
+#
+# 5) punch
+#
+
+# 4+2 (OC_EC_4P2G1) EC obj degraded-fetch testing
+# with full-stripe update plus partial overwrite
+
+test_lvl daos
+dkey dkey_5
+akey akey_array_1
+iod_size 1
+obj_class ec OC_EC_4P2G1
+
+update --tx 1 -r "[0, 262144]3"
+
+update --tx 2 -r "[32812, 45777]7"
+
+update --tx 5 -r "[262144, 524288]9"
+update --tx 6 -r "[264559, 524111]11"
+fail_shard_fetch set 1 3
+fetch --tx 7 -r "[0, 524277]"
+fail_shard_fetch clear

--- a/src/tests/suite/io_conf/daos_io_conf_5
+++ b/src/tests/suite/io_conf/daos_io_conf_5
@@ -71,6 +71,6 @@ update --tx 2 -r "[32812, 45777]7"
 
 update --tx 5 -r "[262144, 524288]9"
 update --tx 6 -r "[264559, 524111]11"
-fail_shard_fetch set 1 3
+fail_shard_fetch set 3 4
 fetch --tx 7 -r "[0, 524277]"
 fail_shard_fetch clear


### PR DESCRIPTION
1. Add EC degraded fetch test
    change daos_epoch_io to support EC degraded fetch test.
    Add two test case - daos_io_conf_4 and daos_io_conf_5 for
    2+2 and 4+2 EC obj class degraded fetch.
    run by: orterun ... daos_test -x -w ./daos_io_conf_4/_5
2. some bug fixes
2.1) fix a bug in obj_ec_recov_fill_back()
       Should copy the need-to-recover recxs rather than recovered full-stripe
       to original sgl.
2.2) obj_iod_idx_vos2daos(), should break vos extend on cell boundary,
       as one mapped vos extent possibly correspond to multiple
       discontinuous daos extents.
2.3) obj_recx_ep_list_idx_parity2daos() is to translate shadow parity
       extent to daos extent, should translate to full-stripe extent.
2.4) fix two bugs - obj_ec_recx_cell_nr() and obj_recx_ep_list_idx_parity2daos().
2.5) handle new tgt failure in recovery
        It possibly meet new target failure in recovery tasks, in that case
        will start another round of data recovery.

Signed-off-by: Xuezhao Liu <xuezhao.liu@intel.com>