### PR TITLE
DAOS-5554 dtx: DTX entry on server for read only operation

### DIFF
--- a/src/include/daos_srv/vos.h
+++ b/src/include/daos_srv/vos.h
@@ -55,6 +55,15 @@ void
 vos_dtx_rsrvd_fini(struct dtx_handle *dth);
 
 /**
+ * Generate DTX entry for the given DTX. It is usually used for read
+ * only TX or on the server that only contains read sub operations.
+ *
+ * \param dth	[IN]	The dtx handle
+ */
+int
+vos_dtx_pin(struct dtx_handle *dth);
+
+/**
  * Check the specified DTX's status, and related epoch, pool map version
  * information if required.
  *

--- a/src/object/srv_obj.c
+++ b/src/object/srv_obj.c
@@ -3502,6 +3502,12 @@ out:
 	D_FREE(biods);
 	D_FREE(bulks);
 
+	if (rc == 0 && dth->dth_modification_cnt == 0)
+		/* For the case of only containing read sub operations,
+		 * we will generate DTX entry for DTX recovery.
+		 */
+		rc = vos_dtx_pin(dth);
+
 	return rc;
 }
 

--- a/src/vos/vos_dtx.c
+++ b/src/vos/vos_dtx.c
@@ -2276,6 +2276,39 @@ vos_dtx_cleanup(struct dtx_handle *dth)
 		vos_obj_evict_by_oid(vos_obj_cache_current(), cont, oids[i]);
 }
 
+int
+vos_dtx_pin(struct dtx_handle *dth)
+{
+	struct vos_container	*cont;
+	struct umem_instance	*umm;
+	int			 rc;
+
+	D_ASSERT(dtx_is_valid_handle(dth));
+	D_ASSERT(dth->dth_ent == NULL);
+
+	if (dth->dth_solo)
+		return 0;
+
+	cont = vos_hdl2cont(dth->dth_coh);
+	D_ASSERT(cont != NULL);
+
+	umm = vos_cont2umm(cont);
+	rc = vos_dtx_alloc(umm, dth);
+	if (rc != 0)
+		return rc;
+
+	rc = umem_tx_begin(umm, NULL);
+	if (rc == 0) {
+		rc = vos_dtx_prepared(dth);
+		rc = umem_tx_end(umm, rc);
+	}
+
+	if (rc != 0)
+		vos_dtx_cleanup_internal(dth);
+
+	return rc;
+}
+
 /** Allocate space for saving the vos reservations and deferred actions */
 int
 vos_dtx_rsrvd_init(struct dtx_handle *dth)


### PR DESCRIPTION
For the server that only contains read sub operation(s) of some
distributed transaction, we still need to generate DTX entry on
such server for possible DTX recovery. Such DTX entry will only
contain the DTX entry header, not record to trace detailed read
targets (obj/key/sv/ev).

Signed-off-by: Fan Yong <fan.yong@intel.com>