### PR TITLE
DAOS-4604 vos: add vea overhead to vos_size.yaml

### DIFF
--- a/src/common/btree_class.c
+++ b/src/common/btree_class.c
@@ -1398,7 +1398,21 @@ iv_rec_string(struct btr_instance *tins, struct btr_record *rec, bool leaf,
 	return buf;
 }
 
+static int
+iv_key_msize(int alloc_overhead)
+{
+	return alloc_overhead + sizeof(struct iv_rec);
+}
+
+static int
+iv_hkey_size(void)
+{
+	return sizeof(uint32_t);
+}
+
 btr_ops_t dbtree_iv_ops = {
+	.to_rec_msize	= iv_key_msize,
+	.to_hkey_size	= iv_hkey_size,
 	.to_key_cmp	= iv_key_cmp,
 	.to_key_encode	= iv_key_encode,
 	.to_key_decode	= iv_key_decode,

--- a/src/include/daos_srv/vos_types.h
+++ b/src/include/daos_srv/vos_types.h
@@ -428,7 +428,7 @@ struct vos_iter_anchors {
 			ia_reprobe_ev:1;
 };
 
-/* Ignores DTX as they are transient records.   Add VEA overheads later */
+/* Ignores DTX as they are transient records */
 enum VOS_TREE_CLASS {
 	VOS_TC_CONTAINER,
 	VOS_TC_OBJECT,
@@ -436,6 +436,7 @@ enum VOS_TREE_CLASS {
 	VOS_TC_AKEY,
 	VOS_TC_SV,
 	VOS_TC_ARRAY,
+	VOS_TC_VEA,
 };
 
 #endif /* __VOS_TYPES_H__ */

--- a/src/vos/vos_internal.h
+++ b/src/vos/vos_internal.h
@@ -85,7 +85,8 @@
 #define VOS_KTR_ORDER		23	/* order of d/a-key tree */
 #define VOS_SVT_ORDER		5	/* order of single value tree */
 #define VOS_EVT_ORDER		23	/* evtree order */
-#define DTX_BTREE_ORDER		23	/* Order for DTX tree */
+#define DTX_BTREE_ORDER	23	/* Order for DTX tree */
+#define VEA_TREE_ODR		20	/* Order of a VEA tree */
 
 #define DAOS_VOS_VERSION 1
 

--- a/src/vos/vos_overhead.c
+++ b/src/vos/vos_overhead.c
@@ -54,6 +54,10 @@ vos_tree_get_overhead(int alloc_overhead, enum VOS_TREE_CLASS tclass,
 		tree_order = VOS_SVT_ORDER;
 		btr_class = VOS_BTR_SINGV;
 		break;
+	case VOS_TC_VEA:
+		tree_order = VEA_TREE_ODR;
+		btr_class = DBTREE_CLASS_IV;
+		break;
 	default:
 		D_ASSERT(0);
 		break;

--- a/src/vos/vos_size.c
+++ b/src/vos/vos_size.c
@@ -42,7 +42,8 @@
 	ACTION(integer_dkey, VOS_TC_DKEY, BTR_FEAT_DIRECT_KEY)		\
 	ACTION(integer_akey, VOS_TC_AKEY, BTR_FEAT_DIRECT_KEY)		\
 	ACTION(single_value, VOS_TC_SV, 0)				\
-	ACTION(array, VOS_TC_ARRAY, 0)
+	ACTION(array, VOS_TC_ARRAY, 0)					\
+	ACTION(vea, VOS_TC_VEA, 0)
 
 #define DECLARE_TYPE(name, type, feats)	\
 	struct daos_tree_overhead	name;

--- a/src/vos/vos_tree.c
+++ b/src/vos/vos_tree.c
@@ -27,6 +27,7 @@
  */
 #define D_LOGFAC	DD_FAC(vos)
 
+#include <daos/btree_class.h>
 #include <daos/btree.h>
 #include <daos/mem.h>
 #include <daos/object.h>
@@ -714,6 +715,13 @@ static struct vos_btr_attr vos_btr_attrs[] = {
 		.ta_feats	= BTR_FEAT_DYNAMIC_ROOT,
 		.ta_name	= "singv",
 		.ta_ops		= &singv_btr_ops,
+	},
+	{
+		.ta_class	= DBTREE_CLASS_IV,
+		.ta_order	= VEA_TREE_ODR,
+		.ta_feats	= BTR_FEAT_UINT_KEY | BTR_FEAT_DIRECT_KEY,
+		.ta_name	= "vea",
+		.ta_ops		= &dbtree_iv_ops,
 	},
 	{
 		.ta_class	= VOS_BTR_END,


### PR DESCRIPTION
Retrieve VEA trees overhead and save these metadata
into vos_size.yaml file.

Signed-off-by: Martinez Montes, Jonathan <jonathan.martinez.montes@intel.com>