### PR TITLE
DAOS-5320 control: Add missing method authorizations

### DIFF
--- a/src/control/security/grpc_authorization.go
+++ b/src/control/security/grpc_authorization.go
@@ -1,5 +1,5 @@
 //
-// (C) Copyright 2019 Intel Corporation.
+// (C) Copyright 2019-2020 Intel Corporation.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -65,13 +65,10 @@ var methodAuthorizations = map[string]Component{
 	"/mgmt.MgmtSvc/PoolEvict":         ComponentAdmin,
 	"/mgmt.MgmtSvc/PoolExtend":        ComponentAdmin,
 	"/mgmt.MgmtSvc/GetAttachInfo":     ComponentAgent,
-	"/mgmt.MgmtSvc/BioHealthQuery":    ComponentAdmin,
-	"/mgmt.MgmtSvc/SmdListDevs":       ComponentAdmin,
-	"/mgmt.MgmtSvc/SmdListPools":      ComponentAdmin,
+	"/mgmt.MgmtSvc/SmdQuery":          ComponentAdmin,
 	"/mgmt.MgmtSvc/ListPools":         ComponentAdmin,
-	"/mgmt.MgmtSvc/DevStateQuery":     ComponentAdmin,
-	"/mgmt.MgmtSvc/StorageSetFaulty":  ComponentAdmin,
 	"/mgmt.MgmtSvc/ListContainers":    ComponentAdmin,
+	"/mgmt.MgmtSvc/ContSetOwner":      ComponentAdmin,
 	"/mgmt.MgmtSvc/PrepShutdownRanks": ComponentServer,
 	"/mgmt.MgmtSvc/StopRanks":         ComponentServer,
 	"/mgmt.MgmtSvc/PingRanks":         ComponentServer,

