### PR TITLE
DAOS-4900 sched: Make scheduler space pressure aware

### DIFF
--- a/src/container/srv_target.c
+++ b/src/container/srv_target.c
@@ -167,7 +167,7 @@ cont_child_aggregate(struct ds_cont_child *cont, uint64_t *msecs)
 		   sched_req_space_check(req) == SCHED_SPACE_PRESS_NONE) {
 		/*
 		 * When there isn't space pressure, don't aggregate too often,
-		 * otherwise, aggregation will be inefficent because the data
+		 * otherwise, aggregation will be inefficient because the data
 		 * to be aggregated could be changed by new update very soon.
 		 */
 		return 0;

--- a/src/container/srv_target.c
+++ b/src/container/srv_target.c
@@ -58,6 +58,18 @@
  */
 #define DAOS_AGG_THRESHOLD	90 /* seconds */
 
+static inline bool
+cont_aggregate_yield(void *arg)
+{
+	struct sched_request	*req = (struct sched_request *)arg;
+
+	if (sched_req_is_aborted(req))
+		return true;
+
+	sched_req_yield(req);
+	return false;
+}
+
 static inline int
 cont_aggregate_epr(struct ds_cont_child *cont, daos_epoch_range_t *epr)
 {
@@ -65,15 +77,18 @@ cont_aggregate_epr(struct ds_cont_child *cont, daos_epoch_range_t *epr)
 	 * Avoid calling into vos_aggregate() when aborting aggregation
 	 * on ds_cont_child purging.
 	 */
-	if (cont->sc_abort_vos_aggregating)
+	D_ASSERT(cont->sc_agg_req != NULL);
+	if (sched_req_is_aborted(cont->sc_agg_req))
 		return 1;
-	return vos_aggregate(cont->sc_hdl, epr, ds_csum_recalc);
+	return vos_aggregate(cont->sc_hdl, epr, ds_csum_recalc,
+			     cont_aggregate_yield, (void *)cont->sc_agg_req);
 }
 
 static bool
 cont_aggregate_runnable(struct ds_cont_child *cont)
 {
-	struct ds_pool	*pool = cont->sc_pool->spc_pool;
+	struct ds_pool		*pool = cont->sc_pool->spc_pool;
+	struct sched_request	*req = cont->sc_agg_req;
 
 	/* snapshot list isn't fetched yet */
 	if (cont->sc_aggregation_max == 0) {
@@ -81,19 +96,28 @@ cont_aggregate_runnable(struct ds_cont_child *cont)
 		return false;
 	}
 
-	if ((pool->sp_reclaim == DAOS_RECLAIM_DISABLED) ||
-	    (pool->sp_reclaim == DAOS_RECLAIM_LAZY && dss_xstream_is_busy()))
+	if (pool->sp_reclaim == DAOS_RECLAIM_DISABLED) {
+		D_DEBUG(DB_EPC, "Pool reclaim strategy is disabled\n");
 		return false;
+	}
+
+	if (pool->sp_reclaim == DAOS_RECLAIM_LAZY && dss_xstream_is_busy() &&
+	    sched_req_space_check(req) != SCHED_SPACE_PRESS_NONE) {
+		D_DEBUG(DB_EPC, "Pool reclaim strategy is lazy, service is "
+			"busy and no space pressure\n");
+		return false;
+	}
 
 	return true;
 }
 
 static int
-cont_child_aggregate(struct ds_cont_child *cont, uint64_t *sleep)
+cont_child_aggregate(struct ds_cont_child *cont, uint64_t *msecs)
 {
 	daos_epoch_t		epoch_max, epoch_min;
 	daos_epoch_range_t	epoch_range;
 	vos_cont_info_t		cinfo;
+	struct sched_request	*req = cont->sc_agg_req;
 	uint64_t		hlc = crt_hlc_get();
 	uint64_t		change_hlc;
 	uint64_t		interval;
@@ -103,7 +127,7 @@ cont_child_aggregate(struct ds_cont_child *cont, uint64_t *sleep)
 	int			i, rc;
 
 	/* Check if it's ok to start aggregation in every 2 seconds */
-	*sleep = 2ULL * NSEC_PER_SEC;
+	*msecs = 2ULL * 1000;
 	if (!cont_aggregate_runnable(cont))
 		return 0;
 
@@ -135,9 +159,17 @@ cont_child_aggregate(struct ds_cont_child *cont, uint64_t *sleep)
 	 * transactions under this epoch is either committed or aborted).
 	 */
 	epoch_max = hlc - interval;
-	/* Throttle the aggregation a bit */
-	if (epoch_min > epoch_max - interval) {
-		*sleep = (epoch_min - (epoch_max - interval));
+
+	if (epoch_min > epoch_max) {
+		/* Nothing can be aggregated */
+		return 0;
+	} else if (epoch_min > epoch_max - interval &&
+		   sched_req_space_check(req) == SCHED_SPACE_PRESS_NONE) {
+		/*
+		 * When there isn't space pressure, don't aggregate too often,
+		 * otherwise, aggregation will be inefficent because the data
+		 * to be aggregated could be changed by new update very soon.
+		 */
 		return 0;
 	}
 
@@ -197,7 +229,7 @@ cont_child_aggregate(struct ds_cont_child *cont, uint64_t *sleep)
 	if (epoch_range.epr_lo >= epoch_max)
 		D_GOTO(free, rc = 0);
 
-	*sleep = 0;
+	*msecs = 0;
 	D_DEBUG(DB_EPC, DF_CONT"[%d]: MIN: %lu; HLC: %lu\n",
 		DP_CONT(cont->sc_pool->spc_uuid, cont->sc_uuid),
 		tgt_id, epoch_min, hlc);
@@ -240,27 +272,20 @@ free:
 static void
 cont_aggregate_ult(void *arg)
 {
-	struct ds_cont_child		*cont	= arg;
-	struct dss_module_info		*dmi	= dss_get_module_info();
-	int				 rc	= 0;
-
-	cont->sc_agg_ult = dss_sleep_ult_create();
-	if (cont->sc_agg_ult == NULL) {
-		D_CRIT(DF_CONT"[%d]: Failed to start aggregation ULT\n",
-		       DP_CONT(cont->sc_pool->spc_uuid, cont->sc_uuid),
-		       dmi->dmi_tgt_id);
-		return;
-	}
+	struct ds_cont_child	*cont = arg;
+	struct dss_module_info	*dmi = dss_get_module_info();
+	int			 rc = 0;
 
 	D_DEBUG(DB_EPC, DF_CONT"[%d]: Aggregation ULT started\n",
 		DP_CONT(cont->sc_pool->spc_uuid, cont->sc_uuid),
 		dmi->dmi_tgt_id);
 
-	while (!cont->sc_abort_vos_aggregating &&
+	D_ASSERT(cont->sc_agg_req != NULL);
+	while (!sched_req_is_aborted(cont->sc_agg_req) &&
 	       !dss_xstream_exiting(dmi->dmi_xstream)) {
-		uint64_t sleep; /* nano secs */
+		uint64_t msecs;	/* milli seconds */
 
-		rc = cont_child_aggregate(cont, &sleep);
+		rc = cont_child_aggregate(cont, &msecs);
 		if (rc == -DER_SHUTDOWN) {
 			break;	/* pool destroyed */
 		} else if (rc < 0) {
@@ -269,17 +294,11 @@ cont_aggregate_ult(void *arg)
 				rc);
 		}
 
-		if (dss_xstream_exiting(dmi->dmi_xstream) ||
-		    cont->sc_abort_vos_aggregating)
+		if (dss_xstream_exiting(dmi->dmi_xstream))
 			break;
 
-		if (sleep > 0)
-			dss_ult_sleep(cont->sc_agg_ult, sleep);
-		else
-			ABT_thread_yield();
+		sched_req_sleep(cont->sc_agg_req, msecs);
 	}
-
-	cont->sc_vos_aggregating = 0;
 
 	D_DEBUG(DB_EPC, DF_CONT"[%d]: Aggregation ULT stopped\n",
 		DP_CONT(cont->sc_pool->spc_uuid, cont->sc_uuid),
@@ -289,49 +308,51 @@ cont_aggregate_ult(void *arg)
 static int
 cont_start_agg_ult(struct ds_cont_child *cont)
 {
-	int rc;
+	struct dss_module_info	*dmi = dss_get_module_info();
+	struct sched_req_attr	 attr;
+	ABT_thread		 agg_ult = ABT_THREAD_NULL;
+	int			 rc;
 
 	D_ASSERT(cont != NULL);
-	if (cont->sc_abort_vos_aggregating || cont->sc_vos_aggregating)
+	if (cont->sc_agg_req != NULL)
 		return 0;
 
-	cont->sc_vos_aggregating = 1;
-	rc = dss_ult_create(cont_aggregate_ult, cont,
-			    DSS_ULT_AGGREGATE, DSS_TGT_SELF, 0, NULL);
+	rc = dss_ult_create(cont_aggregate_ult, cont, DSS_ULT_AGGREGATE,
+			    DSS_TGT_SELF, 0, &agg_ult);
 	if (rc) {
-		D_ERROR(DF_CONT": Failed to create aggregation ULT; rc %d\n",
-			DP_CONT(cont->sc_pool->spc_uuid, cont->sc_uuid), rc);
-		cont->sc_vos_aggregating = 0;
+		D_ERROR(DF_CONT"[%d]: Failed to create aggregation ULT. %d\n",
+			DP_CONT(cont->sc_pool->spc_uuid, cont->sc_uuid),
+			dmi->dmi_tgt_id, rc);
+		return rc;
 	}
-	return rc;
+
+	D_ASSERT(agg_ult != ABT_THREAD_NULL);
+	sched_req_attr_init(&attr, SCHED_REQ_GC, &cont->sc_pool->spc_uuid);
+	cont->sc_agg_req = sched_req_get(&attr, agg_ult);
+	if (cont->sc_agg_req == NULL) {
+		D_CRIT(DF_CONT"[%d]: Failed to get req for aggregation ULT\n",
+		       DP_CONT(cont->sc_pool->spc_uuid, cont->sc_uuid),
+		       dmi->dmi_tgt_id);
+		ABT_thread_join(agg_ult);
+		return -DER_NOMEM;
+	}
+
+	return 0;
 }
 
 static void
 cont_stop_agg_ult(struct ds_cont_child *cont)
 {
-	int rc;
-
-	if (cont->sc_agg_ult) {
-		dss_ult_wakeup(cont->sc_agg_ult);
-		dss_sleep_ult_destroy(cont->sc_agg_ult);
-		cont->sc_agg_ult = NULL;
-	}
-
-	if (!cont->sc_vos_aggregating)
+	if (cont->sc_agg_req == NULL)
 		return;
 
 	D_DEBUG(DB_EPC, DF_CONT"[%d]: Stopping aggregation ULT\n",
 		DP_CONT(cont->sc_pool->spc_uuid, cont->sc_uuid),
 		dss_get_module_info()->dmi_tgt_id);
 
-	cont->sc_abort_vos_aggregating = 1;
-	rc = vos_cont_ctl(cont->sc_hdl, VOS_CO_CTL_ABORT_AGG);
-	if (rc)
-		D_ERROR(DF_UUID": Abort aggregation failed. %d\n",
-			DP_UUID(cont->sc_uuid), rc);
-
-	while (cont->sc_vos_aggregating)
-		ABT_thread_yield();
+	sched_req_wait(cont->sc_agg_req, true);
+	sched_req_put(cont->sc_agg_req);
+	cont->sc_agg_req = NULL;
 }
 
 /* Per VOS container DTX re-index ULT ***************************************/
@@ -460,8 +481,6 @@ cont_child_alloc_ref(void *co_uuid, unsigned int ksize, void *po_uuid,
 	cont->sc_aggregation_max = 0;
 	cont->sc_snapshots_nr = 0;
 	cont->sc_snapshots = NULL;
-	cont->sc_vos_aggregating = 0;
-	cont->sc_abort_vos_aggregating = 0;
 	D_INIT_LIST_HEAD(&cont->sc_link);
 
 	*link = &cont->sc_list;

--- a/src/include/daos_srv/container.h
+++ b/src/include/daos_srv/container.h
@@ -73,11 +73,9 @@ struct ds_cont_child {
 				 sc_dtx_aggregating:1,
 				 sc_dtx_reindex:1,
 				 sc_dtx_reindex_abort:1,
-				 sc_vos_aggregating:1,
-				 sc_abort_vos_aggregating:1,
 				 sc_stopping:1;
-	/* Aggregate ULT */
-	struct dss_sleep_ult	 *sc_agg_ult;
+	/* Tracks the schedule request for aggregation ULT */
+	struct sched_request	*sc_agg_req;
 
 	/*
 	 * Snapshot delete HLC (0 means no change), which is used

--- a/src/include/daos_srv/daos_server.h
+++ b/src/include/daos_srv/daos_server.h
@@ -247,9 +247,114 @@ struct dss_drpc_handler {
 	drpc_handler_t	handler;	/** dRPC handler for the module */
 };
 
+enum {
+	SCHED_REQ_IO	= 0,
+	SCHED_REQ_GC,
+	SCHED_REQ_MIGRATE,
+	SCHED_REQ_MAX,
+};
+
+struct sched_req_attr {
+	uuid_t		sra_pool_id;
+	uint32_t	sra_type;
+};
+
+static inline void
+sched_req_attr_init(struct sched_req_attr *attr, unsigned int type,
+		    uuid_t *pool_id)
+{
+	attr->sra_type = type;
+	uuid_copy(attr->sra_pool_id, *pool_id);
+}
+
+struct sched_request;	/* Opaque schedule request */
+
+/**
+ * Get A sched request.
+ *
+ * \param[in] attr	Sched request attributes.
+ * \param[in] ult	ULT attached to the sched request,
+ *			self ULT will be used when ult == ABT_THREAD_NULL.
+ *
+ * \retval		Sched request.
+ */
+struct sched_request *
+sched_req_get(struct sched_req_attr *attr, ABT_thread ult);
+
+/**
+ * Put A sched request.
+ *
+ * \param[in] req	Sched request.
+ *
+ * \retval		N/A
+ */
+void sched_req_put(struct sched_request *req);
+
+/**
+ * Suspend (or yield) a sched request attached ULT.
+ *
+ * \param[in] req	Sched request.
+ *
+ * \retval		N/A
+ */
+void sched_req_yield(struct sched_request *req);
+
+/**
+ * Put a sched request attached ULT to sleep for few msecs.
+ *
+ * \param[in] req	Sched request.
+ * \param[in] msec	Milli seconds.
+ *
+ * \retval		N/A
+ */
+void sched_req_sleep(struct sched_request *req, uint32_t msec);
+
+/**
+ * Wakeup a sched request attached ULT.
+ *
+ * \param[in] req	Sched request.
+ *
+ * \retval		N/A
+ */
+void sched_req_wakeup(struct sched_request *req);
+
+/**
+ * Wakeup a sched request attached ULT terminated.
+ *
+ * \param[in] req	Sched request.
+ * \param[in] abort	Abort the ULT or not.
+ *
+ * \retval		N/A
+ */
+void sched_req_wait(struct sched_request *req, bool abort);
+
+/**
+ * Check if a sched request is set as aborted.
+ *
+ * \param[in] req	Sched request.
+ *
+ * \retval		True for aborted, False otherwise.
+ */
+bool sched_req_is_aborted(struct sched_request *req);
+
+enum {
+	SCHED_SPACE_PRESS_NONE	= 0,
+	SCHED_SPACE_PRESS_LIGHT,
+	SCHED_SPACE_PRESS_SEVERE,
+};
+
+/**
+ * Check space pressure of the pool of current sched request.
+ *
+ * \param[in] req	Sched request.
+ *
+ * \retval		None, light or severe.
+ */
+int sched_req_space_check(struct sched_request *req);
+
 struct dss_module_ops {
-	/* The callback for each module will choose ABT pool to handle RPC */
-	ABT_pool (*dms_abt_pool_choose_cb)(crt_rpc_t *rpc, ABT_pool *pools);
+	/* Get schedule request attributes from RPC */
+	int (*dms_get_req_attr)(crt_rpc_t *rpc, struct sched_req_attr *attr);
 
 	/* Each module to start/stop the profiling */
 	int	(*dms_profile_start)(char *path, int avg);

--- a/src/include/daos_srv/vos.h
+++ b/src/include/daos_srv/vos.h
@@ -267,6 +267,19 @@ int
 vos_pool_query(daos_handle_t poh, vos_pool_info_t *pinfo);
 
 /**
+ * Query pool space by pool UUID
+ *
+ * \param pool_id [IN]	Pool UUID
+ * \param vps     [OUT]	Returned pool space info
+ *
+ * \return		Zero		: success
+ *			-DER_NONEXIST	: pool isn't opened
+ *			-ve		: error
+ */
+int
+vos_pool_query_space(uuid_t pool_id, struct vos_pool_space *vps);
+
+/**
  * Create a container within a VOSP
  *
  * \param poh	[IN]	Pool open handle
@@ -333,12 +346,16 @@ vos_cont_query(daos_handle_t coh, vos_cont_info_t *cinfo);
  *
  * \param coh	  [IN]		Container open handle
  * \param epr	  [IN]		The epoch range of aggregation
- * \param func	  [IN]		Pointer to csum recalculation function
+ * \param csum_func  [IN]	Pointer to csum recalculation function
+ * \param yield_func [IN]	Pointer to customized yield function
+ * \param yield_arg  [IN]	Argument of yield function
  *
  * \return			Zero on success, negative value if error
  */
 int
-vos_aggregate(daos_handle_t coh, daos_epoch_range_t *epr, void (*func)(void *));
+vos_aggregate(daos_handle_t coh, daos_epoch_range_t *epr,
+	      void (*csum_func)(void *), bool (*yield_func)(void *arg),
+	      void *yield_arg);
 
 /**
  * Discards changes in all epochs with the epoch range \a epr
@@ -357,11 +374,14 @@ vos_aggregate(daos_handle_t coh, daos_epoch_range_t *epr, void (*func)(void *));
  * \param coh		[IN]	Container open handle
  * \param epr		[IN]	The epoch range to discard
  *				keys to discard
+ * \param yield_func	[IN]	Pointer to customized yield function
+ * \param yield_arg	[IN]	Argument of yield function
  *
  * \return			Zero on success, negative value if error
  */
 int
-vos_discard(daos_handle_t coh, daos_epoch_range_t *epr);
+vos_discard(daos_handle_t coh, daos_epoch_range_t *epr,
+	    bool (*yield_func)(void *arg), void *yield_arg);
 
 /**
  * VOS object API
@@ -895,8 +915,7 @@ int
 vos_gc_pool(daos_handle_t poh, int *credits);
 
 enum vos_cont_opc {
-	/** abort VOS aggregation **/
-	VOS_CO_CTL_ABORT_AGG,
+	VOS_CO_CTL_DUMMY,
 };
 
 /**

--- a/src/iosrv/sched.c
+++ b/src/iosrv/sched.c
@@ -212,7 +212,7 @@ static d_hash_table_ops_t sched_pool_hash_ops = {
 };
 
 /*
- * d_hash_table_traverse() doesn't support item deletion in traverse
+ * d_hash_table_traverse() does not support item deletion in traverse
  * callback, so the stale 'spi' (pool was destroyed) will be added into
  * a purge list in traverse callback and being deleted later.
  */

--- a/src/iosrv/sched.c
+++ b/src/iosrv/sched.c
@@ -26,7 +26,937 @@
 #include <abt.h>
 #include <daos/common.h>
 #include <daos_errno.h>
+#include <daos_srv/vos.h>
 #include "srv_internal.h"
+
+struct sched_req_info {
+	d_list_t		sri_req_list;
+	/* Total request count in 'sri_req_list' */
+	uint32_t		sri_req_cnt;
+	/* How many requests are kicked in current cycle */
+	uint32_t		sri_req_kicked;
+	/* Limit of kicked requests in current cycle */
+	uint32_t		sri_req_limit;
+};
+
+struct sched_pool_info {
+	/* Link to 'sched_info->si_pool_hash' */
+	d_list_t		spi_hash_link;
+	uuid_t			spi_pool_id;
+	struct sched_req_info	spi_req_array[SCHED_REQ_MAX];
+	/* When space pressure info acquired, in msecs */
+	uint64_t		spi_space_ts;
+	int			spi_space_pressure;
+	int			spi_ref;
+};
+
+struct sched_request {
+	/*
+	 * IO request links to 'sched_info->si_fifo_list', other types of
+	 * request link to each 'sched_req_info->sri_req_list' respectively.
+	 * When request is not used, it's in 'sched_info->si_idle_list'.
+	 */
+	d_list_t		 sr_link;
+	struct sched_req_attr	 sr_attr;
+	void			*sr_func;
+	void			*sr_arg;
+	ABT_thread		 sr_ult;
+	struct sched_pool_info	*sr_pool_info;
+	/* Wakeup time for the sleeping request, in milli seconds */
+	uint64_t		 sr_wakeup_time;
+	/* When the request is enqueued, in msecs */
+	uint64_t		 sr_enqueue_ts;
+	unsigned int		 sr_abort:1;
+};
+
+static bool	sched_prio_disabled;
+
+enum {
+	/* All requests for various pools are processed in FIFO */
+	SCHED_POLICY_FIFO	= 0,
+	/*
+	 * All requests are processed in RR based on certain ID (Client ID,
+	 * Pool ID, Container ID, JobID, UID, etc.)
+	 */
+	SCHED_POLICY_ID_RR,
+	/*
+	 * Request priority is based on certain ID (Client ID, Pool ID,
+	 * Container ID, JobID, UID, etc.)
+	 */
+	SCHED_POLICY_ID_PRIO,
+	SCHED_POLICY_MAX
+};
+
+static int	sched_policy;
+
+static unsigned int max_delay_msecs[SCHED_REQ_MAX] = {
+	5000,	/* SCHED_REQ_IO */
+	10000,	/* SCHED_REQ_GC */
+	5000,	/* SCHED_REQ_MIGRATE */
+};
+
+static unsigned int max_qds[SCHED_REQ_MAX] = {
+	10240,	/* SCHED_REQ_IO */
+	1024,	/* SCHED_REQ_GC */
+	4096,	/* SCHED_REQ_MIGRATE */
+};
+
+static unsigned int req_throttle[SCHED_REQ_MAX] = {
+	0,	/* SCHED_REQ_IO */
+	30,	/* SCHED_REQ_GC */
+	30,	/* SCHED_REQ_REBUILD */
+};
+
+/*
+ * Throttle certain type of requests to N percent of IO requests
+ * in a cycle. IO requests can't be throttled.
+ */
+int
+sched_set_throttle(unsigned int type, unsigned int percent)
+{
+	if (percent >= 100) {
+		D_ERROR("Invalid throttle number: %d\n", percent);
+		return -DER_INVAL;
+	}
+
+	if (type >= SCHED_REQ_MAX) {
+		D_ERROR("Invalid request type: %d\n", type);
+		return -DER_INVAL;
+	}
+
+	if (type == SCHED_REQ_IO) {
+		D_ERROR("Can't throttle IO requests");
+		return -DER_INVAL;
+	}
+
+	req_throttle[type] = percent;
+	return 0;
+}
+
+static inline unsigned int
+pool2req_cnt(struct sched_pool_info *pool_info, unsigned int type)
+{
+	D_ASSERT(type < SCHED_REQ_MAX);
+	return pool_info->spi_req_array[type].sri_req_cnt;
+}
+
+static inline d_list_t *
+pool2req_list(struct sched_pool_info *pool_info, unsigned int type)
+{
+	D_ASSERT(type < SCHED_REQ_MAX);
+	return &pool_info->spi_req_array[type].sri_req_list;
+}
+
+static inline struct sched_pool_info *
+sched_rlink2spi(d_list_t *rlink)
+{
+	return container_of(rlink, struct sched_pool_info, spi_hash_link);
+}
+
+static bool
+spi_key_cmp(struct d_hash_table *htable, d_list_t *rlink,
+	    const void *key, unsigned int len)
+{
+	struct sched_pool_info	*spi = sched_rlink2spi(rlink);
+
+	D_ASSERT(len == sizeof(uuid_t));
+	return uuid_compare(*(uuid_t *)key, spi->spi_pool_id) == 0;
+}
+
+static uint32_t
+spi_key_hash(struct d_hash_table *htable, const void *key, unsigned int len)
+{
+	D_ASSERT(len == sizeof(uuid_t));
+	return d_hash_string_u32((const char *)key, len);
+}
+
+static void
+spi_rec_addref(struct d_hash_table *htable, d_list_t *rlink)
+{
+	struct sched_pool_info	*spi = sched_rlink2spi(rlink);
+
+	spi->spi_ref++;
+}
+
+static bool
+spi_rec_decref(struct d_hash_table *htable, d_list_t *rlink)
+{
+	struct sched_pool_info	*spi = sched_rlink2spi(rlink);
+
+	D_ASSERT(spi->spi_ref > 0);
+	spi->spi_ref--;
+
+	return spi->spi_ref == 0;
+}
+
+static void
+spi_rec_free(struct d_hash_table *htable, d_list_t *rlink)
+{
+	struct sched_pool_info	*spi = sched_rlink2spi(rlink);
+	unsigned int		 type;
+
+	for (type = SCHED_REQ_IO; type < SCHED_REQ_MAX; type++) {
+		D_ASSERT(pool2req_cnt(spi, type) == 0);
+		D_ASSERT(d_list_empty(pool2req_list(spi, type)));
+	}
+
+	D_FREE(spi);
+}
+
+static d_hash_table_ops_t sched_pool_hash_ops = {
+	.hop_key_cmp	= spi_key_cmp,
+	.hop_key_hash	= spi_key_hash,
+	.hop_rec_addref	= spi_rec_addref,
+	.hop_rec_decref	= spi_rec_decref,
+	.hop_rec_free	= spi_rec_free,
+};
+
+/*
+ * d_hash_table_traverse() doesn't support item deletion in traverse
+ * callback, so the stale 'spi' (pool was destroyed) will be added into
+ * a purge list in traverse callback and being deleted later.
+ */
+struct purge_item {
+	d_list_t	pi_link;
+	uuid_t		pi_pool_id;
+};
+
+static void
+prune_purge_list(struct dss_xstream *dx)
+{
+	struct sched_info	*info = &dx->dx_sched_info;
+	struct purge_item	*pi, *tmp;
+	bool			 deleted;
+
+	d_list_for_each_entry_safe(pi, tmp, &info->si_purge_list, pi_link) {
+		deleted = d_hash_rec_delete(info->si_pool_hash, pi->pi_pool_id,
+					    sizeof(uuid_t));
+		if (!deleted)
+			D_ERROR("XS(%d): Purge "DF_UUID" failed.\n",
+				dx->dx_xs_id, DP_UUID(pi->pi_pool_id));
+
+		d_list_del_init(&pi->pi_link);
+		D_FREE(pi);
+	}
+}
+
+static void
+add_purge_list(struct dss_xstream *dx, struct sched_pool_info *spi)
+{
+	struct sched_info	*info = &dx->dx_sched_info;
+	struct purge_item	*pi;
+
+	D_ALLOC_PTR(pi);
+	if (pi == NULL) {
+		D_ERROR("XS(%d): Alloc purge item failed.\n", dx->dx_xs_id);
+		return;
+	}
+	D_INIT_LIST_HEAD(&pi->pi_link);
+	uuid_copy(pi->pi_pool_id, spi->spi_pool_id);
+	d_list_add_tail(&pi->pi_link, &info->si_purge_list);
+}
+
+static void
+sched_info_fini(struct dss_xstream *dx)
+{
+	struct sched_info	*info = &dx->dx_sched_info;
+	struct sched_request	*req, *tmp;
+
+	D_ASSERT(info->si_req_cnt == 0);
+	D_ASSERT(d_list_empty(&info->si_sleep_list));
+	D_ASSERT(d_list_empty(&info->si_fifo_list));
+
+	prune_purge_list(dx);
+
+	if (info->si_pool_hash) {
+		d_hash_table_destroy(info->si_pool_hash, true);
+		info->si_pool_hash = NULL;
+	}
+
+	d_list_for_each_entry_safe(req, tmp, &info->si_idle_list,
+				   sr_link) {
+		d_list_del_init(&req->sr_link);
+		D_FREE(req);
+	}
+}
+
+static int
+prealloc_requests(struct sched_info *info, int cnt)
+{
+	struct sched_request	*req;
+	int			 i;
+
+	for (i = 0; i < cnt; i++) {
+		D_ALLOC_PTR(req);
+		if (req == NULL) {
+			D_ERROR("Alloc req failed.\n");
+			return -DER_NOMEM;
+		}
+		D_INIT_LIST_HEAD(&req->sr_link);
+		req->sr_ult = ABT_THREAD_NULL;
+		d_list_add_tail(&req->sr_link, &info->si_idle_list);
+	}
+	return 0;
+}
+
+#define SCHED_PREALLOC_INIT_CNT		8192
+#define SCHED_PREALLOC_BATCH_CNT	1024
+
+static int
+sched_info_init(struct dss_xstream *dx)
+{
+	struct sched_info	*info = &dx->dx_sched_info;
+	int			 rc;
+
+	info->si_cur_ts = daos_getntime_coarse() / 1000000;
+	D_INIT_LIST_HEAD(&info->si_idle_list);
+	D_INIT_LIST_HEAD(&info->si_sleep_list);
+	D_INIT_LIST_HEAD(&info->si_fifo_list);
+	D_INIT_LIST_HEAD(&info->si_purge_list);
+	info->si_req_cnt = 0;
+	info->si_stop = 0;
+
+	rc = d_hash_table_create(D_HASH_FT_NOLOCK, 4,
+				 NULL, &sched_pool_hash_ops,
+				 &info->si_pool_hash);
+	if (rc) {
+		D_ERROR("XS(%d): Create sched pool hash failed. "DF_RC".\n",
+			dx->dx_xs_id, DP_RC(rc));
+		return rc;
+	}
+
+	rc = prealloc_requests(info, SCHED_PREALLOC_INIT_CNT);
+	if (rc)
+		sched_info_fini(dx);
+
+	return rc;
+}
+
+static struct sched_pool_info *
+cur_pool_info(struct sched_info *info, uuid_t pool_uuid)
+{
+	struct sched_pool_info	*spi;
+	d_list_t		*rlink, *list;
+	unsigned int		 type;
+	int			 rc;
+
+	D_ASSERT(info->si_pool_hash != NULL);
+	rlink = d_hash_rec_find(info->si_pool_hash, pool_uuid, sizeof(uuid_t));
+	if (rlink != NULL) {
+		spi = sched_rlink2spi(rlink);
+		D_ASSERT(spi->spi_ref > 1);
+		d_hash_rec_decref(info->si_pool_hash, rlink);
+
+		return spi;
+	}
+
+	D_ALLOC_PTR(spi);
+	if (spi == NULL) {
+		D_ERROR("Failed to allocate spi\n");
+		return NULL;
+	}
+	D_INIT_LIST_HEAD(&spi->spi_hash_link);
+	uuid_copy(spi->spi_pool_id, pool_uuid);
+
+	for (type = SCHED_REQ_IO; type < SCHED_REQ_MAX; type++) {
+		list = pool2req_list(spi, type);
+		D_INIT_LIST_HEAD(list);
+	}
+
+	rc = d_hash_rec_insert(info->si_pool_hash, pool_uuid, sizeof(uuid_t),
+			       &spi->spi_hash_link, false);
+	if (rc)
+		D_ERROR("Failed to insert pool hash. "DF_RC"\n", DP_RC(rc));
+
+	D_ASSERT(spi->spi_ref == 1);
+	return spi;
+}
+
+
+static struct sched_request *
+req_get(struct dss_xstream *dx, struct sched_req_attr *attr,
+	void (*func)(void *), void *arg, ABT_thread ult)
+{
+	struct sched_info	*info = &dx->dx_sched_info;
+	struct sched_pool_info	*spi;
+	struct sched_request	*req;
+	int			 rc;
+
+	spi = cur_pool_info(info, attr->sra_pool_id);
+	if (spi == NULL) {
+		D_ERROR("XS(%d): get pool info "DF_UUID" failed.\n",
+			dx->dx_xs_id, DP_UUID(attr->sra_pool_id));
+		return NULL;
+	}
+
+	if (d_list_empty(&info->si_idle_list)) {
+		rc = prealloc_requests(info, SCHED_PREALLOC_BATCH_CNT);
+		if (rc)
+			return NULL;
+	}
+
+	req = d_list_entry(info->si_idle_list.next, struct sched_request,
+			   sr_link);
+	d_list_del_init(&req->sr_link);
+
+	req->sr_attr	= *attr;
+	req->sr_func	= func;
+	req->sr_arg	= arg;
+	req->sr_ult	= ult;
+	req->sr_abort	= 0;
+	req->sr_pool_info = spi;
+
+	return req;
+}
+
+static void
+req_put(struct dss_xstream *dx, struct sched_request *req)
+{
+	struct sched_info	*info = &dx->dx_sched_info;
+
+	D_ASSERT(d_list_empty(&req->sr_link));
+	/* Don't put into idle list when the request is tracked by caller */
+	if (req->sr_ult == ABT_THREAD_NULL)
+		d_list_add_tail(&req->sr_link, &info->si_idle_list);
+}
+
+static int
+req_kickoff_internal(struct dss_xstream *dx, struct sched_req_attr *attr,
+		     void (*func)(void *), void *arg)
+{
+	ABT_pool	abt_pool;
+	int		rc;
+
+	D_ASSERT(attr && func && arg);
+	switch (attr->sra_type) {
+	case SCHED_REQ_IO:
+		abt_pool = dx->dx_pools[DSS_POOL_IO];
+		break;
+	case SCHED_REQ_GC:
+		abt_pool = dx->dx_pools[DSS_POOL_GC];
+		break;
+	case SCHED_REQ_MIGRATE:
+		abt_pool = dx->dx_pools[DSS_POOL_REBUILD];
+		break;
+	default:
+		D_ASSERTF(0, "Invalid req type: %u\n", attr->sra_type);
+		break;
+	}
+
+	rc = ABT_thread_create(abt_pool, func, arg, ABT_THREAD_ATTR_NULL, NULL);
+
+	return dss_abterr2der(rc);
+}
+
+static int
+req_kickoff(struct dss_xstream *dx, struct sched_request *req)
+{
+	struct sched_info	*info = &dx->dx_sched_info;
+	struct sched_pool_info	*spi = req->sr_pool_info;
+	struct sched_req_info	*sri;
+	int			 rc;
+
+	if (req->sr_ult != ABT_THREAD_NULL) {
+		rc = ABT_thread_resume(req->sr_ult);
+		rc = dss_abterr2der(rc);
+	} else {
+		rc = req_kickoff_internal(dx, &req->sr_attr, req->sr_func,
+					  req->sr_arg);
+	}
+
+	D_ASSERT(spi != NULL);
+	D_ASSERT(req->sr_attr.sra_type < SCHED_REQ_MAX);
+	sri = &spi->spi_req_array[req->sr_attr.sra_type];
+
+	D_ASSERT(sri->sri_req_cnt > 0);
+	sri->sri_req_cnt--;
+	D_ASSERT(info->si_req_cnt > 0);
+	info->si_req_cnt--;
+
+	d_list_del_init(&req->sr_link);
+	req_put(dx, req);
+
+	return rc;
+}
+
+#define SCHED_SPACE_AGE_MAX	2000	/* 2000 msecs */
+
+static int
+check_space_pressure(struct dss_xstream *dx, struct sched_pool_info *spi,
+		     bool purge)
+{
+	struct sched_info	*info = &dx->dx_sched_info;
+	struct vos_pool_space	 vps = { 0 };
+	uint64_t		 scm_left, nvme_left;
+	int			 rc;
+
+	D_ASSERT(spi->spi_space_ts <= info->si_cur_ts);
+	/* Use cached space presure info */
+	if ((spi->spi_space_ts + SCHED_SPACE_AGE_MAX) > info->si_cur_ts)
+		goto out;
+
+	rc = vos_pool_query_space(spi->spi_pool_id, &vps);
+	if (rc == -DER_NONEXIST) {	/* vos pool is destroyed */
+		D_CDEBUG(purge, DB_TRACE, DLOG_ERR,
+			 "XS(%d): vos pool:"DF_UUID" is destroyed.\n",
+			 dx->dx_xs_id, DP_UUID(spi->spi_pool_id));
+		if (purge)
+			add_purge_list(dx, spi);
+		goto out;
+	} else if (rc) {
+		D_ERROR("XS(%d): query pool:"DF_UUID" space failed. "DF_RC"\n",
+			dx->dx_xs_id, DP_UUID(spi->spi_pool_id), DP_RC(rc));
+		goto out;
+	}
+	spi->spi_space_ts = info->si_cur_ts;
+
+	D_ASSERT(SCM_SYS(&vps) < SCM_TOTAL(&vps));
+	/* NVME_TOTAL and NVME_SYS could be both zero */
+	D_ASSERT(NVME_SYS(&vps) <= NVME_TOTAL(&vps));
+
+	if (SCM_FREE(&vps) > SCM_SYS(&vps))
+		scm_left = SCM_FREE(&vps) - SCM_SYS(&vps);
+	else
+		scm_left = 0;
+
+	if (NVME_FREE(&vps) > NVME_SYS(&vps))
+		nvme_left = NVME_FREE(&vps) - NVME_SYS(&vps);
+	else
+		nvme_left = 0;
+
+	if (scm_left < (SCM_TOTAL(&vps) * 1 / 10) ||
+	    nvme_left < (NVME_TOTAL(&vps) * 1 / 10))
+		spi->spi_space_pressure = SCHED_SPACE_PRESS_SEVERE;
+	else if (scm_left < (SCM_TOTAL(&vps) * 3 / 10) ||
+		 nvme_left < (NVME_TOTAL(&vps) * 3 / 10))
+		spi->spi_space_pressure = SCHED_SPACE_PRESS_LIGHT;
+	else
+		spi->spi_space_pressure = SCHED_SPACE_PRESS_NONE;
+
+	if (spi->spi_space_pressure != 0)
+		D_WARN("XS(%d): pool:"DF_UUID" is under %s presure, "
+		       "SCM: tot["DF_U64"], sys["DF_U64"], free["DF_U64"] "
+		       "NVMe: tot["DF_U64"], sys["DF_U64"], free["DF_U64"]\n",
+		       dx->dx_xs_id, DP_UUID(spi->spi_pool_id),
+		       spi->spi_space_pressure == 1 ? "light" : "severe",
+		       SCM_TOTAL(&vps), SCM_SYS(&vps), SCM_FREE(&vps),
+		       NVME_TOTAL(&vps), NVME_SYS(&vps), NVME_FREE(&vps));
+out:
+	return spi->spi_space_pressure;
+}
+
+static int
+process_req(struct dss_xstream *dx, struct sched_request *req)
+{
+	struct sched_info	*info = &dx->dx_sched_info;
+	struct sched_pool_info	*spi = req->sr_pool_info;
+	struct sched_req_info	*sri;
+	unsigned int		 req_type = req->sr_attr.sra_type;
+
+	D_ASSERT(spi != NULL);
+	D_ASSERT(req_type < SCHED_REQ_MAX);
+
+	sri = &spi->spi_req_array[req_type];
+
+	/* Kickoff all requests on shutdown */
+	if (info->si_stop)
+		goto kickoff;
+
+	if (sri->sri_req_kicked < sri->sri_req_limit)
+		goto kickoff;
+
+	/* Request expired */
+	D_ASSERT(info->si_cur_ts >= req->sr_enqueue_ts);
+	if ((info->si_cur_ts - req->sr_enqueue_ts) > max_delay_msecs[req_type])
+		goto kickoff;
+
+	/* Remaining requests are not expired */
+	return 1;
+kickoff:
+	sri->sri_req_kicked++;
+	req_kickoff(dx, req);
+	return 0;
+}
+
+static inline void
+process_req_list(struct dss_xstream *dx, d_list_t *list)
+{
+	struct sched_request	*req, *tmp;
+	int			 rc;
+
+	d_list_for_each_entry_safe(req, tmp, list, sr_link) {
+		rc = process_req(dx, req);
+		if (rc)
+			break;
+	}
+}
+
+static inline void
+reset_req_limit(struct dss_xstream *dx, struct sched_pool_info *spi,
+		unsigned int req_type, unsigned int limit)
+{
+	unsigned int	tot = pool2req_cnt(spi, req_type);
+
+	D_ASSERT(limit <= tot);
+	if (tot - limit > max_qds[req_type]) {
+		D_CRIT("XS(%d) Too large QD: %u/%u/%u for req:%d\n",
+		       dx->dx_xs_id, tot, max_qds[req_type], limit, req_type);
+		limit = tot - max_qds[req_type];
+	}
+	spi->spi_req_array[req_type].sri_req_limit = limit;
+	spi->spi_req_array[req_type].sri_req_kicked = 0;
+}
+
+static int
+process_pool_cb(d_list_t *rlink, void *arg)
+{
+	struct dss_xstream	*dx = (struct dss_xstream *)arg;
+	struct sched_pool_info	*spi;
+	unsigned int		 io_max, gc_max, mig_max;
+	unsigned int		 gc_thr, mig_thr;
+	int			 rc;
+
+	spi = sched_rlink2spi(rlink);
+
+	gc_thr	= req_throttle[SCHED_REQ_GC];
+	mig_thr	= req_throttle[SCHED_REQ_MIGRATE];
+	D_ASSERT(gc_thr < 100 && mig_thr < 100);
+
+	io_max	= pool2req_cnt(spi, SCHED_REQ_IO);
+	gc_max	= pool2req_cnt(spi, SCHED_REQ_GC);
+	mig_max	= pool2req_cnt(spi, SCHED_REQ_MIGRATE);
+
+	rc = check_space_pressure(dx, spi, true);
+
+	switch (rc) {
+	case SCHED_SPACE_PRESS_SEVERE:
+		if ((gc_max / 2) > 0)
+			io_max = min(io_max, gc_max / 2);
+		else if (gc_max)
+			io_max = min(io_max, gc_max);
+		break;
+	case SCHED_SPACE_PRESS_LIGHT:
+		if (gc_max)
+			io_max = min(gc_max, io_max);
+		break;
+	case SCHED_SPACE_PRESS_NONE:
+		if (io_max && gc_max && gc_thr) {
+			gc_thr = min(1, io_max * gc_thr / 100);
+			gc_max = min(gc_max, gc_thr);
+		}
+		break;
+	default:
+		D_ASSERT(0);
+		break;
+	}
+
+	/* Throttle rebuild and reintegraion */
+	if (mig_max && io_max && mig_thr) {
+		mig_thr = min(1, io_max * mig_thr / 100);
+		mig_max = min(mig_max, mig_thr);
+	}
+
+	reset_req_limit(dx, spi, SCHED_REQ_IO, io_max);
+	reset_req_limit(dx, spi, SCHED_REQ_GC, gc_max);
+	reset_req_limit(dx, spi, SCHED_REQ_MIGRATE, mig_max);
+
+	process_req_list(dx, pool2req_list(spi, SCHED_REQ_GC));
+	process_req_list(dx, pool2req_list(spi, SCHED_REQ_MIGRATE));
+
+	return 0;
+}
+
+static void
+policy_fifo_enqueue(struct dss_xstream *dx, struct sched_request *req,
+		    void *prio_data)
+{
+	struct sched_info	*info = &dx->dx_sched_info;
+
+	d_list_add_tail(&req->sr_link, &info->si_fifo_list);
+}
+
+static void
+policy_fifo_process(struct dss_xstream *dx)
+{
+	struct sched_info	*info = &dx->dx_sched_info;
+
+	process_req_list(dx, &info->si_fifo_list);
+}
+
+struct sched_policy_ops {
+	void (*enqueue_io)(struct dss_xstream *dx, struct sched_request *req,
+			   void *prio_data);
+	void (*process_io)(struct dss_xstream *dx);
+};
+
+static struct sched_policy_ops	policy_ops[SCHED_POLICY_MAX] = {
+	{	/* SCHED_POLICY_FIFO */
+		.enqueue_io = policy_fifo_enqueue,
+		.process_io = policy_fifo_process,
+	},
+	{	/* SCHED_POLICY_ID_RR */
+		.enqueue_io = NULL,
+		.process_io = NULL,
+	},
+	{	/* SCHED_POLICY_ID_PRIO */
+		.enqueue_io = NULL,
+		.process_io = NULL,
+	}
+};
+
+static void
+process_all(struct dss_xstream *dx)
+{
+	struct sched_info	*info = &dx->dx_sched_info;
+	int			 rc;
+
+	if (info->si_req_cnt == 0) {
+		D_ASSERT(d_list_empty(&info->si_fifo_list));
+		return;
+	}
+
+	prune_purge_list(dx);
+	rc = d_hash_table_traverse(info->si_pool_hash, process_pool_cb, dx);
+	if (rc)
+		D_ERROR("XS(%d) traverse pool hash error. "DF_RC"\n",
+			dx->dx_xs_id, DP_RC(rc));
+
+	D_ASSERT(policy_ops[sched_policy].process_io != NULL);
+	policy_ops[sched_policy].process_io(dx);
+}
+
+static inline bool
+should_enqueue_req(struct dss_xstream *dx, struct sched_req_attr *attr)
+{
+	struct sched_info	*info = &dx->dx_sched_info;
+
+	if (sched_prio_disabled || info->si_stop)
+		return false;
+
+	D_ASSERT(attr->sra_type == SCHED_REQ_GC ||
+		 attr->sra_type == SCHED_REQ_IO ||
+		 attr->sra_type == SCHED_REQ_MIGRATE);
+
+	/* For VOS xstream only */
+	return dx->dx_main_xs;
+}
+
+static void
+req_enqueue(struct dss_xstream *dx, struct sched_request *req)
+{
+	struct sched_info	*info = &dx->dx_sched_info;
+	struct sched_req_attr	*attr = &req->sr_attr;
+	struct sched_req_info	*sri;
+
+	D_ASSERT(req->sr_pool_info != NULL);
+	sri = &req->sr_pool_info->spi_req_array[attr->sra_type];
+
+	D_ASSERT(d_list_empty(&req->sr_link));
+	if (attr->sra_type == SCHED_REQ_IO) {
+		D_ASSERT(policy_ops[sched_policy].enqueue_io != NULL);
+		policy_ops[sched_policy].enqueue_io(dx, req, NULL);
+	} else {
+		d_list_add_tail(&req->sr_link, &sri->sri_req_list);
+	}
+	req->sr_enqueue_ts = info->si_cur_ts;
+
+	sri->sri_req_cnt++;
+	info->si_req_cnt++;
+}
+
+int
+sched_req_enqueue(struct dss_xstream *dx, struct sched_req_attr *attr,
+		  void (*func)(void *), void *arg)
+{
+	struct sched_request	*req;
+
+	if (!should_enqueue_req(dx, attr))
+		return req_kickoff_internal(dx, attr, func, arg);
+
+	D_ASSERT(attr->sra_type < SCHED_REQ_MAX);
+	req = req_get(dx, attr, func, arg, ABT_THREAD_NULL);
+	if (req == NULL) {
+		D_ERROR("XS(%d): get req failed.\n", dx->dx_xs_id);
+		return -DER_NOMEM;
+	}
+	req_enqueue(dx, req);
+
+	return 0;
+}
+
+void
+sched_req_yield(struct sched_request *req)
+{
+	struct dss_xstream	*dx = dss_current_xstream();
+
+	D_ASSERT(req != NULL);
+	if (!should_enqueue_req(dx, &req->sr_attr)) {
+		ABT_thread_yield();
+		return;
+	}
+
+	D_ASSERT(req->sr_ult != ABT_THREAD_NULL);
+	req_enqueue(dx, req);
+
+	ABT_self_suspend();
+}
+
+void
+sched_req_sleep(struct sched_request *req, uint32_t msecs)
+{
+	struct dss_xstream	*dx = dss_current_xstream();
+	struct sched_info	*info = &dx->dx_sched_info;
+	struct sched_request	*tmp;
+	int			 rc;
+
+	D_ASSERT(req != NULL);
+	if (msecs == 0 || info->si_stop || req->sr_abort) {
+		sched_req_yield(req);
+		return;
+	}
+
+	/* Don't put GC & aggregation ULTs in sleep under space pressure */
+	if (req->sr_attr.sra_type == SCHED_REQ_GC) {
+		D_ASSERT(req->sr_pool_info != NULL);
+		rc = check_space_pressure(dx, req->sr_pool_info, false);
+		if (rc != 0) {	/* under space pressure */
+			sched_req_yield(req);
+			return;
+		}
+	}
+
+	D_ASSERT(req->sr_ult != ABT_THREAD_NULL);
+	req->sr_wakeup_time = info->si_cur_ts + msecs;
+
+	D_ASSERT(d_list_empty(&req->sr_link));
+	/* Sleep list is sorted in wakeup time ascending order */
+	d_list_for_each_entry_reverse(tmp, &info->si_sleep_list, sr_link) {
+		if (req->sr_wakeup_time >= tmp->sr_wakeup_time) {
+			d_list_add(&req->sr_link, &tmp->sr_link);
+			break;
+		}
+	}
+	if (d_list_empty(&req->sr_link))
+		d_list_add(&req->sr_link, &info->si_sleep_list);
+
+	ABT_self_suspend();
+}
+
+void
+sched_req_wakeup(struct sched_request *req)
+{
+	D_ASSERT(req != NULL);
+	/* The request is not in sleep */
+	if (req->sr_wakeup_time == 0) {
+		D_ASSERT(d_list_empty(&req->sr_link));
+		return;
+	}
+
+	D_ASSERT(!d_list_empty(&req->sr_link));
+	d_list_del_init(&req->sr_link);
+	req->sr_wakeup_time = 0;
+	D_ASSERT(req->sr_ult != ABT_THREAD_NULL);
+	ABT_thread_resume(req->sr_ult);
+}
+
+void
+sched_req_wait(struct sched_request *req, bool abort)
+{
+	D_ASSERT(req != NULL);
+	if (abort) {
+		req->sr_abort = 1;
+		sched_req_wakeup(req);
+	}
+	D_ASSERT(req->sr_ult != ABT_THREAD_NULL);
+	ABT_thread_join(req->sr_ult);
+}
+
+inline bool
+sched_req_is_aborted(struct sched_request *req)
+{
+	D_ASSERT(req != NULL);
+	return req->sr_abort != 0;
+}
+
+int
+sched_req_space_check(struct sched_request *req)
+{
+	struct dss_xstream	*dx = dss_current_xstream();
+
+	D_ASSERT(req != NULL && req->sr_pool_info != NULL);
+	return check_space_pressure(dx, req->sr_pool_info, false);
+}
+
+static void
+wakeup_all(struct dss_xstream *dx)
+{
+	struct sched_info	*info = &dx->dx_sched_info;
+	struct sched_request	*req, *tmp;
+
+	/* Update current ts stored in sched_info */
+	info->si_cur_ts = daos_getntime_coarse() / 1000000;
+
+	d_list_for_each_entry_safe(req, tmp, &info->si_sleep_list, sr_link) {
+		D_ASSERT(req->sr_wakeup_time > 0);
+		if (!info->si_stop && req->sr_wakeup_time > info->si_cur_ts)
+			break;
+
+		if (!should_enqueue_req(dx, &req->sr_attr)) {
+			sched_req_wakeup(req);
+		} else {
+			d_list_del_init(&req->sr_link);
+			req->sr_wakeup_time = 0;
+			D_ASSERT(req->sr_ult != ABT_THREAD_NULL);
+			req_enqueue(dx, req);
+		}
+	}
+}
+
+struct sched_request *
+sched_req_get(struct sched_req_attr *attr, ABT_thread ult)
+{
+	struct dss_xstream	*dx = dss_current_xstream();
+	int			 rc;
+
+	D_ASSERT(attr->sra_type == SCHED_REQ_GC ||
+		 attr->sra_type == SCHED_REQ_IO ||
+		 attr->sra_type == SCHED_REQ_MIGRATE);
+
+	if (ult == ABT_THREAD_NULL) {
+		ABT_thread	self;
+
+		rc = ABT_thread_self(&self);
+		if (rc) {
+			D_ERROR("Failed to get self thread. "DF_RC"\n",
+				DP_RC(dss_abterr2der(rc)));
+			return NULL;
+		}
+		ult = self;
+	}
+
+	return req_get(dx, attr, NULL, NULL, ult);
+}
+
+void
+sched_req_put(struct sched_request *req)
+{
+	struct dss_xstream	*dx = dss_current_xstream();
+	struct sched_info	*info = &dx->dx_sched_info;
+
+	D_ASSERT(req != NULL && req->sr_ult != ABT_THREAD_NULL);
+	D_ASSERT(d_list_empty(&req->sr_link));
+	d_list_add_tail(&req->sr_link, &info->si_idle_list);
+}
+
+void
+sched_stop(struct dss_xstream *dx)
+{
+	struct sched_info	*info = &dx->dx_sched_info;
+
+	info->si_stop = 1;
+	wakeup_all(dx);
+	process_all(dx);
+}
 
 /*
  * A schedule cycle consists of three stages:
@@ -36,20 +966,11 @@
  * 3. Ending with a NVMe poll ULT;
  *
  * Extra network & NVMe poll ULTs could be scheduled in executing stage
- * according to network/NVMe poll age and request/IO statistics.
+ * according to network/NVMe poll age;
  */
 struct sched_cycle {
 	uint32_t	sc_ults_cnt[DSS_POOL_CNT];
 	uint32_t	sc_ults_tot;
-	/*
-	 * bound[0]: Minimum network/NVMe poll age, scheduler always try to
-	 * execute few ULTs (if there is any) before next poll.
-	 *
-	 * bound[1]: Maximum network/NVMe poll age, scheduler will do an extra
-	 * poll if it's not polled after executing cerntain amount of ULTs.
-	 */
-	uint32_t	sc_age_net_bound[2];
-	uint32_t	sc_age_nvme_bound[2];
 	uint32_t	sc_age_net;
 	uint32_t	sc_age_nvme;
 	unsigned int	sc_new_cycle:1,
@@ -62,37 +983,6 @@ struct sched_data {
 	uint32_t		 sd_event_freq;
 };
 
-static unsigned int sched_throttle[DSS_POOL_CNT] = {
-	0,	/* DSS_POOL_NET_POLL */
-	0,	/* DSS_POOL_NVME_POLL */
-	0,	/* DSS_POOL_IO */
-	30,	/* DSS_POOL_REBUILD */
-	0,	/* DSS_POOL_AGGREGATE */
-	0,	/* DSS_POOL_GC */
-};
-
-int
-sched_set_throttle(int pool_idx, unsigned int percent)
-{
-	if (percent >= 100) {
-		D_ERROR("Invalid throttle number: %d\n", percent);
-		return -DER_INVAL;
-	}
-
-	if (pool_idx >= DSS_POOL_CNT) {
-		D_ERROR("Invalid pool idx: %d\n", pool_idx);
-		return -DER_INVAL;
-	}
-
-	if (pool_idx == DSS_POOL_NET_POLL || pool_idx == DSS_POOL_NVME_POLL) {
-		D_ERROR("Can't throttle network or NVMe poll\n");
-		return -DER_INVAL;
-	}
-
-	sched_throttle[pool_idx] = percent;
-	return 0;
-}
-
 /* #define SCHED_DEBUG */
 static void
 sched_dump_data(struct sched_data *data)
@@ -101,31 +991,24 @@ sched_dump_data(struct sched_data *data)
 	struct dss_xstream	*dx = data->sd_dx;
 	struct sched_cycle	*cycle = &data->sd_cycle;
 
-	D_PRINT("XS(%d): comm:%d main:%d. age_net:%u, [%u, %u], "
-		"age_nvme:%u, [%u, %u] new_cycle:%d cycle_started:%d "
-		"total_ults:%u [%u, %u, %u, %u]\n", dx->dx_xs_id,
-		dx->dx_comm, dx->dx_main_xs, cycle->sc_age_net,
-		cycle->sc_age_net_bound[0], cycle->sc_age_net_bound[1],
-		cycle->sc_age_nvme, cycle->sc_age_nvme_bound[0],
-		cycle->sc_age_nvme_bound[1], cycle->sc_new_cycle,
+	D_PRINT("XS(%d): comm:%d main:%d. age_net:%u, age_nvme:%u, "
+		"new_cycle:%d cycle_started:%d total_ults:%u [%u, %u, %u]\n",
+		dx->dx_xs_id, dx->dx_comm, dx->dx_main_xs, cycle->sc_age_net,
+		cycle->sc_age_nvme, cycle->sc_new_cycle,
 		cycle->sc_cycle_started, cycle->sc_ults_tot,
 		cycle->sc_ults_cnt[DSS_POOL_IO],
 		cycle->sc_ults_cnt[DSS_POOL_REBUILD],
-		cycle->sc_ults_cnt[DSS_POOL_AGGREGATE],
 		cycle->sc_ults_cnt[DSS_POOL_GC]);
 #endif
 }
 
-#define SCHED_AGE_NET_MIN		32
 #define SCHED_AGE_NET_MAX		512
-#define SCHED_AGE_NVME_MIN		32
 #define SCHED_AGE_NVME_MAX		512
 
 static int
 sched_init(ABT_sched sched, ABT_sched_config config)
 {
 	struct sched_data	*data;
-	struct sched_cycle	*cycle;
 	int			 ret;
 
 	D_ALLOC_PTR(data);
@@ -139,12 +1022,6 @@ sched_init(ABT_sched sched, ABT_sched_config config)
 		D_FREE(data);
 		return ret;
 	}
-
-	cycle = &data->sd_cycle;
-	cycle->sc_age_net_bound[0] = SCHED_AGE_NET_MIN;
-	cycle->sc_age_net_bound[1] = SCHED_AGE_NET_MAX;
-	cycle->sc_age_nvme_bound[0] = SCHED_AGE_NVME_MIN;
-	cycle->sc_age_nvme_bound[1] = SCHED_AGE_NVME_MAX;
 
 	ret = ABT_sched_set_data(sched, (void *)data);
 	return ret;
@@ -167,10 +1044,8 @@ need_net_poll(struct sched_cycle *cycle)
 	 * Need extra net poll when too many ULTs are processed in
 	 * current cycle.
 	 */
-	if (cycle->sc_age_net > cycle->sc_age_net_bound[1])
+	if (cycle->sc_age_net > SCHED_AGE_NET_MAX)
 		return true;
-
-	/* TODO: Take network request statistics into account */
 
 	return false;
 }
@@ -221,6 +1096,13 @@ need_nvme_poll(struct sched_cycle *cycle)
 
 	/* Need nvme poll to end current cycle */
 	if (cycle->sc_ults_tot == 0)
+		return true;
+
+	/*
+	 * Need extra NVMe poll when too many ULTs are processed in
+	 * current cycle.
+	 */
+	if (cycle->sc_age_nvme > SCHED_AGE_NVME_MAX)
 		return true;
 
 	dmi = dss_get_module_info();
@@ -305,8 +1187,6 @@ sched_start_cycle(struct sched_data *data, ABT_pool *pools)
 	struct dss_xstream	*dx = data->sd_dx;
 	struct sched_cycle	*cycle = &data->sd_cycle;
 	size_t			 cnt;
-	uint32_t		 limit = 0;
-	bool			 space_pressure = false;
 	int			 i, ret;
 
 	D_ASSERT(cycle->sc_new_cycle == 1);
@@ -315,6 +1195,9 @@ sched_start_cycle(struct sched_data *data, ABT_pool *pools)
 
 	cycle->sc_new_cycle = 0;
 	cycle->sc_cycle_started = 1;
+
+	wakeup_all(dx);
+	process_all(dx);
 
 	/* Get number of ULTS for each ABT pool */
 	for (i = DSS_POOL_IO; i < DSS_POOL_CNT; i++) {
@@ -329,46 +1212,6 @@ sched_start_cycle(struct sched_data *data, ABT_pool *pools)
 
 		cycle->sc_ults_cnt[i] = cnt;
 		cycle->sc_ults_tot += cycle->sc_ults_cnt[i];
-
-		if (sched_throttle[i] > 0 && cycle->sc_ults_cnt[i] > 1)
-			limit = 1;
-	}
-
-	/* No throttling for helper xstream so far */
-	if (!dx->dx_main_xs)
-		return;
-
-	if (!limit && !space_pressure)
-		return;
-
-	/*
-	 * Throttle the ABT pools which have throttle setting.
-	 * TODO: If it's under space pressure, throttle IO pool.
-	 */
-	for (i = DSS_POOL_IO; i < DSS_POOL_CNT; i++) {
-		unsigned int	throttle = sched_throttle[i];
-		int		diff;
-
-		if (sched_throttle[i] == 0)
-			continue;
-
-		/*
-		 * No ULTs from other ABT pools in current cycle, or too few
-		 * ULTs in current cycle.
-		 */
-		if (cycle->sc_ults_cnt[i] == cycle->sc_ults_tot ||
-		    cycle->sc_ults_tot <= cycle->sc_age_net_bound[0])
-			continue;
-
-		D_ASSERT(throttle < 100);
-		limit = max(cycle->sc_ults_tot * throttle / 100, 1);
-		diff = cycle->sc_ults_cnt[i] - limit;
-
-		if (diff > 0 &&
-		    (cycle->sc_ults_tot - diff) > cycle->sc_age_net_bound[0]) {
-			cycle->sc_ults_cnt[i] -= diff;
-			cycle->sc_ults_tot -= diff;
-		}
 	}
 }
 
@@ -500,6 +1343,7 @@ dss_sched_fini(struct dss_xstream *dx)
 	D_ASSERT(dx->dx_sched != ABT_SCHED_NULL);
 	/* Pools will be automatically freed by ABT_sched_free() */
 	ABT_sched_free(&dx->dx_sched);
+	sched_info_fini(dx);
 }
 
 int
@@ -523,22 +1367,30 @@ dss_sched_init(struct dss_xstream *dx)
 	};
 	int			rc;
 
+	rc = sched_info_init(dx);
+	if (rc)
+		return rc;
+
 	/* Create argobots pools */
 	rc = sched_create_pools(dx);
 	if (rc != ABT_SUCCESS)
-		goto out;
+		goto err_sched_info;
 
 	/* Create a scheduler config */
 	rc = ABT_sched_config_create(&config, event_freq, 512, dx_ptr, dx,
 				     ABT_sched_config_var_end);
 	if (rc != ABT_SUCCESS)
-		goto out;
+		goto err_pools;
 
 	rc = ABT_sched_create(&sched_def, DSS_POOL_CNT, dx->dx_pools, config,
 			      &dx->dx_sched);
 	ABT_sched_config_free(&config);
-out:
-	if (rc)
-		sched_free_pools(dx);
+
+	if (rc == ABT_SUCCESS)
+		return 0;
+err_pools:
+	sched_free_pools(dx);
+err_sched_info:
+	sched_info_fini(dx);
 	return dss_abterr2der(rc);
 }

--- a/src/iosrv/srv.c
+++ b/src/iosrv/srv.c
@@ -329,12 +329,11 @@ static int
 dss_iv_resp_hdlr(crt_context_t *ctx, void *hdlr_arg,
 		 void (*real_rpc_hdlr)(void *), void *arg)
 {
-	ABT_pool	pool, *pools = arg;
-	int		rc;
+	struct dss_xstream	*dx = (struct dss_xstream *)arg;
+	int			 rc;
 
-	pool = pools[DSS_POOL_IO];
-	rc = ABT_thread_create(pool, real_rpc_hdlr, hdlr_arg,
-			       ABT_THREAD_ATTR_NULL, NULL);
+	rc = ABT_thread_create(dx->dx_pools[DSS_POOL_IO], real_rpc_hdlr,
+			       hdlr_arg, ABT_THREAD_ATTR_NULL, NULL);
 	return dss_abterr2der(rc);
 }
 
@@ -342,16 +341,27 @@ static int
 dss_rpc_hdlr(crt_context_t *ctx, void *hdlr_arg,
 	     void (*real_rpc_hdlr)(void *), void *arg)
 {
-	ABT_pool	*pools = arg;
-	ABT_pool	 pool;
-	int		 rc;
+	struct dss_xstream	*dx = (struct dss_xstream *)arg;
+	crt_rpc_t		*rpc = (crt_rpc_t *)hdlr_arg;
+	unsigned int		 mod_id = opc_get_mod_id(rpc->cr_opc);
+	struct dss_module	*module = dss_module_get(mod_id);
+	struct sched_req_attr	 attr = { 0 };
+	int			 rc = -DER_NOSYS;
 
 	if (DAOS_FAIL_CHECK(DAOS_FAIL_LOST_REQ))
 		return 0;
+	/*
+	 * The mod_id for the RPC originated from CART is 0xfe, and 'module'
+	 * will be NULL for this case.
+	 */
+	if (module != NULL && module->sm_mod_ops != NULL &&
+	    module->sm_mod_ops->dms_get_req_attr != NULL)
+		rc = module->sm_mod_ops->dms_get_req_attr(rpc, &attr);
 
-	pool = pools[DSS_POOL_IO];
+	if (rc == 0)
+		return sched_req_enqueue(dx, &attr, real_rpc_hdlr, rpc);
 
-	rc = ABT_thread_create(pool, real_rpc_hdlr, hdlr_arg,
+	rc = ABT_thread_create(dx->dx_pools[DSS_POOL_IO], real_rpc_hdlr, rpc,
 			       ABT_THREAD_ATTR_NULL, NULL);
 	return dss_abterr2der(rc);
 }
@@ -378,6 +388,9 @@ static void
 wait_all_exited(struct dss_xstream *dx)
 {
 	D_DEBUG(DB_TRACE, "XS(%d) draining ULTs.\n", dx->dx_xs_id);
+
+	sched_stop(dx);
+
 	while (1) {
 		size_t	total_size = 0;
 		int	i;
@@ -461,8 +474,7 @@ dss_srv_handler(void *arg)
 		}
 
 		rc = crt_context_register_rpc_task(dmi->dmi_ctx, dss_rpc_hdlr,
-						   dss_iv_resp_hdlr,
-						   dx->dx_pools);
+						   dss_iv_resp_hdlr, dx);
 		if (rc != 0) {
 			D_ERROR("failed to register process cb "DF_RC"\n",
 				DP_RC(rc));
@@ -1135,7 +1147,7 @@ dss_parameters_set(unsigned int key_id, uint64_t value)
 			break;
 		}
 		D_WARN("set rebuild percentage to "DF_U64"\n", value);
-		rc = sched_set_throttle(DSS_POOL_REBUILD, value);
+		rc = sched_set_throttle(SCHED_REQ_MIGRATE, value);
 		break;
 	default:
 		D_ERROR("invalid key_id %d\n", key_id);

--- a/src/iosrv/ult.c
+++ b/src/iosrv/ult.c
@@ -119,7 +119,6 @@ sched_ult2pool(int ult_type)
 	case DSS_ULT_REBUILD:
 		return DSS_POOL_REBUILD;
 	case DSS_ULT_AGGREGATE:
-		return DSS_POOL_AGGREGATE;
 	case DSS_ULT_GC:
 		return DSS_POOL_GC;
 	default:

--- a/src/object/obj_rpc.h
+++ b/src/object/obj_rpc.h
@@ -354,4 +354,34 @@ obj_is_tgt_modification_opc(uint32_t opc)
 	       opc == DAOS_OBJ_RPC_TGT_PUNCH_AKEYS;
 }
 
+static inline bool
+obj_rpc_is_update(crt_rpc_t *rpc)
+{
+	return opc_get(rpc->cr_opc) == DAOS_OBJ_RPC_UPDATE ||
+	       opc_get(rpc->cr_opc) == DAOS_OBJ_RPC_TGT_UPDATE;
+}
+
+static inline bool
+obj_rpc_is_fetch(crt_rpc_t *rpc)
+{
+	return opc_get(rpc->cr_opc) == DAOS_OBJ_RPC_FETCH;
+}
+
+static inline bool
+obj_rpc_is_punch(crt_rpc_t *rpc)
+{
+	return opc_get(rpc->cr_opc) == DAOS_OBJ_RPC_PUNCH ||
+	       opc_get(rpc->cr_opc) == DAOS_OBJ_RPC_PUNCH_DKEYS ||
+	       opc_get(rpc->cr_opc) == DAOS_OBJ_RPC_PUNCH_AKEYS ||
+	       opc_get(rpc->cr_opc) == DAOS_OBJ_RPC_TGT_PUNCH ||
+	       opc_get(rpc->cr_opc) == DAOS_OBJ_RPC_TGT_PUNCH_DKEYS ||
+	       opc_get(rpc->cr_opc) == DAOS_OBJ_RPC_TGT_PUNCH_AKEYS;
+}
+
+static inline bool
+obj_rpc_is_migrate(crt_rpc_t *rpc)
+{
+	return opc_get(rpc->cr_opc) == DAOS_OBJ_RPC_MIGRATE;
+}
+
 #endif /* __DAOS_OBJ_RPC_H__ */

--- a/src/object/srv_mod.c
+++ b/src/object/srv_mod.c
@@ -118,8 +118,28 @@ struct dss_module_key obj_module_key = {
 	.dmk_fini = obj_tls_fini,
 };
 
+static int
+obj_get_req_attr(crt_rpc_t *rpc, struct sched_req_attr *attr)
+{
+	if (obj_rpc_is_update(rpc) || obj_rpc_is_fetch(rpc)) {
+		struct obj_rw_in	*orw = crt_req_get(rpc);
+
+		sched_req_attr_init(attr, SCHED_REQ_IO, &orw->orw_pool_uuid);
+	} else if (obj_rpc_is_migrate(rpc)) {
+		struct obj_migrate_in	*omi = crt_req_get(rpc);
+
+		sched_req_attr_init(attr, SCHED_REQ_MIGRATE,
+				    &omi->om_pool_uuid);
+	} else {
+		/* Other requests will not be queued, see dss_rpc_hdlr() */
+		return -DER_NOSYS;
+	}
+
+	return 0;
+}
+
 static struct dss_module_ops ds_obj_mod_ops = {
-	.dms_abt_pool_choose_cb = NULL,
+	.dms_get_req_attr = obj_get_req_attr,
 };
 
 struct dss_module obj_module =  {

--- a/src/object/srv_obj.c
+++ b/src/object/srv_obj.c
@@ -59,19 +59,6 @@ obj_verify_bio_csum(crt_rpc_t *rpc, daos_iod_t *iods,
 		    struct dcs_iod_csums *iod_csums, struct bio_desc *biod,
 		    struct daos_csummer *csummer);
 
-static bool
-obj_rpc_is_update(crt_rpc_t *rpc)
-{
-	return opc_get(rpc->cr_opc) == DAOS_OBJ_RPC_UPDATE ||
-	       opc_get(rpc->cr_opc) == DAOS_OBJ_RPC_TGT_UPDATE;
-}
-
-static bool
-obj_rpc_is_fetch(crt_rpc_t *rpc)
-{
-	return opc_get(rpc->cr_opc) == DAOS_OBJ_RPC_FETCH;
-}
-
 /* For single RDG based DTX, parse DTX participants information
  * from the client given dispatch targets information that does
  * NOT contains the original leader information.

--- a/src/rdb/rdb_util.c
+++ b/src/rdb/rdb_util.c
@@ -542,7 +542,7 @@ rdb_vos_discard(daos_handle_t cont, daos_epoch_t low, daos_epoch_t high)
 	range.epr_lo = low;
 	range.epr_hi = high;
 
-	return vos_discard(cont, &range);
+	return vos_discard(cont, &range, NULL, NULL);
 }
 
 int
@@ -554,5 +554,5 @@ rdb_vos_aggregate(daos_handle_t cont, daos_epoch_t high)
 	epr.epr_lo = 0;
 	epr.epr_hi = high;
 
-	return vos_aggregate(cont, &epr, NULL);
+	return vos_aggregate(cont, &epr, NULL, NULL, NULL);
 }

--- a/src/vos/tests/vts_aggregate.c
+++ b/src/vos/tests/vts_aggregate.c
@@ -421,10 +421,10 @@ aggregate_basic(struct io_test_args *arg, struct agg_tst_dataset *ds,
 		    "Discard" : "Aggregate", epr_a->epr_lo, epr_a->epr_hi);
 
 	if (ds->td_discard)
-		rc = vos_discard(arg->ctx.tc_co_hdl, epr_a);
+		rc = vos_discard(arg->ctx.tc_co_hdl, epr_a, NULL, NULL);
 	else
 		rc = vos_aggregate(arg->ctx.tc_co_hdl, epr_a,
-				   ds_csum_agg_recalc);
+				   ds_csum_agg_recalc, NULL, NULL);
 	if (rc != -DER_CSUM) {
 		assert_int_equal(rc, 0);
 		verify_view(arg, oid, dkey, akey, ds);
@@ -593,9 +593,9 @@ aggregate_multi(struct io_test_args *arg, struct agg_tst_dataset *ds_sample)
 		    "Discard" : "Aggregate");
 
 	if (ds_sample->td_discard)
-		rc = vos_discard(arg->ctx.tc_co_hdl, epr_a);
+		rc = vos_discard(arg->ctx.tc_co_hdl, epr_a, NULL, NULL);
 	else
-		rc = vos_aggregate(arg->ctx.tc_co_hdl, epr_a, NULL);
+		rc = vos_aggregate(arg->ctx.tc_co_hdl, epr_a, NULL, NULL, NULL);
 	assert_int_equal(rc, 0);
 
 	multi_view(arg, oids, dkeys, akeys, AT_OBJ_KEY_NR, ds_arr, true);
@@ -1120,9 +1120,10 @@ agg_punches_test_helper(void **state, int record_type, int type, bool discard,
 
 	for (i = 0; i < 2; i++) {
 		if (discard)
-			rc = vos_discard(arg->ctx.tc_co_hdl, &epr);
+			rc = vos_discard(arg->ctx.tc_co_hdl, &epr, NULL, NULL);
 		else
-			rc = vos_aggregate(arg->ctx.tc_co_hdl, &epr, NULL);
+			rc = vos_aggregate(arg->ctx.tc_co_hdl, &epr, NULL,
+					   NULL, NULL);
 
 		assert_int_equal(rc, 0);
 
@@ -1812,7 +1813,7 @@ aggregate_14(void **state)
 
 		VERBOSE_MSG("Aggregate round: %d\n", i);
 		epr.epr_hi = epc_hi;
-		rc = vos_aggregate(arg->ctx.tc_co_hdl, &epr, NULL);
+		rc = vos_aggregate(arg->ctx.tc_co_hdl, &epr, NULL, NULL, NULL);
 		if (rc) {
 			print_error("aggregate %d failed:%d\n", i, rc);
 			break;
@@ -1995,7 +1996,7 @@ aggregate_22(void **state)
 
 	epr.epr_hi = epoch++;
 
-	rc = vos_aggregate(arg->ctx.tc_co_hdl, &epr, NULL);
+	rc = vos_aggregate(arg->ctx.tc_co_hdl, &epr, NULL, NULL, NULL);
 	assert_int_equal(rc, 0);
 
 	fetch_value(arg, oid, epoch++,

--- a/src/vos/vos_aggregate.c
+++ b/src/vos/vos_aggregate.c
@@ -147,6 +147,8 @@ struct vos_agg_param {
 	daos_key_t		ap_akey;	/* current akey */
 	unsigned int		ap_discard:1;
 	struct umem_instance	*ap_umm;
+	bool			(*ap_yield_func)(void *arg);
+	void			*ap_yield_arg;
 	/* SV tree: Max epoch in specified iterate epoch range */
 	daos_epoch_t		 ap_max_epoch;
 	/* EV tree: Merge window for evtree aggregation */
@@ -1727,6 +1729,16 @@ out:
 	return rc;
 }
 
+static inline bool
+vos_aggregate_yield(struct vos_agg_param *agg_param)
+{
+	if (agg_param->ap_yield_func != NULL)
+		return agg_param->ap_yield_func(agg_param->ap_yield_arg);
+
+	bio_yield();
+	return false;
+}
+
 static int
 vos_aggregate_pre_cb(daos_handle_t ih, vos_iter_entry_t *entry,
 		     vos_iter_type_t type, vos_iter_param_t *param,
@@ -1768,11 +1780,6 @@ vos_aggregate_pre_cb(daos_handle_t ih, vos_iter_entry_t *entry,
 		return rc;
 	}
 
-	if (cont->vc_abort_aggregation) {
-		D_DEBUG(DB_EPC, "VOS discard/aggregation aborted\n");
-		return 1;
-	}
-
 	agg_param->ap_credits++;
 
 	if (agg_param->ap_credits > agg_param->ap_credits_max ||
@@ -1786,7 +1793,10 @@ vos_aggregate_pre_cb(daos_handle_t ih, vos_iter_entry_t *entry,
 		 * see the comment in vos_agg_obj().
 		 */
 		reset_agg_pos(type, agg_param);
-		bio_yield();
+		if (vos_aggregate_yield(agg_param)) {
+			D_DEBUG(DB_EPC, "VOS discard/aggregation aborted\n");
+			return 1;
+		}
 	}
 
 	return 0;
@@ -1881,7 +1891,6 @@ aggregate_enter(struct vos_container *cont, bool discard,
 		cont->vc_epr_aggregation = *epr;
 	}
 
-	cont->vc_abort_aggregation = 0;
 	return 0;
 }
 
@@ -1913,7 +1922,9 @@ merge_window_init(struct agg_merge_window *mw, void (*func)(void *))
 }
 
 int
-vos_aggregate(daos_handle_t coh, daos_epoch_range_t *epr, void (*func)(void *))
+vos_aggregate(daos_handle_t coh, daos_epoch_range_t *epr,
+	      void (*csum_func)(void *),
+	      bool (*yield_func)(void *arg), void *yield_arg)
 {
 	struct vos_container	*cont = vos_hdl2cont(coh);
 	vos_iter_param_t	 iter_param = { 0 };
@@ -1949,7 +1960,9 @@ vos_aggregate(daos_handle_t coh, daos_epoch_range_t *epr, void (*func)(void *))
 	agg_param.ap_credits_max = VOS_AGG_CREDITS_MAX;
 	agg_param.ap_credits = 0;
 	agg_param.ap_discard = false;
-	merge_window_init(&agg_param.ap_window, func);
+	agg_param.ap_yield_func = yield_func;
+	agg_param.ap_yield_arg = yield_arg;
+	merge_window_init(&agg_param.ap_window, csum_func);
 
 	iter_param.ip_flags |= VOS_IT_FOR_PURGE;
 	rc = vos_iterate(&iter_param, VOS_ITER_OBJ, true, &anchors,
@@ -1979,7 +1992,8 @@ exit:
 }
 
 int
-vos_discard(daos_handle_t coh, daos_epoch_range_t *epr)
+vos_discard(daos_handle_t coh, daos_epoch_range_t *epr,
+	    bool (*yield_func)(void *arg), void *yield_arg)
 {
 	struct vos_container	*cont = vos_hdl2cont(coh);
 	vos_iter_param_t	 iter_param = { 0 };
@@ -2018,6 +2032,8 @@ vos_discard(daos_handle_t coh, daos_epoch_range_t *epr)
 	agg_param.ap_credits_max = VOS_AGG_CREDITS_MAX;
 	agg_param.ap_credits = 0;
 	agg_param.ap_discard = true;
+	agg_param.ap_yield_func = yield_func;
+	agg_param.ap_yield_arg = yield_arg;
 
 	iter_param.ip_flags |= VOS_IT_FOR_PURGE;
 	rc = vos_iterate(&iter_param, VOS_ITER_OBJ, true, &anchors,

--- a/src/vos/vos_container.c
+++ b/src/vos/vos_container.c
@@ -533,9 +533,6 @@ vos_cont_ctl(daos_handle_t coh, enum vos_cont_opc opc)
 	}
 
 	switch (opc) {
-	case VOS_CO_CTL_ABORT_AGG:
-		cont->vc_abort_aggregation = 1;
-		break;
 	default:
 		return -DER_NOSYS;
 	}

--- a/src/vos/vos_internal.h
+++ b/src/vos/vos_internal.h
@@ -224,7 +224,6 @@ struct vos_container {
 	/* Various flags */
 	unsigned int		vc_in_aggregation:1,
 				vc_in_discard:1,
-				vc_abort_aggregation:1,
 				vc_reindex_cmt_dtx:1;
 	unsigned int		vc_open_count;
 };

--- a/src/vos/vos_pool.c
+++ b/src/vos/vos_pool.c
@@ -776,6 +776,23 @@ vos_pool_query(daos_handle_t poh, vos_pool_info_t *pinfo)
 }
 
 int
+vos_pool_query_space(uuid_t pool_id, struct vos_pool_space *vps)
+{
+	struct vos_pool	*pool;
+	struct d_uuid	 ukey;
+	int		 rc;
+
+	uuid_copy(ukey.uuid, pool_id);
+	rc = pool_lookup(&ukey, &pool);
+	if (rc)
+		return rc;
+
+	rc = vos_space_query(pool, vps, false);
+	vos_pool_decref(pool);
+	return rc;
+}
+
+int
 vos_pool_ctl(daos_handle_t poh, enum vos_pool_opc opc)
 {
 	struct vos_pool		*pool;

--- a/src/vos/vos_space.c
+++ b/src/vos/vos_space.c
@@ -51,6 +51,10 @@ vos_space_sys_init(struct vos_pool *pool)
 	gc_reserve_space(&pool->vp_space_sys[0]);
 	agg_reserve_space(&pool->vp_space_sys[0]);
 
+	/* NVMe isn't configured */
+	if (nvme_tot == 0)
+		POOL_NVME_SYS(pool) = 0;
+
 	if ((POOL_SCM_SYS(pool) * 2) > scm_tot) {
 		D_WARN("Disable SCM space reserving for tiny pool:"DF_UUID" "
 		       "sys["DF_U64"] > tot["DF_U64"]\n",
@@ -58,7 +62,7 @@ vos_space_sys_init(struct vos_pool *pool)
 		POOL_SCM_SYS(pool) = 0;
 	}
 
-	if (pool->vp_vea_info && (POOL_NVME_SYS(pool) * 2) > nvme_tot) {
+	if ((POOL_NVME_SYS(pool) * 2) > nvme_tot) {
 		D_WARN("Disable NVMe space reserving for tiny Pool:"DF_UUID" "
 		       "sys["DF_U64"] > tot["DF_U64"]\n",
 		       DP_UUID(pool->vp_id), POOL_NVME_SYS(pool), nvme_tot);
@@ -140,7 +144,9 @@ vos_space_query(struct vos_pool *pool, struct vos_pool_space *vps, bool slow)
 
 	/* NVMe isn't configured for this VOS pool */
 	if (pool->vp_vea_info == NULL) {
+		NVME_TOTAL(vps) = 0;
 		NVME_FREE(vps) = 0;
+		NVME_SYS(vps) = 0;
 		return 0;
 	}
 


### PR DESCRIPTION
Improve scheduler to be aware of space pressure for each VOS pool:
when certain VOS pool is under space pressure, the IO ULTs for the
VOS pool will be throttled and the GC & aggregation ULTs for the
VOS pool will be prioritized. Priority of the ULTs for other VOS
pools will keep unchanged.

Make scheduler supporting various schedule policies, FIFO, RR or
customized priority based on certain ID (UID, JobID, etc.). Only
FIFO policy is implemented in this patch.

Introduced set of sched APIs, which could be used to unify all kinds
server ULT's tracking & management. Only aggregation ULT is changed
to use new sched APIs in this patch.

TODO in follow-on patches:
1. Use new sched APIs for GC ULTs, and change the GC ULTs from per
   xtream to per pool;
2. Only return -DER_NOSPACE to client when the pool is really full
   (No pending GC & aggregation Jobs).
3. Use new sched APIs for rebuild, DTX, and other server ULTs.

Signed-off-by: Niu Yawei <yawei.niu@intel.com>