### PR TITLE
DAOS-5583 dtx: properly set dth_solo for distributed transaction

### DIFF
--- a/src/include/daos_srv/dtx_srv.h
+++ b/src/include/daos_srv/dtx_srv.h
@@ -161,7 +161,7 @@ dtx_leader_begin(struct ds_cont_child *cont, struct dtx_id *dti,
 		 struct dtx_epoch *epoch, uint16_t sub_modification_cnt,
 		 uint32_t pm_ver, daos_unit_oid_t *leader_oid,
 		 struct dtx_id *dti_cos, int dti_cos_cnt,
-		 struct daos_shard_tgt *tgts, int tgt_cnt, bool sync,
+		 struct daos_shard_tgt *tgts, int tgt_cnt, bool solo, bool sync,
 		 struct dtx_memberships *mbs, struct dtx_leader_handle *dlh);
 int
 dtx_leader_end(struct dtx_leader_handle *dlh, struct ds_cont_child *cont,

--- a/src/object/srv_obj.c
+++ b/src/object/srv_obj.c
@@ -2110,7 +2110,7 @@ again:
 
 	rc = dtx_leader_begin(ioc.ioc_coc, &orw->orw_dti, &epoch, 1, version,
 			      &orw->orw_oid, dti_cos, dti_cos_cnt,
-			      tgts, tgt_cnt,
+			      tgts, tgt_cnt, tgt_cnt == 0 ? true : false,
 			      (orw->orw_flags & ORF_DTX_SYNC) ? true : false,
 			      mbs, &dlh);
 	if (rc != 0) {
@@ -2866,7 +2866,7 @@ again:
 
 	rc = dtx_leader_begin(ioc.ioc_coc, &opi->opi_dti, &epoch, 1, version,
 			      &opi->opi_oid, dti_cos, dti_cos_cnt,
-			      tgts, tgt_cnt,
+			      tgts, tgt_cnt, tgt_cnt == 0 ? true : false,
 			      (opi->opi_flags & ORF_DTX_SYNC) ? true : false,
 			      mbs, &dlh);
 	if (rc != 0) {
@@ -3798,7 +3798,9 @@ ds_obj_dtx_leader_ult(void *arg)
 	rc = dtx_leader_begin(dca->dca_ioc->ioc_coc, &dcsh->dcsh_xid,
 			      &dcsh->dcsh_epoch, dcde->dcde_write_cnt,
 			      oci->oci_map_ver, &dcsh->dcsh_leader_oid, NULL,
-			      0, tgts, tgt_cnt - 1, true, dcsh->dcsh_mbs, &dlh);
+			      0, tgts, tgt_cnt - 1,
+			      (tgt_cnt > 1 || dcde->dcde_write_cnt > 1) ?
+			      false : true, true, dcsh->dcsh_mbs, &dlh);
 	if (rc != 0)
 		goto out;
 


### PR DESCRIPTION
For distributed transaction, it is possible that there is only one
non-replicated target to be modified on the leader but with others
on the other non-leader servers. Or more than one non-replicated
targets to be modified reside on the leader. Under such cases, we
shall set "dth_solo" as false that will help the DTX logic in VOS
to allocate DTX entry in persistent memory.

Signed-off-by: Fan Yong <fan.yong@intel.com>