### PR TITLE
DAOS-623 vos: Avoid bit fields in durable format

### DIFF
--- a/src/include/daos_srv/evtree.h
+++ b/src/include/daos_srv/evtree.h
@@ -207,10 +207,12 @@ struct evt_weight {
 struct evt_rect_df {
 	/** Epoch of update */
 	uint64_t	rd_epc;
-	/** Length of record */
-	uint64_t	rd_len:48;
+	/** Upper bits of record length */
+	uint32_t	rd_len_hi;
+	/** Lower bits of record length */
+	uint16_t	rd_len_lo;
 	/** Minor epoch of update */
-	uint64_t	rd_minor_epc:16;
+	uint16_t	rd_minor_epc;
 	/** Low offset */
 	uint64_t	rd_lo;
 };

--- a/src/vos/evtree.c
+++ b/src/vos/evtree.c
@@ -34,8 +34,10 @@
 static inline void
 evt_ext_read(struct evt_extent *ext, const struct evt_rect_df *rin)
 {
+	uint64_t	len = ((uint64_t)rin->rd_len_hi << 16) + rin->rd_len_lo;
+
 	ext->ex_lo = rin->rd_lo;
-	ext->ex_hi = rin->rd_lo + rin->rd_len - 1;
+	ext->ex_hi = rin->rd_lo + len  - 1;
 }
 
 /** Read and translate the rectangle in durable format to in-memory format */
@@ -51,7 +53,10 @@ evt_rect_read(struct evt_rect *rout, const struct evt_rect_df *rin)
 static inline void
 evt_rect_write(struct evt_rect_df *rout, const struct evt_rect *rin)
 {
-	rout->rd_len = rin->rc_ex.ex_hi - rin->rc_ex.ex_lo + 1;
+	uint64_t len = rin->rc_ex.ex_hi - rin->rc_ex.ex_lo + 1;
+
+	rout->rd_len_hi = len >> 16;
+	rout->rd_len_lo = len & 0xffff;
 	rout->rd_epc = rin->rc_epc;
 	rout->rd_minor_epc = rin->rc_minor_epc;
 	rout->rd_lo = rin->rc_ex.ex_lo;

--- a/src/vos/vos_layout.h
+++ b/src/vos/vos_layout.h
@@ -105,7 +105,7 @@ enum vos_gc_type {
 #define POOL_DF_MAGIC				0x5ca1ab1e
 
 #define POOL_DF_VER_1				1
-#define POOL_DF_VERSION				10
+#define POOL_DF_VERSION				11
 
 /**
  * Durable format for VOS pool


### PR DESCRIPTION
It was suggested to simplify evt_rect_df by using bit fields but
this can cause issues with different compilers and architectures
so it's best to use fixed sized, well defined fields

Signed-off-by: Jeff Olivier <jeffrey.v.olivier@intel.com>