### PR TITLE
CORCI-1010 nlt: Increase the startup timeout from 10 to 20 seconds.

### DIFF
--- a/utils/node_local_test.py
+++ b/utils/node_local_test.py
@@ -396,8 +396,9 @@ class DaosServer():
 
             if ready:
                 break
-            if time.time() - start > 10:
+            if time.time() - start > 20:
                 raise Exception("Failed to start")
+        print('Server started in {:.2f} seconds'.format(time.time() - start))
 
     def stop(self):
         """Stop a previously started DAOS server"""


### PR DESCRIPTION
This timeout was correct for VMs however now the test has migrated
to real hardware it was borderline and failing ~20% of time.

Signed-off-by: Ashley Pittman <ashley.m.pittman@intel.com>