### PR TITLE
DAOS_5896 rebuild: data epoch should <= parity epoch

### DIFF
--- a/src/include/daos_srv/daos_server.h
+++ b/src/include/daos_srv/daos_server.h
@@ -768,6 +768,7 @@ struct dss_enum_unpack_io {
 	/* punched epochs per akey */
 	daos_epoch_t		*ui_akey_punch_ephs;
 	daos_epoch_t		*ui_rec_punch_ephs;
+	daos_epoch_t		*ui_rec_min_ephs;
 	int			 ui_iods_cap;
 	int			 ui_iods_top;
 	int			*ui_recxs_caps;

--- a/src/object/cli_shard.c
+++ b/src/object/cli_shard.c
@@ -362,7 +362,8 @@ obj_ec_iom_merge(struct obj_reasb_req *reasb_req, uint32_t tgt_idx,
 	/* merge iom_recx_hi */
 	hi = src->iom_recx_hi;
 	end = DAOS_RECX_END(hi);
-	hi.rx_idx = max(hi.rx_idx, rounddown(end - 1, cell_rec_nr));
+	if (end > 0)
+		hi.rx_idx = max(hi.rx_idx, rounddown(end - 1, cell_rec_nr));
 	hi.rx_nr = end - hi.rx_idx;
 	hi.rx_idx = obj_ec_idx_vos2daos(hi.rx_idx, stripe_rec_nr,
 					cell_rec_nr, tgt_idx);

--- a/src/object/obj_enum.c
+++ b/src/object/obj_enum.c
@@ -558,7 +558,8 @@ unpack_csum(d_iov_t *csum_iov, struct dcs_iod_csums *iod_csums)
 /* Parse recxs in <*data, len> and append them to iod and sgl. */
 static int
 unpack_recxs(daos_iod_t *iod, int *recxs_cap, daos_epoch_t *eph,
-	     d_sg_list_t *sgl, daos_key_desc_t *kds, void *data,
+	     daos_epoch_t *min_eph, d_sg_list_t *sgl,
+	     daos_key_desc_t *kds, void *data,
 	     d_iov_t *csum_iov, struct dcs_iod_csums *iod_csums,
 	     unsigned int type)
 {
@@ -614,6 +615,9 @@ unpack_recxs(daos_iod_t *iod, int *recxs_cap, daos_epoch_t *eph,
 	if (*eph < rec->rec_epr.epr_lo)
 		*eph = rec->rec_epr.epr_lo;
 
+	if (*min_eph == 0 || rec->rec_epr.epr_lo < *min_eph)
+		*min_eph = rec->rec_epr.epr_lo;
+
 	iod->iod_recxs[iod->iod_nr] = rec->rec_recx;
 	iod->iod_nr++;
 	iod->iod_size = rec->rec_size;
@@ -668,7 +672,7 @@ dss_enum_unpack_io_init(struct dss_enum_unpack_io *io, daos_unit_oid_t oid,
 			daos_iod_t *iods, struct dcs_iod_csums *iods_csums,
 			int *recxs_caps, d_sg_list_t *sgls,
 			daos_epoch_t *akey_ephs, daos_epoch_t *rec_ephs,
-			int iods_cap)
+			daos_epoch_t *rec_min_ephs, int iods_cap)
 {
 	memset(io, 0, sizeof(*io));
 
@@ -702,6 +706,12 @@ dss_enum_unpack_io_init(struct dss_enum_unpack_io *io, daos_unit_oid_t oid,
 		memset(rec_ephs, 0, sizeof(*rec_ephs) * iods_cap);
 		io->ui_rec_punch_ephs = rec_ephs;
 	}
+
+	if (rec_min_ephs != NULL) {
+		memset(rec_min_ephs, 0, sizeof(*rec_min_ephs) * iods_cap);
+		io->ui_rec_min_ephs = rec_min_ephs;
+	}
+
 }
 
 static void
@@ -867,8 +877,8 @@ static int
 next_iod(struct dss_enum_unpack_io *io, dss_enum_unpack_cb_t cb, void *cb_arg,
 	 d_iov_t *new_iod_name)
 {
-	int idx;
-	int rc = 0;
+	int	idx;
+	int	rc = 0;
 
 	D_ASSERTF(io->ui_iods_cap > 0, "%d > 0\n", io->ui_iods_cap);
 
@@ -882,7 +892,7 @@ next_iod(struct dss_enum_unpack_io *io, dss_enum_unpack_cb_t cb, void *cb_arg,
 		return complete_io_init_iod(io, cb, cb_arg, new_iod_name);
 
 	io->ui_iods_top++;
-
+	io->ui_rec_min_ephs[io->ui_iods_top] = 0;
 	/* Init the iod_name of the new IOD */
 	if (new_iod_name == NULL && idx != -1)
 		new_iod_name = &io->ui_iods[idx].iod_name;
@@ -1050,6 +1060,7 @@ enum_unpack_recxs(daos_key_desc_t *kds, void *data,
 	top = io->ui_iods_top;
 	rc = unpack_recxs(&io->ui_iods[top], &io->ui_recxs_caps[top],
 			  &io->ui_rec_punch_ephs[top],
+			  &io->ui_rec_min_ephs[top],
 			  io->ui_sgls == NULL ?  NULL : &io->ui_sgls[top],
 			  kds, ptr, csum_iov, &io->ui_iods_csums[top], type);
 free:
@@ -1227,6 +1238,7 @@ dss_enum_unpack(daos_unit_oid_t oid, daos_key_desc_t *kds, int kds_num,
 	d_sg_list_t			sgls[DSS_ENUM_UNPACK_MAX_IODS];
 	daos_epoch_t			ephs[DSS_ENUM_UNPACK_MAX_IODS];
 	daos_epoch_t			rec_ephs[DSS_ENUM_UNPACK_MAX_IODS];
+	daos_epoch_t			rec_min_ephs[DSS_ENUM_UNPACK_MAX_IODS];
 	d_iov_t				csum_iov = { 0 };
 	struct io_unpack_arg		unpack_arg;
 	int				rc = 0;
@@ -1234,7 +1246,8 @@ dss_enum_unpack(daos_unit_oid_t oid, daos_key_desc_t *kds, int kds_num,
 	D_ASSERT(kds_num > 0);
 	D_ASSERT(kds != NULL);
 	dss_enum_unpack_io_init(&io, oid, iods, iods_csums, recxs_caps, sgls,
-				ephs, rec_ephs, DSS_ENUM_UNPACK_MAX_IODS);
+				ephs, rec_ephs, rec_min_ephs,
+				DSS_ENUM_UNPACK_MAX_IODS);
 
 	if (csum)
 		csum_iov = *csum;

--- a/src/tests/ftest/daos_test/daos_core_test.yaml
+++ b/src/tests/ftest/daos_test/daos_core_test.yaml
@@ -138,6 +138,10 @@ daos_tests:
       test_name: Checksum tests
       test_timeout: 220
     test_S:
-      daos_test: S 
+      daos_test: S
       test_name: DAOS rebuild ec tests
+      test_timeout: 900
+    test_X:
+      daos_test: X
+      test_name: DAOS degraded ec tests
       test_timeout: 900

--- a/src/tests/simple_array.c
+++ b/src/tests/simple_array.c
@@ -97,7 +97,7 @@ daos_oclass_id_t	 cid = 0x1;/* class identifier */
 #define	MAX_IOREQS	10	   /* number of concurrent i/o reqs in flight */
 
 /** an i/o request in flight */
-struct ioreq {
+struct io_req {
 	char		dstr[KEY_LEN];
 	daos_key_t	dkey;
 
@@ -168,12 +168,12 @@ pool_destroy(void)
 }
 
 static inline void
-ioreqs_init(struct ioreq *reqs) {
+ioreqs_init(struct io_req *reqs) {
 	int rc;
 	int j;
 
 	for (j = 0; j < MAX_IOREQS; j++) {
-		struct ioreq	*req = &reqs[j];
+		struct io_req	*req = &reqs[j];
 
 		/** initialize event */
 		rc = daos_event_init(&req->ev, eq, NULL);
@@ -214,7 +214,7 @@ void
 array(void)
 {
 	daos_handle_t	 oh;
-	struct ioreq	*reqs;
+	struct io_req	*reqs;
 	int		 rc;
 	int		 iter;
 	int		 k;
@@ -234,7 +234,7 @@ array(void)
 		daos_event_t	*evp[MAX_IOREQS];
 		uint64_t	 sid; /* slice ID */
 		int		 submitted = 0;
-		struct ioreq	*req = &reqs[0];
+		struct io_req	*req = &reqs[0];
 
 		/** store very basic array data */
 		for (k = 0; k < SLICE_SIZE; k++)
@@ -296,7 +296,7 @@ array(void)
 				       evp[0]->ev_error);
 
 				submitted--;
-				req = container_of(evp[0], struct ioreq, ev);
+				req = container_of(evp[0], struct io_req, ev);
 			}
 		}
 

--- a/src/tests/suite/daos_array.c
+++ b/src/tests/suite/daos_array.c
@@ -1122,7 +1122,7 @@ static int
 daos_array_setup(void **state)
 {
 	return test_setup(state, SETUP_CONT_CONNECT, true, DEFAULT_POOL_SIZE,
-			  NULL);
+			  0, NULL);
 }
 
 int

--- a/src/tests/suite/daos_base_tx.c
+++ b/src/tests/suite/daos_base_tx.c
@@ -709,7 +709,7 @@ dtx_test_setup(void **state)
 	int     rc;
 
 	rc = test_setup(state, SETUP_CONT_CONNECT, true, DEFAULT_POOL_SIZE,
-			NULL);
+			0, NULL);
 
 	return rc;
 }

--- a/src/tests/suite/daos_capa.c
+++ b/src/tests/suite/daos_capa.c
@@ -549,7 +549,7 @@ static int
 setup(void **state)
 {
 	return test_setup(state, SETUP_CONT_CREATE, true, DEFAULT_POOL_SIZE,
-			  NULL);
+			  0, NULL);
 }
 
 int

--- a/src/tests/suite/daos_checksum.c
+++ b/src/tests/suite/daos_checksum.c
@@ -2208,7 +2208,7 @@ static int
 setup(void **state)
 {
 	return test_setup(state, SETUP_POOL_CONNECT, true, DEFAULT_POOL_SIZE,
-			  NULL);
+			  0, NULL);
 }
 
 #define CSUM_TEST(dsc, test) { dsc, test, csum_replia_enable, \

--- a/src/tests/suite/daos_container.c
+++ b/src/tests/suite/daos_container.c
@@ -328,7 +328,7 @@ co_properties(void **state)
 
 	print_message("create container with properties, and query/verify.\n");
 	rc = test_setup((void **)&arg, SETUP_POOL_CONNECT, arg0->multi_rank,
-			SMALL_POOL_SIZE, NULL);
+			SMALL_POOL_SIZE, 0, NULL);
 	assert_int_equal(rc, 0);
 
 	prop = daos_prop_alloc(2);
@@ -593,7 +593,7 @@ co_acl(void **state)
 
 	print_message("create container with access props, and verify.\n");
 	rc = test_setup((void **)&arg, SETUP_POOL_CONNECT, arg0->multi_rank,
-			SMALL_POOL_SIZE, NULL);
+			SMALL_POOL_SIZE, 0, NULL);
 	assert_int_equal(rc, 0);
 
 	print_message("Case 1: initial non-default ACL/ownership\n");
@@ -746,7 +746,7 @@ co_set_prop(void **state)
 
 	print_message("create container with default props and modify them.\n");
 	rc = test_setup((void **)&arg, SETUP_POOL_CONNECT, arg0->multi_rank,
-			SMALL_POOL_SIZE, NULL);
+			SMALL_POOL_SIZE, 0, NULL);
 	assert_int_equal(rc, 0);
 
 	while (!rc && arg->setup_state != SETUP_CONT_CONNECT)
@@ -814,7 +814,7 @@ co_create_access_denied(void **state)
 	int		 rc;
 
 	rc = test_setup((void **)&arg, SETUP_EQ, arg0->multi_rank,
-			SMALL_POOL_SIZE, NULL);
+			SMALL_POOL_SIZE, 0, NULL);
 	assert_int_equal(rc, 0);
 
 	print_message("Try to create container on pool with no create perms\n");
