### PR TITLE
DAOS-4910 tests: control invalid update during daos_racer

### DIFF
--- a/src/tests/daos_racer.c
+++ b/src/tests/daos_racer.c
@@ -134,23 +134,37 @@ pack_dkey_iod_sgl(char *dkey, d_iov_t *dkey_iov, char akeys[][MAX_KEY_SIZE],
 
 	for (i = 0; i < iod_nr; i++) {
 		unsigned size;
-		unsigned val = rand() % 8;
+		unsigned base = rand();
+		unsigned val = base % 8;
 
-		sprintf(akeys[i], "%d", rand() % max_akey_per_dkey);
+		sprintf(akeys[i], "%d", base % max_akey_per_dkey);
 		d_iov_set(&iods[i].iod_name, akeys[i], strlen(akeys[i]));
 
 		iods[i].iod_nr = 1;
 		if (val % 2 == 1) {
+			if (rand() % 10)
+				iods[i].iod_type = DAOS_IOD_ARRAY;
+			else
+				iods[i].iod_type = DAOS_IOD_SINGLE;
+		} else {
+			if (rand() % 10) {
+				iods[i].iod_type = DAOS_IOD_SINGLE;
+			} else {
+				iods[i].iod_type = DAOS_IOD_ARRAY;
+				if (val == 0)
+					val = 1;
+			}
+		}
+
+		if (iods[i].iod_type == DAOS_IOD_ARRAY) {
 			recxs[i].rx_idx = rand() % (MAX_REC_SIZE / val);
 			recxs[i].rx_nr = rand() % (MAX_REC_SIZE / val);
 			iods[i].iod_recxs = &recxs[i];
 			iods[i].iod_size = 1;
 			size = recxs[i].rx_nr;
-			iods[i].iod_type = DAOS_IOD_ARRAY;
 		} else {
 			iods[i].iod_size = rand() % (MAX_REC_SIZE / (val + 1));
 			size = iods[i].iod_size;
-			iods[i].iod_type = DAOS_IOD_SINGLE;
 		}
 
 		sgls[i].sg_nr = 1;

--- a/src/tests/ftest/io/daos_racer.yaml
+++ b/src/tests/ftest/io/daos_racer.yaml
@@ -6,16 +6,18 @@ hosts:
     - server-D
     - server-E
     - server-F
+    - server-G
   test_clients:
-    - client-G
-timeout: 1800
+    - client-H
+timeout: 10800
 server_config:
     name: daos_server
     servers:
+        log_mask: "ERR"
         bdev_class: nvme
         bdev_list: ["aaaa:aa:aa.a","bbbb:bb:bb.b"]
         scm_class: dcpm
         scm_list: ["/dev/pmem0"]
 daos_racer:
-  runtime: 600
-  clush_timeout: 1500
+  runtime: 7200
+  clush_timeout: 10080

--- a/src/tests/ftest/util/daos_racer_utils.py
+++ b/src/tests/ftest/util/daos_racer_utils.py
@@ -93,6 +93,7 @@ class DaosRacerCommand(ExecutableCommand):
         env["OMPI_MCA_btl"] = "tcp,self"
         env["OMPI_MCA_oob"] = "tcp"
         env["OMPI_MCA_pml"] = "ob1"
+        env["D_LOG_MASK"] = "ERR"
         return env
 
     def set_environment(self, env):


### PR DESCRIPTION
Too many invalid updates during long time daos_racer test may
generate a lot of noisy error message on server as to exhaust
server side log space. This patch controls the invalid update
percentage, about 10%.

Test-tag-hw-large: pr,hw,large daosracer

Signed-off-by: Fan Yong <fan.yong@intel.com>