### PR TITLE
DAOS-5065 csum: Bug Fixes Discovered in CI

### DIFF
--- a/src/client/dfuse/dfuse_core.c
+++ b/src/client/dfuse/dfuse_core.c
@@ -115,7 +115,7 @@ static int
 ih_ndecref(struct d_hash_table *htable, d_list_t *rlink, int count)
 {
 	struct dfuse_inode_entry	*ie;
-	uint				oldref;
+	uint				oldref = 0;
 	uint				newref = 0;
 
 	ie = container_of(rlink, struct dfuse_inode_entry, ie_htl);

--- a/src/common/checksum.c
+++ b/src/common/checksum.c
@@ -997,9 +997,6 @@ calc_csum_recx(struct daos_csummer *obj, d_sg_list_t *sgl, size_t rec_len,
 	for (i = 0; i < nr; i++) { /** for each extent/checksum info */
 		csum_nr = daos_recx_calc_chunks(recxs[i], rec_len,
 						rec_chunksize);
-		C_TRACE("Calculating %zu checksum(s) for Array Value "
-			DF_RECX"\n",
-			csum_nr, DP_RECX(recxs[i]));
 
 		if (map != NULL)
 			rc = calc_csum_recx_with_map(obj, csum_nr, &recxs[i],
@@ -1011,6 +1008,11 @@ calc_csum_recx(struct daos_csummer *obj, d_sg_list_t *sgl, size_t rec_len,
 							rec_chunksize, &idx);
 		if (rc != 0)
 			return rc;
+
+		C_TRACE("Calculating %zu checksum(s) for Array Value "
+				DF_RECX", data_len: %lu -> "DF_CI"\n",
+			csum_nr, DP_RECX(recxs[i]), sgl->sg_iovs[0].iov_len,
+			DP_CI(csums[i]));
 	}
 
 	return 0;
@@ -1031,7 +1033,7 @@ calc_csum_sv(struct daos_csummer *obj, d_sg_list_t *sgl, size_t rec_len,
 	if (!(daos_csummer_initialized(obj)))
 		return 0;
 
-	C_TRACE("Calculating checksum for Single Value\n");
+	C_TRACE("Calculating checksum for Single Value (len=%lu)\n", rec_len);
 	if (singv_lo != NULL && singv_lo->cs_even_dist == 1) {
 		D_ASSERT(singv_lo->cs_bytes > 0 &&
 			 singv_lo->cs_bytes < rec_len);
@@ -1078,6 +1080,9 @@ calc_csum_sv(struct daos_csummer *obj, d_sg_list_t *sgl, size_t rec_len,
 
 		daos_csummer_finish(obj);
 	}
+
+	C_TRACE("Calculating checksum for Single Value (len=%lu) -> "
+		DF_CI"\n", rec_len, DP_CI(csums[0]));
 
 	return 0;
 }
@@ -1226,6 +1231,8 @@ daos_csummer_calc_key(struct daos_csummer *csummer, daos_key_t *key,
 
 	rc = calc_for_iov(csummer, key, dkey_csum_buf, size);
 	if (rc == 0) {
+		C_TRACE("Calculating checksum for Key "DF_KEY" -> "DF_CI"\n",
+			DP_KEY(key), DP_CI(*csum_info));
 		*p_csum = csum_info;
 	} else {
 		D_ERROR("calc_for_iov error: %d\n", rc);

--- a/src/object/cli_ec.c
+++ b/src/object/cli_ec.c
@@ -1481,7 +1481,7 @@ obj_ec_recov_add(struct obj_reasb_req *reasb_req,
 		 struct daos_recx_ep_list *recx_lists, unsigned int nr)
 {
 	struct daos_recx_ep_list	*recov_lists;
-	struct daos_recx_ep_list	*dst_list;
+	struct daos_recx_ep_list	*dst_list = NULL;
 	struct daos_recx_ep_list	*src_list;
 	uint32_t			 i, j;
 	int				 rc;

--- a/src/object/srv_csum.c
+++ b/src/object/srv_csum.c
@@ -30,7 +30,7 @@
 
 #define C_TRACE(...) D_DEBUG(DB_CSUM, __VA_ARGS__)
 
-/** Holds information about checksum and  data to verify when a
+/** Holds information about checksum and data to verify when a
  * new checksum for an extent chunk is needed
  */
 struct to_verify {
@@ -143,7 +143,11 @@ cc_verify_orig_extents(struct csum_context *ctx)
 		match = daos_csummer_csum_compare(csummer, csum,
 						  verify->tv_csum, csum_len);
 		if (!match) {
-			D_ERROR("Original extent corrupted\n");
+			D_ERROR("[%d] Original extent corrupted. "
+				"Calculated ("DF_CI_BUF") != "
+				"Stored ("DF_CI_BUF")\n",
+				v, DP_CI_BUF(csum, csum_len),
+				DP_CI_BUF(verify->tv_csum, csum_len));
 			return -DER_CSUM;
 		}
 	}
@@ -179,6 +183,9 @@ cc_remember_to_verify(struct csum_context *ctx, uint8_t *biov_csum,
 		      struct bio_iov *biov)
 {
 	struct to_verify	*ver;
+	uint16_t		 csum_len;
+
+	csum_len = daos_csummer_get_csum_len(ctx->cc_csummer);
 
 	cc_verify_resize_if_needed(ctx);
 	ver = &ctx->cc_to_verify[ctx->cc_to_verify_nr];
@@ -191,7 +198,8 @@ cc_remember_to_verify(struct csum_context *ctx, uint8_t *biov_csum,
 
 	D_ASSERT(biov_csum != NULL);
 	ver->tv_csum = biov_csum;
-	C_TRACE("To Verify len: %lu\n", ver->tv_len);
+	C_TRACE("To Verify len: %lu, csum: "DF_CI_BUF"\n", ver->tv_len,
+		DP_CI_BUF(ver->tv_csum, csum_len));
 	ctx->cc_to_verify_nr++;
 }
 
@@ -419,10 +427,17 @@ cc_add_csum(struct csum_context *ctx, struct dcs_csum_info *info,
 }
 
 static size_t
-cc_biov_bytes_left(const struct csum_context *ctx) {
+cc_biov_bytes_left(const struct csum_context *ctx)
+{
 	struct bio_iov *biov = cc2iov(ctx);
 
 	return bio_iov2req_len(biov) - ctx->cc_bsgl_idx->iov_offset;
+}
+
+static bool
+cc_bsgl_remaining(struct csum_context *ctx)
+{
+	return (*ctx).cc_bsgl_idx->iov_idx >= (*ctx).cc_bsgl->bs_nr_out;
 }
 
 /** For a given recx, add checksums to the output csum info. Data will come
@@ -451,6 +466,8 @@ cc_add_csums_for_recx(struct csum_context *ctx, daos_recx_t *recx,
 	cc_set_iov2ranges(ctx, cc2iov(ctx));
 
 	sc = (recx->rx_idx * rec_size) / rec_chunksize;
+	C_TRACE("Calculating %d checksum(s) for Array Value "
+			DF_RECX"\n", chunk_nr, DP_RECX(*recx));
 	for (c = 0; c < chunk_nr; c++, sc++) { /** for each chunk/checksum */
 		ctx->cc_recx_chunk = csum_recx_chunkidx2range(recx, rec_size,
 							      rec_chunksize, c);
@@ -469,8 +486,7 @@ cc_add_csums_for_recx(struct csum_context *ctx, daos_recx_t *recx,
 			/** All out of data. Just return because request may
 			 * be larger than previously written data
 			 */
-			if (ctx->cc_bsgl_idx->iov_idx >=
-			    ctx->cc_bsgl->bs_nr_out)
+			if (cc_bsgl_remaining(ctx))
 				break;
 
 			rc = cc_add_csum(ctx, info, c);
@@ -558,6 +574,8 @@ ds_csum_add2iod(daos_iod_t *iod, struct daos_csummer *csummer,
 		struct dcs_csum_info	*info = &iod_csums->ic_data[i];
 
 		if (ctx.cc_rec_len > 0 && ci_is_valid(info)) {
+			if (cc_bsgl_remaining(&ctx))
+				break;
 			rc = cc_add_csums_for_recx(&ctx, recx, info);
 			if (rc != 0) {
 				D_ERROR("Failed to add csum for "
@@ -584,6 +602,7 @@ ds_csum_calc_needed(struct daos_csum_range *raw_ext,
 	bool	is_only_extent_in_chunk;
 	bool	biov_extends_past_chunk;
 	bool	using_whole_chunk_of_extent;
+	bool	biov_starts_at_beginning_of_chunk;
 
 	/** in order to use stored csum
 	 * - a new csum must not have already been started (would mean a
@@ -599,12 +618,16 @@ ds_csum_calc_needed(struct daos_csum_range *raw_ext,
 				  (!has_next_biov || /** nothing after */
 				   biov_extends_past_chunk);
 
+	biov_starts_at_beginning_of_chunk = req_ext->dcr_lo <=
+					    max(raw_ext->dcr_lo, chunk->dcr_lo);
 
-	using_whole_chunk_of_extent = biov_extends_past_chunk ||
-				      (req_ext->dcr_hi < chunk->dcr_hi &&
-				       req_ext->dcr_lo == raw_ext->dcr_lo &&
-				       req_ext->dcr_hi == raw_ext->dcr_hi
-				       );
+	using_whole_chunk_of_extent =
+		(biov_extends_past_chunk &&
+		 biov_starts_at_beginning_of_chunk) ||
+		(req_ext->dcr_hi < chunk->dcr_hi &&
+		 req_ext->dcr_lo == raw_ext->dcr_lo &&
+		 req_ext->dcr_hi == raw_ext->dcr_hi
+		);
 
 	return !(is_only_extent_in_chunk && using_whole_chunk_of_extent);
 }

--- a/src/tests/suite/daos_checksum.c
+++ b/src/tests/suite/daos_checksum.c
@@ -854,6 +854,21 @@ overlapping_after_first_chunk(void **state)
 }
 
 static void
+request_second_half_of_chunk(void **state)
+{
+	ARRAY_UPDATE_FETCH_TESTCASE(state, {
+		.chunksize = 1024,
+		.csum_prop_type = dts_csum_prop_type,
+		.server_verify = false,
+		.rec_size = 1,
+		.recx_cfgs = {
+			{.idx = 0, .nr = 1024, .data = "12345678"},
+		},
+		.fetch_recx = {.rx_idx = 512, .rx_nr = 512},
+	});
+}
+
+static void
 extents_with_holes_1(void **state)
 {
 	ARRAY_UPDATE_FETCH_TESTCASE(state, {
@@ -1370,6 +1385,40 @@ many_iovs_with_single_values(void **state)
 }
 
 static void
+request_non_existent_data(void **state)
+{
+	int			rc;
+	struct csum_test_ctx	ctx;
+
+	setup_from_test_args(&ctx, *state);
+	setup_cont_obj(&ctx, dts_csum_prop_type, false, 1024, dts_csum_oc);
+	setup_simple_data(&ctx);
+
+	ctx.update_iod.iod_recxs[0].rx_idx = 1;
+	ctx.update_iod.iod_recxs[0].rx_nr = 1;
+
+	rc = daos_obj_update(ctx.oh, DAOS_TX_NONE, DAOS_COND_DKEY_INSERT,
+			     &ctx.dkey, 1, &ctx.update_iod,
+			     &ctx.update_sgl, NULL);
+	assert_success(rc);
+
+	ctx.fetch_iod.iod_recxs[0].rx_idx = 0;
+	ctx.fetch_iod.iod_recxs[0].rx_nr = 1;
+	ctx.fetch_iod.iod_recxs[1].rx_idx = 1;
+	ctx.fetch_iod.iod_recxs[1].rx_nr = 1;
+	ctx.fetch_iod.iod_recxs[2].rx_idx = 3;
+	ctx.fetch_iod.iod_recxs[2].rx_nr = 1;
+	ctx.fetch_iod.iod_recxs[3].rx_idx = 4;
+	ctx.fetch_iod.iod_recxs[3].rx_nr = 1;
+	ctx.fetch_iod.iod_nr = 4;
+
+	rc = daos_obj_fetch(ctx.oh, DAOS_TX_NONE, 0, &ctx.dkey,
+			    1, &ctx.fetch_iod,
+			    &ctx.fetch_sgl, NULL, NULL);
+	assert_success(rc);
+}
+
+static void
 test_update_fetch_a_key(void **state)
 {
 	key_csum_fetch_update(state,
@@ -1527,6 +1576,8 @@ static const struct CMUnitTest csum_tests[] = {
 		record_size_larger_than_chunksize),
 	CSUM_TEST("DAOS_CSUM03.4: Setup multiple overlapping/unaligned extents",
 		  overlapping_after_first_chunk),
+	CSUM_TEST("DAOS_CSUM03.5: Request the second half of a chunk",
+		  request_second_half_of_chunk),
 	CSUM_TEST("DAOS_CSUM04.1: With holes between extents. All in 1 chunk",
 		  extents_with_holes_1),
 	CSUM_TEST("DAOS_CSUM04.2: With holes at beginning and end. of extent."
@@ -1552,6 +1603,8 @@ static const struct CMUnitTest csum_tests[] = {
 	CSUM_TEST("DAOS_CSUM10: Enumerate A Keys", test_enumerate_a_key),
 	CSUM_TEST("DAOS_CSUM11: Enumerate D Keys", test_enumerate_d_key),
 	CSUM_TEST("DAOS_CSUM12: Many IODs", many_iovs_with_single_values),
+	CSUM_TEST("DAOS_CSUM13: Request non existent data",
+		  request_non_existent_data),
 
 	EC_CSUM_TEST("DAOS_EC_CSUM00: csum disabled", checksum_disabled),
 	EC_CSUM_TEST("DAOS_EC_CSUM01: simple update with server side verify",

--- a/src/vos/tests/vts_checksum.c
+++ b/src/vos/tests/vts_checksum.c
@@ -107,7 +107,7 @@ void
 csum_for_arrays_test_case(void *const *state, struct test_case_args test)
 {
 	struct dcs_csum_info	*csum_infos;
-	struct dcs_iod_csums	 iod_csums;
+	struct dcs_iod_csums	 iod_csums = {0};
 	daos_iod_t		 iod = {0};
 	daos_recx_t		 recx[MAX_RECX];
 	d_sg_list_t		 sgl;
@@ -146,6 +146,7 @@ csum_for_arrays_test_case(void *const *state, struct test_case_args test)
 
 	D_ALLOC_ARRAY(csum_infos, update_recx_nr);
 	iod_csums.ic_data = csum_infos;
+	iod_csums.ic_nr = update_recx_nr;
 
 	for (i = 0; i < update_recx_nr; i++) {
 		uint64_t csum_buf_len;

--- a/src/vos/vos_io.c
+++ b/src/vos/vos_io.c
@@ -113,7 +113,8 @@ vos_ioc2ioh(struct vos_io_context *ioc)
 static struct dcs_csum_info *
 vos_ioc2csum(struct vos_io_context *ioc)
 {
-	if (ioc->iod_csums != NULL)
+	/** is enabled and has csums (might not for punch) */
+	if (ioc->iod_csums != NULL && ioc->iod_csums[ioc->ic_sgl_at].ic_nr > 0)
 		return ioc->iod_csums[ioc->ic_sgl_at].ic_data;
 	return NULL;
 }


### PR DESCRIPTION
Several bug fixes discovered by a CI and IOR run.

- Fix for request of non-existent data.
- In the VOS layer, check if iod_csum has csum infos before returning. 
  This prevents issues with punched records when csum is enabled.
- Fix case where second half of chunk is requested. Logic was incomplete
  and only looked at rest of chunk to determine if biov extent was
  whole chunk.
- More tracing to help troubleshoot.

Signed-off-by: Ryon Jensen <ryon.jensen@intel.com>