### PR TITLE
DAOS-5359 control: Fix JSON output for pool query

### DIFF
--- a/src/control/cmd/dmg/pool.go
+++ b/src/control/cmd/dmg/pool.go
@@ -419,7 +419,7 @@ func (c *PoolQueryCmd) Execute(args []string) error {
 	resp, err := control.PoolQuery(ctx, c.ctlInvoker, req)
 
 	if c.jsonOutputEnabled() {
-		return c.errorJSON(err)
+		return c.outputJSON(resp, err)
 	}
 
 	if err != nil {
@@ -460,7 +460,7 @@ func (c *PoolSetPropCmd) Execute(_ []string) error {
 	resp, err := control.PoolSetProp(ctx, c.ctlInvoker, req)
 
 	if c.jsonOutputEnabled() {
-		return c.errorJSON(err)
+		return c.outputJSON(resp, err)
 	}
 
 	if err != nil {


### PR DESCRIPTION
When support was added for errors in JSON output, the wrong
helper function was chosen for pool query and the method
result wasn't being included in the output.