### PR TITLE
DAOS-4357 dfs: dfs_move() should also copy extended attributes

### DIFF
--- a/src/client/dfs/dfs.c
+++ b/src/client/dfs/dfs.c
@@ -77,13 +77,14 @@
 #define SYML_IDX	(CSIZE_IDX + sizeof(daos_size_t))
 
 /** Parameters for dkey enumeration */
-#define ENUM_DESC_NR    10
-#define ENUM_DESC_BUF   (ENUM_DESC_NR * DFS_MAX_PATH)
+#define ENUM_DESC_NR	10
+#define ENUM_DESC_BUF	(ENUM_DESC_NR * DFS_MAX_PATH)
+#define ENUM_XDESC_BUF	(ENUM_DESC_NR * (DFS_MAX_XATTR_NAME + 2))
 
 /** OIDs for Superblock and Root objects */
 #define RESERVED_LO	0
 #define SB_HI		0
-#define ROOT_HI	1
+#define ROOT_HI		1
 
 typedef uint64_t dfs_magic_t;
 typedef uint16_t dfs_sb_ver_t;
@@ -3371,6 +3372,105 @@ dfs_get_symlink_value(dfs_obj_t *obj, char *buf, daos_size_t *size)
 	return 0;
 }
 
+static int
+xattr_copy(daos_handle_t src_oh, char *src_name, daos_handle_t dst_oh,
+	   char *dst_name, daos_handle_t th)
+{
+	daos_key_t	src_dkey, dst_dkey;
+	daos_anchor_t	anchor = {0};
+	d_sg_list_t	sgl, fsgl;
+	d_iov_t		iov, fiov;
+	daos_iod_t	iod;
+	void		*val_buf;
+	char		enum_buf[ENUM_XDESC_BUF];
+	daos_key_desc_t	kds[ENUM_DESC_NR];
+	int		rc = 0;
+
+	/** set dkey for src entry name */
+	d_iov_set(&src_dkey, (void *)src_name, strlen(src_name));
+
+	/** set dkey for dst entry name */
+	d_iov_set(&dst_dkey, (void *)dst_name, strlen(dst_name));
+
+	/** Set IOD descriptor for fetching every xattr */
+	iod.iod_nr	= 1;
+	iod.iod_recxs	= NULL;
+	iod.iod_type	= DAOS_IOD_SINGLE;
+	iod.iod_size	= DFS_MAX_XATTR_LEN;
+
+	/** set sgl for fetch - user a preallocated buf to avoid a roundtrip */
+	D_ALLOC(val_buf, DFS_MAX_XATTR_LEN);
+	if (val_buf == NULL)
+		return ENOMEM;
+	fsgl.sg_nr	= 1;
+	fsgl.sg_nr_out	= 0;
+	fsgl.sg_iovs	= &fiov;
+
+	/** set sgl for akey_list */
+	sgl.sg_nr = 1;
+	sgl.sg_nr_out = 0;
+	d_iov_set(&iov, enum_buf, ENUM_XDESC_BUF);
+	sgl.sg_iovs = &iov;
+
+	/** iterate over every akey to look for xattrs */
+	while (!daos_anchor_is_eof(&anchor)) {
+		uint32_t	number = ENUM_DESC_NR;
+		uint32_t	i;
+		char		*ptr;
+
+		memset(enum_buf, 0, ENUM_XDESC_BUF);
+		rc = daos_obj_list_akey(src_oh, th, &src_dkey, &number, kds,
+					&sgl, &anchor, NULL);
+		if (rc) {
+			D_ERROR("daos_obj_list_akey() failed (%d)\n", rc);
+			D_GOTO(out, rc = daos_der2errno(rc));
+		}
+
+		/** nothing enumerated, continue loop */
+		if (number == 0)
+			continue;
+
+		/*
+		 * for every entry enumerated, check if it's an xattr, and
+		 * insert it in the new entry.
+		 */
+		for (ptr = enum_buf, i = 0; i < number; i++) {
+			/** if not an xattr, go to next entry */
+			if (strncmp("x:", ptr, 2) != 0) {
+				ptr += kds[i].kd_key_len;
+				continue;
+			}
+
+			/** set akey as the xattr name */
+			d_iov_set(&iod.iod_name, ptr, kds[i].kd_key_len);
+			d_iov_set(&fiov, val_buf, DFS_MAX_XATTR_LEN);
+
+			/** fetch the xattr value from the src */
+			rc = daos_obj_fetch(src_oh, th, 0, &src_dkey, 1,
+					    &iod, &fsgl, NULL, NULL);
+			if (rc) {
+				D_ERROR("daos_obj_fetch() failed (%d)\n", rc);
+				D_GOTO(out, rc = daos_der2errno(rc));
+			}
+
+			d_iov_set(&fiov, val_buf, iod.iod_size);
+
+			/** add it to the destination */
+			rc = daos_obj_update(dst_oh, th, 0, &dst_dkey, 1,
+					     &iod, &fsgl, NULL);
+			if (rc) {
+				D_ERROR("daos_obj_update() failed (%d)\n", rc);
+				D_GOTO(out, rc = daos_der2errno(rc));
+			}
+			ptr += kds[i].kd_key_len;
+		}
+	}
+
+out:
+	D_FREE(val_buf);
+	return rc;
+}
+
 int
 dfs_move(dfs_t *dfs, dfs_obj_t *parent, char *name, dfs_obj_t *new_parent,
 	 char *new_name, daos_obj_id_t *oid)
