### PR TITLE
DAOS-4898 obj: simplify csum report handling

### DIFF
--- a/src/object/cli_obj.c
+++ b/src/object/cli_obj.c
@@ -104,7 +104,7 @@ struct obj_auxi_args {
 					 ec_in_recov:1,
 					 new_shard_tasks:1,
 					 reset_param:1;
-	/* request flags. currently only: ORF_RESEND, ORF_CSUM_REPORT */
+	/* request flags. currently only: ORF_RESEND */
 	uint32_t			 flags;
 	uint32_t			 specified_shard;
 	struct obj_req_tgts		 req_tgts;
@@ -3539,14 +3539,7 @@ obj_comp_cb(tse_task_t *task, void *data)
 			if (!obj_auxi->spec_shard && !obj_auxi->spec_group &&
 			    !obj_auxi->no_retry && !obj_auxi->ec_wait_recov &&
 			     obj_auxi->opc == DAOS_OBJ_RPC_FETCH) {
-				if (!obj_auxi->csum_retry &&
-				    !obj_auxi->csum_report) {
-					obj_auxi->csum_report = 1;
-				} else if (obj_auxi->csum_report) {
-					obj_auxi->flags &= ~ORF_CSUM_REPORT;
-					obj_auxi->csum_report = 0;
-					obj_auxi->csum_retry = 1;
-				}
+				obj_auxi->csum_retry = 1;
 			} else {
 				/* not retrying updates yet */
 				obj_auxi->io_retry = 0;
@@ -4054,19 +4047,7 @@ dc_obj_fetch_task(tse_task_t *task)
 		obj_auxi->to_leader = (args->extra_flags & DIOF_TO_LEADER) != 0;
 	}
 
-	/* for CSUM error, build a bitmap with only the next target set,
-	 * based current obj->auxi.req_tgt.ort_shart_tgts[0].st_shard.
-	 * (increment shard mod rdg-size, set appropriate bit).
-	 */
-	if (obj_auxi->csum_report) {
-		obj_auxi->flags |= ORF_CSUM_REPORT;
-		D_ASSERT(!obj_auxi->csum_retry);
-		/* the spec_shard case will not cause csum_report, so just
-		 * reuse it to make sure the csum_report send to correct tgt.
-		 */
-		shard = obj_auxi->req_tgts.ort_shard_tgts[0].st_shard;
-		obj_auxi->spec_shard = 1;
-	} else if (obj_auxi->csum_retry && !obj_auxi->is_ec_obj) {
+	if (obj_auxi->csum_retry && !obj_auxi->is_ec_obj) {
 		rc = obj_retry_csum_err(obj, obj_auxi, dkey_hash, map_ver,
 					&csum_bitmap);
 		if (rc)
@@ -4085,8 +4066,6 @@ dc_obj_fetch_task(tse_task_t *task)
 			      obj_auxi->spec_shard, obj_auxi);
 	if (rc != 0)
 		D_GOTO(out_task, rc);
-	if (obj_auxi->csum_report)
-		obj_auxi->spec_shard = 0;
 
 	rc = obj_csum_fetch(obj, args, obj_auxi);
 	if (rc != 0) {

--- a/src/object/obj_rpc.h
+++ b/src/object/obj_rpc.h
@@ -515,7 +515,6 @@ obj_req_create(crt_context_t crt_ctx, crt_endpoint_t *tgt_ep, crt_opcode_t opc,
 		return -DER_TIMEDOUT;
 
 	opcode = DAOS_RPC_OPCODE(opc, DAOS_OBJ_MODULE, DAOS_OBJ_VERSION);
-	/* call daos_rpc_tag to get the target tag/context idx */
 	tgt_ep->ep_tag = daos_rpc_tag(DAOS_REQ_IO, tgt_ep->ep_tag);
 
 	return crt_req_create(crt_ctx, tgt_ep, opcode, req);

--- a/src/object/srv_obj.c
+++ b/src/object/srv_obj.c
@@ -2013,7 +2013,7 @@ ds_obj_rw_handler(crt_rpc_t *rpc)
 
 		if (orw->orw_flags & ORF_CSUM_REPORT) {
 			obj_log_csum_err();
-			D_GOTO(out, rc = -DER_CSUM);
+			D_GOTO(out, rc = 0);
 		}
 
 		if (DAOS_FAIL_CHECK(DAOS_OBJ_FETCH_DATA_LOST))


### PR DESCRIPTION
Originally csum report is done by retry the IO task, that complicate the
retry logic and target selection details.
This patch simplify it by send another RPC to same shard target when
gets csum error for that shard.

Signed-off-by: Xuezhao Liu <xuezhao.liu@intel.com>