### PR TITLE
DAOS-5277 cart: Removed locking from hot path for callbacks

### DIFF
--- a/src/cart/crt_context.c
+++ b/src/cart/crt_context.c
@@ -620,23 +620,26 @@ crt_req_timeout_untrack(struct crt_rpc_priv *rpc_priv)
 static void
 crt_exec_timeout_cb(struct crt_rpc_priv *rpc_priv)
 {
-	struct crt_timeout_cb_priv *cb_priv;
+	struct crt_timeout_cb_priv	*cbs_timeout;
+	crt_timeout_cb			 cb_func;
+	void				*cb_args;
+	size_t				 cbs_size;
+	size_t				 i;
 
-	if (crt_plugin_gdata.cpg_inited == 0)
+	if (unlikely(crt_plugin_gdata.cpg_inited == 0 || rpc_priv == NULL))
 		return;
-	if (rpc_priv == NULL) {
-		D_ERROR("Invalid parameter, rpc_priv == NULL\n");
-		return;
+
+	cbs_size = crt_plugin_gdata.cpg_timeout_size;
+	cbs_timeout = crt_plugin_gdata.cpg_timeout_cbs;
+
+	for (i = 0; i < cbs_size; i++) {
+		cb_func = cbs_timeout[i].ctcp_func;
+		cb_args = cbs_timeout[i].ctcp_args;
+		/* check for and execute timeout callbacks here */
+		if (cb_func != NULL)
+			cb_func(rpc_priv->crp_pub.cr_ctx, &rpc_priv->crp_pub,
+				cb_args);
 	}
-	D_RWLOCK_RDLOCK(&crt_plugin_gdata.cpg_timeout_rwlock);
-	d_list_for_each_entry(cb_priv,
-			      &crt_plugin_gdata.cpg_timeout_cbs,
-			      ctcp_link) {
-		cb_priv->ctcp_func(rpc_priv->crp_pub.cr_ctx,
-				   &rpc_priv->crp_pub,
-				   cb_priv->ctcp_args);
-	}
-	D_RWLOCK_UNLOCK(&crt_plugin_gdata.cpg_timeout_rwlock);
 }
 
 static bool
@@ -1172,35 +1175,32 @@ crt_context_empty(int locked)
 static void
 crt_exec_progress_cb(struct crt_context *ctx)
 {
-	struct crt_prog_cb_priv	*cb_priv;
+	struct crt_prog_cb_priv	*cbs_prog;
+	crt_progress_cb		 cb_func;
+	void			*cb_args;
+	size_t i, cbs_size;
 	int ctx_idx;
 	int rc;
 
-	if (crt_plugin_gdata.cpg_inited == 0)
+	if (unlikely(crt_plugin_gdata.cpg_inited == 0 || ctx == NULL))
 		return;
-
-	if (ctx == NULL) {
-		D_ERROR("Invalid parameter.\n");
-		return;
-	}
 
 	rc = crt_context_idx(ctx, &ctx_idx);
-	if (rc) {
+	if (unlikely(rc)) {
 		D_ERROR("crt_context_idx() failed, rc: %d.\n", rc);
 		return;
 	}
 
-	/* avoid lock and list traverse overhead if no progress cb */
-	if (d_list_empty(&crt_plugin_gdata.cpg_prog_cbs[ctx_idx]))
-		return;
+	cbs_size = crt_plugin_gdata.cpg_prog_size[ctx_idx];
+	cbs_prog = crt_plugin_gdata.cpg_prog_cbs[ctx_idx];
 
-	D_RWLOCK_RDLOCK(&crt_plugin_gdata.cpg_prog_rwlock[ctx_idx]);
-	d_list_for_each_entry(cb_priv, &crt_plugin_gdata.cpg_prog_cbs[ctx_idx],
-			      cpcp_link) {
+	for (i = 0; i < cbs_size; i++) {
+		cb_func = cbs_prog[i].cpcp_func;
+		cb_args = cbs_prog[i].cpcp_args;
 		/* check for and execute progress callbacks here */
-		cb_priv->cpcp_func(ctx, cb_priv->cpcp_args);
+		if (cb_func != NULL)
+			cb_func(ctx, cb_args);
 	}
-	D_RWLOCK_UNLOCK(&crt_plugin_gdata.cpg_prog_rwlock[ctx_idx]);
 }
 
 int
@@ -1345,55 +1345,94 @@ crt_progress(crt_context_t crt_ctx, int64_t timeout)
  * 2) call crt_register_progress_cb(user_cb);
  */
 int
-crt_register_progress_cb(crt_progress_cb cb, int ctx_idx, void *arg)
+crt_register_progress_cb(crt_progress_cb func, int ctx_idx, void *args)
 {
-	/* save the function pointer and arg to a global list */
-	struct crt_prog_cb_priv	*cb_priv = NULL;
-	int			 rc = 0;
+	struct crt_prog_cb_priv	*cbs_prog;
+	size_t i, cbs_size;
+	int rc = 0;
 
 	if (ctx_idx >= CRT_SRV_CONTEXT_NUM) {
 		D_ERROR("ctx_idx %d >= %d\n", ctx_idx, CRT_SRV_CONTEXT_NUM);
 		D_GOTO(out, rc = -DER_INVAL);
 	}
 
-	D_ALLOC_PTR(cb_priv);
-	if (cb_priv == NULL)
-		D_GOTO(out, rc = -DER_NOMEM);
+	D_MUTEX_LOCK(&crt_plugin_gdata.cpg_mutex);
 
-	cb_priv->cpcp_func = cb;
-	cb_priv->cpcp_args = arg;
+	cbs_size = crt_plugin_gdata.cpg_prog_size[ctx_idx];
+	cbs_prog = crt_plugin_gdata.cpg_prog_cbs[ctx_idx];
 
-	D_RWLOCK_WRLOCK(&crt_plugin_gdata.cpg_prog_rwlock[ctx_idx]);
-	d_list_add_tail(&cb_priv->cpcp_link,
-			&crt_plugin_gdata.cpg_prog_cbs[ctx_idx]);
-	D_RWLOCK_UNLOCK(&crt_plugin_gdata.cpg_prog_rwlock[ctx_idx]);
+	for (i = 0; i < cbs_size; i++) {
+		if (cbs_prog[i].cpcp_func == func &&
+		    cbs_prog[i].cpcp_args == args) {
+			D_GOTO(out_unlock, rc = -DER_EXIST);
+		}
+	}
+
+	for (i = 0; i < cbs_size; i++) {
+		if (cbs_prog[i].cpcp_func == NULL) {
+			cbs_prog[i].cpcp_args = args;
+			cbs_prog[i].cpcp_func = func;
+			D_GOTO(out_unlock, rc = 0);
+		}
+	}
+
+	if (crt_plugin_gdata.cpg_prog_cbs_old[ctx_idx] != NULL)
+		D_FREE(crt_plugin_gdata.cpg_prog_cbs_old[ctx_idx]);
+
+	crt_plugin_gdata.cpg_prog_cbs_old[ctx_idx] = cbs_prog;
+	cbs_size += CRT_CALLBACKS_NUM;
+
+	D_ALLOC_ARRAY(cbs_prog, cbs_size);
+	if (cbs_prog == NULL) {
+		crt_plugin_gdata.cpg_prog_cbs_old[ctx_idx] = NULL;
+		D_GOTO(out_unlock, rc = -DER_NOMEM);
+	}
+
+	if (i > 0)
+		memcpy(cbs_prog, crt_plugin_gdata.cpg_prog_cbs_old[ctx_idx],
+		       i * sizeof(*cbs_prog));
+	cbs_prog[i].cpcp_args = args;
+	cbs_prog[i].cpcp_func = func;
+
+	crt_plugin_gdata.cpg_prog_cbs[ctx_idx]  = cbs_prog;
+	crt_plugin_gdata.cpg_prog_size[ctx_idx] = cbs_size;
+
+out_unlock:
+	D_MUTEX_UNLOCK(&crt_plugin_gdata.cpg_mutex);
 out:
 	return rc;
 }
 
 int
-crt_unregister_progress_cb(crt_progress_cb cb, int ctx_idx, void *arg)
+crt_unregister_progress_cb(crt_progress_cb func, int ctx_idx, void *args)
 {
-	struct crt_prog_cb_priv *tmp, *cb_priv;
-	int			 rc = -DER_NONEXIST;
+	struct crt_prog_cb_priv	*cbs_prog;
+	size_t i, cbs_size;
+	int rc = -DER_NONEXIST;
 
 	if (ctx_idx >= CRT_SRV_CONTEXT_NUM) {
 		D_ERROR("ctx_idx %d >= %d\n", ctx_idx, CRT_SRV_CONTEXT_NUM);
 		D_GOTO(out, rc = -DER_INVAL);
 	}
 
-	D_RWLOCK_WRLOCK(&crt_plugin_gdata.cpg_prog_rwlock[ctx_idx]);
-	d_list_for_each_entry_safe(cb_priv, tmp,
-				   &crt_plugin_gdata.cpg_prog_cbs[ctx_idx],
-				   cpcp_link) {
-		if (cb_priv->cpcp_func == cb && cb_priv->cpcp_args == arg) {
-			d_list_del_init(&cb_priv->cpcp_link);
-			D_FREE(cb_priv);
-			D_GOTO(out_unlock, rc = -DER_SUCCESS);
+	D_MUTEX_LOCK(&crt_plugin_gdata.cpg_mutex);
+
+	cbs_size = crt_plugin_gdata.cpg_prog_size[ctx_idx];
+	cbs_prog = crt_plugin_gdata.cpg_prog_cbs[ctx_idx];
+
+	for (i = 0; i < cbs_size; i++) {
+		if (cbs_prog[i].cpcp_func == func &&
+		    cbs_prog[i].cpcp_args == args) {
+			cbs_prog[i].cpcp_func = NULL;
+			cbs_prog[i].cpcp_args = NULL;
+			D_GOTO(out_unlock, rc = 0);
 		}
 	}
+
 out_unlock:
-	D_RWLOCK_UNLOCK(&crt_plugin_gdata.cpg_prog_rwlock[ctx_idx]);
+	D_FREE(crt_plugin_gdata.cpg_prog_cbs_old[ctx_idx]);
+
+	D_MUTEX_UNLOCK(&crt_plugin_gdata.cpg_mutex);
 out:
 	return rc;
 }
@@ -1404,23 +1443,54 @@ out:
  * 2) call crt_register_timeout_cb_core(user_cb);
  */
 int
-crt_register_timeout_cb(crt_timeout_cb cb, void *arg)
+crt_register_timeout_cb(crt_timeout_cb func, void *args)
 {
-	/* TODO: save the function pointer somewhere for retrieval later on */
-	struct crt_timeout_cb_priv	*timeout_cb_priv = NULL;
-	int				 rc = 0;
+	struct crt_timeout_cb_priv *cbs_timeout;
+	size_t i, cbs_size;
+	int rc = 0;
 
-	D_ALLOC_PTR(timeout_cb_priv);
-	if (timeout_cb_priv == NULL)
-		D_GOTO(out, rc = -DER_NOMEM);
-	timeout_cb_priv->ctcp_func = cb;
-	timeout_cb_priv->ctcp_args = arg;
-	D_RWLOCK_WRLOCK(&crt_plugin_gdata.cpg_timeout_rwlock);
-	d_list_add_tail(&timeout_cb_priv->ctcp_link,
-			&crt_plugin_gdata.cpg_timeout_cbs);
-	D_RWLOCK_UNLOCK(&crt_plugin_gdata.cpg_timeout_rwlock);
+	D_MUTEX_LOCK(&crt_plugin_gdata.cpg_mutex);
 
-out:
+	cbs_size = crt_plugin_gdata.cpg_timeout_size;
+	cbs_timeout = crt_plugin_gdata.cpg_timeout_cbs;
+
+	for (i = 0; i < cbs_size; i++) {
+		if (cbs_timeout[i].ctcp_func == func &&
+		    cbs_timeout[i].ctcp_args == args) {
+			D_GOTO(out_unlock, rc = -DER_EXIST);
+		}
+	}
+
+	for (i = 0; i < cbs_size; i++) {
+		if (cbs_timeout[i].ctcp_func == NULL) {
+			cbs_timeout[i].ctcp_args = args;
+			cbs_timeout[i].ctcp_func = func;
+			D_GOTO(out_unlock, rc = 0);
+		}
+	}
+
+	D_FREE(crt_plugin_gdata.cpg_timeout_cbs_old);
+
+	crt_plugin_gdata.cpg_timeout_cbs_old = cbs_timeout;
+	cbs_size += CRT_CALLBACKS_NUM;
+
+	D_ALLOC_ARRAY(cbs_timeout, cbs_size);
+	if (cbs_timeout == NULL) {
+		crt_plugin_gdata.cpg_timeout_cbs_old = NULL;
+		D_GOTO(out_unlock, rc = -DER_NOMEM);
+	}
+
+	if (i > 0)
+		memcpy(cbs_timeout, crt_plugin_gdata.cpg_timeout_cbs_old,
+		       i * sizeof(*cbs_timeout));
+	cbs_timeout[i].ctcp_args = args;
+	cbs_timeout[i].ctcp_func = func;
+
+	crt_plugin_gdata.cpg_timeout_cbs  = cbs_timeout;
+	crt_plugin_gdata.cpg_timeout_size = cbs_size;
+
+out_unlock:
+	D_MUTEX_UNLOCK(&crt_plugin_gdata.cpg_mutex);
 	return rc;
 }
 

--- a/src/cart/crt_init.c
+++ b/src/cart/crt_init.c
@@ -207,38 +207,56 @@ exit:
 static int
 crt_plugin_init(void)
 {
+	struct crt_prog_cb_priv *cbs_prog;
+	struct crt_timeout_cb_priv *cbs_timeout;
+	struct crt_event_cb_priv *cbs_event;
+	size_t cbs_size = CRT_CALLBACKS_NUM;
 	int i, rc;
 
 	D_ASSERT(crt_plugin_gdata.cpg_inited == 0);
 
-	/** init the lists */
 	for (i = 0; i < CRT_SRV_CONTEXT_NUM; i++) {
-		D_INIT_LIST_HEAD(&crt_plugin_gdata.cpg_prog_cbs[i]);
-		rc = D_RWLOCK_INIT(&crt_plugin_gdata.cpg_prog_rwlock[i], NULL);
-		if (rc != 0)
-			D_GOTO(out, rc);
+		crt_plugin_gdata.cpg_prog_cbs_old[i] = NULL;
+		D_ALLOC_ARRAY(cbs_prog, cbs_size);
+		if (cbs_prog == NULL) {
+			while (i > 0)
+				D_FREE(crt_plugin_gdata.cpg_prog_cbs[--i]);
+			D_GOTO(out, rc = -DER_NOMEM);
+		}
+		crt_plugin_gdata.cpg_prog_size[i] = cbs_size;
+		crt_plugin_gdata.cpg_prog_cbs[i]  = cbs_prog;
 	}
 
-	D_INIT_LIST_HEAD(&crt_plugin_gdata.cpg_timeout_cbs);
-	rc = D_RWLOCK_INIT(&crt_plugin_gdata.cpg_timeout_rwlock, NULL);
-	if (rc != 0)
-		D_GOTO(out_destroy_prog, rc);
+	crt_plugin_gdata.cpg_timeout_cbs_old = NULL;
+	D_ALLOC_ARRAY(cbs_timeout, cbs_size);
+	if (cbs_timeout == NULL) {
+		D_GOTO(out_destroy_prog, rc = -DER_NOMEM);
+	}
+	crt_plugin_gdata.cpg_timeout_size = cbs_size;
+	crt_plugin_gdata.cpg_timeout_cbs  = cbs_timeout;
 
-	D_INIT_LIST_HEAD(&crt_plugin_gdata.cpg_event_cbs);
-	rc = D_RWLOCK_INIT(&crt_plugin_gdata.cpg_event_rwlock, NULL);
-	if (rc != 0)
-		D_GOTO(out_destroy_timeout, rc);
+	crt_plugin_gdata.cpg_event_cbs_old = NULL;
+	D_ALLOC_ARRAY(cbs_event, cbs_size);
+	if (cbs_event == NULL) {
+		D_GOTO(out_destroy_timeout, rc = -DER_NOMEM);
+	}
+	crt_plugin_gdata.cpg_event_size = cbs_size;
+	crt_plugin_gdata.cpg_event_cbs  = cbs_event;
 
+	rc = D_MUTEX_INIT(&crt_plugin_gdata.cpg_mutex, NULL);
+	if (rc)
+		D_GOTO(out_destroy_event, rc);
 
 	crt_plugin_gdata.cpg_inited = 1;
 	D_GOTO(out, rc = 0);
 
-	D_RWLOCK_DESTROY(&crt_plugin_gdata.cpg_event_rwlock);
+out_destroy_event:
+	D_FREE(crt_plugin_gdata.cpg_event_cbs);
 out_destroy_timeout:
-	D_RWLOCK_DESTROY(&crt_plugin_gdata.cpg_timeout_rwlock);
+	D_FREE(crt_plugin_gdata.cpg_timeout_cbs);
 out_destroy_prog:
 	for (i = 0; i < CRT_SRV_CONTEXT_NUM; i++)
-		D_RWLOCK_DESTROY(&crt_plugin_gdata.cpg_prog_rwlock[i]);
+		D_FREE(crt_plugin_gdata.cpg_prog_cbs[i]);
 out:
 	return rc;
 }
@@ -467,37 +485,24 @@ crt_initialized()
 void
 crt_plugin_fini(void)
 {
-	struct crt_prog_cb_priv		*prog_cb_priv;
-	struct crt_timeout_cb_priv	*timeout_cb_priv;
-	struct crt_event_cb_priv	*event_cb_priv;
-	int				 i;
+	int i;
 
 	D_ASSERT(crt_plugin_gdata.cpg_inited == 1);
 
+	crt_plugin_gdata.cpg_inited = 0;
+
 	for (i = 0; i < CRT_SRV_CONTEXT_NUM; i++) {
-		while ((prog_cb_priv = d_list_pop_entry(
-					&crt_plugin_gdata.cpg_prog_cbs[i],
-					struct crt_prog_cb_priv,
-					cpcp_link))) {
-			D_FREE(prog_cb_priv);
-		}
+		D_FREE(crt_plugin_gdata.cpg_prog_cbs[i]);
+		D_FREE(crt_plugin_gdata.cpg_prog_cbs_old[i]);
 	}
 
-	while ((timeout_cb_priv = d_list_pop_entry(&crt_plugin_gdata.cpg_timeout_cbs,
-						   struct crt_timeout_cb_priv,
-						   ctcp_link))) {
-		D_FREE(timeout_cb_priv);
-	}
-	while ((event_cb_priv = d_list_pop_entry(&crt_plugin_gdata.cpg_event_cbs,
-						 struct crt_event_cb_priv,
-						 cecp_link))) {
-		D_FREE(event_cb_priv);
-	}
+	D_FREE(crt_plugin_gdata.cpg_timeout_cbs);
+	D_FREE(crt_plugin_gdata.cpg_timeout_cbs_old);
 
-	for (i = 0; i < CRT_SRV_CONTEXT_NUM; i++)
-		D_RWLOCK_DESTROY(&crt_plugin_gdata.cpg_prog_rwlock[i]);
-	D_RWLOCK_DESTROY(&crt_plugin_gdata.cpg_timeout_rwlock);
-	D_RWLOCK_DESTROY(&crt_plugin_gdata.cpg_event_rwlock);
+	D_FREE(crt_plugin_gdata.cpg_event_cbs);
+	D_FREE(crt_plugin_gdata.cpg_event_cbs_old);
+
+	D_MUTEX_DESTROY(&crt_plugin_gdata.cpg_mutex);
 }
 
 int

--- a/src/cart/crt_internal_types.h
+++ b/src/cart/crt_internal_types.h
@@ -92,33 +92,18 @@ struct crt_gdata {
 extern struct crt_gdata		crt_gdata;
 
 struct crt_prog_cb_priv {
-	d_list_t		 cpcp_link;
 	crt_progress_cb		 cpcp_func;
 	void			*cpcp_args;
 };
 
 struct crt_timeout_cb_priv {
-	d_list_t		 ctcp_link;
 	crt_timeout_cb		 ctcp_func;
 	void			*ctcp_args;
 };
 
 struct crt_event_cb_priv {
-	d_list_t		 cecp_link;
 	crt_event_cb		 cecp_func;
 	void			*cecp_args;
-};
-
-/* TODO: remove the three structs above, use the following one for all */
-struct crt_plugin_cb_priv {
-	d_list_t			 cp_link;
-	union {
-		crt_progress_cb		 cp_prog_cb;
-		crt_timeout_cb		 cp_timeout_cb;
-		crt_event_cb		 cp_event_cb;
-		crt_eviction_cb		 cp_eviction_cb;
-	};
-	void				*cp_args;
 };
 
 /* TODO may use a RPC to query server-side context number */
@@ -126,18 +111,27 @@ struct crt_plugin_cb_priv {
 # define CRT_SRV_CONTEXT_NUM		(256)
 #endif
 
+#ifndef CRT_PROGRESS_NUM
+# define CRT_CALLBACKS_NUM		(4)	/* start number of CBs */
+#endif
+
 /* structure of global fault tolerance data */
 struct crt_plugin_gdata {
 	/* list of progress callbacks */
-	d_list_t		cpg_prog_cbs[CRT_SRV_CONTEXT_NUM];
+	size_t				 cpg_prog_size[CRT_SRV_CONTEXT_NUM];
+	struct crt_prog_cb_priv		*cpg_prog_cbs[CRT_SRV_CONTEXT_NUM];
+	struct crt_prog_cb_priv		*cpg_prog_cbs_old[CRT_SRV_CONTEXT_NUM];
 	/* list of rpc timeout callbacks */
-	d_list_t		cpg_timeout_cbs;
+	size_t				 cpg_timeout_size;
+	struct crt_timeout_cb_priv	*cpg_timeout_cbs;
+	struct crt_timeout_cb_priv	*cpg_timeout_cbs_old;
 	/* list of event notification callbacks */
-	d_list_t		cpg_event_cbs;
-	uint32_t		cpg_inited:1;
-	pthread_rwlock_t	cpg_prog_rwlock[CRT_SRV_CONTEXT_NUM];
-	pthread_rwlock_t	cpg_timeout_rwlock;
-	pthread_rwlock_t	cpg_event_rwlock;
+	size_t				 cpg_event_size;
+	struct crt_event_cb_priv	*cpg_event_cbs;
+	struct crt_event_cb_priv	*cpg_event_cbs_old;
+	uint32_t			 cpg_inited:1;
+	/* mutex to protect all callbacks change only */
+	pthread_mutex_t			 cpg_mutex;
 };
 
 extern struct crt_plugin_gdata		crt_plugin_gdata;

--- a/src/cart/crt_swim.c
+++ b/src/cart/crt_swim.c
@@ -361,10 +361,11 @@ out:
 static void
 crt_swim_notify_rank_state(d_rank_t rank, struct swim_member_state *state)
 {
-	struct crt_event_cb_priv *cb_priv;
-	enum crt_event_type	 cb_type;
+	struct crt_event_cb_priv *cbs_event;
 	crt_event_cb		 cb_func;
-	void			*cb_arg;
+	void			*cb_args;
+	enum crt_event_type	 cb_type;
+	size_t			 i, cbs_size;
 
 	D_ASSERT(state != NULL);
 	switch (state->sms_status) {
@@ -379,14 +380,16 @@ crt_swim_notify_rank_state(d_rank_t rank, struct swim_member_state *state)
 	}
 
 	/* walk the global list to execute the user callbacks */
-	D_RWLOCK_RDLOCK(&crt_plugin_gdata.cpg_event_rwlock);
-	d_list_for_each_entry(cb_priv, &crt_plugin_gdata.cpg_event_cbs,
-			      cecp_link) {
-		cb_func = cb_priv->cecp_func;
-		cb_arg  = cb_priv->cecp_args;
-		cb_func(rank, CRT_EVS_SWIM, cb_type, cb_arg);
+	cbs_size = crt_plugin_gdata.cpg_event_size;
+	cbs_event = crt_plugin_gdata.cpg_event_cbs;
+
+	for (i = 0; i < cbs_size; i++) {
+		cb_func = cbs_event[i].cecp_func;
+		cb_args = cbs_event[i].cecp_args;
+		/* check for and execute event callbacks here */
+		if (cb_func != NULL)
+			cb_func(rank, CRT_EVS_SWIM, cb_type, cb_args);
 	}
-	D_RWLOCK_UNLOCK(&crt_plugin_gdata.cpg_event_rwlock);
 }
 
 static int crt_swim_get_member_state(struct swim_context *ctx,


### PR DESCRIPTION
In this patch I removed locking from read access to callbacks list.
The race with update of this list should not affect functionality
because of it updated in special order that allow to work correctly
during simultaneous update.

```
Options:
api                 : DFS
apiVersion          : DAOS
test filename       : /testfile
access              : single-shared-file
type                : independent
segments            : 1
ordering in a file  : sequential
ordering inter file : no tasks offsets
nodes               : 4
tasks               : 16
clients per node    : 4
repetitions         : 2

xfersize            : 256 bytes
blocksize           : 2 MiB
aggregate filesize  : 32 MiB
Operation   Max(MiB)   Min(MiB)  Mean(MiB)     StdDev   Max(OPs)   Min(OPs)  Mean(OPs)     StdDev    Mean(s) Stonewall(s) Stonewall(MiB) Test# #Tasks tPN reps fPP reord reordoff reordrand seed segcnt   blksiz    xsize aggs(MiB)   API RefNum
master:
write          24.66      16.29      20.48       4.19  101021.75   66712.98   83867.36   17154.38    1.63109         NA            NA     0     16   4    2   0     0        1         0    0      1  2097152      256      32.0 DFS      0
read           20.27      18.96      19.61       0.66   83023.79   77657.51   80340.65    2683.14    1.63327         NA            NA     0     16   4    2   0     0        1         0    0      1  2097152      256      32.0 DFS      0
this patch:
write          27.67      16.20      21.94       5.73  113329.34   66364.58   89846.96   23482.38    1.56579         NA            NA     0     16   4    2   0     0        1         0    0      1  2097152      256      32.0 DFS      0
read           24.18      23.55      23.87       0.31   99045.90   96481.16   97763.53    1282.37    1.34094         NA            NA     0     16   4    2   0     0        1         0    0      1  2097152      256      32.0 DFS      0

xfersize            : 1 MiB
blocksize           : 32 MiB
aggregate filesize  : 512 MiB
Operation   Max(MiB)   Min(MiB)  Mean(MiB)     StdDev   Max(OPs)   Min(OPs)  Mean(OPs)     StdDev    Mean(s) Stonewall(s) Stonewall(MiB) Test# #Tasks tPN reps fPP reord reordoff reordrand seed segcnt   blksiz    xsize aggs(MiB)   API RefNum
master:
write        6248.44    2048.63    4148.54    2099.90    6248.44    2048.63    4148.54    2099.90    0.16593         NA            NA     0     16   4    2   0     0        1         0    0      1 33554432  1048576     512.0 DFS      0
read         6293.47    6272.52    6282.99      10.48    6293.47    6272.52    6282.99      10.48    0.08149         NA            NA     0     16   4    2   0     0        1         0    0      1 33554432  1048576     512.0 DFS      0
this patch:
write        6664.43    2222.89    4443.66    2220.77    6664.43    2222.89    4443.66    2220.77    0.15358         NA            NA     0     16   4    2   0     0        1         0    0      1 33554432  1048576     512.0 DFS      0
read         6501.33    6390.53    6445.93      55.40    6501.33    6390.53    6445.93      55.40    0.07944         NA            NA     0     16   4    2   0     0        1         0    0      1 33554432  1048576     512.0 DFS      0
```
