### PR TITLE
DAOS-3800 object: split fetch internal flags from API flags

### DIFF
--- a/src/client/api/init.c
+++ b/src/client/api/init.c
@@ -110,7 +110,6 @@ const struct daos_task_api dc_funcs[] = {
 	{dc_obj_query, sizeof(daos_obj_query_t)},
 	{dc_obj_query_key, sizeof(daos_obj_query_key_t)},
 	{dc_obj_sync, sizeof(struct daos_obj_sync_args)},
-	{dc_obj_fetch_shard_task,	sizeof(struct daos_obj_fetch_shard)},
 	{dc_obj_fetch_task,		sizeof(daos_obj_fetch_t)},
 	{dc_obj_update_task,		sizeof(daos_obj_update_t)},
 	{dc_obj_list_dkey, sizeof(daos_obj_list_dkey_t)},

--- a/src/client/api/object.c
+++ b/src/client/api/object.c
@@ -160,19 +160,10 @@ daos_obj_fetch(daos_handle_t oh, daos_handle_t th, uint64_t flags,
 	       d_sg_list_t *sgls, daos_iom_t *maps, daos_event_t *ev)
 {
 	tse_task_t	*task;
-	uint32_t	*ptr = NULL;
-	uint32_t	 extra_flags = 0;
-	uint32_t	 shard;
 	int		 rc;
 
-	if (DAOS_FAIL_CHECK(DAOS_OBJ_SPECIAL_SHARD)) {
-		extra_flags = DIOF_TO_SPEC_SHARD;
-		shard = daos_fail_value_get();
-		ptr = &shard;
-	}
-
-	rc = dc_obj_fetch_task_create(oh, th, flags, dkey, nr, extra_flags,
-				      iods, sgls, maps, ptr, ev, NULL, &task);
+	rc = dc_obj_fetch_task_create(oh, th, flags, dkey, nr, 0, iods,
+				      sgls, maps, NULL, ev, NULL, &task);
 	if (rc)
 		return rc;
 

--- a/src/client/api/object.c
+++ b/src/client/api/object.c
@@ -160,10 +160,19 @@ daos_obj_fetch(daos_handle_t oh, daos_handle_t th, uint64_t flags,
 	       d_sg_list_t *sgls, daos_iom_t *maps, daos_event_t *ev)
 {
 	tse_task_t	*task;
-	int		rc;
+	uint32_t	*ptr = NULL;
+	uint32_t	 extra_flags = 0;
+	uint32_t	 shard;
+	int		 rc;
 
-	rc = dc_obj_fetch_task_create(oh, th, flags, dkey, nr, iods, sgls, NULL,
-				      maps, ev, NULL, &task);
+	if (DAOS_FAIL_CHECK(DAOS_OBJ_SPECIAL_SHARD)) {
+		extra_flags = DIOF_TO_SPEC_SHARD;
+		shard = daos_fail_value_get();
+		ptr = &shard;
+	}
+
+	rc = dc_obj_fetch_task_create(oh, th, flags, dkey, nr, extra_flags,
+				      iods, sgls, maps, ptr, ev, NULL, &task);
 	if (rc)
 		return rc;
 

--- a/src/client/api/task_internal.h
+++ b/src/client/api/task_internal.h
@@ -92,7 +92,6 @@ struct daos_task_args {
 		daos_obj_query_t	obj_query;
 		daos_obj_query_key_t	obj_query_key;
 		struct daos_obj_sync_args obj_sync;
-		struct daos_obj_fetch_shard obj_fetch_shard;
 		daos_obj_fetch_t	obj_fetch;
 		daos_obj_update_t	obj_update;
 		daos_obj_list_dkey_t	obj_list_dkey;

--- a/src/include/daos/object.h
+++ b/src/include/daos/object.h
@@ -342,7 +342,6 @@ int dc_obj_punch_akeys_task(tse_task_t *task);
 int dc_obj_query(tse_task_t *task);
 int dc_obj_query_key(tse_task_t *task);
 int dc_obj_sync(tse_task_t *task);
-int dc_obj_fetch_shard_task(tse_task_t *task);
 int dc_obj_fetch_task(tse_task_t *task);
 int dc_obj_update_task(tse_task_t *task);
 int dc_obj_list_dkey(tse_task_t *task);

--- a/src/include/daos/task.h
+++ b/src/include/daos/task.h
@@ -136,19 +136,11 @@ dc_obj_sync_task_create(daos_handle_t oh, daos_epoch_t epoch,
 			daos_epoch_t **epochs_p, int *nr, daos_event_t *ev,
 			tse_sched_t *tse, tse_task_t **task);
 int
-dc_obj_fetch_shard_task_create(daos_handle_t oh, daos_handle_t th,
-			       unsigned int flags, unsigned int shard,
-			       daos_key_t *dkey, unsigned int nr,
-			       daos_iod_t *iods, d_sg_list_t *sgls,
-			       daos_iom_t *maps, daos_event_t *ev,
-			       tse_sched_t *tse, tse_task_t **task);
-
-int
-dc_obj_fetch_task_create(daos_handle_t oh, daos_handle_t th, uint64_t flags,
-			 daos_key_t *dkey, unsigned int nr, daos_iod_t *iods,
-			 d_sg_list_t *sgls, void *extra_args,
-			 daos_iom_t *maps, daos_event_t *ev,
-			 tse_sched_t *tse, tse_task_t **task);
+dc_obj_fetch_task_create(daos_handle_t oh, daos_handle_t th, uint64_t api_flags,
+			 daos_key_t *dkey, uint32_t nr, uint32_t extra_flags,
+			 daos_iod_t *iods, d_sg_list_t *sgls, daos_iom_t *ioms,
+			 void *extra_arg, daos_event_t *ev, tse_sched_t *tse,
+			 tse_task_t **task);
 int
 dc_obj_update_task_create(daos_handle_t oh, daos_handle_t th, uint64_t flags,
 			  daos_key_t *dkey, unsigned int nr,

--- a/src/include/daos_task.h
+++ b/src/include/daos_task.h
@@ -111,7 +111,6 @@ typedef enum {
 	DAOS_OPC_OBJ_QUERY,
 	DAOS_OPC_OBJ_QUERY_KEY,
 	DAOS_OPC_OBJ_SYNC,
-	DAOS_OPC_OBJ_FETCH_SHARD,
 	DAOS_OPC_OBJ_FETCH,
 	DAOS_OPC_OBJ_UPDATE,
 	DAOS_OPC_OBJ_LIST_DKEY,
@@ -698,12 +697,14 @@ typedef struct {
 	daos_handle_t		th;
 	/** Object open handle */
 	daos_handle_t		oh;
-	/** Operation flags. */
+	/** API flags. */
 	uint64_t		flags;
 	/** Distribution Key. */
 	daos_key_t		*dkey;
 	/** Number of elements in \a iods and \a sgls. */
-	unsigned int		nr;
+	uint32_t		nr;
+	/** Internal flags. */
+	uint32_t		extra_flags;
 	/** IO descriptor describing IO layout in the object. */
 	daos_iod_t		*iods;
 	/** Scatter / gather list for a memory descriptor. */
@@ -718,16 +719,6 @@ typedef struct {
 typedef daos_obj_rw_t		daos_obj_fetch_t;
 /** update args struct */
 typedef daos_obj_rw_t		daos_obj_update_t;
-
-/** Object shard fetch args */
-struct daos_obj_fetch_shard {
-	/** base. */
-	daos_obj_fetch_t	base;
-	/** Operation flags. */
-	unsigned int		flags;
-	/** shard. */
-	unsigned int		shard;
-};
 
 /** Object sync args */
 struct daos_obj_sync_args {

--- a/src/object/obj_task.c
+++ b/src/object/obj_task.c
@@ -191,61 +191,15 @@ dc_obj_sync_task_create(daos_handle_t oh, daos_epoch_t epoch,
 	return 0;
 }
 
-static void
-obj_fetch_init_args(daos_obj_fetch_t *args, daos_handle_t oh, daos_handle_t th,
-		    uint64_t flags, daos_key_t *dkey, unsigned int nr,
-		    daos_iod_t *iods, d_sg_list_t *sgls, void *extra_arg,
-		    daos_iom_t *ioms)
-{
-	args->oh	= oh;
-	args->th	= th;
-	args->flags	= flags;
-	args->dkey	= dkey;
-	args->nr	= nr;
-	args->iods	= iods;
-	args->sgls	= sgls;
-	args->extra_arg	= extra_arg;
-	args->ioms	= ioms;
-}
-
 int
-dc_obj_fetch_shard_task_create(daos_handle_t oh, daos_handle_t th,
-			       unsigned int flags, unsigned int shard,
-			       daos_key_t *dkey, unsigned int nr,
-			       daos_iod_t *iods, d_sg_list_t *sgls,
-			       daos_iom_t *ioms, daos_event_t *ev,
-			       tse_sched_t *tse, tse_task_t **task)
-{
-	struct daos_obj_fetch_shard	*args;
-	int				 rc;
-
-	DAOS_API_ARG_ASSERT(*args, OBJ_FETCH_SHARD);
-	rc = dc_task_create(dc_obj_fetch_shard_task, tse, ev, task);
-	if (rc)
-		return rc;
-
-	args = dc_task_get_args(*task);
-	obj_fetch_init_args(&args->base, oh, th, 0, dkey, nr, iods, sgls, NULL,
-			    ioms);
-	args->flags	= flags;
-	args->shard	= shard;
-
-	return 0;
-}
-
-int
-dc_obj_fetch_task_create(daos_handle_t oh, daos_handle_t th, uint64_t flags,
-			 daos_key_t *dkey, unsigned int nr, daos_iod_t *iods,
-			 d_sg_list_t *sgls, void *extra_arg, daos_iom_t *ioms,
-			 daos_event_t *ev, tse_sched_t *tse, tse_task_t **task)
+dc_obj_fetch_task_create(daos_handle_t oh, daos_handle_t th, uint64_t api_flags,
+			 daos_key_t *dkey, uint32_t nr, uint32_t extra_flags,
+			 daos_iod_t *iods, d_sg_list_t *sgls, daos_iom_t *ioms,
+			 void *extra_arg, daos_event_t *ev, tse_sched_t *tse,
+			 tse_task_t **task)
 {
 	daos_obj_fetch_t	*args;
 	int			 rc;
-
-	if (DAOS_FAIL_CHECK(DAOS_OBJ_SPECIAL_SHARD))
-		return dc_obj_fetch_shard_task_create(oh, th,
-				DIOF_TO_SPEC_SHARD, daos_fail_value_get(),
-				dkey, nr, iods, sgls, ioms, ev, tse, task);
 
 	DAOS_API_ARG_ASSERT(*args, OBJ_FETCH);
 	rc = dc_task_create(dc_obj_fetch_task, tse, ev, task);
@@ -253,8 +207,16 @@ dc_obj_fetch_task_create(daos_handle_t oh, daos_handle_t th, uint64_t flags,
 		return rc;
 
 	args = dc_task_get_args(*task);
-	obj_fetch_init_args(args, oh, th, flags, dkey, nr, iods, sgls,
-			    extra_arg, ioms);
+	args->oh		= oh;
+	args->th		= th;
+	args->flags		= api_flags;
+	args->dkey		= dkey;
+	args->nr		= nr;
+	args->extra_flags	= extra_flags;
+	args->iods		= iods;
+	args->sgls		= sgls;
+	args->ioms		= ioms;
+	args->extra_arg		= extra_arg;
 
 	return 0;
 }

--- a/src/object/obj_verify.c
+++ b/src/object/obj_verify.c
@@ -106,6 +106,7 @@ dc_obj_verify_fetch(struct dc_obj_verify_args *dova)
 	struct dc_obj_verify_cursor	*cursor = &dova->cursor;
 	daos_iod_t			*iod = &cursor->iod;
 	tse_task_t			*task;
+	uint32_t			 shard;
 	size_t				 size;
 	int				 rc;
 
@@ -134,10 +135,10 @@ dc_obj_verify_fetch(struct dc_obj_verify_args *dova)
 	dova->fetch_sgl.sg_nr_out = 1;
 	dova->fetch_sgl.sg_iovs = &dova->fetch_iov;
 
-	rc = dc_obj_fetch_shard_task_create(dova->oh, dova->th,
-		DIOF_TO_SPEC_SHARD, dc_obj_anchor2shard(&dova->dkey_anchor),
-		&cursor->dkey, 1, iod, &dova->fetch_sgl, NULL, NULL, NULL,
-		&task);
+	shard = dc_obj_anchor2shard(&dova->dkey_anchor);
+	rc = dc_obj_fetch_task_create(dova->oh, dova->th, 0, &cursor->dkey, 1,
+				      DIOF_TO_SPEC_SHARD, iod, &dova->fetch_sgl,
+				      NULL, &shard, NULL, NULL, &task);
 	if (rc == 0)
 		rc = dc_task_schedule(task, true);
 

--- a/src/object/srv_cli.c
+++ b/src/object/srv_cli.c
@@ -155,9 +155,9 @@ dsc_obj_fetch(daos_handle_t oh, daos_epoch_t epoch, daos_key_t *dkey,
 	if (rc)
 		return rc;
 
-	rc = dc_obj_fetch_shard_task_create(oh, th, DIOF_TO_LEADER, 0, dkey,
-					    nr, iods, sgls, maps, NULL,
-					    dsc_scheduler(), &task);
+	rc = dc_obj_fetch_task_create(oh, th, 0, dkey, nr, DIOF_TO_LEADER,
+				      iods, sgls, maps, NULL, NULL,
+				      dsc_scheduler(), &task);
 	if (rc)
 		return rc;
 


### PR DESCRIPTION
Currently, we allow DAOS client to specify some internal flags for
dc_obj_fetch_task() to control the fetch behavior. These flags are
transafered via DAOS fetch external API 'flags' parameter. But the
API flags (such as the obes for conditional operation) are defined
independently from internal ones. Then it is possible that the two
sets 'flags' have the same value but with different meanings. Such
conflict is dangerous, may cause very serious issues but difficult
to debug.

This patch extends dc_obj_fetch_task_create() function to transfer
DAOS internal fetch flags via independent parameter.

It re-organizes dc_obj_fetch_shard_task_create(), merges realted
functionality (fetching data from specified shard) with function
dc_obj_fetch_task_create(), more cleanup the code.

Signed-off-by: Fan Yong <fan.yong@intel.com>