### PR TITLE
CART-89 cart: Update to ofi 1.11 with patch

### DIFF
--- a/utils/build.config
+++ b/utils/build.config
@@ -8,10 +8,10 @@ ISAL = v2.26.0
 SPDK = v20.01.1
 FUSE = fuse-3.6.1
 FIO = e3ccbdd5f93d33162a93000586461ac6bba5a7d3
-OFI = 8fa7c5bbbfee7df5194b65d9294929a893eb4093
+OFI = v1.11.0
 OPENPA = v1.0.4
 MERCURY = v2.0.0rc1
 PSM2 = PSM2_11.2.78
 
 [patch_versions]
-OFI = https://raw.githubusercontent.com/daos-stack/libfabric/master/sockets_provider.patch
+OFI = https://patch-diff.githubusercontent.com/raw/ofiwg/libfabric/pull/6252.diff

--- a/utils/rpms/daos.spec
+++ b/utils/rpms/daos.spec
@@ -11,7 +11,7 @@
 
 Name:          daos
 Version:       1.1.0
-Release:       32%{?relval}%{?dist}
+Release:       33%{?relval}%{?dist}
 Summary:       DAOS Storage Engine
 
 License:       Apache
@@ -384,6 +384,9 @@ getent passwd daos_server >/dev/null || useradd -M daos_server
 %{_libdir}/*.a
 
 %changelog
+* Fri Sep 18 2020 Michael MacDonald <mjmac.macdonald@intel.com> 1.1.0-33
+- Update OFI to v1.11.0 with SA_ONSTACK patch
+
 * Mon Aug 17 2020 Michael MacDonald <mjmac.macdonald@intel.com> 1.1.0-32
 - Install completion script in /etc/bash_completion.d
 


### PR DESCRIPTION
We want to update to ofi v1.11, but we need a patch to correctly
register signal handlers.