### PR TITLE
DAOS-4895 obj: EC obj fetch - unknown iod_size and set output sgl

### DIFF
--- a/src/object/cli_shard.c
+++ b/src/object/cli_shard.c
@@ -579,12 +579,18 @@ dc_obj_shard_rw(struct dc_obj_shard *shard, enum obj_rpc_opc opc,
 		if (fw_shard_tgts != NULL)
 			orw->orw_flags |= ORF_BULK_BIND;
 	} else {
-		/* Transfer data inline */
-		if (sgls != NULL)
-			orw->orw_sgls.ca_count = nr;
-		else
+		if (args->reasb_req && args->reasb_req->orr_size_fetch) {
+			/* NULL bulk and NULL sgl for size_fetch */
 			orw->orw_sgls.ca_count = 0;
-		orw->orw_sgls.ca_arrays = sgls;
+			orw->orw_sgls.ca_arrays = NULL;
+		} else {
+			/* Transfer data inline */
+			if (sgls != NULL)
+				orw->orw_sgls.ca_count = nr;
+			else
+				orw->orw_sgls.ca_count = 0;
+			orw->orw_sgls.ca_arrays = sgls;
+		}
 		orw->orw_bulks.ca_count = 0;
 		orw->orw_bulks.ca_arrays = NULL;
 	}

--- a/src/object/obj_ec.h
+++ b/src/object/obj_ec.h
@@ -587,6 +587,7 @@ struct obj_tgt_oiod *obj_ec_tgt_oiod_init(struct obj_io_desc *r_oiods,
 			uint32_t tgt_max_idx, uint32_t tgt_nr);
 struct obj_tgt_oiod *obj_ec_tgt_oiod_get(struct obj_tgt_oiod *tgt_oiods,
 			uint32_t tgt_nr, uint32_t tgt_idx);
+void obj_ec_fetch_set_sgl(struct obj_reasb_req *reasb_req, uint32_t iod_nr);
 int obj_ec_recov_add(struct obj_reasb_req *reasb_req,
 		     struct daos_recx_ep_list *recx_lists, unsigned int nr);
 struct obj_ec_fail_info *obj_ec_fail_info_get(struct obj_reasb_req *reasb_req,

--- a/src/object/obj_internal.h
+++ b/src/object/obj_internal.h
@@ -149,7 +149,12 @@ struct obj_reasb_req {
 	struct obj_tgt_oiod		*tgt_oiods;
 	/* IO failure information */
 	struct obj_ec_fail_info		*orr_fail;
-	uint32_t			 orr_recov:1; /* for recovery flag */
+	/* for data recovery flag */
+	uint32_t			 orr_recov:1,
+	/* for iod_size fetching flag */
+					 orr_size_fetch:1,
+	/* for iod_size fetched flag */
+					 orr_size_fetched:1;
 };
 
 static inline void

--- a/src/object/obj_internal.h
+++ b/src/object/obj_internal.h
@@ -139,6 +139,8 @@ struct obj_reasb_req {
 	struct obj_ec_recx_array	*orr_recxs;
 	struct obj_ec_seg_sorter	*orr_sorters;
 	struct dcs_layout		*orr_singv_los;
+	/* to record returned data size from each targets */
+	daos_size_t			*orr_data_sizes;
 	uint32_t			 orr_tgt_nr;
 	struct daos_oclass_attr		*orr_oca;
 	struct obj_ec_codec		*orr_codec;
@@ -154,7 +156,9 @@ struct obj_reasb_req {
 	/* for iod_size fetching flag */
 					 orr_size_fetch:1,
 	/* for iod_size fetched flag */
-					 orr_size_fetched:1;
+					 orr_size_fetched:1,
+	/* only with single target flag */
+					 orr_single_tgt:1;
 };
 
 static inline void
@@ -437,6 +441,34 @@ dc_io_epoch_set(struct dc_obj_epoch *epoch)
 	} else {
 		epoch->oe_value = DAOS_EPOCH_MAX;
 		epoch->oe_uncertain = false; /* not applicable */
+	}
+}
+
+static inline void
+dc_sgl_out_set(d_sg_list_t *sgl, daos_size_t data_size)
+{
+	d_iov_t		*iov;
+	daos_size_t	 buf_size;
+	uint32_t	 i;
+
+	if (data_size == 0) {
+		sgl->sg_nr_out = 0;
+		return;
+	}
+	buf_size = 0;
+	for (i = 0; i < sgl->sg_nr; i++) {
+		iov = &sgl->sg_iovs[i];
+		buf_size += iov->iov_buf_len;
+		if (buf_size < data_size) {
+			iov->iov_len = iov->iov_buf_len;
+			sgl->sg_nr_out = i + 1;
+			continue;
+		}
+
+		iov->iov_len = iov->iov_buf_len -
+			       (buf_size - data_size);
+		sgl->sg_nr_out = i + 1;
+		break;
 	}
 }
 

