### PR TITLE
DAOS-5321 test: Use newer hdf5 with broken test disabled

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -165,7 +165,7 @@ String qb_inst_rpms_run_test() {
 String functional_rpms(String distro) {
     String rpms = "openmpi3 hwloc ndctl " +
                   "ior-hpc-cart-4-daos-0 " +
-                  "romio-tests-cart-4-daos-0 hdf5-tests-cart-4-daos-0 " +
+                  "romio-tests-cart-4-daos-0 " +
                   "testmpio-cart-4-daos-0 fio " +
                   "mpi4py-tests-cart-4-daos-0 " +
                   "MACSio"

--- a/ci/rpm/scan_daos_node.sh
+++ b/ci/rpm/scan_daos_node.sh
@@ -2,7 +2,7 @@
 
 set -uex
 
-sudo yum -y install \
+sudo yum -y install --exclude ompi \
   daos{,-{client,server,tests,debuginfo,devel}}-"${DAOS_PKG_VERSION}"
 
 lmd_src="maldet-current"

--- a/src/tests/ftest/io/hdf5.yaml
+++ b/src/tests/ftest/io/hdf5.yaml
@@ -31,4 +31,4 @@ container:
 client_processes:
     np: 6
 test_repo:
-    hdf5: "/usr/lib64/hdf5/tests"
+    hdf5: "/usr/lib64/hdf5/mpich/tests"

--- a/utils/rpms/daos.spec
+++ b/utils/rpms/daos.spec
@@ -11,7 +11,7 @@
 
 Name:          daos
 Version:       1.1.0
-Release:       28%{?relval}%{?dist}
+Release:       29%{?relval}%{?dist}
 Summary:       DAOS Storage Engine
 
 License:       Apache
@@ -152,6 +152,7 @@ Summary: The DAOS test suite
 Requires: %{name}-client = %{version}-%{release}
 Requires: python-pathlib
 Requires: fio
+Requires: hdf5-mpich2-tests-daos-0 >= 1.10.5-10.g07066a381e%{dist}
 %if (0%{?suse_version} >= 1315)
 Requires: libpsm_infinipath1
 %endif
@@ -373,6 +374,9 @@ getent passwd daos_server >/dev/null || useradd -M daos_server
 %{_libdir}/*.a
 
 %changelog
+* Tue Jul 28 2020 Brian J. Murrell <brian.murrell@intel.com> - 1.1.0-29
+- Add hdf5-tests requirement to the tests subpackage
+
 * Mon Jul 13 2020 Brian J. Murrell <brian.murrell@intel.com> - 1.1.0-28
 - Change fuse requirement to fuse3
 - Use Lmod for MPI module loading


### PR DESCRIPTION
Add hdf5-tests requirement to daos-tests subpackage so that we don't
need to specify it in Jenkinsfile any more.

Exclude ompi from RPM scan and test stages install due to YUM's
simplistic dependency resolver.

Signed-off-by: Brian J. Murrell <brian.murrell@intel.com>