### PR TITLE
DAOS-3911 dtx: distributed transaction recovery

### DIFF
--- a/src/dtx/dtx_internal.h
+++ b/src/dtx/dtx_internal.h
@@ -111,11 +111,11 @@ int dtx_del_cos(struct ds_cont_child *cont, struct dtx_id *xid,
 uint64_t dtx_cos_oldest(struct ds_cont_child *cont);
 
 /* dtx_rpc.c */
-int dtx_commit(uuid_t po_uuid, uuid_t co_uuid, struct dtx_entry **dtes,
+int dtx_commit(struct ds_cont_child *cont, struct dtx_entry **dtes,
 	       int count, bool drop_cos);
-int dtx_abort(uuid_t po_uuid, uuid_t co_uuid, daos_epoch_t epoch,
+int dtx_abort(struct ds_cont_child *cont, daos_epoch_t epoch,
 	      struct dtx_entry **dtes, int count);
-int dtx_check(uuid_t po_uuid, uuid_t co_uuid, struct dtx_entry *dte);
-
+int dtx_check(struct ds_cont_child *cont, struct dtx_entry *dte,
+	      daos_epoch_t epoch);
 
 #endif /* __DTX_INTERNAL_H__ */

--- a/src/dtx/dtx_resync.c
+++ b/src/dtx/dtx_resync.c
@@ -51,7 +51,6 @@ struct dtx_resync_head {
 
 struct dtx_resync_args {
 	struct ds_cont_child	*cont;
-	uuid_t			 po_uuid;
 	struct dtx_resync_head	 tables;
 	daos_epoch_t		 epoch;
 	uint32_t		 version;
@@ -68,7 +67,7 @@ dtx_dre_release(struct dtx_resync_head *drh, struct dtx_resync_entry *dre)
 }
 
 static int
-dtx_resync_commit(uuid_t po_uuid, struct ds_cont_child *cont,
+dtx_resync_commit(struct ds_cont_child *cont,
 		  struct dtx_resync_head *drh, int count)
 {
 	struct dtx_resync_entry		 *dre;
@@ -109,7 +108,7 @@ next:
 	}
 
 	if (j > 0) {
-		rc = dtx_commit(po_uuid, cont->sc_uuid, dte, j, false);
+		rc = dtx_commit(cont, dte, j, false);
 		if (rc < 0)
 			D_ERROR("Failed to commit the DTXs: rc = "DF_RC"\n",
 				DP_RC(rc));
@@ -129,6 +128,88 @@ next:
 	return rc;
 }
 
+static bool
+dtx_target_alive(struct ds_pool *pool, uint32_t id)
+{
+	struct pool_target	*target;
+	int			 rc;
+
+	rc = pool_map_find_target(pool->sp_map, id, &target);
+	D_ASSERT(rc == 1);
+
+	return target->ta_comp.co_status == PO_COMP_ST_UPIN ? true : false;
+}
+
+static int
+dtx_is_leader(struct ds_pool *pool, struct dtx_resync_args *dra,
+	      struct dtx_resync_entry *dre)
+{
+	struct dtx_memberships	*mbs = dre->dre_dte.dte_mbs;
+
+	if (mbs->dm_dte_flags & DTE_LEADER)
+		return 1;
+
+	/* Old leader is still alive, then current server is not the leader. */
+	if (mbs->dm_flags & DMF_CONTAIN_LEADER &&
+	    dtx_target_alive(pool, mbs->dm_tgts[0].ddt_id))
+		return 0;
+
+	return ds_pool_check_dtx_leader(pool, &dre->dre_oid, dra->version);
+}
+
+static bool
+dtx_verify_groups(struct ds_pool *pool, struct dtx_memberships *mbs,
+		  struct dtx_id *xid, int *tgt_array)
+{
+	struct dtx_redundancy_group	*group;
+	int				 i, j, k;
+	bool				 rdonly = true;
+
+	group = (void *)mbs->dm_data +
+		sizeof(struct dtx_daos_target) * mbs->dm_tgt_cnt;
+
+	for (i = 0; i < mbs->dm_grp_cnt; i++) {
+		if (!(group->drg_flags & DGF_RDONLY))
+			rdonly = false;
+
+		for (j = 0, k = 0; j < group->drg_tgt_cnt; j++) {
+			if (tgt_array[group->drg_ids[j]] > 0)
+				continue;
+
+			if (tgt_array[group->drg_ids[j]] < 0) {
+				k++;
+				continue;
+			}
+
+			if (dtx_target_alive(pool, group->drg_ids[j])) {
+				tgt_array[group->drg_ids[j]] = 1;
+			} else {
+				tgt_array[group->drg_ids[j]] = -1;
+				k++;
+			}
+		}
+
+		/* For read only TX, if some redundancy group totally lost,
+		 * we still can make the commit/abort decision based on the
+		 * others. Although the decision may be different from the
+		 * original case, it will not correctness issue.
+		 */
+		if (k >= group->drg_redundancy && !rdonly) {
+			D_WARN("The DTX "DF_DTI" has %d redundancy group, "
+			       "the No.%d lost too many members %d/%d/%d, "
+			       "cannot recover such DTX.\n",
+			       DP_DTI(xid), mbs->dm_grp_cnt, i,
+			       group->drg_tgt_cnt, group->drg_redundancy, k);
+			return false;
+		}
+
+		group = (void *)group + sizeof(*group) +
+			sizeof(uint32_t) * group->drg_tgt_cnt;
+	}
+
+	return true;
+}
+
 static int
 dtx_status_handle(struct dtx_resync_args *dra)
 {
@@ -137,6 +218,9 @@ dtx_status_handle(struct dtx_resync_args *dra)
 	struct dtx_resync_entry		*dre;
 	struct dtx_resync_entry		*next;
 	struct dtx_entry		*dte;
+	struct ds_pool			*pool = cont->sc_pool->spc_pool;
+	int				*tgt_array = NULL;
+	int				 tgt_cnt;
 	int				 count = 0;
 	int				 err = 0;
 	int				 rc;
@@ -144,18 +228,17 @@ dtx_status_handle(struct dtx_resync_args *dra)
 	if (drh->drh_count == 0)
 		goto out;
 
-	d_list_for_each_entry_safe(dre, next, &drh->drh_list, dre_link) {
-		if (dre->dre_dte.dte_mbs->dm_grp_cnt > 1) {
-			D_WARN("Not support to recover the DTX across more "
-			       "1 modification groups %d, skip it "DF_DTI"\n",
-			       dre->dre_dte.dte_mbs->dm_grp_cnt,
-			       DP_DTI(&dre->dre_xid));
-			dtx_dre_release(drh, dre);
-			continue;
-		}
+	tgt_cnt = pool_map_target_nr(pool->sp_map);
+	D_ASSERT(tgt_cnt != 0);
 
-		rc = ds_pool_check_leader(dra->po_uuid, &dre->dre_oid,
-					  dra->version);
+	D_ALLOC_ARRAY(tgt_array, tgt_cnt);
+	if (tgt_array == NULL)
+		D_GOTO(out, err = -DER_NOMEM);
+
+	d_list_for_each_entry_safe(dre, next, &drh->drh_list, dre_link) {
+		struct dtx_memberships	*mbs = dre->dre_dte.dte_mbs;
+
+		rc = dtx_is_leader(pool, dra, dre);
 		if (rc <= 0) {
 			if (rc < 0)
 				D_WARN("Not sure about the leader for the DTX "
@@ -169,13 +252,41 @@ dtx_status_handle(struct dtx_resync_args *dra)
 			continue;
 		}
 
-		rc = dtx_check(dra->po_uuid, cont->sc_uuid, &dre->dre_dte);
+		rc = dtx_check(cont, &dre->dre_dte, dre->dre_epoch);
 
-		/* The DTX has been committed or ready to be committed on
-		 * some remote replica(s), let's commit the DTX globally.
+		/* The DTX has been committed on some remote replica(s),
+		 * let's commit the DTX globally.
 		 */
-		if (rc == DTX_ST_COMMITTED || rc == DTX_ST_PREPARED)
+		if (rc == DTX_ST_COMMITTED)
 			goto commit;
+
+		if (rc == DTX_ST_PREPARED) {
+			/* If the transaction across multiple redundancy groups,
+			 * need to check whether there are enough alive targets.
+			 */
+			if (mbs->dm_grp_cnt > 1 &&
+			    !dtx_verify_groups(pool, mbs, &dre->dre_xid,
+					       tgt_array)) {
+				/* XXX: For the distributed transaction that
+				 *	lose too many particiants (the whole
+				 *	redundancy group), it's difficult to
+				 *	make decision whether commit or abort
+				 *	the DTX. we need more human knowledge
+				 *	to manually recover related things.
+				 *
+				 *	One possible TBD is that we can mark
+				 *	the DTX as 'failed' on related servers,
+				 *	that will fail subsequent accessing of
+				 *	related data directly without talk with
+				 *	the leader again.
+				 */
+
+				dtx_dre_release(drh, dre);
+				continue;
+			}
+
+			goto commit;
+		}
 
 		if (rc != -DER_NONEXIST) {
 			D_WARN("Not sure about whether the DTX "DF_DTI
@@ -221,8 +332,7 @@ dtx_status_handle(struct dtx_resync_args *dra)
 		 * abort the DTXs one by one, not batched.
 		 */
 		dte = &dre->dre_dte;
-		rc = dtx_abort(dra->po_uuid, cont->sc_uuid, dre->dre_epoch,
-			       &dte, 1);
+		rc = dtx_abort(cont, dre->dre_epoch, &dte, 1);
 		if (rc < 0)
 			err = rc;
 
@@ -231,7 +341,7 @@ dtx_status_handle(struct dtx_resync_args *dra)
 
 commit:
 		if (++count >= DTX_THRESHOLD_COUNT) {
-			rc = dtx_resync_commit(dra->po_uuid, cont, drh, count);
+			rc = dtx_resync_commit(cont, drh, count);
 			if (rc < 0)
 				err = rc;
 			count = 0;
@@ -239,16 +349,17 @@ commit:
 	}
 
 	if (count > 0) {
-		rc = dtx_resync_commit(dra->po_uuid, cont, drh, count);
+		rc = dtx_resync_commit(cont, drh, count);
 		if (rc < 0)
 			err = rc;
 	}
 
 out:
+	D_FREE(tgt_array);
+
 	if (err >= 0)
 		/* Drain old committable DTX to help subsequent rebuild. */
-		err = dtx_obj_sync(dra->po_uuid, cont->sc_uuid, cont,
-				   NULL, dra->epoch);
+		err = dtx_obj_sync(cont, NULL, dra->epoch);
 
 	return err;
 }
@@ -296,6 +407,7 @@ dtx_iter_cb(uuid_t co_uuid, vos_iter_entry_t *ent, void *args)
 	mbs->dm_grp_cnt = ent->ie_dtx_grp_cnt;
 	mbs->dm_data_size = ent->ie_dtx_mbs_dsize;
 	mbs->dm_flags = ent->ie_dtx_mbs_flags;
+	mbs->dm_dte_flags = ent->ie_dtx_flags;
 	memcpy(mbs->dm_data, ent->ie_dtx_mbs, ent->ie_dtx_mbs_dsize);
 
 	dte->dte_xid = ent->ie_dtx_xid;
@@ -348,7 +460,6 @@ dtx_resync(daos_handle_t po_hdl, uuid_t po_uuid, uuid_t co_uuid, uint32_t ver,
 	ABT_mutex_unlock(cont->sc_mutex);
 
 	dra.cont = cont;
-	uuid_copy(dra.po_uuid, po_uuid);
 	dra.version = ver;
 	dra.epoch = crt_hlc_get();
 	if (resync_all)

--- a/src/include/daos/dtx.h
+++ b/src/include/daos/dtx.h
@@ -137,8 +137,12 @@ struct dtx_memberships {
 	/* see dtx_mbs_flags. */
 	uint16_t			dm_flags;
 
-	/* For alignment. */
-	uint16_t			dm_padding;
+	union {
+		/* DTX entry flags during DTX recovery. */
+		uint16_t		dm_dte_flags;
+		/* For alignment. */
+		uint16_t		dm_padding;
+	};
 
 	/* The first 'sizeof(struct dtx_daos_target) * dm_tgt_cnt' is the
 	 * dtx_daos_target array. The subsequent are modification groups.

--- a/src/include/daos_srv/dtx_srv.h
+++ b/src/include/daos_srv/dtx_srv.h
@@ -195,8 +195,8 @@ int dtx_batched_commit_register(struct ds_cont_child *cont);
 
 void dtx_batched_commit_deregister(struct ds_cont_child *cont);
 
-int dtx_obj_sync(uuid_t po_uuid, uuid_t co_uuid, struct ds_cont_child *cont,
-		 daos_unit_oid_t *oid, daos_epoch_t epoch);
+int dtx_obj_sync(struct ds_cont_child *cont, daos_unit_oid_t *oid,
+		 daos_epoch_t epoch);
 
 /**
  * Check whether the given DTX is resent one or not.

--- a/src/include/daos_srv/pool.h
+++ b/src/include/daos_srv/pool.h
@@ -209,8 +209,8 @@ int ds_pool_iv_srv_hdl_fetch(struct ds_pool *pool, uuid_t *pool_hdl_uuid,
 
 int ds_pool_svc_term_get(uuid_t uuid, uint64_t *term);
 
-int ds_pool_check_leader(uuid_t pool_uuid, daos_unit_oid_t *oid,
-			 uint32_t version);
+int ds_pool_check_dtx_leader(struct ds_pool *pool, daos_unit_oid_t *oid,
+			     uint32_t version);
 
 int
 ds_pool_child_map_refresh_sync(struct ds_pool_child *dpc);

--- a/src/object/srv_obj.c
+++ b/src/object/srv_obj.c
@@ -3001,8 +3001,7 @@ ds_obj_sync_handler(crt_rpc_t *rpc)
 	if (rc != 0)
 		D_GOTO(out, rc);
 
-	rc = dtx_obj_sync(osi->osi_pool_uuid, osi->osi_co_uuid, ioc.ioc_coc,
-			  &osi->osi_oid, oso->oso_epoch);
+	rc = dtx_obj_sync(ioc.ioc_coc, &osi->osi_oid, oso->oso_epoch);
 
 out:
 	obj_reply_map_version_set(rpc, ioc.ioc_map_ver);


### PR DESCRIPTION
Enhance current DTX resync (recovery) logic to support distributed
transaction recovery. Mainly include:

1. The initial leader information is stored inside the DTX entry,
   Different from stand-alone modification, it is not calculated
   from the object layout. The DTX resync (recovery) logic needs
   to check whether the initial leader is still alive or not: if
   yes, then leave such DTX to be handled by the initial leader;
   otherwise, elect new leader as stand-alone modification case.

2. Redundancy group verification. A distributed transaction may
   touch many objects/keys that may cross multiple RDGs. During
   DTX recovery, if some RDG(s) lost too many members, then the
   DTX logic may not have enough knowledge to make the decision
   whether commit or abort related DTX.

Signed-off-by: Fan Yong <fan.yong@intel.com>