### PR TITLE
DAOS-4587 test: Add dmg_pool helpers to libdaos_tests

### DIFF
--- a/src/common/SConscript
+++ b/src/common/SConscript
@@ -33,10 +33,11 @@ def scons():
     denv.Install('$PREFIX/lib64/', common)
 
     tenv = denv.Clone()
+    tenv.AppendUnique(LIBS=['json-c'])
 
     prereqs.require(tenv, 'argobots')
 
-    tests_lib_src = ['tests_lib.c']
+    tests_lib_src = ['tests_lib.c', 'tests_dmg_helpers.c']
     tests_lib = daos_build.library(tenv, 'libdaos_tests', tests_lib_src)
     tenv.Install('$PREFIX/lib64/', tests_lib)
 

--- a/src/common/tests_dmg_helpers.c
+++ b/src/common/tests_dmg_helpers.c
@@ -1,0 +1,503 @@
+/**
+ * (C) Copyright 2020 Intel Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * GOVERNMENT LICENSE RIGHTS-OPEN SOURCE SOFTWARE
+ * The Government's rights to use, modify, reproduce, release, perform, display,
+ * or disclose this software are subject to the terms of the Apache License as
+ * provided in Contract No. B609815.
+ * Any reproduction of computer software, computer software documentation, or
+ * portions thereof marked with this legend must also reproduce the markings.
+ */
+
+#include <pwd.h>
+#include <grp.h>
+#include <linux/limits.h>
+#include <json-c/json.h>
+
+#include <daos/common.h>
+#include <daos.h>
+
+static void
+cmd_free_args(char **args, int argcount)
+{
+	int i;
+
+	for (i = 0; i < argcount; i++) {
+		D_FREE(args[i]);
+	}
+
+	if (argcount)
+		D_FREE(args);
+}
+
+static char **
+cmd_push_arg(char *args[], int *argcount, const char *fmt, ...)
+{
+	char		**tmp = NULL;
+	char		*arg = NULL;
+	va_list		ap;
+	int		rc;
+
+	va_start(ap, fmt);
+	rc = vasprintf(&arg, fmt, ap);
+	if (arg == NULL || rc < 0) {
+		D_ERROR("failed to create arg\n");
+		cmd_free_args(args, *argcount);
+		return NULL;
+	}
+	va_end(ap);
+
+	D_REALLOC(tmp, args, sizeof(char *) * (*argcount + 1));
+	if (tmp == NULL) {
+		D_ERROR("realloc failed\n");
+		D_FREE(arg);
+		cmd_free_args(args, *argcount);
+		return NULL;
+	}
+
+	tmp[*argcount] = arg;
+	(*argcount)++;
+
+	return tmp;
+}
+
+static char *
+cmd_string(const char *cmd_base, char *args[], int argcount)
+{
+	char		*tmp = NULL;
+	char		*cmd_str = NULL;
+	size_t		size;
+	int		i;
+
+	if (cmd_base == NULL)
+		return NULL;
+
+	size = strnlen(cmd_base, ARG_MAX - 1) + 1;
+	D_STRNDUP(cmd_str, cmd_base, size);
+	if (cmd_str == NULL)
+		return NULL;
+
+	for (i = 0; i < argcount; i++) {
+		size += strnlen(args[i], ARG_MAX - 1) + 1;
+		if (size >= ARG_MAX) {
+			D_ERROR("arg list too long\n");
+			D_FREE(cmd_str);
+			return NULL;
+		}
+
+		D_REALLOC(tmp, cmd_str, size);
+		if (tmp == NULL) {
+			D_FREE(cmd_str);
+			return NULL;
+		}
+		strncat(tmp, args[i], size);
+		cmd_str = tmp;
+	}
+
+	return cmd_str;
+}
+
+#ifndef HAVE_JSON_TOKENER_GET_PARSE_END
+#define json_tokener_get_parse_end(tok) ((tok)->char_offset)
+#endif
+
+#define JSON_CHUNK_SIZE 4096
+#define JSON_MAX_INPUT (1 << 20) /* 1MB is plenty */
+
+/* JSON output handling for dmg command */
+static int
+daos_dmg_json_pipe(const char *dmg_cmd, const char *dmg_config_file,
+		   char *args[], int argcount,
+		   struct json_object **json_out)
+{
+	char			*cmd_str = NULL;
+	char			*cmd_base = NULL;
+	struct	json_object	*obj = NULL;
+	int			parse_depth = JSON_TOKENER_DEFAULT_DEPTH;
+	json_tokener		*tok = NULL;
+	FILE			*fp = NULL;
+	int			pc_rc, rc = 0;
+
+	if (dmg_config_file == NULL)
+		D_ASPRINTF(cmd_base, "dmg -j -i %s ", dmg_cmd);
+	else
+		D_ASPRINTF(cmd_base, "dmg -j -o %s %s ",
+			   dmg_config_file, dmg_cmd);
+	if (cmd_base == NULL)
+		return -DER_NOMEM;
+	cmd_str = cmd_string(cmd_base, args, argcount);
+	D_FREE(cmd_base);
+	if (cmd_str == NULL)
+		return -DER_NOMEM;
+
+	D_DEBUG(DB_TEST, "running %s\n", cmd_str);
+	fp = popen(cmd_str, "r");
+	if (!fp) {
+		D_ERROR("failed to invoke %s\n", cmd_str);
+		D_GOTO(out, rc = -DER_IO);
+	}
+
+	/* If the caller doesn't care about output, don't bother parsing it. */
+	if (json_out == NULL)
+		goto out_pclose;
+
+	char	*jbuf = NULL, *temp;
+	size_t	size = 0;
+	size_t	total = 0;
+	size_t	n;
+
+	while (1) {
+		if (total + JSON_CHUNK_SIZE + 1 > size) {
+			size = total + JSON_CHUNK_SIZE + 1;
+
+			if (size >= JSON_MAX_INPUT) {
+				D_ERROR("JSON input too large\n");
+				D_GOTO(out_jbuf, rc = -DER_REC2BIG);
+			}
+
+			D_REALLOC(temp, jbuf, size);
+			if (temp == NULL)
+				D_GOTO(out_jbuf, rc = -DER_NOMEM);
+			jbuf = temp;
+		}
+
+		n = fread(jbuf + total, 1, JSON_CHUNK_SIZE, fp);
+		if (n == 0)
+			break;
+
+		total += n;
+	}
+
+	D_REALLOC(temp, jbuf, total + 1);
+	if (temp == NULL)
+		D_GOTO(out_jbuf, rc = -DER_NOMEM);
+	jbuf = temp;
+	jbuf[total] = '\0';
+
+	tok = json_tokener_new_ex(parse_depth);
+	if (tok == NULL)
+		D_GOTO(out_jbuf, rc = -DER_NOMEM);
+
+	obj = json_tokener_parse_ex(tok, jbuf, total);
+	if (obj == NULL) {
+		enum json_tokener_error jerr = json_tokener_get_error(tok);
+		int fail_off = json_tokener_get_parse_end(tok);
+		char *aterr = &jbuf[fail_off];
+
+		D_ERROR("failed to parse JSON at offset %d: %s %c\n",
+			fail_off, json_tokener_error_desc(jerr), aterr[0]);
+		D_GOTO(out_tokener, rc = -DER_INVAL);
+	}
+
+out_tokener:
+	json_tokener_free(tok);
+out_jbuf:
+	D_FREE(jbuf);
+out_pclose:
+	pc_rc = pclose(fp);
+	if (pc_rc != 0) {
+		D_ERROR("%s exited with %d\n", cmd_str, pc_rc % 0xFF);
+		if (rc == 0)
+			rc = -DER_MISC;
+	}
+out:
+	D_FREE(cmd_str);
+
+	if (obj != NULL) {
+		struct json_object *tmp;
+		int flags = JSON_C_TO_STRING_PRETTY | JSON_C_TO_STRING_SPACED;
+
+		D_DEBUG(DB_TEST, "parsed output:\n%s\n",
+			json_object_to_json_string_ext(obj, flags));
+
+		json_object_object_get_ex(obj, "error", &tmp);
+
+		if (tmp && !json_object_is_type(tmp, json_type_null)) {
+			const char *err_str;
+
+			err_str = json_object_get_string(tmp);
+			D_ERROR("dmg error: %s\n", err_str);
+			*json_out = json_object_get(tmp);
+
+			if (json_object_object_get_ex(obj, "status", &tmp)) {
+				rc = json_object_get_int(tmp);
+			}
+		} else {
+			if (json_object_object_get_ex(obj, "response", &tmp))
+				*json_out = json_object_get(tmp);
+		}
+
+		json_object_put(obj);
+	}
+
+	return rc;
+}
+
+static int
+parse_pool_info(struct json_object *json_pool, daos_mgmt_pool_info_t *pool_info)
+{
+	struct json_object	*tmp, *rank;
+	int			n_svcranks;
+	const char		*uuid_str;
+	int			i;
+
+	if (json_pool == NULL || pool_info == NULL)
+		return -DER_INVAL;
+
+	if (!json_object_object_get_ex(json_pool, "UUID", &tmp)) {
+		D_ERROR("unable to extract pool UUID from JSON\n");
+		return -DER_INVAL;
+	}
+	uuid_str = json_object_get_string(tmp);
+	uuid_parse(uuid_str, pool_info->mgpi_uuid);
+
+	if (!json_object_object_get_ex(json_pool, "Svcreps", &tmp)) {
+		D_ERROR("unable to parse pool svcreps from JSON\n");
+		return -DER_INVAL;
+	}
+
+	n_svcranks = json_object_array_length(tmp);
+	if (pool_info->mgpi_svc == NULL) {
+		pool_info->mgpi_svc = d_rank_list_alloc(n_svcranks);
+		if (pool_info->mgpi_svc == NULL) {
+			D_ERROR("failed to allocate rank list\n");
+			return -DER_NOMEM;
+		}
+	}
+
+	for (i = 0; i < n_svcranks; i++) {
+		rank = json_object_array_get_idx(tmp, i);
+		pool_info->mgpi_svc->rl_ranks[i] =
+			json_object_get_int(rank);
+	}
+
+	return 0;
+}
+
+static char *
+rank_list_to_string(const d_rank_list_t *rank_list)
+{
+	char		*ranks_str = NULL;
+	int		 width;
+	int		 i;
+	int		 idx = 0;
+
+	if (rank_list == NULL)
+		return NULL;
+
+	width = 0;
+	for (i = 0; i < rank_list->rl_nr; i++)
+		width += snprintf(NULL, 0, "%d,", rank_list->rl_ranks[i]);
+	width++;
+	D_ALLOC(ranks_str, width);
+	if (ranks_str == NULL)
+		return NULL;
+	for (i = 0; i < rank_list->rl_nr; i++)
+		idx += sprintf(&ranks_str[idx], "%d,", rank_list->rl_ranks[i]);
+	ranks_str[width - 1] = '\0';
+
+	return ranks_str;
+}
+
+int
+dmg_pool_create(const char *dmg_config_file,
+		uid_t uid, gid_t gid, const char *grp,
+		const d_rank_list_t *tgts,
+		daos_size_t scm_size, daos_size_t nvme_size,
+		d_rank_list_t *svc, uuid_t uuid)
+{
+	int			argcount = 0;
+	char			**args = NULL;
+	struct passwd		*passwd = NULL;
+	struct group		*group = NULL;
+	daos_mgmt_pool_info_t	pool_info = {};
+	struct json_object	*dmg_out = NULL;
+	int			rc = 0;
+
+	if (grp != NULL) {
+		args = cmd_push_arg(args, &argcount,
+				    "--sys=%s ", grp);
+		if (args == NULL)
+			D_GOTO(out, rc = -DER_NOMEM);
+	}
+
+	if (tgts != NULL) {
+		char *ranks_str = rank_list_to_string(tgts);
+
+		if (ranks_str == NULL) {
+			D_ERROR("failed to create rank string\n");
+			D_GOTO(out_cmd, rc = -DER_NOMEM);
+		}
+		args = cmd_push_arg(args, &argcount,
+				    "--ranks=%s ", ranks_str);
+		D_FREE(ranks_str);
+		if (args == NULL)
+			D_GOTO(out, rc = -DER_NOMEM);
+	}
+
+	passwd = getpwuid(uid);
+	if (passwd == NULL) {
+		D_ERROR("unable to resolve %d to passwd entry\n", uid);
+		D_GOTO(out_cmd, rc = -DER_INVAL);
+	}
+
+	args = cmd_push_arg(args, &argcount,
+			    "--user=%s ", passwd->pw_name);
+	if (args == NULL)
+		D_GOTO(out, rc = -DER_NOMEM);
+
+	group = getgrgid(gid);
+	if (group == NULL) {
+		D_ERROR("unable to resolve %d to group name\n", gid);
+		D_GOTO(out_cmd, rc = -DER_INVAL);
+	}
+
+	args = cmd_push_arg(args, &argcount,
+			    "--group=%s ", group->gr_name);
+	if (args == NULL)
+		D_GOTO(out, rc = -DER_NOMEM);
+
+	args = cmd_push_arg(args, &argcount,
+			    "--scm-size=%"PRIu64"b ", scm_size);
+	if (args == NULL)
+		D_GOTO(out, rc = -DER_NOMEM);
+
+	if (nvme_size > 0) {
+		args = cmd_push_arg(args, &argcount,
+				    "--nvme-size=%"PRIu64"b ", nvme_size);
+		if (args == NULL)
+			D_GOTO(out, rc = -DER_NOMEM);
+	}
+
+	rc = daos_dmg_json_pipe("pool create", dmg_config_file,
+				args, argcount, &dmg_out);
+	if (rc != 0) {
+		D_ERROR("dmg failed");
+		goto out_json;
+	}
+
+	rc = parse_pool_info(dmg_out, &pool_info);
+	if (rc != 0) {
+		D_ERROR("failed to parse pool info\n");
+		goto out_json;
+	}
+
+	uuid_copy(uuid, pool_info.mgpi_uuid);
+	if (svc == NULL)
+		goto out_svc;
+
+	rc = d_rank_list_copy(svc, pool_info.mgpi_svc);
+	if (rc != 0) {
+		D_ERROR("failed to dup svc rank list\n");
+		goto out_svc;
+	}
+
+out_svc:
+	d_rank_list_free(pool_info.mgpi_svc);
+out_json:
+	if (dmg_out != NULL)
+		json_object_put(dmg_out);
+out_cmd:
+	cmd_free_args(args, argcount);
+out:
+	return rc;
+}
+
+int
+dmg_pool_destroy(const char *dmg_config_file,
+		 const uuid_t uuid, const char *grp, int force)
+{
+	char			uuid_str[DAOS_UUID_STR_SIZE];
+	int			argcount = 0;
+	char			**args = NULL;
+	struct json_object	*dmg_out = NULL;
+	int			rc = 0;
+
+	uuid_unparse_lower(uuid, uuid_str);
+	args = cmd_push_arg(args, &argcount,
+			    "--pool=%s ", uuid_str);
+	if (args == NULL)
+		D_GOTO(out, rc = -DER_NOMEM);
+
+	if (force != 0) {
+		args = cmd_push_arg(args, &argcount, "--force");
+		if (args == NULL)
+			D_GOTO(out, rc = -DER_NOMEM);
+	}
+
+	rc = daos_dmg_json_pipe("pool destroy", dmg_config_file,
+				args, argcount, &dmg_out);
+	if (rc != 0) {
+		D_ERROR("dmg failed");
+		goto out_json;
+	}
+
+out_json:
+	if (dmg_out != NULL)
+		json_object_put(dmg_out);
+	cmd_free_args(args, argcount);
+out:
+	return rc;
+}
+
+int
+dmg_pool_list(const char *dmg_config_file, const char *group,
+	      daos_size_t *npools, daos_mgmt_pool_info_t *pools)
+{
+	daos_size_t		npools_in;
+	struct json_object	*dmg_out = NULL;
+	struct json_object	*pool_list = NULL;
+	struct json_object	*pool = NULL;
+	int			rc = 0;
+	int			i;
+
+	if (npools == NULL)
+		return -DER_INVAL;
+	npools_in = *npools;
+
+	rc = daos_dmg_json_pipe("pool list", dmg_config_file,
+				NULL, 0, &dmg_out);
+	if (rc != 0) {
+		D_ERROR("dmg failed");
+		goto out_json;
+	}
+
+	json_object_object_get_ex(dmg_out, "Pools", &pool_list);
+	if (pool_list == NULL)
+		*npools = 0;
+	else
+		*npools = json_object_array_length(pool_list);
+
+	if (pools == NULL)
+		goto out_json;
+	else if (npools_in < *npools)
+		D_GOTO(out_json, rc = -DER_TRUNC);
+
+	for (i = 0; i < *npools; i++) {
+		pool = json_object_array_get_idx(pool_list, i);
+		if (pool == NULL)
+			D_GOTO(out_json, rc = -DER_INVAL);
+
+		rc = parse_pool_info(pool, &pools[i]);
+		if (rc != 0)
+			goto out_json;
+	}
+
+out_json:
+	if (dmg_out != NULL)
+		json_object_put(dmg_out);
+
+	return rc;
+}

