### PR TITLE
DAOS-5735 test: Replacing '-' with '_' in avocado tags.

### DIFF
--- a/src/tests/ftest/aggregation/aggregation_basic.py
+++ b/src/tests/ftest/aggregation/aggregation_basic.py
@@ -57,7 +57,7 @@ class DaosAggregationBasic(IorTestBase):
             reclaimed the overwritten capacity.
 
         :avocado: tags=all,pr,hw,large,aggregate,daosio,aggregatebasic
-        :avocado: tags=DAOS-5610
+        :avocado: tags=DAOS_5610
         """
 
         # Create pool and container

--- a/src/tests/ftest/daos_test/daos_core_test-rebuild.py
+++ b/src/tests/ftest/daos_test/daos_core_test-rebuild.py
@@ -42,6 +42,6 @@ class DaosCoreTestRebuild(DaosCoreBase):
             Balance testing load between hardware and VM clusters.
 
         :avocado: tags=all,pr,hw,medium,ib2,unittest,daos_test_rebuild
-        :avocado: tags=DAOS-5610
+        :avocado: tags=DAOS_5610
         """
         DaosCoreBase.run_subtest(self)

--- a/src/tests/ftest/daos_test/daos_core_test.py
+++ b/src/tests/ftest/daos_test/daos_core_test.py
@@ -38,6 +38,6 @@ class DaosCoreTest(DaosCoreBase):
 
         Use Cases: core tests for daos_test
 
-        :avocado: tags=all,pr,hw,ib2,medium,daos_test,DAOS-5610
+        :avocado: tags=all,pr,hw,ib2,medium,daos_test,DAOS_5610
         """
         DaosCoreBase.run_subtest(self)

--- a/src/tests/ftest/io/daos_vol.py
+++ b/src/tests/ftest/io/daos_vol.py
@@ -59,6 +59,6 @@ class DaosVol(VolTestBase):
               h5daos_test_map_parallel
               h5daos_test_oclass
 
-        :avocado: tags=all,pr,hw,small,hdf5,vol,DAOS-5610
+        :avocado: tags=all,pr,hw,small,hdf5,vol,DAOS_5610
         """
         self.run_test()

--- a/src/tests/ftest/io/io_consistency.py
+++ b/src/tests/ftest/io/io_consistency.py
@@ -53,7 +53,7 @@ class IoConsistency(IorTestBase):
             Try to re-create to the same file name after deletion, which should
             work without issues.
             Repeat the same steps as above for SSF this time.
-        :avocado: tags=all,daosio,hw,large,pr,ioconsistency,DAOS-5610
+        :avocado: tags=all,daosio,hw,large,pr,ioconsistency,DAOS_5610
         """
 
         # test params

--- a/src/tests/ftest/io/ior_small.py
+++ b/src/tests/ftest/io/ior_small.py
@@ -49,7 +49,7 @@ class IorSmall(IorTestBase):
             All above three cases to be run with single client and
                 multiple client processes in two separate nodes.
 
-        :avocado: tags=all,pr,hw,large,daosio,iorsmall,DAOS-5610
+        :avocado: tags=all,pr,hw,large,daosio,iorsmall,DAOS_5610
         """
         results = []
         ior_timeout = self.params.get("ior_timeout", '/run/ior/*')

--- a/src/tests/ftest/io/macsio_test.py
+++ b/src/tests/ftest/io/macsio_test.py
@@ -51,7 +51,7 @@ class MacsioTest(DfuseTestBase, MacsioTestBase):
         Use case:
             Six clients and two servers.
 
-        :avocado: tags=all,pr,hw,large,io,macsio,DAOS-5610
+        :avocado: tags=all,pr,hw,large,io,macsio,DAOS_5610
         """
         # Create a pool
         self.add_pool()
@@ -79,7 +79,7 @@ class MacsioTest(DfuseTestBase, MacsioTestBase):
         Use case:
             Six clients and two servers.
 
-        :avocado: tags=all,pr,hw,large,io,macsio_daos_vol,DAOS-5610
+        :avocado: tags=all,pr,hw,large,io,macsio_daos_vol,DAOS_5610
         """
         plugin_path = self.params.get("plugin_path")
 

--- a/src/tests/ftest/io/mdtest_small.py
+++ b/src/tests/ftest/io/mdtest_small.py
@@ -48,7 +48,7 @@ class MdtestSmall(MdtestBase):
             read bytes: 0|4K
             depth of hierarchical directory structure: 0|5
 
