### PR TITLE
DAOS-5430 tests: increase nvme pool size for rebuild test

### DIFF
--- a/src/tests/suite/daos_capa.c
+++ b/src/tests/suite/daos_capa.c
@@ -71,7 +71,7 @@ query(void **state)
 
 	/** connect to the pool */
 	rc = daos_pool_connect(arg->pool.pool_uuid, arg->group,
-			       &arg->pool.svc, DAOS_PC_RW, &poh,
+			       arg->pool.svc, DAOS_PC_RW, &poh,
 			       NULL /* info */,
 			       NULL /* ev */);
 	assert_int_equal(rc, 0);
@@ -108,7 +108,7 @@ create(void **state)
 
 	/** connect to the pool in read-only mode */
 	rc = daos_pool_connect(arg->pool.pool_uuid, arg->group,
-			       &arg->pool.svc, DAOS_PC_RO, &poh,
+			       arg->pool.svc, DAOS_PC_RO, &poh,
 			       NULL /* info */,
 			       NULL /* ev */);
 	assert_int_equal(rc, 0);
@@ -125,7 +125,7 @@ create(void **state)
 
 	/** connect to the pool in read-write mode */
 	rc = daos_pool_connect(arg->pool.pool_uuid, arg->group,
-			       &arg->pool.svc, DAOS_PC_RW, &poh,
+			       arg->pool.svc, DAOS_PC_RW, &poh,
 			       NULL /* info */,
 			       NULL /* ev */);
 	assert_int_equal(rc, 0);
@@ -158,7 +158,7 @@ destroy(void **state)
 
 	/** connect to the pool in read-write mode */
 	rc = daos_pool_connect(arg->pool.pool_uuid, arg->group,
-			       &arg->pool.svc, DAOS_PC_RW, &poh,
+			       arg->pool.svc, DAOS_PC_RW, &poh,
 			       NULL /* info */,
 			       NULL /* ev */);
 	assert_int_equal(rc, 0);
@@ -182,7 +182,7 @@ destroy(void **state)
 
 	/** connect to the pool in read-only mode */
 	rc = daos_pool_connect(arg->pool.pool_uuid, arg->group,
-			       &arg->pool.svc, DAOS_PC_RO, &poh,
+			       arg->pool.svc, DAOS_PC_RO, &poh,
 			       NULL /* info */,
 			       NULL /* ev */);
 	assert_int_equal(rc, 0);
@@ -198,7 +198,7 @@ destroy(void **state)
 
 	/** connect to the pool in read-write mode */
 	rc = daos_pool_connect(arg->pool.pool_uuid, arg->group,
-			       &arg->pool.svc, DAOS_PC_RW, &poh,
+			       arg->pool.svc, DAOS_PC_RW, &poh,
 			       NULL /* info */,
 			       NULL /* ev */);
 	assert_int_equal(rc, 0);
@@ -228,7 +228,7 @@ open(void **state)
 
 	/** connect to the pool in read-write mode */
 	rc = daos_pool_connect(arg->pool.pool_uuid, arg->group,
-			       &arg->pool.svc, DAOS_PC_RW, &poh,
+			       arg->pool.svc, DAOS_PC_RW, &poh,
 			       NULL /* info */,
 			       NULL /* ev */);
 	assert_int_equal(rc, 0);
@@ -247,7 +247,7 @@ open(void **state)
 
 	/** reconnect to the pool in read-only mode */
 	rc = daos_pool_connect(arg->pool.pool_uuid, arg->group,
-			       &arg->pool.svc, DAOS_PC_RO, &poh,
+			       arg->pool.svc, DAOS_PC_RO, &poh,
 			       NULL /* info */,
 			       NULL /* ev */);
 	assert_int_equal(rc, 0);
