### PR TITLE
DAOS-3906 java: Update junit dependency due to security alert

### DIFF
--- a/src/client/java/pom.xml
+++ b/src/client/java/pom.xml
@@ -279,7 +279,7 @@
       <dependency>
         <groupId>junit</groupId>
         <artifactId>junit</artifactId>
-        <version>4.11</version>
+        <version>4.13.1</version>
       </dependency>
     </dependencies>
   </dependencyManagement>


### PR DESCRIPTION
Addresses https://github.com/advisories/GHSA-269g-pwp5-87pp by
updating junit to 4.13.1.