### PR TITLE
DAOS-5553 dtx: purge cached obj when cleanup DTX handle

### DIFF
--- a/src/object/obj_tx.c
+++ b/src/object/obj_tx.c
@@ -1969,6 +1969,12 @@ out_tx:
 	return rc;
 }
 
+static inline daos_obj_id_t
+dc_tx_dcsr2oid(struct daos_cpd_sub_req *dcsr)
+{
+	return ((struct dc_object *)(dcsr->dcsr_obj))->cob_md.omd_id;
+}
+
 static int
 dc_tx_add_update(struct dc_tx *tx, daos_handle_t oh, uint64_t flags,
 		 daos_key_t *dkey, uint32_t nr, daos_iod_t *iods,
@@ -2045,6 +2051,11 @@ dc_tx_add_update(struct dc_tx *tx, daos_handle_t oh, uint64_t flags,
 
 	tx->tx_write_cnt++;
 
+	D_DEBUG(DB_TRACE, "Cache update: DTI "DF_DTI", obj "DF_OID", dkey "
+		DF_KEY", flags %lx, nr = %d, write cnt %d\n",
+		DP_DTI(&tx->tx_id), DP_OID(dc_tx_dcsr2oid(dcsr)),
+		DP_KEY(dkey), flags, nr, tx->tx_write_cnt);
+
 	return 0;
 
 fail:
@@ -2091,6 +2102,11 @@ dc_tx_add_punch_obj(struct dc_tx *tx, daos_handle_t oh, uint64_t flags)
 
 	tx->tx_write_cnt++;
 
+	D_DEBUG(DB_TRACE, "Cache punch obj: DTI "DF_DTI", obj "DF_OID
+		", flags %lx, write cnt %d\n",
+		DP_DTI(&tx->tx_id), DP_OID(dc_tx_dcsr2oid(dcsr)),
+		flags, tx->tx_write_cnt);
+
 	return 0;
 }
 
@@ -2120,6 +2136,11 @@ dc_tx_add_punch_dkey(struct dc_tx *tx, daos_handle_t oh, uint64_t flags,
 	dcsr->dcsr_api_flags = flags;
 
 	tx->tx_write_cnt++;
+
+	D_DEBUG(DB_TRACE, "Cache punch dkey: DTI "DF_DTI", obj "DF_OID", dkey "
+		DF_KEY", flags %lx, write cnt %d\n",
+		DP_DTI(&tx->tx_id), DP_OID(dc_tx_dcsr2oid(dcsr)),
+		DP_KEY(dkey), flags, tx->tx_write_cnt);
 
 	return 0;
 }
@@ -2165,6 +2186,11 @@ dc_tx_add_punch_akeys(struct dc_tx *tx, daos_handle_t oh, uint64_t flags,
 
 	tx->tx_write_cnt++;
 
+	D_DEBUG(DB_TRACE, "Cache punch akey: DTI "DF_DTI", obj "DF_OID", dkey "
+		DF_KEY", flags %lx, nr %d, write cnt %d\n",
+		DP_DTI(&tx->tx_id), DP_OID(dc_tx_dcsr2oid(dcsr)),
+		DP_KEY(dkey), flags, nr, tx->tx_write_cnt);
+
 	return 0;
 
 fail:
@@ -2182,7 +2208,7 @@ fail:
 }
 
 static int
-dc_tx_add_read(struct dc_tx *tx, daos_handle_t oh, uint64_t flags,
+dc_tx_add_read(struct dc_tx *tx, int opc, daos_handle_t oh, uint64_t flags,
 	       daos_key_t *dkey, uint32_t nr, void *iods_or_akey)
 {
 	struct daos_cpd_sub_req	*dcsr = NULL;
@@ -2247,6 +2273,17 @@ done:
 	dcsr->dcsr_api_flags = flags;
 
 	tx->tx_read_cnt++;
+
+	if (dkey != NULL)
+		D_DEBUG(DB_TRACE, "Cache read opc %d: DTI "DF_DTI", obj "DF_OID
+			", dkey "DF_KEY", flags %lx, nr %d, read cnt %d\n",
+			opc, DP_DTI(&tx->tx_id), DP_OID(dc_tx_dcsr2oid(dcsr)),
+			DP_KEY(dkey), flags, nr, tx->tx_read_cnt);
+	else
+		D_DEBUG(DB_TRACE, "Cache enum obj: DTI "DF_DTI", obj "DF_OID
+			", flags %lx, nr %d, read cnt %d\n",
+			DP_DTI(&tx->tx_id), DP_OID(dc_tx_dcsr2oid(dcsr)),
+			flags, nr, tx->tx_read_cnt);
 
 	return 0;
 
@@ -2520,8 +2557,8 @@ dc_tx_attach(daos_handle_t th, enum obj_rpc_opc opc, tse_task_t *task)
 	case DAOS_OBJ_RPC_FETCH: {
 		daos_obj_fetch_t	*fe = dc_task_get_args(task);
 
-		rc = dc_tx_add_read(tx, fe->oh, fe->flags, fe->dkey, fe->nr,
-				    fe->nr != 1 ? fe->iods :
+		rc = dc_tx_add_read(tx, opc, fe->oh, fe->flags, fe->dkey,
+				    fe->nr, fe->nr != 1 ? fe->iods :
 				    (void *)&fe->iods[0].iod_name);
 		break;
 	}
@@ -2541,25 +2578,25 @@ dc_tx_attach(daos_handle_t th, enum obj_rpc_opc opc, tse_task_t *task)
 			nr = 1;
 		}
 
-		rc = dc_tx_add_read(tx, qu->oh, 0, dkey, nr, qu->akey);
+		rc = dc_tx_add_read(tx, opc, qu->oh, 0, dkey, nr, qu->akey);
 		break;
 	}
 	case DAOS_OBJ_RECX_RPC_ENUMERATE: {
 		daos_obj_list_recx_t	*lr = dc_task_get_args(task);
 
-		rc = dc_tx_add_read(tx, lr->oh, 0, lr->dkey, 1, lr->akey);
+		rc = dc_tx_add_read(tx, opc, lr->oh, 0, lr->dkey, 1, lr->akey);
 		break;
 	}
 	case DAOS_OBJ_AKEY_RPC_ENUMERATE: {
 		daos_obj_list_akey_t	*la = dc_task_get_args(task);
 
-		rc = dc_tx_add_read(tx, la->oh, 0, la->dkey, 0, NULL);
+		rc = dc_tx_add_read(tx, opc, la->oh, 0, la->dkey, 0, NULL);
 		break;
 	}
 	case DAOS_OBJ_DKEY_RPC_ENUMERATE: {
 		daos_obj_list_dkey_t	*ld = dc_task_get_args(task);
 
-		rc = dc_tx_add_read(tx, ld->oh, 0, NULL, 0, NULL);
+		rc = dc_tx_add_read(tx, opc, ld->oh, 0, NULL, 0, NULL);
 		break;
 	}
 	default:


### PR DESCRIPTION
For compounded modification, it is possible that some sub-modification
fails as to all the former sub-modifications need to be aborted. Under
such case, the objects (created in former sub-modifications) should be
purged from cache to avoid misguide subsequent operations.

This patch also adds more log messages for DTX related logic.

Signed-off-by: Fan Yong <fan.yong@intel.com>