### PR TITLE
DAOS-5709 bio: health unavailable on start

### DIFF
--- a/src/bio/bio_monitor.c
+++ b/src/bio/bio_monitor.c
@@ -168,6 +168,29 @@ get_spdk_err_log_page_completion(struct spdk_bdev_io *bdev_io, bool success,
 	dev_health->bdh_inflights--;
 }
 
+static int
+populate_health_cdata(struct nvme_health_stats *dev_state,
+		      const struct spdk_nvme_ctrlr_data *cdata)
+{
+	int	written;
+
+	written = snprintf(dev_state->model, sizeof(dev_state->model),
+			   "%-20.20s", cdata->mn);
+	if (written >= sizeof(dev_state->model)) {
+		D_ERROR("writing model to dev_state");
+		return -DER_TRUNC;
+	}
+
+	written = snprintf(dev_state->serial, sizeof(dev_state->serial),
+			   "%-20.20s", cdata->sn);
+	if (written >= sizeof(dev_state->serial)) {
+		D_ERROR("writing serial to dev_state");
+		return -DER_TRUNC;
+	}
+
+	return 0;
+}
+
 static void
 get_spdk_identify_ctrlr_completion(struct spdk_bdev_io *bdev_io, bool success,
 				   void *cb_arg)
@@ -196,7 +219,14 @@ get_spdk_identify_ctrlr_completion(struct spdk_bdev_io *bdev_io, bool success,
 	D_ASSERT(dev_health->bdh_io_channel != NULL);
 	bdev = spdk_bdev_desc_get_bdev(dev_health->bdh_desc);
 	D_ASSERT(bdev != NULL);
+
+	/* Store ctrlr details in in-memory health state log. */
 	cdata = dev_health->bdh_ctrlr_buf;
+	rc = populate_health_cdata(&dev_health->bdh_health_state, cdata);
+	if (rc != 0) {
+		D_ERROR("failed to populate device details in health state");
+		goto out;
+	}
 
 	/* Prep NVMe command to get device error log pages */
 	ep_sz = sizeof(struct spdk_nvme_error_information_entry);
@@ -237,13 +267,11 @@ out:
 	spdk_bdev_free_io(bdev_io);
 }
 
