### PR TITLE
DAOS-4326 api: daos_pool_get_vos_state()

### DIFF
--- a/src/client/api/init.c
+++ b/src/client/api/init.c
@@ -53,6 +53,7 @@ const struct daos_task_api dc_funcs[] = {
 	{dc_pool_add_replicas, sizeof(daos_pool_replicas_t)},
 	{dc_pool_remove_replicas, sizeof(daos_pool_replicas_t)},
 	{dc_mgmt_get_bs_state, sizeof(daos_mgmt_get_bs_state_t)},
+	{dc_pool_get_vos_state, sizeof(daos_pool_get_vos_state_t)},
 
 	/** Pool */
 	{dc_pool_connect, sizeof(daos_pool_connect_t)},

--- a/src/client/api/mgmt.c
+++ b/src/client/api/mgmt.c
@@ -266,3 +266,26 @@ daos_mgmt_get_bs_state(const char *group, uuid_t blobstore_uuid,
 
 	return dc_task_schedule(task, true);
 }
+
+int
+daos_pool_get_vos_state(const char *group, uuid_t pool_uuid, d_rank_t tgt,
+			d_rank_t rank, int *state, daos_event_t *ev)
+{
+	daos_pool_get_vos_state_t	*args;
+	tse_task_t			*task;
+	int				 rc;
+
+	DAOS_API_ARG_ASSERT(*args, MGMT_GET_VOS_STATUS);
+
+	rc = dc_task_create(dc_pool_get_vos_state, NULL, ev, &task);
+	if (rc)
+		return rc;
+	args = dc_task_get_args(task);
+	args->grp = group;
+	args->tgt = tgt;
+	args->rank = rank;
+	args->state = state;
+	uuid_copy(args->pool_uuid, pool_uuid);
+
+	return dc_task_schedule(task, true);
+}

--- a/src/include/daos/mgmt.h
+++ b/src/include/daos/mgmt.h
@@ -41,6 +41,7 @@ int dc_mgmt_set_params(tse_task_t *task);
 int dc_mgmt_profile(char *path, int avg, bool start);
 int dc_mgmt_add_mark(const char *mark);
 int dc_mgmt_get_bs_state(tse_task_t *task);
+int dc_pool_get_vos_state(tse_task_t *task);
 
 #define SYS_INFO_BUF_SIZE 16
 

--- a/src/include/daos/tests_lib.h
+++ b/src/include/daos/tests_lib.h
@@ -173,6 +173,15 @@ typedef struct {
 	char		host[50];
 }  device_list;
 
+#define MAX_TEST_TARGETS_PER_POOL 10
+#define MAX_TEST_RANKS_PER_POOL 5
+typedef struct {
+	uuid_t		pool_id;
+	int		rank[MAX_TEST_RANKS_PER_POOL];
+	int		tgts[MAX_TEST_TARGETS_PER_POOL];
+	char		host[50];
+}  pool_table_list;
+
 /** Initialize an SGL with a variable number of IOVs and set the IOV buffers
  *  to the value of the strings passed. This will allocate memory for the iov
  *  structures as well as the iov buffers, so d_sgl_fini(sgl, true) must be
@@ -326,6 +335,19 @@ int dmg_storage_device_list(const char *dmg_config_file, int *ndisks,
 			    device_list *devices);
 
 /**
+ * List all pools from the SMD pool table in the specified DAOS system.
+ *
+ *  \param dmg_config_file	[IN]	DMG config file
+ *  \param npools		[OUT]	Number of pools in the DAOS system.
+ *  \param pool			[OUT]	Array of NVMe pool table info structures
+ *					NULL is permitted in which case only the
+ *					number of pool will be returned in
+ *					\a npools.
+ */
+int dmg_storage_pool_list(const char *dmg_config_file, int *npools,
+			  pool_table_list *pools);
+
+/**
  * Set NVMe device to faulty. Which will trigger the rebuild and all the
  * target attached to the disk will be excluded.
  *
@@ -352,5 +374,7 @@ int dmg_storage_set_nvme_fault(const char *dmg_config_file,
  *					expected state
  */
 int verify_blobstore_state(int state, const char *state_str);
+
+const char *vos_state_enum_to_str(int state);
 
 #endif /* __DAOS_TESTS_LIB_H__ */

--- a/src/include/daos_mgmt.h
+++ b/src/include/daos_mgmt.h
@@ -318,6 +318,25 @@ int
 daos_mgmt_get_bs_state(const char *group, uuid_t blobstore_uuid,
 		       int *blobstore_state, daos_event_t *ev);
 
+/**
+ * Query the VOS pool target state for given pool uuid, target index, and rank
+ * in the specified DAOS system.
+ *
+ * \param group		  [IN]	Name of DAOS system managing the service.
+ * \param pool_uuid	  [IN]	UUID of the pool to query.
+ * \param tgt		  [IN]  Pool target index to query the VOS state
+ * \param rank		  [IN]  Rank that the pool target resides on
+ * \param state		  [OUT] VOS target state
+ *				ie DOWN/DOWNOUT/UP/UPIN/NEW/DRAIN
+ * \param ev		  [IN]  Completion event. Optional and can be NULL.
+ *				The function will run in blocking mode
+ *				if \a ev is NULL.
+ *
+ * \return			0		Success
+ */
+int
+daos_pool_get_vos_state(const char *group, uuid_t pool_uuid, d_rank_t tgt,
+			d_rank_t rank, int *state, daos_event_t *ev);
 
 #if defined(__cplusplus)
 }

