### PR TITLE
DAOS-5978 control: refactor ipmctl and ndctl commandline interaction

### DIFF
--- a/src/control/cmd/daos_server/storage_test.go
+++ b/src/control/cmd/daos_server/storage_test.go
@@ -70,9 +70,9 @@ func TestDaosServer_StoragePrepare(t *testing.T) {
 		},
 		"prepared scm; success": {
 			smbc: &scm.MockBackendConfig{
-				DiscoverRes:     storage.ScmModules{storage.MockScmModule()},
-				GetNamespaceRes: storage.ScmNamespaces{storage.MockScmNamespace()},
-				StartingState:   storage.ScmStateNoCapacity,
+				DiscoverRes:         storage.ScmModules{storage.MockScmModule()},
+				GetPmemNamespaceRes: storage.ScmNamespaces{storage.MockScmNamespace()},
+				StartingState:       storage.ScmStateNoCapacity,
 			},
 		},
 		"unprepared scm; warn": {

--- a/src/control/server/ctl_storage.go
+++ b/src/control/server/ctl_storage.go
@@ -181,7 +181,7 @@ func (c *StorageControlService) NvmePrepare(req bdev.PrepareRequest) (*bdev.Prep
 // GetScmState performs required initialization and returns current state
 // of SCM module preparation.
 func (c *StorageControlService) GetScmState() (storage.ScmState, error) {
-	return c.scm.GetState()
+	return c.scm.GetPmemState()
 }
 
 // ScmPrepare preps locally attached modules and returns need to reboot message,

--- a/src/control/server/ctl_storage_rpc_test.go
+++ b/src/control/server/ctl_storage_rpc_test.go
@@ -79,8 +79,8 @@ func TestServer_CtlSvc_StorageScan_PreIOStart(t *testing.T) {
 				},
 			},
 			smbc: &scm.MockBackendConfig{
-				DiscoverRes:     storage.ScmModules{storage.MockScmModule()},
-				GetNamespaceRes: storage.ScmNamespaces{storage.MockScmNamespace()},
+				DiscoverRes:         storage.ScmModules{storage.MockScmModule()},
+				GetPmemNamespaceRes: storage.ScmNamespaces{storage.MockScmNamespace()},
 			},
 			expResp: StorageScanResp{
 				Nvme: &ScanNvmeResp{
@@ -118,8 +118,8 @@ func TestServer_CtlSvc_StorageScan_PreIOStart(t *testing.T) {
 				ScanErr: errors.New("spdk scan failed"),
 			},
 			smbc: &scm.MockBackendConfig{
-				DiscoverRes:     storage.ScmModules{storage.MockScmModule()},
-				GetNamespaceRes: storage.ScmNamespaces{storage.MockScmNamespace()},
+				DiscoverRes:         storage.ScmModules{storage.MockScmModule()},
+				GetPmemNamespaceRes: storage.ScmNamespaces{storage.MockScmNamespace()},
 			},
 			expResp: StorageScanResp{
 				Nvme: &ScanNvmeResp{
@@ -745,8 +745,8 @@ func TestServer_CtlSvc_StorageScan_PostIOStart(t *testing.T) {
 		},
 		"scan scm with space utilization": {
 			smbc: &scm.MockBackendConfig{
-				DiscoverRes:     storage.ScmModules{storage.MockScmModule()},
-				GetNamespaceRes: storage.ScmNamespaces{storage.MockScmNamespace()},
+				DiscoverRes:         storage.ScmModules{storage.MockScmModule()},
+				GetPmemNamespaceRes: storage.ScmNamespaces{storage.MockScmNamespace()},
 			},
 			smsc: &scm.MockSysConfig{
 				GetfsUsageTotal: mockPbScmMount.TotalBytes,
@@ -772,8 +772,8 @@ func TestServer_CtlSvc_StorageScan_PostIOStart(t *testing.T) {
 		},
 		"scan scm with pmem not in instance device list": {
 			smbc: &scm.MockBackendConfig{
-				DiscoverRes:     storage.ScmModules{storage.MockScmModule()},
-				GetNamespaceRes: storage.ScmNamespaces{storage.MockScmNamespace()},
+				DiscoverRes:         storage.ScmModules{storage.MockScmModule()},
+				GetPmemNamespaceRes: storage.ScmNamespaces{storage.MockScmNamespace()},
 			},
 			smsc: &scm.MockSysConfig{
 				GetfsUsageTotal: mockPbScmMount.TotalBytes,

--- a/src/control/server/storage/scm/ipmctl_test.go
+++ b/src/control/server/storage/scm/ipmctl_test.go
@@ -116,9 +116,49 @@ func newMockIpmctl(cfg *mockIpmctlCfg) *mockIpmctl {
 	}
 }
 
-// TestGetState tests the internals of ipmCtlRunner, pass in mock runCmd to verify
+// TestIpmctl_checkIpmctl verified that bad versions trigger an error.
+func TestIpmctl_checkIpmctl(t *testing.T) {
+	preTxt := "Intel(R) Optane(TM) Persistent Memory Command Line Interface Version "
+
+	for name, tc := range map[string]struct {
+		verOut  string
+		badVers []semVer
+		expErr  error
+	}{
+		"no bad versions": {
+			verOut:  "02.00.00.3816",
+			badVers: []semVer{},
+		},
+		"good version": {
+			verOut:  "02.00.00.3825",
+			badVers: badIpmctlVers,
+		},
+		"bad version": {
+			verOut:  "02.00.00.3816",
+			badVers: badIpmctlVers,
+			expErr:  FaultIpmctlBadVersion("02.00.00.3816"),
+		},
+		"no version": {
+			expErr: errors.New("could not read ipmctl version"),
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			log, buf := logging.NewTestLogger(t.Name())
+			defer ShowBufferOnFailure(t, buf)
+
+			mockRun := func(_ string) (string, error) {
+				return preTxt + tc.verOut, nil
+			}
+
+			cr := newCmdRunner(log, nil, mockRun, nil)
+			CmpErr(t, tc.expErr, cr.checkIpmctl(tc.badVers))
+		})
+	}
+}
+
+// TestIpmctl_GetPmemState tests the internals of ipmCtlRunner, pass in mock runCmd to verify
 // behavior. Don't use mockPrepScm as we want to test prepScm logic.
-func TestGetState(t *testing.T) {
+func TestIpmctl_GetPmemState(t *testing.T) {
 	var regionsOut string  // variable cmd output
 	commands := []string{} // external commands issued
 	// ndctl create-namespace command return json format
@@ -134,27 +174,29 @@ func TestGetState(t *testing.T) {
    "numa_node":%d
 }
 `
-	//oneNs, _ := parseNamespaces(fmt.Sprintf(nsOut, 1, 1, 0))
-	twoNsJson := "[" + fmt.Sprintf(nsOut, 1, 1, 0) + "," + fmt.Sprintf(nsOut, 2, 2, 1) + "]"
-	//twoNs, _ := parseNamespaces(twoNsJson)
+	oneNs, _ := parseNamespaces(fmt.Sprintf(nsOut, 1, 1, 0))
+	twoNsJSON := "[" + fmt.Sprintf(nsOut, 1, 1, 0) + "," + fmt.Sprintf(nsOut, 2, 2, 1) + "]"
+	twoNs, _ := parseNamespaces(twoNsJSON)
 	createRegionsOut := "hooray it worked\n"
-	pmemId := 1
+	pmemID := 1
 
 	mockRun := func(in string) (string, error) {
 		retString := in
 
 		switch in {
-		case cmdScmCreateRegions:
+		case cmdCreateRegions:
 			retString = createRegionsOut // example successful output
-		case cmdScmShowRegions:
+		case cmdShowRegions:
 			retString = regionsOut
-		case cmdScmCreateNamespace:
+		case cmdCreateNamespace:
 			// stimulate free capacity of region being used
 			regionsOut = strings.Replace(regionsOut, "3012.0", "0.0", 1)
-			retString = fmt.Sprintf(nsOut, pmemId, pmemId, pmemId-1)
-			pmemId += 1
-		case cmdScmListNamespaces:
-			retString = twoNsJson
+			retString = fmt.Sprintf(nsOut, pmemID, pmemID, pmemID-1)
+			pmemID++
+		case cmdListNamespaces:
+			retString = twoNsJSON
+		case cmdShowIpmctlVersion:
+			retString = "02.00.00.3825\n"
 		}
 
 		commands = append(commands, in)
@@ -162,82 +204,86 @@ func TestGetState(t *testing.T) {
 	}
 
 	tests := []struct {
-		desc              string
-		showRegionOut     string
-		expGetStateErrMsg string
-		expErrMsg         string
-		expRebootRequired bool
-		expNamespaces     storage.ScmNamespaces
-		expCommands       []string
-		lookPathErrMsg    string
+		desc                  string
+		showRegionOut         string
+		expGetPmemStateErrMsg string
+		expErrMsg             string
+		expRebootRequired     bool
+		expNamespaces         storage.ScmNamespaces
+		expCommands           []string
+		lookPathErrMsg        string
 	}{
-		//		{
-		//			desc:              "modules but no regions",
-		//			showRegionOut:     outScmNoRegions,
-		//			expRebootRequired: true,
-		//			expCommands:       []string{cmdScmShowRegions, cmdScmDeleteGoal, cmdScmCreateRegions},
-		//		},
-		//		{
-		//			desc: "single region with free capacity",
-		//			showRegionOut: "\n" +
-		//				"---ISetID=0x2aba7f4828ef2ccc---\n" +
-		//				"   PersistentMemoryType=AppDirect\n" +
-		//				"   FreeCapacity=0.0 GiB\n" +
-		//				"---ISetID=0x81187f4881f02ccc---\n" +
-		//				"   PersistentMemoryType=AppDirect\n" +
-		//				"   FreeCapacity=3012.0 GiB\n" +
-		//				"\n",
-		//			expCommands:   []string{cmdScmShowRegions, cmdScmCreateNamespace, cmdScmShowRegions},
-		//			expNamespaces: oneNs,
-		//		},
-		//		{
-		//			desc: "regions with free capacity",
-		//			showRegionOut: "\n" +
-		//				"---ISetID=0x2aba7f4828ef2ccc---\n" +
-		//				"   PersistentMemoryType=AppDirect\n" +
-		//				"   FreeCapacity=3012.0 GiB\n" +
-		//				"---ISetID=0x81187f4881f02ccc---\n" +
-		//				"   PersistentMemoryType=AppDirect\n" +
-		//				"   FreeCapacity=3012.0 GiB\n" +
-		//				"\n",
-		//			expCommands: []string{
-		//				cmdScmShowRegions, cmdScmCreateNamespace, cmdScmShowRegions,
-		//				cmdScmCreateNamespace, cmdScmShowRegions,
-		//			},
-		//			expNamespaces: twoNs,
-		//		},
-		//		{
-		//			desc: "regions with no capacity",
-		//			showRegionOut: "\n" +
-		//				"---ISetID=0x2aba7f4828ef2ccc---\n" +
-		//				"   PersistentMemoryType=AppDirect\n" +
-		//				"   FreeCapacity=0.0 GiB\n" +
-		//				"---ISetID=0x81187f4881f02ccb---\n" +
-		//				"   PersistentMemoryType=AppDirect\n" +
-		//				"   FreeCapacity=0.0 GiB\n" +
-		//				"\n",
-		//			expCommands:   []string{cmdScmShowRegions, cmdScmListNamespaces},
-		//			expNamespaces: twoNs,
-		//		},
-		//		{
-		//			desc: "v2 regions with no capacity",
-		//			showRegionOut: "\n" +
-		//				"---ISetID=0x2aba7f4828ef2ccc---\n" +
-		//				"   PersistentMemoryType=AppDirect\n" +
-		//				"   FreeCapacity=0.000 GiB\n" +
-		//				"---ISetID=0x81187f4881f02ccb---\n" +
-		//				"   PersistentMemoryType=AppDirect\n" +
-		//				"   FreeCapacity=0.000 GiB\n" +
-		//				"\n",
-		//			expCommands:   []string{cmdScmShowRegions, cmdScmListNamespaces},
-		//			expNamespaces: twoNs,
-		//		},
-		//		{
-		//			desc: "unexpected output",
-		//			showRegionOut: "\n" +
-		//				"---ISetID=0x2aba7f4828ef2ccc---\n",
-		//			expGetStateErrMsg: "checking scm region capacity: expecting at least 4 lines, got 3",
-		//		},
+		{
+			desc:              "modules but no regions",
+			showRegionOut:     outScmNoRegions,
+			expRebootRequired: true,
+			expCommands: []string{
+				cmdShowRegions, cmdShowIpmctlVersion, cmdDeleteGoal, cmdCreateRegions,
+			},
+		},
+		{
+			desc: "single region with free capacity",
+			showRegionOut: "\n" +
+				"---ISetID=0x2aba7f4828ef2ccc---\n" +
+				"   PersistentMemoryType=AppDirect\n" +
+				"   FreeCapacity=0.0 GiB\n" +
+				"---ISetID=0x81187f4881f02ccc---\n" +
+				"   PersistentMemoryType=AppDirect\n" +
+				"   FreeCapacity=3012.0 GiB\n" +
+				"\n",
+			expCommands: []string{
+				cmdShowRegions, cmdShowIpmctlVersion, cmdCreateNamespace, cmdShowRegions,
+			},
+			expNamespaces: oneNs,
+		},
+		{
+			desc: "regions with free capacity",
+			showRegionOut: "\n" +
+				"---ISetID=0x2aba7f4828ef2ccc---\n" +
+				"   PersistentMemoryType=AppDirect\n" +
+				"   FreeCapacity=3012.0 GiB\n" +
+				"---ISetID=0x81187f4881f02ccc---\n" +
+				"   PersistentMemoryType=AppDirect\n" +
+				"   FreeCapacity=3012.0 GiB\n" +
+				"\n",
+			expCommands: []string{
+				cmdShowRegions, cmdShowIpmctlVersion, cmdCreateNamespace, cmdShowRegions,
+				cmdCreateNamespace, cmdShowRegions,
+			},
+			expNamespaces: twoNs,
+		},
+		{
+			desc: "regions with no capacity",
+			showRegionOut: "\n" +
+				"---ISetID=0x2aba7f4828ef2ccc---\n" +
+				"   PersistentMemoryType=AppDirect\n" +
+				"   FreeCapacity=0.0 GiB\n" +
+				"---ISetID=0x81187f4881f02ccb---\n" +
+				"   PersistentMemoryType=AppDirect\n" +
+				"   FreeCapacity=0.0 GiB\n" +
+				"\n",
+			expCommands:   []string{cmdShowRegions, cmdShowIpmctlVersion, cmdListNamespaces},
+			expNamespaces: twoNs,
+		},
+		{
+			desc: "v2 regions with no capacity",
+			showRegionOut: "\n" +
+				"---ISetID=0x2aba7f4828ef2ccc---\n" +
+				"   PersistentMemoryType=AppDirect\n" +
+				"   FreeCapacity=0.000 GiB\n" +
+				"---ISetID=0x81187f4881f02ccb---\n" +
+				"   PersistentMemoryType=AppDirect\n" +
+				"   FreeCapacity=0.000 GiB\n" +
+				"\n",
+			expCommands:   []string{cmdShowRegions, cmdShowIpmctlVersion, cmdListNamespaces},
+			expNamespaces: twoNs,
+		},
+		{
+			desc: "unexpected output",
+			showRegionOut: "\n" +
+				"---ISetID=0x2aba7f4828ef2ccc---\n",
+			expGetPmemStateErrMsg: "checking scm region capacity: expecting at least 4 lines, got 3",
+		},
 	}
 
 	for _, tt := range tests {
@@ -259,12 +305,12 @@ func TestGetState(t *testing.T) {
 
 			// reset to initial values between tests
 			regionsOut = tt.showRegionOut
-			pmemId = 1
+			pmemID = 1
 			commands = nil
 
-			scmState, err := cr.GetState()
-			ExpectError(t, err, tt.expGetStateErrMsg, tt.desc)
-			if tt.expGetStateErrMsg != "" {
+			scmState, err := cr.GetPmemState()
+			ExpectError(t, err, tt.expGetPmemStateErrMsg, tt.desc)
+			if tt.expGetPmemStateErrMsg != "" {
 				return
 			}
 
@@ -284,7 +330,9 @@ func TestGetState(t *testing.T) {
 	}
 }
 
-func TestParseNamespaces(t *testing.T) {
+// TestIpTestIpmctl_parseNamespaces verified expected output from ndctl utility
+// can be converted into native storage ScmNamespaces type.
+func TestIpmctl_parseNamespaces(t *testing.T) {
 	// template for `ndctl list -N` output
 	listTmpl := `{
    "dev":"namespace%d.0",
@@ -355,9 +403,9 @@ func TestParseNamespaces(t *testing.T) {
 	}
 }
 
-// TestGetNamespaces tests the internals of prepScm, pass in mock runCmd to verify
+// TestIpmctl_GetPmemNamespaces tests the internals of prepScm, pass in mock runCmd to verify
 // behavior. Don't use mockPrepScm as we want to test prepScm logic.
-func TestGetNamespaces(t *testing.T) {
+func TestIpmctl_GetPmemNamespaces(t *testing.T) {
 	commands := []string{} // external commands issued
 	// ndctl create-namespace command return json format
 	nsOut := `{
@@ -373,8 +421,8 @@ func TestGetNamespaces(t *testing.T) {
 }
 `
 	oneNs, _ := parseNamespaces(fmt.Sprintf(nsOut, 1, 1, 0))
-	twoNsJson := "[" + fmt.Sprintf(nsOut, 1, 1, 0) + "," + fmt.Sprintf(nsOut, 2, 2, 1) + "]"
-	twoNs, _ := parseNamespaces(twoNsJson)
+	twoNsJSON := "[" + fmt.Sprintf(nsOut, 1, 1, 0) + "," + fmt.Sprintf(nsOut, 2, 2, 1) + "]"
+	twoNs, _ := parseNamespaces(twoNsJSON)
 
 	tests := []struct {
 		desc           string
@@ -387,19 +435,19 @@ func TestGetNamespaces(t *testing.T) {
 		{
 			desc:          "no namespaces",
 			cmdOut:        "",
-			expCommands:   []string{cmdScmListNamespaces},
+			expCommands:   []string{cmdListNamespaces},
 			expNamespaces: storage.ScmNamespaces{},
 		},
 		{
 			desc:          "single pmem device",
 			cmdOut:        fmt.Sprintf(nsOut, 1, 1, 0),
-			expCommands:   []string{cmdScmListNamespaces},
+			expCommands:   []string{cmdListNamespaces},
 			expNamespaces: oneNs,
 		},
 		{
 			desc:          "two pmem device",
-			cmdOut:        twoNsJson,
-			expCommands:   []string{cmdScmListNamespaces},
+			cmdOut:        twoNsJSON,
+			expCommands:   []string{cmdListNamespaces},
 			expNamespaces: twoNs,
 		},
 		{
@@ -438,13 +486,13 @@ func TestGetNamespaces(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			namespaces, err := cr.GetNamespaces()
+			namespaces, err := cr.GetPmemNamespaces()
 			if err != nil {
 				if tt.lookPathErrMsg != "" {
 					ExpectError(t, err, tt.lookPathErrMsg, tt.desc)
 					return
 				}
-				t.Fatal(tt.desc + ": GetNamespaces: " + err.Error())
+				t.Fatal(tt.desc + ": GetPmemNamespaces: " + err.Error())
 			}
 
 			AssertEqual(t, commands, tt.expCommands, tt.desc+": unexpected list of commands run")

--- a/src/control/server/storage/scm/mocks.go
+++ b/src/control/server/storage/scm/mocks.go
@@ -128,9 +128,9 @@ func DefaultMockSysProvider() *MockSysProvider {
 type MockBackendConfig struct {
 	DiscoverRes          storage.ScmModules
 	DiscoverErr          error
-	GetNamespaceRes      storage.ScmNamespaces
-	GetNamespaceErr      error
-	GetStateErr          error
+	GetPmemNamespaceRes  storage.ScmNamespaces
+	GetPmemNamespaceErr  error
+	GetPmemStateErr      error
 	StartingState        storage.ScmState
 	NextState            storage.ScmState
 	PrepNeedsReboot      bool
@@ -151,13 +151,13 @@ func (mb *MockBackend) Discover() (storage.ScmModules, error) {
 	return mb.cfg.DiscoverRes, mb.cfg.DiscoverErr
 }
 
-func (mb *MockBackend) GetNamespaces() (storage.ScmNamespaces, error) {
-	return mb.cfg.GetNamespaceRes, mb.cfg.GetNamespaceErr
+func (mb *MockBackend) GetPmemNamespaces() (storage.ScmNamespaces, error) {
+	return mb.cfg.GetPmemNamespaceRes, mb.cfg.GetPmemNamespaceErr
 }
 
-func (mb *MockBackend) GetState() (storage.ScmState, error) {
-	if mb.cfg.GetStateErr != nil {
-		return storage.ScmStateUnknown, mb.cfg.GetStateErr
+func (mb *MockBackend) GetPmemState() (storage.ScmState, error) {
+	if mb.cfg.GetPmemStateErr != nil {
+		return storage.ScmStateUnknown, mb.cfg.GetPmemStateErr
 	}
 	mb.RLock()
 	defer mb.RUnlock()

--- a/src/control/server/storage/scm/provider.go
+++ b/src/control/server/storage/scm/provider.go
@@ -144,8 +144,8 @@ type (
 		Discover() (storage.ScmModules, error)
 		Prep(storage.ScmState) (bool, storage.ScmNamespaces, error)
 		PrepReset(storage.ScmState) (bool, error)
-		GetState() (storage.ScmState, error)
-		GetNamespaces() (storage.ScmNamespaces, error)
+		GetPmemState() (storage.ScmState, error)
+		GetPmemNamespaces() (storage.ScmNamespaces, error)
 		GetFirmwareStatus(deviceUID string) (*storage.ScmFirmwareInfo, error)
 		UpdateFirmware(deviceUID string, firmwarePath string) error
 	}
@@ -384,7 +384,7 @@ func (p *Provider) currentState() storage.ScmState {
 }
 
 func (p *Provider) updateState() (state storage.ScmState, err error) {
-	state, err = p.backend.GetState()
+	state, err = p.backend.GetPmemState()
 	if err != nil {
 		return
 	}
@@ -396,8 +396,8 @@ func (p *Provider) updateState() (state storage.ScmState, err error) {
 	return
 }
 
-// GetState returns the current state of DCPM namespaces, if available.
-func (p *Provider) GetState() (storage.ScmState, error) {
+// GetPmemState returns the current state of DCPM namespaces, if available.
+func (p *Provider) GetPmemState() (storage.ScmState, error) {
 	if !p.isInitialized() {
 		if _, err := p.Scan(ScanRequest{}); err != nil {
 			return p.lastState, err
@@ -454,12 +454,12 @@ func (p *Provider) Scan(req ScanRequest) (*ScanResponse, error) {
 		return p.createScanResponse(), nil
 	}
 
-	namespaces, err := p.backend.GetNamespaces()
+	namespaces, err := p.backend.GetPmemNamespaces()
 	if err != nil {
 		return p.createScanResponse(), err
 	}
 
-	state, err := p.backend.GetState()
+	state, err := p.backend.GetPmemState()
 	if err != nil {
 		return nil, err
 	}

--- a/src/control/server/storage/scm/provider_test.go
+++ b/src/control/server/storage/scm/provider_test.go
@@ -91,7 +91,7 @@ func TestProviderScan(t *testing.T) {
 		"Discover fails": {
 			discoverErr: FaultDiscoveryFailed,
 		},
-		"GetState fails": {
+		"GetPmemState fails": {
 			getStateErr: errors.New("getstate failed"),
 		},
 	} {
@@ -106,11 +106,11 @@ func TestProviderScan(t *testing.T) {
 				tc.getNamespaceRes = storage.ScmNamespaces{defaultNamespace}
 			}
 			mbc := &MockBackendConfig{
-				DiscoverRes:     tc.discoverRes,
-				DiscoverErr:     tc.discoverErr,
-				GetNamespaceRes: tc.getNamespaceRes,
-				GetNamespaceErr: tc.getNamespaceErr,
-				GetStateErr:     tc.getStateErr,
+				DiscoverRes:         tc.discoverRes,
+				DiscoverErr:         tc.discoverErr,
+				GetPmemNamespaceRes: tc.getNamespaceRes,
+				GetPmemNamespaceErr: tc.getNamespaceErr,
+				GetPmemStateErr:     tc.getStateErr,
 			}
 			p := NewMockProvider(log, mbc, nil)
 			cmpRes := func(t *testing.T, want, got *ScanResponse) {
@@ -226,15 +226,15 @@ func TestProviderPrepare(t *testing.T) {
 				tc.getNamespaceRes = storage.ScmNamespaces{defaultNamespace}
 			}
 			mbc := &MockBackendConfig{
-				DiscoverErr:     tc.discoverErr,
-				DiscoverRes:     storage.ScmModules{defaultModule},
-				GetNamespaceRes: tc.getNamespaceRes,
-				GetNamespaceErr: tc.getNamespaceErr,
-				GetStateErr:     tc.getStateErr,
-				StartingState:   tc.startState,
-				NextState:       tc.expEndState,
-				PrepNeedsReboot: tc.shouldReboot,
-				PrepErr:         tc.prepErr,
+				DiscoverErr:         tc.discoverErr,
+				DiscoverRes:         storage.ScmModules{defaultModule},
+				GetPmemNamespaceRes: tc.getNamespaceRes,
+				GetPmemNamespaceErr: tc.getNamespaceErr,
+				GetPmemStateErr:     tc.getStateErr,
+				StartingState:       tc.startState,
+				NextState:           tc.expEndState,
+				PrepNeedsReboot:     tc.shouldReboot,
+				PrepErr:             tc.prepErr,
 			}
 			p := NewMockProvider(log, mbc, nil)
 
@@ -267,7 +267,7 @@ func TestProviderPrepare(t *testing.T) {
 	}
 }
 
-func TestProviderGetState(t *testing.T) {
+func TestProviderGetPmemState(t *testing.T) {
 	for name, tc := range map[string]struct {
 		startInitialized bool
 		discoverErr      error
@@ -291,11 +291,11 @@ func TestProviderGetState(t *testing.T) {
 			defer common.ShowBufferOnFailure(t, buf)
 
 			mbc := &MockBackendConfig{
-				DiscoverErr:     tc.discoverErr,
-				DiscoverRes:     storage.ScmModules{defaultModule},
-				GetNamespaceErr: tc.getNamespaceErr,
-				StartingState:   tc.startState,
-				NextState:       tc.expEndState,
+				DiscoverErr:         tc.discoverErr,
+				DiscoverRes:         storage.ScmModules{defaultModule},
+				GetPmemNamespaceErr: tc.getNamespaceErr,
+				StartingState:       tc.startState,
+				NextState:           tc.expEndState,
 			}
 			p := NewMockProvider(log, mbc, nil)
 			p.scanCompleted = tc.startInitialized
@@ -306,7 +306,7 @@ func TestProviderGetState(t *testing.T) {
 				}
 			}
 
-			res, err := p.GetState()
+			res, err := p.GetPmemState()
 			if err != nil {
 				switch err {
 				case tc.discoverErr, tc.getNamespaceErr:
@@ -449,9 +449,9 @@ func TestProviderCheckFormat(t *testing.T) {
 			defer common.ShowBufferOnFailure(t, buf)
 
 			mbc := &MockBackendConfig{
-				DiscoverErr:     tc.discoverErr,
-				DiscoverRes:     storage.ScmModules{defaultModule},
-				GetNamespaceErr: tc.getNamespaceErr,
+				DiscoverErr:         tc.discoverErr,
+				DiscoverRes:         storage.ScmModules{defaultModule},
+				GetPmemNamespaceErr: tc.getNamespaceErr,
 			}
 			msc := &MockSysConfig{
 				IsMountedBool: tc.alreadyMounted,
@@ -773,9 +773,9 @@ func TestProviderFormat(t *testing.T) {
 			defer common.ShowBufferOnFailure(t, buf)
 
 			mbc := &MockBackendConfig{
-				DiscoverErr:     tc.discoverErr,
-				DiscoverRes:     storage.ScmModules{defaultModule},
-				GetNamespaceErr: tc.getNamespaceErr,
+				DiscoverErr:         tc.discoverErr,
+				DiscoverRes:         storage.ScmModules{defaultModule},
+				GetPmemNamespaceErr: tc.getNamespaceErr,
 			}
 			msc := &MockSysConfig{
 				IsMountedBool: tc.alreadyMounted,

--- a/src/tests/ftest/util/server_utils.py
+++ b/src/tests/ftest/util/server_utils.py
@@ -465,7 +465,7 @@ class DaosServerManager(SubprocessManager):
             cmd.sub_command_class.sub_command_class.hugepages.value = 4096
 
         self.log.info("Preparing DAOS server storage: %s", str(cmd))
-        result = pcmd(self._hosts, str(cmd), timeout=32)
+        result = pcmd(self._hosts, str(cmd), timeout=40)
         if len(result) > 1 or 0 not in result:
             dev_type = "nvme"
             if using_dcpm and using_nvme:


### PR DESCRIPTION
Control-plane interacts with ipmctl and ndctl binaries when provisioning
SCM, improve code structure for invoking commands and handling output. 
Re-enable temporarily disabled unit tests.

Signed-off-by: Tom Nabarro <tom.nabarro@intel.com>