### PR TITLE
DAOS-5623: Unify management of flags for VOS fetch

### DIFF
--- a/src/include/daos_srv/vos.h
+++ b/src/include/daos_srv/vos.h
@@ -614,21 +614,6 @@ int
 vos_obj_delete(daos_handle_t coh, daos_unit_oid_t oid);
 
 /**
- * I/O APIs
- */
-
-enum vos_fetch_flags {
-	/* only query iod_size */
-	VOS_FETCH_SIZE_ONLY		= (1 << 0),
-	/* query recx list */
-	VOS_FETCH_RECX_LIST		= (1 << 1),
-	/* only set read TS */
-	VOS_FETCH_SET_TS_ONLY		= (1 << 2),
-	/* check the target (obj/dkey/akey) existence */
-	VOS_FETCH_CHECK_EXISTENCE	= (1 << 3),
-};
-
-/**
  *
  * Find and return I/O source buffers for the data of the specified
  * arrays of the given object. The caller can directly use these buffers
@@ -663,7 +648,7 @@ enum vos_fetch_flags {
  */
 int
 vos_fetch_begin(daos_handle_t coh, daos_unit_oid_t oid, daos_epoch_t epoch,
-		uint64_t cond_flags, daos_key_t *dkey, unsigned int nr,
+		daos_key_t *dkey, unsigned int nr,
 		daos_iod_t *iods, uint32_t fetch_flags,
 		struct daos_recx_ep_list *shadows, daos_handle_t *ioh,
 		struct dtx_handle *dth);

--- a/src/include/daos_srv/vos.h
+++ b/src/include/daos_srv/vos.h
@@ -636,8 +636,8 @@ vos_obj_delete(daos_handle_t coh, daos_unit_oid_t oid);
  *			Array of I/O descriptors. The returned record
  *			sizes are also restored in this parameter.
  * \param fetch_flags [IN]
- *			VOS fetch flags, VOS_FETCH_SIZE_ONLY or
- *			VOS_FETCH_RECX_LIST.
+ *			VOS fetch flags, VOS_OF_FETCH_SIZE_ONLY or
+ *			VOS_OF_FETCH_RECX_LIST.
  * \param shadows [IN]	Optional shadow recx/epoch lists, one for each iod.
  *			data of extents covered by these should not be returned
  *			by fetch function. Only used for EC obj degraded fetch.

--- a/src/include/daos_srv/vos_types.h
+++ b/src/include/daos_srv/vos_types.h
@@ -228,6 +228,14 @@ enum {
 	 * under the specified range. Intended for internal use only.
 	 */
 	VOS_OF_REMOVE		= (1 << 9),
+	/* only query iod_size */
+	VOS_FETCH_SIZE_ONLY		= (1 << 10),
+	/* query recx list */
+	VOS_FETCH_RECX_LIST		= (1 << 11),
+	/* only set read TS */
+	VOS_FETCH_SET_TS_ONLY		= (1 << 12),
+	/* check the target (obj/dkey/akey) existence */
+	VOS_FETCH_CHECK_EXISTENCE	= (1 << 13),
 };
 
 /** Mask for any conditionals passed to to the fetch */

