### PR TITLE
DAOS-5440 vos: Add nosnap API to mem APIs

### DIFF
--- a/src/common/mem.c
+++ b/src/common/mem.c
@@ -120,6 +120,14 @@ pmem_tx_add(struct umem_instance *umm, umem_off_t umoff,
 	return pmemobj_tx_add_range(umem_off2id(umm, umoff), offset, size);
 }
 
+static int
+pmem_tx_xadd(struct umem_instance *umm, umem_off_t umoff, uint64_t offset,
+	     size_t size, uint64_t flags)
+{
+	return pmemobj_tx_xadd_range(umem_off2id(umm, umoff), offset, size,
+				     flags);
+}
+
 
 static int
 pmem_tx_add_ptr(struct umem_instance *umm, void *ptr, size_t size)
@@ -345,6 +353,7 @@ static umem_ops_t	pmem_ops = {
 	.mo_tx_free		= pmem_tx_free,
 	.mo_tx_alloc		= pmem_tx_alloc,
 	.mo_tx_add		= pmem_tx_add,
+	.mo_tx_xadd		= pmem_tx_xadd,
 	.mo_tx_add_ptr		= pmem_tx_add_ptr,
 	.mo_tx_abort		= pmem_tx_abort,
 	.mo_tx_begin		= pmem_tx_begin,

--- a/src/vos/vos_tree.c
+++ b/src/vos/vos_tree.c
@@ -557,7 +557,11 @@ svt_rec_alloc_common(struct btr_instance *tins, struct btr_record *rec,
 	int			 rc;
 
 	D_ASSERT(!UMOFF_IS_NULL(rbund->rb_off));
-	umem_tx_add(&tins->ti_umm, rbund->rb_off, vos_irec_msize(rbund));
+	rc = umem_tx_xadd(&tins->ti_umm, rbund->rb_off, vos_irec_msize(rbund),
+			  POBJ_XADD_NO_SNAPSHOT);
+	if (rc != 0)
+		return rc;
+
 	rec->rec_off = rbund->rb_off;
 	rbund->rb_off = UMOFF_NULL; /* taken over by btree */
 


### PR DESCRIPTION
In order to accomodate adding uninitialized memory to a transaction
and avoiding uninitialized read in valgrind, add a new mem API
to utilize the PMDK flags (including no snapshot flag)

Signed-off-by: Jeff Olivier <jeffrey.v.olivier@intel.com>