### PR TITLE
DAOS-4984 ctrl: Enable VMD in DAOS config

### DIFF
--- a/src/bio/SConscript
+++ b/src/bio/SConscript
@@ -22,6 +22,7 @@ def scons():
     libs += ['spdk_conf', 'spdk_blob', 'spdk_nvme', 'spdk_util']
     libs += ['spdk_json', 'spdk_jsonrpc', 'spdk_rpc', 'spdk_trace']
     libs += ['spdk_sock', 'spdk_log', 'spdk_notify', 'spdk_blob_bdev']
+    libs += ['spdk_vmd']
 
     # Other libs
     libs += ['numa', 'dl', 'smd']

--- a/src/control/SConscript
+++ b/src/control/SConscript
@@ -183,7 +183,7 @@ def scons():
                        " -lrte_bus_pci -lrte_pci -lrte_ring -lrte_mbuf" + \
                        " -lrte_eal -lrte_kvargs -lspdk_bdev_aio" + \
                        " -lspdk_bdev_nvme -lspdk_bdev_malloc -lspdk_conf" + \
-                       " -lspdk_blob -lspdk_nvme -lspdk_util -lspdk_json" + \
+                       " -lspdk_blob -lspdk_nvme -lspdk_vmd -lspdk_util -lspdk_json" + \
                        " -lspdk_jsonrpc -lspdk_rpc -lspdk_trace" + \
                        " -lspdk_sock -lspdk_log -lspdk_notify" + \
                        " -lspdk_blob_bdev -lnuma -ldl -lisal", sep=" ")

--- a/src/control/lib/spdk/SConscript
+++ b/src/control/lib/spdk/SConscript
@@ -21,6 +21,7 @@ def scons():
     libs += ['spdk_conf', 'spdk_blob', 'spdk_nvme', 'spdk_util']
     libs += ['spdk_json', 'spdk_jsonrpc', 'spdk_rpc', 'spdk_trace']
     libs += ['spdk_sock', 'spdk_log', 'spdk_notify', 'spdk_blob_bdev']
+    libs += ['spdk_vmd']
 
     # Other libs
     libs += ['numa', 'dl', 'isal']

--- a/src/control/lib/spdk/ctests/SConscript
+++ b/src/control/lib/spdk/ctests/SConscript
@@ -21,6 +21,7 @@ def scons():
     libs += ['spdk_conf', 'spdk_blob', 'spdk_nvme', 'spdk_util']
     libs += ['spdk_json', 'spdk_jsonrpc', 'spdk_rpc', 'spdk_trace']
     libs += ['spdk_sock', 'spdk_log', 'spdk_notify', 'spdk_blob_bdev']
+    libs += ['spdk_vmd']
 
     # Other libs
     libs += ['numa', 'dl', 'isal', 'cmocka', 'pthread']

