### PR TITLE
DAOS-5799 build: Fix FIRMWARE_MGMT build

### DIFF
--- a/src/control/SConscript
+++ b/src/control/SConscript
@@ -92,7 +92,7 @@ def install_go_bin(denv, gosrc, libs, name, install_name):
     # Must be run from the top of the source dir in order to
     # pick up the vendored modules.
     denv.Command(build_bin, src + gurt_lib,
-                 'cd %s; %s build -mod vendor -v %s %s -o %s %s %s' %
+                 'cd %s; %s build -mod vendor -v %s %s %s -o %s %s' %
                  (gosrc, GO_BIN, go_ldflags(), get_build_flags(denv), get_build_tags(denv),
                   build_bin, install_src))
     # Use the intermediate build location in order to play nicely


### PR DESCRIPTION
The Go build string wasn't correct for the case where scons
adds Go build tags.

Signed-off-by: Kris Jacque <kristin.jacque@intel.com>