### PR TITLE
DAOS-4345 swim: network glitch detection

### DIFF
--- a/src/cart/crt_swim.h
+++ b/src/cart/crt_swim.h
@@ -46,9 +46,11 @@ struct crt_swim_membs {
 	D_CIRCLEQ_HEAD(, crt_swim_target) csm_head;
 	struct crt_swim_target		*csm_target;
 	struct swim_context		*csm_ctx;
+	uint64_t			 csm_hlc;
+	uint64_t			 csm_avg_delay;
+	uint64_t			 csm_msg_count;
 	int				 csm_crt_ctx_idx;
 };
-
 
 int  crt_swim_enable(struct crt_grp_priv *grp_priv, int crt_ctx_idx);
 int  crt_swim_disable(struct crt_grp_priv *grp_priv, int crt_ctx_idx);

--- a/src/include/cart/swim.h
+++ b/src/include/cart/swim.h
@@ -200,6 +200,15 @@ int swim_parse_message(struct swim_context *ctx, swim_id_t from,
  */
 int swim_progress(struct swim_context *ctx, int64_t timeout);
 
+/**
+ * Update the state machine of SWIM protocol with unexpected network glitch.
+ *
+ * @param[in]  ctx   SWIM context pointer from swim_init()
+ * @param[in]  delay The amount of time in milliseconds by which
+ *                   ALL timeouts will be shifted.
+ * @returns          0 on success, negative error ID otherwise
+ */
+int swim_net_glitch_update(struct swim_context *ctx, uint64_t delay);
 /** @} */
 
 #ifdef __cplusplus

--- a/src/tests/ftest/util/server_utils_params.py
+++ b/src/tests/ftest/util/server_utils_params.py
@@ -355,10 +355,7 @@ class DaosServerYamlParameters(YamlParameters):
                 default_env_vars.extend([
                     "FI_SOCKETS_MAX_CONN_RETRY=5",
                     "FI_SOCKETS_CONN_TIMEOUT=2000",
-                    "CRT_SWIM_RPC_TIMEOUT=10",
-                    "SWIM_PING_TIMEOUT=10000",
-                    "SWIM_PROTOCOL_PERIOD_LEN=30000",
-                    "SWIM_SUSPECT_TIMEOUT=90000",
+                    "CRT_SWIM_RPC_TIMEOUT=10"
                 ])
             self.env_vars = BasicParameter(None, default_env_vars)
 


### PR DESCRIPTION
Based on HLC timestamp from RPC detect the network glitch.
If network glitches happens very frequently tune timeouts
accordantly.
