### PR TITLE
CART-908 hg: Remove usage of NA_* interfaces

### DIFF
--- a/src/cart/src/cart/crt_context.c
+++ b/src/cart/src/cart/crt_context.c
@@ -199,7 +199,7 @@ crt_context_create(crt_context_t *crt_ctx)
 		D_GOTO(out, rc = -DER_INVAL);
 	}
 
-	if (crt_gdata.cg_share_na &&
+	if (crt_gdata.cg_sep_mode &&
 	    crt_gdata.cg_ctx_num >= crt_gdata.cg_ctx_max_num) {
 		D_ERROR("Number of active contexts (%d) reached limit (%d).\n",
 			crt_gdata.cg_ctx_num, crt_gdata.cg_ctx_max_num);

--- a/src/cart/src/cart/crt_group.c
+++ b/src/cart/src/cart/crt_group.c
@@ -783,7 +783,7 @@ crt_grp_lc_addr_insert(struct crt_grp_priv *passed_grp_priv,
 
 	D_ASSERT(crt_ctx != NULL);
 
-	if (crt_gdata.cg_share_na == true)
+	if (crt_gdata.cg_sep_mode == true)
 		tag = 0;
 
 	grp_priv = passed_grp_priv;
@@ -852,7 +852,7 @@ crt_grp_lc_lookup(struct crt_grp_priv *grp_priv, int ctx_idx,
 	D_ASSERT(uri != NULL || hg_addr != NULL);
 	D_ASSERT(ctx_idx >= 0 && ctx_idx < CRT_SRV_CONTEXT_NUM);
 
-	if (crt_gdata.cg_share_na == true)
+	if (crt_gdata.cg_sep_mode == true)
 		tag = 0;
 
 	default_grp_priv = grp_priv;

--- a/src/cart/src/cart/crt_group.c
+++ b/src/cart/src/cart/crt_group.c
@@ -2543,8 +2543,8 @@ crt_rank_self_set(d_rank_t rank)
 {
 	int rc = 0;
 	struct crt_grp_priv	*default_grp_priv;
-	na_class_t		*na_class;
-	na_size_t		size = CRT_ADDR_STR_MAX_LEN;
+	hg_class_t		*hg_class;
+	hg_size_t		size = CRT_ADDR_STR_MAX_LEN;
 	struct crt_context	*ctx;
 	char			uri_addr[CRT_ADDR_STR_MAX_LEN] = {'\0'};
 
@@ -2575,11 +2575,11 @@ crt_rank_self_set(d_rank_t rank)
 
 	D_RWLOCK_RDLOCK(&crt_gdata.cg_rwlock);
 	d_list_for_each_entry(ctx, &crt_gdata.cg_ctx_list, cc_link) {
-		na_class =  ctx->cc_hg_ctx.chc_nacla;
+		hg_class =  ctx->cc_hg_ctx.chc_hgcla;
 
-		rc = crt_na_class_get_addr(na_class, uri_addr, &size);
+		rc = crt_hg_get_addr(hg_class, uri_addr, &size);
 		if (rc != 0) {
-			D_ERROR("crt_na_class_get_addr() failed; rc=%d\n", rc);
+			D_ERROR("crt_hg_get_addr() failed; rc=%d\n", rc);
 			D_GOTO(unlock, rc);
 		}
 
@@ -2590,7 +2590,6 @@ crt_rank_self_set(d_rank_t rank)
 				rc);
 			D_GOTO(unlock, rc);
 		}
-
 	}
 
 unlock:

--- a/src/cart/src/cart/crt_hg.c
+++ b/src/cart/src/cart/crt_hg.c
@@ -563,7 +563,8 @@ crt_hg_ctx_init(struct crt_hg_context *hg_ctx, int idx)
 		init_info.na_init_info.progress_mode = 0;
 		init_info.na_init_info.max_contexts = 1;
 
-		hg_class = HG_Init_opt(info_string, crt_is_service(), &init_info);
+		hg_class = HG_Init_opt(info_string, crt_is_service(),
+				       &init_info);
 		if (hg_class == NULL) {
 			D_ERROR("Could not initialize HG class.\n");
 			D_GOTO(out, rc = -DER_HG);

--- a/src/cart/src/cart/crt_hg.h
+++ b/src/cart/src/cart/crt_hg.h
@@ -34,7 +34,6 @@
 #include <mercury_proc.h>
 #include <mercury_proc_string.h>
 #include <mercury_log.h>
-#include <na.h>
 
 /** the shared HG RPC ID used for all CRT opc */
 #define CRT_HG_RPCID		(0xDA036868)
@@ -100,7 +99,6 @@ struct crt_hg_pool {
 /** HG context */
 struct crt_hg_context {
 	bool			 chc_shared_na; /* flag for shared na_class */
-	na_class_t		*chc_nacla; /* NA class */
 	hg_class_t		*chc_hgcla; /* HG class */
 	hg_context_t		*chc_hgctx; /* HG context */
 	hg_class_t		*chc_bulkcla; /* bulk class */
@@ -110,7 +108,6 @@ struct crt_hg_context {
 
 /** HG level global data */
 struct crt_hg_gdata {
-	na_class_t		*chg_nacla; /* NA class */
 	hg_class_t		*chg_hgcla; /* HG class */
 };
 

--- a/src/cart/src/cart/crt_hg.h
+++ b/src/cart/src/cart/crt_hg.h
@@ -98,7 +98,8 @@ struct crt_hg_pool {
 
 /** HG context */
 struct crt_hg_context {
-	bool			 chc_shared_na; /* flag for shared na_class */
+	/* Flag indicating whether hg class is shared; true for SEP mode */
+	bool			 chc_shared_hg_class;
 	hg_class_t		*chc_hgcla; /* HG class */
 	hg_context_t		*chc_hgctx; /* HG context */
 	hg_class_t		*chc_bulkcla; /* bulk class */

--- a/src/cart/src/cart/crt_init.c
+++ b/src/cart/src/cart/crt_init.c
@@ -114,7 +114,7 @@ static int data_init(int server, crt_init_options_t *opt)
 	crt_gdata.cg_inited = 0;
 	crt_gdata.cg_addr = NULL;
 	crt_gdata.cg_na_plugin = CRT_NA_OFI_SOCKETS;
-	crt_gdata.cg_share_na = false;
+	crt_gdata.cg_sep_mode = false;
 
 	srand(d_timeus_secdiff(0) + getpid());
 	start_rpcid = ((uint64_t)rand()) << 32;
@@ -180,23 +180,23 @@ static int data_init(int server, crt_init_options_t *opt)
 
 	if (opt && opt->cio_sep_override) {
 		if (opt->cio_use_sep) {
-			crt_gdata.cg_share_na = true;
-			D_DEBUG(DB_ALL, "crt_gdata.cg_share_na turned on.\n");
+			crt_gdata.cg_sep_mode = true;
+			D_DEBUG(DB_ALL, "crt_gdata.cg_sep_mode turned on.\n");
 		}
 		crt_gdata.cg_ctx_max_num = opt->cio_ctx_max_num;
 	} else {
 		d_getenv_bool("CRT_CTX_SHARE_ADDR", &share_addr);
 		if (share_addr) {
-			crt_gdata.cg_share_na = true;
-			D_DEBUG(DB_ALL, "crt_gdata.cg_share_na turned on.\n");
+			crt_gdata.cg_sep_mode = true;
+			D_DEBUG(DB_ALL, "crt_gdata.cg_sep_mode turned on.\n");
 		}
 
 		d_getenv_int("CRT_CTX_NUM", &ctx_num);
 		crt_gdata.cg_ctx_max_num = ctx_num;
 	}
-	D_DEBUG(DB_ALL, "set cg_share_na %d, cg_ctx_max_num %d.\n",
-		crt_gdata.cg_share_na, crt_gdata.cg_ctx_max_num);
-	if (crt_gdata.cg_share_na == false && crt_gdata.cg_ctx_max_num > 1)
+	D_DEBUG(DB_ALL, "set cg_sep_mode %d, cg_ctx_max_num %d.\n",
+		crt_gdata.cg_sep_mode, crt_gdata.cg_ctx_max_num);
+	if (crt_gdata.cg_sep_mode == false && crt_gdata.cg_ctx_max_num > 1)
 		D_WARN("CRT_CTX_NUM has no effect because CRT_CTX_SHARE_ADDR "
 		       "is not set or set to 0\n");
 
@@ -366,10 +366,10 @@ do_init:
 		if ((crt_gdata.cg_na_plugin == CRT_NA_OFI_VERBS_RXM ||
 		     crt_gdata.cg_na_plugin == CRT_NA_OFI_VERBS ||
 		     crt_gdata.cg_na_plugin == CRT_NA_OFI_TCP_RXM) &&
-		    crt_gdata.cg_share_na) {
+		    crt_gdata.cg_sep_mode) {
 			D_WARN("set CRT_CTX_SHARE_ADDR as 1 is invalid "
 			       "for current provider, ignore it.\n");
-			crt_gdata.cg_share_na = false;
+			crt_gdata.cg_sep_mode = false;
 		}
 
 		if (crt_gdata.cg_na_plugin == CRT_NA_OFI_VERBS_RXM ||

--- a/src/cart/src/cart/crt_internal_fns.h
+++ b/src/cart/src/cart/crt_internal_fns.h
@@ -37,11 +37,6 @@ void crt_opc_map_destroy(struct crt_opc_map *map);
 struct crt_opc_info *crt_opc_lookup(struct crt_opc_map *map, crt_opcode_t opc,
 				    int locked);
 
-/** crt_hg.c */
-int
-crt_na_class_get_addr(na_class_t *na_class,
-		char *addr_str, na_size_t *str_size);
-
 /** crt_context.c */
 /* return values of crt_context_req_track, in addition to standard
  * gurt error values.

--- a/src/cart/src/cart/crt_internal_types.h
+++ b/src/cart/src/cart/crt_internal_types.h
@@ -46,12 +46,8 @@ struct crt_gdata {
 	crt_phy_addr_t		cg_addr;
 
 	bool			cg_server;
-	/*
-	 * share NA addr flag, true means all contexts share one NA class, fasle
-	 * means each context has its own NA class.  Each NA class has an
-	 * independent listening address.
-	 */
-	bool			cg_share_na;
+	/* Flag indicating whether scalable endpoint mode is enabled */
+	bool			cg_sep_mode;
 	int			cg_na_plugin; /* NA plugin type */
 
 	/* global timeout value (second) for all RPCs */


### PR DESCRIPTION
Remove usage of NA_* interfaces directly and instead use
corresponding HG_* functions.

Signed-off-by: Alexander Oganezov <alexander.a.oganezov@intel.com>