### PR TITLE
DAOS-5332 test: Fix pool ver check after exclude.

### DIFF
--- a/src/tests/ftest/osa/osa_offline_reintegration.py
+++ b/src/tests/ftest/osa/osa_offline_reintegration.py
@@ -149,21 +149,36 @@ class OSAOfflineReintegration(TestWithServers):
             output = self.dmg_command.pool_exclude(self.pool.uuid,
                                                    rank, t_string)
             self.log.info(output)
-            time.sleep(10)
-            pver_exclude = self.get_pool_version()
+
+            fail_count = 0
+            while fail_count <= 20:
+                pver_exclude = self.get_pool_version()
+                time.sleep(10)
+                fail_count += 1
+                if pver_exclude > (pver_begin + len(target_list)):
+                    break
+
             self.log.info("Pool Version after exclude %s", pver_exclude)
             # Check pool version incremented after pool exclude
-            self.assertTrue(pver_exclude > pver_begin,
+            self.assertTrue(pver_exclude > (pver_begin + len(target_list)),
                             "Pool Version Error:  After exclude")
             output = self.dmg_command.pool_reintegrate(self.pool.uuid,
                                                        rank,
                                                        t_string)
             self.log.info(output)
-            time.sleep(10)
+
+            fail_count = 0
+            while fail_count <= 20:
+                pver_reint = self.get_pool_version()
+                time.sleep(10)
+                fail_count += 1
+                if pver_reint > (pver_exclude + 1):
+                    break
+
             pver_reint = self.get_pool_version()
             self.log.info("Pool Version after reintegrate %d", pver_reint)
             # Check pool version incremented after pool reintegrate
-            self.assertTrue(pver_reint > pver_exclude,
+            self.assertTrue(pver_reint > (pver_exclude + 1),
                             "Pool Version Error:  After reintegrate")
 
         for val in range(0, num_pool):

--- a/src/tests/ftest/osa/osa_online_reintegration.py
+++ b/src/tests/ftest/osa/osa_online_reintegration.py
@@ -207,20 +207,32 @@ class OSAOnlineReintegration(TestWithServers):
             output = self.dmg_command.pool_exclude(self.pool.uuid,
                                                    rank, t_string)
             self.log.info(output)
-            time.sleep(70)
 
-            pver_exclude = self.get_pool_version()
+            fail_count = 0
+            while fail_count <= 20:
+                pver_exclude = self.get_pool_version()
+                time.sleep(10)
+                fail_count += 1
+                if pver_exclude > (pver_begin + len(target_list)):
+                    break
+
             self.log.info("Pool Version after exclude %s", pver_exclude)
             # Check pool version incremented after pool exclude
-            self.assertTrue(pver_exclude > (pver_begin + 1),
+            self.assertTrue(pver_exclude > (pver_begin + len(target_list)),
                             "Pool Version Error:  After exclude")
             output = self.dmg_command.pool_reintegrate(self.pool.uuid,
                                                        rank,
                                                        t_string)
             self.log.info(output)
-            time.sleep(70)
 
-            pver_reint = self.get_pool_version()
+            fail_count = 0
+            while fail_count <= 20:
+                pver_reint = self.get_pool_version()
+                time.sleep(10)
+                fail_count += 1
+                if pver_reint > (pver_exclude + 1):
+                    break
+
             self.log.info("Pool Version after reintegrate %d", pver_reint)
             # Check pool version incremented after pool reintegrate
             self.assertTrue(pver_reint > (pver_exclude + 1),


### PR DESCRIPTION
Summary:
Fix the following issues on the reintegration script:
- Pool versions are incremented by the number of failed targets (or
excluded)
- Add a timeout loop with 10 second increments (instead of long
timeouts)

Signed-off-by: Padmanabhan <ravindran.padmanabhan@intel.com>