### PR TITLE
DAOS-5369 pool: missing ds_pool_put

### DIFF
--- a/src/pool/srv_pool.c
+++ b/src/pool/srv_pool.c
@@ -4960,6 +4960,7 @@ is_container_from_srv(uuid_t pool_uuid, uuid_t coh_uuid)
 	}
 
 	rc = ds_pool_iv_srv_hdl_fetch(pool, NULL, &hdl_uuid);
+	ds_pool_put(pool);
 	if (rc) {
 		D_ERROR(DF_UUID" fetch srv hdl: %d\n", DP_UUID(pool_uuid), rc);
 		return false;


### PR DESCRIPTION
missing ds_pool_put in is_container_from_srv().

Signed-off-by: Di Wang <di.wang@intel.com>