### PR TITLE
DAOS-5584 doc: Clarify pool/cont ownership docs

### DIFF
--- a/doc/admin/pool_operations.md
+++ b/doc/admin/pool_operations.md
@@ -125,6 +125,12 @@ This is reflected in the set of supported
 A user must be able to connect to the pool in order to access any containers
 inside, regardless of their permissions on those containers.
 
+### Ownership
+
+Pool ownership conveys no special privileges for access control decisions. All
+desired privileges of the owner-user (`OWNER@`) and owner-group (`GROUP@`) must
+be explicitly defined by an administrator in the pool ACL.
+
 ### Creating a pool with a custom ACL
 
 To create a pool with a custom ACL:

--- a/doc/user/container.md
+++ b/doc/user/container.md
@@ -304,9 +304,16 @@ The ownership of the container corresponds to the special principals `OWNER@`
 and `GROUP@` in the ACL. These values are a part of the container properties.
 They may be set on container creation and changed later.
 
-The owner-user (`OWNER@`) always has set-ACL and get-ACL permissions, even if
-they are not explicitly granted by the ACL. This applies regardless of the other
-permissions they are granted by ACE(s) in the ACL.
+#### Privileges
+
+The owner-user (`OWNER@`) has implicit privileges on their container. The
+owner-user can always open the container, and has set-ACL (A) and get-ACL (a)
+permissions. These permissions are included alongside any permissions that the
+user was explicitly granted by entries in the ACL.
+
+Because the owner's special permissions are implicit, they apply to access
+control decisions even if they do not appear in the `OWNER@` entry, and even if
+the `OWNER@` entry is deleted.
 
 The owner-group (`GROUP@`) has no special permissions outside what they are
 granted by the ACL.


### PR DESCRIPTION
- Add description of how ownership affects pool permissions
  (it doesn't).
- Clarify description of the implicit owner permissions on
  containers.

Signed-off-by: Kris Jacque <kristin.jacque@intel.com>