### PR TITLE
DAOS-4897 test: some changes to daos_perf and EC test

### DIFF
--- a/src/include/daos_obj_class.h
+++ b/src/include/daos_obj_class.h
@@ -266,6 +266,7 @@ enum {
 
 	/** EC 2+2 object classes */
 	OC_EC_2P2G1	= 300,
+	OC_EC_2P2G1_32K,
 	OC_EC_2P2G2,
 	OC_EC_2P2G4,
 	OC_EC_2P2G8,
@@ -300,6 +301,7 @@ enum {
 
 	/** EC 4+2 object classes */
 	OC_EC_4P2G1	= 340,
+	OC_EC_4P2G1_32K,
 	OC_EC_4P2G2,
 	OC_EC_4P2G4,
 	OC_EC_4P2G8,

--- a/src/object/cli_obj.c
+++ b/src/object/cli_obj.c
@@ -40,7 +40,7 @@
 #define CLI_OBJ_IO_PARMS	8
 #define NIL_BITMAP		(NULL)
 
-#define OBJ_TGT_INLINE_NR	(22)
+#define OBJ_TGT_INLINE_NR	(21)
 struct obj_req_tgts {
 	/* to save memory allocation if #targets <= OBJ_TGT_INLINE_NR */
 	struct daos_shard_tgt	 ort_tgts_inline[OBJ_TGT_INLINE_NR];

--- a/src/object/obj_class.c
+++ b/src/object/obj_class.c
@@ -301,6 +301,18 @@ static struct daos_obj_class daos_obj_classes[] = {
 		},
 	},
 	{
+		.oc_name	= "EC_2P2G1_32K",
+		.oc_id		= OC_EC_2P2G1_32K,
+		{
+			.ca_schema		= DAOS_OS_SINGLE,
+			.ca_resil		= DAOS_RES_EC,
+			.ca_grp_nr		= 1,
+			.ca_ec_k		= 2,
+			.ca_ec_p		= 2,
+			.ca_ec_cell		= 1 << 15,
+		},
+	},
+	{
 		.oc_name	= "EC_4P1G1",
 		.oc_id		= OC_EC_4P1G1,
 		{
@@ -322,6 +334,18 @@ static struct daos_obj_class daos_obj_classes[] = {
 			.ca_ec_k		= 4,
 			.ca_ec_p		= 2,
 			.ca_ec_cell		= 1 << 20,
+		},
+	},
+	{
+		.oc_name	= "EC_4P2G1_32K",
+		.oc_id		= OC_EC_4P2G1_32K,
+		{
+			.ca_schema		= DAOS_OS_SINGLE,
+			.ca_resil		= DAOS_RES_EC,
+			.ca_grp_nr		= 1,
+			.ca_ec_k		= 4,
+			.ca_ec_p		= 2,
+			.ca_ec_cell		= 1 << 15,
 		},
 	},
 	{

--- a/src/object/obj_internal.h
+++ b/src/object/obj_internal.h
@@ -151,6 +151,10 @@ struct obj_reasb_req {
 	struct obj_tgt_oiod		*tgt_oiods;
 	/* IO failure information */
 	struct obj_ec_fail_info		*orr_fail;
+	/* object ID */
+	daos_obj_id_t			 orr_oid;
+	/* #iods of IO req */
+	uint32_t			 orr_iod_nr;
 	/* for data recovery flag */
 	uint32_t			 orr_recov:1,
 	/* for iod_size fetching flag */

--- a/src/tests/daos_perf.c
+++ b/src/tests/daos_perf.c
@@ -79,8 +79,8 @@ bool			 ts_verify_fetch;
 bool			 ts_shuffle	= false;
 
 daos_handle_t		*ts_ohs;		/* all opened objects */
-daos_obj_id_t		 ts_oid;		/* object ID */
-daos_unit_oid_t		 ts_uoid;		/* object shard ID (for VOS) */
+daos_obj_id_t		*ts_oids;		/* object IDs */
+daos_unit_oid_t		*ts_uoids;		/* object shard IDs (for VOS) */
 
 struct dts_context	 ts_ctx;
 bool			 ts_nest_iterator;
@@ -170,35 +170,36 @@ do {						\
 } while (0)
 
 static int
-_vos_update_or_fetch(enum ts_op_type op_type, struct dts_io_credit *cred,
-		     daos_epoch_t epoch, double *duration)
+_vos_update_or_fetch(int obj_idx, enum ts_op_type op_type,
+		     struct dts_io_credit *cred, daos_epoch_t epoch,
+		     double *duration)
 {
-	uint64_t start = 0;
-	int	 rc = 0;
+	uint64_t	start = 0;
+	int		rc = 0;
 
 	TS_TIME_START(duration, start);
 	if (!ts_zero_copy) {
 		if (op_type == TS_DO_UPDATE)
-			rc = vos_obj_update(ts_ctx.tsc_coh, ts_uoid, epoch, 0,
-					    0, &cred->tc_dkey, 1, &cred->tc_iod,
-					    NULL, &cred->tc_sgl);
+			rc = vos_obj_update(ts_ctx.tsc_coh, ts_uoids[obj_idx],
+					    epoch, 0, 0, &cred->tc_dkey, 1,
+					    &cred->tc_iod, NULL, &cred->tc_sgl);
 		else
-			rc = vos_obj_fetch(ts_ctx.tsc_coh, ts_uoid, epoch,
-					   0, &cred->tc_dkey, 1,
-					   &cred->tc_iod,
-					   &cred->tc_sgl);
+			rc = vos_obj_fetch(ts_ctx.tsc_coh, ts_uoids[obj_idx],
+					   epoch, 0, &cred->tc_dkey, 1,
+					   &cred->tc_iod, &cred->tc_sgl);
 	} else { /* zero-copy */
 		struct bio_sglist	*bsgl;
 		daos_handle_t		 ioh;
 
 		if (op_type == TS_DO_UPDATE)
-			rc = vos_update_begin(ts_ctx.tsc_coh, ts_uoid, epoch, 0,
-					      &cred->tc_dkey, 1, &cred->tc_iod,
-					      NULL, &ioh, NULL);
+			rc = vos_update_begin(ts_ctx.tsc_coh, ts_uoids[obj_idx],
+					      epoch, 0, &cred->tc_dkey, 1,
+					      &cred->tc_iod, NULL, &ioh, NULL);
 		else
-			rc = vos_fetch_begin(ts_ctx.tsc_coh, ts_uoid, epoch, 0,
-					     &cred->tc_dkey, 1, &cred->tc_iod,
-					     0, NULL, &ioh, NULL);
+			rc = vos_fetch_begin(ts_ctx.tsc_coh, ts_uoids[obj_idx],
+					     epoch, 0, &cred->tc_dkey, 1,
+					     &cred->tc_iod, 0, NULL, &ioh,
+					     NULL);
 		if (rc)
 			return rc;
 
@@ -234,11 +235,12 @@ end:
 }
 
 struct vos_ult_arg {
-	enum ts_op_type op_type;
-	struct dts_io_credit *cred;
-	daos_epoch_t	epoch;
-	double		*duration;
-	int		status;
+	struct dts_io_credit	*cred;
+	double			*duration;
+	daos_epoch_t		 epoch;
+	enum ts_op_type		 op_type;
+	int			 obj_idx;
+	int			 status;
 };
 
 static void
@@ -246,26 +248,29 @@ vos_update_or_fetch_ult(void *arg)
 {
 	struct vos_ult_arg *ult_arg = arg;
 
-	ult_arg->status = _vos_update_or_fetch(ult_arg->op_type, ult_arg->cred,
-					       ult_arg->epoch,
-					       ult_arg->duration);
+	ult_arg->status = _vos_update_or_fetch(ult_arg->obj_idx,
+				ult_arg->op_type, ult_arg->cred,
+				ult_arg->epoch, ult_arg->duration);
 }
 
 static int
-vos_update_or_fetch(enum ts_op_type op_type, struct dts_io_credit *cred,
-		    daos_epoch_t epoch, double *duration)
+vos_update_or_fetch(int obj_idx, enum ts_op_type op_type,
+		    struct dts_io_credit *cred, daos_epoch_t epoch,
+		    double *duration)
 {
 	ABT_thread		thread;
 	struct vos_ult_arg	ult_arg;
 	int			rc;
 
 	if (!ts_in_ult)
-		return _vos_update_or_fetch(op_type, cred, epoch, duration);
+		return _vos_update_or_fetch(obj_idx, op_type, cred, epoch,
+					    duration);
 
 	ult_arg.op_type = op_type;
 	ult_arg.cred = cred;
 	ult_arg.epoch = epoch;
 	ult_arg.duration = duration;
+	ult_arg.obj_idx = obj_idx;
 	rc = ABT_thread_create_on_xstream(abt_xstream, vos_update_or_fetch_ult,
 					  &ult_arg, ABT_THREAD_ATTR_NULL,
 					  &thread);
@@ -282,7 +287,7 @@ vos_update_or_fetch(enum ts_op_type op_type, struct dts_io_credit *cred,
 }
 
 static int
-daos_update_or_fetch(daos_handle_t oh, enum ts_op_type op_type,
+daos_update_or_fetch(int obj_idx, enum ts_op_type op_type,
 		     struct dts_io_credit *cred, daos_epoch_t epoch,
 		     double *duration)
 {
@@ -292,13 +297,13 @@ daos_update_or_fetch(daos_handle_t oh, enum ts_op_type op_type,
 	if (!dts_is_async(&ts_ctx))
 		TS_TIME_START(duration, start);
 	if (op_type == TS_DO_UPDATE) {
-		rc = daos_obj_update(oh, DAOS_TX_NONE, 0, &cred->tc_dkey, 1,
-				     &cred->tc_iod, &cred->tc_sgl,
-				     cred->tc_evp);
+		rc = daos_obj_update(ts_ohs[obj_idx], DAOS_TX_NONE, 0,
+				     &cred->tc_dkey, 1, &cred->tc_iod,
+				     &cred->tc_sgl, cred->tc_evp);
 	} else {
-		rc = daos_obj_fetch(oh, DAOS_TX_NONE, 0, &cred->tc_dkey, 1,
-				    &cred->tc_iod, &cred->tc_sgl, NULL,
-				    cred->tc_evp);
+		rc = daos_obj_fetch(ts_ohs[obj_idx], DAOS_TX_NONE, 0,
+				    &cred->tc_dkey, 1, &cred->tc_iod,
+				    &cred->tc_sgl, NULL, cred->tc_evp);
 	}
 
 	if (!dts_is_async(&ts_ctx))
@@ -317,7 +322,7 @@ set_value_buffer(char *buffer, int idx)
 }
 
 static int
-akey_update_or_fetch(daos_handle_t oh, enum ts_op_type op_type,
+akey_update_or_fetch(int obj_idx, enum ts_op_type op_type,
 		     char *dkey, char *akey, daos_epoch_t *epoch,
 		     uint64_t *indices, int idx, char *verify_buff,
 		     double *duration)
@@ -380,9 +385,11 @@ akey_update_or_fetch(daos_handle_t oh, enum ts_op_type op_type,
 	sgl->sg_nr = 1;
 
 	if (ts_mode == TS_MODE_VOS)
-		rc = vos_update_or_fetch(op_type, cred, *epoch, duration);
+		rc = vos_update_or_fetch(obj_idx, op_type, cred, *epoch,
+					 duration);
 	else
-		rc = daos_update_or_fetch(oh, op_type, cred, *epoch, duration);
+		rc = daos_update_or_fetch(obj_idx, op_type, cred, *epoch,
+					  duration);
 
 	if (rc != 0) {
 		fprintf(stderr, "%s failed. rc=%d, epoch=%"PRIu64"\n",
@@ -404,13 +411,14 @@ akey_update_or_fetch(daos_handle_t oh, enum ts_op_type op_type,
 }
 
 static int
-dkey_update_or_fetch(daos_handle_t oh, enum ts_op_type op_type, char *dkey,
-		     daos_epoch_t *epoch, double *duration)
+dkey_update_or_fetch(enum ts_op_type op_type, char *dkey, daos_epoch_t *epoch,
+		     double *duration)
 {
 	uint64_t	*indices;
 	char		 akey[DTS_KEY_LEN];
 	int		 i;
 	int		 j;
+	int		 k;
 	int		 rc = 0;
 
 	indices = dts_rand_iarr_alloc_set(ts_recx_p_akey, 0, ts_shuffle);
@@ -419,11 +427,13 @@ dkey_update_or_fetch(daos_handle_t oh, enum ts_op_type op_type, char *dkey,
 	for (i = 0; i < ts_akey_p_dkey; i++) {
 		dts_key_gen(akey, DTS_KEY_LEN, "walker");
 		for (j = 0; j < ts_recx_p_akey; j++) {
-			rc = akey_update_or_fetch(oh, op_type, dkey, akey,
-						  epoch, indices, j, NULL,
-						  duration);
-			if (rc)
-				goto failed;
+			for (k = 0; k < ts_obj_p_cont; k++) {
+				rc = akey_update_or_fetch(k, op_type, dkey,
+						akey, epoch, indices, j, NULL,
+						duration);
+				if (rc)
+					goto failed;
+			}
 		}
 	}
 
@@ -433,10 +443,36 @@ failed:
 }
 
 static int
+ts_io_prep(void)
+{
+	int	i;
+	int	rc;
+
+	for (i = 0; i < ts_obj_p_cont; i++) {
+		ts_oids[i] = dts_oid_gen(ts_class, 0, ts_ctx.tsc_mpi_rank);
+		if (ts_class == DAOS_OC_R2S_SPEC_RANK)
+			ts_oids[i] = dts_oid_set_rank(ts_oids[i], RANK_ZERO);
+
+		if (ts_mode == TS_MODE_DAOS || ts_mode == TS_MODE_ECHO) {
+			rc = daos_obj_open(ts_ctx.tsc_coh, ts_oids[i],
+					   DAOS_OO_RW, &ts_ohs[i], NULL);
+			if (rc) {
+				fprintf(stderr, "object open failed\n");
+				return -1;
+			}
+		} else {
+			memset(&ts_uoids[i], 0, sizeof(*ts_uoids));
+			ts_uoids[i].id_pub = ts_oids[i];
+		}
+	}
+
+	return 0;
+}
+
+static int
 objects_update(double *duration, d_rank_t rank)
 {
 	int		i;
-	int		j;
 	int		rc;
 	uint64_t	start = 0;
 	daos_epoch_t	epoch = 1;
@@ -449,33 +485,15 @@ objects_update(double *duration, d_rank_t rank)
 	if (dts_is_async(&ts_ctx))
 		TS_TIME_START(duration, start);
 
-	for (i = 0; i < ts_obj_p_cont; i++) {
-		ts_oid = dts_oid_gen(ts_class, 0, ts_ctx.tsc_mpi_rank);
-		if (ts_class == DAOS_OC_R2S_SPEC_RANK)
-			ts_oid = dts_oid_set_rank(ts_oid, rank);
+	for (i = 0; i < ts_dkey_p_obj; i++) {
+		char	 dkey[DTS_KEY_LEN];
 
-		if (ts_mode == TS_MODE_DAOS || ts_mode == TS_MODE_ECHO) {
-			rc = daos_obj_open(ts_ctx.tsc_coh, ts_oid,
-					   DAOS_OO_RW, &ts_ohs[i], NULL);
-			if (rc) {
-				fprintf(stderr, "object open failed\n");
-				return -1;
-			}
-		} else {
-			memset(&ts_uoid, 0, sizeof(ts_uoid));
-			ts_uoid.id_pub = ts_oid;
-		}
-
-		for (j = 0; j < ts_dkey_p_obj; j++) {
-			char	 dkey[DTS_KEY_LEN];
-
-			dts_key_gen(dkey, DTS_KEY_LEN, "blade");
-			rc = dkey_update_or_fetch(ts_ohs[i], TS_DO_UPDATE, dkey,
-						  &epoch, duration);
-			if (rc)
-				return rc;
-		}
+		dts_key_gen(dkey, DTS_KEY_LEN, "blade");
+		rc = dkey_update_or_fetch(TS_DO_UPDATE, dkey, &epoch, duration);
+		if (rc)
+			return rc;
 	}
+
 	rc = dts_credit_drain(&ts_ctx);
 
 	if (dts_is_async(&ts_ctx))
@@ -485,9 +503,10 @@ objects_update(double *duration, d_rank_t rank)
 }
 
 static int
-dkey_verify(daos_handle_t oh, char *dkey, daos_epoch_t *epoch)
+dkey_verify(char *dkey, daos_epoch_t *epoch)
 {
 	int		 i;
+	int		 j;
 	uint64_t	*indices;
 	char		 ground_truth[TEST_VAL_SIZE];
 	char		 test_string[TEST_VAL_SIZE];
@@ -500,15 +519,20 @@ dkey_verify(daos_handle_t oh, char *dkey, daos_epoch_t *epoch)
 
 	for (i = 0; i < ts_recx_p_akey; i++) {
 		set_value_buffer(ground_truth, i);
-		rc = akey_update_or_fetch(oh, TS_DO_FETCH, dkey, akey, epoch,
-					  indices, i, test_string, NULL);
-		if (rc)
-			goto failed;
-		if (memcmp(test_string, ground_truth, TEST_VAL_SIZE) != 0) {
-			D_PRINT("MISMATCH! ground_truth=%s, test_string=%s\n",
-				ground_truth, test_string);
-			rc = -1;
-			goto failed;
+		for (j = 0; j < ts_obj_p_cont; j++) {
+			rc = akey_update_or_fetch(j, TS_DO_FETCH, dkey, akey,
+						  epoch, indices, i,
+						  test_string, NULL);
+			if (rc)
+				goto failed;
+			if (memcmp(test_string, ground_truth, TEST_VAL_SIZE)
+			    != 0) {
+				D_PRINT("MISMATCH! ground_truth=%s, "
+					"test_string=%s\n",
+					ground_truth, test_string);
+				rc = -1;
+				goto failed;
+			}
 		}
 	}
 failed:
@@ -519,7 +543,6 @@ failed:
 static int
 objects_verify(void)
 {
-	int		i;
 	int		j;
 	int		k;
 	int		rc = 0;
@@ -529,16 +552,16 @@ objects_verify(void)
 	dts_reset_key();
 	if (!ts_overwrite)
 		++epoch;
-	for (i = 0; i < ts_obj_p_cont; i++) {
-		for (j = 0; j < ts_dkey_p_obj; j++) {
-			dts_key_gen(dkey, DTS_KEY_LEN, "blade");
-			for (k = 0; k < ts_akey_p_dkey; k++) {
-				rc = dkey_verify(ts_ohs[i], dkey, &epoch);
-				if (rc != 0)
-					return rc;
-			}
+
+	for (j = 0; j < ts_dkey_p_obj; j++) {
+		dts_key_gen(dkey, DTS_KEY_LEN, "blade");
+		for (k = 0; k < ts_akey_p_dkey; k++) {
+			rc = dkey_verify(dkey, &epoch);
+			if (rc != 0)
+				return rc;
 		}
 	}
+
 	rc = dts_credit_drain(&ts_ctx);
 	return rc;
 }
@@ -570,7 +593,6 @@ static int
 objects_fetch(double *duration, d_rank_t rank)
 {
 	int		i;
-	int		j;
 	int		rc = 0;
 	uint64_t	start = 0;
 	daos_epoch_t	epoch = crt_hlc_get();
@@ -582,17 +604,15 @@ objects_fetch(double *duration, d_rank_t rank)
 	if (dts_is_async(&ts_ctx))
 		TS_TIME_START(duration, start);
 
-	for (i = 0; i < ts_obj_p_cont; i++) {
-		for (j = 0; j < ts_dkey_p_obj; j++) {
-			char	 dkey[DTS_KEY_LEN];
+	for (i = 0; i < ts_dkey_p_obj; i++) {
+		char	 dkey[DTS_KEY_LEN];
 
-			dts_key_gen(dkey, DTS_KEY_LEN, "blade");
-			rc = dkey_update_or_fetch(ts_ohs[i], TS_DO_FETCH, dkey,
-						  &epoch, duration);
-			if (rc != 0)
-				return rc;
-		}
+		dts_key_gen(dkey, DTS_KEY_LEN, "blade");
+		rc = dkey_update_or_fetch(TS_DO_FETCH, dkey, &epoch, duration);
+		if (rc != 0)
+			return rc;
 	}
+
 	rc = dts_credit_drain(&ts_ctx);
 
 	if (dts_is_async(&ts_ctx))
@@ -699,7 +719,7 @@ ts_iterate_records_internal(double *duration, d_rank_t rank)
 
 	/* prepare iterate parameters */
 	param.ip_hdl = ts_ctx.tsc_coh;
-	param.ip_oid = ts_uoid;
+	param.ip_oid = ts_uoids[0];
 
 	param.ip_epr.epr_lo = 0;
 	param.ip_epr.epr_hi = DAOS_EPOCH_MAX;
@@ -712,8 +732,13 @@ ts_iterate_records_internal(double *duration, d_rank_t rank)
 }
 
 static int
-ts_prep_update(void)
+ts_prep_fetch(void)
 {
+	int	rc;
+
+	rc = ts_io_prep();
+	if (rc)
+		return rc;
 	return objects_update(NULL, RANK_ZERO);
 }
 
@@ -1041,9 +1066,10 @@ void show_result(double duration, uint64_t start, uint64_t end,
 			   MPI_MIN, 0, MPI_COMM_WORLD);
 		MPI_Reduce(&end, &last_end, 1, MPI_UINT64_T,
 			   MPI_MAX, 0, MPI_COMM_WORLD);
-		agg_duration = (last_end - first_start) / (1000 * 1000 * 1000);
+		agg_duration = (last_end - first_start) /
+			       (1000.0 * 1000 * 1000);
 	} else {
-		agg_duration = duration / (1000 * 1000);
+		agg_duration = duration / (1000.0 * 1000);
 	}
 
 	/* nano sec to sec */
@@ -1254,15 +1280,17 @@ main(int argc, char **argv)
 			strncpy(ts_pmem_file, optarg, PATH_MAX - 1);
 			break;
 		case 'U':
+			perf_tests_prep[UPDATE_TEST] = ts_io_prep;
 			perf_tests[UPDATE_TEST] = ts_write_perf;
 			perf_tests_post[UPDATE_TEST] = ts_post_verify;
 			break;
 		case 'F':
-			perf_tests_prep[FETCH_TEST] = ts_prep_update;
+			perf_tests_prep[FETCH_TEST] = ts_prep_fetch;
 			perf_tests[FETCH_TEST] = ts_fetch_perf;
 			perf_tests_post[FETCH_TEST] = ts_post_verify;
 			break;
 		case 'R':
+			perf_tests_prep[REBUILD_TEST] = ts_io_prep;
 			perf_tests[REBUILD_TEST] = ts_rebuild_perf;
 			break;
 		case 'i':
@@ -1272,7 +1300,7 @@ main(int argc, char **argv)
 			ts_rebuild_no_update = true;
 			break;
 		case 'B':
-			perf_tests_prep[UPDATE_FETCH_TEST] = ts_prep_update;
+			perf_tests_prep[UPDATE_FETCH_TEST] = ts_prep_fetch;
 			perf_tests[UPDATE_FETCH_TEST] = ts_update_fetch_perf;
 			perf_tests_post[UPDATE_FETCH_TEST] = ts_post_verify;
 			break;
@@ -1321,8 +1349,11 @@ main(int argc, char **argv)
 	if (perf_tests[REBUILD_TEST] == NULL &&
 	    perf_tests[FETCH_TEST] == NULL && perf_tests[UPDATE_TEST] == NULL &&
 	    perf_tests[UPDATE_FETCH_TEST] == NULL &&
-	    perf_tests[ITERATE_TEST] == NULL)
+	    perf_tests[ITERATE_TEST] == NULL) {
+		perf_tests_prep[UPDATE_TEST] = ts_io_prep;
 		perf_tests[UPDATE_TEST] = ts_write_perf;
+		perf_tests_post[UPDATE_TEST] = ts_post_verify;
+	}
 
 	if ((perf_tests[FETCH_TEST] != NULL ||
 	     perf_tests[UPDATE_FETCH_TEST] != NULL) && ts_overwrite) {
@@ -1394,7 +1425,7 @@ main(int argc, char **argv)
 	D_ASSERT(oca != NULL);
 	if (DAOS_OC_IS_EC(oca))
 		ec_vsize = oca->u.ec.e_len * oca->u.ec.e_k;
-	if (ec_vsize != 0 && vsize % ec_vsize != 0)
+	if (ec_vsize != 0 && vsize % ec_vsize != 0 && ts_ctx.tsc_mpi_rank == 0)
 		fprintf(stdout, "for EC obj perf test, vsize (-s) %d should be "
 			"multiple of %d (full-stripe size) to get better "
 			"performance.\n", vsize, ec_vsize);
@@ -1438,7 +1469,9 @@ main(int argc, char **argv)
 	}
 
 	ts_ohs = calloc(ts_obj_p_cont, sizeof(*ts_ohs));
-	if (!ts_ohs) {
+	ts_oids = calloc(ts_obj_p_cont, sizeof(*ts_oids));
+	ts_uoids = calloc(ts_obj_p_cont, sizeof(*ts_uoids));
+	if (!ts_ohs || !ts_oids || !ts_uoids) {
 		fprintf(stderr, "failed to allocate %u open handles\n",
 			ts_obj_p_cont);
 		return -1;

--- a/src/tests/daos_perf.c
+++ b/src/tests/daos_perf.c
@@ -946,7 +946,7 @@ The options are as follows:\n\
 	and 64. The utility runs in synchronous mode if credits is set to 0.\n\
 	This option is ignored for mode 'vos'.\n\
 \n\
--c TINY|LARGE|R2S|R3S|R4S|EC2P2|EC4P2|EC8P2\n\
+-c TINY|LARGE|R2S|R3S|R4S|EC2P1|EC2P2|EC4P2|EC8P2\n\
 	Object class for DAOS full stack test.\n\
 \n\
 -o number\n\
@@ -1188,7 +1188,9 @@ main(int argc, char **argv)
 				ts_class = OC_S1;
 			} else if (!strcasecmp(optarg, "LARGE")) {
 				ts_class = OC_SX;
-			} else if (!strcasecmp(optarg, "EC2P2")) {
+			} else if (!strcasecmp(optarg, "EC2P1")) {
+				ts_class = OC_EC_2P1G1;
+			} else if (!strcasecmp(optarg, "EC2P")) {
 				ts_class = OC_EC_2P2G1;
 			} else if (!strcasecmp(optarg, "EC4P2")) {
 				ts_class = OC_EC_4P2G1;

--- a/src/tests/suite/daos_epoch_io.c
+++ b/src/tests/suite/daos_epoch_io.c
@@ -1246,13 +1246,13 @@ cmd_line_parse(test_arg_t *arg, const char *cmd_line,
 			arg->eio_args.op_ec = 1;
 			if ((argc == 3 && strcmp(argv[2], "OC_EC_2P2G1") == 0)
 			    || argc == 2) {
-				print_message("EC obj class OC_EC_2P2G1\n");
-				dts_ec_obj_class = OC_EC_2P2G1;
+				print_message("EC obj class OC_EC_2P2G1_32K\n");
+				dts_ec_obj_class = OC_EC_2P2G1_32K;
 				dts_ec_grp_size = 4;
 			} else if (argc == 3 &&
 				   strcmp(argv[2], "OC_EC_4P2G1") == 0) {
-				print_message("EC obj class OC_EC_4P2G1\n");
-				dts_ec_obj_class = OC_EC_4P2G1;
+				print_message("EC obj class OC_EC_4P2G1_32K\n");
+				dts_ec_obj_class = OC_EC_4P2G1_32K;
 				dts_ec_grp_size = 6;
 			} else {
 				print_message("bad parameter");


### PR DESCRIPTION
1. Add two EC obj classes with 32K cell size for EC degraded test.
2. A slight change to EC encoding (define obj_ec_encode()).
3. fix a bug in daos_perf time calculation for multiple ranks.
4. For daos_perf benchmark, move the obj switch to 1st level loop
    to make the IO send to different objects firstly. When testing with
    multiple objects, the load balance is better for example EC obj IO's
    leader server can be evenly distributed.
5. Add EC2P1 obj class to daos_perf

Signed-off-by: Xuezhao Liu <xuezhao.liu@intel.com>