### PR TITLE
DAOS-4622 duns: Mark duns_resolve_path as in,out.

### DIFF
--- a/src/client/dfuse/dfuse_main.c
+++ b/src/client/dfuse/dfuse_main.c
@@ -263,7 +263,7 @@ main(int argc, char **argv)
 	struct dfuse_pool	*dfpn;
 	struct dfuse_dfs	*dfs = NULL;
 	struct dfuse_dfs	*dfsn;
-	struct duns_attr_t	duns_attr;
+	struct duns_attr_t	duns_attr = {};
 	uuid_t			tmp_uuid;
 	char			c;
 	int			ret = -DER_SUCCESS;

--- a/src/include/daos_uns.h
+++ b/src/include/daos_uns.h
@@ -109,8 +109,8 @@ duns_create_path(daos_handle_t poh, const char *path,
  * is accessing a posix container, or it can be empty for example in the case of
  * an HDF5 file.
  *
- * \param[in]	path	Valid path in an existing namespace.
- * \param[out]	attr	Struct containing the xattrs on the path.
+ * \param[in]		path	Valid path in an existing namespace.
+ * \param[in,out]	attr	Struct containing the xattrs on the path.
  *
  * \return		0 on Success. errno code on failure.
  */


### PR DESCRIPTION
Zero this field in dfuse before passing it into duns.

Signed-off-by: Ashley Pittman <ashley.m.pittman@intel.com>