### PR TITLE
DAOS-5198 csum: fix algo_table[] index bug in daos_str2csumcontprop()

### DIFF
--- a/src/common/checksum.c
+++ b/src/common/checksum.c
@@ -453,7 +453,7 @@ daos_str2csumcontprop(const char *value)
 	int t;
 
 	for (t = CSUM_TYPE_UNKNOWN + 1; t < CSUM_TYPE_END; t++) {
-		char *name = algo_table[t]->cf_name;
+		char *name = algo_table[t - 1]->cf_name;
 
 		if (!strncmp(name, value,
 			     min(strlen(name), strlen(value)) + 1)) {


### PR DESCRIPTION
Change-Id: I457eec213edc7201687016db56f7b354fbc8c6d6
Signed-off-by: Bruno Faccini <bruno.faccini@intel.com>