### PR TITLE
DAOS-5369 test: add dmg_config_file back

### DIFF
--- a/src/tests/ftest/util/daos_core_base.py
+++ b/src/tests/ftest/util/daos_core_base.py
@@ -62,14 +62,16 @@ class DaosCoreBase(TestWithServers):
                                        '/run/daos_tests/num_replicas/*')
         scm_size = self.params.get("scm_size", '/run/pool/*')
         args = self.params.get("args", '/run/daos_tests/Tests/*', "")
+        dmg = self.get_dmg_command()
+        dmg_config_file = dmg.yaml.filename
 
         cmd = "{} {} -n {} -x D_LOG_FILE={} \
             -x D_LOG_MASK=DEBUG -x DD_MASK=mgmt,io,md,epc,rebuild \
-            {} -s {} -n {} {}".format(self.orterun, self.client_mca,
+            {} -s {} -n {} -{} {}".format(self.orterun, self.client_mca,
                                       num_clients,
                                       get_log_file(self.client_log),
                                       self.daos_test, num_replicas,
-                                      subtest, args)
+                                      dmg_config_file, subtest, args)
 
         env = {}
         env['CMOCKA_XML_FILE'] = "%g_results.xml"


### PR DESCRIPTION
PR-3046 remove dmg_config_file from daos_test, which
may cause tests being run multiple time, let's
Add dmg_config_file back to daos_test run cmd.

Signed-off-by: Di Wang <di.wang@intel.com>