### PR TITLE
DAOS-3596 test: Fix daos_server_restart

### DIFF
--- a/src/tests/ftest/server/daos_server_restart.py
+++ b/src/tests/ftest/server/daos_server_restart.py
@@ -78,6 +78,7 @@ class DaosServerTest(TestWithServers):
     def get_pool_list(self):
         """method to get the pool list contents"""
         pool_list = self.get_dmg_command().get_output("pool_list")
+        pool_list.sort(key=lambda p: p[0])
         self.log.info("get_pool-list: %s", pool_list)
         return pool_list
 


### PR DESCRIPTION
Sort the list of pool tuples to ensure stable comparison.

Test-tag: server_restart