### PR TITLE
DAOS-3030 dfs: Add support for changing gid of a file.

### DIFF
--- a/src/client/dfs/dfs.c
+++ b/src/client/dfs/dfs.c
@@ -1103,7 +1103,7 @@ dfs_cont_create(daos_handle_t poh, uuid_t co_uuid, dfs_attr_t *attr,
 	entry.mode = S_IFDIR | 0755;
 	entry.atime = entry.mtime = entry.ctime = time(NULL);
 	entry.chunk_size = dattr.da_chunk_size;
-	entry.gid = dfs->gid;
+	entry.gid = getegid();
 
 	/*
 	 * Since we don't support daos cont create atomicity (2 or more cont

--- a/src/client/dfuse/ops/setattr.c
+++ b/src/client/dfuse/ops/setattr.c
@@ -33,6 +33,14 @@ dfuse_cb_setattr(fuse_req_t req, struct dfuse_inode_entry *ie,
 
 	DFUSE_TRA_DEBUG(ie, "flags %#x", to_set);
 
+	if (to_set & FUSE_SET_ATTR_GID) {
+		DFUSE_TRA_DEBUG(ie, "gid %d %d",
+				attr->st_gid, ie->ie_stat.st_gid);
+
+		to_set &= ~FUSE_SET_ATTR_GID;
+		dfs_flags |= DFS_SET_ATTR_GID;
+	}
+
 	if (to_set & FUSE_SET_ATTR_MODE) {
 		DFUSE_TRA_DEBUG(ie, "mode %#x %#x",
 				attr->st_mode, ie->ie_stat.st_mode);

--- a/src/include/daos_fs.h
+++ b/src/include/daos_fs.h
@@ -685,6 +685,8 @@ dfs_ostat(dfs_t *dfs, dfs_obj_t *obj, struct stat *stbuf);
 #define DFS_SET_ATTR_MTIME	(1 << 2)
 /** Option to set size of a file */
 #define DFS_SET_ATTR_SIZE	(1 << 3)
+/** Option to set gid of a file */
+#define DFS_SET_ATTR_GID	(1 << 4)
 
 /**
  * set stat attributes for a file and fetch new values.  If the object is a


### PR DESCRIPTION
Extend the osetattr function to allow setting of gid, and
add the dfuse code to support it.

All files are still initially created as egid however this
updates the object format, and adds the code to change the
id.

Signed-off-by: Ashley Pittman <ashley.m.pittman@intel.com>