### PR TITLE
DAOS-4415 md: add locking around raft state transitions

### DIFF
--- a/src/rdb/rdb.c
+++ b/src/rdb/rdb.c
@@ -251,11 +251,19 @@ rdb_start(const char *path, const uuid_t uuid, struct rdb_cbs *cbs, void *arg,
 		goto err_db;
 	}
 
+	rc = ABT_mutex_create(&db->d_raft_mutex);
+	if (rc != ABT_SUCCESS) {
+		D_ERROR(DF_DB": failed to create raft mutex: %d\n",
+			DP_DB(db), rc);
+		rc = dss_abterr2der(rc);
+		goto err_mutex;
+	}
+
 	rc = ABT_cond_create(&db->d_ref_cv);
 	if (rc != ABT_SUCCESS) {
 		D_ERROR(DF_DB": failed to create ref CV: %d\n", DP_DB(db), rc);
 		rc = dss_abterr2der(rc);
-		goto err_mutex;
+		goto err_raft_mutex;
 	}
 
 	rc = rdb_kvs_cache_create(&db->d_kvss);
@@ -317,6 +325,8 @@ err_kvss:
 	rdb_kvs_cache_destroy(db->d_kvss);
 err_ref_cv:
 	ABT_cond_free(&db->d_ref_cv);
+err_raft_mutex:
+	ABT_mutex_free(&db->d_raft_mutex);
 err_mutex:
 	ABT_mutex_free(&db->d_mutex);
 err_db:
@@ -346,6 +356,7 @@ rdb_stop(struct rdb *db)
 	vos_pool_close(db->d_pool);
 	rdb_kvs_cache_destroy(db->d_kvss);
 	ABT_cond_free(&db->d_ref_cv);
+	ABT_mutex_free(&db->d_raft_mutex);
 	ABT_mutex_free(&db->d_mutex);
 	D_FREE(db);
 }

