### PR TITLE
DAOS-5658 container: only free container during failure

### DIFF
--- a/src/container/srv_cli.c
+++ b/src/container/srv_cli.c
@@ -110,20 +110,23 @@ dsc_cont_open(daos_handle_t poh, uuid_t cont_uuid, uuid_t coh_uuid,
 			D_GOTO(out, rc);
 	}
 
-	cont = dc_cont_alloc(cont_uuid);
-	if (cont == NULL)
-		D_GOTO(out, rc = -DER_NOMEM);
-
 	D_ASSERT(!daos_handle_is_inval(poh));
 	pool = dc_hdl2pool(poh);
 	if (pool == NULL)
 		D_GOTO(out, rc = -DER_NO_HDL);
 
+	cont = dc_cont_alloc(cont_uuid);
+	if (cont == NULL)
+		D_GOTO(out, rc = -DER_NOMEM);
+
 	/** destroyed in dsc_cont_close */
 	rc = dsc_cont_csummer_init(&cont->dc_csummer, pool->dp_pool,
 				   cont_uuid);
-	if (rc != 0)
+	if (rc != 0) {
+		dc_cont_free(cont);
+		cont = NULL;
 		D_GOTO(out, rc);
+	}
 
 	uuid_copy(cont->dc_cont_hdl, coh_uuid);
 	cont->dc_capas = flags;
@@ -137,7 +140,7 @@ dsc_cont_open(daos_handle_t poh, uuid_t cont_uuid, uuid_t coh_uuid,
 	dc_cont2hdl(cont, coh);
 out:
 	if (cont != NULL)
-		dc_cont_free(cont);
+		dc_cont_put(cont);
 	if (pool != NULL)
 		dc_pool_put(pool);
 


### PR DESCRIPTION
Only free container if dsc_cont_open failed, the failure
brought in by PR-3520.

Signed-off-by: Di Wang <di.wang@intel.com>