--- a/src/tests/suite/daos_obj.c
+++ b/src/tests/suite/daos_obj.c
@@ -2143,12 +2143,13 @@ next_step:
 	recx[3].rx_nr	= buf_len;
 	iod.iod_nr	= 1;
 	iod.iod_recxs	= &recx[3];
+	iod.iod_size	= DAOS_REC_ANY;
+	assert_int_equal(iod.iod_size, 0);
 	d_iov_set(&sg_iov[1], buf_out + tmp_len, buf_len - tmp_len);
 	rc = daos_obj_fetch(oh, DAOS_TX_NONE, 0, &dkey, 1, &iod, &sgl,
 			    NULL, NULL);
 	assert_int_equal(rc, 0);
-	if (!test_ec)
-		assert_int_equal(sgl.sg_nr_out, 0);
+	assert_int_equal(sgl.sg_nr_out, 0);
 
 	print_message("reading all data back ...\n");
 	memset(buf_out, 0, buf_len);
@@ -2162,8 +2163,7 @@ next_step:
 	/** Verify data consistency */
 	print_message("validating data ... sg_nr_out %d, iod_size %d.\n",
 		      sgl.sg_nr_out, (int)iod.iod_size);
-	if (!test_ec)
-		assert_int_equal(sgl.sg_nr_out, 2);
+	assert_int_equal(sgl.sg_nr_out, 2);
 	assert_memory_equal(buf, buf_out, buf_len);
 
 	print_message("short read should get iov_len with tail hole trimmed\n");
@@ -2183,10 +2183,8 @@ next_step:
 	/** Verify data consistency */
 	print_message("validating data ... sg_nr_out %d, iov_len %d.\n",
 		      sgl.sg_nr_out, (int)sgl.sg_iovs[0].iov_len);
-	if (!test_ec) {
-		assert_int_equal(sgl.sg_nr_out, 1);
-		assert_int_equal(sgl.sg_iovs[0].iov_len, tmp_len);
-	}
+	assert_int_equal(sgl.sg_nr_out, 1);
+	assert_int_equal(sgl.sg_iovs[0].iov_len, tmp_len);
 	assert_memory_equal(buf, buf_out, tmp_len);
 
 	if (step++ == 1)

--- a/src/tests/suite/io_conf/daos_io_conf_2
+++ b/src/tests/suite/io_conf/daos_io_conf_2
@@ -74,7 +74,7 @@ update --tx 100 -d dkey_another -a akey_another -r "[0, 3000]"
 
 fetch --tx 1 -r "[0, 1000]"
 fetch --tx 2 -r "[0, 50] [300, 1000]"
-fetch --tx 3 -r "[1, 20] [30, 80] [100, 290] [250, 400] [500, 1100]"
+fetch --tx 3 -r "[1, 20] [30, 80] [100, 240] [250, 400] [500, 1100]"
 fetch --tx 4 -r "[20, 30] [48, 333] [377, 388] [400, 2000]"
 fetch --tx 4 -d dkey_another -a akey_another -r "[0, 2000]"
 fetch --tx 110 -d dkey_another -a akey_another -r "[0, 3000]"


### PR DESCRIPTION
1. When iod_size unknown, for EC obj fetch it will first do a size query,
    and then do the real obj fetch.
2. Added the code to handle EC obj fetch's output sgl's sg_nr_out and
     iov_len.
3. Chaneg IO13 (basic_byte_array) to add the test of above 2 cases.

Signed-off-by: Xuezhao Liu <xuezhao.liu@intel.com>