### PR TITLE
DAOS-5338 object: Check checksum init in a simple way

### DIFF
--- a/src/object/obj_internal.h
+++ b/src/object/obj_internal.h
@@ -489,7 +489,8 @@ struct obj_io_context {
 	struct ds_cont_child	*ioc_coc;
 	daos_handle_t		 ioc_vos_coh;
 	uint32_t		 ioc_map_ver;
-	bool			 ioc_began;
+	uint32_t		 ioc_began:1,
+				 ioc_csummer_init:1;
 };
 
 struct ds_obj_exec_arg {


### PR DESCRIPTION
Adding a flag to check checksum init, instead of calling
IV fetch to fetch the server hdl, which will hurt the IO
performance.

Signed-off-by: Di Wang <di.wang@intel.com>