### PR TITLE
DAOS-5128 control: Fix up agent subcommand handling

### DIFF
--- a/doc/admin/deployment.md
+++ b/doc/admin/deployment.md
@@ -570,8 +570,6 @@ $ daos_server network scan -p all
 localhost
 ---------
 
-    Available providers: ofi+tcp, ofi+verbs;ofi_rxm, ofi+psm2, ofi+sockets, ofi+tcp;ofi_rxm, ofi+verbs
-
     -------------
     NUMA Socket 0
     -------------
@@ -598,9 +596,9 @@ localhost
         ofi+sockets       ib1
         ofi+psm2          ib1
 ```
-The results show 'Available providers', which is a list of all available OFI fabric providers associated with at least one network interface on the daos_server node.  Use one of these providers to configure the `provider` in the daos_server.yml.  Only one provider may be specified for the entire DAOS installation.  Client nodes must be capable of communicating to the daos_server nodes via the same provider.  Therefore, it is helpful to choose network settings for the daos_server that are compatible with the expected client node configuration.
+Use one of these providers to configure the `provider` in the daos_server.yml.  Only one provider may be specified for the entire DAOS installation. Client nodes must be capable of communicating to the daos_server nodes via the same provider. Therefore, it is helpful to choose network settings for the daos_server that are compatible with the expected client node configuration.
 
-After the daos_server.yml file has been edited and contains a provider, subsequent `daos_server network scan` commands will filter the results based on that provider.  If it is desired to view an unfiltered list again, issue `daos_server network scan -p all`.
+After the daos_server.yml file has been edited and contains a provider, subsequent `daos_server network scan` commands will filter the results based on that provider. If it is desired to view an unfiltered list again, issue `daos_server network scan -p all`.
 
 Regardless of the provider in the daos_server.yml file, the results may be filtered to the specified provider with the command `daos_server network scan -p ofi_provider` where `ofi_provider` is one of the available providers from the list.
 
@@ -608,22 +606,20 @@ The results of the network scan may be used to help configure the IO server
 instances for this daos_server node.
 
 Each IO server instance is configured with a unique `fabric_iface` and
-optional `pinned_numa_node`.  The interfaces and NUMA Sockets listed in the scan
+optional `pinned_numa_node`. The interfaces and NUMA Sockets listed in the scan
 results map to the daos_server.yml `fabric_iface` and `pinned_numa_node`
-respectively.  The use of `pinned_numa_node` is optional, but recommended for best performance.  When specified with the value that matches the network interface, the IO server will bind itself to that NUMA node and to cores purely within that NUMA node.  This configuration yields the fastest access to that network device.
+respectively. The use of `pinned_numa_node` is optional, but recommended for best performance. When specified with the value that matches the network interface, the IO server will bind itself to that NUMA node and to cores purely within that NUMA node. This configuration yields the fastest access to that network device.
 
 ## Network Scanning All DAOS Server Nodes
-While the `daos_server network scan` is useful for scanning the localhost, it does not provide results for any other daos_server instance on the network.  The DAOS Management tool, `dmg`, is used for that purpose.  The network scan operates the same way as the daos_server network scan, however, to use the dmg tool, at least one known daos_server instance must be running.
+While the `daos_server network scan` is useful for scanning the localhost, it does not provide results for any other daos_server instance on the network.  The DAOS Management tool, `dmg`, is used for that purpose. The network scan operates the same way as the daos_server network scan, however, to use the dmg tool, at least one known daos_server instance must be running.
 
-The command `dmg network scan` performs a query over all daos_servers in the daos_control.yml `hostlist`.  By default, the scan will return results that are filtered by the provider that is specified in the daos_server.yml.  Like the `daos_server network scan`, the `dmg network scan` supports the optional `-p/--provider` where a different provider may be specified, or `all` for an unfiltered list that is unrelated to what was already configured on the daos_server installation.
+The command `dmg network scan` performs a query over all daos_servers in the daos_control.yml `hostlist`. By default, the scan will return results that are filtered by the provider that is specified in the daos_server.yml. Like the `daos_server network scan`, the `dmg network scan` supports the optional `-p/--provider` where a different provider may be specified, or `all` for an unfiltered list that is unrelated to what was already configured on the daos_server installation.
 
 ```bash
 dmg network scan
 -------
 wolf-29
 -------
-
-    Available providers: ofi+sockets
 
     -------------
     NUMA Socket 1
@@ -636,8 +632,6 @@ wolf-29
 ---------
 localhost
 ---------
-
-    Available providers: ofi+sockets
 
     -------------
     NUMA Socket 0
@@ -660,8 +654,8 @@ localhost
 
 To aid in provider configuration and debug, it may be helpful to run the
 fi_pingpong test (delivered as part of OFI/libfabric).  To run that test,
