### PR TITLE
DAOS-4257 EC: a few fixes for EC

### DIFF
--- a/src/include/daos/object.h
+++ b/src/include/daos/object.h
@@ -431,6 +431,7 @@ enum daos_recx_type {
 struct daos_recx_ep {
 	daos_recx_t	re_recx;
 	daos_epoch_t	re_ep;
+	uint32_t	re_rec_size;
 	uint8_t		re_type;
 };
 

--- a/src/object/cli_ec.c
+++ b/src/object/cli_ec.c
@@ -1657,7 +1657,7 @@ obj_ec_recov_add(struct obj_reasb_req *reasb_req,
 				return rc;
 		}
 	}
-	daos_recx_ep_list_set_ep_valid(dst_list, nr);
+	daos_recx_ep_list_set_ep_valid(recov_lists, nr);
 	return 0;
 }
 
@@ -2007,7 +2007,7 @@ obj_ec_recov_task_init(struct obj_reasb_req *reasb_req, daos_obj_id_t oid,
 			rtask = &fail_info->efi_recov_tasks[tidx++];
 			rtask->ert_iod.iod_name = iod->iod_name;
 			rtask->ert_iod.iod_type = iod->iod_type;
-			rtask->ert_iod.iod_size = iod->iod_size;
+			rtask->ert_iod.iod_size = recx_ep->re_rec_size;
 			rtask->ert_iod.iod_nr = 1;
 			rtask->ert_iod.iod_recxs = &recx_ep->re_recx;
 			rtask->ert_epoch = recx_ep->re_ep;

--- a/src/object/obj_rpc.c
+++ b/src/object/obj_rpc.c
@@ -400,12 +400,13 @@ crt_proc_struct_daos_recx_ep_list(crt_proc_t proc,
 	rc = crt_proc_uint32_t(proc, &list->re_nr);
 	if (rc != 0)
 		return -DER_HG;
-	if (list->re_nr == 0)
-		return 0;
 
 	rc = crt_proc_bool(proc, &list->re_ep_valid);
 	if (rc != 0)
 		return -DER_HG;
+
+	if (list->re_nr == 0)
+		return 0;
 
 	switch (proc_op) {
 	case CRT_PROC_DECODE:
@@ -420,16 +421,20 @@ crt_proc_struct_daos_recx_ep_list(crt_proc_t proc,
 			if (rc != 0)
 				return -DER_HG;
 
-			rc = crt_proc_uint8_t(proc, &list->re_items[i].re_type);
-			if (rc != 0)
-				return -DER_HG;
-
 			if (list->re_ep_valid) {
 				rc = crt_proc_daos_epoch_t(proc,
 						&list->re_items[i].re_ep);
 				if (rc != 0)
 					return -DER_HG;
 			}
+			rc = crt_proc_uint32_t(proc,
+					&list->re_items[i].re_rec_size);
+			if (rc != 0)
+				return -DER_HG;
+
+			rc = crt_proc_uint8_t(proc, &list->re_items[i].re_type);
+			if (rc != 0)
+				return -DER_HG;
 		}
 		break;
 	default: /* CRT_PROC_FREE */

--- a/src/vos/vos_io.c
+++ b/src/vos/vos_io.c
@@ -479,7 +479,7 @@ biov_align_lens(struct bio_iov *biov, struct evt_entry *ent, daos_size_t rsize)
  */
 static int
 save_recx(struct vos_io_context *ioc, uint64_t rx_idx, uint64_t rx_nr,
-	  daos_epoch_t ep, int type)
+	  daos_epoch_t ep, uint32_t rec_size, int type)
 {
 	struct daos_recx_ep_list	*recx_list;
 	struct daos_recx_ep		 recx_ep;
@@ -495,6 +495,7 @@ save_recx(struct vos_io_context *ioc, uint64_t rx_idx, uint64_t rx_nr,
 	recx_ep.re_recx.rx_nr = rx_nr;
 	recx_ep.re_ep = ep;
 	recx_ep.re_type = type;
+	recx_ep.re_rec_size = rec_size;
 
 	return daos_recx_ep_add(recx_list, &recx_ep);
 }
@@ -560,7 +561,8 @@ akey_fetch_recx(daos_handle_t toh, const daos_epoch_range_t *epr,
 		if (holes != 0) {
 			if (with_shadow) {
 				rc = save_recx(ioc, lo - holes, holes,
-					       shadow_ep, DRT_SHADOW);
+					       shadow_ep, ent_array.ea_inob,
+					       DRT_SHADOW);
 				if (rc != 0)
 					goto failed;
 			}
@@ -577,7 +579,8 @@ akey_fetch_recx(daos_handle_t toh, const daos_epoch_range_t *epr,
 		D_ASSERT(rsize == ent_array.ea_inob);
 
 		if (ioc->ic_save_recx) {
-			rc = save_recx(ioc, lo, nr, ent->en_epoch, DRT_NORMAL);
+			rc = save_recx(ioc, lo, nr, ent->en_epoch,
+				       ent_array.ea_inob, DRT_NORMAL);
 			if (rc != 0)
 				goto failed;
 		}
@@ -610,7 +613,7 @@ akey_fetch_recx(daos_handle_t toh, const daos_epoch_range_t *epr,
 	if (holes != 0) { /* trailing holes */
 		if (with_shadow) {
 			rc = save_recx(ioc, end - holes, holes, shadow_ep,
-				       DRT_SHADOW);
+				       ent_array.ea_inob, DRT_SHADOW);
 			if (rc != 0)
 				goto failed;
 		}


### PR DESCRIPTION
1. A minor fix in proc recx_ep_list to make sure
re_ep_valid is processed in any cases.

2. Add re_rec_size for shadow extent list, since
shadow iod_size may not return correctly by normal fetch.

3. a minor fix in recov_add to make sure all recov lists
are initialized correctly.

Signed-off-by: Di Wang <di.wang@intel.com>