### PR TITLE
DAOS-5855 dfuse: Use a smaller value for max_write.

### DIFF
--- a/src/client/dfuse/dfuse_core.c
+++ b/src/client/dfuse/dfuse_core.c
@@ -282,7 +282,7 @@ dfuse_start(struct dfuse_info *dfuse_info, struct dfuse_dfs *dfs)
 	 * the interception library handles reads vs writes
 	 */
 	fs_handle->dpi_max_read = 1024 * 1024 * 4;
-	fs_handle->dpi_max_write = 1024 * 1024 * 4;
+	fs_handle->dpi_max_write = 1024 * 1024;
 
 	rc = d_hash_table_create_inplace(D_HASH_FT_RWLOCK | D_HASH_FT_EPHEMERAL,
 					 3, fs_handle, &ie_hops,

--- a/src/client/dfuse/dfuse_fuseops.c
+++ b/src/client/dfuse/dfuse_fuseops.c
@@ -79,7 +79,7 @@ dfuse_fuse_init(void *arg, struct fuse_conn_info *conn)
 	 * set it before reporting the value.
 	 */
 	conn->max_read = fs_handle->dpi_max_read;
-	conn->max_write = fs_handle->dpi_max_read;
+	conn->max_write = fs_handle->dpi_max_write;
 
 	DFUSE_TRA_INFO(fs_handle, "max read %#x", conn->max_read);
 	DFUSE_TRA_INFO(fs_handle, "max write %#x", conn->max_write);


### PR DESCRIPTION
Workaround a bug in libfuse by using a value for max_write
which is smaller than the libfuse buffer size.

The kernel imposes an additional limit of 128k transfers anyway, so
there's no performance impact of this.

Signed-off-by: Ashley Pittman <ashley.m.pittman@intel.com>