### PR TITLE
DAOS-5641 dfs: return ENOENT if moved source does not exist

### DIFF
--- a/src/client/dfs/dfs.c
+++ b/src/client/dfs/dfs.c
@@ -3423,7 +3423,7 @@ restart:
 		D_GOTO(out, rc);
 	}
 	if (exists == false)
-		D_GOTO(out, rc);
+		D_GOTO(out, rc = ENOENT);
 
 	rc = fetch_entry(new_parent->oh, th, new_name, true, &exists,
 			 &new_entry);

--- a/src/tests/suite/dfs_test.c
+++ b/src/tests/suite/dfs_test.c
@@ -569,6 +569,7 @@ dfs_test_cond(void **state)
 		rc = dfs_release(file);
 		assert_int_equal(rc, 0);
 	}
+	MPI_Barrier(MPI_COMM_WORLD);
 
 	char newfilename[1024];
 


### PR DESCRIPTION
If the file or directory (to be moved) does not exist, dfs
should return ENOENT instead of zero.

This patch also adds MPI_Barrier() in dfs tests to guarantee
that all ranks will try to rename the same file after it has
been created.

Signed-off-by: Fan Yong <fan.yong@intel.com>