### PR TITLE
DAOS-5751 test: Remove deprecated control_method=API

### DIFF
--- a/src/tests/ftest/aggregation/aggregation_basic.yaml
+++ b/src/tests/ftest/aggregation/aggregation_basic.yaml
@@ -24,7 +24,6 @@ pool:
     scm_size: 50000000000
     nvme_size: 500000000000
     svcn: 1
-    control_method: dmg
 container:
     type: POSIX
     control_method: daos

--- a/src/tests/ftest/aggregation/aggregation_checksum.yaml
+++ b/src/tests/ftest/aggregation/aggregation_checksum.yaml
@@ -15,7 +15,6 @@ pool:
   scm_size: 1000000000
   nvme_size: 10000000000
   svcn: 1
-  control_method: dmg
 container:
   type: POSIX
   properties: cksum:crc16,cksum_size:16384,srv_cksum:on

--- a/src/tests/ftest/aggregation/aggregation_io_small.yaml
+++ b/src/tests/ftest/aggregation/aggregation_io_small.yaml
@@ -24,7 +24,6 @@ pool:
     scm_size: 10000000000
     nvme_size: 10000000000
     svcn: 1
-    control_method: dmg
 container:
     type: POSIX
     control_method: daos

--- a/src/tests/ftest/aggregation/aggregation_punching.yaml
+++ b/src/tests/ftest/aggregation/aggregation_punching.yaml
@@ -20,7 +20,6 @@ pool:
     scm_size: 8000000000
     nvme_size: 80000000000
     svcn: 1
-    control_method: dmg
 container:
     type: POSIX
     control_method: daos

--- a/src/tests/ftest/aggregation/aggregation_throttling.yaml
+++ b/src/tests/ftest/aggregation/aggregation_throttling.yaml
@@ -24,7 +24,6 @@ pool:
     scm_size: 20000000000
     nvme_size: 50000000000
     svcn: 1
-    control_method: dmg
 container:
     type: POSIX
     control_method: daos

--- a/src/tests/ftest/aggregation/dfuse_space_check.yaml
+++ b/src/tests/ftest/aggregation/dfuse_space_check.yaml
@@ -18,7 +18,6 @@ pool:
   scm_size: 200000000
   nvme_size: 1073741824
   svcn: 1
-  control_method: dmg
 container:
   type: POSIX
   control_method: daos

--- a/src/tests/ftest/checksum/basic_checksum.yaml
+++ b/src/tests/ftest/checksum/basic_checksum.yaml
@@ -18,7 +18,6 @@ pool:
         scm_size: 3000000000
     createsvc:
         svcn: 1
-    control_method: dmg
 container: !mux
    properties:
        enable_checksum: True

--- a/src/tests/ftest/container/attribute.yaml
+++ b/src/tests/ftest/container/attribute.yaml
@@ -7,7 +7,6 @@ timeout: 60
 server_config:
   name: daos_server
 pool:
-  control_method: dmg
   mode: 511
   scm_size: 1073741824
   name: daos_server

--- a/src/tests/ftest/container/basic_snapshot.yaml
+++ b/src/tests/ftest/container/basic_snapshot.yaml
@@ -10,7 +10,6 @@ server_config:
 pool:
     mode: 511
     name: daos_server
-    control_method: dmg
     scm_size_mux: !mux
         size1gb:
             scm_size: 1073741824

--- a/src/tests/ftest/container/basic_tx_test.yaml
+++ b/src/tests/ftest/container/basic_tx_test.yaml
@@ -24,4 +24,3 @@ pool:
   mode: 511
   name: daos_server
   scm_size: 1073741824
-  control_method: dmg

--- a/src/tests/ftest/container/container_async.yaml
+++ b/src/tests/ftest/container/container_async.yaml
@@ -6,7 +6,6 @@ timeout: 60
 server_config:
   name: daos_server
 pool:
-  control_method: dmg
   name: daos_server
   scm_size: 1G
   mode: 146

--- a/src/tests/ftest/container/container_check.yaml
+++ b/src/tests/ftest/container/container_check.yaml
@@ -11,7 +11,6 @@ pool:
   name: daos_server
   scm_size: 500000000
   svcn: 1
-  control_method: dmg
 container:
   cont_types:
     - ""

--- a/src/tests/ftest/container/create.yaml
+++ b/src/tests/ftest/container/create.yaml
@@ -10,7 +10,6 @@ pool:
    mode: 511
    name: daos_server
    scm_size: 1073741824
-   control_method: dmg
 uuids: !mux
    perfect:
      uuid:

--- a/src/tests/ftest/container/delete.yaml
+++ b/src/tests/ftest/container/delete.yaml
@@ -10,7 +10,6 @@ pool:
   mode: 511
   scm_size: 1073741824
   name: daos_server
-  control_method: dmg
 createtests:
   ContainerUUIDS: !mux
     gooduid:

--- a/src/tests/ftest/container/full_pool_container_create.yaml
+++ b/src/tests/ftest/container/full_pool_container_create.yaml
@@ -7,6 +7,5 @@ server_config:
    name: daos_server
 timeout: 300
 pool:
-  control_method: dmg
   mode: 511
   scm_size: 16777216 # 16 mb pool, minimum size currently possible

--- a/src/tests/ftest/container/global_handle.yaml
+++ b/src/tests/ftest/container/global_handle.yaml
@@ -7,7 +7,6 @@ timeout: 60
 server_config:
   name: daos_server
 pool:
-  control_method: dmg
   mode: 511
   name: daos_server
   scm_size: 1073741824

--- a/src/tests/ftest/container/multiple_container_delete.yaml
+++ b/src/tests/ftest/container/multiple_container_delete.yaml
@@ -21,7 +21,6 @@ pool:
     scm_size: 4000000000
     nvme_size: 40000000000
     svcn: 1
-    control_method: dmg
 container:
     type: POSIX
     control_method: daos

--- a/src/tests/ftest/container/open.py
+++ b/src/tests/ftest/container/open.py
@@ -125,8 +125,7 @@ class OpenContainerTest(TestWithServers):
         # Add the pool and the container created into a list
         container_uuids = []
         for _ in range(2):
-            self.pool.append(TestPool(
-                self.context, dmg_command=self.get_dmg_command()))
+            self.pool.append(TestPool(self.context, self.get_dmg_command()))
             self.pool[-1].get_params(self)
             self.pool[-1].create()
             self.pool[-1].connect()

--- a/src/tests/ftest/container/open.yaml
+++ b/src/tests/ftest/container/open.yaml
@@ -7,7 +7,6 @@ pool:
   mode: 511
   name: daos_server
   scm_size: 1G
-  control_method: dmg
 container:
   control_method: daos
 container_uuid_states: !mux

--- a/src/tests/ftest/container/open_close.yaml
+++ b/src/tests/ftest/container/open_close.yaml
@@ -8,7 +8,6 @@ pool:
     mode: 146
     name: daos_server
     scm_size: 1G
-    control_method: dmg
 container:
     container_handle: !mux
         good_coh:

--- a/src/tests/ftest/container/query_attribute.yaml
+++ b/src/tests/ftest/container/query_attribute.yaml
@@ -8,4 +8,3 @@ server_config:
     targets: 8
 pool:
   scm_size: 1G
-  control_method: dmg

--- a/src/tests/ftest/container/root_container_test.yaml
+++ b/src/tests/ftest/container/root_container_test.yaml
@@ -13,7 +13,6 @@ pool:
   name: daos_server
   scm_size: 30000000000
   svcn: 1
-  control_method: dmg
   pool_count: 5
 container:
     type: POSIX

--- a/src/tests/ftest/container/simple_create_delete_test.yaml
+++ b/src/tests/ftest/container/simple_create_delete_test.yaml
@@ -10,4 +10,3 @@ pool:
   mode: 511
   name: daos_server
   scm_size: 1073741824
-  control_method: dmg

--- a/src/tests/ftest/container/snapshot.yaml
+++ b/src/tests/ftest/container/snapshot.yaml
@@ -13,7 +13,6 @@ server_config:
 pool:
     name: daos_server
     scm_size: 107374182
