### PR TITLE
DAOS-4946 test: Fix the offline test cases

### DIFF
--- a/src/tests/ftest/osa/osa_offline_drain.py
+++ b/src/tests/ftest/osa/osa_offline_drain.py
@@ -25,14 +25,14 @@ import time
 import random
 import ctypes
 from avocado import fail_on
-from apricot import TestWithServers
+from osa_utils import OSAUtils
 from test_utils_pool import TestPool
 from command_utils import CommandFailure
 from pydaos.raw import (DaosContainer, IORequest,
                         DaosObj, DaosApiError)
 
 
-class OSAOfflineDrain(TestWithServers):
+class OSAOfflineDrain(OSAUtils):
     # pylint: disable=too-many-ancestors
     """
     Test Class Description: This test runs
@@ -44,61 +44,6 @@ class OSAOfflineDrain(TestWithServers):
         """Set up for test case."""
         super(OSAOfflineDrain, self).setUp()
         self.dmg_command = self.get_dmg_command()
-        self.no_of_dkeys = self.params.get("no_of_dkeys", '/run/dkeys/*')[0]
-        self.no_of_akeys = self.params.get("no_of_akeys", '/run/akeys/*')[0]
-        self.record_length = self.params.get("length", '/run/record/*')[0]
-
-    @fail_on(CommandFailure)
-    def get_pool_leader(self):
-        """Get the pool leader.
-
-        Returns:
-            int: pool leader value
-
-        """
-        data = self.dmg_command.pool_query(self.pool.uuid)
-        return int(data["leader"])
-
-    @fail_on(CommandFailure)
-    def get_pool_version(self):
-        """Get the pool version.
-
-        Returns:
-            int: pool_version_value
-
-        """
-        data = self.dmg_command.pool_query(self.pool.uuid)
-        return int(data["version"])
-
-    @fail_on(DaosApiError)
-    def write_single_object(self):
-        """Write some data to the existing pool."""
-        self.pool.connect(2)
-        csum = self.params.get("enable_checksum", '/run/container/*')
-        container = DaosContainer(self.context)
-        input_param = container.cont_input_values
-        input_param.enable_chksum = csum
-        container.create(poh=self.pool.pool.handle,
-                         con_prop=input_param)
-        container.open()
-        obj = DaosObj(self.context, container)
-        obj.create(objcls=1)
-        obj.open()
-        ioreq = IORequest(self.context,
-                          container,
-                          obj, objtype=4)
-        self.log.info("Writing the Single Dataset")
-        for dkey in range(self.no_of_dkeys):
-            for akey in range(self.no_of_akeys):
-                indata = ("{0}".format(str(akey)[0])
-                          * self.record_length)
-                d_key_value = "dkey {0}".format(dkey)
-                c_dkey = ctypes.create_string_buffer(d_key_value)
-                a_key_value = "akey {0}".format(akey)
-                c_akey = ctypes.create_string_buffer(a_key_value)
-                c_value = ctypes.create_string_buffer(indata)
-                c_size = ctypes.c_size_t(ctypes.sizeof(c_value))
-                ioreq.single_insert(c_dkey, c_akey, c_value, c_size)
 
     def run_offline_drain_test(self, num_pool, data=False):
         """Run the offline drain without data.
@@ -123,7 +68,7 @@ class OSAOfflineDrain(TestWithServers):
         rank = random.randint(1, drain_servers)
 
         for val in range(0, num_pool):
