### PR TITLE
DAOS-3907 dtx: (2) compounded RPC server side handler

### DIFF
--- a/src/dtx/dtx_common.c
+++ b/src/dtx/dtx_common.c
@@ -540,10 +540,10 @@ init:
 			     pm_ver, leader_oid, dti_cos, dti_cos_cnt, mbs,
 			     true, tgt_cnt == 0 ? true : false, dth);
 
-	D_DEBUG(DB_IO, "Start DTX "DF_DTI" sub_reqs %d, ver %u, "
-		"dti_cos_cnt %d: "DF_RC"\n",
+	D_DEBUG(DB_IO, "Start DTX "DF_DTI" sub_reqs %d, ver %u, leader "DF_UOID
+		", dti_cos_cnt %d: "DF_RC"\n",
 		DP_DTI(dti), sub_modification_cnt,
-		dth->dth_ver, dti_cos_cnt, DP_RC(rc));
+		dth->dth_ver, DP_UOID(*leader_oid), dti_cos_cnt, DP_RC(rc));
 
 	if (rc != 0)
 		D_FREE(dlh->dlh_subs);

--- a/src/object/obj_ec.h
+++ b/src/object/obj_ec.h
@@ -68,6 +68,21 @@ struct obj_shard_iod {
 	uint64_t		 siod_off;
 };
 
+struct obj_iod_array {
+	/* number of iods (oia_iods) */
+	uint32_t		 oia_iod_nr;
+	/* number obj iods (oia_oiods) */
+	uint32_t		 oia_oiod_nr;
+	daos_iod_t		*oia_iods;
+	struct dcs_iod_csums	*oia_iod_csums;
+	struct obj_io_desc	*oia_oiods;
+	/* byte offset array for target, need this info after RPC dispatched
+	 * to specific target server as there is no oiod info already.
+	 * one for each iod, NULL for replica.
+	 */
+	uint64_t		*oia_offs;
+};
+
 /** Evenly distributed for EC full-stripe-only mode */
 #define OBJ_SIOD_EVEN_DIST	((uint32_t)1 << 0)
 /** Flag used only for proc func, to only proc to one specific target */
@@ -613,7 +628,11 @@ int obj_ec_get_degrade(struct obj_reasb_req *reasb_req, uint16_t fail_tgt_idx,
 
 /* srv_ec.c */
 struct obj_rw_in;
-int obj_ec_rw_req_split(struct obj_rw_in *orw, struct obj_ec_split_req **req);
+int obj_ec_rw_req_split(daos_unit_oid_t oid, struct obj_iod_array *iod_array,
+			uint32_t iod_nr, uint32_t start_shard,
+			void *tgt_map, uint32_t map_size,
+			uint32_t tgt_nr, struct daos_shard_tgt *tgts,
+			struct obj_ec_split_req **split_req);
 void obj_ec_split_req_fini(struct obj_ec_split_req *req);
 
 #endif /* __OBJ_EC_H__ */

--- a/src/object/obj_rpc.c
+++ b/src/object/obj_rpc.c
@@ -910,6 +910,8 @@ crt_proc_struct_daos_cpd_sub_req(crt_proc_t proc,
 				if (dcu->dcu_ec_tgts == NULL)
 					D_GOTO(out, rc = -DER_NOMEM);
 			}
+
+			dcu->dcu_ec_split_req = NULL;
 		}
 
 		rc = crt_proc_struct_dcs_csum_info(proc, &dcu->dcu_dkey_csum);
@@ -1304,6 +1306,9 @@ obj_reply_set_status(crt_rpc_t *rpc, int status)
 	case DAOS_OBJ_RPC_SYNC:
 		((struct obj_sync_out *)reply)->oso_ret = status;
 		break;
+	case DAOS_OBJ_RPC_CPD:
+		((struct obj_cpd_out *)reply)->oco_ret = status;
+		break;
 	default:
 		D_ASSERT(0);
 	}
@@ -1335,6 +1340,8 @@ obj_reply_get_status(crt_rpc_t *rpc)
 		return ((struct obj_query_key_out *)reply)->okqo_ret;
 	case DAOS_OBJ_RPC_SYNC:
 		return ((struct obj_sync_out *)reply)->oso_ret;
