### PR TITLE
DAOS-623 build: Remove fio and fix minor build issue

### DIFF
--- a/src/vos/vos_internal.h
+++ b/src/vos/vos_internal.h
@@ -243,7 +243,6 @@ struct vos_dtx_act_ent {
 
 extern struct vos_tls	*standalone_tls;
 #ifdef VOS_STANDALONE
-unsigned int tmp_count;
 #define VOS_TIME_START(start, op)		\
 do {						\
 	if (standalone_tls->vtl_dp == NULL)	\

--- a/utils/sl/components/__init__.py
+++ b/utils/sl/components/__init__.py
@@ -283,13 +283,6 @@ def define_components(reqs):
     reqs.define('fuse', libs=['fuse3'], defines=["FUSE_USE_VERSION=35"],
                 headers=['fuse3/fuse.h'], package='fuse3-devel')
 
-    reqs.define('fio',
-                retriever=GitRepoRetriever(
-                    'https://github.com/axboe/fio.git'),
-                commands=['./configure --prefix="$FIO_PREFIX"',
-                          'make $JOBS_OPT', 'make install'],
-                progs=['genfio', 'fio'])
-
     retriever = GitRepoRetriever("https://github.com/spdk/spdk.git", True)
     reqs.define('spdk',
                 retriever=retriever,


### PR DESCRIPTION
Unused variable declared in header file reported by
Jerome Soumagne
Also remove unused fio definition

Signed-off-by: Jeff Olivier <jeffrey.v.olivier@intel.com>