### PR TITLE
DAOS-4946: Re-enable OSA tests with data

### DIFF
--- a/src/pool/srv_pool.c
+++ b/src/pool/srv_pool.c
@@ -4466,6 +4466,7 @@ ds_pool_evict_handler(crt_rpc_t *rpc)
 	size_t			hdl_uuids_size;
 	int			n_hdl_uuids;
 	int			rc;
+	int			n;
 
 	D_DEBUG(DF_DSMS, DF_UUID": processing rpc %p\n",
 		DP_UUID(in->pvi_op.pi_uuid), rpc);
@@ -4492,6 +4493,9 @@ ds_pool_evict_handler(crt_rpc_t *rpc)
 		if (in->pvi_pool_destroy && !in->pvi_pool_destroy_force) {
 			D_DEBUG(DF_DSMS, DF_UUID": busy, %u open handles\n",
 				DP_UUID(in->pvi_op.pi_uuid), n_hdl_uuids);
+			for (n = 0; n < n_hdl_uuids; n++)
+				D_DEBUG(DF_DSMS, "Open handle: "DF_UUID"\n",
+					DP_UUID(hdl_uuids[n]));
 			D_GOTO(out_free, rc = -DER_BUSY);
 		} else {
 			/* Pool evict, or pool destroy with force=true */

--- a/src/tests/ftest/osa/osa_offline_drain.py
+++ b/src/tests/ftest/osa/osa_offline_drain.py
@@ -180,5 +180,4 @@ class OSAOfflineDrain(TestWithServers):
         for pool_num in range(1, 2):
             self.run_offline_drain_test(pool_num)
         # Perform drain testing : inserting data in pool
-        # Bug : DAOS-4946 blocks the following test case.
-        # self.run_offline_drain_test(1, True)
+        self.run_offline_drain_test(1, True)

--- a/src/tests/ftest/osa/osa_offline_extend.py
+++ b/src/tests/ftest/osa/osa_offline_extend.py
@@ -170,8 +170,7 @@ class OSAOfflineExtend(TestWithServers):
         # Perform extend testing with 1 pool
         self.run_offline_extend_test(1)
         # Perform extend testing : inserting data in pool
-        # Blocked by DAOS-4946
-        # self.stop_servers()
-        # time.sleep(15)
-        # self.start_servers()
-        # self.run_offline_extend_test(1, True)
+        self.stop_servers()
+        time.sleep(15)
+        self.start_servers()
+        self.run_offline_extend_test(1, True)

--- a/src/tests/ftest/osa/osa_offline_parallel_test.py
+++ b/src/tests/ftest/osa/osa_offline_parallel_test.py
@@ -257,5 +257,4 @@ class OSAOfflineParallelTest(TestWithServers):
         # Fix range from 1,2 to 1,3
         self.run_offline_parallel_test(1)
         # Perform drain testing : inserting data in pool
-        # Bug : DAOS-4946 blocks the following test case.
-        # self.run_offline_parallel_test(1, True)
+        self.run_offline_parallel_test(1, True)

--- a/src/tests/ftest/osa/osa_offline_reintegration.py
+++ b/src/tests/ftest/osa/osa_offline_reintegration.py
@@ -198,5 +198,4 @@ class OSAOfflineReintegration(TestWithServers):
         for x in range(1, 4):
             self.run_offline_reintegration_test(x)
         # Perform reintegration testing : inserting data in pool
-        # Remove the comment below after DAOS-4946 is fixed.
-        # self.run_offline_reintegration_test(1, True)
+        self.run_offline_reintegration_test(1, True)


### PR DESCRIPTION
These tests were disabled because of a bug that used to prevent users from destroying pools after data had been inserted in them. 

This bug seems to have been fixed elsewhere. I can no longer reproduce it locally. This patch adds one small thing to help make debugging this easier in the future, and re-enables the tests that required this functionality. 