### PR TITLE
DAOS-3714: test  Delete entry from container ACL

### DIFF
--- a/src/tests/ftest/security/cont_delete_acl.py
+++ b/src/tests/ftest/security/cont_delete_acl.py
@@ -59,7 +59,7 @@ class DeleteContainerACLTest(ContSecurityTestBase):
                 exit status
 
         Returns:
-            list: list of test erros encountered.
+            list: list of test errors encountered.
         """
         test_errs = []
         if results.exit_status == 0:

--- a/src/tests/ftest/security/cont_delete_acl.py
+++ b/src/tests/ftest/security/cont_delete_acl.py
@@ -1,0 +1,147 @@
+#!/usr/bin/python
+"""
+  (C) Copyright 2020 Intel Corporation.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+  GOVERNMENT LICENSE RIGHTS-OPEN SOURCE SOFTWARE
+  The Government's rights to use, modify, reproduce, release, perform, display,
+  or disclose this software are subject to the terms of the Apache License as
+  provided in Contract No. 8F-30005.
+  Any reproduction of computer software, computer software documentation, or
+  portions thereof marked with this legend must also reproduce the markings.
+"""
+
+from command_utils import CommandFailure
+from server_utils import ServerFailed
+from apricot import TestWithServers
+from avocado.utils import process
+from avocado import fail_on
+
+
+class DeleteContainerACLTest(ContSecurityTestBase):
+    # pylint: disable=too-many-ancestors
+    """Test Class Description:
+
+    Test to verify ACL entry deletion.
+
+    :avocado: recursive
+    """
+    def setUp(self):
+        """Set up each test case."""
+        super(DeleteContainerACLTest, self).setUp()
+        self.prepare_pool()
+        self.add_container(self.pool)
+
+        # Get list of ACL entries
+        cont_acl = self.get_container_acl_list(
+            self.pool.uuid, self.pool.svc_ranks[0], self.container.uuid)
+
+        # Get principals
+        self.principals_table = {}
+        for entry in cont_acl:
+            self.principals_table[entry.split(":")[2]] = entry
+
+
+    @fail_on(CommandFailure)
+    def test_acl_delete_invalid_inputs(self):
+        """
+        JIRA ID: DAOS-3714
+
+        Test Description: Test that container delete command performs as
+            expected with invalid inputs.
+
+        :avocado: tags=all,pr,security,container_acl,cont_delete_acl
+        """
+        # Get list of invalid ACL principal values
+        invalid_principals = self.get.params("invalid_principals", "/run/*")
+        daos_cmd = self.get_daos_command()
+
+        # Check for failure on invalid inputs.
+        for principal in invalid_principals:
+            try:
+                daos_cmd.container_delete_acl(
+                    self.pool.uuid,
+                    self.pool.svc_ranks[0],
+                    self.container.uuid,
+                    principal)
+            except process.CmdError as err:
+                if "-1003" in err.result.stderr:
+                    self.log.info(
+                        "Found expected error %s with invalid principal %s",
+                        err.result.stderr,
+                        principal)
+                else:
+                    self.fail("delete-acl seems to have failed with \
+                        unexpected error: {}".format(err))
+        self.fail("container delete-acl command expected to fail.")
+
+    @fail_on(CommandFailure)
+    def test_delete_valid_acl(self):
+        """
+        JIRA ID: DAOS-3714
+
+        Test Description: Test that container delete command successfully
+            removes principal in ACL.
+
+        :avocado: tags=all,pr,security,container_acl,cont_delete_acl
+        """
+        daos_cmd = self.get_daos_command()
+        for principal in self.principals_table:
+            daos_cmd.container_delete_acl(
+                self.pool.uuid,
+                self.pool.svc_ranks[0],
+                self.container.uuid,
+                principal)
+            if self.principals_table[principal] in daos_cmd.result.stdout:
+                self.fail(
+                    "Found acl that was to be deleted in output: {}".format(
+                        daos_cmd.result.stdout))
+
+    @fail_on(CommandFailure)
+    def test_no_user_permissions(self):
+        """
+        JIRA ID: DAOS-3714
+
+        Test Description: Test that container delete command successfully
+            removes principal in ACL.
+
+        :avocado: tags=all,pr,security,container_acl,cont_delete_acl
+        """
+        # Let's give access to the pool to the root user
+        self.get_dmg_command().pool_update_acl(
+            self.pool.uuid, entry="A::EVERYONE@:rw")
+
+        # The root user should't have access to deleting container ACL entries.
+        daos_cmd = self.get_daos_command()
+        daos_cmd.sudo = True
+
+        # Let's check that we can't run as root (or other user) and delete
+        # entries if no permissions are set for that user.
+
+        for principal in self.principals_table:
+            try:
+                daos_cmd.container_delete_acl(
+                    self.pool.uuid,
+                    self.pool.svc_ranks[0],
+                    self.container.uuid,
+                    principal)
+            except process.CmdError as err:
+                if "-1001" in err.result.stderr:
+                    self.log.info(
+                        "Found expected error %s with invalid principal %s",
+                        err.result.stderr, principal)
+                else:
+                    self.fail("delete-acl seems to have failed with \
+                        unexpected error: {}".format(err))
+        self.fail("container delete-acl command expected to fail.")

--- a/src/tests/ftest/security/cont_delete_acl.py
+++ b/src/tests/ftest/security/cont_delete_acl.py
@@ -63,7 +63,7 @@ class DeleteContainerACLTest(ContSecurityTestBase):
         :avocado: tags=all,pr,security,container_acl,cont_delete_acl
         """
         # Get list of invalid ACL principal values
