### PR TITLE
DAOS-5465 csum: Checksum Scrubbing Scanner

### DIFF
--- a/src/common/checksum.c
+++ b/src/common/checksum.c
@@ -1080,9 +1080,9 @@ calc_csum_sv(struct daos_csummer *obj, d_sg_list_t *sgl, size_t rec_len,
 }
 
 /** Using the data from the iov, calculate the checksum */
-static int
-calc_for_iov(struct daos_csummer *csummer, daos_key_t *iov,
-	     uint8_t *csum_buf, uint16_t csum_buf_len)
+int
+daos_csummer_calc_for_iov(struct daos_csummer *csummer, daos_key_t *iov,
+			  uint8_t *csum_buf, uint16_t csum_buf_len)
 {
 	int rc;
 
@@ -1163,13 +1163,13 @@ daos_csummer_calc_iods(struct daos_csummer *obj, d_sg_list_t *sgls,
 
 		/** akey */
 		if (!obj->dcs_skip_key_calc) {
-			rc = calc_for_iov(obj, &iod->iod_name,
-					  csums->ic_akey.cs_csum, csum_len);
+			rc = daos_csummer_calc_for_iov(obj, &iod->iod_name,
+						       csums->ic_akey.cs_csum,
+						       csum_len);
 			if (rc != 0) {
 				D_ERROR("calc_for_iov error: %d\n", rc);
 				goto error;
 			}
-
 		}
 
 		if (akey_only)
@@ -1224,7 +1224,7 @@ daos_csummer_calc_key(struct daos_csummer *csummer, daos_key_t *key,
 
 	ci_set(csum_info, dkey_csum_buf, size, size, 1, CSUM_NO_CHUNK, type);
 
-	rc = calc_for_iov(csummer, key, dkey_csum_buf, size);
+	rc = daos_csummer_calc_for_iov(csummer, key, dkey_csum_buf, size);
 	if (rc == 0) {
 		*p_csum = csum_info;
 		C_TRACE("Checksum created for key: "DF_KEY"->"DF_CI"\n",
@@ -1237,7 +1237,6 @@ daos_csummer_calc_key(struct daos_csummer *csummer, daos_key_t *key,
 
 	return rc;
 }
-
 
 void
 daos_csummer_free_ic(struct daos_csummer *obj, struct dcs_iod_csums **p_cds)

--- a/src/include/daos/checksum.h
+++ b/src/include/daos/checksum.h
@@ -275,6 +275,10 @@ daos_csummer_csum_compare(struct daos_csummer *obj, uint8_t *a,
 			  uint8_t *b, uint32_t csum_len);
 
 int
+daos_csummer_calc_for_iov(struct daos_csummer *csummer, daos_key_t *iov,
+			  uint8_t *csum_buf, uint16_t csum_buf_len);
+
+int
 daos_csummer_calc_one(struct daos_csummer *obj, d_sg_list_t *sgl,
 		       struct dcs_csum_info *csums, size_t rec_len, size_t nr,
 		       size_t idx);

--- a/src/include/daos/tests_lib.h
+++ b/src/include/daos/tests_lib.h
@@ -36,6 +36,11 @@
 #define DAOS_ON_VALGRIND 0
 #endif
 
+#define assert_success(r) do {\
+	int __rc = (r); \
+	if (__rc != 0) \
+		fail_msg("Not successful!! Error code: " DF_RC, DP_RC(__rc)); \
+	} while (0)
 
 /** Read a command line from stdin. */
 char *dts_readline(const char *prompt);

--- a/src/include/daos_srv/bio.h
+++ b/src/include/daos_srv/bio.h
@@ -33,6 +33,13 @@
 #include <daos/common.h>
 #include <abt.h>
 
+#define BIO_ADDR_IS_CORRUPTED(addr) ((addr)->ba_flags == BIO_FLAG_CORRUPTED)
+#define BIO_ADDR_SET_CORRUPTED(addr) ((addr)->ba_flags |= BIO_FLAG_CORRUPTED)
+
+enum BIO_FLAG {
+	BIO_FLAG_CORRUPTED = (1 << 0),
+};
+
 typedef struct {
 	/*
 	 * Byte offset within PMDK pmemobj pool for SCM;
@@ -44,7 +51,7 @@ typedef struct {
 	/* Is the address a hole ? */
 	uint16_t	ba_hole;
 	uint16_t	ba_dedup;
-	uint16_t	ba_padding;
+	uint16_t	ba_flags;
 } bio_addr_t;
 
 /** Ensure this remains compatible */

--- a/src/include/daos_srv/evtree.h
+++ b/src/include/daos_srv/evtree.h
@@ -300,6 +300,7 @@ struct evt_entry_in {
 	uint32_t		ei_inob;
 	/** Address of record to insert */
 	bio_addr_t		ei_addr;
+	bool			ei_corrupted;
 };
 
 enum evt_visibility {
@@ -325,6 +326,7 @@ struct evt_entry {
 	struct evt_extent		en_sel_ext;
 	/** checksums of the actual extent*/
 	struct dcs_csum_info		en_csum;
+	bool				en_corrupted;
 	/** pool map version */
 	uint32_t			en_ver;
 	/** Visibility flags for extent */

--- a/src/include/daos_srv/pool.h
+++ b/src/include/daos_srv/pool.h
@@ -101,6 +101,7 @@ struct ds_pool_child {
 	struct ds_pool		*spc_pool;
 	uuid_t			spc_uuid;	/* pool UUID */
 	struct sched_request	*spc_gc_req;	/* Track GC ULT */
+	struct sched_request	*spc_scrubbing_req; /* Track scrubbing ULT*/
 	d_list_t		spc_cont_list;
 
 	/* The current maxim rebuild epoch, (0 if there is no rebuild), so
@@ -115,6 +116,7 @@ struct ds_pool_child {
 	uint64_t	spc_rebuild_end_hlc;
 	uint32_t	spc_map_version;
 	int		spc_ref;
+
 };
 
 struct ds_pool_child *ds_pool_child_lookup(const uuid_t uuid);

--- a/src/include/daos_srv/vos_types.h
+++ b/src/include/daos_srv/vos_types.h
@@ -228,6 +228,8 @@ enum {
 	 * under the specified range. Intended for internal use only.
 	 */
 	VOS_OF_REMOVE		= (1 << 9),
+	/** Mark the record's bio address as being corrupted */
+	VOS_OF_CORRUPT		= (1 << 10),
 };
 
 /** Mask for any conditionals passed to to the fetch */

--- a/src/object/tests/SConscript
+++ b/src/object/tests/SConscript
@@ -7,8 +7,10 @@ def scons():
 
     unit_env = denv.Clone()
     srv_checksum_tests = daos_build.test(unit_env, 'srv_checksum_tests',
-                    ['srv_checksum_tests.c', '../srv_csum.c'],
-                    LIBS=['daos_common', 'gurt', 'cmocka'])
+                    ['srv_checksum_tests.c', 'srv_scrubbing_tests.c',
+                     '../srv_csum.c'],
+                    LIBS=['daos_common', 'gurt', 'uuid', 'vos', 'bio', 'abt',
+                          'daos_tests', 'cmocka'])
     unit_env.Install('$PREFIX/bin/', [srv_checksum_tests])
 
 if __name__ == "SCons.Script":

--- a/src/object/tests/srv_checksum_tests.c
+++ b/src/object/tests/srv_checksum_tests.c
@@ -29,8 +29,7 @@
 #include <daos/checksum.h>
 #include <daos_srv/evtree.h>
 #include <daos_srv/srv_csum.h>
-
-#define ASSERT_SUCCESS(exp) assert_int_equal(0, (exp))
+#include <daos/tests_lib.h>
 
 static void
 print_chars(const uint8_t *buf, const size_t len, const uint32_t max)
@@ -339,7 +338,7 @@ request_that_matches_single_extent(void **state)
 	       ctx.iod_csum->ic_data->cs_buf_len);
 
 	/** Act */
-	ASSERT_SUCCESS(fetch_csum_verify_bsgl_with_args(&ctx));
+	assert_success(fetch_csum_verify_bsgl_with_args(&ctx));
 
 	/** Verify */
 
@@ -375,7 +374,7 @@ extent_smaller_than_chunk(void **state)
 	});
 
 	/** Act */
-	ASSERT_SUCCESS(fetch_csum_verify_bsgl_with_args(&ctx));
+	assert_success(fetch_csum_verify_bsgl_with_args(&ctx));
 
 	/** Verify */
 	ASSERT_CSUM(ctx, "SSSS");
@@ -415,7 +414,7 @@ request_that_matches_single_extent_multiple_chunks(void **state)
 	});
 
 	/** Act */
