### PR TITLE
DAOS-5876 dfs: not forget to close TX handle for dfs_open()

### DIFF
--- a/src/client/dfs/dfs.c
+++ b/src/client/dfs/dfs.c
@@ -2362,7 +2362,6 @@ restart:
 
 	*_obj = obj;
 
-	return rc;
 out:
 	if (daos_handle_is_valid(th)) {
 		int ret;
@@ -2370,11 +2369,16 @@ out:
 		ret = daos_tx_close(th,  NULL);
 		if (ret) {
 			D_ERROR("daos_tx_close() failed (%d)\n", ret);
-			if (rc == 0)
+			if (rc == 0) {
+				*_obj = NULL;
 				rc = daos_der2errno(ret);
+			}
 		}
 	}
-	D_FREE(obj);
+
+	if (rc != 0)
+		D_FREE(obj);
+
 	return rc;
 }
 


### PR DESCRIPTION
The dfs_open() is the entry for DFS to create regular file and
directory. If DTX is enabled (DFS_USE_DTX=1), then related TX
handle needs to be explicitly closed before dfs_open() return.
Otherwise there will be TX handle leak.

Signed-off-by: Fan Yong <fan.yong@intel.com>