### PR TITLE
DAOS-5872 bio: Avoid health data collecting on shutdown

### DIFF
--- a/src/bio/bio_device.c
+++ b/src/bio/bio_device.c
@@ -325,15 +325,16 @@ replace_dev(struct bio_xs_context *xs_ctxt, struct smd_dev_info *old_info,
 	/* Avoid re-enter or being destroyed by hot remove callback */
 	new_dev->bb_replacing = true;
 
-	/* Create existing blobs on new device */
 	D_INIT_LIST_HEAD(&pool_list);
+	D_INIT_LIST_HEAD(&blob_list);
+
+	/* Create existing blobs on new device */
 	rc = smd_pool_list(&pool_list, &pool_cnt);
 	if (rc) {
 		D_ERROR("Failed to list pools in SMD. "DF_RC"\n", DP_RC(rc));
 		goto out;
 	}
 
-	D_INIT_LIST_HEAD(&blob_list);
 	rc = create_old_blobs(xs_ctxt, old_info, new_dev, &pool_list,
 			      &blob_list);
 	if (rc) {

--- a/src/bio/bio_monitor.c
+++ b/src/bio/bio_monitor.c
@@ -147,13 +147,28 @@ bio_dev_set_faulty(struct bio_xs_context *xs)
 	return rc;
 }
 
+static inline struct bio_dev_health *
+xs_ctxt2dev_health(struct bio_xs_context *ctxt)
+{
+	D_ASSERT(ctxt != NULL);
+	/* bio_xsctxt_free() is underway */
+	if (ctxt->bxc_blobstore == NULL)
+		return NULL;
+
+	return &ctxt->bxc_blobstore->bb_dev_health;
+}
+
 static void
 get_spdk_err_log_page_completion(struct spdk_bdev_io *bdev_io, bool success,
 				 void *cb_arg)
 {
-	struct bio_dev_health			 *dev_health = cb_arg;
-	int					  sc, sct;
-	uint32_t				  cdw0;
+	struct bio_xs_context	*ctxt = cb_arg;
+	struct bio_dev_health	*dev_health = xs_ctxt2dev_health(ctxt);
+	int			 sc, sct;
+	uint32_t		 cdw0;
+
+	if (dev_health == NULL)
+		goto out;
 
 	D_ASSERT(dev_health->bdh_inflights == 1);
 
@@ -162,10 +177,11 @@ get_spdk_err_log_page_completion(struct spdk_bdev_io *bdev_io, bool success,
 	if (sc)
 		D_ERROR("NVMe status code/type: %d/%d\n", sc, sct);
 
-	/* Free I/O request in the completion callback */
-	spdk_bdev_free_io(bdev_io);
 	/*Decrease inflights on error or successful callback completion chain*/
 	dev_health->bdh_inflights--;
+out:
+	/* Free I/O request in the completion callback */
+	spdk_bdev_free_io(bdev_io);
 }
 
 static int
@@ -195,7 +211,8 @@ static void
 get_spdk_identify_ctrlr_completion(struct spdk_bdev_io *bdev_io, bool success,
 				   void *cb_arg)
 {
-	struct bio_dev_health		*dev_health = cb_arg;
+	struct bio_xs_context		*ctxt = cb_arg;
+	struct bio_dev_health		*dev_health = xs_ctxt2dev_health(ctxt);
 	struct spdk_nvme_ctrlr_data	*cdata;
 	struct spdk_bdev		*bdev;
 	struct spdk_nvme_cmd		 cmd;
@@ -205,6 +222,9 @@ get_spdk_identify_ctrlr_completion(struct spdk_bdev_io *bdev_io, bool success,
 	int				 rc;
 	int				 sc, sct;
 	uint32_t			 cdw0;
+
+	if (dev_health == NULL)
+		goto out;
 
 	D_ASSERT(dev_health->bdh_inflights == 1);
 
@@ -256,7 +276,7 @@ get_spdk_identify_ctrlr_completion(struct spdk_bdev_io *bdev_io, bool success,
 					   dev_health->bdh_error_buf,
 					   ep_buf_sz,
 					   get_spdk_err_log_page_completion,
-					   dev_health);
+					   ctxt);
 	if (rc) {
 		D_ERROR("NVMe admin passthru (error log), rc:%d\n", rc);
 		dev_health->bdh_inflights--;
@@ -295,12 +315,16 @@ static void
 get_spdk_log_page_completion(struct spdk_bdev_io *bdev_io, bool success,
 			     void *cb_arg)
 {
-	struct bio_dev_health	*dev_health = cb_arg;
+	struct bio_xs_context	*ctxt = cb_arg;
+	struct bio_dev_health	*dev_health = xs_ctxt2dev_health(ctxt);
 	struct spdk_bdev	*bdev;
 	struct spdk_nvme_cmd	 cmd;
 	uint32_t		 cp_sz;
 	int			 rc, sc, sct;
 	uint32_t		 cdw0;
+
+	if (dev_health == NULL)
+		goto out;
 
 	D_ASSERT(dev_health->bdh_inflights == 1);
 
@@ -337,7 +361,7 @@ get_spdk_log_page_completion(struct spdk_bdev_io *bdev_io, bool success,
 					   dev_health->bdh_ctrlr_buf,
 					   cp_sz,
 					   get_spdk_identify_ctrlr_completion,
-					   dev_health);
+					   ctxt);
 	if (rc) {
 		D_ERROR("NVMe admin passthru (identify ctrlr), rc:%d\n", rc);
 		dev_health->bdh_inflights--;
@@ -365,8 +389,9 @@ auto_detect_faulty(struct bio_blobstore *bbs)
 
 /* Collect the raw device health state through SPDK admin APIs */
 static void
-collect_raw_health_data(struct bio_dev_health *dev_health)
+collect_raw_health_data(struct bio_xs_context *ctxt)
 {
+	struct bio_dev_health	*dev_health = xs_ctxt2dev_health(ctxt);
 	struct spdk_bdev	*bdev;
 	struct spdk_nvme_cmd	 cmd;
 	uint32_t		 numd, numdl, numdu;
@@ -420,7 +445,7 @@ collect_raw_health_data(struct bio_dev_health *dev_health)
 					   dev_health->bdh_health_buf,
 					   health_page_sz,
 					   get_spdk_log_page_completion,
-					   dev_health);
+					   ctxt);
 	if (rc) {
 		D_ERROR("NVMe admin passthru (health log), rc:%d\n", rc);
 		dev_health->bdh_inflights--;
@@ -461,7 +486,7 @@ bio_bs_monitor(struct bio_xs_context *ctxt, uint64_t now)
 		D_ERROR("State transition on target %d failed. %d\n",
 			ctxt->bxc_tgt_id, rc);
 
-	collect_raw_health_data(dev_health);
+	collect_raw_health_data(ctxt);
 }
 
 /* Print the io stat every few seconds, for debug only */


### PR DESCRIPTION
Raw heath data collecting is done by series of completion callbacks
being executed by spdk_thread_poll(), and some cp callbacks could be
executed after bio_dev_health is finalized in bio_xsctxt_free(),
let's check validity of bio_dev_health in these cp callbacks.

Initialize 'blob_list' ealier in replace_dev() to avoid accessing
uninitialized list header in error cleanup code path.

Signed-off-by: Niu Yawei <yawei.niu@intel.com>