### PR TITLE
DAOS-623 fuse: Request fuse API version 35.

### DIFF
--- a/src/client/dfs/SConscript
+++ b/src/client/dfs/SConscript
@@ -33,7 +33,7 @@ def scons():
 
     denv = configure_lustre(denv)
 
-    denv.AppendUnique(CPPDEFINES=['-DFUSE_USE_VERSION=32'])
+    denv.AppendUnique(CPPDEFINES=['-DFUSE_USE_VERSION=35'])
 
     libraries = ['$LIBS', 'daos_common', 'daos', 'uuid', 'gurt']
 

--- a/src/client/dfuse/SConscript
+++ b/src/client/dfuse/SConscript
@@ -160,7 +160,7 @@ def scons():
     cenv = dfuse_env.Clone()
     # Set the define in SConscript so that it's in place for the prereqs.require
     # check which will verify fuse3/fuse.h can be loaded.
-    cenv.AppendUnique(CPPDEFINES=['-DFUSE_USE_VERSION=32'])
+    cenv.AppendUnique(CPPDEFINES=['-DFUSE_USE_VERSION=35'])
     cenv.AppendUnique(LIBPATH=["../dfs"])
 
     cenv.AppendUnique(LIBS=['dfs', 'duns'])

--- a/utils/sl/components/__init__.py
+++ b/utils/sl/components/__init__.py
@@ -278,7 +278,7 @@ def define_components(reqs):
                 libs=['abt'],
                 headers=['abt.h'])
 
-    reqs.define('fuse', libs=['fuse3'], defines=["FUSE_USE_VERSION=32"],
+    reqs.define('fuse', libs=['fuse3'], defines=["FUSE_USE_VERSION=35"],
                 headers=['fuse3/fuse.h'], package='fuse3-devel')
 
     reqs.define('fio',


### PR DESCRIPTION
The avoids compilation errors with later versions of libfuse.
There are no code changes required to suport this.

Signed-off-by: Ashley Pittman <ashley.m.pittman@intel.com>