### PR TITLE
DAOS-5274 pool: Create pool/container hld uuid

### DIFF
--- a/src/include/daos_srv/container.h
+++ b/src/include/daos_srv/container.h
@@ -54,6 +54,9 @@ int ds_cont_svc_set_prop(uuid_t pool_uuid, uuid_t cont_uuid,
 int ds_cont_list(uuid_t pool_uuid, struct daos_pool_cont_info **conts,
 		 uint64_t *ncont);
 
+int ds_cont_tgt_close(uuid_t hdl_uuid);
+int ds_cont_tgt_open(uuid_t pool_uuid, uuid_t cont_hdl_uuid,
+		     uuid_t cont_uuid, uint64_t flags, uint64_t sec_capas);
 /*
  * Per-thread container (memory) object
  *

--- a/src/include/daos_srv/daos_server.h
+++ b/src/include/daos_srv/daos_server.h
@@ -823,4 +823,6 @@ void dss_init_state_set(enum dss_init_state state);
 
 int notify_bio_error(int media_err_type, int tgt_id);
 
+bool is_container_from_srv(uuid_t pool_uuid, uuid_t coh_uuid);
+bool is_pool_from_srv(uuid_t pool_uuid, uuid_t poh_uuid);
 #endif /* __DSS_API_H__ */

--- a/src/include/daos_srv/iv.h
+++ b/src/include/daos_srv/iv.h
@@ -290,6 +290,7 @@ enum iv_key {
 	IV_CONT_CAPA,
 	/* Container properties */
 	IV_CONT_PROP,
+	IV_POOL_HDL,
 };
 
 int ds_iv_fetch(struct ds_iv_ns *ns, struct ds_iv_key *key, d_sg_list_t *value,

--- a/src/include/daos_srv/pool.h
+++ b/src/include/daos_srv/pool.h
@@ -191,6 +191,9 @@ int ds_pool_iv_map_update(struct ds_pool *pool, struct pool_buf *buf,
 int ds_pool_iv_prop_update(struct ds_pool *pool, daos_prop_t *prop);
 int ds_pool_iv_prop_fetch(struct ds_pool *pool, daos_prop_t *prop);
 
+int ds_pool_iv_srv_hdl_fetch(struct ds_pool *pool, uuid_t *pool_hdl_uuid,
+			     uuid_t *cont_hdl_uuid);
+
 int ds_pool_svc_term_get(uuid_t uuid, uint64_t *term);
 
 int ds_pool_check_leader(uuid_t pool_uuid, daos_unit_oid_t *oid,

--- a/src/include/daos_srv/rebuild.h
+++ b/src/include/daos_srv/rebuild.h
@@ -48,9 +48,6 @@ typedef enum {
 			  (rb_op) == RB_OP_ADD ? "RB_OP_ADD" : \
 			  "RB_OP_UNKNOWN")
 
-bool is_rebuild_container(uuid_t pool_uuid, uuid_t coh_uuid);
-bool is_rebuild_pool(uuid_t pool_uuid, uuid_t poh_uuid);
-
 int ds_rebuild_schedule(const uuid_t uuid, uint32_t map_ver,
 			struct pool_target_id_list *tgts,
 			daos_rebuild_opc_t rebuild_op);

--- a/src/object/srv_obj.c
+++ b/src/object/srv_obj.c
@@ -1327,8 +1327,7 @@ obj_ioc_init(uuid_t pool_uuid, uuid_t coh_uuid, uuid_t cont_uuid, int opc,
 		D_GOTO(failed, rc = -DER_NONEXIST);
 	}
 
-	/** A rebuild container */
-	if (!is_rebuild_container(pool_uuid, coh_uuid)) {
+	if (!is_container_from_srv(pool_uuid, coh_uuid)) {
 		D_ERROR("Empty container "DF_UUID" (ref=%d) handle?\n",
 			DP_UUID(cont_uuid), coh->sch_ref);
 		D_GOTO(failed, rc = -DER_NO_HDL);
@@ -1376,7 +1375,7 @@ obj_ioc_is_rebuild_container(struct obj_io_context *ioc)
 	    ioc->ioc_coc->sc_pool == NULL)
 		return false;
 
-	return is_rebuild_container(ioc->ioc_coc->sc_pool->spc_uuid,
+	return is_container_from_srv(ioc->ioc_coc->sc_pool->spc_uuid,
 				    ioc->ioc_coh->sch_uuid);
 }
 

--- a/src/pool/srv_internal.h
+++ b/src/pool/srv_internal.h
@@ -83,6 +83,11 @@ struct pool_iv_key {
 	uint32_t	pik_entry_size; /* IV entry size */
 };
 
+struct pool_iv_hdl {
+	uuid_t		pih_pool_hdl;
+	uuid_t		pih_cont_hdl;
+};
+
 struct pool_iv_entry {
 	uuid_t				piv_pool_uuid;
 	uint32_t			piv_master_rank;
@@ -91,6 +96,7 @@ struct pool_iv_entry {
 		struct pool_iv_map	piv_map;
 		struct pool_iv_prop	piv_prop;
 		struct pool_iv_conn	piv_conn;
+		struct pool_iv_hdl	piv_hdl;
 	};
 };
 
@@ -162,6 +168,11 @@ int ds_pool_iv_fini(void);
 int pool_iv_map_fetch(void *ns, struct pool_iv_entry *pool_iv);
 void ds_pool_map_refresh_ult(void *arg);
 
-int ds_pool_iv_hdl_update(struct ds_pool *pool, uuid_t hdl_uuid,
-			  uint64_t flags, uint64_t capas, d_iov_t *cred);
+int ds_pool_iv_conn_hdl_update(struct ds_pool *pool, uuid_t hdl_uuid,
+			       uint64_t flags, uint64_t capas, d_iov_t *cred);
+
+int ds_pool_iv_srv_hdl_update(struct ds_pool *pool, uuid_t pool_hdl_uuid,
+			      uuid_t cont_hdl_uuid);
+
+int ds_pool_iv_srv_hdl_invalidate(struct ds_pool *pool);
 #endif /* __POOL_SRV_INTERNAL_H__ */

--- a/src/pool/srv_iv.c
+++ b/src/pool/srv_iv.c
@@ -26,6 +26,8 @@
 #define D_LOGFAC	DD_FAC(pool)
 
 #include <daos_srv/pool.h>
+#include <daos_srv/container.h>
+#include <daos_srv/security.h>
 #include <daos/pool_map.h>
 #include <daos_srv/iv.h>
 #include <daos_prop.h>
@@ -352,6 +354,14 @@ pool_iv_ent_copy(int class_id, d_sg_list_t *dst, d_sg_list_t *src)
 		D_DEBUG(DB_MD, "pool "DF_UUID" map ver %d\n",
 			DP_UUID(dst_iv->piv_pool_uuid),
 			dst_iv->piv_pool_map_ver);
+	} else if (class_id == IV_POOL_HDL) {
+		uuid_copy(dst_iv->piv_hdl.pih_pool_hdl,
+			  src_iv->piv_hdl.pih_pool_hdl);
+		uuid_copy(dst_iv->piv_hdl.pih_cont_hdl,
+			  src_iv->piv_hdl.pih_cont_hdl);
+		D_DEBUG(DB_MD, "pool/cont "DF_UUID"/"DF_UUID"\n",
+			DP_UUID(dst_iv->piv_hdl.pih_pool_hdl),
+			DP_UUID(dst_iv->piv_hdl.pih_cont_hdl));
 	} else {
 		D_ERROR("bad class id %d\n", class_id);
 		return -DER_INVAL;
@@ -439,8 +449,14 @@ pool_iv_ent_refresh(struct ds_iv_entry *entry, struct ds_iv_key *key,
 	struct ds_pool		*pool;
 	int			rc;
 
-	if (src == NULL) /* invalidate */
+	if (src == NULL) {
+		/* invalidate */
+		if (entry->iv_valid &&
+		    entry->iv_class->iv_class_id == IV_POOL_HDL &&
+		    !uuid_is_null(dst_iv->piv_hdl.pih_cont_hdl))
+			ds_cont_tgt_close(dst_iv->piv_hdl.pih_cont_hdl);
 		return 0;
+	}
 
 	src_iv = src->sg_iovs[0].iov_buf;
 	D_ASSERT(dst_iv != NULL);
@@ -461,11 +477,16 @@ pool_iv_ent_refresh(struct ds_iv_entry *entry, struct ds_iv_key *key,
 		rc = ds_pool_tgt_prop_update(pool, &src_iv->piv_prop);
 	else if (entry->iv_class->iv_class_id == IV_POOL_CONN)
 		rc = ds_pool_tgt_connect(pool, &src_iv->piv_conn);
-	else
+	else if (entry->iv_class->iv_class_id == IV_POOL_MAP)
 		rc = ds_pool_tgt_map_update(pool,
 				src_iv->piv_map.piv_pool_buf.pb_nr > 0 ?
 				&src_iv->piv_map.piv_pool_buf : NULL,
 				src_iv->piv_pool_map_ver);
+	else if (entry->iv_class->iv_class_id == IV_POOL_HDL)
+		rc = ds_cont_tgt_open(src_iv->piv_pool_uuid,
+				      src_iv->piv_hdl.pih_cont_hdl, NULL, 0,
+				      ds_sec_get_rebuild_cont_capabilities());
+
 	ds_pool_put(pool);
 
 	return rc;
@@ -629,8 +650,9 @@ pool_connect_iv_ent_size(size_t cred_size)
 }
 
 int
-ds_pool_iv_hdl_update(struct ds_pool *pool, uuid_t hdl_uuid, uint64_t flags,
-		      uint64_t sec_capas, d_iov_t *cred)
+ds_pool_iv_conn_hdl_update(struct ds_pool *pool, uuid_t hdl_uuid,
+			   uint64_t flags, uint64_t sec_capas,
+			   d_iov_t *cred)
 {
 	struct pool_iv_entry	*iv_entry;
 	struct pool_iv_conn	*pic;
@@ -735,6 +757,80 @@ out:
 }
 
 int
+ds_pool_iv_srv_hdl_invalidate(struct ds_pool *pool)
+{
+	struct ds_iv_key	key = { 0 };
+	int			rc;
+
+	key.class_id = IV_POOL_HDL;
+	rc = ds_iv_invalidate(pool->sp_iv_ns, &key, CRT_IV_SHORTCUT_NONE,
+			      CRT_IV_SYNC_NONE, 0, false /* retry */);
+	if (rc)
+		D_ERROR("iv invalidate failed "DF_RC"\n", DP_RC(rc));
+
+	return rc;
+}
+
+int
+ds_pool_iv_srv_hdl_update(struct ds_pool *pool, uuid_t pool_hdl_uuid,
+			  uuid_t cont_hdl_uuid)
+{
+	struct pool_iv_entry	iv_entry;
+	int			 rc;
+
+	/* Only happens on xstream 0 */
+	D_ASSERT(dss_get_module_info()->dmi_xs_id == 0);
+
+	crt_group_rank(pool->sp_group, &iv_entry.piv_master_rank);
+	uuid_copy(iv_entry.piv_pool_uuid, pool->sp_uuid);
+	iv_entry.piv_pool_map_ver = pool->sp_map_version;
+	uuid_copy(iv_entry.piv_hdl.pih_pool_hdl, pool_hdl_uuid);
+	uuid_copy(iv_entry.piv_hdl.pih_cont_hdl, cont_hdl_uuid);
+
+	rc = pool_iv_update(pool->sp_iv_ns, IV_POOL_HDL, &iv_entry,
+			    sizeof(struct pool_iv_entry),
+			    CRT_IV_SHORTCUT_NONE, CRT_IV_SYNC_LAZY, true);
+	if (rc)
+		D_ERROR("pool_iv_update failed "DF_RC"\n", DP_RC(rc));
+
+	return rc;
+}
+
+int
+ds_pool_iv_srv_hdl_fetch(struct ds_pool *pool, uuid_t *pool_hdl_uuid,
+			 uuid_t *cont_hdl_uuid)
+{
+	struct pool_iv_entry	iv_entry;
+	d_sg_list_t		sgl = { 0 };
+	d_iov_t			iov = { 0 };
+	struct ds_iv_key	 key;
+	struct pool_iv_key	*pool_key;
+	int			 rc;
+
+	d_iov_set(&iov, &iv_entry, sizeof(struct pool_iv_entry));
+	sgl.sg_nr = 1;
+	sgl.sg_nr_out = 0;
+	sgl.sg_iovs = &iov;
+
+	memset(&key, 0, sizeof(key));
+	key.class_id = IV_POOL_HDL;
+	pool_key = (struct pool_iv_key *)key.key_buf;
+	pool_key->pik_entry_size = sizeof(struct pool_iv_entry);
+	rc = ds_iv_fetch(pool->sp_iv_ns, &key, &sgl, false /* retry */);
+	if (rc) {
+		D_ERROR("iv fetch failed "DF_RC"\n", DP_RC(rc));
+		D_GOTO(out, rc);
+	}
+
+	if (pool_hdl_uuid)
+		uuid_copy(*pool_hdl_uuid, iv_entry.piv_hdl.pih_pool_hdl);
+	if (cont_hdl_uuid)
+		uuid_copy(*cont_hdl_uuid, iv_entry.piv_hdl.pih_cont_hdl);
+out:
+	return rc;
+}
+
+int
 ds_pool_iv_prop_update(struct ds_pool *pool, daos_prop_t *prop)
 {
 	struct pool_iv_entry	*iv_entry;
@@ -826,36 +922,39 @@ out:
 }
 
 int
+ds_pool_iv_fini(void)
+{
+	ds_iv_class_unregister(IV_POOL_MAP);
+	ds_iv_class_unregister(IV_POOL_PROP);
+	ds_iv_class_unregister(IV_POOL_CONN);
+	ds_iv_class_unregister(IV_POOL_HDL);
+
+	return 0;
+}
+
+int
 ds_pool_iv_init(void)
 {
 	int	rc;
 
 	rc = ds_iv_class_register(IV_POOL_MAP, &iv_cache_ops, &pool_iv_ops);
 	if (rc)
-		return rc;
+		D_GOTO(out, rc);
 
 	rc = ds_iv_class_register(IV_POOL_PROP, &iv_cache_ops, &pool_iv_ops);
-	if (rc) {
-		ds_iv_class_unregister(IV_POOL_MAP);
-		return rc;
-	}
+	if (rc)
+		D_GOTO(out, rc);
 
 	rc = ds_iv_class_register(IV_POOL_CONN, &iv_cache_ops, &pool_iv_ops);
-	if (rc) {
-		ds_iv_class_unregister(IV_POOL_MAP);
-		ds_iv_class_unregister(IV_POOL_PROP);
-		return rc;
-	}
+	if (rc)
+		D_GOTO(out, rc);
+
+	rc = ds_iv_class_register(IV_POOL_HDL, &iv_cache_ops, &pool_iv_ops);
+	if (rc)
+		D_GOTO(out, rc);
+out:
+	if (rc)
+		ds_pool_iv_fini();
 
 	return rc;
-}
-
-int
-ds_pool_iv_fini(void)
-{
-	ds_iv_class_unregister(IV_POOL_MAP);
-	ds_iv_class_unregister(IV_POOL_PROP);
-	ds_iv_class_unregister(IV_POOL_CONN);
-
-	return 0;
 }

--- a/src/pool/srv_pool.c
+++ b/src/pool/srv_pool.c
@@ -1145,6 +1145,8 @@ pool_svc_step_up_cb(struct ds_rsvc *rsvc)
 	struct rdb_tx		tx;
 	struct pool_buf	       *map_buf = NULL;
 	uint32_t		map_version;
+	uuid_t			pool_hdl_uuid;
+	uuid_t			cont_hdl_uuid;
 	daos_prop_t	       *prop = NULL;
 	uint64_t		prop_bits;
 	bool			cont_svc_up = false;
@@ -1211,6 +1213,19 @@ unlock:
 	if (rc)
 		D_GOTO(out, rc);
 
+	uuid_generate(pool_hdl_uuid);
+	uuid_generate(cont_hdl_uuid);
+	rc = ds_pool_iv_srv_hdl_update(svc->ps_pool, pool_hdl_uuid,
+				       cont_hdl_uuid);
+	if (rc) {
+		D_ERROR("ds_pool_iv_srv_hdl_update failed %d.\n", rc);
+		D_GOTO(out, rc);
+	}
+
+	D_PRINT(DF_UUID": pool/cont hdl uuid "DF_UUID"/"DF_UUID"\n",
+		DP_UUID(svc->ps_uuid), DP_UUID(pool_hdl_uuid),
+		DP_UUID(cont_hdl_uuid));
+
 	rc = ds_rebuild_regenerate_task(svc->ps_pool);
 	if (rc != 0)
 		goto out;
@@ -1244,6 +1259,7 @@ pool_svc_step_down_cb(struct ds_rsvc *rsvc)
 
 	crt_unregister_event_cb(ds_pool_crt_event_cb, svc);
 
+	ds_pool_iv_srv_hdl_invalidate(svc->ps_pool);
 	ds_cont_svc_step_down(svc->ps_cont_svc);
 	fini_svc_pool(svc);
 
@@ -1796,8 +1812,8 @@ pool_connect_iv_dist(struct pool_svc *svc, uuid_t pool_hdl,
 	if (rc != 0)
 		D_GOTO(out, rc);
 
-	rc = ds_pool_iv_hdl_update(svc->ps_pool, pool_hdl, flags,
-				   sec_capas, cred);
+	rc = ds_pool_iv_conn_hdl_update(svc->ps_pool, pool_hdl, flags,
+					sec_capas, cred);
 	if (rc)
 		D_GOTO(out, rc);
 out:
@@ -2551,7 +2567,8 @@ ds_pool_list_cont_handler(crt_rpc_t *rpc)
 		 * connect the pool, so we only verify the non-rebuild
 		 * pool.
 		 */
-		if (!is_rebuild_pool(in->plci_op.pi_uuid, in->plci_op.pi_hdl)) {
+		if (!is_pool_from_srv(in->plci_op.pi_uuid,
+				      in->plci_op.pi_hdl)) {
 			d_iov_set(&key, in->plci_op.pi_hdl, sizeof(uuid_t));
 			d_iov_set(&value, &hdl, sizeof(hdl));
 			rc = rdb_tx_lookup(&tx, &svc->ps_handles, &key, &value);
@@ -2648,7 +2665,7 @@ ds_pool_query_handler(crt_rpc_t *rpc)
 	 * handle.
 	 */
 	if (daos_rpc_from_client(rpc) &&
-	    !is_rebuild_pool(in->pqi_op.pi_uuid, in->pqi_op.pi_hdl)) {
+	    !is_pool_from_srv(in->pqi_op.pi_uuid, in->pqi_op.pi_hdl)) {
 		d_iov_set(&key, in->pqi_op.pi_hdl, sizeof(uuid_t));
 		d_iov_set(&value, &hdl, sizeof(hdl));
 		rc = rdb_tx_lookup(&tx, &svc->ps_handles, &key, &value);
@@ -2766,7 +2783,7 @@ out_svc:
 	ds_rsvc_set_hint(&svc->ps_rsvc, &out->pqo_op.po_hint);
 	/* See comment above, rebuild doesn't connect the pool */
 	if (rc == 0 && (in->pqi_query_bits & DAOS_PO_QUERY_SPACE) &&
-	    !is_rebuild_pool(in->pqi_op.pi_uuid, in->pqi_op.pi_hdl))
+	    !is_pool_from_srv(in->pqi_op.pi_uuid, in->pqi_op.pi_hdl))
 		rc = pool_space_query_bcast(rpc->cr_ctx, svc, in->pqi_op.pi_hdl,
 					    &out->pqo_space);
 	pool_svc_put_leader(svc);
@@ -4927,5 +4944,51 @@ out_tx:
 out_svc:
 	pool_svc_put_leader(svc);
 	return rc;
+}
+
+bool
+is_container_from_srv(uuid_t pool_uuid, uuid_t coh_uuid)
+{
+	struct ds_pool	*pool;
+	uuid_t		hdl_uuid;
+	int		rc;
+
+	pool = ds_pool_lookup(pool_uuid);
+	if (pool == NULL) {
+		D_ERROR(DF_UUID": failed to get ds_pool\n",
+			DP_UUID(pool_uuid));
+		return false;
+	}
+
+	rc = ds_pool_iv_srv_hdl_fetch(pool, NULL, &hdl_uuid);
+	if (rc) {
+		D_ERROR(DF_UUID" fetch srv hdl: %d\n", DP_UUID(pool_uuid), rc);
+		return false;
+	}
+
+	return !uuid_compare(coh_uuid, hdl_uuid);
+}
+
+bool
+is_pool_from_srv(uuid_t pool_uuid, uuid_t poh_uuid)
+{
+	struct ds_pool	*pool;
+	uuid_t		hdl_uuid;
+	int		rc;
+
+	pool = ds_pool_lookup(pool_uuid);
+	if (pool == NULL) {
+		D_ERROR(DF_UUID": failed to get ds_pool\n",
+			DP_UUID(pool_uuid));
+		return false;
+	}
+
+	rc = ds_pool_iv_srv_hdl_fetch(pool, &hdl_uuid, NULL);
+	if (rc) {
+		D_ERROR(DF_UUID" fetch srv hdl: %d\n", DP_UUID(pool_uuid), rc);
+		return false;
+	}
+
+	return !uuid_compare(poh_uuid, hdl_uuid);
 }
 

--- a/src/rebuild/rebuild_internal.h
+++ b/src/rebuild/rebuild_internal.h
@@ -120,10 +120,6 @@ struct rebuild_global_pool_tracker {
 	/* link to rebuild_global.rg_global_tracker_list */
 	d_list_t	rgt_list;
 
-	/* rebuild cont/pool hdl uuid */
-	uuid_t		rgt_poh_uuid;
-	uuid_t		rgt_coh_uuid;
-
 	/* the pool uuid */
 	uuid_t		rgt_pool_uuid;
 

--- a/src/rebuild/rpc.h
+++ b/src/rebuild/rpc.h
@@ -62,8 +62,6 @@ extern struct crt_proto_format rebuild_proto_fmt;
 
 #define DAOS_ISEQ_REBUILD_SCAN	/* input fields */		 \
 	((uuid_t)		(rsi_pool_uuid)		CRT_VAR) \
-	((uuid_t)		(rsi_pool_hdl_uuid)	CRT_VAR) \
-	((uuid_t)		(rsi_cont_hdl_uuid)	CRT_VAR) \
 	((uint64_t)		(rsi_leader_term)	CRT_VAR) \
 	((int32_t)		(rsi_rebuild_op)	CRT_VAR) \
 	((uint32_t)		(rsi_tgts_num)		CRT_VAR) \

--- a/src/rebuild/srv.c
+++ b/src/rebuild/srv.c
@@ -331,46 +331,6 @@ rebuild_status_completed_remove(const uuid_t pool_uuid)
 	}
 }
 
-bool
-is_rebuild_container(uuid_t pool_uuid, uuid_t coh_uuid)
-{
-	struct rebuild_pool_tls	*tls;
-	bool			is_rebuild = false;
-
-	tls = rebuild_pool_tls_lookup(pool_uuid, -1);
-	if (tls == NULL)
-		return false;
-
-	if (!uuid_is_null(tls->rebuild_coh_uuid)) {
-		D_DEBUG(DB_REBUILD, "rebuild "DF_UUID" cont_hdl_uuid "
-			DF_UUID"\n", DP_UUID(tls->rebuild_coh_uuid),
-			DP_UUID(coh_uuid));
-		is_rebuild = !uuid_compare(tls->rebuild_coh_uuid, coh_uuid);
-	}
-
-	return is_rebuild;
-}
-
-bool
-is_rebuild_pool(uuid_t pool_uuid, uuid_t poh_uuid)
-{
-	struct rebuild_pool_tls	*tls;
-	bool			is_rebuild = false;
-
-	tls = rebuild_pool_tls_lookup(pool_uuid, -1);
-	if (tls == NULL)
-		return false;
-
-	if (!uuid_is_null(tls->rebuild_poh_uuid)) {
-		D_DEBUG(DB_REBUILD, "rebuild "DF_UUID" cont_hdl_uuid "
-			DF_UUID"\n", DP_UUID(tls->rebuild_poh_uuid),
-			DP_UUID(poh_uuid));
-		is_rebuild = !uuid_compare(tls->rebuild_poh_uuid, poh_uuid);
-	}
-
-	return is_rebuild;
-}
-
 static void
 rebuild_tls_fini(const struct dss_thread_local_storage *dtls,
 		 struct dss_module_key *key, void *data)
@@ -774,8 +734,6 @@ rebuild_prepare(struct ds_pool *pool, uint32_t rebuild_ver,
 	}
 
 	(*rgt)->rgt_leader_term = leader_term;
-	uuid_generate((*rgt)->rgt_coh_uuid);
-	uuid_generate((*rgt)->rgt_poh_uuid);
 	(*rgt)->rgt_time_start = d_timeus_secdiff(0);
 
 	D_ASSERT(rebuild_op == RB_OP_FAIL ||
@@ -860,8 +818,6 @@ retry:
 		DP_UUID(pool->sp_uuid), RB_OP_STR(rebuild_op));
 
 	uuid_copy(rsi->rsi_pool_uuid, pool->sp_uuid);
-	uuid_copy(rsi->rsi_pool_hdl_uuid, rgt->rgt_poh_uuid);
-	uuid_copy(rsi->rsi_cont_hdl_uuid, rgt->rgt_coh_uuid);
 	rsi->rsi_ns_id = pool->sp_iv_ns->iv_ns_id;
 	rsi->rsi_leader_term = rgt->rgt_leader_term;
 	rsi->rsi_rebuild_ver = rgt->rgt_rebuild_ver;
@@ -1619,7 +1575,6 @@ rebuild_fini_one(void *arg)
 	ds_migrate_fini_one(rpt->rt_pool_uuid, rpt->rt_rebuild_ver);
 	/* close the opened local ds_cont on main XS */
 	D_ASSERT(dss_get_module_info()->dmi_xs_id != 0);
-	ds_cont_local_close(rpt->rt_coh_uuid);
 
 	dpc = ds_pool_child_lookup(rpt->rt_pool_uuid);
 	D_ASSERT(dpc != NULL);
@@ -1851,12 +1806,6 @@ rebuild_prepare_one(void *data)
 	D_ASSERT(dpc != NULL);
 
 	D_ASSERT(dss_get_module_info()->dmi_xs_id != 0);
-	/* Create ds_container locally on main XS */
-	rc = ds_cont_local_open(rpt->rt_pool_uuid, rpt->rt_coh_uuid,
-				NULL, 0, ds_sec_get_rebuild_cont_capabilities(),
-				NULL);
-	if (rc)
-		pool_tls->rebuild_pool_status = rc;
 
 	/* Set the rebuild epoch per VOS container, so VOS aggregation will not
 	 * cross the epoch to cause problem.
@@ -1996,8 +1945,10 @@ rebuild_tgt_prepare(crt_rpc_t *rpc, struct rebuild_tgt_pool_tracker **p_rpt)
 
 	rpt->rt_rebuild_op = rsi->rsi_rebuild_op;
 
-	uuid_copy(rpt->rt_poh_uuid, rsi->rsi_pool_hdl_uuid);
-	uuid_copy(rpt->rt_coh_uuid, rsi->rsi_cont_hdl_uuid);
+	rc = ds_pool_iv_srv_hdl_fetch(pool, &rpt->rt_poh_uuid,
+				      &rpt->rt_coh_uuid);
+	if (rc)
+		D_GOTO(out, rc);
 
 	D_DEBUG(DB_REBUILD, "rebuild coh/poh "DF_UUID"/"DF_UUID"\n",
 		DP_UUID(rpt->rt_coh_uuid), DP_UUID(rpt->rt_poh_uuid));


### PR DESCRIPTION
Move rebuild pool/container handle uuid outside of
rebuild module, so all other modules will share the
pool/container handle uuid for remote fetch.

Signed-off-by: Di Wang <di.wang@intel.com>