### PR TITLE
Add QAT support for multihash

### DIFF
--- a/src/common/SConscript
+++ b/src/common/SConscript
@@ -22,14 +22,24 @@ def scons():
 
     prereqs.require(denv, 'protobufc')
     denv.AppendUnique(LIBS=['cart', 'gurt'])
+
+    # TODO: need add qat dependency
+    #denv.AppendUnique(CPPDEFINES =['-DHAVE_QAT'])
+    #denv.AppendUnique(LIBS=['qat_s'])
+    #denv.AppendUnique(CPPPATH=['$ICP_ROOT/quickassist/include/',
+    #    '$ICP_ROOT/quickassist/include/lac', 
+    #    '$ICP_ROOT/quickassist/include/dc',
+    #    '$ICP_ROOT/quickassist/lookaside/access_layer/include', 
+    #    '$ICP_ROOT/quickassist/utilities/libusdm_drv/'])
+    
     common_src = ['debug.c', 'mem.c', 'fail_loc.c', 'lru.c',
                   'misc.c', 'pool_map.c', 'sort.c', 'btree.c', 'prop.c',
                   'btree_class.c', 'tse.c', 'rsvc.c', 'checksum.c',
                   'drpc.c', 'drpc.pb-c.c', 'proc.c',
                   'acl_api.c', 'acl_util.c', 'acl_principal.c', 'cont_props.c',
                   'dedup.c', 'profile.c', 'compression.c', 'compression_isal.c',
-                  'multihash.c', 'multihash_isal.c', 'cipher.c',
-                  'cipher_isal.c']
+                  'multihash.c', 'multihash_isal.c', 'multihash_qat.c', 'cipher.c',
+                  'cipher_isal.c', 'qat.c']
 
     common = daos_build.library(denv, 'libdaos_common', common_src)
     denv.Install('$PREFIX/lib64/', common)

--- a/src/common/multihash.c
+++ b/src/common/multihash.c
@@ -36,6 +36,7 @@
 
 /** ISA-L hash function table implemented in multihash_isal.c */
 extern struct hash_ft *isal_hash_algo_table[];
+extern struct hash_ft *qat_hash_algo_table[];
 
 /** Container Property knowledge */
 enum DAOS_HASH_TYPE
@@ -86,14 +87,17 @@ daos_hashtype2contprop(enum DAOS_HASH_TYPE daos_hash_type)
  * and other accelerator support.
  */
 static struct hash_ft **algo_table = isal_hash_algo_table;
