### PR TITLE
DAOS-5129 test: Remove deprecated setup method.

### DIFF
--- a/src/tests/ftest/io/nvme_pool_capacity.py
+++ b/src/tests/ftest/io/nvme_pool_capacity.py
@@ -110,8 +110,9 @@ class NvmePoolCapacity(TestWithServers):
                                                       api,
                                                       test[2])])
         env = ior_cmd.get_default_env(str(manager))
-        manager.setup_command(env, self.hostfile_clients,
-                              processes)
+        manager.assign_hosts(self.hostlist_clients, self.workdir, None)
+        manager.assign_processes(processes)
+        manager.assign_environment(env, True)
 
         # run IOR Command
         try:


### PR DESCRIPTION
Test-tag-hw-medium: full_regression,hw,medium,ib2,nvme_pool_capacity

Summary: Remove the deprecated setup_method from nvme_pool_capacity
test case. Looks some changes were merged without running
full_regression testing.

Signed-off-by: Padmanabhan <ravindran.padmanabhan@intel.com>