### PR TITLE
DAOS-5634 csum: Checksum error should be mismatch for object verify

### DIFF
--- a/src/object/obj_verify.c
+++ b/src/object/obj_verify.c
@@ -710,6 +710,11 @@ dc_obj_verify_rdg(struct dc_object *obj, struct dc_obj_verify_args *dova,
 		for (i = 1; i < reps; i++) {
 			rc = dc_obj_verify_cmp(&dova[0], &dova[i],
 					       oid, reps, start, start + i);
+			if (rc == -DER_CSUM) {
+				D_ERROR("Failed to verify because of "
+					"data corruption");
+				D_GOTO(out, rc = -DER_MISMATCH);
+			}
 			if (rc != 0) {
 				D_ERROR("Failed to verify cmp: "DF_RC"\n",
 					DP_RC(rc));


### PR DESCRIPTION
If checksums is enabled and object verify encounters data corruption,
it should return the error as a object mismatch instead of checksum error
because from the application perspective, it does not care about whether
it is the checksum caused inconsistency or not.

Signed-off-by: Ryon Jensen <ryon.jensen@intel.com>