### PR TITLE
DAOS-5525 test: Add pool mgmt shims to client API

### DIFF
--- a/src/client/api/SConscript
+++ b/src/client/api/SConscript
@@ -18,7 +18,9 @@ def scons():
     dc_tgts += dc_mgmt_tgts + dc_array_tgts + dc_kv_tgts + dc_security_tgts
     libdaos = daos_build.library(env, 'daos', dc_tgts,
                                  SHLIBVERSION=API_VERSION,
-                                 LIBS=['daos_common'])
+                                 LIBS=['daos_common', 'daos_tests'])
+    # TODO (DAOS-4600): Remove dependency on daos_tests, which was
+    # added temporarily to ease migration from the C mgmt API.
     if hasattr(env, 'InstallVersionedLib'):
         env.InstallVersionedLib('$PREFIX/lib64/', libdaos,
                                 SHLIBVERSION=API_VERSION)

--- a/src/client/api/mgmt.c
+++ b/src/client/api/mgmt.c
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2015-2018 Intel Corporation.
+ * (C) Copyright 2015-2020 Intel Corporation.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,6 +26,7 @@
 #include <daos/pool.h>
 #include <daos/task.h>
 #include <daos_mgmt.h>
+#include <daos/tests_lib.h>
 #include "client_internal.h"
 #include "task_internal.h"
 
