### PR TITLE
DAOS-5413 control: Quiet daos_admin debug logging

### DIFF
--- a/src/control/drpc/drpc_server.go
+++ b/src/control/drpc/drpc_server.go
@@ -60,7 +60,6 @@ type DomainSocketServer struct {
 // sessions.
 func (d *DomainSocketServer) closeSession(s *Session) {
 	d.sessionsMutex.Lock()
-	d.log.Debug("Closing a session")
 	s.Close()
 	delete(d.sessions, s.Conn)
 	d.sessionsMutex.Unlock()
@@ -96,7 +95,6 @@ func (d *DomainSocketServer) Listen() {
 			return
 		}
 
-		d.log.Debug("Creating session for connection")
 		c := NewSession(conn, d.service)
 		d.sessionsMutex.Lock()
 		d.sessions[conn] = c

--- a/src/control/security/domain_info.go
+++ b/src/control/security/domain_info.go
@@ -1,5 +1,5 @@
 //
-// (C) Copyright 2018-2019 Intel Corporation.
+// (C) Copyright 2018-2020 Intel Corporation.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -67,21 +67,16 @@ func DomainInfoFromUnixConn(log logging.Logger, sock *net.UnixConn) (*DomainInfo
 	}
 	defer f.Close()
 
-	log.Debugf("Client Socket Credentials:\n")
 	fd := int(f.Fd())
 	creds, err := syscall.GetsockoptUcred(fd, syscall.SOL_SOCKET, syscall.SO_PEERCRED)
 	if err != nil {
 		return nil, errors.Wrap(err, "Failed to get sockopt creds")
 	}
-	log.Debugf("Pid: %d\n", creds.Pid)
-	log.Debugf("Uid: %d\n", creds.Uid)
-	log.Debugf("Gid: %d", creds.Gid)
 
 	ctx, err := unix.GetsockoptString(fd, syscall.SOL_SOCKET, syscall.SO_PEERSEC)
 	if err != nil {
-		log.Debugf("Unable to obtain peer context: %s\n", err)
 		ctx = ""
 	}
-	log.Debugf("Context: %s", ctx)
+	log.Debugf("client pid: %d uid: %d gid %d ctx: %s", creds.Pid, creds.Uid, creds.Gid, ctx)
 	return InitDomainInfo(creds, ctx), nil
 }


### PR DESCRIPTION
The security module was creating 6 lines per client connection,
which got pretty noisy. Now it emits a single line per connection.