### PR TITLE
DAOS-5628 scheduler: allow null crt_ctx in sched_init to use internal global ctx

### DIFF
--- a/src/client/api/task.c
+++ b/src/client/api/task.c
@@ -265,8 +265,10 @@ daos_progress(tse_sched_t *sched, int64_t timeout, bool *is_empty)
 	args.sched = sched;
 	args.is_empty = is_empty;
 
-	rc = crt_progress_cond((crt_context_t *)sched->ds_udata, timeout,
-			       sched_progress_cb, &args);
+	rc = crt_progress_cond(sched->ds_udata ?
+			       (crt_context_t *)sched->ds_udata :
+			       daos_get_crt_ctx(), timeout, sched_progress_cb,
+			       &args);
 	if (rc != 0 && rc != -DER_TIMEDOUT)
 		D_ERROR("crt progress failed with "DF_RC"\n", DP_RC(rc));
 
@@ -279,6 +281,7 @@ daos_task2ctx(tse_task_t *task)
 {
 	tse_sched_t *sched = tse_task2sched(task);
 
-	D_ASSERT(sched->ds_udata != NULL);
+	if (sched->ds_udata == NULL)
+		return daos_get_crt_ctx();
 	return (crt_context_t *)sched->ds_udata;
 }


### PR DESCRIPTION
Allow users to pass a NULL context in tse_sched_create() in which the
scheduler will use the internal global cart context created by DAOS.

Signed-off-by: Mohamad Chaarawi <mohamad.chaarawi@intel.com>