### PR TITLE
DAOS-5558 tests: Fix dfuse stop/tearDown

### DIFF
--- a/src/tests/ftest/util/dfuse_utils.py
+++ b/src/tests/ftest/util/dfuse_utils.py
@@ -296,7 +296,7 @@ class Dfuse(DfuseCommand):
         self.check_running()
         umount_cmd = [
             "if [ -x '$(command -v fusermount)' ]",
-            "then fusermount -u {0}",
+            "then fusermount -u {0}".format(self.mount_dir.value),
             "else fusermount3 -u {0}".format(self.mount_dir.value),
             "fi"
         ]


### PR DESCRIPTION
Add missing dfuse directory for fusermount command in stop method.

Signed-off-by: Phillip Henderson <phillip.henderson@intel.com>