### PR TITLE
DAOS-5276 obj: increase EC obj class' cell size to be 1M

### DIFF
--- a/src/cart/src/cart/crt_rpc.c
+++ b/src/cart/src/cart/crt_rpc.c
@@ -607,7 +607,10 @@ crt_req_uri_lookup_by_rpc_cb(const struct crt_cb_info *cb_info)
 	int				 rc = 0;
 
 	rpc_priv = cb_info->cci_arg;
-	D_ASSERT(rpc_priv->crp_state == RPC_STATE_URI_LOOKUP);
+	D_ASSERT(rpc_priv->crp_state == RPC_STATE_URI_LOOKUP ||
+		 rpc_priv->crp_state == RPC_STATE_TIMEOUT ||
+		 rpc_priv->crp_state == RPC_STATE_FWD_UNREACH ||
+		 rpc_priv->crp_state == RPC_STATE_COMPLETED);
 	D_ASSERT(rpc_priv->crp_ul_req == cb_info->cci_rpc);
 
 	tgt_ep = &rpc_priv->crp_pub.cr_ep;

--- a/src/common/tests_lib.c
+++ b/src/common/tests_lib.c
@@ -242,8 +242,8 @@ dts_cmd_parser(struct option *opts, const char *prompt,
 static void
 rand_iarr_swap(void *array, int a, int b)
 {
-	int	*iarray = (int *)array;
-	int	 tmp;
+	uint64_t	*iarray = array;
+	uint64_t	 tmp;
 
 	tmp = iarray[a];
 	iarray[a] = iarray[b];
@@ -254,22 +254,40 @@ static daos_sort_ops_t rand_iarr_ops = {
 	.so_swap	= rand_iarr_swap,
 };
 
-int *
-dts_rand_iarr_alloc(int nr, int base, bool shuffle)
+uint64_t *
+dts_rand_iarr_alloc(int nr)
 {
-	int	*array;
-	int	 i;
+	uint64_t	*array;
 
 	D_ALLOC_ARRAY(array, nr);
 	if (!array)
 		return NULL;
+
+	return array;
+}
+
+void
+dts_rand_iarr_set(uint64_t *array, int nr, int base, bool shuffle)
+{
+	int		 i;
 
 	for (i = 0; i < nr; i++)
 		array[i] = base + i;
 
 	if (shuffle)
 		daos_array_shuffle((void *)array, nr, &rand_iarr_ops);
+}
 
+uint64_t *
+dts_rand_iarr_alloc_set(int nr, int base, bool shuffle)
+{
+	uint64_t	*array;
+
+	array = dts_rand_iarr_alloc(nr);
+	if (!array)
+		return NULL;
+
+	dts_rand_iarr_set(array, nr, base, shuffle);
 	return array;
 }
 

--- a/src/include/daos/tests_lib.h
+++ b/src/include/daos/tests_lib.h
@@ -66,7 +66,9 @@ daos_unit_oid_t dts_unit_oid_gen(uint16_t oclass, uint8_t ofeats,
  * Create a random (optionally) ordered integer array with \a nr elements, value
  * of this array starts from \a base.
  */
-int *dts_rand_iarr_alloc(int nr, int base, bool shuffle);
+uint64_t *dts_rand_iarr_alloc_set(int nr, int base, bool shuffle);
+uint64_t *dts_rand_iarr_alloc(int nr);
+void dts_rand_iarr_set(uint64_t *array, int nr, int base, bool shuffle);
 
 static inline double
 dts_time_now(void)

--- a/src/object/cli_ec.c
+++ b/src/object/cli_ec.c
@@ -1102,7 +1102,7 @@ obj_ec_recx_reasb(daos_iod_t *iod, d_sg_list_t *sgl,
 	uint64_t			 stripe_rec_nr =
 						 obj_ec_stripe_rec_nr(oca);
 	uint64_t			 cell_rec_nr = obj_ec_cell_rec_nr(oca);
-	struct obj_ec_recx		*full_ec_recx;
+	struct obj_ec_recx		*full_ec_recx = NULL;
 	uint32_t			 tidx[OBJ_EC_MAX_M] = {0};
 	uint32_t			 ridx[OBJ_EC_MAX_M] = {0};
 	d_iov_t				 iov_inline[EC_INLINE_IOVS];

--- a/src/object/cli_obj.c
+++ b/src/object/cli_obj.c
@@ -1633,16 +1633,26 @@ static int
 obj_iod_sgl_valid(unsigned int nr, daos_iod_t *iods, d_sg_list_t *sgls,
 		  bool update, bool size_fetch)
 {
-	int	i;
+	int	i, j;
 	int	rc;
 
 	if (iods == NULL)
 		return -DER_INVAL;
 
 	for (i = 0; i < nr; i++) {
-		if (iods[i].iod_name.iov_buf == NULL)
-			/* XXX checksum & eprs should not be mandatory */
+		if (iods[i].iod_name.iov_buf == NULL) {
+			D_ERROR("Invalid argument of NULL akey\n");
 			return -DER_INVAL;
+		}
+		for (j = 0; j < iods[i].iod_nr; j++) {
+			if (iods[i].iod_recxs != NULL &&
+			   (iods[i].iod_recxs[j].rx_idx & PARITY_INDICATOR)
+			    != 0) {
+				D_ERROR("Invalid IOD, the bit-63 of rx_idx is "
+					"reserved.\n");
+				return -DER_INVAL;
+			}
+		}
 
 		switch (iods[i].iod_type) {
 		default:
@@ -2656,8 +2666,8 @@ obj_comp_cb(tse_task_t *task, void *data)
 		fail_info = obj_auxi->reasb_req.orr_fail;
 		new_tgt_fail = obj_auxi->ec_wait_recov &&
 			       task->dt_result == -DER_BAD_TARGET;
-		if (fail_info != NULL && (task->dt_result == 0 ||
-					  new_tgt_fail)) {
+		if (fail_info != NULL && fail_info->efi_nrecx_lists > 0 &&
+		    (task->dt_result == 0 ||  new_tgt_fail)) {
 			if (obj_auxi->ec_wait_recov && task->dt_result == 0) {
 				daos_obj_fetch_t *args = dc_task_get_args(task);
 

--- a/src/object/obj_class.c
+++ b/src/object/obj_class.c
@@ -285,7 +285,7 @@ static struct daos_obj_class daos_obj_classes[] = {
 			.ca_grp_nr		= 1,
 			.ca_ec_k		= 2,
 			.ca_ec_p		= 1,
-			.ca_ec_cell		= 1 << 15,
+			.ca_ec_cell		= 1 << 20,
 		},
 	},
 	{
@@ -297,7 +297,7 @@ static struct daos_obj_class daos_obj_classes[] = {
 			.ca_grp_nr		= 1,
 			.ca_ec_k		= 2,
 			.ca_ec_p		= 2,
-			.ca_ec_cell		= 1 << 15,
+			.ca_ec_cell		= 1 << 20,
 		},
 	},
 	{
@@ -309,7 +309,7 @@ static struct daos_obj_class daos_obj_classes[] = {
 			.ca_grp_nr		= 1,
 			.ca_ec_k		= 4,
 			.ca_ec_p		= 1,
-			.ca_ec_cell		= 1 << 15,
+			.ca_ec_cell		= 1 << 20,
 		},
 	},
 	{
@@ -321,7 +321,7 @@ static struct daos_obj_class daos_obj_classes[] = {
 			.ca_grp_nr		= 1,
 			.ca_ec_k		= 4,
 			.ca_ec_p		= 2,
-			.ca_ec_cell		= 1 << 15,
+			.ca_ec_cell		= 1 << 20,
 		},
 	},
 	{
@@ -333,7 +333,7 @@ static struct daos_obj_class daos_obj_classes[] = {
 			.ca_grp_nr		= 1,
 			.ca_ec_k		= 8,
 			.ca_ec_p		= 2,
-			.ca_ec_cell		= 1 << 15,
+			.ca_ec_cell		= 1 << 20,
 		},
 	},
 	{
@@ -345,7 +345,7 @@ static struct daos_obj_class daos_obj_classes[] = {
 			.ca_grp_nr		= 1,
 			.ca_ec_k		= 16,
 			.ca_ec_p		= 2,
-			.ca_ec_cell		= 1 << 15,
+			.ca_ec_cell		= 1 << 20,
 		},
 	},
 	{

--- a/src/tests/daos_perf.c
+++ b/src/tests/daos_perf.c
@@ -321,7 +321,7 @@ set_value_buffer(char *buffer, int idx)
 static int
 akey_update_or_fetch(daos_handle_t oh, enum ts_op_type op_type,
 		     char *dkey, char *akey, daos_epoch_t *epoch,
-		     int *indices, int idx, char *verify_buff,
+		     uint64_t *indices, int idx, char *verify_buff,
 		     double *duration)
 {
 	struct dts_io_credit *cred;
@@ -409,13 +409,13 @@ static int
 dkey_update_or_fetch(daos_handle_t oh, enum ts_op_type op_type, char *dkey,
 		     daos_epoch_t *epoch, double *duration)
 {
-	int		*indices;
+	uint64_t	*indices;
 	char		 akey[DTS_KEY_LEN];
 	int		 i;
 	int		 j;
 	int		 rc = 0;
 
-	indices = dts_rand_iarr_alloc(ts_recx_p_akey, 0, ts_shuffle);
+	indices = dts_rand_iarr_alloc_set(ts_recx_p_akey, 0, ts_shuffle);
 	D_ASSERT(indices != NULL);
 
 	for (i = 0; i < ts_akey_p_dkey; i++) {
@@ -489,14 +489,14 @@ objects_update(double *duration, d_rank_t rank)
 static int
 dkey_verify(daos_handle_t oh, char *dkey, daos_epoch_t *epoch)
 {
-	int	 i;
-	int	*indices;
-	char	 ground_truth[TEST_VAL_SIZE];
-	char	 test_string[TEST_VAL_SIZE];
-	char	 akey[DTS_KEY_LEN];
-	int	 rc = 0;
+	int		 i;
+	uint64_t	*indices;
+	char		 ground_truth[TEST_VAL_SIZE];
+	char		 test_string[TEST_VAL_SIZE];
+	char		 akey[DTS_KEY_LEN];
+	int		 rc = 0;
 
-	indices = dts_rand_iarr_alloc(ts_recx_p_akey, 0, ts_shuffle);
+	indices = dts_rand_iarr_alloc_set(ts_recx_p_akey, 0, ts_shuffle);
 	D_ASSERT(indices != NULL);
 	dts_key_gen(akey, DTS_KEY_LEN, "walker");
 
@@ -1143,6 +1143,8 @@ main(int argc, char **argv)
 	int		ec_vsize = 0;
 	d_rank_t	svc_rank  = 0;	/* pool service rank */
 	int		i;
+	daos_obj_id_t	tmp_oid;
+	struct daos_oclass_attr	*oca;
 	double		duration = 0;
 	bool		pause = false;
 	unsigned	seed = 0;
@@ -1400,13 +1402,11 @@ main(int argc, char **argv)
 		ts_ctx.tsc_svc.rl_ranks  = &svc_rank;
 	}
 
-	if (ts_class == OC_EC_2P2G1)
-		ec_vsize = (1 << 15) * 2;
-	else if (ts_class == OC_EC_4P2G1)
-		ec_vsize = (1 << 15) * 4;
-	else if (ts_class == OC_EC_8P2G1)
-		ec_vsize = (1 << 15) * 8;
-
+	tmp_oid = dts_oid_gen(ts_class, 0, 0);
+	oca = daos_oclass_attr_find(tmp_oid);
+	D_ASSERT(oca != NULL);
+	if (DAOS_OC_IS_EC(oca))
+		ec_vsize = oca->u.ec.e_len * oca->u.ec.e_k;
 	if (ec_vsize != 0 && vsize % ec_vsize != 0)
 		fprintf(stdout, "for EC obj perf test, vsize (-s) %d should be "
 			"multiple of %d (full-stripe size) to get better "

--- a/src/tests/suite/daos_obj.c
+++ b/src/tests/suite/daos_obj.c
@@ -963,7 +963,7 @@ io_var_idx_offset(void **state)
 	oid = dts_oid_gen(dts_obj_class, 0, arg->myrank);
 	ioreq_init(&req, arg->coh, oid, DAOS_IOD_ARRAY, arg);
 
-	for (offset = UINT64_MAX; offset > 0; offset >>= 8) {
+	for (offset = (UINT64_MAX >> 1); offset > 0; offset >>= 8) {
 		char buf[10];
 
 

--- a/src/vos/tests/evt_ctl.c
+++ b/src/vos/tests/evt_ctl.c
@@ -665,7 +665,7 @@ ts_many_add(void **state)
 {
 	char			*buf;
 	char			*tmp;
-	int			*seq;
+	uint64_t		*seq;
 	struct evt_rect		*rect;
 	struct evt_entry_in	 entry = {0};
 	bio_addr_t		 bio_addr = {0}; /* Fake bio addr */
@@ -730,7 +730,7 @@ ts_many_add(void **state)
 	if (!buf)
 		fail();
 
-	seq = dts_rand_iarr_alloc(nr, 0, true);
+	seq = dts_rand_iarr_alloc_set(nr, 0, true);
 	if (!seq) {
 		D_FREE(buf);
 		fail();


### PR DESCRIPTION
1. increase default defined EC obj class' cell size to be 1M
2. reject user IO request if rx_idx's bit-63 is set, as it is
   reserved for internal usage.
3. Fix a bug in daos_perf code that using "int" as array rx_idx
   that possibly overflow for big io_size and recx_per_akey.
4. Fix a bug in cart URI_LOOKUP complete callback.

Signed-off-by: Xuezhao Liu <xuezhao.liu@intel.com>