### PR TITLE
DAOS-4410 common: fix retry loop upon -DER_INVAL

### DIFF
--- a/src/common/rsvc.c
+++ b/src/common/rsvc.c
@@ -239,7 +239,12 @@ rsvc_client_complete_rpc(struct rsvc_client *client, const crt_endpoint_t *ep,
 	 * Enumerate all cases of <rc_crt, rc_svc, hint>. Keep them at the same
 	 * indentation level, please.
 	 */
-	if (rc_crt == -DER_OOG) {
+	if (rc_crt == -DER_INVAL) {
+		D_DEBUG(DB_MD, "group-id %s does not exist for rank %u: rc_crt=%d\n",
+			ep->ep_grp->cg_grpid, ep->ep_rank, rc_crt);
+		rsvc_client_process_error(client, rc_crt, ep);
+		return RSVC_CLIENT_PROCEED;
+	} else if (rc_crt == -DER_OOG) {
 		D_DEBUG(DB_MD, "rank %u out of group: rc_crt=%d\n",
 			ep->ep_rank, rc_crt);
 		rsvc_client_process_error(client, rc_crt, ep);

--- a/src/tests/ftest/pool/evict_test.py
+++ b/src/tests/ftest/pool/evict_test.py
@@ -112,8 +112,7 @@ class EvictTests(TestWithServers):
         # exception is expected
         except DaosApiError as result:
             if test_param == "BAD_SERVER_NAME":
-                # Due to DAOS-3835, no specific error code is available for now.
-                err = "-1025"
+                err = "-1003"
             else:
                 err = "-1005"
             status = err in str(result)
@@ -266,7 +265,7 @@ class EvictTests(TestWithServers):
         """
         Test evicting a pool using an invalid server group name.
 
-        :avocado: tags=all,pool,full_regression,small,poolevict
+        :avocado: tags=all,pool,pr,full_regression,small,poolevict
         :avocado: tags=poolevict_bad_server_name
         """
         test_param = self.params.get("server_name", '/run/badparams/*')


### PR DESCRIPTION
If a wrong/unexisting group-id is provided as part of pool
evict request, this cause to enter an endless loop resending
the same RPC/request.
This patch fixes handling of specific error in retry logic, and
also associated CI test using wrong/old error value.
Also reenables disabled CI test due to problem.

Change-Id: I54ee37a530bd324f91b2d8207c48a736ac39ee78
Signed-off-by: Bruno Faccini <bruno.faccini@intel.com>