-	ASSERT_SUCCESS(fetch_csum_verify_bsgl_with_args(&ctx));
+	assert_success(fetch_csum_verify_bsgl_with_args(&ctx));
 
 	/** Verify */
 	ASSERT_CSUM(ctx, "SSSS");
@@ -451,7 +450,7 @@ request_that_matches_single_extent_multiple_chunks_not_aligned(void **state)
 	});
 
 	/** Act */
-	ASSERT_SUCCESS(fetch_csum_verify_bsgl_with_args(&ctx));
+	assert_success(fetch_csum_verify_bsgl_with_args(&ctx));
 
 	/** Verify */
 	ASSERT_CSUM(ctx, "SSSSSSSSSSSSSSSS");
@@ -489,7 +488,7 @@ request_that_matches_multiple_aligned_extents(void **state)
 	});
 
 	/** Act */
-	ASSERT_SUCCESS(fetch_csum_verify_bsgl_with_args(&ctx));
+	assert_success(fetch_csum_verify_bsgl_with_args(&ctx));
 
 	/** Verify */
 	ASSERT_CSUM(ctx, "SSSSSSSS");
@@ -527,7 +526,7 @@ request_that_matches_multiple_aligned_extents2(void **state)
 	});
 
 	/** Act */
-	ASSERT_SUCCESS(fetch_csum_verify_bsgl_with_args(&ctx));
+	assert_success(fetch_csum_verify_bsgl_with_args(&ctx));
 
 	/** Verify */
 	ASSERT_CSUM(ctx, "SSSSSSSS");
@@ -563,7 +562,7 @@ request_that_is_more_than_extents(void **state)
 	});
 
 	/** Act */
-	ASSERT_SUCCESS(fetch_csum_verify_bsgl_with_args(&ctx));
+	assert_success(fetch_csum_verify_bsgl_with_args(&ctx));
 
 	/** Verify */
 	ASSERT_CSUM(ctx, "SSSS");
@@ -602,7 +601,7 @@ partial_chunk_request0(void **state)
 	});
 
 	/** Act */
-	ASSERT_SUCCESS(fetch_csum_verify_bsgl_with_args(&ctx));
+	assert_success(fetch_csum_verify_bsgl_with_args(&ctx));
 
 	/** Verify */
 	FAKE_UPDATE_SAW(">ZYXW|>ZYXWVUTS|");
@@ -640,7 +639,7 @@ partial_chunk_request1(void **state)
 	});
 
 	/** Act */
-	ASSERT_SUCCESS(fetch_csum_verify_bsgl_with_args(&ctx));
+	assert_success(fetch_csum_verify_bsgl_with_args(&ctx));
 
 	/** Verify */
 	FAKE_UPDATE_SAW(">VUTS|>ZYXWVUTS|");
@@ -678,7 +677,7 @@ partial_chunk_request2(void **state)
 	});
 
 	/** Act */
-	ASSERT_SUCCESS(fetch_csum_verify_bsgl_with_args(&ctx));
+	assert_success(fetch_csum_verify_bsgl_with_args(&ctx));
 
 	/** Verify */
 	FAKE_UPDATE_SAW(">XWVU|>ZYXWVUTS|");
@@ -721,7 +720,7 @@ request_needs_new_and_copy(void **state)
 	});
 
 	/** Act */
-	ASSERT_SUCCESS(fetch_csum_verify_bsgl_with_args(&ctx));
+	assert_success(fetch_csum_verify_bsgl_with_args(&ctx));
 
 	/** Verify */
 	FAKE_UPDATE_SAW(">XW|>ZYXW|>VU|>VUTS|");
@@ -765,7 +764,7 @@ unaligned_chunks_csums_new_csum_is_created(void **state)
 	});
 
 	/** Act */
-	ASSERT_SUCCESS(fetch_csum_verify_bsgl_with_args(&ctx));
+	assert_success(fetch_csum_verify_bsgl_with_args(&ctx));
 
 	/** Verify */
 	FAKE_UPDATE_SAW(">1|A|>12|>A|");
@@ -815,7 +814,7 @@ extent_larger_than_request(void **state)
 	});
 
 	/** Act */
-	ASSERT_SUCCESS(fetch_csum_verify_bsgl_with_args(&ctx));
+	assert_success(fetch_csum_verify_bsgl_with_args(&ctx));
 
 	/** Verify */
 	FAKE_UPDATE_SAW(">5|ABC|>567|>ABCDEFG|");
@@ -857,7 +856,7 @@ unaligned_first_chunk(void **state)
 	});
 
 	/** Act */
-	ASSERT_SUCCESS(fetch_csum_verify_bsgl_with_args(&ctx));
+	assert_success(fetch_csum_verify_bsgl_with_args(&ctx));
 
 	/** Verify */
 	FAKE_UPDATE_SAW("");
@@ -898,7 +897,7 @@ fetch_multiple_unaligned_extents(void **state)
 	});
 
 	/** Act */