@@ -300,7 +300,7 @@ io_invalid_poh(void **state)
 	if (arg->myrank == 0) {
 		/** connect to the pool in read-write mode */
 		rc = daos_pool_connect(arg->pool.pool_uuid, arg->group,
-				       &arg->pool.svc, DAOS_PC_RW, &poh,
+				       arg->pool.svc, DAOS_PC_RW, &poh,
 				       NULL /* info */,
 				       NULL /* ev */);
 		assert_int_equal(rc, 0);

--- a/src/tests/suite/daos_checksum.c
+++ b/src/tests/suite/daos_checksum.c
@@ -1550,7 +1550,7 @@ rebuild_test(void **state, int chunksize, int data_len_bytes, int iod_type)
 	print_message("Excluding rank %d\n", rank_to_exclude);
 	disabled_nr = disabled_targets(arg);
 	daos_exclude_server(arg->pool.pool_uuid, arg->group,
-			    arg->dmg_config, &arg->pool.alive_svc,
+			    arg->dmg_config, arg->pool.alive_svc,
 			    layout1->ol_shards[0]->os_ranks[0]);
 	assert_true(disabled_nr < disabled_targets(arg));
 
@@ -1578,7 +1578,7 @@ rebuild_test(void **state, int chunksize, int data_len_bytes, int iod_type)
 	assert_success(rc);
 
 	daos_add_server(arg->pool.pool_uuid, arg->group, arg->dmg_config,
-			&arg->pool.alive_svc, rank_to_exclude);
+			arg->pool.alive_svc, rank_to_exclude);
 	assert_int_equal(disabled_nr, disabled_targets(arg));
 	/** wait for rebuild */
 	test_rebuild_wait(&arg, 1);

--- a/src/tests/suite/daos_degraded.c
+++ b/src/tests/suite/daos_degraded.c
@@ -131,7 +131,7 @@ insert_lookup_enum_with_ops(test_arg_t *arg, int op_kill)
 		if (op_kill == UPDATE && rank == 0 &&
 		    g_dkeys > 1 && (i == g_dkeys/2))
 			daos_kill_server(arg, arg->pool.pool_uuid,
-					 arg->group, &arg->pool.svc, -1);
+					 arg->group, arg->pool.svc, -1);
 	}
 
 	MPI_Barrier(MPI_COMM_WORLD);
@@ -160,7 +160,7 @@ insert_lookup_enum_with_ops(test_arg_t *arg, int op_kill)
 		if (op_kill == LOOKUP && rank == 0 &&
 		    g_dkeys > 1 && (i == g_dkeys/2))
 			daos_kill_server(arg, arg->pool.pool_uuid,
-					 arg->group, &arg->pool.svc, -1);
+					 arg->group, arg->pool.svc, -1);
 	}
 	D_FREE(rec_verify);
 
@@ -207,7 +207,7 @@ insert_lookup_enum_with_ops(test_arg_t *arg, int op_kill)
 		if (op_kill == ENUMERATE && rank == 0 && enum_op &&
 		    g_dkeys > 1 && (key_nr  >= g_dkeys/2)) {
 			daos_kill_server(arg, arg->pool.pool_uuid,
-					 arg->group, &arg->pool.svc, -1);
+					 arg->group, arg->pool.svc, -1);
 			enum_op = 0;
 		}
 

--- a/src/tests/suite/daos_epoch_io.c
+++ b/src/tests/suite/daos_epoch_io.c
@@ -361,7 +361,7 @@ daos_test_cb_add(test_arg_t *arg, struct test_op_record *op,
 	print_message("add rank %u\n", op->ae_arg.ua_rank);
 	test_rebuild_wait(&arg, 1);
 	daos_add_server(arg->pool.pool_uuid, arg->group, arg->dmg_config,
-			&arg->pool.svc, op->ae_arg.ua_rank);
+			arg->pool.svc, op->ae_arg.ua_rank);
 	return 0;
 }
 
