### PR TITLE
CART-89 test: Use --fair-sched=try and change error handling in nlt.

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -869,8 +869,12 @@ pipeline {
                                     unstableThresholdInvalidReadWrite: '0',
                                     unstableThresholdTotal: '0'
                             )
+                            // TODO: Re-enable failOnError once nlt has it's own
+                            // job.  Currently if run_test.sh fails then nlt
+                            // doesn't get run, so there's no results file and
+                            // and the nlt code should not error in this case
                             recordIssues enabledForFailure: true,
-                                         failOnError: true,
+                                         failOnError: false,
                                          referenceJobName: 'daos-stack/daos/master',
                                          ignoreFailedBuilds: false,
                                          ignoreQualityGate: true,
@@ -885,7 +889,7 @@ pipeline {
                                                         [threshold: 1, type: 'TOTAL_ERROR', unstable: true],
                                                         [threshold: 1, type: 'NEW_NORMAL', unstable: true]],
                                          name: "Node local testing",
-                                         tool: issues(pattern: 'vm_test/nlt-errors.json',
+                                         tool: issues(pattern: 'nlt-errors.json',
                                                       name: 'NLT results',
                                                       id: 'VM_test')
                         }

--- a/ci/unit/test_main.sh
+++ b/ci/unit/test_main.sh
@@ -14,7 +14,7 @@ mkdir -p "${SL_BUILD_DIR}/src/control/src/github.com/daos-stack/daos/src/"
 ln -s ../../../../../../../../src/control \
   "${SL_BUILD_DIR}/src/control/src/github.com/daos-stack/daos/src/control"
 DAOS_BASE=${SL_PREFIX%/install*}
-rm -f dnt.*.memcheck.xml nlt-errors.json
+rm -f dnt.*.memcheck.xml
 NODE=${NODELIST%%,*}
 mydir="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
 

--- a/ci/unit/test_post_always_node.sh
+++ b/ci/unit/test_post_always_node.sh
@@ -5,7 +5,6 @@ set -uex
 cd "$DAOS_BASE"
 mkdir run_test.sh
 mkdir vm_test
-mv nlt-errors.json vm_test/
 if ls /tmp/daos*.log > /dev/null; then
   mv /tmp/daos*.log run_test.sh/
 fi

--- a/utils/node_local_test.py
+++ b/utils/node_local_test.py
@@ -380,7 +380,7 @@ class ValgrindHelper():
 
         self._xml_file = 'dnt.{}.memcheck'.format(self._logid)
 
-        cmd = ['valgrind', '--quiet']
+        cmd = ['valgrind', '--quiet', '--fair-sched=yes']
 
         if self.full_check:
             cmd.extend(['--leak-check=full', '--show-leak-kinds=all'])


### PR DESCRIPTION
Recent mercury releases have significant performance regression
under valgrind unless the --fair-sched option is used, so enable
it.
Do not check for or abort if nlt results file cannot be found,
this can happen if there is a problem running run_test.sh as the
nlt code doesn't get launched in that case, so simply skip
if there is no results file from ntl for now.

Signed-off-by: Ashley Pittman <ashley.m.pittman@intel.com>