### PR TITLE
DAOS-4910 object: remove invalid media type check

### DIFF
--- a/src/object/obj_enum.c
+++ b/src/object/obj_enum.c
@@ -384,8 +384,16 @@ fill_rec(daos_handle_t ih, vos_iter_entry_t *key_ent, struct dss_enum_arg *arg,
 	if (inline_data && data_size > 0) {
 		d_iov_t iov_out;
 
+		/* It may be partial visible, so it may be not in SCM. */
+#if 0
 		/* inline packing for the small recx located on SCM */
-		D_ASSERT(key_ent->ie_biov.bi_addr.ba_type == DAOS_MEDIA_SCM);
+		D_ASSERTF(key_ent->ie_biov.bi_addr.ba_type == DAOS_MEDIA_SCM,
+			  "Invalid ba_type %d, ba_off "DF_X64
+			  ", thres %ld, data_size %ld, type %d, iod_size %ld\n",
+			  key_ent->ie_biov.bi_addr.ba_type,
+			  key_ent->ie_biov.bi_addr.ba_off,
+			  arg->inline_thres, data_size, type, iod_size);
+#endif
 
 		d_iov_set(&iov_out, iovs[arg->sgl_idx].iov_buf +
 				       iovs[arg->sgl_idx].iov_len, data_size);

--- a/src/tests/daos_racer.c
+++ b/src/tests/daos_racer.c
@@ -134,20 +134,21 @@ pack_dkey_iod_sgl(char *dkey, d_iov_t *dkey_iov, char akeys[][MAX_KEY_SIZE],
 
 	for (i = 0; i < iod_nr; i++) {
 		unsigned size;
+		unsigned val = rand() % 8;
 
 		sprintf(akeys[i], "%d", rand() % max_akey_per_dkey);
 		d_iov_set(&iods[i].iod_name, akeys[i], strlen(akeys[i]));
 
 		iods[i].iod_nr = 1;
-		if (rand() % 2 == 1) {
-			recxs[i].rx_idx = rand() % MAX_REC_SIZE;
-			recxs[i].rx_nr = rand() % MAX_REC_SIZE;
+		if (val % 2 == 1) {
+			recxs[i].rx_idx = rand() % (MAX_REC_SIZE / val);
+			recxs[i].rx_nr = rand() % (MAX_REC_SIZE / val);
 			iods[i].iod_recxs = &recxs[i];
 			iods[i].iod_size = 1;
 			size = recxs[i].rx_nr;
 			iods[i].iod_type = DAOS_IOD_ARRAY;
 		} else {
-			iods[i].iod_size = rand() % MAX_REC_SIZE;
+			iods[i].iod_size = rand() % (MAX_REC_SIZE / (val + 1));
 			size = iods[i].iod_size;
 			iods[i].iod_type = DAOS_IOD_SINGLE;
 		}

--- a/src/tests/ftest/io/daos_racer.yaml
+++ b/src/tests/ftest/io/daos_racer.yaml
@@ -6,9 +6,10 @@ hosts:
     - server-D
     - server-E
     - server-F
+    - server-G
   test_clients:
-    - client-G
-timeout: 1800
+    - client-H
+timeout: 10800
 server_config:
     name: daos_server
     servers:
@@ -17,5 +18,5 @@ server_config:
         scm_class: dcpm
         scm_list: ["/dev/pmem0"]
 daos_racer:
-  runtime: 600
-  clush_timeout: 1500
+  runtime: 7200
+  clush_timeout: 10080

--- a/src/vos/vos_aggregate.c
+++ b/src/vos/vos_aggregate.c
@@ -1004,6 +1004,9 @@ fill_one_segment(daos_handle_t ih, struct agg_merge_window *mw,
 	D_ASSERT(!bio_addr_is_hole(&addr_dst));
 	mark_yield(&addr_dst, acts);
 
+	if (seg_size < 32)
+		D_ASSERT(addr_dst.ba_type == DAOS_MEDIA_SCM);
+
 	iov.iov_buf = io->ic_buf;
 	iov.iov_buf_len = io->ic_buf_len;
 	iov.iov_len = seg_size;

--- a/src/vos/vos_io.c
+++ b/src/vos/vos_io.c
@@ -1734,6 +1734,9 @@ vos_reserve_single(struct vos_io_context *ioc, uint16_t media,
 done:
 	bio_addr_set(&biov.bi_addr, media, off);
 	bio_iov_set_len(&biov, size);
+	if (size < 32)
+		D_ASSERT(media == DAOS_MEDIA_SCM);
+
 	rc = iod_reserve(ioc, &biov);
 
 	return rc;
@@ -1785,6 +1788,9 @@ vos_reserve_recx(struct vos_io_context *ioc, uint16_t media, daos_size_t size,
 done:
 	bio_addr_set(&biov.bi_addr, media, off);
 	bio_iov_set_len(&biov, size);
+	if (size < 32)
+		D_ASSERT(media == DAOS_MEDIA_SCM);
+
 	rc = iod_reserve(ioc, &biov);
 
 	return rc;


### PR DESCRIPTION
The small data may be partial visible, so it may be not in SCM.

Test-tag-hw-large: pr,hw,large daosracer

Signed-off-by: Fan Yong <fan.yong@intel.com>