### PR TITLE
DAOS-5147 build: make gcc happy for debug build

### DIFF
--- a/src/client/dfuse/dfuse_core.c
+++ b/src/client/dfuse/dfuse_core.c
@@ -116,7 +116,7 @@ ih_ndecref(struct d_hash_table *htable, d_list_t *rlink, int count)
 {
 	struct dfuse_inode_entry	*ie;
 	uint				oldref;
-	uint				newref;
+	uint				newref = 0;
 
 	ie = container_of(rlink, struct dfuse_inode_entry, ie_htl);
 


### PR DESCRIPTION
Fix [-Werror=maybe-uninitialized] compiler warning.
Even if it appears to be a false positive according to
correct handling of (oldref < count) condition.

Change-Id: Ib6a692d6ab9ad0bcc627e372bd10453eb01c7041
Signed-off-by: Bruno Faccini <bruno.faccini@intel.com>