### PR TITLE
DAOS-4717 pool: per VOS pool GC ULT

### DIFF
--- a/src/container/srv_target.c
+++ b/src/container/srv_target.c
@@ -160,7 +160,7 @@ cont_child_aggregate(struct ds_cont_child *cont, uint64_t *msecs)
 
 	if (epoch_min > epoch_max) {
 		/* Nothing can be aggregated */
-		*msecs = max(*msecs, (epoch_min - epoch_max) / 1000000);
+		*msecs = max(*msecs, (epoch_min - epoch_max) / NSEC_PER_MSEC);
 		return 0;
 	} else if (epoch_min > epoch_max - interval &&
 		   sched_req_space_check(req) == SCHED_SPACE_PRESS_NONE) {

--- a/src/container/srv_target.c
+++ b/src/container/srv_target.c
@@ -58,21 +58,11 @@
  */
 #define DAOS_AGG_THRESHOLD	90 /* seconds */
 
-static inline bool
-cont_aggregate_yield(void *arg)
-{
-	struct sched_request	*req = (struct sched_request *)arg;
-
-	if (sched_req_is_aborted(req))
-		return true;
-
-	sched_req_yield(req);
-	return false;
-}
-
 static inline int
 cont_aggregate_epr(struct ds_cont_child *cont, daos_epoch_range_t *epr)
 {
+	int	rc;
+
 	/*
 	 * Avoid calling into vos_aggregate() when aborting aggregation
 	 * on ds_cont_child purging.
@@ -80,8 +70,12 @@ cont_aggregate_epr(struct ds_cont_child *cont, daos_epoch_range_t *epr)
 	D_ASSERT(cont->sc_agg_req != NULL);
 	if (sched_req_is_aborted(cont->sc_agg_req))
 		return 1;
-	return vos_aggregate(cont->sc_hdl, epr, ds_csum_recalc,
-			     cont_aggregate_yield, (void *)cont->sc_agg_req);
+
+	rc = vos_aggregate(cont->sc_hdl, epr, ds_csum_recalc, dss_ult_yield,
+			   (void *)cont->sc_agg_req);
+	/* Wake up GC ULT */
+	sched_req_wakeup(cont->sc_pool->spc_gc_req);
+	return rc;
 }
 
 static bool
@@ -166,6 +160,7 @@ cont_child_aggregate(struct ds_cont_child *cont, uint64_t *msecs)
 
 	if (epoch_min > epoch_max) {
 		/* Nothing can be aggregated */
+		*msecs = max(*msecs, (epoch_min - epoch_max) / 1000000);
 		return 0;
 	} else if (epoch_min > epoch_max - interval &&
 		   sched_req_space_check(req) == SCHED_SPACE_PRESS_NONE) {
@@ -285,8 +280,7 @@ cont_aggregate_ult(void *arg)
 		dmi->dmi_tgt_id);
 
 	D_ASSERT(cont->sc_agg_req != NULL);
-	while (!sched_req_is_aborted(cont->sc_agg_req) &&
-	       !dss_xstream_exiting(dmi->dmi_xstream)) {
+	while (!dss_ult_exiting(cont->sc_agg_req)) {
 		uint64_t msecs;	/* milli seconds */
 
 		rc = cont_child_aggregate(cont, &msecs);
@@ -298,7 +292,7 @@ cont_aggregate_ult(void *arg)
 				rc);
 		}
 
-		if (dss_xstream_exiting(dmi->dmi_xstream))
+		if (dss_ult_exiting(cont->sc_agg_req))
 			break;
 
 		sched_req_sleep(cont->sc_agg_req, msecs);
@@ -908,6 +902,39 @@ ds_cont_hdl_get(struct ds_cont_hdl *hdl)
 	cont_hdl_get_internal(hash, hdl);
 }
 
