### PR TITLE
DAOS-3114 vos: Remove VOS_OF_USE_TIMESTAMPS flag, replace with dth

### DIFF
--- a/src/common/misc.c
+++ b/src/common/misc.c
@@ -628,6 +628,17 @@ daos_crt_init_opt_get(bool server, int ctx_nr)
 }
 
 void
+daos_dti_gen_unique(struct dtx_id *dti)
+{
+	uuid_t uuid;
+
+	uuid_generate(uuid);
+
+	uuid_copy(dti->dti_uuid, uuid);
+	dti->dti_hlc = crt_hlc_get();
+}
+
+void
 daos_dti_gen(struct dtx_id *dti, bool zero)
 {
 	static __thread uuid_t uuid;

--- a/src/include/daos/dtx.h
+++ b/src/include/daos/dtx.h
@@ -134,6 +134,7 @@ struct dtx_id {
 	uint64_t		dti_hlc;
 };
 
+void daos_dti_gen_unique(struct dtx_id *dti);
 void daos_dti_gen(struct dtx_id *dti, bool zero);
 
 static inline void

--- a/src/include/daos_srv/vos_types.h
+++ b/src/include/daos_srv/vos_types.h
@@ -214,15 +214,14 @@ enum {
 	/** Conditional Op: Fetch akey if it exists, fail otherwise */
 	VOS_OF_COND_AKEY_FETCH	= DAOS_COND_AKEY_FETCH,
 	/** Indicates the operation should check mvcc timestamps */
-	VOS_OF_USE_TIMESTAMPS	= (1 << 7),
 	/** replay punch (underwrite) */
-	VOS_OF_REPLAY_PC	= (1 << 8),
+	VOS_OF_REPLAY_PC	= (1 << 7),
 	/* critical update - skip checks on SCM system/held space */
-	VOS_OF_CRIT		= (1 << 9),
+	VOS_OF_CRIT		= (1 << 8),
 	/** Instead of update or punch of extents, remove all extents
 	 * under the specified range. Intended for internal use only.
 	 */
-	VOS_OF_REMOVE		= (1 << 10),
+	VOS_OF_REMOVE		= (1 << 9),
 };
 
 /** Mask for any conditionals passed to to the fetch */
@@ -246,7 +245,6 @@ enum {
 	(VOS_OF_COND_DKEY_UPDATE | VOS_OF_COND_AKEY_UPDATE)
 
 D_CASSERT((VOS_OF_REPLAY_PC & DAOS_COND_MASK) == 0);
-D_CASSERT((VOS_OF_USE_TIMESTAMPS & DAOS_COND_MASK) == 0);
 
 /** vos definitions that match daos_obj_key_query flags */
 enum {

--- a/src/object/srv_obj.c
+++ b/src/object/srv_obj.c
@@ -1128,8 +1128,7 @@ obj_local_rw(crt_rpc_t *rpc, struct obj_io_context *ioc,
 		}
 
 		rc = vos_update_begin(ioc->ioc_coc->sc_hdl, orw->orw_oid,
-			      orw->orw_epoch,
-			      orw->orw_api_flags | VOS_OF_USE_TIMESTAMPS,
+			      orw->orw_epoch, orw->orw_api_flags,
 			      dkey, orw->orw_nr, iods,
 			      iod_csums, &ioh, dth);
 		if (rc) {
@@ -1143,7 +1142,7 @@ obj_local_rw(crt_rpc_t *rpc, struct obj_io_context *ioc,
 		bool				 ec_deg_fetch;
 		struct daos_recx_ep_list	*shadows = NULL;
 
-		cond_flags = orw->orw_api_flags | VOS_OF_USE_TIMESTAMPS;
+		cond_flags = orw->orw_api_flags;
 		bulk_op = CRT_BULK_PUT;
 		if (!rma && orw->orw_sgls.ca_arrays == NULL) {
 			spec_fetch = true;
@@ -2193,7 +2192,7 @@ obj_local_punch(struct obj_punch_in *opi, crt_opcode_t opc,
 	case DAOS_OBJ_RPC_TGT_PUNCH:
 		rc = vos_obj_punch(cont->sc_hdl, opi->opi_oid,
 				   opi->opi_epoch, opi->opi_map_ver,
-				   VOS_OF_USE_TIMESTAMPS, NULL, 0, NULL, dth);
+				   0, NULL, 0, NULL, dth);
 		break;
 	case DAOS_OBJ_RPC_PUNCH_DKEYS:
 	case DAOS_OBJ_RPC_PUNCH_AKEYS:
@@ -2208,7 +2207,7 @@ obj_local_punch(struct obj_punch_in *opi, crt_opcode_t opc,
 		dkey = &((daos_key_t *)opi->opi_dkeys.ca_arrays)[0];
 		rc = vos_obj_punch(cont->sc_hdl, opi->opi_oid,
 				   opi->opi_epoch, opi->opi_map_ver,
-				   opi->opi_api_flags | VOS_OF_USE_TIMESTAMPS,
+				   opi->opi_api_flags,
 				   dkey, opi->opi_akeys.ca_count,
 				   opi->opi_akeys.ca_arrays, dth);
 		break;
@@ -2543,9 +2542,8 @@ ds_obj_query_key_handler(crt_rpc_t *rpc)
 	D_ASSERTF(rc == 0, "%d\n", rc);
 
 	rc = vos_obj_query_key(ioc.ioc_vos_coh, okqi->okqi_oid,
-			       VOS_USE_TIMESTAMPS | okqi->okqi_api_flags,
-			       okqi->okqi_epoch, dkey, akey, &okqo->okqo_recx,
-			       &dth);
+			       okqi->okqi_api_flags, okqi->okqi_epoch, dkey,
+			       akey, &okqo->okqo_recx, &dth);
 
 	rc = dtx_end(&dth, ioc.ioc_coc, rc);
 

--- a/src/tests/daos_perf.c
+++ b/src/tests/daos_perf.c
@@ -192,13 +192,11 @@ _vos_update_or_fetch(enum ts_op_type op_type, struct dts_io_credit *cred,
 		daos_handle_t		 ioh;
 
 		if (op_type == TS_DO_UPDATE)
-			rc = vos_update_begin(ts_ctx.tsc_coh, ts_uoid, epoch,
-					      VOS_OF_USE_TIMESTAMPS,
+			rc = vos_update_begin(ts_ctx.tsc_coh, ts_uoid, epoch, 0,
 					      &cred->tc_dkey, 1, &cred->tc_iod,
 					      NULL, &ioh, NULL);
 		else
-			rc = vos_fetch_begin(ts_ctx.tsc_coh, ts_uoid, epoch,
-					     VOS_OF_USE_TIMESTAMPS,
+			rc = vos_fetch_begin(ts_ctx.tsc_coh, ts_uoid, epoch, 0,
 					     &cred->tc_dkey, 1, &cred->tc_iod,
 					     0, NULL, &ioh, NULL);
 		if (rc)

--- a/src/vos/tests/vts_aggregate.c
+++ b/src/vos/tests/vts_aggregate.c
@@ -1976,17 +1976,17 @@ aggregate_22(void **state)
 		     sizeof(buf_u), &recx, buf_u);
 
 	fetch_value(arg, oid, epoch++,
-		    VOS_OF_USE_TIMESTAMPS | VOS_OF_COND_AKEY_FETCH, dkey, akey,
+		    VOS_OF_COND_AKEY_FETCH, dkey, akey,
 		    DAOS_IOD_ARRAY, sizeof(buf_u), &recx, buf_u);
 	fetch_value(arg, oid, epoch++,
-		    VOS_OF_USE_TIMESTAMPS | VOS_OF_COND_AKEY_FETCH, dkey, akey2,
+		    VOS_OF_COND_AKEY_FETCH, dkey, akey2,
 		    DAOS_IOD_SINGLE, sizeof(buf_u), &recx, buf_u);
 	memset(buf_u, 0, sizeof(buf_u));
 	fetch_value(arg, oid, epoch++,
-		    VOS_OF_USE_TIMESTAMPS | VOS_OF_COND_AKEY_FETCH, dkey, akey3,
+		    VOS_OF_COND_AKEY_FETCH, dkey, akey3,
 		    DAOS_IOD_ARRAY, sizeof(buf_u), &recx, buf_u);
 	fetch_value(arg, oid, epoch++,
-		    VOS_OF_USE_TIMESTAMPS | VOS_OF_COND_AKEY_FETCH, dkey, akey4,
+		    VOS_OF_COND_AKEY_FETCH, dkey, akey4,
 		    DAOS_IOD_SINGLE, sizeof(buf_u), &recx, buf_u);
 
 	update_value(arg, oid, epoch++, 0, dkey, akey, DAOS_IOD_ARRAY,
@@ -2000,16 +2000,16 @@ aggregate_22(void **state)
 	assert_int_equal(rc, 0);
 
 	fetch_value(arg, oid, epoch++,
-		    VOS_OF_USE_TIMESTAMPS | VOS_OF_COND_AKEY_FETCH, dkey, akey,
+		    VOS_OF_COND_AKEY_FETCH, dkey, akey,
 		    DAOS_IOD_ARRAY, sizeof(buf_u), &recx, buf_u);
 	fetch_value(arg, oid, epoch++,
-		    VOS_OF_USE_TIMESTAMPS | VOS_OF_COND_AKEY_FETCH, dkey, akey2,
+		    VOS_OF_COND_AKEY_FETCH, dkey, akey2,
 		    DAOS_IOD_SINGLE, sizeof(buf_u), &recx, buf_u);
 	fetch_value(arg, oid, epoch++,
-		    VOS_OF_USE_TIMESTAMPS | VOS_OF_COND_AKEY_FETCH, dkey, akey3,
+		    VOS_OF_COND_AKEY_FETCH, dkey, akey3,
 		    DAOS_IOD_ARRAY, sizeof(buf_u), &recx, buf_u);
 	fetch_value(arg, oid, epoch++,
-		    VOS_OF_USE_TIMESTAMPS | VOS_OF_COND_AKEY_FETCH, dkey, akey4,
+		    VOS_OF_COND_AKEY_FETCH, dkey, akey4,
 		    DAOS_IOD_SINGLE, sizeof(buf_u), &recx, buf_u);
 
 	arg->ta_flags &= TF_PUNCH;
@@ -2018,16 +2018,16 @@ aggregate_22(void **state)
 
 	/* Also check conditional updates still work */
 	update_value(arg, oid, epoch++,
-		     VOS_OF_USE_TIMESTAMPS | VOS_OF_COND_DKEY_UPDATE, dkey,
+		     VOS_OF_COND_DKEY_UPDATE, dkey,
 		     akey, DAOS_IOD_ARRAY, sizeof(buf_u), &recx, buf_u);
 	update_value(arg, oid, epoch++,
-		     VOS_OF_USE_TIMESTAMPS | VOS_OF_COND_AKEY_UPDATE, dkey,
+		     VOS_OF_COND_AKEY_UPDATE, dkey,
 		     akey2, DAOS_IOD_SINGLE, sizeof(buf_u), &recx, buf_u);
 	update_value(arg, oid, epoch++,
-		     VOS_OF_USE_TIMESTAMPS | VOS_OF_COND_AKEY_UPDATE, dkey,
+		     VOS_OF_COND_AKEY_UPDATE, dkey,
 		     akey3, DAOS_IOD_ARRAY, sizeof(buf_u), &recx, buf_u);
 	update_value(arg, oid, epoch++,
-		     VOS_OF_USE_TIMESTAMPS | VOS_OF_COND_DKEY_UPDATE, dkey,
+		     VOS_OF_COND_DKEY_UPDATE, dkey,
 		     akey4, DAOS_IOD_SINGLE, sizeof(buf_u), &recx, buf_u);
 }
 

--- a/src/vos/tests/vts_common.h
+++ b/src/vos/tests/vts_common.h
@@ -129,4 +129,10 @@ int run_ilog_tests(const char *cfg);
 int run_csum_extent_tests(const char *cfg);
 int run_mvcc_tests(const char *cfg);
 
+void
+vts_dtx_begin(const daos_unit_oid_t *oid, daos_handle_t coh, daos_epoch_t epoch,
+	      uint64_t dkey_hash, struct dtx_handle **dthp);
+void
+vts_dtx_end(struct dtx_handle *dth);
+
 #endif

--- a/src/vos/tests/vts_dtx.c
+++ b/src/vos/tests/vts_dtx.c
@@ -48,14 +48,15 @@ vts_init_dte(struct dtx_entry *dte)
 	mbs->dm_data_size = sizeof(struct dtx_daos_target);
 	mbs->dm_tgts[0].ddt_id = 1;
 
-	daos_dti_gen(&dte->dte_xid, false);
+	/** Use unique API so new UUID is generated even on same thread */
+	daos_dti_gen_unique(&dte->dte_xid);
 	dte->dte_ver = 1;
 	dte->dte_refs = 1;
 	dte->dte_mbs = mbs;
 }
 
-static void
-vts_dtx_begin(daos_unit_oid_t *oid, daos_handle_t coh, daos_epoch_t epoch,
+void
+vts_dtx_begin(const daos_unit_oid_t *oid, daos_handle_t coh, daos_epoch_t epoch,
 	      uint64_t dkey_hash, struct dtx_handle **dthp)
 {
 	struct dtx_handle	*dth;
@@ -94,7 +95,7 @@ vts_dtx_begin(daos_unit_oid_t *oid, daos_handle_t coh, daos_epoch_t epoch,
 	*dthp = dth;
 }
 
-static void
+void
 vts_dtx_end(struct dtx_handle *dth)
 {
 	D_FREE(dth->dth_dte.dte_mbs);

--- a/src/vos/tests/vts_pm.c
+++ b/src/vos/tests/vts_pm.c
@@ -622,7 +622,7 @@ punch_model_test(void **state)
 
 	/* Write the original value (under) */
 	rc = vos_obj_update(arg->ctx.tc_co_hdl, oid, 1, 0,
-			    VOS_OF_USE_TIMESTAMPS, &dkey, 1, &iod, NULL, &sgl);
+			    0, &dkey, 1, &iod, NULL, &sgl);
 	assert_int_equal(rc, 0);
 	/* Punch the akey */
 	rc = vos_obj_punch(arg->ctx.tc_co_hdl, oid, 2, 0, 0, &dkey, 1, &akey,
@@ -633,7 +633,7 @@ punch_model_test(void **state)
 	rex.rx_nr = strlen(expected);
 	d_iov_set(&sgl.sg_iovs[0], (void *)expected, strlen(expected));
 	rc = vos_obj_update(arg->ctx.tc_co_hdl, oid, 3, 0,
-			    VOS_OF_USE_TIMESTAMPS, &dkey, 1, &iod, NULL, &sgl);
+			    0, &dkey, 1, &iod, NULL, &sgl);
 	assert_int_equal(rc, 0);
 
 	/* Now read back original # of bytes */
@@ -648,7 +648,7 @@ punch_model_test(void **state)
 	/* Write the original value at latest epoch (under) */
 	d_iov_set(&sgl.sg_iovs[0], (void *)under, strlen(under));
 	rc = vos_obj_update(arg->ctx.tc_co_hdl, oid, 5, 0,
-			    VOS_OF_USE_TIMESTAMPS, &dkey, 1, &iod, NULL, &sgl);
+			    0, &dkey, 1, &iod, NULL, &sgl);
 	assert_int_equal(rc, 0);
 	/* Punch the dkey */
 	rc = vos_obj_punch(arg->ctx.tc_co_hdl, oid, 6, 0, 0, &dkey, 0, NULL,
@@ -659,7 +659,7 @@ punch_model_test(void **state)
 	rex.rx_nr = strlen(expected);
 	d_iov_set(&sgl.sg_iovs[0], (void *)expected, strlen(expected));
 	rc = vos_obj_update(arg->ctx.tc_co_hdl, oid, 7, 0,
-			    VOS_OF_USE_TIMESTAMPS, &dkey, 1, &iod, NULL, &sgl);
+			    0, &dkey, 1, &iod, NULL, &sgl);
 	assert_int_equal(rc, 0);
 
 	memset(buf, 0, sizeof(buf));
@@ -676,7 +676,7 @@ punch_model_test(void **state)
 	rex.rx_nr = strlen(expected);
 	d_iov_set(&sgl.sg_iovs[0], (void *)expected, strlen(expected));
 	rc = vos_obj_update(arg->ctx.tc_co_hdl, oid, 9, 0,
-			    VOS_OF_USE_TIMESTAMPS, &dkey, 1, &iod, NULL, &sgl);
+			    0, &dkey, 1, &iod, NULL, &sgl);
 	assert_int_equal(rc, 0);
 
 	/* Punch the object at 10 */
@@ -688,7 +688,7 @@ punch_model_test(void **state)
 	rex.rx_nr = strlen(latest);
 	d_iov_set(&sgl.sg_iovs[0], (void *)latest, strlen(latest));
 	rc = vos_obj_update(arg->ctx.tc_co_hdl, oid, 11, 0,
-			    VOS_OF_USE_TIMESTAMPS, &dkey, 1, &iod, NULL, &sgl);
+			    0, &dkey, 1, &iod, NULL, &sgl);
 	assert_int_equal(rc, 0);
 
 	/** read old one for sanity */
@@ -777,7 +777,7 @@ simple_multi_update(void **state)
 	}
 
 	rc = vos_obj_update(arg->ctx.tc_co_hdl, oid, 1, 0,
-			    VOS_OF_USE_TIMESTAMPS, &dkey, 2, iod, NULL, sgl);
+			    0, &dkey, 2, iod, NULL, sgl);
 	assert_int_equal(rc, 0);
 
 	for (i = 0; i < 2; i++) {
@@ -803,7 +803,7 @@ simple_multi_update(void **state)
 	assert_int_equal(rc, 0);
 
 	rc = vos_obj_update(arg->ctx.tc_co_hdl, oid, 1, 0,
-			    VOS_OF_USE_TIMESTAMPS, &dkey, 2, iod, NULL, sgl);
+			    0, &dkey, 2, iod, NULL, sgl);
 	assert_int_equal(rc, 0);
 
 	for (i = 0; i < 2; i++) {
@@ -871,7 +871,7 @@ object_punch_and_fetch(void **state)
 		iod.iod_recxs = NULL;
 
 		rc = vos_obj_update(arg->ctx.tc_co_hdl, oid, epoch++, 0,
-				    VOS_OF_USE_TIMESTAMPS, &dkey, 1, &iod, NULL,
+				    0, &dkey, 1, &iod, NULL,
 				    &sgl);
 		assert_int_equal(rc, 0);
 
@@ -934,7 +934,7 @@ sgl_test(void **state)
 	/* Write just index 2 */
 	recx[0].rx_idx = 2;
 	rc = vos_obj_update(arg->ctx.tc_co_hdl, oid, epoch++, 0,
-			    VOS_OF_USE_TIMESTAMPS, &dkey, 1, &iod, NULL, &sgl);
+			    0, &dkey, 1, &iod, NULL, &sgl);
 	assert_int_equal(rc, 0);
 
 	memset(rbuf, 'a', sizeof(rbuf));
@@ -1025,11 +1025,19 @@ static void
 obj_punch_op(void **state, daos_handle_t coh, daos_unit_oid_t oid,
 	     daos_epoch_t epoch)
 {
-	int	rc;
+	struct dtx_handle	*dth;
+	struct dtx_id		 xid;
+	int			 rc;
 
-	rc = vos_obj_punch(coh, oid, epoch, 0, 0, NULL, 0, NULL, NULL);
+	vts_dtx_begin(&oid, coh, epoch, 0, &dth);
+	rc = vos_obj_punch(coh, oid, epoch, 0, 0, NULL, 0, NULL, dth);
+	xid = dth->dth_xid;
+	vts_dtx_end(dth);
 
 	assert_int_equal(rc, 0);
+
+	rc = vos_dtx_commit(coh, &xid, 1, NULL);
+	assert_int_equal(rc, 1);
 }
 
 static void
@@ -1037,17 +1045,27 @@ cond_dkey_punch_op(void **state, daos_handle_t coh, daos_unit_oid_t oid,
 		   daos_epoch_t epoch, const char *dkey_str, uint64_t flags,
 		   int expected_rc)
 {
-	char	dkey_buf[OP_MAX_STRING];
-	size_t	dkey_len;
-	d_iov_t	dkey;
-	int	rc;
+	struct dtx_handle	*dth;
+	struct dtx_id		 xid;
+	char			 dkey_buf[OP_MAX_STRING];
+	size_t			 dkey_len;
+	d_iov_t			 dkey;
+	int			 rc;
 
 	copy_str(dkey_buf, dkey_str, &dkey_len);
 	d_iov_set(&dkey, dkey_buf, dkey_len);
 
-	rc = vos_obj_punch(coh, oid, epoch, 0, flags, &dkey, 0, NULL, NULL);
+	vts_dtx_begin(&oid, coh, epoch, 0, &dth);
+	rc = vos_obj_punch(coh, oid, epoch, 0, flags, &dkey, 0, NULL, dth);
+	xid = dth->dth_xid;
+	vts_dtx_end(dth);
 
 	assert_int_equal(rc, expected_rc);
+
+	if (expected_rc == 0) {
+		rc = vos_dtx_commit(coh, &xid, 1, NULL);
+		assert_int_equal(rc, 1);
+	}
 }
 
 static void
@@ -1055,22 +1073,32 @@ cond_akey_punch_op(void **state, daos_handle_t coh, daos_unit_oid_t oid,
 		   daos_epoch_t epoch, const char *dkey_str,
 		   const char *akey_str, uint64_t flags, int expected_rc)
 {
-	char	dkey_buf[OP_MAX_STRING];
-	size_t	dkey_len;
-	char	akey_buf[OP_MAX_STRING];
-	size_t	akey_len;
-	d_iov_t	dkey;
-	d_iov_t	akey;
-	int	rc;
+	struct dtx_handle	*dth;
+	struct dtx_id		 xid;
+	char			 dkey_buf[OP_MAX_STRING];
+	size_t			 dkey_len;
+	d_iov_t			 dkey;
+	char			 akey_buf[OP_MAX_STRING];
+	size_t			 akey_len;
+	d_iov_t			 akey;
+	int			 rc;
 
 	copy_str(dkey_buf, dkey_str, &dkey_len);
 	d_iov_set(&dkey, dkey_buf, dkey_len);
 	copy_str(akey_buf, akey_str, &akey_len);
 	d_iov_set(&akey, akey_buf, akey_len);
 
-	rc = vos_obj_punch(coh, oid, epoch, 0, flags, &dkey, 1, &akey, NULL);
+	vts_dtx_begin(&oid, coh, epoch, 0, &dth);
+	rc = vos_obj_punch(coh, oid, epoch, 0, flags, &dkey, 1, &akey, dth);
+	xid = dth->dth_xid;
+	vts_dtx_end(dth);
 
 	assert_int_equal(rc, expected_rc);
+
+	if (expected_rc == 0) {
+		rc = vos_dtx_commit(coh, &xid, 1, NULL);
+		assert_int_equal(rc, 1);
+	}
 }
 
 static void
@@ -1079,16 +1107,17 @@ cond_fetch_op(void **state, daos_handle_t coh, daos_unit_oid_t oid,
 	      uint64_t flags, int expected_rc, d_sg_list_t *sgl,
 	      const char *value_str, char fill_char)
 {
-	char		dkey_buf[OP_MAX_STRING];
-	char		akey_buf[OP_MAX_STRING];
-	char		value_buf[OP_MAX_STRING];
-	char		read_buf[OP_MAX_STRING];
-	daos_iod_t	iod = {0};
-	d_iov_t		dkey;
-	size_t		dkey_len;
-	size_t		akey_len;
-	size_t		value_len;
-	int		rc;
+	struct dtx_handle	*dth;
+	char			 dkey_buf[OP_MAX_STRING];
+	char			 akey_buf[OP_MAX_STRING];
+	char			 value_buf[OP_MAX_STRING];
+	char			 read_buf[OP_MAX_STRING];
+	daos_iod_t		 iod = {0};
+	d_iov_t			 dkey;
+	size_t			 dkey_len;
+	size_t			 akey_len;
+	size_t			 value_len;
+	int			 rc;
 
 	copy_str(value_buf, value_str, &value_len);
 	copy_str(dkey_buf, dkey_str, &dkey_len);
@@ -1103,8 +1132,10 @@ cond_fetch_op(void **state, daos_handle_t coh, daos_unit_oid_t oid,
 	iod.iod_nr = 1;
 	iod.iod_recxs = NULL;
 
-	rc = vos_obj_fetch(coh, oid, epoch, flags, &dkey, 1, &iod, sgl);
+	vts_dtx_begin(&oid, coh, epoch, 0, &dth);
+	rc = vos_obj_fetch_ex(coh, oid, epoch, flags, &dkey, 1, &iod, sgl, dth);
 	assert_int_equal(rc, expected_rc);
+	vts_dtx_end(dth);
 
 	if (value_len == 0)
 		return;
@@ -1117,19 +1148,21 @@ cond_updaten_op(void **state, daos_handle_t coh, daos_unit_oid_t oid,
 	       daos_epoch_t epoch, const char *dkey_str,
 	       uint64_t flags, int expected_rc, d_sg_list_t *sgl, int n, ...)
 {
-	const char	*val_arg;
-	const char	*akey_arg;
-	va_list		list;
-	char		dkey_buf[OP_MAX_STRING];
-	char		akey_buf[n][OP_MAX_STRING];
-	char		value_buf[n][OP_MAX_STRING];
-	daos_iod_t	iod[n];
-	d_iov_t		dkey;
-	size_t		dkey_len;
-	size_t		akey_len[n];
-	size_t		value_len[n];
-	int		rc;
-	int		i;
+	struct dtx_handle	*dth;
+	struct dtx_id		 xid;
+	const char		*val_arg;
+	const char		*akey_arg;
+	va_list			 list;
+	char			 dkey_buf[OP_MAX_STRING];
+	char			 akey_buf[n][OP_MAX_STRING];
+	char			 value_buf[n][OP_MAX_STRING];
+	daos_iod_t		 iod[n];
+	d_iov_t			 dkey;
+	size_t			 dkey_len;
+	size_t			 akey_len[n];
+	size_t			 value_len[n];
+	int			 rc;
+	int			 i;
 
 	memset(&iod, 0, sizeof(iod[0]) * n);
 
@@ -1153,9 +1186,17 @@ cond_updaten_op(void **state, daos_handle_t coh, daos_unit_oid_t oid,
 
 	}
 	va_end(list);
-	rc = vos_obj_update(coh, oid, epoch, 0, flags, &dkey, n, iod, NULL,
-			    sgl);
+	vts_dtx_begin(&oid, coh, epoch, 0, &dth);
+	rc = vos_obj_update_ex(coh, oid, epoch, 0, flags, &dkey, n, iod, NULL,
+			       sgl, dth);
+	xid = dth->dth_xid;
 	assert_int_equal(rc, expected_rc);
+	vts_dtx_end(dth);
+
+	if (expected_rc == 0) {
+		rc = vos_dtx_commit(coh, &xid, 1, NULL);
+		assert_int_equal(rc, 1);
+	}
 
 }
 
@@ -1196,85 +1237,82 @@ cond_test(void **state)
 
 	/** Conditional update of non-existed key should fail */
 	cond_update_op(state, arg->ctx.tc_co_hdl, oid, epoch++, "a", "b",
-		       VOS_OF_USE_TIMESTAMPS | VOS_OF_COND_DKEY_UPDATE,
+		       VOS_OF_COND_DKEY_UPDATE,
 		       -DER_NONEXIST, sgl, "foo");
 	/** Non conditional update should fail due to later read */
 	cond_update_op(state, arg->ctx.tc_co_hdl, oid, epoch - 3, "a", "b",
-		       VOS_OF_USE_TIMESTAMPS, -DER_TX_RESTART, sgl, "foo");
+		       0, -DER_TX_RESTART, sgl, "foo");
 	/** Conditional insert should succeed */
 	cond_update_op(state, arg->ctx.tc_co_hdl, oid, epoch++, "a", "b",
-		       VOS_OF_USE_TIMESTAMPS | VOS_OF_COND_DKEY_INSERT, 0, sgl,
+		       VOS_OF_COND_DKEY_INSERT, 0, sgl,
 		       "foo");
 	/** Conditional insert should fail */
 	cond_update_op(state, arg->ctx.tc_co_hdl, oid, epoch++, "a", "b",
-		       VOS_OF_USE_TIMESTAMPS | VOS_OF_COND_DKEY_INSERT,
+		       VOS_OF_COND_DKEY_INSERT,
 		       -DER_EXIST, sgl, "bar");
 	/** Check the value */
 	cond_fetch_op(state, arg->ctx.tc_co_hdl, oid, epoch++, "a", "b",
-		      VOS_OF_USE_TIMESTAMPS, 0, sgl, "foo", 'x');
+		      0, 0, sgl, "foo", 'x');
 	/** Check the value before, should be empty */
 	cond_fetch_op(state, arg->ctx.tc_co_hdl, oid, epoch - 4, "a", "b",
-		      VOS_OF_USE_TIMESTAMPS, 0, sgl, "xxxx", 'x');
+		      0, 0, sgl, "xxxx", 'x');
 	obj_punch_op(state, arg->ctx.tc_co_hdl, oid, epoch++);
 	/** Non conditional fetch should not see data anymore */
 	cond_fetch_op(state, arg->ctx.tc_co_hdl, oid, epoch++, "a", "b",
-		      VOS_OF_USE_TIMESTAMPS, 0, sgl, "xxxx", 'x');
-	/** Conditional update of non-existed key should fail */
+		      0, 0, sgl, "xxxx", 'x');
+	/** Conditional update of non-existent key should fail */
 	cond_update_op(state, arg->ctx.tc_co_hdl, oid, epoch - 1, "a", "b",
-		       VOS_OF_USE_TIMESTAMPS | VOS_OF_COND_DKEY_UPDATE,
+		       VOS_OF_COND_DKEY_UPDATE,
 		       -DER_NONEXIST, sgl, "foo");
-	/** Conditional punch of non-existed akey should fail */
+	/** Conditional punch of non-existent akey should fail */
 	cond_akey_punch_op(state, arg->ctx.tc_co_hdl, oid, epoch, "a", "b",
-			   VOS_OF_USE_TIMESTAMPS | VOS_OF_COND_PUNCH,
-			   -DER_NONEXIST);
+			   VOS_OF_COND_PUNCH, -DER_NONEXIST);
 	/** Key doesn't exist still, that supersedes read conflict */
 	cond_dkey_punch_op(state, arg->ctx.tc_co_hdl, oid, epoch++, "a",
-			   VOS_OF_USE_TIMESTAMPS | VOS_OF_COND_PUNCH,
-			   -DER_NONEXIST);
+			   VOS_OF_COND_PUNCH, -DER_NONEXIST);
 	/** Conditional punch of non-existed dkey should fail */
 	cond_dkey_punch_op(state, arg->ctx.tc_co_hdl, oid, epoch++, "a",
-			   VOS_OF_USE_TIMESTAMPS | VOS_OF_COND_PUNCH,
-			   -DER_NONEXIST);
+			   VOS_OF_COND_PUNCH, -DER_NONEXIST);
 	cond_updaten_op(state, arg->ctx.tc_co_hdl, oid, epoch++, "z",
-			VOS_OF_COND_DKEY_UPDATE | VOS_OF_USE_TIMESTAMPS,
+			VOS_OF_COND_DKEY_UPDATE | 0,
 			-DER_NONEXIST, sgl, 5, "a", "foo", "b", "bar", "c",
 			"foobar", "d", "value", "e", "abc");
 	cond_updaten_op(state, arg->ctx.tc_co_hdl, oid, epoch - 2, "z",
-			VOS_OF_COND_DKEY_INSERT | VOS_OF_USE_TIMESTAMPS,
+			VOS_OF_COND_DKEY_INSERT | 0,
 			-DER_TX_RESTART, sgl, 5, "a", "foo", "b", "bar", "c",
 			"foobar", "d", "value", "e", "abc");
 	cond_updaten_op(state, arg->ctx.tc_co_hdl, oid, epoch++, "z",
-			VOS_OF_COND_DKEY_INSERT | VOS_OF_USE_TIMESTAMPS,
+			VOS_OF_COND_DKEY_INSERT | 0,
 			0, sgl, 5, "a", "foo", "b", "bar", "c",
 			"foobar", "d", "value", "e", "abc");
 	cond_fetch_op(state, arg->ctx.tc_co_hdl, oid, epoch++, "z", "a",
-		      VOS_OF_COND_AKEY_FETCH | VOS_OF_USE_TIMESTAMPS, 0, sgl,
+		      VOS_OF_COND_AKEY_FETCH | 0, 0, sgl,
 		      "foo", 'x');
 	cond_fetch_op(state, arg->ctx.tc_co_hdl, oid, epoch++, "a", "nonexist",
-		      VOS_OF_COND_AKEY_FETCH | VOS_OF_USE_TIMESTAMPS,
+		      VOS_OF_COND_AKEY_FETCH | 0,
 		      -DER_NONEXIST, sgl, "xxx", 'x');
 	cond_update_op(state, arg->ctx.tc_co_hdl, oid, epoch - 2, "a",
-		       "nonexist", VOS_OF_USE_TIMESTAMPS, -DER_TX_RESTART, sgl,
+		       "nonexist", 0, -DER_TX_RESTART, sgl,
 		       "foo");
 	cond_fetch_op(state, arg->ctx.tc_co_hdl, oid, epoch++, "nonexist", "a",
-		      VOS_OF_COND_DKEY_FETCH | VOS_OF_USE_TIMESTAMPS,
+		      VOS_OF_COND_DKEY_FETCH | 0,
 		      -DER_NONEXIST, sgl, "xxx", 'x');
 	cond_update_op(state, arg->ctx.tc_co_hdl, oid, epoch - 2, "nonexist",
-		       "a", VOS_OF_USE_TIMESTAMPS, -DER_TX_RESTART, sgl,
+		       "a", 0, -DER_TX_RESTART, sgl,
 		       "foo");
 	cond_update_op(state, arg->ctx.tc_co_hdl, oid, epoch++, "nonexist",
-		       "a", VOS_OF_USE_TIMESTAMPS, 0, sgl, "foo");
+		       "a", 0, 0, sgl, "foo");
 	cond_fetch_op(state, arg->ctx.tc_co_hdl, oid, epoch++, "nonexist", "a",
-		      VOS_OF_COND_DKEY_FETCH | VOS_OF_USE_TIMESTAMPS, 0, sgl,
+		      VOS_OF_COND_DKEY_FETCH | 0, 0, sgl,
 		      "foo", 'x');
 
 	oid = gen_oid(0);
 	/** Test duplicate akey */
 	cond_updaten_op(state, arg->ctx.tc_co_hdl, oid, epoch, "a",
-			VOS_OF_USE_TIMESTAMPS, -DER_NO_PERM, sgl, 5, "c", "foo",
+			0, -DER_NO_PERM, sgl, 5, "c", "foo",
 			"c", "bar", "d", "val", "e", "flag", "f", "temp");
 	cond_updaten_op(state, arg->ctx.tc_co_hdl, oid, epoch, "a",
-			VOS_OF_USE_TIMESTAMPS, -DER_NO_PERM, sgl, 5, "new",
+			0, -DER_NO_PERM, sgl, 5, "new",
 			"foo", "f", "bar", "d", "val", "e", "flag", "new",
 			"temp");
 }