@@ -372,13 +372,13 @@ daos_test_cb_exclude(test_arg_t *arg, struct test_op_record *op,
 	if (op->ae_arg.ua_tgt == -1) {
 		print_message("exclude rank %u\n", op->ae_arg.ua_rank);
 		daos_exclude_server(arg->pool.pool_uuid, arg->group,
-				    arg->dmg_config, &arg->pool.svc,
+				    arg->dmg_config, arg->pool.svc,
 				    op->ae_arg.ua_rank);
 	} else {
 		print_message("exclude rank %u target %d\n",
 			       op->ae_arg.ua_rank, op->ae_arg.ua_tgt);
 		daos_exclude_target(arg->pool.pool_uuid, arg->group,
-				    arg->dmg_config, &arg->pool.svc,
+				    arg->dmg_config, arg->pool.svc,
 				    op->ae_arg.ua_rank, op->ae_arg.ua_tgt);
 	}
 	return 0;

--- a/src/tests/suite/daos_epoch_recovery.c
+++ b/src/tests/suite/daos_epoch_recovery.c
@@ -145,7 +145,7 @@ epoch_recovery(test_arg_t *arg, enum epoch_recovery_op op)
 		if (arg->myrank == 0) {
 			print_message("evicting pool connections\n");
 			rc = daos_pool_evict(arg->pool.pool_uuid, arg->group,
-					     &arg->pool.svc, NULL /* ev */);
+					     arg->pool.svc, NULL /* ev */);
 			assert_int_equal(rc, 0);
 		}
 		MPI_Barrier(MPI_COMM_WORLD);
@@ -164,7 +164,7 @@ epoch_recovery(test_arg_t *arg, enum epoch_recovery_op op)
 		print_message("reconnecting to pool\n");
 		if (arg->myrank == 0) {
 			rc = daos_pool_connect(arg->pool.pool_uuid, arg->group,
-					       &arg->pool.svc, DAOS_PC_RW,
+					       arg->pool.svc, DAOS_PC_RW,
 					       &arg->pool.poh, NULL /* info */,
 					       NULL /* ev */);
 			assert_int_equal(rc, 0);

--- a/src/tests/suite/daos_md_replication.c
+++ b/src/tests/suite/daos_md_replication.c
@@ -44,19 +44,19 @@ mdr_stop_pool_svc(void **argv)
 		rc = dmg_pool_create(dmg_config_file,
 				     geteuid(), getegid(), arg->group,
 				     NULL, 128 * 1024 * 1024, 0,
-				     &arg->pool.svc, uuid);
+				     arg->pool.svc, uuid);
 	}
 	MPI_Bcast(&rc, 1, MPI_INT, 0, MPI_COMM_WORLD);
 	assert_int_equal(rc, 0);
 	MPI_Bcast(uuid, 16, MPI_CHAR, 0, MPI_COMM_WORLD);
