### PR TITLE
DAOS-5387 test: fix the parameter order for server exclude

### DIFF
--- a/src/tests/suite/daos_rebuild.c
+++ b/src/tests/suite/daos_rebuild.c
@@ -913,8 +913,8 @@ rebuild_multiple_tgts(void **state)
 			if (rank != leader) {
 				exclude_ranks[fail_cnt] = rank;
 				daos_exclude_server(arg->pool.pool_uuid,
-						    arg->dmg_config,
 						    arg->group,
+						    arg->dmg_config,
 						    &arg->pool.svc,
 						    rank);
 				if (++fail_cnt >= 2)


### PR DESCRIPTION
Fix parameters order of daos_exclude_server() in
rebuild_multiple_tgts().

Signed-off-by: Di Wang <di.wang@intel.com>