### PR TITLE
DAOS-5291 pool: reint callback for dev replace

### DIFF
--- a/src/bio/smd/smd_pool.c
+++ b/src/bio/smd/smd_pool.c
@@ -69,7 +69,7 @@ smd_pool_assign(uuid_t pool_id, int tgt_id, uint64_t blob_id, uint64_t blob_sz)
 				""DF_U64" != "DF_U64"\n",
 				DP_UUID(&key_pool.uuid), entry.spe_blob_sz,
 				blob_sz);
-			rc = -DER_MISMATCH;
+			rc = -DER_INVAL;
 			goto out;
 		}
 

--- a/src/bio/smd/tests/smd_ut.c
+++ b/src/bio/smd/tests/smd_ut.c
@@ -195,7 +195,7 @@ ut_pool(void **state)
 	assert_int_equal(rc, -DER_EXIST);
 
 	rc = smd_pool_assign(id1, 4, 4 << 10, 200);
-	assert_int_equal(rc, -DER_MISMATCH);
+	assert_int_equal(rc, -DER_INVAL);
 
 	rc = smd_pool_get(id1, &pool_info);
 	assert_int_equal(rc, 0);

--- a/src/include/daos_srv/daos_server.h
+++ b/src/include/daos_srv/daos_server.h
@@ -685,6 +685,8 @@ int dsc_obj_list_obj(daos_handle_t oh, daos_epoch_range_t *epr,
 		     daos_anchor_t *akey_anchor, d_iov_t *csum);
 int dsc_pool_tgt_exclude(const uuid_t uuid, const char *grp,
 			 const d_rank_list_t *svc, struct d_tgt_list *tgts);
+int dsc_pool_tgt_reint(const uuid_t uuid, const char *grp,
+		       const d_rank_list_t *svc, struct d_tgt_list *tgts);
 
 int dsc_task_run(tse_task_t *task, tse_task_cb_t retry_cb, void *arg,
 		 int arg_size, bool sync);

--- a/src/pool/srv_cli.c
+++ b/src/pool/srv_cli.c
@@ -123,3 +123,26 @@ dsc_pool_tgt_exclude(const uuid_t uuid, const char *grp,
 
 	return dsc_task_run(task, NULL, NULL, 0, true);
 }
+
+int
+dsc_pool_tgt_reint(const uuid_t uuid, const char *grp,
+		   const d_rank_list_t *svc, struct d_tgt_list *tgts)
+{
+	daos_pool_update_t	*args;
+	tse_task_t		*task;
+	int			 rc;
+
+	DAOS_API_ARG_ASSERT(*args, POOL_EXCLUDE);
+
+	rc = dc_task_create(dc_pool_reint, dsc_scheduler(), NULL, &task);
+	if (rc)
+		return rc;
+
+	args = dc_task_get_args(task);
+	args->grp	= grp;
+	args->svc	= (d_rank_list_t *)svc;
+	args->tgts	= tgts;
+	uuid_copy((unsigned char *)args->uuid, uuid);
+
+	return dsc_task_run(task, NULL, NULL, 0, true);
+}

--- a/src/pool/srv_util.c
+++ b/src/pool/srv_util.c
@@ -637,32 +637,25 @@ output:
 	return rc;
 }
 
-/* See nvme_faulty_reaction() for return values */
+/* See nvme_reaction() for return values */
 static int