-            pool[val] = TestPool(self.context, self.get_dmg_command())
+            pool[val] = TestPool(self.context, dmg_command=self.dmg_command)
             pool[val].get_params(self)
             # Split total SCM and NVME size for creating multiple pools.
             pool[val].scm_size.value = int(pool[val].scm_size.value /
@@ -164,7 +109,9 @@ class OSAOfflineDrain(TestWithServers):
         for val in range(0, num_pool):
             display_string = "Pool{} space at the End".format(val)
             pool[val].display_pool_daos_space(display_string)
-            pool[val].destroy()
+
+        if data:
+            self.verify_single_object()
 
     def test_osa_offline_drain(self):
         """
@@ -174,11 +121,5 @@ class OSAOfflineDrain(TestWithServers):
 
         :avocado: tags=all,pr,hw,large,osa,osa_drain,offline_drain
         """
-        # Perform drain testing with 1 to 2 pools
-        # Two pool testing blocked by DAOS-5333.
-        # Fix range from 1,2 to 1,3
-        for pool_num in range(1, 2):
-            self.run_offline_drain_test(pool_num)
-        # Perform drain testing : inserting data in pool
-        # Bug : DAOS-4946 blocks the following test case.
-        # self.run_offline_drain_test(1, True)
+        for pool_num in range(1, 3):
+            self.run_offline_drain_test(pool_num, True)

--- a/src/tests/ftest/osa/osa_offline_drain.py
+++ b/src/tests/ftest/osa/osa_offline_drain.py
@@ -23,13 +23,8 @@
 """
 import time
 import random
-import ctypes
-from avocado import fail_on
 from osa_utils import OSAUtils
 from test_utils_pool import TestPool
-from command_utils import CommandFailure
-from pydaos.raw import (DaosContainer, IORequest,
-                        DaosObj, DaosApiError)
 
 
 class OSAOfflineDrain(OSAUtils):

--- a/src/tests/ftest/osa/osa_offline_extend.py
+++ b/src/tests/ftest/osa/osa_offline_extend.py
@@ -22,14 +22,8 @@
   portions thereof marked with this legend must also reproduce the markings.
 """
 import time
-import ctypes
-from avocado import fail_on
-from apricot import TestWithServers
 from osa_utils import OSAUtils
 from test_utils_pool import TestPool
-from command_utils import CommandFailure
-from pydaos.raw import (DaosContainer, IORequest,
-                        DaosObj, DaosApiError)
 
 
 class OSAOfflineExtend(OSAUtils):

--- a/src/tests/ftest/osa/osa_offline_extend.py
+++ b/src/tests/ftest/osa/osa_offline_extend.py
@@ -25,13 +25,14 @@ import time
 import ctypes
 from avocado import fail_on
 from apricot import TestWithServers
+from osa_utils import OSAUtils
 from test_utils_pool import TestPool
 from command_utils import CommandFailure
 from pydaos.raw import (DaosContainer, IORequest,
                         DaosObj, DaosApiError)
 
 
-class OSAOfflineExtend(TestWithServers):
+class OSAOfflineExtend(OSAUtils):
     # pylint: disable=too-many-ancestors
     """
     Test Class Description: This test runs
@@ -43,53 +44,9 @@ class OSAOfflineExtend(TestWithServers):
         """Set up for test case."""
         super(OSAOfflineExtend, self).setUp()
         self.dmg_command = self.get_dmg_command()
-        self.no_of_dkeys = self.params.get("no_of_dkeys", '/run/dkeys/*')[0]
-        self.no_of_akeys = self.params.get("no_of_akeys", '/run/akeys/*')[0]
-        self.record_length = self.params.get("length", '/run/record/*')[0]
         # Start an additional server.
         self.extra_servers = self.params.get("test_servers",
                                              "/run/extra_servers/*")
-
-    @fail_on(CommandFailure)
-    def get_pool_version(self):
-        """Get the pool version.
-
-        Returns:
-            int: pool_version_value
-
-        """
-        data = self.dmg_command.pool_query(self.pool.uuid)
-        return int(data["version"])
-
-    @fail_on(DaosApiError)
-    def write_single_object(self):
-        """Write some data to the existing pool."""
-        self.pool.connect(2)
-        csum = self.params.get("enable_checksum", '/run/container/*')
-        container = DaosContainer(self.context)
-        input_param = container.cont_input_values
-        input_param.enable_chksum = csum
-        container.create(poh=self.pool.pool.handle,
-                         con_prop=input_param)
-        container.open()
-        obj = DaosObj(self.context, container)
-        obj.create(objcls=1)
-        obj.open()
-        ioreq = IORequest(self.context,
-                          container,
-                          obj, objtype=4)
-        self.log.info("Writing the Single Dataset")
-        for dkey in range(self.no_of_dkeys):
-            for akey in range(self.no_of_akeys):
-                indata = ("{0}".format(str(akey)[0])
-                          * self.record_length)
-                d_key_value = "dkey {0}".format(dkey)
-                c_dkey = ctypes.create_string_buffer(d_key_value)
-                a_key_value = "akey {0}".format(akey)
-                c_akey = ctypes.create_string_buffer(a_key_value)
-                c_value = ctypes.create_string_buffer(indata)
-                c_size = ctypes.c_size_t(ctypes.sizeof(c_value))
-                ioreq.single_insert(c_dkey, c_akey, c_value, c_size)
 
     def run_offline_extend_test(self, num_pool, data=False):
         """Run the offline extend without data.
@@ -108,7 +65,7 @@ class OSAOfflineExtend(TestWithServers):
         rank = total_servers
 
         for val in range(0, num_pool):
-            pool[val] = TestPool(self.context, self.dmg_command)
+            pool[val] = TestPool(self.context, dmg_command=self.dmg_command)
             pool[val].get_params(self)
             # Split total SCM and NVME size for creating multiple pools.
             pool[val].scm_size.value = int(pool[val].scm_size.value /
@@ -157,7 +114,9 @@ class OSAOfflineExtend(TestWithServers):
         for val in range(0, num_pool):
             display_string = "Pool{} space at the End".format(val)
             pool[val].display_pool_daos_space(display_string)
-            pool[val].destroy()
+
+        if data:
+            self.verify_single_object()
 
     def test_osa_offline_extend(self):
         """
@@ -168,10 +127,4 @@ class OSAOfflineExtend(TestWithServers):
         :avocado: tags=all,pr,hw,large,osa,osa_extend,offline_extend
         """
         # Perform extend testing with 1 pool
-        self.run_offline_extend_test(1)
-        # Perform extend testing : inserting data in pool
-        # Blocked by DAOS-4946
-        # self.stop_servers()
-        # time.sleep(15)
-        # self.start_servers()
-        # self.run_offline_extend_test(1, True)
+        self.run_offline_extend_test(1, True)

--- a/src/tests/ftest/osa/osa_offline_parallel_test.py
+++ b/src/tests/ftest/osa/osa_offline_parallel_test.py
@@ -23,15 +23,11 @@
 """
 import time
 import random
-import ctypes
 import threading
 import copy
-from avocado import fail_on
 from osa_utils import OSAUtils
 from test_utils_pool import TestPool
-from command_utils import CommandFailure
-from pydaos.raw import (DaosContainer, IORequest,
-                        DaosObj, DaosApiError)
+
 try:
     # python 3.x
     import queue as queue
@@ -157,9 +153,6 @@ class OSAOfflineParallelTest(OSAUtils):
             if "FAIL" in failure:
                 self.fail("Test failed : {0}".format(failure))
 
-        if data:
-            self.verify_single_object()
-
         for val in range(0, num_pool):
             display_string = "Pool{} space at the End".format(val)
             pool[val].display_pool_daos_space(display_string)
@@ -173,7 +166,8 @@ class OSAOfflineParallelTest(OSAUtils):
             self.log.info("Pool Version at the End %s", pver_end)
             self.assertTrue(pver_end == 25,
                             "Pool Version Error:  at the end")
-            pool[val].destroy()
+        if data:
+            self.verify_single_object()
 
     def test_osa_offline_parallel_test(self):
         """
@@ -183,7 +177,5 @@ class OSAOfflineParallelTest(OSAUtils):
 
         :avocado: tags=all,pr,hw,large,osa,osa_parallel,offline_parallel
         """
-        # Perform drain testing with 1 to 2 pools
-        # Two pool testing blocked by DAOS-5333.
-        # Fix range from 1,2 to 1,3
+        # Run the parallel offline test.
         self.run_offline_parallel_test(1, True)

--- a/src/tests/ftest/osa/osa_offline_parallel_test.py
+++ b/src/tests/ftest/osa/osa_offline_parallel_test.py
@@ -27,7 +27,7 @@ import ctypes
 import threading
 import copy
 from avocado import fail_on
-from apricot import TestWithServers
+from osa_utils import OSAUtils
 from test_utils_pool import TestPool
 from command_utils import CommandFailure
 from pydaos.raw import (DaosContainer, IORequest,
@@ -39,7 +39,7 @@ except ImportError:
     # python 2.7
     import Queue as queue
 
-class OSAOfflineParallelTest(TestWithServers):
+class OSAOfflineParallelTest(OSAUtils):
     # pylint: disable=too-many-ancestors
     """
     Test Class Description: This test runs
@@ -52,76 +52,7 @@ class OSAOfflineParallelTest(TestWithServers):
         """Set up for test case."""
         super(OSAOfflineParallelTest, self).setUp()
         self.dmg_command = self.get_dmg_command()
-        self.no_of_dkeys = self.params.get("no_of_dkeys", '/run/dkeys/*')[0]
-        self.no_of_akeys = self.params.get("no_of_akeys", '/run/akeys/*')[0]
-        self.record_length = self.params.get("length", '/run/record/*')[0]
         self.out_queue = queue.Queue()
-        self.test_ioreq = None
-
-    @fail_on(CommandFailure)
-    def get_pool_version(self):
-        """Get the pool version.
-
-        Returns:
-            int: pool_version_value
-
-        """
-        data = self.dmg_command.pool_query(self.pool.uuid)
-        return int(data["version"])
-
-    @fail_on(DaosApiError)
-    def write_single_object(self):
-        """Write some data to the existing pool."""
-        self.pool.connect(2)
-        csum = self.params.get("enable_checksum", '/run/container/*')
-        container = DaosContainer(self.context)
-        input_param = container.cont_input_values
-        input_param.enable_chksum = csum
-        container.create(poh=self.pool.pool.handle,
-                         con_prop=input_param)
-        container.open()
-        obj = DaosObj(self.context, container)
-        obj.create(objcls=1)
-        obj.open()
-        ioreq = IORequest(self.context,
-                          container,
-                          obj, objtype=4)
-        self.test_ioreq = ioreq
-        self.log.info("Writing the Single Dataset")
-        for dkey in range(self.no_of_dkeys):
-            for akey in range(self.no_of_akeys):
-                indata = ("{0}".format(str(akey)[0])
-                          * self.record_length)
-                d_key_value = "dkey {0}".format(dkey)
-                c_dkey = ctypes.create_string_buffer(d_key_value)
-                a_key_value = "akey {0}".format(akey)
-                c_akey = ctypes.create_string_buffer(a_key_value)
-                c_value = ctypes.create_string_buffer(indata)
-                c_size = ctypes.c_size_t(ctypes.sizeof(c_value))
-                ioreq.single_insert(c_dkey, c_akey, c_value, c_size)
-
-    @fail_on(DaosApiError)
-    def verify_single_object(self):
-        """Verify the container data on the existing pool."""
-        self.log.info("Single Dataset Verification -- Started")
-        for dkey in range(self.no_of_dkeys):
-            for akey in range(self.no_of_akeys):
-                indata = ("{0}".format(str(akey)[0]) *
-                          self.record_length)
-                c_dkey = ctypes.create_string_buffer("dkey {0}".format(dkey))
-                c_akey = ctypes.create_string_buffer("akey {0}".format(akey))
-                val = self.test_ioreq.single_fetch(c_dkey,
-                                                   c_akey,
-                                                   len(indata)+1)
-                if indata != (repr(val.value)[1:-1]):
-                    self.d_log.error("ERROR:Data mismatch for "
-                                     "dkey = {0}, "
-                                     "akey = {1}".format(
-                                         "dkey {0}".format(dkey),
-                                         "akey {0}".format(akey)))
-                    self.fail("ERROR: Data mismatch for dkey = {0}, akey={1}"
-                              .format("dkey {0}".format(dkey),
-                                      "akey {0}".format(akey)))
 
     def dmg_thread(self, action, action_args, results):
         """Generate different dmg command related to OSA.
@@ -255,7 +186,4 @@ class OSAOfflineParallelTest(TestWithServers):
         # Perform drain testing with 1 to 2 pools
         # Two pool testing blocked by DAOS-5333.
         # Fix range from 1,2 to 1,3
-        self.run_offline_parallel_test(1)
-        # Perform drain testing : inserting data in pool
-        # Bug : DAOS-4946 blocks the following test case.
-        # self.run_offline_parallel_test(1, True)
+        self.run_offline_parallel_test(1, True)

--- a/src/tests/ftest/osa/osa_offline_reintegration.py
+++ b/src/tests/ftest/osa/osa_offline_reintegration.py
@@ -26,13 +26,14 @@ import random
 import ctypes
 from avocado import fail_on
 from apricot import TestWithServers
+from osa_utils import OSAUtils
 from test_utils_pool import TestPool
 from command_utils import CommandFailure
 from pydaos.raw import (DaosContainer, IORequest,
                         DaosObj, DaosApiError)
 
 
-class OSAOfflineReintegration(TestWithServers):
+class OSAOfflineReintegration(OSAUtils):
     # pylint: disable=too-many-ancestors
     """
     Test Class Description: This test runs
@@ -44,66 +45,6 @@ class OSAOfflineReintegration(TestWithServers):
         """Set up for test case."""
         super(OSAOfflineReintegration, self).setUp()
         self.dmg_command = self.get_dmg_command()
-        self.no_of_dkeys = self.params.get("no_of_dkeys", '/run/dkeys/*')
-        self.no_of_akeys = self.params.get("no_of_akeys", '/run/akeys/*')
-        self.record_length = self.params.get("length", '/run/record/*')
-
-    @fail_on(CommandFailure)
-    def get_pool_leader(self):
-        """Get the pool leader.
-
-        Returns:
-            int: pool leader number
-
-        """
-        data = self.dmg_command.pool_query(self.pool.uuid)
-        return int(data["leader"])
-
-    @fail_on(CommandFailure)
-    def get_pool_version(self):
-        """Get the pool version.
-
-        Returns:
-            int: pool version number
-
-        """
-        data = self.dmg_command.pool_query(self.pool.uuid)
-        return int(data["version"])
-
-    @fail_on(DaosApiError)
-    def write_single_object(self):
-        """Write some data to the existing pool.
-        """
-        self.pool.connect(2)
-        csum = self.params.get("enable_checksum", '/run/container/*')
-        container = DaosContainer(self.context)
-        input_param = container.cont_input_values
-        input_param.enable_chksum = csum
-        container.create(poh=self.pool.pool.handle,
-                         con_prop=input_param)
-        container.open()
-        obj = DaosObj(self.context, container)
-        obj.create(objcls=1)
-        obj.open()
-        ioreq = IORequest(self.context,
-                          container,
-                          obj, objtype=4)
-        self.log.info("Writing the Single Dataset")
-        record_index = 0
-        for dkey in range(self.no_of_dkeys):
-            for akey in range(self.no_of_akeys):
-                indata = ("{0}".format(str(akey)[0])
-                          * self.record_length[record_index])
-                d_key_value = "dkey {0}".format(dkey)
-                c_dkey = ctypes.create_string_buffer(d_key_value)
-                a_key_value = "akey {0}".format(akey)
-                c_akey = ctypes.create_string_buffer(a_key_value)
-                c_value = ctypes.create_string_buffer(indata)
-                c_size = ctypes.c_size_t(ctypes.sizeof(c_value))
-                ioreq.single_insert(c_dkey, c_akey, c_value, c_size)
-                record_index = record_index + 1
-                if record_index == len(self.record_length):
-                    record_index = 0
 
     def run_offline_reintegration_test(self, num_pool, data=False):
         """Run the offline reintegration without data.
@@ -128,7 +69,8 @@ class OSAOfflineReintegration(TestWithServers):
         rank = random.randint(1, exclude_servers)
 
         for val in range(0, num_pool):
-            pool[val] = TestPool(self.context, self.get_dmg_command())
+            pool[val] = TestPool(self.context,
+                                 dmg_command=self.get_dmg_command())
             pool[val].get_params(self)
             # Split total SCM and NVME size for creating multiple pools.
             pool[val].scm_size.value = int(pool[val].scm_size.value /
@@ -186,7 +128,9 @@ class OSAOfflineReintegration(TestWithServers):
             display_string = "Pool{} space at the End".format(val)
             self.pool = pool[val]
             self.pool.display_pool_daos_space(display_string)
-            pool[val].destroy()
+
+        if data:
+            self.verify_single_object()
 
     def test_osa_offline_reintegration(self):
         """Test ID: DAOS-4749
@@ -196,7 +140,4 @@ class OSAOfflineReintegration(TestWithServers):
         """
         # Perform reintegration testing with 1 to 3 pools
         for x in range(1, 4):
-            self.run_offline_reintegration_test(x)
-        # Perform reintegration testing : inserting data in pool
-        # Remove the comment below after DAOS-4946 is fixed.
-        # self.run_offline_reintegration_test(1, True)
+            self.run_offline_reintegration_test(x, True)

--- a/src/tests/ftest/osa/osa_offline_reintegration.py
+++ b/src/tests/ftest/osa/osa_offline_reintegration.py
@@ -23,14 +23,8 @@
 """
 import time
 import random
-import ctypes
-from avocado import fail_on
-from apricot import TestWithServers
 from osa_utils import OSAUtils
 from test_utils_pool import TestPool
-from command_utils import CommandFailure
-from pydaos.raw import (DaosContainer, IORequest,
-                        DaosObj, DaosApiError)
 
 
 class OSAOfflineReintegration(OSAUtils):

--- a/src/tests/ftest/util/osa_utils.py
+++ b/src/tests/ftest/util/osa_utils.py
@@ -21,8 +21,6 @@
   Any reproduction of computer software, computer software documentation, or
   portions thereof marked with this legend must also reproduce the markings.
 """
-import time
-import random
 import ctypes
 from avocado import fail_on
 from apricot import TestWithServers

--- a/src/tests/ftest/util/osa_utils.py
+++ b/src/tests/ftest/util/osa_utils.py
@@ -1,0 +1,133 @@
+#!/usr/bin/python
+"""
+  (C) Copyright 2020 Intel Corporation.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+  GOVERNMENT LICENSE RIGHTS-OPEN SOURCE SOFTWARE
+  The Government's rights to use, modify, reproduce, release, perform, display,
+  or disclose this software are subject to the terms of the Apache License as
+  provided in Contract No. B609815.
+  Any reproduction of computer software, computer software documentation, or
+  portions thereof marked with this legend must also reproduce the markings.
+"""
+import time
+import random
+import ctypes
+from avocado import fail_on
+from apricot import TestWithServers
+from command_utils import CommandFailure
+from pydaos.raw import (DaosContainer, IORequest,
+                        DaosObj, DaosApiError)
+
+
+class OSAUtils(TestWithServers):
+    # pylint: disable=too-many-ancestors
+    """
+    Test Class Description: This test runs
+    daos_server offline drain test cases.
+
+    :avocado: recursive
+    """
+    def setUp(self):
+        """Set up for test case."""
+        super(OSAUtils, self).setUp()
+        self.container = None
+        self.obj = None
+        self.ioreq = None
+        self.dmg_command = self.get_dmg_command()
+        self.no_of_dkeys = self.params.get("no_of_dkeys", '/run/dkeys/*')[0]
+        self.no_of_akeys = self.params.get("no_of_akeys", '/run/akeys/*')[0]
+        self.record_length = self.params.get("length", '/run/record/*')[0]
+
+    @fail_on(CommandFailure)
+    def get_pool_leader(self):
+        """Get the pool leader.
+
+        Returns:
+            int: pool leader value
+
+        """
+        data = self.dmg_command.pool_query(self.pool.uuid)
+        return int(data["leader"])
+
+    @fail_on(CommandFailure)
+    def get_pool_version(self):
+        """Get the pool version.
+
+        Returns:
+            int: pool_version_value
+
+        """
+        data = self.dmg_command.pool_query(self.pool.uuid)
+        return int(data["version"])
+
+    @fail_on(DaosApiError)
+    def write_single_object(self):
+        """Write some data to the existing pool."""
+        self.pool.connect(2)
+        csum = self.params.get("enable_checksum", '/run/container/*')
+        self.container = DaosContainer(self.context)
+        input_param = self.container.cont_input_values
+        input_param.enable_chksum = csum
+        self.container.create(poh=self.pool.pool.handle,
+                              con_prop=input_param)
+        self.container.open()
+        self.obj = DaosObj(self.context, self.container)
+        self.obj.create(objcls=1)
+        self.obj.open()
+        self.ioreq = IORequest(self.context,
+                               self.container,
+                               self.obj, objtype=4)
+        self.log.info("Writing the Single Dataset")
+        for dkey in range(self.no_of_dkeys):
+            for akey in range(self.no_of_akeys):
+                indata = ("{0}".format(str(akey)[0])
+                          * self.record_length)
+                d_key_value = "dkey {0}".format(dkey)
+                c_dkey = ctypes.create_string_buffer(d_key_value)
+                a_key_value = "akey {0}".format(akey)
+                c_akey = ctypes.create_string_buffer(a_key_value)
+                c_value = ctypes.create_string_buffer(indata)
+                c_size = ctypes.c_size_t(ctypes.sizeof(c_value))
+                self.ioreq.single_insert(c_dkey, c_akey, c_value, c_size)
+        self.obj.close()
+        self.container.close()
+
+    @fail_on(DaosApiError)
+    def verify_single_object(self):
+        """Verify the container data on the existing pool."""
+        self.pool.connect(2)
+        self.container.open()
+        self.obj.open()
+        self.log.info("Single Dataset Verification -- Started")
+        for dkey in range(self.no_of_dkeys):
+            for akey in range(self.no_of_akeys):
+                indata = ("{0}".format(str(akey)[0]) *
+                          self.record_length)
+                c_dkey = ctypes.create_string_buffer("dkey {0}".format(dkey))
+                c_akey = ctypes.create_string_buffer("akey {0}".format(akey))
+                val = self.ioreq.single_fetch(c_dkey,
+                                              c_akey,
+                                              len(indata)+1)
+                if indata != (repr(val.value)[1:-1]):
+                    self.d_log.error("ERROR:Data mismatch for "
+                                     "dkey = {0}, "
+                                     "akey = {1}".format(
+                                         "dkey {0}".format(dkey),
+                                         "akey {0}".format(akey)))
+                    self.fail("ERROR: Data mismatch for dkey = {0}, akey={1}"
+                              .format("dkey {0}".format(dkey),
+                                      "akey {0}".format(akey)))
+        self.obj.close()
+        self.container.close()


### PR DESCRIPTION
Summary: Fix the offline test cases to use data.
Address the pool_destroy issue stated under DAOS-4946.
Start moving common methods to osa_utils.py

Signed-off-by: Padmanabhan <ravindran.padmanabhan@intel.com>