-    control_method: dmg
 snapshot:
     dkey: "dkey"
     akey: "akey"

--- a/src/tests/ftest/container/snapshot_aggregation.yaml
+++ b/src/tests/ftest/container/snapshot_aggregation.yaml
@@ -18,7 +18,6 @@ server_config:
         scm_class: dcpm
         scm_list: ["/dev/pmem0"]
 pool:
-  control_method: dmg
   scm_size: 80G
   nvme_size: 100G
   target_list: [0, 1]

--- a/src/tests/ftest/control/daos_object_query.yaml
+++ b/src/tests/ftest/control/daos_object_query.yaml
@@ -8,6 +8,5 @@ server_config:
 pool:
     name: daos_server
     scm_size: 1G
-    control_method: dmg
 container:
     control_method: daos

--- a/src/tests/ftest/control/daos_scm_config.yaml
+++ b/src/tests/ftest/control/daos_scm_config.yaml
@@ -22,7 +22,6 @@ dmg:
   transport_config:
     allow_insecure: True
 pool:
-  control_method: dmg
   mode: 511
   scm_size: 1073741824
   name: daos_server

--- a/src/tests/ftest/control/daos_snapshot.yaml
+++ b/src/tests/ftest/control/daos_snapshot.yaml
@@ -6,7 +6,6 @@ server_config:
   name: daos_server
 pool:
   scm_size: 1G
-  control_method: dmg
 container:
   control_method: daos
 stress_test: !mux

--- a/src/tests/ftest/control/dmg_pool_evict.yaml
+++ b/src/tests/ftest/control/dmg_pool_evict.yaml
@@ -5,7 +5,6 @@ timeout: 140
 server_config:
     name: daos_server
 pool:
-    control_method: dmg
     scm_size: 1GB
 container:
     control_method: daos

--- a/src/tests/ftest/control/dmg_pool_query_test.py
+++ b/src/tests/ftest/control/dmg_pool_query_test.py
@@ -40,7 +40,7 @@ class DmgPoolQueryTest(ControlTestBase, IorTestBase):
         super(DmgPoolQueryTest, self).setUp()
 
         # Init the pool
-        self.pool = TestPool(self.context, dmg_command=self.dmg)
+        self.pool = TestPool(self.context, self.dmg)
         self.pool.get_params(self)
         self.pool.create()
         self.uuid = self.pool.pool.get_uuid_str()

--- a/src/tests/ftest/control/dmg_pool_query_test.yaml
+++ b/src/tests/ftest/control/dmg_pool_query_test.yaml
@@ -24,7 +24,6 @@ dmg:
   transport_config:
     allow_insecure: True
 pool:
-  control_method: dmg
   mode: 146
   scm_size: "16GB"
   nvme_size: "32GB"

--- a/src/tests/ftest/control/dmg_storage_query.yaml
+++ b/src/tests/ftest/control/dmg_storage_query.yaml
@@ -18,4 +18,3 @@ pool:
     scm_size: 3000000000
     nvme_size: 9000000000
     svcn: 1
-    control_method: dmg

--- a/src/tests/ftest/erasurecode/ec_ior_smoke.yaml
+++ b/src/tests/ftest/erasurecode/ec_ior_smoke.yaml
@@ -43,7 +43,6 @@ pool:
     name: daos_server
     scm_size: 100G
     nvme_size: 200G
-    control_method: dmg
 container:
     type: POSIX
     control_method: daos

--- a/src/tests/ftest/erasurecode/ec_mdtest_smoke.yaml
+++ b/src/tests/ftest/erasurecode/ec_mdtest_smoke.yaml
@@ -43,7 +43,6 @@ pool:
     name: daos_server
     scm_size: 200G
     nvme_size: 400G
-    control_method: dmg
 container:
     type: POSIX
     control_method: daos

--- a/src/tests/ftest/io/daos_vol.yaml
+++ b/src/tests/ftest/io/daos_vol.yaml
@@ -13,7 +13,6 @@ server_config:
         scm_class: dcpm
         scm_list: ["/dev/pmem0"]
 pool:
-    control_method: dmg
     mode: 511
     name: daos_server
     scm_size: 50G

--- a/src/tests/ftest/io/dfuse_bash_cmd.yaml
+++ b/src/tests/ftest/io/dfuse_bash_cmd.yaml
@@ -15,7 +15,6 @@ pool:
   name: daos_server
   scm_size: 1000000000
   svcn: 1
-  control_method: dmg
   pool_count: 5
 container:
   type: POSIX

--- a/src/tests/ftest/io/dfuse_sparse_file.yaml
+++ b/src/tests/ftest/io/dfuse_sparse_file.yaml
@@ -18,7 +18,6 @@ pool:
   scm_size: 200000000
   nvme_size: 1073741824
   svcn: 1
-  control_method: dmg
 container:
   type: POSIX
   control_method: daos

--- a/src/tests/ftest/io/fio_small.yaml
+++ b/src/tests/ftest/io/fio_small.yaml
@@ -45,7 +45,6 @@ pool:
   scm_size: 1600000000
   nvme_size: 20000000000
   svcn: 1
-  control_method: dmg
 container:
   type: POSIX
   properties: cksum:crc16,cksum_size:16384,srv_cksum:on

--- a/src/tests/ftest/io/hdf5.yaml
+++ b/src/tests/ftest/io/hdf5.yaml
@@ -25,7 +25,6 @@ pool:
     scm_size: 30000000000
     nvme_size: 40000000000
     svcn: 1
-    control_method: dmg
 container:
     type: POSIX
 client_processes:

--- a/src/tests/ftest/io/io_consistency.yaml
+++ b/src/tests/ftest/io/io_consistency.yaml
@@ -22,7 +22,6 @@ pool:
   scm_size: 5000000000
   nvme_size: 20000000000
   svcn: 1
-  control_method: dmg
 container:
   type: POSIX
   control_method: daos

--- a/src/tests/ftest/io/ior_hdf5.yaml
+++ b/src/tests/ftest/io/ior_hdf5.yaml
@@ -23,7 +23,6 @@ pool:
     scm_size: 500GiB
     nvme_size: 500GiB
     svcn: 1
-    control_method: dmg
 container:
     type: POSIX
     properties: cksum:crc16,cksum_size:16384,srv_cksum:on

--- a/src/tests/ftest/io/ior_intercept_basic.yaml
+++ b/src/tests/ftest/io/ior_intercept_basic.yaml
@@ -19,7 +19,6 @@ pool:
     scm_size: 30000000000
     nvme_size: 420000000000
     svcn: 1
-    control_method: dmg
 container:
     type: POSIX
     control_method: daos

--- a/src/tests/ftest/io/ior_intercept_dfuse_mix.yaml
+++ b/src/tests/ftest/io/ior_intercept_dfuse_mix.yaml
@@ -21,7 +21,6 @@ pool:
     scm_size: 50000000000
     nvme_size: 500000000000
     svcn: 1
-    control_method: dmg
 container:
     type: POSIX
     control_method: daos

--- a/src/tests/ftest/io/ior_intercept_multi_client.yaml
+++ b/src/tests/ftest/io/ior_intercept_multi_client.yaml
@@ -21,7 +21,6 @@ pool:
     scm_size: 40000000000
     nvme_size: 400000000000
     svcn: 1
-    control_method: dmg
 container:
     type: POSIX
     control_method: daos

--- a/src/tests/ftest/io/ior_intercept_verify_data_integrity.yaml
+++ b/src/tests/ftest/io/ior_intercept_verify_data_integrity.yaml
@@ -33,7 +33,6 @@ pool:
         svcn: 1
 container:
     type: POSIX
-    control_method: daos
 ior:
     client_processes:
         np_24:

--- a/src/tests/ftest/io/ior_large.yaml
+++ b/src/tests/ftest/io/ior_large.yaml
@@ -43,7 +43,6 @@ pool:
   scm_size: 20000000000   # large scm_size for 1K transfersize
   nvme_size: 40000000000
   svcn: 1
