### PR TITLE
DAOS-5332 rebuild: Explicit pool target state transitions

### DIFF
--- a/src/pool/srv_util.c
+++ b/src/pool/srv_util.c
@@ -229,7 +229,7 @@ update_one_tgt(struct pool_map *map, struct pool_target *target,
 		case PO_COMP_ST_DOWNOUT:
 			/* Nothing to do, already excluded */
 			D_INFO("Skip exclude down target (rank %u idx %u)\n",
-				target->ta_comp.co_rank,
+			       target->ta_comp.co_rank,
 				target->ta_comp.co_index);
 			break;
 		case PO_COMP_ST_UP:
@@ -262,7 +262,7 @@ update_one_tgt(struct pool_map *map, struct pool_target *target,
 		case PO_COMP_ST_DOWNOUT:
 			/* Nothing to do, already excluded / draining */
 			D_INFO("Skip drain down target (rank %u idx %u)\n",
-				target->ta_comp.co_rank,
+			       target->ta_comp.co_rank,
 				target->ta_comp.co_index);
 			break;
 		case PO_COMP_ST_UP:
@@ -290,7 +290,7 @@ update_one_tgt(struct pool_map *map, struct pool_target *target,
 		case PO_COMP_ST_UPIN:
 			/* Nothing to do, already added */
 			D_INFO("Skip add up target (rank %u idx %u)\n",
-				target->ta_comp.co_rank,
+			       target->ta_comp.co_rank,
 				target->ta_comp.co_index);
 			break;
 		case PO_COMP_ST_DOWN:
@@ -321,7 +321,7 @@ update_one_tgt(struct pool_map *map, struct pool_target *target,
 		case PO_COMP_ST_UPIN:
 			/* Nothing to do, already UPIN */
 			D_INFO("Skip ADD_IN UPIN target (rank %u idx %u)\n",
-				target->ta_comp.co_rank,
+			       target->ta_comp.co_rank,
 				target->ta_comp.co_index);
 			break;
 		case PO_COMP_ST_DOWN:
@@ -346,7 +346,7 @@ update_one_tgt(struct pool_map *map, struct pool_target *target,
 		case PO_COMP_ST_DOWNOUT:
 			/* Nothing to do, already DOWNOUT */
 			D_INFO("Skip EXCLUDEOUT DOWNOUT tgt (rank %u idx %u)\n",
-				target->ta_comp.co_rank,
+			       target->ta_comp.co_rank,
 				target->ta_comp.co_index);
 			break;
 		case PO_COMP_ST_DRAIN:


### PR DESCRIPTION
This patch improves the state transition logic in
ds_pool_map_tgts_update which all state transitions should go through.

For example - a request might come in to reintegrate a target. This will
explicitly check all available states for that target and either print
an info message (no change), an error message (invalid transition), or
actually perform the operation. If the transition is currently invalid,
it will return either -DER_BUSY for operations that will be valid later
once rebuild completes (i.e. reintegrate a target that is still
undergoing failure recovery), or -DER_INVAL for operations which never
make sense (i.e move a DRAIN'ing target directly to UPIN).

This fixes a couple timing problems where it was possible to exclude a
target (starting rebuild), then reintegrate that same target before the
exclude operation was complete. This resulted in the reintegrate command
"succeeding" even though nothing actually changed - which is confusing
both to operators and to people digging through test logs to understand
failures.