### PR TITLE
DAOS-3708 test: Overwrite container ACL

### DIFF
--- a/src/tests/ftest/security/cont_delete_acl.py
+++ b/src/tests/ftest/security/cont_delete_acl.py
@@ -56,7 +56,8 @@ class DeleteContainerACLTest(ContSecurityTestBase):
 
         Args:
             results (CmdResult): object containing stdout, stderr and
-                exit status
+                exit status.
+            err_msg (str): error message string to look for in stderr.
 
         Returns:
             list: list of test errors encountered.
@@ -84,7 +85,7 @@ class DeleteContainerACLTest(ContSecurityTestBase):
         Test Description: Test that container delete command performs as
             expected with invalid inputs.
 
-        :avocado: tags=all,pr,security,container_acl,cont_delete_acl
+        :avocado: tags=all,pr,security,container_acl,cont_delete_acl_inputs
         """
         # Get list of invalid ACL principal values
         invalid_principals = self.params.get("invalid_principals", "/run/*")
@@ -133,7 +134,7 @@ class DeleteContainerACLTest(ContSecurityTestBase):
         Test Description: Test that container delete command doesn't
             remove principal in ACL without permission.
 
-        :avocado: tags=all,pr,security,container_acl,cont_delete_acl
+        :avocado: tags=all,pr,security,container_acl,cont_delete_acl_noperms
         """
         # Let's give access to the pool to the root user
         self.get_dmg_command().pool_update_acl(

--- a/src/tests/ftest/security/cont_overwrite_acl.py
+++ b/src/tests/ftest/security/cont_overwrite_acl.py
@@ -57,7 +57,7 @@ class OverwriteContainerACLTest(ContSecurityTestBase):
                 exit status
 
         Returns:
-            list: list of test erros encountered.
+            list: list of test errors encountered.
         """
         test_errs = []
         if results.exit_status == 0:

--- a/src/tests/ftest/security/cont_overwrite_acl.py
+++ b/src/tests/ftest/security/cont_overwrite_acl.py
@@ -54,7 +54,7 @@ class OverwriteContainerACLTest(ContSecurityTestBase):
     @fail_on(CommandFailure)
     def test_acl_overwrite_invalid_inputs(self):
         """
-        JIRA ID: DAOS-3714
+        JIRA ID: DAOS-3708
 
         Test Description: Test that container overwrite command performs as
             expected with invalid inputs in command line and within ACL file
@@ -63,32 +63,45 @@ class OverwriteContainerACLTest(ContSecurityTestBase):
         :avocado: tags=all,pr,security,container_acl,cont_overwrite_acl
         """
         # Get list of invalid ACL principal values
-        invalid_principals = self.params.get("invalid_acl_filename", "/run/*")
+        invalid_acl_filename = self.params.get("invalid_acl_filename", "/run/*")
         daos_cmd = self.get_daos_command()
 
         # Check for failure on invalid inputs.
-        for principal in invalid_principals:
+        for acl_file in invalid_acl_filename:
             try:
-                daos_cmd.container_delete_acl(
+                daos_cmd.container_overwrite_acl(
                     self.pool.uuid,
                     self.pool.svc_ranks[0],
                     self.container.uuid,
-                    principal)
+                    acl_file)
             except process.CmdError as err:
-                if "-1003" in err.result.stderr:
+                if "No such file or directory" in err.result.stderr:
                     self.log.info(
-                        "Found expected error %s with invalid principal %s",
+                        "Found expected error %s with invalid acl-file %s",
                         err.result.stderr,
-                        principal)
+                        acl_file)
                 else:
-                    self.fail("delete-acl seems to have failed with \
+                    self.fail("overwrite-acl seems to have failed with \
                         unexpected error: {}".format(err))
-        self.fail("container delete-acl command expected to fail.")
+
+        self.fail("container overwrite-acl command expected to fail.")
+
+    def test_overwrite_invalid_acl_file(self):
+        """
+        JIRA ID: DAOS-3708
+
+        Test Description: Test that container overwrite command performs as
+            expected with invalid inputs in command line and within ACL file
+            provided.
+
+        :avocado: tags=all,pr,security,container_acl,cont_overwrite_acl
+        """
+
 
     @fail_on(CommandFailure)
     def test_delete_valid_acl(self):
         """
-        JIRA ID: DAOS-3714
+        JIRA ID: DAOS-3708
 
         Test Description: Test that container delete command successfully
             removes principal in ACL.
@@ -110,7 +123,7 @@ class OverwriteContainerACLTest(ContSecurityTestBase):
     @fail_on(CommandFailure)
     def test_no_user_permissions(self):
         """
-        JIRA ID: DAOS-3714
+        JIRA ID: DAOS-3708
 
         Test Description: Test that container delete command successfully
             removes principal in ACL.

--- a/src/tests/ftest/security/cont_overwrite_acl.py
+++ b/src/tests/ftest/security/cont_overwrite_acl.py
@@ -83,7 +83,7 @@ class OverwriteContainerACLTest(ContSecurityTestBase):
             expected with invalid inputs in command line and within ACL file
             provided.
 
-        :avocado: tags=all,pr,security,container_acl,cont_overwrite_acl
+        :avocado: tags=all,pr,security,container_acl,cont_overwrite_acl_inputs
         """
         # Get list of invalid ACL principal values
         invalid_acl_filename = self.params.get("invalid_acl_filename", "/run/*")
@@ -123,7 +123,7 @@ class OverwriteContainerACLTest(ContSecurityTestBase):
             expected with invalid inputs in command line and within ACL file
             provided.
 
-        :avocado: tags=all,pr,security,container_acl,cont_overwrite_acl
+        :avocado: tags=all,pr,security,container_acl,cont_overwrite_acl_file
         """
         acl_filename = "test_acl_file.txt"
         invalid_file_content = self.params.get(
@@ -164,7 +164,7 @@ class OverwriteContainerACLTest(ContSecurityTestBase):
         Test Description: Test that container overwrite command performs as
             expected with valid ACL file provided.
 
-        :avocado: tags=all,pr,security,container_acl,cont_overwrite_acl
+        :avocado: tags=all,pr,security,container_acl,cont_overwrite_acl_file
         """
         acl_filename = "test_acl_file.txt"
         valid_file_acl = self.params.get("valid_acl_file", "/run/*")
@@ -196,7 +196,7 @@ class OverwriteContainerACLTest(ContSecurityTestBase):
         Test Description: Test that container overwrite command fails with
             no permission -1001 when user doesn't have the right permissions.
 
-        :avocado: tags=all,pr,security,container_acl,cont_overwrite_acl
+        :avocado: tags=all,pr,security,container_acl,cont_overwrite_acl_noperms
         """
         acl_filename = "test_acl_file.txt"
         valid_file_content = self.params.get("valid_acl_file", "/run/*")

--- a/src/tests/ftest/security/cont_overwrite_acl.py
+++ b/src/tests/ftest/security/cont_overwrite_acl.py
@@ -1,0 +1,146 @@
+#!/usr/bin/python
+"""
+  (C) Copyright 2020 Intel Corporation.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+  GOVERNMENT LICENSE RIGHTS-OPEN SOURCE SOFTWARE
+  The Government's rights to use, modify, reproduce, release, perform, display,
+  or disclose this software are subject to the terms of the Apache License as
+  provided in Contract No. 8F-30005.
+  Any reproduction of computer software, computer software documentation, or
+  portions thereof marked with this legend must also reproduce the markings.
+"""
+
+from cont_security_test_base import ContSecurityTestBase
+from command_utils import CommandFailure
+from avocado.utils import process
+from avocado import fail_on
+
+
+class OverwriteContainerACLTest(ContSecurityTestBase):
+    # pylint: disable=too-many-ancestors
+    """Test Class Description:
+
+    Test to verify ACL entry overwrite.
+
+    :avocado: recursive
+    """
+    def setUp(self):
+        """Set up each test case."""
+        super(OverwriteContainerACLTest, self).setUp()
+        self.prepare_pool()
+        self.add_container(self.pool)
+
+        # Get list of ACL entries
+        cont_acl = self.get_container_acl_list(
+            self.pool.uuid, self.pool.svc_ranks[0], self.container.uuid)
+
+        # Get principals
+        self.principals_table = {}
+        for entry in cont_acl:
+            self.principals_table[entry.split(":")[2]] = entry
+
+    @fail_on(CommandFailure)
+    def test_acl_overwrite_invalid_inputs(self):
+        """
+        JIRA ID: DAOS-3714
+
+        Test Description: Test that container overwrite command performs as
+            expected with invalid inputs in command line and within ACL file
+            provided.
+
+        :avocado: tags=all,pr,security,container_acl,cont_overwrite_acl
+        """
+        # Get list of invalid ACL principal values
+        invalid_principals = self.params.get("invalid_acl_filename", "/run/*")
+        daos_cmd = self.get_daos_command()
+
+        # Check for failure on invalid inputs.
+        for principal in invalid_principals:
+            try:
+                daos_cmd.container_delete_acl(
+                    self.pool.uuid,
+                    self.pool.svc_ranks[0],
+                    self.container.uuid,
+                    principal)
+            except process.CmdError as err:
+                if "-1003" in err.result.stderr:
+                    self.log.info(
+                        "Found expected error %s with invalid principal %s",
+                        err.result.stderr,
+                        principal)
+                else:
+                    self.fail("delete-acl seems to have failed with \
+                        unexpected error: {}".format(err))
+        self.fail("container delete-acl command expected to fail.")
+
+    @fail_on(CommandFailure)
+    def test_delete_valid_acl(self):
+        """
+        JIRA ID: DAOS-3714
+
+        Test Description: Test that container delete command successfully
+            removes principal in ACL.
+
+        :avocado: tags=all,pr,security,container_acl,cont_overwrite_acl
+        """
+        daos_cmd = self.get_daos_command()
+        for principal in self.principals_table:
+            daos_cmd.container_delete_acl(
+                self.pool.uuid,
+                self.pool.svc_ranks[0],
+                self.container.uuid,
+                principal)
+            if self.principals_table[principal] in daos_cmd.result.stdout:
+                self.fail(
+                    "Found acl that was to be deleted in output: {}".format(
+                        daos_cmd.result.stdout))
+
+    @fail_on(CommandFailure)
+    def test_no_user_permissions(self):
+        """
+        JIRA ID: DAOS-3714
+
+        Test Description: Test that container delete command successfully
+            removes principal in ACL.
+
+        :avocado: tags=all,pr,security,container_acl,cont_overwrite_acl
+        """
+        # Let's give access to the pool to the root user
+        self.get_dmg_command().pool_update_acl(
+            self.pool.uuid, entry="A::EVERYONE@:rw")
+
+        # The root user shouldn't have access to deleting container ACL entries
+        daos_cmd = self.get_daos_command()
+        daos_cmd.sudo = True
+
+        # Let's check that we can't run as root (or other user) and delete
+        # entries if no permissions are set for that user.
+
+        for principal in self.principals_table:
+            try:
+                daos_cmd.container_delete_acl(
+                    self.pool.uuid,
+                    self.pool.svc_ranks[0],
+                    self.container.uuid,
+                    principal)
+            except process.CmdError as err:
+                if "-1001" in err.result.stderr:
+                    self.log.info(
+                        "Found expected error %s with invalid principal %s",
+                        err.result.stderr, principal)
+                else:
+                    self.fail("delete-acl seems to have failed with \
+                        unexpected error: {}".format(err))
+        self.fail("container delete-acl command expected to fail.")

--- a/src/tests/ftest/security/cont_overwrite_acl.yaml
+++ b/src/tests/ftest/security/cont_overwrite_acl.yaml
@@ -1,0 +1,26 @@
+# change host names to your reserved nodes, the
+# required quantity is indicated by the placeholders
+hosts:
+  test_servers:
+    - server-A
+  test_clients:
+    - client-B
+timeout: 120
+server_config:
+  name: daos_server
+  servers:
+    scm_class: dcpm
+    scm_list: ["/dev/pmem0"]
+pool:
+  control_method: dmg
+  mode: 511
+  scm_size: 8G
+  name: daos_server
+container:
+  control_method: daos
+  type: POSIX
+
+invalid_acl_filename:
+  - 123456789
+  - NoT_vAliD.txt
+  - 1ab2@3c4$%(

--- a/src/tests/ftest/security/cont_overwrite_acl.yaml
+++ b/src/tests/ftest/security/cont_overwrite_acl.yaml
@@ -8,13 +8,10 @@ hosts:
 timeout: 120
 server_config:
   name: daos_server
-  servers:
-    scm_class: dcpm
-    scm_list: ["/dev/pmem0"]
 pool:
   control_method: dmg
   mode: 511
-  scm_size: 8G
+  scm_size: 1G
   name: daos_server
 container:
   control_method: daos

--- a/src/tests/ftest/security/cont_overwrite_acl.yaml
+++ b/src/tests/ftest/security/cont_overwrite_acl.yaml
@@ -21,3 +21,13 @@ invalid_acl_filename:
   - 123456789
   - NoT_vAliD.txt
   - 1ab2@3c4$%(
+
+invalid_acl_file_content:
+  - ["@$%656672!7", "987654321", "A::OWNER@:dtTaAo"]
+  - ["B::OWNER@:dtTaAo", "C::GROUP@:dtTaAo"]
+  - ["A::OWNER@:NOTPERMISSIONS", "A::OWNER@:123456"]
+  - ["A::OWNER:dtTaAo", "A:G:GROUP:dtTaAo"]
+
+valid_acl_file:
+  - [""]
+  - ["A::OWNER@:dtTaAo", "A:G:my_great_test@:rw", "A::person@:r"]

--- a/src/tests/ftest/security/cont_overwrite_acl.yaml
+++ b/src/tests/ftest/security/cont_overwrite_acl.yaml
@@ -29,5 +29,5 @@ invalid_acl_file_content:
   - ["A::OWNER:dtTaAo", "A:G:GROUP:dtTaAo"]
 
 valid_acl_file:
-  - [""]
+  - []
   - ["A::OWNER@:dtTaAo", "A:G:my_great_test@:rw", "A::person@:r"]

--- a/src/tests/ftest/util/cont_security_test_base.py
+++ b/src/tests/ftest/util/cont_security_test_base.py
@@ -58,7 +58,6 @@ class ContSecurityTestBase(TestWithServers):
         self.pool_svc = None
         self.container_uuid = None
 
-
     def setUp(self):
         """Set up each test case."""
         super(ContSecurityTestBase, self).setUp()
@@ -88,7 +87,6 @@ class ContSecurityTestBase(TestWithServers):
         pool_svc = self.pool.svc_ranks[0]
 
         return pool_uuid, pool_svc
-
 
     def create_container_with_daos(self, pool, acl_type=None):
         """Create a container with the daos tool
@@ -129,7 +127,6 @@ class ContSecurityTestBase(TestWithServers):
             container_uuid = None
 
         return container_uuid
-
 
     def get_container_acl_list(self, pool_uuid, pool_svc, container_uuid,
                                verbose=False, outfile=None):
@@ -173,10 +170,8 @@ class ContSecurityTestBase(TestWithServers):
                     cont_permission_list.append(line)
         return cont_permission_list
 
-
     def compare_acl_lists(self, get_acl_list, expected_list):
         """Compares two permission lists
-
         Args:
             get_acl_list (str list): list of permissions obtained by get-acl
             expected_list (str list): list of expected permissions
@@ -187,15 +182,15 @@ class ContSecurityTestBase(TestWithServers):
         self.log.info("    ===> get-acl ACL:  %s", get_acl_list)
         self.log.info("    ===> Expected ACL: %s", expected_list)
 
-        if len(get_acl_list) == len(expected_list):
-            for element in get_acl_list:
-                if element in expected_list:
-                    continue
-                else:
-                    return False
-            return True
-        return False
-
+        exp_list = expected_list[:]
+        if len(get_acl_list) != len(exp_list):
+            return False
+        for acl in get_acl_list:
+            if acl in exp_list:
+                exp_list.remove(acl)
+            else:
+                return False
+        return True
 
     def cleanup(self, types):
         """Removes all temporal acl files created during the test.

--- a/src/tests/ftest/util/daos_utils.py
+++ b/src/tests/ftest/util/daos_utils.py
@@ -195,7 +195,7 @@ class DaosCommand(DaosCommandBase):
             pool (str): Pool UUID
             svc (str): Service replicas
             cont (str): Container for which to get the ACL.
-            acl_file (str, optional): input file containing ACL
+            acl_file (str): input file containing ACL
 
         Returns:
             CmdResult: Object that contains exit status, stdout, and other

--- a/src/tests/ftest/util/daos_utils.py
+++ b/src/tests/ftest/util/daos_utils.py
@@ -188,6 +188,27 @@ class DaosCommand(DaosCommandBase):
             ("container", "get-acl"), pool=pool, svc=svc, cont=cont,
             verbose=verbose, outfile=outfile)
 
