### PR TITLE
DAOS-5768 control: Add agent startup timing output

### DIFF
--- a/src/control/cmd/daos_agent/start.go
+++ b/src/control/cmd/daos_agent/start.go
@@ -29,6 +29,7 @@ import (
 	"os/signal"
 	"path/filepath"
 	"syscall"
+	"time"
 
 	"github.com/daos-stack/daos/src/control/drpc"
 	"github.com/daos-stack/daos/src/control/lib/atm"
@@ -47,6 +48,7 @@ type startCmd struct {
 
 func (cmd *startCmd) Execute(_ []string) error {
 	cmd.log.Infof("Starting %s:", versionString())
+	startedAt := time.Now()
 
 	ctx, shutdown := context.WithCancel(context.Background())
 	defer shutdown()
@@ -93,6 +95,7 @@ func (cmd *startCmd) Execute(_ []string) error {
 		return err
 	}
 
+	cmd.log.Debugf("startup complete in %s", time.Since(startedAt))
 	cmd.log.Infof("Listening on %s", sockPath)
 
 	// Setup signal handlers so we can block till we get SIGINT or SIGTERM


### PR DESCRIPTION
Collect more information about agent startup, in an effort
to determine if the agent is starting too slowly, or if
the harness is too aggressive in timing out agents.