@@ -1326,7 +1364,7 @@ remove_test(void **state)
 
 	/* Write the records */
 	rc = vos_obj_update(arg->ctx.tc_co_hdl, oid, epoch++, 0,
-			    VOS_OF_USE_TIMESTAMPS, &dkey, 1, &iod, NULL, &sgl);
+			    0, &dkey, 1, &iod, NULL, &sgl);
 	assert_int_equal(rc, 0);
 
 	/* Try removing partial entries */
@@ -1349,7 +1387,7 @@ remove_test(void **state)
 	recx[0].rx_nr = sizeof(REM_VAL1) - 1;
 
 	rc = vos_obj_update(arg->ctx.tc_co_hdl, oid, epoch++, 0,
-			    VOS_OF_USE_TIMESTAMPS, &dkey, 1, &iod, NULL, &sgl);
+			    0, &dkey, 1, &iod, NULL, &sgl);
 	assert_int_equal(rc, 0);
 
 	recx[0].rx_idx = 0;

--- a/src/vos/tests/vts_ts.c
+++ b/src/vos/tests/vts_ts.c
@@ -734,6 +734,9 @@ ts_test_init(void **state)
 	struct vos_ts_table	*ts_table;
 	struct ts_test_arg	*ts_arg;
 	int			 rc;