+    def container_overwrite_acl(self, pool, svc, cont, acl_file):
+        """Get the ACL for a given container.
+
+        Args:
+            pool (str): Pool UUID
+            svc (str): Service replicas
+            cont (str): Container for which to get the ACL.
+            acl_file (str, optional): input file containing ACL
+
+        Returns:
+            CmdResult: Object that contains exit status, stdout, and other
+                information.
+
+        Raises:
+            CommandFailure: if the daos container overwrite-acl command fails.
+
+        """
+        return self._get_result(
+            ("container", "overwrite-acl"), pool=pool, svc=svc, cont=cont,
+            acl_file=acl_file)
+
     def pool_list_cont(self, pool, svc, sys_name=None):
         """List containers in the given pool.
 

--- a/src/tests/ftest/util/security_test_base.py
+++ b/src/tests/ftest/util/security_test_base.py
@@ -96,7 +96,7 @@ def create_acl_file(file_name, permissions):
         permissions (str): daos acl permission list.
 
     """
-    acl_file = open(file_name, "w")
+    acl_file = open(file_name, "w+")
     acl_file.write("\n".join(permissions))
     acl_file.close()
 


### PR DESCRIPTION
Test covers the following: 
SRS-10: Container Management - container ACL allows add/remove access control - https://jira.hpdd.intel.com/browse/SRS-10
- Test that container overwrite command performs as expected with invalid inputs in command line.
- Test that container overwrite command performs as expected with invalid inputs within ACL file provided.
- Test that container overwrite command performs as expected with valid ACL file provided.
- Test that container overwrite command fails with no permission -1001 when user doesn't have the right permissions.

Signed-off-by: Justiniano-pagn amanda.justiniano-pagn@intel.com