### PR TITLE
DAOS-5217 test: Switch all CI IOR tests to use the DFS driver instead of DAOS

### DIFF
--- a/src/tests/ftest/aggregation/aggregation_basic.yaml
+++ b/src/tests/ftest/aggregation/aggregation_basic.yaml
@@ -37,7 +37,7 @@ ior:
     daos_destroy: False
     iorflags:
         flags: "-v -w -W -r -R -k"
-    api: DAOS
+    api: DFS
     transfer_size: '1M'
     block_size: '8G'
     objectclass: !mux

--- a/src/tests/ftest/aggregation/aggregation_basic.yaml
+++ b/src/tests/ftest/aggregation/aggregation_basic.yaml
@@ -34,7 +34,7 @@ ior:
             np: 12
     test_file: daos:testFile
     repetitions: 1
-    daos_destroy: False
+    dfs_destroy: False
     iorflags:
         flags: "-v -w -W -r -R -k"
     api: DFS
@@ -42,6 +42,6 @@ ior:
     block_size: '8G'
     objectclass: !mux
         oclass_SX:
-            daos_oclass: "SX"
+            dfs_oclass: "SX"
         oclass_RP_2GX:
-            daos_oclass: "RP_2GX"
+            dfs_oclass: "RP_2GX"

--- a/src/tests/ftest/aggregation/aggregation_io_small.yaml
+++ b/src/tests/ftest/aggregation/aggregation_io_small.yaml
@@ -34,7 +34,7 @@ ior:
             np: 12
     test_file: daos:testFile
     repetitions: 1
-    daos_destroy: False
+    dfs_destroy: False
     iorflags:
         flags: "-v -w -W -k"
     api: DFS
@@ -42,4 +42,4 @@ ior:
     block_size: '256M'
     objectclass:
       oclass_SX:
-        daos_oclass: "SX"
+        dfs_oclass: "SX"

--- a/src/tests/ftest/aggregation/aggregation_io_small.yaml
+++ b/src/tests/ftest/aggregation/aggregation_io_small.yaml
@@ -37,7 +37,7 @@ ior:
     daos_destroy: False
     iorflags:
         flags: "-v -w -W -k"
-    api: DAOS
+    api: DFS
     transfer_size: '1K'
     block_size: '256M'
     objectclass:

--- a/src/tests/ftest/aggregation/aggregation_throttling.yaml
+++ b/src/tests/ftest/aggregation/aggregation_throttling.yaml
@@ -34,7 +34,7 @@ ior:
             np: 12
     test_file: daos:testFile
     repetitions: 1
-    daos_destroy: False
+    dfs_destroy: False
     iorflags:
         flags: "-v -w -W -r -R -k"
     api: DFS
@@ -42,4 +42,4 @@ ior:
     block_size: '512M'
     objectclass:
         oclass_SX:
-            daos_oclass: "SX"
+            dfs_oclass: "SX"

--- a/src/tests/ftest/aggregation/aggregation_throttling.yaml
+++ b/src/tests/ftest/aggregation/aggregation_throttling.yaml
@@ -37,7 +37,7 @@ ior:
     daos_destroy: False
     iorflags:
         flags: "-v -w -W -r -R -k"
-    api: DAOS
+    api: DFS
     transfer_size: '1K'
     block_size: '512M'
     objectclass:

--- a/src/tests/ftest/container/multiple_container_delete.yaml
+++ b/src/tests/ftest/container/multiple_container_delete.yaml
@@ -38,4 +38,4 @@ ior:
     api: DFS
     transfer_size: '1M'
     block_size: '1G'
-    daos_oclass: "SX"
+    dfs_oclass: "SX"

--- a/src/tests/ftest/control/dmg_pool_query_test.yaml
+++ b/src/tests/ftest/control/dmg_pool_query_test.yaml
@@ -36,7 +36,7 @@ ior:
   flags: "-k -w -r"
   transfer_size: "64M"
   block_size: "2G"
-  daos_destroy: False
+  dfs_destroy: False
 
 exp_vals:
   pool_info: ['8', '0', '0', '1']

--- a/src/tests/ftest/control/dmg_pool_query_test.yaml
+++ b/src/tests/ftest/control/dmg_pool_query_test.yaml
@@ -29,7 +29,9 @@ pool:
   scm_size: "16GB"
   nvme_size: "32GB"
   name: daos_server
-
+container:
+    type: POSIX
+    control_method: daos
 ior:
   flags: "-k -w -r"
   transfer_size: "64M"

--- a/src/tests/ftest/io/crash_ior.yaml
+++ b/src/tests/ftest/io/crash_ior.yaml
@@ -32,7 +32,7 @@ ior:
   api: "DFS"
   client_processes:
     np: 2
-  daos_destroy: False
+  dfs_destroy: False
   iorflags:
     sequential:
       flags: "-v -D 100 -w -r"
@@ -44,7 +44,7 @@ ior:
       block_size: '4G'
   objectclass:
     SX:
-      daos_oclass: "SX"
+      dfs_oclass: "SX"
   subprocess: True
 dfuse:
   mount_dir: "/tmp/daos_dfuse/"

--- a/src/tests/ftest/io/crash_ior.yaml
+++ b/src/tests/ftest/io/crash_ior.yaml
@@ -29,7 +29,7 @@ container:
   type: POSIX
   control_method: daos
 ior:
-  api: "DAOS"
+  api: "DFS"
   client_processes:
     np: 2
   daos_destroy: False

