### PR TITLE
DAOS-5356 osa: increase logging in offline reintegration test

### DIFF
--- a/src/tests/ftest/osa/osa_offline_reintegration.yaml
+++ b/src/tests/ftest/osa/osa_offline_reintegration.yaml
@@ -15,6 +15,9 @@ server_config:
       scm_class: dcpm
       scm_list: ["/dev/pmem0"]
       scm_mount: /mnt/daos0
+      log_mask: DEBUG,RPC=ERR,MEM=ERR
+      env_vars:
+        - DD_MASK=mgmt,md,dsms,any
   transport_config:
     allow_insecure: True
 agent_config:


### PR DESCRIPTION
Increase debug logging level to gain insight into server crash
observed (intermittently?) in pool create.

Skip-checkpatch: true
Skip-run_test: true
Skip-func-test: true
Skip-func-hw-test-small: true
Skip-func-hw-test-medium: true
Skip-bullseye: true
Test-tag-hw-large: pr,hw,large,osa,offline_reintegration

Signed-off-by: Kenneth Cain <kenneth.c.cain@intel.com>