### PR TITLE
DAOS-4818 dtx: use zero sub_modification_cnt for read only DTX

### DIFF
--- a/src/object/srv_obj.c
+++ b/src/object/srv_obj.c
@@ -1913,7 +1913,7 @@ obj_local_enum(struct obj_io_context *ioc, crt_rpc_t *rpc,
 	 * is our epoch. (See dc_obj_shard_list.)
 	 */
 	rc = dtx_begin(ioc->ioc_coc, &oei->oei_dti, oei->oei_epr.epr_hi,
-		       oei->oei_flags & ORF_EPOCH_UNCERTAIN, 1,
+		       oei->oei_flags & ORF_EPOCH_UNCERTAIN, 0,
 		       oei->oei_map_ver, &oei->oei_oid, NULL, 0, NULL, &dth);
 	D_ASSERTF(rc == 0, "%d\n", rc);
 
@@ -2505,7 +2505,7 @@ ds_obj_query_key_handler(crt_rpc_t *rpc)
 		akey = &okqo->okqo_akey;
 
 	rc = dtx_begin(ioc.ioc_coc, &okqi->okqi_dti, okqi->okqi_epoch,
-		       okqi->okqi_flags & ORF_EPOCH_UNCERTAIN, 1,
+		       okqi->okqi_flags & ORF_EPOCH_UNCERTAIN, 0,
 		       okqi->okqi_map_ver, &okqi->okqi_oid, NULL, 0, NULL,
 		       &dth);
 	D_ASSERTF(rc == 0, "%d\n", rc);


### PR DESCRIPTION
For standalone enumerate and query case, the DTX is read only.
Under such case, we should use "0" zero "sub_modification_cnt"
for dtx_begin().

Signed-off-by: Fan Yong <fan.yong@intel.com>