### PR TITLE
DAOS-5882 cart: fix crt_common_hdr alignment, add a few logs

### DIFF
--- a/src/cart/crt_rpc.c
+++ b/src/cart/crt_rpc.c
@@ -323,8 +323,10 @@ static int check_ep(crt_endpoint_t *tgt_ep, struct crt_grp_priv **ret_grp_priv)
 	int rc = 0;
 
 	grp_priv = crt_grp_pub2priv(tgt_ep->ep_grp);
-	if (grp_priv == NULL)
+	if (grp_priv == NULL) {
+		D_ERROR("crt_grp_pub2priv(%p) got NULL.\n", tgt_ep->ep_grp);
 		D_GOTO(out, rc = -DER_BAD_TARGET);
+	}
 
 out:
 	if (rc == 0)
@@ -1377,8 +1379,8 @@ crt_rpc_common_hdlr(struct crt_rpc_priv *rpc_priv)
 		(crt_ctx->cc_idx != rpc_priv->crp_req_hdr.cch_dst_tag)) {
 
 		if (!skip_check) {
-			D_DEBUG(DB_TRACE, "Mismatch rpc: %p opc: %x rank:%d "
-				"tag:%d self:%d cc_idx:%d ep_rank:%d ep_tag:%d\n",
+			D_ERROR("Mismatch rpc: %p opc: %x rank:%d tag:%d "
+				"self:%d cc_idx:%d ep_rank:%d ep_tag:%d\n",
 				rpc_priv,
 				rpc_priv->crp_pub.cr_opc,
 				rpc_priv->crp_req_hdr.cch_dst_rank,

--- a/src/cart/crt_rpc.h
+++ b/src/cart/crt_rpc.h
@@ -76,14 +76,14 @@ struct crt_common_hdr {
 	uint32_t	cch_flags;
 	/* HLC timestamp */
 	uint64_t	cch_hlc;
+	/* RPC id */
+	uint64_t	cch_rpcid;
 	/* destination rank in default primary group */
 	d_rank_t	cch_dst_rank;
 	/* originator rank in default primary group */
 	d_rank_t	cch_src_rank;
 	/* tag to which rpc request was sent to */
 	uint32_t	cch_dst_tag;
-	/* RPC id */
-	uint64_t	cch_rpcid;
 	/* used in crp_reply_hdr to propagate rpc failure back to sender */
 	uint32_t	cch_rc;
 };


### PR DESCRIPTION
Fix crt_common_hdr alignment, and add a few logs for DER_BAD_TARGET.

Signed-off-by: Xuezhao Liu <xuezhao.liu@intel.com>