### PR TITLE
DAOS-5570 dtx: leader election for single RDG based TX

### DIFF
--- a/src/dtx/dtx_common.c
+++ b/src/dtx/dtx_common.c
@@ -651,6 +651,8 @@ again:
 		if (dth->dth_sync)
 			goto sync;
 
+		D_ASSERT(dth->dth_mbs != NULL);
+
 		size = sizeof(*dte) + sizeof(*mbs) + dth->dth_mbs->dm_data_size;
 		D_ALLOC(dte, size);
 		if (dte == NULL) {

--- a/src/dtx/dtx_resync.c
+++ b/src/dtx/dtx_resync.c
@@ -295,6 +295,7 @@ dtx_iter_cb(uuid_t co_uuid, vos_iter_entry_t *ent, void *args)
 	mbs->dm_tgt_cnt = ent->ie_dtx_tgt_cnt;
 	mbs->dm_grp_cnt = ent->ie_dtx_grp_cnt;
 	mbs->dm_data_size = ent->ie_dtx_mbs_dsize;
+	mbs->dm_flags = ent->ie_dtx_mbs_flags;
 	memcpy(mbs->dm_data, ent->ie_dtx_mbs, ent->ie_dtx_mbs_dsize);
 
 	dte->dte_xid = ent->ie_dtx_xid;

--- a/src/include/daos/dtx.h
+++ b/src/include/daos/dtx.h
@@ -42,6 +42,23 @@ enum dtx_target_flags {
 	DTF_RDONLY			= (1 << 0),
 };
 
+enum dtx_grp_flags {
+	/* The group only contains read-only operations for the DTX. */
+	DGF_RDONLY			= (1 << 0),
+};
+
+enum dtx_mbs_flags {
+	/* The targets that are modified by the distributed transaction
+	 * are in the same single redundancy group.
+	 */
+	DMF_MODIFY_SRDG			= (1 << 0),
+	/* The MDS contains the leader information, used for distributed
+	 * transaction. For stand-alone modification, leader information
+	 * is not stored inside MBS as optimization.
+	 */
+	DMF_CONTAIN_LEADER		= (1 << 1),
+};
+
 /**
  * The daos target that participates in the DTX.
  */
@@ -90,7 +107,10 @@ struct dtx_redundancy_group {
 	 * If all the shards 'drg_ids[0 - drg_redundancy - 1]' are lost,
 	 * then the group is regarded as unavailable.
 	 */
-	uint32_t			drg_redundancy;
+	uint16_t			drg_redundancy;
+
+	/* See dtx_grp_flags. */
+	uint16_t			drg_flags;
 
 	/* The shards' IDs, corresponding to pool_component::co_id. For the
 	 * leader group that is the first in dtx_memberships, 'drg_index[0]'
@@ -104,14 +124,21 @@ struct dtx_memberships {
 	/* How many touched shards in the DTX. */
 	uint32_t			dm_tgt_cnt;
 
-	/* How many modification groups in the DTX. For single modification
-	 * group, be as optimization, we will nots store modification group
-	 * information inside 'dm_data'.
+	/* How many modification groups in the DTX. For standalone modification,
+	 * be as optimization, we will not store modification group information
+	 * inside 'dm_data'. Similarly for the distributed transaction that all
+	 * the touched targets are in the same redundancy group.
 	 */
 	uint32_t			dm_grp_cnt;
 
 	/* sizeof(dm_data). */
 	uint32_t			dm_data_size;
+
+	/* see dtx_mbs_flags. */
+	uint16_t			dm_flags;
+
+	/* For alignment. */
+	uint16_t			dm_padding;
 
 	/* The first 'sizeof(struct dtx_daos_target) * dm_tgt_cnt' is the
 	 * dtx_daos_target array. The subsequent are modification groups.

--- a/src/include/daos_srv/vos_types.h
+++ b/src/include/daos_srv/vos_types.h
@@ -402,8 +402,10 @@ typedef struct {
 			daos_unit_oid_t		ie_dtx_oid;
 			/** The pool map version when handling DTX on server. */
 			uint32_t		ie_dtx_ver;
-			/* The dkey hash for DTX iteration. */
+			/* The DTX entry flags, see dtx_entry_flags. */
 			uint16_t		ie_dtx_flags;
+			/* DTX mbs flags, see dtx_mbs_flags. */
+			uint16_t		ie_dtx_mbs_flags;
 			/** DTX tgt count. */
 			uint32_t		ie_dtx_tgt_cnt;
 			/** DTX modified group count. */

--- a/src/object/cli_obj.c
+++ b/src/object/cli_obj.c
@@ -469,14 +469,6 @@ obj_grp_valid_shard_get(struct dc_object *obj, int idx,
 	return idx;
 }
 
-static inline struct pl_obj_shard*
-obj_get_shard(void *data, int idx)
-{
-	struct dc_object	*obj = data;
-
-	return &obj->cob_shards->do_shards[idx].do_pl_shard;
-}
-
 static int
 obj_grp_leader_get(struct dc_object *obj, int idx, unsigned int map_ver)
 {

--- a/src/object/obj_internal.h
+++ b/src/object/obj_internal.h
@@ -484,6 +484,14 @@ obj_singv_ec_rw_filter(daos_unit_oid_t *oid, daos_iod_t *iods, uint64_t *offs,
 		       uint32_t nr, bool for_update, bool deg_fetch,
 		       struct daos_recx_ep_list **recov_lists_ptr);
 
+static inline struct pl_obj_shard*
+obj_get_shard(void *data, int idx)
+{
+	struct dc_object	*obj = data;
+
+	return &obj->cob_shards->do_shards[idx].do_pl_shard;
+}
+
 static inline bool
 obj_retry_error(int err)
 {

--- a/src/object/obj_rpc.c
+++ b/src/object/obj_rpc.c
@@ -684,7 +684,11 @@ crt_proc_struct_dtx_redundancy_group(crt_proc_t proc,
 	if (rc != 0)
 		return -DER_HG;
 
-	rc = crt_proc_uint32_t(proc, &drg->drg_redundancy);
+	rc = crt_proc_uint16_t(proc, &drg->drg_redundancy);
+	if (rc != 0)
+		return -DER_HG;
+
+	rc = crt_proc_uint16_t(proc, &drg->drg_flags);
 	if (rc != 0)
 		return -DER_HG;
 
@@ -716,11 +720,25 @@ crt_proc_struct_dtx_memberships(crt_proc_t proc, struct dtx_memberships *mbs)
 	if (rc != 0)
 		return -DER_HG;
 
+	rc = crt_proc_uint16_t(proc, &mbs->dm_flags);
+	if (rc != 0)
+		return -DER_HG;
+
+	rc = crt_proc_uint16_t(proc, &mbs->dm_padding);
+	if (rc != 0)
+		return -DER_HG;
+
 	for (i = 0; i < mbs->dm_tgt_cnt; i++) {
 		rc = crt_proc_struct_dtx_daos_target(proc, &mbs->dm_tgts[i]);
 		if (rc != 0)
 			return rc;
 	}
+
+	/* We do not need the group information if all the targets are
+	 * in the same redundancy group.
+	 */
+	if (mbs->dm_grp_cnt == 1)
+		return 0;
 
 	drg = (struct dtx_redundancy_group *)mbs->dm_data;
 	rc = sizeof(mbs->dm_tgts[0]) * mbs->dm_tgt_cnt;

--- a/src/object/srv_obj.c
+++ b/src/object/srv_obj.c
@@ -86,6 +86,7 @@ obj_gen_dtx_mbs(struct daos_shard_tgt *tgts, uint32_t *tgt_cnt,
 		mbs->dm_tgt_cnt = j;
 		mbs->dm_grp_cnt = 1;
 		mbs->dm_data_size = size;
+		mbs->dm_flags = DMF_MODIFY_SRDG;
 	}
 
 	*p_mbs = mbs;
@@ -3754,7 +3755,11 @@ ds_obj_dtx_leader_ult(void *arg)
 	else
 		tgts++;
 
-	/* For distributed transaction, ask DTX  to 'sync' commit. */
+	/* For distributed transaction, ask DTX  to 'sync' commit. For single
+	 * RDG based modification (with the dm_flag DMF_MODIFY_SRDG), we will
+	 * consider 'async' mode when batched commit is ready for distributed
+	 * transaction.
+	 */
 	rc = dtx_leader_begin(dca->dca_ioc->ioc_coc, &dcsh->dcsh_xid,
 			      &dcsh->dcsh_epoch, dcde->dcde_write_cnt,
 			      oci->oci_map_ver, &dcsh->dcsh_leader_oid, NULL,

--- a/src/vos/vos_dtx.c
+++ b/src/vos/vos_dtx.c
@@ -1031,6 +1031,7 @@ vos_dtx_alloc(struct umem_instance *umm, struct dtx_handle *dth)
 	DAE_TGT_CNT(dae) = dth->dth_mbs->dm_tgt_cnt;
 	DAE_GRP_CNT(dae) = dth->dth_mbs->dm_grp_cnt;
 	DAE_MBS_DSIZE(dae) = dth->dth_mbs->dm_data_size;
+	DAE_MBS_FLAGS(dae) = dth->dth_mbs->dm_flags;
 
 	/* Will be set as dbd::dbd_index via vos_dtx_prepared(). */
 	DAE_INDEX(dae) = DTX_INDEX_INVAL;

--- a/src/vos/vos_dtx_iter.c
+++ b/src/vos/vos_dtx_iter.c
@@ -177,6 +177,7 @@ dtx_iter_fetch(struct vos_iterator *iter, vos_iter_entry_t *it_entry,
 	it_entry->ie_dtx_oid = DAE_OID(dae);
 	it_entry->ie_dtx_ver = DAE_VER(dae);
 	it_entry->ie_dtx_flags = DAE_FLAGS(dae);
+	it_entry->ie_dtx_mbs_flags = DAE_MBS_FLAGS(dae);
 	it_entry->ie_dtx_tgt_cnt = DAE_TGT_CNT(dae);
 	it_entry->ie_dtx_grp_cnt = DAE_GRP_CNT(dae);
 	it_entry->ie_dtx_mbs_dsize = DAE_MBS_DSIZE(dae);

--- a/src/vos/vos_internal.h
+++ b/src/vos/vos_internal.h
@@ -278,6 +278,7 @@ do {						\
 #define DAE_EPOCH(dae)		((dae)->dae_base.dae_epoch)
 #define DAE_LID(dae)		((dae)->dae_base.dae_lid)
 #define DAE_FLAGS(dae)		((dae)->dae_base.dae_flags)
+#define DAE_MBS_FLAGS(dae)	((dae)->dae_base.dae_mbs_flags)
 #define DAE_REC_INLINE(dae)	((dae)->dae_base.dae_rec_inline)
 #define DAE_REC_CNT(dae)	((dae)->dae_base.dae_rec_cnt)
 #define DAE_VER(dae)		((dae)->dae_base.dae_ver)

--- a/src/vos/vos_layout.h
+++ b/src/vos/vos_layout.h
@@ -189,7 +189,9 @@ struct vos_dtx_act_ent_df {
 	/** The allocated local id for the DTX entry */
 	uint32_t			dae_lid;
 	/** DTX flags, see enum dtx_entry_flags. */
-	uint32_t			dae_flags;
+	uint16_t			dae_flags;
+	/** DTX flags, see enum dtx_mbs_flags. */
+	uint16_t			dae_mbs_flags;
 	/** The inlined dtx records. */
 	umem_off_t			dae_rec_inline[DTX_INLINE_REC_CNT];
 	/** The DTX records count, including inline case. */


### PR DESCRIPTION
If all the targets to be modified via the distributed transaction
are in the same single redundancy group, then we elect the leader
as standalone modification does. With such unification, we do not
need sync commit the DTX for single RDG based case.

Signed-off-by: Fan Yong <fan.yong@intel.com>