### PR TITLE
DAOS-3800 dtx: optimize read if hit non-committed sync mode DTX

### DIFF
--- a/src/dtx/dtx_common.c
+++ b/src/dtx/dtx_common.c
@@ -285,7 +285,6 @@ dtx_handle_init(struct dtx_id *dti, daos_handle_t coh, struct dtx_epoch *epoch,
 	dth->dth_refs = 1;
 	dth->dth_mbs = mbs;
 
-	dth->dth_sync = 0;
 	dth->dth_resent = 0;
 	dth->dth_solo = solo ? 1 : 0;
 	dth->dth_modify_shared = 0;
@@ -297,6 +296,19 @@ dtx_handle_init(struct dtx_id *dti, daos_handle_t coh, struct dtx_epoch *epoch,
 	dth->dth_dti_cos_count = dti_cos_cnt;
 	dth->dth_ent = NULL;
 	dth->dth_flags = leader ? DTE_LEADER : 0;
+
+	/* Set 'DTE_BLOCK' flag for EC object modification or
+	 * distributed transaction. At the same time, ask DTX
+	 * to 'sync' commit.
+	 */
+	if (daos_oclass_is_ec(leader_oid->id_pub, NULL) ||
+	    (mbs != NULL && mbs->dm_grp_cnt > 1)) {
+		dth->dth_flags |= DTE_BLOCK;
+		dth->dth_sync = 1;
+	} else {
+		dth->dth_sync = 0;
+	}
+
 	dth->dth_modification_cnt = sub_modification_cnt;
 
 	dth->dth_op_seq = 0;
@@ -638,13 +650,6 @@ again:
 
 			dth->dth_sync = 1;
 		}
-
-		/* FIXME: For the DTX across multiple modification groups,
-		 *	  commit it synchronously. That will be changed in
-		 *	  next phase.
-		 */
-		if (dth->dth_mbs->dm_grp_cnt > 1)
-			dth->dth_sync = 1;
 
 		/* For synchronous DTX, do not add it into CoS cache, otherwise,
 		 * we may have no way to remove it from the cache.

--- a/src/include/daos_errno.h
+++ b/src/include/daos_errno.h
@@ -170,7 +170,9 @@ extern "C" {
 	/** Data lost or not recoverable */				\
 	ACTION(DER_DATA_LOSS,		(DER_ERR_DAOS_BASE + 26))	\
 	/** Operation canceled (non-crt) */				\
-	ACTION(DER_OP_CANCELED,		(DER_ERR_DAOS_BASE + 27))
+	ACTION(DER_OP_CANCELED,		(DER_ERR_DAOS_BASE + 27))	\
+	/** TX is not committed, not sure whether committable or not */	\
+	ACTION(DER_TX_BUSY,		(DER_ERR_DAOS_BASE + 28))
 
 /** Defines the gurt error codes */
 #define D_FOREACH_ERR_RANGE(ACTION)	\

--- a/src/include/daos_srv/vos_types.h
+++ b/src/include/daos_srv/vos_types.h
@@ -51,6 +51,13 @@ enum dtx_entry_flags {
 	DTE_LEADER		= (1 << 0),
 	/* The DTX entry is invalid. */
 	DTE_INVALID		= (1 << 1),
+	/* If the DTX with this flag is non-committed, then others
+	 * will be blocked (retry again and again) when access the
+	 * data being modified via this DTX. Currently, it is used
+	 * for distributed transaction. It also can be used for EC
+	 * object modification via standalone update/punch.
+	 */
+	DTE_BLOCK		= (1 << 2),
 };
 
 struct dtx_entry {

--- a/src/object/cli_obj.c
+++ b/src/object/cli_obj.c
@@ -2720,7 +2720,8 @@ obj_comp_cb(tse_task_t *task, void *data)
 		 */
 
 		if ((!obj_auxi->spec_shard && !obj_auxi->no_retry) ||
-		    task->dt_result != -DER_INPROGRESS)
+		    (task->dt_result != -DER_INPROGRESS &&
+		     task->dt_result != -DER_TX_BUSY))
 			obj_auxi->io_retry = 1;
 
 		if (task->dt_result == -DER_CSUM) {
@@ -2738,6 +2739,7 @@ obj_comp_cb(tse_task_t *task, void *data)
 				obj_auxi->io_retry = 0;
 			}
 		}
+
 		if (!obj_auxi->spec_shard && task->dt_result == -DER_INPROGRESS)
 			obj_auxi->to_leader = 1;
 	}

