### PR TITLE
DAOS-2448 obj: EC degraded fetch handling (no data recovering)

### DIFF
--- a/src/cart/src/include/gurt/errno.h
+++ b/src/cart/src/include/gurt/errno.h
@@ -178,7 +178,9 @@
 	/** Record size error */					\
 	ACTION(DER_REC_SIZE,		(DER_ERR_DAOS_BASE + 24))	\
 	/** Used to indicate a transaction should restart */		\
-	ACTION(DER_TX_RESTART,		(DER_ERR_DAOS_BASE + 25))
+	ACTION(DER_TX_RESTART,		(DER_ERR_DAOS_BASE + 25))	\
+	/** Data lost or not recoverable */				\
+	ACTION(DER_DATA_LOSS,		(DER_ERR_DAOS_BASE + 26))
 
 /** Defines the gurt error codes */
 #define D_FOREACH_ERR_RANGE(ACTION)	\

--- a/src/dtx/dtx_common.c
+++ b/src/dtx/dtx_common.c
@@ -880,7 +880,7 @@ dtx_leader_exec_ops_ult(void *arg)
 
 		sub->dss_result = 0;
 
-		if (sub->dss_tgt.st_rank == TGTS_IGNORE) {
+		if (sub->dss_tgt.st_rank == DAOS_TGT_IGNORE) {
 			int ret;
 
 			ret = ABT_future_set(future, dlh);

--- a/src/include/daos/object.h
+++ b/src/include/daos/object.h
@@ -175,13 +175,19 @@ struct daos_obj_layout {
 	struct daos_obj_shard	*ol_shards[0];
 };
 
-#define TGTS_IGNORE		((d_rank_t)-1)
+/**
+ * can be used as st_rank to indicate target can be ignored for IO, for example
+ * update DAOS_OBJ_REPL_MAX obj with some target failed case.
+ */
+#define DAOS_TGT_IGNORE		((d_rank_t)-1)
 /** to identify each obj shard's target */
 struct daos_shard_tgt {
 	uint32_t		st_rank;	/* rank of the shard */
 	uint32_t		st_shard;	/* shard index */
-	uint32_t		st_tgt_idx;	/* target xstream index */
 	uint32_t		st_tgt_id;	/* target id */
+	uint16_t		st_tgt_idx;	/* target xstream index */
+	/* target idx for EC obj, only used for client */
+	uint16_t		st_ec_tgt;
 };
 
 static inline bool
@@ -448,6 +454,9 @@ static inline void
 daos_recx_ep_list_free(struct daos_recx_ep_list *list, unsigned int nr)
 {
 	unsigned int	i;
+
+	if (list == NULL)
+		return;
 
 	for (i = 0; i < nr; i++)
 		daos_recx_ep_free(&list[i]);

--- a/src/object/cli_ec.c
+++ b/src/object/cli_ec.c
@@ -640,7 +640,7 @@ recx_with_full_stripe(uint32_t recx_idx, struct obj_ec_recx_array *r_array,
 		(r_idx)[tgt]++;						       \
 	} while (0)
 #define ec_vos_idx(idx)							       \
-	obj_ec_vos_recx_idx(idx, stripe_rec_nr, cell_rec_nr)
+	obj_ec_idx_daos2vos(idx, stripe_rec_nr, cell_rec_nr)
 
 /**
  * Add data recx to reassemble recx array.
@@ -868,13 +868,13 @@ dump_recx(daos_recx_t *recx, struct daos_oclass_attr *oca,
 
 	/* when oca != NULL, translate VOS idx to original daos index */
 	if (tgt < obj_ec_data_tgt_nr(oca)) {
-		start = obj_ec_idx_of_vos_idx(recx->rx_idx, stripe_rec_nr,
+		start = obj_ec_idx_vos2daos(recx->rx_idx, stripe_rec_nr,
 				obj_ec_cell_rec_nr(oca), tgt);
 		D_PRINT(" ["DF_U64", "DF_U64"]", start, recx->rx_nr);
 	} else {
 		if (recx->rx_idx & PARITY_INDICATOR) {
 			tmp_idx = recx->rx_idx & (~PARITY_INDICATOR);
-			start = obj_ec_idx_of_vos_idx(tmp_idx, stripe_rec_nr,
+			start = obj_ec_idx_vos2daos(tmp_idx, stripe_rec_nr,
 					obj_ec_cell_rec_nr(oca),
 					tgt - obj_ec_data_tgt_nr(oca));
 			D_PRINT(" [P_"DF_U64", "DF_U64"]", start,

--- a/src/object/cli_obj.c
+++ b/src/object/cli_obj.c
@@ -40,7 +40,7 @@
 #define CLI_OBJ_IO_PARMS	8
 #define NIL_BITMAP		(NULL)
 
-#define OBJ_TGT_INLINE_NR	(24)
+#define OBJ_TGT_INLINE_NR	(23)
 struct obj_req_tgts {
 	/* to save memory allocation if #targets <= OBJ_TGT_INLINE_NR */
 	struct daos_shard_tgt	 ort_tgts_inline[OBJ_TGT_INLINE_NR];
@@ -638,6 +638,7 @@ obj_reasb_req_fini(struct obj_auxi_args *obj_auxi)
 		reasb_req->tgt_oiods = NULL;
 	}
 	obj_ec_recov_free(reasb_req);
+	D_FREE(reasb_req->orr_err_list);
 	D_FREE(reasb_req->orr_iods);
 }
 
@@ -688,24 +689,127 @@ obj_rw_req_reassemb(struct dc_object *obj, daos_obj_rw_t *args,
 	return rc;
 }
 
+static bool
+obj_ec_tgt_in_err(uint32_t *err_list, uint32_t nerrs, uint16_t tgt_idx)
+{
+	uint32_t	i;
+
+	for (i = 0; i < nerrs; i++) {
+		if (err_list[i] == tgt_idx)
+			return true;
+	}
+	return false;
+}
+
+static int
+obj_ec_get_degrade(struct obj_auxi_args *obj_auxi, uint16_t fail_tgt_idx,
+		   uint32_t *parity_tgt_idx)
+{
+	struct obj_reasb_req	*reasb_req = &obj_auxi->reasb_req;
+	uint16_t		 p = obj_ec_parity_tgt_nr(reasb_req->orr_oca);
+	uint16_t		 k = obj_ec_data_tgt_nr(reasb_req->orr_oca);
+	uint32_t		*err_list;
+	uint32_t		 nerrs, i;
+	bool			 with_parity = false;
+
+	D_ASSERT(fail_tgt_idx < k + p);
+	if (reasb_req->orr_err_list == NULL) {
+		D_ALLOC_ARRAY(reasb_req->orr_err_list, p);
+		if (reasb_req->orr_err_list == NULL)
+			return -DER_NOMEM;
+		reasb_req->orr_nerrs = 0;
+	}
+	err_list = reasb_req->orr_err_list;
+	nerrs = reasb_req->orr_nerrs;
+	D_ASSERT(nerrs <= p);
+	if (nerrs == p) {
+		D_ERROR("already with %d error targets, not recoverable.\n", p);
+		return -DER_DATA_LOSS;
+	}
+
+	for (i = 0; i < nerrs; i++)
+		D_ASSERT(err_list[i] != fail_tgt_idx);
+
+	err_list[nerrs] = fail_tgt_idx;
+	reasb_req->orr_nerrs++;
+	nerrs = reasb_req->orr_nerrs;
+
+	for (i = k; i < k + p; i++) {
+		if (!obj_ec_tgt_in_err(err_list, nerrs, i)) {
+			*parity_tgt_idx = i;
+			with_parity = true;
+		}
+	}
+	D_ASSERT(with_parity);
+
+	return 0;
+}
+
+bool
+obj_op_is_ec_fetch(struct obj_auxi_args *obj_auxi)
+{
+	return obj_auxi->is_ec_obj && obj_auxi->opc == DAOS_OBJ_RPC_FETCH;
+}
+
+/**
+ * Query target info. ec_tgt_idx only used for EC obj fetch.
+ */
 static int
 obj_shard_tgts_query(struct dc_object *obj, uint32_t map_ver, uint32_t shard,
-		     bool ignore_nonexist, struct daos_shard_tgt *shard_tgt)
+		     uint16_t ec_tgt_idx, struct daos_shard_tgt *shard_tgt,
+		     struct obj_auxi_args *obj_auxi)
 {
 	struct dc_obj_shard	*obj_shard;
+	bool			 ec_degrade = false;
+	uint32_t		 ec_deg_tgt = 0, start_shard;
 	int			 rc;
 
+	shard_tgt->st_ec_tgt = ec_tgt_idx;
+	start_shard = shard - ec_tgt_idx;
+shard_open:
 	rc = obj_shard_open(obj, shard, map_ver, &obj_shard);
-	if (rc != 0) {
-		if (ignore_nonexist && (rc == -DER_NONEXIST)) {
-			shard_tgt->st_rank = TGTS_IGNORE;
-			rc = 0;
+	if (rc == 0) {
+		if (obj_op_is_ec_fetch(obj_auxi) && obj_shard->do_rebuilding) {
+			ec_degrade = true;
+			obj_shard_close(obj_shard);
+		}
+	} else {
+		if (rc == -DER_NONEXIST) {
+			if (!obj_auxi->is_ec_obj) {
+				shard_tgt->st_rank = DAOS_TGT_IGNORE;
+				rc = 0;
+			} else {
+				if (obj_auxi->opc == DAOS_OBJ_RPC_FETCH)
+					ec_degrade = true;
+			}
 		} else {
 			D_ERROR(DF_OID" obj_shard_open failed, rc "DF_RC".\n",
 				DP_OID(obj->cob_md.omd_id), DP_RC(rc));
 		}
-		D_GOTO(out, rc);
+		if (!ec_degrade)
+			D_GOTO(out, rc);
 	}
+
+	if (ec_degrade) {
+		rc = obj_ec_get_degrade(obj_auxi, shard - start_shard,
+					&ec_deg_tgt);
+		if (rc) {
+			D_ERROR(DF_OID" obj_ec_get_degrade failed, rc "
+				DF_RC".\n", DP_OID(obj->cob_md.omd_id),
+				DP_RC(rc));
+			D_GOTO(out, rc);
+		}
+		D_ASSERT(ec_deg_tgt >=
+			 obj_ec_data_tgt_nr(obj_auxi->reasb_req.orr_oca));
+		shard = start_shard + ec_deg_tgt;
+		D_DEBUG(DB_IO, DF_OID" shard %d fetch re-direct to shard %d.\n",
+			DP_OID(obj->cob_md.omd_id), start_shard + ec_tgt_idx,
+			start_shard + ec_deg_tgt);
+		ec_degrade = false;
+		goto shard_open;
+	}
+	if (rc != 0)
+		D_GOTO(out, rc);
 
 	shard_tgt->st_rank	= obj_shard->do_target_rank;
 	shard_tgt->st_shard	= shard,
@@ -753,8 +857,9 @@ obj_req_tgts_dump(struct obj_req_tgts *req_tgts)
 static int
 obj_shards_2_fwtgts(struct dc_object *obj, uint32_t map_ver, uint8_t *bit_map,
 		    uint32_t start_shard, uint32_t shard_cnt, uint32_t grp_nr,
-		    struct obj_req_tgts *req_tgts, uint32_t flags)
+		    uint32_t flags, struct obj_auxi_args *obj_auxi)
 {
+	struct obj_req_tgts	*req_tgts = &obj_auxi->req_tgts;
 	struct daos_shard_tgt	*tgt = NULL;
 	uint32_t		 leader_shard = -1;
 	uint32_t		 i, j;
@@ -814,7 +919,7 @@ obj_shards_2_fwtgts(struct dc_object *obj, uint32_t map_ver, uint8_t *bit_map,
 			}
 			leader_shard = rc;
 			rc = obj_shard_tgts_query(obj, map_ver, leader_shard,
-						  false, tgt++);
+						  0, tgt++, obj_auxi);
 			if (rc != 0)
 				return rc;
 
@@ -827,7 +932,8 @@ obj_shards_2_fwtgts(struct dc_object *obj, uint32_t map_ver, uint8_t *bit_map,
 			    (bit_map != NIL_BITMAP && isclr(bit_map, j)))
 				continue;
 			rc = obj_shard_tgts_query(obj, map_ver, shard_idx,
-						  bit_map == NIL_BITMAP, tgt++);
+						  shard_idx - start_shard,
+						  tgt++, obj_auxi);
 			if (rc != 0)
 				return rc;
 		}
@@ -1595,12 +1701,14 @@ out:
 
 /* Query the obj request's targets */
 static int
-obj_req_get_tgts(struct dc_object *obj, enum obj_rpc_opc opc, int *shard,
-		 daos_key_t *dkey, uint64_t dkey_hash, uint8_t *bit_map,
-		 uint32_t map_ver, bool to_leader, bool spec_shard,
-		 struct obj_req_tgts *req_tgts)
+obj_req_get_tgts(struct dc_object *obj, int *shard, daos_key_t *dkey,
+		 uint64_t dkey_hash, uint8_t *bit_map, uint32_t map_ver,
+		 bool to_leader, bool spec_shard,
+		 struct obj_auxi_args *obj_auxi)
 {
-	int		rc;
+	struct obj_req_tgts	*req_tgts = &obj_auxi->req_tgts;
+	enum obj_rpc_opc	 opc = obj_auxi->opc;
+	int			 rc;
 
 	switch (opc) {
 	uint32_t	shard_idx;
@@ -1649,8 +1757,8 @@ obj_req_get_tgts(struct dc_object *obj, enum obj_rpc_opc opc, int *shard,
 		grp_nr = 1;
 
 		rc = obj_shards_2_fwtgts(obj, map_ver, bit_map, shard_idx,
-					 shard_cnt, grp_nr, req_tgts,
-					 OBJ_TGT_FLAG_CLI_DISPATCH);
+					 shard_cnt, grp_nr,
+					 OBJ_TGT_FLAG_CLI_DISPATCH, obj_auxi);
 		if (rc != 0) {
 			D_ERROR("opc %d "DF_OID", obj_shards_2_fwtgts failed "
 				""DF_RC".\n", opc, DP_OID(obj->cob_md.omd_id),
@@ -1673,7 +1781,7 @@ obj_req_get_tgts(struct dc_object *obj, enum obj_rpc_opc opc, int *shard,
 		}
 		req_tgts->ort_start_shard = shard_idx;
 		rc = obj_shards_2_fwtgts(obj, map_ver, bit_map, shard_idx,
-					 shard_cnt, grp_nr, req_tgts, 0);
+					 shard_cnt, grp_nr, 0, obj_auxi);
 		if (rc != 0) {
 			D_ERROR("opc %d "DF_OID", obj_shards_2_fwtgts failed "
 				""DF_RC".\n", opc, DP_OID(obj->cob_md.omd_id),
@@ -1711,8 +1819,8 @@ obj_req_get_tgts(struct dc_object *obj, enum obj_rpc_opc opc, int *shard,
 		req_tgts->ort_srv_disp = 0;
 		req_tgts->ort_grp_nr = 1;
 		req_tgts->ort_grp_size = 1;
-		rc = obj_shard_tgts_query(obj, map_ver, *shard, false,
-					  req_tgts->ort_shard_tgts);
+		rc = obj_shard_tgts_query(obj, map_ver, *shard, 0,
+					  req_tgts->ort_shard_tgts, obj_auxi);
 		if (rc != 0)
 			goto out;
 		break;
@@ -1720,8 +1828,8 @@ obj_req_get_tgts(struct dc_object *obj, enum obj_rpc_opc opc, int *shard,
 		obj_ptr2shards(obj, &shard_idx, &shard_cnt, &grp_nr);
 		req_tgts->ort_start_shard = shard_idx;
 		rc = obj_shards_2_fwtgts(obj, map_ver, NIL_BITMAP, shard_idx,
-					 shard_cnt, grp_nr, req_tgts,
-					 OBJ_TGT_FLAG_LEADER_ONLY);
+					 shard_cnt, grp_nr,
+					 OBJ_TGT_FLAG_LEADER_ONLY, obj_auxi);
 		if (rc != 0)
 			D_ERROR("opc %d "DF_OID", obj_shards_2_fwtgts failed "
 				""DF_RC".\n", opc, DP_OID(obj->cob_md.omd_id),
@@ -1749,12 +1857,13 @@ shard_task_abort(tse_task_t *task, void *arg)
 static void
 shard_auxi_set_param(struct shard_auxi_args *shard_arg, uint32_t map_ver,
 		     uint32_t shard, uint32_t tgt_id,
-		     struct dc_obj_epoch *epoch)
+		     struct dc_obj_epoch *epoch, uint16_t ec_tgt_idx)
 {
 	shard_arg->epoch = *epoch;
 	shard_arg->shard = shard;
 	shard_arg->target = tgt_id;
 	shard_arg->map_ver = map_ver;
+	shard_arg->ec_tgt_idx = ec_tgt_idx;
 }
 
 struct shard_task_sched_args {
@@ -1807,7 +1916,8 @@ shard_task_sched(tse_task_t *task, void *arg)
 			if (!obj_auxi->req_tgts.ort_srv_disp)
 				shard_auxi_set_param(shard_auxi, map_ver,
 					shard_auxi->shard, target,
-					&sched_arg->tsa_epoch);
+					&sched_arg->tsa_epoch,
+					shard_auxi->ec_tgt_idx);
 			sched_arg->tsa_scheded = true;
 		}
 	} else {
@@ -1937,7 +2047,7 @@ shard_task_reset_param(tse_task_t *shard_task, void *arg)
 		     shard_arg->grp_idx * req_tgts->ort_grp_size;
 	shard_auxi_set_param(shard_arg, obj_auxi->map_ver_req,
 			     leader_tgt->st_shard, leader_tgt->st_tgt_id,
-			     &reset_arg->epoch);
+			     &reset_arg->epoch, leader_tgt->st_ec_tgt);
 	return 0;
 }
 
@@ -2015,7 +2125,8 @@ obj_req_fanout(struct dc_object *obj, struct obj_auxi_args *obj_auxi,
 			shard_auxi = obj_embedded_shard_arg(obj_auxi);
 			D_ASSERT(shard_auxi != NULL);
 			shard_auxi_set_param(shard_auxi, map_ver, tgt->st_shard,
-					     tgt->st_tgt_id, epoch);
+					     tgt->st_tgt_id, epoch,
+					     tgt->st_ec_tgt);
 			shard_auxi->shard_io_cb = io_cb;
 			rc = shard_io(obj_task, shard_auxi);
 			return rc;
@@ -2029,7 +2140,7 @@ obj_req_fanout(struct dc_object *obj, struct obj_auxi_args *obj_auxi,
 		shard_auxi = obj_embedded_shard_arg(obj_auxi);
 		D_ASSERT(shard_auxi != NULL);
 		shard_auxi_set_param(shard_auxi, map_ver, tgt->st_shard,
-				     tgt->st_tgt_id, epoch);
+				     tgt->st_tgt_id, epoch, tgt->st_ec_tgt);
 		shard_auxi->grp_idx = 0;
 		shard_auxi->start_shard = req_tgts->ort_start_shard;
 		shard_auxi->obj = obj;
@@ -2059,7 +2170,7 @@ obj_req_fanout(struct dc_object *obj, struct obj_auxi_args *obj_auxi,
 		shard_auxi = tse_task_buf_embedded(shard_task,
 						   sizeof(*shard_auxi));
 		shard_auxi_set_param(shard_auxi, map_ver, tgt->st_shard,
-				     tgt->st_tgt_id, epoch);
+				     tgt->st_tgt_id, epoch, tgt->st_ec_tgt);
 		shard_auxi->grp_idx = req_tgts->ort_srv_disp ? i :
 				      (i / req_tgts->ort_grp_size);
 		shard_auxi->start_shard = req_tgts->ort_start_shard;
@@ -2361,6 +2472,13 @@ obj_comp_cb(tse_task_t *task, void *data)
 		 * the usage in dac_array_set_size().
 		 */
 		memset(obj_auxi, 0, sizeof(*obj_auxi));
+	} else {
+		if (obj_auxi->reasb_req.orr_err_list) {
+			memset(obj_auxi->reasb_req.orr_err_list, 0,
+			       sizeof(*obj_auxi->reasb_req.orr_err_list) *
+			       obj_auxi->reasb_req.orr_nerrs);
+		}
+		obj_auxi->reasb_req.orr_nerrs = 0;
 	}
 
 	obj_decref(obj);
@@ -2414,7 +2532,7 @@ shard_rw_prep(struct shard_auxi_args *shard_auxi, struct dc_object *obj,
 			D_ASSERT(obj_auxi->opc == DAOS_OBJ_RPC_FETCH);
 			toiod = obj_ec_tgt_oiod_get(
 				reasb_req->tgt_oiods, reasb_req->orr_tgt_nr,
-				shard_auxi->shard - shard_auxi->start_shard);
+				shard_auxi->ec_tgt_idx);
 			D_ASSERT(toiod != NULL);
 			shard_arg->oiods = toiod->oto_oiods;
 			shard_arg->offs = toiod->oto_offs;
@@ -2641,10 +2759,9 @@ dc_obj_fetch(tse_task_t *task, daos_obj_fetch_t *args, uint32_t flags,
 		if (obj_auxi->is_ec_obj)
 			tgt_bitmap = obj_auxi->reasb_req.tgt_bitmap;
 	}
-	rc = obj_req_get_tgts(obj, DAOS_OBJ_RPC_FETCH, (int *)&shard,
-			      args->dkey, dkey_hash, tgt_bitmap, map_ver,
-			      obj_auxi->to_leader, obj_auxi->spec_shard,
-			      &obj_auxi->req_tgts);
+	rc = obj_req_get_tgts(obj, (int *)&shard, args->dkey, dkey_hash,
+			      tgt_bitmap, map_ver, obj_auxi->to_leader,
+			      obj_auxi->spec_shard, obj_auxi);
 	if (rc != 0)
 		D_GOTO(out_task, rc);
 	if (obj_auxi->csum_report)
@@ -2732,9 +2849,9 @@ dc_obj_update(tse_task_t *task, struct dc_obj_epoch *epoch, uint32_t map_ver,
 	}
 
 	dkey_hash = obj_dkey2hash(args->dkey);
-	rc = obj_req_get_tgts(obj, DAOS_OBJ_RPC_UPDATE, NULL, args->dkey,
-			      dkey_hash, obj_auxi->reasb_req.tgt_bitmap,
-			      map_ver, false, false, &obj_auxi->req_tgts);
+	rc = obj_req_get_tgts(obj, NULL, args->dkey, dkey_hash,
+			      obj_auxi->reasb_req.tgt_bitmap, map_ver, false,
+			      false, obj_auxi);
 	if (rc)
 		goto out_task;
 
@@ -2870,9 +2987,9 @@ obj_list_common(tse_task_t *task, int opc, daos_obj_list_t *args)
 		obj_auxi->spec_shard = 0;
 	}
 
-	rc = obj_req_get_tgts(obj, opc, &shard, args->dkey, dkey_hash,
-			      NIL_BITMAP, map_ver, obj_auxi->to_leader,
-			      obj_auxi->spec_shard, &obj_auxi->req_tgts);
+	rc = obj_req_get_tgts(obj, &shard, args->dkey, dkey_hash, NIL_BITMAP,
+			      map_ver, obj_auxi->to_leader,
+			      obj_auxi->spec_shard, obj_auxi);
 	if (rc != 0)
 		goto out_task;
 	if (args->dkey == NULL)
@@ -3002,9 +3119,8 @@ dc_obj_punch(tse_task_t *task, struct dc_obj_epoch *epoch, uint32_t map_ver,
 	}
 
 	dkey_hash = obj_dkey2hash(api_args->dkey);
-	rc = obj_req_get_tgts(obj, opc, NULL, api_args->dkey, dkey_hash,
-			      NIL_BITMAP, map_ver, false, false,
-			      &obj_auxi->req_tgts);
+	rc = obj_req_get_tgts(obj, NULL, api_args->dkey, dkey_hash, NIL_BITMAP,
+			      map_ver, false, false, obj_auxi);
 	if (rc != 0)
 		goto out_task;
 
@@ -3495,8 +3611,8 @@ dc_obj_sync(tse_task_t *task)
 			*args->epochs_p[i] = 0;
 	}
 
-	rc = obj_req_get_tgts(obj, DAOS_OBJ_RPC_SYNC, NULL, NULL, 0, NIL_BITMAP,
-			      map_ver, true, false, &obj_auxi->req_tgts);
+	rc = obj_req_get_tgts(obj, NULL, NULL, 0, NIL_BITMAP, map_ver, true,
+			      false, obj_auxi);
 	if (rc != 0)
 		D_GOTO(out_task, rc);
 

--- a/src/object/obj_internal.h
+++ b/src/object/obj_internal.h
@@ -50,13 +50,6 @@
  */
 #define IO_BYPASS_ENV	"DAOS_IO_BYPASS"
 
-/* EC parity is stored in a private address range that is selected by setting
- * the most-significant bit of the offset (an unsigned long). This effectively
- * limits the addressing of user extents to the lower 63 bits of the offset
- * range. The client stack should enforce this limitation.
- */
-#define PARITY_INDICATOR (1UL << 63)
-
 /**
  * Bypass client I/O RPC, it means the client stack will complete the
  * fetch/update RPC immediately, nothing will be submitted to remote server.
@@ -74,7 +67,7 @@ struct dc_obj_shard {
 	daos_unit_oid_t		do_id;
 	/** container handler of the object */
 	daos_handle_t		do_co_hdl;
-	uint32_t		do_target_idx;	/* target VOS index in node */
+	uint8_t			do_target_idx;	/* target VOS index in node */
 	uint32_t		do_target_rank;
 	struct pl_obj_shard	do_pl_shard;
 	/** point back to object */
@@ -151,6 +144,10 @@ struct obj_reasb_req {
 	 */
 	uint8_t				*tgt_bitmap;
 	struct obj_tgt_oiod		*tgt_oiods;
+	/* list of error targets */
+	uint32_t			*orr_err_list;
+	/* number of error targets */
+	uint32_t			 orr_nerrs;
 };
 
 static inline void
@@ -268,6 +265,8 @@ struct shard_auxi_args {
 	uint16_t		 grp_idx;
 	/* only for EC, the start shard of the EC stripe */
 	uint32_t		 start_shard;
+	/* only for EC, the target idx [0, k + p) */
+	uint16_t		 ec_tgt_idx;
 };
 
 struct shard_rw_args {
@@ -399,6 +398,7 @@ int dc_obj_shard_sync(struct dc_obj_shard *shard, enum obj_rpc_opc opc,
 
 int dc_obj_verify_rdg(struct dc_object *obj, struct dc_obj_verify_args *dova,
 		      uint32_t rdg_idx, uint32_t reps, daos_epoch_t epoch);
+bool obj_op_is_ec_fetch(struct obj_auxi_args *obj_auxi);
 
 static inline bool
 obj_retry_error(int err)

--- a/src/object/obj_rpc.c
+++ b/src/object/obj_rpc.c
@@ -581,12 +581,13 @@ crt_proc_struct_daos_shard_tgt(crt_proc_t proc, struct daos_shard_tgt *st)
 	rc = crt_proc_uint32_t(proc, &st->st_shard);
 	if (rc != 0)
 		return -DER_HG;
-	rc = crt_proc_uint32_t(proc, &st->st_tgt_idx);
-	if (rc != 0)
-		return -DER_HG;
 	rc = crt_proc_uint32_t(proc, &st->st_tgt_id);
 	if (rc != 0)
 		return -DER_HG;
+	rc = crt_proc_uint16_t(proc, &st->st_tgt_idx);
+	if (rc != 0)
+		return -DER_HG;
+	/* st_ec_tgt need not pack */
 
 	return 0;
 }

--- a/src/object/obj_rpc.h
+++ b/src/object/obj_rpc.h
@@ -143,6 +143,8 @@ enum obj_rpc_flags {
 	ORF_CREATE_MAP		= (1 << 5),
 	/** The epoch (e.g., orw_epoch for OBJ_RW) is uncertain. */
 	ORF_EPOCH_UNCERTAIN	= (1 << 6),
+	/** Erasure coding degraded fetch flag */
+	ORF_EC_DEGRADED		= (1 << 7),
 };
 
 struct obj_iod_array {
@@ -180,7 +182,8 @@ struct obj_iod_array {
 	((struct dtx_id)	(orw_dti_cos)		CRT_ARRAY) \
 	((d_sg_list_t)		(orw_sgls)		CRT_ARRAY) \
 	((crt_bulk_t)		(orw_bulks)		CRT_ARRAY) \
-	((struct daos_shard_tgt)(orw_shard_tgts)	CRT_ARRAY)
+	((struct daos_shard_tgt)(orw_shard_tgts)	CRT_ARRAY) \
+	((uint32_t)		(orw_tgt_idx)		CRT_VAR)
 
 #define DAOS_OSEQ_OBJ_RW	/* output fields */		 \
 	((int32_t)		(orw_ret)		CRT_VAR) \

--- a/src/object/srv_obj.c
+++ b/src/object/srv_obj.c
@@ -93,7 +93,7 @@ obj_gen_dtx_mbs(struct daos_shard_tgt *tgts, uint32_t *tgt_cnt,
 		return -DER_NOMEM;
 
 	for (i = 0, j = 0; i < *tgt_cnt; i++) {
-		if (tgts[i].st_rank == TGTS_IGNORE)
+		if (tgts[i].st_rank == DAOS_TGT_IGNORE)
 			continue;
 
 		mbs->dm_tgts[j++].ddt_id = tgts[i].st_tgt_id;
@@ -1054,6 +1054,46 @@ obj_fetch_create_maps(crt_rpc_t *rpc, struct bio_desc *biod)
 }
 
 static int
+obj_fetch_shadow(daos_handle_t coh, daos_unit_oid_t oid, daos_epoch_t epoch,
+		uint64_t cond_flags, daos_key_t *dkey, unsigned int iod_nr,
+		daos_iod_t *iods, uint32_t tgt_idx,
+		struct daos_recx_ep_list **pshadows)
+{
+	struct daos_oclass_attr		*oca;
+	daos_handle_t			 ioh = DAOS_HDL_INVAL;
+	int				 rc;
+
+	obj_iod_idx_vos2parity(iod_nr, iods);
+	oca = daos_oclass_attr_find(oid.id_pub);
+	if (oca == NULL || !DAOS_OC_IS_EC(oca)) {
+		rc = -DER_INVAL;
+		D_ERROR(DF_UOID" oca not found or not EC obj: "DF_RC"\n",
+			DP_UOID(oid), DP_RC(rc));
+		goto out;
+	}
+
+	rc = vos_fetch_begin(coh, oid, epoch, cond_flags, dkey, iod_nr, iods,
+			     VOS_FETCH_RECX_LIST, NULL, &ioh, NULL);
+	if (rc) {
+		D_ERROR(DF_UOID" Fetch begin failed: "DF_RC"\n",
+			DP_UOID(oid), DP_RC(rc));
+		goto out;
+	}
+
+	*pshadows = vos_ioh2recx_list(ioh);
+	vos_fetch_end(ioh, 0);
+
+out:
+	obj_iod_idx_parity2vos(iod_nr, iods);
+	if (rc == 0) {
+		obj_iod_idx_vos2daos(iod_nr, iods, tgt_idx, oca);
+		obj_recx_ep_list_idx_parity2daos(iod_nr, *pshadows, tgt_idx,
+						 oca);
+	}
+	return rc;
+}
+
+static int
 obj_local_rw(crt_rpc_t *rpc, struct ds_cont_hdl *cont_hdl,
 	     struct ds_cont_child *cont, daos_iod_t *split_iods,
 	     struct dcs_iod_csums *split_csums, uint64_t *split_offs,
@@ -1135,16 +1175,32 @@ obj_local_rw(crt_rpc_t *rpc, struct ds_cont_hdl *cont_hdl,
 			goto out;
 		}
 	} else {
-		uint32_t	fetch_flags;
+		uint64_t			 cond_flags;
+		uint32_t			 fetch_flags;
+		bool				 ec_deg_fetch;
+		struct daos_recx_ep_list	*shadows = NULL;
 
 		size_fetch = (!rma && orw->orw_sgls.ca_arrays == NULL);
 		fetch_flags = size_fetch ? VOS_FETCH_SIZE_ONLY : 0;
+		cond_flags = orw->orw_api_flags | VOS_OF_USE_TIMESTAMPS;
 		bulk_op = CRT_BULK_PUT;
 
+		ec_deg_fetch = orw->orw_flags & ORF_EC_DEGRADED;
+		if (ec_deg_fetch && !size_fetch) {
+			rc = obj_fetch_shadow(cont->sc_hdl, orw->orw_oid,
+				orw->orw_epoch, cond_flags, dkey, orw->orw_nr,
+				iods, orw->orw_tgt_idx, &shadows);
+			if (rc) {
+				D_ERROR(DF_UOID" Fetch shadow failed: "DF_RC
+					"\n", DP_UOID(orw->orw_oid), DP_RC(rc));
+				goto out;
+			}
+		}
+
 		rc = vos_fetch_begin(cont->sc_hdl, orw->orw_oid, orw->orw_epoch,
-				     orw->orw_api_flags | VOS_OF_USE_TIMESTAMPS,
-				     dkey, orw->orw_nr, iods, fetch_flags, NULL,
-				     &ioh, dth);
+				     cond_flags, dkey, orw->orw_nr, iods,
+				     fetch_flags, shadows, &ioh, dth);
+		daos_recx_ep_list_free(shadows, orw->orw_nr);
 		if (rc) {
 			D_CDEBUG(rc == -DER_INPROGRESS, DB_IO, DLOG_ERR,
 				 "Fetch begin for "DF_UOID" failed: "DF_RC"\n",


### PR DESCRIPTION
Add basic EC obj degraded fetch handling, without full-stripe updated
data recovering now (only works for with partial-updated data's degraded
fetch).

Signed-off-by: Xuezhao Liu <xuezhao.liu@intel.com>