### PR TITLE
DAOS-5171 control: update all member details on join

### DIFF
--- a/src/control/server/instance.go
+++ b/src/control/server/instance.go
@@ -403,18 +403,7 @@ func (srv *IOServerInstance) registerMember(membership *system.Membership) error
 		return errors.Wrapf(err, "instance %d: failed to extract member details", idx)
 	}
 
-	created, oldState := membership.AddOrUpdate(m)
-	if created {
-		srv.log.Debugf("instance %d: bootstrapping system member: rank %d, addr %s",
-			idx, m.Rank, m.Addr)
-	} else {
-		srv.log.Debugf("instance %d: updated bootstrapping system member: rank %d, addr %s, %s->%s",
-			idx, m.Rank, m.Addr, *oldState, m.State())
-		if *oldState == m.State() {
-			srv.log.Errorf("instance %d: unexpected same state in rank %d update (%s->%s)",
-				idx, m.Rank, *oldState, m.State())
-		}
-	}
+	membership.AddOrUpdate(m)
 
 	return nil
 }

--- a/src/control/server/instance.go
+++ b/src/control/server/instance.go
@@ -403,7 +403,7 @@ func (srv *IOServerInstance) registerMember(membership *system.Membership) error
 		return errors.Wrapf(err, "instance %d: failed to extract member details", idx)
 	}
 
-	membership.AddOrUpdate(m)
+	membership.AddOrReplace(m)
 
 	return nil
 }

--- a/src/control/server/mgmt_system.go
+++ b/src/control/server/mgmt_system.go
@@ -146,7 +146,7 @@ func (svc *mgmtSvc) Join(ctx context.Context, req *mgmtpb.JoinReq) (*mgmtpb.Join
 			newState = system.MemberStateJoined
 		}
 
