### PR TITLE
supported UNS and refactored URI in hadoop daos

### DIFF
--- a/src/client/java/README.md
+++ b/src/client/java/README.md
@@ -1,29 +1,45 @@
 ## Description
-This module is DAOS Java client and DAOS DFS implementation of Hadoop FileSystem. There are two submodules,
-daos-client and hadoop-daos.
 
-### daos-client
-It wraps most of common APIs from daos_fs.h, as well as some pool and container connection related APIs from
-daos_api.h. There are two main classes, DaosFsClient and DaosFile.
+This module is DAOS Java client and DAOS DFS implementation of Hadoop FileSystem. There are two submodules,
+daos-java and hadoop-daos.
+
+### daos-java
+
+It wraps most of common APIs from daos_fs.h and daos_uns.h, as well as some pool and container connection related APIs
+from daos_pool.h and daos_cont.h. There are three main classes, DaosFsClient, DaosFile and DaosUns.
 
 * DaosFsClient
-There will be single instance of DaosFsClient per pool and container. All DAOS DFS calls and init/finalize, are from
+
+There will be single instance of DaosFsClient per pool and container. All DAOS DFS/UNS calls and init/finalize, are from
 this class which has all native methods implementations in jni which call DAOS APIs directly. It provides a few public
 APIs, move, delete, mkdir, exists, for simple non-repetitive file operations. They release all opened files, if any,
 immediately. If you have multiple operations on same file in short period of time, you should use DaosFile which can be
 instantiated by calling getFile methods.
+It also has some DAOS UNS native methods which should be indirectly accessed via DaosUns.
 
 * DaosFile
+
 It's a simple and efficient representative of underlying DAOS file. You just need to give a posix-compatible path to
 create a DaosFile instance. All later file operations can be done via this instance. It provides java File-like APIs to
 make it friendly to Java developers. And you don't need to release DaosFile explicitly since it will be released
 automatically if there is no reference to this DaosFile instance. You, of course, can release DaosFile explicitly if
 you like or you have to. Besides, it's more efficient for multiple consecutive file operations since underlying DFS
-object is cached and remain open until being released. Later DFS operations don't
-need to lookup repeatedly for each FS operation.
+object is cached and remain open until being released. Later DFS operations don't need to lookup repeatedly for each FS
+operation.
+
+* DaosUns
+
+It wraps some DAOS UNS APIs, like creating, resolving and destroying UNS path, as well as parsing DAOS UNS string
+attribute. Besides, this class can be run from command line in which you can call all DAOS UNS APIs with different
+parameters. Use below command to show its usage in details.
+
+```bash
+$ java -cp ./daos-java-1.1.0-shaded.jar io.daos.dfs.DaosUns --help
+```
 
 ### hadoop-daos
-It's DAOS FS implementation of Hadoop FileSystem based on daos-client. There are three main classes, DaosFileSystem,
+
+It's DAOS FS implementation of Hadoop FileSystem based on daos-java. There are three main classes, DaosFileSystem,
 DaosInputStream and DaosOutputStream.
 
 * DaosFileSystem, it provides APIs to create file as DaosOutputStream, open file as DaosInputStream, list file
@@ -32,27 +48,112 @@ DaosInputStream and DaosOutputStream.
 * DaosOutputStream, for writing file.
 
 #### Hadoop DAOS FileSystem Configuration
-DAOS FileSystem binds to schema, "daos". All DAOS FileSystem configuration will be read from daos-site.xml. So make
-sure daos-site.xml can be loaded by Hadoop. Please check [example](hadoop-daos/src/main/resources/daos-site-example.xml)
-for configuration items, defaults and their description.
+
+##### DAOS URIs
+
+DAOS FileSystem binds to schema, "daos". And DAOS URIs are in the format of "daos://\[authority\]//\[path\]".
+Both authority and path are optional. There are two types of DAOS URIs, with and without DAOS UNS path depending on
+where you want DAOS Filesystem get initialized and configured.
+
+* With DAOS UNS Path
+
+The simple form of URI is "daos:///\<your uns path\>\[/sub path\]". "\<your path\>" is your OS file path created
+with DAOS command or Java DAOS UNS method, DaosUns.create(). "\[sub path\]" is optional. You can create the UNS path
+with below command.
+
+```bash
+$ daos cont create --pool <pool UUID> --svc <svc list> -path <your path> --type=POSIX
+```
+Or
+
+```bash
+$ java -Dpath="your path" -Dpool_id="your pool uuid" -cp ./daos-java-1.1.0-shaded.jar io.daos.dfs.DaosUns create
+```
+
+After creation, you can use below command to see what DAOS properties set to the path.
+
+```path
+$ getfattr -d -m - <your path>
+```
+
+* Without DAOS UNS Path
+
+The simple form of URI is "daos:///\[sub path\]". Please check description of "fs.defaultFS" in
+[example](hadoop-daos/src/main/resources/daos-site-example.xml) for how to configure filesystem.
+In this way, preferred configurations are in daos-site.xml which should be put in right place, e.g., Java classpath, and
+loadable by Hadoop DAOS FileSystem.
+
+You may want to connect to two DAOS servers or two DFS instances mounted to different containers in one DAOS server from
+same JVM. Then, you need to add authority to your URI to make it unique since Hadoop caches filesystem instance keyed by
+"schema + authority" in global (JVM). It applies to the both types of URIs described above.
+
+##### Tune More Configurations
+
+If your DAOS URI has no UNS path, you can follow descriptions of each config item in
+[example](hadoop-daos/src/main/resources/daos-site-example.xml) to set your own values in loadable daos-site.xml.
+
+If your DAOS URI is with UNS path, your configurations, except those set by DAOS UNS creation, in daos-site.xml can
+still be effective. To make configuration source consistent, an alternative to configuration file, daos-site.xml, is to
+set all configurations to the UNS path. You put the configs to the same UNS path with below command.
+
+```bash
+# install attr package if get "command not found" error
+$ setfattr -n user.daos.hadoop -v "fs.daos.server.group=daos_server:fs.daos.pool.svc=0" <your path>
+```
+Or
+
+```bash
+$ java -Dpath="your path" -Dattr=user.daos.hadoop -Dvalue="fs.daos.server.group=daos_server:fs.daos.pool.svc=0"
+        -cp ./daos-java-1.1.0-shaded.jar io.daos.dfs.DaosUns setappinfo
+```
+
+For the "value" property, you need to follow pattern, key1=value1:key2=value2... And key* should be from
+[example](hadoop-daos/src/main/resources/daos-site-example.xml). If value* contains characters of '=' or ':', you need
+to escape the value with below command.
+
+```bash
+$ java -Dop=escape-app-value -Dinput="daos_server:1=2" -cp ./daos-java-1.1.0-shaded.jar io.daos.dfs.DaosUns util
+```
+
+You'll get escaped value, "daos_server\u003a1\u003d2", for "daos_server:1=2".
+
+If you configure the same property in both daos-site.mxl and UNS path, the value in daos-sitem.xml takes priority. If
+user set Hadoop configuration before initializing Hadoop DAOS FileSystem, the user's configuration takes priority.
 
 ## Build
-It's Java module and built by Maven. Java 1.8 and Maven 3 are required to build this module. After they are installed,
-you can change to this <DAOS_INSTALL>/src/client/java folder and build by below command line.
+
+They are Java modules and built by Maven. Java 1.8 and Maven 3 are required to build these modules. After they are
+installed, you can change to this \<DAOS_INSTALL\>/src/client/java folder and build by below command line.
 
     mvn -DskipITs clean install
 
-daos-client module depends on DAOS which is assumed being installed under /usr/local/daos. If you have different
-location, you need to set it with '-Ddaos.install.path=<your DAOS install dir>'. For example,
+The `daos-java-<version>.jar` shades protobuf 3 dependency with its package renamed from "com.google.protobuf" to
+"com.google.protoshadebuf3".
+
+daos-java module depends on DAOS which is assumed being installed under /usr/local/daos. If you have different
+location, you need to set it with '-Ddaos.install.path=\<your DAOS install dir\>'. For example,
 
     mvn -DskipITs -Ddaos.install.path=/code/daos/install clean install