-	MPI_Bcast(&arg->pool.svc.rl_nr, sizeof(arg->pool.svc.rl_nr), MPI_CHAR,
+	MPI_Bcast(&arg->pool.svc->rl_nr, sizeof(arg->pool.svc->rl_nr), MPI_CHAR,
 		  0, MPI_COMM_WORLD);
 	MPI_Bcast(arg->pool.ranks,
-		  sizeof(arg->pool.ranks[0]) * arg->pool.svc.rl_nr,
+		  sizeof(arg->pool.ranks[0]) * arg->pool.svc->rl_nr,
 		  MPI_CHAR, 0, MPI_COMM_WORLD);
 
 	/* Check the number of pool service replicas. */
-	if (arg->pool.svc.rl_nr < 3) {
+	if (arg->pool.svc->rl_nr < 3) {
 		if (arg->myrank == 0)
 			print_message(">= 3 pool service replicas needed; ");
 		skip = true;
@@ -66,7 +66,7 @@ mdr_stop_pool_svc(void **argv)
 	/* Connect to the pool. */
 	if (arg->myrank == 0) {
 		print_message("connecting to pool\n");
-		rc = daos_pool_connect(uuid, arg->group, &arg->pool.svc,
+		rc = daos_pool_connect(uuid, arg->group, arg->pool.svc,
 				       DAOS_PC_RW, &poh, NULL /* info */,
 				       NULL /* ev */);
 	}
@@ -138,11 +138,11 @@ mdr_stop_cont_svc(void **argv)
 	print_message("creating pool\n");
 	rc = dmg_pool_create(dmg_config_file,
 			     geteuid(), getegid(), arg->group,
-			     NULL, 128 * 1024 * 1024, 0, &arg->pool.svc,
+			     NULL, 128 * 1024 * 1024, 0, arg->pool.svc,
 			     pool_uuid);
 	assert_int_equal(rc, 0);
 
-	if (arg->pool.svc.rl_nr < 3) {
+	if (arg->pool.svc->rl_nr < 3) {
 		if (arg->myrank == 0)
 			print_message(">= 3 pool service replicas needed; ");
 		skip = true;
@@ -150,7 +150,7 @@ mdr_stop_cont_svc(void **argv)
 	}
 
 	print_message("connecting to pool\n");
-	rc = daos_pool_connect(pool_uuid, arg->group, &arg->pool.svc,
+	rc = daos_pool_connect(pool_uuid, arg->group, arg->pool.svc,
 			       DAOS_PC_RW, &poh, NULL, NULL /* ev */);
 	assert_int_equal(rc, 0);
 	print_message("creating container\n");

--- a/src/tests/suite/daos_mgmt.c
+++ b/src/tests/suite/daos_mgmt.c
@@ -56,7 +56,7 @@ pool_create_all(void **state)
 			     arg->group, NULL /* tgts */,
 			     128 * 1024 * 1024 /* minimal size */,
 			     0 /* nvme size */,
-			     &arg->pool.svc /* svc */, uuid);
+			     arg->pool.svc /* svc */, uuid);
 	assert_int_equal(rc, 0);
 
 	uuid_unparse_lower(uuid, uuid_str);
@@ -95,10 +95,13 @@ setup_pools(void **state, daos_size_t npools)
 		goto err_free_lparg;
 
 	for (i = 0; i < npools; i++) {
+		d_rank_list_t	tmp_list;
+
 		/* Set some properties in the in/out tpools[i] struct */
 		lparg->tpools[i].poh = DAOS_HDL_INVAL;
-		lparg->tpools[i].svc.rl_ranks = lparg->tpools[i].ranks;
-		lparg->tpools[i].svc.rl_nr = svc_nreplicas;
+		tmp_list.rl_nr = svc_nreplicas;
+		tmp_list.rl_ranks = lparg->tpools[i].ranks;
+		d_rank_list_dup(&lparg->tpools[i].svc, &tmp_list);
 		lparg->tpools[i].pool_size = 1 << 28;	/* 256MB SCM */
 
 		/* Create the pool */
@@ -117,6 +120,8 @@ err_destroy_pools:
 		if (!uuid_is_null(lparg->tpools[i].pool_uuid) &&
 		    (arg->myrank == 0))
 			(void) pool_destroy_safe(arg, &lparg->tpools[i]);
+		if (lparg->tpools[i].svc)
+			d_rank_list_free(lparg->tpools[i].svc);
 	}
 
 	D_FREE(lparg->tpools);
@@ -207,8 +212,8 @@ find_pool(void **state, daos_mgmt_pool_info_t *pool)
 
 		uuid_match = (uuid_compare(pool->mgpi_uuid,
 					   lparg->tpools[i].pool_uuid) == 0);
-		ranks_match = d_rank_list_identical(&lparg->tpools[i].svc,
-							 pool->mgpi_svc);
+		ranks_match = d_rank_list_identical(lparg->tpools[i].svc,
+						    pool->mgpi_svc);
 
 		if (uuid_match && ranks_match) {
 			found_idx = i;
@@ -388,7 +393,7 @@ pool_create_and_destroy_retry(void **state)
 			     arg->group, NULL /* tgts */,
 			     128 * 1024 * 1024 /* minimal size */,
 			     0 /* nvme size */,
-			     &arg->pool.svc /* svc */, uuid);
+			     arg->pool.svc /* svc */, uuid);
 	assert_int_equal(rc, 0);
 	print_message("success uuid = "DF_UUIDF"\n", DP_UUID(uuid));
 

--- a/src/tests/suite/daos_obj.c
+++ b/src/tests/suite/daos_obj.c
@@ -3036,7 +3036,7 @@ tgt_idx_change_retry(void **state)
 		/** exclude target of the replica */
 		print_message("rank 0 excluding target rank %u ...\n", rank);
 		daos_exclude_server(arg->pool.pool_uuid, arg->group,
-				    arg->dmg_config, &arg->pool.svc, rank);
+				    arg->dmg_config, arg->pool.svc, rank);
 		assert_int_equal(rc, 0);
 
 		/** progress the async IO (not must) */
@@ -3093,7 +3093,7 @@ tgt_idx_change_retry(void **state)
 	if (arg->myrank == 0) {
 		print_message("rank 0 adding target rank %u ...\n", rank);
 		daos_add_server(arg->pool.pool_uuid, arg->group,
-				arg->dmg_config, &arg->pool.svc,
+				arg->dmg_config, arg->pool.svc,
 				rank);
 	}
 	MPI_Barrier(MPI_COMM_WORLD);
@@ -3131,7 +3131,7 @@ fetch_replica_unavail(void **state)
 	if (arg->myrank == 0) {
 		/** exclude the target of this obj's replicas */
 		daos_exclude_server(arg->pool.pool_uuid, arg->group,
-				    arg->dmg_config, &arg->pool.svc, rank);
+				    arg->dmg_config, arg->pool.svc, rank);
 	}
 	MPI_Barrier(MPI_COMM_WORLD);
 
@@ -3149,7 +3149,7 @@ fetch_replica_unavail(void **state)
 
 		/* add back the excluded targets */
 		daos_add_server(arg->pool.pool_uuid, arg->group,
-				arg->dmg_config, &arg->pool.svc,
+				arg->dmg_config, arg->pool.svc,
 				rank);
 
 		/* wait until reintegration is done */

--- a/src/tests/suite/daos_oid_alloc.c
+++ b/src/tests/suite/daos_oid_alloc.c
@@ -45,7 +45,7 @@ reconnect(test_arg_t *arg) {
 	flags = (DAOS_COO_RW | DAOS_COO_FORCE);
 	if (arg->myrank == 0) {
 		rc = daos_pool_connect(arg->pool.pool_uuid, arg->group,
-				       &arg->pool.svc, DAOS_PC_RW,
+				       arg->pool.svc, DAOS_PC_RW,
 				       &arg->pool.poh, &arg->pool.pool_info,
 				       NULL /* ev */);
 		if (rc)
@@ -258,7 +258,7 @@ oid_allocator_checker(void **state)
 					daos_kill_server(arg,
 						arg->pool.pool_uuid,
 						arg->group,
-						&arg->pool.svc, -1);
+						arg->pool.svc, -1);
 			}
 			MPI_Barrier(MPI_COMM_WORLD);
 		}