-  control_method: dmg
 container:
   type: POSIX
   control_method: daos

--- a/src/tests/ftest/io/ior_small.yaml
+++ b/src/tests/ftest/io/ior_small.yaml
@@ -31,7 +31,6 @@ pool:
     scm_size: 3000000000
     nvme_size: 9000000000
     svcn: 1
-    control_method: dmg
 container:
     type: POSIX
     properties: cksum:crc16,cksum_size:16384,srv_cksum:on

--- a/src/tests/ftest/io/llnl_mpi4py.yaml
+++ b/src/tests/ftest/io/llnl_mpi4py.yaml
@@ -14,7 +14,6 @@ pool:
     name: daos_server
     scm_size: 1000000000
     svcn: 1
-    control_method: dmg
 container:
     type: POSIX
 client_processes:

--- a/src/tests/ftest/io/macsio_test.yaml
+++ b/src/tests/ftest/io/macsio_test.yaml
@@ -18,7 +18,6 @@ server_config:
         scm_class: dcpm
         scm_list: ["/dev/pmem0"]
 pool:
-  control_method: dmg
   mode: 511
   name: daos_server
   scm_size: 5G

--- a/src/tests/ftest/io/mdtest_large.yaml
+++ b/src/tests/ftest/io/mdtest_large.yaml
@@ -42,7 +42,6 @@ pool:
   scm_size: 15000000000
   nvme_size: 30000000000
   svcn: 1
-  control_method: dmg
 container:
   type: POSIX
   properties: cksum:crc16,cksum_size:16384,srv_cksum:on

--- a/src/tests/ftest/io/mdtest_small.yaml
+++ b/src/tests/ftest/io/mdtest_small.yaml
@@ -23,7 +23,6 @@ pool:
   name: daos_server
   scm_size: 6000000000
   svcn: 1
-  control_method: dmg
 container:
   type: POSIX
   properties: cksum:crc16,cksum_size:16384,srv_cksum:on

--- a/src/tests/ftest/io/parallel_io.yaml
+++ b/src/tests/ftest/io/parallel_io.yaml
@@ -15,7 +15,6 @@ pool:
   name: daos_server
   scm_size: 1000000000
   svcn: 1
-  control_method: dmg
   pool_count: 10
 container:
   type: POSIX

--- a/src/tests/ftest/io/romio.yaml
+++ b/src/tests/ftest/io/romio.yaml
@@ -13,7 +13,6 @@ pool:
     name: daos_server
     scm_size: 1000000000
     svcn: 1
-    control_method: dmg
 container:
     type: POSIX
 romio:

--- a/src/tests/ftest/io/seg_count.yaml
+++ b/src/tests/ftest/io/seg_count.yaml
@@ -19,7 +19,6 @@ pool:
     name: daos_server
     scm_size: 60000000000
     svcn: 3
-    control_method: dmg
 ior:
     client_processes: !mux
         slots_16:

--- a/src/tests/ftest/nvme/enospace.yaml
+++ b/src/tests/ftest/nvme/enospace.yaml
@@ -47,7 +47,6 @@ pool:
     name: daos_server
     scm_size: 5368709120 #5G
     nvme_size: 5368709120 #5G
-    control_method: dmg
 container:
     control_method: daos
     type: POSIX

--- a/src/tests/ftest/nvme/nvme_fault.yaml
+++ b/src/tests/ftest/nvme/nvme_fault.yaml
@@ -46,7 +46,6 @@ pool:
     mode: 146
     name: daos_server
     scm_size: 53687091200 #50GB
-    control_method: dmg
 container:
     type: POSIX
     control_method: daos

--- a/src/tests/ftest/nvme/nvme_fragmentation.py
+++ b/src/tests/ftest/nvme/nvme_fragmentation.py
@@ -161,7 +161,7 @@ class NvmeFragmentation(TestWithServers):
         """
         no_of_jobs = self.params.get("no_parallel_job", '/run/ior/*')
         # Create a pool
-        self.pool = TestPool(self.context, dmg_command=self.get_dmg_command())
+        self.pool = TestPool(self.context, self.get_dmg_command())
         self.pool.get_params(self)
         self.pool.create()
         self.pool.display_pool_daos_space("Pool space at the Beginning")

--- a/src/tests/ftest/nvme/nvme_fragmentation.yaml
+++ b/src/tests/ftest/nvme/nvme_fragmentation.yaml
@@ -38,7 +38,6 @@ pool:
     scm_size: 500000000000
     nvme_size: 700000000000
     svcn: 1
-    control_method: dmg
 container:
     type: POSIX
     control_method: daos

--- a/src/tests/ftest/nvme/nvme_health.py
+++ b/src/tests/ftest/nvme/nvme_health.py
@@ -58,7 +58,7 @@ class NvmeHealth(ServerFillUp):
         self.pool = []
         #Create the Large number of pools
         for _pool in range(no_of_pools):
-            pool = TestPool(self.context, dmg_command=self.get_dmg_command())
+            pool = TestPool(self.context, self.get_dmg_command())
             pool.get_params(self)
             #SCM size is 10% of NVMe
             pool.scm_size.update('{}'.format(int(single_pool_nvme_size * 0.10)))

--- a/src/tests/ftest/nvme/nvme_health.yaml
+++ b/src/tests/ftest/nvme/nvme_health.yaml
@@ -42,5 +42,4 @@ dmg:
 pool:
     mode: 146
     name: daos_server
-    control_method: dmg
     number_of_pools: 40

--- a/src/tests/ftest/nvme/nvme_io.py
+++ b/src/tests/ftest/nvme/nvme_io.py
@@ -67,8 +67,7 @@ class NvmeIo(IorTestBase):
                     continue
 
                 # Create and connect to a pool
-                self.pool = TestPool(
-                    self.context, dmg_command=self.get_dmg_command())
+                self.pool = TestPool(self.context, self.get_dmg_command())
                 self.pool.get_params(self)
                 self.pool.scm_size.update(ior_param[0])
                 self.pool.nvme_size.update(ior_param[1])

--- a/src/tests/ftest/nvme/nvme_io.yaml
+++ b/src/tests/ftest/nvme/nvme_io.yaml
@@ -24,7 +24,6 @@ pool:
  svcn: 1
  prop_name: reclaim
  prop_value: disabled
- control_method: dmg
 ior:
  flags: "-w -r -k -vv"
  repetitions: 1

--- a/src/tests/ftest/nvme/nvme_io_stats.yaml
+++ b/src/tests/ftest/nvme/nvme_io_stats.yaml
@@ -19,7 +19,6 @@ pool:
     scm_size: 21474836480 #20G
     nvme_size: 107374182400 #100G
     svcn: 1
-    control_method: dmg
 container:
     type: POSIX
     control_method: daos

--- a/src/tests/ftest/nvme/nvme_io_verification.py
+++ b/src/tests/ftest/nvme/nvme_io_verification.py
@@ -72,8 +72,7 @@ class NvmeIoVerification(IorTestBase):
         # Loop for every IOR object type
         for ior_param in tests:
             # Create and connect to a pool
-            self.pool = TestPool(
-                self.context, dmg_command=self.get_dmg_command())
+            self.pool = TestPool(self.context, self.get_dmg_command())
             self.pool.get_params(self)
 
             # update pool sizes
@@ -141,8 +140,7 @@ class NvmeIoVerification(IorTestBase):
         # Loop for every IOR object type
         for ior_param in tests:
             # Create and connect to a pool
-            self.pool = TestPool(
-                self.context, dmg_command=self.get_dmg_command())
+            self.pool = TestPool(self.context, self.get_dmg_command())
             self.pool.get_params(self)
 
             # update pool sizes

--- a/src/tests/ftest/nvme/nvme_io_verification.yaml
+++ b/src/tests/ftest/nvme/nvme_io_verification.yaml
@@ -19,7 +19,6 @@ pool:
  mode: 511
  name: daos_server
  svcn: 1
- control_method: dmg
 container:
  type: POSIX
  control_method: daos

--- a/src/tests/ftest/nvme/nvme_object.py
+++ b/src/tests/ftest/nvme/nvme_object.py
@@ -77,8 +77,7 @@ def test_runner(self, size, record_size, index, array_size, thread_per_size=4):
         thread_per_size (int): threads per rec size
     """
     # pool initialization
