### PR TITLE
DAOS-5460 tests: reduce ratio of large update in daos_racer

### DIFF
--- a/src/tests/daos_racer.c
+++ b/src/tests/daos_racer.c
@@ -134,20 +134,21 @@ pack_dkey_iod_sgl(char *dkey, d_iov_t *dkey_iov, char akeys[][MAX_KEY_SIZE],
 
 	for (i = 0; i < iod_nr; i++) {
 		unsigned size;
+		unsigned val = rand() % 8;
 
 		sprintf(akeys[i], "%d", rand() % max_akey_per_dkey);
 		d_iov_set(&iods[i].iod_name, akeys[i], strlen(akeys[i]));
 
 		iods[i].iod_nr = 1;
-		if (rand() % 2 == 1) {
-			recxs[i].rx_idx = rand() % MAX_REC_SIZE;
-			recxs[i].rx_nr = rand() % MAX_REC_SIZE;
+		if (val % 2 == 1) {
+			recxs[i].rx_idx = rand() % (MAX_REC_SIZE / val);
+			recxs[i].rx_nr = rand() % (MAX_REC_SIZE / val);
 			iods[i].iod_recxs = &recxs[i];
 			iods[i].iod_size = 1;
 			size = recxs[i].rx_nr;
 			iods[i].iod_type = DAOS_IOD_ARRAY;
 		} else {
-			iods[i].iod_size = rand() % MAX_REC_SIZE;
+			iods[i].iod_size = rand() % (MAX_REC_SIZE / (val + 1));
 			size = iods[i].iod_size;
 			iods[i].iod_type = DAOS_IOD_SINGLE;
 		}


### PR DESCRIPTION
That will reduce server side space pressure. Otherwise we may
hit out of space issues very frequently during run daos_racer
for long time.

Signed-off-by: Fan Yong <fan.yong@intel.com>