+	uuid_t			 uuid;
+
+	uuid_clear(uuid);
 
 	D_ALLOC_PTR(ts_arg);
 	if (ts_arg == NULL)
@@ -748,7 +751,7 @@ ts_test_init(void **state)
 	for (i = 0; i < VOS_TS_TYPE_COUNT; i++)
 		ts_arg->ta_counts[i] = ts_table->tt_type_info[i].ti_count;
 
-	rc = vos_ts_set_allocate(&ts_arg->ta_ts_set, VOS_OF_USE_TIMESTAMPS, 1);
+	rc = vos_ts_set_allocate(&ts_arg->ta_ts_set, 0, 1, &uuid);
 	if (rc != 0) {
 		D_FREE(ts_arg);
 		return rc;

--- a/src/vos/vos_io.c
+++ b/src/vos/vos_io.c
@@ -206,7 +206,7 @@ vos_ioc_create(daos_handle_t coh, daos_unit_oid_t oid, bool read_only,
 	       daos_epoch_t epoch, uint64_t cond_flags, unsigned int iod_nr,
 	       daos_iod_t *iods, struct dcs_iod_csums *iod_csums,
 	       uint32_t fetch_flags, struct daos_recx_ep_list *shadows,
-	       struct vos_io_context **ioc_pp)
+	       struct dtx_handle *dth, struct vos_io_context **ioc_pp)
 {
 	struct vos_container *cont;
 	struct vos_io_context *ioc = NULL;
@@ -250,7 +250,8 @@ vos_ioc_create(daos_handle_t coh, daos_unit_oid_t oid, bool read_only,
 	if (rc != 0)
 		goto error;
 
-	rc = vos_ts_set_allocate(&ioc->ic_ts_set, cond_flags, iod_nr);
+	rc = vos_ts_set_allocate(&ioc->ic_ts_set, cond_flags, iod_nr,
+				 dth ? &dth->dth_xid.dti_uuid : NULL);
 	if (rc != 0)
 		goto error;
 
@@ -940,17 +941,17 @@ update_ts_on_fetch(struct vos_io_context *ioc, int err)
 	 *  both akey timestamps regardless
 	 */
 	entry = vos_ts_set_get_entry_type(ts_set, VOS_TS_TYPE_CONT, 0);
-	entry->te_ts_rh = MAX(entry->te_ts_rh, ioc->ic_epr.epr_hi);
+	vos_ts_rh_update(entry, ioc->ic_epr.epr_hi, ts_set->ts_tx_id);
 	entry = vos_ts_set_get_entry_type(ts_set, VOS_TS_TYPE_OBJ, 0);
-	entry->te_ts_rh = MAX(entry->te_ts_rh, ioc->ic_epr.epr_hi);
+	vos_ts_rh_update(entry, ioc->ic_epr.epr_hi, ts_set->ts_tx_id);
 	prev = entry;
 	entry = vos_ts_set_get_entry_type(ts_set, VOS_TS_TYPE_DKEY, 0);
 
 	if (entry == NULL)
 		goto update_prev;
 	if (ts_set->ts_flags & VOS_OF_COND_DKEY_FETCH)
-		entry->te_ts_rl = MAX(entry->te_ts_rl, ioc->ic_epr.epr_hi);
-	entry->te_ts_rh = MAX(entry->te_ts_rh, ioc->ic_epr.epr_hi);
+		vos_ts_rl_update(entry, ioc->ic_epr.epr_hi, ts_set->ts_tx_id);
+	vos_ts_rh_update(entry, ioc->ic_epr.epr_hi, ts_set->ts_tx_id);
 
 	if (entry == prev)
 		return;
@@ -963,14 +964,14 @@ update_ts_on_fetch(struct vos_io_context *ioc, int err)
 		if (entry == NULL)
 			goto update_prev;
 
-		entry->te_ts_rl = MAX(entry->te_ts_rl, ioc->ic_epr.epr_hi);
-		entry->te_ts_rh = MAX(entry->te_ts_rh, ioc->ic_epr.epr_hi);
+		vos_ts_rl_update(entry, ioc->ic_epr.epr_hi, ts_set->ts_tx_id);
+		vos_ts_rh_update(entry, ioc->ic_epr.epr_hi, ts_set->ts_tx_id);
 	}
 
 	return;
 
 update_prev:
-	prev->te_ts_rl = MAX(prev->te_ts_rl, ioc->ic_epr.epr_hi);
+	vos_ts_rl_update(prev, ioc->ic_epr.epr_hi, ts_set->ts_tx_id);
 }
 
 int