@@ -859,7 +859,7 @@ co_destroy_access_denied(void **state)
 	daos_handle_t	coh;
 
 	rc = test_setup((void **)&arg, SETUP_EQ, arg0->multi_rank,
-			SMALL_POOL_SIZE, NULL);
+			SMALL_POOL_SIZE, 0, NULL);
 	assert_int_equal(rc, 0);
 
 	/*
@@ -934,7 +934,7 @@ co_destroy_allowed_by_pool(void **state)
 	int		 rc;
 
 	rc = test_setup((void **)&arg, SETUP_EQ, arg0->multi_rank,
-			SMALL_POOL_SIZE, NULL);
+			SMALL_POOL_SIZE, 0, NULL);
 	assert_int_equal(rc, 0);
 
 	/* pool gives the owner all privs, including delete cont */
@@ -999,7 +999,7 @@ co_open_access(void **state)
 	int		rc;
 
 	rc = test_setup((void **)&arg, SETUP_EQ, arg0->multi_rank,
-			SMALL_POOL_SIZE, NULL);
+			SMALL_POOL_SIZE, 0, NULL);
 	assert_int_equal(rc, 0);
 
 	print_message("cont ACL gives the user no permissions\n");
@@ -1076,7 +1076,7 @@ co_query_access(void **state)
 	int		rc;
 
 	rc = test_setup((void **)&arg, SETUP_EQ, arg0->multi_rank,
-			SMALL_POOL_SIZE, NULL);
+			SMALL_POOL_SIZE, 0, NULL);
 	assert_int_equal(rc, 0);
 
 	print_message("Not asking for any props\n");
@@ -1252,7 +1252,7 @@ co_get_acl_access(void **state)
 	int		rc;
 
 	rc = test_setup((void **)&arg, SETUP_EQ, arg0->multi_rank,
-			SMALL_POOL_SIZE, NULL);
+			SMALL_POOL_SIZE, 0, NULL);
 	assert_int_equal(rc, 0);
 
 	print_message("No get-ACL permissions\n");
