### PR TITLE
DAOS-4943 tests: Enable libfabric warn messages

### DIFF
--- a/src/tests/ftest/util/server_utils_params.py
+++ b/src/tests/ftest/util/server_utils_params.py
@@ -349,7 +349,8 @@ class DaosServerYamlParameters(YamlParameters):
                 "ABT_ENV_MAX_NUM_XSTREAMS=100",
                 "ABT_MAX_NUM_XSTREAMS=100",
                 "DAOS_MD_CAP=1024",
-                "DD_MASK=mgmt,io,md,epc,rebuild"
+                "DD_MASK=mgmt,io,md,epc,rebuild",
+                "FI_LOG_LEVEL=warn"
             ]
             if default_provider == "ofi+sockets":
                 default_env_vars.extend([


### PR DESCRIPTION
Enable libfabric "warn" level log messages, which should not overly
verbose, in order to help diagnose network issues.

Signed-off-by: Li Wei <wei.g.li@intel.com>