### PR TITLE
DAOS-5311 pool: close the server container hdl

### DIFF
--- a/src/include/daos_srv/pool.h
+++ b/src/include/daos_srv/pool.h
@@ -56,6 +56,13 @@ struct ds_pool {
 	ABT_mutex		sp_iv_refresh_lock;
 	struct ds_iv_ns	       *sp_iv_ns;
 	uint32_t		sp_dtx_resync_version;
+	/* Special pool/container handle uuid, which are
+	 * created on the pool leader step up, and propagated
+	 * to all servers by IV. Then they will be used by server
+	 * to access the data on other servers.
+	 */
+	uuid_t			sp_srv_cont_hdl;
+	uuid_t			sp_srv_pool_hdl;
 };
 
 struct ds_pool *ds_pool_lookup(const uuid_t uuid);

--- a/src/pool/srv_iv.c
+++ b/src/pool/srv_iv.c
@@ -440,6 +440,28 @@ pool_iv_ent_update(struct ds_iv_entry *entry, struct ds_iv_key *key,
 				&entry->iv_value, src);
 }
 
+int
+ds_pool_iv_refresh_hdl(struct ds_pool *pool, struct pool_iv_hdl *pih)
+{
+	int rc;
+
+	if (!uuid_is_null(pool->sp_srv_cont_hdl)) {
+		if (uuid_compare(pool->sp_srv_cont_hdl,
+				 pih->pih_cont_hdl) == 0)
+			return 0;
+		ds_cont_tgt_close(pool->sp_srv_cont_hdl);
+	}
+
+	rc = ds_cont_tgt_open(pool->sp_uuid, pih->pih_cont_hdl, NULL, 0,
+			      ds_sec_get_rebuild_cont_capabilities());
+	if (rc == 0) {
+		uuid_copy(pool->sp_srv_cont_hdl, pih->pih_cont_hdl);
+		uuid_copy(pool->sp_srv_pool_hdl, pih->pih_pool_hdl);
+	}
+
+	return rc;
+}
+
 static int
 pool_iv_ent_refresh(struct ds_iv_entry *entry, struct ds_iv_key *key,
 		    d_sg_list_t *src, int ref_rc, void **priv)
@@ -449,12 +471,20 @@ pool_iv_ent_refresh(struct ds_iv_entry *entry, struct ds_iv_key *key,
 	struct ds_pool		*pool;
 	int			rc;
 
+	/* Update pool map version or pool map */
 	if (src == NULL) {
 		/* invalidate */
 		if (entry->iv_valid &&
 		    entry->iv_class->iv_class_id == IV_POOL_HDL &&
-		    !uuid_is_null(dst_iv->piv_hdl.pih_cont_hdl))
+		    !uuid_is_null(dst_iv->piv_hdl.pih_cont_hdl)) {
+			pool = ds_pool_lookup(dst_iv->piv_pool_uuid);
+			if (pool == NULL)
+				return 0;
 			ds_cont_tgt_close(dst_iv->piv_hdl.pih_cont_hdl);
+			uuid_clear(pool->sp_srv_cont_hdl);
+			uuid_clear(pool->sp_srv_pool_hdl);
+			ds_pool_put(pool);
+		}
 		return 0;
 	}
 
@@ -483,9 +513,7 @@ pool_iv_ent_refresh(struct ds_iv_entry *entry, struct ds_iv_key *key,
 				&src_iv->piv_map.piv_pool_buf : NULL,
 				src_iv->piv_pool_map_ver);
 	else if (entry->iv_class->iv_class_id == IV_POOL_HDL)
-		rc = ds_cont_tgt_open(src_iv->piv_pool_uuid,
-				      src_iv->piv_hdl.pih_cont_hdl, NULL, 0,
-				      ds_sec_get_rebuild_cont_capabilities());
+		rc = ds_pool_iv_refresh_hdl(pool, &src_iv->piv_hdl);
 
 	ds_pool_put(pool);
 

--- a/src/pool/srv_pool.c
+++ b/src/pool/srv_pool.c
@@ -1213,8 +1213,14 @@ unlock:
 	if (rc)
 		D_GOTO(out, rc);
 
-	uuid_generate(pool_hdl_uuid);
-	uuid_generate(cont_hdl_uuid);
+	if (!uuid_is_null(svc->ps_pool->sp_srv_cont_hdl)) {
+		uuid_copy(pool_hdl_uuid, svc->ps_pool->sp_srv_pool_hdl);
+		uuid_copy(cont_hdl_uuid, svc->ps_pool->sp_srv_cont_hdl);
+	} else {
+		uuid_generate(pool_hdl_uuid);
+		uuid_generate(cont_hdl_uuid);
+	}
+
 	rc = ds_pool_iv_srv_hdl_update(svc->ps_pool, pool_hdl_uuid,
 				       cont_hdl_uuid);
 	if (rc) {
@@ -4455,6 +4461,8 @@ ds_pool_evict_handler(crt_rpc_t *rpc)
 				   &ds_pool_prop_connectable, &value);
 		if (rc != 0)
 			D_GOTO(out_free, rc);
+
+		ds_pool_iv_srv_hdl_invalidate(svc->ps_pool);
 		D_DEBUG(DF_DSMS, DF_UUID": pool destroy/evict: mark pool for "
 			"no new connections\n", DP_UUID(in->pvi_op.pi_uuid));
 	}


### PR DESCRIPTION
Close the server container handle, used for server to
server fetch, before pool destory.

Reuse the existing pool/container handle for the new
leader.

Signed-off-by: Di Wang <di.wang@intel.com>