### PR TITLE
DAOS-5550 ci: Only do doc-only skips on PRs

### DIFF
--- a/ci/doc_only_change.sh
+++ b/ci/doc_only_change.sh
@@ -5,14 +5,17 @@
 
 set -uex
 
-mb_modifier=
+# However note, that we don't want to do this on branch landings since
+# we want the full run for a branch landing so that the lastSuccessfulBuild
+# will always have artifacts in it.
 if [ "$CHANGE_ID" = "null" ]; then
-    mb_modifier=^
+    # exiting 1 means doc-only change
+    exit 0
 fi
 
 # The fetch of $TARGET_BRANCH gets the branch for the compare as a commit hash
 # with the temporary name FETCH_HEAD.
 git fetch origin "${TARGET_BRANCH}"
 git diff-tree --no-commit-id --name-only                                \
-  "$(git merge-base "FETCH_HEAD$mb_modifier" HEAD)" HEAD | \
+  "$(git merge-base "FETCH_HEAD" HEAD)" HEAD | \
   grep -v -e "^doc$"


### PR DESCRIPTION

Since we need landings to always create artifacts so that
lastSuccessfulBuild has artifacts in it.

Signed-off-by: Brian J. Murrell <brian.murrell@intel.com>