### PR TITLE
DAOS-6017 dfuse: Add the default-permissions option.

### DIFF
--- a/src/client/dfuse/dfuse.h
+++ b/src/client/dfuse/dfuse.h
@@ -332,7 +332,7 @@ struct fuse_lowlevel_ops *dfuse_get_fuse_ops();
 #define DFUSE_REPLY_ATTR(ie, req, attr)					\
 	do {								\
 		int __rc;						\
-		DFUSE_TRA_DEBUG(ie, "Returning attr mode %#x dir:%d",	\
+		DFUSE_TRA_DEBUG(ie, "Returning attr mode %#o dir:%d",	\
 				(attr)->st_mode,			\
 				S_ISDIR(((attr)->st_mode)));		\
 		__rc = fuse_reply_attr(req, attr,			\
@@ -427,7 +427,7 @@ struct fuse_lowlevel_ops *dfuse_get_fuse_ops();
 	do {								\
 		int __rc;						\
 		DFUSE_TRA_DEBUG(desc,					\
-				"Returning entry inode %li mode %#x dir:%d", \
+				"Returning entry inode %li mode %#o dir:%d", \
 				(entry).attr.st_ino,			\
 				(entry).attr.st_mode,			\
 				S_ISDIR((entry).attr.st_mode));		\

--- a/src/client/dfuse/dfuse_core.c
+++ b/src/client/dfuse/dfuse_core.c
@@ -297,7 +297,7 @@ dfuse_start(struct dfuse_info *dfuse_info, struct dfuse_dfs *dfs)
 
 	atomic_store_relaxed(&fs_handle->dpi_ino_next, 2);
 
-	args.argc = 4;
+	args.argc = 5;
 
 	/* These allocations are freed later by libfuse so do not use the
 	 * standard allocation macros
@@ -323,6 +323,10 @@ dfuse_start(struct dfuse_info *dfuse_info, struct dfuse_dfs *dfs)
 	if (rc < 0 || !args.argv[3])
 		D_GOTO(err_irt, rc = -DER_NOMEM);
 
+	args.argv[4] = strndup("-odefault_permissions", 32);
+	if (!args.argv[4])
+		D_GOTO(err_irt, rc = -DER_NOMEM);
+
 	fuse_ops = dfuse_get_fuse_ops();
 	if (!fuse_ops)
 		D_GOTO(err_irt, rc = -DER_NOMEM);
@@ -340,6 +344,8 @@ dfuse_start(struct dfuse_info *dfuse_info, struct dfuse_dfs *dfs)
 	ie->ie_parent = 1;
 	atomic_store_relaxed(&ie->ie_ref, 1);
 	ie->ie_stat.st_ino = 1;
+	ie->ie_stat.st_uid = geteuid();
+	ie->ie_stat.st_gid = getegid();
 	ie->ie_stat.st_mode = 0700 | S_IFDIR;
 	dfs->dfs_root = ie->ie_stat.st_ino;
 

--- a/src/client/dfuse/ops/setattr.c
+++ b/src/client/dfuse/ops/setattr.c
@@ -34,7 +34,7 @@ dfuse_cb_setattr(fuse_req_t req, struct dfuse_inode_entry *ie,
 	DFUSE_TRA_DEBUG(ie, "flags %#x", to_set);
 
 	if (to_set & FUSE_SET_ATTR_MODE) {
-		DFUSE_TRA_DEBUG(ie, "mode %#x %#x",
+		DFUSE_TRA_DEBUG(ie, "mode %#o %#o",
 				attr->st_mode, ie->ie_stat.st_mode);
 
 		to_set &= ~FUSE_SET_ATTR_MODE;


### PR DESCRIPTION
Change the way mode flags are logged so they're easier to read.

Set the root inode to be owned by the current user so it's accessible.
This should ideally inherit ownership through the function table but there is
no generic ->stat() callback so that will need a minor rewrite and
everything else is using hardcoded uid/gids currently so I can address this
at the same time.

Signed-off-by: Ashley Pittman <ashley.m.pittman@intel.com>