### PR TITLE
DAOS-2666 dfuse: check for FS that does not support xattr on dfuse mount

### DIFF
--- a/src/client/dfuse/dfuse_main.c
+++ b/src/client/dfuse/dfuse_main.c
@@ -444,7 +444,7 @@ main(int argc, char **argv)
 		}
 		uuid_copy(dfp->dfp_pool, duns_attr.da_puuid);
 		uuid_copy(dfs->dfs_cont, duns_attr.da_cuuid);
-	} else if (rc == ENODATA) {
+	} else if (rc == ENODATA || rc == ENOTSUP) {
 		if (dfuse_info->di_pool) {
 
 			if (uuid_parse(dfuse_info->di_pool,


### PR DESCRIPTION
when starting dfuse mount point on a FS that does not support xattr, we
should detect that and bypass the error and mount without supporting
the dfuse mount as a UNS point.

Signed-off-by: Mohamad Chaarawi <mohamad.chaarawi@intel.com>