### PR TITLE
DAOS-5818: test: fix NLT test_alloc_fail to use a real pool

### DIFF
--- a/utils/node_local_test.py
+++ b/utils/node_local_test.py
@@ -1294,7 +1294,7 @@ def test_alloc_fail(conf):
 
     pools = get_pool_list()
 
-    if len(pools) > 1:
+    if len(pools) > 0:
         pool = pools[0]
     else:
         pool = '5848df55-a97c-46e3-8eca-45adf85591d6'


### PR DESCRIPTION
A conditional in test_alloc_fail() in node_local_test.py is intended
to run a daos command specifying the UUID of a previously-created pool.
But a bug causes it to fall back and use a hard-coded (nonexistent)
pool UUID. This causes daos_io_server to reply with DER_NOTREPLICA,
that in turn causes the client to remove the server from its list
of pool service replica ranks (leaving the list empty). This change
fixes the if statement to choose an existing pool UUID.

Signed-off-by: Kenneth Cain <kenneth.c.cain@intel.com>