### PR TITLE
DAOS-5554 dtx: async batched commit distributed transactions

### DIFF
--- a/src/common/btree.c
+++ b/src/common/btree.c
@@ -953,6 +953,9 @@ btr_check_availability(struct btr_context *tcx, struct btr_check_alb *alb)
 	if (rc == -DER_INPROGRESS) /* Unceration */
 		return PROBE_RC_INPROGRESS;
 
+	if (rc == -DER_DATA_LOSS)
+		return rc;
+
 	if (rc < 0) /* Failure */
 		return PROBE_RC_ERR;
 
@@ -1336,7 +1339,7 @@ btr_probe(struct btr_context *tcx, dbtree_probe_opc_t probe_opc,
 	int			 at;
 	int			 rc;
 	int			 cmp;
-	int			 level;
+	int			 level = -1;
 	int			 saved = -1;
 	bool			 next_level;
 	struct btr_node		*nd;
@@ -1350,7 +1353,6 @@ btr_probe(struct btr_context *tcx, dbtree_probe_opc_t probe_opc,
 		goto out;
 	}
 
-	level = -1;
 	memset(&tcx->tc_traces[0], 0,
 	       sizeof(tcx->tc_traces[0]) * BTR_TRACE_MAX);
 
@@ -1588,8 +1590,11 @@ again:
 	rc = PROBE_RC_OK;
  out:
 	tcx->tc_probe_rc = rc;
+	if (rc == -DER_DATA_LOSS)
+		rc = PROBE_RC_ERR;
+
 	if (rc == PROBE_RC_ERR)
-		D_ERROR("Failed to probe\n");
+		D_ERROR("Failed to probe: rc = %d\n", tcx->tc_probe_rc);
 	else if (level >= 0)
 		btr_trace_debug(tcx, &tcx->tc_trace[level], "\n");
 
@@ -1756,14 +1761,21 @@ dbtree_fetch(daos_handle_t toh, dbtree_probe_opc_t opc, uint32_t intent,
 		return -DER_NO_HDL;
 
 	rc = btr_probe_key(tcx, opc, intent, key);
-	if (rc == PROBE_RC_INPROGRESS) {
+	switch (rc) {
+	case PROBE_RC_INPROGRESS:
 		D_DEBUG(DB_TRACE, "Target is in some uncommitted DTX.\n");
 		return -DER_INPROGRESS;
-	}
-	if (rc == PROBE_RC_NONE || rc == PROBE_RC_ERR) {
-		D_DEBUG(DB_TRACE, "Cannot find key\n");
+	case PROBE_RC_NONE:
+		D_DEBUG(DB_TRACE, "Key does not exist.\n");
 		return -DER_NONEXIST;
+	case PROBE_RC_ERR:
+		D_DEBUG(DB_TRACE, "Cannot find key: %d\n", tcx->tc_probe_rc);
+		return tcx->tc_probe_rc == -DER_DATA_LOSS ?
+			tcx->tc_probe_rc : -DER_NONEXIST;
+	default:
+		break;
 	}
+
 	rec = btr_trace2rec(tcx, tcx->tc_depth - 1);
 
 	return btr_rec_fetch(tcx, rec, key_out, val_out);
@@ -1917,6 +1929,9 @@ btr_upsert(struct btr_context *tcx, dbtree_probe_opc_t probe_opc,
 	case PROBE_RC_INPROGRESS:
 		D_DEBUG(DB_TRACE, "The target is in some uncommitted DTX.");
 		return -DER_INPROGRESS;
+	case -DER_DATA_LOSS:
+		D_DEBUG(DB_TRACE, "Upsert hit some corrupted transaction.\n");
+		return rc;
 	}
 
 	tcx->tc_probe_rc = PROBE_RC_UNKNOWN; /* path changed */
@@ -2801,6 +2816,11 @@ dbtree_delete(daos_handle_t toh, dbtree_probe_opc_t opc, d_iov_t *key,
 		return -DER_INPROGRESS;
 	}
 
+	if (rc == -DER_DATA_LOSS) {
+		D_DEBUG(DB_TRACE, "Delete hit some corrupted transaction.\n");
+		return rc;
+	}
+
 	if (rc != PROBE_RC_OK) {
 		D_DEBUG(DB_TRACE, "Cannot find key\n");
 		return -DER_NONEXIST;
@@ -3503,9 +3523,15 @@ dbtree_iter_probe(daos_handle_t ih, dbtree_probe_opc_t opc, uint32_t intent,
 		return -DER_INPROGRESS;
 	}
 
-	if (rc == PROBE_RC_NONE || rc == PROBE_RC_ERR) {
+	if (rc == PROBE_RC_NONE) {
 		itr->it_state = BTR_ITR_FINI;
 		return -DER_NONEXIST;
+	}
+
+	if (rc == PROBE_RC_ERR) {
+		itr->it_state = BTR_ITR_FINI;
+		return tcx->tc_probe_rc == -DER_DATA_LOSS ?
+			tcx->tc_probe_rc : -DER_NONEXIST;
 	}
 
 	itr->it_state = BTR_ITR_READY;
@@ -3606,7 +3632,8 @@ again:
 	case PROBE_RC_ERR:
 	default:
 		itr->it_state = BTR_ITR_FINI;
-		return -DER_INVAL;
+		return tcx->tc_probe_rc == -DER_DATA_LOSS ?
+			tcx->tc_probe_rc : -DER_INVAL;
 	}
 }
 

--- a/src/container/srv_oi_table.c
+++ b/src/container/srv_oi_table.c
@@ -197,7 +197,7 @@ cont_child_gather_oids(struct ds_cont_child *coc, uuid_t coh_uuid,
 	memset(&ip, 0, sizeof(ip));
 	ip.ip_epr.epr_lo = epoch;
 	ip.ip_epr.epr_hi = epoch;
-	ip.ip_flags	 = VOS_IT_FOR_REBUILD;	/* XXX */
+	ip.ip_flags	 = VOS_IT_FOR_MIGRATION;	/* XXX */
 	ip.ip_hdl	 = coc->sc_hdl;
 
 	rc = vos_iterate(&ip, VOS_ITER_OBJ, false, &anchors,

--- a/src/container/srv_target.c
+++ b/src/container/srv_target.c
@@ -1984,7 +1984,7 @@ ds_cont_iter(daos_handle_t ph, uuid_t co_uuid, cont_iter_cb_t callback,
 	param.ip_hdl = coh;
 	param.ip_epr.epr_lo = 0;
 	param.ip_epr.epr_hi = DAOS_EPOCH_MAX;
-	param.ip_flags = VOS_IT_FOR_REBUILD;
+	param.ip_flags = VOS_IT_FOR_MIGRATION;
 
 	rc = vos_iter_prepare(type, &param, &iter_h, NULL);
 	if (rc != 0) {

--- a/src/dtx/dtx_common.c
+++ b/src/dtx/dtx_common.c
@@ -253,6 +253,63 @@ dtx_epoch_bound(struct dtx_epoch *epoch)
  */
 #define DTX_SUB_MOD_MAX	(((uint16_t)-1) - 2)
 
+static void
+dtx_shares_init(struct dtx_handle *dth)
+{
+	D_INIT_LIST_HEAD(&dth->dth_share_cmt_list);
+	D_INIT_LIST_HEAD(&dth->dth_share_act_list);
+	D_INIT_LIST_HEAD(&dth->dth_share_tbd_list);
+	dth->dth_share_tbd_count = 0;
+	dth->dth_shares_inited = 1;
+}
+
+static void
+dtx_shares_fini(struct dtx_handle *dth)
+{
+	struct dtx_share_peer	*dsp;
+
+	if (!dth->dth_shares_inited)
+		return;
+
+	while ((dsp = d_list_pop_entry(&dth->dth_share_cmt_list,
+				       struct dtx_share_peer,
+				       dsp_link)) != NULL)
+		D_FREE(dsp);
+
+	while ((dsp = d_list_pop_entry(&dth->dth_share_act_list,
+				       struct dtx_share_peer,
+				       dsp_link)) != NULL)
+		D_FREE(dsp);
+
+	while ((dsp = d_list_pop_entry(&dth->dth_share_tbd_list,
+				       struct dtx_share_peer,
+				       dsp_link)) != NULL)
+		D_FREE(dsp);
+
+	dth->dth_share_tbd_count = 0;
+}
+
+int
+dtx_handle_reinit(struct dtx_handle *dth)
+{
+	dth->dth_modify_shared = 0;
+	dth->dth_active = 0;
+	dth->dth_touched_leader_oid = 0;
+	dth->dth_local_tx_started = 0;
+	dth->dth_local_retry = 0;
+
+	dth->dth_ent = NULL;
+
+	dth->dth_op_seq = 0;
+	dth->dth_oid_cnt = 0;
+	dth->dth_oid_cap = 0;
+	D_FREE(dth->dth_oid_array);
+	dth->dth_dkey_hash = 0;
+	vos_dtx_rsrvd_fini(dth);
+
+	return vos_dtx_rsrvd_init(dth);
+}
+
 /**
  * Init local dth handle.
  */
@@ -261,26 +318,20 @@ dtx_handle_init(struct dtx_id *dti, daos_handle_t coh, struct dtx_epoch *epoch,
 		uint16_t sub_modification_cnt, uint32_t pm_ver,
 		daos_unit_oid_t *leader_oid, struct dtx_id *dti_cos,
 		int dti_cos_cnt, struct dtx_memberships *mbs, bool leader,
-		bool solo, bool sync, struct dtx_handle *dth)
+		bool solo, bool sync, bool dist, bool migration,
+		struct dtx_handle *dth)
 {
 	if (sub_modification_cnt > DTX_SUB_MOD_MAX) {
 		D_ERROR("Too many modifications in a single transaction:"
 			"%u > %u\n", sub_modification_cnt, DTX_SUB_MOD_MAX);
 		return -DER_OVERFLOW;
 	}
+	dth->dth_modification_cnt = sub_modification_cnt;
+
+	dtx_shares_init(dth);
 
 	dth->dth_xid = *dti;
 	dth->dth_coh = coh;
-
-	if (!dtx_epoch_chosen(epoch)) {
-		D_ERROR("initializing DTX "DF_DTI" with invalid epoch: value="
-			DF_U64" first="DF_U64" flags=%x\n",
-			DP_DTI(dti), epoch->oe_value, epoch->oe_first,
-			epoch->oe_flags);
-		return -DER_INVAL;
-	}
-	dth->dth_epoch = epoch->oe_value;
-	dth->dth_epoch_bound = dtx_epoch_bound(epoch);
 
 	dth->dth_leader_oid = *leader_oid;
 	dth->dth_ver = pm_ver;
@@ -294,6 +345,8 @@ dtx_handle_init(struct dtx_id *dti, daos_handle_t coh, struct dtx_epoch *epoch,
 	dth->dth_touched_leader_oid = 0;
 	dth->dth_local_tx_started = 0;
 	dth->dth_local_retry = 0;
+	dth->dth_dist = dist ? 1 : 0;
+	dth->dth_for_migration = migration ? 1 : 0;
 
 	dth->dth_dti_cos = dti_cos;
 	dth->dth_dti_cos_count = dti_cos_cnt;
@@ -307,14 +360,28 @@ dtx_handle_init(struct dtx_id *dti, daos_handle_t coh, struct dtx_epoch *epoch,
 		dth->dth_sync = 0;
 	}
 
-	dth->dth_modification_cnt = sub_modification_cnt;
-
 	dth->dth_op_seq = 0;
 	dth->dth_oid_cnt = 0;
 	dth->dth_oid_cap = 0;
 	dth->dth_oid_array = NULL;
 
 	dth->dth_dkey_hash = 0;
+
+	if (daos_is_zero_dti(dti))
+		return 0;
+
+	if (!dtx_epoch_chosen(epoch)) {
+		D_ERROR("initializing DTX "DF_DTI" with invalid epoch: value="
+			DF_U64" first="DF_U64" flags=%x\n",
+			DP_DTI(dti), epoch->oe_value, epoch->oe_first,
+			epoch->oe_flags);
+		return -DER_INVAL;
+	}
+	dth->dth_epoch = epoch->oe_value;
+	dth->dth_epoch_bound = dtx_epoch_bound(epoch);
+
+	if (dth->dth_modification_cnt == 0)
+		return 0;
 
 	return vos_dtx_rsrvd_init(dth);
 }
@@ -413,8 +480,8 @@ dtx_sub_init(struct dtx_handle *dth, daos_unit_oid_t *oid, uint64_t dkey_hash)
 
 	D_ASSERT(dth->dth_op_seq < (uint16_t)(-1));
 
-	dth->dth_op_seq++;
 	dth->dth_dkey_hash = dkey_hash;
+	dth->dth_op_seq++;
 
 	rc = daos_unit_oid_compare(dth->dth_leader_oid, *oid);
 	if (rc == 0) {
@@ -483,8 +550,7 @@ out:
  * \param dti_cos_cnt	[IN]	The @dti_cos array size.
  * \param tgts		[IN]	targets for distribute transaction.
  * \param tgt_cnt	[IN]	number of targets.
- * \param solo		[IN]	single operand or not.
- * \param sync		[IN]	sync mode or not.
+ * \param flags		[IN]	See dtx_flags.
  * \param mbs		[IN]	DTX participants information.
  * \param dth		[OUT]	Pointer to the DTX handle.
  *
@@ -495,7 +561,7 @@ dtx_leader_begin(struct ds_cont_child *cont, struct dtx_id *dti,
 		 struct dtx_epoch *epoch, uint16_t sub_modification_cnt,
 		 uint32_t pm_ver, daos_unit_oid_t *leader_oid,
 		 struct dtx_id *dti_cos, int dti_cos_cnt,
-		 struct daos_shard_tgt *tgts, int tgt_cnt, bool solo, bool sync,
+		 struct daos_shard_tgt *tgts, int tgt_cnt, uint32_t flags,
 		 struct dtx_memberships *mbs, struct dtx_leader_handle *dlh)
 {
 	struct dtx_handle	*dth = &dlh->dlh_handle;
@@ -504,35 +570,46 @@ dtx_leader_begin(struct ds_cont_child *cont, struct dtx_id *dti,
 
 	memset(dlh, 0, sizeof(*dlh));
 
-	/* Single replica case. */
-	if (tgt_cnt == 0) {
-		if (!daos_is_zero_dti(dti))
-			goto init;
+	if (tgt_cnt > 0) {
+		dlh->dlh_future = ABT_FUTURE_NULL;
+		D_ALLOC_ARRAY(dlh->dlh_subs, tgt_cnt);
+		if (dlh->dlh_subs == NULL)
+			return -DER_NOMEM;
 
-		return 0;
+		for (i = 0; i < tgt_cnt; i++)
+			dlh->dlh_subs[i].dss_tgt = tgts[i];
+		dlh->dlh_sub_cnt = tgt_cnt;
 	}
 
-	dlh->dlh_future = ABT_FUTURE_NULL;
-	D_ALLOC_ARRAY(dlh->dlh_subs, tgt_cnt);
-	if (dlh->dlh_subs == NULL)
-		return -DER_NOMEM;
-
-	for (i = 0; i < tgt_cnt; i++)
-		dlh->dlh_subs[i].dss_tgt = tgts[i];
-	dlh->dlh_sub_cnt = tgt_cnt;
-
-	if (daos_is_zero_dti(dti))
-		return 0;
-
-init:
 	rc = dtx_handle_init(dti, cont->sc_hdl, epoch, sub_modification_cnt,
 			     pm_ver, leader_oid, dti_cos, dti_cos_cnt, mbs,
-			     true, solo, sync, dth);
+			     true, (flags & DTX_SOLO) ? true : false,
+			     (flags & DTX_SYNC) ? true : false,
+			     (flags & DTX_DIST) ? true : false,
+			     (flags & DTX_FOR_MIGRATION) ? true : false, dth);
 
-	D_DEBUG(DB_IO, "Start %s DTX "DF_DTI" sub_reqs %d, ver %u, leader "
-		DF_UOID", dti_cos_cnt %d: "DF_RC"\n",
-		sync ? "sync" : "async", DP_DTI(dti), sub_modification_cnt,
-		dth->dth_ver, DP_UOID(*leader_oid), dti_cos_cnt, DP_RC(rc));
+	/* XXX: For non-solo DTX, the leader and non-leader will make each own
+	 *	local modification in parallel. If the non-leader goes so fast
+	 *	as to when non-leader has already moved to handle next requet,
+	 *	the leader may has not really started current modification yet,
+	 *	such as being blocked at bulk transfer phase. Under such case,
+	 *	it is possible that when the non-leader handles next request,
+	 *	it hits the DTX that is just prepared locally, then non-leader
+	 *	will check such DTX status with leader. But at that time, the
+	 *	DTX entry on the leader does not exist, that will misguide the
+	 *	non-leader as missed to abort such DTX. To avoid such bad case,
+	 *	the leader need to build its DTX entry in DRAM before dispatch
+	 *	current request to non-leader.
+	 */
+
+	if (rc == 0 && dtx_is_valid_handle(dth) && !dth->dth_solo &&
+	    sub_modification_cnt > 0)
+		rc = vos_dtx_pin(dth, false);
+
+	D_DEBUG(DB_IO, "Start DTX "DF_DTI" sub modification %d, ver %u, leader "
+		DF_UOID", dti_cos_cnt %d, flags %x: "DF_RC"\n",
+		DP_DTI(dti), sub_modification_cnt, dth->dth_ver,
+		DP_UOID(*leader_oid), dti_cos_cnt, flags, DP_RC(rc));
 
 	if (rc != 0)
 		D_FREE(dlh->dlh_subs);
@@ -576,6 +653,8 @@ dtx_leader_end(struct dtx_leader_handle *dlh, struct ds_cont_child *cont,
 
 	D_ASSERT(cont != NULL);
 
+	dtx_shares_fini(dth);
+
 	/* NB: even the local request failure, dth_ent == NULL, we
 	 * should still wait for remote object to finish the request.
 	 */
@@ -607,10 +686,20 @@ again:
 	 */
 	if (dth->dth_ver < cont->sc_dtx_resync_ver) {
 		rc = vos_dtx_check(cont->sc_hdl, &dth->dth_xid,
-				   NULL, NULL, false);
+				   NULL, NULL, NULL, false);
 		/* Committed by race, do nothing. */
-		if (rc == DTX_ST_COMMITTED)
+		if (rc == DTX_ST_COMMITTED || rc == DTX_ST_COMMITTABLE)
 			D_GOTO(abort, result = 0);
+
+		/* The DTX is marked as 'corrupted' by DTX resync by race,
+		 * then let's abort it.
+		 */
+		if (rc == DTX_ST_CORRUPTED) {
+			D_WARN(DF_UUID": DTX "DF_DTI" is marked as corrupted "
+			       "by resync because of lost some participants\n",
+			       DP_UUID(cont->sc_uuid), DP_DTI(&dth->dth_xid));
+			D_GOTO(abort, result = -DER_TX_RESTART);
+		}
 
 		/* Aborted by race, restart it. */
 		if (rc == -DER_NONEXIST) {
@@ -642,6 +731,7 @@ again:
 	if (rc == 0) {
 		struct dtx_memberships	*mbs;
 		size_t			 size;
+		uint32_t		 flags;
 
 		/* For synchronous DTX, do not add it into CoS cache, otherwise,
 		 * we may have no way to remove it from the cache.
@@ -668,12 +758,16 @@ again:
 
 		/* Use the new created @dte instead of dth->dth_dte that will be
 		 * released after dtx_leader_end().
-		 *
-		 * Only the DTX for single RDG may be added into CoS cache.
 		 */
+
+		if (!(mbs->dm_flags & DMF_SRDG_REP))
+			flags = DCF_EXP_CMT;
+		else if (dth->dth_modify_shared)
+			flags = DCF_SHARED;
+		else
+			flags = 0;
 		rc = dtx_add_cos(cont, dte, &dth->dth_leader_oid,
-				 dth->dth_dkey_hash, dth->dth_epoch,
-				 dth->dth_modify_shared ? DCF_SHARED : 0);
+				 dth->dth_dkey_hash, dth->dth_epoch, flags);
 		dtx_entry_put(dte);
 		if (rc == 0)
 			vos_dtx_mark_committable(dth);
@@ -769,10 +863,9 @@ out:
  *			[IN]	Sub modifications count.
  * \param pm_ver	[IN]	Pool map version for the DTX.
  * \param leader_oid	[IN]    The object ID is used to elect the DTX leader.
- * \param dkey_hash	[IN]	Hash of the dkey to be modified if applicable.
- * \param intent	[IN]	The intent of related operations.
  * \param dti_cos	[IN]	The DTX array to be committed because of shared.
  * \param dti_cos_cnt	[IN]	The @dti_cos array size.
+ * \param flags		[IN]	See dtx_flags.
  * \param mbs		[IN]	DTX participants information.
  * \param dth		[OUT]	Pointer to the DTX handle.
  *
@@ -782,26 +875,21 @@ int
 dtx_begin(struct ds_cont_child *cont, struct dtx_id *dti,
 	  struct dtx_epoch *epoch, uint16_t sub_modification_cnt,
 	  uint32_t pm_ver, daos_unit_oid_t *leader_oid,
-	  struct dtx_id *dti_cos, int dti_cos_cnt,
+	  struct dtx_id *dti_cos, int dti_cos_cnt, uint32_t flags,
 	  struct dtx_memberships *mbs, struct dtx_handle *dth)
 {
 	int	rc;
 
-	D_ASSERT(dth != NULL);
-
-	if (daos_is_zero_dti(dti)) {
-		daos_dti_gen(&dth->dth_xid, true);
-		return 0;
-	}
-
 	rc = dtx_handle_init(dti, cont->sc_hdl, epoch, sub_modification_cnt,
 			     pm_ver, leader_oid, dti_cos, dti_cos_cnt, mbs,
-			     false, false, false, dth);
+			     false, false, false,
+			     (flags & DTX_DIST) ? true : false,
+			     (flags & DTX_FOR_MIGRATION) ? true : false, dth);
 
-	D_DEBUG(DB_IO, "Start DTX "DF_DTI" sub_reqs %d, ver %u, "
-		"dti_cos_cnt %d: "DF_RC"\n",
+	D_DEBUG(DB_IO, "Start DTX "DF_DTI" sub modification %d, ver %u, "
+		"dti_cos_cnt %d, flags %x: "DF_RC"\n",
 		DP_DTI(dti), sub_modification_cnt,
-		dth->dth_ver, dti_cos_cnt, DP_RC(rc));
+		dth->dth_ver, dti_cos_cnt, flags, DP_RC(rc));
 
 	return rc;
 }
@@ -810,6 +898,8 @@ int
 dtx_end(struct dtx_handle *dth, struct ds_cont_child *cont, int result)
 {
 	D_ASSERT(dth != NULL);
+
+	dtx_shares_fini(dth);
 
 	if (daos_is_zero_dti(&dth->dth_xid))
 		return result;
@@ -967,12 +1057,15 @@ dtx_handle_resend(daos_handle_t coh,  struct dtx_id *dti,
 		return -DER_NONEXIST;
 
 again:
-	rc = vos_dtx_check(coh, dti, epoch, pm_ver, true);
+	rc = vos_dtx_check(coh, dti, epoch, pm_ver, NULL, true);
 	switch (rc) {
 	case DTX_ST_PREPARED:
 		return 0;
 	case DTX_ST_COMMITTED:
+	case DTX_ST_COMMITTABLE:
 		return -DER_ALREADY;
+	case DTX_ST_CORRUPTED:
+		return -DER_DATA_LOSS;
 	case -DER_NONEXIST:
 		age = dtx_hlc_age2sec(dti->dti_hlc);
 		if (age > DTX_AGG_THRESHOLD_AGE_LOWER ||

--- a/src/dtx/dtx_cos.c
+++ b/src/dtx/dtx_cos.c
@@ -49,10 +49,16 @@ struct dtx_cos_rec {
 	 *	operation efficiency.
 	 */
 	d_list_t		 dcr_prio_list;
+	/* The list for those DTXs that need to committed via explicit DTX
+	 * commit RPC instead of piggyback via dispatched update/punch RPC.
+	 */
+	d_list_t		 dcr_expcmt_list;
 	/* The number of the PUNCH DTXs in the dcr_reg_list. */
 	int			 dcr_reg_count;
 	/* The number of the DTXs in the dcr_prio_list. */
 	int			 dcr_prio_count;
+	/* The number of the DTXs in the dcr_explicit_list. */
+	int			 dcr_expcmt_count;
 };
 
 /* Above dtx_cos_rec is consisted of a series of dtx_cos_rec_child uints.
@@ -126,6 +132,7 @@ dtx_cos_rec_alloc(struct btr_instance *tins, d_iov_t *key_iov,
 	dcr->dcr_oid = key->oid;
 	D_INIT_LIST_HEAD(&dcr->dcr_reg_list);
 	D_INIT_LIST_HEAD(&dcr->dcr_prio_list);
+	D_INIT_LIST_HEAD(&dcr->dcr_expcmt_list);
 
 	D_ALLOC_PTR(dcrc);
 	if (dcrc == NULL) {
@@ -141,7 +148,10 @@ dtx_cos_rec_alloc(struct btr_instance *tins, d_iov_t *key_iov,
 			&cont->sc_dtx_cos_list);
 	cont->sc_dtx_committable_count++;
 
-	if (rbund->flags & DCF_SHARED) {
+	if (rbund->flags & DCF_EXP_CMT) {
+		d_list_add_tail(&dcrc->dcrc_lo_link, &dcr->dcr_expcmt_list);
+		dcr->dcr_expcmt_count = 1;
+	} else if (rbund->flags & DCF_SHARED) {
 		d_list_add_tail(&dcrc->dcrc_lo_link, &dcr->dcr_prio_list);
 		dcr->dcr_prio_count = 1;
 	} else {
@@ -174,6 +184,14 @@ dtx_cos_rec_free(struct btr_instance *tins, struct btr_record *rec, void *args)
 		cont->sc_dtx_committable_count--;
 	}
 	d_list_for_each_entry_safe(dcrc, next, &dcr->dcr_prio_list,
+				   dcrc_lo_link) {
+		d_list_del(&dcrc->dcrc_lo_link);
+		d_list_del(&dcrc->dcrc_gl_committable);
+		dtx_entry_put(dcrc->dcrc_dte);
+		D_FREE_PTR(dcrc);
+		cont->sc_dtx_committable_count--;
+	}
+	d_list_for_each_entry_safe(dcrc, next, &dcr->dcr_expcmt_list,
 				   dcrc_lo_link) {
 		d_list_del(&dcrc->dcrc_lo_link);
 		d_list_del(&dcrc->dcrc_gl_committable);
@@ -226,7 +244,10 @@ dtx_cos_rec_update(struct btr_instance *tins, struct btr_record *rec,
 			&cont->sc_dtx_cos_list);
 	cont->sc_dtx_committable_count++;
 
-	if (rbund->flags & DCF_SHARED) {
+	if (rbund->flags & DCF_EXP_CMT) {
+		d_list_add_tail(&dcrc->dcrc_lo_link, &dcr->dcr_expcmt_list);
+		dcr->dcr_expcmt_count++;
+	} else if (rbund->flags & DCF_SHARED) {
 		d_list_add_tail(&dcrc->dcrc_lo_link, &dcr->dcr_prio_list);
 		dcr->dcr_prio_count++;
 	} else {
@@ -342,41 +363,6 @@ dtx_list_cos(struct ds_cont_child *cont, daos_unit_oid_t *oid,
 }
 
 int
-dtx_lookup_cos(struct ds_cont_child *cont, struct dtx_id *xid,
-	       daos_unit_oid_t *oid, uint64_t dkey_hash)
-{
-	struct dtx_cos_key		 key;
-	d_iov_t				 kiov;
-	d_iov_t				 riov;
-	struct dtx_cos_rec		*dcr;
-	struct dtx_cos_rec_child	*dcrc;
-	int				 rc;
-
-	key.oid = *oid;
-	key.dkey_hash = dkey_hash;
-	d_iov_set(&kiov, &key, sizeof(key));
-	d_iov_set(&riov, NULL, 0);
-
-	rc = dbtree_lookup(cont->sc_dtx_cos_hdl, &kiov, &riov);
-	if (rc != 0)
-		return rc;
-
-	dcr = (struct dtx_cos_rec *)riov.iov_buf;
-
-	d_list_for_each_entry(dcrc, &dcr->dcr_prio_list, dcrc_lo_link) {
-		if (memcmp(&dcrc->dcrc_dte->dte_xid, xid, sizeof(*xid)) == 0)
-			return 0;
-	}
-
-	d_list_for_each_entry(dcrc, &dcr->dcr_reg_list, dcrc_lo_link) {
-		if (memcmp(&dcrc->dcrc_dte->dte_xid, xid, sizeof(*xid)) == 0)
-			return 0;
-	}
-
-	return -DER_NONEXIST;
-}
-
-int
 dtx_add_cos(struct ds_cont_child *cont, struct dtx_entry *dte,
 	    daos_unit_oid_t *oid, uint64_t dkey_hash,
 	    daos_epoch_t epoch, uint32_t flags)
@@ -403,9 +389,8 @@ dtx_add_cos(struct ds_cont_child *cont, struct dtx_entry *dte,
 			   DAOS_INTENT_UPDATE, &kiov, &riov);
 
 	D_DEBUG(DB_IO, "Insert DTX "DF_DTI" to CoS cache, key %lu, "
-		"%s shared entry: rc = "DF_RC"\n",
-		DP_DTI(&dte->dte_xid), (unsigned long)dkey_hash,
-		flags & DCF_SHARED ? "has" : "has not", DP_RC(rc));
+		"flags %x: rc = "DF_RC"\n", DP_DTI(&dte->dte_xid),
+		(unsigned long)dkey_hash, flags, DP_RC(rc));
 
 	return rc;
 }
@@ -470,9 +455,25 @@ dtx_del_cos(struct ds_cont_child *cont, struct dtx_id *xid,
 		D_GOTO(out, found = 2);
 	}
 
+	d_list_for_each_entry(dcrc, &dcr->dcr_expcmt_list, dcrc_lo_link) {
+		if (memcmp(&dcrc->dcrc_dte->dte_xid, xid, sizeof(*xid)) != 0)
+			continue;
+
+		d_list_del(&dcrc->dcrc_gl_committable);
+		d_list_del(&dcrc->dcrc_lo_link);
+		dtx_entry_put(dcrc->dcrc_dte);
+		D_FREE_PTR(dcrc);
+
+		cont->sc_dtx_committable_count--;
+		dcr->dcr_expcmt_count--;
+
+		D_GOTO(out, found = 3);
+	}
+
 out:
 	if (found > 0) {
-		if (dcr->dcr_reg_count == 0 && dcr->dcr_prio_count == 0)
+		if (dcr->dcr_reg_count == 0 && dcr->dcr_prio_count == 0 &&
+		    dcr->dcr_expcmt_count == 0)
 			rc = dbtree_delete(cont->sc_dtx_cos_hdl, BTR_PROBE_EQ,
 					   &kiov, NULL);
 

--- a/src/dtx/dtx_internal.h
+++ b/src/dtx/dtx_internal.h
@@ -45,7 +45,8 @@
 #define DTX_PROTO_SRV_RPC_LIST(X)				\
 	X(DTX_COMMIT, 0, &CQF_dtx, dtx_handler, NULL),		\
 	X(DTX_ABORT, 0, &CQF_dtx, dtx_handler, NULL),		\
-	X(DTX_CHECK, 0, &CQF_dtx, dtx_handler, NULL)
+	X(DTX_CHECK, 0, &CQF_dtx, dtx_handler, NULL),		\
+	X(DTX_REFRESH, 0, &CQF_dtx, dtx_handler, NULL)
 
 #define X_OPC(a, b, c, d, e) a
 
@@ -62,7 +63,8 @@ enum dtx_operation {
 
 /* DTX RPC output fields */
 #define DAOS_OSEQ_DTX							\
-	((int32_t)		(do_status)		CRT_VAR)
+	((int32_t)		(do_status)		CRT_VAR)	\
+	((int32_t)		(do_sub_rets)		CRT_ARRAY)
 
 CRT_RPC_DECLARE(dtx, DAOS_ISEQ_DTX, DAOS_OSEQ_DTX);
 
@@ -94,15 +96,13 @@ extern btr_ops_t dbtree_dtx_cf_ops;
 extern btr_ops_t dtx_btr_cos_ops;
 
 /* dtx_common.c */
-void dtx_aggregate(void *arg);
+int dtx_handle_reinit(struct dtx_handle *dth);
 void dtx_batched_commit(void *arg);
 
 /* dtx_cos.c */
 int dtx_fetch_committable(struct ds_cont_child *cont, uint32_t max_cnt,
 			  daos_unit_oid_t *oid, daos_epoch_t epoch,
 			  struct dtx_entry ***dtes);
-int dtx_lookup_cos(struct ds_cont_child *cont, struct dtx_id *xid,
-		   daos_unit_oid_t *oid, uint64_t dkey_hash);
 int dtx_add_cos(struct ds_cont_child *cont, struct dtx_entry *dte,
 		daos_unit_oid_t *oid, uint64_t dkey_hash,
 		daos_epoch_t epoch, uint32_t flags);

--- a/src/dtx/dtx_resync.c
+++ b/src/dtx/dtx_resync.c
@@ -91,10 +91,11 @@ dtx_resync_commit(struct ds_cont_child *cont,
 		 * DTXs. So double check the status before current commit.
 		 */
 		rc = vos_dtx_check(cont->sc_hdl, &dre->dre_xid,
-				   NULL, NULL, false);
+				   NULL, NULL, NULL, false);
 
 		/* Skip this DTX since it has been committed or aggregated. */
-		if (rc == DTX_ST_COMMITTED || rc == -DER_NONEXIST)
+		if (rc == DTX_ST_COMMITTED || rc == DTX_ST_COMMITTABLE ||
+		    rc == -DER_NONEXIST)
 			goto next;
 
 		/* If we failed to check the status, then assume that it is
@@ -134,7 +135,9 @@ dtx_target_alive(struct ds_pool *pool, uint32_t id)
 	struct pool_target	*target;
 	int			 rc;
 
+	ABT_rwlock_wrlock(pool->sp_lock);
 	rc = pool_map_find_target(pool->sp_map, id, &target);
+	ABT_rwlock_unlock(pool->sp_lock);
 	D_ASSERT(rc == 1);
 
 	return target->ta_comp.co_status == PO_COMP_ST_UPIN ? true : false;
@@ -154,6 +157,9 @@ dtx_is_leader(struct ds_pool *pool, struct dtx_resync_args *dra,
 	    dtx_target_alive(pool, mbs->dm_tgts[0].ddt_id))
 		return 0;
 
+	/* XXX: need more work when we support to elect DTX leader from
+	 *	data shard for EC object in the future.
+	 */
 	return ds_pool_check_dtx_leader(pool, &dre->dre_oid, dra->version);
 }
 
@@ -228,7 +234,9 @@ dtx_status_handle(struct dtx_resync_args *dra)
 	if (drh->drh_count == 0)
 		goto out;
 
+	ABT_rwlock_wrlock(pool->sp_lock);
 	tgt_cnt = pool_map_target_nr(pool->sp_map);
+	ABT_rwlock_unlock(pool->sp_lock);
 	D_ASSERT(tgt_cnt != 0);
 
 	D_ALLOC_ARRAY(tgt_array, tgt_cnt);
@@ -257,7 +265,7 @@ dtx_status_handle(struct dtx_resync_args *dra)
 		/* The DTX has been committed on some remote replica(s),
 		 * let's commit the DTX globally.
 		 */
-		if (rc == DTX_ST_COMMITTED)
+		if (rc == DTX_ST_COMMITTED || rc == DTX_ST_COMMITTABLE)
 			goto commit;
 
 		if (rc == DTX_ST_PREPARED) {
@@ -274,12 +282,13 @@ dtx_status_handle(struct dtx_resync_args *dra)
 				 *	the DTX. we need more human knowledge
 				 *	to manually recover related things.
 				 *
-				 *	One possible TBD is that we can mark
-				 *	the DTX as 'failed' on related servers,
-				 *	that will fail subsequent accessing of
-				 *	related data directly without talk with
-				 *	the leader again.
+				 *	Then we will mark the TX as corrupted
+				 *	via special dtx_abort() with 0 @epoch.
 				 */
+				dte = &dre->dre_dte;
+				rc = dtx_abort(cont, 0, &dte, 1);
+				if (rc < 0)
+					err = rc;
 
 				dtx_dre_release(drh, dre);
 				continue;
@@ -301,10 +310,11 @@ dtx_status_handle(struct dtx_resync_args *dra)
 		 * DTXs. So double check the status before next action.
 		 */
 		rc = vos_dtx_check(cont->sc_hdl, &dre->dre_xid,
-				   NULL, NULL, false);
+				   NULL, NULL, NULL, false);
 
 		/* Skip this DTX that it may has been committed or aborted. */
-		if (rc == DTX_ST_COMMITTED || rc == -DER_NONEXIST) {
+		if (rc == DTX_ST_COMMITTED || rc == DTX_ST_COMMITTABLE ||
+		    rc == -DER_NONEXIST) {
 			dtx_dre_release(drh, dre);
 			continue;
 		}
@@ -383,6 +393,10 @@ dtx_iter_cb(uuid_t co_uuid, vos_iter_entry_t *ent, void *args)
 	D_ASSERT(!(ent->ie_dtx_flags & DTE_INVALID));
 
 	if (ent->ie_dtx_flags & DTE_LEADER && !dra->resync_all)
+		return 0;
+
+	/* Skip corrupted entry that will be handled via other special tool. */
+	if (ent->ie_dtx_flags & DTE_CORRUPTED)
 		return 0;
 
 	/* Only handle the DTX that happened before the DTX resync. */
@@ -546,7 +560,7 @@ dtx_resync_one(void *data)
 
 	cb_arg.arg = *arg;
 	param.ip_hdl = child->spc_hdl;
-	param.ip_flags = VOS_IT_FOR_REBUILD;
+	param.ip_flags = VOS_IT_FOR_MIGRATION;
 	rc = vos_iterate(&param, VOS_ITER_COUUID, false, &anchor,
 			 container_scan_cb, NULL, &cb_arg, NULL);
 

--- a/src/dtx/dtx_rpc.c
+++ b/src/dtx/dtx_rpc.c
@@ -73,6 +73,10 @@ struct dtx_req_args {
 	int				 dra_length;
 	/* The collective RPC result. */
 	int				 dra_result;
+	/* Pointer to the DTX handle, used for DTX_REFRESH case. */
+	struct dtx_handle		*dra_dth;
+	/* Pointer to the container, used for DTX_REFRESH case. */
+	struct ds_cont_child		*dra_cont;
 };
 
 /* The record for the DTX classify-tree in DRAM.
@@ -89,6 +93,7 @@ struct dtx_req_rec {
 	int				 drr_count; /* DTX count */
 	int				 drr_result; /* The RPC result */
 	struct dtx_id			*drr_dti; /* The DTX array */
+	struct dtx_share_peer		**drr_cb_args; /* Used by dtx_req_cb. */
 };
 
 struct dtx_cf_rec_bundle {
@@ -125,12 +130,83 @@ dtx_req_cb(const struct crt_cb_info *cb_info)
 	struct dtx_in		*din = crt_req_get(req);
 	struct dtx_out		*dout;
 	int			 rc = cb_info->cci_rc;
+	int			 i;
 
-	if (rc == 0) {
-		dout = crt_reply_get(req);
-		rc = dout->do_status;
+	if (rc != 0)
+		goto out;
+
+	dout = crt_reply_get(req);
+	if (dra->dra_opc != DTX_REFRESH)
+		D_GOTO(out, rc = dout->do_status);
+
+	if (din->di_dtx_array.ca_count != dout->do_sub_rets.ca_count)
+		D_GOTO(out, rc = -DER_PROTO);
+
+	for (i = 0; i < dout->do_sub_rets.ca_count; i++) {
+		struct dtx_handle	*dth = dra->dra_dth;
+		struct dtx_share_peer	*dsp;
+		int			*ret;
+		int			 rc1;
+
+		dsp = drr->drr_cb_args[i];
+		if (dsp == NULL)
+			continue;
+
+		drr->drr_cb_args[i] = NULL;
+		ret = (int *)dout->do_sub_rets.ca_arrays + i;
+
+		switch (*ret) {
+		case DTX_ST_PREPARED:
+		case -DER_INPROGRESS:
+			/* Not committable yet. */
+			d_list_add_tail(&dsp->dsp_link,
+					&dth->dth_share_act_list);
+			break;
+		case DTX_ST_COMMITTABLE:
+			/* Committable, will be committed soon. */
+			d_list_add_tail(&dsp->dsp_link,
+					&dth->dth_share_cmt_list);
+			break;
+		case DTX_ST_COMMITTED:
+			/* Has been committed on leader, we may miss related
+			 * commit request, so let's commit it locally.
+			 */
+			rc1 = vos_dtx_commit(dra->dra_cont->sc_hdl,
+					     &dsp->dsp_xid, 1, NULL);
+			if (rc1 < 0 && rc1 != -DER_NONEXIST)
+				d_list_add_tail(&dsp->dsp_link,
+						&dth->dth_share_cmt_list);
+			else
+				D_FREE(dsp);
+			break;
+		case DTX_ST_CORRUPTED:
+			/* The DTX entry is corrupted. */
+			D_FREE(dsp);
+			D_GOTO(out, rc = -DER_DATA_LOSS);
+		case DTX_ST_UNCERTAIN:
+			/* The DTX is in resync, ask client to retry. */
+			D_FREE(dsp);
+			D_GOTO(out, rc = -DER_INPROGRESS);
+		case -DER_NONEXIST:
+			/* The leader does not have related DTX info,
+			 * we may miss related DTX abort request, so
+			 * let's abort it locally.
+			 */
+			rc1 = vos_dtx_abort(dra->dra_cont->sc_hdl,
+					    DAOS_EPOCH_MAX, &dsp->dsp_xid, 1);
+			if (rc1 < 0 && rc1 != -DER_NONEXIST)
+				d_list_add_tail(&dsp->dsp_link,
+						&dth->dth_share_act_list);
+			else
+				D_FREE(dsp);
+			break;
+		default:
+			D_FREE(dsp);
+			D_GOTO(out, rc = *ret);
+		}
 	}
 
+out:
 	drr->drr_result = rc;
 	rc = ABT_future_set(dra->dra_future, drr);
 	D_ASSERTF(rc == ABT_SUCCESS,
@@ -198,6 +274,7 @@ dtx_req_list_cb(void **args)
 			drr = args[i];
 			switch (drr->drr_result) {
 			case DTX_ST_COMMITTED:
+			case DTX_ST_COMMITTABLE:
 				dra->dra_result = DTX_ST_COMMITTED;
 				/* As long as one target has committed the DTX,
 				 * then the DTX is committable on all targets.
@@ -208,8 +285,13 @@ dtx_req_list_cb(void **args)
 					drr->drr_rank, drr->drr_tag);
 				return;
 			case DTX_ST_PREPARED:
+				if (dra->dra_result == 0 ||
+				    dra->dra_result == DTX_ST_CORRUPTED)
+					dra->dra_result = drr->drr_result;
+				break;
+			case DTX_ST_CORRUPTED:
 				if (dra->dra_result == 0)
-					dra->dra_result = DTX_ST_PREPARED;
+					dra->dra_result = drr->drr_result;
 				break;
 			default:
 				dra->dra_result = drr->drr_result >= 0 ?
@@ -258,7 +340,8 @@ dtx_req_wait(struct dtx_req_args *dra)
 
 static int
 dtx_req_list_send(struct dtx_req_args *dra, crt_opcode_t opc, d_list_t *head,
-		  int len, uuid_t po_uuid, uuid_t co_uuid, daos_epoch_t epoch)
+		  int len, uuid_t po_uuid, uuid_t co_uuid, daos_epoch_t epoch,
+		  struct dtx_handle *dth, struct ds_cont_child *cont)
 {
 	ABT_future		 future;
 	struct dtx_req_rec	*drr;
@@ -271,6 +354,8 @@ dtx_req_list_send(struct dtx_req_args *dra, crt_opcode_t opc, d_list_t *head,
 	dra->dra_list = head;
 	dra->dra_length = len;
 	dra->dra_result = 0;
+	dra->dra_dth = dth;
+	dra->dra_cont = cont;
 
 	rc = ABT_future_create(len, dtx_req_list_cb, &future);
 	if (rc != ABT_SUCCESS) {
@@ -344,6 +429,7 @@ dtx_cf_rec_free(struct btr_instance *tins, struct btr_record *rec, void *args)
 
 	drr = (struct dtx_req_rec *)umem_off2ptr(&tins->ti_umm, rec->rec_off);
 	d_list_del(&drr->drr_link);
+	D_FREE(drr->drr_cb_args);
 	D_FREE(drr->drr_dti);
 	D_FREE_PTR(drr);
 
@@ -412,8 +498,10 @@ dtx_dti_classify_one(struct ds_pool *pool, daos_handle_t tree, d_list_t *head,
 		d_iov_t			 kiov;
 		d_iov_t			 riov;
 
+		ABT_rwlock_wrlock(pool->sp_lock);
 		rc = pool_map_find_target(pool->sp_map,
 					  mbs->dm_tgts[i].ddt_id, &target);
+		ABT_rwlock_unlock(pool->sp_lock);
 		D_ASSERT(rc == 1);
 
 		/* Skip the target that (re-)joined the system after the DTX. */
@@ -521,7 +609,8 @@ dtx_commit(struct ds_cont_child *cont, struct dtx_entry **dtes,
 	dra.dra_future = ABT_FUTURE_NULL;
 	if (!d_list_empty(&head)) {
 		rc = dtx_req_list_send(&dra, DTX_COMMIT, &head, length,
-				       pool->sp_uuid, cont->sc_uuid, 0);
+				       pool->sp_uuid, cont->sc_uuid, 0,
+				       NULL, NULL);
 		if (rc != 0)
 			goto out;
 	}
@@ -606,7 +695,8 @@ dtx_abort(struct ds_cont_child *cont, daos_epoch_t epoch,
 
 	if (rc == 0 && !d_list_empty(&head)) {
 		rc = dtx_req_list_send(&dra, DTX_ABORT, &head, length,
-				       pool->sp_uuid, cont->sc_uuid, epoch);
+				       pool->sp_uuid, cont->sc_uuid, epoch,
+				       NULL, NULL);
 		if (rc != 0)
 			goto out;
 
@@ -658,8 +748,10 @@ dtx_check(struct ds_cont_child *cont, struct dtx_entry *dte, daos_epoch_t epoch)
 	for (i = 0; i < mbs->dm_tgt_cnt; i++) {
 		struct pool_target	*target;
 
+		ABT_rwlock_wrlock(pool->sp_lock);
 		rc = pool_map_find_target(pool->sp_map,
 					  mbs->dm_tgts[i].ddt_id, &target);
+		ABT_rwlock_unlock(pool->sp_lock);
 		D_ASSERT(rc == 1);
 
 		/* Skip the target that (re-)joined the system after the DTX. */
@@ -700,7 +792,7 @@ dtx_check(struct ds_cont_child *cont, struct dtx_entry *dte, daos_epoch_t epoch)
 	}
 
 	rc = dtx_req_list_send(&dra, DTX_CHECK, &head, length, pool->sp_uuid,
-			       cont->sc_uuid, epoch);
+			       cont->sc_uuid, epoch, NULL, NULL);
 	if (rc == 0)
 		rc = dtx_req_wait(&dra);
 
@@ -711,4 +803,129 @@ out:
 	}
 
 	return rc;
+}
+
+/*
+ * Because of async batched commit semantics, the DTX status on the leader
+ * maybe different from the one on non-leaders. For the leader, it exactly
+ * knows whether the DTX is committable or not, but the non-leader does not
+ * know if the DTX is in 'prepared' status. If someone on non-leader wants
+ * to know whether some 'prepared' DTX is real committable or not, it needs
+ * to refresh such DTX status from the leader. The DTX_REFRESH RPC is used
+ * for such purpose.
+ */
+int
+dtx_refresh(struct dtx_handle *dth, struct ds_cont_child *cont)
+{
+	struct ds_pool		*pool = cont->sc_pool->spc_pool;
+	struct pool_target	*target;
+	struct dtx_share_peer	*dsp;
+	struct dtx_req_rec	*drr;
+	struct dtx_req_args	 dra;
+	d_list_t		 head;
+	int			 len = 0;
+	int			 rc = 0;
+
+	D_INIT_LIST_HEAD(&head);
+
+	d_list_for_each_entry(dsp, &dth->dth_share_tbd_list, dsp_link) {
+		if (dsp->dsp_leader == PO_COMP_ID_ALL) {
+
+again:
+			rc = ds_pool_elect_dtx_leader(pool, &dsp->dsp_oid,
+						      dsp->dsp_ver);
+			if (rc < 0) {
+				D_ERROR("Failed to find DTX leader for "DF_DTI
+					": "DF_RC"\n",
+					DP_DTI(&dsp->dsp_xid), DP_RC(rc));
+				goto out;
+			}
+
+			/* Still get the same leader, ask client to retry. */
+			if (dsp->dsp_leader == rc)
+				D_GOTO(out, rc = -DER_INPROGRESS);
+
+			dsp->dsp_leader = rc;
+		}
+
+		ABT_rwlock_wrlock(pool->sp_lock);
+		rc = pool_map_find_target(pool->sp_map, dsp->dsp_leader,
+					  &target);
+		ABT_rwlock_unlock(pool->sp_lock);
+		D_ASSERT(rc == 1);
+
+		/* The leader is not healthy, related DTX will be resynced
+		 * by the new leader, let's find out new leader and retry.
+		 */
+		if (target->ta_comp.co_status != PO_COMP_ST_UPIN)
+			goto again;
+
+		d_list_for_each_entry(drr, &head, drr_link) {
+			if (drr->drr_rank == target->ta_comp.co_rank &&
+			    drr->drr_tag == target->ta_comp.co_index) {
+				drr->drr_dti[drr->drr_count] = dsp->dsp_xid;
+				drr->drr_cb_args[drr->drr_count++] = dsp;
+				goto next;
+			}
+		}
+
+		D_ALLOC_PTR(drr);
+		if (drr == NULL)
+			D_GOTO(out, rc = -DER_NOMEM);
+
+		D_ALLOC_ARRAY(drr->drr_dti, dth->dth_share_tbd_count);
+		if (drr->drr_dti == NULL) {
+			D_FREE(drr);
+			D_GOTO(out, rc = -DER_NOMEM);
+		}
+
+		D_ALLOC_ARRAY(drr->drr_cb_args, dth->dth_share_tbd_count);
+		if (drr->drr_cb_args == NULL) {
+			D_FREE(drr->drr_dti);
+			D_FREE(drr);
+			D_GOTO(out, rc = -DER_NOMEM);
+		}
+
+		drr->drr_rank = target->ta_comp.co_rank;
+		drr->drr_tag = target->ta_comp.co_index;
+		drr->drr_count = 1;
+		drr->drr_dti[0] = dsp->dsp_xid;
+		drr->drr_cb_args[0] = dsp;
+		d_list_add_tail(&drr->drr_link, &head);
+		len++;
+
+next:
+		d_list_del(&dsp->dsp_link);
+		dth->dth_share_tbd_count--;
+		D_ASSERT(dth->dth_share_tbd_count >= 0);
+	}
+
+	rc = dtx_req_list_send(&dra, DTX_REFRESH, &head, len,
+			       pool->sp_uuid, cont->sc_uuid, 0, dth, cont);
+	if (rc == 0)
+		rc = dtx_req_wait(&dra);
+
+out:
+	while ((drr = d_list_pop_entry(&head, struct dtx_req_rec,
+				       drr_link)) != NULL) {
+		D_FREE(drr->drr_cb_args);
+		D_FREE(drr->drr_dti);
+		D_FREE(drr);
+	}
+
+	/* If some DTX entry is corrupted, then reply -DER_DATA_LOSS.
+	 * Otherwise if we cannot resolve the DTX status, then reply
+	 * -DER_INPROGRESS to the client for retry in further. As for
+	 * the other cases, return -DER_AGAIN for retry locally.
+	 */
+
+	if (rc < 0)
+		return rc == -DER_DATA_LOSS ? rc : -DER_INPROGRESS;
+
+	vos_dtx_cleanup(dth);
+	dtx_handle_reinit(dth);
+
+	D_ASSERT(dth->dth_share_tbd_count == 0);
+
+	return -DER_AGAIN;
 }

--- a/src/dtx/dtx_srv.c
+++ b/src/dtx/dtx_srv.c
@@ -42,10 +42,12 @@ dtx_handler(crt_rpc_t *rpc)
 	struct dtx_out		*dout = crt_reply_get(rpc);
 	struct ds_cont_child	*cont = NULL;
 	struct dtx_id		*dtis;
+	struct dtx_memberships	*mbs[DTX_DETECT_MAX] = { 0 };
+	uint32_t		 vers[DTX_DETECT_MAX] = { 0 };
 	uint32_t		 opc = opc_get(rpc->cr_opc);
 	int			 count = DTX_YIELD_CYCLE;
 	int			 i = 0;
-	int			 rc1;
+	int			 rc1 = 0;
 	int			 rc;
 
 	rc = ds_cont_child_lookup(din->di_po_uuid, din->di_co_uuid, &cont);
@@ -92,7 +94,35 @@ dtx_handler(crt_rpc_t *rpc)
 		else
 			rc = vos_dtx_check(cont->sc_hdl,
 					   din->di_dtx_array.ca_arrays,
-					   NULL, NULL, false);
+					   NULL, NULL, NULL, false);
+		break;
+	case DTX_REFRESH:
+		count = din->di_dtx_array.ca_count;
+		if (count == 0)
+			D_GOTO(out, rc = 0);
+
+		if (count > DTX_DETECT_MAX)
+			D_GOTO(out, rc = -DER_PROTO);
+
+		D_ALLOC(dout->do_sub_rets.ca_arrays, sizeof(int32_t) * count);
+		if (dout->do_sub_rets.ca_arrays == NULL)
+			D_GOTO(out, rc = -DER_NOMEM);
+
+		dout->do_sub_rets.ca_count = count;
+
+		for (i = 0, rc1 = 0; i < count; i++) {
+			int	*ptr = (int *)dout->do_sub_rets.ca_arrays + i;
+
+			dtis = (struct dtx_id *)din->di_dtx_array.ca_arrays + i;
+			*ptr = vos_dtx_check(cont->sc_hdl, dtis, NULL, &vers[i],
+					     &mbs[i], false);
+			/* The DTX status may be changes by DTX resync soon. */
+			if (*ptr == DTX_ST_PREPARED &&
+			    vers[i] < cont->sc_dtx_resync_ver)
+				*ptr = DTX_ST_UNCERTAIN;
+			if (mbs[i] != NULL)
+				rc1++;
+		}
 		break;
 	default:
 		rc = -DER_INVAL;
@@ -110,6 +140,40 @@ out:
 	if (rc != 0)
 		D_ERROR("send reply failed for DTX rpc %u: rc = "DF_RC"\n", opc,
 			DP_RC(rc));
+
+	if (opc == DTX_REFRESH && rc1 > 0) {
+		struct dtx_entry	 dtes[DTX_DETECT_MAX] = { 0 };
+		struct dtx_entry	*pdte[DTX_DETECT_MAX] = { 0 };
+		int			 j;
+
+		for (i = 0, j = 0; i < count; i++) {
+			if (mbs[i] == NULL)
+				continue;
+
+			daos_dti_copy(&dtes[j].dte_xid,
+				      (struct dtx_id *)
+				      din->di_dtx_array.ca_arrays + i);
+			dtes[j].dte_ver = vers[i];
+			dtes[j].dte_refs = 1;
+			dtes[j].dte_mbs = mbs[i];
+
+			pdte[j] = &dtes[j];
+			j++;
+		}
+
+		D_ASSERT(j == rc1);
+
+		/* Commit the DTX after replied the original refresh request to
+		 * avoid further query the same DTX.
+		 */
+		dtx_commit(cont, pdte, j, true);
+
+		for (i = 0; i < j; i++)
+			D_FREE(pdte[i]->dte_mbs);
+	}
+
+	D_FREE(dout->do_sub_rets.ca_arrays);
+	dout->do_sub_rets.ca_count = 0;
 
 	if (cont != NULL)
 		ds_cont_child_put(cont);

--- a/src/include/daos/dtx.h
+++ b/src/include/daos/dtx.h
@@ -48,11 +48,11 @@ enum dtx_grp_flags {
 };
 
 enum dtx_mbs_flags {
-	/* The targets that are modified by the distributed transaction
-	 * are in the same single redundancy group.
+	/* The targets modified via the DTX belong to replicated object
+	 * within single redundancy group.
 	 */
-	DMF_MODIFY_SRDG			= (1 << 0),
-	/* The MDS contains the leader information, used for distributed
+	DMF_SRDG_REP			= (1 << 0),
+	/* The MBS contains the leader information, used for distributed
 	 * transaction. For stand-alone modification, leader information
 	 * is not stored inside MBS as optimization.
 	 */
@@ -196,7 +196,7 @@ enum daos_ops_intent {
 	DAOS_INTENT_PURGE		= 1, /* purge/aggregation */
 	DAOS_INTENT_UPDATE		= 2, /* write/insert */
 	DAOS_INTENT_PUNCH		= 3, /* punch/delete */
-	DAOS_INTENT_REBUILD		= 4, /* for rebuild related scan */
+	DAOS_INTENT_MIGRATION		= 4, /* for migration related scan */
 	DAOS_INTENT_CHECK		= 5, /* check aborted or not */
 	DAOS_INTENT_KILL		= 6, /* delete object/key */
 	DAOS_INTENT_COS			= 7, /* add something into CoS cache. */

--- a/src/include/daos/object.h
+++ b/src/include/daos/object.h
@@ -425,6 +425,8 @@ enum daos_io_flags {
 	DIOF_CHECK_EXISTENCE	= 0x10,
 	/* The RPC will be sent to specified redundancy group. */
 	DIOF_TO_SPEC_GROUP	= 0x20,
+	/* For data migration. */
+	DIOF_FOR_MIGRATION	= 0x40,
 };
 
 /**

--- a/src/include/daos_srv/dtx_srv.h
+++ b/src/include/daos_srv/dtx_srv.h
@@ -31,6 +31,16 @@
 #include <daos_srv/pool.h>
 #include <daos_srv/container.h>
 
+#define DTX_DETECT_MAX	4
+
+struct dtx_share_peer {
+	d_list_t		dsp_link;
+	struct dtx_id		dsp_xid;
+	daos_unit_oid_t		dsp_oid;
+	uint32_t		dsp_leader;
+	uint32_t		dsp_ver;
+};
+
 /**
  * DAOS two-phase commit transaction handle in DRAM.
  */
@@ -76,7 +86,13 @@ struct dtx_handle {
 					 /* Local TX is started. */
 					 dth_local_tx_started:1,
 					 /* Retry with this server. */
-					 dth_local_retry:1;
+					 dth_local_retry:1,
+					 /* The DTX share lists are inited. */
+					 dth_shares_inited:1,
+					 /* Distributed transaction. */
+					 dth_dist:1,
+					 /* For data migration. */
+					 dth_for_migration:1;
 
 	/* The count the DTXs in the dth_dti_cos array. */
 	uint32_t			 dth_dti_cos_count;
@@ -108,7 +124,11 @@ struct dtx_handle {
 	struct dtx_rsrvd_uint		*dth_rsrvds;
 	void				**dth_deferred;
 	/* NVME extents to release */
-	d_list_t			dth_deferred_nvme;
+	d_list_t			 dth_deferred_nvme;
+	d_list_t			 dth_share_cmt_list;
+	d_list_t			 dth_share_act_list;
+	d_list_t			 dth_share_tbd_list;
+	int				 dth_share_tbd_count;
 };
 
 /* Each sub transaction handle to manage each sub thandle */
@@ -156,6 +176,23 @@ enum dtx_status {
 	DTX_ST_PREPARED		= 1,
 	/** The DTX has been committed. */
 	DTX_ST_COMMITTED	= 2,
+	/** The DTX is committable, but not committed. */
+	DTX_ST_COMMITTABLE	= 3,
+	/** The DTX is corrupted, some participant RDG(s) may be lost. */
+	DTX_ST_CORRUPTED	= 4,
+	/** The DTX is in-resync, not sure its status. */
+	DTX_ST_UNCERTAIN	= 5,
+};
+
+enum dtx_flags {
+	/** Single operand. */
+	DTX_SOLO		= (1 << 0),
+	/** Sync mode transaction. */
+	DTX_SYNC		= (1 << 1),
+	/** Distributed transaction.  */
+	DTX_DIST		= (1 << 2),
+	/** For data migration. */
+	DTX_FOR_MIGRATION	= (1 << 3),
 };
 
 int
@@ -165,7 +202,7 @@ dtx_leader_begin(struct ds_cont_child *cont, struct dtx_id *dti,
 		 struct dtx_epoch *epoch, uint16_t sub_modification_cnt,
 		 uint32_t pm_ver, daos_unit_oid_t *leader_oid,
 		 struct dtx_id *dti_cos, int dti_cos_cnt,
-		 struct daos_shard_tgt *tgts, int tgt_cnt, bool solo, bool sync,
+		 struct daos_shard_tgt *tgts, int tgt_cnt, uint32_t flags,
 		 struct dtx_memberships *mbs, struct dtx_leader_handle *dlh);
 int
 dtx_leader_end(struct dtx_leader_handle *dlh, struct ds_cont_child *cont,
@@ -180,7 +217,7 @@ int
 dtx_begin(struct ds_cont_child *cont, struct dtx_id *dti,
 	  struct dtx_epoch *epoch, uint16_t sub_modification_cnt,
 	  uint32_t pm_ver, daos_unit_oid_t *leader_oid,
-	  struct dtx_id *dti_cos, int dti_cos_cnt,
+	  struct dtx_id *dti_cos, int dti_cos_cnt, uint32_t flags,
 	  struct dtx_memberships *mbs, struct dtx_handle *dth);
 int
 dtx_end(struct dtx_handle *dth, struct ds_cont_child *cont, int result);
@@ -197,6 +234,8 @@ void dtx_batched_commit_deregister(struct ds_cont_child *cont);
 
 int dtx_obj_sync(struct ds_cont_child *cont, daos_unit_oid_t *oid,
 		 daos_epoch_t epoch);
+
+int dtx_refresh(struct dtx_handle *dth, struct ds_cont_child *cont);
 
 /**
  * Check whether the given DTX is resent one or not.
@@ -215,6 +254,9 @@ int dtx_obj_sync(struct ds_cont_child *cont, daos_unit_oid_t *oid,
  *					committable.
  *			-DER_MISMATCH	means that the DTX has ever been
  *					processed with different epoch.
+ *			-DER_DATA_LOSS	means that related DTX is marked as
+ *					'corrupted', not sure whether former
+ *					sent has even succeed or not.
  *			Other negative value if error.
  */
 int dtx_handle_resend(daos_handle_t coh, struct dtx_id *dti,

--- a/src/include/daos_srv/evtree.h
+++ b/src/include/daos_srv/evtree.h
@@ -624,8 +624,8 @@ enum {
 
 	/** The iterator is for purge operation */
 	EVT_ITER_FOR_PURGE	= (1 << 5),
-	/** The iterator is for rebuild scan */
-	EVT_ITER_FOR_REBUILD	= (1 << 6),
+	/** The iterator is for data migration scan */
+	EVT_ITER_FOR_MIGRATION	= (1 << 6),
 };
 
 /**

--- a/src/include/daos_srv/pool.h
+++ b/src/include/daos_srv/pool.h
@@ -211,6 +211,8 @@ int ds_pool_iv_srv_hdl_fetch(struct ds_pool *pool, uuid_t *pool_hdl_uuid,
 
 int ds_pool_svc_term_get(uuid_t uuid, uint64_t *term);
 
+int ds_pool_elect_dtx_leader(struct ds_pool *pool, daos_unit_oid_t *oid,
+			     uint32_t version);
 int ds_pool_check_dtx_leader(struct ds_pool *pool, daos_unit_oid_t *oid,
 			     uint32_t version);
 

--- a/src/include/daos_srv/vos.h
+++ b/src/include/daos_srv/vos.h
@@ -55,30 +55,34 @@ void
 vos_dtx_rsrvd_fini(struct dtx_handle *dth);
 
 /**
- * Generate DTX entry for the given DTX. It is usually used for read
- * only TX or on the server that only contains read sub operations.
+ * Generate DTX entry for the given DTX.
  *
- * \param dth	[IN]	The dtx handle
+ * \param dth		[IN]	The dtx handle
+ * \param persistent	[IN]	Save the DTX entry in persistent storage if set.
  */
 int
-vos_dtx_pin(struct dtx_handle *dth);
+vos_dtx_pin(struct dtx_handle *dth, bool persistent);
 
 /**
  * Check the specified DTX's status, and related epoch, pool map version
  * information if required.
  *
  * \param coh		[IN]	Container open handle.
- * \param xid		[IN]	Pointer to the DTX identifier.
+ * \param dti		[IN]	Pointer to the DTX identifier.
  * \param epoch		[IN,OUT] Pointer to current epoch, if it is zero and
  *				 if the DTX exists, then the DTX's epoch will
  *				 be saved in it.
  * \param pm_ver	[OUT]	Hold the DTX's pool map version.
+ * \param mbs		[OUT	Pointer to the DTX participants information.]
  * \param for_resent	[IN]	The check is for check resent or not.
  *
  * \return		DTX_ST_PREPARED	means that the DTX has been 'prepared',
  *					so the local modification has been done
  *					on related replica(s).
  *			DTX_ST_COMMITTED means the DTX has been committed.
+ *			DTX_ST_COMMITTABLE means that the DTX is committable,
+ *					   but not real committed.
+ *			DTX_ST_CORRUPTED means the DTX entry is corrupted.
  *			-DER_MISMATCH	means that the DTX has ever been
  *					processed with different epoch.
  *			-DER_AGAIN means DTX re-index is in processing, not sure
@@ -88,7 +92,7 @@ vos_dtx_pin(struct dtx_handle *dth);
  */
 int
 vos_dtx_check(daos_handle_t coh, struct dtx_id *dti, daos_epoch_t *epoch,
-	      uint32_t *pm_ver, bool for_resent);
+	      uint32_t *pm_ver, struct dtx_memberships **mbs, bool for_resent);
 
 /**
  * Commit the specified DTXs.

--- a/src/include/daos_srv/vos_types.h
+++ b/src/include/daos_srv/vos_types.h
@@ -38,7 +38,12 @@ struct dtx_rsrvd_uint {
 };
 
 enum dtx_cos_flags {
-	DCF_SHARED	= (1 << 0),
+	DCF_SHARED		= (1 << 0),
+	/* Some DTX (such as for the distributed transaction across multiple
+	 * RDGs, or for EC object modification) need to be committed via DTX
+	 * RPC instead of piggyback via other dispatched update/punch RPC.
+	 */
+	DCF_EXP_CMT		= (1 << 1),
 };
 
 struct dtx_cos_key {
@@ -58,6 +63,8 @@ enum dtx_entry_flags {
 	 * object modification via standalone update/punch.
 	 */
 	DTE_BLOCK		= (1 << 2),
+	/* The DTX is corrupted, some participant RDG(s) may be lost. */
+	DTE_CORRUPTED		= (1 << 3),
 };
 
 struct dtx_entry {
@@ -306,8 +313,8 @@ enum {
 	VOS_IT_RECX_REVERSE	= (1 << 3),
 	/** The iterator is for purge operation */
 	VOS_IT_FOR_PURGE	= (1 << 4),
-	/** The iterator is for rebuild scan */
-	VOS_IT_FOR_REBUILD	= (1 << 5),
+	/** The iterator is for data migration scan */
+	VOS_IT_FOR_MIGRATION	= (1 << 5),
 	/** Iterate only show punched records in interval */
 	VOS_IT_PUNCHED		= (1 << 6),
 	/** Mask for all flags */

--- a/src/object/cli_ec.c
+++ b/src/object/cli_ec.c
@@ -1434,7 +1434,7 @@ obj_ec_singv_req_reasb(daos_obj_id_t oid, daos_iod_t *iod, d_sg_list_t *sgl,
 
 	ec_recx_array->oer_k = oca->u.ec.e_k;
 	ec_recx_array->oer_p = oca->u.ec.e_p;
-	if (obj_ec_singv_one_tgt(iod, sgl, oca)) {
+	if (obj_ec_singv_one_tgt(iod->iod_size, sgl, oca)) {
 		/* small singv stores on one target and replicates to all
 		 * parity targets.
 		 */
@@ -2553,7 +2553,8 @@ obj_ec_recov_data(struct obj_reasb_req *reasb_req, daos_obj_id_t oid,
 		for (j = 0; j < recx_nr; j++) {
 			if (singv) {
 				stripe_nr = 1;
-				if (obj_ec_singv_one_tgt(iod, sgl, oca))
+				if (obj_ec_singv_one_tgt(iod->iod_size,
+							 sgl, oca))
 					continue;
 			} else {
 				recx_ep = &stripe_list->re_items[j];

--- a/src/object/obj_ec.h
+++ b/src/object/obj_ec.h
@@ -331,12 +331,12 @@ struct obj_ec_singv_local {
 
 /** Query if the single value record is stored in one data target */
 static inline bool
-obj_ec_singv_one_tgt(daos_iod_t *iod, d_sg_list_t *sgl,
+obj_ec_singv_one_tgt(daos_size_t iod_size, d_sg_list_t *sgl,
 		     struct daos_oclass_attr *oca)
 {
 	uint64_t size = OBJ_EC_SINGV_EVENDIST_SZ(obj_ec_data_tgt_nr(oca));
 
-	if ((iod->iod_size != DAOS_REC_ANY && iod->iod_size <= size) ||
+	if ((iod_size != DAOS_REC_ANY && iod_size <= size) ||
 	    (sgl != NULL && daos_sgl_buf_size(sgl) <= size))
 		return true;
 

--- a/src/object/obj_enum.c
+++ b/src/object/obj_enum.c
@@ -50,6 +50,12 @@ fill_recxs(daos_handle_t ih, vos_iter_entry_t *key_ent,
 		return 1;
 	}
 
+	if (arg->eprs_len >= arg->eprs_cap) {
+		D_DEBUG(DB_IO, "eprs_len %d eprs_cap %d\n",
+			arg->eprs_len, arg->eprs_cap);
+		return 1;
+	}
+
 	arg->eprs[arg->eprs_len].epr_lo = key_ent->ie_epoch;
 	arg->eprs[arg->eprs_len].epr_hi = DAOS_EPOCH_MAX;
 	arg->eprs_len++;

--- a/src/object/obj_rpc.c
+++ b/src/object/obj_rpc.c
@@ -793,7 +793,7 @@ crt_proc_struct_daos_cpd_sub_req(crt_proc_t proc,
 		if (dcsr->dcsr_nr == 0)
 			D_GOTO(out, rc = 0);
 
-		if (dcu->dcu_flags & DRF_CPD_BULK) {
+		if (dcu->dcu_flags & ORF_CPD_BULK) {
 			if (DECODING(proc_op)) {
 				D_ALLOC_ARRAY(dcu->dcu_bulks, dcsr->dcsr_nr);
 				if (dcu->dcu_bulks == NULL)

--- a/src/object/obj_rpc.h
+++ b/src/object/obj_rpc.h
@@ -151,15 +151,17 @@ enum obj_rpc_flags {
 	 */
 	ORF_ENUM_WITHOUT_EPR	= (1 << 8),
 	/* CPD RPC leader */
-	DRF_CPD_LEADER		= (1 << 9),
+	ORF_CPD_LEADER		= (1 << 9),
 	/* Bulk data transfer for CPD RPC. */
-	DRF_CPD_BULK		= (1 << 10),
+	ORF_CPD_BULK		= (1 << 10),
 	/* Contain EC split req, only used on CPD leader locally. */
-	DRF_HAS_EC_SPLIT	= (1 << 11),
+	ORF_HAS_EC_SPLIT	= (1 << 11),
 	/* Checking the existence of the object/key. */
-	DRF_CHECK_EXISTENCE	= (1 << 12),
+	ORF_CHECK_EXISTENCE	= (1 << 12),
 	/** Include the map details on fetch (daos_iom_t::iom_recxs) */
 	ORF_CREATE_MAP_DETAIL	= (1 << 13),
+	/* For data migration. */
+	ORF_FOR_MIGRATION	= (1 << 14),
 };
 
 /* common for update/fetch */

--- a/src/object/obj_tx.c
+++ b/src/object/obj_tx.c
@@ -380,7 +380,7 @@ dc_tx_cleanup_one(struct dc_tx *tx, struct daos_cpd_sub_req *dcsr)
 
 		csummer = dc_cont_hdl2csummer(tx->tx_coh);
 
-		if (dcu->dcu_flags & DRF_CPD_BULK) {
+		if (dcu->dcu_flags & ORF_CPD_BULK) {
 			for (i = 0; i < dcsr->dcsr_nr; i++) {
 				if (dcu->dcu_bulks[i] != CRT_BULK_NULL)
 					crt_bulk_free(dcu->dcu_bulks[i]);
@@ -1040,7 +1040,7 @@ tx_bulk_prepare(struct daos_cpd_sub_req *dcsr, tse_task_t *task)
 	rc = obj_bulk_prep(dcsr->dcsr_sgls, dcsr->dcsr_nr, true,
 			   CRT_BULK_RO, task, &dcu->dcu_bulks);
 	if (rc == 0)
-		dcu->dcu_flags |= ORF_BULK_BIND | DRF_CPD_BULK;
+		dcu->dcu_flags |= ORF_BULK_BIND | ORF_CPD_BULK;
 
 	return rc;
 }
@@ -1608,8 +1608,7 @@ dc_tx_commit_prepare(struct dc_tx *tx, tse_task_t *task)
 		if (grp_idx < 0)
 			D_GOTO(out, rc = grp_idx);
 
-		i = pl_select_leader(obj->cob_md.omd_id,
-				     grp_idx * obj->cob_grp_size,
+		i = pl_select_leader(obj->cob_md.omd_id, grp_idx,
 				     obj->cob_grp_size, false,
 				     obj_get_shard, obj);
 		if (i < 0)
@@ -1618,7 +1617,13 @@ dc_tx_commit_prepare(struct dc_tx *tx, tse_task_t *task)
 		leader_oid.id_pub = obj->cob_md.omd_id;
 		leader_oid.id_shard = i;
 		leader_dtrg_idx = obj_get_shard(obj, i)->po_target;
-		mbs->dm_flags |= DMF_MODIFY_SRDG;
+		if (!daos_oclass_is_ec(obj->cob_md.omd_id, NULL))
+			mbs->dm_flags |= DMF_SRDG_REP;
+
+		/* If there is only one redundancy group to be modified,
+		 * then such redundancy group information should already
+		 * has been at the head position in the dtr_list.
+		 */
 	}
 
 	dcsh->dcsh_xid = tx->tx_id;
@@ -1790,7 +1795,7 @@ dc_tx_commit_trigger(tse_task_t *task, struct dc_tx *tx, daos_tx_commit_t *args)
 
 	uuid_copy(oci->oci_pool_uuid, tx->tx_pool->dp_pool);
 	oci->oci_map_ver = tx->tx_pm_ver;
-	oci->oci_flags = DRF_CPD_LEADER | (tx->tx_set_resend ? ORF_RESEND : 0);
+	oci->oci_flags = ORF_CPD_LEADER | (tx->tx_set_resend ? ORF_RESEND : 0);
 
 	oci->oci_sub_heads.ca_arrays = &tx->tx_head;
 	oci->oci_sub_heads.ca_count = 1;

--- a/src/object/srv_obj.c
+++ b/src/object/srv_obj.c
@@ -47,6 +47,12 @@
 #include "obj_rpc.h"
 #include "obj_internal.h"
 
+static inline bool
+obj_dtx_need_refresh(struct dtx_handle *dth, int rc)
+{
+	return rc == -DER_INPROGRESS && dth->dth_share_tbd_count > 0;
+}
+
 static int
 obj_verify_bio_csum(daos_obj_id_t oid, daos_iod_t *iods,
 		    struct dcs_iod_csums *iod_csums, struct bio_desc *biod,
@@ -57,7 +63,7 @@ obj_verify_bio_csum(daos_obj_id_t oid, daos_iod_t *iods,
  * NOT contains the original leader information.
  */
 static int
-obj_gen_dtx_mbs(struct daos_shard_tgt *tgts, uint32_t *tgt_cnt,
+obj_gen_dtx_mbs(struct daos_shard_tgt *tgts, bool is_ec, uint32_t *tgt_cnt,
 		struct dtx_memberships **p_mbs)
 {
 	struct dtx_memberships	*mbs;
@@ -86,7 +92,8 @@ obj_gen_dtx_mbs(struct daos_shard_tgt *tgts, uint32_t *tgt_cnt,
 		mbs->dm_tgt_cnt = j;
 		mbs->dm_grp_cnt = 1;
 		mbs->dm_data_size = size;
-		mbs->dm_flags = DMF_MODIFY_SRDG;
+		if (!is_ec)
+			mbs->dm_flags = DMF_SRDG_REP;
 	}
 
 	*p_mbs = mbs;
@@ -176,12 +183,6 @@ obj_rw_reply(crt_rpc_t *rpc, int status, uint64_t epoch,
 
 			D_FREE(orwo->orw_maps.ca_arrays);
 			orwo->orw_maps.ca_count = 0;
-		}
-
-		if (ioc->ioc_coc) {
-			daos_csummer_free_ic(ioc->ioc_coc->sc_csummer,
-				&orwo->orw_iod_csums.ca_arrays);
-			orwo->orw_iod_csums.ca_count = 0;
 		}
 
 		daos_recx_ep_list_free(orwo->orw_rels.ca_arrays,
@@ -486,46 +487,48 @@ obj_bulk_transfer(crt_rpc_t *rpc, crt_bulk_op_t bulk_op, bool bulk_bind,
 }
 
 static int
-obj_set_reply_sizes(crt_rpc_t *rpc)
+obj_set_reply_sizes(crt_rpc_t *rpc, daos_iod_t *iods, int iod_nr)
 {
 	struct obj_rw_in	*orw = crt_req_get(rpc);
 	struct obj_rw_out	*orwo = crt_reply_get(rpc);
-	daos_iod_t		*iods;
 	uint64_t		*sizes = NULL;
-	int			size_count = 0;
 	int			i;
 
 	D_ASSERT(obj_rpc_is_fetch(rpc));
 	D_ASSERT(orwo != NULL);
 	D_ASSERT(orw != NULL);
 
-	if (orw->orw_flags & DRF_CHECK_EXISTENCE)
+	if (orw->orw_flags & ORF_CHECK_EXISTENCE)
 		goto out;
 
-	iods = orw->orw_iod_array.oia_iods;
-	size_count = orw->orw_iod_array.oia_iod_nr;
-
-	if (size_count <= 0) {
+	if (iod_nr <= 0) {
 		D_ERROR("rpc %p contains invalid sizes count %d for "
 			DF_UOID" with epc "DF_U64".\n",
-			rpc, size_count, DP_UOID(orw->orw_oid), orw->orw_epoch);
+			rpc, iod_nr, DP_UOID(orw->orw_oid), orw->orw_epoch);
 		return -DER_INVAL;
 	}
 
-	D_ALLOC_ARRAY(sizes, size_count);
-	if (sizes == NULL)
-		return -DER_NOMEM;
+	/* Re-entry case.*/
+	if (orwo->orw_iod_sizes.ca_count != 0) {
+		D_ASSERT(orwo->orw_iod_sizes.ca_count == iod_nr);
+	} else {
+		D_ALLOC_ARRAY(sizes, iod_nr);
+		if (sizes == NULL)
+			return -DER_NOMEM;
+	}
 
 	for (i = 0; i < orw->orw_iod_array.oia_iod_nr; i++)
 		sizes[i] = iods[i].iod_size;
 
 out:
-	orwo->orw_iod_sizes.ca_count = size_count;
+	if (sizes == NULL)
+		iod_nr = 0;
+	orwo->orw_iod_sizes.ca_count = iod_nr;
 	orwo->orw_iod_sizes.ca_arrays = sizes;
 
 	D_DEBUG(DB_TRACE, "rpc %p set sizes count as %d for "
 		DF_UOID" with epc "DF_U64".\n",
-		rpc, size_count, DP_UOID(orw->orw_oid), orw->orw_epoch);
+		rpc, iod_nr, DP_UOID(orw->orw_oid), orw->orw_epoch);
 
 	return 0;
 }
@@ -551,6 +554,12 @@ obj_set_reply_nrs(crt_rpc_t *rpc, daos_handle_t ioh, d_sg_list_t *sgls)
 
 	if (nrs_count == 0)
 		return 0;
+
+	/* Re-entry case. */
+	if (orwo->orw_nrs.ca_count != 0) {
+		D_ASSERT(orwo->orw_nrs.ca_count == nrs_count);
+		return 0;
+	}
 
 	/* return sg_nr_out and data size for sgl */
 	orwo->orw_nrs.ca_count = nrs_count;
@@ -611,7 +620,8 @@ obj_echo_rw(crt_rpc_t *rpc, daos_iod_t *split_iods, uint64_t *split_offs)
 		orw->orw_epoch);
 
 	if (obj_rpc_is_fetch(rpc)) {
-		rc = obj_set_reply_sizes(rpc);
+		rc = obj_set_reply_sizes(rpc, orw->orw_iod_array.oia_iods,
+					 orw->orw_iod_array.oia_iod_nr);
 		if (rc)
 			D_GOTO(out, rc);
 	}
@@ -847,35 +857,64 @@ obj_singv_ec_rw_filter(daos_unit_oid_t *oid, daos_iod_t *iods, uint64_t *offs,
 	uint32_t			 tgt_idx;
 	uint32_t			 i;
 	int				 rc = 0;
+	bool				 reentry = false;
+
+	if (!(flags & ORF_EC))
+		return rc;
 
 	tgt_idx = oid->id_shard - start_shard;
 	for (i = 0; i < nr; i++) {
+		uint64_t	gsize;
+
 		iod = &iods[i];
-		if (iod->iod_type != DAOS_IOD_SINGLE || (flags & ORF_EC) == 0)
+		if (iod->iod_type != DAOS_IOD_SINGLE)
 			continue;
-		/* for singv EC */
-		D_ASSERT(iod->iod_recxs == NULL);
+
 		if (iod->iod_size == DAOS_REC_ANY) /* punch */
 			continue;
+
+		/* Use iod_recxs to pass ir_gsize:
+		 * akey_update() => akey_update_single()
+		 */
+		if (for_update) {
+			/* For singv EC, "iod_recxs != NULL" means re-entry. */
+			if (iod->iod_recxs != NULL) {
+				reentry = true;
+			} else {
+				D_ASSERT(!reentry);
+				iod->iod_recxs = (void *)iod->iod_size;
+			}
+		} else {
+			D_ASSERT(iod->iod_recxs == NULL);
+		}
+
+		if (reentry)
+			gsize = (uintptr_t)iod->iod_recxs;
+		else
+			gsize = iod->iod_size;
+
 		if (oca == NULL) {
 			oca = daos_oclass_attr_find(oid->id_pub);
 			D_ASSERT(oca != NULL && DAOS_OC_IS_EC(oca));
 		}
-		/* using iod_recxs to pass ir_gsize (akey_update_single) */
-		if (for_update)
-			iod->iod_recxs = (void *)iod->iod_size;
-		if (!obj_ec_singv_one_tgt(iod, NULL, oca)) {
-			obj_ec_singv_local_sz(iod->iod_size, oca, tgt_idx,
-					      &loc, for_update);
-			if (offs != NULL)
-				offs[i] = loc.esl_off;
-			if (for_update)
+
+		if (obj_ec_singv_one_tgt(gsize, NULL, oca))
+			continue;
+
+		obj_ec_singv_local_sz(gsize, oca, tgt_idx, &loc, for_update);
+		if (offs != NULL)
+			offs[i] = loc.esl_off;
+
+		if (for_update) {
+			if (!reentry) {
 				iod->iod_size = loc.esl_size;
-			if (deg_fetch)
-				rc = obj_singv_ec_add_recov(nr, i,
-							    iod->iod_size,
-							    epoch,
-							    recov_lists_ptr);
+				D_ASSERT(iod->iod_size != DAOS_REC_ANY);
+			} else {
+				D_ASSERT(iod->iod_size == loc.esl_size);
+			}
+		} else if (deg_fetch) {
+			rc = obj_singv_ec_add_recov(nr, i, iod->iod_size,
+						    epoch, recov_lists_ptr);
 		}
 	}
 
@@ -912,7 +951,7 @@ map_add_recx(daos_iom_t *map, const struct bio_iov *biov, uint64_t rec_idx)
 
 /** create maps for actually written to extents. */
 static int
-obj_fetch_create_maps(crt_rpc_t *rpc, struct bio_desc *biod)
+obj_fetch_create_maps(crt_rpc_t *rpc, struct bio_desc *biod, daos_iod_t *iods)
 {
 	struct obj_rw_in	*orw = crt_req_get(rpc);
 	struct obj_rw_out	*orwo = crt_reply_get(rpc);
@@ -931,12 +970,19 @@ obj_fetch_create_maps(crt_rpc_t *rpc, struct bio_desc *biod)
 	 * Will be freed in obj_rw_reply
 	 */
 	iods_nr = orw->orw_iod_array.oia_iod_nr;
+
+	/* Re-entry case. */
+	if (orwo->orw_maps.ca_count != 0) {
+		D_ASSERT(orwo->orw_maps.ca_count == iods_nr);
+		return 0;
+	}
+
 	D_ALLOC_ARRAY(maps, iods_nr);
 	if (maps == NULL)
 		return -DER_NOMEM;
 	for (i = 0; i <  iods_nr; i++) {
 		bsgl = bio_iod_sgl(biod, i); /** 1 bsgl per iod */
-		iod = &orw->orw_iod_array.oia_iods[i];
+		iod = &iods[i];
 		map = &maps[i];
 		map->iom_nr = bsgl->bs_nr_out - bio_sgl_holes(bsgl);
 
@@ -1154,10 +1200,56 @@ out:
 	return rc;
 }
 
+static void
+daos_iod_recx_free(daos_iod_t *iods, uint32_t iod_nr)
+{
+	uint32_t	i;
+
+	if (iods != NULL) {
+		for (i = 0; i < iod_nr; i++)
+			D_FREE(iods[i].iod_recxs);
+		D_FREE(iods);
+	}
+}
+
+/** Duplicate iod and recx, reuse original iod's dkey/akey, reallocate recxs. */
 static int
-obj_local_rw(crt_rpc_t *rpc, struct obj_io_context *ioc,
-	     daos_iod_t *split_iods, struct dcs_iod_csums *split_csums,
-	     uint64_t *split_offs, struct dtx_handle *dth)
+daos_iod_recx_dup(daos_iod_t *iods, uint32_t iod_nr, daos_iod_t **iods_dup_ptr)
+{
+	daos_iod_t	*iods_dup;
+	daos_iod_t	*src, *dst;
+	uint32_t	 i;
+
+	D_ALLOC_ARRAY(iods_dup, iod_nr);
+	if (iods_dup == NULL)
+		return -DER_NOMEM;
+
+	for (i = 0; i < iod_nr; i++) {
+		src = &iods[i];
+		dst = &iods_dup[i];
+		*dst = *src;
+		if (src->iod_nr == 0 || src->iod_recxs == NULL)
+			continue;
+
+		D_ALLOC_ARRAY(dst->iod_recxs, dst->iod_nr);
+		if (dst->iod_recxs == NULL) {
+			daos_iod_recx_free(iods_dup, iod_nr);
+			return -DER_NOMEM;
+		}
+
+		memcpy(dst->iod_recxs, src->iod_recxs,
+		       sizeof(*dst->iod_recxs) * dst->iod_nr);
+	}
+
+	*iods_dup_ptr = iods_dup;
+
+	return 0;
+}
+
+static int
+obj_local_rw_internal(crt_rpc_t *rpc, struct obj_io_context *ioc,
+		      daos_iod_t *split_iods, struct dcs_iod_csums *split_csums,
+		      uint64_t *split_offs, struct dtx_handle *dth)
 {
 	struct obj_rw_in		*orw = crt_req_get(rpc);
 	struct obj_rw_out		*orwo = crt_reply_get(rpc);
@@ -1176,6 +1268,7 @@ obj_local_rw(crt_rpc_t *rpc, struct obj_io_context *ioc,
 	daos_iod_t			*iods;
 	uint64_t			*offs;
 	struct bio_sglist		*bsgls_dup = NULL; /* dedup verify */
+	daos_iod_t			*iods_dup = NULL; /* for EC deg fetch */
 	int				err, rc = 0;
 
 	D_TIME_START(time_start, OBJ_PF_UPDATE_LOCAL);
@@ -1261,7 +1354,7 @@ obj_local_rw(crt_rpc_t *rpc, struct obj_io_context *ioc,
 		bulk_op = CRT_BULK_PUT;
 		if (!rma && orw->orw_sgls.ca_arrays == NULL) {
 			spec_fetch = true;
-			if (orw->orw_flags & DRF_CHECK_EXISTENCE)
+			if (orw->orw_flags & ORF_CHECK_EXISTENCE)
 				fetch_flags = VOS_OF_FETCH_CHECK_EXISTENCE;
 			else
 				fetch_flags = VOS_OF_FETCH_SIZE_ONLY;
@@ -1269,6 +1362,27 @@ obj_local_rw(crt_rpc_t *rpc, struct obj_io_context *ioc,
 
 		ec_deg_fetch = orw->orw_flags & ORF_EC_DEGRADED;
 		if (ec_deg_fetch && !spec_fetch) {
+			if (orwo->orw_rels.ca_arrays != NULL) {
+				/* Re-entry case */
+				daos_recx_ep_list_free(orwo->orw_rels.ca_arrays,
+						       orwo->orw_rels.ca_count);
+				orwo->orw_rels.ca_arrays = NULL;
+				orwo->orw_rels.ca_count = 0;
+			}
+
+			/* Copy the iods to make it reentrant, as the
+			 * obj_fetch_shadow() possibly change the iod.
+			 */
+			rc = daos_iod_recx_dup(iods, orw->orw_nr, &iods_dup);
+			if (rc != 0) {
+				D_ERROR(DF_UOID"iod_recx_dup failed: "DF_RC"\n",
+					DP_UOID(orw->orw_oid), DP_RC(rc));
+				goto out;
+			}
+
+			D_ASSERT(iods_dup != NULL);
+			iods = iods_dup;
+
 			rc = obj_fetch_shadow(ioc->ioc_coc->sc_hdl,
 				orw->orw_oid, orw->orw_epoch, cond_flags,
 				dkey, orw->orw_nr, iods, orw->orw_tgt_idx,
@@ -1293,7 +1407,7 @@ obj_local_rw(crt_rpc_t *rpc, struct obj_io_context *ioc,
 			goto out;
 		}
 
-		rc = obj_set_reply_sizes(rpc);
+		rc = obj_set_reply_sizes(rpc, iods, orw->orw_nr);
 		if (rc != 0)
 			goto out;
 
@@ -1328,7 +1442,7 @@ obj_local_rw(crt_rpc_t *rpc, struct obj_io_context *ioc,
 		}
 	}
 
-	if (orw->orw_flags & DRF_CHECK_EXISTENCE)
+	if (orw->orw_flags & ORF_CHECK_EXISTENCE)
 		goto out;
 
 	biod = vos_ioh2desc(ioh);
@@ -1403,7 +1517,7 @@ obj_local_rw(crt_rpc_t *rpc, struct obj_io_context *ioc,
 		}
 	}
 	if (obj_rpc_is_fetch(rpc) && create_map)
-		rc = obj_fetch_create_maps(rpc, biod);
+		rc = obj_fetch_create_maps(rpc, biod, iods);
 
 	if (rc == -DER_CSUM)
 		obj_log_csum_err();
@@ -1422,7 +1536,28 @@ out:
 	}
 
 	rc = obj_rw_complete(rpc, ioc->ioc_map_ver, ioh, rc, dth);
+	if (iods_dup != NULL)
+		daos_iod_recx_free(iods_dup, orw->orw_nr);
 	D_TIME_END(time_start, OBJ_PF_UPDATE_LOCAL);
+	return rc;
+}
+
+static int
+obj_local_rw(crt_rpc_t *rpc, struct obj_io_context *ioc,
+	     daos_iod_t *split_iods, struct dcs_iod_csums *split_csums,
+	     uint64_t *split_offs, struct dtx_handle *dth)
+{
+	int	rc;
+
+again:
+	rc = obj_local_rw_internal(rpc, ioc, split_iods, split_csums,
+				   split_offs, dth);
+	if (obj_dtx_need_refresh(dth, rc)) {
+		rc = dtx_refresh(dth, ioc->ioc_coc);
+		if (rc == -DER_AGAIN)
+			goto again;
+	}
+
 	return rc;
 }
 
@@ -1716,7 +1851,8 @@ ds_obj_tgt_update_handler(crt_rpc_t *rpc)
 	tgt_cnt = orw->orw_shard_tgts.ca_count;
 
 	if (!daos_is_zero_dti(&orw->orw_dti) && tgt_cnt != 0) {
-		rc = obj_gen_dtx_mbs(tgts, &tgt_cnt, &mbs);
+		rc = obj_gen_dtx_mbs(tgts, orw->orw_flags & ORF_EC,
+				     &tgt_cnt, &mbs);
 		if (rc != 0)
 			D_GOTO(out, rc);
 	}
@@ -1728,7 +1864,9 @@ ds_obj_tgt_update_handler(crt_rpc_t *rpc)
 	rc = dtx_begin(ioc.ioc_coc, &orw->orw_dti, &epoch, 1,
 		       orw->orw_map_ver, &orw->orw_oid,
 		       orw->orw_dti_cos.ca_arrays,
-		       orw->orw_dti_cos.ca_count, mbs, &dth);
+		       orw->orw_dti_cos.ca_count,
+		       (orw->orw_flags & ORF_DTX_SYNC) ? DTX_SYNC : 0,
+		       mbs, &dth);
 	if (rc != 0) {
 		D_ERROR(DF_UOID": Failed to start DTX for update "DF_RC".\n",
 			DP_UOID(orw->orw_oid), DP_RC(rc));
@@ -1832,6 +1970,7 @@ ds_obj_rw_handler(crt_rpc_t *rpc)
 	struct obj_io_context		ioc;
 	uint64_t			time_start = 0;
 	uint32_t			flags = 0;
+	uint32_t			dtx_flags = 0;
 	uint32_t			opc = opc_get(rpc->cr_opc);
 	struct obj_ec_split_req		*split_req = NULL;
 	struct dtx_memberships		*mbs = NULL;
@@ -1884,10 +2023,13 @@ ds_obj_rw_handler(crt_rpc_t *rpc)
 		epoch.oe_first = orw->orw_epoch_first;
 		epoch.oe_flags = orf_to_dtx_epoch_flags(orw->orw_flags);
 
+		if (orw->orw_flags & ORF_FOR_MIGRATION)
+			dtx_flags = DTX_FOR_MIGRATION;
+
 re_fetch:
 		rc = dtx_begin(ioc.ioc_coc, &orw->orw_dti, &epoch, 0,
 			       orw->orw_map_ver, &orw->orw_oid,
-			       NULL, 0, NULL, &dth);
+			       NULL, 0, dtx_flags, NULL, &dth);
 		if (rc != 0)
 			goto out;
 
@@ -1925,12 +2067,18 @@ re_fetch:
 	tgt_cnt = orw->orw_shard_tgts.ca_count;
 
 	if (!daos_is_zero_dti(&orw->orw_dti) && tgt_cnt != 0) {
-		rc = obj_gen_dtx_mbs(tgts, &tgt_cnt, &mbs);
+		rc = obj_gen_dtx_mbs(tgts, orw->orw_flags & ORF_EC,
+				     &tgt_cnt, &mbs);
 		if (rc != 0)
 			D_GOTO(out, rc);
 	}
 
 	version = orw->orw_map_ver;
+
+	if (tgt_cnt == 0)
+		dtx_flags |= DTX_SOLO;
+	if (orw->orw_flags & ORF_DTX_SYNC)
+		dtx_flags |= DTX_SYNC;
 
 again:
 	/* Handle resend. */
@@ -2003,9 +2151,7 @@ again:
 
 	rc = dtx_leader_begin(ioc.ioc_coc, &orw->orw_dti, &epoch, 1, version,
 			      &orw->orw_oid, dti_cos, dti_cos_cnt,
-			      tgts, tgt_cnt, tgt_cnt == 0 ? true : false,
-			      (orw->orw_flags & ORF_DTX_SYNC) ? true : false,
-			      mbs, &dlh);
+			      tgts, tgt_cnt, dtx_flags, mbs, &dlh);
 	if (rc != 0) {
 		D_ERROR(DF_UOID": Failed to start DTX for update "DF_RC".\n",
 			DP_UOID(orw->orw_oid), DP_RC(rc));
@@ -2099,13 +2245,74 @@ obj_enum_complete(crt_rpc_t *rpc, int status, int map_version,
 }
 
 static int
+obj_enum_prep_sgls(d_sg_list_t *dst_sgls, d_sg_list_t *sgls, int number)
+{
+	int i;
+	int j;
+	int rc = 0;
+
+	for (i = 0; i < number; i++) {
+		dst_sgls[i].sg_nr = sgls[i].sg_nr;
+		D_ALLOC_ARRAY(dst_sgls[i].sg_iovs, sgls[i].sg_nr);
+		if (dst_sgls[i].sg_iovs == NULL)
+			D_GOTO(out, rc = -DER_NOMEM);
+
+		for (j = 0; j < dst_sgls[i].sg_nr; j++) {
+			dst_sgls[i].sg_iovs[j].iov_buf_len =
+				sgls[i].sg_iovs[j].iov_buf_len;
+
+			D_ALLOC(dst_sgls[i].sg_iovs[j].iov_buf,
+				dst_sgls[i].sg_iovs[j].iov_buf_len);
+			if (dst_sgls[i].sg_iovs[j].iov_buf == NULL)
+				D_GOTO(out, rc = -DER_NOMEM);
+		}
+	}
+out:
+	return rc;
+}
+
+static int
+obj_restore_enum_args(crt_rpc_t *rpc, struct dss_enum_arg *des,
+		      struct dss_enum_arg *src)
+{
+	struct obj_key_enum_out	*oeo = crt_reply_get(rpc);
+	struct obj_key_enum_in	*oei = crt_req_get(rpc);
+	int			 rc;
+
+	if (!des->fill_recxs && des->csum_iov.iov_buf != NULL)
+		daos_iov_free(&des->csum_iov);
+
+	*des = *src;
+
+	if (des->fill_recxs)
+		return 0;
+
+	if (des->kds != NULL)
+		memset(des->kds, 0, des->kds_cap * sizeof(daos_key_desc_t));
+
+	if (oeo->oeo_sgl.sg_iovs == NULL)
+		return 0;
+
+	d_sgl_fini(&oeo->oeo_sgl, true);
+	rc = obj_enum_prep_sgls(&oeo->oeo_sgl, &oei->oei_sgl, 1);
+	if (rc != 0)
+		return rc;
+
+	des->sgl = &oeo->oeo_sgl;
+	return 0;
+}
+
+static int
 obj_local_enum(struct obj_io_context *ioc, crt_rpc_t *rpc,
 	       struct vos_iter_anchors *anchors, struct dss_enum_arg *enum_arg,
 	       daos_epoch_t *e_out)
 {
 	vos_iter_param_t	param = { 0 };
+	struct vos_iter_anchors	saved_anchors;
+	struct dss_enum_arg	saved_arg;
 	struct obj_key_enum_in	*oei = crt_req_get(rpc);
 	struct dss_sleep_ult	*sleep_ult = NULL;
+	uint32_t		flags = 0;
 	int			retry = 0;
 	int			opc = opc_get(rpc->cr_opc);
 	int			type;
@@ -2205,14 +2412,30 @@ obj_local_enum(struct obj_io_context *ioc, crt_rpc_t *rpc,
 		goto failed;
 	}
 
+	saved_anchors = *anchors;
+	saved_arg = *enum_arg;
+
+	if (oei->oei_flags & ORF_FOR_MIGRATION)
+		flags = DTX_FOR_MIGRATION;
+
 again:
-	rc = dtx_begin(ioc->ioc_coc, &oei->oei_dti, &epoch, 0,
-		       oei->oei_map_ver, &oei->oei_oid, NULL, 0, NULL, &dth);
+	rc = dtx_begin(ioc->ioc_coc, &oei->oei_dti, &epoch, 0, oei->oei_map_ver,
+		       &oei->oei_oid, NULL, 0, flags, NULL, &dth);
 	if (rc != 0)
 		goto failed;
 
+re_pack:
 	rc = dss_enum_pack(&param, type, recursive, anchors, enum_arg,
 			   vos_iterate, &dth);
+	if (obj_dtx_need_refresh(&dth, rc)) {
+		rc = dtx_refresh(&dth, ioc->ioc_coc);
+		if (rc == -DER_AGAIN) {
+			*anchors = saved_anchors;
+			obj_restore_enum_args(rpc, enum_arg, &saved_arg);
+
+			goto re_pack;
+		}
+	}
 
 	/* dss_enum_pack may return 1. */
 	rc_tmp = dtx_end(&dth, ioc->ioc_coc, rc > 0 ? 0 : rc);
@@ -2240,7 +2463,9 @@ again:
 			DF_UOID" (%d)\n", DP_UOID(oei->oei_oid), retry);
 		dss_ult_sleep(sleep_ult, 30000);
 
-		/* re-enumeration from the last -DER_TX_BUSY. */
+		*anchors = saved_anchors;
+		obj_restore_enum_args(rpc, enum_arg, &saved_arg);
+
 		goto again;
 	}
 
@@ -2317,33 +2542,6 @@ obj_enum_reply_bulk(crt_rpc_t *rpc)
 	return rc;
 }
 
-static int
-obj_enum_prep_sgls(d_sg_list_t *dst_sgls, d_sg_list_t *sgls, int number)
-{
-	int i;
-	int j;
-	int rc = 0;
-
-	for (i = 0; i < number; i++) {
-		dst_sgls[i].sg_nr = sgls[i].sg_nr;
-		D_ALLOC_ARRAY(dst_sgls[i].sg_iovs, sgls[i].sg_nr);
-		if (dst_sgls[i].sg_iovs == NULL)
-			D_GOTO(out, rc = -DER_NOMEM);
-
-		for (j = 0; j < dst_sgls[i].sg_nr; j++) {
-			dst_sgls[i].sg_iovs[j].iov_buf_len =
-				sgls[i].sg_iovs[j].iov_buf_len;
-
-			D_ALLOC(dst_sgls[i].sg_iovs[j].iov_buf,
-				dst_sgls[i].sg_iovs[j].iov_buf_len);
-			if (dst_sgls[i].sg_iovs[j].iov_buf == NULL)
-				D_GOTO(out, rc = -DER_NOMEM);
-		}
-	}
-out:
-	return rc;
-}
-
 void
 ds_obj_enum_handler(crt_rpc_t *rpc)
 {
@@ -2389,9 +2587,7 @@ ds_obj_enum_handler(crt_rpc_t *rpc)
 		enum_arg.eprs = oeo->oeo_eprs.ca_arrays;
 		enum_arg.eprs_cap = oei->oei_nr;
 		enum_arg.eprs_len = 0;
-	}
 
-	if (opc == DAOS_OBJ_RECX_RPC_ENUMERATE) {
 		oeo->oeo_recxs.ca_count = 0;
 		D_ALLOC(oeo->oeo_recxs.ca_arrays,
 			oei->oei_nr * sizeof(daos_recx_t));
@@ -2484,6 +2680,7 @@ obj_local_punch(struct obj_punch_in *opi, crt_opcode_t opc,
 		dth = NULL;
 	}
 
+again:
 	rc = dtx_sub_init(dth, &opi->opi_oid, opi->opi_dkey_hash);
 	if (rc != 0)
 		goto out;
@@ -2517,6 +2714,13 @@ obj_local_punch(struct obj_punch_in *opi, crt_opcode_t opc,
 		D_ERROR("opc %#x not supported\n", opc);
 		D_GOTO(out, rc = -DER_NOSYS);
 	}
+
+	if (obj_dtx_need_refresh(dth, rc)) {
+		rc = dtx_refresh(dth, ioc->ioc_coc);
+		if (rc == -DER_AGAIN)
+			goto again;
+	}
+
 out:
 	return rc;
 }
@@ -2569,7 +2773,8 @@ ds_obj_tgt_punch_handler(crt_rpc_t *rpc)
 	tgt_cnt = opi->opi_shard_tgts.ca_count;
 
 	if (!daos_is_zero_dti(&opi->opi_dti) && tgt_cnt != 0) {
-		rc = obj_gen_dtx_mbs(tgts, &tgt_cnt, &mbs);
+		rc = obj_gen_dtx_mbs(tgts, opi->opi_flags & ORF_EC,
+				     &tgt_cnt, &mbs);
 		if (rc != 0)
 			D_GOTO(out, rc);
 	}
@@ -2582,7 +2787,9 @@ ds_obj_tgt_punch_handler(crt_rpc_t *rpc)
 	rc = dtx_begin(ioc.ioc_coc, &opi->opi_dti, &epoch, 1,
 		       opi->opi_map_ver, &opi->opi_oid,
 		       opi->opi_dti_cos.ca_arrays,
-		       opi->opi_dti_cos.ca_count, mbs, &dth);
+		       opi->opi_dti_cos.ca_count,
+		       (opi->opi_flags & ORF_DTX_SYNC) ? DTX_SYNC : 0,
+		       mbs, &dth);
 	if (rc != 0) {
 		D_ERROR(DF_UOID": Failed to start DTX for punch "DF_RC".\n",
 			DP_UOID(opi->opi_oid), DP_RC(rc));
@@ -2668,10 +2875,9 @@ obj_tgt_punch(struct dtx_leader_handle *dlh, void *arg, int idx,
 		struct obj_punch_in	*opi = crt_req_get(rpc);
 		int			rc = 0;
 
-		if (!(exec_arg->flags & ORF_RESEND)) {
+		if (!(exec_arg->flags & ORF_RESEND))
 			rc = obj_local_punch(opi, opc_get(rpc->cr_opc),
 					     exec_arg->ioc, &dlh->dlh_handle);
-		}
 		if (comp_cb != NULL)
 			comp_cb(dlh, idx, rc);
 
@@ -2696,6 +2902,7 @@ ds_obj_punch_handler(crt_rpc_t *rpc)
 	int				dti_cos_cnt;
 	uint32_t			tgt_cnt;
 	uint32_t			flags = 0;
+	uint32_t			dtx_flags = 0;
 	uint32_t			version;
 	struct dtx_epoch		epoch;
 	int				rc;
@@ -2739,10 +2946,16 @@ ds_obj_punch_handler(crt_rpc_t *rpc)
 	tgt_cnt = opi->opi_shard_tgts.ca_count;
 
 	if (!daos_is_zero_dti(&opi->opi_dti) && tgt_cnt != 0) {
-		rc = obj_gen_dtx_mbs(tgts, &tgt_cnt, &mbs);
+		rc = obj_gen_dtx_mbs(tgts, opi->opi_flags & ORF_EC,
+				     &tgt_cnt, &mbs);
 		if (rc != 0)
 			D_GOTO(out, rc);
 	}
+
+	if (tgt_cnt == 0)
+		dtx_flags |= DTX_SOLO;
+	if (opi->opi_flags & ORF_DTX_SYNC)
+		dtx_flags |= DTX_SYNC;
 
 again:
 	/* Handle resend. */
@@ -2799,9 +3012,7 @@ again:
 
 	rc = dtx_leader_begin(ioc.ioc_coc, &opi->opi_dti, &epoch, 1, version,
 			      &opi->opi_oid, dti_cos, dti_cos_cnt,
-			      tgts, tgt_cnt, tgt_cnt == 0 ? true : false,
-			      (opi->opi_flags & ORF_DTX_SYNC) ? true : false,
-			      mbs, &dlh);
+			      tgts, tgt_cnt, dtx_flags, mbs, &dlh);
 	if (rc != 0) {
 		D_ERROR(DF_UOID": Failed to start DTX for punch "DF_RC".\n",
 			DP_UOID(opi->opi_oid), DP_RC(rc));
@@ -2904,7 +3115,7 @@ again:
 	epoch.oe_flags = orf_to_dtx_epoch_flags(okqi->okqi_flags);
 
 	rc = dtx_begin(ioc.ioc_coc, &okqi->okqi_dti, &epoch, 0,
-		       okqi->okqi_map_ver, &okqi->okqi_oid, NULL, 0, NULL,
+		       okqi->okqi_map_ver, &okqi->okqi_oid, NULL, 0, 0, NULL,
 		       &dth);
 	if (rc != 0)
 		goto out;
@@ -2917,12 +3128,19 @@ again:
 	} else {
 		query_recx = &okqo->okqo_recx;
 	}
+
+re_query:
 	rc = vos_obj_query_key(ioc.ioc_vos_coh, okqi->okqi_oid, query_flags,
 			       okqi->okqi_epoch, dkey, akey, query_recx, &dth);
 	if (rc == 0 && (query_flags & VOS_GET_RECX_EC)) {
 		okqo->okqo_recx = ec_recx[0];
 		okqo->okqo_recx_parity = ec_recx[1];
+	} else if (obj_dtx_need_refresh(&dth, rc)) {
+		rc = dtx_refresh(&dth, ioc.ioc_coc);
+		if (rc == -DER_AGAIN)
+			goto re_query;
 	}
+
 	rc = dtx_end(&dth, ioc.ioc_coc, rc);
 
 out:
@@ -3249,7 +3467,7 @@ ds_obj_dtx_handle_one(crt_rpc_t *rpc, struct daos_cpd_sub_head *dcsh,
 			goto out;
 		}
 
-		if (dcu->dcu_flags & DRF_CPD_BULK) {
+		if (dcu->dcu_flags & ORF_CPD_BULK) {
 			if (bulks == NULL) {
 				D_ALLOC_ARRAY(bulks, dcde->dcde_write_cnt);
 				if (bulks == NULL)
@@ -3497,7 +3715,7 @@ out:
 		/* For the case of only containing read sub operations,
 		 * we will generate DTX entry for DTX recovery.
 		 */
-		rc = vos_dtx_pin(dth);
+		rc = vos_dtx_pin(dth, true);
 
 	return rc;
 }
@@ -3510,6 +3728,7 @@ ds_obj_dtx_follower(crt_rpc_t *rpc, struct obj_io_context *ioc)
 	struct daos_cpd_sub_head	*dcsh = ds_obj_cpd_get_dcsh(rpc, 0);
 	struct daos_cpd_disp_ent	*dcde = ds_obj_cpd_get_dcde(rpc, 0, 0);
 	struct daos_cpd_sub_req		*dcsr = ds_obj_cpd_get_dcsr(rpc, 0);
+	uint32_t			 dtx_flags = DTX_DIST;
 	int				 rc = 0;
 	int				 rc1 = 0;
 
@@ -3553,13 +3772,27 @@ ds_obj_dtx_follower(crt_rpc_t *rpc, struct obj_io_context *ioc)
 			D_GOTO(out, rc);
 	}
 
+	if (rc1 < 0 && rc1 != -DER_NONEXIST)
+		goto out;
+
+	if (oci->oci_flags & ORF_DTX_SYNC)
+		dtx_flags |= DTX_SYNC;
+
 	rc = dtx_begin(ioc->ioc_coc, &dcsh->dcsh_xid, &dcsh->dcsh_epoch,
 		       dcde->dcde_write_cnt, oci->oci_map_ver,
-		       &dcsh->dcsh_leader_oid, NULL, 0, dcsh->dcsh_mbs, &dth);
+		       &dcsh->dcsh_leader_oid, NULL, 0, dtx_flags,
+		       dcsh->dcsh_mbs, &dth);
 	if (rc != 0)
 		goto out;
 
+again:
 	rc = ds_obj_dtx_handle_one(rpc, dcsh, dcde, dcsr, ioc, &dth);
+	if (obj_dtx_need_refresh(&dth, rc)) {
+		rc = dtx_refresh(&dth, ioc->ioc_coc);
+		if (rc == -DER_AGAIN)
+			goto again;
+	}
+
 	rc = dtx_end(&dth, ioc->ioc_coc, rc);
 
 out:
@@ -3582,6 +3815,7 @@ obj_obj_dtx_leader(struct dtx_leader_handle *dlh, void *arg, int idx,
 	if (idx == -1) {
 		if (!(exec_arg->flags & ORF_RESEND)) {
 			struct daos_cpd_disp_ent	*dcde;
+			struct obj_io_context		*ioc = dca->dca_ioc;
 
 			dcde = ds_obj_cpd_get_dcde(dca->dca_rpc,
 						   dca->dca_idx, 0);
@@ -3589,8 +3823,7 @@ obj_obj_dtx_leader(struct dtx_leader_handle *dlh, void *arg, int idx,
 			 * the CPD RPC. Here, only need to check the write capa.
 			 */
 			if (dcde->dcde_write_cnt != 0) {
-				rc = obj_capa_check(dca->dca_ioc->ioc_coh,
-						    true);
+				rc = obj_capa_check(ioc->ioc_coh, true);
 				if (rc != 0) {
 					comp_cb(dlh, idx, rc);
 
@@ -3598,11 +3831,18 @@ obj_obj_dtx_leader(struct dtx_leader_handle *dlh, void *arg, int idx,
 				}
 			}
 
+again:
 			rc = ds_obj_dtx_handle_one(dca->dca_rpc,
 				ds_obj_cpd_get_dcsh(dca->dca_rpc, dca->dca_idx),
 				dcde,
 				ds_obj_cpd_get_dcsr(dca->dca_rpc, dca->dca_idx),
-				dca->dca_ioc, &dlh->dlh_handle);
+				ioc, &dlh->dlh_handle);
+			if (obj_dtx_need_refresh(&dlh->dlh_handle, rc)) {
+				rc = dtx_refresh(&dlh->dlh_handle,
+						 ioc->ioc_coc);
+				if (rc == -DER_AGAIN)
+					goto again;
+			}
 		}
 
 		if (comp_cb != NULL)
@@ -3649,7 +3889,7 @@ ds_obj_dtx_leader_prep_handle(struct daos_cpd_sub_head *dcsh,
 		}
 
 		if (dcu->dcu_ec_split_req != NULL)
-			*flags |= DRF_HAS_EC_SPLIT;
+			*flags |= ORF_HAS_EC_SPLIT;
 	}
 
 	return rc;
@@ -3668,6 +3908,7 @@ ds_obj_dtx_leader_ult(void *arg)
 	struct daos_cpd_sub_req		 *dcsrs = NULL;
 	struct daos_shard_tgt		 *tgts;
 	uint32_t			  flags = 0;
+	uint32_t			  dtx_flags = DTX_DIST;
 	uint32_t			  tgt_cnt = 0;
 	uint32_t			  req_cnt = 0;
 	int				  rc = 0;
@@ -3773,17 +4014,14 @@ ds_obj_dtx_leader_ult(void *arg)
 	else
 		tgts++;
 
-	/* For distributed transaction, ask DTX  to 'sync' commit. For single
-	 * RDG based modification (with the dm_flag DMF_MODIFY_SRDG), we will
-	 * consider 'async' mode when batched commit is ready for distributed
-	 * transaction.
-	 */
+	if (tgt_cnt <= 1 && dcde->dcde_write_cnt <= 1)
+		dtx_flags |= DTX_SOLO;
+
 	rc = dtx_leader_begin(dca->dca_ioc->ioc_coc, &dcsh->dcsh_xid,
 			      &dcsh->dcsh_epoch, dcde->dcde_write_cnt,
-			      oci->oci_map_ver, &dcsh->dcsh_leader_oid, NULL,
-			      0, tgts, tgt_cnt - 1,
-			      (tgt_cnt > 1 || dcde->dcde_write_cnt > 1) ?
-			      false : true, true, dcsh->dcsh_mbs, &dlh);
+			      oci->oci_map_ver, &dcsh->dcsh_leader_oid,
+			      NULL, 0, tgts, tgt_cnt - 1, dtx_flags,
+			      dcsh->dcsh_mbs, &dlh);
 	if (rc != 0)
 		goto out;
 
@@ -3842,7 +4080,7 @@ ds_obj_cpd_handler(crt_rpc_t *rpc)
 
 	D_ASSERT(oci != NULL);
 
-	if (oci->oci_flags & DRF_CPD_LEADER)
+	if (oci->oci_flags & ORF_CPD_LEADER)
 		leader = true;
 	else
 		leader = false;

--- a/src/object/srv_obj_remote.c
+++ b/src/object/srv_obj_remote.c
@@ -481,7 +481,7 @@ ds_obj_cpd_dispatch(struct dtx_leader_handle *dlh, void *arg, int idx,
 	uuid_copy(oci->oci_co_uuid, oci_parent->oci_co_uuid);
 	oci->oci_map_ver = oci_parent->oci_map_ver;
 	oci->oci_flags = (oci_parent->oci_flags | exec_arg->flags) &
-			~(DRF_HAS_EC_SPLIT | DRF_CPD_LEADER);
+			~(ORF_HAS_EC_SPLIT | ORF_CPD_LEADER);
 
 	oci->oci_disp_tgts.ca_arrays = NULL;
 	oci->oci_disp_tgts.ca_count = 0;
@@ -502,7 +502,7 @@ ds_obj_cpd_dispatch(struct dtx_leader_handle *dlh, void *arg, int idx,
 		D_GOTO(out, rc = -DER_INVAL);
 
 	count = dcde_parent->dcde_read_cnt + dcde_parent->dcde_write_cnt;
-	if (count < total || exec_arg->flags & DRF_HAS_EC_SPLIT) {
+	if (count < total || exec_arg->flags & ORF_HAS_EC_SPLIT) {
 		rc = ds_obj_cpd_clone_reqs(dlh, shard_tgt, dcde_parent,
 					   dcsr_parent, total, &dcde, &dcsr);
 		if (rc != 0)

--- a/src/pool/srv_pool.c
+++ b/src/pool/srv_pool.c
@@ -4968,6 +4968,42 @@ out:
 	crt_reply_send(rpc);
 }
 
+int
+ds_pool_elect_dtx_leader(struct ds_pool *pool, daos_unit_oid_t *oid,
+			 uint32_t version)
+{
+	struct pl_map		*map;
+	struct pl_obj_layout	*layout;
+	struct daos_obj_md	 md = { 0 };
+	int			 rc = 0;
+
+	map = pl_map_find(pool->sp_uuid, oid->id_pub);
+	if (map == NULL) {
+		D_WARN("Failed to find pool map tp select leader for "
+		       DF_UOID" version = %d\n", DP_UOID(*oid), version);
+		return -DER_INVAL;
+	}
+
+	md.omd_id = oid->id_pub;
+	md.omd_ver = version;
+	rc = pl_obj_place(map, &md, NULL, &layout);
+	if (rc != 0)
+		goto out;
+
+	rc = pl_select_leader(oid->id_pub, oid->id_shard / layout->ol_grp_size,
+			      layout->ol_grp_size, true,
+			      pl_obj_get_shard, layout);
+	pl_obj_layout_free(layout);
+	if (rc < 0)
+		D_WARN("Failed to select leader for "DF_UOID
+		       "version = %d: rc = %d\n",
+		       DP_UOID(*oid), version, rc);
+
+out:
+	pl_map_decref(map);
+	return rc;
+}
+
 /**
  * Check whether the leader replica of the given object resides
  * on current server or not.
@@ -4984,59 +5020,31 @@ int
 ds_pool_check_dtx_leader(struct ds_pool *pool, daos_unit_oid_t *oid,
 			 uint32_t version)
 {
-	struct pl_map		*map;
-	struct pl_obj_layout	*layout = NULL;
 	struct pool_target	*target;
-	struct daos_obj_md	 md = { 0 };
-	int			 leader;
 	d_rank_t		 myrank;
-	int			 rc = 0;
+	int			 leader;
+	int			 rc;
 
-	map = pl_map_find(pool->sp_uuid, oid->id_pub);
-	if (map == NULL) {
-		D_WARN("Failed to find pool map tp select leader for "
-		       DF_UOID" version = %d\n", DP_UOID(*oid), version);
-		return -DER_INVAL;
-	}
-
-	md.omd_id = oid->id_pub;
-	md.omd_ver = version;
-	rc = pl_obj_place(map, &md, NULL, &layout);
-	if (rc != 0)
-		goto out;
-
-	leader = pl_select_leader(oid->id_pub,
-				  oid->id_shard / layout->ol_grp_size,
-				  layout->ol_grp_size, true,
-				  pl_obj_get_shard, layout);
-	if (leader < 0) {
-		D_WARN("Failed to select leader for "DF_UOID
-		       "version = %d: rc = %d\n",
-		       DP_UOID(*oid), version, leader);
-		D_GOTO(out, rc = leader);
-	}
+	leader = ds_pool_elect_dtx_leader(pool, oid, version);
+	if (leader < 0)
+		return leader;
 
 	D_DEBUG(DB_TRACE, "get new leader tgt id %d\n", leader);
 	rc = pool_map_find_target(pool->sp_map, leader, &target);
 	if (rc < 0)
-		goto out;
+		return rc;
 
 	if (rc != 1)
-		D_GOTO(out, rc = -DER_INVAL);
+		return -DER_INVAL;
 
 	rc = crt_group_rank(NULL, &myrank);
 	if (rc < 0)
-		goto out;
+		return rc;
 
 	if (myrank != target->ta_comp.co_rank)
 		rc = 0;
 	else
 		rc = 1;
-
-out:
-	if (layout != NULL)
-		pl_obj_layout_free(layout);
-	pl_map_decref(map);
 
 	return rc;
 }

--- a/src/rebuild/scan.c
+++ b/src/rebuild/scan.c
@@ -97,7 +97,7 @@ rebuild_obj_fill_buf(daos_handle_t ih, d_iov_t *key_iov,
 		arg->count, arg->tgt_id);
 
 	/* re-probe the dbtree after delete */
-	rc = dbtree_iter_probe(ih, BTR_PROBE_FIRST, DAOS_INTENT_REBUILD, NULL,
+	rc = dbtree_iter_probe(ih, BTR_PROBE_FIRST, DAOS_INTENT_MIGRATION, NULL,
 			       NULL);
 	if (rc == -DER_NONEXIST)
 		return 1;
@@ -118,7 +118,7 @@ rebuild_obj_send_cb(struct tree_cache_root *root, struct rebuild_send_arg *arg)
 	/* re-init the send argument to fill the object buffer */
 	arg->count = 0;
 	arg->tgt_id = -1;
-	rc = dbtree_iterate(root->root_hdl, DAOS_INTENT_REBUILD, false,
+	rc = dbtree_iterate(root->root_hdl, DAOS_INTENT_MIGRATION, false,
 			    rebuild_obj_fill_buf, arg);
 	if (rc < 0 || arg->count == 0) {
 		D_DEBUG(DB_REBUILD, "Can not get objects: "DF_RC"\n",
@@ -180,7 +180,7 @@ rebuild_cont_send_cb(daos_handle_t ih, d_iov_t *key_iov,
 	}
 
 	/* Some one might insert new record to the tree let's reprobe */
-	rc = dbtree_iter_probe(ih, BTR_PROBE_EQ, DAOS_INTENT_REBUILD, key_iov,
+	rc = dbtree_iter_probe(ih, BTR_PROBE_EQ, DAOS_INTENT_MIGRATION, key_iov,
 			       NULL);
 	if (rc) {
 		D_ERROR("dbtree_iter_probe failed: "DF_RC"\n", DP_RC(rc));
@@ -194,7 +194,7 @@ rebuild_cont_send_cb(daos_handle_t ih, d_iov_t *key_iov,
 	}
 
 	/* re-probe the dbtree after delete */
-	rc = dbtree_iter_probe(ih, BTR_PROBE_FIRST, DAOS_INTENT_REBUILD, NULL,
+	rc = dbtree_iter_probe(ih, BTR_PROBE_FIRST, DAOS_INTENT_MIGRATION, NULL,
 			       NULL);
 	if (rc == -DER_NONEXIST)
 		return 1;
@@ -241,7 +241,8 @@ rebuild_objects_send_ult(void *data)
 		}
 
 		/* walk through the rebuild tree and send the rebuild objects */
-		rc = dbtree_iterate(tls->rebuild_tree_hdl, DAOS_INTENT_REBUILD,
+		rc = dbtree_iterate(tls->rebuild_tree_hdl,
+				    DAOS_INTENT_MIGRATION,
 				    false, rebuild_cont_send_cb, &arg);
 		if (rc < 0) {
 			D_ERROR("dbtree iterate failed: rc "DF_RC"\n",
@@ -473,7 +474,7 @@ rebuild_container_scan_cb(daos_handle_t ih, vos_iter_entry_t *entry,
 	param.ip_hdl = coh;
 	param.ip_epr.epr_lo = 0;
 	param.ip_epr.epr_hi = DAOS_EPOCH_MAX;
-	param.ip_flags = VOS_IT_FOR_REBUILD;
+	param.ip_flags = VOS_IT_FOR_MIGRATION;
 	uuid_copy(arg->co_uuid, entry->ie_couuid);
 	rc = vos_iterate(&param, VOS_ITER_OBJ, false, &anchor,
 			 rebuild_obj_scan_cb, NULL, arg, NULL);
@@ -541,7 +542,7 @@ rebuild_scanner(void *data)
 		D_GOTO(out, rc = -DER_NONEXIST);
 
 	param.ip_hdl = child->spc_hdl;
-	param.ip_flags = VOS_IT_FOR_REBUILD;
+	param.ip_flags = VOS_IT_FOR_MIGRATION;
 	arg.rpt = rpt;
 	arg.yield_freq = DEFAULT_YIELD_FREQ;
 	if (!rebuild_status_match(rpt, PO_COMP_ST_UP)) {

--- a/src/vos/evt_iter.c
+++ b/src/vos/evt_iter.c
@@ -209,8 +209,8 @@ evt_iter_intent(struct evt_iterator *iter)
 {
 	if (iter->it_options & EVT_ITER_FOR_PURGE)
 		return DAOS_INTENT_PURGE;
-	if (iter->it_options & EVT_ITER_FOR_REBUILD)
-		return DAOS_INTENT_REBUILD;
+	if (iter->it_options & EVT_ITER_FOR_MIGRATION)
+		return DAOS_INTENT_MIGRATION;
 	return DAOS_INTENT_DEFAULT;
 }
 

--- a/src/vos/evtree.c
+++ b/src/vos/evtree.c
@@ -2116,6 +2116,128 @@ evt_entry_fill(struct evt_context *tcx, struct evt_node *node, unsigned int at,
 	}
 }
 
+struct evt_data_loss_item {
+	d_list_t		edli_link;
+	struct evt_rect		edli_rect;
+};
+
+static struct evt_data_loss_item *
+evt_data_loss_add(d_list_t *head, struct evt_rect *rect)
+{
+	struct evt_data_loss_item	*edli;
+
+	D_ALLOC_PTR(edli);
+	if (edli != NULL) {
+		edli->edli_rect = *rect;
+		d_list_add(&edli->edli_link, head);
+	}
+
+	return edli;
+}
+
+static int
+evt_data_loss_check(d_list_t *head, struct evt_entry_array *ent_array)
+{
+	struct evt_data_loss_item	*edli;
+	struct evt_data_loss_item	*tmp;
+	struct evt_list_entry		*entry;
+	int				 i;
+
+	d_list_for_each_entry_safe(edli, tmp, head, edli_link) {
+		bool	visible = true;
+
+		d_list_del(&edli->edli_link);
+
+		for (i = 0; i < ent_array->ea_ent_nr; i++) {
+			entry = &ent_array->ea_ents[i];
+
+			/* edli is newer */
+			if (edli->edli_rect.rc_epc > entry->le_ent.en_epoch)
+				continue;
+
+			/* non-overlap */
+			if (edli->edli_rect.rc_ex.ex_lo >
+			    entry->le_ent.en_ext.ex_hi ||
+			    edli->edli_rect.rc_ex.ex_hi <
+			    entry->le_ent.en_ext.ex_lo)
+				continue;
+
+			/* edli is totally covered by entry */
+			if (edli->edli_rect.rc_ex.ex_lo >=
+			    entry->le_ent.en_ext.ex_lo &&
+			    edli->edli_rect.rc_ex.ex_hi <=
+			    entry->le_ent.en_ext.ex_lo) {
+				visible = false;
+				break;
+			}
+
+			/* edli totally covers entry */
+			if (edli->edli_rect.rc_ex.ex_lo <=
+			    entry->le_ent.en_ext.ex_lo &&
+			    edli->edli_rect.rc_ex.ex_hi >=
+			    entry->le_ent.en_ext.ex_lo) {
+				/* cur low part */
+				if (edli->edli_rect.rc_ex.ex_lo ==
+				    entry->le_ent.en_ext.ex_lo) {
+					edli->edli_rect.rc_ex.ex_lo =
+						entry->le_ent.en_ext.ex_hi + 1;
+					continue;
+				}
+
+				/* cut high part */
+				if (edli->edli_rect.rc_ex.ex_hi ==
+				    entry->le_ent.en_ext.ex_hi) {
+					edli->edli_rect.rc_ex.ex_hi =
+						entry->le_ent.en_ext.ex_lo - 1;
+					continue;
+				}
+
+				tmp = evt_data_loss_add(head, &edli->edli_rect);
+				if (tmp == NULL) {
+					D_FREE(edli);
+					return -DER_NOMEM;
+				}
+
+				/* split edli */
+				tmp->edli_rect.rc_ex.ex_lo =
+					entry->le_ent.en_ext.ex_hi + 1;
+				tmp->edli_rect.rc_ex.ex_hi =
+					edli->edli_rect.rc_ex.ex_hi;
+				edli->edli_rect.rc_ex.ex_hi =
+					entry->le_ent.en_ext.ex_lo - 1;
+				continue;
+			}
+
+			/* edli low part overlap with entry */
+			if (edli->edli_rect.rc_ex.ex_lo <=
+			    entry->le_ent.en_ext.ex_hi &&
+			    edli->edli_rect.rc_ex.ex_hi >
+			    entry->le_ent.en_ext.ex_hi) {
+				edli->edli_rect.rc_ex.ex_lo =
+					entry->le_ent.en_ext.ex_hi + 1;
+				continue;
+			}
+
+			/* edli high part overlap with entry */
+			if (edli->edli_rect.rc_ex.ex_hi >=
+			    entry->le_ent.en_ext.ex_lo &&
+			    edli->edli_rect.rc_ex.ex_lo <
+			    entry->le_ent.en_ext.ex_lo) {
+				edli->edli_rect.rc_ex.ex_hi =
+					entry->le_ent.en_ext.ex_lo - 1;
+				continue;
+			}
+		}
+
+		D_FREE(edli);
+
+		if (visible)
+			return -DER_DATA_LOSS;
+	}
+
+	return 0;
+}
+
 /**
  * See the description in evt_priv.h
  */
@@ -2125,16 +2247,20 @@ evt_ent_array_fill(struct evt_context *tcx, enum evt_find_opc find_opc,
 		   const struct evt_rect *rect,
 		   struct evt_entry_array *ent_array)
 {
-	umem_off_t	nd_off;
-	int		level;
-	int		at;
-	int		i;
-	int		rc = 0;
+	struct evt_data_loss_item	*edli;
+	d_list_t			 data_loss_list;
+	umem_off_t			 nd_off;
+	int				 level;
+	int				 at;
+	int				 i;
+	int				 rc = 0;
 
 	V_TRACE(DB_TRACE, "Searching rectangle "DF_RECT" opc=%d\n",
 		DP_RECT(rect), find_opc);
 	if (tcx->tc_root->tr_depth == 0)
 		return 0; /* empty tree */
+
+	D_INIT_LIST_HEAD(&data_loss_list);
 
 	evt_tcx_reset_trace(tcx);
 	ent_array->ea_inob = tcx->tc_inob;
@@ -2268,6 +2394,13 @@ evt_ent_array_fill(struct evt_context *tcx, enum evt_find_opc find_opc,
 				if (rc < 0)
 					D_GOTO(out, rc);
 			case EVT_FIND_ALL:
+				if (rc == -DER_DATA_LOSS) {
+					if (evt_data_loss_add(&data_loss_list,
+							      &rtmp) == NULL)
+						D_GOTO(out, rc = -DER_NOMEM);
+
+					continue;
+				}
 				break;
 			}
 
@@ -2320,8 +2453,16 @@ evt_ent_array_fill(struct evt_context *tcx, enum evt_find_opc find_opc,
 		}
 	}
 out:
+	if (rc == 0 && !d_list_empty(&data_loss_list))
+		rc = evt_data_loss_check(&data_loss_list, ent_array);
+
 	if (rc != 0)
 		evt_ent_array_fini(ent_array);
+
+	while ((edli = d_list_pop_entry(&data_loss_list,
+					struct evt_data_loss_item,
+					edli_link)) != NULL)
+		D_FREE(edli);
 
 	return rc;
 }
@@ -3267,7 +3408,7 @@ evt_remove_all(daos_handle_t toh, const struct evt_extent *ext,
 {
 	struct evt_context	*tcx;
 	struct evt_entry	*entry;
-	struct evt_entry_array	 ent_array;
+	struct evt_entry_array	 ent_array = { 0 };
 	struct evt_filter	 filter = {0};
 	int			 rc;
 	struct evt_rect		 rect;
@@ -3289,12 +3430,11 @@ evt_remove_all(daos_handle_t toh, const struct evt_extent *ext,
 				&filter, &rect, &ent_array);
 	if (rc != 0) {
 		D_ERROR("ent_array_fill failed: "DF_RC"\n", DP_RC(rc));
-		evt_ent_array_fini(&ent_array);
-		return rc;
+		goto done;
 	}
 
 	if (ent_array.ea_ent_nr == 0)
-		return 0;
+		D_GOTO(done, rc = 0);
 
 	evt_ent_array_for_each(entry, &ent_array) {
 		if (entry->en_visibility & EVT_PARTIAL) {
@@ -3308,7 +3448,7 @@ evt_remove_all(daos_handle_t toh, const struct evt_extent *ext,
 
 	rc = evt_tx_begin(tcx);
 	if (rc != 0)
-		return rc;
+		goto done;
 
 	evt_ent_array_for_each(entry, &ent_array) {
 		struct evt_rect	to_delete;

--- a/src/vos/tests/vts_dtx.c
+++ b/src/vos/tests/vts_dtx.c
@@ -78,6 +78,8 @@ vts_dtx_begin(const daos_unit_oid_t *oid, daos_handle_t coh, daos_epoch_t epoch,
 	dth->dth_solo = 0;
 	dth->dth_modify_shared = 0;
 	dth->dth_active = 0;
+	dth->dth_dist = 0;
+	dth->dth_for_migration = 0;
 
 	dth->dth_dti_cos_count = 0;
 	dth->dth_dti_cos = NULL;
@@ -92,6 +94,12 @@ vts_dtx_begin(const daos_unit_oid_t *oid, daos_handle_t coh, daos_epoch_t epoch,
 
 	dth->dth_dkey_hash = dkey_hash;
 
+	D_INIT_LIST_HEAD(&dth->dth_share_cmt_list);
+	D_INIT_LIST_HEAD(&dth->dth_share_act_list);
+	D_INIT_LIST_HEAD(&dth->dth_share_tbd_list);
+	dth->dth_share_tbd_count = 0;
+	dth->dth_shares_inited = 1;
+
 	vos_dtx_rsrvd_init(dth);
 
 	*dthp = dth;
@@ -100,6 +108,27 @@ vts_dtx_begin(const daos_unit_oid_t *oid, daos_handle_t coh, daos_epoch_t epoch,
 void
 vts_dtx_end(struct dtx_handle *dth)
 {
+	struct dtx_share_peer	*dsp;
+
+	if (dth->dth_shares_inited) {
+		while ((dsp = d_list_pop_entry(&dth->dth_share_cmt_list,
+					       struct dtx_share_peer,
+					       dsp_link)) != NULL)
+			D_FREE(dsp);
+
+		while ((dsp = d_list_pop_entry(&dth->dth_share_act_list,
+					       struct dtx_share_peer,
+					       dsp_link)) != NULL)
+			D_FREE(dsp);
+
+		while ((dsp = d_list_pop_entry(&dth->dth_share_tbd_list,
+					       struct dtx_share_peer,
+					       dsp_link)) != NULL)
+			D_FREE(dsp);
+
+		dth->dth_share_tbd_count = 0;
+	}
+
 	vos_dtx_rsrvd_fini(dth);
 	D_FREE(dth->dth_dte.dte_mbs);
 	D_FREE_PTR(dth);
@@ -804,7 +833,7 @@ dtx_18(void **state)
 
 	for (i = 0; i < 10; i++) {
 		rc = vos_dtx_check(args->ctx.tc_co_hdl, &xid[i],
-				   NULL, NULL, false);
+				   NULL, NULL, NULL, false);
 		assert_int_equal(rc, DTX_ST_COMMITTED);
 	}
 
@@ -816,7 +845,7 @@ dtx_18(void **state)
 
 	for (i = 0; i < 10; i++) {
 		rc = vos_dtx_check(args->ctx.tc_co_hdl, &xid[i],
-				   NULL, NULL, false);
+				   NULL, NULL, NULL, false);
 		assert_int_equal(rc, -DER_NONEXIST);
 	}
 

--- a/src/vos/tests/vts_mvcc.c
+++ b/src/vos/tests/vts_mvcc.c
@@ -43,6 +43,8 @@
 struct tx_helper {
 	/** Current transaction handle */
 	struct dtx_handle	*th_dth;
+	/** Save the XID to cleanup related TX. */
+	struct dtx_id		 th_saved_xid;
 	/** Number of total ops in current tx */
 	uint32_t		 th_nr_ops;
 	/** Number of write ops in current tx */
@@ -262,6 +264,10 @@ stop_tx(daos_handle_t coh, struct tx_helper *txh, bool success, bool write)
 			if (success && !txh->th_skip_commit) {
 				err = vos_dtx_commit(coh, &xid, 1, NULL);
 				assert(err >= 0);
+			} else {
+				if (!success)
+					txh->th_skip_commit = false;
+				daos_dti_copy(&txh->th_saved_xid, &xid);
 			}
 		}
 	}
@@ -1490,6 +1496,25 @@ out:
 		print_message("FAILED: "DF_CASE"\n",
 			      DP_CASE(i, j, empty, w, wp, we, commit, a, ap, ae,
 				      bound, mvcc_arg->i));
+
+	if (!daos_is_zero_dti(&wtx->th_saved_xid)) {
+		if (wtx->th_skip_commit)
+			vos_dtx_commit(arg->ctx.tc_co_hdl, &wtx->th_saved_xid,
+				       1, NULL);
+		else
+			vos_dtx_abort(arg->ctx.tc_co_hdl, DAOS_EPOCH_MAX,
+				      &wtx->th_saved_xid, 1);
+	}
+
+	if (!daos_is_zero_dti(&atx->th_saved_xid)) {
+		if (atx->th_skip_commit)
+			vos_dtx_commit(arg->ctx.tc_co_hdl, &atx->th_saved_xid,
+				       1, NULL);
+		else
+			vos_dtx_abort(arg->ctx.tc_co_hdl, DAOS_EPOCH_MAX,
+				      &atx->th_saved_xid, 1);
+	}
+
 #undef DP_CASE
 #undef DF_CASE
 	return nfailed;

--- a/src/vos/vos_common.c
+++ b/src/vos/vos_common.c
@@ -168,6 +168,9 @@ vos_tx_publish(struct dtx_handle *dth, bool publish)
 	int			 rc;
 	int			 i;
 
+	if (dth->dth_rsrvds == NULL)
+		return 0;
+
 	for (i = 0; i < dth->dth_rsrvd_cnt; i++) {
 		dru = &dth->dth_rsrvds[i];
 		rc = vos_publish_scm(cont, dru->dru_scm, publish);
@@ -216,7 +219,7 @@ vos_tx_begin(struct dtx_handle *dth, struct umem_instance *umm)
 {
 	int	rc;
 
-	if (!dtx_is_valid_handle(dth))
+	if (dth == NULL)
 		return umem_tx_begin(umm, vos_txd_get());
 
 	if (dth->dth_local_tx_started)

--- a/src/vos/vos_dtx.c
+++ b/src/vos/vos_dtx.c
@@ -109,30 +109,92 @@ dtx_set_aborted(uint32_t *tx_lid)
 
 static inline int
 dtx_inprogress(struct vos_dtx_act_ent *dae, struct dtx_handle *dth,
-	       bool for_read, int pos)
+	       bool hit_again, int pos)
 {
-	/* If the modifications crosses multiple redundancy groups, then it
-	 * is possible that the sub modifications on the DTX leader are not
-	 * the same as the ones on non-leaders. Under such case, if someone
-	 * wants to read the data on some non-leader but hits non-committed
-	 * DTX, then asking the client to retry with leader maybe not help.
-	 * Instead, we can ask make the client to retry the read again (and
-	 * again) sometime later. We do sync commit the DTX with 'DTE_BLOCK'
-	 * flag. So it will not cause the client to retry read for too many
-	 * times unless such DTX hit some trouble (such as client or server
-	 * failure) that may cause current readers to be blocked until such
-	 * DTX has been handled by the new leader via DTX recovery.
-	 */
-	if (DAE_FLAGS(dae) & DTE_BLOCK && for_read && dth != NULL &&
-	    dth->dth_modification_cnt == 0)
-		dth->dth_local_retry = 1;
-	else if (dth != NULL)
-		dth->dth_local_retry = 0;
+	struct dtx_share_peer	*dsp;
+	bool			 s_try = false;
 
+	if (dth == NULL)
+		goto out;
+
+	if (DAE_FLAGS(dae) & DTE_LEADER)
+		goto out;
+
+	/* If hit the same non-committed DTX again after once dtx_refresh,
+	 * then ask client to retry, the leader may be waiting non-leader
+	 * to reply at that time.
+	 */
+	if (hit_again) {
+		while ((dsp = d_list_pop_entry(&dth->dth_share_tbd_list,
+					       struct dtx_share_peer,
+					       dsp_link)) != NULL)
+			D_FREE(dsp);
+		dth->dth_share_tbd_count = 0;
+		goto out;
+	}
+
+	/* For the DTX with 'DTE_BLOCK' flag, we will sych commit them. But
+	 * before it is committed, if someone wants to read related data on
+	 * non-leader, we can make related IO handle to retry locally, that
+	 * will not cause too much overhead unless the DTX hit some trouble
+	 * (such as client or server failure) that may cause current reader
+	 * to be blocked until such DTX has been handled by the new leader.
+	 */
+
+	if (DAE_FLAGS(dae) & DTE_BLOCK && dth->dth_modification_cnt == 0) {
+		if (dth->dth_share_tbd_count == 0)
+			dth->dth_local_retry = 1;
+		goto out;
+	}
+
+	if (DAE_MBS_FLAGS(dae) & DMF_SRDG_REP && dth->dth_dist == 0)
+		goto out;
+
+	s_try = true;
+
+	d_list_for_each_entry(dsp, &dth->dth_share_tbd_list, dsp_link) {
+		if (memcmp(&dsp->dsp_xid, &DAE_XID(dae),
+			   sizeof(struct dtx_id)) == 0)
+			goto out;
+	}
+
+	if (dth->dth_share_tbd_count >= DTX_DETECT_MAX)
+		goto out;
+
+	D_ALLOC_PTR(dsp);
+	if (dsp == NULL) {
+		D_ERROR("Hit uncommitted DTX "DF_DTI" at %d: lid=%d, "
+			"but fail to alloc DRAM.\n",
+			DP_DTI(&DAE_XID(dae)), pos, DAE_LID(dae));
+		return -DER_NOMEM;
+	}
+
+	dsp->dsp_xid = DAE_XID(dae);
+	dsp->dsp_oid = DAE_OID(dae);
+	if (DAE_MBS_FLAGS(dae) & DMF_CONTAIN_LEADER) {
+		struct umem_instance	*umm;
+		struct dtx_daos_target	*ddt;
+
+		if (DAE_MBS_DSIZE(dae) <= sizeof(DAE_MBS_INLINE(dae))) {
+			ddt = DAE_MBS_INLINE(dae);
+		} else {
+			umm = vos_cont2umm(vos_hdl2cont(dth->dth_coh));
+			ddt = umem_off2ptr(umm, DAE_MBS_OFF(dae));
+		}
+		dsp->dsp_leader = ddt->ddt_id;
+	} else {
+		dsp->dsp_leader = PO_COMP_ID_ALL;
+	}
+
+	d_list_add_tail(&dsp->dsp_link, &dth->dth_share_tbd_list);
+	dth->dth_share_tbd_count++;
+
+out:
 	D_DEBUG(DB_IO,
-		"Hit uncommitted DTX "DF_DTI" at %d: lid=%d, need %s retry\n",
-		DP_DTI(&DAE_XID(dae)), pos, DAE_LID(dae),
-		(dth != NULL && dth->dth_local_retry) ? "local" : "remote");
+		"%s hit uncommitted DTX "DF_DTI" at %d: lid=%d, "
+		"may need %s retry.\n", hit_again ? "Repeat" : "First",
+		DP_DTI(&DAE_XID(dae)), pos, DAE_LID(dae), s_try ? "server" :
+		(dth != NULL && dth->dth_local_retry) ? "local" : "client");
 
 	return -DER_INPROGRESS;
 }
@@ -589,6 +651,9 @@ dtx_rec_release(struct vos_container *cont, struct vos_dtx_act_ent *dae,
 
 	D_ASSERT(DAE_INDEX(dae) >= 0);
 
+	if (dae->dae_dbd == NULL)
+		return 0;
+
 	dbd = dae->dae_dbd;
 	D_ASSERT(dbd->dbd_magic == DTX_ACT_BLOB_MAGIC);
 
@@ -903,21 +968,47 @@ vos_dtx_abort_one(struct vos_container *cont, daos_epoch_t epoch,
 		goto out;
 	}
 
-	if (epoch != 0 && DAE_EPOCH(dae) > epoch)
-		D_GOTO(out, rc = -DER_NONEXIST);
+	/* XXX: If @epoch is zero, then it is a special abort: we will mark
+	 *	related DTX as 'corrupted'. An corrupted DTX entry will not
+	 *	be removed (destroyed) from the system, instead, it will be
+	 *	kept there until related corruption (lost servers) has been
+	 *	recovered or being cleanup via some special tools.
+	 */
+	if (epoch == 0) {
+		struct umem_instance		*umm = vos_cont2umm(cont);
+		struct vos_dtx_act_ent_df	*dae_df;
 
-	rc = dtx_rec_release(cont, dae, true);
-	if (rc != 0) {
-		*fatal = true;
-		goto out;
+		dae_df = umem_off2ptr(umm, dae->dae_df_off);
+		D_ASSERT(dae_df != NULL);
+
+		rc = umem_tx_add_ptr(umm, &dae_df->dae_flags,
+				     sizeof(dae_df->dae_flags));
+		if (rc == 0) {
+			dae_df->dae_flags |= DTE_CORRUPTED;
+			DAE_FLAGS(dae) |= DTE_CORRUPTED;
+		}
+	} else {
+		if (DAE_EPOCH(dae) > epoch)
+			D_GOTO(out, rc = -DER_NONEXIST);
+
+		rc = dtx_rec_release(cont, dae, true);
+		if (rc != 0) {
+			*fatal = true;
+			goto out;
+		}
+
+		D_ASSERT(dae_p != NULL);
+		*dae_p = dae;
 	}
 
-	D_ASSERT(dae_p != NULL);
-	*dae_p = dae;
-
 out:
-	D_DEBUG(DB_IO, "Abort the DTX "DF_DTI": rc = "DF_RC"\n", DP_DTI(dti),
-		DP_RC(rc));
+	if (epoch == 0)
+		D_CDEBUG(rc != 0, DLOG_ERR, DLOG_WARN,
+			 "Mark the DTX entry "DF_DTI" as corrupted: "DF_RC"\n",
+			 DP_DTI(dti), DP_RC(rc));
+	else
+		D_DEBUG(DB_IO, "Abort the DTX "DF_DTI": rc = "DF_RC"\n",
+			DP_DTI(dti), DP_RC(rc));
 
 	return rc;
 }
@@ -985,12 +1076,10 @@ vos_dtx_extend_act_table(struct vos_container *cont)
 }
 
 static int
-vos_dtx_alloc(struct umem_instance *umm, struct dtx_handle *dth)
+vos_dtx_alloc(struct vos_dtx_blob_df *dbd, struct dtx_handle *dth)
 {
 	struct vos_dtx_act_ent		*dae = NULL;
 	struct vos_container		*cont;
-	struct vos_cont_df		*cont_df;
-	struct vos_dtx_blob_df		*dbd;
 	uint32_t			 idx;
 	d_iov_t				 kiov;
 	d_iov_t				 riov;
@@ -998,17 +1087,6 @@ vos_dtx_alloc(struct umem_instance *umm, struct dtx_handle *dth)
 
 	cont = vos_hdl2cont(dth->dth_coh);
 	D_ASSERT(cont != NULL);
-
-	cont_df = cont->vc_cont_df;
-
-	dbd = umem_off2ptr(umm, cont_df->cd_dtx_active_tail);
-	if (dbd == NULL || dbd->dbd_index >= dbd->dbd_cap) {
-		rc = vos_dtx_extend_act_table(cont);
-		if (rc != 0)
-			return rc;
-
-		dbd = umem_off2ptr(umm, cont_df->cd_dtx_active_tail);
-	}
 
 	rc = lrua_allocx(cont->vc_dtx_array, &idx, dth->dth_epoch, &dae);
 	if (rc != 0) {
@@ -1033,14 +1111,17 @@ vos_dtx_alloc(struct umem_instance *umm, struct dtx_handle *dth)
 	DAE_MBS_DSIZE(dae) = dth->dth_mbs->dm_data_size;
 	DAE_MBS_FLAGS(dae) = dth->dth_mbs->dm_flags;
 
-	/* Will be set as dbd::dbd_index via vos_dtx_prepared(). */
-	DAE_INDEX(dae) = DTX_INDEX_INVAL;
+	if (dbd != NULL) {
+		D_ASSERT(dbd->dbd_magic == DTX_ACT_BLOB_MAGIC);
 
-	dae->dae_df_off = cont_df->cd_dtx_active_tail +
+		dae->dae_df_off = cont->vc_cont_df->cd_dtx_active_tail +
 			offsetof(struct vos_dtx_blob_df, dbd_active_data) +
 			sizeof(struct vos_dtx_act_ent_df) * dbd->dbd_index;
+	}
+
+	/* Will be set as dbd::dbd_index via vos_dtx_prepared(). */
+	DAE_INDEX(dae) = DTX_INDEX_INVAL;
 	dae->dae_dbd = dbd;
-	D_ASSERT(dbd->dbd_magic == DTX_ACT_BLOB_MAGIC);
 	D_DEBUG(DB_IO, "Allocated new lid DTX: "DF_DTI" lid=%d dae=%p"
 		" dae_dbd=%p\n", DP_DTI(&dth->dth_xid), DAE_LID(dae), dae, dbd);
 
@@ -1048,12 +1129,10 @@ vos_dtx_alloc(struct umem_instance *umm, struct dtx_handle *dth)
 	d_iov_set(&riov, dae, sizeof(*dae));
 	rc = dbtree_upsert(cont->vc_dtx_active_hdl, BTR_PROBE_EQ,
 			   DAOS_INTENT_UPDATE, &kiov, &riov);
-	if (rc == 0) {
+	if (rc == 0)
 		dth->dth_ent = dae;
-		dth->dth_active = 1;
-	} else {
+	else
 		dtx_evict_lid(cont, dae);
-	}
 
 	return rc;
 }
@@ -1112,6 +1191,9 @@ vos_dtx_check_availability(daos_handle_t coh, uint32_t entry,
 	struct vos_dtx_act_ent		*dae = NULL;
 	bool				 found;
 
+	if (dth != NULL && dth->dth_for_migration)
+		intent = DAOS_INTENT_MIGRATION;
+
 	switch (type) {
 	case DTX_RT_SVT:
 	case DTX_RT_EVT:
@@ -1139,25 +1221,31 @@ vos_dtx_check_availability(daos_handle_t coh, uint32_t entry,
 	if (entry == DTX_LID_COMMITTED)
 		return ALB_AVAILABLE_CLEAN;
 
-	if (intent == DAOS_INTENT_PURGE)
-		return ALB_AVAILABLE_DIRTY;
-
 	/* Aborted */
 	if (dtx_is_aborted(entry))
-		return ALB_UNAVAILABLE;
-
-	/* The DTX owner can always see the DTX. */
-	if (dtx_is_valid_handle(dth) && dth->dth_ent != NULL) {
-		dae = dth->dth_ent;
-		if (DAE_LID(dae) == entry && DAE_EPOCH(dae) == epoch)
-			return ALB_AVAILABLE_CLEAN;
-	}
+		return intent == DAOS_INTENT_PURGE ?
+			ALB_AVAILABLE_DIRTY : ALB_UNAVAILABLE;
 
 	cont = vos_hdl2cont(coh);
 	D_ASSERT(cont != NULL);
 
 	found = lrua_lookupx(cont->vc_dtx_array, entry - DTX_LID_RESERVED,
 			     epoch, &dae);
+
+	/* The DTX owner can always see the DTX. */
+	if (found && dtx_is_valid_handle(dth) && dae == dth->dth_ent)
+		return ALB_AVAILABLE_CLEAN;
+
+	if (intent == DAOS_INTENT_PURGE) {
+		/* XXX: For the corrupted DTX entry, we need some special
+		 *	tools (TBD) to recover or handle it. So NOT purge
+		 *	it via general VOS aggregation.
+		 */
+		if (found && DAE_FLAGS(dae) & DTE_CORRUPTED)
+			return ALB_UNAVAILABLE;
+
+		return ALB_AVAILABLE_DIRTY;
+	}
 
 	if (!found) {
 		/** If we move to not marking entries explicitly, this
@@ -1175,29 +1263,69 @@ vos_dtx_check_availability(daos_handle_t coh, uint32_t entry,
 	if (dae->dae_aborted)
 		return ALB_UNAVAILABLE;
 
-	/* The following are for non-committable cases. */
+	/* Access corrupted DTX entry. */
+	if (DAE_FLAGS(dae) & DTE_CORRUPTED) {
+		/* Allow update/punch against corrupted SV or EV with new
+		 * epoch. But if the obj/key is corrupted, or it is fetch
+		 * operation, then return -DER_DATA_LOSS.
+		 */
+		if ((intent == DAOS_INTENT_UPDATE ||
+		     intent == DAOS_INTENT_PUNCH) &&
+		    (type == DTX_RT_SVT || type == DTX_RT_EVT))
+			return ALB_AVAILABLE_CLEAN;
 
-	if (intent == DAOS_INTENT_DEFAULT || intent == DAOS_INTENT_REBUILD ||
+		/* Corrupted DTX is invisible to data migration. */
+		if (intent == DAOS_INTENT_MIGRATION)
+			return ALB_UNAVAILABLE;
+
+		return -DER_DATA_LOSS;
+	}
+
+	if (!(DAE_FLAGS(dae) & DTE_LEADER) &&
+	    !(DAE_MBS_FLAGS(dae) & DMF_SRDG_REP) && dth != NULL) {
+		struct dtx_share_peer	*dsp;
+
+		d_list_for_each_entry(dsp, &dth->dth_share_cmt_list, dsp_link) {
+			if (memcmp(&dsp->dsp_xid, &DAE_XID(dae),
+				   sizeof(struct dtx_id)) == 0)
+				return ALB_AVAILABLE_CLEAN;
+		}
+
+		d_list_for_each_entry(dsp, &dth->dth_share_act_list, dsp_link) {
+			if (memcmp(&dsp->dsp_xid, &DAE_XID(dae),
+				   sizeof(struct dtx_id)) == 0) {
+				if (!dtx_is_valid_handle(dth) ||
+				    intent == DAOS_INTENT_IGNORE_NONCOMMITTED)
+					return ALB_UNAVAILABLE;
+
+				return dtx_inprogress(dae, dth, true, 4);
+			}
+		}
+	}
+
+	/* The following are for non-committable cases.
+	 *
+	 * Current CoS mechanism only works for single RDG based replicated
+	 * object modification. For other cases, such as transaction across
+	 * multiple RDGs, or modifying EC object, we may have to query with
+	 * related leader.
+	 */
+
+	if (intent == DAOS_INTENT_DEFAULT || intent == DAOS_INTENT_MIGRATION ||
 	    intent == DAOS_INTENT_IGNORE_NONCOMMITTED) {
 		if (!(DAE_FLAGS(dae) & DTE_LEADER) ||
-		    DAOS_FAIL_CHECK(DAOS_VOS_NON_LEADER)) {
-			/* Inavailable for rebuild case. */
-			if (intent == DAOS_INTENT_REBUILD)
-				return ALB_UNAVAILABLE;
-
-			/* Non-leader and non-rebuild case, return
-			 * -DER_INPROGRESS, then the caller will retry
-			 * the RPC with leader replica.
+		    DAOS_FAIL_CHECK(DAOS_VOS_NON_LEADER))
+			/* Non-leader or rebuild case, return -DER_INPROGRESS,
+			 * then the caller will retry the RPC (with leader).
 			 */
-			return dtx_inprogress(dae, dth, true, 1);
-		}
+			return dtx_inprogress(dae, dth, false, 1);
 
 		/* For transactional read, has to wait the non-committed
 		 * modification to guarantee the transaction semantics.
 		 */
 		if (dtx_is_valid_handle(dth) &&
 		    intent != DAOS_INTENT_IGNORE_NONCOMMITTED)
-			return dtx_inprogress(dae, dth, true, 2);
+			return dtx_inprogress(dae, dth, false, 2);
 
 		/* For stand-alone read on leader, ignore non-committed DTX. */
 		return ALB_UNAVAILABLE;
@@ -1253,6 +1381,7 @@ vos_dtx_register_record(struct umem_instance *umm, umem_off_t record,
 			uint32_t type, uint32_t *tx_id)
 {
 	struct dtx_handle	*dth = vos_dth_get();
+	struct vos_dtx_act_ent	*dae;
 	int			 rc = 0;
 
 	if (!dtx_is_valid_handle(dth)) {
@@ -1269,22 +1398,56 @@ vos_dtx_register_record(struct umem_instance *umm, umem_off_t record,
 		return 0;
 	}
 
-	if (dth->dth_ent == NULL) {
-		rc = vos_dtx_alloc(umm, dth);
-		if (rc != 0)
-			return rc;
+	dae = dth->dth_ent;
+	if (!dth->dth_active) {
+		struct vos_container	*cont;
+		struct vos_cont_df	*cont_df;
+		struct vos_dtx_blob_df	*dbd;
+
+		cont = vos_hdl2cont(dth->dth_coh);
+		D_ASSERT(cont != NULL);
+
+		umm = vos_cont2umm(cont);
+		cont_df = cont->vc_cont_df;
+
+		dbd = umem_off2ptr(umm, cont_df->cd_dtx_active_tail);
+		if (dbd == NULL || dbd->dbd_index >= dbd->dbd_cap) {
+			rc = vos_dtx_extend_act_table(cont);
+			if (rc != 0)
+				goto out;
+
+			dbd = umem_off2ptr(umm, cont_df->cd_dtx_active_tail);
+		}
+
+		if (dae == NULL) {
+			rc = vos_dtx_alloc(dbd, dth);
+			if (rc != 0)
+				goto out;
+
+			dae = dth->dth_ent;
+		} else {
+			D_ASSERT(dbd->dbd_magic == DTX_ACT_BLOB_MAGIC);
+
+			dae->dae_df_off = cont_df->cd_dtx_active_tail +
+					offsetof(struct vos_dtx_blob_df,
+						 dbd_active_data) +
+					sizeof(struct vos_dtx_act_ent_df) *
+					dbd->dbd_index;
+			dae->dae_dbd = dbd;
+		}
+
+		dth->dth_active = 1;
 	}
 
 	rc = vos_dtx_append(dth, record, type);
 	if (rc == 0) {
-		struct vos_dtx_act_ent	*dae = dth->dth_ent;
-
 		/* Incarnation log entry implies a share */
 		*tx_id = DAE_LID(dae);
 		if (type == DTX_RT_ILOG)
 			dth->dth_modify_shared = 1;
 	}
 
+out:
 	D_DEBUG(DB_TRACE, "Register DTX record for "DF_DTI
 		": lid=%d entry %p, type %d, %s ilog entry, rc %d\n",
 		DP_DTI(&dth->dth_xid),
@@ -1416,12 +1579,23 @@ vos_dtx_prepared(struct dtx_handle *dth)
 
 	umm = vos_cont2umm(cont);
 	dbd = dae->dae_dbd;
+	D_ASSERT(dbd != NULL);
+
+	/* Use the dkey_hash for the last modification as the dkey_hash
+	 * for the whole transaction. It will used as the index for DTX
+	 * committable/CoS cache.
+	 */
+	DAE_DKEY_HASH(dae) = dth->dth_dkey_hash;
 
 	/* If the DTX is for punch object that is quite possible affect
 	 * subsequent operations, then synchronously commit the DTX when
 	 * it becomes committable to avoid availability trouble.
+	 *
+	 * If someone (from non-leader) tried to refresh the DTX status
+	 * before its 'prepared', then let's commit it synchronously.
 	 */
-	if (DAE_DKEY_HASH(dae) == 0)
+	if ((DAE_DKEY_HASH(dae) == 0 || dae->dae_maybe_shared) &&
+	    (dth->dth_modification_cnt > 0))
 		dth->dth_sync = 1;
 
 	DAE_OID_CNT(dae) = dth->dth_oid_cnt;
@@ -1500,9 +1674,34 @@ vos_dtx_prepared(struct dtx_handle *dth)
 	return 0;
 }
 
+static struct dtx_memberships *
+vos_dtx_pack_mbs(struct umem_instance *umm, struct vos_dtx_act_ent *dae)
+{
+	struct dtx_memberships	*tmp;
+	size_t			 size;
+
+	size = sizeof(*tmp) + DAE_MBS_DSIZE(dae);
+	D_ALLOC(tmp, size);
+	if (tmp == NULL)
+		return NULL;
+
+	tmp->dm_tgt_cnt = DAE_TGT_CNT(dae);
+	tmp->dm_grp_cnt = DAE_GRP_CNT(dae);
+	tmp->dm_data_size = DAE_MBS_DSIZE(dae);
+	tmp->dm_flags = DAE_MBS_FLAGS(dae);
+	tmp->dm_dte_flags = DAE_FLAGS(dae);
+	if (tmp->dm_data_size <= sizeof(DAE_MBS_INLINE(dae)))
+		memcpy(tmp->dm_data, DAE_MBS_INLINE(dae), tmp->dm_data_size);
+	else
+		memcpy(tmp->dm_data, umem_off2ptr(umm, DAE_MBS_OFF(dae)),
+		       tmp->dm_data_size);
+
+	return tmp;
+}
+
 int
 vos_dtx_check(daos_handle_t coh, struct dtx_id *dti, daos_epoch_t *epoch,
-	      uint32_t *pm_ver, bool for_resent)
+	      uint32_t *pm_ver, struct dtx_memberships **mbs, bool for_resent)
 {
 	struct vos_container	*cont;
 	struct vos_dtx_act_ent	*dae;
@@ -1518,11 +1717,33 @@ vos_dtx_check(daos_handle_t coh, struct dtx_id *dti, daos_epoch_t *epoch,
 	rc = dbtree_lookup(cont->vc_dtx_active_hdl, &kiov, &riov);
 	if (rc == 0) {
 		dae = (struct vos_dtx_act_ent *)riov.iov_buf;
-		if (dae->dae_committable || dae->dae_committed)
+
+		if (DAE_FLAGS(dae) & DTE_CORRUPTED)
+			return DTX_ST_CORRUPTED;
+
+		if (pm_ver != NULL)
+			*pm_ver = DAE_VER(dae);
+
+		if (dae->dae_committed)
 			return DTX_ST_COMMITTED;
+
+		if (dae->dae_committable) {
+			if (mbs != NULL)
+				*mbs = vos_dtx_pack_mbs(vos_cont2umm(cont),
+							dae);
+
+			return DTX_ST_COMMITTABLE;
+		}
 
 		if (dae->dae_aborted)
 			return -DER_NONEXIST;
+
+		if (mbs != NULL)
+			dae->dae_maybe_shared = 1;
+
+		/* Leader has not finish the 'prepare' phase, */
+		if (dae->dae_dbd == NULL)
+			return -DER_INPROGRESS;
 
 		if (epoch != NULL) {
 			if (*epoch == 0)
@@ -1530,9 +1751,6 @@ vos_dtx_check(daos_handle_t coh, struct dtx_id *dti, daos_epoch_t *epoch,
 			else if (*epoch != DAE_EPOCH(dae))
 				return -DER_MISMATCH;
 		}
-
-		if (pm_ver != NULL)
-			*pm_ver = DAE_VER(dae);
 
 		return DTX_ST_PREPARED;
 	}
@@ -1773,6 +1991,7 @@ vos_dtx_post_handle(struct vos_container *cont, struct vos_dtx_act_ent **daes,
 				daes[i]->dae_aborted = 1;
 			else
 				daes[i]->dae_committed = 1;
+			DAE_FLAGS(daes[i]) &= ~DTE_CORRUPTED;
 		}
 	}
 }
@@ -1969,6 +2188,7 @@ vos_dtx_mark_committable(struct dtx_handle *dth)
 		D_ASSERT(dae != NULL);
 
 		dae->dae_committable = 1;
+		DAE_FLAGS(dae) &= ~DTE_CORRUPTED;
 	}
 }
 
@@ -2223,7 +2443,8 @@ vos_dtx_cleanup_internal(struct dtx_handle *dth)
 	d_iov_t			 kiov;
 	int			 rc;
 
-	if (!dtx_is_valid_handle(dth) || !dth->dth_active)
+	if (!dtx_is_valid_handle(dth) ||
+	    (!dth->dth_active && dth->dth_ent == NULL))
 		return;
 
 	dth->dth_active = 0;
@@ -2252,7 +2473,8 @@ vos_dtx_cleanup(struct dtx_handle *dth)
 	int			 max;
 	int			 i;
 
-	if (!dtx_is_valid_handle(dth) || !dth->dth_active)
+	if (!dtx_is_valid_handle(dth) ||
+	    (!dth->dth_active && dth->dth_ent == NULL))
 		return;
 
 	cont = vos_hdl2cont(dth->dth_coh);
@@ -2277,10 +2499,10 @@ vos_dtx_cleanup(struct dtx_handle *dth)
 }
 
 int
-vos_dtx_pin(struct dtx_handle *dth)
+vos_dtx_pin(struct dtx_handle *dth, bool persistent)
 {
-	struct vos_container	*cont;
-	struct umem_instance	*umm;
+	struct umem_instance	*umm = NULL;
+	struct vos_dtx_blob_df	*dbd = NULL;
 	bool			 began = false;
 	int			 rc;
 
@@ -2290,18 +2512,36 @@ vos_dtx_pin(struct dtx_handle *dth)
 	if (dth->dth_solo)
 		return 0;
 
-	cont = vos_hdl2cont(dth->dth_coh);
-	D_ASSERT(cont != NULL);
+	if (persistent) {
+		struct vos_container	*cont;
+		struct vos_cont_df	*cont_df;
 
-	umm = vos_cont2umm(cont);
-	rc = umem_tx_begin(umm, NULL);
-	if (rc != 0)
-		goto out;
+		cont = vos_hdl2cont(dth->dth_coh);
+		D_ASSERT(cont != NULL);
 
-	began = true;
-	rc = vos_dtx_alloc(umm, dth);
-	if (rc == 0)
+		umm = vos_cont2umm(cont);
+		cont_df = cont->vc_cont_df;
+
+		rc = umem_tx_begin(umm, NULL);
+		if (rc != 0)
+			goto out;
+
+		began = true;
+		dbd = umem_off2ptr(umm, cont_df->cd_dtx_active_tail);
+		if (dbd == NULL || dbd->dbd_index >= dbd->dbd_cap) {
+			rc = vos_dtx_extend_act_table(cont);
+			if (rc != 0)
+				return rc;
+
+			dbd = umem_off2ptr(umm, cont_df->cd_dtx_active_tail);
+		}
+	}
+
+	rc = vos_dtx_alloc(dbd, dth);
+	if (rc == 0 && persistent) {
+		dth->dth_active = 1;
 		rc = vos_dtx_prepared(dth);
+	}
 
 out:
 	if (rc != 0) {
@@ -2347,8 +2587,10 @@ vos_dtx_rsrvd_init(struct dtx_handle *dth)
 void
 vos_dtx_rsrvd_fini(struct dtx_handle *dth)
 {
-	D_ASSERT(d_list_empty(&dth->dth_deferred_nvme));
-	D_FREE(dth->dth_deferred);
-	if (dth->dth_rsrvds != &dth->dth_rsrvd_inline)
-		D_FREE(dth->dth_rsrvds);
+	if (dth->dth_rsrvds != NULL) {
+		D_ASSERT(d_list_empty(&dth->dth_deferred_nvme));
+		D_FREE(dth->dth_deferred);
+		if (dth->dth_rsrvds != &dth->dth_rsrvd_inline)
+			D_FREE(dth->dth_rsrvds);
+	}
 }

--- a/src/vos/vos_dtx_iter.c
+++ b/src/vos/vos_dtx_iter.c
@@ -141,9 +141,9 @@ dtx_iter_next(struct vos_iterator *iter)
 		D_ASSERT(rec_iov.iov_len == sizeof(struct vos_dtx_act_ent));
 		dae = (struct vos_dtx_act_ent *)rec_iov.iov_buf;
 
-		/* Skip committable, committed, or aborted ones. */
+		/* Only return prepared ones. */
 		if (!dae->dae_committable && !dae->dae_committed &&
-		    !dae->dae_aborted)
+		    !dae->dae_aborted && dae->dae_dbd != NULL)
 			break;
 	}
 

--- a/src/vos/vos_internal.h
+++ b/src/vos/vos_internal.h
@@ -241,7 +241,8 @@ struct vos_dtx_act_ent {
 	int				 dae_rec_cap;
 	unsigned int			 dae_committable:1,
 					 dae_committed:1,
-					 dae_aborted:1;
+					 dae_aborted:1,
+					 dae_maybe_shared:1;
 };
 
 extern struct vos_tls	*standalone_tls;
@@ -791,7 +792,7 @@ struct vos_iterator {
 	uint32_t		 it_ref_cnt;
 	uint32_t		 it_from_parent:1,
 				 it_for_purge:1,
-				 it_for_rebuild:1,
+				 it_for_migration:1,
 				 it_ignore_uncommitted:1;
 };
 
@@ -1043,8 +1044,8 @@ vos_iter_intent(struct vos_iterator *iter)
 {
 	if (iter->it_for_purge)
 		return DAOS_INTENT_PURGE;
-	if (iter->it_for_rebuild)
-		return DAOS_INTENT_REBUILD;
+	if (iter->it_for_migration)
+		return DAOS_INTENT_MIGRATION;
 	if (iter->it_ignore_uncommitted)
 		return DAOS_INTENT_IGNORE_NONCOMMITTED;
 	return DAOS_INTENT_DEFAULT;
@@ -1181,6 +1182,25 @@ vos_epc_punched(daos_epoch_t epc, uint16_t minor_epc,
 		return true;
 
 	return false;
+}
+
+static inline bool
+vos_dtx_hit_inprogress(void)
+{
+	struct dtx_handle	*dth = vos_dth_get();
+
+	return dth != NULL && dth->dth_share_tbd_count > 0;
+}
+
+static inline bool
+vos_dtx_continue_detect(int rc)
+{
+	struct dtx_handle	*dth = vos_dth_get();
+
+	/* Continue to detect other potential in-prepared DTX. */
+	return rc == -DER_INPROGRESS && dth != NULL &&
+		dth->dth_share_tbd_count > 0 &&
+		dth->dth_share_tbd_count < DTX_DETECT_MAX;
 }
 
 static inline bool

--- a/src/vos/vos_io.c
+++ b/src/vos/vos_io.c
@@ -634,9 +634,6 @@ bsgl_csums_resize(struct vos_io_context *ioc)
 	struct dcs_csum_info *csums = ioc->ic_biov_csums;
 	uint32_t	 dcb_nr = ioc->ic_biov_csums_nr;
 
-	if (ioc->ic_size_fetch)
-		return 0;
-
 	if (ioc->ic_biov_csums_at == dcb_nr - 1) {
 		struct dcs_csum_info *new_infos;
 		uint32_t	 new_nr = dcb_nr * 2;
@@ -706,6 +703,9 @@ akey_fetch_single(daos_handle_t toh, const daos_epoch_range_t *epr,
 
 	rc = dbtree_fetch(toh, BTR_PROBE_LE, DAOS_INTENT_DEFAULT, &kiov, &kiov,
 			  &riov);
+	if (vos_dtx_hit_inprogress())
+		D_GOTO(out, rc = (rc == 0 ? -DER_INPROGRESS : rc));
+
 	if (rc == -DER_NONEXIST) {
 		rbund.rb_rsize = 0;
 		bio_addr_set_hole(&biov.bi_addr, 1);
@@ -825,8 +825,8 @@ akey_fetch_recx(daos_handle_t toh, const daos_epoch_range_t *epr,
 
 	evt_ent_array_init(&ent_array);
 	rc = evt_find(toh, &filter, &ent_array);
-	if (rc != 0)
-		goto failed;
+	if (rc != 0 || vos_dtx_hit_inprogress())
+		D_GOTO(failed, rc = (rc == 0 ? -DER_INPROGRESS : rc));
 
 	holes = 0;
 	rsize = 0;
@@ -1023,6 +1023,9 @@ stop_check(struct vos_io_context *ioc, uint64_t cond, daos_iod_t *iod, int *rc,
 	if (*rc != -DER_NONEXIST)
 		return true;
 
+	if (vos_dtx_hit_inprogress())
+		return true;
+
 	if (ioc->ic_check_existence)
 		goto check;
 
@@ -1143,12 +1146,19 @@ fetch_value:
 					    &shadow_ep);
 			rc = akey_fetch_recx(toh, &val_epr, &fetch_recx,
 					     shadow_ep, &rsize, ioc);
+
+			if (vos_dtx_continue_detect(rc))
+				continue;
+
 			if (rc != 0) {
-				D_DEBUG(DB_IO, "Failed to fetch index %d: "
-					DF_RC"\n", i, DP_RC(rc));
+				VOS_TX_LOG_FAIL(rc, "Failed to fetch index %d: "
+						DF_RC"\n", i, DP_RC(rc));
 				goto out;
 			}
 		}
+
+		if (vos_dtx_hit_inprogress())
+			continue;
 
 		/*
 		 * Empty tree or all holes, DAOS array API relies on zero
@@ -1168,12 +1178,15 @@ fetch_value:
 		}
 	}
 
+	if (vos_dtx_hit_inprogress())
+		goto out;
+
 	ioc_trim_tail_holes(ioc);
 out:
 	if (!daos_handle_is_inval(toh))
 		key_tree_release(toh, is_array);
 
-	return rc;
+	return vos_dtx_hit_inprogress() ? -DER_INPROGRESS : rc;
 }
 
 static void
@@ -1239,14 +1252,22 @@ fetch_akey:
 	for (i = 0; i < ioc->ic_iod_nr; i++) {
 		iod_set_cursor(ioc, i);
 		rc = akey_fetch(ioc, toh);
+		if (vos_dtx_continue_detect(rc))
+			continue;
+
 		if (rc != 0)
 			break;
 	}
+
+	/* Add this check to prevent some new added logic after above for(). */
+	if (vos_dtx_hit_inprogress())
+		goto out;
+
 out:
 	if (!daos_handle_is_inval(toh))
 		key_tree_release(toh, false);
 
-	return rc;
+	return vos_dtx_hit_inprogress() ? -DER_INPROGRESS : rc;
 }
 
 int
@@ -1571,6 +1592,7 @@ akey_update(struct vos_io_context *ioc, uint32_t pm_ver, daos_handle_t ak_toh,
 		if (rc != 0)
 			goto out;
 	}
+
 out:
 	if (!daos_handle_is_inval(toh))
 		key_tree_release(toh, is_array);
@@ -1633,6 +1655,7 @@ dkey_update(struct vos_io_context *ioc, uint32_t pm_ver, daos_key_t *dkey,
 		if (rc != 0)
 			goto out;
 	}
+
 out:
 	if (!subtr_created)
 		return rc;

--- a/src/vos/vos_obj.c
+++ b/src/vos/vos_obj.c
@@ -58,6 +58,7 @@ static int
 tree_is_empty(struct vos_object *obj, daos_handle_t toh,
 	      const daos_epoch_range_t *epr, vos_iter_type_t type)
 {
+	struct dtx_handle	*dth = vos_dth_get();
 	bool			 empty = true;
 	int			 rc;
 
@@ -65,7 +66,7 @@ tree_is_empty(struct vos_object *obj, daos_handle_t toh,
 	 *  when there are no committed entries
 	 */
 	rc = vos_iterate_key(obj, toh, type, epr, true, empty_tree_check,
-			     &empty, NULL);
+			     &empty, dth);
 
 	if (rc < 0)
 		return rc;
@@ -78,7 +79,7 @@ tree_is_empty(struct vos_object *obj, daos_handle_t toh,
 	 *  are, this will return -DER_INPROGRESS.
 	 */
 	rc = vos_iterate_key(obj, toh, type, epr, false, empty_tree_check,
-			     &empty, NULL);
+			     &empty, dth);
 
 	if (rc < 0)
 		return rc;
@@ -1137,8 +1138,8 @@ done:
 		options |= EVT_ITER_REVERSE;
 	if (oiter->it_flags & VOS_IT_FOR_PURGE)
 		options |= EVT_ITER_FOR_PURGE;
-	if (oiter->it_flags & VOS_IT_FOR_REBUILD)
-		options |= EVT_ITER_FOR_REBUILD;
+	if (oiter->it_flags & VOS_IT_FOR_MIGRATION)
+		options |= EVT_ITER_FOR_MIGRATION;
 	return options;
 }
 
@@ -1318,8 +1319,8 @@ vos_obj_iter_prep(vos_iter_type_t type, vos_iter_param_t *param,
 	oiter->it_recx = param->ip_recx;
 	if (param->ip_flags & VOS_IT_FOR_PURGE)
 		oiter->it_iter.it_for_purge = 1;
-	if (param->ip_flags & VOS_IT_FOR_REBUILD)
-		oiter->it_iter.it_for_rebuild = 1;
+	if (param->ip_flags & VOS_IT_FOR_MIGRATION)
+		oiter->it_iter.it_for_migration = 1;
 	if (param->ip_flags == VOS_IT_KEY_TREE) {
 		/** Prepare the iterator from an already open tree handle.   See
 		 *  vos_iterate_key
@@ -1510,8 +1511,8 @@ vos_obj_iter_nested_prep(vos_iter_type_t type, struct vos_iter_info *info,
 		oiter->it_obj = obj;
 	if (info->ii_flags & VOS_IT_FOR_PURGE)
 		oiter->it_iter.it_for_purge = 1;
-	if (info->ii_flags & VOS_IT_FOR_REBUILD)
-		oiter->it_iter.it_for_rebuild = 1;
+	if (info->ii_flags & VOS_IT_FOR_MIGRATION)
+		oiter->it_iter.it_for_migration = 1;
 
 	switch (type) {
 	default:

--- a/src/vos/vos_obj_index.c
+++ b/src/vos/vos_obj_index.c
@@ -485,8 +485,8 @@ oi_iter_prep(vos_iter_type_t type, vos_iter_param_t *param,
 	oiter->oit_flags = param->ip_flags;
 	if (param->ip_flags & VOS_IT_FOR_PURGE)
 		oiter->oit_iter.it_for_purge = 1;
-	if (param->ip_flags & VOS_IT_FOR_REBUILD)
-		oiter->oit_iter.it_for_rebuild = 1;
+	if (param->ip_flags & VOS_IT_FOR_MIGRATION)
+		oiter->oit_iter.it_for_migration = 1;
 
 	rc = dbtree_iter_prepare(cont->vc_btr_hdl, 0, &oiter->oit_hdl);
 	if (rc)

--- a/src/vos/vos_query.c
+++ b/src/vos/vos_query.c
@@ -126,12 +126,18 @@ find_key(struct open_query *query, daos_handle_t toh, daos_key_t *key,
 		ci_set_null(rbund.rb_csum);
 
 		rc = dbtree_iter_fetch(ih, &kiov, &riov, anchor);
+		if (vos_dtx_continue_detect(rc))
+			goto next;
+
 		if (rc != 0)
 			break;
 
 		rc = check_key(query, rbund.rb_krec);
 		if (rc == 0)
 			break;
+
+		if (vos_dtx_continue_detect(rc))
+			continue;
 
 		if (rc != -DER_NONEXIST)
 			break;
@@ -140,6 +146,7 @@ find_key(struct open_query *query, daos_handle_t toh, daos_key_t *key,
 		query->qt_epr = epr;
 		query->qt_punch = punch;
 
+next:
 		if (query->qt_flags & VOS_GET_MAX)
 			rc = dbtree_iter_prev(ih);
 		else
@@ -151,7 +158,7 @@ out:
 	if (rc == 0)
 		rc = fini_rc;
 
-	return rc;
+	return vos_dtx_hit_inprogress() ? -DER_INPROGRESS : rc;
 }
 
 static int

--- a/src/vos/vos_tls.h
+++ b/src/vos/vos_tls.h
@@ -37,6 +37,7 @@
 #include <daos/lru.h>
 #include <daos_srv/daos_server.h>
 #include <daos_srv/bio.h>
+#include <daos_srv/dtx_srv.h>
 
 struct vos_imem_strts {
 	/**
@@ -125,13 +126,30 @@ vos_ts_table_set(struct vos_ts_table *ts_table)
 static inline void
 vos_dth_set(struct dtx_handle *dth)
 {
-	vos_tls_get()->vtl_dth = dth;
+	struct vos_tls		*tls = vos_tls_get();
+	struct dtx_share_peer	*dsp;
+
+	if (dth != NULL && dth != tls->vtl_dth &&
+	    dth->dth_share_tbd_count != 0) {
+		while ((dsp = d_list_pop_entry(&dth->dth_share_tbd_list,
+					       struct dtx_share_peer,
+					       dsp_link)) != NULL)
+			D_FREE(dsp);
+		dth->dth_share_tbd_count = 0;
+	}
+
+	tls->vtl_dth = dth;
 }
 
 static inline struct dtx_handle *
 vos_dth_get(void)
 {
-	return vos_tls_get()->vtl_dth;
+	struct vos_tls	*tls = vos_tls_get();
+
+	if (tls != NULL)
+		return vos_tls_get()->vtl_dth;
+
+	return NULL;
 }
 
 static inline void


### PR DESCRIPTION
Originally, for the distributed transaction that cross multiple
redundancy groups, we will sychronously commit it when all the
participants 'prepared'. Such sync commit may introduce latency
for related distributed transaction.

This patch adjusts the commit behavior, similar as the case of
stand-alone modification, the 'committable' DTX will be cached
on the leader, and will be batched committed via dedicated ULT
sometime later. It is expected that some transactions may have
some participants on the same DAOS target(s), then the batched
commit can save some DTX commit RPCs.

Under such async batched commit mode, the DTX status on leader
may be 'committable', but is 'prepared' on non-leader. If some
read request hits these 'prepared' DTX on non-leader (in VOS),
then related caller (object) will get -DER_INPROGRESS together
with related DTX information (ID, leader), and then the caller
will query with related DTX leader whether it is committable
or not. If yes, reply the non-leader and then commit such DRX
to avoid further check by others. Introduce 'DTX_REFRESH' RPC
for such purpose.

Another main change is for DTX resync to handle the distributed
transaction that lost some whole redundancy group. Under such
case, the DTX resync logic cannot make the decision whether
commit or abort related transaction, because either one maybe
wrong as to cause or data loss or break transaction semantics.
Then it will mark the DTX entry as 'corrputed' globally. That
will prevent subsequent read operations against such DTX via
returning -DER_DATA_LOSS. On the other hand, the 'corrupted'
DTX only affects its modified pieces, but not affect others
that share the same target (object/key). The targets attached
to the 'corrupted' DTX will not be purged by vos aggregation,
but may be freshed by new update/punch. We need special tools
to handle (recover or cleanup) those 'corrupted' DTX entries
in the future.

The patch also fixes current confused 'rebuild' intent for
DTX availability check. We use new 'DAOS_INTENT_MIGRATION'
for all rebuild and migration related logic. The DTX logic
in VOS needs some special handling for the operations with
such intent, for example, return 'ALB_UNAVAILABLE' instead
of '-DER_DATA_LOSS' when hit 'corrupted' DTX entry.

It also contains some code cleanup for 'enum obj_rpc_flags'.

Signed-off-by: Fan Yong <fan.yong@intel.com>