### PR TITLE
DAOS-5770 swim: make SWIM more rubust for network issues

### DIFF
--- a/src/cart/crt_swim.c
+++ b/src/cart/crt_swim.c
@@ -44,13 +44,7 @@ static inline int
 crt_proc_struct_swim_member_update(crt_proc_t proc,
 				   struct swim_member_update *data)
 {
-	int rc;
-
-	rc = crt_proc_memcpy(proc, data, sizeof(*data));
-	if (rc != 0)
-		return -DER_HG;
-
-	return 0;
+	return crt_proc_memcpy(proc, data, sizeof(*data));
 }
 
 /* One way RPC */
@@ -105,18 +99,25 @@ static void crt_swim_srv_cb(crt_rpc_t *rpc_req)
 	struct swim_context	*ctx = csm->csm_ctx;
 	struct crt_rpc_swim_in	*rpc_swim_input = crt_req_get(rpc_req);
 	struct crt_rpc_swim_wack_out *rpc_swim_output = crt_reply_get(rpc_req);
+	struct crt_swim_target	*cst;
 	swim_id_t		 self_id = swim_self_get(ctx);
+	swim_id_t		 from_id = rpc_swim_input->src;
 	uint64_t		 max_delay = swim_ping_timeout_get() / 2;
-	uint64_t		 delay;
 	uint64_t		 hlc = crt_hlc_get();
-	int			 rc = -ENOTCONN;
+	uint32_t		 rcv_delay = 0;
+	uint32_t		 snd_delay = 0;
+	int			 rc;
+	int			 i;
 
 	D_ASSERT(crt_is_service());
 
 	D_TRACE_DEBUG(DB_TRACE, rpc_req,
 		"incoming opc %#x with %zu updates %lu <= %lu\n",
 		rpc_req->cr_opc, rpc_swim_input->upds.ca_count,
-		self_id, rpc_swim_input->src);
+		self_id, from_id);
+
+	if (self_id == SWIM_ID_INVALID)
+		D_GOTO(out, rc = -DER_UNINIT);
 
 	rpc_priv = container_of(rpc_req, struct crt_rpc_priv, crp_pub);
 	/*
@@ -124,66 +125,73 @@ static void crt_swim_srv_cb(crt_rpc_t *rpc_req)
 	 * this request.
 	 */
 	if (hlc > rpc_priv->crp_req_hdr.cch_hlc)
-		delay = (hlc - rpc_priv->crp_req_hdr.cch_hlc) / NSEC_PER_MSEC;
-	else
-		delay = 0;
-	csm->csm_msg_count++;
+		rcv_delay = (hlc - rpc_priv->crp_req_hdr.cch_hlc)
+			  / NSEC_PER_MSEC;
 
