### PR TITLE
DAOS-623 build: Use extern in headers

### DIFF
--- a/src/control/lib/spdk/include/nvme_control_common.h
+++ b/src/control/lib/spdk/include/nvme_control_common.h
@@ -122,7 +122,7 @@ struct dev_health_entry {
 	int					 inflight;
 };
 
-struct ctrlr_entry	*g_controllers;
+extern struct ctrlr_entry	*g_controllers;
 
 /**
  * Attach call back function to report a device that has been

--- a/src/control/lib/spdk/src/nvme_control_common.c
+++ b/src/control/lib/spdk/src/nvme_control_common.c
@@ -1,5 +1,5 @@
 /**
-* (C) Copyright 2019 Intel Corporation.
+* (C) Copyright 2019-2020 Intel Corporation.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -26,6 +26,8 @@
 #include <spdk/env.h>
 
 #include "nvme_control_common.h"
+
+struct ctrlr_entry	*g_controllers;
 
 static bool
 probe_cb(void *cb_ctx, const struct spdk_nvme_transport_id *trid,

--- a/src/vos/vos_common.c
+++ b/src/vos/vos_common.c
@@ -35,6 +35,7 @@
 #include <daos/lru.h>
 #include <daos/btree_class.h>
 
+struct bio_xs_context	*vsa_xsctxt_inst;
 static pthread_mutex_t	mutex = PTHREAD_MUTEX_INITIALIZER;
 
 static bool vsa_nvme_init;

--- a/src/vos/vos_internal.h
+++ b/src/vos/vos_internal.h
@@ -301,7 +301,7 @@ struct vos_dtx_cmt_ent {
 #define DCE_DKEY_HASH(dce)	((dce)->dce_base.dce_dkey_hash)
 
 /* in-memory structures standalone instance */
-struct bio_xs_context		*vsa_xsctxt_inst;
+extern struct bio_xs_context		*vsa_xsctxt_inst;
 extern int vos_evt_feats;
 
 static inline struct bio_xs_context *


### PR DESCRIPTION
A couple of variables declared in headers where they should
be extern

Contributed by Jerome Soumagne

Signed-off-by: Jeff Olivier <jeffrey.v.olivier@intel.com>