### PR TITLE
DAOS-4415 md: set aside portion of rdb vos pool for SLC

### DIFF
--- a/src/include/daos_srv/vos.h
+++ b/src/include/daos_srv/vos.h
@@ -288,6 +288,21 @@ int
 vos_pool_query_space(uuid_t pool_id, struct vos_pool_space *vps);
 
 /**
+ * Set aside additional "system reserved" space in pool SCM and NVMe
+ * (additive to any existing reserved space by vos)
+ *
+ * \param poh		[IN]	Pool open handle
+ * \param space_sys	[IN]	Array of sizes in bytes, indexed by media type
+ *				(DAOS_MEDIA_SCM and DAOS_MEDIA_NVME)
+ *
+ * \return		Zero		: success
+ *			-DER_NO_HDL	: invalid pool handle
+ *			-DER_INVAL	: space_sys is NULL
+ */
+int
+vos_pool_space_sys_set(daos_handle_t poh, daos_size_t *space_sys);
+
+/**
  * Create a container within a VOSP
  *
  * \param poh	[IN]	Pool open handle

--- a/src/rdb/rdb.c
+++ b/src/rdb/rdb.c
@@ -291,15 +291,22 @@ rdb_start(const char *path, const uuid_t uuid, struct rdb_cbs *cbs, void *arg,
 			DP_DB(db), DP_RC(rc));
 		goto err_pool;
 	}
-	rdb_extra_sys[DAOS_MEDIA_SCM] =
-		     ((SCM_FREE(&vps) - SCM_SYS(&vps)) * 52) / 100;
+	rdb_extra_sys[DAOS_MEDIA_SCM] = 0;
 	rdb_extra_sys[DAOS_MEDIA_NVME] = 0;
-	rc = vos_pool_space_sys_set(db->d_pool, &rdb_extra_sys[0]);
-	if (rc != 0) {
-		D_ERROR(DF_DB": failed to reserve more vos pool SCM space "
-			DF_U64" : "DF_RC"\n", DP_DB(db),
-			rdb_extra_sys[DAOS_MEDIA_SCM], DP_RC(rc));
-		goto err_pool;
+	if (SCM_FREE(&vps) > SCM_SYS(&vps)) {
+		rdb_extra_sys[DAOS_MEDIA_SCM] =
+			     ((SCM_FREE(&vps) - SCM_SYS(&vps)) * 52) / 100;
+		rc = vos_pool_space_sys_set(db->d_pool, &rdb_extra_sys[0]);
+		if (rc != 0) {
+			D_ERROR(DF_DB": failed to reserve more vos pool SCM space "
+				DF_U64" : "DF_RC"\n", DP_DB(db),
+				rdb_extra_sys[DAOS_MEDIA_SCM], DP_RC(rc));
+			goto err_pool;
+		}
+	} else {
+		D_WARN(DF_DB": vos pool SCM not reserved for SLC: "
+		       "free="DF_U64 "sys="DF_U64"\n", DP_DB(db),
+		       SCM_FREE(&vps), SCM_SYS(&vps));
 	}
 	D_DEBUG(DB_MD, DF_DB": vos pool SCM: tot: "DF_U64" free: "DF_U64
 		" vos-rsvd: "DF_U64" rdb-rsvd-slc: "DF_U64"\n", DP_DB(db),

--- a/src/rdb/rdb.c
+++ b/src/rdb/rdb.c
@@ -223,10 +223,12 @@ int
 rdb_start(const char *path, const uuid_t uuid, struct rdb_cbs *cbs, void *arg,
 	  struct rdb **dbp)
 {
-	struct rdb     *db;
-	d_iov_t	value;
-	uuid_t		uuid_persist;
-	int		rc;
+	struct rdb	       *db;
+	d_iov_t			value;
+	uuid_t			uuid_persist;
+	int			rc;
+	struct vos_pool_space	vps;
+	uint64_t		rdb_extra_sys[DAOS_MEDIA_MAX];
 
 	D_ASSERT(cbs->dc_stop != NULL);
 	D_DEBUG(DB_MD, DF_UUID": starting db %s\n", DP_UUID(uuid), path);
@@ -276,6 +278,33 @@ rdb_start(const char *path, const uuid_t uuid, struct rdb_cbs *cbs, void *arg,
 			DP_RC(rc));
 		goto err_kvss;
 	}
+
+	/* metadata vos pool management: reserved memory:
+	 * vos sets aside a portion of a pool for system activity:
+	 *   fragmentation overhead (e.g., 5%), aggregation, GC
+	 * rdb here set aside additional memory, > 50% of remaining usable
+	 * for INSTALLSNAPSHOT / staging log container.
+	 */
+	rc = vos_pool_query_space(db->d_uuid, &vps);
+	if (rc != 0) {
+		D_ERROR(DF_DB": failed to query vos pool space: "DF_RC"\n",
+			DP_DB(db), DP_RC(rc));
+		goto err_pool;
+	}
+	rdb_extra_sys[DAOS_MEDIA_SCM] =
+		     ((SCM_FREE(&vps) - SCM_SYS(&vps)) * 52) / 100;
+	rdb_extra_sys[DAOS_MEDIA_NVME] = 0;
+	rc = vos_pool_space_sys_set(db->d_pool, &rdb_extra_sys[0]);
+	if (rc != 0) {
+		D_ERROR(DF_DB": failed to reserve more vos pool SCM space "
+			DF_U64" : "DF_RC"\n", DP_DB(db),
+			rdb_extra_sys[DAOS_MEDIA_SCM], DP_RC(rc));
+		goto err_pool;
+	}
+	D_DEBUG(DB_MD, DF_DB": vos pool SCM: tot: "DF_U64" free: "DF_U64
+		" vos-rsvd: "DF_U64" rdb-rsvd-slc: "DF_U64"\n", DP_DB(db),
+		SCM_TOTAL(&vps), SCM_FREE(&vps), SCM_SYS(&vps),
+		rdb_extra_sys[DAOS_MEDIA_SCM]);
 
 	rc = vos_cont_open(db->d_pool, (unsigned char *)uuid, &db->d_mc);
 	if (rc != 0) {

--- a/src/rdb/rdb.c
+++ b/src/rdb/rdb.c
@@ -298,7 +298,7 @@ rdb_start(const char *path, const uuid_t uuid, struct rdb_cbs *cbs, void *arg,
 			     ((SCM_FREE(&vps) - SCM_SYS(&vps)) * 52) / 100;
 		rc = vos_pool_space_sys_set(db->d_pool, &rdb_extra_sys[0]);
 		if (rc != 0) {
-			D_ERROR(DF_DB": failed to reserve more vos pool SCM space "
+			D_ERROR(DF_DB": failed to reserve more vos pool SCM "
 				DF_U64" : "DF_RC"\n", DP_DB(db),
 				rdb_extra_sys[DAOS_MEDIA_SCM], DP_RC(rc));
 			goto err_pool;

--- a/src/rdb/rdb_raft.c
+++ b/src/rdb/rdb_raft.c
@@ -713,9 +713,9 @@ rdb_raft_exec_unpack_io(struct dss_enum_unpack_io *io, void *arg)
 	}
 #endif
 	return vos_obj_update(unpack_arg->slc, io->ui_oid, unpack_arg->eph,
-			      io->ui_version, 0 /* flags */, &io->ui_dkey,
-			      io->ui_iods_top + 1, io->ui_iods, NULL,
-			      io->ui_sgls);
+			      io->ui_version, VOS_OF_CRIT /* flags */,
+			      &io->ui_dkey, io->ui_iods_top + 1, io->ui_iods,
+			      NULL, io->ui_sgls);
 }
 
 static int

--- a/src/tests/ftest/server/metadata.py
+++ b/src/tests/ftest/server/metadata.py
@@ -48,12 +48,10 @@ from test_utils_pool import TestPool
 # and taking into account vos reserving in vos_space_init():
 #  5% for fragmentation overhead
 #  ~ 1MB for background garbage collection use
-#  ~40MB for background aggregation use
-NO_OF_MAX_CONTAINER = 9300
-
-# DAOS_MD_CAP=92, 5% fragmentation, and ~47700000 bytes more overhead
-# NO_OF_MAX_CONTAINER = 5500
-
+#  ~48MB for background aggregation use
+# 52% of remaining free space set aside for staging log container
+# (installsnapshot RPC handling in raft)
+NO_OF_MAX_CONTAINER = 4464
 
 def ior_runner_thread(manager, uuids, results):
     """IOR run thread method.

--- a/src/tests/ftest/server/metadata.yaml
+++ b/src/tests/ftest/server/metadata.yaml
@@ -9,7 +9,7 @@ hosts:
     - server-D
   test_clients:
     - client-C
-timeout: 240
+timeout: 300
 server_config:
   name: daos_server
   servers_per_host: 2
@@ -53,7 +53,7 @@ pool:
   createset:
     group: daos_server
   createsvc:
-    svcn: 1
+    svcn: 3
   createsize:
     scm_size: 1073741824
     nvme_size: 8589934592

--- a/src/vos/vos_pool.c
+++ b/src/vos/vos_pool.c
@@ -804,6 +804,19 @@ vos_pool_query_space(uuid_t pool_id, struct vos_pool_space *vps)
 }
 
 int
+vos_pool_space_sys_set(daos_handle_t poh, daos_size_t *space_sys)
+{
+	struct vos_pool	*pool = vos_hdl2pool(poh);
+
+	if (pool == NULL)
+		return -DER_NO_HDL;
+	if (space_sys == NULL)
+		return -DER_INVAL;
+
+	return vos_space_sys_set(pool, space_sys);
+}
+
+int
 vos_pool_ctl(daos_handle_t poh, enum vos_pool_opc opc)
 {
 	struct vos_pool		*pool;


### PR DESCRIPTION
When starting an rdb instance, in the vos pool allocation use vos API
vos_space_sys_set() to logically reserve some portion of the memory to
support a staging log container (SLC). When a slow follower situation
occurs the leader will issue raft installsnapshot RPCs to the follower.
On the follower a staging log container is allocated to receive the
latest log container state from the leader. Up front, reserve slightly
more than 50% of the usable vos pool storage to accommodate the SLC,
so that -DER_NOSPACE can be avoided in a follower's handling of
installsnapshot RPCs. And when performing updates in the SLC, specify
VOS_OF_CRIT in the flags.

Test-tag-hw-large: pr,hw,large metadatafill

Signed-off-by: Kenneth Cain <kenneth.c.cain@intel.com>