### PR TITLE
Revert "DAOS-5618 test: Fixed regex for methods used in container/query_attribute.py"

### DIFF
--- a/src/tests/ftest/container/query_attribute.py
+++ b/src/tests/ftest/container/query_attribute.py
@@ -129,13 +129,13 @@ class ContainerQueryAttributeTest(TestWithServers):
         errors = []
         expected_attrs = []
         for attr_value in attr_values:
-            self.daos_cmd.container_set_attr(
+            _ = self.daos_cmd.container_set_attr(
                 pool=actual_pool_uuid, cont=actual_cont_uuid,
                 attr=attr_value[0], val=attr_value[1],
                 svc=self.pool.svc_ranks[0])
             kwargs["attr"] = attr_value[0]
-            output = self.daos_cmd.container_get_attr(**kwargs)
-            actual_val = output["value"]
+            actual_val = self.daos_cmd.get_output(
+                "container_get_attr", **kwargs)[0]
             if attr_value[1] in escape_to_not:
                 # Special character string.
                 if actual_val != escape_to_not[attr_value[1]]:
@@ -162,8 +162,8 @@ class ContainerQueryAttributeTest(TestWithServers):
             "svc": self.pool.svc_ranks[0],
             "cont": actual_cont_uuid
         }
-        data = self.daos_cmd.container_list_attrs(**kwargs)
-        actual_attrs = data["attrs"]
+        actual_attrs = self.daos_cmd.get_output(
+            "container_list_attrs", **kwargs)
         actual_attrs.sort()
         self.log.debug(str(actual_attrs))
         self.assertEqual(actual_attrs, expected_attrs)
@@ -195,8 +195,8 @@ class ContainerQueryAttributeTest(TestWithServers):
             "svc": self.pool.svc_ranks[0],
             "cont": self.expected_cont_uuid
         }
-        data = self.daos_cmd.container_list_attrs(**kwargs)
-        actual_attrs = data["attrs"]
+        actual_attrs = self.daos_cmd.get_output(
+            "container_list_attrs", **kwargs)
         actual_attrs.sort()
         self.assertEqual(
             expected_attrs, actual_attrs, "Unexpected output from list_attrs")

--- a/src/tests/ftest/container/query_attribute.yaml
+++ b/src/tests/ftest/container/query_attribute.yaml
@@ -1,7 +1,7 @@
 hosts:
   test_servers:
     - server-A
-timeout: 180
+timeout: 155
 server_config:
   name: daos_server
   servers:

--- a/src/tests/ftest/util/cont_security_test_base.py
+++ b/src/tests/ftest/util/cont_security_test_base.py
@@ -246,13 +246,12 @@ class ContSecurityTestBase(TestWithServers):
             attr (str): container attribute.
 
         Return:
-            CmdResult: Object that contains exit status, stdout, and other
-                information.
+            result (str): daos_tool.container_get_attr result.
         """
         self.daos_tool.exit_status_exception = False
-        self.daos_tool.container_get_attr(
+        result = self.daos_tool.container_get_attr(
             pool_uuid, container_uuid, attr, pool_svc)
-        return self.daos_tool.result
+        return result
 
     def list_container_attribute(
             self, pool_uuid, pool_svc, container_uuid):

--- a/src/tests/ftest/util/daos_utils.py
+++ b/src/tests/ftest/util/daos_utils.py
@@ -71,6 +71,15 @@ class DaosCommand(DaosCommandBase):
             r"Number of snapshots:\s+(\d+)\n" +
             r"Latest Persistent Snapshot:\s+(\d+)\n" +
             r"Highest Aggregated Epoch:\s+(\d+)",
+        # Sample get-attr output - no line break.
+        # 04/20-17:47:07.86 wolf-3 Container's attr1 attribute value:  04
+        # /20-17:47:07.86 wolf-3 val1
+        "container_get_attr": r"value:  \S+ \S+ (.+)$",
+        # Sample list output.
+        #  04/20-17:52:33.63 wolf-3 Container attributes:
+        #  04/20-17:52:33.63 wolf-3 attr1
+        #  04/20-17:52:33.63 wolf-3 attr2
+        "container_list_attrs": r"\n \S+ \S+ (.+)"
     }
 
     def pool_query(self, pool, sys_name=None, svc=None, sys=None):
@@ -448,27 +457,16 @@ class DaosCommand(DaosCommandBase):
                 Defaults to None.
 
         Returns:
-            dict: Dictionary that stores the attribute and value in "attr" and
-                "value" key.
+            CmdResult: Object that contains exit status, stdout, and other
+                information.
 
         Raises:
             CommandFailure: if the daos get-attr command fails.
 
         """
-        self._get_result(
+        return self._get_result(
             ("container", "get-attr"), pool=pool, svc=svc, cont=cont,
             sys_name=sys_name, attr=attr)
-
-        # Sample output.
-        # Container's `&()\;'"!<> attribute value: attr12
-        match = re.findall(
-            r"Container's\s+([\S ]+)\s+attribute\s+value:\s+(.+)$",
-            self.result.stdout)[0]
-        data = {}
-        data["attr"] = match[0]
-        data["value"] = match[1]
-
-        return data
 
     def container_list_attrs(self, pool, cont, svc=None, sys_name=None):
         """Call daos container list-attrs.
@@ -482,24 +480,16 @@ class DaosCommand(DaosCommandBase):
                 Defaults to None.
 
         Returns:
-            dict: Dictionary that stores the attribute values in the key "attrs"
+            CmdResult: Object that contains exit status, stdout, and other
+                information.
 
         Raises:
             CommandFailure: if the daos container list-attrs command fails.
 
         """
-        self._get_result(
+        return self._get_result(
             ("container", "list-attrs"), pool=pool, svc=svc, cont=cont,
             sys_name=sys_name)
-
-        # Sample output.
-        # Container attributes:
-        # attr0
-        # ~@#$%^*-=_+[]{}:/?,.
-        # aa bb
-        # attr48
-        match = re.findall(r"\n([\S ]+)", self.result.stdout)
-        return {"attrs": match}
 
     def container_create_snap(self, pool, cont, snap_name=None, epoch=None,
                               svc=None, sys_name=None):
@@ -533,7 +523,6 @@ class DaosCommand(DaosCommandBase):
             r"[A-Za-z\/]+\s([0-9]+)\s[a-z\s]+", self.result.stdout)
         if match:
             data["epoch"] = match[0]
-
         return data
 
     def container_destroy_snap(self, pool, cont, snap_name=None, epc=None,


### PR DESCRIPTION
Skip-functional-hardware: true

Reverts daos-stack/daos#3486