### PR TITLE
DAOS-4652 csum: Use distinct csummer for checksum calculations

### DIFF
--- a/src/common/checksum.c
+++ b/src/common/checksum.c
@@ -482,6 +482,17 @@ daos_csummer_init_with_props(struct daos_csummer **obj, daos_prop_t *props)
 					   daos_cont_prop2serververify(props));
 }
 
+struct daos_csummer *
+daos_csummer_copy(const struct daos_csummer *obj)
+{
+	struct daos_csummer *result = NULL;
+
+	daos_csummer_init(&result, obj->dcs_algo,
+			  obj->dcs_chunk_size, obj->dcs_srv_verify);
+
+	return result;
+}
+
 void daos_csummer_destroy(struct daos_csummer **obj)
 {
 	struct daos_csummer *csummer = *obj;
@@ -1215,8 +1226,6 @@ daos_csummer_calc_key(struct daos_csummer *csummer, daos_key_t *key,
 
 	rc = calc_for_iov(csummer, key, dkey_csum_buf, size);
 	if (rc == 0) {
-		C_TRACE("Calculating checksum for Key "DF_KEY" -> "DF_CI"\n",
-			DP_KEY(key), DP_CI(*csum_info));
 		*p_csum = csum_info;
 		C_TRACE("Checksum created for key: "DF_KEY"->"DF_CI"\n",
 			DP_KEY(key), DP_CI(*csum_info));

--- a/src/include/daos/checksum.h
+++ b/src/include/daos/checksum.h
@@ -203,6 +203,15 @@ daos_csummer_init_with_type(struct daos_csummer **obj, enum DAOS_CSUM_TYPE type,
 int
 daos_csummer_init_with_props(struct daos_csummer **obj, daos_prop_t *props);
 
+/**
+ * Initialize a daos_csummer as a copy of an existing daos_csummer
+ * @param obj		daos_csummer to be copied.
+ *
+ * @return		Allocated daos_csummer, or NULL if not enough memory.
+ */
+struct daos_csummer *
+daos_csummer_copy(const struct daos_csummer *obj);
+
 /** Destroy the daos_csummer */
 void
 daos_csummer_destroy(struct daos_csummer **obj);

--- a/src/tests/ftest/io/ior_small.yaml
+++ b/src/tests/ftest/io/ior_small.yaml
@@ -34,8 +34,7 @@ pool:
     control_method: dmg
 container:
     type: POSIX
-    # Disabling checksum due to DAOS-4458
-    # properties: cksum:crc16,cksum_size:16384,srv_cksum:on
+    properties: cksum:crc16,cksum_size:16384,srv_cksum:on
     control_method: daos
 ior:
     client_processes:


### PR DESCRIPTION
An issue was discovered running IOR with multiple tasks that
caused csum error false positives. It appeared that multiple
tasks would stomp on each others checksum buffer, sending
the incorrect checksum to the server. Creating a copy
of the csummer on the client for when calculating checksums
resolves the issue.

To complete DAOS-4652, am enabling checksum for the
ior_small tests.

Signed-off-by: Ryon Jensen <ryon.jensen@intel.com>