+/* #define CONT_DESTROY_SYNC_WAIT */
+static void
+cont_destroy_wait(struct ds_pool_child *child, uuid_t co_uuid)
+{
+#ifdef CONT_DESTROY_SYNC_WAIT
+	struct dss_module_info	*dmi = dss_get_module_info();
+	struct sched_req_attr	 attr;
+	struct sched_request	*req;
+
+	D_DEBUG(DF_DSMS, DF_CONT": wait container destroy\n",
+		DP_CONT(child->spc_uuid, co_uuid));
+
+	D_ASSERT(child != NULL);
+	sched_req_attr_init(&attr, SCHED_REQ_IO, &child->spc_uuid);
+	req = sched_req_get(&attr, ABT_THREAD_NULL);
+	if (req == NULL) {
+		D_CRIT(DF_UUID"[%d]: Failed to get sched req\n",
+		       DP_UUID(child->spc_uuid), dmi->dmi_tgt_id);
+		return;
+	}
+
+	while (!dss_xstream_exiting(dmi->dmi_xstream)) {
+		if (vos_gc_pool_idle(child->spc_hdl))
+			break;
+		sched_req_sleep(req, 500);
+	}
+	sched_req_put(req);
+
+	D_DEBUG(DF_DSMS, DF_CONT": container destroy done\n",
+		DP_CONT(child->spc_uuid, co_uuid));
+#endif
+}
+
 /*
  * Called via dss_collective() to destroy the ds_cont object as well as the vos
  * container.
@@ -971,26 +998,15 @@ cont_child_destroy_one(void *vin)
 		 * container open time, so it might legitimately not exist if
 		 * the container has never been opened */
 		rc = 0;
