### PR TITLE
DAOS-4855 log: disable client logging by default

### DIFF
--- a/doc/admin/troubleshooting.md
+++ b/doc/admin/troubleshooting.md
@@ -73,8 +73,8 @@ DEBUG-level logging will be sent to the specified file.
 
 DAOS uses the debug system defined in
 [CaRT](https://github.com/daos-stack/cart) but more specifically the
-GURT library. Log files for both client and server are written to
-"/tmp/daos.log" unless otherwise set by D_LOG_FILE.
+GURT library. Default server log is "/tmp/daos.log" and client default
+log is stdout, unless otherwise set by `D_LOG_FILE`.
 
 ### Registered Subsystems/Facilities
 

--- a/doc/debugging.md
+++ b/doc/debugging.md
@@ -1,8 +1,8 @@
 # DAOS Debugging
 
 DAOS uses the debug system defined in [CaRT](https://github.com/daos-stack/cart)
-but more specifically the GURT library. Logging for both client and server are
-written to "/tmp/daos.log" unless otherwise set by `D_LOG_FILE`.
+but more specifically the GURT library. Default server log is "/tmp/daos.log"
+and client default log is stdout, unless otherwise set by `D_LOG_FILE`.
 
 ## Registered Subsystems/Facilities
 

--- a/src/bio/smd/tests/smd_ut.c
+++ b/src/bio/smd/tests/smd_ut.c
@@ -41,7 +41,7 @@ smd_ut_setup(void **state)
 {
 	int	rc;
 
-	rc = daos_debug_init(NULL);
+	rc = daos_debug_init(DAOS_LOG_DEFAULT);
 	if (rc) {
 		print_error("Error initializing the debug instance\n");
 		return rc;

--- a/src/client/api/tests/eq_tests.c
+++ b/src/client/api/tests/eq_tests.c
@@ -990,7 +990,7 @@ main(int argc, char **argv)
 
 	setenv("OFI_INTERFACE", "lo", 1);
 
-	rc = daos_debug_init(NULL);
+	rc = daos_debug_init(DAOS_LOG_DEFAULT);
 	if (rc != 0) {
 		print_error("Failed daos_debug_init: %d\n", rc);
 		return rc;

--- a/src/client/dfuse/dfuse_main.c
+++ b/src/client/dfuse/dfuse_main.c
@@ -150,7 +150,7 @@ main(int argc, char **argv)
 		{0, 0, 0, 0}
 	};
 
-	rc = daos_debug_init(NULL);
+	rc = daos_debug_init(DAOS_LOG_DEFAULT);
 	if (rc != 0)
 		D_GOTO(out, rc);
 

--- a/src/common/debug.c
+++ b/src/common/debug.c
@@ -29,9 +29,6 @@
 #include <limits.h>
 #include <daos/common.h>
 
-/* default debug log file */
-#define DAOS_LOG_DEFAULT	"/tmp/daos.log"
-
 #define DAOS_DBG_MAX_LEN	(32)
 #define DAOS_FAC_MAX_LEN	(128)
 
@@ -146,7 +143,8 @@ daos_debug_fini(void)
 int
 daos_debug_init(char *logfile)
 {
-	int		rc;
+	int	flags = DLOG_FLV_FAC | DLOG_FLV_LOGPID | DLOG_FLV_TAG;
+	int	rc;
 
 	D_MUTEX_LOCK(&dd_lock);
 	if (dd_ref > 0) {
@@ -155,15 +153,15 @@ daos_debug_init(char *logfile)
 		return 0;
 	}
 
-	if (getenv(D_LOG_FILE_ENV)) /* honor the env variable first */
-		logfile = getenv(D_LOG_FILE_ENV);
-	else if (logfile == NULL)
-		logfile = DAOS_LOG_DEFAULT;
+	/* honor the env variable first */
+	logfile = getenv(D_LOG_FILE_ENV);
+	if (logfile == NULL || strlen(logfile) == 0) {
+		flags |= DLOG_FLV_STDOUT;
+		logfile = NULL;
+	}
 
 
-	rc = d_log_init_adv("DAOS", logfile,
-			    DLOG_FLV_FAC | DLOG_FLV_LOGPID | DLOG_FLV_TAG,
-			    DLOG_INFO, DLOG_CRIT);
+	rc = d_log_init_adv("DAOS", logfile, flags, DLOG_INFO, DLOG_CRIT);
 	if (rc != 0) {
 		D_PRINT_ERR("Failed to init DAOS debug log: "DF_RC"\n",
 			DP_RC(rc));

--- a/src/common/tests/btree.c
+++ b/src/common/tests/btree.c
@@ -1021,7 +1021,7 @@ main(int argc, char **argv)
 	ik_toh = DAOS_HDL_INVAL;
 	ik_root_off = UMOFF_NULL;
 
-	rc = daos_debug_init(NULL);
+	rc = daos_debug_init(DAOS_LOG_DEFAULT);
 	if (rc != 0)
 		return rc;
 

--- a/src/common/tests/btree_direct.c
+++ b/src/common/tests/btree_direct.c
@@ -1160,7 +1160,7 @@ main(int argc, char **argv)
 	sk_toh = DAOS_HDL_INVAL;
 	sk_root_off = UMOFF_NULL;
 
-	rc = daos_debug_init(NULL);
+	rc = daos_debug_init(DAOS_LOG_DEFAULT);
 	if (rc != 0)
 		return rc;
 

--- a/src/common/tests/lru.c
+++ b/src/common/tests/lru.c
@@ -114,7 +114,7 @@ main(int argc, char **argv)
 	struct daos_llink	*link_ret[3] = {NULL};
 	struct daos_lru_cache	*tcache = NULL;
 
-	rc = daos_debug_init(NULL);
+	rc = daos_debug_init(DAOS_LOG_DEFAULT);
 	if (rc != 0)
 		return rc;
 

--- a/src/common/tests/other.c
+++ b/src/common/tests/other.c
@@ -100,7 +100,7 @@ main(int argc, char **argv)
 	int	opc;
 	int	rc = 0;
 
-	rc = daos_debug_init(NULL);
+	rc = daos_debug_init(DAOS_LOG_DEFAULT);
 	if (rc != 0)
 		return rc;
 

--- a/src/common/tests/sched.c
+++ b/src/common/tests/sched.c
@@ -825,7 +825,7 @@ main(int argc, char **argv)
 	int		test_fail = 0;
 	int		rc;
 
-	rc = daos_debug_init(NULL);
+	rc = daos_debug_init(DAOS_LOG_DEFAULT);
 	if (rc != 0)
 		return rc;
 

--- a/src/include/daos/common.h
+++ b/src/include/daos/common.h
@@ -740,4 +740,7 @@ daos_unparse_ctype(daos_cont_layout_t ctype, char *string)
 	}
 }
 
+/* default debug log file */
+#define DAOS_LOG_DEFAULT	"/tmp/daos.log"
+
 #endif /* __DAOS_COMMON_H__ */

--- a/src/iosrv/init.c
+++ b/src/iosrv/init.c
@@ -465,7 +465,7 @@ server_init(int argc, char *argv[])
 	char		hostname[256] = { 0 };
 	int		rc;
 
-	rc = daos_debug_init(NULL);
+	rc = daos_debug_init(DAOS_LOG_DEFAULT);
 	if (rc != 0)
 		return rc;
 

--- a/src/placement/tests/jump_map_place_obj.c
+++ b/src/placement/tests/jump_map_place_obj.c
@@ -446,7 +446,7 @@ main(int argc, char **argv)
 	int			 oc_index;
 	int			 rc;
 
-	rc = daos_debug_init(NULL);
+	rc = daos_debug_init(DAOS_LOG_DEFAULT);
 	if (rc != 0)
 		return rc;
 

--- a/src/placement/tests/pl_bench.c
+++ b/src/placement/tests/pl_bench.c
@@ -688,7 +688,7 @@ main(int argc, char **argv)
 		print_usage(argv[0], op_names, ARRAY_SIZE(op_names));
 		return -1;
 	}
-	rc = daos_debug_init(NULL);
+	rc = daos_debug_init(DAOS_LOG_DEFAULT);
 	if (rc != 0)
 		return rc;
 

--- a/src/placement/tests/ring_map_place_obj.c
+++ b/src/placement/tests/ring_map_place_obj.c
@@ -58,7 +58,7 @@ main(int argc, char **argv)
 	uint32_t                 reint_tgts[SPARE_MAX_NUM];
 
 	po_ver = 1;
-	rc = daos_debug_init(NULL);
+	rc = daos_debug_init(DAOS_LOG_DEFAULT);
 	if (rc != 0)
 		return rc;
 

--- a/src/tests/dts_common.c
+++ b/src/tests/dts_common.c
@@ -340,7 +340,7 @@ dts_ctx_init(struct dts_context *tsc)
 	int	rc;
 
 	tsc->tsc_init = DTS_INIT_NONE;
-	rc = daos_debug_init(NULL);
+	rc = daos_debug_init(DAOS_LOG_DEFAULT);
 	if (rc)
 		goto out;
 	tsc->tsc_init = DTS_INIT_DEBUG;

--- a/src/vea/tests/vea_ut.c
+++ b/src/vea/tests/vea_ut.c
@@ -492,7 +492,7 @@ vea_ut_setup(void **state)
 {
 	int rc;
 
-	rc = daos_debug_init(NULL);
+	rc = daos_debug_init(DAOS_LOG_DEFAULT);
 	if (rc != 0)
 		return rc;
 

--- a/src/vos/tests/evt_ctl.c
+++ b/src/vos/tests/evt_ctl.c
@@ -2381,7 +2381,7 @@ main(int argc, char **argv)
 
 	ts_toh = DAOS_HDL_INVAL;
 
-	rc = daos_debug_init(NULL);
+	rc = daos_debug_init(DAOS_LOG_DEFAULT);
 	if (rc != 0)
 		return rc;
 

--- a/src/vos/tests/vos_size.c
+++ b/src/vos/tests/vos_size.c
@@ -181,7 +181,7 @@ main(int argc, char **argv)
 	int				 index = 0;
 	int				 opt = 0;
 
-	rc = daos_debug_init(NULL);
+	rc = daos_debug_init(DAOS_LOG_DEFAULT);
 	if (rc) {
 		printf("Error initializing debug system\n");
 		return rc;

--- a/src/vos/tests/vos_tests.c
+++ b/src/vos/tests/vos_tests.c
@@ -160,7 +160,7 @@ main(int argc, char **argv)
 
 	d_register_alt_assert(mock_assert);
 
-	rc = daos_debug_init(NULL);
+	rc = daos_debug_init(DAOS_LOG_DEFAULT);
 	if (rc) {
 		print_error("Error initializing debug system\n");
 		return rc;

--- a/src/vos/tests/vts_common.c
+++ b/src/vos/tests/vts_common.c
@@ -323,7 +323,7 @@ dts_ctx_init(struct dts_context *tsc)
 	int	rc;
 
 	tsc->tsc_init = DTS_INIT_NONE;
-	rc = daos_debug_init(NULL);
+	rc = daos_debug_init(DAOS_LOG_DEFAULT);
 	if (rc)
 		goto out;
 	tsc->tsc_init = DTS_INIT_DEBUG;


### PR DESCRIPTION
Use D_LOG_FILE_ENV env var setting or not to determine
if/where logging should occur, for clients. Continue to
use DAOS_LOG_DEFAULT for tests and by default for servers.

Change-Id: I5eda2857a27ebade21f5775345f33a9ee5bf7ae8
Signed-off-by: Bruno Faccini <bruno.faccini@intel.com>