### PR TITLE
DAOS-2666 test: fix bug in DFS test with multiple ranks

### DIFF
--- a/src/tests/suite/dfs_test.c
+++ b/src/tests/suite/dfs_test.c
@@ -674,9 +674,14 @@ dfs_test_hole_mgmt(void **state)
 	/** reset */
 	memset(rbuf[0], '-', buf_size + 100);
 
+	MPI_Barrier(MPI_COMM_WORLD);
 	/** truncate file back to 0 */
-	rc = dfs_punch(dfs_mt, obj, 0, DFS_MAX_FSIZE);
-	assert_int_equal(rc, 0);
+	if (arg->myrank == 0) {
+		rc = dfs_punch(dfs_mt, obj, 0, DFS_MAX_FSIZE);
+		assert_int_equal(rc, 0);
+	}
+	MPI_Barrier(MPI_COMM_WORLD);
+
 	rc = dfs_ostat(dfs_mt, obj, &stbuf);
 	assert_int_equal(rc, 0);
 	assert_int_equal(stbuf.st_size, 0);
@@ -757,9 +762,14 @@ dfs_test_hole_mgmt(void **state)
 	for (i = 0; i < NUM_SEGS; i++)
 		memset(rbuf[i], '-', buf_size + 100);
 
+	MPI_Barrier(MPI_COMM_WORLD);
 	/** truncate file back to 0 */
-	rc = dfs_punch(dfs_mt, obj, 0, DFS_MAX_FSIZE);
-	assert_int_equal(rc, 0);
+	if (arg->myrank == 0) {
+		rc = dfs_punch(dfs_mt, obj, 0, DFS_MAX_FSIZE);
+		assert_int_equal(rc, 0);
+	}
+	MPI_Barrier(MPI_COMM_WORLD);
+
 	rc = dfs_ostat(dfs_mt, obj, &stbuf);
 	assert_int_equal(rc, 0);
 	assert_int_equal(stbuf.st_size, 0);
@@ -805,12 +815,10 @@ dfs_test_hole_mgmt(void **state)
 			rptr = rbuf[1];
 
 		if (i%2 == 0) {
-			printf("idx %u, check valid\n", i);
 			rc = memcmp(rptr, wptr, 64);
 			assert_int_equal(rc, 0);
 			wptr += 64;
 		} else {
-			printf("idx %u, check hole\n", i);
 			/** last block is beyond EOF */
 			if (i == (buf_size*2)/64 - 1) {
 				rc = memcmp(rptr, obuf, 64);


### PR DESCRIPTION
Add a barrier before and after the file is punched to make sure all
ranks see the expected result.

Signed-off-by: Mohamad Chaarawi <mohamad.chaarawi@intel.com>