### PR TITLE
DAOS-5554 dtx: async batched commit distributed transactions

### DIFF
--- a/src/dtx/dtx_cos.c
+++ b/src/dtx/dtx_cos.c
@@ -49,10 +49,16 @@ struct dtx_cos_rec {
 	 *	operation efficiency.
 	 */
 	d_list_t		 dcr_prio_list;
+	/* The list for those DTXs that need to committed via explicit DTX
+	 * commit RPC instead of piggyback via dispatched update/punch RPC.
+	 */
+	d_list_t		 dcr_expcmt_list;
 	/* The number of the PUNCH DTXs in the dcr_reg_list. */
 	int			 dcr_reg_count;
 	/* The number of the DTXs in the dcr_prio_list. */
 	int			 dcr_prio_count;
+	/* The number of the DTXs in the dcr_explicit_list. */
+	int			 dcr_expcmt_count;
 };
 
 /* Above dtx_cos_rec is consisted of a series of dtx_cos_rec_child uints.
@@ -126,6 +132,7 @@ dtx_cos_rec_alloc(struct btr_instance *tins, d_iov_t *key_iov,
 	dcr->dcr_oid = key->oid;
 	D_INIT_LIST_HEAD(&dcr->dcr_reg_list);
 	D_INIT_LIST_HEAD(&dcr->dcr_prio_list);
+	D_INIT_LIST_HEAD(&dcr->dcr_expcmt_list);
 
 	D_ALLOC_PTR(dcrc);
 	if (dcrc == NULL) {
@@ -141,7 +148,10 @@ dtx_cos_rec_alloc(struct btr_instance *tins, d_iov_t *key_iov,
 			&cont->sc_dtx_cos_list);
 	cont->sc_dtx_committable_count++;
 
-	if (rbund->flags & DCF_SHARED) {
+	if (rbund->flags & DCF_EXP_CMT) {
+		d_list_add_tail(&dcrc->dcrc_lo_link, &dcr->dcr_expcmt_list);
+		dcr->dcr_expcmt_count = 1;
+	} else if (rbund->flags & DCF_SHARED) {
 		d_list_add_tail(&dcrc->dcrc_lo_link, &dcr->dcr_prio_list);
 		dcr->dcr_prio_count = 1;
 	} else {
@@ -174,6 +184,14 @@ dtx_cos_rec_free(struct btr_instance *tins, struct btr_record *rec, void *args)
 		cont->sc_dtx_committable_count--;
 	}
 	d_list_for_each_entry_safe(dcrc, next, &dcr->dcr_prio_list,
+				   dcrc_lo_link) {
+		d_list_del(&dcrc->dcrc_lo_link);
+		d_list_del(&dcrc->dcrc_gl_committable);
+		dtx_entry_put(dcrc->dcrc_dte);
+		D_FREE_PTR(dcrc);
+		cont->sc_dtx_committable_count--;
+	}
+	d_list_for_each_entry_safe(dcrc, next, &dcr->dcr_expcmt_list,
 				   dcrc_lo_link) {
 		d_list_del(&dcrc->dcrc_lo_link);
 		d_list_del(&dcrc->dcrc_gl_committable);
@@ -226,7 +244,10 @@ dtx_cos_rec_update(struct btr_instance *tins, struct btr_record *rec,
 			&cont->sc_dtx_cos_list);
 	cont->sc_dtx_committable_count++;
 
-	if (rbund->flags & DCF_SHARED) {
+	if (rbund->flags & DCF_EXP_CMT) {
+		d_list_add_tail(&dcrc->dcrc_lo_link, &dcr->dcr_expcmt_list);
+		dcr->dcr_expcmt_count++;
+	} else if (rbund->flags & DCF_SHARED) {
 		d_list_add_tail(&dcrc->dcrc_lo_link, &dcr->dcr_prio_list);
 		dcr->dcr_prio_count++;
 	} else {
@@ -342,41 +363,6 @@ dtx_list_cos(struct ds_cont_child *cont, daos_unit_oid_t *oid,
 }
 
 int
-dtx_lookup_cos(struct ds_cont_child *cont, struct dtx_id *xid,
-	       daos_unit_oid_t *oid, uint64_t dkey_hash)
-{
-	struct dtx_cos_key		 key;
-	d_iov_t				 kiov;
-	d_iov_t				 riov;
-	struct dtx_cos_rec		*dcr;
-	struct dtx_cos_rec_child	*dcrc;
-	int				 rc;
-
-	key.oid = *oid;
-	key.dkey_hash = dkey_hash;
-	d_iov_set(&kiov, &key, sizeof(key));
-	d_iov_set(&riov, NULL, 0);
-
-	rc = dbtree_lookup(cont->sc_dtx_cos_hdl, &kiov, &riov);
-	if (rc != 0)
-		return rc;
-
-	dcr = (struct dtx_cos_rec *)riov.iov_buf;
-
-	d_list_for_each_entry(dcrc, &dcr->dcr_prio_list, dcrc_lo_link) {
-		if (memcmp(&dcrc->dcrc_dte->dte_xid, xid, sizeof(*xid)) == 0)
-			return 0;
-	}
-
-	d_list_for_each_entry(dcrc, &dcr->dcr_reg_list, dcrc_lo_link) {
-		if (memcmp(&dcrc->dcrc_dte->dte_xid, xid, sizeof(*xid)) == 0)
-			return 0;
-	}
-
-	return -DER_NONEXIST;
-}
-
-int
 dtx_add_cos(struct ds_cont_child *cont, struct dtx_entry *dte,
 	    daos_unit_oid_t *oid, uint64_t dkey_hash,
 	    daos_epoch_t epoch, uint32_t flags)
@@ -403,9 +389,8 @@ dtx_add_cos(struct ds_cont_child *cont, struct dtx_entry *dte,
 			   DAOS_INTENT_UPDATE, &kiov, &riov);
 
 	D_DEBUG(DB_IO, "Insert DTX "DF_DTI" to CoS cache, key %lu, "
-		"%s shared entry: rc = "DF_RC"\n",
-		DP_DTI(&dte->dte_xid), (unsigned long)dkey_hash,
-		flags & DCF_SHARED ? "has" : "has not", DP_RC(rc));
+		"flags %x: rc = "DF_RC"\n", DP_DTI(&dte->dte_xid),
+		(unsigned long)dkey_hash, flags, DP_RC(rc));
 
 	return rc;
 }
@@ -470,9 +455,25 @@ dtx_del_cos(struct ds_cont_child *cont, struct dtx_id *xid,
 		D_GOTO(out, found = 2);
 	}
 
+	d_list_for_each_entry(dcrc, &dcr->dcr_expcmt_list, dcrc_lo_link) {
+		if (memcmp(&dcrc->dcrc_dte->dte_xid, xid, sizeof(*xid)) != 0)
+			continue;
+
+		d_list_del(&dcrc->dcrc_gl_committable);
+		d_list_del(&dcrc->dcrc_lo_link);
+		dtx_entry_put(dcrc->dcrc_dte);
+		D_FREE_PTR(dcrc);
+
+		cont->sc_dtx_committable_count--;
+		dcr->dcr_expcmt_count--;
+
+		D_GOTO(out, found = 3);
+	}
+
 out:
 	if (found > 0) {
-		if (dcr->dcr_reg_count == 0 && dcr->dcr_prio_count == 0)
+		if (dcr->dcr_reg_count == 0 && dcr->dcr_prio_count == 0 &&
+		    dcr->dcr_expcmt_count == 0)
 			rc = dbtree_delete(cont->sc_dtx_cos_hdl, BTR_PROBE_EQ,
 					   &kiov, NULL);
 

--- a/src/dtx/dtx_internal.h
+++ b/src/dtx/dtx_internal.h
@@ -45,7 +45,8 @@
 #define DTX_PROTO_SRV_RPC_LIST(X)				\
 	X(DTX_COMMIT, 0, &CQF_dtx, dtx_handler, NULL),		\
 	X(DTX_ABORT, 0, &CQF_dtx, dtx_handler, NULL),		\
-	X(DTX_CHECK, 0, &CQF_dtx, dtx_handler, NULL)
+	X(DTX_CHECK, 0, &CQF_dtx, dtx_handler, NULL),		\
+	X(DTX_REFRESH, 0, &CQF_dtx, dtx_handler, NULL)
 
 #define X_OPC(a, b, c, d, e) a
 
@@ -62,7 +63,8 @@ enum dtx_operation {
 
 /* DTX RPC output fields */
 #define DAOS_OSEQ_DTX							\