@@ -3509,6 +3609,13 @@ restart:
 	rc = insert_entry(new_parent->oh, th, new_name, entry);
 	if (rc) {
 		D_ERROR("Inserting entry %s failed (%d)\n", new_name, rc);
+		D_GOTO(out, rc);
+	}
+
+	/** cp the extended attributes if they exist */
+	rc = xattr_copy(parent->oh, name, new_parent->oh, new_name, th);
+	if (rc) {
+		D_ERROR("Failed to copy extended attributes (%d)\n", rc);
 		D_GOTO(out, rc);
 	}
 
@@ -3736,6 +3843,12 @@ dfs_setxattr(dfs_t *dfs, dfs_obj_t *obj, const char *name,
 		return EPERM;
 	if (obj == NULL)
 		return EINVAL;
+	if (name == NULL)
+		return EINVAL;
+	if (strnlen(name, DFS_MAX_XATTR_NAME + 1) > DFS_MAX_XATTR_NAME)
+		return EINVAL;
+	if (size > DFS_MAX_XATTR_LEN)
+		return EINVAL;
 
 	rc = check_access(dfs, geteuid(), getegid(), obj->mode, W_OK);
 	if (rc)
@@ -3804,6 +3917,10 @@ dfs_getxattr(dfs_t *dfs, dfs_obj_t *obj, const char *name, void *value,
 	if (dfs == NULL || !dfs->mounted)
 		return EINVAL;
 	if (obj == NULL)
+		return EINVAL;
+	if (name == NULL)
+		return EINVAL;
+	if (strnlen(name, DFS_MAX_XATTR_NAME + 1) > DFS_MAX_XATTR_NAME)
 		return EINVAL;
 
 	rc = check_access(dfs, geteuid(), getegid(), obj->mode, R_OK);
@@ -3879,6 +3996,10 @@ dfs_removexattr(dfs_t *dfs, dfs_obj_t *obj, const char *name)
 		return EPERM;
 	if (obj == NULL)
 		return EINVAL;
+	if (name == NULL)
+		return EINVAL;
+	if (strnlen(name, DFS_MAX_XATTR_NAME + 1) > DFS_MAX_XATTR_NAME)
+		return EINVAL;
 
 	rc = check_access(dfs, geteuid(), getegid(), obj->mode, W_OK);
 	if (rc)
@@ -3945,7 +4066,7 @@ dfs_listxattr(dfs_t *dfs, dfs_obj_t *obj, char *list, daos_size_t *size)
 		uint32_t	number = ENUM_DESC_NR;
 		uint32_t	i;
 		d_iov_t		iov;
-		char		enum_buf[ENUM_DESC_BUF] = {0};
+		char		enum_buf[ENUM_XDESC_BUF] = {0};
 		d_sg_list_t	sgl;
 		char		*ptr;
 

--- a/src/include/daos_fs.h
+++ b/src/include/daos_fs.h
@@ -44,6 +44,11 @@ extern "C" {
 /** Maximum file size */
 #define DFS_MAX_FSIZE		(~0ULL)
 
+/** Maximum xattr name */
+#define DFS_MAX_XATTR_NAME	255
+/** Maximum xattr value */
+#define DFS_MAX_XATTR_LEN	65536
+
 /** File/Directory/Symlink object handle struct */
 typedef struct dfs_obj dfs_obj_t;
 /** DFS mount handle struct */


### PR DESCRIPTION
- add some limitations to the xattr name (255) and xattr size (64 k)
- copy the extended attribute when it's renamed

Signed-off-by: Mohamad Chaarawi <mohamad.chaarawi@intel.com>