@@ -988,7 +989,7 @@ vos_fetch_begin(daos_handle_t coh, daos_unit_oid_t oid, daos_epoch_t epoch,
 		DP_UOID(oid), iod_nr, epoch);
 
 	rc = vos_ioc_create(coh, oid, true, epoch, cond_flags, iod_nr, iods,
-			    NULL, fetch_flags, shadows, &ioc);
+			    NULL, fetch_flags, shadows, dth, &ioc);
 	if (rc != 0)
 		return rc;
 
@@ -1694,18 +1695,18 @@ update_ts_on_update(struct vos_io_context *ioc, int err)
 	}
 
 	entry = vos_ts_set_get_entry_type(ts_set, VOS_TS_TYPE_CONT, 0);
-	entry->te_ts_rh = MAX(entry->te_ts_rh, ioc->ic_epr.epr_hi);
+	vos_ts_rh_update(entry, ioc->ic_epr.epr_hi, ts_set->ts_tx_id);
 	entry = vos_ts_set_get_entry_type(ts_set, VOS_TS_TYPE_OBJ, 0);
-	entry->te_ts_rh = MAX(entry->te_ts_rh, ioc->ic_epr.epr_hi);
+	vos_ts_rh_update(entry, ioc->ic_epr.epr_hi, ts_set->ts_tx_id);
 	centry = vos_ts_set_get_entry_type(ts_set, VOS_TS_TYPE_DKEY, 0);
 	if (centry == NULL) {
-		entry->te_ts_rl = MAX(entry->te_ts_rl, ioc->ic_epr.epr_hi);
+		vos_ts_rl_update(entry, ioc->ic_epr.epr_hi, ts_set->ts_tx_id);
 		return;
 	}
 	entry = centry;
 	if (ts_set->ts_flags & VOS_COND_DKEY_UPDATE_MASK)
