### PR TITLE
DAOS-4449 control: Handle no output from fault domain CB

### DIFF
--- a/src/control/fault/code/codes.go
+++ b/src/control/fault/code/codes.go
@@ -139,6 +139,7 @@ const (
 	ServerConfigFaultCallbackBadPerms
 	ServerConfigFaultCallbackFailed
 	ServerConfigBothFaultPathAndCb
+	ServerConfigFaultCallbackEmpty
 
 	// spdk library bindings codes
 	SpdkUnknown Code = iota + 700

--- a/src/control/server/faultdomain.go
+++ b/src/control/server/faultdomain.go
@@ -92,5 +92,14 @@ func getFaultDomainFromCallback(callbackPath string) (*system.FaultDomain, error
 		return nil, FaultConfigFaultCallbackFailed(err)
 	}
 
-	return newFaultDomainFromConfig(string(output))
+	fd, err := newFaultDomainFromConfig(string(output))
+	if err != nil {
+		return nil, err
+	}
+
+	if fd.Empty() {
+		return nil, FaultConfigFaultCallbackEmpty
+	}
+
+	return fd, nil
 }

--- a/src/control/server/faultdomain.go
+++ b/src/control/server/faultdomain.go
@@ -26,6 +26,7 @@ package server
 import (
 	"os"
 	"os/exec"
+	"strings"
 
 	"github.com/pkg/errors"
 	"golang.org/x/sys/unix"
@@ -92,14 +93,10 @@ func getFaultDomainFromCallback(callbackPath string) (*system.FaultDomain, error
 		return nil, FaultConfigFaultCallbackFailed(err)
 	}
 
-	fd, err := newFaultDomainFromConfig(string(output))
-	if err != nil {
-		return nil, err
-	}
-
-	if fd.Empty() {
+	trimmedOutput := strings.TrimSpace(string(output))
+	if trimmedOutput == "" {
 		return nil, FaultConfigFaultCallbackEmpty
 	}
 
-	return fd, nil
+	return newFaultDomainFromConfig(trimmedOutput)
 }

--- a/src/control/server/faultdomain_test.go
+++ b/src/control/server/faultdomain_test.go
@@ -187,6 +187,9 @@ func TestServer_getFaultDomainFromCallback(t *testing.T) {
 	emptyScriptPath := filepath.Join(tmpDir, "empty.sh")
 	createFaultCBScriptFile(t, emptyScriptPath, 0755, "")
 
+	whitespaceScriptPath := filepath.Join(tmpDir, "whitespace.sh")
+	createFaultCBScriptFile(t, whitespaceScriptPath, 0755, "     ")
+
 	invalidScriptPath := filepath.Join(tmpDir, "invalid.sh")
 	createFaultCBScriptFile(t, invalidScriptPath, 0755, "some junk")
 
@@ -214,8 +217,12 @@ func TestServer_getFaultDomainFromCallback(t *testing.T) {
 			input:  errorScriptPath,
 			expErr: FaultConfigFaultCallbackFailed(errors.New("exit status 2")),
 		},
-		"script returned no fault domain": {
+		"script returned no output": {
 			input:  emptyScriptPath,
+			expErr: FaultConfigFaultCallbackEmpty,
+		},
+		"script returned only whitespace": {
+			input:  whitespaceScriptPath,
 			expErr: FaultConfigFaultCallbackEmpty,
 		},
 		"script returned invalid fault domain": {

--- a/src/control/server/faultdomain_test.go
+++ b/src/control/server/faultdomain_test.go
@@ -184,6 +184,9 @@ func TestServer_getFaultDomainFromCallback(t *testing.T) {
 	errorScriptPath := filepath.Join(tmpDir, "fail.sh")
 	createErrorScriptFile(t, errorScriptPath)
 
+	emptyScriptPath := filepath.Join(tmpDir, "empty.sh")
+	createFaultCBScriptFile(t, emptyScriptPath, 0755, "")
+
 	invalidScriptPath := filepath.Join(tmpDir, "invalid.sh")
 	createFaultCBScriptFile(t, invalidScriptPath, 0755, "some junk")
 
@@ -210,6 +213,10 @@ func TestServer_getFaultDomainFromCallback(t *testing.T) {
 		"error within the script": {
 			input:  errorScriptPath,
 			expErr: FaultConfigFaultCallbackFailed(errors.New("exit status 2")),
+		},
+		"script returned no fault domain": {
+			input:  emptyScriptPath,
+			expErr: FaultConfigFaultCallbackEmpty,
 		},
 		"script returned invalid fault domain": {
 			input:  invalidScriptPath,

--- a/src/control/server/faults.go
+++ b/src/control/server/faults.go
@@ -110,6 +110,11 @@ var (
 		"both fault domain and fault path are defined in the configuration",
 		"remove either the fault domain ('fault_path' parameter) or callback script ('fault_cb' parameter) and restart the control server",
 	)
+	FaultConfigFaultCallbackEmpty = serverFault(
+		code.ServerConfigFaultCallbackEmpty,
+		"fault domain callback executed but did not generate output",
+		"specify a valid fault domain callback script ('fault_cb' parameter) and restart the control server",
+	)
 )
 
 func FaultInstancesNotStopped(action string, rank system.Rank) *fault.Fault {


### PR DESCRIPTION
Catch the error case where the fault domain callback script
executes, but generates either no output, or only whitespace.

Signed-off-by: Kris Jacque <kristin.jacque@intel.com>