### PR TITLE
DAOS-5691 control: Update agent dRPC socket filename

### DIFF
--- a/src/client/api/tests/agent_tests.c
+++ b/src/client/api/tests/agent_tests.c
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright 2018-2019 Intel Corporation.
+ * (C) Copyright 2018-2020 Intel Corporation.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -87,7 +87,7 @@ test_dc_agent_init_no_env(void **state)
 static void
 test_dc_agent_init_with_env(void **state)
 {
-	char *expected_sockaddr = "/nice/good/agent.sock";
+	char *expected_sockaddr = "/nice/good/daos_agent.sock";
 
 	getenv_return = "/nice/good";
 

--- a/src/control/cmd/daos_agent/start.go
+++ b/src/control/cmd/daos_agent/start.go
@@ -36,7 +36,7 @@ import (
 )
 
 const (
-	agentSockName = "agent.sock"
+	agentSockName = "daos_agent.sock"
 )
 
 type startCmd struct {

--- a/src/include/daos/agent.h
+++ b/src/include/daos/agent.h
@@ -54,7 +54,7 @@ extern char *dc_agent_sockpath;
 /**
  * Socket name used to craft path from environment variable
  */
-#define DAOS_AGENT_DRPC_SOCK_NAME "agent.sock"
+#define DAOS_AGENT_DRPC_SOCK_NAME "daos_agent.sock"
 
 /**
  * Default Unix Domain Socket path for the DAOS agent dRPC connection


### PR DESCRIPTION
Add the "daos_" prefix for consistency with other sockets.