### PR TITLE
DAOS-5154 sched: comparing uint32_t with negative value

### DIFF
--- a/src/iosrv/sched.c
+++ b/src/iosrv/sched.c
@@ -364,7 +364,6 @@ sched_start_cycle(struct sched_data *data, ABT_pool *pools)
 		limit = max(cycle->sc_ults_tot * throttle / 100, 1);
 		diff = cycle->sc_ults_cnt[i] - limit;
 
-		D_ASSERT(cycle->sc_ults_tot > diff);
 		if (diff > 0 &&
 		    (cycle->sc_ults_tot - diff) > cycle->sc_age_net_bound[0]) {
 			cycle->sc_ults_cnt[i] -= diff;


### PR DESCRIPTION
Remove the improper assert which comparing 'uint32_t' with 'int',
and the the 'int' value could be negative.

Signed-off-by: Niu Yawei <yawei.niu@intel.com>