+	case DAOS_OBJ_RPC_CPD:
+		return ((struct obj_cpd_out *)reply)->oco_ret;
 	default:
 		D_ASSERT(0);
 	}
@@ -1374,6 +1381,9 @@ obj_reply_map_version_set(crt_rpc_t *rpc, uint32_t map_version)
 	case DAOS_OBJ_RPC_SYNC:
 		((struct obj_sync_out *)reply)->oso_map_version = map_version;
 		break;
+	case DAOS_OBJ_RPC_CPD:
+		((struct obj_cpd_out *)reply)->oco_map_version = map_version;
+		break;
 	default:
 		D_ASSERT(0);
 	}
@@ -1405,6 +1415,8 @@ obj_reply_map_version_get(crt_rpc_t *rpc)
 		return ((struct obj_query_key_out *)reply)->okqo_map_version;
 	case DAOS_OBJ_RPC_SYNC:
 		return ((struct obj_sync_out *)reply)->oso_map_version;
+	case DAOS_OBJ_RPC_CPD:
+		return ((struct obj_cpd_out *)reply)->oco_map_version;
 	default:
 		D_ASSERT(0);
 	}

--- a/src/object/srv_ec.c
+++ b/src/object/srv_ec.c
@@ -34,34 +34,58 @@
 #include "obj_rpc.h"
 #include "obj_internal.h"
 
+static inline bool
+obj_ec_is_valid_tgt(struct daos_cpd_ec_tgts *tgt_map, uint32_t map_size,
+		    uint32_t id, uint32_t *shard)
+{
+	int	i;
+
+	/* XXX: The distributed transaction may contains the updates of
+	 *	multiple EC objects that share the same forward targets
+	 *	array. So for some update of EC object, the targets may
+	 *	be unordered. So checking the bitmap may be inefficient.
+	 */
+	for (i = 0; i < map_size; i++) {
+		if (tgt_map[i].dcet_tgt_idx == id) {
+			*shard = tgt_map[i].dcet_shard_idx;
+			return true;
+		}
+	}
+
+	return false;
+}
+
 /**
  * Split EC obj read/write request.
  * For object update, client sends update request to leader, the leader needs to
  * split it for different targets before dispatch.
  */
 int
