### PR TITLE
DAOS-5269 cart: optimize (un)packing

### DIFF
--- a/src/common/proc.c
+++ b/src/common/proc.c
@@ -61,7 +61,7 @@ crt_proc_struct_daos_acl(crt_proc_t proc, struct daos_acl **data)
 		*data = (struct daos_acl *)iov.iov_buf;
 		break;
 	case CRT_PROC_FREE:
-		daos_acl_free(*data);
+		*data = NULL;
 		break;
 	default:
 		D_ERROR("bad proc_op %d.\n", proc_op);

--- a/utils/build.config
+++ b/utils/build.config
@@ -3,7 +3,7 @@ component=daos
 
 [commit_versions]
 ARGOBOTS = 89507c1f8cfec4e918e8b9861e41b4e9cef71461
-CART = 4cd401d159b14f431f4a77e94ae0e0eebce5f0e3
+CART = e2dac4c973c5c314043f63a1ff922578930cb0a9
 PMDK = 1.8
 ISAL = v2.26.0
 SPDK = v19.04.1


### PR DESCRIPTION
Don't memcpy inline data and use pointer in request buffer instead.
Use direct assignment for basic types instead of memcpy.

Signed-off-by: Dmitry Eremin <dmitry.eremin@intel.com>