### PR TITLE
DAOS-4955 doc: Fix security doc links

### DIFF
--- a/src/security/README.md
+++ b/src/security/README.md
@@ -23,13 +23,13 @@ are outlined
 This section covers the implementation details of pool and container access
 control.
 
-See the [ACL section of the User Guide](/doc/user/acl.md) for background on DAOS
-Access Control Lists.
+See the [security overview](/doc/overview/security.md#access-control-lists) for
+background on DAOS Access Control Lists.
 
-See the [Admin Guide](/doc/admin/pool_operations.md#pool-access-control-lists)
+See the [Admin Guide](/doc/admin/pool_operations.md#access-control-lists)
 for a higher-level view of pool access control.
 
-See the [User Guide](/doc/user/container.md#container-access-control-lists)
+See the [User Guide](/doc/user/container.md#access-control-lists)
 for a higher-level view of container access control.
 
 ### Pool Access


### PR DESCRIPTION
During a documentation reorganization, we forgot to update
the links in the security README file.

Signed-off-by: Kris Jacque <kristin.jacque@intel.com>