### PR TITLE
DAOS-5980 test: Re-enable most ior_small tests

### DIFF
--- a/src/tests/ftest/io/ior_small.py
+++ b/src/tests/ftest/io/ior_small.py
@@ -49,7 +49,7 @@ class IorSmall(IorTestBase):
             All above three cases to be run with single client and
                 multiple client processes in two separate nodes.
 
-        :avocado: tags=all,hw,large,daosio,iorsmall,DAOS_5610
+        :avocado: tags=all,pr,hw,large,daosio,iorsmall,DAOS_5610
         """
         results = []
         ior_timeout = self.params.get("ior_timeout", '/run/ior/*')

--- a/src/tests/ftest/io/ior_small.yaml
+++ b/src/tests/ftest/io/ior_small.yaml
@@ -53,7 +53,8 @@ ior:
             - MPIIO
             - POSIX
             - HDF5
-            - HDF5-VOL
+# DAOS-5980: Disable HDF5-VOL until upstream is updated.
+#            - HDF5-VOL
           transfer_block_size:
             - [256B, 2M]
             - [1M, 32M]


### PR DESCRIPTION
The HDF5-VOL API is currently broken, but the rest of the
tests should be running for PRs.