### PR TITLE
CART-822 test: use prefix in path to cart_logtest.py

### DIFF
--- a/src/tests/ftest/launch.py
+++ b/src/tests/ftest/launch.py
@@ -955,7 +955,7 @@ def archive_files(destination, host_list, source_files):
         "copied=()",
         "for file in $(ls {})".format(source_files),
         "do ls -sh $file",
-        "/lib/cart/TESTING/util/cart_logtest.py $file",
+        "$SL_PREFIX/lib/cart/TESTING/util/cart_logtest.py $file",
         "if scp $file {}:{}/${{file##*/}}-$(hostname -s)".format(
             this_host, destination),
         "then copied+=($file)",


### PR DESCRIPTION
Manual invocation of launch.py results in a failure to archive logs
to the artifacts daos_logs subdirectory. It has been shown this is
due to a failure to find the cart_logtest.py file whose invocation
added in PR 3228 uses a hard-coded path beginning with /lib.

With this change, the $SL_PREFIX environment variable is prepended
to the command that launches cart_logtest.py.

Signed-off-by: Kenneth Cain <kenneth.c.cain@intel.com>