-	ASSERT_SUCCESS(fetch_csum_verify_bsgl_with_args(&ctx));
+	assert_success(fetch_csum_verify_bsgl_with_args(&ctx));
 
 	/** Verify */
 	FAKE_UPDATE_SAW(">D|EF|>D|>EF|");
@@ -948,7 +947,7 @@ many_extents(void **state)
 	});
 
 	/** Act */
-	ASSERT_SUCCESS(fetch_csum_verify_bsgl_with_args(&ctx));
+	assert_success(fetch_csum_verify_bsgl_with_args(&ctx));
 
 	/** Verify */
 	FAKE_UPDATE_SAW(">A|B|C|D|>A|>B|>C|>D|>E|F|>E|>F|");
@@ -989,7 +988,7 @@ request_that_begins_before_extent(void **state)
 	});
 
 	/** Act */
-	ASSERT_SUCCESS(fetch_csum_verify_bsgl_with_args(&ctx));
+	assert_success(fetch_csum_verify_bsgl_with_args(&ctx));
 
 	/** Verify */
 	ASSERT_CSUM(ctx, "SSSS");
@@ -1032,7 +1031,7 @@ fetch_with_hole(void **state)
 	});
 
 	/** Act */
-	ASSERT_SUCCESS(fetch_csum_verify_bsgl_with_args(&ctx));
+	assert_success(fetch_csum_verify_bsgl_with_args(&ctx));
 
 	/** Verify */
 	FAKE_UPDATE_SAW("");
@@ -1071,7 +1070,7 @@ fetch_with_hole2(void **state)
 	});
 
 	/** Act */
-	ASSERT_SUCCESS(fetch_csum_verify_bsgl_with_args(&ctx));
+	assert_success(fetch_csum_verify_bsgl_with_args(&ctx));
 
 	/** Verify */
 	FAKE_UPDATE_SAW(">ABC|GH|>ABC|>GH|");
@@ -1127,7 +1126,7 @@ fetch_with_hole3(void **state)
 	});
 
 	/** Act */
-	ASSERT_SUCCESS(fetch_csum_verify_bsgl_with_args(&ctx));
+	assert_success(fetch_csum_verify_bsgl_with_args(&ctx));
 
 	/** Verify */
 	FAKE_UPDATE_SAW(">A|B|C|D|E|F|>A|>B|>C|>D|>E|>F|");
@@ -1163,7 +1162,7 @@ fetch_with_hole4(void **state)
 	});
 
 	/** Act */
-	ASSERT_SUCCESS(fetch_csum_verify_bsgl_with_args(&ctx));
+	assert_success(fetch_csum_verify_bsgl_with_args(&ctx));
 
 	/** Verify */
 	FAKE_UPDATE_SAW("");
@@ -1206,7 +1205,7 @@ fetch_with_hole5(void **state)
 	});
 
 	/** Act */
-	ASSERT_SUCCESS(fetch_csum_verify_bsgl_with_args(&ctx));
+	assert_success(fetch_csum_verify_bsgl_with_args(&ctx));
 
 	/** Verify */
 	FAKE_UPDATE_SAW(">A|BC|>A|>BC|");
@@ -1247,7 +1246,7 @@ fetch_with_hole6(void **state)
 	});
 
 	/** Act */
-	ASSERT_SUCCESS(fetch_csum_verify_bsgl_with_args(&ctx));
+	assert_success(fetch_csum_verify_bsgl_with_args(&ctx));
 
 	/** Verify */
 	FAKE_UPDATE_SAW(">A|>ABCD|");
@@ -1287,7 +1286,7 @@ request_is_only_part_of_biovs(void **state)
 	});
 
 	/** Act */
-	ASSERT_SUCCESS(fetch_csum_verify_bsgl_with_args(&ctx));
+	assert_success(fetch_csum_verify_bsgl_with_args(&ctx));
 
 	/** Verify */
 	FAKE_UPDATE_SAW("");
@@ -1326,7 +1325,7 @@ larger_records(void **state)
 	});
 
 	/** Act */
-	ASSERT_SUCCESS(fetch_csum_verify_bsgl_with_args(&ctx));
+	assert_success(fetch_csum_verify_bsgl_with_args(&ctx));
 
 	/** Verify */
 	/** 1 record from 1st extent (mnop) and 2 records from 2nd extent
@@ -1367,7 +1366,7 @@ larger_records2(void **state)
 	});
 
 	/** Act */
-	ASSERT_SUCCESS(fetch_csum_verify_bsgl_with_args(&ctx));
+	assert_success(fetch_csum_verify_bsgl_with_args(&ctx));
 
 	/** Verify */
 	assert_int_equal(4, fake_update_called);
@@ -1379,12 +1378,14 @@ larger_records2(void **state)
 	D_FREE(large_data02);
 }
 
-int setup(void **state)
+static int
+sct_setup(void **state)
 {
 	return 0;
 }
 
-int teardown(void **state)
+static int
+sct_teardown(void **state)
 {
 	reset_fake_algo();
 	return 0;
@@ -1392,7 +1393,7 @@ int teardown(void **state)
 
 /* Convenience macro for unit tests */
 #define	TA(desc, test_fn) \
-	{ desc, test_fn, setup, teardown }
+	{ desc, test_fn, sct_setup, sct_teardown }
 
 static const struct CMUnitTest array_tests[] = {
 	TA("SRV_CSUM_ARRAY01: Whole extent requested",
@@ -1494,14 +1495,16 @@ update_fetch_sv(void **state)
 	daos_csummer_destroy(&csummer);
 }
 
-
 #define	TS(desc, test_fn) \
-	{ "SRV_CSUM_SV" desc, test_fn, setup, teardown }
+	{ "SRV_CSUM_SV" desc, test_fn, sct_setup, sct_teardown }
 
 static const struct CMUnitTest sv_tests[] = {
 	TS("01: Various scenarios for update/fetch with fault injection",
 	   update_fetch_sv),
 };
+
+/** in srv_scrubbing_tests.c */
+extern int run_scrubbing_tests(void);
 
 int
 main(int argc, char **argv)
@@ -1516,7 +1519,6 @@ main(int argc, char **argv)
 	}
 #endif
 
-
 	rc += cmocka_run_group_tests_name(
 		"Storage and retrieval of checksums for Array Type",
 		array_tests, NULL, NULL);
@@ -1525,6 +1527,7 @@ main(int argc, char **argv)
 		"Storage and retrieval of checksums for Single Value Type",
 		sv_tests, NULL, NULL);
 
+	rc += run_scrubbing_tests();
 	return rc;
 
 }