-obj_ec_rw_req_split(struct obj_rw_in *orw, struct obj_ec_split_req **split_req)
+obj_ec_rw_req_split(daos_unit_oid_t oid, struct obj_iod_array *iod_array,
+		    uint32_t iod_nr, uint32_t start_shard,
+		    void *tgt_map, uint32_t map_size,
+		    uint32_t tgt_nr, struct daos_shard_tgt *tgts,
+		    struct obj_ec_split_req **split_req)
 {
-	daos_iod_t		*iod, *iods = orw->orw_iod_array.oia_iods;
-	struct obj_io_desc	*oiods = orw->orw_iod_array.oia_oiods;
-	struct daos_shard_tgt	*fw_tgts = orw->orw_shard_tgts.ca_arrays;
+	daos_iod_t		*iod;
+	daos_iod_t		*iods = iod_array->oia_iods;
+	struct obj_io_desc	*oiods = iod_array->oia_oiods;
 	struct obj_ec_split_req	*req;
 	daos_iod_t		*split_iod, *split_iods;
 	struct obj_shard_iod	*siod;
 	struct obj_tgt_oiod	*tgt_oiod, *tgt_oiods = NULL;
 	struct dcs_iod_csums	*iod_csum = NULL;
-	struct dcs_iod_csums	*iod_csums = orw->orw_iod_array.oia_iod_csums;
+	struct dcs_iod_csums	*iod_csums = iod_array->oia_iod_csums;
 	struct dcs_iod_csums	*split_iod_csum = NULL;
 	struct dcs_iod_csums	*split_iod_csums;
-	uint32_t		 tgt_nr = orw->orw_shard_tgts.ca_count;
-	uint32_t		 iod_nr = orw->orw_nr;
-	uint32_t		 start_shard = orw->orw_start_shard;
-	uint32_t		 i, tgt_idx, tgt_max_idx;
+	uint32_t		 i, tgt_max_idx;
 	daos_size_t		 req_size, iods_size;
 	daos_size_t		 csums_size = 0, singv_ci_size = 0;
 	uint8_t			 tgt_bit_map[OBJ_TGT_BITMAP_LEN] = {0};
 	bool			 with_csums = (iod_csums != NULL);
 	void			*buf = NULL;
+	uint32_t		 tgt_idx;
+	int			 count = 0;
 	int			 rc = 0;
 
 	/* minimal K/P is 2/1, so at least 1 forward targets */
@@ -72,7 +96,11 @@ obj_ec_rw_req_split(struct obj_rw_in *orw, struct obj_ec_split_req **split_req)
 	 */
 	D_ASSERT((oiods[0].oiod_flags & OBJ_SIOD_SINGV) ||
 		 oiods[0].oiod_nr >= 2);
-	tgt_max_idx = orw->orw_oid.id_shard - start_shard;
+
+	if (tgt_map != NULL)
+		tgt_max_idx = 0;
+	else
+		tgt_max_idx = oid.id_shard - start_shard;
 
 	req_size = roundup(sizeof(struct obj_ec_split_req), 8);
 	iods_size = roundup(sizeof(daos_iod_t) * iod_nr, 8);
@@ -84,6 +112,7 @@ obj_ec_rw_req_split(struct obj_rw_in *orw, struct obj_ec_split_req **split_req)
 	D_ALLOC(buf, req_size + iods_size + csums_size + singv_ci_size);
 	if (buf == NULL)
 		return -DER_NOMEM;
+
 	req = buf;
 	req->osr_iods = buf + req_size;
 	if (with_csums) {
@@ -93,39 +122,77 @@ obj_ec_rw_req_split(struct obj_rw_in *orw, struct obj_ec_split_req **split_req)
 	req->osr_start_shard = start_shard;
 
 	for (i = 0; i < tgt_nr; i++) {
-		tgt_idx = fw_tgts[i].st_shard - start_shard;
-		D_ASSERT(tgt_idx < tgt_max_idx);
+		if (tgt_map != NULL) {
+			if (!obj_ec_is_valid_tgt(tgt_map, map_size,
+						 tgts[i].st_tgt_id, &tgt_idx))
+				continue;
+
+			D_ASSERT(tgt_idx >= start_shard);
+
+			tgt_idx -= start_shard;
+			if (tgt_max_idx < tgt_idx)
+				tgt_max_idx = tgt_idx;
+		} else {
+			tgt_idx = tgts[i].st_shard - start_shard;
+			D_ASSERT(tgt_idx < tgt_max_idx);
+		}
+
 		setbit(tgt_bit_map, tgt_idx);
+		count++;
 	}
-	setbit(tgt_bit_map, tgt_max_idx);
+
+	if (tgt_map != NULL) {
+		D_ASSERT(count == map_size);
+
+		if (obj_ec_is_valid_tgt(tgt_map, map_size,
+					tgts[0].st_tgt_id, &tgt_idx))
+			tgt_idx -= start_shard;
+		else
+			/* If the leader (tgt[0]) is not in current EC RDG,
+			 * then set 'tgt_idx' as zero to select 'tgt_oiod'.
+			 * Related modification will not be executed on the
+			 * leader.
+			 */
+			tgt_idx = 0;
+	} else {
+		setbit(tgt_bit_map, tgt_max_idx);
+		count++;
+		tgt_idx = tgt_max_idx;
+	}
 
 	tgt_oiods = obj_ec_tgt_oiod_init(oiods, iod_nr, tgt_bit_map,
-					 tgt_max_idx, tgt_nr + 1);
+					 tgt_max_idx, count);
 	if (tgt_oiods == NULL)
 		D_GOTO(out, rc = -DER_NOMEM);
-	req->osr_tgt_oiods = tgt_oiods;
-	tgt_oiod = obj_ec_tgt_oiod_get(tgt_oiods, tgt_nr + 1, tgt_max_idx);
-	D_ASSERT(tgt_oiod != NULL && tgt_oiod->oto_tgt_idx == tgt_max_idx);
-	req->osr_offs = tgt_oiod->oto_offs;
 
+	req->osr_tgt_oiods = tgt_oiods;
+	tgt_oiod = obj_ec_tgt_oiod_get(tgt_oiods, count, tgt_idx);
+	D_ASSERT(tgt_oiod != NULL && tgt_oiod->oto_tgt_idx == tgt_idx);
+
+	req->osr_offs = tgt_oiod->oto_offs;
 	split_iods = req->osr_iods;
 	split_iod_csums = req->osr_iod_csums;
+
 	for (i = 0; i < iod_nr; i++) {
 		int	idx;
 
 		iod = &iods[i];
 		if (with_csums) {
 			D_ASSERT(split_iod_csums != NULL);
+
 			split_iod_csum = &split_iod_csums[i];
 			iod_csum = &iod_csums[i];
 			*split_iod_csum = *iod_csum;
 		}
+
 		split_iod = &split_iods[i];
 		split_iod->iod_name = iod->iod_name;
 		split_iod->iod_type = iod->iod_type;
 		split_iod->iod_size = iod->iod_size;
+
 		if (tgt_oiod->oto_oiods[i].oiod_flags & OBJ_SIOD_SINGV) {
 			D_ASSERT(iod->iod_type == DAOS_IOD_SINGLE);
+
 			idx = 0;
 			split_iod->iod_nr = 1;
 			if (with_csums) {

--- a/src/object/srv_obj_remote.c
+++ b/src/object/srv_obj_remote.c
@@ -46,6 +46,11 @@ struct obj_remote_cb_arg {
 	crt_rpc_t			*parent_req;
 	struct dtx_leader_handle	*dlh;
 	int				idx;
+	void				*cpd_reqs;
+	void				*cpd_desc;
+	void				*cpd_head;
+	void				*cpd_dcsr;
+	void				*cpd_dcde;
 };
 
 static void
@@ -160,8 +165,9 @@ ds_obj_remote_update(struct dtx_leader_handle *dlh, void *data, int idx,
 	if (rc != 0) {
 		D_ERROR("crt_req_send failed, rc "DF_RC"\n", DP_RC(rc));
 		crt_req_decref(req);
-		D_GOTO(out, rc);
 	}
+
+	return rc;
 
 out:
 	if (rc) {
@@ -275,8 +281,9 @@ ds_obj_remote_punch(struct dtx_leader_handle *dlh, void *data, int idx,
 	if (rc != 0) {
 		D_ERROR("crt_req_send failed, rc "DF_RC"\n", DP_RC(rc));
 		crt_req_decref(req);
-		D_GOTO(out, rc);
 	}
+
+	return rc;
 
 out:
 	if (rc) {
@@ -289,5 +296,270 @@ out:
 			D_FREE_PTR(remote_arg);
 		}
 	}
+	return rc;
+}
+
+static void
+shard_cpd_req_cb(const struct crt_cb_info *cb_info)
+{
+	crt_rpc_t			*req = cb_info->cci_rpc;
+	struct obj_remote_cb_arg	*arg = cb_info->cci_arg;
+	struct obj_cpd_out		*oco = crt_reply_get(req);
+	int				rc = cb_info->cci_rc;
+
+	if (rc >= 0)
+		rc = oco->oco_ret;
+
+	arg->comp_cb(arg->dlh, arg->idx, rc);
+	crt_req_decref(arg->parent_req);
+	D_FREE(arg->cpd_reqs);
+	D_FREE(arg->cpd_desc);
+	D_FREE(arg->cpd_head);
+	D_FREE(arg->cpd_dcsr);
+	D_FREE(arg->cpd_dcde);
+	D_FREE_PTR(arg);
+}
+
+static int
+ds_obj_cpd_clone_reqs(struct dtx_leader_handle *dlh, struct daos_shard_tgt *tgt,
+		      struct daos_cpd_disp_ent *dcde_parent,
+		      struct daos_cpd_sub_req *dcsr_parent, int total,
+		      struct daos_cpd_disp_ent **p_dcde,
+		      struct daos_cpd_sub_req **p_dcsr)
+{
+	struct daos_cpd_disp_ent	*dcde = NULL;
+	struct daos_cpd_sub_req		*dcsr = NULL;
+	int				 count;
+	int				 rc = 0;
+	int				 i;
+
+	count = dcde_parent->dcde_read_cnt + dcde_parent->dcde_write_cnt;
+	D_ALLOC_ARRAY(dcsr, count);
+	if (dcsr == NULL)
+		D_GOTO(out, rc = -DER_NOMEM);
+
+	D_ALLOC(dcde, sizeof(*dcde) +
+		sizeof(struct daos_cpd_req_idx) * count);
+	if (dcde == NULL)
+		D_GOTO(out, rc = -DER_NOMEM);
+
+	dcde->dcde_reqs = (struct daos_cpd_req_idx *)(dcde + 1);
+	dcde->dcde_read_cnt = dcde_parent->dcde_read_cnt;
+	dcde->dcde_write_cnt = dcde_parent->dcde_write_cnt;
+
+	for (i = 0; i < count; i++) {
+		struct daos_cpd_req_idx		*dcri_parent;
+		int				 idx;
+
+		dcri_parent = &dcde_parent->dcde_reqs[i];
+		idx = dcri_parent->dcri_req_idx;
+		D_ASSERT(idx < total);
+
+		memcpy(&dcsr[i], &dcsr_parent[idx], sizeof(dcsr[i]));
+
+		if (dcsr_parent[idx].dcsr_opc == DCSO_UPDATE) {
+			struct daos_cpd_update	*dcu_parent;
+			struct daos_cpd_update	*dcu;
+			struct obj_ec_split_req	*split;
+
+			dcu_parent = &dcsr_parent[idx].dcsr_update;
+			dcu = &dcsr[i].dcsr_update;
+
+			/* For non-leader, does not need split EC sub-req. */
+			dcu->dcu_ec_tgts = NULL;
+			dcu->dcu_ec_split_req = NULL;
+			dcsr[i].dcsr_ec_tgt_nr = 0;
+
+			split = dcu_parent->dcu_ec_split_req;
+			if (split != NULL) {
+				struct obj_tgt_oiod	*oiod;
+
+				oiod = obj_ec_tgt_oiod_get(split->osr_tgt_oiods,
+						dcsr_parent[idx].dcsr_ec_tgt_nr,
+						dcri_parent->dcri_shard_idx);
+				D_ASSERT(oiod != NULL);
+
+				dcu->dcu_iod_array->oia_oiods = oiod->oto_oiods;
+				dcu->dcu_iod_array->oia_oiod_nr = oiod->oto_iod_nr;
+				dcu->dcu_iod_array->oia_offs = oiod->oto_offs;
+			}
+		}
+
+		dcde->dcde_reqs[i].dcri_shard_idx = dcri_parent->dcri_shard_idx;
+		dcde->dcde_reqs[i].dcri_req_idx = i;
+	}
+
+out:
+	if (rc != 0) {
+		D_FREE(dcde);
+		D_FREE(dcsr);
+	} else {
+		*p_dcde = dcde;
+		*p_dcsr = dcsr;
+	}
+
+	return rc;
+}
+
+/* Dispatch CPD RPC and handle sub requests remotely */
+int
+ds_obj_cpd_dispatch(struct dtx_leader_handle *dlh, void *arg, int idx,
+		    dtx_sub_comp_cb_t comp_cb)
+{
+	struct ds_obj_exec_arg		*exec_arg = arg;
+	struct daos_cpd_args		*dca = exec_arg->args;
+	struct daos_cpd_sub_head	*dcsh;
+	struct daos_cpd_disp_ent	*dcde_parent = NULL;
+	struct daos_cpd_disp_ent	*dcde = NULL;
+	struct daos_cpd_sub_req		*dcsr_parent = NULL;
+	struct daos_cpd_sub_req		*dcsr = NULL;
+	struct obj_cpd_in		*oci;
+	struct obj_cpd_in		*oci_parent;
+	struct obj_remote_cb_arg	*remote_arg = NULL;
+	struct daos_shard_tgt		*shard_tgt;
+	crt_rpc_t			*parent_req = exec_arg->rpc;
+	crt_rpc_t			*req = NULL;
+	struct dtx_sub_status		*sub;
+	crt_endpoint_t			 tgt_ep;
+	struct daos_cpd_sg		*head_dcs = NULL;
+	struct daos_cpd_sg		*dcsr_dcs = NULL;
+	struct daos_cpd_sg		*dcde_dcs = NULL;
+	int				 total;
+	int				 count;
+	int				 rc = 0;
+
+	D_ASSERT(idx < dlh->dlh_sub_cnt);
+
+	sub = &dlh->dlh_subs[idx];
+	shard_tgt = &sub->dss_tgt;
+
+	D_ALLOC_PTR(head_dcs);
+	if (head_dcs == NULL)
+		D_GOTO(out, rc = -DER_NOMEM);
+
+	D_ALLOC_PTR(dcsr_dcs);
+	if (dcsr_dcs == NULL)
+		D_GOTO(out, rc = -DER_NOMEM);
+
+	D_ALLOC_PTR(dcde_dcs);
+	if (dcde_dcs == NULL)
+		D_GOTO(out, rc = -DER_NOMEM);
+
+	D_ALLOC_PTR(remote_arg);
+	if (remote_arg == NULL)
+		D_GOTO(out, rc = -DER_NOMEM);
+
+	remote_arg->dlh = dlh;
+	remote_arg->comp_cb = comp_cb;
+	remote_arg->idx = idx;
+	crt_req_addref(parent_req);
+	remote_arg->parent_req = parent_req;
+
+	remote_arg->cpd_head = head_dcs;
+	remote_arg->cpd_dcsr = dcsr_dcs;
+	remote_arg->cpd_dcde = dcde_dcs;
+
+	tgt_ep.ep_grp = NULL;
+	tgt_ep.ep_rank = shard_tgt->st_rank;
+	tgt_ep.ep_tag = shard_tgt->st_tgt_idx;
+
+	rc = obj_req_create(dss_get_module_info()->dmi_ctx, &tgt_ep,
+			    DAOS_OBJ_RPC_CPD, &req);
+	if (rc != 0) {
+		D_ERROR("CPD crt_req_create failed, idx %u: "DF_RC"\n",
+			idx, DP_RC(rc));
+		D_GOTO(out, rc);
+	}
+
+	oci_parent = crt_req_get(parent_req);
+	oci = crt_req_get(req);
+
+	uuid_copy(oci->oci_pool_uuid, oci_parent->oci_pool_uuid);
+	uuid_copy(oci->oci_co_hdl, oci_parent->oci_co_hdl);
+	uuid_copy(oci->oci_co_uuid, oci_parent->oci_co_uuid);
+	oci->oci_map_ver = oci_parent->oci_map_ver;
+	oci->oci_flags = (oci_parent->oci_flags | exec_arg->flags) &
+			~(DRF_HAS_EC_SPLIT | DRF_CPD_LEADER);
+
+	oci->oci_disp_tgts.ca_arrays = NULL;
+	oci->oci_disp_tgts.ca_count = 0;
+
+	dcsh = ds_obj_cpd_get_dcsh(dca->dca_rpc, dca->dca_idx);
+	head_dcs->dcs_type = DCST_HEAD;
+	head_dcs->dcs_nr = 1;
+	head_dcs->dcs_buf = dcsh;
+	oci->oci_sub_heads.ca_arrays = head_dcs;
+	oci->oci_sub_heads.ca_count = 1;
+
+	dcsr_parent = ds_obj_cpd_get_dcsr(dca->dca_rpc, dca->dca_idx);
+	total = ds_obj_cpd_get_dcsr_cnt(dca->dca_rpc, dca->dca_idx);
+
+	/* IDX[0] is for leader. */
+	dcde_parent = ds_obj_cpd_get_dcde(dca->dca_rpc, dca->dca_idx, idx + 1);
+	if (dcde_parent == NULL)
+		D_GOTO(out, rc = -DER_INVAL);
+
+	count = dcde_parent->dcde_read_cnt + dcde_parent->dcde_write_cnt;
+	if (count < total || exec_arg->flags & DRF_HAS_EC_SPLIT) {
+		rc = ds_obj_cpd_clone_reqs(dlh, shard_tgt, dcde_parent,
+					   dcsr_parent, total, &dcde, &dcsr);
+		if (rc != 0)
+			goto out;
+
+		remote_arg->cpd_reqs = dcsr;
+		remote_arg->cpd_desc = dcde;
+	} else {
+		dcsr = dcsr_parent;
+		dcde = dcde_parent;
+	}
+
+	dcsr_dcs->dcs_type = DCST_REQ_SRV;
+	dcsr_dcs->dcs_nr = count;
+	dcsr_dcs->dcs_buf = dcsr;
+	oci->oci_sub_reqs.ca_arrays = dcsr_dcs;
+	oci->oci_sub_reqs.ca_count = 1;
+
+	dcde_dcs->dcs_type = DCST_DISP;
+	dcde_dcs->dcs_nr = 1;
+	dcde_dcs->dcs_buf = dcde;
+	oci->oci_disp_ents.ca_arrays = dcde_dcs;
+	oci->oci_disp_ents.ca_count = 1;
+
+	D_DEBUG(DB_TRACE, "Forwarding CPD RPC to rank:%d tag:%d idx %u for DXT "
+		DF_DTI"\n",
+		tgt_ep.ep_rank, tgt_ep.ep_tag, idx, DP_DTI(&dcsh->dcsh_xid));
+
+	rc = crt_req_send(req, shard_cpd_req_cb, remote_arg);
+
+	D_CDEBUG(rc != 0, DLOG_ERR, DB_TRACE,
+		 "Forwarded CPD RPC to rank:%d tag:%d idx %u for DXT "
+		 DF_DTI": "DF_RC"\n", tgt_ep.ep_rank, tgt_ep.ep_tag, idx,
+		 DP_DTI(&dcsh->dcsh_xid), DP_RC(rc));
+
+	return rc;
+
+out:
+	D_ASSERT(rc != 0);
+
+	if (req != NULL)
+		crt_req_decref(req);
+
+	comp_cb(dlh, idx, rc);
+
+	if (remote_arg != NULL) {
+		if (remote_arg->parent_req != NULL)
+			crt_req_decref(remote_arg->parent_req);
+		D_FREE_PTR(remote_arg);
+	}
+
+	if (dcsr != dcsr_parent)
+		D_FREE(dcsr);
+	if (dcde != dcde_parent)
+		D_FREE(dcde);
+
+	D_FREE(head_dcs);
+	D_FREE(dcsr_dcs);
+	D_FREE(dcde_dcs);
+
 	return rc;
 }

--- a/src/vos/vos_io.c
+++ b/src/vos/vos_io.c
@@ -1293,8 +1293,6 @@ out:
 	if (rc != 0) {
 		daos_recx_ep_list_free(ioc->ic_recx_lists, ioc->ic_iod_nr);
 		ioc->ic_recx_lists = NULL;
-		if (rc == -DER_NONEXIST && ioc->ic_read_ts_only)
-			rc = 0;
 		return vos_fetch_end(vos_ioc2ioh(ioc), rc);
 	}
 	return 0;


### PR DESCRIPTION
On the leader, for each DTX in the CPD RPC, the leader
handler handles it via a dedicated ULT. These ULTs run
in parallel to process the sub requests that belong to
its own DTX, including forwarding realted sub requests
to remote server(s) via CPD RPC and local execution.

Each of the ULTs starts each own leader DTX on the CPD
leader and uses the general DTX framework to drive its
DTX with multiple sub requests.

The CPD RPC from client to the leader can contain many
independent transactions. But the CPD RPC for dispatch
to non-leader only contains the sub requests belong to
one transaction corresponding to the ULT handled DTX.

On the non-leader, since only single transaction is in
the dispatched CPD RPC, the handler can process it via
current ULT directly: use the general DTX framework to
drive its DTX with multiple sub requests.

The CPD leader and non-leader shares the same logic to
process the sub requests belong to a transaction after
starting the DTX locally.

Signed-off-by: Fan Yong <fan.yong@intel.com>