--- a/src/tests/suite/daos_rebuild.c
+++ b/src/tests/suite/daos_rebuild.c
@@ -767,7 +767,7 @@ rebuild_master_change_during_scan(void **state)
 	daos_obj_id_t	oids[OBJ_NR];
 	int		i;
 
-	if (!test_runable(arg, 6) || arg->pool.alive_svc.rl_nr == 1)
+	if (!test_runable(arg, 6) || arg->pool.alive_svc->rl_nr == 1)
 		return;
 
 	for (i = 0; i < OBJ_NR; i++) {
@@ -797,7 +797,7 @@ rebuild_master_change_during_rebuild(void **state)
 	daos_obj_id_t	oids[OBJ_NR];
 	int		i;
 
-	if (!test_runable(arg, 6) || arg->pool.alive_svc.rl_nr == 1)
+	if (!test_runable(arg, 6) || arg->pool.alive_svc->rl_nr == 1)
 		return;
 
 	for (i = 0; i < OBJ_NR; i++) {
@@ -915,7 +915,7 @@ rebuild_multiple_tgts(void **state)
 				daos_exclude_server(arg->pool.pool_uuid,
 						    arg->dmg_config,
 						    arg->group,
-						    &arg->pool.svc,
+						    arg->pool.svc,
 						    rank);
 				if (++fail_cnt >= 2)
 					break;
@@ -941,7 +941,7 @@ rebuild_multiple_tgts(void **state)
 	if (arg->myrank == 0) {
 		for (i = 0; i < 2; i++)
 			daos_add_server(arg->pool.pool_uuid, arg->group,
-					arg->dmg_config, &arg->pool.svc,
+					arg->dmg_config, arg->pool.svc,
 					exclude_ranks[i]);
 	}
 	MPI_Barrier(MPI_COMM_WORLD);
@@ -984,7 +984,7 @@ rebuild_master_failure(void **state)
 	int			rc;
 
 	/* need 5 svc replicas, as will kill the leader 2 times */
-	if (!test_runable(arg, 6) || arg->pool.alive_svc.rl_nr < 5) {
+	if (!test_runable(arg, 6) || arg->pool.alive_svc->rl_nr < 5) {
 		print_message("testing skipped ...\n");
 		return;
 	}
@@ -1093,7 +1093,7 @@ rebuild_fail_all_replicas_before_rebuild(void **state)
 	struct daos_obj_layout *layout;
 	struct daos_obj_shard *shard;
 
-	if (!test_runable(arg, 6) || arg->pool.alive_svc.rl_nr < 3)
+	if (!test_runable(arg, 6) || arg->pool.alive_svc->rl_nr < 3)
 		return;
 
 	oid = dts_oid_gen(DAOS_OC_R2S_SPEC_RANK, 0, arg->myrank);
@@ -1110,7 +1110,7 @@ rebuild_fail_all_replicas_before_rebuild(void **state)
 	/* Kill one replica and start rebuild */
 	shard = layout->ol_shards[0];
 	daos_kill_server(arg, arg->pool.pool_uuid, arg->group,
-			 &arg->pool.alive_svc, shard->os_ranks[0]);
+			 arg->pool.alive_svc, shard->os_ranks[0]);
 
 	/* Sleep 10 seconds after it scan finish and hang before rebuild */
 	print_message("sleep 10 seconds to wait scan to be finished \n");
@@ -1118,7 +1118,7 @@ rebuild_fail_all_replicas_before_rebuild(void **state)
 
 	/* Then kill rank 1 */
 	daos_kill_server(arg, arg->pool.pool_uuid, arg->group,
-			 &arg->pool.alive_svc, shard->os_ranks[1]);
+			 arg->pool.alive_svc, shard->os_ranks[1]);
 
 	/* Continue rebuild */
 	daos_mgmt_set_params(arg->group, -1, DMG_KEY_FAIL_LOC, 0, 0, NULL);
@@ -1146,7 +1146,7 @@ rebuild_fail_all_replicas(void **state)
 	 * in svcs, so make sure there are at least 6 ranks in svc, so
 	 * the new leader can be chosen.
 	 */
-	if (!test_runable(arg, 6) || arg->pool.alive_svc.rl_nr < 6) {
+	if (!test_runable(arg, 6) || arg->pool.alive_svc->rl_nr < 6) {
 		print_message("need at least 6 svcs, -s5\n");
 		return;
 	}
@@ -1165,7 +1165,7 @@ rebuild_fail_all_replicas(void **state)
 			d_rank_t rank = layout->ol_shards[i]->os_ranks[j];
 
 			daos_kill_server(arg, arg->pool.pool_uuid,
-					 arg->group, &arg->pool.alive_svc,
+					 arg->group, arg->pool.alive_svc,
 					 rank);
 		}
 	}

