### PR TITLE
DAOS-5390 tests: Reduce logging of certificate file copies

### DIFF
--- a/src/tests/ftest/util/command_utils.py
+++ b/src/tests/ftest/util/command_utils.py
@@ -765,14 +765,15 @@ class YamlCommand(SubProcessCommand):
                 for name in data:
                     run_command(
                         "clush -S -v -w {} /usr/bin/mkdir -p {}".format(
-                            ",".join(hosts), name))
+                            ",".join(hosts), name),
+                        verbose=False)
                     for file_name in data[name]:
                         src_file = os.path.join(source, file_name)
                         dst_file = os.path.join(name, file_name)
                         result = run_command(
                             "clush -S -v -w {} --copy {} --dest {}".format(
                                 ",".join(hosts), src_file, dst_file),
-                            raise_exception=False)
+                            raise_exception=False, verbose=False)
                         if result.exit_status != 0:
                             self.log.info(
                                 "WARNING: failure copying '%s' to '%s' on %s",


### PR DESCRIPTION
Reduce log file sizes by only logging details about the
certificate file mkdir and scp commands if the commands fail.

Signed-off-by: Phillip Henderson <phillip.henderson@intel.com>