### PR TITLE
DAOS-5059 utils: handle unexpected extra args for daos cmd

### DIFF
--- a/src/utils/daos.c
+++ b/src/utils/daos.c
@@ -530,10 +530,11 @@ common_op_parse_hdlr(int argc, char *argv[], struct cmd_args_s *ap)
 	if (cmdname == NULL)
 		D_GOTO(out_free, rc = RC_NO_HELP);
 
-	/* Parse command options. Use goto on any errors here
-	 * since some options may result in resource allocation.
+	/* Parse remaining command-line options (skip resource and command).
+	 * Use goto on any errors here * since some options may result in
+	 * resource allocation.
 	 */
-	while ((rc = getopt_long(argc, argv, "", options, NULL)) != -1) {
+	while ((rc = getopt_long(argc - 2, &argv[2], "", options, NULL)) != -1) {
 		switch (rc) {
 		case 'G':
 			D_FREE(ap->sysname);
@@ -702,6 +703,13 @@ common_op_parse_hdlr(int argc, char *argv[], struct cmd_args_s *ap)
 			fprintf(stderr, "unknown option : %d\n", rc);
 			D_GOTO(out_free, rc = RC_PRINT_HELP);
 		}
+	}
+
+	/* unexpected extra arguments not allowed */
+	if (optind < argc - 2) {
+		fprintf(stderr, "unexpected extra argument : '%s'\n",
+			argv[optind + 2]);
+		D_GOTO(out_free, rc = RC_NO_HELP);
 	}
 
 	cmd_args_print(ap);

--- a/src/utils/daos.c
+++ b/src/utils/daos.c
@@ -452,6 +452,11 @@ enum {
 	DAOS_PROPERTIES_OPTION = 1,
 };
 
+/* resource and command arguments (ie "container create" for example) can be
+ * skipped for options evaluation
+ */
+#define SKIP_RES_AND_CMD_ARGS 2
+
 static int
 common_op_parse_hdlr(int argc, char *argv[], struct cmd_args_s *ap)
 {
@@ -531,10 +536,12 @@ common_op_parse_hdlr(int argc, char *argv[], struct cmd_args_s *ap)
 		D_GOTO(out_free, rc = RC_NO_HELP);
 
 	/* Parse remaining command-line options (skip resource and command).
-	 * Use goto on any errors here * since some options may result in
+	 * Use goto on any errors here since some options may result in
 	 * resource allocation.
 	 */
-	while ((rc = getopt_long(argc - 2, &argv[2], "", options, NULL)) != -1) {
+	while ((rc = getopt_long(argc - SKIP_RES_AND_CMD_ARGS,
+				 &argv[SKIP_RES_AND_CMD_ARGS], "", options,
+				 NULL)) != -1) {
 		switch (rc) {
 		case 'G':
 			D_FREE(ap->sysname);
@@ -706,9 +713,9 @@ common_op_parse_hdlr(int argc, char *argv[], struct cmd_args_s *ap)
 	}
 
 	/* unexpected extra arguments not allowed */
-	if (optind < argc - 2) {
+	if (optind < argc - SKIP_RES_AND_CMD_ARGS) {
 		fprintf(stderr, "unexpected extra argument : '%s'\n",
-			argv[optind + 2]);
+			argv[optind + SKIP_RES_AND_CMD_ARGS]);
 		D_GOTO(out_free, rc = RC_NO_HELP);
 	}
 


### PR DESCRIPTION
To prevent any typo or mistake with daos cmd syntax, enhance
parsing to detect unexpected extra arguments.

Change-Id: If542283941e32143ca75f96e35d5af1dcb7429a5
Signed-off-by: Bruno Faccini <bruno.faccini@intel.com>