-		entry->te_ts_rl = MAX(entry->te_ts_rl, ioc->ic_epr.epr_hi);
-	entry->te_ts_rh = MAX(entry->te_ts_rh, ioc->ic_epr.epr_hi);
+		vos_ts_rl_update(entry, ioc->ic_epr.epr_hi, ts_set->ts_tx_id);
+	vos_ts_rh_update(entry, ioc->ic_epr.epr_hi, ts_set->ts_tx_id);
 
 	if ((ts_set->ts_flags & VOS_COND_AKEY_UPDATE_MASK) == 0)
 		return;
@@ -1714,12 +1715,12 @@ update_ts_on_update(struct vos_io_context *ioc, int err)
 		centry = vos_ts_set_get_entry_type(ts_set, VOS_TS_TYPE_AKEY,
 						  akey_idx);
 		if (centry == NULL) {
-			entry->te_ts_rl = MAX(entry->te_ts_rl,
-					      ioc->ic_epr.epr_hi);
+			vos_ts_rl_update(entry, ioc->ic_epr.epr_hi,
+					 ts_set->ts_tx_id);
 			continue;
 		}
-		centry->te_ts_rl = MAX(entry->te_ts_rl, ioc->ic_epr.epr_hi);
-		centry->te_ts_rh = MAX(entry->te_ts_rh, ioc->ic_epr.epr_hi);
+		vos_ts_rl_update(centry, ioc->ic_epr.epr_hi, ts_set->ts_tx_id);
+		vos_ts_rh_update(centry, ioc->ic_epr.epr_hi, ts_set->ts_tx_id);
 	}
 }
 
