### PR TITLE
DAOS-5842 Test: Enabled MDtest Erasure Code test in CI.

### DIFF
--- a/src/tests/ftest/erasurecode/ec_mdtest_smoke.py
+++ b/src/tests/ftest/erasurecode/ec_mdtest_smoke.py
@@ -22,7 +22,6 @@
   portions thereof marked with this legend must also reproduce the markings.
 '''
 from mdtest_test_base import MdtestBase
-from apricot import skipForTicket
 
 class ErasureCodeMdtest(MdtestBase):
     # pylint: disable=too-many-ancestors
@@ -31,7 +30,6 @@ class ErasureCodeMdtest(MdtestBase):
     :avocado: recursive
     """
 
-    @skipForTicket("DAOS-5809")
     def test_mdtest_large(self):
         """
         Jira ID: DAOS-2494


### PR DESCRIPTION
Now DAOS-5809 is resolved so enabling MDtest for EC in Ci.

Signed-off-by: Samir Raval <samir.raval@intel.com>