### PR TITLE
DAOS-4560 cart: check bulk handle for iv sync

### DIFF
--- a/src/cart/crt_iv.c
+++ b/src/cart/crt_iv.c
@@ -2062,7 +2062,8 @@ handle_ivsync_response(const struct crt_cb_info *cb_info)
 	struct iv_sync_cb_info	*iv_sync = cb_info->cci_arg;
 	struct crt_iv_ops	*iv_ops;
 
-	crt_bulk_free(iv_sync->isc_bulk_hdl);
+	if (iv_sync->isc_bulk_hdl != CRT_BULK_NULL)
+		crt_bulk_free(iv_sync->isc_bulk_hdl);
 
 	/* do_callback is set based on sync value specified */
 	if (iv_sync->isc_do_callback) {


### PR DESCRIPTION
Check bulk handle for iv_sync completion cb to
avoid error message in crt_bulk_free.

Signed-off-by: Di Wang <di.wang@intel.com>