### PR TITLE
DAOS-5649 control: Add harness.CallDrpc method

### DIFF
--- a/src/control/server/harness.go
+++ b/src/control/server/harness.go
@@ -28,8 +28,10 @@ import (
 	"sync"
 	"time"
 
+	"github.com/golang/protobuf/proto"
 	"github.com/pkg/errors"
 
+	"github.com/daos-stack/daos/src/control/drpc"
 	"github.com/daos-stack/daos/src/control/lib/atm"
 	"github.com/daos-stack/daos/src/control/logging"
 	"github.com/daos-stack/daos/src/control/system"
@@ -112,9 +114,19 @@ func (h *IOServerHarness) AddInstance(srv *IOServerInstance) error {
 	return nil
 }
 
-// GetMSLeaderInstance returns a managed IO Server instance to be used as a
+// CallDrpc calls the supplied dRPC method on a managed I/O server instance.
+func (h *IOServerHarness) CallDrpc(method drpc.Method, body proto.Message) (*drpc.Response, error) {
+	mi, err := h.getMSLeaderInstance()
+	if err != nil {
+		return nil, err
+	}
+
+	return mi.CallDrpc(method, body)
+}
+
+// getMSLeaderInstance returns a managed IO Server instance to be used as a
 // management target and fails if selected instance is not MS Leader.
-func (h *IOServerHarness) GetMSLeaderInstance() (*IOServerInstance, error) {
+func (h *IOServerHarness) getMSLeaderInstance() (*IOServerInstance, error) {
 	if !h.isStarted() {
 		return nil, FaultHarnessNotStarted
 	}

--- a/src/control/server/harness_test.go
+++ b/src/control/server/harness_test.go
@@ -152,7 +152,7 @@ func TestServer_HarnessGetMSLeaderInstance(t *testing.T) {
 			}
 			h.started.SetTrue()
 
-			_, err := h.GetMSLeaderInstance()
+			_, err := h.getMSLeaderInstance()
 			CmpErr(t, tc.expError, err)
 		})
 	}

--- a/src/control/server/instance_superblock_test.go
+++ b/src/control/server/instance_superblock_test.go
@@ -102,7 +102,7 @@ func TestServer_Instance_createSuperblock(t *testing.T) {
 	}
 
 	h.started.SetTrue()
