### PR TITLE
DAOS-5195 hlc: Refine epsilon-related computations

### DIFF
--- a/src/cart/src/cart/crt_hlc.c
+++ b/src/cart/src/cart/crt_hlc.c
@@ -92,11 +92,17 @@ uint64_t crt_hlc2sec(uint64_t hlc)
 
 void crt_hlc_epsilon_set(uint64_t epsilon)
 {
-	D_INFO("setting maximum system clock offset to "DF_U64" ns\n", epsilon);
-	crt_hlc_epsilon = epsilon;
+	crt_hlc_epsilon = (epsilon + CRT_HLC_MASK) & ~CRT_HLC_MASK;
+	D_INFO("set maximum system clock offset to "DF_U64" ns\n",
+	       crt_hlc_epsilon);
 }
 
 uint64_t crt_hlc_epsilon_get(void)
 {
 	return crt_hlc_epsilon;
+}
+
+uint64_t crt_hlc_epsilon_get_bound(uint64_t hlc)
+{
+	return (hlc + crt_hlc_epsilon) | CRT_HLC_MASK;
 }

--- a/src/cart/src/include/cart/api.h
+++ b/src/cart/src/include/cart/api.h
@@ -478,7 +478,8 @@ crt_hlc2sec(uint64_t hlc);
  *
  * This is the maximum offset believed to be observable between the physical
  * clocks behind any two HLCs in the system. The format of the value represent
- * a nonnegative diff between two HLC timestamps.
+ * a nonnegative diff between two HLC timestamps. The value is rounded up to
+ * the HLC physical resolution.
  *
  * \param[in] epsilon          Nonnegative HLC duration
  */
@@ -492,6 +493,17 @@ crt_hlc_epsilon_set(uint64_t epsilon);
  */
 uint64_t
 crt_hlc_epsilon_get(void);
+
+/**
+ * Get the upper bound of the HLC timestamp of an event happened before
+ * (through out of band communication) the event at \a hlc.
+ * 
+ * \param[in] hlc              HLC timestamp
+ * 
+ * \return                     Upper bound HLC timestamp
+ */
+uint64_t
+crt_hlc_epsilon_get_bound(uint64_t hlc);
 
 /**
  * Abort an RPC request.

--- a/src/cart/src/include/cart/api.h
+++ b/src/cart/src/include/cart/api.h
@@ -497,9 +497,9 @@ crt_hlc_epsilon_get(void);
 /**
  * Get the upper bound of the HLC timestamp of an event happened before
  * (through out of band communication) the event at \a hlc.
- * 
+ *
  * \param[in] hlc              HLC timestamp
- * 
+ *
  * \return                     Upper bound HLC timestamp
  */
 uint64_t

--- a/src/dtx/dtx_common.c
+++ b/src/dtx/dtx_common.c
@@ -235,7 +235,7 @@ dtx_epoch_bound(struct dtx_epoch *epoch)
 		 */
 		return epoch->oe_value;
 
-	limit = epoch->oe_first + crt_hlc_epsilon_get();
+	limit = crt_hlc_epsilon_get_bound(epoch->oe_first);
 	if (epoch->oe_value >= limit)
 		/*
 		 * The epoch is already out of the potential uncertainty


### PR DESCRIPTION
Refine the epsilon-based HLC upper bound computation, especially to
incorporate the maximum logical timestamp.

Signed-off-by: Li Wei <wei.g.li@intel.com>