### PR TITLE
DAOS-5731 rdb: Fix a double free of db->d_replicas

### DIFF
--- a/src/rdb/rdb_raft.c
+++ b/src/rdb/rdb_raft.c
@@ -296,6 +296,7 @@ rdb_raft_load_replicas(struct rdb *db, uint64_t index)
 
 err_replicas:
 	d_rank_list_free(db->d_replicas);
+	db->d_replicas = NULL;
 err:
 	return rc;
 }
@@ -1291,6 +1292,7 @@ rdb_raft_cb_log_pop(raft_server_t *raft, void *arg, raft_entry_t *entry,
 		return rc;
 	}
 	d_rank_list_free(db->d_replicas);
+	db->d_replicas = NULL;
 	rc = rdb_raft_load_replicas(db, db->d_lc_record.dlr_tail - 1);
 	if (rc != 0)
 		return rc;

--- a/src/rdb/rdb_raft.c
+++ b/src/rdb/rdb_raft.c
@@ -58,7 +58,6 @@ static int rdb_raft_destroy_lc(daos_handle_t pool, daos_handle_t mc,
 			       struct rdb_lc_record *record);
 static void *rdb_raft_lookup_result(struct rdb *db, uint64_t index);
 static int rdb_raft_add_node(struct rdb *db, d_rank_t rank);
-static void rdb_raft_unload_replicas(struct rdb *db);
 
 /* Translate a raft error into an rdb error. */
 static inline int
@@ -321,7 +320,9 @@ rdb_raft_unload_replicas(struct rdb *db)
 		raft_remove_node(db->d_raft, node);
 		D_FREE(rdb_node);
 	}
+
 	d_rank_list_free(db->d_replicas);
+	db->d_replicas = NULL;
 }
 
 /* Load the LC base. */
@@ -2406,6 +2407,7 @@ rdb_raft_start(struct rdb *db)
 		goto err_raft;
 
 	d_rank_list_free(db->d_replicas);
+	db->d_replicas = NULL;
 	rc = rdb_raft_load_replicas(db, db->d_lc_record.dlr_tail - 1);
 	if (rc != 0 && rc != -DER_NONEXIST)
 		goto err_lc;


### PR DESCRIPTION
Coverity found that db->d_replicas could be double freed in the
following code path in rdb_raft_start:

  d_rank_list_free(db->d_replicas);	/* first free */
  ...
  rc = rdb_raft_load_replicas(...);
  if (rc != 0 && rc != -DER_NONEXIST)
          goto err_lc;			/* go this way */
  ...
 err_lc:
  rdb_raft_unload_lc(db);		/* second free */

This patch sets db->d_replicas to NULL after freeing it, so that
rdb_raft_unload_lc won't free the pointer again.

Signed-off-by: Li Wei <wei.g.li@intel.com>