### PR TITLE
DAOS-5715 tests: properly set fail_loc for VC test

### DIFF
--- a/src/tests/suite/daos_verify_consistency.c
+++ b/src/tests/suite/daos_verify_consistency.c
@@ -227,7 +227,8 @@ vc_4(void **state)
 	oid = dts_oid_gen(dts_vc_class, 0, arg->myrank);
 	ioreq_init(&req, arg->coh, oid, DAOS_IOD_SINGLE, arg);
 
-	vc_gen_modifications(arg, &req, oid, 7, 7, 7, 0, 0, DAOS_VC_DIFF_REC);
+	vc_gen_modifications(arg, &req, oid, 7, 7, 7, 0, 0,
+			     DAOS_VC_DIFF_REC | DAOS_FAIL_ALWAYS);
 
 	rc = vc_obj_verify(arg, oid);
 	assert_int_equal(rc, -DER_MISMATCH);


### PR DESCRIPTION
For DAOS consistency verification test_4, set DAOS_FAIL_ALWAYS
to guarantee that we can inject expected inconsistency.

Signed-off-by: Fan Yong <fan.yong@intel.com>