### PR TITLE
CART-89 build: Remove boost header from types.h

### DIFF
--- a/src/cart/src/include/cart/types.h
+++ b/src/cart/src/include/cart/types.h
@@ -52,9 +52,6 @@
 
 #include <stdint.h>
 #include <gurt/types.h>
-
-#include <boost/preprocessor.hpp>
-
 /**
  * Initialization options passed during crt_init() call.
  *


### PR DESCRIPTION
- Remove boost header include from types.h

Signed-off-by: Alexander Oganezov <alexander.a.oganezov@intel.com>