### PR TITLE
DAOS-5971 security: Add ACL output stream print func

### DIFF
--- a/src/common/acl_util.c
+++ b/src/common/acl_util.c
@@ -918,3 +918,81 @@ daos_acl_to_strs(struct daos_acl *acl, char ***ace_strs, size_t *ace_nr)
 
 	return 0;
 }
+
+#define D_FPRINTF(...)							\
+	({								\
+		size_t	printed = fprintf(__VA_ARGS__);			\
+		int	tmp_rc = 0;					\
+									\
+		if (printed < 0) {					\
+			D_ERROR("failed to print to stream\n");		\
+			tmp_rc = -DER_IO;				\
+		}							\
+		tmp_rc;							\
+	})
+
+static int
+verbose_str_to_stream(FILE *stream, const char *ace_str)
+{
+	char	verbose_str[DAOS_ACL_MAX_ACE_STR_LEN * 2];
+	int	rc;
+
+	rc = daos_ace_str_get_verbose(ace_str, verbose_str, 
+				      sizeof(verbose_str));
+	/* String may have been truncated - that's OK */
+	if (rc != 0 && rc != -DER_TRUNC) {
+		D_ERROR("failed verbose translation for ACE string '%s': %d\n",
+			ace_str, rc);
+		return rc;
+	}
+
+	return D_FPRINTF(stream, "# %s\n", verbose_str);
+}
+
+int
+daos_acl_to_stream(FILE *stream, struct daos_acl *acl, bool verbose)
+{
+	int	rc = 0;
+	char	**aces = NULL;
+	size_t	aces_nr, i;
+
+	if (stream == NULL) {
+		D_ERROR("Invalid stream\n");
+		return -DER_INVAL;
+	}
+
+	if (acl != NULL) {
+		rc = daos_acl_to_strs(acl, &aces, &aces_nr);
+		if (rc != 0)
+			return rc;
+	}
+
+	rc = D_FPRINTF(stream, "# Entries:\n");
+	if (rc != 0)
+		goto out;
+
+	if (acl == NULL || acl->dal_len == 0) {
+		rc = D_FPRINTF(stream, "#   None\n");
+		goto out;
+	}
+
+	for (i = 0; i < aces_nr; i++) {
+		if (verbose) {
+			rc = verbose_str_to_stream(stream, aces[i]);
+			if (rc != 0)
+				goto out;
+		}
+		
+		rc = D_FPRINTF(stream, "%s\n", aces[i]);
+		if (rc != 0)
+			goto out;
+	}
+
+out:
+	if (aces != NULL) {
+		free_strings(aces, aces_nr);
+		D_FREE(aces);
+	}
+	
+	return rc;
+}

--- a/src/common/acl_util.c
+++ b/src/common/acl_util.c
@@ -937,7 +937,7 @@ verbose_str_to_stream(FILE *stream, const char *ace_str)
 	char	verbose_str[DAOS_ACL_MAX_ACE_STR_LEN * 2];
 	int	rc;
 
-	rc = daos_ace_str_get_verbose(ace_str, verbose_str, 
+	rc = daos_ace_str_get_verbose(ace_str, verbose_str,
 				      sizeof(verbose_str));
 	/* String may have been truncated - that's OK */
 	if (rc != 0 && rc != -DER_TRUNC) {
@@ -982,7 +982,6 @@ daos_acl_to_stream(FILE *stream, struct daos_acl *acl, bool verbose)
 			if (rc != 0)
 				goto out;
 		}
-		
 		rc = D_FPRINTF(stream, "%s\n", aces[i]);
 		if (rc != 0)
 			goto out;
@@ -993,6 +992,5 @@ out:
 		free_strings(aces, aces_nr);
 		D_FREE(aces);
 	}
-	
 	return rc;
 }

--- a/src/common/acl_util.c
+++ b/src/common/acl_util.c
@@ -919,18 +919,6 @@ daos_acl_to_strs(struct daos_acl *acl, char ***ace_strs, size_t *ace_nr)
 	return 0;
 }
 
-#define D_FPRINTF(...)							\
-	({								\
-		size_t	printed = fprintf(__VA_ARGS__);			\
-		int	tmp_rc = 0;					\
-									\
-		if (printed < 0) {					\
-			D_ERROR("failed to print to stream\n");		\
-			tmp_rc = -DER_IO;				\
-		}							\
-		tmp_rc;							\
-	})
-
 static int
 verbose_str_to_stream(FILE *stream, const char *ace_str)
 {

--- a/src/common/tests/acl_util_tests.c
+++ b/src/common/tests/acl_util_tests.c
@@ -1004,6 +1004,122 @@ test_ace_str_to_verbose_truncated(void **state)
 	assert_string_equal(result, "Allow::user@:");
 }
 