+
+daos-java module uses protobuf 3 to serialize/deserialize complex parameters between Java and C. The corresponding Java
+code and C code are generated from src/main/resources/DunsAttribute.proto and put under src/main/java/io/daos/dfs/uns
+and src/main/native respectively. If you change DunsAttribute.proto or want to regenerate these codes, you can build
+with below command.
+
+    mvn -DskipITs -Dcompile.proto=true clean install
+
+Before issuing above command, you need [protobuf 3](https://github.com/protocolbuffers/protobuf.git) and its
+[C plugin](https://github.com/protobuf-c/protobuf-c.git) installed.
 
 If you have DAOS pool and DAOS container with type of posix, you can run integration test when build with below command.
 Before running it, make sure you have DAOS environment properly setup, including server and user environment variables.
 
     mvn -Dpool_id=<your pool uuid> -Dcont_id=<your container uuid> clean install
 
-User can go to each submodule and build it separately too. 
+User can go to each submodule and build it separately too.
+
+For distribution, the default is for including two artifacts daos-jar and hadoop-daos. The other choice is to include
+all dependencies as well when build with "-P with-deps"
 
 ## Documentation
 You can run below command to generate JavaDoc. There could be some error message during build. Just ignore them if your
@@ -61,9 +162,19 @@ final build status is success. Then go to target/site folder to find documentati
     mvn site
 
 ## Run
-Besides DAOS setup and environment variables, one more environment for JVM signal chaining should be set as below.
+Beside DAOS setup and environment variables, one more environment for JVM signal chaining should be set as below.
 
     export LD_PRELOAD=<YOUR JDK HOME>/jre/lib/amd64/libjsig.so
+
+* daos-java Jars
+
+There are three choices when put daos-java jar, depending on your application.<br/>
+1, daos-java-\<version\>.jar, if your app has protobuf 3 in your classpath.<br/>
+2, daos-java-\<version\>-protobuf3-shaded.jar, if your app don't have protobuf 3 or have protobuf 2 in your classpath.
+<br/>
+3, daos-java-\<version\>-shaded.jar, if you want to run daos-jar as standalone app.<br/>
+
+* YARN
 
 When run with Hadoop yarn, you need to add below configuration to core-site.xml.
 
@@ -72,7 +183,7 @@ When run with Hadoop yarn, you need to add below configuration to core-site.xml.
 <name>fs.AbstractFileSystem.daos.impl</name>
 <value>io.daos.fs.hadoop.DaosAbsFsImpl</value>
 </property>
-  ```
+```
 
 DAOS has no data locality since it is remote storage. You need to add below configuration to scheduler configuration
 file, like capacity-scheduler.xml in yarn.

--- a/src/client/java/hadoop-daos/pom.xml
+++ b/src/client/java/hadoop-daos/pom.xml
@@ -112,6 +112,12 @@
                   <resource>META-INF/org.apache.hadoop.fs.FileSystem</resource>
                 </transformer>
               </transformers>
+              <relocations>
+                <relocation>
+                  <pattern>com.google.protobuf</pattern>
+                  <shadedPattern>com.google.protoshadebuf3</shadedPattern>
+                </relocation>
+              </relocations>
             </configuration>
           </execution>
         </executions>

--- a/src/client/java/hadoop-daos/src/main/java/io/daos/fs/hadoop/Constants.java
+++ b/src/client/java/hadoop-daos/src/main/java/io/daos/fs/hadoop/Constants.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright 2018-2019 Intel Corporation.
+ * (C) Copyright 2018-2020 Intel Corporation.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -30,16 +30,17 @@ public final class Constants {
 
   public static final String DAOS_SCHEMA = "daos";
 
+  public static final String UNS_ATTR_NAME_HADOOP = "user.daos.hadoop";
+
   public static final String DAOS_CONFIG_FILE_NAME = "daos-site.xml";
 
-  public static final String DAOS_CONFIG_POOL_KEY_DEFAULT = "default";
-
-  // cannot be zero which is deemed as empty value in hadoop
-  public static final String DAOS_CONFIG_CONTAINER_KEY_DEFAULT = "1";
-
-  public static final String DAOS_CONFIG_CONTAINER_KEY_PREFIX = "c";
-
   public static final String DAOS_DEFAULT_FS = "fs.defaultFS";
+
+  public static final String DAOS_CONFIG_PREFIX = "fs.daos.";
+
+  public static final String DAOS_SERVER_GROUP = "fs.daos.server.group";
+
+  public static final String DAOS_POOL_FLAGS = "fs.daos.pool.flags";
   // daos pool
   public static final String DAOS_POOL_UUID = "fs.daos.pool.uuid";
 
@@ -54,7 +55,6 @@ public final class Constants {
   public static final int DEFAULT_DAOS_CHUNK_SIZE = 1024 * 1024;
   public static final int MAXIMUM_DAOS_CHUNK_SIZE = Integer.MAX_VALUE;
   public static final int MINIMUM_DAOS_CHUNK_SIZE = 4 * 1024;
-
 
   public static final int DAOS_MODLE = 0755;
 

--- a/src/client/java/hadoop-daos/src/main/java/io/daos/fs/hadoop/DaosAbsFsImpl.java
+++ b/src/client/java/hadoop-daos/src/main/java/io/daos/fs/hadoop/DaosAbsFsImpl.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright 2018-2019 Intel Corporation.
+ * (C) Copyright 2018-2020 Intel Corporation.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -45,13 +45,13 @@ public class DaosAbsFsImpl extends DelegateToFileSystem {
   }
 
   /**
-   * get DAOS FS default port which is {@link Constants#DAOS_CONFIG_CONTAINER_KEY_DEFAULT}.
-   * see resources/daos-site-example.xml for port usage in DAOS FS.
-   * @return default port
+   * not used in DAOS. Just return 1 as fake port.
+   *
+   * @return 1
    */
   @Override
   public int getUriDefaultPort() {
-    return Integer.valueOf(Constants.DAOS_CONFIG_CONTAINER_KEY_DEFAULT);
+    return 1;
   }
 
   @Override

--- a/src/client/java/hadoop-daos/src/main/java/io/daos/fs/hadoop/DaosConfigFile.java
+++ b/src/client/java/hadoop-daos/src/main/java/io/daos/fs/hadoop/DaosConfigFile.java
@@ -163,7 +163,7 @@ public class DaosConfigFile {
    * For other configurations, fallback on default DAOS configuration if no specific configurations for
    * <code>authority</code>.
    * Configurations from <code>hadoopConfig</code> have higher priority than ones from daos-site.xml.
-   * 
+   *
    * @param authority
    * A valid URI authority name to denote unique pool and container. The empty value means no authority provided in URI
    *     which is default URI. see {@link #getDaosUriDesc()} for details.
@@ -203,7 +203,7 @@ public class DaosConfigFile {
 
   /**
    * merge default configuration with hadoop configuration. And hadoop configuration has higher priority than default.
-   * 
+   *
    * @param authority
    * URI authority
    * @param hadoopConfig

--- a/src/client/java/hadoop-daos/src/main/java/io/daos/fs/hadoop/DaosConfigFile.java
+++ b/src/client/java/hadoop-daos/src/main/java/io/daos/fs/hadoop/DaosConfigFile.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright 2018-2019 Intel Corporation.
+ * (C) Copyright 2018-2020 Intel Corporation.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,8 +24,13 @@
 package io.daos.fs.hadoop;
 
 import java.io.InputStream;
+import java.lang.reflect.Field;
+import java.net.URI;
+import java.util.Collections;
+import java.util.HashSet;
 import java.util.Iterator;
 import java.util.Map;
+import java.util.Set;
 
 import javax.xml.parsers.DocumentBuilderFactory;
 
@@ -42,8 +47,8 @@ import org.w3c.dom.NodeList;
  * A class for reading daos-site.xml, if any, from class path as well as verifying and merging Hadoop configuration.
  *
  * <B>daos-site.xml</B>
- * Should be put under class path's root. If not present in class path, DAOS URI must be default URI (daos://default:0).
- * Pool UUID and container UUID must be provided in Hadoop configuration.
+ * Should be put under class path's root for initializing {@link DaosFileSystem}. If not present in class path, DAOS URI
+ * must be default URI (daos:///). And pool UUID and container UUID must be provided in Hadoop configuration then.
  *
  * <B>configuration verification</B>
  * pool UUID and container UUID must be provided by either Hadoop configuration or daos-site.xml if any. If DAOS URI
@@ -51,24 +56,26 @@ import org.w3c.dom.NodeList;
  * any.
  *
  * <B>merge configuration</B>
- * see {@link #getDaosUriDesc()} and {@link #parseConfig(String, String, Configuration)} for how configurations are
+ * see {@link #getDaosUriDesc()} and {@link #parseConfig(String, Configuration)} for how configurations are
  * read and merged.
  */
-public class DaosConfig {
+public class DaosConfigFile {
 
   private Configuration defaultConfig;
 
+  private Set<String> fsConfigNames;
+
   private String daosUriDesc;
 
-  private static final Logger log = LoggerFactory.getLogger(DaosConfig.class);
+  private static final Logger log = LoggerFactory.getLogger(DaosConfigFile.class);
 
-  private static final DaosConfig _INSTANCE = new DaosConfig();
+  private static final DaosConfigFile _INSTANCE = new DaosConfigFile();
 
-  private DaosConfig() {
+  private DaosConfigFile() {
     defaultConfig = new Configuration(false);
-    defaultConfig.addResource("daos-site.xml");
+    defaultConfig.addResource(Constants.DAOS_CONFIG_FILE_NAME);
     if (log.isDebugEnabled()) {
-      log.debug("configs from daos-site.xml");
+      log.debug("configs from " + Constants.DAOS_CONFIG_FILE_NAME);
       Iterator<Map.Entry<String, String>> it = defaultConfig.iterator();
       while (it.hasNext()) {
         Map.Entry<String, String> item = it.next();
@@ -97,14 +104,39 @@ public class DaosConfig {
     } catch (Exception e) {
       throw new IllegalStateException("cannot read description from " + exampleFile, e);
     }
+    fsConfigNames = collectFsConfigNames();
   }
 
-  public static final DaosConfig getInstance() {
+  private Set<String> collectFsConfigNames() {
+    Set<String> fsNames = new HashSet<>();
+    Field[] fields = Constants.class.getFields();
+    for (Field field : fields) {
+      try {
+        Object value = field.get(null);
+        if (value instanceof String) {
+          String s = (String)value;
+          if (s.startsWith(Constants.DAOS_CONFIG_PREFIX) && s.length() > Constants.DAOS_CONFIG_PREFIX.length()) {
+            fsNames.add(s);
+          }
+        }
+      } catch (IllegalAccessException e) {
+        log.error("failed to get field value, " + field.getName());
+      }
+    }
+    return fsNames;
+  }
+
+  public Set<String> getFsConfigNames() {
+    return Collections.unmodifiableSet(fsConfigNames);
+  }
+
+  public static final DaosConfigFile getInstance() {
     return _INSTANCE;
   }
 
   /**
    * get configuration from daos-site.xml if any.
+   *
    * @param name
    * name of configuration
    * @return value of configuration, null if not configured.
@@ -115,6 +147,7 @@ public class DaosConfig {
 
   /**
    * get configuration from daos-site.xml, if any, with default values.
+   *
    * @param name
    * name of configuration
    * @param value
@@ -126,74 +159,70 @@ public class DaosConfig {
   }
 
   /**
-   * verify if pkey and ckey in URI are valid in terms of pool UUID and container UUID.
-   * For other configurations, fallback on default DAOS configuration if no specific configurations for pkey+c+ckey.
+   * verify if <code>authority</code> in URI are valid in terms of pool UUID and container UUID.
+   * For other configurations, fallback on default DAOS configuration if no specific configurations for
+   * <code>authority</code>.
    * Configurations from <code>hadoopConfig</code> have higher priority than ones from daos-site.xml.
-   * @param pkey
-   * pool key mapped to real pool UUID configured in daos-site.xml if any. see {@link #getDaosUriDesc()} for details.
-   * @param ckey
-   * container key mapped to real container UUID configured in daos-site.xml if any. see {@link #getDaosUriDesc()}
-   * for details.
+   * 
+   * @param authority
+   * A valid URI authority name to denote unique pool and container. The empty value means no authority provided in URI
+   *     which is default URI. see {@link #getDaosUriDesc()} for details.
    * @param hadoopConfig
    * configuration from Hadoop, could be manipulated by upper layer application, like Spark
    * @return verified and merged configuration
    */
-  Configuration parseConfig(String pkey, String ckey, Configuration hadoopConfig) {
-    StringBuilder sb = new StringBuilder();
-    pkey = setUuid(pkey, Constants.DAOS_CONFIG_POOL_KEY_DEFAULT, Constants.DAOS_POOL_UUID, hadoopConfig);
-    sb.append(pkey);
-
-    ckey = setUuid(ckey, Constants.DAOS_CONFIG_CONTAINER_KEY_DEFAULT, Constants.DAOS_CONTAINER_UUID, hadoopConfig);
-    if (!ckey.isEmpty()) {
-      sb.append(Constants.DAOS_CONFIG_CONTAINER_KEY_PREFIX).append(ckey);
-    }
-    if (sb.length() > 0) {
-      sb.append('.');
-    }
+  Configuration parseConfig(String authority, Configuration hadoopConfig) {
+    setUuid(authority, Constants.DAOS_POOL_UUID, hadoopConfig);
+    setUuid(authority, Constants.DAOS_CONTAINER_UUID, hadoopConfig);
     //set other configurations after the UUIDs are set
-    return merge(sb.toString(), hadoopConfig);
+    return merge(StringUtils.isEmpty(authority) ? "" : (authority + "."), hadoopConfig, null);
   }
 
-  private String setUuid(String key, String defaultKey, String configName, Configuration hadoopConfig) {
+  private void setUuid(String authority, String configName, Configuration hadoopConfig) {
     String hid = hadoopConfig.get(configName);
-    if (defaultKey.equals(key)) {
-      String did = defaultConfig.get(configName);
-      if (!StringUtils.isEmpty(hid) && !StringUtils.isEmpty(did) && !hid.equals(did)) {
-        throw new IllegalArgumentException("Inconsistent value of " + configName + ", from hadoop: " + hid +
-                ". from " + Constants.DAOS_CONFIG_FILE_NAME + ": " + did +
-                ".\n Considering to change your URI to non-default. See daos URI description. \n" +
-                daosUriDesc);
-      }
-      if (StringUtils.isEmpty(hid)) { //make sure UUID is set
+    if (StringUtils.isEmpty(authority)) { // default URI
+      if (StringUtils.isEmpty(hid)) { // make sure UUID is set
+        String did = defaultConfig.get(configName);
         if (StringUtils.isEmpty(did)) {
           throw new IllegalArgumentException(configName + " is neither specified nor default value found.");
         }
         hadoopConfig.set(configName, did);
       }
-      return "";
+      return;
     }
     // non-default
-    if (StringUtils.isEmpty(hid)) { //make sure UUID is set
-      String prefix = Constants.DAOS_POOL_UUID.equals(configName) ?
-              key + "." : Constants.DAOS_CONFIG_CONTAINER_KEY_PREFIX + key + ".";
-      String did = defaultConfig.get(prefix + configName) ;
+    if (StringUtils.isEmpty(hid)) { // make sure UUID is set
+      String did = defaultConfig.get(authority + "." + configName) ;
       if (StringUtils.isEmpty(did)) {
-        throw new IllegalArgumentException(configName + " is neither specified nor default value found for key " +
-                prefix);
+        throw new IllegalArgumentException(configName + " is neither specified nor default value found for authority " +
+                authority);
       }
       hadoopConfig.set(configName, did);
     }
-    return key;
   }
 
-  private Configuration merge(String prefix, Configuration hadoopConfig) {
-    Iterator<Map.Entry<String, String>> it = defaultConfig.iterator();
+  /**
+   * merge default configuration with hadoop configuration. And hadoop configuration has higher priority than default.
+   * 
+   * @param authority
+   * URI authority
+   * @param hadoopConfig
+   * hadoop configuration from user, typically from {@link org.apache.hadoop.fs.FileSystem#get(URI, Configuration)}
+   * @param excludeProps
+   * excluded properties from merging
+   * @return merged hadoop configuration
+   */
+  public Configuration merge(String authority, Configuration hadoopConfig, Set<String> excludeProps) {
+    Iterator<String> it = fsConfigNames.iterator();
     while (it.hasNext()) {
-      Map.Entry<String, String> item = it.next();
-      String name = item.getKey();
-      if (name.startsWith("fs.daos.")) {
+      String name = it.next();
+      if (excludeProps == null || !excludeProps.contains(name)) {
         if (hadoopConfig.get(name) == null) { //not set by user
-          hadoopConfig.set(name, defaultConfig.get(prefix + name, item.getValue()));
+          String value = StringUtils.isEmpty(authority) ? defaultConfig.get(name) :
+              defaultConfig.get(authority + name, defaultConfig.get(name));
+          if (value != null) {
+            hadoopConfig.set(name, value);
+          }
         }
       }
     }
@@ -205,6 +234,7 @@ public class DaosConfig {
    * - how DAOS URI is constructed
    * - how pool UUID and container UUID are mapped
    * - how config values are read.
+   *
    * @return DAOS URI description
    */
   public String getDaosUriDesc() {

--- a/src/client/java/hadoop-daos/src/main/java/io/daos/fs/hadoop/DaosFileSystem.java
+++ b/src/client/java/hadoop-daos/src/main/java/io/daos/fs/hadoop/DaosFileSystem.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright 2018-2019 Intel Corporation.
+ * (C) Copyright 2018-2020 Intel Corporation.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,13 +23,19 @@
 
 package io.daos.fs.hadoop;
 
+import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.net.URI;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 import com.google.common.collect.Lists;
+
 import io.daos.dfs.*;
+
+import org.apache.commons.lang.StringEscapeUtils;
 import org.apache.commons.lang.StringUtils;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.*;
@@ -60,11 +66,29 @@ import org.slf4j.LoggerFactory;
  * </thead>
  * <tbody>
  * <tr>
+ *   <td>{@value io.daos.fs.hadoop.Constants#DAOS_SERVER_GROUP}</td>
+ *   <td>{@value io.daos.dfs.Constants#POOL_DEFAULT_SERVER_GROUP}</td>
+ *   <td></td>
+ *   <td>false</td>
+ *   <td>daos server group name</td>
+ * </tr>
+ * <tr>
  *   <td>{@value io.daos.fs.hadoop.Constants#DAOS_POOL_UUID}</td>
  *   <td></td>
  *   <td></td>
  *   <td>true</td>
  *   <td>UUID of DAOS pool</td>
+ * </tr>
+ * <tr>
+ *   <td>{@value io.daos.fs.hadoop.Constants#DAOS_POOL_FLAGS}</td>
+ *   <td>{@value io.daos.dfs.Constants#ACCESS_FLAG_POOL_READWRITE}</td>
+ *   <td>
+ *       {@value io.daos.dfs.Constants#ACCESS_FLAG_POOL_READONLY},
+ *       {@value io.daos.dfs.Constants#ACCESS_FLAG_POOL_READWRITE},
+ *       {@value io.daos.dfs.Constants#ACCESS_FLAG_POOL_EXECUTE}
+ *   </td>
+ *   <td>false</td>
+ *   <td>pool access flags</td>
  * </tr>
  * <tr>
  *   <td>{@value io.daos.fs.hadoop.Constants#DAOS_CONTAINER_UUID}</td>
@@ -138,6 +162,11 @@ public class DaosFileSystem extends FileSystem {
   private int blockSize;
   private int chunkSize;
   private String bucket;
+  private boolean uns;
+  private String unsPrefix;
+  private String qualifiedUnsPrefix;
+  private String qualifiedUnsWorkPath;
+  private String workPath;
 
   static {
     if (ShutdownHookManager.removeHook(DaosFsClient.FINALIZER)) {
@@ -159,27 +188,166 @@ public class DaosFileSystem extends FileSystem {
     if (!getScheme().equals(name.getScheme())) {
       throw new IllegalArgumentException("schema should be " + getScheme());
     }
-    if (StringUtils.isEmpty(name.getAuthority())) {
-      throw new IllegalArgumentException("authority (ip:port) cannot be empty. we need it to identify a " +
-              "unique DAOS File System.");
+    DunsInfo info = searchUnsPath(name.getPath());
+    if (info != null) {
+      LOG.info("initializing from uns path, " + name);
+      uns = true;
+      initializeFromUns(name, conf, info);
+    } else {
+      LOG.info("initializing from config file, " + name);
+      uns = false;
+      initializeFromConfigFile(name, conf);
     }
-    String[] ipPort = name.getAuthority().split(":");
-    if (ipPort.length != 2 || StringUtils.isEmpty(ipPort[0]) || StringUtils.isEmpty(ipPort[1])) {
-      throw new IllegalArgumentException("authority should be in format ip:port. No colon in ip or port");
+  }
+
+  /**
+   * initialize from DAOS UNS.
+   * Existing configuration from <code>conf</code> will be overwritten by UNS configs if any.
+   *
+   * @param name
+   * hadoop URI
+   * @param conf
+   * hadoop configuration
+   * @param unsInfo
+   * information get from UNS path
+   * @throws IOException
+   * {@link DaosIOException}
+   */
+  private void initializeFromUns(URI name, Configuration conf, DunsInfo unsInfo) throws IOException {
+    String path = name.getPath();
+    if (!path.startsWith("/")) {
+      throw new IllegalArgumentException("path should be started with /, " + path);
     }
 
-    try {
-      if (Integer.valueOf(ipPort[1]) < Integer.valueOf(Constants.DAOS_CONFIG_CONTAINER_KEY_DEFAULT)) {
-        throw new IllegalArgumentException("container key " + ipPort[1] + " should be no less than " +
-                Constants.DAOS_CONFIG_CONTAINER_KEY_DEFAULT);
+    Set<String> exProps = new HashSet<>();
+    exProps.add(Constants.DAOS_POOL_UUID);
+    exProps.add(Constants.DAOS_CONTAINER_UUID);
+    DaosConfigFile.getInstance().merge(name.getAuthority(), conf, exProps);
+    parseUnsConfig(conf, unsInfo);
+    super.initialize(name, conf);
+    validateAndConnect(name, conf);
+  }
+
+  /**
+   * search UNS path from given <code>path</code> or its ancestors.
+   *
+   * @param path
+   * path of URI
+   * @return DunsInfo
+   * @throws IOException
+   * {@link DaosIOException}
+   */
+  private DunsInfo searchUnsPath(String path) throws IOException {
+    if ("/".equals(path) || !path.startsWith("/")) {
+      return null;
+    }
+    File file = new File(path);
+    DunsInfo info = null;
+    while (info == null && file != null) {
+      if (file.exists()) {
+        try {
+          info = DaosUns.getAccessInfo(file.getAbsolutePath(), Constants.UNS_ATTR_NAME_HADOOP,
+            io.daos.dfs.Constants.UNS_ATTR_VALUE_MAX_LEN_DEFAULT, false);
+          if (info != null) {
+            break;
+          }
+        } catch (DaosIOException e) {
+          // ignoring error
+        }
       }
-    } catch (NumberFormatException e) {
-      throw new IllegalArgumentException("container key should be a integer. " + ipPort[1]);
+      file = file.getParentFile();
     }
+    if (info != null) {
+      unsPrefix = file.getAbsolutePath();
+    }
+    return info;
+  }
 
-    conf = DaosConfig.getInstance().parseConfig(ipPort[0], ipPort[1], conf);
+  private void parseUnsConfig(Configuration conf, DunsInfo info) throws IOException {
+    if (!"POSIX".equalsIgnoreCase(info.getLayout())) {
+      throw new IllegalArgumentException("expect POSIX file system, but " + info.getLayout());
+    }
+    String poolId = info.getPoolId();
+    String contId = info.getContId();
+    String appInfo = info.getAppInfo();
+    if (appInfo != null) {
+      String[] pairs = appInfo.split(":");
+      for (String pair : pairs) {
+        if (StringUtils.isBlank(pair)) {
+          continue;
+        }
+        String[] kv = pair.split("=");
+        try {
+          switch (kv[0]) {
+            case Constants.DAOS_SERVER_GROUP:
+              if (StringUtils.isBlank(conf.get(Constants.DAOS_SERVER_GROUP))) {
+                conf.set(Constants.DAOS_SERVER_GROUP, StringEscapeUtils.unescapeJava(kv[1]));
+              }
+              break;
+            case Constants.DAOS_POOL_UUID:
+              if (StringUtils.isBlank(poolId)) {
+                poolId = StringEscapeUtils.unescapeJava(kv[1]);
+              } else {
+                LOG.warn("ignoring pool id {} from app info", kv[1]);
+              }
+              break;
+            case Constants.DAOS_POOL_SVC:
+              if (StringUtils.isBlank(conf.get(Constants.DAOS_POOL_SVC))) {
+                conf.set(Constants.DAOS_POOL_SVC, StringEscapeUtils.unescapeJava(kv[1]));
+              }
+              break;
+            case Constants.DAOS_POOL_FLAGS:
+              if (StringUtils.isBlank(conf.get(Constants.DAOS_POOL_FLAGS))) {
+                conf.set(Constants.DAOS_POOL_FLAGS, StringEscapeUtils.unescapeJava(kv[1]));
+              }
+              break;
+            case Constants.DAOS_CONTAINER_UUID:
+              if (StringUtils.isBlank(contId)) {
+                contId = StringEscapeUtils.unescapeJava(kv[1]);
+              } else {
+                LOG.warn("ignoring container id {} from app info", kv[1]);
+              }
+              break;
+            case Constants.DAOS_READ_BUFFER_SIZE:
+            case Constants.DAOS_WRITE_BUFFER_SIZE:
+            case Constants.DAOS_BLOCK_SIZE:
+            case Constants.DAOS_CHUNK_SIZE:
+            case Constants.DAOS_PRELOAD_SIZE:
+              if (StringUtils.isBlank(conf.get(kv[0]))) {
+                conf.setInt(kv[0], Integer.valueOf(kv[1]));
+              }
+              break;
+            default:
+              throw new IllegalArgumentException("unknown daos config, " + kv[0]);
+          }
+        } catch (NumberFormatException e) {
+          throw new IllegalArgumentException("bad config " + pair, e);
+        }
+      }
+    }
+    // TODO: adjust logic after DAOS added more info to the ext attribute
+    conf.set(Constants.DAOS_POOL_UUID, poolId);
+    conf.set(Constants.DAOS_CONTAINER_UUID, contId);
+  }
+
+  /**
+   * initialize from daos-site.xml.
+   *
+   * @param name
+   * hadoop URI
+   * @param conf
+   * hadoop configuration
+   * @throws IOException
+   * {@link DaosIOException}
+   */
+  private void initializeFromConfigFile(URI name, Configuration conf) throws IOException {
+    conf = DaosConfigFile.getInstance().parseConfig(name.getAuthority(), conf);
     super.initialize(name, conf);
 
+    validateAndConnect(name, conf);
+  }
+
+  private void validateAndConnect(URI name, Configuration conf) throws IOException {
     try {
       this.bucket = name.getHost();
       this.readBufferSize = conf.getInt(Constants.DAOS_READ_BUFFER_SIZE, Constants.DEFAULT_DAOS_READ_BUFFER_SIZE);
@@ -211,6 +379,10 @@ public class DaosFileSystem extends FileSystem {
                 " should not be greater than reader buffer size, " + readBufferSize);
       }
 
+      String svrGrp = conf.get(Constants.DAOS_SERVER_GROUP);
+      String poolFlags = conf.get(Constants.DAOS_POOL_FLAGS);
+      String svc = conf.get(Constants.DAOS_POOL_SVC);
+
       String poolUuid = conf.get(Constants.DAOS_POOL_UUID);
       if (StringUtils.isEmpty(poolUuid)) {
         throw new IllegalArgumentException(Constants.DAOS_POOL_UUID +
@@ -221,17 +393,20 @@ public class DaosFileSystem extends FileSystem {
         throw new IllegalArgumentException(Constants.DAOS_CONTAINER_UUID +
                 " is null, need to set " + Constants.DAOS_CONTAINER_UUID);
       }
-      String svc = conf.get(Constants.DAOS_POOL_SVC);
-      if (StringUtils.isEmpty(svc)) {
-        throw new IllegalArgumentException(Constants.DAOS_POOL_SVC +
-                " is null, need to set " + Constants.DAOS_POOL_SVC);
-      }
 
       if (LOG.isDebugEnabled()) {
         LOG.debug(name + " configs:");
+        if (!StringUtils.isBlank(svrGrp)) {
+          LOG.debug("daos server group: " + svrGrp);
+        }
         LOG.debug("pool uuid: " + poolUuid);
+        if (!StringUtils.isBlank(poolFlags)) {
+          LOG.debug("pool flags: " + poolFlags);
+        }
         LOG.debug("container uuid: " + contUuid);
-        LOG.debug("pool svc: " + svc);
+        if (!StringUtils.isBlank(svc)) {
+          LOG.debug("pool svc: " + svc);
+        }
         LOG.debug("read buffer size " + readBufferSize);
         LOG.debug("write buffer size: " + writeBufferSize);
         LOG.debug("block size: " + blockSize);
@@ -240,12 +415,31 @@ public class DaosFileSystem extends FileSystem {
       }
 
       // daosFSclient build
-      this.daos = new DaosFsClient.DaosFsClientBuilder().poolId(poolUuid).containerId(contUuid).ranks(svc).build();
-      this.uri = URI.create(name.getScheme() + "://" + name.getAuthority());
-      this.workingDir = new Path("/user", System.getProperty("user.name"))
-              .makeQualified(this.uri, this.getWorkingDirectory());
-      //mkdir workingDir in DAOS
-      daos.mkdir(workingDir.toUri().getPath(), true);
+      DaosFsClient.DaosFsClientBuilder builder = new DaosFsClient.DaosFsClientBuilder().poolId(poolUuid)
+              .containerId(contUuid);
+      if (!StringUtils.isBlank(svrGrp)) {
+        builder.serverGroup(svrGrp);
+      }
+      if (!StringUtils.isBlank(poolFlags)) {
+        builder.poolFlags(Integer.valueOf(poolFlags));
+      }
+      if (!StringUtils.isBlank(svc)) {
+        builder.ranks(svc);
+      }
+      this.daos = builder.build();
+      String tmpUri = name.getScheme() + "://" + (name.getAuthority() == null ? "/" : name.getAuthority());
+      workPath = "/user/" + System.getProperty("user.name");
+      this.uri = URI.create(tmpUri);
+      if (uns) {
+        qualifiedUnsPrefix = tmpUri + unsPrefix;
+        qualifiedUnsWorkPath = qualifiedUnsPrefix + workPath;
+        workingDir = new Path(qualifiedUnsWorkPath);
+      } else {
+        this.workingDir = new Path(workPath)
+          .makeQualified(this.uri, this.getWorkingDirectory());
+      }
+      // mkdir workingDir in DAOS
+      daos.mkdir(workPath, true);
       setConf(conf);
       LOG.info("DaosFileSystem initialized");
     } catch (IOException e) {
@@ -253,9 +447,17 @@ public class DaosFileSystem extends FileSystem {
     }
   }
 
+  public boolean isUns() {
+    return uns;
+  }
+
+  public String getUnsPrefix() {
+    return unsPrefix;
+  }
+
   @Override
   public int getDefaultPort() {
-    return Integer.valueOf(Constants.DAOS_CONFIG_CONTAINER_KEY_DEFAULT);
+    return 1;
   }
 
   private void checkSizeMin(int size, int min, String msg) {
@@ -287,13 +489,49 @@ public class DaosFileSystem extends FileSystem {
 
   /**
    * This method make sure schema and authority are prepended to path.
+   *
    * @param p
+   * path to resolve
    * @return path with schema and authority
-   * @throws IOException
    */
   @Override
-  public Path resolvePath(final Path p) throws IOException {
-    return p.makeQualified(getUri(), this.getWorkingDirectory());
+  public Path resolvePath(final Path p) {
+    if (!uns) {
+      return p.makeQualified(getUri(), this.getWorkingDirectory());
+    }
+    // UNS path
+    URI puri = p.toUri();
+    if (puri.getScheme() == null && puri.getAuthority() == null) {
+      String path = puri.getPath();
+      if (!path.startsWith(unsPrefix)) {
+        path = path.startsWith("/") ? (qualifiedUnsPrefix + path) :
+          (qualifiedUnsWorkPath + "/" + path);
+      } else {
+        path = qualifiedUnsPrefix.substring(0, qualifiedUnsPrefix.indexOf(unsPrefix)) + path;
+      }
+      return new Path(path);
+    }
+    return p;
+  }
+
+  private String getDaosRelativePath(Path path) {
+    String p = path.toUri().getPath();
+    boolean truncated = false;
+    if (uns && p.startsWith(unsPrefix)) {
+      if (p.length() > unsPrefix.length()) {
+        p = p.substring(unsPrefix.length());
+        truncated = true;
+      } else {
+        p = "/";
+      }
+    }
+    if (!p.startsWith("/")) {
+      if (truncated) { // ensure correct uns prefix, counter example, <unsPrefix>abc, is not on uns path
+        return path.toUri().getPath();
+      }
+      p = workPath + "/" + p;
+    }
+    return p;
   }
 
   @Override
@@ -304,7 +542,8 @@ public class DaosFileSystem extends FileSystem {
       LOG.debug("DaosFileSystem open :  path = " + f.toUri().getPath() + " ; buffer size = " + bufferSize);
     }
 
-    DaosFile file = daos.getFile(f.toUri().getPath());
+    String p = getDaosRelativePath(f);
+    DaosFile file = daos.getFile(p);
     if (!file.exists()) {
       throw new FileNotFoundException(f + " not exist");
     }
@@ -334,7 +573,7 @@ public class DaosFileSystem extends FileSystem {
       LOG.debug("DaosFileSystem create file , path= " + f.toUri().toString() + ", buffer size = " + bufferSize +
               ", block size = " + bs);
     }
-    String key = f.toUri().getPath();
+    String key = getDaosRelativePath(f);
 
     DaosFile daosFile = this.daos.getFile(key);
 
@@ -372,17 +611,16 @@ public class DaosFileSystem extends FileSystem {
    * @param src path to be renamed
    * @param dst new path after rename
    * @return
-   * @throws IOException on IO failure
    */
   @Override
-  public boolean rename(Path src, Path dst) throws IOException {
+  public boolean rename(Path src, Path dst) {
     if (LOG.isDebugEnabled()) {
       LOG.debug("DaosFileSystem: rename old path {} to new path {}", src.toUri().getPath(), dst.toUri().getPath());
     }
-    String srckey = src.toUri().getPath();
-    String dstkey = dst.toUri().getPath();
-    DaosFile srcDaosFile = this.daos.getFile(srckey);
-    DaosFile dstDaosFile = this.daos.getFile(dstkey);
+    String srcPath = getDaosRelativePath(src);
+    String destPath = getDaosRelativePath(dst);
+    DaosFile srcDaosFile = this.daos.getFile(srcPath);
+    DaosFile dstDaosFile = this.daos.getFile(destPath);
 
     try {
       return innerRename(srcDaosFile, dstDaosFile);
@@ -404,9 +642,10 @@ public class DaosFileSystem extends FileSystem {
    * the description of the operation.
    * This operation throws an exception on any failure  which needs to be
    * reported and downgraded to a failure.
+   *
    * @param srcDaosFile path to be renamed
    * @param dstDaosFile new path after rename
-   * @return
+   * @return true for successful renaming. false otherwise
    * @throws IOException on IO failure
    */
 
@@ -476,7 +715,7 @@ public class DaosFileSystem extends FileSystem {
    *
    * @param srcDaosFile path to be renamed
    * @param dst new path after rename
-   * @throws IOException
+   * @throws IOException hadoop compatible exception
    */
   private void innerMove(DaosFile srcDaosFile, Path  dst) throws IOException {
     try {
@@ -497,7 +736,7 @@ public class DaosFileSystem extends FileSystem {
     }
     DaosFile file = daos.getFile(f.toUri().getPath());
 
-    FileStatus[] statuses = null;
+    FileStatus[] statuses;
 
     // indicating root directory "/".
     if (f.toUri().getPath().equals("/")) {
@@ -538,6 +777,7 @@ public class DaosFileSystem extends FileSystem {
    * attempt to continue with the delete operation: deleting root
    * directories is never allowed. This method simply implements
    * the policy of when to return an exit code versus raise an exception.
+   *
    * @param isEmptyDir empty directory or not
    * @param recursive recursive flag from command
    * @return a return code for the operation
@@ -562,21 +802,21 @@ public class DaosFileSystem extends FileSystem {
     if (LOG.isDebugEnabled()) {
       LOG.debug("DaosFileSystem listStatus :  List status for path = {}", f.toUri().getPath());
     }
-
-    DaosFile file = daos.getFile(f.toUri().getPath());
+    String path = getDaosRelativePath(f);
+    DaosFile file = daos.getFile(path);
     final List<FileStatus> result = Lists.newArrayList();
     try {
       if (file.isDirectory()) {
         String[] children = file.listChildren();
         if (children != null && children.length > 0) {
           for (String child : children) {
-            FileStatus childStatus = getFileStatus(new Path(f, child).makeQualified(this.uri, this.workingDir),
+            FileStatus childStatus = getFileStatus(resolvePath(new Path(path, child)),
                     daos.getFile(file, child));
             result.add(childStatus);
           }
         }
       } else {
-        result.add(getFileStatus(f, file));
+        result.add(getFileStatus(resolvePath(new Path(path)), file));
       }
     } catch (DaosIOException e) {
       throw HadoopDaosUtils.translateException(e);
@@ -600,7 +840,8 @@ public class DaosFileSystem extends FileSystem {
       LOG.debug("DaosFileSystem mkdirs: Making directory = {} ", f.toUri().getPath());
     }
 
-    DaosFile file = daos.getFile(f.toUri().getPath());
+    String key = getDaosRelativePath(f);
+    DaosFile file = daos.getFile(key);
     if (file.exists()) {
       // if the thread reaches here, there is something at the path
       if (file.isDirectory()) {
@@ -624,16 +865,18 @@ public class DaosFileSystem extends FileSystem {
 
   /**
    * get DAOS file status with detailed info, like modification time, access time, names.
+   *
    * @param f
+   * file path
    * @return file status with times and username and groupname
-   * @throws IOException
+   * @throws IOException hadoop compatible exception
    */
   @Override
   public FileStatus getFileStatus(Path f) throws IOException {
     if (LOG.isDebugEnabled()) {
       LOG.debug("DaosFileSystem getFileStatus:  Get File Status , path = {}", f.toUri().getPath());
     }
-    String key = f.toUri().getPath();
+    String key = getDaosRelativePath(f);
     return getFileStatus(f, daos.getFile(key));
   }
 
@@ -670,7 +913,7 @@ public class DaosFileSystem extends FileSystem {
       LOG.debug(" DaosFileSystem exists: Is path = {} exists", f.toUri().getPath());
     }
     try {
-      String key = f.toUri().getPath();
+      String key = getDaosRelativePath(f);
       return daos.exists(key);
     } catch (IOException e) {
       return false;

--- a/src/client/java/hadoop-daos/src/main/java/io/daos/fs/hadoop/DaosInputStream.java
+++ b/src/client/java/hadoop-daos/src/main/java/io/daos/fs/hadoop/DaosInputStream.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright 2018-2019 Intel Corporation.
+ * (C) Copyright 2018-2020 Intel Corporation.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -31,7 +31,6 @@ import io.daos.dfs.DaosFile;
 
 import org.apache.hadoop.fs.FSInputStream;
 import org.apache.hadoop.fs.FileSystem;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/src/client/java/hadoop-daos/src/main/java/io/daos/fs/hadoop/DaosOutputStream.java
+++ b/src/client/java/hadoop-daos/src/main/java/io/daos/fs/hadoop/DaosOutputStream.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright 2018-2019 Intel Corporation.
+ * (C) Copyright 2018-2020 Intel Corporation.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -30,7 +30,6 @@ import java.nio.ByteBuffer;
 import io.daos.dfs.DaosFile;
 
 import org.apache.hadoop.fs.FileSystem;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/src/client/java/hadoop-daos/src/main/java/io/daos/fs/hadoop/HadoopDaosUtils.java
+++ b/src/client/java/hadoop-daos/src/main/java/io/daos/fs/hadoop/HadoopDaosUtils.java
@@ -1,7 +1,27 @@
-package io.daos.fs.hadoop;
+/*
+ * (C) Copyright 2018-2020 Intel Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * GOVERNMENT LICENSE RIGHTS-OPEN SOURCE SOFTWARE
+ * The Government's rights to use, modify, reproduce, release, perform, display,
+ * or disclose this software are subject to the terms of the Apache License as
+ * provided in Contract No. B609815.
+ * Any reproduction of computer software, computer software documentation, or
+ * portions thereof marked with this legend must also reproduce the markings.
+ */
 
-import io.daos.dfs.DaosIOException;
-import org.apache.hadoop.fs.ParentNotDirectoryException;
+package io.daos.fs.hadoop;
 
 import java.io.FileNotFoundException;
 import java.io.IOException;
@@ -9,6 +29,9 @@ import java.nio.file.DirectoryNotEmptyException;
 import java.nio.file.FileAlreadyExistsException;
 import java.nio.file.NotDirectoryException;
 
+import io.daos.dfs.DaosIOException;
+
+import org.apache.hadoop.fs.ParentNotDirectoryException;
 
 /**
  * Utility class.
@@ -22,15 +45,16 @@ public class HadoopDaosUtils {
   private static final int BASE_DIR_NO_EMPTY = 39;
   private static final int BASE_ENOTDIR = 20;
 
-
   /**
-   * translate specific exception by DAOS error code
+   * translate specific exception by DAOS error code.
+   *
    * @param daosIOException
-   * @return
+   * {@link DaosIOException} to be translated
+   * @return hadoop exception
    */
 
   public static IOException translateException(DaosIOException daosIOException) {
-    IOException ioe = null;
+    IOException ioe;
     int status = daosIOException.getErrorCode();
     switch (status) {
       case BASE_ENOENT :

--- a/src/client/java/hadoop-daos/src/main/java/io/daos/fs/hadoop/package-info.java
+++ b/src/client/java/hadoop-daos/src/main/java/io/daos/fs/hadoop/package-info.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright 2018-2019 Intel Corporation.
+ * (C) Copyright 2018-2020 Intel Corporation.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -45,3 +45,4 @@
  * @see io.daos.fs.hadoop.DaosFileSystem
  */
 package io.daos.fs.hadoop;
+

--- a/src/client/java/hadoop-daos/src/main/resources/META-INF/services/org.apache.hadoop.fs.FileSystem
+++ b/src/client/java/hadoop-daos/src/main/resources/META-INF/services/org.apache.hadoop.fs.FileSystem
@@ -1,4 +1,4 @@
-# (C) Copyright 2018-2019 Intel Corporation.
+# (C) Copyright 2018-2020 Intel Corporation.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/client/java/hadoop-daos/src/main/resources/daos-site-example.xml
+++ b/src/client/java/hadoop-daos/src/main/resources/daos-site-example.xml
@@ -1,35 +1,44 @@
 <configuration>
   <property>
     <name>fs.defaultFS</name>
-    <value>daos://default:1</value>
-    <description>Unique DAOS server URI which follows standard URI format, schema://ip:port.
-      For now, ip and port are not actually used by DAOS to connect to DAOS server since DAOS uses shared file
-      to connect to server. Instead ip and port here are used for representing pool uuid and container uuid on
-      which DAOS FS mounted. To make it flexible, ip and port are not real pool uuid and container  uuid, but
-      keys which are mapped to real uuids. Here is the convention.
+    <value>daos:///</value>
+    <description>Unique DAOS server URI which follows standard URI format, schema://[authority]/. 'schema' is fixed
+      'daos'. And '[authority]' is optional depending on your choices. Different from other file systems, pool UUID and
+      container UUID are needed to connect to DAOS instead of IP/port. And long UUIDs are not good choice put as URI
+      authority. Thus a mapping between authority and UUIDs is given here for simplicity if authority is necessary. Here
+      is the convention.
 
-      IP:
-      default means value of "fs.daos.pool.uuid".
-      pkey means value of "pkey.fs.daos.pool.uuid".
+      1, default URI without authority, 'daos:///'. It reads default values of "fs.daos.pool.uuid" and
+      "fs.daos.container.uuid". And try to read other optional configs prefixed with "fs.daos." from this file. Be sure
+      there is no DAOS URI with authority, like 'daos://fs/', configured to "fs.DefaultFS". Otherwise, you'll get
+      filesystem instance of 'daos://fs/' instead of your desired one, 'daos:///', after you called the Hadoop
+      FileSystem get methods, like 'get(uri, configuration)'.
 
-      Port:
-      1 means value of "fs.daos.container.uuid".
-      ckey (positive integer) means value of "cckey.fs.daos.container.uuid". (additional c due to  ckey is integer)
+      2, URI with authority, like 'daos://fs1/'. It reads values of "fs1.fs.daos.pool.uuid" and
+      "fs1.fs.daos.container.uuid" first. And try to read other optional configs from "fs1.fs.daos.*" first and
+      fall back to optional configs prefixed with "fs.daos." from this file.
 
-      Other configuration (fs.daos.*) values will be read first from pkeycckey.fs.daos.* and fall back to default
-      fs.daos.*.
-
-      For example,
-      daos://default:1 uses default values of "fs.daos.pool.uuid" and "fs.daos.container.uuid". And read other
-      default configurations.
-      daos://pool1:2 uses values of "pool1.fs.daos.pool.uuid" and "c2.fs.daos.container.uuid". And try to read
-      other configurations from pool1c2.fs.daos.* first and fall back to defaults.
+      The two UUID configs must be provided whilst the others are all optional. If this file is not provided in
+      classpath or the UUIDs are not configured, user should at least set "fs.daos.pool.uuid" and
+      "fs.daos.container.uuid" in Hadoop Configuration instance passed for getting file system. Configs from Hadoop have
+      higher priority than this file, including the UUIDs. And you should not prefix the configs with authority when set
+      them in Hadoop Configuration even URI has authority.
     </description>
+  </property>
+  <property>
+    <name>fs.daos.server.group</name>
+    <value>daos_server</value>
+    <description>daos server group</description>
   </property>
   <property>
     <name>fs.daos.pool.uuid</name>
     <value>uuid of pool</value>
     <description>UUID of DAOS pool</description>
+  </property>
+  <property>
+    <name>fs.daos.pool.flags</name>
+    <value>2</value>
+    <description>daos pool access flags, 1 for readonly, 2 for read/write, 4 for execute</description>
   </property>
   <property>
     <name>fs.daos.container.uuid</name>

--- a/src/client/java/hadoop-daos/src/test/java/io/daos/fs/hadoop/DaosConfigFileTest.java
+++ b/src/client/java/hadoop-daos/src/test/java/io/daos/fs/hadoop/DaosConfigFileTest.java
@@ -6,9 +6,9 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -21,29 +21,31 @@ package io.daos.fs.hadoop;
 import java.io.File;
 import java.lang.reflect.Constructor;
 import java.net.URL;
+import java.util.HashSet;
+import java.util.Set;
 import java.util.function.Consumer;
 
 import org.apache.hadoop.conf.Configuration;
 import org.junit.Assert;
 import org.junit.Test;
 
-public class DaosConfigTest {
+public class DaosConfigFileTest {
 
   @Test
   public void testInstantiateWithoutDaosFile() throws Exception {
-    URL url = DaosConfigTest.class.getResource("/daos-site.xml");
+    URL url = DaosConfigFileTest.class.getResource("/daos-site.xml");
     if (url == null) {
       return;
     }
     File file = new File(url.getFile());
-    File backFile = new File(file.getAbsolutePath()+".back");
+    File backFile = new File(file.getAbsolutePath() + ".back");
     try {
       if (!file.renameTo(backFile)) {
-        throw new Exception("failed to rename daos file to "+backFile.getAbsolutePath());
+        throw new Exception("failed to rename daos file to " + backFile.getAbsolutePath());
       }
-      Constructor<DaosConfig> constructor = DaosConfig.class.getDeclaredConstructor();
+      Constructor<DaosConfigFile> constructor = DaosConfigFile.class.getDeclaredConstructor();
       constructor.setAccessible(true);
-      DaosConfig config = constructor.newInstance();
+      DaosConfigFile config = constructor.newInstance();
       Assert.assertNull(config.getFromDaosFile(Constants.DAOS_DEFAULT_FS));
       Assert.assertEquals("unset", config.getFromDaosFile(Constants.DAOS_POOL_UUID, "unset"));
     } finally {
@@ -54,11 +56,17 @@ public class DaosConfigTest {
   }
 
   @Test
+  public void testFsConfigNamesSize() throws Exception {
+    DaosConfigFile cf = DaosConfigFile.getInstance();
+    Assert.assertEquals(10, cf.getFsConfigNames().size());
+  }
+
+  @Test
   public void testGetUriDesc() throws Exception {
-    DaosConfig config = DaosConfig.getInstance();
+    DaosConfigFile config = DaosConfigFile.getInstance();
     String desc = config.getDaosUriDesc().trim();
     Assert.assertTrue(desc.startsWith("Unique DAOS server"));
-    Assert.assertTrue(desc.endsWith("back to defaults."));
+    Assert.assertTrue(desc.endsWith("Hadoop Configuration even URI has authority."));
     Assert.assertFalse(desc.contains("</description>"));
     Assert.assertTrue(desc.length() > 700);
   }
@@ -69,8 +77,8 @@ public class DaosConfigTest {
     Assert.assertNull(hadoopConfig.get(Constants.DAOS_DEFAULT_FS));
     Assert.assertNull(hadoopConfig.get(Constants.DAOS_POOL_UUID));
     Assert.assertNull(hadoopConfig.get(Constants.DAOS_CONTAINER_UUID));
-    DaosConfig config = DaosConfig.getInstance();
-    hadoopConfig = config.parseConfig("default", "1", hadoopConfig);
+    DaosConfigFile config = DaosConfigFile.getInstance();
+    hadoopConfig = config.parseConfig(null, hadoopConfig);
     Assert.assertEquals("uuid of pool", hadoopConfig.get(Constants.DAOS_POOL_UUID));
     Assert.assertEquals("uuid of container", hadoopConfig.get(Constants.DAOS_CONTAINER_UUID));
   }
@@ -82,10 +90,10 @@ public class DaosConfigTest {
     hadoopConfig.set(Constants.DAOS_CONTAINER_UUID, "hadoop cid");
     hadoopConfig.set(Constants.DAOS_PRELOAD_SIZE, "9876");
 
-    DaosConfig config = DaosConfig.getInstance();
+    DaosConfigFile config = DaosConfigFile.getInstance();
     try {
-      config.parseConfig("default", "1", hadoopConfig);
-    }catch (Exception e) {
+      config.parseConfig("", hadoopConfig);
+    } catch (Exception e) {
       Assert.assertTrue(e.getMessage().contains("hadoop pid"));
       Assert.assertTrue(e.getMessage().contains(config.getDaosUriDesc()));
     }
@@ -99,38 +107,38 @@ public class DaosConfigTest {
     hadoopConfig.set(Constants.DAOS_PRELOAD_SIZE, "9876");
     hadoopConfig.set(Constants.DAOS_CHUNK_SIZE, "45678");
 
-    DaosConfig config = DaosConfig.getInstance();
-    hadoopConfig = config.parseConfig("pkey", "3", hadoopConfig);
+    DaosConfigFile config = DaosConfigFile.getInstance();
+    hadoopConfig = config.parseConfig("pkeyc3", hadoopConfig);
     Assert.assertEquals("hadoop pid", hadoopConfig.get(Constants.DAOS_POOL_UUID));
     Assert.assertEquals("hadoop cid", hadoopConfig.get(Constants.DAOS_CONTAINER_UUID));
     Assert.assertEquals("9876", hadoopConfig.get(Constants.DAOS_PRELOAD_SIZE));
     Assert.assertEquals("0", hadoopConfig.get(Constants.DAOS_POOL_SVC));
   }
 
-  private void parseConfigWithDifferentDaosFile(String newDaosFile, Consumer<Constructor<DaosConfig>> function)
-          throws Exception {
-    URL url = DaosConfigTest.class.getResource("/daos-site.xml");
+  private void parseConfigWithDifferentDaosFile(String newDaosFile, Consumer<Constructor<DaosConfigFile>> function)
+      throws Exception {
+    URL url = DaosConfigFileTest.class.getResource("/daos-site.xml");
     if (url == null) {
       throw new Exception("cannot load daos-site.xml");
     }
-    URL url2 = DaosConfigTest.class.getResource("/" + newDaosFile);
+    URL url2 = DaosConfigFileTest.class.getResource("/" + newDaosFile);
     if (url2 == null) {
       throw new Exception("cannot load " + newDaosFile);
     }
     File file = new File(url.getFile());
-    File backFile = new File(file.getAbsolutePath()+".back");
+    File backFile = new File(file.getAbsolutePath() + ".back");
 
     File file2 = new File(url2.getFile());
     try {
       if (!file.renameTo(backFile)) {
-        throw new Exception("failed to rename daos file to "+backFile.getAbsolutePath());
+        throw new Exception("failed to rename daos file to " + backFile.getAbsolutePath());
       }
 
       if (!file2.renameTo(file)) {
-        throw new Exception("failed to rename test file to "+file.getAbsolutePath());
+        throw new Exception("failed to rename test file to " + file.getAbsolutePath());
       }
 
-      Constructor<DaosConfig> constructor = DaosConfig.class.getDeclaredConstructor();
+      Constructor<DaosConfigFile> constructor = DaosConfigFile.class.getDeclaredConstructor();
       constructor.setAccessible(true);
       function.accept(constructor);
     } finally {
@@ -143,13 +151,13 @@ public class DaosConfigTest {
     }
   }
 
-  private void poolDefaultFunction(Constructor<DaosConfig> constructor) {
+  private void poolDefaultFunction(Constructor<DaosConfigFile> constructor) {
     try {
-      DaosConfig config = constructor.newInstance();
+      DaosConfigFile config = constructor.newInstance();
       Assert.assertNotNull(config.getFromDaosFile(Constants.DAOS_DEFAULT_FS));
 
       Configuration hadoopConfig = new Configuration(false);
-      hadoopConfig = config.parseConfig("default", "2", hadoopConfig);
+      hadoopConfig = config.parseConfig("c2", hadoopConfig);
       Assert.assertEquals("uuid of pool", hadoopConfig.get(Constants.DAOS_POOL_UUID));
       Assert.assertEquals("c1 uuid", hadoopConfig.get(Constants.DAOS_CONTAINER_UUID));
       Assert.assertEquals("234567", hadoopConfig.get(Constants.DAOS_READ_BUFFER_SIZE));
@@ -158,14 +166,14 @@ public class DaosConfigTest {
       Assert.assertEquals("1048", hadoopConfig.get(Constants.DAOS_CHUNK_SIZE));
       Assert.assertEquals("-1", hadoopConfig.get(Constants.DAOS_PRELOAD_SIZE));
 
-      DaosConfig config2 = constructor.newInstance();
+      DaosConfigFile config2 = constructor.newInstance();
       Assert.assertNotNull(config2.getFromDaosFile(Constants.DAOS_DEFAULT_FS));
 
       Configuration hadoopConfig2 = new Configuration(false);
       hadoopConfig2.set(Constants.DAOS_READ_BUFFER_SIZE, "765432");
       hadoopConfig2.set(Constants.DAOS_CONTAINER_UUID, "hc1 uuid");
       hadoopConfig2.set(Constants.DAOS_PRELOAD_SIZE, "24567");
-      hadoopConfig2 = config2.parseConfig("default", "2", hadoopConfig2);
+      hadoopConfig2 = config2.parseConfig("c2", hadoopConfig2);
       Assert.assertEquals("uuid of pool", hadoopConfig2.get(Constants.DAOS_POOL_UUID));
       Assert.assertEquals("hc1 uuid", hadoopConfig2.get(Constants.DAOS_CONTAINER_UUID));
       Assert.assertEquals("765432", hadoopConfig2.get(Constants.DAOS_READ_BUFFER_SIZE));
@@ -183,13 +191,13 @@ public class DaosConfigTest {
     parseConfigWithDifferentDaosFile("daos-site-default-pool.xml", this::poolDefaultFunction);
   }
 
-  private void containerDefaultFunction(Constructor<DaosConfig> constructor) {
+  private void containerDefaultFunction(Constructor<DaosConfigFile> constructor) {
     try {
-      DaosConfig config = constructor.newInstance();
+      DaosConfigFile config = constructor.newInstance();
       Assert.assertNotNull(config.getFromDaosFile(Constants.DAOS_DEFAULT_FS));
 
       Configuration hadoopConfig = new Configuration(false);
-      hadoopConfig = config.parseConfig("pool2", "1", hadoopConfig);
+      hadoopConfig = config.parseConfig("pool2", hadoopConfig);
       Assert.assertEquals("pool1 uuid", hadoopConfig.get(Constants.DAOS_POOL_UUID));
       Assert.assertEquals("uuid of container", hadoopConfig.get(Constants.DAOS_CONTAINER_UUID));
       Assert.assertEquals("234567", hadoopConfig.get(Constants.DAOS_READ_BUFFER_SIZE));
@@ -198,13 +206,13 @@ public class DaosConfigTest {
       Assert.assertEquals("1048", hadoopConfig.get(Constants.DAOS_CHUNK_SIZE));
       Assert.assertEquals("4194304", hadoopConfig.get(Constants.DAOS_PRELOAD_SIZE));
 
-      DaosConfig config2 = constructor.newInstance();
+      DaosConfigFile config2 = constructor.newInstance();
       Assert.assertNotNull(config2.getFromDaosFile(Constants.DAOS_DEFAULT_FS));
 
       Configuration hadoopConfig2 = new Configuration(false);
       hadoopConfig2.set(Constants.DAOS_READ_BUFFER_SIZE, "765432");
       hadoopConfig2.set(Constants.DAOS_POOL_UUID, "hp1 uuid");
-      hadoopConfig2 = config2.parseConfig("pool2", "1", hadoopConfig2);
+      hadoopConfig2 = config2.parseConfig("pool2", hadoopConfig2);
       Assert.assertEquals("hp1 uuid", hadoopConfig2.get(Constants.DAOS_POOL_UUID));
       Assert.assertEquals("uuid of container", hadoopConfig2.get(Constants.DAOS_CONTAINER_UUID));
       Assert.assertEquals("765432", hadoopConfig2.get(Constants.DAOS_READ_BUFFER_SIZE));
@@ -221,13 +229,13 @@ public class DaosConfigTest {
     parseConfigWithDifferentDaosFile("daos-site-default-container.xml", this::containerDefaultFunction);
   }
 
-  private void noDefaultFunction(Constructor<DaosConfig> constructor) {
+  private void noDefaultFunction(Constructor<DaosConfigFile> constructor) {
     try {
-      DaosConfig config = constructor.newInstance();
+      DaosConfigFile config = constructor.newInstance();
       Assert.assertNotNull(config.getFromDaosFile(Constants.DAOS_DEFAULT_FS));
 
       Configuration hadoopConfig = new Configuration(false);
-      hadoopConfig = config.parseConfig("pool2", "2", hadoopConfig);
+      hadoopConfig = config.parseConfig("pool2c2", hadoopConfig);
       Assert.assertEquals("pool2 uuid", hadoopConfig.get(Constants.DAOS_POOL_UUID));
       Assert.assertEquals("c2 uuid", hadoopConfig.get(Constants.DAOS_CONTAINER_UUID));
       Assert.assertEquals("234567", hadoopConfig.get(Constants.DAOS_READ_BUFFER_SIZE));
@@ -235,7 +243,7 @@ public class DaosConfigTest {
       Assert.assertEquals("1234567", hadoopConfig.get(Constants.DAOS_BLOCK_SIZE));
       Assert.assertEquals("1048", hadoopConfig.get(Constants.DAOS_CHUNK_SIZE));
 
-      DaosConfig config2 = constructor.newInstance();
+      DaosConfigFile config2 = constructor.newInstance();
       Assert.assertNotNull(config2.getFromDaosFile(Constants.DAOS_DEFAULT_FS));
 
       Configuration hadoopConfig2 = new Configuration(false);
@@ -243,7 +251,7 @@ public class DaosConfigTest {
       hadoopConfig2.set(Constants.DAOS_CHUNK_SIZE, "5698");
       hadoopConfig2.set(Constants.DAOS_POOL_UUID, "hp1 uuid");
       hadoopConfig2.set(Constants.DAOS_CONTAINER_UUID, "hc1 uuid");
-      hadoopConfig2 = config2.parseConfig("pool2", "2", hadoopConfig2);
+      hadoopConfig2 = config2.parseConfig("pool2c2", hadoopConfig2);
       Assert.assertEquals("hp1 uuid", hadoopConfig2.get(Constants.DAOS_POOL_UUID));
       Assert.assertEquals("hc1 uuid", hadoopConfig2.get(Constants.DAOS_CONTAINER_UUID));
       Assert.assertEquals("765432", hadoopConfig2.get(Constants.DAOS_READ_BUFFER_SIZE));
@@ -258,5 +266,30 @@ public class DaosConfigTest {
   @Test
   public void testParseConfigWithNoDefault() throws Exception {
     parseConfigWithDifferentDaosFile("daos-site-no-default.xml", this::noDefaultFunction);
+  }
+
+  @Test
+  public void testMergeWithExcludedAttribute() throws Exception {
+    Constructor<DaosConfigFile> constructor = DaosConfigFile.class.getDeclaredConstructor();
+    constructor.setAccessible(true);
+    Configuration hconfig = new Configuration(false);
+    DaosConfigFile config = constructor.newInstance();
+    config.merge("fs2", hconfig, null);
+    Assert.assertEquals("uuid of pool", hconfig.get(Constants.DAOS_POOL_UUID));
+    Assert.assertEquals("uuid of container", hconfig.get(Constants.DAOS_CONTAINER_UUID));
+
+    Set<String> exProps = new HashSet<>();
+    exProps.add(Constants.DAOS_POOL_UUID);
+    exProps.add(Constants.DAOS_CONTAINER_UUID);
+    Configuration hconfig2 = new Configuration(false);
+    hconfig2.set(Constants.DAOS_READ_BUFFER_SIZE, "765432");
+    hconfig2.set(Constants.DAOS_CHUNK_SIZE, "5698");
+    hconfig2.set(Constants.DAOS_POOL_UUID, "hp1 uuid");
+    hconfig2.set(Constants.DAOS_CONTAINER_UUID, "hc1 uuid");
+    config.merge("fs3", hconfig2, exProps);
+    Assert.assertEquals("hp1 uuid", hconfig2.get(Constants.DAOS_POOL_UUID));
+    Assert.assertEquals("hc1 uuid", hconfig2.get(Constants.DAOS_CONTAINER_UUID));
+    Assert.assertEquals("5698", hconfig2.get(Constants.DAOS_CHUNK_SIZE));
+    Assert.assertEquals("765432", hconfig2.get(Constants.DAOS_READ_BUFFER_SIZE));
   }
 }

--- a/src/client/java/hadoop-daos/src/test/java/io/daos/fs/hadoop/DaosFSFactory.java
+++ b/src/client/java/hadoop-daos/src/test/java/io/daos/fs/hadoop/DaosFSFactory.java
@@ -6,9 +6,9 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -20,6 +20,7 @@ package io.daos.fs.hadoop;
 
 import io.daos.dfs.DaosFile;
 import io.daos.dfs.DaosFsClient;
+import org.apache.commons.lang.StringUtils;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
 
@@ -29,12 +30,8 @@ import java.io.IOException;
  *
  */
 public class DaosFSFactory {
-
-//  public final static String pooluuid = "53a47469-ea2a-418e-89d3-6d1df1aaadb4";
-//  public final static String contuuid = "9e60aff2-ca28-45fe-bdb0-d1a6c182c342";
-  public final static String defaultPoolId = "6112d3ac-f99b-4e46-a2ab-549d9d56c069";
-  public final static String defaultContId = "10e8b68a-c80a-4840-84fe-3b707ebb5475";
-
+  public final static String defaultPoolId = "07f519b1-f06a-4411-b0f5-638cc39d3825";
+  public final static String defaultContId = "9c9de970-2b43-43ec-ad2c-6a3fc33bd389";
   public final static String pooluuid = System.getProperty("pool_id", defaultPoolId);
   public final static String contuuid = System.getProperty("cont_id", defaultContId);
   public final static String svc = "0";
@@ -44,40 +41,40 @@ public class DaosFSFactory {
     conf.set(Constants.DAOS_POOL_UUID, pooluuid);
     conf.set(Constants.DAOS_CONTAINER_UUID, contuuid);
     conf.set(Constants.DAOS_POOL_SVC, svc);
-    return DaosUtils.createTestFileSystem(conf);
+    return DaosHadoopTestUtils.createTestFileSystem(conf);
   }
 
-  public synchronized static FileSystem getFS() throws IOException{
+  public synchronized static FileSystem getFS() throws IOException {
     prepareFs();
     return createFS();
   }
 
-  public synchronized static DaosFsClient getFsClient() throws IOException{
+  public synchronized static DaosFsClient getFsClient() throws IOException {
     DaosFsClient.DaosFsClientBuilder builder = new DaosFsClient.DaosFsClientBuilder();
     builder.poolId(pooluuid).containerId(contuuid);
     return builder.build();
   }
 
-  private static DaosFsClient prepareFs()throws IOException{
+  private static DaosFsClient prepareFs() throws IOException {
     try {
       DaosFsClient client = getFsClient();
       //clear all content
       DaosFile daosFile = client.getFile("/");
       String[] children = daosFile.listChildren();
-      for(String child : children) {
-        if(child.length() == 0 || ".".equals(child)){
+      for (String child : children) {
+        if (child.length() == 0 || ".".equals(child)) {
           continue;
         }
-        String path = "/"+child;
+        String path = "/" + child;
         DaosFile childFile = client.getFile(path);
-        if(childFile.delete(true)){
-          System.out.println("deleted folder "+path);
-        }else{
-          System.out.println("failed to delete folder "+path);
+        if (childFile.delete(true)) {
+          System.out.println("deleted folder " + path);
+        } else {
+          System.out.println("failed to delete folder " + path);
         }
       }
       return client;
-    }catch (Exception e){
+    } catch (Exception e) {
       System.out.println("failed to clear/prepare file system");
       e.printStackTrace();
     }

--- a/src/client/java/hadoop-daos/src/test/java/io/daos/fs/hadoop/DaosFileSystemContractIT.java
+++ b/src/client/java/hadoop-daos/src/test/java/io/daos/fs/hadoop/DaosFileSystemContractIT.java
@@ -6,9 +6,9 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -26,7 +26,6 @@ import org.apache.hadoop.fs.FileSystemContractBaseTest;
 import org.apache.hadoop.fs.Path;
 import org.junit.Test;
 
-import java.io.FileNotFoundException;
 import java.io.IOException;
 
 import static org.junit.Assume.assumeTrue;
@@ -65,8 +64,8 @@ public class DaosFileSystemContractIT extends FileSystemContractBaseTest {
   public void testRenameRootDirForbidden() throws Exception {
     assumeTrue(renameSupported());
     rename(super.path("/"),
-              super.path("/test/newRootDir"),
-              false, true, false);
+        super.path("/test/newRootDir"),
+        false, true, false);
   }
 
   @Test
@@ -159,13 +158,13 @@ public class DaosFileSystemContractIT extends FileSystemContractBaseTest {
     rename(src, dst, true, false, true);
 
     assertFalse("Nested file1 exists",
-            fs.exists(path("/test/hadoop/dir/file1")));
+        fs.exists(path("/test/hadoop/dir/file1")));
     assertFalse("Nested file2 exists",
-            fs.exists(path("/test/hadoop/dir/subdir/file2")));
+        fs.exists(path("/test/hadoop/dir/subdir/file2")));
     assertTrue("Renamed nested file1 exists",
-            fs.exists(path("/test/new/newdir/file1")));
+        fs.exists(path("/test/new/newdir/file1")));
     assertTrue("Renamed nested exists",
-            fs.exists(path("/test/new/newdir/subdir/file2")));
+        fs.exists(path("/test/new/newdir/subdir/file2")));
   }
 
   @Override
@@ -183,15 +182,15 @@ public class DaosFileSystemContractIT extends FileSystemContractBaseTest {
     fs.mkdirs(parent);
     rename(src, dst, true, false, true);
     assertTrue("Destination changed",
-            fs.exists(path("/test/new/dir")));
+        fs.exists(path("/test/new/dir")));
     assertFalse("Nested file1 exists",
-            fs.exists(path("/test/hadoop/dir/file1")));
+        fs.exists(path("/test/hadoop/dir/file1")));
     assertFalse("Nested file2 exists",
-            fs.exists(path("/test/hadoop/dir/subdir/file2")));
+        fs.exists(path("/test/hadoop/dir/subdir/file2")));
     assertTrue("Renamed nested file1 exists",
-            fs.exists(path("/test/new/dir")));
+        fs.exists(path("/test/new/dir")));
     assertTrue("Renamed nested exists",
-            fs.exists(path("/test/new/dir/subdir/file2")));
+        fs.exists(path("/test/new/dir/subdir/file2")));
   }
 
 
@@ -207,7 +206,7 @@ public class DaosFileSystemContractIT extends FileSystemContractBaseTest {
     this.fs.mkdirs(parent);
     rename(src, dst, true, false, true);
     assertTrue("Destination changed",
-            fs.exists(path("/test/new/file")));
+        fs.exists(path("/test/new/file")));
   }
 
   @Override
@@ -225,9 +224,9 @@ public class DaosFileSystemContractIT extends FileSystemContractBaseTest {
 
   @Override
   public void testListStatus() throws Exception {
-    Path[] testDirs = { path("/test/hadoop/a"),
-            path("/test/hadoop/b"),
-            path("/test/hadoop/c/1"), };
+    Path[] testDirs = {path("/test/hadoop/a"),
+        path("/test/hadoop/b"),
+        path("/test/hadoop/c/1"),};
     assertFalse(fs.exists(testDirs[0]));
 
     for (Path path : testDirs) {
@@ -259,7 +258,7 @@ public class DaosFileSystemContractIT extends FileSystemContractBaseTest {
 
     rename(src, dst, false, true, true);
     assertFalse("Destination changed",
-            fs.exists(path("/test/hadoop/dir/subdir/dir")));
+        fs.exists(path("/test/hadoop/dir/subdir/dir")));
   }
 
   public void testRenameDirMoveToItSelf() throws Exception {
@@ -271,7 +270,7 @@ public class DaosFileSystemContractIT extends FileSystemContractBaseTest {
 
     rename(src, dst, false, true, true);
     assertTrue("Destination changed",
-            fs.exists(path("/test/hadoop/dir")));
+        fs.exists(path("/test/hadoop/dir")));
   }
 
   public void testRenameFileToItSelf() throws Exception {
@@ -283,6 +282,6 @@ public class DaosFileSystemContractIT extends FileSystemContractBaseTest {
 
     rename(src, dst, true, true, true);
     assertTrue("Destination changed",
-            fs.exists(path("/test/hadoop/file")));
+        fs.exists(path("/test/hadoop/file")));
   }
 }

--- a/src/client/java/hadoop-daos/src/test/java/io/daos/fs/hadoop/DaosFileSystemTest.java
+++ b/src/client/java/hadoop-daos/src/test/java/io/daos/fs/hadoop/DaosFileSystemTest.java
@@ -6,9 +6,9 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -19,9 +19,13 @@
 package io.daos.fs.hadoop;
 
 import io.daos.dfs.DaosFsClient;
+import io.daos.dfs.DaosUns;
+import io.daos.dfs.DaosUtils;
+import io.daos.dfs.DunsInfo;
 import org.apache.commons.io.FileUtils;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.security.UserGroupInformation;
 import org.junit.Assert;
 import org.junit.Test;
@@ -33,16 +37,20 @@ import org.powermock.core.classloader.annotations.SuppressStaticInitializationFo
 import org.powermock.modules.junit4.PowerMockRunner;
 
 import java.io.File;
+import java.io.IOException;
 import java.io.InputStream;
 import java.net.URI;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.mockito.Mockito.*;
 
 @RunWith(PowerMockRunner.class)
 @PowerMockIgnore("javax.management.*")
-@PrepareForTest({DaosFsClient.DaosFsClientBuilder.class, DaosFileSystem.class})
+@PrepareForTest({DaosFsClient.DaosFsClientBuilder.class, DaosFileSystem.class, DaosUns.class})
 @SuppressStaticInitializationFor("io.daos.dfs.DaosFsClient")
 public class DaosFileSystemTest {
+
+  private static AtomicInteger unsId = new AtomicInteger(1);
 
   @Test
   public void testNewDaosFileSystemByDifferentURIs() throws Exception {
@@ -63,11 +71,72 @@ public class DaosFileSystemTest {
 
     UserGroupInformation.setLoginUser(UserGroupInformation.createRemoteUser("test"));
 
-    FileSystem fs1 = FileSystem.get(URI.create("daos://1234:56/"), cfg);
+    FileSystem fs1 = FileSystem.get(URI.create("daos://fs1/"), cfg);
     FileSystem fs2 = FileSystem.get(URI.create("daos://12345:567/"), cfg);
     Assert.assertNotSame(fs1, fs2);
     fs1.close();
     fs2.close();
+
+    FileSystem fs3 = FileSystem.get(URI.create("daos:///"), cfg);
+    Assert.assertNotNull(fs3);
+    fs3.close();
+
+    String path = "/file/abc";
+    DunsInfo info = new DunsInfo("123", "56", "POSIX", Constants.DAOS_POOL_SVC + "=0");
+    PowerMockito.mockStatic(DaosUns.class);
+    when(DaosUns.getAccessInfo(anyString(), eq(Constants.UNS_ATTR_NAME_HADOOP),
+        eq(io.daos.dfs.Constants.UNS_ATTR_VALUE_MAX_LEN_DEFAULT), eq(false))).thenReturn(info);
+    URI uri = URI.create("daos://" + unsId.getAndIncrement() + path);
+    FileSystem unsFs = FileSystem.get(uri, cfg);
+    unsFs.close();
+
+    IOException eie = null;
+    try {
+      FileSystem.get(URI.create("daosss://file/abc"), cfg);
+    } catch (IOException e) {
+      eie = e;
+    }
+    Assert.assertNotNull(eie);
+    Assert.assertTrue(eie.getMessage().contains("No FileSystem for scheme: daosss"));
+  }
+
+  @Test
+  public void testNewDaosFileSystemFromUnsWithAppInfo() throws Exception {
+    PowerMockito.mockStatic(DaosFsClient.class);
+    DaosFsClient.DaosFsClientBuilder builder = mock(DaosFsClient.DaosFsClientBuilder.class);
+    PowerMockito.whenNew(DaosFsClient.DaosFsClientBuilder.class).withNoArguments().thenReturn(builder);
+
+    Configuration cfg = new Configuration();
+    DaosFsClient client = mock(DaosFsClient.class);
+    when(builder.poolId(anyString())).thenReturn(builder);
+    when(builder.containerId(anyString())).thenReturn(builder);
+    when(builder.ranks(anyString())).thenReturn(builder);
+    when(builder.build()).thenReturn(client);
+
+    UserGroupInformation.setLoginUser(UserGroupInformation.createRemoteUser("test"));
+
+    String path = "/file/abc";
+    StringBuilder sb = new StringBuilder();
+    sb.append(Constants.DAOS_SERVER_GROUP).append("=").append(DaosUtils.escapeUnsValue("daos_=:group")).append(":");
+    sb.append(Constants.DAOS_POOL_UUID).append("=").append("456").append(":");
+    sb.append(Constants.DAOS_CONTAINER_UUID).append("=").append("789").append(":");
+    sb.append(Constants.DAOS_POOL_SVC).append("=").append(DaosUtils.escapeUnsValue("0,1:2,3")).append(":");
+    sb.append(Constants.DAOS_POOL_FLAGS).append("=").append("4").append(":");
+    sb.append(Constants.DAOS_READ_BUFFER_SIZE).append("=").append("4194304").append(":");
+    DunsInfo info = new DunsInfo("123", "56", "POSIX",
+        sb.toString());
+    PowerMockito.mockStatic(DaosUns.class);
+    when(DaosUns.getAccessInfo(anyString(), eq(Constants.UNS_ATTR_NAME_HADOOP),
+        eq(io.daos.dfs.Constants.UNS_ATTR_VALUE_MAX_LEN_DEFAULT), eq(false))).thenReturn(info);
+    URI uri = URI.create("daos://" + unsId.getAndIncrement() + path);
+    FileSystem unsFs = FileSystem.get(uri, cfg);
+    unsFs.close();
+
+    Assert.assertEquals("123", cfg.get(Constants.DAOS_POOL_UUID));
+    Assert.assertEquals("56", cfg.get(Constants.DAOS_CONTAINER_UUID));
+    Assert.assertEquals("daos_=:group", cfg.get(Constants.DAOS_SERVER_GROUP));
+    Assert.assertEquals("8388608", cfg.get(Constants.DAOS_READ_BUFFER_SIZE));
+    Assert.assertEquals("0", cfg.get(Constants.DAOS_POOL_SVC));
   }
 
   @Test
@@ -88,8 +157,10 @@ public class DaosFileSystemTest {
     cfg.set(Constants.DAOS_CONTAINER_UUID, "123");
     cfg.set(Constants.DAOS_POOL_SVC, "0");
     fs.initialize(URI.create("daos://1234:56/"), cfg);
-    Assert.assertEquals("daos://1234:56/user/"+System.getProperty("user.name"), fs.getWorkingDirectory().toString());
-    verify(client, times(1)).mkdir("/user/"+System.getProperty("user.name"), true);
+    Assert.assertEquals("daos://1234:56/user/" + System.getProperty("user.name"),
+        fs.getWorkingDirectory().toString());
+    verify(client, times(1))
+        .mkdir("/user/" + System.getProperty("user.name"), true);
     fs.close();
   }
 
@@ -111,7 +182,7 @@ public class DaosFileSystemTest {
     cfg.set(Constants.DAOS_CONTAINER_UUID, "123");
     cfg.set(Constants.DAOS_POOL_SVC, "0");
     try {
-      fs.initialize(URI.create("daos://1234:56/root"), cfg);
+      fs.initialize(URI.create("daos://1234:56"), cfg);
     } catch (IllegalArgumentException e) {
       Assert.assertTrue(e.getMessage().contains(Constants.DAOS_POOL_UUID));
       throw e;
@@ -138,7 +209,7 @@ public class DaosFileSystemTest {
     cfg.set(Constants.DAOS_CONTAINER_UUID, "");
     cfg.set(Constants.DAOS_POOL_SVC, "0");
     try {
-      fs.initialize(URI.create("daos://1234:56/root"), cfg);
+      fs.initialize(URI.create("daos://1234:56/"), cfg);
     } catch (IllegalArgumentException e) {
       Assert.assertTrue(e.getMessage().contains(Constants.DAOS_CONTAINER_UUID));
       throw e;
@@ -147,8 +218,8 @@ public class DaosFileSystemTest {
     }
   }
 
-  @Test(expected = IllegalArgumentException.class)
-  public void testNewDaosFileSystemFailedNoSvc() throws Exception {
+  @Test
+  public void testNewDaosFileSystemSuccessfulNoSvc() throws Exception {
     PowerMockito.mockStatic(DaosFsClient.class);
     DaosFsClient.DaosFsClientBuilder builder = mock(DaosFsClient.DaosFsClientBuilder.class);
     DaosFsClient client = mock(DaosFsClient.class);
@@ -165,10 +236,10 @@ public class DaosFileSystemTest {
     cfg.set(Constants.DAOS_CONTAINER_UUID, "123");
     cfg.set(Constants.DAOS_POOL_SVC, "");
     try {
-      fs.initialize(URI.create("daos://1234:56/root"), cfg);
-    } catch (IllegalArgumentException e) {
-      Assert.assertTrue(e.getMessage().contains(Constants.DAOS_POOL_SVC));
-      throw e;
+      URI uri = URI.create("daos://1234:56/");
+      fs.initialize(uri, cfg);
+      Assert.assertEquals(new Path("/user", System.getProperty("user.name")).makeQualified(uri, null),
+          fs.getWorkingDirectory());
     } finally {
       fs.close();
     }
@@ -206,7 +277,7 @@ public class DaosFileSystemTest {
     Configuration cfg = new Configuration(false);
     cfg.addResource("daos-site.xml");
     String s = cfg.get("fs.defaultFS");
-    Assert.assertEquals("daos://default:1", s);
+    Assert.assertEquals("daos:///", s);
     Assert.assertEquals(8388608, cfg.getInt("fs.daos.read.buffer.size", 0));
   }
 
@@ -220,7 +291,7 @@ public class DaosFileSystemTest {
     }
     cfg.addResource(tempFile.toURI().toURL(), false);
     String s = cfg.get("fs.defaultFS");
-    Assert.assertEquals("daos://default:1", s);
+    Assert.assertEquals("daos:///", s);
     Assert.assertEquals(8388608, cfg.getInt("fs.daos.read.buffer.size", 0));
   }
 
@@ -228,7 +299,34 @@ public class DaosFileSystemTest {
   public void testLoadingConfigFromCoreSite() throws Exception {
     Configuration cfg = new Configuration(true);
     String s = cfg.get("fs.defaultFS");
-    Assert.assertEquals("daos://id:2", s);
+    Assert.assertEquals("daos://id:2/", s);
     Assert.assertEquals(8388608, cfg.getInt("fs.daos.read.buffer.size", 0));
+  }
+
+  @Test
+  public void testSpecialUnsPath() throws Exception {
+    URI uri = URI.create("daos://uns:" + unsId.getAndIncrement() + "/tmp/uns_path#/abc");
+    Assert.assertEquals("/tmp/uns_path", uri.getPath());
+    Assert.assertEquals("/abc", uri.getFragment());
+
+    Path path = new Path("daos://uns:" + unsId.getAndIncrement() + "/tmp/uns_path#abc");
+    Path path1 = path.makeQualified(uri, null);
+    System.out.println(path1);
+
+
+    Assert.assertEquals("/tmp/uns_path#abc", path.toUri().getPath());
+    Assert.assertEquals(null, path.toUri().getFragment());
+
+    Path path2 = new Path("/abc");
+    System.out.println(path2.toString());
+    Path path3 = path2.makeQualified(uri, new Path("/user/zjf"));
+    System.out.println(path3.toString());
+
+    Path path4 = new Path("abc");
+    System.out.println(path4.toUri().getPath());
+
+    String s = "daos://uns:" + unsId.getAndIncrement() + "/tmp/uns_path#";
+    Path p6 = new Path(s + path2.toString());
+    System.out.println(p6);
   }
 }

--- a/src/client/java/hadoop-daos/src/test/java/io/daos/fs/hadoop/DaosHadoopTestUtils.java
+++ b/src/client/java/hadoop-daos/src/test/java/io/daos/fs/hadoop/DaosHadoopTestUtils.java
@@ -6,9 +6,9 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -28,26 +28,27 @@ import java.net.URI;
 /**
  *
  */
-public class DaosUtils {
+public class DaosHadoopTestUtils {
   private static Configuration configuration;
   public static final String TEST_FS_DAOS_NAME = "test.fs.daos.name";
 
-  private DaosUtils(){}
+  private DaosHadoopTestUtils() {
+  }
 
-  public static DaosFileSystem createTestFileSystem(Configuration conf)throws IOException{
+  public static DaosFileSystem createTestFileSystem(Configuration conf) throws IOException {
     DaosFileSystem daosFileSystem = new DaosFileSystem();
     configuration = conf;
     daosFileSystem.initialize(getURI(configuration), configuration);
     return daosFileSystem;
   }
 
-  public static Configuration getConfiguration(){
-    return configuration!=null ? configuration:null;
+  public static Configuration getConfiguration() {
+    return configuration != null ? configuration : null;
   }
 
   private static URI getURI(Configuration conf) {
     String fsname = conf.getTrimmed(
-            DaosUtils.TEST_FS_DAOS_NAME, "daos://192.168.2.1:23456/");
+        DaosHadoopTestUtils.TEST_FS_DAOS_NAME, "daos://192.168.2.1:23456/");
 
     boolean liveTest = !StringUtils.isEmpty(fsname);
     URI testURI = null;
@@ -58,7 +59,7 @@ public class DaosUtils {
 
     if (!liveTest) {
       throw new AssumptionViolatedException("No test filesystem in "
-          + DaosUtils.TEST_FS_DAOS_NAME);
+          + DaosHadoopTestUtils.TEST_FS_DAOS_NAME);
     }
     return testURI;
   }

--- a/src/client/java/hadoop-daos/src/test/java/io/daos/fs/hadoop/DaosInputStreamIT.java
+++ b/src/client/java/hadoop-daos/src/test/java/io/daos/fs/hadoop/DaosInputStreamIT.java
@@ -6,9 +6,9 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -41,7 +41,7 @@ import static org.junit.Assert.assertTrue;
 public class DaosInputStreamIT {
   private static final Logger LOG = LoggerFactory.getLogger(DaosInputStreamIT.class);
   private static FileSystem fs;
-  private static String testRootPath = DaosUtils.generateUniqueTestPath();
+  private static String testRootPath = DaosHadoopTestUtils.generateUniqueTestPath();
 
   @Rule
   public Timeout testTimeout = new Timeout(30 * 60 * 1000);
@@ -68,8 +68,8 @@ public class DaosInputStreamIT {
     fs.mkdirs(p);
     List<Path> files = new ArrayList<>();
 
-    for (int i=0; i<numFiles; i++) {
-      Path file = new Path(p, ""+i);
+    for (int i = 0; i < numFiles; i++) {
+      Path file = new Path(p, "" + i);
       files.add(file);
     }
     for (Path file : files) {
@@ -79,13 +79,13 @@ public class DaosInputStreamIT {
   }
 
   private Path setPath(String path) throws IOException {
-    Path p ;
+    Path p;
     if (path.startsWith("/")) {
       p = new Path(testRootPath + path);
     } else {
       p = new Path(testRootPath + "/" + path);
     }
-    if(!fs.exists(p.getParent())){
+    if (!fs.exists(p.getParent())) {
       fs.mkdirs(p.getParent());
     }
     return p;
@@ -138,7 +138,7 @@ public class DaosInputStreamIT {
     byte[] buf = new byte[bufLen];
     long bytesRead = 0;
     while (bytesRead < size) {
-      int bytes = 0 ;
+      int bytes = 0;
       if (size - bytesRead < bufLen) {
         int remaining = (int) (size - bytesRead);
         bytes = instream.read(buf, 0, remaining);
@@ -170,23 +170,23 @@ public class DaosInputStreamIT {
 
     FSDataInputStream fsDataInputStream = this.fs.open(smallSeekFile);
     assertTrue("expected position at:" + 0 + ", but got:"
-            + fsDataInputStream.getPos(), fsDataInputStream.getPos() == 0);
+        + fsDataInputStream.getPos(), fsDataInputStream.getPos() == 0);
     DaosInputStream in =
-            (DaosInputStream)fsDataInputStream.getWrappedStream();
+        (DaosInputStream) fsDataInputStream.getWrappedStream();
     byte[] buf = new byte[Constants.DEFAULT_DAOS_PRELOAD_SIZE];
-    in.read(buf,0, Constants.DEFAULT_DAOS_PRELOAD_SIZE);
+    in.read(buf, 0, Constants.DEFAULT_DAOS_PRELOAD_SIZE);
     assertTrue("expected position at:"
-                    + Constants.DEFAULT_DAOS_READ_BUFFER_SIZE + ", but got:"
-                    + in.getPos(),
-            in.getPos() == Constants.DEFAULT_DAOS_PRELOAD_SIZE);
+            + Constants.DEFAULT_DAOS_READ_BUFFER_SIZE + ", but got:"
+            + in.getPos(),
+        in.getPos() == Constants.DEFAULT_DAOS_PRELOAD_SIZE);
 
     fsDataInputStream.seek(4 * 1024 * 1024);
     buf = new byte[1 * 1024 * 1024];
-    in.read(buf,0, 1 * 1024 * 1024);
+    in.read(buf, 0, 1 * 1024 * 1024);
     assertTrue("expected position at:" + size + ", but got:"
-                      + in.getPos(),
-              in.getPos() == size);
+            + in.getPos(),
+        in.getPos() == size);
 
-      IOUtils.closeStream(fsDataInputStream);
+    IOUtils.closeStream(fsDataInputStream);
   }
 }

--- a/src/client/java/hadoop-daos/src/test/java/io/daos/fs/hadoop/DaosInputStreamTest.java
+++ b/src/client/java/hadoop-daos/src/test/java/io/daos/fs/hadoop/DaosInputStreamTest.java
@@ -6,9 +6,9 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -35,19 +35,19 @@ import static org.mockito.Mockito.*;
 public class DaosInputStreamTest {
 
   @Test(expected = IllegalArgumentException.class)
-  public void testNewDaosInputStreamNonDirectBuffer() throws Exception{
+  public void testNewDaosInputStreamNonDirectBuffer() throws Exception {
     DaosFile file = mock(DaosFile.class);
     new DaosInputStream(file, null, ByteBuffer.allocate(10), 10);
   }
 
   @Test(expected = IllegalArgumentException.class)
-  public void testNewDaosInputStreamIllegalSize() throws Exception{
+  public void testNewDaosInputStreamIllegalSize() throws Exception {
     DaosFile file = mock(DaosFile.class);
     new DaosInputStream(file, null, ByteBuffer.allocateDirect(10), 20);
   }
 
   @Test(expected = IllegalArgumentException.class)
-  public void testReadLenIllegal()throws Exception{
+  public void testReadLenIllegal() throws Exception {
     DaosFile file = mock(DaosFile.class);
     DaosInputStream is = new DaosInputStream(file, null, 10, 10);
     byte[] buf = new byte[10];
@@ -55,7 +55,7 @@ public class DaosInputStreamTest {
   }
 
   @Test(expected = IllegalArgumentException.class)
-  public void testReadOffsetIllegal()throws Exception{
+  public void testReadOffsetIllegal() throws Exception {
     DaosFile file = mock(DaosFile.class);
     DaosInputStream is = new DaosInputStream(file, null, 10, 10);
     byte[] buf = new byte[10];
@@ -63,7 +63,7 @@ public class DaosInputStreamTest {
   }
 
   @Test
-  public void testRead0Len()throws Exception{
+  public void testRead0Len() throws Exception {
     DaosFile file = mock(DaosFile.class);
     DaosInputStream is = new DaosInputStream(file, null, 10, 10);
     byte[] buf = new byte[10];
@@ -71,10 +71,10 @@ public class DaosInputStreamTest {
     Assert.assertEquals(0, len);
   }
 
-  private void readFromDaosOnce(int bufferCap, int preloadSize, int requestLen, long readLen)throws Exception{
+  private void readFromDaosOnce(int bufferCap, int preloadSize, int requestLen, long readLen) throws Exception {
     DaosFile file = mock(DaosFile.class);
     FileSystem.Statistics stats = mock(FileSystem.Statistics.class);
-    long actualReadLen = requestLen<preloadSize ? preloadSize:requestLen;
+    long actualReadLen = requestLen < preloadSize ? preloadSize : requestLen;
     when(file.read(any(ByteBuffer.class), anyLong(), anyLong(), eq(actualReadLen))).thenReturn(actualReadLen);
     when(file.length()).thenReturn(200L);
 
@@ -91,33 +91,33 @@ public class DaosInputStreamTest {
 
     Assert.assertEquals(0, offSetCap.getValue().intValue());
 
-    Assert.assertEquals(requestLen<preloadSize ? preloadSize:requestLen, is.getBuffer().limit());
+    Assert.assertEquals(requestLen < preloadSize ? preloadSize : requestLen, is.getBuffer().limit());
     Assert.assertEquals(requestLen, len);
     Assert.assertEquals(requestLen, is.getBuffer().position());
     Assert.assertEquals(requestLen, is.getPos());
   }
 
   @Test
-  public void testReadFromDaosLessThanPreload() throws Exception{
+  public void testReadFromDaosLessThanPreload() throws Exception {
     readFromDaosOnce(100, 50, 20, 20);
   }
 
   @Test
-  public void testReadFromDaosEqualToPreload() throws Exception{
+  public void testReadFromDaosEqualToPreload() throws Exception {
     readFromDaosOnce(100, 50, 50, 50);
   }
 
   @Test
-  public void testReadFromDaosGreaterThanPreload() throws Exception{
+  public void testReadFromDaosGreaterThanPreload() throws Exception {
     readFromDaosOnce(100, 50, 80, 80);
   }
 
   @Test
-  public void testReadFromDaosEqualToBufferCap() throws Exception{
+  public void testReadFromDaosEqualToBufferCap() throws Exception {
     readFromDaosOnce(100, 50, 100, 100);
   }
 
-  private void readFromDaosMultipleTimes(int requestLen, long actualRemainingLen, int readTimes)throws Exception{
+  private void readFromDaosMultipleTimes(int requestLen, long actualRemainingLen, int readTimes) throws Exception {
     int bufferCap = 100;
     int preloadSize = 50;
     DaosFile file = mock(DaosFile.class);
@@ -132,7 +132,7 @@ public class DaosInputStreamTest {
     long actualReadLen1 = 100;
     when(file.read(any(ByteBuffer.class), anyLong(), anyLong(), eq(actualReadLen1))).thenReturn(actualReadLen1);
 
-    long actualReadLen2 = actualRemainingLen<preloadSize ? preloadSize:actualRemainingLen;
+    long actualReadLen2 = actualRemainingLen < preloadSize ? preloadSize : actualRemainingLen;
     when(file.read(any(ByteBuffer.class), anyLong(), anyLong(), eq(actualReadLen2))).thenReturn(actualReadLen2);
 
     int len = is.read(buf, 0, requestLen);
@@ -143,41 +143,41 @@ public class DaosInputStreamTest {
     ArgumentCaptor<Integer> offSetCap = ArgumentCaptor.forClass(Integer.class);
     verify(sbuffer, times((readTimes + 1))).get(eq(buf), offSetCap.capture(), anyInt());
 
-    int mod = requestLen%bufferCap;
-    int remain = mod>preloadSize ? mod:preloadSize;
+    int mod = requestLen % bufferCap;
+    int remain = mod > preloadSize ? mod : preloadSize;
     Assert.assertEquals(remain, is.getBuffer().limit());
     Assert.assertEquals(requestLen, len);
     Assert.assertEquals(mod, is.getBuffer().position());
 
-    Integer expect[] = new Integer[readTimes+1];
-    for(int i=0; i<expect.length; i++){
-      expect[i] = i*100;
+    Integer expect[] = new Integer[readTimes + 1];
+    for (int i = 0; i < expect.length; i++) {
+      expect[i] = i * 100;
     }
     Assert.assertTrue(Arrays.equals(expect, offSetCap.getAllValues().toArray()));
     Assert.assertEquals(requestLen, is.getPos());
   }
 
   @Test
-  public void testReadFromDaosGreaterThanBufferCapAndRemainingLessThanPreload()throws Exception{
+  public void testReadFromDaosGreaterThanBufferCapAndRemainingLessThanPreload() throws Exception {
     readFromDaosMultipleTimes(249, 49, 2);
   }
 
   @Test
-  public void testReadFromDaosGreaterThanBufferCapAndRemainingEqualToPreload()throws Exception{
+  public void testReadFromDaosGreaterThanBufferCapAndRemainingEqualToPreload() throws Exception {
     readFromDaosMultipleTimes(350, 50, 3);
   }
 
   @Test
-  public void testReadFromDaosGreaterThanBufferCapAndRemainingGreaterThanPreload()throws Exception{
+  public void testReadFromDaosGreaterThanBufferCapAndRemainingGreaterThanPreload() throws Exception {
     readFromDaosMultipleTimes(463, 63, 4);
   }
 
   @Test
-  public void testSeekAndSkip() throws Exception{
+  public void testSeekAndSkip() throws Exception {
     DaosFile file = mock(DaosFile.class);
     FileSystem.Statistics stats = mock(FileSystem.Statistics.class);
 
-    when(file.length()).thenReturn((long)500);
+    when(file.length()).thenReturn((long) 500);
     DaosInputStream is = new DaosInputStream(file, stats, 100, 50);
     Assert.assertEquals(0, is.getPos());
 
@@ -189,7 +189,7 @@ public class DaosInputStreamTest {
   }
 
   @Test
-  public void testReadAllFromCache()throws Exception{
+  public void testReadAllFromCache() throws Exception {
     int bufferCap = 100;
     int preloadSize = 100;
     int requestLen = 50;
@@ -197,7 +197,7 @@ public class DaosInputStreamTest {
     DaosFile file = mock(DaosFile.class);
     FileSystem.Statistics stats = mock(FileSystem.Statistics.class);
 
-    when(file.length()).thenReturn((long)500);
+    when(file.length()).thenReturn((long) 500);
     ByteBuffer buffer = ByteBuffer.allocateDirect(bufferCap);
     ByteBuffer sbuffer = spy(buffer);
     DaosInputStream is = new DaosInputStream(file, stats, sbuffer, preloadSize);
@@ -234,7 +234,7 @@ public class DaosInputStreamTest {
   }
 
   @Test
-  public void testReadPartialFromCache()throws Exception{
+  public void testReadPartialFromCache() throws Exception {
     int bufferCap = 100;
     int preloadSize = 80;
     int requestLen = 320;
@@ -242,7 +242,7 @@ public class DaosInputStreamTest {
     DaosFile file = mock(DaosFile.class);
     FileSystem.Statistics stats = mock(FileSystem.Statistics.class);
 
-    when(file.length()).thenReturn((long)500);
+    when(file.length()).thenReturn((long) 500);
     ByteBuffer buffer = ByteBuffer.allocateDirect(bufferCap);
     ByteBuffer sbuffer = spy(buffer);
     DaosInputStream is = new DaosInputStream(file, stats, sbuffer, preloadSize);
@@ -253,15 +253,19 @@ public class DaosInputStreamTest {
 
     int len = is.read(buf, 0, requestLen);
 
-    verify(file, times(3)).read(any(ByteBuffer.class), eq(0L), anyLong(), eq(100L));
-    verify(file, times(1)).read(any(ByteBuffer.class), eq(0L), anyLong(), eq(80L));
+    verify(file, times(3)).read(any(ByteBuffer.class), eq(0L), anyLong(),
+        eq(100L));
+    verify(file, times(1)).read(any(ByteBuffer.class), eq(0L), anyLong(),
+        eq(80L));
     Assert.assertEquals(requestLen, len);
 
     when(file.read(any(ByteBuffer.class), eq(0L), anyLong(), eq(80L))).thenReturn(80L);
     len = is.read(buf, 0, 137);
 
-    verify(file, times(3)).read(any(ByteBuffer.class), eq(0L), anyLong(), eq(100L));
-    verify(file, times(2)).read(any(ByteBuffer.class), eq(0L), anyLong(), eq(80L));
+    verify(file, times(3)).read(any(ByteBuffer.class), eq(0L), anyLong(),
+        eq(100L));
+    verify(file, times(2)).read(any(ByteBuffer.class), eq(0L), anyLong(),
+        eq(80L));
 
     ArgumentCaptor<Integer> offSetCap = ArgumentCaptor.forClass(Integer.class);
     verify(sbuffer, times(3)).get(eq(buf), offSetCap.capture(), eq(100));
@@ -284,14 +288,14 @@ public class DaosInputStreamTest {
   }
 
   @Test
-  public void testReadSingleFromCache() throws Exception{
+  public void testReadSingleFromCache() throws Exception {
     int bufferCap = 100;
     int preloadSize = 80;
 
     DaosFile file = mock(DaosFile.class);
     FileSystem.Statistics stats = mock(FileSystem.Statistics.class);
 
-    when(file.length()).thenReturn((long)500);
+    when(file.length()).thenReturn((long) 500);
     ByteBuffer buffer = ByteBuffer.allocateDirect(bufferCap);
     ByteBuffer sbuffer = spy(buffer);
     DaosInputStream is = new DaosInputStream(file, stats, sbuffer, preloadSize);
@@ -301,18 +305,18 @@ public class DaosInputStreamTest {
     is.seek(5);
 
     int b = is.read();
-    Assert.assertEquals('f', (byte)b);
+    Assert.assertEquals('f', (byte) b);
   }
 
   @Test
-  public void testReadSingleFromDaos() throws Exception{
+  public void testReadSingleFromDaos() throws Exception {
     int bufferCap = 100;
     int preloadSize = 80;
 
     DaosFile file = mock(DaosFile.class);
     FileSystem.Statistics stats = mock(FileSystem.Statistics.class);
 
-    when(file.length()).thenReturn((long)500);
+    when(file.length()).thenReturn((long) 500);
 
     ByteBuffer buffer = ByteBuffer.allocateDirect(bufferCap);
     ByteBuffer sbuffer = spy(buffer);
@@ -320,7 +324,7 @@ public class DaosInputStreamTest {
 
     Answer<Long> answer = (invocation) -> {
       sbuffer.limit(1);
-      sbuffer.put((byte)'a');
+      sbuffer.put((byte) 'a');
       sbuffer.flip();
       return 80L;
     };
@@ -328,17 +332,17 @@ public class DaosInputStreamTest {
 
     int b = is.read();
 
-    Assert.assertEquals('a', (byte)b);
+    Assert.assertEquals('a', (byte) b);
     verify(file, times(1)).read(any(ByteBuffer.class), anyLong(), anyLong(), eq(80L));
     verify(sbuffer, times(1)).get(any(byte[].class), eq(0), eq(1));
   }
 
   @Test
-  public void testAvailable() throws Exception{
+  public void testAvailable() throws Exception {
     DaosFile file = mock(DaosFile.class);
     FileSystem.Statistics stats = mock(FileSystem.Statistics.class);
 
-    when(file.length()).thenReturn((long)500);
+    when(file.length()).thenReturn((long) 500);
     ByteBuffer buffer = ByteBuffer.allocateDirect(100);
     ByteBuffer sbuffer = spy(buffer);
     DaosInputStream is = new DaosInputStream(file, stats, sbuffer, 80);
@@ -347,11 +351,11 @@ public class DaosInputStreamTest {
     is.close();
   }
 
-  private DaosInputStream close()throws Exception{
+  private DaosInputStream close() throws Exception {
     DaosFile file = mock(DaosFile.class);
     FileSystem.Statistics stats = mock(FileSystem.Statistics.class);
 
-    when(file.length()).thenReturn((long)500);
+    when(file.length()).thenReturn((long) 500);
     ByteBuffer buffer = ByteBuffer.allocateDirect(100);
     ByteBuffer sbuffer = spy(buffer);
     DaosInputStream is = new DaosInputStream(file, stats, sbuffer, 80);
@@ -362,12 +366,12 @@ public class DaosInputStreamTest {
   }
 
   @Test
-  public void testClose() throws Exception{
+  public void testClose() throws Exception {
     close();
   }
 
   @Test(expected = IOException.class)
-  public void testOperationAfterClose() throws Exception{
+  public void testOperationAfterClose() throws Exception {
     DaosInputStream is = close();
     is.read(null, 0, 0);
   }
@@ -382,24 +386,24 @@ public class DaosInputStreamTest {
     byte[] data = new byte[]{19, 49, 89, 64, 20, 19, 1, 2, 3};
 
     doAnswer(
-      invocationOnMock -> {
-        ByteBuffer buffer = (ByteBuffer) invocationOnMock.getArguments()[0];
-        long bufferOffset = (long) invocationOnMock.getArguments()[1];
-        long len = (long) invocationOnMock.getArguments()[3];
-        long i;
-        for (i = bufferOffset; i < bufferOffset + len; i++) {
-          buffer.put((int) i, data[(int) (i - bufferOffset)]);
-        }
-        buffer.limit((int)i);
-        return len;
-      })
-      .when(file)
-      .read(any(ByteBuffer.class), anyLong(), anyLong(), anyLong());
-    doReturn((long)data.length).when(file).length();
+        invocationOnMock -> {
+          ByteBuffer buffer = (ByteBuffer) invocationOnMock.getArguments()[0];
+          long bufferOffset = (long) invocationOnMock.getArguments()[1];
+          long len = (long) invocationOnMock.getArguments()[3];
+          long i;
+          for (i = bufferOffset; i < bufferOffset + len; i++) {
+            buffer.put((int) i, data[(int) (i - bufferOffset)]);
+          }
+          buffer.limit((int) i);
+          return len;
+        })
+        .when(file)
+        .read(any(ByteBuffer.class), anyLong(), anyLong(), anyLong());
+    doReturn((long) data.length).when(file).length();
 
     boolean[] trueFalse = new boolean[]{true, false};
 
-    for (int j = 0; j < 2; j ++) {
+    for (int j = 0; j < 2; j++) {
       boolean bufferedReadEnabled = trueFalse[j];
       int preloadSize = bufferedReadEnabled ? bufferSize : 0;
       DaosInputStream input = new DaosInputStream(file, stats, internalBuffer, preloadSize);
@@ -431,31 +435,31 @@ public class DaosInputStreamTest {
     byte[] data = new byte[]{19, 49, 89, 64, 20, 19, 1, 2, 3};
 
     doAnswer(
-      invocationOnMock -> {
-        ByteBuffer buffer = (ByteBuffer) invocationOnMock.getArguments()[0];
-        long bufferOffset = (long) invocationOnMock.getArguments()[1];
-        long fileOffset = (long) invocationOnMock.getArguments()[2];
-        long len = (long) invocationOnMock.getArguments()[3];
-        if (len > buffer.capacity() - bufferOffset) {
-          throw new IOException(
-                  String.format("buffer (%d) has no enough space start at %d for reading %d bytes from file",
-                          buffer.capacity(), bufferOffset, len));
-        }
-        long actualRead = 0;
-        for (long i = bufferOffset; i < bufferOffset + len &&
-                (i - bufferOffset + fileOffset) < data.length; i++) {
-          buffer.put((int) i, data[(int) (i - bufferOffset + fileOffset)]);
-          actualRead ++;
-        }
-        return actualRead;
-      })
+        invocationOnMock -> {
+          ByteBuffer buffer = (ByteBuffer) invocationOnMock.getArguments()[0];
+          long bufferOffset = (long) invocationOnMock.getArguments()[1];
+          long fileOffset = (long) invocationOnMock.getArguments()[2];
+          long len = (long) invocationOnMock.getArguments()[3];
+          if (len > buffer.capacity() - bufferOffset) {
+            throw new IOException(
+                String.format("buffer (%d) has no enough space start at %d for reading %d bytes from file",
+                    buffer.capacity(), bufferOffset, len));
+          }
+          long actualRead = 0;
+          for (long i = bufferOffset; i < bufferOffset + len &&
+              (i - bufferOffset + fileOffset) < data.length; i++) {
+            buffer.put((int) i, data[(int) (i - bufferOffset + fileOffset)]);
+            actualRead++;
+          }
+          return actualRead;
+        })
         .when(file)
         .read(any(ByteBuffer.class), anyLong(), anyLong(), anyLong());
-    doReturn((long)data.length).when(file).length();
+    doReturn((long) data.length).when(file).length();
 
     boolean[] trueFalse = new boolean[]{true, false};
 
-    for (int j = 0; j < 2; j ++) {
+    for (int j = 0; j < 2; j++) {
       boolean bufferedReadEnabled = trueFalse[j];
       int preloadSize = bufferedReadEnabled ? bufferSize : 0;
       DaosInputStream input = new DaosInputStream(file, stats, internalBuffer, preloadSize);
@@ -488,35 +492,35 @@ public class DaosInputStreamTest {
     AtomicInteger timesReadFromDaos = new AtomicInteger(0);
 
     doAnswer(
-      invocationOnMock -> {
-        ByteBuffer buffer = (ByteBuffer) invocationOnMock.getArguments()[0];
-        int times = timesReadFromDaos.incrementAndGet();
-        Assert.assertTrue("Read to internal buffer more than once!", times <= 1);
-        long bufferOffset = (long) invocationOnMock.getArguments()[1];
-        long fileOffset = (long) invocationOnMock.getArguments()[2];
-        long len = (long) invocationOnMock.getArguments()[3];
-        if (len > buffer.capacity() - bufferOffset) {
-          throw new IOException(
-            String.format("buffer (%d) has no enough space start at %d for reading %d bytes from file",
-              buffer.capacity(), bufferOffset, len));
-        }
-        long actualRead = 0;
-        for (long i = bufferOffset; i < bufferOffset + len &&
-                (i - bufferOffset + fileOffset) < data.length; i++) {
-          buffer.put((int) i, data[(int) (i - bufferOffset + fileOffset)]);
-          actualRead ++;
-        }
-        return actualRead;
-      })
-      .when(file)
-      .read(any(ByteBuffer.class), anyLong(), anyLong(), anyLong());
-    doReturn((long)data.length).when(file).length();
+        invocationOnMock -> {
+          ByteBuffer buffer = (ByteBuffer) invocationOnMock.getArguments()[0];
+          int times = timesReadFromDaos.incrementAndGet();
+          Assert.assertTrue("Read to internal buffer more than once!", times <= 1);
+          long bufferOffset = (long) invocationOnMock.getArguments()[1];
+          long fileOffset = (long) invocationOnMock.getArguments()[2];
+          long len = (long) invocationOnMock.getArguments()[3];
+          if (len > buffer.capacity() - bufferOffset) {
+            throw new IOException(
+                String.format("buffer (%d) has no enough space start at %d for reading %d bytes from file",
+                    buffer.capacity(), bufferOffset, len));
+          }
+          long actualRead = 0;
+          for (long i = bufferOffset; i < bufferOffset + len &&
+              (i - bufferOffset + fileOffset) < data.length; i++) {
+            buffer.put((int) i, data[(int) (i - bufferOffset + fileOffset)]);
+            actualRead++;
+          }
+          return actualRead;
+        })
+        .when(file)
+        .read(any(ByteBuffer.class), anyLong(), anyLong(), anyLong());
+    doReturn((long) data.length).when(file).length();
 
     DaosInputStream input = new DaosInputStream(file, stats, internalBuffer, bufferSize);
     int readSize = 3;
     byte[] answer = new byte[bufferSize];
     input.read(answer, 0, readSize);
-    input.read(answer, readSize, bufferSize-readSize);
+    input.read(answer, readSize, bufferSize - readSize);
     byte[] expect = data;
     Assert.assertArrayEquals(expect, answer);
   }

--- a/src/client/java/hadoop-daos/src/test/java/io/daos/fs/hadoop/DaosOutputStreamIT.java
+++ b/src/client/java/hadoop-daos/src/test/java/io/daos/fs/hadoop/DaosOutputStreamIT.java
@@ -6,9 +6,9 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -34,21 +34,19 @@ import static org.junit.Assert.assertEquals;
  */
 public class DaosOutputStreamIT {
   private static FileSystem fs;
-  private static String testRootPath = DaosUtils.generateUniqueTestPath();
+  private static String testRootPath = DaosHadoopTestUtils.generateUniqueTestPath();
 
   @Rule
   public Timeout testTimeout = new Timeout(30 * 60 * 1000);
 
   @BeforeClass
   public static void setup() throws IOException {
-    System.out.println("@BeforeClass");
     fs = DaosFSFactory.getFS();
     fs.mkdirs(new Path(testRootPath));
   }
 
   @AfterClass
-  public  static void tearDown() throws Exception {
-    System.out.println("@AfterClass");
+  public static void tearDown() throws Exception {
     if (fs != null) {
       fs.delete(new Path(testRootPath), true);
     }
@@ -57,7 +55,7 @@ public class DaosOutputStreamIT {
 
   private Path getTestPath() throws IOException {
     Path p = new Path(testRootPath + "/daos");
-    if(!fs.exists(p)){
+    if (!fs.exists(p)) {
       fs.mkdirs(p);
     }
     return p;
@@ -73,7 +71,7 @@ public class DaosOutputStreamIT {
     ContractTestUtils.generateTestFile(fs, file, size, 256, 255);
     try {
       ContractTestUtils.generateTestFile(fs, file, size, 256, 255);
-    } catch (FileAlreadyExistsException e ) {
+    } catch (FileAlreadyExistsException e) {
       // throw new FileAlreadyExistsException
     }
     Assert.assertEquals(1024, fs.listStatus(file)[0].getLen());
@@ -89,7 +87,7 @@ public class DaosOutputStreamIT {
     FileSystem.clearStatistics();
     long size = 1024 * 1024;
     FileSystem.Statistics statistics =
-            FileSystem.getStatistics("daos", DaosFileSystem.class);
+        FileSystem.getStatistics("daos", DaosFileSystem.class);
     // This test is a little complicated for statistics, lifecycle is
     // generateTestFile
     //   fs.create(getFileStatus)    read 1
@@ -101,12 +99,11 @@ public class DaosOutputStreamIT {
     // fs.delete
     //   getFileStatus & delete & exists & create fake dir read 2, write 2
     ContractTestUtils.createAndVerifyFile(fs, getTestPath(), size - 1);
-    int readNum = (int) (size-1)/ Constants.DEFAULT_DAOS_PRELOAD_SIZE + 1;
+    int readNum = (int) (size - 1) / Constants.DEFAULT_DAOS_PRELOAD_SIZE + 1;
     assertEquals(readNum, statistics.getReadOps());
     assertEquals(size - 1, statistics.getBytesRead());
-    int writeNum = (int) (size-1)/ Constants.DEFAULT_DAOS_WRITE_BUFFER_SIZE + 1;
+    int writeNum = (int) (size - 1) / Constants.DEFAULT_DAOS_WRITE_BUFFER_SIZE + 1;
     assertEquals(writeNum, statistics.getWriteOps());
     assertEquals(size - 1, statistics.getBytesWritten());
   }
-
 }

--- a/src/client/java/hadoop-daos/src/test/java/io/daos/fs/hadoop/DaosOutputStreamTest.java
+++ b/src/client/java/hadoop-daos/src/test/java/io/daos/fs/hadoop/DaosOutputStreamTest.java
@@ -6,9 +6,9 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -33,14 +33,14 @@ import static org.mockito.Mockito.*;
 public class DaosOutputStreamTest {
 
   @Test(expected = IllegalArgumentException.class)
-  public void testNonDirectBuffer() throws Exception{
+  public void testNonDirectBuffer() throws Exception {
     FileSystem.Statistics stats = mock(FileSystem.Statistics.class);
     DaosOutputStream dos = new DaosOutputStream(null, null, ByteBuffer.allocate(100), stats);
     dos.close();
   }
 
   @Test(expected = IllegalArgumentException.class)
-  public void testWriteLenIllegal()throws Exception{
+  public void testWriteLenIllegal() throws Exception {
     DaosFile file = mock(DaosFile.class);
     FileSystem.Statistics stats = mock(FileSystem.Statistics.class);
     DaosOutputStream os = new DaosOutputStream(file, "/zjf", 100, stats);
@@ -49,7 +49,7 @@ public class DaosOutputStreamTest {
   }
 
   @Test(expected = IndexOutOfBoundsException.class)
-  public void testWriteOverflowException()throws Exception{
+  public void testWriteOverflowException() throws Exception {
     DaosFile file = mock(DaosFile.class);
     FileSystem.Statistics stats = mock(FileSystem.Statistics.class);
     DaosOutputStream os = new DaosOutputStream(file, "/zjf", 100, stats);
@@ -57,7 +57,7 @@ public class DaosOutputStreamTest {
     os.write(buf, 0, 200);
   }
 
-  private void writeNoMoreThanBuffer(int writeLen, int writeTimes)throws Exception{
+  private void writeNoMoreThanBuffer(int writeLen, int writeTimes) throws Exception {
     int bufCap = 100;
     DaosFile file = mock(DaosFile.class);
     FileSystem.Statistics stats = mock(FileSystem.Statistics.class);
@@ -65,21 +65,22 @@ public class DaosOutputStreamTest {
     ByteBuffer sbuffer = spy(byteBuffer);
     DaosOutputStream daos = new DaosOutputStream(file, "/zjf", sbuffer, stats);
     byte buf[] = new byte[writeLen];
-    for(int i=0; i<buf.length; i++){
-      buf[i] = (byte)i;
+    for (int i = 0; i < buf.length; i++) {
+      buf[i] = (byte) i;
     }
 
     daos.write(buf, 0, buf.length);
 
     boolean less = writeLen < bufCap;
     boolean mod = writeLen % bufCap == 0;
-    int fullBufferTimes = less ? 0 : (mod ? writeTimes:writeTimes-1);
+    int fullBufferTimes = less ? 0 : (mod ? writeTimes : writeTimes - 1);
     verify(file, times(fullBufferTimes)).write(sbuffer, 0L, 0L,
-            bufCap);
+        bufCap);
     daos.close();
     verify(sbuffer, times(fullBufferTimes)).put(buf, 0, bufCap);
-    verify(sbuffer, times(writeTimes-fullBufferTimes)).put(buf, 0, writeLen%bufCap);
-    verify(file, times(writeTimes-fullBufferTimes)).write(sbuffer, 0L, 0L, writeLen%bufCap);
+    verify(sbuffer, times(writeTimes - fullBufferTimes)).put(buf, 0, writeLen % bufCap);
+    verify(file, times(writeTimes - fullBufferTimes)).write(sbuffer, 0L, 0L,
+        writeLen % bufCap);
   }
 
   @Test
@@ -92,7 +93,7 @@ public class DaosOutputStreamTest {
     writeNoMoreThanBuffer(100, 1);
   }
 
-  public void writeOne(boolean flush)throws Exception{
+  public void writeOne(boolean flush) throws Exception {
     int bufCap = 100;
     DaosFile file = mock(DaosFile.class);
     FileSystem.Statistics stats = mock(FileSystem.Statistics.class);
@@ -103,10 +104,10 @@ public class DaosOutputStreamTest {
     daos.write('e');
 
     verify(file, times(0)).write(sbuffer, 0L, 0L,
-            bufCap);
-    verify(sbuffer, times(1)).put((byte)'e');
+        bufCap);
+    verify(sbuffer, times(1)).put((byte) 'e');
 
-    if (flush){
+    if (flush) {
       daos.flush();
     } else {
       daos.close();
@@ -115,16 +116,16 @@ public class DaosOutputStreamTest {
   }
 
   @Test
-  public void testWriteOneByte()throws Exception{
+  public void testWriteOneByte() throws Exception {
     writeOne(false);
   }
 
   @Test
-  public void testFlush()throws Exception{
+  public void testFlush() throws Exception {
     writeOne(true);
   }
 
-  private void writeMoreThanBuffer(int writeLen, int writeTimes)throws Exception{
+  private void writeMoreThanBuffer(int writeLen, int writeTimes) throws Exception {
     int bufCap = 100;
     DaosFile file = mock(DaosFile.class);
     FileSystem.Statistics stats = mock(FileSystem.Statistics.class);
@@ -132,41 +133,44 @@ public class DaosOutputStreamTest {
     ByteBuffer sbuffer = spy(byteBuffer);
     DaosOutputStream daos = new DaosOutputStream(file, "/zjf", sbuffer, stats);
     byte buf[] = new byte[writeLen];
-    for(int i=0; i<buf.length; i++){
-      buf[i] = (byte)i;
+    for (int i = 0; i < buf.length; i++) {
+      buf[i] = (byte) i;
     }
 
-    when(file.write(any(ByteBuffer.class), anyLong(), anyLong(), eq((long)bufCap))).thenReturn((long)bufCap);
-    when(file.write(any(ByteBuffer.class), anyLong(), anyLong(), eq((long)writeLen % bufCap))).thenReturn((long)writeLen % bufCap);
+    when(file.write(any(ByteBuffer.class), anyLong(), anyLong(), eq((long) bufCap))).thenReturn((long) bufCap);
+    when(file.write(any(ByteBuffer.class), anyLong(), anyLong(),
+        eq((long) writeLen % bufCap))).thenReturn((long) writeLen % bufCap);
     daos.write(buf, 0, buf.length);
 
     boolean less = writeLen < bufCap;
     boolean mod = writeLen % bufCap == 0;
-    int fullBufferTimes = less ? 0 : (mod ? writeTimes:writeTimes-1);
+    int fullBufferTimes = less ? 0 : (mod ? writeTimes : writeTimes - 1);
 
     ArgumentCaptor<Long> writeCaptor1 = ArgumentCaptor.forClass(Long.class);
     verify(file, times(fullBufferTimes)).write(eq(sbuffer), eq(0L), writeCaptor1.capture(),
-            eq((long)bufCap));
+        eq((long) bufCap));
 
     ArgumentCaptor<Integer> bufCaptor1 = ArgumentCaptor.forClass(Integer.class);
     verify(sbuffer, times(fullBufferTimes)).put(eq(buf), bufCaptor1.capture(), eq(bufCap));
     ArgumentCaptor<Integer> bufCaptor2 = ArgumentCaptor.forClass(Integer.class);
-    verify(sbuffer, times(writeTimes-fullBufferTimes)).put(eq(buf), bufCaptor2.capture(), eq(writeLen%bufCap));
+    verify(sbuffer, times(writeTimes - fullBufferTimes)).put(eq(buf), bufCaptor2.capture(),
+        eq(writeLen % bufCap));
 
     daos.close();
 
     ArgumentCaptor<Long> writeCaptor2 = ArgumentCaptor.forClass(Long.class);
-    verify(file, times(writeTimes-fullBufferTimes)).write(eq(sbuffer), eq(0L), writeCaptor2.capture(), eq((long)writeLen%bufCap));
+    verify(file, times(writeTimes - fullBufferTimes)).write(eq(sbuffer),
+        eq(0L), writeCaptor2.capture(), eq((long) writeLen % bufCap));
 
     Long write1Exp[] = new Long[fullBufferTimes];
-    for(int i=0; i<write1Exp.length; i++){
-      write1Exp[i] = (long)i*bufCap;
+    for (int i = 0; i < write1Exp.length; i++) {
+      write1Exp[i] = (long) i * bufCap;
     }
     Assert.assertTrue(Arrays.equals(write1Exp, writeCaptor1.getAllValues().toArray(new Long[write1Exp.length])));
 
     Integer buf1Exp[] = new Integer[fullBufferTimes];
-    for(int i=0; i<write1Exp.length; i++){
-      buf1Exp[i] = i*bufCap;
+    for (int i = 0; i < write1Exp.length; i++) {
+      buf1Exp[i] = i * bufCap;
     }
     Assert.assertTrue(Arrays.equals(buf1Exp, bufCaptor1.getAllValues().toArray(new Integer[buf1Exp.length])));
 
@@ -186,7 +190,7 @@ public class DaosOutputStreamTest {
     writeMoreThanBuffer(535, 6);
   }
 
-  private DaosOutputStream close()throws Exception{
+  private DaosOutputStream close() throws Exception {
     int bufCap = 100;
     DaosFile file = mock(DaosFile.class);
     FileSystem.Statistics stats = mock(FileSystem.Statistics.class);
@@ -201,12 +205,12 @@ public class DaosOutputStreamTest {
   }
 
   @Test
-  public void testClose() throws Exception{
+  public void testClose() throws Exception {
     close();
   }
 
   @Test(expected = IOException.class)
-  public void testOperationAfterClose() throws Exception{
+  public void testOperationAfterClose() throws Exception {
     DaosOutputStream dos = close();
     dos.write('e');
   }

--- a/src/client/java/hadoop-daos/src/test/java/io/daos/fs/hadoop/HadoopCmdIT.java
+++ b/src/client/java/hadoop-daos/src/test/java/io/daos/fs/hadoop/HadoopCmdIT.java
@@ -6,9 +6,9 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -83,8 +83,8 @@ public class HadoopCmdIT {
   @Test
   public void testMkdir() throws Exception {
     String filePath = "/job_1581472776049_0003-1581473346405-" +
-            "root-autogen%2D7.1%2DSNAPSHOT%2Djar%2Dwith%2Ddependencies.jar-" +
-            "1581473454525-16-1-SUCCEEDED-default-1581473439146.jhist_tmp";
+        "root-autogen%2D7.1%2DSNAPSHOT%2Djar%2Dwith%2Ddependencies.jar-" +
+        "1581473454525-16-1-SUCCEEDED-default-1581473439146.jhist_tmp";
     String[] argv = new String[]{"-rm", "-r", filePath};
     int res = run(argv);
 //    Assert.assertTrue(res == 0);

--- a/src/client/java/hadoop-daos/src/test/java/io/daos/fs/hadoop/contract/DaosContractCreateIT.java
+++ b/src/client/java/hadoop-daos/src/test/java/io/daos/fs/hadoop/contract/DaosContractCreateIT.java
@@ -6,9 +6,9 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/src/client/java/hadoop-daos/src/test/java/io/daos/fs/hadoop/contract/DaosContractDeleteIT.java
+++ b/src/client/java/hadoop-daos/src/test/java/io/daos/fs/hadoop/contract/DaosContractDeleteIT.java
@@ -6,9 +6,9 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/src/client/java/hadoop-daos/src/test/java/io/daos/fs/hadoop/contract/DaosContractIT.java
+++ b/src/client/java/hadoop-daos/src/test/java/io/daos/fs/hadoop/contract/DaosContractIT.java
@@ -6,9 +6,9 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -18,7 +18,6 @@
 
 package io.daos.fs.hadoop.contract;
 
-import io.daos.fs.hadoop.DaosUtils;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.contract.AbstractBondedFSContract;
@@ -27,13 +26,14 @@ import java.io.IOException;
 
 public class DaosContractIT extends AbstractBondedFSContract {
   private static final String CONTRACT_XML = "contract/daos.xml";
+
   protected DaosContractIT(Configuration conf) {
-        super(conf);
-        addConfResource(CONTRACT_XML);
-    }
+    super(conf);
+    addConfResource(CONTRACT_XML);
+  }
 
   @Override
   public String getScheme() {
-        return "daos";
-    }
+    return "daos";
+  }
 }

--- a/src/client/java/hadoop-daos/src/test/java/io/daos/fs/hadoop/contract/DaosContractMkdirIT.java
+++ b/src/client/java/hadoop-daos/src/test/java/io/daos/fs/hadoop/contract/DaosContractMkdirIT.java
@@ -6,9 +6,9 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -34,5 +34,4 @@ public class DaosContractMkdirIT extends AbstractContractMkdirTest {
     configuration.set(Constants.DAOS_POOL_SVC, DaosFSFactory.svc);
     return new DaosContractIT(configuration);
   }
-
 }

--- a/src/client/java/hadoop-daos/src/test/java/io/daos/fs/hadoop/contract/DaosContractOpenIT.java
+++ b/src/client/java/hadoop-daos/src/test/java/io/daos/fs/hadoop/contract/DaosContractOpenIT.java
@@ -6,9 +6,9 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/src/client/java/hadoop-daos/src/test/java/io/daos/fs/hadoop/contract/DaosContractRenameIT.java
+++ b/src/client/java/hadoop-daos/src/test/java/io/daos/fs/hadoop/contract/DaosContractRenameIT.java
@@ -6,9 +6,9 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/src/client/java/hadoop-daos/src/test/java/io/daos/fs/hadoop/contract/DaosContractRootDirIT.java
+++ b/src/client/java/hadoop-daos/src/test/java/io/daos/fs/hadoop/contract/DaosContractRootDirIT.java
@@ -6,9 +6,9 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -33,5 +33,4 @@ public class DaosContractRootDirIT extends AbstractContractRootDirectoryTest {
     configuration.set(Constants.DAOS_POOL_SVC, DaosFSFactory.svc);
     return new DaosContractIT(configuration);
   }
-
 }

--- a/src/client/java/hadoop-daos/src/test/java/io/daos/fs/hadoop/contract/DaosContractSeekIT.java
+++ b/src/client/java/hadoop-daos/src/test/java/io/daos/fs/hadoop/contract/DaosContractSeekIT.java
@@ -33,5 +33,4 @@ public class DaosContractSeekIT extends AbstractContractSeekTest {
     configuration.set(Constants.DAOS_POOL_SVC, DaosFSFactory.svc);
     return new DaosContractIT(configuration);
   }
-
 }

--- a/src/client/java/hadoop-daos/src/test/java/io/daos/fs/hadoop/multiple/MultipleDaosOpenFileIT.java
+++ b/src/client/java/hadoop-daos/src/test/java/io/daos/fs/hadoop/multiple/MultipleDaosOpenFileIT.java
@@ -6,9 +6,9 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -41,23 +41,23 @@ public class MultipleDaosOpenFileIT {
   }
 
   @Test
-  public void testConcurrentRead() throws Exception{
+  public void testConcurrentRead() throws Exception {
     String path = "/test/data";
     DataOutputStream os = fs.create(new Path(path));
-    for (int i=0; i<100000; i++) {
+    for (int i = 0; i < 100000; i++) {
       os.write("abcdddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd".getBytes());
     }
     os.close();
 
     List<ReadThread> list = new ArrayList<>();
     int num = 20;
-    for (int i=0; i<num; i++) {
+    for (int i = 0; i < num; i++) {
       list.add(new ReadThread(fs, path));
     }
-    for (int i=0; i<num; i++) {
+    for (int i = 0; i < num; i++) {
       list.get(i).start();
     }
-    for (int i=0; i<num; i++) {
+    for (int i = 0; i < num; i++) {
       list.get(i).join();
     }
   }
@@ -65,23 +65,25 @@ public class MultipleDaosOpenFileIT {
   private static class ReadThread extends Thread {
     String path;
     FileSystem fs;
-    ReadThread(FileSystem fs, String path){
+
+    ReadThread(FileSystem fs, String path) {
       this.fs = fs;
       this.path = path;
     }
+
     @Override
     public void run() {
       byte[] bytes = new byte[100000];
       Random random = new Random();
-      try(DataInputStream dis = fs.open(new Path(path))){
-        while(dis.read(bytes)>0){
+      try (DataInputStream dis = fs.open(new Path(path))) {
+        while (dis.read(bytes) > 0) {
           try {
             Thread.sleep(random.nextInt(100));
-          }catch (InterruptedException e){
+          } catch (InterruptedException e) {
             e.printStackTrace();
           }
         }
-      }catch (IOException e){
+      } catch (IOException e) {
         e.printStackTrace();
       }
     }

--- a/src/client/java/hadoop-daos/src/test/java/io/daos/fs/hadoop/perf/Main.java
+++ b/src/client/java/hadoop-daos/src/test/java/io/daos/fs/hadoop/perf/Main.java
@@ -6,9 +6,9 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -31,7 +31,7 @@ import java.util.concurrent.*;
 import io.daos.dfs.DaosFile;
 import io.daos.dfs.DaosFsClient;
 import io.daos.fs.hadoop.Constants;
-import io.daos.fs.hadoop.DaosConfig;
+import io.daos.fs.hadoop.DaosConfigFile;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FSDataInputStream;
 import org.apache.hadoop.fs.FSDataOutputStream;
@@ -119,7 +119,7 @@ public class Main {
     protected String api;
     protected String scriptPath;
 
-    protected Runner(FileSystem fs){
+    protected Runner(FileSystem fs) {
       this.fs = fs;
     }
 
@@ -128,7 +128,7 @@ public class Main {
       seq = System.getProperty("seq");
       System.out.println("seq: " + seq);
       String hostname = InetAddress.getLocalHost().getHostName();
-      path = path + "/" + hostname + "/" + (seq==null?"":seq);
+      path = path + "/" + hostname + "/" + (seq == null ? "" : seq);
       System.out.println("write path: " + path);
       jvmThreads = Integer.valueOf(System.getProperty("jvmThreads", "1"));
       System.out.println("JVM threads: " + jvmThreads);
@@ -141,20 +141,20 @@ public class Main {
     public abstract void run() throws Exception;
   }
 
-  static abstract class WriteRunner extends Runner{
+  static abstract class WriteRunner extends Runner {
     protected int writeSize;
     protected long fileSize;
 
-    protected WriteRunner(FileSystem fs){
+    protected WriteRunner(FileSystem fs) {
       super(fs);
     }
 
     protected void prepare() throws Exception {
       super.prepare();
-      writeSize = Integer.parseInt(DaosConfig.getInstance().getFromDaosFile(Constants.DAOS_WRITE_BUFFER_SIZE,
-              String.valueOf(Constants.DEFAULT_DAOS_WRITE_BUFFER_SIZE)));
+      writeSize = Integer.parseInt(DaosConfigFile.getInstance().getFromDaosFile(Constants.DAOS_WRITE_BUFFER_SIZE,
+          String.valueOf(Constants.DEFAULT_DAOS_WRITE_BUFFER_SIZE)));
       System.out.println("write buffer size: " + writeSize);
-      fileSize = Long.valueOf(System.getProperty("fileSize", String.valueOf(1L * 1024L*1024L*1024L)));
+      fileSize = Long.valueOf(System.getProperty("fileSize", String.valueOf(1L * 1024L * 1024L * 1024L)));
       System.out.println("file size: " + fileSize);
     }
   }
@@ -173,13 +173,13 @@ public class Main {
     }
 
     @Override
-    public void run() throws Exception{
+    public void run() throws Exception {
       prepare();
 
       ExecutorService executor = Executors.newFixedThreadPool(parallel);
       List<Future<Double>> futures = new ArrayList<>();
-      for (int i=0; i<parallel; i++) {
-        Future<Double> future = executor.submit(new WriteTask(i, fs, path+"/thread"+i, writeSize, fileSize));
+      for (int i = 0; i < parallel; i++) {
+        Future<Double> future = executor.submit(new WriteTask(i, fs, path + "/thread" + i, writeSize, fileSize));
         futures.add(future);
       }
 
@@ -210,8 +210,8 @@ public class Main {
       prepare();
 
       List<ShellExecutor> executors = new ArrayList<>();
-      for (int i=0; i<parallel; i++) {
-        File dir = new File(".", i+"");
+      for (int i = 0; i < parallel; i++) {
+        File dir = new File(".", i + "");
         if (!dir.exists()) {
           dir.mkdir();
         }
@@ -259,6 +259,7 @@ public class Main {
     List<String> cmdList;
     String resultPrefix;
     String finalRstPrefix;
+
     ShellExecutor(int id, List<String> cmdList, File out, File err, String resultPrefix, String finalRstPrefix) {
       this.id = id;
       this.cmdList = cmdList;
@@ -269,14 +270,14 @@ public class Main {
       this.finalRstPrefix = finalRstPrefix;
     }
 
-    public void execute() throws Exception{
+    public void execute() throws Exception {
       process = pb.start();
     }
 
-    public Double getPerf() throws Exception{
+    public Double getPerf() throws Exception {
       try (BufferedReader br = new BufferedReader(new FileReader(out))) {
         String line;
-        while((line=br.readLine()) != null) {
+        while ((line = br.readLine()) != null) {
           int index = line.indexOf(finalRstPrefix);
           if (index >= 0) {
             System.out.println(line);
@@ -294,7 +295,7 @@ public class Main {
       StringBuilder sb = new StringBuilder();
       try (BufferedReader br = new BufferedReader(new FileReader(err))) {
         String line;
-        while((line=br.readLine()) != null) {
+        while ((line = br.readLine()) != null) {
           sb.append(line);
           sb.append('\n');
         }
@@ -308,26 +309,26 @@ public class Main {
     protected boolean random;
     protected long fileSize;
 
-    protected ReadRunner(FileSystem fs){
+    protected ReadRunner(FileSystem fs) {
       super(fs);
     }
 
     @Override
     protected void prepare() throws Exception {
       super.prepare();
-      readSize = Integer.valueOf(DaosConfig.getInstance().getFromDaosFile(Constants.DAOS_READ_BUFFER_SIZE,
-              String.valueOf(Constants.DEFAULT_DAOS_READ_BUFFER_SIZE)));
+      readSize = Integer.valueOf(DaosConfigFile.getInstance().getFromDaosFile(Constants.DAOS_READ_BUFFER_SIZE,
+          String.valueOf(Constants.DEFAULT_DAOS_READ_BUFFER_SIZE)));
       System.out.println("read buffer size: " + readSize);
       random = "true".equalsIgnoreCase(System.getProperty("random"));
       System.out.println("random: " + random);
-      fileSize = Long.valueOf(System.getProperty("fileSize", String.valueOf(1L * 1024L*1024L*1024L)));
+      fileSize = Long.valueOf(System.getProperty("fileSize", String.valueOf(1L * 1024L * 1024L * 1024L)));
       System.out.println("file size: " + fileSize);
     }
   }
 
   static class ThreadsReadRunner extends ReadRunner {
 
-    protected ThreadsReadRunner(FileSystem fs){
+    protected ThreadsReadRunner(FileSystem fs) {
       super(fs);
     }
 
@@ -344,9 +345,9 @@ public class Main {
 
       ExecutorService executor = Executors.newFixedThreadPool(parallel);
       List<Future<Double>> futures = new ArrayList<>();
-      for (int i=0; i<parallel; i++) {
+      for (int i = 0; i < parallel; i++) {
         Future<Double> future = executor.submit(
-                new ReadTask(i, fs, path+"/thread"+i, readSize, random, fileSize));
+            new ReadTask(i, fs, path + "/thread" + i, readSize, random, fileSize));
         futures.add(future);
       }
 
@@ -377,8 +378,8 @@ public class Main {
       prepare();
 
       List<ShellExecutor> executors = new ArrayList<>();
-      for (int i=0; i<parallel; i++) {
-        File dir = new File(".", i+"");
+      for (int i = 0; i < parallel; i++) {
+        File dir = new File(".", i + "");
         if (!dir.exists()) {
           dir.mkdir();
         }
@@ -395,7 +396,7 @@ public class Main {
         list.add("-Duid=" + System.getProperty("uid"));
         list.add("-Dthreads=" + jvmThreads);
         list.add("-Dseq=" + i);
-        list.add("-Drandom=" + (random?"true":"false"));
+        list.add("-Drandom=" + (random ? "true" : "false"));
         list.add("-Dapi=" + api);
         executors.add(new ShellExecutor(i, list, out, err, READ_PERF_PREFIX, FINAL_READ_PERF_PREFIX));
       }
@@ -423,6 +424,7 @@ public class Main {
     String writePath;
     int writeSize;
     long fileSize;
+
     WriteTask(int id, FileSystem fs, String writePath, int writeSize, long fileSize) {
       this.id = id;
       this.fs = fs;
@@ -437,8 +439,8 @@ public class Main {
       byte[] bytes = new byte[writeSize];
 
       int v = 0;
-      for (int i=0; i<bytes.length; i++) {
-        bytes[i] = (byte)((v++) % 255);
+      for (int i = 0; i < bytes.length; i++) {
+        bytes[i] = (byte) ((v++) % 255);
       }
 
       long count = 0;
@@ -453,10 +455,10 @@ public class Main {
       }
       long end = System.currentTimeMillis();
 
-      double rst = count*1.0/((end-start)*1.0/1000);
+      double rst = count * 1.0 / ((end - start) * 1.0 / 1000);
       System.out.println("write path: " + writePath);
       System.out.println(WRITE_PERF_PREFIX + "file size(" + id + "): " + count);
-      System.out.println(WRITE_PERF_PREFIX + "time(" + id + "): " + ((end-start)*1.0/1000));
+      System.out.println(WRITE_PERF_PREFIX + "time(" + id + "): " + ((end - start) * 1.0 / 1000));
       System.out.println(WRITE_PERF_PREFIX + "perf(" + id + "): " + rst);
       return rst;
     }
@@ -493,13 +495,13 @@ public class Main {
 
       if ("java-api".equalsIgnoreCase(api)) {
         String poolId = System.getProperty("pid",
-                DaosConfig.getInstance().getFromDaosFile(Constants.DAOS_POOL_UUID));
+            DaosConfigFile.getInstance().getFromDaosFile(Constants.DAOS_POOL_UUID));
         String contId = System.getProperty("uid",
-                DaosConfig.getInstance().getFromDaosFile(Constants.DAOS_CONTAINER_UUID));
+            DaosConfigFile.getInstance().getFromDaosFile(Constants.DAOS_CONTAINER_UUID));
         String svc = System.getProperty("svc",
-                DaosConfig.getInstance().getFromDaosFile(Constants.DAOS_POOL_SVC));
+            DaosConfigFile.getInstance().getFromDaosFile(Constants.DAOS_POOL_SVC));
         DaosFsClient client = new DaosFsClient.DaosFsClientBuilder().poolId(poolId).containerId(contId)
-                .ranks(svc).build();
+            .ranks(svc).build();
 
         start = System.currentTimeMillis();
 
@@ -512,7 +514,7 @@ public class Main {
           while (count < fileSize) {
             long offset = (long) (fileSize * rd.nextFloat());
             size = file.read(byteBuffer, 0, offset,
-                    offset + readSize > fileSize ? (fileSize - offset) : readSize);
+                offset + readSize > fileSize ? (fileSize - offset) : readSize);
 //            size = fos.read(bytes);
             count += size;
             times++;
@@ -559,12 +561,12 @@ public class Main {
       }
 
 
-      double rst = count*1.0/((end-start)*1.0/1000);
+      double rst = count * 1.0 / ((end - start) * 1.0 / 1000);
       System.out.println("api: " + api);
       System.out.println("read path: " + readPath);
       System.out.println("number of reads: " + times);
       System.out.println(READ_PERF_PREFIX + "file size(" + id + "): " + count);
-      System.out.println(READ_PERF_PREFIX + "time(" + id + "): " + ((end-start)*1.0/1000));
+      System.out.println(READ_PERF_PREFIX + "time(" + id + "): " + ((end - start) * 1.0 / 1000));
       System.out.println(READ_PERF_PREFIX + "perf(" + id + "): " + rst);
       return rst;
     }

--- a/src/client/java/hadoop-daos/src/test/java/io/daos/fs/hadoop/perf/Test.java
+++ b/src/client/java/hadoop-daos/src/test/java/io/daos/fs/hadoop/perf/Test.java
@@ -6,9 +6,9 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -23,8 +23,8 @@ import java.util.Random;
 public class Test {
 
   public static void main(String args[]) {
-    int i=10;
-    while(i-->0) {
+    int i = 10;
+    while (i-- > 0) {
       run();
     }
   }
@@ -36,9 +36,9 @@ public class Test {
     int exceed = 0;
     long count = 0;
     while (count < fileSize) {
-      long offset = (long)(fileSize*rd.nextFloat());
+      long offset = (long) (fileSize * rd.nextFloat());
       round++;
-      if (offset + 4*1024*1024 > fileSize) {
+      if (offset + 4 * 1024 * 1024 > fileSize) {
         exceed++;
       }
 //      System.out.println(offset);

--- a/src/client/java/hadoop-daos/src/test/resources/core-site.xml
+++ b/src/client/java/hadoop-daos/src/test/resources/core-site.xml
@@ -1,7 +1,7 @@
 <configuration>
   <property>
     <name>fs.defaultFS</name>
-    <value>daos://id:2</value>
+    <value>daos://id:2/</value>
   </property>
   <property>
     <name>fs.daos.pool.uuid</name>

--- a/src/client/java/hadoop-daos/src/test/resources/daos-site-default-container.xml
+++ b/src/client/java/hadoop-daos/src/test/resources/daos-site-default-container.xml
@@ -1,7 +1,7 @@
 <configuration>
   <property>
     <name>fs.defaultFS</name>
-    <value>daos://default:1</value>
+    <value>daos:///</value>
   </property>
   <property>
     <name>fs.daos.pool.uuid</name>
@@ -15,6 +15,11 @@
   </property>
   <property>
     <name>fs.daos.container.uuid</name>
+    <value>uuid of container</value>
+    <description>UUID of DAOS container which created with "--type posix"</description>
+  </property>
+  <property>
+    <name>pool2.fs.daos.container.uuid</name>
     <value>uuid of container</value>
     <description>UUID of DAOS container which created with "--type posix"</description>
   </property>

--- a/src/client/java/hadoop-daos/src/test/resources/daos-site-default-pool.xml
+++ b/src/client/java/hadoop-daos/src/test/resources/daos-site-default-pool.xml
@@ -1,7 +1,7 @@
 <configuration>
   <property>
     <name>fs.defaultFS</name>
-    <value>daos://default:1</value>
+    <value>daos:///</value>
   </property>
   <property>
     <name>fs.daos.pool.uuid</name>
@@ -12,6 +12,11 @@
     <name>fs.daos.container.uuid</name>
     <value>uuid of container</value>
     <description>UUID of DAOS container which created with "--type posix"</description>
+  </property>
+  <property>
+    <name>c2.fs.daos.pool.uuid</name>
+    <value>uuid of pool</value>
+    <description>UUID of DAOS pool</description>
   </property>
   <property>
     <name>c2.fs.daos.container.uuid</name>

--- a/src/client/java/hadoop-daos/src/test/resources/daos-site-no-default.xml
+++ b/src/client/java/hadoop-daos/src/test/resources/daos-site-no-default.xml
@@ -1,7 +1,7 @@
 <configuration>
   <property>
     <name>fs.defaultFS</name>
-    <value>daos://default:1</value>
+    <value>daos:///</value>
   </property>
   <property>
     <name>fs.daos.pool.uuid</name>
@@ -53,12 +53,12 @@
   </property>
 
   <property>
-    <name>pool2.fs.daos.pool.uuid</name>
+    <name>pool2c2.fs.daos.pool.uuid</name>
     <value>pool2 uuid</value>
     <description>UUID of DAOS pool</description>
   </property>
   <property>
-    <name>c2.fs.daos.container.uuid</name>
+    <name>pool2c2.fs.daos.container.uuid</name>
     <value>c2 uuid</value>
     <description>UUID of DAOS container which created with "--type posix"</description>
   </property>

--- a/src/client/java/hadoop-daos/src/test/resources/daos-site.xml
+++ b/src/client/java/hadoop-daos/src/test/resources/daos-site.xml
@@ -1,7 +1,7 @@
 <configuration>
   <property>
     <name>fs.defaultFS</name>
-    <value>daos://default:1</value>
+    <value>daos:///</value>
   </property>
   <property>
     <name>fs.daos.pool.uuid</name>


### PR DESCRIPTION
It's last PR to supported UNS and refactored URI in hadoop daos. For the URI, the changes are,

-	UNS,  we’ll have default UNS URI without any authority, like “daos:///tmp/uns/HiBench…”. It should be our first choice to use UNS URI. User should be aware of the cache of this type of URI. For example, next UNS URI with different path, “daos:///tmp/uns/HiBench2”, will get same FS instance due to cache. Furthermore, the fs.DefaultFS configured should not have scheme of “daos” with any authority, e.g., “daos://default/. Otherwise, Hadoop Filesystem will use the fs.DefaultFS to initialize filesystem instead of UNS path you provided. 
Besides, to make our Hadoop DAOS impl compatible with Hadoop, the advanced mode with authority like, “daos://<your uns authority>/tmp...”, is  also supported to give user choice of bypassing Hadoop cache and have different FS instances for UNS paths with authorities.

-	Mapped UUIDs from daos-sitem.xml, the default URI is changed to “daos:///” from “daos://default:1/”. The same cache logic in UNS described above applied here too. The advanced URI format will be “daos://<your fs name>/” without any “:port”.


You can find doc from either doc/user/spark.md or src/client/java/README.md.

Signed-off-by: jiafu zhang <jiafu.zhang@intel.com>