### PR TITLE
DAOS-5625 object: set iod_recxs to NULL for single value

### DIFF
--- a/src/object/srv_obj.c
+++ b/src/object/srv_obj.c
@@ -968,10 +968,17 @@ obj_singv_ec_rw_filter(daos_unit_oid_t *oid, daos_iod_t *iods, uint64_t *offs,
 	tgt_idx = oid->id_shard - start_shard;
 	for (i = 0; i < nr; i++) {
 		iod = &iods[i];
-		if (iod->iod_type != DAOS_IOD_SINGLE || (flags & ORF_EC) == 0)
+		if (iod->iod_type != DAOS_IOD_SINGLE)
 			continue;
+
+		/* Set iod_recx to NULL, since for EC object, the iod_recx
+		 * will be reused.
+		 */
+		iod->iod_recxs = NULL;
+		if ((flags & ORF_EC) == 0)
+			continue;
+
 		/* for singv EC */
-		D_ASSERT(iod->iod_recxs == NULL);
 		if (iod->iod_size == DAOS_REC_ANY) /* punch */
 			continue;
 		if (oca == NULL) {

--- a/src/object/srv_obj_migrate.c
+++ b/src/object/srv_obj_migrate.c
@@ -588,6 +588,9 @@ migrate_fetch_update_inline(struct migrate_one *mrone, daos_handle_t oh,
 		mrone_recx_daos2_vos(mrone, oca);
 
 	for (i = 0, start = 0; i < mrone->mo_iod_num; i++) {
+		if (mrone->mo_iods[i].iod_type == DAOS_IOD_SINGLE)
+			mrone->mo_iods[i].iod_recxs = NULL;
+
 		if (mrone->mo_iods[i].iod_size > 0) {
 			iod_cnt++;
 			continue;


### PR DESCRIPTION
Since iod_recxs might be reused inside VOS, let's make
sure iod_recxs to be NULL for non-EC object, otherwise
the iod_size might be wrong.

Signed-off-by: Di Wang <di.wang@intel.com>