### PR TITLE
DAOS-5519 control: Increase test cleanup pause to 250ms

### DIFF
--- a/src/control/lib/control/rpc_test.go
+++ b/src/control/lib/control/rpc_test.go
@@ -187,7 +187,7 @@ func TestControl_InvokeUnaryRPCAsync(t *testing.T) {
 			cancel()
 			// Give things a little bit of time to settle down before checking for
 			// any lingering goroutines.
-			time.Sleep(5 * time.Millisecond)
+			time.Sleep(250 * time.Millisecond)
 			goRoutinesAtEnd := runtime.NumGoroutine()
 			if goRoutinesAtEnd != goRoutinesAtStart {
 				t.Errorf("expected final goroutine count to be %d, got %d\n", goRoutinesAtStart, goRoutinesAtEnd)


### PR DESCRIPTION
In TestControl_InvokeUnaryRPCAsync, the test needs to wait for
a little bit of time after invoking the cancel closure to clean up
any goroutines started by the test. It was waiting for 5ms, but sometimes
this was not quite enough. The stack dumps didn't show any lingering
goroutines, so increasing the time between calling cancel and
checking the number of goroutines should fix this.