### PR TITLE
DAOS-5784 rebuild: set status correctly for normal pool

### DIFF
--- a/src/rebuild/rpc.h
+++ b/src/rebuild/rpc.h
@@ -47,7 +47,7 @@
 #define REBUILD_PROTO_SRV_RPC_LIST					\
 	X(REBUILD_OBJECTS_SCAN,						\
 		0, &CQF_rebuild_scan,					\
-		rebuild_tgt_scan_handler, NULL)
+		rebuild_tgt_scan_handler, &rebuild_tgt_scan_co_ops)
 
 /* Define for RPC enum population below */
 #define X(a, b, c, d, e) a

--- a/src/rebuild/scan.c
+++ b/src/rebuild/scan.c
@@ -702,3 +702,20 @@ out:
 	ro->rso_stable_epoch = crt_hlc_get();
 	dss_rpc_reply(rpc, DAOS_REBUILD_DROP_SCAN);
 }
+
+int
+rebuild_tgt_scan_aggregator(crt_rpc_t *source, crt_rpc_t *result,
+			    void *priv)
+{
+	struct rebuild_scan_out	*src = crt_reply_get(source);
+	struct rebuild_scan_out *dst = crt_reply_get(result);
+
+	if (dst->rso_status == 0)
+		dst->rso_status = src->rso_status;
+
+	if (src->rso_status == 0 &&
+	    dst->rso_stable_epoch < src->rso_stable_epoch)
+		dst->rso_stable_epoch = src->rso_stable_epoch;
+
+	return 0;
+}

--- a/src/rebuild/srv.c
+++ b/src/rebuild/srv.c
@@ -478,14 +478,10 @@ ds_rebuild_query(uuid_t pool_uuid, struct daos_rebuild_status *status)
 	rgt = rebuild_global_pool_tracker_lookup(pool_uuid, -1);
 	if (rgt == NULL) {
 		rs_inlist = rebuild_status_completed_lookup(pool_uuid);
-		if (rs_inlist != NULL) {
+		if (rs_inlist != NULL)
 			memcpy(status, rs_inlist, sizeof(*status));
-		} else {
-			if (d_list_empty(&rebuild_gst.rg_queue_list) &&
-			    rebuild_gst.rg_inflight == 0)
-				status->rs_done = 1;
-			D_GOTO(out, rc = 0);
-		}
+		else
+			status->rs_done = 1;
 	} else {
 		memcpy(status, &rgt->rgt_status, sizeof(*status));
 		status->rs_version = rgt->rgt_rebuild_ver;
@@ -507,7 +503,6 @@ ds_rebuild_query(uuid_t pool_uuid, struct daos_rebuild_status *status)
 		}
 	}
 
-out:
 	D_DEBUG(DB_REBUILD, "rebuild "DF_UUID" done %s rec "DF_U64" obj "
 		DF_U64" ver %d err %d\n", DP_UUID(pool_uuid),
 		status->rs_done ? "yes" : "no", status->rs_rec_nr,
@@ -1946,6 +1941,10 @@ out:
 
 	return rc;
 }
+
+static struct crt_corpc_ops rebuild_tgt_scan_co_ops = {
+	.co_aggregate	= rebuild_tgt_scan_aggregator,
+};
 
 /* Define for cont_rpcs[] array population below.
  * See REBUILD_PROTO_*_RPC_LIST macro definition


### PR DESCRIPTION
1. The rebuild status of normal pool should be done,
otherwise it might cause pool destroy hang.

2. PR-3535 incorrectly remove rebuild scan status aggregation,
but the aggregation is still needed to collect the scan rpc status,
in case it may resend the scan request if needed.

Signed-off-by: Di Wang <di.wang@intel.com>