### PR TITLE
WIP Implement daos_pool_query_target() API

### DIFF
--- a/src/client/api/pool.c
+++ b/src/client/api/pool.c
@@ -115,11 +115,27 @@ daos_pool_query(daos_handle_t poh, d_rank_list_t *tgts, daos_pool_info_t *info,
 }
 
 int
-daos_pool_query_target(daos_handle_t poh, d_rank_list_t *tgts,
-		       d_rank_list_t *failed, daos_target_info_t *info_list,
-		       daos_event_t *ev)
+daos_pool_query_target(daos_handle_t poh, d_rank_t tgt, d_rank_t rank,
+		       daos_target_info_t *info, daos_event_t *ev)
 {
-	return -DER_NOSYS;
+	daos_pool_query_target_t	*args;
+	tse_task_t			*task;
+	int				 rc;
+
+	DAOS_API_ARG_ASSERT(*args, POOL_TGT_INFO);
+
+	rc = dc_task_create(dc_pool_query_target, NULL, ev, &task);
+	if (rc)
+		return rc;
+
+	args = dc_task_get_args(task);
+	args->poh	= poh;
+	args->tgt	= tgt;
+	args->rank	= rank;
+	args->info	= info;
+
+	return dc_task_schedule(task, true);
+
 }
 
 int

--- a/src/include/daos_pool.h
+++ b/src/include/daos_pool.h
@@ -54,6 +54,10 @@ typedef enum {
 	DAOS_TS_UP,
 	/* Up and running */
 	DAOS_TS_UP_IN,
+	/* Intermediate state for pool map change */
+	DAOS_TS_NEW,
+	/* Being drained */
+	DAOS_TS_DRAIN,
 } daos_target_state_t;
 
 /** Description of target performance */
