### PR TITLE
DAOS-5191 test: Add PR test tag to control/dmg_storage_reformat.py

### DIFF
--- a/src/tests/ftest/control/dmg_storage_reformat.py
+++ b/src/tests/ftest/control/dmg_storage_reformat.py
@@ -44,7 +44,7 @@ class DmgStorageReformatTest(ControlTestBase):
 
         Test Description: Test dmg storage reformat functionality.
 
-        :avocado: tags=all,small,full_regression,hw,control,reformat,dmg,basic
+        :avocado: tags=all,small,pr,hw,control,reformat,dmg,basic
         """
 
         # At this point the server has been started, storage has been formatted


### PR DESCRIPTION
A regression was seen on the reformat functionality and it was not caught seemingly because the test is not running with the PR tag.

Signed-off-by: Justiniano-pagn <amanda.justiniano-pagn@intel.com>