### PR TITLE
DAOS-5539: rebuild: rebuild iv hang

### DIFF
--- a/src/cart/crt_iv.c
+++ b/src/cart/crt_iv.c
@@ -2090,7 +2090,8 @@ handle_ivsync_response(const struct crt_cb_info *cb_info)
 
 	if (iv_sync->isc_sync_type.ivs_comp_cb)
 		iv_sync->isc_sync_type.ivs_comp_cb(
-			iv_sync->isc_sync_type.ivs_comp_cb_arg);
+			iv_sync->isc_sync_type.ivs_comp_cb_arg,
+			cb_info->cci_rc);
 
 	if (iv_sync->isc_ivns_internal)
 		IVNS_DECREF(iv_sync->isc_ivns_internal);
@@ -2256,7 +2257,7 @@ exit:
 			D_FREE(iv_sync_cb);
 		}
 		if (sync_type->ivs_comp_cb)
-			sync_type->ivs_comp_cb(sync_type->ivs_comp_cb_arg);
+			sync_type->ivs_comp_cb(sync_type->ivs_comp_cb_arg, rc);
 	}
 
 	return rc;
@@ -3173,7 +3174,7 @@ put:
 	iv_ops->ivo_on_put(ivns, NULL, priv);
 exit:
 	if (rc != 0 && sync_type.ivs_comp_cb)
-		sync_type.ivs_comp_cb(sync_type.ivs_comp_cb_arg);
+		sync_type.ivs_comp_cb(sync_type.ivs_comp_cb_arg, rc);
 
 	if (ivns_internal)
 		IVNS_DECREF(ivns_internal);
@@ -3204,7 +3205,7 @@ crt_iv_update(crt_iv_namespace_t ivns, uint32_t class_id,
 			rc, cb_arg);
 
 		if (sync_type.ivs_comp_cb)
-			sync_type.ivs_comp_cb(sync_type.ivs_comp_cb_arg);
+			sync_type.ivs_comp_cb(sync_type.ivs_comp_cb_arg, rc);
 		D_GOTO(exit, rc);
 	}
 

--- a/src/include/cart/iv.h
+++ b/src/include/cart/iv.h
@@ -614,7 +614,7 @@ typedef enum {
 	CRT_IV_SYNC_BIDIRECTIONAL = 0x2,
 } crt_iv_sync_flag_t;
 
