### PR TITLE
DAOS-5319: Adding maximum SCM/NVMe pool size ratio to current test.

### DIFF
--- a/src/tests/ftest/pool/storage_ratio.yaml
+++ b/src/tests/ftest/pool/storage_ratio.yaml
@@ -47,3 +47,4 @@ pool:
     - ['16', '100G', 'FAIL']    # Low SCM Size
     - ['1G', '200G', 'WARNING'] # SCM Size ratio is less than 1%
     - ['6G', '650G', 'WARNING'] # SCM Size ratio is less than 1%
+    - ['650G', '650G', 'PASS']  # SCM Size ratio should be 100%


### PR DESCRIPTION
Test-tag-hw-medium: storage_ratio

Signed-off-by: Samir Raval <samir.raval@intel.com>