### PR TITLE
DAOS-5663 control: Add rich errors for MS raft

### DIFF
--- a/src/control/build/variables.go
+++ b/src/control/build/variables.go
@@ -28,6 +28,12 @@ var (
 	ConfigDir string = "./"
 	// DaosVersion should be set via linker flag using the value of DAOS_VERSION.
 	DaosVersion string = "unset"
+	// ControlPlaneName defines a consistent name for the control plane server.
+	ControlPlaneName = "DAOS Control Server"
+	// DataPlaneName defines a consistent name for the ioserver.
+	DataPlaneName = "DAOS I/O Server"
+	// ManagementServiceName defines a consistent name for the Management Service.
+	ManagementServiceName = "DAOS Management Service"
 
 	// DefaultControlPort defines the default control plane listener port.
 	DefaultControlPort = 10001

--- a/src/control/cmd/daos_server/main.go
+++ b/src/control/cmd/daos_server/main.go
@@ -38,7 +38,6 @@ import (
 	"github.com/daos-stack/daos/src/control/lib/netdetect"
 	"github.com/daos-stack/daos/src/control/logging"
 	"github.com/daos-stack/daos/src/control/pbin"
-	"github.com/daos-stack/daos/src/control/server"
 )
 
 const (
@@ -168,7 +167,7 @@ func main() {
 
 	if err := parseOpts(os.Args[1:], &opts, log); err != nil {
 		if errors.Cause(err) == context.Canceled {
-			log.Infof("%s (pid %d) shutting down", server.ControlPlaneName, os.Getpid())
+			log.Infof("%s (pid %d) shutting down", build.ControlPlaneName, os.Getpid())
 			os.Exit(0)
 		}
 		exitWithError(log, err)

--- a/src/control/cmd/dmg/storage.go
+++ b/src/control/cmd/dmg/storage.go
@@ -194,6 +194,11 @@ func (cmd *storageFormatCmd) shouldReformatSystem(ctx context.Context) (bool, er
 	if cmd.Reformat {
 		resp, err := control.SystemQuery(ctx, cmd.ctlInvoker, &control.SystemQueryReq{})
 		if err != nil {
+			// If the AP hasn't been started, it will respond as if it
+			// is not a replica.
+			if system.IsNotReplica(err) {
+				return false, nil
+			}
 			return false, errors.Wrap(err, "System-Query command failed")
 		}
 

--- a/src/control/common/proto/error_test.go
+++ b/src/control/common/proto/error_test.go
@@ -35,50 +35,8 @@ import (
 	"github.com/daos-stack/daos/src/control/drpc"
 	"github.com/daos-stack/daos/src/control/fault"
 	"github.com/daos-stack/daos/src/control/fault/code"
+	"github.com/daos-stack/daos/src/control/system"
 )
-
-func TestProto_FaultFromMeta(t *testing.T) {
-	for name, tc := range map[string]struct {
-		meta     map[string]string
-		expFault *fault.Fault
-		expErr   error
-	}{
-		"success": {
-			meta: map[string]string{
-				"Domain":      "Domain",
-				"Code":        "42",
-				"Description": "Description",
-				"Resolution":  "Resolution",
-			},
-			expFault: &fault.Fault{
-				Domain:      "Domain",
-				Code:        code.Code(42),
-				Description: "Description",
-				Resolution:  "Resolution",
-			},
-		},
-		"empty meta": {
-			expFault: &fault.Fault{},
-		},
-		"weird code": {
-			meta: map[string]string{
-				"Code": "bananas",
-			},
-			expErr: errors.New("strconv.Atoi"),
-		},
-	} {
-		t.Run(name, func(t *testing.T) {
-			gotFault, gotErr := proto.FaultFromMeta(tc.meta)
-			common.CmpErr(t, tc.expErr, gotErr)
-			if tc.expErr != nil {
-				return
-			}
-			if diff := cmp.Diff(tc.expFault, gotFault); diff != "" {
-				t.Fatalf("unexpected Fault (-want, +got):\n%s\n", diff)
-			}
-		})
-	}
-}
 
 func TestProto_MetaFromFault(t *testing.T) {
 	for name, tc := range map[string]struct {
@@ -128,16 +86,33 @@ func TestProto_AnnotateError(t *testing.T) {
 		Resolution:  "Resolution",
 	}
 	testStatus := drpc.DaosInvalidInput
+	testNotReplica := &system.ErrNotReplica{
+		Replicas: []string{"a", "b", "c"},
+	}
+	testNotLeader := &system.ErrNotLeader{
+		LeaderHint: "foo.bar.baz",
+		Replicas:   []string{"a", "b", "c"},
+	}
 
 	for name, tc := range map[string]struct {
 		err    error
 		expErr error
 	}{
 		"wrap/unwrap Fault": {
-			err: testFault,
+			err:    testFault,
+			expErr: testFault,
 		},
-		"wrap/unwrap DaoStatus": {
-			err: testStatus,
+		"wrap/unwrap DaosStatus": {
+			err:    testStatus,
+			expErr: testStatus,
+		},
+		"wrap/unwrap ErrNotReplica": {
+			err:    testNotReplica,
+			expErr: testNotReplica,
+		},
+		"wrap/unwrap ErrNotLeader": {
+			err:    testNotLeader,
+			expErr: testNotLeader,
 		},
 		"non-fault err": {
 			err:    errors.New("not a fault"),
@@ -148,27 +123,29 @@ func TestProto_AnnotateError(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			aErr := proto.AnnotateError(tc.err)
 
-			var gotErr error
+			gotErr := proto.UnwrapError(status.Convert(aErr))
+			common.CmpErr(t, tc.expErr, gotErr)
+			if tc.expErr == nil {
+				return
+			}
+
 			switch tc.err.(type) {
 			case *fault.Fault:
-				var gotFault *fault.Fault
-				gotFault, gotErr = proto.UnwrapFault(status.Convert(aErr))
-				common.CmpErr(t, tc.expErr, gotErr)
-				if diff := cmp.Diff(testFault, gotFault); diff != "" {
+				if diff := cmp.Diff(testFault, gotErr); diff != "" {
 					t.Fatalf("unexpected fault: (-want, +got):\n%s\n", diff)
 				}
 			case drpc.DaosStatus:
-				var gotStatus drpc.DaosStatus
-				gotStatus, gotErr = proto.UnwrapDaosStatus(status.Convert(aErr))
-				common.CmpErr(t, tc.expErr, gotErr)
-				if gotStatus != testStatus {
-					t.Fatalf("unexpected status: %d != %d", testStatus, gotStatus)
+				if gotErr != testStatus {
+					t.Fatalf("unexpected status: %d != %d", testStatus, gotErr)
 				}
-			default:
-				_, gotErr = proto.UnwrapFault(status.Convert(aErr))
-				common.CmpErr(t, tc.expErr, gotErr)
-				_, gotErr = proto.UnwrapDaosStatus(status.Convert(aErr))
-				common.CmpErr(t, tc.expErr, gotErr)
+			case *system.ErrNotReplica:
+				if diff := cmp.Diff(testNotReplica, gotErr); diff != "" {
+					t.Fatalf("unexpected ErrNotReplica: (-want, +got):\n%s\n", diff)
+				}
+			case *system.ErrNotLeader:
+				if diff := cmp.Diff(testNotLeader, gotErr); diff != "" {
+					t.Fatalf("unexpected ErrNotLeader: (-want, +got):\n%s\n", diff)
+				}
 			}
 		})
 	}

--- a/src/control/common/proto/error_test.go
+++ b/src/control/common/proto/error_test.go
@@ -128,25 +128,6 @@ func TestProto_AnnotateError(t *testing.T) {
 			if tc.expErr == nil {
 				return
 			}
-
-			switch tc.err.(type) {
-			case *fault.Fault:
-				if diff := cmp.Diff(testFault, gotErr); diff != "" {
-					t.Fatalf("unexpected fault: (-want, +got):\n%s\n", diff)
-				}
-			case drpc.DaosStatus:
-				if gotErr != testStatus {
-					t.Fatalf("unexpected status: %d != %d", testStatus, gotErr)
-				}
-			case *system.ErrNotReplica:
-				if diff := cmp.Diff(testNotReplica, gotErr); diff != "" {
-					t.Fatalf("unexpected ErrNotReplica: (-want, +got):\n%s\n", diff)
-				}
-			case *system.ErrNotLeader:
-				if diff := cmp.Diff(testNotLeader, gotErr); diff != "" {
-					t.Fatalf("unexpected ErrNotLeader: (-want, +got):\n%s\n", diff)
-				}
-			}
 		})
 	}
 }

--- a/src/control/lib/control/interceptors.go
+++ b/src/control/lib/control/interceptors.go
@@ -31,39 +31,7 @@ import (
 	"google.golang.org/grpc/status"
 
 	"github.com/daos-stack/daos/src/control/common/proto"
-	"github.com/daos-stack/daos/src/control/drpc"
-	"github.com/daos-stack/daos/src/control/fault"
 )
-
-// unwrapFault takes a gRPC status object
-// and unwraps additional information, if available.
-func unwrapFault(st *status.Status) error {
-	if st == nil {
-		return nil
-	}
-
-	f, err := proto.UnwrapFault(st)
-	if f != nil {
-		return f
-	}
-
-	return err
-}
-
-// unwrapDaosStatus takes a gRPC status object
-// and unwraps additional information, if available.
-func unwrapDaosStatus(st *status.Status) error {
-	if st == nil {
-		return nil
-	}
-
-	s, err := proto.UnwrapDaosStatus(st)
-	if err == nil {
-		return s
-	}
-
-	return err
-}
 
 // connErrToFault attempts to resolve a network connection
 // error to a more informative Fault with resolution.
@@ -89,11 +57,9 @@ func streamErrorInterceptor() grpc.DialOption {
 		cs, err := streamer(ctx, desc, cc, method, opts...)
 		if err != nil {
 			st := status.Convert(err)
-			if f, isFault := unwrapFault(st).(*fault.Fault); isFault {
-				return cs, f
-			}
-			if s, isStatus := unwrapDaosStatus(st).(drpc.DaosStatus); isStatus {
-				return cs, s
+			err = proto.UnwrapError(st)
+			if err.Error() != st.Err().Error() {
+				return cs, err
 			}
 			return cs, connErrToFault(st, cc.Target())
 		}
@@ -107,11 +73,9 @@ func unaryErrorInterceptor() grpc.DialOption {
 		err := invoker(ctx, method, req, reply, cc, opts...)
 		if err != nil {
 			st := status.Convert(err)
-			if f, isFault := unwrapFault(st).(*fault.Fault); isFault {
-				return f
-			}
-			if s, isStatus := unwrapDaosStatus(st).(drpc.DaosStatus); isStatus {
-				return s
+			err = proto.UnwrapError(st)
+			if err.Error() != st.Err().Error() {
+				return err
 			}
 			return connErrToFault(st, cc.Target())
 		}

--- a/src/control/server/config.go
+++ b/src/control/server/config.go
@@ -429,7 +429,7 @@ func (c *Configuration) Validate(log logging.Logger) (err error) {
 	// config without servers is valid when initially discovering hardware
 	// prior to adding per-server sections with device allocations
 	if len(c.Servers) == 0 {
-		log.Infof("No %ss in configuration, %s starting in discovery mode", DataPlaneName, ControlPlaneName)
+		log.Infof("No %ss in configuration, %s starting in discovery mode", build.DataPlaneName, build.ControlPlaneName)
 		c.Servers = nil
 		return nil
 	}

--- a/src/control/server/faults.go
+++ b/src/control/server/faults.go
@@ -27,6 +27,7 @@ import (
 
 	"github.com/dustin/go-humanize"
 
+	"github.com/daos-stack/daos/src/control/build"
 	"github.com/daos-stack/daos/src/control/common"
 	"github.com/daos-stack/daos/src/control/fault"
 	"github.com/daos-stack/daos/src/control/fault/code"
@@ -81,12 +82,12 @@ var (
 	)
 	FaultHarnessNotStarted = serverFault(
 		code.ServerHarnessNotStarted,
-		fmt.Sprintf("%s harness not started", DataPlaneName),
+		fmt.Sprintf("%s harness not started", build.DataPlaneName),
 		"retry the operation or check server logs for more details",
 	)
 	FaultDataPlaneNotStarted = serverFault(
 		code.ServerDataPlaneNotStarted,
-		fmt.Sprintf("%s instance not started or not responding on dRPC", DataPlaneName),
+		fmt.Sprintf("%s instance not started or not responding on dRPC", build.DataPlaneName),
 		"retry the operation or check server logs for more details",
 	)
 )

--- a/src/control/server/instance.go
+++ b/src/control/server/instance.go
@@ -33,6 +33,7 @@ import (
 	"github.com/golang/protobuf/proto"
 	"github.com/pkg/errors"
 
+	"github.com/daos-stack/daos/src/control/build"
 	mgmtpb "github.com/daos-stack/daos/src/control/common/proto/mgmt"
 	srvpb "github.com/daos-stack/daos/src/control/common/proto/srv"
 	"github.com/daos-stack/daos/src/control/drpc"
@@ -255,7 +256,7 @@ func (srv *IOServerInstance) startMgmtSvc() error {
 
 	// should have been loaded by now
 	if superblock == nil {
-		return errors.Errorf("%s instance %d: nil superblock", DataPlaneName, srv.Index())
+		return errors.Errorf("%s instance %d: nil superblock", build.DataPlaneName, srv.Index())
 	}
 
 	if superblock.CreateMS {

--- a/src/control/server/instance_drpc.go
+++ b/src/control/server/instance_drpc.go
@@ -29,6 +29,7 @@ import (
 	"github.com/golang/protobuf/proto"
 	"github.com/pkg/errors"
 
+	"github.com/daos-stack/daos/src/control/build"
 	mgmtpb "github.com/daos-stack/daos/src/control/common/proto/mgmt"
 	srvpb "github.com/daos-stack/daos/src/control/common/proto/srv"
 	"github.com/daos-stack/daos/src/control/drpc"
@@ -53,7 +54,7 @@ func (srv *IOServerInstance) getDrpcClient() (drpc.DomainSocketClient, error) {
 // NotifyDrpcReady receives a ready message from the running IOServer
 // instance.
 func (srv *IOServerInstance) NotifyDrpcReady(msg *srvpb.NotifyReadyReq) {
-	srv.log.Debugf("%s instance %d drpc ready: %v", DataPlaneName, srv.Index(), msg)
+	srv.log.Debugf("%s instance %d drpc ready: %v", build.DataPlaneName, srv.Index(), msg)
 
 	// Activate the dRPC client connection to this iosrv
 	srv.setDrpcClient(drpc.NewClientConnection(msg.DrpcListenerSock))

--- a/src/control/server/instance_exec.go
+++ b/src/control/server/instance_exec.go
@@ -29,6 +29,7 @@ import (
 
 	"github.com/pkg/errors"
 
+	"github.com/daos-stack/daos/src/control/build"
 	srvpb "github.com/daos-stack/daos/src/control/common/proto/srv"
 	"github.com/daos-stack/daos/src/control/server/ioserver"
 	"github.com/daos-stack/daos/src/control/system"
@@ -81,7 +82,7 @@ func (srv *IOServerInstance) start(ctx context.Context, errChan chan<- error) er
 // management service on MS replicas immediately so other instances can join.
 // I/O server modules are then loaded.
 func (srv *IOServerInstance) waitReady(ctx context.Context, errChan chan error) error {
-	srv.log.Debugf("instance %d: awaiting %s init", srv.Index(), DataPlaneName)
+	srv.log.Debugf("instance %d: awaiting %s init", srv.Index(), build.DataPlaneName)
 
 	select {
 	case <-ctx.Done(): // propagated harness exit

--- a/src/control/server/instance_storage.go
+++ b/src/control/server/instance_storage.go
@@ -32,6 +32,7 @@ import (
 	"github.com/dustin/go-humanize"
 	"github.com/pkg/errors"
 
+	"github.com/daos-stack/daos/src/control/build"
 	"github.com/daos-stack/daos/src/control/server/storage"
 	"github.com/daos-stack/daos/src/control/server/storage/scm"
 )
@@ -123,7 +124,7 @@ func (srv *IOServerInstance) awaitStorageReady(ctx context.Context, skipMissingS
 		return errors.Errorf("can't wait for storage: instance %d already started", idx)
 	}
 
-	srv.log.Infof("Checking %s instance %d storage ...", DataPlaneName, idx)
+	srv.log.Infof("Checking %s instance %d storage ...", build.DataPlaneName, idx)
 
 	needsScmFormat, err := srv.NeedsScmFormat()
 	if err != nil {
@@ -161,9 +162,9 @@ func (srv *IOServerInstance) awaitStorageReady(ctx context.Context, skipMissingS
 
 	select {
 	case <-ctx.Done():
-		srv.log.Infof("%s instance %d storage not ready: %s", DataPlaneName, srv.Index(), ctx.Err())
+		srv.log.Infof("%s instance %d storage not ready: %s", build.DataPlaneName, srv.Index(), ctx.Err())
 	case <-srv.storageReady:
-		srv.log.Infof("%s instance %d storage ready", DataPlaneName, srv.Index())
+		srv.log.Infof("%s instance %d storage ready", build.DataPlaneName, srv.Index())
 	}
 
 	srv.waitFormat.SetFalse()

--- a/src/control/server/instance_storage_rpc.go
+++ b/src/control/server/instance_storage_rpc.go
@@ -28,6 +28,7 @@ import (
 
 	"github.com/pkg/errors"
 
+	"github.com/daos-stack/daos/src/control/build"
 	"github.com/daos-stack/daos/src/control/common/proto"
 	ctlpb "github.com/daos-stack/daos/src/control/common/proto/ctl"
 	"github.com/daos-stack/daos/src/control/fault"
@@ -137,7 +138,7 @@ func (srv *IOServerInstance) StorageFormatSCM(reformat bool) (mResult *ctlpb.Scm
 	needsScmFormat := reformat
 
 	srv.log.Infof("Formatting scm storage for %s instance %d (reformat: %t)",
-		DataPlaneName, srvIdx, reformat)
+		build.DataPlaneName, srvIdx, reformat)
 
 	var scmErr error
 	defer func() {
@@ -173,7 +174,7 @@ func (srv *IOServerInstance) StorageFormatSCM(reformat bool) (mResult *ctlpb.Scm
 }
 
 func (srv *IOServerInstance) StorageFormatNVMe(bdevProvider *bdev.Provider) (cResults proto.NvmeControllerResults) {
-	srv.log.Infof("Formatting nvme storage for %s instance %d", DataPlaneName, srv.Index())
+	srv.log.Infof("Formatting nvme storage for %s instance %d", build.DataPlaneName, srv.Index())
 
 	// If no superblock exists, format NVMe and populate response with results.
 	needsSuperblock, err := srv.NeedsSuperblock()

--- a/src/control/server/interceptors.go
+++ b/src/control/server/interceptors.go
@@ -55,6 +55,7 @@ func checkAccess(ctx context.Context, FullMethod string) error {
 
 	return nil
 }
+
 func componentFromContext(ctx context.Context) (comp *security.Component, err error) {
 	clientPeer, ok := peer.FromContext(ctx)
 	if !ok {

--- a/src/control/server/mgmt_svc.go
+++ b/src/control/server/mgmt_svc.go
@@ -160,6 +160,8 @@ func newMgmtSvc(h *IOServerHarness, m *system.Membership, c *ClientNetworkCfg) *
 }
 
 func (svc *mgmtSvc) GetAttachInfo(ctx context.Context, req *mgmtpb.GetAttachInfoReq) (*mgmtpb.GetAttachInfoResp, error) {
+	svc.log.Debugf("MgmtSvc.GetAttachInfo dispatch, req:%+v\n", *req)
+
 	if svc.clientNetworkCfg == nil {
 		return nil, errors.New("clientNetworkCfg is missing")
 	}
@@ -178,6 +180,8 @@ func (svc *mgmtSvc) GetAttachInfo(ctx context.Context, req *mgmtpb.GetAttachInfo
 	resp.CrtCtxShareAddr = svc.clientNetworkCfg.CrtCtxShareAddr
 	resp.CrtTimeout = svc.clientNetworkCfg.CrtTimeout
 	resp.NetDevClass = svc.clientNetworkCfg.NetDevClass
+
+	svc.log.Debugf("MgmtSvc.GetAttachInfo dispatch, resp:%+v\n", *resp)
 	return resp, nil
 }
 

--- a/src/control/server/server.go
+++ b/src/control/server/server.go
@@ -37,6 +37,7 @@ import (
 	"github.com/pkg/errors"
 	"google.golang.org/grpc"
 
+	"github.com/daos-stack/daos/src/control/build"
 	ctlpb "github.com/daos-stack/daos/src/control/common/proto/ctl"
 	mgmtpb "github.com/daos-stack/daos/src/control/common/proto/mgmt"
 	"github.com/daos-stack/daos/src/control/lib/control"
@@ -51,11 +52,6 @@ import (
 )
 
 const (
-	// ControlPlaneName defines a consistent name for the control plane server.
-	ControlPlaneName = "DAOS Control Server"
-	// DataPlaneName defines a consistent name for the ioserver.
-	DataPlaneName = "DAOS I/O Server"
-
 	iommuPath        = "/sys/class/iommu"
 	minHugePageCount = 128
 )
@@ -308,7 +304,7 @@ func Start(log *logging.LeveledLogger, cfg *Configuration) error {
 	}()
 	defer grpcServer.GracefulStop()
 
-	log.Infof("%s (pid %d) listening on %s", ControlPlaneName, os.Getpid(), controlAddr)
+	log.Infof("%s (pid %d) listening on %s", build.ControlPlaneName, os.Getpid(), controlAddr)
 
 	sigChan := make(chan os.Signal)
 	signal.Notify(sigChan, syscall.SIGINT, syscall.SIGQUIT, syscall.SIGTERM)
@@ -321,5 +317,5 @@ func Start(log *logging.LeveledLogger, cfg *Configuration) error {
 		shutdown()
 	}()
 
-	return errors.Wrapf(harness.Start(ctx, membership, cfg), "%s exited with error", DataPlaneName)
+	return errors.Wrapf(harness.Start(ctx, membership, cfg), "%s exited with error", build.DataPlaneName)
 }

--- a/src/control/system/errors.go
+++ b/src/control/system/errors.go
@@ -1,0 +1,69 @@
+//
+// (C) Copyright 2020 Intel Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// GOVERNMENT LICENSE RIGHTS-OPEN SOURCE SOFTWARE
+// The Government's rights to use, modify, reproduce, release, perform, display,
+// or disclose this software are subject to the terms of the Apache License as
+// provided in Contract No. 8F-30005.
+// Any reproduction of computer software, computer software documentation, or
+// portions thereof marked with this legend must also reproduce the markings.
+//
+
+package system
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/daos-stack/daos/src/control/build"
+	"github.com/pkg/errors"
+)
+
+// ErrNotReplica indicates that a request was made to a control plane
+// instance that is not a designated Management Service replica.
+type ErrNotReplica struct {
+	Replicas []string
+}
+
+func (err *ErrNotReplica) Error() string {
+	return fmt.Sprintf("not a %s replica (try one of %s)",
+		build.ManagementServiceName, strings.Join(err.Replicas, ","))
+}
+
+// IsNotReplica returns a boolean indicating whether or not the
+// supplied error is an instance of ErrNotReplica.
+func IsNotReplica(err error) bool {
+	_, ok := errors.Cause(err).(*ErrNotReplica)
+	return ok
+}
+
+// ErrNotLeader indicates that a request was made to a control plane
+// instance that is not the current Management Service Leader.
+type ErrNotLeader struct {
+	LeaderHint string
+	Replicas   []string
+}
+
+func (err *ErrNotLeader) Error() string {
+	return fmt.Sprintf("not the %s leader (try %s or one of %s)",
+		build.ManagementServiceName, err.LeaderHint, strings.Join(err.Replicas, ","))
+}
+
+// IsNotLeader returns a boolean indicating whether or not the
+// supplied error is an instance of ErrNotLeader.
+func IsNotLeader(err error) bool {
+	_, ok := errors.Cause(err).(*ErrNotLeader)
+	return ok
+}


### PR DESCRIPTION
Encode MS leadership/replica info in new error types that
survive the trip over gRPC.

Also moves the component name variables into the build
package, which is a better location for them.