### PR TITLE
DAOS-5950: Fix memory leak in evt test case test_evt_overlap_split

### DIFF
--- a/src/vos/tests/evt_ctl.c
+++ b/src/vos/tests/evt_ctl.c
@@ -1927,6 +1927,9 @@ test_evt_overlap_split(struct test_arg *arg, int major_num, int minor_num)
 		assert_int_equal(rc, 0);
 	}
 
+	rc = evt_iter_finish(ih);
+	assert_int_equal(rc, 0);
+
 	D_PRINT("Tree depth :%d\n", arg->ta_root->tr_depth);
 	if (arg->ta_root->tr_depth < 2)
 		tree_depth_fail = 1;

--- a/utils/test_memcheck.supp
+++ b/utils/test_memcheck.supp
@@ -299,20 +299,6 @@
 {
    <insert_a_suppression_name_here>
    Memcheck:Leak
-   match-leak-kinds:definite
-   fun:calloc
-   fun:evt_tcx_create
-   fun:evt_tcx_clone
-   fun:evt_iter_prepare
-   fun:test_evt_overlap_split_internal
-   obj:/usr/lib64/libcmocka.so.*
-   fun:_cmocka_run_group_tests
-   fun:run_internal_tests
-   fun:main
-}
-{
-   <insert_a_suppression_name_here>
-   Memcheck:Leak
    match-leak-kinds:reachable
    fun:malloc
    fun:xmalloc
@@ -519,18 +505,6 @@
    fun:xmalloc
    fun:array_create_element
    ...
-}
-{
-   <insert_a_suppression_name_here>
-   Memcheck:Leak
-   match-leak-kinds:definite
-   fun:calloc
-   fun:evt_tcx_create
-   fun:evt_tcx_clone
-   fun:evt_iter_prepare
-   fun:test_evt_overlap_split
-   ...
-   fun:main
 }
 {
    <insert_a_suppression_name_here>


### PR DESCRIPTION
Add evt_iter_finish in test_evt_overlap_split

Signed-off-by: Marcela Rosales <marcela.a.rosales.jimenez@intel.com>