### PR TITLE
DAOS-5766 object: update EC object single value size

### DIFF
--- a/src/object/cli_ec.c
+++ b/src/object/cli_ec.c
@@ -1678,6 +1678,22 @@ out:
 	return rc;
 }
 
+void
+obj_ec_update_iod_size(struct obj_reasb_req *reasb_req, uint32_t iod_nr)
+{
+	daos_iod_t	*u_iods = reasb_req->orr_uiods;
+	daos_iod_t	*re_iods = reasb_req->orr_iods;
+	int i;
+
+	if (re_iods == NULL || u_iods == re_iods)
+		return;
+
+	for (i = 0; i < iod_nr; i++) {
+		D_ASSERT(re_iods[i].iod_type == u_iods[i].iod_type);
+		u_iods[i].iod_size = re_iods[i].iod_size;
+	}
+}
+
 static daos_size_t
 obj_ec_recx_size(daos_iod_t *iod, struct obj_shard_iod *siod,
 		 daos_size_t iod_size)

--- a/src/object/cli_obj.c
+++ b/src/object/cli_obj.c
@@ -3446,12 +3446,14 @@ obj_comp_cb(tse_task_t *task, void *data)
 			}
 		} else {
 			if (obj_auxi->is_ec_obj && task->dt_result == 0 &&
-			    obj_auxi->opc == DAOS_OBJ_RPC_FETCH &&
-			    obj_auxi->bulks != NULL) {
+			    obj_auxi->opc == DAOS_OBJ_RPC_FETCH) {
 				daos_obj_fetch_t *args = dc_task_get_args(task);
 
-				obj_ec_fetch_set_sgl(&obj_auxi->reasb_req,
-						     args->nr);
+				if (obj_auxi->bulks != NULL)
+					obj_ec_fetch_set_sgl(
+						&obj_auxi->reasb_req, args->nr);
+				obj_ec_update_iod_size(&obj_auxi->reasb_req,
+						       args->nr);
 			}
 
 			obj_bulk_fini(obj_auxi);

--- a/src/object/obj_ec.h
+++ b/src/object/obj_ec.h
@@ -638,6 +638,7 @@ struct obj_tgt_oiod *obj_ec_tgt_oiod_init(struct obj_io_desc *r_oiods,
 struct obj_tgt_oiod *obj_ec_tgt_oiod_get(struct obj_tgt_oiod *tgt_oiods,
 			uint32_t tgt_nr, uint32_t tgt_idx);
 void obj_ec_fetch_set_sgl(struct obj_reasb_req *reasb_req, uint32_t iod_nr);
+void obj_ec_update_iod_size(struct obj_reasb_req *reasb_req, uint32_t iod_nr);
 int obj_ec_recov_add(struct obj_reasb_req *reasb_req,
 		     struct daos_recx_ep_list *recx_lists, unsigned int nr);
 struct obj_ec_fail_info *obj_ec_fail_info_get(struct obj_reasb_req *reasb_req,


### PR DESCRIPTION
IODs pointer in task argument has been changed
for EC object in some cases, so let's update the
iod_size in the original iod.

Signed-off-by: Di Wang <di.wang@intel.com>