-determine the name of the provider to test usually by removing the "ofi+" prefix from the network scan provider data.  Do use the "ofi+" prefix in the
-daos_server.yml.  Do not use the "ofi+" prefix with fi_pingpong.
+determine the name of the provider to test usually by removing the "ofi+" prefix from the network scan provider data. Do use the "ofi+" prefix in the
+daos_server.yml. Do not use the "ofi+" prefix with fi_pingpong.
 
 Then, the fi_pingpong test can be used to verify that the targeted OFI provider works fine:
 ```bash

--- a/src/control/cmd/daos_agent/network.go
+++ b/src/control/cmd/daos_agent/network.go
@@ -50,8 +50,6 @@ func (cmd *netScanCmd) printUnlessJson(fmtStr string, args ...interface{}) {
 }
 
 func (cmd *netScanCmd) Execute(_ []string) error {
-	defer os.Exit(0)
-
 	numaAware, err := netdetect.NumaAware()
 	if err != nil {
 		exitWithError(cmd.log, err)
@@ -92,7 +90,7 @@ func (cmd *netScanCmd) Execute(_ []string) error {
 	}
 
 	var bld strings.Builder
-	if err := pretty.PrintHostFabricMap(hfm, &bld, false); err != nil {
+	if err := pretty.PrintHostFabricMap(hfm, &bld); err != nil {
 		return err
 	}
 	cmd.log.Info(bld.String())

--- a/src/control/cmd/daos_agent/start.go
+++ b/src/control/cmd/daos_agent/start.go
@@ -46,7 +46,7 @@ type startCmd struct {
 }
 
 func (cmd *startCmd) Execute(_ []string) error {
-	cmd.log.Info("Starting daos_agent:")
+	cmd.log.Infof("Starting %s:", versionString())
 
 	ctx, shutdown := context.WithCancel(context.Background())
 	defer shutdown()

--- a/src/control/cmd/daos_server/network.go
+++ b/src/control/cmd/daos_server/network.go
@@ -1,5 +1,5 @@
 //
-// (C) Copyright 2019 Intel Corporation.
+// (C) Copyright 2019-2020 Intel Corporation.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -82,7 +82,7 @@ func (cmd *networkScanCmd) Execute(args []string) error {
 	}
 
 	var bld strings.Builder
-	if err := pretty.PrintHostFabricMap(hfm, &bld, false); err != nil {
+	if err := pretty.PrintHostFabricMap(hfm, &bld); err != nil {
 		return err
 	}
 	cmd.log.Info(bld.String())

--- a/src/control/cmd/dmg/network.go
+++ b/src/control/cmd/dmg/network.go
@@ -72,7 +72,7 @@ func (cmd *networkScanCmd) Execute(_ []string) error {
 		return err
 	}
 
-	if err := pretty.PrintHostFabricMap(resp.HostFabrics, &bld, false); err != nil {
+	if err := pretty.PrintHostFabricMap(resp.HostFabrics, &bld); err != nil {
 		return err
 	}
 	cmd.log.Info(bld.String())

--- a/src/control/cmd/dmg/pretty/network.go
+++ b/src/control/cmd/dmg/pretty/network.go
@@ -43,7 +43,7 @@ func (h hfiMap) addInterface(fi *control.HostFabricInterface) {
 
 // PrintHostFabricMap generates a human-readable representation of the supplied
 // HostFabricMap and writes it to the supplied io.Writer.
-func PrintHostFabricMap(hfm control.HostFabricMap, out io.Writer, onlyProviders bool, opts ...control.PrintConfigOption) error {
+func PrintHostFabricMap(hfm control.HostFabricMap, out io.Writer, opts ...control.PrintConfigOption) error {
 	if len(hfm) == 0 {
 		return nil
 	}
@@ -61,12 +61,6 @@ func PrintHostFabricMap(hfm control.HostFabricMap, out io.Writer, onlyProviders 
 		iw := txtfmt.NewIndentWriter(ew, txtfmt.WithPadCount(4))
 		fmt.Fprintf(ew, "%s\n%s\n%s\n", lineBreak, hosts, lineBreak)
 		fmt.Fprintln(ew)
-		fmt.Fprintf(iw, "Available providers: %s\n", strings.Join(hfs.HostFabric.Providers, ", "))
-		fmt.Fprintln(ew)
-
-		if onlyProviders {
-			continue
-		}
 
 		hfim := make(hfiMap)
 		for _, fi := range hfs.HostFabric.Interfaces {

--- a/src/tests/ftest/control/dmg_network_scan.py
+++ b/src/tests/ftest/control/dmg_network_scan.py
@@ -247,7 +247,7 @@ class DmgNetworkScanTest(TestWithServers):
         for host_info in info:
             parsed_devs = {}
             host = host_info[0][0]
-            for dev_info in host_info[2:]:
+            for dev_info in host_info[1:]:
                 if len(dev_info) == 1:
                     numa = dev_info[0]
                     continue

--- a/src/tests/ftest/util/dmg_utils.py
+++ b/src/tests/ftest/util/dmg_utils.py
@@ -38,8 +38,7 @@ class DmgCommand(YamlCommand):
 
     METHOD_REGEX = {
         "run": r"(.*)",
-        "network_scan": r"[-]+(?:\n|\n\r)([a-z0-9-]+)(?:\n|\n\r)[-]+|"
-                        r"Available\s+providers:\s+([a-z0-9+,;_ ]+)|NUMA\s+"
+        "network_scan": r"[-]+(?:\n|\n\r)([a-z0-9-]+)(?:\n|\n\r)[-]+|NUMA\s+"
                         r"Socket\s+(\d+)|(ofi\+[a-z0-9;_]+)\s+([a-z0-9, ]+)",
         # Sample output of dmg pool list.
         # wolf-3:10001: connected


### PR DESCRIPTION
* Don't require valid config for version or net-scan
* Exit with an error on unknown commands
* Show agent version on startup

Also removes the redundant list of providers in the fabric
pretty-printer function.