### PR TITLE
DAOS-5625 object: retry for pool map version mismatch

### DIFF
--- a/src/object/cli_obj.c
+++ b/src/object/cli_obj.c
@@ -4486,6 +4486,11 @@ shard_query_key_task(tse_task_t *task)
 	tse_task_stack_push_data(task, &args->kqa_dkey_hash,
 				 sizeof(args->kqa_dkey_hash));
 	api_args = args->kqa_api_args;
+	/* let's set the current pool map version in the req to
+	 * avoid ESTALE.
+	 */
+	args->kqa_auxi.obj_auxi->map_ver_reply =
+			args->kqa_auxi.obj_auxi->map_ver_req;
 	rc = dc_obj_shard_query_key(obj_shard, epoch, api_args->flags, obj,
 				    api_args->dkey, api_args->akey,
 				    api_args->recx, args->kqa_coh_uuid,

--- a/src/object/srv_obj.c
+++ b/src/object/srv_obj.c
@@ -1696,9 +1696,7 @@ do_obj_ioc_begin(uint32_t rpc_map_ver, uuid_t pool_uuid,
 		if (opc == DAOS_OBJ_RPC_CPD)
 			D_GOTO(out, rc = -DER_TX_RESTART);
 
-		if (obj_is_modification_opc(opc))
-			D_GOTO(out, rc = -DER_STALE);
-		/* It is harmless if fetch with old pool map version. */
+		D_GOTO(out, rc = -DER_STALE);
 	} else if (DAOS_FAIL_CHECK(DAOS_DTX_STALE_PM)) {
 		D_GOTO(out, rc = -DER_STALE);
 	}


### PR DESCRIPTION
After Online server addition, all shards might be
be repositioned, so let's return -DER_STALE to force
client to refresh the pool map and retry for all
operations.

Signed-off-by: Di Wang <di.wang@intel.com>