### PR TITLE
DAOS-5195 hlc: Export crt_hlc_get_msg

### DIFF
--- a/src/cart/src/cart/crt_internal_fns.h
+++ b/src/cart/src/cart/crt_internal_fns.h
@@ -95,7 +95,4 @@ crt_bulk_desc_dup(struct crt_bulk_desc *bulk_desc_new,
 void
 crt_hdlr_proto_query(crt_rpc_t *rpc_req);
 
-/* Internal API to sync timestamp with remote message */
-uint64_t crt_hlc_get_msg(uint64_t msg);
-
 #endif /* __CRT_INTERNAL_FNS_H__ */

--- a/src/cart/src/include/cart/api.h
+++ b/src/cart/src/include/cart/api.h
@@ -469,6 +469,16 @@ uint64_t
 crt_hlc_get(void);
 
 /**
+ * Sync HLC with remote message and return current HLC timestamp.
+ *
+ * \param[in] msg              remote HLC timestamp
+ *
+ * \return                     HLC timestamp
+ */
+uint64_t
+crt_hlc_get_msg(uint64_t msg);
+
+/**
  * Return the second timestamp of hlc.
  *
  * \param[in] hlc              HLC timestamp


### PR DESCRIPTION
In object module, we need to sync servers' HLCs with epochs when
executing transactional I/Os, once we stop to sync server HLCs with
client HCLs. Every epoch will be an HLC timestamp read from some
server's HLC. This is to ensure that a server's current HLC reading is
always higher than the epochs of all I/Os it has executed. This patch
exports crt_hlc_get_msg to crt users.

Signed-off-by: Li Wei <wei.g.li@intel.com>