### PR TITLE
DAOS-1968 control: auto generate config file

### DIFF
--- a/doc/man/man8/dmg.8
+++ b/doc/man/man8/dmg.8
@@ -1,4 +1,4 @@
-.TH dmg 1 "22 October 2020"
+.TH dmg 1 "9 November 2020"
 .SH NAME
 dmg \- Administrative tool for managing DAOS clusters
 .SH SYNOPSIS
@@ -16,7 +16,7 @@ and access control settings, along with system wide operations.
 Allow proxy configuration via environment
 .TP
 \fB\fB\-l\fR, \fB\-\-host-list\fR\fP
-comma separated list of addresses <ipv4addr/hostname:port>
+comma separated list of addresses <ipv4addr/hostname>
 .TP
 \fB\fB\-i\fR, \fB\-\-insecure\fR\fP
 have dmg attempt to connect without certificates
@@ -47,6 +47,9 @@ Generate DAOS server configuration file based on discoverable hardware devices
 \fBAliases\fP: g
 
 .TP
+\fB\fB\-a\fR, \fB\-\-access-points\fR\fP
+Comma separated list of access point addresses <ipv4addr/hostname>
+.TP
 \fB\fB\-p\fR, \fB\-\-num-pmem\fR\fP
 Minimum number of SCM (pmem) devices required per storage host in DAOS system
 .TP
@@ -54,7 +57,7 @@ Minimum number of SCM (pmem) devices required per storage host in DAOS system
 Minimum number of NVMe devices required per storage host in DAOS system
 .TP
 \fB\fB\-c\fR, \fB\-\-net-class\fR <default: \fI"best-available"\fR>\fP
-Network class preferred, defaults to best available
+Network class preferred
 .SS cont
 Perform tasks related to DAOS containers
 

--- a/src/control/cmd/dmg/auto.go
+++ b/src/control/cmd/dmg/auto.go
@@ -29,6 +29,7 @@ import (
 	"gopkg.in/yaml.v2"
 
 	"github.com/daos-stack/daos/src/control/lib/control"
+	"github.com/daos-stack/daos/src/control/lib/netdetect"
 )
 
 // configCmd is the struct representing the top-level config subcommand.
@@ -44,7 +45,7 @@ type configGenCmd struct {
 	jsonOutputCmd
 	NumPmem  int    `short:"p" long:"num-pmem" description:"Minimum number of SCM (pmem) devices required per storage host in DAOS system"`
 	NumNvme  int    `short:"n" long:"num-nvme" description:"Minimum number of NVMe devices required per storage host in DAOS system"`
-	NetClass string `default:"best-available" short:"c" long:"net-class" description:"Network class preferred, defaults to best available" choice:"best-available" choice:"ethernet" choice:"infiniband"`
+	NetClass string `default:"best-available" short:"c" long:"net-class" description:"Network class preferred" choice:"best-available" choice:"ethernet" choice:"infiniband"`
 }
 
 // Execute is run when configGenCmd activates.
@@ -64,9 +65,11 @@ func (cmd *configGenCmd) Execute(_ []string) error {
 	}
 	switch cmd.NetClass {
 	case "ethernet":
-		req.NetClass = control.NetDevEther
+		req.NetClass = netdetect.Ether
 	case "infiniband":
-		req.NetClass = control.NetDevInfiniband
+		req.NetClass = netdetect.Infiniband
+	default:
+		req.NetClass = netdetect.NetDevAny
 	}
 
 	resp, err := control.ConfigGenerate(ctx, req)