--- a/src/include/daos_task.h
+++ b/src/include/daos_task.h
@@ -54,6 +54,7 @@ typedef enum {
 	DAOS_OPC_POOL_ADD_REPLICAS,
 	DAOS_OPC_POOL_REMOVE_REPLICAS,
 	DAOS_OPC_MGMT_GET_BS_STATE,
+	DAOS_OPC_MGMT_GET_VOS_STATUS,
 
 	/** Pool APIs */
 	DAOS_OPC_POOL_CONNECT,
@@ -369,6 +370,20 @@ typedef struct {
 	uuid_t			uuid;
 	int			*state;
 } daos_mgmt_get_bs_state_t;
+
+/** pool management pool query VOS tgt state */
+typedef struct {
+	/** Process set name of the DAOS servers managing the pool */
+	const char		*grp;
+	/** Local VOS target idx */
+	d_rank_t		 tgt;
+	/** Rank of the pool target to query */
+	d_rank_t		 rank;
+	/** Returned VOS target state */
+	int			*state;
+	/** UUID of the of the pool that the target resides */
+	uuid_t			 pool_uuid;
+} daos_pool_get_vos_state_t;
 
 /** pool service stop args */
 typedef struct {

--- a/src/mgmt/rpc.c
+++ b/src/mgmt/rpc.c
@@ -48,7 +48,9 @@ CRT_RPC_DEFINE(mgmt_tgt_map_update, DAOS_ISEQ_MGMT_TGT_MAP_UPDATE,
 		DAOS_OSEQ_MGMT_TGT_MAP_UPDATE)
 
 CRT_RPC_DEFINE(mgmt_get_bs_state, DAOS_ISEQ_MGMT_GET_BS_STATE,
-	       DAOS_OSEQ_MGMT_GET_BS_STATE)
+		DAOS_OSEQ_MGMT_GET_BS_STATE)
+CRT_RPC_DEFINE(mgmt_get_vos_state, DAOS_ISEQ_MGMT_GET_VOS_STATE,
+		DAOS_OSEQ_MGMT_GET_VOS_STATE)
 
 /* Define for cont_rpcs[] array population below.
  * See MGMT_PROTO_*_RPC_LIST macro definition

--- a/src/mgmt/rpc.h
+++ b/src/mgmt/rpc.h
@@ -54,7 +54,10 @@
 		ds_mgmt_mark_hdlr, NULL),				\
 	X(MGMT_GET_BS_STATE,						\
 		0, &CQF_mgmt_get_bs_state,				\
-		ds_mgmt_hdlr_get_bs_state, NULL)
+		ds_mgmt_hdlr_get_bs_state, NULL),			\
+	X(MGMT_GET_VOS_STATE,						\
+		0, &CQF_mgmt_get_vos_state,				\
+		ds_mgmt_hdlr_get_vos_state, NULL)
 #define MGMT_PROTO_SRV_RPC_LIST						\
 	X(MGMT_TGT_CREATE,						\
 		0, &CQF_mgmt_tgt_create,				\
@@ -199,5 +202,20 @@ CRT_RPC_DECLARE(mgmt_mark, DAOS_ISEQ_MGMT_MARK, DAOS_OSEQ_MGMT_MARK)
 
 CRT_RPC_DECLARE(mgmt_get_bs_state, DAOS_ISEQ_MGMT_GET_BS_STATE,
 		DAOS_OSEQ_MGMT_GET_BS_STATE)
+
+/* Get VOS target state */
+#define DAOS_ISEQ_MGMT_GET_VOS_STATE /* input fields */	 \
+	((d_rank_t)		(vs_rank)		CRT_VAR) \
+	((d_rank_t)		(vs_tgt)		CRT_VAR) \
+	((uuid_t)		(vs_pool_uuid)		CRT_VAR)
+
+#define DAOS_OSEQ_MGMT_GET_VOS_STATE /* output fields */	 \
+	((d_rank_t)		(vs_rank)		CRT_VAR) \
+	((d_rank_t)		(vs_tgt)		CRT_VAR) \
+	((int32_t)		(vs_state)		CRT_VAR) \
+	((int32_t)		(vs_rc)			CRT_VAR)
+
+CRT_RPC_DECLARE(mgmt_get_vos_state, DAOS_ISEQ_MGMT_GET_VOS_STATE,
+		DAOS_OSEQ_MGMT_GET_VOS_STATE)
 
 #endif /* __MGMT_RPC_H__ */

--- a/src/mgmt/srv_internal.h
+++ b/src/mgmt/srv_internal.h
@@ -116,6 +116,9 @@ int ds_mgmt_dev_state_query(uuid_t uuid, Mgmt__DevStateResp *resp);
 int ds_mgmt_dev_set_faulty(uuid_t uuid, Mgmt__DevStateResp *resp);
 int ds_mgmt_get_bs_state(uuid_t bs_uuid, int *bs_state);
 void ds_mgmt_hdlr_get_bs_state(crt_rpc_t *rpc_req);
+int ds_mgmt_get_vos_state(d_rank_t rank, d_rank_t tgt, const uuid_t pool_uuid,
+			  int *state);
+void ds_mgmt_hdlr_get_vos_state(crt_rpc_t *rpc);
 
 /** srv_target.c */
 int ds_mgmt_tgt_setup(void);

--- a/src/tests/suite/daos_test.h
+++ b/src/tests/suite/daos_test.h
@@ -401,6 +401,8 @@ int verify_state_in_log(char *host, char *log_file, char *state);
 
 int wait_and_verify_blobstore_state(uuid_t bs_uuid, char *expected_state,
 				    const char *group);
+int wait_and_verify_vos_state(uuid_t pool_uuid, int tgtidx[], int n_tgtidx,
+			      int rank, char *expected_state, const char *group);
 
 static inline void
 daos_test_print(int rank, char *message)


### PR DESCRIPTION
A DAOS mgmt/pool C API to query the VOS target state
is required for daos_test validation of DAOS NVMe recovery
tests (and can later be applied to rebuild tests).

Add capabilty to check the VOS target state before, during,
and after rebuild have completed (ie NEW/UP/UPIN/DOWN/DOWNOUT/DRAIN).
This is accomplished using the daos_pool_get_vos_state() C API,
which will return the VOS target state for a given pool uuid, rank,
and target idx. Not currently exported via dmg command for admin use.

Test-tag-hw-medium: daos_test_nvme_recovery

Signed-off-by: Sydney Vanda <sydney.m.vanda@intel.com>