### PR TITLE
DAOS-5776 placement: use target number from ocattr

### DIFF
--- a/src/placement/pl_map.c
+++ b/src/placement/pl_map.c
@@ -570,11 +570,13 @@ pl_select_leader(daos_obj_id_t oid, uint32_t shard_idx, uint32_t grp_size,
 
 	oc_attr = daos_oclass_attr_find(oid);
 	if (oc_attr->ca_resil != DAOS_RES_REPL) {
+		int tgt_nr = oc_attr->u.ec.e_k + oc_attr->u.ec.e_p;
+
 		/* For EC object, elect last shard in the group (must to be
 		 * a parity node) as leader.
 		 */
-		shard = pl_get_shard(data,
-				rounddown(shard_idx, grp_size) + grp_size - 1);
+		shard = pl_get_shard(data, rounddown(shard_idx, tgt_nr) +
+					   tgt_nr - 1);
 		if (for_tgt_id)
 			return shard->po_target;
 


### PR DESCRIPTION
Use target number from obj attribute to get the
leader, since during server addition, the reintegration
shard might be added to object layout, so group size
is not the same as c_k + c_p anymore.

Signed-off-by: Di Wang <di.wang@intel.com>