### PR TITLE
DAOS-5269 cart: optimize (un)packing

### DIFF
--- a/src/cart/src/include/cart/api.h
+++ b/src/cart/src/include/cart/api.h
@@ -1344,6 +1344,8 @@ typedef enum {
 	CRT_PROC_FREE
 } crt_proc_op_t;
 
+#define crt_proc_raw crt_proc_memcpy
+
 /**
  * Get the operation type associated to the proc processor.
  *
@@ -1357,7 +1359,6 @@ crt_proc_get_op(crt_proc_t proc, crt_proc_op_t *proc_op);
 
 /**
  * Base proc routine using memcpy().
- * Only uses memcpy() / use crt_proc_raw() for encoding raw buffers.
  *
  * \param[in,out] proc         abstract processor object
  * \param[in,out] data         pointer to data
@@ -1466,18 +1467,6 @@ crt_proc_uint64_t(crt_proc_t proc, uint64_t *data);
  */
 int
 crt_proc_bool(crt_proc_t proc, bool *data);
-
-/**
- * Generic processing routine.
- *
- * \param[in,out] proc         abstract processor object
- * \param[in,out] buf          pointer to buffer
- * \param[in] buf_size         buffer size
- *
- * \return                     DER_SUCCESS on success, negative value if error
- */
-int
-crt_proc_raw(crt_proc_t proc, void *buf, size_t buf_size);
 
 /**
  * Generic processing routine.

--- a/src/common/proc.c
+++ b/src/common/proc.c
@@ -61,7 +61,7 @@ crt_proc_struct_daos_acl(crt_proc_t proc, struct daos_acl **data)
 		*data = (struct daos_acl *)iov.iov_buf;
 		break;
 	case CRT_PROC_FREE:
-		daos_acl_free(*data);
+		*data = NULL;
 		break;
 	default:
 		D_ERROR("bad proc_op %d.\n", proc_op);


### PR DESCRIPTION
Don't memcpy inline data and use pointer in request buffer instead.
Use direct assignment for basic types instead of memcpy.

Signed-off-by: Johann Lombardi <johann.lombardi@intel.com>