### PR TITLE
DAOS-5133 iosrv: move net progress to SMT when available

### DIFF
--- a/src/cart/src/cart/crt_hg.c
+++ b/src/cart/src/cart/crt_hg.c
@@ -519,7 +519,11 @@ crt_hg_init(crt_phy_addr_t *addr, bool server)
 	if (rc != 0)
 		D_GOTO(out, rc);
 
-	init_info.na_init_info.progress_mode = 0;
+	/**
+	 * Use non-block progress since it seems more efficient to drive it
+	 * from DAOS
+	 */
+	init_info.na_init_info.progress_mode = NA_NO_BLOCK;
 	if (crt_gdata.cg_share_na == false)
 		/* one context per NA class */
 		init_info.na_init_info.max_contexts = 1;
@@ -679,7 +683,7 @@ crt_hg_ctx_init(struct crt_hg_context *hg_ctx, int idx)
 		if (rc != 0)
 			D_GOTO(out, rc);
 
-		init_info.na_init_info.progress_mode = 0;
+		init_info.na_init_info.progress_mode = NA_NO_BLOCK;
 		init_info.na_init_info.max_contexts = 1;
 		na_class = NA_Initialize_opt(info_string, crt_is_service(),
 					     &init_info.na_init_info);

--- a/src/iosrv/srv_internal.h
+++ b/src/iosrv/srv_internal.h
@@ -51,6 +51,7 @@ struct dss_xstream {
 	char			dx_name[DSS_XS_NAME_LEN];
 	ABT_future		dx_shutdown;
 	hwloc_cpuset_t		dx_cpuset;
+	hwloc_cpuset_t		dx_cpuset_net;
 	ABT_xstream		dx_xstream;
 	ABT_pool		dx_pools[DSS_POOL_CNT];
 	ABT_sched		dx_sched;
@@ -66,9 +67,10 @@ struct dss_xstream {
 	int			dx_tgt_id;
 	/* CART context id, invalid (-1) for the offload XS w/o CART context */
 	int			dx_ctx_id;
-	bool			dx_main_xs;	/* true for main XS */
-	bool			dx_comm;	/* true with cart context */
-	bool			dx_dsc_started;	/* DSC progress ULT started */
+	/** vairous flags */
+	uint32_t		dx_main_xs:1,	 /* true for main XS */
+				dx_comm:1,	 /* true with cart context */
+				dx_dsc_started:1;/* DSC progress ULT started */
 };
 
 /** Server node topology */


### PR DESCRIPTION
Fork a separate pthread to drive network progress and bind it to
the other hyperthread when SMT is enabled.
Also enable manual progress in CART since it provides better performance
in this mode.

Signed-off-by: Johann Lombardi <johann.lombardi@intel.com>