### PR TITLE
DAOS-5549 tests: Unskip IV and RPC two node tests

### DIFF
--- a/src/tests/ftest/cart/iv/cart_iv_two_node.py
+++ b/src/tests/ftest/cart/iv/cart_iv_two_node.py
@@ -34,8 +34,6 @@ import codecs
 import subprocess
 import shlex
 
-from apricot import skipForTicket
-
 from avocado  import Test
 from avocado  import main
 
@@ -221,8 +219,6 @@ class CartIvTwoNodeTest(Test):
                     raise ValueError('Error code {!s} running command "{!s}"' \
                             .format(cli_rtn, command))
 
-    # Use of DAOS_TEST_SHARED_DIR should fix this test failure
-    @skipForTicket("DAOS-5549")
     def test_cart_iv(self):
         """
         Test CaRT IV

--- a/src/tests/ftest/cart/rpc/cart_rpc_two_node.py
+++ b/src/tests/ftest/cart/rpc/cart_rpc_two_node.py
@@ -26,8 +26,6 @@ from __future__ import print_function
 
 import sys
 
-from apricot import skipForTicket
-
 from avocado  import Test
 from avocado  import main
 
@@ -53,7 +51,6 @@ class CartRpcTwoNodeTest(Test):
         """ Test tear down """
         print("Run TearDown\n")
 
-    @skipForTicket("DAOS-5549")
     def test_cart_rpc(self):
         """
         Test CaRT RPC

--- a/src/tests/ftest/cart/util/cart_utils.py
+++ b/src/tests/ftest/cart/util/cart_utils.py
@@ -143,6 +143,12 @@ class CartUtils():
             env_CCSA = ""
             log_dir = "{}".format(test_name)
 
+        # Write hostfile to HOME or DAOS_TEST_SHARED_DIR (can't be '.' or
+        # cwd(), it must be some place writable)
+        daos_test_shared_dir = os.environ['HOME']
+        if 'DAOS_TEST_SHARED_DIR' in os.environ:
+            daos_test_shared_dir = os.environ['DAOS_TEST_SHARED_DIR']
+
         log_path = os.environ['DAOS_TEST_LOG_DIR']
         log_file = os.path.join(log_path, log_dir,
                                 test_name + "_" + env_CCSA + "_cart.log")
@@ -178,7 +184,7 @@ class CartUtils():
         if ofi_share_addr is not None:
             env += " -x CRT_CTX_SHARE_ADDR={!s}".format(ofi_share_addr)
 
-        env += " -x CRT_ATTACH_INFO_PATH={!s}".format(log_path)
+        env += " -x CRT_ATTACH_INFO_PATH={!s}".format(daos_test_shared_dir)
 
         cartobj.log_path = log_path
 

--- a/src/tests/ftest/cart/util/cart_utils.py
+++ b/src/tests/ftest/cart/util/cart_utils.py
@@ -143,8 +143,8 @@ class CartUtils():
             env_CCSA = ""
             log_dir = "{}".format(test_name)
 
-        # Write hostfile to HOME or DAOS_TEST_SHARED_DIR (can't be '.' or
-        # cwd(), it must be some place writable)
+        # Write group attach info file(s) to HOME or DAOS_TEST_SHARED_DIR.
+        # (It can't be '.' or cwd(), it must be some place writable.)
         daos_test_shared_dir = os.environ['HOME']
         if 'DAOS_TEST_SHARED_DIR' in os.environ:
             daos_test_shared_dir = os.environ['DAOS_TEST_SHARED_DIR']


### PR DESCRIPTION
Skip-build-leap15-rpm: true
Skip-build-ubuntu-clang: true
Skip-build-leap15-icc: true
Skip-coverity-test: true
Skip-checkpatch: true
Quick-build: true
Skip-func-test-leap15: true
Skip-func-hw-test-small: true
Skip-func-hw-test-medium: true
Skip-func-hw-test-large: true

Signed-off-by: Ethan Mallove <ethanx.a.mallove@intel.com>