### PR TITLE
DAOS-5554 dtx: DTX entry on server for read only operation

### DIFF
--- a/src/dtx/dtx_common.c
+++ b/src/dtx/dtx_common.c
@@ -586,14 +586,22 @@ dtx_leader_end(struct dtx_leader_handle *dlh, struct ds_cont_child *cont,
 
 	if (dlh->dlh_sub_cnt != 0)
 		rc = dtx_leader_wait(dlh);
-	else if (dth->dth_modification_cnt <= 1)
-		goto out;
 
 	if (daos_is_zero_dti(&dth->dth_xid))
 		D_GOTO(out, result = result < 0 ? result : rc);
 
-	if (result < 0 || rc < 0 || (!dth->dth_active && !dth->dth_resent))
+	if (result < 0 || rc < 0 || dth->dth_solo)
 		D_GOTO(abort, result = result < 0 ? result : rc);
+
+	if (!dth->dth_active && !dth->dth_resent) {
+		/* We do not know whether some other participants have
+		 * some active entry for this DTX, consider distributed
+		 * transaction case, the other participants may execute
+		 * different operations. Sync commit the DTX for safe.
+		 */
+		dth->dth_sync = 1;
+		goto sync;
+	}
 
 again:
 	/* If the DTX is started befoe DTX resync (for rebuild), then it is
@@ -628,22 +636,16 @@ again:
 		}
 	}
 
-	rc = vos_dtx_check_sync(dth->dth_coh, dth->dth_leader_oid, &epoch);
+	rc = 0;
+
+	if (dth->dth_modification_cnt != 0)
+		rc = vos_dtx_check_sync(dth->dth_coh, dth->dth_leader_oid,
+					&epoch);
+
 	/* Only add async DTX into the CoS cache. */
 	if (rc == 0) {
 		struct dtx_memberships	*mbs;
 		size_t			 size;
-
-		/* When we come here, the modification on all participants have
-		 * been done successfully. If 'dth->dth_active' is false, means
-		 * that it is for resent case. Under such case, we have no way
-		 * to mark it as committable, then commit it sychronously.
-		 */
-		if (!dth->dth_active) {
-			D_ASSERT(dth->dth_resent);
-
-			dth->dth_sync = 1;
-		}
 
 		/* For synchronous DTX, do not add it into CoS cache, otherwise,
 		 * we may have no way to remove it from the cache.
@@ -727,7 +729,7 @@ abort:
 	 * to locally retry for avoiding RPC timeout. The leader replica
 	 * will trigger retry globally without aborting 'prepared' ones.
 	 */
-	if (result < 0 && result != -DER_AGAIN) {
+	if (result < 0 && result != -DER_AGAIN && !dth->dth_solo) {
 		dte = &dth->dth_dte;
 		dtx_abort(cont->sc_pool->spc_uuid, cont->sc_uuid,
 			  dth->dth_epoch, &dte, 1);

--- a/src/include/daos_srv/vos.h
+++ b/src/include/daos_srv/vos.h
@@ -55,6 +55,15 @@ void
 vos_dtx_rsrvd_fini(struct dtx_handle *dth);
 
 /**
+ * Generate DTX entry for the given DTX. It is usually used for read
+ * only TX or on the server that only contains read sub operations.
+ *
+ * \param dth	[IN]	The dtx handle
+ */
+int
+vos_dtx_pin(struct dtx_handle *dth);
+
+/**
  * Check the specified DTX's status, and related epoch, pool map version
  * information if required.
  *

--- a/src/object/srv_obj.c
+++ b/src/object/srv_obj.c
@@ -3501,6 +3501,12 @@ out:
 	D_FREE(biods);
 	D_FREE(bulks);
 
+	if (rc == 0 && dth->dth_modification_cnt == 0)
+		/* For the case of only containing read sub operations,
+		 * we will generate DTX entry for DTX recovery.
+		 */
+		rc = vos_dtx_pin(dth);
+
 	return rc;
 }
 

--- a/src/vos/vos_dtx.c
+++ b/src/vos/vos_dtx.c
@@ -2275,6 +2275,44 @@ vos_dtx_cleanup(struct dtx_handle *dth)
 		vos_obj_evict_by_oid(vos_obj_cache_current(), cont, oids[i]);
 }
 
+int
+vos_dtx_pin(struct dtx_handle *dth)
+{
+	struct vos_container	*cont;
+	struct umem_instance	*umm;
+	int			 rc;
+
+	D_ASSERT(dtx_is_valid_handle(dth));
+	D_ASSERT(dth->dth_ent == NULL);
+
+	if (dth->dth_solo)
+		return 0;
+
+	cont = vos_hdl2cont(dth->dth_coh);
+	D_ASSERT(cont != NULL);
+
+	umm = vos_cont2umm(cont);
+	rc = vos_dtx_alloc(umm, dth);
+	if (rc != 0)
+		goto out;
+
+	rc = umem_tx_begin(umm, NULL);
+	if (rc == 0) {
+		rc = vos_dtx_prepared(dth);
+		rc = umem_tx_end(umm, rc);
+	}
+
+	if (rc != 0)
+		vos_dtx_cleanup_internal(dth);
+
+out:
+	if (rc != 0)
+		D_ERROR("Failed to pin DTX entry for "DF_DTI": "DF_RC"\n",
+			DP_DTI(&dth->dth_xid), DP_RC(rc));
+
+	return rc;
+}
+
 /** Allocate space for saving the vos reservations and deferred actions */
 int
 vos_dtx_rsrvd_init(struct dtx_handle *dth)


### PR DESCRIPTION
For the server that only contains read sub operation(s) of some
distributed transaction, we still need to generate DTX entry on
such server for possible DTX recovery. Such DTX entry will only
contain the DTX entry header, not record to trace detailed read
targets (obj/key/sv/ev).

Signed-off-by: Fan Yong <fan.yong@intel.com>