### PR TITLE
DAOS-5642 bio: spdk_thread_lib_init() failing on Ubuntu

### DIFF
--- a/src/bio/SConscript
+++ b/src/bio/SConscript
@@ -9,6 +9,7 @@ def scons():
     env.AppendUnique(LIBPATH=[Dir('.')])
 
     denv = env.Clone()
+    denv.AppendUnique(LINKFLAGS=["-Wl,--no-as-needed"])
     prereqs.require(denv, 'pmdk', 'spdk', 'argobots', 'protobufc', 'hwloc')
 
     SConscript('smd/SConscript')

--- a/src/bio/bio_xstream.c
+++ b/src/bio/bio_xstream.c
@@ -30,7 +30,6 @@
 #include <spdk/env.h>
 #include <spdk/nvme.h>
 #include <spdk/vmd.h>
-#include <spdk/string.h>
 #include <spdk/thread.h>
 #include <spdk/bdev.h>
 #include <spdk/io_channel.h>
@@ -381,8 +380,7 @@ bio_spdk_env_init(void)
 	rc = spdk_thread_lib_init(NULL, 0);
 	if (rc != 0) {
 		rc = -DER_INVAL;
-		D_ERROR("Failed to init SPDK thread lib, %s (%d)\n",
-			spdk_strerror(rc), rc);
+		D_ERROR("Failed to init SPDK thread lib, "DF_RC"\n", DP_RC(rc));
 		spdk_env_fini();
 		return rc;
 	}

--- a/src/control/SConscript
+++ b/src/control/SConscript
@@ -180,6 +180,7 @@ def scons():
     SConscript('lib/spdk/SConscript', exports='denv')
 
     senv = denv.Clone()
+    denv.AppendUnique(LINKFLAGS=["-Wl,--no-as-needed"])
     prereqs.require(senv, 'pmdk', 'spdk', 'ofi', 'hwloc')
 
     cgolibdirs = senv.subst("-L$BUILD_DIR/src/control/lib/spdk "


### PR DESCRIPTION
Ubuntu 20.04 seems to ship with linker configured to use
"--as-needed" instead of "--no-as-needed" and as a result there are
constructor functions in `rte_mempool_ring` that don't get run unless
we pass "-Wl,-no-as-needed" when linking `libbio.so`. Add those flags
to bio/SConstruct file.

Signed-off-by: Tom Nabarro <tom.nabarro@intel.com>