+static void
+test_acl_to_stream_bad_stream(void **state)
+{
+	struct daos_acl *valid_acl = daos_acl_create(NULL, 0);
+
+	assert_int_equal(daos_acl_to_stream(NULL, valid_acl, false),
+			 -DER_INVAL);
+
+	daos_acl_free(valid_acl);
+}
+
+static void
+assert_stream_written(FILE *stream, const char *exp_str)
+{
+	char	result[DAOS_ACL_MAX_ACE_STR_LEN];
+	char	*exp_str_mutable;
+	char	*pch;
+
+	/* Arbitrary max size - these are just tests, after all */
+	D_STRNDUP(exp_str_mutable, exp_str, DAOS_ACL_MAX_ACE_STR_LEN * 5);
+	assert_non_null(exp_str_mutable);
+
+	rewind(stream);
+
+	/* Check line by line */
+	pch = strtok(exp_str_mutable, "\n");
+	while (pch != NULL) {
+		char *end;
+
+		memset(result, 0, sizeof(result));
+		assert_non_null(fgets(result, sizeof(result), stream));
+
+		/* trim result to match the line from exp_str */
+		end = strpbrk(result, "\n");
+		assert_non_null(end);
+		*end = '\0';
+
+		assert_string_equal(result, pch);
+
+		pch = strtok(NULL, "\n");
+	}
+
+	/* Should be no more output in stream */
+	assert_null(fgets(result, sizeof(result), stream));
+
+	D_FREE(exp_str_mutable);
+}
+
+static void
+add_ace_allow(struct daos_acl **acl, enum daos_acl_principal_type type, 
+	      const char *principal, uint64_t perms)
+{
+	struct daos_ace *ace = daos_ace_create(type, principal);
+
+	assert_non_null(ace);
+	ace->dae_access_types = DAOS_ACL_ACCESS_ALLOW;
+	ace->dae_allow_perms = perms;
+	assert_int_equal(daos_acl_add_ace(acl, ace), 0);
+
+	daos_ace_free(ace);
+}
+
+static void
+test_acl_to_stream_success(void **state)
+{
+	FILE		*tmpstream = tmpfile();
+	struct daos_acl	*acl = daos_acl_create(NULL, 0);
+	const char	*exp_empty_str = "# Entries:\n"
+					 "#   None\n";
+
+	assert_non_null(acl); /* sanity check */
+
+	printf("= NULL ACL\n");
+	assert_int_equal(daos_acl_to_stream(tmpstream, NULL, false), 0);
+	assert_stream_written(tmpstream, exp_empty_str);
+
+	rewind(tmpstream);
+
+	printf("= Empty ACL\n");
+	assert_int_equal(daos_acl_to_stream(tmpstream, acl, false), 0);
+	assert_stream_written(tmpstream, exp_empty_str);
+
+	rewind(tmpstream);
+
+	printf("= Empty ACL (verbose)\n");
+	assert_int_equal(daos_acl_to_stream(tmpstream, acl, true), 0);
+	assert_stream_written(tmpstream, exp_empty_str);
+
+	rewind(tmpstream);
+
+	printf("= ACL with entries\n");
+	add_ace_allow(&acl, DAOS_ACL_OWNER, NULL, DAOS_ACL_PERM_CONT_ALL);
+	add_ace_allow(&acl, DAOS_ACL_GROUP, "readers@", DAOS_ACL_PERM_READ);
+	assert_int_equal(daos_acl_to_stream(tmpstream, acl, false), 0);
+	assert_stream_written(tmpstream,
+			      "# Entries:\n"
+			      "A::OWNER@:rwdtTaAo\n"
+			      "A:G:readers@:r\n");
+
+	rewind(tmpstream);
+
+	printf("= ACL with entries (verbose)\n");
+	assert_int_equal(daos_acl_to_stream(tmpstream, acl, true), 0);
+	assert_stream_written(tmpstream,
+			      "# Entries:\n"
+			      "# Allow::Owner:Read/Write/Delete-Container/"
+			      "Get-Prop/Set-Prop/Get-ACL/Set-ACL/Set-Owner\n"
+			      "A::OWNER@:rwdtTaAo\n"
+			      "# Allow:Group:readers@:Read\n"
+			      "A:G:readers@:r\n");
+	
+	fclose(tmpstream);
+
+	daos_acl_free(acl);
+}
+
 int
 main(void)
 {
@@ -1057,6 +1173,8 @@ main(void)
 		cmocka_unit_test(test_ace_str_to_verbose_invalid),
 		cmocka_unit_test(test_ace_str_to_verbose_valid),
 		cmocka_unit_test(test_ace_str_to_verbose_truncated),
+		cmocka_unit_test(test_acl_to_stream_bad_stream),
+		cmocka_unit_test(test_acl_to_stream_success),
 	};
 
 	return cmocka_run_group_tests(tests, NULL, NULL);

