### PR TITLE
DAOS-5747 obj: refine io map handling for EC obj fetch

### DIFF
--- a/src/client/array/dc_array.c
+++ b/src/client/array/dc_array.c
@@ -1187,37 +1187,6 @@ process_iod(daos_off_t start_off, daos_size_t array_size,
 }
 
 static int
-reprocess_iom_cb(tse_task_t *task, void *data)
-{
-	struct io_params	*current = *((struct io_params **)data);
-	daos_obj_fetch_t	*io_arg = daos_task_get_args(task);
-	daos_off_t		start_off;
-	unsigned int		i, iom_nr;
-	struct daos_sgl_idx	idx = {0};
-	int			rc = task->dt_result;
-
-	if (rc != 0) {
-		D_ERROR("Array Read Failed (%d)\n", rc);
-		return rc;
-	}
-
-	D_ASSERT(current);
-
-	start_off = (current->dkey_val - 1) * current->chunk_size;
-	iom_nr = 0;
-
-	for (i = 0; i < current->iod.iod_nr; i++) {
-		rc = process_iod(start_off, current->array_size, io_arg->sgls,
-				 &idx, &current->iod.iod_recxs[i],
-				 &current->iom, &iom_nr);
-		if (rc)
-			return rc;
-	}
-
-	return 0;
-}
-
-static int
 process_iomap(struct hole_params *params, daos_array_io_t *args)
 {
 	struct io_params        *io_list;
@@ -1242,63 +1211,7 @@ process_iomap(struct hole_params *params, daos_array_io_t *args)
 		if (sgl->sg_nr == 0)
 			goto next;
 
-		/*
-		 * If the iomap array was not enough, refetch with more ioms.
-		 * TODO - support iomap refresh without fetching data again.
-		 */
-		if (current->iom.iom_nr_out > current->iom.iom_nr) {
-			daos_obj_fetch_t	*io_arg;
-			tse_task_t		*io_task = NULL;
-
-			rc = daos_task_create(DAOS_OPC_OBJ_FETCH,
-					      tse_task2sched(params->ptask),
-					      0, NULL, &io_task);
-			if (rc)
-				return rc;
-
-			io_arg = daos_task_get_args(io_task);
-			io_arg->oh	= params->oh;
-			io_arg->th	= args->th;
-			io_arg->dkey	= &current->dkey;
-			io_arg->nr	= 1;
-			io_arg->iods	= &current->iod;
-			io_arg->sgls	= sgl;
-
-			current->iom.iom_nr = current->iom.iom_nr_out;
-			current->iom.iom_nr_out = 0;
-			D_FREE(current->iom.iom_recxs);
-			D_ALLOC_ARRAY(current->iom.iom_recxs,
-				      current->iom.iom_nr);
-			if (current->iom.iom_recxs == NULL) {
-				tse_task_complete(io_task, -DER_NOMEM);
-				return -DER_NOMEM;
-			}
-			io_arg->ioms = &current->iom;
-			current->array_size = params->array_size;
-
-			rc = tse_task_register_cbs(io_task, NULL, NULL, 0,
-						   reprocess_iom_cb, &current,
-						   sizeof(current));
-			if (rc) {
-				tse_task_complete(io_task, rc);
-				return rc;
-			}
-
-			rc = tse_task_register_deps(params->ptask, 1, &io_task);
-			if (rc) {
-				tse_task_complete(io_task, rc);
-				return rc;
-			}
-
-			rc = tse_task_schedule(io_task, false);
-			if (rc) {
-				tse_task_complete(io_task, rc);
-				return rc;
-			}
-
-			goto next;
-		}
-
+		D_ASSERT(current->iom.iom_nr_out <= current->iom.iom_nr);
 		start_off = (current->dkey_val - 1) * current->chunk_size;
 
 		iom_nr = 0;
@@ -1799,10 +1712,9 @@ dc_array_io(daos_handle_t array_oh, daos_handle_t th,
 
 			/** if this is a byte array, add ioms for hole mgmt */
 			if (array->byte_array) {
-				iom->iom_nr = iod->iod_nr * 2;
-				D_ALLOC_ARRAY(iom->iom_recxs, iom->iom_nr);
-				if (iom->iom_recxs == NULL)
-					D_GOTO(err_iotask, rc = -DER_NOMEM);
+				iom->iom_nr = 0;
+				iom->iom_recxs = NULL;
+				iom->iom_flags = DAOS_IOMF_DETAIL;
 				io_arg->ioms = iom;
 				rc = tse_task_register_deps(stask, 1, &io_task);
 				if (rc)

--- a/src/client/array/dc_array.c
+++ b/src/client/array/dc_array.c
@@ -179,8 +179,10 @@ free_io_params_cb(tse_task_t *task, void *data)
 	while (io_list) {
 		struct io_params *current = io_list;
 
-		if (current->iom.iom_recxs)
-			D_FREE(current->iom.iom_recxs);
+		if (current->iom.iom_recxs) {
+			daos_recx_free(current->iom.iom_recxs);
+			current->iom.iom_recxs = NULL;
+		}
 		if (current->iod.iod_recxs)
 			D_FREE(current->iod.iod_recxs);
 		if (!current->user_sgl_used && current->sgl.sg_iovs)

--- a/src/common/misc.c
+++ b/src/common/misc.c
@@ -655,3 +655,22 @@ daos_dti_gen(struct dtx_id *dti, bool zero)
 		dti->dti_hlc = crt_hlc_get();
 	}
 }
+
+/**
+ * daos_recx_alloc/_free to provide same log facility for recx's alloc and free
+ * for iom->iom_recxs' usage for example.
+ */
+daos_recx_t *
+daos_recx_alloc(uint32_t nr)
+{
+	daos_recx_t	*recxs;
+
+	D_ALLOC_ARRAY(recxs, nr);
+	return recxs;
+}
+
+void
+daos_recx_free(daos_recx_t *recx)
+{
+	D_FREE(recx);
+}

--- a/src/include/daos/common.h
+++ b/src/include/daos/common.h
@@ -47,6 +47,7 @@
 #include <gurt/common.h>
 #include <cart/api.h>
 #include <daos_types.h>
+#include <daos_obj.h>
 #include <daos_prop.h>
 #include <daos_security.h>
 #include <daos/profile.h>
@@ -711,6 +712,29 @@ bool daos_hhash_link_delete(struct d_hlink *hlink);
 #define DAOS_RECX_PTR_OVERLAP(recx_1, recx_2)				\
 	(((recx_1)->rx_idx < (recx_2)->rx_idx + (recx_2)->rx_nr) &&	\
 	 ((recx_2)->rx_idx < (recx_1)->rx_idx + (recx_1)->rx_nr))
+
+#define DAOS_RECX_ADJACENT(recx_1, recx_2)				\
+	(((recx_1).rx_idx == (recx_2).rx_idx + (recx_2).rx_nr) ||	\
+	 ((recx_2).rx_idx == (recx_1).rx_idx + (recx_1).rx_nr))
+#define DAOS_RECX_PTR_ADJACENT(recx_1, recx_2)				\
+	(((recx_1)->rx_idx == (recx_2)->rx_idx + (recx_2)->rx_nr) ||	\
+	 ((recx_2)->rx_idx == (recx_1)->rx_idx + (recx_1)->rx_nr))
+
+#define DAOS_RECX_END(recx)	((recx).rx_idx + (recx).rx_nr)
+#define DAOS_RECX_PTR_END(recx)	((recx)->rx_idx + (recx)->rx_nr)
+
+/**
+ * Merge \a src recx to \a dst recx.
+ */
+static inline void
+daos_recx_merge(daos_recx_t *src, daos_recx_t *dst)
+{
+	uint64_t	end;
+
+	dst->rx_idx = min(src->rx_idx, dst->rx_idx);
+	end = max(DAOS_RECX_PTR_END(dst), DAOS_RECX_PTR_END(src));
+	dst->rx_nr = end - dst->rx_idx;
+}
 
 /* NVMe shared constants */
 #define DAOS_NVME_SHMID_NONE	-1

--- a/src/include/daos/common.h
+++ b/src/include/daos/common.h
@@ -731,8 +731,8 @@ daos_recx_merge(daos_recx_t *src, daos_recx_t *dst)
 {
 	uint64_t	end;
 
+	end = max(DAOS_RECX_PTR_END(src), DAOS_RECX_PTR_END(dst));
 	dst->rx_idx = min(src->rx_idx, dst->rx_idx);
-	end = max(DAOS_RECX_PTR_END(dst), DAOS_RECX_PTR_END(src));
 	dst->rx_nr = end - dst->rx_idx;
 }
 

--- a/src/include/daos/common.h
+++ b/src/include/daos/common.h
@@ -752,6 +752,8 @@ struct daos_prop_entry *daos_prop_entry_get(daos_prop_t *prop, uint32_t type);
 int daos_prop_copy(daos_prop_t *prop_req, daos_prop_t *prop_reply);
 int daos_prop_entry_copy(struct daos_prop_entry *entry,
 			 struct daos_prop_entry *entry_dup);
+daos_recx_t *daos_recx_alloc(uint32_t nr);
+void daos_recx_free(daos_recx_t *recx);
 
 static inline void
 daos_parse_ctype(const char *string, daos_cont_layout_t *type)

--- a/src/include/daos_obj.h
+++ b/src/include/daos_obj.h
@@ -249,6 +249,22 @@ typedef struct {
 } daos_iod_t;
 
 /**
+ * I/O map flags -
+ * DAOS_IOMF_DETAIL	zero means only need to know the iom_recx_hi/lo.
+ *			1 means need to retrieve detailed iom_recxs array, in
+ *			that case user can either -
+ *			1) provides allocated iom_recxs buffer (iom_nr indicates
+ *			   #elements allocated), if returned iom_nr_out is
+ *			   greater than iom_nr, iom_recxs will still be
+ *			   populated, but it will be a truncated list).
+ *			2) provides NULL iod_recxs and zero iom_nr, in that case
+ *			   DAOS will internally allocated needed buffer for
+ *			   iom_recxs array (#elements is iom_nr, and equals
+ *			   iom_nr_out). User is responsible for free the
+ *			   iom_recxs buffer after using.
+ */
+#define DAOS_IOMF_DETAIL		(0x1U)
+/**
  * A I/O map represents the physical extent mapping inside an array for a
  * given range of indices.
  */
@@ -258,14 +274,15 @@ typedef struct {
 	/**
 	 * Number of elements allocated in iom_recxs.
 	 */
-	unsigned int		 iom_nr;
+	uint32_t		 iom_nr;
 	/**
 	 * Number of extents in the mapping. If iom_nr_out is greater than
 	 * iom_nr, iom_recxs will still be populated, but it will be a
 	 * truncated list.
 	 * 1 for SV.
 	 */
-	unsigned int		 iom_nr_out;
+	uint32_t		 iom_nr_out;
+	uint32_t		 iom_flags;
 	/** Size of the single value or the record size */
 	daos_size_t		 iom_size;
 	/**

--- a/src/object/cli_obj.c
+++ b/src/object/cli_obj.c
@@ -41,7 +41,7 @@
 #define CLI_OBJ_IO_PARMS	8
 #define NIL_BITMAP		(NULL)
 
-#define OBJ_TGT_INLINE_NR	(18)
+#define OBJ_TGT_INLINE_NR	(17)
 struct obj_req_tgts {
 	/* to save memory allocation if #targets <= OBJ_TGT_INLINE_NR */
 	struct daos_shard_tgt	 ort_tgts_inline[OBJ_TGT_INLINE_NR];
@@ -647,6 +647,7 @@ obj_reasb_req_init(struct obj_reasb_req *reasb_req, daos_iod_t *iods,
 
 	D_ASSERT((uintptr_t)(tmp_ptr - size_tgt_nr) <=
 		 (uintptr_t)(buf + buf_size));
+	D_SPIN_INIT(&reasb_req->orr_spin, PTHREAD_PROCESS_PRIVATE);
 
 	return 0;
 }
@@ -670,6 +671,7 @@ obj_reasb_req_fini(struct obj_reasb_req *reasb_req, uint32_t iod_nr)
 		obj_ec_tgt_oiod_fini(reasb_req->tgt_oiods);
 		reasb_req->tgt_oiods = NULL;
 	}
+	D_SPIN_DESTROY(&reasb_req->orr_spin);
 	obj_ec_fail_info_free(reasb_req);
 	D_FREE(reasb_req->orr_iods);
 }

--- a/src/object/cli_shard.c
+++ b/src/object/cli_shard.c
@@ -469,7 +469,7 @@ daos_iom_copy(const daos_iom_t *src, daos_iom_t *dst)
 
 	dst->iom_nr_out = src->iom_nr_out;
 	if (dst->iom_recxs == NULL) {
-		D_ALLOC_ARRAY(dst->iom_recxs, dst->iom_nr_out);
+		dst->iom_recxs = daos_recx_alloc(dst->iom_nr_out);
 		if (dst->iom_recxs == NULL)
 			return -DER_NOMEM;
 		dst->iom_nr = dst->iom_nr_out;

--- a/src/object/obj_internal.h
+++ b/src/object/obj_internal.h
@@ -172,7 +172,9 @@ struct obj_reasb_req {
 	/* only with single target flag */
 					 orr_single_tgt:1,
 	/* only for single-value IO flag */
-					 orr_singv_only:1;
+					 orr_singv_only:1,
+	/* the flag of IOM re-allocable (used for EC IOM merge) */
+					 orr_iom_realloc:1;
 };
 
 static inline void
@@ -713,6 +715,41 @@ daos_iom_sort(daos_iom_t *map)
 		return;
 	qsort(map->iom_recxs, map->iom_nr_out,
 	      sizeof(*map->iom_recxs), recx_compare);
+}
+
+static inline void
+daos_iom_dump(daos_iom_t *iom)
+{
+	uint32_t	i;
+
+	if (iom == NULL)
+		return;
+
+	if (iom->iom_type == DAOS_IOD_ARRAY)
+		D_PRINT("iom_type array\n");
+	else if (iom->iom_type == DAOS_IOD_SINGLE)
+		D_PRINT("iom_type single\n");
+	else
+		D_PRINT("iom_type bad (%d)\n", iom->iom_type);
+
+	D_PRINT("iom_nr %d, iom_nr_out %d, iom_flags %d\n",
+		iom->iom_nr, iom->iom_nr_out, iom->iom_flags);
+	D_PRINT("iom_size "DF_U64"\n", iom->iom_size);
+	D_PRINT("iom_recx_lo - "DF_RECX"\n", DP_RECX(iom->iom_recx_lo));
+	D_PRINT("iom_recx_hi - "DF_RECX"\n", DP_RECX(iom->iom_recx_hi));
+
+	if (iom->iom_recxs == NULL) {
+		D_PRINT("NULL iom_recxs array\n");
+		return;
+	}
+
+	D_PRINT("iom_recxs array -\n");
+	for (i = 0; i < iom->iom_nr_out; i++) {
+		D_PRINT("[%d] "DF_RECX" ", i, DP_RECX(iom->iom_recxs[i]));
+		if (i % 8 == 7)
+			D_PRINT("\n");
+	}
+	D_PRINT("\n");
 }
 
 int  obj_utils_init(void);

--- a/src/object/obj_rpc.c
+++ b/src/object/obj_rpc.c
@@ -312,25 +312,14 @@ free:
 static int crt_proc_daos_iom_t(crt_proc_t proc, daos_iom_t *map)
 {
 	crt_proc_op_t		 proc_op;
+	uint32_t		 iom_nr = 0;
 	int			 i, rc;
 
 	rc = crt_proc_get_op(proc, &proc_op);
 	if (rc)
 		return rc;
 
-	rc = crt_proc_uint64_t(proc, &map->iom_size);
-	if (rc != 0)
-		return -DER_HG;
-
 	rc = crt_proc_memcpy(proc, &map->iom_type, sizeof(map->iom_type));
-	if (rc != 0)
-		return -DER_HG;
-
-	rc = crt_proc_uint32_t(proc, &map->iom_nr);
-	if (rc != 0)
-		return -DER_HG;
-
-	rc = crt_proc_uint32_t(proc, &map->iom_nr_out);
 	if (rc != 0)
 		return -DER_HG;
 
@@ -346,7 +335,19 @@ static int crt_proc_daos_iom_t(crt_proc_t proc, daos_iom_t *map)
 	if (rc != 0)
 		return -DER_HG;
 
-	if (DECODING(proc_op)) {
+	if (ENCODING(proc_op)) {
+		iom_nr = map->iom_nr;
+		if ((map->iom_flags & DAOS_IOMF_DETAIL) == 0)
+			iom_nr = 0;
+	}
+
+	rc = crt_proc_uint32_t(proc, &iom_nr);
+	if (rc != 0)
+		return -DER_HG;
+
+	if (DECODING(proc_op) && iom_nr > 0) {
+		map->iom_nr = iom_nr;
+		map->iom_nr_out = iom_nr;
 		D_ALLOC_ARRAY(map->iom_recxs, map->iom_nr);
 		if (map->iom_recxs == NULL)
 			return -DER_NOMEM;
@@ -359,8 +360,8 @@ static int crt_proc_daos_iom_t(crt_proc_t proc, daos_iom_t *map)
 		}
 	}
 
-	if (ENCODING(proc_op)) {
-		for (i = 0; i < map->iom_nr; i++) {
+	if (ENCODING(proc_op) && iom_nr > 0) {
+		for (i = 0; i < iom_nr; i++) {
 			rc = crt_proc_daos_recx_t(proc, &map->iom_recxs[i]);
 			if (rc != 0)
 				return -DER_HG;

--- a/src/object/obj_rpc.h
+++ b/src/object/obj_rpc.h
@@ -158,6 +158,8 @@ enum obj_rpc_flags {
 	DRF_HAS_EC_SPLIT	= (1 << 11),
 	/* Checking the existence of the object/key. */
 	DRF_CHECK_EXISTENCE	= (1 << 12),
+	/** Include the map details on fetch (daos_iom_t::iom_recxs) */
+	ORF_CREATE_MAP_DETAIL	= (1 << 13),
 };
 
 /* common for update/fetch */

--- a/src/object/srv_obj.c
+++ b/src/object/srv_obj.c
@@ -1108,6 +1108,8 @@ obj_fetch_create_maps(crt_rpc_t *rpc, struct bio_desc *biod)
 			  map->iom_nr, map->iom_nr_out);
 		map->iom_recx_lo = map->iom_recxs[0];
 		map->iom_recx_hi = map->iom_recxs[map->iom_nr - 1];
+		if (orw->orw_flags & ORF_CREATE_MAP_DETAIL)
+			map->iom_flags = DAOS_IOMF_DETAIL;
 	}
 
 	orwo->orw_maps.ca_count = iods_nr;

--- a/src/object/srv_obj.c
+++ b/src/object/srv_obj.c
@@ -1036,30 +1036,6 @@ map_add_recx(daos_iom_t *map, const struct bio_iov *biov, uint64_t rec_idx)
 	map->iom_nr_out++;
 }
 
-static inline int
-recx_compare(const void *rank1, const void *rank2)
-{
-	const daos_recx_t *r1 = rank1;
-	const daos_recx_t *r2 = rank2;
-
-	D_ASSERT(r1 != NULL && r2 != NULL);
-	if (r1->rx_idx < r2->rx_idx)
-		return -1;
-	else if (r1->rx_idx == r2->rx_idx)
-		return 0;
-	else /** r1->rx_idx < r2->rx_idx */
-		return 1;
-}
-
-static void
-daos_iom_sort(daos_iom_t *map)
-{
-	if (map == NULL)
-		return;
-	qsort(map->iom_recxs, map->iom_nr_out,
-	      sizeof(*map->iom_recxs), recx_compare);
-}
-
 /** create maps for actually written to extents. */
 static int
 obj_fetch_create_maps(crt_rpc_t *rpc, struct bio_desc *biod)

--- a/src/tests/suite/daos_obj_array.c
+++ b/src/tests/suite/daos_obj_array.c
@@ -955,6 +955,7 @@ fetch_array_with_map(void **state)
 	/** init map */
 	map.iom_recxs = map_recxs;
 	map.iom_nr = SM_BUF_LEN;
+	map.iom_flags = DAOS_IOMF_DETAIL;
 
 	/** init I/O descriptor */
 	d_iov_set(&iod.iod_name, "akey", strlen("akey"));
@@ -1019,12 +1020,11 @@ fetch_array_with_map(void **state)
 	memset(map_recxs, 0, sizeof(map_recxs));
 	map.iom_nr = 0;
 	map.iom_recxs = NULL;
+	map.iom_flags = 0;
 	rc = daos_obj_fetch(oh, DAOS_TX_NONE, 0, &dkey, 1, &iod, &sgl,
 			    &map, NULL);
 	assert_int_equal(0, rc);
 	assert_int_equal(0, map.iom_nr);
-	/** still get nr required */
-	assert_int_equal(3, map.iom_nr_out);
 	/** still get hi/lo */
 	assert_recx_equal(update_recxs[0], map.iom_recx_lo);
 	assert_recx_equal(update_recxs[2], map.iom_recx_hi);
@@ -1070,6 +1070,7 @@ fetch_array_with_map_2(void **state)
 	/** init map */
 	map.iom_recxs = map_recxs;
 	map.iom_nr = SM_BUF_LEN;
+	map.iom_flags = DAOS_IOMF_DETAIL;
 
 	/** init I/O descriptor */
 	d_iov_set(&iod.iod_name, "akey", strlen("akey"));
@@ -1146,6 +1147,7 @@ fetch_array_with_map_3(void **state)
 	/** init map */
 	map.iom_recxs = map_recxs;
 	map.iom_nr = SM_BUF_LEN;
+	map.iom_flags = DAOS_IOMF_DETAIL;
 
 	/** init I/O descriptor */
 	d_iov_set(&iod.iod_name, "akey", strlen("akey"));
@@ -1222,6 +1224,7 @@ fetch_array_with_map_4(void **state)
 	/** init map */
 	map.iom_recxs = map_recxs;
 	map.iom_nr = SM_BUF_LEN;
+	map.iom_flags = DAOS_IOMF_DETAIL;
 
 	/** init I/O descriptor */
 	d_iov_set(&iod.iod_name, "akey", strlen("akey"));


### PR DESCRIPTION
Add iom_flags to allow user to indicate whether need IOM details
(iom_recxs array). When DAOS_IOMF_DETAIL specified and user provide
NULL iom_recxs ptr, DAOS will internally allocate the needed buffer
(user should free it later after use). With benefit of -
1) save RPC size when DAOS_IOMF_DETAIL not set,
2) dc_array's complex handling of refetch and reprocess iom when
     iom_recxs buffer not enough can be avoided.

And for EC obj fetch's IOM handling, should:
1) translate back the VOS ext to DAOS ext, and
2) merge IOM from different shards.

Signed-off-by: Xuezhao Liu <xuezhao.liu@intel.com>