### PR TITLE
DAOS-3911 dtx: distributed transaction recovery

### DIFF
--- a/src/dtx/dtx_internal.h
+++ b/src/dtx/dtx_internal.h
@@ -111,11 +111,11 @@ int dtx_del_cos(struct ds_cont_child *cont, struct dtx_id *xid,
 uint64_t dtx_cos_oldest(struct ds_cont_child *cont);
 
 /* dtx_rpc.c */
-int dtx_commit(uuid_t po_uuid, uuid_t co_uuid, struct dtx_entry **dtes,
+int dtx_commit(struct ds_cont_child *cont, struct dtx_entry **dtes,
 	       int count, bool drop_cos);
-int dtx_abort(uuid_t po_uuid, uuid_t co_uuid, daos_epoch_t epoch,
+int dtx_abort(struct ds_cont_child *cont, daos_epoch_t epoch,
 	      struct dtx_entry **dtes, int count);
-int dtx_check(uuid_t po_uuid, uuid_t co_uuid, struct dtx_entry *dte);
-
+int dtx_check(struct ds_cont_child *cont, struct dtx_entry *dte,
+	      daos_epoch_t epoch);
 
 #endif /* __DTX_INTERNAL_H__ */

--- a/src/dtx/dtx_rpc.c
+++ b/src/dtx/dtx_rpc.c
@@ -86,6 +86,7 @@ struct dtx_req_rec {
 	struct dtx_req_args		*drr_parent; /* The top level args */
 	d_rank_t			 drr_rank; /* The server ID */
 	uint32_t			 drr_tag; /* The VOS ID */
+	uint32_t			 drr_flags; /* The flags. */
 	int				 drr_count; /* DTX count */
 	int				 drr_result; /* The RPC result */
 	struct dtx_id			*drr_dti; /* The DTX array */
@@ -164,7 +165,10 @@ dtx_req_send(struct dtx_req_rec *drr, daos_epoch_t epoch)
 		din = crt_req_get(req);
 		uuid_copy(din->di_po_uuid, dra->dra_po_uuid);
 		uuid_copy(din->di_co_uuid, dra->dra_co_uuid);
-		din->di_epoch = epoch;
+		if (dra->dra_opc == DTX_CHECK && !(drr->drr_flags & DTF_RDONLY))
+			din->di_epoch = 0;
+		else
+			din->di_epoch = epoch;
 		din->di_dtx_array.ca_count = drr->drr_count;
 		din->di_dtx_array.ca_arrays = drr->drr_dti;
 
@@ -444,18 +448,14 @@ dtx_dti_classify_one(struct ds_pool *pool, daos_handle_t tree, d_list_t *head,
 }
 
 static int
-dtx_dti_classify(uuid_t po_uuid, daos_handle_t tree, struct dtx_entry **dtes,
-		 int count, d_list_t *head, struct dtx_id **dtis)
+dtx_dti_classify(struct ds_pool *pool, daos_handle_t tree,
+		 struct dtx_entry **dtes, int count,
+		 d_list_t *head, struct dtx_id **dtis)
 {
 	struct dtx_id		*dti = NULL;
-	struct ds_pool		*pool;
 	int			 length = 0;
 	int			 rc = 0;
 	int			 i;
-
-	pool = ds_pool_lookup(po_uuid);
-	if (pool == NULL)
-		return -DER_INVAL;
 
 	D_ALLOC_ARRAY(dti, count);
 	if (dti != NULL) {
@@ -476,7 +476,6 @@ dtx_dti_classify(uuid_t po_uuid, daos_handle_t tree, struct dtx_entry **dtes,
 		rc = -DER_NOMEM;
 	}
 
-	ds_pool_put(pool);
 	return rc < 0 ? rc : length;
 }
 
@@ -495,11 +494,11 @@ dtx_dti_classify(uuid_t po_uuid, daos_handle_t tree, struct dtx_entry **dtes,
  * targets when dtx_resync() is triggered next time.
  */
 int
-dtx_commit(uuid_t po_uuid, uuid_t co_uuid, struct dtx_entry **dtes,
+dtx_commit(struct ds_cont_child *cont, struct dtx_entry **dtes,
 	   int count, bool drop_cos)
 {
 	struct dtx_req_args	 dra;
-	struct ds_cont_child	*cont = NULL;
+	struct ds_pool		*pool = cont->sc_pool->spc_pool;
 	struct dtx_id		*dti = NULL;
 	struct dtx_cos_key	*dcks = NULL;
 	struct umem_attr	 uma;
@@ -511,10 +510,6 @@ dtx_commit(uuid_t po_uuid, uuid_t co_uuid, struct dtx_entry **dtes,
 	int			 rc1 = 0;
 	int			 rc2 = 0;
 
-	rc = ds_cont_child_lookup(po_uuid, co_uuid, &cont);
-	if (rc != 0)
-		return rc;
-
 	D_INIT_LIST_HEAD(&head);
 	memset(&uma, 0, sizeof(uma));
 	uma.uma_id = UMEM_CLASS_VMEM;
@@ -523,14 +518,14 @@ dtx_commit(uuid_t po_uuid, uuid_t co_uuid, struct dtx_entry **dtes,
 	if (rc != 0)
 		goto out;
 
-	length = dtx_dti_classify(po_uuid, tree_hdl, dtes, count, &head, &dti);
+	length = dtx_dti_classify(pool, tree_hdl, dtes, count, &head, &dti);
 	if (length < 0)
 		D_GOTO(out, rc = length);
 
 	dra.dra_future = ABT_FUTURE_NULL;
 	if (!d_list_empty(&head)) {
-		rc = dtx_req_list_send(&dra, DTX_COMMIT, &head, length, po_uuid,
-				       co_uuid, crt_hlc_get());
+		rc = dtx_req_list_send(&dra, DTX_COMMIT, &head, length,
+				       pool->sp_uuid, cont->sc_uuid, 0);
 		if (rc != 0)
 			goto out;
 	}
@@ -577,18 +572,15 @@ out:
 
 	D_ASSERT(d_list_empty(&head));
 
-	if (cont != NULL)
-		ds_cont_child_put(cont);
-
 	return rc < 0 ? rc : (rc1 < 0 ? rc1 : (rc2 < 0 ? rc2 : 0));
 }
 
 int
-dtx_abort(uuid_t po_uuid, uuid_t co_uuid, daos_epoch_t epoch,
+dtx_abort(struct ds_cont_child *cont, daos_epoch_t epoch,
 	  struct dtx_entry **dtes, int count)
 {
 	struct dtx_req_args	 dra;
-	struct ds_cont_child	*cont = NULL;
+	struct ds_pool		*pool = cont->sc_pool->spc_pool;
 	struct dtx_id		*dti = NULL;
 	struct umem_attr	 uma;
 	struct btr_root		 tree_root = { 0 };
@@ -596,10 +588,6 @@ dtx_abort(uuid_t po_uuid, uuid_t co_uuid, daos_epoch_t epoch,
 	d_list_t		 head;
 	int			 length;
 	int			 rc;
-
-	rc = ds_cont_child_lookup(po_uuid, co_uuid, &cont);
-	if (rc != 0)
-		return rc;
 
 	D_INIT_LIST_HEAD(&head);
 	memset(&uma, 0, sizeof(uma));
@@ -609,7 +597,7 @@ dtx_abort(uuid_t po_uuid, uuid_t co_uuid, daos_epoch_t epoch,
 	if (rc != 0)
 		goto out;
 
-	length = dtx_dti_classify(po_uuid, tree_hdl, dtes, count, &head, &dti);
+	length = dtx_dti_classify(pool, tree_hdl, dtes, count, &head, &dti);
 	if (length < 0)
 		D_GOTO(out, rc = length);
 
@@ -621,8 +609,8 @@ dtx_abort(uuid_t po_uuid, uuid_t co_uuid, daos_epoch_t epoch,
 		rc = 0;
 
 	if (rc == 0 && !d_list_empty(&head)) {
-		rc = dtx_req_list_send(&dra, DTX_ABORT, &head, length, po_uuid,
-				       co_uuid, epoch);
+		rc = dtx_req_list_send(&dra, DTX_ABORT, &head, length,
+				       pool->sp_uuid, cont->sc_uuid, epoch);
 		if (rc != 0)
 			goto out;
 
@@ -643,18 +631,15 @@ out:
 
 	D_ASSERT(d_list_empty(&head));
 
-	if (cont != NULL)
-		ds_cont_child_put(cont);
-
 	return rc < 0 ? rc : 0;
 }
 
 int
-dtx_check(uuid_t po_uuid, uuid_t co_uuid, struct dtx_entry *dte)
+dtx_check(struct ds_cont_child *cont, struct dtx_entry *dte, daos_epoch_t epoch)
 {
 	struct dtx_req_args	 dra;
 	struct dtx_memberships	*mbs = dte->dte_mbs;
-	struct ds_pool		*pool;
+	struct ds_pool		*pool = cont->sc_pool->spc_pool;
 	struct dtx_req_rec	*drr;
 	struct dtx_req_rec	*next;
 	d_list_t		 head;
@@ -671,10 +656,6 @@ dtx_check(uuid_t po_uuid, uuid_t co_uuid, struct dtx_entry *dte)
 	 */
 	if (mbs->dm_tgt_cnt == 1)
 		return DTX_ST_PREPARED;
-
-	pool = ds_pool_lookup(po_uuid);
-	if (pool == NULL)
-		return -DER_INVAL;
 
 	D_INIT_LIST_HEAD(&head);
 	crt_group_rank(NULL, &myrank);
@@ -708,6 +689,7 @@ dtx_check(uuid_t po_uuid, uuid_t co_uuid, struct dtx_entry *dte)
 
 		drr->drr_rank = target->ta_comp.co_rank;
 		drr->drr_tag = target->ta_comp.co_index;
+		drr->drr_flags = mbs->dm_tgts[i].ddt_flags;
 		drr->drr_count = 1;
 		drr->drr_dti = &dte->dte_xid;
 		d_list_add_tail(&drr->drr_link, &head);
@@ -722,8 +704,8 @@ dtx_check(uuid_t po_uuid, uuid_t co_uuid, struct dtx_entry *dte)
 		goto out;
 	}
 
-	rc = dtx_req_list_send(&dra, DTX_CHECK, &head, length, po_uuid,
-			       co_uuid, crt_hlc_get());
+	rc = dtx_req_list_send(&dra, DTX_CHECK, &head, length, pool->sp_uuid,
+			       cont->sc_uuid, epoch);
 	if (rc == 0)
 		rc = dtx_req_wait(&dra);
 
@@ -733,6 +715,5 @@ out:
 		D_FREE_PTR(drr);
 	}
 
-	ds_pool_put(pool);
 	return rc;
 }

--- a/src/include/daos/dtx.h
+++ b/src/include/daos/dtx.h
@@ -137,8 +137,12 @@ struct dtx_memberships {
 	/* see dtx_mbs_flags. */
 	uint16_t			dm_flags;
 
-	/* For alignment. */
-	uint16_t			dm_padding;
+	union {
+		/* DTX entry flags during DTX recovery. */
+		uint16_t		dm_dte_flags;
+		/* For alignment. */
+		uint16_t		dm_padding;
+	};
 
 	/* The first 'sizeof(struct dtx_daos_target) * dm_tgt_cnt' is the
 	 * dtx_daos_target array. The subsequent are modification groups.

--- a/src/include/daos_srv/dtx_srv.h
+++ b/src/include/daos_srv/dtx_srv.h
@@ -195,8 +195,8 @@ int dtx_batched_commit_register(struct ds_cont_child *cont);
 
 void dtx_batched_commit_deregister(struct ds_cont_child *cont);
 
-int dtx_obj_sync(uuid_t po_uuid, uuid_t co_uuid, struct ds_cont_child *cont,
-		 daos_unit_oid_t *oid, daos_epoch_t epoch);
+int dtx_obj_sync(struct ds_cont_child *cont, daos_unit_oid_t *oid,
+		 daos_epoch_t epoch);
 
 /**
  * Check whether the given DTX is resent one or not.

--- a/src/include/daos_srv/pool.h
+++ b/src/include/daos_srv/pool.h
@@ -209,8 +209,8 @@ int ds_pool_iv_srv_hdl_fetch(struct ds_pool *pool, uuid_t *pool_hdl_uuid,
 
 int ds_pool_svc_term_get(uuid_t uuid, uint64_t *term);
 
-int ds_pool_check_leader(uuid_t pool_uuid, daos_unit_oid_t *oid,
-			 uint32_t version);
+int ds_pool_check_dtx_leader(struct ds_pool *pool, daos_unit_oid_t *oid,
+			     uint32_t version);
 
 int
 ds_pool_child_map_refresh_sync(struct ds_pool_child *dpc);

--- a/src/object/srv_obj.c
+++ b/src/object/srv_obj.c
@@ -3018,8 +3018,7 @@ ds_obj_sync_handler(crt_rpc_t *rpc)
 	if (rc != 0)
 		D_GOTO(out, rc);
 
-	rc = dtx_obj_sync(osi->osi_pool_uuid, osi->osi_co_uuid, ioc.ioc_coc,
-			  &osi->osi_oid, oso->oso_epoch);
+	rc = dtx_obj_sync(ioc.ioc_coc, &osi->osi_oid, oso->oso_epoch);
 
 out:
 	obj_reply_map_version_set(rpc, ioc.ioc_map_ver);


### PR DESCRIPTION
Enhance current DTX resync (recovery) logic to support distributed
transaction recovery. Mainly include:

1. The initial leader information is stored inside the DTX entry,
   Different from stand-alone modification, it is not calculated
   from the object layout. The DTX resync (recovery) logic needs
   to check whether the initial leader is still alive or not: if
   yes, then leave such DTX to be handled by the initial leader;
   otherwise, elect new leader as stand-alone modification case.

2. Redundancy group verification. A distributed transaction may
   touch many objects/keys that may cross multiple RDGs. During
   DTX recovery, if some RDG(s) lost too many members, then the
   DTX logic may not have enough knowledge to make the decision
   whether commit or abort related DTX.

Signed-off-by: Fan Yong <fan.yong@intel.com>