### PR TITLE
DAOS-5302 vos: Don't ignore -DER_REC2BIG issue

### DIFF
--- a/src/bio/bio_buffer.c
+++ b/src/bio/bio_buffer.c
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2018-2019 Intel Corporation.
+ * (C) Copyright 2018-2020 Intel Corporation.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -321,6 +321,8 @@ iterate_biov(struct bio_desc *biod,
 			if (rc)
 				break;
 		}
+		if (rc)
+			break;
 	}
 
 	return rc;
@@ -859,7 +861,7 @@ copy_one(struct bio_desc *biod, struct bio_iov *biov,
 	}
 
 	D_DEBUG(DB_TRACE, "Consumed all iovs, "DF_U64" bytes left\n", size);
-	return -DER_OVERFLOW;
+	return -DER_REC2BIG;
 }
 
 static void


### PR DESCRIPTION
biod_iod_copy was ignoring the return code for a given
akey so silently ignoring the fact that the supplied
buffer is too small.

Co-authored-by: Mohamad Chaarawi <mohamad.chaarawi@intel.com>
Signed-off-by: Jeff Olivier <jeffrey.v.olivier@intel.com>