### PR TITLE
DAOS-5078 control: Remove hard-coded limit on ioserver count

### DIFF
--- a/src/control/lib/netdetect/netdetect.go
+++ b/src/control/lib/netdetect/netdetect.go
@@ -266,6 +266,15 @@ func HasNUMA(ctx context.Context) bool {
 	return ndc.numaAware
 }
 
+// NumNumaNodes returns the number of detected NUMA nodes, or 0 if none.
+func NumNumaNodes(ctx context.Context) int {
+	ndc, err := getContext(ctx)
+	if err != nil || !HasNUMA(ctx) {
+		return 0
+	}
+	return ndc.numNUMANodes
+}
+
 // Cleanup releases the hwloc topology resources
 func CleanUp(ctx context.Context) {
 	ndc, err := getContext(ctx)

--- a/src/control/server/harness.go
+++ b/src/control/server/harness.go
@@ -54,7 +54,7 @@ type IOServerHarness struct {
 func NewIOServerHarness(log logging.Logger) *IOServerHarness {
 	return &IOServerHarness{
 		log:              log,
-		instances:        make([]*IOServerInstance, 0, maxIOServers),
+		instances:        make([]*IOServerInstance, 0),
 		started:          atm.NewBool(false),
 		rankReqTimeout:   defaultRequestTimeout,
 		rankStartTimeout: defaultStartTimeout,
@@ -83,7 +83,7 @@ func (h *IOServerHarness) FilterInstancesByRankSet(ranks string) ([]*IOServerIns
 	if err != nil {
 		return nil, err
 	}
-	out := make([]*IOServerInstance, 0, maxIOServers)
+	out := make([]*IOServerInstance, 0)
 
 	for _, i := range h.instances {
 		r, err := i.GetRank()
@@ -204,7 +204,7 @@ func (h *IOServerHarness) readyRanks() []system.Rank {
 	h.RLock()
 	defer h.RUnlock()
 
-	ranks := make([]system.Rank, 0, maxIOServers)
+	ranks := make([]system.Rank, 0)
 	for _, srv := range h.instances {
 		if srv.hasSuperblock() && srv.isReady() {
 			ranks = append(ranks, *srv.getSuperblock().Rank)

--- a/src/control/server/harness_test.go
+++ b/src/control/server/harness_test.go
@@ -53,6 +53,7 @@ const (
 	testShortTimeout   = 50 * time.Millisecond
 	testLongTimeout    = 1 * time.Minute
 	delayedFailTimeout = 20 * testShortTimeout
+	maxIOServers       = 2
 )
 
 func TestServer_HarnessGetMSLeaderInstance(t *testing.T) {

--- a/src/control/server/server.go
+++ b/src/control/server/server.go
@@ -55,8 +55,6 @@ const (
 	ControlPlaneName = "DAOS Control Server"
 	// DataPlaneName defines a consistent name for the ioserver.
 	DataPlaneName = "DAOS I/O Server"
-	// define supported maximum number of I/O servers
-	maxIOServers = 2
 
 	iommuPath        = "/sys/class/iommu"
 	minHugePageCount = 128
@@ -187,11 +185,14 @@ func Start(log *logging.LeveledLogger, cfg *Configuration) error {
 	}
 	defer netdetect.CleanUp(netCtx)
 
-	for i, srvCfg := range cfg.Servers {
-		if i+1 > maxIOServers {
-			break
-		}
+	// On a NUMA-aware system, emit a message when the configuration
+	// may be sub-optimal.
+	numaCount := netdetect.NumNumaNodes(netCtx)
+	if numaCount > 0 && len(cfg.Servers) > numaCount {
+		log.Infof("NOTICE: Detected %d NUMA node(s); %d-server config may not perform as expected", numaCount, len(cfg.Servers))
+	}
 
+	for i, srvCfg := range cfg.Servers {
 		// Provide special handling for the ofi+verbs provider.
 		// Mercury uses the interface name such as ib0, while OFI uses the device name such as hfi1_0
 		// CaRT and Mercury will now support the new OFI_DOMAIN environment variable so that we can


### PR DESCRIPTION
Testing on Frontera and other systems has shown that DAOS is
capable of running > 2 ioservers per node, so there doesn't
seem to be a reason for maintaining a hard-coded limit.

Instead, check for the number of NUMA nodes available and emit
a message if the configuration has more servers than nodes.