--- a/src/tests/suite/daos_rebuild_common.c
+++ b/src/tests/suite/daos_rebuild_common.c
@@ -53,7 +53,7 @@ rebuild_exclude_tgt(test_arg_t **args, int arg_cnt, d_rank_t rank,
 
 	if (kill) {
 		daos_kill_server(args[0], args[0]->pool.pool_uuid,
-				 args[0]->group, &args[0]->pool.alive_svc,
+				 args[0]->group, args[0]->pool.alive_svc,
 				 rank);
 		sleep(5);
 		/* If one rank is killed, then it has to exclude all
@@ -66,7 +66,7 @@ rebuild_exclude_tgt(test_arg_t **args, int arg_cnt, d_rank_t rank,
 	for (i = 0; i < arg_cnt; i++) {
 		daos_exclude_target(args[i]->pool.pool_uuid,
 				    args[i]->group, args[i]->dmg_config,
-				    &args[i]->pool.svc,
+				    args[i]->pool.svc,
 				    rank, tgt_idx);
 		sleep(2);
 	}
@@ -83,7 +83,7 @@ rebuild_add_tgt(test_arg_t **args, int args_cnt, d_rank_t rank,
 			daos_add_target(args[i]->pool.pool_uuid,
 					args[i]->group,
 					args[i]->dmg_config,
-					&args[i]->pool.svc,
+					args[i]->pool.svc,
 					rank, tgt_idx);
 		sleep(2);
 	}
@@ -100,7 +100,7 @@ rebuild_drain_tgt(test_arg_t **args, int args_cnt, d_rank_t rank,
 			daos_drain_target(args[i]->pool.pool_uuid,
 					args[i]->group,
 					args[i]->dmg_config,
-					&args[i]->pool.svc,
+					args[i]->pool.svc,
 					rank, tgt_idx);
 		sleep(2);
 	}
@@ -246,9 +246,9 @@ rebuild_pool_connect_internal(void *data)
 	MPI_Barrier(MPI_COMM_WORLD);
 	if (arg->myrank == 0) {
 		rc = daos_pool_connect(arg->pool.pool_uuid, arg->group,
-			&arg->pool.svc, DAOS_PC_RW,
-			&arg->pool.poh, &arg->pool.pool_info,
-			NULL /* ev */);
+				       arg->pool.svc, DAOS_PC_RW,
+				       &arg->pool.poh, &arg->pool.pool_info,
+				       NULL /* ev */);
 		if (rc)
 			print_message("daos_pool_connect failed, rc: %d\n", rc);
 
