### PR TITLE
DAOS-5304 build: fix python syntax post commit 35fea9b

### DIFF
--- a/src/tests/suite/SConscript
+++ b/src/tests/suite/SConscript
@@ -33,11 +33,13 @@ def CheckCmockaSkip(context):
     context.Message('Checking if cmocka skip() bug is present ... ')
     rc = context.TryCompile(test_cmocka_skip, '.c')
     if rc == 0:
-        print(" (Compile failed) assuming ", context.Result(not rc))
+        print(" (Compile failed) assuming ")
+        context.Result(not rc)
         return rc
     rc = context.TryLink(test_cmocka_skip, '.c')
     if rc == 0:
-        print(" (Link failed) assuming ", context.Result(not rc))
+        print(" (Link failed) assuming ")
+        context.Result(not rc)
         return rc
     prog = context.lastTarget
     pname = prog.get_abspath()
@@ -45,12 +47,13 @@ def CheckCmockaSkip(context):
                          stderr=DEVNULL)
     #in case of abort rc is -6 instead of 134 (128+6) with shell ...
     if rc == -6:
-        print(" (Bug reproduced) ", context.Result(rc))
+        print(" (Bug reproduced) ")
     else:
         if rc != 0:
-            print(" (Other error than bug) assuming ", context.Result(rc))
+            print(" (Other error than bug) assuming ")
         else:
-            print(" (Bug not reproduced) ", context.Result(rc))
+            print(" (Bug not reproduced) ")
+    context.Result(rc)
     #return 0 means error
     return not rc
 


### PR DESCRIPTION
commit 35fea9b54c20b09539cea1fdba34f7bdb4e14505, submitted
to apply changes to original python code and make it also
compatible with python3, has introduced a regression causing
wrong msgs to be output during build.

Change-Id: I16098e54bc8f07a4506fe96075c0f34f164abb91
Signed-off-by: Bruno Faccini <bruno.faccini@intel.com>