### PR TITLE
DAOS-5661 KV: add ops for KV open/close/destroy

### DIFF
--- a/src/client/api/kv.c
+++ b/src/client/api/kv.c
@@ -33,6 +33,62 @@
 #include <daos_kv.h>
 
 int
+daos_kv_open(daos_handle_t coh, daos_obj_id_t oid, unsigned int mode,
+	     daos_handle_t *oh, daos_event_t *ev)
+{
+	daos_kv_open_t	*args;
+	tse_task_t	*task;
+	int		rc;
+
+	rc = dc_task_create(dc_kv_open, NULL, ev, &task);
+	if (rc)
+		return rc;
+
+	args = dc_task_get_args(task);
+	args->coh	 = coh;
+	args->oid	 = oid;
+	args->mode	 = mode;
+	args->oh	 = oh;
+
+	return dc_task_schedule(task, true);
+}
+
+int
+daos_kv_close(daos_handle_t oh, daos_event_t *ev)
+{
+	daos_kv_close_t	*args;
+	tse_task_t	*task;
+	int		rc;
+
+	rc = dc_task_create(dc_kv_close, NULL, ev, &task);
+	if (rc)
+		return rc;
+
+	args = dc_task_get_args(task);
+	args->oh = oh;
+
+	return dc_task_schedule(task, true);
+}
+
+int
+daos_kv_destroy(daos_handle_t oh, daos_handle_t th, daos_event_t *ev)
+{
+	daos_kv_destroy_t	*args;
+	tse_task_t		*task;
+	int			 rc;
+
+	rc = dc_task_create(dc_kv_destroy, NULL, ev, &task);
+	if (rc)
+		return rc;
+
+	args = dc_task_get_args(task);
+	args->oh	= oh;
+	args->th	= th;
+
+	return dc_task_schedule(task, true);
+}
+
+int
 daos_kv_put(daos_handle_t oh, daos_handle_t th, uint64_t flags, const char *key,
 	    daos_size_t buf_size, const void *buf, daos_event_t *ev)
 {

--- a/src/client/array/dc_array.c
+++ b/src/client/array/dc_array.c
@@ -43,7 +43,7 @@
 struct dc_array {
 	/** link chain in the global handle hash table */
 	struct d_hlink		hlink;
-	/** DAOS KV object handle */
+	/** DAOS object handle */
 	daos_handle_t		daos_oh;
 	/** Array cell size of each element */
 	daos_size_t		cell_size;
@@ -774,7 +774,7 @@ dc_array_open(tse_task_t *task)
 		rc = tse_task_register_deps(task, 1, &open_task);
 		if (rc != 0) {
 			D_ERROR("Failed to register dependency\n");
-			D_GOTO(err_put2, rc);
+			D_GOTO(err_put1, rc);
 		}
 
 		rc = tse_task_register_comp_cb(task, open_handle_cb, &args,

--- a/src/client/kv/dc_kv.c
+++ b/src/client/kv/dc_kv.c
@@ -35,6 +35,19 @@
 #include <daos_kv.h>
 #include <daos_task.h>
 
+struct dc_kv {
+	/** link chain in the global handle hash table */
+	struct d_hlink		hlink;
+	/** DAOS object handle */
+	daos_handle_t		daos_oh;
+	/** DAOS container handle of kv */
+	daos_handle_t		coh;
+	/** DAOS object ID of kv */
+	daos_obj_id_t		oid;
+	/** object handle access mode */
+	unsigned int		mode;
+};
+
 struct io_params {
 	daos_key_t		dkey;
 	daos_iod_t		iod;
@@ -42,6 +55,287 @@ struct io_params {
 	d_sg_list_t		sgl;
 	char			akey_val;
 };
+
+static void
+kv_free(struct d_hlink *hlink)
+{
+	struct dc_kv *kv;
+
+	kv = container_of(hlink, struct dc_kv, hlink);
+	D_ASSERT(daos_hhash_link_empty(&kv->hlink));
+	D_FREE(kv);
+}
+
+static struct d_hlink_ops kv_h_ops = {
+	.hop_free	= kv_free,
+};
+
+static struct dc_kv *
+kv_alloc(void)
+{
+	struct dc_kv *kv;
+
+	D_ALLOC_PTR(kv);
+	if (kv == NULL)
+		return NULL;
+
+	daos_hhash_hlink_init(&kv->hlink, &kv_h_ops);
+	return kv;
+}
+
+static void
+kv_decref(struct dc_kv *kv)
+{
+	daos_hhash_link_putref(&kv->hlink);
+}
+
+static daos_handle_t
+kv_ptr2hdl(struct dc_kv *kv)
+{
+	daos_handle_t oh;
+
+	daos_hhash_link_key(&kv->hlink, &oh.cookie);
+	return oh;
+}
+
+static struct dc_kv *
+kv_hdl2ptr(daos_handle_t oh)
+{
+	struct d_hlink *hlink;
+
+	hlink = daos_hhash_link_lookup(oh.cookie);
+	if (hlink == NULL)
+		return NULL;
+
+	return container_of(hlink, struct dc_kv, hlink);
+}
+
+static void
+kv_hdl_link(struct dc_kv *kv)
+{
+	daos_hhash_link_insert(&kv->hlink, DAOS_HTYPE_KV);
+}
+
+static void
+kv_hdl_unlink(struct dc_kv *kv)
+{
+	daos_hhash_link_delete(&kv->hlink);
+}
+
+static int
+open_handle_cb(tse_task_t *task, void *data)
+{
+	daos_kv_open_t	*args = *((daos_kv_open_t **)data);
+	struct dc_kv	*kv;
+	int		rc = task->dt_result;
+
+	if (rc != 0) {
+		D_ERROR("Failed to open kv obj "DF_RC"\n", DP_RC(rc));
+		D_GOTO(err_obj, rc);
+	}
+
+	/** Create an KV OH from the DAOS one */
+	kv = kv_alloc();
+	if (kv == NULL)
+		D_GOTO(err_obj, rc = -DER_NOMEM);
+
+	kv->coh		= args->coh;
+	kv->oid.hi	= args->oid.hi;
+	kv->oid.lo	= args->oid.lo;
+	kv->mode	= DAOS_OO_RW;
+	kv->daos_oh	= *args->oh;
+
+	kv_hdl_link(kv);
+	*args->oh = kv_ptr2hdl(kv);
+
+	return 0;
+
+err_obj:
+	if (daos_handle_is_valid(*args->oh)) {
+		daos_obj_close_t *close_args;
+		tse_task_t *close_task;
+
+		daos_task_create(DAOS_OPC_OBJ_CLOSE, tse_task2sched(task),
+				 0, NULL, &close_task);
+		close_args = daos_task_get_args(close_task);
+		close_args->oh = *args->oh;
+		tse_task_schedule(close_task, true);
+	}
+	return rc;
+}
+
+static int
+free_handle_cb(tse_task_t *task, void *data)
+{
+	struct dc_kv	*kv = *((struct dc_kv **)data);
+	int		rc = task->dt_result;
+
+	if (rc != 0)
+		return rc;
+
+	kv_hdl_unlink(kv);
+
+	/* -1 for ref taken in dc_kv_close */
+	kv_decref(kv);
+	/* -1 for kv handle */
+	kv_decref(kv);
+
+	return 0;
+}
+
+int
+dc_kv_open(tse_task_t *task)
+{
+	daos_kv_open_t		*args = daos_task_get_args(task);
+	tse_task_t		*open_task = NULL;
+	daos_obj_open_t		*open_args;
+	daos_ofeat_t		ofeat;
+	int			rc;
+
+	ofeat = daos_obj_id2feat(args->oid);
+	if (!(ofeat & DAOS_OF_KV_FLAT)) {
+		D_ERROR("KV object must be of type Flat KV (OID feats).\n");
+		D_GOTO(err_ptask, rc = -DER_INVAL);
+	}
+
+	/** Create task to open object */
+	rc = daos_task_create(DAOS_OPC_OBJ_OPEN, tse_task2sched(task),
+			      0, NULL, &open_task);
+	if (rc != 0) {
+		D_ERROR("Failed to open object_open task\n");
+		D_GOTO(err_ptask, rc);
+	}
+
+	open_args = daos_task_get_args(open_task);
+	open_args->coh	= args->coh;
+	open_args->oid	= args->oid;
+	open_args->mode	= args->mode;
+	open_args->oh	= args->oh;
+
+	/** The upper task completes when the open task completes */
+	rc = tse_task_register_deps(task, 1, &open_task);
+	if (rc != 0) {
+		D_ERROR("Failed to register dependency\n");
+		D_GOTO(err_put1, rc);
+	}
+
+	rc = tse_task_register_comp_cb(task, open_handle_cb, &args,
+				       sizeof(args));
+	if (rc != 0) {
+		D_ERROR("Failed to register completion cb\n");
+		D_GOTO(err_put1, rc);
+	}
+
+	tse_task_schedule(open_task, false);
+	tse_sched_progress(tse_task2sched(task));
+	return rc;
+
+err_put1:
+	tse_task_complete(open_task, rc);
+err_ptask:
+	tse_task_complete(task, rc);
+	return rc;
+}
+
+int
+dc_kv_close(tse_task_t *task)
+{
+	daos_kv_close_t		*args = daos_task_get_args(task);
+	struct dc_kv		*kv;
+	tse_task_t		*close_task;
+	daos_obj_close_t	*close_args;
+	int			rc;
+
+	/** decref for that in free_handle_cb */
+	kv = kv_hdl2ptr(args->oh);
+	if (kv == NULL)
+		D_GOTO(err_ptask, rc = -DER_NO_HDL);
+
+	/** Create task to close object */
+	rc = daos_task_create(DAOS_OPC_OBJ_CLOSE, tse_task2sched(task),
+			      0, NULL, &close_task);
+	if (rc != 0) {
+		D_ERROR("Failed to create object_close task\n");
+		D_GOTO(err_put1, rc);
+	}
+	close_args = daos_task_get_args(close_task);
+	close_args->oh = kv->daos_oh;
+
+	/** The upper task completes when the close task completes */
+	rc = tse_task_register_deps(task, 1, &close_task);
+	if (rc != 0) {
+		D_ERROR("Failed to register dependency\n");
+		D_GOTO(err_put2, rc);
+	}
+
+	/** Add a completion CB on the upper task to free the kv */
+	rc = tse_task_register_cbs(task, NULL, NULL, 0, free_handle_cb,
+				   &kv, sizeof(kv));
+	if (rc != 0) {
+		D_ERROR("Failed to register completion cb\n");
+		D_GOTO(err_put2, rc);
+	}
+
+	tse_task_schedule(close_task, false);
+	tse_sched_progress(tse_task2sched(task));
+
+	return rc;
+err_put2:
+	tse_task_complete(close_task, rc);
+err_put1:
+	kv_decref(kv);
+err_ptask:
+	tse_task_complete(task, rc);
+	return rc;
+}
+
+int
+dc_kv_destroy(tse_task_t *task)
+{
+	daos_kv_destroy_t	*args = daos_task_get_args(task);
+	struct dc_kv		*kv;
+	tse_task_t		*punch_task;
+	daos_obj_punch_t	*punch_args;
+	int			rc;
+
+	kv = kv_hdl2ptr(args->oh);
+	if (kv == NULL)
+		D_GOTO(err_ptask, rc = -DER_NO_HDL);
+
+	/** Create task to punch object */
+	rc = daos_task_create(DAOS_OPC_OBJ_PUNCH, tse_task2sched(task),
+			      0, NULL, &punch_task);
+	if (rc != 0) {
+		D_ERROR("Failed to create object_punch task\n");
+		D_GOTO(err_put1, rc);
+	}
+	punch_args = daos_task_get_args(punch_task);
+	punch_args->oh		= kv->daos_oh;
+	punch_args->th		= args->th;
+	punch_args->dkey	= NULL;
+	punch_args->akeys	= NULL;
+	punch_args->akey_nr	= 0;
+
+	/** The upper task completes when the punch task completes */
+	rc = tse_task_register_deps(task, 1, &punch_task);
+	if (rc != 0) {
+		D_ERROR("Failed to register dependency\n");
+		D_GOTO(err_put2, rc);
+	}
+
+	tse_task_schedule(punch_task, false);
+	tse_sched_progress(tse_task2sched(task));
+	kv_decref(kv);
+
+	return rc;
+err_put2:
+	tse_task_complete(punch_task, rc);
+err_put1:
+	kv_decref(kv);
+err_ptask:
+	tse_task_complete(task, rc);
+	return rc;
+}
 
 static int
 free_io_params_cb(tse_task_t *task, void *data)
@@ -67,6 +361,7 @@ int
 dc_kv_put(tse_task_t *task)
 {
 	daos_kv_put_t		*args = daos_task_get_args(task);
+	struct dc_kv		*kv;
 	daos_obj_update_t	*update_args;
 	tse_task_t		*update_task = NULL;
 	struct io_params	*params = NULL;
@@ -74,6 +369,10 @@ dc_kv_put(tse_task_t *task)
 
 	if (args->key == NULL || args->buf_size == 0 || args->buf == NULL)
 		D_GOTO(err_task, rc = -DER_INVAL);
+
+	kv = kv_hdl2ptr(args->oh);
+	if (kv == NULL)
+		D_GOTO(err_task, rc = -DER_NO_HDL);
 
 	D_ALLOC_PTR(params);
 	if (params == NULL)
@@ -101,7 +400,7 @@ dc_kv_put(tse_task_t *task)
 		D_GOTO(err_task, rc);
 
 	update_args = daos_task_get_args(update_task);
-	update_args->oh		= args->oh;
+	update_args->oh		= kv->daos_oh;
 	update_args->th		= args->th;
 	update_args->flags	= args->flags;
 	update_args->dkey	= &params->dkey;
@@ -139,6 +438,7 @@ int
 dc_kv_get(tse_task_t *task)
 {
 	daos_kv_get_t		*args = daos_task_get_args(task);
+	struct dc_kv		*kv;
 	daos_obj_fetch_t	*fetch_args;
 	tse_task_t		*fetch_task = NULL;
 	struct io_params	*params = NULL;
@@ -148,6 +448,10 @@ dc_kv_get(tse_task_t *task)
 
 	if (args->key == NULL)
 		D_GOTO(err_task, rc = -DER_INVAL);
+
+	kv = kv_hdl2ptr(args->oh);
+	if (kv == NULL)
+		D_GOTO(err_task, rc = -DER_NO_HDL);
 
 	buf = args->buf;
 	buf_size = args->buf_size;
@@ -184,7 +488,7 @@ dc_kv_get(tse_task_t *task)
 		D_GOTO(err_task, rc);
 
 	fetch_args = daos_task_get_args(fetch_task);
-	fetch_args->oh		= args->oh;
+	fetch_args->oh		= kv->daos_oh;
 	fetch_args->th		= args->th;
 	fetch_args->flags	= args->flags;
 	fetch_args->dkey	= &params->dkey;
@@ -228,6 +532,7 @@ int
 dc_kv_remove(tse_task_t *task)
 {
 	daos_kv_remove_t	*args = daos_task_get_args(task);
+	struct dc_kv		*kv;
 	daos_obj_punch_t	*punch_args;
 	tse_task_t		*punch_task = NULL;
 	struct io_params	*params = NULL;
@@ -235,6 +540,10 @@ dc_kv_remove(tse_task_t *task)
 
 	if (args->key == NULL)
 		D_GOTO(err_task, rc = -DER_INVAL);
+
+	kv = kv_hdl2ptr(args->oh);
+	if (kv == NULL)
+		D_GOTO(err_task, rc = -DER_NO_HDL);
 
 	D_ALLOC_PTR(params);
 	if (params == NULL)
@@ -249,7 +558,7 @@ dc_kv_remove(tse_task_t *task)
 		D_GOTO(err_task, rc);
 
 	punch_args = daos_task_get_args(punch_task);
-	punch_args->oh		= args->oh;
+	punch_args->oh		= kv->daos_oh;
 	punch_args->th		= args->th;
 	punch_args->flags	= args->flags;
 	punch_args->dkey	= &params->dkey;
@@ -286,9 +595,14 @@ int
 dc_kv_list(tse_task_t *task)
 {
 	daos_kv_list_t		*args = daos_task_get_args(task);
+	struct dc_kv		*kv;
 	daos_obj_list_dkey_t	*list_args;
 	tse_task_t		*list_task = NULL;
 	int			rc;
+
+	kv = kv_hdl2ptr(args->oh);
+	if (kv == NULL)
+		D_GOTO(err_task, rc = -DER_NO_HDL);
 
 	rc = daos_task_create(DAOS_OPC_OBJ_LIST_DKEY, tse_task2sched(task),
 			      0, NULL, &list_task);
@@ -296,7 +610,7 @@ dc_kv_list(tse_task_t *task)
 		D_GOTO(err_task, rc);
 
 	list_args = daos_task_get_args(list_task);
-	list_args->oh		= args->oh;
+	list_args->oh		= kv->daos_oh;
 	list_args->th		= args->th;
 	list_args->nr		= args->nr;
 	list_args->sgl		= args->sgl;

--- a/src/client/pydaos/pydaos_core.py
+++ b/src/client/pydaos/pydaos_core.py
@@ -199,12 +199,12 @@ class _Obj(object):
         self._dc = DaosClient()
         self.oid = oid
         # Set self.oh to Null here so it's defined in __dell__ if there's
-        # a problem with the obj_open() call.
+        # a problem with the kv_open() call.
         self.oh = None
         # keep container around until all objects are gone
         self.cont = cont
         # Open to the object
-        (ret, oh) = pydaos_shim.obj_open(DAOS_MAGIC, coh, self.oid.hi,
+        (ret, oh) = pydaos_shim.kv_open(DAOS_MAGIC, coh, self.oid.hi,
                                          self.oid.lo, 0)
         if ret != pydaos_shim.DER_SUCCESS:
             raise PyDError("failed to open object", ret)
@@ -213,7 +213,7 @@ class _Obj(object):
     def __del__(self):
         if self.oh is None:
             return
-        ret = pydaos_shim.obj_close(DAOS_MAGIC, self.oh)
+        ret = pydaos_shim.kv_close(DAOS_MAGIC, self.oh)
         if ret != pydaos_shim.DER_SUCCESS:
             raise PyDError("failed to close object", ret)
 

--- a/src/client/pydaos/pydaos_shim.c
+++ b/src/client/pydaos/pydaos_shim.c
@@ -385,7 +385,7 @@ __shim_handle__obj_idroot(PyObject *self, PyObject *args)
 	oid.hi = 0;
 	oid.lo = 0;
 
-	daos_obj_generate_id(&oid, 0, cid, 0);
+	daos_obj_generate_id(&oid, DAOS_OF_KV_FLAT, cid, 0);
 
 	return_list = PyList_New(3);
 	PyList_SetItem(return_list, 0, PyInt_FromLong(DER_SUCCESS));
@@ -413,7 +413,7 @@ __shim_handle__obj_idgen(PyObject *self, PyObject *args)
 	oid.lo = rand();
 	oid.hi = 0;
 
-	daos_obj_generate_id(&oid, 0, cid, 0);
+	daos_obj_generate_id(&oid, DAOS_OF_KV_FLAT, cid, 0);
 
 	return_list = PyList_New(3);
 	PyList_SetItem(return_list, 0, PyInt_FromLong(DER_SUCCESS));
@@ -424,7 +424,7 @@ __shim_handle__obj_idgen(PyObject *self, PyObject *args)
 }
 
 static PyObject *
-__shim_handle__obj_open(PyObject *self, PyObject *args)
+__shim_handle__kv_open(PyObject *self, PyObject *args)
 {
 	PyObject	*return_list;
 	daos_handle_t	 coh;
@@ -438,7 +438,7 @@ __shim_handle__obj_open(PyObject *self, PyObject *args)
 				       &oid.lo, &flags);
 
 	/** Open object */
-	rc = daos_obj_open(coh, oid, DAOS_OO_RW, &oh, NULL);
+	rc = daos_kv_open(coh, oid, DAOS_OO_RW, &oh, NULL);
 
 	/* Populate return list */
 	return_list = PyList_New(2);
@@ -449,7 +449,7 @@ __shim_handle__obj_open(PyObject *self, PyObject *args)
 }
 
 static PyObject *
-__shim_handle__obj_close(PyObject *self, PyObject *args)
+__shim_handle__kv_close(PyObject *self, PyObject *args)
 {
 	daos_handle_t	 oh;
 	int		 rc;
@@ -458,7 +458,7 @@ __shim_handle__obj_close(PyObject *self, PyObject *args)
 	RETURN_NULL_IF_FAILED_TO_PARSE(args, "L", &oh.cookie);
 
 	/** Close object */
-	rc = daos_obj_close(oh, NULL);
+	rc = daos_kv_close(oh, NULL);
 
 	return PyInt_FromLong(rc);
 }
@@ -994,10 +994,10 @@ static PyMethodDef daosMethods[] = {
 	/** Object operations */
 	EXPORT_PYTHON_METHOD(obj_idgen),
 	EXPORT_PYTHON_METHOD(obj_idroot),
-	EXPORT_PYTHON_METHOD(obj_open),
-	EXPORT_PYTHON_METHOD(obj_close),
 
 	/** KV operations */
+	EXPORT_PYTHON_METHOD(kv_open),
+	EXPORT_PYTHON_METHOD(kv_close),
 	EXPORT_PYTHON_METHOD(kv_get),
 	EXPORT_PYTHON_METHOD(kv_put),
 	EXPORT_PYTHON_METHOD(kv_iter),

--- a/src/include/daos/kv.h
+++ b/src/include/daos/kv.h
@@ -28,6 +28,9 @@
 #define  __DAOS_KVX_H__
 
 /* task function for HL operations */
+int dc_kv_open(tse_task_t *task);
+int dc_kv_close(tse_task_t *task);
+int dc_kv_destroy(tse_task_t *task);
 int dc_kv_get(tse_task_t *task);
 int dc_kv_put(tse_task_t *task);
 int dc_kv_remove(tse_task_t *task);

--- a/src/include/daos/task.h
+++ b/src/include/daos/task.h
@@ -110,7 +110,10 @@ struct daos_task_args {
 		daos_array_get_size_t	array_get_size;
 		daos_array_set_size_t	array_set_size;
 
-		/** HL */
+		/** KV */
+		daos_kv_open_t		kv_open;
+		daos_kv_close_t		kv_close;
+		daos_kv_destroy_t	kv_destroy;
 		daos_kv_get_t		kv_get;
 		daos_kv_put_t		kv_put;
 		daos_kv_remove_t	kv_remove;

--- a/src/include/daos_kv.h
+++ b/src/include/daos_kv.h
@@ -46,6 +46,61 @@ extern "C" {
 #define DAOS_COND_KEY_REMOVE	DAOS_COND_PUNCH
 
 /**
+ * Open a KV object. This is a local operation (no RPC involved).
+ *
+ * \param[in]	coh	Container open handle.
+ * \param[in]	oid	Object ID. It is required that the feat for dkey type
+ *			be set to DAOS_OF_KV_FLAT.
+ * \param[in]	mode	Open mode: DAOS_OO_RO/RW
+ * \param[out]	oh	Returned kv object open handle.
+ * \param[in]	ev	Completion event, it is optional and can be NULL.
+ *			The function will run in blocking mode if \a ev is NULL.
+ *
+ * \return		These values will be returned by \a ev::ev_error in
+ *			non-blocking mode:
+ *			0		Success
+ *			-DER_NO_HDL	Invalid container handle
+ *			-DER_INVAL	Invalid parameter
+ */
+int
+daos_kv_open(daos_handle_t coh, daos_obj_id_t oid, unsigned int mode,
+	     daos_handle_t *oh, daos_event_t *ev);
+
+/**
+ * Close an opened KV object.
+ *
+ * \param[in]	oh	KV object open handle.
+ * \param[in]	ev	Completion event, it is optional and can be NULL.
+ *			Function will run in blocking mode if \a ev is NULL.
+ *
+ * \return		These values will be returned by \a ev::ev_error in
+ *			non-blocking mode:
+ *			0		Success
+ *			-DER_NO_HDL	Invalid object open handle
+ */
+int
+daos_kv_close(daos_handle_t oh, daos_event_t *ev);
+
+/**
+ * Destroy the kV object by punching all data (keys) in the kv object.
+ * daos_obj_punch() is called underneath. The oh still needs to be closed with a
+ * call to daos_kv_close().
+ *
+ * \param[in]	oh	KV object open handle.
+ * \param[in]	th	Transaction handle.
+ * \param[in]	ev	Completion event, it is optional and can be NULL.
+ *			Function will run in blocking mode if \a ev is NULL.
+ *
+ * \return		These values will be returned by \a ev::ev_error in
+ *			non-blocking mode:
+ *			0		Success
+ *			-DER_NO_HDL	Invalid object open handle
+ *			-DER_INVAL	Invalid parameter
+ */
+int
+daos_kv_destroy(daos_handle_t oh, daos_handle_t th, daos_event_t *ev);
+
+/**
  * Insert or update a single object KV pair. The key specified will be mapped to
  * a dkey in DAOS. The object akey will be the same as the dkey. If a value
  * existed before it will be overwritten (punched first if not previously an

--- a/src/include/daos_task.h
+++ b/src/include/daos_task.h
@@ -131,7 +131,10 @@ typedef enum {
 	DAOS_OPC_ARRAY_GET_SIZE,
 	DAOS_OPC_ARRAY_SET_SIZE,
 
-	/** HL APIs */
+	/** KV APIs */
+	DAOS_OPC_KV_OPEN,
+	DAOS_OPC_KV_CLOSE,
+	DAOS_OPC_KV_DESTROY,
 	DAOS_OPC_KV_GET,
 	DAOS_OPC_KV_PUT,
 	DAOS_OPC_KV_REMOVE,
@@ -942,6 +945,32 @@ typedef struct {
 	/** Transaction open handle. */
 	daos_handle_t		th;
 } daos_array_destroy_t;
+
+/** KV open args */
+typedef struct {
+	/** Container open handle. */
+	daos_handle_t		coh;
+	/** KV ID, */
+	daos_obj_id_t		oid;
+	/** Open mode. */
+	unsigned int		mode;
+	/** Returned KV open handle */
+	daos_handle_t		*oh;
+} daos_kv_open_t;
+
+/** KV close args */
+typedef struct {
+	/** KV open handle. */
+	daos_handle_t		oh;
+} daos_kv_close_t;
+
+/** KV destroy args */
+typedef struct {
+	/** KV open handle. */
+	daos_handle_t		oh;
+	/** Transaction open handle. */
+	daos_handle_t		th;
+} daos_kv_destroy_t;
 
 /** KV get args */
 typedef struct {

--- a/src/include/daos_types.h
+++ b/src/include/daos_types.h
@@ -235,6 +235,7 @@ enum {
 	DAOS_HTYPE_OBJ		= 7, /**< object */
 	DAOS_HTYPE_ARRAY	= 9, /**< array */
 	DAOS_HTYPE_TX		= 11, /**< transaction */
+	DAOS_HTYPE_KV		= 13, /**< KV */
 	/* Must enlarge D_HTYPE_BITS to add more types */
 };
 

--- a/src/tests/suite/daos_kv.c
+++ b/src/tests/suite/daos_kv.c
@@ -46,11 +46,11 @@ static void
 list_keys(daos_handle_t oh, int *num_keys)
 {
 	char		*buf;
-	daos_key_desc_t  kds[ENUM_DESC_NR];
-	daos_anchor_t	 anchor = {0};
-	int		 key_nr = 0;
-	d_sg_list_t	 sgl;
-	d_iov_t       sg_iov;
+	daos_key_desc_t kds[ENUM_DESC_NR];
+	daos_anchor_t	anchor = {0};
+	int		key_nr = 0;
+	d_sg_list_t	sgl;
+	d_iov_t		sg_iov;
 
 	buf = malloc(ENUM_DESC_BUF);
 	d_iov_set(&sg_iov, buf, ENUM_DESC_BUF);
@@ -117,7 +117,7 @@ simple_put_get(void **state)
 	}
 
 	/** open the object */
-	rc = daos_obj_open(arg->coh, oid, 0, &oh, NULL);
+	rc = daos_kv_open(arg->coh, oid, 0, &oh, NULL);
 	assert_int_equal(rc, 0);
 
 	rc = daos_kv_put(oh, DAOS_TX_NONE, 0, NULL, buf_size, buf, NULL);
@@ -250,7 +250,11 @@ simple_put_get(void **state)
 	list_keys(oh, &num_keys);
 	assert_int_equal(num_keys, NUM_KEYS - 10);
 
-	rc = daos_obj_close(oh, NULL);
+	print_message("Destroying KV\n");
+	rc = daos_kv_destroy(oh, DAOS_TX_NONE, NULL);
+	assert_int_equal(rc, 0);
+
+	rc = daos_kv_close(oh, NULL);
 	assert_int_equal(rc, 0);
 
 	D_FREE(buf_out);
@@ -276,7 +280,7 @@ kv_cond_ops(void **state)
 	oid = dts_oid_gen(OC_SX, feat, arg->myrank);
 
 	/** open the object */
-	rc = daos_obj_open(arg->coh, oid, 0, &oh, NULL);
+	rc = daos_kv_open(arg->coh, oid, 0, &oh, NULL);
 	assert_int_equal(rc, 0);
 
 	val_out = 5;
@@ -319,6 +323,13 @@ kv_cond_ops(void **state)
 	print_message("Conditional Remove existing Key\n");
 	rc = daos_kv_remove(oh, DAOS_TX_NONE, DAOS_COND_KEY_REMOVE, "Key1",
 			    NULL);
+	assert_int_equal(rc, 0);
+
+	print_message("Destroying KV\n");
+	rc = daos_kv_destroy(oh, DAOS_TX_NONE, NULL);
+	assert_int_equal(rc, 0);
+
+	rc = daos_kv_close(oh, NULL);
 	assert_int_equal(rc, 0);
 
 	print_message("all good\n");


### PR DESCRIPTION
Add three new API functions for opening, closing and destroying
a KV object. previosuly KV objects were relying on the basic obj
API for opening and closing, but this add a wrapper around those
for checking for example the oid to make sure its set to flat.

also update the pydaos shim.

Signed-off-by: Mohamad Chaarawi <mohamad.chaarawi@intel.com>