### PR TITLE
DAOS-5802 tests: Change debug mask for daos core tests

### DIFF
--- a/src/tests/ftest/daos_test/daos_core_test-rebuild.yaml
+++ b/src/tests/ftest/daos_test/daos_core_test-rebuild.yaml
@@ -25,6 +25,9 @@ server_config:
       # scm_class: dcpm
       # scm_list: ["/dev/pmem0"]
       scm_mount: /mnt/daos0
+      log_mask: DEBUG,MEM=ERR
+      env_vars:
+        - DD_MASK=mgmt,io,md,epc,rebuild
     1:
       pinned_numa_node: 1
       nr_xs_helpers: 1
@@ -37,6 +40,9 @@ server_config:
       # scm_class: dcpm
       # scm_list: ["/dev/pmem1"]
       scm_mount: /mnt/daos1
+      log_mask: DEBUG,MEM=ERR
+      env_vars:
+        - DD_MASK=mgmt,io,md,epc,rebuild
   transport_config:
     allow_insecure: True
 agent_config:

--- a/src/tests/ftest/daos_test/daos_core_test.yaml
+++ b/src/tests/ftest/daos_test/daos_core_test.yaml
@@ -29,6 +29,9 @@ server_config:
       scm_class: dcpm
       scm_list: ["/dev/pmem0"]
       scm_mount: /mnt/daos0
+      log_mask: DEBUG,MEM=ERR
+      env_vars:
+        - DD_MASK=mgmt,io,md,epc,rebuild
     1:
       pinned_numa_node: 1
       nr_xs_helpers: 1
@@ -40,6 +43,9 @@ server_config:
       scm_class: dcpm
       scm_list: ["/dev/pmem1"]
       scm_mount: /mnt/daos1
+      log_mask: DEBUG,MEM=ERR
+      env_vars:
+        - DD_MASK=mgmt,io,md,epc,rebuild
   transport_config:
     allow_insecure: True
 agent_config:


### PR DESCRIPTION
Change debug mask for daos core tests to use
DD_MASK=mgmt,io,md,epc,rebuild