### PR TITLE
DAOS-5808 Disable DAOS master nightly cron in CI

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -309,8 +309,7 @@ pipeline {
     agent { label 'lightweight' }
 
     triggers {
-        cron(env.BRANCH_NAME == 'master' ? '0 0 * * *\n' : '' +
-             env.BRANCH_NAME == 'weekly-testing' ? 'H 0 * * 6' : '')
+        cron(env.BRANCH_NAME == 'weekly-testing' ? 'H 0 * * 6' : '')
     }
 
     environment {


### PR DESCRIPTION
Turn off master nightly build.
Every PR landing triggers a build in master.

Skip-build: true
Skip-test: true