### PR TITLE
DAOS-5839 vos: Add per-akey conditional capability

### DIFF
--- a/src/client/pydaos/raw/daos_api.py
+++ b/src/client/pydaos/raw/daos_api.py
@@ -974,6 +974,7 @@ class IORequest(object):
         self.iod.iod_name.iov_len = ctypes.sizeof(akey)
         self.iod.iod_type = 2
         self.iod.iod_size = c_data[0][1]
+        self.iod.iod_flags = 0
         self.iod.iod_nr = 1
         self.iod.iod_recxs = ctypes.pointer(extent)
 
@@ -1013,6 +1014,7 @@ class IORequest(object):
         self.iod.iod_name.iov_len = ctypes.sizeof(akey)
         self.iod.iod_type = 2
         self.iod.iod_size = rec_size
+        self.iod.iod_flags = 0
         self.iod.iod_nr = 1
         self.iod.iod_recxs = ctypes.pointer(extent)
 
@@ -1082,6 +1084,7 @@ class IORequest(object):
             self.iod.iod_name.iov_len = ctypes.sizeof(akey)
             self.iod.iod_type = 1
             self.iod.iod_size = size
+            self.iod.iod_flags = 0
             self.iod.iod_nr = 1
             self.iod.iod_recxs = None
 
@@ -1149,6 +1152,7 @@ class IORequest(object):
             self.iod.iod_name.iov_len = ctypes.sizeof(akey)
             self.iod.iod_type = 1
             self.iod.iod_size = ctypes.c_size_t(size)
+            self.iod.iod_flags = 0
             self.iod.iod_nr = 1
             # self.iod.iod_eprs = ctypes.cast(ctypes.pointer(self.epoch_range),
             #                                 ctypes.c_void_p)
@@ -1204,6 +1208,7 @@ class IORequest(object):
             iods[i].iod_name.iov_len = ctypes.sizeof(tup[0])
             iods[i].iod_type = 1
             iods[i].iod_size = len(tup[1])+1
+            iods[i].iod_flags = 0
             iods[i].iod_nr = 1
             i += 1
         iod_ptr = ctypes.pointer(iods)
@@ -1262,6 +1267,7 @@ class IORequest(object):
             iods[i].iod_name.iov_len = ctypes.sizeof(key[0])
             iods[i].iod_type = 1
             iods[i].iod_size = ctypes.c_ulong(key[1].value+1)
+            iods[i].iod_flags = 0
 
             iods[i].iod_nr = 1
             i += 1

--- a/src/client/pydaos/raw/daos_cref.py
+++ b/src/client/pydaos/raw/daos_cref.py
@@ -179,6 +179,7 @@ class DaosIODescriptor(ctypes.Structure):
     _fields_ = [("iod_name", IOV),
                 ("iod_type", ctypes.c_int),
                 ("iod_size", ctypes.c_uint64),
+                ("iod_flags", ctypes.c_uint64),
                 ("iod_nr", ctypes.c_uint32),
                 ("iod_recxs", ctypes.POINTER(Extent))]
 

--- a/src/include/daos_obj.h
+++ b/src/include/daos_obj.h
@@ -108,7 +108,7 @@ enum {
 };
 
 /** Number of bits reserved in IO flags bitmap for conditional checks.  */
