### PR TITLE
DAOS-5411 hash: simplify hash calculation for uuid

### DIFF
--- a/src/gurt/hash.c
+++ b/src/gurt/hash.c
@@ -1364,20 +1364,21 @@ uh_op_key_hash(struct d_hash_table *htable, const void *key, unsigned int ksize)
 {
 	struct d_uhash_bundle	*uhbund	= (struct d_uhash_bundle *)key;
 	struct d_uuid		*lkey	= uhbund->key;
+	uint32_t		*retp	= (uint32_t *)lkey->uuid;
 
 	D_ASSERT(ksize == sizeof(struct d_uhash_bundle));
 	D_DEBUG(DB_TRACE, "uuid_key: "CF_UUID"\n", CP_UUID(lkey->uuid));
 
-	return d_hash_string_u32((const char *)lkey->uuid, sizeof(uuid_t));
+	return *retp;
 }
 
 static uint32_t
 uh_op_rec_hash(struct d_hash_table *htable, d_list_t *link)
 {
 	struct d_ulink		*ulink	= link2ulink(link);
+	uint32_t		*retp	= (uint32_t *)ulink->ul_uuid.uuid;
 
-	return d_hash_string_u32((const char *)ulink->ul_uuid.uuid,
-				 sizeof(uuid_t));
+	return *retp;
 }
 
 static bool

--- a/src/iosrv/sched.c
+++ b/src/iosrv/sched.c
@@ -223,7 +223,7 @@ static uint32_t
 spi_key_hash(struct d_hash_table *htable, const void *key, unsigned int len)
 {
 	D_ASSERT(len == sizeof(uuid_t));
-	return d_hash_string_u32((const char *)key, len);
+	return *((const uint32_t *)key);
 }
 
 static void

--- a/src/placement/pl_map.c
+++ b/src/placement/pl_map.c
@@ -333,7 +333,7 @@ pl_hop_key_hash(struct d_hash_table *htab, const void *key,
 		unsigned int ksize)
 {
 	D_ASSERT(ksize == sizeof(uuid_t));
-	return d_hash_string_u32((const char *)key, ksize);
+	return *((const uint32_t *)key);
 }
 
 static bool

--- a/src/pool/srv_target.c
+++ b/src/pool/srv_target.c
@@ -586,11 +586,20 @@ pool_hdl_key_cmp(struct d_hash_table *htable, d_list_t *rlink,
 }
 
 static uint32_t
+pool_hdl_key_hash(struct d_hash_table *htable, const void *key,
+		  unsigned int ksize)
+{
+	D_ASSERTF(ksize == sizeof(uuid_t), "%u\n", ksize);
+	return *((const uint32_t *)key);
+}
+
+static uint32_t
 pool_hdl_rec_hash(struct d_hash_table *htable, d_list_t *link)
 {
 	struct ds_pool_hdl *hdl = pool_hdl_obj(link);
+	uint32_t *retp = (uint32_t *)hdl->sph_uuid;
 
-	return d_hash_string_u32((const char *)hdl->sph_uuid, sizeof(uuid_t));
+	return *retp;
 }
 
 static void
