### PR TITLE
DAOS-5396 Test: Update the test code for recent changes in certificate.

### DIFF
--- a/src/tests/ftest/nvme/nvme_fault.yaml
+++ b/src/tests/ftest/nvme/nvme_fault.yaml
@@ -34,6 +34,14 @@ server_config:
       scm_list: ["/dev/pmem1"]
       scm_mount: /mnt/daos1
       log_mask: ERR
+  transport_config:
+    allow_insecure: True
+agent_config:
+  transport_config:
+    allow_insecure: True
+dmg:
+  transport_config:
+    allow_insecure: True
 pool:
     mode: 146
     name: daos_server
@@ -55,7 +63,7 @@ ior:
       transfer_size: 16777216 #16M
   objectclass:
     RP_2G1:
-      obj_class: "RP_2G1"
+      daos_oclass: "RP_2G1"
 faulttests:
   pool_capacity:
     10_Percent:

--- a/src/tests/ftest/nvme/nvme_health.yaml
+++ b/src/tests/ftest/nvme/nvme_health.yaml
@@ -31,6 +31,14 @@ server_config:
       scm_class: dcpm
       scm_list: ["/dev/pmem1"]
       scm_mount: /mnt/daos1
+  transport_config:
+    allow_insecure: True
+agent_config:
+  transport_config:
+    allow_insecure: True
+dmg:
+  transport_config:
+    allow_insecure: True
 pool:
     mode: 146
     name: daos_server

--- a/src/tests/ftest/nvme/nvme_io_stats.py
+++ b/src/tests/ftest/nvme/nvme_io_stats.py
@@ -54,18 +54,6 @@ class NvmeIOStates(IorTestBase):
 
         :avocado: tags=all,hw,medium,nvme,ib2,nvme_io_stats,full_regression
         """
-        transfer_block_size = self.params.get("transfer_block_size",
-                                              '/run/ior/iorflags/*')
-
-        # Update IOR parameter
-        self.ior_cmd.flags.update(self.params.get("ior_flags",
-                                                  '/run/ior/iorflags/*'))
-        self.ior_cmd.daos_oclass.update(self.params.get("obj_class",
-                                                        '/run/ior/iorflags/*'))
-        self.ior_cmd.api.update(self.params.get("ior_api",
-                                                '/run/ior/iorflags/*'))
-        self.ior_cmd.transfer_size.update(transfer_block_size[0])
-        self.ior_cmd.block_size.update(transfer_block_size[1])
         # run ior
         self.run_ior_with_pool()
 

--- a/src/tests/ftest/nvme/nvme_io_stats.yaml
+++ b/src/tests/ftest/nvme/nvme_io_stats.yaml
@@ -21,14 +21,16 @@ pool:
     svcn: 1
     control_method: dmg
 ior:
-    client_processes:
-        np_16:
-            np: 16
-    test_file: daos:testFile
-    repetitions: 2
-    daos_destroy: False
-    iorflags:
-          ior_flags: "-v -W -w -r -R"
-          ior_api: DAOS
-          transfer_block_size: [1M, 2G]
-          obj_class: "SX"
+  api: "DAOS"
+  client_processes:
+    np: 16
+  daos_destroy: False
+  iorflags:
+      flags: "-v -W -w -r -R"
+  test_file: daos:testFile
+  repetitions: 2
+  transfer_size: '1M'
+  block_size: '1G'
+  objectclass:
+    SX:
+      daos_oclass: "SX"

--- a/src/tests/ftest/util/nvme_utils.py
+++ b/src/tests/ftest/util/nvme_utils.py
@@ -28,6 +28,7 @@ import os
 
 from general_utils import run_task
 from command_utils_base import CommandFailure
+from avocado.core.exceptions import TestFail
 from ior_test_base import IorTestBase
 from test_utils_pool import TestPool
 
@@ -247,7 +248,7 @@ class ServerFillUp(IorTestBase):
         try:
             self.run_ior_with_pool(create_cont=_create_cont)
             results.put("PASS")
-        except CommandFailure as _error:
+        except (CommandFailure, TestFail) as _error:
             results.put("FAIL")
 
         self.container_info["{}{}{}"


### PR DESCRIPTION
Fix certificate in tests nvme_health.py and nvme_fault.py
Removed IOR read param lines from nvme_io_stats.py

Test-tag-hw-medium: nvme_health
Test-tag-hw-medium: nvme_io_stats
Test-tag-hw-medium: nvme_fault

Signed-off-by: Samir Raval <samir.raval@intel.com>