### PR TITLE
DAOS-5929 test: Enable largefilecount.py test for SX.

### DIFF
--- a/src/tests/ftest/io/large_file_count.py
+++ b/src/tests/ftest/io/large_file_count.py
@@ -19,7 +19,6 @@
 """
 from ior_test_base import IorTestBase
 from mdtest_test_base import MdtestBase
-from apricot import skipForTicket
 
 import write_host_file
 
@@ -41,7 +40,6 @@ class LargeFileCount(MdtestBase, IorTestBase):
                 self.hostlist_clients, self.workdir,
                 self.hostfile_clients_slots)
 
-    @skipForTicket("DAOS-5841")
     def test_largefilecount(self):
         """Jira ID: DAOS-3845.
         Test Description:

--- a/src/tests/ftest/io/large_file_count.yaml
+++ b/src/tests/ftest/io/large_file_count.yaml
@@ -40,7 +40,9 @@ largefilecount:
     - POSIX
   object_class:
     - SX
-    - RP_3GX
+# Uncomment when DAOS-5841 is resolved.
+# Ticket for re-enabling this is DAOS-5911
+#    - RP_3GX
 ior:
   np: 30
   dfs_destroy: False


### PR DESCRIPTION
Enable largefilecount.py test for SX and keeping the RP_3GX
as skipped until DAOS-5841 is resolved.

Test-tag-hw-large: pr,hw,large largefilecount

Signed-off-by: Saurabh Tandan <saurabh.tandan@intel.com>