### PR TITLE
DAOS-5679 bug fix: Remove duplicate update_container_acl method from daos_utils.py

### DIFF
--- a/src/tests/ftest/util/cont_security_test_base.py
+++ b/src/tests/ftest/util/cont_security_test_base.py
@@ -197,7 +197,7 @@ class ContSecurityTestBase(TestWithServers):
         """
         self.daos_tool.exit_status_exception = False
         result = self.daos_tool.container_update_acl(
-            self.pool_uuid, self.container_uuid, entry, self.pool_svc)
+            self.pool_uuid, self.container_uuid, self.pool_svc, entry=entry)
         return result
 
     def test_container_destroy(self, pool_uuid, pool_svc, container_uuid):

--- a/src/tests/ftest/util/daos_utils.py
+++ b/src/tests/ftest/util/daos_utils.py
@@ -351,27 +351,6 @@ class DaosCommand(DaosCommandBase):
             ("container", "query"), pool=pool, svc=svc, cont=cont,
             sys_name=sys_name)
 
-    def container_update_acl(self, pool, cont, entry, svc=None):
-        """Call daos container update-acl.
-        Args:
-            pool (str): Pool UUID.
-            cont (str): Container UUID.
-            entry (str): Container acl entry to be updated.
-            svc (str, optional): Pool service replicas, e.g., '1,2,3'. Defaults
-                to None.
-
-        Returns:
-            CmdResult: Object that contains exit status, stdout, and other
-                information.
-
-        Raises:
-            CommandFailure: if the daos container update-acl command fails.
-
-        """
-        return self._get_result(
-            ("container", "update-acl"),
-            pool=pool, svc=svc, cont=cont, entry=entry)
-
     def container_set_prop(self, pool, cont, prop, value, svc=None):
         """Call daos container set-prop.
 

--- a/src/tests/ftest/util/daos_utils_base.py
+++ b/src/tests/ftest/util/daos_utils_base.py
@@ -324,6 +324,7 @@ class DaosCommandBase(CommandWithSubCommand):
                 super(
                     DaosCommandBase.ContainerSubCommand.UpdateAclSubCommand,
                     self).__init__("update-acl")
+                self.acl_file = FormattedParameter("--acl-file={}")
                 self.entry = FormattedParameter("--entry={}")
 
         class DeleteAclSubCommand(CommonContainerSubCommand):


### PR DESCRIPTION
Remove duplicate method for container_update_acl and add back removed acl-file argument.

It appears that on this PR: https://github.com/daos-stack/daos/pull/3367 a duplicate method of update_container_acl was added onto master and was not caught in review. 

Signed-off-by: Justiniano-pagn <amanda.justiniano-pagn@intel.com>