### PR TITLE
DAOS-4693 build: Enable fault injection in build

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -49,7 +49,7 @@ def scons_faults_args() {
 def rpm_faults_args() {
     // if the faults-enabled pragma is false or it a release candidate; disable fault injection
     if ((cachedCommitPragma(pragma: 'faults-enabled', def_val: 'true') != 'true') || release_candidate()) {
-        return ""
+        return "--without=fault-injection"
     } else {
         return "--with=fault-injection"
     }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -49,9 +49,9 @@ def scons_faults_args() {
 def rpm_faults_args() {
     // if the faults-enabled pragma is false or it a release candidate; disable fault injection
     if ((cachedCommitPragma(pragma: 'faults-enabled', def_val: 'true') != 'true') || release_candidate()) {
-        return "--define 'build_type release'"
+        return ""
     } else {
-        return "--define 'build_type dev'"
+        return "--with=fault-injection"
     }
 }
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -31,13 +31,10 @@ boolean doc_only_change() {
 }
 
 boolean release_candidate() {
-    if (!sh(label: "Determine if building (a PR of) an RC",
+    sh(label: "Determine if building (a PR of) an RC",
            script: "git diff-index --name-only HEAD^ | grep -q TAG && " +
                    "grep -i '[0-9]rc[0-9]' TAG",
-          returnStatus: true)) {
-        return true
-    }
-    return false
+          returnStatus: true)
 }
 
 def scons_faults_args() {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -30,6 +30,34 @@ boolean doc_only_change() {
     return rc == 1
 }
 
+boolean release_candidate() {
+    if (!sh(label: "Determine if building (a PR of) an RC",
+           script: "git diff-index --name-only HEAD^ | grep -q TAG && " +
+                   "grep -i '[0-9]rc[0-9]' TAG",
+          returnStatus: true)) {
+        return true
+    }
+    return false
+}
+
+def scons_faults_args() {
+    // if the faults-enabled pragma is false or it a release candidate; disable fault injection
+    if ((cachedCommitPragma(pragma: 'faults-enabled', def_val: 'true') != 'true') || release_candidate()) {
+        return "BUILD_TYPE=release"
+    } else {
+        return "BUILD_TYPE=dev"
+    }
+}
+
+def rpm_faults_args() {
+    // if the faults-enabled pragma is false or it a release candidate; disable fault injection
+    if ((cachedCommitPragma(pragma: 'faults-enabled', def_val: 'true') != 'true') || release_candidate()) {
+        return "--define 'build_type release'"
+    } else {
+        return "--define 'build_type dev'"
+    }
+}
+
 def skip_stage(String stage, boolean def_val = false) {
     String value = 'false'
     if (def_val) {
@@ -335,6 +363,7 @@ pipeline {
                                             "2>/dev/null",
                                     returnStdout: true
         TEST_RPMS = cachedCommitPragma(pragma: 'RPM-test', def_val: 'true')
+        BUILD_OPTION = rpm_faults_args()
     }
 
     options {
@@ -556,7 +585,8 @@ pipeline {
                     }
                     steps {
                         sconsBuild parallel_build: parallel_build(),
-                                   stash_files: 'ci/test_files_to_stash.txt'
+                                   stash_files: 'ci/test_files_to_stash.txt',
+                                   scons_args: scons_faults_args()
                     }
                     post {
                         always {
@@ -604,7 +634,8 @@ pipeline {
                     }
                     steps {
                         sconsBuild parallel_build: parallel_build(),
-                                   stash_files: 'ci/test_files_to_stash.txt'
+                                   stash_files: 'ci/test_files_to_stash.txt',
+                                   scons_args: scons_faults_args()
                     }
                     post {
                         always {
@@ -738,7 +769,8 @@ pipeline {
                         }
                     }
                     steps {
-                        sconsBuild parallel_build: parallel_build()
+                        sconsBuild parallel_build: parallel_build(),
+                                   scons_args: scons_faults_args()
                     }
                     post {
                         always {
@@ -780,7 +812,8 @@ pipeline {
                         }
                     }
                     steps {
-                        sconsBuild parallel_build: parallel_build()
+                        sconsBuild parallel_build: parallel_build(),
+                                   scons_args: scons_faults_args()
                     }
                     post {
                         always {
@@ -824,7 +857,8 @@ pipeline {
                         }
                     }
                     steps {
-                        sconsBuild parallel_build: parallel_build()
+                        sconsBuild parallel_build: parallel_build(),
+                                   scons_args: scons_faults_args()
                     }
                     post {
                         always {
@@ -863,7 +897,8 @@ pipeline {
                     }
                     steps {
                         sconsBuild parallel_build: parallel_build(),
-                                   stash_files: 'ci/test_files_to_stash.txt'
+                                   stash_files: 'ci/test_files_to_stash.txt',
+                                   scons_args: scons_faults_args()
                     }
                     post {
                         always {
@@ -905,7 +940,8 @@ pipeline {
                         }
                     }
                     steps {
-                        sconsBuild parallel_build: parallel_build()
+                        sconsBuild parallel_build: parallel_build(),
+                                   scons_args: scons_faults_args()
                     }
                     post {
                         always {
@@ -950,7 +986,8 @@ pipeline {
                         }
                     }
                     steps {
-                        sconsBuild parallel_build: parallel_build()
+                        sconsBuild parallel_build: parallel_build(),
+                                   scons_args: scons_faults_args()
                     }
                     post {
                         always {

--- a/SConstruct
+++ b/SConstruct
@@ -149,6 +149,9 @@ def set_defaults(env):
         #could refine this but for now, just assume these warnings are ok
         env.AppendIfSupported(CCFLAGS=PP_ONLY_FLAGS)
 
+    if env.get('BUILD_TYPE') != 'release':
+        env.Append(CCFLAGS=['-DFAULT_INJECTION=1'])
+
 def preload_prereqs(prereqs):
     """Preload prereqs specific to platform"""
 

--- a/ci/rpm/build.sh
+++ b/ci/rpm/build.sh
@@ -8,7 +8,8 @@
 # and TARGET can be set.
 #
 # Default is to build for CentOS 7.
-
+# Fault injection will be enabled by default in CI unless a pragma has
+# has disabled fault injection or this is a Release build
 set -ex
 
 mydir="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
@@ -23,4 +24,5 @@ fi
 
 rm -rf "artifacts/${TARGET}/"
 mkdir -p "artifacts/${TARGET}/"
-make CHROOT_NAME="${CHROOT_NAME}" -C utils/rpms chrootbuild
+make CHROOT_NAME="${CHROOT_NAME}" \
+    EXTERNAL_RPM_BUILD_OPTIONS="${BUILD_OPTION}" -C utils/rpms chrootbuild

--- a/src/cart/crt_init.c
+++ b/src/cart/crt_init.c
@@ -270,7 +270,7 @@ crt_init_opt(crt_group_id_t grpid, uint32_t flags, crt_init_options_t *opt)
 
 	/* d_fault_inject_init() is reference counted */
 	rc = d_fault_inject_init();
-	if (rc != DER_SUCCESS) {
+	if (rc != DER_SUCCESS && rc != -DER_NOSYS) {
 		D_ERROR("d_fault_inject_init() failed, rc: %d.\n", rc);
 		D_GOTO(out, rc);
 	}
@@ -572,7 +572,7 @@ crt_finalize(void)
 out:
 	/* d_fault_inject_fini() is reference counted */
 	local_rc = d_fault_inject_fini();
-	if (local_rc != 0)
+	if (local_rc != 0 && local_rc != -DER_NOSYS)
 		D_ERROR("d_fault_inject_fini() failed, rc: %d\n", local_rc);
 
 direct_out:

--- a/src/cart/crt_rpc.c
+++ b/src/cart/crt_rpc.c
@@ -40,9 +40,9 @@ crt_hdlr_ctl_fi_toggle(crt_rpc_t *rpc_req)
 	out_args = crt_reply_get(rpc_req);
 
 	if (in_args->op)
-		d_fault_inject_enable();
+		rc = d_fault_inject_enable();
 	else
-		d_fault_inject_disable();
+		rc = d_fault_inject_disable();
 
 	out_args->rc = rc;
 	rc = crt_reply_send(rpc_req);

--- a/src/common/fail_loc.c
+++ b/src/common/fail_loc.c
@@ -178,7 +178,7 @@ daos_fail_init(void)
 	int rc;
 
 	rc = d_fault_inject_init();
-	if (rc)
+	if (rc != 0 && rc != -DER_NOSYS)
 		return rc;
 
 	rc = d_fault_attr_set(DAOS_FAIL_UNIT_TEST_GROUP, attr);

--- a/src/gurt/fault_inject.c
+++ b/src/gurt/fault_inject.c
@@ -35,7 +35,15 @@
 #include <gurt/hash.h>
 #include "fi.h"
 
+/**
+ * global switch for fault injection. zero globally turns off fault injection,
+ * non-zero turns on fault injection
+ */
+unsigned int			d_fault_inject;
+unsigned int			d_fault_config_file;
 struct d_fault_attr_t *d_fault_attr_mem;
+
+#if FAULT_INJECTION
 
 static struct d_fault_attr *
 fa_link2ptr(d_list_t *rlink)
@@ -587,21 +595,23 @@ d_fault_inject_fini()
 }
 
 
-void
+int
 d_fault_inject_enable(void)
 {
 	if (!d_fault_config_file) {
 		D_ERROR("No fault config file.\n");
-		return;
+		return -DER_NOSYS;
 	}
 
 	d_fault_inject = 1;
+	return 0;
 }
 
-void
+int
 d_fault_inject_disable(void)
 {
 	d_fault_inject = 0;
+	return 0;
 }
 
 bool
@@ -670,4 +680,59 @@ out:
 	D_SPIN_UNLOCK(&fault_attr->fa_lock);
 	return rc;
 };
+#else /* FAULT_INJECT */
+int d_fault_inject_init(void)
+{
+	D_WARN("Fault Injection not initialized feature not included in build");
+	return -DER_NOSYS;
+}
 
+int d_fault_inject_fini(void)
+{
+	D_WARN("Fault Injection not finalized feature not included in build");
+	return -DER_NOSYS;
+}
+
+int d_fault_inject_enable(void)
+{
+	D_WARN("Fault Injection not enabled feature not included in build");
+	return -DER_NOSYS;
+}
+
+int d_fault_inject_disable(void)
+{
+	D_WARN("Fault Injection not disabled feature not included in build");
+	return -DER_NOSYS;
+}
+
+bool
+d_fault_inject_is_enabled(void)
+{
+	return false;
+}
+
+bool
+d_should_fail(struct d_fault_attr_t *fault_attr)
+{
+	return false;
+}
+
+int
+d_fault_attr_set(uint32_t fault_id, struct d_fault_attr_t fa_in)
+{
+	D_WARN("Fault Injection attr not set feature not included in build");
+	return 0;
+}
+
+struct d_fault_attr_t *
+d_fault_attr_lookup(uint32_t fault_id)
+{
+	return NULL;
+}
+
+int
+d_fault_attr_err_code(uint32_t fault_id)
+{
+	return 0;
+}
+#endif /* FAULT_INJECT */

--- a/src/include/gurt/fault_inject.h
+++ b/src/include/gurt/fault_inject.h
@@ -115,13 +115,17 @@ int d_fault_inject_fini(void);
 
 /**
  * Start injecting faults.
+ *
+ * \return                   DER_SUCCESS on success, -DER_NOSYS if not supported
  */
-void d_fault_inject_enable(void);
+int d_fault_inject_enable(void);
 
 /**
  * Stop injecting faults.
+ *
+ * \return                   DER_SUCCESS on success, -DER_NOSYS if not supported
  */
-void d_fault_inject_disable(void);
+int d_fault_inject_disable(void);
 
 bool d_fault_inject_is_enabled(void);
 

--- a/src/tests/ftest/cart/SConscript
+++ b/src/tests/ftest/cart/SConscript
@@ -58,6 +58,7 @@ SWIM_TESTS = ['test_swim.c', 'test_swim_net.c']
 HLC_TESTS = ['test_hlc_net.c']
 TEST_GROUP_NP_TESTS = ['test_group_np_srv.c', 'test_group_np_cli.c',
                        'no_pmix_group_version.c']
+FI_TEST = ['fault_status.c']
 
 def scons():
     """scons function"""
@@ -96,6 +97,10 @@ def scons():
         target = daos_build.test(tenv, test, install_off='../../../../')
         tenv.Requires(target, [cart_lib, gurt_lib])
         tenv.Install(tests_dir, target)
+
+    target = tenv.Program(FI_TEST)
+    tenv.Requires(target, [cart_lib, gurt_lib])
+    tenv.Install(os.path.join("$PREFIX", 'bin'), target)
 
     benv = tenv.Clone()
 

--- a/src/tests/ftest/cart/fault_status.c
+++ b/src/tests/ftest/cart/fault_status.c
@@ -1,0 +1,31 @@
+/**
+ * (C) Copyright 2020 Intel Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * GOVERNMENT LICENSE RIGHTS-OPEN SOURCE SOFTWARE
+ * The Government's rights to use, modify, reproduce, release, perform, display,
+ * or disclose this software are subject to the terms of the Apache License as
+ * provided in Contract No. B620873.
+ * Any reproduction of computer software, computer software documentation, or
+ * portions thereof marked with this legend must also reproduce the markings.
+ */
+int main(void)
+{
+#if FAULT_INJECTION
+    return 0;
+#else
+    return 1;
+#endif
+}
+

--- a/src/tests/ftest/checksum/csum_error_logging.py
+++ b/src/tests/ftest/checksum/csum_error_logging.py
@@ -92,7 +92,7 @@ class CSumErrorLog(DaosCoreBase):
         Test ID: DAOS-3927
         Test Description: Write Avocado Test to verify single data after
                           pool/container disconnect/reconnect.
-        :avocado: tags=all,pr,hw,medium,ib2,csum_error_log
+        :avocado: tags=all,pr,hw,medium,ib2,csum_error_log,faults
         """
         dev_id = self.get_nvme_device_id()
         self.log.info("%s", dev_id)

--- a/src/tests/suite/daos_base_tx.c
+++ b/src/tests/suite/daos_base_tx.c
@@ -196,6 +196,7 @@ dtx_io_test_fail(void **state, uint64_t fail_loc)
 static void
 dtx_3(void **state)
 {
+	FAULT_INJECTION_REQUIRED();
 	print_message("failed to update/punch on leader\n");
 	dtx_io_test_fail(state, DAOS_DTX_LEADER_ERROR | DAOS_FAIL_ALWAYS);
 }
@@ -203,6 +204,7 @@ dtx_3(void **state)
 static void
 dtx_4(void **state)
 {
+	FAULT_INJECTION_REQUIRED();
 	print_message("failed to update/punch on non-leader\n");
 	dtx_io_test_fail(state, DAOS_DTX_NONLEADER_ERROR | DAOS_FAIL_ALWAYS);
 }
@@ -577,6 +579,7 @@ dtx_15(void **state)
 static void
 dtx_16(void **state)
 {
+	FAULT_INJECTION_REQUIRED();
 	test_arg_t	*arg = *state;
 	char		*update_buf;
 	const char	*dkey = dts_dtx_dkey;

--- a/src/tests/suite/daos_checksum.c
+++ b/src/tests/suite/daos_checksum.c
@@ -391,6 +391,8 @@ io_with_server_side_verify(void **state)
 	daos_oclass_id_t	 oc = dts_csum_oc;
 	int			 rc;
 
+	FAULT_INJECTION_REQUIRED();
+
 	if (csum_ec_enabled() && !test_runable(*state, csum_ec_grp_size()))
 		skip();
 
@@ -458,6 +460,8 @@ test_server_data_corruption(void **state)
 	daos_oclass_id_t	 oc = dts_csum_oc;
 	int			 rc;
 
+	FAULT_INJECTION_REQUIRED();
+
 	setup_from_test_args(&ctx, *state);
 	setup_cont_obj(&ctx, dts_csum_prop_type, false, 1024*8, oc);
 
@@ -487,6 +491,8 @@ test_fetch_array(void **state)
 	struct csum_test_ctx	ctx = {0};
 	daos_oclass_id_t	oc = dts_csum_oc;
 	int			rc;
+
+	FAULT_INJECTION_REQUIRED();
 
 	/**
 	 * Setup
@@ -1221,6 +1227,8 @@ single_value_test(void **state, bool large_buf)
 static void
 single_value(void **state)
 {
+	FAULT_INJECTION_REQUIRED();
+
 	if (csum_ec_enabled() && !test_runable(*state, csum_ec_grp_size()))
 		skip();
 
@@ -1277,6 +1285,8 @@ mix_test(void **state)
 	d_sg_list_t		 fetch_sgls[2] = {0};
 	d_sg_list_t		*fetch_sv_sgl = &fetch_sgls[0];
 	d_sg_list_t		*fetch_array_sgl = &fetch_sgls[1];
+
+	FAULT_INJECTION_REQUIRED();
 
 	setup_from_test_args(&ctx, *state);
 
@@ -1868,6 +1878,8 @@ punch_before_insert(void **state)
 static void
 test_update_fetch_a_key(void **state)
 {
+	FAULT_INJECTION_REQUIRED();
+
 	key_csum_fetch_update(state,
 			      DAOS_CSUM_CORRUPT_UPDATE_AKEY,
 			      DAOS_CSUM_CORRUPT_FETCH_AKEY);
@@ -1876,6 +1888,8 @@ test_update_fetch_a_key(void **state)
 static void
 test_update_fetch_d_key(void **state)
 {
+	FAULT_INJECTION_REQUIRED();
+
 	key_csum_fetch_update(state,
 			      DAOS_CSUM_CORRUPT_UPDATE_DKEY,
 			      DAOS_CSUM_CORRUPT_FETCH_DKEY);
@@ -1894,6 +1908,8 @@ test_enumerate_a_key(void **state)
 	daos_key_desc_t		kds[KDS_NR] = {0};
 	d_sg_list_t		sgl = {0};
 	uint32_t		nr = KDS_NR;
+
+	FAULT_INJECTION_REQUIRED();
 
 	setup_from_test_args(&ctx, *state);
 	setup_cont_obj(&ctx, dts_csum_prop_type, false, 1024, oc);
@@ -1946,6 +1962,8 @@ test_enumerate_d_key(void **state)
 	d_sg_list_t		sgl = {0};
 	uint32_t		nr = KDS_NR;
 	uint32_t		key_count = 0;
+
+	FAULT_INJECTION_REQUIRED();
 
 	setup_from_test_args(&ctx, *state);
 	setup_cont_obj(&ctx, dts_csum_prop_type, false, 1024, oc);
@@ -2039,6 +2057,8 @@ test_enumerate_object(void **state)
 	uint32_t		 i;
 	uint32_t		 nr;
 	int			 rc;
+
+	FAULT_INJECTION_REQUIRED();
 
 	memset(kds, 0, enum_nr * sizeof(*kds));
 

--- a/src/tests/suite/daos_container.c
+++ b/src/tests/suite/daos_container.c
@@ -2055,6 +2055,8 @@ co_open_fail_destroy(void **state)
 	daos_cont_info_t info;
 	int		 rc;
 
+	FAULT_INJECTION_REQUIRED();
+
 	if (arg->myrank != 0)
 		return;
 

--- a/src/tests/suite/daos_dist_tx.c
+++ b/src/tests/suite/daos_dist_tx.c
@@ -598,6 +598,8 @@ dtx_14(void **state)
 	struct ioreq	 req;
 	int		 rc;
 
+	FAULT_INJECTION_REQUIRED();
+
 	print_message("DTX restart because of conflict with others\n");
 	MUST(daos_tx_open(arg->coh, &th, 0, NULL));
 
@@ -656,6 +658,8 @@ dtx_15(void **state)
 	daos_handle_t	 th = { 0 };
 	daos_obj_id_t	 oid;
 	struct ioreq	 req;
+
+	FAULT_INJECTION_REQUIRED();
 
 	print_message("DTX restart because of stale pool map\n");
 	MUST(daos_tx_open(arg->coh, &th, 0, NULL));
@@ -781,6 +785,8 @@ dtx_18(void **state)
 	daos_obj_id_t	 oid;
 	struct ioreq	 req;
 	int		 rc;
+
+	FAULT_INJECTION_REQUIRED();
 
 	print_message("Spread read time-stamp when commit\n");
 

--- a/src/tests/suite/daos_mgmt.c
+++ b/src/tests/suite/daos_mgmt.c
@@ -377,6 +377,8 @@ pool_create_and_destroy_retry(void **state)
 	uuid_t		 uuid;
 	int		 rc;
 
+	FAULT_INJECTION_REQUIRED();
+
 	if (arg->myrank != 0)
 		return;
 
@@ -440,13 +442,23 @@ setup(void **state)
 }
 
 int
-run_daos_mgmt_test(int rank, int size)
+run_daos_mgmt_test(int rank, int size, int *sub_tests, int sub_tests_size)
 {
 	int	rc;
 
-	if (rank == 0)
-		rc = cmocka_run_group_tests_name("Management tests", tests,
-						 setup, test_teardown);
+	if (rank == 0) {
+		if (sub_tests_size == 0) {
+			rc = cmocka_run_group_tests_name(
+				"Management tests", tests, setup,
+				test_teardown);
+		} else {
+			rc = run_daos_sub_tests(
+				"Management tests", tests,
+				ARRAY_SIZE(tests),
+				sub_tests, sub_tests_size, setup,
+				test_teardown);
+		}
+	}
 
 	MPI_Bcast(&rc, 1, MPI_INT, 0, MPI_COMM_WORLD);
 	return rc;

--- a/src/tests/suite/daos_obj.c
+++ b/src/tests/suite/daos_obj.c
@@ -2913,6 +2913,8 @@ io_nospace(void **state)
 	char		key[10];
 	int		i;
 
+	FAULT_INJECTION_REQUIRED();
+
 	/** choose random object */
 	oid = dts_oid_gen(dts_obj_class, 0, arg->myrank);
 

--- a/src/tests/suite/daos_test.c
+++ b/src/tests/suite/daos_test.c
@@ -114,7 +114,8 @@ run_specified_tests(const char *tests, int rank, int size,
 			daos_test_print(rank, "\n\n=================");
 			daos_test_print(rank, "DAOS management tests..");
 			daos_test_print(rank, "=====================");
-			nr_failed = run_daos_mgmt_test(rank, size);
+			nr_failed = run_daos_mgmt_test(rank, size, sub_tests,
+						       sub_tests_size);
 			break;
 		case 'p':
 			daos_test_print(rank, "\n\n=================");

--- a/src/tests/suite/daos_test.h
+++ b/src/tests/suite/daos_test.h
@@ -57,6 +57,16 @@
 	} while  (0)
 #endif
 
+#if FAULT_INJECTION
+#define FAULT_INJECTION_REQUIRED() do { } while (0)
+#else
+#define FAULT_INJECTION_REQUIRED() \
+	do { \
+		print_message("Fault injection required for test, skipping...\n"); \
+		skip();\
+	} while (0)
+#endif /* FAULT_INJECTION */
+
 #include <mpi.h>
 #include <daos/debug.h>
 #include <daos/common.h>
@@ -281,7 +291,7 @@ enum {
 	HANDLE_CO
 };
 
-int run_daos_mgmt_test(int rank, int size);
+int run_daos_mgmt_test(int rank, int size, int *sub_tests, int sub_tests_size);
 int run_daos_pool_test(int rank, int size);
 int run_daos_cont_test(int rank, int size);
 int run_daos_capa_test(int rank, int size);

--- a/src/tests/suite/daos_verify_consistency.c
+++ b/src/tests/suite/daos_verify_consistency.c
@@ -219,6 +219,8 @@ vc_4(void **state)
 	struct ioreq	 req;
 	int		 rc;
 
+	FAULT_INJECTION_REQUIRED();
+
 	print_message("verify with different rec\n");
 
 	if (!test_runable(arg, dts_vc_replica_cnt))
@@ -283,6 +285,9 @@ vc_test_lost_data(void **state, int type)
 static void
 vc_5(void **state)
 {
+
+	FAULT_INJECTION_REQUIRED();
+
 	print_message("verify with lost rec\n");
 	vc_test_lost_data(state, VTLT_REC);
 }
@@ -290,6 +295,9 @@ vc_5(void **state)
 static void
 vc_6(void **state)
 {
+
+	FAULT_INJECTION_REQUIRED();
+
 	print_message("verify with lost akey\n");
 	vc_test_lost_data(state, VTLT_AKEY);
 }
@@ -297,6 +305,9 @@ vc_6(void **state)
 static void
 vc_7(void **state)
 {
+
+	FAULT_INJECTION_REQUIRED();
+
 	print_message("verify with lost dkey\n");
 	vc_test_lost_data(state, VTLT_DKEY);
 }
@@ -308,6 +319,8 @@ vc_8(void **state)
 	daos_obj_id_t	 oid;
 	struct ioreq	 req;
 	int		 rc;
+
+	FAULT_INJECTION_REQUIRED();
 
 	print_message("verify with lost replica\n");
 
@@ -342,6 +355,8 @@ vc_9(void **state)
 	daos_obj_id_t	 oid;
 	struct ioreq	 req;
 	int		 rc;
+
+	FAULT_INJECTION_REQUIRED();
 
 	print_message("verify with different dkey\n");
 

--- a/src/vos/tests/vts_common.h
+++ b/src/vos/tests/vts_common.h
@@ -41,6 +41,16 @@
 	#pragma GCC diagnostic ignored "-Wframe-larger-than="
 #endif
 
+#if FAULT_INJECTION
+#define FAULT_INJECTION_REQUIRED() do { } while (0)
+#else
+#define FAULT_INJECTION_REQUIRED() \
+	do { \
+		print_message("Fault injection required for test, skipping...\n"); \
+		skip();\
+	} while (0)
+#endif /* FAULT_INJECTION */
+
 #define VPOOL_16M	(16ULL << 20)
 #define VPOOL_1G	(1ULL << 30)
 #define VPOOL_2G	(2ULL << 30)

--- a/src/vos/tests/vts_dtx.c
+++ b/src/vos/tests/vts_dtx.c
@@ -579,6 +579,8 @@ dtx_16(void **state)
 	char				 fetch_buf[UPDATE_BUF_SIZE];
 	int				 rc;
 
+	FAULT_INJECTION_REQUIRED();
+
 	vts_dtx_prep_update(args, &val_iov, &dkey_iov, &dkey, dkey_buf,
 			    &akey, akey_buf, &iod, &sgl, &rex, update_buf,
 			    UPDATE_BUF_SIZE, UPDATE_REC_SIZE, &dkey_hash,

--- a/src/vos/tests/vts_pool.c
+++ b/src/vos/tests/vts_pool.c
@@ -124,6 +124,8 @@ pool_interop(void **state)
 	daos_handle_t		poh;
 	int			ret;
 
+	FAULT_INJECTION_REQUIRED();
+
 	uuid_generate(uuid);
 
 	daos_fail_loc_set(FLC_POOL_DF_VER | DAOS_FAIL_ONCE);

--- a/utils/rpms/daos.spec
+++ b/utils/rpms/daos.spec
@@ -1,7 +1,7 @@
 %define daoshome %{_exec_prefix}/lib/%{name}
 %define server_svc_name daos_server.service
 %define agent_svc_name daos_agent.service
-%if 0%{?build_type}
+%if (0%{?build_type})
 %else
 %global build_type release
 %endif

--- a/utils/rpms/daos.spec
+++ b/utils/rpms/daos.spec
@@ -1,10 +1,7 @@
+%bcond_with fault_injection
 %define daoshome %{_exec_prefix}/lib/%{name}
 %define server_svc_name daos_server.service
 %define agent_svc_name daos_agent.service
-%if (0%{?build_type})
-%else
-%global build_type release
-%endif
 %if (0%{?suse_version} >= 1500)
 # until we get an updated mercury build on 15.2
 %global mercury_version 2.0.0~rc1-1.suse.lp151
@@ -209,7 +206,8 @@ scons %{?_smp_mflags}      \
       USE_INSTALLED=all    \
       CONF_DIR=%{conf_dir} \
       PREFIX=%{?buildroot} \
-      BUILD_TYPE=%{?build_type}
+      %{?with_fault_injection:BUILD_TYPE=dev} \
+      %{!?with_fault_injection:BUILD_TYPE=release}
 
 
 %install
@@ -222,7 +220,8 @@ scons %{?_smp_mflags}                 \
       USE_INSTALLED=all               \
       CONF_DIR=%{conf_dir}            \
       PREFIX=%{_prefix}               \
-      BUILD_TYPE=%{?build_type}
+      %{?with_fault_injection:BUILD_TYPE=dev} \
+      %{!?with_fault_injection:BUILD_TYPE=release}
 
 BUILDROOT="%{?buildroot}"
 PREFIX="%{?_prefix}"

--- a/utils/rpms/daos.spec
+++ b/utils/rpms/daos.spec
@@ -4,6 +4,7 @@
 %if 0%{?build_type}
 %else
 %global build_type release
+%endif
 %if (0%{?suse_version} >= 1500)
 # until we get an updated mercury build on 15.2
 %global mercury_version 2.0.0~rc1-1.suse.lp151


### PR DESCRIPTION
The fault injection framework in CART and DAOS is a developer/test focused
feature. The feature should not be present in production systems so it is not
built in by default.   If BUILD_TYPE=dev or BUILD_TYPE=debug, fault injection
will be enabled.   If BUILD_TYPE=release, fault injection is disabled

Signed-off-by: Maureen Jean <maureen.jean@intel.com>