-    self.pool.append(TestPool(
-        self.context, dmg_command=self.get_dmg_command()))
+    self.pool.append(TestPool(self.context, self.get_dmg_command()))
     self.pool[index].get_params(self)
 
     # set pool size

--- a/src/tests/ftest/nvme/nvme_object.yaml
+++ b/src/tests/ftest/nvme/nvme_object.yaml
@@ -40,7 +40,6 @@ pool:
       - 800000000000
   createsvc:
     svcn: 1
-  control_method: dmg
 container:
   object_qty: 10
   record_size:

--- a/src/tests/ftest/nvme/nvme_pool_capacity.py
+++ b/src/tests/ftest/nvme/nvme_pool_capacity.py
@@ -142,8 +142,7 @@ class NvmePoolCapacity(TestWithServers):
         for loop_count in range(0, total_count):
             self.log.info("Running test %s", loop_count)
             for val in range(0, num_pool):
-                pool[val] = TestPool(self.context,
-                                     dmg_command=self.get_dmg_command())
+                pool[val] = TestPool(self.context, self.get_dmg_command())
                 pool[val].get_params(self)
                 # Split total SCM and NVME size for creating multiple pools.
                 temp = int(scm_size) / num_pool

--- a/src/tests/ftest/nvme/nvme_pool_capacity.yaml
+++ b/src/tests/ftest/nvme/nvme_pool_capacity.yaml
@@ -20,7 +20,6 @@ pool:
     mode: 146
     name: daos_server
     svcn: 1
-    control_method: dmg
 container:
     type: POSIX
     control_method: daos

--- a/src/tests/ftest/object/array_obj_test.yaml
+++ b/src/tests/ftest/object/array_obj_test.yaml
@@ -7,7 +7,6 @@ timeout: 60
 server_config:
      name: daos_server
 pool:
-     control_method: dmg
      mode: 511
      name: daos_server
      scm_size: 1073741824

--- a/src/tests/ftest/object/create_many_dkeys.yaml
+++ b/src/tests/ftest/object/create_many_dkeys.yaml
@@ -11,6 +11,5 @@ pool:
   mode: 511
   name: daos_server
   scm_size: 2000000000
-  control_method: dmg
 dkeys:
   number_of_dkeys: 1000000

--- a/src/tests/ftest/object/obj_fetch_bad_param.yaml
+++ b/src/tests/ftest/object/obj_fetch_bad_param.yaml
@@ -8,4 +8,3 @@ pool:
    mode: 511
    name: daos_server
    scm_size: 1073741824
-   control_method: dmg

--- a/src/tests/ftest/object/obj_open_bad_param.yaml
+++ b/src/tests/ftest/object/obj_open_bad_param.yaml
@@ -7,4 +7,3 @@ pool:
   mode: 511
   name: daos_server
   scm_size: 1073741824
-  control_method: dmg

--- a/src/tests/ftest/object/obj_update_bad_param.yaml
+++ b/src/tests/ftest/object/obj_update_bad_param.yaml
@@ -8,4 +8,3 @@ pool:
   mode: 511
   name: daos_server
   scm_size: 1073741824
-  control_method: dmg

--- a/src/tests/ftest/object/object_integrity.yaml
+++ b/src/tests/ftest/object/object_integrity.yaml
@@ -10,7 +10,6 @@ pool:
   mode: 511
   name: daos_server
   scm_size: 8000000000
-  control_method: dmg
 array_size:
   size: 10
 dkeys: !mux

--- a/src/tests/ftest/object/punch_test.yaml
+++ b/src/tests/ftest/object/punch_test.yaml
@@ -9,4 +9,3 @@ pool:
   mode: 511
   name: daos_server
   scm_size: 1073741824
-  control_method: dmg

--- a/src/tests/ftest/object/same_key_different_value.yaml
+++ b/src/tests/ftest/object/same_key_different_value.yaml
@@ -8,4 +8,3 @@ pool:
   mode: 511
   name: daos_server
   scm_size: 10000000
-  control_method: dmg

--- a/src/tests/ftest/osa/osa_offline_drain.py
+++ b/src/tests/ftest/osa/osa_offline_drain.py
@@ -123,8 +123,7 @@ class OSAOfflineDrain(TestWithServers):
         rank = random.randint(1, drain_servers)
 
         for val in range(0, num_pool):
