### PR TITLE
DAOS-3114 vos: add read timestamps for list APIs

### DIFF
--- a/src/vos/README.md
+++ b/src/vos/README.md
@@ -495,6 +495,7 @@ and writes:
       - List objects under container [container level]
       - List dkeys under object [object level]
       - List akeys under dkey [dkey level]
+      - List recx under akey [akey level]
       - Query min/max dkeys under object [object level]
       - Query min/max akeys under dkey [dkey level]
       - Query min/max recx under akey [akey level]

--- a/src/vos/tests/vts_mvcc.c
+++ b/src/vos/tests/vts_mvcc.c
@@ -156,7 +156,8 @@ set_oid(int i, char *path, daos_unit_oid_t *oid)
 	 */
 	oid->id_pub.hi = 0;
 	oid->id_pub.lo = (i << 8) + path[L_O];
-	daos_obj_generate_id(&oid->id_pub, 0, 0, 0);
+	daos_obj_generate_id(&oid->id_pub,
+			     DAOS_OF_AKEY_UINT64 | DAOS_OF_DKEY_UINT64, 0, 0);
 	oid->id_shard = 0;
 	oid->id_pad_32 = 0;
 }
@@ -164,23 +165,21 @@ set_oid(int i, char *path, daos_unit_oid_t *oid)
 static void
 set_dkey(int i, char *path, daos_key_t *dkey)
 {
-	int rc;
+	uint64_t key = i * 2;
 
-	rc = snprintf(dkey->iov_buf, dkey->iov_buf_len, "%d-dkey-%c", i,
-		      path[L_D]);
-	D_ASSERT(rc < dkey->iov_buf_len);
-	dkey->iov_len = strlen(dkey->iov_buf) + 1;
+	D_ASSERT(dkey->iov_buf_len >= sizeof(key));
+	*(uint64_t *)dkey->iov_buf = key;
+	dkey->iov_len = sizeof(key);
 }
 
 static void
 set_akey(int i, char *path, daos_key_t *akey)
 {
-	int rc;
+	uint64_t key = (i * 2) + 1;
 
-	rc = snprintf(akey->iov_buf, akey->iov_buf_len, "%d-akey-%c", i,
-		      path[L_A]);
-	D_ASSERT(rc < akey->iov_buf_len);
-	akey->iov_len = strlen(akey->iov_buf) + 1;
+	D_ASSERT(akey->iov_buf_len >= sizeof(key));
+	*(uint64_t *)akey->iov_buf = key;
+	akey->iov_len = sizeof(key);
 }
 
 static void