--- a/src/control/cmd/dmg/main.go
+++ b/src/control/cmd/dmg/main.go
@@ -36,6 +36,7 @@ import (
 
 	"github.com/daos-stack/daos/src/control/build"
 	"github.com/daos-stack/daos/src/control/common"
+	"github.com/daos-stack/daos/src/control/drpc"
 	"github.com/daos-stack/daos/src/control/fault"
 	"github.com/daos-stack/daos/src/control/lib/control"
 	"github.com/daos-stack/daos/src/control/logging"
@@ -89,15 +90,23 @@ func (cmd *jsonOutputCmd) jsonOutputEnabled() bool {
 }
 
 func (cmd *jsonOutputCmd) outputJSON(in interface{}, cmdErr error) error {
+	status := 0
 	var errStr *string
 	if cmdErr != nil {
 		errStr = new(string)
 		*errStr = cmdErr.Error()
+		if s, ok := errors.Cause(cmdErr).(drpc.DaosStatus); ok {
+			status = int(s)
+		} else {
+			status = int(drpc.DaosMiscError)
+		}
 	}
+
 	data, err := json.MarshalIndent(struct {
 		Response interface{} `json:"response"`
 		Error    *string     `json:"error"`
-	}{in, errStr}, "", "  ")
+		Status   int         `json:"status"`
+	}{in, errStr, status}, "", "  ")
 	if err != nil {
 		return err
 	}

--- a/src/control/common/proto/error.go
+++ b/src/control/common/proto/error.go
@@ -31,6 +31,7 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
+	"github.com/daos-stack/daos/src/control/drpc"
 	"github.com/daos-stack/daos/src/control/fault"
 )
 
@@ -38,6 +39,9 @@ const (
 	// AnnotatedFaultType defines a stable identifier for Faults serialized as gRPC
 	// status metadata.
 	AnnotatedFaultType = "proto.fault.Fault"
+	// AnnotatedDaosStatusType defines an identifier for DaosStatus errors serialized
+	// as gRPC status metadata.
+	AnnotatedDaosStatusType = "proto.drpc.DaosStatus"
 )
 
 // FaultFromMeta converts a map of metadata into a *fault.Fault.
@@ -77,6 +81,19 @@ func AnnotateError(in error) error {
 			return out.Err()
 		}
 	}
+	if s, isStatus := errors.Cause(in).(drpc.DaosStatus); isStatus {
+		out, attachErr := status.New(codes.Internal, s.Error()).
+			WithDetails(&errdetails.ErrorInfo{
+				Reason: AnnotatedDaosStatusType,
+				Domain: "DAOS",
+				Metadata: map[string]string{
+					"Status": strconv.Itoa(int(s)),
+				},
+			})
+		if attachErr == nil {
+			return out.Err()
+		}
+	}
 
 	return in
 }
@@ -98,4 +115,27 @@ func UnwrapFault(st *status.Status) (*fault.Fault, error) {
 		}
 	}
 	return nil, st.Err()
+}
+
+// UnwrapDaosStatus ranges through the status details, looking
+// for the first DaosStatus it can successfully return. Returns
+// the original status as an error if no DaosStatus is unwrapped.
+func UnwrapDaosStatus(st *status.Status) (drpc.DaosStatus, error) {
+	if st == nil {
+		return drpc.DaosSuccess, nil
+	}
+
+	for _, detail := range st.Details() {
+		switch t := detail.(type) {
+		case *errdetails.ErrorInfo:
+			if t.Reason == AnnotatedDaosStatusType {
+				i, err := strconv.Atoi(t.Metadata["Status"])
+				if err != nil {
+					return drpc.DaosMiscError, err
+				}
+				return drpc.DaosStatus(i), nil
+			}
+		}
+	}
+	return drpc.DaosMiscError, st.Err()
 }

--- a/src/control/lib/control/interceptors.go
+++ b/src/control/lib/control/interceptors.go
@@ -31,6 +31,7 @@ import (
 	"google.golang.org/grpc/status"
 
 	"github.com/daos-stack/daos/src/control/common/proto"
+	"github.com/daos-stack/daos/src/control/drpc"
 	"github.com/daos-stack/daos/src/control/fault"
 )
 
