### PR TITLE
DAOS-5322 test: Fix OSA reintegration bug.

### DIFF
--- a/src/tests/ftest/osa/osa_online_reintegration.yaml
+++ b/src/tests/ftest/osa/osa_online_reintegration.yaml
@@ -28,7 +28,7 @@ container:
   properties:
     enable_checksum: True
 ior:
-  no_parallel_job: 5
+  no_parallel_job: 3
   clientslots:
     slots: 2
   test_file: daos:testFile

--- a/src/tests/ftest/osa/osa_online_reintegration.yaml
+++ b/src/tests/ftest/osa/osa_online_reintegration.yaml
@@ -28,7 +28,7 @@ container:
   properties:
     enable_checksum: True
 ior:
-  no_parallel_job: 10
+  no_parallel_job: 5
   clientslots:
     slots: 2
   test_file: daos:testFile

--- a/src/tests/ftest/osa/osa_online_reintegration.yaml
+++ b/src/tests/ftest/osa/osa_online_reintegration.yaml
@@ -20,15 +20,15 @@ server_config:
 pool:
   mode: 146
   name: daos_server
-  scm_size: 6000000000
-  nvme_size: 54000000000
+  scm_size: 12000000000
+  nvme_size: 108000000000
   svcn: 4
   control_method: dmg
 container:
   properties:
     enable_checksum: True
 ior:
-  no_parallel_job: 3
+  no_parallel_job: 10
   clientslots:
     slots: 2
   test_file: daos:testFile


### PR DESCRIPTION
Summary: Online Server Reintegration test fails under CI with NOSPACE reported by IOR.
Increasing the pool scm/nvme size to address NOSPACE issue.
Signed-off-by: Padmanabhan <ravindran.padmanabhan@intel.com>