### PR TITLE
DAOS-5452 object: prepare sgls for inline fetch

### DIFF
--- a/src/object/cli_obj.c
+++ b/src/object/cli_obj.c
@@ -3257,7 +3257,7 @@ obj_comp_cb(tse_task_t *task, void *data)
 	if (rc != 0 || obj_auxi->result) {
 		if (task->dt_result == 0)
 			task->dt_result = rc ? rc : obj_auxi->result;
-		D_ERROR("obj complete callback failure %d\n", task->dt_result);
+		D_DEBUG(DB_IO, "obj complete callback: %d\n", task->dt_result);
 	}
 
 	if (obj->cob_time_fetch_leader != NULL &&

--- a/src/object/obj_internal.h
+++ b/src/object/obj_internal.h
@@ -535,7 +535,9 @@ struct obj_io_context {
 	struct ds_cont_child	*ioc_coc;
 	daos_handle_t		 ioc_vos_coh;
 	uint32_t		 ioc_map_ver;
-	uint32_t		 ioc_began:1;
+	uint32_t		 ioc_began:1,
+				 ioc_free_sgls:1,
+				 ioc_lost_reply:1;
 };
 
 struct ds_obj_exec_arg {


### PR DESCRIPTION
After PR-3047 is landed, the orw_sgls will not be allocated,
instead it will point to the buffer inside the request, and
also it reserved the buffer by iov_len, which is usually 0
for fetch inline request, i.e. the orw_sgls might not be big
enough to hold the fetched data. So let's check and reallocate
the fetched data buffer.

Change the error message to normal message in obj_comp_cb(), because
it might also happen for normal operation.

Signed-off-by: Di Wang <di.wang@intel.com>