-static int
-populate_dev_health(struct nvme_health_stats *dev_state,
-		    struct spdk_nvme_health_information_page *page,
-		    const struct spdk_nvme_ctrlr_data *cdata)
+static void
+populate_health_stats(struct nvme_health_stats *dev_state,
+		      struct spdk_nvme_health_information_page *page)
 {
 	union spdk_nvme_critical_warning_state	cw = page->critical_warning;
-	int					written;
 
 	dev_state->warn_temp_time = page->warning_temp_time;
 	dev_state->crit_temp_time = page->critical_temp_time;
@@ -261,35 +289,18 @@ populate_dev_health(struct nvme_health_stats *dev_state,
 	dev_state->read_only_warn = cw.bits.read_only ? true : false;
 	dev_state->volatile_mem_warn = cw.bits.volatile_memory_backup ?
 		true : false;
-
-	written = snprintf(dev_state->model, sizeof(dev_state->model),
-			   "%-20.20s", cdata->mn);
-	if (written >= sizeof(dev_state->model)) {
-		D_ERROR("writing model to dev_state");
-		return -DER_TRUNC;
-	}
-
-	written = snprintf(dev_state->serial, sizeof(dev_state->serial),
-			   "%-20.20s", cdata->sn);
-	if (written >= sizeof(dev_state->serial)) {
-		D_ERROR("writing serial to dev_state");
-		return -DER_TRUNC;
-	}
-
-	return 0;
 }
 
 static void
 get_spdk_log_page_completion(struct spdk_bdev_io *bdev_io, bool success,
 			     void *cb_arg)
 {
-	struct bio_dev_health			 *dev_health = cb_arg;
-	struct nvme_health_stats		 *dev_state;
-	struct spdk_bdev			 *bdev;
-	struct spdk_nvme_cmd			  cmd;
-	uint32_t				  cp_sz;
-	int					  rc, sc, sct;
-	uint32_t				  cdw0;
+	struct bio_dev_health	*dev_health = cb_arg;
+	struct spdk_bdev	*bdev;
+	struct spdk_nvme_cmd	 cmd;
+	uint32_t		 cp_sz;
+	int			 rc, sc, sct;
+	uint32_t		 cdw0;
 
 	D_ASSERT(dev_health->bdh_inflights == 1);
 
@@ -306,12 +317,9 @@ get_spdk_log_page_completion(struct spdk_bdev_io *bdev_io, bool success,
 	D_ASSERT(bdev != NULL);
 
 	/* Store device health info in in-memory health state log. */
-	dev_state = &dev_health->bdh_health_state;
-	dev_state->timestamp = dev_health->bdh_stat_age;
-	rc = populate_dev_health(dev_state, dev_health->bdh_health_buf,
-				 dev_health->bdh_ctrlr_buf);
-	if (rc != 0)
-		goto out;
+	dev_health->bdh_health_state.timestamp = dev_health->bdh_stat_age;
+	populate_health_stats(&dev_health->bdh_health_state,
+			      dev_health->bdh_health_buf);
 
 	/* Prep NVMe command to get controller data */
 	cp_sz = sizeof(struct spdk_nvme_ctrlr_data);

--- a/src/bio/bio_monitor.c
+++ b/src/bio/bio_monitor.c
@@ -172,23 +172,23 @@ static int
 populate_health_cdata(struct nvme_health_stats *dev_state,
 		      const struct spdk_nvme_ctrlr_data *cdata)
 {
-	int	written;
+	int	written, rc = 0;
 
 	written = snprintf(dev_state->model, sizeof(dev_state->model),
 			   "%-20.20s", cdata->mn);
 	if (written >= sizeof(dev_state->model)) {
-		D_ERROR("writing model to dev_state");
-		return -DER_TRUNC;
+		D_WARN("data truncated when writing model to health state");
+		rc = -DER_TRUNC;
 	}
 
 	written = snprintf(dev_state->serial, sizeof(dev_state->serial),
 			   "%-20.20s", cdata->sn);
 	if (written >= sizeof(dev_state->serial)) {
-		D_ERROR("writing serial to dev_state");
-		return -DER_TRUNC;
+		D_WARN("data truncated when writing model to health state");
+		rc = -DER_TRUNC;
 	}
 
-	return 0;
+	return rc;
 }
 
 static void

--- a/src/control/server/ctl_storage_rpc_test.go
+++ b/src/control/server/ctl_storage_rpc_test.go
@@ -547,7 +547,8 @@ func TestServer_CtlSvc_StorageScan_PostIOStart(t *testing.T) {
 				Scm: &ScanScmResp{State: new(ResponseState)},
 			},
 		},
-		"scan twice bdev meta with multiple io servers up": {
+		// make sure information is not duplicated in cache
+		"verify cache integrity over multiple storage scan calls": {
 			req: &StorageScanReq{Nvme: &ScanNvmeReq{Meta: true}},
 			bmbc: &bdev.MockBackendConfig{
 				ScanRes: &bdev.ScanResponse{

--- a/src/control/server/instance_drpc.go
+++ b/src/control/server/instance_drpc.go
@@ -229,8 +229,7 @@ func (srv *IOServerInstance) updateInUseBdevs(ctx context.Context, ctrlrMap map[
 
 		key, err := health.GenAltKey()
 		if err != nil {
-			srv.log.Infof("%s: data not yet available", msg)
-			continue
+			return errors.Wrapf(err, msg)
 		}
 
 		msg += fmt.Sprintf(" with key %s", key)


### PR DESCRIPTION
Controller model and serial number were not being populated in health
state immediately after start-up, moving the collection of cdata info to
the right callback fixes this.

Signed-off-by: Tom Nabarro <tom.nabarro@intel.com>