### PR TITLE
DAOS-5768 test: Adjust agent startup timeouts

### DIFF
--- a/src/tests/ftest/util/agent_utils.py
+++ b/src/tests/ftest/util/agent_utils.py
@@ -52,7 +52,7 @@ def include_local_host(hosts):
 class DaosAgentCommand(YamlCommand):
     """Defines an object representing a daos_agent command."""
 
-    def __init__(self, path="", yaml_cfg=None, timeout=5):
+    def __init__(self, path="", yaml_cfg=None, timeout=15):
         """Create a daos_agent command object.
 
         Args:

--- a/src/tests/ftest/util/apricot/apricot/test.py
+++ b/src/tests/ftest/util/apricot/apricot/test.py
@@ -485,7 +485,7 @@ class TestWithServers(TestWithoutServers):
         filename = "{}_{}_{}.yaml".format(self.config_file_base, name, command)
         return os.path.join(self.tmp, filename)
 
-    def add_agent_manager(self, config_file=None, common_cfg=None, timeout=5):
+    def add_agent_manager(self, config_file=None, common_cfg=None, timeout=15):
         """Add a new daos agent manager object to the agent manager list.
 
         Args:


### PR DESCRIPTION
Commit 349abea aggressively reduced a number of test timeouts,
including the agent startup timeout. This has resulted in a
number of intermittent failures of tests run in VMs, most likely
due to variability of load on the underlying host nodes.