### PR TITLE
DAOS-5194 iv: Make cont prop IV per-container

### DIFF
--- a/src/container/srv_container.c
+++ b/src/container/srv_container.c
@@ -1112,8 +1112,7 @@ cont_open(struct rdb_tx *tx, struct ds_pool_hdl *pool_hdl, struct cont *cont,
 
 	/* query the container properties from RDB and update to IV */
 	rc = cont_iv_prop_update(pool_hdl->sph_pool->sp_iv_ns,
-				 in->coi_op.ci_hdl, in->coi_op.ci_uuid,
-				 prop);
+				 in->coi_op.ci_uuid, prop);
 	daos_prop_free(prop);
 	if (rc != 0) {
 		D_ERROR(DF_CONT": cont_iv_prop_update failed %d.\n",
@@ -1706,7 +1705,7 @@ cont_query(struct rdb_tx *tx, struct ds_pool_hdl *pool_hdl, struct cont *cont,
 			return -DER_NOMEM;
 
 		rc = cont_iv_prop_fetch(pool_hdl->sph_pool->sp_iv_ns,
-					in->cqi_op.ci_hdl, iv_prop);
+					in->cqi_op.ci_uuid, iv_prop);
 		if (rc) {
 			D_ERROR("cont_iv_prop_fetch failed "DF_RC"\n",
 				DP_RC(rc));
@@ -1873,8 +1872,7 @@ set_prop(struct rdb_tx *tx, struct ds_pool *pool,
 		D_GOTO(out, rc);
 
 	/* Update prop IV with merged prop */
-	rc = cont_iv_prop_update(pool->sp_iv_ns,
-				 hdl_uuid, cont->c_uuid, prop_iv);
+	rc = cont_iv_prop_update(pool->sp_iv_ns, cont->c_uuid, prop_iv);
 	if (rc)
 		D_ERROR(DF_UUID": failed to update prop IV for cont, "
 			"%d.\n", DP_UUID(cont->c_uuid), rc);
@@ -2742,3 +2740,44 @@ out:
 	crt_reply_send(rpc);
 }
 
+int
+ds_cont_get_prop(uuid_t pool_uuid, uuid_t cont_uuid, daos_prop_t **prop_out)
+{
+	daos_prop_t	*prop = NULL;
+	struct cont_svc	*svc;
+	struct rdb_tx	 tx;
+	struct cont	*cont = NULL;
+	int		 rc;
+
+	D_ASSERT(dss_get_module_info()->dmi_xs_id == 0);
+	rc = cont_svc_lookup_leader(pool_uuid, 0, &svc, NULL);
+	if (rc != 0)
+		return rc;
+
+	rc = rdb_tx_begin(svc->cs_rsvc->s_db, svc->cs_rsvc->s_term, &tx);
+	if (rc != 0)
+		D_GOTO(out_put, rc);
+
+	ABT_rwlock_rdlock(svc->cs_lock);
+	rc = cont_lookup(&tx, svc, cont_uuid, &cont);
+	if (rc != 0)
+		D_GOTO(out_lock, rc);
+
+	rc = cont_prop_read(&tx, cont, DAOS_CO_QUERY_PROP_ALL, &prop);
+	cont_put(cont);
+
+	D_ASSERT(prop != NULL);
+	D_ASSERT(prop->dpp_nr == CONT_PROP_NUM);
+
+	if (rc != 0)
+		D_GOTO(out_lock, rc);
+
+	*prop_out = prop;
+
+out_lock:
+	ABT_rwlock_unlock(svc->cs_lock);
+	rdb_tx_end(&tx);
+out_put:
+	cont_svc_put_leader(svc);
+	return rc;
+}

--- a/src/container/srv_internal.h
+++ b/src/container/srv_internal.h
@@ -166,6 +166,8 @@ int ds_cont_acl_update(struct rdb_tx *tx, struct ds_pool_hdl *pool_hdl,
 int ds_cont_acl_delete(struct rdb_tx *tx, struct ds_pool_hdl *pool_hdl,
 		       struct cont *cont, struct container_hdl *hdl,
 		       crt_rpc_t *rpc);
+int ds_cont_get_prop(uuid_t pool_uuid, uuid_t cont_uuid,
+		     daos_prop_t **prop_out);
 
 /*
  * srv_epoch.c
@@ -240,10 +242,9 @@ int ds_cont_iv_fini(void);
 int cont_iv_capability_update(void *ns, uuid_t cont_hdl_uuid, uuid_t cont_uuid,
 			      uint64_t flags, uint64_t sec_capas);
 int cont_iv_capability_invalidate(void *ns, uuid_t cont_hdl_uuid);
-int cont_iv_prop_fetch(struct ds_iv_ns *ns, uuid_t cont_hdl_uuid,
+int cont_iv_prop_fetch(struct ds_iv_ns *ns, uuid_t cont_uuid,
 		       daos_prop_t *cont_prop);
-int cont_iv_prop_update(void *ns, uuid_t iv_key_uuid, uuid_t cont_uuid,
-			daos_prop_t *prop);
+int cont_iv_prop_update(void *ns, uuid_t cont_uuid, daos_prop_t *prop);
 int cont_iv_snapshots_refresh(void *ns, uuid_t cont_uuid);
 int cont_iv_snapshots_update(void *ns, uuid_t cont_uuid,
 			     uint64_t *snapshots, int snap_count);

--- a/src/container/srv_target.c
+++ b/src/container/srv_target.c
@@ -855,7 +855,7 @@ cont_hdl_csummer_init(struct ds_cont_hdl *hdl)
 	props->dpp_entries[1].dpe_type = DAOS_PROP_CO_CSUM_CHUNK_SIZE;
 	props->dpp_entries[2].dpe_type = DAOS_PROP_CO_CSUM_SERVER_VERIFY;
 	rc = cont_iv_prop_fetch(hdl->sch_cont->sc_pool->spc_pool->sp_iv_ns,
-				hdl->sch_uuid, props);
+				hdl->sch_cont->sc_uuid, props);
 	if (rc != 0)
 		goto done;
 	csum_val = daos_cont_prop2csum(props);

--- a/src/include/daos_srv/container.h
+++ b/src/include/daos_srv/container.h
@@ -161,8 +161,8 @@ int ds_cont_iter(daos_handle_t ph, uuid_t co_uuid, cont_iter_cb_t callback,
  * Query container properties.
  *
  * \param[in]	ns	pool IV namespace
- * \param[in]	coh_uuid
- *			container handle uuid
+ * \param[in]	co_uuid
+ *			container uuid
  * \param[out]	cont_prop
  *			returned container properties
  *			If it is NULL, return -DER_INVAL;
@@ -180,7 +180,7 @@ int ds_cont_iter(daos_handle_t ph, uuid_t co_uuid, cont_iter_cb_t callback,
  *
  * \return		0 if Success, negative if failed.
  */
-int ds_cont_fetch_prop(struct ds_iv_ns *ns, uuid_t coh_uuid,
+int ds_cont_fetch_prop(struct ds_iv_ns *ns, uuid_t co_uuid,
 		       daos_prop_t *cont_prop);
 
 /** get all snapshots of the container from IV */

--- a/src/object/srv_obj.c
+++ b/src/object/srv_obj.c
@@ -265,28 +265,6 @@ obj_bulk_bypass(d_sg_list_t *sgl, crt_bulk_op_t bulk_op)
 	}
 }
 
-bool
-cont_prop_csum_enabled(struct ds_iv_ns *ns, uuid_t co_hdl)
-{
-	int			rc;
-	daos_prop_t		cont_prop = {0};
-	struct daos_prop_entry	entry = {0};
-	uint32_t		csum_val;
-
-	entry.dpe_type = DAOS_PROP_CO_CSUM;
-	cont_prop.dpp_entries = &entry;
-	cont_prop.dpp_nr = 1;
-
-	rc = ds_cont_fetch_prop(ns, co_hdl, &cont_prop);
-	if (rc != 0)
-		return false;
-	csum_val = daos_cont_prop2csum(&cont_prop);
-	if (daos_cont_csum_prop_is_enabled(csum_val))
-		return true;
-	else
-		return false;
-}
-
 static int
 obj_bulk_transfer(crt_rpc_t *rpc, crt_bulk_op_t bulk_op, bool bulk_bind,
 		  crt_bulk_t *remote_bulks, uint64_t *remote_offs,


### PR DESCRIPTION
The IV key of container prop IV should be container UUID but not
container open handle ID.

Signed-off-by: Niu Yawei <yawei.niu@intel.com>