@@ -44,6 +45,21 @@ func unwrapFault(st *status.Status) error {
 	f, err := proto.UnwrapFault(st)
 	if f != nil {
 		return f
+	}
+
+	return err
+}
+
+// unwrapDaosStatus takes a gRPC status object
+// and unwraps additional information, if available.
+func unwrapDaosStatus(st *status.Status) error {
+	if st == nil {
+		return nil
+	}
+
+	s, err := proto.UnwrapDaosStatus(st)
+	if err == nil {
+		return s
 	}
 
 	return err
@@ -76,6 +92,9 @@ func streamErrorInterceptor() grpc.DialOption {
 			if f, isFault := unwrapFault(st).(*fault.Fault); isFault {
 				return cs, f
 			}
+			if s, isStatus := unwrapDaosStatus(st).(drpc.DaosStatus); isStatus {
+				return cs, s
+			}
 			return cs, connErrToFault(st, cc.Target())
 		}
 		return cs, nil
@@ -90,6 +109,9 @@ func unaryErrorInterceptor() grpc.DialOption {
 			st := status.Convert(err)
 			if f, isFault := unwrapFault(st).(*fault.Fault); isFault {
 				return f
+			}
+			if s, isStatus := unwrapDaosStatus(st).(drpc.DaosStatus); isStatus {
+				return s
 			}
 			return connErrToFault(st, cc.Target())
 		}

--- a/src/control/lib/control/pool.go
+++ b/src/control/lib/control/pool.go
@@ -161,7 +161,7 @@ type (
 	// PoolCreateResp contains the response from a pool create request.
 	PoolCreateResp struct {
 		UUID    string
-		SvcReps []uint32
+		SvcReps []uint32 `json:"Svcreps"`
 	}
 )
 

--- a/src/control/server/mgmt_pool.go
+++ b/src/control/server/mgmt_pool.go
@@ -94,7 +94,7 @@ func (svc *mgmtSvc) PoolCreate(ctx context.Context, req *mgmtpb.PoolCreateReq) (
 		ds := drpc.DaosStatus(resp.GetStatus())
 		switch ds {
 		// retryable errors
-		case drpc.DaosGroupVersionMismatch:
+		case drpc.DaosGroupVersionMismatch, drpc.DaosTimedOut:
 			svc.log.Infof("MgmtSvc.PoolCreate (try %d), retrying due to %s", try, ds)
 			try++
 			select {

--- a/src/include/daos/tests_lib.h
+++ b/src/include/daos/tests_lib.h
@@ -270,6 +270,7 @@ int dmg_pool_list(const char *dmg_config_file, const char *group,
  *			supported target size.
  * \param nvme_size
  *		[IN]	Target NVMe (Non-Volatile Memory express) size in bytes.
+ * \param prop	[IN]	Optional, pool properties.
  * \param svc	[IN]	Number of desired pool service replicas. Callers must
  *			specify svc->rl_nr and allocate a matching
  *			svc->rl_ranks; svc->rl_nr and svc->rl_ranks
@@ -285,6 +286,7 @@ int dmg_pool_create(const char *dmg_config_file,
 		    uid_t uid, gid_t gid, const char *grp,
 		    const d_rank_list_t *tgts,
 		    daos_size_t scm_size, daos_size_t nvme_size,
+		    daos_prop_t *prop,
 		    d_rank_list_t *svc, uuid_t uuid);
 
 /**

--- a/src/include/daos/tests_lib.h
+++ b/src/include/daos/tests_lib.h
@@ -26,6 +26,8 @@
 
 #include <getopt.h>
 #include <daos_types.h>
+#include <daos/common.h>
+#include <daos_mgmt.h>
 #include <daos/object.h>
 #ifdef DAOS_HAS_VALGRIND
 #include <valgrind/valgrind.h>
@@ -221,5 +223,82 @@ dts_append_config(char buf[DTS_CFG_MAX], const char *format, ...)
 	if (strlen(buf) >= DTS_CFG_MAX)
 		buf[DTS_CFG_MAX - 1] = 0;
 }
+
+/**
+ * List all pools created in the specified DAOS system.
+ *
+ * \param dmg_config_file
+ *			[IN]	DMG config file
+ * \param group		[IN]	Name of DAOS system managing the service.
+ * \param npools	[IN,OUT]
+ *				[in] \a pools length in items.
+ *				[out] Number of pools in the DAOS system.
+ * \param pools		[OUT]	Array of pool mgmt information structures.
+ *				NULL is permitted in which case only the
+ *				number of pools will be returned in \a npools.
+ *				When non-NULL and on successful return, a
+ *				service replica rank list (mgpi_svc) is
+ *				allocated for each item in \pools.
+ *				The rank lists must be freed by the caller.
+ *
+ * \return			0		Success
+ *				-DER_TRUNC	\a pools cannot hold \a npools
+ *						items
+ */
+int dmg_pool_list(const char *dmg_config_file, const char *group,
+		  daos_size_t *npools, daos_mgmt_pool_info_t *pools);
+
+/**
+ * Create a pool spanning \a tgts in \a grp. Upon successful completion, report
+ * back the pool UUID in \a uuid and the pool service rank(s) in \a svc, which
+ * are required by daos_pool_connect() to establish a pool connection.
+ *
+ * Targets are assumed to share the same \a size.
+ *
+ * \param dmg_config_file
+ *		[IN]	DMG config file
+ * \param uid	[IN]	User owning the pool
+ * \param gid	[IN]	Group owning the pool
+ * \param grp	[IN]	Process set name of the DAOS servers managing the pool
+ * \param tgts	[IN]	Optional, allocate targets on this list of ranks
+ *			If set to NULL, create the pool over all the ranks
+ *			available in the service group.
+ * \param scm_size
+ *		[IN]	Target SCM (Storage Class Memory) size in bytes (i.e.,
+ *			maximum amounts of SCM storage space targets can
+ *			consume) in bytes. Passing 0 will use the minimal
+ *			supported target size.
+ * \param nvme_size
+ *		[IN]	Target NVMe (Non-Volatile Memory express) size in bytes.
+ * \param svc	[IN]	Number of desired pool service replicas. Callers must
+ *			specify svc->rl_nr and allocate a matching
+ *			svc->rl_ranks; svc->rl_nr and svc->rl_ranks
+ *			content are ignored.
+ *		[OUT]	List of actual pool service replicas. svc->rl_nr
+ *			is the number of actual pool service replicas, which
+ *			shall be equal to or smaller than the desired number.
+ *			The first svc->rl_nr elements of svc->rl_ranks
+ *			shall be the list of pool service ranks.
+ * \param uuid	[OUT]	UUID of the pool created
+ */
+int dmg_pool_create(const char *dmg_config_file,
+		    uid_t uid, gid_t gid, const char *grp,
+		    const d_rank_list_t *tgts,
+		    daos_size_t scm_size, daos_size_t nvme_size,
+		    d_rank_list_t *svc, uuid_t uuid);
+
+/**
+ * Destroy a pool with \a uuid. If there is at least one connection to this
+ * pool, and \a force is zero, then this operation completes with DER_BUSY.
+ * Otherwise, the pool is destroyed when the operation completes.
+ *
+ * \param dmg_config_file
+ *		[IN]	DMG config file
+ * \param uuid	[IN]	UUID of the pool to destroy
+ * \param grp	[IN]	Process set name of the DAOS servers managing the pool
+ * \param force	[IN]	Force destruction even if there are active connections
+ */
+int dmg_pool_destroy(const char *dmg_config_file,
+		     const uuid_t uuid, const char *grp, int force);
 
 #endif /* __DAOS_TESTS_LIB_H__ */

--- a/src/tests/SConscript
+++ b/src/tests/SConscript
@@ -6,7 +6,8 @@ def scons():
     """Execute build"""
     Import('env', 'prereqs')
 
-    libs = ['daos', 'daos_common', 'gurt', 'cart', 'uuid', 'cmocka']
+    libs = ['daos', 'daos_common', 'gurt', 'cart', 'uuid', 'cmocka',
+            'daos_tests']
 
     denv = env.Clone()
 
@@ -24,7 +25,7 @@ def scons():
     prereqs.require(denv, 'argobots', 'hwloc', 'protobufc')
 
     daos_build.program(denv, 'simple_array', 'simple_array.c', LIBS=libs)
-    libs += ['vos', 'bio', 'pthread', 'abt', 'daos_tests']
+    libs += ['vos', 'bio', 'pthread', 'abt']
 
     dts_common = denv.Object('dts_common.c')
     daos_perf = daos_build.program(denv, 'daos_perf',

--- a/src/tests/daos_racer.c
+++ b/src/tests/daos_racer.c
@@ -454,6 +454,7 @@ racer_valid_oid(daos_obj_id_t oid, daos_pool_info_t *pinfo)
 }
 
 static struct option ts_ops[] = {
+	{ "dmg_config",	required_argument,	NULL,	'n' },
 	{ "pool_uuid",	required_argument,	NULL,	'p' },
 	{ "cont_uuid",	required_argument,	NULL,	'c' },
 	{ "time",	required_argument,	NULL,	't' },
@@ -478,7 +479,7 @@ main(int argc, char **argv)
 	MPI_Comm_rank(MPI_COMM_WORLD, &ts_ctx.tsc_mpi_rank);
 	MPI_Comm_size(MPI_COMM_WORLD, &ts_ctx.tsc_mpi_size);
 	while ((rc = getopt_long(argc, argv,
-				 "p:c:t:",
+				 "n:p:c:t:",
 				 ts_ops, NULL)) != -1) {
 		char	*endp;
 
@@ -486,6 +487,9 @@ main(int argc, char **argv)
 		default:
 			fprintf(stderr, "Unknown option %c\n", rc);
 			return -1;
+		case 'n':
+			dmg_config_file = optarg;
+			break;
 		case 'p':
 			rc = uuid_parse(optarg, ts_ctx.tsc_pool_uuid);
 			if (rc)

--- a/src/tests/dts_common.c
+++ b/src/tests/dts_common.c
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2017-2018 Intel Corporation.
+ * (C) Copyright 2017-2020 Intel Corporation.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -43,6 +43,9 @@
 #include <daos_srv/vos.h>
 #include <daos_test.h>
 #include "dts_common.h"
+
+/* path to dmg config file */
+const char *dmg_config_file;
 
 enum {
 	DTS_INIT_NONE,		/* nothing has been initialized */
@@ -227,10 +230,10 @@ pool_init(struct dts_context *tsc)
 	} else if (tsc->tsc_mpi_rank == 0) { /* DAOS mode and rank zero */
 		d_rank_list_t	*svc = &tsc->tsc_svc;
 
-		rc = daos_pool_create(0731, geteuid(), getegid(),
-				      NULL, NULL, "pmem",
-				      tsc->tsc_scm_size, tsc->tsc_nvme_size,
-				      NULL, svc, tsc->tsc_pool_uuid, NULL);
+		rc = dmg_pool_create(dmg_config_file, geteuid(), getegid(),
+				     NULL, NULL,
+				     tsc->tsc_scm_size, tsc->tsc_nvme_size,
+				     svc, tsc->tsc_pool_uuid);
 		if (rc)
 			goto bcast;
 
@@ -269,8 +272,8 @@ pool_fini(struct dts_context *tsc)
 		daos_pool_disconnect(tsc->tsc_poh, NULL);
 		MPI_Barrier(MPI_COMM_WORLD);
 		if (tsc->tsc_mpi_rank == 0) {
-			rc = daos_pool_destroy(tsc->tsc_pool_uuid, NULL, true,
-					       NULL);
+			rc = dmg_pool_destroy(dmg_config_file,
+					      tsc->tsc_pool_uuid, NULL, true);
 			D_ASSERTF(rc == 0 || rc == -DER_NONEXIST ||
 				  rc == -DER_TIMEDOUT, "rc="DF_RC"\n",
 				  DP_RC(rc));

--- a/src/tests/dts_common.c
+++ b/src/tests/dts_common.c
@@ -233,7 +233,7 @@ pool_init(struct dts_context *tsc)
 		rc = dmg_pool_create(dmg_config_file, geteuid(), getegid(),
 				     NULL, NULL,
 				     tsc->tsc_scm_size, tsc->tsc_nvme_size,
-				     svc, tsc->tsc_pool_uuid);
+				     NULL, svc, tsc->tsc_pool_uuid);
 		if (rc)
 			goto bcast;
 

--- a/src/tests/ftest/daos_test/daos_core_test-rebuild.yaml
+++ b/src/tests/ftest/daos_test/daos_core_test-rebuild.yaml
@@ -7,6 +7,8 @@ hosts:
     - server-C
     - server-D
 timeout: 600
+pool:
+  nvme_size: 0G
 server_config:
   servers_per_host: 2
   name: daos_server

--- a/src/tests/ftest/daos_test/daos_core_test.yaml
+++ b/src/tests/ftest/daos_test/daos_core_test.yaml
@@ -13,6 +13,7 @@ timeout: 600
 pool:
   #This will create 8G of SCM and 16G of NVMe size of pool.
   scm_size: 8G
+  nvme_size: 16G
 server_config:
   servers_per_host: 2
   name: daos_server

--- a/src/tests/ftest/network/zero_config.py
+++ b/src/tests/ftest/network/zero_config.py
@@ -125,8 +125,13 @@ class ZeroConfigTest(TestWithServers):
         cnt_before = self.get_port_cnt(
             self.hostlist_clients, hfi_map[exp_iface], "port_rcv_data")
 
+        # get the dmg config file for daos_racer
+        dmg = self.get_dmg_command()
+        dmg_config = dmg.yaml.filename
+
         # Let's run daos_racer as a client
-        daos_racer = DaosRacerCommand(self.bin, self.hostlist_clients[0])
+        daos_racer = DaosRacerCommand(self.bin,
+                                      self.hostlist_clients[0], dmg_config)
         daos_racer.get_params(self)
 
         # Update env_name list to add OFI_INTERFACE if needed.

--- a/src/tests/ftest/network/zero_config.yaml
+++ b/src/tests/ftest/network/zero_config.yaml
@@ -13,6 +13,14 @@ server_config:
     bdev_list: ["aaaa:aa:aa.a","bbbb:bb:bb.b"]
     scm_class: dcpm
     scm_list: ["/dev/pmem0"]
+  transport_config:
+    allow_insecure: True
+agent_config:
+  transport_config:
+    allow_insecure: True
+dmg:
+  transport_config:
+    allow_insecure: True
 daos_racer:
   runtime: 30
   clush_timeout: 60

--- a/src/tests/ftest/util/daos_core_base.py
+++ b/src/tests/ftest/util/daos_core_base.py
@@ -101,6 +101,7 @@ class DaosCoreBase(TestWithServers):
         num_replicas = self.params.get("num_replicas",
                                        '/run/daos_tests/num_replicas/*')
         scm_size = self.params.get("scm_size", '/run/pool/*')
+        nvme_size = self.params.get("nvme_size", '/run/pool/*')
         args = self.params.get("args", self.TEST_PATH, "")
         dmg = self.get_dmg_command()
         dmg_config_file = dmg.yaml.filename
@@ -125,6 +126,9 @@ class DaosCoreBase(TestWithServers):
         env['CMOCKA_XML_FILE'] = os.path.join(self.outputdir, "%g_results.xml")
         env['CMOCKA_MESSAGE_OUTPUT'] = "xml"
         env['POOL_SCM_SIZE'] = "{}".format(scm_size)
+        if not nvme_size:
+            nvme_size = 0
+        env['POOL_NVME_SIZE'] = "{}".format(nvme_size)
 
         load_mpi("openmpi")
         try:

--- a/src/tests/ftest/util/daos_racer_utils.py
+++ b/src/tests/ftest/util/daos_racer_utils.py
@@ -30,12 +30,13 @@ from general_utils import pcmd
 class DaosRacerCommand(ExecutableCommand):
     """Defines a object representing a daos_racer command."""
 
-    def __init__(self, path, host):
+    def __init__(self, path, host, dmg_config=None):
         """Create a daos_racer command object.
 
         Args:
             path (str): path of the daos_racer command
             host (str): host on which to run the daos_racer command
+            dmg_config (str): path to dmg config file
         """
         super(DaosRacerCommand, self).__init__(
             "/run/daos_racer/*", "daos_racer", path)
@@ -43,6 +44,9 @@ class DaosRacerCommand(ExecutableCommand):
 
         # Number of seconds to run
         self.runtime = FormattedParameter("-t {}", 60)
+
+        if dmg_config:
+            self.dmg_config = FormattedParameter("-n {}", dmg_config)
 
         # Optional timeout for the clush command running the daos_racer command.
         # This should be set greater than the 'runtime' value but less than the

--- a/src/tests/simple_array.c
+++ b/src/tests/simple_array.c
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2016-2018 Intel Corporation.
+ * (C) Copyright 2016-2020 Intel Corporation.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -44,6 +44,7 @@
 #include <stdio.h>
 #include <string.h>
 
+#include <daos/tests_lib.h>
 #include <daos.h>
 #include "suite/daos_test.h"
 #include <mpi.h>
@@ -136,25 +137,22 @@ pool_create(void)
 
 	/**
 	 * allocate list of service nodes, returned as output parameter of
-	 * daos_pool_create() and used to connect
+	 * dmg_pool_create() and used to connect
 	 */
 
 	/** create pool over all the storage targets */
 	svcl.rl_nr	= 3;
 	ASSERT(ARRAY_SIZE(svc) >= svcl.rl_nr);
 	svcl.rl_ranks	= svc;
-	rc = daos_pool_create(0731 /* mode */,
-			      geteuid() /* user owner */,
-			      getegid() /* group owner */,
-			      DSS_PSETID /* daos server process set ID */,
-			      NULL /* list of targets, NULL = all */,
-			      NULL /* storage type to use, use default */,
-			      10ULL << 30 /* target SCM size, 10G */,
-			      40ULL << 30 /* target NVMe size, 40G */,
-			      NULL, /* pool properties */
-			      &svcl /* pool service nodes, used for connect */,
-			      pool_uuid, /* the uuid of the pool created */
-			      NULL /* event, use blocking call for now */);
+	rc = dmg_pool_create(NULL /* config file */,
+			     geteuid() /* user owner */,
+			     getegid() /* group owner */,
+			     DSS_PSETID /* daos server process set ID */,
+			     NULL /* list of targets, NULL = all */,
+			     10ULL << 30 /* target SCM size, 10G */,
+			     40ULL << 30 /* target NVMe size, 40G */,
+			     &svcl /* pool service nodes, used for connect */,
+			     pool_uuid /* the uuid of the pool created */);
 	ASSERT(rc == 0, "pool create failed with %d", rc);
 }
 
@@ -164,8 +162,7 @@ pool_destroy(void)
 	int	rc;
 
 	/** destroy the pool created in pool_create */
-	rc = daos_pool_destroy(pool_uuid, DSS_PSETID, 1 /* force */,
-			       NULL /* event */);
+	rc = dmg_pool_destroy(NULL, pool_uuid, DSS_PSETID, 1 /* force */);
 	ASSERT(rc == 0, "pool destroy failed with %d", rc);
 }
 

--- a/src/tests/simple_array.c
+++ b/src/tests/simple_array.c
@@ -151,6 +151,7 @@ pool_create(void)
 			     NULL /* list of targets, NULL = all */,
 			     10ULL << 30 /* target SCM size, 10G */,
 			     40ULL << 30 /* target NVMe size, 40G */,
+			     NULL /* pool props */,
 			     &svcl /* pool service nodes, used for connect */,
 			     pool_uuid /* the uuid of the pool created */);
 	ASSERT(rc == 0, "pool create failed with %d", rc);

--- a/src/tests/suite/SConscript
+++ b/src/tests/suite/SConscript
@@ -80,7 +80,7 @@ def scons():
     Import('denv')
 
     libraries = ['daos_common', 'daos', 'dfs', 'daos_tests', 'gurt', 'cart']
-    libraries += ['uuid', 'dfs', 'cmocka', 'pthread', 'json-c']
+    libraries += ['uuid', 'dfs', 'cmocka', 'pthread']
 
     denv.AppendUnique(LIBPATH=["$BUILD_DIR/src/client/dfs"])
 

--- a/src/tests/suite/daos_capa.c
+++ b/src/tests/suite/daos_capa.c
@@ -71,7 +71,7 @@ query(void **state)
 
 	/** connect to the pool */
 	rc = daos_pool_connect(arg->pool.pool_uuid, arg->group,
-			       &arg->pool.svc, DAOS_PC_RW, &poh,
+			       arg->pool.svc, DAOS_PC_RW, &poh,
 			       NULL /* info */,
 			       NULL /* ev */);
 	assert_int_equal(rc, 0);
@@ -108,7 +108,7 @@ create(void **state)
 
 	/** connect to the pool in read-only mode */
 	rc = daos_pool_connect(arg->pool.pool_uuid, arg->group,
-			       &arg->pool.svc, DAOS_PC_RO, &poh,
+			       arg->pool.svc, DAOS_PC_RO, &poh,
 			       NULL /* info */,
 			       NULL /* ev */);
 	assert_int_equal(rc, 0);
@@ -125,7 +125,7 @@ create(void **state)
 
 	/** connect to the pool in read-write mode */
 	rc = daos_pool_connect(arg->pool.pool_uuid, arg->group,
-			       &arg->pool.svc, DAOS_PC_RW, &poh,
+			       arg->pool.svc, DAOS_PC_RW, &poh,
 			       NULL /* info */,
 			       NULL /* ev */);
 	assert_int_equal(rc, 0);
@@ -158,7 +158,7 @@ destroy(void **state)
 
 	/** connect to the pool in read-write mode */
 	rc = daos_pool_connect(arg->pool.pool_uuid, arg->group,
-			       &arg->pool.svc, DAOS_PC_RW, &poh,
+			       arg->pool.svc, DAOS_PC_RW, &poh,
 			       NULL /* info */,
 			       NULL /* ev */);
 	assert_int_equal(rc, 0);
@@ -182,7 +182,7 @@ destroy(void **state)
 
 	/** connect to the pool in read-only mode */
 	rc = daos_pool_connect(arg->pool.pool_uuid, arg->group,
-			       &arg->pool.svc, DAOS_PC_RO, &poh,
+			       arg->pool.svc, DAOS_PC_RO, &poh,
 			       NULL /* info */,
 			       NULL /* ev */);
 	assert_int_equal(rc, 0);
@@ -198,7 +198,7 @@ destroy(void **state)
 
 	/** connect to the pool in read-write mode */
 	rc = daos_pool_connect(arg->pool.pool_uuid, arg->group,
-			       &arg->pool.svc, DAOS_PC_RW, &poh,
+			       arg->pool.svc, DAOS_PC_RW, &poh,
 			       NULL /* info */,
 			       NULL /* ev */);
 	assert_int_equal(rc, 0);
@@ -228,7 +228,7 @@ open(void **state)
 
 	/** connect to the pool in read-write mode */
 	rc = daos_pool_connect(arg->pool.pool_uuid, arg->group,
-			       &arg->pool.svc, DAOS_PC_RW, &poh,
+			       arg->pool.svc, DAOS_PC_RW, &poh,
 			       NULL /* info */,
 			       NULL /* ev */);
 	assert_int_equal(rc, 0);
@@ -247,7 +247,7 @@ open(void **state)
 
 	/** reconnect to the pool in read-only mode */
 	rc = daos_pool_connect(arg->pool.pool_uuid, arg->group,
-			       &arg->pool.svc, DAOS_PC_RO, &poh,
+			       arg->pool.svc, DAOS_PC_RO, &poh,
 			       NULL /* info */,
 			       NULL /* ev */);
 	assert_int_equal(rc, 0);
@@ -300,7 +300,7 @@ io_invalid_poh(void **state)
 	if (arg->myrank == 0) {
 		/** connect to the pool in read-write mode */
 		rc = daos_pool_connect(arg->pool.pool_uuid, arg->group,
-				       &arg->pool.svc, DAOS_PC_RW, &poh,
+				       arg->pool.svc, DAOS_PC_RW, &poh,
 				       NULL /* info */,
 				       NULL /* ev */);
 		assert_int_equal(rc, 0);

--- a/src/tests/suite/daos_checksum.c
+++ b/src/tests/suite/daos_checksum.c
@@ -1622,7 +1622,7 @@ rebuild_test(void **state, int chunksize, int data_len_bytes, int iod_type)
 	print_message("Excluding rank %d\n", rank_to_exclude);
 	disabled_nr = disabled_targets(arg);
 	daos_exclude_server(arg->pool.pool_uuid, arg->group,
-			    arg->dmg_config, &arg->pool.alive_svc,
+			    arg->dmg_config, arg->pool.alive_svc,
 			    layout1->ol_shards[0]->os_ranks[0]);
 	assert_true(disabled_nr < disabled_targets(arg));
 
@@ -1650,7 +1650,7 @@ rebuild_test(void **state, int chunksize, int data_len_bytes, int iod_type)
 	assert_success(rc);
 
 	daos_add_server(arg->pool.pool_uuid, arg->group, arg->dmg_config,
-			&arg->pool.alive_svc, rank_to_exclude);
+			arg->pool.alive_svc, rank_to_exclude);
 	assert_int_equal(disabled_nr, disabled_targets(arg));
 	/** wait for rebuild */
 	test_rebuild_wait(&arg, 1);

--- a/src/tests/suite/daos_degraded.c
+++ b/src/tests/suite/daos_degraded.c
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2016-2018 Intel Corporation.
+ * (C) Copyright 2016-2020 Intel Corporation.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -131,7 +131,7 @@ insert_lookup_enum_with_ops(test_arg_t *arg, int op_kill)
 		if (op_kill == UPDATE && rank == 0 &&
 		    g_dkeys > 1 && (i == g_dkeys/2))
 			daos_kill_server(arg, arg->pool.pool_uuid,
-					 arg->group, &arg->pool.svc, -1);
+					 arg->group, arg->pool.svc, -1);
 	}
 
 	MPI_Barrier(MPI_COMM_WORLD);
@@ -160,7 +160,7 @@ insert_lookup_enum_with_ops(test_arg_t *arg, int op_kill)
 		if (op_kill == LOOKUP && rank == 0 &&
 		    g_dkeys > 1 && (i == g_dkeys/2))
 			daos_kill_server(arg, arg->pool.pool_uuid,
-					 arg->group, &arg->pool.svc, -1);
+					 arg->group, arg->pool.svc, -1);
 	}
 	D_FREE(rec_verify);
 
@@ -207,7 +207,7 @@ insert_lookup_enum_with_ops(test_arg_t *arg, int op_kill)
 		if (op_kill == ENUMERATE && rank == 0 && enum_op &&
 		    g_dkeys > 1 && (key_nr  >= g_dkeys/2)) {
 			daos_kill_server(arg, arg->pool.pool_uuid,
-					 arg->group, &arg->pool.svc, -1);
+					 arg->group, arg->pool.svc, -1);
 			enum_op = 0;
 		}
 

