### PR TITLE
DAOS-5950: Fix InvalidWrite in evt internal tests

### DIFF
--- a/src/vos/tests/evt_ctl.c
+++ b/src/vos/tests/evt_ctl.c
@@ -1646,7 +1646,7 @@ test_evt_various_data_size_internal(void **state)
 					break;
 			}
 			entry.ei_rect.rc_ex.ex_lo = epoch;
-			entry.ei_rect.rc_ex.ex_hi = epoch + data_size;
+			entry.ei_rect.rc_ex.ex_hi = epoch + data_size - 1;
 			entry.ei_rect.rc_epc = epoch;
 			entry.ei_ver = 0;
 			entry.ei_inob = data_size;
@@ -1671,7 +1671,7 @@ test_evt_various_data_size_internal(void **state)
 			if (epoch == 1) {
 				evt_ent_array_init(&ent_array);
 				filter.fr_ex.ex_lo = epoch;
-				filter.fr_ex.ex_hi = epoch + data_size;
+				filter.fr_ex.ex_hi = epoch + data_size - 1;
 				filter.fr_epr.epr_hi = epoch;
 				rc = evt_find(toh, &filter, &ent_array);
 				if (rc != 0)
@@ -1700,7 +1700,8 @@ test_evt_various_data_size_internal(void **state)
 			/* Delete a record*/
 			if (epoch % 10 == 0) {
 				entry.ei_rect.rc_ex.ex_lo = epoch;
-				entry.ei_rect.rc_ex.ex_hi = epoch + data_size;
+				entry.ei_rect.rc_ex.ex_hi = epoch + data_size
+							    - 1;
 				entry.ei_rect.rc_epc = epoch;
 
 				rc = evt_delete(toh, &entry.ei_rect, NULL);

--- a/utils/run_test.sh
+++ b/utils/run_test.sh
@@ -83,6 +83,7 @@ if [ -d "/mnt/daos" ]; then
     VALGRIND_CMD=""
     if [ -z "$RUN_TEST_VALGRIND" ]; then
         # Tests that do not run valgrind
+        run_test src/client/storage_estimator/common/tests/storage_estimator.sh
         run_test src/rdb/raft_tests/raft_tests.py
         go_spdk_ctests="${SL_PREFIX}/bin/nvme_control_ctests"
         if test -f "$go_spdk_ctests"; then
@@ -137,7 +138,6 @@ if [ -d "/mnt/daos" ]; then
     run_test "${SL_BUILD_DIR}/src/mgmt/tests/srv_drpc_tests"
 
     # Scripts launching tests
-    run_test src/client/storage_estimator/common/tests/storage_estimator.sh
     export USE_VALGRIND=${RUN_TEST_VALGRIND}
     export VALGRIND_SUPP=${VALGRIND_SUPP}
     unset VALGRIND_CMD


### PR DESCRIPTION
Also, do not run valgrind on storage_estimator.sh in run_test.sh

Signed-off-by: Marcela Rosales <marcela.a.rosales.jimenez@intel.com>