@@ -1377,7 +1377,7 @@ co_set_prop_access(void **state)
 	int		 rc;
 
 	rc = test_setup((void **)&arg, SETUP_EQ, arg0->multi_rank,
-			SMALL_POOL_SIZE, NULL);
+			SMALL_POOL_SIZE, 0, NULL);
 	assert_int_equal(rc, 0);
 
 	/*
@@ -1586,7 +1586,7 @@ co_modify_acl_access(void **state)
 					    DAOS_ACL_PERM_SET_ACL;
 
 	rc = test_setup((void **)&arg, SETUP_EQ, arg0->multi_rank,
-			SMALL_POOL_SIZE, NULL);
+			SMALL_POOL_SIZE, 0, NULL);
 	assert_int_equal(rc, 0);
 
 	print_message("Overwrite ACL denied with no set-ACL perm\n");
@@ -1663,7 +1663,7 @@ co_set_owner(void **state)
 	int		 rc;
 
 	rc = test_setup((void **)&arg, SETUP_CONT_CONNECT, arg0->multi_rank,
-			SMALL_POOL_SIZE, NULL);
+			SMALL_POOL_SIZE, 0, NULL);
 	assert_int_equal(rc, 0);
 
 	/*
@@ -1755,7 +1755,7 @@ co_set_owner_access(void **state)
 				   ~DAOS_ACL_PERM_SET_OWNER;
 
 	rc = test_setup((void **)&arg, SETUP_EQ, arg0->multi_rank,
-			SMALL_POOL_SIZE, NULL);
+			SMALL_POOL_SIZE, 0, NULL);
 	assert_int_equal(rc, 0);
 
 	print_message("Set owner user denied with no set-owner perm\n");
@@ -1835,7 +1835,7 @@ co_owner_implicit_access(void **state)
 							     DAOS_PROP_CO_ACL);
 
 	rc = test_setup((void **)&arg, SETUP_EQ, arg0->multi_rank,
-			SMALL_POOL_SIZE, NULL);
+			SMALL_POOL_SIZE, 0, NULL);
 	assert_int_equal(rc, 0);
 
 	while (!rc && arg->setup_state != SETUP_CONT_CONNECT)
@@ -1993,7 +1993,7 @@ co_attribute_access(void **state)
 	int		 rc;
 
 	rc = test_setup((void **)&arg, SETUP_EQ, arg0->multi_rank,
-			SMALL_POOL_SIZE, NULL);
+			SMALL_POOL_SIZE, 0, NULL);
 	assert_int_equal(rc, 0);
 
 	print_message("Set attr denied with no write-data perms\n");
@@ -2086,7 +2086,7 @@ co_setup_sync(void **state)
 {
 	async_disable(state);
 	return test_setup(state, SETUP_CONT_CONNECT, true, SMALL_POOL_SIZE,
-			  NULL);
+			  0, NULL);
 }
 
 static int
@@ -2094,14 +2094,14 @@ co_setup_async(void **state)
 {
 	async_enable(state);
 	return test_setup(state, SETUP_CONT_CONNECT, true, SMALL_POOL_SIZE,
-			  NULL);
+			  0, NULL);
 }
 
 static int
 setup(void **state)
 {
 	return test_setup(state, SETUP_POOL_CONNECT, true, SMALL_POOL_SIZE,
-			  NULL);
+			  0, NULL);
 }
 
 static const struct CMUnitTest co_tests[] = {

--- a/src/tests/suite/daos_dedup.c
+++ b/src/tests/suite/daos_dedup.c
@@ -318,7 +318,7 @@ static int
 setup(void **state)
 {
 	return test_setup(state, SETUP_POOL_CONNECT, true, DEFAULT_POOL_SIZE,
-			  NULL);
+			  0, NULL);
 }
 
 #define DEDUP_TEST(dsc, test) { dsc, test, NULL, test_case_teardown }

--- a/src/tests/suite/daos_degrade_ec.c
+++ b/src/tests/suite/daos_degrade_ec.c
@@ -1,0 +1,217 @@
+/**
+ * (C) Copyright 2016-2020 Intel Corporation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * GOVERNMENT LICENSE RIGHTS-OPEN SOURCE SOFTWARE
+ * The Government's rights to use, modify, reproduce, release, perform, display,
+ * or disclose this software are subject to the terms of the Apache License as
+ * provided in Contract No. B609815.
+ * Any reproduction of computer software, computer software documentation, or
+ * portions thereof marked with this legend must also reproduce the markings.
+ */
+/**
+ * This file is for simple tests of degraded EC object.
+ *
+ * tests/suite/daos_degraded_ec.c
+ *
+ *
+ */
+#define D_LOGFAC	DD_FAC(tests)
+
+#include "daos_iotest.h"
+#include <daos/pool.h>
+#include <daos/mgmt.h>
+#include <daos/container.h>
+
+static void
+degrade_ec_internal(void **state, int *shards, int shards_nr, int write_type)
+{
+	test_arg_t	*arg = *state;
+	daos_obj_id_t	oid;
+	struct ioreq	req;
+	d_rank_t	ranks[4] = { -1 };
+	int		idx = 0;
+
+	if (!test_runable(arg, 6))
+		return;
+
+	oid = dts_oid_gen(OC_EC_4P2G1, 0, arg->myrank);
+	ioreq_init(&req, arg->coh, oid, DAOS_IOD_ARRAY, arg);
+
+	if (write_type == PARTIAL_UPDATE)
+		write_ec_partial(&req, arg->index, 0);
+	else if (write_type == FULL_UPDATE)
+		write_ec_full(&req, arg->index, 0);
+	else if (write_type == FULL_PARTIAL_UPDATE)
+		write_ec_full_partial(&req, arg->index, 0);
+	else if (write_type == PARTIAL_FULL_UPDATE)
+		write_ec_partial_full(&req, arg->index, 0);
+
+	ioreq_fini(&req);
+
+	while (shards_nr-- > 0) {
+		ranks[idx] = get_rank_by_oid_shard(arg, oid, shards[idx]);
+		idx++;
+	}
+	rebuild_pools_ranks(&arg, 1, ranks, idx, false);
+
+	ioreq_init(&req, arg->coh, oid, DAOS_IOD_ARRAY, arg);
+	if (write_type == PARTIAL_UPDATE)
+		verify_ec_partial(&req, arg->index, 0);
+	else if (write_type == FULL_UPDATE)
+		verify_ec_full(&req, arg->index, 0);
+	else if (write_type == FULL_PARTIAL_UPDATE)
+		verify_ec_full_partial(&req, arg->index, 0);
+	else if (write_type == PARTIAL_FULL_UPDATE)
+		verify_ec_full(&req, arg->index, 0);
+
+	ioreq_fini(&req);
+#if 0
+	while (idx > 0)
+		rebuild_add_back_tgts(arg, ranks[--idx], NULL, 1);
+#endif
+}
+
+static void
+degrade_partial_fail_data(void **state)
+{
+	int shard;
+
+	shard = 1;
+	degrade_ec_internal(state, &shard, 1, FULL_UPDATE);
+}
+
+static void
+degrade_partial_fail_2data(void **state)
+{
+	int shards[2];
+
+	shards[0] = 0;
+	shards[1] = 3;
+	degrade_ec_internal(state, shards, 2, PARTIAL_UPDATE);
+}
+
+static void
+degrade_full_fail_data(void **state)
+{
+	int shard;
+
+	shard = 3;
+	degrade_ec_internal(state, &shard, 1, FULL_UPDATE);
+}
+
+static void
+degrade_full_fail_2data(void **state)
+{
+	int shards[2];
+
+	shards[0] = 0;
+	shards[1] = 3;
+	degrade_ec_internal(state, shards, 2, FULL_UPDATE);
+}
+
+static void
+degrade_full_partial_fail_2data(void **state)
+{
+	int shards[2];
+
+	shards[0] = 0;
+	shards[1] = 3;
+	degrade_ec_internal(state, shards, 2, FULL_PARTIAL_UPDATE);
+}
+
+static void
+degrade_partial_full_fail_2data(void **state)
+{
+	int shards[2];
+
+	shards[0] = 0;
+	shards[1] = 3;
+	degrade_ec_internal(state, shards, 2, PARTIAL_FULL_UPDATE);
+}
+
+static void
+degrade_partial_fail_data_parity(void **state)
+{
+	int shards[2];
+
+	shards[0] = 0;
+	shards[1] = 4;
+	degrade_ec_internal(state, shards, 2, PARTIAL_UPDATE);
+}
+
+static void
+degrade_full_fail_data_parity(void **state)
+{
+	int shards[2];
+
+	shards[0] = 0;
+	shards[1] = 5;
+	degrade_ec_internal(state, shards, 2, FULL_UPDATE);
+}
+
+#define DEGRADE_SMALL_POOL_SIZE (1ULL << 28)
+int
+degrade_small_sub_setup(void **state)
+{
+	int rc;
+
+	rc = test_setup(state, SETUP_CONT_CONNECT, true,
+			DEGRADE_SMALL_POOL_SIZE, 6, NULL);
+	return rc;
+}
+
+/** create a new pool/container for each test */
+static const struct CMUnitTest degrade_tests[] = {
+	{"DEGRADE0: degrade partial update with data tgt fail",
+	 degrade_partial_fail_data, degrade_small_sub_setup, test_teardown},
+	{"DEGRADE1: degrade partial update with 2 data tgt fail",
+	 degrade_partial_fail_2data, degrade_small_sub_setup, test_teardown},
+	{"DEGRADE2: degrade full stripe update with data tgt fail",
+	 degrade_full_fail_data, degrade_small_sub_setup, test_teardown},
+	{"DEGRADE3: degrade full stripe update with 2 data tgt fail",
+	 degrade_full_fail_2data, degrade_small_sub_setup, test_teardown},
+	{"DEGRADE4: degrade full then partial update with 2 data tgt fail",
+	 degrade_full_partial_fail_2data, degrade_small_sub_setup,
+	 test_teardown},
+	{"DEGRADE5: degrade partial then full update with 2 data tgt fail",
+	 degrade_partial_full_fail_2data, degrade_small_sub_setup,
+	 test_teardown},
+	{"DEGRADE6: degrade partial full update with data/parity tgt fail",
+	 degrade_partial_fail_data_parity, degrade_small_sub_setup,
+	 test_teardown},
+	{"DEGRADE7: degrade full update with data/parity tgt fail ",
+	 degrade_full_fail_data_parity, degrade_small_sub_setup,
+	 test_teardown},
+};
+
+int
+run_daos_degrade_simple_ec_test(int rank, int size, int *sub_tests,
+				int sub_tests_size)
+{
+	int rc = 0;
+
+	MPI_Barrier(MPI_COMM_WORLD);
+	if (sub_tests_size == 0) {
+		sub_tests_size = ARRAY_SIZE(degrade_tests);
+		sub_tests = NULL;
+	}
+	run_daos_sub_tests_only("DAOS degrade ec tests", degrade_tests,
+				ARRAY_SIZE(degrade_tests), sub_tests,
+				sub_tests_size);
+
+	MPI_Barrier(MPI_COMM_WORLD);
+
+	return rc;
+}

