### PR TITLE
DAOS-5488 test: shrink the swim timeout for aggregation tests

### DIFF
--- a/src/tests/ftest/util/server_utils_params.py
+++ b/src/tests/ftest/util/server_utils_params.py
@@ -356,9 +356,9 @@ class DaosServerYamlParameters(YamlParameters):
                     "FI_SOCKETS_MAX_CONN_RETRY=5",
                     "FI_SOCKETS_CONN_TIMEOUT=2000",
                     "CRT_SWIM_RPC_TIMEOUT=10",
-                    "SWIM_PING_TIMEOUT=10000",
-                    "SWIM_PROTOCOL_PERIOD_LEN=30000",
-                    "SWIM_SUSPECT_TIMEOUT=90000",
+                    "SWIM_PING_TIMEOUT=5000",
+                    "SWIM_PROTOCOL_PERIOD_LEN=6000",
+                    "SWIM_SUSPECT_TIMEOUT=11000",
                 ])
             self.env_vars = BasicParameter(None, default_env_vars)
 


### PR DESCRIPTION
Try to increase the swim timeout to allow aggregation tests pass.