### PR TITLE
DAOS-5089 lru: Improve HASH implementation

### DIFF
--- a/src/cart/SConscript
+++ b/src/cart/SConscript
@@ -43,7 +43,7 @@ import daos_build
 Import('prereqs', 'env')
 
 # Keep versioned libs for now to avoid any conflict with 1.0
-CART_VERSION = "4.7.0"
+CART_VERSION = "4.8.0"
 
 def scons():
     """Scons function"""

--- a/src/cart/src/cart/crt_context.c
+++ b/src/cart/src/cart/crt_context.c
@@ -57,7 +57,8 @@ epi_op_key_hash(struct d_hash_table *hhtab, const void *key,
 {
 	D_ASSERT(ksize == sizeof(d_rank_t));
 
-	return *(const uint32_t *)key % (1U << CRT_EPI_TABLE_BITS);
+	return (uint32_t)(*(const uint32_t *)key
+			 & ((1U << CRT_EPI_TABLE_BITS) - 1));
 }
 
 static bool
@@ -77,7 +78,8 @@ epi_op_rec_hash(struct d_hash_table *htable, d_list_t *link)
 {
 	struct crt_ep_inflight *epi = epi_link2ptr(link);
 
-	return epi->epi_ep.ep_rank % (1U << CRT_EPI_TABLE_BITS);
+	return (uint32_t)epi->epi_ep.ep_rank
+			& ((1U << CRT_EPI_TABLE_BITS) - 1);
 }
 
 static void

--- a/src/cart/src/cart/crt_context.c
+++ b/src/cart/src/cart/crt_context.c
@@ -51,24 +51,13 @@ epi_link2ptr(d_list_t *rlink)
 	return container_of(rlink, struct crt_ep_inflight, epi_link);
 }
 
-static int
-epi_op_key_get(struct d_hash_table *hhtab, d_list_t *rlink, void **key_pp)
-{
-	struct crt_ep_inflight *epi = epi_link2ptr(rlink);
-
-	/* TODO: use global rank */
-	*key_pp = (void *)&epi->epi_ep.ep_rank;
-	return sizeof(epi->epi_ep.ep_rank);
-}
-
 static uint32_t
 epi_op_key_hash(struct d_hash_table *hhtab, const void *key,
 		unsigned int ksize)
 {
 	D_ASSERT(ksize == sizeof(d_rank_t));
 
-	return (unsigned int)(*(const uint32_t *)key %
-		(1U << CRT_EPI_TABLE_BITS));
+	return *(const uint32_t *)key % (1U << CRT_EPI_TABLE_BITS);
 }
 
 static bool
@@ -81,6 +70,14 @@ epi_op_key_cmp(struct d_hash_table *hhtab, d_list_t *rlink,
 	/* TODO: use global rank */
 
 	return epi->epi_ep.ep_rank == *(d_rank_t *)key;
+}
+
+static uint32_t
+epi_op_rec_hash(struct d_hash_table *htable, d_list_t *link)
+{
+	struct crt_ep_inflight *epi = epi_link2ptr(link);
+
+	return epi->epi_ep.ep_rank % (1U << CRT_EPI_TABLE_BITS);
 }
 
 static void
@@ -105,9 +102,9 @@ epi_op_rec_free(struct d_hash_table *hhtab, d_list_t *rlink)
 }
 
 static d_hash_table_ops_t epi_table_ops = {
-	.hop_key_get		= epi_op_key_get,
 	.hop_key_hash		= epi_op_key_hash,
 	.hop_key_cmp		= epi_op_key_cmp,
+	.hop_rec_hash		= epi_op_rec_hash,
 	.hop_rec_addref		= epi_op_rec_addref,
 	.hop_rec_decref		= epi_op_rec_decref,
 	.hop_rec_free		= epi_op_rec_free,

--- a/src/cart/src/cart/crt_group.c
+++ b/src/cart/src/cart/crt_group.c
@@ -77,22 +77,12 @@ crt_li_link2ptr(d_list_t *rlink)
 	return container_of(rlink, struct crt_lookup_item, li_link);
 }
 
-static int
-li_op_key_get(struct d_hash_table *hhtab, d_list_t *rlink, void **key_pp)
-{
-	struct crt_lookup_item *li = crt_li_link2ptr(rlink);
-
-	*key_pp = (void *)&li->li_rank;
-	return sizeof(li->li_rank);
-}
-
 static uint32_t
 li_op_key_hash(struct d_hash_table *hhtab, const void *key, unsigned int ksize)
 {
 	D_ASSERT(ksize == sizeof(d_rank_t));
 
-	return (unsigned int)(*(const uint32_t *)key %
-		(1U << CRT_LOOKUP_CACHE_BITS));
+	return *(const uint32_t *)key % (1U << CRT_LOOKUP_CACHE_BITS);
 }
 
 static bool
@@ -104,6 +94,14 @@ li_op_key_cmp(struct d_hash_table *hhtab, d_list_t *rlink,
 	D_ASSERT(ksize == sizeof(d_rank_t));
 
 	return li->li_rank == *(d_rank_t *)key;
+}
+
+static uint32_t
+li_op_rec_hash(struct d_hash_table *htable, d_list_t *link)
+{
+	struct crt_lookup_item *li = crt_li_link2ptr(link);
+
+	return li->li_rank % (1U << CRT_LOOKUP_CACHE_BITS);
 }
 
 static void
@@ -131,9 +129,9 @@ li_op_rec_free(struct d_hash_table *hhtab, d_list_t *rlink)
 }
 
 static d_hash_table_ops_t lookup_table_ops = {
-	.hop_key_get		= li_op_key_get,
 	.hop_key_hash		= li_op_key_hash,
 	.hop_key_cmp		= li_op_key_cmp,
+	.hop_rec_hash		= li_op_rec_hash,
 	.hop_rec_addref		= li_op_rec_addref,
 	.hop_rec_decref		= li_op_rec_decref,
 	.hop_rec_free		= li_op_rec_free,
@@ -146,22 +144,12 @@ crt_rm_link2ptr(d_list_t *rlink)
 	return container_of(rlink, struct crt_rank_mapping, rm_link);
 }
 
-static int
-rm_op_key_get(struct d_hash_table *hhtab, d_list_t *rlink, void **key_pp)
-{
-	struct crt_rank_mapping *rm = crt_rm_link2ptr(rlink);
-
-	*key_pp = (void *)&rm->rm_key;
-	return sizeof(rm->rm_key);
-}
-
 static uint32_t
 rm_op_key_hash(struct d_hash_table *hhtab, const void *key, unsigned int ksize)
 {
 	D_ASSERT(ksize == sizeof(d_rank_t));
 
-	return (unsigned int)(*(const uint32_t *)key %
-		(1U << CRT_LOOKUP_CACHE_BITS));
+	return *(const uint32_t *)key % (1U << CRT_LOOKUP_CACHE_BITS);
 }
 
 static bool
