### PR TITLE
DAOS-5277 mem: cashe hot memory allocations and reuse them

### DIFF
--- a/src/bio/bio_buffer.c
+++ b/src/bio/bio_buffer.c
@@ -181,7 +181,7 @@ bio_iod_alloc(struct bio_io_context *ctxt, unsigned int sgl_cnt, bool update)
 	D_ASSERT(ctxt != NULL && ctxt->bic_umem != NULL);
 	D_ASSERT(sgl_cnt != 0);
 
-	D_ALLOC(biod, offsetof(struct bio_desc, bd_sgls[sgl_cnt]));
+	D_MM_ALLOC(biod, offsetof(struct bio_desc, bd_sgls[sgl_cnt]));
 	if (biod == NULL)
 		return NULL;
 
@@ -205,7 +205,7 @@ bio_iod_free(struct bio_desc *biod)
 
 	for (i = 0; i < biod->bd_sgl_cnt; i++)
 		bio_sgl_fini(&biod->bd_sgls[i]);
-	D_FREE(biod);
+	D_MM_FREE(biod);
 }
 
 static inline struct bio_dma_buffer *

--- a/src/cart/crt_corpc.c
+++ b/src/cart/crt_corpc.c
@@ -42,14 +42,14 @@ crt_corpc_info_init(struct crt_rpc_priv *rpc_priv,
 	D_ASSERT(rpc_priv != NULL);
 	D_ASSERT(grp_priv != NULL);
 
-	D_ALLOC_PTR(co_info);
+	D_MM_ALLOC_PTR(co_info);
 	if (co_info == NULL)
 		D_GOTO(out, rc = -DER_NOMEM);
 
 	rc = d_rank_list_dup_sort_uniq(&co_info->co_filter_ranks, filter_ranks);
 	if (rc != 0) {
 		D_ERROR("d_rank_list_dup failed, rc: %d.\n", rc);
-		D_FREE_PTR(co_info);
+		D_MM_FREE(co_info);
 		D_GOTO(out, rc);
 	}
 	if (!grp_ref_taken)
@@ -100,7 +100,7 @@ crt_corpc_info_fini(struct crt_rpc_priv *rpc_priv)
 	d_rank_list_free(rpc_priv->crp_corpc_info->co_filter_ranks);
 	if (rpc_priv->crp_corpc_info->co_grp_ref_taken)
 		crt_grp_priv_decref(rpc_priv->crp_corpc_info->co_grp_priv);
-	D_FREE_PTR(rpc_priv->crp_corpc_info);
+	D_MM_FREE(rpc_priv->crp_corpc_info);
 }
 
 static int
@@ -225,7 +225,7 @@ crt_corpc_free_chained_bulk(crt_bulk_t bulk_hdl)
 		D_ERROR("bad zero seg_num.\n");
 		D_GOTO(out, rc = -DER_PROTO);
 	}
-	D_ALLOC_ARRAY(iovs, seg_num);
+	D_MM_ALLOC_ARRAY(iovs, seg_num);
 	if (iovs == NULL)
 		D_GOTO(out, rc = -DER_NOMEM);
 
@@ -245,8 +245,7 @@ crt_corpc_free_chained_bulk(crt_bulk_t bulk_hdl)
 		D_ERROR("crt_bulk_free failed, rc: %d.\n", rc);
 
 out:
-	if (iovs != NULL)
-		D_FREE(iovs);
+	D_MM_FREE(iovs);
 	return rc;
 }
 
@@ -284,7 +283,7 @@ crt_corpc_common_hdlr(struct crt_rpc_priv *rpc_priv)
 			D_GOTO(out, rc);
 		}
 
-		bulk_iov.iov_buf = calloc(1, bulk_len);
+		D_ALLOC(bulk_iov.iov_buf, bulk_len);
 		if (bulk_iov.iov_buf == NULL)
 			D_GOTO(out, rc = -DER_NOMEM);
 		bulk_iov.iov_buf_len = bulk_len;

--- a/src/cart/crt_hg.c
+++ b/src/cart/crt_hg.c
@@ -759,7 +759,7 @@ crt_rpc_handler_common(hg_handle_t hg_hdl)
 	}
 	D_ASSERT(opc_info->coi_opc == opc);
 
