### PR TITLE
DAOS-4410 debug: run evict_test with debug logs in CI

### DIFF
--- a/src/tests/ftest/pool/evict_test.py
+++ b/src/tests/ftest/pool/evict_test.py
@@ -266,7 +266,7 @@ class EvictTests(TestWithServers):
         """
         Test evicting a pool using an invalid server group name.
 
-        :avocado: tags=all,pool,full_regression,small,poolevict
+        :avocado: tags=all,pool,pr,full_regression,small,poolevict
         :avocado: tags=poolevict_bad_server_name
         """
         test_param = self.params.get("server_name", '/run/badparams/*')

--- a/src/tests/ftest/pool/evict_test.yaml
+++ b/src/tests/ftest/pool/evict_test.yaml
@@ -5,6 +5,15 @@ hosts:
     - server-C
     - server-D
 server_config:
+  servers:
+    log_mask: DEBUG
+    env_vars:
+     - ABT_ENV_MAX_NUM_XSTREAMS=100
+     - ABT_MAX_NUM_XSTREAMS=100
+     - DAOS_MD_CAP=1024
+     - FI_SOCKETS_MAX_CONN_RETRY=1
+     - FI_SOCKETS_CONN_TIMEOUT=2000
+     - DD_MASK=all
    name: daos_server
 timeout: 400
 pool:


### PR DESCRIPTION
In order to help debug the reason of evict_test with
bad_server_name timeout under CI, 1) reallow test to
run for PR testing, 2) enable full debug logs.

Change-Id: I6597e650a1cae7661e00be9d7985988b3eebfd9b
Signed-off-by: Bruno Faccini <bruno.faccini@intel.com>