@@ -1853,7 +1854,8 @@ vos_update_begin(daos_handle_t coh, daos_unit_oid_t oid, daos_epoch_t epoch,
 		"\n", DP_UOID(oid), iod_nr, dth ? dth->dth_epoch :  epoch);
 
 	rc = vos_ioc_create(coh, oid, false, dth ? dth->dth_epoch : epoch,
-			    flags, iod_nr, iods, iods_csums, 0, NULL, &ioc);
+			    flags, iod_nr, iods, iods_csums, 0, NULL, dth,
+			    &ioc);
 	if (rc != 0)
 		return rc;
 
@@ -1953,16 +1955,17 @@ vos_obj_copy(struct vos_io_context *ioc, d_sg_list_t *sgls,
 }
 
 int
-vos_obj_update(daos_handle_t coh, daos_unit_oid_t oid, daos_epoch_t epoch,
-	       uint32_t pm_ver, uint64_t flags, daos_key_t *dkey,
-	       unsigned int iod_nr, daos_iod_t *iods,
-	       struct dcs_iod_csums *iods_csums, d_sg_list_t *sgls)
+vos_obj_update_ex(daos_handle_t coh, daos_unit_oid_t oid, daos_epoch_t epoch,
+		  uint32_t pm_ver, uint64_t flags, daos_key_t *dkey,
+		  unsigned int iod_nr, daos_iod_t *iods,
+		  struct dcs_iod_csums *iods_csums, d_sg_list_t *sgls,
+		  struct dtx_handle *dth)
 {
 	daos_handle_t ioh;
 	int rc;
 
 	rc = vos_update_begin(coh, oid, epoch, flags, dkey, iod_nr, iods,
-			      iods_csums, &ioh, NULL);
+			      iods_csums, &ioh, dth);
 	if (rc) {
 		D_ERROR("Update "DF_UOID" failed "DF_RC"\n", DP_UOID(oid),
 			DP_RC(rc));
@@ -1976,8 +1979,18 @@ vos_obj_update(daos_handle_t coh, daos_unit_oid_t oid, daos_epoch_t epoch,
 				DP_RC(rc));
 	}
 
-	rc = vos_update_end(ioh, pm_ver, dkey, rc, NULL);
+	rc = vos_update_end(ioh, pm_ver, dkey, rc, dth);
 	return rc;
+}
+
+int
+vos_obj_update(daos_handle_t coh, daos_unit_oid_t oid, daos_epoch_t epoch,
+	       uint32_t pm_ver, uint64_t flags, daos_key_t *dkey,
+	       unsigned int iod_nr, daos_iod_t *iods,
+	       struct dcs_iod_csums *iods_csums, d_sg_list_t *sgls)
+{
+	return vos_obj_update_ex(coh, oid, epoch, pm_ver, flags, dkey, iod_nr,
+				 iods, iods_csums, sgls, NULL);
 }
 
 int
@@ -2014,9 +2027,9 @@ vos_obj_array_remove(daos_handle_t coh, daos_unit_oid_t oid,
 }
 
 int
