### PR TITLE
DAOS-5835 bug: Zero-config test failing, can't find "client provided OFI_INTERFACE: %s" set

### DIFF
--- a/src/tests/ftest/network/zero_config.py
+++ b/src/tests/ftest/network/zero_config.py
@@ -145,6 +145,7 @@ class ZeroConfigTest(TestWithServers):
         # Add FI_LOG_LEVEL to get more info on device issues
         racer_env = daos_racer.get_environment(self.server_managers[0], logf)
         racer_env["FI_LOG_LEVEL"] = "info"
+        racer_env["D_LOG_MASK"] = "INFO,object=ERR,placement=ERR"
         daos_racer.set_environment(racer_env)
 
         # Run client

--- a/src/tests/ftest/network/zero_config.yaml
+++ b/src/tests/ftest/network/zero_config.yaml
@@ -22,7 +22,7 @@ dmg:
   transport_config:
     allow_insecure: True
 daos_racer:
-  runtime: 30
+  runtime: 20
   clush_timeout: 60
 zero_config: !mux
   set:


### PR DESCRIPTION
 Change D_LOG_MASK value to INFO for the zero-config test.

Signed-off-by: Justiniano-pagn <amanda.justiniano-pagn@intel.com>