@@ -36,6 +37,8 @@ daos_mgmt_svc_rip(const char *grp, d_rank_t rank, bool force,
 	daos_svc_rip_t		*args;
 	tse_task_t		*task;
 	int			 rc;
+
+	D_DEPRECATED("");
 
 	DAOS_API_ARG_ASSERT(*args, SVC_RIP);
 	rc = dc_task_create(dc_mgmt_svc_rip, NULL, ev, &task);
@@ -57,6 +60,8 @@ daos_mgmt_set_params(const char *grp, d_rank_t rank, unsigned int key_id,
 	daos_set_params_t	*args;
 	tse_task_t		*task;
 	int			 rc;
+
+	D_DEPRECATED("");
 
 	DAOS_API_ARG_ASSERT(*args, SET_PARAMS);
 	rc = dc_task_create(dc_mgmt_set_params, NULL, ev, &task);
@@ -80,58 +85,17 @@ daos_pool_create(uint32_t mode, uid_t uid, gid_t gid, const char *grp,
 		 daos_prop_t *pool_prop, d_rank_list_t *svc,
 		 uuid_t uuid, daos_event_t *ev)
 {
-	daos_pool_create_t	*args;
-	tse_task_t		*task;
-	int			 rc;
-
-	DAOS_API_ARG_ASSERT(*args, POOL_CREATE);
-	if (pool_prop != NULL && !daos_prop_valid(pool_prop, true, true)) {
-		D_ERROR("Invalid pool properties.\n");
-		return -DER_INVAL;
-	}
-
-	rc = dc_task_create(dc_pool_create, NULL, ev, &task);
-	if (rc)
-		return rc;
-
-	args = dc_task_get_args(task);
-	args->mode	= mode;
-	args->uid	= uid;
-	args->gid	= gid;
-	args->grp	= grp;
-	args->tgts	= tgts;
-	args->dev	= dev;
-	args->scm_size	= scm_size;
-	args->nvme_size	= nvme_size;
-	args->prop	= pool_prop;
-	args->svc	= svc;
-	args->uuid	= uuid;
-
-	return dc_task_schedule(task, true);
+	D_DEPRECATED("dmg_pool_create()");
+	return dmg_pool_create(NULL, uid, gid, grp, tgts,
+			       scm_size, nvme_size, pool_prop, svc, uuid);
 }
 
 int
 daos_pool_destroy(const uuid_t uuid, const char *grp, int force,
 		  daos_event_t *ev)
 {
-	daos_pool_destroy_t	*args;
-	tse_task_t		*task;
-	int			 rc;
-
-	DAOS_API_ARG_ASSERT(*args, POOL_DESTROY);
-	if (!daos_uuid_valid(uuid))
-		return -DER_INVAL;
-
-	rc = dc_task_create(dc_pool_destroy, NULL, ev, &task);
-	if (rc)
-		return rc;
-
-	args = dc_task_get_args(task);
-	args->grp	= grp;
-	args->force	= force;
-	uuid_copy((unsigned char *)args->uuid, uuid);
-
-	return dc_task_schedule(task, true);
+	D_DEPRECATED("dmg_pool_destroy()");
+	return dmg_pool_destroy(NULL, uuid, grp, force);
 }
 
 int
@@ -142,6 +106,8 @@ daos_pool_add_tgt(const uuid_t uuid, const char *grp,
 	daos_pool_update_t	*args;
 	tse_task_t		*task;
 	int			 rc;
+
+	D_DEPRECATED("");
 
 	if (!daos_uuid_valid(uuid))
 		return -DER_INVAL;
@@ -168,6 +134,8 @@ daos_pool_drain_tgt(const uuid_t uuid, const char *grp,
 	tse_task_t		*task;
 	int			 rc;
 
+	D_DEPRECATED("");
+
 	if (!daos_uuid_valid(uuid))
 		return -DER_INVAL;
 
@@ -192,6 +160,8 @@ daos_pool_tgt_exclude_out(const uuid_t uuid, const char *grp,
 	daos_pool_update_t	*args;
 	tse_task_t		*task;
 	int			 rc;
+
+	D_DEPRECATED("");
 
 	if (!daos_uuid_valid(uuid))
 		return -DER_INVAL;
@@ -218,6 +188,8 @@ daos_pool_tgt_exclude(const uuid_t uuid, const char *grp,
 	tse_task_t		*task;
 	int			 rc;
 
+	D_DEPRECATED("");
+
 	DAOS_API_ARG_ASSERT(*args, POOL_EXCLUDE);
 	if (!daos_uuid_valid(uuid))
 		return -DER_INVAL;
@@ -239,6 +211,8 @@ int
 daos_pool_extend(const uuid_t uuid, const char *grp, d_rank_list_t *tgts,
 		 d_rank_list_t *failed, daos_event_t *ev)
 {
+	D_DEPRECATED("");
+
 	return -DER_NOSYS;
 }
 
@@ -250,6 +224,8 @@ daos_pool_add_replicas(const uuid_t uuid, const char *group,
 	daos_pool_replicas_t	*args;
 	tse_task_t		*task;
 	int			 rc;
+
+	D_DEPRECATED("");
 
 	DAOS_API_ARG_ASSERT(*args, POOL_ADD_REPLICAS);
 	if (!daos_uuid_valid(uuid))
@@ -278,6 +254,8 @@ daos_pool_remove_replicas(const uuid_t uuid, const char *group,
 	tse_task_t		*task;
 	int			 rc;
 
+	D_DEPRECATED("");
+
 	DAOS_API_ARG_ASSERT(*args, POOL_REMOVE_REPLICAS);
 	if (!daos_uuid_valid(uuid))
 		return -DER_INVAL;
@@ -300,30 +278,13 @@ int
 daos_mgmt_list_pools(const char *group, daos_size_t *npools,
 		     daos_mgmt_pool_info_t *pools, daos_event_t *ev)
 {
-	daos_mgmt_list_pools_t	*args;
-	tse_task_t		*task;
-	int			 rc;
-
-	DAOS_API_ARG_ASSERT(*args, MGMT_LIST_POOLS);
-
-	if (npools == NULL) {
-		D_ERROR("npools must be non-NULL\n");
-		return -DER_INVAL;
-	}
-
-	rc = dc_task_create(dc_mgmt_list_pools, NULL, ev, &task);
-	if (rc)
-		return rc;
-	args = dc_task_get_args(task);
-	args->grp = group;
-	args->pools = pools;
-	args->npools = npools;
-
-	return dc_task_schedule(task, true);
+	D_DEPRECATED("dmg_pool_list()");
+	return dmg_pool_list(NULL, group, npools, pools);
 }
 
 int
 daos_mgmt_add_mark(const char *mark)
 {
+	D_DEPRECATED("");
 	return dc_mgmt_add_mark(mark);
 }

--- a/src/client/api/pool.c
+++ b/src/client/api/pool.c
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2015, 2016 Intel Corporation.
+ * (C) Copyright 2015-2020 Intel Corporation.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -93,6 +93,8 @@ daos_pool_query(daos_handle_t poh, d_rank_list_t *tgts, daos_pool_info_t *info,
 	daos_pool_query_t	*args;
 	tse_task_t		*task;
 	int			 rc;
+
+	D_DEPRECATED("dmg pool query");
 
 	DAOS_API_ARG_ASSERT(*args, POOL_QUERY);
 

--- a/src/common/SConscript
+++ b/src/common/SConscript
@@ -6,6 +6,7 @@ def scons():
     Import('env', 'prereqs', 'platform_arm')
 
     env.AppendUnique(LIBPATH=[Dir('.')])
+    env.AppendUnique(LINKFLAGS=["-Wl,-rpath-link=%s" % Dir('.').abspath])
 
     # Hack alert, the argobots headers are required but the shared
     # library isn't so add the dependency so the include path

--- a/src/include/gurt/debug.h
+++ b/src/include/gurt/debug.h
@@ -302,6 +302,12 @@ do {									\
 #define DF_U64		"%" PRIu64
 #define DF_X64		"%" PRIx64
 
+#define D_DEPRECATED(replacement)					\
+	if (sizeof(replacement) == 1)					\
+		D_ERROR("is deprecated\n");				\
+	else								\
+		D_ERROR("is deprecated (use " replacement " instead)\n");
+
 /** @}
  */
 #endif /* __GURT_DEBUG_H__ */

--- a/utils/node_local_test.py
+++ b/utils/node_local_test.py
@@ -1239,6 +1239,9 @@ def main():
 
     conf = load_conf()
 
+    # set the path so that dmg, etc. can be found
+    os.environ['PATH'] += os.pathsep + os.path.join(conf['PREFIX'], 'bin')
+
     wf = WarningsFactory(args.output_file)
 
     conf.set_wf(wf)


### PR DESCRIPTION
The following client API methods have been modified
to use the dmg pool helpers:
  * daos_pool_create()
  * daos_pool_destroy()
  * daos_mgmt_list_pools()

Callers will see a deprecation warning in the client log.
Additionally, deprecation warnings have been added to the
rest of the mgmt methods.