--- a/src/rdb/rdb_raft.c
+++ b/src/rdb/rdb_raft.c
@@ -1854,10 +1854,6 @@ rdb_raft_append_apply_internal(struct rdb *db, msg_entry_t *mentry,
 	uint64_t		index;
 	int			rc;
 
-	/*
-	 * Do not yield before calling raft_recv_entry(), so that the index
-	 * assertion below will hold.
-	 */
 	index = raft_get_current_idx(db->d_raft) + 1;
 	if (result != NULL) {
 		rc = rdb_raft_register_result(db, index, result);

--- a/src/rdb/rdb_rpc.c
+++ b/src/rdb/rdb_rpc.c
@@ -425,6 +425,7 @@ rdb_raft_rpc_cb(const struct crt_cb_info *cb_info)
 	ABT_mutex_unlock(db->d_mutex);
 }
 
+/* Caller holds d_raft_mutex lock */
 int
 rdb_send_raft_rpc(crt_rpc_t *rpc, struct rdb *db)
 {
@@ -437,12 +438,12 @@ rdb_send_raft_rpc(crt_rpc_t *rpc, struct rdb *db)
 	if (rrpc == NULL)
 		return -DER_NOMEM;
 
-	ABT_mutex_lock(db->d_mutex);
 	if (db->d_stop) {
-		ABT_mutex_unlock(db->d_mutex);
 		rdb_free_raft_rpc(rrpc);
 		return -DER_CANCELED;
 	}
+
+	ABT_mutex_lock(db->d_mutex);
 	d_list_add_tail(&rrpc->drc_entry, &db->d_requests);
 	ABT_mutex_unlock(db->d_mutex);
 

--- a/src/rdb/rdb_tx.c
+++ b/src/rdb/rdb_tx.c
@@ -39,7 +39,7 @@
 #include "rdb_internal.h"
 #include "rdb_layout.h"
 
-/* Check leadership locally. */
+/* Check leadership locally. Caller must hold d_raft_mutex lock. */
 static inline int
 rdb_tx_leader_check(struct rdb_tx *tx)
 {
@@ -71,6 +71,7 @@ rdb_tx_begin(struct rdb *db, uint64_t term, struct rdb_tx *tx)
 	struct rdb_tx	t = {};
 	int		rc;
 
+	ABT_mutex_lock(db->d_raft_mutex);
 	if (term == RDB_NIL_TERM)
 		term = raft_get_current_term(db->d_raft);
 	/*
@@ -86,6 +87,7 @@ rdb_tx_begin(struct rdb *db, uint64_t term, struct rdb_tx *tx)
 	 * valid results.
 	 */
 	rc = rdb_raft_verify_leadership(db);
+	ABT_mutex_unlock(db->d_raft_mutex);
 	if (rc != 0)
 		return rc;
 	rdb_get(db);
@@ -112,12 +114,15 @@ rdb_tx_commit(struct rdb_tx *tx)
 	/* Don't fail query-only TXs for leader checks. */
 	if (tx->dt_entry == NULL)
 		return 0;
+
+	ABT_mutex_lock(tx->dt_db->d_raft_mutex);
 	rc = rdb_tx_leader_check(tx);
 	if (rc != 0)
 		return rc;
 
 	rc = rdb_raft_append_apply(tx->dt_db, tx->dt_entry, tx->dt_entry_len,
 				   &result);
+	ABT_mutex_unlock(tx->dt_db->d_raft_mutex);
 	if (rc != 0)
 		return rc;
 	return result;
@@ -329,7 +334,9 @@ rdb_tx_append(struct rdb_tx *tx, struct rdb_tx_op *op)
 			return -DER_INVAL;
 	}
 
+	ABT_mutex_lock(tx->dt_db->d_raft_mutex);
 	rc = rdb_tx_leader_check(tx);
+	ABT_mutex_unlock(tx->dt_db->d_raft_mutex);
 	if (rc != 0)
 		return rc;
 
@@ -886,7 +893,9 @@ rdb_tx_query_pre(struct rdb_tx *tx, const rdb_path_t *path,
 {
 	int rc;
 
+	ABT_mutex_lock(tx->dt_db->d_raft_mutex);
 	rc = rdb_tx_leader_check(tx);
+	ABT_mutex_unlock(tx->dt_db->d_raft_mutex);
 	if (rc != 0)
 		return rc;
 	return rdb_kvs_lookup(tx->dt_db, path, tx->dt_db->d_applied,

--- a/src/tests/ftest/server/metadata.py
+++ b/src/tests/ftest/server/metadata.py
@@ -51,6 +51,10 @@ from test_utils_pool import TestPool
 #  ~40MB for background aggregation use
 NO_OF_MAX_CONTAINER = 9300
 
+# DAOS_MD_CAP=92, 5% fragmentation, and ~47700000 bytes more overhead
+# NO_OF_MAX_CONTAINER = 5500
+
+
 def ior_runner_thread(manager, uuids, results):
     """IOR run thread method.
 

--- a/src/tests/ftest/server/metadata.yaml
+++ b/src/tests/ftest/server/metadata.yaml
@@ -12,9 +12,36 @@ hosts:
 timeout: 240
 server_config:
   name: daos_server
-  servers_per_host: 1
+  servers_per_host: 2
   servers:
     0:
+      targets: 8
+      first_core: 0
+      pinned_numa_node: 0
+      fabric_iface: ib0
+      fabric_iface_port: 31416
+      log_file: daos_server0.log
+      scm_mount: /mnt/daos0
+      # common items below (same in server 0 and server 1)
+      scm_class: ram
+      scm_size: 6
+      nr_xs_helpers: 16
+      log_mask: DEBUG,RPC=ERR,MEM=ERR
+      env_vars:
+        - DAOS_MD_CAP=128
+        - DD_MASK=mgmt,md,dsms,any
+    1:
+      targets: 8
+      first_core: 0
+      pinned_numa_node: 1
+      fabric_iface: ib0
+      fabric_iface_port: 31417
+      log_file: daos_server1.log
+      scm_mount: /mnt/daos1
+      # common items below (same in server 0 and server 1)
+      scm_class: ram
+      scm_size: 6
+      nr_xs_helpers: 16
       log_mask: DEBUG,RPC=ERR,MEM=ERR
       env_vars:
         - DAOS_MD_CAP=128


### PR DESCRIPTION
Before this change, rdb assumed vos discard does not yield.
In the meantime vos changed so that aggregation and discard yield.
In testing metadata space exhaustion after PR-2483, it was observed
that rdb invoked vos_discard from multiple rdb tx for the same epoch,
and the second tx was flagged by vos for "already in discard".
The issue was observed in multi-replica testing in a follower handling
successive AppendEntries RPCs for the same log index; the first that
issued discard (due to -DER_NOSPACE) and yielded ; and the second that
issued discard (for the same reason) but was flagged for the error.

With this change, a new mutex d_raft_mutex is added for use with
most struct rdb condition variables and to serialize raft transitions.

Also with this change, the server metadata test configuration is
updated to use 2 DAOS IO servers per node. This change was tested
with svcn: 3 and 8 IO servers, to confirm that "already in discard"
is not observed. However, svcn: 1 remains in the configuration, since
there are more changes required to stabilize "out of space" handling
with multiple service replicas.

Test-tag-hw-large: pr,hw,large metadatafill

Signed-off-by: Kenneth Cain <kenneth.c.cain@intel.com>