-        :avocado: tags=all,pr,hw,large,mdtest,mdtestsmall,DAOS-5610
+        :avocado: tags=all,pr,hw,large,mdtest,mdtestsmall,DAOS_5610
         """
         # local params
         mdtest_params = self.params.get("mdtest_params", "/run/mdtest/*")

--- a/src/tests/ftest/nvme/nvme_object.py
+++ b/src/tests/ftest/nvme/nvme_object.py
@@ -185,7 +185,7 @@ class NvmeObject(TestWithServers):
             corrupted.
 
         :avocado: tags=all,pr,hw,large,nvme_object_single_pool,nvme_object
-        :avocado: tags=DAOS-5610
+        :avocado: tags=DAOS_5610
         """
         # perform multiple object writes to a single pool
         test_runner(self, self.pool_size[0], self.record_size[:-1], 0,

--- a/src/tests/ftest/osa/osa_online_drain.py
+++ b/src/tests/ftest/osa/osa_online_drain.py
@@ -225,7 +225,7 @@ class OSAOnlineDrain(TestWithServers):
         """Test ID: DAOS-4750
         Test Description: Validate Online drain
 
-        :avocado: tags=all,pr,hw,large,osa,osa_drain,online_drain,DAOS-5610
+        :avocado: tags=all,pr,hw,large,osa,osa_drain,online_drain,DAOS_5610
         """
         # Perform drain testing with 1 to 2 pools
         for pool_num in range(1, 3):

--- a/src/tests/ftest/osa/osa_online_reintegration.py
+++ b/src/tests/ftest/osa/osa_online_reintegration.py
@@ -276,7 +276,7 @@ class OSAOnlineReintegration(TestWithServers):
         """Test ID: DAOS-5075
         Test Description: Validate Online Reintegration
 
-        :avocado: tags=all,pr,hw,large,osa,online_reintegration,DAOS-5610
+        :avocado: tags=all,pr,hw,large,osa,online_reintegration,DAOS_5610
         """
         # Perform reintegration testing with 1 pool.
         for pool_num in range(1, 2):

--- a/src/tests/ftest/pool/evict_test.py
+++ b/src/tests/ftest/pool/evict_test.py
@@ -176,7 +176,7 @@ class EvictTests(TestWithServers):
         The handle is removed.
         The test verifies that the other two pools were not affected
         by the evict
-        :avocado: tags=all,pool,pr,full_regression,small,poolevict,DAOS-5610
+        :avocado: tags=all,pool,pr,full_regression,small,poolevict,DAOS_5610
         """
         pool = []
         container = []
@@ -266,7 +266,7 @@ class EvictTests(TestWithServers):
         Test evicting a pool using an invalid server group name.
 
         :avocado: tags=all,pool,pr,full_regression,small,poolevict
-        :avocado: tags=poolevict_bad_server_name,DAOS-5610
+        :avocado: tags=poolevict_bad_server_name,DAOS_5610
         """
         test_param = self.params.get("server_name", '/run/badparams/*')
         self.assertTrue(self.evict_badparam(test_param))
@@ -276,7 +276,7 @@ class EvictTests(TestWithServers):
         Test evicting a pool using an invalid uuid.
 
         :avocado: tags=all,pool,pr,full_regression,small,poolevict
-        :avocado: tags=poolevict_bad_uuid,DAOS-5610
+        :avocado: tags=poolevict_bad_uuid,DAOS_5610
         """
         test_param = self.params.get("uuid", '/run/badparams/*')
         self.assertTrue(self.evict_badparam(test_param))

--- a/src/tests/ftest/pool/pool_svc.py
+++ b/src/tests/ftest/pool/pool_svc.py
@@ -43,7 +43,7 @@ class PoolSvc(TestWithServers):
         """
         Test svc arg during pool create.
 
-        :avocado: tags=all,pool,pr,medium,svc,DAOS-5610
+        :avocado: tags=all,pool,pr,medium,svc,DAOS_5610
         """
         # parameter used in pool create
         createsvc = self.params.get("svc", '/run/createtests/createsvc/*/')

--- a/src/tests/ftest/server/daos_server_restart.py
+++ b/src/tests/ftest/server/daos_server_restart.py
@@ -123,7 +123,7 @@ class DaosServerTest(TestWithServers):
         (5)Verify after DAOS server restarted, it should appear as an empty
            fresh installation.
 
-        :avocado: tags=all,pr,hw,large,server_test,server_reformat,DAOS-5610
+        :avocado: tags=all,pr,hw,large,server_test,server_reformat,DAOS_5610
         """
 
         self.log.info("(1)Verify daos server pool list after started.")
@@ -155,7 +155,7 @@ class DaosServerTest(TestWithServers):
         (5)Use the cmd line to perform a controlled shutdown when the
            daos cluster is incomplete (i.e. 1 of the 2 servers is down).
 
-        :avocado: tags=all,pr,hw,large,server_test,server_restart,DAOS-5610
+        :avocado: tags=all,pr,hw,large,server_test,server_restart,DAOS_5610
         """
 
         self.log.info(


### PR DESCRIPTION
Replacing '-' with '_' in avocado tags

Signed-off-by: Saurabh Tandan <saurabh.tandan@intel.com>