--- a/src/tests/suite/daos_degraded.c
+++ b/src/tests/suite/daos_degraded.c
@@ -267,7 +267,7 @@ static int
 degraded_setup(void **state)
 {
 	return test_setup(state, SETUP_CONT_CONNECT, true, DEFAULT_POOL_SIZE,
-			  NULL);
+			  0, NULL);
 }
 
 static int

--- a/src/tests/suite/daos_dist_tx.c
+++ b/src/tests/suite/daos_dist_tx.c
@@ -981,7 +981,7 @@ dtx_test_setup(void **state)
 	int     rc;
 
 	rc = test_setup(state, SETUP_CONT_CONNECT, true, DEFAULT_POOL_SIZE,
-			NULL);
+			0, NULL);
 
 	return rc;
 }

--- a/src/tests/suite/daos_epoch.c
+++ b/src/tests/suite/daos_epoch.c
@@ -342,7 +342,7 @@ static int
 setup(void **state)
 {
 	return test_setup(state, SETUP_POOL_CONNECT, false, DEFAULT_POOL_SIZE,
-			  NULL);
+			  0, NULL);
 }
 
 int

--- a/src/tests/suite/daos_epoch_recovery.c
+++ b/src/tests/suite/daos_epoch_recovery.c
@@ -220,7 +220,7 @@ static int
 setup(void **state)
 {
 	return test_setup(state, SETUP_POOL_CONNECT, true, DEFAULT_POOL_SIZE,
-			  NULL);
+			  0, NULL);
 }
 
 int

--- a/src/tests/suite/daos_iotest.h
+++ b/src/tests/suite/daos_iotest.h
@@ -38,32 +38,6 @@ extern int dts_obj_replica_cnt;
 extern int dts_ec_obj_class;
 extern int dts_ec_grp_size;
 
-#define IOREQ_IOD_NR	5
-#define IOREQ_SG_NR	5
-#define IOREQ_SG_IOD_NR	5
-
-#define DTS_MAX_EXT_NUM		5
-#define DTS_MAX_DISTANCE	10
-#define DTS_MAX_EXTENT_SIZE	50
-#define DTS_MAX_OFFSET		1048576
-#define DTS_MAX_EPOCH_TIMES	20
-
-struct ioreq {
-	daos_handle_t		oh;
-	test_arg_t		*arg;
-	daos_event_t		ev;
-	daos_key_t		dkey;
-	daos_key_t		akey;
-	d_iov_t			val_iov[IOREQ_SG_IOD_NR][IOREQ_SG_NR];
-	d_sg_list_t		sgl[IOREQ_SG_IOD_NR];
-	daos_recx_t		rex[IOREQ_SG_IOD_NR][IOREQ_IOD_NR];
-	daos_epoch_range_t	erange[IOREQ_SG_IOD_NR][IOREQ_IOD_NR];
-	daos_iod_t		iod[IOREQ_SG_IOD_NR];
-	daos_iod_type_t		iod_type;
-	uint64_t		fail_loc;
-	int			result;
-};
-
 #define SEGMENT_SIZE (10 * 1048576) /* 10MB */
 
 void

--- a/src/tests/suite/daos_kv.c
+++ b/src/tests/suite/daos_kv.c
@@ -348,7 +348,7 @@ int
 kv_setup(void **state)
 {
 	return test_setup(state, SETUP_CONT_CONNECT, true, DEFAULT_POOL_SIZE,
-			  NULL);
+			  0, NULL);
 }
 
 int

--- a/src/tests/suite/daos_md_replication.c
+++ b/src/tests/suite/daos_md_replication.c
@@ -199,7 +199,7 @@ static const struct CMUnitTest mdr_tests[] = {
 static int
 setup(void **state)
 {
-	return test_setup(state, SETUP_EQ, false, DEFAULT_POOL_SIZE, NULL);
+	return test_setup(state, SETUP_EQ, false, DEFAULT_POOL_SIZE, 0, NULL);
 }
 
 int

--- a/src/tests/suite/daos_mgmt.c
+++ b/src/tests/suite/daos_mgmt.c
@@ -436,7 +436,7 @@ static const struct CMUnitTest tests[] = {
 static int
 setup(void **state)
 {
-	return test_setup(state, SETUP_EQ, false, DEFAULT_POOL_SIZE, NULL);
+	return test_setup(state, SETUP_EQ, false, DEFAULT_POOL_SIZE, 0, NULL);
 }
 
 int

--- a/src/tests/suite/daos_nvme_recovery.c
+++ b/src/tests/suite/daos_nvme_recovery.c
@@ -375,7 +375,7 @@ nvme_recov_test_setup(void **state)
 	int     rc;
 
 	rc = test_setup(state, SETUP_CONT_CONNECT, true, DEFAULT_POOL_SIZE,
-			NULL);
+			0, NULL);
 
 	return rc;
 }

