### PR TITLE
DAOS-5625 dtx: move dtx_rsvd_cnt to dth_sub_init

### DIFF
--- a/src/vos/vos_common.c
+++ b/src/vos/vos_common.c
@@ -157,6 +157,7 @@ vos_tx_publish(struct dtx_handle *dth, bool publish)
 		if (rc && publish)
 			return rc;
 	}
+	dth->dth_rsrvd_cnt = 0;
 
 	for (i = 0; i < dth->dth_deferred_cnt; i++) {
 		scm = dth->dth_deferred[i];
@@ -166,6 +167,7 @@ vos_tx_publish(struct dtx_handle *dth, bool publish)
 		if (rc && publish)
 			return rc;
 	}
+	dth->dth_deferred_cnt = 0;
 
 	/** Handle the deferred NVMe cancellations */
 	if (!publish)


### PR DESCRIPTION
Since this is per target, let's move this to
dth_sub_init, otherwise if it will cause issue
when do mulitple sub dtx on the local target.

Signed-off-by: Di Wang <di.wang@intel.com>