-typedef int (*crt_iv_sync_done_cb_t)(void *cb_arg);
+typedef int (*crt_iv_sync_done_cb_t)(void *cb_arg, int rc);
 typedef struct {
 	crt_iv_sync_mode_t	ivs_mode;
 	crt_iv_sync_event_t	ivs_event;

--- a/src/iosrv/server_iv.c
+++ b/src/iosrv/server_iv.c
@@ -867,7 +867,7 @@ iv_op_internal(struct ds_iv_ns *ns, struct ds_iv_key *key_iv,
 	rc = ABT_future_create(1, NULL, &future);
 	if (rc) {
 		if (sync != NULL && sync->ivs_comp_cb)
-			sync->ivs_comp_cb(sync->ivs_comp_cb_arg);
+			sync->ivs_comp_cb(sync->ivs_comp_cb_arg, rc);
 		return rc;
 	}
 
@@ -916,14 +916,95 @@ out:
 	return rc;
 }
 
+struct sync_comp_cb_arg {
+	d_sg_list_t	iv_value;
+	struct ds_iv_key iv_key;
+	struct ds_iv_ns	*ns;
+	unsigned int	shortcut;
+	crt_iv_sync_t	iv_sync;
+	int		opc;
+	bool		retry;
+};
+
+static int
+iv_op(struct ds_iv_ns *ns, struct ds_iv_key *key, d_sg_list_t *value,
+      crt_iv_sync_t *sync, unsigned int shortcut, bool retry, int opc);
+
+static int
+sync_comp_cb(void *arg, int rc)
+{
+	struct sync_comp_cb_arg *cb_arg = arg;
+
+	if (cb_arg == NULL)
+		return rc;
+
+	/* Let's retry asynchronous IV only for GRPVER for the moment */
+	if (cb_arg->retry && rc == -DER_GRPVER) {
+		int rc1;
+
+		/* If the IV ns leader has been changed, then it will retry
+		 * in the mean time, it will rely on others to update the
+		 * ns for it.
+		 */
+		D_WARN("retry upon %d for class %d opc %d\n", rc,
+		       cb_arg->iv_key.class_id, IV_UPDATE);
+		rc1 = iv_op(cb_arg->ns, &cb_arg->iv_key, &cb_arg->iv_value,
+			    &cb_arg->iv_sync, cb_arg->shortcut, cb_arg->retry,
+			    cb_arg->opc);
+		if (rc1) {
+			D_ERROR("ds iv update retry failed: %d\n", rc1);
+			rc = rc1;
+		}
+	}
+
+	daos_sgl_fini(&cb_arg->iv_value, true);
+	D_FREE(cb_arg);
+	return rc;
+}
+
 static int
 iv_op(struct ds_iv_ns *ns, struct ds_iv_key *key, d_sg_list_t *value,
       crt_iv_sync_t *sync, unsigned int shortcut, bool retry, int opc)
 {
+	struct ds_iv_key *_key = key;
+	d_sg_list_t	 *_value = value;
 	int rc;
 
 retry:
-	rc = iv_op_internal(ns, key, value, sync, shortcut, opc);
+	if (sync && sync->ivs_mode == CRT_IV_SYNC_LAZY) {
+		struct sync_comp_cb_arg *arg = NULL;
+
+		/* Register asynchronous sync(lazy mode) callback */
+		D_ALLOC_PTR(arg);
+		if (arg == NULL)
+			return -DER_NOMEM;
+
+		/* Asynchronous mode, let's realloc the value and key, since
+		 * the input parameters will be invalid after the call.
+		 */
+		if (value) {
+			rc = daos_sgl_alloc_copy_data(&arg->iv_value, value);
+			if (rc) {
+				D_FREE_PTR(arg);
+				return -DER_NOMEM;
+			}
+		}
+
+		memcpy(&arg->iv_key, key, sizeof(*key));
+		arg->shortcut = shortcut;
+		arg->iv_sync = *sync;
+		arg->retry = retry;
+		arg->ns = ns;
+		arg->opc = opc;
+
+		sync->ivs_comp_cb = sync_comp_cb;
+		sync->ivs_comp_cb_arg = arg;
+		if (value)
+			_value = &arg->iv_value;
+		_key = &arg->iv_key;
+	}
+
+	rc = iv_op_internal(ns, _key, _value, sync, shortcut, opc);
 	if (retry && (daos_rpc_retryable_rc(rc) || rc == -DER_NOTLEADER)) {
 		/* If the IV ns leader has been changed, then it will retry
 		 * in the mean time, it will rely on others to update the
@@ -954,25 +1035,6 @@ ds_iv_fetch(struct ds_iv_ns *ns, struct ds_iv_key *key, d_sg_list_t *value,
 	return iv_op(ns, key, value, NULL, 0, retry, IV_FETCH);
 }
 
-struct sync_comp_cb_arg {
-	d_sg_list_t iv_value;
-	struct ds_iv_key iv_key;
-};
-
-int
-sync_comp_cb(void *arg)
-{
-	struct sync_comp_cb_arg *cb_arg = arg;
-
-	if (cb_arg == NULL)
-		return 0;
-
-	daos_sgl_fini(&cb_arg->iv_value, true);
-	D_FREE(cb_arg);
-
-	return 0;
-}
-
 /**
  * Update the value to the iv_entry through Cart IV, and it will mark the
  * entry to be valid, so the following fetch will retrieve the value from
@@ -995,30 +1057,12 @@ ds_iv_update(struct ds_iv_ns *ns, struct ds_iv_key *key, d_sg_list_t *value,
 	     unsigned int sync_flags, bool retry)
 {
 	crt_iv_sync_t		iv_sync = { 0 };
-	struct sync_comp_cb_arg *arg = NULL;
 	int			rc;
 
 	iv_sync.ivs_event = CRT_IV_SYNC_EVENT_UPDATE;
 	iv_sync.ivs_mode = sync_mode;
 	iv_sync.ivs_flags = sync_flags;
-	if (sync_mode == CRT_IV_SYNC_LAZY) {
-		D_ALLOC_PTR(arg);
-		if (arg == NULL)
-			D_GOTO(out, rc = -DER_NOMEM);
-
-		rc = daos_sgl_alloc_copy_data(&arg->iv_value, value);
-		if (rc)
-			D_GOTO(out, rc);
-		memcpy(&arg->iv_key, key, sizeof(*key));
-
-		iv_sync.ivs_comp_cb = sync_comp_cb;
-		iv_sync.ivs_comp_cb_arg = arg;
-		value = &arg->iv_value;
-		key = &arg->iv_key;
-	}
-
 	rc = iv_op(ns, key, value, &iv_sync, shortcut, retry, IV_UPDATE);
-out:
 	return rc;
 }
 

--- a/src/rebuild/rebuild_internal.h
+++ b/src/rebuild/rebuild_internal.h
@@ -288,7 +288,8 @@ int rebuild_tgt_scan_pre_forward(crt_rpc_t *rpc, void *arg);
 
 int rebuild_iv_fetch(void *ns, struct rebuild_iv *rebuild_iv);
 int rebuild_iv_update(void *ns, struct rebuild_iv *rebuild_iv,
-		      unsigned int shortcut, unsigned int sync_mode);
+		      unsigned int shortcut, unsigned int sync_mode,
+		      bool retry);
 int rebuild_iv_ns_create(struct ds_pool *pool, uint32_t map_ver,
 			 d_rank_list_t *exclude_tgts,
 			 unsigned int master_rank);

--- a/src/rebuild/rebuild_iv.c
+++ b/src/rebuild/rebuild_iv.c
@@ -302,8 +302,8 @@ rebuild_iv_fetch(void *ns, struct rebuild_iv *rebuild_iv)
 }
 
 int
-rebuild_iv_update(void *ns, struct rebuild_iv *iv,
-		  unsigned int shortcut, unsigned int sync_mode)
+rebuild_iv_update(void *ns, struct rebuild_iv *iv, unsigned int shortcut,
+		  unsigned int sync_mode, bool retry)
 {
 	d_sg_list_t		sgl;
 	d_iov_t		iov;
@@ -319,8 +319,7 @@ rebuild_iv_update(void *ns, struct rebuild_iv *iv,
 
 	memset(&key, 0, sizeof(key));
 	key.class_id = IV_REBUILD;
-	rc = ds_iv_update(ns, &key, &sgl, shortcut, sync_mode, 0,
-			  false /* retry */);
+	rc = ds_iv_update(ns, &key, &sgl, shortcut, sync_mode, 0, retry);
 	if (rc)
 		D_ERROR("iv update failed "DF_RC"\n", DP_RC(rc));
 


### PR DESCRIPTION
1. Add retry (for GRPVER) for lazymode sync, so to make
sure the leader will notify all servers when rebuild finish.

2. Let the server finish the rebuild itself, if it finds out
the leader does not know the rebuild anymore.

Signed-off-by: Di Wang <di.wang@intel.com>