--- a/src/tests/suite/daos_obj.c
+++ b/src/tests/suite/daos_obj.c
@@ -468,8 +468,6 @@ lookup_recxs(const char *dkey, const char *akey, daos_size_t iod_size,
 	     daos_handle_t th, daos_recx_t *recxs, int nr, void *data,
 	     daos_size_t data_size, struct ioreq *req)
 {
-	assert_in_range(nr, 1, IOREQ_IOD_NR);
-
 	/* dkey */
 	ioreq_dkey_set(req, dkey);
 
@@ -4201,7 +4199,7 @@ obj_setup(void **state)
 	int	rc;
 
 	rc = test_setup(state, SETUP_CONT_CONNECT, true, DEFAULT_POOL_SIZE,
-			NULL);
+			0, NULL);
 	if (rc != 0)
 		return rc;
 

--- a/src/tests/suite/daos_obj_array.c
+++ b/src/tests/suite/daos_obj_array.c
@@ -1462,7 +1462,7 @@ static int
 obj_array_setup(void **state)
 {
 	return test_setup(state, SETUP_CONT_CONNECT, false, DEFAULT_POOL_SIZE,
-			  NULL);
+			  0, NULL);
 }
 
 int

--- a/src/tests/suite/daos_oid_alloc.c
+++ b/src/tests/suite/daos_oid_alloc.c
@@ -291,7 +291,7 @@ int
 oid_alloc_setup(void **state)
 {
 	return test_setup(state, SETUP_CONT_CONNECT, true, DEFAULT_POOL_SIZE,
-			  NULL);
+			  0, NULL);
 }
 
 int

--- a/src/tests/suite/daos_pool.c
+++ b/src/tests/suite/daos_pool.c
@@ -485,7 +485,7 @@ pool_properties(void **state)
 
 	print_message("create pool with properties, and query it to verify.\n");
 	rc = test_setup((void **)&arg, SETUP_EQ, arg0->multi_rank,
-			SMALL_POOL_SIZE, NULL);
+			SMALL_POOL_SIZE, 0, NULL);
 	assert_int_equal(rc, 0);
 
 /* FIXME (DAOS-5456): label/space_rb props not supported with dmg */
@@ -643,7 +643,7 @@ pool_setup_sync(void **state)
 {
 	async_disable(state);
 	return test_setup(state, SETUP_POOL_CONNECT, true, SMALL_POOL_SIZE,
-			  NULL);
+			  0, NULL);
 }
 
 static int
@@ -651,14 +651,14 @@ pool_setup_async(void **state)
 {
 	async_enable(state);
 	return test_setup(state, SETUP_POOL_CONNECT, true, SMALL_POOL_SIZE,
-			  NULL);
+			  0, NULL);
 }
 
 static int
 setup(void **state)
 {
 	return test_setup(state, SETUP_POOL_CREATE, true, SMALL_POOL_SIZE,
-			  NULL);
+			  0, NULL);
 }
 
 /* Private definition for void * typed test_arg_t.pool_lc_args */
@@ -1037,7 +1037,7 @@ expect_pool_connect_access(test_arg_t *arg0, uint64_t perms,
 	int		 rc;
 
 	rc = test_setup((void **)&arg, SETUP_EQ, arg0->multi_rank,
-			SMALL_POOL_SIZE, NULL);
+			SMALL_POOL_SIZE, 0, NULL);
 	assert_int_equal(rc, 0);
 
 	arg->pool.pool_connect_flags = flags;

--- a/src/tests/suite/daos_rebuild.c
+++ b/src/tests/suite/daos_rebuild.c
@@ -1320,7 +1320,7 @@ rebuild_test_setup(void **state)
 	int rc;
 
 	rc = test_setup(state, SETUP_CONT_CONNECT, true, REBUILD_POOL_SIZE,
-			NULL);
+			0, NULL);
 	if (rc)
 		return rc;
 

--- a/src/tests/suite/daos_rebuild_ec.c
+++ b/src/tests/suite/daos_rebuild_ec.c
@@ -35,174 +35,6 @@
 #include <daos/pool.h>
 #include <daos/mgmt.h>
 #include <daos/container.h>
-
-#define MAX_SIZE		1048576 * 3
-#define DATA_SIZE		(1048576 * 2 + 512)
-#define PARTIAL_DATA_SIZE	1024
-#define IOD3_DATA_SIZE		300
-
-#define KEY_NR 5
-static void
-write_ec(struct ioreq *req, int index, char *data, daos_off_t off, int size)
-{
-	char		key[32];
-	daos_recx_t	recx;
-	int		i;
-	char		single_data[8500];
-
-	for (i = 0; i < KEY_NR; i++) {
-		req->iod_type = DAOS_IOD_ARRAY;
-		sprintf(key, "dkey_%d", index);
-		recx.rx_nr = size;
-		recx.rx_idx = off + i * 10485760;
-		insert_recxs(key, "a_key", 1, DAOS_TX_NONE, &recx, 1,
-			     data, size, req);
-
-		recx.rx_nr = IOD3_DATA_SIZE;
-		insert_recxs(key, "a_key_iod3", 3, DAOS_TX_NONE, &recx, 1,
-			     data, IOD3_DATA_SIZE * 3, req);
-
-		req->iod_type = DAOS_IOD_SINGLE;
-		memset(single_data, 'a' + i, 8500);
-		sprintf(key, "dkey_single_small_%d_%d", index, i);
-		insert_single(key, "a_key", 0, single_data, 32, DAOS_TX_NONE,
-			      req);
-
-		sprintf(key, "dkey_single_large_%d_%d", index, i);
-		insert_single(key, "a_key", 0, single_data, 8500, DAOS_TX_NONE,
-			      req);
-	}
-}
-
-static void
-verify_ec(struct ioreq *req, int index, char *verify_data, daos_off_t off,
-	  int size)
-{
-	char		key[32];
-	char		key_buf[32];
-	const char	*akey = key_buf;
-	char		data_buf[MAX_SIZE];
-	void		*read_data = data_buf;
-	char		single_buf[8500];
-	void		*single_data = single_buf;
-	char		verify_single_data[8500];
-	int		i;
-
-	for (i = 0; i < KEY_NR; i++) {
-		uint64_t	offset = off + i * 10485760;
-		uint64_t	idx = 0;
-		daos_size_t	read_size = 0;
-		daos_size_t	iod_size = 1;
-		daos_size_t	single_data_size;
-		daos_size_t	iod3_datasize = IOD3_DATA_SIZE * 3;
-		daos_size_t	datasize = size;
-
-		req->iod_type = DAOS_IOD_ARRAY;
-		sprintf(key, "dkey_%d", index);
-		sprintf(key_buf, "a_key");
-		memset(read_data, 0, size);
-		lookup(key, 1, &akey, &offset, &iod_size,
-		       &read_data, &datasize, DAOS_TX_NONE, req, false);
-		assert_memory_equal(read_data, verify_data, datasize);
-		assert_int_equal(iod_size, 1);
-
-		sprintf(key_buf, "a_key_iod3");
-		memset(read_data, 0, size);
-		lookup(key, 1, &akey, &offset, &iod_size, &read_data,
-		       &iod3_datasize, DAOS_TX_NONE, req, false);
-		assert_int_equal(iod_size, 3);
-		assert_memory_equal(read_data, verify_data, iod3_datasize);
-
-		req->iod_type = DAOS_IOD_SINGLE;
-		memset(single_data, 0, 32);
-		memset(verify_single_data, 'a' + i, 8500);
-		single_data_size = 32;
-		sprintf(key, "dkey_single_small_%d_%d", index, i);
-		sprintf(key_buf, "a_key");
-		lookup(key, 1, &akey, &idx, &read_size, &single_data,
-		       &single_data_size, DAOS_TX_NONE, req, false);
-		assert_int_equal(read_size, 32);
-		assert_memory_equal(single_data, verify_single_data, 32);
-
-		idx = 0;
-		read_size = 0;
-		single_data_size = 8500;
-		memset(single_data, 0, 8500);
-		sprintf(key, "dkey_single_large_%d_%d", index, i);
-		lookup(key, 1, &akey, &idx, &read_size, &single_data,
-		       &single_data_size, DAOS_TX_NONE, req, false);
-		assert_int_equal(read_size, 8500);
-		assert_memory_equal(single_data, verify_single_data, 8500);
-	}
-}
-
-static void
-write_ec_partial(struct ioreq *req, int test_idx, daos_off_t off)
-{
-	char	buffer[PARTIAL_DATA_SIZE];
-
-	memset(buffer, 'a', PARTIAL_DATA_SIZE);
-	write_ec(req, test_idx, buffer, off, PARTIAL_DATA_SIZE);
-}
-
-static void
-verify_ec_partial(struct ioreq *req, int test_idx, daos_off_t off)
-{
-	char	buffer[PARTIAL_DATA_SIZE];
-
-	memset(buffer, 'a', PARTIAL_DATA_SIZE);
-	verify_ec(req, test_idx, buffer, off, PARTIAL_DATA_SIZE);
-}
-
-static void
-write_ec_full(struct ioreq *req, int test_idx, daos_off_t off)
-{
-	char	buffer[DATA_SIZE];
-
-	memset(buffer, 'b', DATA_SIZE);
-	write_ec(req, test_idx, buffer, off, DATA_SIZE);
-}
-
-static void
-verify_ec_full(struct ioreq *req, int test_idx, daos_off_t off)
-{
-	char	buffer[DATA_SIZE];
-
-	memset(buffer, 'b', DATA_SIZE);
-	verify_ec(req, test_idx, buffer, off, DATA_SIZE);
-}
-
-static void
-write_ec_full_partial(struct ioreq *req, int test_idx, daos_off_t off)
-{
-	write_ec_full(req, test_idx, off);
-	write_ec_partial(req, test_idx, off);
-}
-
-static void
-write_ec_partial_full(struct ioreq *req, int test_idx, daos_off_t off)
-{
-	write_ec_partial(req, test_idx, off);
-	write_ec_full(req, test_idx, off);
-}
-
-static void
-verify_ec_full_partial(struct ioreq *req, int test_idx, daos_off_t off)
-{
-	char	buffer[DATA_SIZE];
-
-	memset(buffer, 'b', DATA_SIZE);
-	memset(buffer, 'a', PARTIAL_DATA_SIZE);
-	verify_ec(req, test_idx, buffer, off, DATA_SIZE);
-}
-
-enum op_type {
-	PARTIAL_UPDATE	=	1,
-	FULL_UPDATE,
-	FULL_PARTIAL_UPDATE,
-	PARTIAL_FULL_UPDATE
-};
-
 static void
 rebuild_ec_internal(void **state, uint16_t oclass, int kill_data_nr,
 		    int kill_parity_nr, int write_type)
