### PR TITLE
DAOS-5238 vos: Add vos_obj_array_remove API to handle epr lower bound

### DIFF
--- a/src/include/daos/mem.h
+++ b/src/include/daos/mem.h
@@ -435,7 +435,7 @@ umem_tx_abort(struct umem_instance *umm, int err)
 	if (umm->umm_ops->mo_tx_abort)
 		return umm->umm_ops->mo_tx_abort(umm, err);
 	else
-		return 0;
+		return err;
 }
 
 static inline int

--- a/src/include/daos_srv/evtree.h
+++ b/src/include/daos_srv/evtree.h
@@ -559,15 +559,15 @@ int evt_delete(daos_handle_t toh, const struct evt_rect *rect,
  * specified epoch. The range must only cover whole extents.   If any
  * partial extents are in the range, the function fails.
  *
- * \param toh		[IN]	The tree open handle
- * \param ext		[IN]	The extent range
- * \param epoch		[IN]	High epoch
+ * \param[in] toh	The tree open handle
+ * \param[in] ext	The extent range
+ * \param[in] epr	Epoch range
  *
  * \return	0		Success
  *		-DER_NOPERM	Partial overlaps found
  */
 int evt_remove_all(daos_handle_t toh, const struct evt_extent *ext,
-		   daos_epoch_t epoch);
+		   const daos_epoch_range_t *epr);
 
 /**
  * Search the tree and return all visible versioned extents which overlap with

--- a/src/include/daos_srv/vos.h
+++ b/src/include/daos_srv/vos.h
@@ -460,6 +460,25 @@ vos_obj_update(daos_handle_t coh, daos_unit_oid_t oid, daos_epoch_t epoch,
 	       struct dcs_iod_csums *iods_csums, d_sg_list_t *sgls);
 
 /**
+ * Remove all array values within the specified range.  If the specified
+ * extent and epoch range includes partial extents, the function will
+ * fail and no changes will be made.
+ *
+ * \param[in]	coh	Container open handle
+ * \param[in]	oid	object ID
+ * \param[in]	epr	Epoch range
+ * \param[in]	dkey	Distribution key
+ * \param[in]	akey	Attribute key
+ * \param[in]	recx	Extent range to remove
+ *
+ * \return		Zero on success, negative value if error
+ */
+int
+vos_obj_array_remove(daos_handle_t coh, daos_unit_oid_t oid,
+		     const daos_epoch_range_t *epr, const daos_key_t *dkey,
+		     const daos_key_t *akey, const daos_recx_t *recx);
+
+/**
  * Punch an object, or punch a dkey, or punch an array of akeys under a akey.
  *
  * \param coh	[IN]	Container open handle

--- a/src/include/daos_srv/vos_types.h
+++ b/src/include/daos_srv/vos_types.h
@@ -220,7 +220,7 @@ enum {
 	/* critical update - skip checks on SCM system/held space */
 	VOS_OF_CRIT		= (1 << 9),
 	/** Instead of update or punch of extents, remove all extents
-	 * under the specified range
+	 * under the specified range. Intended for internal use only.
 	 */
 	VOS_OF_REMOVE		= (1 << 10),
 };

