### PR TITLE
DAOS-5759 obj: refine DAOS_GET_RECX handling for EC

### DIFF
--- a/src/include/daos/object.h
+++ b/src/include/daos/object.h
@@ -27,6 +27,13 @@
 #include <daos/tse.h>
 #include <daos_obj.h>
 
+/* EC parity is stored in a private address range that is selected by setting
+ * the most-significant bit of the offset (an unsigned long). This effectively
+ * limits the addressing of user extents to the lower 63 bits of the offset
+ * range.
+ */
+#define DAOS_EC_PARITY_BIT	(1ULL << 63)
+
 static inline daos_oclass_id_t
 daos_obj_id2class(daos_obj_id_t oid)
 {

--- a/src/include/daos_srv/vos_types.h
+++ b/src/include/daos_srv/vos_types.h
@@ -277,8 +277,14 @@ enum {
 	VOS_GET_AKEY		= DAOS_GET_AKEY,
 	/** retrieve the idx of array value */
 	VOS_GET_RECX		= DAOS_GET_RECX,
+	/**
+	 * Internal flag to indicate retrieve the idx of EC array value,
+	 * in that case need to retrieve both normal space and parity space
+	 * (parity space with DAOS_EC_PARITY_BIT in the recx index).
+	 */
+	VOS_GET_RECX_EC		= (1 << 5),
 	/** Internal flag to indicate timestamps are used */
-	VOS_USE_TIMESTAMPS	= (1 << 5),
+	VOS_USE_TIMESTAMPS	= (1 << 6),
 };
 
 D_CASSERT((VOS_USE_TIMESTAMPS & (VOS_GET_MAX | VOS_GET_MIN | VOS_GET_DKEY |

--- a/src/object/cli_obj.c
+++ b/src/object/cli_obj.c
@@ -397,6 +397,15 @@ obj_get_oca(struct dc_object *obj, bool force_check)
 	return obj->cob_oca;
 }
 
+bool
+obj_is_ec(struct dc_object *obj)
+{
+	struct daos_oclass_attr	*oca;
+
+	oca = obj_get_oca(obj, false);
+	return (oca != NULL && DAOS_OC_IS_EC(oca));
+}
+
 int
 obj_get_replicas(struct dc_object *obj)
 {

--- a/src/object/obj_ec.h
+++ b/src/object/obj_ec.h
@@ -25,6 +25,7 @@
 #define __OBJ_EC_H__
 
 #include <daos_types.h>
+#include <daos/object.h>
 #include <daos_obj.h>
 
 #include <isa-l.h>
@@ -43,7 +44,7 @@
  * limits the addressing of user extents to the lower 63 bits of the offset
  * range. The client stack should enforce this limitation.
  */
-#define PARITY_INDICATOR (1ULL << 63)
+#define PARITY_INDICATOR DAOS_EC_PARITY_BIT
 
 /** EC codec for object EC encoding/decoding */
 struct obj_ec_codec {

--- a/src/object/obj_internal.h
+++ b/src/object/obj_internal.h
@@ -96,6 +96,8 @@ struct dc_object {
 	 * version in it.
 	 */
 	struct daos_obj_md	 cob_md;
+	/** object class attribute */
+	struct daos_oclass_attr	*cob_oca;
 	/** container open handle */
 	daos_handle_t		 cob_coh;
 	/** object open mode */
@@ -451,6 +453,7 @@ void obj_reasb_req_fini(struct obj_reasb_req *reasb_req, uint32_t iod_nr);
 int obj_bulk_prep(d_sg_list_t *sgls, unsigned int nr, bool bulk_bind,
 		  crt_bulk_perm_t bulk_perm, tse_task_t *task,
 		  crt_bulk_t **p_bulks);
+struct daos_oclass_attr *obj_get_oca(struct dc_object *obj, bool force_check);
 int obj_get_replicas(struct dc_object *obj);
 int obj_shard_open(struct dc_object *obj, unsigned int shard,
 		   unsigned int map_ver, struct dc_obj_shard **shard_ptr);

--- a/src/object/obj_internal.h
+++ b/src/object/obj_internal.h
@@ -454,6 +454,7 @@ int obj_bulk_prep(d_sg_list_t *sgls, unsigned int nr, bool bulk_bind,
 		  crt_bulk_perm_t bulk_perm, tse_task_t *task,
 		  crt_bulk_t **p_bulks);
 struct daos_oclass_attr *obj_get_oca(struct dc_object *obj, bool force_check);
+bool obj_is_ec(struct dc_object *obj);
 int obj_get_replicas(struct dc_object *obj);
 int obj_shard_open(struct dc_object *obj, unsigned int shard,
 		   unsigned int map_ver, struct dc_obj_shard **shard_ptr);

--- a/src/object/obj_rpc.h
+++ b/src/object/obj_rpc.h
@@ -271,8 +271,7 @@ CRT_RPC_DECLARE(obj_punch, DAOS_ISEQ_OBJ_PUNCH, DAOS_OSEQ_OBJ_PUNCH)
 	((uint32_t)		(okqi_flags)		CRT_VAR) \
 	((uint64_t)		(okqi_api_flags)	CRT_VAR) \
 	((daos_key_t)		(okqi_dkey)		CRT_VAR) \
-	((daos_key_t)		(okqi_akey)		CRT_VAR) \
-	((daos_recx_t)		(okqi_recx)		CRT_VAR)
+	((daos_key_t)		(okqi_akey)		CRT_VAR)
 
 #define DAOS_OSEQ_OBJ_QUERY_KEY	/* output fields */		 \
 	((int32_t)		(okqo_ret)		CRT_VAR) \
@@ -282,7 +281,10 @@ CRT_RPC_DECLARE(obj_punch, DAOS_ISEQ_OBJ_PUNCH, DAOS_OSEQ_OBJ_PUNCH)
 	((uint32_t)		(okqo_pad32_1)		CRT_VAR) \
 	((daos_key_t)		(okqo_dkey)		CRT_VAR) \
 	((daos_key_t)		(okqo_akey)		CRT_VAR) \
-	((daos_recx_t)		(okqo_recx)		CRT_VAR)
+	/* recx for normal data space */			 \
+	((daos_recx_t)		(okqo_recx)		CRT_VAR) \
+	/* recx for EC parity space */				 \
+	((daos_recx_t)		(okqo_recx_parity)	CRT_VAR)
 
 CRT_RPC_DECLARE(obj_query_key, DAOS_ISEQ_OBJ_QUERY_KEY, DAOS_OSEQ_OBJ_QUERY_KEY)
 

--- a/src/object/srv_obj.c
+++ b/src/object/srv_obj.c
@@ -3016,6 +3016,9 @@ ds_obj_query_key_handler(crt_rpc_t *rpc)
 	struct dtx_handle		 dth = {0};
 	struct dtx_epoch		 epoch = {0};
 	struct dss_sleep_ult		*sleep_ult = NULL;
+	uint32_t			 query_flags;
+	daos_recx_t			 ec_recx[2] = {0};
+	daos_recx_t			*query_recx;
 	int				 retry = 0;
 	int				 rc;
 
@@ -3057,10 +3060,20 @@ again:
 	if (rc != 0)
 		goto out;
 
-	rc = vos_obj_query_key(ioc.ioc_vos_coh, okqi->okqi_oid,
-			       okqi->okqi_api_flags, okqi->okqi_epoch, dkey,
-			       akey, &okqo->okqo_recx, &dth);
-
+	query_flags = okqi->okqi_api_flags;
+	if ((okqi->okqi_flags & ORF_EC) &&
+	    (okqi->okqi_api_flags & DAOS_GET_RECX)) {
+		query_flags |= VOS_GET_RECX_EC;
+		query_recx = ec_recx;
+	} else {
+		query_recx = &okqo->okqo_recx;
+	}
+	rc = vos_obj_query_key(ioc.ioc_vos_coh, okqi->okqi_oid, query_flags,
+			       okqi->okqi_epoch, dkey, akey, query_recx, &dth);
+	if (rc == 0 && (query_flags & VOS_GET_RECX_EC)) {
+		okqo->okqo_recx = ec_recx[0];
+		okqo->okqo_recx_parity = ec_recx[1];
+	}
 	rc = dtx_end(&dth, ioc.ioc_coc, rc);
 
 out:

--- a/src/vos/vos_query.c
+++ b/src/vos/vos_query.c
@@ -161,6 +161,9 @@ query_recx(struct open_query *query, daos_recx_t *recx)
 	int			close_rc;
 	int			opc;
 	uint32_t		inob;
+	bool			re_itered = false;
+	bool			exist = false;
+	bool			for_ec_recx;
 
 	recx->rx_idx = 0;
 	recx->rx_nr = 0;
@@ -174,13 +177,18 @@ query_recx(struct open_query *query, daos_recx_t *recx)
 	if (query->qt_flags & VOS_GET_MAX)
 		opc |= EVT_ITER_REVERSE;
 
+	for_ec_recx = (query->qt_flags & VOS_GET_RECX_EC);
 	filter.fr_ex.ex_lo = 0;
-	filter.fr_ex.ex_hi = ~(uint64_t)0;
+	if (for_ec_recx)
+		filter.fr_ex.ex_hi = DAOS_EC_PARITY_BIT - 1;
+	else
+		filter.fr_ex.ex_hi = ~(uint64_t)0;
 	filter.fr_punch_epc = query->qt_punch.pr_epc;
 	filter.fr_punch_minor_epc = query->qt_punch.pr_minor_epc;
 	filter.fr_epr = query->qt_epr;
 
 
+re_iter:
 	rc = evt_iter_prepare(toh, opc, &filter, &ih);
 	if (rc != 0)
 		goto out;
@@ -200,11 +208,26 @@ query_recx(struct open_query *query, daos_recx_t *recx)
 	recx->rx_idx = entry.en_sel_ext.ex_lo;
 	recx->rx_nr = entry.en_sel_ext.ex_hi - entry.en_sel_ext.ex_lo + 1;
 fini:
+	if (rc == 0)
+		exist = true;
+	if (rc == -DER_NONEXIST)
+		rc = 0;
 	close_rc = evt_iter_finish(ih);
 	if (rc == 0)
 		rc = close_rc;
+	if (rc == 0 && !re_itered && for_ec_recx) {
+		re_itered = true;
+		filter.fr_ex.ex_lo = DAOS_EC_PARITY_BIT;
+		filter.fr_ex.ex_hi = ~(uint64_t)0;
+		recx++;
+		recx->rx_idx = 0;
+		recx->rx_nr = 0;
+		goto re_iter;
+	}
 out:
 	close_rc = evt_close(toh);
+	if (rc == 0 && !exist)
+		rc = -DER_NONEXIST;
 	if (rc == 0)
 		rc = close_rc;
 


### PR DESCRIPTION
For EC obj need to translate from VOX extend to DAOS extend.

Signed-off-by: Xuezhao Liu <xuezhao.liu@intel.com>