@@ -272,9 +271,10 @@ fetch_with_flags(struct io_test_args *arg, struct tx_helper *txh, char *path,
 	char		 akey_buf[64];
 	daos_key_t	 akey = {akey_buf, sizeof(akey_buf), 0};
 	daos_iod_t	 iod;
-	char		 value_buf[64];
+	char		 value_buf[64] = {0};
 	d_iov_t		 value = {value_buf, sizeof(value_buf), 0};
 	d_sg_list_t	 sgl;
+	daos_recx_t	 recx;
 
 	set_oid(mvcc_arg->i, path, &oid);
 	set_dkey(mvcc_arg->i, path, &dkey);
@@ -282,9 +282,12 @@ fetch_with_flags(struct io_test_args *arg, struct tx_helper *txh, char *path,
 
 	memset(&iod, 0, sizeof(iod));
 	iod.iod_name = akey;
-	iod.iod_type = DAOS_IOD_SINGLE;
-	iod.iod_size = value.iov_len;
+	iod.iod_type = DAOS_IOD_ARRAY;
+	iod.iod_size = 1;
 	iod.iod_nr = 1;
+	iod.iod_recxs = &recx;
+	recx.rx_idx = 0;
+	recx.rx_nr = sizeof(value_buf);
 
 	memset(&sgl, 0, sizeof(sgl));
 	sgl.sg_nr = 1;
@@ -348,6 +351,7 @@ update_with_flags(struct io_test_args *arg, struct tx_helper *txh, char *path,
 	char		 value_buf[64];
 	d_iov_t		 value = {value_buf, sizeof(value_buf), 0};
 	d_sg_list_t	 sgl;
+	daos_recx_t	 recx;
 
 	set_oid(mvcc_arg->i, path, &oid);
 	set_dkey(mvcc_arg->i, path, &dkey);
@@ -356,9 +360,12 @@ update_with_flags(struct io_test_args *arg, struct tx_helper *txh, char *path,
 
 	memset(&iod, 0, sizeof(iod));
 	iod.iod_name = akey;
-	iod.iod_type = DAOS_IOD_SINGLE;
-	iod.iod_size = value.iov_len;
+	iod.iod_type = DAOS_IOD_ARRAY;
+	iod.iod_size = 1;
 	iod.iod_nr = 1;
+	iod.iod_recxs = &recx;
+	recx.rx_idx = 0;
+	recx.rx_nr = value.iov_len;
 
 	memset(&sgl, 0, sizeof(sgl));
 	sgl.sg_nr = 1;
@@ -488,10 +495,10 @@ puncha_with_flags(struct io_test_args *arg, struct tx_helper *txh, char *path,
 {
 	struct mvcc_arg	*mvcc_arg = arg->custom;
 	daos_unit_oid_t	 oid;
-	char		 dkey_buf[64];
-	daos_key_t	 dkey = {dkey_buf, sizeof(dkey_buf), 0};
-	char		 akey_buf[64];
-	daos_key_t	 akey = {akey_buf, sizeof(akey_buf), 0};
+	uint64_t	 dkey_val;
+	daos_key_t	 dkey = {&dkey_val, sizeof(dkey_val), 0};
+	uint64_t	 akey_val;
+	daos_key_t	 akey = {&akey_val, sizeof(akey_val), 0};
 
 	set_oid(mvcc_arg->i, path, &oid);
 	set_dkey(mvcc_arg->i, path, &dkey);
@@ -515,19 +522,123 @@ puncha_ane_f(struct io_test_args *arg, struct tx_helper *txh, char *path,
 	return puncha_with_flags(arg, txh, path, epoch, VOS_OF_COND_PUNCH);
 }
 
+static int
+simple_cb(daos_handle_t ih, vos_iter_entry_t *entry, vos_iter_type_t type,
+	  vos_iter_param_t *param, void *cb_arg, unsigned int *acts)
+{
+	/** At some point perhaps we want to verify something sane but for
+	 *  now this is just a noop
+	 */
+	return 0;
+}
+
+static int
+tx_list(vos_iter_param_t *param, vos_iter_type_t type, struct tx_helper *txh)
+{
+	struct dtx_handle	*dth;
+	struct vos_iter_anchors	 anchors = {0};
+	int			 rc;
+
+	dth = start_tx(param->ip_hdl, param->ip_oid, param->ip_epr.epr_hi, txh);
+
+	rc = vos_iterate(param, type, false, &anchors, simple_cb, NULL, NULL,
+			 dth);
+
+	stop_tx(param->ip_hdl, txh, rc == 0, false);
+
+	return rc;
+}
+
+static int
+listo(struct io_test_args *arg, struct tx_helper *txh, char *path,
+      daos_epoch_t epoch)
+{
+	struct mvcc_arg		*mvcc_arg = arg->custom;
+	vos_iter_param_t	 param = {0};
+
+	param.ip_hdl = arg->ctx.tc_co_hdl;
+	param.ip_epr.epr_hi = epoch;
+	/** We may need to figure out how to initialize the dtx without an oid
+	 *  but for now, just use the one we have
+	 */
+	set_oid(mvcc_arg->i, path, &param.ip_oid);
+
+	return tx_list(&param, VOS_ITER_OBJ, txh);
+}
+
+static int
+listd(struct io_test_args *arg, struct tx_helper *txh, char *path,
+      daos_epoch_t epoch)
+{
+	struct mvcc_arg		*mvcc_arg = arg->custom;
+	vos_iter_param_t	 param = {0};
+	uint64_t		 dkey_val;
+	daos_key_t		 dkey = {&dkey_val, sizeof(dkey_val), 0};
+
+	set_dkey(mvcc_arg->i, path, &dkey);
+	param.ip_hdl = arg->ctx.tc_co_hdl;
+	param.ip_epr.epr_hi = epoch;
+
+	set_oid(mvcc_arg->i, path, &param.ip_oid);
+
+	return tx_list(&param, VOS_ITER_DKEY, txh);
+}
+
+static int
+lista(struct io_test_args *arg, struct tx_helper *txh, char *path,
+      daos_epoch_t epoch)
+{
+	struct mvcc_arg		*mvcc_arg = arg->custom;
+	vos_iter_param_t	 param = {0};
+	uint64_t		 dkey_val;
+	daos_key_t		 dkey = {&dkey_val, sizeof(dkey_val), 0};
+
+	set_dkey(mvcc_arg->i, path, &dkey);
+	param.ip_hdl = arg->ctx.tc_co_hdl;
+	param.ip_epr.epr_hi = epoch;
+	param.ip_dkey = dkey;
+	set_oid(mvcc_arg->i, path, &param.ip_oid);
+
+	return tx_list(&param, VOS_ITER_AKEY, txh);
+}
+
+static int
+listr(struct io_test_args *arg, struct tx_helper *txh, char *path,
+      daos_epoch_t epoch)
+{
+	struct mvcc_arg		*mvcc_arg = arg->custom;
+	vos_iter_param_t	 param = {0};
+	uint64_t		 dkey_val;
+	daos_key_t		 dkey = {&dkey_val, sizeof(dkey_val), 0};
+	uint64_t		 akey_val;
+	daos_key_t		 akey = {&akey_val, sizeof(akey_val), 0};
+
+	set_dkey(mvcc_arg->i, path, &dkey);
+	set_akey(mvcc_arg->i, path, &akey);
+	param.ip_hdl = arg->ctx.tc_co_hdl;
+	param.ip_epr.epr_hi = epoch;
+	param.ip_dkey = dkey;
+	param.ip_akey = akey;
+	set_oid(mvcc_arg->i, path, &param.ip_oid);
+
+	return tx_list(&param, VOS_ITER_RECX, txh);
+}
+
+
 static struct op operations[] = {
 	/* {name,	type,	rlevel,	wlevel,	rtype,	wtype,	func} */
 
 	/* Reads */
-	{"fetch",       T_R,	L_A,	L_NIL,	R_R,	W_NIL,	fetch_f},
+	{"fetch",	T_R,	L_A,	L_NIL,	R_R,	W_NIL,	fetch_f},
 	{"fetch_dne",	T_R,	L_A,	L_NIL,	R_NE,	W_NIL,	fetch_dne_f},
 	{"fetch_ane",	T_R,	L_A,	L_NIL,	R_NE,	W_NIL,	fetch_ane_f},
-	{"listc",       T_R,	L_C,	L_NIL,	R_R,	W_NIL,	NULL},
-	{"listo",       T_R,	L_O,	L_NIL,	R_R,	W_NIL,	NULL},
-	{"listd",   	T_R,	L_D,	L_NIL,	R_R,	W_NIL,	NULL},
-	{"queryc",  	T_R,	L_C,	L_NIL,	R_R,	W_NIL,	NULL},
-	{"queryo",  	T_R,	L_O,	L_NIL,	R_R,	W_NIL,	NULL},
-	{"queryd",  	T_R,	L_D,	L_NIL,	R_R,	W_NIL,	NULL},
+	{"listo",	T_R,	L_O,	L_NIL,	R_R,	W_NIL,	listo},
+	{"listd",	T_R,	L_D,	L_NIL,	R_R,	W_NIL,	listd},
+	{"lista",	T_R,	L_A,	L_NIL,	R_R,	W_NIL,	lista},
+	{"listr",	T_R,	L_A,	L_NIL,	R_R,	W_NIL,	listr},
+	{"queryc",	T_R,	L_C,	L_NIL,	R_R,	W_NIL,	NULL},
+	{"queryo",	T_R,	L_O,	L_NIL,	R_R,	W_NIL,	NULL},
+	{"queryd",	T_R,	L_D,	L_NIL,	R_R,	W_NIL,	NULL},
 
 	/*
 	 * Readwrites

--- a/src/vos/tests/vts_mvcc.c
+++ b/src/vos/tests/vts_mvcc.c
@@ -163,9 +163,9 @@ set_oid(int i, char *path, daos_unit_oid_t *oid)
 }
 
 static void
-set_dkey(int i, char *path, daos_key_t *dkey)
+set_dkey(uint64_t i, char *path, daos_key_t *dkey)
 {
-	uint64_t key = i * 2;
+	uint64_t key = (i << 32) + path[L_D];
 
 	D_ASSERT(dkey->iov_buf_len >= sizeof(key));
 	*(uint64_t *)dkey->iov_buf = key;
@@ -173,9 +173,9 @@ set_dkey(int i, char *path, daos_key_t *dkey)
 }
 
 static void
-set_akey(int i, char *path, daos_key_t *akey)
+set_akey(uint64_t i, char *path, daos_key_t *akey)
 {
-	uint64_t key = (i * 2) + 1;
+	uint64_t key = (i << 32) + path[L_A];
 
 	D_ASSERT(akey->iov_buf_len >= sizeof(key));
 	*(uint64_t *)akey->iov_buf = key;
@@ -550,8 +550,8 @@ tx_list(vos_iter_param_t *param, vos_iter_type_t type, struct tx_helper *txh)
 }
 
 static int
-listo(struct io_test_args *arg, struct tx_helper *txh, char *path,
-      daos_epoch_t epoch)
+listo_f(struct io_test_args *arg, struct tx_helper *txh, char *path,
+	daos_epoch_t epoch)
 {
 	struct mvcc_arg		*mvcc_arg = arg->custom;
 	vos_iter_param_t	 param = {0};
@@ -567,8 +567,8 @@ listo(struct io_test_args *arg, struct tx_helper *txh, char *path,
 }
 
 static int
-listd(struct io_test_args *arg, struct tx_helper *txh, char *path,
-      daos_epoch_t epoch)
+listd_f(struct io_test_args *arg, struct tx_helper *txh, char *path,
+	daos_epoch_t epoch)
 {
 	struct mvcc_arg		*mvcc_arg = arg->custom;
 	vos_iter_param_t	 param = {0};
@@ -585,8 +585,8 @@ listd(struct io_test_args *arg, struct tx_helper *txh, char *path,
 }
 
 static int
-lista(struct io_test_args *arg, struct tx_helper *txh, char *path,
-      daos_epoch_t epoch)
+lista_f(struct io_test_args *arg, struct tx_helper *txh, char *path,
+	daos_epoch_t epoch)
 {
 	struct mvcc_arg		*mvcc_arg = arg->custom;
 	vos_iter_param_t	 param = {0};
@@ -603,8 +603,8 @@ lista(struct io_test_args *arg, struct tx_helper *txh, char *path,
 }
 
 static int
-listr(struct io_test_args *arg, struct tx_helper *txh, char *path,
-      daos_epoch_t epoch)
+listr_f(struct io_test_args *arg, struct tx_helper *txh, char *path,
+	daos_epoch_t epoch)
 {
 	struct mvcc_arg		*mvcc_arg = arg->custom;
 	vos_iter_param_t	 param = {0};
@@ -632,10 +632,10 @@ static struct op operations[] = {
 	{"fetch",	T_R,	L_A,	L_NIL,	R_R,	W_NIL,	fetch_f},
 	{"fetch_dne",	T_R,	L_A,	L_NIL,	R_NE,	W_NIL,	fetch_dne_f},
 	{"fetch_ane",	T_R,	L_A,	L_NIL,	R_NE,	W_NIL,	fetch_ane_f},
-	{"listo",	T_R,	L_O,	L_NIL,	R_R,	W_NIL,	listo},
-	{"listd",	T_R,	L_D,	L_NIL,	R_R,	W_NIL,	listd},
-	{"lista",	T_R,	L_A,	L_NIL,	R_R,	W_NIL,	lista},
-	{"listr",	T_R,	L_A,	L_NIL,	R_R,	W_NIL,	listr},
+	{"listo",	T_R,	L_O,	L_NIL,	R_R,	W_NIL,	listo_f},
+	{"listd",	T_R,	L_D,	L_NIL,	R_R,	W_NIL,	listd_f},
+	{"lista",	T_R,	L_A,	L_NIL,	R_R,	W_NIL,	lista_f},
+	{"listr",	T_R,	L_A,	L_NIL,	R_R,	W_NIL,	listr_f},
 	{"queryc",	T_R,	L_C,	L_NIL,	R_R,	W_NIL,	NULL},
 	{"queryo",	T_R,	L_O,	L_NIL,	R_R,	W_NIL,	NULL},
 	{"queryd",	T_R,	L_D,	L_NIL,	R_R,	W_NIL,	NULL},

--- a/src/vos/vos_container.c
+++ b/src/vos/vos_container.c
@@ -686,7 +686,7 @@ cont_iter_fini(struct vos_iterator *iter)
 
 int
 cont_iter_prep(vos_iter_type_t type, vos_iter_param_t *param,
-	       struct vos_iterator **iter_pp)
+	       struct vos_iterator **iter_pp, struct vos_ts_set *ts_set)
 {
 	struct cont_iterator	*co_iter = NULL;
 	struct vos_pool		*vpool = NULL;

--- a/src/vos/vos_dtx_iter.c
+++ b/src/vos/vos_dtx_iter.c
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2019 Intel Corporation.
+ * (C) Copyright 2019-2020 Intel Corporation.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -70,7 +70,7 @@ dtx_iter_fini(struct vos_iterator *iter)
 
 static int
 dtx_iter_prep(vos_iter_type_t type, vos_iter_param_t *param,
-	      struct vos_iterator **iter_pp)
+	      struct vos_iterator **iter_pp, struct vos_ts_set *ts_set)
 {
 	struct vos_dtx_iter	*oiter;
 	struct vos_container	*cont;

--- a/src/vos/vos_internal.h
+++ b/src/vos/vos_internal.h
@@ -783,6 +783,7 @@ struct vos_iter_ops;
 struct vos_iterator {
 	struct vos_iter_ops	*it_ops;
 	struct vos_iterator	*it_parent; /* parent iterator */
+	struct vos_ts_set	*it_ts_set;
 	vos_iter_type_t		 it_type;
 	enum vos_iter_state	 it_state;
 	uint32_t		 it_ref_cnt;
@@ -826,7 +827,8 @@ struct vos_iter_info {
 struct vos_iter_ops {
 	/** prepare a new iterator with the specified type and parameters */
 	int	(*iop_prepare)(vos_iter_type_t type, vos_iter_param_t *param,
-			       struct vos_iterator **iter_pp);
+			       struct vos_iterator **iter_pp,
+			       struct vos_ts_set *ts_set);
 	/** fetch the record that the cursor points to and open the subtree
 	 *  corresponding to specified type, return info about the iterator
 	 *  and nested object.   If NULL, it isn't supported for the parent

--- a/src/vos/vos_iterator.c
+++ b/src/vos/vos_iterator.c
@@ -200,9 +200,10 @@ vos_iter_prepare(vos_iter_type_t type, vos_iter_param_t *param,
 		D_DEBUG(DB_TRACE, "Preparing nested iterator of type %s\n",
 			dict->id_name);
 		/** Nested operations are only used internally so there
-		 * shouldn't be any active transaction involved.
+		 * shouldn't be any active transaction involved.  However,
+		 * the upper layer is still passing in a valid handle in
+		 * some cases.
 		 */
-		D_ASSERT(!dtx_is_valid_handle(dth));
 		rc = nested_prepare(type, dict, param, ih);
 
 		goto out;
@@ -224,7 +225,7 @@ vos_iter_prepare(vos_iter_type_t type, vos_iter_param_t *param,
 	default:
 		rlevel = 0;
 		/** There should not be any cases where a DTX is active outside
-		 *  of the four listed above
+		 *  of the four listed above.
 		 */
 		D_ASSERT(!dtx_is_valid_handle(dth));
 		break;

--- a/src/vos/vos_iterator.c
+++ b/src/vos/vos_iterator.c
@@ -224,7 +224,8 @@ vos_iter_prepare(vos_iter_type_t type, vos_iter_param_t *param,
 	default:
 		rlevel = 0;
 		/** There should not be any cases where a DTX is active outside
-		 * of the four listed above */
+		 *  of the four listed above
+		 */
 		D_ASSERT(!dtx_is_valid_handle(dth));
 		break;
 	}

--- a/src/vos/vos_iterator.c
+++ b/src/vos/vos_iterator.c
@@ -167,10 +167,11 @@ int
 vos_iter_prepare(vos_iter_type_t type, vos_iter_param_t *param,
 		 daos_handle_t *ih, struct dtx_handle *dth)
 {
-	struct dtx_handle	*saved = vos_dth_get();
 	struct vos_iter_dict	*dict;
 	struct vos_iterator	*iter;
+	struct vos_ts_set	*ts_set = NULL;
 	int			 rc;
+	int			 rlevel;
 
 	if (ih == NULL) {
 		D_ERROR("Argument 'ih' is invalid to vos_iter_param\n");
@@ -195,19 +196,48 @@ vos_iter_prepare(vos_iter_type_t type, vos_iter_param_t *param,
 		return -DER_NOSYS;
 	}
 
-	vos_dth_set(dth);
-
 	if (!daos_handle_is_inval(param->ip_ih)) {
 		D_DEBUG(DB_TRACE, "Preparing nested iterator of type %s\n",
 			dict->id_name);
+		/** Nested operations are only used internally so there
+		 * shouldn't be any active transaction involved.
+		 */
+		D_ASSERT(!dtx_is_valid_handle(dth));
 		rc = nested_prepare(type, dict, param, ih);
 
 		goto out;
 	}
 
+	switch (type) {
+	case VOS_ITER_OBJ:
+		rlevel = VOS_TS_READ_CONT;
+		break;
+	case VOS_ITER_DKEY:
+		rlevel = VOS_TS_READ_OBJ;
+		break;
+	case VOS_ITER_AKEY:
+		rlevel = VOS_TS_READ_DKEY;
+		break;
+	case VOS_ITER_RECX:
+		rlevel = VOS_TS_READ_AKEY;
+		break;
+	default:
+		rlevel = 0;
+		/** There should not be any cases where a DTX is active outside
+		 * of the four listed above */
+		D_ASSERT(!dtx_is_valid_handle(dth));
+		break;
+	}
+	rc = vos_ts_set_allocate(&ts_set, 0, rlevel, 1 /* max akeys */,
+				 dtx_is_valid_handle(dth) ?
+				 &dth->dth_xid : NULL);
+	if (rc != 0)
+		goto out;
+
+
 	D_DEBUG(DB_TRACE, "Preparing standalone iterator of type %s\n",
 		dict->id_name);
-	rc = dict->id_ops->iop_prepare(type, param, &iter);
+	rc = dict->id_ops->iop_prepare(type, param, &iter, ts_set);
 	if (rc != 0) {
 		if (rc == -DER_NONEXIST)
 			D_DEBUG(DB_TRACE, "No %s to iterate: "DF_RC"\n",
@@ -226,11 +256,14 @@ vos_iter_prepare(vos_iter_type_t type, vos_iter_param_t *param,
 	iter->it_ref_cnt	= 1;
 	iter->it_parent		= NULL;
 	iter->it_from_parent	= 0;
+	iter->it_ts_set		= ts_set;
 
 	*ih = vos_iter2hdl(iter);
-
 out:
-	vos_dth_set(saved);
+	if (rc == -DER_NONEXIST && dtx_is_valid_handle(dth))
+		vos_ts_set_update(ts_set, dth->dth_epoch);
+	if (rc != 0)
+		vos_ts_set_free(ts_set);
 	return rc;
 }
 
@@ -245,8 +278,21 @@ iter_decref(struct vos_iterator *iter)
 	if (iter->it_ref_cnt)
 		return 0;
 
+	vos_ts_set_free(iter->it_ts_set);
 	D_ASSERT(iter->it_ops != NULL);
 	return iter->it_ops->iop_finish(iter);
+}
+
+void
+vos_iter_ts_set_update(daos_handle_t ih, daos_epoch_t read_time)
+{
+	struct vos_iterator	*iter;
+
+	if (daos_handle_is_inval(ih))
+		return;
+
+	iter = vos_hdl2iter(ih);
+	vos_ts_set_update(iter->it_ts_set, read_time);
 }
 
 int
@@ -545,8 +591,8 @@ vos_iterate(vos_iter_param_t *param, vos_iter_type_t type, bool recursive,
 	    vos_iter_cb_t post_cb, void *arg, struct dtx_handle *dth)
 {
 	daos_anchor_t		*anchor, *probe_anchor = NULL;
-	struct dtx_handle	*saved = vos_dth_get();
 	vos_iter_entry_t	iter_ent = {0};
+	daos_epoch_t		read_time = 0;
 	daos_handle_t		ih;
 	unsigned int		acts = 0;
 	bool			skipped;
@@ -558,8 +604,6 @@ vos_iterate(vos_iter_param_t *param, vos_iter_type_t type, bool recursive,
 
 	anchor = type2anchor(type, anchors);
 
-	vos_dth_set(dth);
-
 	rc = vos_iter_prepare(type, param, &ih, dth);
 	if (rc != 0) {
 		if (rc == -DER_NONEXIST) {
@@ -570,11 +614,9 @@ vos_iterate(vos_iter_param_t *param, vos_iter_type_t type, bool recursive,
 				""DF_RC"\n", type, DP_RC(rc));
 		}
 
-		vos_dth_set(saved);
-
 		return rc;
 	}
-
+	read_time = dtx_is_valid_handle(dth) ? dth->dth_epoch : 0 /* unused */;
 probe:
 	if (!daos_anchor_is_zero(anchor))
 		probe_anchor = anchor;
@@ -680,10 +722,12 @@ probe:
 		rc = 0;
 	}
 out:
+	if (rc >= 0)
+		vos_iter_ts_set_update(ih, read_time);
+
 	VOS_TX_LOG_FAIL(rc, "abort iteration type:%d, "DF_RC"\n", type,
 			DP_RC(rc));
 
 	vos_iter_finish(ih);
-	vos_dth_set(saved);
 	return rc;
 }

--- a/src/vos/vos_obj.c
+++ b/src/vos/vos_obj.c
@@ -342,7 +342,7 @@ static int
 key_ilog_prepare(struct vos_obj_iter *oiter, daos_handle_t toh, int key_type,
 		 daos_key_t *key, int flags, daos_handle_t *sub_toh,
 		 daos_epoch_range_t *epr, struct vos_punch_record *punched,
-		 struct vos_ilog_info *info)
+		 struct vos_ilog_info *info, struct vos_ts_set *ts_set)
 {
 	struct vos_krec_df	*krec = NULL;
 	struct vos_object	*obj = oiter->it_obj;
@@ -350,7 +350,7 @@ key_ilog_prepare(struct vos_obj_iter *oiter, daos_handle_t toh, int key_type,
 
 	rc = key_tree_prepare(obj, toh, key_type, key, flags,
 			      vos_iter_intent(&oiter->it_iter), &krec,
-			      sub_toh, NULL);
+			      sub_toh, ts_set);
 	if (rc == -DER_NONEXIST)
 		return rc;
 
@@ -557,7 +557,7 @@ key_iter_match(struct vos_obj_iter *oiter, vos_iter_entry_t *ent)
 
 	vos_ilog_fetch_init(&info);
 	rc = key_ilog_prepare(oiter, toh, VOS_BTR_AKEY, &oiter->it_akey, 0,
-			      NULL, NULL, NULL, &info);
+			      NULL, NULL, NULL, &info, NULL);
 	if (rc == 0)
 		rc = IT_OPC_NOOP;
 
@@ -662,14 +662,15 @@ dkey_iter_prepare(struct vos_obj_iter *oiter, daos_key_t *akey)
  * Iterator for the akey tree.
  */
 static int
-akey_iter_prepare(struct vos_obj_iter *oiter, daos_key_t *dkey)
+akey_iter_prepare(struct vos_obj_iter *oiter, daos_key_t *dkey,
+		  struct vos_ts_set *ts_set)
 {
 	daos_handle_t		 toh;
 	int			 rc;
 
 	rc = key_ilog_prepare(oiter, oiter->it_obj->obj_toh, VOS_BTR_DKEY, dkey,
 			      0, &toh, &oiter->it_epr, &oiter->it_punched,
-			      &oiter->it_ilog_info);
+			      &oiter->it_ilog_info, ts_set);
 	if (rc != 0)
 		goto failed;
 
@@ -709,13 +710,13 @@ singv_iter_prepare(struct vos_obj_iter *oiter, daos_key_t *dkey,
 
 	rc = key_ilog_prepare(oiter, obj->obj_toh, VOS_BTR_DKEY, dkey, 0,
 			      &ak_toh, &oiter->it_epr, &oiter->it_punched,
-			      &oiter->it_ilog_info);
+			      &oiter->it_ilog_info, NULL);
 	if (rc != 0)
 		return rc;
 
 	rc = key_ilog_prepare(oiter, ak_toh, VOS_BTR_AKEY, akey, 0, &sv_toh,
 			      &oiter->it_epr, &oiter->it_punched,
-			      &oiter->it_ilog_info);
+			      &oiter->it_ilog_info, NULL);
 	if (rc != 0)
 		D_GOTO(failed_1, rc);
 
@@ -980,7 +981,7 @@ done:
  */
 static int
 recx_iter_prepare(struct vos_obj_iter *oiter, daos_key_t *dkey,
-		  daos_key_t *akey)
+		  daos_key_t *akey, struct vos_ts_set *ts_set)
 {
 	struct vos_object	*obj = oiter->it_obj;
 	struct evt_filter	 filter = {0};
@@ -991,13 +992,13 @@ recx_iter_prepare(struct vos_obj_iter *oiter, daos_key_t *dkey,
 
 	rc = key_ilog_prepare(oiter, obj->obj_toh, VOS_BTR_DKEY, dkey, 0,
 			      &ak_toh, &oiter->it_epr, &oiter->it_punched,
-			      &oiter->it_ilog_info);
+			      &oiter->it_ilog_info, ts_set);
 	if (rc != 0)
 		return rc;
 
 	rc = key_ilog_prepare(oiter, ak_toh, VOS_BTR_AKEY, akey, SUBTR_EVT,
 			      &rx_toh, &oiter->it_epr, &oiter->it_punched,
-			      &oiter->it_ilog_info);
+			      &oiter->it_ilog_info, ts_set);
 	if (rc != 0)
 		D_GOTO(failed, rc);
 
@@ -1110,10 +1111,12 @@ static int vos_obj_iter_fini(struct vos_iterator *vitr);
 /** prepare an object content iterator */
 int
 vos_obj_iter_prep(vos_iter_type_t type, vos_iter_param_t *param,
-		  struct vos_iterator **iter_pp)
+		  struct vos_iterator **iter_pp,
+		  struct vos_ts_set *ts_set)
 {
-	struct vos_obj_iter *oiter;
-	int		     rc;
+	struct vos_obj_iter	*oiter;
+	struct vos_container	*cont;
+	int			 rc;
 
 	D_ALLOC_PTR(oiter);
 	if (oiter == NULL)
@@ -1129,15 +1132,19 @@ vos_obj_iter_prep(vos_iter_type_t type, vos_iter_param_t *param,
 	if (param->ip_flags & VOS_IT_FOR_REBUILD)
 		oiter->it_iter.it_for_rebuild = 1;
 
+	cont = vos_hdl2cont(param->ip_hdl);
+	rc = vos_ts_set_add(ts_set, cont->vc_ts_idx, NULL, 0);
+	D_ASSERT(rc == 0);
+
 	/* XXX the condition epoch ranges could cover multiple versions of
 	 * the object/key if it's punched more than once. However, rebuild
 	 * system should guarantee this will never happen.
 	 */
-	rc = vos_obj_hold(vos_obj_cache_current(), vos_hdl2cont(param->ip_hdl),
+	rc = vos_obj_hold(vos_obj_cache_current(), cont,
 			  param->ip_oid, &oiter->it_epr, true,
 			  vos_iter_intent(&oiter->it_iter),
 			  (oiter->it_flags & VOS_IT_PUNCHED) == 0,
-			  &oiter->it_obj, NULL);
+			  &oiter->it_obj, ts_set);
 
 	if (rc != 0) {
 		VOS_TX_LOG_FAIL(rc, "Could not hold object to iterate: "DF_RC
@@ -1162,7 +1169,7 @@ vos_obj_iter_prep(vos_iter_type_t type, vos_iter_param_t *param,
 		break;
 
 	case VOS_ITER_AKEY:
-		rc = akey_iter_prepare(oiter, &param->ip_dkey);
+		rc = akey_iter_prepare(oiter, &param->ip_dkey, ts_set);
 		break;
 
 	case VOS_ITER_SINGLE:
@@ -1171,7 +1178,8 @@ vos_obj_iter_prep(vos_iter_type_t type, vos_iter_param_t *param,
 		break;
 
 	case VOS_ITER_RECX:
-		rc = recx_iter_prepare(oiter, &param->ip_dkey, &param->ip_akey);
+		rc = recx_iter_prepare(oiter, &param->ip_dkey, &param->ip_akey,
+				       ts_set);
 		break;
 	}
 

--- a/src/vos/vos_obj_index.c
+++ b/src/vos/vos_obj_index.c
@@ -444,7 +444,7 @@ oi_iter_nested_tree_fetch(struct vos_iterator *iter, vos_iter_type_t type,
 
 static int
 oi_iter_prep(vos_iter_type_t type, vos_iter_param_t *param,
-	   struct vos_iterator **iter_pp)
+	   struct vos_iterator **iter_pp, struct vos_ts_set *ts_set)
 {
 	struct vos_oi_iter	*oiter = NULL;
 	struct vos_container	*cont = NULL;
@@ -463,6 +463,9 @@ oi_iter_prep(vos_iter_type_t type, vos_iter_param_t *param,
 	D_ALLOC_PTR(oiter);
 	if (oiter == NULL)
 		return -DER_NOMEM;
+
+	rc = vos_ts_set_add(ts_set, cont->vc_ts_idx, NULL, 0);
+	D_ASSERT(rc == 0);
 
 	vos_ilog_fetch_init(&oiter->oit_ilog_info);
 	oiter->oit_iter.it_type = type;

--- a/src/vos/vos_obj_index.c
+++ b/src/vos/vos_obj_index.c
@@ -444,7 +444,7 @@ oi_iter_nested_tree_fetch(struct vos_iterator *iter, vos_iter_type_t type,
 
 static int
 oi_iter_prep(vos_iter_type_t type, vos_iter_param_t *param,
-	   struct vos_iterator **iter_pp, struct vos_ts_set *ts_set)
+	     struct vos_iterator **iter_pp, struct vos_ts_set *ts_set)
 {
 	struct vos_oi_iter	*oiter = NULL;
 	struct vos_container	*cont = NULL;


### PR DESCRIPTION
Update the read timestamps for list APIs when called in
a distributed transaction.   This is simplified by the
assumption that the nested iterator is never used
for user facing list API.

Signed-off-by: Jeff Olivier <jeffrey.v.olivier@intel.com>