### PR TITLE
DAOS-XXXX rebuild: Fix many problems found by OSA demo

### DIFF
--- a/src/common/pool_map.c
+++ b/src/common/pool_map.c
@@ -1425,7 +1425,7 @@ gen_pool_buf(struct pool_map *map, struct pool_buf **map_buf_out,
 
 		rc = pool_buf_attach(map_buf, &map_comp, 1 /* comp_nr */);
 		if (rc != 0)
-			return rc;
+			D_GOTO(out_map_buf, rc);
 	}
 
 	if (map != NULL)
@@ -1458,11 +1458,11 @@ gen_pool_buf(struct pool_map *map, struct pool_buf **map_buf_out,
 
 		rc = pool_buf_attach(map_buf, &map_comp, 1 /* comp_nr */);
 		if (rc != 0)
-			return rc;
+			D_GOTO(out_map_buf, rc);
 	}
 
 	if (!updated)
-		return -DER_ALREADY;
+		D_GOTO(out_map_buf, rc = -DER_ALREADY);
 
 	if (map != NULL)
 		num_comps = pool_map_find_target(map, PO_COMP_ID_ALL, NULL);
@@ -1485,7 +1485,7 @@ gen_pool_buf(struct pool_map *map, struct pool_buf **map_buf_out,
 
 			rc = pool_buf_attach(map_buf, &map_comp, 1);
 			if (rc != 0)
-				return rc;
+				D_GOTO(out_map_buf, rc);
 		}
 	}
 	if (uuids_out)
@@ -2160,9 +2160,9 @@ pool_domain_print(struct pool_domain *domain, int dep)
 {
 	int		i;
 
-	pool_indent_print(dep);
-	D_PRINT("%s[%d] %d\n", pool_domain_name(domain),
-		domain->do_comp.co_id, domain->do_comp.co_ver);
+	D_PRINT("%*s%s[%d] %d %s\n", dep * 8, "", pool_domain_name(domain),
+		domain->do_comp.co_id, domain->do_comp.co_ver,
+		pool_comp_state2str(domain->do_comp.co_status));
 
 	D_ASSERT(domain->do_targets != NULL);
 
@@ -2178,9 +2178,10 @@ pool_domain_print(struct pool_domain *domain, int dep)
 		D_ASSERTF(comp->co_type == PO_COMP_TP_TARGET,
 			  "%s\n", pool_comp_type2str(comp->co_type));
 
-		pool_indent_print(dep + 1);
-		D_PRINT("%s[%d] %d\n", pool_comp_type2str(comp->co_type),
-				       comp->co_id, comp->co_ver);
+		D_PRINT("%*s%s[%d] %d %s\n", (dep + 1) * 8, "",
+			pool_comp_type2str(comp->co_type),
+			comp->co_id, comp->co_ver,
+			pool_comp_state2str(comp->co_status));
 	}
 }
 

--- a/src/common/tests_dmg_helpers.c
+++ b/src/common/tests_dmg_helpers.c
@@ -307,6 +307,7 @@ rank_list_to_string(const d_rank_list_t *rank_list)
 	for (i = 0; i < rank_list->rl_nr; i++)
 		idx += sprintf(&ranks_str[idx], "%d,", rank_list->rl_ranks[i]);
 	ranks_str[width - 1] = '\0';
+	ranks_str[width - 2] = '\0';
 
 	return ranks_str;
 }

--- a/src/dtx/dtx_common.c
+++ b/src/dtx/dtx_common.c
@@ -413,6 +413,7 @@ dtx_sub_init(struct dtx_handle *dth, daos_unit_oid_t *oid, uint64_t dkey_hash)
 
 	dth->dth_op_seq++;
 	dth->dth_dkey_hash = dkey_hash;
