### PR TITLE
DAOS-5625 object: check req_tgts

### DIFF
--- a/src/object/cli_obj.c
+++ b/src/object/cli_obj.c
@@ -3263,6 +3263,7 @@ obj_comp_cb(tse_task_t *task, void *data)
 	}
 
 	if (obj->cob_time_fetch_leader != NULL &&
+	    obj_auxi->req_tgts.ort_shard_tgts != NULL &&
 	    ((!obj_is_modification_opc(obj_auxi->opc) &&
 	      task->dt_result == -DER_INPROGRESS) ||
 	     (obj_is_modification_opc(obj_auxi->opc) &&


### PR DESCRIPTION
Check req_tgts before set coarse time, in case
the req_tgts are not set for the operation.

Signed-off-by: Di Wang <di.wang@intel.com>