-#define IO_FLAGS_COND_BITS	7
+#define IO_FLAGS_COND_BITS	8
 
 enum {
 	/* Conditional Op: Punch key if it exists, fail otherwise */
@@ -125,6 +125,11 @@ enum {
 	DAOS_COND_AKEY_UPDATE	= (1 << 5),
 	/* Conditional Op: Fetch akey if it exists, fail otherwise */
 	DAOS_COND_AKEY_FETCH	= (1 << 6),
+	/* Inidication of per akey conditional ops.  If set, the global
+	 * flag should not have any akey conditional ops specified. The
+	 * per akey flags will be read from the iod_flags field.
+	 */
+	DAOS_COND_PER_AKEY	= (1 << 7),
 	/** Mask for convenience */
 	DAOS_COND_MASK		= ((1 << IO_FLAGS_COND_BITS) - 1),
 };
@@ -226,6 +231,10 @@ typedef struct {
 	daos_iod_type_t		iod_type;
 	/** Size of the single value or the record size of the array */
 	daos_size_t		iod_size;
+	/** Per akey conditional. If DAOS_COND_PER_AKEY not set, this is
+	 *  ignored.
+	 */
+	uint64_t		iod_flags;
 	/*
 	 * Number of entries in the \a iod_recxs for arrays,
 	 * should be 1 if single value.

--- a/src/include/daos_srv/vos_types.h
+++ b/src/include/daos_srv/vos_types.h
@@ -220,8 +220,8 @@ enum {
 	VOS_OF_COND_AKEY_UPDATE		= DAOS_COND_AKEY_UPDATE,
 	/** Conditional Op: Fetch akey if it exists, fail otherwise */
 	VOS_OF_COND_AKEY_FETCH		= DAOS_COND_AKEY_FETCH,
-	/** replay punch (underwrite) */
-	VOS_OF_REPLAY_PC		= (1 << 7),
+	/** Indiciates akey conditions are specified in iod_flags */
+	VOS_OF_COND_PER_AKEY		= DAOS_COND_PER_AKEY,
 	/* critical update - skip checks on SCM system/held space */
 	VOS_OF_CRIT			= (1 << 8),
 	/** Instead of update or punch of extents, remove all extents
@@ -238,6 +238,8 @@ enum {
 	VOS_OF_FETCH_CHECK_EXISTENCE	= (1 << 13),
 	/** Set when propagating a punch that results in empty subtree */
 	VOS_OF_PUNCH_PROPAGATE		= (1 << 14),
+	/** replay punch (underwrite) */
+	VOS_OF_REPLAY_PC		= (1 << 15),
 };
 
 /** Mask for any conditionals passed to to the fetch */

--- a/src/include/daos_srv/vos_types.h
+++ b/src/include/daos_srv/vos_types.h
@@ -220,7 +220,7 @@ enum {
 	VOS_OF_COND_AKEY_UPDATE		= DAOS_COND_AKEY_UPDATE,
 	/** Conditional Op: Fetch akey if it exists, fail otherwise */
 	VOS_OF_COND_AKEY_FETCH		= DAOS_COND_AKEY_FETCH,
-	/** Indiciates akey conditions are specified in iod_flags */
+	/** Indicates akey conditions are specified in iod_flags */
 	VOS_OF_COND_PER_AKEY		= DAOS_COND_PER_AKEY,
 	/* critical update - skip checks on SCM system/held space */
 	VOS_OF_CRIT			= (1 << 8),

--- a/src/object/obj_rpc.c
+++ b/src/object/obj_rpc.c
@@ -204,6 +204,10 @@ crt_proc_daos_iod_and_csum(crt_proc_t proc, crt_proc_op_t proc_op,
 	if (rc != 0)
 		return -DER_HG;
 
+	rc = crt_proc_uint64_t(proc, &iod->iod_flags);
+	if (rc != 0)
+		return -DER_HG;
+
 	if (proc_op == CRT_PROC_ENCODE && oiod != NULL &&
 	    (oiod->oiod_flags & OBJ_SIOD_PROC_ONE) != 0) {
 		proc_one = true;
@@ -818,6 +822,10 @@ crt_proc_daos_iod_t(crt_proc_t proc, daos_iod_t *iod)
 		return -DER_HG;
 
 	rc = crt_proc_uint64_t(proc, &iod->iod_size);
+	if (rc != 0)
+		return -DER_HG;
+
+	rc = crt_proc_uint64_t(proc, &iod->iod_flags);
 	if (rc != 0)
 		return -DER_HG;
 

--- a/src/tests/suite/daos_obj_array.c
+++ b/src/tests/suite/daos_obj_array.c
@@ -1332,6 +1332,85 @@ small_sgl(void **state)
 	assert_int_equal(rc, 0);
 }
 
+static void
+cond_ops(void **state)
+{
+	test_arg_t	*arg = *state;
+	daos_obj_id_t	oid;
+	daos_handle_t	oh;
+	d_iov_t		dkey;
+	d_sg_list_t	sgl[2];
+	d_iov_t		sg_iov[2];
+	daos_iod_t	iod[2];
+	daos_recx_t	recx[2];
+	char		akey_str[2][10];
+	uint64_t	flags;
+	char		buf[2][STACK_BUF_LEN];
+	int		i, rc;
+
+	/** open object */
+	oid = dts_oid_gen(OC_SX, 0, arg->myrank);
+	rc = daos_obj_open(arg->coh, oid, 0, &oh, NULL);
+	assert_int_equal(rc, 0);
+
+	/** init dkey */
+	d_iov_set(&dkey, "dkey", strlen("dkey"));
+
+	for (i = 0; i < 2; i++) {
+		dts_buf_render(buf[i], STACK_BUF_LEN);
+
+		/** init scatter/gather */
+		d_iov_set(&sg_iov[i], buf[i], sizeof(buf[i]));
+		sgl[i].sg_nr		= 1;
+		sgl[i].sg_nr_out	= 0;
+		sgl[i].sg_iovs		= &sg_iov[i];
+
+		sprintf(akey_str[i], "akey_%d", i);
+		/** init I/O descriptor */
+		d_iov_set(&iod[i].iod_name, akey_str[i], strlen(akey_str[i]));
+		iod[i].iod_nr	= 1;
+		iod[i].iod_size	= 1;
+		recx[i].rx_idx	= 0;
+		recx[i].rx_nr	= sizeof(buf[i]);
+		iod[i].iod_recxs = &recx[i];
+		iod[i].iod_type	= DAOS_IOD_ARRAY;
+	}
+
+	flags = DAOS_COND_DKEY_UPDATE | DAOS_COND_AKEY_INSERT;
+	/** Cond update dkey should fail */
+	rc = daos_obj_update(oh, DAOS_TX_NONE, flags, &dkey, 2, iod, sgl, NULL);
+	assert_int_equal(rc, -DER_NONEXIST);
+
+	flags = DAOS_COND_DKEY_INSERT | DAOS_COND_AKEY_UPDATE;
+	/** Cond update akey should fail */
+	rc = daos_obj_update(oh, DAOS_TX_NONE, flags, &dkey, 2, iod, sgl, NULL);
+	assert_int_equal(rc, -DER_NONEXIST);
+
+	flags = DAOS_COND_DKEY_INSERT | DAOS_COND_PER_AKEY;
+	iod[0].iod_flags = DAOS_COND_AKEY_INSERT;
+	/** akey doesn't exist so update should fail */
+	iod[1].iod_flags = DAOS_COND_AKEY_UPDATE;
+	rc = daos_obj_update(oh, DAOS_TX_NONE, flags, &dkey, 2, iod, sgl, NULL);
+	assert_int_equal(rc, -DER_NONEXIST);
+
+	/** should succeed */
+	iod[1].iod_flags = DAOS_COND_AKEY_INSERT;
+	rc = daos_obj_update(oh, DAOS_TX_NONE, flags, &dkey, 2, iod, sgl, NULL);
+	assert_int_equal(rc, 0);
+
+	/** both exist now, insert should fail */
+	flags = DAOS_COND_DKEY_UPDATE | DAOS_COND_PER_AKEY;
+	iod[0].iod_flags = DAOS_COND_AKEY_INSERT;
+	iod[1].iod_flags = DAOS_COND_AKEY_UPDATE;
+	rc = daos_obj_update(oh, DAOS_TX_NONE, flags, &dkey, 2, iod, sgl, NULL);
+	assert_int_equal(rc, -DER_EXIST);
+
+	/** close object */
+	rc = daos_obj_close(oh, NULL);
+	assert_int_equal(rc, 0);
+	print_message("all good\n");
+}
+
 static const struct CMUnitTest array_tests[] = {
 	{ "ARRAY0: small_sgl",
 	  small_sgl, NULL, test_case_teardown},
@@ -1364,14 +1443,16 @@ static const struct CMUnitTest array_tests[] = {
 	{ "ARRAY14: Reading from incomplete array",
 	  array_recx_read_incomplete, NULL, test_case_teardown},
 	{ "ARRAY15: Reading from array with holes",
-		fetch_array_with_map, NULL, test_case_teardown},
+	  fetch_array_with_map, NULL, test_case_teardown},
 	{ "ARRAY16: Reading from array with holes not starting at idx 0",
-		fetch_array_with_map_2, NULL, test_case_teardown},
+	  fetch_array_with_map_2, NULL, test_case_teardown},
 	{ "ARRAY16: Reading from array with holes not starting at idx 0, fetch "
 	  "idx doesn't align with extent",
-		fetch_array_with_map_3, NULL, test_case_teardown},
+	  fetch_array_with_map_3, NULL, test_case_teardown},
 	{ "ARRAY17: Reading from array without holes, but many recxs",
-		fetch_array_with_map_4, NULL, test_case_teardown},
+	  fetch_array_with_map_4, NULL, test_case_teardown},
+	{ "ARRAY18: Simple Conditional Operations",
+	  cond_ops, NULL, test_case_teardown},
 };
 
 static int

