### PR TITLE
DAOS-5896 EC: fix bug of obj_ec_recx_encode() parameter passing

### DIFF
--- a/src/object/cli_ec.c
+++ b/src/object/cli_ec.c
@@ -1560,8 +1560,8 @@ obj_ec_encode(struct obj_reasb_req *reasb_req)
 
 	for (i = 0; i < reasb_req->orr_iod_nr; i++) {
 		rc = obj_ec_recx_encode(reasb_req->orr_oid,
-					&reasb_req->orr_iods[i],
-					&reasb_req->orr_sgls[i],
+					&reasb_req->orr_uiods[i],
+					&reasb_req->orr_usgls[i],
 					reasb_req->orr_oca,
 					codec,
 					&reasb_req->orr_recxs[i]);


### PR DESCRIPTION
obj_ec_recx_encode should use user original IOD and sgl,
rather than reassembled IOD/sgl.

Signed-off-by: Di Wang <di.wang@intel.com>