### PR TITLE
DAOS-3800 object: fix client side stack overflow

### DIFF
--- a/src/object/cli_obj.c
+++ b/src/object/cli_obj.c
@@ -40,7 +40,7 @@
 #define CLI_OBJ_IO_PARMS	8
 #define NIL_BITMAP		(NULL)
 
-#define OBJ_TGT_INLINE_NR	(23)
+#define OBJ_TGT_INLINE_NR	(22)
 struct obj_req_tgts {
 	/* to save memory allocation if #targets <= OBJ_TGT_INLINE_NR */
 	struct daos_shard_tgt	 ort_tgts_inline[OBJ_TGT_INLINE_NR];


### PR DESCRIPTION
Shrink obj_auxi_args to avoid client side stack overflow.

Signed-off-by: Fan Yong <fan.yong@intel.com>