### PR TITLE
DAOS-5142 control: Handle empty membership in SystemQuery

### DIFF
--- a/src/control/server/ctl_system.go
+++ b/src/control/server/ctl_system.go
@@ -138,6 +138,10 @@ func (svc *ControlService) SystemQuery(parent context.Context, pbReq *ctlpb.Syst
 		return nil, errors.New("nil request")
 	}
 
+	if len(svc.membership.Members()) == 0 {
+		return new(ctlpb.SystemQueryResp), nil
+	}
+
 	ctx, cancel := context.WithTimeout(parent, systemReqTimeout)
 	defer cancel()
 

--- a/src/control/server/ctl_system_test.go
+++ b/src/control/server/ctl_system_test.go
@@ -271,6 +271,9 @@ func TestServer_CtlSvc_SystemQuery(t *testing.T) {
 			nilReq:    true,
 			expErrMsg: "nil request",
 		},
+		"empty membership": {
+			members: system.Members{},
+		},
 		"unfiltered rank results": {
 			members: system.Members{
 				system.NewMember(0, "", getHostAddr(1), system.MemberStateStopped),


### PR DESCRIPTION
Fixes an edge case where SystemQuery is called on a system
that has started but has an empty membership.