### PR TITLE
DAOS-5535 test: Whitelist variable name from spell checking.

### DIFF
--- a/ci/patch_src_in_place
+++ b/ci/patch_src_in_place
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 # shellcheck disable=SC2046,SC2035
-codespell -w --ignore-words-list dedup,nd,uint,ths,ba,creat,te,cas,mapp,pres,crashers,dout,tre,reord,mimick,cloneable,keypair,bject,tread,cancelled --builtin clear,rare,informal,names,en-GB_to_en-US --skip *.png,*.PNG,*.pyc,src/rdb/raft/*,src/control/vendor/*,RSA.golden $(git ls-tree --full-tree --name-only HEAD)
+codespell -w --ignore-words-list dedup,nd,uint,ths,ba,creat,te,cas,mapp,pres,crashers,dout,tre,reord,mimick,cloneable,keypair,bject,tread,cancelled,controllerd --builtin clear,rare,informal,names,en-GB_to_en-US --skip *.png,*.PNG,*.pyc,src/rdb/raft/*,src/control/vendor/*,RSA.golden $(git ls-tree --full-tree --name-only HEAD)
 
 # The return code of codespell is the number of words it could not correct
 # because of multiple options.  We could report on these but they're rare


### PR DESCRIPTION
Do not warn on spelling of controllerD.

Signed-off-by: Ashley Pittman <ashley.m.pittman@intel.com>