--- a/src/common/tests/acl_util_tests.c
+++ b/src/common/tests/acl_util_tests.c
@@ -1053,7 +1053,7 @@ assert_stream_written(FILE *stream, const char *exp_str)
 }
 
 static void
-add_ace_allow(struct daos_acl **acl, enum daos_acl_principal_type type, 
+add_ace_allow(struct daos_acl **acl, enum daos_acl_principal_type type,
 	      const char *principal, uint64_t perms)
 {
 	struct daos_ace *ace = daos_ace_create(type, principal);
@@ -1114,7 +1114,6 @@ test_acl_to_stream_success(void **state)
 			      "A::OWNER@:rwdtTaAo\n"
 			      "# Allow:Group:readers@:Read\n"
 			      "A:G:readers@:r\n");
-	
 	fclose(tmpstream);
 
 	daos_acl_free(acl);

--- a/src/include/daos_security.h
+++ b/src/include/daos_security.h
@@ -34,6 +34,7 @@
 extern "C" {
 #endif
 
+#include <stdio.h>
 #include <stdint.h>
 #include <stdbool.h>
 #include <sys/types.h>
@@ -328,7 +329,8 @@ daos_acl_remove_ace(struct daos_acl **acl,
 		    const char *principal_name);
 
 /**
- * Print the Access Control List to stdout in a human-readable format.
+ * Print the Access Control List to stdout in a detailed human-readable format,
+ * for debug purposes.
  *
  * \param	acl	Access Control List to print
  */
@@ -624,6 +626,21 @@ int
 daos_acl_principal_from_str(const char *principal_str,
 			    enum daos_acl_principal_type *type,
 			    char **name);
+
+/**
+ * Print the Access Control List to a stream in the ACL file format.
+ *
+ * \param[in]	stream	Open stream to which the ACL should be printed
+ * \param[in]	acl	Access Control List to print
+ * \param[in]	verbose	Include verbose comment for each ACE in output
+ *
+ * \return	0		Success
+ *		-DER_INVAL	Invalid input
+ *		-DER_NOMEM	Could not allocate memory
+ *		-DER_IO		Failed to write to stream
+ */
+int
+daos_acl_to_stream(FILE *stream, struct daos_acl *acl, bool verbose);
 
 #if defined(__cplusplus)
 }

--- a/src/include/gurt/common.h
+++ b/src/include/gurt/common.h
@@ -211,6 +211,18 @@ extern "C" {
 		goto label;			\
 	} while (0)
 
+#define D_FPRINTF(...)							\
+	({								\
+		int	printed = fprintf(__VA_ARGS__);			\
+		int	_rc = 0;					\
+									\
+		if (printed < 0) {					\
+			D_ERROR("failed to print to stream\n");		\
+			_rc = -DER_IO;					\
+		}							\
+		_rc;							\
+	})
+
 /* Internal helper macros, not to be called directly by the outside caller */
 #define __D_PTHREAD(fn, x)						\
 	({								\

--- a/src/utils/daos_hdlr.c
+++ b/src/utils/daos_hdlr.c
@@ -1551,7 +1551,7 @@ print_acl(FILE *outstream, daos_prop_t *acl_prop, bool verbose)
 
 	rc = daos_acl_to_stream(outstream, acl, verbose);
 	if (rc != 0) {
-		fprintf(stderr, "failed to print ACL: %s (%d)\n", 
+		fprintf(stderr, "failed to print ACL: %s (%d)\n",
 			d_errstr(rc), rc);
 	}
 


### PR DESCRIPTION
- Add new public API function daos_acl_to_stream, which
  prints the ACL to an output stream of the caller's choice
  in the DAOS ACL file/display format.
- Update daos tool to use the new API to print ACLs.

Signed-off-by: Kris Jacque <kristin.jacque@intel.com>