### PR TITLE
DAOS-623 build: Add -no-rpath option for RPM build

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -121,6 +121,11 @@ def set_defaults(env):
               action='store_true',
               default=False,
               help='Preprocess selected files for profiling')
+    AddOption('--no-rpath',
+              dest='no_rpath',
+              action='store_true',
+              default=False,
+              help='Disable rpath')
 
     env.Append(CCFLAGS=['-g', '-Wshadow', '-Wall', '-Wno-missing-braces',
                         '-fpic', '-D_GNU_SOURCE', '-DD_LOG_V2'])

--- a/src/cart/src/utest/SConscript
+++ b/src/cart/src/utest/SConscript
@@ -72,7 +72,7 @@ def scons():
     test_env.AppendUnique(CPPPATH=['../include'])
     test_env.AppendUnique(CXXFLAGS=['-std=c++0x'])
     test_env.AppendUnique(LIBPATH=LIBPATH)
-    test_env.AppendUnique(RPATH=LIBPATH)
+    test_env.AppendUnique(RPATH_FULL=LIBPATH)
     tests = []
 
     for test in TEST_SRC:

--- a/src/client/dfuse/test/SConscript
+++ b/src/client/dfuse/test/SConscript
@@ -50,7 +50,7 @@ def scons():
     tenv.AppendUnique(CPPPATH=['..'])
     tenv.AppendUnique(CPPPATH='../il')
     tenv.AppendUnique(LIBPATH='../il')
-    tenv.AppendUnique(RPATH='$PREFIX/lib64')
+    tenv.AppendUnique(RPATH_FULL='$PREFIX/lib64')
     tenv.AppendUnique(LINKFLAGS=["-Wl,-rpath-link=%s" % Dir('../../dfs').path])
 
     prereqs.require(tenv, 'cunit')

--- a/src/placement/tests/SConscript
+++ b/src/placement/tests/SConscript
@@ -7,7 +7,7 @@ def scons():
 
     denv.AppendUnique(LIBPATH=['../../client/api'])
 
-    denv.AppendUnique(RPATH=[Literal(r'\$$ORIGIN/../lib64/daos_srv')])
+    denv.AppendUnique(RPATH_FULL=['$PREFIX/lib64/daos_srv'])
 
     ring_test_tgt = denv.SharedObject('ring_map_place_obj.c')
     jump_test_tgt = denv.SharedObject('jump_map_place_obj.c')

--- a/utils/daos_build.py
+++ b/utils/daos_build.py
@@ -16,6 +16,11 @@ class DaosLiteral(Literal):
 
 def add_rpaths(env, install_off, set_cgo_ld, is_bin):
     """Add relative rpath entries"""
+    if GetOption('no_rpath'):
+        if set_cgo_ld:
+            env.AppendENVPath("CGO_LDFLAGS", env.subst("$_LIBDIRFLAGS "),
+                              sep=" ")
+        return
     env.AppendUnique(RPATH_FULL=['$PREFIX/lib64'])
     rpaths = env.subst("$RPATH_FULL").split()
     prefix = env.get("PREFIX")

--- a/utils/rpms/daos.spec
+++ b/utils/rpms/daos.spec
@@ -6,7 +6,7 @@
 
 Name:          daos
 Version:       1.1.0
-Release:       24%{?relval}%{?dist}
+Release:       25%{?relval}%{?dist}
 Summary:       DAOS Storage Engine
 
 License:       Apache
@@ -178,15 +178,12 @@ This is the package needed to build software with the DAOS library.
 %setup -q
 
 %build
-# remove rpathing from the build
-rpath_files="utils/daos_build.py"
-rpath_files+=" $(find . -name SConscript)"
-sed -i -e 's/[_a-zA-Z0-9]*\.AppendUnique(RPATH=.*)/pass/' $rpath_files
 
 %define conf_dir %{_sysconfdir}/daos
 
 scons %{?_smp_mflags}      \
       --config=force       \
+      --no-rpath           \
       USE_INSTALLED=all    \
       CONF_DIR=%{conf_dir} \
       PREFIX=%{?buildroot}
@@ -194,6 +191,7 @@ scons %{?_smp_mflags}      \
 %install
 scons %{?_smp_mflags}                 \
       --config=force                  \
+      --no-rpath                      \
       --install-sandbox=%{?buildroot} \
       %{?buildroot}%{_prefix}         \
       %{?buildroot}%{conf_dir}        \
@@ -364,6 +362,10 @@ getent passwd daos_server >/dev/null || useradd -M daos_server
 %{_libdir}/*.a
 
 %changelog
+* Tue Jun 23 2020 Jeff Olivier <jeffrey.v.olivier@intel.com> - 1.1.0-25
+- Add -no-rpath option and use it for rpm build rather than modifying
+  SCons files in place
+
 * Tue Jun 16 2020 Jeff Olivier <jeffrey.v.olivier@intel.com> - 1.1.0-24
 - Modify RPATH removal snippet to replace line with pass as some lines
   can't be removed without breaking the code


### PR DESCRIPTION
Add option to skip rpath rather than modifying SCons files
via sed

Signed-off-by: Jeff Olivier <jeffrey.v.olivier@intel.com>