### PR TITLE
jgm/DAOS-5816 object: Add target index to daos_obj_layout structure.

### DIFF
--- a/src/client/pydaos/raw/daos_api.py
+++ b/src/client/pydaos/raw/daos_api.py
@@ -751,7 +751,7 @@ class DaosObj(object):
             del self.tgt_rank_list[:]
             for i in range(0, shards):
                 self.tgt_rank_list.append(
-                    obj_layout_ptr[0].ol_shards[0][0].os_ranks[i])
+                    obj_layout_ptr[0].ol_shards[0][0].os_shard_data[i].sd_rank)
         else:
             raise DaosApiError("get_layout returned. RC: {0}".format(ret))
 

--- a/src/include/daos/object.h
+++ b/src/include/daos/object.h
@@ -165,12 +165,17 @@ struct daos_obj_shard_md {
 	uint32_t		smd_padding;
 };
 
+struct daos_shard_data {
+	uint32_t	sd_rank;
+	uint32_t	sd_tgt_idx;
+};
+
 /**
  * object layout information.
  **/
 struct daos_obj_shard {
-	uint32_t	os_replica_nr;
-	uint32_t	os_ranks[0];
+	uint32_t		os_replica_nr;
+	struct daos_shard_data	os_shard_data[0];
 };
 
 struct daos_obj_layout {

--- a/src/tests/suite/daos_obj.c
+++ b/src/tests/suite/daos_obj.c
@@ -3077,7 +3077,7 @@ tgt_idx_change_retry(void **state)
 		assert_int_equal(layout->ol_shards[0]->os_replica_nr, 3);
 		/* FIXME disable rank compare until we fix the layout_get */
 		/* assert_int_equal(layout->ol_shards[0]->os_ranks[0], 2); */
-		rank = layout->ol_shards[0]->os_ranks[replica];
+		rank = layout->ol_shards[0]->os_shard_data[replica].sd_rank;
 		rc = daos_obj_layout_free(layout);
 		assert_int_equal(rc, 0);
 
@@ -3103,7 +3103,8 @@ tgt_idx_change_retry(void **state)
 		 *		     rank);
 		*/
 		print_message("target of shard %d changed from %d to %d\n",
-			      replica, rank, layout->ol_shards[0]->os_ranks[0]);
+			      replica, rank,
+			      layout->ol_shards[0]->os_shard_data[0].sd_rank);
 		rc = daos_obj_layout_free(layout);
 		assert_int_equal(rc, 0);
 	}

--- a/src/utils/daos_hdlr.c
+++ b/src/utils/daos_hdlr.c
@@ -1041,24 +1041,16 @@ cont_decode_props(daos_prop_t *props)
 			D_PRINT("off\n");
 		else if (entry->dpe_val == DAOS_PROP_CO_COMPRESS_LZ4)
 			D_PRINT("lz4\n");
-		else if (entry->dpe_val == DAOS_PROP_CO_COMPRESS_GZIP1)
-			D_PRINT("gzip1\n");
-		else if (entry->dpe_val == DAOS_PROP_CO_COMPRESS_GZIP2)
-			D_PRINT("gzip2\n");
-		else if (entry->dpe_val == DAOS_PROP_CO_COMPRESS_GZIP3)
-			D_PRINT("gzip3\n");
-		else if (entry->dpe_val == DAOS_PROP_CO_COMPRESS_GZIP4)
-			D_PRINT("gzip4\n");
-		else if (entry->dpe_val == DAOS_PROP_CO_COMPRESS_GZIP5)
-			D_PRINT("gzip5\n");
-		else if (entry->dpe_val == DAOS_PROP_CO_COMPRESS_GZIP6)
-			D_PRINT("gzip (= gzip6)\n");
-		else if (entry->dpe_val == DAOS_PROP_CO_COMPRESS_GZIP7)
-			D_PRINT("gzip7\n");
-		else if (entry->dpe_val == DAOS_PROP_CO_COMPRESS_GZIP8)
-			D_PRINT("gzip8\n");
-		else if (entry->dpe_val == DAOS_PROP_CO_COMPRESS_GZIP9)
-			D_PRINT("gzip9\n");
+		else if (entry->dpe_val == DAOS_PROP_CO_COMPRESS_DEFLATE)
+			D_PRINT("deflate\n");
+		else if (entry->dpe_val == DAOS_PROP_CO_COMPRESS_DEFLATE1)
+			D_PRINT("deflate1\n");
+		else if (entry->dpe_val == DAOS_PROP_CO_COMPRESS_DEFLATE2)
+			D_PRINT("deflate2\n");
+		else if (entry->dpe_val == DAOS_PROP_CO_COMPRESS_DEFLATE3)
+			D_PRINT("deflate3\n");
+		else if (entry->dpe_val == DAOS_PROP_CO_COMPRESS_DEFLATE4)
+			D_PRINT("deflate4\n");
 		else
 			D_PRINT("<unknown> ("DF_X64")\n", entry->dpe_val);
 	}

