### PR TITLE
DAOS-1873 csum: Rebuild with Checksums

### DIFF
--- a/src/client/dfuse/dfuse_core.c
+++ b/src/client/dfuse/dfuse_core.c
@@ -116,7 +116,7 @@ ih_ndecref(struct d_hash_table *htable, d_list_t *rlink, int count)
 {
 	struct dfuse_inode_entry	*ie;
 	uint				oldref;
-	uint				newref;
+	uint				newref = 0;
 
 	ie = container_of(rlink, struct dfuse_inode_entry, ie_htl);
 

--- a/src/common/checksum.c
+++ b/src/common/checksum.c
@@ -221,11 +221,27 @@ daos_csummer_init(struct daos_csummer **obj, struct csum_ft *ft,
 }
 
 int
-daos_csummer_type_init(struct daos_csummer **obj, enum DAOS_CSUM_TYPE type,
-		       size_t chunk_bytes, bool srv_verify)
+daos_csummer_init_with_type(struct daos_csummer **obj, enum DAOS_CSUM_TYPE type,
+			    size_t chunk_bytes, bool srv_verify)
 {
 	return daos_csummer_init(obj, daos_csum_type2algo(type), chunk_bytes,
 				 srv_verify);
+}
+
+int
+daos_csummer_init_with_props(struct daos_csummer **obj, daos_prop_t *props)
+{
+	uint32_t csum_prop = daos_cont_prop2csum(props);
+
+	if (!daos_cont_csum_prop_is_enabled(csum_prop)) {
+		*obj = NULL;
+		return 0;
+	}
+
+	return daos_csummer_init_with_type(obj,
+					   daos_contprop2csumtype(csum_prop),
+					   daos_cont_prop2chunksize(props),
+					   daos_cont_prop2serververify(props));
 }
 
 void daos_csummer_destroy(struct daos_csummer **obj)
@@ -244,6 +260,8 @@ void daos_csummer_destroy(struct daos_csummer **obj)
 uint16_t
 daos_csummer_get_csum_len(struct daos_csummer *obj)
 {
+	if (!daos_csummer_initialized(obj))
+		return 0;
 	if (obj->dcs_algo->cf_get_size)
 		return obj->dcs_algo->cf_get_size(obj);
 	return obj->dcs_algo->cf_csum_len;
@@ -911,7 +929,6 @@ error:
 	return rc;
 }
 
-
 int
 daos_csummer_calc_key(struct daos_csummer *csummer, daos_key_t *key,
 		      struct dcs_csum_info **p_csum)
@@ -925,6 +942,7 @@ daos_csummer_calc_key(struct daos_csummer *csummer, daos_key_t *key,
 	if (!daos_csummer_initialized(csummer))
 		return 0;
 
+	C_TRACE("Creating checksum for key: "DF_KEY"\n", DP_KEY(key));
 	D_ALLOC(csum_info, sizeof(*csum_info) + size);
 	if (csum_info == NULL)
 		return -DER_NOMEM;
@@ -936,6 +954,8 @@ daos_csummer_calc_key(struct daos_csummer *csummer, daos_key_t *key,
 	rc = calc_for_iov(csummer, key, dkey_csum_buf, size);
 	if (rc == 0) {
 		*p_csum = csum_info;
+		C_TRACE("Checksum created for key: "DF_KEY"->"DF_CI"\n",
+			DP_KEY(key), DP_CI(*csum_info));
 	} else {
 		D_ERROR("calc_for_iov error: %d\n", rc);
 		*p_csum = NULL;
@@ -1061,6 +1081,82 @@ ic_idx2csum(struct dcs_iod_csums *iod_csum, uint32_t iod_idx,
 	return csum_info->cs_csum + offset;
 }
 
+daos_size_t
+ic_size(struct dcs_iod_csums *obj)
+{
+	daos_size_t	result = sizeof (*obj);
+	int		i;
+
+	for (i = 0; i < obj->ic_nr; i++)
+		result += ci_size(obj->ic_data[i]);
+
+	return result;
+}
+
+int
+ic_serialize(struct dcs_iod_csums *iod_csums, d_iov_t *iov)
+{
+	int i;
+
+	if (ic_size(iod_csums) > daos_iov_remaining(*iov))
+		return -DER_REC2BIG;
+
+	/** append the dcs_iod_csum structure (includes akey csum_info struct */
+	daos_iov_append(iov, iod_csums, sizeof(*iod_csums));
+	/** append the akey csum buf */
+	daos_iov_append(iov, iod_csums->ic_akey.cs_csum,
+			ci_csums_len(iod_csums->ic_akey));
+	/** append all csum_info structures for the data */
+	daos_iov_append(iov, iod_csums->ic_data, sizeof(*iod_csums->ic_data) *
+						 iod_csums->ic_nr);
+	/** append all the data csum bufs */
+	for (i = 0; i < iod_csums->ic_nr; i++) {
+		struct dcs_csum_info *csum_info = &iod_csums->ic_data[i];
+
+		daos_iov_append(iov, csum_info->cs_csum,
+				ci_csums_len(*csum_info));
+	}
+
+	return 0;
+}
+
+int
+ic_iov2iod_csum(struct dcs_iod_csums **obj, d_iov_t *iov)
+{
+	int i;
+	void *ptr = iov->iov_buf;
+	struct dcs_iod_csums *iod_csums;
+	void *end = iov->iov_buf + iov->iov_buf_len;
+
+	*obj = NULL;
+
+	iod_csums = (struct dcs_iod_csums *)ptr;
+	ptr += sizeof(struct dcs_iod_csums);
+	if (ptr > end)
+		return -DER_TRUNC;
+
+	iod_csums->ic_akey.cs_csum = ptr;
+	ptr += ci_csums_len(iod_csums->ic_akey);
+	if (ptr > end)
+		return -DER_TRUNC;
+
+	iod_csums->ic_data = ptr;
+	ptr += iod_csums->ic_nr * sizeof (*iod_csums->ic_data);
+	if (ptr > end)
+		return -DER_TRUNC;
+
+	for (i = 0; i < iod_csums->ic_nr; i++) {
+		iod_csums->ic_data[i].cs_csum = ptr;
+		ptr += ci_csums_len(iod_csums->ic_data[i]);
+		if (ptr > end)
+			return -DER_TRUNC;
+	}
+
+	*obj = iod_csums;
+
+	return 0;
+}
+
 /**
  * -----------------------------------------------------------------------------
  * struct daos_csum_info functions
@@ -1154,6 +1250,48 @@ uint64_t
 ci2csum(struct dcs_csum_info ci)
 {
 	return ci_buf2uint64(ci.cs_csum, ci.cs_len);
+}
+
+int
+ci_serialize(struct dcs_csum_info *obj, d_iov_t *iov)
+{
+	if (ci_size(*obj) > daos_iov_remaining(*iov))
+		return -DER_REC2BIG;
+	daos_iov_append(iov, obj, sizeof(*obj));
+	daos_iov_append(iov, obj->cs_csum, obj->cs_buf_len);
+
+	return 0;
+}
+
+void
+ci_cast(struct dcs_csum_info **obj, const d_iov_t *iov)
+{
+	void			*buf;
+	struct dcs_csum_info	*tmp;
+
+	D_ASSERT(iov != NULL);
+	D_ASSERT(obj != NULL);
+	*obj = NULL;
+
+	buf = iov->iov_buf;
+	tmp = (struct dcs_csum_info *)buf;
+
+	if (ci_size(*tmp) > iov->iov_len)
+		return;
+
+	tmp->cs_csum = buf + sizeof (struct dcs_csum_info);
+	*obj = tmp;
+}
+
+void
+ci_move_next_iov(struct dcs_csum_info *csum_info, d_iov_t *csum_iov)
+{
+	D_ASSERT(csum_iov->iov_buf_len >= ci_size(*csum_info));
+	D_ASSERT(csum_iov->iov_len >= ci_size(*csum_info));
+
+	csum_iov->iov_buf += ci_size(*csum_info);
+	csum_iov->iov_buf_len -= ci_size(*csum_info);
+	csum_iov->iov_len -= ci_size(*csum_info);
 }
 
 /** Other Functions */

--- a/src/common/misc.c
+++ b/src/common/misc.c
@@ -385,6 +385,14 @@ daos_iov_cmp(d_iov_t *iov1, d_iov_t *iov2)
 	return !memcmp(iov1->iov_buf, iov2->iov_buf, iov1->iov_len);
 }
 
+void
+daos_iov_append(d_iov_t *iov, void *buf, uint64_t buf_len)
+{
+	D_ASSERT(iov->iov_len + buf_len <= iov->iov_buf_len);
+	memcpy(iov->iov_buf + iov->iov_len, buf, buf_len);
+	iov->iov_len += buf_len;
+}
+
 d_rank_list_t *
 daos_rank_list_parse(const char *str, const char *sep)
 {

--- a/src/common/tests/checksum_tests.c
+++ b/src/common/tests/checksum_tests.c
@@ -37,6 +37,23 @@
 
 static bool verbose;
 
+#define assert_ci_equal(e, a) do {\
+        assert_int_equal((e).cs_nr, (a).cs_nr); \
+        assert_int_equal((e).cs_len, (a).cs_len); \
+        assert_int_equal((e).cs_buf_len, (a).cs_buf_len); \
+        assert_int_equal((e).cs_chunksize, (a).cs_chunksize); \
+        assert_int_equal((e).cs_type, (a).cs_type); \
+        assert_memory_equal((e).cs_csum, (a).cs_csum, (e).cs_len * (e).cs_nr); \
+	} while(0)
+
+#define assert_ic_equal(e, a) do {\
+	int __i; \
+	assert_int_equal((e).ic_nr, (a).ic_nr); \
+	assert_ci_equal((e).ic_akey, (a).ic_akey); \
+	for (__i = 0; __i < (e).ic_nr; __i++) \
+		assert_ci_equal((e).ic_data[__i], (a).ic_data[__i]);\
+} while(0)
+
 /**
  * -----------------------------------------------------------------------------
  * Setup some fake functions and veriables to track how the functions are
@@ -1397,8 +1414,9 @@ test_verify_sv_data(void **state)
 	int			 rc;
 	struct dcs_iod_csums	*iod_csums = NULL;
 
-	daos_csummer_type_init(&csummer, CSUM_TYPE_ISAL_CRC64_REFL, 1024 * 1024,
-			       0);
+	daos_csummer_init_with_type(&csummer, CSUM_TYPE_ISAL_CRC64_REFL,
+				    1024 * 1024,
+				    0);
 	dts_sgl_init_with_strings(&sgl, 1, "0123456789");
 
 
@@ -1522,19 +1540,143 @@ test_formatter(void **state)
 			    result);
 }
 
-static int test_setup(void **state)
+static void
+test_ci_serialize(void **state)
+{
+	const size_t		iov_buf_len = 64;
+	const uint32_t		csum_size = 8;
+	uint64_t		csum_buf = 0x1234567890ABCDEF;
+	uint8_t			iov_buf[iov_buf_len];
+	d_iov_t			iov = {0};
+	struct dcs_csum_info	*actual = NULL;
+	struct dcs_csum_info	expected = {
+		.cs_csum = (uint8_t *)&csum_buf,
+		.cs_buf_len = csum_size,
+		.cs_nr = 1,
+		.cs_type = 99,
+		.cs_len = csum_size,
+		.cs_chunksize = 1234
+	};
+
+	iov.iov_buf = iov_buf;
+	iov.iov_buf_len = iov_buf_len;
+	ci_serialize(&expected, &iov);
+
+	ci_cast(&actual, &iov);
+	assert_ci_equal(expected, *actual);
+
+	/** iov buf is too short */
+	iov.iov_len = iov.iov_len - 1;
+	ci_cast(&actual, &iov);
+	assert_null(actual);
+}
+
+static void
+test_ic_serialize(void **state)
+{
+	struct dcs_iod_csums	*result = NULL;
+	d_iov_t			 iov = {0};
+	const daos_size_t	 iov_buf_len = 100;
+	uint8_t			*iov_buf[iov_buf_len];
+	uint32_t		 csum_len = 8;
+	uint32_t		 csum_type = FAKE_CSUM_TYPE;
+	int			 rc = 0;
+
+	uint64_t		 csum_bufs[10] = {
+		0x1234567890A,
+		0x1234567890B,
+		0x1234567890C,
+		0x1234567890D,
+		0x1234567890E,
+		0x1234567890F,
+		0x1234567891A,
+		0x1234567891B,
+		0x1234567891C,
+		0x1234567891D,
+		};
+
+	struct dcs_csum_info	 data_csum_info[3] = {
+		{
+			.cs_nr = 1,
+			.cs_len = csum_len, .cs_buf_len = csum_len,
+			.cs_chunksize = CSUM_NO_CHUNK,
+			.cs_type = csum_type,
+			.cs_csum = (uint8_t *)&csum_bufs[0]
+		},
+		{
+			.cs_nr = 2,
+			.cs_len = csum_len,
+			.cs_buf_len = csum_len * 2,
+			.cs_chunksize = CSUM_NO_CHUNK,
+			.cs_type = csum_type,
+			.cs_csum = (uint8_t *)&csum_bufs[1]
+		},
+		{
+			.cs_nr = 3,
+			.cs_len = csum_len, .cs_buf_len = csum_len,
+			.cs_chunksize = CSUM_NO_CHUNK,
+			.cs_type = csum_type,
+			.cs_csum = (uint8_t *)&csum_bufs[3]
+		},
+	};
+
+	struct dcs_iod_csums iod_csum = {
+		.ic_nr = 1,
+		.ic_akey = { .cs_nr = 1,
+			.cs_len = csum_len, .cs_buf_len = csum_len,
+			.cs_chunksize = CSUM_NO_CHUNK,
+			.cs_type = csum_type,
+			.cs_csum = (uint8_t *)&csum_bufs[7]
+		},
+		.ic_data = data_csum_info
+	};
+
+	memset(iov_buf, 0, iov_buf_len);
+
+	d_iov_set(&iov, iov_buf, ic_size(&iod_csum) - 1);
+	iov.iov_len = 0;
+
+	rc = ic_serialize(&iod_csum, &iov);
+	assert_int_equal(-DER_TRUNC, rc);
+
+	if (iov_buf_len < ic_size(&iod_csum))
+		fail_msg("Test cannot continue because the iov "
+			 "buffer isn't big enough");
+
+	d_iov_set(&iov, iov_buf, iov_buf_len);
+	iov.iov_len = 0;
+
+	rc = ic_serialize(&iod_csum, &iov);
+	assert_int_equal(0, rc);
+	assert_true(iov.iov_len > 0);
+
+	ic_iov2iod_csum(&result, &iov);
+
+	assert_non_null(result);
+	assert_ic_equal(iod_csum, *result);
+
+	/** test casting iov to iod csum with too small iov_buf */
+	d_iov_set(&iov, iov_buf, 10);
+	rc = ic_iov2iod_csum(&result, &iov);
+	assert_int_equal(-DER_TRUNC, rc);
+	assert_null(result);
+}
+
+static int
+csum_test_setup(void **state)
 {
 	return 0;
 }
 
-static int test_teardown(void **state)
+static int
+csum_test_teardown(void **state)
 {
 	reset_fake_algo();
 	return 0;
 }
 
-#define TEST(dsc, test) { dsc, test, test_setup, \
-				test_teardown }
+#define TEST(dsc, test) { dsc, test, csum_test_setup, \
+				csum_test_teardown }
 
 static const struct CMUnitTest tests[] = {
 	TEST("CSUM01: Test initialize and destroy checksummer",
@@ -1559,12 +1701,10 @@ static const struct CMUnitTest tests[] = {
 		test_all_checksum_types),
 	TEST("CSUM10: Test map from container prop to csum type",
 		test_container_prop_to_csum_type),
-	TEST("CSUM11: Some helper function tests",
-		test_helper_functions),
-	TEST("CSUM12: Is Valid Checksum Property",
-		test_is_valid_csum),
-	TEST("CSUM13: Is Checksum Property Enabled",
-		test_is_csum_enabled),
+	TEST("CSUM11: Some helper function tests", test_helper_functions),
+	TEST("CSUM12: Is Valid Checksum Property", test_is_valid_csum),
+	TEST("CSUM12: Is Valid Checksum Property", test_is_valid_csum),
+	TEST("CSUM13: Is Checksum Property Enabled", test_is_csum_enabled),
 	TEST("CSUM14: A simple checksum comparison test",
 		simple_test_compare_checksums),
 	TEST("CSUM15: Compare checksums after actual calculation",
@@ -1596,6 +1736,8 @@ static const struct CMUnitTest tests[] = {
 	TEST("CSUM28: Formatter",
 		test_formatter),
 	TEST("CSUM28: Get the recxes from a map", get_map_test),
+	TEST("CSUM29: csum_info serialization", test_ci_serialize),
+	TEST("CSUM30: csum_info serialization", test_ic_serialize),
 	TEST("CSUM_HOLES01: With 2 mapped extents that leave a hole "
 	     "at the beginning, in between and "
 	     "at the end, all within a single chunk.", holes_1),
@@ -1608,7 +1750,6 @@ static const struct CMUnitTest tests[] = {
 	     "multiple chuncks", holes_4),
 	TEST("CSUM_HOLES05: With record size 2 and many holes within a "
 	     "single chunk", holes_5),
-
 };
 
 int

--- a/src/container/container_iv.c
+++ b/src/container/container_iv.c
@@ -997,7 +997,7 @@ out:
 struct iv_prop_ult_arg {
 	struct ds_iv_ns		*iv_ns;
 	daos_prop_t		*prop;
-	uuid_t			 cont_hdl_uuid;
+	uuid_t			 cont_uuid;
 	ABT_eventual		 eventual;
 };
 
@@ -1022,7 +1022,7 @@ cont_iv_prop_fetch_ult(void *data)
 	if (prop_fetch == NULL)
 		D_GOTO(out, rc = -DER_NOMEM);
 
-	rc = cont_iv_fetch(arg->iv_ns, IV_CONT_PROP, arg->cont_hdl_uuid,
+	rc = cont_iv_fetch(arg->iv_ns, IV_CONT_PROP, arg->cont_uuid,
 			   iv_entry, iv_entry_size, false /* retry */);
 	if (rc) {
 		D_ERROR("cont_iv_fetch failed "DF_RC"\n", DP_RC(rc));
@@ -1065,7 +1065,7 @@ cont_iv_prop_fetch(struct ds_iv_ns *ns, uuid_t cont_hdl_uuid,
 		return dss_abterr2der(rc);
 
 	arg.iv_ns = ns;
-	uuid_copy(arg.cont_hdl_uuid, cont_hdl_uuid);
+	uuid_copy(arg.cont_uuid, cont_hdl_uuid);
 	arg.prop = cont_prop;
 	arg.eventual = eventual;
 	rc = dss_ult_create(cont_iv_prop_fetch_ult, &arg,

--- a/src/container/srv_container.c
+++ b/src/container/srv_container.c
@@ -1112,7 +1112,7 @@ cont_open(struct rdb_tx *tx, struct ds_pool_hdl *pool_hdl, struct cont *cont,
 
 	/* query the container properties from RDB and update to IV */
 	rc = cont_iv_prop_update(pool_hdl->sph_pool->sp_iv_ns,
-				 in->coi_op.ci_hdl, in->coi_op.ci_uuid,
+				 in->coi_op.ci_uuid, in->coi_op.ci_uuid,
 				 prop);
 	daos_prop_free(prop);
 	if (rc != 0) {
@@ -1706,7 +1706,7 @@ cont_query(struct rdb_tx *tx, struct ds_pool_hdl *pool_hdl, struct cont *cont,
 			return -DER_NOMEM;
 
 		rc = cont_iv_prop_fetch(pool_hdl->sph_pool->sp_iv_ns,
-					in->cqi_op.ci_hdl, iv_prop);
+					in->cqi_op.ci_uuid, iv_prop);
 		if (rc) {
 			D_ERROR("cont_iv_prop_fetch failed "DF_RC"\n",
 				DP_RC(rc));
@@ -1874,7 +1874,7 @@ set_prop(struct rdb_tx *tx, struct ds_pool *pool,
 
 	/* Update prop IV with merged prop */
 	rc = cont_iv_prop_update(pool->sp_iv_ns,
-				 hdl_uuid, cont->c_uuid, prop_iv);
+				 cont->c_uuid, cont->c_uuid, prop_iv);
 	if (rc)
 		D_ERROR(DF_UUID": failed to update prop IV for cont, "
 			"%d.\n", DP_UUID(cont->c_uuid), rc);

--- a/src/container/srv_csum_recalc.c
+++ b/src/container/srv_csum_recalc.c
@@ -214,8 +214,8 @@ ds_csum_agg_recalc(void *recalc_args)
 		args->cra_rc = -DER_NOMEM;
 		return;
 	}
-	daos_csummer_type_init(&csummer, csum_info.cs_type,
-			       csum_info.cs_chunksize, 0);
+	daos_csummer_init_with_type(&csummer, csum_info.cs_type,
+				    csum_info.cs_chunksize, 0);
 	for (i = 0; i < args->cra_seg_cnt; i++) {
 		bool		is_valid = false;
 		unsigned int	this_buf_nr, this_buf_idx;

--- a/src/container/srv_target.c
+++ b/src/container/srv_target.c
@@ -835,43 +835,6 @@ ds_cont_hdl_put(struct ds_cont_hdl *hdl)
 	cont_hdl_put_internal(hash, hdl);
 }
 
-static int
-cont_hdl_csummer_init(struct ds_cont_hdl *hdl)
-{
-	daos_prop_t	*props;
-	uint32_t	 csum_val;
-	int		 rc;
-
-	D_ASSERT(hdl->sch_cont != NULL);
-	/** Get the container csum related properties
-	 * Need the pool for the IV namespace
-	 */
-	hdl->sch_csummer = NULL;
-	props = daos_prop_alloc(3);
-	if (props == NULL) {
-		return -DER_NOMEM;
-	}
-	props->dpp_entries[0].dpe_type = DAOS_PROP_CO_CSUM;
-	props->dpp_entries[1].dpe_type = DAOS_PROP_CO_CSUM_CHUNK_SIZE;
-	props->dpp_entries[2].dpe_type = DAOS_PROP_CO_CSUM_SERVER_VERIFY;
-	rc = cont_iv_prop_fetch(hdl->sch_cont->sc_pool->spc_pool->sp_iv_ns,
-				hdl->sch_uuid, props);
-	if (rc != 0)
-		goto done;
-	csum_val = daos_cont_prop2csum(props);
-
-	/** If enabled, initialize the csummer for the container */
-	if (daos_cont_csum_prop_is_enabled(csum_val))
-		rc = daos_csummer_type_init(&hdl->sch_csummer,
-					    daos_contprop2csumtype(csum_val),
-					    daos_cont_prop2chunksize(props),
-					    daos_cont_prop2serververify(props));
-done:
-	daos_prop_free(props);
-
-	return rc;
-}
-
 /**
  * Get target container handle.
  *
@@ -1026,6 +989,35 @@ ds_cont_child_lookup(uuid_t pool_uuid, uuid_t cont_uuid,
 
 	return cont_child_lookup(tls->dt_cont_cache, cont_uuid, pool_uuid,
 				 ds_cont);
+}
+
+/** initialize a csummer based on container properties */
+int ds_cont_csummer_init(struct daos_csummer **csummer,
+			 uuid_t pool_uuid, uuid_t cont_uuid)
+{
+	daos_prop_t	*props;
+	struct ds_pool	*pool;
+	int		 rc;
+
+	props = daos_prop_alloc(3);
+	if (props == NULL)
+		return -DER_NOMEM;
+
+	props->dpp_entries[0].dpe_type = DAOS_PROP_CO_CSUM;
+	props->dpp_entries[1].dpe_type = DAOS_PROP_CO_CSUM_CHUNK_SIZE;
+	props->dpp_entries[2].dpe_type = DAOS_PROP_CO_CSUM_SERVER_VERIFY;
+
+	pool = ds_pool_lookup(pool_uuid);
+	if (pool == NULL)
+		return -DER_NONEXIST;
+	rc = ds_cont_fetch_prop(pool->sp_iv_ns, cont_uuid, props);
+	if (rc == 0)
+		rc = daos_csummer_init_with_props(csummer, props);
+
+	daos_prop_free(props);
+	ds_pool_put(pool);
+
+	return rc;
 }
 
 /**
@@ -1267,7 +1259,12 @@ ds_cont_local_open(uuid_t pool_uuid, uuid_t cont_hdl_uuid, uuid_t cont_uuid,
 		}
 
 csummer:
-		rc = cont_hdl_csummer_init(hdl);
+		D_ASSERT(hdl->sch_cont != NULL);
+		D_ASSERT(hdl->sch_cont->sc_pool != NULL);
+		rc = ds_cont_csummer_init(&hdl->sch_csummer,
+					  hdl->sch_cont->sc_pool->spc_uuid,
+					  hdl->sch_cont->sc_uuid);
+
 		if (rc != 0)
 			D_GOTO(err_register, rc);
 	}

--- a/src/include/daos/checksum.h
+++ b/src/include/daos/checksum.h
@@ -177,8 +177,19 @@ daos_csummer_init(struct daos_csummer **obj, struct csum_ft *ft,
  * @return		0 for success, or an error code
  */
 int
-daos_csummer_type_init(struct daos_csummer **obj, enum DAOS_CSUM_TYPE type,
-		       size_t chunk_bytes, bool srv_verify);
+daos_csummer_init_with_type(struct daos_csummer **obj, enum DAOS_CSUM_TYPE type,
+			    size_t chunk_bytes, bool srv_verify);
+
+/**
+ * Initialize the daos_csummer using container properties
+ * @param obj		daos_csummer to be initialized. Memory will be allocated
+ *			for it.
+ * @param props		Container properties used to configure the daos_csummer.
+ *
+ * @return		0 for success, or an error code
+ */
+int
+daos_csummer_init_with_props(struct daos_csummer **obj, daos_prop_t *props);
 
 /** Destroy the daos_csummer */
 void
@@ -328,10 +339,10 @@ daos_csummer_verify_iod(struct daos_csummer *obj, daos_iod_t *iod,
 			daos_iom_t *map);
 
 /**
- * Verify a single buffer to a checksum
+ * Verify a key to a checksum
  *
  * @param obj		the daos_csummer obj
- * @param key		I/O vector of the key
+ * @param key		he key
  * @param dcb		The dcs_csum_info that describes the checksum
  *
  * @return		0 for success, -DER_CSUM if corruption is detected
@@ -403,9 +414,41 @@ daos_csummer_free_ci(struct daos_csummer *obj,
  * struct dcs_iod_csums Functions
  * -----------------------------------------------------------------------------
  */
+ /** return a specific csum buffer from a specific iod csum info */
 uint8_t *
 ic_idx2csum(struct dcs_iod_csums *iod_csum, uint32_t iod_idx,
 	    uint32_t csum_idx);
+
+/** return the size needed to serialize an iod_csums structure. Should include
+ * the size of the structure, all csum_infos and the length of all csum buffers
+ */
+daos_size_t
+ic_size(struct dcs_iod_csums *obj);
+
+/** serialize an iod_csums object into an iov buffer. The length of the csum
+ * bufs is described by the csum info. The akey csum info is part of the
+ * iod_csums struct. The layout of the serialized structures is as follows and
+ * was done this way so that it's easy to "cast" the memory directly to an
+ * iod_csums structure when received and only the csum_buf points would need
+ * to be updated.
+ * [ iod_csums structure	]
+ * [ akey csum buf		]
+ * [ data csum_info struct 1	]
+ * [ data csum_info struct 2	]
+ * [ data csum_info struct n	]
+ * [ data csum buf 1		]
+ * [ data csum buf 2		]
+ * [ data csum buf n		]
+ */
+int
+ic_serialize(struct dcs_iod_csums *iod_csums, d_iov_t *iov);
+
+/**
+ * "cast" a serialized iod_csums back to an iod_csums. See \ic_serialize for
+ * details on the structure in the memory
+ */
+int
+ic_iov2iod_csum(struct dcs_iod_csums **obj, d_iov_t *iov);
 
 /**
  * -----------------------------------------------------------------------------
@@ -460,6 +503,32 @@ ci2csum(struct dcs_csum_info ci);
 #define	DP_CI_BUF(buf, len) ci_buf2uint64(buf, len)
 #define	DF_CI "{nr: %d, len: %d, first_csum: %lu}"
 #define	DP_CI(ci) (ci).cs_nr, (ci).cs_len, ci2csum(ci)
+
+/**
+ * return the number of bytes needed to serialize a dcs_csum_info into a
+ * buffer
+ */
+#define	ci_size(obj) (sizeof (obj) + (obj).cs_nr * (obj).cs_len)
+
+/** return the actual length for the csums stored in obj. Note that the buffer
+ * (cs_buf_len) might be larger than the actual csums len
+ */
+#define	ci_csums_len(obj) (obj).cs_nr * (obj).cs_len
+
+/** Serialze a \dcs_csum_info structure to an I/O vector. First the structure
+* fields are added to the memory buf, then the actual csum.
+*/
+int
+ci_serialize(struct dcs_csum_info *obj, d_iov_t *iov);
+void
+ci_cast(struct dcs_csum_info **obj, const d_iov_t *iov);
+
+/**
+ * change the iov so that buf points to the next csum_info, assuming the
+ * current csum info's csum buf is right after it in the buffer.
+ */
+void
+ci_move_next_iov(struct dcs_csum_info *obj, d_iov_t *iov);
 
 /**
  * -----------------------------------------------------------------------------

--- a/src/include/daos/common.h
+++ b/src/include/daos/common.h
@@ -250,6 +250,10 @@ daos_size_t daos_sgls_packed_size(d_sg_list_t *sgls, int nr,
 /** Get the leftover space in an iov of sgl */
 #define daos_iov_left(sgl, iov_idx, iov_off)				\
 	((sgl)->sg_iovs[iov_idx].iov_len - (iov_off))
+/** get remaining space in an iov, assuming that iov_len is used and
+ * iov_buf_len is total in buf
+ */
+#define daos_iov_remaining(iov) (iov).iov_buf_len - (iov).iov_len
 /**
  * Move sgl forward from iov_idx/iov_off, with move_dist distance. It is
  * caller's responsibility to check the boundary.
@@ -348,6 +352,7 @@ char *daos_str_trimwhite(char *str);
 int daos_iov_copy(d_iov_t *dst, d_iov_t *src);
 void daos_iov_free(d_iov_t *iov);
 bool daos_iov_cmp(d_iov_t *iov1, d_iov_t *iov2);
+void daos_iov_append(d_iov_t *iov, void *buf, uint64_t buf_len);
 
 #define daos_key_match(key1, key2)	daos_iov_cmp(key1, key2)
 

--- a/src/include/daos/task.h
+++ b/src/include/daos/task.h
@@ -178,13 +178,13 @@ dc_obj_list_recx_task_create(daos_handle_t oh, daos_handle_t th,
 int
 dc_obj_list_obj_task_create(daos_handle_t oh, daos_handle_t th,
 			    daos_epoch_range_t *epr, daos_key_t *dkey,
-			    daos_key_t *akey, daos_size_t *size, uint32_t *nr,
-			    daos_key_desc_t *kds, d_sg_list_t *sgl,
-			    daos_anchor_t *anchor,
-			    daos_anchor_t *dkeay_anchor,
-			    daos_anchor_t *akey_anchor,
-			    bool incr_order, daos_event_t *ev, tse_sched_t *tse,
-			    tse_task_t **task);
+			    daos_key_t *akey, daos_size_t *size,
+			    uint32_t *nr, daos_key_desc_t *kds,
+			    d_sg_list_t *sgl, daos_anchor_t *anchor,
+			    daos_anchor_t *dkey_anchor,
+			    daos_anchor_t *akey_anchor, bool incr_order,
+			    daos_event_t *ev, tse_sched_t *tse,
+			    d_iov_t *csum, tse_task_t **task);
 
 void *
 dc_task_get_args(tse_task_t *task);

--- a/src/include/daos_obj.h
+++ b/src/include/daos_obj.h
@@ -308,10 +308,6 @@ typedef struct {
 	 * It is ignored for dkey enumeration.
 	 */
 	uint32_t	kd_val_type;
-	/** Checksum type */
-	uint16_t	kd_csum_type;
-	/** Checksum length */
-	uint16_t	kd_csum_len;
 } daos_key_desc_t;
 
 /**

--- a/src/include/daos_srv/container.h
+++ b/src/include/daos_srv/container.h
@@ -147,6 +147,12 @@ void ds_cont_child_stop_all(struct ds_pool_child *pool_child);
 int ds_cont_child_lookup(uuid_t pool_uuid, uuid_t cont_uuid,
 			 struct ds_cont_child **ds_cont);
 
+/** initialize a csummer based on container properties. Will retrieve the
+ * checksum related properties from IV
+ */
+int ds_cont_csummer_init(struct daos_csummer **csummer,
+			 uuid_t pool_uuid, uuid_t cont_uuid);
+
 void ds_cont_child_put(struct ds_cont_child *cont);
 void ds_cont_child_get(struct ds_cont_child *cont);
 

--- a/src/include/daos_srv/daos_server.h
+++ b/src/include/daos_srv/daos_server.h
@@ -545,10 +545,10 @@ int dsc_obj_fetch(daos_handle_t oh, daos_epoch_t epoch,
 		daos_iod_t *iods, d_sg_list_t *sgls,
 		daos_iom_t *maps);
 int dsc_obj_list_obj(daos_handle_t oh, daos_epoch_range_t *epr,
-		daos_key_t *dkey, daos_key_t *akey, daos_size_t *size,
-		uint32_t *nr, daos_key_desc_t *kds, d_sg_list_t *sgl,
-		daos_anchor_t *anchor, daos_anchor_t *dkey_anchor,
-		daos_anchor_t *akey_anchor);
+		     daos_key_t *dkey, daos_key_t *akey, daos_size_t *size,
+		     uint32_t *nr, daos_key_desc_t *kds, d_sg_list_t *sgl,
+		     daos_anchor_t *anchor, daos_anchor_t *dkey_anchor,
+		     daos_anchor_t *akey_anchor, d_iov_t *csum);
 int dsc_pool_tgt_exclude(const uuid_t uuid, const char *grp,
 			 const d_rank_list_t *svc, struct d_tgt_list *tgts);
 
@@ -614,6 +614,7 @@ struct dss_enum_unpack_io {
 	daos_unit_oid_t		 ui_oid;	/**< type <= OBJ */
 	daos_key_t		 ui_dkey;	/**< type <= DKEY */
 	daos_iod_t		*ui_iods;
+	struct dcs_iod_csums	*ui_iods_csums;
 	/* punched epochs per akey */
 	daos_epoch_t		*ui_akey_punch_ephs;
 	daos_epoch_t		*ui_rec_punch_ephs;

--- a/src/include/daos_task.h
+++ b/src/include/daos_task.h
@@ -776,6 +776,10 @@ typedef struct {
 	daos_anchor_t		*akey_anchor;
 	/** versions. */
 	uint32_t		*versions;
+	/** Serialized checksum info for enumerated keys and data in sgl.
+	 * (for internal use only)
+	 */
+	d_iov_t			*csum;
 	/** order. */
 	bool			incr_order;
 } daos_obj_list_t;

--- a/src/iosrv/vos.c
+++ b/src/iosrv/vos.c
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright 2018-2019 Intel Corporation.
+ * (C) Copyright 2018-2020 Intel Corporation.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -31,6 +31,15 @@
 #include <daos_srv/daos_server.h>
 #include <daos_srv/vos.h>
 #include <daos/object.h>
+
+static struct dcs_iod_csums *
+io_iod_csums(const struct dss_enum_unpack_io *io, int i)
+{
+	if (io->ui_iods_csums != NULL)
+		return &io->ui_iods_csums[i];
+	return NULL;
+}
+
 static int
 fill_recxs(daos_handle_t ih, vos_iter_entry_t *key_ent,
 	   struct dss_enum_arg *arg, vos_iter_type_t type)
@@ -137,56 +146,82 @@ fill_obj(daos_handle_t ih, vos_iter_entry_t *entry, struct dss_enum_arg *arg,
 	return 0;
 }
 
-static void
-iov_append(d_iov_t *iov, void *buf, uint64_t buf_len)
+static int
+iov_alloc_for_csum_info(d_iov_t *iov, struct dcs_csum_info *csum_info)
 {
-	D_ASSERT(iov->iov_len + buf_len <= iov->iov_buf_len);
-	memcpy(iov->iov_buf + iov->iov_len, buf, buf_len);
-	iov->iov_len += buf_len;
+	size_t size_needed = ci_size(*csum_info);
+
+	/** Make sure the csum buffer is big enough ... resize if needed */
+	if (iov->iov_buf == NULL) {
+		/** This must be freed by the object layer
+		 * (currently in obj_enum_complete)
+		 */
+		D_ALLOC(iov->iov_buf, size_needed);
+		if (iov->iov_buf == NULL)
+			return -DER_NOMEM;
+		iov->iov_buf_len = size_needed;
+		iov->iov_len = 0;
+	} else if (iov->iov_len + size_needed > iov->iov_buf_len) {
+		void	*p;
+		size_t	 new_size = max(iov->iov_buf_len * 2,
+					      iov->iov_len + size_needed);
+
+		D_REALLOC(p, iov->iov_buf, new_size);
+		if (p == NULL)
+			return -DER_NOMEM;
+		iov->iov_buf = p;
+		iov->iov_buf_len = new_size;
+	}
+
+	return 0;
 }
 
+/** Fill the arg.csum information and iov with what's in the entry */
 static int
-fill_csum(vos_iter_entry_t *key_ent, struct dss_enum_arg *arg)
+fill_data_csum(struct dcs_csum_info *src_csum_info, d_iov_t *csum_iov)
+{
+	int			 rc;
+
+	if (csum_iov  == NULL || !ci_is_valid(src_csum_info))
+		return 0;
+
+	rc = iov_alloc_for_csum_info(csum_iov, src_csum_info);
+	if (rc != 0)
+		return rc;
+	rc = ci_serialize(src_csum_info, csum_iov);
+	/** iov_alloc_for_csum_info should have allocated enough so this
+	 * would be a programmer error and want to know right away
+	 */
+	D_ASSERT(rc == 0);
+
+	return 0;
+}
+
+/**
+ * Key's don't have checksums stored so key_ent won't have a valid
+ * checksum and must rely on csummer to calculate a new one.
+ */
+static int
+fill_key_csum(vos_iter_entry_t *key_ent, struct dss_enum_arg *arg)
 {
 	struct daos_csummer	*csummer = arg->csummer;
 	d_iov_t			*csum_iov = &arg->csum_iov;
 	struct dcs_csum_info	*csum_info;
-	uint16_t		 csum_len;
 	int			 rc;
 
 	if (!daos_csummer_initialized(csummer))
 		return 0;
 
-	csum_len = daos_csummer_get_csum_len(csummer);
-	arg->kds[arg->kds_len].kd_csum_len = csum_len;
-	arg->kds[arg->kds_len].kd_csum_type = daos_csummer_get_type(csummer);
-
 	rc = daos_csummer_calc_key(csummer, &key_ent->ie_key, &csum_info);
 	if (rc != 0)
 		return rc;
 
-	/** Make sure the csum buffer is big enough ... resize if needed */
-	if (csum_iov->iov_buf == NULL) {
-		/** This must be freed by the object layer
-		 * (currently in obj_enum_complete)
-		 */
-		D_ALLOC(csum_iov->iov_buf, csum_len);
-		if (csum_iov->iov_buf == NULL)
-			return -DER_NOMEM;
-		csum_iov->iov_buf_len = csum_len;
-		csum_iov->iov_len = 0;
-	} else if (csum_iov->iov_len + csum_len > csum_iov->iov_buf_len) {
-		void *p;
-
-		D_REALLOC(p, csum_iov->iov_buf,
-			  csum_iov->iov_buf_len * 2);
-		if (p == NULL)
-			return -DER_NOMEM;
-		csum_iov->iov_buf = p;
-		csum_iov->iov_buf_len *= 2;
-	}
-
-	iov_append(csum_iov, csum_info->cs_csum, csum_info->cs_buf_len);
+	iov_alloc_for_csum_info(csum_iov, csum_info);
+	rc = ci_serialize(csum_info, csum_iov);
+	/** iov_alloc_for_csum_info should have allocated enough so this
+	 * would be a programmer error and want to know right away
+	 */
+	D_ASSERT(rc == 0);
 	daos_csummer_free_ci(csummer, &csum_info);
 
 	return 0;
@@ -238,18 +273,17 @@ fill_key(daos_handle_t ih, vos_iter_entry_t *key_ent, struct dss_enum_arg *arg,
 	D_ASSERT(arg->kds_len < arg->kds_cap);
 	arg->kds[arg->kds_len].kd_key_len = key_ent->ie_key.iov_len;
 	arg->kds[arg->kds_len].kd_val_type = type;
-	rc = fill_csum(key_ent, arg);
+	rc = fill_key_csum(key_ent, arg);
 	if (rc != 0)
 		return rc;
 	arg->kds_len++;
 
-	iov_append(iov, key_ent->ie_key.iov_buf, key_ent->ie_key.iov_len);
+	daos_iov_append(iov, key_ent->ie_key.iov_buf, key_ent->ie_key.iov_len);
 
 	if (key_ent->ie_punch != 0 && arg->need_punch) {
 		int pi_size = sizeof(key_ent->ie_punch);
 
 		arg->kds[arg->kds_len].kd_key_len = pi_size;
-		arg->kds[arg->kds_len].kd_csum_len = 0;
 		if (type == OBJ_ITER_AKEY)
 			arg->kds[arg->kds_len].kd_val_type =
 						OBJ_ITER_AKEY_EPOCH;
@@ -363,6 +397,8 @@ fill_rec(daos_handle_t ih, vos_iter_entry_t *key_ent, struct dss_enum_arg *arg,
 		}
 	}
 
+	fill_data_csum(&key_ent->ie_csum, &arg->csum_iov);
+
 	D_DEBUG(DB_IO, "Pack rec "DF_U64"/"DF_U64
 		" rsize "DF_U64" ver %u kd_len "DF_U64" type %d sgl_idx %d "
 		"kds_len %d inline "DF_U64" epr "DF_U64"/"DF_U64"\n",
@@ -465,11 +501,38 @@ enum {
 	UNPACK_COMPLETE_IOD = 2,	/* Only finish current IOD */
 };
 
+static int
+unpack_csum(d_iov_t *csum_iov, struct dcs_iod_csums *iod_csums)
+{
+	if (csum_iov != NULL) {
+		/** unpack csums */
+		struct dcs_csum_info *tmp_csum_info;
+
+		ci_cast(&tmp_csum_info, csum_iov);
+		ci_move_next_iov(tmp_csum_info, csum_iov);
+
+		iod_csums->ic_data[iod_csums->ic_nr] = *tmp_csum_info;
+		/** will be freed in clear_iod_csum() */
+		D_ALLOC(iod_csums->ic_data[iod_csums->ic_nr].cs_csum,
+			ci_csums_len(*tmp_csum_info));
+		if (iod_csums->ic_data[iod_csums->ic_nr].cs_csum == NULL)
+			return -DER_NOMEM;
+		memcpy(iod_csums->ic_data[iod_csums->ic_nr].cs_csum,
+		       tmp_csum_info->cs_csum, ci_csums_len(*tmp_csum_info));
+
+		iod_csums->ic_nr++;
+	}
+
+	return 0;
+}
+
 /* Parse recxs in <*data, len> and append them to iod and sgl. */
 static int
 unpack_recxs(daos_iod_t *iod, int *recxs_cap, daos_epoch_t *eph,
-	     d_sg_list_t *sgl, daos_key_t *akey, daos_key_desc_t *kds,
-	     void **data, daos_size_t len, uint32_t *version)
+	     d_sg_list_t *sgl, daos_key_t *akey,
+	     daos_key_desc_t *kds, void **data, daos_size_t len,
+	     d_iov_t *csum_iov, struct dcs_iod_csums *iod_csums,
+	     uint32_t *version)
 {
 	int rc = 0;
 	int type;
@@ -533,6 +596,16 @@ unpack_recxs(daos_iod_t *iod, int *recxs_cap, daos_epoch_t *eph,
 				if (rc != 0)
 					break;
 			}
+
+			/** will be freed with iod.recxs in clear_top_iod */
+			if (csum_iov != NULL) {
+				rc = grow_array((void **)&iod_csums->ic_data,
+						sizeof(*iod_csums->ic_data),
+						*recxs_cap, cap);
+				if (rc != 0)
+					break;
+			}
+
 			/* If we execute any of the three breaks above,
 			 * *recxs_cap will be < the real capacities of some of
 			 * the arrays. This is harmless, as it only causes the
@@ -572,6 +645,10 @@ unpack_recxs(daos_iod_t *iod, int *recxs_cap, daos_epoch_t *eph,
 			len -= iov->iov_len;
 		}
 
+		rc = unpack_csum(csum_iov, iod_csums);
+		if (rc != 0)
+			return rc;
+
 		D_DEBUG(DB_IO,
 			"unpacked data %p len "DF_U64" idx/nr "DF_U64"/"DF_U64
 			" ver %u eph "DF_U64" size %zd\n",
@@ -600,9 +677,9 @@ unpack_recxs(daos_iod_t *iod, int *recxs_cap, daos_epoch_t *eph,
  */
 static void
 dss_enum_unpack_io_init(struct dss_enum_unpack_io *io, daos_iod_t *iods,
-			int *recxs_caps, d_sg_list_t *sgls,
-			daos_epoch_t *akey_ephs, daos_epoch_t *rec_ephs,
-			int iods_cap)
+			struct dcs_iod_csums *iods_csums, int *recxs_caps,
+			d_sg_list_t *sgls, daos_epoch_t *akey_ephs,
+			daos_epoch_t *rec_ephs, int iods_cap)
 {
 	memset(io, 0, sizeof(*io));
 
@@ -612,6 +689,10 @@ dss_enum_unpack_io_init(struct dss_enum_unpack_io *io, daos_iod_t *iods,
 	D_ASSERT(iods != NULL);
 	memset(iods, 0, sizeof(*iods) * iods_cap);
 	io->ui_iods = iods;
+
+	D_ASSERT(iods_csums != NULL);
+	memset(iods_csums, 0, sizeof(*iods_csums) * iods_cap);
+	io->ui_iods_csums = iods_csums;
 
 	D_ASSERT(recxs_caps != NULL);
 	memset(recxs_caps, 0, sizeof(*recxs_caps) * iods_cap);
@@ -650,6 +731,20 @@ clear_iod(daos_iod_t *iod, d_sg_list_t *sgl, int *recxs_cap)
 
 	*recxs_cap = 0;
 }
+static void
+clear_iod_csum(struct dcs_iod_csums *iod_csum)
+{
+	int i;
+
+	if (iod_csum == NULL || iod_csum->ic_data == NULL)
+		return;
+
+	for (i = 0; i < iod_csum->ic_nr; i++)
+		if (iod_csum->ic_data[i].cs_csum != NULL)
+			D_FREE(iod_csum->ic_data->cs_csum);
+
+	D_FREE(iod_csum->ic_data);
+}
 
 /**
  * Clear the iods/sgls in \a io.
@@ -666,6 +761,7 @@ dss_enum_unpack_io_clear(struct dss_enum_unpack_io *io)
 
 		if (io->ui_sgls != NULL)
 			sgl = &io->ui_sgls[i];
+		clear_iod_csum(io_iod_csums(io, i));
 		clear_iod(&io->ui_iods[i], sgl, &io->ui_recxs_caps[i]);
 	}
 
@@ -681,7 +777,7 @@ dss_enum_unpack_io_clear(struct dss_enum_unpack_io *io)
 }
 
 /**
- * Finalize \a io. All iods/sgls must have already been cleard.
+ * Finalize \a io. All iods/sgls must have already been cleared.
  *
  * \param[in]	io	I/O descriptor
  */
@@ -706,6 +802,7 @@ clear_top_iod(struct dss_enum_unpack_io *io)
 		D_DEBUG(DB_IO, "iod without recxs: %d\n", idx);
 		if (io->ui_sgls != NULL)
 			sgl = &io->ui_sgls[idx];
+		clear_iod_csum(io_iod_csums(io, idx));
 		clear_iod(&io->ui_iods[idx], sgl, &io->ui_recxs_caps[idx]);
 		io->ui_iods_top--;
 	}
@@ -766,15 +863,26 @@ out:
  * Unpack dkey and akey
  */
 static int
-enum_unpack_key(daos_key_desc_t *kds, char *key_data,
-		struct dss_enum_unpack_io *io,
-		dss_enum_unpack_cb_t cb, void *cb_arg)
+enum_unpack_key(daos_key_desc_t *kds, char *key_data, d_iov_t *csum_iov,
+		struct dss_enum_unpack_io *io, dss_enum_unpack_cb_t cb,
+		void *cb_arg)
 {
 	daos_key_t	key;
 	int		rc = 0;
 
 	D_ASSERT(kds->kd_val_type == OBJ_ITER_DKEY ||
 		 kds->kd_val_type == OBJ_ITER_AKEY);
+
+	if (csum_iov != NULL) {
+		struct dcs_csum_info *csum_info;
+
+		/** keys aren't stored or needed by the I/O (they will have
+		 * already been verified at this point), so just move the iov
+		 * along.
+		 */
+		ci_cast(&csum_info, csum_iov);
+		ci_move_next_iov(csum_info, csum_iov);
+	}
 
 	key.iov_buf = key_data;
 	key.iov_buf_len = kds->kd_key_len;
@@ -850,8 +958,9 @@ enum_unpack_punched_ephs(daos_key_desc_t *kds, char *data,
 
 static int
 enum_unpack_recxs(daos_key_desc_t *kds, void *data,
-		  struct dss_enum_unpack_io *io,
-		  dss_enum_unpack_cb_t cb, void *cb_arg)
+		  struct dss_enum_unpack_io *io, d_iov_t *csum_iov,
+		  dss_enum_unpack_cb_t cb,
+		  void *cb_arg)
 {
 	daos_iod_t	*iod;
 	daos_key_t	iod_akey;
@@ -890,6 +999,7 @@ enum_unpack_recxs(daos_key_desc_t *kds, void *data,
 				  io->ui_sgls == NULL ?
 				  NULL : &io->ui_sgls[j], &iod_akey,
 				  kds, &ptr, len,
+				  csum_iov, &io->ui_iods_csums[j],
 				  &io->ui_version);
 		if (rc <= 0) /* normal case */
 			break;
@@ -969,10 +1079,13 @@ dss_enum_unpack(vos_iter_type_t vos_type, struct dss_enum_arg *arg,
 {
 	struct dss_enum_unpack_io	io;
 	daos_iod_t			iods[DSS_ENUM_UNPACK_MAX_IODS];
+	struct dcs_iod_csums		iods_csums[DSS_ENUM_UNPACK_MAX_IODS];
 	int				recxs_caps[DSS_ENUM_UNPACK_MAX_IODS];
 	d_sg_list_t			sgls[DSS_ENUM_UNPACK_MAX_IODS];
 	daos_epoch_t			ephs[DSS_ENUM_UNPACK_MAX_IODS];
 	daos_epoch_t			rec_ephs[DSS_ENUM_UNPACK_MAX_IODS];
+	/** Will be used to enum the csum data */
+	d_iov_t				csum_iov_iter;
 	void				*ptr;
 	unsigned int			i;
 	int				rc = 0;
@@ -992,7 +1105,7 @@ dss_enum_unpack(vos_iter_type_t vos_type, struct dss_enum_arg *arg,
 		return -DER_INVAL;
 	}
 
-	dss_enum_unpack_io_init(&io, iods, recxs_caps, sgls, ephs,
+	dss_enum_unpack_io_init(&io, iods, iods_csums, recxs_caps, sgls, ephs,
 				rec_ephs, DSS_ENUM_UNPACK_MAX_IODS);
 	if (type != OBJ_ITER_OBJ)
 		io.ui_oid = arg->oid;
@@ -1001,6 +1114,7 @@ dss_enum_unpack(vos_iter_type_t vos_type, struct dss_enum_arg *arg,
 	D_ASSERT(arg->sgl->sg_iovs != NULL);
 	ptr = arg->sgl->sg_iovs[0].iov_buf;
 
+	csum_iov_iter = arg->csum_iov;
 	for (i = 0; i < arg->kds_len; i++) {
 		daos_key_desc_t *kds = &arg->kds[i];
 
@@ -1011,16 +1125,18 @@ dss_enum_unpack(vos_iter_type_t vos_type, struct dss_enum_arg *arg,
 		D_ASSERT(kds->kd_key_len > 0);
 		switch (kds->kd_val_type) {
 		case OBJ_ITER_OBJ:
-			rc = enum_unpack_oid(&arg->kds[i], ptr, &io, cb,
-					     cb_arg);
+			rc = enum_unpack_oid(kds, ptr, &io, cb, cb_arg);
 			break;
 		case OBJ_ITER_DKEY:
 		case OBJ_ITER_AKEY:
-			rc = enum_unpack_key(kds, ptr, &io, cb, cb_arg);
+				rc = enum_unpack_key(kds, ptr,
+						     &csum_iov_iter, &io, cb,
+						     cb_arg);
 			break;
 		case OBJ_ITER_RECX:
 		case OBJ_ITER_SINGLE:
-			rc = enum_unpack_recxs(kds, ptr, &io, cb, cb_arg);
+			rc = enum_unpack_recxs(kds, ptr, &io,
+					       &csum_iov_iter, cb, cb_arg);
 			break;
 		case OBJ_ITER_DKEY_EPOCH:
 		case OBJ_ITER_AKEY_EPOCH:

--- a/src/object/cli_shard.c
+++ b/src/object/cli_shard.c
@@ -413,9 +413,13 @@ dc_rw_cb(tse_task_t *task, void *arg)
 				}
 			}
 		}
+		if (rc != 0)
+			goto out;
 
-		if (rc == 0)
-			rc = dc_rw_cb_csum_verify(rw_args);
+		rc = dc_rw_cb_csum_verify(rw_args);
+		if (rc != 0)
+			goto out;
+
 	}
 out:
 	crt_req_decref(rw_args->rpc);
@@ -737,17 +741,79 @@ struct obj_enum_args {
 	daos_recx_t		*eaa_recxs;
 	daos_size_t		*eaa_size;
 	unsigned int		*eaa_map_ver;
+	d_iov_t			*csum;
 };
 
-int csum_enum_verify_keys(const struct obj_enum_args *enum_args,
-			  const struct obj_key_enum_out *oeo)
+/**
+ * use iod/iod_csum as vehicle to verify data
+ */
+static int
+csum_enum_verify_recx(struct daos_csummer *csummer,
+		      struct obj_enum_rec *rec,
+		      struct dcs_csum_info *csum_info,
+		      d_iov_t *enum_type_val)
+{
+	daos_iod_t		 tmp_iod = {0};
+	d_sg_list_t		 tmp_sgl = {0};
+	struct dcs_iod_csums	 tmp_iod_csum = {0};
+
+	tmp_iod.iod_size = rec->rec_size;
+	tmp_iod.iod_type = DAOS_IOD_ARRAY;
+	tmp_iod.iod_recxs = &rec->rec_recx;
+	tmp_iod.iod_nr = 1;
+
+	tmp_sgl.sg_nr = tmp_sgl.sg_nr_out = 1;
+	tmp_sgl.sg_iovs = enum_type_val;
+
+	tmp_iod_csum.ic_nr = 1;
+	tmp_iod_csum.ic_data = csum_info;
+
+	return daos_csummer_verify_iod(csummer,
+				       &tmp_iod, &tmp_sgl, &tmp_iod_csum,
+				       NULL, 0, NULL);
+}
+
+/**
+ * use iod/iod_csum as vehicle to verify data
+ */
+static int
+csum_enum_verify_sv(struct daos_csummer *csummer,
+		 d_iov_t *enum_type_val, d_iov_t *csum_iov)
+{
+	daos_iod_t		 tmp_iod = {0};
+	d_sg_list_t		 tmp_sgl = {0};
+	struct dcs_iod_csums	 tmp_iod_csum = {0};
+	struct dcs_csum_info	*tmp_csum_info = {0};
+
+	tmp_iod.iod_size = enum_type_val->iov_len;
+	tmp_iod.iod_type = DAOS_IOD_SINGLE;
+	tmp_iod.iod_nr = 1;
+
+	tmp_sgl.sg_nr = tmp_sgl.sg_nr_out = 1;
+	tmp_sgl.sg_iovs = enum_type_val;
+
+	ci_cast(&tmp_csum_info, csum_iov);
+	ci_move_next_iov(tmp_csum_info, csum_iov);
+
+	tmp_iod_csum.ic_nr = 1;
+	tmp_iod_csum.ic_data = tmp_csum_info;
+
+	return daos_csummer_verify_iod(csummer,
+				       &tmp_iod, &tmp_sgl, &tmp_iod_csum,
+				       NULL, 0, NULL);
+}
+
+static int
+csum_enum_verify(const struct obj_enum_args *enum_args,
+		 const struct obj_key_enum_out *oeo)
 {
 	struct daos_csummer	*csummer;
-	uint8_t			*csum_ptr;
 	uint64_t		 i;
 	int			 rc = 0;
 	struct daos_sgl_idx	 sgl_idx = {0};
 	d_sg_list_t		 sgl = oeo->oeo_sgl;
+	d_iov_t			 csum_iov = oeo->oeo_csum_iov;
+	struct dcs_csum_info	 *tmp = NULL;
 
 	if (enum_args->eaa_nr == NULL ||
 	    *enum_args->eaa_nr == 0 ||
@@ -758,51 +824,76 @@ int csum_enum_verify_keys(const struct obj_enum_args *enum_args,
 	if (!daos_csummer_initialized(csummer))
 		return 0; /** csums not enabled */
 
-	csum_ptr = oeo->oeo_csum_iov.iov_buf;
-	if (csum_ptr == NULL) {
-		D_ERROR("CSUM is enabled but key checksum not set.");
+	if (csum_iov.iov_len == 0) {
+		D_ERROR("CSUM is enabled but no  checksum provided.");
 		return -DER_CSUM;
 	}
 
 	for (i = 0; i < *enum_args->eaa_nr; i++) {
 		daos_key_desc_t		*kd = &enum_args->eaa_kds[i];
-		void			*key_buf;
-		d_iov_t			 key_iov;
-		struct dcs_csum_info	 csum_info;
+		void			*buf;
+		d_iov_t			 enum_type_val;
 		d_iov_t			 iov = sgl.sg_iovs[sgl_idx.iov_idx];
 
-		if (kd->kd_csum_len != daos_csummer_get_csum_len(csummer)) {
-			D_ERROR("Key descriptor CSUM length doesn't match "
-				"configured CSUM type's length");
-			return -DER_CSUM;
+		buf = iov.iov_buf + sgl_idx.iov_offset;
 
+		switch (kd->kd_val_type) {
+		case OBJ_ITER_RECX: {
+			struct obj_enum_rec *rec = buf;
+
+			/**
+			 * Even if don't use csum info at this point because
+			 * the data isn't inline, still need to move to next
+			 */
+			ci_cast(&tmp, &csum_iov);
+			ci_move_next_iov(tmp, &csum_iov);
+
+			if (rec->rec_flags & RECX_INLINE) {
+				buf += sizeof(*rec);
+				d_iov_set(&enum_type_val, buf,
+					  rec->rec_size * rec->rec_recx.rx_nr);
+				rc = csum_enum_verify_recx(csummer, rec, tmp,
+							   &enum_type_val);
+				if (rc != 0)
+					return rc;
+			}
+			break;
 		}
-		if (kd->kd_csum_type != daos_csummer_get_type(csummer)) {
-			D_ERROR("Key descriptor CSUM type doesn't match "
-				"configured CSUM type");
-			return -DER_CSUM;
+		case OBJ_ITER_SINGLE: {
+			d_iov_set(&enum_type_val, buf, kd->kd_key_len);
+
+			ci_cast(&tmp, &csum_iov);
+			ci_move_next_iov(tmp, &csum_iov);
+
+			rc = csum_enum_verify_sv(csummer,
+						 &enum_type_val, &csum_iov);
+
+			if (rc != 0)
+				return rc;
+			break;
+		}
+		case OBJ_ITER_AKEY:
+		case OBJ_ITER_DKEY:
+			d_iov_set(&enum_type_val, buf, kd->kd_key_len);
+			/**
+			  * fault injection - corrupt keys before verifying -
+			  * simulates corruption over network
+			  */
+			if (DAOS_FAIL_CHECK(DAOS_CSUM_CORRUPT_FETCH_AKEY) ||
+			    DAOS_FAIL_CHECK(DAOS_CSUM_CORRUPT_FETCH_DKEY))
+				((uint8_t *)buf)[0] += 2;
+
+			ci_cast(&tmp, &csum_iov);
+			ci_move_next_iov(tmp, &csum_iov);
+
+			rc = daos_csummer_verify_key(csummer,
+						     &enum_type_val, tmp);
+
+			if (rc != 0)
+				return rc;
+			break;
 		}
 
-		key_buf = iov.iov_buf + sgl_idx.iov_offset;
-
-		ci_set(&csum_info, csum_ptr, kd->kd_csum_len,
-		       kd->kd_csum_len, 1, CSUM_NO_CHUNK, kd->kd_csum_type);
-		d_iov_set(&key_iov, key_buf, kd->kd_key_len);
-
-		/**
-		 * fault injection - corrupt keys before verifying - simulates
-		 * corruption over network
-		 */
-		if (DAOS_FAIL_CHECK(DAOS_CSUM_CORRUPT_FETCH_AKEY) ||
-		    DAOS_FAIL_CHECK(DAOS_CSUM_CORRUPT_FETCH_DKEY))
-			((uint8_t *)key_buf)[0] += 2;
-		rc = daos_csummer_verify_key(csummer, &key_iov, &csum_info);
-		if (rc != 0) {
-			D_ERROR("daos_csummer_verify_key error: %d", rc);
-			return rc;
-		}
-
-		csum_ptr += kd->kd_csum_len;
 		sgl_idx.iov_offset += kd->kd_key_len;
 
 		/** move to next iov if necessary */
@@ -812,6 +903,23 @@ int csum_enum_verify_keys(const struct obj_enum_args *enum_args,
 		}
 	}
 	return rc;
+}
+
+/**
+ * If requested (dst iov is set) and there is csum info to copy, copy the
+ * serialized csum. If not all of it will fit into the provided buffer, copy
+ * what can and set the destination iov len to needed len and let caller
+ * decide what to do.
+ */
+static void
+dc_enumerate_copy_csum(d_iov_t *dst, const d_iov_t *src)
+{
+	if (dst != NULL && src->iov_len > 0) {
+		memcpy(dst->iov_buf, src->iov_buf,
+		       min(dst->iov_buf_len,
+			   src->iov_len));
+		dst->iov_len = src->iov_len;
+	}
 }
 
 static int
@@ -837,6 +945,9 @@ dc_enumerate_cb(tse_task_t *task, void *arg)
 
 	oeo = crt_reply_get(enum_args->rpc);
 	rc = obj_reply_get_status(enum_args->rpc);
+
+	dc_enumerate_copy_csum(enum_args->csum, &oeo->oeo_csum_iov);
+
 	if (rc != 0) {
 		if (rc == -DER_KEY2BIG) {
 			D_DEBUG(DB_IO, "key size "DF_U64" too big.\n",
@@ -894,7 +1005,7 @@ dc_enumerate_cb(tse_task_t *task, void *arg)
 	if (enum_args->eaa_anchor)
 		enum_anchor_copy(enum_args->eaa_anchor,
 				 &oeo->oeo_anchor);
-	rc = csum_enum_verify_keys(enum_args, oeo);
+	rc = csum_enum_verify(enum_args, oeo);
 	if (rc != 0)
 		D_GOTO(out, rc);
 
@@ -1030,6 +1141,7 @@ dc_obj_shard_list(struct dc_obj_shard *obj_shard, enum obj_rpc_opc opc,
 	enum_args.eaa_obj = obj_shard;
 	enum_args.eaa_size = obj_args->size;
 	enum_args.eaa_sgl = sgl;
+	enum_args.csum = obj_args->csum;
 	enum_args.eaa_map_ver = &args->la_auxi.map_ver;
 	enum_args.eaa_recxs = obj_args->recxs;
 	rc = tse_task_register_comp_cb(task, dc_enumerate_cb, &enum_args,

--- a/src/object/obj_rpc.c
+++ b/src/object/obj_rpc.c
@@ -61,14 +61,6 @@ crt_proc_daos_key_desc_t(crt_proc_t proc, daos_key_desc_t *key)
 	if (rc != 0)
 		return -DER_HG;
 
-	rc = crt_proc_uint16_t(proc, &key->kd_csum_type);
-	if (rc != 0)
-		return -DER_HG;
-
-	rc = crt_proc_uint16_t(proc, &key->kd_csum_len);
-	if (rc != 0)
-		return -DER_HG;
-
 	return 0;
 }
 

--- a/src/object/obj_task.c
+++ b/src/object/obj_task.c
@@ -371,15 +371,14 @@ dc_obj_list_recx_task_create(daos_handle_t oh, daos_handle_t th,
 
 int
 dc_obj_list_obj_task_create(daos_handle_t oh, daos_handle_t th,
-			    daos_epoch_range_t *epr,
-			    daos_key_t *dkey, daos_key_t *akey,
-			    daos_size_t *size, uint32_t *nr,
-			    daos_key_desc_t *kds,
+			    daos_epoch_range_t *epr, daos_key_t *dkey,
+			    daos_key_t *akey, daos_size_t *size,
+			    uint32_t *nr, daos_key_desc_t *kds,
 			    d_sg_list_t *sgl, daos_anchor_t *anchor,
 			    daos_anchor_t *dkey_anchor,
-			    daos_anchor_t *akey_anchor,
-			    bool incr_order, daos_event_t *ev, tse_sched_t *tse,
-			    tse_task_t **task)
+			    daos_anchor_t *akey_anchor, bool incr_order,
+			    daos_event_t *ev, tse_sched_t *tse,
+			    d_iov_t *csum, tse_task_t **task)
 {
 	daos_obj_list_obj_t	*args;
 	int			rc;
@@ -402,6 +401,7 @@ dc_obj_list_obj_task_create(daos_handle_t oh, daos_handle_t th,
 	args->dkey_anchor = dkey_anchor;
 	args->akey_anchor = akey_anchor;
 	args->incr_order = incr_order;
+	args->csum	= csum;
 
 	return 0;
 }

--- a/src/object/obj_verify.c
+++ b/src/object/obj_verify.c
@@ -65,7 +65,7 @@ again:
 					 &dova->size, &dova->num, dova->kds,
 					 &dova->list_sgl, &dova->anchor,
 					 &dova->dkey_anchor, &dova->akey_anchor,
-					 true, NULL, NULL, &task);
+					 true, NULL, NULL, NULL, &task);
 	if (rc != 0)
 		return rc;
 

--- a/src/object/srv_cli.c
+++ b/src/object/srv_cli.c
@@ -175,7 +175,8 @@ int
 dsc_obj_list_obj(daos_handle_t oh, daos_epoch_range_t *epr, daos_key_t *dkey,
 		 daos_key_t *akey, daos_size_t *size, uint32_t *nr,
 		 daos_key_desc_t *kds, d_sg_list_t *sgl, daos_anchor_t *anchor,
-		 daos_anchor_t *dkey_anchor, daos_anchor_t *akey_anchor)
+		 daos_anchor_t *dkey_anchor, daos_anchor_t *akey_anchor,
+		 d_iov_t *csum)
 {
 	tse_task_t	*task;
 	daos_handle_t	coh, th;
@@ -189,7 +190,7 @@ dsc_obj_list_obj(daos_handle_t oh, daos_epoch_range_t *epr, daos_key_t *dkey,
 	rc = dc_obj_list_obj_task_create(oh, th, epr, dkey, akey, size, nr,
 					 kds, sgl, anchor, dkey_anchor,
 					 akey_anchor, true, NULL,
-					 dsc_scheduler(), &task);
+					 dsc_scheduler(), csum, &task);
 	if (rc)
 		return rc;
 

--- a/src/object/srv_obj_migrate.c
+++ b/src/object/srv_obj_migrate.c
@@ -46,25 +46,27 @@ int ds_cont_tgt_destroy(uuid_t pool_uuid, uuid_t cont_uuid);
 #if D_HAS_WARNING(4, "-Wframe-larger-than=")
 	#pragma GCC diagnostic ignored "-Wframe-larger-than="
 #endif
+
 struct migrate_one {
-	daos_key_t	mo_dkey;
-	uuid_t		mo_pool_uuid;
-	uuid_t		mo_cont_uuid;
-	daos_unit_oid_t	mo_oid;
-	daos_epoch_t	mo_dkey_punch_eph;
-	daos_epoch_t	mo_epoch;
-	daos_iod_t	*mo_iods;
-	daos_iod_t	*mo_punch_iods;
-	daos_epoch_t	*mo_akey_punch_ephs;
-	daos_epoch_t	mo_rec_punch_eph;
-	d_sg_list_t	*mo_sgls;
-	unsigned int	mo_iod_num;
-	unsigned int	mo_punch_iod_num;
-	unsigned int	mo_iod_alloc_num;
-	unsigned int	mo_rec_num;
-	uint64_t	mo_size;
-	uint64_t	mo_version;
-	uint32_t	mo_pool_tls_version;
+	daos_key_t		 mo_dkey;
+	uuid_t			 mo_pool_uuid;
+	uuid_t			 mo_cont_uuid;
+	daos_unit_oid_t		 mo_oid;
+	daos_epoch_t		 mo_dkey_punch_eph;
+	daos_epoch_t		 mo_epoch;
+	daos_iod_t		*mo_iods;
+	struct dcs_iod_csums	*mo_iods_csums;
+	daos_iod_t		*mo_punch_iods;
+	daos_epoch_t		*mo_akey_punch_ephs;
+	daos_epoch_t		 mo_rec_punch_eph;
+	d_sg_list_t		*mo_sgls;
+	unsigned int		 mo_iod_num;
+	unsigned int		 mo_punch_iod_num;
+	unsigned int		 mo_iod_alloc_num;
+	unsigned int		 mo_rec_num;
+	uint64_t		 mo_size;
+	uint64_t		 mo_version;
+	uint32_t		 mo_pool_tls_version;
 };
 
 struct migrate_obj_key {
@@ -478,14 +480,15 @@ static int
 migrate_fetch_update_inline(struct migrate_one *mrone, daos_handle_t oh,
 			    struct ds_cont_child *ds_cont)
 {
-	d_sg_list_t	sgls[DSS_ENUM_UNPACK_MAX_IODS];
-	d_iov_t	iov[DSS_ENUM_UNPACK_MAX_IODS];
-	int		iod_cnt = 0;
-	int		start;
-	char		iov_buf[DSS_ENUM_UNPACK_MAX_IODS][MAX_BUF_SIZE];
-	bool		fetch = false;
-	int		i;
-	int		rc = 0;
+	d_sg_list_t		 sgls[DSS_ENUM_UNPACK_MAX_IODS];
+	d_iov_t			 iov[DSS_ENUM_UNPACK_MAX_IODS];
+	struct dcs_iod_csums	*iod_csums;
+	int			 iod_cnt = 0;
+	int			 start;
+	char			 iov_buf[DSS_ENUM_UNPACK_MAX_IODS][MAX_BUF_SIZE];
+	bool			 fetch = false;
+	int			 i;
+	int			 rc = 0;
 
 	D_ASSERT(mrone->mo_iod_num <= DSS_ENUM_UNPACK_MAX_IODS);
 	for (i = 0; i < mrone->mo_iod_num; i++) {
@@ -535,12 +538,14 @@ migrate_fetch_update_inline(struct migrate_one *mrone, daos_handle_t oh,
 				continue;
 			}
 
+			iod_csums = mrone->mo_iods_csums == NULL ? NULL
+					: &mrone->mo_iods_csums[start];
 			D_DEBUG(DB_TRACE, "update start %d cnt %d\n",
 				start, iod_cnt);
 			rc = vos_obj_update(ds_cont->sc_hdl, mrone->mo_oid,
 					    mrone->mo_epoch, mrone->mo_version,
 					    0, &mrone->mo_dkey, iod_cnt,
-					    &mrone->mo_iods[start], NULL,
+					    &mrone->mo_iods[start], iod_csums,
 					    &sgls[start]);
 			if (rc) {
 				D_ERROR("migrate failed: rc %d\n", rc);
@@ -551,12 +556,15 @@ migrate_fetch_update_inline(struct migrate_one *mrone, daos_handle_t oh,
 		}
 	}
 
-	if (iod_cnt > 0)
+	if (iod_cnt > 0) {
+		iod_csums = mrone->mo_iods_csums == NULL ? NULL
+				: &mrone->mo_iods_csums[start];
 		rc = vos_obj_update(ds_cont->sc_hdl, mrone->mo_oid,
 				    mrone->mo_epoch, mrone->mo_version,
 				    0, &mrone->mo_dkey, iod_cnt,
-				    &mrone->mo_iods[start], NULL,
+				    &mrone->mo_iods[start], iod_csums,
 				    &sgls[start]);
+	}
 
 	return rc;
 }
@@ -572,7 +580,7 @@ migrate_fetch_update_bulk(struct migrate_one *mrone, daos_handle_t oh,
 	D_ASSERT(mrone->mo_iod_num <= DSS_ENUM_UNPACK_MAX_IODS);
 	rc = vos_update_begin(ds_cont->sc_hdl, mrone->mo_oid, mrone->mo_epoch,
 			      0, &mrone->mo_dkey, mrone->mo_iod_num,
-			      mrone->mo_iods, NULL, &ioh, NULL);
+			      mrone->mo_iods, mrone->mo_iods_csums, &ioh, NULL);
 	if (rc != 0) {
 		D_ERROR(DF_UOID"preparing update fails: %d\n",
 			DP_UOID(mrone->mo_oid), rc);
@@ -785,6 +793,19 @@ migrate_one_destroy(struct migrate_one *mrone)
 		D_FREE(mrone->mo_sgls);
 	}
 
+	if (mrone->mo_iods_csums) {
+		struct dcs_iod_csums	*iod_csum;
+		int			 j;
+
+		for (i = 0; i < mrone->mo_iod_alloc_num; i++) {
+			iod_csum = &mrone->mo_iods_csums[i];
+			for (j = 0; j < iod_csum->ic_nr; j++)
+				D_FREE(iod_csum->ic_data[j].cs_csum);
+			D_FREE(iod_csum->ic_data);
+		}
+		D_FREE(mrone->mo_iods_csums);
+	}
+
 	D_FREE(mrone);
 }
 
@@ -914,9 +935,11 @@ punch_iod_pack(struct migrate_one *mrone, daos_iod_t *iod, daos_epoch_t eph)
  */
 static int
 migrate_one_queue(struct iter_obj_arg *iter_arg, daos_epoch_t epoch,
-		  daos_unit_oid_t *oid, daos_key_t *dkey, daos_epoch_t dkey_eph,
-		  daos_iod_t *iods, daos_epoch_t *akey_ephs,
-		  daos_epoch_t *rec_ephs, int iod_eph_total, d_sg_list_t *sgls,
+		  daos_unit_oid_t *oid, daos_key_t *dkey,
+		  daos_epoch_t dkey_eph, daos_iod_t *iods,
+		  struct dcs_iod_csums *iods_csums,
+		  daos_epoch_t *akey_ephs, daos_epoch_t *rec_ephs,
+		  int iod_eph_total, d_sg_list_t *sgls,
 		  uint32_t version)
 {
 	struct migrate_pool_tls *tls;
@@ -944,6 +967,10 @@ migrate_one_queue(struct iter_obj_arg *iter_arg, daos_epoch_t epoch,
 
 	D_ALLOC_ARRAY(mrone->mo_iods, iod_eph_total);
 	if (mrone->mo_iods == NULL)
+		D_GOTO(free, rc = -DER_NOMEM);
+
+	D_ALLOC_ARRAY(mrone->mo_iods_csums, iod_eph_total);
+	if (mrone->mo_iods_csums == NULL)
 		D_GOTO(free, rc = -DER_NOMEM);
 
 	mrone->mo_epoch = epoch;
@@ -990,6 +1017,16 @@ migrate_one_queue(struct iter_obj_arg *iter_arg, daos_epoch_t epoch,
 		else
 			rc = rw_iod_pack(mrone, &iods[i],
 					 inline_copy ? &sgls[i] : NULL);
+
+		if (rc != 0)
+			return rc;
+
+		mrone->mo_iods_csums[i] = iods_csums[i];
+		/**
+		 * mrone owns the allocated memory now and will free it in
+		 * migrate_one_destroy
+		 */
+		iods_csums[i].ic_data = NULL;
 	}
 
 	mrone->mo_version = version;
@@ -1035,7 +1072,8 @@ migrate_enum_unpack_cb(struct dss_enum_unpack_io *io, void *data)
 
 	return migrate_one_queue(arg->arg, arg->epr.epr_hi, &io->ui_oid,
 				 &io->ui_dkey, io->ui_dkey_punch_eph,
-				 io->ui_iods, io->ui_akey_punch_ephs,
+				 io->ui_iods, io->ui_iods_csums,
+				 io->ui_akey_punch_ephs,
 				 io->ui_rec_punch_ephs,
 				 io->ui_iods_top + 1, io->ui_sgls,
 				 io->ui_version);
@@ -1068,7 +1106,8 @@ migrate_obj_punch_one(void *data)
 }
 
 #define KDS_NUM		16
-#define ITER_BUF_SIZE   2048
+#define ITER_BUF_SIZE	2048
+#define CSUM_BUF_SIZE	256
 
 /**
  * Iterate akeys/dkeys of the object
@@ -1077,20 +1116,22 @@ static int
 migrate_one_epoch_object(daos_handle_t oh, daos_epoch_range_t *epr,
 			 struct migrate_pool_tls *tls, struct iter_obj_arg *arg)
 {
-	daos_anchor_t	anchor;
-	daos_anchor_t	dkey_anchor;
-	daos_anchor_t	akey_anchor;
-	char		stack_buf[ITER_BUF_SIZE];
-	char		*buf = NULL;
-	daos_size_t	buf_len;
-	daos_key_desc_t		kds[KDS_NUM] = { 0 };
-	struct dss_enum_arg	enum_arg = { 0 };
-	struct enum_unpack_arg unpack_arg = { 0 };
-	d_iov_t		iov = { 0 };
-	d_sg_list_t	sgl = { 0 };
-	uint32_t	num;
-	daos_size_t	size;
-	int		rc = 0;
+	daos_anchor_t		 anchor;
+	daos_anchor_t		 dkey_anchor;
+	daos_anchor_t		 akey_anchor;
+	char			 stack_buf[ITER_BUF_SIZE] = {0};
+	char			*buf = NULL;
+	daos_size_t		 buf_len;
+	daos_key_desc_t		 kds[KDS_NUM] = {0};
+	d_iov_t			 csum = {0};
+	uint8_t			 stack_csum_buf[CSUM_BUF_SIZE] = {0};
+	struct dss_enum_arg	 enum_arg = { 0 };
+	struct enum_unpack_arg	 unpack_arg = { 0 };
+	d_iov_t			 iov = { 0 };
+	d_sg_list_t		 sgl = { 0 };
+	uint32_t		 num;
+	daos_size_t		 size;
+	int			 rc = 0;
 
 	D_DEBUG(DB_TRACE, "migrate obj "DF_UOID" for shard %u eph "
 		DF_U64"-"DF_U64"\n", DP_UOID(arg->oid), arg->shard, epr->epr_lo,
@@ -1107,6 +1148,9 @@ migrate_one_epoch_object(daos_handle_t oh, daos_epoch_range_t *epr,
 	unpack_arg.epr = *epr;
 	buf = stack_buf;
 	buf_len = ITER_BUF_SIZE;
+
+	d_iov_set(&csum, stack_csum_buf, CSUM_BUF_SIZE);
+
 	while (!tls->mpt_fini) {
 		memset(buf, 0, buf_len);
 		iov.iov_len = 0;
@@ -1117,10 +1161,13 @@ migrate_one_epoch_object(daos_handle_t oh, daos_epoch_range_t *epr,
 		sgl.sg_nr_out = 1;
 		sgl.sg_iovs = &iov;
 
+		csum.iov_len = 0;
+
 		num = KDS_NUM;
 		rc = dsc_obj_list_obj(oh, epr, NULL, NULL, &size,
 				     &num, kds, &sgl, &anchor,
-				     &dkey_anchor, &akey_anchor);
+				     &dkey_anchor, &akey_anchor, &csum);
+
 		if (rc == -DER_KEY2BIG) {
 			D_DEBUG(DB_TRACE, "migrate obj "DF_UOID" got "
 				"-DER_KEY2BIG, key_len "DF_U64"\n",
@@ -1141,6 +1188,21 @@ migrate_one_epoch_object(daos_handle_t oh, daos_epoch_range_t *epr,
 			 */
 			rc = (rc == -DER_NONEXIST) ? 0 : rc;
 			break;
+		} else if (csum.iov_len > csum.iov_buf_len) {
+			D_DEBUG(DB_TRACE, "migrate obj csum buf "
+					  "not large enough. Increase and try "
+					  "again");
+			if (csum.iov_buf != stack_csum_buf)
+				D_FREE(csum.iov_buf);
+
+			csum.iov_buf_len = csum.iov_len;
+			csum.iov_len = 0;
+			D_ALLOC(csum.iov_buf, csum.iov_buf_len);
+			if (csum.iov_buf == NULL) {
+				rc = -DER_NOMEM;
+				break;
+			}
+			continue;
 		}
 		if (num == 0)
 			break;
@@ -1154,6 +1216,7 @@ migrate_one_epoch_object(daos_handle_t oh, daos_epoch_range_t *epr,
 		enum_arg.sgl = &sgl;
 		enum_arg.sgl_idx = 1;
 		enum_arg.chk_key2big = true;
+		enum_arg.csum_iov = csum;
 		rc = dss_enum_unpack(VOS_ITER_DKEY, &enum_arg,
 				     migrate_enum_unpack_cb, &unpack_arg);
 		if (rc) {
@@ -1168,6 +1231,9 @@ migrate_one_epoch_object(daos_handle_t oh, daos_epoch_range_t *epr,
 
 	if (buf != NULL && buf != stack_buf)
 		D_FREE(buf);
+
+	if (csum.iov_buf != NULL && csum.iov_buf != stack_csum_buf)
+		D_FREE(csum.iov_buf);
 
 	D_DEBUG(DB_TRACE, "obj "DF_UOID" for shard %u eph "
 		DF_U64"-"DF_U64": rc %d\n", DP_UOID(arg->oid), arg->shard,

--- a/src/tests/suite/daos_checksum.c
+++ b/src/tests/suite/daos_checksum.c
@@ -27,6 +27,12 @@
 #include <daos/checksum.h>
 #include <gurt/types.h>
 #include <daos_prop.h>
+#include <daos/task.h>
+#include <daos/event.h>
+#include <daos/container.h>
+
+static void
+iov_update_fill(d_iov_t *iov, char *data, uint64_t len_to_fill);
 
 #define assert_success(r) do {\
 	int __rc = (r); \
@@ -180,26 +186,33 @@ setup_cont_obj(struct csum_test_ctx *ctx, int csum_prop_type, bool csum_sv,
 
 	rc = daos_cont_create(ctx->poh, ctx->uuid, props, NULL);
 	daos_prop_free(props);
-	assert_int_equal(0, rc);
+	assert_success(rc);
 
 	rc = daos_cont_open(ctx->poh, ctx->uuid, DAOS_COO_RW,
 			    &ctx->coh, &ctx->info, NULL);
-	assert_int_equal(0, rc);
+	assert_success(rc);
 
-	ctx->oid = dts_oid_gen(oclass, 0, 1);
+	ctx->oid.lo = 1;
+	ctx->oid.hi =  100;
+	daos_obj_generate_id(&ctx->oid, 0, oclass, 0);
 	rc = daos_obj_open(ctx->coh, ctx->oid, 0, &ctx->oh, NULL);
-	assert_int_equal(0, rc);
+	assert_success(rc);
 }
 
 static void
-setup_simple_data(struct csum_test_ctx *ctx)
+setup_single_recx_data(struct csum_test_ctx *ctx, char *seed_data,
+		       daos_size_t data_bytes)
 {
-	dts_sgl_init_with_strings(&ctx->update_sgl, 1, "0123456789");
-	/** just need to make the buffers the same size */
-	dts_sgl_init_with_strings(&ctx->fetch_sgl, 1, "0000000000");
-
 	iov_alloc_str(&ctx->dkey, "dkey");
 	iov_alloc_str(&ctx->update_iod.iod_name, "akey");
+
+	daos_sgl_init(&ctx->update_sgl, 1);
+	iov_alloc(&ctx->update_sgl.sg_iovs[0], data_bytes);
+	iov_update_fill(ctx->update_sgl.sg_iovs, seed_data, data_bytes);
+
+	daos_sgl_init(&ctx->fetch_sgl, 1);
+	iov_alloc(&ctx->fetch_sgl.sg_iovs[0], data_bytes);
+
 	ctx->recx[0].rx_idx = 0;
 	ctx->recx[0].rx_nr = daos_sgl_buf_size(&ctx->update_sgl);
 	ctx->update_iod.iod_size = 1;
@@ -213,6 +226,37 @@ setup_simple_data(struct csum_test_ctx *ctx)
 	ctx->fetch_iod.iod_recxs = ctx->update_iod.iod_recxs;
 	ctx->fetch_iod.iod_nr = ctx->update_iod.iod_nr;
 	ctx->fetch_iod.iod_type = ctx->update_iod.iod_type;
+}
+static void
+setup_single_value_data(struct csum_test_ctx *ctx, char *seed_data,
+		       daos_size_t data_bytes)
+{
+	iov_alloc_str(&ctx->dkey, "dkey");
+	iov_alloc_str(&ctx->update_iod.iod_name, "akey");
+
+	daos_sgl_init(&ctx->update_sgl, 1);
+	iov_alloc(&ctx->update_sgl.sg_iovs[0], data_bytes);
+	iov_update_fill(ctx->update_sgl.sg_iovs, seed_data, data_bytes);
+
+	daos_sgl_init(&ctx->fetch_sgl, 1);
+	iov_alloc(&ctx->fetch_sgl.sg_iovs[0], data_bytes);
+
+	ctx->update_iod.iod_size = daos_sgl_buf_size(&ctx->update_sgl);
+	ctx->update_iod.iod_nr	= 1;
+	ctx->update_iod.iod_type  = DAOS_IOD_SINGLE;
+
+	/** Setup Fetch IOD*/
+	ctx->fetch_iod.iod_name = ctx->update_iod.iod_name;
+	ctx->fetch_iod.iod_size = ctx->update_iod.iod_size;
+	ctx->fetch_iod.iod_recxs = ctx->update_iod.iod_recxs;
+	ctx->fetch_iod.iod_nr = ctx->update_iod.iod_nr;
+	ctx->fetch_iod.iod_type = ctx->update_iod.iod_type;
+}
+
+static void
+setup_simple_data(struct csum_test_ctx *ctx)
+{
+	setup_single_recx_data(ctx, "0123456789", strlen("0123456789") + 1);
 }
 
 /**
@@ -403,7 +447,7 @@ test_server_data_corruption(void **state)
 	int			 rc;
 
 	setup_from_test_args(&ctx, *state);
-	setup_cont_obj(&ctx, DAOS_PROP_CO_CSUM_CRC64, false, 1024*8, oc);
+	setup_cont_obj(&ctx, DAOS_PROP_CO_CSUM_CRC64, false, 1024 * 8, oc);
 
 	/**1. Simple server data corruption after RDMA */
 	setup_multiple_extent_data(&ctx);
@@ -437,7 +481,7 @@ test_fetch_array(void **state)
 	 */
 	setup_from_test_args(&ctx, (test_arg_t *) *state);
 
-	setup_cont_obj(&ctx, DAOS_PROP_CO_CSUM_CRC64, false, 1024*8, oc);
+	setup_cont_obj(&ctx, DAOS_PROP_CO_CSUM_CRC64, false, 1024 * 8, oc);
 
 	/**
 	 * Act
@@ -500,7 +544,7 @@ test_fetch_array(void **state)
 		/** 5. Replicated object with corruption */
 		cleanup_cont_obj(&ctx);
 		setup_cont_obj(&ctx, DAOS_PROP_CO_CSUM_CRC64, false,
-			       1024*8, OC_RP_2GX);
+			       1024 * 8, OC_RP_2GX);
 		rc = daos_obj_update(ctx.oh, DAOS_TX_NONE, 0, &ctx.dkey, 1,
 				     &ctx.update_iod, &ctx.update_sgl, NULL);
 		assert_int_equal(rc, 0);
@@ -664,7 +708,7 @@ array_update_fetch_testcase(char *file, int line, test_arg_t *test_arg,
 
 	/** Setup Update IOD */
 	ctx.update_iod.iod_size = rec_size;
-	/** These thest cases always use 1 recx at a time */
+	/** These test cases always use 1 recx at a time */
 	ctx.update_iod.iod_nr	= 1;
 	ctx.update_iod.iod_recxs = ctx.recx;
 	ctx.update_iod.iod_type  = DAOS_IOD_ARRAY;
@@ -1357,6 +1401,177 @@ many_iovs_with_single_values(void **state)
 	assert_int_equal(0, rc);
 }
 
+static bool
+rank_in_placement(uint32_t rank, struct daos_obj_layout *placement)
+{
+	int s, r;
+
+	for (s = 0; s < placement->ol_nr; s++) {
+		for (r = 0; r < placement->ol_shards[s]->os_replica_nr; r++) {
+			if (rank == placement->ol_shards[s]->os_ranks[r])
+				return true;
+		}
+	}
+	return false;
+}
+
+static int
+get_rank_not_in_placement(struct daos_obj_layout *placement,
+				   struct daos_obj_layout *not_in_placement)
+{
+	int s, r;
+
+	for (s = 0; s < placement->ol_nr; s++) {
+		struct daos_obj_shard *shard = placement->ol_shards[s];
+
+		for (r = 0; r < shard->os_replica_nr; r++) {
+			uint32_t rank = shard->os_ranks[r];
+
+			if (!rank_in_placement(rank,not_in_placement))
+				return rank;
+		}
+	}
+
+	return -1;
+}
+
+static int
+disabled_nodes(test_arg_t *arg)
+{
+	int			rc;
+	daos_pool_info_t	info;
+
+	rc = daos_pool_query(arg->pool.poh, NULL, &info, NULL, NULL);
+
+	if (rc < 0)
+		return rc;
+
+	return info.pi_ndisabled;
+}
+
+static void
+rebuild_test(void **state, int chunksize, int data_len_bytes, int iod_type)
+{
+	struct csum_test_ctx	 ctx;
+	test_arg_t		*arg = *state;
+	struct daos_obj_layout *layout1 = NULL;
+	struct daos_obj_layout *layout2 = NULL;
+	uint32_t		 rank_to_exclude;
+	int			 rank_to_fetch;
+	int			 rc;
+
+	if (!test_runable(*state, 3)) {
+		skip();
+	}
+
+	setup_from_test_args(&ctx, *state);
+	setup_cont_obj(&ctx, DAOS_PROP_CO_CSUM_CRC64, false, chunksize,
+		       DAOS_OC_R2S_SPEC_RANK);
+
+	if (iod_type == DAOS_IOD_ARRAY)
+		setup_single_recx_data(&ctx, "abc", data_len_bytes);
+	else if (iod_type == DAOS_IOD_SINGLE)
+		setup_single_value_data(&ctx, "abc", data_len_bytes);
+	else
+		fail_msg("Invalid iod_type: %d\n", iod_type);
+
+	rc = daos_obj_update(ctx.oh, DAOS_TX_NONE, 0, &ctx.dkey, 1,
+			     &ctx.update_iod, &ctx.update_sgl, NULL);
+	assert_success(rc);
+
+	rc = daos_obj_layout_get(ctx.coh, ctx.oid, &layout1);
+	assert_success(rc);
+	print_message("Before rebuild: Object replicated across ranks %d, %d\n",
+		      layout1->ol_shards[0]->os_ranks[0],
+		      layout1->ol_shards[0]->os_ranks[1]);
+
+	rank_to_exclude = layout1->ol_shards[0]->os_ranks[0];
+	print_message("Excluding rank %d\n",
+		      rank_to_exclude);
+	daos_exclude_server(arg->pool.pool_uuid, arg->group,
+			    &arg->pool.alive_svc,
+			    layout1->ol_shards[0]->os_ranks[0]);
+	assert_int_equal(1, disabled_nodes(arg));
+
+	/** wait for rebuild */
+	test_rebuild_wait(&arg, 1);
+
+	rc = daos_obj_layout_get(ctx.coh, ctx.oid, &layout2);
+	assert_success(rc);
+
+	print_message("After rebuild: Object replicated across ranks %d, %d\n",
+		      layout2->ol_shards[0]->os_ranks[0],
+		      layout2->ol_shards[0]->os_ranks[1]);
+
+	/** force to fetch from rank that was rebuilt to ensure checksum
+	 * was rebuilt appropriately
+	 */
+	rank_to_fetch = get_rank_not_in_placement(layout2, layout1);
+	assert_true(rank_to_fetch >= 0);
+	print_message("Rank to fetch: %d\n", rank_to_fetch);
+
+	daos_fail_loc_set(DAOS_OBJ_SPECIAL_SHARD);
+	daos_fail_num_set(rank_to_fetch);
+	rc = daos_obj_fetch(ctx.oh, DAOS_TX_NONE, 0, &ctx.dkey,
+			    1, &ctx.fetch_iod, &ctx.fetch_sgl, NULL, NULL);
+	assert_success(rc);
+
+	daos_add_server(arg->pool.pool_uuid, arg->group, &arg->pool.alive_svc,
+		rank_to_exclude);
+	assert_int_equal(0, disabled_nodes(arg));
+
+	daos_obj_layout_free(layout1);
+	daos_obj_layout_free(layout2);
+
+	cleanup_data(&ctx);
+	cleanup_cont_obj(&ctx);
+}
+
+#define	INLINE_DATA	10
+#define	FETCHED_DATA	1024
+#define	BULK_DATA	1024*32
+
+/** Test rebuild enumerating objects and getting data inline */
+static void
+rebuild_1(void **state)
+{
+	rebuild_test(state, 1024, INLINE_DATA, DAOS_IOD_ARRAY);
+}
+
+/** Test rebuild when data is fetched after enumeration */
+static void
+rebuild_2(void **state)
+{
+	rebuild_test(state, 1024, FETCHED_DATA, DAOS_IOD_ARRAY);
+}
+
+/** Test rebuild when data is bulk transferred */
+static void
+rebuild_3(void **state)
+{
+	rebuild_test(state, 1024, BULK_DATA, DAOS_IOD_ARRAY);
+}
+static void
+rebuild_4(void **state)
+{
+	rebuild_test(state, 1024, INLINE_DATA, DAOS_IOD_SINGLE);
+
+}
+
+/** Test rebuild when data is fetched after enumeration */
+static void
+rebuild_5(void **state)
+{
+	rebuild_test(state, 1024, FETCHED_DATA, DAOS_IOD_SINGLE);
+}
+
+/** Test rebuild when data is bulk transferred */
+static void
+rebuild_6(void **state)
+{
+	rebuild_test(state, 1024, BULK_DATA, DAOS_IOD_SINGLE);
+}
+
 static void
 test_update_fetch_a_key(void **state)
 {
@@ -1488,6 +1703,170 @@ test_enumerate_d_key(void **state)
 	cleanup_cont_obj(&ctx);
 }
 
+/** Used to test the obj_list_obj. There is no DAOS API that will test
+ * this so creating a local test version to verify functionality with checksums
+ * for rebuild
+ */
+int
+tst_obj_list_obj(daos_handle_t oh, daos_epoch_range_t *epr, daos_key_t *dkey,
+		 daos_key_t *akey, daos_size_t *size, uint32_t *nr,
+		 daos_key_desc_t *kds, d_sg_list_t *sgl, daos_anchor_t *anchor,
+		 daos_anchor_t *dkey_anchor, daos_anchor_t *akey_anchor,
+		 d_iov_t *csum_iov)
+{
+	tse_task_t	*task;
+	int		rc;
+
+	rc = dc_obj_list_obj_task_create(oh, DAOS_TX_NONE, epr, dkey, akey,
+					 size, nr, kds, sgl,
+					 anchor, dkey_anchor, akey_anchor,
+					 true, NULL, NULL, csum_iov, &task);
+	assert_int_equal(0, rc);
+	return dc_task_schedule(task, true);
+}
+
+static void
+test_enumerate_object(void **state)
+{
+	struct csum_test_ctx	 ctx = {0};
+	daos_oclass_id_t	 oc = dts_csum_oc;
+	daos_anchor_t		 anchor = {0};
+	d_iov_t			 csum_iov = {0};
+	d_sg_list_t		 sgl = {0};
+	struct dcs_csum_info	*csum_info = NULL;
+	void			*csum_ptr;
+	const uint32_t		 akey_nr = 5;
+	/** will enumerate for each akey, value of each akey, and 1 dkey */
+	const uint32_t		 enum_nr = akey_nr * 2 + 1;
+	daos_key_desc_t		 kds[enum_nr];
+	uint8_t			 csum_buf[1024];
+	uint32_t		 csum_count = 0;
+	uint32_t		 i;
+	uint32_t		 nr;
+	int			 rc;
+
+	memset(kds, 0, enum_nr * sizeof(*kds));
+
+	d_iov_set(&csum_iov, csum_buf, 1024);
+	csum_iov.iov_len = 0;
+
+	setup_from_test_args(&ctx, *state);
+	setup_cont_obj(&ctx, DAOS_PROP_CO_CSUM_CRC64, false, 10, oc);
+	setup_simple_data(&ctx);
+
+	/** insert multiple a keys.*/
+	for (i = 0; i < akey_nr; i++) {
+		rc = daos_obj_update(ctx.oh, DAOS_TX_NONE, 0, &ctx.dkey, 1,
+				     &ctx.update_iod, &ctx.update_sgl,
+				     NULL);
+		assert_int_equal(0, rc);
+		((uint8_t *)ctx.update_iod.iod_name.iov_buf)[1] += 1;
+		((uint8_t *)ctx.update_sgl.sg_iovs->iov_buf)[0] += 1;
+	}
+
+	/** Make sure can handle data over multiple iovs */
+	d_sgl_init(&sgl, 2);
+	iov_alloc(&sgl.sg_iovs[0], 10);
+	iov_alloc(&sgl.sg_iovs[1], 1024);
+
+	daos_anchor_t dkey_anchor = {0};
+	daos_anchor_t akey_anchor = {0};
+
+	/** inject failure ... should return CSUM error */
+	client_corrupt_akey_on_fetch();
+	nr = enum_nr;
+	rc = tst_obj_list_obj(ctx.oh, NULL, &ctx.dkey, NULL, NULL, &nr, kds,
+		&sgl, &anchor, &dkey_anchor, &akey_anchor, &csum_iov);
+
+	assert_int_equal(-DER_CSUM, rc);
+	client_clear_fault();
+
+	/** Sanity check that no failure still returns success */
+	nr = enum_nr;
+	memset(&anchor, 0, sizeof(anchor));
+	memset(&dkey_anchor, 0, sizeof(dkey_anchor));
+	memset(&akey_anchor, 0, sizeof(akey_anchor));
+	sgl.sg_nr_out = 0;
+	rc = tst_obj_list_obj(ctx.oh, NULL, &ctx.dkey, NULL, NULL, &nr, kds, &sgl,
+			      &anchor, &dkey_anchor, &akey_anchor, &csum_iov);
+	assert_int_equal(0, rc);
+	assert_int_equal(enum_nr, nr);
+
+	/** Make sure csum iov is correct */
+	csum_ptr = csum_iov.iov_buf;
+	while (csum_ptr < csum_iov.iov_buf + csum_iov.iov_len) {
+		ci_cast(&csum_info, &csum_iov);
+		assert_int_equal(1, csum_info->cs_nr);
+		csum_ptr += ci_size(*csum_info);
+		csum_count++;
+	}
+
+	assert_int_equal(13, csum_count);
+
+	/** Clean up */
+	d_sgl_fini(&sgl, true);
+	cleanup_data(&ctx);
+	cleanup_cont_obj(&ctx);
+}
+
+static void
+test_enumerate_object_csum_buf_too_small(void **state)
+{
+	struct csum_test_ctx	ctx = {0};
+	daos_anchor_t		anchor = {0};
+	daos_anchor_t		dkey_anchor = {0};
+	daos_anchor_t		akey_anchor = {0};
+	d_iov_t			csum_iov = {0};
+	d_sg_list_t		sgl = {0};
+	const uint32_t		akey_nr = 5;
+	const uint32_t		enum_nr = akey_nr * 2 + 1;
+	daos_key_desc_t		kds[enum_nr];
+	const size_t		csum_buf_len = 10;
+	uint8_t			csum_buf[csum_buf_len];
+	uint32_t		i;
+	uint32_t		nr;
+	int			rc;
+
+	memset(kds, 0, enum_nr * sizeof(*kds));
+
+	d_iov_set(&csum_iov, csum_buf, csum_buf_len);
+	csum_iov.iov_len = 0;
+
+	setup_from_test_args(&ctx, *state);
+	setup_cont_obj(&ctx, DAOS_PROP_CO_CSUM_CRC64, false, 1024, dts_csum_oc);
+	setup_simple_data(&ctx);
+
+	/** insert multiple a keys.*/
+	for (i = 0; i < akey_nr; i++) {
+		rc = daos_obj_update(ctx.oh, DAOS_TX_NONE, 0, &ctx.dkey, 1,
+				     &ctx.update_iod, &ctx.update_sgl,
+				     NULL);
+		assert_int_equal(0, rc);
+		((uint8_t *)ctx.update_iod.iod_name.iov_buf)[1] += 1;
+		((uint8_t *)ctx.update_sgl.sg_iovs->iov_buf)[0] += 1;
+	}
+
+	d_sgl_init(&sgl, 1);
+	iov_alloc(&sgl.sg_iovs[0], 1024);
+
+	nr = enum_nr;
+	rc = tst_obj_list_obj(ctx.oh, NULL, &ctx.dkey, NULL, NULL, &nr, kds, &sgl,
+			      &anchor, &dkey_anchor, &akey_anchor, &csum_iov);
+	assert_int_equal(0, rc);
+
+	/** csum iov buf len shouldn't change, but iov_len should reflect
+	 * what's needed to hold all csum info. Caller can decide what to do
+	 * from here. */
+	assert_int_equal(10, csum_iov.iov_buf_len);
+	assert_int_equal(11 * (sizeof(struct dcs_csum_info) + 8),
+		csum_iov.iov_len);
+
+	/** Clean up */
+	d_sgl_fini(&sgl, true);
+	cleanup_data(&ctx);
+	cleanup_cont_obj(&ctx);
+}
+
 static int
 setup(void **state)
 {
@@ -1538,8 +1917,21 @@ static const struct CMUnitTest csum_tests[] = {
 	CSUM_TEST("DAOS_CSUM08: Update/Fetch A Key", test_update_fetch_a_key),
 	CSUM_TEST("DAOS_CSUM09: Update/Fetch D Key", test_update_fetch_d_key),
 	CSUM_TEST("DAOS_CSUM10: Enumerate A Keys", test_enumerate_a_key),
-	CSUM_TEST("DAOS_CSUM11: Enumerate D Keys", test_enumerate_d_key),
-	CSUM_TEST("DAOS_CSUM12: Many IODs", many_iovs_with_single_values),
+	CSUM_TEST("DAOS_CSUM11: Enumerate objects", test_enumerate_object),
+	CSUM_TEST("DAOS_CSUM12: Enumerate objects with too small csum buffer",
+		  test_enumerate_object_csum_buf_too_small),
+	CSUM_TEST("DAOS_CSUM13: Enumerate D Keys", test_enumerate_d_key),
+	CSUM_TEST("DAOS_CSUM14: Many IODs", many_iovs_with_single_values),
+	CSUM_TEST("DAOS_CSUM15: Many IODs", many_iovs_with_single_values),
+
+	CSUM_TEST("DAOS_CSUM_REBUILD01: Array, Data is inlined", rebuild_1),
+	CSUM_TEST("DAOS_CSUM_REBUILD02: Array, Data not inlined, not bulk",
+		  rebuild_2),
+	CSUM_TEST("DAOS_CSUM_REBUILD03: Array, Data bulk transfer", rebuild_3),
+	CSUM_TEST("DAOS_CSUM_REBUILD04: SV, Data is inlined", rebuild_4),
+	CSUM_TEST("DAOS_CSUM_REBUILD05: SV, Data not inlined, not bulk",
+		  rebuild_5),
+	CSUM_TEST("DAOS_CSUM_REBUILD06: SV, Data bulk transfer", rebuild_6),
 
 	EC_CSUM_TEST("DAOS_EC_CSUM00: csum disabled", checksum_disabled),
 	EC_CSUM_TEST("DAOS_EC_CSUM01: simple update with server side verify",

--- a/src/vos/tests/vts_io.c
+++ b/src/vos/tests/vts_io.c
@@ -515,7 +515,7 @@ io_test_add_csums(daos_iod_t *iod, d_sg_list_t *sgl,
 	size_t			 chunk_size = 1 << 12;
 	int			 rc = 0;
 
-	rc = daos_csummer_type_init(p_csummer, type, chunk_size, 0);
+	rc = daos_csummer_init_with_type(p_csummer, type, chunk_size, 0);
 	if (rc)
 		return rc;
 	rc = daos_csummer_calc_iods(*p_csummer, sgl, iod, NULL, 1, false,

--- a/src/vos/vos_iterator.c
+++ b/src/vos/vos_iterator.c
@@ -535,7 +535,7 @@ vos_iterate(vos_iter_param_t *param, vos_iter_type_t type, bool recursive,
 	    vos_iter_cb_t post_cb, void *arg)
 {
 	daos_anchor_t		*anchor, *probe_anchor = NULL;
-	vos_iter_entry_t	iter_ent;
+	vos_iter_entry_t	iter_ent = {0};
 	daos_handle_t		ih;
 	unsigned int		acts = 0;
 	bool			skipped;


### PR DESCRIPTION
When rebuild occurs, the rebuilt objects should have the checksums
previously saved for the object data.

- Because rebuild relies on the client enumerate api, a checksum
  buffer is added to the object list object task api.
- Added helper functions to serialize/deserialize checksum structures
- Added function to initialize a csummer with container properties
- Container properties were stored in IV with the container handle as
  key. Because rebuild doesn't really open containers, the container
  properties IV store was changed to use container uuid instead. This
  way the csummer can be initialized on demand by rebuild (again,
  because not really opening containers, the container csummer isn't
  initialized)
- VOS enum pack/unpack IO updated to include checksum info
- Removed checksum information from daos_key_desc_t. This should have
  been removed with the other checksum removal from the API.

Signed-off-by: Ryon Jensen <ryon.jensen@intel.com>