### PR TITLE
DAOS-4819 test: Update pool rebuild tests failure

### DIFF
--- a/src/tests/ftest/pool/rebuild_tests.py
+++ b/src/tests/ftest/pool/rebuild_tests.py
@@ -21,7 +21,7 @@
   Any reproduction of computer software, computer software documentation, or
   portions thereof marked with this legend must also reproduce the markings.
 """
-from apricot import TestWithServers
+from apricot import TestWithServers, skipForTicket
 from test_utils_pool import TestPool
 from test_utils_container import TestContainer
 
@@ -130,6 +130,7 @@ class RebuildTests(TestWithServers):
                 "Data verification error after rebuild")
         self.log.info("Test Passed")
 
+    @skipForTicket("DAOS-5611")
     def test_simple_rebuild(self):
         """JIRA ID: DAOS-XXXX Rebuild-001.
 
@@ -143,6 +144,7 @@ class RebuildTests(TestWithServers):
         """
         self.run_rebuild_test(1)
 
+    @skipForTicket("DAOS-5611")
     def test_multipool_rebuild(self):
         """JIRA ID: DAOS-XXXX (Rebuild-002).
 

--- a/src/tests/ftest/pool/rebuild_tests.py
+++ b/src/tests/ftest/pool/rebuild_tests.py
@@ -21,7 +21,7 @@
   Any reproduction of computer software, computer software documentation, or
   portions thereof marked with this legend must also reproduce the markings.
 """
-from apricot import TestWithServers, skipForTicket
+from apricot import TestWithServers
 from test_utils_pool import TestPool
 from test_utils_container import TestContainer
 
@@ -130,7 +130,6 @@ class RebuildTests(TestWithServers):
                 "Data verification error after rebuild")
         self.log.info("Test Passed")
 
-    @skipForTicket("DAOS-2922")
     def test_simple_rebuild(self):
         """JIRA ID: DAOS-XXXX Rebuild-001.
 
@@ -144,7 +143,6 @@ class RebuildTests(TestWithServers):
         """
         self.run_rebuild_test(1)
 
-    @skipForTicket("DAOS-2922")
     def test_multipool_rebuild(self):
         """JIRA ID: DAOS-XXXX (Rebuild-002).
 

--- a/src/tests/ftest/pool/rebuild_with_io.py
+++ b/src/tests/ftest/pool/rebuild_with_io.py
@@ -36,7 +36,7 @@ class RebuildWithIO(TestWithServers):
     :avocado: recursive
     """
 
-    @skipForTicket("DAOS-2922")
+    #@skipForTicket("DAOS-2922")
     def test_rebuild_with_io(self):
         """JIRA ID: Rebuild-003.
 

--- a/src/tests/ftest/pool/rebuild_with_io.py
+++ b/src/tests/ftest/pool/rebuild_with_io.py
@@ -21,7 +21,7 @@
   Any reproduction of computer software, computer software documentation, or
   portions thereof marked with this legend must also reproduce the markings.
 """
-from apricot import TestWithServers, skipForTicket
+from apricot import TestWithServers
 from test_utils_pool import TestPool
 from test_utils_container import TestContainer
 
@@ -36,7 +36,6 @@ class RebuildWithIO(TestWithServers):
     :avocado: recursive
     """
 
-    #@skipForTicket("DAOS-2922")
     def test_rebuild_with_io(self):
         """JIRA ID: Rebuild-003.
 

--- a/src/tests/ftest/pool/rebuild_with_io.py
+++ b/src/tests/ftest/pool/rebuild_with_io.py
@@ -21,7 +21,7 @@
   Any reproduction of computer software, computer software documentation, or
   portions thereof marked with this legend must also reproduce the markings.
 """
-from apricot import TestWithServers
+from apricot import TestWithServers, skipForTicket
 from test_utils_pool import TestPool
 from test_utils_container import TestContainer
 
@@ -36,6 +36,7 @@ class RebuildWithIO(TestWithServers):
     :avocado: recursive
     """
 
+    @skipForTicket("DAOS-5611")
     def test_rebuild_with_io(self):
         """JIRA ID: Rebuild-003.
 


### PR DESCRIPTION
Re-enable all pool rebuild tests that were skipped for
DAOS-2922
as the issue has been resolved