### PR TITLE
DAOS-4257 ec: add EC enumeration and rebuild

### DIFF
--- a/src/include/daos/object.h
+++ b/src/include/daos/object.h
@@ -94,6 +94,9 @@ enum {
 	DAOS_OC_EC_K4P2_L32K,	/* Erasure code, 4 data cells, 2 parity cells,
 				 * cell size 32K.
 				 */
+
+	DAOS_OC_EC_K2P1_SPEC_RANK_L32K,
+	DAOS_OC_EC_K4P1_SPEC_RANK_L32K,
 };
 
 static inline bool
@@ -115,7 +118,9 @@ daos_obj_is_srank(daos_obj_id_t oid)
 	int	oc = daos_obj_id2class(oid);
 
 	return oc == DAOS_OC_R3S_SPEC_RANK || oc == DAOS_OC_R1S_SPEC_RANK ||
-	       oc == DAOS_OC_R2S_SPEC_RANK;
+	       oc == DAOS_OC_R2S_SPEC_RANK ||
+	       oc == DAOS_OC_EC_K2P1_SPEC_RANK_L32K ||
+	       oc == DAOS_OC_EC_K4P1_SPEC_RANK_L32K;
 }
 
 enum daos_io_mode {
@@ -388,7 +393,7 @@ enum daos_io_flags {
 	DIOF_WITH_SPEC_EPOCH	= 0x4,
 	/* The operation is for EC recovering. */
 	DIOF_EC_RECOV		= 0x8,
-	/* The the key existence. */
+	/* The key existence. */
 	DIOF_CHECK_EXISTENCE	= 0x10,
 };
 

--- a/src/include/daos_srv/daos_server.h
+++ b/src/include/daos_srv/daos_server.h
@@ -776,8 +776,10 @@ struct dss_enum_unpack_io {
 
 typedef int (*dss_enum_unpack_cb_t)(struct dss_enum_unpack_io *io, void *arg);
 
-int dss_enum_unpack(vos_iter_type_t type, struct dss_enum_arg *arg,
-		    dss_enum_unpack_cb_t cb, void *cb_arg);
+int
+dss_enum_unpack(daos_unit_oid_t oid, daos_key_desc_t *kds, int kds_num,
+		d_sg_list_t *sgl, d_iov_t *csum, dss_enum_unpack_cb_t cb,
+		void *cb_arg);
 
 d_rank_t dss_self_rank(void);
 

--- a/src/include/daos_types.h
+++ b/src/include/daos_types.h
@@ -71,11 +71,13 @@ typedef enum {
 } daos_anchor_type_t;
 
 /** Iteration Anchor */
-#define DAOS_ANCHOR_BUF_MAX	120
+#define DAOS_ANCHOR_BUF_MAX	104
 typedef struct {
 	uint16_t	da_type; /** daos_anchor_type_t */
 	uint16_t	da_shard;
 	uint32_t	da_flags; /** see enum daos_anchor_flags */
+	/* record the offset for each shards for EC object */
+	uint64_t	da_sub_anchors;
 	uint8_t		da_buf[DAOS_ANCHOR_BUF_MAX];
 } daos_anchor_t;
 

--- a/src/object/cli_shard.c
+++ b/src/object/cli_shard.c
@@ -893,10 +893,15 @@ csum_enum_verify(const struct obj_enum_args *enum_args,
 		daos_key_desc_t		*kd = &enum_args->eaa_kds[i];
 		void			*buf;
 		d_iov_t			 enum_type_val;
-		d_iov_t			 iov = sgl.sg_iovs[sgl_idx.iov_idx];
+		d_iov_t			 iov;
 
+		if (sgl_idx.iov_offset + kd->kd_key_len >
+		    sgl.sg_iovs[sgl_idx.iov_idx].iov_len) {
+			sgl_idx.iov_idx++;
+			sgl_idx.iov_offset = 0;
+		}
+		iov = sgl.sg_iovs[sgl_idx.iov_idx];
 		buf = iov.iov_buf + sgl_idx.iov_offset;
-
 		switch (kd->kd_val_type) {
 		case OBJ_ITER_RECX: {
 			struct obj_enum_rec *rec = buf;
@@ -1115,8 +1120,8 @@ dc_obj_shard_list(struct dc_obj_shard *obj_shard, enum obj_rpc_opc opc,
 {
 	struct shard_list_args *args = shard_args;
 	daos_obj_list_t	       *obj_args = args->la_api_args;
-	daos_key_desc_t	       *kds = obj_args->kds;
-	d_sg_list_t	       *sgl = obj_args->sgl;
+	daos_key_desc_t	       *kds = args->la_kds;
+	d_sg_list_t	       *sgl = args->la_sgl;
 	crt_endpoint_t		tgt_ep;
 	struct dc_pool	       *pool = NULL;
 	crt_rpc_t	       *req;
@@ -1180,19 +1185,19 @@ dc_obj_shard_list(struct dc_obj_shard *obj_shard, enum obj_rpc_opc opc,
 		oei->oei_flags |= ORF_ENUM_WITHOUT_EPR;
 	}
 
-	oei->oei_nr		= *obj_args->nr;
+	oei->oei_nr		= args->la_nr;
 	oei->oei_rec_type	= obj_args->type;
 	uuid_copy(oei->oei_pool_uuid, pool->dp_pool);
 	uuid_copy(oei->oei_co_hdl, cont_hdl_uuid);
 	uuid_copy(oei->oei_co_uuid, cont_uuid);
 	daos_dti_copy(&oei->oei_dti, &args->la_dti);
 
-	if (obj_args->anchor != NULL)
-		enum_anchor_copy(&oei->oei_anchor, obj_args->anchor);
-	if (obj_args->dkey_anchor != NULL)
-		enum_anchor_copy(&oei->oei_dkey_anchor, obj_args->dkey_anchor);
-	if (obj_args->akey_anchor != NULL)
-		enum_anchor_copy(&oei->oei_akey_anchor, obj_args->akey_anchor);
+	if (args->la_anchor != NULL)
+		enum_anchor_copy(&oei->oei_anchor, args->la_anchor);
+	if (args->la_dkey_anchor != NULL)
+		enum_anchor_copy(&oei->oei_dkey_anchor, args->la_dkey_anchor);
+	if (args->la_akey_anchor != NULL)
+		enum_anchor_copy(&oei->oei_akey_anchor, args->la_akey_anchor);
 
 	if (sgl != NULL) {
 		oei->oei_sgl = *sgl;
@@ -1207,11 +1212,11 @@ dc_obj_shard_list(struct dc_obj_shard *obj_shard, enum obj_rpc_opc opc,
 		}
 	}
 
-	if (*obj_args->nr > KDS_BULK_LIMIT) {
+	if (args->la_nr > KDS_BULK_LIMIT) {
 		d_sg_list_t	tmp_sgl = { 0 };
 		d_iov_t		tmp_iov = { 0 };
 
-		tmp_iov.iov_buf_len = sizeof(*kds) * (*obj_args->nr);
+		tmp_iov.iov_buf_len = sizeof(*kds) * args->la_nr;
 		tmp_iov.iov_buf = kds;
 		tmp_sgl.sg_nr_out = 1;
 		tmp_sgl.sg_nr = 1;
@@ -1227,17 +1232,17 @@ dc_obj_shard_list(struct dc_obj_shard *obj_shard, enum obj_rpc_opc opc,
 	crt_req_addref(req);
 	enum_args.rpc = req;
 	enum_args.hdlp = (daos_handle_t *)pool;
-	enum_args.eaa_nr = obj_args->nr;
+	enum_args.eaa_nr = &args->la_nr;
 	enum_args.eaa_kds = kds;
-	enum_args.eaa_anchor = obj_args->anchor;
-	enum_args.eaa_dkey_anchor = obj_args->dkey_anchor;
-	enum_args.eaa_akey_anchor = obj_args->akey_anchor;
+	enum_args.eaa_anchor = args->la_anchor;
+	enum_args.eaa_dkey_anchor = args->la_dkey_anchor;
+	enum_args.eaa_akey_anchor = args->la_akey_anchor;
 	enum_args.eaa_obj = obj_shard;
 	enum_args.eaa_size = obj_args->size;
 	enum_args.eaa_sgl = sgl;
 	enum_args.csum = obj_args->csum;
 	enum_args.eaa_map_ver = &args->la_auxi.map_ver;
-	enum_args.eaa_recxs = obj_args->recxs;
+	enum_args.eaa_recxs = args->la_recxs;
 	enum_args.epoch = &args->la_auxi.epoch;
 	enum_args.th = &args->la_api_args->th;
 	rc = tse_task_register_comp_cb(task, dc_enumerate_cb, &enum_args,

--- a/src/object/obj_class.c
+++ b/src/object/obj_class.c
@@ -373,6 +373,30 @@ static struct daos_obj_class daos_obj_classes[] = {
 		},
 	},
 	{
+		.oc_name	= "EC_2P1G1_SPEC",
+		.oc_id		= DAOS_OC_EC_K2P1_SPEC_RANK_L32K,
+		{
+			.ca_schema		= DAOS_OS_SINGLE,
+			.ca_resil		= DAOS_RES_EC,
+			.ca_grp_nr		= 1,
+			.ca_ec_k		= 2,
+			.ca_ec_p		= 1,
+			.ca_ec_cell		= 1 << 15,
+		},
+	},
+	{
+		.oc_name	= "EC_4P1G1_SPEC",
+		.oc_id		= DAOS_OC_EC_K4P1_SPEC_RANK_L32K,
+		{
+			.ca_schema		= DAOS_OS_SINGLE,
+			.ca_resil		= DAOS_RES_EC,
+			.ca_grp_nr		= 1,
+			.ca_ec_k		= 4,
+			.ca_ec_p		= 1,
+			.ca_ec_cell		= 1 << 15,
+		},
+	},
+	{
 		.oc_name	= NULL,
 		.oc_id		= OC_UNKNOWN,
 	},

--- a/src/object/obj_ec.h
+++ b/src/object/obj_ec.h
@@ -291,6 +291,9 @@ struct obj_reasb_req;
 	((((vos_idx) / (e_len)) * stripe_rec_nr) + (tgt_idx) * (e_len) +       \
 	 (vos_idx) % (e_len))
 
+#define obj_ec_idx_parity2daos(vos_off, e_len, stripe_rec_nr)		\
+	(((vos_off) / e_len) * stripe_rec_nr)
+
 /**
  * Threshold size of EC single-value layout (even distribution).
  * When record_size <= OBJ_EC_SINGV_EVENDIST_SZ then stored in one data
@@ -578,6 +581,24 @@ obj_ec_tgt_in_err(uint32_t *err_list, uint32_t nerrs, uint16_t tgt_idx)
 			return true;
 	}
 	return false;
+}
+
+static inline bool
+obj_shard_is_ec_parity(daos_unit_oid_t oid, struct daos_oclass_attr **p_attr)
+{
+	struct daos_oclass_attr *attr;
+	bool is_ec;
+
+	is_ec = daos_oclass_is_ec(oid.id_pub, &attr);
+	if (p_attr != NULL)
+		*p_attr = attr;
+	if (!is_ec)
+		return false;
+
+	if ((oid.id_shard % obj_ec_tgt_nr(attr)) < obj_ec_data_tgt_nr(attr))
+		return false;
+
+	return true;
 }
 
 /* obj_class.c */

--- a/src/object/obj_enum.c
+++ b/src/object/obj_enum.c
@@ -111,38 +111,41 @@ is_sgl_full(struct dss_enum_arg *arg, daos_size_t size)
 	return 0;
 }
 
+int
+fill_oid(daos_unit_oid_t oid, struct dss_enum_arg *arg)
+{
+	d_iov_t *iov;
+
+	/* Check if sgl or kds is full */
+	if (is_sgl_full(arg, sizeof(oid)) || arg->kds_len >= arg->kds_cap)
+		return 1;
+
+	iov = &arg->sgl->sg_iovs[arg->sgl_idx];
+	/* Append a new descriptor to kds. */
+	memset(&arg->kds[arg->kds_len], 0, sizeof(arg->kds[arg->kds_len]));
+	arg->kds[arg->kds_len].kd_key_len = sizeof(oid);
+	arg->kds[arg->kds_len].kd_val_type =
+				vos_iter_type_2pack_type(VOS_ITER_OBJ);
+	arg->kds_len++;
+
+	/* Append the object ID to iov. */
+	daos_iov_append(iov, &oid, sizeof(oid));
+	D_DEBUG(DB_IO, "Pack obj "DF_UOID" iov_len/sgl %zu/%d kds_len %d\n",
+		DP_UOID(oid), iov->iov_len, arg->sgl_idx, arg->kds_len);
+	return 0;
+}
+
 static int
 fill_obj(daos_handle_t ih, vos_iter_entry_t *entry, struct dss_enum_arg *arg,
 	 vos_iter_type_t vos_type)
 {
-	d_iov_t *iovs = arg->sgl->sg_iovs;
-	int type;
+	int rc;
 
 	D_ASSERTF(vos_type == VOS_ITER_OBJ, "%d\n", vos_type);
 
-	/* Check if sgl or kds is full */
-	if (is_sgl_full(arg, sizeof(entry->ie_oid)) ||
-	    arg->kds_len >= arg->kds_cap)
-		return 1;
+	rc = fill_oid(entry->ie_oid, arg);
 
-	type = vos_iter_type_2pack_type(vos_type);
-	/* Append a new descriptor to kds. */
-	memset(&arg->kds[arg->kds_len], 0, sizeof(arg->kds[arg->kds_len]));
-	arg->kds[arg->kds_len].kd_key_len = sizeof(entry->ie_oid);
-	arg->kds[arg->kds_len].kd_val_type = type;
-	arg->kds_len++;
-
-	/* Append the object ID to iovs. */
-	D_ASSERT(iovs[arg->sgl_idx].iov_len + sizeof(entry->ie_oid) <
-		 iovs[arg->sgl_idx].iov_buf_len);
-	memcpy(iovs[arg->sgl_idx].iov_buf + iovs[arg->sgl_idx].iov_len,
-	       &entry->ie_oid, sizeof(entry->ie_oid));
-	iovs[arg->sgl_idx].iov_len += sizeof(entry->ie_oid);
-
-	D_DEBUG(DB_IO, "Pack obj "DF_UOID" iov_len %zu kds_len %d\n",
-		DP_UOID(entry->ie_oid), iovs[arg->sgl_idx].iov_len,
-		arg->kds_len);
-	return 0;
+	return rc;
 }
 
 static int
@@ -258,7 +261,7 @@ fill_key(daos_handle_t ih, vos_iter_entry_t *key_ent, struct dss_enum_arg *arg,
 		 * (kds_len < 2) before return KEY2BIG.
 		 */
 		if (arg->kds_len == 0 ||
-		    (arg->chk_key2big && arg->kds_len < 2)) {
+		    (arg->chk_key2big && arg->kds_len <= 2)) {
 			if (arg->kds[0].kd_key_len < total_size)
 				arg->kds[0].kd_key_len = total_size;
 			return -DER_KEY2BIG;
@@ -629,6 +632,7 @@ out:
  * \a sgls[\a iods_cap].
  *
  * \param[in,out]	io		I/O descriptor
+ * \param[in]		oid		oid
  * \param[in]		iods		daos_iod_t array
  * \param[in]		recxs_caps	recxs capacity array
  * \param[in]		sgls		optional sgl array for inline recxs
@@ -638,10 +642,11 @@ out:
  *					\a recxs_caps, \a sgls, and \a ephs
  */
 static void
-dss_enum_unpack_io_init(struct dss_enum_unpack_io *io, daos_iod_t *iods,
-			struct dcs_iod_csums *iods_csums, int *recxs_caps,
-			d_sg_list_t *sgls, daos_epoch_t *akey_ephs,
-			daos_epoch_t *rec_ephs, int iods_cap)
+dss_enum_unpack_io_init(struct dss_enum_unpack_io *io, daos_unit_oid_t oid,
+			daos_iod_t *iods, struct dcs_iod_csums *iods_csums,
+			int *recxs_caps, d_sg_list_t *sgls,
+			daos_epoch_t *akey_ephs, daos_epoch_t *rec_ephs,
+			int iods_cap)
 {
 	memset(io, 0, sizeof(*io));
 
@@ -1058,8 +1063,7 @@ enum_unpack_oid(daos_key_desc_t *kds, void *data,
 		io->ui_oid = *oid;
 	}
 
-	D_DEBUG(DB_REBUILD, "process obj "DF_UOID"\n",
-		DP_UOID(io->ui_oid));
+	D_DEBUG(DB_REBUILD, "process obj "DF_UOID"\n", DP_UOID(io->ui_oid));
 
 	return rc;
 }
@@ -1134,13 +1138,14 @@ obj_enum_iterate(daos_key_desc_t *kdss, d_sg_list_t *sgl, int nr,
 		D_DEBUG(DB_REBUILD, "process %d type %d ptr %p len "DF_U64
 			" total %zd\n", i, kds->kd_val_type, ptr,
 			kds->kd_key_len, sgl->sg_iovs[0].iov_len);
-
-		if (kds->kd_val_type != type && type != -1) {
+		if (kds->kd_val_type == 0 ||
+		    (kds->kd_val_type != type && type != -1)) {
 			ptr += kds->kd_key_len;
+			D_DEBUG(DB_REBUILD, "skip type/size %d/%zd\n",
+				kds->kd_val_type, kds->kd_key_len);
 			continue;
 		}
 
-		D_ASSERT(kds->kd_key_len > 0);
 		if (kds->kd_val_type == OBJ_ITER_RECX ||
 		    kds->kd_val_type == OBJ_ITER_SINGLE) {
 			char *end = ptr + kds->kd_key_len;
@@ -1172,7 +1177,7 @@ obj_enum_iterate(daos_key_desc_t *kdss, d_sg_list_t *sgl, int nr,
 		}
 	}
 
-	D_DEBUG(DB_REBUILD, "process list buf rc "DF_RC"\n", DP_RC(rc));
+	D_DEBUG(DB_REBUILD, "process %d list buf rc "DF_RC"\n", nr, DP_RC(rc));
 
 	return rc;
 }
@@ -1182,14 +1187,18 @@ obj_enum_iterate(daos_key_desc_t *kdss, d_sg_list_t *sgl, int nr,
  * be used to issue a VOS update. \a arg->*_anchor are ignored currently. \a cb
  * will be called, for the caller to consume the recxs accumulated in \a io.
  *
- * \param[in]		vos_type	enumeration type
- * \param[in]		arg		enumeration argument
- * \param[in]		cb		callback
- * \param[in]		cb_arg		callback argument
+ * \param[in]	oid	OID
+ * \param[in]	kds	key description
+ * \param[in]	kds_num	kds number
+ * \param[in]	sgl	sgl
+ * \param[in]	csum	checksum buffer
+ * \param[in]	cb	callback
+ * \param[in]	cb_arg	callback argument
  */
 int
-dss_enum_unpack(vos_iter_type_t vos_type, struct dss_enum_arg *arg,
-		dss_enum_unpack_cb_t cb, void *cb_arg)
+dss_enum_unpack(daos_unit_oid_t oid, daos_key_desc_t *kds, int kds_num,
+		d_sg_list_t *sgl, d_iov_t *csum, dss_enum_unpack_cb_t cb,
+		void *cb_arg)
 {
 	struct dss_enum_unpack_io	io = { 0 };
 	daos_iod_t			iods[DSS_ENUM_UNPACK_MAX_IODS];
@@ -1198,40 +1207,25 @@ dss_enum_unpack(vos_iter_type_t vos_type, struct dss_enum_arg *arg,
 	d_sg_list_t			sgls[DSS_ENUM_UNPACK_MAX_IODS];
 	daos_epoch_t			ephs[DSS_ENUM_UNPACK_MAX_IODS];
 	daos_epoch_t			rec_ephs[DSS_ENUM_UNPACK_MAX_IODS];
-	/** Will be used to enum the csum data */
-	d_iov_t				csum_iov_iter;
+	d_iov_t				csum_iov = { 0 };
 	struct io_unpack_arg		unpack_arg;
 	int				rc = 0;
-	int				type;
 
-	/* Currently, this function is only for unpacking recursive
-	 * enumerations from arg->kds and arg->sgl.
-	 */
-	D_ASSERT(arg->chk_key2big && !arg->fill_recxs);
+	D_ASSERT(kds_num > 0);
+	D_ASSERT(kds != NULL);
+	dss_enum_unpack_io_init(&io, oid, iods, iods_csums, recxs_caps, sgls,
+				ephs, rec_ephs, DSS_ENUM_UNPACK_MAX_IODS);
 
-	D_ASSERT(arg->kds_len > 0);
-	D_ASSERT(arg->kds != NULL);
-	type = vos_iter_type_2pack_type(vos_type);
-	if (arg->kds[0].kd_val_type != type) {
-		D_ERROR("the first kds type %d != %d\n",
-			arg->kds[0].kd_val_type, type);
-		return -DER_INVAL;
-	}
-
-	dss_enum_unpack_io_init(&io, iods, iods_csums, recxs_caps, sgls, ephs,
-				rec_ephs, DSS_ENUM_UNPACK_MAX_IODS);
-	if (type != OBJ_ITER_OBJ)
-		io.ui_oid = arg->oid;
-
-	D_ASSERTF(arg->sgl->sg_nr > 0, "%u\n", arg->sgl->sg_nr);
-	D_ASSERT(arg->sgl->sg_iovs != NULL);
-	csum_iov_iter = arg->csum_iov;
+	if (csum)
+		csum_iov = *csum;
+	D_ASSERTF(sgl->sg_nr > 0, "%u\n", sgl->sg_nr);
+	D_ASSERT(sgl->sg_iovs != NULL);
 	unpack_arg.cb = cb;
 	unpack_arg.io = &io;
 	unpack_arg.cb_arg = cb_arg;
-	unpack_arg.csum_iov = &csum_iov_iter;
-	rc = obj_enum_iterate(arg->kds, arg->sgl, arg->kds_len, -1,
-			      enum_obj_io_unpack_cb, &unpack_arg);
+	unpack_arg.csum_iov = &csum_iov;
+	rc = obj_enum_iterate(kds, sgl, kds_num, -1, enum_obj_io_unpack_cb,
+			      &unpack_arg);
 	if (rc)
 		D_GOTO(out, rc);
 

--- a/src/object/obj_internal.h
+++ b/src/object/obj_internal.h
@@ -310,7 +310,35 @@ struct shard_list_args {
 	struct shard_auxi_args	 la_auxi;
 	daos_obj_list_t		*la_api_args;
 	struct dtx_id		 la_dti;
+	daos_recx_t		*la_recxs;
+	uint32_t		la_nr;
+	d_sg_list_t		*la_sgl;
+	daos_key_desc_t		*la_kds;
+	daos_anchor_t		*la_anchor;
+	daos_anchor_t		*la_akey_anchor;
+	daos_anchor_t		*la_dkey_anchor;
 };
+
+struct obj_auxi_list_recx {
+	daos_recx_t	recx;
+	d_list_t	recx_list;
+};
+
+struct obj_auxi_list_key {
+	d_iov_t		key;
+	d_list_t	key_list;
+};
+
+struct obj_auxi_list_obj_enum {
+	d_iov_t		dkey;
+	d_list_t	enum_list;
+	daos_iod_t	*iods;
+	d_list_t	*recx_lists;
+	int		iods_nr;
+};
+
+int
+merge_recx(d_list_t *head, uint64_t offset, uint64_t size);
 
 struct ec_bulk_spec {
 	uint64_t is_skip:	1;
@@ -414,7 +442,12 @@ int dc_obj_shard_sync(struct dc_obj_shard *shard, enum obj_rpc_opc opc,
 
 int dc_obj_verify_rdg(struct dc_object *obj, struct dc_obj_verify_args *dova,
 		      uint32_t rdg_idx, uint32_t reps, daos_epoch_t epoch);
+
 bool obj_op_is_ec_fetch(struct obj_auxi_args *obj_auxi);
+
+int obj_recx_ec2_daos(struct daos_oclass_attr *oca, int shard,
+		      daos_recx_t *recxs, int nr, daos_recx_t **output_recxs,
+		      int *output_nr);
 
 static inline bool
 obj_retry_error(int err)
@@ -571,4 +604,7 @@ dc_tx_attach(daos_handle_t th, void *args, enum obj_rpc_opc opc,
 void
 dc_tx_check_existence_cb(void *data, tse_task_t *task);
 
+/* obj_enum.c */
+int
+fill_oid(daos_unit_oid_t oid, struct dss_enum_arg *arg);
 #endif /* __DAOS_OBJ_INTENRAL_H__ */

--- a/src/object/obj_rpc.c
+++ b/src/object/obj_rpc.c
@@ -559,6 +559,9 @@ crt_proc_daos_anchor_t(crt_proc_t proc, daos_anchor_t *anchor)
 	if (crt_proc_uint32_t(proc, &anchor->da_flags) != 0)
 		return -DER_HG;
 
+	if (crt_proc_uint64_t(proc, &anchor->da_sub_anchors) != 0)
+		return -DER_HG;
+
 	if (crt_proc_raw(proc, anchor->da_buf, sizeof(anchor->da_buf)) != 0)
 		return -DER_HG;
 

--- a/src/object/obj_rpc.h
+++ b/src/object/obj_rpc.h
@@ -573,4 +573,12 @@ obj_rpc_is_migrate(crt_rpc_t *rpc)
 	return opc_get(rpc->cr_opc) == DAOS_OBJ_RPC_MIGRATE;
 }
 
+static inline bool
+obj_is_enum_opc(uint32_t opc)
+{
+	return (opc == DAOS_OBJ_DKEY_RPC_ENUMERATE ||
+		opc == DAOS_OBJ_RPC_ENUMERATE ||
+		opc == DAOS_OBJ_AKEY_RPC_ENUMERATE ||
+		opc == DAOS_OBJ_RECX_RPC_ENUMERATE);
+}
 #endif /* __DAOS_OBJ_RPC_H__ */

--- a/src/object/obj_verify.c
+++ b/src/object/obj_verify.c
@@ -496,6 +496,7 @@ again:
 			break;
 		case OBJ_ITER_DKEY_EPOCH:
 		case OBJ_ITER_AKEY_EPOCH:
+		case OBJ_ITER_OBJ:
 			break;
 		default:
 			D_ERROR(DF_OID" invalid type %d\n",

--- a/src/object/srv_obj.c
+++ b/src/object/srv_obj.c
@@ -1503,7 +1503,6 @@ obj_ioc_init(uuid_t pool_uuid, uuid_t coh_uuid, uuid_t cont_uuid, int opc,
 	rc = ds_cont_csummer_init(coc);
 	if (rc)
 		D_GOTO(failed, rc);
-
 out:
 	D_ASSERT(coc->sc_pool != NULL);
 	ioc->ioc_map_ver = coc->sc_pool->spc_map_version;
@@ -2155,6 +2154,7 @@ obj_local_enum(struct obj_io_context *ioc, crt_rpc_t *rpc,
 		enum_arg->chk_key2big = true;
 		enum_arg->need_punch = true;
 		enum_arg->copy_data_cb = vos_iter_copy;
+		fill_oid(oei->oei_oid, enum_arg);
 	}
 
 	/*

--- a/src/object/srv_obj_migrate.c
+++ b/src/object/srv_obj_migrate.c
@@ -68,6 +68,7 @@ struct migrate_one {
 	uint64_t		 mo_size;
 	uint64_t		 mo_version;
 	uint32_t		 mo_pool_tls_version;
+	d_list_t		 mo_list;
 };
 
 struct migrate_obj_key {
@@ -571,12 +572,190 @@ migrate_fetch_update_inline(struct migrate_one *mrone, daos_handle_t oh,
 }
 
 static int
+obj_ec_encode_buf(daos_obj_id_t oid, struct daos_oclass_attr *oca,
+		  daos_size_t iod_size, unsigned char *buffer,
+		  unsigned char *p_bufs[])
+{
+	struct obj_ec_codec	*codec;
+	daos_size_t	cell_bytes = obj_ec_cell_rec_nr(oca) * iod_size;
+	unsigned int	k = obj_ec_data_tgt_nr(oca);
+	unsigned int	p = obj_ec_parity_tgt_nr(oca);
+	unsigned char	*data[k];
+	int		i;
+
+	codec = obj_ec_codec_get(daos_obj_id2class(oid));
+	D_ASSERT(codec != NULL);
+
+	for (i = 0; i < p && p_bufs[i] == NULL; i++) {
+		D_ALLOC(p_bufs[i], cell_bytes);
+		if (p_bufs[i] == NULL)
+			return -DER_NOMEM;
+	}
+
+	for (i = 0; i < k; i++)
+		data[i] = buffer + i * cell_bytes;
+
+	ec_encode_data((int)cell_bytes, k, p, codec->ec_gftbls, data, p_bufs);
+	return 0;
+}
+
+static int
+migrate_update_parity(struct migrate_one *mrone, struct ds_cont_child *ds_cont,
+		      unsigned char *buffer, daos_off_t offset,
+		      daos_size_t size, struct daos_oclass_attr *oca,
+		      daos_iod_t *iod, unsigned char *p_bufs[])
+{
+	daos_size_t	stride_bytes = obj_ec_stripe_rec_nr(oca);
+	daos_size_t	cell_bytes = obj_ec_cell_rec_nr(oca);
+	daos_recx_t	tmp_recx;
+	d_iov_t		tmp_iov;
+	d_sg_list_t	tmp_sgl;
+	daos_size_t	write_bytes;
+	int		rc = 0;
+
+	tmp_sgl.sg_nr = tmp_sgl.sg_nr_out = 1;
+	while (size > 0) {
+		if (offset % stride_bytes != 0)
+			write_bytes =
+			  min(roundup(offset, stride_bytes) - offset, size);
+		else
+			write_bytes = min(stride_bytes, size);
+
+		if (write_bytes == stride_bytes) {
+			unsigned int shard;
+
+			shard = mrone->mo_oid.id_shard % obj_ec_tgt_nr(oca);
+
+			D_ASSERT(shard >= obj_ec_data_tgt_nr(oca));
+			shard -= obj_ec_data_tgt_nr(oca);
+			rc = obj_ec_encode_buf(mrone->mo_oid.id_pub,
+					       oca, iod->iod_size, buffer,
+					       p_bufs);
+			if (rc)
+				D_GOTO(out, rc);
+			tmp_recx.rx_idx = obj_ec_idx_daos2vos(offset,
+						stride_bytes, cell_bytes);
+			tmp_recx.rx_nr = cell_bytes;
+			d_iov_set(&tmp_iov, p_bufs[shard], cell_bytes);
+			D_DEBUG(DB_IO, "parity "DF_U64"/"DF_U64"\n",
+				tmp_recx.rx_idx, tmp_recx.rx_nr);
+		} else {
+			tmp_recx.rx_idx = offset;
+			tmp_recx.rx_nr = write_bytes;
+			d_iov_set(&tmp_iov, buffer, write_bytes);
+			D_DEBUG(DB_IO, "replicate "DF_U64"/"DF_U64"\n",
+				tmp_recx.rx_idx, tmp_recx.rx_nr);
+		}
+
+		tmp_sgl.sg_iovs = &tmp_iov;
+		iod->iod_recxs = &tmp_recx;
+		rc = vos_obj_update(ds_cont->sc_hdl, mrone->mo_oid,
+				    mrone->mo_epoch, mrone->mo_version,
+				    0, &mrone->mo_dkey, 1, iod, NULL,
+				    &tmp_sgl);
+		size -= write_bytes;
+		offset += write_bytes;
+		buffer += write_bytes;
+	}
+out:
+	return rc;
+}
+
+static int
+migrate_fetch_update_parity(struct migrate_one *mrone, daos_handle_t oh,
+			    struct ds_cont_child *ds_cont,
+			    struct daos_oclass_attr *oca)
+{
+	d_sg_list_t	 sgl;
+	d_iov_t		 iov;
+	char		 *data;
+	daos_size_t	 size;
+	unsigned int	 p = obj_ec_parity_tgt_nr(oca);
+	unsigned char	 *p_bufs[p];
+	unsigned char	 *ptr;
+	int		 i;
+	int		 rc;
+
+	size = daos_iods_len(mrone->mo_iods, mrone->mo_iod_num);
+	D_ALLOC(data, size);
+	if (data == NULL)
+		return -DER_NOMEM;
+
+	memset(p_bufs, 0, p * sizeof(p_bufs));
+	d_iov_set(&iov, data, size);
+	sgl.sg_nr = 1;
+	sgl.sg_nr_out = 1;
+	sgl.sg_iovs = &iov;
+
+	D_DEBUG(DB_REBUILD,
+		DF_UOID" mrone %p dkey "DF_KEY" nr %d eph "DF_U64"\n",
+		DP_UOID(mrone->mo_oid), mrone, DP_KEY(&mrone->mo_dkey),
+		mrone->mo_iod_num, mrone->mo_epoch);
+
+	rc = dsc_obj_fetch(oh, mrone->mo_epoch, &mrone->mo_dkey,
+			   mrone->mo_iod_num, mrone->mo_iods, &sgl, NULL);
+	if (rc) {
+		D_ERROR("migrate dkey "DF_KEY" failed rc %d\n",
+			DP_KEY(&mrone->mo_dkey), rc);
+		D_GOTO(out, rc);
+	}
+
+	ptr = iov.iov_buf;
+	for (i = 0; i < mrone->mo_iod_num; i++) {
+		daos_iod_t	*iod;
+		int		j;
+		daos_off_t	offset;
+		daos_iod_t	tmp_iod;
+
+		iod = &mrone->mo_iods[i];
+		offset = iod->iod_recxs[0].rx_idx;
+		size = iod->iod_recxs[0].rx_nr;
+		tmp_iod = *iod;
+		for (j = 1; j < iod->iod_nr; j++) {
+			daos_recx_t	*recx = &iod->iod_recxs[j];
+
+			if (offset + size == recx->rx_idx) {
+				size += recx->rx_nr;
+				continue;
+			}
+
+			tmp_iod.iod_nr = 1;
+			rc = migrate_update_parity(mrone, ds_cont, ptr, offset,
+						   size, oca, &tmp_iod, p_bufs);
+			if (rc)
+				D_GOTO(out, rc);
+			ptr += size;
+			offset = recx->rx_idx;
+			size = recx->rx_nr;
+		}
+
+		if (size > 0)
+			rc = migrate_update_parity(mrone, ds_cont, ptr, offset,
+						   size, oca, &tmp_iod, p_bufs);
+	}
+out:
+	if (data)
+		D_FREE(data);
+
+	for (i = 0; i < p; i++) {
+		if (p_bufs[i] != NULL)
+			D_FREE(p_bufs[i]);
+	}
+
+	return rc;
+}
+
+static int
 migrate_fetch_update_bulk(struct migrate_one *mrone, daos_handle_t oh,
 			  struct ds_cont_child *ds_cont)
 {
 	d_sg_list_t	 sgls[DSS_ENUM_UNPACK_MAX_IODS], *sgl;
 	daos_handle_t	 ioh;
+	struct daos_oclass_attr *oca;
 	int		 rc, i, ret, sgl_cnt = 0;
+
+	if (obj_shard_is_ec_parity(mrone->mo_oid, &oca))
+		return migrate_fetch_update_parity(mrone, oh, ds_cont, oca);
 
 	D_ASSERT(mrone->mo_iod_num <= DSS_ENUM_UNPACK_MAX_IODS);
 	rc = vos_update_begin(ds_cont->sc_hdl, mrone->mo_oid, mrone->mo_epoch,
@@ -777,6 +956,7 @@ migrate_one_destroy(struct migrate_one *mrone)
 {
 	int i;
 
+	D_ASSERT(d_list_empty(&mrone->mo_list));
 	daos_iov_free(&mrone->mo_dkey);
 
 	if (mrone->mo_iods)
@@ -867,14 +1047,16 @@ rw_iod_pack(struct migrate_one *mrone, daos_iod_t *iod, d_sg_list_t *sgls)
 		return rc;
 
 	for (i = 0; i < iod->iod_nr; i++) {
+		D_DEBUG(DB_REBUILD, "recx "DF_U64"/"DF_U64"\n",
+			iod->iod_recxs[i].rx_idx, iod->iod_recxs[i].rx_nr);
 		rec_cnt += iod->iod_recxs[i].rx_nr;
 		total_size += iod->iod_recxs[i].rx_nr * iod->iod_size;
 	}
 
-	D_DEBUG(DB_TRACE,
-		"idx %d akey "DF_KEY" nr %d size "DF_U64" type %d\n",
-		idx, DP_KEY(&iod->iod_name), iod->iod_nr, iod->iod_size,
-		iod->iod_type);
+	D_DEBUG(DB_REBUILD,
+		"idx %d akey "DF_KEY" nr %d size "DF_U64" type %d rec %d total "
+		DF_U64"\n", idx, DP_KEY(&iod->iod_name), iod->iod_nr,
+		iod->iod_size, iod->iod_type, rec_cnt, total_size);
 
 	/* Check if data has been retrieved by iteration */
 	if (sgls) {
@@ -930,24 +1112,150 @@ punch_iod_pack(struct migrate_one *mrone, daos_iod_t *iod, daos_epoch_t eph)
 	return 0;
 }
 
+static int
+migrate_one_iod_merge_recx(daos_unit_oid_t oid, daos_iod_t *dst_iod,
+			   daos_iod_t *src_iod)
+{
+	struct obj_auxi_list_recx	*recx;
+	struct obj_auxi_list_recx	*tmp;
+	struct daos_oclass_attr		*oca;
+	daos_recx_t	*recxs;
+	d_list_t	merge_list;
+	int		nr_recxs = 0;
+	int		i;
+	int		rc = 0;
+
+	oca = daos_oclass_attr_find(oid.id_pub);
+	if (oca == NULL)
+		return -DER_NONEXIST;
+
+	D_INIT_LIST_HEAD(&merge_list);
+	recxs = src_iod->iod_recxs;
+	for (i = 0; i < dst_iod->iod_nr; i++) {
+		D_DEBUG(DB_REBUILD, "src merge "DF_U64"/"DF_U64"\n",
+			recxs[i].rx_idx, recxs[i].rx_nr);
+		rc = merge_recx(&merge_list, recxs[i].rx_idx, recxs[i].rx_nr);
+		if (rc)
+			D_GOTO(out, rc);
+	}
+
+	recxs = dst_iod->iod_recxs;
+	for (i = 0; i < src_iod->iod_nr; i++) {
+		D_DEBUG(DB_REBUILD, "dst merge "DF_U64"/"DF_U64"\n",
+			recxs[i].rx_idx, recxs[i].rx_nr);
+		rc = merge_recx(&merge_list, recxs[i].rx_idx, recxs[i].rx_nr);
+		if (rc)
+			D_GOTO(out, rc);
+	}
+
+	d_list_for_each_entry(recx, &merge_list, recx_list)
+		nr_recxs++;
+
+	if (nr_recxs > dst_iod->iod_nr) {
+		D_ALLOC_ARRAY(recxs, nr_recxs);
+		if (recxs == NULL)
+			D_GOTO(out, rc = -DER_NOMEM);
+	} else {
+		recxs = dst_iod->iod_recxs;
+	}
+
+	i = 0;
+	d_list_for_each_entry_safe(recx, tmp, &merge_list, recx_list) {
+		recxs[i++] = recx->recx;
+
+		D_DEBUG(DB_REBUILD, "merge recx "DF_U64"/"DF_U64"\n",
+			recx->recx.rx_idx, recx->recx.rx_nr);
+		d_list_del(&recx->recx_list);
+		D_FREE(recx);
+	}
+
+	if (dst_iod->iod_recxs != recxs)
+		D_FREE(dst_iod->iod_recxs);
+
+	dst_iod->iod_recxs = recxs;
+	dst_iod->iod_nr = i;
+out:
+	d_list_for_each_entry_safe(recx, tmp, &merge_list, recx_list) {
+		d_list_del(&recx->recx_list);
+		D_FREE(recx);
+	}
+	return rc;
+}
+
 /*
- * Queue dkey to the migrate dkey list on each xstream. Note that this function
- * steals the memory of the recx, csum, and epr arrays from iods.
+ * Try merge IOD into other IODs.
+ *
+ * return 0 means all recxs of the IOD are merged.
+ * return 1 means not all recxs of the IOD are merged, i.e. it still
+ * needs to insert IOD.
  */
 static int
-migrate_one_queue(struct iter_obj_arg *iter_arg, daos_epoch_t epoch,
-		  daos_unit_oid_t *oid, daos_key_t *dkey,
-		  daos_epoch_t dkey_eph, daos_iod_t *iods,
-		  struct dcs_iod_csums *iods_csums,
-		  daos_epoch_t *akey_ephs, daos_epoch_t *rec_ephs,
-		  int iod_eph_total, d_sg_list_t *sgls,
-		  uint32_t version)
+migrate_one_merge(struct migrate_one *mo, struct dss_enum_unpack_io *io)
 {
+	bool	need_insert = false;
+	int	i;
+	int	rc = 0;
+
+	for (i = 0; i <= io->ui_iods_top; i++) {
+		int j;
+
+		if (io->ui_iods[i].iod_nr == 0)
+			continue;
+
+		for (j = 0; j < mo->mo_iod_num; j++) {
+			if (!daos_iov_cmp(&mo->mo_iods[j].iod_name,
+					  &io->ui_iods[i].iod_name))
+				continue;
+			rc = migrate_one_iod_merge_recx(io->ui_oid,
+							&mo->mo_iods[j],
+							&io->ui_iods[i]);
+			if (rc)
+				D_GOTO(out, rc);
+
+			/* If recxs can be merged to other iods, then
+			 * it do not need to be processed anymore
+			 */
+			io->ui_iods[i].iod_nr = 0;
+			break;
+		}
+		if (j == mo->mo_iod_num)
+			need_insert = true;
+	}
+
+	if (need_insert)
+		rc = 1;
+out:
+	return rc;
+}
+
+struct enum_unpack_arg {
+	struct iter_obj_arg	*arg;
+	daos_epoch_range_t	epr;
+	d_list_t		merge_list;
+	uint32_t		iterate_parity:1;
+};
+
+static int
+migrate_one_insert(struct enum_unpack_arg *arg,
+		   struct dss_enum_unpack_io *io)
+{
+	struct iter_obj_arg	*iter_arg = arg->arg;
+	daos_epoch_t		epoch = arg->epr.epr_hi;
+	daos_unit_oid_t		oid = io->ui_oid;
+	daos_key_t		*dkey = &io->ui_dkey;
+	daos_epoch_t		dkey_punch_eph = io->ui_dkey_punch_eph;
+	daos_iod_t		*iods = io->ui_iods;
+	struct dcs_iod_csums	*iods_csums = io->ui_iods_csums;
+	daos_epoch_t		*akey_ephs = io->ui_akey_punch_ephs;
+	daos_epoch_t		*rec_ephs = io->ui_rec_punch_ephs;
+	int			iod_eph_total = io->ui_iods_top + 1;
+	d_sg_list_t		*sgls = io->ui_sgls;
+	uint32_t		version = io->ui_version;
 	struct migrate_pool_tls *tls;
 	struct migrate_one	*mrone = NULL;
 	bool			inline_copy = true;
 	int			i;
-	int			rc;
+	int			rc = 0;
 
 	D_DEBUG(DB_REBUILD, "migrate dkey "DF_KEY" iod nr %d\n", DP_KEY(dkey),
 		iod_eph_total);
@@ -957,7 +1265,7 @@ migrate_one_queue(struct iter_obj_arg *iter_arg, daos_epoch_t epoch,
 	if (iod_eph_total == 0 || tls->mpt_version <= version ||
 	    tls->mpt_fini) {
 		D_DEBUG(DB_REBUILD, "No need eph_total %d version %u"
-			" migrate ver %ui fini %d\n", iod_eph_total, version,
+			" migrate ver %u fini %d\n", iod_eph_total, version,
 			tls->mpt_version, tls->mpt_fini);
 		D_GOTO(put, rc = 0);
 	}
@@ -966,6 +1274,7 @@ migrate_one_queue(struct iter_obj_arg *iter_arg, daos_epoch_t epoch,
 	if (mrone == NULL)
 		D_GOTO(put, rc = -DER_NOMEM);
 
+	D_INIT_LIST_HEAD(&mrone->mo_list);
 	D_ALLOC_ARRAY(mrone->mo_iods, iod_eph_total);
 	if (mrone->mo_iods == NULL)
 		D_GOTO(free, rc = -DER_NOMEM);
@@ -975,7 +1284,7 @@ migrate_one_queue(struct iter_obj_arg *iter_arg, daos_epoch_t epoch,
 		D_GOTO(free, rc = -DER_NOMEM);
 
 	mrone->mo_epoch = epoch;
-	mrone->mo_dkey_punch_eph = dkey_eph;
+	mrone->mo_dkey_punch_eph = dkey_punch_eph;
 	D_ALLOC_ARRAY(mrone->mo_akey_punch_ephs, iod_eph_total);
 	if (mrone->mo_akey_punch_ephs == NULL)
 		D_GOTO(free, rc = -DER_NOMEM);
@@ -1038,7 +1347,7 @@ migrate_one_queue(struct iter_obj_arg *iter_arg, daos_epoch_t epoch,
 	if (rc != 0)
 		D_GOTO(free, rc);
 
-	mrone->mo_oid = *oid;
+	mrone->mo_oid = oid;
 	uuid_copy(mrone->mo_cont_uuid, iter_arg->cont_uuid);
 	uuid_copy(mrone->mo_pool_uuid, tls->mpt_pool_uuid);
 	mrone->mo_pool_tls_version = tls->mpt_version;
@@ -1047,37 +1356,66 @@ migrate_one_queue(struct iter_obj_arg *iter_arg, daos_epoch_t epoch,
 		DP_KEY(dkey), iter_arg->tgt_idx,
 		mrone->mo_iod_num);
 
-	rc = dss_ult_create(migrate_one_ult, mrone, DSS_ULT_REBUILD,
-			    iter_arg->tgt_idx, MIGRATE_STACK_SIZE, NULL);
-	if (rc)
-		D_GOTO(free, rc);
+	d_list_add(&mrone->mo_list, &arg->merge_list);
 
-	tls->mpt_generated_ult++;
 free:
-	if (rc != 0 && mrone != NULL)
+	if (rc != 0 && mrone != NULL) {
+		d_list_del_init(&mrone->mo_list);
 		migrate_one_destroy(mrone);
+	}
 put:
 	migrate_pool_tls_put(tls);
 	return rc;
 }
 
-struct enum_unpack_arg {
-	struct iter_obj_arg	*arg;
-	daos_epoch_range_t	epr;
-};
-
 static int
 migrate_enum_unpack_cb(struct dss_enum_unpack_io *io, void *data)
 {
-	struct enum_unpack_arg *arg = data;
+	struct enum_unpack_arg	*arg = data;
+	struct migrate_one	*mo;
+	struct daos_oclass_attr	*oca;
+	bool			merged = false;
+	int			rc = 0;
+	int			i;
 
-	return migrate_one_queue(arg->arg, arg->epr.epr_hi, &io->ui_oid,
-				 &io->ui_dkey, io->ui_dkey_punch_eph,
-				 io->ui_iods, io->ui_iods_csums,
-				 io->ui_akey_punch_ephs,
-				 io->ui_rec_punch_ephs,
-				 io->ui_iods_top + 1, io->ui_sgls,
-				 io->ui_version);
+	if (daos_oclass_is_ec(io->ui_oid.id_pub, &oca)) {
+		/* Convert EC object offset to DAOS offset. */
+		for (i = 0; i <= io->ui_iods_top; i++) {
+			daos_iod_t *iod = &io->ui_iods[i];
+			daos_recx_t *recxs;
+			int nr = 0;
+
+			rc = obj_recx_ec2_daos(oca, io->ui_oid.id_shard,
+					       iod->iod_recxs, iod->iod_nr,
+					       &recxs, &nr);
+			if (rc != 0)
+				return rc;
+
+			if (iod->iod_recxs != recxs) {
+				D_FREE(iod->iod_recxs);
+				iod->iod_recxs = recxs;
+				iod->iod_nr = nr;
+			}
+		}
+
+		d_list_for_each_entry(mo, &arg->merge_list, mo_list) {
+			if (daos_oid_cmp(mo->mo_oid.id_pub,
+					 io->ui_oid.id_pub) == 0 &&
+			    daos_key_match(&mo->mo_dkey, &io->ui_dkey)) {
+				rc = migrate_one_merge(mo, io);
+				if (rc != 1) {
+					if (rc == 0)
+						merged = true;
+					break;
+				}
+			}
+		}
+	}
+
+	if (!merged)
+		rc = migrate_one_insert(arg, io);
+
+	return rc;
 }
 
 static int
@@ -1107,6 +1445,42 @@ migrate_obj_punch_one(void *data)
 	return rc;
 }
 
+static int
+migrate_start_ult(struct enum_unpack_arg *unpack_arg)
+{
+	struct migrate_pool_tls *tls;
+	struct iter_obj_arg	*arg = unpack_arg->arg;
+	struct migrate_one	*mrone;
+	struct migrate_one	*tmp;
+	int			rc = 0;
+
+	tls = migrate_pool_tls_lookup(arg->pool_uuid, arg->version);
+	D_ASSERT(tls != NULL);
+	d_list_for_each_entry_safe(mrone, tmp, &unpack_arg->merge_list,
+				   mo_list) {
+		/* Recover the OID (with correct shard) after merging IOD
+		 * from all shards.
+		 */
+		mrone->mo_oid = arg->oid;
+		D_DEBUG(DB_REBUILD, DF_UOID" %p dkey "DF_KEY" migrate on idx %d"
+			" iod_num %d\n", DP_UOID(mrone->mo_oid), mrone,
+			DP_KEY(&mrone->mo_dkey), arg->tgt_idx,
+			mrone->mo_iod_num);
+
+		d_list_del_init(&mrone->mo_list);
+		rc = dss_ult_create(migrate_one_ult, mrone, DSS_ULT_REBUILD,
+				    arg->tgt_idx, MIGRATE_STACK_SIZE, NULL);
+		if (rc) {
+			migrate_one_destroy(mrone);
+			break;
+		}
+		tls->mpt_generated_ult++;
+	}
+
+	migrate_pool_tls_put(tls);
+	return rc;
+}
+
 #define KDS_NUM		16
 #define ITER_BUF_SIZE	2048
 #define CSUM_BUF_SIZE	256
@@ -1127,7 +1501,6 @@ migrate_one_epoch_object(daos_handle_t oh, daos_epoch_range_t *epr,
 	daos_key_desc_t		 kds[KDS_NUM] = {0};
 	d_iov_t			 csum = {0};
 	uint8_t			 stack_csum_buf[CSUM_BUF_SIZE] = {0};
-	struct dss_enum_arg	 enum_arg = { 0 };
 	struct enum_unpack_arg	 unpack_arg = { 0 };
 	d_iov_t			 iov = { 0 };
 	d_sg_list_t		 sgl = { 0 };
@@ -1143,18 +1516,18 @@ migrate_one_epoch_object(daos_handle_t oh, daos_epoch_range_t *epr,
 	memset(&dkey_anchor, 0, sizeof(dkey_anchor));
 	memset(&akey_anchor, 0, sizeof(akey_anchor));
 	dc_obj_shard2anchor(&dkey_anchor, arg->shard);
-	daos_anchor_set_flags(&dkey_anchor,
-			      DIOF_TO_LEADER | DIOF_WITH_SPEC_EPOCH);
-
+	daos_anchor_set_flags(&dkey_anchor, DIOF_TO_LEADER |
+					    DIOF_WITH_SPEC_EPOCH);
 	unpack_arg.arg = arg;
 	unpack_arg.epr = *epr;
+	D_INIT_LIST_HEAD(&unpack_arg.merge_list);
 	buf = stack_buf;
 	buf_len = ITER_BUF_SIZE;
 
 	d_iov_set(&csum, stack_csum_buf, CSUM_BUF_SIZE);
-
 	while (!tls->mpt_fini) {
 		memset(buf, 0, buf_len);
+		memset(kds, 0, KDS_NUM * sizeof(*kds));
 		iov.iov_len = 0;
 		iov.iov_buf = buf;
 		iov.iov_buf_len = buf_len;
@@ -1211,20 +1584,18 @@ migrate_one_epoch_object(daos_handle_t oh, daos_epoch_range_t *epr,
 		if (num == 0)
 			break;
 
-		iov.iov_len = size;
-
-		enum_arg.oid = arg->oid;
-		enum_arg.kds = kds;
-		enum_arg.kds_cap = KDS_NUM;
-		enum_arg.kds_len = num;
-		enum_arg.sgl = &sgl;
-		enum_arg.sgl_idx = 1;
-		enum_arg.chk_key2big = true;
-		enum_arg.csum_iov = csum;
-		rc = dss_enum_unpack(VOS_ITER_DKEY, &enum_arg,
+		sgl.sg_iovs[0].iov_len = size;
+		rc = dss_enum_unpack(arg->oid, kds, num, &sgl, &csum,
 				     migrate_enum_unpack_cb, &unpack_arg);
 		if (rc) {
 			D_ERROR("migrate "DF_UOID" failed: %d\n",
+				DP_UOID(arg->oid), rc);
+			break;
+		}
+
+		rc = migrate_start_ult(&unpack_arg);
+		if (rc) {
+			D_ERROR("start migrate "DF_UOID" failed: %d\n",
 				DP_UOID(arg->oid), rc);
 			break;
 		}

--- a/src/placement/jump_map.c
+++ b/src/placement/jump_map.c
@@ -678,18 +678,13 @@ get_object_layout(struct pl_jump_map *jmap, struct pl_obj_layout *layout,
 	 * hand picked because there is no other way to specify a starting
 	 * location.
 	 */
-	if (daos_obj_id2class(oid) == DAOS_OC_R3S_SPEC_RANK ||
-	    daos_obj_id2class(oid) == DAOS_OC_R1S_SPEC_RANK ||
-	    daos_obj_id2class(oid) == DAOS_OC_R2S_SPEC_RANK) {
-
+	if (daos_obj_is_srank(oid)) {
 		rc = jump_map_obj_spec_place_get(jmap, oid, &target, dom_used,
 						 dom_used_length);
-
 		if (rc) {
 			D_ERROR("special oid "DF_OID" failed: rc %d\n",
 				DP_OID(oid), rc);
 			D_GOTO(out, rc);
-
 		}
 
 		layout->ol_shards[0].po_target = target->ta_comp.co_id;

--- a/src/placement/pl_map.c
+++ b/src/placement/pl_map.c
@@ -595,7 +595,11 @@ pl_select_leader(daos_obj_id_t oid, uint32_t shard_idx, uint32_t grp_size,
 
 		/* Single replicated object will not rebuild. */
 		D_ASSERT(!shard->po_rebuilding);
-		D_ASSERT(shard->po_shard == shard_idx);
+		/* During target adding, it will add some -1 targets
+		 * into the object layout, so this assert is not right
+		 * anymore. see pl_map_extend().
+		 */
+		/*D_ASSERT(shard->po_shard == shard_idx);*/
 
 		if (for_tgt_id)
 			return shard->po_target;

--- a/src/placement/pl_map_common.c
+++ b/src/placement/pl_map_common.c
@@ -169,9 +169,7 @@ spec_place_rank_get(unsigned int *pos, daos_obj_id_t oid,
 	int                     tgt;
 	int                     current_index;
 
-	D_ASSERT(daos_obj_id2class(oid) == DAOS_OC_R3S_SPEC_RANK ||
-		 daos_obj_id2class(oid) == DAOS_OC_R1S_SPEC_RANK ||
-		 daos_obj_id2class(oid) == DAOS_OC_R2S_SPEC_RANK);
+	D_ASSERT(daos_obj_is_srank(oid));
 
 	/* locate rank in the pool map targets */
 	tgts = pool_map_targets(pl_poolmap);
@@ -219,65 +217,8 @@ remap_list_fill(struct pl_map *map, struct daos_obj_md *md,
 			 * for rebuild, perhaps they should be unified.
 			 */
 			if (l_shard->po_shard != -1) {
-				struct pool_target      *target;
-				int                      leader;
-
 				D_ASSERT(f_shard->fs_tgt_id != -1);
 				D_ASSERT(*idx < array_size);
-
-				/* If the caller does not care about DTX related
-				 * things (myrank == -1), then fill it directly.
-				 */
-				if (myrank == -1)
-					goto fill;
-
-				leader = pl_select_leader(md->omd_id,
-					l_shard->po_shard, layout->ol_nr,
-					true, pl_obj_get_shard, layout);
-
-				if (leader < 0) {
-					D_WARN("Not sure whether current shard "
-					       "is leader or not for obj "
-					       DF_OID", fseq:%d, status:%d, "
-					       "ver:%d, shard:%d, rc = %d\n",
-					       DP_OID(md->omd_id),
-					       f_shard->fs_fseq,
-					       f_shard->fs_status, r_ver,
-					       l_shard->po_shard, leader);
-					goto fill;
-				}
-
-				rc = pool_map_find_target(map->pl_poolmap,
-							  leader, &target);
-				D_ASSERT(rc == 1);
-
-				if (myrank != target->ta_comp.co_rank) {
-					/* The leader shard is not on current
-					* server, then current server cannot
-					 * know whether DTXs for current shard
-					 * have been re-synced or not. So skip
-					 * the shard that will be handled by
-					 * the leader on another server.
-					 */
-					D_DEBUG(DB_PL, "Current replica (%d)"
-						"isn't the leader (%d) for obj "
-						DF_OID", fseq:%d, status:%d, "
-						"ver:%d, shard:%d, skip it\n",
-						myrank, target->ta_comp.co_rank,
-						DP_OID(md->omd_id),
-						f_shard->fs_fseq,
-						f_shard->fs_status,
-						r_ver, l_shard->po_shard);
-					continue;
-				}
-
-fill:
-				D_DEBUG(DB_PL, "Current replica (%d) is the "
-					"leader for obj "DF_OID", fseq:%d, "
-					"ver:%d, shard:%d, to be rebuilt.\n",
-					myrank, DP_OID(md->omd_id),
-					f_shard->fs_fseq,
-					r_ver, l_shard->po_shard);
 				tgt_id[*idx] = f_shard->fs_tgt_id;
 				shard_idx[*idx] = l_shard->po_shard;
 				(*idx)++;

--- a/src/rdb/rdb_raft.c
+++ b/src/rdb/rdb_raft.c
@@ -722,29 +722,21 @@ rdb_raft_exec_unpack_io(struct dss_enum_unpack_io *io, void *arg)
 static int
 rdb_raft_unpack_chunk(daos_handle_t slc, d_iov_t *kds, d_iov_t *data, int index)
 {
-	struct dss_enum_arg	   arg = { 0 };
 	struct rdb_raft_unpack_arg unpack_arg;
+	daos_unit_oid_t		   invalid_oid = { 0 };
 	d_sg_list_t		   sgl;
 
-	/* Set up the same iteration as rdb_raft_pack_chunk. */
-	memset(&arg, 0, sizeof(arg));
-	arg.chk_key2big = true;
-
 	/* Set up the buffers. */
-	arg.kds = kds->iov_buf;
-	arg.kds_cap = kds->iov_buf_len / sizeof(*arg.kds);
-	arg.kds_len = kds->iov_len / sizeof(*arg.kds);
 	sgl.sg_nr = 1;
 	sgl.sg_nr_out = 1;
 	sgl.sg_iovs = data;
-	arg.sgl = &sgl;
 
 	unpack_arg.eph = index;
 	unpack_arg.slc = slc;
 
-	/* Unpack from the object level. */
-	return dss_enum_unpack(VOS_ITER_OBJ, &arg, rdb_raft_exec_unpack_io,
-			       &unpack_arg);
+	return dss_enum_unpack(invalid_oid, (daos_key_desc_t *)kds,
+			       kds->iov_len / sizeof(*kds), &sgl, NULL,
+			       rdb_raft_exec_unpack_io, &unpack_arg);
 }
 
 static int

--- a/src/tests/suite/daos_checksum.c
+++ b/src/tests/suite/daos_checksum.c
@@ -1937,7 +1937,7 @@ test_enumerate_object(void **state)
 		csum_count++;
 	}
 
-	assert_int_equal(13, csum_count);
+	assert_int_equal(11, csum_count);
 
 	/** Clean up */
 	d_sgl_fini(&sgl, true);
@@ -1956,7 +1956,7 @@ test_enumerate_object_csum_buf_too_small(void **state)
 	d_iov_t			csum_iov = {0};
 	d_sg_list_t		sgl = {0};
 	const uint32_t		akey_nr = 5;
-	const uint32_t		enum_nr = akey_nr * 2 + 1;
+	const uint32_t		enum_nr = akey_nr * 2 + 2;
 	daos_key_desc_t		kds[enum_nr];
 	const size_t		csum_buf_len = 10;
 	uint8_t			csum_buf[csum_buf_len];

--- a/src/tests/suite/daos_obj.c
+++ b/src/tests/suite/daos_obj.c
@@ -1327,7 +1327,7 @@ insert_records(daos_obj_id_t oid, struct ioreq *req, char *data_buf,
 }
 
 static int
-iterate_records(struct ioreq *req)
+iterate_records(struct ioreq *req, char *dkey, char *akey, int iod_size)
 {
 	daos_anchor_t	anchor;
 	int		key_nr;
@@ -1343,13 +1343,13 @@ iterate_records(struct ioreq *req)
 		daos_size_t		size;
 
 		number = 5;
-		enumerate_rec(DAOS_TX_NONE, "d_key", "a_rec", &size,
+		enumerate_rec(DAOS_TX_NONE, dkey, akey, &size,
 			      &number, recxs, eprs, &anchor, true, req);
 		if (number == 0)
 			continue;
 
 		for (i = 0; i < (number - 1); i++) {
-			assert_true(size == ENUM_IOD_SIZE);
+			assert_true(size == iod_size);
 			/* Print a subset of enumerated records */
 			if ((i + key_nr) % ENUM_PRINT != 0)
 				continue;
@@ -1370,7 +1370,7 @@ iterate_records(struct ioreq *req)
 	return key_nr;
 }
 
-
+#define ENUM_BUF_SIZE (128 * 1024)
 /** very basic enumerate */
 static void
 enumerate_simple(void **state)
@@ -1402,9 +1402,9 @@ enumerate_simple(void **state)
 	large_key[ENUM_LARGE_KEY_BUF - 1] = '\0';
 	D_ALLOC(large_buf, ENUM_LARGE_KEY_BUF * 2);
 
-	D_ALLOC(data_buf, IO_SIZE_NVME);
+	D_ALLOC(data_buf, ENUM_BUF_SIZE);
 	assert_non_null(data_buf);
-	dts_buf_render(data_buf, IO_SIZE_NVME);
+	dts_buf_render(data_buf, ENUM_BUF_SIZE);
 
 	/**
 	 * Insert 1000 dkey records, all with the same key value and the same
@@ -1554,7 +1554,7 @@ enumerate_simple(void **state)
 	 * Insert N mixed NVMe and SCM records, all with same dkey and akey.
 	 */
 	insert_records(oid, &req, data_buf, 0);
-	key_nr = iterate_records(&req);
+	key_nr = iterate_records(&req, "d_key", "a_rec", ENUM_IOD_SIZE);
 	assert_int_equal(key_nr, ENUM_KEY_REC_NR);
 
 	/**
@@ -1562,7 +1562,7 @@ enumerate_simple(void **state)
 	 * all with same dkey and akey.
 	 */
 	insert_records(oid, &req, data_buf, 1);
-	key_nr = iterate_records(&req);
+	key_nr = iterate_records(&req, "d_key", "a_rec", ENUM_IOD_SIZE);
 	/** Records could be merged with previous updates by aggregation */
 	print_message("key_nr = %d\n", key_nr);
 
@@ -1571,10 +1571,16 @@ enumerate_simple(void **state)
 	 * all with same dkey and akey.
 	 */
 	insert_records(oid, &req, data_buf, 2);
-	key_nr = iterate_records(&req);
+	key_nr = iterate_records(&req, "d_key", "a_rec", ENUM_IOD_SIZE);
 	/** Records could be merged with previous updates by aggregation */
 	print_message("key_nr = %d\n", key_nr);
 
+	for (i = 0; i < 5; i++)
+		insert_single_with_rxnr("d_key", "a_lrec", i * 128 * 1024,
+					data_buf, 1, 128 * 1024, DAOS_TX_NONE,
+					&req);
+	key_nr = iterate_records(&req, "d_key", "a_lrec", 1);
+	print_message("key_nr = %d\n", key_nr);
 	D_FREE(small_buf);
 	D_FREE(large_buf);
 	D_FREE(large_key);
@@ -4105,8 +4111,8 @@ obj_setup_internal(void **state)
 
 	if (arg->pool.pool_info.pi_nnodes < 2)
 		dts_obj_class = OC_S1;
-	else if (arg->objclass != OC_UNKNOWN)
-		dts_obj_class = arg->objclass;
+	else if (arg->obj_class != OC_UNKNOWN)
+		dts_obj_class = arg->obj_class;
 
 	return 0;
 }

--- a/src/tests/suite/daos_rebuild.c
+++ b/src/tests/suite/daos_rebuild.c
@@ -503,7 +503,6 @@ rebuild_tgt_start_fail(void **state)
 
 	/* Rebuild rank 1 */
 	rebuild_single_pool_rank(arg, ranks_to_kill[0], false);
-	rebuild_io_validate(arg, oids, OBJ_NR, true);
 }
 
 static void

--- a/src/tests/suite/daos_rebuild_common.c
+++ b/src/tests/suite/daos_rebuild_common.c
@@ -600,17 +600,43 @@ restore_group_state(void **state)
 int
 rebuild_sub_setup(void **state)
 {
+	test_arg_t	*arg;
+	int		rc;
+
 	save_group_state(state);
-	return test_setup(state, SETUP_CONT_CONNECT, true,
+	rc = test_setup(state, SETUP_CONT_CONNECT, true,
 			REBUILD_SUBTEST_POOL_SIZE, NULL);
+	if (rc)
+		return rc;
+
+	arg = *state;
+	if (dt_obj_class != DAOS_OC_UNKNOWN)
+		arg->obj_class = dt_obj_class;
+	else
+		arg->obj_class = DAOS_OC_R3S_SPEC_RANK;
+
+	return 0;
 }
 
 int
 rebuild_small_sub_setup(void **state)
 {
+	test_arg_t	*arg;
+	int rc;
+
 	save_group_state(state);
-	return test_setup(state, SETUP_CONT_CONNECT, true,
+	rc = test_setup(state, SETUP_CONT_CONNECT, true,
 			REBUILD_SMALL_POOL_SIZE, NULL);
+	if (rc)
+		return rc;
+
+	arg = *state;
+	if (dt_obj_class != DAOS_OC_UNKNOWN)
+		arg->obj_class = dt_obj_class;
+	else
+		arg->obj_class = DAOS_OC_R3S_SPEC_RANK;
+
+	return 0;
 }
 
 int

--- a/src/tests/suite/daos_rebuild_simple.c
+++ b/src/tests/suite/daos_rebuild_simple.c
@@ -36,7 +36,7 @@
 #include <daos/mgmt.h>
 #include <daos/container.h>
 
-#define KEY_NR		100
+#define KEY_NR		10
 #define OBJ_NR		10
 #define OBJ_CLS		OC_RP_3G1
 #define OBJ_REPLICAS	3
@@ -45,38 +45,88 @@
 #define REBUILD_SUBTEST_POOL_SIZE (1ULL << 30)
 #define REBUILD_SMALL_POOL_SIZE (1ULL << 28)
 
+d_rank_t
+get_rank_by_oid_shard(test_arg_t *arg, daos_obj_id_t oid,
+		      uint32_t shard)
+{
+	struct daos_obj_layout	*layout;
+	uint32_t		grp_idx;
+	uint32_t		idx;
+	d_rank_t		rank;
+
+	daos_obj_layout_get(arg->coh, oid, &layout);
+	grp_idx = shard / layout->ol_shards[0]->os_replica_nr;
+	idx = shard % layout->ol_shards[0]->os_replica_nr;
+	rank = layout->ol_shards[grp_idx]->os_ranks[idx];
+
+	print_message("idx %u grp %u rank %d\n", idx, grp_idx, rank);
+	daos_obj_layout_free(layout);
+	return rank;
+}
+
+d_rank_t
+get_killing_rank_by_oid(test_arg_t *arg, daos_obj_id_t oid, bool parity)
+{
+	struct daos_oclass_attr *oca;
+	uint32_t		shard = 0;
+
+	oca = daos_oclass_attr_find(oid);
+	if (oca->ca_resil == DAOS_RES_REPL) {
+		shard = 0;
+	} else if (oca->ca_resil == DAOS_RES_EC) {
+		if (parity)
+			shard = oca->u.ec.e_k;
+		else
+			shard = 0;
+	}
+
+	print_message("get shard %u k %u\n", shard, oca->u.ec.e_k);
+	return get_rank_by_oid_shard(arg, oid, shard);
+}
+
+#define DATA_SIZE	(1048576 * 2 + 512)
 static void
 rebuild_dkeys(void **state)
 {
 	test_arg_t		*arg = *state;
 	daos_obj_id_t		oid;
 	struct ioreq		req;
-	int			tgt = DEFAULT_FAIL_TGT;
+	d_rank_t		kill_rank = 0;
 	int			i;
 
 	if (!test_runable(arg, 4))
 		return;
 
-	oid = dts_oid_gen(DAOS_OC_R3S_SPEC_RANK, 0, arg->myrank);
-	oid = dts_oid_set_rank(oid, ranks_to_kill[0]);
-	oid = dts_oid_set_tgt(oid, tgt);
+	oid = dts_oid_gen(arg->obj_class, 0, arg->myrank);
 	ioreq_init(&req, arg->coh, oid, DAOS_IOD_ARRAY, arg);
 
 	/** Insert 1000 records */
 	print_message("Insert %d kv record in object "DF_OID"\n",
 		      KEY_NR, DP_OID(oid));
-	for (i = 0; i < KEY_NR; i++) {
+	for (i = 0; i < 5; i++) {
 		char	key[16];
+		daos_recx_t recx;
+		char	data[DATA_SIZE];
 
 		sprintf(key, "dkey_0_%d", i);
 		insert_single(key, "a_key", 0, "data", strlen("data") + 1,
 			      DAOS_TX_NONE, &req);
+
+		sprintf(key, "dkey_0_1M_%d", i);
+		recx.rx_idx = 0;
+		recx.rx_nr = DATA_SIZE;
+
+		memset(data, 'a', DATA_SIZE);
+		insert_recxs(key, "a_key_1M", 1, DAOS_TX_NONE, &recx, 1,
+			     data, DATA_SIZE, &req);
 	}
+
+	kill_rank = get_killing_rank_by_oid(arg, oid, true);
 	ioreq_fini(&req);
 
-	rebuild_single_pool_target(arg, ranks_to_kill[0], tgt, false);
+	rebuild_single_pool_target(arg, kill_rank, -1, false);
 
-	reintegrate_single_pool_target(arg, ranks_to_kill[0], tgt);
+	reintegrate_single_pool_target(arg, kill_rank, -1);
 }
 
 static void
@@ -85,32 +135,43 @@ rebuild_akeys(void **state)
 	test_arg_t		*arg = *state;
 	daos_obj_id_t		oid;
 	struct ioreq		req;
-	int			tgt = DEFAULT_FAIL_TGT;
+	d_rank_t		kill_rank = 0;
+	int			tgt = -1;
 	int			i;
 
 	if (!test_runable(arg, 4))
 		return;
 
-	oid = dts_oid_gen(DAOS_OC_R3S_SPEC_RANK, 0, arg->myrank);
-	oid = dts_oid_set_rank(oid, ranks_to_kill[0]);
-	oid = dts_oid_set_tgt(oid, tgt);
+	oid = dts_oid_gen(arg->obj_class, 0, arg->myrank);
 	ioreq_init(&req, arg->coh, oid, DAOS_IOD_ARRAY, arg);
 
 	/** Insert 1000 records */
 	print_message("Insert %d kv record in object "DF_OID"\n",
 		      KEY_NR, DP_OID(oid));
 	for (i = 0; i < KEY_NR; i++) {
-		char	akey[16];
+		char		key[16];
+		daos_recx_t	recx;
+		char		data[DATA_SIZE];
 
-		sprintf(akey, "%d", i);
-		insert_single("dkey_1_0", akey, 0, "data", strlen("data") + 1,
+		sprintf(key, "%d", i);
+		insert_single("dkey_1_0", key, 0, "data", strlen("data") + 1,
 			      DAOS_TX_NONE, &req);
+
+		sprintf(key, "dkey_1_1M_%d", i);
+		recx.rx_idx = 0;
+		recx.rx_nr = DATA_SIZE;
+
+		memset(data, 'a', DATA_SIZE);
+		insert_recxs(key, "a_key_1M", 1, DAOS_TX_NONE, &recx, 1,
+			     data, DATA_SIZE, &req);
+
 	}
+	kill_rank = get_killing_rank_by_oid(arg, oid, false);
 	ioreq_fini(&req);
 
-	rebuild_single_pool_target(arg, ranks_to_kill[0], tgt, false);
+	rebuild_single_pool_target(arg, kill_rank, tgt, false);
 
-	reintegrate_single_pool_target(arg, ranks_to_kill[0], tgt);
+	reintegrate_single_pool_target(arg, kill_rank, tgt);
 }
 
 static void
@@ -126,7 +187,7 @@ rebuild_indexes(void **state)
 	if (!test_runable(arg, 4))
 		return;
 
-	oid = dts_oid_gen(DAOS_OC_R3S_SPEC_RANK, 0, arg->myrank);
+	oid = dts_oid_gen(arg->obj_class, 0, arg->myrank);
 	oid = dts_oid_set_rank(oid, ranks_to_kill[0]);
 	oid = dts_oid_set_tgt(oid, tgt);
 	ioreq_init(&req, arg->coh, oid, DAOS_IOD_ARRAY, arg);
@@ -166,7 +227,7 @@ rebuild_snap_update_recs(void **state)
 	if (!test_runable(arg, 4))
 		return;
 
-	oid = dts_oid_gen(DAOS_OC_R3S_SPEC_RANK, 0, arg->myrank);
+	oid = dts_oid_gen(arg->obj_class, 0, arg->myrank);
 	oid = dts_oid_set_rank(oid, ranks_to_kill[0]);
 	oid = dts_oid_set_tgt(oid, tgt);
 	ioreq_init(&req, arg->coh, oid, DAOS_IOD_ARRAY, arg);
@@ -194,11 +255,11 @@ rebuild_snap_update_recs(void **state)
 
 	for (i = 0; i < 5; i++) {
 		rc = daos_obj_verify(arg->coh, oid, snap_epoch[i]);
-		assert_int_equal(rc, 0);
+		assert_true(rc == 0 || rc == -DER_NOSYS);
 	}
 
 	rc = daos_obj_verify(arg->coh, oid, DAOS_EPOCH_MAX);
-	assert_int_equal(rc, 0);
+	assert_true(rc == 0 || rc == -DER_NOSYS);
 
 	ioreq_fini(&req);
 
@@ -221,7 +282,7 @@ rebuild_snap_punch_recs(void **state)
 	if (!test_runable(arg, 4))
 		return;
 
-	oid = dts_oid_gen(DAOS_OC_R3S_SPEC_RANK, 0, arg->myrank);
+	oid = dts_oid_gen(arg->obj_class, 0, arg->myrank);
 	oid = dts_oid_set_rank(oid, ranks_to_kill[0]);
 	oid = dts_oid_set_tgt(oid, tgt);
 	ioreq_init(&req, arg->coh, oid, DAOS_IOD_ARRAY, arg);
@@ -245,11 +306,11 @@ rebuild_snap_punch_recs(void **state)
 
 	for (i = 0; i < 5; i++) {
 		rc = daos_obj_verify(arg->coh, oid, snap_epoch[i]);
-		assert_int_equal(rc, 0);
+		assert_true(rc == 0 || rc == -DER_NOSYS);
 	}
 
 	rc = daos_obj_verify(arg->coh, oid, DAOS_EPOCH_MAX);
-	assert_int_equal(rc, 0);
+	assert_true(rc == 0 || rc == -DER_NOSYS);
 
 	ioreq_fini(&req);
 
@@ -269,7 +330,7 @@ rebuild_snap_update_keys(void **state)
 	if (!test_runable(arg, 4))
 		return;
 
-	oid = dts_oid_gen(DAOS_OC_R3S_SPEC_RANK, 0, arg->myrank);
+	oid = dts_oid_gen(arg->obj_class, 0, arg->myrank);
 	oid = dts_oid_set_rank(oid, ranks_to_kill[0]);
 	oid = dts_oid_set_tgt(oid, tgt);
 	ioreq_init(&req, arg->coh, oid, DAOS_IOD_ARRAY, arg);
@@ -348,7 +409,7 @@ rebuild_snap_punch_keys(void **state)
 	if (!test_runable(arg, 4))
 		return;
 
-	oid = dts_oid_gen(DAOS_OC_R3S_SPEC_RANK, 0, arg->myrank);
+	oid = dts_oid_gen(arg->obj_class, 0, arg->myrank);
 	oid = dts_oid_set_rank(oid, ranks_to_kill[0]);
 	oid = dts_oid_set_tgt(oid, tgt);
 	ioreq_init(&req, arg->coh, oid, DAOS_IOD_ARRAY, arg);
@@ -440,7 +501,7 @@ rebuild_multiple(void **state)
 	if (!test_runable(arg, 4))
 		return;
 
-	oid = dts_oid_gen(DAOS_OC_R3S_SPEC_RANK, 0, arg->myrank);
+	oid = dts_oid_gen(arg->obj_class, 0, arg->myrank);
 	oid = dts_oid_set_rank(oid, ranks_to_kill[0]);
 	oid = dts_oid_set_tgt(oid, tgt);
 	ioreq_init(&req, arg->coh, oid, DAOS_IOD_ARRAY, arg);
@@ -467,6 +528,7 @@ rebuild_multiple(void **state)
 	rebuild_single_pool_target(arg, ranks_to_kill[0], tgt, false);
 }
 
+#define LARGE_BUFFER_SIZE	(32 * 1024 * 4)
 static void
 rebuild_large_rec(void **state)
 {
@@ -475,12 +537,12 @@ rebuild_large_rec(void **state)
 	struct ioreq		req;
 	int			tgt = DEFAULT_FAIL_TGT;
 	int			i;
-	char			buffer[5000];
+	char			buffer[LARGE_BUFFER_SIZE];
 
 	if (!test_runable(arg, 4))
 		return;
 
-	oid = dts_oid_gen(DAOS_OC_R3S_SPEC_RANK, 0, arg->myrank);
+	oid = dts_oid_gen(arg->obj_class, 0, arg->myrank);
 	oid = dts_oid_set_rank(oid, ranks_to_kill[0]);
 	oid = dts_oid_set_tgt(oid, tgt);
 	ioreq_init(&req, arg->coh, oid, DAOS_IOD_ARRAY, arg);
@@ -488,13 +550,22 @@ rebuild_large_rec(void **state)
 	/** Insert 1000 records */
 	print_message("Insert %d kv record in object "DF_OID"\n",
 		      KEY_NR, DP_OID(oid));
-	memset(buffer, 'a', 5000);
+	memset(buffer, 'a', LARGE_BUFFER_SIZE);
 	for (i = 0; i < KEY_NR; i++) {
 		char	key[16];
+		const char *lakey = "a_key_L";
+		daos_size_t iod_size = 1;
+		int	rx_nr = LARGE_BUFFER_SIZE;
+		uint64_t offset = 0;
+		void	*data = buffer;
 
 		sprintf(key, "dkey_4_%d", i);
+
 		insert_single(key, "a_key", 0, buffer, 5000, DAOS_TX_NONE,
 			      &req);
+
+		insert(key, 1, &lakey, &iod_size, &rx_nr,
+		       &offset, &data, DAOS_TX_NONE, &req);
 	}
 	ioreq_fini(&req);
 
@@ -513,7 +584,7 @@ rebuild_objects(void **state)
 		return;
 
 	for (i = 0; i < OBJ_NR; i++) {
-		oids[i] = dts_oid_gen(DAOS_OC_R3S_SPEC_RANK, 0, arg->myrank);
+		oids[i] = dts_oid_gen(arg->obj_class, 0, arg->myrank);
 		oids[i] = dts_oid_set_rank(oids[i], ranks_to_kill[0]);
 		oids[i] = dts_oid_set_tgt(oids[i], DEFAULT_FAIL_TGT);
 	}

--- a/src/tests/suite/daos_test.c
+++ b/src/tests/suite/daos_test.c
@@ -336,8 +336,8 @@ main(int argc, char **argv)
 		{"dfs",		no_argument,		NULL,	'F'},
 		{"work_dir",	required_argument,	NULL,	'W'},
 		{"workload_file", required_argument,	NULL,	'w'},
+		{"obj_class",	required_argument,	NULL,	'l'},
 		{"help",	no_argument,		NULL,	'h'},
-		{"object",	required_argument,	NULL,	'X'},
 		{NULL,		0,			NULL,	0}
 	};
 
@@ -350,7 +350,7 @@ main(int argc, char **argv)
 	memset(tests, 0, sizeof(tests));
 
 	while ((opt = getopt_long(argc, argv,
-				  "ampcCdXVizxADKeoROg:n:s:u:E:f:Fw:W:hrNvb",
+				  "ampcCdXVizxADKeoROg:n:s:u:E:f:Fw:W:hrNvbl:",
 				  long_options, &index)) != -1) {
 		if (strchr(all_tests_defined, opt) != NULL) {
 			tests[ntests] = opt;
@@ -397,9 +397,9 @@ main(int argc, char **argv)
 			D_STRNDUP(test_io_dir, optarg, PATH_MAX);
 			if (test_io_dir == NULL)
 				return -1;
-		case 'X':
-			objclass = daos_oclass_name2id(optarg);
-			if (objclass == OC_UNKNOWN)
+		case 'l':
+			dt_obj_class = daos_oclass_name2id(optarg);
+			if (dt_obj_class == OC_UNKNOWN)
 				return -1;
 			break;
 		case CHECKSUM_ARG_VAL_TYPE:

--- a/src/tests/suite/daos_test.h
+++ b/src/tests/suite/daos_test.h
@@ -79,7 +79,7 @@ extern const char *dmg_config_file;
 extern unsigned int dt_csum_type;
 extern unsigned int dt_csum_chunksize;
 extern bool dt_csum_server_verify;
-extern int  objclass;
+extern int  dt_obj_class;
 
 /* the temporary IO dir*/
 extern char *test_io_dir;
@@ -153,7 +153,7 @@ typedef struct {
 	int			srv_disabled_ntgts;
 	int			index;
 	daos_epoch_t		hce;
-	int			objclass;
+	int			obj_class;
 
 	/* The callback is called before pool rebuild. like disconnect
 	 * pool etc.

--- a/src/tests/suite/daos_test_common.c
+++ b/src/tests/suite/daos_test_common.c
@@ -44,7 +44,7 @@ unsigned int svc_nreplicas = 1;
 unsigned int	dt_csum_type;
 unsigned int	dt_csum_chunksize;
 bool		dt_csum_server_verify;
-int		objclass;
+int		dt_obj_class;
 
 
 /* Create or import a single pool with option to store info in arg->pool
@@ -326,7 +326,7 @@ test_setup(void **state, unsigned int step, bool multi_rank,
 		arg->pool.pool_connect_flags = DAOS_PC_RW;
 		arg->coh = DAOS_HDL_INVAL;
 		arg->cont_open_flags = DAOS_COO_RW;
-		arg->objclass = objclass;
+		arg->obj_class = dt_obj_class;
 		arg->pool.destroyed = false;
 	}
 

--- a/src/vos/vos_internal.h
+++ b/src/vos/vos_internal.h
@@ -559,7 +559,7 @@ struct vos_rec_bundle {
  * Inline data structure for embedding the key bundle and key into an anchor
  * for serialization.
  */
-#define	EMBEDDED_KEY_MAX	96
+#define	EMBEDDED_KEY_MAX	80
 struct vos_embedded_key {
 	/** Inlined iov key references */
 	d_iov_t		ek_kiov;


### PR DESCRIPTION
Add EC enumeration and some cleanup.

1. If parity is avaible, the enumeration will be sent to
parity node.

2. If parity node is not avaible, the enumeration will be
sent to all data shards, and sub_anchors will be added
to anchors to track the offset for each data shard individually.

3. Add object enumeration for EC object rebuild.

4. Add EC rebuild test and some cleanup.

5. Add EC parity rebuild.

Signed-off-by: Di Wang <di.wang@intel.com>