--- a/src/control/security/grpc_authorization_test.go
+++ b/src/control/security/grpc_authorization_test.go
@@ -114,16 +114,17 @@ func TestSecurity_ComponentHasAccess(t *testing.T) {
 		}
 	}
 	if len(invalid) > 0 {
-		t.Fatalf("%s has test cases for the following invalid methods:\n%s", t.Name(), strings.Join(invalid, "\n"))
+		t.Fatalf("%s has test cases for the following methods that are not in methodAuthorizations:\n%s", t.Name(), strings.Join(invalid, "\n"))
 	}
 
 	for method, correctComponent := range testCases {
-		t.Run(method, func(t *testing.T) {
+		methodName := strings.SplitAfterN(method, "/", 3)[2]
+		t.Run(methodName, func(t *testing.T) {
 			for _, comp := range allComponents {
 				if comp == correctComponent {
-					common.AssertTrue(t, comp.HasAccess(method), fmt.Sprintf("%s should have access to %s but does not", comp, method))
+					common.AssertTrue(t, comp.HasAccess(method), fmt.Sprintf("%s should have access to %s but does not", comp, methodName))
 				} else {
-					common.AssertFalse(t, comp.HasAccess(method), fmt.Sprintf("%s should not have access to %s but does", comp, method))
+					common.AssertFalse(t, comp.HasAccess(method), fmt.Sprintf("%s should not have access to %s but does", comp, methodName))
 				}
 			}
 		})

--- a/src/control/security/grpc_authorization_test.go
+++ b/src/control/security/grpc_authorization_test.go
@@ -1,5 +1,5 @@
 //
-// (C) Copyright 2019 Intel Corporation.
+// (C) Copyright 2019-2020 Intel Corporation.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -25,12 +25,16 @@ package security
 
 import (
 	"fmt"
+	"reflect"
+	"strings"
 	"testing"
 
 	"github.com/daos-stack/daos/src/control/common"
+	ctlpb "github.com/daos-stack/daos/src/control/common/proto/ctl"
+	mgmtpb "github.com/daos-stack/daos/src/control/common/proto/mgmt"
 )
 
-func TestCommonNameToComponent(t *testing.T) {
+func TestSecurity_CommonNameToComponent(t *testing.T) {
 	testCases := []struct {
 		testname   string
 		commonname string
@@ -53,64 +57,151 @@ func TestCommonNameToComponent(t *testing.T) {
 	}
 }
 
-func TestHasAccess(t *testing.T) {
-	allComponents := [4]Component{ComponentUndefined, ComponentAdmin, ComponentAgent, ComponentServer}
-	testCases := []struct {
-		testname         string
-		correctComponent Component
-		method           string
-	}{
-		{"StoragePrepare", ComponentAdmin, "/ctl.MgmtCtl/StoragePrepare"},
-		{"StorageScan", ComponentAdmin, "/ctl.MgmtCtl/StorageScan"},
-		{"StorageFormat", ComponentAdmin, "/ctl.MgmtCtl/StorageFormat"},
-		{"SystemQuery", ComponentAdmin, "/ctl.MgmtCtl/SystemQuery"},
-		{"SystemStop", ComponentAdmin, "/ctl.MgmtCtl/SystemStop"},
-		{"SystemResetFormat", ComponentAdmin, "/ctl.MgmtCtl/SystemResetFormat"},
-		{"SystemStart", ComponentAdmin, "/ctl.MgmtCtl/SystemStart"},
-		{"NetworkScan", ComponentAdmin, "/ctl.MgmtCtl/NetworkScan"},
-		{"FirmwareQuery", ComponentAdmin, "/ctl.MgmtCtl/FirmwareQuery"},
-		{"FirmwareUpdate", ComponentAdmin, "/ctl.MgmtCtl/FirmwareUpdate"},
-		{"Join", ComponentServer, "/mgmt.MgmtSvc/Join"},
-		{"LeaderQuery", ComponentAdmin, "/mgmt.MgmtSvc/LeaderQuery"},
-		{"PoolCreate", ComponentAdmin, "/mgmt.MgmtSvc/PoolCreate"},
-		{"PoolDestroy", ComponentAdmin, "/mgmt.MgmtSvc/PoolDestroy"},
-		{"PoolQuery", ComponentAdmin, "/mgmt.MgmtSvc/PoolQuery"},
-		{"PoolSetProp", ComponentAdmin, "/mgmt.MgmtSvc/PoolSetProp"},
-		{"PoolGetACL", ComponentAdmin, "/mgmt.MgmtSvc/PoolGetACL"},
-		{"PoolOverwriteACL", ComponentAdmin, "/mgmt.MgmtSvc/PoolOverwriteACL"},
-		{"PoolUpdateACL", ComponentAdmin, "/mgmt.MgmtSvc/PoolUpdateACL"},
-		{"PoolDeleteACL", ComponentAdmin, "/mgmt.MgmtSvc/PoolDeleteACL"},
-		{"PoolExclude", ComponentAdmin, "/mgmt.MgmtSvc/PoolExclude"},
-		{"PoolDrain", ComponentAdmin, "/mgmt.MgmtSvc/PoolDrain"},
-		{"PoolReintegrate", ComponentAdmin, "/mgmt.MgmtSvc/PoolReintegrate"},
-		{"PoolEvict", ComponentAdmin, "/mgmt.MgmtSvc/PoolEvict"},
-		{"PoolExtend", ComponentAdmin, "/mgmt.MgmtSvc/PoolExtend"},
-		{"GetAttachInfo", ComponentAgent, "/mgmt.MgmtSvc/GetAttachInfo"},
-		{"BioHealthQuery", ComponentAdmin, "/mgmt.MgmtSvc/BioHealthQuery"},
-		{"SmdListDevs", ComponentAdmin, "/mgmt.MgmtSvc/SmdListDevs"},
-		{"SmdListPools", ComponentAdmin, "/mgmt.MgmtSvc/SmdListPools"},
-		{"ListPools", ComponentAdmin, "/mgmt.MgmtSvc/ListPools"},
-		{"DevStateQuery", ComponentAdmin, "/mgmt.MgmtSvc/DevStateQuery"},
-		{"StorageSetFaulty", ComponentAdmin, "/mgmt.MgmtSvc/StorageSetFaulty"},
-		{"ListContainers", ComponentAdmin, "/mgmt.MgmtSvc/ListContainers"},
-		{"PrepShutdownRanks", ComponentServer, "/mgmt.MgmtSvc/PrepShutdownRanks"},
-		{"StopRanks", ComponentServer, "/mgmt.MgmtSvc/StopRanks"},
-		{"PingRanks", ComponentServer, "/mgmt.MgmtSvc/PingRanks"},
-		{"ResetFormatRanks", ComponentServer, "/mgmt.MgmtSvc/ResetFormatRanks"},
-		{"StartRanks", ComponentServer, "/mgmt.MgmtSvc/StartRanks"},
+func TestSecurity_ComponentHasAccess(t *testing.T) {
+	allComponents := []Component{ComponentUndefined, ComponentAdmin, ComponentAgent, ComponentServer}
+	testCases := map[string]Component{
+		"/ctl.MgmtCtl/StoragePrepare":     ComponentAdmin,
+		"/ctl.MgmtCtl/StorageScan":        ComponentAdmin,
+		"/ctl.MgmtCtl/StorageFormat":      ComponentAdmin,
+		"/ctl.MgmtCtl/SystemQuery":        ComponentAdmin,
+		"/ctl.MgmtCtl/SystemStop":         ComponentAdmin,
+		"/ctl.MgmtCtl/SystemResetFormat":  ComponentAdmin,
+		"/ctl.MgmtCtl/SystemStart":        ComponentAdmin,
+		"/ctl.MgmtCtl/NetworkScan":        ComponentAdmin,
+		"/ctl.MgmtCtl/FirmwareQuery":      ComponentAdmin,
+		"/ctl.MgmtCtl/FirmwareUpdate":     ComponentAdmin,
+		"/mgmt.MgmtSvc/Join":              ComponentServer,
+		"/mgmt.MgmtSvc/LeaderQuery":       ComponentAdmin,
+		"/mgmt.MgmtSvc/PoolCreate":        ComponentAdmin,
+		"/mgmt.MgmtSvc/PoolDestroy":       ComponentAdmin,
+		"/mgmt.MgmtSvc/PoolQuery":         ComponentAdmin,
+		"/mgmt.MgmtSvc/PoolSetProp":       ComponentAdmin,
+		"/mgmt.MgmtSvc/PoolGetACL":        ComponentAdmin,
+		"/mgmt.MgmtSvc/PoolOverwriteACL":  ComponentAdmin,
+		"/mgmt.MgmtSvc/PoolUpdateACL":     ComponentAdmin,
+		"/mgmt.MgmtSvc/PoolDeleteACL":     ComponentAdmin,
+		"/mgmt.MgmtSvc/PoolExclude":       ComponentAdmin,
+		"/mgmt.MgmtSvc/PoolDrain":         ComponentAdmin,
+		"/mgmt.MgmtSvc/PoolReintegrate":   ComponentAdmin,
+		"/mgmt.MgmtSvc/PoolEvict":         ComponentAdmin,
+		"/mgmt.MgmtSvc/PoolExtend":        ComponentAdmin,
+		"/mgmt.MgmtSvc/GetAttachInfo":     ComponentAgent,
+		"/mgmt.MgmtSvc/SmdQuery":          ComponentAdmin,
+		"/mgmt.MgmtSvc/ListPools":         ComponentAdmin,
+		"/mgmt.MgmtSvc/ListContainers":    ComponentAdmin,
+		"/mgmt.MgmtSvc/ContSetOwner":      ComponentAdmin,
+		"/mgmt.MgmtSvc/PrepShutdownRanks": ComponentServer,
+		"/mgmt.MgmtSvc/StopRanks":         ComponentServer,
+		"/mgmt.MgmtSvc/PingRanks":         ComponentServer,
+		"/mgmt.MgmtSvc/ResetFormatRanks":  ComponentServer,
+		"/mgmt.MgmtSvc/StartRanks":        ComponentServer,
 	}
 
-	if len(testCases) != len(methodAuthorizations) {
-		t.Errorf("component access tests is missing a case for a newly added method")
+	var missing []string
+	for method := range methodAuthorizations {
+		if _, found := testCases[method]; !found {
+			missing = append(missing, method)
+		}
 	}
-	for _, tc := range testCases {
-		t.Run(tc.testname, func(t *testing.T) {
+	if len(missing) > 0 {
+		t.Fatalf("%s is missing test cases for the following methods:\n%s", t.Name(), strings.Join(missing, "\n"))
+	}
+
+	var invalid []string
+	for testMethod := range testCases {
+		if _, found := methodAuthorizations[testMethod]; !found {
+			invalid = append(invalid, testMethod)
+		}
+	}
+	if len(invalid) > 0 {
+		t.Fatalf("%s has test cases for the following invalid methods:\n%s", t.Name(), strings.Join(invalid, "\n"))
+	}
+
+	for method, correctComponent := range testCases {
+		t.Run(method, func(t *testing.T) {
 			for _, comp := range allComponents {
-				if comp == tc.correctComponent {
-					common.AssertTrue(t, comp.HasAccess(tc.method), fmt.Sprintf("%s should have access to %s but does not", comp, tc.method))
+				if comp == correctComponent {
+					common.AssertTrue(t, comp.HasAccess(method), fmt.Sprintf("%s should have access to %s but does not", comp, method))
 				} else {
-					common.AssertFalse(t, comp.HasAccess(tc.method), fmt.Sprintf("%s should not have access to %s but does", comp, tc.method))
+					common.AssertFalse(t, comp.HasAccess(method), fmt.Sprintf("%s should not have access to %s but does", comp, method))
 				}
+			}
+		})
+	}
+}
+
+func TestSecurity_AllRpcsAreAuthorized(t *testing.T) {
+	for name, tc := range map[string]struct {
+		service interface{}
+		prefix  string
+	}{
+		"mgmt rpcs": {
+			service: (*mgmtpb.MgmtSvcServer)(nil),
+			prefix:  "/mgmt.MgmtSvc/",
+		},
+		"ctl rpcs": {
+			service: (*ctlpb.MgmtCtlServer)(nil),
+			prefix:  "/ctl.MgmtCtl/",
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			svcType := reflect.TypeOf(tc.service).Elem()
+
+			var rpcNames []string
+			for i := 0; i < svcType.NumMethod(); i++ {
+				fullName := tc.prefix + svcType.Method(i).Name
+				rpcNames = append(rpcNames, fullName)
+			}
+
+			var missing []string
+			for _, rpcName := range rpcNames {
+				if _, ok := methodAuthorizations[rpcName]; !ok {
+					missing = append(missing, rpcName)
+				}
+			}
+
+			if len(missing) > 0 {
+				t.Fatalf("unauthorized RPCs (add to methodAuthorizations):\n%s", strings.Join(missing, "\n"))
+			}
+		})
+	}
+}
+
+func TestSecurity_AuthorizedRpcsAreValid(t *testing.T) {
+	for name, tc := range map[string]struct {
+		service interface{}
+		prefix  string
+	}{
+		"mgmt rpcs": {
+			service: (*mgmtpb.MgmtSvcServer)(nil),
+			prefix:  "/mgmt.MgmtSvc/",
+		},
+		"ctl rpcs": {
+			service: (*ctlpb.MgmtCtlServer)(nil),
+			prefix:  "/ctl.MgmtCtl/",
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			svcType := reflect.TypeOf(tc.service).Elem()
+
+			rpcNames := make(map[string]struct{})
+			for i := 0; i < svcType.NumMethod(); i++ {
+				fullName := tc.prefix + svcType.Method(i).Name
+				rpcNames[fullName] = struct{}{}
+			}
+
+			var invalid []string
+			for registeredName := range methodAuthorizations {
+				if !strings.HasPrefix(registeredName, tc.prefix) {
+					continue
+				}
+				if _, ok := rpcNames[registeredName]; !ok {
+					invalid = append(invalid, registeredName)
+				}
+			}
+
+			if len(invalid) > 0 {
+				t.Fatalf("authorized RPCs without server methods (remove from methodAuthorizations):\n%s", strings.Join(invalid, "\n"))
 			}
 		})
 	}


### PR DESCRIPTION
Also removed some authorizations that became invalid after
the storage query RPCs were reworked.

Added new test coverage that uses the reflect package to
verify that every server RPC method has a corresponding
authorization and test.