### PR TITLE
DAOS-5460 object: properly check media type when enumeration pack

### DIFF
--- a/src/object/obj_enum.c
+++ b/src/object/obj_enum.c
@@ -384,8 +384,21 @@ fill_rec(daos_handle_t ih, vos_iter_entry_t *key_ent, struct dss_enum_arg *arg,
 	if (inline_data && data_size > 0) {
 		d_iov_t iov_out;
 
-		/* inline packing for the small recx located on SCM */
-		D_ASSERT(key_ent->ie_biov.bi_addr.ba_type == DAOS_MEDIA_SCM);
+		/* For SV case, inline data must be located on SCM.
+		 * For EV case, the inline data may be only part of
+		 * the original extent. The other part(s) of the EV
+		 * may be invisible to current enumeration. Then it
+		 * may be located on SCM or NVMe.
+		 */
+		if (type != OBJ_ITER_RECX)
+			D_ASSERTF(key_ent->ie_biov.bi_addr.ba_type ==
+				  DAOS_MEDIA_SCM,
+				  "Invalid storage media type %d, ba_off "
+				  DF_X64", thres %ld, data_size %ld, type %d, "
+				  "iod_size %ld\n",
+				  key_ent->ie_biov.bi_addr.ba_type,
+				  key_ent->ie_biov.bi_addr.ba_off,
+				  arg->inline_thres, data_size, type, iod_size);
 
 		d_iov_set(&iov_out, iovs[arg->sgl_idx].iov_buf +
 				       iovs[arg->sgl_idx].iov_len, data_size);


### PR DESCRIPTION
During the enumeration pack, fill_rec() may pack small-sized data
inline the buffer. For SV case, inline data must be located on SCM,
but for EV case, the inline data may be only part of the original
extent. The other part of the whole EV may be invisible to current
enumeration. Then it may be located on SCM or NVMe.

Signed-off-by: Fan Yong <fan.yong@intel.com>