### PR TITLE
DAOS-4910 tests: control invalid update during daos_racer

### DIFF
--- a/src/dtx/dtx_rpc.c
+++ b/src/dtx/dtx_rpc.c
@@ -231,7 +231,9 @@ dtx_req_list_cb(void **args)
 		}
 
 		drr = args[0];
-		D_CDEBUG(dra->dra_result < 0, DLOG_ERR, DB_TRACE,
+		D_CDEBUG(dra->dra_result < 0 &&
+			 dra->dra_result != -DER_NONEXIST,
+			 DLOG_ERR, DB_TRACE,
 			 "DTX req for opc %x ("DF_DTI") %s, count %d: %d.\n",
 			 dra->dra_opc, DP_DTI(drr->drr_dti),
 			 dra->dra_result < 0 ? "failed" : "succeed",

--- a/src/tests/ftest/io/daos_racer.yaml
+++ b/src/tests/ftest/io/daos_racer.yaml
@@ -6,16 +6,18 @@ hosts:
     - server-D
     - server-E
     - server-F
+    - server-G
   test_clients:
-    - client-G
-timeout: 1800
+    - client-H
+timeout: 10800
 server_config:
     name: daos_server
     servers:
+        log_mask: "ERR"
         bdev_class: nvme
         bdev_list: ["aaaa:aa:aa.a","bbbb:bb:bb.b"]
         scm_class: dcpm
         scm_list: ["/dev/pmem0"]
 daos_racer:
-  runtime: 600
-  clush_timeout: 1500
+  runtime: 7200
+  clush_timeout: 10080

--- a/src/tests/ftest/util/daos_racer_utils.py
+++ b/src/tests/ftest/util/daos_racer_utils.py
@@ -93,6 +93,7 @@ class DaosRacerCommand(ExecutableCommand):
         env["OMPI_MCA_btl"] = "tcp,self"
         env["OMPI_MCA_oob"] = "tcp"
         env["OMPI_MCA_pml"] = "ob1"
+        env["D_LOG_MASK"] = "ERR"
         return env
 
     def set_environment(self, env):


### PR DESCRIPTION
Too many invalid updates during long time daos_racer test may
generate a lot of noisy error message on server as to exhaust
server side log space. This patch controls the invalid update
percentage, about 5%.

Test-tag-hw-large: pr,hw,large daosracer

Signed-off-by: Fan Yong <fan.yong@intel.com>