### PR TITLE
DAOS-5533 test: use object cls RP_2G1 (osa drain)

### DIFF
--- a/src/tests/ftest/osa/osa_online_drain.yaml
+++ b/src/tests/ftest/osa/osa_online_drain.yaml
@@ -41,7 +41,7 @@ ior:
       ior_api:
         - DFS
       obj_class:
-        - "RP_2GX"
+        - "RP_2G1"
     ior_test_sequence:
     #   - [scmsize, nvmesize, transfersize, blocksize, PASS/FAIL(Expected) ]
     #    The values are set to be in the multiples of 10.


### PR DESCRIPTION
Summary: Replace the unsupported RP_2GX class with RP_GP1. RP_GPX is not
supported under OSA now.

Signed-off-by: Padmanabhan <ravindran.padmanabhan@intel.com>