--- a/src/tests/ftest/io/io_aggregation.yaml
+++ b/src/tests/ftest/io/io_aggregation.yaml
@@ -35,7 +35,7 @@ ior:
   api: "DFS"
   client_processes:
     np: 1
-  daos_destroy: False
+  dfs_destroy: False
   iorflags:
       flags: "-w -E -k"
   repetitions: 1
@@ -45,4 +45,4 @@ ior:
       block_size: '104857600'  # 100M
   objectclass:
     SX:
-      daos_oclass: "SX"
+      dfs_oclass: "SX"

--- a/src/tests/ftest/io/io_aggregation.yaml
+++ b/src/tests/ftest/io/io_aggregation.yaml
@@ -32,7 +32,7 @@ container:
   type: POSIX
   control_method: daos
 ior:
-  api: "DAOS"
+  api: "DFS"
   client_processes:
     np: 1
   daos_destroy: False

--- a/src/tests/ftest/io/io_consistency.yaml
+++ b/src/tests/ftest/io/io_consistency.yaml
@@ -52,6 +52,6 @@ ior:
       block_size: '2G'
   objectclass:
     SX:
-      daos_oclass: "SX"
+      dfs_oclass: "SX"
 dfuse:
   mount_dir: "/tmp/daos_dfuse/"

--- a/src/tests/ftest/io/ior_intercept_basic.yaml
+++ b/src/tests/ftest/io/ior_intercept_basic.yaml
@@ -30,7 +30,7 @@ ior:
     test_file: daos:testFile
     repetitions: 1
 # Remove the below line once DAOS-3143 is resolved
-    daos_destroy: False
+    dfs_destroy: False
     iorflags:
         ssf:
           flags: "-v -D 300 -w -r"
@@ -49,6 +49,6 @@ ior:
               read_x: 2
           objectclass:
             oclass_SX:
-              daos_oclass: "SX"
+              dfs_oclass: "SX"
 dfuse:
     mount_dir: "/tmp/daos_dfuse"

--- a/src/tests/ftest/io/ior_intercept_dfuse_mix.yaml
+++ b/src/tests/ftest/io/ior_intercept_dfuse_mix.yaml
@@ -31,7 +31,7 @@ ior:
     test_file: daos:testFile
     repetitions: 1
 # Remove the below line once DAOS-3143 is resolved
-    daos_destroy: False
+    dfs_destroy: False
     iorflags:
         ssf:
           flags: "-k -D 300 -v -w -r"
@@ -40,6 +40,6 @@ ior:
           block_size: '8G'
           write_x: 1
           read_x: 1
-          daos_oclass: "SX"
+          dfs_oclass: "SX"
 dfuse:
     mount_dir: "/tmp/daos_dfuse"

--- a/src/tests/ftest/io/ior_intercept_multi_client.yaml
+++ b/src/tests/ftest/io/ior_intercept_multi_client.yaml
@@ -31,12 +31,12 @@ ior:
     test_file: daos:testFile
     repetitions: 1
 # Remove the below line once DAOS-3143 is resolved
-    daos_destroy: False
+    dfs_destroy: False
     iorflags:
         ssf:
           flags: "-k -v -D 300 -w -r"
           api: POSIX
-          daos_oclass: "SX"
+          dfs_oclass: "SX"
           transfersize_blocksize: !mux
             512B:
               transfer_size: '512B'

--- a/src/tests/ftest/io/ior_intercept_verify_data_integrity.yaml
+++ b/src/tests/ftest/io/ior_intercept_verify_data_integrity.yaml
@@ -41,12 +41,12 @@ ior:
     test_file: daos:testFile
     repetitions: 1
 # Remove the below line once DAOS-3143 is resolved
-    daos_destroy: False
+    dfs_destroy: False
     iorflags:
         api: POSIX
         transfer_size: '4K'
         block_size: '512M'
-        daos_oclass: "SX"
+        dfs_oclass: "SX"
         file_options: !mux
           ssf:
             flags: "-k -e -D 600 -v -w -W -r -R"

--- a/src/tests/ftest/io/ior_large.yaml
+++ b/src/tests/ftest/io/ior_large.yaml
@@ -64,7 +64,7 @@ ior:
       F: "-v -W -w -r -R -F"
   ior_api: !mux
     daos:
-      api: DAOS
+      api: DFS
     mpiio:
       api: MPIIO
     posix:

--- a/src/tests/ftest/io/ior_large.yaml
+++ b/src/tests/ftest/io/ior_large.yaml
@@ -92,8 +92,8 @@ ior:
       block_size: '64M'
   objectclass: !mux
     SX:
-      daos_oclass: "SX"
+      dfs_oclass: "SX"
     2-way_Replication:
-      daos_oclass: "RP_2GX"
+      dfs_oclass: "RP_2GX"
 dfuse:
     mount_dir: "/tmp/daos_dfuse"

--- a/src/tests/ftest/io/ior_small.py
+++ b/src/tests/ftest/io/ior_small.py
@@ -37,7 +37,7 @@ class IorSmall(IorTestBase):
 
         Test Description:
             Purpose of this test is to have small ior test to check basic
-            functionality for both DAOS and MPIIO api
+            functionality for both DFS and MPIIO api
 
         Use case:
             Run ior with read, write, CheckWrite, CheckRead in ssf mode.
@@ -58,7 +58,7 @@ class IorSmall(IorTestBase):
         # run tests for different variants
         self.ior_cmd.flags.update(flags[0])
         for oclass in obj_class:
-            self.ior_cmd.daos_oclass.update(oclass)
+            self.ior_cmd.dfs_oclass.update(oclass)
             for api in apis:
                 self.ior_cmd.api.update(api)
                 for test in transfer_block_size:
