### PR TITLE
DAOS-5992 test: fix mdtest dfuse dir to add a '/'

### DIFF
--- a/src/tests/ftest/aggregation/dfuse_space_check.yaml
+++ b/src/tests/ftest/aggregation/dfuse_space_check.yaml
@@ -25,4 +25,4 @@ container:
 dfusespacecheck:
   block_size: 2097152
 dfuse:
-  mount_dir: "/tmp/daos_dfuse"
+  mount_dir: "/tmp/daos_dfuse/"

--- a/src/tests/ftest/datamover/container_copy.yaml
+++ b/src/tests/ftest/datamover/container_copy.yaml
@@ -59,7 +59,7 @@ mdtest:
   bytes: 4096
   depth: 0
 dfuse:
-  mount_dir: "/tmp/daos_dfuse"
+  mount_dir: "/tmp/daos_dfuse/"
 datamover:
   src_path: "/"
   dest_path: "/"

--- a/src/tests/ftest/io/dfuse_sparse_file.yaml
+++ b/src/tests/ftest/io/dfuse_sparse_file.yaml
@@ -23,4 +23,4 @@ container:
   type: POSIX
   control_method: daos
 dfuse:
-  mount_dir: "/tmp/daos_dfuse"
+  mount_dir: "/tmp/daos_dfuse/"

--- a/src/tests/ftest/io/ior_hdf5.yaml
+++ b/src/tests/ftest/io/ior_hdf5.yaml
@@ -45,5 +45,5 @@ ior:
       transfer_size: '1M'
       block_size: '6G'
 dfuse:
-    mount_dir: "/tmp/daos_dfuse"
+    mount_dir: "/tmp/daos_dfuse/"
 

--- a/src/tests/ftest/io/ior_intercept_basic.yaml
+++ b/src/tests/ftest/io/ior_intercept_basic.yaml
@@ -51,4 +51,4 @@ ior:
             oclass_SX:
               dfs_oclass: "SX"
 dfuse:
-    mount_dir: "/tmp/daos_dfuse"
+    mount_dir: "/tmp/daos_dfuse/"

--- a/src/tests/ftest/io/ior_intercept_dfuse_mix.yaml
+++ b/src/tests/ftest/io/ior_intercept_dfuse_mix.yaml
@@ -42,4 +42,4 @@ ior:
           read_x: 1
           dfs_oclass: "SX"
 dfuse:
-    mount_dir: "/tmp/daos_dfuse"
+    mount_dir: "/tmp/daos_dfuse/"

--- a/src/tests/ftest/io/ior_intercept_multi_client.yaml
+++ b/src/tests/ftest/io/ior_intercept_multi_client.yaml
@@ -59,4 +59,4 @@ ior:
               write_x: 3
               read_x: 1
 dfuse:
-    mount_dir: "/tmp/daos_dfuse"
+    mount_dir: "/tmp/daos_dfuse/"

--- a/src/tests/ftest/io/ior_intercept_verify_data_integrity.yaml
+++ b/src/tests/ftest/io/ior_intercept_verify_data_integrity.yaml
@@ -53,4 +53,4 @@ ior:
           fpp:
             flags: "-F -k -e -D 600 -v -w -W -r -R"
 dfuse:
-    mount_dir: "/tmp/daos_dfuse"
+    mount_dir: "/tmp/daos_dfuse/"

--- a/src/tests/ftest/io/ior_large.yaml
+++ b/src/tests/ftest/io/ior_large.yaml
@@ -96,4 +96,4 @@ ior:
     2-way_Replication:
       dfs_oclass: "RP_2GX"
 dfuse:
-    mount_dir: "/tmp/daos_dfuse"
+    mount_dir: "/tmp/daos_dfuse/"

--- a/src/tests/ftest/io/ior_small.yaml
+++ b/src/tests/ftest/io/ior_small.yaml
@@ -63,6 +63,6 @@ ior:
 # Commenting it out until DAOS-3097/3143 is resolved.
 #            - "RP_2GX"
 dfuse:
-    mount_dir: "/tmp/daos_dfuse"
+    mount_dir: "/tmp/daos_dfuse/"
 hdf5_vol:
     plugin_path: /usr/lib64/mpich/lib