@@ -366,7 +366,7 @@ rebuild_add_back_tgts(test_arg_t *arg, d_rank_t failed_rank, int *failed_tgts,
 
 		for (i = 0; i < nr; i++)
 			daos_add_target(arg->pool.pool_uuid, arg->group,
-					arg->dmg_config, &arg->pool.svc,
+					arg->dmg_config, arg->pool.svc,
 					failed_rank,
 					failed_tgts ? failed_tgts[i] : -1);
 	}

--- a/src/tests/suite/daos_test.h
+++ b/src/tests/suite/daos_test.h
@@ -100,12 +100,12 @@ struct test_pool {
 	/* Updated if some ranks are killed during degraged or rebuild
 	 * test, so we know whether some tests is allowed to be run.
 	 */
-	d_rank_list_t		alive_svc;
+	d_rank_list_t		*alive_svc;
 	/* Used for all pool related operation, since client will
 	 * use this rank list to find out the real leader, so it
 	 * can not be changed.
 	 */
-	d_rank_list_t		svc;
+	d_rank_list_t		*svc;
 	/* flag of slave that share the pool of other test_arg_t */
 	bool			slave;
 	bool			destroyed;

--- a/src/tests/suite/daos_test_common.c
+++ b/src/tests/suite/daos_test_common.c
@@ -70,10 +70,8 @@ test_setup_pool_create(void **state, struct test_pool *ipool,
 		assert_int_equal(outpool->slave, 0);
 		outpool->pool_size = ipool->pool_size;
 		uuid_copy(outpool->pool_uuid, ipool->pool_uuid);
-		outpool->alive_svc.rl_nr = ipool->alive_svc.rl_nr;
-		outpool->svc.rl_nr = ipool->svc.rl_nr;
-		memcpy(outpool->ranks, ipool->ranks,
-		       sizeof(outpool->ranks[0]) * TEST_RANKS_MAX_NUM);
+		d_rank_list_dup(&outpool->alive_svc, ipool->alive_svc);
+		d_rank_list_dup(&outpool->svc, ipool->svc);
 		outpool->slave = 1;
 		if (arg->multi_rank)
 			MPI_Barrier(MPI_COMM_WORLD);
@@ -94,12 +92,12 @@ test_setup_pool_create(void **state, struct test_pool *ipool,
 		}
 
 		/*
-		 * Set the default NVMe partition size to "4 * scm_size", so
+		 * Set the default NVMe partition size to "32 * scm_size", so
 		 * that we need to specify SCM size only for each test case.
 		 *
 		 * Set env POOL_NVME_SIZE to overwrite the default NVMe size.
 		 */
-		nvme_size = outpool->pool_size * 4;
+		nvme_size = outpool->pool_size * 32;
 		env = getenv("POOL_NVME_SIZE");
 		if (env) {
 			size_gb = atoi(env);
@@ -112,7 +110,7 @@ test_setup_pool_create(void **state, struct test_pool *ipool,
 		rc = dmg_pool_create(dmg_config_file,
 				     arg->uid, arg->gid, arg->group,
 				     NULL, outpool->pool_size, nvme_size,
-				     &outpool->svc, outpool->pool_uuid);
+				     outpool->svc, outpool->pool_uuid);
 		if (rc)
 			print_message("dmg_pool_create failed, rc: %d\n", rc);
 		else
@@ -126,12 +124,12 @@ test_setup_pool_create(void **state, struct test_pool *ipool,
 		if (!rc) {
 			MPI_Bcast(outpool->pool_uuid, 16,
 				  MPI_CHAR, 0, MPI_COMM_WORLD);
-			MPI_Bcast(&outpool->svc.rl_nr,
-				  sizeof(outpool->svc.rl_nr),
+			MPI_Bcast(&outpool->svc->rl_nr,
+				  sizeof(outpool->svc->rl_nr),
 				  MPI_CHAR, 0, MPI_COMM_WORLD);
-			MPI_Bcast(outpool->ranks,
-				  sizeof(outpool->ranks[0]) *
-					 outpool->svc.rl_nr,
+			MPI_Bcast(outpool->svc->rl_ranks,
+				  sizeof(outpool->svc->rl_ranks[0]) *
+					 outpool->svc->rl_nr,
 				  MPI_CHAR, 0, MPI_COMM_WORLD);
 		}
 	}
@@ -160,7 +158,7 @@ test_setup_pool_connect(void **state, struct test_pool *pool)
 
 		print_message("setup: connecting to pool\n");
 		rc = daos_pool_connect(arg->pool.pool_uuid, arg->group,
-				       &arg->pool.svc,
+				       arg->pool.svc,
 				       arg->pool.pool_connect_flags,
 				       &arg->pool.poh, &arg->pool.pool_info,
 				       NULL /* ev */);
@@ -293,6 +291,8 @@ test_setup(void **state, unsigned int step, bool multi_rank,
 	srandom(seed);
 
 	if (arg == NULL) {
+		d_rank_list_t	tmp_list;
+
 		D_ALLOC(arg, sizeof(test_arg_t));
 		if (arg == NULL)
 			return -1;
@@ -305,10 +305,11 @@ test_setup(void **state, unsigned int step, bool multi_rank,
 		arg->pool.pool_size = pool_size;
 		arg->setup_state = -1;
 
-		arg->pool.alive_svc.rl_nr = svc_nreplicas;
-		arg->pool.alive_svc.rl_ranks = arg->pool.ranks;
-		arg->pool.svc.rl_nr = svc_nreplicas;
-		arg->pool.svc.rl_ranks = arg->pool.ranks;
+		tmp_list.rl_nr = svc_nreplicas;
+		tmp_list.rl_ranks = arg->pool.ranks;
+
+		d_rank_list_dup(&arg->pool.alive_svc, &tmp_list);
+		d_rank_list_dup(&arg->pool.svc, &tmp_list);
 		arg->pool.slave = false;
 
 		arg->uid = geteuid();
@@ -382,7 +383,7 @@ pool_destroy_safe(test_arg_t *arg, struct test_pool *extpool)
 
 	if (daos_handle_is_inval(poh)) {
 		rc = daos_pool_connect(pool->pool_uuid, arg->group,
-				       &pool->svc, DAOS_PC_RW,
+				       pool->svc, DAOS_PC_RW,
 				       &poh, &pool->pool_info,
 				       NULL /* ev */);
 		if (rc != 0) { /* destroy straight away */
@@ -540,6 +541,10 @@ test_teardown(void **state)
 	}
 
 free:
+	if (arg->pool.svc)
+		d_rank_list_free(arg->pool.svc);
+	if (arg->pool.alive_svc)
+		d_rank_list_free(arg->pool.alive_svc);
 	D_FREE(arg);
 	*state = NULL;
 	return 0;
@@ -619,7 +624,7 @@ test_pool_get_info(test_arg_t *arg, daos_pool_info_t *pinfo)
 
 	if (daos_handle_is_inval(arg->pool.poh)) {
 		rc = daos_pool_connect(arg->pool.pool_uuid, arg->group,
-				       &arg->pool.svc, DAOS_PC_RW,
+				       arg->pool.svc, DAOS_PC_RW,
 				       &arg->pool.poh, pinfo,
 				       NULL /* ev */);
 		if (rc) {


### PR DESCRIPTION
1. Increase NVME pool size to satisfy new dmg pool create.

2. Change test_pool.svc to pointer, since dmg_pool_create
might reallocate svc.

Signed-off-by: Di Wang <di.wang@intel.com>