### PR TITLE
DAOS-5121 Placement: Placement Changes for OSA Drain

### DIFF
--- a/src/common/pool_map.c
+++ b/src/common/pool_map.c
@@ -1919,7 +1919,8 @@ pool_map_find_failed_tgts(struct pool_map *map, struct pool_target **tgt_pp,
 
 	memset(&param, 0, sizeof(param));
 	param.ftp_chk_status = 1;
-	param.ftp_status = PO_COMP_ST_DOWN | PO_COMP_ST_DOWNOUT;
+	param.ftp_status = PO_COMP_ST_DOWN | PO_COMP_ST_DOWNOUT |
+		PO_COMP_ST_DRAIN;
 
 	return pool_map_find_tgts(map, &param, &fseq_sort_ops, tgt_pp,
 				  tgt_cnt);
@@ -1967,8 +1968,10 @@ pool_map_find_failed_tgts_by_rank(struct pool_map *map,
 				  struct pool_target ***tgt_ppp,
 				  unsigned int *tgt_cnt, d_rank_t rank)
 {
-	return pool_map_find_by_rank_status(map, tgt_ppp, tgt_cnt,
-					    PO_COMP_ST_DOWN|PO_COMP_ST_DOWNOUT,
+	unsigned int status;
+
+	status = PO_COMP_ST_DOWN | PO_COMP_ST_DOWNOUT | PO_COMP_ST_DRAIN;
+	return pool_map_find_by_rank_status(map, tgt_ppp, tgt_cnt, status,
 					    rank);
 }
 

--- a/src/include/daos/pool_map.h
+++ b/src/include/daos/pool_map.h
@@ -58,6 +58,8 @@ typedef enum pool_comp_state {
 	PO_COMP_ST_DOWN		= 1 << 3,
 	/** component is dead, its data has already been rebuilt */
 	PO_COMP_ST_DOWNOUT	= 1 << 4,
+	/** component is currently being drained and rebuilt elsewhere */
+	PO_COMP_ST_DRAIN	= 1 << 5,
 } pool_comp_state_t;
 
 /** parent class of all all pool components: target, domain */
@@ -267,6 +269,10 @@ pool_component_unavail(struct pool_component *comp, bool for_reint)
 
 	/* If it's down or down-out it is definitely unavailable */
 	if ((status == PO_COMP_ST_DOWN) || (status == PO_COMP_ST_DOWNOUT))
+		return true;
+
+	/* Targets being drained should not be used */
+	if (status == PO_COMP_ST_DRAIN)
 		return true;
 
 	/*

--- a/src/placement/jump_map.c
+++ b/src/placement/jump_map.c
@@ -105,6 +105,25 @@ jump_consistent_hash(uint64_t key, uint32_t num_buckets)
 }
 
 /**
+ * This functions determines whether the object layout should be extended or
+ * not based on the operation performed and the target status.
+ *
+ * \param[in]	op	The operation being performed
+ * \paramp[in]	status	The component status.
+ *
+ * \return		True if the layout should be extended,
+ *			False otherwise.
+ */
+static inline bool
+can_extend(enum PL_OP_TYPE op, enum pool_comp_state state)
+{
+	if (op != PL_PLACE_EXTENDED)
+		return false;
+	if (state != PO_COMP_ST_UP && state != PO_COMP_ST_DRAIN)
+		return false;
+	return true;
+}
+/**
  * This is useful for jump_map placement to pseudorandomly permute input keys
  * that are similar to each other. This dramatically improves the even-ness of
  * the distribution of output placements.
@@ -192,15 +211,22 @@ jm_obj_placement_get(struct pl_jump_map *jmap, struct daos_obj_md *md,
  * \return              True if there exists a spare, false otherwise.
  */
 static bool
-jump_map_remap_next_spare(struct pl_jump_map *jmap,
-			  struct jm_obj_placement *jmop, uint32_t spares_left)
+jump_map_has_next_spare(struct pl_jump_map *jmap, struct jm_obj_placement *jmop,
+		uint32_t spares_left, enum PL_OP_TYPE op,
+		enum pool_comp_state state)
 {
 	D_ASSERTF(jmop->jmop_grp_size <= jmap->jmp_domain_nr,
 		  "grp_size: %u > domain_nr: %u\n",
 		  jmop->jmop_grp_size, jmap->jmp_domain_nr);
 
 	if ((jmop->jmop_grp_size == jmap->jmp_domain_nr &&
-	    jmop->jmop_grp_size > 1) || spares_left == 0)
+	    jmop->jmop_grp_size > 1))
+		return false;
+
+	if (spares_left == 0)
+		return false;
+
+	if (state == PO_COMP_ST_DOWN && op == PL_REBUILD)
 		return false;
 
 	return true;
@@ -255,7 +281,7 @@ pl_map2jmap(struct pl_map *map)
 static void
 get_target(struct pool_domain *curr_dom, struct pool_target **target,
 	   uint64_t obj_key, uint8_t *dom_used, uint8_t *tgts_used,
-	   struct pl_obj_layout *layout, int shard_num)
+	   int shard_num)
 {
 	int                     range_set;
 	uint8_t                 found_target = 0;
@@ -360,13 +386,13 @@ count_available_spares(struct pl_jump_map *jmap, struct pl_obj_layout *layout,
 	uint32_t unusable_tgts;
 	uint32_t num_targets;
 
-	num_targets =  pool_map_find_domain(jmap->jmp_map.pl_poolmap,
-			jmap->min_redundant_dom, PO_COMP_ID_ALL, NULL);
+	num_targets =  pool_map_find_target(jmap->jmp_map.pl_poolmap,
+			PO_COMP_ID_ALL, NULL);
 
 	/* we might not have any valid targets left at all */
 	unusable_tgts = layout->ol_nr;
 
-	if (unusable_tgts >= num_targets || layout->ol_grp_size == 1)
+	if (unusable_tgts >= num_targets)
 		return 0;
 
 	return num_targets - unusable_tgts;
@@ -424,33 +450,30 @@ obj_remap_shards(struct pl_jump_map *jmap, struct daos_obj_md *md,
 	rc = pool_map_find_domain(jmap->jmp_map.pl_poolmap, PO_COMP_TP_ROOT,
 				  PO_COMP_ID_ALL, &root);
 	D_ASSERT(rc == 1);
-
 	while (current != remap_list) {
 		uint64_t rebuild_key;
 		uint32_t shard_id;
 
 		f_shard = d_list_entry(current, struct failed_shard, fs_list);
+
 		shard_id = f_shard->fs_shard_idx;
 		l_shard = &layout->ol_shards[f_shard->fs_shard_idx];
 
-		spare_avail = jump_map_remap_next_spare(jmap, jmop,
-				spares_left);
-
+		spare_avail = jump_map_has_next_spare(jmap, jmop, spares_left,
+				op_type, f_shard->fs_status);
 		if (spare_avail) {
 			rebuild_key = crc(key, f_shard->fs_shard_idx);
-
 			get_target(root, &spare_tgt, crc(key, rebuild_key),
-				   dom_used, tgts_used, layout, shard_id);
+				   dom_used, tgts_used, shard_id);
 			spares_left--;
+			if (can_extend(op_type, spare_tgt->ta_comp.co_status)) {
+				rc = remap_alloc_one(extend_list, shard_id,
+						spare_tgt, true);
+				if (rc)
+					return rc;
+			}
 		}
 
-		if (op_type == PL_PLACE_EXTENDED && spare_avail &&
-		   spare_tgt->ta_comp.co_status == PO_COMP_ST_UP) {
-			rc = remap_alloc_one(extend_list, shard_id, spare_tgt,
-					     true);
-			if (rc)
-				return rc;
-		}
 		determine_valid_spares(spare_tgt, md, spare_avail,
 				&current, remap_list, for_reint, f_shard,
 				l_shard);
@@ -552,6 +575,7 @@ get_object_layout(struct pl_jump_map *jmap, struct pl_obj_layout *layout,
 	uint64_t                key;
 	uint32_t		fail_tgt_cnt;
 	bool			for_reint;
+	enum pool_comp_state	state;
 	int i, j, k, rc;
 
 	/* Set the pool map version */
@@ -607,11 +631,11 @@ get_object_layout(struct pl_jump_map *jmap, struct pl_obj_layout *layout,
 
 		if (pool_target_unavail(target, for_reint)) {
 			fail_tgt_cnt++;
+			state = target->ta_comp.co_status;
 			rc = remap_alloc_one(remap_list, 0, target, false);
 			if (rc)
 				D_GOTO(out, rc);
-			if (op_type == PL_PLACE_EXTENDED &&
-			   target->ta_comp.co_status == PO_COMP_ST_UP) {
+			if (can_extend(op_type, state)) {
 				rc = remap_alloc_one(&extend_list, k, target,
 						     true);
 				if (rc != 0)
@@ -625,15 +649,13 @@ get_object_layout(struct pl_jump_map *jmap, struct pl_obj_layout *layout,
 		j = 1;
 		k = 1;
 	}
-
 	for (i = 0; i < jmop->jmop_grp_nr; i++) {
 
 		for (; j < jmop->jmop_grp_size; j++, k++) {
 			uint32_t tgt_id;
 			uint32_t fseq;
 
-			get_target(root, &target, key, dom_used, tgts_used,
-				   layout, k);
+			get_target(root, &target, key, dom_used, tgts_used, k);
 
 			tgt_id = target->ta_comp.co_id;
 			fseq = target->ta_comp.co_fseq;
@@ -645,14 +667,13 @@ get_object_layout(struct pl_jump_map *jmap, struct pl_obj_layout *layout,
 			/** If target is failed queue it for remap*/
 			if (pool_target_unavail(target, for_reint)) {
 				fail_tgt_cnt++;
-
+				state = target->ta_comp.co_status;
 				rc = remap_alloc_one(remap_list, k, target,
 						false);
 				if (rc)
 					D_GOTO(out, rc);
 
-				if (op_type == PL_PLACE_EXTENDED &&
-				   target->ta_comp.co_status == PO_COMP_ST_UP) {
+				if (can_extend(op_type, state)) {
 					remap_alloc_one(&extend_list, k,
 							target, true);
 				}
@@ -668,14 +689,12 @@ get_object_layout(struct pl_jump_map *jmap, struct pl_obj_layout *layout,
 		rc = obj_remap_shards(jmap, md, layout, jmop, remap_list,
 				op_type, tgts_used, dom_used, fail_tgt_cnt,
 				&extend_list);
-
 out:
 	if (rc) {
 		D_ERROR("jump_map_obj_layout_fill failed, rc "DF_RC"\n",
 			DP_RC(rc));
 		remap_list_free_all(remap_list);
 	}
-
 	if (dom_used)
 		D_FREE(dom_used);
 	if (tgts_used)
@@ -883,12 +902,6 @@ jump_map_obj_find_rebuild(struct pl_map *map, struct daos_obj_md *md,
 		return rc;
 	}
 
-	if (jmop.jmop_grp_size == 1) {
-		D_DEBUG(DB_PL, "Not replicated object "DF_OID"\n",
-			DP_OID(md->omd_id));
-		return 0;
-	}
-
 	/* Allocate space to hold the layout */
 	rc = pl_obj_layout_alloc(jmop.jmop_grp_size, jmop.jmop_grp_nr,
 				 &layout);
@@ -951,12 +964,6 @@ jump_map_obj_find_reint(struct pl_map *map, struct daos_obj_md *md,
 	if (rc) {
 		D_ERROR("jm_obj_placement_get failed, rc %d.\n", rc);
 		return rc;
-	}
-
-	if (jop.jmop_grp_size == 1) {
-		D_DEBUG(DB_PL, "Not replicated object "DF_OID"\n",
-			DP_OID(md->omd_id));
-		return 0;
 	}
 
 	/* Allocate space to hold the layout */

--- a/src/placement/pl_map_common.c
+++ b/src/placement/pl_map_common.c
@@ -210,7 +210,8 @@ remap_list_fill(struct pl_map *map, struct daos_obj_md *md,
 			break;
 
 		if (f_shard->fs_status == PO_COMP_ST_DOWN ||
-		    f_shard->fs_status == PO_COMP_ST_UP) {
+		    f_shard->fs_status == PO_COMP_ST_UP ||
+		    f_shard->fs_status == PO_COMP_ST_DRAIN) {
 			/*
 			 * Target id is used for rw, but rank is used
 			 * for rebuild, perhaps they should be unified.
@@ -329,13 +330,13 @@ determine_valid_spares(struct pool_target *spare_tgt, struct daos_obj_md *md,
 		 */
 		if (spare_tgt->ta_comp.co_fseq < f_shard->fs_fseq)
 			return; /* try next spare */
-
 		/*
 		 * If both failed target and spare target are down, then
 		 * add the spare target to the fail list for remap, and
-		 * try next spare on the ring.
+		 * try next spare.
 		 */
-		if (f_shard->fs_status == PO_COMP_ST_DOWN)
+		if (f_shard->fs_status == PO_COMP_ST_DOWN ||
+		    f_shard->fs_status == PO_COMP_ST_DRAIN)
 			D_ASSERTF(spare_tgt->ta_comp.co_status !=
 				  PO_COMP_ST_DOWNOUT,
 				  "down fseq(%u) < downout fseq(%u)\n",
@@ -365,30 +366,14 @@ next_fail:
 	if (spare_avail) {
 		/* The selected spare target is up and ready */
 		l_shard->po_target = spare_tgt->ta_comp.co_id;
-
-		/* XXX: Use pl_obj_shard::po_fseq to record the latest
-		 *      failure sequence of the targets on the remap
-		 *      chain for the given shard (@l_shard).
-		 *
-		 *      The f_shard->fs_fseq is the snapshot of the
-		 *      pool map version (that is incremental only)
-		 *      when related spare (or the original target)
-		 *      became down.
-		 *
-		 *      Currently, DAOS does not support the target
-		 *      re-integration. So the failure sequence for
-		 *      available spares will be the initial value
-		 *      (the oldest one). So here, we only need to
-		 *      consider those unavailable spares's failure
-		 *      sequences to find out the latest (largest).
-		 */
-		l_shard->po_fseq = f_shard->fs_fseq;
+		l_shard->po_fseq = spare_tgt->ta_comp.co_fseq;
 
 		/*
 		 * Mark the shard as 'rebuilding' so that read will
 		 * skip this shard.
 		 */
-		if (f_shard->fs_status == PO_COMP_ST_DOWN) {
+		if (f_shard->fs_status == PO_COMP_ST_DOWN ||
+		    f_shard->fs_status == PO_COMP_ST_DRAIN) {
 			l_shard->po_rebuilding = 1;
 			f_shard->fs_tgt_id = spare_tgt->ta_comp.co_id;
 		}
@@ -403,6 +388,7 @@ int
 pl_map_extend(struct pl_obj_layout *layout, d_list_t *extended_list)
 {
 	struct pl_obj_shard	*new_shards;
+	struct pl_obj_shard     *org_shard;
 	struct failed_shard	*f_shard;
 	d_list_t		*current;
 	uint8_t                 *grp_map;
@@ -418,7 +404,7 @@ pl_map_extend(struct pl_obj_layout *layout, d_list_t *extended_list)
 	grp_count = NULL;
 
 	/* Empty list, no extension needed */
-	if (extended_list == extended_list->next || layout->ol_grp_size == 1)
+	if (extended_list == extended_list->next)
 		goto out;
 
 	D_ALLOC_ARRAY(grp_map, (layout->ol_nr / 8) + 1);
@@ -464,6 +450,7 @@ pl_map_extend(struct pl_obj_layout *layout, d_list_t *extended_list)
 	current = extended_list->next;
 	while (current != extended_list) {
 		f_shard = d_list_entry(current, struct failed_shard, fs_list);
+		org_shard = &new_shards[f_shard->fs_shard_idx];
 
 		grp = f_shard->fs_shard_idx / layout->ol_grp_size;
 		grp_idx = ((grp + 1) * layout->ol_grp_size) + grp;
@@ -473,7 +460,11 @@ pl_map_extend(struct pl_obj_layout *layout, d_list_t *extended_list)
 		new_shards[grp_idx].po_fseq = f_shard->fs_fseq;
 		new_shards[grp_idx].po_shard = f_shard->fs_shard_idx;
 		new_shards[grp_idx].po_target = f_shard->fs_tgt_id;
-		new_shards[grp_idx].po_rebuilding = 1;
+		if (org_shard->po_fseq > f_shard->fs_shard_idx &&
+				org_shard->po_target != -1)
+			new_shards[grp_idx].po_rebuilding = 1;
+		else
+			new_shards[grp_idx].po_rebuilding = 0;
 
 		current = current->next;
 	}

--- a/src/placement/tests/jump_map_place_obj.c
+++ b/src/placement/tests/jump_map_place_obj.c
@@ -83,11 +83,13 @@ rebuild_object_class(daos_oclass_id_t cid)
 	uuid_t			pl_uuid;
 	struct daos_obj_md	*md_arr;
 	struct daos_obj_md	md = { 0 };
-	struct pl_obj_layout	*layout;
+	struct pl_obj_layout	**org_layout;
+	struct pl_obj_layout    *layout;
 	uint32_t		po_ver;
 	int			test_num;
 	int			num_new_spares;
 	int			fail_tgt;
+	int			spares_left;
 	int			rc, i;
 
 	uuid_generate(pl_uuid);
@@ -97,6 +99,8 @@ rebuild_object_class(daos_oclass_id_t cid)
 
 	D_ALLOC_ARRAY(md_arr, TEST_PER_OC);
 	D_ASSERT(md_arr != NULL);
+	D_ALLOC_ARRAY(org_layout, TEST_PER_OC);
+	D_ASSERT(org_layout != NULL);
 
 	gen_pool_and_placement_map(DOM_NR, NODE_PER_DOM,
 				   VOS_PER_TARGET, PL_TYPE_JUMP_MAP,
@@ -104,6 +108,7 @@ rebuild_object_class(daos_oclass_id_t cid)
 	D_ASSERT(po_map != NULL);
 	D_ASSERT(pl_map != NULL);
 
+	/* Create array of object IDs to use later */
 	for (i = 0; i < TEST_PER_OC; ++i) {
 		oid.lo = rand();
 		daos_obj_generate_id(&oid, 0, cid, 0);
@@ -112,35 +117,59 @@ rebuild_object_class(daos_oclass_id_t cid)
 		md_arr[i] = md;
 	}
 
-	for (fail_tgt = 0; fail_tgt < NUM_TARGETS; ++fail_tgt) {
+	/* Generate layouts for later comparison*/
+	for (test_num = 0; test_num < TEST_PER_OC; ++test_num) {
+		rc = pl_obj_place(pl_map, &md_arr[test_num], NULL,
+					&org_layout[test_num]);
+		D_ASSERT(rc == 0);
+		plt_obj_layout_check(org_layout[test_num], COMPONENT_NR, 0);
+	}
 
+	for (fail_tgt = 0; fail_tgt < NUM_TARGETS; ++fail_tgt) {
 		/* Fail target and update the pool map */
 		plt_fail_tgt(fail_tgt, &po_ver, po_map,  pl_debug_msg);
 		pl_map_update(pl_uuid, po_map, false, PL_TYPE_JUMP_MAP);
 		pl_map = pl_map_find(pl_uuid, oid);
 
-		for (test_num = 0; test_num < TEST_PER_OC; ++test_num) {
-			md_arr[test_num].omd_ver = po_ver;
-
-			num_new_spares = pl_obj_find_rebuild(pl_map,
-					&md_arr[test_num], NULL, po_ver,
-					spare_tgt_ranks, shard_ids,
-					SPARE_MAX_NUM, -1);
-
-			D_ASSERT(num_new_spares >= 0 && num_new_spares < 2);
-		}
-
-
-		plt_fail_tgt_out(fail_tgt, &po_ver, po_map,  pl_debug_msg);
-		pl_map_update(pl_uuid, po_map, false, PL_TYPE_JUMP_MAP);
-		pl_map = pl_map_find(pl_uuid, oid);
-
+		/*
+		 * For each failed target regenerate all layouts and
+		 * fetch rebuild targets, then verify basic conditions met
+		 */
 		for (test_num = 0; test_num < TEST_PER_OC; ++test_num) {
 			md_arr[test_num].omd_ver = po_ver;
 
 			rc = pl_obj_place(pl_map, &md_arr[test_num], NULL,
 					&layout);
 			D_ASSERT(rc == 0);
+
+			num_new_spares = pl_obj_find_rebuild(pl_map,
+					&md_arr[test_num], NULL, po_ver,
+					spare_tgt_ranks, shard_ids,
+					SPARE_MAX_NUM, -1);
+
+			spares_left = NUM_TARGETS - layout->ol_nr + fail_tgt;
+			plt_obj_rebuild_layout_check(layout,
+					org_layout[test_num], COMPONENT_NR,
+					&fail_tgt, 1, spares_left,
+					num_new_spares, spare_tgt_ranks,
+					shard_ids);
+
+			pl_obj_layout_free(layout);
+		}
+
+		/* Move target to Down state */
+		plt_fail_tgt_out(fail_tgt, &po_ver, po_map,  pl_debug_msg);
+		pl_map_update(pl_uuid, po_map, false, PL_TYPE_JUMP_MAP);
+		pl_map = pl_map_find(pl_uuid, oid);
+
+		/* Verify post rebuild layout */
+		for (test_num = 0; test_num < TEST_PER_OC; ++test_num) {
+			md_arr[test_num].omd_ver = po_ver;
+
+			rc = pl_obj_place(pl_map, &md_arr[test_num], NULL,
+					&layout);
+			D_ASSERT(rc == 0);
+			D_ASSERT(layout->ol_nr == org_layout[test_num]->ol_nr);
 
 			plt_obj_layout_check(layout, COMPONENT_NR,
 					layout->ol_nr);
@@ -149,6 +178,10 @@ rebuild_object_class(daos_oclass_id_t cid)
 
 	}
 
+	/* Cleanup Memory */
+	for (i = 0; i < TEST_PER_OC; ++i)
+		D_FREE(org_layout[i]);
+	D_FREE(org_layout);
 	free_pool_and_placement_map(po_map, pl_map);
 	D_PRINT("\tRebuild: OK\n");
 }
@@ -164,12 +197,13 @@ reint_object_class(daos_oclass_id_t cid)
 	uuid_t			pl_uuid;
 	struct daos_obj_md	*md_arr;
 	struct daos_obj_md	md = { 0 };
-	struct pl_obj_layout	**layout;
-	struct pl_obj_layout    *temp_layout;
+	struct pl_obj_layout	***layout;
+	struct pl_obj_layout	*temp_layout;
 	uint32_t		po_ver;
 	int			test_num;
 	int			num_reint;
 	int			fail_tgt;
+	int			spares_left;
 	int			rc, i;
 
 	uuid_generate(pl_uuid);
@@ -179,8 +213,147 @@ reint_object_class(daos_oclass_id_t cid)
 
 	D_ALLOC_ARRAY(md_arr, TEST_PER_OC);
 	D_ASSERT(md_arr != NULL);
-	D_ALLOC_ARRAY(layout, TEST_PER_OC);
+	D_ALLOC_ARRAY(layout, NUM_TARGETS + 1);
 	D_ASSERT(layout != NULL);
+
+	for (i = 0; i < NUM_TARGETS + 1; ++i) {
+		D_ALLOC_ARRAY(layout[i], TEST_PER_OC);
+		D_ASSERT(layout[i] != NULL);
+	}
+
+	gen_pool_and_placement_map(DOM_NR, NODE_PER_DOM,
+			   VOS_PER_TARGET, PL_TYPE_JUMP_MAP,
+			   &po_map, &pl_map);
+	D_ASSERT(po_map != NULL);
+	D_ASSERT(pl_map != NULL);
+
+	for (i = 0; i < TEST_PER_OC; ++i) {
+		oid.lo = rand();
+		daos_obj_generate_id(&oid, 0, cid, 0);
+		dc_obj_fetch_md(oid, &md);
+		md.omd_ver = po_ver;
+		md_arr[i] = md;
+	}
+
+	/* Generate original layouts for later comparison*/
+	for (test_num = 0; test_num < TEST_PER_OC; ++test_num) {
+		rc = pl_obj_place(pl_map, &md_arr[test_num], NULL,
+					&layout[0][test_num]);
+		D_ASSERT(rc == 0);
+		plt_obj_layout_check(layout[0][test_num], COMPONENT_NR, 0);
+	}
+
+	/* fail all the targets */
+	for (fail_tgt = 0; fail_tgt < NUM_TARGETS; ++fail_tgt) {
+
+		plt_fail_tgt(fail_tgt, &po_ver, po_map,  pl_debug_msg);
+		pl_map_update(pl_uuid, po_map, false, PL_TYPE_JUMP_MAP);
+
+		plt_fail_tgt_out(fail_tgt, &po_ver, po_map,  pl_debug_msg);
+		pl_map_update(pl_uuid, po_map, false, PL_TYPE_JUMP_MAP);
+
+		/* Generate layouts for all N target failures*/
+		for (test_num = 0; test_num < TEST_PER_OC; ++test_num) {
+			md_arr[test_num].omd_ver = po_ver;
+
+			rc = pl_obj_place(pl_map, &md_arr[test_num], NULL,
+					&layout[fail_tgt + 1][test_num]);
+			D_ASSERT(rc == 0);
+			plt_obj_layout_check(layout[fail_tgt + 1][test_num],
+					COMPONENT_NR, NUM_TARGETS);
+		}
+	}
+
+	/* Reintegrate targets one-by-one and compare layouts */
+	spares_left = NUM_TARGETS - (layout[0][0]->ol_nr + fail_tgt);
+	for (fail_tgt = NUM_TARGETS-1; fail_tgt >= 0; --fail_tgt) {
+		plt_reint_tgt(fail_tgt, &po_ver, po_map,  pl_debug_msg);
+		pl_map_update(pl_uuid, po_map, false, PL_TYPE_JUMP_MAP);
+		pl_map = pl_map_find(pl_uuid, oid);
+
+		for (test_num = 0; test_num < TEST_PER_OC; ++test_num) {
+			md_arr[test_num].omd_ver = po_ver;
+			rc = pl_obj_place(pl_map, &md_arr[test_num], NULL,
+					&temp_layout);
+			D_ASSERT(rc == 0);
+
+			num_reint = pl_obj_find_reint(pl_map, &md_arr[test_num],
+					NULL, po_ver,  spare_tgt_ranks,
+					shard_ids, SPARE_MAX_NUM, -1);
+
+			plt_obj_reint_layout_check(temp_layout,
+					layout[fail_tgt][test_num],
+					COMPONENT_NR, &fail_tgt, 1, spares_left,
+					num_reint, spare_tgt_ranks, shard_ids);
+
+			pl_obj_layout_free(temp_layout);
+		}
+
+		/* Set the target to up */
+		plt_reint_tgt_up(fail_tgt, &po_ver, po_map,  pl_debug_msg);
+		pl_map_update(pl_uuid, po_map, false, PL_TYPE_JUMP_MAP);
+
+		/*
+		 * Verify that the post-reintegration layout matches the
+		 * pre-failure layout
+		 */
+		for (test_num = 0; test_num < TEST_PER_OC; ++test_num) {
+			md_arr[test_num].omd_ver = po_ver;
+
+			rc = pl_obj_place(pl_map, &md_arr[test_num], NULL,
+					&temp_layout);
+			D_ASSERT(rc == 0);
+
+			plt_obj_layout_check(temp_layout, COMPONENT_NR,
+					NUM_TARGETS);
+
+			D_ASSERT(plt_obj_layout_match(temp_layout,
+					layout[fail_tgt][test_num]));
+
+			pl_obj_layout_free(temp_layout);
+		}
+
+	}
+	/* Cleanup Memory */
+	for (i = 0; i <= NUM_TARGETS; ++i) {
+		for (test_num = 0; test_num < TEST_PER_OC; ++test_num)
+			D_FREE(layout[i][test_num]);
+		D_FREE(layout[i]);
+	}
+	D_FREE(layout);
+	free_pool_and_placement_map(po_map, pl_map);
+	D_PRINT("\tReintegration: OK\n");
+}
+
+void
+drain_object_class(daos_oclass_id_t cid)
+{
+	struct pool_map		*po_map;
+	struct pl_map		*pl_map;
+	uint32_t		spare_tgt_ranks[SPARE_MAX_NUM];
+	uint32_t		shard_ids[SPARE_MAX_NUM];
+	uint32_t		po_ver;
+	daos_obj_id_t		oid;
+	uuid_t			pl_uuid;
+	struct daos_obj_md	*md_arr;
+	struct daos_obj_md	md = { 0 };
+	struct pl_obj_layout	*layout;
+	struct pl_obj_layout	**org_layout;
+	int			test_num;
+	int			num_new_spares;
+	int			fail_tgt;
+	int			rc, i;
+	int			spares_left;
+
+	uuid_generate(pl_uuid);
+	srand(time(NULL));
+	oid.hi = 5;
+	po_ver = 1;
+
+	D_ALLOC_ARRAY(md_arr, TEST_PER_OC);
+	D_ASSERT(md_arr != NULL);
+	D_ALLOC_ARRAY(org_layout, TEST_PER_OC);
+	D_ASSERT(org_layout != NULL);
 
 	gen_pool_and_placement_map(DOM_NR, NODE_PER_DOM,
 				   VOS_PER_TARGET, PL_TYPE_JUMP_MAP,
@@ -201,48 +374,67 @@ reint_object_class(daos_oclass_id_t cid)
 		md_arr[test_num].omd_ver = po_ver;
 
 		rc = pl_obj_place(pl_map, &md_arr[test_num], NULL,
-					&layout[test_num]);
+					&org_layout[test_num]);
 		D_ASSERT(rc == 0);
-		plt_obj_layout_check(layout[test_num], COMPONENT_NR, 0);
+		plt_obj_layout_check(org_layout[test_num], COMPONENT_NR, 0);
 	}
 
-	/* fail all the targets */
+	spares_left = NUM_TARGETS - (org_layout[0]->ol_nr + fail_tgt);
 	for (fail_tgt = 0; fail_tgt < NUM_TARGETS; ++fail_tgt) {
-
-		plt_fail_tgt(fail_tgt, &po_ver, po_map,  pl_debug_msg);
-		pl_map_update(pl_uuid, po_map, false, PL_TYPE_JUMP_MAP);
-
-		plt_fail_tgt_out(fail_tgt, &po_ver, po_map,  pl_debug_msg);
-		pl_map_update(pl_uuid, po_map, false, PL_TYPE_JUMP_MAP);
-
-	}
-
-	for (fail_tgt = 0; fail_tgt < NUM_TARGETS; ++fail_tgt) {
-		plt_reint_tgt(fail_tgt, &po_ver, po_map,  pl_debug_msg);
+		/* Drain target and update the pool map */
+		plt_drain_tgt(fail_tgt, &po_ver, po_map,  pl_debug_msg);
 		pl_map_update(pl_uuid, po_map, false, PL_TYPE_JUMP_MAP);
 		pl_map = pl_map_find(pl_uuid, oid);
 
 		for (test_num = 0; test_num < TEST_PER_OC; ++test_num) {
-			rc = pl_obj_place(pl_map, &md_arr[test_num], NULL,
-					&temp_layout);
+			md_arr[test_num].omd_ver = po_ver;
+			rc = pl_obj_place(pl_map, &md_arr[test_num],
+					  NULL, &layout);
 			D_ASSERT(rc == 0);
 
-			num_reint = pl_obj_find_reint(pl_map, &md_arr[test_num],
-					NULL, po_ver,  spare_tgt_ranks,
-					shard_ids, SPARE_MAX_NUM, -1);
+			num_new_spares = pl_obj_find_rebuild(pl_map,
+					&md_arr[test_num], NULL, po_ver,
+					spare_tgt_ranks, shard_ids,
+					SPARE_MAX_NUM, -1);
 
-			reint_check(layout[test_num], temp_layout,
-					spare_tgt_ranks, shard_ids, num_reint,
-					fail_tgt);
+			plt_obj_layout_check(layout, COMPONENT_NR,
+					layout->ol_nr);
+
+			plt_obj_drain_layout_check(layout,
+					org_layout[test_num], COMPONENT_NR,
+					&fail_tgt, 1, spares_left,
+					num_new_spares, spare_tgt_ranks,
+					shard_ids);
+
+			pl_obj_layout_free(layout);
 		}
 
-		plt_reint_tgt_up(fail_tgt, &po_ver, po_map,  pl_debug_msg);
+		/* Move target to Down-Out state */
+		plt_fail_tgt_out(fail_tgt, &po_ver, po_map,  pl_debug_msg);
 		pl_map_update(pl_uuid, po_map, false, PL_TYPE_JUMP_MAP);
+		pl_map = pl_map_find(pl_uuid, oid);
+
+		for (test_num = 0; test_num < TEST_PER_OC; ++test_num) {
+			md_arr[test_num].omd_ver = po_ver;
+			pl_obj_layout_free(org_layout[test_num]);
+
+			rc = pl_obj_place(pl_map, &md_arr[test_num], NULL,
+					&org_layout[test_num]);
+			D_ASSERT(rc == 0);
+
+			plt_obj_layout_check(org_layout[test_num], COMPONENT_NR,
+					org_layout[test_num]->ol_nr);
+
+		}
+
 	}
 
-
+	/* Cleanup Memory */
+	for (i = 0; i < TEST_PER_OC; ++i)
+		D_FREE(org_layout[i]);
+	D_FREE(org_layout);
 	free_pool_and_placement_map(po_map, pl_map);
-	D_PRINT("\tReintegration: OK\n");
+	D_PRINT("\tRebuild with Drain: OK\n");
 }
 
 int
@@ -273,6 +465,7 @@ main(int argc, char **argv)
 
 		placement_object_class(test_classes[oc_index]);
 		rebuild_object_class(test_classes[oc_index]);
+		drain_object_class(test_classes[oc_index]);
 		reint_object_class(test_classes[oc_index]);
 
 	}

--- a/src/placement/tests/place_obj_common.h
+++ b/src/placement/tests/place_obj_common.h
@@ -30,6 +30,9 @@
 #include <daos.h>
 
 void
+print_layout(struct pl_obj_layout *layout);
+
+void
 plt_obj_place(daos_obj_id_t oid, struct pl_obj_layout **layout,
 		struct pl_map *pl_map, bool print_layout);
 
@@ -38,21 +41,40 @@ plt_obj_layout_check(struct pl_obj_layout *layout, uint32_t pool_size,
 		int num_allowed_failures);
 
 void
-reint_check(struct pl_obj_layout *layout, struct pl_obj_layout *temp_layout,
-		uint32_t *spare_tgt_ranks, uint32_t *shard_ids, int num_reint,
-		uint32_t curr_fail_tgt);
+plt_obj_rebuild_layout_check(struct pl_obj_layout *layout,
+		struct pl_obj_layout *org_layout, uint32_t pool_size,
+		int *down_tgts, int num_down, int num_spares_left,
+		uint32_t num_spares_returned, uint32_t *spare_tgt_ranks,
+		uint32_t *shard_ids);
+
+void
+plt_obj_drain_layout_check(struct pl_obj_layout *layout,
+		struct pl_obj_layout *org_layout, uint32_t pool_size,
+		int *draining_tgts, int num_draining, int num_spares,
+		uint32_t num_spares_returned, uint32_t *spare_tgt_ranks,
+		uint32_t *shard_ids);
+
+void
+plt_obj_reint_layout_check(struct pl_obj_layout *layout,
+		struct pl_obj_layout *org_layout, uint32_t pool_size,
+		int *reint_tgts, int num_reint, int num_spares,
+		uint32_t num_spares_returned, uint32_t *spare_tgt_ranks,
+		uint32_t *shard_ids);
 
 void
 plt_obj_rebuild_unique_check(uint32_t *shard_ids, uint32_t num_shards,
 		uint32_t pool_size);
 
 bool
-pt_obj_layout_match(struct pl_obj_layout *lo_1, struct pl_obj_layout *lo_2,
-		uint32_t dom_nr);
+plt_obj_layout_match(struct pl_obj_layout *lo_1, struct pl_obj_layout *lo_2);
 
 void
 plt_set_tgt_status(uint32_t id, int status, uint32_t ver,
 		struct pool_map *po_map, bool pl_debug_msg);
+
+void
+plt_drain_tgt(uint32_t id, uint32_t *po_ver, struct pool_map *po_map,
+		bool pl_debug_msg);
 
 void
 plt_fail_tgt(uint32_t id, uint32_t *po_ver, struct pool_map *po_map,

--- a/src/placement/tests/ring_map_place_obj.c
+++ b/src/placement/tests/ring_map_place_obj.c
@@ -94,7 +94,7 @@ main(int argc, char **argv)
 			     pl_debug_msg);
 	plt_obj_place(oid, &lo_2, pl_map, true);
 	plt_obj_layout_check(lo_2, COMPONENT_NR, 0);
-	D_ASSERT(!pt_obj_layout_match(lo_1, lo_2, DOM_NR));
+	D_ASSERT(!plt_obj_layout_match(lo_1, lo_2));
 	D_PRINT("spare target candidate:");
 	for (i = 0; i < SPARE_MAX_NUM && i < lo_1->ol_nr; i++) {
 		spare_tgt_candidate[i] = lo_2->ol_shards[i].po_target;
@@ -108,7 +108,7 @@ main(int argc, char **argv)
 			    pl_debug_msg);
 	plt_obj_place(oid, &lo_3, pl_map, true);
 	plt_obj_layout_check(lo_3, COMPONENT_NR, 0);
-	D_ASSERT(pt_obj_layout_match(lo_1, lo_3, DOM_NR));
+	D_ASSERT(plt_obj_layout_match(lo_1, lo_3));
 
 	/* test pl_obj_find_rebuild */
 	D_PRINT("\ntest pl_obj_find_rebuild to get correct spare tagets ...\n");

--- a/src/pool/srv_util.c
+++ b/src/pool/srv_util.c
@@ -41,7 +41,8 @@ map_ranks_include(enum map_ranks_class class, int status)
 		return status == PO_COMP_ST_UP || status == PO_COMP_ST_UPIN;
 	case MAP_RANKS_DOWN:
 		return status == PO_COMP_ST_DOWN ||
-		       status == PO_COMP_ST_DOWNOUT;
+		       status == PO_COMP_ST_DOWNOUT ||
+		       status == PO_COMP_ST_DRAIN;
 	default:
 		D_ASSERTF(0, "%d\n", class);
 	}


### PR DESCRIPTION
The following changes are toward the online server drain feature.
This feature allows the draining and preemptive rebuilding of object data
including non-replicated object shards.

* Added the Drain component status
* Placement and Rebuild not support Draining targets
* Reworked tests to increase coverage
* Created tests for Drain

Signed-off-by: Peter Fetros <peter.fetros@intel.com>