-	if (csm->csm_hlc) {
-		csm->csm_avg_delay = (csm->csm_avg_delay + delay) / 2;
+	/* Update all piggybacked members with remote delays */
+	for (i = 0; i < rpc_swim_input->upds.ca_count; i++) {
+		struct swim_member_state *state;
+		swim_id_t id;
 
-		D_TRACE_DEBUG(DB_TRACE, rpc_req,
-			      "%lu. delay: %lu ms, avg: %lu ms, max: %lu ms\n",
-			      csm->csm_msg_count, delay, csm->csm_avg_delay,
-			      max_delay);
+		state = &rpc_swim_input->upds.ca_arrays[i].smu_state;
+		id = rpc_swim_input->upds.ca_arrays[i].smu_id;
 
-		if (delay > max_delay) {
-			swim_net_glitch_update(ctx, delay);
-			if (csm->csm_avg_delay > max_delay) {
-				delay = swim_ping_timeout_get() + max_delay;
-				swim_ping_timeout_set(delay);
-				D_ERROR("%lu: increase ping timeout to "
-					"%lu ms\n", ctx->sc_self, delay);
-
-				/* according protocol period requirement */
-				delay *= 3;
-				if (delay > swim_period_get()) {
-					swim_period_set(delay);
-					/* according protocol requirement */
-					delay *= 3;
-					swim_suspect_timeout_set(delay);
-				}
+		D_SPIN_LOCK(&csm->csm_lock);
+		D_CIRCLEQ_FOREACH(cst, &csm->csm_head, cst_link) {
+			if (cst->cst_id == id) {
+				snd_delay = cst->cst_state.sms_delay;
+				snd_delay = snd_delay
+					  ? (snd_delay + state->sms_delay) / 2
+					  : state->sms_delay;
+				cst->cst_state.sms_delay = snd_delay;
+				break;
 			}
 		}
-	} else {
-		csm->csm_avg_delay = delay;
+		D_SPIN_UNLOCK(&csm->csm_lock);
 	}
-	csm->csm_hlc = hlc;
 
-	if (self_id != SWIM_ID_INVALID) {
-		rc = swim_parse_message(ctx, rpc_swim_input->src,
-					rpc_swim_input->upds.ca_arrays,
-					rpc_swim_input->upds.ca_count);
-		if (rc == -ESHUTDOWN) {
-			if (grp_priv->gp_size > 1)
-				D_ERROR("SWIM shutdown\n");
-			swim_self_set(ctx, SWIM_ID_INVALID);
-		} else if (rc) {
-			D_ERROR("swim_parse_message() failed rc=%d\n", rc);
+	/* Update from_id member with remote delay */
+	D_SPIN_LOCK(&csm->csm_lock);
+	D_CIRCLEQ_FOREACH(cst, &csm->csm_head, cst_link) {
+		if (cst->cst_id == from_id) {
+			snd_delay = cst->cst_state.sms_delay;
+			snd_delay = snd_delay ? (snd_delay + rcv_delay) / 2
+					      : rcv_delay;
+			cst->cst_state.sms_delay = snd_delay;
+			break;
 		}
 	}
+	D_SPIN_UNLOCK(&csm->csm_lock);
 
+	if (rcv_delay > max_delay)
+		swim_net_glitch_update(ctx, self_id, rcv_delay - max_delay);
+	else if (snd_delay > max_delay)
+		swim_net_glitch_update(ctx, from_id, snd_delay - max_delay);
+
+	rc = swim_parse_message(ctx, from_id,
+				rpc_swim_input->upds.ca_arrays,
+				rpc_swim_input->upds.ca_count);
+	if (rc == -ESHUTDOWN) {
+		if (grp_priv->gp_size > 1)
+			D_ERROR("SWIM shutdown\n");
+		swim_self_set(ctx, SWIM_ID_INVALID);
+	} else if (rc) {
+		D_ERROR("swim_parse_message() failed: %s (%d)\n",
+			strerror(rc), rc);
+	}
+
+out:
 	if (rpc_req->cr_opc & 0xFFFF) { /* RPC with acknowledge? */
 		D_TRACE_DEBUG(DB_TRACE, rpc_req,
 			"reply to opc %#x with %zu updates %lu <= %lu rc=%d\n",
 			rpc_req->cr_opc, rpc_swim_input->upds.ca_count,
-			self_id, rpc_swim_input->src, rc);
+			self_id, from_id, rc);
 
 		rpc_swim_output->rc = rc;
 		rc = crt_reply_send(rpc_req);
 		if (rc)
-			D_ERROR("send reply %d failed: rc=%d\n",
-				rpc_swim_output->rc, rc);
+			D_ERROR("send reply %d failed "DF_RC"\n",
+				rpc_swim_output->rc, DP_RC(rc));
 	}
 }
 
@@ -202,9 +210,9 @@ static void crt_swim_cli_cb(const struct crt_cb_info *cb_info)
 	int			 rc;
 
 	D_TRACE_DEBUG(DB_TRACE, rpc_req,
-		"complete opc %#x with %zu updates %lu => %lu rc=%d\n",
-		rpc_req->cr_opc, rpc_swim_input->upds.ca_count,
-		rpc_swim_input->src, id, cb_info->cci_rc);
+		      "complete opc %#x with %zu updates %lu => %lu "DF_RC"\n",
+		      rpc_req->cr_opc, rpc_swim_input->upds.ca_count,
+		      rpc_swim_input->src, id, DP_RC(cb_info->cci_rc));
 
 	/* check for RPC with acknowledge a return code of request */
 	if (cb_info->cci_rc && (rpc_req->cr_opc & 0xFFFF)) {
@@ -256,7 +264,7 @@ static int crt_swim_send_message(struct swim_context *ctx, swim_id_t to,
 	opc = CRT_PROTO_OPC(CRT_OPC_SWIM_PROTO, CRT_OPC_SWIM_VERSION, opc_idx);
 	rc = crt_req_create(crt_ctx, &ep, opc, &rpc_req);
 	if (rc) {
-		D_ERROR("crt_req_create() failed rc=%d\n", rc);
+		D_ERROR("crt_req_create() failed "DF_RC"\n", DP_RC(rc));
 		D_GOTO(out, rc);
 	}
 
@@ -264,7 +272,8 @@ static int crt_swim_send_message(struct swim_context *ctx, swim_id_t to,
 		rc = crt_req_set_timeout(rpc_req, crt_swim_rpc_timeout);
 		if (rc) {
 			D_TRACE_ERROR(rpc_req,
-				"crt_req_set_timeout() failed rc=%d\n", rc);
+				      "crt_req_set_timeout() failed "DF_RC"\n",
+				      DP_RC(rc));
 			crt_req_decref(rpc_req);
 			D_GOTO(out, rc);
 		}
@@ -281,7 +290,8 @@ static int crt_swim_send_message(struct swim_context *ctx, swim_id_t to,
 
 	rc = crt_req_send(rpc_req, crt_swim_cli_cb, ctx);
 	if (rc) {
-		D_TRACE_ERROR(rpc_req, "crt_req_send() failed rc=%d\n", rc);
+		D_TRACE_ERROR(rpc_req, "crt_req_send() failed "DF_RC"\n",
+			      DP_RC(rc));
 		D_GOTO(out, rc);
 	}
 out:
@@ -420,6 +430,9 @@ static int crt_swim_set_member_state(struct swim_context *ctx,
 	struct crt_swim_target	*cst;
 	int			 rc = -DER_NONEXIST;
 
+	if (state->sms_status == SWIM_MEMBER_SUSPECT)
+		state->sms_delay += swim_ping_timeout_get();
+
 	D_SPIN_LOCK(&csm->csm_lock);
 	D_CIRCLEQ_FOREACH(cst, &csm->csm_head, cst_link) {
 		if (cst->cst_id == id) {
@@ -453,7 +466,8 @@ static void crt_swim_progress_cb(crt_context_t crt_ctx, void *arg)
 			D_ERROR("SWIM shutdown\n");
 		swim_self_set(ctx, SWIM_ID_INVALID);
 	} else if (rc && rc != -ETIMEDOUT) {
-		D_ERROR("swim_progress() failed rc=%d\n", rc);
+		D_ERROR("swim_progress() failed: %s (%d)\n",
+			strerror(rc), rc);
 	}
 }
 
@@ -494,7 +508,6 @@ int crt_swim_init(int crt_ctx_idx)
 	d_rank_list_t		*grp_membs;
 	d_rank_t		 self = grp_priv->gp_self;
 	int			 i, rc;
-
 
 	if (crt_gdata.cg_swim_inited) {
 		D_ERROR("Swim already initialized\n");
@@ -594,15 +607,15 @@ int crt_swim_enable(struct crt_grp_priv *grp_priv, int crt_ctx_idx)
 		if (rc == -DER_NONEXIST)
 			rc = 0;
 		if (rc)
-			D_ERROR("crt_unregister_progress_cb() failed: rc=%d\n",
-				rc);
+			D_ERROR("crt_unregister_progress_cb() failed "DF_RC"\n",
+				DP_RC(rc));
 	}
 	if (old_ctx_idx != crt_ctx_idx) {
 		rc = crt_register_progress_cb(crt_swim_progress_cb,
 					      crt_ctx_idx, NULL);
 		if (rc)
-			D_ERROR("crt_register_progress_cb() failed: rc=%d\n",
-				rc);
+			D_ERROR("crt_register_progress_cb() failed "DF_RC"\n",
+				DP_RC(rc));
 	}
 
 out:
@@ -638,8 +651,8 @@ int crt_swim_disable(struct crt_grp_priv *grp_priv, int crt_ctx_idx)
 		if (rc == -DER_NONEXIST)
 			rc = 0;
 		if (rc)
-			D_ERROR("crt_unregister_progress_cb() failed: rc=%d\n",
-				rc);
+			D_ERROR("crt_unregister_progress_cb() failed "DF_RC"\n",
+				DP_RC(rc));
 	}
 
 out:

--- a/src/cart/crt_swim.h
+++ b/src/cart/crt_swim.h
@@ -47,8 +47,6 @@ struct crt_swim_membs {
 	struct crt_swim_target		*csm_target;
 	struct swim_context		*csm_ctx;
 	uint64_t			 csm_hlc;
-	uint64_t			 csm_avg_delay;
-	uint64_t			 csm_msg_count;
 	int				 csm_crt_ctx_idx;
 };
 

--- a/src/cart/swim/swim.c
+++ b/src/cart/swim/swim.c
@@ -278,25 +278,8 @@ update:
 	/* if member is suspected, remove from suspect list */
 	TAILQ_FOREACH(item, &ctx->sc_suspects, si_link) {
 		if (item->si_id == id) {
-			uint64_t timeout = swim_ping_timeout_get();
-
 			/* remove this member from suspect list */
 			TAILQ_REMOVE(&ctx->sc_suspects, item, si_link);
-
-			timeout += timeout / 2;
-			swim_ping_timeout_set(timeout);
-			SWIM_ERROR("%lu: increase ping timeout to %lu ms\n",
-				   ctx->sc_self, timeout);
-
-			/* according protocol period requirement */
-			timeout *= 3;
-			if (timeout > swim_period_get()) {
-				swim_period_set(timeout);
-				/* according protocol requirement */
-				timeout *= 3;
-				swim_suspect_timeout_set(timeout);
-			}
-
 			D_FREE(item);
 			break;
 		}
@@ -648,8 +631,10 @@ swim_fini(struct swim_context *ctx)
 }
 
 int
-swim_net_glitch_update(struct swim_context *ctx, uint64_t net_glitch_delay)
+swim_net_glitch_update(struct swim_context *ctx, swim_id_t id,
+		       uint64_t delay)
 {
+	swim_id_t self_id = swim_self_get(ctx);
 	struct swim_item *item;
 	int rc = 0;
 
@@ -657,31 +642,32 @@ swim_net_glitch_update(struct swim_context *ctx, uint64_t net_glitch_delay)
 
 	/* update expire time of suspected members */
 	TAILQ_FOREACH(item, &ctx->sc_suspects, si_link) {
-		item->u.si_deadline += net_glitch_delay;
+		if (id == self_id || id == item->si_id)
+			item->u.si_deadline += delay;
 	}
 	/* update expire time of ipinged members */
 	TAILQ_FOREACH(item, &ctx->sc_ipings, si_link) {
-		item->u.si_deadline += net_glitch_delay;
+		if (id == self_id || id == item->si_id)
+			item->u.si_deadline += delay;
 	}
 
-	switch (swim_state_get(ctx)) {
-	case SCS_BEGIN:
-		ctx->sc_next_tick_time += net_glitch_delay;
-		break;
-	case SCS_DPINGED:
-		ctx->sc_dping_deadline += net_glitch_delay;
-		break;
-	case SCS_IPINGED:
-		ctx->sc_iping_deadline += net_glitch_delay;
-		break;
-	default:
-		break;
+	if (id == self_id || id == ctx->sc_target) {
+		switch (swim_state_get(ctx)) {
+		case SCS_DPINGED:
+			ctx->sc_dping_deadline += delay;
+			break;
+		case SCS_IPINGED:
+			ctx->sc_iping_deadline += delay;
+			break;
+		default:
+			break;
+		}
 	}
 
 	swim_ctx_unlock(ctx);
 
-	SWIM_ERROR("Network glitch delay for %lu ms is detected.\n",
-		   net_glitch_delay);
+	SWIM_ERROR("%lu: A network glitch of %lu with %lu msec delay"
+		   " is detected.\n", self_id, id, delay);
 	return rc;
 }
 
@@ -800,16 +786,15 @@ swim_progress(struct swim_context *ctx, int64_t timeout)
 			ctx->sc_iping_deadline += net_glitch_delay;
 			if (now > ctx->sc_iping_deadline) {
 				/* no response from indirect pings,
-				 * dead this member
+				 * will be dead by suspicion timeout
+				 * if there are no gossips about it.
 				 */
 				SWIM_ERROR("%lu: iping timeout {%lu %c %lu}\n",
 					   ctx->sc_self, ctx->sc_target,
 					   SWIM_STATUS_CHARS[
 						       target_state.sms_status],
 					   target_state.sms_incarnation);
-				swim_member_dead(ctx, ctx->sc_self,
-						 ctx->sc_target,
-						 target_state.sms_incarnation);
+				/* So, just goto next member. */
 				ctx_state = SCS_DEAD;
 			}
 			break;

--- a/src/cart/swim/swim_internal.h
+++ b/src/cart/swim/swim_internal.h
@@ -65,11 +65,9 @@ extern "C" {
 #endif
 
 /** SWIM protocol parameter defaults */
-#define SWIM_PROTOCOL_PERIOD_LEN 2400	/* milliseconds, should NOT be less
-					 * than 3 * SWIM_PING_TIMEOUT
-					 */
-#define SWIM_SUSPECT_TIMEOUT	3 * SWIM_PROTOCOL_PERIOD_LEN
-#define SWIM_PING_TIMEOUT	800	/* milliseconds */
+#define SWIM_PROTOCOL_PERIOD_LEN 1000	/* milliseconds */
+#define SWIM_SUSPECT_TIMEOUT	(8 * SWIM_PROTOCOL_PERIOD_LEN)
+#define SWIM_PING_TIMEOUT	900	/* milliseconds */
 #define SWIM_SUBGROUP_SIZE	2
 #define SWIM_PIGGYBACK_ENTRIES	8	/**< count of piggybacked entries */
 #define SWIM_PIGGYBACK_TX_COUNT	50	/**< count of transfers each entry

--- a/src/include/cart/swim.h
+++ b/src/include/cart/swim.h
@@ -55,7 +55,8 @@ enum swim_member_status {
 struct swim_member_state {
 	uint64_t		 sms_incarnation; /**< incarnation number */
 	enum swim_member_status	 sms_status;	  /**< status of member */
-	uint32_t		 sms_padding;
+	uint32_t		 sms_delay;	  /**< SWIM message transfer
+						       network duration */
 };
 
 struct swim_member_update {
@@ -204,11 +205,13 @@ int swim_progress(struct swim_context *ctx, int64_t timeout);
  * Update the state machine of SWIM protocol with unexpected network glitch.
  *
  * @param[in]  ctx   SWIM context pointer from swim_init()
+ * @param[in]  id    The SWIM member to whom shift timeouts
  * @param[in]  delay The amount of time in milliseconds by which
  *                   ALL timeouts will be shifted.
  * @returns          0 on success, negative error ID otherwise
  */
-int swim_net_glitch_update(struct swim_context *ctx, uint64_t delay);
+int swim_net_glitch_update(struct swim_context *ctx, swim_id_t id,
+			   uint64_t delay);
 /** @} */
 
 #ifdef __cplusplus

--- a/src/tests/ftest/cart/SConscript
+++ b/src/tests/ftest/cart/SConscript
@@ -54,7 +54,7 @@ TEST_GROUP_SRC = 'test_group.c'
 IV_TESTS = ['iv_client.c', 'iv_server.c']
 #TEST_RPC_ERR_SRC = 'test_rpc_error.c'
 #CRT_RPC_TESTS = ['rpc_test_cli.c', 'rpc_test_srv.c', 'rpc_test_srv2.c']
-SWIM_TESTS = ['test_swim.c', 'test_swim_net.c']
+SWIM_TESTS = ['test_swim.c', 'test_swim_net.c', 'test_swim_emu.c']
 HLC_TESTS = ['test_hlc_net.c']
 TEST_GROUP_NP_TESTS = ['test_group_np_srv.c', 'test_group_np_cli.c',
                        'no_pmix_group_version.c']

--- a/src/tests/ftest/cart/test_swim_emu.c
+++ b/src/tests/ftest/cart/test_swim_emu.c
@@ -1,0 +1,687 @@
+/*
+ * (C) Copyright 2020 Intel Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * GOVERNMENT LICENSE RIGHTS-OPEN SOURCE SOFTWARE
+ * The Government's rights to use, modify, reproduce, release, perform, display,
+ * or disclose this software are subject to the terms of the Apache License as
+ * provided in Contract No. 8F-30005.
+ * Any reproduction of computer software, computer software documentation, or
+ * portions thereof marked with this legend must also reproduce the markings.
+ */
+/**
+ * This is a simple example of SWIM implementation on top of CaRT APIs.
+ */
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include <stdint.h>
+#include <assert.h>
+#include <getopt.h>
+#include <sys/queue.h>
+
+#include <gurt/common.h>
+#include <cart/swim.h>
+
+#include "../../../cart/swim/swim_internal.h"
+
+#define USE_CART_FOR_DEBUG_LOG 1
+
+#define MEMBERS_MAX	10000
+#define GLITCHES_MIN	1
+#define GLITCHES_MAX	1000
+#define FAILURES_MIN	1
+#define FAILURES_MAX	1000
+
+static int verbose;
+static int glitches;
+static int failures;
+static int net_delay;
+static size_t members_count;
+static swim_id_t victim = SWIM_ID_INVALID;
+
+static size_t pkt_sent;
+static size_t pkt_total;
+static size_t pkt_glitch;
+
+struct network_pkt {
+	TAILQ_ENTRY(network_pkt)	 np_link;
+	swim_id_t			 np_from;
+	swim_id_t			 np_to;
+	struct swim_member_update	*np_upds;
+	size_t				 np_nupds;
+	uint64_t			 np_time;
+};
+
+struct swim_target {
+	CIRCLEQ_ENTRY(swim_target)	 st_link;
+	swim_id_t			 st_id;
+};
+
+static struct global {
+	pthread_spinlock_t		 lock;
+	pthread_t			 progress_tid;
+	pthread_t			 network_tid;
+	TAILQ_HEAD(, network_pkt)	 pkts;
+	struct swim_member_state	 swim_state[MEMBERS_MAX][MEMBERS_MAX];
+	CIRCLEQ_HEAD(, swim_target)	 target_list[MEMBERS_MAX];
+	struct swim_target		*target[MEMBERS_MAX];
+	struct swim_context		*swim_ctx[MEMBERS_MAX];
+	/* SWIM statistics: */
+	uint64_t			 detect_sec[MEMBERS_MAX];
+	uint64_t			 victim_sec;
+	uint64_t			 detect_min;
+	uint64_t			 detect_max;
+	/* SWIM control flags: */
+	unsigned int			 shutdown:1;
+} g;
+
+static int test_send_message(struct swim_context *ctx, swim_id_t to,
+			     struct swim_member_update *upds,
+			     size_t nupds)
+{
+	struct network_pkt *item;
+	int rc = -DER_NOMEM;
+
+	item = malloc(sizeof(*item));
+	if (item != NULL) {
+		item->np_from  = swim_self_get(ctx);
+		item->np_to    = to;
+		item->np_upds  = upds;
+		item->np_nupds = nupds;
+		item->np_time  = swim_now_ms();
+
+		D_SPIN_LOCK(&g.lock);
+		TAILQ_INSERT_TAIL(&g.pkts, item, np_link);
+		pkt_sent++;
+		D_SPIN_UNLOCK(&g.lock);
+
+		rc = 0;
+	}
+
+	return rc;
+}
+
+static swim_id_t test_get_dping_target(struct swim_context *ctx)
+{
+	swim_id_t self = swim_self_get(ctx);
+	static swim_id_t id;
+	int count = 0;
+
+	do {
+		if (count++ > members_count)
+			return SWIM_ID_INVALID;
+		g.target[self] = CIRCLEQ_LOOP_NEXT(&g.target_list[self],
+						   g.target[self], st_link);
+		id = g.target[self]->st_id;
+	} while (id == self ||
+		 g.swim_state[self][id].sms_status == SWIM_MEMBER_DEAD);
+	return id;
+}
+
+static swim_id_t test_get_iping_target(struct swim_context *ctx)
+{
+	swim_id_t self = swim_self_get(ctx);
+	static swim_id_t id;
+	int count = 0;
+
+	do {
+		if (count++ > members_count)
+			return SWIM_ID_INVALID;
+		g.target[self] = CIRCLEQ_LOOP_NEXT(&g.target_list[self],
+						   g.target[self], st_link);
+		id = g.target[self]->st_id;
+	} while (id == self ||
+		 g.swim_state[self][id].sms_status != SWIM_MEMBER_ALIVE);
+	return id;
+}
+
+static int test_get_member_state(struct swim_context *ctx,
+				 swim_id_t id, struct swim_member_state *state)
+{
+	swim_id_t self = swim_self_get(ctx);
+	int rc = 0;
+
+	if (self == SWIM_ID_INVALID)
+		return -EINVAL;
+
+	*state = g.swim_state[self][id];
+	return rc;
+}
+
+static int test_set_member_state(struct swim_context *ctx,
+				 swim_id_t id, struct swim_member_state *state)
+{
+	swim_id_t self_id = swim_self_get(ctx);
+	enum swim_member_status s;
+	struct timespec now;
+	uint64_t sec;
+	int i, cnt, rc = 0;
+
+	if (self_id == SWIM_ID_INVALID)
+		return -EINVAL;
+
+	switch (state->sms_status) {
+	case SWIM_MEMBER_INACTIVE:
+		break;
+	case SWIM_MEMBER_ALIVE:
+		break;
+	case SWIM_MEMBER_SUSPECT:
+		state->sms_delay += swim_ping_timeout_get();
+		break;
+	case SWIM_MEMBER_DEAD:
+		if (id == victim) {
+			rc = clock_gettime(CLOCK_MONOTONIC, &now);
+			if (!rc) {
+				g.detect_sec[self_id] = now.tv_sec;
+				sec = g.detect_sec[self_id] - g.victim_sec;
+				if (sec < g.detect_min)
+					g.detect_min = sec;
+				if (sec > g.detect_max)
+					g.detect_max = sec;
+			} else {
+				fprintf(stderr, "%lu: clock_gettime() "
+					"error %d\n", self_id, rc);
+			}
+		} else if (self_id != victim) {
+			fprintf(stdout, "%lu: false DEAD %lu\n", self_id, id);
+			abort();
+		}
+		break;
+	default:
+		fprintf(stderr, "%lu: notify %lu unknown\n", self_id, id);
+		break;
+	}
+
+	g.swim_state[self_id][id] = *state;
+
+	cnt = 0;
+	for (i = 0; i < members_count; i++) {
+		if (i != victim) {
+			s = g.swim_state[i][victim].sms_status;
+			if (s == SWIM_MEMBER_DEAD)
+				cnt++;
+		}
+	}
+	if (cnt == members_count - 1) {
+		fprintf(stdout, "DEAD detected by all members. Shutdown...\n");
+		g.shutdown = 1;
+	}
+
+	return rc;
+}
+
+int test_run(void)
+{
+	enum swim_member_status s;
+	struct timespec now;
+	uint64_t time = swim_now_ms();
+	int i, j, cs, cd, tick, rc = 0;
+
+	sleep(1);
+	fprintf(stderr, "-=main=- thread running on core %d\n", sched_getcpu());
+	for (i = 0; i < members_count; i++)
+		g.swim_ctx[i]->sc_next_tick_time = time;
+
+	tick = 0;
+	/* print the state of all members from all targets */
+	while (!g.shutdown && g.swim_ctx[0]->sc_self != SWIM_ID_INVALID) {
+		if (time != g.swim_ctx[0]->sc_next_tick_time) {
+			time = g.swim_ctx[0]->sc_next_tick_time;
+			tick++;
+
+			if (verbose) {
+				fprintf(stdout, "     ");
+				for (i = 0; i < members_count; i++)
+					fprintf(stdout, " [%2u]", i);
+				fprintf(stdout, "avg:self\n");
+			}
+
+			cs = 0;
+			cd = 0;
+			for (i = 0; i < members_count; i++) {
+				uint32_t dmin, dmax, davg, delay;
+
+				dmin = UINT32_MAX;
+				dmax = 0;
+				davg = 0;
+				for (j = 0; j < members_count; j++) {
+					if (i == j)
+						continue;
+					delay = g.swim_state[i][j].sms_delay;
+					if (delay < dmin)
+						dmin = delay;
+					if (delay > dmax)
+						dmax = delay;
+					davg += delay;
+				}
+				davg /= members_count - 1;
+
+				s = g.swim_state[i][victim].sms_status;
+				if (s == SWIM_MEMBER_SUSPECT)
+					cs++;
+				if (s == SWIM_MEMBER_DEAD)
+					cd++;
+
+				if (verbose) {
+					fprintf(stdout, "[%2u]", i);
+					for (j = 0; j < members_count; j++) {
+						delay = g.swim_state[i][j].sms_delay;
+						fprintf(stdout, " %4u", delay);
+					}
+					delay = g.swim_state[i][i].sms_delay;
+					fprintf(stdout, " %3u:%u\n", davg, delay);
+				}
+			}
+
+			fprintf(stdout, "%3d. ALIVE=%zu\tSUSPECT=%u\tDEAD=%u\n",
+				tick, members_count - cs - cd, cs, cd);
+			fflush(stdout);
+		}
+
+		if (victim == SWIM_ID_INVALID && !g.victim_sec && tick > 0) {
+			rc = clock_gettime(CLOCK_MONOTONIC, &now);
+			if (!rc) {
+				victim = rand() % members_count;
+				g.victim_sec = now.tv_sec;
+
+				fprintf(stdout, "%3d. *** VICTIM %lu ***\n",
+					tick, victim);
+				fflush(stdout);
+			} else {
+				fprintf(stderr, "clock_gettime() rc=%d\n", rc);
+			}
+		}
+		usleep(1000);
+	}
+	g.shutdown = 1;
+
+	fprintf(stderr, "\nWith %zu members failure was detected after:\n"
+		"min %lu sec max %lu sec\n",
+		members_count, g.detect_min, g.detect_max);
+
+	return rc;
+}
+
+/*
+ * NB: Keep this functionality the same as in crt_swim_srv_cb() !!!
+ */
+static void deliver_pkt(struct network_pkt *item)
+{
+	swim_id_t id;
+	swim_id_t self_id = item->np_to;
+	swim_id_t from_id = item->np_from;
+	struct swim_context *ctx = g.swim_ctx[self_id];
+	struct swim_member_state *state;
+	uint64_t max_delay, rcv_delay, snd_delay;
+	int i, rc = 0;
+
+	max_delay = swim_ping_timeout_get() / 2;
+	rcv_delay = swim_now_ms() - item->np_time;
+
+	for (i = 0; i < item->np_nupds; i++) {
+		id = item->np_upds[i].smu_id;
+		state = &item->np_upds[i].smu_state;
+		snd_delay = g.swim_state[self_id][id].sms_delay;
+		snd_delay = snd_delay ? (snd_delay + state->sms_delay) / 2
+				      : state->sms_delay;
+		g.swim_state[self_id][id].sms_delay = snd_delay;
+	}
+
+	snd_delay = g.swim_state[self_id][from_id].sms_delay;
+	snd_delay = snd_delay ? (snd_delay + rcv_delay) / 2 : rcv_delay;
+	g.swim_state[self_id][from_id].sms_delay = snd_delay;
+
+	if (rcv_delay > max_delay)
+		swim_net_glitch_update(ctx, self_id, rcv_delay - max_delay);
+	else if (snd_delay > max_delay)
+		swim_net_glitch_update(ctx, from_id, snd_delay - max_delay);
+
+	/* emulate RPC receive by target */
+	rc = swim_parse_message(ctx, from_id, item->np_upds, item->np_nupds);
+	if (rc == -ESHUTDOWN)
+		swim_self_set(ctx, SWIM_ID_INVALID);
+	else if (rc)
+		fprintf(stderr, "swim_parse_message() rc=%d\n", rc);
+}
+
+static int cur_core;
+
+static void *network_thread(void *arg)
+{
+	struct network_pkt *item;
+	cpu_set_t	cpuset;
+	int		num_cores = sysconf(_SC_NPROCESSORS_ONLN);
+	int		rc = 0;
+
+	CPU_ZERO(&cpuset);
+	CPU_SET(++cur_core % num_cores, &cpuset);
+	pthread_setaffinity_np(pthread_self(), sizeof(cpu_set_t), &cpuset);
+
+	fprintf(stderr, "network  thread running on core %d\n", sched_getcpu());
+
+	do {
+		D_SPIN_LOCK(&g.lock);
+		item = TAILQ_FIRST(&g.pkts);
+		if (item != NULL) {
+			TAILQ_REMOVE(&g.pkts, item, np_link);
+			pkt_total++;
+			D_SPIN_UNLOCK(&g.lock);
+
+			if (!(rand() % glitches)) {
+				usleep(rand() % (6 * net_delay));
+				D_SPIN_LOCK(&g.lock);
+				TAILQ_INSERT_TAIL(&g.pkts, item, np_link);
+				pkt_glitch++;
+				D_SPIN_UNLOCK(&g.lock);
+			} else {
+				if (!(!(rand() % failures) &&
+				      (item->np_from == victim ||
+				       item->np_to == victim)))
+					deliver_pkt(item);
+
+				D_FREE(item->np_upds);
+				free(item);
+			}
+		} else {
+			D_SPIN_UNLOCK(&g.lock);
+			usleep(1000);
+		}
+
+		usleep(rand() % (3 * net_delay));
+	} while (!g.shutdown);
+
+	fprintf(stderr, "network  thread exit rc=%d\n", rc);
+
+	pthread_exit(NULL);
+}
+
+static void *progress_thread(void *arg)
+{
+	int		num_cores = sysconf(_SC_NPROCESSORS_ONLN);
+	cpu_set_t	cpuset;
+	int64_t		timeout = 0;
+	int		i, rc = 0;
+
+	CPU_ZERO(&cpuset);
+	CPU_SET(++cur_core % num_cores, &cpuset);
+	pthread_setaffinity_np(pthread_self(), sizeof(cpu_set_t), &cpuset);
+
+	fprintf(stderr, "progress thread running on core %d\n", sched_getcpu());
+
+	do {
+		for (i = 0; i < members_count; i++) {
+			rc = swim_progress(g.swim_ctx[i], timeout);
+			if (rc == -ESHUTDOWN)
+				swim_self_set(g.swim_ctx[i], SWIM_ID_INVALID);
+			else if (rc && rc != -ETIMEDOUT)
+				fprintf(stderr, "swim_progress() rc=%d\n", rc);
+		}
+		usleep(100);
+	} while (!g.shutdown);
+
+	fprintf(stderr, "progress thread exit rc=%d\n", rc);
+
+	pthread_exit(NULL);
+}
+
+static struct swim_ops swim_ops = {
+	.send_message     = &test_send_message,
+	.get_dping_target = &test_get_dping_target,
+	.get_iping_target = &test_get_iping_target,
+	.get_member_state = &test_get_member_state,
+	.set_member_state = &test_set_member_state,
+};
+
+int test_fini(void)
+{
+	struct swim_target *st;
+	int i, rc = 0;
+
+	g.shutdown = 1;
+
+	if (g.network_tid) {
+		rc = pthread_join(g.network_tid, NULL);
+		if (rc)
+			fprintf(stderr, "pthread_join() rc=%d\n", rc);
+	}
+
+	if (g.progress_tid) {
+		rc = pthread_join(g.progress_tid, NULL);
+		if (rc)
+			fprintf(stderr, "pthread_join() rc=%d\n", rc);
+	}
+
+	for (i = 0; i < members_count; i++) {
+		swim_fini(g.swim_ctx[i]);
+
+		while (!CIRCLEQ_EMPTY(&g.target_list[i])) {
+			st = CIRCLEQ_FIRST(&g.target_list[i]);
+			CIRCLEQ_REMOVE(&g.target_list[i], st, st_link);
+			free(st);
+		}
+	}
+
+	D_SPIN_DESTROY(&g.lock);
+
+	return rc;
+}
+
+#ifdef USE_CART_FOR_DEBUG_LOG
+extern int crt_init_opt(char *grpid, uint32_t flags, void *opt);
+#endif
+
+int test_init(void)
+{
+	struct swim_target *st;
+	int i, j, n, rc = -EFAULT;
+
+#ifdef USE_CART_FOR_DEBUG_LOG
+	rc = crt_init_opt("test_swim", 2 /*CRT_FLAG_BIT_AUTO_SWIM_DISABLE*/,
+			  NULL);
+	if (rc) /* need to logging only, therefore ignore all errors */
+		fprintf(stderr, "crt_init() rc=%d\n", rc);
+#endif
+	memset(&g, 0, sizeof(g));
+
+	TAILQ_INIT(&g.pkts);
+	g.shutdown   = 0;
+	g.detect_min = UINT64_MAX;
+	g.detect_max = 0;
+
+	for (i = 0; i < members_count; i++) {
+		CIRCLEQ_INIT(&g.target_list[i]);
+
+		st = malloc(sizeof(struct swim_target));
+		if (st == NULL) {
+			fprintf(stderr, "malloc() for swim_target failed\n");
+			goto out;
+		}
+		st->st_id = i;
+		CIRCLEQ_INSERT_HEAD(&g.target_list[i], st, st_link);
+		g.target[i] = st;
+
+		for (j = 0; j < members_count; j++) {
+			if (i != j) {
+				st = malloc(sizeof(struct swim_target));
+				if (st == NULL) {
+					fprintf(stderr, "malloc() for "
+							"swim_target failed\n");
+					goto out;
+				}
+				st->st_id = j;
+				CIRCLEQ_INSERT_AFTER(&g.target_list[i],
+						     g.target[i], st, st_link);
+
+				for (n = 1 + rand() % (j + 1); n > 0; n--)
+					g.target[i] = CIRCLEQ_LOOP_NEXT(
+							&g.target_list[i],
+							g.target[i], st_link);
+			}
+
+			g.swim_state[i][j].sms_incarnation = 0;
+			g.swim_state[i][j].sms_status = SWIM_MEMBER_ALIVE;
+		}
+
+		g.swim_ctx[i] = swim_init(i, &swim_ops, &g);
+		if (g.swim_ctx[i] == NULL) {
+			fprintf(stderr, "swim_init() failed\n");
+			goto out;
+		}
+	}
+
+	rc = D_SPIN_INIT(&g.lock, PTHREAD_PROCESS_PRIVATE);
+	if (rc) {
+		fprintf(stderr, "D_SPIN_INIT() rc=%d\n", rc);
+		goto out;
+	}
+
+	rc = pthread_create(&g.network_tid, NULL, network_thread, NULL);
+	if (rc) {
+		fprintf(stderr, "pthread_create() rc=%d\n", rc);
+		goto out;
+	}
+
+	rc = pthread_create(&g.progress_tid, NULL, progress_thread, NULL);
+	if (rc) {
+		fprintf(stderr, "pthread_create() rc=%d\n", rc);
+		goto out;
+	}
+out:
+	return rc;
+}
+
+int test_parse_args(int argc, char **argv)
+{
+	unsigned int nr;
+	int option_index = 0;
+	int rc = 0;
+	char *end;
+	struct option long_options[] = {
+		{"size",     required_argument, 0, 's'},
+		{"glitches", required_argument, 0, 'g'},
+		{"failures", required_argument, 0, 'f'},
+		{"delay",    required_argument, 0, 'd'},
+		{"verbose",  no_argument, &verbose, 1},
+		{0, 0, 0, 0}
+	};
+
+	while (1) {
+		rc = getopt_long(argc, argv, "?s:g:f:d:v", long_options,
+				 &option_index);
+		if (rc == -1)
+			break;
+		switch (rc) {
+		case 's':
+			nr = strtoul(optarg, &end, 10);
+			if (end == optarg || nr < 2 || nr > MEMBERS_MAX) {
+				fprintf(stderr, "size %d not in range "
+					"[%d, %d], using %d for test.\n", nr,
+					2, MEMBERS_MAX, MEMBERS_MAX);
+			} else {
+				members_count = nr;
+				fprintf(stderr, "will use %d members.\n", nr);
+			}
+			break;
+		case 'g':
+			nr = strtoul(optarg, &end, 10);
+			if (end == optarg ||
+			    nr < GLITCHES_MIN || nr > GLITCHES_MAX) {
+				fprintf(stderr, "glitches 1/%d not in range "
+					"[1/%d, 1/%d], using 1/%d for test.\n",
+					nr, GLITCHES_MIN, GLITCHES_MAX,
+					glitches);
+			} else {
+				glitches = nr;
+				fprintf(stderr, "will introduce 1/%d "
+					"glitches.\n", nr);
+			}
+			break;
+		case 'f':
+			nr = strtoul(optarg, &end, 10);
+			if (end == optarg ||
+			    nr < FAILURES_MIN || nr > FAILURES_MAX) {
+				fprintf(stderr, "failures 1/%d not in range "
+					"[1/%d, 1/%d], using 1/%d for test.\n",
+					nr, FAILURES_MIN, FAILURES_MAX,
+					failures);
+			} else {
+				failures = nr;
+				fprintf(stderr, "will introduce 1/%d "
+					"failures.\n", nr);
+			}
+			break;
+		case 'd':
+			nr = strtoul(optarg, &end, 10);
+			if (end == optarg ||
+			    nr < 1 || nr > 1000) {
+				fprintf(stderr, "delay %d not in range "
+					"[%d, %d], using %d usec for test.\n",
+					nr, 1, 1000,
+					net_delay);
+			} else {
+				net_delay = nr;
+				fprintf(stderr, "will use %d usec "
+					"net delay.\n", nr);
+			}
+			break;
+		case 'v':
+			verbose = 1;
+			break;
+		case 0:
+			if (long_options[option_index].flag != 0)
+				break;
+		case '?':
+		default:
+			fprintf(stderr, "Usage: %s [options]\n", argv[0]);
+			fprintf(stderr, "Options are:\n"
+"-s (--size)     : count of SWIM members (group size)\n"
+"-g (--glitches) : how many glitches will be introduced in communication\n"
+"-f (--failures) : how many failures will be introduced in communication\n"
+"-d (--delay)    : the amount of communication delay for each packet in usec\n"
+"-v              : verbose output about internal state during simulation\n");
+			return 1;
+		}
+	}
+	if (optind < argc) {
+		fprintf(stderr, "non-option argv elements encountered");
+		return 1;
+	}
+
+	return 0;
+}
+
+int main(int argc, char **argv)
+{
+	struct timespec now;
+	int rc;
+
+	glitches = GLITCHES_MAX;
+	failures = FAILURES_MAX;
+	net_delay = 10;
+	members_count = 1000;
+	rc = test_parse_args(argc, argv);
+	if (rc)
+		return rc;
+
+	rc = clock_gettime(CLOCK_MONOTONIC, &now);
+	if (!rc)
+		srand(now.tv_nsec + getpid());
+	rc = test_init();
+	if (!rc)
+		rc = test_run();
+	test_fini();
+
+	return rc;
+}


### PR DESCRIPTION
According to simulation the currect defaults for SWIM algorithm
like a suspicion timeout is wrong. Therefore, increase the suspicion
timeout till 8 periods and decrease period duration to 1 second.

Also rework a network glitches detection algorithm with information
about network latency for each node. Now information about network
delay for particular node is spread across the cluster and used for
timeouts tuning.

Add SWIM simulator code to play with tunables and simulate hughe
cluster with unstable network. The amount of network glitches and
network issues are configurable in command line arguments.