### PR TITLE
DAOS-5327 build: Fix Ubuntu build error

### DIFF
--- a/src/client/api/tests/job_tests.c
+++ b/src/client/api/tests/job_tests.c
@@ -73,7 +73,7 @@ int uname(struct utsname *buf)
 		return -1;
 	}
 
-	strncpy(buf->nodename, uname_nodename, _UTSNAME_LENGTH);
+	strncpy(buf->nodename, uname_nodename, _UTSNAME_LENGTH - 1);
 	return 0;
 }
 

--- a/src/client/api/tests/job_tests.c
+++ b/src/client/api/tests/job_tests.c
@@ -73,6 +73,7 @@ int uname(struct utsname *buf)
 		return -1;
 	}
 
+	memset(buf->nodename, 0, sizeof(buf->nodename));
 	strncpy(buf->nodename, uname_nodename, _UTSNAME_LENGTH - 1);
 	return 0;
 }


### PR DESCRIPTION
Ubuntu 20.04's version of gcc flagged the length passed
to a strncpy call in a test.

Signed-off-by: Kris Jacque <kristin.jacque@intel.com>