### PR TITLE
DAOS-5412 test: checksum tests use dmg (pool mgmt)

### DIFF
--- a/src/tests/ftest/checksum/basic_checksum.py
+++ b/src/tests/ftest/checksum/basic_checksum.py
@@ -26,7 +26,6 @@ import ctypes
 from pydaos.raw import (DaosContainer, IORequest,
                         DaosObj)
 from apricot import TestWithServers
-from test_utils_pool import TestPool
 
 
 class ChecksumContainerValidation(TestWithServers):
@@ -58,9 +57,7 @@ class ChecksumContainerValidation(TestWithServers):
         self.no_of_akeys = self.params.get("no_of_akeys", '/run/akeys/*')[0]
         self.record_length = self.params.get("length", '/run/record/*')
 
-        self.pool = TestPool(self.context)
-        self.pool.get_params(self)
-        self.pool.create()
+        self.add_pool(connect=False)
         self.pool.connect(2)
 
         self.csum = self.params.get("enable_checksum", '/run/container/*')

--- a/src/tests/ftest/checksum/basic_checksum.py
+++ b/src/tests/ftest/checksum/basic_checksum.py
@@ -35,9 +35,6 @@ class ChecksumContainerValidation(TestWithServers):
     single object inserts and verifies
     contents. This is a basic sanity
     test for enabling checksum testing.
-    This test case doesn't use TestPool/
-    TestContainer for now. TestPool/TestContainer
-    needs changes to support checksum.
     :avocado: recursive
     """
     # pylint: disable=too-many-instance-attributes

--- a/src/tests/ftest/checksum/basic_checksum.yaml
+++ b/src/tests/ftest/checksum/basic_checksum.yaml
@@ -18,6 +18,7 @@ pool:
         scm_size: 3000000000
     createsvc:
         svcn: 1
+    control_method: dmg
 container: !mux
    properties:
        enable_checksum: True


### PR DESCRIPTION
Summary:
 Update the basic_checksum.py script to use dmg for pool creation.

Signed-off-by: Padmanabhan <ravindran.padmanabhan@intel.com>