--- a/src/object/tests/srv_scrubbing_tests.c
+++ b/src/object/tests/srv_scrubbing_tests.c
@@ -1,0 +1,545 @@
+/*
+ * (C) Copyright 2020 Intel Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * GOVERNMENT LICENSE RIGHTS-OPEN SOURCE SOFTWARE
+ * The Government's rights to use, modify, reproduce, release, perform, display,
+ * or disclose this software are subject to the terms of the Apache License as
+ * provided in Contract No. 8F-30005.
+ * Any reproduction of computer software, computer software documentation, or
+ * portions thereof marked with this legend must also reproduce the markings.
+ */
+
+#include <stddef.h>
+#include <setjmp.h>
+#include <stdarg.h>
+#include <cmocka.h>
+#include <daos/test_utils.h>
+#include <daos/checksum.h>
+#include <daos_srv/evtree.h>
+#include <daos_srv/srv_csum.h>
+#include <daos_srv/vos_types.h>
+#include <daos_srv/vos.h>
+#include <fcntl.h>
+#include <daos/tests_lib.h>
+
+
+/**
+ * Scrubbing tests are integration tests between checksum functionality
+ * and VOS. VOS does not calculate any checksums so the checksums for the
+ * data are calculated here in the tests, which makes it convinient for making
+ * the data appear as though it is corrupted. In general the tests write data
+ * using vos_obj_update, run the scanner, then try to fetch the data using
+ * vos_obj_fetch. If the data is corrupted, vos_obj_fetch should return
+ * -DER_CSUM. There are also callbacks that should be called appropriately
+ * to handle progress of the scanner and when corruption is discovered.
+ */
+
+#define assert_csum_error(r) do {\
+	int __rc = (r); \
+	if (__rc != -DER_CSUM) \
+		fail_msg("Expected -DER_CSUM but found: " DF_RC, DP_RC(__rc)); \
+	} while (0)
+
+/** ds_progress_handler_t */
+static int progress_cb_count;
+static int
+tst_handle_progress()
+{
+	progress_cb_count++;
+	return 0;
+}
+
+/** ds_corruption_handler */
+static int corruption_cb_count;
+static int
+tst_handle_corruption()
+{
+	corruption_cb_count++;
+	return 0;
+}
+
+/** easily setup and allocate an iov */
+static void
+iov_alloc(d_iov_t *iov, size_t len)
+{
+	D_ALLOC(iov->iov_buf, len);
+	iov->iov_buf_len = iov->iov_len = len;
+}
+
+static void
+iov_alloc_str(d_iov_t *iov, const char *str)
+{
+	iov_alloc(iov, strlen(str) + 1);
+	strcpy(iov->iov_buf, str);
+}
+
+/** Different types of IOD configurations for the test */
+enum TEST_IOD_TYPE {
+	TEST_IOD_SINGLE, /** DAOS_IOD_SINGLE */
+	TEST_IOD_ARRAY_1, /** DAOS_IOD_ARRAY with record size 1 */
+	TEST_IOD_ARRAY_2, /** DAOS_IOD_ARRAY with record size 2 */
+	TEST_IOD_ARRAY_20, /** DAOS_IOD_ARRAY with record size 20 */
+	TEST_IOD_ARRAY_256, /** DAOS_IOD_ARRAY with record size 256 */
+};
+
+/**
+ * setup the iod based on the iod test type. Will define the iod type, recxs
+ * if an array with different record sizes and start indexes.
+ */
+static void
+setup_iod_type(daos_iod_t *iod, int iod_type, daos_size_t data_len,
+	       daos_recx_t *recx)
+{
+	iod->iod_nr = 1;
+
+	switch (iod_type) {
+	case TEST_IOD_SINGLE:
+		iod->iod_type = DAOS_IOD_SINGLE;
+		iod->iod_size = data_len;
+		break;
+	case TEST_IOD_ARRAY_1:
+		iod->iod_recxs = recx;
+		iod->iod_type = DAOS_IOD_ARRAY;
+		iod->iod_size = 1;
+		iod->iod_recxs->rx_nr = data_len;
+		break;
+	case TEST_IOD_ARRAY_2:
+		iod->iod_type = DAOS_IOD_ARRAY;
+		iod->iod_recxs = recx;
+		iod->iod_size = 2;
+		iod->iod_recxs->rx_idx = 10;
+		iod->iod_recxs->rx_nr = data_len / 2;
+		break;
+	case TEST_IOD_ARRAY_20:
+		iod->iod_type = DAOS_IOD_ARRAY;
+		iod->iod_recxs = recx;
+		iod->iod_size = 20;
+		iod->iod_recxs->rx_idx = 95;
+		iod->iod_recxs->rx_nr = data_len / 20;
+		break;
+	case TEST_IOD_ARRAY_256:
+		iod->iod_type = DAOS_IOD_ARRAY;
+		iod->iod_recxs = recx;
+		iod->iod_size = 256;
+		iod->iod_recxs->rx_idx = 12345678;
+		iod->iod_recxs->rx_nr = data_len / 256;
+	}
+}
+
+/** scrubbing test context */
+struct sts_context {
+	char			 tsc_pmem_file[256];
+	uuid_t			 tsc_pool_uuid;
+	uuid_t			 tsc_cont_uuid;
+	uint64_t		 tsc_scm_size;
+	uint64_t		 tsc_nvme_size;
+	daos_size_t		 tsc_chunk_size;
+	daos_size_t		 tsc_data_len;
+	daos_handle_t		 tsc_poh;
+	daos_handle_t		 tsc_coh;
+	struct daos_csummer	*tsc_csummer;
+	ds_progress_handler_t	 tsc_credits_consumed_handler;
+	ds_corruption_handler_t	 tsc_corruption_handler;
+};
+
+static void
+sts_ctx_pool_init(struct sts_context *ctx)
+{
+	char		*pmem_file = ctx->tsc_pmem_file;
+	daos_handle_t	 poh = DAOS_HDL_INVAL;
+	int		 fd;
+	int		 rc;
+
+	if (!daos_file_is_dax(pmem_file)) {
+		rc = open(pmem_file, O_CREAT | O_TRUNC | O_RDWR, 0666);
+		if (rc < 0)
+			fail_msg("Unable to open pmem_file");
+
+		fd = rc;
+		rc = fallocate(fd, 0, 0, ctx->tsc_scm_size);
+		if (rc)
+			fail_msg("fallocate failed");
+	}
+
+	/* Use pool size as blob size for this moment. */
+	assert_success(vos_pool_create(pmem_file, ctx->tsc_pool_uuid, 0,
+			     ctx->tsc_nvme_size));
+	assert_success(vos_pool_open(pmem_file, ctx->tsc_pool_uuid, &poh));
+
+	ctx->tsc_poh = poh;
+}
+
+static void
+sts_ctx_pool_fini(struct sts_context *ctx)
+{
+	int	rc;
+
+	vos_pool_close(ctx->tsc_poh);
+	rc = vos_pool_destroy(ctx->tsc_pmem_file, ctx->tsc_pool_uuid);
+	D_ASSERTF(rc == 0 || rc == -DER_NONEXIST, "rc="DF_RC"\n", DP_RC(rc));
+}
+
+static int
+sts_ctx_cont_init(struct sts_context *ctx)
+{
+	daos_handle_t	coh = DAOS_HDL_INVAL;
+
+	assert_success(vos_cont_create(ctx->tsc_poh, ctx->tsc_cont_uuid));
+	assert_success(vos_cont_open(ctx->tsc_poh, ctx->tsc_cont_uuid, &coh));
+
+	ctx->tsc_coh = coh;
+
+	return 0;
+}
+
+static void
+sts_ctx_cont_fini(struct sts_context *ctx)
+{
+	vos_cont_close(ctx->tsc_coh);
+}
+
+static void
+sts_ctx_init(struct sts_context *ctx)
+{
+	/** default values */
+	ctx->tsc_scm_size = (1024 * 1024 * 1024);
+	if (ctx->tsc_scm_size == 0)
+		ctx->tsc_scm_size = (1024 * 1024 * 1024);
+	if (ctx->tsc_chunk_size == 0)
+		ctx->tsc_chunk_size = 1024;
+	if (ctx->tsc_data_len == 0)
+		ctx->tsc_data_len = 1024;
+
+	ctx->tsc_credits_consumed_handler = tst_handle_progress;
+	ctx->tsc_corruption_handler = tst_handle_corruption;
+	uuid_parse("12345678-1234-1234-1234-123456789012", ctx->tsc_pool_uuid);
+	sprintf(ctx->tsc_pmem_file, "/mnt/daos/vos_scrubbing.pmem");
+
+	assert_success(daos_debug_init(DAOS_LOG_DEFAULT));
+	assert_success(vos_init());
+	sts_ctx_pool_init(ctx);
+	sts_ctx_cont_init(ctx);
+
+	assert_success(
+		daos_csummer_init_with_type(&ctx->tsc_csummer,
+					    CSUM_TYPE_ISAL_CRC16_T10DIF,
+					    ctx->tsc_chunk_size, false));
+}
+
+static void
+sts_ctx_fini(struct sts_context *ctx)
+{
+	daos_csummer_destroy(&ctx->tsc_csummer);
+	sts_ctx_cont_fini(ctx);
+	sts_ctx_pool_fini(ctx);
+}
+
+static int
+sts_ctx_fetch(struct sts_context *ctx, daos_oclass_id_t oclass, int oid_lo,
+	      uint32_t shard, int iod_type, const char *dkey_str,
+	      const char *akey_str, int epoch, uint64_t data_len)
+{
+	daos_unit_oid_t	oid = {0};
+	daos_key_t	dkey;
+	daos_recx_t	recx = {0};
+	daos_iod_t	iod = {0};
+	char		data[data_len];
+	d_sg_list_t	sgl;
+	int		rc;
+
+	oid.id_shard	= shard;
+	oid.id_pad_32	= 0;
+	oid.id_pub.lo = oid_lo;
+	daos_obj_generate_id(&oid.id_pub, 0, oclass, 0);
+
+	iov_alloc_str(&iod.iod_name, akey_str);
+	setup_iod_type(&iod, iod_type, data_len, &recx);
+
+	d_sgl_init(&sgl, 1);
+	d_iov_set(&sgl.sg_iovs[0], data, data_len);
+
+	iov_alloc_str(&dkey, dkey_str);
+	rc = vos_obj_fetch(ctx->tsc_coh, oid, epoch, 0, &dkey, 1, &iod, &sgl);
+
+	D_FREE(dkey.iov_buf);
+	D_FREE(iod.iod_name.iov_buf);
+
+	return rc;
+}
+
+static void
+sts_ctx_update(struct sts_context *ctx, daos_oclass_id_t oclass, int oid_lo,
+	       uint32_t shard, int iod_type, const char *dkey_str,
+	       const char *akey_str, int epoch, const char *data_str,
+	       bool corrupt_it)
+{
+	daos_unit_oid_t		 oid = {0};
+	daos_key_t		 dkey;
+	struct dcs_iod_csums	*iod_csum = NULL;
+	daos_iod_t		 iod = {0};
+	daos_recx_t		 recx = {0};
+	d_sg_list_t		 sgl;
+	size_t			 data_len;
+	char			*data = NULL;
+	int			 rc;
+
+	oid.id_shard	= shard;
+	oid.id_pad_32	= 0;
+	oid.id_pub.lo = oid_lo;
+	daos_obj_generate_id(&oid.id_pub, 0, oclass, 0);
+
+	if (data_str != NULL) {
+		data_len = strlen(data_str);
+		D_ALLOC(data,  data_len);
+		memcpy(data, data_str, data_len);
+	} else {
+		data_len = ctx->tsc_data_len;
+		D_ALLOC(data, data_len);
+		dts_buf_render(data, data_len);
+	}
+
+	iov_alloc_str(&iod.iod_name, akey_str);
+	setup_iod_type(&iod, iod_type, data_len, &recx);
+
+	d_sgl_init(&sgl, 1);
+	d_iov_set(&sgl.sg_iovs[0], data, data_len);
+
+	rc = daos_csummer_calc_iods(ctx->tsc_csummer, &sgl, &iod, NULL, 1,
+				    false, NULL, 0, &iod_csum);
+	assert_success(rc);
+	if (corrupt_it) {
+		uint32_t idx_to_corrupt = 0;
+
+		if (iod.iod_type == DAOS_IOD_ARRAY) {
+			/** corrupt last record */
+			idx_to_corrupt = (iod.iod_recxs->rx_nr - 1)  *
+				iod.iod_size;
+		}
+
+		((char *)sgl.sg_iovs[0].iov_buf)[idx_to_corrupt] += 2;
+	}
+
+	iov_alloc_str(&dkey, dkey_str);
+	rc = vos_obj_update(ctx->tsc_coh, oid, epoch, 0, 0, &dkey, 1, &iod,
+			    iod_csum, &sgl);
+	assert_success(rc);
+
+	/**
+	 * make sure can fetch right after update. Even if data was corrupted,
+	 * it should still fetch fine
+	 */
+	rc = sts_ctx_fetch(ctx, oclass, oid_lo, shard, iod_type,
+			   dkey_str, akey_str, epoch, data_len);
+	assert_success(rc);
+
+	daos_csummer_free_ic(ctx->tsc_csummer, &iod_csum);
+
+	D_FREE(dkey.iov_buf);
+	D_FREE(iod.iod_name.iov_buf);
+}
+
+static void
+sts_ctx_do_scrub(struct sts_context *ctx)
+{
+	assert_success(ds_obj_csum_scrub(ctx->tsc_coh, ctx->tsc_csummer,
+					 ctx->tsc_credits_consumed_handler,
+					 ctx->tsc_corruption_handler));
+}
+
+/**
+ * ----------------------------------------------------------------------------
+ * Tests
+ * ----------------------------------------------------------------------------
+ */
+static void
+scrubbing_with_no_corruption(void **state)
+{
+	struct sts_context *ctx = *state;
+
+	/** setup data */
+	sts_ctx_update(ctx, OC_SX, 1, 0, TEST_IOD_SINGLE, "dkey", "akey",
+		       1, NULL, false);
+
+	/** act */
+	sts_ctx_do_scrub(ctx);
+
+	/** verify after scrub value is still good */
+	assert_success(
+		sts_ctx_fetch(ctx, OC_SX, 1, 0, TEST_IOD_SINGLE, "dkey",
+			      "akey", 1, 1024));
+
+	assert_int_equal(1, progress_cb_count);
+	assert_int_equal(0, corruption_cb_count);
+}
+
+static void
+scrubbing_with_sv_corrupted(void **state)
+{
+	struct sts_context *ctx = *state;
+
+	/** setup data */
+	sts_ctx_update(ctx, OC_SX, 1, 0, TEST_IOD_SINGLE, "dkey", "akey",
+		       1, NULL, true);
+
+	/** act */
+	sts_ctx_do_scrub(ctx);
+
+	/** verify after scrub fetching the akey returns a csum error */
+	assert_csum_error(
+		sts_ctx_fetch(ctx, OC_SX, 1, 0, TEST_IOD_SINGLE, "dkey",
+			      "akey", 1, 1024));
+
+	assert_int_equal(1, progress_cb_count);
+	assert_int_equal(1, corruption_cb_count);
+}
+
+static void
+corrupted_extent(void **state)
+{
+	struct sts_context *ctx = *state;
+
+
+	ctx->tsc_data_len = ctx->tsc_chunk_size * 2;
+	/** setup data */
+	sts_ctx_update(ctx, OC_SX, 1, 0, TEST_IOD_ARRAY_1, "dkey", "akey",
+		       1, NULL, true);
+
+	sts_ctx_do_scrub(ctx);
+
+	assert_int_equal(2, progress_cb_count);
+	assert_int_equal(1, corruption_cb_count);
+}
+
+static void
+scrubbing_with_arrays_corrupted(void **state)
+{
+	struct sts_context *ctx = *state;
+
+	/** setup data */
+	sts_ctx_update(ctx, OC_SX, 1, 0, TEST_IOD_ARRAY_1, "dkey", "akey",
+		       1, NULL, true);
+	sts_ctx_update(ctx, OC_SX, 1, 0, TEST_IOD_ARRAY_2, "dkey", "akey-2",
+		       1, NULL, true);
+	sts_ctx_update(ctx, OC_SX, 1, 0, TEST_IOD_ARRAY_20,
+		       "dkey", "akey-3", 1, NULL, true);
+
+	/** act */
+	sts_ctx_do_scrub(ctx);
+
+	/** verify saw all errors */
+	assert_int_equal(3, corruption_cb_count);
+
+	/** verify after scrub fetching the akey values return csum errors */
+	assert_csum_error(
+		sts_ctx_fetch(ctx, OC_SX, 1, 0, TEST_IOD_ARRAY_1, "dkey",
+			      "akey", 1, 1024));
+	assert_csum_error(
+		sts_ctx_fetch(ctx, OC_SX, 1, 0, TEST_IOD_ARRAY_2, "dkey",
+			      "akey-2", 1, 1024));
+	assert_csum_error(
+		sts_ctx_fetch(ctx, OC_SX, 1, 0, TEST_IOD_ARRAY_20, "dkey",
+			      "akey-3", 1, 1024));
+}
+
+static void
+scrubbing_with_multiple_dkeys_akeys(void **state)
+{
+	struct sts_context *ctx = *state;
+
+	sts_ctx_update(ctx, OC_SX, 1, 0, TEST_IOD_SINGLE, "dkey", "akey",
+		       1, NULL, false);
+
+	/** insert a corrupted value */
+	sts_ctx_update(ctx, OC_SX, 1, 0, TEST_IOD_SINGLE, "dkey",
+		       "akey-corrupted",
+		       1, NULL, true);
+
+	/** Cover corruption with write to later epoch */
+	sts_ctx_update(ctx, OC_SX, 1, 0, TEST_IOD_SINGLE, "dkey",
+		       "akey-corrupted", 2, NULL, false);
+
+	sts_ctx_update(ctx, OC_SX, 1, 0, TEST_IOD_SINGLE, "dkey",
+		       "akey-2", 1, NULL, false);
+
+	sts_ctx_update(ctx, OC_SX, 1, 1, TEST_IOD_ARRAY_1, "dkey",
+		       "akey-3", 1, NULL, false);
+
+	sts_ctx_update(ctx, OC_SX, 1, 1, TEST_IOD_ARRAY_2, "dkey",
+		       "akey-4", 1, NULL, false);
+
+	/** Act */
+	sts_ctx_do_scrub(ctx);
+
+	/** corrupted akey should error */
+	assert_csum_error(sts_ctx_fetch(ctx, OC_SX, 1, 0, TEST_IOD_SINGLE,
+					"dkey", "akey-corrupted", 1, 1024));
+
+	/** non-corrupted akey should still succeed */
+	assert_success(sts_ctx_fetch(ctx, OC_SX, 1, 1, TEST_IOD_ARRAY_1,
+				     "dkey", "akey", 1, 1024));
+}
+
+static int
+sts_setup(void **state)
+{
+	struct sts_context	*ctx;
+
+	D_ALLOC_PTR(ctx);
+
+	assert_non_null(ctx);
+	sts_ctx_init(ctx);
+	*state = ctx;
+
+	progress_cb_count = 0;
+	corruption_cb_count = 0;
+
+	return 0;
+}
+
+static int
+sts_teardown(void **state)
+{
+	struct sts_context *ctx = *state;
+
+	sts_ctx_fini(ctx);
+	D_FREE(ctx);
+
+	return 0;
+}
+
+#define	TS(desc, test_fn) \
+	{ desc, test_fn, sts_setup, sts_teardown }
+
+static const struct CMUnitTest scrubbing_tests[] = {
+	TS("CSUM_SCRUBBING_01: WIP With no corruption",
+	   scrubbing_with_no_corruption),
+	TS("CSUM_SCRUBBING_02: With a single value corrupted",
+	   scrubbing_with_sv_corrupted),
+	TS("CSUM_SCRUBBING_03: With an corrupted extent value",
+	   corrupted_extent),
+	TS("CSUM_SCRUBBING_04: With an array value",
+	   scrubbing_with_arrays_corrupted),
+	TS("CSUM_SCRUBBING_05: Multiple keys",
+	   scrubbing_with_multiple_dkeys_akeys),
+};
+
+int
+run_scrubbing_tests()
+{
+	return cmocka_run_group_tests_name(
+		"Storage and retrieval of checksums for Single Value Type",
+		scrubbing_tests, NULL, NULL);
+
+}

