### PR TITLE
DAOS-4587 test: Fix cmd_free_args() in tests_dmg_helpers.c

### DIFF
--- a/src/common/tests_dmg_helpers.c
+++ b/src/common/tests_dmg_helpers.c
@@ -38,8 +38,7 @@ cmd_free_args(char **args, int argcount)
 	for (i = 0; i < argcount; i++)
 		D_FREE(args[i]);
 
-	if (argcount)
-		D_FREE(args);
+	D_FREE(args);
 }
 
 static char **


### PR DESCRIPTION
Don't make the D_FREE() contingent on argcount being > 0,
just call it. Not sure how this would be an issue in practice,
but hopefully it will make Coverity happy.