### PR TITLE
DAOS-722 log: Remove key names from logging in release builds(#2668)

### DIFF
--- a/src/common/debug.c
+++ b/src/common/debug.c
@@ -226,6 +226,7 @@ DP_UUID(const void *uuid)
 	return buf;
 }
 
+#ifndef DAOS_BUILD_RELEASE
 #define DF_KEY_MAX		8
 #define DF_KEY_STR_SIZE		64
 
@@ -263,3 +264,4 @@ daos_key2str(daos_key_t *key)
 	thread_key_buf_idx = (thread_key_buf_idx + 1) % DF_KEY_MAX;
 	return buf;
 }
+#endif

--- a/src/common/debug.c
+++ b/src/common/debug.c
@@ -265,3 +265,4 @@ daos_key2str(daos_key_t *key)
 	return buf;
 }
 #endif
+

--- a/src/include/daos/common.h
+++ b/src/include/daos/common.h
@@ -104,16 +104,16 @@ char *DP_UUID(const void *uuid);
 #define DP_CONT(puuid, cuuid)	DP_UUID(puuid), DP_UUID(cuuid)
 #define DF_CONTF		DF_UUIDF"/"DF_UUIDF
 
-#ifndef DAOS_BUILD_RELEASE
+#ifdef DAOS_BUILD_RELEASE
+#define DF_KEY			"[%d]"
+#define DP_KEY(key)		(int)((key)->iov_len)
+#else
 char *daos_key2str(daos_key_t *key);
 
 #define DF_KEY			"[%d] %.*s"
 #define DP_KEY(key)		(int)(key)->iov_len,	\
-		                (int)(key)->iov_len,	\
-		                daos_key2str(key)
-#else
-#define DF_KEY			"[%d]"
-#define DP_KEY(key)		(int)((key)->iov_len)
+				(int)(key)->iov_len,	\
+				daos_key2str(key)
 #endif
 
 #define DF_RECX			"["DF_U64"-"DF_U64"]"

--- a/src/include/daos/common.h
+++ b/src/include/daos/common.h
@@ -104,12 +104,17 @@ char *DP_UUID(const void *uuid);
 #define DP_CONT(puuid, cuuid)	DP_UUID(puuid), DP_UUID(cuuid)
 #define DF_CONTF		DF_UUIDF"/"DF_UUIDF
 
+#ifndef DAOS_BUILD_RELEASE
 char *daos_key2str(daos_key_t *key);
 
 #define DF_KEY			"[%d] %.*s"
 #define DP_KEY(key)		(int)(key)->iov_len,	\
 		                (int)(key)->iov_len,	\
 		                daos_key2str(key)
+#else
+#define DF_KEY			"[%d]"
+#define DP_KEY(key)		(int)((key)->iov_len)
+#endif
 
 #define DF_RECX			"["DF_U64"-"DF_U64"]"
 #define DP_RECX(r)		(r).rx_idx, ((r).rx_idx + (r).rx_nr - 1)


### PR DESCRIPTION
To avoid logging sensitive information key names are being removed from logging
statements on the server side for release builds.

Co-authored-by: Ashley Pittman <ashley.m.pittman@intel.com>
Signed-off-by: David Quigley <david.quigley@intel.com>