### PR TITLE
DAOS-5927 EC: fixes about iod_size and single value

### DIFF
--- a/src/object/cli_ec.c
+++ b/src/object/cli_ec.c
@@ -475,7 +475,7 @@ obj_ec_stripe_encode(daos_iod_t *iod, d_sg_list_t *sgl, uint32_t iov_idx,
 	int				 rc = 0;
 
 	if (iod->iod_type == DAOS_IOD_SINGLE)
-		obj_ec_singv_local_sz(iod->iod_size, oca, k - 1, &loc);
+		obj_ec_singv_local_sz(iod->iod_size, oca, k - 1, &loc, true);
 
 	for (i = 0; i < k; i++) {
 		c_data[i] = NULL;

--- a/src/object/cli_shard.c
+++ b/src/object/cli_shard.c
@@ -691,14 +691,13 @@ dc_rw_cb(tse_task_t *task, void *arg)
 		/* update the sizes in iods */
 		for (i = 0; i < orw->orw_nr; i++) {
 			if (!is_ec_obj || reasb_req->orr_fail == NULL ||
-			    iods[i].iod_size == 0)
+			    iods[i].iod_size == 0 || sizes[i] != 0)
 				iods[i].iod_size = sizes[i];
-			if (is_ec_obj && reasb_req->orr_recov &&
-			    reasb_req->orr_fail &&
-			    reasb_req->orr_fail->efi_uiods[i].iod_size == 0) {
+			if ((is_ec_obj && reasb_req->orr_recov) &&
+			    (reasb_req->orr_fail->efi_uiods[i].iod_size == 0 ||
+			     sizes[i] != 0))
 				reasb_req->orr_fail->efi_uiods[i].iod_size =
 					sizes[i];
-			}
 		}
 
 		if (is_ec_obj && reasb_req->orr_size_fetch)

--- a/src/object/srv_obj.c
+++ b/src/object/srv_obj.c
@@ -865,7 +865,7 @@ obj_singv_ec_rw_filter(daos_unit_oid_t *oid, daos_iod_t *iods, uint64_t *offs,
 			iod->iod_recxs = (void *)iod->iod_size;
 		if (!obj_ec_singv_one_tgt(iod, NULL, oca)) {
 			obj_ec_singv_local_sz(iod->iod_size, oca, tgt_idx,
-					      &loc);
+					      &loc, for_update);
 			if (offs != NULL)
 				offs[i] = loc.esl_off;
 			if (for_update)

--- a/src/tests/suite/daos_obj.c
+++ b/src/tests/suite/daos_obj.c
@@ -520,6 +520,9 @@ lookup(const char *dkey, int nr, const char **akey, uint64_t *idx,
 
 	req->result = -1;
 	lookup_internal(&req->dkey, nr, req->sgl, req->iod, th, req, empty);
+	for (i = 0; i < nr; i++)
+		/** record extent */
+		iod_size[i] = req->iod[i].iod_size;
 }
 
 /**


### PR DESCRIPTION
1. Add more tests to verify single value and iod_size
rebuild.

2. reset the iod_size in any cases in dc_rw_cb(), and
missing iod_size to prepare the rebuild fetch buffer.

3. fix the alignment for single value degraded fetch,
and also prepare the single value degrade buffer with
alignment.

Signed-off-by: Di Wang <di.wang@intel.com>
Signed-off-by: Xuezhao Liu <xuezhao.liu@intel.com>