### PR TITLE
CART-917 cart: Do not return DER errors to mercury

### DIFF
--- a/src/cart/crt_hg.h
+++ b/src/cart/crt_hg.h
@@ -142,16 +142,37 @@ crt_hgret_2_der(int hg_ret)
 		return 0;
 	case HG_TIMEOUT:
 		return -DER_TIMEDOUT;
-	case HG_INVALID_PARAM:
+	case HG_INVALID_ARG:
 		return -DER_INVAL;
-	case HG_SIZE_ERROR:
+	case HG_MSGSIZE:
 		return -DER_OVERFLOW;
-	case HG_NOMEM_ERROR:
+	case HG_NOMEM:
 		return -DER_NOMEM;
 	case HG_CANCELED:
 		return -DER_CANCELED;
 	default:
 		return -DER_HG;
+	};
+}
+
+static inline int
+crt_der_2_hgret(int der)
+{
+	switch (der) {
+	case 0:
+		return HG_SUCCESS;
+	case -DER_TIMEDOUT:
+		return HG_TIMEOUT;
+	case -DER_INVAL:
+		return HG_INVALID_ARG;
+	case -DER_OVERFLOW:
+		return HG_MSGSIZE;
+	case -DER_NOMEM:
+		return HG_NOMEM;
+	case -DER_CANCELED:
+		return HG_CANCELED;
+	default:
+		return HG_OTHER_ERROR;
 	};
 }
 

--- a/src/cart/crt_hg_proc.c
+++ b/src/cart/crt_hg_proc.c
@@ -516,7 +516,7 @@ crt_proc_in_common(crt_proc_t proc, crt_rpc_input_t *data)
 
 	rc = crt_proc_get_op(proc, &proc_op);
 	if (rc != 0)
-		return -DER_HG;
+		D_GOTO(out, rc);
 
 	D_ASSERT(data != NULL);
 	rpc_priv = container_of(data, struct crt_rpc_priv, crp_pub.cr_input);
@@ -595,7 +595,7 @@ crt_proc_in_common(crt_proc_t proc, crt_rpc_input_t *data)
 		D_GOTO(out, rc);
 	}
 out:
-	return rc;
+	return crt_der_2_hgret(rc);
 }
 
 /* NB: caller should pass in &rpc_pub->cr_output as the \param data */
@@ -611,7 +611,7 @@ crt_proc_out_common(crt_proc_t proc, crt_rpc_output_t *data)
 
 	rc = crt_proc_get_op(proc, &proc_op);
 	if (rc != 0)
-		return -DER_HG;
+		D_GOTO(out, rc);
 
 	D_ASSERT(data != NULL);
 	rpc_priv = container_of(data, struct crt_rpc_priv, crp_pub.cr_output);
@@ -657,5 +657,5 @@ crt_proc_out_common(crt_proc_t proc, crt_rpc_output_t *data)
 
 	rc = crt_proc_output(rpc_priv, proc);
 out:
-	return rc;
+	return crt_der_2_hgret(rc);
 }


### PR DESCRIPTION
Starting apparently from mercury commit 68a82c82, returning non-mercury
errors to mercury in crt_proc_out_common may cause segfaults as mercury
translates the errors to strings. This patch translates DER errors to
mercury errors before returning them from crt_proc_{in,out}_common. It
also replaces old HG error names in crt_hgret_2_der with new ones.

Signed-off-by: Li Wei <wei.g.li@intel.com>