--- a/src/object/tests/srv_scrubbing_tests.c
+++ b/src/object/tests/srv_scrubbing_tests.c
@@ -34,7 +34,6 @@
 #include <fcntl.h>
 #include <daos/tests_lib.h>
 
-
 /**
  * Scrubbing tests are integration tests between checksum functionality
  * and VOS. VOS does not calculate any checksums so the checksums for the
@@ -358,6 +357,17 @@ sts_ctx_do_scrub(struct sts_context *ctx)
 					 ctx->tsc_corruption_handler));
 }
 
+
+/** Test Fake */
+int
+dss_ult_create(void (*func)(void *), void *arg, int ult_type, int tgt_idx,
+	       size_t stack_size, ABT_thread *ult)
+{
+	func(arg);
+
+	return 0;
+}
+
 /**
  * ----------------------------------------------------------------------------
  * Tests
@@ -523,7 +533,7 @@ sts_teardown(void **state)
 	{ desc, test_fn, sts_setup, sts_teardown }
 
 static const struct CMUnitTest scrubbing_tests[] = {
-	TS("CSUM_SCRUBBING_01: WIP With no corruption",
+	TS("CSUM_SCRUBBING_01: With no corruption",
 	   scrubbing_with_no_corruption),
 	TS("CSUM_SCRUBBING_02: With a single value corrupted",
 	   scrubbing_with_sv_corrupted),

--- a/src/tests/suite/daos_checksum.c
+++ b/src/tests/suite/daos_checksum.c
@@ -34,12 +34,6 @@
 static void
 iov_update_fill(d_iov_t *iov, char *data, uint64_t len_to_fill);
 
-#define assert_success(r) do {\
-	int __rc = (r); \
-	if (__rc != 0) \
-		fail_msg("Not successful!! Error code: " DF_RC, DP_RC(__rc)); \
-	} while (0)
-
 unsigned int
 daos_checksum_test_arg2type(char *str)
 {

--- a/src/tests/suite/daos_dedup.c
+++ b/src/tests/suite/daos_dedup.c
@@ -28,12 +28,6 @@
 #include <gurt/types.h>
 #include <daos_prop.h>
 
-#define assert_success(r) do {\
-	int __rc = (r); \
-	if (__rc != 0) \
-		fail_msg("Not successful!! Error code: " DF_RC, DP_RC(__rc)); \
-	} while (0)
-
 struct dedup_test_ctx {
 	/** Pool */
 	daos_handle_t		poh;

