### PR TITLE
DAOS-4623 rebuild: change trace to rebuild in migration.

### DIFF
--- a/src/object/obj_internal.h
+++ b/src/object/obj_internal.h
@@ -182,11 +182,6 @@ struct migrate_pool_tls {
 	daos_handle_t		mpt_root_hdl;
 	struct btr_root		mpt_root;
 
-	/* Indicates whether containers should be cleared of all contents
-	 * before any data is migrated to them (via destroy & recreate)
-	 */
-	bool			mpt_clear_conts;
-
 	/* Hash table to store the container uuids which have already been
 	 * deleted (used by reintegration)
 	 */
@@ -221,6 +216,10 @@ struct migrate_pool_tls {
 	uint64_t		mpt_refcount;
 	/* migrate leader ULT */
 	unsigned int		mpt_ult_running:1,
+	/* Indicates whether containers should be cleared of all contents
+	 * before any data is migrated to them (via destroy & recreate)
+	 */
+				mpt_clear_conts:1,
 				mpt_fini:1;
 };
 

--- a/src/tests/ftest/daos_test/daos_core_test-rebuild.yaml
+++ b/src/tests/ftest/daos_test/daos_core_test-rebuild.yaml
@@ -91,10 +91,6 @@ daos_tests:
       daos_test: r
       test_name: rebuild tests 25
       args: -s3 -u subtests="25"
-    test_r_26:
-      daos_test: r
-      test_name: rebuild tests 26
-      args: -s3 -u subtests="26"
     test_r_27:
       daos_test: r
       test_name: rebuild tests 27


### PR DESCRIPTION
1. Change trace to rebuild in object migrate module.
2. In migrate container call back, if the container list
   is empty(), it should return 1 instead of NONEXIST.
3. Disable rebuild test 26 to until DAOS-4626 is fixed.

Signed-off-by: Di Wang <di.wang@intel.com>