### PR TITLE
DAOS-5627 test: Fix pool_destroy tests

### DIFF
--- a/src/pool/srv_pool.c
+++ b/src/pool/srv_pool.c
@@ -4528,8 +4528,9 @@ ds_pool_svc_check_evict(uuid_t pool_uuid, d_rank_list_t *ranks, uint32_t force)
 	struct pool_evict_in	*in;
 	struct pool_evict_out	*out;
 
-	D_DEBUG(DB_MGMT, DF_UUID": Destroy pool, inspect/evict handles\n",
-		DP_UUID(pool_uuid));
+	D_DEBUG(DB_MGMT,
+		DF_UUID": Destroy pool (force: %d), inspect/evict handles\n",
+		DP_UUID(pool_uuid), force);
 
 	rc = rsvc_client_init(&client, ranks);
 	if (rc != 0)

--- a/src/tests/ftest/pool/destroy_tests.yaml
+++ b/src/tests/ftest/pool/destroy_tests.yaml
@@ -15,6 +15,7 @@ pool:
   mode: 146
   name: daos_server
   scm_size: 1073741824
+  control_method: dmg
 container:
   object_qty: 1
   record_qty: 1

--- a/src/tests/ftest/util/test_utils_pool.py
+++ b/src/tests/ftest/util/test_utils_pool.py
@@ -207,7 +207,7 @@ class TestPool(TestDaosApiBase):
 
     @fail_on(CommandFailure)
     @fail_on(DaosApiError)
-    def destroy(self, force=1):
+    def destroy(self, force=1, disconnect=1):
         """Destroy the pool with either API or dmg.
 
         It uses control_method member previously set, so if you want to use the
@@ -215,6 +215,7 @@ class TestPool(TestDaosApiBase):
 
         Args:
             force (int, optional): force flag. Defaults to 1.
+            disconnect (int, optional): disconnect flag. Defaults to 1.
 
         Returns:
             bool: True if the pool has been destroyed; False if the pool is not
@@ -223,7 +224,8 @@ class TestPool(TestDaosApiBase):
         """
         status = False
         if self.pool:
-            self.disconnect()
+            if disconnect:
+                self.disconnect()
             if self.pool.attached:
                 self.log.info("Destroying pool %s", self.uuid)
 


### PR DESCRIPTION
These tests weren't using control_method: dmg for pool
management. They also needed to be updated to stop using
the C API for destroys without disconnect.