--- a/src/tests/suite/daos_epoch_io.c
+++ b/src/tests/suite/daos_epoch_io.c
@@ -361,7 +361,7 @@ daos_test_cb_add(test_arg_t *arg, struct test_op_record *op,
 	print_message("add rank %u\n", op->ae_arg.ua_rank);
 	test_rebuild_wait(&arg, 1);
 	daos_add_server(arg->pool.pool_uuid, arg->group, arg->dmg_config,
-			&arg->pool.svc, op->ae_arg.ua_rank);
+			arg->pool.svc, op->ae_arg.ua_rank);
 	return 0;
 }
 
@@ -372,13 +372,13 @@ daos_test_cb_exclude(test_arg_t *arg, struct test_op_record *op,
 	if (op->ae_arg.ua_tgt == -1) {
 		print_message("exclude rank %u\n", op->ae_arg.ua_rank);
 		daos_exclude_server(arg->pool.pool_uuid, arg->group,
-				    arg->dmg_config, &arg->pool.svc,
+				    arg->dmg_config, arg->pool.svc,
 				    op->ae_arg.ua_rank);
 	} else {
 		print_message("exclude rank %u target %d\n",
 			       op->ae_arg.ua_rank, op->ae_arg.ua_tgt);
 		daos_exclude_target(arg->pool.pool_uuid, arg->group,
-				    arg->dmg_config, &arg->pool.svc,
+				    arg->dmg_config, arg->pool.svc,
 				    op->ae_arg.ua_rank, op->ae_arg.ua_tgt);
 	}
 	return 0;

--- a/src/tests/suite/daos_epoch_recovery.c
+++ b/src/tests/suite/daos_epoch_recovery.c
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2016-2018 Intel Corporation.
+ * (C) Copyright 2016-2020 Intel Corporation.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -145,7 +145,7 @@ epoch_recovery(test_arg_t *arg, enum epoch_recovery_op op)
 		if (arg->myrank == 0) {
 			print_message("evicting pool connections\n");
 			rc = daos_pool_evict(arg->pool.pool_uuid, arg->group,
-					     &arg->pool.svc, NULL /* ev */);
+					     arg->pool.svc, NULL /* ev */);
 			assert_int_equal(rc, 0);
 		}
 		MPI_Barrier(MPI_COMM_WORLD);