--- a/src/vos/evtree.c
+++ b/src/vos/evtree.c
@@ -1907,6 +1907,8 @@ evt_desc_copy(struct evt_context *tcx, const struct evt_entry_in *ent,
 
 	dst_desc->dc_ex_addr = ent->ei_addr;
 	dst_desc->dc_ver = ent->ei_ver;
+	if (ent->ei_corrupted)
+		BIO_ADDR_SET_CORRUPTED(&dst_desc->dc_ex_addr);
 	evt_desc_csum_fill(tcx, dst_desc, ent, csum_bufp);
 
 	return 0;
@@ -2083,6 +2085,7 @@ evt_entry_fill(struct evt_context *tcx, struct evt_node *node, unsigned int at,
 	evt_entry_csum_fill(tcx, desc, entry);
 	entry->en_avail_rc = evt_desc_log_status(tcx, entry->en_epoch, desc,
 						 intent);
+	entry->en_corrupted = BIO_ADDR_IS_CORRUPTED(&desc->dc_ex_addr);
 
 	if (offset != 0) {
 		/* Adjust cached pointer since we're only referencing a
@@ -2247,6 +2250,10 @@ evt_ent_array_fill(struct evt_context *tcx, enum evt_find_opc find_opc,
 			}
 
 			evt_entry_fill(tcx, node, i, rect, intent, ent);
+			if (ent->en_corrupted) {
+				rc = -DER_CSUM;
+				goto out;
+			}
 			switch (find_opc) {
 			default:
 				D_ASSERTF(0, "%d\n", find_opc);
@@ -2709,6 +2716,8 @@ evt_common_insert(struct evt_context *tcx, struct evt_node *nd,
 		desc->dc_ex_addr = ent->ei_addr;
 		evt_desc_csum_fill(tcx, desc, ent, csum_bufp);
 		desc->dc_ver = ent->ei_ver;
+		if (ent->ei_corrupted)
+			BIO_ADDR_SET_CORRUPTED(&desc->dc_ex_addr);
 	} else {
 		nd->tn_child[i] = in_off;
 	}

--- a/src/vos/tests/vts_checksum.c
+++ b/src/vos/tests/vts_checksum.c
@@ -30,6 +30,7 @@
  * Structure which uniquely identifies a extent in a key value pair.
  */
 struct extent_key {
+	daos_handle_t	pool_hdl;
 	daos_handle_t	container_hdl;
 	daos_unit_oid_t	object_id;
 	daos_key_t	dkey;
@@ -43,7 +44,7 @@ struct extent_key {
  */
 void
 extent_key_from_test_args(struct extent_key *k,
-			       struct io_test_args *args)
+			  struct io_test_args *args)
 {
 	/* Set up dkey and akey */
 	dts_key_gen(&k->dkey_buf[0], args->dkey_size, args->dkey);
@@ -52,6 +53,7 @@ extent_key_from_test_args(struct extent_key *k,
 	set_iov(&k->akey, &k->akey_buf[0], args->ofeat & DAOS_OF_AKEY_UINT64);
 
 	k->container_hdl = args->ctx.tc_co_hdl;
+	k->pool_hdl = args->ctx.tc_po_hdl;
 	k->object_id = args->oid;
 }
 
@@ -419,6 +421,91 @@ update_fetch_csum_for_array_10(void **state)
 	});
 }
 
+static void
+mark_sv_corrupted(void **state)
+{
+	struct extent_key	 k = {0};
+	daos_iod_t		 iod = {0};
+	d_sg_list_t		 sgl = {0};
+	int			 rc = 0;
+
+	/** setup */
+	extent_key_from_test_args(&k, *state);
+	dts_sgl_init_with_strings(&sgl, 1, "Going to be corrupted!!");
+
+	iod.iod_name = k.akey;
+	iod.iod_size = daos_sgl_buf_size(&sgl);
+	iod.iod_nr = 1;
+	iod.iod_type = DAOS_IOD_SINGLE;
+
+	assert_success(vos_obj_update(k.container_hdl, k.object_id, 1, 0, 0,
+				      &k.dkey, 1, &iod, NULL, &sgl));
+
+	/** reset sgl and fetch just to sanity check that it works before
+	 * marking as corrupted
+	 */
+	memset(sgl.sg_iovs[0].iov_buf, 0, sgl.sg_iovs[0].iov_buf_len);
+	assert_success(vos_obj_fetch(k.container_hdl, k.object_id, 1, 0,
+				     &k.dkey, 1, &iod, &sgl));
+
+	/** Mark as corrupted using the corrupt flag */
+	assert_success(vos_obj_update(k.container_hdl, k.object_id, 1, 0,
+				      VOS_OF_CORRUPT,
+				      &k.dkey, 1, &iod, NULL, &sgl));
+
+	/** now should return a checksum error */
+	rc = vos_obj_fetch(k.container_hdl, k.object_id, 1, 0, &k.dkey, 1, &iod,
+			   &sgl);
+	assert_int_equal(-DER_CSUM, rc);
+
+	/** clean up */
+	daos_sgl_fini(&sgl, true);
+}
+static void
+mark_extent_corrupted(void **state)
+{
+	struct extent_key	k;
+	daos_iod_t		iod = {0};
+	daos_recx_t		recx;
+	d_sg_list_t		sgl;
+	int			rc;
+
+	/** setup */
+	extent_key_from_test_args(&k, *state);
+	dts_sgl_init_with_strings(&sgl, 1, "Going to be corrupted!!");
+
+	recx.rx_nr = daos_sgl_buf_size(&sgl);
+	recx.rx_idx = 0;
+	iod.iod_name = k.akey;
+	iod.iod_size = 1;
+	iod.iod_nr = 1;
+	iod.iod_recxs = &recx;
+	iod.iod_type = DAOS_IOD_ARRAY;
+
+	assert_success(vos_obj_update(k.container_hdl, k.object_id, 1, 0, 0,
+				      &k.dkey, 1, &iod, NULL, &sgl));
+
+	/** reset sgl and fetch just to sanity check that it works before
+	 * marking as corrupted
+	 */
+	memset(sgl.sg_iovs[0].iov_buf, 0, sgl.sg_iovs[0].iov_buf_len);
+	assert_success(vos_obj_fetch(k.container_hdl, k.object_id, 1, 0,
+				     &k.dkey, 1, &iod, &sgl));
+
+	/** Mark as corrupted using the corrupt flag */
+	assert_success(vos_obj_update(k.container_hdl, k.object_id, 1, 0,
+				      VOS_OF_CORRUPT,
+				      &k.dkey, 1, &iod, NULL, &sgl));
+
+	/** now should return a checksum error */
+	rc = vos_obj_fetch(k.container_hdl, k.object_id, 1, 0, &k.dkey, 1, &iod,
+			   &sgl);
+	assert_int_equal(-DER_CSUM, rc);
+
+	/** clean up */
+	daos_sgl_fini(&sgl, true);
+}
+
 /**
  * -------------------------------------
  * Helper function tests
@@ -737,18 +824,18 @@ test_evt_entry_csum_update(void **state)
 			 actual.cs_csum);
 }
 
-int setup(void **state)
+int vts_csum_setup(void **state)
 {
 	return 0;
 }
 
-int teardown(void **state)
+int vts_csum_teardown(void **state)
 {
 	return 0;
 }
 
 #define	VOS(desc, test_fn) \
-	{ "VOS_CSUM" desc, test_fn, setup, teardown}
+	{ "VOS_CSUM" desc, test_fn, vts_csum_setup, vts_csum_teardown}
 
 static const struct CMUnitTest update_fetch_checksums_for_array_types[] = {
 	VOS("01: Single chunk", update_fetch_csum_for_array_1),
@@ -761,10 +848,12 @@ static const struct CMUnitTest update_fetch_checksums_for_array_types[] = {
 	VOS("08: Partial -> more partial", update_fetch_csum_for_array_8),
 	VOS("09: Many sequential extents", update_fetch_csum_for_array_9),
 	VOS("10: Holes", update_fetch_csum_for_array_10),
+	VOS("11: Mark corrupted", mark_sv_corrupted),
+	VOS("12: Mark corrupted", mark_extent_corrupted),
 };
 
 #define	EVT(desc, test_fn) \
-	{ "EVT_CSUM" desc, test_fn, setup, teardown}
+	{ "EVT_CSUM" desc, test_fn, vts_csum_setup, vts_csum_teardown}
 static const struct CMUnitTest evt_checksums_tests[] = {
 	EVT("01: Some EVT Checksum Helper Functions",
 		evt_csum_helper_functions_tests),

--- a/src/vos/vos_internal.h
+++ b/src/vos/vos_internal.h
@@ -535,6 +535,8 @@ struct vos_rec_bundle {
 	umem_off_t		 rb_off;
 	/** checksum buffer for the daos key */
 	struct dcs_csum_info	*rb_csum;
+	/** The record is corrupted */
+	bool			 rb_corrupt;
 	/**
 	 * Input  : value buffer (non-rdma data)
 	 *	    TODO also support scatter/gather list input.

--- a/src/vos/vos_tree.c
+++ b/src/vos/vos_tree.c
@@ -431,6 +431,8 @@ svt_rec_store(struct btr_instance *tins, struct btr_record *rec,
 	irec->ir_ex_addr	= biov->bi_addr;
 	irec->ir_ver		= rbund->rb_ver;
 	irec->ir_minor_epc	= skey->sk_minor_epc;
+	if (rbund->rb_corrupt)
+		BIO_ADDR_SET_CORRUPTED(&irec->ir_ex_addr);
 
 	if (irec->ir_size == 0) { /* it is a punch */
 		csum->cs_csum = NULL;
@@ -493,6 +495,7 @@ svt_rec_load(struct btr_instance *tins, struct btr_record *rec,
 	rbund->rb_rsize	= irec->ir_size;
 	rbund->rb_gsize	= irec->ir_gsize;
 	rbund->rb_ver	= irec->ir_ver;
+	rbund->rb_corrupt = BIO_ADDR_IS_CORRUPTED(&irec->ir_ex_addr);
 	return 0;
 }
 
@@ -665,8 +668,7 @@ svt_rec_fetch(struct btr_instance *tins, struct btr_record *rec,
 	if (key_iov != NULL)
 		key = iov2svt_key(key_iov);
 
-	svt_rec_load(tins, rec, key, rbund);
-	return 0;
+	return svt_rec_load(tins, rec, key, rbund);
 }
 
 static int


### PR DESCRIPTION
The scanner iterates over the vos tree structure for all objects in a given
open container. It will calculate new checksums for the data and compare
to the checksums stored for the data. If they don't match then corruption
has been discovered.

- Added a flags field to bio addr. Will use to indicate data is corrupted.
- vos_obj_update can be used to mark a bio addr as being corrupted using
  the VOS_OF_CORRUPTED flag.
- vos_obj_fetch will return -DER_CSUM if the bio addr is marked corrupted.

Signed-off-by: Ryon Jensen <ryon.jensen@intel.com>