### PR TITLE
DAOS-5579 doc: fix go unit tests after config file update

### DIFF
--- a/src/control/server/config_test.go
+++ b/src/control/server/config_test.go
@@ -234,7 +234,7 @@ func TestServer_ConstructedConfig(t *testing.T) {
 		WithControlLogFile("/tmp/daos_control.log").
 		WithHelperLogFile("/tmp/daos_admin.log").
 		WithFirmwareHelperLogFile("/tmp/daos_firmware.log").
-		WithSystemName("daos").
+		WithSystemName("daos_server").
 		WithSocketDir("./.daos/daos_server").
 		WithFabricProvider("ofi+verbs;ofi_rxm").
 		WithCrtCtxShareAddr(1).

--- a/utils/config/daos_server.yml
+++ b/utils/config/daos_server.yml
@@ -8,7 +8,8 @@
 ## Name associated with the DAOS system.
 ## Immutable after reformat.
 #
-# NOTE: Changing the name is not supported in DAOS 1.0, it must be daos_server
+## NOTE: Changing the name is not supported in DAOS 1.0, it must not be changed
+##       from the default "daos_server".
 #
 ## default: daos_server
 #name: daos_server


### PR DESCRIPTION
DAOS-5579 doc change altered config file comments resulting in line
with one few to many comment characters ("#"), config file parsing
test then failed with unmarshal error.

Signed-off-by: Tom Nabarro <tom.nabarro@intel.com>