### PR TITLE
DAOS-3800 dtx: optimize read with non-committed sync mod DTX

### DIFF
--- a/src/dtx/dtx_common.c
+++ b/src/dtx/dtx_common.c
@@ -285,7 +285,6 @@ dtx_handle_init(struct dtx_id *dti, daos_handle_t coh, struct dtx_epoch *epoch,
 	dth->dth_refs = 1;
 	dth->dth_mbs = mbs;
 
-	dth->dth_sync = 0;
 	dth->dth_resent = 0;
 	dth->dth_solo = solo ? 1 : 0;
 	dth->dth_modify_shared = 0;
@@ -297,6 +296,17 @@ dtx_handle_init(struct dtx_id *dti, daos_handle_t coh, struct dtx_epoch *epoch,
 	dth->dth_dti_cos_count = dti_cos_cnt;
 	dth->dth_ent = NULL;
 	dth->dth_flags = leader ? DTE_LEADER : 0;
+
+	/* Set 'DTE_BLOCK' flag for distributed transaction.
+	 * At the same time, ask DTX to 'sync' commit.
+	 */
+	if (mbs != NULL && mbs->dm_grp_cnt > 1) {
+		dth->dth_flags |= DTE_BLOCK;
+		dth->dth_sync = 1;
+	} else {
+		dth->dth_sync = 0;
+	}
+
 	dth->dth_modification_cnt = sub_modification_cnt;
 
 	dth->dth_op_seq = 0;
@@ -638,13 +648,6 @@ again:
 
 			dth->dth_sync = 1;
 		}
-
-		/* FIXME: For the DTX across multiple modification groups,
-		 *	  commit it synchronously. That will be changed in
-		 *	  next phase.
-		 */
-		if (dth->dth_mbs->dm_grp_cnt > 1)
-			dth->dth_sync = 1;
 
 		/* For synchronous DTX, do not add it into CoS cache, otherwise,
 		 * we may have no way to remove it from the cache.

--- a/src/include/daos_errno.h
+++ b/src/include/daos_errno.h
@@ -170,7 +170,9 @@ extern "C" {
 	/** Data lost or not recoverable */				\
 	ACTION(DER_DATA_LOSS,		(DER_ERR_DAOS_BASE + 26))	\
 	/** Operation canceled (non-crt) */				\
-	ACTION(DER_OP_CANCELED,		(DER_ERR_DAOS_BASE + 27))
+	ACTION(DER_OP_CANCELED,		(DER_ERR_DAOS_BASE + 27))	\
+	/** TX is not committed, not sure whether committable or not */	\
+	ACTION(DER_TX_BUSY,		(DER_ERR_DAOS_BASE + 28))
 
 /** Defines the gurt error codes */
 #define D_FOREACH_ERR_RANGE(ACTION)	\

--- a/src/include/daos_srv/vos_types.h
+++ b/src/include/daos_srv/vos_types.h
@@ -51,6 +51,12 @@ enum dtx_entry_flags {
 	DTE_LEADER		= (1 << 0),
 	/* The DTX entry is invalid. */
 	DTE_INVALID		= (1 << 1),
+	/* If the DTX with this flag is non-committed, then others
+	 * will be blocked (retry again and again) when access the
+	 * data being modified via this DTX. Currently, it is used
+	 * for distributed transaction.
+	 */
+	DTE_BLOCK		= (1 << 2),
 };
 
 struct dtx_entry {

--- a/src/object/obj_internal.h
+++ b/src/object/obj_internal.h
@@ -421,7 +421,7 @@ obj_retry_error(int err)
 {
 	return err == -DER_TIMEDOUT || err == -DER_STALE ||
 	       err == -DER_INPROGRESS || err == -DER_GRPVER ||
-	       err == -DER_EVICTED || err == -DER_CSUM ||
+	       err == -DER_EVICTED || err == -DER_CSUM || err == -DER_TX_BUSY ||
 	       daos_crt_network_error(err);
 }
 

--- a/src/object/srv_obj.c
+++ b/src/object/srv_obj.c
@@ -1303,7 +1303,8 @@ obj_local_rw(crt_rpc_t *rpc, struct obj_io_context *ioc,
 				     fetch_flags, shadows, &ioh, dth);
 		daos_recx_ep_list_free(shadows, orw->orw_nr);
 		if (rc) {
-			D_CDEBUG(rc == -DER_INPROGRESS, DB_IO, DLOG_ERR,
+			D_CDEBUG(rc == -DER_INPROGRESS || rc == -DER_TX_BUSY,
+				 DB_IO, DLOG_ERR,
 				 "Fetch begin for "DF_UOID" failed: "DF_RC"\n",
 				 DP_UOID(orw->orw_oid), DP_RC(rc));
 			goto out;
@@ -1817,6 +1818,7 @@ ds_obj_rw_handler(crt_rpc_t *rpc)
 	struct dtx_memberships		*mbs = NULL;
 	struct daos_shard_tgt		*tgts = NULL;
 	struct dtx_id			*dti_cos = NULL;
+	struct dss_sleep_ult		*sleep_ult = NULL;
 	int				dti_cos_cnt;
 	uint32_t			tgt_cnt;
 	uint32_t			version;
@@ -1849,6 +1851,7 @@ ds_obj_rw_handler(crt_rpc_t *rpc)
 
 	if (obj_rpc_is_fetch(rpc)) {
 		struct dtx_handle dth = {0};
+		int		  retry = 0;
 
 		if (orw->orw_flags & ORF_CSUM_REPORT) {
 			obj_log_csum_err();
@@ -1859,6 +1862,7 @@ ds_obj_rw_handler(crt_rpc_t *rpc)
 		epoch.oe_first = orw->orw_epoch_first;
 		epoch.oe_flags = orf_to_dtx_epoch_flags(orw->orw_flags);
 
+re_fetch:
 		rc = dtx_begin(ioc.ioc_coc, &orw->orw_dti, &epoch, 0,
 			       orw->orw_map_ver, &orw->orw_oid,
 			       NULL, 0, NULL, &dth);
@@ -1867,6 +1871,27 @@ ds_obj_rw_handler(crt_rpc_t *rpc)
 
 		rc = obj_local_rw(rpc, &ioc, NULL, NULL, NULL, &dth);
 		rc = dtx_end(&dth, ioc.ioc_coc, rc);
+
+		if (rc == -DER_TX_BUSY && ++retry < 3) {
+			/* XXX: Currently, we commit the distributed transaction
+			 *	sychronously. Normally, it will be very quickly.
+			 *	So let's wait on the server for a while (30 ms),
+			 *	then retry. If related distributed transaction
+			 *	is still not committed after several cycles try,
+			 *	then replies '-DER_TX_BUSY' to the client.
+			 */
+			if (sleep_ult == NULL)
+				sleep_ult = dss_sleep_ult_create();
+
+			if (sleep_ult != NULL) {
+				D_DEBUG(DB_IO, "Fetch obj "DF_UOID", dkey "
+					DF_KEY", hit non-committed DTX (%d)\n",
+					DP_UOID(orw->orw_oid),
+					DP_KEY(&orw->orw_dkey), retry);
+				dss_ult_sleep(sleep_ult, 30000);
+				goto re_fetch;
+			}
+		}
 
 		D_GOTO(out, rc);
 	}
@@ -2010,6 +2035,9 @@ out:
 
 cleanup:
 	D_TIME_END(time_start, OBJ_PF_UPDATE);
+	if (sleep_ult != NULL)
+		dss_sleep_ult_destroy(sleep_ult);
+
 	obj_ec_split_req_fini(split_req);
 	D_FREE(mbs);
 	D_FREE(dti_cos);
@@ -2057,6 +2085,8 @@ obj_local_enum(struct obj_io_context *ioc, crt_rpc_t *rpc,
 {
 	vos_iter_param_t	param = { 0 };
 	struct obj_key_enum_in	*oei = crt_req_get(rpc);
+	struct dss_sleep_ult	*sleep_ult = NULL;
+	int			retry = 0;
 	int			opc = opc_get(rpc->cr_opc);
 	int			type;
 	int			rc;
@@ -2154,6 +2184,7 @@ obj_local_enum(struct obj_io_context *ioc, crt_rpc_t *rpc,
 		goto failed;
 	}
 
+again:
 	rc = dtx_begin(ioc->ioc_coc, &oei->oei_dti, &epoch, 0,
 		       oei->oei_map_ver, &oei->oei_oid, NULL, 0, NULL, &dth);
 	if (rc != 0)
@@ -2167,6 +2198,27 @@ obj_local_enum(struct obj_io_context *ioc, crt_rpc_t *rpc,
 	if (rc_tmp != 0)
 		rc = rc_tmp;
 
+	if (rc == -DER_TX_BUSY && ++retry < 3) {
+		/* XXX: Currently, we commit the distributed transaction
+		 *	sychronously. Normally, it will be very quickly.
+		 *	So let's wait on the server for a while (30 ms),
+		 *	then retry. If related distributed transaction
+		 *	is still not committed after several cycles try,
+		 *	then replies '-DER_TX_BUSY' to the client.
+		 */
+		if (sleep_ult == NULL)
+			sleep_ult = dss_sleep_ult_create();
+
+		if (sleep_ult != NULL) {
+			D_DEBUG(DB_IO, "Enumerate obj "DF_UOID
+				", hit non-committed DTX (%d)\n",
+				DP_UOID(oei->oei_oid), retry);
+			dss_ult_sleep(sleep_ult, 30000);
+			/* re-enumeration from the last -DER_TX_BUSY. */
+			goto again;
+		}
+	}
+
 	if (type == VOS_ITER_SINGLE)
 		anchors->ia_ev = anchors->ia_sv;
 
@@ -2175,6 +2227,9 @@ obj_local_enum(struct obj_io_context *ioc, crt_rpc_t *rpc,
 		param.ip_epr.epr_hi, type, dss_get_module_info()->dmi_tgt_id,
 		rc);
 failed:
+	if (sleep_ult != NULL)
+		dss_sleep_ult_destroy(sleep_ult);
+
 	*e_out = epoch.oe_value;
 	return rc;
 }
@@ -2733,6 +2788,8 @@ ds_obj_query_key_handler(crt_rpc_t *rpc)
 	struct obj_io_context		 ioc;
 	struct dtx_handle		 dth = {0};
 	struct dtx_epoch		 epoch = {0};
+	struct dss_sleep_ult		*sleep_ult = NULL;
+	int				 retry = 0;
 	int				 rc;
 
 	okqi = crt_req_get(rpc);
@@ -2753,6 +2810,7 @@ ds_obj_query_key_handler(crt_rpc_t *rpc)
 	if (rc == PE_OK_LOCAL)
 		okqi->okqi_flags &= ~ORF_EPOCH_UNCERTAIN;
 
+again:
 	dkey = &okqi->okqi_dkey;
 	akey = &okqi->okqi_akey;
 	d_iov_set(&okqo->okqo_akey, NULL, 0);
@@ -2779,6 +2837,29 @@ ds_obj_query_key_handler(crt_rpc_t *rpc)
 	rc = dtx_end(&dth, ioc.ioc_coc, rc);
 
 out:
+	if (rc == -DER_TX_BUSY && ++retry < 3) {
+		/* XXX: Currently, we commit the distributed transaction
+		 *	sychronously. Normally, it will be very quickly.
+		 *	So let's wait on the server for a while (30 ms),
+		 *	then retry. If related distributed transaction
+		 *	is still not committed after several cycles try,
+		 *	then replies '-DER_TX_BUSY' to the client.
+		 */
+		if (sleep_ult == NULL)
+			sleep_ult = dss_sleep_ult_create();
+
+		if (sleep_ult != NULL) {
+			D_DEBUG(DB_IO, "Query obj "DF_UOID
+				", hit non-committed DTX (%d)\n",
+				DP_UOID(okqi->okqi_oid), retry);
+			dss_ult_sleep(sleep_ult, 30000);
+			goto again;
+		}
+	}
+
+	if (sleep_ult != NULL)
+		dss_sleep_ult_destroy(sleep_ult);
+
 	obj_reply_set_status(rpc, rc);
 	obj_reply_map_version_set(rpc, ioc.ioc_map_ver);
 	okqo->okqo_epoch = epoch.oe_value;


### PR DESCRIPTION
If the modifications corsses multiple redundancy groups, then it
is possible that the sub modifications on the DTX leader are not
the same as the ones on non-leaders. Under such case, if someone
wants to read the data on some non-leader but hits non-committed
DTX, then asking the client to retry with leader maybe not help.

Instead, we can ask make the client to retry the read again (and
again) sometime later. We do sync commit the DTX with 'DTE_BLOCK'
flag. So it will not cause the client to retry read for too many
times unless such DTX hit some trouble (such as client or server
failure) that may cause current readers to be blocked until such
DTX has been handled by the new leader via DTX recovery.

On the other hand, be as the first step, since we commit the DTX
with sync mode, we can directly make the server side related ULT
to sleep for a short time when hit above cases instead of asking
the client to retry. If related DTX is still not committed after
several server side retries, then return -DER_TX_BUSY to client.

Signed-off-by: Fan Yong <fan.yong@intel.com>