### PR TITLE
DAOS-5793 ports: Prevent clashing ports when multiple servers are used

### DIFF
--- a/ci/provisioning/post_provision_config_nodes_EL_7.sh
+++ b/ci/provisioning/post_provision_config_nodes_EL_7.sh
@@ -4,6 +4,10 @@ post_provision_config_nodes() {
     local yum_repo_args="--disablerepo=*"
     yum_repo_args+=" --enablerepo=repo.dc.hpdd.intel.com_repository_*"
     yum_repo_args+=",build.hpdd.intel.com_job_daos-stack*"
+
+    # Reserve port ranges for DAOS and CART servers
+    echo 31416-31516 > /proc/sys/net/ipv4/ip_local_reserved_ports
+
     if $CONFIG_POWER_ONLY; then
         rm -f /etc/yum.repos.d/*.hpdd.intel.com_job_daos-stack_job_*_job_*.repo
         yum -y erase fio fuse ior-hpc mpich-autoload               \

--- a/ci/provisioning/post_provision_config_nodes_LEAP_15.sh
+++ b/ci/provisioning/post_provision_config_nodes_LEAP_15.sh
@@ -13,6 +13,9 @@ post_provision_config_nodes() {
     #                 slurm-example-configs slurmctld slurm-slurmmd
     #fi
 
+    # Reserve port ranges 31416-31516 for DAOS and CART servers
+    echo 31416-31516 > /proc/sys/net/ipv4/ip_local_reserved_ports
+
     if [ -n "$DAOS_STACK_GROUP_REPO" ]; then
          # rm -f /etc/yum.repos.d/*"$DAOS_STACK_GROUP_REPO"
         zypper --non-interactive ar                                           \


### PR DESCRIPTION
When multiple servers are started on the same node it is possible for
one servers non-0 contexts to end up picking port which was supposed
to be used by other servers.

To workaround this problem, ports 31416-31516 are now reserved via
"echo 31416-31516 > /proc/sys/net/ipv4/ip_local_reserved_ports" done
by provisioning scripts.
Ports in that range as a result will not be handed out to non-0
contexts, avoiding the clash.

crt_launch utility modified to hand out ports for context0 to each
launched server starting from port 31416 in sequential order.

Signed-off-by: Alexander Oganezov <alexander.a.oganezov@intel.com>