--- a/src/include/daos_srv/vos_types.h
+++ b/src/include/daos_srv/vos_types.h
@@ -207,27 +207,27 @@ typedef enum {
 
 enum {
 	/** Conditional Op: Punch key if it exists, fail otherwise */
-	VOS_OF_COND_PUNCH	= DAOS_COND_PUNCH,
+	VOS_OF_COND_PUNCH		= DAOS_COND_PUNCH,
 	/** Conditional Op: Insert dkey if it doesn't exist, fail otherwise */
-	VOS_OF_COND_DKEY_INSERT	= DAOS_COND_DKEY_INSERT,
+	VOS_OF_COND_DKEY_INSERT		= DAOS_COND_DKEY_INSERT,
 	/** Conditional Op: Update dkey if it exists, fail otherwise */
-	VOS_OF_COND_DKEY_UPDATE	= DAOS_COND_DKEY_UPDATE,
+	VOS_OF_COND_DKEY_UPDATE		= DAOS_COND_DKEY_UPDATE,
 	/** Conditional Op: Fetch dkey if it exists, fail otherwise */
-	VOS_OF_COND_DKEY_FETCH	= DAOS_COND_DKEY_FETCH,
+	VOS_OF_COND_DKEY_FETCH		= DAOS_COND_DKEY_FETCH,
 	/** Conditional Op: Insert akey if it doesn't exist, fail otherwise */
-	VOS_OF_COND_AKEY_INSERT	= DAOS_COND_AKEY_INSERT,
+	VOS_OF_COND_AKEY_INSERT		= DAOS_COND_AKEY_INSERT,
 	/** Conditional Op: Update akey if it exists, fail otherwise */
-	VOS_OF_COND_AKEY_UPDATE	= DAOS_COND_AKEY_UPDATE,
+	VOS_OF_COND_AKEY_UPDATE		= DAOS_COND_AKEY_UPDATE,
 	/** Conditional Op: Fetch akey if it exists, fail otherwise */
-	VOS_OF_COND_AKEY_FETCH	= DAOS_COND_AKEY_FETCH,
+	VOS_OF_COND_AKEY_FETCH		= DAOS_COND_AKEY_FETCH,
 	/** replay punch (underwrite) */
-	VOS_OF_REPLAY_PC	= (1 << 7),
+	VOS_OF_REPLAY_PC		= (1 << 7),
 	/* critical update - skip checks on SCM system/held space */
-	VOS_OF_CRIT		= (1 << 8),
+	VOS_OF_CRIT			= (1 << 8),
 	/** Instead of update or punch of extents, remove all extents
 	 * under the specified range. Intended for internal use only.
 	 */
-	VOS_OF_REMOVE		= (1 << 9),
+	VOS_OF_REMOVE			= (1 << 9),
 	/* only query iod_size */
 	VOS_FETCH_SIZE_ONLY		= (1 << 10),
 	/* query recx list */

--- a/src/include/daos_srv/vos_types.h
+++ b/src/include/daos_srv/vos_types.h
@@ -229,13 +229,13 @@ enum {
 	 */
 	VOS_OF_REMOVE			= (1 << 9),
 	/* only query iod_size */
-	VOS_FETCH_SIZE_ONLY		= (1 << 10),
+	VOS_OF_FETCH_SIZE_ONLY		= (1 << 10),
 	/* query recx list */
-	VOS_FETCH_RECX_LIST		= (1 << 11),
+	VOS_OF_FETCH_RECX_LIST		= (1 << 11),
 	/* only set read TS */
-	VOS_FETCH_SET_TS_ONLY		= (1 << 12),
+	VOS_OF_FETCH_SET_TS_ONLY		= (1 << 12),
 	/* check the target (obj/dkey/akey) existence */
-	VOS_FETCH_CHECK_EXISTENCE	= (1 << 13),
+	VOS_OF_FETCH_CHECK_EXISTENCE	= (1 << 13),
 };
 
 /** Mask for any conditionals passed to to the fetch */

--- a/src/object/srv_obj.c
+++ b/src/object/srv_obj.c
@@ -1187,7 +1187,8 @@ obj_fetch_shadow(daos_handle_t coh, daos_unit_oid_t oid, daos_epoch_t epoch,
 
 	obj_iod_idx_vos2parity(iod_nr, iods);
 	rc = vos_fetch_begin(coh, oid, epoch, dkey, iod_nr, iods,
-                cond_flags | VOS_FETCH_RECX_LIST, NULL, &ioh, NULL);
+			     cond_flags | VOS_FETCH_RECX_LIST, NULL, &ioh,
+			     NULL);
 	if (rc) {
 		D_ERROR(DF_UOID" Fetch begin failed: "DF_RC"\n",
 			DP_UOID(oid), DP_RC(rc));
@@ -1392,8 +1393,9 @@ obj_local_rw(crt_rpc_t *rpc, struct obj_io_context *ioc,
 		}
 
 		rc = vos_fetch_begin(ioc->ioc_coc->sc_hdl, orw->orw_oid,
-		        orw->orw_epoch, dkey, orw->orw_nr, iods,
-			cond_flags | fetch_flags, shadows, &ioh, dth);
+				     orw->orw_epoch, dkey, orw->orw_nr, iods,
+				     cond_flags | fetch_flags, shadows, &ioh,
+				     dth);
 		daos_recx_ep_list_free(shadows, orw->orw_nr);
 		if (rc) {
 			D_CDEBUG(rc == -DER_INPROGRESS, DB_IO, DLOG_ERR,

--- a/src/object/srv_obj.c
+++ b/src/object/srv_obj.c
@@ -1187,7 +1187,7 @@ obj_fetch_shadow(daos_handle_t coh, daos_unit_oid_t oid, daos_epoch_t epoch,
 
 	obj_iod_idx_vos2parity(iod_nr, iods);
 	rc = vos_fetch_begin(coh, oid, epoch, dkey, iod_nr, iods,
-			     cond_flags | VOS_FETCH_RECX_LIST, NULL, &ioh, NULL);
+                cond_flags | VOS_FETCH_RECX_LIST, NULL, &ioh, NULL);
 	if (rc) {
 		D_ERROR(DF_UOID" Fetch begin failed: "DF_RC"\n",
 			DP_UOID(oid), DP_RC(rc));
@@ -1392,9 +1392,8 @@ obj_local_rw(crt_rpc_t *rpc, struct obj_io_context *ioc,
 		}
 
 		rc = vos_fetch_begin(ioc->ioc_coc->sc_hdl, orw->orw_oid,
-				     orw->orw_epoch,
-				     dkey, orw->orw_nr, iods,
-				     cond_flags | fetch_flags, shadows, &ioh, dth);
+		        orw->orw_epoch, dkey, orw->orw_nr, iods,
+			cond_flags | fetch_flags, shadows, &ioh, dth);
 		daos_recx_ep_list_free(shadows, orw->orw_nr);
 		if (rc) {
 			D_CDEBUG(rc == -DER_INPROGRESS, DB_IO, DLOG_ERR,

--- a/src/object/srv_obj.c
+++ b/src/object/srv_obj.c
@@ -1187,7 +1187,7 @@ obj_fetch_shadow(daos_handle_t coh, daos_unit_oid_t oid, daos_epoch_t epoch,
 
 	obj_iod_idx_vos2parity(iod_nr, iods);
 	rc = vos_fetch_begin(coh, oid, epoch, dkey, iod_nr, iods,
-			     cond_flags | VOS_FETCH_RECX_LIST, NULL, &ioh,
+			     cond_flags | VOS_OF_FETCH_RECX_LIST, NULL, &ioh,
 			     NULL);
 	if (rc) {
 		D_ERROR(DF_UOID" Fetch begin failed: "DF_RC"\n",
@@ -1374,9 +1374,9 @@ obj_local_rw(crt_rpc_t *rpc, struct obj_io_context *ioc,
 		if (!rma && orw->orw_sgls.ca_arrays == NULL) {
 			spec_fetch = true;
 			if (orw->orw_flags & DRF_CHECK_EXISTENCE)
-				fetch_flags = VOS_FETCH_CHECK_EXISTENCE;
+				fetch_flags = VOS_OF_FETCH_CHECK_EXISTENCE;
 			else
-				fetch_flags = VOS_FETCH_SIZE_ONLY;
+				fetch_flags = VOS_OF_FETCH_SIZE_ONLY;
 		}
 
 		ec_deg_fetch = orw->orw_flags & ORF_EC_DEGRADED;
@@ -3209,7 +3209,7 @@ ds_obj_dtx_handle_one(crt_rpc_t *rpc, struct daos_cpd_sub_head *dcsh,
 				     dcsh->dcsh_epoch.oe_value,
 				     &dcsr->dcsr_dkey, dcsr->dcsr_nr,
 				     dcsr->dcsr_read.dcr_iods,
-				     VOS_FETCH_SET_TS_ONLY, NULL, &ioh, dth);
+				     VOS_OF_FETCH_SET_TS_ONLY, NULL, &ioh, dth);
 		if (rc == 0)
 			rc = vos_fetch_end(ioh, 0);
 		else if (rc == -DER_NONEXIST)

--- a/src/object/srv_obj.c
+++ b/src/object/srv_obj.c
@@ -1186,8 +1186,8 @@ obj_fetch_shadow(daos_handle_t coh, daos_unit_oid_t oid, daos_epoch_t epoch,
 	}
 
 	obj_iod_idx_vos2parity(iod_nr, iods);
-	rc = vos_fetch_begin(coh, oid, epoch, cond_flags, dkey, iod_nr, iods,
-			     VOS_FETCH_RECX_LIST, NULL, &ioh, NULL);
+	rc = vos_fetch_begin(coh, oid, epoch, dkey, iod_nr, iods,
+			     cond_flags | VOS_FETCH_RECX_LIST, NULL, &ioh, NULL);
 	if (rc) {
 		D_ERROR(DF_UOID" Fetch begin failed: "DF_RC"\n",
 			DP_UOID(oid), DP_RC(rc));
@@ -1393,8 +1393,8 @@ obj_local_rw(crt_rpc_t *rpc, struct obj_io_context *ioc,
 
 		rc = vos_fetch_begin(ioc->ioc_coc->sc_hdl, orw->orw_oid,
 				     orw->orw_epoch,
-				     cond_flags, dkey, orw->orw_nr, iods,
-				     fetch_flags, shadows, &ioh, dth);
+				     dkey, orw->orw_nr, iods,
+				     cond_flags | fetch_flags, shadows, &ioh, dth);
 		daos_recx_ep_list_free(shadows, orw->orw_nr);
 		if (rc) {
 			D_CDEBUG(rc == -DER_INPROGRESS, DB_IO, DLOG_ERR,
@@ -3205,7 +3205,7 @@ ds_obj_dtx_handle_one(crt_rpc_t *rpc, struct daos_cpd_sub_head *dcsh,
 
 		dcsr->dcsr_oid.id_shard = dcri[i].dcri_shard_idx;
 		rc = vos_fetch_begin(ioc->ioc_coc->sc_hdl, dcsr->dcsr_oid,
-				     dcsh->dcsh_epoch.oe_value, 0,
+				     dcsh->dcsh_epoch.oe_value,
 				     &dcsr->dcsr_dkey, dcsr->dcsr_nr,
 				     dcsr->dcsr_read.dcr_iods,
 				     VOS_FETCH_SET_TS_ONLY, NULL, &ioh, dth);

--- a/src/rdb/rdb_util.c
+++ b/src/rdb/rdb_util.c
@@ -333,8 +333,8 @@ rdb_vos_fetch_addr(daos_handle_t cont, daos_epoch_t epoch, rdb_oid_t oid,
 
 	rdb_oid_to_uoid(oid, &uoid);
 	rdb_vos_set_iods(RDB_VOS_QUERY, 1 /* n */, akey, value, &iod);
-	rc = vos_fetch_begin(cont, uoid, epoch, 0 /* flags */, &rdb_dkey,
-			     1 /* n */, &iod, 0 /* fetch_flags */, NULL, &io,
+	rc = vos_fetch_begin(cont, uoid, epoch, &rdb_dkey,
+			     1 /* n */, &iod, 0 /* vos_flags */, NULL, &io,
 			     NULL /* dth */);
 	if (rc != 0)
 		return rc;

--- a/src/tests/daos_perf.c
+++ b/src/tests/daos_perf.c
@@ -198,7 +198,7 @@ _vos_update_or_fetch(int obj_idx, enum ts_op_type op_type,
 					      &ioh, NULL);
 		else
 			rc = vos_fetch_begin(ts_ctx.tsc_coh, ts_uoids[obj_idx],
-					     epoch, 0, &cred->tc_dkey, 1,
+					     epoch, &cred->tc_dkey, 1,
 					     &cred->tc_iod, 0, NULL, &ioh,
 					     NULL);
 		if (rc)

--- a/src/vos/tests/vts_checksum.c
+++ b/src/vos/tests/vts_checksum.c
@@ -189,7 +189,7 @@ csum_for_arrays_test_case(void *const *state, struct test_case_args test)
 	 * have access to the vos io handler to get the checksums (this is
 	 * how the server object layer already interfaces with VOS)
 	 */
-	vos_fetch_begin(k.container_hdl, k.object_id, 1, 0, &k.dkey, 1, &iod,
+	vos_fetch_begin(k.container_hdl, k.object_id, 1, &k.dkey, 1, &iod,
 			0, NULL, &ioh, NULL);
 
 	biod = vos_ioh2desc(ioh);

--- a/src/vos/tests/vts_dtx.c
+++ b/src/vos/tests/vts_dtx.c
@@ -596,7 +596,7 @@ dtx_16(void **state)
 	iod.iod_size = DAOS_REC_ANY;
 
 	rc = vos_fetch_begin(args->ctx.tc_co_hdl, args->oid, epoch,
-			     0, &dkey_iov, 1, &iod, 0, NULL, &ioh, NULL);
+			     &dkey_iov, 1, &iod, 0, NULL, &ioh, NULL);
 	/* The former DTX is not committed, so need to retry with leader. */
 	assert_int_equal(rc, -DER_INPROGRESS);
 

--- a/src/vos/tests/vts_io.c
+++ b/src/vos/tests/vts_io.c
@@ -617,8 +617,8 @@ io_test_obj_fetch(struct io_test_args *arg, daos_epoch_t epoch, uint64_t flags,
 		return rc;
 	}
 
-	rc = vos_fetch_begin(arg->ctx.tc_co_hdl, arg->oid, epoch, flags, dkey,
-			     1, iod, 0, NULL, &ioh, NULL);
+	rc = vos_fetch_begin(arg->ctx.tc_co_hdl, arg->oid, epoch, dkey,
+			     1, iod, flags, NULL, &ioh, NULL);
 	if (rc != 0) {
 		if (verbose && rc != -DER_INPROGRESS)
 			print_error("Failed to prepare ZC update: "DF_RC"\n",

--- a/src/vos/vos_io.c
+++ b/src/vos/vos_io.c
@@ -89,7 +89,7 @@ struct vos_io_context {
 	struct daos_recx_ep_list *ic_shadows;
 	/**
 	 * Output recx/epoch lists, one for each iod. To save the recx list when
-	 * vos_fetch_begin() with VOS_FETCH_RECX_LIST flag. User can get it by
+	 * vos_fetch_begin() with VOS_OF_FETCH_RECX_LIST flag. User can get it by
 	 * vos_ioh2recx_list() and should free it by daos_recx_ep_list_free().
 	 */
 	struct daos_recx_ep_list *ic_recx_lists;
@@ -470,7 +470,7 @@ vos_ioc_create(daos_handle_t coh, daos_unit_oid_t oid, bool read_only,
 
 	if (iod_nr == 0 &&
 	    !(vos_flags &
-	      (VOS_FETCH_SET_TS_ONLY | VOS_FETCH_CHECK_EXISTENCE))) {
+	      (VOS_OF_FETCH_SET_TS_ONLY | VOS_OF_FETCH_CHECK_EXISTENCE))) {
 		D_ERROR("Invalid iod_nr (0).\n");
 		rc = -DER_IO_INVAL;
 		goto error;
@@ -488,13 +488,13 @@ vos_ioc_create(daos_handle_t coh, daos_unit_oid_t oid, bool read_only,
 	ioc->ic_cont = vos_hdl2cont(coh);
 	vos_cont_addref(ioc->ic_cont);
 	ioc->ic_update = !read_only;
-	ioc->ic_size_fetch = ((vos_flags & VOS_FETCH_SIZE_ONLY) != 0);
-	ioc->ic_save_recx = ((vos_flags & VOS_FETCH_RECX_LIST) != 0);
+	ioc->ic_size_fetch = ((vos_flags & VOS_OF_FETCH_SIZE_ONLY) != 0);
+	ioc->ic_save_recx = ((vos_flags & VOS_OF_FETCH_RECX_LIST) != 0);
 	ioc->ic_dedup = dedup;
 	ioc->ic_dedup_th = dedup_th;
-	ioc->ic_read_ts_only = ((vos_flags & VOS_FETCH_SET_TS_ONLY) != 0);
+	ioc->ic_read_ts_only = ((vos_flags & VOS_OF_FETCH_SET_TS_ONLY) != 0);
 	ioc->ic_check_existence =
-		((vos_flags & VOS_FETCH_CHECK_EXISTENCE) != 0);
+		((vos_flags & VOS_OF_FETCH_CHECK_EXISTENCE) != 0);
 	ioc->ic_remove =
 		((vos_flags & VOS_OF_REMOVE) != 0);
 	ioc->ic_umoffs_cnt = ioc->ic_umoffs_at = 0;
@@ -2311,7 +2311,7 @@ vos_obj_fetch_ex(daos_handle_t coh, daos_unit_oid_t oid, daos_epoch_t epoch,
 {
 	daos_handle_t	ioh;
 	bool		size_fetch = (sgls == NULL);
-	uint32_t	fetch_flags = size_fetch ? VOS_FETCH_SIZE_ONLY : 0;
+	uint32_t	fetch_flags = size_fetch ? VOS_OF_FETCH_SIZE_ONLY : 0;
 	uint32_t	vos_flags = flags | fetch_flags;
 	int		rc;
 

--- a/src/vos/vos_io.c
+++ b/src/vos/vos_io.c
@@ -2033,7 +2033,7 @@ vos_update_begin(daos_handle_t coh, daos_unit_oid_t oid, daos_epoch_t epoch,
 		dtx_is_valid_handle(dth) ? dth->dth_epoch :  epoch);
 
 	rc = vos_ioc_create(coh, oid, false, epoch, iod_nr, iods, iods_csums,
-                        flags, NULL, dedup, dedup_th, dth, &ioc);
+			    flags, NULL, dedup, dedup_th, dth, &ioc);
 	if (rc != 0)
 		return rc;
 

--- a/src/vos/vos_io.c
+++ b/src/vos/vos_io.c
@@ -89,8 +89,8 @@ struct vos_io_context {
 	struct daos_recx_ep_list *ic_shadows;
 	/**
 	 * Output recx/epoch lists, one for each iod. To save the recx list when
-	 * vos_fetch_begin() with VOS_OF_FETCH_RECX_LIST flag. User can get it by
-	 * vos_ioh2recx_list() and should free it by daos_recx_ep_list_free().
+	 * vos_fetch_begin() with VOS_OF_FETCH_RECX_LIST flag. User can get it
+	 * by vos_ioh2recx_list() and shall free it by daos_recx_ep_list_free().
 	 */
 	struct daos_recx_ep_list *ic_recx_lists;
 };

--- a/src/vos/vos_io.c
+++ b/src/vos/vos_io.c
@@ -2032,8 +2032,8 @@ vos_update_begin(daos_handle_t coh, daos_unit_oid_t oid, daos_epoch_t epoch,
 		"\n", DP_UOID(oid), iod_nr,
 		dtx_is_valid_handle(dth) ? dth->dth_epoch :  epoch);
 
-	rc = vos_ioc_create(coh, oid, false, epoch, iod_nr, iods,
-			    iods_csums, flags, NULL, dedup, dedup_th, dth, &ioc);
+	rc = vos_ioc_create(coh, oid, false, epoch, iod_nr, iods, iods_csums,
+                        flags, NULL, dedup, dedup_th, dth, &ioc);
 	if (rc != 0)
 		return rc;
 

--- a/src/vos/vos_io.c
+++ b/src/vos/vos_io.c
@@ -456,9 +456,9 @@ vos_ioc_destroy(struct vos_io_context *ioc, bool evict)
 
 static int
 vos_ioc_create(daos_handle_t coh, daos_unit_oid_t oid, bool read_only,
-	       daos_epoch_t epoch, uint64_t cond_flags, unsigned int iod_nr,
+	       daos_epoch_t epoch, unsigned int iod_nr,
 	       daos_iod_t *iods, struct dcs_iod_csums *iod_csums,
-	       uint32_t fetch_flags, struct daos_recx_ep_list *shadows,
+	       uint32_t vos_flags, struct daos_recx_ep_list *shadows,
 	       bool dedup, uint32_t dedup_th,
 	       struct dtx_handle *dth, struct vos_io_context **ioc_pp)
 {
@@ -469,7 +469,7 @@ vos_ioc_create(daos_handle_t coh, daos_unit_oid_t oid, bool read_only,
 	int			 i, rc;
 
 	if (iod_nr == 0 &&
-	    !(fetch_flags &
+	    !(vos_flags &
 	      (VOS_FETCH_SET_TS_ONLY | VOS_FETCH_CHECK_EXISTENCE))) {
 		D_ERROR("Invalid iod_nr (0).\n");
 		rc = -DER_IO_INVAL;
@@ -488,15 +488,15 @@ vos_ioc_create(daos_handle_t coh, daos_unit_oid_t oid, bool read_only,
 	ioc->ic_cont = vos_hdl2cont(coh);
 	vos_cont_addref(ioc->ic_cont);
 	ioc->ic_update = !read_only;
-	ioc->ic_size_fetch = ((fetch_flags & VOS_FETCH_SIZE_ONLY) != 0);
-	ioc->ic_save_recx = ((fetch_flags & VOS_FETCH_RECX_LIST) != 0);
+	ioc->ic_size_fetch = ((vos_flags & VOS_FETCH_SIZE_ONLY) != 0);
+	ioc->ic_save_recx = ((vos_flags & VOS_FETCH_RECX_LIST) != 0);
 	ioc->ic_dedup = dedup;
 	ioc->ic_dedup_th = dedup_th;
-	ioc->ic_read_ts_only = ((fetch_flags & VOS_FETCH_SET_TS_ONLY) != 0);
+	ioc->ic_read_ts_only = ((vos_flags & VOS_FETCH_SET_TS_ONLY) != 0);
 	ioc->ic_check_existence =
-		((fetch_flags & VOS_FETCH_CHECK_EXISTENCE) != 0);
+		((vos_flags & VOS_FETCH_CHECK_EXISTENCE) != 0);
 	ioc->ic_remove =
-		((cond_flags & VOS_OF_REMOVE) != 0);
+		((vos_flags & VOS_OF_REMOVE) != 0);
 	ioc->ic_umoffs_cnt = ioc->ic_umoffs_at = 0;
 	ioc->iod_csums = iod_csums;
 	vos_ilog_fetch_init(&ioc->ic_dkey_info);
@@ -512,18 +512,18 @@ vos_ioc_create(daos_handle_t coh, daos_unit_oid_t oid, bool read_only,
 	if (dtx_is_valid_handle(dth)) {
 		if (read_only) {
 			cflags = VOS_TS_READ_AKEY;
-			if (cond_flags & VOS_OF_COND_DKEY_FETCH)
+			if (vos_flags & VOS_OF_COND_DKEY_FETCH)
 				cflags |= VOS_TS_READ_DKEY;
 		} else {
 			cflags = VOS_TS_WRITE_AKEY;
-			if (cond_flags & VOS_COND_AKEY_UPDATE_MASK)
+			if (vos_flags & VOS_COND_AKEY_UPDATE_MASK)
 				cflags |= VOS_TS_READ_AKEY;
-			if (cond_flags & VOS_COND_DKEY_UPDATE_MASK)
+			if (vos_flags & VOS_COND_DKEY_UPDATE_MASK)
 				cflags |= VOS_TS_READ_DKEY;
 		}
 	}
 
-	rc = vos_ts_set_allocate(&ioc->ic_ts_set, cond_flags, cflags, iod_nr,
+	rc = vos_ts_set_allocate(&ioc->ic_ts_set, vos_flags, cflags, iod_nr,
 				 dtx_is_valid_handle(dth) ?
 				 &dth->dth_xid : NULL);
 	if (rc != 0)
@@ -1205,8 +1205,8 @@ vos_fetch_end(daos_handle_t ioh, int err)
 
 int
 vos_fetch_begin(daos_handle_t coh, daos_unit_oid_t oid, daos_epoch_t epoch,
-		uint64_t cond_flags, daos_key_t *dkey, unsigned int iod_nr,
-		daos_iod_t *iods, uint32_t fetch_flags,
+		daos_key_t *dkey, unsigned int iod_nr,
+		daos_iod_t *iods, uint32_t vos_flags,
 		struct daos_recx_ep_list *shadows, daos_handle_t *ioh,
 		struct dtx_handle *dth)
 {
@@ -1216,8 +1216,8 @@ vos_fetch_begin(daos_handle_t coh, daos_unit_oid_t oid, daos_epoch_t epoch,
 	D_DEBUG(DB_TRACE, "Fetch "DF_UOID", desc_nr %d, epoch "DF_X64"\n",
 		DP_UOID(oid), iod_nr, epoch);
 
-	rc = vos_ioc_create(coh, oid, true, epoch, cond_flags, iod_nr, iods,
-			    NULL, fetch_flags, shadows, false, 0,
+	rc = vos_ioc_create(coh, oid, true, epoch, iod_nr, iods,
+			    NULL, vos_flags, shadows, false, 0,
 			    dth, &ioc);
 	if (rc != 0)
 		return rc;
@@ -2032,8 +2032,8 @@ vos_update_begin(daos_handle_t coh, daos_unit_oid_t oid, daos_epoch_t epoch,
 		"\n", DP_UOID(oid), iod_nr,
 		dtx_is_valid_handle(dth) ? dth->dth_epoch :  epoch);
 
-	rc = vos_ioc_create(coh, oid, false, epoch, flags, iod_nr, iods,
-			    iods_csums, 0, NULL, dedup, dedup_th, dth, &ioc);
+	rc = vos_ioc_create(coh, oid, false, epoch, iod_nr, iods,
+			    iods_csums, flags, NULL, dedup, dedup_th, dth, &ioc);
 	if (rc != 0)
 		return rc;
 
@@ -2312,10 +2312,11 @@ vos_obj_fetch_ex(daos_handle_t coh, daos_unit_oid_t oid, daos_epoch_t epoch,
 	daos_handle_t	ioh;
 	bool		size_fetch = (sgls == NULL);
 	uint32_t	fetch_flags = size_fetch ? VOS_FETCH_SIZE_ONLY : 0;
+	uint32_t	vos_flags = flags | fetch_flags;
 	int		rc;
 
-	rc = vos_fetch_begin(coh, oid, epoch, flags, dkey, iod_nr, iods,
-			     fetch_flags, NULL, &ioh, dth);
+	rc = vos_fetch_begin(coh, oid, epoch, dkey, iod_nr, iods,
+			     vos_flags, NULL, &ioh, dth);
 	if (rc) {
 		VOS_TX_TRACE_FAIL(rc, "Cannot fetch "DF_UOID": "DF_RC"\n",
 				  DP_UOID(oid), DP_RC(rc));


### PR DESCRIPTION
First, merge vos flags in a single enum. Then fix usage in vos_fetch_begin,
vos_ioc_create, vos_obj_fetch_ex, rdb, tests, vos tests and srv_obj.

Signed-off-by: Marcela Rosales <marcela.a.rosales.jimenez@intel.com>