--- a/src/control/lib/spdk/nvme_test.go
+++ b/src/control/lib/spdk/nvme_test.go
@@ -141,6 +141,9 @@ func TestDiscover(t *testing.T) {
 		//		if err := se.InitSPDKEnv(tt.shmID); err != nil {
 		//			t.Fatal(err.Error())
 		//		}
+		//		if err := se.InitVMDEnv(); err != nil {
+		//			t.Fatal(err.Error())
+		//		}
 		//
 		//		cs, nss, err := n.Discover()
 		//		if checkFailure(tt.shouldSucceed, err) != nil {

--- a/src/control/lib/spdk/spdk.go
+++ b/src/control/lib/spdk/spdk.go
@@ -28,12 +28,13 @@ package spdk
 // to specify additional dirs.
 
 /*
-#cgo LDFLAGS: -lspdk_env_dpdk -lrte_mempool -lrte_mempool_ring -lrte_bus_pci
+#cgo LDFLAGS: -lspdk_env_dpdk -lspdk_vmd  -lrte_mempool -lrte_mempool_ring -lrte_bus_pci
 #cgo LDFLAGS: -lrte_pci -lrte_ring -lrte_mbuf -lrte_eal -lrte_kvargs -ldl -lnuma
 
 #include <stdlib.h>
 #include <spdk/stdinc.h>
 #include <spdk/env.h>
+#include <spdk/vmd.h>
 */
 import "C"
 
@@ -45,6 +46,7 @@ import (
 // ENV is the interface that provides SPDK environment management.
 type ENV interface {
 	InitSPDKEnv(int) error
+	InitVMDEnv() error
 }
 
 // Env is a simple ENV implementation.
@@ -86,6 +88,18 @@ func (e *Env) InitSPDKEnv(shmID int) (err error) {
 
 	rc := C.spdk_env_init(opts)
 	if err = Rc2err("spdk_env_opts_init", rc); err != nil {
+		return
+	}
+
+	return
+}
+
+// InitVMDEnv initializes the VMD environment in SPDK
+
+// Enumerate VMD devices and hook them into the SPDK PCI subsystem.
+func (e *Env) InitVMDEnv() (err error) {
+	rc := C.spdk_vmd_init()
+	if err = Rc2err("spdk_vmd_init", rc); err != nil {
 		return
 	}
 

--- a/src/control/server/config.go
+++ b/src/control/server/config.go
@@ -69,6 +69,7 @@ type Configuration struct {
 	Servers             []*ioserver.Config        `yaml:"servers"`
 	BdevInclude         []string                  `yaml:"bdev_include,omitempty"`
 	BdevExclude         []string                  `yaml:"bdev_exclude,omitempty"`
+	VmdInclude          []string                  `yaml:"vmd_include,omitempty"`
 	NrHugepages         int                       `yaml:"nr_hugepages"`
 	SetHugepages        bool                      `yaml:"set_hugepages"`
 	ControlLogMask      ControlLogLevel           `yaml:"control_log_mask"`
@@ -260,6 +261,12 @@ func (c *Configuration) WithBdevExclude(bList ...string) *Configuration {
 // WithBdevInclude sets the block device include list.
 func (c *Configuration) WithBdevInclude(bList ...string) *Configuration {
 	c.BdevInclude = bList
+	return c
+}
+
+// WithVmdInclude sets the VMD address include list.
+func (c *Configuration) WithVmdInclude(vList ...string) *Configuration {
+	c.VmdInclude = vList
 	return c
 }
 

--- a/src/control/server/config_test.go
+++ b/src/control/server/config_test.go
@@ -208,7 +208,8 @@ func TestServer_ConstructedConfig(t *testing.T) {
 	constructed := NewConfiguration().
 		WithControlPort(10001).
 		WithBdevInclude("0000:81:00.1", "0000:81:00.2", "0000:81:00.3").
-		WithBdevExclude("0000:81:00.1").
+		WithVmdInclude("0000:5d:05.5")
+	WithBdevExclude("0000:81:00.1").
 		WithNrHugePages(4096).
 		WithControlLogMask(ControlLogLevelError).
 		WithControlLogFile("/tmp/daos_control.log").
@@ -234,7 +235,8 @@ func TestServer_ConstructedConfig(t *testing.T) {
 				WithScmClass("ram").
 				WithScmRamdiskSize(16).
 				WithBdevClass("nvme").
-				WithBdevDeviceList("0000:81:00.0").
+				WithEnableVmd(true).
+				WithBdevDeviceList("0000:81:00.0", "5d0505:01:00.0").
 				WithFabricInterface("qib0").
 				WithFabricInterfacePort(20000).
 				WithPinnedNumaNode(&numaNode0).

--- a/src/control/server/ioserver/config.go
+++ b/src/control/server/ioserver/config.go
@@ -268,6 +268,12 @@ func (c *Config) WithBdevClass(bdevClass string) *Config {
 	return c
 }
 
+// WithEnableVmd defines if VMD devices will be used.
+func (c *Config) WithEnableVmd(enable bool) *Config {
+	c.Storage.Bdev.EnableVmd = enable
+	return c
+}
+
 // WithBdevDeviceList sets the list of block devices to be used.
 func (c *Config) WithBdevDeviceList(devices ...string) *Config {
 	c.Storage.Bdev.DeviceList = devices

--- a/src/control/server/server.go
+++ b/src/control/server/server.go
@@ -155,6 +155,21 @@ func Start(log *logging.LeveledLogger, cfg *Configuration) error {
 		}
 	}
 
+	// If VMD devices are set in config, then need to run a separate
+	// SPDK setup with the VMD address as the PCI_WHITELIST
+	if len(cfg.VmdInclude) > 0 {
+		prepReqVmd := bdev.PrepareRequest{
+			PCIWhitelist:  strings.Join(cfg.VmdInclude, ","),
+			SkipReset:     true,
+			HugePageCount: prepReq.HugePageCount,
+			TargetUser:    prepReq.TargetUser,
+		}
+		log.Debugf("automatic VMD prepare req: %+v", prepReqVmd)
+		if _, err := bdevProvider.Prepare(prepReqVmd); err != nil {
+			log.Errorf("automatic NVMe prepare for VMD failed (check configuration?)\n%s", err)
+		}
+	}
+
 	// If this daos_server instance ends up being the MS leader,
 	// this will record the DAOS system membership.
 	membership := system.NewMembership(log)

--- a/src/control/server/storage/bdev/backend.go
+++ b/src/control/server/storage/bdev/backend.go
@@ -106,6 +106,11 @@ func (w *spdkWrapper) init(log logging.Logger, initShmID ...int) (err error) {
 		return errors.Wrap(err, "failed to initialize SPDK")
 	}
 
+	// TODO: Only call init when VMD is enabled in config
+	if err := w.InitVMDEnv(); err != nil {
+		return errors.Wrap(err, "failed to initialize VMD")
+	}
+
 	cs, err := w.Discover(log)
 	if err != nil {
 		return errors.Wrap(err, "failed to discover NVMe")

--- a/src/control/server/storage/bdev/class.go
+++ b/src/control/server/storage/bdev/class.go
@@ -49,6 +49,19 @@ const (
     HotplugEnable No
     HotplugPollRate 0
 `
+	vmdTempl = `[VMD]
+    Enable True
+
+[Nvme]
+{{ $host := .Hostname }}{{ range $i, $e := .DeviceList }}    TransportID "trtype:PCIe traddr:{{$e}}" Nvme_{{$host}}_{{$i}}
+{{ end }}    RetryCount 4
+    TimeoutUsec 0
+    ActionOnTimeout None
+    AdminPollRate 100000
+    HotplugEnable No
+    HotplugPollRate 0
+
+`
 	// device block size hardcoded to 4096
 	fileTempl = `[AIO]
 {{ $host := .Hostname }}{{ range $i, $e := .DeviceList }}    AIO {{$e}} AIO_{{$host}}_{{$i}} 4096
@@ -183,8 +196,14 @@ func NewClassProvider(log logging.Logger, cfgDir string, cfg *storage.BdevConfig
 	}
 
 	switch cfg.Class {
-	case storage.BdevClassNone, storage.BdevClassNvme:
+	case storage.BdevClassNone:
 		p.bdev = bdev{nvmeTempl, "", isEmptyList, isValidList, nilPrep}
+	case storage.BdevClassNvme:
+		if cfg.EnableVmd {
+			p.bdev = bdev{vmdTempl, "VMD", isEmptyList, isValidList, nilPrep}
+		} else {
+			p.bdev = bdev{nvmeTempl, "NVME", isEmptyList, isValidList, nilPrep}
+		}
 	case storage.BdevClassMalloc:
 		p.bdev = bdev{mallocTempl, "MALLOC", isEmptyNumber, nilValidate, nilPrep}
 	case storage.BdevClassKdev:

--- a/src/control/server/storage/bdev/provider.go
+++ b/src/control/server/storage/bdev/provider.go
@@ -58,6 +58,7 @@ type (
 		PCIWhitelist  string
 		TargetUser    string
 		ResetOnly     bool
+		SkipReset     bool
 	}
 
 	// PrepareResponse contains the results of a successful Prepare operation.
@@ -157,9 +158,11 @@ func (p *Provider) Prepare(req PrepareRequest) (*PrepareResponse, error) {
 		return p.fwd.Prepare(req)
 	}
 
-	// run reset first to ensure reallocation of hugepages
-	if err := p.backend.Reset(); err != nil {
-		return nil, errors.WithMessage(err, "SPDK setup reset")
+	if !req.SkipReset {
+		// run reset first to ensure reallocation of hugepages
+		if err := p.backend.Reset(); err != nil {
+			return nil, errors.WithMessage(err, "SPDK setup reset")
+		}
 	}
 
 	res := &PrepareResponse{}

--- a/src/control/server/storage/config.go
+++ b/src/control/server/storage/config.go
@@ -135,6 +135,7 @@ func (b BdevClass) String() string {
 type BdevConfig struct {
 	ConfigPath  string    `yaml:"-" cmdLongFlag:"--nvme" cmdShortFlag:"-n"`
 	Class       BdevClass `yaml:"bdev_class,omitempty"`
+	EnableVmd   bool      `yaml:"enable_vmd,omitempty"`
 	DeviceList  []string  `yaml:"bdev_list,omitempty"`
 	DeviceCount int       `yaml:"bdev_number,omitempty"`
 	FileSize    int       `yaml:"bdev_size,omitempty"`
@@ -154,4 +155,12 @@ func (bc *BdevConfig) GetNvmeDevs() []string {
 	}
 
 	return []string{}
+}
+
+func (bc *BdevConfig) IsVMDEnabled() bool {
+	if bc.EnableVmd {
+		return true
+	}
+
+	return false
 }

--- a/utils/config/daos_server.yml
+++ b/utils/config/daos_server.yml
@@ -92,6 +92,15 @@
 #
 #bdev_include: ["0000:81:00.1","0000:81:00.2","0000:81:00.3"]
 #
+## VMD PCI whitelist
+#
+## Allow use of NVMe SSDs behind listed VMD PCI addresses.
+## If Volume Management Devices (VMD) are to be used, then the VMD address
+## needs to be explicitly listed for use. VMD whitelist can be used alone
+## or in addition to the NVMe SSD whitelist.
+#
+vmd_include: ["0000:5d:05.5"]
+#
 #
 ## NVMe SSD blacklist
 #
@@ -336,6 +345,15 @@
 #  # - "kdev" to use a kernel block device, bdev_{size,number} ignored
 #  # Immutable after reformat.
 #
+#  # If Volume Management Devices (VMD) are used, then the enable_vmd flag
+#  # needs to be set. The bdev_class will remain the default "nvme" type,
+#  # and similar to NVMe, bdev_list will include the NVMe SSD address behind
+#  # the VMD. vmd_include also needs to be set to the VMD address in order for
+#  # the BDF address of the NVMe VMD SSD (ie "5d0505:01:00.0") to be parsed.
+#  bdev_class: nvme
+#  enable_vmd: true
+#  bdev_list: ["0000:81:00.0","5d0505:01:00.0","5d0505:03:00.0"]
+#
 #  # When bdev_class is set to malloc, bdev_number is the number of devices
 #  # to allocate and bdev_size is the size in GB of each LUN/device.
 #  bdev_class: malloc
@@ -353,3 +371,4 @@
 #  # block devices that should be different across different server instance.
 #  bdev_class: kdev
 #  bdev_list: [/dev/sdc,/dev/sdd]
+

--- a/utils/config/examples/daos_server_unittests.yml
+++ b/utils/config/examples/daos_server_unittests.yml
@@ -85,3 +85,4 @@ servers:
   # bdev_list: [/tmp/daos-bdev]	# generate nvme.conf as follows:
               # [AIO]
               #   AIO /tmp/aiofile AIO1 4096
+


### PR DESCRIPTION
***TODO: Need find a way to only call spdk_vmd_init() to initialize VMD within SPDK if VMD is enabled in the server config. Still unsure how init is currently called from the control plane, wondering if passing a config variable is an option? see src/control/server/storage/bdev/backend.go where InitVMDEnv() is called right after InitSPDKEnv()

Enable Volume Management Devices (VMD) to be used in DAOS.
Currently there is a dependency with running VMD with VFIO.

In order to enable use of NVMe SSDs behind VMD, a few things need to be set in the server config.
daos_server.yml:
- "vmd_include" needs to be set to the VMD address that will be ran with the SPDK setup script.This address can be found with "$ lspci | grep 201d", and should be a normal PCI address starting with "000:".
	vmd_include: ["0000:5d:05.5"]
vmd_include is completely independent of bdev_include, however if vmd_include is not set than the VMD address will not automatically be scanned and used like bdev_include defaults to if not set.

- "bdev_class" will be set to nvme, no additional bdev class for vmd
	bdev_class: nvme
- "enable_vmd" flag needs to be set
	enable_vmd: true
- "bdev_list" can now include regular NVMe SSDs or VMD NVMe SSDs
	bdev_list: ["0000:81:00.0","5d0505:01:00.0","5d0505:03:00.0"]
The bdev_list must include the address of the NVMe SSD behind the VMD. This can be found by running "$ ./spdk/app/spdk_lspci/spdk_lspci" after manually unbinding the driver "$ PCI_WHITELIST="0000:5d:05.5" spdk/scripts/setup.sh". (Once DAOS server is ran, it will handle reseting all of the controllers and will re-run the SPDK setup.)

Example of the DAOS NVMe configuration file with VMD enabled.
daos_nvme.conf:

    [VMD]
        Enable True

    [Nvme]
      TransportID "trtype:PCIe traddr:5d0505:01:00.0" Nvme_boro-82.boro.hpdd.intel.com_0
      TransportID "trtype:PCIe traddr:5d0505:03:00.0" Nvme_boro-82.boro.hpdd.intel.com_1
      TransportID "trtype:PCIe traddr:0000:81:00.0" Nvme_boro-82.boro.hpdd.intel.com_2
      RetryCount 4
      TimeoutUsec 0
      ActionOnTimeout None
      AdminPollRate 100000
      HotplugEnable No
      HotplugPollRate 0

Signed-off-by: Sydney Vanda <sydney.m.vanda@intel.com>