@@ -221,9 +53,6 @@ rebuild_ec_internal(void **state, uint16_t oclass, int kill_data_nr,
 
 	oid = dts_oid_gen(oclass, 0, arg->myrank);
 	ioreq_init(&req, arg->coh, oid, DAOS_IOD_ARRAY, arg);
-
-	print_message("Insert %d kv record in object "DF_OID"\n",
-		      KEY_NR, DP_OID(oid));
 
 	if (write_type == PARTIAL_UPDATE)
 		write_ec_partial(&req, arg->index, 0);
@@ -320,31 +149,88 @@ rebuild_partial_full_fail_parity(void **state)
 static void
 rebuild2p_partial_fail_data(void **state)
 {
-	rebuild_ec_internal(state, OC_EC_4P2G1, 1, 0, PARTIAL_UPDATE);
+	rebuild_ec_internal(state, OC_EC_4P2G1, 1, 0, FULL_UPDATE);
 }
 
 static void
 rebuild2p_partial_fail_2data(void **state)
 {
-	rebuild_ec_internal(state, OC_EC_4P2G1, 2, 0, PARTIAL_UPDATE);
+	rebuild_ec_internal(state, OC_EC_4P2G1, 2, 0, FULL_UPDATE);
 }
 
 static void
 rebuild2p_partial_fail_data_parity(void **state)
 {
-	rebuild_ec_internal(state, OC_EC_4P2G1, 1, 1, PARTIAL_UPDATE);
+	rebuild_ec_internal(state, OC_EC_4P2G1, 1, 1, FULL_UPDATE);
 }
 
 static void
 rebuild2p_partial_fail_parity(void **state)
 {
-	rebuild_ec_internal(state, OC_EC_4P2G1, 0, 1, PARTIAL_UPDATE);
+	rebuild_ec_internal(state, OC_EC_4P2G1, 0, 1, FULL_UPDATE);
 }
 
 static void
 rebuild2p_partial_fail_2parity(void **state)
 {
-	rebuild_ec_internal(state, OC_EC_4P2G1, 0, 2, PARTIAL_UPDATE);
+	rebuild_ec_internal(state, OC_EC_4P2G1, 0, 2, FULL_UPDATE);
+}
+
+#define CELL_SIZE	1048576
+
+static void
+rebuild_mixed_stripes(void **state)
+{
+	test_arg_t	*arg = *state;
+	daos_obj_id_t	oid;
+	struct ioreq	req;
+	char		*data;
+	char		*verify_data;
+	daos_recx_t	recxs[5];
+	d_rank_t	rank = 0;
+	int		size = 8 * 1048576 + 10000;
+
+	if (!test_runable(arg, 7))
+		return;
+
+	oid = dts_oid_gen(OC_EC_4P2G1, 0, arg->myrank);
+	ioreq_init(&req, arg->coh, oid, DAOS_IOD_ARRAY, arg);
+
+	recxs[0].rx_idx = 0;		/* full stripe */
+	recxs[0].rx_nr = 4 * CELL_SIZE;
+
+	recxs[1].rx_idx = 5 * CELL_SIZE; /* partial stripe */
+	recxs[1].rx_nr = 2000;
+
+	recxs[2].rx_idx = 8 * CELL_SIZE;	/* full stripe */
+	recxs[2].rx_nr = 4 * 1048576;
+
+	recxs[3].rx_idx = 12 * 1048576;	/* partial stripe */
+	recxs[3].rx_nr = 5000;
+
+	recxs[4].rx_idx = 16 * 1048576 - 3000;	/* partial stripe */
+	recxs[4].rx_nr = 3000;
+
+	data = (char *)malloc(size);
+	verify_data = (char *)malloc(size);
+	make_buffer(data, 'a', size);
+	make_buffer(verify_data, 'a', size);
+
+	req.iod_type = DAOS_IOD_ARRAY;
+	insert_recxs("d_key", "a_key", 1, DAOS_TX_NONE, recxs, 5,
+		     data, size, &req);
+
+	rank = get_rank_by_oid_shard(arg, oid, 0);
+	rebuild_pools_ranks(&arg, 1, &rank, 1, false);
+
+	memset(data, 0, size);
+	lookup_recxs("d_key", "a_key", 1, DAOS_TX_NONE, recxs, 5,
+		     data, size, &req);
+	assert_memory_equal(data, verify_data, size);
+
+	ioreq_fini(&req);
+
+	reintegrate_pools_ranks(&arg, 1, &rank, 1);
 }
 
 /** create a new pool/container for each test */
@@ -381,6 +267,8 @@ static const struct CMUnitTest rebuild_tests[] = {
 	{"REBUILD12: rebuild2p partial update with 2 parity tgt fail",
 	 rebuild2p_partial_fail_2parity, rebuild_small_sub_setup,
 	 test_teardown},
+	{"REBUILD13: rebuild with mixed partial/full stripe",
+	 rebuild_mixed_stripes, rebuild_small_sub_setup, test_teardown},
 };
 
 int

--- a/src/tests/suite/daos_test.c
+++ b/src/tests/suite/daos_test.c
@@ -34,7 +34,7 @@
  * all will be run if no test is specified. Tests will be run in order
  * so tests that kill nodes must be last.
  */
-#define TESTS "mpcetTViADKFCoRvSbOzUdrNb"
+#define TESTS "mpcetTViADKFCoRvSXbOzUdrNb"
 /**
  * These tests will only be run if explicitly specified. They don't get
  * run if no test is specified.
@@ -80,6 +80,7 @@ print_usage(int rank)
 	print_message("daos_test -r|--rebuild\n");
 	print_message("daos_test -v|--rebuild_simple\n");
 	print_message("daos_test -S|--rebuild_ec\n");
+	print_message("daos_test -X|--degrade_ec\n");
 	print_message("daos_test -b|--drain_simple\n");
 	print_message("daos_test -N|--nvme_recovery\n");
 	print_message("daos_test -a|--daos_all_tests\n");
@@ -275,7 +276,14 @@ run_specified_tests(const char *tests, int rank, int size,
 								     sub_tests,
 								sub_tests_size);
 			break;
-
+		case 'X':
+			daos_test_print(rank, "\n\n=================");
+			daos_test_print(rank, "DAOS degrade ec tests..");
+			daos_test_print(rank, "=================");
+			nr_failed += run_daos_degrade_simple_ec_test(rank, size,
+								     sub_tests,
+								sub_tests_size);
+			break;
 		default:
 			D_ASSERT(0);
 		}
@@ -337,6 +345,8 @@ main(int argc, char **argv)
 		{"degraded",	no_argument,		NULL,	'd'},
 		{"rebuild",	no_argument,		NULL,	'r'},
 		{"rebuild_simple",	no_argument,	NULL,	'v'},
+		{"rebuild_ec",	no_argument,		NULL,	'S'},
+		{"degrade_ec",	no_argument,		NULL,	'X'},
 		{"drain_simple",	no_argument,	NULL,	'b'},
 		{"nvme_recovery",	no_argument,	NULL,	'N'},
 		{"group",	required_argument,	NULL,	'g'},
@@ -368,7 +378,7 @@ main(int argc, char **argv)
 	memset(tests, 0, sizeof(tests));
 
 	while ((opt = getopt_long(argc, argv,
-				  "ampcCdtTVizxADKeoROg:n:s:u:E:f:Fw:W:hrNvbSl:",
+				  "ampcCdtTVizxADKeoROg:n:s:u:E:f:Fw:W:hrNvbSXl:",
 				  long_options, &index)) != -1) {
 		if (strchr(all_tests_defined, opt) != NULL) {
 			tests[ntests] = opt;

--- a/src/tests/suite/daos_test.h
+++ b/src/tests/suite/daos_test.h
@@ -148,6 +148,7 @@ typedef struct {
 	int			expect_result;
 	daos_size_t		size;
 	int			nr;
+	int			pool_node_size;
 	int			srv_nnodes;
 	int			srv_ntgts;
 	int			srv_disabled_ntgts;
@@ -180,6 +181,33 @@ typedef struct {
 	/* List containers (pool tests) */
 	void			*pool_lc_args;
 } test_arg_t;