-		svc.membership.AddOrUpdate(system.NewMember(
+		svc.membership.AddOrReplace(system.NewMember(
 			system.Rank(resp.GetRank()), req.GetUuid(), replyAddr, newState))
 	}
 

--- a/src/control/server/mgmt_system.go
+++ b/src/control/server/mgmt_system.go
@@ -139,27 +139,15 @@ func (svc *mgmtSvc) Join(ctx context.Context, req *mgmtpb.JoinReq) (*mgmtpb.Join
 		return nil, errors.Wrap(err, "unmarshal Join response")
 	}
 
-	// if join successful, record membership
+	// if join response indicates success, update membership
 	if resp.GetStatus() == 0 {
 		newState := system.MemberStateEvicted
 		if resp.GetState() == mgmtpb.JoinResp_IN {
 			newState = system.MemberStateJoined
 		}
 
-		member := system.NewMember(system.Rank(resp.GetRank()), req.GetUuid(), replyAddr, newState)
-
-		created, oldState := svc.membership.AddOrUpdate(member)
-		if created {
-			svc.log.Debugf("new system member: rank %d, addr %s",
-				resp.GetRank(), replyAddr)
-		} else {
-			svc.log.Debugf("updated system member: rank %d, addr %s, %s->%s",
-				member.Rank, replyAddr, *oldState, newState)
-			if *oldState == newState {
-				svc.log.Errorf("unexpected same state in rank %d update (%s->%s)",
-					member.Rank, *oldState, newState)
-			}
-		}
+		svc.membership.AddOrUpdate(system.NewMember(
+			system.Rank(resp.GetRank()), req.GetUuid(), replyAddr, newState))
 	}
 
 	return resp, nil

--- a/src/control/system/member_test.go
+++ b/src/control/system/member_test.go
@@ -24,6 +24,7 @@
 package system
 
 import (
+	"fmt"
 	"net"
 	"testing"
 
@@ -134,13 +135,25 @@ func TestMember_AddRemove(t *testing.T) {
 }
 
 func TestMember_AddOrUpdate(t *testing.T) {
-	started := MemberStateJoined
+	m0a := *MockMember(t, 0, MemberStateStopped)
+	m1a := *MockMember(t, 1, MemberStateStopped)
+	m2a := *MockMember(t, 2, MemberStateStopped)
+	m0b := m0a
+	m0b.UUID = "m0b" // uuid changes after reformat
+	m0b.state = MemberStateJoined
+	m1b := m1a
+	m1b.Addr = m0a.Addr // rank allocated differently between hosts after reformat
+	m1b.UUID = "m1b"
+	m1b.state = MemberStateJoined
+	m2b := m2a
+	m2a.Addr = m0a.Addr // ranks 0,2 on same host before reformat
+	m2b.Addr = m1a.Addr // ranks 0,1 on same host after reformat
+	m2b.UUID = "m2b"
+	m2b.state = MemberStateJoined
 
 	for name, tc := range map[string]struct {
 		membersToAddOrUpdate Members
 		expMembers           Members
-		expCreated           []bool
-		expOldState          []*MemberState
 	}{
 		"add then update": {
 			Members{
@@ -148,8 +161,6 @@ func TestMember_AddOrUpdate(t *testing.T) {
 				MockMember(t, 1, MemberStateStopped),
 			},
 			Members{MockMember(t, 1, MemberStateStopped)},
-			[]bool{true, false},
-			[]*MemberState{nil, &started},
 		},
 		"add multiple": {
 			Members{
@@ -160,17 +171,10 @@ func TestMember_AddOrUpdate(t *testing.T) {
 				MockMember(t, 1, MemberStateUnknown),
 				MockMember(t, 2, MemberStateUnknown),
 			},
-			[]bool{true, true},
-			[]*MemberState{nil, nil},
 		},
-		"update same state": {
-			Members{
-				MockMember(t, 1, MemberStateJoined),
-				MockMember(t, 1, MemberStateJoined),
-			},
-			Members{MockMember(t, 1, MemberStateJoined)},
-			[]bool{true, false},
-			[]*MemberState{nil, &started},
+		"rank uuid and address changed after reformat": {
+			Members{&m0a, &m1a, &m2a, &m0b, &m2b, &m1b},
+			Members{&m0b, &m1b, &m2b},
 		},
 	} {
 		t.Run(name, func(t *testing.T) {
@@ -179,11 +183,8 @@ func TestMember_AddOrUpdate(t *testing.T) {
 
 			ms := NewMembership(log)
 
-			for i, m := range tc.membersToAddOrUpdate {
-				created, oldState := ms.AddOrUpdate(m)
-				AssertEqual(t, tc.expCreated[i], created, name)
-				AssertEqual(t, tc.expOldState[i], oldState, name)
-
+			for _, m := range tc.membersToAddOrUpdate {
+				ms.AddOrUpdate(m)
 			}
 
 			AssertEqual(t, len(tc.expMembers), len(ms.members), name)
@@ -193,16 +194,7 @@ func TestMember_AddOrUpdate(t *testing.T) {
 				if err != nil {
 					t.Fatal(err)
 				}
-				AssertEqual(t, em.Rank, m.Rank, name)
-				AssertEqual(t, em.State(), m.State(), name)
-
-				m, err = ms.Get(em.Rank)
-				if err != nil {
-					t.Fatal(err)
-				}
-				m.state = MemberStateEvicted
-				AssertEqual(t, em.Rank, m.Rank, name)
-				AssertEqual(t, MemberStateEvicted, m.State(), name)
+				AssertTrue(t, em.Equals(m), fmt.Sprintf("want %#v, got %#v", em, m))
 			}
 		})
 	}

--- a/src/control/system/member_test.go
+++ b/src/control/system/member_test.go
@@ -26,6 +26,7 @@ package system
 import (
 	"fmt"
 	"net"
+	"reflect"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -134,7 +135,13 @@ func TestMember_AddRemove(t *testing.T) {
 	}
 }
 
-func TestMember_AddOrUpdate(t *testing.T) {
+func assertMembersEqual(t *testing.T, a Member, b Member, msg string) {
+	t.Helper()
+	AssertTrue(t, reflect.DeepEqual(a, b),
+		fmt.Sprintf("%s: want %#v, got %#v", msg, a, b))
+}
+
+func TestMember_AddOrReplace(t *testing.T) {
 	m0a := *MockMember(t, 0, MemberStateStopped)
 	m1a := *MockMember(t, 1, MemberStateStopped)
 	m2a := *MockMember(t, 2, MemberStateStopped)
@@ -152,8 +159,8 @@ func TestMember_AddOrUpdate(t *testing.T) {
 	m2b.state = MemberStateJoined
 
 	for name, tc := range map[string]struct {
-		membersToAddOrUpdate Members
-		expMembers           Members
+		membersToAddOrReplace Members
+		expMembers            Members
 	}{
 		"add then update": {
 			Members{
@@ -183,8 +190,8 @@ func TestMember_AddOrUpdate(t *testing.T) {
 
 			ms := NewMembership(log)
 
-			for _, m := range tc.membersToAddOrUpdate {
-				ms.AddOrUpdate(m)
+			for _, m := range tc.membersToAddOrReplace {
+				ms.AddOrReplace(m)
 			}
 
 			AssertEqual(t, len(tc.expMembers), len(ms.members), name)
@@ -194,7 +201,7 @@ func TestMember_AddOrUpdate(t *testing.T) {
 				if err != nil {
 					t.Fatal(err)
 				}
-				AssertTrue(t, em.Equals(m), fmt.Sprintf("want %#v, got %#v", em, m))
+				assertMembersEqual(t, *em, *m, name)
 			}
 		})
 	}


### PR DESCRIPTION
When membership is updated on member join, update all details including
control address and UUID in case they have changed after reformat.

Signed-off-by: Tom Nabarro <tom.nabarro@intel.com>