### PR TITLE
DAOS-5478 bio: don't release bdev on faulty teardown

### DIFF
--- a/src/bio/bio_xstream.c
+++ b/src/bio/bio_xstream.c
@@ -749,8 +749,14 @@ bio_release_bdev(void *arg)
 	if (d_bdev->bb_desc == NULL)
 		return;
 
-	spdk_bdev_close(d_bdev->bb_desc);
-	d_bdev->bb_desc = NULL;
+	/*
+	 * It could be called from faulty device teardown procedure, where
+	 * the device is still plugged.
+	 */
+	if (d_bdev->bb_removed) {
+		spdk_bdev_close(d_bdev->bb_desc);
+		d_bdev->bb_desc = NULL;
+	}
 }
 
 static void
@@ -835,7 +841,6 @@ bio_bdev_event_cb(enum spdk_bdev_event_type type, struct spdk_bdev *bdev,
 void
 replace_bio_bdev(struct bio_bdev *old_dev, struct bio_bdev *new_dev)
 {
-	D_ASSERT(old_dev->bb_removed);
 	D_ASSERT(old_dev->bb_blobstore != NULL);
 
 	new_dev->bb_blobstore = old_dev->bb_blobstore;
@@ -965,6 +970,7 @@ create_bio_bdev(struct bio_xs_context *ctxt, const char *bdev_name,
 			       DP_UUID(old_dev->bb_uuid), old_dev->bb_name);
 			destroy_bio_bdev(d_bdev);
 		} else {
+			D_ASSERT(old_dev->bb_removed);
 			replace_bio_bdev(old_dev, d_bdev);
 			d_list_add(&d_bdev->bb_link, &nvme_glb.bd_bdevs);
 			/* Inform caller to trigger device setup */
@@ -1632,6 +1638,9 @@ scan_bio_bdevs(struct bio_xs_context *ctxt, uint64_t now)
 
 		D_INFO("Detected hot plugged device %s\n",
 		       spdk_bdev_get_name(bdev));
+		/* Print a console message */
+		D_PRINT("Detected hot plugged device %s\n",
+			spdk_bdev_get_name(bdev));
 
 		scan_period = 0;
 


### PR DESCRIPTION
The bdev should only be released when the device is hot removed,
a faulty device teardown should still hold the bdev for future
reviving or hot remove.

Fix device replace/revive accordingly.

Signed-off-by: Niu Yawei <yawei.niu@intel.com>