### PR TITLE
DAOS-5664 control: Add retry/cancel logic to dRPC

### DIFF
--- a/src/control/drpc/module_svc.go
+++ b/src/control/drpc/module_svc.go
@@ -1,5 +1,5 @@
 //
-// (C) Copyright 2018-2019 Intel Corporation.
+// (C) Copyright 2018-2020 Intel Corporation.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -116,7 +116,7 @@ func (r *ModuleService) ProcessMessage(session *Session, msgBytes []byte) ([]byt
 	}
 	module, ok := r.GetModule(ModuleID(msg.GetModule()))
 	if !ok {
-		err = errors.Errorf("Attempted to call unregistered module")
+		r.log.Errorf("Attempted to call unregistered module %d", msg.GetModule())
 		return marshalResponse(msg.GetSequence(), Status_UNKNOWN_MODULE, nil)
 	}
 	var method Method
@@ -126,7 +126,7 @@ func (r *ModuleService) ProcessMessage(session *Session, msgBytes []byte) ([]byt
 	}
 	respBody, err := module.HandleCall(session, method, msg.GetBody())
 	if err != nil {
-		r.log.Errorf("HandleCall for %d:%s failed: %s\n", method.String(), method, err)
+		r.log.Errorf("HandleCall for %s:%s failed: %s\n", module, method, err)
 		return marshalResponse(msg.GetSequence(), ErrorToStatus(err), nil)
 	}
 

--- a/src/control/drpc/modules.go
+++ b/src/control/drpc/modules.go
@@ -109,7 +109,7 @@ func (m securityAgentMethod) String() string {
 		return s
 	}
 
-	return fmt.Sprintf("%d:%d", m.Module(), m.ID())
+	return fmt.Sprintf("%s:%d", m.Module(), m.ID())
 }
 
 // IsValid sanity checks the Method ID is within expected bounds.
@@ -140,15 +140,25 @@ func (m mgmtMethod) ID() int32 {
 
 func (m mgmtMethod) String() string {
 	if s, ok := map[mgmtMethod]string{
-		MethodPrepShutdown: "prep shutdown",
-		MethodPingRank:     "ping",
-		MethodSetRank:      "set rank",
-		MethodSetUp:        "setup MS",
+		MethodPrepShutdown:    "PrepShutdown",
+		MethodPingRank:        "Ping",
+		MethodSetRank:         "SetRank",
+		MethodSetUp:           "SetUp",
+		MethodPoolCreate:      "PoolCreate",
+		MethodPoolDestroy:     "PoolDestroy",
+		MethodPoolEvict:       "PoolEvict",
+		MethodPoolExclude:     "PoolExclude",
+		MethodPoolDrain:       "PoolDrain",
+		MethodPoolExtend:      "PoolExtend",
+		MethodPoolReintegrate: "PoolReintegrate",
+		MethodPoolQuery:       "PoolQuery",
+		MethodPoolSetProp:     "PoolSetProp",
+		MethodListPools:       "ListPools",
 	}[m]; ok {
 		return s
 	}
 
-	return fmt.Sprintf("%d:%d", m.Module(), m.ID())
+	return fmt.Sprintf("%s:%d", m.Module(), m.ID())
 }
 
 // IsValid sanity checks the Method ID is within expected bounds.
@@ -241,7 +251,7 @@ func (m srvMethod) String() string {
 		return s
 	}
 
-	return fmt.Sprintf("%d:%d", m.Module(), m.ID())
+	return fmt.Sprintf("%s:%d", m.Module(), m.ID())
 }
 
 // IsValid sanity checks the Method ID is within expected bounds.
@@ -279,7 +289,7 @@ func (m securityMethod) String() string {
 		return s
 	}
 
-	return fmt.Sprintf("%d:%d", m.Module(), m.ID())
+	return fmt.Sprintf("%s:%d", m.Module(), m.ID())
 }
 
 // IsValid sanity checks the Method ID is within expected bounds.

--- a/src/control/server/drpc.go
+++ b/src/control/server/drpc.go
@@ -27,14 +27,68 @@ import (
 	"context"
 	"os"
 	"path/filepath"
+	"time"
 
 	"github.com/golang/protobuf/proto"
 	"github.com/pkg/errors"
 
+	mgmtpb "github.com/daos-stack/daos/src/control/common/proto/mgmt"
 	"github.com/daos-stack/daos/src/control/drpc"
 	"github.com/daos-stack/daos/src/control/logging"
 	"github.com/daos-stack/daos/src/control/security"
 )
