### PR TITLE
DAOS-5865 common: move fn defns shared with control-plane to common

### DIFF
--- a/src/bio/SConscript
+++ b/src/bio/SConscript
@@ -28,8 +28,9 @@ def scons():
     # Other libs
     libs += ['numa', 'dl', 'smd']
 
-    bio = daos_build.library(denv, "bio", Glob('*.c'), install_off="../..",
-                             LIBS=libs)
+    tgts = Glob('*.c')
+    tgts += ['../common/control.c']
+    bio = daos_build.library(denv, "bio", tgts, install_off="../..", LIBS=libs)
     denv.Install('$PREFIX/lib64/daos_srv', bio)
 
 if __name__ == "SCons.Script":

--- a/src/common/control.c
+++ b/src/common/control.c
@@ -1,0 +1,55 @@
+/**
+ * (C) Copyright 2020 Intel Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * GOVERNMENT LICENSE RIGHTS-OPEN SOURCE SOFTWARE
+ * The Government's rights to use, modify, reproduce, release, perform, display,
+ * or disclose this software are subject to the terms of the Apache License as
+ * provided in Contract No. B620873.
+ * Any reproduction of computer software, computer software documentation, or
+ * portions thereof marked with this legend must also reproduce the markings.
+ */
+/**
+ * This file implements functions shared with the control-plane.
+ */
+#include <stdlib.h>
+#include <assert.h>
+#include <stdint.h>
+
+int
+copy_ascii(char *dst, size_t dst_sz, const void *src, size_t src_sz)
+{
+	const uint8_t	*str = src;
+	int		 i, len = src_sz;
+
+	assert(dst != NULL);
+	assert(src != NULL);
+
+	/* Trim trailing spaces */
+	while (len > 0 && str[len - 1] == ' ')
+		len--;
+
+	if (len >= dst_sz)
+		return -1;
+
+	for (i = 0; i < len; i++, str++) {
+		if (*str >= 0x20 && *str <= 0x7E)
+			dst[i] = (char)*str;
+		else
+			dst[i] = '.';
+	}
+	dst[len] = '\0';
+
+	return 0;
+}

--- a/src/control/lib/spdk/SConscript
+++ b/src/control/lib/spdk/SConscript
@@ -28,7 +28,9 @@ def scons():
 
     senv.nc = senv.Object("src/nvme_control.c")
     senv.ncc = senv.Object("src/nvme_control_common.c")
-    denv.nvmecontrol = senv.StaticLibrary("nvme_control", [senv.nc, senv.ncc],
+    senv.cc = senv.Object("../../../common/control.c")
+    denv.nvmecontrol = senv.StaticLibrary("nvme_control",
+                                          [senv.nc, senv.ncc, senv.cc],
                                           LIBS=libs)
 
     senv.Install(join(senv.subst("$PREFIX"), "lib64"), denv.nvmecontrol)

--- a/src/control/lib/spdk/ctests/SConscript
+++ b/src/control/lib/spdk/ctests/SConscript
@@ -38,7 +38,7 @@ def scons():
     if os.path.isfile(look_path):
         testbin = daos_build.test(unit_env, 'nvme_control_ctests',
                                   ['nvme_control_ut.c', unit_env.ncc,
-                                   unit_env.nc], LIBS=libs)
+                                   unit_env.nc, unit_env.cc], LIBS=libs)
         unit_env.Install("$PREFIX/bin", testbin)
     else:
         print(look_path, " missing, skipping nvme_control_ut build")

--- a/src/control/server/ctl_storage_rpc.go
+++ b/src/control/server/ctl_storage_rpc.go
@@ -159,10 +159,10 @@ func (c *ControlService) scanInstanceBdevs(ctx context.Context) (*bdev.ScanRespo
 	instances := c.harness.Instances()
 
 	for _, srv := range instances {
-		bdevReq := bdev.ScanRequest{} // use cached controller details by default
-
 		// only retrieve results for devices listed in server config
-		bdevReq.DeviceList = c.instanceStorage[srv.Index()].Bdev.GetNvmeDevs()
+		bdevReq := bdev.ScanRequest{
+			DeviceList: c.instanceStorage[srv.Index()].Bdev.GetNvmeDevs(),
+		}
 		c.log.Debugf("instance %d storage scan: only show bdev devices in config %v",
 			srv.Index(), bdevReq.DeviceList)
 

--- a/src/control/server/storage/bdev/backend.go
+++ b/src/control/server/storage/bdev/backend.go
@@ -96,7 +96,6 @@ func (w *spdkWrapper) init(log logging.Logger, spdkOpts spdk.EnvOptions) (func()
 		return nil, errors.Wrap(err, "failed to suppress spdk output")
 	}
 
-	// provide empty whitelist on init so all devices are discovered
 	if err := w.InitSPDKEnv(log, spdkOpts); err != nil {
 		restore()
 		return nil, errors.Wrap(err, "failed to init spdk env")
@@ -130,7 +129,8 @@ func (b *spdkBackend) IsVMDDisabled() bool {
 // Scan discovers NVMe controllers accessible by SPDK.
 func (b *spdkBackend) Scan(req ScanRequest) (*ScanResponse, error) {
 	restoreOutput, err := b.binding.init(b.log, spdk.EnvOptions{
-		DisableVMD: b.IsVMDDisabled(),
+		PciWhiteList: req.DeviceList,
+		DisableVMD:   b.IsVMDDisabled(),
 	})
 	if err != nil {
 		return nil, err

--- a/src/include/daos_srv/control.h
+++ b/src/include/daos_srv/control.h
@@ -78,32 +78,7 @@ struct nvme_stats {
  * \param[in]  src	source buffer containing char array
  * \param[in]  src_sz	source buffer size
  *
- * \retval		integer return code, non-zero on failure
+ * \return		Zero on success, negative value on error
  */
-static inline int
-copy_ascii(char *dst, size_t dst_sz, const void *src, size_t src_sz)
-{
-	const uint8_t	*str = src;
-	int		 i, len = src_sz;
-
-	assert(dst != NULL);
-	assert(src != NULL);
-
-	/* Trim trailing spaces */
-	while (len > 0 && str[len - 1] == ' ')
-		len--;
-
-	if (len >= dst_sz)
-		return -1;
-
-	for (i = 0; i < len; i++, str++) {
-		if (*str >= 0x20 && *str <= 0x7E)
-			dst[i] = (char)*str;
-		else
-			dst[i] = '.';
-	}
-	dst[len] = '\0';
-
-	return 0;
-}
+int copy_ascii(char *dst, size_t dst_sz, const void *src, size_t src_sz);
 #endif /* __CONTROL_H_ */


### PR DESCRIPTION
Split inline parse_ascii in daos_srv/control.h and move definition to
common/control.c which implements functions shared between data and
control planes.

Add include list to bdev scan when online to fix cosmetic probe error.

Signed-off-by: Tom Nabarro <tom.nabarro@intel.com>