### PR TITLE
DAOS-5762 test: Fix test failures when rpm-test is disabled

### DIFF
--- a/ftest.sh
+++ b/ftest.sh
@@ -244,7 +244,7 @@ if ! $TEST_RPMS; then
     ls -al /usr/share/daos/control
     ls -al /usr/share/spdk/scripts
     ls -al /usr/share/spdk/include
-    ls -al \$DAOS_BASE/install/share/spdk/scripts
+    ls -al $DAOS_BASE/install/share/spdk/scripts
 fi
 
 rm -rf \"${TEST_TAG_DIR:?}/\"

--- a/ftest.sh
+++ b/ftest.sh
@@ -134,8 +134,9 @@ if ${TEST_RPMS:-false}; then
     SL_PREFIX=$PWD
 else
     TEST_RPMS=false
-    PREFIX=install
+    #PREFIX=install
     . .build_vars.sh
+    PREFIX=$SL_PREFIX
 fi
 
 if ${TEARDOWN_ONLY:-false}; then
@@ -243,6 +244,7 @@ if ! $TEST_RPMS; then
     ls -al /usr/share/daos/control
     ls -al /usr/share/spdk/scripts
     ls -al /usr/share/spdk/include
+    ls -al \$DAOS_BASE/install/share/spdk/scripts
 fi
 
 rm -rf \"${TEST_TAG_DIR:?}/\"

--- a/ftest.sh
+++ b/ftest.sh
@@ -241,9 +241,10 @@ if ! $TEST_RPMS; then
 
     echo DAOS_BASE $DAOS_BASE
     echo SL_PREFIX $SL_PREFIX
-    ls -al /usr/share/daos/control
-    ls -al /usr/share/spdk/scripts
-    ls -al /usr/share/spdk/include
+    ls -al $DAOS_BASE
+    ls -al $DAOS_BASE/install/
+    ls -al $DAOS_BASE/install/share/
+    ls -al $DAOS_BASE/install/share/spdk/
     ls -al $DAOS_BASE/install/share/spdk/scripts
 fi
 

--- a/ftest.sh
+++ b/ftest.sh
@@ -214,20 +214,20 @@ if ! $TEST_RPMS; then
     # necessary if we were testing from RPMs) in order to
     # perform NVMe operations via daos_admin
     sudo mkdir -p /usr/share/daos/control
-    sudo ln -sf $SL_PREFIX/share/daos/control/setup_spdk.sh \
+    sudo ln -sf $DAOS_BASE/install/share/daos/control/setup_spdk.sh \
                /usr/share/daos/control
     sudo mkdir -p /usr/share/spdk/scripts
     if [ ! -f /usr/share/spdk/scripts/setup.sh ]; then
-        sudo ln -sf $SL_PREFIX/share/spdk/scripts/setup.sh \
+        sudo ln -sf $DAOS_BASE/install/share/spdk/scripts/setup.sh \
                    /usr/share/spdk/scripts
     fi
     if [ ! -f /usr/share/spdk/scripts/common.sh ]; then
-        sudo ln -sf $SL_PREFIX/share/spdk/scripts/common.sh \
+        sudo ln -sf $DAOS_BASE/install/share/spdk/scripts/common.sh \
                    /usr/share/spdk/scripts
     fi
     if [ ! -f /usr/share/spdk/include/spdk/pci_ids.h ]; then
         sudo rm -f /usr/share/spdk/include
-        sudo ln -s $SL_PREFIX/include \
+        sudo ln -s $DAOS_BASE/install/include \
                    /usr/share/spdk/include
     fi
 
@@ -237,6 +237,12 @@ if ! $TEST_RPMS; then
     sudo cp $DAOS_BASE/install/bin/daos_admin /usr/bin/daos_admin && \
 	    sudo chown root /usr/bin/daos_admin && \
 	    sudo chmod 4755 /usr/bin/daos_admin
+
+    echo DAOS_BASE $DAOS_BASE
+    echo SL_PREFIX $SL_PREFIX
+    ls -al /usr/share/daos/control
+    ls -al /usr/share/spdk/scripts
+    ls -al /usr/share/spdk/include
 fi
 
 rm -rf \"${TEST_TAG_DIR:?}/\"
@@ -268,6 +274,8 @@ else
     mkdir -p $DAOS_BASE/install/tmp
     logs_prefix=\"$DAOS_BASE/install/lib/daos/TESTING\"
     cd $DAOS_BASE
+    export DAOS_TEST_SHARED_DIR=$DAOS_BASE/install/tmp
+    echo \$DAOS_TEST_SHARED_DIR
 fi
 
 export CRT_PHY_ADDR_STR=ofi+sockets

--- a/src/tests/ftest/cart/util/cart_utils.py
+++ b/src/tests/ftest/cart/util/cart_utils.py
@@ -186,6 +186,8 @@ class CartUtils():
 
         env += " -x CRT_ATTACH_INFO_PATH={!s}".format(daos_test_shared_dir)
 
+        env += " -x PATH"
+
         cartobj.log_path = log_path
 
         if not os.path.exists(log_path):

--- a/src/tests/ftest/launch.py
+++ b/src/tests/ftest/launch.py
@@ -192,6 +192,8 @@ def set_test_environment(args):
     os.environ["CRT_CTX_SHARE_ADDR"] = "0"
     os.environ["OFI_INTERFACE"] = os.environ.get("OFI_INTERFACE", interface)
 
+    print("SCHAN15 - Using PATH={}".format(os.environ["PATH"]))
+
     # Set the default location for daos log files written during testing if not
     # already defined.
     if "DAOS_TEST_LOG_DIR" not in os.environ:


### PR DESCRIPTION
Fix tests on the hardware clusters failing because CI is
looking at the incorrect dir for spdk_setup.sh when
RPM-test is disabled.

Quick-build: true
RPM-test: false