+	dth->dth_rsrvd_cnt = 0;
 
 	rc = daos_unit_oid_compare(dth->dth_leader_oid, *oid);
 	if (rc == 0) {
@@ -1042,10 +1043,13 @@ dtx_leader_exec_ops_ult(void *arg)
 	D_ASSERT(future != ABT_FUTURE_NULL);
 	for (i = 0; i < dlh->dlh_sub_cnt; i++) {
 		struct dtx_sub_status *sub = &dlh->dlh_subs[i];
+		uint32_t my_rank;
 
 		sub->dss_result = 0;
 
-		if (sub->dss_tgt.st_rank == DAOS_TGT_IGNORE) {
+		crt_group_rank(NULL, &my_rank);
+		if (sub->dss_tgt.st_rank == DAOS_TGT_IGNORE ||
+		    sub->dss_tgt.st_rank == my_rank) {
 			int ret;
 
 			ret = ABT_future_set(future, dlh);
@@ -1073,6 +1077,21 @@ dtx_leader_exec_ops_ult(void *arg)
 	}
 }
 
+static bool
+dth_local_op(struct dtx_leader_handle *dlh, int idx)
+{
+	d_rank_t my_rank;
+
+	if (idx == -1)
+		return true;
+
+	crt_group_rank(NULL, &my_rank);
+	if (dlh->dlh_subs[idx].dss_tgt.st_rank == my_rank)
+		return true;
+
+	return false;
+}
+
 /**
  * Execute the operations on all targets.
  */
@@ -1082,6 +1101,7 @@ dtx_leader_exec_ops(struct dtx_leader_handle *dlh, dtx_sub_func_t func,
 {
 	struct dtx_ult_arg	*ult_arg;
 	int			rc;
+	int			i;
 
 	if (dlh->dlh_sub_cnt == 0)
 		goto exec;
@@ -1119,6 +1139,10 @@ dtx_leader_exec_ops(struct dtx_leader_handle *dlh, dtx_sub_func_t func,
 
 exec:
 	/* Then execute the local operation */
+	for (i = 0; i < dlh->dlh_sub_cnt; i++) {
+		if (dth_local_op(dlh, i))
+			rc = func(dlh, func_arg, i, NULL);
+	}
 	rc = func(dlh, func_arg, -1, NULL);
 out:
 	return rc;

--- a/src/mgmt/srv_drpc.c
+++ b/src/mgmt/srv_drpc.c
@@ -665,8 +665,9 @@ pool_change_target_state(char *id, size_t n_targetidx, uint32_t *targetidx,
 	if (n_targetidx > 0) {
 		for (i = 0; i < n_targetidx; ++i)
 			target_id_list.pti_ids[i].pti_id = targetidx[i];
-	} else
+	} else {
 		target_id_list.pti_ids[0].pti_id = -1;
+	}
 
 	rc = ds_mgmt_pool_target_update_state(uuid, rank, &target_id_list,
 					      state);

--- a/src/object/obj_internal.h
+++ b/src/object/obj_internal.h
@@ -545,6 +545,7 @@ struct ds_obj_exec_arg {
 	crt_rpc_t		*rpc;
 	struct obj_io_context	*ioc;
 	void			*args;
+	daos_unit_oid_t		 oid;
 	uint32_t		 flags;
 	uint32_t		 start; /* The start shard for EC obj. */
 };

--- a/src/object/srv_obj_migrate.c
+++ b/src/object/srv_obj_migrate.c
@@ -588,6 +588,9 @@ migrate_fetch_update_inline(struct migrate_one *mrone, daos_handle_t oh,
 		mrone_recx_daos2_vos(mrone, oca);
 
 	for (i = 0, start = 0; i < mrone->mo_iod_num; i++) {
+		if (mrone->mo_iods[i].iod_type == DAOS_IOD_SINGLE)
+			mrone->mo_iods[i].iod_recxs = NULL;
+
 		if (mrone->mo_iods[i].iod_size > 0) {
 			iod_cnt++;
 			continue;

--- a/src/placement/pl_map.c
+++ b/src/placement/pl_map.c
@@ -615,15 +615,16 @@ pl_select_leader(daos_obj_id_t oid, uint32_t shard_idx, uint32_t grp_size,
 	 *      The one with the lowest f_seq will be elected as the leader
 	 *      to avoid leader switch.
 	 */
-	rdg_idx = shard_idx / replicas;
-	start = rdg_idx * replicas;
-	replica_idx = (oid.lo + rdg_idx) % replicas;
+	rdg_idx = shard_idx / grp_size;
+	start = rdg_idx * grp_size;
+	replica_idx = (oid.lo + rdg_idx) % grp_size;
 	preferred = start + replica_idx;
 
-	for (i = 0, off = preferred, pos = -1; i < replicas;
-	     i++, replica_idx = (replica_idx + 1) % replicas,
+	for (i = 0, off = preferred, pos = -1; i < grp_size;
+	     i++, replica_idx = (replica_idx + 1) % grp_size,
 	     off = start + replica_idx) {
 		shard = pl_get_shard(data, off);
+
 		/*
 		 * shard->po_shard != off is necessary because during
 		 * reintegration we may have an extended layout and we don't

--- a/src/pool/srv_target.c
+++ b/src/pool/srv_target.c
@@ -533,6 +533,7 @@ retry:
 			DP_UUID(pool->sp_uuid));
 		D_GOTO(out, rc);
 	}
+	memset(buf, 0, STACK_HDL_BUF_SIZE);
 	d_iov_set(&iov, buf, STACK_HDL_BUF_SIZE);
 	rc = ds_pool_iv_conn_hdl_fetch(pool, NULL, &iov);
 	if (rc) {
@@ -1118,6 +1119,7 @@ update_child_map(void *data)
 	ds_rebuild_pool_map_update(pool);
 	child->spc_map_version = pool->sp_map_version;
 	ds_pool_child_put(child);
+	D_DEBUG(DB_TRACE, "child %p version %d\n", child, child->spc_map_version);
 	return 0;
 }
 

--- a/src/rebuild/scan.c
+++ b/src/rebuild/scan.c
@@ -605,6 +605,7 @@ rebuild_tgt_scan_handler(crt_rpc_t *rpc)
 {
 	struct rebuild_scan_in		*rsi;
 	struct rebuild_scan_out		*ro;
+	struct rebuild_pool_tls		*tls;
 	struct rebuild_tgt_pool_tracker	*rpt = NULL;
 	d_rank_list_t			*fail_list = NULL;
 	int				 rc;
@@ -659,6 +660,13 @@ rebuild_tgt_scan_handler(crt_rpc_t *rpc)
 		rpt->rt_leader_term = rsi->rsi_leader_term;
 
 		D_GOTO(out, rc = 0);
+	}
+
+	tls = rebuild_pool_tls_lookup(rsi->rsi_pool_uuid, rsi->rsi_rebuild_ver);
+	if(tls != NULL) {
+		D_WARN("the previous rebuild "DF_UUID"/%d is not cleanup yet\n",
+			DP_UUID(rsi->rsi_pool_uuid), rsi->rsi_rebuild_ver);
+		D_GOTO(out, rc = -DER_BUSY);
 	}
 
 	if (daos_fail_check(DAOS_REBUILD_TGT_START_FAIL))

--- a/src/vos/vos_dtx.c
+++ b/src/vos/vos_dtx.c
@@ -246,10 +246,11 @@ dtx_act_ent_update(struct btr_instance *tins, struct btr_record *rec,
 	struct vos_dtx_act_ent	*dae_old;
 
 	dae_old = umem_off2ptr(&tins->ti_umm, rec->rec_off);
-	D_ASSERTF(0, "NOT allow to update act DTX entry for "DF_DTI
-		  " from epoch "DF_X64" to "DF_X64"\n",
-		  DP_DTI(&DAE_XID(dae_old)),
-		  DAE_EPOCH(dae_old), DAE_EPOCH(dae_new));
+	if (DAE_EPOCH(dae_old) != DAE_EPOCH(dae_new))
+		D_ASSERTF(0, "NOT allow to update act DTX entry for "DF_DTI
+			  " from epoch "DF_X64" to "DF_X64"\n",
+			  DP_DTI(&DAE_XID(dae_old)),
+			  DAE_EPOCH(dae_old), DAE_EPOCH(dae_new));
 
 	return 0;
 }


### PR DESCRIPTION
- Fix some memory leak and initialization in pool map extend
- Retry rebuild scan if previous rebuild is still not done
- Improve pool map printing
- Fix extra comma in rank list printing
- Fix DTX moving shards between local targets
- Fix leader not being found for draining object
- Fix iod_size single setting.
- Fix client not refreshing pool map on stale fetch
- Fix placement using replicas instead of correct group size
- Fix DTX assert when two shards of the same object go to the same target