@@ -173,6 +161,14 @@ rm_op_key_cmp(struct d_hash_table *hhtab, d_list_t *rlink,
 	D_ASSERT(ksize == sizeof(d_rank_t));
 
 	return rm->rm_key == *(d_rank_t *)key;
+}
+
+static uint32_t
+rm_op_rec_hash(struct d_hash_table *htable, d_list_t *link)
+{
+	struct crt_rank_mapping *rm = crt_rm_link2ptr(link);
+
+	return rm->rm_key % (1U << CRT_LOOKUP_CACHE_BITS);
 }
 
 static void
@@ -216,22 +212,12 @@ crt_ui_link2ptr(d_list_t *rlink)
 	return container_of(rlink, struct crt_uri_item, ui_link);
 }
 
-static int
-ui_op_key_get(struct d_hash_table *hhtab, d_list_t *rlink, void **key_pp)
-{
-	struct crt_uri_item *ui = crt_ui_link2ptr(rlink);
-
-	*key_pp = (void *)&ui->ui_rank;
-	return sizeof(ui->ui_rank);
-}
-
 static uint32_t
 ui_op_key_hash(struct d_hash_table *hhtab, const void *key, unsigned int ksize)
 {
 	D_ASSERT(ksize == sizeof(d_rank_t));
 
-	return (unsigned int)(*(const uint32_t *)key %
-		(1U << CRT_LOOKUP_CACHE_BITS));
+	return *(const uint32_t *)key % (1U << CRT_LOOKUP_CACHE_BITS);
 }
 
 static bool
@@ -243,6 +229,14 @@ ui_op_key_cmp(struct d_hash_table *hhtab, d_list_t *rlink,
 	D_ASSERT(ksize == sizeof(d_rank_t));
 
 	return ui->ui_rank == *(d_rank_t *)key;
+}
+
+static uint32_t
+ui_op_rec_hash(struct d_hash_table *htable, d_list_t *link)
+{
+	struct crt_uri_item *ui = crt_ui_link2ptr(link);
+
+	return ui->ui_rank % (1U << CRT_LOOKUP_CACHE_BITS);
 }
 
 static void
