### PR TITLE
DAOS-5432 vos: add check to obj_tree_register()

### DIFF
--- a/src/vos/vos_common.c
+++ b/src/vos/vos_common.c
@@ -379,8 +379,10 @@ vos_mod_init(void)
 	}
 
 	rc = obj_tree_register();
-	if (rc)
+	if (rc) {
 		D_ERROR("Failed to register vos trees\n");
+		return rc;
+	}
 
 	rc = vos_ilog_init();
 	if (rc)


### PR DESCRIPTION
Propagate the error code that might be produced by
registering two tree classes using the same class ID.

Signed-off-by: Martinez Montes, Jonathan <jonathan.martinez.montes@intel.com>