### PR TITLE
DAOS-2666 test: add env variable for MPIIO tests to bypass duns

### DIFF
--- a/src/tests/ftest/util/ior_utils.py
+++ b/src/tests/ftest/util/ior_utils.py
@@ -259,6 +259,7 @@ class IorCommand(ExecutableCommand):
                 env["DAOS_POOL"] = self.dfs_pool.value
                 env["DAOS_SVCL"] = self.dfs_svcl.value
                 env["DAOS_CONT"] = self.dfs_cont.value
+                env["DAOS_BYPASS_DUNS"] = "1"
                 env["IOR_HINT__MPI__romio_daos_obj_class"] = \
                     self.dfs_oclass.value
         return env

--- a/src/tests/ftest/util/mpio_utils.py
+++ b/src/tests/ftest/util/mpio_utils.py
@@ -99,6 +99,7 @@ class MpioUtils():
         env["DAOS_POOL"] = "{}".format(pool_uuid)
         env["DAOS_SVCL"] = "{}".format(":".join([str(item) for item in svcl]))
         env["DAOS_CONT"] = "{}".format(cont_uuid)
+        env["DAOS_BYPASS_DUNS"] = "1"
         mpirun = os.path.join(self.mpichinstall, "bin", "mpirun")
 
         executables = {


### PR DESCRIPTION
The default mode for MPIIO will be using DUNS to query pool and container uuids.
For now we will switch CI to set the env variable to use the uuid from DAOS_POOL and DAOS_CONT set in env variables.

Signed-off-by: Mohamad Chaarawi <mohamad.chaarawi@intel.com>