+
+#define IOREQ_IOD_NR	5
+#define IOREQ_SG_NR	5
+#define IOREQ_SG_IOD_NR	5
+
+#define DTS_MAX_EXT_NUM		5
+#define DTS_MAX_DISTANCE	10
+#define DTS_MAX_EXTENT_SIZE	50
+#define DTS_MAX_OFFSET		1048576
+#define DTS_MAX_EPOCH_TIMES	20
+
+struct ioreq {
+	daos_handle_t		oh;
+	test_arg_t		*arg;
+	daos_event_t		ev;
+	daos_key_t		dkey;
+	daos_key_t		akey;
+	d_iov_t			val_iov[IOREQ_SG_IOD_NR][IOREQ_SG_NR];
+	d_sg_list_t		sgl[IOREQ_SG_IOD_NR];
+	daos_recx_t		rex[IOREQ_SG_IOD_NR][IOREQ_IOD_NR];
+	daos_epoch_range_t	erange[IOREQ_SG_IOD_NR][IOREQ_IOD_NR];
+	daos_iod_t		iod[IOREQ_SG_IOD_NR];
+	daos_iod_type_t		iod_type;
+	uint64_t		fail_loc;
+	int			result;
+};
+
 
 enum {
 	SETUP_EQ,
@@ -218,7 +246,7 @@ int
 test_teardown_cont(test_arg_t *arg);
 int
 test_setup(void **state, unsigned int step, bool multi_rank,
-	   daos_size_t pool_size, struct test_pool *pool);
+	   daos_size_t pool_size, int node_size, struct test_pool *pool);
 int
 test_setup_next_step(void **state, struct test_pool *pool, daos_prop_t *po_prop,
 		     daos_prop_t *co_prop);
@@ -311,7 +339,8 @@ int run_daos_rebuild_simple_test(int rank, int size, int *tests, int test_size);
 int run_daos_drain_simple_test(int rank, int size, int *tests, int test_size);
 int run_daos_rebuild_simple_ec_test(int rank, int size, int *tests,
 				    int test_size);
-
+int run_daos_degrade_simple_ec_test(int rank, int size, int *sub_tests,
+				    int sub_tests_size);
 void daos_kill_server(test_arg_t *arg, const uuid_t pool_uuid, const char *grp,
 		      d_rank_list_t *svc, d_rank_t rank);
 struct daos_acl *get_daos_acl_with_owner_perms(uint64_t perms);
@@ -401,6 +430,22 @@ int verify_state_in_log(char *host, char *log_file, char *state);
 
 int wait_and_verify_blobstore_state(uuid_t bs_uuid, char *expected_state,
 				    const char *group);
+
+enum op_type {
+	PARTIAL_UPDATE	=	1,
+	FULL_UPDATE,
+	FULL_PARTIAL_UPDATE,
+	PARTIAL_FULL_UPDATE
+};
+
+void write_ec_partial(struct ioreq *req, int test_idx, daos_off_t off);
+void verify_ec_partial(struct ioreq *req, int test_idx, daos_off_t off);
+void write_ec_full(struct ioreq *req, int test_idx, daos_off_t off);
+void verify_ec_full(struct ioreq *req, int test_idx, daos_off_t off);
+void write_ec_full_partial(struct ioreq *req, int test_idx, daos_off_t off);
+void write_ec_partial_full(struct ioreq *req, int test_idx, daos_off_t off);
+void verify_ec_full_partial(struct ioreq *req, int test_idx, daos_off_t off);
+void make_buffer(char *buffer, char start, int total);
 
 static inline void
 daos_test_print(int rank, char *message)

