### PR TITLE
DAOS-5132 Control: daos init get_attach_info() crash

### DIFF
--- a/src/control/lib/netdetect/netdetect_integration_test.go
+++ b/src/control/lib/netdetect/netdetect_integration_test.go
@@ -1,0 +1,66 @@
+//
+// (C) Copyright 2019 Intel Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// GOVERNMENT LICENSE RIGHTS-OPEN SOURCE SOFTWARE
+// The Government's rights to use, modify, reproduce, release, perform, display,
+// or disclose this software are subject to the terms of the Apache License as
+// provided in Contract No. 8F-30005.
+// Any reproduction of computer software, computer software documentation, or
+// portions thereof marked with this legend must also reproduce the markings.
+//
+
+// +build concurrency
+
+package netdetect
+
+import (
+	"fmt"
+	"math/rand"
+	"sync"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/daos-stack/daos/src/control/common"
+	"github.com/daos-stack/daos/src/control/logging"
+)
+
+const maxConcurrent = 1000
+
+func getSocketID(t *testing.T, pid int32, wg *sync.WaitGroup) {
+	defer wg.Done()
+	numaNode, err := GetNUMASocketIDForPid(int32(pid))
+	common.AssertEqual(t, err, nil, fmt.Sprintf("GetNUMASocketIDForPid error on NUMA %d / pid %d", numaNode, pid))
+}
+
+// TestConcurrentGetNUMASocket launches maxConcurrent go routines
+// that concurrently access the hwloc topology.  This test verifies that there are
+// no race conditions
+func TestConcurrentGetNUMASocket(t *testing.T) {
+	_, buf := logging.NewTestLogger(t.Name())
+	defer common.ShowBufferOnFailure(t, buf)
+
+	var wg sync.WaitGroup
+	pid := syscall.Getpid()
+	rand.Seed(time.Now().UnixNano())
+	for i := 0; i < maxConcurrent; i++ {
+		wg.Add(1)
+		go func(n int32) {
+			time.Sleep(time.Duration(rand.Intn(100)) * time.Microsecond)
+			getSocketID(t, n, &wg)
+		}(int32(pid))
+	}
+	wg.Wait()
+}


### PR DESCRIPTION
    Resolves a defect that caused the daos_agent to crash
    when initializing the hwloc topology for a PID to NUMA lookup
    that is part of the GetAttachInfo workflow within daos_agent.

    Concurrent access to the hwloc topology was not safe and
    suffered from a race condition that caused an abnormal
    termination.  In this case, the agent could not complete a
    GetAttachInfo drpc that was in flight.  Error checking of
    the drpc message contents by the client found that the
    provider string was empty, yielding this error.  In reality,
    the entire drpc message is bad, not just the provider string.

Signed-off-by: Joel Rosenzweig <joel.b.rosenzweig@intel.com>