### PR TITLE
DAOS-5896 tests: add 6 server check for DFS EC test

### DIFF
--- a/src/tests/suite/dfs_test.c
+++ b/src/tests/suite/dfs_test.c
@@ -879,6 +879,11 @@ dfs_test_hole_mgmt(void **state)
 static void
 dfs_test_ec_short_read(void **state)
 {
+	test_arg_t	*arg = *state;
+
+	if (!test_runable(arg, 6))
+		return;
+
 	/* less than 1 EC stripe */
 	dfs_test_short_read_internal(state, DAOS_OC_EC_K4P2_L32K,
 				     32 * 1024 * 8, 2000);


### PR DESCRIPTION
Add 6 server check for DFS EC test.

Signed-off-by: Di Wang <di.wang@intel.com>