### PR TITLE
Add new struct to encapsulate read timestamps and ids.  This is a step

### DIFF
--- a/src/vos/vos_io.c
+++ b/src/vos/vos_io.c
@@ -511,7 +511,7 @@ vos_ioc_create(daos_handle_t coh, daos_unit_oid_t oid, bool read_only,
 
 	rc = vos_ts_set_allocate(&ioc->ic_ts_set, cond_flags, cflags, iod_nr,
 				 dtx_is_valid_handle(dth) ?
-				 &dth->dth_xid.dti_uuid : NULL);
+				 &dth->dth_xid : NULL);
 	if (rc != 0)
 		goto error;
 

--- a/src/vos/vos_obj.c
+++ b/src/vos/vos_obj.c
@@ -208,7 +208,7 @@ vos_obj_punch(daos_handle_t coh, daos_unit_oid_t oid, daos_epoch_t epoch,
 
 	rc = vos_ts_set_allocate(&ts_set, flags, cflags, akey_nr,
 				 dtx_is_valid_handle(dth) ?
-				 &dth->dth_xid.dti_uuid : NULL);
+				 &dth->dth_xid : NULL);
 	if (rc != 0)
 		goto reset;
 


### PR DESCRIPTION
toward making negative entries part of the corresponding positive entry
rather than their own timestamp cache.

Signed-off-by: Jeff Olivier <jeffrey.v.olivier@intel.com>