### PR TITLE
DAOS-5843 vos: properly handle when hit non-committed DTX

### DIFF
--- a/src/include/daos/dtx.h
+++ b/src/include/daos/dtx.h
@@ -161,14 +161,15 @@ daos_dti_equal(struct dtx_id *dti0, struct dtx_id *dti1)
 #define DP_DTI(dti)	DP_UUID((dti)->dti_uuid), (dti)->dti_hlc
 
 enum daos_ops_intent {
-	DAOS_INTENT_DEFAULT	= 0,	/* fetch/enumerate/query */
-	DAOS_INTENT_PURGE	= 1,	/* purge/aggregation */
-	DAOS_INTENT_UPDATE	= 2,	/* write/insert */
-	DAOS_INTENT_PUNCH	= 3,	/* punch/delete */
-	DAOS_INTENT_REBUILD	= 4,	/* for rebuild related scan */
-	DAOS_INTENT_CHECK	= 5,	/* check aborted or not */
-	DAOS_INTENT_KILL	= 6,	/* delete object/key */
-	DAOS_INTENT_COS		= 7,	/* add something into CoS cache. */
+	DAOS_INTENT_DEFAULT		= 0, /* fetch/enumerate/query */
+	DAOS_INTENT_PURGE		= 1, /* purge/aggregation */
+	DAOS_INTENT_UPDATE		= 2, /* write/insert */
+	DAOS_INTENT_PUNCH		= 3, /* punch/delete */
+	DAOS_INTENT_REBUILD		= 4, /* for rebuild related scan */
+	DAOS_INTENT_CHECK		= 5, /* check aborted or not */
+	DAOS_INTENT_KILL		= 6, /* delete object/key */
+	DAOS_INTENT_COS			= 7, /* add something into CoS cache. */
+	DAOS_INTENT_IGNORE_NONCOMMITTED	= 8, /* ignore non-committed DTX. */
 };
 
 enum daos_dtx_alb {

--- a/src/vos/vos_dtx.c
+++ b/src/vos/vos_dtx.c
@@ -109,7 +109,7 @@ dtx_set_aborted(uint32_t *tx_lid)
 
 static inline int
 dtx_inprogress(struct vos_dtx_act_ent *dae, struct dtx_handle *dth,
-	       bool for_read)
+	       bool for_read, int pos)
 {
 	/* If the modifications crosses multiple redundancy groups, then it
 	 * is possible that the sub modifications on the DTX leader are not
@@ -130,8 +130,8 @@ dtx_inprogress(struct vos_dtx_act_ent *dae, struct dtx_handle *dth,
 		dth->dth_local_retry = 0;
 
 	D_DEBUG(DB_IO,
-		"Hit uncommitted DTX "DF_DTI" lid=%d, need %s retry\n",
-		DP_DTI(&DAE_XID(dae)), DAE_LID(dae),
+		"Hit uncommitted DTX "DF_DTI" at %d: lid=%d, need %s retry\n",
+		DP_DTI(&DAE_XID(dae)), pos, DAE_LID(dae),
 		(dth != NULL && dth->dth_local_retry) ? "local" : "remote");
 
 	return -DER_INPROGRESS;
@@ -1176,7 +1176,8 @@ vos_dtx_check_availability(daos_handle_t coh, uint32_t entry,
 
 	/* The following are for non-committable cases. */
 
-	if (intent == DAOS_INTENT_DEFAULT || intent == DAOS_INTENT_REBUILD) {
+	if (intent == DAOS_INTENT_DEFAULT || intent == DAOS_INTENT_REBUILD ||
+	    intent == DAOS_INTENT_IGNORE_NONCOMMITTED) {
 		if (!(DAE_FLAGS(dae) & DTE_LEADER) ||
 		    DAOS_FAIL_CHECK(DAOS_VOS_NON_LEADER)) {
 			/* Inavailable for rebuild case. */
@@ -1187,10 +1188,17 @@ vos_dtx_check_availability(daos_handle_t coh, uint32_t entry,
 			 * -DER_INPROGRESS, then the caller will retry
 			 * the RPC with leader replica.
 			 */
-			return dtx_inprogress(dae, dth, true);
+			return dtx_inprogress(dae, dth, true, 1);
 		}
 
-		/* For leader, non-committed DTX is unavailable. */
+		/* For transactional read, has to wait the non-committed
+		 * modification to guarantee the transaction semantics.
+		 */
+		if (dtx_is_valid_handle(dth) &&
+		    intent != DAOS_INTENT_IGNORE_NONCOMMITTED)
+			return dtx_inprogress(dae, dth, true, 2);
+
+		/* For stand-alone read on leader, ignore non-committed DTX. */
 		return ALB_UNAVAILABLE;
 	}
 
@@ -1210,7 +1218,7 @@ vos_dtx_check_availability(daos_handle_t coh, uint32_t entry,
 			 */
 			return ALB_UNAVAILABLE;
 
-		return dtx_inprogress(dae, dth, false);
+		return dtx_inprogress(dae, dth, false, 3);
 	}
 
 	D_ASSERTF(intent == DAOS_INTENT_UPDATE,


### PR DESCRIPTION
Before introducing distributed transaction, the DTX model
only considered stand-alone operation. For fetch operation,
if hit non-committed modification on the leader, it will be
regarded as that related modification happens concurrently
with the fetch operation, it is not guaranteed that such
modification is visible to the fetch. So the fetch will
ignore such non-committed modification.

But in distributed transaction case, things become different:
the transactional fetch needs to wait for such non-committed
modification (either committed or aborted) to guarantee the
transaction semantics.

This patch also defines a new vos operation intent:
DAOS_INTENT_IGNORE_NONCOMMITTED
It allows the sponsor to ignore non-committed DTX on leader
even if it is for transactional operation. The sponsor has
its own logic handle (find out) related non-committed DTX.

Signed-off-by: Fan Yong <fan.yong@intel.com>