--- a/src/vos/vos_io.c
+++ b/src/vos/vos_io.c
@@ -2074,8 +2074,8 @@ vos_update_begin(daos_handle_t coh, daos_unit_oid_t oid, daos_epoch_t epoch,
 	int			 rc;
 
 	D_DEBUG(DB_TRACE, "Prepare IOC for "DF_UOID", iod_nr %d, epc "DF_X64
-		"\n", DP_UOID(oid), iod_nr,
-		dtx_is_valid_handle(dth) ? dth->dth_epoch :  epoch);
+		", flags="DF_X64"\n", DP_UOID(oid), iod_nr,
+		dtx_is_valid_handle(dth) ? dth->dth_epoch :  epoch, flags);
 
 	rc = vos_ioc_create(coh, oid, false, epoch, iod_nr, iods, iods_csums,
 			    flags, NULL, dedup, dedup_th, dth, &ioc);

--- a/src/vos/vos_ts.c
+++ b/src/vos/vos_ts.c
@@ -324,7 +324,8 @@ vos_ts_set_allocate(struct vos_ts_set **ts_set, uint64_t flags,
 {
 	uint32_t	size;
 	uint64_t	array_size;
-	uint64_t	cond_mask = VOS_COND_FETCH_MASK | VOS_COND_UPDATE_MASK;
+	uint64_t	cond_mask = VOS_COND_FETCH_MASK | VOS_COND_UPDATE_MASK |
+		VOS_OF_COND_PER_AKEY;
 
 	*ts_set = NULL;
 	if (tx_id == NULL && (flags & cond_mask) == 0)


### PR DESCRIPTION
Allow the user to specify a per-akey conditional rather
than a global one.   This allows a user more flexibility
in using conditional operations.

User specified usage of per-akey iod by setting
DAOS_COND_PER_AKEY in the flags.  This allows a simple
check by distributed transaction logic to know if the iod
needs to be searched for conditionals.

TODO:
1. Add the distributed transaciton logic to handle the
DAOS_COND_PER_AKEY flag.  It isn't needed for the
immediate use case and is thus deferred.
2. Modify the logic so read timestamps are set per akey
on conditionals rather than on all akeys in the operation.
This is an optimization to avoid some false conflicts and
is deferred for simplicity.  It's also not required for
the immediate use case

Signed-off-by: Jeff Olivier <jeffrey.v.olivier@intel.com>