### PR TITLE
DAOS-5160 object: return correct pool map version

### DIFF
--- a/src/object/srv_obj.c
+++ b/src/object/srv_obj.c
@@ -1338,7 +1338,6 @@ obj_ioc_fini(struct obj_io_context *ioc)
 		ds_cont_child_put(ioc->ioc_coc);
 		ioc->ioc_coc = NULL;
 	}
-	ioc->ioc_map_ver = 0;
 }
 
 /* Various check before access VOS */


### PR DESCRIPTION
Do not reset ioc_map_version, otherwise it will return
wrong pool map version to client for ESTALE case.

Signed-off-by: Di Wang <di.wang@intel.com>