### PR TITLE
DAOS-3907 object: (1) compounded RPC protocol

### DIFF
--- a/src/common/proc.c
+++ b/src/common/proc.c
@@ -32,6 +32,22 @@
 #include <cart/api.h>
 
 int
+crt_proc_struct_dtx_id(crt_proc_t proc, struct dtx_id *dti)
+{
+	int rc;
+
+	rc = crt_proc_uuid_t(proc, &dti->dti_uuid);
+	if (rc != 0)
+		return -DER_HG;
+
+	rc = crt_proc_uint64_t(proc, &dti->dti_hlc);
+	if (rc != 0)
+		return -DER_HG;
+
+	return 0;
+}
+
+int
 crt_proc_struct_daos_acl(crt_proc_t proc, struct daos_acl **data)
 {
 	int		rc;

--- a/src/dtx/dtx_rpc.c
+++ b/src/dtx/dtx_rpc.c
@@ -36,22 +36,6 @@
 #include <daos_srv/daos_server.h>
 #include "dtx_internal.h"
 
-static int
-crt_proc_struct_dtx_id(crt_proc_t proc, struct dtx_id *dti)
-{
-	int rc;
-
-	rc = crt_proc_uuid_t(proc, &dti->dti_uuid);
-	if (rc != 0)
-		return -DER_HG;
-
-	rc = crt_proc_uint64_t(proc, &dti->dti_hlc);
-	if (rc != 0)
-		return -DER_HG;
-
-	return 0;
-}
-
 CRT_RPC_DEFINE(dtx, DAOS_ISEQ_DTX, DAOS_OSEQ_DTX);
 
 #define X_RPC(a, b, c, d, e)	\

--- a/src/include/daos/common.h
+++ b/src/include/daos/common.h
@@ -50,6 +50,7 @@
 #include <daos_prop.h>
 #include <daos_security.h>
 #include <daos/profile.h>
+#include <daos/dtx.h>
 
 #define DF_OID		DF_U64"."DF_U64
 #define DP_OID(o)	(o).hi, (o).lo
@@ -705,6 +706,7 @@ bool daos_hhash_link_delete(struct d_hlink *hlink);
 
 crt_init_options_t *daos_crt_init_opt_get(bool server, int crt_nr);
 
+int crt_proc_struct_dtx_id(crt_proc_t proc, struct dtx_id *dti);
 int crt_proc_daos_prop_t(crt_proc_t proc, daos_prop_t **data);
 int crt_proc_struct_daos_acl(crt_proc_t proc, struct daos_acl **data);
 

--- a/src/include/daos/dtx.h
+++ b/src/include/daos/dtx.h
@@ -38,12 +38,12 @@
 #define DTX_COMMIT_THRESHOLD_AGE	10
 
 enum dtx_target_flags {
+	/* The target only contains read-only operations for the DTX. */
 	DTF_RDONLY			= (1 << 0),
 };
 
 /**
- * The daos target that participates in the DTX. It may be shared by
- * multiple modification groups.
+ * The daos target that participates in the DTX.
  */
 struct dtx_daos_target {
 	/* Globally target ID, corresponding to pool_component::co_id. */
@@ -53,9 +53,8 @@ struct dtx_daos_target {
 };
 
 /**
- * If the modified items (replica or EC shard) belong to the same redundancy
- * group, then related DAOS targets on which these items reside will make up
- * a modification group. It is a subset of related DAOS redundancy group.
+ * The items (replica or EC shard) belong to the same redundancy group make
+ * up a modification group that is subset of related DAOS redundancy group.
  *
  * These information will be used for DTX recovery as following:
  *
@@ -88,17 +87,17 @@ struct dtx_redundancy_group {
 	 * count of parity nodes + 1. For replicated one, it is the same as
 	 * the drg_tgt_cnt.
 	 *
-	 * If all the shards 'drg_index[1 - drg_redundancy - 1]' are lost,
+	 * If all the shards 'drg_ids[0 - drg_redundancy - 1]' are lost,
 	 * then the group is regarded as unavailable.
 	 */
 	uint32_t			drg_redundancy;
 
-	/* The indexes for the shards in the dtx_daos_target array. For the
-	 * leader group that is the first one in dtx_memberships, 'drg_index[0]'
+	/* The shards' IDs, corresponding to pool_component::co_id. For the
+	 * leader group that is the first in dtx_memberships, 'drg_index[0]'
 	 * is for the leader, the other 'drg_index[1 - drg_redundancy - 1]'
 	 * are the leader candidates for DTX recovery.
 	 */
-	uint32_t			drg_index[0];
+	uint32_t			drg_ids[0];
 };
 
 struct dtx_memberships {

--- a/src/object/cli_obj.c
+++ b/src/object/cli_obj.c
@@ -3969,3 +3969,11 @@ out:
 
 	return rc;
 }
+
+void
+daos_dc_obj2id(void *ptr, daos_obj_id_t *id)
+{
+	struct dc_object *obj = ptr;
+
+	*id = obj->cob_md.omd_id;
+}

--- a/src/object/obj_rpc.c
+++ b/src/object/obj_rpc.c
@@ -33,22 +33,6 @@
 #include "rpc_csum.h"
 
 static int
-crt_proc_struct_dtx_id(crt_proc_t proc, struct dtx_id *dti)
-{
-	int rc;
-
-	rc = crt_proc_uuid_t(proc, &dti->dti_uuid);
-	if (rc != 0)
-		return -DER_HG;
-
-	rc = crt_proc_uint64_t(proc, &dti->dti_hlc);
-	if (rc != 0)
-		return -DER_HG;
-
-	return 0;
-}
-
-static int
 crt_proc_daos_key_desc_t(crt_proc_t proc, daos_key_desc_t *key)
 {
 	int rc;
@@ -616,7 +600,6 @@ crt_proc_d_sg_list_t(crt_proc_t proc, d_sg_list_t *sgl)
 	return rc;
 }
 
-
 static int
 crt_proc_struct_daos_shard_tgt(crt_proc_t proc, struct daos_shard_tgt *st)
 {
@@ -639,12 +622,592 @@ crt_proc_struct_daos_shard_tgt(crt_proc_t proc, struct daos_shard_tgt *st)
 	return 0;
 }
 
+/* For compounded RPC. */
+static int
+crt_proc_struct_dtx_daos_target(crt_proc_t proc, struct dtx_daos_target *ddt)
+{
+	int	rc;
+
+	rc = crt_proc_uint32_t(proc, &ddt->ddt_id);
+	if (rc != 0)
+		return -DER_HG;
+
+	rc = crt_proc_uint32_t(proc, &ddt->ddt_flags);
+	if (rc != 0)
+		return -DER_HG;
+
+	return 0;
+}
+
+static int
+crt_proc_struct_dtx_redundancy_group(crt_proc_t proc,
+				     struct dtx_redundancy_group *drg)
+{
+	int	rc;
+	int	i;
+
+	rc = crt_proc_uint32_t(proc, &drg->drg_tgt_cnt);
+	if (rc != 0)
+		return -DER_HG;
+
+	rc = crt_proc_uint32_t(proc, &drg->drg_redundancy);
+	if (rc != 0)
+		return -DER_HG;
+
+	for (i = 0; i < drg->drg_tgt_cnt; i++) {
+		rc = crt_proc_uint32_t(proc, &drg->drg_ids[i]);
+		if (rc != 0)
+			return -DER_HG;
+	}
+
+	return sizeof(*drg) + sizeof(drg->drg_ids[0]) * drg->drg_tgt_cnt;
+}
+
+static int
+crt_proc_struct_dtx_memberships(crt_proc_t proc, struct dtx_memberships *mbs)
+{
+	struct dtx_redundancy_group	*drg;
+	int				 rc;
+	int				 i;
+
+	rc = crt_proc_uint32_t(proc, &mbs->dm_tgt_cnt);
+	if (rc != 0)
+		return -DER_HG;
+
+	rc = crt_proc_uint32_t(proc, &mbs->dm_grp_cnt);
+	if (rc != 0)
+		return -DER_HG;
+
+	rc = crt_proc_uint32_t(proc, &mbs->dm_data_size);
+	if (rc != 0)
+		return -DER_HG;
+
+	for (i = 0; i < mbs->dm_tgt_cnt; i++) {
+		rc = crt_proc_struct_dtx_daos_target(proc, &mbs->dm_tgts[i]);
+		if (rc != 0)
+			return rc;
+	}
+
+	drg = (struct dtx_redundancy_group *)mbs->dm_data;
+	rc = sizeof(mbs->dm_tgts[0]) * mbs->dm_tgt_cnt;
+	for (i = 0; i < mbs->dm_grp_cnt; i++) {
+		drg = (struct dtx_redundancy_group *)((char *)drg + rc);
+		rc = crt_proc_struct_dtx_redundancy_group(proc, drg);
+		if (rc < 0)
+			return rc;
+	}
+
+	return 0;
+}
+
+static int
+crt_proc_struct_daos_cpd_sub_head(crt_proc_t proc,
+				  struct daos_cpd_sub_head *dcsh)
+{
+	crt_proc_op_t	proc_op;
+	uint32_t	size;
+	int		rc;
+
+	rc = crt_proc_get_op(proc, &proc_op);
+	if (rc != 0)
+		return -DER_HG;
+
+	if (proc_op == CRT_PROC_FREE) {
+		D_FREE(dcsh->dcsh_mbs);
+		return 0;
+	}
+
+	rc = crt_proc_struct_dtx_id(proc, &dcsh->dcsh_xid);
+	if (rc != 0)
+		return -DER_HG;
+
+	rc = crt_proc_daos_unit_oid_t(proc, &dcsh->dcsh_leader_oid);
+	if (rc != 0)
+		return -DER_HG;
+
+	rc = crt_proc_uint64_t(proc, &dcsh->dcsh_epoch);
+	if (rc != 0)
+		return -DER_HG;
+
+	if (proc_op == CRT_PROC_DECODE) {
+		struct dtx_memberships	*mbs;
+
+		rc = crt_proc_uint32_t(proc, &size);
+		if (rc != 0)
+			return -DER_HG;
+
+		D_ALLOC(mbs, size);
+		if (mbs == NULL)
+			return -DER_NOMEM;
+
+		rc = crt_proc_struct_dtx_memberships(proc, mbs);
+		if (rc != 0) {
+			D_FREE(mbs);
+			return -DER_HG;
+		}
+
+		dcsh->dcsh_mbs = mbs;
+		return 0;
+	}
+
+	D_ASSERT(proc_op == CRT_PROC_ENCODE);
+
+	/* Pack the size of dcsh->dcsh_mbs to help decode case. */
+	size = sizeof(*dcsh->dcsh_mbs) + dcsh->dcsh_mbs->dm_data_size;
+	rc = crt_proc_uint32_t(proc, &size);
+	if (rc != 0)
+		return -DER_HG;
+
+	return crt_proc_struct_dtx_memberships(proc, dcsh->dcsh_mbs);
+}
+
+static int
+crt_proc_daos_iod_t(crt_proc_t proc, daos_iod_t *iod)
+{
+	crt_proc_op_t	proc_op;
+	int		rc;
+	int		i;
+
+	rc = crt_proc_daos_key_t(proc, &iod->iod_name);
+	if (rc != 0)
+		return -DER_HG;
+
+	rc = crt_proc_get_op(proc, &proc_op);
+	if (rc != 0)
+		return -DER_HG;
+
+	if (proc_op == CRT_PROC_FREE) {
+		D_FREE(iod->iod_recxs);
+		return 0;
+	}
+
+	rc = crt_proc_memcpy(proc, &iod->iod_type, sizeof(iod->iod_type));
+	if (rc != 0)
+		return -DER_HG;
+
+	rc = crt_proc_uint64_t(proc, &iod->iod_size);
+	if (rc != 0)
+		return -DER_HG;
+
+	rc = crt_proc_uint32_t(proc, &iod->iod_nr);
+	if (rc != 0)
+		return -DER_HG;
+
+	if (iod->iod_nr == 0)
+		return 0;
+
+	if (proc_op == CRT_PROC_DECODE) {
+		D_ALLOC_ARRAY(iod->iod_recxs, iod->iod_nr);
+		if (iod->iod_recxs == NULL)
+			return -DER_NOMEM;
+	}
+
+	for (i = 0; i < iod->iod_nr; i++) {
+		rc = crt_proc_daos_recx_t(proc, &iod->iod_recxs[i]);
+		if (rc != 0) {
+			if (proc_op == CRT_PROC_DECODE)
+				D_FREE(iod->iod_recxs);
+
+			return -DER_HG;
+		}
+	}
+
+	return 0;
+}
+
+static int
+crt_proc_struct_daos_cpd_sub_req(crt_proc_t proc,
+				 struct daos_cpd_sub_req *dcsr)
+{
+	crt_proc_op_t	proc_op;
+	int		rc;
+	int		i;
+
+	rc = crt_proc_uint16_t(proc, &dcsr->dcsr_opc);
+	if (rc != 0)
+		return -DER_HG;
+
+	rc = crt_proc_uint16_t(proc, &dcsr->dcsr_ec_tgt_nr);
+	if (rc != 0)
+		return -DER_HG;
+
+	rc = crt_proc_uint32_t(proc, &dcsr->dcsr_nr);
+	if (rc != 0)
+		return -DER_HG;
+
+	rc = crt_proc_get_op(proc, &proc_op);
+	if (rc != 0)
+		return -DER_HG;
+
+	if (proc_op == CRT_PROC_DECODE) {
+		rc = crt_proc_daos_unit_oid_t(proc, &dcsr->dcsr_oid);
+	} else if (proc_op == CRT_PROC_ENCODE) {
+		daos_unit_oid_t		 oid;
+
+		daos_dc_obj2id(dcsr->dcsr_obj, &oid.id_pub);
+		/* It is not important what the id_shard is, that
+		 * is packed via daos_cpd_req_idx::dcri_shard_idx.
+		 */
+		rc = crt_proc_daos_unit_oid_t(proc, &oid);
+	}
+	if (rc != 0)
+		return -DER_HG;
+
+	rc = crt_proc_daos_key_t(proc, &dcsr->dcsr_dkey);
+	if (rc != 0)
+		return -DER_HG;
+
+	rc = crt_proc_uint64_t(proc, &dcsr->dcsr_dkey_hash);
+	if (rc != 0)
+		return -DER_HG;
+
+	rc = crt_proc_uint64_t(proc, &dcsr->dcsr_api_flags);
+	if (rc != 0)
+		return -DER_HG;
+
+	switch (dcsr->dcsr_opc) {
+	case DCSO_UPDATE: {
+		struct daos_cpd_update	*dcu = &dcsr->dcsr_update;
+
+		if (proc_op == CRT_PROC_DECODE) {
+			D_ALLOC(dcu->dcu_dkey_csum,
+				sizeof(*dcu->dcu_dkey_csum));
+			if (dcu->dcu_dkey_csum == NULL)
+				D_GOTO(out, rc = -DER_NOMEM);
+
+			D_ALLOC(dcu->dcu_iods, sizeof(*dcu->dcu_iods));
+			if (dcu->dcu_iods == NULL)
+				D_GOTO(out, rc = -DER_NOMEM);
+
+			if (dcsr->dcsr_ec_tgt_nr != 0) {
+				D_ALLOC_ARRAY(dcu->dcu_ec_tgts,
+					      dcsr->dcsr_ec_tgt_nr);
+				if (dcu->dcu_ec_tgts == NULL)
+					D_GOTO(out, rc = -DER_NOMEM);
+			}
+		}
+
+		rc = proc_struct_dcs_csum_info(proc, dcu->dcu_dkey_csum);
+		if (rc != 0)
+			D_GOTO(out, rc = -DER_HG);
+
+		rc = crt_proc_struct_obj_iod_array(proc, dcu->dcu_iods);
+		if (rc != 0)
+			D_GOTO(out, rc = -DER_HG);
+
+		for (i = 0; i < dcsr->dcsr_ec_tgt_nr; i++) {
+			rc = crt_proc_uint32_t(proc, &dcu->dcu_ec_tgts[i]);
+			if (rc != 0)
+				D_GOTO(out, rc = -DER_HG);
+		}
+
+		rc = crt_proc_uint32_t(proc, &dcu->dcu_start_shard);
+		if (rc != 0)
+			D_GOTO(out, rc = -DER_HG);
+
+		rc = crt_proc_uint32_t(proc, &dcu->dcu_flags);
+		if (rc != 0)
+			D_GOTO(out, rc = -DER_HG);
+
+		if (dcsr->dcsr_nr == 0)
+			D_GOTO(out, rc = 0);
+
+		if (dcu->dcu_flags & DRF_CPD_BULK) {
+			if (proc_op == CRT_PROC_DECODE) {
+				D_ALLOC_ARRAY(dcu->dcu_bulks, dcsr->dcsr_nr);
+				if (dcu->dcu_bulks == NULL)
+					D_GOTO(out, rc = -DER_NOMEM);
+			}
+
+			for (i = 0; i < dcsr->dcsr_nr; i++) {
+				rc = crt_proc_crt_bulk_t(proc,
+							 &dcu->dcu_bulks[i]);
+				if (rc != 0)
+					D_GOTO(out, rc = -DER_HG);
+			}
+		} else {
+			if (proc_op == CRT_PROC_DECODE) {
+				D_ALLOC_ARRAY(dcu->dcu_sgls, dcsr->dcsr_nr);
+				if (dcu->dcu_sgls == NULL)
+					D_GOTO(out, rc = -DER_NOMEM);
+			}
+
+			for (i = 0; i < dcsr->dcsr_nr; i++) {
+				rc = crt_proc_d_sg_list_t(proc,
+							  &dcu->dcu_sgls[i]);
+				if (rc != 0)
+					D_GOTO(out, rc = -DER_HG);
+			}
+		}
+
+		break;
+	}
+	case DCSO_PUNCH_OBJ:
+	case DCSO_PUNCH_DKEY:
+	case DCSO_PUNCH_AKEY: {
+		struct daos_cpd_punch	*dcp = &dcsr->dcsr_punch;
+
+		if (dcsr->dcsr_nr == 0)
+			D_GOTO(out, rc = 0);
+
+		if (proc_op == CRT_PROC_DECODE) {
+			D_ALLOC_ARRAY(dcp->dcp_akeys, dcsr->dcsr_nr);
+			if (dcp->dcp_akeys == NULL)
+				return -DER_NOMEM;
+		}
+
+		for (i = 0; i < dcsr->dcsr_nr; i++) {
+			rc = crt_proc_daos_key_t(proc, &dcp->dcp_akeys[i]);
+			if (rc != 0)
+				D_GOTO(out, rc = -DER_HG);
+		}
+
+		break;
+	}
+	case DCSO_READ: {
+		struct daos_cpd_read	*dcr = &dcsr->dcsr_read;
+
+		if (dcsr->dcsr_nr == 0)
+			D_GOTO(out, rc = 0);
+
+		if (proc_op == CRT_PROC_DECODE) {
+			D_ALLOC_ARRAY(dcr->dcr_iods, dcsr->dcsr_nr);
+			if (dcr->dcr_iods == NULL)
+				D_GOTO(out, rc = -DER_NOMEM);
+		}
+
+		for (i = 0; i < dcsr->dcsr_nr; i++) {
+			rc = crt_proc_daos_iod_t(proc, &dcr->dcr_iods[i]);
+			if (rc != 0)
+				D_GOTO(out, rc = -DER_HG);
+		}
+
+		break;
+	}
+	default:
+		return -DER_INVAL;
+	}
+
+out:
+	if ((proc_op == CRT_PROC_ENCODE) ||
+	    (proc_op == CRT_PROC_DECODE && rc == 0))
+		return rc;
+
+	switch (dcsr->dcsr_opc) {
+	case DCSO_UPDATE:
+		D_FREE(dcsr->dcsr_update.dcu_dkey_csum);
+		D_FREE(dcsr->dcsr_update.dcu_iods);
+		D_FREE(dcsr->dcsr_update.dcu_ec_tgts);
+		D_FREE(dcsr->dcsr_update.dcu_sgls);
+		break;
+	case DCSO_PUNCH_OBJ:
+	case DCSO_PUNCH_DKEY:
+	case DCSO_PUNCH_AKEY:
+		D_FREE(dcsr->dcsr_punch.dcp_akeys);
+		break;
+	case DCSO_READ:
+		D_FREE(dcsr->dcsr_read.dcr_iods);
+		break;
+	}
+
+	return rc;
+}
+
+static int
+crt_proc_struct_daos_cpd_req_idx(crt_proc_t proc,
+				 struct daos_cpd_req_idx *dcri)
+{
+	int	rc;
+
+	rc = crt_proc_uint32_t(proc, &dcri->dcri_shard_idx);
+	if (rc != 0)
+		return -DER_HG;
+
+	rc = crt_proc_uint32_t(proc, &dcri->dcri_req_idx);
+	if (rc != 0)
+		return -DER_HG;
+
+	return 0;
+}
+
+static int
+crt_proc_struct_daos_cpd_disp_ent(crt_proc_t proc,
+				   struct daos_cpd_disp_ent *dcde)
+{
+	crt_proc_op_t	proc_op;
+	uint32_t	count;
+	int		rc;
+	int		i;
+
+	rc = crt_proc_uint32_t(proc, &dcde->dcde_read_cnt);
+	if (rc != 0)
+		return -DER_HG;
+
+	rc = crt_proc_uint32_t(proc, &dcde->dcde_write_cnt);
+	if (rc != 0)
+		return -DER_HG;
+
+	rc = crt_proc_get_op(proc, &proc_op);
+	if (rc != 0)
+		return -DER_HG;
+
+	if (proc_op == CRT_PROC_FREE) {
+		D_FREE(dcde->dcde_reqs);
+		return 0;
+	}
+
+	count = dcde->dcde_read_cnt + dcde->dcde_read_cnt;
+	if (proc_op == CRT_PROC_DECODE) {
+		D_ALLOC_ARRAY(dcde->dcde_reqs, count);
+		if (dcde->dcde_reqs == NULL)
+			return -DER_NOMEM;
+	}
+
+	for (i = 0; i < count; i++) {
+		rc = crt_proc_struct_daos_cpd_req_idx(proc,
+						      &dcde->dcde_reqs[i]);
+		if (rc != 0) {
+			if (proc_op == CRT_PROC_DECODE)
+				D_FREE(dcde->dcde_reqs);
+
+			return -DER_HG;
+		}
+	}
+
+	return 0;
+}
+
+static int
+crt_proc_struct_daos_cpd_sg(crt_proc_t proc, struct daos_cpd_sg *dcs)
+{
+	crt_proc_op_t	proc_op;
+	int		rc;
+	int		i;
+
+	rc = crt_proc_uint32_t(proc, &dcs->dcs_type);
+	if (rc != 0)
+		return -DER_HG;
+
+	rc = crt_proc_uint32_t(proc, &dcs->dcs_nr);
+	if (rc != 0)
+		return -DER_HG;
+
+	rc = crt_proc_get_op(proc, &proc_op);
+	if (rc != 0)
+		return -DER_HG;
+
+	switch (dcs->dcs_type) {
+	case DCST_HEAD: {
+		struct daos_cpd_sub_head	*dcsh;
+
+		if (proc_op == CRT_PROC_DECODE) {
+			D_ALLOC_ARRAY(dcsh, dcs->dcs_nr);
+			if (dcsh == NULL)
+				D_GOTO(out, rc = -DER_NOMEM);
+
+			dcs->dcs_buf = dcsh;
+		} else {
+			dcsh = dcs->dcs_buf;
+		}
+
+		for (i = 0; i < dcs->dcs_nr; i++) {
+			rc = crt_proc_struct_daos_cpd_sub_head(proc, &dcsh[i]);
+			if (rc != 0)
+				D_GOTO(out, rc = -DER_HG);
+		}
+
+		break;
+	}
+	case DCST_REQ: {
+		struct daos_cpd_sub_req		*dcsr;
+
+		if (proc_op == CRT_PROC_DECODE) {
+			D_ALLOC_ARRAY(dcsr, dcs->dcs_nr);
+			if (dcsr == NULL)
+				D_GOTO(out, rc = -DER_NOMEM);
+
+			dcs->dcs_buf = dcsr;
+		} else {
+			dcsr = dcs->dcs_buf;
+		}
+
+		for (i = 0; i < dcs->dcs_nr; i++) {
+			rc = crt_proc_struct_daos_cpd_sub_req(proc, &dcsr[i]);
+			if (rc != 0)
+				D_GOTO(out, rc = -DER_HG);
+		}
+
+		break;
+	}
+	case DCST_DISP: {
+		struct daos_cpd_disp_ent	*dcde;
+
+		if (proc_op == CRT_PROC_DECODE) {
+			D_ALLOC_ARRAY(dcde, dcs->dcs_nr);
+			if (dcde == NULL)
+				D_GOTO(out, rc = -DER_NOMEM);
+
+			dcs->dcs_buf = dcde;
+		} else {
+			dcde = dcs->dcs_buf;
+		}
+
+		for (i = 0; i < dcs->dcs_nr; i++) {
+			rc = crt_proc_struct_daos_cpd_disp_ent(proc, &dcde[i]);
+			if (rc != 0)
+				D_GOTO(out, rc = -DER_HG);
+		}
+
+		break;
+	}
+	case DCST_TGT: {
+		struct daos_shard_tgt		*dst;
+
+		if (proc_op == CRT_PROC_DECODE) {
+			D_ALLOC_ARRAY(dst, dcs->dcs_nr);
+			if (dst == NULL)
+				D_GOTO(out, rc = -DER_NOMEM);
+
+			dcs->dcs_buf = dst;
+		} else {
+			dst = dcs->dcs_buf;
+		}
+
+		for (i = 0; i < dcs->dcs_nr; i++) {
+			rc = crt_proc_struct_daos_shard_tgt(proc, &dst[i]);
+			if (rc != 0)
+				D_GOTO(out, rc = -DER_HG);
+		}
+
+		break;
+	}
+	default:
+		return -DER_INVAL;
+	}
+
+out:
+	/* XXX: There is potential memory leak for the case of CRT_PROC_DECODE
+	 *	with failure. We may allocate some DRAM in some low layer proc
+	 *	functions when decoding former elements.
+	 *
+	 *	Currently, We seems not have efficient way to release them. It
+	 *	is not special for CPD related proc interfaces, instead, it is
+	 *	general issue for the whole CRT proc mechanism.
+	 */
+	if ((proc_op == CRT_PROC_FREE) ||
+	    (proc_op == CRT_PROC_DECODE && rc != 0))
+		D_FREE(dcs->dcs_buf);
+
+	return rc;
+}
+
 CRT_RPC_DEFINE(obj_rw, DAOS_ISEQ_OBJ_RW, DAOS_OSEQ_OBJ_RW)
 CRT_RPC_DEFINE(obj_key_enum, DAOS_ISEQ_OBJ_KEY_ENUM, DAOS_OSEQ_OBJ_KEY_ENUM)
 CRT_RPC_DEFINE(obj_punch, DAOS_ISEQ_OBJ_PUNCH, DAOS_OSEQ_OBJ_PUNCH)
 CRT_RPC_DEFINE(obj_query_key, DAOS_ISEQ_OBJ_QUERY_KEY, DAOS_OSEQ_OBJ_QUERY_KEY)
 CRT_RPC_DEFINE(obj_sync, DAOS_ISEQ_OBJ_SYNC, DAOS_OSEQ_OBJ_SYNC)
 CRT_RPC_DEFINE(obj_migrate, DAOS_ISEQ_OBJ_MIGRATE, DAOS_OSEQ_OBJ_MIGRATE)
+CRT_RPC_DEFINE(obj_cpd, DAOS_ISEQ_OBJ_CPD, DAOS_OSEQ_OBJ_CPD)
 
 
 /* Define for cont_rpcs[] array population below.

--- a/src/object/obj_rpc.h
+++ b/src/object/obj_rpc.h
@@ -145,6 +145,10 @@ enum obj_rpc_flags {
 	ORF_EPOCH_UNCERTAIN	= (1 << 6),
 	/** Erasure coding degraded fetch flag */
 	ORF_EC_DEGRADED		= (1 << 7),
+	/* CPD RPC leader */
+	DRF_CPD_LEADER		= (1 << 8),
+	/* Bulk data transfer for CPD RPC. */
+	DRF_CPD_BULK		= (1 << 9),
 };
 
 struct obj_iod_array {
@@ -317,6 +321,173 @@ CRT_RPC_DECLARE(obj_sync, DAOS_ISEQ_OBJ_SYNC, DAOS_OSEQ_OBJ_SYNC)
 
 CRT_RPC_DECLARE(obj_migrate, DAOS_ISEQ_OBJ_MIGRATE, DAOS_OSEQ_OBJ_MIGRATE)
 
+void daos_dc_obj2id(void *ptr, daos_obj_id_t *id);
+
+enum daos_cpd_sub_opc {
+	DCSO_UPDATE		= 0,
+	DCSO_READ		= 1,
+	DCSO_PUNCH_OBJ		= 2,
+	DCSO_PUNCH_DKEY		= 3,
+	DCSO_PUNCH_AKEY		= 4,
+};
+
+/**
+ * Each transaction (in spite of distributed one or simple individual
+ * modification) has a 'daos_cpd_sub_head', that is shared by the sub
+ * requests belong to the transaction.
+ */
+struct daos_cpd_sub_head {
+	struct dtx_id			 dcsh_xid;
+	/* The object ID is used to elect leader for DTX recovery.
+	 * If it is empty, then it is for a readonly transaction.
+	 */
+	daos_unit_oid_t			 dcsh_leader_oid;
+	daos_epoch_t			 dcsh_epoch;
+	struct dtx_memberships		*dcsh_mbs;
+};
+
+struct daos_cpd_update {
+	struct dcs_csum_info		*dcu_dkey_csum;
+	struct obj_iod_array		*dcu_iods;
+	/* The index for EC target in its transaction's 'oci_disp_tgts' set.
+	 * Ascending sorted.
+	 */
+	uint32_t			*dcu_ec_tgts;
+	/* Used for split EC update request. */
+	uint32_t			 dcu_start_shard;
+	/* see obj_rpc_flags. */
+	uint32_t			 dcu_flags;
+	union {
+		d_sg_list_t		*dcu_sgls;
+		crt_bulk_t		*dcu_bulks;
+	};
+};
+
+struct daos_cpd_punch {
+	daos_key_t			*dcp_akeys;
+};
+
+/**
+ * It is fake read style (daos fetch/enumerate/query) operation, only for set
+ * read timestamp on related target(s). It does not need iod/sgl information.
+ */
+struct daos_cpd_read {
+	daos_iod_t			*dcr_iods;
+};
+
+/**
+ * Each daos_cpd_sub_req stands for one simple DAOS operation that can be
+ * handled via single VOS API call.
+ */
+struct daos_cpd_sub_req {
+	/* See enum daos_cpd_sub_opc.*/
+	uint16_t			 dcsr_opc;
+	/* Size of 'dcu_ec_tgts', only used for updating of EC object. */
+	uint16_t			 dcsr_ec_tgt_nr;
+	uint32_t			 dcsr_nr;
+	union {
+		/* Used by CPD PRC and server side logic. */
+		daos_unit_oid_t		 dcsr_oid;
+		/* Used by client side cache. */
+		void			*dcsr_obj;
+	};
+	daos_key_t			 dcsr_dkey;
+	uint64_t			 dcsr_dkey_hash;
+	uint64_t			 dcsr_api_flags;
+	union {
+		struct daos_cpd_update	 dcsr_update;
+		struct daos_cpd_punch	 dcsr_punch;
+		struct daos_cpd_read	 dcsr_read;
+	};
+};
+
+/**
+ * Used for locating a sub request to be executed on the specified DAOS target.
+ */
+struct daos_cpd_req_idx {
+	/* Shard index of the object for the sub request on this DAOS target. */
+	uint32_t			 dcri_shard_idx;
+	/* The index (relative to the first sub request for its transaction)
+	 * of sub-request in the 'oci_sub_reqs' array. For parsing convenience,
+	 * DCSO_READ requests firstly, then modification ones. The update and
+	 * punch are sorted as their original executed order.
+	 */
+	uint32_t			 dcri_req_idx;
+};
+
+/**
+ * Each 'daos_cpd_disp_ent' describes all the sub requests that belong to
+ * one transaction (in spite of compounded or not) on one DAOS target.
+ */
+struct daos_cpd_disp_ent {
+	/* The count of read sub requests for the DTX on the DAOS target. */
+	uint32_t			 dcde_read_cnt;
+	/* The count of write sub requests for the DTX on the DAOS target.
+	 * It can be up to '2 ^ 16 - 1' at most because of the restriction
+	 * of 16-bits minor epoch on the server.
+	 */
+	uint32_t			 dcde_write_cnt;
+	/* Pointer to 'daos_cpd_req_idx' array. */
+	struct daos_cpd_req_idx		*dcde_reqs;
+};
+
+enum daos_cpd_sg_type {
+	DCST_HEAD	= 1,
+	DCST_REQ	= 2,
+	DCST_DISP	= 3,
+	DCST_TGT	= 4,
+};
+
+/** Scatter/gather info for CPD RPC data structure. */
+struct daos_cpd_sg {
+	uint32_t	 dcs_type;
+	uint32_t	 dcs_nr;
+	void		*dcs_buf;
+};
+
+#define DAOS_ISEQ_OBJ_CPD /* input fields */				    \
+	((uuid_t)			(oci_pool_uuid)		CRT_VAR)    \
+	((uuid_t)			(oci_co_hdl)		CRT_VAR)    \
+	((uuid_t)			(oci_co_uuid)		CRT_VAR)    \
+	((uint32_t)			(oci_map_ver)		CRT_VAR)    \
+	((uint32_t)			(oci_flags)		CRT_VAR)    \
+	/* scatter array for daos_cpd_sub_head. */			    \
+	((struct daos_cpd_sg)		(oci_sub_heads)		CRT_ARRAY)  \
+	/* scatter array for daos_cpd_sub_req. */			    \
+	((struct daos_cpd_sg)		(oci_sub_reqs)		CRT_ARRAY)  \
+	/* scatter array for daos_cpd_disp_ent. */			    \
+	((struct daos_cpd_sg)		(oci_disp_ents)		CRT_ARRAY)  \
+	/* scatter array for daos_shard_tgt. */				    \
+	((struct daos_cpd_sg)		(oci_disp_tgts)		CRT_ARRAY)
+
+	/* For parse and dispatch convenience, the 'oci_disp_tgts' are sorted
+	 * as the same order as 'oci_disp_ents' do. Each transaction has each
+	 * own different daos_shard_tgt set. If some DAOS target contains the
+	 * requests belonging to multiple transactions, its daos_shard_tgt is
+	 * repeatedly packed in every related dipatch set.
+	 */
+
+#define DAOS_OSEQ_OBJ_CPD /* output fields */				    \
+	((int32_t)			(oco_ret)		CRT_VAR)    \
+	((uint32_t)			(oco_map_version)	CRT_VAR)    \
+	((uint64_t)			(oco_epoch)		CRT_VAR)    \
+	((int32_t)			(oco_sub_rets)		CRT_ARRAY)
+
+	/* Compouned replies. Eac sub reply responding to one independent
+	 * transaction.
+	 *
+	 * Resent:
+	 * If the CPD RPC needs to be resent, then all the sub requests in
+	 * the CPD RPC are resent. So the server side logic needs to track
+	 * sub requests resent one by one.
+	 *
+	 * Restart:
+	 * Support restart the specified independent DTX without affecting
+	 * other transactions in the same CPD RPC.
+	 */
+
+CRT_RPC_DECLARE(obj_cpd, DAOS_ISEQ_OBJ_CPD, DAOS_OSEQ_OBJ_CPD)
+
 static inline int
 obj_req_create(crt_context_t crt_ctx, crt_endpoint_t *tgt_ep, crt_opcode_t opc,
 	       crt_rpc_t **req)
@@ -387,5 +558,7 @@ obj_rpc_is_migrate(crt_rpc_t *rpc)
 {
 	return opc_get(rpc->cr_opc) == DAOS_OBJ_RPC_MIGRATE;
 }
+
+int proc_struct_dcs_csum_info(crt_proc_t proc, struct dcs_csum_info *csum);
 
 #endif /* __DAOS_OBJ_RPC_H__ */

--- a/src/object/rpc_csum.c
+++ b/src/object/rpc_csum.c
@@ -98,7 +98,7 @@ proc_struct_dcs_csum_info_adv(crt_proc_t proc, crt_proc_op_t proc_op,
 	return 0;
 }
 
-static int
+int
 proc_struct_dcs_csum_info(crt_proc_t proc, struct dcs_csum_info *csum)
 {
 	crt_proc_op_t		proc_op;


### PR DESCRIPTION
DAOS compounded RPC ('CPD' for short) is used to send multiple
simple DAOS operations (such as update, punch, fetch and so on)
to a specified leader via single RPC. These simiple operatinos
can belong to the same distributed transaction (DTX)or not. If
they belong to multiple DTXs, those DTXs should be independent
from one another.

The CPD RPC can be used between daos client and leader server,
and also can be between leader and non-leader servers.

The DTX client side logic uses CPD RPC to batched send cached
operations on the DTX leader for handling tx_commit. Then the
DTX leader will dispatch the modifications to related servers
via CPD RPC.

Currently, we cannot embed compounded operations into CPD RPC.

Signed-off-by: Fan Yong <fan.yong@intel.com>