### PR TITLE
DAOS-5296 rebuild: Only send rebuild stop IV once scan succeeds

### DIFF
--- a/src/rebuild/rebuild_internal.h
+++ b/src/rebuild/rebuild_internal.h
@@ -141,7 +141,8 @@ struct rebuild_global_pool_tracker {
 	uint64_t	rgt_stable_epoch;
 
 	unsigned int	rgt_abort:1,
-			rgt_notify_stable_epoch:1;
+			rgt_notify_stable_epoch:1,
+			rgt_init_scan:1;
 };
 
 /* Structure on raft replica nodes to serve completed rebuild status querying */


### PR DESCRIPTION
1. Only send rebuild stop IV if scan succeeds.

2. Do not exclude the target if rebuild fails, otherwise
the data will be rebuilt will be missing in the following
rebuild.

Signed-off-by: Di Wang <di.wang@intel.com>