-            pool[val] = TestPool(self.context,
-                                 dmg_command=self.get_dmg_command())
+            pool[val] = TestPool(self.context, self.get_dmg_command())
             pool[val].get_params(self)
             # Split total SCM and NVME size for creating multiple pools.
             pool[val].scm_size.value = int(pool[val].scm_size.value /

--- a/src/tests/ftest/osa/osa_offline_drain.yaml
+++ b/src/tests/ftest/osa/osa_offline_drain.yaml
@@ -23,7 +23,6 @@ pool:
     scm_size: 6000000000
     nvme_size: 54000000000
     svcn: 4
-    control_method: dmg
 container:
   properties:
     enable_checksum: True

--- a/src/tests/ftest/osa/osa_offline_extend.py
+++ b/src/tests/ftest/osa/osa_offline_extend.py
@@ -108,8 +108,7 @@ class OSAOfflineExtend(TestWithServers):
         rank = total_servers
 
         for val in range(0, num_pool):
-            pool[val] = TestPool(self.context,
-                                 dmg_command=self.dmg_command)
+            pool[val] = TestPool(self.context, self.dmg_command)
             pool[val].get_params(self)
             # Split total SCM and NVME size for creating multiple pools.
             pool[val].scm_size.value = int(pool[val].scm_size.value /

--- a/src/tests/ftest/osa/osa_offline_extend.yaml
+++ b/src/tests/ftest/osa/osa_offline_extend.yaml
@@ -27,7 +27,6 @@ pool:
     scm_size: 6000000000
     nvme_size: 54000000000
     svcn: 4
-    control_method: dmg
 container:
   properties:
     enable_checksum: True

--- a/src/tests/ftest/osa/osa_offline_reintegration.py
+++ b/src/tests/ftest/osa/osa_offline_reintegration.py
@@ -128,8 +128,7 @@ class OSAOfflineReintegration(TestWithServers):
         rank = random.randint(1, exclude_servers)
 
         for val in range(0, num_pool):
-            pool[val] = TestPool(self.context,
-                                 dmg_command=self.get_dmg_command())
+            pool[val] = TestPool(self.context, self.get_dmg_command())
             pool[val].get_params(self)
             # Split total SCM and NVME size for creating multiple pools.
             pool[val].scm_size.value = int(pool[val].scm_size.value /

--- a/src/tests/ftest/osa/osa_offline_reintegration.yaml
+++ b/src/tests/ftest/osa/osa_offline_reintegration.yaml
@@ -29,7 +29,6 @@ pool:
     scm_size: 6000000000
     nvme_size: 54000000000
     svcn: 4
-    control_method: dmg
 container:
   properties:
     enable_checksum: True

--- a/src/tests/ftest/osa/osa_online_drain.py
+++ b/src/tests/ftest/osa/osa_online_drain.py
@@ -158,8 +158,7 @@ class OSAOnlineDrain(TestWithServers):
         rank = random.randint(1, drain_servers)
 
         for val in range(0, num_pool):
-            pool[val] = TestPool(self.context,
-                                 dmg_command=self.get_dmg_command())
+            pool[val] = TestPool(self.context, self.get_dmg_command())
             pool[val].get_params(self)
             # Split total SCM and NVME size for creating multiple pools.
             pool[val].scm_size.value = int(pool[val].scm_size.value /

--- a/src/tests/ftest/osa/osa_online_drain.yaml
+++ b/src/tests/ftest/osa/osa_online_drain.yaml
@@ -23,7 +23,6 @@ pool:
     scm_size: 12000000000
     nvme_size: 108000000000
     svcn: 4
-    control_method: dmg
 container:
     type: POSIX
     control_method: daos

--- a/src/tests/ftest/osa/osa_online_extend.py
+++ b/src/tests/ftest/osa/osa_online_extend.py
@@ -162,8 +162,7 @@ class OSAOnlineExtend(TestWithServers):
         time.sleep(30)
 
         for val in range(0, num_pool):
-            pool[val] = TestPool(self.context,
-                                 dmg_command=self.get_dmg_command())
+            pool[val] = TestPool(self.context, self.get_dmg_command())
             pool[val].get_params(self)
             # Split total SCM and NVME size for creating multiple pools.
             pool[val].scm_size.value = int(pool[val].scm_size.value /

--- a/src/tests/ftest/osa/osa_online_extend.yaml
+++ b/src/tests/ftest/osa/osa_online_extend.yaml
@@ -27,7 +27,6 @@ pool:
     scm_size: 12000000000
     nvme_size: 108000000000
     svcn: 4
-    control_method: dmg
 container:
     type: POSIX
     control_method: daos

--- a/src/tests/ftest/osa/osa_online_reintegration.py
+++ b/src/tests/ftest/osa/osa_online_reintegration.py
@@ -186,8 +186,7 @@ class OSAOnlineReintegration(TestWithServers):
         time.sleep(30)
 
         for val in range(0, num_pool):
-            pool[val] = TestPool(self.context,
-                                 dmg_command=self.get_dmg_command())
+            pool[val] = TestPool(self.context, self.get_dmg_command())
             pool[val].get_params(self)
             # Split total SCM and NVME size for creating multiple pools.
             pool[val].scm_size.value = int(pool[val].scm_size.value /

--- a/src/tests/ftest/osa/osa_online_reintegration.yaml
+++ b/src/tests/ftest/osa/osa_online_reintegration.yaml
@@ -21,7 +21,6 @@ pool:
   scm_size: 12000000000
   nvme_size: 108000000000
   svcn: 4
-  control_method: dmg
 container:
     type: POSIX
     control_method: daos

--- a/src/tests/ftest/pool/attribute.py
+++ b/src/tests/ftest/pool/attribute.py
@@ -90,7 +90,7 @@ class PoolAttributeTest(TestWithServers):
 
         self.large_data_set = {}
 
-        self.pool = TestPool(self.context, dmg_command=self.get_dmg_command())
+        self.pool = TestPool(self.context, self.get_dmg_command())
         self.pool.get_params(self)
         self.pool.create()
         self.pool.connect()

--- a/src/tests/ftest/pool/attribute.yaml
+++ b/src/tests/ftest/pool/attribute.yaml
@@ -7,7 +7,6 @@ timeout: 60
 server_config:
   name: daos_server
 pool:
-  control_method: dmg
   mode: 511
   scm_size: 1073741824
   name: daos_server

--- a/src/tests/ftest/pool/bad_connect.py
+++ b/src/tests/ftest/pool/bad_connect.py
@@ -27,7 +27,7 @@ import traceback
 import ctypes
 from pydaos.raw import RankList
 from avocado.core.exceptions import TestFail
-from apricot import TestWithServers, skipForTicket
+from apricot import TestWithServers
 from test_utils_pool import TestPool
 
 class BadConnectTest(TestWithServers):
@@ -77,7 +77,7 @@ class BadConnectTest(TestWithServers):
         pgroup = ctypes.create_string_buffer(0)
         # initialize a python pool object then create the underlying
         # daos storage
-        self.pool = TestPool(self.context, dmg_command=self.get_dmg_command())
+        self.pool = TestPool(self.context, self.get_dmg_command())
         self.pool.get_params(self)
         self.pool.create()
         # save this uuid since we might trash it as part of the test

--- a/src/tests/ftest/pool/bad_connect.yaml
+++ b/src/tests/ftest/pool/bad_connect.yaml
@@ -7,7 +7,6 @@ hosts:
     - server-A
 timeout: 700
 pool:
-  control_method: dmg
   mode: 511
   scm_size: 1073741824
   name: daos_server

--- a/src/tests/ftest/pool/bad_create.py
+++ b/src/tests/ftest/pool/bad_create.py
@@ -114,8 +114,7 @@ class BadCreateTest(TestWithServers):
 
         # initialize a python pool object then create the underlying
         # daos storage
-        self.pool = TestPool(self.context,
-                             dmg_command=self.get_dmg_command())
+        self.pool = TestPool(self.context, self.get_dmg_command())
         self.pool.get_params(self)
         # Manually set TestPool members before calling create
         self.pool.mode.value = mode

--- a/src/tests/ftest/pool/bad_create.yaml
+++ b/src/tests/ftest/pool/bad_create.yaml
@@ -6,8 +6,6 @@ hosts:
 server_config:
    name: daos_server
 timeout: 60
-pool:
-   control_method: dmg
 createtests:
    modes: !mux
       goodmode:

--- a/src/tests/ftest/pool/bad_exclude.yaml
+++ b/src/tests/ftest/pool/bad_exclude.yaml
@@ -59,4 +59,3 @@ pool:
    mode: 511
    name: daos_server
    scm_size: 1073741824
-   control_method: dmg

--- a/src/tests/ftest/pool/bad_query.py
+++ b/src/tests/ftest/pool/bad_query.py
@@ -68,7 +68,7 @@ class BadQueryTest(TestWithServers):
 
         # initialize a python pool object then create the underlying
         # daos storage
-        self.pool = TestPool(self.context, dmg_command=self.get_dmg_command())
+        self.pool = TestPool(self.context, self.get_dmg_command())
         self.pool.get_params(self)
         self.pool.create()
         self.pool.connect()

--- a/src/tests/ftest/pool/bad_query.yaml
+++ b/src/tests/ftest/pool/bad_query.yaml
@@ -7,7 +7,6 @@ hosts:
     - server-A
 timeout: 150
 pool:
-  control_method: dmg
   mode: 511
   scm_size: 1073741824
   name: daos_server

--- a/src/tests/ftest/pool/destroy_rebuild.py
+++ b/src/tests/ftest/pool/destroy_rebuild.py
@@ -48,8 +48,7 @@ class DestroyRebuild(TestWithServers):
         :avocado: tags=all,pr,medium,pool,destroypoolrebuild
         """
         # Get the test parameters
-        self.pool = TestPool(self.context, self.log,
-                             dmg_command=self.get_dmg_command())
+        self.pool = TestPool(self.context, self.get_dmg_command(), log=self.log)
         self.pool.get_params(self)
         targets = self.params.get("targets", "/run/server_config/*")
         rank = self.params.get("rank_to_kill", "/run/testparams/*")

--- a/src/tests/ftest/pool/destroy_rebuild.yaml
+++ b/src/tests/ftest/pool/destroy_rebuild.yaml
@@ -19,7 +19,6 @@ pool:
   mode: 511
   name: daos_server
   scm_size: 16428800
-  control_method: dmg
 testparams:
   rank_to_kill: 0
   # rank_to_kill: 1

--- a/src/tests/ftest/pool/destroy_tests.yaml
+++ b/src/tests/ftest/pool/destroy_tests.yaml
@@ -15,7 +15,6 @@ pool:
   mode: 146
   name: daos_server
   scm_size: 1073741824
-  control_method: dmg
 container:
   object_qty: 1
   record_qty: 1

--- a/src/tests/ftest/pool/dynamic_server_pool.yaml
+++ b/src/tests/ftest/pool/dynamic_server_pool.yaml
@@ -14,4 +14,3 @@ extra_servers:
     - server-C
 pool:
   scm_size: 1G
-  control_method: dmg

--- a/src/tests/ftest/pool/evict_test.py
+++ b/src/tests/ftest/pool/evict_test.py
@@ -50,8 +50,7 @@ class EvictTests(TestWithServers):
             TestPool (object)
 
         """
-        pool = TestPool(self.context, self.log,
-                        dmg_command=self.get_dmg_command())
+        pool = TestPool(self.context, self.get_dmg_command(), log=self.log)
         pool.get_params(self)
         if targets is not None:
             pool.target_list.value = targets

--- a/src/tests/ftest/pool/evict_test.yaml
+++ b/src/tests/ftest/pool/evict_test.yaml
@@ -11,7 +11,6 @@ pool:
    mode: 146
    name: daos_server
    scm_size: 1073741824
-   control_method: dmg
 container:
   akey_size: 5
   dkey_size: 5

--- a/src/tests/ftest/pool/global_handle.py
+++ b/src/tests/ftest/pool/global_handle.py
@@ -74,7 +74,7 @@ class GlobalHandle(TestWithServers):
         """
         # initialize a python pool object then create the underlying
         # daos storage
-        self.pool = TestPool(self.context, dmg_command=self.get_dmg_command())
+        self.pool = TestPool(self.context, self.get_dmg_command())
         self.pool.get_params(self)
         self.pool.create()
 

--- a/src/tests/ftest/pool/global_handle.yaml
+++ b/src/tests/ftest/pool/global_handle.yaml
@@ -7,7 +7,6 @@ timeout: 60
 server_config:
   name: daos_server
 pool:
-  control_method: dmg
   mode: 511
   name: daos_server
   scm_size: 1073741824

--- a/src/tests/ftest/pool/info_tests.py
+++ b/src/tests/ftest/pool/info_tests.py
@@ -47,8 +47,8 @@ class InfoTests(TestWithServers):
         :avocado: tags=all,tiny,pr,pool,smoke,infotest
         """
         # Get the test params
-        self.pool = TestPool(self.context, self.log,
-                             dmg_command=self.get_dmg_command())
+        self.pool = TestPool(self.context, self.get_dmg_command(),
+                             log=self.log)
         self.pool.get_params(self)
         permissions = self.params.get("permissions", "/run/test/*")
         targets = self.params.get("targets", "/run/server_config/*")

--- a/src/tests/ftest/pool/info_tests.yaml
+++ b/src/tests/ftest/pool/info_tests.yaml
@@ -16,7 +16,6 @@ pool:
       mode: 146
   createset:
     name: daos_server
-  control_method: dmg
   createsize: !mux
     size1gb:
       scm_size: 1073741824

--- a/src/tests/ftest/pool/multiple_creates_test.yaml
+++ b/src/tests/ftest/pool/multiple_creates_test.yaml
@@ -10,4 +10,3 @@ timeout: 60
 pool:
     name: daos_server
     scm_size: 1073741824
-    control_method: dmg

--- a/src/tests/ftest/pool/permission.py
+++ b/src/tests/ftest/pool/permission.py
@@ -72,7 +72,7 @@ class Permission(TestWithServers):
 
         # initialize a python pool object then create the underlying
         # daos storage
-        self.pool = TestPool(self.context, dmg_command=self.get_dmg_command())
+        self.pool = TestPool(self.context, self.get_dmg_command())
         self.test_log.debug("Pool initialization successful")
         self.pool.get_params(self)
         self.pool.mode.value = createmode

--- a/src/tests/ftest/pool/permission.yaml
+++ b/src/tests/ftest/pool/permission.yaml
@@ -14,7 +14,6 @@ timeout: 300
 server_config:
     name: daos_server
 pool:
-    control_method: dmg
     scm_size: 1000000000
     name: daos_server
 createtests:

--- a/src/tests/ftest/pool/pool_svc.py
+++ b/src/tests/ftest/pool/pool_svc.py
@@ -52,7 +52,7 @@ class PoolSvc(TestWithServers):
 
         # initialize a python pool object then create the underlying
         # daos storage
-        self.pool = TestPool(self.context, dmg_command=self.get_dmg_command())
+        self.pool = TestPool(self.context, self.get_dmg_command())
         self.pool.get_params(self)
         self.pool.svcn.update(createsvc[0])
         try:

--- a/src/tests/ftest/pool/pool_svc.yaml
+++ b/src/tests/ftest/pool/pool_svc.yaml
@@ -8,7 +8,6 @@ server_config:
     name: daos_server
 timeout: 60
 pool:
-    control_method: dmg
     mode: 146
     name: daos_server
     scm_size: 134217728

--- a/src/tests/ftest/pool/rebuild_no_cap.py
+++ b/src/tests/ftest/pool/rebuild_no_cap.py
@@ -48,8 +48,8 @@ class RebuildNoCap(TestWithServers):
         :avocado: tags=all,medium,pr,pool,rebuild,nocap
         """
         # Get the test params
-        self.pool = TestPool(self.context, self.log,
-                             dmg_command=self.get_dmg_command())
+        self.pool = TestPool(self.context, self.get_dmg_command(),
+                             log=self.log)
         self.pool.get_params(self)
         targets = self.params.get("targets", "/run/server_config/*")
         rank = self.params.get("rank_to_kill", "/run/testparams/*")

--- a/src/tests/ftest/pool/rebuild_no_cap.yaml
+++ b/src/tests/ftest/pool/rebuild_no_cap.yaml
@@ -22,7 +22,6 @@ pool:
     name: daos_server
   createsize:
     scm_size: 16777216
-  control_method: dmg
 testparams:
   ranks:
     rank_to_kill: 0

--- a/src/tests/ftest/pool/rebuild_tests.py
+++ b/src/tests/ftest/pool/rebuild_tests.py
@@ -45,8 +45,8 @@ class RebuildTests(TestWithServers):
         pools = []
         containers = []
         for index in range(pool_quantity):
-            pools.append(TestPool(self.context, self.log,
-                                  dmg_command=self.get_dmg_command()))
+            pools.append(TestPool(self.context, self.get_dmg_command(),
+                                  log=self.log))
             pools[index].get_params(self)
             containers.append(TestContainer(pools[index]))
             containers[index].get_params(self)

--- a/src/tests/ftest/pool/rebuild_tests.yaml
+++ b/src/tests/ftest/pool/rebuild_tests.yaml
@@ -17,7 +17,6 @@ pool:
   mode: 511
   name: daos_server
   scm_size: 1073741824
-  control_method: dmg
 container:
   akey_size: 5
   dkey_size: 5

--- a/src/tests/ftest/pool/rebuild_with_io.py
+++ b/src/tests/ftest/pool/rebuild_with_io.py
@@ -50,8 +50,7 @@ class RebuildWithIO(TestWithServers):
         :avocado: tags=all,pool,rebuild,pr,medium,rebuildwithio
         """
         # Get the test params
-        pool = TestPool(self.context, self.log,
-                        dmg_command=self.get_dmg_command())
+        pool = TestPool(self.context, self.get_dmg_command(), log=self.log)
         pool.get_params(self)
         container = TestContainer(pool)
         container.get_params(self)

--- a/src/tests/ftest/pool/rebuild_with_io.yaml
+++ b/src/tests/ftest/pool/rebuild_with_io.yaml
@@ -17,7 +17,6 @@ pool:
   mode: 511
   name: daos_server
   scm_size: 1073741824
-  control_method: dmg
 container:
   akey_size: 5
   dkey_size: 5

--- a/src/tests/ftest/pool/rebuild_with_ior.yaml
+++ b/src/tests/ftest/pool/rebuild_with_ior.yaml
@@ -26,7 +26,6 @@ pool:
     scm_size: 30000000000
   createsvc:
     svcn: 1
-  control_method: dmg
 ior:
     client_processes:
         np_8:

--- a/src/tests/ftest/pool/simple_create_delete_test.py
+++ b/src/tests/ftest/pool/simple_create_delete_test.py
@@ -74,8 +74,7 @@ class SimpleCreateDeleteTest(TestWithServers):
                 break
 
         try:
-            self.pool = TestPool(
-                self.context, dmg_command=self.get_dmg_command())
+            self.pool = TestPool(self.context, self.get_dmg_command())
             self.pool.get_params(self)
             self.pool.uid = uid
             self.pool.gid = gid

--- a/src/tests/ftest/pool/simple_create_delete_test.yaml
+++ b/src/tests/ftest/pool/simple_create_delete_test.yaml
@@ -4,7 +4,6 @@ hosts:
 server_config:
  name: daos_server
 pool:
- control_method: dmg
  mode: 511
  scm_size: 1073741824
 tests:

--- a/src/tests/ftest/pool/storage_ratio.py
+++ b/src/tests/ftest/pool/storage_ratio.py
@@ -53,8 +53,7 @@ class StorageRatio(TestWithServers):
         tests = self.params.get("storage_ratio", '/run/pool/*')
         results = {}
         for num, test in enumerate(tests):
-            pool = TestPool(
-                self.context, dmg_command=self.get_dmg_command())
+            pool = TestPool(self.context, self.get_dmg_command())
             pool.get_params(self)
             pool.scm_size.update(test[0])
             pool.nvme_size.update(test[1])

--- a/src/tests/ftest/pool/storage_ratio.yaml
+++ b/src/tests/ftest/pool/storage_ratio.yaml
@@ -35,7 +35,6 @@ pool:
     mode: 146
     name: daos_server
     svcn: 1
-    control_method: dmg
     storage_ratio:
 #   - [scm_size, nvme_size, Expected Result]
     - ['2G', '100G', 'PASS']    # SCM Size ratio is greater than 1%

--- a/src/tests/ftest/rebuild/cascading_failures.yaml
+++ b/src/tests/ftest/rebuild/cascading_failures.yaml
@@ -18,7 +18,6 @@ pool:
   name: daos_server
   scm_size: 1073741824
   svcn: 2
-  control_method: dmg
 container:
   akey_size: 5
   dkey_size: 5

--- a/src/tests/ftest/rebuild/container_create.py
+++ b/src/tests/ftest/rebuild/container_create.py
@@ -149,7 +149,7 @@ class ContainerCreate(TestWithServers):
         self.pool = []
         for index in range(pool_qty):
             self.pool.append(
-                TestPool(self.context, dmg_command=self.get_dmg_command()))
+                TestPool(self.context, self.get_dmg_command()))
             self.pool[-1].get_params(self)
 
         if use_ior:

--- a/src/tests/ftest/rebuild/container_create.yaml
+++ b/src/tests/ftest/rebuild/container_create.yaml
@@ -15,7 +15,6 @@ pool:
   name: daos_server
   scm_size: 8589934592
   svcn: 3
-  control_method: dmg
 container:
   type: POSIX
   control_method: daos

--- a/src/tests/ftest/rebuild/delete_objects.yaml
+++ b/src/tests/ftest/rebuild/delete_objects.yaml
@@ -19,7 +19,6 @@ pool:
   scm_size: 1073741824
   svcn: 2
   debug: True
-  control_method: dmg
 container:
   akey_size: 5
   dkey_size: 5

--- a/src/tests/ftest/rebuild/io_conf_run.yaml
+++ b/src/tests/ftest/rebuild/io_conf_run.yaml
@@ -16,7 +16,6 @@ server_config:
     bdev_list: ["0000:5e:00.0","0000:5f:00.0"]
 pool:
   scm_size: 14G
-  control_method: dmg
 gen_io_conf:
   no_of_ranks: !mux
     default_single_rank:

--- a/src/tests/ftest/rebuild/read_array.yaml
+++ b/src/tests/ftest/rebuild/read_array.yaml
@@ -15,7 +15,6 @@ pool:
   name: daos_server
   scm_size: 1073741824
   svcn: 2
-  control_method: dmg
 container:
   object_qty: 10
   record_qty: 10

--- a/src/tests/ftest/security/cont_create_acl.yaml
+++ b/src/tests/ftest/security/cont_create_acl.yaml
@@ -11,6 +11,5 @@ pool:
   mode: 511
   name: daos_server
   scm_size: 1073741824
-  control_method: dmg
 container:
   control_method: daos

--- a/src/tests/ftest/security/cont_delete_acl.yaml
+++ b/src/tests/ftest/security/cont_delete_acl.yaml
@@ -9,7 +9,6 @@ timeout: 100
 server_config:
   name: daos_server
 pool:
-  control_method: dmg
   mode: 511
   scm_size: 2G
   name: daos_server

--- a/src/tests/ftest/security/cont_get_acl.yaml
+++ b/src/tests/ftest/security/cont_get_acl.yaml
@@ -9,7 +9,6 @@ timeout: 100
 server_config:
   name: daos_server
 pool:
-  control_method: dmg
   mode: 511
   scm_size: 2G
   name: daos_server

--- a/src/tests/ftest/security/cont_overwrite_acl.yaml
+++ b/src/tests/ftest/security/cont_overwrite_acl.yaml
@@ -9,7 +9,6 @@ timeout: 120
 server_config:
   name: daos_server
 pool:
-  control_method: dmg
   mode: 511
   scm_size: 1G
   name: daos_server

--- a/src/tests/ftest/security/cont_update_acl.yaml
+++ b/src/tests/ftest/security/cont_update_acl.yaml
@@ -9,7 +9,6 @@ timeout: 120
 server_config:
   name: daos_server
 pool:
-  control_method: dmg
   mode: 511
   scm_size: 1G
   name: daos_server

--- a/src/tests/ftest/security/container_security_acl.yaml
+++ b/src/tests/ftest/security/container_security_acl.yaml
@@ -12,7 +12,6 @@ server_config:
 pool:
   name: daos_server
   scm_size: 138374182
-  control_method: dmg
 container:
   control_method: daos
 container_acl:

--- a/src/tests/ftest/security/pool_connect_init.py
+++ b/src/tests/ftest/security/pool_connect_init.py
@@ -55,7 +55,7 @@ class PoolSecurityTest(TestWithServers):
         user_uid = os.geteuid()
         user_gid = os.getegid()
 
-        self.pool = TestPool(self.context, dmg_command=self.get_dmg_command())
+        self.pool = TestPool(self.context, self.get_dmg_command())
         self.pool.get_params(self)
 
         uid, gid, expected = self.params.get("ids", "/run/pool/tests/*")

--- a/src/tests/ftest/security/pool_connect_init.yaml
+++ b/src/tests/ftest/security/pool_connect_init.yaml
@@ -18,7 +18,6 @@ pool:
   mode: 511
   name: daos_server
   scm_size: 16777216
-  control_method: dmg
   tests: !mux
       user_root:
         ids:

--- a/src/tests/ftest/server/dynamic_start_stop.yaml
+++ b/src/tests/ftest/server/dynamic_start_stop.yaml
@@ -12,6 +12,5 @@ extra_servers:
         - server-E
 pool:
     scm_size: 1G
-    control_method: dmg
 dmg:
     json: True

--- a/src/tests/ftest/server/metadata.py
+++ b/src/tests/ftest/server/metadata.py
@@ -95,8 +95,8 @@ class ObjectMetadata(TestWithServers):
         super(ObjectMetadata, self).setUp()
 
         # Create a pool
-        self.pool = TestPool(self.context, self.log,
-                             dmg_command=self.get_dmg_command())
+        self.pool = TestPool(self.context, self.get_dmg_command(),
+                             log=self.log)
         self.pool.get_params(self)
         self.pool.create()
         self.log.info("Created pool %s: svcranks:",

--- a/src/tests/ftest/server/metadata.yaml
+++ b/src/tests/ftest/server/metadata.yaml
@@ -57,7 +57,6 @@ pool:
   createsize:
     scm_size: 1073741824
     nvme_size: 8589934592
-  control_method: dmg
 ior:
     clientslots:
       slots: 1

--- a/src/tests/ftest/soak/soak_utils.py
+++ b/src/tests/ftest/soak/soak_utils.py
@@ -54,7 +54,7 @@ def DDHHMMSS_format(seconds):
     seconds = int(seconds)
     if seconds < 86400:
         return time.strftime("%H:%M:%S", time.gmtime(seconds))
-    num_days = seconds/86400
+    num_days = seconds / 86400
     return "{} {} {}".format(
         num_days, 'Day' if num_days == 1 else 'Days', time.strftime(
             "%H:%M:%S", time.gmtime(seconds % 86400)))
@@ -70,8 +70,11 @@ def add_pools(self, pool_names):
     for pool_name in pool_names:
         path = "".join(["/run/", pool_name, "/*"])
         # Create a pool and add it to the overall list of pools
-        self.pool.append(TestPool(
-            self.context, self.log, dmg_command=self.get_dmg_command()))
+        self.pool.append(
+            TestPool(
+                self.context,
+                self.get_dmg_command(),
+                log=self.log))
         self.pool[-1].namespace = path
         self.pool[-1].get_params(self)
         self.pool[-1].create()
@@ -580,17 +583,17 @@ def build_job_script(self, commands, job, ppn, nodesperjob):
             cmd = [cmd]
         output = os.path.join(
             self.test_log_dir, self.test_name + "_" + job + "_" +
-            log_name + "_" + str(ppn*nodesperjob) + "_%N_" + "%j_")
+            log_name + "_" + str(ppn * nodesperjob) + "_%N_" + "%j_")
         error = os.path.join(
             self.test_log_dir, self.test_name + "_" + job + "_" +
             log_name + "_" +
-            str(ppn*nodesperjob) + "_%N_" + "%j_" + "ERROR_")
+            str(ppn * nodesperjob) + "_%N_" + "%j_" + "ERROR_")
         sbatch = {
             "time": str(self.job_timeout) + ":00",
             "exclude": NodeSet.fromlist(self.exclude_slurm_nodes),
             "error": str(error),
             "export": "ALL"
-            }
+        }
         # include the cluster specific params
         sbatch.update(self.srun_params)
         unique = get_random_string(5, self.used)

--- a/src/tests/ftest/util/apricot/apricot/test.py
+++ b/src/tests/ftest/util/apricot/apricot/test.py
@@ -895,7 +895,7 @@ class TestWithServers(TestWithoutServers):
             TestPool: the created test pool object.
 
         """
-        pool = TestPool(self.context, dmg_command=self.get_dmg_command(index))
+        pool = TestPool(self.context, self.get_dmg_command(index))
         if namespace is not None:
             pool.namespace = namespace
         pool.get_params(self)

--- a/src/tests/ftest/util/daos_io_conf.py
+++ b/src/tests/ftest/util/daos_io_conf.py
@@ -26,7 +26,7 @@ import random
 
 from apricot import TestWithServers
 from command_utils_base import \
-    CommandFailure, BasicParameter, FormattedParameter
+    BasicParameter, FormattedParameter
 from command_utils import ExecutableCommand
 from test_utils_pool import TestPool
 from job_manager_utils import Orterun
@@ -117,7 +117,7 @@ class IoConfTestBase(TestWithServers):
 
     def setup_test_pool(self):
         """Define a TestPool object."""
-        self.pool = TestPool(self.context, dmg_command=self.get_dmg_command())
+        self.pool = TestPool(self.context, self.get_dmg_command())
         self.pool.get_params(self)
         avocao_tmp_dir = os.environ['AVOCADO_TESTS_COMMON_TMPDIR']
         self.testfile = os.path.join(avocao_tmp_dir, 'testfile')

--- a/src/tests/ftest/util/ior_test_base.py
+++ b/src/tests/ftest/util/ior_test_base.py
@@ -76,8 +76,7 @@ class IorTestBase(DfuseTestBase):
     def create_pool(self):
         """Create a TestPool object to use with ior."""
         # Get the pool params
-        self.pool = TestPool(
-            self.context, dmg_command=self.get_dmg_command())
+        self.pool = TestPool(self.context, self.get_dmg_command())
         self.pool.get_params(self)
 
         # Create a pool
@@ -245,13 +244,17 @@ class IorTestBase(DfuseTestBase):
                 self.pool.display_pool_daos_space()
             out = manager.run()
 
-            if not self.subprocess:
-                for line in out.stdout.splitlines():
-                    if 'WARNING' in line:
-                        if fail_on_warning:
-                            self.fail("IOR command issued warnings.\n")
-                        else:
-                            self.log.warning("IOR command issued warnings.\n")
+            if self.subprocess:
+                return out
+
+            if fail_on_warning:
+                report_warning = self.fail
+            else:
+                report_warning = self.log.warning
+
+            for line in out.stdout.splitlines():
+                if 'WARNING' in line:
+                    report_warning("IOR command issued warnings.\n")
             return out
         except CommandFailure as error:
             self.log.error("IOR Failed: %s", str(error))
@@ -269,8 +272,8 @@ class IorTestBase(DfuseTestBase):
         Args:
             manager (str): mpi job manager command
         """
-        self.log.info(
-            "<IOR> Stopping in-progress IOR command: %s", str(self.job_manager))
+        self.log.info("<IOR> Stopping in-progress IOR command: %s",
+                      str(self.job_manager))
 
         try:
             out = self.job_manager.stop()
@@ -353,7 +356,10 @@ class IorTestBase(DfuseTestBase):
         env = self.ior_cmd.get_default_env(str(manager), self.client_log)
         if intercept:
             env["LD_PRELOAD"] = intercept
-        manager.assign_hosts(clients, self.workdir, self.hostfile_clients_slots)
+        manager.assign_hosts(
+            clients,
+            self.workdir,
+            self.hostfile_clients_slots)
         manager.assign_processes(procs)
         manager.assign_environment(env)
         self.lock.release()
@@ -416,7 +422,10 @@ class IorTestBase(DfuseTestBase):
         try:
             # execute bash cmds
             ret = pcmd(
-                self.hostlist_clients, cmd, verbose=display_output, timeout=300)
+                self.hostlist_clients,
+                cmd,
+                verbose=display_output,
+                timeout=300)
             if 0 not in ret:
                 error_hosts = NodeSet(
                     ",".join(

--- a/src/tests/ftest/util/mpio_test_base.py
+++ b/src/tests/ftest/util/mpio_test_base.py
@@ -54,8 +54,7 @@ class MpiioTests(TestWithServers):
         self.daos_cmd = DaosCommand(self.bin)
 
         # initialize a python pool object then create the underlying
-        self.pool = TestPool(
-            self.context, dmg_command=self.get_dmg_command())
+        self.pool = TestPool(self.context, self.get_dmg_command())
         self.pool.get_params(self)
         self.pool.create()
 

--- a/src/tests/ftest/util/nvme_utils.py
+++ b/src/tests/ftest/util/nvme_utils.py
@@ -398,7 +398,7 @@ class ServerFillUp(IorTestBase):
               Replace with dmg options in future when it's available.
         """
         # Create a pool
-        self.pool = TestPool(self.context, dmg_command=self.get_dmg_command())
+        self.pool = TestPool(self.context, self.get_dmg_command())
         self.pool.get_params(self)
 
         #If NVMe is True get the max NVMe size from servers

--- a/src/tests/ftest/util/rebuild_test_base.py
+++ b/src/tests/ftest/util/rebuild_test_base.py
@@ -67,7 +67,7 @@ class RebuildTestBase(TestWithServers):
 
     def setup_test_pool(self):
         """Define a TestPool object."""
-        self.pool = TestPool(self.context, dmg_command=self.get_dmg_command())
+        self.pool = TestPool(self.context, self.get_dmg_command())
         self.pool.get_params(self)
 
     def setup_test_container(self):

--- a/src/tests/ftest/util/test_utils_base.py
+++ b/src/tests/ftest/util/test_utils_base.py
@@ -96,7 +96,7 @@ class TestDaosApiBase(ObjectWithParameters):
         self.debug = BasicParameter(None, False)
 
         # Test yaml parameter used to define the control method:
-        #   USE_API    - use the API methods to create/destroy pools/containers
+        #   USE_API    - use the API methods to create/destroy containers
         #   USE_DMG    - use the dmg command to create/destroy pools/containers
         #   USE_DAOS   - use the daos command to create/destroy pools/containers
         self.control_method = BasicParameter(self.USE_API, self.USE_API)


### PR DESCRIPTION
In DAOS-5630 the DaosPool.create() method was removed from
pydaos. This patch updates the TestPool.create() method to
use the DmgCommand only for pool creation.

Signed-off-by: Martinez Montes, Jonathan <jonathan.martinez.montes@intel.com>