### PR TITLE
DAOS-5150 control: Allow VFIO to be optionally disabled

### DIFF
--- a/src/control/fault/code/codes.go
+++ b/src/control/fault/code/codes.go
@@ -129,6 +129,7 @@ const (
 	ServerDataPlaneNotStarted
 	ServerInstancesNotStopped
 	ServerConfigInvalidNetDevClass
+	ServerVfioDisabled
 
 	// spdk library bindings codes
 	SpdkUnknown Code = iota + 700

--- a/src/control/server/config.go
+++ b/src/control/server/config.go
@@ -71,6 +71,7 @@ type Configuration struct {
 	Servers             []*ioserver.Config        `yaml:"servers"`
 	BdevInclude         []string                  `yaml:"bdev_include,omitempty"`
 	BdevExclude         []string                  `yaml:"bdev_exclude,omitempty"`
+	DisableVFIO         bool                      `yaml:"disable_vfio"`
 	NrHugepages         int                       `yaml:"nr_hugepages"`
 	SetHugepages        bool                      `yaml:"set_hugepages"`
 	ControlLogMask      ControlLogLevel           `yaml:"control_log_mask"`
@@ -266,6 +267,14 @@ func (c *Configuration) WithBdevExclude(bList ...string) *Configuration {
 // WithBdevInclude sets the block device include list.
 func (c *Configuration) WithBdevInclude(bList ...string) *Configuration {
 	c.BdevInclude = bList
+	return c
+}
+
+// WithDisableVFIO indicates that the vfio-pci driver should not be
+// used by SPDK even if an IOMMU is detected. Note that this option
+// requires that DAOS be run as root.
+func (c *Configuration) WithDisableVFIO() *Configuration {
+	c.DisableVFIO = true
 	return c
 }
 

--- a/src/control/server/config_test.go
+++ b/src/control/server/config_test.go
@@ -228,6 +228,7 @@ func TestServer_ConstructedConfig(t *testing.T) {
 		WithControlPort(10001).
 		WithBdevInclude("0000:81:00.1", "0000:81:00.2", "0000:81:00.3").
 		WithBdevExclude("0000:81:00.1").
+		WithDisableVFIO().
 		WithNrHugePages(4096).
 		WithControlLogMask(ControlLogLevelError).
 		WithControlLogFile("/tmp/daos_control.log").

--- a/src/control/server/faults.go
+++ b/src/control/server/faults.go
@@ -74,6 +74,11 @@ var (
 		"no IOMMU detected while running as non-root user with NVMe devices",
 		"enable IOMMU per the DAOS Admin Guide or run daos_server as root",
 	)
+	FaultVfioDisabled = serverFault(
+		code.ServerVfioDisabled,
+		"disable_vfio: true in config while running as non-root user with NVMe devices",
+		"set disable_vfio: false or run daos_server as root",
+	)
 	FaultHarnessNotStarted = serverFault(
 		code.ServerHarnessNotStarted,
 		fmt.Sprintf("%s harness not started", DataPlaneName),

--- a/src/control/server/init/setup_spdk.sh
+++ b/src/control/server/init/setup_spdk.sh
@@ -78,8 +78,11 @@ if [[ $1 == reset ]]; then
 	"$scriptpath" reset
 else
 	# avoid shadowing by prefixing input envars
-	PCI_WHITELIST="$_PCI_WHITELIST" NRHUGE="$_NRHUGE" \
-	TARGET_USER="$_TARGET_USER" "$scriptpath"
+	PCI_WHITELIST="$_PCI_WHITELIST" \
+	NRHUGE="$_NRHUGE" \
+	TARGET_USER="$_TARGET_USER" \
+	DRIVER_OVERRIDE="$_DRIVER_OVERRIDE" \
+	"$scriptpath"
 
 	# build arglist manually to filter missing directories/files
 	# so we don't error on non-existent entities

--- a/src/control/server/storage/bdev/backend.go
+++ b/src/control/server/storage/bdev/backend.go
@@ -217,8 +217,8 @@ func (b *spdkBackend) Format(pciAddr string) (*storage.NvmeController, error) {
 	return ctrlr, nil
 }
 
-func (b *spdkBackend) Prepare(nrHugePages int, targetUser, pciWhiteList string) error {
-	return b.script.Prepare(nrHugePages, targetUser, pciWhiteList)
+func (b *spdkBackend) Prepare(req PrepareRequest) error {
+	return b.script.Prepare(req)
 }
 
 func (b *spdkBackend) Reset() error {

--- a/src/control/server/storage/bdev/mocks.go
+++ b/src/control/server/storage/bdev/mocks.go
@@ -1,5 +1,5 @@
 //
-// (C) Copyright 2019 Intel Corporation.
+// (C) Copyright 2019-2020 Intel Corporation.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -109,7 +109,7 @@ func (mb *MockBackend) Reset() error {
 	return mb.cfg.ResetErr
 }
 
-func (mb *MockBackend) Prepare(_ int, _, _ string) error {
+func (mb *MockBackend) Prepare(_ PrepareRequest) error {
 	return mb.cfg.PrepareErr
 }
 

--- a/src/control/server/storage/bdev/provider.go
+++ b/src/control/server/storage/bdev/provider.go
@@ -1,5 +1,5 @@
 //
-// (C) Copyright 2019 Intel Corporation.
+// (C) Copyright 2019-2020 Intel Corporation.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -58,6 +58,7 @@ type (
 		PCIWhitelist  string
 		TargetUser    string
 		ResetOnly     bool
+		DisableVFIO   bool
 	}
 
 	// PrepareResponse contains the results of a successful Prepare operation.
@@ -89,7 +90,7 @@ type (
 	Backend interface {
 		Init(shmID ...int) error
 		Reset() error
-		Prepare(hugePageCount int, targetUser string, pciWhitelist string) error
+		Prepare(PrepareRequest) error
 		Scan() (storage.NvmeControllers, error)
 		Format(pciAddr string) (*storage.NvmeController, error)
 	}
@@ -168,7 +169,7 @@ func (p *Provider) Prepare(req PrepareRequest) (*PrepareResponse, error) {
 		return res, nil
 	}
 
-	if err := p.backend.Prepare(req.HugePageCount, req.TargetUser, req.PCIWhitelist); err != nil {
+	if err := p.backend.Prepare(req); err != nil {
 		return nil, errors.WithMessage(err, "SPDK prepare")
 	}
 

--- a/src/control/server/storage/bdev/runner_test.go
+++ b/src/control/server/storage/bdev/runner_test.go
@@ -74,12 +74,14 @@ func TestBdevRunnerPrepare(t *testing.T) {
 				HugePageCount: testNrHugePages,
 				TargetUser:    testTargetUser,
 				PCIWhitelist:  testPciWhitelist,
+				DisableVFIO:   true,
 			},
 			expEnv: []string{
 				fmt.Sprintf("PATH=%s", os.Getenv("PATH")),
 				fmt.Sprintf("%s=%d", nrHugepagesEnv, testNrHugePages),
 				fmt.Sprintf("%s=%s", targetUserEnv, testTargetUser),
 				fmt.Sprintf("%s=%s", pciWhiteListEnv, testPciWhitelist),
+				fmt.Sprintf("%s=%s", driverOverrideEnv, vfioDisabledDriver),
 			},
 		},
 	} {

--- a/utils/config/daos_server.yml
+++ b/utils/config/daos_server.yml
@@ -102,6 +102,15 @@
 #bdev_exclude: ["0000:81:00.1"]
 #
 #
+## Disable VFIO Driver
+#
+## In some circumstances it may be preferable to force SPDK to use the UIO
+## driver for NVMe device access even though an IOMMU is available. Note
+## that use of the UIO driver requires that DAOS must run as root.
+#
+#disable_vfio: true
+#
+#
 ## Use Hyperthreads
 #
 ## When Hyperthreading is enabled and supported on the system, this parameter


### PR DESCRIPTION
In some circumstances it is desirable to force SPDK to
use the UIO driver even when an IOMMU is present. Setting
vfio_disabled: true in the server config will prevent
automatic use of the VFIO driver.