### PR TITLE
DAOS-623 build: Fix cart test/utility builds

### DIFF
--- a/src/cart/src/crt_launch/SConscript
+++ b/src/cart/src/crt_launch/SConscript
@@ -62,7 +62,7 @@ def scons():
     tenv.AppendUnique(LIBPATH=['#/src/cart/src/cart'])
     tenv.AppendUnique(FLAGS='-pthread')
 
-    crt_launch = tenv.Program(CRT_LAUNCH)
+    crt_launch = daos_build.program(tenv, CRT_LAUNCH)
 
     tenv.Requires(crt_launch, [cart_lib, gurt_lib])
     tenv.Install(os.path.join("$PREFIX", 'bin'), crt_launch)

--- a/src/cart/src/ctl/SConscript
+++ b/src/cart/src/ctl/SConscript
@@ -38,6 +38,7 @@
 """Build cart_ctl test"""
 
 import os
+import daos_build
 
 SRC = ['cart_ctl.c']
 
@@ -50,7 +51,7 @@ def scons():
     tenv.AppendUnique(LIBS=['cart', 'gurt', 'pthread'])
     prereqs.require(tenv, 'mercury')
 
-    ctl = tenv.Program(SRC)
+    ctl = daos_build.program(tenv, SRC)
     tenv.Requires(ctl, [cart_lib, gurt_lib])
     tenv.Install(os.path.join("$PREFIX", 'bin'), ctl)
 

--- a/src/cart/src/self_test/SConscript
+++ b/src/cart/src/self_test/SConscript
@@ -38,6 +38,7 @@
 """Build self test"""
 
 import os
+import daos_build
 
 SELF_TEST = 'self_test.c'
 
@@ -54,7 +55,7 @@ def scons():
     tenv.AppendUnique(LIBPATH=['#/src/cart/src/cart'])
     tenv.AppendUnique(FLAGS='-pthread')
 
-    self_test = tenv.Program(SELF_TEST)
+    self_test = daos_build.program(tenv, SELF_TEST)
     tenv.Requires(self_test, [cart_lib, gurt_lib])
     tenv.Install(os.path.join("$PREFIX", 'bin'), self_test)
 

--- a/src/cart/src/test/SConscript
+++ b/src/cart/src/test/SConscript
@@ -38,6 +38,7 @@
 """Build crt tests"""
 
 import os
+import daos_build
 
 SIMPLE_TEST_SRC = ['threaded_client.c',
                    'no_pmix_multi_ctx.c', 'threaded_server.c',
@@ -72,42 +73,34 @@ def scons():
     tests_dir = os.path.join("$PREFIX", 'lib', 'cart', 'TESTING', 'tests')
     # Compile all of the tests
     for test in SIMPLE_TEST_SRC:
-        target = tenv.Program(test)
+        target = daos_build.test(tenv, test, install_off='../../../../')
         tenv.Requires(target, [cart_lib, gurt_lib])
         tenv.Install(tests_dir, target)
 
     for test in IV_TESTS:
-        target = tenv.Program(test)
+        target = daos_build.test(tenv, test, install_off='../../../../')
         tenv.Requires(target, [cart_lib, gurt_lib])
         tenv.Install(tests_dir, target)
 
-#    for test in CRT_RPC_TESTS:
-#        target = tenv.Program(test)
-#        tenv.Requires(target, [cart_lib, gurt_lib])
-#        tenv.Install(os.path.join("$PREFIX", 'TESTING', 'tests'), target)
-
     for test in SWIM_TESTS:
-        target = tenv.Program(test)
+        target = daos_build.test(tenv, test, install_off='../../../../')
         tenv.Requires(target, [cart_lib, gurt_lib])
         tenv.Install(tests_dir, target)
 
     for test in HLC_TESTS:
-        target = tenv.Program(test)
+        target = daos_build.test(tenv, test, install_off='../../../../')
         tenv.Requires(target, [cart_lib, gurt_lib])
         tenv.Install(tests_dir, target)
 
     for test in TEST_GROUP_NP_TESTS:
-        target = tenv.Program(test)
+        target = daos_build.test(tenv, test, install_off='../../../../')
         tenv.Requires(target, [cart_lib, gurt_lib])
         tenv.Install(tests_dir, target)
-#    test_rpc_err = tenv.Program([TEST_RPC_ERR_SRC])
-#    tenv.Requires(test_rpc_err, [cart_lib, gurt_lib])
-#    tenv.Install(os.path.join("$PREFIX", 'TESTING', 'tests'), test_rpc_err)
 
     benv = tenv.Clone()
 
     benv.AppendUnique(CFLAGS=['-std=gnu99', '-pedantic'])
-    basic_target = benv.Program(BASIC_SRC)
+    basic_target = daos_build.test(tenv, BASIC_SRC)
     benv.Requires(basic_target, [cart_lib, gurt_lib])
 
 if __name__ == "SCons.Script":

--- a/src/tests/drpc/SConscript
+++ b/src/tests/drpc/SConscript
@@ -1,5 +1,7 @@
 """Build drpc test"""
 
+import daos_build
+
 def scons():
     """Execute build"""
     Import('env', 'prereqs')
@@ -13,11 +15,11 @@ def scons():
 
     prereqs.require(denv, 'protobufc')
 
-    drpc_test = denv.Program('drpc_test', sources, LIBS=libs)
+    drpc_test = daos_build.program(denv, 'drpc_test', sources, LIBS=libs)
     env.Install('$PREFIX/bin/', drpc_test)
 
-    drpc_iosrv_test = denv.Program('drpc_iosrv_test',
-                                   ['drpc_iosrv_test.c'], LIBS=libs)
+    drpc_iosrv_test = daos_build.program(denv, 'drpc_iosrv_test',
+                                         ['drpc_iosrv_test.c'], LIBS=libs)
     env.Install('$PREFIX/bin/', drpc_iosrv_test)
 
 if __name__ == "SCons.Script":

--- a/src/tests/security/SConscript
+++ b/src/tests/security/SConscript
@@ -1,4 +1,5 @@
 """Build security test"""
+import daos_build
 
 def scons():
     """Execute build"""
@@ -14,10 +15,12 @@ def scons():
 
     prereqs.require(denv, 'argobots', 'protobufc', 'hwloc')
 
-    security_test = denv.Program('security_test', sec_sources, LIBS=libs)
+    security_test = daos_build.program(denv, 'security_test', sec_sources,
+                                       LIBS=libs)
     env.Install('$PREFIX/bin/', security_test)
 
-    acl_dump_test = denv.Program('acl_dump_test', acl_sources, LIBS=libs)
+    acl_dump_test = daos_build.program(denv, 'acl_dump_test', acl_sources,
+                                       LIBS=libs)
     env.Install('$PREFIX/bin/', acl_dump_test)
 
 if __name__ == "SCons.Script":


### PR DESCRIPTION
These builds need to use daos_build.program/test to get
proper RPATH settings

Signed-off-by: Jeff Olivier <jeffrey.v.olivier@intel.com>