-	mi, err := h.GetMSLeaderInstance()
+	mi, err := h.getMSLeaderInstance()
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/src/control/server/mgmt_pool.go
+++ b/src/control/server/mgmt_pool.go
@@ -55,7 +55,7 @@ func (svc *mgmtSvc) PoolCreate(ctx context.Context, req *mgmtpb.PoolCreateReq) (
 
 	svc.log.Debugf("MgmtSvc.PoolCreate dispatch, req:%+v\n", *req)
 
-	mi, err := svc.harness.GetMSLeaderInstance()
+	mi, err := svc.harness.getMSLeaderInstance()
 	if err != nil {
 		return nil, err
 	}
@@ -79,7 +79,7 @@ func (svc *mgmtSvc) PoolCreate(ctx context.Context, req *mgmtpb.PoolCreateReq) (
 		default:
 		}
 
-		dresp, err := mi.CallDrpc(drpc.MethodPoolCreate, req)
+		dresp, err := svc.harness.CallDrpc(drpc.MethodPoolCreate, req)
 		if err != nil {
 			return nil, err
 		}
@@ -121,12 +121,7 @@ func (svc *mgmtSvc) PoolDestroy(ctx context.Context, req *mgmtpb.PoolDestroyReq)
 
 	svc.log.Debugf("MgmtSvc.PoolDestroy dispatch, req:%+v\n", *req)
 
-	mi, err := svc.harness.GetMSLeaderInstance()
-	if err != nil {
-		return nil, err
-	}
-
-	dresp, err := mi.CallDrpc(drpc.MethodPoolDestroy, req)
+	dresp, err := svc.harness.CallDrpc(drpc.MethodPoolDestroy, req)
 	if err != nil {
 		return nil, err
 	}
@@ -152,12 +147,7 @@ func (svc *mgmtSvc) PoolEvict(ctx context.Context, req *mgmtpb.PoolEvictReq) (*m
 
 	svc.log.Debugf("MgmtSvc.PoolEvict dispatch, req:%+v\n", *req)
 
-	mi, err := svc.harness.GetMSLeaderInstance()
-	if err != nil {
-		return nil, err
-	}
-
-	dresp, err := mi.CallDrpc(drpc.MethodPoolEvict, req)
+	dresp, err := svc.harness.CallDrpc(drpc.MethodPoolEvict, req)
 	if err != nil {
 		return nil, err
 	}
@@ -184,12 +174,7 @@ func (svc *mgmtSvc) PoolExclude(ctx context.Context, req *mgmtpb.PoolExcludeReq)
 
 	svc.log.Debugf("MgmtSvc.PoolExclude dispatch, req:%+v\n", *req)
 
-	mi, err := svc.harness.GetMSLeaderInstance()
-	if err != nil {
-		return nil, err
-	}
-
-	dresp, err := mi.CallDrpc(drpc.MethodPoolExclude, req)
+	dresp, err := svc.harness.CallDrpc(drpc.MethodPoolExclude, req)
 	if err != nil {
 		return nil, err
 	}
@@ -216,12 +201,7 @@ func (svc *mgmtSvc) PoolDrain(ctx context.Context, req *mgmtpb.PoolDrainReq) (*m
 
 	svc.log.Debugf("MgmtSvc.PoolDrain dispatch, req:%+v\n", *req)
 
-	mi, err := svc.harness.GetMSLeaderInstance()
-	if err != nil {
-		return nil, err
-	}
-
-	dresp, err := mi.CallDrpc(drpc.MethodPoolDrain, req)
+	dresp, err := svc.harness.CallDrpc(drpc.MethodPoolDrain, req)
 	if err != nil {
 		return nil, err
 	}
@@ -247,12 +227,7 @@ func (svc *mgmtSvc) PoolExtend(ctx context.Context, req *mgmtpb.PoolExtendReq) (
 
 	svc.log.Debugf("MgmtSvc.PoolExtend dispatch, req:%+v\n", *req)
 
-	mi, err := svc.harness.GetMSLeaderInstance()
-	if err != nil {
-		return nil, err
-	}
-
-	dresp, err := mi.CallDrpc(drpc.MethodPoolExtend, req)
+	dresp, err := svc.harness.CallDrpc(drpc.MethodPoolExtend, req)
 	if err != nil {
 		return nil, err
 	}
@@ -279,12 +254,7 @@ func (svc *mgmtSvc) PoolReintegrate(ctx context.Context, req *mgmtpb.PoolReinteg
 
 	svc.log.Debugf("MgmtSvc.PoolReintegrate dispatch, req:%+v\n", *req)
 
-	mi, err := svc.harness.GetMSLeaderInstance()
-	if err != nil {
-		return nil, err
-	}
-
-	dresp, err := mi.CallDrpc(drpc.MethodPoolReintegrate, req)
+	dresp, err := svc.harness.CallDrpc(drpc.MethodPoolReintegrate, req)
 	if err != nil {
 		return nil, err
 	}
@@ -307,12 +277,7 @@ func (svc *mgmtSvc) PoolQuery(ctx context.Context, req *mgmtpb.PoolQueryReq) (*m
 
 	svc.log.Debugf("MgmtSvc.PoolQuery dispatch, req:%+v\n", *req)
 
-	mi, err := svc.harness.GetMSLeaderInstance()
-	if err != nil {
-		return nil, err
-	}
-
-	dresp, err := mi.CallDrpc(drpc.MethodPoolQuery, req)
+	dresp, err := svc.harness.CallDrpc(drpc.MethodPoolQuery, req)
 	if err != nil {
 		return nil, err
 	}
@@ -360,11 +325,6 @@ func resolvePoolPropVal(req *mgmtpb.PoolSetPropReq) (*mgmtpb.PoolSetPropReq, err
 func (svc *mgmtSvc) PoolSetProp(ctx context.Context, req *mgmtpb.PoolSetPropReq) (*mgmtpb.PoolSetPropResp, error) {
 	svc.log.Debugf("MgmtSvc.PoolSetProp dispatch, req:%+v", *req)
 
-	mi, err := svc.harness.GetMSLeaderInstance()
-	if err != nil {
-		return nil, err
-	}
-
 	newReq, err := resolvePoolPropVal(req)
 	if err != nil {
 		return nil, err
@@ -372,7 +332,7 @@ func (svc *mgmtSvc) PoolSetProp(ctx context.Context, req *mgmtpb.PoolSetPropReq)
 
 	svc.log.Debugf("MgmtSvc.PoolSetProp dispatch, req (converted):%+v", *newReq)
 
-	dresp, err := mi.CallDrpc(drpc.MethodPoolSetProp, newReq)
+	dresp, err := svc.harness.CallDrpc(drpc.MethodPoolSetProp, newReq)
 	if err != nil {
 		return nil, err
 	}
@@ -409,12 +369,7 @@ func (svc *mgmtSvc) PoolSetProp(ctx context.Context, req *mgmtpb.PoolSetPropReq)
 func (svc *mgmtSvc) PoolGetACL(ctx context.Context, req *mgmtpb.GetACLReq) (*mgmtpb.ACLResp, error) {
 	svc.log.Debugf("MgmtSvc.PoolGetACL dispatch, req:%+v\n", *req)
 
-	mi, err := svc.harness.GetMSLeaderInstance()
-	if err != nil {
-		return nil, err
-	}
-
-	dresp, err := mi.CallDrpc(drpc.MethodPoolGetACL, req)
+	dresp, err := svc.harness.CallDrpc(drpc.MethodPoolGetACL, req)
 	if err != nil {
 		return nil, err
 	}
@@ -433,12 +388,7 @@ func (svc *mgmtSvc) PoolGetACL(ctx context.Context, req *mgmtpb.GetACLReq) (*mgm
 func (svc *mgmtSvc) PoolOverwriteACL(ctx context.Context, req *mgmtpb.ModifyACLReq) (*mgmtpb.ACLResp, error) {
 	svc.log.Debugf("MgmtSvc.PoolOverwriteACL dispatch, req:%+v\n", *req)
 
-	mi, err := svc.harness.GetMSLeaderInstance()
-	if err != nil {
-		return nil, err
-	}
-
-	dresp, err := mi.CallDrpc(drpc.MethodPoolOverwriteACL, req)
+	dresp, err := svc.harness.CallDrpc(drpc.MethodPoolOverwriteACL, req)
 	if err != nil {
 		return nil, err
 	}
@@ -458,12 +408,7 @@ func (svc *mgmtSvc) PoolOverwriteACL(ctx context.Context, req *mgmtpb.ModifyACLR
 func (svc *mgmtSvc) PoolUpdateACL(ctx context.Context, req *mgmtpb.ModifyACLReq) (*mgmtpb.ACLResp, error) {
 	svc.log.Debugf("MgmtSvc.PoolUpdateACL dispatch, req:%+v\n", *req)
 
-	mi, err := svc.harness.GetMSLeaderInstance()
-	if err != nil {
-		return nil, err
-	}
-
-	dresp, err := mi.CallDrpc(drpc.MethodPoolUpdateACL, req)
+	dresp, err := svc.harness.CallDrpc(drpc.MethodPoolUpdateACL, req)
 	if err != nil {
 		return nil, err
 	}
@@ -483,12 +428,7 @@ func (svc *mgmtSvc) PoolUpdateACL(ctx context.Context, req *mgmtpb.ModifyACLReq)
 func (svc *mgmtSvc) PoolDeleteACL(ctx context.Context, req *mgmtpb.DeleteACLReq) (*mgmtpb.ACLResp, error) {
 	svc.log.Debugf("MgmtSvc.PoolDeleteACL dispatch, req:%+v\n", *req)
 
-	mi, err := svc.harness.GetMSLeaderInstance()
-	if err != nil {
-		return nil, err
-	}
-
-	dresp, err := mi.CallDrpc(drpc.MethodPoolDeleteACL, req)
+	dresp, err := svc.harness.CallDrpc(drpc.MethodPoolDeleteACL, req)
 	if err != nil {
 		return nil, err
 	}
@@ -508,12 +448,7 @@ func (svc *mgmtSvc) PoolDeleteACL(ctx context.Context, req *mgmtpb.DeleteACLReq)
 func (svc *mgmtSvc) ListPools(ctx context.Context, req *mgmtpb.ListPoolsReq) (*mgmtpb.ListPoolsResp, error) {
 	svc.log.Debugf("MgmtSvc.ListPools dispatch, req:%+v\n", *req)
 
-	mi, err := svc.harness.GetMSLeaderInstance()
-	if err != nil {
-		return nil, err
-	}
-
-	dresp, err := mi.CallDrpc(drpc.MethodListPools, req)
+	dresp, err := svc.harness.CallDrpc(drpc.MethodListPools, req)
 	if err != nil {
 		return nil, err
 	}

--- a/src/control/server/mgmt_pool_test.go
+++ b/src/control/server/mgmt_pool_test.go
@@ -175,7 +175,7 @@ func TestServer_MgmtSvc_PoolCreate(t *testing.T) {
 			}
 			tc.mgmtSvc.log = log
 
-			if _, err := tc.mgmtSvc.harness.GetMSLeaderInstance(); err == nil {
+			if _, err := tc.mgmtSvc.harness.getMSLeaderInstance(); err == nil {
 				if tc.setupMockDrpc == nil {
 					tc.setupMockDrpc = func(svc *mgmtSvc, err error) {
 						setupMockDrpcClient(tc.mgmtSvc, tc.expResp, tc.expErr)
@@ -261,7 +261,7 @@ func TestServer_MgmtSvc_PoolDestroy(t *testing.T) {
 			}
 			tc.mgmtSvc.log = log
 
-			if _, err := tc.mgmtSvc.harness.GetMSLeaderInstance(); err == nil {
+			if _, err := tc.mgmtSvc.harness.getMSLeaderInstance(); err == nil {
 				if tc.setupMockDrpc == nil {
 					tc.setupMockDrpc = func(svc *mgmtSvc, err error) {
 						setupMockDrpcClient(tc.mgmtSvc, tc.expResp, tc.expErr)
@@ -345,7 +345,7 @@ func TestServer_MgmtSvc_PoolDrain(t *testing.T) {
 			}
 			tc.mgmtSvc.log = log
 
-			if _, err := tc.mgmtSvc.harness.GetMSLeaderInstance(); err == nil {
+			if _, err := tc.mgmtSvc.harness.getMSLeaderInstance(); err == nil {
 				if tc.setupMockDrpc == nil {
 					tc.setupMockDrpc = func(svc *mgmtSvc, err error) {
 						setupMockDrpcClient(tc.mgmtSvc, tc.expResp, tc.expErr)
@@ -429,7 +429,7 @@ func TestServer_MgmtSvc_PoolEvict(t *testing.T) {
 			}
 			tc.mgmtSvc.log = log
 
-			if _, err := tc.mgmtSvc.harness.GetMSLeaderInstance(); err == nil {
+			if _, err := tc.mgmtSvc.harness.getMSLeaderInstance(); err == nil {
 				if tc.setupMockDrpc == nil {
 					tc.setupMockDrpc = func(svc *mgmtSvc, err error) {
 						setupMockDrpcClient(tc.mgmtSvc, tc.expResp, tc.expErr)
@@ -915,7 +915,7 @@ func TestServer_MgmtSvc_PoolQuery(t *testing.T) {
 			}
 			tc.mgmtSvc.log = log
 
-			if _, err := tc.mgmtSvc.harness.GetMSLeaderInstance(); err == nil {
+			if _, err := tc.mgmtSvc.harness.getMSLeaderInstance(); err == nil {
 				if tc.setupMockDrpc == nil {
 					tc.setupMockDrpc = func(svc *mgmtSvc, err error) {
 						setupMockDrpcClient(tc.mgmtSvc, tc.expResp, tc.expErr)
@@ -955,7 +955,7 @@ func TestServer_MgmtSvc_PoolSetProp(t *testing.T) {
 		return r
 	}
 	lastCall := func(svc *mgmtSvc) *drpc.Call {
-		mi, _ := svc.harness.GetMSLeaderInstance()
+		mi, _ := svc.harness.getMSLeaderInstance()
 		if mi == nil || mi._drpcClient == nil {
 			return nil
 		}

--- a/src/control/server/mgmt_svc.go
+++ b/src/control/server/mgmt_svc.go
@@ -164,12 +164,7 @@ func (svc *mgmtSvc) GetAttachInfo(ctx context.Context, req *mgmtpb.GetAttachInfo
 		return nil, errors.New("clientNetworkCfg is missing")
 	}
 
-	mi, err := svc.harness.GetMSLeaderInstance()
-	if err != nil {
-		return nil, err
-	}
-
-	dresp, err := mi.CallDrpc(drpc.MethodGetAttachInfo, req)
+	dresp, err := svc.harness.CallDrpc(drpc.MethodGetAttachInfo, req)
 	if err != nil {
 		return nil, err
 	}
@@ -493,12 +488,7 @@ func (svc *mgmtSvc) SmdQuery(ctx context.Context, req *mgmtpb.SmdQueryReq) (*mgm
 func (svc *mgmtSvc) ListContainers(ctx context.Context, req *mgmtpb.ListContReq) (*mgmtpb.ListContResp, error) {
 	svc.log.Debugf("MgmtSvc.ListContainers dispatch, req:%+v\n", *req)
 
-	mi, err := svc.harness.GetMSLeaderInstance()
-	if err != nil {
-		return nil, err
-	}
-
-	dresp, err := mi.CallDrpc(drpc.MethodListContainers, req)
+	dresp, err := svc.harness.CallDrpc(drpc.MethodListContainers, req)
 	if err != nil {
 		return nil, err
 	}
@@ -517,12 +507,7 @@ func (svc *mgmtSvc) ListContainers(ctx context.Context, req *mgmtpb.ListContReq)
 func (svc *mgmtSvc) ContSetOwner(ctx context.Context, req *mgmtpb.ContSetOwnerReq) (*mgmtpb.ContSetOwnerResp, error) {
 	svc.log.Debugf("MgmtSvc.ContSetOwner dispatch, req:%+v\n", *req)
 
-	mi, err := svc.harness.GetMSLeaderInstance()
-	if err != nil {
-		return nil, err
-	}
-
-	dresp, err := mi.CallDrpc(drpc.MethodContSetOwner, req)
+	dresp, err := svc.harness.CallDrpc(drpc.MethodContSetOwner, req)
 	if err != nil {
 		return nil, err
 	}

--- a/src/control/server/mgmt_system.go
+++ b/src/control/server/mgmt_system.go
@@ -124,12 +124,7 @@ func (svc *mgmtSvc) Join(ctx context.Context, req *mgmtpb.JoinReq) (*mgmtpb.Join
 			"combining peer addr with listener port")
 	}
 
-	mi, err := svc.harness.GetMSLeaderInstance()
-	if err != nil {
-		return nil, err
-	}
-
-	dresp, err := mi.CallDrpc(drpc.MethodJoin, req)
+	dresp, err := svc.harness.CallDrpc(drpc.MethodJoin, req)
 	if err != nil {
 		return nil, err
 	}

--- a/src/control/server/test_utils.go
+++ b/src/control/server/test_utils.go
@@ -145,7 +145,7 @@ func newMockDrpcClient(cfg *mockDrpcClientConfig) *mockDrpcClient {
 // setupMockDrpcClientBytes sets up the dRPC client for the mgmtSvc to return
 // a set of bytes as a response.
 func setupMockDrpcClientBytes(svc *mgmtSvc, respBytes []byte, err error) {
-	mi, _ := svc.harness.GetMSLeaderInstance()
+	mi, _ := svc.harness.getMSLeaderInstance()
 
 	cfg := &mockDrpcClientConfig{}
 	cfg.setSendMsgResponse(drpc.Status_SUCCESS, respBytes, err)


### PR DESCRIPTION
Reduces boilerplate in the server gRPC handlers and hides
the instance selection logic from callers that don't need
to know about it.