### PR TITLE
DAOS-3413 control: Fix MountScmDevice tests

### DIFF
--- a/src/control/server/instance_storage_test.go
+++ b/src/control/server/instance_storage_test.go
@@ -38,11 +38,12 @@ import (
 )
 
 func TestIOServerInstance_MountScmDevice(t *testing.T) {
-	const (
-		goodMountPoint = "/mnt/daos"
-	)
+	testDir, cleanup := common.CreateTestDir(t)
+	defer cleanup()
+
 	var (
-		ramCfg = &ioserver.Config{
+		goodMountPoint = testDir + "/mnt/daos"
+		ramCfg         = &ioserver.Config{
 			Storage: ioserver.StorageConfig{
 				SCM: storage.ScmConfig{
 					MountPoint:  goodMountPoint,


### PR DESCRIPTION
These tests fail unless /mnt/daos exists, which is not
desirable. Use a tempdir for testing so that the test
can create the fake mountpoint.

Skip-func-test: true