@@ -164,7 +164,7 @@ epoch_recovery(test_arg_t *arg, enum epoch_recovery_op op)
 		print_message("reconnecting to pool\n");
 		if (arg->myrank == 0) {
 			rc = daos_pool_connect(arg->pool.pool_uuid, arg->group,
-					       &arg->pool.svc, DAOS_PC_RW,
+					       arg->pool.svc, DAOS_PC_RW,
 					       &arg->pool.poh, NULL /* info */,
 					       NULL /* ev */);
 			assert_int_equal(rc, 0);

--- a/src/tests/suite/daos_md_replication.c
+++ b/src/tests/suite/daos_md_replication.c
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2017-2018 Intel Corporation.
+ * (C) Copyright 2017-2020 Intel Corporation.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -41,9 +41,10 @@ mdr_stop_pool_svc(void **argv)
 	/* Create the pool. */
 	if (arg->myrank == 0) {
 		print_message("creating pool\n");
-		rc = daos_pool_create(0731, geteuid(), getegid(), arg->group,
-				      NULL, "pmem", 128*1024*1024, 0, NULL,
-				      &arg->pool.svc, uuid, NULL);
+		rc = dmg_pool_create(dmg_config_file,
+				     geteuid(), getegid(), arg->group,
+				     NULL, 128 * 1024 * 1024, 0,
+				     &arg->pool.svc, uuid);
 	}
 	MPI_Bcast(&rc, 1, MPI_INT, 0, MPI_COMM_WORLD);
 	assert_int_equal(rc, 0);
@@ -115,7 +116,8 @@ destroy:
 		if (skip)
 			print_message("skipping\n");
 		print_message("destroying pool\n");
-		rc = daos_pool_destroy(uuid, arg->group, 1, NULL);
+		rc = dmg_pool_destroy(dmg_config_file,
+				      uuid, arg->group, 1);
 		assert_int_equal(rc, 0);
 	}
 	if (skip)
@@ -134,9 +136,10 @@ mdr_stop_cont_svc(void **argv)
 	int			rc;
 
 	print_message("creating pool\n");
-	rc = daos_pool_create(0731, geteuid(), getegid(), arg->group, NULL,
-			      "pmem", 128*1024*1024, 0, NULL, &arg->pool.svc,
-			      pool_uuid, NULL);
+	rc = dmg_pool_create(dmg_config_file,
+			     geteuid(), getegid(), arg->group,
+			     NULL, 128 * 1024 * 1024, 0, &arg->pool.svc,
+			     pool_uuid);
 	assert_int_equal(rc, 0);
 
 	if (arg->pool.svc.rl_nr < 3) {
@@ -178,7 +181,8 @@ destroy:
 		if (skip)
 			print_message("skipping\n");
 		print_message("destroying pool\n");
-		rc = daos_pool_destroy(pool_uuid, arg->group, 1, NULL);
+		rc = dmg_pool_destroy(dmg_config_file,
+				      pool_uuid, arg->group, 1);
 		assert_int_equal(rc, 0);
 	}
 	if (skip)

--- a/src/tests/suite/daos_md_replication.c
+++ b/src/tests/suite/daos_md_replication.c
@@ -44,19 +44,19 @@ mdr_stop_pool_svc(void **argv)
 		rc = dmg_pool_create(dmg_config_file,
 				     geteuid(), getegid(), arg->group,
 				     NULL, 128 * 1024 * 1024, 0,
-				     NULL, &arg->pool.svc, uuid);
+				     NULL, arg->pool.svc, uuid);
 	}
 	MPI_Bcast(&rc, 1, MPI_INT, 0, MPI_COMM_WORLD);
 	assert_int_equal(rc, 0);
 	MPI_Bcast(uuid, 16, MPI_CHAR, 0, MPI_COMM_WORLD);
-	MPI_Bcast(&arg->pool.svc.rl_nr, sizeof(arg->pool.svc.rl_nr), MPI_CHAR,
+	MPI_Bcast(&arg->pool.svc->rl_nr, sizeof(arg->pool.svc->rl_nr), MPI_CHAR,
 		  0, MPI_COMM_WORLD);
 	MPI_Bcast(arg->pool.ranks,
-		  sizeof(arg->pool.ranks[0]) * arg->pool.svc.rl_nr,
+		  sizeof(arg->pool.ranks[0]) * arg->pool.svc->rl_nr,
 		  MPI_CHAR, 0, MPI_COMM_WORLD);
 
 	/* Check the number of pool service replicas. */
-	if (arg->pool.svc.rl_nr < 3) {
+	if (arg->pool.svc->rl_nr < 3) {
 		if (arg->myrank == 0)
 			print_message(">= 3 pool service replicas needed; ");
 		skip = true;
@@ -66,7 +66,7 @@ mdr_stop_pool_svc(void **argv)
 	/* Connect to the pool. */
 	if (arg->myrank == 0) {
 		print_message("connecting to pool\n");
-		rc = daos_pool_connect(uuid, arg->group, &arg->pool.svc,
+		rc = daos_pool_connect(uuid, arg->group, arg->pool.svc,
 				       DAOS_PC_RW, &poh, NULL /* info */,
 				       NULL /* ev */);
 	}
@@ -139,10 +139,10 @@ mdr_stop_cont_svc(void **argv)
 	rc = dmg_pool_create(dmg_config_file,
 			     geteuid(), getegid(), arg->group,
 			     NULL, 128 * 1024 * 1024, 0,
-			     NULL, &arg->pool.svc, pool_uuid);
+			     NULL, arg->pool.svc, pool_uuid);
 	assert_int_equal(rc, 0);
 
-	if (arg->pool.svc.rl_nr < 3) {
+	if (arg->pool.svc->rl_nr < 3) {
 		if (arg->myrank == 0)
 			print_message(">= 3 pool service replicas needed; ");
 		skip = true;
@@ -150,7 +150,7 @@ mdr_stop_cont_svc(void **argv)
 	}
 
 	print_message("connecting to pool\n");
-	rc = daos_pool_connect(pool_uuid, arg->group, &arg->pool.svc,
+	rc = daos_pool_connect(pool_uuid, arg->group, arg->pool.svc,
 			       DAOS_PC_RW, &poh, NULL, NULL /* ev */);
 	assert_int_equal(rc, 0);
 	print_message("creating container\n");

--- a/src/tests/suite/daos_md_replication.c
+++ b/src/tests/suite/daos_md_replication.c
@@ -44,7 +44,7 @@ mdr_stop_pool_svc(void **argv)
 		rc = dmg_pool_create(dmg_config_file,
 				     geteuid(), getegid(), arg->group,
 				     NULL, 128 * 1024 * 1024, 0,
-				     &arg->pool.svc, uuid);
+				     NULL, &arg->pool.svc, uuid);
 	}
 	MPI_Bcast(&rc, 1, MPI_INT, 0, MPI_COMM_WORLD);
 	assert_int_equal(rc, 0);
@@ -138,8 +138,8 @@ mdr_stop_cont_svc(void **argv)
 	print_message("creating pool\n");
 	rc = dmg_pool_create(dmg_config_file,
 			     geteuid(), getegid(), arg->group,
-			     NULL, 128 * 1024 * 1024, 0, &arg->pool.svc,
-			     pool_uuid);
+			     NULL, 128 * 1024 * 1024, 0,
+			     NULL, &arg->pool.svc, pool_uuid);
 	assert_int_equal(rc, 0);
 
 	if (arg->pool.svc.rl_nr < 3) {

--- a/src/tests/suite/daos_mgmt.c
+++ b/src/tests/suite/daos_mgmt.c
@@ -55,7 +55,7 @@ pool_create_all(void **state)
 			     geteuid(), getegid(),
 			     arg->group, NULL /* tgts */,
 			     128 * 1024 * 1024 /* minimal size */,
-			     0 /* nvme size */,
+			     0 /* nvme size */, NULL /* prop */,
 			     &arg->pool.svc /* svc */, uuid);
 	assert_int_equal(rc, 0);
 
@@ -103,7 +103,7 @@ setup_pools(void **state, daos_size_t npools)
 
 		/* Create the pool */
 		rc = test_setup_pool_create(state, NULL /* ipool */,
-					    &lparg->tpools[i]);
+					    &lparg->tpools[i], NULL /* prop */);
 		if (rc != 0)
 			goto err_destroy_pools;
 	}
@@ -387,7 +387,7 @@ pool_create_and_destroy_retry(void **state)
 			     geteuid(), getegid(),
 			     arg->group, NULL /* tgts */,
 			     128 * 1024 * 1024 /* minimal size */,
-			     0 /* nvme size */,
+			     0 /* nvme size */, NULL /* prop */,
 			     &arg->pool.svc /* svc */, uuid);
 	assert_int_equal(rc, 0);
 	print_message("success uuid = "DF_UUIDF"\n", DP_UUID(uuid));

--- a/src/tests/suite/daos_mgmt.c
+++ b/src/tests/suite/daos_mgmt.c
@@ -42,53 +42,31 @@ pool_create_all(void **state)
 	test_arg_t	*arg = *state;
 	uuid_t		 uuid;
 	char		 uuid_str[64];
-	daos_event_t	 ev;
-	daos_event_t	*evp;
 	int		 rc;
 
 	if (arg->async) {
-		rc = daos_event_init(&ev, arg->eq, NULL);
-		assert_int_equal(rc, 0);
+		print_message("async not supported");
+		return;
 	}
-
 
 	/** create container */
-	print_message("creating pool %ssynchronously ... ",
-		      arg->async ? "a" : "");
-	rc = daos_pool_create(0700 /* mode */, 0 /* uid */, 0 /* gid */,
-			      arg->group, NULL /* tgts */, "pmem" /* dev */,
-			      0 /* minimal size */, 0 /* nvme size */,
-			      NULL /* properties */, &arg->pool.svc /* svc */,
-			      uuid, arg->async ? &ev : NULL);
+	print_message("creating pool synchronously ... ");
+	rc = dmg_pool_create(dmg_config_file,
+			     geteuid(), getegid(),
+			     arg->group, NULL /* tgts */,
+			     128 * 1024 * 1024 /* minimal size */,
+			     0 /* nvme size */,
+			     &arg->pool.svc /* svc */, uuid);
 	assert_int_equal(rc, 0);
-
-	if (arg->async) {
-		/** wait for container creation */
-		rc = daos_eq_poll(arg->eq, 1, DAOS_EQ_WAIT, 1, &evp);
-		assert_int_equal(rc, 1);
-		assert_ptr_equal(evp, &ev);
-		assert_int_equal(ev.ev_error, 0);
-	}
 
 	uuid_unparse_lower(uuid, uuid_str);
 	print_message("success uuid = %s\n", uuid_str);
 
 	/** destroy container */
-	print_message("destroying pool %ssynchronously ... ",
-		      arg->async ? "a" : "");
-	rc = daos_pool_destroy(uuid, arg->group, 1, arg->async ? &ev : NULL);
+	print_message("destroying pool synchronously ... ");
+	rc = dmg_pool_destroy(dmg_config_file, uuid, arg->group, 1);
 	assert_int_equal(rc, 0);
 
-	if (arg->async) {
-		/** for container destroy */
-		rc = daos_eq_poll(arg->eq, 1, DAOS_EQ_WAIT, 1, &evp);
-		assert_int_equal(rc, 1);
-		assert_ptr_equal(evp, &ev);
-		assert_int_equal(ev.ev_error, 0);
-
-		rc = daos_event_fini(&ev);
-		assert_int_equal(rc, 0);
-	}
 	print_message("success\n");
 }
 
@@ -125,7 +103,7 @@ setup_pools(void **state, daos_size_t npools)
 
 		/* Create the pool */
 		rc = test_setup_pool_create(state, NULL /* ipool */,
-				&lparg->tpools[i], NULL /* prop */);
+					    &lparg->tpools[i]);
 		if (rc != 0)
 			goto err_destroy_pools;
 	}
