### PR TITLE
DAOS-623 build: Remove some build options, always build prereqs same way

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -954,6 +954,7 @@ pipeline {
                                        inst_rpms: 'gotestsum openmpi3 ' +
                                                   'hwloc-devel argobots ' +
                                                   'fuse3-libs fuse3 ' +
+                                                  'boost-devel ' +
                                                   'libisa-l-devel libpmem ' +
                                                   'libpmemobj protobuf-c ' +
                                                   'spdk-devel libfabric-devel '+

--- a/doc/dev/development.md
+++ b/doc/dev/development.md
@@ -7,14 +7,13 @@ only required for development purposes.
 
 ## Building DAOS for Development
 
-For development, it is recommended to build and install each dependency in a
-unique subdirectory. The DAOS build system supports this through the
-TARGET\_PREFIX variable. Once the submodules have been initialized and updated,
-run the following commands:
+Prerequisite when built using --build-deps are installed in component specific
+directories under PREFIX/prereq/$TARGET_TYPE.  Once the submodules have been
+initialized and updated, run the following commands:
 
 ```bash
 $ scons PREFIX=${daos_prefix_path}
-      TARGET_PREFIX=${daos_prefix_path}/opt install
+      install
       --build-deps=yes
       --config=force
 ```
@@ -26,30 +25,39 @@ configuration from before. For automated environment setup, source
 utils/sl/utils/setup_local.sh.
 
 ```bash
-ARGOBOTS=${daos_prefix_path}/opt/argobots
-CART=${daos_prefix_path}/opt/cart
-FIO=${daos_prefix_path}/opt/fio
-FUSE=${daos_prefix_path}/opt/fuse
-ISAL=${daos_prefix_path}/opt/isal
-MERCURY=${daos_prefix_path}/opt/mercury
-OFI=${daos_prefix_path}/opt/ofi
-OPENPA=${daos_prefix_path}/opt/openpa
-PMDK=${daos_prefix_path}/opt/pmdk
-PROTOBUFC=${daos_prefix_path}/opt/protobufc
-SPDK=${daos_prefix_path}/opt/spdk
+ARGOBOTS=${daos_prefix_path}/prereq/argobots
+CART=${daos_prefix_path}/prereq/cart
+FIO=${daos_prefix_path}/prereq/fio
+FUSE=${daos_prefix_path}/prereq/fuse
+ISAL=${daos_prefix_path}/prereq/isal
+MERCURY=${daos_prefix_path}/prereq/mercury
+OFI=${daos_prefix_path}/prereq/ofi
+OPENPA=${daos_prefix_path}/prereq/openpa
+PMDK=${daos_prefix_path}/prereq/pmdk
+PROTOBUFC=${daos_prefix_path}/prereq/protobufc
+SPDK=${daos_prefix_path}/prereq/spdk
 
 
 PATH=$CART/bin/:${daos_prefix_path}/bin/:$PATH
 ```
 
 With this approach, DAOS would get built using the prebuilt dependencies in
-${daos_prefix_path}/opt, and required options are saved for future compilations.
+${daos_prefix_path}/prereq, and required options are saved for future compilations.
 So, after the first time, during development, only "scons --config=force" and
 "scons --config=force install" would suffice for compiling changes to DAOS
 source code.
 
 If you wish to compile DAOS with clang rather than gcc, set COMPILER=clang on
 the scons command line.   This option is also saved for future com pilations.
+
+Additionally, users can specify BUILD_TYPE=[dev|release|debug] and scons will
+save the intermediate build for the various BUILD_TYPE, COMPILER, and TARGET_TYPE
+options so a user can switch between options without a full rebuild and thus
+with minimal cost.   By default, TARGET_TYPE is set to 'default' which means
+it uses the BUILD_TYPE setting.  To avoid rebuilding prerequisites for every
+BUILD_TYPE setting, TARGET_TYPE can be explicitly set to a BUILD_TYPE setting
+to always use that set of prerequisites.  These settings are stored in daos.conf
+so setting the values on subsequent builds is not necessary.
 
 ## Go dependencies
 

--- a/src/cart/src/SConscript
+++ b/src/cart/src/SConscript
@@ -51,8 +51,6 @@ def scons():
     # There is probably a better way to do this but let's get it linking first
     env.AppendUnique(LIBPATH=[Dir('cart')])
     env.AppendUnique(LIBPATH=[Dir('gurt')])
-    env.AppendUnique(RPATH=[Dir('cart')])
-    env.AppendUnique(RPATH=[Dir('gurt')])
     env.AppendUnique(LINKFLAGS=["-Wl,-rpath-link=%s" % Dir('cart').path])
     env.AppendUnique(LINKFLAGS=["-Wl,-rpath-link=%s" % Dir('gurt').path])
     env.AppendUnique(CPPPATH=[Dir('include').srcnode()])

--- a/src/cart/src/cart/SConscript
+++ b/src/cart/src/cart/SConscript
@@ -38,6 +38,7 @@
 """Build cart src"""
 
 import os
+import daos_build
 
 # pylint: disable=no-name-in-module
 # pylint: disable=import-error
@@ -113,7 +114,7 @@ def scons():
 
         denv.Requires(cart_targets, pp_files)
 
-    cart_lib = denv.SharedLibrary('libcart', [cart_targets, swim_targets],
+    cart_lib = daos_build.library(denv, 'libcart', [cart_targets, swim_targets],
                                   SHLIBVERSION=CART_VERSION)
     denv.Requires(cart_lib, [swim_targets, gurt_lib])
     denv.InstallVersionedLib('$PREFIX/lib64/', cart_lib,

--- a/src/cart/src/crt_launch/SConscript
+++ b/src/cart/src/crt_launch/SConscript
@@ -50,7 +50,7 @@ def scons():
 
     libs = ['cart', 'gurt', 'pthread', 'm']
     if not GetOption('help') and not GetOption('clean'):
-        mpi = daos_build.configure_mpi(prereqs, tenv, libs)
+        mpi = daos_build.configure_mpi(tenv, libs)
         if mpi is None:
             print("\nSkipping compilation for tests that need MPI")
             print("Install and load mpich or openmpi\n")

--- a/src/cart/src/gurt/SConscript
+++ b/src/cart/src/gurt/SConscript
@@ -37,6 +37,7 @@
 # THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 """Build libgurt"""
 
+import daos_build
 SRC = ['debug.c', 'dlog.c', 'hash.c', 'misc.c', 'heap.c', 'errno.c',
        'fault_inject.c']
 
@@ -54,7 +55,7 @@ def scons():
     prereqs.require(denv, 'uuid')
 
     gurt_targets = denv.SharedObject(SRC)
-    gurt_lib = denv.SharedLibrary('libgurt', gurt_targets,
+    gurt_lib = daos_build.library(denv, 'libgurt', gurt_targets,
                                   SHLIBVERSION=CART_VERSION)
     denv.InstallVersionedLib('$PREFIX/lib64/', gurt_lib,
                              SHLIBVERSION=CART_VERSION)

--- a/src/cart/src/utest/SConscript
+++ b/src/cart/src/utest/SConscript
@@ -37,6 +37,7 @@
 """Unit tests"""
 
 import os
+import daos_build
 
 TEST_SRC = ['test_linkage.cpp', 'test_gurt.c', 'utest_hlc.c', 'utest_swim.c']
 LIBPATH = [Dir('../cart'), Dir('../gurt')]
@@ -78,11 +79,9 @@ def scons():
         flags = []
         testobj = test_env.Object(test)
         testname = os.path.splitext(test)[0]
-        testprog = test_env.Program(target=testname,
-                                    source=testobj + \
-                                    cart_targets + \
-                                    swim_targets + \
-                                    gurt_targets,
+        testprog = daos_build.test(test_env, target=testname,
+                                   source=testobj + cart_targets +
+                                   swim_targets + gurt_targets,
                                     LIBS=test_env["LIBS"] + ['yaml'],
                                     LINKFLAGS=flags)
         tests.append(testprog)

--- a/src/client/dfuse/test/SConscript
+++ b/src/client/dfuse/test/SConscript
@@ -1,4 +1,5 @@
 """Build ping test"""
+import daos_build
 
 IOIL_TEST_SRC = ['test_ioil.c']
 IOIL_BUILD_STATIC = False
@@ -72,8 +73,8 @@ def scons():
     lfenv.AppendUnique(LIBS=['ioil', 'daos'])
 
     for test in IOIL_TEST_SRC:
-        il_test += tenv.Program(test)
-        il_test += lfenv.Program(test)
+        il_test += daos_build.test(tenv, test, install_off="../../../..")
+        il_test += daos_build.test(lfenv, test, install_off="../../../..")
 
     Default(il_test)
 

--- a/src/client/pydaos/SConscript
+++ b/src/client/pydaos/SConscript
@@ -22,7 +22,6 @@ def build_shim_module(env, lib_prefix, version):
 
     new_env.Replace(LIBS=['daos', 'duns'])
     new_env.AppendUnique(LIBPATH=["../dfs"])
-    new_env.AppendUnique(RPATH=[Literal(r'\$$ORIGIN/../../..')])
 
     daos_build.clear_icc_env(new_env)
 
@@ -32,6 +31,7 @@ def build_shim_module(env, lib_prefix, version):
                                SHLIBPREFIX="",
                                CPPFLAGS=extra_flags)
     base = daos_build.library(new_env, target=tgt_name, source=[obj],
+                              install_off="../../../..",
                               SHLINK='gcc -pthread -shared',
                               SHLINKFLAGS=[],
                               SHLIBPREFIX="",

--- a/src/control/SConscript
+++ b/src/control/SConscript
@@ -3,6 +3,7 @@
 #pylint: disable=too-many-locals
 import sys
 import os
+import daos_build
 from os.path import join, isdir
 from os import urandom
 from binascii import b2a_hex
@@ -160,14 +161,11 @@ def scons():
 
     # Version-controlled DAOS Go source directory src/control
     gosrc = Dir('.').srcnode().abspath
-    cartpath = Dir('#/src/cart/src/include').srcnode().abspath
 
-    prereqs.require(denv, 'ofi', 'hwloc')
+    prereqs.require(denv, 'ofi', 'hwloc', 'spdk')
 
-    denv.AppendENVPath("CGO_LDFLAGS",
-                       denv.subst("$_LIBDIRFLAGS "
-                                  "$_RPATH"),
-                       sep=" ")
+    # Sets CGO_LDFLAGS
+    daos_build.add_rpaths(denv, "..", True, True)
 
     denv.AppendENVPath("CGO_CFLAGS", denv.subst("$_CPPINCFLAGS"),
                        sep=" ")

--- a/src/iosrv/SConscript
+++ b/src/iosrv/SConscript
@@ -11,14 +11,16 @@ def scons():
     libraries += ['bio', 'dl', 'uuid', 'pthread', 'abt']
     libraries += ['hwloc', 'pmemobj', 'protobuf-c']
 
-    prereqs.require(denv, 'hwloc', 'argobots', 'protobufc')
+    # Added spdk here as an indirect requirement because libraries don't have
+    # rpath internally set
+    prereqs.require(denv, 'hwloc', 'argobots', 'protobufc', 'spdk')
 
     # the "-rdynamic" is to allow other dll to refer symbol defined in
     # daos_io_server such as dss_tls_key etc.
     denv.AppendUnique(LINKFLAGS=['-rdynamic'])
 
     # Add runtime paths for daos libraries
-    denv.AppendUnique(RPATH=[Literal(r'\$$ORIGIN/../lib64/daos_srv')])
+    denv.AppendUnique(RPATH_FULL=['$PREFIX/lib64/daos_srv'])
 
     # Generate I/O server program
     iosrv = daos_build.program(denv, 'daos_io_server',

--- a/src/tests/SConscript
+++ b/src/tests/SConscript
@@ -11,14 +11,14 @@ def scons():
     denv = env.Clone()
 
     if not GetOption('help') and not GetOption('clean'):
-        mpi = daos_build.configure_mpi(prereqs, denv, libs)
+        mpi = daos_build.configure_mpi(denv, libs)
         if mpi is None:
             print("\nSkipping compilation for tests that need MPI")
             print("Install and load mpich or openmpi\n")
             return
 
     # Add runtime paths for daos libraries
-    denv.AppendUnique(RPATH=[Literal(r'\$$ORIGIN/../lib64/daos_srv')])
+    denv.AppendUnique(RPATH_FULL=['$PREFIX/lib64/daos_srv'])
 
     denv.Append(CPPPATH=[Dir('suite').srcnode()])
     prereqs.require(denv, 'argobots', 'hwloc', 'protobufc')
@@ -27,15 +27,21 @@ def scons():
     libs += ['vos', 'bio', 'pthread', 'abt', 'daos_tests']
 
     dts_common = denv.Object('dts_common.c')
-    daos_perf = daos_build.program(denv, 'daos_perf',
-                                   ['daos_perf.c', dts_common], LIBS=libs)
+    penv = denv.Clone()
+    # Indirect requirement but needed because spdk has no RPATH on its
+    # internal libraries.
+    prereqs.require(penv, 'spdk')
+    daos_perf = daos_build.program(penv, 'daos_perf',
+                                   ['daos_perf.c', dts_common],
+                                   LIBS=libs)
     denv.Install('$PREFIX/bin/', daos_perf)
 
-    daos_racer = daos_build.program(denv, 'daos_racer',
-                                    ['daos_racer.c', dts_common], LIBS=libs)
+    daos_racer = daos_build.program(penv, 'daos_racer',
+                                    ['daos_racer.c', dts_common],
+                                    LIBS=libs)
     denv.Install('$PREFIX/bin/', daos_racer)
 
-    obj_ctl = daos_build.program(denv, 'obj_ctl', ['obj_ctl.c', dts_common],
+    obj_ctl = daos_build.program(penv, 'obj_ctl', ['obj_ctl.c', dts_common],
                                  LIBS=libs)
     denv.Install('$PREFIX/bin/', obj_ctl)
 

--- a/src/vos/tests/SConscript
+++ b/src/vos/tests/SConscript
@@ -8,10 +8,10 @@ def scons():
     libraries = ['vos', 'bio', 'abt', 'pthread', 'daos_common', 'daos_tests',
                  'gurt', 'cart', 'uuid', 'pthread', 'pmemobj', 'cmocka', 'gomp']
 
-    prereqs.require(denv, 'argobots')
+    prereqs.require(denv, 'argobots', 'spdk')
 
     # Add runtime paths for daos libraries
-    denv.AppendUnique(RPATH=[Literal(r'\$$ORIGIN/../lib64/daos_srv')])
+    denv.AppendUnique(RPATH_FULL=['$PREFIX/lib64/daos_srv'])
     vtsenv = denv.Clone()
     vtsenv.Append(CPPDEFINES={'VOS_UNIT_TEST' : '1'})
 

--- a/utils/daos_build.py
+++ b/utils/daos_build.py
@@ -1,26 +1,60 @@
 """Common DAOS build functions"""
-from SCons.Script import Literal
+from SCons.Subst import Literal
 from SCons.Script import GetOption
 from env_modules import load_mpi
 from distutils.spawn import find_executable
 import os
 
+# pylint: disable=too-few-public-methods
+class DaosLiteral(Literal):
+    """A wrapper for a Literal."""
+
+    def __hash__(self):
+        """Workaround for missing hash function"""
+        return hash(self.lstr)
+# pylint: enable=too-few-public-methods
+
+def add_rpaths(env, install_off, set_cgo_ld, is_bin):
+    """Add relative rpath entries"""
+    env.AppendUnique(RPATH_FULL=['$PREFIX/lib64'])
+    rpaths = env.subst("$RPATH_FULL").split()
+    prefix = env.get("PREFIX")
+    for rpath in rpaths:
+        if install_off is None:
+            env.AppendUnique(RPATH=[os.path.join(prefix, rpath)])
+            continue
+        relpath = os.path.relpath(rpath, prefix)
+        path = r'\$$ORIGIN/%s/%s' % (install_off, relpath)
+        if set_cgo_ld:
+            env.AppendENVPath("CGO_LDFLAGS", "-Wl,-rpath=$ORIGIN/%s/%s" %
+                              (install_off, relpath), sep=" ")
+        else:
+            env.AppendUnique(RPATH=[DaosLiteral(path)])
+        if "prereq" in relpath and not is_bin:
+            # NB: Also use full path so intermediate linking works
+            env.AppendUnique(RPATH=[os.path.join(prefix, rpath)])
+
+    if set_cgo_ld:
+        env.AppendENVPath("CGO_LDFLAGS",
+                          env.subst("$_LIBDIRFLAGS " "$_RPATH"),
+                          sep=" ")
+
 def library(env, *args, **kwargs):
     """build SharedLibrary with relative RPATH"""
     denv = env.Clone()
-    denv.AppendUnique(RPATH=[Literal(r'\$$ORIGIN')])
+    add_rpaths(denv, kwargs.get('install_off', '..'), False, False)
     return denv.SharedLibrary(*args, **kwargs)
 
 def program(env, *args, **kwargs):
     """build Program with relative RPATH"""
     denv = env.Clone()
-    denv.AppendUnique(RPATH=[Literal(r'\$$ORIGIN/../lib64')])
+    add_rpaths(denv, kwargs.get('install_off', '..'), False, True)
     return denv.Program(*args, **kwargs)
 
 def test(env, *args, **kwargs):
     """build Program with fixed RPATH"""
     denv = env.Clone()
-    denv.AppendUnique(RPATH=["$PREFIX/lib64"])
+    add_rpaths(denv, kwargs.get("install_off", None), False, True)
     return denv.Program(*args, **kwargs)
 
 def install(env, subdir, files):
@@ -68,7 +102,7 @@ def _find_mpicc(env):
 def _configure_mpi_pkg(env, libs):
     """Configure MPI using pkg-config"""
     if GetOption('help'):
-        return
+        return "mpi"
     if _find_mpicc(env):
         return env.subst("$MPI_PKG")
     try:
@@ -84,7 +118,7 @@ def _configure_mpi_pkg(env, libs):
     libs.append('mpi')
     return env.subst("$MPI_PKG")
 
-def configure_mpi(prereqs, env, libs, required=None):
+def configure_mpi(env, libs, required=None):
     """Check if mpi exists and configure environment"""
     if env.subst("$MPI_PKG") != "":
         return _configure_mpi_pkg(env, libs)

--- a/utils/docker/Dockerfile.ubuntu.20.04
+++ b/utils/docker/Dockerfile.ubuntu.20.04
@@ -17,6 +17,7 @@ ARG UID=1000
 # It's better to put the apt-get update in the same "cache layer" as the
 # apt-get install command so that the apt database is updated if/when the
 # installed packages list below is updated
+RUN ls
 
 # Install basic tools
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y \
@@ -29,7 +30,7 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y \
             locales make meson nasm ninja-build pandoc patch            \
             pylint python-dev python3-dev scons sg3-utils uuid-dev      \
             yasm valgrind libhwloc-dev man fuse3 libfuse3-dev 		\
-	    openjdk-8-jdk maven
+	    openjdk-8-jdk maven libopenmpi-dev
 
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y \
                        software-properties-common &&                    \

--- a/utils/rpms/daos.spec
+++ b/utils/rpms/daos.spec
@@ -6,7 +6,7 @@
 
 Name:          daos
 Version:       1.1.0
-Release:       23%{?relval}%{?dist}
+Release:       24%{?relval}%{?dist}
 Summary:       DAOS Storage Engine
 
 License:       Apache
@@ -181,7 +181,7 @@ This is the package needed to build software with the DAOS library.
 # remove rpathing from the build
 rpath_files="utils/daos_build.py"
 rpath_files+=" $(find . -name SConscript)"
-sed -i -e '/AppendUnique(RPATH=.*)/d' $rpath_files
+sed -i -e 's/[_a-zA-Z0-9]*\.AppendUnique(RPATH=.*)/pass/' $rpath_files
 
 %define conf_dir %{_sysconfdir}/daos
 
@@ -364,6 +364,10 @@ getent passwd daos_server >/dev/null || useradd -M daos_server
 %{_libdir}/*.a
 
 %changelog
+* Tue Jun 16 2020 Jeff Olivier <jeffrey.v.olivier@intel.com> - 1.1.0-24
+- Modify RPATH removal snippet to replace line with pass as some lines
+  can't be removed without breaking the code
+
 * Fri Jun 05 2020 Ryon Jensen <ryon.jensen@intel.com> - 1.1.0-23
 - Add libisa-l_crypto dependency
 

--- a/utils/sl/README.md
+++ b/utils/sl/README.md
@@ -30,37 +30,6 @@ PREFIX=<path>                      The installation path of the user's
                                    A user can do this via:
                                    ENV.Alias('install', "$PREFIX")
                                    ENV.Install("$PREFIX/bin", program).
-                                   By default, prerequisites will
-                                   also be installed here.   If a
-                                   user specifies TARGET_PREFIX,
-                                   only symbolic links for such
-                                   will be installed here.
-
-TARGET_PREFIX=<path>               An alternative location to place
-                                   prerequisite builds.  If set,
-                                   Each individual prerequisite
-                                   component will be installed in
-                                   $TARGET_PREFIX/<component> and
-                                   a symbolic link to the
-                                   installation targets will be
-                                   placed in $PREFIX.
-                                   will be installed here.
-
-PREBUILT_PREFIX=<path>[:<path>...] If set, the directories will be
-                                   searched for component builds.
-                                   Each component will be found
-                                   in $PREBUILT_PREFIX/<component>.
-                                   If a component is missing, it
-                                   will be fetched and built
-                                   using the definition of the
-                                   component.
-
-<COMPONENT>_PREBUILT=<path>        If set, the directory will be
-                                   used as the already installed
-                                   location for the component.
-                                   If the location doesn't exist,
-                                   the build will fail with an
-                                   error.
 
 SRC_PREFIX=<path>[:<path>...]      If set, the directories will be
                                    searched for component sources.
@@ -105,6 +74,17 @@ COMPILER=<compiler>                Specify an alternate compiler.
 BUILD_DIR=<path>                   Alternative path to place
                                    intermediate build targets.  Default
                                    is /path/to/daos_src/build
+
+BUILD_TYPE=dev|release|debug       Specify type of the build.
+
+TARGET_TYPE=default|dev|release|   Specify type of prerequisite build.
+            debug                  By default, prerequisites are
+                                   installed in
+                                   $PREFIX/prereq/$TARGET_TYPE/[component].
+                                   By default, TARGET_TYPE is same as
+                                   BUILD_TYPE.  If this is set, user can
+                                   mix and match build types for daos
+                                   vs prerequisites.
 
 EXCLUDE=<component>                Components that should not be built.
                                    Only option is psm2 at present.

--- a/utils/sl/fake_scons/SCons/Subst/__init__.py
+++ b/utils/sl/fake_scons/SCons/Subst/__init__.py
@@ -1,4 +1,5 @@
-# Copyright (c) 2016 Intel Corporation
+
+# Copyright (c) 2016-2018 Intel Corporation
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -17,8 +18,15 @@
 # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
-"""Fake SCons"""
+"""Fake scons environment shutting up pylint on SCons files"""
 
-__all__ = ['Script',
-           'Variables',
-           'Subst']
+# pylint: disable=too-few-public-methods
+class Literal():
+    """Fake Literal"""
+
+    def __init__(self, lstr):
+        """constructor"""
+        self.lstr = lstr
+
+
+__all__ = ['Literal']


### PR DESCRIPTION
Remove TARGET_PREFIX, PREBUILT_PREFIX, and [component]_PREBUILT options
Add TARGET_TYPE option
Remove --build-type option, use BUILD_TYPE for both prerequisites and daos

This patch makes a fundamental change to the build but always building
prerequisites in $PREFIX/prereq/$TARGET_TYPE/[component] making
TARGET_PREFIX style build the default for developer local builds.

This enables automatic switching as TARGET_TYPE default is BUILD_TYPE
so if user does a debug build, they will get debug prerequisites by
default unless they set TARGET_TYPE to something stable.

Also makes some adjustments to rpath to include origin based rpath in
libraries and tools

Signed-off-by: Jeff Olivier <jeffrey.v.olivier@intel.com>