### PR TITLE
DAOS-5338 cli: Remove unnecessary warning in log

### DIFF
--- a/src/object/cli_shard.c
+++ b/src/object/cli_shard.c
@@ -247,9 +247,6 @@ daos_iom_copy(const daos_iom_t *src, daos_iom_t *dst)
 	dst->iom_recx_lo = src->iom_recx_lo;
 	dst->iom_nr_out = src->iom_nr_out;
 
-	if (dst->iom_nr < dst->iom_nr_out)
-		D_WARN("mapped recxs list will be truncated");
-
 	to_copy = min(dst->iom_nr, dst->iom_nr_out);
 
 	for (i = 0; i < to_copy ; i++)


### PR DESCRIPTION
A warning was logged when the provided io map is
smaller than what's returned and so is truncated
when returned to user. The user will have the
needed size for the map so the warning is
redundant and filling up logs too much so it's
being removed.

Signed-off-by: Ryon Jensen <ryon.jensen@intel.com>