### PR TITLE
CART-89 log: Add D_LOG_LIMIT_MB envariable

### DIFF
--- a/src/cart/README.env
+++ b/src/cart/README.env
@@ -53,6 +53,9 @@ This file lists the environment variables used in CaRT.
    The default for cart is DLOG_EMERG ("fatal"), and for daos is DLOG_CRIT
    ("critical"). Options include: "info/note/warn(ing)/err(or)/crit(ical)/fatal"
 
+ . D_LOG_LIMIT_MB
+   Limit log size in MBs. Value of 0 (default) sets to unlimited.
+
  . DD_SUBSYS
    User can specify which subsystems to enable. Gurt default subsystems which
    are always enabled are MEM, MISC, and CLOG. All CaRT facilities are enabled

--- a/src/cart/src/include/gurt/debug.h
+++ b/src/cart/src/include/gurt/debug.h
@@ -82,6 +82,7 @@ extern void (*d_alt_assert)(const int, const char*, const char*, const int);
 #define D_LOG_FILE_APPEND_PID_ENV	"D_LOG_FILE_APPEND_PID"
 
 #define D_LOG_TRUNCATE_ENV		"D_LOG_TRUNCATE"
+#define D_LOG_LIMIT_MB_ENV		"D_LOG_LIMIT_MB"
 
 /* Enable shadow warning where users use same variable name in nested
  * scope.   This enables use of a variable in the macro below and is

--- a/src/cart/src/include/gurt/dlog.h
+++ b/src/cart/src/include/gurt/dlog.h
@@ -164,6 +164,7 @@ struct d_log_xstate {
 	struct dlog_fac		*dlog_facs; /**< array of facility */
 	char			*nodename; /**< pointer to our utsname */
 	int			 fac_cnt; /**< # of facilities */
+	int			 log_limit_mb; /**< log limit in mb */
 };
 
 struct d_debug_data {

--- a/src/tests/ftest/util/server_utils_params.py
+++ b/src/tests/ftest/util/server_utils_params.py
@@ -326,7 +326,8 @@ class DaosServerYamlParameters(YamlParameters):
                 "ABT_ENV_MAX_NUM_XSTREAMS=100",
                 "ABT_MAX_NUM_XSTREAMS=100",
                 "DAOS_MD_CAP=1024",
-                "DD_MASK=mgmt,io,md,epc,rebuild"
+                "DD_MASK=mgmt,io,md,epc,rebuild",
+                "D_LOG_LIMIT_MB=100"
             ]
             if default_provider == "ofi+sockets":
                 default_env_vars.extend([

--- a/src/tests/ftest/util/server_utils_params.py
+++ b/src/tests/ftest/util/server_utils_params.py
@@ -327,7 +327,7 @@ class DaosServerYamlParameters(YamlParameters):
                 "ABT_MAX_NUM_XSTREAMS=100",
                 "DAOS_MD_CAP=1024",
                 "DD_MASK=mgmt,io,md,epc,rebuild",
-                "D_LOG_LIMIT_MB=100"
+                "D_LOG_LIMIT_MB=1024"
             ]
             if default_provider == "ofi+sockets":
                 default_env_vars.extend([


### PR DESCRIPTION
- Add "D_LOG_LIMIT_MB" envariable to limit log size in mbs.
- Limit log size to 100mb in daos server config script

Signed-off-by: Alexander Oganezov <alexander.a.oganezov@intel.com>