### PR TITLE
DAOS-4898 obj: fix bug in EC degraded fetch found in rebuild test

### DIFF
--- a/src/object/cli_ec.c
+++ b/src/object/cli_ec.c
@@ -2333,6 +2333,7 @@ again:
 					iod_recx.rx_idx + iod_recx.rx_nr) -
 				    ovl.rx_idx;
 			rec_nr += recov_recx.rx_idx - iod_recx.rx_idx;
+			break;
 		}
 		D_ASSERT(overlapped);
 		iod_off = rec_nr * iod_size;

--- a/src/object/cli_shard.c
+++ b/src/object/cli_shard.c
@@ -395,7 +395,9 @@ dc_rw_cb(tse_task_t *task, void *arg)
 
 		/* update the sizes in iods */
 		for (i = 0; i < orw->orw_nr; i++) {
-			iods[i].iod_size = sizes[i];
+			if (!is_ec_obj || reasb_req->orr_fail == NULL ||
+			    iods[i].iod_size == 0)
+				iods[i].iod_size = sizes[i];
 			if (is_ec_obj && reasb_req->orr_recov &&
 			    reasb_req->orr_fail->efi_uiods[i].iod_size == 0) {
 				reasb_req->orr_fail->efi_uiods[i].iod_size =

--- a/src/object/obj_ec.h
+++ b/src/object/obj_ec.h
@@ -449,7 +449,7 @@ obj_shadow_list_vos2daos(uint32_t nr, struct daos_recx_ep_list *lists,
 		list = &lists[i];
 		for (j = 0; j < list->re_nr; j++) {
 			recx = &list->re_items[j].re_recx;
-			D_ASSERT(recx->rx_idx % cell_rec_nr == 0);
+			recx->rx_idx = rounddown(recx->rx_idx, cell_rec_nr);
 			stripe_nr = roundup(recx->rx_nr, cell_rec_nr) /
 				    cell_rec_nr;
 			D_ASSERT((recx->rx_idx & PARITY_INDICATOR) != 0);
@@ -489,7 +489,8 @@ obj_iod_break(daos_iod_t *iod, struct daos_oclass_attr *oca)
 		for (j = 0; j < stripe_nr; j++) {
 			if (j == 0) {
 				new_recx[i].rx_idx = recx->rx_idx;
-				new_recx[i].rx_nr = cell_size - recx->rx_idx;
+				new_recx[i].rx_nr = cell_size -
+						    (recx->rx_idx % cell_size);
 				rec_nr -= new_recx[i].rx_nr;
 			} else {
 				new_recx[i + j].rx_idx =

--- a/src/tests/suite/io_conf/daos_io_conf_4
+++ b/src/tests/suite/io_conf/daos_io_conf_4
@@ -74,6 +74,12 @@ update --tx 6 -r "[65540, 130000]11"
 fail_shard_fetch set 0 1
 fetch --tx 7 -r "[0, 262144]"
 fail_shard_fetch clear
+fail_shard_fetch set 0 1
+fetch --tx 7 -r "[163840, 262144]"
+fail_shard_fetch clear
+fail_shard_fetch set 0 1
+fetch --tx 7 -r "[0, 32768] [65542, 65588] [65591, 65598]"
+fail_shard_fetch clear
 
 akey akey_single_1
 iod_size 102

--- a/src/tests/suite/io_conf/daos_io_conf_5
+++ b/src/tests/suite/io_conf/daos_io_conf_5
@@ -74,6 +74,10 @@ update --tx 6 -r "[264559, 524111]11"
 fail_shard_fetch set 3 4
 fetch --tx 7 -r "[0, 524277]"
 fail_shard_fetch clear
+fail_shard_fetch set 3 4
+fetch --tx 7 -r "[0, 524277]"
+fetch --tx 7 -r "[262144, 524277]"
+fail_shard_fetch clear
 
 akey akey_single_1
 iod_size 10240


### PR DESCRIPTION
1. in obj_iod_break() a bug when calculate rx_nr
2. in dc_rw_cb() should not reset iod_size as zero for EC
    obj when it is in degraded mode.
3. fix an assertion in obj_shadow_list_vos2daos().
4. fix a bug in obj_ec_recov_fill_back().
And add test cases in epoch io test tool.
    
Signed-off-by: Xuezhao Liu <xuezhao.liu@intel.com>