--- a/src/utils/daos_hdlr.c
+++ b/src/utils/daos_hdlr.c
@@ -1041,16 +1041,24 @@ cont_decode_props(daos_prop_t *props)
 			D_PRINT("off\n");
 		else if (entry->dpe_val == DAOS_PROP_CO_COMPRESS_LZ4)
 			D_PRINT("lz4\n");
-		else if (entry->dpe_val == DAOS_PROP_CO_COMPRESS_DEFLATE)
-			D_PRINT("deflate\n");
-		else if (entry->dpe_val == DAOS_PROP_CO_COMPRESS_DEFLATE1)
-			D_PRINT("deflate1\n");
-		else if (entry->dpe_val == DAOS_PROP_CO_COMPRESS_DEFLATE2)
-			D_PRINT("deflate2\n");
-		else if (entry->dpe_val == DAOS_PROP_CO_COMPRESS_DEFLATE3)
-			D_PRINT("deflate3\n");
-		else if (entry->dpe_val == DAOS_PROP_CO_COMPRESS_DEFLATE4)
-			D_PRINT("deflate4\n");
+		else if (entry->dpe_val == DAOS_PROP_CO_COMPRESS_GZIP1)
+			D_PRINT("gzip1\n");
+		else if (entry->dpe_val == DAOS_PROP_CO_COMPRESS_GZIP2)
+			D_PRINT("gzip2\n");
+		else if (entry->dpe_val == DAOS_PROP_CO_COMPRESS_GZIP3)
+			D_PRINT("gzip3\n");
+		else if (entry->dpe_val == DAOS_PROP_CO_COMPRESS_GZIP4)
+			D_PRINT("gzip4\n");
+		else if (entry->dpe_val == DAOS_PROP_CO_COMPRESS_GZIP5)
+			D_PRINT("gzip5\n");
+		else if (entry->dpe_val == DAOS_PROP_CO_COMPRESS_GZIP6)
+			D_PRINT("gzip (= gzip6)\n");
+		else if (entry->dpe_val == DAOS_PROP_CO_COMPRESS_GZIP7)
+			D_PRINT("gzip7\n");
+		else if (entry->dpe_val == DAOS_PROP_CO_COMPRESS_GZIP8)
+			D_PRINT("gzip8\n");
+		else if (entry->dpe_val == DAOS_PROP_CO_COMPRESS_GZIP9)
+			D_PRINT("gzip9\n");
 		else
 			D_PRINT("<unknown> ("DF_X64")\n", entry->dpe_val);
 	}
@@ -1862,7 +1870,7 @@ obj_query_hdlr(struct cmd_args_s *ap)
 		fprintf(stdout, "grp: %d\n", i);
 		for (j = 0; j < shard->os_replica_nr; j++)
 			fprintf(stdout, "replica %d %d\n", j,
-				shard->os_ranks[j]);
+				shard->os_shard_data[j].sd_rank);
 	}
 
 	daos_obj_layout_free(layout);


### PR DESCRIPTION
This change will allow a server target to initiate an RPC to another target without sending and I/O through the client stack. This is needed for EC aggregation.

This structure is currently used in test code to obtain the rank for a shard, The patch changes the syntax of all prior usage of struct daos_obj_layout.