### PR TITLE
DAOS-5818 test: Fix NLT test_alloc_fail to use real pool, and resolve…

### DIFF
--- a/src/pool/cli.c
+++ b/src/pool/cli.c
@@ -269,8 +269,8 @@ process_query_reply(struct dc_pool *pool, struct pool_buf *map_buf,
 			D_ERROR("Couldn't get failed targets, "DF_RC"\n",
 				DP_RC(rc));
 	}
-	pool_map_decref(map); /* NB: protected by pool::dp_map_lock */
 out_unlock:
+	pool_map_decref(map); /* NB: protected by pool::dp_map_lock */
 	D_RWLOCK_UNLOCK(&pool->dp_map_lock);
 
 	if (prop_req != NULL && rc == 0)

--- a/src/utils/daos_hdlr.c
+++ b/src/utils/daos_hdlr.c
@@ -521,6 +521,15 @@ out_free:
 out_disconnect:
 	/* Pool disconnect  in normal and error flows: preserve rc */
 	rc2 = daos_pool_disconnect(ap->pool, NULL);
+	/* Automatically retry in case of DER_NOMEM.  This is to allow the
+	 * NLT testing to correctly stress-test all code paths and not
+	 * register any memory leaks.
+	 * TODO: Move this retry login into daos_pool_disconnect()
+	 * or work out another way to effectively shut down and release
+	 * resources in this case.
+	 */
+	if (rc2 == -DER_NOMEM)
+		rc2 = daos_pool_disconnect(ap->pool, NULL);
 	if (rc2 != 0)
 		fprintf(stderr, "failed to disconnect from pool "DF_UUIDF
 			": %s (%d)\n", DP_UUID(ap->p_uuid), d_errdesc(rc2),

--- a/utils/node_local_test.py
+++ b/utils/node_local_test.py
@@ -1278,7 +1278,7 @@ def test_pydaos_kv(server, conf):
     print('Closing container and opening new one')
     kv = container.get_kv_by_name('my_test_kv')
 
-def test_alloc_fail(conf):
+def test_alloc_fail(server, conf):
     """run 'daos' client binary with fault injection
 
     Enable the fault injection for the daos binary, injecting
@@ -1294,10 +1294,10 @@ def test_alloc_fail(conf):
 
     pools = get_pool_list()
 
-    if len(pools) > 1:
-        pool = pools[0]
-    else:
-        pool = '5848df55-a97c-46e3-8eca-45adf85591d6'
+    while len(pools) < 1:
+        pools = make_pool(server)
+
+    pool = pools[0]
 
     cmd = ['pool', 'list-containers', '--svc', '0', '--pool', pool]
 
@@ -1306,6 +1306,8 @@ def test_alloc_fail(conf):
     fatal_errors = False
 
     while True:
+        print()
+
         fc = {}
         fc['fault_config'] = [{'id': 0,
                                'probability_x': 1,
@@ -1375,13 +1377,13 @@ def main():
     elif args.mode == 'overlay':
         fatal_errors.add_result(run_duns_overlay_test(server, conf))
     elif args.mode == 'fi':
-        fatal_errors.add_result(test_alloc_fail(conf))
+        fatal_errors.add_result(test_alloc_fail(server, conf))
     elif args.mode == 'all':
         fatal_errors.add_result(run_il_test(server, conf))
         fatal_errors.add_result(run_dfuse(server, conf))
         fatal_errors.add_result(run_duns_overlay_test(server, conf))
         test_pydaos_kv(server, conf)
-        fatal_errors.add_result(test_alloc_fail(conf))
+        fatal_errors.add_result(test_alloc_fail(server, conf))
     else:
         fatal_errors.add_result(run_il_test(server, conf))
         fatal_errors.add_result(run_dfuse(server, conf))


### PR DESCRIPTION
… errors.

The fault injection test in NLT was using a hard-coded uuid
instead of a valid one so correct this.  This means we do
not get any NOTREPLICA errors from the server which is good,
but does mean we have another couple of leaks from the client,
so fix these.

Add re-try logic around pool_disconnect so even under NLT
it manages to complete correctly, othewise without being
able to disconnect from the pool references are held and
a considerable amount of memory is leaked.

Signed-off-by: Ashley Pittman <ashley.m.pittman@intel.com>