--- a/src/object/cli_shard.c
+++ b/src/object/cli_shard.c
@@ -320,7 +320,7 @@ dc_rw_cb(tse_task_t *task, void *arg)
 	}
 
 	if (rc != 0) {
-		if (rc == -DER_INPROGRESS) {
+		if (rc == -DER_INPROGRESS || rc == -DER_TX_BUSY) {
 			D_DEBUG(DB_IO, "rpc %p opc %d to rank %d tag %d may "
 				"need retry: "DF_RC"\n", rw_args->rpc, opc,
 				rw_args->rpc->cr_ep.ep_rank,
@@ -1029,7 +1029,7 @@ dc_enumerate_cb(tse_task_t *task, void *arg)
 			D_DEBUG(DB_IO, "key size "DF_U64" too big.\n",
 				oeo->oeo_size);
 			enum_args->eaa_kds[0].kd_key_len = oeo->oeo_size;
-		} else if (rc == -DER_INPROGRESS) {
+		} else if (rc == -DER_INPROGRESS || rc == -DER_TX_BUSY) {
 			D_DEBUG(DB_TRACE, "rpc %p RPC %d may need retry: "
 				""DF_RC"\n", enum_args->rpc, opc, DP_RC(rc));
 		} else {
@@ -1328,7 +1328,7 @@ obj_shard_query_key_cb(tse_task_t *task, void *data)
 		if (rc == -DER_NONEXIST)
 			D_GOTO(out, rc = 0);
 
-		if (rc == -DER_INPROGRESS)
+		if (rc == -DER_INPROGRESS || rc == -DER_TX_BUSY)
 			D_DEBUG(DB_TRACE, "rpc %p RPC %d may need retry: %d\n",
 				cb_args->rpc, opc, rc);
 		else
@@ -1529,7 +1529,7 @@ obj_shard_sync_cb(tse_task_t *task, void *data)
 	if (rc == -DER_NONEXIST)
 		D_GOTO(out, rc = 0);
 
-	if (rc == -DER_INPROGRESS) {
+	if (rc == -DER_INPROGRESS || rc == -DER_TX_BUSY) {
 		D_DEBUG(DB_TRACE,
 			"rpc %p OBJ_SYNC_RPC may need retry: rc = "DF_RC"\n",
 			rpc, DP_RC(rc));

--- a/src/object/obj_internal.h
+++ b/src/object/obj_internal.h
@@ -421,7 +421,7 @@ obj_retry_error(int err)
 {
 	return err == -DER_TIMEDOUT || err == -DER_STALE ||
 	       err == -DER_INPROGRESS || err == -DER_GRPVER ||
-	       err == -DER_EVICTED || err == -DER_CSUM ||
+	       err == -DER_EVICTED || err == -DER_CSUM || err == -DER_TX_BUSY ||
 	       daos_crt_network_error(err);
 }
 

--- a/src/object/srv_obj.c
+++ b/src/object/srv_obj.c
@@ -1303,7 +1303,8 @@ obj_local_rw(crt_rpc_t *rpc, struct obj_io_context *ioc,
 				     fetch_flags, shadows, &ioh, dth);
 		daos_recx_ep_list_free(shadows, orw->orw_nr);
 		if (rc) {
-			D_CDEBUG(rc == -DER_INPROGRESS, DB_IO, DLOG_ERR,
+			D_CDEBUG(rc == -DER_INPROGRESS || rc == -DER_TX_BUSY,
+				 DB_IO, DLOG_ERR,
 				 "Fetch begin for "DF_UOID" failed: "DF_RC"\n",
 				 DP_UOID(orw->orw_oid), DP_RC(rc));
 			goto out;


### PR DESCRIPTION
If the modifications corsses multiple redundancy groups, then it
is possible that the sub modifications on the DTX leader are not
the same as the ones on non-leaders. Under such case, if someone
wants to read the data on some non-leader but hits non-committed
DTX, then asking the client to retry with leader maybe not help.

Instead, we can ask make the client to retry the read again (and
again) sometime later. We do sync commit the DTX with 'DTE_BLOCK'
flag. So it will not cause the client to retry read for too many
times unless such DTX hit some trouble (such as client or server
failure) that may cause current readers to be blocked until such
DTX has been handled by the new leader via DTX recovery.

On the other hand, be as the first step, since we commit the DTX
with sync mode, we can directly make the server side related ULT
to sleep for a short time when hit above cases instead of asking
the client to retry. If related DTX is still not committed after
several server side retries, then return -DER_TX_BUSY to client.

Currently, we will handle reading EC object similarly since the
DTX leader for EC modification (a parity node) may does not has
the data for client read.

Signed-off-by: Fan Yong <fan.yong@intel.com>