### PR TITLE
DAOS-5704 Test: Regression in test util for dmg command.

### DIFF
--- a/src/tests/ftest/util/dmg_utils_base.py
+++ b/src/tests/ftest/util/dmg_utils_base.py
@@ -457,7 +457,7 @@ class DmgCommandBase(YamlCommand):
                     DmgCommandBase.StorageSubCommand.ScanSubCommand,
                     self).__init__(
                         "/run/dmg/storage/scan/*", "scan")
-                self.nvme_health = FormattedParameter("--nvme_health", False)
+                self.nvme_health = FormattedParameter("--nvme-health", False)
                 self.verbose = FormattedParameter("--verbose", False)
 
         class SetSubCommand(CommandWithSubCommand):


### PR DESCRIPTION
dmg storage scan has option --nvme-health instead of nvme_health.

Signed-off-by: Samir Raval <samir.raval@intel.com>