### PR TITLE
DAOS-5611 test:  Re-enable pool rebuild test

### DIFF
--- a/src/tests/ftest/pool/rebuild_tests.py
+++ b/src/tests/ftest/pool/rebuild_tests.py
@@ -21,7 +21,7 @@
   Any reproduction of computer software, computer software documentation, or
   portions thereof marked with this legend must also reproduce the markings.
 """
-from apricot import TestWithServers, skipForTicket
+from apricot import TestWithServers
 from test_utils_pool import TestPool
 from test_utils_container import TestContainer
 
@@ -130,7 +130,6 @@ class RebuildTests(TestWithServers):
                 "Data verification error after rebuild")
         self.log.info("Test Passed")
 
-    @skipForTicket("DAOS-5611")
     def test_simple_rebuild(self):
         """JIRA ID: DAOS-XXXX Rebuild-001.
 
@@ -144,7 +143,6 @@ class RebuildTests(TestWithServers):
         """
         self.run_rebuild_test(1)
 
-    @skipForTicket("DAOS-5611")
     def test_multipool_rebuild(self):
         """JIRA ID: DAOS-XXXX (Rebuild-002).
 

--- a/src/tests/ftest/pool/rebuild_tests.yaml
+++ b/src/tests/ftest/pool/rebuild_tests.yaml
@@ -24,28 +24,28 @@ container:
   data:
     small_data:
       data_size: 32
-    large_data:
-      data_size: 250
+#    large_data:
+#      data_size: 250
   objects:
     zero_objects:
       object_qty: 0
-    one_object:
-      object_qty: 1
-    twenty_objects:
-      object_qty: 20
+#    one_object:
+#      object_qty: 1
+#    twenty_objects:
+#      object_qty: 20
   records:
     one_record:
       record_qty: 1
-    ten_records:
-      record_qty: 10
+#    ten_records:
+#      record_qty: 10
 testparams:
   ranks: 
     rank1:
       rank: 1
-    rank4:
-      rank: 4
-    rank3:
-      rank: 3
+#    rank4:
+#      rank: 4
+#    rank3:
+#      rank: 3
   quantity: 2
   object_class: DAOS_OC_R3_RW
 

--- a/src/tests/ftest/pool/rebuild_tests.yaml
+++ b/src/tests/ftest/pool/rebuild_tests.yaml
@@ -11,8 +11,6 @@ hosts:
 timeout: 1200
 server_config:
   name: daos_server
-  servers:
-    targets: 8
 pool:
   mode: 511
   name: daos_server

--- a/src/tests/ftest/pool/rebuild_tests.yaml
+++ b/src/tests/ftest/pool/rebuild_tests.yaml
@@ -21,25 +21,25 @@ pool:
 container:
   akey_size: 5
   dkey_size: 5
-  data: !mux
+  data:
     small_data:
       data_size: 32
     large_data:
       data_size: 250
-  objects: !mux
+  objects:
     zero_objects:
       object_qty: 0
     one_object:
       object_qty: 1
     twenty_objects:
       object_qty: 20
-  records: !mux
+  records:
     one_record:
       record_qty: 1
     ten_records:
       record_qty: 10
 testparams:
-  ranks: !mux
+  ranks: 
     rank1:
       rank: 1
     rank4:

--- a/src/tests/ftest/pool/rebuild_tests.yaml
+++ b/src/tests/ftest/pool/rebuild_tests.yaml
@@ -11,6 +11,8 @@ hosts:
 timeout: 1200
 server_config:
   name: daos_server
+  servers:
+    targets: 1
 pool:
   mode: 511
   name: daos_server


### PR DESCRIPTION
Re-enable pool rebuild test
Removed server target in yaml file

Skipping the following test stages because
pool rebuild test falls in medium stage

Skip-run_test: true
Skip-func-test: true
Skip-func-hw-test-small: true
Skip-func-hw-test-large: true