### PR TITLE
DAOS-6007 obj: fix bug for EC singv csum check

### DIFF
--- a/src/common/checksum.c
+++ b/src/common/checksum.c
@@ -666,7 +666,7 @@ calc_csum_sv(struct daos_csummer *obj, d_sg_list_t *sgl, size_t rec_len,
 			 * data cell possibly with less valid bytes, and
 			 * followed by parity cells.
 			 */
-			if (singv_idx < data_tgt_nr)
+			if (singv_lo->cs_cell_align || singv_idx < data_tgt_nr)
 				singv_off = singv_idx * singv_lo->cs_bytes;
 			else
 				singv_off = rec_len +

--- a/src/include/daos/checksum.h
+++ b/src/include/daos/checksum.h
@@ -71,7 +71,14 @@ struct dcs_layout {
 	/** targets number */
 	uint32_t	cs_nr;
 	/** even distribution flag */
-	uint32_t	cs_even_dist:1;
+	uint32_t	cs_even_dist:1,
+	/**
+	 * Align flag, used only for single value fetch that parity buffer's
+	 * location possibly not immediately following data buffer (to align
+	 * with cell size to avoid data movement in data recovery). For update
+	 * the data immediately followed by parity (this flag is zero).
+	 */
+			cs_cell_align:1;
 };
 
 struct daos_csummer {

--- a/src/object/cli_ec.c
+++ b/src/object/cli_ec.c
@@ -1286,7 +1286,7 @@ obj_ec_get_degrade(struct obj_reasb_req *reasb_req, uint16_t fail_tgt_idx,
 	uint32_t		 nerrs, i;
 	bool			 with_parity = false;
 
-	fail_info = obj_ec_fail_info_get(reasb_req, true, p);
+	fail_info = obj_ec_fail_info_get(reasb_req, true, k + p);
 	if (fail_info == NULL)
 		return -DER_NOMEM;
 
@@ -1880,20 +1880,20 @@ obj_ec_recov_codec_free(struct obj_reasb_req *reasb_req)
 }
 
 struct obj_ec_fail_info *
-obj_ec_fail_info_get(struct obj_reasb_req *reasb_req, bool create, uint16_t p)
+obj_ec_fail_info_get(struct obj_reasb_req *reasb_req, bool create, uint16_t nr)
 {
 	struct obj_ec_fail_info *fail_info = reasb_req->orr_fail;
 
 	if (fail_info != NULL || !create)
 		return fail_info;
 
-	D_ASSERT(p <= OBJ_EC_MAX_P);
+	D_ASSERT(nr <= OBJ_EC_MAX_M);
 	D_ALLOC_PTR(fail_info);
 	if (fail_info == NULL)
 		return NULL;
 	reasb_req->orr_fail = fail_info;
 
-	D_ALLOC_ARRAY(fail_info->efi_tgt_list, p);
+	D_ALLOC_ARRAY(fail_info->efi_tgt_list, nr);
 	if (fail_info->efi_tgt_list == NULL)
 		return NULL;
 

--- a/src/object/cli_shard.c
+++ b/src/object/cli_shard.c
@@ -263,6 +263,8 @@ dc_rw_cb_csum_verify(const struct rw_cb_args *rw_args)
 		}
 
 		singv_lo = (singv_los == NULL) ? NULL : &singv_los[i];
+		if (singv_lo != NULL)
+			singv_lo->cs_cell_align = 1;
 		rc = daos_csummer_verify_iod(csummer_copy, &shard_iod,
 					     &shard_sgl, iod_csum, singv_lo,
 					     shard_idx, map);


### PR DESCRIPTION
1. fix mem usage in obj_ec_fail_info
2. fix csum calculation for EC singv

Signed-off-by: Xuezhao Liu <xuezhao.liu@intel.com>