### PR TITLE
DAOS-5534 build: separate out openmpi install in docker file

### DIFF
--- a/doc/admin/installation.md
+++ b/doc/admin/installation.md
@@ -68,7 +68,7 @@ maintained in the Docker files:
 
 The command lines to install the required packages can be extracted from
 the Docker files by removing the "RUN" command, which is specific to Docker.
-Check the [docker](https://github.com/daos-stack/daos/tree/master/utils/docker)
+Check the [utils/docker](https://github.com/daos-stack/daos/tree/master/utils/docker)
 directory for different Linux distribution versions.
 
 Some DAOS tests use MPI.   The DAOS build process

--- a/utils/docker/Dockerfile.centos.7
+++ b/utils/docker/Dockerfile.centos.7
@@ -73,8 +73,9 @@ RUN yum -y install \
            python2-clustershell python2-Cython                 \
            python36-clustershell python36-paramiko             \
            python36-numpy python36-jira python3-pip Lmod       \
-           fuse3-devel libipmctl-devel openmpi3-devel          \
+           fuse3-devel libipmctl-devel                         \
            hwloc-devel patchelf python36-tabulate java-1.8.0-openjdk
+RUN yum -y install openmpi3-devel
 
 # DAOS python 3 packages required for pylint
 #  - excluding mpi4py as it depends on CORCI-635


### PR DESCRIPTION
Do the yum install of openmpi3-devel as an individual step in
the CentOS docker file. This yum install fails when MOFED is
installed, and doing this install as an isolated step avoids
failing the install of the whole list of "DAOS specific" RPMs.

Signed-off-by: Michael Hennecke <mhennecke@lenovo.com>