### PR TITLE
DAOS-5195 hlc: Change source to CLOCK_REALTIME

### DIFF
--- a/src/cart/src/cart/crt_hlc.c
+++ b/src/cart/src/cart/crt_hlc.c
@@ -42,7 +42,7 @@ static inline uint64_t crt_hlc_localtime_get(void)
 	uint64_t	pt;
 	int		rc;
 
-	rc = clock_gettime(CLOCK_REALTIME_COARSE, &now);
+	rc = clock_gettime(CLOCK_REALTIME, &now);
 	pt = rc ? crt_hlc : (now.tv_sec * NSEC_PER_SEC + now.tv_nsec);
 
 	/**


### PR DESCRIPTION
The resolution of the CLOCK_REALTIME_COARSE clock source used by hlc is
1 ms (verified on CentOS 7), which is too coarse compared to the I/O
latency we are targeting. This patch changes the clock source to
CLOCK_REALTIME, whose resolution is 1 ns (verified on CentOS 7).
Although the new clock source is a few times slower, we will still be
able to read it 10s of millions times per second.

Signed-off-by: Li Wei <wei.g.li@intel.com>