### PR TITLE
DAOS-5765 control: Enable Go race detector for non-release builds

### DIFF
--- a/src/control/SConscript
+++ b/src/control/SConscript
@@ -44,6 +44,17 @@ def get_build_tags(benv):
         return ""
     return "-tags firmware"
 
+def is_release_build(benv):
+    "Check whether this build is for release."
+    return benv.get("BUILD_TYPE") == "release"
+
+def get_build_flags(benv):
+    flags = ""
+    if not is_release_build(benv):
+        # enable race detector for non-release builds
+        flags += "-race"
+    return flags
+
 #pylint: disable=too-many-arguments
 def install_go_bin(denv, gosrc, libs, name, install_name):
     """
@@ -81,8 +92,8 @@ def install_go_bin(denv, gosrc, libs, name, install_name):
     # Must be run from the top of the source dir in order to
     # pick up the vendored modules.
     denv.Command(build_bin, src + gurt_lib,
-                 'cd %s; %s build -mod vendor -v %s %s -o %s %s' %
-                 (gosrc, GO_BIN, go_ldflags(), get_build_tags(denv),
+                 'cd %s; %s build -mod vendor -v %s %s -o %s %s %s' %
+                 (gosrc, GO_BIN, go_ldflags(), get_build_flags(denv), get_build_tags(denv),
                   build_bin, install_src))
     # Use the intermediate build location in order to play nicely
     # with --install-sandbox.

--- a/utils/docker/Dockerfile.leap.15
+++ b/utils/docker/Dockerfile.leap.15
@@ -74,7 +74,7 @@ RUN zypper --non-interactive install --allow-unsigned-rpm lua-lmod
 RUN zypper --non-interactive addrepo \
     https://download.opensuse.org/repositories/devel:languages:go/openSUSE_Leap_15.1/devel:languages:go.repo; \
     zypper --non-interactive --gpg-auto-import-keys refresh; \
-    zypper --non-interactive install -y ipmctl-devel go
+    zypper --non-interactive install -y ipmctl-devel go go-race
 
 # Add DAOS user
 ENV USER daos

--- a/utils/rpms/daos.spec
+++ b/utils/rpms/daos.spec
@@ -11,7 +11,7 @@
 
 Name:          daos
 Version:       1.1.0
-Release:       33%{?relval}%{?dist}
+Release:       34%{?relval}%{?dist}
 Summary:       DAOS Storage Engine
 
 License:       Apache
@@ -37,6 +37,10 @@ BuildRequires: libjson-c-devel
 BuildRequires: libpmem-devel >= 1.8, libpmemobj-devel >= 1.8
 BuildRequires: fuse3-devel >= 3.4.2
 %if (0%{?suse_version} >= 1500)
+# NB: OpenSUSE is stupid about this... If we just
+# specify go >= 1.X, it installs go=1.11 AND 1.X.
+BuildRequires: go1.14
+BuildRequires: go1.14-race
 BuildRequires: libprotobuf-c-devel
 BuildRequires: liblz4-devel
 %else
@@ -78,7 +82,6 @@ BuildRequires: libcurl4
 BuildRequires: distribution-release
 BuildRequires: libnuma-devel
 BuildRequires: cunit-devel
-BuildRequires: go >= 1.12
 BuildRequires: ipmctl-devel
 BuildRequires: python-devel python3-devel
 BuildRequires: lua-lmod
@@ -388,6 +391,9 @@ getent passwd daos_server >/dev/null || useradd -M daos_server
 %{_libdir}/*.a
 
 %changelog
+* Sat Oct 03 2020 Michael MacDonald <mjmac.macdonald@intel.com> 1.1.0-34
+- Add go-race to BuildRequires on OpenSUSE Leap
+
 * Wed Sep 16 2020 Alexander Oganezov <alexander.a.oganezov@intel.com> 1.1.0-33
 - Update OFI to v1.11.0
 


### PR DESCRIPTION
The Go race detector is enabled for Go unit tests, but we should
also enable it for produced binaries in order to get full testing
with the detector enabled. This will help us find any concurrency
issues more quickly.