### PR TITLE
CART-923 test: fix prefwd test

### DIFF
--- a/src/tests/ftest/cart/test_corpc_prefwd.c
+++ b/src/tests/ftest/cart/test_corpc_prefwd.c
@@ -199,8 +199,8 @@ int main(void)
 		}
 
 		sleep(2);
-		rc = tc_wait_for_ranks(g_main_ctx, grp, rank_list, 0,
-				1, 10, 100.0);
+		rc = tc_wait_for_ranks(g_main_ctx, grp, rank_list,
+				       0, 1, 10, 100.0);
 		if (rc != 0) {
 			D_ERROR("wait_for_ranks() failed; rc=%d\n", rc);
 			assert(0);

--- a/src/tests/ftest/cart/test_corpc_prefwd.c
+++ b/src/tests/ftest/cart/test_corpc_prefwd.c
@@ -191,30 +191,24 @@ int main(void)
 		assert(0);
 	}
 
-	rc = crt_group_ranks_get(grp, &rank_list);
-	if (rc != 0) {
-		D_ERROR("crt_group_ranks_get() failed; rc=%d\n", rc);
-		assert(0);
-	}
-
-	sleep(2);
-	rc = tc_wait_for_ranks(g_main_ctx, grp, rank_list, 0,
-			1, 10, 100.0);
-	if (rc != 0) {
-		D_ERROR("wait_for_ranks() failed; rc=%d\n", rc);
-		assert(0);
-	}
-
-	d_rank_list_free(rank_list);
-	rank_list = NULL;
-
-	rc = crt_swim_init(0);
-	if (rc != 0) {
-		D_ERROR("crt_swim_init() failed; rc=%d\n", rc);
-		assert(0);
-	}
-
 	if (my_rank == 0) {
+		rc = crt_group_ranks_get(grp, &rank_list);
+		if (rc != 0) {
+			D_ERROR("crt_group_ranks_get() failed; rc=%d\n", rc);
+			assert(0);
+		}
+
+		sleep(2);
+		rc = tc_wait_for_ranks(g_main_ctx, grp, rank_list, 0,
+				1, 10, 100.0);
+		if (rc != 0) {
+			D_ERROR("wait_for_ranks() failed; rc=%d\n", rc);
+			assert(0);
+		}
+
+		d_rank_list_free(rank_list);
+		rank_list = NULL;
+
 		DBG_PRINT("Rank 0 sending CORPC call\n");
 		rc = crt_corpc_req_create(g_main_ctx, NULL, &excluded_membs,
 			CRT_PROTO_OPC(TEST_CORPC_PREFWD_BASE,


### PR DESCRIPTION
- Do not enable swim for this test
- Only wait for all ranks to come up from rank0

Signed-off-by: Alexander Oganezov <alexander.a.oganezov@intel.com>