-	((int32_t)		(do_status)		CRT_VAR)
+	((int32_t)		(do_status)		CRT_VAR)	\
+	((int32_t)		(do_sub_rets)		CRT_ARRAY)
 
 CRT_RPC_DECLARE(dtx, DAOS_ISEQ_DTX, DAOS_OSEQ_DTX);
 
@@ -94,15 +96,13 @@ extern btr_ops_t dbtree_dtx_cf_ops;
 extern btr_ops_t dtx_btr_cos_ops;
 
 /* dtx_common.c */
-void dtx_aggregate(void *arg);
+int dtx_handle_reinit(struct dtx_handle *dth);
 void dtx_batched_commit(void *arg);
 
 /* dtx_cos.c */
 int dtx_fetch_committable(struct ds_cont_child *cont, uint32_t max_cnt,
 			  daos_unit_oid_t *oid, daos_epoch_t epoch,
 			  struct dtx_entry ***dtes);
-int dtx_lookup_cos(struct ds_cont_child *cont, struct dtx_id *xid,
-		   daos_unit_oid_t *oid, uint64_t dkey_hash);
 int dtx_add_cos(struct ds_cont_child *cont, struct dtx_entry *dte,
 		daos_unit_oid_t *oid, uint64_t dkey_hash,
 		daos_epoch_t epoch, uint32_t flags);

--- a/src/dtx/dtx_resync.c
+++ b/src/dtx/dtx_resync.c
@@ -91,10 +91,11 @@ dtx_resync_commit(struct ds_cont_child *cont,
 		 * DTXs. So double check the status before current commit.
 		 */
 		rc = vos_dtx_check(cont->sc_hdl, &dre->dre_xid,
-				   NULL, NULL, false);
+				   NULL, NULL, NULL, false);
 
 		/* Skip this DTX since it has been committed or aggregated. */
-		if (rc == DTX_ST_COMMITTED || rc == -DER_NONEXIST)
+		if (rc == DTX_ST_COMMITTED || rc == DTX_ST_COMMITTABLE ||
+		    rc == -DER_NONEXIST)
 			goto next;
 
 		/* If we failed to check the status, then assume that it is
@@ -257,7 +258,7 @@ dtx_status_handle(struct dtx_resync_args *dra)
 		/* The DTX has been committed on some remote replica(s),
 		 * let's commit the DTX globally.
 		 */
-		if (rc == DTX_ST_COMMITTED)
+		if (rc == DTX_ST_COMMITTED || rc == DTX_ST_COMMITTABLE)
 			goto commit;
 
 		if (rc == DTX_ST_PREPARED) {
@@ -301,10 +302,11 @@ dtx_status_handle(struct dtx_resync_args *dra)
 		 * DTXs. So double check the status before next action.
 		 */
 		rc = vos_dtx_check(cont->sc_hdl, &dre->dre_xid,
-				   NULL, NULL, false);
+				   NULL, NULL, NULL, false);
 
 		/* Skip this DTX that it may has been committed or aborted. */
