### PR TITLE
DAOS-623 java: Update log4j-core version due to security alert (#3027)

### DIFF
--- a/src/client/java/pom.xml
+++ b/src/client/java/pom.xml
@@ -25,7 +25,7 @@
     <junit.platform.version>1.4.0</junit.platform.version>
     <junit.jupiter.version>5.4.0</junit.jupiter.version>
     <slf4j.version>1.7.25</slf4j.version>
-    <log4j.version>2.11.1</log4j.version>
+    <log4j.version>2.13.3</log4j.version>
     <forkCount>2</forkCount>
     <checkstyle.failOnViolation>true</checkstyle.failOnViolation>
     <maven.compiler.source>1.8</maven.compiler.source>

--- a/utils/build.config
+++ b/utils/build.config
@@ -8,6 +8,7 @@ PMDK = 1.8
 ISAL = v2.26.0
 SPDK = v19.04.1
 FUSE = fuse-3.6.1
+FIO = fio-3.20
 
 [configs]
 cart=utils/build.config


### PR DESCRIPTION
Update to version 2.13.3 or greater due to github security alert

Also, we need to use a fixed version of fio in the SPDK build to ensure it can always build.

Signed-off-by: Jeff Olivier <jeffrey.v.olivier@intel.com>