### PR TITLE
DAOS-5195 cart: Add HLC Tracker

### DIFF
--- a/src/cart/src/cart/SConscript
+++ b/src/cart/src/cart/SConscript
@@ -36,7 +36,7 @@ SRC = ['crt_bulk.c', 'crt_context.c', 'crt_corpc.c',
        'crt_init.c', 'crt_iv.c', 'crt_register.c',
        'crt_rpc.c', 'crt_self_test_client.c', 'crt_self_test_service.c',
        'crt_swim.c', 'crt_tree.c', 'crt_tree_flat.c', 'crt_tree_kary.c',
-       'crt_tree_knomial.c', 'crt_hlc.c']
+       'crt_tree_knomial.c', 'crt_hlc.c', 'crt_hlct.c']
 
 # pylint: disable=unused-argument
 def macro_expand(target, source, env):

--- a/src/cart/src/cart/crt_hg_proc.c
+++ b/src/cart/src/cart/crt_hg_proc.c
@@ -405,6 +405,8 @@ crt_hg_unpack_header(hg_handle_t handle, struct crt_rpc_priv *rpc_priv,
 		D_ERROR("crt_proc_common_hdr failed rc: %d.\n", rc);
 		D_GOTO(out, rc);
 	}
+	/* Clients never decode requests. */
+	D_ASSERT(crt_is_service());
 	(void)crt_hlc_get_msg(rpc_priv->crp_req_hdr.cch_hlc);
 	rpc_priv->crp_flags = rpc_priv->crp_req_hdr.cch_flags;
 	if (rpc_priv->crp_flags & CRT_RPC_FLAG_COLL) {
@@ -526,16 +528,23 @@ crt_proc_in_common(crt_proc_t proc, crt_rpc_input_t *data)
 						);
 			hdr->cch_dst_tag = rpc_priv->crp_pub.cr_ep.ep_tag;
 
-			if (crt_is_service())
+			if (crt_is_service()) {
 				hdr->cch_src_rank =
 					crt_grp_priv_get_primary_rank(
 						rpc_priv->crp_grp_priv,
 						rpc_priv->crp_grp_priv->gp_self
 						);
-			else
+				hdr->cch_hlc = crt_hlc_get();
+			} else {
 				hdr->cch_src_rank = CRT_NO_RANK;
-
-			hdr->cch_hlc = crt_hlc_get();
+				/*
+				 * Because client HLC timestamps shall never be
+				 * used to sync server HLCs, we forward the
+				 * HLCT reading, which must be either zero or a
+				 * server HLC timestamp.
+				 */
+				hdr->cch_hlc = crt_hlct_get();
+			}
 		}
 		rc = crt_proc_common_hdr(proc, &rpc_priv->crp_req_hdr);
 		if (rc != 0) {
@@ -604,16 +613,25 @@ crt_proc_out_common(crt_proc_t proc, crt_rpc_output_t *data)
 	/* D_DEBUG("in crt_proc_out_common, data: %p\n", *data); */
 
 	if (proc_op != CRT_PROC_FREE) {
-		if (proc_op == CRT_PROC_ENCODE)
+		if (proc_op == CRT_PROC_ENCODE) {
+			/* Clients never encode replies. */
+			D_ASSERT(crt_is_service());
 			rpc_priv->crp_reply_hdr.cch_hlc = crt_hlc_get();
+		}
 		rc = crt_proc_common_hdr(proc, &rpc_priv->crp_reply_hdr);
 		if (rc != 0) {
 			RPC_ERROR(rpc_priv,
 				  "crt_proc_common_hdr failed rc: %d\n", rc);
 			D_GOTO(out, rc);
 		}
-		if (proc_op == CRT_PROC_DECODE)
-			(void)crt_hlc_get_msg(rpc_priv->crp_reply_hdr.cch_hlc);
+		if (proc_op == CRT_PROC_DECODE) {
+			uint64_t t = rpc_priv->crp_reply_hdr.cch_hlc;
+
+			if (crt_is_service())
+				crt_hlc_get_msg(t);
+			else
+				crt_hlct_sync(t);
+		}
 		if (rpc_priv->crp_reply_hdr.cch_rc != 0) {
 			RPC_ERROR(rpc_priv,
 				  "RPC failed to execute on target. error code: %d\n",

--- a/src/cart/src/cart/crt_hlct.c
+++ b/src/cart/src/cart/crt_hlct.c
@@ -1,0 +1,64 @@
+/* Copyright (C) 2020 Intel Corporation
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted for any purpose (including commercial purposes)
+ * provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions, and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions, and the following disclaimer in the
+ *    documentation and/or materials provided with the distribution.
+ *
+ * 3. In addition, redistributions of modified forms of the source or binary
+ *    code must carry prominent notices stating that the original code was
+ *    changed and the date of the change.
+ *
+ * 4. All publications or advertising materials mentioning features or use of
+ *    this software are asked, but not required, to acknowledge that it was
+ *    developed by Intel Corporation and credit the contributors.
+ *
+ * 5. Neither the name of Intel Corporation, nor the name of any Contributor
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+/**
+ * This file is part of CaRT. Hybrid Logical Clock Tracker (HLCT)
+ * implementation. An HLCT tracks the highest HLC timestamp the process has
+ * heard of. It never generates any new HLC timestamps.
+ */
+
+#include "crt_internal.h"
+#include <gurt/atomic.h>
+
+static ATOMIC uint64_t crt_hlct;
+
+uint64_t crt_hlct_get(void)
+{
+	return crt_hlct;
+}
+
+void crt_hlct_sync(uint64_t msg)
+{
+	uint64_t hlct, hlct_new;
+
+	do {
+		hlct = crt_hlct;
+		if (hlct >= msg)
+			break;
+		hlct_new = msg;
+	} while (!atomic_compare_exchange(&crt_hlct, hlct, hlct_new));
+}

--- a/src/cart/src/cart/crt_internal_fns.h
+++ b/src/cart/src/cart/crt_internal_fns.h
@@ -56,6 +56,10 @@ int crt_req_timeout_track(struct crt_rpc_priv *rpc_priv);
 void crt_req_timeout_untrack(struct crt_rpc_priv *rpc_priv);
 void crt_req_force_timeout(struct crt_rpc_priv *rpc_priv);
 
+/** crt_hlct.c */
+uint64_t crt_hlct_get(void);
+void crt_hlct_sync(uint64_t msg);
+
 /** some simple helper functions */
 
 static inline bool


### PR DESCRIPTION
Add HLC Tracker (HLCT), a device that tracks the highest HLC timestamp
the process has ever encountered. When sending requests to servers,
clients will forward their HLCT readings, which are either zero or
server HLC timestamps, instead of their HLC readings. When receiving
replies from servers, clients will sync their HLCTs, instead their HLCs,
with HLC timestamps in replies from servers. This isolates server HLCs
from client physical clocks.

Signed-off-by: Li Wei <wei.g.li@intel.com>