### PR TITLE
DAOS-5473 bio: Handle hot remove/plug event

### DIFF
--- a/src/bio/bio_context.c
+++ b/src/bio/bio_context.c
@@ -258,7 +258,8 @@ bio_bs_hold(struct bio_blobstore *bbs)
 	}
 
 	if (bbs->bb_state == BIO_BS_STATE_TEARDOWN ||
-	    bbs->bb_state == BIO_BS_STATE_OUT) {
+	    bbs->bb_state == BIO_BS_STATE_OUT ||
+	    bbs->bb_state == BIO_BS_STATE_SETUP) {
 		D_ERROR("Blobstore %p is in %d state, reject request.\n",
 			bbs, bbs->bb_state);
 		rc = -DER_DOS;
@@ -440,8 +441,8 @@ bio_blob_create(uuid_t uuid, struct bio_xs_context *xs_ctxt, uint64_t blob_sz)
 	return rc;
 }
 
-static int
-bio_blob_open(struct bio_io_context *ctxt, uuid_t uuid, bool async)
+int
+bio_blob_open(struct bio_io_context *ctxt, bool async)
 {
 	struct bio_xs_context		*xs_ctxt = ctxt->bic_xs_ctxt;
 	spdk_blob_id			 blob_id;
@@ -467,10 +468,11 @@ bio_blob_open(struct bio_io_context *ctxt, uuid_t uuid, bool async)
 	/*
 	 * Query per-server metadata to get blobID for this pool:target
 	 */
-	rc = smd_pool_get_blob(uuid, xs_ctxt->bxc_tgt_id, &blob_id);
+	rc = smd_pool_get_blob(ctxt->bic_pool_id, xs_ctxt->bxc_tgt_id,
+			       &blob_id);
 	if (rc != 0) {
 		D_ERROR("Failed to find blobID for xs:%p, pool:"DF_UUID"\n",
-			xs_ctxt, DP_UUID(uuid));
+			xs_ctxt, DP_UUID(ctxt->bic_pool_id));
 		return -DER_NONEXIST;
 	}
 
@@ -480,7 +482,7 @@ bio_blob_open(struct bio_io_context *ctxt, uuid_t uuid, bool async)
 	ba = &bma->bma_cp_arg;
 
 	D_DEBUG(DB_MGMT, "Opening blobID "DF_U64" for xs:%p pool:"DF_UUID"\n",
-		blob_id, xs_ctxt, DP_UUID(uuid));
+		blob_id, xs_ctxt, DP_UUID(ctxt->bic_pool_id));
 
 	ctxt->bic_opening = 1;
 	ba->bca_inflights = 1;
@@ -499,12 +501,13 @@ bio_blob_open(struct bio_io_context *ctxt, uuid_t uuid, bool async)
 
 	if (rc != 0) {
 		D_ERROR("Open blobID "DF_U64" failed for xs:%p pool:"DF_UUID" "
-			"rc:%d\n", blob_id, xs_ctxt, DP_UUID(uuid), rc);
+			"rc:%d\n", blob_id, xs_ctxt, DP_UUID(ctxt->bic_pool_id),
+			rc);
 	} else {
 		D_ASSERT(ba->bca_blob != NULL);
 		D_DEBUG(DB_MGMT, "Successfully opened blobID "DF_U64" for xs:%p"
 			" pool:"DF_UUID" blob:%p\n", blob_id, xs_ctxt,
-			DP_UUID(uuid), ba->bca_blob);
+			DP_UUID(ctxt->bic_pool_id), ba->bca_blob);
 		ctxt->bic_blob = ba->bca_blob;
 	}
 
