### PR TITLE
DAOS-5731 md: rdb/raft regression test Coverity defect fix

### DIFF
--- a/src/rdb/tests/README
+++ b/src/rdb/tests/README
@@ -27,13 +27,13 @@ rdbt init --group=daos_server --uuid <uuid> --replicas=<N>
 
 # wait a short number of seconds for RDB initialization, then:
 # create KV stores in the initialized RDB on N replicas
-rdbt create --group=daos_server -replicas=<N> --ranks=<S>
+rdbt create --group=daos_server -replicas=<N> --nranks=<S>
 
 # run multi-replica tests
 rdbt test-multi --group=daos_server --replicas=<N> --nranks=<S>
 
 # destroy the KV stores
-rdbt destroy --group=daos_server -replicas=<N> --ranks=<S>
+rdbt destroy --group=daos_server -replicas=<N> --nranks=<S>
 
 # finalize the replicated database
 rdbt fini --group=daos-server

--- a/src/rdb/tests/rdbt.c
+++ b/src/rdb/tests/rdbt.c
@@ -201,12 +201,12 @@ rdbt_find_leader(crt_group_t *group, uint32_t nranks, uint32_t nreplicas,
 		if ((rc_svc == -DER_NOTLEADER) && !hint_isvalid) {
 			resp_isvalid = (rank < nreplicas);
 			if (!resp_isvalid)
-				break;
+				goto resp_valid_check;
 			notleaders++;
 		} else if (rc_svc == -DER_NOTLEADER) {
 			resp_isvalid = (rank < nreplicas);
 			if (!resp_isvalid)
-				break;
+				goto resp_valid_check;
 			notleaders++;
 			if (found_leader) {
 				/* update leader rank and term if applicable */
@@ -232,13 +232,13 @@ rdbt_find_leader(crt_group_t *group, uint32_t nranks, uint32_t nreplicas,
 		} else if (rc_svc == -DER_NOTREPLICA) {
 			resp_isvalid = (rank >= nreplicas);
 			if (!resp_isvalid)
-				break;
+				goto resp_valid_check;
 			notreplicas++;
 		} else if (!hint_isvalid) {
 			/* Leader reply without a hint */
 			resp_isvalid = ((rc_svc == 0) && (rank < nreplicas));
 			if (!resp_isvalid)
-				break;
+				goto resp_valid_check;
 			if (found_leader) {
 				if (rank != ldr_rank) {
 					printf("WARN: rank=%u replied as leader"
@@ -255,7 +255,7 @@ rdbt_find_leader(crt_group_t *group, uint32_t nranks, uint32_t nreplicas,
 			/* Leader reply with a hint (does it happen)? */
 			resp_isvalid = ((rc_svc == 0) && (rank < nreplicas));
 			if (!resp_isvalid)
-				break;
+				goto resp_valid_check;
 			if (found_leader) {
 				/* reject if h.sh_term lower? */
 				if (rank != ldr_rank) {
@@ -272,6 +272,7 @@ rdbt_find_leader(crt_group_t *group, uint32_t nranks, uint32_t nreplicas,
 			}
 		}
 
+resp_valid_check:
 		if (!resp_isvalid) {
 			printf("ERR: rank %u invalid reply: rc="DF_RC", "
 			       "hint is %s valid (rank=%u, term="DF_U64")\n",


### PR DESCRIPTION
The rdbt client code in rdbt_find_leader() erroneously issued a break
that exits the containing for loop. This was done when a sanity check
on an RPC reply failed. The intent was to goto a test near the bottom
of the loop to print an error and set a return code indicating error.
The test at the bottom of the loop was effectively dead code, detected
in a coverity scan of the daos code.

With this change, the initial tests are converted to gotos and the
previously dead code is now reachable. Also with this change, a typo
in the rdbt client command line usage is fixed (--nranks argument).

Skip-unit-test: true
Skip-func-test: true
Skip-func-hw-test: true

Signed-off-by: Kenneth Cain <kenneth.c.cain@intel.com>