### PR TITLE
DAOS-5313 container: add retry for snapshot fetch

### DIFF
--- a/src/container/container_iv.c
+++ b/src/container/container_iv.c
@@ -16,8 +16,8 @@
 #include <daos/dtx.h>
 #include <daos_api.h>
 
-/* XXX Temporary limit for IV */
-#define MAX_SNAP_CNT	50
+/* INIT snap count */
+#define INIT_SNAP_CNT	10
 
 static struct cont_iv_key *
 key2priv(struct ds_iv_key *iv_key)
@@ -31,59 +31,10 @@ cont_iv_snap_ent_size(int nr)
 	return offsetof(struct cont_iv_entry, iv_snap.snaps[nr]);
 }
 
-static int
-cont_iv_snap_alloc_internal(d_sg_list_t *sgl)
-{
-	struct cont_iv_entry	*entry;
-	int			entry_size;
-	int			rc;
-
-	rc = d_sgl_init(sgl, 1);
-	if (rc)
-		return rc;
-
-	/* FIXME: allocate entry by the real size */
-	entry_size = cont_iv_snap_ent_size(MAX_SNAP_CNT);
-	D_ALLOC(entry, entry_size);
-	if (entry == NULL)
-		D_GOTO(out, rc = -DER_NOMEM);
-
-	d_iov_set(&sgl->sg_iovs[0], entry, entry_size);
-out:
-	if (rc)
-		d_sgl_fini(sgl, true);
-
-	return rc;
-}
-
 static uint32_t
 cont_iv_prop_ent_size(int nr)
 {
 	return offsetof(struct cont_iv_entry, iv_prop.cip_acl.dal_ace[nr]);
-}
-
-static int
-cont_iv_prop_alloc_internal(d_sg_list_t *sgl)
-{
-	struct cont_iv_entry	*entry;
-	int			entry_size;
-	int			rc;
-
-	rc = d_sgl_init(sgl, 1);
-	if (rc)
-		return rc;
-
-	entry_size = cont_iv_prop_ent_size(DAOS_ACL_MAX_ACE_LEN);
-	D_ALLOC(entry, entry_size);
-	if (entry == NULL)
-		D_GOTO(out, rc = -DER_NOMEM);
-
-	d_iov_set(&sgl->sg_iovs[0], entry, entry_size);
-out:
-	if (rc)
-		d_sgl_fini(sgl, true);
-
-	return rc;
 }
 
 static int
@@ -188,35 +139,57 @@ cont_iv_ent_destroy(d_sg_list_t *sgl)
 }
 
 static int
-cont_iv_ent_copy(struct ds_iv_entry *entry, d_sg_list_t *dst_sgl,
-		 struct cont_iv_entry *src)
+cont_iv_ent_copy(struct ds_iv_entry *entry, struct cont_iv_key *key,
+		 d_sg_list_t *dst_sgl, struct cont_iv_entry *src)
 {
-	struct cont_iv_entry *dst = dst_sgl->sg_iovs[0].iov_buf;
+	struct cont_iv_entry	*dst = dst_sgl->sg_iovs[0].iov_buf;
+	daos_size_t		size;
+	uint64_t		snap_cnt;
+	int			rc = 0;
 
 	uuid_copy(dst->cont_uuid, src->cont_uuid);
 	switch (entry->iv_class->iv_class_id) {
 	case IV_CONT_SNAP:
-		D_ASSERT(src->iv_snap.snap_cnt <= MAX_SNAP_CNT);
+		if (src->iv_snap.snap_cnt == (uint64_t)(-1)) {
+			snap_cnt = 1;
+			rc = -DER_IVCB_FORWARD;
+		} else {
+			snap_cnt = src->iv_snap.snap_cnt;
+		}
 
-		dst->iv_snap.snap_cnt = src->iv_snap.snap_cnt;
-		memcpy(dst->iv_snap.snaps, src->iv_snap.snaps,
-		       src->iv_snap.snap_cnt * sizeof(src->iv_snap.snaps[0]));
+		D_DEBUG(DB_MD, "snap_cnt "DF_U64":"DF_U64"\n",
+			snap_cnt, src->iv_snap.snap_cnt);
+		size = cont_iv_snap_ent_size(snap_cnt);
+		if (size > dst_sgl->sg_iovs[0].iov_buf_len) {
+			/* Return -1 so client can reallocate the buffer. */
+			dst->iv_snap.snap_cnt = (uint64_t)-1;
+			dst->iv_snap.snaps[0] = src->iv_snap.snap_cnt;
+			D_DEBUG(DB_MD, "%zd < %zd\n",
+				dst_sgl->sg_iovs[0].iov_buf_len, size);
+			return 0;
+		}
+
+		size = offsetof(struct cont_iv_snapshot, snaps[snap_cnt]);
+		memcpy(&dst->iv_snap, &src->iv_snap, size);
+
 		break;
 	case IV_CONT_CAPA:
 		dst->iv_capa.flags = src->iv_capa.flags;
 		dst->iv_capa.sec_capas = src->iv_capa.sec_capas;
 		break;
 	case IV_CONT_PROP:
-		memcpy(&dst->iv_prop, &src->iv_prop,
-		       offsetof(struct cont_iv_prop,
-				cip_acl.dal_ace[src->iv_prop.cip_acl.dal_len]));
+		D_ASSERT(dst_sgl->sg_iovs[0].iov_buf_len >=
+			 cont_iv_prop_ent_size(src->iv_prop.cip_acl.dal_len));
+		size = offsetof(struct cont_iv_prop,
+				cip_acl.dal_ace[src->iv_prop.cip_acl.dal_len]);
+		memcpy(&dst->iv_prop, &src->iv_prop, size);
 		break;
 	default:
 		D_ERROR("bad iv_class_id %d.\n", entry->iv_class->iv_class_id);
 		return -DER_INVAL;
 	};
 
-	return 0;
+	return rc;
 }
 
 static bool
@@ -238,7 +211,7 @@ cont_iv_snap_ent_create(struct ds_iv_entry *entry, struct ds_iv_key *key)
 	d_iov_t			key_iov;
 	d_iov_t			val_iov;
 	daos_epoch_t		*snaps = NULL;
-	int			snap_cnt = MAX_SNAP_CNT;
+	int			snap_cnt = -1;
 	int			rc;
 
 	rc = ds_cont_get_snapshots(entry->ns->iv_pool_uuid,
@@ -247,6 +220,7 @@ cont_iv_snap_ent_create(struct ds_iv_entry *entry, struct ds_iv_key *key)
 	if (rc)
 		D_GOTO(out, rc);
 
+	D_ASSERT(snap_cnt >= 0);
 	D_ALLOC(iv_entry, cont_iv_snap_ent_size(snap_cnt));
 	if (iv_entry == NULL)
 		D_GOTO(out, rc = -DER_NOMEM);
@@ -258,7 +232,7 @@ cont_iv_snap_ent_create(struct ds_iv_entry *entry, struct ds_iv_key *key)
 	memcpy(iv_entry->iv_snap.snaps, snaps, snap_cnt * sizeof(*snaps));
 	d_iov_set(&val_iov, iv_entry,
 		  cont_iv_snap_ent_size(iv_entry->iv_snap.snap_cnt));
-	d_iov_set(&key_iov, civ_key, sizeof(*civ_key));
+	d_iov_set(&key_iov, &civ_key->cont_uuid, sizeof(civ_key->cont_uuid));
 	rc = dbtree_update(root_hdl, &key_iov, &val_iov);
 	if (rc)
 		D_GOTO(out, rc);
@@ -388,7 +362,7 @@ cont_iv_prop_ent_create(struct ds_iv_entry *entry, struct ds_iv_key *key)
 	uuid_copy(iv_entry->cont_uuid, civ_key->cont_uuid);
 	cont_iv_prop_l2g(prop, &iv_entry->iv_prop);
 	d_iov_set(&val_iov, iv_entry, entry_size);
-	d_iov_set(&key_iov, civ_key, sizeof(*civ_key));
+	d_iov_set(&key_iov, &civ_key->cont_uuid, sizeof(civ_key->cont_uuid));
 
 	rc = dbtree_update(root_hdl, &key_iov, &val_iov);
 	if (rc)
@@ -403,7 +377,7 @@ out:
 
 static int
 cont_iv_ent_fetch(struct ds_iv_entry *entry, struct ds_iv_key *key,
-		  d_sg_list_t *dst, d_sg_list_t *src, void **priv)
+		  d_sg_list_t *dst, void **priv)
 {
 	struct cont_iv_entry	*src_iv;
 	daos_handle_t		root_hdl;
@@ -413,9 +387,10 @@ cont_iv_ent_fetch(struct ds_iv_entry *entry, struct ds_iv_key *key,
 	int			rc;
 
 	D_ASSERT(dss_get_module_info()->dmi_xs_id == 0);
+
 	memcpy(&root_hdl, entry->iv_value.sg_iovs[0].iov_buf, sizeof(root_hdl));
 
-	d_iov_set(&key_iov, civ_key, sizeof(*civ_key));
+	d_iov_set(&key_iov, &civ_key->cont_uuid, sizeof(civ_key->cont_uuid));
 	d_iov_set(&val_iov, NULL, 0);
 again:
 	rc = dbtree_lookup(root_hdl, &key_iov, &val_iov);
@@ -446,25 +421,8 @@ again:
 	}
 
 	src_iv = val_iov.iov_buf;
-	rc = cont_iv_ent_copy(entry, dst, src_iv);
+	rc = cont_iv_ent_copy(entry, civ_key, dst, src_iv);
 out:
-	return rc;
-}
-
-static int
-cont_iv_capa_ent_update(struct ds_iv_entry *entry, struct ds_iv_key *key,
-			d_sg_list_t *src, void **priv)
-{
-	struct cont_iv_key	*civ_key = key2priv(key);
-	struct cont_iv_entry	*civ_ent;
-	int rc;
-
-	civ_ent = src->sg_iovs[0].iov_buf;
-	/* open the container locally */
-	rc = ds_cont_tgt_open(entry->ns->iv_pool_uuid,
-			      civ_key->cont_uuid, civ_ent->cont_uuid,
-			      civ_ent->iv_capa.flags,
-			      civ_ent->iv_capa.sec_capas);
 	return rc;
 }
 
