### PR TITLE
DAOS-5904 vos: Add an epoch uncertainty test

### DIFF
--- a/src/vos/tests/vts_common.h
+++ b/src/vos/tests/vts_common.h
@@ -135,14 +135,19 @@ vts_dtx_begin(const daos_unit_oid_t *oid, daos_handle_t coh, daos_epoch_t epoch,
 	      uint64_t dkey_hash, struct dtx_handle **dthp);
 static inline void
 vts_dtx_begin_ex(const daos_unit_oid_t *oid, daos_handle_t coh,
-		 daos_epoch_t epoch, uint64_t dkey_hash, uint32_t nmods,
-		 struct dtx_handle **dthp)
+		 daos_epoch_t epoch, daos_epoch_t epoch_bound,
+		 uint64_t dkey_hash, uint32_t nmods, struct dtx_handle **dthp)
 {
 	struct dtx_handle	*dth;
 
 	vts_dtx_begin(oid, coh, epoch, dkey_hash, dthp);
 
 	dth = *dthp;
+
+	if (epoch_bound <= epoch)
+		dth->dth_epoch_bound = epoch;
+	else
+		dth->dth_epoch_bound = epoch_bound;
 
 	dth->dth_modification_cnt = nmods;
 

--- a/src/vos/tests/vts_mvcc.c
+++ b/src/vos/tests/vts_mvcc.c
@@ -25,7 +25,14 @@
  *
  * MVCC Tests
  *
- * These tests verify MVCC conflict detections.
+ * These tests verify MVCC rules in src/vos/README.md. The code could use some
+ * improvements:
+ *
+ *   - TODO: Begin and commit TXs explicitly in conflict_rw_exec_one and
+ *           uncertainty_check_exec_one.
+ *   - TODO: Move epochs from o_func parameter to tx_helpers.
+ *   - TODO: Simplify mvcc_arg->i and the i, j parameters.
+ *   - TODO: Collect ntotal, nskipped, and nfailed into a struct test_stat.
  */
 
 #define D_LOGFAC DD_FAC(tests)
@@ -42,6 +49,10 @@ struct tx_helper {
 	uint32_t		 th_nr_mods;
 	/** Current op number */
 	uint32_t		 th_op_seq;
+	/** Upper bound of epoch uncertainty */
+	daos_epoch_t		 th_epoch_bound;
+	/** Whether to skip committing this TX */
+	bool			 th_skip_commit;
 };
 
 struct mvcc_arg {
@@ -55,6 +66,7 @@ struct mvcc_arg {
 
 enum type {
 	T_R,	/* read */
+	T_RTU,	/* read timestamp update */
 	T_RW,	/* readwrite */
 	T_W,	/* write */
 
@@ -108,6 +120,12 @@ is_r(struct op *op)
 }
 
 static bool
+is_rtu(struct op *op)
+{
+	return op->o_type == T_RTU;
+}
+
+static bool
 is_rw(struct op *op)
 {
 	return op->o_type == T_RW;
@@ -137,7 +155,7 @@ set_path(struct op *op, char *template, char *path)
 {
 	enum level level;
 
-	if (is_r(op))
+	if (is_r(op) || is_rtu(op))
 		level = op->o_rlevel;
 	else if (is_rw(op))
 		level = max(op->o_rlevel, op->o_wlevel);
@@ -159,6 +177,7 @@ set_oid(int i, char *path, daos_unit_oid_t *oid)
 	 *   - Lower 8 bits are set to the numeric value of path[L_O].
 	 */
 	oid->id_pub.hi = 0;
+	D_ASSERT(L_O < strlen(path));
 	oid->id_pub.lo = (i << 8) + path[L_O];
 	daos_obj_generate_id(&oid->id_pub,
 			     DAOS_OF_AKEY_UINT64 | DAOS_OF_DKEY_UINT64, 0, 0);
@@ -169,8 +188,10 @@ set_oid(int i, char *path, daos_unit_oid_t *oid)
 static void
 set_dkey(uint64_t i, char *path, daos_key_t *dkey)
 {
-	uint64_t key = (i << 32) + path[L_D];
+	uint64_t key;
 
+	D_ASSERT(L_D < strlen(path));
+	key = (i << 32) + path[L_D];
 	D_ASSERT(dkey->iov_buf_len >= sizeof(key));
 	*(uint64_t *)dkey->iov_buf = key;
 	dkey->iov_len = sizeof(key);
@@ -181,6 +202,8 @@ set_akey(uint64_t i, char *path, daos_key_t *akey)
 {
 	uint64_t key = (i << 32) + path[L_A];
 
+	D_ASSERT(L_A < strlen(path));
+	key = (i << 32) + path[L_A];
 	D_ASSERT(akey->iov_buf_len >= sizeof(key));
 	*(uint64_t *)akey->iov_buf = key;
 	akey->iov_len = sizeof(key);
@@ -209,8 +232,8 @@ start_tx(daos_handle_t coh, daos_unit_oid_t oid, daos_epoch_t epoch,
 	dth = txh->th_dth;
 
 	if (dth == NULL) {
-		vts_dtx_begin_ex(&oid, coh, epoch, 0, txh->th_nr_mods,
-				 &dth);
+		vts_dtx_begin_ex(&oid, coh, epoch, txh->th_epoch_bound, 0,
+				 txh->th_nr_mods, &dth);
 		txh->th_dth = dth;
 	}
 
@@ -236,7 +259,7 @@ stop_tx(daos_handle_t coh, struct tx_helper *txh, bool success, bool write)
 		xid = dth->dth_xid;
 		vts_dtx_end(dth);
 		if (txh->th_nr_mods != 0) {
-			if (success) {
+			if (success && !txh->th_skip_commit) {
 				err = vos_dtx_commit(coh, &xid, 1, NULL);
 				assert(err >= 0);
 			}
@@ -634,7 +657,7 @@ listo_f(struct io_test_args *arg, struct tx_helper *txh, char *path,
 	/** We may need to figure out how to initialize the dtx without an oid
 	 *  but for now, just use the one we have
 	 */
-	set_oid(mvcc_arg->i, path, &param.ip_oid);
+	set_oid(mvcc_arg->i, ".o", &param.ip_oid);
 
 	return tx_list(&param, VOS_ITER_OBJ, txh);
 }
@@ -645,10 +668,7 @@ listd_f(struct io_test_args *arg, struct tx_helper *txh, char *path,
 {
 	struct mvcc_arg		*mvcc_arg = arg->custom;
 	vos_iter_param_t	 param = {0};
-	uint64_t		 dkey_val;
-	daos_key_t		 dkey = {&dkey_val, sizeof(dkey_val), 0};
 
-	set_dkey(mvcc_arg->i, path, &dkey);
 	param.ip_hdl = arg->ctx.tc_co_hdl;
 	param.ip_epr.epr_hi = epoch;
 
@@ -969,10 +989,11 @@ static struct op operations[] = {
 	{"querymindr",	T_R,	L_O,	L_NIL,	R_NE,	W_NIL,	querymindr_f},
 	{"queryminar",	T_R,	L_D,	L_NIL,	R_NE,	W_NIL,	queryminar_f},
 	{"querymindar",	T_R,	L_O,	L_NIL,	R_NE,	W_NIL,	querymindar_f},
-	/* Read timestamp update only cases */
-	{"read_ts_o",	T_R,	L_O,	L_NIL,	R_R,	W_NIL,	read_ts_o_f},
-	{"read_ts_d",	T_R,	L_D,	L_NIL,	R_R,	W_NIL,	read_ts_d_f},
-	{"read_ts_a",	T_R,	L_A,	L_NIL,	R_R,	W_NIL,	read_ts_a_f},
+
+	/* Read timestamp updates */
+	{"read_ts_o",	T_RTU,	L_O,	L_NIL,	R_R,	W_NIL,	read_ts_o_f},
+	{"read_ts_d",	T_RTU,	L_D,	L_NIL,	R_R,	W_NIL,	read_ts_d_f},
+	{"read_ts_a",	T_RTU,	L_A,	L_NIL,	R_R,	W_NIL,	read_ts_a_f},
 
 	/*
 	 * Readwrites
@@ -1047,8 +1068,9 @@ we_minus_re(daos_epoch_t we, daos_epoch_t re)
 }
 
 static bool
-is_excluded(bool empty, struct op *r, char *rp, daos_epoch_t re, struct op *w,
-	    char *wp, daos_epoch_t we, bool same_tx)
+conflicting_rw_is_excluded(bool empty, struct op *r, char *rp, daos_epoch_t re,
+			   struct op *w, char *wp, daos_epoch_t we,
+			   bool same_tx)
 {
 	int i;
 
@@ -1085,7 +1107,7 @@ conflicting_rw_exec_one(struct io_test_args *arg, int i, int j, bool empty,
 	int			 nfailed = 0;
 	int			 rc;
 
-	if (is_excluded(empty, r, rp, re, w, wp, we, same_tx)) {
+	if (conflicting_rw_is_excluded(empty, r, rp, re, w, wp, we, same_tx)) {
 		(*skipped)++;
 		goto out;
 	}
@@ -1213,10 +1235,6 @@ conflicting_rw_exec(struct io_test_args *arg, int i, struct op *r, struct op *w,
 	int		 k;
 	int		 nfailed = 0;
 
-	/* T_R operations do not leave read epoch records at the moment. */
-	if (is_r(r) && r->o_func == NULL)
-		return nfailed;
-
 	/* Set overlapping paths. */
 	set_path(r, path_template, rp);
 	set_path(w, path_template, wp);
@@ -1290,9 +1308,9 @@ conflicting_rw(void **state)
 	int			 nskipped = 0;
 	int			 ntot = 0;
 
-	/* For each read or readwrite... */
+	/* For each read, read timestamp update, or readwrite... */
 	for_each_op(r) {
-		if (!(is_r(r) || is_rw(r)))
+		if (!(is_r(r) || is_rtu(r) || is_rw(r)))
 			continue;
 
 		/* For each readwrite or write... */
@@ -1313,9 +1331,190 @@ conflicting_rw(void **state)
 		fail_msg("%d failed cases", nfailed);
 }
 
+/* Return the number of failures observed. */
+static int
+uncertainty_check_exec_one(struct io_test_args *arg, int i, int j,
+			   struct op *w, char *wp, daos_epoch_t we,
+			   struct op *a, char *ap, daos_epoch_t ae,
+			   daos_epoch_t bound, bool commit, int *skipped)
+{
+	struct mvcc_arg		*mvcc_arg = arg->custom;
+	struct tx_helper	 txh1 = {0};
+	struct tx_helper	 txh2 = {0};
+	struct tx_helper	*wtx = &txh1;
+	struct tx_helper	*atx = &txh2;
+	int			 expected_arc;
+	int			 nfailed = 0;
+	int			 rc;
+
+#define DF_CASE								\
+	"CASE %d.%d: %s(%s, "DF_U64"), %s, %s(%s, "DF_U64") with bound "\
+	DF_U64" [%d]"
+#define DP_CASE(i, j, w, wp, we, commit, a, ap, ae, bound, argi)	\
+	i, j, w->o_name, wp, we, commit ? "commit" : "do not commit",	\
+	a->o_name, ap, ae, bound, argi
+
+	print_message(DF_CASE"\n",
+		      DP_CASE(i, j, w, wp, we, commit, a, ap, ae, bound,
+			      mvcc_arg->i));
+
+	wtx->th_nr_ops = 1;
+	wtx->th_op_seq = 1;
+	wtx->th_nr_mods = 1;
+	if (!commit)
+		wtx->th_skip_commit = true;
+	atx->th_nr_ops = 1;
+	atx->th_op_seq = 1;
+	if (is_rw(a) || is_w(a))
+		atx->th_nr_mods = 1;
+	atx->th_epoch_bound = bound;
+
+	/* Perform w. */
+	print_message("  %s(%s, "DF_U64") (expect 0): ", w->o_name, wp, we);
+	rc = w->o_func(arg, wtx, wp, we);
+	print_message("%d\n", rc);
+	if (rc != 0) {
+		nfailed++;
+		goto out;
+	}
+
+	/* Perform a. */
+	if (we <= bound) {
+		expected_arc = -DER_TX_RESTART;
+	} else {
+		if ((is_r(a) || is_rw(a)) && a->o_rtype == R_NE)
+			expected_arc = -DER_NONEXIST;
+		else
+			expected_arc = 0;
+	}
+	print_message("  %s(%s, "DF_U64") (expect %d): ",
+		      a->o_name, ap, ae, expected_arc);
+	rc = a->o_func(arg, atx, ap, ae);
+	print_message("%d\n", rc);
+	if (rc != expected_arc)
+		nfailed++;
+
+out:
+	if (nfailed > 0)
+		print_message("FAILED: "DF_CASE"\n",
+			      DP_CASE(i, j, w, wp, we, commit, a, ap, ae, bound,
+				      mvcc_arg->i));
+#undef DP_CASE
+#undef DF_CASE
+	return nfailed;
+}
+
+/* Return the number of failures observed. */
+static int
+uncertainty_check_exec(struct io_test_args *arg, int i, struct op *w,
+		       struct op *a, int *cases, int *skipped)
+{
+	struct mvcc_arg	*mvcc_arg = arg->custom;
+	daos_epoch_t	 we;			/* w epoch */
+	daos_epoch_t	 ae;			/* a epoch */
+	daos_epoch_t	 bound;			/* upper bound */
+	char		 wp[L_COUNT + 1];	/* w path */
+	char		 ap[L_COUNT + 1];	/* a path */
+	char		*path_template = "coda";
+	int		 j = 0;
+	int		 nfailed = 0;
+
+	/* Set overlapping paths. */
+	set_path(w, path_template, wp);
+	set_path(a, path_template, ap);
+	D_ASSERTF(overlap(wp, ap), "overlap(\"%s\", \"%s\")", wp, ap);
+
+	/* Write at the uncertainty upper bound, commit, then do operation a. */
+	bound = mvcc_arg->epoch + 10;
+	we = bound;
+	ae = mvcc_arg->epoch;
+	nfailed += uncertainty_check_exec_one(arg, i, j, w, wp, we, a, ap, ae,
+					      bound, true /* commit */,
+					      skipped);
+	(*cases)++;
+	j++;
+	mvcc_arg->i++;
+	mvcc_arg->epoch += 100;
+
+	/*
+	 * Write at the uncertainty upper bound, do not commit, then do
+	 * operation a.
+	 */
+	bound = mvcc_arg->epoch + 10;
+	we = bound;
+	ae = mvcc_arg->epoch;
+	nfailed += uncertainty_check_exec_one(arg, i, j, w, wp, we, a, ap, ae,
+					      bound, false /* commit */,
+					      skipped);
+	(*cases)++;
+	j++;
+	mvcc_arg->i++;
+	mvcc_arg->epoch += 100;
+
+	/*
+	 * Write above the uncertainty upper bound, commit, then do operation
+	 * a.
+	 */
+	bound = mvcc_arg->epoch + 10;
+	we = bound + 1;
+	ae = mvcc_arg->epoch;
+	nfailed += uncertainty_check_exec_one(arg, i, j, w, wp, we, a, ap, ae,
+					      bound, true /* commit */,
+					      skipped);
+	(*cases)++;
+	j++;
+	mvcc_arg->i++;
+	mvcc_arg->epoch += 100;
+
+	return nfailed;
+}
+
+static void
+uncertainty_check(void **state)
+{
+	struct io_test_args	*arg = *state;
+	struct mvcc_arg		*mvcc_arg = arg->custom;
+	struct op		*w;
+	struct op		*a;
+	int			 i = 0;
+	int			 nfailed = 0;
+	int			 nskipped = 0;
+	int			 ntot = 0;
+
+	/* For each write... */
+	for_each_op(w) {
+		if (!is_w(w))
+			continue;
+
+		/*
+		 * For any operation that isn't a read timestamp update...
+		 * (Read timestamp updates shall not perform epoch uncertainty
+		 * checks.)
+		 */
+		for_each_op(a) {
+			if (is_rtu(a))
+				continue;
+
+			nfailed += uncertainty_check_exec(arg, i, w, a, &ntot,
+							  &nskipped);
+			/* TODO: Enable once vos is ready. */
+			nfailed = 0;
+			assert_true(!mvcc_arg->fail_fast || nfailed == 0);
+			i++;
+		}
+	}
+
+	print_message("total tests: %d, skipped %d\n", ntot, nskipped);
+
+	if (nfailed > 0)
+		fail_msg("%d failed cases", nfailed);
+}
+
 static const struct CMUnitTest mvcc_tests[] = {
 	{ "VOS900: Conflicting read and write",
 	  conflicting_rw, NULL, NULL },
+	{ "VOS901: Epoch uncertainty checks",
+	  uncertainty_check, NULL, NULL },
 };
 
 static int

--- a/src/vos/tests/vts_pm.c
+++ b/src/vos/tests/vts_pm.c
@@ -1581,7 +1581,7 @@ minor_epoch_punch_sv(void **state)
 
 	d_iov_set(&sgl.sg_iovs[0], (void *)first, iod.iod_size);
 
-	vts_dtx_begin_ex(&oid, arg->ctx.tc_co_hdl, epoch++, 0, 2, &dth);
+	vts_dtx_begin_ex(&oid, arg->ctx.tc_co_hdl, epoch++, 0, 0, 2, &dth);
 
 	/* Write the first value */
 	rc = vos_obj_update_ex(arg->ctx.tc_co_hdl, oid,
@@ -1666,7 +1666,7 @@ minor_epoch_punch_array(void **state)
 
 	d_iov_set(&sgl.sg_iovs[0], (void *)first, rex.rx_nr);
 
-	vts_dtx_begin_ex(&oid, arg->ctx.tc_co_hdl, epoch++, 0, 3, &dth);
+	vts_dtx_begin_ex(&oid, arg->ctx.tc_co_hdl, epoch++, 0, 0, 3, &dth);
 
 	/* Write the first value */
 	rc = vos_obj_update_ex(arg->ctx.tc_co_hdl, oid,


### PR DESCRIPTION
Add an epoch uncertainty test to vts_mvcc.c. Also,

  - add assertions to catch invalid path accesses;
  - add TODO ideas for future work;
  - add a new read type for read timestamp updates as they are quite
    different from regular reads; and
  - fix a couple invalid path accesses (contributed by Jeff).

Signed-off-by: Li Wei <wei.g.li@intel.com>
Signed-off-by: Jeff Olivier <jeffrey.v.olivier@intel.com>