### PR TITLE
DAOS-5198 control: fail daos_server unrecognised cmdline args

### DIFF
--- a/src/control/cmd/daos_server/main.go
+++ b/src/control/cmd/daos_server/main.go
@@ -97,6 +97,11 @@ func parseOpts(args []string, opts *mainOpts, log *logging.LeveledLogger) error 
 	p := flags.NewParser(opts, flags.HelpFlag|flags.PassDoubleDash)
 	p.SubcommandsOptional = false
 	p.CommandHandler = func(cmd flags.Commander, cmdArgs []string) error {
+		if len(cmdArgs) > 0 {
+			// don't support positional arguments, extra cmdArgs are unexpected
+			return errors.Errorf("unexpected commandline arguments: %v", cmdArgs)
+		}
+
 		if !opts.AllowProxy {
 			common.ScrubProxyVariables()
 		}


### PR DESCRIPTION
Supplying config option `-o` with the file path that doesn't exist
will yield an error, whereas the same commandline without the config
option specifier will not error and will continue as though no config
file has been specified. Detect and fail on unrecognised args as we
don't support positional arguments to daos_server cmd.

Signed-off-by: Tom Nabarro <tom.nabarro@intel.com>