### PR TITLE
DAOS-5988 enable coredumps when DAOS is started under systemd

### DIFF
--- a/utils/systemd/daos_agent.service
+++ b/utils/systemd/daos_agent.service
@@ -12,6 +12,7 @@ ExecStart=/usr/bin/daos_agent
 StandardOutput=journal
 StandardError=journal
 Restart=always
+LimitCORE=infinity
 
 [Install]
 WantedBy = multi-user.target

--- a/utils/systemd/daos_server.service
+++ b/utils/systemd/daos_server.service
@@ -14,6 +14,7 @@ StandardOutput=journal
 StandardError=journal
 Restart=on-failure
 LimitMEMLOCK=infinity
+LimitCORE=infinity
 
 [Install]
 WantedBy = multi-user.target


### PR DESCRIPTION
Add "LimitCORE=infinity" to the [Service] section of the systemd .
configfiles to allow core files to be created

Signed-off-by: Michael Hennecke <mhennecke@lenovo.com>