### PR TITLE
DAOS-5823 vos: Reset the dth_ent field on cleanup

### DIFF
--- a/src/vos/vos_dtx.c
+++ b/src/vos/vos_dtx.c
@@ -2231,6 +2231,7 @@ vos_dtx_cleanup_internal(struct dtx_handle *dth)
 				DP_DTI(&dth->dth_xid), DP_RC(rc));
 		} else {
 			dtx_act_ent_cleanup(cont, dae, true);
+			dth->dth_ent = NULL;
 			dtx_evict_lid(cont, dae);
 		}
 	}


### PR DESCRIPTION
Without resetting the field, it's possible for dtx handle to be
reused without allocating a proper lid causing undefined
results.

Signed-off-by: Jeff Olivier <jeffrey.v.olivier@intel.com>