### PR TITLE
DAOS-5160 object: write correct version in record

### DIFF
--- a/src/object/obj_internal.h
+++ b/src/object/obj_internal.h
@@ -442,10 +442,18 @@ int dc_obj_update(tse_task_t *task, struct dc_obj_epoch *epoch,
 int dc_obj_punch(tse_task_t *task, struct dc_obj_epoch *epoch, uint32_t map_ver,
 		 enum obj_rpc_opc opc, daos_obj_punch_t *api_args);
 
+/* handles, pointers for handling I/O */
+struct obj_io_context {
+	struct ds_cont_hdl	*ioc_coh;
+	struct ds_cont_child	*ioc_coc;
+	daos_handle_t		 ioc_vos_coh;
+	uint32_t		 ioc_map_ver;
+	bool			 ioc_began;
+};
+
 struct ds_obj_exec_arg {
 	crt_rpc_t		*rpc;
-	struct ds_cont_hdl	*cont_hdl;
-	struct ds_cont_child	*cont;
+	struct obj_io_context	*ioc;
 	void			*args;
 	uint32_t		 flags;
 };

--- a/src/object/srv_obj_migrate.c
+++ b/src/object/srv_obj_migrate.c
@@ -931,7 +931,7 @@ migrate_one_queue(struct iter_obj_arg *iter_arg, daos_epoch_t epoch,
 	D_ASSERT(tls != NULL);
 	if (iod_eph_total == 0 || tls->mpt_version <= version ||
 	    tls->mpt_fini) {
-		D_DEBUG(DB_TRACE, "No need eph_total %d version %u"
+		D_DEBUG(DB_REBUILD, "No need eph_total %d version %u"
 			" migrate ver %ui fini %d\n", iod_eph_total, version,
 			tls->mpt_version, tls->mpt_fini);
 		D_GOTO(put, rc = 0);


### PR DESCRIPTION
Let's write the correct pool map version into
the array/single record, i.e. the one used to
do the ESTALE check, otherwise if the pool map
is updated during IO, which then is written
into the VOS record, then the record may be
ignored during rebuild, and it can cause data
corruption.

Signed-off-by: Di Wang <di.wang@intel.com>