--- a/src/tests/ftest/io/macsio_test.yaml
+++ b/src/tests/ftest/io/macsio_test.yaml
@@ -50,4 +50,4 @@ mpi: !mux
     macsio_path: /usr/lib64/openmpi3/bin
     plugin_path: /usr/lib64/openmpi3/lib
 dfuse:
-  mount_dir: "/tmp/daos_dfuse"
+  mount_dir: "/tmp/daos_dfuse/"

--- a/src/tests/ftest/io/mdtest_large.yaml
+++ b/src/tests/ftest/io/mdtest_large.yaml
@@ -93,4 +93,4 @@ mdtest:
       read_bytes: 32000
       depth: 0
 dfuse:
-  mount_dir: "/tmp/daos_dfuse"
+  mount_dir: "/tmp/daos_dfuse/"

--- a/src/tests/ftest/io/mdtest_small.yaml
+++ b/src/tests/ftest/io/mdtest_small.yaml
@@ -48,4 +48,4 @@ mdtest:
     - [POSIX, 0, 0, 2, 10, 5, '-u']
 
 dfuse:
-  mount_dir: "/tmp/daos_dfuse"
+  mount_dir: "/tmp/daos_dfuse/"

--- a/src/tests/ftest/io/mdtest_small.yaml
+++ b/src/tests/ftest/io/mdtest_small.yaml
@@ -7,7 +7,7 @@ hosts:
   test_clients:
     - client-E
     - client-F
-timeout: 305
+timeout: 605
 server_config:
   name: daos_server
   transport_config:

--- a/src/tests/ftest/io/parallel_io.yaml
+++ b/src/tests/ftest/io/parallel_io.yaml
@@ -51,4 +51,4 @@ ior:
         oclass_SX:
           dfs_oclass: "SX"
 dfuse:
-  mount_dir: "/tmp/daos_dfuse"
+  mount_dir: "/tmp/daos_dfuse/"

--- a/src/tests/ftest/soak/soak_smoke.yaml
+++ b/src/tests/ftest/soak/soak_smoke.yaml
@@ -135,7 +135,7 @@ fio_smoke:
       - global
       - test
   global:
-    directory: "/tmp/daos_dfuse"
+    directory: "/tmp/daos_dfuse/"
     ioengine: 'libaio'
     thread: 1
     group_reporting: 1
@@ -153,7 +153,7 @@ fio_smoke:
         - 'rw'
         - 'randrw'
 dfuse:
-    mount_dir: "/tmp/daos_dfuse"
+    mount_dir: "/tmp/daos_dfuse/"
     disable_direct_io: True
 hdf5_vol:
     plugin_path: "/usr/lib64/mpich/lib"

--- a/src/tests/ftest/soak/soak_stress_2h.yaml
+++ b/src/tests/ftest/soak/soak_stress_2h.yaml
@@ -138,7 +138,7 @@ fio_stress:
     - global
     - test
   global:
-    directory: "/tmp/daos_dfuse"
+    directory: "/tmp/daos_dfuse/"
     ioengine: 'libaio'
     thread: 1
     group_reporting: 1
@@ -158,6 +158,6 @@ fio_stress:
         - 'rw'
         - 'randrw'
 dfuse:
-  mount_dir: "/tmp/daos_dfuse"
+  mount_dir: "/tmp/daos_dfuse/"
   disable_direct_io: True
 

--- a/src/tests/ftest/soak/soak_stress_48h.yaml
+++ b/src/tests/ftest/soak/soak_stress_48h.yaml
@@ -136,7 +136,7 @@ fio_stress:
     - global
     - test
   global:
-    directory: "/tmp/daos_dfuse"
+    directory: "/tmp/daos_dfuse/"
     ioengine: 'libaio'
     thread: 1
     group_reporting: 1
@@ -156,7 +156,7 @@ fio_stress:
         - 'rw'
         - 'randrw'
 dfuse:
-    mount_dir: "/tmp/daos_dfuse"
+    mount_dir: "/tmp/daos_dfuse/"
     disable_direct_io: True
 hdf5_vol:
     plugin_path: "/usr/lib64/mpich/lib"


### PR DESCRIPTION
this is an IOR/mdtest issue where it doesn't parse the dir where the test should
start properly. parsing /tmp/dfuse fails, whereas /tmp/dfuse/ works.

Signed-off-by: Mohamad Chaarawi <mohamad.chaarawi@intel.com>