### PR TITLE
DAOS-5543 test: Updated io_consistency pool create to use dmg

### DIFF
--- a/src/tests/ftest/io/io_consistency.yaml
+++ b/src/tests/ftest/io/io_consistency.yaml
@@ -17,16 +17,12 @@ server_config:
     scm_class: dcpm
     scm_list: ["/dev/pmem0"]
 pool:
-  createmode:
-    mode_RW:
-      mode: 146
-  createset:
-    setname: daos_server
-  createsize:
-    scm_size: 5000000000
-    nvme_size: 20000000000
-  createsvc:
-    svcn: 1
+  mode: 146
+  name: daos_server
+  scm_size: 5000000000
+  nvme_size: 20000000000
+  svcn: 1
+  control_method: dmg
 container:
   type: POSIX
   control_method: daos


### PR DESCRIPTION
Updated io_consistency pool create to use dmg

Signed-off-by: Saurabh Tandan <saurabh.tandan@intel.com>