### PR TITLE
DAOS-623 build: Limit go builder to a single process

### DIFF
--- a/utils/sl/prereq_tools/base.py
+++ b/utils/sl/prereq_tools/base.py
@@ -811,6 +811,11 @@ class PreReqComponent():
         """Set the JOBS_OPT variable for builds"""
         jobs_opt = GetOption('num_jobs')
         self.__env["JOBS_OPT"] = "-j %d" % jobs_opt
+        #Multiple go jobs can be running at once via the -j option so limit each
+        #to 1 proc.   This allows for compilation to continue on systems with
+        #limited processor resources where the number of go procs will be
+        #multiplied by jobs_opt.
+        self.__env["ENV"]["GOMAXPROCS"] = "1"
 
     def get_build_info(self):
         """Retrieve the BuildInfo"""


### PR DESCRIPTION
In systems (such as Frontera) where ulimit is set on maximum
processes, go creates way too many.  Set an envirable to limit
go to 1 process.   We still get the parallelism from the -j
option of scons so more than one go builder can run but they
just won't each create some large number of processes.

Signed-off-by: Jeff Olivier <jeffrey.v.olivier@intel.com>