### PR TITLE
DAOS-2448 obj: two cli_obj change for EC 

### DIFF
--- a/src/common/tse_internal.h
+++ b/src/common/tse_internal.h
@@ -34,7 +34,7 @@
  */
 
 /* NB: tse_task_private is TSE_PRIV_SIZE = 1016 bytes for now */
-#define TSE_TASK_ARG_LEN		880
+#define TSE_TASK_ARG_LEN		888
 
 struct tse_task_private {
 	struct tse_sched_private	*dtp_sched;


### PR DESCRIPTION
1. Need not check API args again for retry case, that fixed a bug
    for EC IO retry as the reassembled IOD possibly cause the check
    failure.
2. Should not ignore -DER_NONEXIST error of obj_shard_open for some cases,
     it fixes EC obj IO case.

Signed-off-by: Xuezhao Liu xuezhao.liu@intel.com