### PR TITLE
DAOS-3800 dtx: optimize read with non-committed sync mod DTX (2)

### DIFF
--- a/src/dtx/dtx_common.c
+++ b/src/dtx/dtx_common.c
@@ -261,6 +261,8 @@ dtx_handle_init(struct dtx_id *dti, daos_handle_t coh, struct dtx_epoch *epoch,
 		int dti_cos_cnt, struct dtx_memberships *mbs, bool leader,
 		bool solo, struct dtx_handle *dth)
 {
+	bool is_ec = false;
+
 	if (sub_modification_cnt > DTX_SUB_MOD_MAX) {
 		D_ERROR("Too many modifications in a single transaction:"
 			"%u > %u\n", sub_modification_cnt, DTX_SUB_MOD_MAX);
@@ -285,18 +287,38 @@ dtx_handle_init(struct dtx_id *dti, daos_handle_t coh, struct dtx_epoch *epoch,
 	dth->dth_refs = 1;
 	dth->dth_mbs = mbs;
 
-	dth->dth_sync = 0;
 	dth->dth_resent = 0;
 	dth->dth_solo = solo ? 1 : 0;
 	dth->dth_modify_shared = 0;
 	dth->dth_active = 0;
 	dth->dth_touched_leader_oid = 0;
 	dth->dth_local_tx_started = 0;
+	dth->dth_local_retry = 0;
 
 	dth->dth_dti_cos = dti_cos;
 	dth->dth_dti_cos_count = dti_cos_cnt;
 	dth->dth_ent = NULL;
 	dth->dth_flags = leader ? DTE_LEADER : 0;
+
+	/* Set 'DTE_BLOCK' flag for EC object modification or
+	 * distributed transaction. At the same time, ask DTX
+	 * to 'sync' commit.
+	 */
+	if (daos_oclass_is_ec(leader_oid->id_pub, NULL))
+		is_ec = true;
+
+	if (is_ec || (mbs != NULL && mbs->dm_grp_cnt > 1)) {
+		dth->dth_flags |= DTE_BLOCK;
+		dth->dth_sync = 1;
+		D_WARN("Set BLOCK flags for DTX "DF_DTI" on obj (%s) "
+		       DF_UOID", grp_cnt %d\n",
+		       DP_DTI(dti), is_ec ? "EC" : "REP",
+		       DP_UOID(dth->dth_leader_oid),
+		       mbs != NULL ? mbs->dm_grp_cnt : 1);
+	} else {
+		dth->dth_sync = 0;
+	}
+
 	dth->dth_modification_cnt = sub_modification_cnt;
 
 	dth->dth_op_seq = 0;
@@ -638,13 +660,6 @@ again:
 
 			dth->dth_sync = 1;
 		}
-
-		/* FIXME: For the DTX across multiple modification groups,
-		 *	  commit it synchronously. That will be changed in
-		 *	  next phase.
-		 */
-		if (dth->dth_mbs->dm_grp_cnt > 1)
-			dth->dth_sync = 1;
 
 		/* For synchronous DTX, do not add it into CoS cache, otherwise,
 		 * we may have no way to remove it from the cache.

--- a/src/include/daos_errno.h
+++ b/src/include/daos_errno.h
@@ -170,7 +170,9 @@ extern "C" {
 	/** Data lost or not recoverable */				\
 	ACTION(DER_DATA_LOSS,		(DER_ERR_DAOS_BASE + 26))	\
 	/** Operation canceled (non-crt) */				\
-	ACTION(DER_OP_CANCELED,		(DER_ERR_DAOS_BASE + 27))
+	ACTION(DER_OP_CANCELED,		(DER_ERR_DAOS_BASE + 27))	\
+	/** TX is not committed, not sure whether committable or not */	\
+	ACTION(DER_TX_BUSY,		(DER_ERR_DAOS_BASE + 28))
 
 /** Defines the gurt error codes */
 #define D_FOREACH_ERR_RANGE(ACTION)	\

--- a/src/include/daos_srv/dtx_srv.h
+++ b/src/include/daos_srv/dtx_srv.h
@@ -74,7 +74,9 @@ struct dtx_handle {
 					 /* Leader oid is touched. */
 					 dth_touched_leader_oid:1,
 					 /* Local TX is started. */
-					 dth_local_tx_started:1;
+					 dth_local_tx_started:1,
+					 /* Retry with this server. */
+					 dth_local_retry:1;
 
 	/* The count the DTXs in the dth_dti_cos array. */
 	uint32_t			 dth_dti_cos_count;
@@ -231,6 +233,12 @@ dtx_entry_put(struct dtx_entry *dte)
 {
 	if (--(dte->dte_refs) == 0)
 		D_FREE(dte);
+}
+
+static inline bool
+dtx_is_valid_handle(struct dtx_handle *dth)
+{
+	return dth != NULL && !daos_is_zero_dti(&dth->dth_xid);
 }
 
 struct dtx_scan_args {

--- a/src/include/daos_srv/vos_types.h
+++ b/src/include/daos_srv/vos_types.h
@@ -51,6 +51,13 @@ enum dtx_entry_flags {
 	DTE_LEADER		= (1 << 0),
 	/* The DTX entry is invalid. */
 	DTE_INVALID		= (1 << 1),
+	/* If the DTX with this flag is non-committed, then others
+	 * will be blocked (retry again and again) when access the
+	 * data being modified via this DTX. Currently, it is used
+	 * for distributed transaction. It also can be used for EC
+	 * object modification via standalone update/punch.
+	 */
+	DTE_BLOCK		= (1 << 2),
 };
 
 struct dtx_entry {

--- a/src/object/cli_obj.c
+++ b/src/object/cli_obj.c
@@ -2720,7 +2720,8 @@ obj_comp_cb(tse_task_t *task, void *data)
 		 */
 
 		if ((!obj_auxi->spec_shard && !obj_auxi->no_retry) ||
-		    task->dt_result != -DER_INPROGRESS)
+		    (task->dt_result != -DER_INPROGRESS &&
+		     task->dt_result != -DER_TX_BUSY))
 			obj_auxi->io_retry = 1;
 
 		if (task->dt_result == -DER_CSUM) {
@@ -2738,6 +2739,7 @@ obj_comp_cb(tse_task_t *task, void *data)
 				obj_auxi->io_retry = 0;
 			}
 		}
+
 		if (!obj_auxi->spec_shard && task->dt_result == -DER_INPROGRESS)
 			obj_auxi->to_leader = 1;
 	}

--- a/src/object/cli_shard.c
+++ b/src/object/cli_shard.c
@@ -320,7 +320,7 @@ dc_rw_cb(tse_task_t *task, void *arg)
 	}
 
 	if (rc != 0) {
-		if (rc == -DER_INPROGRESS) {
+		if (rc == -DER_INPROGRESS || rc == -DER_TX_BUSY) {
 			D_DEBUG(DB_IO, "rpc %p opc %d to rank %d tag %d may "
 				"need retry: "DF_RC"\n", rw_args->rpc, opc,
 				rw_args->rpc->cr_ep.ep_rank,
@@ -1029,7 +1029,7 @@ dc_enumerate_cb(tse_task_t *task, void *arg)
 			D_DEBUG(DB_IO, "key size "DF_U64" too big.\n",
 				oeo->oeo_size);
 			enum_args->eaa_kds[0].kd_key_len = oeo->oeo_size;
-		} else if (rc == -DER_INPROGRESS) {
+		} else if (rc == -DER_INPROGRESS || rc == -DER_TX_BUSY) {
 			D_DEBUG(DB_TRACE, "rpc %p RPC %d may need retry: "
 				""DF_RC"\n", enum_args->rpc, opc, DP_RC(rc));
 		} else {
@@ -1328,7 +1328,7 @@ obj_shard_query_key_cb(tse_task_t *task, void *data)
 		if (rc == -DER_NONEXIST)
 			D_GOTO(out, rc = 0);
 
-		if (rc == -DER_INPROGRESS)
+		if (rc == -DER_INPROGRESS || rc == -DER_TX_BUSY)
 			D_DEBUG(DB_TRACE, "rpc %p RPC %d may need retry: %d\n",
 				cb_args->rpc, opc, rc);
 		else
@@ -1529,7 +1529,7 @@ obj_shard_sync_cb(tse_task_t *task, void *data)
 	if (rc == -DER_NONEXIST)
 		D_GOTO(out, rc = 0);
 
-	if (rc == -DER_INPROGRESS) {
+	if (rc == -DER_INPROGRESS || rc == -DER_TX_BUSY) {
 		D_DEBUG(DB_TRACE,
 			"rpc %p OBJ_SYNC_RPC may need retry: rc = "DF_RC"\n",
 			rpc, DP_RC(rc));

--- a/src/object/obj_internal.h
+++ b/src/object/obj_internal.h
@@ -421,7 +421,7 @@ obj_retry_error(int err)
 {
 	return err == -DER_TIMEDOUT || err == -DER_STALE ||
 	       err == -DER_INPROGRESS || err == -DER_GRPVER ||
-	       err == -DER_EVICTED || err == -DER_CSUM ||
+	       err == -DER_EVICTED || err == -DER_CSUM || err == -DER_TX_BUSY ||
 	       daos_crt_network_error(err);
 }
 

--- a/src/object/srv_obj.c
+++ b/src/object/srv_obj.c
@@ -1198,11 +1198,6 @@ obj_local_rw(crt_rpc_t *rpc, struct obj_io_context *ioc,
 
 	create_map = orw->orw_flags & ORF_CREATE_MAP;
 
-	if (daos_is_zero_dti(&orw->orw_dti)) {
-		D_DEBUG(DB_TRACE, "disable dtx\n");
-		dth = NULL;
-	}
-
 	iods = split_iods == NULL ? orw->orw_iod_array.oia_iods : split_iods;
 	offs = split_offs == NULL ? orw->orw_iod_array.oia_offs : split_offs;
 	iod_csums = split_csums == NULL ? orw->orw_iod_array.oia_iod_csums :
@@ -1817,6 +1812,7 @@ ds_obj_rw_handler(crt_rpc_t *rpc)
 	struct dtx_memberships		*mbs = NULL;
 	struct daos_shard_tgt		*tgts = NULL;
 	struct dtx_id			*dti_cos = NULL;
+	struct dss_sleep_ult		*sleep_ult = NULL;
 	int				dti_cos_cnt;
 	uint32_t			tgt_cnt;
 	uint32_t			version;
@@ -1849,6 +1845,7 @@ ds_obj_rw_handler(crt_rpc_t *rpc)
 
 	if (obj_rpc_is_fetch(rpc)) {
 		struct dtx_handle dth = {0};
+		int		  retry = 0;
 
 		if (orw->orw_flags & ORF_CSUM_REPORT) {
 			obj_log_csum_err();
@@ -1859,6 +1856,7 @@ ds_obj_rw_handler(crt_rpc_t *rpc)
 		epoch.oe_first = orw->orw_epoch_first;
 		epoch.oe_flags = orf_to_dtx_epoch_flags(orw->orw_flags);
 
+re_fetch:
 		rc = dtx_begin(ioc.ioc_coc, &orw->orw_dti, &epoch, 0,
 			       orw->orw_map_ver, &orw->orw_oid,
 			       NULL, 0, NULL, &dth);
@@ -1867,6 +1865,30 @@ ds_obj_rw_handler(crt_rpc_t *rpc)
 
 		rc = obj_local_rw(rpc, &ioc, NULL, NULL, NULL, &dth);
 		rc = dtx_end(&dth, ioc.ioc_coc, rc);
+
+		if (rc == -DER_INPROGRESS && dth.dth_local_retry) {
+			if (++retry > 3)
+				D_GOTO(out, rc = -DER_TX_BUSY);
+
+			/* XXX: Currently, we commit the distributed transaction
+			 *	sychronously. Normally, it will be very quickly.
+			 *	So let's wait on the server for a while (30 ms),
+			 *	then retry. If related distributed transaction
+			 *	is still not committed after several cycles try,
+			 *	then replies '-DER_TX_BUSY' to the client.
+			 */
+			if (sleep_ult == NULL) {
+				sleep_ult = dss_sleep_ult_create();
+				if (sleep_ult == NULL)
+					D_GOTO(out, rc = -DER_TX_BUSY);
+			}
+
+			D_WARN("Hit non-commit DTX when fetch "
+			       DF_UOID" (%d)\n", DP_UOID(orw->orw_oid), retry);
+			dss_ult_sleep(sleep_ult, 30000);
+
+			goto re_fetch;
+		}
 
 		D_GOTO(out, rc);
 	}
@@ -2010,6 +2032,9 @@ out:
 
 cleanup:
 	D_TIME_END(time_start, OBJ_PF_UPDATE);
+	if (sleep_ult != NULL)
+		dss_sleep_ult_destroy(sleep_ult);
+
 	obj_ec_split_req_fini(split_req);
 	D_FREE(mbs);
 	D_FREE(dti_cos);
@@ -2057,6 +2082,8 @@ obj_local_enum(struct obj_io_context *ioc, crt_rpc_t *rpc,
 {
 	vos_iter_param_t	param = { 0 };
 	struct obj_key_enum_in	*oei = crt_req_get(rpc);
+	struct dss_sleep_ult	*sleep_ult = NULL;
+	int			retry = 0;
 	int			opc = opc_get(rpc->cr_opc);
 	int			type;
 	int			rc;
@@ -2154,6 +2181,7 @@ obj_local_enum(struct obj_io_context *ioc, crt_rpc_t *rpc,
 		goto failed;
 	}
 
+again:
 	rc = dtx_begin(ioc->ioc_coc, &oei->oei_dti, &epoch, 0,
 		       oei->oei_map_ver, &oei->oei_oid, NULL, 0, NULL, &dth);
 	if (rc != 0)
@@ -2167,6 +2195,32 @@ obj_local_enum(struct obj_io_context *ioc, crt_rpc_t *rpc,
 	if (rc_tmp != 0)
 		rc = rc_tmp;
 
+	if (rc == -DER_INPROGRESS && dth.dth_local_retry) {
+		if (++retry > 3)
+			D_GOTO(out, rc = -DER_TX_BUSY);
+
+		/* XXX: Currently, we commit the distributed transaction
+		 *	sychronously. Normally, it will be very quickly.
+		 *	So let's wait on the server for a while (30 ms),
+		 *	then retry. If related distributed transaction
+		 *	is still not committed after several cycles try,
+		 *	then replies '-DER_TX_BUSY' to the client.
+		 */
+		if (sleep_ult == NULL) {
+			sleep_ult = dss_sleep_ult_create();
+			if (sleep_ult == NULL)
+				D_GOTO(out, rc = -DER_TX_BUSY);
+		}
+
+		D_WARN("Hit non-commit DTX when enum "DF_UOID" (%d)\n",
+		       DP_UOID(oei->oei_oid), retry);
+		dss_ult_sleep(sleep_ult, 30000);
+
+		/* re-enumeration from the last -DER_TX_BUSY. */
+		goto again;
+	}
+
+out:
 	if (type == VOS_ITER_SINGLE)
 		anchors->ia_ev = anchors->ia_sv;
 
@@ -2175,6 +2229,9 @@ obj_local_enum(struct obj_io_context *ioc, crt_rpc_t *rpc,
 		param.ip_epr.epr_hi, type, dss_get_module_info()->dmi_tgt_id,
 		rc);
 failed:
+	if (sleep_ult != NULL)
+		dss_sleep_ult_destroy(sleep_ult);
+
 	*e_out = epoch.oe_value;
 	return rc;
 }
@@ -2733,6 +2790,8 @@ ds_obj_query_key_handler(crt_rpc_t *rpc)
 	struct obj_io_context		 ioc;
 	struct dtx_handle		 dth = {0};
 	struct dtx_epoch		 epoch = {0};
+	struct dss_sleep_ult		*sleep_ult = NULL;
+	int				 retry = 0;
 	int				 rc;
 
 	okqi = crt_req_get(rpc);
@@ -2753,6 +2812,7 @@ ds_obj_query_key_handler(crt_rpc_t *rpc)
 	if (rc == PE_OK_LOCAL)
 		okqi->okqi_flags &= ~ORF_EPOCH_UNCERTAIN;
 
+again:
 	dkey = &okqi->okqi_dkey;
 	akey = &okqi->okqi_akey;
 	d_iov_set(&okqo->okqo_akey, NULL, 0);
@@ -2779,6 +2839,34 @@ ds_obj_query_key_handler(crt_rpc_t *rpc)
 	rc = dtx_end(&dth, ioc.ioc_coc, rc);
 
 out:
+	if (rc == -DER_INPROGRESS && dth.dth_local_retry) {
+		if (++retry > 3)
+			D_GOTO(failed, rc = -DER_TX_BUSY);
+
+		/* XXX: Currently, we commit the distributed transaction
+		 *	sychronously. Normally, it will be very quickly.
+		 *	So let's wait on the server for a while (30 ms),
+		 *	then retry. If related distributed transaction
+		 *	is still not committed after several cycles try,
+		 *	then replies '-DER_TX_BUSY' to the client.
+		 */
+		if (sleep_ult == NULL) {
+			sleep_ult = dss_sleep_ult_create();
+			if (sleep_ult == NULL)
+				D_GOTO(failed, rc = -DER_TX_BUSY);
+		}
+
+		D_WARN("Hit non-commit DTX when query "DF_UOID" (%d)\n",
+		       DP_UOID(okqi->okqi_oid), retry);
+		dss_ult_sleep(sleep_ult, 30000);
+
+		goto again;
+	}
+
+failed:
+	if (sleep_ult != NULL)
+		dss_sleep_ult_destroy(sleep_ult);
+
 	obj_reply_set_status(rpc, rc);
 	obj_reply_map_version_set(rpc, ioc.ioc_map_ver);
 	okqo->okqo_epoch = epoch.oe_value;

--- a/src/vos/tests/vts_dtx.c
+++ b/src/vos/tests/vts_dtx.c
@@ -74,6 +74,7 @@ vts_dtx_begin(const daos_unit_oid_t *oid, daos_handle_t coh, daos_epoch_t epoch,
 	dth->dth_resent = 0;
 	dth->dth_touched_leader_oid = 0;
 	dth->dth_local_tx_started = 0;
+	dth->dth_local_retry = 0;
 	dth->dth_solo = 0;
 	dth->dth_modify_shared = 0;
 	dth->dth_active = 0;

--- a/src/vos/vos_common.c
+++ b/src/vos/vos_common.c
@@ -169,7 +169,7 @@ vos_tx_begin(struct dtx_handle *dth, struct umem_instance *umm)
 {
 	int	rc;
 
-	if (dth == NULL)
+	if (!dtx_is_valid_handle(dth))
 		return umem_tx_begin(umm, vos_txd_get());
 
 	if (dth->dth_local_tx_started)
@@ -185,7 +185,7 @@ vos_tx_begin(struct dtx_handle *dth, struct umem_instance *umm)
 int
 vos_tx_end(struct dtx_handle *dth, struct umem_instance *umm, int err)
 {
-	if (dth == NULL)
+	if (!dtx_is_valid_handle(dth))
 		return umem_tx_end(umm, err);
 
 	if (!dth->dth_local_tx_started)

--- a/src/vos/vos_dtx.c
+++ b/src/vos/vos_dtx.c
@@ -108,10 +108,33 @@ dtx_set_aborted(uint32_t *tx_lid)
 }
 
 static inline int
-dtx_inprogress(struct vos_dtx_act_ent *dae, int pos)
+dtx_inprogress(struct vos_dtx_act_ent *dae, struct dtx_handle *dth,
+	       bool for_read)
 {
-	D_DEBUG(DB_IO, "Hit uncommitted DTX "DF_DTI" lid=%d at %d\n",
-		DP_DTI(&DAE_XID(dae)), DAE_LID(dae), pos);
+	/* If the modifications crosses multiple redundancy groups, then it
+	 * is possible that the sub modifications on the DTX leader are not
+	 * the same as the ones on non-leaders. Under such case, if someone
+	 * wants to read the data on some non-leader but hits non-committed
+	 * DTX, then asking the client to retry with leader maybe not help.
+	 * Instead, we can ask make the client to retry the read again (and
+	 * again) sometime later. We do sync commit the DTX with 'DTE_BLOCK'
+	 * flag. So it will not cause the client to retry read for too many
+	 * times unless such DTX hit some trouble (such as client or server
+	 * failure) that may cause current readers to be blocked until such
+	 * DTX has been handled by the new leader via DTX recovery.
+	 */
+	if (DAE_FLAGS(dae) & DTE_BLOCK && for_read && dth != NULL &&
+	    dth->dth_modification_cnt == 0) {
+		dth->dth_local_retry = 1;
+		D_WARN("Hit uncommitted DTX "DF_DTI" lid=%d, local retry\n",
+		       DP_DTI(&DAE_XID(dae)), DAE_LID(dae));
+	} else {
+		if (dth != NULL)
+			dth->dth_local_retry = 0;
+
+		D_DEBUG(DB_IO, "Hit uncommitted DTX "DF_DTI" lid=%d, remote "
+			"retry\n", DP_DTI(&DAE_XID(dae)), DAE_LID(dae));
+	}
 
 	return -DER_INPROGRESS;
 }
@@ -778,7 +801,7 @@ vos_dtx_commit_one(struct vos_container *cont, struct dtx_id *dti,
 	} else {
 		struct dtx_handle	*dth = vos_dth_get();
 
-		D_ASSERT(dth != NULL);
+		D_ASSERT(dtx_is_valid_handle(dth));
 
 		DCE_XID(dce) = *dti;
 		DCE_EPOCH(dce) = epoch;
@@ -1115,7 +1138,7 @@ vos_dtx_check_availability(struct umem_instance *umm, daos_handle_t coh,
 		return ALB_UNAVAILABLE;
 
 	/* The DTX owner can always see the DTX. */
-	if (dth != NULL && dth->dth_ent != NULL) {
+	if (dtx_is_valid_handle(dth) && dth->dth_ent != NULL) {
 		dae = dth->dth_ent;
 		if (DAE_LID(dae) == entry && DAE_EPOCH(dae) == epoch)
 			return ALB_AVAILABLE_CLEAN;
@@ -1156,7 +1179,7 @@ vos_dtx_check_availability(struct umem_instance *umm, daos_handle_t coh,
 			 * -DER_INPROGRESS, then the caller will retry
 			 * the RPC with leader replica.
 			 */
-			return dtx_inprogress(dae, 1);
+			return dtx_inprogress(dae, dth, true);
 		}
 
 		/* For leader, non-committed DTX is unavailable. */
@@ -1167,7 +1190,7 @@ vos_dtx_check_availability(struct umem_instance *umm, daos_handle_t coh,
 		  "Unexpected intent (1) %u\n", intent);
 
 	if (type == DTX_RT_ILOG) {
-		if (dth == NULL)
+		if (!dtx_is_valid_handle(dth))
 			/* XXX: For rebuild case, if some normal IO has
 			 *	generated related record by race before
 			 *	rebuild logic handling it. Then rebuild
@@ -1179,7 +1202,7 @@ vos_dtx_check_availability(struct umem_instance *umm, daos_handle_t coh,
 			 */
 			return ALB_UNAVAILABLE;
 
-		return dtx_inprogress(dae, 2);
+		return dtx_inprogress(dae, dth, false);
 	}
 
 	D_ASSERTF(intent == DAOS_INTENT_UPDATE,
@@ -1199,7 +1222,7 @@ vos_dtx_get(void)
 	struct dtx_handle	*dth = vos_dth_get();
 	struct vos_dtx_act_ent	*dae;
 
-	if (dth == NULL || dth->dth_ent == NULL)
+	if (!dtx_is_valid_handle(dth) || dth->dth_ent == NULL)
 		return DTX_LID_COMMITTED;
 
 	dae = dth->dth_ent;
@@ -1215,7 +1238,7 @@ vos_dtx_register_record(struct umem_instance *umm, umem_off_t record,
 	struct dtx_handle	*dth = vos_dth_get();
 	int			 rc = 0;
 
-	if (dth == NULL) {
+	if (!dtx_is_valid_handle(dth)) {
 		*tx_id = DTX_LID_COMMITTED;
 		return 0;
 	}
@@ -2174,7 +2197,7 @@ vos_dtx_cleanup(struct dtx_handle *dth)
 	d_iov_t			 kiov;
 	int			 rc;
 
-	if (dth == NULL || !dth->dth_active)
+	if (!dtx_is_valid_handle(dth) || !dth->dth_active)
 		return;
 
 	dth->dth_active = 0;

--- a/src/vos/vos_ilog.c
+++ b/src/vos/vos_ilog.c
@@ -71,7 +71,7 @@ vos_ilog_is_same_tx(struct umem_instance *umm, uint32_t tx_id,
 		 * transactional, treat it as the same transaction and let the
 		 * minor epoch handle any conflicts.
 		 */
-		if (dth == NULL)
+		if (!dtx_is_valid_handle(dth))
 			*same = true;
 	} else if (tx_id == dtx) {
 		*same = true;
@@ -386,9 +386,8 @@ update:
 		return rc;
 	}
 
-	rc = ilog_update(loh, &max_epr, epr->epr_hi,
-			 dth != NULL ? dth->dth_op_seq : VOS_MINOR_EPC_MAX,
-			 false);
+	rc = ilog_update(loh, &max_epr, epr->epr_hi, dtx_is_valid_handle(dth) ?
+			 dth->dth_op_seq : VOS_MINOR_EPC_MAX, false);
 
 	ilog_close(loh);
 

--- a/src/vos/vos_io.c
+++ b/src/vos/vos_io.c
@@ -495,7 +495,8 @@ vos_ioc_create(daos_handle_t coh, daos_unit_oid_t oid, bool read_only,
 		goto error;
 
 	rc = vos_ts_set_allocate(&ioc->ic_ts_set, cond_flags, iod_nr,
-				 dth ? &dth->dth_xid.dti_uuid : NULL);
+				 dtx_is_valid_handle(dth) ?
+				 &dth->dth_xid.dti_uuid : NULL);
 	if (rc != 0)
 		goto error;
 
@@ -1245,6 +1246,8 @@ vos_fetch_begin(daos_handle_t coh, daos_unit_oid_t oid, daos_epoch_t epoch,
 	if (rc != 0)
 		return rc;
 
+	vos_dth_set(dth);
+
 	if (!vos_ts_lookup(ioc->ic_ts_set, ioc->ic_cont->vc_ts_idx, false,
 			   &entry)) {
 		/** Re-cache the container timestamps */
@@ -1283,6 +1286,8 @@ vos_fetch_begin(daos_handle_t coh, daos_unit_oid_t oid, daos_epoch_t epoch,
 	*ioh = vos_ioc2ioh(ioc);
 
 out:
+	vos_dth_set(NULL);
+
 	update_ts_on_fetch(ioc, rc);
 
 	if (rc != 0) {
@@ -2046,7 +2051,7 @@ vos_update_end(daos_handle_t ioh, uint32_t pm_ver, daos_key_t *dkey, int err,
 	vos_dth_set(dth);
 
 	/* Commit the CoS DTXs via the IO PMDK transaction. */
-	if (dth != NULL && dth->dth_dti_cos_count > 0) {
+	if (dtx_is_valid_handle(dth) && dth->dth_dti_cos_count > 0) {
 		D_ALLOC_ARRAY(daes, dth->dth_dti_cos_count);
 		if (daes == NULL)
 			D_GOTO(abort, err = -DER_NOMEM);
@@ -2069,7 +2074,7 @@ vos_update_end(daos_handle_t ioh, uint32_t pm_ver, daos_key_t *dkey, int err,
 		ioc->ic_read_conflict = true;
 
 	/* Update tree index */
-	err = dkey_update(ioc, pm_ver, dkey, dth != NULL ?
+	err = dkey_update(ioc, pm_ver, dkey, dtx_is_valid_handle(dth) ?
 			  dth->dth_op_seq : VOS_MINOR_EPC_MAX);
 	if (err) {
 		VOS_TX_LOG_FAIL(err, "Failed to update tree index: "DF_RC"\n",
@@ -2085,7 +2090,7 @@ vos_update_end(daos_handle_t ioh, uint32_t pm_ver, daos_key_t *dkey, int err,
 		goto abort;
 	}
 
-	if (dth != NULL) {
+	if (dtx_is_valid_handle(dth)) {
 		struct dtx_rsrvd_uint	*dru;
 
 		dru = &dth->dth_rsrvds[dth->dth_rsrvd_cnt++];
@@ -2142,9 +2147,11 @@ vos_update_begin(daos_handle_t coh, daos_unit_oid_t oid, daos_epoch_t epoch,
 	int			 rc;
 
 	D_DEBUG(DB_TRACE, "Prepare IOC for "DF_UOID", iod_nr %d, epc "DF_X64
-		"\n", DP_UOID(oid), iod_nr, dth ? dth->dth_epoch :  epoch);
+		"\n", DP_UOID(oid), iod_nr,
+		dtx_is_valid_handle(dth) ? dth->dth_epoch :  epoch);
 
-	rc = vos_ioc_create(coh, oid, false, dth ? dth->dth_epoch : epoch,
+	rc = vos_ioc_create(coh, oid, false,
+			    dtx_is_valid_handle(dth) ? dth->dth_epoch : epoch,
 			    flags, iod_nr, iods, iods_csums, 0, NULL, dedup,
 			    dedup_th, dth, &ioc);
 	if (rc != 0)

--- a/src/vos/vos_iterator.c
+++ b/src/vos/vos_iterator.c
@@ -167,6 +167,7 @@ int
 vos_iter_prepare(vos_iter_type_t type, vos_iter_param_t *param,
 		 daos_handle_t *ih, struct dtx_handle *dth)
 {
+	struct dtx_handle	*saved = vos_dth_get();
 	struct vos_iter_dict	*dict;
 	struct vos_iterator	*iter;
 	int			 rc;
@@ -193,10 +194,15 @@ vos_iter_prepare(vos_iter_type_t type, vos_iter_param_t *param,
 		D_ERROR("Can't find iterator type %d\n", type);
 		return -DER_NOSYS;
 	}
+
+	vos_dth_set(dth);
+
 	if (!daos_handle_is_inval(param->ip_ih)) {
 		D_DEBUG(DB_TRACE, "Preparing nested iterator of type %s\n",
 			dict->id_name);
-		return nested_prepare(type, dict, param, ih);
+		rc = nested_prepare(type, dict, param, ih);
+
+		goto out;
 	}
 
 	D_DEBUG(DB_TRACE, "Preparing standalone iterator of type %s\n",
@@ -209,7 +215,8 @@ vos_iter_prepare(vos_iter_type_t type, vos_iter_param_t *param,
 		else
 			D_ERROR("Failed to prepare %s iterator: "DF_RC"\n",
 				dict->id_name, DP_RC(rc));
-		return rc;
+
+		goto out;
 	}
 
 	D_ASSERT(iter->it_type == type);
@@ -221,7 +228,10 @@ vos_iter_prepare(vos_iter_type_t type, vos_iter_param_t *param,
 	iter->it_from_parent	= 0;
 
 	*ih = vos_iter2hdl(iter);
-	return 0;
+
+out:
+	vos_dth_set(saved);
+	return rc;
 }
 
 /* Internal function to ensure parent iterator remains
@@ -535,6 +545,7 @@ vos_iterate(vos_iter_param_t *param, vos_iter_type_t type, bool recursive,
 	    vos_iter_cb_t post_cb, void *arg, struct dtx_handle *dth)
 {
 	daos_anchor_t		*anchor, *probe_anchor = NULL;
+	struct dtx_handle	*saved = vos_dth_get();
 	vos_iter_entry_t	iter_ent = {0};
 	daos_handle_t		ih;
 	unsigned int		acts = 0;
@@ -547,6 +558,8 @@ vos_iterate(vos_iter_param_t *param, vos_iter_type_t type, bool recursive,
 
 	anchor = type2anchor(type, anchors);
 
+	vos_dth_set(dth);
+
 	rc = vos_iter_prepare(type, param, &ih, dth);
 	if (rc != 0) {
 		if (rc == -DER_NONEXIST) {
@@ -556,6 +569,9 @@ vos_iterate(vos_iter_param_t *param, vos_iter_type_t type, bool recursive,
 			D_ERROR("failed to prepare iterator (type=%d): "
 				""DF_RC"\n", type, DP_RC(rc));
 		}
+
+		vos_dth_set(saved);
+
 		return rc;
 	}
 
@@ -668,5 +684,6 @@ out:
 			DP_RC(rc));
 
 	vos_iter_finish(ih);
+	vos_dth_set(saved);
 	return rc;
 }

--- a/src/vos/vos_obj_index.c
+++ b/src/vos/vos_obj_index.c
@@ -120,7 +120,7 @@ oi_rec_alloc(struct btr_instance *tins, d_iov_t *key_iov,
 	 * potential conflict with subsequent modifications against
 	 * the same object.
 	 */
-	if (dth != NULL)
+	if (dtx_is_valid_handle(dth))
 		dth->dth_sync = 1;
 
 	D_DEBUG(DB_TRACE, "alloc "DF_UOID" rec "DF_X64"\n",
@@ -282,8 +282,8 @@ do_log:
 	if (rc != 0)
 		return rc;
 
-	rc = ilog_update(loh, NULL, epoch, dth != NULL ? dth->dth_op_seq : 1,
-			 false);
+	rc = ilog_update(loh, NULL, epoch,
+			 dtx_is_valid_handle(dth) ? dth->dth_op_seq : 1, false);
 
 	ilog_close(loh);
 skip_log:

--- a/src/vos/vos_tree.c
+++ b/src/vos/vos_tree.c
@@ -439,7 +439,7 @@ svt_rec_store(struct btr_instance *tins, struct btr_record *rec,
 	/** at this point, it's assumed that enough was allocated for the irec
 	 *  to hold a checksum of length csum->cs_len
 	 */
-	if (dth != NULL && dth->dth_flags & DTE_LEADER &&
+	if (dtx_is_valid_handle(dth) && dth->dth_flags & DTE_LEADER &&
 	    irec->ir_ex_addr.ba_type == DAOS_MEDIA_SCM &&
 	    DAOS_FAIL_CHECK(DAOS_VC_DIFF_REC)) {
 		void	*addr;


### PR DESCRIPTION
If the modifications corsses multiple redundancy groups, then it
is possible that the sub modifications on the DTX leader are not
the same as the ones on non-leaders. Under such case, if someone
wants to read the data on some non-leader but hits non-committed
DTX, then asking the client to retry with leader maybe not help.

Instead, we can ask make the client to retry the read again (and
again) sometime later. We do sync commit the DTX with 'DTE_BLOCK'
flag. So it will not cause the client to retry read for too many
times unless such DTX hit some trouble (such as client or server
failure) that may cause current readers to be blocked until such
DTX has been handled by the new leader via DTX recovery.

On the other hand, be as the first step, since we commit the DTX
with sync mode, we can directly make the server side related ULT
to sleep for a short time when hit above cases instead of asking
the client to retry. If related DTX is still not committed after
several server side retries, then return -DER_TX_BUSY to client.

Currently, we will handle reading EC object similarly since the
DTX leader for EC modification (a parity node) may does not has
the data for client read.

Signed-off-by: Fan Yong <fan.yong@intel.com>