-
+static struct hash_ft **qat_algo_table = qat_hash_algo_table;
 struct hash_ft *
 daos_mhash_type2algo(enum DAOS_HASH_TYPE type)
 {
 	struct hash_ft *result = NULL;
 
 	if (type > HASH_TYPE_UNKNOWN && type < HASH_TYPE_END) {
-		result = algo_table[type - 1];
+		if (qat_algo_table[type-1] != NULL)
+			result = qat_algo_table[type - 1];
+		else
+			result = algo_table[type - 1];
 	}
 	if (result && result->cf_type == HASH_TYPE_UNKNOWN)
 		result->cf_type = type;

--- a/src/common/multihash_qat.c
+++ b/src/common/multihash_qat.c
@@ -1,0 +1,320 @@
+/**
+ * (C) Copyright 2020 Intel Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * GOVERNMENT LICENSE RIGHTS-OPEN SOURCE SOFTWARE
+ * The Government's rights to use, modify, reproduce, release, perform, display,
+ * or disclose this software are subject to the terms of the Apache License as
+ * provided in Contract No. B609815.
+ * Any reproduction of computer software, computer software documentation, or
+ * portions thereof marked with this legend must also reproduce the markings.
+ */
+#define D_LOGFAC    DD_FAC(csum)
+
+#ifdef HAVE_QAT
+#include <stddef.h>
+#include <string.h>
+#include <stdlib.h>
+#include <stdint.h>
+#include <gurt/types.h>
+#include <daos/common.h>
+#include <daos/multihash.h>
+#include <daos/qat.h>
+
+#define SHA1_DIGEST_LENGTH   20
+#define SHA256_DIGEST_LENGTH 32
+#define SHA512_DIGEST_LENGTH 64
+#define QAT_SHA1_BLK_SIZE    64
+#define QAT_SHA256_BLK_SIZE  64
+#define QAT_SHA512_BLK_SIZE  128
+
+/**
+ * ---------------------------------------------------------------------------
+ * QAT Hash Algorithms
+ * ---------------------------------------------------------------------------
+ */
+
+/** SHA1 */
+struct sha1_qat_ctx {
+    CpaInstanceHandle  cyInstHandle;
+    CpaCySymSessionCtx sessionCtx;
+    uint8_t            csum_buf[SHA1_DIGEST_LENGTH];
+    bool               partial;
+    bool               s1_updated;
+};
+
+static int
+sha1_init(void ** daos_mhash_ctx)
+{
+    struct sha1_qat_ctx *ctx;
+    int rc;
+    D_ALLOC(ctx, sizeof(*ctx));
+    if (ctx == NULL)
+        return -DER_NOMEM;
+
+    rc = qat_hash_init(&ctx->cyInstHandle, &ctx->sessionCtx, 
+                CPA_CY_SYM_HASH_SHA1, SHA1_DIGEST_LENGTH);
+    if (rc == 0)
+        *daos_mhash_ctx = ctx;
+    return rc;
+}
+
+static int
+sha1_reset(void *daos_mhash_ctx)
+{
+    struct sha1_qat_ctx *ctx = daos_mhash_ctx;
+    ctx->partial = false;
+    ctx->s1_updated = false;
+    return 0;
+}
+
+static void
+sha1_destroy(void *daos_mhash_ctx)
+{
+    struct sha1_qat_ctx *ctx = daos_mhash_ctx;
+    qat_hash_destroy(&ctx->cyInstHandle, &ctx->sessionCtx);
+    
+    D_FREE(daos_mhash_ctx);
+}
+
+static int
+sha1_update(void *daos_mhash_ctx, uint8_t *buf, size_t buf_len)
+{
+    struct sha1_qat_ctx *ctx = daos_mhash_ctx;
+
+    /** QAT requires 64-byte aligned for SHA1 partial submission,
+     *  if it's not the last one */
+    ctx->partial = (ctx->s1_updated ||
+                    ((buf_len & (QAT_SHA512_BLK_SIZE - 1)) == 0));
+    ctx->s1_updated = true;
+    
+    return qat_hash_update(&ctx->cyInstHandle, &ctx->sessionCtx, buf, buf_len, 
+                            ctx->csum_buf, SHA1_DIGEST_LENGTH, ctx->partial);
+}
+
+static int
+sha1_finish(void *daos_mhash_ctx, uint8_t *buf, size_t buf_len)
+{
+    struct sha1_qat_ctx *ctx = daos_mhash_ctx;
+
+    if (ctx->s1_updated) {
+        if (ctx->partial)
+            return qat_hash_finish(&ctx->cyInstHandle, &ctx->sessionCtx, 
+                                    buf, buf_len);
+        else
+            memcpy(buf, ctx->csum_buf, buf_len);
+    }
+    return 0;
+}
+
+struct hash_ft qat_sha1_algo = {
+    .cf_update = sha1_update,
+    .cf_init = sha1_init,
+    .cf_reset = sha1_reset,
+    .cf_destroy = sha1_destroy,
+    .cf_finish = sha1_finish,
+    .cf_hash_len = SHA1_DIGEST_LENGTH,
+    .cf_name = "sha1"
+};
+
+/** SHA256 */
+struct sha256_qat_ctx {
+    CpaInstanceHandle  cyInstHandle;
+    CpaCySymSessionCtx sessionCtx;
+    uint8_t            csum_buf[SHA256_DIGEST_LENGTH];
+    bool               partial;
+    bool               s2_updated;
+};
+
+static int
+sha256_init(void ** daos_mhash_ctx)
+{
+    struct sha256_qat_ctx *ctx;
+    int rc;
+
+    D_ALLOC(ctx, sizeof(*ctx));
+    if (ctx == NULL)
+        return -DER_NOMEM;
+
+    rc = qat_hash_init(&ctx->cyInstHandle, &ctx->sessionCtx, 
+            CPA_CY_SYM_HASH_SHA256, SHA256_DIGEST_LENGTH);
+    if (rc == 0)
+        *daos_mhash_ctx = ctx;
+    return rc;
+}
+
+static int
+sha256_reset(void *daos_mhash_ctx)
+{
+    struct sha256_qat_ctx *ctx = daos_mhash_ctx;
+
+    ctx->partial = false;
+    ctx->s2_updated = false;
+    return 0;
+}
+
+static void
+sha256_destroy(void *daos_mhash_ctx)
+{
+    struct sha256_qat_ctx *ctx = daos_mhash_ctx;
+    qat_hash_destroy(&ctx->cyInstHandle, &ctx->sessionCtx);
+    
+    D_FREE(daos_mhash_ctx);
+}
+
+static int
+sha256_update(void *daos_mhash_ctx, uint8_t *buf, size_t buf_len)
+{
+    struct sha256_qat_ctx *ctx = daos_mhash_ctx;
+
+    /** QAT requires 64-byte aligned for SHA256 partial submission,
+     *  if it's not the last one */
+    ctx->partial = (ctx->s2_updated || 
+                    ((buf_len & (QAT_SHA512_BLK_SIZE - 1)) == 0));
+    ctx->s2_updated = true;
+    
+    return qat_hash_update(&ctx->cyInstHandle, &ctx->sessionCtx, buf, buf_len, 
+                            ctx->csum_buf, SHA256_DIGEST_LENGTH, ctx->partial);
+}
+
+static int
+sha256_finish(void *daos_mhash_ctx, uint8_t *buf, size_t buf_len)
+{
+    struct sha256_qat_ctx *ctx = daos_mhash_ctx;
+
+    if (ctx->s2_updated) {
+        if (ctx->partial)
+            return qat_hash_finish(&ctx->cyInstHandle, &ctx->sessionCtx, 
+                                    buf, buf_len);
+        else
+            memcpy(buf, ctx->csum_buf, buf_len);
+    }
+    return 0;
+}
+
+struct hash_ft qat_sha256_algo = {
+    .cf_update = sha256_update,
+    .cf_init = sha256_init,
+    .cf_reset = sha256_reset,
+    .cf_destroy = sha256_destroy,
+    .cf_finish = sha256_finish,
+    .cf_hash_len = SHA256_DIGEST_LENGTH,
+    .cf_name = "sha256"
+};
+
+/** SHA512 */
+struct sha512_qat_ctx {
+    CpaInstanceHandle  cyInstHandle;
+    CpaCySymSessionCtx sessionCtx;
+    uint8_t            csum_buf[SHA512_DIGEST_LENGTH];
+    bool               partial;
+    bool               s5_updated;
+};
+
+static int
+sha512_init(void ** daos_mhash_ctx)
+{
+    struct sha512_qat_ctx *ctx;
+    int rc;
+
+    D_ALLOC(ctx, sizeof(*ctx));
+    if (ctx == NULL)
+        return -DER_NOMEM;
+
+    rc = qat_hash_init(&ctx->cyInstHandle, &ctx->sessionCtx, 
+                    CPA_CY_SYM_HASH_SHA512, SHA512_DIGEST_LENGTH);
+    if (rc == 0)
+        *daos_mhash_ctx = ctx;
+    return rc;
+}
+
+static int
+sha512_reset(void *daos_mhash_ctx)
+{
+    struct sha512_qat_ctx *ctx = daos_mhash_ctx;
+
+    ctx->partial = false;
+    ctx->s5_updated = false;
+    return 0;
+}
+
+static void
+sha512_destroy(void *daos_mhash_ctx)
+{
+    struct sha512_qat_ctx *ctx = daos_mhash_ctx;
+    qat_hash_destroy(&ctx->cyInstHandle, &ctx->sessionCtx);
+    
+    D_FREE(daos_mhash_ctx);
+}
+
+static int
+sha512_update(void *daos_mhash_ctx, uint8_t *buf, size_t buf_len)
+{
+    struct sha512_qat_ctx *ctx = daos_mhash_ctx;
+
+    /** QAT requires 128-byte aligned for SHA512 partial submission,
+     *  if it's not the last one */
+    ctx->partial = (ctx->s5_updated ||
+                    ((buf_len & (QAT_SHA512_BLK_SIZE - 1)) == 0));
+    ctx->s5_updated = true;
+    
+    return qat_hash_update(&ctx->cyInstHandle, &ctx->sessionCtx, buf, buf_len, 
+                            ctx->csum_buf, SHA512_DIGEST_LENGTH, ctx->partial);
+}
+
+static int
+sha512_finish(void *daos_mhash_ctx, uint8_t *buf, size_t buf_len)
+{
+    struct sha512_qat_ctx *ctx = daos_mhash_ctx;
+
+    if (ctx->s5_updated) {
+        if (ctx->partial)
+            return qat_hash_finish(&ctx->cyInstHandle, &ctx->sessionCtx, 
+                                    buf, buf_len);
+        else
+            memcpy(buf, ctx->csum_buf, buf_len);
+    }
+    return 0;
+}
+
+struct hash_ft qat_sha512_algo = {
+    .cf_update = sha512_update,
+    .cf_init = sha512_init,
+    .cf_reset = sha512_reset,
+    .cf_destroy = sha512_destroy,
+    .cf_finish = sha512_finish,
+    .cf_hash_len = SHA512_DIGEST_LENGTH,
+    .cf_name = "sha512"
+};
+
+/** Index to algo table should align with enum DAOS_HASH_TYPE - 1 */
+struct hash_ft *qat_hash_algo_table[] = {
+    NULL, /* CRC16 is not supported by QAT */
+    NULL, /* CRC32 is not supported by QAT */
+    NULL, /* CRC64 is not supported by QAT */
+    &qat_sha1_algo,
+    &qat_sha256_algo,
+    &qat_sha512_algo,
+};
+#else
+#include <gurt/types.h>
+struct hash_ft *qat_hash_algo_table[] = {
+    NULL,
+    NULL,
+    NULL,
+    NULL,
+    NULL,
+    NULL,
+};
+#endif

--- a/src/common/qat.c
+++ b/src/common/qat.c
@@ -1,0 +1,434 @@
+/**
+ * (C) Copyright 2020 Intel Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * GOVERNMENT LICENSE RIGHTS-OPEN SOURCE SOFTWARE
+ * The Government's rights to use, modify, reproduce, release, perform, display,
+ * or disclose this software are subject to the terms of the Apache License as
+ * provided in Contract No. B609815.
+ * Any reproduction of computer software, computer software documentation, or
+ * portions thereof marked with this legend must also reproduce the markings.
+ */
+#define D_LOGFAC    DD_FAC(csum)
+
+#ifdef HAVE_QAT
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <stddef.h>
+#include <string.h>
+#include <stdint.h>
+
+#include <daos/common.h>
+#include <gurt/types.h>
+
+#include <cpa.h>
+#include <cpa_cy_im.h>
+#include <cpa_cy_sym.h>
+#include <icp_sal_user.h>
+#include <icp_sal_poll.h>
+#include <qae_mem.h>
+
+#define MAX_INSTANCES 32
+
+/* Memory */
+#define PHYS_CONTIG_ALLOC(ppMemAddr, sizeBytes)                                \
+    Mem_Alloc_Contig((void *)(ppMemAddr), (sizeBytes), 1)
+
+#define PHYS_CONTIG_ALLOC_ALIGNED(ppMemAddr, sizeBytes, alignment)             \
+    Mem_Alloc_Contig((void *)(ppMemAddr), (sizeBytes), (alignment))
+
+#define PHYS_CONTIG_FREE(pMemAddr) Mem_Free_Contig((void *)&pMemAddr)
+
+extern CpaStatus qaeMemInit(void);
+extern void qaeMemDestroy(void);
+
+static __inline CpaStatus 
+Mem_Alloc_Contig(void **ppMemAddr,
+                 Cpa32U sizeBytes,
+                 Cpa32U alignment)
+{
+    *ppMemAddr = qaeMemAllocNUMA(sizeBytes, 0, alignment);
+    if (NULL == *ppMemAddr)
+    {
+        return CPA_STATUS_RESOURCE;
+    }
+    return CPA_STATUS_SUCCESS;
+}
+
+static __inline void 
+Mem_Free_Contig(void **ppMemAddr)
+{
+    if (NULL != *ppMemAddr)
+    {
+        qaeMemFreeNUMA(ppMemAddr);
+        *ppMemAddr = NULL;
+    }
+}
+
+static __inline CpaStatus 
+OS_SLEEP(Cpa32U ms)
+{
+    int ret = 0;
+    struct timespec resTime, remTime;
+    resTime.tv_sec = ms / 1000;
+    resTime.tv_nsec = (ms % 1000) * 1000000;
+    do
+    {
+        ret = nanosleep(&resTime, &remTime);
+        resTime = remTime;
+    } while ((ret != 0) && (errno == EINTR));
+
+    if (ret != 0)
+    {
+        return CPA_STATUS_FAIL;
+    }
+    else
+    {
+        return CPA_STATUS_SUCCESS;
+    }
+}
+
+static __inline CpaPhysicalAddr 
+virtToPhys(void *virtAddr)
+{
+    return (CpaPhysicalAddr)qaeVirtToPhysNUMA(virtAddr);
+}
+
+static void 
+getInstance(CpaInstanceHandle *pCyInstHandle)
+{
+    CpaInstanceHandle cyInstHandles[MAX_INSTANCES];
+    Cpa16U numInstances = 0;
+    CpaStatus status = CPA_STATUS_SUCCESS;
+
+    *pCyInstHandle = NULL;
+    status = cpaCyGetNumInstances(&numInstances);
+
+    if (numInstances >= MAX_INSTANCES)
+        numInstances = MAX_INSTANCES;
+
+    if ((status == CPA_STATUS_SUCCESS) && (numInstances > 0))
+    {
+        status = cpaCyGetInstances(numInstances, cyInstHandles);
+        if (status == CPA_STATUS_SUCCESS)
+            *pCyInstHandle = cyInstHandles[0];
+    }
+
+    if (0 == numInstances)
+        D_DEBUG(DB_TRACE, "No QAT instances found.\n");
+}
+
+static void 
+symCallback(void *pCallbackTag,
+                        CpaStatus status,
+                        const CpaCySymOp operationType,
+                        void *pOpData,
+                        CpaBufferList *pDstBuffer,
+                        CpaBoolean verifyResult)
+{
+    if (NULL != pCallbackTag)
+    {
+       *(Cpa32U*)pCallbackTag = 1;
+    }
+}
+
+CpaStatus 
+qat_hash_init(CpaInstanceHandle *cyInstHandle, 
+                        CpaCySymSessionCtx *sessionCtx,
+                        CpaCySymHashAlgorithm hashAlg, 
+                        Cpa32U digestResultLenInBytes)
+{
+    CpaStatus status = CPA_STATUS_SUCCESS;
+    Cpa32U sessionCtxSize = 0;
+    CpaCySymSessionSetupData sessionSetupData = {0};
+
+    status = qaeMemInit();
+    if (CPA_STATUS_SUCCESS != status)
+    {
+        D_DEBUG(DB_TRACE, "Failed to initialize memory driver\n");
+        return 0;
+    }
+
+    status = icp_sal_userStartMultiProcess("SSL", CPA_FALSE);
+    if (CPA_STATUS_SUCCESS != status)
+    {
+        D_DEBUG(DB_TRACE, "Failed to start user process SSL\n");
+        qaeMemDestroy();
+        return 0;
+    }
+    
+    getInstance(cyInstHandle);
+    if (*cyInstHandle == NULL)
+    {
+        return CPA_STATUS_FAIL;
+    }
+
+    status = cpaCyStartInstance(*cyInstHandle);
+
+    if (CPA_STATUS_SUCCESS == status)
+    {
+        /*
+         * Set the address translation function for the instance
+         */
+        status = cpaCySetAddressTranslation(*cyInstHandle, virtToPhys);
+    }
+
+    if (CPA_STATUS_SUCCESS == status)
+    {
+        /*
+         * We now populate the fields of the session operational data and create
+         * the session.  Note that the size required to store a session is
+         * implementation-dependent, so we query the API first to determine how
+         * much memory to allocate, and then allocate that memory.
+         */
+        sessionSetupData.sessionPriority = CPA_CY_PRIORITY_NORMAL;
+        sessionSetupData.symOperation = CPA_CY_SYM_OP_HASH;
+        sessionSetupData.hashSetupData.hashAlgorithm = hashAlg;
+        sessionSetupData.hashSetupData.hashMode = CPA_CY_SYM_HASH_MODE_PLAIN;
+        sessionSetupData.hashSetupData.digestResultLenInBytes = digestResultLenInBytes;
+        sessionSetupData.digestIsAppended = CPA_FALSE;
+        sessionSetupData.verifyDigest = CPA_FALSE;
+
+        status = cpaCySymSessionCtxGetSize(
+            *cyInstHandle, &sessionSetupData, &sessionCtxSize);
+    }
+
+    if (CPA_STATUS_SUCCESS == status)
+    {
+        /* Allocate session context */
+        status = PHYS_CONTIG_ALLOC(sessionCtx, sessionCtxSize);
+    }
+
+    if (CPA_STATUS_SUCCESS == status)
+    {
+        status = cpaCySymInitSession(
+            *cyInstHandle, symCallback, &sessionSetupData, *sessionCtx);
+    }
+    return status;
+}
+
+CpaStatus 
+qat_hash_update(CpaInstanceHandle *cyInstHandle, 
+                                    CpaCySymSessionCtx *sessionCtx, 
+                                    uint8_t *buf, 
+                                    size_t bufLen, 
+                                    uint8_t *csumBuf,
+                                    size_t csumLen,
+                                    bool packetTypePartial)
+{
+    CpaStatus status = CPA_STATUS_SUCCESS;
+    Cpa8U *pBufferMeta = NULL;
+    Cpa32U bufferMetaSize = 0;
+    CpaBufferList *pBufferList = NULL;
+    CpaFlatBuffer *pFlatBuffer = NULL;
+    CpaCySymOpData *pOpData = NULL;
+    Cpa32U bufferSize = bufLen;
+    Cpa32U numBuffers = 1;
+    Cpa32U bufferListMemSize =
+        (sizeof(CpaBufferList) + (numBuffers * sizeof(CpaFlatBuffer)));
+    Cpa8U *pSrcBuffer = NULL;
+    Cpa8U *pDigestBuffer = NULL;
+    Cpa32U complete = 0;
+
+    /* The following variables are allocated on the stack because we block
+     * until the callback comes back. If a non-blocking approach was to be
+     * used then these variables should be dynamically allocated */
+    status =
+        cpaCyBufferListGetMetaSize(*cyInstHandle, numBuffers, &bufferMetaSize);
+
+    if (CPA_STATUS_SUCCESS == status)
+    {
+        status = PHYS_CONTIG_ALLOC(&pBufferMeta, bufferMetaSize);
+    }
+
+    if (CPA_STATUS_SUCCESS == status)
+    {
+        D_ALLOC(pBufferList, bufferListMemSize);
+        status = pBufferList ? CPA_STATUS_SUCCESS : CPA_STATUS_FAIL;
+    }
+
+    if (CPA_STATUS_SUCCESS == status)
+    {
+        status = PHYS_CONTIG_ALLOC(&pSrcBuffer, bufferSize);
+    }
+
+    if (CPA_STATUS_SUCCESS == status)
+    {
+        status = PHYS_CONTIG_ALLOC(&pDigestBuffer, csumLen);
+    }
+
+    if (CPA_STATUS_SUCCESS == status)
+    {
+        /* increment by sizeof(CpaBufferList) to get at the
+         * array of flatbuffers */
+        pFlatBuffer = (CpaFlatBuffer *)(pBufferList + 1);
+
+        pBufferList->pBuffers = pFlatBuffer;
+        pBufferList->numBuffers = 1;
+        pBufferList->pPrivateMetaData = pBufferMeta;
+
+        pFlatBuffer->dataLenInBytes = bufferSize;
+        pFlatBuffer->pData = pSrcBuffer;
+
+        D_ALLOC(pOpData, sizeof(CpaCySymOpData));
+        status = pOpData ? CPA_STATUS_SUCCESS : CPA_STATUS_FAIL;
+    }
+
+    if (CPA_STATUS_SUCCESS == status)
+    {
+        memcpy(pSrcBuffer, buf, bufLen);
+
+        pOpData->packetType = packetTypePartial ? 
+                CPA_CY_SYM_PACKET_TYPE_PARTIAL : CPA_CY_SYM_PACKET_TYPE_FULL;
+        pOpData->sessionCtx = *sessionCtx;
+        pOpData->hashStartSrcOffsetInBytes = 0;
+        pOpData->messageLenToHashInBytes = bufferSize;
+        pOpData->pDigestResult = pDigestBuffer;
+
+        status = cpaCySymPerformOp(
+            *cyInstHandle,
+            (void *)&complete, /* data sent as is to the callback function*/
+            pOpData,           /* operational data struct */
+            pBufferList,       /* source buffer list */
+            pBufferList,       /* same src & dst for an in-place operation*/
+            NULL);
+
+        if (CPA_STATUS_SUCCESS != status)
+        {
+            D_DEBUG(DB_TRACE, "cpaCySymPerformOp failed. (status = %d)\n", status);
+        }
+
+        if (CPA_STATUS_SUCCESS == status)
+        {
+            /** wait until the completion of the operation*/
+            do {
+                icp_sal_CyPollInstance(*cyInstHandle, 0);
+                /** Busy polling vs. sleep and polling */
+                // OS_SLEEP(1);
+            } while (!complete);
+        } 
+
+        if (!packetTypePartial)
+            memcpy(csumBuf, pDigestBuffer, csumLen);
+    }
+
+    PHYS_CONTIG_FREE(pSrcBuffer);
+    D_FREE(pBufferList);
+    PHYS_CONTIG_FREE(pBufferMeta);
+    PHYS_CONTIG_FREE(pDigestBuffer);
+    D_FREE(pOpData);
+
+    return status;
+}
+
+CpaStatus 
+qat_hash_finish(CpaInstanceHandle *cyInstHandle, 
+                                    CpaCySymSessionCtx *sessionCtx, 
+                                    uint8_t *csumBuf, size_t csumLen)
+{
+    CpaStatus status = CPA_STATUS_SUCCESS;
+    Cpa8U *pBufferMeta = NULL;
+    Cpa32U bufferMetaSize = 0;
+    CpaBufferList *pBufferList = NULL;
+    CpaCySymOpData *pOpData = NULL;
+    Cpa32U bufferListMemSize =
+        sizeof(CpaBufferList) +  sizeof(CpaFlatBuffer);
+    Cpa8U *pDigestBuffer = NULL;
+    Cpa32U complete = 0;
+
+    status =
+        cpaCyBufferListGetMetaSize(*cyInstHandle, 1, &bufferMetaSize);
+
+    if (CPA_STATUS_SUCCESS == status)
+    {
+        status = PHYS_CONTIG_ALLOC(&pBufferMeta, bufferMetaSize);
+    }
+
+    if (CPA_STATUS_SUCCESS == status)
+    {        
+        D_ALLOC(pBufferList, bufferListMemSize);        
+        status = pBufferList ? CPA_STATUS_SUCCESS : CPA_STATUS_FAIL;
+    }
+
+    if (CPA_STATUS_SUCCESS == status)
+    {
+        status = PHYS_CONTIG_ALLOC(&pDigestBuffer, csumLen);
+    }
+
+    if (CPA_STATUS_SUCCESS == status)
+    {
+        pBufferList->numBuffers = 0;
+        pBufferList->pPrivateMetaData = pBufferMeta;
+        D_ALLOC(pOpData, sizeof(CpaCySymOpData));        
+        status = pOpData ? CPA_STATUS_SUCCESS : CPA_STATUS_FAIL;
+    }
+
+    if (CPA_STATUS_SUCCESS == status)
+    {
+        /* Set packet type to final */ 
+        pOpData->packetType = CPA_CY_SYM_PACKET_TYPE_LAST_PARTIAL;
+
+        pOpData->sessionCtx = *sessionCtx;
+        pOpData->hashStartSrcOffsetInBytes = 0;
+        pOpData->messageLenToHashInBytes = 0;
+        pOpData->pDigestResult = pDigestBuffer;
+
+        status = cpaCySymPerformOp(
+            *cyInstHandle,
+            (void *)&complete, /* data sent as is to the callback function*/
+            pOpData,           /* operational data struct */
+            pBufferList,       /* source buffer list */
+            pBufferList,       /* same src & dst for an in-place operation*/
+            NULL);
+
+        if (CPA_STATUS_SUCCESS != status)
+        {
+            D_DEBUG(DB_TRACE, "cpaCySymPerformOp failed. (status = %d)\n", status);
+        }
+
+        if (CPA_STATUS_SUCCESS == status)
+        {
+            /** wait until the completion of the operation*/
+            do {
+                icp_sal_CyPollInstance(*cyInstHandle, 0);
+                /** Busy polling vs. sleep and polling */
+                // OS_SLEEP(1);
+            } while (!complete);
+        } 
+
+        memcpy(csumBuf, pDigestBuffer, csumLen);
+    }
+
+    D_FREE(pBufferList);
+    PHYS_CONTIG_FREE(pBufferMeta);
+    PHYS_CONTIG_FREE(pDigestBuffer);
+    D_FREE(pOpData);
+    
+    return status;
+}
+
+CpaStatus 
+qat_hash_destroy(CpaInstanceHandle *cyInstHandle, 
+                                    CpaCySymSessionCtx *sessionCtx)
+{
+    /* Free session Context */
+    PHYS_CONTIG_FREE(*sessionCtx);
+
+    /* Stop instance */
+    cpaCyStopInstance(*cyInstHandle);
+
+    return CPA_STATUS_SUCCESS;
+}
+#endif

--- a/src/include/daos/qat.h
+++ b/src/include/daos/qat.h
@@ -1,0 +1,53 @@
+/**
+ * (C) Copyright 2019-2020 Intel Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * GOVERNMENT LICENSE RIGHTS-OPEN SOURCE SOFTWARE
+ * The Government's rights to use, modify, reproduce, release, perform, display,
+ * or disclose this software are subject to the terms of the Apache License as
+ * provided in Contract No. B609815.
+ * Any reproduction of computer software, computer software documentation, or
+ * portions thereof marked with this legend must also reproduce the markings.
+ */
+#ifndef __DAOS_QAT_H
+#define __DAOS_QAT_H
+
+#include "cpa.h"
+#include "cpa_cy_im.h"
+#include "cpa_cy_sym.h"
+
+/** Hash Functions */
+CpaStatus qat_hash_init(CpaInstanceHandle *cyInstHandle, 
+                                    CpaCySymSessionCtx *sessionCtx,
+						            CpaCySymHashAlgorithm hashAlg, 
+                                    Cpa32U digestResultLenInBytes);
+CpaStatus qat_hash_update(CpaInstanceHandle *cyInstHandle, 
+                                    CpaCySymSessionCtx *sessionCtx, 
+                                    uint8_t *buf, 
+                                    size_t bufLen, 
+                                    uint8_t *csumBuf,
+									size_t csumLen,
+                                    bool packetTypePartial);
+CpaStatus qat_hash_finish(CpaInstanceHandle *cyInstHandle, 
+                                    CpaCySymSessionCtx *sessionCtx, 
+                                    uint8_t *csumBuf, size_t csumLen);
+
+CpaStatus qat_hash_destroy(CpaInstanceHandle *cyInstHandle, 
+                                    CpaCySymSessionCtx *sessionCtx);
+
+/** Encryption Functions */
+
+/** Compression Functions */
+
+#endif /** __DAOS_QAT_H */


### PR DESCRIPTION
Support SHA1, SHA256 and SHA512 algorithms.
QAT related code will not be built unless "HAVE_QAT" is defined.
Synchronized mode, wait for QAT response in the current context.
This PR is just for functional working, not for performance.
Note: QAT HW requires message length with multiple of block size for
partial submission (update), if it is not the last request, the
block size required by each algorithm are:
SHA1: 64 bytes
SHA256: 64 bytes
SHA512: 128 bytes

Signed-off-by: Weigang Li <weigang.li@intel.com>