### PR TITLE
DAOS-5421 tests: change -u to -U for dedup test

### DIFF
--- a/src/tests/suite/daos_test.c
+++ b/src/tests/suite/daos_test.c
@@ -34,7 +34,7 @@
  * all will be run if no test is specified. Tests will be run in order
  * so tests that kill nodes must be last.
  */
-#define TESTS "mpceXVizuADKCoROdrFNvb"
+#define TESTS "mpceXViADKFCoRvbOzUdrNb"
 /**
  * These tests will only be run if explicitly specified. They don't get
  * run if no test is specified.
@@ -62,7 +62,7 @@ print_usage(int rank)
 	print_message("daos_test -p|--daos_pool_tests\n");
 	print_message("daos_test -c|--daos_container_tests\n");
 	print_message("daos_test -C|--capa\n");
-	print_message("daos_test -u|--dedup\n");
+	print_message("daos_test -U|--dedup\n");
 	print_message("daos_test -z|--checksum\n");
 	print_message("daos_test -X|--dtx\n");
 	print_message("daos_test -i|--daos_io_tests\n");
@@ -153,7 +153,7 @@ run_specified_tests(const char *tests, int rank, int size,
 			nr_failed += run_daos_checksum_test(rank, size,
 						sub_tests, sub_tests_size);
 			break;
-		case 'u':
+		case 'U':
 			daos_test_print(rank, "\n\n=================");
 			daos_test_print(rank, "DAOS dedup tests..");
 			daos_test_print(rank, "=================");
@@ -347,7 +347,7 @@ main(int argc, char **argv)
 	memset(tests, 0, sizeof(tests));
 
 	while ((opt = getopt_long(argc, argv,
-				  "ampcCdXVizuxADKeoROg:n:s:u:E:f:Fw:W:hrNvb",
+				  "ampcCdXVizxADKeoROg:n:s:u:E:f:Fw:W:hrNvb",
 				  long_options, &index)) != -1) {
 		if (strchr(all_tests_defined, opt) != NULL) {
 			tests[ntests] = opt;


### PR DESCRIPTION
1. replace -u with -U for dedup test, which is conflict
with the original -u subtest options.

2. Adjust default daos subtest sequence to match CI test
sequence.

Signed-off-by: Di Wang <di.wang@intel.com>