### PR TITLE
DAOS-5333 Pool: Fixed Drained Targets Not Moving to DOWNOUT

### DIFF
--- a/src/pool/srv_util.c
+++ b/src/pool/srv_util.c
@@ -349,13 +349,13 @@ update_one_tgt(struct pool_map *map, struct pool_target *target,
 			       target->ta_comp.co_rank,
 				target->ta_comp.co_index);
 			break;
-		case PO_COMP_ST_DRAIN:
 		case PO_COMP_ST_UP:
 		case PO_COMP_ST_UPIN:
 			D_ERROR("Can't EXCLOUT non-down tgt (rank %u idx %u)\n",
 				target->ta_comp.co_rank,
 				target->ta_comp.co_index);
 			return -DER_INVAL;
+		case PO_COMP_ST_DRAIN:
 		case PO_COMP_ST_DOWN:
 			D_DEBUG(DF_DSMS, "change target %u/%u to DOWNOUT %p\n",
 				target->ta_comp.co_rank,
@@ -374,6 +374,9 @@ update_one_tgt(struct pool_map *map, struct pool_target *target,
 			}
 		}
 		break;
+	default:
+		D_ERROR("Invalid pool target opeartion: %d\n", opc);
+		D_ASSERT(0);
 	}
 
 	return DER_SUCCESS;

--- a/src/pool/srv_util.c
+++ b/src/pool/srv_util.c
@@ -375,7 +375,7 @@ update_one_tgt(struct pool_map *map, struct pool_target *target,
 		}
 		break;
 	default:
-		D_ERROR("Invalid pool target opeartion: %d\n", opc);
+		D_ERROR("Invalid pool target operation: %d\n", opc);
 		D_ASSERT(0);
 	}
 


### PR DESCRIPTION
There was an error in the target update case statement that wouldn't
allow drained targets to move to the DOWNOUT state.

Also added an assert for unhandled target update op codes.

Signed-off-by: Peter Fetros <peter.fetros@intel.com>