### PR TITLE
DAOS-5542: Fix rebuild tests to use dmg for pool destroy

### DIFF
--- a/src/tests/suite/daos_rebuild.c
+++ b/src/tests/suite/daos_rebuild.c
@@ -377,10 +377,13 @@ rebuild_destroy_pool_cb(void *data)
 	rebuild_pool_disconnect_internal(data);
 
 	if (arg->myrank == 0) {
-		rc = daos_pool_destroy(arg->pool.pool_uuid, NULL, true, NULL);
-		if (rc)
-			print_message("failed to destroy pool"DF_UUIDF" %d\n",
+		rc = dmg_pool_destroy(dmg_config_file, arg->pool.pool_uuid,
+				      NULL, true);
+		if (rc) {
+			print_message("failed to destroy pool "DF_UUIDF" %d\n",
 				      DP_UUID(arg->pool.pool_uuid), rc);
+			goto out;
+		}
 	}
 
 	arg->pool.destroyed = true;
@@ -393,6 +396,7 @@ rebuild_destroy_pool_cb(void *data)
 
 	MPI_Barrier(MPI_COMM_WORLD);
 
+out:
 	return rc;
 }
 

--- a/src/tests/suite/daos_rebuild.c
+++ b/src/tests/suite/daos_rebuild.c
@@ -377,10 +377,13 @@ rebuild_destroy_pool_cb(void *data)
 	rebuild_pool_disconnect_internal(data);
 
 	if (arg->myrank == 0) {
+		/* Disable fail_loc and start rebuild */
+		daos_mgmt_set_params(arg->group, -1, DMG_KEY_FAIL_LOC,
+				     0, 0, NULL);
 		rc = dmg_pool_destroy(dmg_config_file, arg->pool.pool_uuid,
 				      NULL, true);
 		if (rc) {
-			print_message("failed to destroy pool "DF_UUIDF" %d\n",
+			print_message("failed to destroy pool"DF_UUIDF" %d\n",
 				      DP_UUID(arg->pool.pool_uuid), rc);
 			goto out;
 		}
@@ -389,10 +392,6 @@ rebuild_destroy_pool_cb(void *data)
 	arg->pool.destroyed = true;
 	print_message("pool destroyed "DF_UUIDF"\n",
 		      DP_UUID(arg->pool.pool_uuid));
-	/* Disable fail_loc and start rebuild */
-	if (arg->myrank == 0)
-		daos_mgmt_set_params(arg->group, -1, DMG_KEY_FAIL_LOC,
-				     0, 0, NULL);
 
 	MPI_Barrier(MPI_COMM_WORLD);
 


### PR DESCRIPTION
There was a daos_pool_destroy() call that hadn't been updated
yet.