### PR TITLE
DAOS-5254 ref: Always perform RPC_DECREF() inside of crt_rpc_complete()

### DIFF
--- a/src/cart/crt_context.c
+++ b/src/cart/crt_context.c
@@ -294,6 +294,8 @@ crt_rpc_complete(struct crt_rpc_priv *rpc_priv, int rc)
 
 		rpc_priv->crp_complete_cb(&cbinfo);
 	}
+
+	RPC_DECREF(rpc_priv);
 }
 
 /* Flag bits definition for crt_ctx_epi_abort */
@@ -353,8 +355,6 @@ crt_ctx_epi_abort(d_list_t *rlink, void *arg)
 		d_list_del_init(&rpc_priv->crp_epi_link);
 		epi->epi_req_wait_num--;
 		crt_rpc_complete(rpc_priv, -DER_CANCELED);
-		/* corresponds to ref taken when adding to waitq */
-		RPC_DECREF(rpc_priv);
 	}
 
 	/* abort RPCs in inflight queue */
@@ -725,7 +725,6 @@ crt_req_timeout_hdlr(struct crt_rpc_priv *rpc_priv)
 			  rpc_priv->crp_tgt_uri);
 		crt_context_req_untrack(rpc_priv);
 		crt_rpc_complete(rpc_priv, -DER_UNREACH);
-		RPC_DECREF(rpc_priv);
 		break;
 	case RPC_STATE_FWD_UNREACH:
 		RPC_ERROR(rpc_priv,
@@ -735,7 +734,6 @@ crt_req_timeout_hdlr(struct crt_rpc_priv *rpc_priv)
 			  rpc_priv->crp_tgt_uri);
 		crt_context_req_untrack(rpc_priv);
 		crt_rpc_complete(rpc_priv, -DER_UNREACH);
-		RPC_DECREF(rpc_priv);
 		break;
 	default:
 		if (rpc_priv->crp_on_wire) {
@@ -1043,7 +1041,6 @@ crt_context_req_untrack(struct crt_rpc_priv *rpc_priv)
 		crt_context_req_untrack(tmp_rpc);
 		/* for error case here */
 		crt_rpc_complete(tmp_rpc, rc);
-		RPC_DECREF(tmp_rpc);
 	}
 }
 

--- a/src/cart/crt_rpc.c
+++ b/src/cart/crt_rpc.c
@@ -623,7 +623,6 @@ out:
 	if (rc != 0) {
 		crt_context_req_untrack(chained_rpc_priv);
 		crt_rpc_complete(chained_rpc_priv, rc);
-		RPC_DECREF(chained_rpc_priv);
 	}
 
 	/* Addref done in crt_issue_uri_lookup() */
@@ -1118,9 +1117,11 @@ out:
 			/* failure already reported through complete cb */
 			if (complete_cb != NULL)
 				rc = 0;
+		} else {
+			RPC_DECREF(rpc_priv);
 		}
-		RPC_DECREF(rpc_priv);
 	}
+
 	/* corresponds to RPC_ADDREF in this function */
 	RPC_DECREF(rpc_priv);
 	return rc;


### PR DESCRIPTION
crt_rpc_complete() is supposed to be called whenever an actual completion
callback (which is triggered via mercury) cannot be invoked.
During mercury-invoked completion callback, the rpc in question is decref-ed.
The same logic is now done when rpc completion is force-triggered via
crt_rpc_complete(). In past code used to call crt_rpc_complete() and afterwards
sometimes call RPC_DECREF() (incorrect behavior), causing dangling RPC
handle in some error-case situations when forced completion is done.

Signed-off-by: Alexander Oganezov <alexander.a.oganezov@intel.com>