### PR TITLE
DAOS-6489 misc: Correct DER_ error code misuse.

### DIFF
--- a/src/cart/src/cart/crt_self_test_client.c
+++ b/src/cart/src/cart/crt_self_test_client.c
@@ -467,7 +467,7 @@ send_rpc:
 
 			/* Free the RPC request that was created but not sent */
 			RPC_PUB_DECREF(new_rpc);
-			D_GOTO(abort, ret = -DER_UNKNOWN);
+			D_GOTO(abort, ret = -DER_MISC);
 		}
 
 		/* Send the RPC */

--- a/src/cart/src/test/tests_common.h
+++ b/src/cart/src/test/tests_common.h
@@ -306,7 +306,7 @@ tc_load_group_from_file(const char *grp_cfg_file,
 	f = fopen(grp_cfg_file, "r");
 	if (!f) {
 		D_ERROR("Failed to open %s for reading\n", grp_cfg_file);
-		D_GOTO(out, rc = DER_NONEXIST);
+		D_GOTO(out, rc = -DER_NONEXIST);
 	}
 
 	while (1) {

--- a/src/common/mem.c
+++ b/src/common/mem.c
@@ -372,7 +372,7 @@ umem_tx_errno(int err)
 
 	if (err == 0) {
 		D_ERROR("Transaction aborted for unknown reason\n");
-		return -DER_UNKNOWN;
+		return -DER_MISC;
 	}
 
 	if (err < 0) {

--- a/src/iosrv/README.md
+++ b/src/iosrv/README.md
@@ -48,7 +48,7 @@ The server loop runs in its own User-Level Thread (ULT) in xstream 0. The dRPC s
     2. If the client has disconnected or the connection has been broken: Free the `struct drpc` object and remove it from the `drpc_progress_context`.
 3. If any activity is seen on the listener:
     1. If a new connection has come in: Call `drpc_accept` and add the new `struct drpc` object to the client connection list in the `drpc_progress_context`.
-    2. If there was an error: Return `-DER_UNKNOWN` to the caller. This causes an error to be logged in the I/O server, but does not interrupt the dRPC server loop. Getting an error on the listener is unexpected.
+    2. If there was an error: Return `-DER_MISC` to the caller. This causes an error to be logged in the I/O server, but does not interrupt the dRPC server loop. Getting an error on the listener is unexpected.
 4. If no activity was seen, return `-DER_TIMEDOUT` to the caller. This is purely for debugging purposes. In practice the I/O server ignores this error code, since lack of activity is not actually an error case.
 
 ### dRPC Handler Registration

--- a/src/iosrv/drpc_internal.h
+++ b/src/iosrv/drpc_internal.h
@@ -104,7 +104,7 @@ void drpc_progress_context_close(struct drpc_progress_context *ctx);
  *		-DER_TIMEDOUT		No activity
  *		-DER_AGAIN		Couldn't process activity, try again
  *		-DER_NOMEM		Out of memory
- *		-DER_UNKNOWN		Unexpected error
+ *		-DER_MISC		Unexpected error
  */
 int drpc_progress(struct drpc_progress_context *ctx, int timeout);
 

--- a/src/iosrv/drpc_listener.c
+++ b/src/iosrv/drpc_listener.c
@@ -116,7 +116,7 @@ setup_listener_ctx(struct drpc_progress_context **new_ctx)
 	if (listener == NULL) {
 		D_ERROR("Failed to create listener socket at '%s'\n",
 			sockpath);
-		return -DER_UNKNOWN;
+		return -DER_MISC;
 	}
 
 	*new_ctx = drpc_progress_context_create(listener);

--- a/src/iosrv/drpc_progress.c
+++ b/src/iosrv/drpc_progress.c
@@ -219,7 +219,7 @@ drpc_progress_context_accept(struct drpc_progress_context *ctx)
 		 * Any failure to accept is weird and surprising
 		 */
 		D_ERROR("Failed to accept new drpc connection\n");
-		return -DER_UNKNOWN;
+		return -DER_MISC;
 	}
 
 	D_ALLOC_PTR(session_node);
@@ -255,7 +255,7 @@ process_listener_activity(struct drpc_progress_context *ctx,
 		/* Unexpected - don't do anything */
 		D_INFO("Ignoring surprising listener activity: %u\n",
 		       listener_comm->activity);
-		rc = -DER_UNKNOWN;
+		rc = -DER_MISC;
 		break;
 
 	default:

--- a/src/iosrv/tests/drpc_listener_tests.c
+++ b/src/iosrv/tests/drpc_listener_tests.c
@@ -185,7 +185,7 @@ test_drpc_listener_init_cant_create_socket(void **state)
 {
 	socket_return = -1; /* Make the drpc_listen call fail */
 
-	assert_int_equal(drpc_listener_init(), -DER_UNKNOWN);
+	assert_int_equal(drpc_listener_init(), -DER_MISC);
 }
 
 static void

--- a/src/iosrv/tests/drpc_progress_tests.c
+++ b/src/iosrv/tests/drpc_progress_tests.c
@@ -388,7 +388,7 @@ test_drpc_progress_listener_accept_failed(void **state)
 	accept_return = -1;
 
 	/* No clear reason why accept would fail if we got data on it */
-	assert_int_equal(drpc_progress(&ctx, 100), -DER_UNKNOWN);
+	assert_int_equal(drpc_progress(&ctx, 100), -DER_MISC);
 
 	cleanup_drpc_progress_context(&ctx);
 }
@@ -651,7 +651,7 @@ test_drpc_progress_session_cleanup_if_ult_fails(void **state)
 
 	poll_revents_return[num_sessions] = POLLIN; /* listener */
 
-	dss_ult_create_return = -DER_UNKNOWN;
+	dss_ult_create_return = -DER_MISC;
 
 	/* the error was handled by closing the sessions */
 	assert_int_equal(drpc_progress(&ctx, 1), DER_SUCCESS);
@@ -687,7 +687,7 @@ test_drpc_progress_listener_fails_if_pollerr(void **state)
 	/* Listener has an error */
 	poll_revents_return[num_sessions] = POLLERR;
 
-	assert_int_equal(drpc_progress(&ctx, 1), -DER_UNKNOWN);
+	assert_int_equal(drpc_progress(&ctx, 1), -DER_MISC);
 
 	/* Tried all the sessions with data */
 	assert_int_equal(recvmsg_call_count, num_sessions);
@@ -720,7 +720,7 @@ test_drpc_progress_listener_fails_if_pollhup(void **state)
 	/* Unexpected event, in theory listener shouldn't get hangup */
 	poll_revents_return[num_sessions] = POLLIN | POLLHUP;
 
-	assert_int_equal(drpc_progress(&ctx, 1), -DER_UNKNOWN);
+	assert_int_equal(drpc_progress(&ctx, 1), -DER_MISC);
 
 	/* Tried all the sessions with data */
 	assert_int_equal(recvmsg_call_count, num_sessions);

--- a/src/mgmt/cli_mgmt.c
+++ b/src/mgmt/cli_mgmt.c
@@ -74,7 +74,7 @@ dc_mgmt_svc_rip(tse_task_t *task)
 	if (rc != 0) {
 		D_ERROR("failed to attach to grp %s, rc "DF_RC".\n",
 			args->grp, DP_RC(rc));
-		rc = DER_INVAL;
+		rc = -DER_INVAL;
 		goto out_task;
 	}
 

--- a/src/mgmt/srv_drpc.c
+++ b/src/mgmt/srv_drpc.c
@@ -1362,7 +1362,7 @@ ds_mgmt_drpc_list_pools(Drpc__Call *drpc_req, Drpc__Response *drpc_resp)
 	} else if (pools_len != 0) {
 		D_ERROR("Invalid results - pools=NULL, pools_len=%lu\n",
 			pools_len);
-		D_GOTO(out, rc = -DER_UNKNOWN);
+		D_GOTO(out, rc = -DER_MISC);
 	}
 
 out:

--- a/src/mgmt/srv_pool.c
+++ b/src/mgmt/srv_pool.c
@@ -944,7 +944,7 @@ enum_pool_cb(daos_handle_t ih, d_iov_t *key, d_iov_t *val, void *varg)
 	uuid_copy(pool->lp_puuid, key->iov_buf);
 	pool->lp_svc = d_rank_list_alloc(rec->pr_nreplicas);
 	if (pool->lp_svc == NULL)
-		return DER_NOMEM;
+		return -DER_NOMEM;
 	for (ri = 0; ri < rec->pr_nreplicas; ri++)
 		pool->lp_svc->rl_ranks[ri] = rec->pr_replicas[ri];
 	return 0;

--- a/src/mgmt/tests/srv_drpc_tests.c
+++ b/src/mgmt/tests/srv_drpc_tests.c
@@ -291,7 +291,7 @@ test_drpc_pool_get_acl_mgmt_svc_fails(void **state)
 	Drpc__Response	resp = DRPC__RESPONSE__INIT;
 
 	setup_get_acl_drpc_call(&call, TEST_UUID);
-	ds_mgmt_pool_get_acl_return = -DER_UNKNOWN;
+	ds_mgmt_pool_get_acl_return = -DER_MISC;
 
 	ds_mgmt_drpc_pool_get_acl(&call, &resp);
 
@@ -444,7 +444,7 @@ test_drpc_pool_overwrite_acl_mgmt_svc_fails(void **state)
 	Drpc__Response	resp = DRPC__RESPONSE__INIT;
 
 	setup_modify_acl_drpc_call(&call, TEST_UUID, TEST_ACES, TEST_ACES_NR);
-	ds_mgmt_pool_overwrite_acl_return = -DER_UNKNOWN;
+	ds_mgmt_pool_overwrite_acl_return = -DER_MISC;
 
 	ds_mgmt_drpc_pool_overwrite_acl(&call, &resp);
 
@@ -524,7 +524,7 @@ test_drpc_pool_update_acl_mgmt_svc_fails(void **state)
 	Drpc__Response	resp = DRPC__RESPONSE__INIT;
 
 	setup_modify_acl_drpc_call(&call, TEST_UUID, TEST_ACES, TEST_ACES_NR);
-	ds_mgmt_pool_update_acl_return = -DER_UNKNOWN;
+	ds_mgmt_pool_update_acl_return = -DER_MISC;
 
 	ds_mgmt_drpc_pool_update_acl(&call, &resp);
 
@@ -610,7 +610,7 @@ test_drpc_pool_delete_acl_mgmt_svc_fails(void **state)
 	Drpc__Response	resp = DRPC__RESPONSE__INIT;
 
 	setup_delete_acl_drpc_call(&call, TEST_UUID, "OWNER@");
-	ds_mgmt_pool_delete_acl_return = -DER_UNKNOWN;
+	ds_mgmt_pool_delete_acl_return = -DER_MISC;
 
 	ds_mgmt_drpc_pool_delete_acl(&call, &resp);
 
@@ -706,7 +706,7 @@ test_drpc_list_pools_mgmt_svc_fails(void **state)
 
 	setup_list_pools_drpc_call(&call, "DaosSys");
 
-	ds_mgmt_list_pools_return = -DER_UNKNOWN;
+	ds_mgmt_list_pools_return = -DER_MISC;
 
 	ds_mgmt_drpc_list_pools(&call, &resp);
 
@@ -730,7 +730,7 @@ test_drpc_list_pools_svc_results_invalid(void **state)
 
 	ds_mgmt_drpc_list_pools(&call, &resp);
 
-	expect_drpc_list_pools_resp_with_error(&resp, -DER_UNKNOWN);
+	expect_drpc_list_pools_resp_with_error(&resp, -DER_MISC);
 
 	D_FREE(call.body.data);
 	D_FREE(resp.body.data);
@@ -932,7 +932,7 @@ test_drpc_pool_list_cont_mgmt_svc_fails(void **state)
 	Drpc__Response	 resp = DRPC__RESPONSE__INIT;
 
 	setup_list_cont_drpc_call(&call, TEST_UUID);
-	ds_mgmt_pool_list_cont_return = -DER_UNKNOWN;
+	ds_mgmt_pool_list_cont_return = -DER_MISC;
 
 	ds_mgmt_drpc_pool_list_cont(&call, &resp);
 
@@ -1223,7 +1223,7 @@ test_drpc_pool_query_mgmt_svc_fails(void **state)
 	Drpc__Response	resp = DRPC__RESPONSE__INIT;
 
 	setup_pool_query_drpc_call(&call, TEST_UUID);
-	ds_mgmt_pool_query_return = -DER_UNKNOWN;
+	ds_mgmt_pool_query_return = -DER_MISC;
 
 	ds_mgmt_drpc_pool_query(&call, &resp);
 
@@ -1417,7 +1417,7 @@ test_drpc_pool_query_success_rebuild_err(void **state)
 
 	init_test_pool_info(&exp_info);
 	exp_info.pi_rebuild_st.rs_version = 1;
-	exp_info.pi_rebuild_st.rs_errno = -DER_UNKNOWN;
+	exp_info.pi_rebuild_st.rs_errno = -DER_MISC;
 
 	ds_mgmt_pool_query_info_out = exp_info;
 	/*
@@ -1594,7 +1594,7 @@ test_drpc_exclude_mgmt_svc_fails(void **state)
 	Drpc__Response	resp = DRPC__RESPONSE__INIT;
 
 	setup_exclude_drpc_call(&call, TEST_UUID, 0);
-	ds_mgmt_target_update_return = -DER_UNKNOWN;
+	ds_mgmt_target_update_return = -DER_MISC;
 
 	ds_mgmt_drpc_pool_exclude(&call, &resp);
 	expect_drpc_exclude_resp_with_error(&resp,
@@ -1699,7 +1699,7 @@ test_drpc_drain_mgmt_svc_fails(void **state)
 	Drpc__Response	resp = DRPC__RESPONSE__INIT;
 
 	setup_drain_drpc_call(&call, TEST_UUID, 0);
-	ds_mgmt_target_update_return = -DER_UNKNOWN;
+	ds_mgmt_target_update_return = -DER_MISC;
 
 	ds_mgmt_drpc_pool_drain(&call, &resp);
 	expect_drpc_drain_resp_with_error(&resp,
@@ -1804,7 +1804,7 @@ test_drpc_extend_mgmt_svc_fails(void **state)
 	Drpc__Response	resp = DRPC__RESPONSE__INIT;
 
 	setup_extend_drpc_call(&call, TEST_UUID);
-	ds_mgmt_pool_extend_return = -DER_UNKNOWN;
+	ds_mgmt_pool_extend_return = -DER_MISC;
 
 	ds_mgmt_drpc_pool_extend(&call, &resp);
 	expect_drpc_extend_resp_with_error(&resp, ds_mgmt_pool_extend_return);
@@ -1966,7 +1966,7 @@ test_drpc_pool_evict_mgmt_svc_fails(void **state)
 	Drpc__Response	resp = DRPC__RESPONSE__INIT;
 
 	setup_evict_drpc_call(&call, TEST_UUID, "DaosSys");
-	ds_mgmt_pool_evict_return = -DER_UNKNOWN;
+	ds_mgmt_pool_evict_return = -DER_MISC;
 
 	ds_mgmt_drpc_pool_evict(&call, &resp);
 	expect_drpc_evict_resp_with_status(&resp,
@@ -2190,7 +2190,7 @@ test_drpc_cont_set_owner_failed(void **state)
 	Drpc__Call		call = DRPC__CALL__INIT;
 	Drpc__Response		resp = DRPC__RESPONSE__INIT;
 	Mgmt__ContSetOwnerReq	req = MGMT__CONT_SET_OWNER_REQ__INIT;
-	int			exp_rc = -DER_UNKNOWN;
+	int			exp_rc = -DER_MISC;
 
 	req.pooluuid = "11111111-1111-1111-1111-111111111111";
 	req.contuuid = "22222222-2222-2222-2222-222222222222";

--- a/src/placement/ring_map.c
+++ b/src/placement/ring_map.c
@@ -488,7 +488,7 @@ ring_create(struct pl_ring_map *rimap, unsigned int index,
 
 	first = pool_map_targets(rimap->rmp_map.pl_poolmap);
 	if (first == NULL)
-		return DER_INVAL;
+		return -DER_INVAL;
 
 	for (plt = &ring->ri_targets[0], i = 0;
 	     plt <= &ring->ri_targets[rimap->rmp_target_nr - 1]; i++) {
@@ -1056,7 +1056,7 @@ ring_obj_layout_fill(struct pl_map *map, struct daos_obj_md *md,
 	grp_start = rop->rop_begin;
 	tgts = pool_map_targets(map->pl_poolmap);
 	if (tgts == NULL) {
-		rc = DER_INVAL;
+		rc = -DER_INVAL;
 		goto out;
 	}
 

--- a/src/rdb/rdb_raft.c
+++ b/src/rdb/rdb_raft.c
@@ -74,7 +74,7 @@ rdb_raft_rc(int raft_rc)
 	case RAFT_ERR_SHUTDOWN:			return -DER_SHUTDOWN;
 	case RAFT_ERR_NOMEM:			return -DER_NOMEM;
 	case RAFT_ERR_SNAPSHOT_ALREADY_LOADED:	return -DER_ALREADY;
-	default:				return -DER_UNKNOWN;
+	default:				return -DER_MISC;
 	}
 }
 

--- a/src/security/tests/srv_acl_tests.c
+++ b/src/security/tests/srv_acl_tests.c
@@ -291,7 +291,7 @@ test_validate_creds_drpc_call_failed(void **state)
 
 	init_default_cred(&cred);
 
-	drpc_call_return = -DER_UNKNOWN;
+	drpc_call_return = -DER_MISC;
 	drpc_call_resp_return_ptr = NULL;
 
 	assert_int_equal(ds_sec_validate_credentials(&cred, &result),
@@ -411,11 +411,11 @@ test_validate_creds_drpc_response_bad_status(void **state)
 
 	init_default_cred(&cred);
 
-	resp.status = -DER_UNKNOWN;
+	resp.status = -DER_MISC;
 	pack_validate_resp_in_drpc_call_resp_body(&resp);
 
 	assert_int_equal(ds_sec_validate_credentials(&cred, &result),
-			 -DER_UNKNOWN);
+			 -DER_MISC);
 
 	assert_null(result);
 
@@ -716,7 +716,7 @@ test_pool_get_capas_validate_cred_failed(void **state)
 	acl = daos_acl_create(NULL, 0);
 
 	/* drpc call failure will fail validation */
-	drpc_call_return = -DER_UNKNOWN;
+	drpc_call_return = -DER_MISC;
 	drpc_call_resp_return_ptr = NULL;
 
 	assert_int_equal(ds_sec_pool_get_capabilities(DAOS_PC_RO, &cred,


### PR DESCRIPTION
Correct a number of locations to use negative values.
Do not use DER_UNKNOWN in normal use, this is reserved for unknown
error values, not unknown errors so replace with DER_MISC.

Signed-off-by: Ashley Pittman <ashley.m.pittman@intel.com>