@@ -73,6 +73,6 @@ class IorSmall(IorTestBase):
         self.ior_cmd.api.update(apis[0])
         self.ior_cmd.block_size.update((transfer_block_size[1])[1])
         self.ior_cmd.transfer_size.update((transfer_block_size[1])[0])
-        self.ior_cmd.daos_oclass.update(obj_class[0])
+        self.ior_cmd.dfs_oclass.update(obj_class[0])
         # run ior
         self.run_ior_with_pool()

--- a/src/tests/ftest/io/ior_small.yaml
+++ b/src/tests/ftest/io/ior_small.yaml
@@ -49,7 +49,7 @@ ior:
             - "-v -W -w -r -R"
             - "-v -W -w -r -R -F"
           ior_api:
-            - DAOS
+            - DFS
             - MPIIO
             - POSIX
           transfer_block_size:

--- a/src/tests/ftest/io/ior_small.yaml
+++ b/src/tests/ftest/io/ior_small.yaml
@@ -43,7 +43,7 @@ ior:
             np: 16
     test_file: daos:testFile
     repetitions: 2
-    daos_destroy: False
+    dfs_destroy: False
     iorflags:
           ior_flags:
             - "-v -W -w -r -R"

--- a/src/tests/ftest/io/large_file_count.yaml
+++ b/src/tests/ftest/io/large_file_count.yaml
@@ -52,7 +52,7 @@ ior:
       block_size: '2G'
   objectclass:
     SX:
-      daos_oclass: "SX"
+      dfs_oclass: "SX"
 dfuse:
   mount_dir: "/tmp/daos_dfuse/"
 

--- a/src/tests/ftest/io/parallel_io.yaml
+++ b/src/tests/ftest/io/parallel_io.yaml
@@ -49,6 +49,6 @@ ior:
     block_size: '26214400'    # 25M
     objectclass:
         oclass_SX:
-          daos_oclass: "SX"
+          dfs_oclass: "SX"
 dfuse:
   mount_dir: "/tmp/daos_dfuse"

--- a/src/tests/ftest/io/seg_count.yaml
+++ b/src/tests/ftest/io/seg_count.yaml
@@ -42,7 +42,7 @@ ior:
             transfer_size: '4m'
     objectclass: !mux
         SX:
-            daos_oclass: "SX"
+            dfs_oclass: "SX"
         2-way_Replication:
-            daos_oclass: "RP_2GX"
+            dfs_oclass: "RP_2GX"
 

--- a/src/tests/ftest/nvme/nvme_fault.yaml
+++ b/src/tests/ftest/nvme/nvme_fault.yaml
@@ -54,7 +54,7 @@ ior:
   api: "DFS"
   client_processes:
     np: 16
-  daos_destroy: False
+  dfs_destroy: False
   iorflags:
       flags: "-w -F -r -R -k -G 1"
   test_file: daos:testFile
@@ -64,7 +64,7 @@ ior:
       transfer_size: 16777216 #16M
   objectclass:
     RP_2G1:
-      daos_oclass: "RP_2G1"
+      dfs_oclass: "RP_2G1"
 faulttests:
   pool_capacity:
     10_Percent:

--- a/src/tests/ftest/nvme/nvme_fault.yaml
+++ b/src/tests/ftest/nvme/nvme_fault.yaml
@@ -48,9 +48,10 @@ pool:
     scm_size: 53687091200 #50GB
     control_method: dmg
 container:
+    type: POSIX
     control_method: daos
 ior:
-  api: "DAOS"
+  api: "DFS"
   client_processes:
     np: 16
   daos_destroy: False

--- a/src/tests/ftest/nvme/nvme_fragmentation.py
+++ b/src/tests/ftest/nvme/nvme_fragmentation.py
@@ -64,7 +64,7 @@ class NvmeFragmentation(TestWithServers):
         self.ior_apis = self.params.get("ior_api", '/run/ior/iorflags/*')
         self.ior_transfer_size = self.params.get("transfer_block_size",
                                                  '/run/ior/iorflags/*')
