### PR TITLE
DAOS-3114 vos: Add read timestamp to key query

### DIFF
--- a/src/include/daos_srv/vos.h
+++ b/src/include/daos_srv/vos.h
@@ -439,8 +439,7 @@ vos_discard(daos_handle_t coh, daos_epoch_range_t *epr,
  *
  * \param coh	[IN]	Container open handle
  * \param oid	[IN]	Object ID
- * \param epoch	[IN]	Epoch for the fetch. It will be ignored if epoch range
- *			is provided by \a iods.
+ * \param epoch	[IN]	Epoch for the fetch.
  * \param flags	[IN]	Fetch flags
  * \param dkey	[IN]	Distribution key.
  * \param iod_nr [IN]	Number of I/O descriptors in \a iods.
@@ -467,8 +466,8 @@ vos_obj_fetch(daos_handle_t coh, daos_unit_oid_t oid, daos_epoch_t epoch,
  *
  * \param coh	[IN]	Container open handle
  * \param oid	[IN]	Object ID
- * \param epoch	[IN]	Epoch for the fetch. It will be ignored if epoch range
- *			is provided by \a iods.
+ * \param epoch	[IN]	Epoch for the fetch.  Ignored if a valid DTX handle
+ *			is provided.
  * \param flags	[IN]	Fetch flags
  * \param dkey	[IN]	Distribution key.
  * \param iod_nr [IN]	Number of I/O descriptors in \a iods.
@@ -494,8 +493,8 @@ vos_obj_fetch_ex(daos_handle_t coh, daos_unit_oid_t oid, daos_epoch_t epoch,
  *
  * \param coh	[IN]	Container open handle
  * \param oid	[IN]	object ID
- * \param epoch	[IN]	Epoch for the update. It will be ignored if epoch
- *			range is provided by \a iods (kvl::kv_epr).
+ * \param epoch	[IN]	Epoch for the update. Ignored if a DTX handle
+ *			is provided.
  * \param pm_ver [IN]   Pool map version for this update, which will be
  *			used during rebuild.
  * \param flags	[IN]	Update flags
@@ -529,8 +528,8 @@ vos_obj_update(daos_handle_t coh, daos_unit_oid_t oid, daos_epoch_t epoch,
  *
  * \param coh	[IN]	Container open handle
  * \param oid	[IN]	object ID
- * \param epoch	[IN]	Epoch for the update. It will be ignored if epoch
- *			range is provided by \a iods (kvl::kv_epr).
+ * \param epoch	[IN]	Epoch for the update. Ignored if a DTX handle
+ *			is provided.
  * \param pm_ver [IN]   Pool map version for this update, which will be
  *			used during rebuild.
  * \param flags	[IN]	Update flags
@@ -582,7 +581,8 @@ vos_obj_array_remove(daos_handle_t coh, daos_unit_oid_t oid,
  * \param coh	[IN]	Container open handle
  * \param oid	[IN]	object ID, the full object will be punched if \a dkey
  *			and \a akeys are not provided.
- * \param epoch	[IN]	Epoch for the punch.
+ * \param epoch	[IN]	Epoch for the punch. Ignored if a DTX handle
+ *			is provided.
  * \param pm_ver [IN]   Pool map version for this update, which will be
  *			used during rebuild.
  * \param flags [IN]	Object punch flags, including VOS_OF_REPLAY_PC and
@@ -639,8 +639,8 @@ enum vos_fetch_flags {
  *
  * \param coh	[IN]	Container open handle
  * \param oid	[IN]	Object ID
- * \param epoch	[IN]	Epoch for the fetch. It will be ignored if epoch range
- *			is provided by \a iods.
+ * \param epoch	[IN]	Epoch for the fetch. Ignored if a DTX handle
+ *			is provided.
  * \param cond_flags [IN]
  *			conditional flags
  * \param dkey	[IN]	Distribution key.
@@ -686,8 +686,8 @@ vos_fetch_end(daos_handle_t ioh, int err);
  *
  * \param coh	[IN]	Container open handle
  * \param oid	[IN]	object ID
- * \param epoch	[IN]	Epoch for the update. It will be ignored if epoch
- *			range is provided by \a iods (kvl::kv_epr).
+ * \param epoch	[IN]	Epoch for the update. Ignored if a DTX handle
+ *			is provided.
  * \param flags [IN]	conditional flags
  * \param dkey	[IN]	Distribution key.
  * \param iod_nr	[IN]	Number of I/O descriptors in \a iods.

--- a/src/vos/README.md
+++ b/src/vos/README.md
@@ -497,6 +497,7 @@ and writes:
       - List akeys under dkey [dkey level]
       - Query min/max dkeys under object [object level]
       - Query min/max akeys under dkey [dkey level]
+      - Query min/max recx under akey [akey level]
   - Writes
       - Update akeys [akey level]
       - Punch akeys [akey level]

--- a/src/vos/tests/vts_io.c
+++ b/src/vos/tests/vts_io.c
@@ -2269,6 +2269,11 @@ io_query_key(void **state)
 	assert_int_equal(rc, 0);
 	assert_int_equal(*(uint64_t *)dkey_read.iov_buf, KEY_INC * 2);
 
+	if (getenv("DAOS_IO_BYPASS"))
+		return;
+
+	/* Only execute the transactional tests when rollback is available */
+
 	vts_dtx_begin(&oid, arg->ctx.tc_co_hdl, epoch++, 0, &dth);
 
 	rc = vos_obj_query_key(arg->ctx.tc_co_hdl, oid, DAOS_GET_DKEY |

--- a/src/vos/tests/vts_io.c
+++ b/src/vos/tests/vts_io.c
@@ -2272,17 +2272,17 @@ io_query_key(void **state)
 	vts_dtx_begin(&oid, arg->ctx.tc_co_hdl, epoch++, 0, &dth);
 
 	rc = vos_obj_query_key(arg->ctx.tc_co_hdl, oid, DAOS_GET_DKEY |
-			       DAOS_GET_MAX, epoch++, &dkey_read, NULL, NULL,
-			       dth);
+			       DAOS_GET_MAX, 0 /* Ignored epoch */, &dkey_read,
+			       NULL, NULL, dth);
 	assert_int_equal(rc, 0);
 	assert_int_equal(*(uint64_t *)dkey_read.iov_buf, MAX_INT_KEY - KEY_INC);
 
 	vts_dtx_end(dth);
 
-	vts_dtx_begin(&oid, arg->ctx.tc_co_hdl, epoch - 3, 0, &dth);
 	/* Now punch the object at earlier epoch */
-	rc = vos_obj_punch(arg->ctx.tc_co_hdl, oid, epoch++, 0, 0, NULL, 0,
-			   NULL, dth);
+	vts_dtx_begin(&oid, arg->ctx.tc_co_hdl, epoch - 3, 0, &dth);
+	rc = vos_obj_punch(arg->ctx.tc_co_hdl, oid, 0 /* ignored epoch */, 0, 0,
+			   NULL, 0, NULL, dth);
 	assert_int_equal(rc, -DER_TX_RESTART);
 	vts_dtx_end(dth);
 

--- a/src/vos/vos_io.c
+++ b/src/vos/vos_io.c
@@ -482,7 +482,7 @@ vos_ioc_create(daos_handle_t coh, daos_unit_oid_t oid, bool read_only,
 
 	ioc->ic_iod_nr = iod_nr;
 	ioc->ic_iods = iods;
-	ioc->ic_epr.epr_hi = dth ? dth->dth_epoch : epoch;
+	ioc->ic_epr.epr_hi = dtx_is_valid_handle(dth) ? dth->dth_epoch : epoch;
 	ioc->ic_epr.epr_lo = 0;
 	ioc->ic_oid = oid;
 	ioc->ic_cont = vos_hdl2cont(coh);

--- a/src/vos/vos_io.c
+++ b/src/vos/vos_io.c
@@ -482,7 +482,7 @@ vos_ioc_create(daos_handle_t coh, daos_unit_oid_t oid, bool read_only,
 
 	ioc->ic_iod_nr = iod_nr;
 	ioc->ic_iods = iods;
-	ioc->ic_epr.epr_hi = epoch;
+	ioc->ic_epr.epr_hi = dth ? dth->dth_epoch : epoch;
 	ioc->ic_epr.epr_lo = 0;
 	ioc->ic_oid = oid;
 	ioc->ic_cont = vos_hdl2cont(coh);
@@ -2032,10 +2032,8 @@ vos_update_begin(daos_handle_t coh, daos_unit_oid_t oid, daos_epoch_t epoch,
 		"\n", DP_UOID(oid), iod_nr,
 		dtx_is_valid_handle(dth) ? dth->dth_epoch :  epoch);
 
-	rc = vos_ioc_create(coh, oid, false,
-			    dtx_is_valid_handle(dth) ? dth->dth_epoch : epoch,
-			    flags, iod_nr, iods, iods_csums, 0, NULL, dedup,
-			    dedup_th, dth, &ioc);
+	rc = vos_ioc_create(coh, oid, false, epoch, flags, iod_nr, iods,
+			    iods_csums, 0, NULL, dedup, dedup_th, dth, &ioc);
 	if (rc != 0)
 		return rc;
 

--- a/src/vos/vos_query.c
+++ b/src/vos/vos_query.c
@@ -310,12 +310,14 @@ vos_obj_query_key(daos_handle_t coh, daos_unit_oid_t oid, uint32_t flags,
 	daos_anchor_t		 dkey_anchor;
 	daos_anchor_t		 akey_anchor;
 	daos_ofeat_t		 obj_feats;
-	daos_epoch_range_t	 obj_epr = {0, dth ? dth->dth_epoch : epoch};
+	daos_epoch_range_t	 obj_epr = {0};
 	int			 akey_save = 0;
 	int			 dkey_save = 0;
 	uint32_t		 cflags = 0;
 	int			 rc = 0;
 	int			 nr_akeys = 0;
+
+	obj_epr.epr_hi = dtx_is_valid_handle(dth) ? dth->dth_epoch : epoch;
 
 	if ((flags & VOS_GET_MAX) && (flags & VOS_GET_MIN)) {
 		D_ERROR("Ambiguous query.  Please select either VOS_GET_MAX"
@@ -410,6 +412,10 @@ vos_obj_query_key(daos_handle_t coh, daos_unit_oid_t oid, uint32_t flags,
 	query.qt_coh	    = coh;
 	query.qt_pool	    = vos_obj2pool(obj);
 
+	/** We may read a dkey/akey that has no valid akey/recx and will need to
+	 *  reset the timestamp cache state to cache the new dkey/akey
+	 *  timestamps.
+	 */
 	vos_ts_set_save(query.qt_ts_set, &dkey_save);
 	for (;;) {
 		/* Reset the epoch range */
@@ -453,6 +459,11 @@ vos_obj_query_key(daos_handle_t coh, daos_unit_oid_t oid, uint32_t flags,
 					/* Reset the epoch range to last dkey */
 					query.qt_epr = dkey_epr;
 					query.qt_punch = dkey_punch;
+					/** Go ahead and save timestamps for
+					 * things we read
+					 */
+					vos_ts_set_update(query.qt_ts_set,
+							  obj_epr.epr_hi);
 					vos_ts_set_restore(query.qt_ts_set,
 							   akey_save);
 					continue;
@@ -462,6 +473,8 @@ vos_obj_query_key(daos_handle_t coh, daos_unit_oid_t oid, uint32_t flags,
 		}
 		if (rc == -DER_NONEXIST &&
 		    query.qt_flags & VOS_GET_DKEY) {
+			/** Go ahead and save timestamps for things we read */
+			vos_ts_set_update(query.qt_ts_set, obj_epr.epr_hi);
 			vos_ts_set_restore(query.qt_ts_set, dkey_save);
 			continue;
 		}
@@ -481,6 +494,8 @@ out:
 
 	if (rc == 0 || rc == -DER_NONEXIST)
 		vos_ts_set_update(query.qt_ts_set, obj_epr.epr_hi);
+
+	vos_ts_set_free(query.qt_ts_set);
 
 	return rc;
 }

--- a/src/vos/vos_query.c
+++ b/src/vos/vos_query.c
@@ -349,17 +349,21 @@ vos_obj_query_key(daos_handle_t coh, daos_unit_oid_t oid, uint32_t flags,
 		cflags = VOS_TS_READ_OBJ;
 	}
 
-	if (flags & VOS_GET_AKEY && akey == NULL) {
-		D_ERROR("akey can't be NULL with VOS_GET_AKEY\n");
-		return -DER_INVAL;
+	if (flags & VOS_GET_AKEY) {
+		if (akey == NULL) {
+			D_ERROR("akey can't be NULL with VOS_GET_AKEY\n");
+			return -DER_INVAL;
+		}
 
 		if (cflags == 0)
 			cflags = VOS_TS_READ_DKEY;
 	}
 
-	if (flags & VOS_GET_RECX && recx == NULL) {
-		D_ERROR("recx can't be NULL with VOS_GET_RECX\n");
-		return -DER_INVAL;
+	if (flags & VOS_GET_RECX) {
+		if (recx == NULL) {
+			D_ERROR("recx can't be NULL with VOS_GET_RECX\n");
+			return -DER_INVAL;
+		}
 
 		nr_akeys = 1;
 		if (cflags == 0)

--- a/src/vos/vos_query.c
+++ b/src/vos/vos_query.c
@@ -34,9 +34,11 @@
 #include <daos_api.h> /* For ofeat bits */
 #include <daos/checksum.h>
 #include "vos_internal.h"
+#include "vos_ts.h"
 
 struct open_query {
 	struct vos_object	*qt_obj;
+	struct vos_ts_set	*qt_ts_set;
 	daos_epoch_range_t	 qt_epr;
 	struct vos_punch_record	 qt_punch;
 	struct vos_ilog_info	 qt_info;
@@ -214,6 +216,7 @@ open_and_query_key(struct open_query *query, daos_key_t *key,
 		   uint32_t tree_type, daos_anchor_t *anchor)
 {
 	daos_handle_t		*toh;
+	struct ilog_df		*ilog = NULL;
 	struct btr_root		*to_open;
 	struct dcs_csum_info	 csum = {0};
 	struct vos_rec_bundle	 rbund;
@@ -261,6 +264,11 @@ open_and_query_key(struct open_query *query, daos_key_t *key,
 
 	rc = dbtree_fetch(*toh, BTR_PROBE_EQ, DAOS_INTENT_DEFAULT, key, NULL,
 			  &riov);
+	if (rc == 0)
+		ilog = &rbund.rb_krec->kr_ilog;
+
+	vos_ilog_ts_add(query->qt_ts_set, ilog, NULL, 0);
+
 	if (rc != 0)
 		return rc;
 
@@ -294,6 +302,7 @@ vos_obj_query_key(daos_handle_t coh, daos_unit_oid_t oid, uint32_t flags,
 		  daos_epoch_t epoch, daos_key_t *dkey, daos_key_t *akey,
 		  daos_recx_t *recx, struct dtx_handle *dth)
 {
+	struct vos_container	*cont;
 	struct vos_object	*obj = NULL;
 	struct open_query	 query;
 	daos_epoch_range_t	 dkey_epr;
@@ -301,8 +310,12 @@ vos_obj_query_key(daos_handle_t coh, daos_unit_oid_t oid, uint32_t flags,
 	daos_anchor_t		 dkey_anchor;
 	daos_anchor_t		 akey_anchor;
 	daos_ofeat_t		 obj_feats;
-	daos_epoch_range_t	 obj_epr = {0, epoch};
+	daos_epoch_range_t	 obj_epr = {0, dth ? dth->dth_epoch : epoch};
+	int			 akey_save = 0;
+	int			 dkey_save = 0;
+	uint32_t		 cflags = 0;
 	int			 rc = 0;
+	int			 nr_akeys = 0;
 
 	if ((flags & VOS_GET_MAX) && (flags & VOS_GET_MIN)) {
 		D_ERROR("Ambiguous query.  Please select either VOS_GET_MAX"
@@ -322,28 +335,51 @@ vos_obj_query_key(daos_handle_t coh, daos_unit_oid_t oid, uint32_t flags,
 		return -DER_INVAL;
 	}
 
+	query.qt_ts_set = NULL;
+
 	if (flags & VOS_GET_DKEY) {
 		if (dkey == NULL) {
 			D_ERROR("dkey can't be NULL with VOS_GET_DKEY\n");
 			return -DER_INVAL;
 		}
 		daos_anchor_set_zero(&dkey_anchor);
+
+		cflags = VOS_TS_READ_OBJ;
 	}
 
 	if (flags & VOS_GET_AKEY && akey == NULL) {
 		D_ERROR("akey can't be NULL with VOS_GET_AKEY\n");
 		return -DER_INVAL;
+
+		if (cflags == 0)
+			cflags = VOS_TS_READ_DKEY;
 	}
 
 	if (flags & VOS_GET_RECX && recx == NULL) {
 		D_ERROR("recx can't be NULL with VOS_GET_RECX\n");
 		return -DER_INVAL;
+
+		nr_akeys = 1;
+		if (cflags == 0)
+			cflags = VOS_TS_READ_AKEY;
 	}
 
 	vos_dth_set(dth);
+	rc = vos_ts_set_allocate(&query.qt_ts_set, 0, cflags, nr_akeys,
+				 dth ? &dth->dth_xid : NULL);
+	if (rc != 0) {
+		D_ERROR("Failed to allocate timestamp set: "DF_RC"\n",
+			DP_RC(rc));
+		return rc;
+	}
+
+	cont = vos_hdl2cont(coh);
+
+	vos_ts_set_add(query.qt_ts_set, cont->vc_ts_idx, NULL, 0);
 
 	rc = vos_obj_hold(vos_obj_cache_current(), vos_hdl2cont(coh), oid,
-			  &obj_epr, true, DAOS_INTENT_DEFAULT, true, &obj, 0);
+			  &obj_epr, true, DAOS_INTENT_DEFAULT, true, &obj,
+			  query.qt_ts_set);
 	if (rc != 0) {
 		LOG_RC(rc, "Could not hold object: %s\n", d_errstr(rc));
 		goto out;
@@ -374,6 +410,7 @@ vos_obj_query_key(daos_handle_t coh, daos_unit_oid_t oid, uint32_t flags,
 	query.qt_coh	    = coh;
 	query.qt_pool	    = vos_obj2pool(obj);
 
+	vos_ts_set_save(query.qt_ts_set, &dkey_save);
 	for (;;) {
 		/* Reset the epoch range */
 		query.qt_epr = obj_epr;
@@ -393,6 +430,7 @@ vos_obj_query_key(daos_handle_t coh, daos_unit_oid_t oid, uint32_t flags,
 
 		dkey_punch = query.qt_punch;
 		dkey_epr = query.qt_epr;
+		vos_ts_set_save(query.qt_ts_set, &akey_save);
 		for (;;) {
 			rc = open_and_query_key(&query, akey, VOS_GET_AKEY,
 						&akey_anchor);
@@ -415,6 +453,8 @@ vos_obj_query_key(daos_handle_t coh, daos_unit_oid_t oid, uint32_t flags,
 					/* Reset the epoch range to last dkey */
 					query.qt_epr = dkey_epr;
 					query.qt_punch = dkey_punch;
+					vos_ts_set_restore(query.qt_ts_set,
+							   akey_save);
 					continue;
 				}
 			}
@@ -422,6 +462,7 @@ vos_obj_query_key(daos_handle_t coh, daos_unit_oid_t oid, uint32_t flags,
 		}
 		if (rc == -DER_NONEXIST &&
 		    query.qt_flags & VOS_GET_DKEY) {
+			vos_ts_set_restore(query.qt_ts_set, dkey_save);
 			continue;
 		}
 		break;
@@ -437,6 +478,9 @@ out:
 		vos_obj_release(vos_obj_cache_current(), obj, false);
 
 	vos_dth_set(NULL);
+
+	if (rc == 0 || rc == -DER_NONEXIST)
+		vos_ts_set_update(query.qt_ts_set, obj_epr.epr_hi);
 
 	return rc;
 }

--- a/src/vos/vos_ts.h
+++ b/src/vos/vos_ts.h
@@ -434,6 +434,9 @@ vos_ts_set_add(struct vos_ts_set *ts_set, uint32_t *idx, const void *rec,
 	if (idx == NULL)
 		goto calc_hash;
 
+	if (ts_set->ts_init_count == ts_set->ts_set_size)
+		return -DER_BUSY; /** No more room in the set */
+
 	if (vos_ts_lookup(ts_set, idx, false, &entry)) {
 		expected_type = entry->te_info->ti_type;
 		D_ASSERT(expected_type == ts_set->ts_etype);
@@ -709,4 +712,31 @@ vos_ts_set_update(struct vos_ts_set *ts_set, daos_epoch_t read_time)
 	}
 }
 
+/** Save the current state of the set
+ *
+ * \param[in]	ts_set	The timestamp set
+ * \param[out]	statep	Target to save state to
+ */
+static inline void
+vos_ts_set_save(struct vos_ts_set *ts_set, int *statep)
+{
+	if (ts_set == NULL)
+		return;
+
+	*statep = ts_set->ts_init_count;
+}
+
+/** Restore previously saved state of the set
+ *
+ * \param[in]	ts_set	The timestamp set
+ * \param[in]	state	The saved state
+ */
+static inline void
+vos_ts_set_restore(struct vos_ts_set *ts_set, int state)
+{
+	if (ts_set == NULL)
+		return;
+
+	ts_set->ts_init_count = state;
+}
 #endif /* __VOS_TS__ */


### PR DESCRIPTION
Add read timestamps for key query API

Signed-off-by: Jeff Olivier <jeffrey.v.olivier@intel.com>