@@ -341,9 +345,8 @@ daos_pool_query(daos_handle_t poh, d_rank_list_t *tgts, daos_pool_info_t *info,
  *			-DER_NONEXIST	No pool on specified targets
  */
 int
-daos_pool_query_target(daos_handle_t poh, d_rank_list_t *tgts,
-		       d_rank_list_t *failed, daos_target_info_t *info_list,
-		       daos_event_t *ev);
+daos_pool_query_target(daos_handle_t poh, d_rank_t tgt, d_rank_t rank,
+		       daos_target_info_t *info, daos_event_t *ev);
 
 /**
  * List the names of all user-defined pool attributes.

--- a/src/include/daos_task.h
+++ b/src/include/daos_task.h
@@ -69,6 +69,7 @@ typedef enum {
 	DAOS_OPC_POOL_DEL_ATTR,
 	DAOS_OPC_POOL_STOP_SVC,
 	DAOS_OPC_POOL_LIST_CONT,
+	DAOS_OPC_POOL_TGT_INFO,
 
 	/** Container APIs */
 	DAOS_OPC_CONT_CREATE,
@@ -273,12 +274,12 @@ typedef struct {
 typedef struct {
 	/** Pool open handle. */
 	daos_handle_t		poh;
-	/** Array of targets to query. */
-	d_rank_list_t		*tgts;
-	/** Optional, buffer to store faulty targets on failure. */
-	d_rank_list_t		*failed;
-	/** Returned storage information of targets. */
-	daos_target_info_t	*info_list;
+	/** Single targets to query. */
+	d_rank_t		tgt;
+	/** Rank of target to query. */
+	d_rank_t		rank;
+	/** Returned storage information of target. */
+	daos_target_info_t	*info;
 } daos_pool_query_target_t;
 
 /** pool container list args */

--- a/src/pool/rpc.c
+++ b/src/pool/rpc.c
@@ -30,6 +30,9 @@
 #include <daos_pool.h>
 #include "rpc.h"
 
+#define crt_proc_daos_target_state_t crt_proc_uint32_t
+#define crt_proc_daos_target_type_t crt_proc_uint32_t
+
 static int
 crt_proc_struct_pool_target_addr(crt_proc_t proc, struct pool_target_addr *tgt)
 {
@@ -100,6 +103,24 @@ crt_proc_struct_daos_pool_space(crt_proc_t proc, struct daos_pool_space *ps)
 	rc = crt_proc_uint32_t(proc, &ps->ps_padding);
 	if (rc)
 		return -DER_HG;
+
+	return 0;
+}
+
+static int
+crt_proc_struct_daos_space(crt_proc_t proc, struct daos_space *ps)
+{
+	int i, rc;
+
+	for (i = 0; i < DAOS_MEDIA_MAX; i++) {
+		rc = crt_proc_uint64_t(proc, &ps->s_total[i]);
+		if (rc)
+			return -DER_HG;
+
+		rc = crt_proc_uint64_t(proc, &ps->s_free[i]);
+		if (rc)
+			return -DER_HG;
+	}
 
 	return 0;
 }
@@ -195,6 +216,7 @@ CRT_RPC_DEFINE(pool_acl_delete, DAOS_ISEQ_POOL_ACL_DELETE,
 		DAOS_OSEQ_POOL_ACL_DELETE)
 CRT_RPC_DEFINE(pool_list_cont, DAOS_ISEQ_POOL_LIST_CONT,
 		DAOS_OSEQ_POOL_LIST_CONT)
+CRT_RPC_DEFINE(pool_tgt_info, DAOS_ISEQ_POOL_TGT_INFO, DAOS_OSEQ_POOL_TGT_INFO)
 
 /* Define for cont_rpcs[] array population below.
  * See POOL_PROTO_*_RPC_LIST macro definition

--- a/src/pool/rpc.h
+++ b/src/pool/rpc.h
@@ -61,6 +61,9 @@
 	X(POOL_QUERY,							\
 		0, &CQF_pool_query,					\
 		ds_pool_query_handler, NULL),				\
+	X(POOL_TGT_INFO,						\
+		0, &CQF_pool_tgt_info,					\
+		ds_pool_tgt_info_handler, NULL),			\
 	X(POOL_EXCLUDE,							\
 		0, &CQF_pool_exclude,					\
 		ds_pool_update_handler, NULL),				\
@@ -214,6 +217,21 @@ CRT_RPC_DECLARE(pool_disconnect, DAOS_ISEQ_POOL_DISCONNECT,
 	((uint32_t)		(pqo_map_buf_size)	CRT_VAR)
 
 CRT_RPC_DECLARE(pool_query, DAOS_ISEQ_POOL_QUERY, DAOS_OSEQ_POOL_QUERY)
+
+#define DAOS_ISEQ_POOL_TGT_INFO	/* input fields */		 \
+	((struct pool_op_in)	(pti_op)		CRT_VAR) \
+	((d_rank_t)		(pti_rank)		CRT_VAR) \
+	((d_rank_t)		(pti_tgt)		CRT_VAR)
+
+#define DAOS_OSEQ_POOL_TGT_INFO	/* output fields */		 \
+	((struct pool_op_out)	  (pto_op)		CRT_VAR) \
+	((d_rank_t)		  (pto_rank)		CRT_VAR) \
+	((d_rank_t)		  (pto_tgt)		CRT_VAR) \
+	((struct daos_space)	  (pto_space)		CRT_VAR) \
+	((daos_target_state_t)	  (pto_state)		CRT_VAR) \
+	((daos_target_type_t)	  (pto_type)		CRT_VAR)
+
+CRT_RPC_DECLARE(pool_tgt_info, DAOS_ISEQ_POOL_TGT_INFO, DAOS_OSEQ_POOL_TGT_INFO)
 
 #define DAOS_ISEQ_POOL_ATTR_LIST /* input fields */		 \
 	((struct pool_op_in)	(pali_op)		CRT_VAR) \

--- a/src/pool/srv_internal.h
+++ b/src/pool/srv_internal.h
@@ -137,6 +137,7 @@ void ds_pool_attr_set_handler(crt_rpc_t *rpc);
 void ds_pool_attr_del_handler(crt_rpc_t *rpc);
 void ds_pool_list_cont_handler(crt_rpc_t *rpc);
 int ds_pool_evict_rank(uuid_t pool_uuid, d_rank_t rank);
+void ds_pool_tgt_info_handler(crt_rpc_t *rpc);
 
 /*
  * srv_target.c


### PR DESCRIPTION
***ERROR: seen when trying to create a containter***
setup: creating pool, SCM size=10 GB, NVMe size=20 GB
setup: created pool ed485306-bf63-46d4-84fe-73b6d21aabfa
setup: connecting to pool
connected to pool, ntarget=32
setup: creating container 42df4a29-dd3d-4fd5-be2d-ec065ca158dd
10/29-17:54:54.30 wolf-156 DAOS[56203/56203] client EMRG src/client/api/container.c:50 daos_cont_create() Assertion 'sizeof(*args) == dc_funcs[__opc].arg_size' failed: Argument size 32 != predefined arg size 48
[  ERROR   ] --- ASSERT: sizeof(*args) == dc_funcs[__opc].arg_size
[   LINE   ] --- src/client/api/container.c:50: error: Failure!
[  FAILED  ] GROUP SETUP

This API will be expanded upon later to return all pool
space usage and other info for the pool target. Currently,
all that is returned in this API is the VOS target status
necessary for DAOS NVMe Recovery test validation.

Signed-off-by: Sydney Vanda <sydney.m.vanda@intel.com>