-check_pool_targets(uuid_t pool_id, int *tgt_ids, int tgt_cnt, d_rank_t *pl_rank)
+check_pool_targets(uuid_t pool_id, int *tgt_ids, int tgt_cnt, bool reint,
+		   d_rank_t *pl_rank)
 {
 	struct ds_pool		*pool;
 	struct pool_target	*target = NULL;
 	d_rank_t		 rank = dss_self_rank();
-	int			 nr_downout, nr_down;
+	int			 nr_downout, nr_down, nr_upin, nr_up;
 	int			 i, nr, rc = 0;
 
 	/* Get pool map to check the target status */
 	pool = ds_pool_lookup(pool_id);
-	/*
-	 * FIXME: Not supporting offline faulty reaction so far.
-	 *
-	 * The pool cache & pool map IV implementation will be improved
-	 * later to not rely on pool connect or rebuild later, then we can
-	 * setup pool cache/IV by a local pool open.
-	 */
 	if (pool == NULL) {
-		D_DEBUG(DB_MGMT, DF_UUID": Pool cache not found\n",
-			DP_UUID(pool_id));
-		return -DER_NOSYS;
+		D_ERROR(DF_UUID": Pool cache not found\n", DP_UUID(pool_id));
+		return -DER_UNINIT;
 	}
 
-	nr_downout = nr_down = 0;
+	nr_downout = nr_down = nr_upin = nr_up = 0;
 	ABT_rwlock_rdlock(pool->sp_lock);
 	for (i = 0; i < tgt_cnt; i++) {
 		nr = pool_map_find_target_by_rank_idx(pool->sp_map, rank,
@@ -682,109 +675,128 @@ check_pool_targets(uuid_t pool_id, int *tgt_ids, int tgt_cnt, d_rank_t *pl_rank)
 		case PO_COMP_ST_DOWN:
 			nr_down++;
 			break;
+		case PO_COMP_ST_UPIN:
+			nr_upin++;
+			break;
+		case PO_COMP_ST_UP:
+			nr_up++;
+			break;
 		default:
 			break;
 		}
 	}
-	D_ASSERT(nr_downout + nr_down <= tgt_cnt);
 
-	if (pool->sp_iv_ns != NULL)
+	if (pool->sp_iv_ns != NULL) {
 		*pl_rank = pool->sp_iv_ns->iv_master_rank;
-	else
+	} else {
 		*pl_rank = -1;
+		D_ERROR(DF_UUID": Pool IV NS isn't initialized\n",
+			DP_UUID(pool_id));
+	}
 
 	ABT_rwlock_unlock(pool->sp_lock);
 	ds_pool_put(pool);
 
 	if (rc)
 		return rc;
-	else if (nr_downout == tgt_cnt)
-		return 0;
-	else if (nr_downout + nr_down == tgt_cnt)
-		return 1;
-	else
-		return (*pl_rank == -1) ? -DER_NOSYS : 2;
+
+	if (reint) {
+		if (nr_upin + nr_up == tgt_cnt)
+			return 0;
+	} else {
+		if (nr_downout + nr_down == tgt_cnt)
+			return 0;
+	}
+
+	return (*pl_rank == -1) ? -DER_UNINIT : 1;
 }
 