--- a/src/vos/evtree.c
+++ b/src/vos/evtree.c
@@ -3230,7 +3230,7 @@ int evt_delete(daos_handle_t toh, const struct evt_rect *rect,
 
 int
 evt_remove_all(daos_handle_t toh, const struct evt_extent *ext,
-	       daos_epoch_t epoch)
+	       const daos_epoch_range_t *epr)
 {
 	struct evt_context	*tcx;
 	struct evt_entry	*entry;
@@ -3244,14 +3244,13 @@ evt_remove_all(daos_handle_t toh, const struct evt_extent *ext,
 		return -DER_NO_HDL;
 
 	rect.rc_ex = *ext;
-	rect.rc_epc = epoch;
+	rect.rc_epc = epr->epr_hi;
 	rect.rc_minor_epc = EVT_MINOR_EPC_MAX;
 
 	evt_ent_array_init(&ent_array);
 
 	filter.fr_ex = rect.rc_ex;
-	filter.fr_epr.epr_lo = 0;
-	filter.fr_epr.epr_hi = rect.rc_epc;
+	filter.fr_epr = *epr;
 	filter.fr_punch = 0;
 	rc = evt_ent_array_fill(tcx, EVT_FIND_ALL, DAOS_INTENT_PURGE,
 				&filter, &rect, &ent_array);

--- a/src/vos/tests/evt_ctl.c
+++ b/src/vos/tests/evt_ctl.c
@@ -439,10 +439,11 @@ ts_delete_rect(void **state)
 static void
 ts_remove_rect(void **state)
 {
+	char			*arg;
 	struct evt_rect		 rect;
+	daos_epoch_range_t	 epr;
 	int			 rc;
 	bool			 should_pass;
-	char			*arg;
 
 	arg = tst_fn_val.optval;
 	if (arg == NULL)
@@ -455,7 +456,9 @@ ts_remove_rect(void **state)
 	D_PRINT("Remove all "DF_RECT" expect_pass=%s\n", DP_RECT(&rect),
 		should_pass ? "true" : "false");
 
-	rc = evt_remove_all(ts_toh, &rect.rc_ex, rect.rc_epc);
+	epr.epr_lo = 0;
+	epr.epr_hi = rect.rc_epc;
+	rc = evt_remove_all(ts_toh, &rect.rc_ex, &epr);
 
 	if (should_pass) {
 		if (rc != 0)

--- a/src/vos/vos_io.c
+++ b/src/vos/vos_io.c
@@ -1151,7 +1151,7 @@ akey_update_recx(daos_handle_t toh, uint32_t pm_ver, daos_recx_t *recx,
 	ent.ei_addr = biov->bi_addr;
 
 	if (ioc->ic_remove)
-		return evt_remove_all(toh, &ent.ei_rect.rc_ex, epoch);
+		return evt_remove_all(toh, &ent.ei_rect.rc_ex, &ioc->ic_epr);
 
 	rc = evt_insert(toh, &ent, NULL);
 
@@ -1977,6 +1977,39 @@ vos_obj_update(daos_handle_t coh, daos_unit_oid_t oid, daos_epoch_t epoch,
 	}
 
 	rc = vos_update_end(ioh, pm_ver, dkey, rc, NULL);
+	return rc;
+}
+
+int
+vos_obj_array_remove(daos_handle_t coh, daos_unit_oid_t oid,
+		     const daos_epoch_range_t *epr, const daos_key_t *dkey,
+		     const daos_key_t *akey, const daos_recx_t *recx)
+{
+	struct vos_io_context	*ioc;
+	daos_iod_t		 iod;
+	daos_handle_t		 ioh;
+	int			 rc;
+
+	iod.iod_type = DAOS_IOD_ARRAY;
+	iod.iod_recxs = (daos_recx_t *)recx;
+	iod.iod_nr = 1;
+	iod.iod_name = *akey;
+	iod.iod_size = 0;
+
+	rc = vos_update_begin(coh, oid, epr->epr_hi, VOS_OF_REMOVE,
+			      (daos_key_t *)dkey, 1, &iod, NULL, &ioh, NULL);
+	if (rc) {
+		D_ERROR("Update "DF_UOID" failed "DF_RC"\n", DP_UOID(oid),
+			DP_RC(rc));
+		return rc;
+	}
+
+	ioc = vos_ioh2ioc(ioh);
+	/** Set lower bound of epoch range */
+	ioc->ic_epr.epr_lo = epr->epr_lo;
+
+	rc = vos_update_end(ioh, 0 /* don't care */, (daos_key_t *)dkey, rc,
+			    NULL);
 	return rc;
 }
 


### PR DESCRIPTION
In order to support snapshot preservation with EC aggregation, we need
a lower bound.  Since vos_obj_update takes no such parameter, add a new
API for this purpose.

Signed-off-by: Jeff Olivier <jeffrey.v.olivier@intel.com>