### PR TITLE
DAOS-5819 common: Add asserts in ACL API

### DIFF
--- a/src/common/acl_api.c
+++ b/src/common/acl_api.c
@@ -65,13 +65,16 @@ copy_ace_array(struct daos_ace *aces[], uint16_t num_aces)
 	}
 
 	for (i = 0; i < num_aces; i++) {
-		D_ALLOC(copy[i], daos_ace_get_size(aces[i]));
+		ssize_t size = daos_ace_get_size(aces[i]);
+
+		D_ASSERTF(size > 0, "ACE should have already been validated");
+		D_ALLOC(copy[i], (size_t)size);
 		if (copy[i] == NULL) {
 			free_ace_array(copy, num_aces);
 			return NULL;
 		}
 
-		memcpy(copy[i], aces[i], daos_ace_get_size(aces[i]));
+		memcpy(copy[i], aces[i], (size_t)size);
 	}
 
 	return copy;
@@ -277,10 +280,12 @@ principals_match(struct daos_ace *ace1, struct daos_ace *ace2)
 static uint8_t *
 write_ace(struct daos_ace *ace, uint8_t *pen)
 {
-	size_t	len;
+	ssize_t	len;
 
 	len = daos_ace_get_size(ace);
-	memcpy(pen, (uint8_t *)ace, len);
+	D_ASSERTF(len > 0, "ACE should have already been validated");
+
+	memcpy(pen, (uint8_t *)ace, (size_t)len);
 
 	return pen + len;
 }


### PR DESCRIPTION
Static analysis flagged a couple cases where negative return
values from daos_ace_get_size were ignored. In practice they
were ignored because the input was validated earlier in the
logic flow, so a bad return value at these points should be
impossible.

Signed-off-by: Kris Jacque <kristin.jacque@intel.com>