@@ -527,6 +530,7 @@ bio_ioctxt_open(struct bio_io_context **pctxt, struct bio_xs_context *xs_ctxt,
 	ctxt->bic_umem = umem;
 	ctxt->bic_pmempool_uuid = umem_get_uuid(umem);
 	ctxt->bic_xs_ctxt = xs_ctxt;
+	uuid_copy(ctxt->bic_pool_id, uuid);
 
 	/* NVMe isn't configured */
 	if (xs_ctxt == NULL) {
@@ -540,7 +544,7 @@ bio_ioctxt_open(struct bio_io_context **pctxt, struct bio_xs_context *xs_ctxt,
 		return rc;
 	}
 
-	rc = bio_blob_open(ctxt, uuid, false);
+	rc = bio_blob_open(ctxt, false);
 	if (rc) {
 		D_FREE(ctxt);
 	} else {

--- a/src/bio/bio_internal.h
+++ b/src/bio/bio_internal.h
@@ -96,12 +96,35 @@ struct bio_dev_health {
 };
 
 /*
+ * 'Init' xstream is the first started VOS xstream, it calls
+ * spdk_bdev_initialize() on server start to initialize SPDK bdev and scan all
+ * the available devices, and the SPDK hotplug poller is registered then.
+ *
+ * Given the SPDK bdev remove callback is called on 'init' xstream, 'init'
+ * xstream is the one responsible for initiating BIO hot plug/remove event,
+ * and managing the list of 'bio_bdev'.
+ */
+struct bio_bdev {
+	d_list_t		 bb_link;
+	uuid_t			 bb_uuid;
+	char			*bb_name;
+	/* Prevent the SPDK bdev being freed by device hot remove */
+	struct spdk_bdev_desc	*bb_desc;
+	struct bio_blobstore	*bb_blobstore;
+	/* count of target(VOS xstream) per device */
+	int			 bb_tgt_cnt;
+	bool			 bb_removed;
+};
+
+/*
  * SPDK blobstore isn't thread safe and there can be only one SPDK
  * blobstore for certain NVMe device.
  */
 struct bio_blobstore {
 	ABT_mutex		 bb_mutex;
 	ABT_cond		 bb_barrier;
+	/* Back pointer to bio_bdev */
+	struct bio_bdev		*bb_dev;
 	struct spdk_blob_store	*bb_bs;
 	/*
 	 * The xstream responsible for blobstore load/unload, monitor
@@ -120,6 +143,9 @@ struct bio_blobstore {
 	 * layer, teardown procedure needs be postponed.
 	 */
 	int			 bb_holdings;
+	/* Flags indicating blobstore load/unload is in-progress */
+	unsigned		 bb_loading:1,
+				 bb_unloading:1;
 };
 
 /* Per-xstream NVMe context */
@@ -144,6 +170,7 @@ struct bio_io_context {
 	struct bio_xs_context	*bic_xs_ctxt;
 	uint32_t		 bic_inflight_dmas;
 	uint32_t		 bic_io_unit;
+	uuid_t			 bic_pool_id;
 	unsigned int		 bic_opening:1,
 				 bic_closing:1;
 };
@@ -221,6 +248,19 @@ enum {
 	BDEV_CLASS_UNKNOWN
 };
 
+static inline int
+get_bdev_type(struct spdk_bdev *bdev)
+{
+	if (strcmp(spdk_bdev_get_product_name(bdev), "NVMe disk") == 0)
+		return BDEV_CLASS_NVME;
+	else if (strcmp(spdk_bdev_get_product_name(bdev), "Malloc disk") == 0)
+		return BDEV_CLASS_MALLOC;
+	else if (strcmp(spdk_bdev_get_product_name(bdev), "AIO disk") == 0)
+		return BDEV_CLASS_AIO;
+	else
+		return BDEV_CLASS_UNKNOWN;
+}
+
 struct media_error_msg {
 	struct bio_blobstore	*mem_bs;
 	int			 mem_err_type;
@@ -232,9 +272,16 @@ extern unsigned int	bio_chk_sz;
 extern unsigned int	bio_chk_cnt_max;
 extern uint64_t		io_stat_period;
 void xs_poll_completion(struct bio_xs_context *ctxt, unsigned int *inflights);
-int get_bdev_type(struct spdk_bdev *bdev);
 void bio_bdev_event_cb(enum spdk_bdev_event_type type, struct spdk_bdev *bdev,
 		       void *event_ctx);
+struct spdk_thread *init_thread(void);
+void bio_release_bdev(void *arg);
+bool is_server_started(void);
+struct spdk_blob_store *
+load_blobstore(struct bio_xs_context *ctxt, char *bdev_name, uuid_t *bs_uuid,
+	       bool create, bool async,
+	       void (*async_cb)(void *arg, struct spdk_blob_store *bs, int rc),
+	       void *async_arg);
 
 /* bio_buffer.c */
 void dma_buffer_destroy(struct bio_dma_buffer *buf);
@@ -251,6 +298,7 @@ void bio_media_error(void *msg_arg);
 
 /* bio_context.c */
 int bio_blob_close(struct bio_io_context *ctxt, bool async);
+int bio_blob_open(struct bio_io_context *ctxt, bool async);
 
 /* bio_recovery.c */
 int bio_bs_state_transit(struct bio_blobstore *bbs);

--- a/src/bio/bio_monitor.c
+++ b/src/bio/bio_monitor.c
@@ -314,8 +314,7 @@ out:
 static int
 auto_detect_faulty(struct bio_blobstore *bbs)
 {
-	if (bbs->bb_state != BIO_BS_STATE_NORMAL &&
-	    bbs->bb_state != BIO_BS_STATE_SETUP)
+	if (bbs->bb_state != BIO_BS_STATE_NORMAL)
 		return 0;
 	/*
 	 * TODO: Check the health data stored in @bbs, and mark the bbs as

--- a/src/bio/bio_recovery.c
+++ b/src/bio/bio_recovery.c
@@ -71,44 +71,52 @@ on_faulty(struct bio_blobstore *bbs)
 	return rc;
 }
 
-/*
- * Return value:	0: Per-xstream context is torn down;
- *			1: Per-xstream context teardown is in progress;
- */
-static int
-teardown_xstream(struct bio_xs_context *xs_ctxt)
+static void
+teardown_xstream(void *arg)
 {
+	struct bio_xs_context	*xs_ctxt = arg;
 	struct bio_io_context	*ioc;
 	int			 opened_blobs = 0;
 
 	D_ASSERT(xs_ctxt != NULL);
-	/* Teardown work for this xstream is done */
+	if (!is_server_started()) {
+		D_INFO("Abort xs teardown on server start/shutdown\n");
+		return;
+	}
+
+	/* This xstream is torndown */
 	if (xs_ctxt->bxc_io_channel == NULL)
-		return 0;
+		return;
 
 	/* Try to close all blobs */
 	d_list_for_each_entry(ioc, &xs_ctxt->bxc_io_ctxts, bic_link) {
-		D_ASSERT(ioc->bic_opening == 0);
-
-		if (ioc->bic_blob == NULL)
+		if (ioc->bic_blob == NULL && ioc->bic_opening == 0)
 			continue;
 
 		opened_blobs++;
-		if (ioc->bic_closing)
+		if (ioc->bic_closing || ioc->bic_opening)
 			continue;
 
 		bio_blob_close(ioc, true);
 	}
 
-	if (opened_blobs)
-		return 1;
+	if (opened_blobs) {
+		D_DEBUG(DB_MGMT, "xs:%p has %d opened blobs\n",
+			xs_ctxt, opened_blobs);
+		return;
+	}
+
+	/* Close open desc for io stats */
+	if (xs_ctxt->bxc_desc != NULL) {
+		spdk_bdev_close(xs_ctxt->bxc_desc);
+		xs_ctxt->bxc_desc = NULL;
+	}
 
 	/* Put the io channel */
-	D_ASSERT(xs_ctxt->bxc_io_channel != NULL);
-	spdk_bs_free_io_channel(xs_ctxt->bxc_io_channel);
-	xs_ctxt->bxc_io_channel = NULL;
-
-	return 0;
+	if (xs_ctxt->bxc_io_channel != NULL) {
+		spdk_bs_free_io_channel(xs_ctxt->bxc_io_channel);
+		xs_ctxt->bxc_io_channel = NULL;
+	}
 }
 
 static void
@@ -116,54 +124,268 @@ unload_bs_cp(void *arg, int rc)
 {
 	struct bio_blobstore *bbs = arg;
 
+	/* Unload blobstore may fail if the device is hot removed */
 	if (rc != 0)
-		D_ERROR("Failed to unload blobstore:%p, "DF_RC"\n",
-			bbs, DP_RC(rc));
-	else
-		bbs->bb_bs = NULL;
+		D_ERROR("Failed to unload blobstore:%p, %d\n",
+			bbs, rc);
+
+	/* Stop accessing bbs, it could be freed on shutdown */
+	if (!is_server_started()) {
+		D_INFO("Abort bs unload on server start/shutdown\n");
+		return;
+	}
+
+	D_ASSERT(!bbs->bb_loading);
+	bbs->bb_unloading = false;
+	/* SPDK will free blobstore even if load failed */
+	bbs->bb_bs = NULL;
+	D_ASSERT(init_thread() != NULL);
+	spdk_thread_send_msg(init_thread(), bio_release_bdev,
+			     bbs->bb_dev);
 }
 
 /*
- * Return value:	0: Blobstore is torn down;
- *			1: Blobstore teardown is in progress;
+ * Return value:	0:  Blobstore is torn down;
+ *			>0: Blobstore teardown is in progress;
  */
 static int
 on_teardown(struct bio_blobstore *bbs)
 {
-	int	i, rc = 0, ret;
-
-	/*
-	 * The blobstore is already closed, transition to next state.
-	 * TODO: Need to cleanup bdev when supporting reintegration.
-	 */
-	if (bbs->bb_bs == NULL)
-		return 0;
+	struct bio_dev_health	*bdh = &bbs->bb_dev_health;
+	int			 i, rc = 0;
 
 	ABT_mutex_lock(bbs->bb_mutex);
-
 	if (bbs->bb_holdings != 0) {
 		D_DEBUG(DB_MGMT, "Blobstore %p is inuse:%d, retry later.\n",
 			bbs, bbs->bb_holdings);
 		ABT_mutex_unlock(bbs->bb_mutex);
 		return 1;
 	}
-
-	/* Hold the lock to prevent other xstreams from exiting */
-	for (i = 0; i < bbs->bb_ref; i++) {
-		ret = teardown_xstream(bbs->bb_xs_ctxts[i]);
-		rc += ret;
-	}
-
 	ABT_mutex_unlock(bbs->bb_mutex);
 
-	if (rc == 0) {
-		/* Unload the blobstore */
-		D_ASSERT(bbs->bb_bs != NULL);
-		D_ASSERT(bbs->bb_holdings == 0);
-		spdk_bs_unload(bbs->bb_bs, unload_bs_cp, bbs);
+	/*
+	 * It's safe to access xs context array without locking when the
+	 * server is neither in start nor shutdown phase.
+	 */
+	D_ASSERT(is_server_started());
+	for (i = 0; i < bbs->bb_ref; i++) {
+		struct bio_xs_context	*xs_ctxt = bbs->bb_xs_ctxts[i];
+
+		/* This xstream is torndown */
+		if (xs_ctxt->bxc_io_channel == NULL)
+			continue;
+
+		D_ASSERT(xs_ctxt->bxc_thread != NULL);
+		spdk_thread_send_msg(xs_ctxt->bxc_thread, teardown_xstream,
+				     xs_ctxt);
+		rc += 1;
 	}
 
+	if (rc)
+		return rc;
+
+	/* Put io channel for health monitor */
+	if (bdh->bdh_io_channel != NULL) {
+		spdk_put_io_channel(bdh->bdh_io_channel);
+		bdh->bdh_io_channel = NULL;
+	}
+
+	/* Close open desc for health monitor */
+	if (bdh->bdh_desc != NULL) {
+		spdk_bdev_close(bdh->bdh_desc);
+		bdh->bdh_desc = NULL;
+	}
+
+	/*
+	 * Unload the blobstore. The blobstore could be still in loading from
+	 * the SETUP stage.
+	 */
+	D_ASSERT(bbs->bb_holdings == 0);
+	if (bbs->bb_bs == NULL && !bbs->bb_loading)
+		return 0;
+
+	if (bbs->bb_loading || bbs->bb_unloading) {
+		D_DEBUG(DB_MGMT, "Blobstore %p is in %s\n", bbs,
+			bbs->bb_loading ? "loading" : "unloading");
+		return 1;
+	}
+
+	bbs->bb_unloading = true;
+	spdk_bs_unload(bbs->bb_bs, unload_bs_cp, bbs);
 	return 1;
+}
+
+static void
+setup_xstream(void *arg)
+{
+	struct bio_xs_context	*xs_ctxt = arg;
+	struct bio_blobstore	*bbs;
+	struct bio_bdev		*d_bdev;
+	struct bio_io_context	*ioc;
+	int			 rc, closed_blobs = 0;
+
+	D_ASSERT(xs_ctxt != NULL);
+	if (!is_server_started()) {
+		D_INFO("Abort xs setup on server start/shutdown\n");
+		return;
+	}
+
+	bbs = xs_ctxt->bxc_blobstore;
+	D_ASSERT(bbs != NULL);
+	D_ASSERT(bbs->bb_bs != NULL);
+
+	/*
+	 * Setup the blobstore io channel. It's must be done as the first step
+	 * of xstream setup, since xstream teardown checks io channel to tell
+	 * if everything is torndown for the xstream.
+	 */
+	if (xs_ctxt->bxc_io_channel == NULL) {
+		xs_ctxt->bxc_io_channel = spdk_bs_alloc_io_channel(bbs->bb_bs);
+		if (xs_ctxt->bxc_io_channel == NULL) {
+			D_ERROR("Failed to create io channel for %p\n", bbs);
+			return;
+		}
+	}
+
+	/* Try to open all blobs */
+	d_list_for_each_entry(ioc, &xs_ctxt->bxc_io_ctxts, bic_link) {
+		if (ioc->bic_blob != NULL && !ioc->bic_closing)
+			continue;
+
+		closed_blobs++;
+		if (ioc->bic_opening || ioc->bic_closing)
+			continue;
+
+		bio_blob_open(ioc, true);
+	}
+
+	if (closed_blobs) {
+		D_DEBUG(DB_MGMT, "xs:%p has %d closed blobs\n",
+			xs_ctxt, closed_blobs);
+		return;
+	}
+
+	d_bdev = bbs->bb_dev;
+	D_ASSERT(d_bdev != NULL);
+	D_ASSERT(d_bdev->bb_name != NULL);
+
+	/* Acquire open desc for io stats as the last step of xs setup */
+	if (xs_ctxt->bxc_desc == NULL) {
+		rc = spdk_bdev_open_ext(d_bdev->bb_name, false,
+					bio_bdev_event_cb, NULL,
+					&xs_ctxt->bxc_desc);
+		if (rc != 0) {
+			D_ERROR("Failed to open bdev %s, for %p, %d\n",
+				d_bdev->bb_name, bbs, rc);
+			return;
+		}
+		D_ASSERT(xs_ctxt->bxc_desc != NULL);
+	}
+}
+
+static void
+load_bs_cp(void *arg, struct spdk_blob_store *bs, int rc)
+{
+	struct bio_blobstore *bbs = arg;
+
+	if (rc != 0)
+		D_ERROR("Failed to load blobstore:%p, %d\n",
+			bbs, rc);
+
+	/* Stop accessing bbs since it could be freed on shutdown */
+	if (!is_server_started()) {
+		D_INFO("Abort bs load on server start/shutdown\n");
+		return;
+	}
+
+	D_ASSERT(!bbs->bb_unloading);
+	D_ASSERT(bbs->bb_bs == NULL);
+	bbs->bb_loading = false;
+	if (rc == 0)
+		bbs->bb_bs = bs;
+}
+
+/*
+ * Return value:	0:  Blobstore loaded, all blobs opened;
+ *			>0: Blobstore or blobs are in loading/opening;
+ */
+static int
+on_setup(struct bio_blobstore *bbs)
+{
+	struct bio_bdev		*d_bdev = bbs->bb_dev;
+	struct bio_dev_health	*bdh = &bbs->bb_dev_health;
+	int			 i, rc = 0;
+
+	ABT_mutex_lock(bbs->bb_mutex);
+	if (bbs->bb_holdings != 0) {
+		D_DEBUG(DB_MGMT, "Blobstore %p is inuse:%d, retry later.\n",
+			bbs, bbs->bb_holdings);
+		ABT_mutex_unlock(bbs->bb_mutex);
+		return 1;
+	}
+	ABT_mutex_unlock(bbs->bb_mutex);
+
+	D_ASSERT(!bbs->bb_unloading);
+	/* Blobstore is already loaded */
+	if (bbs->bb_bs != NULL)
+		goto bs_loaded;
+
+	if (bbs->bb_loading) {
+		D_DEBUG(DB_MGMT, "Blobstore %p is in loading\n", bbs);
+		return 1;
+	}
+
+	D_ASSERT(d_bdev != NULL);
+	D_ASSERT(d_bdev->bb_name != NULL);
+	D_ASSERT(d_bdev->bb_uuid != NULL);
+
+	bbs->bb_loading = true;
+	load_blobstore(NULL, d_bdev->bb_name, &d_bdev->bb_uuid, false, true,
+		       load_bs_cp, bbs);
+	return 1;
+
+bs_loaded:
+	/* Acquire open desc for health monitor */
+	if (bdh->bdh_desc == NULL) {
+		rc = spdk_bdev_open_ext(d_bdev->bb_name, true,
+					bio_bdev_event_cb, NULL,
+					&bdh->bdh_desc);
+		if (rc != 0) {
+			D_ERROR("Failed to open bdev %s, for %p, %d\n",
+				d_bdev->bb_name, bbs, rc);
+			return 1;
+		}
+		D_ASSERT(bdh->bdh_desc != NULL);
+	}
+
+	/* Get io channel for health monitor */
+	if (bdh->bdh_io_channel == NULL) {
+		bdh->bdh_io_channel = spdk_bdev_get_io_channel(bdh->bdh_desc);
+		if (bdh->bdh_io_channel == NULL) {
+			D_ERROR("Failed to get health channel for %p\n", bbs);
+			return 1;
+		}
+	}
+
+	/*
+	 * It's safe to access xs context array without locking when the
+	 * server is neither in start nor shutdown phase.
+	 */
+	D_ASSERT(is_server_started());
+	for (i = 0; i < bbs->bb_ref; i++) {
+		struct bio_xs_context	*xs_ctxt = bbs->bb_xs_ctxts[i];
+
+		/* Setup for the xsteam is done */
+		if (xs_ctxt->bxc_desc != NULL)
+			continue;
+
+		D_ASSERT(xs_ctxt->bxc_thread != NULL);
+		spdk_thread_send_msg(xs_ctxt->bxc_thread, setup_xstream,
+				     xs_ctxt);
+		rc += 1;
+	}
+
+	return rc;
 }
 
 static char *
@@ -214,7 +436,8 @@ bio_bs_state_set(struct bio_blobstore *bbs, enum bio_bs_state new_state)
 			rc = -DER_INVAL;
 		break;
 	case BIO_BS_STATE_SETUP:
-		rc = -DER_NOSYS;
+		if (bbs->bb_state != BIO_BS_STATE_OUT)
+			rc = -DER_INVAL;
 		break;
 	default:
 		rc = -DER_INVAL;
@@ -236,18 +459,14 @@ bio_bs_state_set(struct bio_blobstore *bbs, enum bio_bs_state new_state)
 			bio_state_enum_to_str(new_state));
 		bbs->bb_state = new_state;
 
-		if (new_state == BIO_BS_STATE_NORMAL ||
-		    new_state == BIO_BS_STATE_FAULTY) {
+		if (new_state == BIO_BS_STATE_FAULTY) {
 			struct spdk_bs_type	bstype;
 			uuid_t			dev_id;
-			enum smd_dev_state	dev_state;
 
 			bstype = spdk_bs_get_bstype(bbs->bb_bs);
 			memcpy(dev_id, bstype.bstype, sizeof(dev_id));
-			dev_state = new_state == BIO_BS_STATE_NORMAL ?
-					SMD_DEV_NORMAL : SMD_DEV_FAULTY;
 
-			rc = smd_dev_set_state(dev_id, dev_state);
+			rc = smd_dev_set_state(dev_id, SMD_DEV_FAULTY);
 			if (rc)
 				D_ERROR("Set device state failed. "DF_RC"\n",
 					DP_RC(rc));
@@ -283,7 +502,9 @@ bio_bs_state_transit(struct bio_blobstore *bbs)
 			rc = bio_bs_state_set(bbs, BIO_BS_STATE_OUT);
 		break;
 	case BIO_BS_STATE_SETUP:
-		rc = -DER_NOSYS;
+		rc = on_setup(bbs);
+		if (rc == 0)
+			rc = bio_bs_state_set(bbs, BIO_BS_STATE_NORMAL);
 		break;
 	default:
 		rc = -DER_INVAL;

--- a/src/bio/bio_xstream.c
+++ b/src/bio/bio_xstream.c
@@ -63,26 +63,6 @@ unsigned int bio_chk_cnt_max;
 /* Per-xstream initial DMA buffer size (in chunk count) */
 static unsigned int bio_chk_cnt_init;
 
-/*
- * 'Init' xstream is the first started VOS xstream, it calls
- * spdk_bdev_initialize() on server start to initialize SPDK bdev and scan all
- * the available devices, and the SPDK hotplug poller is registered then.
- *
- * Given the SPDK bdev remove callback is called on 'init' xstream, 'init'
- * xstream is the one responsible for initiating BIO hot plug/remove event,
- * and managing the list of 'bio_bdev'.
- */
-struct bio_bdev {
-	d_list_t		 bb_link;
-	uuid_t			 bb_uuid;
-	char			*bb_name;
-	/* Prevent the SPDK bdev being freed by device hot remove */
-	struct spdk_bdev_desc	*bb_desc;
-	struct bio_blobstore	*bb_blobstore;
-	/* count of target(VOS xstream) per device */
-	int			 bb_tgt_cnt;
-};
-
 struct bio_nvme_data {
 	ABT_mutex		 bd_mutex;
 	ABT_cond		 bd_barrier;
@@ -96,10 +76,12 @@ struct bio_nvme_data {
 	struct spdk_bs_opts	 bd_bs_opts;
 	/* All bdevs can be used by DAOS server */
 	d_list_t		 bd_bdevs;
+	uint64_t		 bd_scan_age;
 	struct spdk_conf	*bd_nvme_conf;
 	int			 bd_shm_id;
 	/* When using SPDK primary mode, specifies memory allocation in MB */
 	int			 bd_mem_size;
+	bool			 bd_started;
 };
 
 static struct bio_nvme_data nvme_glb;
@@ -514,43 +496,28 @@ bio_nvme_fini(void)
 static inline bool
 is_bbs_owner(struct bio_xs_context *ctxt, struct bio_blobstore *bbs)
 {
+	D_ASSERT(ctxt != NULL);
+	D_ASSERT(bbs != NULL);
 	return bbs->bb_owner_xs == ctxt;
 }
 
-/*
- * Execute the messages on msg ring, call all registered pollers.
- *
- * \param[IN] ctxt	Per-xstream NVMe context
- *
- * \returns		0: If mo work was done
- *			1: If work was done
- *			-1: If thread has exited
- */
-int
-bio_nvme_poll(struct bio_xs_context *ctxt)
+inline struct spdk_thread *
+init_thread(void)
 {
+	return nvme_glb.bd_init_thread;
+}
 
-	uint64_t now = d_timeus_secdiff(0);
-	int rc;
+inline bool
+is_server_started(void)
+{
+	return nvme_glb.bd_started;
+}
 
-	/* NVMe context setup was skipped */
-	if (ctxt == NULL)
-		return 0;
-
-	rc = spdk_thread_poll(ctxt->bxc_thread, 0, 0);
-
-	/* Print SPDK I/O stats for each xstream */
-	bio_xs_io_stat(ctxt, now);
-
-	/*
-	 * Query and print the SPDK device health stats for only the device
-	 * owner xstream.
-	 */
-	if (ctxt->bxc_blobstore != NULL &&
-	    is_bbs_owner(ctxt, ctxt->bxc_blobstore))
-		bio_bs_monitor(ctxt, now);
-
-	return rc;
+static inline bool
+is_init_xstream(struct bio_xs_context *ctxt)
+{
+	D_ASSERT(ctxt != NULL);
+	return ctxt->bxc_thread == nvme_glb.bd_init_thread;
 }
 
 bool
@@ -611,27 +578,22 @@ void
 xs_poll_completion(struct bio_xs_context *ctxt, unsigned int *inflights)
 {
 	D_ASSERT(inflights != NULL);
+	D_ASSERT(ctxt != NULL);
 	/* Wait for the completion callback done */
-	while (*inflights != 0)
-		bio_nvme_poll(ctxt);
+	while (*inflights != 0) {
+		spdk_thread_poll(ctxt->bxc_thread, 0, 0);
+
+		/* Called by standalone VOS */
+		if (ctxt->bxc_tgt_id == -1)
+			bio_xs_io_stat(ctxt, d_timeus_secdiff(0));
+	}
 }
 
-int
-get_bdev_type(struct spdk_bdev *bdev)
-{
-	if (strcmp(spdk_bdev_get_product_name(bdev), "NVMe disk") == 0)
-		return BDEV_CLASS_NVME;
-	else if (strcmp(spdk_bdev_get_product_name(bdev), "Malloc disk") == 0)
-		return BDEV_CLASS_MALLOC;
-	else if (strcmp(spdk_bdev_get_product_name(bdev), "AIO disk") == 0)
-		return BDEV_CLASS_AIO;
-	else
-		return BDEV_CLASS_UNKNOWN;
-}
-
-static struct spdk_blob_store *
+struct spdk_blob_store *
 load_blobstore(struct bio_xs_context *ctxt, char *bdev_name, uuid_t *bs_uuid,
-	       bool create)
+	       bool create, bool async,
+	       void (*async_cb)(void *arg, struct spdk_blob_store *bs, int rc),
+	       void *async_arg)
 {
 	struct spdk_bdev_desc	*desc = NULL;
 	struct spdk_bs_dev	*bs_dev;
@@ -670,6 +632,17 @@ load_blobstore(struct bio_xs_context *ctxt, char *bdev_name, uuid_t *bs_uuid,
 	else
 		memcpy(bs_opts.bstype.bstype, bs_uuid,
 		       SPDK_BLOBSTORE_TYPE_LENGTH);
+
+	if (async) {
+		D_ASSERT(async_cb != NULL);
+
+		if (create)
+			spdk_bs_init(bs_dev, &bs_opts, async_cb, async_arg);
+		else
+			spdk_bs_load(bs_dev, &bs_opts, async_cb, async_arg);
+
+		return NULL;
+	}
 
 	common_prep_arg(&cp_arg);
 	if (create)
@@ -750,14 +723,125 @@ lookup_dev_by_id(uuid_t dev_id)
 	return NULL;
 }
 
+static struct bio_bdev *
+lookup_dev_by_name(const char *bdev_name)
+{
+	struct bio_bdev	*d_bdev;
+
+	d_list_for_each_entry(d_bdev, &nvme_glb.bd_bdevs, bb_link) {
+		if (strcmp(d_bdev->bb_name, bdev_name) == 0)
+			return d_bdev;
+	}
+	return NULL;
+}
+
+void
+bio_release_bdev(void *arg)
+{
+	struct bio_bdev	*d_bdev = arg;
+
+	if (!is_server_started()) {
+		D_INFO("Skip device release on server start/shutdown\n");
+		return;
+	}
+
+	D_ASSERT(d_bdev != NULL);
+	if (d_bdev->bb_desc == NULL)
+		return;
+
+	spdk_bdev_close(d_bdev->bb_desc);
+	d_bdev->bb_desc = NULL;
+}
+
+static void
+teardown_bio_bdev(void *arg)
+{
+	struct bio_bdev		*d_bdev = arg;
+	struct bio_blobstore	*bbs = d_bdev->bb_blobstore;
+	int			 rc;
+
+	if (!is_server_started()) {
+		D_INFO("Skip device teardown on server start/shutdown\n");
+		return;
+	}
+
+	switch (bbs->bb_state) {
+	case BIO_BS_STATE_NORMAL:
+	case BIO_BS_STATE_SETUP:
+		rc = bio_bs_state_set(bbs, BIO_BS_STATE_TEARDOWN);
+		D_ASSERT(rc == 0);
+		break;
+	case BIO_BS_STATE_FAULTY:
+	case BIO_BS_STATE_TEARDOWN:
+	case BIO_BS_STATE_OUT:
+		D_DEBUG(DB_MGMT, "Device "DF_UUID"(%s) is already in "
+			"%d state\n", d_bdev->bb_uuid, d_bdev->bb_name,
+			bbs->bb_state);
+		break;
+	default:
+		D_ERROR("Invalid BS state %d\n", bbs->bb_state);
+		break;
+	}
+}
+
 void
 bio_bdev_event_cb(enum spdk_bdev_event_type type, struct spdk_bdev *bdev,
 		  void *event_ctx)
 {
-	if (event_ctx == NULL)
+	struct bio_bdev		*d_bdev = event_ctx;
+	struct bio_blobstore	*bbs;
+
+	if (d_bdev == NULL)
 		return;
 
-	/* TODO: Process hot remove event */
+	D_DEBUG(DB_MGMT, "Got SPDK event(%d) for dev %s\n", type,
+		spdk_bdev_get_name(bdev));
+
+	if (type != SPDK_BDEV_EVENT_REMOVE)
+		return;
+
+	if (!is_server_started()) {
+		D_INFO("Skip device remove cb on server start/shutdown\n");
+		return;
+	}
+
+	D_ASSERT(d_bdev->bb_desc != NULL);
+	d_bdev->bb_removed = true;
+
+	/* The bio_bdev is still under construction */
+	if (d_list_empty(&d_bdev->bb_link)) {
+		D_ASSERT(d_bdev->bb_blobstore == NULL);
+		D_DEBUG(DB_MGMT, "bio_bdev for "DF_UUID"(%s) is still "
+			"under construction\n", DP_UUID(d_bdev->bb_uuid),
+			d_bdev->bb_name);
+		return;
+	}
+
+	bbs = d_bdev->bb_blobstore;
+	/* A new device isn't used by DAOS yet */
+	if (bbs == NULL) {
+		D_DEBUG(DB_MGMT, "Removed device "DF_UUID"(%s)\n",
+			DP_UUID(d_bdev->bb_uuid), d_bdev->bb_name);
+
+		d_list_del_init(&d_bdev->bb_link);
+		destroy_bio_bdev(d_bdev);
+		return;
+	}
+
+	spdk_thread_send_msg(owner_thread(bbs), teardown_bio_bdev, d_bdev);
+}
+
+static void
+replace_bio_bdev(struct bio_bdev *old_dev, struct bio_bdev *new_dev)
+{
+	old_dev->bb_removed = new_dev->bb_removed;
+
+	old_dev->bb_desc = new_dev->bb_desc;
+	new_dev->bb_desc = NULL;
+
+	D_FREE(old_dev->bb_name);
+	old_dev->bb_name = new_dev->bb_name;
+	new_dev->bb_name = NULL;
 }
 
 /*
@@ -769,15 +853,27 @@ bio_bdev_event_cb(enum spdk_bdev_event_type type, struct spdk_bdev *bdev,
  * xstream for this device hasn't been established yet.
  */
 static int
-create_bio_bdev(struct bio_xs_context *ctxt, struct spdk_bdev *bdev)
+create_bio_bdev(struct bio_xs_context *ctxt, const char *bdev_name,
+		struct bio_bdev **dev_out)
 {
-	struct bio_bdev			*d_bdev;
+	struct bio_bdev			*d_bdev, *old_dev;
 	struct spdk_blob_store		*bs = NULL;
 	struct spdk_bs_type		 bstype;
 	struct smd_dev_info		*dev_info;
 	uuid_t				 bs_uuid;
 	int				 rc;
 	bool				 new_bs = false;
+
+	/*
+	 * SPDK guarantees uniqueness of bdev name. When a device is hot
+	 * removed then plugged back to same slot, a new bdev with different
+	 * name will be generated.
+	 */
+	d_bdev = lookup_dev_by_name(bdev_name);
+	if (d_bdev != NULL) {
+		D_ERROR("Device %s is already created\n", bdev_name);
+		return -DER_EXIST;
+	}
 
 	D_ALLOC_PTR(d_bdev);
 	if (d_bdev == NULL) {
@@ -786,11 +882,9 @@ create_bio_bdev(struct bio_xs_context *ctxt, struct spdk_bdev *bdev)
 	}
 
 	D_INIT_LIST_HEAD(&d_bdev->bb_link);
-	D_STRNDUP(d_bdev->bb_name, spdk_bdev_get_name(bdev),
-		  strlen(spdk_bdev_get_name(bdev)));
+	D_STRNDUP(d_bdev->bb_name, bdev_name, strlen(bdev_name));
 	if (d_bdev->bb_name == NULL) {
-		D_ERROR("Failed to allocate bdev name for %s\n",
-			spdk_bdev_get_name(bdev));
+		D_ERROR("Failed to allocate bdev name for %s\n", bdev_name);
 		rc = -DER_NOMEM;
 		goto error;
 	}
@@ -799,7 +893,7 @@ create_bio_bdev(struct bio_xs_context *ctxt, struct spdk_bdev *bdev)
 	 * Hold the SPDK bdev by an open descriptor, otherwise, the bdev
 	 * could be deconstructed by SPDK on device hot remove.
 	 */
-	rc = spdk_bdev_open_ext(d_bdev->bb_name, true, bio_bdev_event_cb,
+	rc = spdk_bdev_open_ext(d_bdev->bb_name, false, bio_bdev_event_cb,
 				d_bdev, &d_bdev->bb_desc);
 	if (rc != 0) {
 		D_ERROR("Failed to hold bdev %s, %d\n", d_bdev->bb_name, rc);
@@ -809,13 +903,15 @@ create_bio_bdev(struct bio_xs_context *ctxt, struct spdk_bdev *bdev)
 
 	D_ASSERT(d_bdev->bb_desc != NULL);
 	/* Try to load blobstore without specifying 'bstype' first */
-	bs = load_blobstore(ctxt, d_bdev->bb_name, NULL, false);
+	bs = load_blobstore(ctxt, d_bdev->bb_name, NULL, false, false,
+			    NULL, NULL);
 	if (bs == NULL) {
 		D_DEBUG(DB_MGMT, "Creating bs for %s\n", d_bdev->bb_name);
 
 		/* Create blobstore if it wasn't created before */
 		uuid_generate(bs_uuid);
-		bs = load_blobstore(ctxt, d_bdev->bb_name, &bs_uuid, true);
+		bs = load_blobstore(ctxt, d_bdev->bb_name, &bs_uuid, true,
+				    false, NULL, NULL);
 		if (bs == NULL) {
 			D_ERROR("Failed to create blobstore on dev: "
 				""DF_UUID"\n", DP_UUID(bs_uuid));
@@ -846,10 +942,30 @@ create_bio_bdev(struct bio_xs_context *ctxt, struct spdk_bdev *bdev)
 	}
 
 	/* Verify if any duplicated device ID */
-	if (lookup_dev_by_id(bs_uuid) != NULL) {
-		D_ERROR("Dup device "DF_UUID" detected!\n", DP_UUID(bs_uuid));
-		rc = -DER_EXIST;
-		goto error;
+	old_dev = lookup_dev_by_id(bs_uuid);
+	if (old_dev != NULL) {
+		/* If it's in server xstreams start phase, report error */
+		if (!is_server_started()) {
+			D_ERROR("Dup device "DF_UUID" detected!\n",
+				DP_UUID(bs_uuid));
+			rc = -DER_EXIST;
+			goto error;
+		}
+		/* Old device is plugged back */
+		D_INFO("Device "DF_UUID" is plugged back\n", DP_UUID(bs_uuid));
+
+		if (old_dev->bb_desc != NULL) {
+			D_INFO("Device "DF_UUID"(%s) isn't torndown\n",
+			       DP_UUID(old_dev->bb_uuid), old_dev->bb_name);
+		} else {
+			replace_bio_bdev(old_dev, d_bdev);
+			/* Inform caller to trigger device setup */
+			D_ASSERT(dev_out != NULL);
+			*dev_out = old_dev;
+		}
+
+		destroy_bio_bdev(d_bdev);
+		return 0;
 	}
 
 	/* Find the initial target count per device */
@@ -858,8 +974,18 @@ create_bio_bdev(struct bio_xs_context *ctxt, struct spdk_bdev *bdev)
 		D_ASSERT(dev_info->sdi_tgt_cnt != 0);
 		d_bdev->bb_tgt_cnt = dev_info->sdi_tgt_cnt;
 		smd_free_dev_info(dev_info);
+		/*
+		 * Something went wrong in hotplug case: device ID is in SMD
+		 * but bio_bdev wasn't created on server start.
+		 */
+		if (is_server_started()) {
+			D_ERROR("bio_bdev for "DF_UUID" wasn't created?\n",
+				DP_UUID(bs_uuid));
+			rc = -DER_INVAL;
+			goto error;
+		}
 	} else if (rc == -DER_NONEXIST) {
-		/* device not present in table, first target mapped to dev */
+		/* Device isn't in SMD, not used by DAOS yet */
 		d_bdev->bb_tgt_cnt = 0;
 	} else {
 		D_ERROR("Unable to get dev info for "DF_UUID"\n",
@@ -885,6 +1011,7 @@ init_bio_bdevs(struct bio_xs_context *ctxt)
 	struct spdk_bdev *bdev;
 	int rc = 0;
 
+	D_ASSERT(!is_server_started());
 	if (spdk_bdev_first() == NULL) {
 		D_ERROR("No SPDK bdevs found!");
 		rc = -DER_NONEXIST;
@@ -895,7 +1022,7 @@ init_bio_bdevs(struct bio_xs_context *ctxt)
 		if (nvme_glb.bd_bdev_class != get_bdev_type(bdev))
 			continue;
 
-		rc = create_bio_bdev(ctxt, bdev);
+		rc = create_bio_bdev(ctxt, spdk_bdev_get_name(bdev), NULL);
 		if (rc)
 			break;
 	}
@@ -918,7 +1045,8 @@ put_bio_blobstore(struct bio_blobstore *bb, struct bio_xs_context *ctxt)
 	ABT_mutex_lock(bb->bb_mutex);
 	/* Unload the blobstore in the same xstream where it was loaded. */
 	if (is_bbs_owner(ctxt, bb) && bb->bb_bs != NULL) {
-		bs = bb->bb_bs;
+		if (!bb->bb_unloading)
+			bs = bb->bb_bs;
 		bb->bb_bs = NULL;
 	}
 
@@ -959,7 +1087,7 @@ fini_bio_bdevs(struct bio_xs_context *ctxt)
 }
 
 static struct bio_blobstore *
-alloc_bio_blobstore(struct bio_xs_context *ctxt)
+alloc_bio_blobstore(struct bio_xs_context *ctxt, struct bio_bdev *d_bdev)
 {
 	struct bio_blobstore	*bb;
 	int			 rc, xs_cnt_max = BIO_XS_CNT_MAX;
@@ -983,6 +1111,7 @@ alloc_bio_blobstore(struct bio_xs_context *ctxt)
 
 	bb->bb_ref = 0;
 	bb->bb_owner_xs = ctxt;
+	bb->bb_dev = d_bdev;
 	return bb;
 
 out_mutex:
@@ -1131,7 +1260,7 @@ retry:
 	 * set current xstream as bbs owner.
 	 */
 	if (d_bdev->bb_blobstore == NULL) {
-		d_bdev->bb_blobstore = alloc_bio_blobstore(ctxt);
+		d_bdev->bb_blobstore = alloc_bio_blobstore(ctxt, d_bdev);
 		if (d_bdev->bb_blobstore == NULL) {
 			rc = -DER_NOMEM;
 			goto out;
@@ -1175,7 +1304,7 @@ retry:
 
 		/* Load blobstore with bstype specified for sanity check */
 		bs = load_blobstore(ctxt, d_bdev->bb_name, &d_bdev->bb_uuid,
-				    false);
+				    false, false, NULL, NULL);
 		if (bs == NULL) {
 			rc = -DER_INVAL;
 			goto out;
@@ -1252,7 +1381,7 @@ bio_xsctxt_free(struct bio_xs_context *ctxt)
 	nvme_glb.bd_xstream_cnt--;
 
 	if (nvme_glb.bd_init_thread != NULL) {
-		if (nvme_glb.bd_init_thread == ctxt->bxc_thread) {
+		if (is_init_xstream(ctxt)) {
 			struct common_cp_arg	cp_arg;
 
 			/*
@@ -1408,5 +1537,200 @@ out:
 		bio_xsctxt_free(ctxt);
 
 	*pctxt = (rc != 0) ? NULL : ctxt;
+	return rc;
+}
+
+int
+bio_nvme_ctl(unsigned int cmd, void *arg)
+{
+	int	rc = 0;
+
+	switch (cmd) {
+	case BIO_CTL_NOTIFY_STARTED:
+		ABT_mutex_lock(nvme_glb.bd_mutex);
+		nvme_glb.bd_started = *((bool *)arg);
+		ABT_mutex_unlock(nvme_glb.bd_mutex);
+		break;
+	default:
+		D_ERROR("Invalid ctl cmd %d\n", cmd);
+		rc = -DER_INVAL;
+		break;
+	}
+	return rc;
+}
+
+static void
+setup_bio_bdev(void *arg)
+{
+	struct smd_dev_info	*dev_info;
+	struct bio_bdev		*d_bdev = arg;
+	struct bio_blobstore	*bbs = d_bdev->bb_blobstore;
+	int			 rc;
+
+	if (!is_server_started()) {
+		D_INFO("Skip device setup on server start/shutdown\n");
+		return;
+	}
+
+	D_ASSERT(bbs->bb_state == BIO_BS_STATE_OUT);
+
+	rc = smd_dev_get_by_id(d_bdev->bb_uuid, &dev_info);
+	if (rc != 0) {
+		D_ERROR("Original dev "DF_UUID" not in SMD. "DF_RC"\n",
+			DP_UUID(d_bdev->bb_uuid), DP_RC(rc));
+		return;
+	}
+
+	if (dev_info->sdi_state == SMD_DEV_FAULTY) {
+		D_INFO("Faulty dev "DF_UUID" is plugged back\n",
+		       DP_UUID(d_bdev->bb_uuid));
+		goto out;
+	} else if (dev_info->sdi_state != SMD_DEV_NORMAL) {
+		D_ERROR("Invalid dev state %d\n", dev_info->sdi_state);
+		goto out;
+	}
+
+	rc = bio_bs_state_set(bbs, BIO_BS_STATE_SETUP);
+	D_ASSERT(rc == 0);
+out:
+	smd_free_dev_info(dev_info);
+}
+
+/*
+ * Scan the SPDK bdev list and compare it with bio_bdev list to see if any
+ * device is hot plugged. This function is periodically called by the 'init'
+ * xstream, be careful on using mutex or any blocking functions, that could
+ * block the NVMe poll and lead to deadlock at the end.
+ */
+static void
+scan_bio_bdevs(struct bio_xs_context *ctxt, uint64_t now)
+{
+	struct bio_blobstore	*bbs;
+	struct bio_bdev		*d_bdev, *tmp;
+	struct spdk_bdev	*bdev;
+	static uint64_t		 scan_period = NVME_MONITOR_PERIOD;
+	int			 rc;
+
+	if (nvme_glb.bd_scan_age + scan_period >= now)
+		return;
+
+	/* Iterate SPDK bdevs to detect hot plugged device */
+	for (bdev = spdk_bdev_first(); bdev != NULL;
+	     bdev = spdk_bdev_next(bdev)) {
+		if (nvme_glb.bd_bdev_class != get_bdev_type(bdev))
+			continue;
+
+		d_bdev = lookup_dev_by_name(spdk_bdev_get_name(bdev));
+		if (d_bdev != NULL)
+			continue;
+
+		D_INFO("Detected hot plugged device %s\n",
+		       spdk_bdev_get_name(bdev));
+
+		scan_period = 0;
+
+		rc = create_bio_bdev(ctxt, spdk_bdev_get_name(bdev), &d_bdev);
+		if (rc) {
+			D_ERROR("Failed to init hot plugged device %s\n",
+				spdk_bdev_get_name(bdev));
+			break;
+		}
+
+		/*
+		 * The plugged device is a new device, or teardown procedure for
+		 * old bio_bdev isn't finished.
+		 */
+		if (d_bdev == NULL)
+			continue;
+
+		D_ASSERT(d_bdev->bb_desc != NULL);
+		bbs = d_bdev->bb_blobstore;
+		/* The device isn't used by DAOS yet */
+		if (bbs == NULL) {
+			D_INFO("New device "DF_UUID" is plugged back\n",
+			       DP_UUID(d_bdev->bb_uuid));
+			continue;
+		}
+
+		spdk_thread_send_msg(owner_thread(bbs), setup_bio_bdev, d_bdev);
+	}
+
+	/* Iterate bio_bdev list to trigger teardown on hot removed device */
+	d_list_for_each_entry_safe(d_bdev, tmp, &nvme_glb.bd_bdevs, bb_link) {
+		/* Device isn't removed */
+		if (!d_bdev->bb_removed)
+			continue;
+
+		bbs = d_bdev->bb_blobstore;
+		/* Device not used by DAOS */
+		if (bbs == NULL) {
+			D_DEBUG(DB_MGMT, "Removed device "DF_UUID"(%s)\n",
+				DP_UUID(d_bdev->bb_uuid), d_bdev->bb_name);
+			d_list_del_init(&d_bdev->bb_link);
+			destroy_bio_bdev(d_bdev);
+			continue;
+		}
+
+		/* Device is already torndown */
+		if (d_bdev->bb_desc == NULL)
+			continue;
+
+		scan_period = 0;
+		spdk_thread_send_msg(owner_thread(bbs), teardown_bio_bdev,
+				     d_bdev);
+	}
+
+	if (scan_period == 0)
+		scan_period = NVME_MONITOR_SHORT_PERIOD;
+	else
+		scan_period = NVME_MONITOR_PERIOD;
+
+	nvme_glb.bd_scan_age = now;
+}
+
+/*
+ * Execute the messages on msg ring, call all registered pollers.
+ *
+ * \param[IN] ctxt	Per-xstream NVMe context
+ *
+ * \returns		0: If mo work was done
+ *			1: If work was done
+ *			-1: If thread has exited
+ */
+int
+bio_nvme_poll(struct bio_xs_context *ctxt)
+{
+
+	uint64_t now = d_timeus_secdiff(0);
+	int rc;
+
+	/* NVMe context setup was skipped */
+	if (ctxt == NULL)
+		return 0;
+
+	rc = spdk_thread_poll(ctxt->bxc_thread, 0, 0);
+
+	/* Print SPDK I/O stats for each xstream */
+	bio_xs_io_stat(ctxt, now);
+
+	/* To avoid complicated race handling (init xstream and starting
+	 * VOS xstream concurrently access global device list & xstream
+	 * context array), we just simply disable faulty device detection
+	 * and hot remove/plug processing during server start/shutdown.
+	 */
+	if (!is_server_started())
+		return 0;
+
+	/*
+	 * Query and print the SPDK device health stats for only the device
+	 * owner xstream.
+	 */
+	if (ctxt->bxc_blobstore != NULL &&
+	    is_bbs_owner(ctxt, ctxt->bxc_blobstore))
+		bio_bs_monitor(ctxt, now);
+
+	if (is_init_xstream(ctxt))
+		scan_bio_bdevs(ctxt, now);
+
 	return rc;
 }

--- a/src/include/daos_srv/bio.h
+++ b/src/include/daos_srv/bio.h
@@ -362,6 +362,21 @@ int bio_nvme_init(const char *storage_path, const char *nvme_conf, int shm_id,
  */
 void bio_nvme_fini(void);
 
+enum {
+	/* Notify BIO that all xsxtream contexts created */
+	BIO_CTL_NOTIFY_STARTED	= 0,
+};
+
+/**
+ * Manipulate global NVMe configuration/state.
+ *
+ * \param[IN] cmd	Ctl command
+ * \param[IN] arg	Ctl argument
+ *
+ * \return		Zero on success, negative value on error
+ */
+int bio_nvme_ctl(unsigned int cmd, void *arg);
+
 /*
  * Initialize SPDK env and per-xstream NVMe context.
  *

--- a/src/iosrv/srv.c
+++ b/src/iosrv/srv.c
@@ -800,9 +800,12 @@ dss_xstreams_fini(bool force)
 	struct dss_xstream	*dx;
 	int			 i;
 	int			 rc;
+	bool			 started = false;
 
 	D_DEBUG(DB_TRACE, "Stopping execution streams\n");
 	dss_xstreams_open_barrier();
+	rc = bio_nvme_ctl(BIO_CTL_NOTIFY_STARTED, &started);
+	D_ASSERT(rc == 0);
 
 	/** Stop & free progress ULTs */
 	for (i = 0; i < xstream_data.xd_xs_nr; i++) {
@@ -1201,6 +1204,7 @@ int
 dss_srv_init()
 {
 	int	rc;
+	bool	started = true;
 
 	xstream_data.xd_init_step  = XD_INIT_NONE;
 	xstream_data.xd_ult_signal = false;
@@ -1248,6 +1252,9 @@ dss_srv_init()
 
 	if (rc != 0)
 		D_GOTO(failed, rc);
+
+	rc = bio_nvme_ctl(BIO_CTL_NOTIFY_STARTED, &started);
+	D_ASSERT(rc == 0);
 
 	/* start up drpc listener */
 	rc = drpc_listener_init();


### PR DESCRIPTION
- Init thread periodically calls scan_bio_bdevs() to compare SPDK
  bdev list with bio_bdev list to see if any new plugged device in
  SPDK bdev list not present in bio_bdev list. If any new plugged
  device detected, update the bio_bdev list then trigger blobstore
  setup accordingly.

- Implemented SPDK bdev remove callback bio_bdev_event_cb() to
  trigger blobstore teardown properly.

- Introduced bio_nvme_ctl(), so that caller may notify BIO whether
  all VOS xstreams are started via this interface. To avoid race of
  accessing global BIO resource, the hot remove/plug processing
  should be disabled during server start/shutdown.

- Minor updates to blobstore state machine to ensure the state
  transition happens only when the prior state reaction is finished
  (doesn't support abort reaction so far). Race handling code is
  also adjusted a bit.

- Implemented BS SETUP state reaction to load blobstore, open all
  existing blobs.

Signed-off-by: Niu Yawei <yawei.niu@intel.com>