### PR TITLE
DAOS-5640 dtx: skip repeated DTX entry when prepare DTX RPC

### DIFF
--- a/src/dtx/dtx_rpc.c
+++ b/src/dtx/dtx_rpc.c
@@ -367,7 +367,14 @@ dtx_cf_rec_update(struct btr_instance *tins, struct btr_record *rec,
 
 	drr = (struct dtx_req_rec *)umem_off2ptr(&tins->ti_umm, rec->rec_off);
 	dcrb = (struct dtx_cf_rec_bundle *)val->iov_buf;
-	drr->drr_dti[drr->drr_count++] = *dcrb->dcrb_dti;
+	D_ASSERT(drr->drr_count >= 1);
+
+	if (!daos_dti_equal(&drr->drr_dti[drr->drr_count - 1],
+			    dcrb->dcrb_dti)) {
+		D_ASSERT(drr->drr_count < dcrb->dcrb_count);
+
+		drr->drr_dti[drr->drr_count++] = *dcrb->dcrb_dti;
+	}
 
 	return 0;
 }


### PR DESCRIPTION
With OSA enabled, it is possible that more than one replicas (shards)
may reside on the same VOS target. When the leader prepares to commit
related DTX, its ID will be attached to some VOS target for more than
once, but we only need one of them, the others are redundant.

The patch filters out repeated DTX entries when classifies DTX ID for
DTX RPC. It can avoid DTX RPC buffer overflow, and simplify VOS logic
for handling repeated DTX commit/abort.

Signed-off-by: Fan Yong <fan.yong@intel.com>