### PR TITLE
DAOS-4717 dtx: shrink batched commit age

### DIFF
--- a/src/container/srv_target.c
+++ b/src/container/srv_target.c
@@ -51,12 +51,13 @@
 /* Per VOS container aggregation ULT ***************************************/
 
 /*
- * DTX batched commit may delay the commit for at most 60 seconds,
- * so we have to use a larger threshold to ensure that all transactions
- * within the aggregation epoch range are either committed or to be
- * aborted.
+ * VOS aggregation should try to avoid aggregating in the epoch range where
+ * lots of data records are pending to commit, so the highest aggregate epoch
+ * will be:
+ *
+ * current HLC - (DTX batched commit threshold + buffer period)
  */
-#define DAOS_AGG_THRESHOLD	90 /* seconds */
+#define DAOS_AGG_THRESHOLD	(DTX_COMMIT_THRESHOLD_AGE + 10) /* seconds */
 
 static inline bool
 cont_aggregate_yield(void *arg)

--- a/src/include/daos/dtx.h
+++ b/src/include/daos/dtx.h
@@ -34,8 +34,8 @@
  */
 #define DTX_THRESHOLD_COUNT		(1 << 9)
 
-/* The time (in second) threshould for batched DTX commit. */
-#define DTX_COMMIT_THRESHOLD_AGE	60
+/* The time (in second) threshold for batched DTX commit. */
+#define DTX_COMMIT_THRESHOLD_AGE	10
 
 enum dtx_target_flags {
 	DTF_RDONLY			= (1 << 0),


### PR DESCRIPTION
Shrink DTX batched commit age from 60 seconds to 10 seconds, so
that VOS aggregation can aggregate on more recent data and reclaim
space promptly.

TODO list:
- VOS aggregation will have to check DTX state of data record and
  skip merging any data records in prepared sate. (when commit or
  abort from leader are delayed for too long somehow)
- DTX aggregation will have to ensure transactions end up with
  committed or aborted state eventually.

Signed-off-by: Niu Yawei <yawei.niu@intel.com>