+
+const (
+	defaultRetryAfter = 250 * time.Millisecond
+)
+
+type daosStatusResp struct {
+	Status int32 `protobuf:"varint,1,opt,name=status,proto3" json:"status,omitempty"`
+}
+
+func (dsr *daosStatusResp) String() string {
+	return ""
+}
+
+func (dsr *daosStatusResp) Reset() {}
+
+func (dsr *daosStatusResp) ProtoMessage() {}
+
+type retryableDrpcReq struct {
+	proto.Message
+	RetryAfter        time.Duration
+	RetryableStatuses []drpc.DaosStatus
+}
+
+func (rdr *retryableDrpcReq) GetMessage() proto.Message {
+	return rdr.Message
+}
+
+// isRetryable tests the request to see if it is already wrapped
+// in a retryableDrpcReq, or if it is a known-retryable request
+// type. In the latter case, the incoming request is wrapped and
+// returned.
+func isRetryable(msg proto.Message) (*retryableDrpcReq, bool) {
+	// NB: This list of retryable types is a convenience to reduce
+	// boilerplate. It's still possible to set custom retry behavior
+	// by manually wrapping a request before calling makeDrpcCall().
+	switch msg := msg.(type) {
+	case *retryableDrpcReq:
+		return msg, true
+	// Pool creates are notorious for needing retry logic
+	// while things are starting up in CI testing.
+	case *mgmtpb.PoolCreateReq:
+		return &retryableDrpcReq{
+			Message: msg,
+			RetryableStatuses: []drpc.DaosStatus{
+				drpc.DaosGroupVersionMismatch,
+				drpc.DaosTimedOut,
+			},
+		}, true
+	}
+
+	return nil, false
+}
 
 func getDrpcServerSocketPath(sockDir string) string {
 	return filepath.Join(sockDir, "daos_server.sock")
@@ -164,33 +218,78 @@ func newDrpcCall(method drpc.Method, bodyMessage proto.Message) (*drpc.Call, err
 // makeDrpcCall opens a drpc connection, sends a message with the
 // protobuf message marshalled in the body, and closes the connection.
 // drpc response is returned after basic checks.
-func makeDrpcCall(client drpc.DomainSocketClient, method drpc.Method, body proto.Message) (drpcResp *drpc.Response, err error) {
-	drpcCall, err := newDrpcCall(method, body)
-	if err != nil {
-		return drpcResp, errors.Wrap(err, "build drpc call")
-	}
-
+func makeDrpcCall(ctx context.Context, log logging.Logger, client drpc.DomainSocketClient, method drpc.Method, body proto.Message) (drpcResp *drpc.Response, err error) {
 	client.Lock()
 	defer client.Unlock()
 
-	// Forward the request to the I/O server via dRPC
-	if err = client.Connect(); err != nil {
-		if te, ok := errors.Cause(err).(interface{ Temporary() bool }); ok {
-			if !te.Temporary() {
-				return nil, FaultDataPlaneNotStarted
+	tryCall := func(msg proto.Message) (*drpc.Response, error) {
+		drpcCall, err := newDrpcCall(method, msg)
+		if err != nil {
+			return nil, errors.Wrap(err, "build drpc call")
+		}
+
+		// Forward the request to the I/O server via dRPC
+		if err = client.Connect(); err != nil {
+			if te, ok := errors.Cause(err).(interface{ Temporary() bool }); ok {
+				if !te.Temporary() {
+					return nil, FaultDataPlaneNotStarted
+				}
+			}
+			return nil, errors.Wrap(err, "connect to client")
+		}
+		defer client.Close()
+
+		if drpcResp, err = client.SendMsg(drpcCall); err != nil {
+			return nil, errors.Wrap(err, "send message")
+		}
+
+		if err = checkDrpcResponse(drpcResp); err != nil {
+			return nil, errors.Wrap(err, "validate response")
+		}
+
+		return drpcResp, nil
+	}
+
+	if rdr, ok := isRetryable(body); ok {
+		for {
+			retryable := false
+			drpcResp, err = tryCall(rdr.GetMessage())
+			if err != nil {
+				return nil, err
+			}
+
+			dsr := new(daosStatusResp)
+			if uErr := proto.Unmarshal(drpcResp.Body, dsr); uErr != nil {
+				return
+			}
+			status := drpc.DaosStatus(dsr.Status)
+
+			for _, retryableStatus := range rdr.RetryableStatuses {
+				if status == retryableStatus {
+					retryable = true
+					break
+				}
+			}
+
+			if !retryable {
+				return
+			}
+
+			retryAfter := rdr.RetryAfter
+			if retryAfter == 0 {
+				retryAfter = defaultRetryAfter
+			}
+
+			log.Infof("method %s: retryable %s; retrying after %s", method, status, retryAfter)
+			select {
+			case <-ctx.Done():
+				log.Errorf("method %s; %s", method, ctx.Err())
+				return nil, ctx.Err()
+			case <-time.After(retryAfter):
+				continue
 			}
 		}
-		return drpcResp, errors.Wrap(err, "connect to client")
-	}
-	defer client.Close()
-
-	if drpcResp, err = client.SendMsg(drpcCall); err != nil {
-		return drpcResp, errors.Wrap(err, "send message")
 	}
 
-	if err = checkDrpcResponse(drpcResp); err != nil {
-		return drpcResp, errors.Wrap(err, "validate response")
-	}
-
-	return
+	return tryCall(body)
 }

--- a/src/control/server/harness.go
+++ b/src/control/server/harness.go
@@ -115,13 +115,13 @@ func (h *IOServerHarness) AddInstance(srv *IOServerInstance) error {
 }
 
 // CallDrpc calls the supplied dRPC method on a managed I/O server instance.
-func (h *IOServerHarness) CallDrpc(method drpc.Method, body proto.Message) (*drpc.Response, error) {
+func (h *IOServerHarness) CallDrpc(ctx context.Context, method drpc.Method, body proto.Message) (*drpc.Response, error) {
 	mi, err := h.getMSLeaderInstance()
 	if err != nil {
 		return nil, err
 	}
 
-	return mi.CallDrpc(method, body)
+	return mi.CallDrpc(ctx, method, body)
 }
 
 // getMSLeaderInstance returns a managed IO Server instance to be used as a

--- a/src/control/server/instance.go
+++ b/src/control/server/instance.go
@@ -199,15 +199,15 @@ func (srv *IOServerInstance) setRank(ctx context.Context, ready *srvpb.NotifyRea
 		}
 	}
 
-	if err := srv.callSetRank(r); err != nil {
+	if err := srv.callSetRank(ctx, r); err != nil {
 		return err
 	}
 
 	return nil
 }
 
-func (srv *IOServerInstance) callSetRank(rank system.Rank) error {
-	dresp, err := srv.CallDrpc(drpc.MethodSetRank, &mgmtpb.SetRankReq{Rank: rank.Uint32()})
+func (srv *IOServerInstance) callSetRank(ctx context.Context, rank system.Rank) error {
+	dresp, err := srv.CallDrpc(ctx, drpc.MethodSetRank, &mgmtpb.SetRankReq{Rank: rank.Uint32()})
 	if err != nil {
 		return err
 	}
@@ -250,7 +250,7 @@ func (srv *IOServerInstance) setTargetCount(numTargets int) {
 // startMgmtSvc starts the DAOS management service replica associated
 // with this instance. If no replica is associated with this instance, this
 // function is a no-op.
-func (srv *IOServerInstance) startMgmtSvc() error {
+func (srv *IOServerInstance) startMgmtSvc(ctx context.Context) error {
 	superblock := srv.getSuperblock()
 
 	// should have been loaded by now
@@ -260,7 +260,7 @@ func (srv *IOServerInstance) startMgmtSvc() error {
 
 	if superblock.CreateMS {
 		srv.log.Debugf("create MS (bootstrap=%t)", superblock.BootstrapMS)
-		if err := srv.callCreateMS(superblock); err != nil {
+		if err := srv.callCreateMS(ctx, superblock); err != nil {
 			return err
 		}
 		superblock.CreateMS = false
@@ -273,7 +273,7 @@ func (srv *IOServerInstance) startMgmtSvc() error {
 
 	if superblock.MS {
 		srv.log.Debug("start MS")
-		if err := srv.callStartMS(); err != nil {
+		if err := srv.callStartMS(ctx); err != nil {
 			return err
 		}
 
@@ -294,11 +294,11 @@ func (srv *IOServerInstance) startMgmtSvc() error {
 }
 
 // loadModules initiates the I/O server startup sequence.
-func (srv *IOServerInstance) loadModules() error {
-	return srv.callSetUp()
+func (srv *IOServerInstance) loadModules(ctx context.Context) error {
+	return srv.callSetUp(ctx)
 }
 
-func (srv *IOServerInstance) callCreateMS(superblock *Superblock) error {
+func (srv *IOServerInstance) callCreateMS(ctx context.Context, superblock *Superblock) error {
 	msAddr, err := srv.msClient.LeaderAddress()
 	if err != nil {
 		return err
@@ -310,7 +310,7 @@ func (srv *IOServerInstance) callCreateMS(superblock *Superblock) error {
 		req.Addr = msAddr
 	}
 
-	dresp, err := srv.CallDrpc(drpc.MethodCreateMS, req)
+	dresp, err := srv.CallDrpc(ctx, drpc.MethodCreateMS, req)
 	if err != nil {
 		return err
 	}
@@ -326,8 +326,8 @@ func (srv *IOServerInstance) callCreateMS(superblock *Superblock) error {
 	return nil
 }
 
-func (srv *IOServerInstance) callStartMS() error {
-	dresp, err := srv.CallDrpc(drpc.MethodStartMS, nil)
+func (srv *IOServerInstance) callStartMS(ctx context.Context) error {
+	dresp, err := srv.CallDrpc(ctx, drpc.MethodStartMS, nil)
 	if err != nil {
 		return err
 	}
@@ -343,8 +343,8 @@ func (srv *IOServerInstance) callStartMS() error {
 	return nil
 }
 
-func (srv *IOServerInstance) callSetUp() error {
-	dresp, err := srv.CallDrpc(drpc.MethodSetUp, nil)
+func (srv *IOServerInstance) callSetUp(ctx context.Context) error {
+	dresp, err := srv.CallDrpc(ctx, drpc.MethodSetUp, nil)
 	if err != nil {
 		return err
 	}

--- a/src/control/server/instance_drpc.go
+++ b/src/control/server/instance_drpc.go
@@ -71,13 +71,13 @@ func (srv *IOServerInstance) awaitDrpcReady() chan *srvpb.NotifyReadyReq {
 }
 
 // CallDrpc makes the supplied dRPC call via this instance's dRPC client.
-func (srv *IOServerInstance) CallDrpc(method drpc.Method, body proto.Message) (*drpc.Response, error) {
+func (srv *IOServerInstance) CallDrpc(ctx context.Context, method drpc.Method, body proto.Message) (*drpc.Response, error) {
 	dc, err := srv.getDrpcClient()
 	if err != nil {
 		return nil, err
 	}
 
-	return makeDrpcCall(dc, method, body)
+	return makeDrpcCall(ctx, srv.log, dc, method, body)
 }
 
 // drespToMemberResult converts drpc.Response to system.MemberResult.
@@ -140,7 +140,7 @@ func (srv *IOServerInstance) TryDrpc(ctx context.Context, method drpc.Method) *s
 
 	resChan := make(chan *system.MemberResult)
 	go func() {
-		dresp, err := srv.CallDrpc(method, nil)
+		dresp, err := srv.CallDrpc(ctx, method, nil)
 		resChan <- drespToMemberResult(rank, dresp, err, targetState)
 	}()
 

--- a/src/control/server/instance_drpc_test.go
+++ b/src/control/server/instance_drpc_test.go
@@ -24,6 +24,7 @@
 package server
 
 import (
+	"context"
 	"fmt"
 	"testing"
 	"time"
@@ -99,7 +100,8 @@ func TestIOServerInstance_CallDrpc(t *testing.T) {
 				instance.setDrpcClient(newMockDrpcClient(cfg))
 			}
 
-			_, err := instance.CallDrpc(drpc.MethodPoolCreate, &mgmtpb.PoolCreateReq{})
+			_, err := instance.CallDrpc(context.TODO(),
+				drpc.MethodPoolCreate, &mgmtpb.PoolCreateReq{})
 			common.CmpErr(t, tc.expErr, err)
 		})
 	}

--- a/src/control/server/instance_exec.go
+++ b/src/control/server/instance_exec.go
@@ -111,12 +111,12 @@ func (srv *IOServerInstance) finishStartup(ctx context.Context, ready *srvpb.Not
 	srv.setTargetCount(int(ready.GetNtgts()))
 
 	if srv.isMSReplica() {
-		if err := srv.startMgmtSvc(); err != nil {
+		if err := srv.startMgmtSvc(ctx); err != nil {
 			return errors.Wrap(err, "failed to start management service")
 		}
 	}
 
-	if err := srv.loadModules(); err != nil {
+	if err := srv.loadModules(ctx); err != nil {
 		return errors.Wrap(err, "failed to load I/O server modules")
 	}
 

--- a/src/control/server/mgmt_svc.go
+++ b/src/control/server/mgmt_svc.go
@@ -164,7 +164,7 @@ func (svc *mgmtSvc) GetAttachInfo(ctx context.Context, req *mgmtpb.GetAttachInfo
 		return nil, errors.New("clientNetworkCfg is missing")
 	}
 
-	dresp, err := svc.harness.CallDrpc(drpc.MethodGetAttachInfo, req)
+	dresp, err := svc.harness.CallDrpc(ctx, drpc.MethodGetAttachInfo, req)
 	if err != nil {
 		return nil, err
 	}
@@ -210,7 +210,7 @@ func queryRank(reqRank uint32, srvRank system.Rank) bool {
 }
 
 func (svc *mgmtSvc) getBioHealth(ctx context.Context, srv *IOServerInstance, req *mgmtpb.BioHealthReq) (*mgmtpb.BioHealthResp, error) {
-	dresp, err := srv.CallDrpc(drpc.MethodBioHealth, req)
+	dresp, err := srv.CallDrpc(ctx, drpc.MethodBioHealth, req)
 	if err != nil {
 		return nil, err
 	}
@@ -247,7 +247,7 @@ func (svc *mgmtSvc) querySmdDevices(ctx context.Context, req *mgmtpb.SmdQueryReq
 		rResp := new(mgmtpb.SmdQueryResp_RankResp)
 		rResp.Rank = srvRank.Uint32()
 
-		dresp, err := srv.CallDrpc(drpc.MethodSmdDevs, new(mgmtpb.SmdDevReq))
+		dresp, err := srv.CallDrpc(ctx, drpc.MethodSmdDevs, new(mgmtpb.SmdDevReq))
 		if err != nil {
 			return err
 		}
@@ -333,7 +333,7 @@ func (svc *mgmtSvc) querySmdPools(ctx context.Context, req *mgmtpb.SmdQueryReq, 
 		rResp := new(mgmtpb.SmdQueryResp_RankResp)
 		rResp.Rank = srvRank.Uint32()
 
-		dresp, err := srv.CallDrpc(drpc.MethodSmdPools, new(mgmtpb.SmdPoolReq))
+		dresp, err := srv.CallDrpc(ctx, drpc.MethodSmdPools, new(mgmtpb.SmdPoolReq))
 		if err != nil {
 			return err
 		}
@@ -416,7 +416,7 @@ func (svc *mgmtSvc) smdSetFaulty(ctx context.Context, req *mgmtpb.SmdQueryReq) (
 
 	svc.log.Debugf("calling set-faulty on rank %d for %s", rank, req.Uuid)
 
-	dresp, err := srvs[0].CallDrpc(drpc.MethodSetFaultyState, &mgmtpb.DevStateReq{
+	dresp, err := srvs[0].CallDrpc(ctx, drpc.MethodSetFaultyState, &mgmtpb.DevStateReq{
 		DevUuid: req.Uuid,
 	})
 	if err != nil {
@@ -488,7 +488,7 @@ func (svc *mgmtSvc) SmdQuery(ctx context.Context, req *mgmtpb.SmdQueryReq) (*mgm
 func (svc *mgmtSvc) ListContainers(ctx context.Context, req *mgmtpb.ListContReq) (*mgmtpb.ListContResp, error) {
 	svc.log.Debugf("MgmtSvc.ListContainers dispatch, req:%+v\n", *req)
 
-	dresp, err := svc.harness.CallDrpc(drpc.MethodListContainers, req)
+	dresp, err := svc.harness.CallDrpc(ctx, drpc.MethodListContainers, req)
 	if err != nil {
 		return nil, err
 	}
@@ -507,7 +507,7 @@ func (svc *mgmtSvc) ListContainers(ctx context.Context, req *mgmtpb.ListContReq)
 func (svc *mgmtSvc) ContSetOwner(ctx context.Context, req *mgmtpb.ContSetOwnerReq) (*mgmtpb.ContSetOwnerResp, error) {
 	svc.log.Debugf("MgmtSvc.ContSetOwner dispatch, req:%+v\n", *req)
 
-	dresp, err := svc.harness.CallDrpc(drpc.MethodContSetOwner, req)
+	dresp, err := svc.harness.CallDrpc(ctx, drpc.MethodContSetOwner, req)
 	if err != nil {
 		return nil, err
 	}

--- a/src/control/server/mgmt_system.go
+++ b/src/control/server/mgmt_system.go
@@ -124,7 +124,7 @@ func (svc *mgmtSvc) Join(ctx context.Context, req *mgmtpb.JoinReq) (*mgmtpb.Join
 			"combining peer addr with listener port")
 	}
 
-	dresp, err := svc.harness.CallDrpc(drpc.MethodJoin, req)
+	dresp, err := svc.harness.CallDrpc(ctx, drpc.MethodJoin, req)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Add a centralized implementation that all request types
can use. Also allows for requests to be canceled in the
control plane (more work needed to cancel in the ioserver).