### PR TITLE
DAOS-6059 test: Restart servers between test cases

### DIFF
--- a/src/tests/ftest/osa/osa_offline_drain.py
+++ b/src/tests/ftest/osa/osa_offline_drain.py
@@ -118,3 +118,7 @@ class OSAOfflineDrain(OSAUtils):
         """
         for pool_num in range(1, 3):
             self.run_offline_drain_test(pool_num, True)
+            self.stop_servers()
+            time.sleep(5)
+            self.start_servers()
+            time.sleep(5)

--- a/src/tests/ftest/osa/osa_online_drain.py
+++ b/src/tests/ftest/osa/osa_online_drain.py
@@ -229,3 +229,7 @@ class OSAOnlineDrain(TestWithServers):
         # Perform drain testing with 1 to 2 pools
         for pool_num in range(1, 3):
             self.run_online_drain_test(pool_num)
+            self.stop_servers()
+            time.sleep(5)
+            self.start_servers()
+            time.sleep(5)


### PR DESCRIPTION
Signed-off-by: Padmanabhan <ravindran.padmanabhan@intel.com>

Summary:
   Restart the daos_servers between different test cases (for mulitple pools).