--- a/src/control/cmd/dmg/auto.go
+++ b/src/control/cmd/dmg/auto.go
@@ -25,6 +25,7 @@ package main
 
 import (
 	"context"
+	"strings"
 
 	"gopkg.in/yaml.v2"
 
@@ -43,9 +44,10 @@ type configGenCmd struct {
 	ctlInvokerCmd
 	hostListCmd
 	jsonOutputCmd
-	NumPmem  int    `short:"p" long:"num-pmem" description:"Minimum number of SCM (pmem) devices required per storage host in DAOS system"`
-	NumNvme  int    `short:"n" long:"num-nvme" description:"Minimum number of NVMe devices required per storage host in DAOS system"`
-	NetClass string `default:"best-available" short:"c" long:"net-class" description:"Network class preferred" choice:"best-available" choice:"ethernet" choice:"infiniband"`
+	AccessPoints string `short:"a" long:"access-points" description:"Comma separated list of access point addresses <ipv4addr/hostname>"`
+	NumPmem      int    `short:"p" long:"num-pmem" description:"Minimum number of SCM (pmem) devices required per storage host in DAOS system"`
+	NumNvme      int    `short:"n" long:"num-nvme" description:"Minimum number of NVMe devices required per storage host in DAOS system"`
+	NetClass     string `default:"best-available" short:"c" long:"net-class" description:"Network class preferred" choice:"best-available" choice:"ethernet" choice:"infiniband"`
 }
 
 // Execute is run when configGenCmd activates.
@@ -70,6 +72,9 @@ func (cmd *configGenCmd) Execute(_ []string) error {
 		req.NetClass = netdetect.Infiniband
 	default:
 		req.NetClass = netdetect.NetDevAny
+	}
+	if cmd.AccessPoints != "" {
+		req.AccessPoints = strings.Split(cmd.AccessPoints, ",")
 	}
 
 	resp, err := control.ConfigGenerate(ctx, req)

--- a/src/control/cmd/dmg/auto.go
+++ b/src/control/cmd/dmg/auto.go
@@ -72,7 +72,7 @@ func (cmd *configGenCmd) Execute(_ []string) error {
 	case "infiniband":
 		req.NetClass = netdetect.Infiniband
 	default:
-		req.NetClass = netdetect.NetDevAny
+		req.NetClass = control.NetDevAny
 	}
 	if cmd.AccessPoints != "" {
 		req.AccessPoints = strings.Split(cmd.AccessPoints, ",")

--- a/src/control/cmd/dmg/auto_test.go
+++ b/src/control/cmd/dmg/auto_test.go
@@ -40,7 +40,7 @@ func TestDmg_ConfigCommands(t *testing.T) {
 			strings.Join([]string{
 				printRequest(t, &control.NetworkScanReq{}),
 			}, " "),
-			nil,
+			errors.New("no host responses"),
 		},
 		{
 			"Generate with minimum storage parameters",
@@ -48,7 +48,7 @@ func TestDmg_ConfigCommands(t *testing.T) {
 			strings.Join([]string{
 				printRequest(t, &control.NetworkScanReq{}),
 			}, " "),
-			nil,
+			errors.New("no host responses"),
 		},
 		{
 			"Generate with ethernet network device class",
@@ -56,7 +56,7 @@ func TestDmg_ConfigCommands(t *testing.T) {
 			strings.Join([]string{
 				printRequest(t, &control.NetworkScanReq{}),
 			}, " "),
-			nil,
+			errors.New("no host responses"),
 		},
 		{
 			"Generate with infiniband network device class",
@@ -64,7 +64,7 @@ func TestDmg_ConfigCommands(t *testing.T) {
 			strings.Join([]string{
 				printRequest(t, &control.NetworkScanReq{}),
 			}, " "),
-			nil,
+			errors.New("no host responses"),
 		},
 		{
 			"Generate with best-available network device class",
@@ -72,7 +72,7 @@ func TestDmg_ConfigCommands(t *testing.T) {
 			strings.Join([]string{
 				printRequest(t, &control.NetworkScanReq{}),
 			}, " "),
-			nil,
+			errors.New("no host responses"),
 		},
 		{
 			"Generate with unsupported network device class",

--- a/src/control/cmd/dmg/main.go
+++ b/src/control/cmd/dmg/main.go
@@ -153,7 +153,7 @@ func (c *cfgCmd) setConfig(cfg *control.Config) {
 
 type cliOptions struct {
 	AllowProxy     bool       `long:"allow-proxy" description:"Allow proxy configuration via environment"`
-	HostList       string     `short:"l" long:"host-list" description:"comma separated list of addresses <ipv4addr/hostname:port>"`
+	HostList       string     `short:"l" long:"host-list" description:"comma separated list of addresses <ipv4addr/hostname>"`
 	Insecure       bool       `short:"i" long:"insecure" description:"have dmg attempt to connect without certificates"`
 	Debug          bool       `short:"d" long:"debug" description:"enable debug output"`
 	JSON           bool       `short:"j" long:"json" description:"Enable JSON output"`

--- a/src/control/lib/control/auto.go
+++ b/src/control/lib/control/auto.go
@@ -306,11 +306,16 @@ func (req *ConfigGenerateReq) validateScmStorage(ctx context.Context, scmNamespa
 	}
 
 	// sanity check that each pmem aligns with expected numa node
+	var wantNodes, gotNodes []uint32
 	for idx := range pmemPaths {
 		ns := scmNamespaces[idx]
+		wantNodes = append(wantNodes, uint32(idx))
+		gotNodes = append(gotNodes, ns.NumaNode)
+
 		if int(ns.NumaNode) != idx {
-			return nil, errors.Errorf("unexpected numa node for %s, want %d got %d",
-				ns.BlockDevice, idx, ns.NumaNode)
+			return nil, errors.Errorf(
+				"pmem devices %v bound to unexpected numa nodes, want %v got %v",
+				pmemPaths, wantNodes, gotNodes)
 		}
 	}
 

--- a/src/control/lib/control/auto.go
+++ b/src/control/lib/control/auto.go
@@ -225,7 +225,7 @@ func (req *ConfigGenerateReq) checkNetwork(ctx context.Context) (*config.Server,
 	for _, iface := range networkSet.HostFabric.Interfaces {
 		msg = fmt.Sprintf("%s\n\t%+v", msg, iface)
 	}
-	req.Log.Infof(msg)
+	req.Log.Debugf(msg)
 
 	matching, complete := req.parseInterfaces(networkSet.HostFabric.Interfaces)
 	if !complete {
@@ -377,7 +377,7 @@ func (req *ConfigGenerateReq) checkStorage(ctx context.Context, cfg *config.Serv
 	scmNamespaces := storageSet.HostStorage.ScmNamespaces
 	nvmeControllers := storageSet.HostStorage.NvmeDevices
 
-	req.Log.Infof("Storage hardware configuration is consistent for hosts %s:\n\t%s\n\t%s",
+	req.Log.Debugf("Storage hardware configuration is consistent for hosts %s:\n\t%s\n\t%s",
 		storageSet.HostSet.String(), scmNamespaces.Summary(), nvmeControllers.Summary())
 
 	// the pmemPaths is a slice of pmem block devices each pinned to NUMA

--- a/src/control/lib/control/auto.go
+++ b/src/control/lib/control/auto.go
@@ -307,9 +307,10 @@ func (req *ConfigGenerateReq) validateScmStorage(ctx context.Context, scmNamespa
 
 	// sanity check that each pmem aligns with expected numa node
 	for idx := range pmemPaths {
-		if int(scmNamespaces[idx].NumaNode) != idx {
-			return nil, errors.Errorf("unexpected numa node for scm %+v, want %d",
-				scmNamespaces[idx], idx)
+		ns := scmNamespaces[idx]
+		if int(ns.NumaNode) != idx {
+			return nil, errors.Errorf("unexpected numa node for %s, want %d got %d",
+				ns.BlockDevice, idx, ns.NumaNode)
 		}
 	}
 
@@ -330,7 +331,7 @@ func (req *ConfigGenerateReq) validateNvmeStorage(ctrlrs storage.NvmeControllers
 	for _, ctrlr := range ctrlrs {
 		if int(ctrlr.SocketID) > (numaCount - 1) {
 			req.Log.Debugf(
-				"skipping nvme device %s with numa %d (in use numa count is %d)",
+				"skipping nvme device %s with numa %d (currently using %d numa nodes)",
 				ctrlr.PciAddr, ctrlr.SocketID, numaCount)
 			continue
 		}

--- a/src/control/lib/control/auto_test.go
+++ b/src/control/lib/control/auto_test.go
@@ -79,6 +79,7 @@ func TestControl_AutoConfig_checkStorage(t *testing.T) {
 	hostRespOneWithScmNs := dualHostResp("withNamespace", "standard")
 	hostRespWithScmNs := dualHostRespSame("withNamespace")
 	hostRespWithScmNss := dualHostRespSame("withNamespaces")
+	hostRespWithScmNssNumaZero := dualHostRespSame("withNamespacesNumaZero")
 	hostRespWithSingleSSD := dualHostRespSame("withSingleSSD")
 	hostRespWithSSDs := dualHostRespSame("withSpaceUsage")
 
@@ -136,6 +137,11 @@ func TestControl_AutoConfig_checkStorage(t *testing.T) {
 			numPmem:       2,
 			hostResponses: hostRespWithScmNss,
 			expCheckErr:   errors.New("insufficient number of nvme devices for numa node 0, want 1 got 0"),
+		},
+		"2 min pmem and 2 pmems present both numa 0": {
+			numPmem:       2,
+			hostResponses: hostRespWithScmNssNumaZero,
+			expCheckErr:   errors.New("bound to unexpected numa nodes"),
 		},
 		"no min nvme and 1 ctrlr present on 1 numa node": {
 			numPmem:       2,

--- a/src/control/lib/control/mocks.go
+++ b/src/control/lib/control/mocks.go
@@ -289,6 +289,16 @@ func MockServerScanResp(t *testing.T, variant string) *ctlpb.StorageScanResp {
 		if err := convert.Types(scmNamespaces, &ssr.Scm.Namespaces); err != nil {
 			t.Fatal(err)
 		}
+	case "withNamespacesNumaZero":
+		ns1 := storage.MockScmNamespace(1)
+		ns1.NumaNode = 0
+		scmNamespaces := storage.ScmNamespaces{
+			ns1,
+			storage.MockScmNamespace(0),
+		}
+		if err := convert.Types(scmNamespaces, &ssr.Scm.Namespaces); err != nil {
+			t.Fatal(err)
+		}
 	case "withSingleSSD":
 		scmNamespaces := storage.ScmNamespaces{
 			storage.MockScmNamespace(0),

--- a/src/control/lib/netdetect/netdetect.go
+++ b/src/control/lib/netdetect/netdetect.go
@@ -122,7 +122,6 @@ import (
 	"context"
 	"fmt"
 	"io/ioutil"
-	"math"
 	"net"
 	"strconv"
 	"strings"
@@ -161,8 +160,6 @@ const (
 	IEEE1394   = 24
 	Eui64      = 27
 	Infiniband = 32
-	// NetDevAny matches any class
-	NetDevAny = math.MaxUint32
 )
 
 // DeviceAffinity describes the essential details of a device and its NUMA affinity
@@ -1306,8 +1303,6 @@ func DevClassName(class uint32) string {
 		return "EUI64"
 	case Infiniband:
 		return "INFINIBAND"
-	case NetDevAny:
-		return "best-available"
 	default:
 		return "UNKNOWN"
 	}

--- a/src/control/lib/netdetect/netdetect.go
+++ b/src/control/lib/netdetect/netdetect.go
@@ -122,6 +122,7 @@ import (
 	"context"
 	"fmt"
 	"io/ioutil"
+	"math"
 	"net"
 	"strconv"
 	"strings"
@@ -160,6 +161,8 @@ const (
 	IEEE1394   = 24
 	Eui64      = 27
 	Infiniband = 32
+	// NetDevAny matches any class
+	NetDevAny = math.MaxUint32
 )
 
 // DeviceAffinity describes the essential details of a device and its NUMA affinity
@@ -1303,6 +1306,8 @@ func DevClassName(class uint32) string {
 		return "EUI64"
 	case Infiniband:
 		return "INFINIBAND"
+	case NetDevAny:
+		return "best-available"
 	default:
 		return "UNKNOWN"
 	}


### PR DESCRIPTION
Updates to initial implementation:
- remove duplicate NetDevClass consts and instead import from netdetect
- refactor auto config logic for clarity and improve comments
- display Info on host errors in tabular form
- take access points on the dmg config generate commandline

Signed-off-by: Tom Nabarro <tom.nabarro@intel.com>