### PR TITLE
DAOS-5404 test: Fixed epoch calls in snapshot.py

### DIFF
--- a/src/tests/ftest/container/snapshot.py
+++ b/src/tests/ftest/container/snapshot.py
@@ -478,8 +478,8 @@ class Snapshot(TestWithServers):
             try:
                 snapshot.destroy(coh, snapshot.epoch)
                 self.log.info(
-                    "  ==snapshot.epoch %s successfully destroyed", 
-                    snapshot.epoch)
+                    "  ==snapshot.epoch %s successfully destroyed",
+                   snapshot.epoch)
             except Exception as error:
                 self.fail("##(6)Error on snapshot.destroy: {}"
                           .format(str(error)))

--- a/src/tests/ftest/container/snapshot.py
+++ b/src/tests/ftest/container/snapshot.py
@@ -474,11 +474,11 @@ class Snapshot(TestWithServers):
 
         #(6)Destroy the individual snapshot
             self.log.info("=(6.%s)Destroy the snapshot epoch: %s",
-                          ss_number, epoch)
+                          ss_number, snapshot.epoch)
             try:
-                snapshot.destroy(coh, epoch)
-                self.log.info("  ==snapshot epoch %s successfully destroyed",
-                              epoch)
+                snapshot.destroy(coh, snapshot.epoch)
+                self.log.info("  ==snapshot.epoch %s successfully destroyed",
+                             snapshot.epoch)
             except Exception as error:
                 self.fail("##(6)Error on snapshot.destroy: {}"
                           .format(str(error)))
@@ -500,8 +500,8 @@ class Snapshot(TestWithServers):
 
         #Still able to open the snapshot and read data after destroyed.
         try:
-            ss_list = snapshot.list(coh, epoch)
-            self.log.info("  -->snapshot.list(coh, epoch)= %s", ss_list)
+            ss_list = snapshot.list(coh, snapshot.epoch)
+            self.log.info("  -->snapshot.list(coh, snapshot.epoch)= %s", ss_list)
         except Exception as error:
             self.fail("##(7)Error when calling the snapshot list: {}"
                       .format(str(error)))

--- a/src/tests/ftest/container/snapshot.py
+++ b/src/tests/ftest/container/snapshot.py
@@ -479,7 +479,7 @@ class Snapshot(TestWithServers):
                 snapshot.destroy(coh, snapshot.epoch)
                 self.log.info(
                     "  ==snapshot.epoch %s successfully destroyed",
-                   snapshot.epoch)
+                    snapshot.epoch)
             except Exception as error:
                 self.fail("##(6)Error on snapshot.destroy: {}"
                           .format(str(error)))

--- a/src/tests/ftest/container/snapshot.py
+++ b/src/tests/ftest/container/snapshot.py
@@ -477,8 +477,9 @@ class Snapshot(TestWithServers):
                           ss_number, snapshot.epoch)
             try:
                 snapshot.destroy(coh, snapshot.epoch)
-                self.log.info("  ==snapshot.epoch %s successfully destroyed",
-                             snapshot.epoch)
+                self.log.info(
+                    "  ==snapshot.epoch %s successfully destroyed", 
+                    snapshot.epoch)
             except Exception as error:
                 self.fail("##(6)Error on snapshot.destroy: {}"
                           .format(str(error)))
@@ -501,7 +502,8 @@ class Snapshot(TestWithServers):
         #Still able to open the snapshot and read data after destroyed.
         try:
             ss_list = snapshot.list(coh, snapshot.epoch)
-            self.log.info("  -->snapshot.list(coh, snapshot.epoch)= %s", ss_list)
+            self.log.info(
+                "  -->snapshot.list(coh, snapshot.epoch)= %s", ss_list)
         except Exception as error:
             self.fail("##(7)Error when calling the snapshot list: {}"
                       .format(str(error)))

--- a/src/tests/ftest/container/snapshot.py
+++ b/src/tests/ftest/container/snapshot.py
@@ -314,7 +314,7 @@ class Snapshot(TestWithServers):
 
 
     def test_snapshots(self):
-        # pylint: disable=no-member
+        # pylint: disable=no-member,too-many-locals
         """
         Test ID: DAOS-1386 Test container SnapShot information
                  DAOS-1371 Test list snapshots

--- a/src/tests/ftest/container/snapshot.yaml
+++ b/src/tests/ftest/container/snapshot.yaml
@@ -12,7 +12,7 @@ server_config:
    name: daos_server
 pool:
     name: daos_server
-    scm_size: 107374182
+    scm_size: 128M
     control_method: dmg
 snapshot:
     dkey: "dkey"

--- a/src/tests/ftest/container/snapshot.yaml
+++ b/src/tests/ftest/container/snapshot.yaml
@@ -12,7 +12,7 @@ server_config:
    name: daos_server
 pool:
     name: daos_server
-    scm_size: 128M
+    scm_size: 1G
     control_method: dmg
 snapshot:
     dkey: "dkey"


### PR DESCRIPTION
Updated snapshot epoch calls that were missisng the underlying
snapshot object reference, including the log messages
associated with them.

Ex:
    destroy(coh, epoch) --> destroy(coh, snapshot.epoch)

Test-tag-hw-small: pr,hw,small snapshots
Signed-off-by: Anders Skaar <ajskaar@gmail.com>