### PR TITLE
DAOS-5919 control: Improve joinSystem() flow

### DIFF
--- a/src/control/server/drpc.go
+++ b/src/control/server/drpc.go
@@ -82,7 +82,6 @@ func isRetryable(msg proto.Message) (*retryableDrpcReq, bool) {
 		return &retryableDrpcReq{
 			Message: msg,
 			RetryableStatuses: []drpc.DaosStatus{
-				drpc.DaosOutOfGroup,
 				drpc.DaosGroupVersionMismatch,
 				drpc.DaosTimedOut,
 			},

--- a/src/control/system/database.go
+++ b/src/control/system/database.go
@@ -110,6 +110,13 @@ type (
 	}
 )
 
+func (sta *syncTCPAddr) String() string {
+	if sta == nil || sta.Addr == nil {
+		return "(nil)"
+	}
+	return sta.Addr.String()
+}
+
 func (sta *syncTCPAddr) set(addr *net.TCPAddr) {
 	sta.Lock()
 	defer sta.Unlock()


### PR DESCRIPTION
Formally indicate that a join was processed locally with a
boolean instead of overloading the returned rank to indicate
state. Also adds a stringer implementation to syncTCPAddr for
improved logging output.