-vos_obj_fetch(daos_handle_t coh, daos_unit_oid_t oid, daos_epoch_t epoch,
-	      uint64_t flags, daos_key_t *dkey, unsigned int iod_nr,
-	      daos_iod_t *iods, d_sg_list_t *sgls)
+vos_obj_fetch_ex(daos_handle_t coh, daos_unit_oid_t oid, daos_epoch_t epoch,
+		 uint64_t flags, daos_key_t *dkey, unsigned int iod_nr,
+		 daos_iod_t *iods, d_sg_list_t *sgls, struct dtx_handle *dth)
 {
 	daos_handle_t	ioh;
 	bool		size_fetch = (sgls == NULL);
@@ -2024,7 +2037,7 @@ vos_obj_fetch(daos_handle_t coh, daos_unit_oid_t oid, daos_epoch_t epoch,
 	int		rc;
 
 	rc = vos_fetch_begin(coh, oid, epoch, flags, dkey, iod_nr, iods,
-			     fetch_flags, NULL, &ioh, NULL);
+			     fetch_flags, NULL, &ioh, dth);
 	if (rc) {
 		if (rc == -DER_INPROGRESS)
 			D_DEBUG(DB_TRACE, "Cannot fetch "DF_UOID" because of "
@@ -2059,6 +2072,15 @@ vos_obj_fetch(daos_handle_t coh, daos_unit_oid_t oid, daos_epoch_t epoch,
 
 	rc = vos_fetch_end(ioh, rc);
 	return rc;
+}
+
+int
+vos_obj_fetch(daos_handle_t coh, daos_unit_oid_t oid, daos_epoch_t epoch,
+	      uint64_t flags, daos_key_t *dkey, unsigned int iod_nr,
+	      daos_iod_t *iods, d_sg_list_t *sgls)
+{
+	return vos_obj_fetch_ex(coh, oid, epoch, flags, dkey, iod_nr, iods,
+				sgls, NULL);
 }
 
 /**

--- a/src/vos/vos_obj.c
+++ b/src/vos/vos_obj.c
@@ -193,18 +193,18 @@ update_read_timestamps(struct vos_ts_set *ts_set, daos_epoch_t epoch,
 	}
 
 	entry = vos_ts_set_get_entry_type(ts_set, VOS_TS_TYPE_CONT, 0);
-	entry->te_ts_rh = MAX(entry->te_ts_rh, epoch);
+	vos_ts_rh_update(entry, epoch, ts_set->ts_tx_id);
 	entry = vos_ts_set_get_entry_type(ts_set, VOS_TS_TYPE_OBJ, 0);
-	entry->te_ts_rh = MAX(entry->te_ts_rh, epoch);
+	vos_ts_rh_update(entry, epoch, ts_set->ts_tx_id);
 
 	if (ts_set->ts_init_count == 2) {
-		entry->te_ts_rl = MAX(entry->te_ts_rl, epoch);
+		vos_ts_rl_update(entry, epoch, ts_set->ts_tx_id);
 		return;
 	}
 	entry = vos_ts_set_get_entry_type(ts_set, VOS_TS_TYPE_DKEY, 0);
-	entry->te_ts_rh = MAX(entry->te_ts_rh, epoch);
+	vos_ts_rh_update(entry, epoch, ts_set->ts_tx_id);
 	if (ts_set->ts_init_count == 3) {
-		entry->te_ts_rl = MAX(entry->te_ts_rl, epoch);
+		vos_ts_rl_update(entry, epoch, ts_set->ts_tx_id);
 		return;
 	}
 	for (akey_idx = 0; akey_idx < akey_nr; akey_idx++) {
@@ -212,8 +212,8 @@ update_read_timestamps(struct vos_ts_set *ts_set, daos_epoch_t epoch,
 						  akey_idx);
 		if (entry == NULL)
 			return;
-		entry->te_ts_rl = MAX(entry->te_ts_rl, epoch);
-		entry->te_ts_rh = MAX(entry->te_ts_rh, epoch);
+		vos_ts_rl_update(entry, epoch, ts_set->ts_tx_id);
+		vos_ts_rh_update(entry, epoch, ts_set->ts_tx_id);
 	}
 }
 
@@ -241,7 +241,8 @@ vos_obj_punch(daos_handle_t coh, daos_unit_oid_t oid, daos_epoch_t epoch,
 	vos_dth_set(dth);
 	cont = vos_hdl2cont(coh);
 
-	rc = vos_ts_set_allocate(&ts_set, flags, akey_nr);
+	rc = vos_ts_set_allocate(&ts_set, flags, akey_nr,
+				 dth ? &dth->dth_xid.dti_uuid : NULL);
 	if (rc != 0)
 		goto reset;
 

--- a/src/vos/vos_ts.c
+++ b/src/vos/vos_ts.c
@@ -84,13 +84,19 @@ ts_update_on_evict(struct vos_ts_table *ts_table, struct vos_ts_entry *entry)
 	}
 
 	if (other == NULL) {
-		ts_table->tt_ts_rl = MAX(ts_table->tt_ts_rl, entry->te_ts_rl);
-		ts_table->tt_ts_rh = MAX(ts_table->tt_ts_rh, entry->te_ts_rh);
+		if (entry->te_ts_rl > ts_table->tt_ts_rl) {
+			ts_table->tt_ts_rl = entry->te_ts_rl;
+			uuid_copy(ts_table->tt_tx_rl, entry->te_tx_rl);
+		}
+		if (entry->te_ts_rh > ts_table->tt_ts_rh) {
+			ts_table->tt_ts_rh = entry->te_ts_rh;
+			uuid_copy(ts_table->tt_tx_rh, entry->te_tx_rh);
+		}
 		return true;
 	}
 
-	other->te_ts_rl = MAX(other->te_ts_rl, entry->te_ts_rl);
-	other->te_ts_rh = MAX(other->te_ts_rh, entry->te_ts_rh);
+	vos_ts_rl_update(other, entry->te_ts_rl, entry->te_tx_rl);
+	vos_ts_rh_update(other, entry->te_ts_rh, entry->te_tx_rh);
 
 	return true;
 }
@@ -178,6 +184,8 @@ vos_ts_table_alloc(struct vos_ts_table **ts_tablep)
 
 	ts_table->tt_ts_rl = vos_start_epoch;
 	ts_table->tt_ts_rh = vos_start_epoch;
+	uuid_clear(ts_table->tt_tx_rl);
+	uuid_clear(ts_table->tt_tx_rh);
 	miss_cursor = ts_table->tt_misses;
 	for (i = 0; i < VOS_TS_TYPE_COUNT; i++) {
 		info = &ts_table->tt_type_info[i];
@@ -260,6 +268,8 @@ vos_ts_evict_lru(struct vos_ts_table *ts_table, struct vos_ts_entry *parent,
 		/** Use global timestamps for the type to initialize it */
 		entry->te_ts_rl = ts_table->tt_ts_rl;
 		entry->te_ts_rh = ts_table->tt_ts_rh;
+		uuid_copy(entry->te_tx_rl, ts_table->tt_tx_rl);
+		uuid_copy(entry->te_tx_rh, ts_table->tt_tx_rh);
 		entry->te_parent_ptr = NULL;
 	} else {
 		entry->te_parent_ptr = parent->te_record_ptr;
@@ -273,6 +283,8 @@ vos_ts_evict_lru(struct vos_ts_table *ts_table, struct vos_ts_entry *parent,
 
 		entry->te_ts_rl = ts_source->te_ts_rl;
 		entry->te_ts_rh = ts_source->te_ts_rh;
+		uuid_copy(entry->te_tx_rl, ts_source->te_tx_rl);
+		uuid_copy(entry->te_tx_rh, ts_source->te_tx_rh);
 	}
 
 	/** Set the lower bounds for the entry */
@@ -289,13 +301,13 @@ vos_ts_evict_lru(struct vos_ts_table *ts_table, struct vos_ts_entry *parent,
 
 int
 vos_ts_set_allocate(struct vos_ts_set **ts_set, uint64_t flags,
-		    uint32_t akey_nr)
+		    uint32_t akey_nr, const uuid_t *tx_id)
 {
 	uint32_t	size;
 	uint64_t	array_size;
 
 	*ts_set = NULL;
-	if ((flags & VOS_OF_USE_TIMESTAMPS) == 0)
+	if (tx_id == NULL)
 		return 0;
 
 	size = 3 + akey_nr;
@@ -307,6 +319,7 @@ vos_ts_set_allocate(struct vos_ts_set **ts_set, uint64_t flags,
 
 	(*ts_set)->ts_flags = flags;
 	(*ts_set)->ts_set_size = size;
+	uuid_copy((*ts_set)->ts_tx_id, *tx_id);
 
 	return 0;
 }

--- a/src/vos/vos_ts.h
+++ b/src/vos/vos_ts.h
@@ -87,6 +87,8 @@ struct vos_ts_set_entry {
 struct vos_ts_set {
 	/** Operation flags */
 	uint64_t		 ts_flags;
+	/** Transaction that owns the set */
+	uuid_t			 ts_tx_id;
 	/** size of the set */
 	uint32_t		 ts_set_size;
 	/** Number of initialized entries */
@@ -118,6 +120,10 @@ struct vos_ts_table {
 	daos_epoch_t		tt_ts_rl;
 	/** Global read high timestamp for type */
 	daos_epoch_t		tt_ts_rh;
+	/** Transaciton id associated with global read low timestamp */
+	uuid_t			tt_tx_rl;
+	/** Transaciton id associated with global read high timestamp */
+	uuid_t			tt_tx_rh;
 	/** Miss index table */
 	uint32_t		*tt_misses;
 	/** Timestamp table pointers for a type */
@@ -146,9 +152,9 @@ ts_set_get_parent(struct vos_ts_set *ts_set)
 
 /** Reset the index in the set so an entry can be replaced
  *
- * \param	ts_set[in]	The timestamp set
- * \param	type[in]	Type of entry
- * \param	akey_idx[in]	Set to 0 if not akey, otherwise idx of akey
+ * \param[in]	ts_set		The timestamp set
+ * \param[in]	type		Type of entry
+ * \param[in]	akey_idx	Set to 0 if not akey, otherwise idx of akey
  */
 static inline void
 vos_ts_set_reset(struct vos_ts_set *ts_set, uint32_t type, uint32_t akey_nr)
@@ -189,10 +195,10 @@ vos_ts_lookup_internal(struct vos_ts_set *ts_set, uint32_t type, uint32_t *idx,
 
 /** Lookup an entry in the timestamp cache and save it to the set.
  *
- * \param	ts_set[in]	The timestamp set
- * \param	idx[in,out]	Address of the entry index.
- * \param	reset[in]	Remove the last entry in the set before checking
- * \param	entryp[in,out]	Valid only if function returns true.  Will be
+ * \param[in]		ts_set	The timestamp set
+ * \param[in,out]	idx	Address of the entry index.
+ * \param[in]		reset	Remove the last entry in the set before checking
+ * \param[in]		entryp	Valid only if function returns true.  Will be
  *				NULL if ts_set is NULL.
  *
  * \return true if the timestamp set is NULL or the entry is found in cache
@@ -225,9 +231,9 @@ vos_ts_evict_lru(struct vos_ts_table *ts_table, struct vos_ts_entry *parent,
 /** Allocate a new entry in the set.   Lookup should be called first and this
  * should only be called if it returns false.
  *
- * \param	ts_set[in]	The timestamp set
- * \param	idx[in,out]	Address of the entry index.
- * \param	hash[in]	Hash to identify the item
+ * \param[in]	ts_set	The timestamp set
+ * \param[in]	idx	Address of the entry index.
+ * \param[in]	hash	Hash to identify the item
  *
  * \return	Returns a pointer to the entry or NULL if ts_set is not
  *		allocated or we detected a duplicate akey.
@@ -280,7 +286,7 @@ vos_ts_alloc(struct vos_ts_set *ts_set, uint32_t *idx, uint64_t hash)
 
 /** Get the last entry in the set
  *
- * \param	ts_set[in]	The timestamp set
+ * \param[in]	ts_set	The timestamp set
  *
  * \return Returns the last entry added to the set or NULL
  */
@@ -298,9 +304,9 @@ vos_ts_set_get_entry(struct vos_ts_set *ts_set)
 
 /** Get the specified entry in the set
  *
- * \param	ts_set[in]	The timestamp set
- * \param	type[in]	The type of entry
- * \param	akey_idx[in]	0 or index of the akey
+ * \param[in]	ts_set		The timestamp set
+ * \param[in]	type		The type of entry
+ * \param[in]	akey_idx	0 or index of the akey
  *
  * \return Returns the last entry added to the set or NULL
  */
@@ -323,9 +329,9 @@ vos_ts_set_get_entry_type(struct vos_ts_set *ts_set, uint32_t type,
 /** Set the index of the associated positive entry in the last entry
  *  in the set.
  *
- *  \param	ts_set[in]	The timestamp set
- *  \param	idx[in]		Pointer to the index that will be used
- *				when allocating the positive entry
+ *  \param[in]	ts_set	The timestamp set
+ *  \param[in]	idx	Pointer to the index that will be used
+ *			when allocating the positive entry
  */
 static inline void
 vos_ts_set_mark_entry(struct vos_ts_set *ts_set, uint32_t *idx)
@@ -346,9 +352,9 @@ vos_ts_set_mark_entry(struct vos_ts_set *ts_set, uint32_t *idx)
  *  case is identified by a hash.  This looks up the negative entry and
  *  allocates it if necessary.  Resets te_create_idx to NULL.
  *
- * \param	ts_set[in]	The timestamp set
- * \param	hash		The hash of the missing subtree entry
- * \param	reset[in]	Remove the last entry in the set before checking
+ * \param[in]	ts_set	The timestamp set
+ * \param[in]	hash	The hash of the missing subtree entry
+ * \param[in]	reset	Remove the last entry in the set before checking
  *
  * \return	The entry for negative lookups on the subtree
  */
@@ -406,8 +412,8 @@ out:
  *  update global timestamps for the type.  Move the evicted entry to the LRU
  *  and mark it as already evicted.
  *
- * \param	idx[in]		Address of the entry index.
- * \param	type[in]	Type of the object
+ * \param[in]	idx	Address of the entry index.
+ * \param[in]	type	Type of the object
  */
 static inline void
 vos_ts_evict(uint32_t *idx, uint32_t type)
@@ -419,10 +425,10 @@ vos_ts_evict(uint32_t *idx, uint32_t type)
 
 /** Allocate thread local timestamp cache.   Set the initial global times
  *
- * \param	ts_table[in,out]	Thread local table pointer
+ * \param[in,out]	ts_table	Thread local table pointer
  *
- * \return	-DER_NOMEM	Not enough memory available
- *		0		Success
+ * \return		-DER_NOMEM	Not enough memory available
+ *			0		Success
  */
 int
 vos_ts_table_alloc(struct vos_ts_table **ts_table);
@@ -430,60 +436,35 @@ vos_ts_table_alloc(struct vos_ts_table **ts_table);
 
 /** Free the thread local timestamp cache and reset pointer to NULL
  *
- * \param	ts_table[in,out]	Thread local table pointer
+ * \param[in,out]	ts_table	Thread local table pointer
  */
 void
 vos_ts_table_free(struct vos_ts_table **ts_table);
 
-/** Update the low read timestamp, if applicable
- *
- *  \param	entry[in,out]	Entry to update
- *  \param	epoch[in]	Update epoch
- */
-static inline void
-vos_ts_update_read_low(struct vos_ts_entry *entry, daos_epoch_t epoch)
-{
-	if (entry == NULL)
-		return;
-	entry->te_ts_rl = MAX(entry->te_ts_rl, epoch);
-}
-
-/** Update the high read timestamp, if applicable
- *
- *  \param	entry[in,out]	Entry to update
- *  \param	epoch[in]	Update epoch
- */
-static inline void
-vos_ts_update_read_high(struct vos_ts_entry *entry, daos_epoch_t epoch)
-{
-	if (entry == NULL)
-		return;
-	entry->te_ts_rh = MAX(entry->te_ts_rh, epoch);
-}
-
 /** Allocate a timestamp set
  *
- * \param	ts_set[in,out]	Pointer to set
- * \param	flags[in]	Operations flags
- * \param	akey_nr[in]	Number of akeys in operation
+ * \param[in,out]	ts_set	Pointer to set
+ * \param[in]		flags	Operations flags
+ * \param[in]		akey_nr	Number of akeys in operation
+ * \param[in]		tx_id	Optional transaction id
  *
  * \return	0 on success, error otherwise.
  */
 int
 vos_ts_set_allocate(struct vos_ts_set **ts_set, uint64_t flags,
-		    uint32_t akey_nr);
+		    uint32_t akey_nr, const uuid_t *tx_id);
 
 /** Upgrade any negative entries in the set now that the associated
  *  update/punch has committed
  *
- *  \param	ts_set[in]	Pointer to set
+ *  \param[in]	ts_set	Pointer to set
  */
 void
 vos_ts_set_upgrade(struct vos_ts_set *ts_set);
 
 /** Free an allocated timestamp set
  *
- * \param	ts_set[in]	Set to free
+ * \param[in]	ts_set	Set to free
  */
 static inline void
 vos_ts_set_free(struct vos_ts_set *ts_set)
@@ -491,10 +472,44 @@ vos_ts_set_free(struct vos_ts_set *ts_set)
 	D_FREE(ts_set);
 }
 
+/** Update the low timestamp if the new read is newer
+ *
+ * \param[in]	entry		The timestamp entry
+ * \param[in]	read_time	The new read timestamp
+ * \param[in]	tx_id		The uuid of the new read
+ */
+static inline void
+vos_ts_rl_update(struct vos_ts_entry *entry, daos_epoch_t read_time,
+		 const uuid_t tx_id)
+{
+	if (entry == NULL || read_time <= entry->te_ts_rl)
+		return;
+
+	entry->te_ts_rl = read_time;
+	uuid_copy(entry->te_tx_rl, tx_id);
+}
+
+/** Update the low timestamp if the new read is newer
+ *
+ * \param[in]	entry		The timestamp entry
+ * \param[in]	read_time	The new read timestamp
+ * \param[in]	tx_id		The uuid of the new read
+ */
+static inline void
+vos_ts_rh_update(struct vos_ts_entry *entry, daos_epoch_t read_time,
+		 const uuid_t tx_id)
+{
+	if (entry == NULL || read_time <= entry->te_ts_rh)
+		return;
+
+	entry->te_ts_rh = read_time;
+	uuid_copy(entry->te_tx_rh, tx_id);
+}
+
 /** Check the read low timestamp at current entry.
  *
- * \param	ts_set[in]	The timestamp set
- * \param	write_time[in]	The write time
+ * \param[in]	ts_set		The timestamp set
+ * \param[in]	write_time	The write time
  *
  * \return	true	Conflict
  *		false	No conflict (or no timestamp set)
@@ -508,16 +523,16 @@ vos_ts_check_rl_conflict(struct vos_ts_set *ts_set, daos_epoch_t write_time)
 	if (entry == NULL || write_time > entry->te_ts_rl)
 		return false;
 
-	/** TODO: Need to eventually handle == case but it should not be an
-	 * issue without MVCC.
-	 */
-	return true;
+	if (write_time != entry->te_ts_rl)
+		return true;
+
+	return uuid_compare(ts_set->ts_tx_id, entry->te_tx_rl) != 0;
 }
 
 /** Check the read high timestamp at current entry.
  *
- * \param	ts_set[in]	The timestamp set
- * \param	write_time[in]	The write time
+ * \param[in]	ts_set		The timestamp set
+ * \param[in]	write_time	The write time
  *
  * \return	true	Conflict
  *		false	No conflict (or no timestamp set)
@@ -531,10 +546,10 @@ vos_ts_check_rh_conflict(struct vos_ts_set *ts_set, daos_epoch_t write_time)
 	if (entry == NULL || write_time > entry->te_ts_rh)
 		return false;
 
-	/** TODO: Need to eventually handle == case but it should not be an
-	 * issue without MVCC.
-	 */
-	return true;
+	if (write_time != entry->te_ts_rh)
+		return true;
+
+	return uuid_compare(ts_set->ts_tx_id, entry->te_tx_rh) != 0;
 }
 
 #endif /* __VOS_TS__ */


### PR DESCRIPTION
This limits any timestamp checks and updates to cases where a dtx
handle exists.  It updates the mvcc and pm tests to use transactions
where needed to get timestamp updates and checks.  It also adds the
check for same transaction updates by comparing the transaction uuid.
Adds an internal API to get unique uuid from the same thread for
internal purposes.   Adds ex API for vos_obj_update/fetch to pass
dth

Signed-off-by: Jeff Olivier <jeffrey.v.olivier@intel.com>