@@ -245,9 +223,9 @@ find_pool(void **state, daos_mgmt_pool_info_t *pool)
 }
 
 /* Verify pool info returned by DAOS API
- * rc_ret:	return code from daos_json_list_pool()
- * npools_in:	npools input argument to daos_json_list_pool()
- * npools_out:	npools output argument value after daos_json_list_pool()
+ * rc_ret:	return code from dmg_list_pool()
+ * npools_in:	npools input argument to dmg_list_pool()
+ * npools_out:	npools output argument value after dmg_list_pool()
  */
 static void
 verify_pool_info(void **state, int rc_ret, daos_size_t npools_in,
@@ -305,7 +283,7 @@ list_pools_test(void **state)
 	/***** Test: retrieve number of pools in system *****/
 	npools = npools_orig = 0xABC0; /* Junk value (e.g., uninitialized) */
 	/* test only */
-	rc = daos_json_list_pool(arg, &npools, NULL /* pools */);
+	rc = dmg_pool_list(dmg_config_file, arg->group, &npools, NULL);
 	assert_int_equal(rc, 0);
 	verify_pool_info(state, rc, npools_orig, NULL /* pools */, npools);
 	print_message("success t%d: output npools=%zu\n", tnum++,
@@ -320,7 +298,7 @@ list_pools_test(void **state)
 	 * and that many items in pools[] filled
 	 *****/
 	npools = npools_alloc;
-	rc = daos_json_list_pool(arg, &npools, pools);
+	rc = dmg_pool_list(dmg_config_file, arg->group, &npools, pools);
 	assert_int_equal(rc, 0);
 	verify_pool_info(state, rc, npools_alloc, pools, npools);
 	clean_pool_info(npools_alloc, pools);
@@ -328,8 +306,11 @@ list_pools_test(void **state)
 
 	/***** Test: provide npools=0, non-NULL pools  ****/
 	npools = 0;
-	rc = daos_json_list_pool(arg, &npools, pools);
-	assert_int_equal(rc, 0);
+	rc = dmg_pool_list(dmg_config_file, arg->group, &npools, pools);
+	if (lparg->nsyspools > 0)
+		assert_int_equal(rc, -DER_TRUNC);
+	else
+		assert_int_equal(rc, 0);
 	assert_int_equal(npools, lparg->nsyspools);
 	print_message("success t%d: npools=0, non-NULL pools[] rc=%d\n",
 		      tnum++, rc);
@@ -339,7 +320,7 @@ list_pools_test(void **state)
 	pools = NULL;
 
 	/***** Test: invalid npools=NULL *****/
-	rc = daos_json_list_pool(arg, NULL /* npools */, NULL /* pools */);
+	rc = dmg_pool_list(dmg_config_file, arg->group, NULL, NULL);
 	assert_int_equal(rc, -DER_INVAL);
 	print_message("success t%d: in &npools NULL, -DER_INVAL\n", tnum++);
 
@@ -354,7 +335,7 @@ list_pools_test(void **state)
 
 		/* Test: Exact size buffer */
 		npools = npools_alloc;
-		rc = daos_json_list_pool(arg, &npools, pools);
+		rc = dmg_pool_list(dmg_config_file, arg->group, &npools, pools);
 		assert_int_equal(rc, 0);
 		verify_pool_info(state, rc, npools_alloc, pools, npools);
 
@@ -371,7 +352,7 @@ list_pools_test(void **state)
 
 		/* Test: Under-sized buffer */
 		npools = npools_alloc;
-		rc = daos_json_list_pool(arg, &npools, pools);
+		rc = dmg_pool_list(dmg_config_file, arg->group, &npools, pools);
 		assert_int_equal(rc, -DER_TRUNC);
 		verify_pool_info(state, rc, npools_alloc, pools, npools);
 		print_message("success t%d: pools[] under-sized\n", tnum++);
@@ -402,11 +383,12 @@ pool_create_and_destroy_retry(void **state)
 	print_message("success\n");
 
 	print_message("creating pool synchronously ... ");
-	rc = daos_pool_create(0700 /* mode */, 0 /* uid */, 0 /* gid */,
-			      arg->group, NULL /* tgts */, "pmem" /* dev */,
-			      0 /* minimal size */, 0 /* nvme size */,
-			      NULL /* properties */, &arg->pool.svc /* svc */,
-			      uuid, NULL /* ev */);
+	rc = dmg_pool_create(dmg_config_file,
+			     geteuid(), getegid(),
+			     arg->group, NULL /* tgts */,
+			     128 * 1024 * 1024 /* minimal size */,
+			     0 /* nvme size */,
+			     &arg->pool.svc /* svc */, uuid);
 	assert_int_equal(rc, 0);
 	print_message("success uuid = "DF_UUIDF"\n", DP_UUID(uuid));
 
@@ -418,7 +400,7 @@ pool_create_and_destroy_retry(void **state)
 	print_message("success\n");
 
 	print_message("destroying pool synchronously ... ");
-	rc = daos_pool_destroy(uuid, arg->group, 1, NULL);
+	rc = dmg_pool_destroy(dmg_config_file, uuid, arg->group, 1);
 #if 0 /* see pool_create_cp */
 	assert_int_equal(rc, 0);
 #else

--- a/src/tests/suite/daos_obj.c
+++ b/src/tests/suite/daos_obj.c
@@ -3042,7 +3042,7 @@ tgt_idx_change_retry(void **state)
 		/** exclude target of the replica */
 		print_message("rank 0 excluding target rank %u ...\n", rank);
 		daos_exclude_server(arg->pool.pool_uuid, arg->group,
-				    arg->dmg_config, &arg->pool.svc, rank);
+				    arg->dmg_config, arg->pool.svc, rank);
 		assert_int_equal(rc, 0);
 
 		/** progress the async IO (not must) */
@@ -3099,7 +3099,7 @@ tgt_idx_change_retry(void **state)
 	if (arg->myrank == 0) {
 		print_message("rank 0 adding target rank %u ...\n", rank);
 		daos_add_server(arg->pool.pool_uuid, arg->group,
-				arg->dmg_config, &arg->pool.svc,
+				arg->dmg_config, arg->pool.svc,
 				rank);
 	}
 	MPI_Barrier(MPI_COMM_WORLD);
@@ -3137,7 +3137,7 @@ fetch_replica_unavail(void **state)
 	if (arg->myrank == 0) {
 		/** exclude the target of this obj's replicas */
 		daos_exclude_server(arg->pool.pool_uuid, arg->group,
-				    arg->dmg_config, &arg->pool.svc, rank);
+				    arg->dmg_config, arg->pool.svc, rank);
 	}
 	MPI_Barrier(MPI_COMM_WORLD);
 
@@ -3155,7 +3155,7 @@ fetch_replica_unavail(void **state)
 
 		/* add back the excluded targets */
 		daos_add_server(arg->pool.pool_uuid, arg->group,
-				arg->dmg_config, &arg->pool.svc,
+				arg->dmg_config, arg->pool.svc,
 				rank);
 
 		/* wait until reintegration is done */

--- a/src/tests/suite/daos_oid_alloc.c
+++ b/src/tests/suite/daos_oid_alloc.c
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2018 Intel Corporation.
+ * (C) Copyright 2018-2020 Intel Corporation.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -45,7 +45,7 @@ reconnect(test_arg_t *arg) {
 	flags = (DAOS_COO_RW | DAOS_COO_FORCE);
 	if (arg->myrank == 0) {
 		rc = daos_pool_connect(arg->pool.pool_uuid, arg->group,
-				       &arg->pool.svc, DAOS_PC_RW,
+				       arg->pool.svc, DAOS_PC_RW,
 				       &arg->pool.poh, &arg->pool.pool_info,
 				       NULL /* ev */);
 		if (rc)
@@ -258,7 +258,7 @@ oid_allocator_checker(void **state)
 					daos_kill_server(arg,
 						arg->pool.pool_uuid,
 						arg->group,
-						&arg->pool.svc, -1);
+						arg->pool.svc, -1);
 			}
 			MPI_Barrier(MPI_COMM_WORLD);
 		}

--- a/src/tests/suite/daos_pool.c
+++ b/src/tests/suite/daos_pool.c
@@ -667,10 +667,9 @@ setup_containers(void **state, daos_size_t nconts)
 	lcarg->tpool.svc.rl_ranks = lcarg->tpool.ranks;
 	lcarg->tpool.pool_size = 1 << 28;	/* 256MB SCM */
 	/* Create the pool */
-	rc = test_setup_pool_create(state, NULL /* ipool */, &lcarg->tpool,
-				    NULL /* prop */);
+	rc = test_setup_pool_create(state, NULL /* ipool */, &lcarg->tpool);
 	if (rc != 0) {
-		print_message("setup: daos_pool_create failed: %d\n", rc);
+		print_message("setup: pool creation failed: %d\n", rc);
 		goto err_free_lcarg;
 	}
 

--- a/src/tests/suite/daos_pool.c
+++ b/src/tests/suite/daos_pool.c
@@ -457,9 +457,11 @@ pool_properties(void **state)
 {
 	test_arg_t		*arg0 = *state;
 	test_arg_t		*arg = NULL;
+#if 0
 	char			*label = "test_pool_properties";
 	uint64_t		 space_rb = 36;
-	daos_prop_t		*prop;
+#endif
+	daos_prop_t		*prop = NULL;
 	daos_prop_t		*prop_query;
 	struct daos_prop_entry	*entry;
 	daos_pool_info_t	 info = {0};
@@ -472,11 +474,14 @@ pool_properties(void **state)
 			SMALL_POOL_SIZE, NULL);
 	assert_int_equal(rc, 0);
 
+/* FIXME (DAOS-5456): label/space_rb props not supported with dmg */
+#if 0
 	prop = daos_prop_alloc(2);
 	prop->dpp_entries[0].dpe_type = DAOS_PROP_PO_LABEL;
 	prop->dpp_entries[0].dpe_str = strdup(label);
 	prop->dpp_entries[1].dpe_type = DAOS_PROP_PO_SPACE_RB;
 	prop->dpp_entries[1].dpe_val = space_rb;
+#endif
 
 	while (!rc && arg->setup_state != SETUP_POOL_CONNECT)
 		rc = test_setup_next_step((void **)&arg, NULL, prop, NULL);
@@ -496,6 +501,7 @@ pool_properties(void **state)
 	assert_int_equal(rc, 0);
 
 	assert_int_equal(prop_query->dpp_nr, DAOS_PROP_PO_NUM);
+#if 0
 	/* set properties should get the value user set */
 	entry = daos_prop_entry_get(prop_query, DAOS_PROP_PO_LABEL);
 	if (entry == NULL || strcmp(entry->dpe_str, label) != 0) {
@@ -507,6 +513,7 @@ pool_properties(void **state)
 		print_message("space_rb verification filed.\n");
 		assert_int_equal(rc, 1); /* fail the test */
 	}
