### PR TITLE
DAOS-5896 EC: a few fixes for EC

### DIFF
--- a/src/placement/pl_map.c
+++ b/src/placement/pl_map.c
@@ -574,9 +574,10 @@ pl_select_leader(daos_obj_id_t oid, uint32_t grp_idx, uint32_t grp_size,
 		 */
 		shard = pl_get_shard(data, grp_idx * tgt_nr + tgt_nr - 1);
 		if (for_tgt_id)
-			return shard->po_target;
+			return shard->po_target == -1 ? -DER_IO :
+						shard->po_target;
 
-		return shard->po_shard;
+		return shard->po_shard == -1 ? -DER_IO : shard->po_shard;
 	}
 
 	replicas = oc_attr->u.rp.r_num;


### PR DESCRIPTION
1. return -DER_IO for -1 shard/target for EC select
leader, to match with other object class.

2. set right version for object md before creating
layout, to make sure it will continuse search the new
replacement, once the current one failed see
determine_valid_spares().

3. Check shard_auxi in shard_comp_cb, since some object
op(for example key_query) does not use these object_auxi
structure yet.

Signed-off-by: Di Wang <di.wang@intel.com>