-	}
-
-	/*
-	 * Pause flushing free extents in VEA aging buffer, otherwise,
-	 * there'll be way more fragments to be processed.
-	 */
-	vos_pool_ctl(pool->spc_hdl, VOS_PO_CTL_VEA_PLUG);
-
-	/* XXX there might be a race between GC and pool destroy, let's do
-	 * synchronous GC for now.
-	 */
-	dss_gc_run(pool->spc_hdl, -1);
-
-	/* Unplug and make the freed extents available immediately. */
-	vos_pool_ctl(pool->spc_hdl, VOS_PO_CTL_VEA_UNPLUG);
-	if (rc) {
-		D_ERROR(DF_CONT": VEA flush failed. "DF_RC"\n",
+	} else if (rc) {
+		D_ERROR(DF_CONT": destroy vos container failed "DF_RC"\n",
 			DP_CONT(pool->spc_uuid, in->tdi_uuid), DP_RC(rc));
-		goto out_pool;
+	} else {
+		/* Wakeup GC ULT */
+		sched_req_wakeup(pool->spc_gc_req);
+		cont_destroy_wait(pool, in->tdi_uuid);
 	}
+
 out_pool:
 	ds_pool_child_put(pool);
 out:

--- a/src/include/daos_srv/daos_server.h
+++ b/src/include/daos_srv/daos_server.h
@@ -366,7 +366,7 @@ dss_ult_exiting(struct sched_request *req)
  * \param[in] req	Sched request.
  *
  * \retval		True:  Abort ULT;
- *			False: Yield then continue;	
+ *			False: Yield then continue;
  */
 static inline bool
 dss_ult_yield(void *arg)

--- a/src/include/daos_srv/daos_server.h
+++ b/src/include/daos_srv/daos_server.h
@@ -352,6 +352,34 @@ enum {
  */
 int sched_req_space_check(struct sched_request *req);
 
+static inline bool
+dss_ult_exiting(struct sched_request *req)
+{
+	struct dss_xstream	*dx = dss_current_xstream();
+
+	return dss_xstream_exiting(dx) || sched_req_is_aborted(req);
+}
+
+/*
+ * Yield function regularly called by long-run ULTs.
+ *
+ * \param[in] req	Sched request.
+ *
+ * \retval		True:  Abort ULT;
+ *			False: Yield then continue;	
+ */
+static inline bool
+dss_ult_yield(void *arg)
+{
+	struct sched_request	*req = (struct sched_request *)arg;
+
+	if (dss_ult_exiting(req))
+		return true;
+
+	sched_req_yield(req);
+	return false;
+}
+
 struct dss_module_ops {
 	/* Get schedule request attributes from RPC */
 	int (*dms_get_req_attr)(crt_rpc_t *rpc, struct sched_req_attr *attr);
@@ -790,14 +818,6 @@ enum dss_media_error_type {
 };
 
 void dss_init_state_set(enum dss_init_state state);
-
-/* default credits */
-#define	DSS_GC_CREDS	256
-
-/**
- * Run GC for an opened pool, it run GC for all pools if @poh is DAOS_HDL_INVAL
- */
-void dss_gc_run(daos_handle_t poh, int credits);
 
 int notify_bio_error(int media_err_type, int tgt_id);
 

--- a/src/include/daos_srv/pool.h
+++ b/src/include/daos_srv/pool.h
@@ -89,11 +89,12 @@ void ds_pool_hdl_put(struct ds_pool_hdl *hdl);
  * object I/Os do not need to access global, parent ds_pool objects.
  */
 struct ds_pool_child {
-	d_list_t	spc_list;
-	daos_handle_t	spc_hdl;	/* vos_pool handle */
-	struct ds_pool	*spc_pool;
-	uuid_t		spc_uuid;	/* pool UUID */
-	d_list_t	spc_cont_list;
+	d_list_t		spc_list;
+	daos_handle_t		spc_hdl;	/* vos_pool handle */
+	struct ds_pool		*spc_pool;
+	uuid_t			spc_uuid;	/* pool UUID */
+	struct sched_request	*spc_gc_req;	/* Track GC ULT */
+	d_list_t		spc_cont_list;
 
 	/* The current maxim rebuild epoch, (0 if there is no rebuild), so
 	 * vos aggregation can not cross this epoch during rebuild to avoid

--- a/src/include/daos_srv/vos.h
+++ b/src/include/daos_srv/vos.h
@@ -910,9 +910,11 @@ int
 vos_pool_ctl(daos_handle_t poh, enum vos_pool_opc opc);
 
 int
-vos_gc_run(int *credits);
-int
-vos_gc_pool(daos_handle_t poh, int *credits);
+vos_gc_pool_run(daos_handle_t poh, int credits,
+		bool (*yield_func)(void *arg), void *yield_arg);
+bool
+vos_gc_pool_idle(daos_handle_t poh);
+
 
 enum vos_cont_opc {
 	VOS_CO_CTL_DUMMY,

--- a/src/iosrv/sched.c
+++ b/src/iosrv/sched.c
@@ -308,7 +308,7 @@ sched_info_init(struct dss_xstream *dx)
 	struct sched_info	*info = &dx->dx_sched_info;
 	int			 rc;
 
-	info->si_cur_ts = daos_getntime_coarse() / 1000000;
+	info->si_cur_ts = daos_getntime_coarse() / NSEC_PER_MSEC;
 	D_INIT_LIST_HEAD(&info->si_idle_list);
 	D_INIT_LIST_HEAD(&info->si_sleep_list);
 	D_INIT_LIST_HEAD(&info->si_fifo_list);
@@ -881,7 +881,7 @@ wakeup_all(struct dss_xstream *dx)
 	struct sched_request	*req, *tmp;
 
 	/* Update current ts stored in sched_info */
-	info->si_cur_ts = daos_getntime_coarse() / 1000000;
+	info->si_cur_ts = daos_getntime_coarse() / NSEC_PER_MSEC;
 
 	d_list_for_each_entry_safe(req, tmp, &info->si_sleep_list, sr_link) {
 		D_ASSERT(req->sr_wakeup_time > 0);

--- a/src/vos/vos_gc.c
+++ b/src/vos/vos_gc.c
@@ -883,7 +883,12 @@ vos_gc_pool(daos_handle_t poh, int *credits)
 	if (empty) {
 		if (total != 0) /* did something */
 			gc_log_pool(pool);
-		gc_del_pool(pool);
+		/*
+		 * Recheck since vea_free() called when drain sv/ev record may
+		 * result in yield on transaction end callback.
+		 */
+		if (gc_have_pool(pool))
+			gc_del_pool(pool);
 	}
 
 	return 0;

--- a/src/vos/vos_internal.h
+++ b/src/vos/vos_internal.h
@@ -1018,6 +1018,8 @@ gc_init_pool(struct umem_instance *umm, struct vos_pool_df *pd);
 int
 gc_add_item(struct vos_pool *pool, enum vos_gc_type type, umem_off_t item_off,
 	    uint64_t args);
+int
+vos_gc_pool(daos_handle_t poh, int *credits);
 void
 gc_reserve_space(daos_size_t *rsrvd);
 

--- a/src/vos/vos_pool.c
+++ b/src/vos/vos_pool.c
@@ -712,9 +712,8 @@ vos_pool_open(const char *path, uuid_t uuid, daos_handle_t *poh)
 	pool->vp_pool_df = pool_df;
 	pool->vp_opened = 1;
 	vos_space_sys_init(pool);
-	/* NB: probably should call gc_add_pool to clean up garbages left
-	 * behind by crash.
-	 */
+	/* Ensure GC is triggered after server restart */
+	gc_add_pool(pool);
 	D_DEBUG(DB_MGMT, "Opened pool %p\n", pool);
 	return 0;
 failed:


### PR DESCRIPTION
Change GC ULTs from per VOS xstream to per VOS pool, so that pool GC
ULTs can be scheduled independently.

Disable container destroy sync wait to avoid RPC timeout on huge
container destroy.

Signed-off-by: Niu Yawei <yawei.niu@intel.com>