-        invalid_principals = self.get.params("invalid_principals", "/run/*")
+        invalid_principals = self.params.get("invalid_principals", "/run/*")
         daos_cmd = self.get_daos_command()
 
         # Check for failure on invalid inputs.

--- a/src/tests/ftest/security/cont_delete_acl.py
+++ b/src/tests/ftest/security/cont_delete_acl.py
@@ -51,7 +51,6 @@ class DeleteContainerACLTest(ContSecurityTestBase):
         for entry in cont_acl:
             self.principals_table[entry.split(":")[2]] = entry
 
-
     @fail_on(CommandFailure)
     def test_acl_delete_invalid_inputs(self):
         """

--- a/src/tests/ftest/security/cont_delete_acl.py
+++ b/src/tests/ftest/security/cont_delete_acl.py
@@ -22,9 +22,8 @@
   portions thereof marked with this legend must also reproduce the markings.
 """
 
+from cont_security_test_base import ContSecurityTestBase
 from command_utils import CommandFailure
-from server_utils import ServerFailed
-from apricot import TestWithServers
 from avocado.utils import process
 from avocado import fail_on
 
@@ -122,7 +121,7 @@ class DeleteContainerACLTest(ContSecurityTestBase):
         self.get_dmg_command().pool_update_acl(
             self.pool.uuid, entry="A::EVERYONE@:rw")
 
-        # The root user should't have access to deleting container ACL entries.
+        # The root user shouldn't have access to deleting container ACL entries
         daos_cmd = self.get_daos_command()
         daos_cmd.sudo = True
 

--- a/src/tests/ftest/security/cont_delete_acl.yaml
+++ b/src/tests/ftest/security/cont_delete_acl.yaml
@@ -1,0 +1,26 @@
+# change host names to your reserved nodes, the
+# required quantity is indicated by the placeholders
+hosts:
+  test_servers:
+    - server-A
+  test_clients:
+    - client-B
+timeout: 120
+server_config:
+  name: daos_server
+  servers:
+    scm_class: dcpm
+    scm_list: ["/dev/pmem0"]
+pool:
+  control_method: dmg
+  mode: 511
+  scm_size: 8G
+  name: daos_server
+container:
+  control_method: daos
+  type: POSIX
+
+invalid_principals:
+  - 123456789
+  - NoT_vAliD
+  - 1ab2@3c4$%(

--- a/src/tests/ftest/security/cont_delete_acl.yaml
+++ b/src/tests/ftest/security/cont_delete_acl.yaml
@@ -5,16 +5,13 @@ hosts:
     - server-A
   test_clients:
     - client-B
-timeout: 120
+timeout: 100
 server_config:
   name: daos_server
-  servers:
-    scm_class: dcpm
-    scm_list: ["/dev/pmem0"]
 pool:
   control_method: dmg
   mode: 511
-  scm_size: 8G
+  scm_size: 2G
   name: daos_server
 container:
   control_method: daos

--- a/src/tests/ftest/util/daos_utils.py
+++ b/src/tests/ftest/util/daos_utils.py
@@ -188,6 +188,27 @@ class DaosCommand(DaosCommandBase):
             ("container", "get-acl"), pool=pool, svc=svc, cont=cont,
             verbose=verbose, outfile=outfile)
 
+    def container_delete_acl(self, pool, svc, cont, principal):
+        """Delete an entry for a given principal in an existing container ACL.
+
+        Args:
+            pool (str): Pool UUID
+            svc (str): Service replicas
+            cont (str): Container for which to get the ACL.
+            principal (str): principal portion of the ACL.
+
+        Returns:
+            CmdResult: Object that contains exit status, stdout, and other
+                information.
+
+        Raises:
+            CommandFailure: if the daos container get-acl command fails.
+
+        """
+        return self._get_result(
+            ("container", "delete-acl"), pool=pool, svc=svc, cont=cont,
+            principal=principal)
+
     def pool_list_cont(self, pool, svc, sys_name=None):
         """List containers in the given pool.
 

--- a/src/tests/ftest/util/daos_utils.py
+++ b/src/tests/ftest/util/daos_utils.py
@@ -202,7 +202,7 @@ class DaosCommand(DaosCommandBase):
                 information.
 
         Raises:
-            CommandFailure: if the daos container get-acl command fails.
+            CommandFailure: if the daos container delete-acl command fails.
 
         """
         return self._get_result(

--- a/src/tests/ftest/util/dmg_utils.py
+++ b/src/tests/ftest/util/dmg_utils.py
@@ -450,13 +450,13 @@ class DmgCommand(DmgCommandBase):
         """
         return self._get_result(("pool", "get-acl"), pool=pool)
 
-    def pool_update_acl(self, pool, acl_file, entry):
+    def pool_update_acl(self, pool, acl_file=None, entry=None):
         """Update the acl for a given pool.
 
         Args:
             pool (str): Pool for which to update the ACL.
-            acl_file (str): ACL file to update
-            entry (str): entry to be updated
+            acl_file (str, optional): ACL file to update
+            entry (str, optional): entry to be updated
 
         Returns:
             CmdResult: Object that contains exit status, stdout, and other


### PR DESCRIPTION
- Test that container delete command performs as expected with invalid inputs.
- Test that container delete command successfully removes principal in ACL.
- Test that container delete command fails with no permissions error (-1001) when trying to perform delete command as other user.

Signed-off-by: Justiniano-pagn <amanda.justiniano-pagn@intel.com>