### PR TITLE
DAOS-5840 vos: Fix a potential segfault in vos_obj_query_key

### DIFF
--- a/src/vos/vos_query.c
+++ b/src/vos/vos_query.c
@@ -311,8 +311,8 @@ vos_obj_query_key(daos_handle_t coh, daos_unit_oid_t oid, uint32_t flags,
 	daos_anchor_t		 akey_anchor;
 	daos_ofeat_t		 obj_feats;
 	daos_epoch_range_t	 obj_epr = {0};
-	struct vos_ts_state	 akey_save = {0};
-	struct vos_ts_state	 dkey_save = {0};
+	struct vos_ts_set	 akey_save = {0};
+	struct vos_ts_set	 dkey_save = {0};
 	uint32_t		 cflags = 0;
 	int			 rc = 0;
 	int			 nr_akeys = 0;

--- a/src/vos/vos_query.c
+++ b/src/vos/vos_query.c
@@ -311,8 +311,8 @@ vos_obj_query_key(daos_handle_t coh, daos_unit_oid_t oid, uint32_t flags,
 	daos_anchor_t		 akey_anchor;
 	daos_ofeat_t		 obj_feats;
 	daos_epoch_range_t	 obj_epr = {0};
-	int			 akey_save = 0;
-	int			 dkey_save = 0;
+	struct vos_ts_state	 akey_save = {0};
+	struct vos_ts_state	 dkey_save = {0};
 	uint32_t		 cflags = 0;
 	int			 rc = 0;
 	int			 nr_akeys = 0;
@@ -469,7 +469,7 @@ vos_obj_query_key(daos_handle_t coh, daos_unit_oid_t oid, uint32_t flags,
 					vos_ts_set_update(query.qt_ts_set,
 							  obj_epr.epr_hi);
 					vos_ts_set_restore(query.qt_ts_set,
-							   akey_save);
+							   &akey_save);
 					continue;
 				}
 			}
@@ -479,7 +479,7 @@ vos_obj_query_key(daos_handle_t coh, daos_unit_oid_t oid, uint32_t flags,
 		    query.qt_flags & VOS_GET_DKEY) {
 			/** Go ahead and save timestamps for things we read */
 			vos_ts_set_update(query.qt_ts_set, obj_epr.epr_hi);
-			vos_ts_set_restore(query.qt_ts_set, dkey_save);
+			vos_ts_set_restore(query.qt_ts_set, &dkey_save);
 			continue;
 		}
 		break;

--- a/src/vos/vos_ts.h
+++ b/src/vos/vos_ts.h
@@ -727,18 +727,25 @@ vos_ts_set_update(struct vos_ts_set *ts_set, daos_epoch_t read_time)
 	}
 }
 
+/** Struct for saving state of timestamp set */
+struct vos_ts_state {
+	uint32_t	ts_etype;
+	int		ts_count;
+};
+
 /** Save the current state of the set
  *
  * \param[in]	ts_set	The timestamp set
  * \param[out]	statep	Target to save state to
  */
 static inline void
-vos_ts_set_save(struct vos_ts_set *ts_set, int *statep)
+vos_ts_set_save(struct vos_ts_set *ts_set, struct vos_ts_state *state)
 {
 	if (ts_set == NULL)
 		return;
 
-	*statep = ts_set->ts_init_count;
+	state->ts_count = ts_set->ts_init_count;
+	state->ts_etype = ts_set->ts_etype;
 }
 
 /** Restore previously saved state of the set
@@ -747,11 +754,12 @@ vos_ts_set_save(struct vos_ts_set *ts_set, int *statep)
  * \param[in]	state	The saved state
  */
 static inline void
-vos_ts_set_restore(struct vos_ts_set *ts_set, int state)
+vos_ts_set_restore(struct vos_ts_set *ts_set, const struct vos_ts_state *state)
 {
 	if (ts_set == NULL)
 		return;
 
-	ts_set->ts_init_count = state;
+	ts_set->ts_etype = state->ts_etype;
+	ts_set->ts_init_count = state->ts_count;
 }
 #endif /* __VOS_TS__ */

--- a/src/vos/vos_ts.h
+++ b/src/vos/vos_ts.h
@@ -727,39 +727,31 @@ vos_ts_set_update(struct vos_ts_set *ts_set, daos_epoch_t read_time)
 	}
 }
 
-/** Struct for saving state of timestamp set */
-struct vos_ts_state {
-	uint32_t	ts_etype;
-	int		ts_count;
-};
-
 /** Save the current state of the set
  *
  * \param[in]	ts_set	The timestamp set
- * \param[out]	state	Target to save state to
+ * \param[out]	save	Target to save state to
  */
 static inline void
-vos_ts_set_save(struct vos_ts_set *ts_set, struct vos_ts_state *state)
+vos_ts_set_save(struct vos_ts_set *ts_set, struct vos_ts_set *save)
 {
 	if (ts_set == NULL)
 		return;
 
-	state->ts_count = ts_set->ts_init_count;
-	state->ts_etype = ts_set->ts_etype;
+	*save = *ts_set;
 }
 
 /** Restore previously saved state of the set
  *
  * \param[in]	ts_set	The timestamp set
- * \param[in]	state	The saved state
+ * \param[in]	restore	The saved state
  */
 static inline void
-vos_ts_set_restore(struct vos_ts_set *ts_set, const struct vos_ts_state *state)
+vos_ts_set_restore(struct vos_ts_set *ts_set, const struct vos_ts_set *restore)
 {
 	if (ts_set == NULL)
 		return;
 
-	ts_set->ts_etype = state->ts_etype;
-	ts_set->ts_init_count = state->ts_count;
+	*ts_set = *restore;
 }
 #endif /* __VOS_TS__ */

--- a/src/vos/vos_ts.h
+++ b/src/vos/vos_ts.h
@@ -736,7 +736,7 @@ struct vos_ts_state {
 /** Save the current state of the set
  *
  * \param[in]	ts_set	The timestamp set
- * \param[out]	statep	Target to save state to
+ * \param[out]	state	Target to save state to
  */
 static inline void
 vos_ts_set_save(struct vos_ts_set *ts_set, struct vos_ts_state *state)


### PR DESCRIPTION
This causes daos_test -D to segfault if few servers are used.
The issue happens when a key query encounters a punched range
in the latest dkey and thus has to revert to a prior dkey.

Signed-off-by: Jeff Olivier <jeffrey.v.olivier@intel.com>