-        self.ior_daos_oclass = self.params.get("obj_class",
+        self.ior_dfs_oclass = self.params.get("obj_class",
                                                '/run/ior/iorflags/*')
         # Recreate the client hostfile without slots defined
         self.hostfile_clients = write_host_file(
@@ -94,7 +94,7 @@ class NvmeFragmentation(TestWithServers):
             self.fail("Exiting Test: Mpich not installed")
 
         # Iterate through IOR different value and run in sequence
-        for oclass, api, test, flags in product(self.ior_daos_oclass,
+        for oclass, api, test, flags in product(self.ior_dfs_oclass,
                                                 self.ior_apis,
                                                 self.ior_transfer_size,
                                                 self.ior_flags):
@@ -102,7 +102,7 @@ class NvmeFragmentation(TestWithServers):
             ior_cmd = IorCommand()
             ior_cmd.get_params(self)
             ior_cmd.set_daos_params(self.server_group, self.pool)
-            ior_cmd.daos_oclass.update(oclass)
+            ior_cmd.dfs_oclass.update(oclass)
             ior_cmd.api.update(api)
             ior_cmd.transfer_size.update(test[0])
             ior_cmd.block_size.update(test[1])

--- a/src/tests/ftest/nvme/nvme_fragmentation.yaml
+++ b/src/tests/ftest/nvme/nvme_fragmentation.yaml
@@ -48,7 +48,7 @@ ior:
       slots: 2
     test_file: daos:testFile
     repetitions: 1
-    daos_destroy: False
+    dfs_destroy: False
     iorflags:
           ior_flags:
             - "-w -r -R -k -G 1"

--- a/src/tests/ftest/nvme/nvme_fragmentation.yaml
+++ b/src/tests/ftest/nvme/nvme_fragmentation.yaml
@@ -39,6 +39,9 @@ pool:
     nvme_size: 700000000000
     svcn: 1
     control_method: dmg
+container:
+    type: POSIX
+    control_method: daos
 ior:
     no_parallel_job: 10
     clientslots:
@@ -50,7 +53,7 @@ ior:
           ior_flags:
             - "-w -r -R -k -G 1"
           ior_api:
-            - DAOS
+            - DFS
           transfer_block_size:
             - [2048, 128M]
             - [256K, 128M]

--- a/src/tests/ftest/nvme/nvme_io.py
+++ b/src/tests/ftest/nvme/nvme_io.py
@@ -84,7 +84,7 @@ class NvmeIo(IorTestBase):
                 # Run ior with the parameters specified for this pass
                 self.ior_cmd.transfer_size.update(ior_param[2])
                 self.ior_cmd.block_size.update(ior_param[3])
-                self.ior_cmd.daos_oclass.update(obj_type)
+                self.ior_cmd.dfs_oclass.update(obj_type)
                 self.ior_cmd.set_daos_params(self.server_group, self.pool)
                 self.run_ior(self.get_ior_job_manager_command(), ior_param[4])
 

--- a/src/tests/ftest/nvme/nvme_io.yaml
+++ b/src/tests/ftest/nvme/nvme_io.yaml
@@ -38,7 +38,7 @@ ior:
   - "RP_3G1"
   - "RP_4GX"
   - "RP_4G1"
- daos_destroy: False
+ dfs_destroy: False
  ior_sequence:
 #   - [scmsize, nvmesize, stripesize, blocksize, clientslots]
     - [6000000000, 139586437120, 1048576, 17179869184, 1]        #[6G, 130G, 1M, 16G, 1]

--- a/src/tests/ftest/nvme/nvme_io_stats.yaml
+++ b/src/tests/ftest/nvme/nvme_io_stats.yaml
@@ -27,7 +27,7 @@ ior:
   api: "DFS"
   client_processes:
     np: 16
-  daos_destroy: False
+  dfs_destroy: False
   iorflags:
       flags: "-v -W -w -r -R"
   test_file: daos:testFile
@@ -36,4 +36,4 @@ ior:
   block_size: '1G'
   objectclass:
     SX:
-      daos_oclass: "SX"
+      dfs_oclass: "SX"

--- a/src/tests/ftest/nvme/nvme_io_stats.yaml
+++ b/src/tests/ftest/nvme/nvme_io_stats.yaml
@@ -20,8 +20,11 @@ pool:
     nvme_size: 107374182400 #100G
     svcn: 1
     control_method: dmg
+container:
+    type: POSIX
+    control_method: daos
 ior:
-  api: "DAOS"
+  api: "DFS"
   client_processes:
     np: 16
   daos_destroy: False

--- a/src/tests/ftest/nvme/nvme_io_verification.yaml
+++ b/src/tests/ftest/nvme/nvme_io_verification.yaml
@@ -33,7 +33,7 @@ ior:
  repetitions: 1
  api: DFS
  object_type: 'SX'
- daos_destroy: False
+ dfs_destroy: False
  transfersize: !mux
    case1:
      block_size: 30000000

--- a/src/tests/ftest/nvme/nvme_io_verification.yaml
+++ b/src/tests/ftest/nvme/nvme_io_verification.yaml
@@ -20,6 +20,9 @@ pool:
  name: daos_server
  svcn: 1
  control_method: dmg
+container:
+ type: POSIX
+ control_method: daos
 ior:
  client_processes:
    np: 16
@@ -28,7 +31,7 @@ ior:
    write: "-w -k -G=5"
    read: "-r -R -k -G=5"
  repetitions: 1
- api: DAOS
+ api: DFS
  object_type: 'SX'
  daos_destroy: False
  transfersize: !mux

--- a/src/tests/ftest/nvme/nvme_pool_capacity.py
+++ b/src/tests/ftest/nvme/nvme_pool_capacity.py
@@ -61,7 +61,7 @@ class NvmePoolCapacity(TestWithServers):
         self.ior_apis = self.params.get("ior_api", '/run/ior/iorflags/*')
         self.ior_test_sequence = self.params.get("ior_test_sequence",
                                                  '/run/ior/iorflags/*')
-        self.ior_daos_oclass = self.params.get("obj_class",
+        self.ior_dfs_oclass = self.params.get("obj_class",
                                                '/run/ior/iorflags/*')
         # Recreate the client hostfile without slots defined
         self.hostfile_clients = write_host_file(
@@ -92,7 +92,7 @@ class NvmePoolCapacity(TestWithServers):
         ior_cmd = IorCommand()
         ior_cmd.get_params(self)
         ior_cmd.set_daos_params(self.server_group, self.pool)
-        ior_cmd.daos_oclass.update(oclass)
+        ior_cmd.dfs_oclass.update(oclass)
         ior_cmd.api.update(api)
         ior_cmd.transfer_size.update(test[2])
         ior_cmd.block_size.update(test[3])
@@ -184,7 +184,7 @@ class NvmePoolCapacity(TestWithServers):
         pool = {}
 
         # Iterate through IOR different ior test sequence
-        for oclass, api, test, flags in product(self.ior_daos_oclass,
+        for oclass, api, test, flags in product(self.ior_dfs_oclass,
                                                 self.ior_apis,
                                                 self.ior_test_sequence,
                                                 self.ior_flags):

--- a/src/tests/ftest/nvme/nvme_pool_capacity.yaml
+++ b/src/tests/ftest/nvme/nvme_pool_capacity.yaml
@@ -30,7 +30,7 @@ ior:
       slots: 2
     test_file: daos:testFile
     repetitions: 1
-    daos_destroy: False
+    dfs_destroy: False
     iorflags:
           ior_flags:
             - "-w -r -R -k -G 1"

--- a/src/tests/ftest/nvme/nvme_pool_capacity.yaml
+++ b/src/tests/ftest/nvme/nvme_pool_capacity.yaml
@@ -21,6 +21,9 @@ pool:
     name: daos_server
     svcn: 1
     control_method: dmg
+container:
+    type: POSIX
+    control_method: daos
 ior:
     no_parallel_job: 10
     clientslots:
@@ -32,7 +35,7 @@ ior:
           ior_flags:
             - "-w -r -R -k -G 1"
           ior_api:
-            - DAOS
+            - DFS
           obj_class:
             - "SX"
     ior_test_sequence:

--- a/src/tests/ftest/osa/osa_online_drain.py
+++ b/src/tests/ftest/osa/osa_online_drain.py
@@ -60,7 +60,7 @@ class OSAOnlineDrain(TestWithServers):
         self.ior_apis = self.params.get("ior_api", '/run/ior/iorflags/*')
         self.ior_test_sequence = self.params.get("ior_test_sequence",
                                                  '/run/ior/iorflags/*')
-        self.ior_daos_oclass = self.params.get("obj_class",
+        self.ior_dfs_oclass = self.params.get("obj_class",
                                                '/run/ior/iorflags/*')
         # Recreate the client hostfile without slots defined
         self.hostfile_clients = write_host_file(
@@ -110,7 +110,7 @@ class OSAOnlineDrain(TestWithServers):
         ior_cmd = IorCommand()
         ior_cmd.get_params(self)
         ior_cmd.set_daos_params(self.server_group, self.pool)
-        ior_cmd.daos_oclass.update(oclass)
+        ior_cmd.dfs_oclass.update(oclass)
         ior_cmd.api.update(api)
         ior_cmd.transfer_size.update(test[2])
         ior_cmd.block_size.update(test[3])
@@ -173,7 +173,7 @@ class OSAOnlineDrain(TestWithServers):
 
         # Drain the pool_uuid, rank and targets
         for val in range(0, num_pool):
-            for oclass, api, test, flags in product(self.ior_daos_oclass,
+            for oclass, api, test, flags in product(self.ior_dfs_oclass,
                                                     self.ior_apis,
                                                     self.ior_test_sequence,
                                                     self.ior_flags):

--- a/src/tests/ftest/osa/osa_online_drain.yaml
+++ b/src/tests/ftest/osa/osa_online_drain.yaml
@@ -25,8 +25,9 @@ pool:
     svcn: 4
     control_method: dmg
 container:
-  properties:
-    enable_checksum: True
+    type: POSIX
+    control_method: daos
+    properties: cksum:crc16,cksum_size:16384,srv_cksum:on
 ior:
     no_parallel_job: 5
     clientslots:
@@ -38,7 +39,7 @@ ior:
       ior_flags:
         - "-w -r -R -k -G 1"
       ior_api:
-        - DAOS
+        - DFS
       obj_class:
         - "RP_2GX"
     ior_test_sequence:

--- a/src/tests/ftest/osa/osa_online_drain.yaml
+++ b/src/tests/ftest/osa/osa_online_drain.yaml
@@ -34,7 +34,7 @@ ior:
       slots: 2
     test_file: daos:testFile
     repetitions: 1
-    daos_destroy: False
+    dfs_destroy: False
     iorflags:
       ior_flags:
         - "-w -r -R -k -G 1"

--- a/src/tests/ftest/osa/osa_online_reintegration.py
+++ b/src/tests/ftest/osa/osa_online_reintegration.py
@@ -63,7 +63,7 @@ class OSAOnlineReintegration(TestWithServers):
         self.ior_apis = self.params.get("ior_api", '/run/ior/iorflags/*')
         self.ior_test_sequence = self.params.get("ior_test_sequence",
                                                  '/run/ior/iorflags/*')
-        self.ior_daos_oclass = self.params.get("obj_class",
+        self.ior_dfs_oclass = self.params.get("obj_class",
                                                '/run/ior/iorflags/*')
         # Recreate the client hostfile without slots defined
         self.hostfile_clients = write_host_file(
@@ -115,7 +115,7 @@ class OSAOnlineReintegration(TestWithServers):
         ior_cmd = IorCommand()
         ior_cmd.get_params(self)
         ior_cmd.set_daos_params(self.server_group, self.pool)
-        ior_cmd.daos_oclass.update(oclass)
+        ior_cmd.dfs_oclass.update(oclass)
         ior_cmd.api.update(api)
         ior_cmd.transfer_size.update(test[2])
         ior_cmd.block_size.update(test[3])
@@ -180,7 +180,7 @@ class OSAOnlineReintegration(TestWithServers):
 
         # Exclude and reintegrate the pool_uuid, rank and targets
         for val in range(0, num_pool):
-            for oclass, api, test, flags in product(self.ior_daos_oclass,
+            for oclass, api, test, flags in product(self.ior_dfs_oclass,
                                                     self.ior_apis,
                                                     self.ior_test_sequence,
                                                     self.ior_flags):

--- a/src/tests/ftest/osa/osa_online_reintegration.yaml
+++ b/src/tests/ftest/osa/osa_online_reintegration.yaml
@@ -32,7 +32,7 @@ ior:
     slots: 2
   test_file: daos:testFile
   repetitions: 1
-  daos_destroy: False
+  dfs_destroy: False
   iorflags:
     ior_flags:
       - "-w -r -R -k -G 1"

--- a/src/tests/ftest/osa/osa_online_reintegration.yaml
+++ b/src/tests/ftest/osa/osa_online_reintegration.yaml
@@ -23,8 +23,9 @@ pool:
   svcn: 4
   control_method: dmg
 container:
-  properties:
-    enable_checksum: True
+    type: POSIX
+    control_method: daos
+    properties: cksum:crc16,cksum_size:16384,srv_cksum:on
 ior:
   no_parallel_job: 10
   clientslots:
@@ -36,7 +37,7 @@ ior:
     ior_flags:
       - "-w -r -R -k -G 1"
     ior_api:
-      - DAOS
+      - DFS
     obj_class:
       - "RP_2G1"
   ior_test_sequence:

--- a/src/tests/ftest/pool/rebuild_with_ior.yaml
+++ b/src/tests/ftest/pool/rebuild_with_ior.yaml
@@ -33,7 +33,7 @@ ior:
             np: 8
     repetitions: 1
     api: MPIIO
-    daos_oclass: "RP_2GX"
+    dfs_oclass: "RP_2GX"
     iorflags:
         write:
           F: "-w -W -k -G 1"

--- a/src/tests/ftest/rebuild/container_create.py
+++ b/src/tests/ftest/rebuild/container_create.py
@@ -212,7 +212,7 @@ class ContainerCreate(TestWithServers):
             # Create a container with 1GB of data in the first pool
             if use_ior:
                 mpirun.job.flags.update("-v -w -W -G 1 -k", "ior.flags")
-                mpirun.job.daos_destroy.update(False, "ior.daos_destroy")
+                mpirun.job.dfs_destroy.update(False, "ior.dfs_destroy")
                 mpirun.job.set_daos_params(self.server_group, self.pool[0])
                 self.log.info(
                     "%s: Running IOR on pool %s to fill container %s with data",
@@ -278,7 +278,7 @@ class ContainerCreate(TestWithServers):
                     "%s: Running IOR on pool %s to verify container %s",
                     loop_id, self.pool[0].uuid, mpirun.job.daos_cont.value)
                 mpirun.job.flags.update("-v -r -R -G 1 -E", "ior.flags")
-                mpirun.job.daos_destroy.update(True, "ior.daos_destroy")
+                mpirun.job.dfs_destroy.update(True, "ior.dfs_destroy")
                 self.run_ior(loop_id, mpirun)
             else:
                 self.log.info(

--- a/src/tests/ftest/rebuild/container_create.yaml
+++ b/src/tests/ftest/rebuild/container_create.yaml
@@ -17,13 +17,15 @@ pool:
   svcn: 3
   control_method: dmg
 container:
+  type: POSIX
+  control_method: daos
   object_qty: 1
   record_qty: 1
   akey_size: 4
   dkey_size: 4
   data_size: 64
 ior:
-  api: DAOS
+  api: DFS
   block_size: 16m
   segment_count: 16
   transfer_size: 16m

--- a/src/tests/ftest/rebuild/container_create.yaml
+++ b/src/tests/ftest/rebuild/container_create.yaml
@@ -29,7 +29,7 @@ ior:
   block_size: 16m
   segment_count: 16
   transfer_size: 16m
-  daos_oclass: RP_3GX
+  dfs_oclass: RP_3GX
 test:
   loop_quantity: !mux
     one_loop:

--- a/src/tests/ftest/server/metadata.yaml
+++ b/src/tests/ftest/server/metadata.yaml
@@ -61,10 +61,10 @@ ior:
     clientslots:
       slots: 1
     repetitions: 1
-    daos_destroy: False
+    dfs_destroy: False
     iorwriteflags:
       F: "-w -W -k -G 1"
     iorreadflags:
       F: "-r -R -G 1"
     objectclass:
-      daos_oclass: "SX"
+      dfs_oclass: "SX"

--- a/src/tests/ftest/soak/soak.py
+++ b/src/tests/ftest/soak/soak.py
@@ -471,10 +471,10 @@ class SoakTestBase(TestWithServers):
         api_list = self.params.get("api", ior_params + "*")
         tsize_list = self.params.get("transfer_size", ior_params + "*")
         bsize_list = self.params.get("block_size", ior_params + "*")
-        oclass_list = self.params.get("daos_oclass", ior_params + "*")
-        # check if capable of doing rebuild; if yes then daos_oclass = RP_*GX
+        oclass_list = self.params.get("dfs_oclass", ior_params + "*")
+        # check if capable of doing rebuild; if yes then dfs_oclass = RP_*GX
         if self.is_harasser("rebuild"):
-            oclass_list = self.params.get("daos_oclass", "/run/rebuild/*")
+            oclass_list = self.params.get("dfs_oclass", "/run/rebuild/*")
         # update IOR cmdline for each additional IOR obj
         for api in api_list:
             for b_size in bsize_list:
@@ -492,7 +492,7 @@ class SoakTestBase(TestWithServers):
                         ior_cmd.api.update(api)
                         ior_cmd.block_size.update(b_size)
                         ior_cmd.transfer_size.update(t_size)
-                        ior_cmd.daos_oclass.update(o_type)
+                        ior_cmd.dfs_oclass.update(o_type)
                         ior_cmd.set_daos_params(self.server_group, pool)
                         # srun cmdline
                         nprocs = nodesperjob * ppn
@@ -924,7 +924,7 @@ class SoakTestBase(TestWithServers):
         rank = self.params.get("rank", "/run/container_reserved/*")
         if self.is_harasser("rebuild"):
             obj_class = "_".join(["OC", str(
-                self.params.get("daos_oclass", "/run/rebuild/*")[0])])
+                self.params.get("dfs_oclass", "/run/rebuild/*")[0])])
         else:
             obj_class = self.params.get(
                 "object_class", "/run/container_reserved/*")

--- a/src/tests/ftest/soak/soak_faults.yaml
+++ b/src/tests/ftest/soak/soak_faults.yaml
@@ -127,7 +127,7 @@ ior_faults:
         - '128k'
         - '1m'
     segment_count: 1
-    daos_oclass:
+    dfs_oclass:
         - 'SX'
 
 

--- a/src/tests/ftest/soak/soak_faults.yaml
+++ b/src/tests/ftest/soak/soak_faults.yaml
@@ -53,6 +53,9 @@ pool_reserved:
     scm_size: 3000000000
     nvme_size: 50000000000
     control_method: dmg
+container:
+    type: POSIX
+    control_method: daos
 container_reserved:
     akey_size: 5
     dkey_size: 5
@@ -108,11 +111,11 @@ soak_faults:
         - ior_faults
 # Commandline parameters
 # Benchmark and application params
-# IOR params -a DAOS and -a MPIIO
+# IOR params -a DFS and -a MPIIO
 # sequential
 ior_faults:
     api:
-        - DAOS
+        - DFS
         - MPIIO
     test_file: daos:testFile
     flags: -v -w -W -r -R

--- a/src/tests/ftest/soak/soak_harassers.yaml
+++ b/src/tests/ftest/soak/soak_harassers.yaml
@@ -114,14 +114,14 @@ ior_harasser:
         - '128k'
         - '1m'
     segment_count: 1
-    daos_oclass:
+    dfs_oclass:
         - 'SX'
 rebuild:
     rebuild_timeout: 30
     ranks_to_kill:
         - 2
     svcl: 1
-    daos_oclass:
+    dfs_oclass:
         - "RP_2GX"
 dmg_create_destroy:
     size:

--- a/src/tests/ftest/soak/soak_harassers.yaml
+++ b/src/tests/ftest/soak/soak_harassers.yaml
@@ -54,6 +54,9 @@ pool_reserved:
     scm_size: 3000000000
     nvme_size: 50000000000
     control_method: dmg
+container:
+    type: POSIX
+    control_method: daos
 container_reserved:
     akey_size: 5
     dkey_size: 5
@@ -95,11 +98,11 @@ soak_harassers:
         #- rebuild
 # Commandline parameters
 # Benchmark and application params
-# IOR params -a DAOS and -a MPIIO
+# IOR params -a DFS and -a MPIIO
 # sequential
 ior_harasser:
     api:
-        - DAOS
+        - DFS
         - MPIIO
     test_file: daos:testFile
     flags: -v -w -W -r -R

--- a/src/tests/ftest/soak/soak_smoke.yaml
+++ b/src/tests/ftest/soak/soak_smoke.yaml
@@ -119,7 +119,7 @@ ior_smoke:
         - '128k'
         - '1m'
     segment_count: 1
-    daos_oclass:
+    dfs_oclass:
         - 'SX'
 fio_smoke:
   names:

--- a/src/tests/ftest/soak/soak_smoke.yaml
+++ b/src/tests/ftest/soak/soak_smoke.yaml
@@ -61,6 +61,9 @@ pool_reserved:
     scm_size: 3000000000
     nvme_size: 50000000000
     control_method: dmg
+container:
+    type: POSIX
+    control_method: daos
 container_reserved:
     akey_size: 5
     dkey_size: 5
@@ -100,11 +103,11 @@ smoke:
         - fio_smoke
 # Commandline parameters
 # Benchmark and application params
-# IOR params -a DAOS and -a MPIIO
+# IOR params -a DFS and -a MPIIO
 # sequential
 ior_smoke:
     api:
-        - DAOS
+        - DFS
         - MPIIO
     test_file: daos:testFile
     flags: -v -w -W -r -R

--- a/src/tests/ftest/soak/soak_stress_2h.yaml
+++ b/src/tests/ftest/soak/soak_stress_2h.yaml
@@ -124,7 +124,7 @@ ior_stress:
         - '1m'
         - '512K'
         - '64k'
-    daos_oclass:
+    dfs_oclass:
         - "SX"
 fio_stress:
   names:

--- a/src/tests/ftest/soak/soak_stress_2h.yaml
+++ b/src/tests/ftest/soak/soak_stress_2h.yaml
@@ -61,6 +61,9 @@ pool_reserved:
     scm_size: 3000000000
     nvme_size: 50000000000
     control_method: dmg
+container:
+    type: POSIX
+    control_method: daos
 container_reserved:
     akey_size: 5
     dkey_size: 5
@@ -102,11 +105,11 @@ soak_stress:
         - fio_stress
 # Commandline parameters
 # Benchmark and application params
-# IOR params -a DAOS and -a MPIIO
+# IOR params -a DFS and -a MPIIO
 # sequential
 ior_stress:
     api:
-        - DAOS
+        - DFS
         - MPIIO
     test_file: daos:testFile
     flags: -v -w -W -r -R

--- a/src/tests/ftest/soak/soak_stress_48h.yaml
+++ b/src/tests/ftest/soak/soak_stress_48h.yaml
@@ -128,7 +128,7 @@ ior_stress:
         - '1m'
         - '512K'
         - '64k'
-    daos_oclass:
+    dfs_oclass:
         - "SX"
 fio_stress:
   names:

--- a/src/tests/ftest/soak/soak_stress_48h.yaml
+++ b/src/tests/ftest/soak/soak_stress_48h.yaml
@@ -63,6 +63,9 @@ pool_reserved:
     scm_size: 3000000000
     nvme_size: 50000000000
     control_method: dmg
+container:
+    type: POSIX
+    control_method: daos
 container_reserved:
     akey_size: 5
     dkey_size: 5
@@ -106,11 +109,11 @@ soak_stress:
         - fio_stress
 # Commandline parameters
 # Benchmark and application params
-# IOR params -a DAOS and -a MPIIO
+# IOR params -a DFS and -a MPIIO
 # sequential
 ior_stress:
     api:
-        - DAOS
+        - DFS
         - MPIIO
     test_file: daos:testFile
     flags: -v -w -W -r -R

--- a/src/tests/ftest/util/ior_test_base.py
+++ b/src/tests/ftest/util/ior_test_base.py
@@ -190,8 +190,8 @@ class IorTestBase(TestWithServers):
             str: the path for the mpi job manager command
 
         """
-        # Initialize MpioUtils if IOR is running in MPIIO or DAOS mode
-        if self.ior_cmd.api.value in ["MPIIO", "DAOS", "POSIX", "DFS"]:
+        # Initialize MpioUtils if IOR is running in MPIIO or DFS mode
+        if self.ior_cmd.api.value in ["MPIIO", "POSIX", "DFS"]:
             mpio_util = MpioUtils()
             if mpio_util.mpich_installed(self.hostlist_clients) is False:
                 self.fail("Exiting Test: Mpich not installed")

--- a/src/tests/ftest/util/mdtest_utils.py
+++ b/src/tests/ftest/util/mdtest_utils.py
@@ -84,29 +84,6 @@ class MdtestCommand(ExecutableCommand):
         self.stonewall_statusfile = FormattedParameter("-x {}")
         self.depth = FormattedParameter("-z {}")
 
-        # Module DAOS (Not intended to be used as of now, hence all
-        # arguments for DAOS module are commented)
-        # Required arguments
-        #  --daos.pool=STRING            pool uuid
-        #  --daos.svcl=STRING            pool SVCL
-        #  --daos.cont=STRING            container uuid
-
-        # Flags
-        #  --daos.destroy                Destroy Container
-
-        # Optional arguments
-        #  --daos.group=STRING           server group
-        #  --daos.chunk_size=1048576     chunk size
-        #  --daos.oclass=STRING          object class
-
-        # self.daos_pool_uuid = FormattedParameter("--daos.pool {}")
-        # self.daos_svcl = FormattedParameter("--daos.svcl {}")
-        # self.daos_cont = FormattedParameter("--daos.cont {}")
-        # self.daos_group = FormattedParameter("--daos.group {}")
-        # self.daos_chunk_size = FormattedParameter(" --daos.chunk_size {}")
-        # self.daos_oclass = FormattedParameter("--daos.oclass {}")
-        # self.daos_destroy = FormattedParameter("--daos.destroy", True)
-
         # Module DFS
         # Required arguments
         #  --dfs.pool=STRING             DAOS pool uuid

--- a/src/tests/ftest/util/nvme_utils.py
+++ b/src/tests/ftest/util/nvme_utils.py
@@ -231,11 +231,11 @@ class ServerFillUp(IorTestBase):
             _create_cont = False
             self.ior_cmd.flags.value = self.ior_read_flags
             self.ior_cmd.daos_cont.value = self.container_info[
-                "{}{}{}".format(self.ior_cmd.daos_oclass.value,
+                "{}{}{}".format(self.ior_cmd.dfs_oclass.value,
                                 self.ior_cmd.api.value,
                                 self.ior_cmd.transfer_size.value)][0]
             self.ior_cmd.block_size.value = self.container_info[
-                "{}{}{}".format(self.ior_cmd.daos_oclass.value,
+                "{}{}{}".format(self.ior_cmd.dfs_oclass.value,
                                 self.ior_cmd.api.value,
                                 self.ior_cmd.transfer_size.value)][1]
         #For IOR Other operation, calculate the block size based on server %
@@ -252,7 +252,7 @@ class ServerFillUp(IorTestBase):
             results.put("FAIL")
 
         self.container_info["{}{}{}"
-                            .format(self.ior_cmd.daos_oclass.value,
+                            .format(self.ior_cmd.dfs_oclass.value,
                                     self.ior_cmd.api.value,
                                     self.ior_cmd.transfer_size.value)] = [
                                         self.ior_cmd.daos_cont.value,
@@ -266,7 +266,7 @@ class ServerFillUp(IorTestBase):
             block_size(int): IOR Block size
         """
         #Check the replica for IOR object to calculate the correct block size.
-        _replica = re.findall(r'_(.+?)G', self.ior_cmd.daos_oclass.value)
+        _replica = re.findall(r'_(.+?)G', self.ior_cmd.dfs_oclass.value)
         if not _replica:
             replica_server = 1
         #This is for EC Parity


### PR DESCRIPTION
- DAOS driver is deprecated and will be removed soon.

Signed-off-by: Mohamad Chaarawi <mohamad.chaarawi@intel.com>