### PR TITLE
DAOS-623 build: Fail the build if no commit version is specified

### DIFF
--- a/utils/sl/prereq_tools/base.py
+++ b/utils/sl/prereq_tools/base.py
@@ -345,6 +345,19 @@ class GitRepoRetriever():
 
     def get(self, subdir, **kw):
         """Downloads sources from a git repository into subdir"""
+
+        # Now checkout the commit_sha if specified
+        passed_commit_sha = kw.get("commit_sha", None)
+        if passed_commit_sha is None:
+            comp = os.path.basename(subdir)
+            print("""
+*********************** ERROR ************************
+No commit_versions entry in utils/build.config for
+%s. Please specify one to avoid breaking the
+build with random upstream changes.
+*********************** ERROR ************************\n""" % comp)
+            raise DownloadFailure(self.url, subdir)
+
         commands = ['git clone %s %s' % (self.url, subdir)]
         if not RUNNER.run_commands(commands):
             raise DownloadFailure(self.url, subdir)


### PR DESCRIPTION
For prerequisites, we should not rely on stability of upstream
commits.   This patch fails the build if nothing is specified
as a commit version in utils/build.config for a component
we clone.   This still allows someone to locally specify
something bad like "master" but I think this is potentially
useful for local testing so I leave it as a possibilty and the
responsibility of the gatekeeper to avoid landing.

Signed-off-by: Jeff Olivier <jeffrey.v.olivier@intel.com>