### PR TITLE
DAOS-623 build: Fix rpath issue on Ubuntu build for libfabric

### DIFF
--- a/utils/sl/components/__init__.py
+++ b/utils/sl/components/__init__.py
@@ -129,7 +129,8 @@ def define_mercury(reqs):
                                   '--enable-psm2' +
                                   check(reqs, 'psm2',
                                         "=$PSM2_PREFIX "
-                                        'LDFLAGS="-Wl,--enable-new-dtags" ',
+                                        'LDFLAGS="-Wl,--enable-new-dtags ' +
+                                        '-Wl,-rpath=$PSM2_PREFIX/lib64" ',
                                         ''),
                                   ''),
                           'make $JOBS_OPT',


### PR DESCRIPTION
The RPATH setting is needed for linking on that platform.

Signed-off-by: Jeff Olivier <jeffrey.v.olivier@intel.com>