-		if (rc == DTX_ST_COMMITTED || rc == -DER_NONEXIST) {
+		if (rc == DTX_ST_COMMITTED || rc == DTX_ST_COMMITTABLE ||
+		    rc == -DER_NONEXIST) {
 			dtx_dre_release(drh, dre);
 			continue;
 		}

--- a/src/dtx/dtx_rpc.c
+++ b/src/dtx/dtx_rpc.c
@@ -73,6 +73,10 @@ struct dtx_req_args {
 	int				 dra_length;
 	/* The collective RPC result. */
 	int				 dra_result;
+	/* Pointer to the DTX handle, used for DTX_REFRESH case. */
+	struct dtx_handle		*dra_dth;
+	/* Pointer to the container, used for DTX_REFRESH case. */
+	struct ds_cont_child		*dra_cont;
 };
 
 /* The record for the DTX classify-tree in DRAM.
@@ -89,6 +93,7 @@ struct dtx_req_rec {
 	int				 drr_count; /* DTX count */
 	int				 drr_result; /* The RPC result */
 	struct dtx_id			*drr_dti; /* The DTX array */
+	struct dtx_share_peer		**drr_cb_args; /* Used by dtx_req_cb. */
 };
 
 struct dtx_cf_rec_bundle {
@@ -125,12 +130,74 @@ dtx_req_cb(const struct crt_cb_info *cb_info)
 	struct dtx_in		*din = crt_req_get(req);
 	struct dtx_out		*dout;
 	int			 rc = cb_info->cci_rc;
+	int			 i;
 
-	if (rc == 0) {
-		dout = crt_reply_get(req);
-		rc = dout->do_status;
+	if (rc != 0)
+		goto out;
+
+	dout = crt_reply_get(req);
+	if (dra->dra_opc != DTX_REFRESH)
+		D_GOTO(out, rc = dout->do_status);
+
+	if (din->di_dtx_array.ca_count != dout->do_sub_rets.ca_count)
+		D_GOTO(out, rc = -DER_PROTO);
+
+	for (i = 0; i < dout->do_sub_rets.ca_count; i++) {
+		struct dtx_handle	*dth = dra->dra_dth;
+		struct dtx_share_peer	*dsp;
+		int			*ret;
+		int			 rc1;
+
+		dsp = drr->drr_cb_args[i];
+		if (dsp == NULL)
+			continue;
+
+		drr->drr_cb_args[i] = NULL;
+		ret = (int *)dout->do_sub_rets.ca_arrays + i;
+
+		switch (*ret) {
+		case DTX_ST_PREPARED:
+			/* Not committable yet. */
+			d_list_add_tail(&dsp->dsp_link,
+					&dth->dth_share_act_list);
+			break;
+		case DTX_ST_COMMITTABLE:
+			/* Committable, will be committed soon. */
+			d_list_add_tail(&dsp->dsp_link,
+					&dth->dth_share_cmt_list);
+			break;
+		case DTX_ST_COMMITTED:
+			/* Has been committed on leader, we may miss related
+			 * commit request, so let's commit it locally.
+			 */
+			rc1 = vos_dtx_commit(dra->dra_cont->sc_hdl,
+					     &dsp->dsp_xid, 1, NULL);
+			if (rc1 < 0 && rc1 != -DER_NONEXIST)
+				d_list_add_tail(&dsp->dsp_link,
+						&dth->dth_share_cmt_list);
+			else
+				D_FREE(dsp);
+			break;
+		case -DER_NONEXIST:
+			/* The leader does not have related DTX info,
+			 * we may miss related DTX abort request, so
+			 * let's abort it locally.
+			 */
+			rc1 = vos_dtx_abort(dra->dra_cont->sc_hdl,
+					    DAOS_EPOCH_MAX, &dsp->dsp_xid, 1);
+			if (rc1 < 0 && rc1 != -DER_NONEXIST)
+				d_list_add_tail(&dsp->dsp_link,
+						&dth->dth_share_act_list);
+			else
+				D_FREE(dsp);
+			break;
+		default:
+			D_FREE(dsp);
+			D_GOTO(out, rc = *ret);
+		}
 	}
 
+out:
 	drr->drr_result = rc;
 	rc = ABT_future_set(dra->dra_future, drr);
 	D_ASSERTF(rc == ABT_SUCCESS,
@@ -198,6 +265,7 @@ dtx_req_list_cb(void **args)
 			drr = args[i];
 			switch (drr->drr_result) {
 			case DTX_ST_COMMITTED:
+			case DTX_ST_COMMITTABLE:
 				dra->dra_result = DTX_ST_COMMITTED;
 				/* As long as one target has committed the DTX,
 				 * then the DTX is committable on all targets.
@@ -258,7 +326,8 @@ dtx_req_wait(struct dtx_req_args *dra)
 
 static int
 dtx_req_list_send(struct dtx_req_args *dra, crt_opcode_t opc, d_list_t *head,
-		  int len, uuid_t po_uuid, uuid_t co_uuid, daos_epoch_t epoch)
+		  int len, uuid_t po_uuid, uuid_t co_uuid, daos_epoch_t epoch,
+		  struct dtx_handle *dth, struct ds_cont_child *cont)
 {
 	ABT_future		 future;
 	struct dtx_req_rec	*drr;
@@ -271,6 +340,8 @@ dtx_req_list_send(struct dtx_req_args *dra, crt_opcode_t opc, d_list_t *head,
 	dra->dra_list = head;
 	dra->dra_length = len;
 	dra->dra_result = 0;
+	dra->dra_dth = dth;
+	dra->dra_cont = cont;
 
 	rc = ABT_future_create(len, dtx_req_list_cb, &future);
 	if (rc != ABT_SUCCESS) {
@@ -344,6 +415,7 @@ dtx_cf_rec_free(struct btr_instance *tins, struct btr_record *rec, void *args)
 
 	drr = (struct dtx_req_rec *)umem_off2ptr(&tins->ti_umm, rec->rec_off);
 	d_list_del(&drr->drr_link);
+	D_FREE(drr->drr_cb_args);
 	D_FREE(drr->drr_dti);
 	D_FREE_PTR(drr);
 
@@ -521,7 +593,8 @@ dtx_commit(struct ds_cont_child *cont, struct dtx_entry **dtes,
 	dra.dra_future = ABT_FUTURE_NULL;
 	if (!d_list_empty(&head)) {
 		rc = dtx_req_list_send(&dra, DTX_COMMIT, &head, length,
-				       pool->sp_uuid, cont->sc_uuid, 0);
+				       pool->sp_uuid, cont->sc_uuid, 0,
+				       NULL, NULL);
 		if (rc != 0)
 			goto out;
 	}
@@ -606,7 +679,8 @@ dtx_abort(struct ds_cont_child *cont, daos_epoch_t epoch,
 
 	if (rc == 0 && !d_list_empty(&head)) {
 		rc = dtx_req_list_send(&dra, DTX_ABORT, &head, length,
-				       pool->sp_uuid, cont->sc_uuid, epoch);
+				       pool->sp_uuid, cont->sc_uuid, epoch,
+				       NULL, NULL);
 		if (rc != 0)
 			goto out;
 
@@ -700,7 +774,7 @@ dtx_check(struct ds_cont_child *cont, struct dtx_entry *dte, daos_epoch_t epoch)
 	}
 
 	rc = dtx_req_list_send(&dra, DTX_CHECK, &head, length, pool->sp_uuid,
-			       cont->sc_uuid, epoch);
+			       cont->sc_uuid, epoch, NULL, NULL);
 	if (rc == 0)
 		rc = dtx_req_wait(&dra);
 
@@ -711,4 +785,105 @@ out:
 	}
 
 	return rc;
+}
+
+int
+dtx_refresh(struct dtx_handle *dth, struct ds_cont_child *cont)
+{
+	struct pool_target	*target;
+	struct dtx_share_peer	*dsp;
+	struct dtx_share_peer	*tmp;
+	struct dtx_req_rec	*drr;
+	struct dtx_req_args	 dra;
+	d_list_t		 head;
+	int			 len = 0;
+	int			 rc = 0;
+
+	D_INIT_LIST_HEAD(&head);
+
+	d_list_for_each_entry_safe(dsp, tmp, &dth->dth_share_tbd_list,
+				   dsp_link) {
+		if (dsp->dsp_leader == PO_COMP_ID_ALL) {
+			rc = ds_pool_elect_dtx_leader(cont->sc_pool->spc_pool,
+						      &dth->dth_leader_oid,
+						      dsp->dsp_ver);
+			if (rc < 0) {
+				D_ERROR("Failed to find DTX leader for "DF_DTI
+					": "DF_RC"\n",
+					DP_DTI(&dsp->dsp_xid), DP_RC(rc));
+				goto out;
+			}
+
+			dsp->dsp_leader = rc;
+		}
+
+		rc = pool_map_find_target(cont->sc_pool->spc_pool->sp_map,
+					  dsp->dsp_leader, &target);
+		D_ASSERT(rc == 1);
+
+		d_list_for_each_entry(drr, &head, drr_link) {
+			if (drr->drr_rank == target->ta_comp.co_rank &&
+			    drr->drr_tag == target->ta_comp.co_index) {
+				drr->drr_dti[drr->drr_count] = dsp->dsp_xid;
+				drr->drr_cb_args[drr->drr_count++] = dsp;
+				goto next;
+			}
+		}
+
+		D_ALLOC_PTR(drr);
+		if (drr == NULL)
+			D_GOTO(out, rc = -DER_NOMEM);
+
+		D_ALLOC_ARRAY(drr->drr_dti, dth->dth_share_tbd_count);
+		if (drr->drr_dti == NULL) {
+			D_FREE(drr);
+			D_GOTO(out, rc = -DER_NOMEM);
+		}
+
+		D_ALLOC_ARRAY(drr->drr_cb_args, dth->dth_share_tbd_count);
+		if (drr->drr_cb_args == NULL) {
+			D_FREE(drr->drr_dti);
+			D_FREE(drr);
+			D_GOTO(out, rc = -DER_NOMEM);
+		}
+
+		drr->drr_rank = target->ta_comp.co_rank;
+		drr->drr_tag = target->ta_comp.co_index;
+		drr->drr_count = 1;
+		drr->drr_dti[0] = dsp->dsp_xid;
+		drr->drr_cb_args[0] = dsp;
+		d_list_add_tail(&drr->drr_link, &head);
+		len++;
+
+next:
+		d_list_del(&dsp->dsp_link);
+		dth->dth_share_tbd_count--;
+		D_ASSERT(dth->dth_share_tbd_count >= 0);
+	}
+
+	rc = dtx_req_list_send(&dra, DTX_REFRESH, &head, len,
+			       cont->sc_pool->spc_pool->sp_uuid,
+			       cont->sc_uuid, 0, dth, cont);
+	if (rc == 0)
+		rc = dtx_req_wait(&dra);
+
+out:
+	while ((drr = d_list_pop_entry(&head, struct dtx_req_rec,
+				       drr_link)) != NULL) {
+		D_FREE(drr->drr_cb_args);
+		D_FREE(drr->drr_dti);
+		D_FREE(drr);
+	}
+
+	/* If we cannot resolve the uncertainty, then reply -DER_INPROGRESS
+	 * to the client for retry in further. Otherwise, return -DER_AGAIN
+	 * to ask the server to retry locally.
+	 */
+	if (rc < 0)
+		return -DER_INPROGRESS;
+
+	vos_dtx_cleanup(dth);
+	dtx_handle_reinit(dth);
+
+	return -DER_AGAIN;
 }

--- a/src/include/daos/dtx.h
+++ b/src/include/daos/dtx.h
@@ -48,11 +48,11 @@ enum dtx_grp_flags {
 };
 
 enum dtx_mbs_flags {
-	/* The targets that are modified by the distributed transaction
-	 * are in the same single redundancy group.
+	/* The targets modified via the DTX belong to replicated object
+	 * within single redundancy group.
 	 */
-	DMF_MODIFY_SRDG			= (1 << 0),
-	/* The MDS contains the leader information, used for distributed
+	DMF_SRDG_REP			= (1 << 0),
+	/* The MBS contains the leader information, used for distributed
 	 * transaction. For stand-alone modification, leader information
 	 * is not stored inside MBS as optimization.
 	 */

--- a/src/include/daos_errno.h
+++ b/src/include/daos_errno.h
@@ -242,7 +242,10 @@ extern "C" {
 	       Agent is incompatible with libdaos)			\
 	/** Multiple shards locate on the same target */		\
 	ACTION(DER_SHARDS_OVERLAP,	(DER_ERR_DAOS_BASE + 30),	\
-	       Shards overlap)
+	       Shards overlap)						\
+	/** Not sure whether the TX is committable or not */		\
+	ACTION(DER_TX_UNCERTAINTY,	(DER_ERR_DAOS_BASE + 31),	\
+	       Not sure whether the TX is committable or not)
 
 /** Defines the gurt error codes */
 #define D_FOREACH_ERR_RANGE(ACTION)	\

--- a/src/include/daos_srv/dtx_srv.h
+++ b/src/include/daos_srv/dtx_srv.h
@@ -31,6 +31,15 @@
 #include <daos_srv/pool.h>
 #include <daos_srv/container.h>
 
+#define DTX_UNCERTAINTY_MAX	4
+
+struct dtx_share_peer {
+	d_list_t		dsp_link;
+	struct dtx_id		dsp_xid;
+	uint32_t		dsp_leader;
+	uint32_t		dsp_ver;
+};
+
 /**
  * DAOS two-phase commit transaction handle in DRAM.
  */
@@ -76,7 +85,9 @@ struct dtx_handle {
 					 /* Local TX is started. */
 					 dth_local_tx_started:1,
 					 /* Retry with this server. */
-					 dth_local_retry:1;
+					 dth_local_retry:1,
+					 /* The DTX share lists are inited. */
+					 dth_shares_inited:1;
 
 	/* The count the DTXs in the dth_dti_cos array. */
 	uint32_t			 dth_dti_cos_count;
@@ -108,7 +119,11 @@ struct dtx_handle {
 	struct dtx_rsrvd_uint		*dth_rsrvds;
 	void				**dth_deferred;
 	/* NVME extents to release */
-	d_list_t			dth_deferred_nvme;
+	d_list_t			 dth_deferred_nvme;
+	d_list_t			 dth_share_cmt_list;
+	d_list_t			 dth_share_act_list;
+	d_list_t			 dth_share_tbd_list;
+	int				 dth_share_tbd_count;
 };
 
 /* Each sub transaction handle to manage each sub thandle */
@@ -154,8 +169,10 @@ struct dtx_stat {
 enum dtx_status {
 	/** Local participant has done the modification. */
 	DTX_ST_PREPARED		= 1,
+	/** The DTX is committable, but not committed. */
+	DTX_ST_COMMITTABLE	= 2,
 	/** The DTX has been committed. */
-	DTX_ST_COMMITTED	= 2,
+	DTX_ST_COMMITTED	= 3,
 };
 
 int
@@ -197,6 +214,8 @@ void dtx_batched_commit_deregister(struct ds_cont_child *cont);
 
 int dtx_obj_sync(struct ds_cont_child *cont, daos_unit_oid_t *oid,
 		 daos_epoch_t epoch);
+
+int dtx_refresh(struct dtx_handle *dth, struct ds_cont_child *cont);
 
 /**
  * Check whether the given DTX is resent one or not.

--- a/src/include/daos_srv/pool.h
+++ b/src/include/daos_srv/pool.h
@@ -209,6 +209,8 @@ int ds_pool_iv_srv_hdl_fetch(struct ds_pool *pool, uuid_t *pool_hdl_uuid,
 
 int ds_pool_svc_term_get(uuid_t uuid, uint64_t *term);
 
+int ds_pool_elect_dtx_leader(struct ds_pool *pool, daos_unit_oid_t *oid,
+			     uint32_t version);
 int ds_pool_check_dtx_leader(struct ds_pool *pool, daos_unit_oid_t *oid,
 			     uint32_t version);
 

--- a/src/include/daos_srv/vos.h
+++ b/src/include/daos_srv/vos.h
@@ -73,12 +73,15 @@ vos_dtx_pin(struct dtx_handle *dth);
  *				 if the DTX exists, then the DTX's epoch will
  *				 be saved in it.
  * \param pm_ver	[OUT]	Hold the DTX's pool map version.
+ * \param mbs		[OUT	Pointer to the DTX participants information.]
  * \param for_resent	[IN]	The check is for check resent or not.
  *
  * \return		DTX_ST_PREPARED	means that the DTX has been 'prepared',
  *					so the local modification has been done
  *					on related replica(s).
  *			DTX_ST_COMMITTED means the DTX has been committed.
+ *			DTX_ST_COMMITTABLE means that the DTX is committable,
+ *					   but not real committed.
  *			-DER_MISMATCH	means that the DTX has ever been
  *					processed with different epoch.
  *			-DER_AGAIN means DTX re-index is in processing, not sure
@@ -88,7 +91,7 @@ vos_dtx_pin(struct dtx_handle *dth);
  */
 int
 vos_dtx_check(daos_handle_t coh, struct dtx_id *dti, daos_epoch_t *epoch,
-	      uint32_t *pm_ver, bool for_resent);
+	      uint32_t *pm_ver, struct dtx_memberships **mbs, bool for_resent);
 
 /**
  * Commit the specified DTXs.

--- a/src/include/daos_srv/vos_types.h
+++ b/src/include/daos_srv/vos_types.h
@@ -38,7 +38,12 @@ struct dtx_rsrvd_uint {
 };
 
 enum dtx_cos_flags {
-	DCF_SHARED	= (1 << 0),
+	DCF_SHARED		= (1 << 0),
+	/* Some DTX (such as for the distributed transaction across multiple
+	 * RDGs, or for EC object modification) need to be committed via DTX
+	 * RPC instead of piggyback via other dispatched update/punch RPC.
+	 */
+	DCF_EXP_CMT		= (1 << 1),
 };
 
 struct dtx_cos_key {
@@ -240,6 +245,8 @@ enum {
 	VOS_OF_PUNCH_PROPAGATE		= (1 << 14),
 	/** replay punch (underwrite) */
 	VOS_OF_REPLAY_PC		= (1 << 15),
+	/** For detecting DTX uncertainty  */
+	VOS_OF_DETECT_UNCERTAINTY	= (1 << 16),
 };
 
 /** Mask for any conditionals passed to to the fetch */

--- a/src/object/cli_obj.c
+++ b/src/object/cli_obj.c
@@ -838,7 +838,6 @@ obj_rw_req_reassemb(struct dc_object *obj, daos_obj_rw_t *args,
 	rc = obj_ec_req_reasb(args->iods, args->sgls, oid, oca, reasb_req,
 			      args->nr, obj_auxi->opc == DAOS_OBJ_RPC_UPDATE);
 	if (rc == 0) {
-		obj_auxi->flags |= ORF_DTX_SYNC;
 		obj_auxi->flags |= ORF_EC;
 		obj_auxi->req_reasbed = true;
 		if (reasb_req->orr_iods != NULL)
@@ -4749,8 +4748,7 @@ dc_obj_punch(tse_task_t *task, struct dtx_epoch *epoch, uint32_t map_ver,
 		goto out_task;
 	}
 
-	if (daos_oclass_is_ec(obj->cob_md.omd_id, NULL) ||
-	    DAOS_FAIL_CHECK(DAOS_DTX_COMMIT_SYNC))
+	if (DAOS_FAIL_CHECK(DAOS_DTX_COMMIT_SYNC))
 		obj_auxi->flags |= ORF_DTX_SYNC;
 
 	D_DEBUG(DB_IO, "punch "DF_OID" dkey %llu\n",

--- a/src/object/obj_tx.c
+++ b/src/object/obj_tx.c
@@ -1604,7 +1604,8 @@ dc_tx_commit_prepare(struct dc_tx *tx, tse_task_t *task)
 		leader_oid.id_pub = obj->cob_md.omd_id;
 		leader_oid.id_shard = i;
 		leader_dtrg_idx = obj_get_shard(obj, i)->po_target;
-		mbs->dm_flags |= DMF_MODIFY_SRDG;
+		if (!daos_oclass_is_ec(obj->cob_md.omd_id, NULL))
+			mbs->dm_flags |= DMF_SRDG_REP;
 	}
 
 	dcsh->dcsh_xid = tx->tx_id;

--- a/src/pool/srv_pool.c
+++ b/src/pool/srv_pool.c
@@ -4889,6 +4889,42 @@ out:
 	crt_reply_send(rpc);
 }
 
+int
+ds_pool_elect_dtx_leader(struct ds_pool *pool, daos_unit_oid_t *oid,
+			 uint32_t version)
+{
+	struct pl_map		*map;
+	struct pl_obj_layout	*layout;
+	struct daos_obj_md	 md = { 0 };
+	int			 rc = 0;
+
+	map = pl_map_find(pool->sp_uuid, oid->id_pub);
+	if (map == NULL) {
+		D_WARN("Failed to find pool map tp select leader for "
+		       DF_UOID" version = %d\n", DP_UOID(*oid), version);
+		return -DER_INVAL;
+	}
+
+	md.omd_id = oid->id_pub;
+	md.omd_ver = version;
+	rc = pl_obj_place(map, &md, NULL, &layout);
+	if (rc != 0)
+		goto out;
+
+	rc = pl_select_leader(oid->id_pub, oid->id_shard / layout->ol_grp_size,
+			      layout->ol_grp_size, true,
+			      pl_obj_get_shard, layout);
+	pl_obj_layout_free(layout);
+	if (rc < 0)
+		D_WARN("Failed to select leader for "DF_UOID
+		       "version = %d: rc = %d\n",
+		       DP_UOID(*oid), version, rc);
+
+out:
+	pl_map_decref(map);
+	return rc;
+}
+
 /**
  * Check whether the leader replica of the given object resides
  * on current server or not.
@@ -4905,59 +4941,31 @@ int
 ds_pool_check_dtx_leader(struct ds_pool *pool, daos_unit_oid_t *oid,
 			 uint32_t version)
 {
-	struct pl_map		*map;
-	struct pl_obj_layout	*layout = NULL;
 	struct pool_target	*target;
-	struct daos_obj_md	 md = { 0 };
-	int			 leader;
 	d_rank_t		 myrank;
-	int			 rc = 0;
+	int			 leader;
+	int			 rc;
 
-	map = pl_map_find(pool->sp_uuid, oid->id_pub);
-	if (map == NULL) {
-		D_WARN("Failed to find pool map tp select leader for "
-		       DF_UOID" version = %d\n", DP_UOID(*oid), version);
-		return -DER_INVAL;
-	}
-
-	md.omd_id = oid->id_pub;
-	md.omd_ver = version;
-	rc = pl_obj_place(map, &md, NULL, &layout);
-	if (rc != 0)
-		goto out;
-
-	leader = pl_select_leader(oid->id_pub,
-				  oid->id_shard / layout->ol_grp_size,
-				  layout->ol_grp_size, true,
-				  pl_obj_get_shard, layout);
-	if (leader < 0) {
-		D_WARN("Failed to select leader for "DF_UOID
-		       "version = %d: rc = %d\n",
-		       DP_UOID(*oid), version, leader);
-		D_GOTO(out, rc = leader);
-	}
+	leader = ds_pool_elect_dtx_leader(pool, oid, version);
+	if (leader < 0)
+		return leader;
 
 	D_DEBUG(DB_TRACE, "get new leader tgt id %d\n", leader);
 	rc = pool_map_find_target(pool->sp_map, leader, &target);
 	if (rc < 0)
-		goto out;
+		return rc;
 
 	if (rc != 1)
-		D_GOTO(out, rc = -DER_INVAL);
+		return -DER_INVAL;
 
 	rc = crt_group_rank(NULL, &myrank);
 	if (rc < 0)
-		goto out;
+		return rc;
 
 	if (myrank != target->ta_comp.co_rank)
 		rc = 0;
 	else
 		rc = 1;
-
-out:
-	if (layout != NULL)
-		pl_obj_layout_free(layout);
-	pl_map_decref(map);
 
 	return rc;
 }

--- a/src/vos/vos_common.c
+++ b/src/vos/vos_common.c
@@ -132,6 +132,9 @@ vos_tx_publish(struct dtx_handle *dth, bool publish)
 	int			 rc;
 	int			 i;
 
+	if (dth->dth_rsrvds == NULL)
+		return 0;
+
 	for (i = 0; i < dth->dth_rsrvd_cnt; i++) {
 		dru = &dth->dth_rsrvds[i];
 		rc = vos_publish_scm(cont, dru->dru_scm, publish);
@@ -180,7 +183,7 @@ vos_tx_begin(struct dtx_handle *dth, struct umem_instance *umm)
 {
 	int	rc;
 
-	if (!dtx_is_valid_handle(dth))
+	if (dth == NULL)
 		return umem_tx_begin(umm, vos_txd_get());
 
 	if (dth->dth_local_tx_started)

--- a/src/vos/vos_dtx.c
+++ b/src/vos/vos_dtx.c
@@ -111,24 +111,74 @@ static inline int
 dtx_inprogress(struct vos_dtx_act_ent *dae, struct dtx_handle *dth,
 	       bool for_read, int pos)
 {
-	/* If the modifications crosses multiple redundancy groups, then it
-	 * is possible that the sub modifications on the DTX leader are not
-	 * the same as the ones on non-leaders. Under such case, if someone
-	 * wants to read the data on some non-leader but hits non-committed
-	 * DTX, then asking the client to retry with leader maybe not help.
-	 * Instead, we can ask make the client to retry the read again (and
-	 * again) sometime later. We do sync commit the DTX with 'DTE_BLOCK'
-	 * flag. So it will not cause the client to retry read for too many
-	 * times unless such DTX hit some trouble (such as client or server
-	 * failure) that may cause current readers to be blocked until such
-	 * DTX has been handled by the new leader via DTX recovery.
-	 */
-	if (DAE_FLAGS(dae) & DTE_BLOCK && for_read && dth != NULL &&
-	    dth->dth_modification_cnt == 0)
-		dth->dth_local_retry = 1;
-	else if (dth != NULL)
-		dth->dth_local_retry = 0;
+	struct dtx_share_peer	*dsp;
 
+	if (dth == NULL)
+		goto out;
+
+	if (DAE_FLAGS(dae) & DTE_LEADER) {
+		dth->dth_local_retry = 0;
+		goto out;
+	}
+
+	/* For the DTX with 'DTE_BLOCK' flag, we will sych commit them. But
+	 * before it is committed, if someone wants to read related data on
+	 * non-leader, we can make related IO handle to retry locally, that
+	 * will not cause too much overhead unless the DTX hit some trouble
+	 * (such as client or server failure) that may cause current reader
+	 * to be blocked until such DTX has been handled by the new leader.
+	 */
+
+	if (DAE_FLAGS(dae) & DTE_BLOCK && for_read &&
+	    dth->dth_modification_cnt == 0) {
+		dth->dth_local_retry = 1;
+		goto out;
+	}
+
+	if (DAE_MBS_FLAGS(dae) & DMF_SRDG_REP) {
+		dth->dth_local_retry = 0;
+		goto out;
+	}
+
+	/* It is expected that the uncertainty list will not be too long, so
+	 * just use direct comparasion without sorting the DTXs in the list.
+	 */
+	d_list_for_each_entry(dsp, &dth->dth_share_tbd_list, dsp_link) {
+		if (memcmp(&dsp->dsp_xid, &DAE_XID(dae),
+			   sizeof(struct dtx_id)) == 0)
+			goto found;
+	}
+
+	D_ALLOC_PTR(dsp);
+	if (dsp == NULL) {
+		D_ERROR("Hit uncertain DTX "DF_DTI" at %d: lid=%d, "
+			"but fail to alloc DRAM.\n",
+			DP_DTI(&DAE_XID(dae)), pos, DAE_LID(dae));
+		return -DER_NOMEM;
+	}
+
+	dsp->dsp_xid = DAE_XID(dae);
+	if (DAE_MBS_FLAGS(dae) & DMF_CONTAIN_LEADER) {
+		struct umem_instance	*umm;
+		struct dtx_daos_target	*ddt;
+
+		umm = vos_cont2umm(vos_hdl2cont(dth->dth_coh));
+		ddt = umem_off2ptr(umm, DAE_MBS_OFF(dae));
+		dsp->dsp_leader = ddt->ddt_id;
+	} else {
+		dsp->dsp_leader = PO_COMP_ID_ALL;
+	}
+
+	d_list_add_tail(&dsp->dsp_link, &dth->dth_share_tbd_list);
+	dth->dth_share_tbd_count++;
+
+found:
+	D_DEBUG(DB_IO, "Hit uncertain DTX "DF_DTI" at %d: lid=%d.\n",
+		DP_DTI(&DAE_XID(dae)), pos, DAE_LID(dae));
+
+	return -DER_TX_UNCERTAINTY;
+
+out:
 	D_DEBUG(DB_IO,
 		"Hit uncommitted DTX "DF_DTI" at %d: lid=%d, need %s retry\n",
 		DP_DTI(&DAE_XID(dae)), pos, DAE_LID(dae),
@@ -1175,7 +1225,30 @@ vos_dtx_check_availability(daos_handle_t coh, uint32_t entry,
 	if (dae->dae_aborted)
 		return ALB_UNAVAILABLE;
 
-	/* The following are for non-committable cases. */
+	if (dth != NULL && !(DAE_FLAGS(dae) & DTE_LEADER) &&
+	    !(DAE_MBS_FLAGS(dae) & DMF_SRDG_REP)) {
+		struct dtx_share_peer	*dsp;
+
+		d_list_for_each_entry(dsp, &dth->dth_share_cmt_list, dsp_link) {
+			if (memcmp(&dsp->dsp_xid, &DAE_XID(dae),
+				   sizeof(struct dtx_id)) == 0)
+				return ALB_AVAILABLE_CLEAN;
+		}
+
+		d_list_for_each_entry(dsp, &dth->dth_share_act_list, dsp_link) {
+			if (memcmp(&dsp->dsp_xid, &DAE_XID(dae),
+				   sizeof(struct dtx_id)) == 0)
+				return ALB_UNAVAILABLE;
+		}
+	}
+
+	/* The following are for non-committable cases.
+	 *
+	 * Current CoS mechanism only works for single RDG based replicated
+	 * object modification. For other cases, such as transaction across
+	 * multiple RDGs, or modifying EC object, we may have to query with
+	 * related leader.
+	 */
 
 	if (intent == DAOS_INTENT_DEFAULT || intent == DAOS_INTENT_REBUILD ||
 	    intent == DAOS_INTENT_IGNORE_NONCOMMITTED) {
@@ -1500,9 +1573,34 @@ vos_dtx_prepared(struct dtx_handle *dth)
 	return 0;
 }
 
+static struct dtx_memberships *
+vos_dtx_pack_mbs(struct umem_instance *umm, struct vos_dtx_act_ent *dae)
+{
+	struct dtx_memberships	*tmp;
+	size_t			 size;
+
+	size = sizeof(*tmp) + DAE_MBS_DSIZE(dae);
+	D_ALLOC(tmp, size);
+	if (tmp == NULL)
+		return NULL;
+
+	tmp->dm_tgt_cnt = DAE_TGT_CNT(dae);
+	tmp->dm_grp_cnt = DAE_GRP_CNT(dae);
+	tmp->dm_data_size = DAE_MBS_DSIZE(dae);
+	tmp->dm_flags = DAE_MBS_FLAGS(dae);
+	tmp->dm_dte_flags = DAE_FLAGS(dae);
+	if (tmp->dm_data_size <= sizeof(DAE_MBS_INLINE(dae)))
+		memcpy(tmp->dm_data, DAE_MBS_INLINE(dae), tmp->dm_data_size);
+	else
+		memcpy(tmp->dm_data, umem_off2ptr(umm, DAE_MBS_OFF(dae)),
+		       tmp->dm_data_size);
+
+	return tmp;
+}
+
 int
 vos_dtx_check(daos_handle_t coh, struct dtx_id *dti, daos_epoch_t *epoch,
-	      uint32_t *pm_ver, bool for_resent)
+	      uint32_t *pm_ver, struct dtx_memberships **mbs, bool for_resent)
 {
 	struct vos_container	*cont;
 	struct vos_dtx_act_ent	*dae;
@@ -1518,8 +1616,20 @@ vos_dtx_check(daos_handle_t coh, struct dtx_id *dti, daos_epoch_t *epoch,
 	rc = dbtree_lookup(cont->vc_dtx_active_hdl, &kiov, &riov);
 	if (rc == 0) {
 		dae = (struct vos_dtx_act_ent *)riov.iov_buf;
-		if (dae->dae_committable || dae->dae_committed)
+
+		if (pm_ver != NULL)
+			*pm_ver = DAE_VER(dae);
+
+		if (dae->dae_committed)
 			return DTX_ST_COMMITTED;
+
+		if (dae->dae_committable) {
+			if (mbs != NULL)
+				*mbs = vos_dtx_pack_mbs(vos_cont2umm(cont),
+							dae);
+
+			return DTX_ST_COMMITTABLE;
+		}
 
 		if (dae->dae_aborted)
 			return -DER_NONEXIST;
@@ -1530,9 +1640,6 @@ vos_dtx_check(daos_handle_t coh, struct dtx_id *dti, daos_epoch_t *epoch,
 			else if (*epoch != DAE_EPOCH(dae))
 				return -DER_MISMATCH;
 		}
-
-		if (pm_ver != NULL)
-			*pm_ver = DAE_VER(dae);
 
 		return DTX_ST_PREPARED;
 	}
@@ -2343,8 +2450,10 @@ vos_dtx_rsrvd_init(struct dtx_handle *dth)
 void
 vos_dtx_rsrvd_fini(struct dtx_handle *dth)
 {
-	D_ASSERT(d_list_empty(&dth->dth_deferred_nvme));
-	D_FREE(dth->dth_deferred);
-	if (dth->dth_rsrvds != &dth->dth_rsrvd_inline)
-		D_FREE(dth->dth_rsrvds);
+	if (dth->dth_rsrvds != NULL) {
+		D_ASSERT(d_list_empty(&dth->dth_deferred_nvme));
+		D_FREE(dth->dth_deferred);
+		if (dth->dth_rsrvds != &dth->dth_rsrvd_inline)
+			D_FREE(dth->dth_rsrvds);
+	}
 }

--- a/src/vos/vos_tree.c
+++ b/src/vos/vos_tree.c
@@ -1104,6 +1104,9 @@ key_tree_punch(struct vos_object *obj, daos_handle_t toh, daos_epoch_t epoch,
 		goto done;
 	}
 
+	if (flags & VOS_OF_DETECT_UNCERTAINTY)
+		return 0;
+
 	if (rc != 0) {
 		/** If it's not a replay punch, we should not insert
 		 *  anything.   In such case, ts_set will be NULL


### PR DESCRIPTION
Originally, for the distributed transaction that cross multiple
redundancy groups, we will sychronously commit it when all the
participants 'prepared'. Such sync commit may introduce latency
for related distributed transaction.

This patch adjusts the commit behavior, similar as the case of
stand-alone modification, the 'committable' DTX will be cached
on the leader, and will be batched committed via dedicated ULT
sometime later. It is expected that some transactions may have
some participants on the same DAOS target(s), then the batched
commit can save some DTX commit RPCs.

Under such async batched commit mode, the DTX status on leader
may be 'committable', but is 'prepared' on non-leader. If some
read request hits these 'prepared' DTX on non-leader (in VOS),
then related caller will get -DER_TX_UNCERTAINTY together with
related DTX information (ID, leader), and then the caller will
query with related DTX leader whether such DTX is committable
or not. If yes, reply the non-leader and then commit such DRX
to avoid further check by others.

Signed-off-by: Fan Yong <fan.yong@intel.com>