-struct exclude_targets_arg {
-	uuid_t		 eta_pool_id;
-	d_rank_t	 eta_pl_rank;
-	d_rank_t	*eta_ranks;
-	int		*eta_tgts;
-	int		 eta_nr;
+struct update_targets_arg {
+	uuid_t		 uta_pool_id;
+	d_rank_t	 uta_pl_rank;
+	d_rank_t	*uta_ranks;
+	int		*uta_tgts;
+	int		 uta_nr;
+	bool		 uta_reint;
 };
 
 static void
-free_exclude_targets_arg(struct exclude_targets_arg *eta)
+free_update_targets_arg(struct update_targets_arg *uta)
 {
-	D_ASSERT(eta != NULL);
-	if (eta->eta_ranks != NULL)
-		D_FREE(eta->eta_ranks);
-	if (eta->eta_tgts != NULL)
-		D_FREE(eta->eta_tgts);
-	D_FREE(eta);
+	D_ASSERT(uta != NULL);
+	if (uta->uta_ranks != NULL)
+		D_FREE(uta->uta_ranks);
+	if (uta->uta_tgts != NULL)
+		D_FREE(uta->uta_tgts);
+	D_FREE(uta);
 }
 
-static struct exclude_targets_arg *
-alloc_exclude_targets_arg(uuid_t pool_id, int *tgt_ids, int tgt_cnt,
-			  d_rank_t pl_rank)
+static struct update_targets_arg *
+alloc_update_targets_arg(uuid_t pool_id, int *tgt_ids, int tgt_cnt, bool reint,
+			 d_rank_t pl_rank)
 {
-	struct exclude_targets_arg	*eta;
+	struct update_targets_arg	*uta;
 	d_rank_t			 rank;
 	int				 i;
 
 	D_ASSERT(tgt_cnt > 0);
 	D_ASSERT(tgt_ids != NULL);
 
-	D_ALLOC_PTR(eta);
-	if (eta == NULL)
+	D_ALLOC_PTR(uta);
+	if (uta == NULL)
 		return NULL;
 
-	D_ALLOC_ARRAY(eta->eta_ranks, tgt_cnt);
-	if (eta->eta_ranks == NULL)
+	D_ALLOC_ARRAY(uta->uta_ranks, tgt_cnt);
+	if (uta->uta_ranks == NULL)
 		goto free;
 
-	D_ALLOC_ARRAY(eta->eta_tgts, tgt_cnt);
-	if (eta->eta_tgts == NULL)
+	D_ALLOC_ARRAY(uta->uta_tgts, tgt_cnt);
+	if (uta->uta_tgts == NULL)
 		goto free;
 
-	uuid_copy(eta->eta_pool_id, pool_id);
-	eta->eta_pl_rank = pl_rank;
-	eta->eta_nr = tgt_cnt;
+	uuid_copy(uta->uta_pool_id, pool_id);
+	uta->uta_reint = reint;
+	uta->uta_pl_rank = pl_rank;
+	uta->uta_nr = tgt_cnt;
 	rank = dss_self_rank();
-	for (i = 0; i < eta->eta_nr; i++) {
-		eta->eta_ranks[i] = rank;
-		eta->eta_tgts[i] = tgt_ids[i];
+	for (i = 0; i < uta->uta_nr; i++) {
+		uta->uta_ranks[i] = rank;
+		uta->uta_tgts[i] = tgt_ids[i];
 	}
 
-	return eta;
+	return uta;
 free:
-	free_exclude_targets_arg(eta);
+	free_update_targets_arg(uta);
 	return NULL;
 }
 
 static void
-exclude_targets_ult(void *arg)
+update_targets_ult(void *arg)
 {
-	struct exclude_targets_arg	*eta = arg;
+	struct update_targets_arg	*uta = arg;
 	struct d_tgt_list		 tgt_list;
 	d_rank_list_t			 svc;
 	int				 rc;
 
-	svc.rl_ranks = &eta->eta_pl_rank;
+	svc.rl_ranks = &uta->uta_pl_rank;
 	svc.rl_nr = 1;
 
-	tgt_list.tl_nr = eta->eta_nr;
-	tgt_list.tl_ranks = eta->eta_ranks;
-	tgt_list.tl_tgts = eta->eta_tgts;
+	tgt_list.tl_nr = uta->uta_nr;
+	tgt_list.tl_ranks = uta->uta_ranks;
+	tgt_list.tl_tgts = uta->uta_tgts;
 
-	rc = dsc_pool_tgt_exclude(eta->eta_pool_id, NULL /* grp */, &svc,
-				  &tgt_list);
+	if (uta->uta_reint)
+		rc = dsc_pool_tgt_reint(uta->uta_pool_id, NULL /* grp */,
+					&svc, &tgt_list);
+	else
+		rc = dsc_pool_tgt_exclude(uta->uta_pool_id, NULL /* grp */,
+					  &svc, &tgt_list);
 	if (rc)
-		D_ERROR(DF_UUID": Exclude targets failed. %d\n",
-			DP_UUID(eta->eta_pool_id), rc);
+		D_ERROR(DF_UUID": %s targets failed. %d\n",
+			uta->uta_reint ? "Reint" : "Exclude",
+			DP_UUID(uta->uta_pool_id), rc);
 
-	free_exclude_targets_arg(eta);
+	free_update_targets_arg(uta);
 }
 
 /*
@@ -795,29 +807,30 @@ exclude_targets_ult(void *arg)
  * to avoid blocking the hardware poll.
  */
 static int
-exclude_pool_targets(uuid_t pool_id, int *tgt_ids, int tgt_cnt,
-		     d_rank_t pl_rank)
+update_pool_targets(uuid_t pool_id, int *tgt_ids, int tgt_cnt, bool reint,
+		    d_rank_t pl_rank)
 {
-	struct exclude_targets_arg	*eta;
+	struct update_targets_arg	*uta;
 	int				 rc;
 
-	eta = alloc_exclude_targets_arg(pool_id, tgt_ids, tgt_cnt, pl_rank);
-	if (eta == NULL)
+	uta = alloc_update_targets_arg(pool_id, tgt_ids, tgt_cnt, reint,
+				       pl_rank);
+	if (uta == NULL)
 		return -DER_NOMEM;
 
-	rc = dss_ult_create(exclude_targets_ult, eta, DSS_ULT_MISC,
+	rc = dss_ult_create(update_targets_ult, uta, DSS_ULT_MISC,
 			    DSS_TGT_SELF, 0, NULL);
 	if (rc) {
-		D_ERROR(DF_UUID": Failed to start excluding ULT. %d\n",
+		D_ERROR(DF_UUID": Failed to start targets updating ULT. %d\n",
 			DP_UUID(pool_id), rc);
-		free_exclude_targets_arg(eta);
+		free_update_targets_arg(uta);
 	}
 
 	return rc;
 }
 
 static int
-nvme_faulty_reaction(int *tgt_ids, int tgt_cnt)
+nvme_reaction(int *tgt_ids, int tgt_cnt, bool reint)
 {
 	struct smd_pool_info	*pool_info, *tmp;
 	d_list_t		 pool_list;
@@ -836,33 +849,27 @@ nvme_faulty_reaction(int *tgt_ids, int tgt_cnt)
 
 	d_list_for_each_entry_safe(pool_info, tmp, &pool_list, spi_link) {
 		ret = check_pool_targets(pool_info->spi_id, tgt_ids, tgt_cnt,
-					 &pl_rank);
+					 reint, &pl_rank);
 		switch (ret) {
 		case 0:
 			/*
-			 * All affected targets are in DOWN_OUT, it's safe to
-			 * transit NVMe state to BIO_BS_STATE_TEARDOWN now.
+			 * All affected targets are in expected state, it's safe
+			 * to transit BIO BS state to now.
 			 */
-			D_DEBUG(DB_MGMT, DF_UUID": Targets are excluded out.\n",
+			D_DEBUG(DB_MGMT, DF_UUID": Targets are all in %s\n",
+				reint ? "UP/UPIN" : "DOWN/DOWNOUT",
 				DP_UUID(pool_info->spi_id));
 			break;
 		case 1:
 			/*
-			 * All affected targets are in DOWN, it's safe to
-			 * transit NVMe state to BIO_BS_STATE_TEARDOWN now.
+			 * Some affected targets are not in expected state,
+			 * need to send exclude/reint RPC.
 			 */
-			D_DEBUG(DB_MGMT, DF_UUID": Targets are in excluding.\n",
+			D_DEBUG(DB_MGMT, DF_UUID": Trigger targets %s.\n",
+				reint ? "reint" : "exclude",
 				DP_UUID(pool_info->spi_id));
-			break;
-		case 2:
-			/*
-			 * Some affected targets are still in UP or UPIN, need
-			 * to send exclude RPC.
-			 */
-			D_DEBUG(DB_MGMT, DF_UUID": Trigger targets exclude.\n",
-				DP_UUID(pool_info->spi_id));
-			rc = exclude_pool_targets(pool_info->spi_id, tgt_ids,
-						  tgt_cnt, pl_rank);
+			rc = update_pool_targets(pool_info->spi_id, tgt_ids,
+						 tgt_cnt, reint, pl_rank);
 			if (rc == 0)
 				rc = 1;
 			break;
@@ -885,6 +892,18 @@ nvme_faulty_reaction(int *tgt_ids, int tgt_cnt)
 }
 
 static int
+nvme_faulty_reaction(int *tgt_ids, int tgt_cnt)
+{
+	return nvme_reaction(tgt_ids, tgt_cnt, false);
+}
+
+static int
+nvme_reint_reaction(int *tgt_ids, int tgt_cnt)
+{
+	return nvme_reaction(tgt_ids, tgt_cnt, true);
+}
+
+static int
 nvme_bio_error(int media_err_type, int tgt_id)
 {
 	int rc;
@@ -896,6 +915,6 @@ nvme_bio_error(int media_err_type, int tgt_id)
 
 struct bio_reaction_ops nvme_reaction_ops = {
 	.faulty_reaction	= nvme_faulty_reaction,
-	.reint_reaction		= NULL,
+	.reint_reaction		= nvme_reint_reaction,
 	.ioerr_reaction		= nvme_bio_error,
 };


### PR DESCRIPTION
Implemented reint callback, which is auto called on a faulty device
being replaced by a good one to trigger targets reintegration.

Changed a -DER_MISMATCH error to -DER_INVAL in SMD. -DER_MISMATCH
is usually used for pool version check.

Signed-off-by: Niu Yawei <yawei.niu@intel.com>