### PR TITLE
DAOS-5576 vos: Use operation sequence number for deferred actions

### DIFF
--- a/src/vos/vos_tree.c
+++ b/src/vos/vos_tree.c
@@ -662,8 +662,8 @@ svt_rec_free_internal(struct btr_instance *tins, struct btr_record *rec,
 	/** There can't be more cancellations than updates in this
 	 *  modification so just use the current one
 	 */
-	D_ASSERT(dth->dth_deferred_cnt > 0);
-	i = dth->dth_deferred_cnt - 1;
+	D_ASSERT(dth->dth_op_seq > 0);
+	i = dth->dth_op_seq - 1;
 	rsrvd_scm = dth->dth_deferred[i];
 	D_ASSERT(rsrvd_scm != NULL);
 	D_ASSERT(rsrvd_scm->rs_actv_at < rsrvd_scm->rs_actv_cnt);

--- a/src/vos/vos_tree.c
+++ b/src/vos/vos_tree.c
@@ -663,6 +663,7 @@ svt_rec_free_internal(struct btr_instance *tins, struct btr_record *rec,
 	 *  modification so just use the current one
 	 */
 	D_ASSERT(dth->dth_op_seq > 0);
+	D_ASSERT(dth->dth_op_seq <= dth->dth_deferred_cnt);
 	i = dth->dth_op_seq - 1;
 	rsrvd_scm = dth->dth_deferred[i];
 	D_ASSERT(rsrvd_scm != NULL);


### PR DESCRIPTION
The deferred actions array was using dth_deferred_cnt - 1.  This is
incorrect.  It should use the operation sequence number instead.
As it was, it would always use the last entry in the array and
thus would fail on the 2nd replacement as with daos_test -T

Signed-off-by: Jeff Olivier <jeffrey.v.olivier@intel.com>