### PR TITLE
DAOS-5158 control: remove uuid parameter for dmg pool create

### DIFF
--- a/doc/man/man8/dmg.8
+++ b/doc/man/man8/dmg.8
@@ -1,4 +1,4 @@
-.TH dmg 1 "24 August 2020"
+.TH dmg 1 "25 August 2020"
 .SH NAME
 dmg \- Administrative tool for managing DAOS clusters
 .SH SYNOPSIS
@@ -105,9 +105,6 @@ Number of pool service replicas
 .TP
 \fB\fB\-S\fR, \fB\-\-sys\fR <default: \fI"daos_server"\fR>\fP
 DAOS system that pool is to be a part of
-.TP
-\fB\fB\-p\fR, \fB\-\-pool\fR\fP
-UUID to be used when creating the pool, randomly generated if not specified
 .SS pool delete-acl
 Delete an entry from a DAOS pool's Access Control List
 

--- a/src/control/cmd/dmg/pool.go
+++ b/src/control/cmd/dmg/pool.go
@@ -79,7 +79,6 @@ type PoolCreateCmd struct {
 	RankList   string `short:"r" long:"ranks" description:"Storage server unique identifiers (ranks) for DAOS pool"`
 	NumSvcReps uint32 `short:"v" long:"nsvc" default:"1" description:"Number of pool service replicas"`
 	Sys        string `short:"S" long:"sys" default:"daos_server" description:"DAOS system that pool is to be a part of"`
-	UUID       string `short:"p" long:"pool" description:"UUID to be used when creating the pool, randomly generated if not specified"`
 }
 
 // Execute is run when PoolCreateCmd subcommand is activated
@@ -134,7 +133,6 @@ func (c *PoolCreateCmd) Execute(args []string) error {
 		ScmBytes: scmBytes, NvmeBytes: nvmeBytes, Ranks: ranks,
 		NumSvcReps: c.NumSvcReps, Sys: c.Sys,
 		User: c.UserName, UserGroup: c.GroupName, ACL: acl,
-		UUID: c.UUID,
 	}
 
 	ctx := context.Background()

--- a/src/control/lib/control/pool.go
+++ b/src/control/lib/control/pool.go
@@ -126,18 +126,11 @@ func genPoolCreateRequest(in *PoolCreateReq) (out *mgmtpb.PoolCreateReq, err err
 		return nil, err
 	}
 
-	// generate a UUID if not supplied in the request
-	if err := checkUUID(out.Uuid); err != nil {
-		if out.Uuid != "" {
-			return nil, err
-		}
-
-		genUUID, err := uuid.NewRandom()
-		if err != nil {
-			return nil, err
-		}
-		out.Uuid = genUUID.String()
+	genUUID, err := uuid.NewRandom()
+	if err != nil {
+		return nil, err
 	}
+	out.Uuid = genUUID.String()
 
 	return
 }
@@ -155,7 +148,6 @@ type (
 		User       string
 		UserGroup  string
 		ACL        *AccessControlList
-		UUID       string
 	}
 
 	// PoolCreateResp contains the response from a pool create request.

--- a/src/control/lib/control/pool_test.go
+++ b/src/control/lib/control/pool_test.go
@@ -29,6 +29,7 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/pkg/errors"
 
 	"github.com/daos-stack/daos/src/control/common"
@@ -251,16 +252,8 @@ func TestControl_PoolCreate(t *testing.T) {
 			},
 			expErr: errors.New("remote failed"),
 		},
-		"invalid UUID": {
-			req: &PoolCreateReq{
-				UUID: "bad",
-			},
-			expErr: errors.New("invalid UUID"),
-		},
 		"success": {
-			req: &PoolCreateReq{
-				UUID: MockUUID,
-			},
+			req: &PoolCreateReq{},
 			mic: &MockInvokerConfig{
 				UnaryResponse: MockMSResponse("host1", nil,
 					&mgmtpb.PoolCreateResp{
@@ -269,7 +262,6 @@ func TestControl_PoolCreate(t *testing.T) {
 				),
 			},
 			expResp: &PoolCreateResp{
-				UUID:    MockUUID,
 				SvcReps: []uint32{0, 1, 2},
 			},
 		},
@@ -292,7 +284,8 @@ func TestControl_PoolCreate(t *testing.T) {
 				return
 			}
 
-			if diff := cmp.Diff(tc.expResp, gotResp); diff != "" {
+			cmpOpt := cmpopts.IgnoreFields(PoolCreateResp{}, "UUID")
+			if diff := cmp.Diff(tc.expResp, gotResp, cmpOpt); diff != "" {
 				t.Fatalf("Unexpected response (-want, +got):\n%s\n", diff)
 			}
 		})


### PR DESCRIPTION
This parameter was added in f82ab3ec (DAOS-4281) as a convenience,
but it turns out that it may cause problems (e.g. user supplies same
UUID twice, etc). Now that dmg has JSON output, a better option for
getting the UUID used to create a pool would involve parsing the
output, e.g. POOL_UUID=$(dmg pool create -s ...  --json | jq '.UUID')

Signed-off-by: Tom Nabarro <tom.nabarro@intel.com>