### PR TITLE
DAOS-5359 control: Clean up JSON output in dmg

### DIFF
--- a/src/control/cmd/dmg/command_test.go
+++ b/src/control/cmd/dmg/command_test.go
@@ -144,6 +144,8 @@ func (bci *bridgeConnInvoker) InvokeUnaryRPC(ctx context.Context, uReq control.U
 		resp = control.MockMSResponse("", nil, &mgmtpb.ListPoolsResp{})
 	case *control.ContSetOwnerReq:
 		resp = control.MockMSResponse("", nil, &mgmtpb.ContSetOwnerResp{})
+	case *control.PoolQueryReq:
+		resp = control.MockMSResponse("", nil, &mgmtpb.PoolQueryResp{})
 	case *control.PoolGetACLReq, *control.PoolOverwriteACLReq,
 		*control.PoolUpdateACLReq, *control.PoolDeleteACLReq:
 		resp = control.MockMSResponse("", nil, &mgmtpb.ACLResp{})

--- a/src/control/cmd/dmg/cont.go
+++ b/src/control/cmd/dmg/cont.go
@@ -26,6 +26,7 @@ package main
 import (
 	"context"
 
+	"github.com/jessevdk/go-flags"
 	"github.com/pkg/errors"
 
 	"github.com/daos-stack/daos/src/control/lib/control"
@@ -40,6 +41,7 @@ type ContCmd struct {
 type ContSetOwnerCmd struct {
 	logCmd
 	ctlInvokerCmd
+	jsonOutputCmd
 	GroupName string `short:"g" long:"group" description:"New owner-group for the container, format name@domain"`
 	UserName  string `short:"u" long:"user" description:"New owner-user for the container, format name@domain"`
 	ContUUID  string `short:"c" long:"cont" required:"1" description:"UUID of the DAOS container"`
@@ -48,6 +50,12 @@ type ContSetOwnerCmd struct {
 
 // Execute runs the container set-owner command
 func (c *ContSetOwnerCmd) Execute(args []string) error {
+	if c.GroupName == "" && c.UserName == "" {
+		return &flags.Error{
+			Type:    flags.ErrRequired,
+			Message: "at least one of `--user' or `--group' must be supplied",
+		}
+	}
 	msg := "SUCCEEDED"
 	req := &control.ContSetOwnerReq{
 		ContUUID: c.ContUUID,
@@ -60,6 +68,10 @@ func (c *ContSetOwnerCmd) Execute(args []string) error {
 	err := control.ContSetOwner(ctx, c.ctlInvoker, req)
 	if err != nil {
 		msg = errors.WithMessage(err, "FAILED").Error()
+	}
+
+	if c.jsonOutputEnabled() {
+		return c.errorJSON(err)
 	}
 
 	c.log.Infof("Container-set-owner command %s\n", msg)

--- a/src/control/cmd/dmg/firmware.go
+++ b/src/control/cmd/dmg/firmware.go
@@ -26,7 +26,6 @@ package main
 
 import (
 	"context"
-	"os"
 	"strings"
 
 	"github.com/daos-stack/daos/src/control/cmd/dmg/pretty"
@@ -68,12 +67,13 @@ func (cmd *firmwareQueryCmd) Execute(args []string) error {
 
 	req.SetHostList(cmd.hostlist)
 	resp, err := control.FirmwareQuery(ctx, cmd.ctlInvoker, req)
-	if err != nil {
-		return err
-	}
 
 	if cmd.jsonOutputEnabled() {
-		return cmd.outputJSON(os.Stdout, resp)
+		return cmd.outputJSON(resp, err)
+	}
+
+	if err != nil {
+		return err
 	}
 
 	var bld strings.Builder
@@ -125,12 +125,13 @@ func (cmd *firmwareUpdateCmd) Execute(args []string) error {
 
 	req.SetHostList(cmd.hostlist)
 	resp, err := control.FirmwareUpdate(ctx, cmd.ctlInvoker, req)
-	if err != nil {
-		return err
-	}
 
 	if cmd.jsonOutputEnabled() {
-		return cmd.outputJSON(os.Stdout, resp)
+		return cmd.outputJSON(resp, err)
+	}
+
+	if err != nil {
+		return err
 	}
 
 	var bld strings.Builder

--- a/src/control/cmd/dmg/firmware_test.go
+++ b/src/control/cmd/dmg/firmware_test.go
@@ -28,8 +28,9 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/daos-stack/daos/src/control/lib/control"
 	"github.com/pkg/errors"
+
+	"github.com/daos-stack/daos/src/control/lib/control"
 )
 
 func TestFirmwareCommands(t *testing.T) {

--- a/src/control/cmd/dmg/json_test.go
+++ b/src/control/cmd/dmg/json_test.go
@@ -1,0 +1,150 @@
+//
+// (C) Copyright 2020 Intel Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// GOVERNMENT LICENSE RIGHTS-OPEN SOURCE SOFTWARE
+// The Government's rights to use, modify, reproduce, release, perform, display,
+// or disclose this software are subject to the terms of the Apache License as
+// provided in Contract No. 8F-30005.
+// Any reproduction of computer software, computer software documentation, or
+// portions thereof marked with this legend must also reproduce the markings.
+
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/daos-stack/daos/src/control/common"
+	"github.com/daos-stack/daos/src/control/lib/control"
+	"github.com/daos-stack/daos/src/control/logging"
+)
+
+func walkStruct(v reflect.Value, prefix []string, visit func([]string)) {
+	vType := v.Type()
+	hasSub := false
+
+	for i := 0; i < vType.NumField(); i++ {
+		f := vType.Field(i)
+		kind := f.Type.Kind()
+		if kind != reflect.Struct {
+			continue
+		}
+
+		cmd := f.Tag.Get("command")
+		if cmd == "" {
+			continue
+		}
+
+		hasSub = true
+		subCmd := append(prefix, []string{cmd}...)
+		walkStruct(v.Field(i), subCmd, visit)
+	}
+
+	if !hasSub {
+		visit(prefix)
+	}
+}
+
+func TestDmg_JsonOutput(t *testing.T) {
+	var cmdArgs [][]string
+
+	// Use reflection to build up a list of commands in order to
+	// verify that they return valid JSON when invoked with valid
+	// arguments. This should catch new commands added without proper
+	// support for JSON output.
+	walkStruct(reflect.ValueOf(cliOptions{}), nil, func(cmd []string) {
+		cmdArgs = append(cmdArgs, cmd)
+	})
+
+	aclPath := filepath.Join(os.TempDir(), "testACLFile.txt")
+	createTestFile(t, aclPath, "A::OWNER@:rw\nA::user1@:rw\nA:g:group1@:r\n")
+	defer os.Remove(aclPath)
+
+	for _, args := range cmdArgs {
+		t.Run(strings.Join(args, " "), func(t *testing.T) {
+			testArgs := append([]string{"-i", "--json"}, args...)
+			switch strings.Join(args, " ") {
+			case "version":
+				return
+			case "storage prepare":
+				testArgs = append(testArgs, "--force")
+			case "storage query target-health":
+				testArgs = append(testArgs, []string{"-r", "0", "-t", "0"}...)
+			case "storage query device-health":
+				testArgs = append(testArgs, []string{"-u", common.MockUUID()}...)
+			case "storage set nvme-faulty":
+				testArgs = append(testArgs, []string{"--force", "-u", common.MockUUID()}...)
+			case "pool create":
+				testArgs = append(testArgs, []string{"-s", "1TB"}...)
+			case "pool destroy", "pool evict", "pool query", "pool get-acl":
+				testArgs = append(testArgs, []string{"--pool", common.MockUUID()}...)
+			case "pool overwrite-acl", "pool update-acl":
+				testArgs = append(testArgs, []string{"--pool", common.MockUUID(), "-a", aclPath}...)
+			case "pool delete-acl":
+				testArgs = append(testArgs, []string{"--pool", common.MockUUID(), "-p", "foo@"}...)
+			case "pool set-prop":
+				testArgs = append(testArgs, []string{"--pool", common.MockUUID(), "-n", "foo", "-v", "bar"}...)
+			case "pool extend":
+				testArgs = append(testArgs, []string{"--pool", common.MockUUID(), "--ranks", "0", "-s", "1TB"}...)
+			case "pool exclude", "pool drain", "pool reintegrate":
+				testArgs = append(testArgs, []string{"--pool", common.MockUUID(), "--rank", "0"}...)
+			case "cont set-owner":
+				testArgs = append(testArgs, []string{"--user", "foo", "--pool", common.MockUUID(), "--cont", common.MockUUID()}...)
+			}
+
+			// replace os.Stdout so that we can verify the generated output
+			var result bytes.Buffer
+			r, w, _ := os.Pipe()
+			done := make(chan struct{})
+			go func() {
+				io.Copy(&result, r)
+				close(done)
+			}()
+			stdout := os.Stdout
+			defer func() {
+				os.Stdout = stdout
+			}()
+			os.Stdout = w
+
+			// Use a normal logger to verify that we don't mess up JSON output.
+			log := logging.NewCommandLineLogger()
+
+			ctlClient := control.DefaultMockInvoker(log)
+			conn := newTestConn(t)
+			bridge := &bridgeConnInvoker{
+				MockInvoker: *ctlClient,
+				t:           t,
+				conn:        conn,
+			}
+
+			err := parseOpts(testArgs, &cliOptions{}, bridge, log)
+			if err != nil {
+				t.Errorf("%s: %s", strings.Join(testArgs, " "), err)
+			}
+			w.Close()
+			<-done
+
+			if !json.Valid(result.Bytes()) {
+				t.Fatalf("invalid JSON in response: %s", result.String())
+			}
+		})
+	}
+}

--- a/src/control/cmd/dmg/main.go
+++ b/src/control/cmd/dmg/main.go
@@ -59,12 +59,14 @@ type (
 	}
 
 	jsonOutputter interface {
-		enableJsonOutput(bool)
+		enableJsonOutput(bool, io.Writer)
 		jsonOutputEnabled() bool
-		outputJSON(io.Writer, interface{}) error
+		outputJSON(interface{}, error) error
+		errorJSON(error) error
 	}
 
 	jsonOutputCmd struct {
+		writer         io.Writer
 		shouldEmitJSON bool
 	}
 )
@@ -77,23 +79,41 @@ func (cmd *hostListCmd) setHostList(hl []string) {
 	cmd.hostlist = hl
 }
 
-func (cmd *jsonOutputCmd) enableJsonOutput(emitJson bool) {
+func (cmd *jsonOutputCmd) enableJsonOutput(emitJson bool, w io.Writer) {
 	cmd.shouldEmitJSON = emitJson
+	cmd.writer = w
 }
 
 func (cmd *jsonOutputCmd) jsonOutputEnabled() bool {
 	return cmd.shouldEmitJSON
 }
 
-func (cmd *jsonOutputCmd) outputJSON(out io.Writer, in interface{}) error {
-	data, err := json.MarshalIndent(in, "", "  ")
+func (cmd *jsonOutputCmd) outputJSON(in interface{}, cmdErr error) error {
+	var errStr *string
+	if cmdErr != nil {
+		errStr = new(string)
+		*errStr = cmdErr.Error()
+	}
+	data, err := json.MarshalIndent(struct {
+		Response interface{} `json:"response"`
+		Error    *string     `json:"error"`
+	}{in, errStr}, "", "  ")
 	if err != nil {
 		return err
 	}
 
-	_, err = out.Write(append(data, []byte("\n")...))
-	return err
+	if _, err = cmd.writer.Write(append(data, []byte("\n")...)); err != nil {
+		return err
+	}
+
+	return cmdErr
 }
+
+func (cmd *jsonOutputCmd) errorJSON(err error) error {
+	return cmd.outputJSON(nil, err)
+}
+
+var _ jsonOutputter = (*jsonOutputCmd)(nil)
 
 type cmdLogger interface {
 	setLog(*logging.LeveledLogger)
@@ -192,7 +212,11 @@ func parseOpts(args []string, opts *cliOptions, invoker control.Invoker, log *lo
 		}
 
 		if jsonCmd, ok := cmd.(jsonOutputter); ok {
-			jsonCmd.enableJsonOutput(opts.JSON)
+			jsonCmd.enableJsonOutput(opts.JSON, os.Stdout)
+			if opts.JSON {
+				// disable output on stdout other than JSON
+				log.SetLevel(logging.LogLevelError)
+			}
 		}
 
 		if logCmd, ok := cmd.(cmdLogger); ok {

--- a/src/control/cmd/dmg/network.go
+++ b/src/control/cmd/dmg/network.go
@@ -25,7 +25,6 @@ package main
 
 import (
 	"context"
-	"os"
 	"strings"
 
 	"github.com/daos-stack/daos/src/control/cmd/dmg/pretty"
@@ -59,12 +58,13 @@ func (cmd *networkScanCmd) Execute(_ []string) error {
 	cmd.log.Debugf("network scan req: %+v", req)
 
 	resp, err := control.NetworkScan(ctx, cmd.ctlInvoker, req)
-	if err != nil {
-		return err
-	}
 
 	if cmd.jsonOutputEnabled() {
-		return cmd.outputJSON(os.Stdout, resp)
+		return cmd.outputJSON(resp, err)
+	}
+
+	if err != nil {
+		return err
 	}
 
 	var bld strings.Builder

--- a/src/control/cmd/dmg/pool.go
+++ b/src/control/cmd/dmg/pool.go
@@ -141,7 +141,7 @@ func (c *PoolCreateCmd) Execute(args []string) error {
 	resp, err := control.PoolCreate(ctx, c.ctlInvoker, req)
 
 	if c.jsonOutputEnabled() {
-		return c.outputJSON(os.Stdout, resp)
+		return c.outputJSON(resp, err)
 	}
 
 	if err != nil {
@@ -160,6 +160,7 @@ func (c *PoolCreateCmd) Execute(args []string) error {
 type PoolDestroyCmd struct {
 	logCmd
 	ctlInvokerCmd
+	jsonOutputCmd
 	// TODO: implement --sys & --svc options (currently unsupported server side)
 	UUID  string `long:"pool" required:"1" description:"UUID of DAOS pool to destroy"`
 	Force bool   `short:"f" long:"force" description:"Force removal of DAOS pool"`
@@ -173,6 +174,11 @@ func (d *PoolDestroyCmd) Execute(args []string) error {
 
 	ctx := context.Background()
 	err := control.PoolDestroy(ctx, d.ctlInvoker, req)
+
+	if d.jsonOutputEnabled() {
+		return d.errorJSON(err)
+	}
+
 	if err != nil {
 		msg = errors.WithMessage(err, "failed").Error()
 	}
@@ -186,6 +192,7 @@ func (d *PoolDestroyCmd) Execute(args []string) error {
 type PoolEvictCmd struct {
 	logCmd
 	ctlInvokerCmd
+	jsonOutputCmd
 	UUID string `long:"pool" required:"1" description:"UUID of DAOS pool to evict connection to"`
 	Sys  string `short:"S" long:"sys" default:"daos_server" description:"DAOS system that the pools connections be evicted from."`
 }
@@ -198,6 +205,11 @@ func (d *PoolEvictCmd) Execute(args []string) error {
 
 	ctx := context.Background()
 	err := control.PoolEvict(ctx, d.ctlInvoker, req)
+
+	if d.jsonOutputEnabled() {
+		return d.errorJSON(err)
+	}
+
 	if err != nil {
 		msg = errors.WithMessage(err, "failed").Error()
 	}
@@ -211,6 +223,7 @@ func (d *PoolEvictCmd) Execute(args []string) error {
 type PoolExcludeCmd struct {
 	logCmd
 	ctlInvokerCmd
+	jsonOutputCmd
 	UUID      string `long:"pool" required:"1" description:"UUID of the DAOS pool to exclude a target from"`
 	Rank      uint32 `long:"rank" required:"1" description:"Rank of the targets to be excluded"`
 	Targetidx string `long:"target-idx" description:"Comma-separated list of target idx(s) to be excluded from the rank"`
@@ -229,6 +242,11 @@ func (r *PoolExcludeCmd) Execute(args []string) error {
 
 	ctx := context.Background()
 	err := control.PoolExclude(ctx, r.ctlInvoker, req)
+
+	if r.jsonOutputEnabled() {
+		return r.errorJSON(err)
+	}
+
 	if err != nil {
 		msg = errors.WithMessage(err, "failed").Error()
 	}
@@ -242,6 +260,7 @@ func (r *PoolExcludeCmd) Execute(args []string) error {
 type PoolDrainCmd struct {
 	logCmd
 	ctlInvokerCmd
+	jsonOutputCmd
 	UUID      string `long:"pool" required:"1" description:"UUID of the DAOS pool to drain a target in"`
 	Rank      uint32 `long:"rank" required:"1" description:"Rank of the targets to be drained"`
 	Targetidx string `long:"target-idx" description:"Comma-separated list of target idx(s) to be drained on the rank"`
@@ -253,13 +272,22 @@ func (r *PoolDrainCmd) Execute(args []string) error {
 
 	var idxlist []uint32
 	if err := common.ParseNumberList(r.Targetidx, &idxlist); err != nil {
-		return errors.WithMessage(err, "parsing rank list")
+		err = errors.WithMessage(err, "parsing rank list")
+		if r.jsonOutputEnabled() {
+			return r.errorJSON(err)
+		}
+		return err
 	}
 
 	req := &control.PoolDrainReq{UUID: r.UUID, Rank: system.Rank(r.Rank), Targetidx: idxlist}
 
 	ctx := context.Background()
 	err := control.PoolDrain(ctx, r.ctlInvoker, req)
+
+	if r.jsonOutputEnabled() {
+		return r.errorJSON(err)
+	}
+
 	if err != nil {
 		msg = errors.WithMessage(err, "failed").Error()
 	}
@@ -273,6 +301,7 @@ func (r *PoolDrainCmd) Execute(args []string) error {
 type PoolExtendCmd struct {
 	logCmd
 	ctlInvokerCmd
+	jsonOutputCmd
 	UUID     string `long:"pool" required:"1" description:"UUID of the DAOS pool to extend"`
 	RankList string `long:"ranks" required:"1" description:"Comma-separated list of ranks to add to the pool"`
 	// Everything after this needs to be removed when pool info can be fetched
@@ -287,7 +316,11 @@ func (e *PoolExtendCmd) Execute(args []string) error {
 
 	ranks, err := system.ParseRanks(e.RankList)
 	if err != nil {
-		return errors.Wrap(err, "parsing rank list")
+		err = errors.Wrap(err, "parsing rank list")
+		if e.jsonOutputEnabled() {
+			return e.errorJSON(err)
+		}
+		return err
 	}
 
 	// Everything below this needs to be removed once Pool Info can be fetched
@@ -314,6 +347,10 @@ func (e *PoolExtendCmd) Execute(args []string) error {
 	ctx := context.Background()
 	err = control.PoolExtend(ctx, e.ctlInvoker, req)
 
+	if e.jsonOutputEnabled() {
+		return e.errorJSON(err)
+	}
+
 	if err != nil {
 		msg = errors.WithMessage(err, "failed").Error()
 	}
@@ -327,6 +364,7 @@ func (e *PoolExtendCmd) Execute(args []string) error {
 type PoolReintegrateCmd struct {
 	logCmd
 	ctlInvokerCmd
+	jsonOutputCmd
 	UUID      string `long:"pool" required:"1" description:"UUID of the DAOS pool to start reintegration in"`
 	Rank      uint32 `long:"rank" required:"1" description:"Rank of the targets to be reintegrated"`
 	Targetidx string `long:"target-idx" description:"Comma-separated list of target idx(s) to be reintegrated into the rank"`
@@ -338,13 +376,22 @@ func (r *PoolReintegrateCmd) Execute(args []string) error {
 
 	var idxlist []uint32
 	if err := common.ParseNumberList(r.Targetidx, &idxlist); err != nil {
-		return errors.WithMessage(err, "parsing rank list")
+		err = errors.WithMessage(err, "parsing rank list")
+		if r.jsonOutputEnabled() {
+			return r.errorJSON(err)
+		}
+		return err
 	}
 
 	req := &control.PoolReintegrateReq{UUID: r.UUID, Rank: system.Rank(r.Rank), Targetidx: idxlist}
 
 	ctx := context.Background()
 	err := control.PoolReintegrate(ctx, r.ctlInvoker, req)
+
+	if r.jsonOutputEnabled() {
+		return r.errorJSON(err)
+	}
+
 	if err != nil {
 		msg = errors.WithMessage(err, "failed").Error()
 	}
@@ -370,12 +417,13 @@ func (c *PoolQueryCmd) Execute(args []string) error {
 
 	ctx := context.Background()
 	resp, err := control.PoolQuery(ctx, c.ctlInvoker, req)
-	if err != nil {
-		return errors.Wrap(err, "pool query failed")
-	}
 
 	if c.jsonOutputEnabled() {
-		return c.outputJSON(os.Stdout, resp)
+		return c.errorJSON(err)
+	}
+
+	if err != nil {
+		return errors.Wrap(err, "pool query failed")
 	}
 
 	var bld strings.Builder
@@ -410,12 +458,13 @@ func (c *PoolSetPropCmd) Execute(_ []string) error {
 
 	ctx := context.Background()
 	resp, err := control.PoolSetProp(ctx, c.ctlInvoker, req)
-	if err != nil {
-		return errors.Wrap(err, "pool set-prop failed")
-	}
 
 	if c.jsonOutputEnabled() {
-		return c.outputJSON(os.Stdout, resp)
+		return c.errorJSON(err)
+	}
+
+	if err != nil {
+		return errors.Wrap(err, "pool set-prop failed")
 	}
 
 	c.log.Infof("pool set-prop succeeded (%s=%q)", resp.Property, resp.Value)
@@ -440,15 +489,16 @@ func (d *PoolGetACLCmd) Execute(args []string) error {
 
 	ctx := context.Background()
 	resp, err := control.PoolGetACL(ctx, d.ctlInvoker, req)
+
+	if d.jsonOutputEnabled() {
+		return d.outputJSON(resp.ACL, err)
+	}
+
 	if err != nil {
 		return errors.Wrap(err, "Pool-get-ACL command failed")
 	}
 
 	d.log.Debugf("Pool-get-ACL command succeeded, UUID: %s\n", d.UUID)
-
-	if d.jsonOutputEnabled() {
-		return d.outputJSON(os.Stdout, resp.ACL)
-	}
 
 	acl := control.FormatACL(resp.ACL, d.Verbose)
 
@@ -504,6 +554,9 @@ type PoolOverwriteACLCmd struct {
 func (d *PoolOverwriteACLCmd) Execute(args []string) error {
 	acl, err := control.ReadACLFile(d.ACLFile)
 	if err != nil {
+		if d.jsonOutputEnabled() {
+			return d.errorJSON(err)
+		}
 		return err
 	}
 
@@ -514,15 +567,16 @@ func (d *PoolOverwriteACLCmd) Execute(args []string) error {
 
 	ctx := context.Background()
 	resp, err := control.PoolOverwriteACL(ctx, d.ctlInvoker, req)
+
+	if d.jsonOutputEnabled() {
+		return d.outputJSON(resp.ACL, err)
+	}
+
 	if err != nil {
 		return errors.Wrap(err, "Pool-overwrite-ACL command failed")
 	}
 
 	d.log.Infof("Pool-overwrite-ACL command succeeded, UUID: %s\n", d.UUID)
-
-	if d.jsonOutputEnabled() {
-		return d.outputJSON(os.Stdout, resp.ACL)
-	}
 
 	d.log.Info(control.FormatACLDefault(resp.ACL))
 
@@ -550,6 +604,9 @@ func (d *PoolUpdateACLCmd) Execute(args []string) error {
 	if d.ACLFile != "" {
 		aclFileResult, err := control.ReadACLFile(d.ACLFile)
 		if err != nil {
+			if d.jsonOutputEnabled() {
+				return d.errorJSON(err)
+			}
 			return err
 		}
 		acl = aclFileResult
@@ -566,15 +623,16 @@ func (d *PoolUpdateACLCmd) Execute(args []string) error {
 
 	ctx := context.Background()
 	resp, err := control.PoolUpdateACL(ctx, d.ctlInvoker, req)
+
+	if d.jsonOutputEnabled() {
+		return d.outputJSON(resp.ACL, err)
+	}
+
 	if err != nil {
 		return errors.Wrap(err, "Pool-update-ACL command failed")
 	}
 
 	d.log.Infof("Pool-update-ACL command succeeded, UUID: %s\n", d.UUID)
-
-	if d.jsonOutputEnabled() {
-		return d.outputJSON(os.Stdout, resp.ACL)
-	}
 
 	d.log.Info(control.FormatACLDefault(resp.ACL))
 
@@ -600,15 +658,16 @@ func (d *PoolDeleteACLCmd) Execute(args []string) error {
 
 	ctx := context.Background()
 	resp, err := control.PoolDeleteACL(ctx, d.ctlInvoker, req)
+
+	if d.jsonOutputEnabled() {
+		return d.outputJSON(resp.ACL, err)
+	}
+
 	if err != nil {
 		return errors.Wrap(err, "Pool-delete-ACL command failed")
 	}
 
 	d.log.Infof("Pool-delete-ACL command succeeded, UUID: %s\n", d.UUID)
-
-	if d.jsonOutputEnabled() {
-		return d.outputJSON(os.Stdout, resp.ACL)
-	}
 
 	d.log.Info(control.FormatACLDefault(resp.ACL))
 

--- a/src/control/cmd/dmg/storage.go
+++ b/src/control/cmd/dmg/storage.go
@@ -25,7 +25,6 @@ package main
 
 import (
 	"context"
-	"os"
 	"strings"
 
 	"github.com/dustin/go-humanize/english"
@@ -63,6 +62,9 @@ type storagePrepareCmd struct {
 func (cmd *storagePrepareCmd) Execute(args []string) error {
 	prepNvme, prepScm, err := cmd.Validate()
 	if err != nil {
+		if cmd.jsonOutputEnabled() {
+			return cmd.errorJSON(err)
+		}
 		return err
 	}
 
@@ -78,6 +80,9 @@ func (cmd *storagePrepareCmd) Execute(args []string) error {
 	}
 
 	if prepScm {
+		if cmd.jsonOutputEnabled() && !cmd.Force {
+			return cmd.errorJSON(errors.New("Cannot use --json without --force"))
+		}
 		if err := cmd.Warn(cmd.log); err != nil {
 			return err
 		}
@@ -92,12 +97,13 @@ func (cmd *storagePrepareCmd) Execute(args []string) error {
 	}
 	req.SetHostList(cmd.hostlist)
 	resp, err := control.StoragePrepare(ctx, cmd.ctlInvoker, req)
-	if err != nil {
-		return err
-	}
 
 	if cmd.jsonOutputEnabled() {
-		return cmd.outputJSON(os.Stdout, resp)
+		return cmd.outputJSON(resp, err)
+	}
+
+	if err != nil {
+		return err
 	}
 
 	var bld strings.Builder
@@ -129,12 +135,13 @@ func (cmd *storageScanCmd) Execute(_ []string) error {
 	req := &control.StorageScanReq{}
 	req.SetHostList(cmd.hostlist)
 	resp, err := control.StorageScan(ctx, cmd.ctlInvoker, req)
-	if err != nil {
-		return err
-	}
 
 	if cmd.jsonOutputEnabled() {
-		return cmd.outputJSON(os.Stdout, resp)
+		return cmd.outputJSON(resp, err)
+	}
+
+	if err != nil {
+		return err
 	}
 
 	var bld strings.Builder
@@ -219,27 +226,7 @@ func (cmd *storageFormatCmd) shouldReformatSystem(ctx context.Context) (bool, er
 	return false, nil
 }
 
-// Execute is run when storageFormatCmd activates.
-//
-// Run NVMe and SCM storage format on all connected servers.
-func (cmd *storageFormatCmd) Execute(args []string) (err error) {
-	ctx := context.Background()
-
-	sysReformat, err := cmd.shouldReformatSystem(ctx)
-	if err != nil {
-		return err
-	}
-	if !sysReformat {
-		req := &control.StorageFormatReq{Reformat: cmd.Reformat}
-		req.SetHostList(cmd.hostlist)
-		resp, err := control.StorageFormat(ctx, cmd.ctlInvoker, req)
-		if err != nil {
-			return err
-		}
-
-		return cmd.printFormatResp(resp)
-	}
-
+func (cmd *storageFormatCmd) systemReformat(ctx context.Context) error {
 	hostSet, rankSet, err := cmd.validateHostsRanks()
 	if err != nil {
 		return err
@@ -249,6 +236,43 @@ func (cmd *storageFormatCmd) Execute(args []string) (err error) {
 	srReq.Ranks = *rankSet
 
 	resp, err := control.SystemReformat(ctx, cmd.ctlInvoker, srReq)
+
+	if cmd.jsonOutputEnabled() {
+		return cmd.outputJSON(resp, err)
+	}
+
+	if err != nil {
+		return err
+	}
+
+	return cmd.printFormatResp(resp)
+}
+
+// Execute is run when storageFormatCmd activates.
+//
+// Run NVMe and SCM storage format on all connected servers.
+func (cmd *storageFormatCmd) Execute(args []string) (err error) {
+	ctx := context.Background()
+
+	sysReformat, err := cmd.shouldReformatSystem(ctx)
+	if err != nil {
+		if cmd.jsonOutputEnabled() {
+			return cmd.errorJSON(err)
+		}
+		return err
+	}
+	if sysReformat {
+		return cmd.systemReformat(ctx)
+	}
+
+	req := &control.StorageFormatReq{Reformat: cmd.Reformat}
+	req.SetHostList(cmd.hostlist)
+	resp, err := control.StorageFormat(ctx, cmd.ctlInvoker, req)
+
+	if cmd.jsonOutputEnabled() {
+		return cmd.outputJSON(resp, err)
+	}
+
 	if err != nil {
 		return err
 	}
@@ -257,10 +281,6 @@ func (cmd *storageFormatCmd) Execute(args []string) (err error) {
 }
 
 func (cmd *storageFormatCmd) printFormatResp(resp *control.StorageFormatResp) error {
-	if cmd.jsonOutputEnabled() {
-		return cmd.outputJSON(os.Stdout, resp)
-	}
-
 	var bld strings.Builder
 	verbose := control.PrintWithVerboseOutput(cmd.Verbose)
 	if err := control.PrintResponseErrors(resp, &bld); err != nil {
@@ -290,8 +310,13 @@ type nvmeSetFaultyCmd struct {
 // Set the SMD device state of the given device to "FAULTY"
 func (cmd *nvmeSetFaultyCmd) Execute(_ []string) error {
 	cmd.log.Info("WARNING: This command will permanently mark the device as unusable!")
-	if !cmd.Force && !common.GetConsent(cmd.log) {
-		return errors.New("consent not given")
+	if !cmd.Force {
+		if cmd.jsonOutputEnabled() {
+			return cmd.errorJSON(errors.New("Cannot use --json without --force"))
+		}
+		if !common.GetConsent(cmd.log) {
+			return errors.New("consent not given")
+		}
 	}
 
 	ctx := context.Background()

--- a/src/control/cmd/dmg/storage_query.go
+++ b/src/control/cmd/dmg/storage_query.go
@@ -25,7 +25,6 @@ package main
 
 import (
 	"context"
-	"os"
 	"strconv"
 	"strings"
 
@@ -55,12 +54,13 @@ type smdQueryCmd struct {
 func (cmd *smdQueryCmd) makeRequest(ctx context.Context, req *control.SmdQueryReq, opts ...control.PrintConfigOption) error {
 	req.SetHostList(cmd.hostlist)
 	resp, err := control.SmdQuery(ctx, cmd.ctlInvoker, req)
-	if err != nil {
-		return err
-	}
 
 	if cmd.jsonOutputEnabled() {
-		return cmd.outputJSON(os.Stdout, resp)
+		return cmd.outputJSON(resp, err)
+	}
+
+	if err != nil {
+		return err
 	}
 
 	var bld strings.Builder
@@ -96,12 +96,13 @@ func (cmd *nvmeHealthQueryCmd) Execute(args []string) error {
 	req := &control.StorageScanReq{}
 	req.SetHostList(cmd.hostlist)
 	resp, err := control.StorageScan(ctx, cmd.ctlInvoker, req)
-	if err != nil {
-		return err
-	}
 
 	if cmd.jsonOutputEnabled() {
-		return cmd.outputJSON(os.Stdout, resp)
+		return cmd.outputJSON(resp, err)
+	}
+
+	if err != nil {
+		return err
 	}
 
 	var bld strings.Builder

--- a/src/control/cmd/dmg/system.go
+++ b/src/control/cmd/dmg/system.go
@@ -27,7 +27,6 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"os"
 	"strings"
 
 	"github.com/dustin/go-humanize/english"
@@ -61,12 +60,13 @@ func (cmd *leaderQueryCmd) Execute(_ []string) error {
 	resp, err := control.LeaderQuery(ctx, cmd.ctlInvoker, &control.LeaderQueryReq{
 		System: cmd.config.SystemName,
 	})
-	if err != nil {
-		return errors.Wrap(err, "leader query failed")
-	}
 
 	if cmd.jsonOutputEnabled() {
-		return cmd.outputJSON(os.Stdout, resp)
+		return cmd.outputJSON(resp, err)
+	}
+
+	if err != nil {
+		return errors.Wrap(err, "leader query failed")
 	}
 
 	cmd.log.Infof("Current Leader: %s\n   Replica Set: %s\n", resp.Leader,
@@ -209,12 +209,13 @@ func (cmd *systemQueryCmd) Execute(_ []string) error {
 	req.Ranks = *rankSet
 
 	resp, err := control.SystemQuery(context.Background(), cmd.ctlInvoker, req)
-	if err != nil {
-		return errors.Wrap(err, "System-Query command failed")
-	}
 
 	if cmd.jsonOutputEnabled() {
-		return cmd.outputJSON(os.Stdout, resp)
+		return cmd.outputJSON(resp, err)
+	}
+
+	if err != nil {
+		return errors.Wrap(err, "System-Query command failed")
 	}
 
 	cmd.log.Debugf("System-Query command succeeded, absent hosts: %s, absent ranks: %s",
@@ -333,12 +334,13 @@ func (cmd *systemStopCmd) Execute(_ []string) error {
 
 	// TODO DAOS-5079: group errors when ranks don't exist
 	resp, err := control.SystemStop(context.Background(), cmd.ctlInvoker, req)
-	if err != nil {
-		return errors.Wrap(err, "System-Stop command failed")
-	}
 
 	if cmd.jsonOutputEnabled() {
-		return cmd.outputJSON(os.Stdout, resp)
+		return cmd.outputJSON(resp, err)
+	}
+
+	if err != nil {
+		return errors.Wrap(err, "System-Stop command failed")
 	}
 
 	if len(resp.Results) == 0 {
@@ -372,12 +374,13 @@ func (cmd *systemStartCmd) Execute(_ []string) error {
 
 	// TODO DAOS-5079: group errors when ranks don't exist
 	resp, err := control.SystemStart(context.Background(), cmd.ctlInvoker, req)
-	if err != nil {
-		return errors.Wrap(err, "System-Start command failed")
-	}
 
 	if cmd.jsonOutputEnabled() {
-		return cmd.outputJSON(os.Stdout, resp)
+		return cmd.outputJSON(resp, err)
+	}
+
+	if err != nil {
+		return errors.Wrap(err, "System-Start command failed")
 	}
 
 	if len(resp.Results) == 0 {
@@ -421,12 +424,13 @@ func (cmd *systemListPoolsCmd) Execute(_ []string) error {
 	resp, err := control.ListPools(ctx, cmd.ctlInvoker, &control.ListPoolsReq{
 		System: cmd.config.SystemName,
 	})
-	if err != nil {
-		return errors.Wrap(err, "List-Pools command failed")
-	}
 
 	if cmd.jsonOutputEnabled() {
-		return cmd.outputJSON(os.Stdout, resp)
+		return cmd.outputJSON(resp, err)
+	}
+
+	if err != nil {
+		return errors.Wrap(err, "List-Pools command failed")
 	}
 
 	if len(resp.Pools) == 0 {

--- a/src/tests/ftest/checksum/csum_error_logging.py
+++ b/src/tests/ftest/checksum/csum_error_logging.py
@@ -60,9 +60,13 @@ class CSumErrorLog(DaosCoreBase):
             self.fail("dmg command failed: {}".format(details))
 
         data = json.loads(result.stdout)
-        if len(data['host_errors']) > 0:
-            self.fail("dmg command failed: {}".format(data['host_errors']))
-        for v in data['host_storage_map'].values():
+        resp = data['response']
+        if data['error'] or len(resp['host_errors']) > 0:
+            if data['error']:
+                self.fail("dmg command failed: {}".format(data['error']))
+            else:
+                self.fail("dmg command failed: {}".format(resp['host_errors']))
+        for v in resp['host_storage_map'].values():
             if v['storage']['smd_info']['devices']:
                 return v['storage']['smd_info']['devices'][0]['uuid']
 
@@ -82,9 +86,13 @@ class CSumErrorLog(DaosCoreBase):
             self.fail("dmg command failed: {}".format(details))
 
         data = json.loads(result.stdout)
-        if len(data['host_errors']) > 0:
-            self.fail("dmg command failed: {}".format(data['host_errors']))
-        for v in data['host_storage_map'].values():
+        resp = data['response']
+        if data['error'] or len(resp['host_errors']) > 0:
+            if data['error']:
+                self.fail("dmg command failed: {}".format(data['error']))
+            else:
+                self.fail("dmg command failed: {}".format(resp['host_errors']))
+        for v in resp['host_storage_map'].values():
             if v['storage']['smd_info']['devices']:
                 dev = v['storage']['smd_info']['devices'][0]
                 return dev['health']['checksum_errors']


### PR DESCRIPTION
Errors should be included in the JSON output. Adds
a new test to verify that all commands can produce
JSON results.
