### PR TITLE
DAOS-5579 doc: misc docfixes

### DIFF
--- a/doc/admin/deployment.md
+++ b/doc/admin/deployment.md
@@ -45,8 +45,8 @@ DAOS server configuration and how to start it on all the storage nodes.
 
 The `daos_server` configuration file is parsed when starting the
 `daos_server` process. The configuration file location can be specified
-on the command line (`daos_server -h` for usage) or default location
-(`install/etc/daos_server.yml`).
+on the command line (`daos_server -h` for usage) or it will be read from
+the default location (`/etc/daos/daos_server.yml`).
 
 Parameter descriptions are specified in [`daos_server.yml`](https://github.com/daos-stack/daos/blob/master/utils/config/daos_server.yml)
 and example configuration files in the [examples](https://github.com/daos-stack/daos/tree/master/utils/config/examples)
@@ -67,7 +67,7 @@ available at
 
 The location of this configuration file is determined by first checking
 for the path specified through the -o option of the `daos_server` command
-line. Otherwise, /etc/daos_server.conf is used.
+line. Otherwise, /etc/daos/daos_server.yml is used.
 
 Refer to the example configuration file ([daos_server.yml](https://github.com/daos-stack/daos/blob/master/utils/config/daos_server.yml))
 for latest information and examples.
@@ -250,13 +250,15 @@ $ journalctl --unit daos_server.service
 ```
 
 After RPM install, `daos_server` service starts automatically running as user
-"daos". Server config is read from `/etc/daos` and certificates from `/etc/daos/certs`.
+"daos". The server config is read from `/etc/daos/daos_server.yml` and 
+certificates are read from `/etc/daos/certs`.
 With no other admin intervention other than the loading of certificates,
 `daos_server` will enter a listening state enabling discovery of storage and
 network hardware through the `dmg` tool without any I/O Servers specified in the
 configuration file. After device discovery and provisioning, an updated
-configuration with a populated per-server section can be provided and the service
-restarted ready for DAOS servers to be formatted.
+configuration file with a populated per-server section can be stored in
+`/etc/daos/daos_server.yml`, and after reestarting the `daos_server` service 
+it is then ready for the storage to be formatted.
 
 #### Kubernetes Pod
 
@@ -290,7 +292,7 @@ storage nodes via the dmg utility.
 
 This section addresses how to verify that Optane DC Persistent Memory
 Module (DCPMM) is correctly installed on the storage nodes, and how to configure
-it in interleaved mode to be used by DAOS in AppDirect mode.
+it in Appdirect interleaved mode to be used by DAOS.
 Instructions for other types of SCM may be covered in the future.
 
 Provisioning the SCM occurs by configuring DCPM modules in AppDirect memory regions
@@ -756,7 +758,7 @@ The `daos_agent` configuration file is parsed when starting the
 `daos_agent` process. The configuration file location can be specified
 on the command line (`daos_agent -h` for usage) or default location
 (`install/etc/daos_agent.yml`). If installed from rpms the default location is
-(`/usr/etc/daos_agent.yml`).
+(`/etc/daos/daos_agent.yml`).
 
 Parameter descriptions are specified in [daos_agent.yml](https://github.com/daos-stack/daos/blob/master/utils/config/daos_agent.yml).
 
@@ -776,9 +778,9 @@ available at
 
 The location of this configuration file is determined by first checking
 for the path specified through the -o option of the daos_agent command
-line. Otherwise, /etc/daos_agent.conf is used.
+line. Otherwise, /etc/daos/daos_agent.yml is used.
 
-Refer to the example configuration file ([daos_server.yml](https://github.com/daos-stack/daos/blob/master/utils/config/daos_server.yml))
+Refer to the example configuration file ([daos_agent.yml](https://github.com/daos-stack/daos/blob/master/utils/config/daos_agent.yml))
 for latest information and examples.
 
 ### Agent Startup
@@ -797,7 +799,10 @@ $ daos_agent -i -o <'path to agent configuration file/daos_agent.yml'> &
 ```
 
 Alternatively, the DAOS Agent can be started as a systemd service. The DAOS Agent
-unit file is installed in the correct location when installing from RPMs.
+unit file is installed in the correct location when installing from RPMs. 
+If you want to run the DAOS Agent without certificates (not recommended in production
+deployments), you need to add the `-i` option to the systemd `ExecStart` invocation
+(see below).
 
 If you wish to use systemd with a development build, you must copy the service
 file from `utils/systemd` to `/usr/lib/systemd/system`. Once the file is copied
@@ -809,6 +814,7 @@ Once the service file is installed, you can start `daos_agent`
 with the following commands:
 
 ```bash
+$ sudo systemctl daemon-reload
 $ sudo systemctl enable daos_agent.service
 $ sudo systemctl start daos_agent.service
 ```

--- a/doc/user/container.md
+++ b/doc/user/container.md
@@ -8,6 +8,12 @@ Containers can be created and destroyed through the daos_cont_create/destroy()
 functions exported by the DAOS API. A user tool called `daos` is also
 provided to manage containers.
 
+!!! note
+    In DAOS 1.0, in order to use the `daos` command the following environment
+    variables need to be set (this is no longer needed in later versions of DAOS):
+     * For Omni-Path: `export OFI_INTERFACE="ib0"; export CRT_PHY_ADDR_STR="ofi+psm2"`
+     * For InfiniBand: `export OFI_INTERFACE="ib0"; export CRT_PHY_ADDR_STR="ofi+verbs;ofi_rxm"; export OFI_DOMAIN="mlx5_0"`
+
 To create a container:
 ```bash
 $ daos cont create --pool=a171434a-05a5-4671-8fe2-615aa0d05094 --svc=0

--- a/src/README.md
+++ b/src/README.md
@@ -1,6 +1,6 @@
 # DAOS Internals
 
-The purpose of this document is to describe the internal code structure and major algorithms used by DAOS. It assumes prior knowledge of the <a href="/doc/storage_model.md">DAOS storage model</a> and <a href="/doc/terminology.md">acronyms</a>.
+The purpose of this document is to describe the internal code structure and major algorithms used by DAOS. It assumes prior knowledge of the <a href="/doc/overview/storage.md">DAOS storage model</a> and <a href="/doc/overview/terminology.md">acronyms</a>.
 This document contains the following sections:
 
 - <a href="#1">DAOS Components</a>
@@ -66,7 +66,7 @@ The libdaos and libdfs libraries provide the foundation to support domain-specif
 <a id="13"></a>
 ### Agent
 
-The <a href="control/cmd/agent/README.md">DAOS agent</a> is a daemon residing on the client node and interacts with the DAOS client library through dRPC to authenticate the application process. It is a trusted entity that can sign the DAOS Client credentials using local certificates. The agent can support different authentication frameworks and uses a Unix Domain Socket to communicate with the client library. The DAOS agent is written in Go and communicates through gRPC with the control plane component of each DAOS server to provide DAOS system membership information to the client library and to support pool listing.
+The <a href="control/cmd/daos_agent/README.md">DAOS agent</a> is a daemon residing on the client node and interacts with the DAOS client library through dRPC to authenticate the application process. It is a trusted entity that can sign the DAOS Client credentials using local certificates. The agent can support different authentication frameworks and uses a Unix Domain Socket to communicate with the client library. The DAOS agent is written in Go and communicates through gRPC with the control plane component of each DAOS server to provide DAOS system membership information to the client library and to support pool listing.
 
 <a id="2"></a>
 ## Network Transport and Communications

--- a/utils/config/daos_agent.yml
+++ b/utils/config/daos_agent.yml
@@ -1,10 +1,10 @@
-# DAOS client configuration file.
+# DAOS agent configuration file.
 #
 # Location of this configuration file is determined by first checking for the
 # path specified through the -o option of the daos_agent command line.
-# Otherwise, etc/daos_agent.yml is used.
+# Otherwise, /etc/daos/daos_agent.yml is used.
 #
-# Section describing the agent configuration
+# Section describing the daos_agent configuration
 #
 # Although not supported for now, one might want to connect to multiple
 # DAOS installations from the same node in the future.
@@ -12,8 +12,10 @@
 # Specify the associated DAOS systems.
 # Name must match name specified in the daos_server.yml file on the server.
 #
+# NOTE: changing the name is not supported in DAOS 1.0, it must be daos_server
+#
 # default: daos_server
-#name: daos
+#name: daos_server
 
 # Management server access points
 # Must have the same value for all agents and servers in a system.

--- a/utils/config/daos_control.yml
+++ b/utils/config/daos_control.yml
@@ -1,10 +1,10 @@
-# DAOS control configuration file.
+# DAOS manager (dmg) configuration file.
 #
 # Location of this configuration file is determined by first checking for the
 # path specified through the -o option of the dmg command line.
-# Otherwise, etc/daos_control.yml is used.
+# Otherwise, /etc/daos/daos_control.yml is used.
 #
-# Section describing the control configuration
+# Section describing the DAOS manager (dmg) configuration
 #
 # Although not supported for now, one might want to connect to multiple
 # DAOS installations from the same node in the future.
@@ -12,8 +12,10 @@
 # Specify the associated DAOS systems.
 # Name must match name specified in the daos_server.yml file on the server.
 #
+# NOTE: Changing the name is not supported in DAOS 1.0, it must be daos_server
+#
 # default: daos_server
-#name: daos
+#name: daos_server
 
 # Default destination port to use if port not specified in host list addresses.
 # default: 10001

--- a/utils/config/daos_server.yml
+++ b/utils/config/daos_server.yml
@@ -2,13 +2,16 @@
 #
 ## Location of this configuration file is determined by first checking for the
 ## path specified through the -o option of the daos_server command line.
-## Otherwise, /etc/daos_server.conf is used.
+## Otherwise, /etc/daos/daos_server.conf is used.
 #
 #
 ## Name associated with the DAOS system.
 ## Immutable after reformat.
 #
-#name: daos
+# NOTE: Changing the name is not supported in DAOS 1.0, it must be daos_server
+#
+## default: daos_server
+#name: daos_server
 #
 #
 ## Access points


### PR DESCRIPTION
Fixed config file names in doc/admin/deployment.md.
Added a note in doc/user/container.md on env vars that need
to be exported to use the "daos" command in DAOS 1.0.
Fixed broken doc links in src/README.md.

Skip-build: true
Skip-test: true

Signed-off-by: Michael Hennecke <mhennecke@lenovo.com>