### PR TITLE
DAOS-0000 vos: flat key implementation

### DIFF
--- a/src/vos/tests/vts_io.c
+++ b/src/vos/tests/vts_io.c
@@ -497,7 +497,7 @@ io_test_obj_update(struct io_test_args *arg, daos_epoch_t epoch,
 {
 	struct bio_sglist	*bsgl;
 	struct bio_iov		*biov;
-	d_iov_t		*srv_iov;
+	d_iov_t			*srv_iov;
 	daos_handle_t		ioh;
 	unsigned int		off;
 	int			i;

--- a/src/vos/vos_internal.h
+++ b/src/vos/vos_internal.h
@@ -555,6 +555,7 @@ struct vos_rec_bundle {
 	uint32_t		 rb_ver;
 	/** tree class */
 	enum vos_tree_class	 rb_tclass;
+	bool			 rb_flat;
 };
 
 /**

--- a/src/vos/vos_layout.h
+++ b/src/vos/vos_layout.h
@@ -284,6 +284,8 @@ enum vos_krec_bf {
 	KREC_BF_BTR			= (1 << 1),
 	/* it's a dkey, otherwise is akey */
 	KREC_BF_DKEY			= (1 << 2),
+	/* it's a flat dkey (no akey) */
+	KREC_BF_FLAT			= (1 << 3),
 };
 
 /**

--- a/src/vos/vos_obj.h
+++ b/src/vos/vos_obj.h
@@ -120,6 +120,15 @@ void vos_obj_evict(struct vos_object *obj);
 int vos_obj_evict_by_oid(struct daos_lru_cache *occ, struct vos_container *cont,
 			 daos_unit_oid_t oid);
 
+static inline bool
+obj_is_flat(struct vos_object *obj)
+{
+	daos_ofeat_t	feats;
+
+	feats = daos_obj_id2feat(obj->obj_id.id_pub);
+	return (feats & DAOS_OF_KV_FLAT);
+}
+
 /**
  * Create an object cache.
  *


### PR DESCRIPTION
- flat key: value is attached to dkey instead of akey
- user should use DAOS_OF_KV_FLAT to generate object ID
  for flat KV object.

Signed-off-by: Liang Zhen <liang.zhen@intel.com>