+#endif
 	/* not set properties should get default value */
 	entry = daos_prop_entry_get(prop_query, DAOS_PROP_PO_SELF_HEAL);
 	if (entry == NULL ||

--- a/src/tests/suite/daos_pool.c
+++ b/src/tests/suite/daos_pool.c
@@ -43,7 +43,7 @@ pool_connect_nonexist(void **state)
 		return;
 
 	uuid_generate(uuid);
-	rc = daos_pool_connect(uuid, arg->group, &arg->pool.svc, DAOS_PC_RW,
+	rc = daos_pool_connect(uuid, arg->group, arg->pool.svc, DAOS_PC_RW,
 			       &poh, NULL /* info */, NULL /* ev */);
 	assert_int_equal(rc, -DER_NONEXIST);
 }
@@ -71,7 +71,7 @@ pool_connect(void **state)
 		print_message("rank 0 connecting to pool %ssynchronously ... ",
 			      arg->async ? "a" : "");
 		rc = daos_pool_connect(arg->pool.pool_uuid, arg->group,
-				       &arg->pool.svc, DAOS_PC_RW, &poh, &info,
+				       arg->pool.svc, DAOS_PC_RW, &poh, &info,
 				       arg->async ? &ev : NULL /* ev */);
 		assert_int_equal(rc, 0);
 		WAIT_ON_ASYNC(arg, ev);
@@ -125,12 +125,12 @@ pool_connect_exclusively(void **state)
 	print_message("SUBTEST 1: other connections already exist; shall get "
 		      "%d\n", -DER_BUSY);
 	print_message("establishing a non-exclusive connection\n");
-	rc = daos_pool_connect(arg->pool.pool_uuid, arg->group, &arg->pool.svc,
+	rc = daos_pool_connect(arg->pool.pool_uuid, arg->group, arg->pool.svc,
 			       DAOS_PC_RW, &poh, NULL /* info */,
 			       NULL /* ev */);
 	assert_int_equal(rc, 0);
 	print_message("trying to establish an exclusive connection\n");
-	rc = daos_pool_connect(arg->pool.pool_uuid, arg->group, &arg->pool.svc,
+	rc = daos_pool_connect(arg->pool.pool_uuid, arg->group, arg->pool.svc,
 			       DAOS_PC_EX, &poh_ex, NULL /* info */,
 			       NULL /* ev */);
 	assert_int_equal(rc, -DER_BUSY);
@@ -140,7 +140,7 @@ pool_connect_exclusively(void **state)
 
 	print_message("SUBTEST 2: no other connections; shall succeed\n");
 	print_message("establishing an exclusive connection\n");
-	rc = daos_pool_connect(arg->pool.pool_uuid, arg->group, &arg->pool.svc,
+	rc = daos_pool_connect(arg->pool.pool_uuid, arg->group, arg->pool.svc,
 			       DAOS_PC_EX, &poh_ex, NULL /* info */,
 			       NULL /* ev */);
 	assert_int_equal(rc, 0);
@@ -148,7 +148,7 @@ pool_connect_exclusively(void **state)
 	print_message("SUBTEST 3: shall prevent other connections (%d)\n",
 		      -DER_BUSY);
 	print_message("trying to establish a non-exclusive connection\n");
-	rc = daos_pool_connect(arg->pool.pool_uuid, arg->group, &arg->pool.svc,
+	rc = daos_pool_connect(arg->pool.pool_uuid, arg->group, arg->pool.svc,
 			       DAOS_PC_RW, &poh, NULL /* info */,
 			       NULL /* ev */);
 	assert_int_equal(rc, -DER_BUSY);
@@ -188,7 +188,7 @@ pool_exclude(void **state)
 	/** connect to pool */
 	print_message("rank 0 connecting to pool %ssynchronously... ",
 		      arg->async ? "a" : "");
-	rc = daos_pool_connect(arg->pool.pool_uuid, arg->group, &arg->pool.svc,
+	rc = daos_pool_connect(arg->pool.pool_uuid, arg->group, arg->pool.svc,
 			       DAOS_PC_RW, &poh, &info,
 			       arg->async ? &ev : NULL /* ev */);
 	assert_int_equal(rc, 0);
@@ -196,16 +196,16 @@ pool_exclude(void **state)
 	print_message("success\n");
 
 	/** exclude last non-svc rank */
-	if (info.pi_nnodes - 1 /* rank 0 */ <= arg->pool.svc.rl_nr) {
+	if (info.pi_nnodes - 1 /* rank 0 */ <= arg->pool.svc->rl_nr) {
 		print_message("not enough non-svc targets; skipping\n");
 		goto disconnect;
 	}
 	rank = info.pi_nnodes - 1;
 	print_message("rank 0 excluding rank %u... ", rank);
-	for (idx = 0; idx < arg->pool.svc.rl_nr; idx++) {
+	for (idx = 0; idx < arg->pool.svc->rl_nr; idx++) {
 		daos_exclude_target(arg->pool.pool_uuid, arg->group,
-				    arg->dmg_config, &arg->pool.svc,
-				    arg->pool.svc.rl_ranks[idx], tgt);
+				    arg->dmg_config, arg->pool.svc,
+				    arg->pool.svc->rl_ranks[idx], tgt);
 	}
 	WAIT_ON_ASYNC(arg, ev);
 	print_message("success\n");
@@ -371,7 +371,7 @@ init_fini_conn(void **state)
 	assert_int_equal(rc, 0);
 
 	rc = daos_pool_connect(arg->pool.pool_uuid, arg->group,
-			       &arg->pool.svc, DAOS_PC_RW,
+			       arg->pool.svc, DAOS_PC_RW,
 			       &arg->pool.poh, &arg->pool.pool_info,
 			       NULL /* ev */);
 	if (rc)
@@ -580,7 +580,7 @@ pool_op_retry(void **state)
 
 	print_message("connecting to pool ... ");
 	rc = daos_pool_connect(arg->pool.pool_uuid, arg->group,
-			       &arg->pool.svc, DAOS_PC_RW, &poh, &info,
+			       arg->pool.svc, DAOS_PC_RW, &poh, &info,
 			       NULL /* ev */);
 	assert_int_equal(rc, 0);
 	assert_memory_equal(info.pi_uuid, arg->pool.pool_uuid,
@@ -654,6 +654,7 @@ setup_containers(void **state, daos_size_t nconts)
 	struct test_list_cont	*lcarg = NULL;
 	int			 i;
 	int			 rc = 0;
+	d_rank_list_t		tmp_list;
 
 	D_ALLOC_PTR(lcarg);
 	if (lcarg == NULL)
@@ -663,8 +664,9 @@ setup_containers(void **state, daos_size_t nconts)
 
 	/* Set some properties in the in/out tpool struct */
 	lcarg->tpool.poh = DAOS_HDL_INVAL;
-	lcarg->tpool.svc.rl_nr = svc_nreplicas;
-	lcarg->tpool.svc.rl_ranks = lcarg->tpool.ranks;
+	tmp_list.rl_nr = svc_nreplicas;
+	tmp_list.rl_ranks = lcarg->tpool.ranks;
+	d_rank_list_dup(&lcarg->tpool.svc, &tmp_list);
 	lcarg->tpool.pool_size = 1 << 28;	/* 256MB SCM */
 	/* Create the pool */
 	rc = test_setup_pool_create(state, NULL /* ipool */, &lcarg->tpool,
@@ -677,7 +679,7 @@ setup_containers(void **state, daos_size_t nconts)
 	/* TODO: make test_setup_pool_connect() more generic, call here */
 	if (arg->myrank == 0) {
 		rc = daos_pool_connect(lcarg->tpool.pool_uuid, arg->group,
-				       &lcarg->tpool.svc, DAOS_PC_RW,
+				       lcarg->tpool.svc, DAOS_PC_RW,
 				       &lcarg->tpool.poh, NULL /* pool info */,
 				       NULL /* ev */);
 		if (rc != 0)
@@ -753,6 +755,8 @@ err_destroy_pool:
 		pool_destroy_safe(arg, &lcarg->tpool);
 
 err_free_lcarg:
+	if (lcarg->tpool.svc)
+		d_rank_list_free(lcarg->tpool.svc);
 	D_FREE(lcarg);
 
 err:

--- a/src/tests/suite/daos_pool.c
+++ b/src/tests/suite/daos_pool.c
@@ -667,7 +667,8 @@ setup_containers(void **state, daos_size_t nconts)
 	lcarg->tpool.svc.rl_ranks = lcarg->tpool.ranks;
 	lcarg->tpool.pool_size = 1 << 28;	/* 256MB SCM */
 	/* Create the pool */
-	rc = test_setup_pool_create(state, NULL /* ipool */, &lcarg->tpool);
+	rc = test_setup_pool_create(state, NULL /* ipool */, &lcarg->tpool,
+				    NULL /* prop */);
 	if (rc != 0) {
 		print_message("setup: pool creation failed: %d\n", rc);
 		goto err_free_lcarg;

--- a/src/tests/suite/daos_rebuild.c
+++ b/src/tests/suite/daos_rebuild.c
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2016-2019 Intel Corporation.
+ * (C) Copyright 2016-2020 Intel Corporation.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -766,7 +766,7 @@ rebuild_master_change_during_scan(void **state)
 	daos_obj_id_t	oids[OBJ_NR];
 	int		i;
 
-	if (!test_runable(arg, 6) || arg->pool.alive_svc.rl_nr == 1)
+	if (!test_runable(arg, 6) || arg->pool.alive_svc->rl_nr == 1)
 		return;
 
 	for (i = 0; i < OBJ_NR; i++) {
@@ -796,7 +796,7 @@ rebuild_master_change_during_rebuild(void **state)
 	daos_obj_id_t	oids[OBJ_NR];
 	int		i;
 
-	if (!test_runable(arg, 6) || arg->pool.alive_svc.rl_nr == 1)
+	if (!test_runable(arg, 6) || arg->pool.alive_svc->rl_nr == 1)
 		return;
 
 	for (i = 0; i < OBJ_NR; i++) {
@@ -914,7 +914,7 @@ rebuild_multiple_tgts(void **state)
 				daos_exclude_server(arg->pool.pool_uuid,
 						    arg->group,
 						    arg->dmg_config,
-						    &arg->pool.svc,
+						    arg->pool.svc,
 						    rank);
 				if (++fail_cnt >= 2)
 					break;
@@ -940,7 +940,7 @@ rebuild_multiple_tgts(void **state)
 	if (arg->myrank == 0) {
 		for (i = 0; i < 2; i++)
 			daos_add_server(arg->pool.pool_uuid, arg->group,
-					arg->dmg_config, &arg->pool.svc,
+					arg->dmg_config, arg->pool.svc,
 					exclude_ranks[i]);
 	}
 	MPI_Barrier(MPI_COMM_WORLD);
@@ -983,7 +983,7 @@ rebuild_master_failure(void **state)
 	int			rc;
 
 	/* need 5 svc replicas, as will kill the leader 2 times */
-	if (!test_runable(arg, 6) || arg->pool.alive_svc.rl_nr < 5) {
+	if (!test_runable(arg, 6) || arg->pool.alive_svc->rl_nr < 5) {
 		print_message("testing skipped ...\n");
 		return;
 	}
@@ -1092,7 +1092,7 @@ rebuild_fail_all_replicas_before_rebuild(void **state)
 	struct daos_obj_layout *layout;
 	struct daos_obj_shard *shard;
 
-	if (!test_runable(arg, 6) || arg->pool.alive_svc.rl_nr < 3)
+	if (!test_runable(arg, 6) || arg->pool.alive_svc->rl_nr < 3)
 		return;
 
 	oid = dts_oid_gen(DAOS_OC_R2S_SPEC_RANK, 0, arg->myrank);
@@ -1109,7 +1109,7 @@ rebuild_fail_all_replicas_before_rebuild(void **state)
 	/* Kill one replica and start rebuild */
 	shard = layout->ol_shards[0];
 	daos_kill_server(arg, arg->pool.pool_uuid, arg->group,
-			 &arg->pool.alive_svc, shard->os_ranks[0]);
+			 arg->pool.alive_svc, shard->os_ranks[0]);
 
 	/* Sleep 10 seconds after it scan finish and hang before rebuild */
 	print_message("sleep 10 seconds to wait scan to be finished \n");
@@ -1117,7 +1117,7 @@ rebuild_fail_all_replicas_before_rebuild(void **state)
 
 	/* Then kill rank 1 */
 	daos_kill_server(arg, arg->pool.pool_uuid, arg->group,
-			 &arg->pool.alive_svc, shard->os_ranks[1]);
+			 arg->pool.alive_svc, shard->os_ranks[1]);
 
 	/* Continue rebuild */
 	daos_mgmt_set_params(arg->group, -1, DMG_KEY_FAIL_LOC, 0, 0, NULL);
@@ -1145,7 +1145,7 @@ rebuild_fail_all_replicas(void **state)
 	 * in svcs, so make sure there are at least 6 ranks in svc, so
 	 * the new leader can be chosen.
 	 */
-	if (!test_runable(arg, 6) || arg->pool.alive_svc.rl_nr < 6) {
+	if (!test_runable(arg, 6) || arg->pool.alive_svc->rl_nr < 6) {
 		print_message("need at least 6 svcs, -s5\n");
 		return;
 	}
@@ -1164,7 +1164,7 @@ rebuild_fail_all_replicas(void **state)
 			d_rank_t rank = layout->ol_shards[i]->os_ranks[j];
 
 			daos_kill_server(arg, arg->pool.pool_uuid,
-					 arg->group, &arg->pool.alive_svc,
+					 arg->group, arg->pool.alive_svc,
 					 rank);
 		}
 	}

--- a/src/tests/suite/daos_rebuild_common.c
+++ b/src/tests/suite/daos_rebuild_common.c
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2016-2019 Intel Corporation.
+ * (C) Copyright 2016-2020 Intel Corporation.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -53,7 +53,7 @@ rebuild_exclude_tgt(test_arg_t **args, int arg_cnt, d_rank_t rank,
 
 	if (kill) {
 		daos_kill_server(args[0], args[0]->pool.pool_uuid,
-				 args[0]->group, &args[0]->pool.alive_svc,
+				 args[0]->group, args[0]->pool.alive_svc,
 				 rank);
 		print_message("sleep 120 seconds for rebuild to start\n");
 		sleep(120);
@@ -67,7 +67,7 @@ rebuild_exclude_tgt(test_arg_t **args, int arg_cnt, d_rank_t rank,
 	for (i = 0; i < arg_cnt; i++) {
 		daos_exclude_target(args[i]->pool.pool_uuid,
 				    args[i]->group, args[i]->dmg_config,
-				    &args[i]->pool.svc,
+				    args[i]->pool.svc,
 				    rank, tgt_idx);
 		sleep(2);
 	}
@@ -84,7 +84,7 @@ rebuild_add_tgt(test_arg_t **args, int args_cnt, d_rank_t rank,
 			daos_add_target(args[i]->pool.pool_uuid,
 					args[i]->group,
 					args[i]->dmg_config,
-					&args[i]->pool.svc,
+					args[i]->pool.svc,
 					rank, tgt_idx);
 		sleep(2);
 	}
@@ -101,7 +101,7 @@ rebuild_drain_tgt(test_arg_t **args, int args_cnt, d_rank_t rank,
 			daos_drain_target(args[i]->pool.pool_uuid,
 					args[i]->group,
 					args[i]->dmg_config,
-					&args[i]->pool.svc,
+					args[i]->pool.svc,
 					rank, tgt_idx);
 		sleep(2);
 	}
@@ -247,9 +247,9 @@ rebuild_pool_connect_internal(void *data)
 	MPI_Barrier(MPI_COMM_WORLD);
 	if (arg->myrank == 0) {
 		rc = daos_pool_connect(arg->pool.pool_uuid, arg->group,
-			&arg->pool.svc, DAOS_PC_RW,
-			&arg->pool.poh, &arg->pool.pool_info,
-			NULL /* ev */);
+				       arg->pool.svc, DAOS_PC_RW,
+				       &arg->pool.poh, &arg->pool.pool_info,
+				       NULL /* ev */);
 		if (rc)
 			print_message("daos_pool_connect failed, rc: %d\n", rc);
 
@@ -367,7 +367,7 @@ rebuild_add_back_tgts(test_arg_t *arg, d_rank_t failed_rank, int *failed_tgts,
 
 		for (i = 0; i < nr; i++)
 			daos_add_target(arg->pool.pool_uuid, arg->group,
-					arg->dmg_config, &arg->pool.svc,
+					arg->dmg_config, arg->pool.svc,
 					failed_rank,
 					failed_tgts ? failed_tgts[i] : -1);
 	}

--- a/src/tests/suite/daos_test.h
+++ b/src/tests/suite/daos_test.h
@@ -224,7 +224,7 @@ test_setup_next_step(void **state, struct test_pool *pool, daos_prop_t *po_prop,
 		     daos_prop_t *co_prop);
 int
 test_setup_pool_create(void **state, struct test_pool *ipool,
-		       struct test_pool *opool);
+		       struct test_pool *opool, daos_prop_t *prop);
 int
 pool_destroy_safe(test_arg_t *arg, struct test_pool *extpool);
 

--- a/src/tests/suite/daos_test.h
+++ b/src/tests/suite/daos_test.h
@@ -224,7 +224,7 @@ test_setup_next_step(void **state, struct test_pool *pool, daos_prop_t *po_prop,
 		     daos_prop_t *co_prop);
 int
 test_setup_pool_create(void **state, struct test_pool *ipool,
-		       struct test_pool *opool, daos_prop_t *prop);
+		       struct test_pool *opool);
 int
 pool_destroy_safe(test_arg_t *arg, struct test_pool *extpool);
 
@@ -382,9 +382,6 @@ int rebuild_sub_setup(void **state);
 int rebuild_sub_teardown(void **state);
 int rebuild_small_sub_setup(void **state);
 
-/* dmg cmd json output parser APIs */
-int daos_json_list_pool(test_arg_t *arg, daos_size_t *npools,
-			daos_mgmt_pool_info_t *pools);
 static inline void
 daos_test_print(int rank, char *message)
 {

--- a/src/tests/suite/daos_test.h
+++ b/src/tests/suite/daos_test.h
@@ -100,12 +100,12 @@ struct test_pool {
 	/* Updated if some ranks are killed during degraged or rebuild
 	 * test, so we know whether some tests is allowed to be run.
 	 */
-	d_rank_list_t		alive_svc;
+	d_rank_list_t		*alive_svc;
 	/* Used for all pool related operation, since client will
 	 * use this rank list to find out the real leader, so it
 	 * can not be changed.
 	 */
-	d_rank_list_t		svc;
+	d_rank_list_t		*svc;
 	/* flag of slave that share the pool of other test_arg_t */
 	bool			slave;
 	bool			destroyed;

--- a/src/tests/suite/daos_test_common.c
+++ b/src/tests/suite/daos_test_common.c
@@ -31,7 +31,6 @@
 #include <daos_prop.h>
 #include <daos_mgmt.h>
 #include "daos_test.h"
-#include <json-c/json.h>
 
 /** Server crt group ID */
 const char *server_group;
@@ -58,7 +57,7 @@ int		dt_obj_class;
  */
 int
 test_setup_pool_create(void **state, struct test_pool *ipool,
-	struct test_pool *opool, daos_prop_t *prop)
+		       struct test_pool *opool)
 {
 	test_arg_t		*arg = *state;
 	struct test_pool	*outpool;
@@ -95,12 +94,12 @@ test_setup_pool_create(void **state, struct test_pool *ipool,
 		}
 
 		/*
-		 * Set the default NVMe partition size to "2 * scm_size", so
+		 * Set the default NVMe partition size to "4 * scm_size", so
 		 * that we need to specify SCM size only for each test case.
 		 *
 		 * Set env POOL_NVME_SIZE to overwrite the default NVMe size.
 		 */
-		nvme_size = outpool->pool_size * 2;
+		nvme_size = outpool->pool_size * 4;
 		env = getenv("POOL_NVME_SIZE");
 		if (env) {
 			size_gb = atoi(env);
@@ -110,12 +109,12 @@ test_setup_pool_create(void **state, struct test_pool *ipool,
 		print_message("setup: creating pool, SCM size="DF_U64" GB, "
 			      "NVMe size="DF_U64" GB\n",
 			      (outpool->pool_size >> 30), nvme_size >> 30);
-		rc = daos_pool_create(0, arg->uid, arg->gid, arg->group,
-				      NULL, "pmem", outpool->pool_size,
-				      nvme_size, prop, &outpool->svc,
-				      outpool->pool_uuid, NULL);
+		rc = dmg_pool_create(dmg_config_file,
+				     arg->uid, arg->gid, arg->group,
+				     NULL, outpool->pool_size, nvme_size,
+				     &outpool->svc, outpool->pool_uuid);
 		if (rc)
-			print_message("daos_pool_create failed, rc: %d\n", rc);
+			print_message("dmg_pool_create failed, rc: %d\n", rc);
 		else
 			print_message("setup: created pool "DF_UUIDF"\n",
 				       DP_UUID(outpool->pool_uuid));
@@ -263,8 +262,7 @@ test_setup_next_step(void **state, struct test_pool *pool, daos_prop_t *po_prop,
 		return daos_eq_create(&arg->eq);
 	case SETUP_EQ:
 		arg->setup_state = SETUP_POOL_CREATE;
-		return test_setup_pool_create(state, pool, NULL /*opool */,
-					      po_prop);
+		return test_setup_pool_create(state, pool, NULL /*opool */);
 	case SETUP_POOL_CREATE:
 		arg->setup_state = SETUP_POOL_CONNECT;
 		return test_setup_pool_connect(state, pool);
@@ -418,9 +416,10 @@ pool_destroy_safe(test_arg_t *arg, struct test_pool *extpool)
 
 	daos_pool_disconnect(poh, NULL);
 
-	rc = daos_pool_destroy(pool->pool_uuid, arg->group, 1, NULL);
+	rc = dmg_pool_destroy(dmg_config_file,
+			      pool->pool_uuid, arg->group, 1);
 	if (rc && rc != -DER_TIMEDOUT)
-		print_message("daos_pool_destroy failed, rc: %d\n", rc);
+		print_message("dmg_pool_destroy failed, rc: %d\n", rc);
 	if (rc == 0)
 		print_message("teardown: destroyed pool "DF_UUIDF"\n",
 			      DP_UUID(pool->pool_uuid));
@@ -1020,134 +1019,4 @@ get_daos_prop_with_user_acl_perms(uint64_t perms)
 	daos_acl_free(acl);
 	D_FREE(user);
 	return prop;
-}
-
-/* JSON output handling for dmg command */
-static int
-daos_dmg_json_contents(const char *dmg_cmd, const char *filename,
-		       struct json_object **parsed_json)
-{
-	long	int size = 0;
-	char	*content = NULL;
-	char	system_cmd[DTS_CFG_MAX];
-	int	rc = 0;
-	FILE	*fp;
-
-	fp = fopen(filename, "w+");
-	if (!fp) {
-		print_message("fopen %s failed!\n", filename);
-		return -DER_IO;
-	}
-
-	dts_create_config(system_cmd, "%s > %s", dmg_cmd, filename);
-	rc = system(system_cmd);
-	assert_int_equal(rc, 0);
-
-	/* get the content size and allocate buffer */
-	fseek(fp, 0, SEEK_END);
-	size = ftell(fp);
-	fseek(fp, 0, SEEK_SET);
-	D_ALLOC(content, size);
-
-	if (fread(content, size, 1, fp) != 1) {
-		print_message("failed to read content of %s\n", filename);
-		D_GOTO(out, rc = -DER_IO);
-	}
-
-	if (parsed_json == NULL)
-		D_GOTO(out, rc = -DER_IO);
-
-	*parsed_json = json_tokener_parse(content);
-
-out:
-	fclose(fp);
-	rc = unlink(filename);
-	if (rc != 0)
-		D_ERROR("unlink %s failed, rc %d", filename, rc);
-	D_FREE(content);
-	return rc;
-}
-
-int daos_json_list_pool(test_arg_t *arg, daos_size_t *npools,
-			daos_mgmt_pool_info_t *pools)
-{
-	struct json_object	*parsed_json = NULL;
-	struct json_object	*response;
-	struct json_object	*pool_list;
-	struct json_object	*pool;
-	struct json_object	*uuid;
-	struct json_object	*rep_ranks;
-	struct json_object	*rank;
-	daos_size_t		npools_in;
-	char			uuid_str[DAOS_UUID_STR_SIZE];
-	char			filename[DTS_CFG_MAX];
-	char			dmg_cmd[DTS_CFG_MAX];
-	int			i, j;
-	int			rl_nr;
-	int			rc = 0;
-
-	if (npools == NULL)
-		return -DER_INVAL;
-	npools_in = *npools;
-
-	dts_create_config(filename, "/tmp/dmg_pool_list_%d.json",
-			  (uint8_t)rand());
-
-	dts_create_config(dmg_cmd, "dmg pool list -i -j");
-	if (arg->dmg_config != NULL)
-		dts_append_config(dmg_cmd, " -o %s", arg->dmg_config);
-
-	rc = daos_dmg_json_contents(dmg_cmd, filename, &parsed_json);
-	if (rc != 0) {
-		print_message("daos_dmg_json_contents failed\n");
-		return -DER_INVAL;
-	}
-
-	if (!json_object_object_get_ex(parsed_json, "response", &response))
-		D_GOTO(out, rc = -DER_INVAL);
-
-	if (!json_object_object_get_ex(response, "Pools", &pool_list))
-		D_GOTO(out, rc = -DER_INVAL);
-
-	if (pool_list == NULL)
-		*npools = 0;
-	else
-		*npools = json_object_array_length(pool_list);
-
-	if (pools == NULL) {
-		/* no need to fill up a NULL pools buffer */
-		goto out;
-	} else if (npools_in && (npools_in < *npools)) {
-		/* For non-NULL pools, the allocated non-zero buffer size is
-		 * not sufficient
-		 */
-		D_GOTO(out, rc = -DER_TRUNC);
-	}
-
-	for (i = 0; i < *npools; i++) {
-		pool = json_object_array_get_idx(pool_list, i);
-		json_object_object_get_ex(pool, "UUID", &uuid);
-		strcpy(uuid_str, json_object_get_string(uuid));
-		uuid_parse(uuid_str, pools[i].mgpi_uuid);
-		/* pool service replica ranks */
-		json_object_object_get_ex(pool, "Svcreps", &rep_ranks);
-		rl_nr = json_object_array_length(rep_ranks);
-		if (pools[i].mgpi_svc == NULL)
-			pools[i].mgpi_svc = d_rank_list_alloc(rl_nr);
-		print_message("pool uuid "DF_UUIDF" rl_nr %d\n",
-			      DP_UUID(pools[i].mgpi_uuid),
-			      pools[i].mgpi_svc->rl_nr);
-
-		for (j = 0; j < pools[i].mgpi_svc->rl_nr; j++) {
-			rank = json_object_array_get_idx(rep_ranks, j);
-			pools[i].mgpi_svc->rl_ranks[j] =
-				json_object_get_int(rank);
-			print_message("rl_ranks = %d\n",
-				      pools[i].mgpi_svc->rl_ranks[j]);
-		}
-	}
-
-out:
-	json_object_put(parsed_json);
-	return rc;
 }

--- a/src/tests/suite/daos_test_common.c
+++ b/src/tests/suite/daos_test_common.c
@@ -57,7 +57,7 @@ int		dt_obj_class;
  */
 int
 test_setup_pool_create(void **state, struct test_pool *ipool,
-		       struct test_pool *opool)
+		       struct test_pool *opool, daos_prop_t *prop)
 {
 	test_arg_t		*arg = *state;
 	struct test_pool	*outpool;
@@ -112,7 +112,7 @@ test_setup_pool_create(void **state, struct test_pool *ipool,
 		rc = dmg_pool_create(dmg_config_file,
 				     arg->uid, arg->gid, arg->group,
 				     NULL, outpool->pool_size, nvme_size,
-				     &outpool->svc, outpool->pool_uuid);
+				     prop, &outpool->svc, outpool->pool_uuid);
 		if (rc)
 			print_message("dmg_pool_create failed, rc: %d\n", rc);
 		else
@@ -262,7 +262,8 @@ test_setup_next_step(void **state, struct test_pool *pool, daos_prop_t *po_prop,
 		return daos_eq_create(&arg->eq);
 	case SETUP_EQ:
 		arg->setup_state = SETUP_POOL_CREATE;
-		return test_setup_pool_create(state, pool, NULL /*opool */);
+		return test_setup_pool_create(state, pool,
+					      NULL /*opool */, po_prop);
 	case SETUP_POOL_CREATE:
 		arg->setup_state = SETUP_POOL_CONNECT;
 		return test_setup_pool_connect(state, pool);


### PR DESCRIPTION
These helpers use dmg to perform pool management functions, and replace the
following mgmt API methods:
  * daos_pool_create()
  * daos_pool_destroy()
  * daos_pool_list()

Additional improvements:
  * Add a retry on pool create for -DER_TIMEDOUT
  * Allow dmg callers to retrieve DaosStatus via JSON, when available

Test updates:
  * Disable secure mode for zero_config test for now, due to daos_racer
    running on a node without admin certificates