@@ -625,6 +634,7 @@ pool_hdl_rec_free(struct d_hash_table *htable, d_list_t *rlink)
 
 static d_hash_table_ops_t pool_hdl_hash_ops = {
 	.hop_key_cmp	= pool_hdl_key_cmp,
+	.hop_key_hash	= pool_hdl_key_hash,
 	.hop_rec_hash	= pool_hdl_rec_hash,
 	.hop_rec_addref	= pool_hdl_rec_addref,
 	.hop_rec_decref	= pool_hdl_rec_decref,


### PR DESCRIPTION
An uuid is randomly generated and don't required additional
complex hashing function.

Performance of **mdtest** master (build 2647):
```
2020-08-08 08:11:21,411 process          L0479 DEBUG| [stdout] 8 tasks, 8000 files/directories
2020-08-08 08:11:30,844 process          L0479 DEBUG| [stdout]    Operation                      Max            Min           Mean        Std Dev
2020-08-08 08:11:30,844 process          L0479 DEBUG| [stdout]    ---------                      ---            ---           ----        -------
2020-08-08 08:11:30,844 process          L0479 DEBUG| [stdout]    Directory creation        :      45359.790      45345.432      45352.562          7.077
2020-08-08 08:11:30,844 process          L0479 DEBUG| [stdout]    Directory stat            :      73820.123      73809.792      73814.974          4.955
2020-08-08 08:11:30,844 process          L0479 DEBUG| [stdout]    Directory removal         :       1444.878       1444.849       1444.863          0.015
2020-08-08 08:11:30,844 process          L0479 DEBUG| [stdout]    File creation             :      21791.911      21784.628      21788.278          3.589
2020-08-08 08:11:30,844 process          L0479 DEBUG| [stdout]    File stat                 :       5664.963       5664.457       5664.710          0.250
2020-08-08 08:11:30,844 process          L0479 DEBUG| [stdout]    File read                 :      24283.516      24282.843      24283.182          0.320
2020-08-08 08:11:30,845 process          L0479 DEBUG| [stdout]    File removal              :       5441.699       5441.693       5441.697          0.002
2020-08-08 08:11:30,845 process          L0479 DEBUG| [stdout]    Tree creation             :       1380.211       1380.211       1380.211          0.000
2020-08-08 08:11:30,845 process          L0479 DEBUG| [stdout]    Tree removal              :         56.106         56.106         56.106          0.000
2020-08-08 08:11:30,845 process          L0479 DEBUG| [stdout] -- finished at 08/08/2020 08:11:30 --
```

Performance of **mdtest** this patch:
```
2020-08-10 18:25:07,246 process          L0479 DEBUG| [stdout] 8 tasks, 8000 files/directories
2020-08-10 18:25:15,416 process          L0479 DEBUG| [stdout]    Operation                      Max            Min           Mean        Std Dev
2020-08-10 18:25:15,416 process          L0479 DEBUG| [stdout]    ---------                      ---            ---           ----        -------
2020-08-10 18:25:15,416 process          L0479 DEBUG| [stdout]    Directory creation        :      50874.901      50841.197      50858.227         16.638
2020-08-10 18:25:15,416 process          L0479 DEBUG| [stdout]    Directory stat            :      86925.088      86923.792      86924.262          0.465
2020-08-10 18:25:15,416 process          L0479 DEBUG| [stdout]    Directory removal         :       1659.912       1659.901       1659.907          0.005
2020-08-10 18:25:15,416 process          L0479 DEBUG| [stdout]    File creation             :      24360.324      24353.194      24356.756          3.553
2020-08-10 18:25:15,417 process          L0479 DEBUG| [stdout]    File stat                 :       6724.513       6724.484       6724.502          0.010
2020-08-10 18:25:15,417 process          L0479 DEBUG| [stdout]    File read                 :      27478.492      27478.077      27478.296          0.192
2020-08-10 18:25:15,417 process          L0479 DEBUG| [stdout]    File removal              :       6316.555       6316.537       6316.545          0.007
2020-08-10 18:25:15,417 process          L0479 DEBUG| [stdout]    Tree creation             :       1431.865       1431.865       1431.865          0.000
2020-08-10 18:25:15,417 process          L0479 DEBUG| [stdout]    Tree removal              :         54.260         54.260         54.260          0.000
2020-08-10 18:25:15,417 process          L0479 DEBUG| [stdout] -- finished at 08/10/2020 18:25:15 --
```
IOR Options:
```
api                 : DAOS
apiVersion          : DAOS
test filename       : daos:testFile
access              : single-shared-file
type                : independent
segments            : 1
ordering in a file  : sequential
ordering inter file : no tasks offsets
nodes               : 4
tasks               : 16
clients per node    : 4
repetitions         : 2
xfersize            : 256 bytes
blocksize           : 2 MiB
aggregate filesize  : 32 MiB
```

Performance of **ior** master (build 2647):
```
Max Write: 31.42 MiB/sec (32.94 MB/sec)
Max Read:  25.48 MiB/sec (26.72 MB/sec)
```

Performance of **ior** this patch:
```
Max Write: 35.12 MiB/sec (36.82 MB/sec)
Max Read:  28.54 MiB/sec (29.93 MB/sec)
```