-	D_ALLOC(rpc_priv, opc_info->coi_rpc_size);
+	D_MM_ALLOC(rpc_priv, opc_info->coi_rpc_size);
 	if (rpc_priv == NULL) {
 		crt_hg_reply_error_send(&rpc_tmp, -DER_DOS);
 		crt_hg_unpack_cleanup(proc);
@@ -1293,7 +1293,7 @@ crt_hg_bulk_create(struct crt_hg_context *hg_ctx, d_sg_list_t *sgl,
 		buf_sizes = buf_sizes_stack;
 	} else {
 		allocate = true;
-		D_ALLOC_ARRAY(buf_sizes, sgl->sg_nr);
+		D_MM_ALLOC_ARRAY(buf_sizes, sgl->sg_nr);
 		if (buf_sizes == NULL)
 			D_GOTO(out, rc = -DER_NOMEM);
 	}
@@ -1304,7 +1304,7 @@ crt_hg_bulk_create(struct crt_hg_context *hg_ctx, d_sg_list_t *sgl,
 		buf_ptrs = NULL;
 	} else {
 		if (allocate) {
-			D_ALLOC_ARRAY(buf_ptrs, sgl->sg_nr);
+			D_MM_ALLOC_ARRAY(buf_ptrs, sgl->sg_nr);
 			if (buf_ptrs == NULL)
 				D_GOTO(out, rc = -DER_NOMEM);
 		} else {
@@ -1327,8 +1327,8 @@ crt_hg_bulk_create(struct crt_hg_context *hg_ctx, d_sg_list_t *sgl,
 out:
 	/* HG_Bulk_create copied the parameters, can free here */
 	if (allocate) {
-		D_FREE(buf_ptrs);
-		D_FREE(buf_sizes);
+		D_MM_FREE(buf_ptrs);
+		D_MM_FREE(buf_sizes);
 	}
 
 	return rc;
@@ -1385,13 +1385,13 @@ crt_hg_bulk_access(crt_bulk_t bulk_hdl, d_sg_list_t *sgl)
 		buf_sizes = buf_sizes_stack;
 		buf_ptrs = buf_ptrs_stack;
 	} else {
-		D_ALLOC_ARRAY(buf_sizes, bulk_sgnum);
+		D_MM_ALLOC_ARRAY(buf_sizes, bulk_sgnum);
 		if (buf_sizes == NULL)
 			D_GOTO(out, rc = -DER_NOMEM);
 
-		D_ALLOC_ARRAY(buf_ptrs, bulk_sgnum);
+		D_MM_ALLOC_ARRAY(buf_ptrs, bulk_sgnum);
 		if (buf_ptrs == NULL) {
-			D_FREE(buf_sizes);
+			D_MM_FREE(buf_sizes);
 			D_GOTO(out, rc = -DER_NOMEM);
 		}
 		allocate = true;
@@ -1415,8 +1415,8 @@ crt_hg_bulk_access(crt_bulk_t bulk_hdl, d_sg_list_t *sgl)
 
 out:
 	if (allocate) {
-		D_FREE(buf_sizes);
-		D_FREE(buf_ptrs);
+		D_MM_FREE(buf_ptrs);
+		D_MM_FREE(buf_sizes);
 	}
 	return rc;
 }

--- a/src/cart/crt_hg_proc.c
+++ b/src/cart/crt_hg_proc.c
@@ -208,17 +208,11 @@ crt_proc_d_rank_list_t(crt_proc_t proc, d_rank_list_t **data)
 			D_GOTO(out, rc = 0);
 		}
 
-		D_ALLOC_PTR(rank_list);
+		rank_list = d_rank_list_alloc(nr);
 		if (rank_list == NULL)
 			D_GOTO(out, rc = -DER_NOMEM);
-		D_ALLOC_ARRAY(rank_list->rl_ranks, nr);
-		if (rank_list->rl_ranks == NULL) {
-			D_FREE(rank_list);
-			D_GOTO(out, rc = -DER_NOMEM);
-		}
 		buf = hg_proc_save_ptr(proc, nr * sizeof(*buf));
 		memcpy(rank_list->rl_ranks, buf, nr * sizeof(*buf));
-		rank_list->rl_nr = nr;
 		*data = rank_list;
 		break;
 	case CRT_PROC_FREE:

--- a/src/cart/crt_init.c
+++ b/src/cart/crt_init.c
@@ -275,6 +275,12 @@ crt_init_opt(crt_group_id_t grpid, uint32_t flags, crt_init_options_t *opt)
 		D_GOTO(out, rc);
 	}
 
+	rc = d_mm_init(9);
+	if (rc && rc != -DER_ALREADY) {
+		D_ERROR("d_mm_init() "DF_RC"\n", DP_RC(rc));
+		D_GOTO(out, rc);
+	}
+
 	if (grpid != NULL) {
 		if (crt_validate_grpid(grpid) != 0) {
 			D_ERROR("grpid contains invalid characters "
@@ -570,6 +576,7 @@ crt_finalize(void)
 	}
 
 out:
+	d_mm_fini();
 	/* d_fault_inject_fini() is reference counted */
 	local_rc = d_fault_inject_fini();
 	if (local_rc != 0)

--- a/src/cart/crt_iv.c
+++ b/src/cart/crt_iv.c
@@ -1776,7 +1776,7 @@ crt_hdlr_iv_sync_aux(void *arg)
 
 		need_put = true;
 
-		D_ALLOC_ARRAY(tmp_iovs, iv_value.sg_nr);
+		D_MM_ALLOC_ARRAY(tmp_iovs, iv_value.sg_nr);
 		if (tmp_iovs == NULL) {
 			D_ERROR("Failed to allocate temporary iovs\n");
 			D_GOTO(exit, rc = -DER_NOMEM);
@@ -1788,14 +1788,14 @@ crt_hdlr_iv_sync_aux(void *arg)
 		/* Populate tmp_iv.sg_iovs[0] to [sg_nr] */
 		rc = crt_bulk_access(rpc_req->cr_co_bulk_hdl, &tmp_iv);
 		if (rc != 0) {
-			D_FREE(tmp_iovs);
+			D_MM_FREE(tmp_iovs);
 			D_ERROR("crt_bulk_access() failed; rc=%d\n", rc);
 			D_GOTO(exit, rc);
 		}
 
 		rc = iv_ops->ivo_on_refresh(ivns_internal, &input->ivs_key,
 					0, &tmp_iv, false, 0, user_priv);
-		D_FREE(tmp_iovs);
+		D_MM_FREE(tmp_iovs);
 		if (rc != 0) {
 			D_ERROR("ivo_on_refresh() failed; rc=%d\n", rc);
 			D_GOTO(exit, rc);
@@ -1953,7 +1953,7 @@ call_pre_sync_cb(struct crt_ivns_internal *ivns_internal,
 	need_put = true;
 
 	if (rpc_req->cr_co_bulk_hdl != CRT_BULK_NULL) {
-		D_ALLOC_ARRAY(tmp_iovs, iv_value.sg_nr);
+		D_MM_ALLOC_ARRAY(tmp_iovs, iv_value.sg_nr);
 		if (tmp_iovs == NULL) {
 			D_ERROR("Failed to allocate temporary iovs\n");
 			D_GOTO(exit, rc);
@@ -1976,8 +1976,7 @@ call_pre_sync_cb(struct crt_ivns_internal *ivns_internal,
 	if (rc != 0)
 		D_ERROR("ivo_pre_sync() failed; rc=%d\n", rc);
 exit:
-	if (tmp_iovs)
-		D_FREE(tmp_iovs);
+	D_MM_FREE(tmp_iovs);
 	if (need_put)
 		iv_ops->ivo_on_put(ivns_internal, &iv_value, user_priv);
 	return rc;

--- a/src/cart/crt_rpc.c
+++ b/src/cart/crt_rpc.c
@@ -246,7 +246,8 @@ crt_rpc_priv_alloc(crt_opcode_t opc, struct crt_rpc_priv **priv_allocated,
 {
 	struct crt_rpc_priv	*rpc_priv;
 	struct crt_opc_info	*opc_info;
-	int			rc = 0;
+	size_t			 size;
+	int			 rc = 0;
 
 	D_ASSERT(priv_allocated != NULL);
 
@@ -265,10 +266,9 @@ crt_rpc_priv_alloc(crt_opcode_t opc, struct crt_rpc_priv **priv_allocated,
 		D_GOTO(out, rc = -DER_INVAL);
 	}
 
-	if (forward)
-		D_ALLOC(rpc_priv, opc_info->coi_input_offset);
-	else
-		D_ALLOC(rpc_priv, opc_info->coi_rpc_size);
+	size = forward ? opc_info->coi_input_offset : opc_info->coi_rpc_size;
+
+	D_MM_ALLOC(rpc_priv, size);
 	if (rpc_priv == NULL)
 		D_GOTO(out, rc = -DER_NOMEM);
 
@@ -299,7 +299,7 @@ crt_rpc_priv_free(struct crt_rpc_priv *rpc_priv)
 
 	D_SPIN_DESTROY(&rpc_priv->crp_lock);
 
-	D_FREE(rpc_priv);
+	D_MM_FREE(rpc_priv);
 }
 
 static inline void

--- a/src/cart/crt_tree.c
+++ b/src/cart/crt_tree.c
@@ -259,7 +259,7 @@ crt_tree_get_children(struct crt_grp_priv *grp_priv, uint32_t grp_ver,
 	result_rank_list = d_rank_list_alloc(nchildren);
 	if (result_rank_list == NULL)
 		D_GOTO(out, rc = -DER_NOMEM);
-	D_ALLOC_ARRAY(tree_children, nchildren);
+	D_MM_ALLOC_ARRAY(tree_children, nchildren);
 	if (tree_children == NULL) {
 		d_rank_list_free(result_rank_list);
 		D_GOTO(out, rc = -DER_NOMEM);
@@ -271,7 +271,7 @@ crt_tree_get_children(struct crt_grp_priv *grp_priv, uint32_t grp_ver,
 			"failed, rc: %d.\n", grp_priv->gp_pub.cg_grpid,
 			root, self, rc);
 		d_rank_list_free(result_rank_list);
-		D_FREE(tree_children);
+		D_MM_FREE(tree_children);
 		D_GOTO(out, rc);
 	}
 
@@ -279,7 +279,7 @@ crt_tree_get_children(struct crt_grp_priv *grp_priv, uint32_t grp_ver,
 		result_rank_list->rl_ranks[i] =
 			grp_rank_list->rl_ranks[tree_children[i]];
 
-	D_FREE(tree_children);
+	D_MM_FREE(tree_children);
 	*children_rank_list = result_rank_list;
 
 out:

--- a/src/client/dfs/dfs.c
+++ b/src/client/dfs/dfs.c
@@ -2014,13 +2014,13 @@ dfs_readdir(dfs_t *dfs, dfs_obj_t *obj, daos_anchor_t *anchor, uint32_t *nr,
 	if (rc)
 		return rc;
 
-	D_ALLOC_ARRAY(kds, *nr);
+	D_MM_ALLOC_ARRAY(kds, *nr);
 	if (kds == NULL)
 		return ENOMEM;
 
-	D_ALLOC_ARRAY(enum_buf, *nr * DFS_MAX_PATH);
+	D_MM_ALLOC_ARRAY(enum_buf, *nr * DFS_MAX_PATH);
 	if (enum_buf == NULL) {
-		D_FREE(kds);
+		D_MM_FREE(kds);
 		return ENOMEM;
 	}
 
@@ -2058,8 +2058,8 @@ dfs_readdir(dfs_t *dfs, dfs_obj_t *obj, daos_anchor_t *anchor, uint32_t *nr,
 	*nr = key_nr;
 
 out:
-	D_FREE(enum_buf);
-	D_FREE(kds);
+	D_MM_FREE(enum_buf);
+	D_MM_FREE(kds);
 	return rc;
 }
 
@@ -2088,14 +2088,14 @@ dfs_iterate(dfs_t *dfs, dfs_obj_t *obj, daos_anchor_t *anchor,
 		return rc;
 
 	num = *nr;
-	D_ALLOC_ARRAY(kds, num);
+	D_MM_ALLOC_ARRAY(kds, num);
 	if (kds == NULL)
 		return ENOMEM;
 
 	/** Allocate a buffer to store the entry keys */
-	D_ALLOC_ARRAY(enum_buf, size);
+	D_MM_ALLOC_ARRAY(enum_buf, size);
 	if (enum_buf == NULL) {
-		D_FREE(kds);
+		D_MM_FREE(kds);
 		return ENOMEM;
 	}
 
@@ -2148,8 +2148,8 @@ dfs_iterate(dfs_t *dfs, dfs_obj_t *obj, daos_anchor_t *anchor,
 
 	*nr = keys_nr;
 out:
-	D_FREE(kds);
-	D_FREE(enum_buf);
+	D_MM_FREE(enum_buf);
+	D_MM_FREE(kds);
 	return rc;
 }
 

--- a/src/common/btree.c
+++ b/src/common/btree.c
@@ -253,7 +253,7 @@ btr_context_decref(struct btr_context *tcx)
 	D_ASSERT(tcx->tc_ref > 0);
 	tcx->tc_ref--;
 	if (tcx->tc_ref == 0)
-		D_FREE(tcx);
+		D_MM_FREE(tcx);
 }
 
 static void
@@ -292,7 +292,7 @@ btr_context_create(umem_off_t root_off, struct btr_root *root,
 	unsigned int		 depth;
 	int			 rc;
 
-	D_ALLOC_PTR(tcx);
+	D_MM_ALLOC_PTR(tcx);
 	if (tcx == NULL)
 		return -DER_NOMEM;
 
@@ -3004,7 +3004,6 @@ dbtree_create(unsigned int tree_class, uint64_t tree_feats,
 		return rc;
 
 	rc = btr_tx_tree_alloc(tcx);
-
 	if (rc != 0)
 		goto failed;
 
@@ -3076,7 +3075,6 @@ dbtree_create_inplace_ex(unsigned int tree_class, uint64_t tree_feats,
 		return rc;
 
 	rc = btr_tx_tree_init(tcx, root);
-
 	if (rc != 0)
 		goto failed;
 

--- a/src/common/mem.c
+++ b/src/common/mem.c
@@ -160,7 +160,7 @@ pmem_process_cb_vec(struct umem_tx_stage_item *vec, unsigned int *cnt,
 		return;
 
 	/* @vec & @cnt could be changed by other ULT while txi_fn yielding */
-	D_ALLOC_ARRAY(txi_arr, num);
+	D_MM_ALLOC_ARRAY(txi_arr, num);
 	if (txi_arr == NULL) {
 		D_ERROR("Failed to allocate txi array\n");
 		return;
@@ -179,7 +179,7 @@ pmem_process_cb_vec(struct umem_tx_stage_item *vec, unsigned int *cnt,
 		txi->txi_fn(txi->txi_data, noop);
 	}
 
-	D_FREE(txi_arr);
+	D_MM_FREE(txi_arr);
 }
 
 /*

--- a/src/common/misc.c
+++ b/src/common/misc.c
@@ -429,7 +429,7 @@ daos_rank_list_parse(const char *str, const char *sep)
 	char		       *p;
 	int			n = 0;
 
-	D_ALLOC_ARRAY(buf, cap);
+	D_MM_ALLOC_ARRAY(buf, cap);
 	if (buf == NULL)
 		D_GOTO(out, ranks = NULL);
 	D_STRNDUP(s_saved, str, strlen(str));
@@ -444,11 +444,11 @@ daos_rank_list_parse(const char *str, const char *sep)
 
 			/* Double the buffer. */
 			cap_new = cap * 2;
-			D_ALLOC_ARRAY(buf_new, cap_new);
+			D_MM_ALLOC_ARRAY(buf_new, cap_new);
 			if (buf_new == NULL)
 				D_GOTO(out_s, ranks = NULL);
 			memcpy(buf_new, buf, sizeof(*buf_new) * n);
-			D_FREE(buf);
+			D_MM_FREE(buf);
 			buf = buf_new;
 			cap = cap_new;
 		}
@@ -466,7 +466,7 @@ daos_rank_list_parse(const char *str, const char *sep)
 out_s:
 	D_FREE(s_saved);
 out_buf:
-	D_FREE(buf);
+	D_MM_FREE(buf);
 out:
 	return ranks;
 }

--- a/src/common/pool_map.c
+++ b/src/common/pool_map.c
@@ -307,7 +307,7 @@ comp_sorter_init(struct pool_comp_sorter *sorter, int nr,
 	D_DEBUG(DB_TRACE, "Initialize sorter for %s, nr %d\n",
 		pool_comp_type2str(type), nr);
 
-	D_ALLOC_ARRAY(sorter->cs_comps, nr);
+	D_MM_ALLOC_ARRAY(sorter->cs_comps, nr);
 	if (sorter->cs_comps == NULL)
 		return -DER_NOMEM;
 
@@ -323,7 +323,7 @@ comp_sorter_fini(struct pool_comp_sorter *sorter)
 		D_DEBUG(DB_TRACE, "Finalise sorter for %s\n",
 			pool_comp_type2str(sorter->cs_type));
 
-		D_FREE(sorter->cs_comps);
+		D_MM_FREE(sorter->cs_comps);
 		sorter->cs_nr = 0;
 	}
 }
@@ -910,14 +910,14 @@ pool_map_finalise(struct pool_map *map)
 	comp_sorter_fini(&map->po_target_sorter);
 
 	if (map->po_comp_fail_cnts != NULL)
-		D_FREE(map->po_comp_fail_cnts);
+		D_MM_FREE(map->po_comp_fail_cnts);
 
 	if (map->po_domain_sorters != NULL) {
 		D_ASSERT(map->po_domain_layers != 0);
 		for (i = 0; i < map->po_domain_layers; i++)
 			comp_sorter_fini(&map->po_domain_sorters[i]);
 
-		D_FREE(map->po_domain_sorters);
+		D_MM_FREE(map->po_domain_sorters);
 
 		map->po_domain_sorters = NULL;
 		map->po_domain_layers = 0;
@@ -964,13 +964,13 @@ pool_map_initialise(struct pool_map *map, struct pool_domain *tree)
 
 	map->po_domain_layers = cntr.cc_layers;
 
-	D_ALLOC_ARRAY(map->po_comp_fail_cnts, map->po_domain_layers);
+	D_MM_ALLOC_ARRAY(map->po_comp_fail_cnts, map->po_domain_layers);
 	if (map->po_comp_fail_cnts == NULL) {
 		rc = -DER_NOMEM;
 		goto failed;
 	}
 
-	D_ALLOC_ARRAY(map->po_domain_sorters, map->po_domain_layers);
+	D_MM_ALLOC_ARRAY(map->po_domain_sorters, map->po_domain_layers);
 	if (map->po_domain_sorters == NULL) {
 		rc = -DER_NOMEM;
 		goto failed;
@@ -1167,7 +1167,7 @@ pool_map_merge(struct pool_map *map, uint32_t version,
 	int			 rc;
 
 	/* create scratch map for merging */
-	D_ALLOC_PTR(src_map);
+	D_MM_ALLOC_PTR(src_map);
 	if (src_map == NULL)
 		return -DER_NOMEM;
 
@@ -1550,7 +1550,7 @@ pool_map_create(struct pool_buf *buf, uint32_t version, struct pool_map **mapp)
 		goto failed;
 	}
 
-	D_ALLOC_PTR(map);
+	D_MM_ALLOC_PTR(map);
 	if (map == NULL) {
 		rc = -DER_NOMEM;
 		goto failed;
@@ -1580,7 +1580,7 @@ pool_map_create(struct pool_buf *buf, uint32_t version, struct pool_map **mapp)
 	if (tree != NULL)
 		pool_tree_free(tree);
 	if (map != NULL)
-		D_FREE(map);
+		D_MM_FREE(map);
 	return rc;
 }
 
@@ -1591,7 +1591,7 @@ static void
 pool_map_destroy(struct pool_map *map)
 {
 	pool_map_finalise(map);
-	D_FREE(map);
+	D_MM_FREE(map);
 }
 
 /** Take a refcount on a pool map */
@@ -2364,7 +2364,7 @@ pool_target_id_list_append(struct pool_target_id_list *id_list,
 	if (pool_target_id_found(id_list, id))
 		return 0;
 
-	D_REALLOC_ARRAY(new_ids, id_list->pti_ids, id_list->pti_number + 1);
+	D_MM_REALLOC_ARRAY(new_ids, id_list->pti_ids, id_list->pti_number + 1);
 	if (new_ids == NULL)
 		return -DER_NOMEM;
 
@@ -2396,7 +2396,7 @@ int
 pool_target_id_list_alloc(unsigned int num,
 			  struct pool_target_id_list *id_list)
 {
-	D_ALLOC_ARRAY(id_list->pti_ids,	num);
+	D_MM_ALLOC_ARRAY(id_list->pti_ids, num);
 	if (id_list->pti_ids == NULL)
 		return -DER_NOMEM;
 
@@ -2411,6 +2411,5 @@ pool_target_id_list_free(struct pool_target_id_list *id_list)
 	if (id_list == NULL)
 		return;
 
-	if (id_list->pti_ids)
-		D_FREE(id_list->pti_ids);
+	D_MM_FREE(id_list->pti_ids);
 }

--- a/src/common/profile.c
+++ b/src/common/profile.c
@@ -282,7 +282,7 @@ daos_profile_dump(struct daos_profile *dp)
 		unlink(path);
 out:
 	if (path != name)
-		free(path);
+		D_FREE(path);
 }
 
 int

--- a/src/common/tests/checksum_timing.c
+++ b/src/common/tests/checksum_timing.c
@@ -155,7 +155,7 @@ run_timings(struct hash_ft *fts[], const int types_count, const size_t *sizes,
 
 			rc = daos_csummer_init(&csummer, ft, 0, 0);
 			if (rc != 0) {
-				free(buf);
+				D_FREE(buf);
 				return rc;
 			}
 
@@ -189,7 +189,7 @@ run_timings(struct hash_ft *fts[], const int types_count, const size_t *sizes,
 			D_FREE(csum_buf);
 			daos_csummer_destroy(&csummer);
 		}
-		free(buf);
+		D_FREE(buf);
 	}
 
 	return 0;

--- a/src/common/tests/drpc_tests.c
+++ b/src/common/tests/drpc_tests.c
@@ -253,7 +253,7 @@ test_drpc_call_sends_call_as_mesg(void **state)
 
 	/* Packed message is the call struct updated by drpc_call */
 	expected_msg_size = drpc__call__get_packed_size(call);
-	expected_msg = calloc(1, expected_msg_size);
+	D_ALLOC(expected_msg, expected_msg_size);
 	drpc__call__pack(call, expected_msg);
 
 	/* Sent to the proper socket */
@@ -307,7 +307,7 @@ test_drpc_call_with_sync_flag_gets_socket_response(void **state)
 	/* Actual contents of the message are arbitrary - just needs to be
 	 * identifiable.
 	 */
-	expected_resp = calloc(1, sizeof(Drpc__Response));
+	D_ALLOC_PTR(expected_resp);
 	drpc__response__init(expected_resp);
 	expected_resp->sequence = 12345;
 	expected_resp->status = DRPC__STATUS__FAILURE;

--- a/src/common/tests/other.c
+++ b/src/common/tests/other.c
@@ -70,7 +70,7 @@ comb_sort_test(int num)
 	int		 i;
 	struct timeval	 tv;
 
-	arr = calloc(num, sizeof(int));
+	D_ALLOC_ARRAY(arr, num);
 	if (arr == NULL)
 		return -ENOMEM;
 

--- a/src/common/tse.c
+++ b/src/common/tse.c
@@ -268,7 +268,7 @@ tse_task_decref(tse_task_t *task)
 	 * user also free it. This now requires task to be on the heap all the
 	 * time.
 	 */
-	D_FREE(task);
+	D_MM_FREE(task);
 }
 
 void
@@ -329,7 +329,7 @@ tse_sched_register_comp_cb(tse_sched_t *sched,
 	struct tse_sched_private	*dsp = tse_sched2priv(sched);
 	struct tse_sched_comp		*dsc;
 
-	D_ALLOC_PTR(dsc);
+	D_MM_ALLOC_PTR(dsc);
 	if (dsc == NULL)
 		return -DER_NOMEM;
 
@@ -357,7 +357,7 @@ tse_sched_complete_cb(tse_sched_t *sched)
 		rc = dsc->dsc_comp_cb(dsc->dsc_arg, sched->ds_result);
 		if (sched->ds_result == 0)
 			sched->ds_result = rc;
-		D_FREE(dsc);
+		D_MM_FREE(dsc);
 	}
 	return 0;
 }
@@ -391,7 +391,7 @@ register_cb(tse_task_t *task, bool is_comp, tse_task_cb_t cb,
 		return -DER_NO_PERM;
 	}
 
-	D_ALLOC(dtc, sizeof(*dtc) + arg_size);
+	D_MM_ALLOC(dtc, sizeof(*dtc) + arg_size);
 	if (dtc == NULL)
 		return -DER_NOMEM;
 
@@ -459,7 +459,7 @@ tse_task_prep_callback(tse_task_t *task)
 				task->dt_result = rc;
 		}
 
-		D_FREE(dtc);
+		D_MM_FREE(dtc);
 
 		/** Task was re-initialized; break */
 		if (!dtp->dtp_running && !dtp->dtp_completing)
@@ -492,7 +492,7 @@ tse_task_complete_callback(tse_task_t *task)
 		if (task->dt_result == 0)
 			task->dt_result = ret;
 
-		D_FREE(dtc);
+		D_MM_FREE(dtc);
 
 		/** Task was re-initialized; break */
 		if (!dtp->dtp_completing) {
@@ -598,7 +598,7 @@ tse_task_post_process(tse_task_t *task)
 		d_list_del(&tlink->tl_link);
 		task_tmp = tlink->tl_task;
 		dtp_tmp = tse_task2priv(task_tmp);
-		D_FREE(tlink);
+		D_MM_FREE(tlink);
 
 		/* propagate dep task's failure */
 		if (task_tmp->dt_result == 0)
@@ -861,7 +861,7 @@ tse_task_add_dependent(tse_task_t *task, tse_task_t *dep)
 	if (dep_dtp->dtp_completed)
 		return 0;
 
-	D_ALLOC_PTR(tlink);
+	D_MM_ALLOC_PTR(tlink);
 	if (tlink == NULL)
 		return -DER_NOMEM;
 
@@ -903,7 +903,7 @@ tse_task_create(tse_task_func_t task_func, tse_sched_t *sched, void *priv,
 	struct tse_task_private	 *dtp;
 	tse_task_t		 *task;
 
-	D_ALLOC_PTR(task);
+	D_MM_ALLOC_PTR(task);
 	if (task == NULL)
 		return -DER_NOMEM;
 

--- a/src/gurt/SConscript
+++ b/src/gurt/SConscript
@@ -24,7 +24,7 @@
 
 import daos_build
 SRC = ['debug.c', 'dlog.c', 'hash.c', 'misc.c', 'heap.c', 'errno.c',
-       'fault_inject.c', 'dtm.c']
+       'fault_inject.c', 'dtm.c', 'memory.c']
 
 def scons():
     """Scons function"""

--- a/src/gurt/memory.c
+++ b/src/gurt/memory.c
@@ -1,0 +1,221 @@
+/*
+ * (C) Copyright 2020 Intel Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * GOVERNMENT LICENSE RIGHTS-OPEN SOURCE SOFTWARE
+ * The Government's rights to use, modify, reproduce, release, perform, display,
+ * or disclose this software are subject to the terms of the Apache License as
+ * provided in Contract No. 8F-30005.
+ * Any reproduction of computer software, computer software documentation, or
+ * portions thereof marked with this legend must also reproduce the markings.
+ */
+#define D_LOGFAC	DD_FAC(mem)
+
+#include <pthread.h>
+#include <gurt/list.h>
+#include <gurt/common.h>
+
+#define MM_MAGIC	0xa5a55a5a
+#define MM_MIN_SIZE	0x80	/* 128 bytes */
+#define MM_MAX_NBUCKETS	10
+
+struct mm_item {
+	d_list_t	 mi_link;
+	uint32_t	 mi_bucket;
+	uint32_t	 mi_magic;
+	char		 mi_buff[0];
+};
+
+struct mm_bucket {
+	d_list_t	   mb_head;
+	pthread_spinlock_t mb_lock;
+	uint32_t	   mb_count;
+};
+
+struct mm_manager {
+	struct mm_bucket *mm_buckets;
+	uint32_t	  mm_count;
+};
+
+static struct mm_manager dmm;
+
+int
+d_mm_init(size_t n)
+{
+	struct mm_bucket *bucket;
+	size_t i;
+	int rc;
+
+	if (unlikely(n < 2 || n >= MM_MAX_NBUCKETS))
+		D_GOTO(out, rc = -DER_INVAL);
+
+	if (unlikely(dmm.mm_count != 0))
+		D_GOTO(out, rc = -DER_ALREADY);
+
+	dmm.mm_buckets = malloc(n * sizeof(*dmm.mm_buckets));
+	if (unlikely(dmm.mm_buckets == NULL))
+		D_GOTO(out, rc = -DER_NOMEM);
+
+	for (i = 0; i < n; i++) {
+		bucket = &dmm.mm_buckets[i];
+		bucket->mb_count = 0;
+		D_INIT_LIST_HEAD(&bucket->mb_head);
+		rc = D_SPIN_INIT(&bucket->mb_lock, PTHREAD_PROCESS_PRIVATE);
+		if (unlikely(rc))
+			D_GOTO(out_free, rc);
+	}
+	dmm.mm_count = n;
+	D_GOTO(out, rc = 0);
+
+out_free:
+	while (i > 0) {
+		bucket = &dmm.mm_buckets[--i];
+		D_SPIN_DESTROY(&bucket->mb_lock);
+	}
+	free(dmm.mm_buckets);
+out:
+	return rc;
+}
+
+void
+d_mm_fini(void)
+{
+	struct mm_bucket *bucket;
+	size_t i, count = dmm.mm_count;
+
+	if (unlikely(count == 0))
+		return;
+
+	d_mm_flush();
+	dmm.mm_count = 0;
+	for (i = 0; i < count; i++) {
+		bucket = &dmm.mm_buckets[i];
+		D_ASSERT(bucket->mb_count == 0);
+		D_SPIN_DESTROY(&bucket->mb_lock);
+	}
+	free(dmm.mm_buckets);
+}
+
+void *
+d_mm_alloc(size_t size)
+{
+	struct mm_bucket *bucket;
+	struct mm_item *item = NULL;
+	size_t i, nsize;
+
+	size += sizeof(struct mm_item);
+	for (i = 0, nsize = MM_MIN_SIZE; nsize < size; i++)
+		nsize <<= 1;
+
+	if (likely(i < dmm.mm_count)) {
+		bucket = &dmm.mm_buckets[i];
+		D_SPIN_LOCK(&bucket->mb_lock);
+		item = d_list_pop_entry(&bucket->mb_head,
+					struct mm_item, mi_link);
+		if (likely(item != NULL))
+			bucket->mb_count--;
+		D_SPIN_UNLOCK(&bucket->mb_lock);
+	}
+
+	if (unlikely(item == NULL)) {
+		item = malloc(nsize);
+		if (unlikely(item == NULL))
+			return NULL;
+		memset(&item->mi_buff[0], 0, size - sizeof(struct mm_item));
+	}
+
+	item->mi_magic  = MM_MAGIC;
+	item->mi_bucket = i;
+
+	return &item->mi_buff[0];
+}
+
+void *
+d_mm_realloc(void *ptr, size_t size)
+{
+	struct mm_item *item = container_of(ptr, struct mm_item, mi_buff);
+	void *ptr2;
+	size_t osize;
+
+
+	if (unlikely(ptr == NULL))
+		return d_mm_alloc(size);
+
+	D_ASSERT(item->mi_magic == MM_MAGIC);
+
+	osize = (MM_MIN_SIZE << item->mi_bucket) - sizeof(struct mm_item);
+	if (size <= osize)
+		return ptr;
+
+	ptr2 = d_mm_alloc(size);
+	if (unlikely(ptr2 == NULL))
+		return realloc(ptr, size);
+
+	memmove(ptr2, ptr, osize);
+
+	d_mm_free(ptr);
+	return ptr2;
+}
+
+void
+d_mm_free(void *ptr)
+{
+	struct mm_bucket *bucket;
+	struct mm_item *item = container_of(ptr, struct mm_item, mi_buff);
+	size_t i, nsize;
+
+	if (unlikely(ptr == NULL))
+		return;
+
+	D_ASSERT(item->mi_magic == MM_MAGIC);
+
+	if (unlikely(item->mi_bucket >= dmm.mm_count)) {
+		free(item);
+		return;
+	}
+
+	i = item->mi_bucket;
+	nsize = (MM_MIN_SIZE << i) - sizeof(struct mm_item);
+	memset(&item->mi_buff[0], 0, nsize);
+
+	bucket = &dmm.mm_buckets[i];
+	D_SPIN_LOCK(&bucket->mb_lock);
+	d_list_add(&item->mi_link, &bucket->mb_head);
+	bucket->mb_count++;
+	D_SPIN_UNLOCK(&bucket->mb_lock);
+}
+
+void
+d_mm_flush(void)
+{
+	struct mm_bucket *bucket;
+	struct mm_item *item;
+	size_t i, count = dmm.mm_count;
+
+	if (unlikely(count == 0))
+		return;
+
+	for (i = 0; i < count; i++) {
+		bucket = &dmm.mm_buckets[i];
+		D_SPIN_LOCK(&bucket->mb_lock);
+		while ((item = d_list_pop_entry(&bucket->mb_head,
+						struct mm_item, mi_link))) {
+			bucket->mb_count--;
+			D_SPIN_UNLOCK(&bucket->mb_lock);
+			free(item);
+			D_SPIN_LOCK(&bucket->mb_lock);
+		}
+		D_SPIN_UNLOCK(&bucket->mb_lock);
+	}
+}

--- a/src/gurt/misc.c
+++ b/src/gurt/misc.c
@@ -53,7 +53,7 @@ d_rank_list_dup(d_rank_list_t **dst, const d_rank_list_t *src)
 
 	D_ALLOC_ARRAY(rank_list->rl_ranks, rank_list->rl_nr);
 	if (rank_list->rl_ranks == NULL) {
-		D_FREE_PTR(rank_list);
+		D_FREE(rank_list);
 		D_GOTO(out, rc = -DER_NOMEM);
 	}
 
@@ -179,7 +179,7 @@ d_rank_list_alloc(uint32_t size)
 
 	D_ALLOC_ARRAY(rank_list->rl_ranks, size);
 	if (rank_list->rl_ranks == NULL) {
-		D_FREE_PTR(rank_list);
+		D_FREE(rank_list);
 		return NULL;
 	}
 

--- a/src/gurt/tests/test_gurt.c
+++ b/src/gurt/tests/test_gurt.c
@@ -282,7 +282,7 @@ static int
 fini_tests(void **state)
 {
 	rmdir(__root);
-	free(__root);
+	D_FREE(__root);
 	d_log_fini();
 
 	return 0;

--- a/src/iosrv/init.c
+++ b/src/iosrv/init.c
@@ -469,6 +469,10 @@ server_init(int argc, char *argv[])
 	if (rc != 0)
 		return rc;
 
+	rc = d_mm_init(9);
+	if (rc && rc != -DER_ALREADY)
+		return rc;
+
 	rc = register_dbtree_classes();
 	if (rc != 0)
 		D_GOTO(exit_debug_init, rc);
@@ -640,6 +644,8 @@ server_fini(bool force)
 	D_INFO("dss_module_fini() done\n");
 	abt_fini();
 	D_INFO("abt_fini() done\n");
+	d_mm_fini();
+	D_INFO("d_mm_fini() done\n");
 	daos_debug_fini();
 	D_INFO("daos_debug_fini() done\n");
 }

--- a/src/placement/tests/jump_map_place_obj.c
+++ b/src/placement/tests/jump_map_place_obj.c
@@ -464,7 +464,7 @@ add_object_class(daos_oclass_id_t cid)
 		return;
 
 	rank_list.rl_nr = NUM_TO_EXTEND;
-	rank_list.rl_ranks = malloc(sizeof(d_rank_t) * NUM_TO_EXTEND);
+	D_ALLOC_ARRAY(rank_list.rl_ranks, NUM_TO_EXTEND);
 	rank_list.rl_ranks[0] = DOM_NR + 1;
 	rank_list.rl_ranks[1] = DOM_NR + 2;
 

--- a/src/pool/rpc.c
+++ b/src/pool/rpc.c
@@ -282,8 +282,7 @@ pool_target_addr_list_free(struct pool_target_addr_list *addr_list)
 	if (addr_list == NULL)
 		return;
 
-	if (addr_list->pta_addrs)
-		D_FREE(addr_list->pta_addrs);
+	D_FREE(addr_list->pta_addrs);
 }
 
 uint64_t

--- a/src/tests/suite/daos_epoch_recovery.c
+++ b/src/tests/suite/daos_epoch_recovery.c
@@ -63,7 +63,7 @@ io(enum io_op op, test_arg_t *arg, daos_handle_t coh, daos_obj_id_t oid,
 		sprintf(akey[i], akey_fmt, i);
 		rec_size[i] = rsize;
 		rx_nr[i] = 1;
-		rec[i] = calloc(rec_size[i], 1);
+		D_ALLOC(rec[i], rec_size[i]);
 		assert_non_null(rec[i]);
 		offset[i] = i * 20;
 	}

--- a/src/tests/suite/daos_obj.c
+++ b/src/tests/suite/daos_obj.c
@@ -1953,7 +1953,7 @@ io_manyrec_internal(void **state, daos_obj_id_t oid, unsigned int size,
 	ioreq_init(&req, arg->coh, oid, iod_type, arg);
 
 	for (i = 0; i < MANYREC_NUMRECS; i++) {
-		akeys[i] = calloc(30, 1);
+		D_ALLOC(akeys[i], 30);
 		assert_non_null(akeys[i]);
 		snprintf(akeys[i], 30, "%s%d", akey, i);
 		D_ALLOC(rec[i], size);
@@ -1962,7 +1962,7 @@ io_manyrec_internal(void **state, daos_obj_id_t oid, unsigned int size,
 		rec_size[i] = size;
 		rx_nr[i] = 1;
 		offset[i] = i * size;
-		val[i] = calloc(size, 1);
+		D_ALLOC(val[i], size);
 		assert_non_null(val[i]);
 		val_size[i] = size;
 	}
@@ -3051,16 +3051,16 @@ tgt_idx_change_retry(void **state)
 	print_message("Insert(e=0)/lookup(e=0)/verify complex kv record "
 		      "with target change.\n");
 	for (i = 0; i < 5; i++) {
-		akey[i] = calloc(20, 1);
+		D_ALLOC(akey[i], 20);
 		assert_non_null(akey[i]);
 		sprintf(akey[i], "test_update akey%d", i);
-		rec[i] = calloc(20, 1);
+		D_ALLOC(rec[i], 20);
 		assert_non_null(rec[i]);
 		sprintf(rec[i], "test_update val%d", i);
 		rec_size[i] = strlen(rec[i]);
 		rx_nr[i] = 1;
 		offset[i] = i * 20;
-		val[i] = calloc(64, 1);
+		D_ALLOC(val[i], 64);
 		assert_non_null(val[i]);
 		val_size[i] = 64;
 	}
@@ -3184,7 +3184,7 @@ fetch_replica_unavail(void **state)
 	MPI_Barrier(MPI_COMM_WORLD);
 
 	/** Lookup */
-	buf = calloc(size, 1);
+	D_ALLOC(buf, size);
 	assert_non_null(buf);
 	/** inject CRT error failure to update pool map + retry */
 	daos_fail_loc_set(DAOS_SHARD_OBJ_RW_CRT_ERROR | DAOS_FAIL_ONCE);
@@ -3651,16 +3651,16 @@ split_sgl_internal(void **state, int size)
 	rc = daos_obj_open(arg->coh, oid, 0, &oh, NULL);
 	assert_int_equal(rc, 0);
 
-	sbuf1 = calloc(size/2, 1);
-	sbuf2 = calloc(size/2, 1);
+	D_ALLOC(sbuf1, size / 2);
+	D_ALLOC(sbuf2, size / 2);
 
 	/** init dkey */
 	d_iov_set(&dkey, "dkey", strlen("dkey"));
-	memset(sbuf1, 'a', size/2);
-	memset(sbuf2, 'a', size/2);
+	memset(sbuf1, 'a', size / 2);
+	memset(sbuf2, 'a', size / 2);
 	/** init scatter/gather */
-	d_iov_set(&sg_iov[0], sbuf1, size/2);
-	d_iov_set(&sg_iov[1], sbuf2, size/2);
+	d_iov_set(&sg_iov[0], sbuf1, size / 2);
+	d_iov_set(&sg_iov[1], sbuf2, size / 2);
 	sgl.sg_nr = 2;
 	sgl.sg_nr_out = 0;
 	sgl.sg_iovs = sg_iov;
@@ -3835,7 +3835,7 @@ static void fetch_mixed_keys_internal(void **state, daos_obj_id_t oid,
 	ioreq_init(&req, arg->coh, oid, iod_type, arg);
 
 	for (i = 0; i < MANYREC_NUMRECS; i++) {
-		akeys[i] = calloc(30, 1);
+		D_ALLOC(akeys[i], 30);
 		assert_non_null(akeys[i]);
 		snprintf(akeys[i], 30, "%s%d", akey, i);
 		D_ALLOC(rec[i], size);
@@ -3844,7 +3844,7 @@ static void fetch_mixed_keys_internal(void **state, daos_obj_id_t oid,
 		rec_size[i] = size;
 		rx_nr[i]    = 1;
 		offset[i]   = i * size;
-		val[i]      = calloc(size, 1);
+		D_ALLOC(val[i], size);
 		assert_non_null(val[i]);
 		val_size[i] = size;
 	}

--- a/src/tests/suite/dfs_test.c
+++ b/src/tests/suite/dfs_test.c
@@ -492,7 +492,7 @@ check_one_success(int rc, int err, MPI_Comm comm)
 			failed++;
 	}
 
-	free(rc_arr);
+	D_FREE(rc_arr);
 
 	if (failed || passed != 1)
 		return -1;

--- a/src/vos/evt_priv.h
+++ b/src/vos/evt_priv.h
@@ -274,7 +274,7 @@ evt_tcx_decref(struct evt_context *tcx)
 		tcx->tc_magic = EVT_HDL_DEAD;
 		/* Free any memory allocated by embedded iterator */
 		evt_ent_array_fini(&tcx->tc_iter.it_entries);
-		D_FREE(tcx);
+		D_MM_FREE(tcx);
 	}
 }
 

--- a/src/vos/evtree.c
+++ b/src/vos/evtree.c
@@ -316,7 +316,7 @@ void
 evt_ent_array_fini(struct evt_entry_array *ent_array)
 {
 	if (ent_array->ea_size > EVT_EMBEDDED_NR)
-		D_FREE(ent_array->ea_ents);
+		D_MM_FREE(ent_array->ea_ents);
 
 	ent_array->ea_size = ent_array->ea_ent_nr = 0;
 }
@@ -330,14 +330,14 @@ ent_array_resize(struct evt_context *tcx, struct evt_entry_array *ent_array,
 {
 	struct evt_list_entry	*ents;
 
-	D_ALLOC_ARRAY(ents, new_size);
+	D_MM_ALLOC_ARRAY(ents, new_size);
 	if (ents == NULL)
 		return -DER_NOMEM;
 
 	memcpy(ents, ent_array->ea_ents,
 	       sizeof(ents[0]) * ent_array->ea_ent_nr);
 	if (ent_array->ea_ents != ent_array->ea_embedded_ents)
-		D_FREE(ent_array->ea_ents);
+		D_MM_FREE(ent_array->ea_ents);
 	ent_array->ea_ents = ents;
 	ent_array->ea_size = new_size;
 
@@ -990,7 +990,7 @@ evt_tcx_create(struct evt_root *root, uint64_t feats, unsigned int order,
 
 	D_ASSERT(root != NULL);
 
-	D_ALLOC_PTR(tcx);
+	D_MM_ALLOC_PTR(tcx);
 	if (tcx == NULL)
 		return -DER_NOMEM;
 

--- a/src/vos/ilog.c
+++ b/src/vos/ilog.c
@@ -410,14 +410,14 @@ ilog_decref(struct ilog_context *lctx)
 {
 	lctx->ic_ref--;
 	if (lctx->ic_ref == 0)
-		D_FREE(lctx);
+		D_MM_FREE(lctx);
 }
 
 static int
 ilog_ctx_create(struct umem_instance *umm, struct ilog_root *root,
 		const struct ilog_desc_cbs *cbs, struct ilog_context **lctxp)
 {
-	D_ALLOC_PTR(*lctxp);
+	D_MM_ALLOC_PTR(*lctxp);
 	if (*lctxp == NULL) {
 		D_ERROR("Could not allocate memory for open incarnation log\n");
 		return -DER_NOMEM;

--- a/src/vos/vos_common.c
+++ b/src/vos/vos_common.c
@@ -135,7 +135,7 @@ vos_tx_publish(struct dtx_handle *dth, bool publish)
 	for (i = 0; i < dth->dth_rsrvd_cnt; i++) {
 		dru = &dth->dth_rsrvds[i];
 		rc = vos_publish_scm(cont, dru->dru_scm, publish);
-		D_FREE(dru->dru_scm);
+		D_MM_FREE(dru->dru_scm);
 
 		/* FIXME: Currently, vos_publish_blocks() will release
 		 *	  reserved information in 'dru_nvme_list' from

--- a/src/vos/vos_dtx_iter.c
+++ b/src/vos/vos_dtx_iter.c
@@ -64,7 +64,7 @@ dtx_iter_fini(struct vos_iterator *iter)
 	if (oiter->oit_cont != NULL)
 		vos_cont_decref(oiter->oit_cont);
 
-	D_FREE_PTR(oiter);
+	D_MM_FREE(oiter);
 	return rc;
 }
 
@@ -85,7 +85,7 @@ dtx_iter_prep(vos_iter_type_t type, vos_iter_param_t *param,
 	if (cont == NULL)
 		return -DER_INVAL;
 
-	D_ALLOC_PTR(oiter);
+	D_MM_ALLOC_PTR(oiter);
 	if (oiter == NULL)
 		return -DER_NOMEM;
 

--- a/src/vos/vos_ts.c
+++ b/src/vos/vos_ts.c
@@ -334,7 +334,7 @@ vos_ts_set_allocate(struct vos_ts_set **ts_set, uint64_t flags,
 	size = VOS_TS_TYPE_AKEY / VOS_TS_PER_LEVEL + akey_nr;
 	array_size = size * sizeof((*ts_set)->ts_entries[0]);
 
-	D_ALLOC(*ts_set, sizeof(**ts_set) + array_size);
+	D_MM_ALLOC(*ts_set, sizeof(**ts_set) + array_size);
 	if (*ts_set == NULL)
 		return -DER_NOMEM;
 

--- a/src/vos/vos_ts.h
+++ b/src/vos/vos_ts.h
@@ -605,7 +605,7 @@ vos_ts_set_upgrade(struct vos_ts_set *ts_set);
 static inline void
 vos_ts_set_free(struct vos_ts_set *ts_set)
 {
-	D_FREE(ts_set);
+	D_MM_FREE(ts_set);
 }
 
 /** Internal API to copy timestamp */


### PR DESCRIPTION
This patch introduce simple cashing for memory allocations from
hot path and reuse it many times without system malloc()/free().

The cash of free regions is split by buckets. Each bucket contain
allocations with size rounded up to power of 2. This means the size
of each allocation is alligned by power of 2 and placed into separate
bucket to minimize locking collisions.