### PR TITLE
DAOS-5622 test: Temporarily disable certs in CI

### DIFF
--- a/ftest.sh
+++ b/ftest.sh
@@ -395,6 +395,7 @@ if [[ \"${TEST_TAG_ARG}\" =~ soak ]]; then
     fi
 fi
 
+
 # can only process cores on EL7 currently
 if [ $(lsb_release -s -i) = CentOS ]; then
     process_cores=\"p\"
@@ -402,7 +403,8 @@ else
     process_cores=\"\"
 fi
 # now run it!
-if ! ./launch.py -cris\${process_cores}a -ts ${TEST_NODES} ${NVME_ARG} \\
+# DAOS-5622: Temporarily disable certs in CI
+if ! ./launch.py -cris\${process_cores}a -ts ${TEST_NODES} ${NVME_ARG} -ins \\
                  ${TEST_TAG_ARR[*]}; then
     rc=\${PIPESTATUS[0]}
 else


### PR DESCRIPTION
Go 1.15 deprecated an aspect of how we use x509 certificates,
and our code will need to be updated in order to fix it properly.
As a short-term workaround to get CI testing going again, we
should just disable certificates.