@@ -377,18 +371,18 @@ ui_op_rec_free(struct d_hash_table *hhtab, d_list_t *rlink)
 }
 
 static d_hash_table_ops_t uri_lookup_table_ops = {
-	.hop_key_get		= ui_op_key_get,
 	.hop_key_hash		= ui_op_key_hash,
 	.hop_key_cmp		= ui_op_key_cmp,
+	.hop_rec_hash		= ui_op_rec_hash,
 	.hop_rec_addref		= ui_op_rec_addref,
 	.hop_rec_decref		= ui_op_rec_decref,
 	.hop_rec_free		= ui_op_rec_free,
 };
 
 static d_hash_table_ops_t rank_mapping_ops = {
-	.hop_key_get		= rm_op_key_get,
 	.hop_key_hash		= rm_op_key_hash,
 	.hop_key_cmp		= rm_op_key_cmp,
+	.hop_rec_hash		= rm_op_rec_hash,
 	.hop_rec_addref		= rm_op_rec_addref,
 	.hop_rec_decref		= rm_op_rec_decref,
 	.hop_rec_free		= rm_op_rec_free,

--- a/src/cart/src/cart/crt_group.c
+++ b/src/cart/src/cart/crt_group.c
@@ -82,7 +82,8 @@ li_op_key_hash(struct d_hash_table *hhtab, const void *key, unsigned int ksize)
 {
 	D_ASSERT(ksize == sizeof(d_rank_t));
 
-	return *(const uint32_t *)key % (1U << CRT_LOOKUP_CACHE_BITS);
+	return (uint32_t)(*(const uint32_t *)key
+			  & ((1U << CRT_LOOKUP_CACHE_BITS) - 1));
 }
 
 static bool
@@ -101,7 +102,7 @@ li_op_rec_hash(struct d_hash_table *htable, d_list_t *link)
 {
 	struct crt_lookup_item *li = crt_li_link2ptr(link);
 
-	return li->li_rank % (1U << CRT_LOOKUP_CACHE_BITS);
+	return (uint32_t)li->li_rank & ((1U << CRT_LOOKUP_CACHE_BITS) - 1);
 }
 
 static void
@@ -149,7 +150,8 @@ rm_op_key_hash(struct d_hash_table *hhtab, const void *key, unsigned int ksize)
 {
 	D_ASSERT(ksize == sizeof(d_rank_t));
 
-	return *(const uint32_t *)key % (1U << CRT_LOOKUP_CACHE_BITS);
+	return (uint32_t)(*(const uint32_t *)key
+			  & ((1U << CRT_LOOKUP_CACHE_BITS) - 1));
 }
 
 static bool
@@ -168,7 +170,7 @@ rm_op_rec_hash(struct d_hash_table *htable, d_list_t *link)
 {
 	struct crt_rank_mapping *rm = crt_rm_link2ptr(link);
 
-	return rm->rm_key % (1U << CRT_LOOKUP_CACHE_BITS);
+	return (uint32_t)rm->rm_key & ((1U << CRT_LOOKUP_CACHE_BITS) - 1);
 }
 
 static void
@@ -217,7 +219,8 @@ ui_op_key_hash(struct d_hash_table *hhtab, const void *key, unsigned int ksize)
 {
 	D_ASSERT(ksize == sizeof(d_rank_t));
 
-	return *(const uint32_t *)key % (1U << CRT_LOOKUP_CACHE_BITS);
+	return (uint32_t)(*(const uint32_t *)key
+			  & ((1U << CRT_LOOKUP_CACHE_BITS) - 1));
 }
 
 static bool
@@ -236,7 +239,7 @@ ui_op_rec_hash(struct d_hash_table *htable, d_list_t *link)
 {
 	struct crt_uri_item *ui = crt_ui_link2ptr(link);
 
-	return ui->ui_rank % (1U << CRT_LOOKUP_CACHE_BITS);
+	return (uint32_t)ui->ui_rank & ((1U << CRT_LOOKUP_CACHE_BITS) - 1);
 }
 
 static void

--- a/src/cart/src/gurt/fault_inject.c
+++ b/src/cart/src/gurt/fault_inject.c
@@ -69,6 +69,14 @@ fa_op_key_cmp(struct d_hash_table *htab, d_list_t *rlink, const void *key,
 
 	return fa_ptr->fa_attr.fa_id == *(uint32_t *)key;
 }
+static uint32_t
+fa_op_rec_hash(struct d_hash_table *htab, d_list_t *link)
+{
+	struct d_fault_attr *fa_ptr = fa_link2ptr(link);
+
+	return d_hash_string_u32((const char *)&fa_ptr->fa_attr.fa_id,
+				 sizeof(fa_ptr->fa_attr.fa_id));
+}
 
 static void
 fa_op_rec_free(struct d_hash_table *htab, d_list_t *rlink)
@@ -97,6 +105,7 @@ fa_op_rec_decref(struct d_hash_table *htab, d_list_t *rlink)
 
 static d_hash_table_ops_t fa_table_ops = {
 	.hop_key_cmp	= fa_op_key_cmp,
+	.hop_rec_hash	= fa_op_rec_hash,
 	.hop_rec_decref	= fa_op_rec_decref,
 	.hop_rec_free	= fa_op_rec_free,
 };

--- a/src/cart/src/include/gurt/hash.h
+++ b/src/cart/src/include/gurt/hash.h
@@ -243,14 +243,14 @@ union d_hash_lock {
 
 struct d_hash_bucket {
 	d_list_t		hb_head;
-	/** different type of locks based on ht_feats */
-	union d_hash_lock	hb_lock;
 #if D_HASH_DEBUG
 	unsigned int		hb_dep;
 #endif
 };
 
 struct d_hash_table {
+	/** different type of locks based on ht_feats */
+	union d_hash_lock	 ht_lock;
 	/** bits to generate number of buckets */
 	uint32_t		 ht_bits;
 	/** feature bits */
@@ -270,7 +270,7 @@ struct d_hash_table {
 	/** array of buckets */
 	struct d_hash_bucket	*ht_buckets;
 	/** different type of locks based on ht_feats */
-	union d_hash_lock	 ht_lock;
+	union d_hash_lock	*ht_locks;
 };
 
 /**
@@ -627,8 +627,6 @@ struct d_ulink {
 	struct d_rlink		 ul_link;
 	struct d_uuid		 ul_uuid;
 	struct d_ulink_ops	*ul_ops;
-	/** optional argument for compare callback */
-	void			*ul_cmp_args;
 };
 
 int  d_uhash_create(uint32_t feats, uint32_t bits,

--- a/src/cart/src/include/gurt/hash.h
+++ b/src/cart/src/include/gurt/hash.h
@@ -49,7 +49,7 @@
 #include <stdbool.h>
 
 #include <gurt/list.h>
-#include <gurt/types.h> /* for d_uuid */
+#include <gurt/types.h>
 
 /**
  * Hash table keeps and prints extra debugging information
@@ -71,67 +71,64 @@ extern "C" {
 
 typedef struct {
 	/**
-	 * Compare \p key with the key of the record \p rlink
+	 * Compare \p key with the key of the record \p link
 	 * This member function is mandatory.
 	 *
-	 * \param[in] htable	hash table
-	 * \param[in] rlink	The link chain of the record
-	 * \param[in] key	Key to compare
-	 * \param[in] ksize	Size of the key
+	 * \param[in]	htable	hash table
+	 * \param[in]	link	The link chain of the record
+	 * \param[in]	key	Key to compare
+	 * \param[in]	ksize	Size of the key
 	 *
 	 * \retval	true	The key of the record equals to \p key.
 	 * \retval	false	No match
 	 */
-	bool	 (*hop_key_cmp)(struct d_hash_table *htable, d_list_t *rlink,
+	bool	 (*hop_key_cmp)(struct d_hash_table *htable, d_list_t *link,
 				const void *key, unsigned int ksize);
 	/**
-	 * Optional, generate a key for the record \p rlink.
+	 * Optional, generate a key for the record \p link.
 	 *
 	 * This function is called before inserting a record w/o key into a
 	 * hash table.
 	 *
-	 * \param[in] htable	hash table
-	 * \param[in] rlink	The link chain of the record to generate key.
-	 * \param[in] arg	Input arguments for the key generating.
+	 * \param[in]	htable	hash table
+	 * \param[in]	link	The link chain of the record to generate key.
+	 * \param[in]	arg	Input arguments for the key generating.
 	 */
-	void	 (*hop_key_init)(struct d_hash_table *htable,
-				 d_list_t *rlink, void *arg);
-	/**
-	 * Optional, return the key of record \p rlink to \p key_pp, and size of
-	 * the key as the returned value.
-	 *
-	 * \param[in] htable	hash table
-	 * \param[in] rlink	The link chain of the record being queried.
-	 * \param[out] key_pp	The returned key.
-	 *
-	 * \return		size of the key.
-	 */
-	int	 (*hop_key_get)(struct d_hash_table *htable, d_list_t *rlink,
-				void **key_pp);
+	void	 (*hop_key_init)(struct d_hash_table *htable, d_list_t *link,
+				 void *arg);
 	/**
 	 * Optional, hash \p key to a 32-bit value.
 	 * DJB2 hash is used when this function is abscent.
 	 *
-	 * \param[in] htable	hash table
-	 * \param[in] key	Key to hash
-	 * \param[in] ksize	Key size
+	 * \param[in]	htable	hash table
+	 * \param[in]	key	Key to hash
+	 * \param[in]	ksize	Key size
 	 *
 	 * \return		hash of the key
 	 */
 	uint32_t (*hop_key_hash)(struct d_hash_table *htable, const void *key,
 				 unsigned int ksize);
 	/**
-	 * Optional, increase refcount on the record \p rlink
+	 * Get the hash of recorded key.
+	 *
+	 * \param[in]	htable	hash table
+	 * \param[in]	link	the link to record.
+	 *
+	 * \return		hash of recorded key
+	 */
+	uint32_t (*hop_rec_hash)(struct d_hash_table *htable, d_list_t *link);
+
+	/**
+	 * Optional, increase refcount on the record \p link
 	 * If this function is provided, it will be called for successfully
 	 * inserted record.
 	 *
-	 * \param[in] htable	hash table
-	 * \param[in] rlink	The record being referenced.
+	 * \param[in]	htable	hash table
+	 * \param[in]	link	The record being referenced.
 	 */
-	void	 (*hop_rec_addref)(struct d_hash_table *htable,
-				   d_list_t *rlink);
+	void	 (*hop_rec_addref)(struct d_hash_table *htable, d_list_t *link);
 	/**
-	 * Optional, release refcount on the record \p rlink
+	 * Optional, release refcount on the record \p link
 	 *
 	 * If this function is provided, it is called while deleting a record
 	 * from the hash table.
@@ -141,27 +138,26 @@ typedef struct {
 	 * If the record should not be automatically freed by the hash table
 	 * despite of refcount, then this function should never return true.
 	 *
-	 * \param[in] htable	hash table
-	 * \param[in] rlink	The rlink being released.
+	 * \param[in]	htable	hash table
+	 * \param[in]	link	The link being released.
 	 *
 	 * \retval	false	Do nothing
 	 * \retval	true	Only if refcount is zero and the hash item
 	 *			can be freed. If this function can return
 	 *			true, then hop_rec_free() should be defined.
 	 */
-	bool	 (*hop_rec_decref)(struct d_hash_table *htable,
-				   d_list_t *rlink);
+	bool	 (*hop_rec_decref)(struct d_hash_table *htable, d_list_t *link);
 
 	/**
-	 * Optional, release multiple refcount on the record \p rlink
+	 * Optional, release multiple refcount on the record \p link
 	 *
 	 * This function expands on hop_rec_decref() so the notes from that
 	 * function apply here.  If hop_rec_decref() is not provided then
 	 * hop_rec_ndecref() shouldn't be either.
 	 *
-	 * \param[in] htable	hash table
-	 * \param[in] rlink	The rlink being released.
-	 * \param[in] count	The number of refs to be dropped.
+	 * \param[in]	htable	hash table
+	 * \param[in]	link	The link being released.
+	 * \param[in]	count	The number of refcounts to be dropped.
 	 *
 	 * \retval	0	Do nothing
 	 * \retval	1	Only if refcount is zero and the hash item
@@ -170,17 +166,16 @@ typedef struct {
 	 *		negative value on error.
 	 */
 	int	 (*hop_rec_ndecref)(struct d_hash_table *htable,
-				    d_list_t *rlink,
-				    int count);
+				    d_list_t *link, int count);
 
 	/**
-	 * Optional, free the record \p rlink
+	 * Optional, free the record \p link
 	 * It is called if hop_decref() returns zero.
 	 *
-	 * \param[in] htable	hash table
-	 * \param[in] rlink	The record being freed.
+	 * \param[in]	htable	hash table
+	 * \param[in]	link	The record being freed.
 	 */
-	void	 (*hop_rec_free)(struct d_hash_table *htable, d_list_t *rlink);
+	void	 (*hop_rec_free)(struct d_hash_table *htable, d_list_t *link);
 } d_hash_table_ops_t;
 
 enum d_hash_feats {
@@ -225,24 +220,39 @@ enum d_hash_feats {
 	 * Note that if addref/decref are not provided this bit has no effect
 	 */
 	D_HASH_FT_EPHEMERAL	= (1 << 3),
+
+	/**
+	 * If the LRU bit is set:
+	 * The found in bucket item is moved on top of the list.
+	 * So, next search for it will be much faster.
+	 */
+	D_HASH_FT_LRU		= (1 << 4),
+
+	/**
+	 * Use Global Table Lock instead of per bucket locking.
+	 * TODO: should be removed when all will use per bucket locking.
+	 */
+	D_HASH_FT_GLOCK		= (1 << 15),
+};
+
+union d_hash_lock {
+	pthread_spinlock_t	spin;
+	pthread_mutex_t		mutex;
+	pthread_rwlock_t	rwlock;
 };
 
 struct d_hash_bucket {
 	d_list_t		hb_head;
+	/** different type of locks based on ht_feats */
+	union d_hash_lock	hb_lock;
 #if D_HASH_DEBUG
 	unsigned int		hb_dep;
 #endif
 };
 
 struct d_hash_table {
-	/** different type of locks based on ht_feats */
-	union {
-		pthread_spinlock_t	ht_spin;
-		pthread_mutex_t		ht_mutex;
-		pthread_rwlock_t	ht_rwlock;
-	};
 	/** bits to generate number of buckets */
-	unsigned int		 ht_bits;
+	uint32_t		 ht_bits;
 	/** feature bits */
 	uint32_t		 ht_feats;
 #if D_HASH_DEBUG
@@ -259,8 +269,9 @@ struct d_hash_table {
 	d_hash_table_ops_t	*ht_ops;
 	/** array of buckets */
 	struct d_hash_bucket	*ht_buckets;
+	/** different type of locks based on ht_feats */
+	union d_hash_lock	 ht_lock;
 };
-
 
 /**
  * Create a new hash table.
@@ -276,8 +287,8 @@ struct d_hash_table {
  *
  * \return			0 on success, negative value on error
  */
-int  d_hash_table_create(uint32_t feats, unsigned int bits,
-			 void *priv, d_hash_table_ops_t *hops,
+int  d_hash_table_create(uint32_t feats, uint32_t bits, void *priv,
+			 d_hash_table_ops_t *hops,
 			 struct d_hash_table **htable_pp);
 
 /**
@@ -296,11 +307,11 @@ int  d_hash_table_create(uint32_t feats, unsigned int bits,
  *
  * \return			0 on success, negative value on error
  */
-int  d_hash_table_create_inplace(uint32_t feats, unsigned int bits,
-				 void *priv, d_hash_table_ops_t *hops,
+int  d_hash_table_create_inplace(uint32_t feats, uint32_t bits, void *priv,
+				 d_hash_table_ops_t *hops,
 				 struct d_hash_table *htable);
 
-typedef int (*d_hash_traverse_cb_t)(d_list_t *rlink, void *arg);
+typedef int (*d_hash_traverse_cb_t)(d_list_t *link, void *arg);
 
 /**
  * Traverse a hash table, call the traverse callback function on every item.
@@ -314,8 +325,8 @@ typedef int (*d_hash_traverse_cb_t)(d_list_t *rlink, void *arg);
  *
  * \return			zero on success, negative value if error.
  */
-int d_hash_table_traverse(struct d_hash_table *htable,
-			  d_hash_traverse_cb_t cb, void *arg);
+int  d_hash_table_traverse(struct d_hash_table *htable,
+			   d_hash_traverse_cb_t cb, void *arg);
 
 /**
  * Destroy a hash table.
@@ -350,36 +361,36 @@ int  d_hash_table_destroy(struct d_hash_table *htable, bool force);
 int  d_hash_table_destroy_inplace(struct d_hash_table *htable, bool force);
 
 /**
- * lookup \p key in the hash table, the found chain rlink is returned on
+ * lookup \p key in the hash table, the found chain link is returned on
  * success.
  *
  * \param[in] htable		Pointer to the hash table
  * \param[in] key		The key to search
  * \param[in] ksize		Size of the key
  *
- * \return			found chain rlink
+ * \return			found chain link
  */
 d_list_t *d_hash_rec_find(struct d_hash_table *htable, const void *key,
 			  unsigned int ksize);
 
 /**
  * Lookup \p key in the hash table, if there is a matched record, it should be
- * returned, otherwise \p rlink will be inserted into the hash table. In the
- * later case, the returned link chain is the input \p rlink.
+ * returned, otherwise \p link will be inserted into the hash table. In the
+ * later case, the returned link chain is the input \p link.
  *
  * \param[in] htable		Pointer to the hash table
  * \param[in] key		The key to be inserted
  * \param[in] ksize		Size of the key
- * \param[in] rlink		The link chain of the record being inserted
+ * \param[in] link		The link chain of the record being inserted
  *
  * \return			matched record
  */
 d_list_t *d_hash_rec_find_insert(struct d_hash_table *htable,
 				 const void *key, unsigned int ksize,
-				 d_list_t *rlink);
+				 d_list_t *link);
 
 /**
- * Insert a new key and its record chain \p rlink into the hash table. The hash
+ * Insert a new key and its record chain \p link into the hash table. The hash
  * table holds a refcount on the successfully inserted record, it releases the
  * refcount while deleting the record.
  *
@@ -389,28 +400,28 @@ d_list_t *d_hash_rec_find_insert(struct d_hash_table *htable,
  * \param[in] htable		Pointer to the hash table
  * \param[in] key		The key to be inserted
  * \param[in] ksize		Size of the key
- * \param[in] rlink		The link chain of the record being inserted
+ * \param[in] link		The link chain of the record being inserted
  * \param[in] exclusive		The key has to be unique if it is true.
  *
  * \return			0 on success, negative value on error
  */
 int  d_hash_rec_insert(struct d_hash_table *htable, const void *key,
-		       unsigned int ksize, d_list_t *rlink,
+		       unsigned int ksize, d_list_t *link,
 		       bool exclusive);
 
 /**
  * Insert an anonymous record (w/o key) into the hash table.
- * This function calls hop_key_init() to generate a key for the new rlink
+ * This function calls hop_key_init() to generate a key for the new link
  * under the protection of the hash table lock.
  *
  * \param[in] htable		Pointer to the hash table
- * \param[in] rlink		The link chain of the hash record
+ * \param[in] link		The link chain of the hash record
  * \param[in] arg		Arguments for key generating
  *
  * \return			0 on success, negative value on error
  */
-int  d_hash_rec_insert_anonym(struct d_hash_table *htable, d_list_t *rlink,
-			       void *arg);
+int  d_hash_rec_insert_anonym(struct d_hash_table *htable, d_list_t *link,
+			      void *arg);
 
 /**
  * Delete the record identified by \p key from the hash table.
@@ -426,26 +437,50 @@ bool d_hash_rec_delete(struct d_hash_table *htable, const void *key,
 		       unsigned int ksize);
 
 /**
- * Delete the record linked by the chain \p rlink.
+ * Delete the record linked by the chain \p link.
  * This record will be freed if hop_rec_free() is defined and the hash table
  * holds the last refcount.
  *
  * \param[in] htable		Pointer to the hash table
- * \param[in] rlink		The link chain of the record
+ * \param[in] link		The link chain of the record
  *
  * \retval			true	Successfully deleted the record
  * \retval			false	The record has already been unlinked
  *					from the hash table
  */
-bool d_hash_rec_delete_at(struct d_hash_table *htable, d_list_t *rlink);
+bool d_hash_rec_delete_at(struct d_hash_table *htable, d_list_t *link);
+
+/**
+ * Evict the record identified by \p key from the hash table.
+ *
+ * \param[in] htable		Pointer to the hash table
+ * \param[in] key		The key of the record being evicted
+ * \param[in] ksize		Size of the key
+ *
+ * \retval			true	Item with \p key has been evicted
+ * \retval			false	Can't find the record by \p key
+ */
+bool d_hash_rec_evict(struct d_hash_table *htable, const void *key,
+		      unsigned int ksize);
+
+/**
+ * Evict the record linked by the chain \p link.
+ *
+ * \param[in] htable		Pointer to the hash table
+ * \param[in] link		The link chain of the record
+ *
+ * \retval			true	Item has been evicted
+ * \retval			false	Not LRU feature
+ */
+bool d_hash_rec_evict_at(struct d_hash_table *htable, d_list_t *link);
 
 /**
  * Increase the refcount of the record.
  *
  * \param[in] htable		Pointer to the hash table
- * \param[in] rlink		The link chain of the record
+ * \param[in] link		The link chain of the record
  */
-void d_hash_rec_addref(struct d_hash_table *htable, d_list_t *rlink);
+void d_hash_rec_addref(struct d_hash_table *htable, d_list_t *link);
 
 /**
  * Decrease the refcount of the record.
@@ -453,9 +488,9 @@ void d_hash_rec_addref(struct d_hash_table *htable, d_list_t *rlink);
  * is set.
  *
  * \param[in] htable		Pointer to the hash table
- * \param[in] rlink		Chain rlink of the hash record
+ * \param[in] link		Chain link of the hash record
  */
-void d_hash_rec_decref(struct d_hash_table *htable, d_list_t *rlink);
+void d_hash_rec_decref(struct d_hash_table *htable, d_list_t *link);
 
 /**
  * Decrease the refcount of the record by count.
@@ -463,28 +498,27 @@ void d_hash_rec_decref(struct d_hash_table *htable, d_list_t *rlink);
  *
  * \param[in] htable		Pointer to the hash table
  * \param[in] count		Number of references to drop
- * \param[in] rlink		Chain rlink of the hash record
+ * \param[in] link		Chain link of the hash record
  *
  * \retval			0		Success
  * \retval			-DER_INVAL	Not enough references were held.
  */
-int d_hash_rec_ndecref(struct d_hash_table *htable, int count,
-		       d_list_t *rlink);
+int  d_hash_rec_ndecref(struct d_hash_table *htable, int count, d_list_t *link);
 
 /**
  * Check if the link chain has already been unlinked from the hash table.
  *
- * \param[in] rlink		The link chain of the record
+ * \param[in] link		The link chain of the record
  *
  * \retval			true	Yes
  * \retval			false	No
  */
-bool d_hash_rec_unlinked(d_list_t *rlink);
+bool d_hash_rec_unlinked(d_list_t *link);
 
 /**
- * Return the first entry in a hash table.  Do this by traversing the table, and
- * returning the first rlink value provided to the callback.
- * Returns rlink on success, or NULL on error or if the hash table is empty.
+ * Return the first entry in a hash table.  Do this by traversing the table,
+ * and returning the first link value provided to the callback.
+ * Returns link on success, or NULL on error or if the hash table is empty.
  *
  * Note this does not take a reference on the returned entry and has no ordering
  * semantics.  It's main use is for draining a hash table before calling
@@ -492,7 +526,7 @@ bool d_hash_rec_unlinked(d_list_t *rlink);
  *
  * \param[in] htable		Pointer to the hash table
  *
- * \retval			rlink	Pointer to first element in hash table
+ * \retval			link	Pointer to first element in hash table
  * \retval			NULL	Hash table is empty or error occurred
  */
 d_list_t *d_hash_rec_first(struct d_hash_table *htable);
@@ -523,20 +557,20 @@ void d_hash_table_debug(struct d_hash_table *htable);
  * set bit 0 to 1.
  */
 enum {
-	D_HTYPE_PTR		= 0, /**< pointer type handle */
+	D_HTYPE_PTR		= 0,	/**< pointer type handle */
 	/* Must enlarge D_HTYPE_BITS to add more types */
 };
 
 struct d_hlink;
 struct d_hlink_ops {
 	/** free callback */
-	void	(*hop_free)(struct d_hlink *rlink);
+	void	(*hop_free)(struct d_hlink *hlink);
 };
 
 struct d_rlink {
 	d_list_t		rl_link;
-	unsigned int		rl_ref;
-	unsigned int		rl_initialized:1;
+	uint32_t		rl_ref:30,
+				rl_initialized:1;
 };
 
 struct d_hlink {
@@ -545,11 +579,11 @@ struct d_hlink {
 	struct d_hlink_ops	*hl_ops;
 };
 
-struct d_hhash;
+struct d_hhash;			/**< internal definition */
 
-int  d_hhash_create(uint32_t feats, unsigned int bits, struct d_hhash **hhash);
-void d_hhash_destroy(struct d_hhash *hh);
-void d_hhash_hlink_init(struct d_hlink *hlink, struct d_hlink_ops *ops);
+int  d_hhash_create(uint32_t feats, uint32_t bits, struct d_hhash **hhash);
+void d_hhash_destroy(struct d_hhash *hhash);
+void d_hhash_hlink_init(struct d_hlink *hlink, struct d_hlink_ops *hl_ops);
 /**
  * Insert to handle hash table.
  * If \a type is D_HTYPE_PTR, user MUST ensure the bit 0 of \a hlink pointer is
@@ -558,7 +592,7 @@ void d_hhash_hlink_init(struct d_hlink *hlink, struct d_hlink_ops *ops);
  * type.
  */
 void d_hhash_link_insert(struct d_hhash *hhash, struct d_hlink *hlink,
-		         int type);
+			 int type);
 struct d_hlink *d_hhash_link_lookup(struct d_hhash *hhash, uint64_t key);
 void d_hhash_link_getref(struct d_hhash *hhash, struct d_hlink *hlink);
 void d_hhash_link_putref(struct d_hhash *hhash, struct d_hlink *hlink);
@@ -567,8 +601,8 @@ bool d_hhash_link_empty(struct d_hlink *hlink);
 void d_hhash_link_key(struct d_hlink *hlink, uint64_t *key);
 int  d_hhash_key_type(uint64_t key);
 bool d_hhash_key_isptr(uint64_t key);
-int  d_hhash_set_ptrtype(struct d_hhash *hhtab);
-bool d_hhash_is_ptrtype(struct d_hhash *hhtab);
+int  d_hhash_set_ptrtype(struct d_hhash *hhash);
+bool d_hhash_is_ptrtype(struct d_hhash *hhash);
 
 /******************************************************************************
  * UUID Hash Table Wrapper
@@ -592,23 +626,23 @@ struct d_ulink_ops {
 struct d_ulink {
 	struct d_rlink		 ul_link;
 	struct d_uuid		 ul_uuid;
+	struct d_ulink_ops	*ul_ops;
 	/** optional argument for compare callback */
 	void			*ul_cmp_args;
-	struct d_ulink_ops	*ul_ops;
 };
 
-int  d_uhash_create(uint32_t feats, unsigned int bits,
-		    struct d_hash_table **uhtab);
-void d_uhash_destroy(struct d_hash_table *uhtab);
-void d_uhash_ulink_init(struct d_ulink *ulink, struct d_ulink_ops *rl_ops);
+int  d_uhash_create(uint32_t feats, uint32_t bits,
+		    struct d_hash_table **htable);
+void d_uhash_destroy(struct d_hash_table *htable);
+void d_uhash_ulink_init(struct d_ulink *ulink, struct d_ulink_ops *ul_ops);
 bool d_uhash_link_empty(struct d_ulink *ulink);
 bool d_uhash_link_last_ref(struct d_ulink *ulink);
-void d_uhash_link_addref(struct d_hash_table *uhtab, struct d_ulink *hlink);
-void d_uhash_link_putref(struct d_hash_table *uhtab, struct d_ulink *hlink);
-void d_uhash_link_delete(struct d_hash_table *uhtab, struct d_ulink *hlink);
-int  d_uhash_link_insert(struct d_hash_table *uhtab, struct d_uuid *key,
-			 void *cmp_args, struct d_ulink *hlink);
-struct d_ulink *d_uhash_link_lookup(struct d_hash_table *uhtab,
+void d_uhash_link_addref(struct d_hash_table *htable, struct d_ulink *ulink);
+void d_uhash_link_putref(struct d_hash_table *htable, struct d_ulink *ulink);
+void d_uhash_link_delete(struct d_hash_table *htable, struct d_ulink *ulink);
+int  d_uhash_link_insert(struct d_hash_table *htable, struct d_uuid *key,
+			 void *cmp_args, struct d_ulink *ulink);
+struct d_ulink *d_uhash_link_lookup(struct d_hash_table *htable,
 				    struct d_uuid *key, void *cmp_args);
 
 #if defined(__cplusplus)

--- a/src/cart/src/utest/test_gurt.c
+++ b/src/cart/src/utest/test_gurt.c
@@ -836,6 +836,15 @@ test_gurt_hash_op_key_cmp(struct d_hash_table *thtab, d_list_t *link,
 	return !memcmp(tlink->tl_key, key, ksize);
 }
 
+static uint32_t
+test_gurt_hash_op_rec_hash(struct d_hash_table *thtab, d_list_t *link)
+{
+	struct test_hash_entry *tlink = test_gurt_hash_link2ptr(link);
+
+	return d_hash_string_u32((const char *)tlink->tl_key,
+				 TEST_GURT_HASH_KEY_LEN);
+}
+
 static void
 test_gurt_hash_op_rec_addref(struct d_hash_table *thtab, d_list_t *link)
 {
@@ -877,7 +886,8 @@ test_gurt_hash_op_rec_free(struct d_hash_table *thtab, d_list_t *link)
 }
 
 static d_hash_table_ops_t th_ops = {
-	.hop_key_cmp    = test_gurt_hash_op_key_cmp,
+	.hop_key_cmp	= test_gurt_hash_op_key_cmp,
+	.hop_rec_hash	= test_gurt_hash_op_rec_hash,
 };
 
 /**
@@ -995,6 +1005,7 @@ test_gurt_hash_empty(void **state)
 
 static d_hash_table_ops_t th_ops_ref = {
 	.hop_key_cmp		= test_gurt_hash_op_key_cmp,
+	.hop_rec_hash		= test_gurt_hash_op_rec_hash,
 	.hop_rec_addref		= test_gurt_hash_op_rec_addref,
 	.hop_rec_decref		= test_gurt_hash_op_rec_decref,
 	.hop_rec_ndecref	= test_gurt_hash_op_rec_ndecref,
@@ -1649,6 +1660,7 @@ test_gurt_hash_op_rec_decref_locked(struct d_hash_table *thtab, d_list_t *link)
 
 static d_hash_table_ops_t th_ref_ops = {
 	.hop_key_cmp    = test_gurt_hash_op_key_cmp,
+	.hop_rec_hash	= test_gurt_hash_op_rec_hash,
 	.hop_rec_addref	= test_gurt_hash_op_rec_addref_locked,
 	.hop_rec_decref	= test_gurt_hash_op_rec_decref_locked,
 };
@@ -1768,6 +1780,7 @@ test_gurt_hash_parallel_same_operations(void **state)
 	test_gurt_hash_threaded_same_operations(D_HASH_FT_RWLOCK);
 	test_gurt_hash_threaded_same_operations(D_HASH_FT_RWLOCK
 						| D_HASH_FT_EPHEMERAL);
+	test_gurt_hash_threaded_same_operations(D_HASH_FT_LRU);
 }
 
 static void
@@ -1778,6 +1791,7 @@ test_gurt_hash_parallel_different_operations(void **state)
 	test_gurt_hash_threaded_concurrent_operations(D_HASH_FT_RWLOCK);
 	test_gurt_hash_threaded_concurrent_operations(D_HASH_FT_RWLOCK
 						      | D_HASH_FT_EPHEMERAL);
+	test_gurt_hash_threaded_concurrent_operations(D_HASH_FT_LRU);
 }
 
 static void
@@ -1788,6 +1802,7 @@ test_gurt_hash_parallel_refcounting(void **state)
 	_test_gurt_hash_parallel_refcounting(D_HASH_FT_RWLOCK);
 	_test_gurt_hash_parallel_refcounting(D_HASH_FT_RWLOCK
 					     | D_HASH_FT_EPHEMERAL);
+	_test_gurt_hash_parallel_refcounting(D_HASH_FT_LRU);
 }
 
 struct circular_item {

--- a/src/cart/src/utest/test_linkage.cpp
+++ b/src/cart/src/utest/test_linkage.cpp
@@ -129,9 +129,17 @@ key_cmp(struct d_hash_table *htable, d_list_t *rlink,
 {
 	return true;
 }
+static uint32_t
+hop_rec_hash(struct d_hash_table *htable, d_list_t *link)
+{
+	return 0;
+}
 
 static d_hash_table_ops_t hash_ops = {
-	hop_key_cmp : key_cmp,
+	hop_key_cmp  : key_cmp,
+	hop_key_init : NULL,
+	hop_key_hash : NULL,
+	hop_rec_hash : hop_rec_hash
 };
 
 static void

--- a/src/client/dfuse/dfuse_core.c
+++ b/src/client/dfuse/dfuse_core.c
@@ -71,7 +71,8 @@ ir_rec_hash(struct d_hash_table *htable, d_list_t *link)
 
 	ir = container_of(link, struct dfuse_inode_record, ir_htl);
 
-	return d_hash_string_u32((const char *)&ir->ir_id, sizeof(ir->ir_id));
+	return (uint32_t)ir->ir_id.irid_oid.hi;
+
 }
 
 static void

--- a/src/client/dfuse/dfuse_core.c
+++ b/src/client/dfuse/dfuse_core.c
@@ -64,6 +64,16 @@ ir_key_cmp(struct d_hash_table *htable, d_list_t *rlink,
 	return true;
 }
 
+static uint32_t
+ir_rec_hash(struct d_hash_table *htable, d_list_t *link)
+{
+	const struct dfuse_inode_record		*ir;
+
+	ir = container_of(link, struct dfuse_inode_record, ir_htl);
+
+	return d_hash_string_u32((const char *)&ir->ir_id, sizeof(ir->ir_id));
+}
+
 static void
 ir_free(struct d_hash_table *htable, d_list_t *rlink)
 {
@@ -75,6 +85,17 @@ ir_free(struct d_hash_table *htable, d_list_t *rlink)
 }
 
 /* Inode entry hash table operations */
+
+static uint32_t
+ih_rec_hash(struct d_hash_table *htable, d_list_t *link)
+{
+	const struct dfuse_inode_entry	*ie;
+
+	ie = container_of(link, struct dfuse_inode_entry, ie_htl);
+
+	return d_hash_string_u32((const char *)&ie->ie_stat.st_ino,
+				 sizeof(ie->ie_stat.st_ino));
+}
 
 static bool
 ih_key_cmp(struct d_hash_table *htable, d_list_t *rlink,
@@ -156,6 +177,7 @@ ih_free(struct d_hash_table *htable, d_list_t *rlink)
 
 static d_hash_table_ops_t ie_hops = {
 	.hop_key_cmp		= ih_key_cmp,
+	.hop_rec_hash		= ih_rec_hash,
 	.hop_rec_addref		= ih_addref,
 	.hop_rec_decref		= ih_decref,
 	.hop_rec_ndecref	= ih_ndecref,
@@ -163,9 +185,10 @@ static d_hash_table_ops_t ie_hops = {
 };
 
 static d_hash_table_ops_t ir_hops = {
-	.hop_key_cmp	= ir_key_cmp,
-	.hop_key_hash   = ir_key_hash,
-	.hop_rec_free	= ir_free,
+	.hop_key_cmp		= ir_key_cmp,
+	.hop_key_hash		= ir_key_hash,
+	.hop_rec_hash		= ir_rec_hash,
+	.hop_rec_free		= ir_free,
 
 };
 

--- a/src/common/lru.c
+++ b/src/common/lru.c
@@ -71,6 +71,14 @@ lru_hop_key_cmp(struct d_hash_table *lr_htab, d_list_t *rlink,
 		return llink->ll_ops->lop_cmp_keys(key, ksize, llink);
 }
 
+static uint32_t
+lru_hop_rec_hash(struct d_hash_table *htable, d_list_t *link)
+{
+	struct daos_llink *llink = hash2lru_link(link);
+
+	return llink->ll_ops->lop_rec_hash(llink);
+}
+
 static void
 lru_hop_rec_free(struct d_hash_table *lr_htab, d_list_t *rlink)
 {
@@ -81,6 +89,7 @@ lru_hop_rec_free(struct d_hash_table *lr_htab, d_list_t *rlink)
 
 static d_hash_table_ops_t lru_ops = {
 	.hop_key_cmp		= lru_hop_key_cmp,
+	.hop_rec_hash		= lru_hop_rec_hash,
 	.hop_rec_addref		= lru_hop_rec_addref,
 	.hop_rec_decref		= lru_hop_rec_decref,
 	.hop_rec_free		= lru_hop_rec_free,
@@ -100,6 +109,7 @@ daos_lru_cache_create(int bits, uint32_t feats,
 
 	if (ops == NULL ||
 	    ops->lop_cmp_keys == NULL ||
+	    ops->lop_rec_hash  == NULL ||
 	    ops->lop_alloc_ref == NULL ||
 	    ops->lop_free_ref == NULL) {
 		D_ERROR("Error missing ops/mandatory-ops for LRU cache\n");

--- a/src/common/tests/lru.c
+++ b/src/common/tests/lru.c
@@ -71,16 +71,27 @@ bool
 uint_ref_lru_cmp(const void *key, unsigned int ksize,
 		 struct daos_llink *llink)
 {
-	struct uint_ref	*ref = NULL;
+	struct uint_ref	*ref = container_of(llink, struct uint_ref, ur_llink);
 
-	ref = container_of(llink, struct uint_ref, ur_llink);
+	D_ASSERT(ksize == sizeof(uint64_t));
+
 	return (ref->ur_key == *(uint64_t *)key);
+}
+
+uint32_t
+uint_ref_lru_hash(struct daos_llink *llink)
+{
+	struct uint_ref	*ref = container_of(llink, struct uint_ref, ur_llink);
+
+	return d_hash_string_u32((const char *)&ref->ur_key,
+				 sizeof(ref->ur_key));
 }
 
 struct daos_llink_ops uint_ref_llink_ops = {
 	.lop_free_ref	= uint_ref_lru_free,
 	.lop_alloc_ref	= uint_ref_lru_alloc,
 	.lop_cmp_keys	= uint_ref_lru_cmp,
+	.lop_rec_hash	= uint_ref_lru_hash,
 };
 
 static inline int

--- a/src/container/srv_target.c
+++ b/src/container/srv_target.c
@@ -524,10 +524,19 @@ cont_child_cmp_keys(const void *key, unsigned int ksize,
 	return uuid_compare(key, cont->sc_uuid) == 0;
 }
 
+static uint32_t
+cont_child_rec_hash(struct daos_llink *llink)
+{
+	struct ds_cont_child *cont = cont_child_obj(llink);
+
+	return d_hash_string_u32((const char *)cont->sc_uuid, sizeof(uuid_t));
+}
+
 static struct daos_llink_ops cont_child_cache_ops = {
 	.lop_alloc_ref	= cont_child_alloc_ref,
 	.lop_free_ref	= cont_child_free_ref,
-	.lop_cmp_keys	= cont_child_cmp_keys
+	.lop_cmp_keys	= cont_child_cmp_keys,
+	.lop_rec_hash	= cont_child_rec_hash,
 };
 
 int

--- a/src/include/daos/lru.h
+++ b/src/include/daos/lru.h
@@ -39,6 +39,8 @@ struct daos_llink_ops {
 	/** Mandatory: Compare keys callback for LRU */
 	bool	(*lop_cmp_keys)(const void *key, unsigned int ksize,
 				struct daos_llink *link);
+	/** Mandatory: Get key's hash callback for LRU */
+	uint32_t (*lop_rec_hash)(struct daos_llink *link);
 	/** Optional print_key function for debugging */
 	void	(*lop_print_key)(void *key, unsigned int ksize);
 };

--- a/src/placement/pl_map.c
+++ b/src/placement/pl_map.c
@@ -328,7 +328,7 @@ pl_link2map(d_list_t *link)
 	return container_of(link, struct pl_map, pl_link);
 }
 
-static unsigned int
+static uint32_t
 pl_hop_key_hash(struct d_hash_table *htab, const void *key,
 		unsigned int ksize)
 {

--- a/src/pool/srv_target.c
+++ b/src/pool/srv_target.c
@@ -420,10 +420,19 @@ pool_cmp_keys(const void *key, unsigned int ksize, struct daos_llink *llink)
 	return uuid_compare(key, pool->sp_uuid) == 0;
 }
 
+static uint32_t
+pool_rec_hash(struct daos_llink *llink)
+{
+	struct ds_pool *pool = pool_obj(llink);
+
+	return d_hash_string_u32((const char *)pool->sp_uuid, sizeof(uuid_t));
+}
+
 static struct daos_llink_ops pool_cache_ops = {
 	.lop_alloc_ref	= pool_alloc_ref,
 	.lop_free_ref	= pool_free_ref,
-	.lop_cmp_keys	= pool_cmp_keys
+	.lop_cmp_keys	= pool_cmp_keys,
+	.lop_rec_hash	= pool_rec_hash,
 };
 
 int
@@ -575,6 +584,14 @@ pool_hdl_key_cmp(struct d_hash_table *htable, d_list_t *rlink,
 	return uuid_compare(hdl->sph_uuid, key) == 0;
 }
 
+static uint32_t
+pool_hdl_rec_hash(struct d_hash_table *htable, d_list_t *link)
+{
+	struct ds_pool_hdl *hdl = pool_hdl_obj(link);
+
+	return d_hash_string_u32((const char *)hdl->sph_uuid, sizeof(uuid_t));
+}
+
 static void
 pool_hdl_rec_addref(struct d_hash_table *htable, d_list_t *rlink)
 {
@@ -607,6 +624,7 @@ pool_hdl_rec_free(struct d_hash_table *htable, d_list_t *rlink)
 
 static d_hash_table_ops_t pool_hdl_hash_ops = {
 	.hop_key_cmp	= pool_hdl_key_cmp,
+	.hop_rec_hash	= pool_hdl_rec_hash,
 	.hop_rec_addref	= pool_hdl_rec_addref,
 	.hop_rec_decref	= pool_hdl_rec_decref,
 	.hop_rec_free	= pool_hdl_rec_free

--- a/src/rdb/rdb_kvs.c
+++ b/src/rdb/rdb_kvs.c
@@ -173,10 +173,20 @@ rdb_kvs_cmp_keys(const void *key, unsigned int ksize, struct daos_llink *llink)
 	return true;
 }
 
+static uint32_t
+rdb_kvs_rec_hash(struct daos_llink *llink)
+{
+	struct rdb_kvs *kvs = rdb_kvs_obj(llink);
+
+	return d_hash_string_u32((const char *)kvs->de_path.iov_buf,
+				 kvs->de_path.iov_len);
+}
+
 static struct daos_llink_ops rdb_kvs_cache_ops = {
 	.lop_alloc_ref	= rdb_kvs_alloc_ref,
 	.lop_free_ref	= rdb_kvs_free_ref,
-	.lop_cmp_keys	= rdb_kvs_cmp_keys
+	.lop_cmp_keys	= rdb_kvs_cmp_keys,
+	.lop_rec_hash	= rdb_kvs_rec_hash,
 };
 
 int

--- a/src/vos/vos_obj_cache.c
+++ b/src/vos/vos_obj_cache.c
@@ -104,6 +104,21 @@ obj_lop_cmp_key(const void *key, unsigned int ksize, struct daos_llink *llink)
 	       !memcmp(&lkey->olk_oid, &obj->obj_id, sizeof(obj->obj_id));
 }
 
+static uint32_t
+obj_lop_rec_hash(struct daos_llink *llink)
+{
+	struct obj_lru_key	 lkey;
+	struct vos_object	*obj;
+
+	obj = container_of(llink, struct vos_object, obj_llink);
+
+	/* Create the key for obj cache */
+	lkey.olk_cont = obj->obj_cont;
+	lkey.olk_oid  = obj->obj_id;
+
+	return d_hash_string_u32((const char *)&lkey, sizeof(lkey));
+}
+
 static void
 obj_lop_free(struct daos_llink *llink)
 {
@@ -132,10 +147,11 @@ obj_lop_print_key(void *key, unsigned int ksize)
 }
 
 static struct daos_llink_ops obj_lru_ops = {
-	.lop_free_ref	=  obj_lop_free,
-	.lop_alloc_ref	=  obj_lop_alloc,
-	.lop_cmp_keys	=  obj_lop_cmp_key,
-	.lop_print_key	=  obj_lop_print_key,
+	.lop_free_ref	= obj_lop_free,
+	.lop_alloc_ref	= obj_lop_alloc,
+	.lop_cmp_keys	= obj_lop_cmp_key,
+	.lop_rec_hash	= obj_lop_rec_hash,
+	.lop_print_key	= obj_lop_print_key,
 };
 
 int


### PR DESCRIPTION
The Hash Table implementation was redesigned to make the locking
per bucket. It led to a change in the API. The new function
hop_rec_hash was introduced.

uint32_t (*hop_rec_hash)(struct d_hash_table *htable, d_list_t *link);

It should return the hash value of key which was used to store it
into the hash table.

Performance testing of new implementations show the following results:

New Hash Table implementation.

Parallel execution of the same operations into several threads:

current master version (the time in processor tiks):
insert(122880)  min=200407811   avg=301821520   max=390762741
-trav-(122880)  min=26457490    avg=142478282   max=251781644
lookup(122880)  min=3091640839  avg=3180550249  max=3231423491
delete(122880)  min=289866694   avg=320578773   max=330955234

this patch version (the time in processor tiks):
insert(122880)  min=20992422    avg=33196314    max=55259780
-trav-(122880)  min=25937342    avg=30285950    max=31452028
lookup(122880)  min=324108436   avg=325161848   max=325536972
delete(122880)  min=23429403    avg=28689445    max=30819230

The performance improvements is about 10 times.

Concurrent execution of the different operations in parallel into
several threads:

current master version: tsc=1864564804
    this patch version: tsc=237032281

The performance improvements again is about 10 times.