--- a/src/tests/suite/daos_test_common.c
+++ b/src/tests/suite/daos_test_common.c
@@ -82,6 +82,7 @@ test_setup_pool_create(void **state, struct test_pool *ipool,
 		char		*env;
 		int		 size_gb;
 		daos_size_t	 nvme_size;
+		d_rank_list_t	 *rank_list = NULL;
 
 		env = getenv("POOL_SCM_SIZE");
 		if (env) {
@@ -104,19 +105,27 @@ test_setup_pool_create(void **state, struct test_pool *ipool,
 			nvme_size = (daos_size_t)size_gb << 30;
 		}
 
+		if (arg->pool_node_size > 0) {
+			rank_list = d_rank_list_alloc(arg->pool_node_size);
+			if (rank_list == NULL)
+				D_GOTO(out, rc = -DER_NOMEM);
+		}
 		print_message("setup: creating pool, SCM size="DF_U64" GB, "
 			      "NVMe size="DF_U64" GB\n",
 			      (outpool->pool_size >> 30), nvme_size >> 30);
 		rc = dmg_pool_create(dmg_config_file,
 				     arg->uid, arg->gid, arg->group,
-				     NULL, outpool->pool_size, nvme_size,
+				     rank_list, outpool->pool_size, nvme_size,
 				     prop, outpool->svc, outpool->pool_uuid);
 		if (rc)
 			print_message("dmg_pool_create failed, rc: %d\n", rc);
 		else
 			print_message("setup: created pool "DF_UUIDF"\n",
 				       DP_UUID(outpool->pool_uuid));
+		if (rank_list)
+			d_rank_list_free(rank_list);
 	}
+out:
 	/** broadcast pool create result */
 	if (arg->multi_rank) {
 		MPI_Bcast(&rc, 1, MPI_INT, 0, MPI_COMM_WORLD);
@@ -276,7 +285,7 @@ test_setup_next_step(void **state, struct test_pool *pool, daos_prop_t *po_prop,
 
 int
 test_setup(void **state, unsigned int step, bool multi_rank,
-	   daos_size_t pool_size, struct test_pool *pool)
+	   daos_size_t pool_size, int node_size, struct test_pool *pool)
 {
 	test_arg_t		*arg = *state;
 	struct timeval		 now;
@@ -316,6 +325,7 @@ test_setup(void **state, unsigned int step, bool multi_rank,
 		arg->uid = geteuid();
 		arg->gid = getegid();
 
+		arg->pool_node_size = node_size;
 		arg->group = server_group;
 		arg->dmg_config = dmg_config_file;
 		uuid_clear(arg->pool.pool_uuid);

--- a/src/tests/suite/daos_verify_consistency.c
+++ b/src/tests/suite/daos_verify_consistency.c
@@ -387,7 +387,7 @@ vc_test_setup(void **state)
 	int     rc;
 
 	rc = test_setup(state, SETUP_CONT_CONNECT, true, DEFAULT_POOL_SIZE,
-			NULL);
+			0, NULL);
 
 	return rc;
 }

--- a/src/tests/suite/dfs_test.c
+++ b/src/tests/suite/dfs_test.c
@@ -325,15 +325,13 @@ dfs_test_read_shared_file(void **state)
 }
 
 #define NUM_SEGS 10
-
 static void
-dfs_test_short_read(void **state)
+dfs_test_short_read_internal(void **state, daos_oclass_id_t cid,
+			     daos_size_t chunk_size, daos_size_t buf_size)
 {
 	test_arg_t		*arg = *state;
 	dfs_obj_t		*obj;
-	daos_size_t		read_size;
-	daos_size_t		chunk_size = 2000;
-	daos_size_t		buf_size = 1024;
+	daos_size_t		read_size = 0;
 	int			*wbuf, *rbuf[NUM_SEGS];
 	char			*name = "short_read_file";
 	d_sg_list_t		wsgl, rsgl;
@@ -357,7 +355,7 @@ dfs_test_short_read(void **state)
 
 	if (arg->myrank == 0) {
 		rc = dfs_open(dfs_mt, NULL, name, S_IFREG | S_IWUSR | S_IRUSR,
-			      O_RDWR | O_CREAT, 0, chunk_size, NULL, &obj);
+			      O_RDWR | O_CREAT, cid, chunk_size, NULL, &obj);
 		assert_int_equal(rc, 0);
 	}
 
@@ -448,7 +446,7 @@ dfs_test_short_read(void **state)
 	if (arg->myrank == 0) {
 		rc = dfs_write(dfs_mt, obj, &wsgl, 0, NULL);
 		assert_int_equal(rc, 0);
-		rc = dfs_write(dfs_mt, obj, &wsgl, 1048576*2, NULL);
+		rc = dfs_write(dfs_mt, obj, &wsgl, 1048576*3, NULL);
 		assert_int_equal(rc, 0);
 	}
 	MPI_Barrier(MPI_COMM_WORLD);
@@ -466,6 +464,12 @@ dfs_test_short_read(void **state)
 	for (i = 0; i < NUM_SEGS; i++)
 		D_FREE(rbuf[i]);
 	D_FREE(rsgl.sg_iovs);
+}
+
+static void
+dfs_test_short_read(void **state)
+{
+	dfs_test_short_read_internal(state, 0, 2000, 1024);
 }
 
 static int
@@ -872,6 +876,30 @@ dfs_test_hole_mgmt(void **state)
 	D_FREE(rsgl.sg_iovs);
 }
 
+static void
+dfs_test_ec_short_read(void **state)
+{
+	/* less than 1 EC stripe */
+	dfs_test_short_read_internal(state, DAOS_OC_EC_K4P2_L32K,
+				     32 * 1024 * 8, 2000);
+
+	/* partial EC stripe */
+	dfs_test_short_read_internal(state, DAOS_OC_EC_K4P2_L32K,
+				     32 * 1024 * 8, 32 * 1024 * 2);
+
+	/* full EC stripe */
+	dfs_test_short_read_internal(state, DAOS_OC_EC_K4P2_L32K,
+				     32 * 1024 * 8, 32 * 1024 * 4);
+
+	/* one full EC stripe + partial EC stripe */
+	dfs_test_short_read_internal(state, DAOS_OC_EC_K4P2_L32K,
+				     32 * 1024 * 8, 32 * 1024 * 6);
+
+	/* 2 full stripe */
+	dfs_test_short_read_internal(state, DAOS_OC_EC_K4P2_L32K,
+				     32 * 1024 * 8, 32 * 1024 * 6);
+}
+
 static const struct CMUnitTest dfs_tests[] = {
 	{ "DFS_TEST1: DFS mount / umount",
 	  dfs_test_mount, async_disable, test_case_teardown},
@@ -885,6 +913,8 @@ static const struct CMUnitTest dfs_tests[] = {
 	  dfs_test_syml, async_disable, test_case_teardown},
 	{ "DFS_TEST6: DFS hole management",
 	  dfs_test_hole_mgmt, async_disable, test_case_teardown},
+	{ "DFS_TEST7: DFS EC object short reads",
+	  dfs_test_ec_short_read, async_disable, test_case_teardown},
 };
 
 static int
@@ -894,7 +924,7 @@ dfs_setup(void **state)
 	int			rc = 0;
 
 	rc = test_setup(state, SETUP_POOL_CONNECT, true, DEFAULT_POOL_SIZE,
-			NULL);
+			0, NULL);
 	assert_int_equal(rc, 0);
 
 	arg = *state;


### PR DESCRIPTION
EC object rebuild has to use epoch, which is less than
parity epoch to rebuild data shard, since degrade fetch
will use epoch on parity node to fetch from data shards.

If it uses stable epoch(larger epoch), then degrade fetch
won't be able to fetch the data.

Note: the sychronization between EC aggregation and VOS
aggregation will make sure using parity epoch (instead of
stable epoch) to be safe here.

Signed-off-by: Di Wang <di.wang@intel.com>