@@ -515,52 +473,59 @@ cont_iv_ent_update(struct ds_iv_entry *entry, struct ds_iv_key *key,
 	struct cont_iv_key	*civ_key = key2priv(key);
 	d_iov_t			key_iov;
 	d_iov_t			val_iov;
-	int			rc;
+	int			rc = 0;
 
 	D_ASSERT(dss_get_module_info()->dmi_xs_id == 0);
 	if (src != NULL) {
-		if (entry->iv_class->iv_class_id == IV_CONT_CAPA) {
-			rc = cont_iv_capa_ent_update(entry, key, src, priv);
-			if (rc)
-				return rc;
-		} else if (entry->iv_class->iv_class_id == IV_CONT_SNAP) {
-			struct cont_iv_entry *civ_ent = src->sg_iovs[0].iov_buf;
+		struct cont_iv_entry *civ_ent;
 
+		civ_ent = src->sg_iovs[0].iov_buf;
+		if (entry->iv_class->iv_class_id == IV_CONT_CAPA) {
+			/* open the container locally */
+			rc = ds_cont_tgt_open(entry->ns->iv_pool_uuid,
+					      civ_key->cont_uuid,
+					      civ_ent->cont_uuid,
+					      civ_ent->iv_capa.flags,
+					      civ_ent->iv_capa.sec_capas);
+			if (rc)
+				D_GOTO(out, rc);
+		} else if (entry->iv_class->iv_class_id == IV_CONT_SNAP &&
+			   civ_ent->iv_snap.snap_cnt != (uint64_t)(-1)) {
 			rc = ds_cont_tgt_snapshots_update(
 						entry->ns->iv_pool_uuid,
 						civ_key->cont_uuid,
 						&civ_ent->iv_snap.snaps[0],
 						civ_ent->iv_snap.snap_cnt);
 			if (rc)
-				return rc;
+				D_GOTO(out, rc);
 		} else if (entry->iv_class->iv_class_id ==
 						IV_CONT_AGG_EPOCH_REPORT) {
 			rc = cont_iv_ent_agg_eph_update(entry, key, src);
 			if (rc)
-				return rc;
+				D_GOTO(out, rc);
 		} else if (entry->iv_class->iv_class_id ==
 						IV_CONT_AGG_EPOCH_BOUNDRY) {
 			rc = cont_iv_ent_agg_eph_refresh(entry, key, src);
 			if (rc)
-				return rc;
+				D_GOTO(out, rc);
 		}
 	}
 
 	memcpy(&root_hdl, entry->iv_value.sg_iovs[0].iov_buf, sizeof(root_hdl));
-	d_iov_set(&key_iov, civ_key, sizeof(*civ_key));
+	d_iov_set(&key_iov, &civ_key->cont_uuid, sizeof(civ_key->cont_uuid));
 	if (src == NULL) {
 		/* If src == NULL, it is invalidate */
 		if (entry->iv_class->iv_class_id == IV_CONT_CAPA &&
 		    !uuid_is_null(civ_key->cont_uuid)) {
 			rc = ds_cont_tgt_close(civ_key->cont_uuid);
 			if (rc)
-				return rc;
+				D_GOTO(out, rc);
 		}
 
 		if (uuid_is_null(civ_key->cont_uuid)) {
 			rc = dbtree_empty(root_hdl);
 			if (rc)
-				return rc;
+				D_GOTO(out, rc);
 		} else {
 			rc = dbtree_delete(root_hdl, BTR_PROBE_EQ, &key_iov,
 					   NULL);
@@ -568,13 +533,22 @@ cont_iv_ent_update(struct ds_iv_entry *entry, struct ds_iv_key *key,
 				rc = 0;
 		}
 	} else {
+		struct cont_iv_entry *iv_entry;
+
+		iv_entry = src->sg_iovs[0].iov_buf;
+		/* Do not update master entry for -1 value */
+		if (entry->iv_class->iv_class_id == IV_CONT_SNAP &&
+		    iv_entry->iv_snap.snap_cnt == (uint64_t)(-1) &&
+		    entry->ns->iv_master_rank == dss_self_rank())
+			goto out;
+
 		/* Put it to IV tree */
-		d_iov_set(&val_iov, src->sg_iovs[0].iov_buf,
-			     src->sg_iovs[0].iov_len);
+		d_iov_set(&val_iov, iv_entry, src->sg_iovs[0].iov_len);
 		rc = dbtree_update(root_hdl, &key_iov, &val_iov);
 	}
 
-	if (rc < 0)
+out:
+	if (rc < 0 && rc != -DER_IVCB_FORWARD)
 		D_ERROR("failed to insert: rc "DF_RC"\n", DP_RC(rc));
 
 	return rc;
@@ -589,8 +563,10 @@ cont_iv_ent_refresh(struct ds_iv_entry *entry, struct ds_iv_key *key,
 }
 
 static int
-cont_iv_ent_alloc_internal(d_sg_list_t *sgl)
+cont_iv_value_alloc(struct ds_iv_entry *iv_entry, struct ds_iv_key *key,
+		    d_sg_list_t *sgl)
 {
+	struct cont_iv_key	*civ_key = key2priv(key);
 	struct cont_iv_entry	*entry;
 	int			rc;
 
@@ -598,36 +574,16 @@ cont_iv_ent_alloc_internal(d_sg_list_t *sgl)
 	if (rc)
 		return rc;
 
-	D_ALLOC_PTR(entry);
-	if (!entry) {
+	D_ALLOC(entry, civ_key->entry_size);
+	if (entry == NULL)
+		D_GOTO(out, rc = -DER_NOMEM);
+
+	d_iov_set(&sgl->sg_iovs[0], entry, civ_key->entry_size);
+out:
+	if (rc)
 		d_sgl_fini(sgl, true);
-		return -DER_NOMEM;
-	}
 
-	d_iov_set(&sgl->sg_iovs[0], entry, sizeof(*entry));
-	return 0;
-}
-
-static int
-cont_iv_value_alloc(struct ds_iv_entry *entry, d_sg_list_t *sgl)
-{
-	D_ASSERT(entry->iv_class != NULL);
-
-	switch (entry->iv_class->iv_class_id) {
-	case IV_CONT_SNAP:
-		return cont_iv_snap_alloc_internal(sgl);
-	case IV_CONT_CAPA:
-	case IV_CONT_AGG_EPOCH_REPORT:
-	case IV_CONT_AGG_EPOCH_BOUNDRY:
-		return cont_iv_ent_alloc_internal(sgl);
-	case IV_CONT_PROP:
-		return cont_iv_prop_alloc_internal(sgl);
-	default:
-		D_ERROR("bad iv_class_id %d.\n", entry->iv_class->iv_class_id);
-		return -DER_INVAL;
-	};
-
-	return 0;
+	return rc;
 }
 
 static bool
@@ -644,7 +600,7 @@ cont_iv_ent_valid(struct ds_iv_entry *entry, struct ds_iv_key *key)
 
 	/* Let's check whether the container really exist */
 	memcpy(&root_hdl, entry->iv_value.sg_iovs[0].iov_buf, sizeof(root_hdl));
-	d_iov_set(&key_iov, civ_key, sizeof(*civ_key));
+	d_iov_set(&key_iov, &civ_key->cont_uuid, sizeof(civ_key->cont_uuid));
 	d_iov_set(&val_iov, NULL, 0);
 	rc = dbtree_lookup(root_hdl, &key_iov, &val_iov);
 	if (rc != 0)
@@ -667,10 +623,11 @@ struct ds_iv_class_ops cont_iv_ops = {
 
 static int
 cont_iv_fetch(void *ns, int class_id, uuid_t key_uuid,
-	      struct cont_iv_entry *cont_iv, int cont_iv_len, bool retry)
+	      struct cont_iv_entry *cont_iv, int cont_iv_len, int entry_size,
+	      bool retry)
 {
 	d_sg_list_t		sgl;
-	d_iov_t			iov;
+	d_iov_t			iov = { 0 };
 	struct ds_iv_key	key = { 0 };
 	struct cont_iv_key	*civ_key;
 	int			rc;
@@ -681,11 +638,11 @@ cont_iv_fetch(void *ns, int class_id, uuid_t key_uuid,
 	sgl.sg_nr = 1;
 	sgl.sg_nr_out = 0;
 	sgl.sg_iovs = &iov;
-
 	key.class_id = class_id;
 	civ_key = key2priv(&key);
 	uuid_copy(civ_key->cont_uuid, key_uuid);
 	civ_key->class_id = class_id;
+	civ_key->entry_size = entry_size;
 	rc = ds_iv_fetch(ns, &key, cont_iv ? &sgl : NULL, retry);
 	if (rc)
 		D_CDEBUG(rc != -DER_NOTLEADER, DLOG_ERR, DB_MGMT,
@@ -718,12 +675,14 @@ cont_iv_update(void *ns, int class_id, uuid_t key_uuid,
 	civ_key = key2priv(&key);
 	uuid_copy(civ_key->cont_uuid, key_uuid);
 	civ_key->class_id = class_id;
+	civ_key->entry_size = cont_iv_len;
 	rc = ds_iv_update(ns, &key, &sgl, shortcut, sync_mode, 0, retry);
 	if (rc)
 		D_CDEBUG(rc == -DER_NOTLEADER || rc == -DER_NONEXIST,
 			 DB_ANY, DLOG_ERR,
 			 DF_UUID" iv update failed "DF_RC"\n",
 			 DP_UUID(key_uuid), DP_RC(rc));
+
 	return rc;
 }
 
@@ -752,18 +711,27 @@ cont_iv_snapshots_fetch(void *ns, uuid_t cont_uuid, uint64_t **snapshots,
 	struct cont_iv_entry	*iv_entry;
 	int			iv_entry_size;
 	int			rc;
-
-	iv_entry_size = cont_iv_snap_ent_size(MAX_SNAP_CNT);
+	uint64_t		snap_cnt = INIT_SNAP_CNT;
+retry:
+	iv_entry_size = cont_iv_snap_ent_size(snap_cnt);
 	D_ALLOC(iv_entry, iv_entry_size);
 	if (iv_entry == NULL)
 		return -DER_NOMEM;
 
-	rc = cont_iv_fetch(ns, IV_CONT_SNAP, cont_uuid, iv_entry,
+	rc = cont_iv_fetch(ns, IV_CONT_SNAP, cont_uuid, iv_entry, iv_entry_size,
 			   iv_entry_size, true);
 	if (rc)
 		D_GOTO(free, rc);
 
-	D_ASSERT(iv_entry->iv_snap.snap_cnt <= MAX_SNAP_CNT);
+	if (iv_entry->iv_snap.snap_cnt == (uint64_t)(-1)) {
+		D_ASSERT(iv_entry->iv_snap.snaps[0] > snap_cnt);
+		D_DEBUG(DB_MD, DF_UUID" retry by snap_cnt "DF_U64"\n",
+			DP_UUID(cont_uuid), iv_entry->iv_snap.snaps[0]);
+		snap_cnt = iv_entry->iv_snap.snaps[0];
+		D_FREE(iv_entry);
+		goto retry;
+	}
+
 	if (iv_entry->iv_snap.snap_cnt == 0) {
 		*snap_count = 0;
 		D_GOTO(free, rc = 0);
@@ -777,8 +745,10 @@ cont_iv_snapshots_fetch(void *ns, uuid_t cont_uuid, uint64_t **snapshots,
 	memcpy(*snapshots, iv_entry->iv_snap.snaps,
 	       sizeof(iv_entry->iv_snap.snaps[0]) * iv_entry->iv_snap.snap_cnt);
 	*snap_count = iv_entry->iv_snap.snap_cnt;
+
 free:
-	D_FREE(iv_entry);
+	if (iv_entry)
+		D_FREE(iv_entry);
 	return rc;
 }
 
@@ -787,53 +757,52 @@ cont_iv_snapshots_update(void *ns, uuid_t cont_uuid, uint64_t *snapshots,
 			 int snap_count)
 {
 	struct cont_iv_entry	*iv_entry;
-	uint32_t		 entry_size;
-	int			 rc;
+	int			iv_entry_size;
+	int			rc;
 
 	/* Only happens on xstream 0 */
 	D_ASSERT(dss_get_module_info()->dmi_xs_id == 0);
 
-	entry_size = cont_iv_snap_ent_size(snap_count);
-	D_ALLOC(iv_entry, entry_size);
+	iv_entry_size = cont_iv_snap_ent_size(snap_count);
+	D_ALLOC(iv_entry, iv_entry_size);
 	if (iv_entry == NULL)
-		D_GOTO(out, rc = -DER_NOMEM);
+		return -DER_NOMEM;
 
 	uuid_copy(iv_entry->cont_uuid, cont_uuid);
 	iv_entry->iv_snap.snap_cnt = snap_count;
 	memcpy(iv_entry->iv_snap.snaps, snapshots,
 	       sizeof(*snapshots) * snap_count);
 
-	rc = cont_iv_update(ns, IV_CONT_SNAP, cont_uuid, iv_entry, entry_size,
-			    CRT_IV_SHORTCUT_TO_ROOT, CRT_IV_SYNC_EAGER,
-			    false /* retry */);
+	rc = cont_iv_update(ns, IV_CONT_SNAP, cont_uuid, iv_entry,
+			    iv_entry_size, CRT_IV_SHORTCUT_TO_ROOT,
+			    CRT_IV_SYNC_EAGER, false /* retry */);
 	D_FREE(iv_entry);
-out:
 	return rc;
 }
 
 int
 cont_iv_snapshots_refresh(void *ns, uuid_t cont_uuid)
 {
-	struct cont_iv_entry	*iv_entry;
-	uint32_t		 entry_size;
-	int			 rc;
+	struct cont_iv_entry	iv_entry = { 0 };
+	int			entry_size = 0;
+	uint64_t		snap_cnt = INIT_SNAP_CNT;
+	int			rc;
 
 	/* Only happens on xstream 0 */
 	D_ASSERT(dss_get_module_info()->dmi_xs_id == 0);
+retry:
+	entry_size = cont_iv_snap_ent_size(snap_cnt);
+	rc = cont_iv_fetch(ns, IV_CONT_SNAP, cont_uuid, &iv_entry,
+			   sizeof(iv_entry), entry_size, false /* retry */);
+	if (rc)
+		return rc;
 
-	entry_size = cont_iv_snap_ent_size(MAX_SNAP_CNT);
-	D_ALLOC(iv_entry, entry_size);
-	if (iv_entry == NULL) {
-		rc = -DER_NOMEM;
-		goto out;
+	if (iv_entry.iv_snap.snap_cnt == (uint64_t)(-1)) {
+		snap_cnt = iv_entry.iv_snap.snaps[0];
+		D_DEBUG(DB_MD, "retry with "DF_U64"\n", snap_cnt);
+		goto retry;
 	}
-	rc = cont_iv_fetch(ns, IV_CONT_SNAP, cont_uuid, iv_entry, entry_size,
-			   false /* retry */);
-	if (rc == 0)
-		D_ASSERT(iv_entry->iv_snap.snap_cnt <= MAX_SNAP_CNT);
 
-	D_FREE(iv_entry);
-out:
 	return rc;
 }
 
@@ -852,7 +821,7 @@ static void
 cont_iv_capa_refresh_ult(void *data)
 {
 	struct iv_capa_ult_arg	*arg = data;
-	struct cont_iv_entry	entry = { 0 };
+	struct cont_iv_entry	iv_entry = { 0 };
 	struct ds_pool		*pool;
 	int			rc;
 
@@ -870,13 +839,13 @@ cont_iv_capa_refresh_ult(void *data)
 			D_GOTO(out, rc);
 	}
 
-	rc = cont_iv_fetch(pool->sp_iv_ns, IV_CONT_CAPA,
-			   arg->cont_hdl_uuid, &entry, sizeof(entry),
+	rc = cont_iv_fetch(pool->sp_iv_ns, IV_CONT_CAPA, arg->cont_hdl_uuid,
+			   &iv_entry, sizeof(iv_entry), sizeof(iv_entry),
 			   false /* retry */);
 	if (rc)
 		D_GOTO(out, rc);
 
-	uuid_copy(arg->cont_uuid, entry.cont_uuid);
+	uuid_copy(arg->cont_uuid, iv_entry.cont_uuid);
 out:
 	if (pool != NULL)
 		ds_pool_put(pool);
@@ -899,7 +868,8 @@ cont_iv_hdl_fetch(uuid_t cont_hdl_uuid, uuid_t pool_uuid,
 	} else {
 		*cont_hdl = ds_cont_hdl_lookup(cont_hdl_uuid);
 		if (*cont_hdl != NULL) {
-			D_DEBUG(DB_TRACE, "get hdl %p\n", cont_hdl);
+			D_DEBUG(DB_TRACE, "get hdl "DF_UUID"\n",
+				DP_UUID(cont_hdl_uuid));
 			return 0;
 		}
 	}
@@ -960,9 +930,8 @@ cont_iv_ec_agg_eph_update_internal(void *ns, uuid_t cont_uuid,
 	if (rc)
 		return rc;
 
-	rc = cont_iv_update(ns, op, cont_uuid, &iv_entry,
-			    sizeof(struct cont_iv_entry), shortcut,
-			    sync_mode, false /* retry */);
+	rc = cont_iv_update(ns, op, cont_uuid, &iv_entry, sizeof(iv_entry),
+			    shortcut, sync_mode, false /* retry */);
 	return rc;
 }
 
@@ -997,9 +966,8 @@ cont_iv_capability_update(void *ns, uuid_t cont_hdl_uuid, uuid_t cont_uuid,
 	uuid_copy(iv_entry.cont_uuid, cont_uuid);
 
 	rc = cont_iv_update(ns, IV_CONT_CAPA, cont_hdl_uuid, &iv_entry,
-			    sizeof(struct cont_iv_entry),
-			    CRT_IV_SHORTCUT_TO_ROOT, CRT_IV_SYNC_EAGER,
-			    false /* retry */);
+			    sizeof(iv_entry), CRT_IV_SHORTCUT_TO_ROOT,
+			    CRT_IV_SYNC_EAGER, false /* retry */);
 	return rc;
 }
 
@@ -1157,26 +1125,24 @@ int
 cont_iv_prop_update(void *ns, uuid_t cont_uuid, daos_prop_t *prop)
 {
 	struct cont_iv_entry	*iv_entry;
-	uint32_t		 entry_size;
-	int			 rc;
+	uint32_t		iv_entry_size;
+	int			rc;
 
 	/* Only happens on xstream 0 */
 	D_ASSERT(dss_get_module_info()->dmi_xs_id == 0);
 
-	entry_size = cont_iv_prop_ent_size(DAOS_ACL_MAX_ACE_LEN);
-	D_ALLOC(iv_entry, entry_size);
+	iv_entry_size = cont_iv_prop_ent_size(DAOS_ACL_MAX_ACE_LEN);
+	D_ALLOC(iv_entry, iv_entry_size);
 	if (iv_entry == NULL)
-		D_GOTO(out, rc = -DER_NOMEM);
+		return -DER_NOMEM;
 
 	uuid_copy(iv_entry->cont_uuid, cont_uuid);
 	cont_iv_prop_l2g(prop, &iv_entry->iv_prop);
 
 	rc = cont_iv_update(ns, IV_CONT_PROP, cont_uuid, iv_entry,
-			    entry_size, CRT_IV_SHORTCUT_TO_ROOT,
+			    iv_entry_size, CRT_IV_SHORTCUT_TO_ROOT,
 			    CRT_IV_SYNC_EAGER, false /* retry */);
 	D_FREE(iv_entry);
-
-out:
 	return rc;
 }
 
@@ -1204,17 +1170,18 @@ cont_iv_prop_fetch_ult(void *data)
 	if (iv_entry == NULL)
 		D_GOTO(out, rc = -DER_NOMEM);
 
-	prop_fetch = daos_prop_alloc(CONT_PROP_NUM);
-	if (prop_fetch == NULL)
-		D_GOTO(out, rc = -DER_NOMEM);
-
 	rc = cont_iv_fetch(arg->iv_ns, IV_CONT_PROP, arg->cont_uuid,
-			   iv_entry, iv_entry_size, false /* retry */);
+			   iv_entry, iv_entry_size, iv_entry_size,
+			   false /* retry */);
 	if (rc) {
 		D_CDEBUG(rc == -DER_NOTLEADER, DB_ANY, DLOG_ERR,
 			 "cont_iv_fetch failed "DF_RC"\n", DP_RC(rc));
 		D_GOTO(out, rc);
 	}
+
+	prop_fetch = daos_prop_alloc(CONT_PROP_NUM);
+	if (prop_fetch == NULL)
+		D_GOTO(out, rc = -DER_NOMEM);
 
 	D_ASSERT(prop != NULL);
 	rc = cont_iv_prop_g2l(&iv_entry->iv_prop, prop_fetch);
@@ -1230,7 +1197,8 @@ cont_iv_prop_fetch_ult(void *data)
 	}
 
 out:
-	D_FREE(iv_entry);
+	if (iv_entry)
+		D_FREE(iv_entry);
 	daos_prop_free(prop_fetch);
 	ABT_eventual_set(arg->eventual, (void *)&rc, sizeof(rc));
 }

--- a/src/container/oid_iv.c
+++ b/src/container/oid_iv.c
@@ -63,7 +63,7 @@ oid_iv_key_cmp(void *key1, void *key2)
 
 static int
 oid_iv_ent_fetch(struct ds_iv_entry *entry, struct ds_iv_key *key,
-		 d_sg_list_t *src, d_sg_list_t *dst, void **priv)
+		 d_sg_list_t *src, void **priv)
 {
 	D_ASSERT(0);
 	return 0;
@@ -272,7 +272,8 @@ oid_iv_ent_destroy(d_sg_list_t *sgl)
 }
 
 static int
-oid_iv_alloc(struct ds_iv_entry *entry, d_sg_list_t *sgl)
+oid_iv_alloc(struct ds_iv_entry *entry, struct ds_iv_key *key,
+	     d_sg_list_t *sgl)
 {
 	int rc;
 

--- a/src/container/srv_internal.h
+++ b/src/container/srv_internal.h
@@ -98,7 +98,7 @@ struct oid_iv_range {
 
 /* Container IV structure */
 struct cont_iv_snapshot {
-	int snap_cnt;
+	uint64_t snap_cnt;
 	uint64_t snaps[0];
 };
 
@@ -153,6 +153,7 @@ struct cont_iv_key {
 	uuid_t		cont_uuid;
 	/* IV class id, to differentiate SNAP/CAPA/PROP IV */
 	uint32_t	class_id;
+	uint32_t	entry_size;
 };
 
 /*

--- a/src/container/srv_target.c
+++ b/src/container/srv_target.c
@@ -1832,7 +1832,7 @@ ds_cont_tgt_snapshots_update(uuid_t pool_uuid, uuid_t cont_uuid,
 	uuid_copy(args.cont_uuid, cont_uuid);
 	args.snap_count = snap_count;
 	args.snapshots = snapshots;
-	D_DEBUG(DB_TRACE, DF_UUID": refreshing snapshots %d\n",
+	D_DEBUG(DB_EPC, DF_UUID": refreshing snapshots %d\n",
 		DP_UUID(cont_uuid), snap_count);
 	return dss_thread_collective(cont_snap_update_one, &args, 0);
 }

--- a/src/engine/server_iv.c
+++ b/src/engine/server_iv.c
@@ -259,22 +259,6 @@ iv_entry_free(struct ds_iv_entry *entry)
 }
 
 static int
-fetch_iv_value(struct ds_iv_entry *entry, struct ds_iv_key *key,
-	       d_sg_list_t *dst, d_sg_list_t *src, void *priv)
-{
-	struct ds_iv_class	*class = entry->iv_class;
-	int			rc;
-
-	if (class->iv_class_ops && class->iv_class_ops->ivc_ent_fetch)
-		rc = class->iv_class_ops->ivc_ent_fetch(entry, key, dst, src,
-							priv);
-	else
-		rc = daos_sgl_copy_data(dst, src);
-
-	return rc;
-}
-
-static int
 update_iv_value(struct ds_iv_entry *entry, struct ds_iv_key *key,
 		d_sg_list_t *src, void **priv)
 {
@@ -412,7 +396,7 @@ ivc_on_fetch(crt_iv_namespace_t ivns, crt_iv_key_t *iv_key,
 	}
 
 	valid = iv_entry_valid(entry, &key);
-	D_DEBUG(DB_TRACE, "FETCH: Key [%d:%d] entry %p valid %s\n", key.rank,
+	D_DEBUG(DB_MD, "FETCH: Key [%d:%d] entry %p valid %s\n", key.rank,
 		key.class_id, entry, valid ? "yes" : "no");
 
 	/* Forward the request to its parent if it is not root, and
@@ -432,9 +416,22 @@ ivc_on_fetch(crt_iv_namespace_t ivns, crt_iv_key_t *iv_key,
 			D_GOTO(output, rc = -DER_IVCB_FORWARD);
 	}
 
-	rc = fetch_iv_value(entry, &key, iv_value, &entry->iv_value, priv);
-	if (rc == 0)
-		entry->iv_valid = true;
+	if (entry->iv_class->iv_class_ops &&
+	    entry->iv_class->iv_class_ops->ivc_ent_fetch)
+		rc = entry->iv_class->iv_class_ops->ivc_ent_fetch(entry, &key,
+								  iv_value,
+								  priv);
+	else
+		rc = daos_sgl_copy_data(iv_value, &entry->iv_value);
+
+	/* store the value of the result */
+	if (flags & CRT_IV_FLAG_PENDING_FETCH &&
+	    rc == -DER_IVCB_FORWARD) {
+		D_DEBUG(DB_MD, "[%d:%d] reset to 0 during IV aggregation.\n",
+			key.rank, key.class_id);
+		rc = 0;
+	}
+
 output:
 	ds_iv_ns_put(ns);
 	return rc;
@@ -473,10 +470,9 @@ iv_on_update_internal(crt_iv_namespace_t ivns, crt_iv_key_t *iv_key,
 		rc = update_iv_value(entry, &key, iv_value,
 				     priv_entry ? priv_entry->priv : NULL);
 	}
-	if (rc != -DER_IVCB_FORWARD && rc != 0) {
-		D_CDEBUG(rc == -DER_NONEXIST, DLOG_INFO, DLOG_ERR,
-			 "key id %d update failed: rc = "DF_RC"\n",
-			 key.class_id, DP_RC(rc));
+	if (rc != 0) {
+		D_DEBUG(DB_MD, "key id %d update failed: rc = %d\n",
+			key.class_id, rc);
 		D_GOTO(output, rc);
 	}
 
@@ -485,7 +481,7 @@ iv_on_update_internal(crt_iv_namespace_t ivns, crt_iv_key_t *iv_key,
 	else
 		entry->iv_valid = true;
 
-	D_DEBUG(DB_TRACE, "key id %d rank %d myrank %d valid %s\n",
+	D_DEBUG(DB_MD, "key id %d rank %d myrank %d valid %s\n",
 		key.class_id, key.rank, dss_self_rank(),
 		invalidate ? "no" : "yes");
 output:
@@ -568,7 +564,8 @@ ivc_on_get(crt_iv_namespace_t ivns, crt_iv_key_t *iv_key,
 
 	class = entry->iv_class;
 	if (iv_value) {
-		rc = class->iv_class_ops->ivc_value_alloc(entry, iv_value);
+		rc = class->iv_class_ops->ivc_value_alloc(entry, &key,
+							  iv_value);
 		if (rc)
 			D_GOTO(out, rc);
 	}
@@ -877,15 +874,20 @@ ds_iv_done(crt_iv_namespace_t ivns, uint32_t class_id,
 	cb_info->result = rc;
 
 	if (cb_info->opc == IV_FETCH && cb_info->value && rc == 0) {
-		struct ds_iv_entry	*entry;
-		struct ds_iv_key	key;
+		struct ds_iv_key key;
 
 		D_ASSERT(cb_info->ns != NULL);
-		entry = iv_class_entry_lookup(cb_info->ns, cb_info->key);
-		D_ASSERT(entry != NULL);
 		iv_key_unpack(&key, iv_key);
-		ret = fetch_iv_value(entry, &key, cb_info->value, iv_value,
-				     NULL);
+		if (iv_value->sg_iovs[0].iov_len > 0 &&
+		    cb_info->value->sg_iovs[0].iov_buf_len >=
+		    iv_value->sg_iovs[0].iov_len)
+			rc = daos_sgl_copy_data(cb_info->value, iv_value);
+		else
+			D_DEBUG(DB_MD, "key %d/%d does not"
+				" provide enough buf "DF_U64" < "
+				DF_U64"\n", key.class_id, key.rank,
+				cb_info->value->sg_iovs[0].iov_buf_len,
+				iv_value->sg_iovs[0].iov_len);
 	}
 
 	ABT_future_set(cb_info->future, &rc);
@@ -894,8 +896,8 @@ ds_iv_done(crt_iv_namespace_t ivns, uint32_t class_id,
 
 static int
 iv_op_internal(struct ds_iv_ns *ns, struct ds_iv_key *key_iv,
-	       d_sg_list_t *value, crt_iv_sync_t *sync, unsigned int shortcut,
-	       int opc)
+	       d_sg_list_t *value, crt_iv_sync_t *sync,
+	       unsigned int shortcut, int opc)
 {
 	struct iv_cb_info	cb_info;
 	ABT_future		future;

--- a/src/include/daos_srv/iv.h
+++ b/src/include/daos_srv/iv.h
@@ -181,15 +181,13 @@ typedef int (*ds_iv_ent_destroy_t)(d_sg_list_t *sgl);
  * \param entry [IN]	class entry.
  * \param key [IN]	key to locate the entry.
  * \param dst [OUT]	destination buffer.
- * \param src [IN]	source buffer.
  * \param priv [OUT]	private buffer from IV callback.
  *
  * \return		0 if succeeds, error code otherwise.
  */
 typedef int (*ds_iv_ent_fetch_t)(struct ds_iv_entry *entry,
 				 struct ds_iv_key *key,
-				 d_sg_list_t *dst, d_sg_list_t *src,
-				 void **priv);
+				 d_sg_list_t *dst, void **priv);
 
 /**
  * Update data to the iv_class entry.
@@ -224,11 +222,13 @@ typedef int (*ds_iv_ent_refresh_t)(struct ds_iv_entry *entry,
  * allocate the value for cart IV.
  *
  * \param ent [IN]	entry to allocate iv_value.
+ * \param key [IN]	key of the IV call.
  * \param src [OUT]	buffer to be allocated.
  *
  * \return		0 if succeeds, error code otherwise.
  */
 typedef int (*ds_iv_value_alloc_t)(struct ds_iv_entry *ent,
+				   struct ds_iv_key *key,
 				   d_sg_list_t *sgl);
 
 /**

--- a/src/object/srv_obj.c
+++ b/src/object/srv_obj.c
@@ -1599,23 +1599,20 @@ obj_ioc_init(uuid_t pool_uuid, uuid_t coh_uuid, uuid_t cont_uuid, int opc,
 		D_ERROR("Stale container handle "DF_UUID" != "DF_UUID"\n",
 			DP_UUID(cont_uuid), DP_UUID(coh->sch_uuid));
 		D_GOTO(failed, rc = -DER_NONEXIST);
+	} else {
+		/**
+		 * The server handle is a dummy and never attached by
+		 * a real container
+		 */
+		D_DEBUG(DB_TRACE, DF_UUID"/%p is server cont hdl\n",
+			DP_UUID(coh_uuid), coh);
 	}
 
-	if (!is_container_from_srv(pool_uuid, coh_uuid)) {
-		D_ERROR("Empty container "DF_UUID" (ref=%d) handle?\n",
-			DP_UUID(cont_uuid), coh->sch_ref);
-		D_GOTO(failed, rc = -DER_NO_HDL);
-	}
-
-	/* rebuild handle is a dummy and never attached by a real container */
 	if (DAOS_FAIL_CHECK(DAOS_REBUILD_NO_HDL))
 		D_GOTO(failed, rc = -DER_NO_HDL);
 
 	if (DAOS_FAIL_CHECK(DAOS_REBUILD_STALE_POOL))
 		D_GOTO(failed, rc = -DER_STALE);
-
-	D_DEBUG(DB_TRACE, DF_UUID"/%p is rebuild cont hdl\n",
-		DP_UUID(coh_uuid), coh);
 
 	/* load VOS container on demand for rebuild */
 	rc = ds_cont_child_lookup(pool_uuid, cont_uuid, &coc);

--- a/src/object/srv_obj_migrate.c
+++ b/src/object/srv_obj_migrate.c
@@ -433,8 +433,10 @@ int migrate_pool_tls_create_one(void *data)
 	if (rc)
 		D_GOTO(out, rc);
 
-	D_DEBUG(DB_REBUILD, "TLS %p create for "DF_UUID" ver %d rc %d\n",
-		pool_tls, DP_UUID(pool_tls->mpt_pool_uuid), arg->version, rc);
+	D_DEBUG(DB_REBUILD, "TLS %p create for "DF_UUID" "DF_UUID"/"DF_UUID
+		"ver %d rc %d\n", pool_tls, DP_UUID(pool_tls->mpt_pool_uuid),
+		DP_UUID(arg->pool_hdl_uuid), DP_UUID(arg->co_hdl_uuid),
+		arg->version, rc);
 	d_list_add(&pool_tls->mpt_list, &tls->ot_pool_list);
 out:
 	if (rc && pool_tls)
@@ -2330,11 +2332,8 @@ migrate_cont_iter_cb(daos_handle_t ih, d_iov_t *key_iov,
 	while (!dbtree_is_empty(root->root_hdl)) {
 		rc = dbtree_iterate(root->root_hdl, DAOS_INTENT_MIGRATION,
 				    false, migrate_obj_iter_cb, &arg);
-		if (rc || tls->mpt_fini) {
-			if (tls->mpt_status == 0)
-				tls->mpt_status = rc;
+		if (rc || tls->mpt_fini)
 			break;
-		}
 	}
 
 	rc1 = dsc_cont_close(tls->mpt_pool_hdl, coh);
@@ -2372,6 +2371,8 @@ free:
 		D_FREE(snapshots);
 
 out_put:
+	if (tls->mpt_status == 0 && rc < 0)
+		tls->mpt_status = rc;
 	ds_pool_put(dp);
 	return rc;
 }

--- a/src/pool/srv_internal.h
+++ b/src/pool/srv_internal.h
@@ -153,7 +153,6 @@ extern struct bio_reaction_ops nvme_reaction_ops;
 uint32_t pool_iv_map_ent_size(int nr);
 int ds_pool_iv_init(void);
 int ds_pool_iv_fini(void);
-int pool_iv_map_fetch(void *ns, struct pool_iv_entry *pool_iv);
 void ds_pool_map_refresh_ult(void *arg);
 
 int ds_pool_iv_conn_hdl_update(struct ds_pool *pool, uuid_t hdl_uuid,
@@ -163,8 +162,7 @@ int ds_pool_iv_srv_hdl_update(struct ds_pool *pool, uuid_t pool_hdl_uuid,
 			      uuid_t cont_hdl_uuid);
 
 int ds_pool_iv_srv_hdl_invalidate(struct ds_pool *pool);
-int ds_pool_iv_conn_hdl_fetch(struct ds_pool *pool, uuid_t key_uuid,
-			      d_iov_t *conn_iov);
+int ds_pool_iv_conn_hdl_fetch(struct ds_pool *pool);
 int ds_pool_iv_conn_hdl_invalidate(struct ds_pool *pool, uuid_t hdl_uuid);
 
 int ds_pool_iv_srv_hdl_fetch_non_sys(struct ds_pool *pool,

--- a/src/pool/srv_iv.c
+++ b/src/pool/srv_iv.c
@@ -59,6 +59,7 @@ pool_iv_value_alloc_internal(struct ds_iv_key *key, d_sg_list_t *sgl)
 		D_GOTO(free, rc = -DER_NOMEM);
 
 	sgl->sg_iovs[0].iov_buf_len = buf_size;
+	sgl->sg_iovs[0].iov_len = buf_size;
 	if (key->class_id == IV_POOL_CONN) {
 		struct pool_iv_conns *conns = sgl->sg_iovs[0].iov_buf;
 
@@ -71,6 +72,26 @@ free:
 		d_sgl_fini(sgl, true);
 
 	return rc;
+}
+
+static inline size_t
+pool_iv_conn_size(size_t cred_size)
+{
+	return sizeof(struct pool_iv_conn) + cred_size;
+}
+
+static inline struct pool_iv_conn*
+pool_iv_conn_next(struct pool_iv_conn *conn)
+{
+	return (struct pool_iv_conn *)((char *)conn +
+		pool_iv_conn_size(conn->pic_cred_size));
+}
+
+static inline size_t
+pool_iv_conn_ent_size(size_t cred_size)
+{
+	return sizeof(struct pool_iv_entry) +
+	       pool_iv_conn_size(cred_size);
 }
 
 /* FIXME: Need better handling here, for example retry if the size is not
@@ -259,26 +280,6 @@ out:
 	return rc;
 }
 
-static inline size_t
-pool_iv_conn_size(size_t cred_size)
-{
-	return sizeof(struct pool_iv_conn) + cred_size;
-}
-
-static inline struct pool_iv_conn*
-pool_iv_conn_next(struct pool_iv_conn *conn)
-{
-	return (struct pool_iv_conn *)((char *)conn +
-		pool_iv_conn_size(conn->pic_cred_size));
-}
-
-static inline size_t
-pool_iv_conn_ent_size(size_t cred_size)
-{
-	return sizeof(struct pool_iv_entry) +
-	       pool_iv_conn_size(cred_size);
-}
-
 static bool
 pool_iv_conn_valid(struct pool_iv_conn *conn, char *end)
 {
@@ -347,25 +348,134 @@ pool_iv_conn_insert(struct pool_iv_conns *conns, struct pool_iv_conn *new_conn)
 	end = (char *)conns->pic_conns + conns->pic_size;
 	memcpy(end, new_conn, new_conn_size);
 	conns->pic_size += new_conn_size;
+	D_DEBUG(DB_MD, "insert conn %u/%u\n", conns->pic_size,
+		conns->pic_buf_size);
 	return 0;
+}
+
+static int
+pool_iv_conns_buf_insert(struct pool_iv_conns *dst_conns,
+			 struct pool_iv_conns *src_conns)
+{
+	struct pool_iv_conn	*conn;
+	char			*end;
+	int			rc = 0;
+
+	/* Insert all connections from src_conns to dst_sgl */
+	conn = src_conns->pic_conns;
+	end = (char *)conn + src_conns->pic_size;
+	while (pool_iv_conn_valid(conn, end)) {
+		rc = pool_iv_conn_insert(dst_conns, conn);
+		if (rc)
+			break;
+
+		D_DEBUG(DB_MD, "insert conn "DF_UUID": %d\n",
+			DP_UUID(conn->pic_hdl), rc);
+		conn = pool_iv_conn_next(conn);
+	}
+
+	return rc;
+}
+
+static int
+pool_iv_conns_ent_fetch(d_sg_list_t *dst_sgl, struct pool_iv_entry *src_iv)
+{
+	struct pool_iv_conns	*src_conns;
+	struct pool_iv_entry	*dst_entry;
+	struct pool_iv_conns	*dst_conns;
+	uint32_t		dst_conns_size;
+	int			rc = 0;
+
+	src_conns = &src_iv->piv_conn_hdls;
+	if (src_conns->pic_size == 0)
+		return 0;
+
+	if (src_conns->pic_size == (uint32_t)(-1)) {
+		struct pool_iv_entry *dst_iv;
+
+		dst_iv = dst_sgl->sg_iovs[0].iov_buf;
+		memcpy(&dst_iv->piv_conn_hdls, &src_iv->piv_conn_hdls,
+		       sizeof(struct pool_iv_conns));
+		return -DER_IVCB_FORWARD;
+	}
+
+	dst_entry = dst_sgl->sg_iovs[0].iov_buf;
+	dst_conns = &dst_entry->piv_conn_hdls;
+	dst_conns_size = dst_conns->pic_size + src_conns->pic_size;
+	if (dst_conns_size > dst_conns->pic_buf_size) {
+		D_DEBUG(DB_MD, "dst_conns_size %d > pic_buf_size %u\n",
+			dst_conns_size, dst_conns->pic_buf_size);
+		dst_conns->pic_size = (uint32_t)(-1);
+		dst_conns->pic_buf_size = dst_conns_size;
+		return 0;
+	}
+
+	rc = pool_iv_conns_buf_insert(dst_conns, src_conns);
+
+	return rc;
 }
 
 static int
 pool_iv_conns_resize(d_sg_list_t *sgl, unsigned int new_size)
 {
-	struct pool_iv_entry *iv_ent = sgl->sg_iovs[0].iov_buf;
-	struct pool_iv_conns *old_conns = &iv_ent->piv_conn_hdls;
+	struct pool_iv_entry *old_ent = sgl->sg_iovs[0].iov_buf;
+	struct pool_iv_entry *new_ent;
 	struct pool_iv_conns *new_conns;
 
-	D_REALLOC(new_conns, old_conns, new_size);
-	if (new_conns == NULL)
+	D_REALLOC(new_ent, old_ent, new_size);
+	if (new_ent == NULL)
 		return -DER_NOMEM;
 
-	D_ASSERT(new_size >= sizeof(*new_conns));
+	new_conns = &new_ent->piv_conn_hdls;
 	new_conns->pic_buf_size = new_size - sizeof(*new_conns);
-	sgl->sg_iovs[0].iov_buf = new_conns;
+	D_DEBUG(DB_MD, "reset iv conns to %u/%u\n", new_conns->pic_size,
+		new_conns->pic_buf_size);
+	sgl->sg_iovs[0].iov_buf = new_ent;
 	sgl->sg_iovs[0].iov_buf_len = new_size;
 	return 0;
+}
+
+static int
+pool_iv_conns_ent_update(d_sg_list_t *dst_sgl, struct pool_iv_entry *src_iv)
+{
+	struct pool_iv_conns	*src_conns;
+	struct pool_iv_entry	*dst_entry;
+	struct pool_iv_conns	*dst_conns;
+	uint32_t		dst_conns_size;
+	int			rc = 0;
+
+	src_conns = &src_iv->piv_conn_hdls;
+	if (src_conns->pic_size == 0)
+		return 0;
+
+	if (src_conns->pic_size == (uint32_t)(-1)) {
+		struct pool_iv_entry *dst_iv;
+
+		D_DEBUG(DB_MD, "Update -1 entry dst_sgl %p\n", dst_sgl);
+		dst_iv = dst_sgl->sg_iovs[0].iov_buf;
+		memcpy(&dst_iv->piv_conn_hdls, &src_iv->piv_conn_hdls,
+		       sizeof(struct pool_iv_conns));
+		return 0;
+	}
+
+	dst_entry = dst_sgl->sg_iovs[0].iov_buf;
+	dst_conns = &dst_entry->piv_conn_hdls;
+	dst_conns_size = dst_conns->pic_size + src_conns->pic_size;
+	if (dst_conns_size > dst_conns->pic_buf_size) {
+		unsigned int new_size;
+
+		new_size = sizeof(*dst_conns) + dst_conns_size;
+		rc = pool_iv_conns_resize(dst_sgl, new_size);
+		if (rc)
+			return rc;
+
+		dst_entry = dst_sgl->sg_iovs[0].iov_buf;
+		dst_conns = &dst_entry->piv_conn_hdls;
+	}
+
+	rc = pool_iv_conns_buf_insert(dst_conns, src_conns);
+
+	return rc;
 }
 
 static int
@@ -403,121 +513,169 @@ pool_iv_ent_destroy(d_sg_list_t *sgl)
 }
 
 static int
-pool_iv_ent_copy(struct ds_iv_key *key, d_sg_list_t *dst, d_sg_list_t *src)
+pool_iv_map_ent_fetch(d_sg_list_t *dst_sgl, struct pool_iv_entry *src_iv)
 {
-	struct pool_iv_entry	*src_iv = src->sg_iovs[0].iov_buf;
-	struct pool_iv_entry	*dst_iv = dst->sg_iovs[0].iov_buf;
-	int			rc = 0;
+	struct pool_iv_entry	*dst_iv;
+	uint32_t		pb_nr;
+	uint32_t		src_pbuf_size;
+	uint32_t		dst_pbuf_size;
 
-	if (dst_iv == src_iv)
-		return 0;
-
-	D_ASSERT(src_iv != NULL);
-	D_ASSERT(dst_iv != NULL);
-
-	if (key->class_id == IV_POOL_MAP) {
-		if (src_iv->piv_map.piv_pool_buf.pb_nr > 0) {
-			int src_len = pool_buf_size(
-				src_iv->piv_map.piv_pool_buf.pb_nr);
-			int dst_len = dst->sg_iovs[0].iov_buf_len -
-				      sizeof(struct pool_iv_map) +
-				      sizeof(struct pool_buf);
-
-			/* copy pool buf */
-			if (dst_len < src_len) {
-				D_ERROR("dst %d src %d\n", dst_len, src_len);
-				return -DER_REC2BIG;
-			}
-
-			memcpy(&dst_iv->piv_map.piv_pool_buf,
-			       &src_iv->piv_map.piv_pool_buf, src_len);
-		}
-		dst->sg_iovs[0].iov_len = src->sg_iovs[0].iov_len;
-	} else if (key->class_id == IV_POOL_PROP) {
-		daos_prop_t	*prop_fetch;
-
-		prop_fetch = daos_prop_alloc(DAOS_PROP_PO_NUM);
-		if (prop_fetch == NULL)
-			return -DER_NOMEM;
-
-		rc = pool_iv_prop_g2l(&src_iv->piv_prop, prop_fetch);
-		if (rc) {
-			daos_prop_free(prop_fetch);
-			D_ERROR("prop g2l failed: rc %d\n", rc);
-			return rc;
-		}
-
-		pool_iv_prop_l2g(prop_fetch, &dst_iv->piv_prop);
-		daos_prop_free(prop_fetch);
-	} else if (key->class_id == IV_POOL_CONN) {
-		struct pool_iv_conns	*src_conns = &src_iv->piv_conn_hdls;
-		struct pool_iv_conns	*dst_conns = &dst_iv->piv_conn_hdls;
-		struct pool_iv_key	*pik = key2priv(key);
-		struct pool_iv_conn	*conn;
-
-		if (src_conns->pic_size == 0)
-			return 0;
-
-		/* only copy iv conn indicated by the uuid, otherwise copy
-		 * all iv conn.
-		 */
-		if (!uuid_is_null(pik->pik_uuid)) {
-			conn = pool_iv_conn_lookup(src_conns, pik->pik_uuid);
-			if (conn == NULL) {
-				D_ERROR("can not find uuid "DF_UUID"\n",
-					DP_UUID(pik->pik_uuid));
-				return -DER_NONEXIST;
-			}
-
-			rc = pool_iv_conn_insert(dst_conns, conn);
-			if (rc) {
-				if (rc == -DER_REC2BIG)
-					pik->pik_entry_size =
-						sizeof(*src_conns) +
-						src_conns->pic_size +
-						dst_conns->pic_size;
-				D_GOTO(out, rc);
-			}
-		} else {
-			char *end;
-
-			conn = src_conns->pic_conns;
-			end = (char *)conn + src_conns->pic_size;
-			while (pool_iv_conn_valid(conn, end)) {
-				rc = pool_iv_conn_insert(dst_conns, conn);
-				if (rc) {
-					if (rc == -DER_REC2BIG)
-						pik->pik_entry_size =
-							sizeof(*src_conns) +
-							src_conns->pic_size +
-							dst_conns->pic_size;
-					D_GOTO(out, rc);
-				}
-				conn = pool_iv_conn_next(conn);
-			}
-		}
-	} else if (key->class_id == IV_POOL_HDL) {
-		uuid_copy(dst_iv->piv_hdl.pih_pool_hdl,
-			  src_iv->piv_hdl.pih_pool_hdl);
-		uuid_copy(dst_iv->piv_hdl.pih_cont_hdl,
-			  src_iv->piv_hdl.pih_cont_hdl);
-		D_DEBUG(DB_MD, "pool/cont "DF_UUID"/"DF_UUID"\n",
-			DP_UUID(dst_iv->piv_hdl.pih_pool_hdl),
-			DP_UUID(dst_iv->piv_hdl.pih_cont_hdl));
-	} else {
-		D_ERROR("bad class id %d\n", key->class_id);
-		return -DER_INVAL;
+	dst_iv = dst_sgl->sg_iovs[0].iov_buf;
+	if (src_iv->piv_map.piv_pool_buf.pb_target_nr == (uint32_t)(-1)) {
+		memcpy(&dst_iv->piv_map.piv_pool_buf,
+		       &src_iv->piv_map.piv_pool_buf, sizeof(*src_iv));
+		return -DER_IVCB_FORWARD;
 	}
 
-out:
+	pb_nr = src_iv->piv_map.piv_pool_buf.pb_nr;
+	D_ASSERT(pb_nr > 0);
+	src_pbuf_size = pool_buf_size(pb_nr);
+	dst_pbuf_size = dst_sgl->sg_iovs[0].iov_buf_len -
+		  sizeof(struct pool_iv_map) + sizeof(struct pool_buf);
+
+	if (src_pbuf_size >= dst_pbuf_size) {
+		memcpy(&dst_iv->piv_map.piv_pool_buf,
+		       &src_iv->piv_map.piv_pool_buf, src_pbuf_size);
+		dst_sgl->sg_iovs[0].iov_len = pool_iv_map_ent_size(pb_nr);
+		return 0;
+	}
+
+	dst_iv->piv_map.piv_pool_buf.pb_target_nr = (uint32_t)(-1);
+	dst_iv->piv_map.piv_pool_buf.pb_nr =
+				src_iv->piv_map.piv_pool_buf.pb_nr;
+	D_DEBUG(DB_MD, "retry pool buf nr %u\n",
+		src_iv->piv_map.piv_pool_buf.pb_nr);
+
+	return 0;
+}
+
+/* update the pool IV map entry */
+static int
+pool_iv_map_ent_update(d_sg_list_t *dst_sgl, struct pool_iv_entry *src_iv)
+{
+	struct pool_iv_entry	*dst_iv;
+	uint32_t		pb_nr = src_iv->piv_map.piv_pool_buf.pb_nr;
+	uint32_t		src_pbuf_size;
+	uint32_t		dst_pbuf_size;
+
+	dst_iv = dst_sgl->sg_iovs[0].iov_buf;
+	if (src_iv->piv_map.piv_pool_buf.pb_target_nr == (uint32_t)(-1)) {
+		/* During fetch aggregation, update/refresh callback might
+		 * be called to store these -1 entry.
+		 **/
+		memcpy(&dst_iv->piv_map.piv_pool_buf,
+		       &src_iv->piv_map.piv_pool_buf, sizeof(*src_iv));
+		return 0;
+	}
+
+	pb_nr = src_iv->piv_map.piv_pool_buf.pb_nr;
+	D_ASSERT(pb_nr > 0);
+	src_pbuf_size = pool_buf_size(pb_nr);
+	dst_pbuf_size = dst_sgl->sg_iovs[0].iov_buf_len -
+			sizeof(struct pool_iv_map) + sizeof(struct pool_buf);
+	if (src_pbuf_size < dst_pbuf_size) {
+		void *new_buf;
+		uint32_t new_size;
+
+		new_size = pool_iv_map_ent_size(pb_nr);
+		D_REALLOC(new_buf, dst_sgl->sg_iovs[0].iov_buf, new_size);
+		if (new_buf == NULL)
+			return -DER_NOMEM;
+
+		dst_sgl->sg_iovs[0].iov_buf = new_buf;
+		dst_sgl->sg_iovs[0].iov_buf_len = new_size;
+		dst_iv = new_buf;
+	}
+
+	memcpy(&dst_iv->piv_map.piv_pool_buf,
+	       &src_iv->piv_map.piv_pool_buf, src_pbuf_size);
+
+	return 0;
+}
+
+static int
+pool_iv_prop_ent_copy(struct pool_iv_entry *dst_iv,
+		      struct pool_iv_entry *src_iv)
+{
+	daos_prop_t	*prop_fetch;
+	int		rc = 0;
+
+	prop_fetch = daos_prop_alloc(DAOS_PROP_PO_NUM);
+	if (prop_fetch == NULL)
+		return -DER_NOMEM;
+
+	rc = pool_iv_prop_g2l(&src_iv->piv_prop, prop_fetch);
+	if (rc) {
+		daos_prop_free(prop_fetch);
+		D_ERROR("prop g2l failed: rc %d\n", rc);
+		return rc;
+	}
+
+	pool_iv_prop_l2g(prop_fetch, &dst_iv->piv_prop);
+	daos_prop_free(prop_fetch);
+
+	return rc;
+}
+
+static void
+pool_iv_srv_hdl_ent_copy(struct pool_iv_entry *dst_iv,
+			 struct pool_iv_entry *src_iv)
+{
+	uuid_copy(dst_iv->piv_hdl.pih_pool_hdl,
+		  src_iv->piv_hdl.pih_pool_hdl);
+	uuid_copy(dst_iv->piv_hdl.pih_cont_hdl,
+		  src_iv->piv_hdl.pih_cont_hdl);
+	D_DEBUG(DB_MD, "pool/cont "DF_UUID"/"DF_UUID"\n",
+		DP_UUID(dst_iv->piv_hdl.pih_pool_hdl),
+		DP_UUID(dst_iv->piv_hdl.pih_cont_hdl));
+}
+
+static int
+pool_iv_ent_copy(struct ds_iv_key *key, d_sg_list_t *dst_sgl,
+		 struct pool_iv_entry *src_iv, bool update)
+{
+	struct pool_iv_entry	*dst_iv = dst_sgl->sg_iovs[0].iov_buf;
+	int			rc = 0;
+
+	D_ASSERT(dst_iv != src_iv);
+	switch (key->class_id) {
+	case IV_POOL_MAP:
+		if (update)
+			rc = pool_iv_map_ent_update(dst_sgl, src_iv);
+		else
+			rc = pool_iv_map_ent_fetch(dst_sgl, src_iv);
+		break;
+	case IV_POOL_PROP:
+		rc = pool_iv_prop_ent_copy(dst_iv, src_iv);
+		break;
+	case IV_POOL_HDL:
+		pool_iv_srv_hdl_ent_copy(dst_iv, src_iv);
+		break;
+	case IV_POOL_CONN:
+		if (update)
+			rc = pool_iv_conns_ent_update(dst_sgl, src_iv);
+		else
+			rc = pool_iv_conns_ent_fetch(dst_sgl, src_iv);
+		break;
+	default:
+		D_ERROR("bad class id %d\n", key->class_id);
+		rc = -DER_INVAL;
+	}
+
+	D_DEBUG(DB_MD, "%u update: %d\n", key->class_id, rc);
 	return rc;
 }
 
 static int
 pool_iv_ent_fetch(struct ds_iv_entry *entry, struct ds_iv_key *key,
-		  d_sg_list_t *dst, d_sg_list_t *src, void **priv)
+		  d_sg_list_t *dst_sgl, void **priv)
 {
-	return pool_iv_ent_copy(key, dst, src);
+	struct pool_iv_entry	*iv_entry = entry->iv_value.sg_iovs[0].iov_buf;
+	int			rc;
+
+	rc = pool_iv_ent_copy(key, dst_sgl, iv_entry, false);
+
+	return rc;
 }
 
 static int
@@ -527,12 +685,13 @@ pool_iv_ent_update(struct ds_iv_entry *entry, struct ds_iv_key *key,
 	struct pool_iv_entry	*src_iv = src->sg_iovs[0].iov_buf;
 	struct ds_pool		*pool;
 	d_rank_t		rank;
-	bool			retried = false;
 	int			rc;
 
 	pool = ds_pool_lookup(entry->ns->iv_pool_uuid);
-	if (pool == NULL)
-		return -DER_NONEXIST;
+	if (pool == NULL) {
+		D_WARN("No pool "DF_UUID"\n", DP_UUID(entry->ns->iv_pool_uuid));
+		D_GOTO(out_put, rc = 0);
+	}
 
 	rc = crt_group_rank(pool->sp_group, &rank);
 	if (rc)
@@ -577,23 +736,10 @@ pool_iv_ent_update(struct ds_iv_entry *entry, struct ds_iv_key *key,
 			D_GOTO(out_put, rc);
 	}
 
-retry:
-	rc = pool_iv_ent_copy(key, &entry->iv_value, src);
-	if (rc == -DER_REC2BIG && key->class_id == IV_POOL_CONN && !retried) {
-		struct pool_iv_key *pik = key2priv(key);
-
-		rc = pool_iv_conns_resize(&entry->iv_value,
-					  pik->pik_entry_size);
-		if (rc == 0) {
-			D_DEBUG(DB_MD, DF_UUID" retry by %u\n",
-				DP_UUID(entry->ns->iv_pool_uuid),
-				pik->pik_entry_size);
-			retried = true;
-			goto retry;
-		}
-	}
-
+	rc = pool_iv_ent_copy(key, &entry->iv_value, src_iv, true);
 out_put:
+	D_DEBUG(DB_MD, DF_UUID": key %u rc %d\n",
+		DP_UUID(entry->ns->iv_pool_uuid), key->class_id, rc);
 	ds_pool_put(pool);
 	return rc;
 }
@@ -656,81 +802,52 @@ static int
 pool_iv_ent_refresh(struct ds_iv_entry *entry, struct ds_iv_key *key,
 		    d_sg_list_t *src, int ref_rc, void **priv)
 {
-	d_iov_t			*dst_iov = &entry->iv_value.sg_iovs[0];
 	struct pool_iv_entry	*src_iv;
-	struct ds_pool		*pool;
-	bool			retried = false;
-	int			rc;
+	struct ds_pool		*pool = 0;
+	int			rc = 0;
 
-	/* Update pool map version or pool map */
-	if (src == NULL) {
-		rc = pool_iv_ent_invalid(entry, key);
-		return rc;
-	}
-
-	if (dst_iov->iov_buf_len < src->sg_iovs[0].iov_len) {
-		char *buf;
-
-		D_DEBUG(DB_MD, DF_UUID" reallocate class %d %zd-->%zd\n",
-			DP_UUID(entry->ns->iv_pool_uuid),
-			entry->iv_class->iv_class_id, dst_iov->iov_buf_len,
-			src->sg_iovs[0].iov_len);
-		D_REALLOC(buf, dst_iov->iov_buf, src->sg_iovs[0].iov_len);
-		if (buf == NULL)
-			return -DER_NOMEM;
-		dst_iov->iov_buf = buf;
-		dst_iov->iov_buf_len = src->sg_iovs[0].iov_len;
-		if (key->class_id == IV_POOL_CONN) {
-			struct pool_iv_conns *conns = dst_iov->iov_buf;
-
-			D_ASSERT(dst_iov->iov_buf_len > sizeof(*conns));
-			conns->pic_buf_size = dst_iov->iov_buf_len -
-					      sizeof(*conns);
-			conns->pic_size = 0;
-		}
-
-	}
-
-retry:
-	rc = pool_iv_ent_copy(key, &entry->iv_value, src);
-	if (rc == -DER_REC2BIG && key->class_id == IV_POOL_CONN && !retried) {
-		struct pool_iv_key *pik = key2priv(key);
-
-		rc = pool_iv_conns_resize(&entry->iv_value,
-					  pik->pik_entry_size);
-		if (rc == 0) {
-			retried = true;
-			goto retry;
-		}
-	}
-
-	if (rc)
-		return rc;
-
-	src_iv = src->sg_iovs[0].iov_buf;
-	D_ASSERTF(src_iv != NULL, "%d\n", entry->iv_class->iv_class_id);
-	/* Update pool map version or pool map */
 	pool = ds_pool_lookup(entry->ns->iv_pool_uuid);
 	if (pool == NULL) {
 		D_WARN("No pool "DF_UUID"\n", DP_UUID(entry->ns->iv_pool_uuid));
-		return 0;
+		D_GOTO(out_put, rc = 0);
 	}
 
+	if (src == NULL) {
+		rc = pool_iv_ent_invalid(entry, key);
+		D_GOTO(out_put, rc);
+	}
+
+	src_iv = src->sg_iovs[0].iov_buf;
 	if (entry->iv_class->iv_class_id == IV_POOL_PROP) {
 		rc = ds_pool_tgt_prop_update(pool, &src_iv->piv_prop);
 	} else if (entry->iv_class->iv_class_id == IV_POOL_CONN) {
 		struct pool_iv_conn *conn;
 		char *end;
 
+		if (src_iv->piv_conn_hdls.pic_size == (unsigned int)(-1) &&
+		    entry->ns->iv_master_rank == dss_self_rank()) {
+			D_DEBUG(DB_MD, "skip -1 update on master %u\n",
+				entry->ns->iv_master_rank);
+			D_GOTO(out_put, rc);
+		}
+
 		conn = src_iv->piv_conn_hdls.pic_conns;
 		end = (char *)conn + src_iv->piv_conn_hdls.pic_size;
 		while (pool_iv_conn_valid(conn, end)) {
 			rc = ds_pool_tgt_connect(pool, conn);
 			if (rc)
-				D_GOTO(out_put, rc);
+				break;
 			conn = pool_iv_conn_next(conn);
 		}
 	} else if (entry->iv_class->iv_class_id == IV_POOL_MAP) {
+		if (src_iv->piv_map.piv_pool_buf.pb_target_nr ==
+					(unsigned int)(-1) &&
+		    entry->ns->iv_master_rank == dss_self_rank()) {
+			D_DEBUG(DB_MD, "skip -1 update on master %u\n",
+				entry->ns->iv_master_rank);
+			D_GOTO(out_put, rc);
+		}
+
 		rc = ds_pool_tgt_map_update(pool,
 				src_iv->piv_map.piv_pool_buf.pb_nr > 0 ?
 				&src_iv->piv_map.piv_pool_buf : NULL,
@@ -738,16 +855,26 @@ retry:
 	} else if (entry->iv_class->iv_class_id == IV_POOL_HDL) {
 		rc = ds_pool_iv_refresh_hdl(pool, &src_iv->piv_hdl);
 	}
+	if (rc)
+		D_GOTO(out_put, rc);
 
+	/* Update IV cache */
+	rc = pool_iv_ent_copy(key, &entry->iv_value, src_iv, true);
+	if (rc)
+		D_GOTO(out_put, rc);
 out_put:
-	ds_pool_put(pool);
+	D_DEBUG(DB_MD, DF_UUID": key %u rc %d\n",
+		DP_UUID(entry->ns->iv_pool_uuid), key->class_id, rc);
+	if (pool)
+		ds_pool_put(pool);
 	return rc;
 }
 
 static int
-pool_iv_value_alloc(struct ds_iv_entry *entry, d_sg_list_t *sgl)
+pool_iv_value_alloc(struct ds_iv_entry *entry,
+		    struct ds_iv_key *key, d_sg_list_t *sgl)
 {
-	return pool_iv_value_alloc_internal(&entry->iv_key, sgl);
+	return pool_iv_value_alloc_internal(key, sgl);
 }
 
 static int
@@ -799,36 +926,45 @@ struct ds_iv_class_ops pool_iv_ops = {
 	.ivc_pre_sync		= pool_iv_pre_sync
 };
 
-int
-pool_iv_map_fetch(void *ns, struct pool_iv_entry *pool_iv)
+static int
+pool_iv_map_fetch(void *ns)
 {
 	d_sg_list_t		sgl = { 0 };
 	d_iov_t			iov = { 0 };
 	uint32_t		pool_iv_len = 0;
 	struct ds_iv_key	key;
+	struct pool_iv_entry	iv_entry = { 0 };
 	struct pool_iv_key	*pool_key;
+	int			pb_nr = 128; /* Init tgt nr */
 	int			rc;
 
-	/* pool_iv == NULL, it means only refreshing local IV cache entry,
-	 * i.e. no need fetch the IV value for the caller.
+	/* sizeof(iv_result) < pool_iv_len, so it will only fetch
+	 * the pool map and cache it locally, instead of copying
+	 * out from ds_iv_fetch. see ds_iv_done().
 	 */
-	if (pool_iv != NULL) {
-		pool_iv_len = pool_buf_size(
-				pool_iv->piv_map.piv_pool_buf.pb_nr);
-		d_iov_set(&iov, pool_iv, pool_iv_len);
-		sgl.sg_nr = 1;
-		sgl.sg_nr_out = 0;
-		sgl.sg_iovs = &iov;
-	}
+	d_iov_set(&iov, &iv_entry, sizeof(iv_entry));
+	sgl.sg_nr = 1;
+	sgl.sg_nr_out = 0;
+	sgl.sg_iovs = &iov;
 
 	memset(&key, 0, sizeof(key));
 	key.class_id = IV_POOL_MAP;
 	pool_key = (struct pool_iv_key *)key.key_buf;
+retry:
+	pool_iv_len = pool_buf_size(pb_nr);
 	pool_key->pik_entry_size = pool_iv_len;
-	rc = ds_iv_fetch(ns, &key, pool_iv == NULL ? NULL : &sgl,
-			 false /* retry */);
-	if (rc)
+	rc = ds_iv_fetch(ns, &key, &sgl, false /* retry */);
+	if (rc) {
 		D_ERROR("iv fetch failed "DF_RC"\n", DP_RC(rc));
+		return rc;
+	}
+
+	if (iv_entry.piv_map.piv_pool_buf.pb_target_nr == (unsigned int)(-1)) {
+		D_ASSERT(iv_entry.piv_map.piv_pool_buf.pb_nr > pb_nr);
+		pb_nr = iv_entry.piv_map.piv_pool_buf.pb_nr;
+		D_DEBUG(DB_MD, "retry by %u\n", pb_nr);
+		goto retry;
+	}
 
 	return rc;
 }
@@ -870,14 +1006,14 @@ ds_pool_iv_map_update(struct ds_pool *pool, struct pool_buf *buf,
 		      uint32_t map_ver)
 {
 	struct pool_iv_entry	*iv_entry;
-	uint32_t		 size;
+	uint32_t		 iv_entry_size;
 	int			 rc;
 
 	D_DEBUG(DB_MD, DF_UUID": map_ver=%u\n", DP_UUID(pool->sp_uuid),
 		map_ver);
 
-	size = pool_iv_map_ent_size(buf->pb_nr);
-	D_ALLOC(iv_entry, size);
+	iv_entry_size = pool_iv_map_ent_size(buf->pb_nr);
+	D_ALLOC(iv_entry, iv_entry_size);
 	if (iv_entry == NULL)
 		return -DER_NOMEM;
 
@@ -890,14 +1026,14 @@ ds_pool_iv_map_update(struct ds_pool *pool, struct pool_buf *buf,
 	 * to revisit here once pool/cart_group/IV is upgraded.
 	 */
 	rc = pool_iv_update(pool->sp_iv_ns, IV_POOL_MAP, pool->sp_uuid,
-			    iv_entry, size, CRT_IV_SHORTCUT_NONE,
+			    iv_entry, iv_entry_size, CRT_IV_SHORTCUT_NONE,
 			    CRT_IV_SYNC_EAGER, false);
 	if (rc != 0)
 		D_DEBUG(DB_MD, DF_UUID": map_ver=%u: %d\n",
 			DP_UUID(pool->sp_uuid), map_ver, rc);
 
-	D_DEBUG(DB_MD, DF_UUID": map_ver=%u: %d\n",
-		DP_UUID(pool->sp_uuid), map_ver, rc);
+	D_DEBUG(DB_MD, DF_UUID": map_ver=%u: %d\n", DP_UUID(pool->sp_uuid),
+		map_ver, rc);
 
 	D_FREE(iv_entry);
 	return rc;
@@ -909,12 +1045,12 @@ ds_pool_iv_conn_hdl_update(struct ds_pool *pool, uuid_t hdl_uuid,
 			   d_iov_t *cred)
 {
 	struct pool_iv_entry	*iv_entry;
+	daos_size_t		iv_entry_size;
 	struct pool_iv_conn	*pic;
-	size_t			size;
 	int			rc;
 
-	size = pool_iv_conn_ent_size(cred->iov_len);
-	D_ALLOC(iv_entry, size);
+	iv_entry_size = pool_iv_conn_ent_size(cred->iov_len);
+	D_ALLOC(iv_entry, iv_entry_size);
 	if (iv_entry == NULL)
 		return -DER_NOMEM;
 
@@ -928,54 +1064,52 @@ ds_pool_iv_conn_hdl_update(struct ds_pool *pool, uuid_t hdl_uuid,
 	memcpy(&pic->pic_creds[0], cred->iov_buf, cred->iov_len);
 
 	rc = pool_iv_update(pool->sp_iv_ns, IV_POOL_CONN, hdl_uuid,
-			    iv_entry, size, CRT_IV_SHORTCUT_NONE,
+			    iv_entry, iv_entry_size, CRT_IV_SHORTCUT_NONE,
 			    CRT_IV_SYNC_EAGER, false);
 	D_DEBUG(DB_MD, DF_UUID" distribute hdl "DF_UUID" capas "DF_U64" %d\n",
 		DP_UUID(pool->sp_uuid), DP_UUID(hdl_uuid), sec_capas, rc);
+
 	D_FREE(iv_entry);
 	return rc;
 }
 
-/* If uuid is NULL, it means to get all pool connect handles for the pool */
+/* Get all pool connect handles for the pool */
 int
-ds_pool_iv_conn_hdl_fetch(struct ds_pool *pool, uuid_t key_uuid,
-			  d_iov_t *conn_iov)
+ds_pool_iv_conn_hdl_fetch(struct ds_pool *pool)
 {
 	d_sg_list_t		sgl = { 0 };
-	struct ds_iv_key	key;
+	d_iov_t			iov = { 0 };
+	struct pool_iv_entry	iv_entry = { 0 };
 	struct pool_iv_key	*pool_key;
+	struct ds_iv_key	key = { 0 };
+	uint32_t		entry_size;
 	int			rc;
 
-	if (conn_iov == NULL)
-		return -DER_INVAL;
-
+	d_iov_set(&iov, &iv_entry, sizeof(iv_entry));
 	sgl.sg_nr = 1;
 	sgl.sg_nr_out = 0;
-	sgl.sg_iovs = conn_iov;
-	if (conn_iov != NULL && conn_iov->iov_buf) {
-		struct pool_iv_conns *conns;
+	sgl.sg_iovs = &iov;
 
-		conns = conn_iov->iov_buf;
-		conns->pic_size = 0;
-		conns->pic_buf_size = conn_iov->iov_buf_len -
-				      sizeof(*conns);
-	}
-	memset(&key, 0, sizeof(key));
 	key.class_id = IV_POOL_CONN;
 	pool_key = key2priv(&key);
-	pool_key->pik_entry_size = conn_iov->iov_len;
-	if (key_uuid)
-		uuid_copy(pool_key->pik_uuid, key_uuid);
+	entry_size = sizeof(iv_entry);
 
+retry:
+	pool_key->pik_entry_size = entry_size;
 	rc = ds_iv_fetch(pool->sp_iv_ns, &key, &sgl, false /* retry */);
 	if (rc) {
-		if (rc == -DER_REC2BIG)
-			conn_iov->iov_len = pool_key->pik_entry_size;
 		D_ERROR("iv fetch failed "DF_RC"\n", DP_RC(rc));
-		D_GOTO(out, rc);
+		return rc;
 	}
-out:
-	return rc;
+
+	if (iv_entry.piv_conn_hdls.pic_size == (uint32_t)(-1)) {
+		D_ASSERT(iv_entry.piv_conn_hdls.pic_buf_size > entry_size);
+		entry_size = iv_entry.piv_conn_hdls.pic_buf_size;
+		D_DEBUG(DB_MD, "retry by %u\n", entry_size);
+		goto retry;
+	}
+
+	return 0;
 }
 
 int
@@ -1058,7 +1192,7 @@ ds_pool_map_refresh_ult(void *arg)
 	if (rc)
 		goto unlock;
 
-	rc = pool_iv_map_fetch(pool->sp_iv_ns, NULL);
+	rc = pool_iv_map_fetch(pool->sp_iv_ns);
 
 unlock:
 	ABT_mutex_unlock(pool->sp_mutex);
@@ -1089,8 +1223,8 @@ int
 ds_pool_iv_srv_hdl_update(struct ds_pool *pool, uuid_t pool_hdl_uuid,
 			  uuid_t cont_hdl_uuid)
 {
-	struct pool_iv_entry	iv_entry;
-	int			 rc;
+	struct pool_iv_entry	iv_entry = { 0 };
+	int			rc;
 
 	/* Only happens on xstream 0 */
 	D_ASSERT(dss_get_module_info()->dmi_xs_id == 0);
@@ -1101,7 +1235,8 @@ ds_pool_iv_srv_hdl_update(struct ds_pool *pool, uuid_t pool_hdl_uuid,
 	rc = pool_iv_update(pool->sp_iv_ns, IV_POOL_HDL, pool_hdl_uuid,
 			    &iv_entry, sizeof(struct pool_iv_entry),
 			    CRT_IV_SHORTCUT_NONE, CRT_IV_SYNC_LAZY, true);
-	if (rc)
+
+	if (rc != 0)
 		D_ERROR("pool_iv_update failed "DF_RC"\n", DP_RC(rc));
 
 	return rc;
@@ -1111,14 +1246,14 @@ int
 ds_pool_iv_srv_hdl_fetch(struct ds_pool *pool, uuid_t *pool_hdl_uuid,
 			 uuid_t *cont_hdl_uuid)
 {
-	struct pool_iv_entry	iv_entry;
+	struct pool_iv_entry	iv_entry = { 0 };
 	d_sg_list_t		sgl = { 0 };
 	d_iov_t			iov = { 0 };
 	struct ds_iv_key	 key;
 	struct pool_iv_key	*pool_key;
 	int			 rc;
 
-	d_iov_set(&iov, &iv_entry, sizeof(struct pool_iv_entry));
+	d_iov_set(&iov, &iv_entry, sizeof(iv_entry));
 	sgl.sg_nr = 1;
 	sgl.sg_nr_out = 0;
 	sgl.sg_iovs = &iov;
@@ -1202,10 +1337,10 @@ out_eventual:
 int
 ds_pool_iv_prop_update(struct ds_pool *pool, daos_prop_t *prop)
 {
-	struct pool_iv_entry	*iv_entry;
+	struct pool_iv_entry	*iv_entry = NULL;
+	uint32_t		 iv_entry_size;
 	struct daos_prop_entry	*prop_entry;
 	d_rank_list_t		*svc_list;
-	uint32_t		 size;
 	int			 rc;
 
 	/* Only happens on xstream 0 */
@@ -1218,21 +1353,24 @@ ds_pool_iv_prop_update(struct ds_pool *pool, daos_prop_t *prop)
 
 	svc_list = prop_entry->dpe_val_ptr;
 
-	size = pool_iv_prop_ent_size(DAOS_ACL_MAX_ACE_LEN, svc_list->rl_nr);
-	D_ALLOC(iv_entry, size);
+	iv_entry_size = pool_iv_prop_ent_size(DAOS_ACL_MAX_ACE_LEN,
+					      svc_list->rl_nr);
+	D_ALLOC(iv_entry, iv_entry_size);
 	if (iv_entry == NULL)
 		D_GOTO(out, rc = -DER_NOMEM);
 
 	pool_iv_prop_l2g(prop, &iv_entry->piv_prop);
 
 	rc = pool_iv_update(pool->sp_iv_ns, IV_POOL_PROP, pool->sp_uuid,
-			    iv_entry, size, CRT_IV_SHORTCUT_NONE,
+			    iv_entry, iv_entry_size, CRT_IV_SHORTCUT_NONE,
 			    CRT_IV_SYNC_LAZY, true);
-	if (rc)
+	if (rc != 0)
 		D_ERROR("pool_iv_update failed "DF_RC"\n", DP_RC(rc));
 
 	D_FREE(iv_entry);
 out:
+	if (iv_entry)
+		D_FREE(iv_entry);
 	return rc;
 }
 
@@ -1298,27 +1436,23 @@ ds_pool_iv_prop_fetch(struct ds_pool *pool, daos_prop_t *prop)
 {
 	daos_prop_t		*prop_fetch = NULL;
 	struct pool_iv_entry	*iv_entry;
+	uint32_t		 iv_entry_size;
 	d_sg_list_t		 sgl = { 0 };
 	d_iov_t			 iov = { 0 };
 	struct ds_iv_key	 key;
 	struct pool_iv_key	*pool_key;
-	uint32_t		 size;
 	int			 rc;
 
 	if (prop == NULL)
 		return -DER_INVAL;
 
-	size = pool_iv_prop_ent_size(DAOS_ACL_MAX_ACE_LEN,
-				     PROP_SVC_LIST_MAX_TMP);
-	D_ALLOC(iv_entry, size);
+	iv_entry_size = pool_iv_prop_ent_size(DAOS_ACL_MAX_ACE_LEN,
+					      PROP_SVC_LIST_MAX_TMP);
+	D_ALLOC(iv_entry, iv_entry_size);
 	if (iv_entry == NULL)
 		D_GOTO(out, rc = -DER_NOMEM);
 
-	prop_fetch = daos_prop_alloc(DAOS_PROP_PO_NUM);
-	if (prop_fetch == NULL)
-		D_GOTO(out, rc = -DER_NOMEM);
-
-	d_iov_set(&iov, iv_entry, size);
+	d_iov_set(&iov, iv_entry, iv_entry_size);
 	sgl.sg_nr = 1;
 	sgl.sg_nr_out = 0;
 	sgl.sg_iovs = &iov;
@@ -1326,12 +1460,16 @@ ds_pool_iv_prop_fetch(struct ds_pool *pool, daos_prop_t *prop)
 	memset(&key, 0, sizeof(key));
 	key.class_id = IV_POOL_PROP;
 	pool_key = (struct pool_iv_key *)key.key_buf;
-	pool_key->pik_entry_size = size;
+	pool_key->pik_entry_size = iv_entry_size;
 	rc = ds_iv_fetch(pool->sp_iv_ns, &key, &sgl, false /* retry */);
 	if (rc) {
 		D_ERROR("iv fetch failed "DF_RC"\n", DP_RC(rc));
 		D_GOTO(out, rc);
 	}
+
+	prop_fetch = daos_prop_alloc(DAOS_PROP_PO_NUM);
+	if (prop_fetch == NULL)
+		D_GOTO(out, rc = -DER_NOMEM);
 
 	rc = pool_iv_prop_g2l(&iv_entry->piv_prop, prop_fetch);
 	if (rc) {
@@ -1346,8 +1484,10 @@ ds_pool_iv_prop_fetch(struct ds_pool *pool, daos_prop_t *prop)
 	}
 
 out:
-	D_FREE(iv_entry);
-	daos_prop_free(prop_fetch);
+	if (iv_entry)
+		D_FREE(iv_entry);
+	if (prop_fetch)
+		daos_prop_free(prop_fetch);
 	return rc;
 }
 

--- a/src/pool/srv_target.c
+++ b/src/pool/srv_target.c
@@ -488,13 +488,10 @@ ds_pool_put(struct ds_pool *pool)
 	ABT_mutex_unlock(pool_cache_lock);
 }
 
-#define STACK_HDL_BUF_SIZE	1024
 void
 pool_fetch_hdls_ult(void *data)
 {
 	struct ds_pool	*pool = data;
-	char		buf[STACK_HDL_BUF_SIZE];
-	d_iov_t		iov = { 0 };
 	int		rc = 0;
 
 	/* sp_map == NULL means the IV ns is not setup yet, i.e.
@@ -505,32 +502,15 @@ pool_fetch_hdls_ult(void *data)
 	if (pool->sp_map == NULL)
 		ABT_cond_wait(pool->sp_fetch_hdls_cond, pool->sp_mutex);
 	ABT_mutex_unlock(pool->sp_mutex);
-retry:
+
 	if (pool->sp_stopping) {
 		D_DEBUG(DB_MD, DF_UUID" skip fetching hdl due to stop\n",
 			DP_UUID(pool->sp_uuid));
 		D_GOTO(out, rc);
 	}
-	memset(buf, 0, STACK_HDL_BUF_SIZE);
-	d_iov_set(&iov, buf, STACK_HDL_BUF_SIZE);
-	rc = ds_pool_iv_conn_hdl_fetch(pool, NULL, &iov);
+	rc = ds_pool_iv_conn_hdl_fetch(pool);
 	if (rc) {
-		if (rc == -DER_REC2BIG) {
-			char		*new_buf;
-			uint64_t	new_size = iov.iov_len;
-
-			D_ALLOC(new_buf, new_size);
-			if (new_buf == NULL)
-				D_GOTO(out, rc = -DER_NOMEM);
-			if (iov.iov_buf != buf)
-				daos_iov_free(&iov);
-			iov.iov_buf = new_buf;
-			iov.iov_buf_len = new_size;
-			iov.iov_len = 0;
-			D_DEBUG(DB_MD, "realloc "DF_U64" and retry.\n",
-				new_size);
-			D_GOTO(retry, rc);
-		}
+		D_ERROR("iv conn fetch %d\n", rc);
 		D_GOTO(out, rc);
 	}
 
@@ -540,9 +520,6 @@ out:
 	ABT_mutex_unlock(pool->sp_mutex);
 
 	pool->sp_fetch_hdls = 0;
-
-	if (iov.iov_buf != NULL && iov.iov_buf != buf)
-		D_FREE(iov.iov_buf);
 }
 
 static void

--- a/src/rebuild/rebuild_iv.c
+++ b/src/rebuild/rebuild_iv.c
@@ -81,7 +81,7 @@ rebuild_iv_ent_destroy(d_sg_list_t *sgl)
 
 static int
 rebuild_iv_ent_fetch(struct ds_iv_entry *entry, struct ds_iv_key *key,
-		     d_sg_list_t *dst, d_sg_list_t *src, void **priv)
+		     d_sg_list_t *dst, void **priv)
 {
 	D_ASSERT(0);
 	return 0;
@@ -247,7 +247,8 @@ out:
 }
 
 static int
-rebuild_iv_alloc(struct ds_iv_entry *entry, d_sg_list_t *sgl)
+rebuild_iv_alloc(struct ds_iv_entry *entry, struct ds_iv_key *key,
+		 d_sg_list_t *sgl)
 {
 	return rebuild_iv_alloc_internal(sgl);
 }

--- a/src/tests/suite/daos_container.c
+++ b/src/tests/suite/daos_container.c
@@ -2058,8 +2058,9 @@ co_open_fail_destroy(void **state)
 
 	rc = daos_cont_open(arg->pool.poh, uuid, DAOS_COO_RW, &coh, &info,
 			    NULL);
+	daos_debug_set_params(arg->group, -1, DMG_KEY_FAIL_LOC,
+			      0, 0, NULL);
 	assert_rc_equal(rc, -DER_IO);
-
 	print_message("destroying container ... ");
 	rc = daos_cont_destroy(arg->pool.poh, uuid, 1 /* force */, NULL);
 	assert_rc_equal(rc, 0);

--- a/src/tests/suite/daos_rebuild_simple.c
+++ b/src/tests/suite/daos_rebuild_simple.c
@@ -178,6 +178,7 @@ rebuild_indexes(void **state)
 		assert_rc_equal(rc, -DER_NOSYS);
 }
 
+#define SNAP_CNT	20
 static void
 rebuild_snap_update_recs(void **state)
 {
@@ -187,7 +188,7 @@ rebuild_snap_update_recs(void **state)
 	daos_recx_t	recx;
 	int		tgt = DEFAULT_FAIL_TGT;
 	char		string[100] = { 0 };
-	daos_epoch_t	snap_epoch[5];
+	daos_epoch_t	snap_epoch[SNAP_CNT];
 	int		i;
 	int		rc;
 
@@ -198,7 +199,7 @@ rebuild_snap_update_recs(void **state)
 	oid = dts_oid_set_rank(oid, ranks_to_kill[0]);
 	oid = dts_oid_set_tgt(oid, tgt);
 	ioreq_init(&req, arg->coh, oid, DAOS_IOD_ARRAY, arg);
-	for (i = 0; i < 5; i++)
+	for (i = 0; i < SNAP_CNT; i++)
 		sprintf(string + strlen(string), "old-snap%d", i);
 
 	recx.rx_idx = 0;
@@ -206,8 +207,8 @@ rebuild_snap_update_recs(void **state)
 	insert_recxs("d_key", "a_key", 1, DAOS_TX_NONE, &recx, 1, string,
 		     strlen(string) + 1, &req);
 
-	for (i = 0; i < 5; i++) {
-		char data[20] = { 0 };
+	for (i = 0; i < SNAP_CNT; i++) {
+		char data[100] = { 0 };
 
 		/* Update string for each snapshot */
 		daos_cont_create_snap(arg->coh, &snap_epoch[i], NULL, NULL);
@@ -220,7 +221,8 @@ rebuild_snap_update_recs(void **state)
 	ioreq_fini(&req);
 
 	rebuild_single_pool_target(arg, ranks_to_kill[0], tgt, false);
-	for (i = 0; i < 5; i++) {
+
+	for (i = 0; i < SNAP_CNT; i++) {
 		rc = daos_obj_verify(arg->coh, oid, snap_epoch[i]);
 		if (rc != 0)
 			assert_rc_equal(rc, -DER_NOSYS);
@@ -230,7 +232,7 @@ rebuild_snap_update_recs(void **state)
 		assert_rc_equal(rc, -DER_NOSYS);
 
 	reintegrate_single_pool_target(arg, ranks_to_kill[0], tgt);
-	for (i = 0; i < 5; i++) {
+	for (i = 0; i < SNAP_CNT; i++) {
 		rc = daos_obj_verify(arg->coh, oid, snap_epoch[i]);
 		if (rc != 0)
 			assert_rc_equal(rc, -DER_NOSYS);
@@ -248,8 +250,8 @@ rebuild_snap_punch_recs(void **state)
 	struct ioreq	req;
 	daos_recx_t	recx;
 	int		tgt = DEFAULT_FAIL_TGT;
-	char		string[100];
-	daos_epoch_t	snap_epoch[5];
+	char		string[200];
+	daos_epoch_t	snap_epoch[SNAP_CNT];
 	int		i;
 	int		rc;
 
@@ -260,7 +262,7 @@ rebuild_snap_punch_recs(void **state)
 	oid = dts_oid_set_rank(oid, ranks_to_kill[0]);
 	oid = dts_oid_set_tgt(oid, tgt);
 	ioreq_init(&req, arg->coh, oid, DAOS_IOD_ARRAY, arg);
-	for (i = 0; i < 5; i++)
+	for (i = 0; i < SNAP_CNT; i++)
 		sprintf(string + strlen(string), "old-snap%d", i);
 
 	recx.rx_idx = 0;
@@ -268,7 +270,7 @@ rebuild_snap_punch_recs(void **state)
 	insert_recxs("d_key", "a_key", 1, DAOS_TX_NONE, &recx, 1, string,
 		     strlen(string) + 1, &req);
 
-	for (i = 0; i < 5; i++) {
+	for (i = 0; i < SNAP_CNT; i++) {
 		/* punch string */
 		daos_cont_create_snap(arg->coh, &snap_epoch[i], NULL, NULL);
 		recx.rx_idx = i * 9; /* strlen("old-snap%d") */
@@ -278,7 +280,8 @@ rebuild_snap_punch_recs(void **state)
 	ioreq_fini(&req);
 
 	rebuild_single_pool_target(arg, ranks_to_kill[0], tgt, false);
-	for (i = 0; i < 5; i++) {
+
+	for (i = 0; i < SNAP_CNT; i++) {
 		rc = daos_obj_verify(arg->coh, oid, snap_epoch[i]);
 		if (rc != 0)
 			assert_rc_equal(rc, -DER_NOSYS);
@@ -288,7 +291,7 @@ rebuild_snap_punch_recs(void **state)
 		assert_rc_equal(rc, -DER_NOSYS);
 
 	reintegrate_single_pool_target(arg, ranks_to_kill[0], tgt);
-	for (i = 0; i < 5; i++) {
+	for (i = 0; i < SNAP_CNT; i++) {
 		rc = daos_obj_verify(arg->coh, oid, snap_epoch[i]);
 		if (rc != 0)
 			assert_rc_equal(rc, -DER_NOSYS);
@@ -305,7 +308,7 @@ rebuild_snap_update_keys(void **state)
 	daos_obj_id_t	oid;
 	struct ioreq	req;
 	int		tgt = DEFAULT_FAIL_TGT;
-	daos_epoch_t	snap_epoch[5];
+	daos_epoch_t	snap_epoch[SNAP_CNT];
 	int		i;
 	int		rc;
 
@@ -317,7 +320,7 @@ rebuild_snap_update_keys(void **state)
 	oid = dts_oid_set_tgt(oid, tgt);
 	ioreq_init(&req, arg->coh, oid, DAOS_IOD_ARRAY, arg);
 	/* Insert dkey/akey by different snapshot */
-	for (i = 0; i < 5; i++) {
+	for (i = 0; i < SNAP_CNT; i++) {
 		char dkey[20] = { 0 };
 		char akey[20] = { 0 };
 
@@ -334,26 +337,26 @@ rebuild_snap_update_keys(void **state)
 	daos_fail_loc_set(DAOS_OBJ_SPECIAL_SHARD);
 	for (i = 0; i < OBJ_REPLICAS; i++) {
 		uint32_t	number;
-		daos_key_desc_t kds[10];
+		daos_key_desc_t kds[SNAP_CNT];
 		daos_anchor_t	anchor = { 0 };
 		char		buf[256];
 		int		buf_len = 256;
 		int		j;
 
 		daos_fail_value_set(i);
-		for (j = 0; j < 5; j++) {
+		for (j = 0; j < SNAP_CNT; j++) {
 			daos_handle_t	th_open;
 
 			memset(&anchor, 0, sizeof(anchor));
 			daos_tx_open_snap(arg->coh, snap_epoch[j], &th_open,
 					  NULL);
-			number = 10;
+			number = SNAP_CNT;
 			enumerate_dkey(th_open, &number, kds, &anchor, buf,
 				       buf_len, &req);
 
 			assert_int_equal(number, j > 0 ? j+1 : 0);
 
-			number = 10;
+			number = SNAP_CNT;
 			memset(&anchor, 0, sizeof(anchor));
 			enumerate_akey(th_open, "dkey", &number, kds, &anchor,
 				       buf, buf_len, &req);
@@ -361,17 +364,17 @@ rebuild_snap_update_keys(void **state)
 			assert_int_equal(number, j);
 			daos_tx_close(th_open, NULL);
 		}
-		number = 10;
+		number = SNAP_CNT;
 		memset(&anchor, 0, sizeof(anchor));
 		enumerate_dkey(DAOS_TX_NONE, &number, kds, &anchor, buf,
 			       buf_len, &req);
-		assert_int_equal(number, 6);
+		assert_int_equal(number, SNAP_CNT);
 
-		number = 10;
+		number = SNAP_CNT;
 		memset(&anchor, 0, sizeof(anchor));
 		enumerate_akey(DAOS_TX_NONE, "dkey", &number, kds, &anchor,
 			       buf, buf_len, &req);
-		assert_int_equal(number, 5);
+		assert_int_equal(number, SNAP_CNT);
 	}
 
 	reintegrate_single_pool_target(arg, ranks_to_kill[0], tgt);
@@ -388,7 +391,7 @@ rebuild_snap_punch_keys(void **state)
 	daos_obj_id_t	oid;
 	struct ioreq	req;
 	int		tgt = DEFAULT_FAIL_TGT;
-	daos_epoch_t	snap_epoch[5];
+	daos_epoch_t	snap_epoch[SNAP_CNT];
 	int		i;
 	int		rc;
 
@@ -400,7 +403,7 @@ rebuild_snap_punch_keys(void **state)
 	oid = dts_oid_set_tgt(oid, tgt);
 	ioreq_init(&req, arg->coh, oid, DAOS_IOD_ARRAY, arg);
 	/* Insert dkey/akey */
-	for (i = 0; i < 5; i++) {
+	for (i = 0; i < SNAP_CNT; i++) {
 		char dkey[20] = { 0 };
 		char akey[20] = { 0 };
 		char akey2[20] = { 0 };
@@ -417,8 +420,8 @@ rebuild_snap_punch_keys(void **state)
 		insert_single("dkey", akey2, 0, "data", 1, DAOS_TX_NONE, &req);
 	}
 
-	/* Insert dkey/akey by different epoch */
-	for (i = 0; i < 5; i++) {
+	/* punch dkey/akey by different epoch */
+	for (i = 0; i < SNAP_CNT; i++) {
 		char dkey[20] = { 0 };
 		char akey[20] = { 0 };
 
@@ -434,46 +437,46 @@ rebuild_snap_punch_keys(void **state)
 
 	daos_fail_loc_set(DAOS_OBJ_SPECIAL_SHARD);
 	for (i = 0; i < OBJ_REPLICAS; i++) {
-		daos_key_desc_t  kds[10];
+		daos_key_desc_t  kds[2 * SNAP_CNT];
 		daos_anchor_t	 anchor;
-		char		 buf[256];
-		int		 buf_len = 256;
+		char		 buf[512];
+		int		 buf_len = 512;
 		uint32_t	 number;
 		int		 j;
 
 		daos_fail_value_set(i);
-		for (j = 0; j < 5; j++) {
+		for (j = 0; j < SNAP_CNT; j++) {
 			daos_handle_t th_open;
 
 			rc = daos_tx_open_snap(arg->coh, snap_epoch[j],
 					       &th_open, NULL);
-			assert_rc_equal(rc, 0);
-			number = 10;
+			assert_int_equal(rc, 0);
+			number = 2 * SNAP_CNT;
 			memset(&anchor, 0, sizeof(anchor));
 			enumerate_dkey(th_open, &number, kds, &anchor, buf,
 				       buf_len, &req);
-			assert_int_equal(number, 6 - j);
+			assert_int_equal(number, 21 - j);
 
-			number = 10;
+			number = 2 * SNAP_CNT;
 			memset(&anchor, 0, sizeof(anchor));
 			enumerate_akey(th_open, "dkey", &number, kds,
 				       &anchor, buf, buf_len, &req);
-			assert_int_equal(number, 10 - j);
+			assert_int_equal(number, 2 * SNAP_CNT - j);
 
 			daos_tx_close(th_open, NULL);
 		}
 
-		number = 10;
+		number =  2 * SNAP_CNT;
 		memset(&anchor, 0, sizeof(anchor));
 		enumerate_dkey(DAOS_TX_NONE, &number, kds, &anchor, buf,
 			       buf_len, &req);
 		assert_int_equal(number, 1);
 
-		number = 10;
+		number = 2 * SNAP_CNT;
 		memset(&anchor, 0, sizeof(anchor));
 		enumerate_akey(DAOS_TX_NONE, "dkey", &number, kds, &anchor,
 			       buf, buf_len, &req);
-		assert_int_equal(number, 5);
+		assert_int_equal(number, SNAP_CNT);
 	}
 
 	reintegrate_single_pool_target(arg, ranks_to_kill[0], tgt);
@@ -810,6 +813,38 @@ rebuild_small_pool_n4_setup(void **state)
 	return 0;
 }
 
+static void
+rebuild_large_snap(void **state)
+{
+	test_arg_t	*arg = *state;
+	daos_obj_id_t	oid;
+	struct ioreq	req;
+	int		tgt = DEFAULT_FAIL_TGT;
+	daos_epoch_t	snap_epoch[100];
+	int		i;
+
+	oid = dts_oid_gen(arg->obj_class, 0, arg->myrank);
+	oid = dts_oid_set_rank(oid, ranks_to_kill[0]);
+	oid = dts_oid_set_tgt(oid, tgt);
+	ioreq_init(&req, arg->coh, oid, DAOS_IOD_ARRAY, arg);
+	/* Insert dkey/akey by different snapshot */
+	for (i = 0; i < 100; i++) {
+		char dkey[20] = { 0 };
+		char akey[20] = { 0 };
+
+		/* Update string for each snapshot */
+		daos_cont_create_snap(arg->coh, &snap_epoch[i], NULL, NULL);
+		sprintf(dkey, "dkey_%d", i);
+		sprintf(akey, "akey_%d", i);
+		insert_single(dkey, "a_key", 0, "data", 1, DAOS_TX_NONE, &req);
+		insert_single("dkey", akey, 0, "data", 1, DAOS_TX_NONE, &req);
+	}
+
+	rebuild_single_pool_target(arg, ranks_to_kill[0], tgt, false);
+	ioreq_fini(&req);
+	reintegrate_single_pool_target(arg, ranks_to_kill[0], tgt);
+}
+
 /** create a new pool/container for each test */
 static const struct CMUnitTest rebuild_tests[] = {
 	{"REBUILD1: rebuild small rec multiple dkeys",
@@ -840,6 +875,8 @@ static const struct CMUnitTest rebuild_tests[] = {
 	 rebuild_xsf_object, rebuild_small_sub_setup, test_teardown},
 	{"REBUILD14: rebuild large stripe object",
 	 rebuild_large_object, rebuild_small_pool_n4_setup, test_teardown},
+	{"REBUILD15: rebuild with 100 snapshot",
+	 rebuild_large_snap, rebuild_small_sub_setup, test_teardown},
 };
 
 int


### PR DESCRIPTION
Remove temporay maxim snapshot limitation, and add
retry for snapshot IV fetch if the fetching buffer
is not big enough.

Add ifo_misc for cart iv fetch so it will return size
information for REC2BIG error.

Move some crt_proc_d_sg_list_t from object module to
cart so ifo_misc can use it.

Add tests in rebuild_simple to verify the large
snapshot handling.

Signed-off-by: Di Wang <di.wang@intel.com>