### PR TITLE
DAOS-6060 dfs: correct error code type from dfs_cont_create

### DIFF
--- a/src/client/dfs/dfs.c
+++ b/src/client/dfs/dfs.c
@@ -1126,7 +1126,7 @@ dfs_cont_create(daos_handle_t poh, uuid_t co_uuid, dfs_attr_t *attr,
 		rc = daos_cont_close(coh, NULL);
 		if (rc) {
 			D_ERROR("daos_cont_close() failed (%d)\n", rc);
-			D_GOTO(err_destroy, rc);
+			D_GOTO(err_destroy, rc = daos_der2errno(rc));
 		}
 	}
 

--- a/src/client/dfuse/dfuse_cont.c
+++ b/src/client/dfuse/dfuse_cont.c
@@ -150,6 +150,8 @@ dfuse_cont_open(fuse_req_t req, struct dfuse_inode_entry *parent,
 		D_GOTO(close, rc);
 	}
 
+	d_list_add(&dfs->dfs_list, &dfp->dfp_dfs_list);
+
 alloc_ie:
 	D_ALLOC_PTR(ie);
 	if (!ie)

--- a/src/client/dfuse/dfuse_cont.c
+++ b/src/client/dfuse/dfuse_cont.c
@@ -36,7 +36,6 @@ dfuse_cont_open(fuse_req_t req, struct dfuse_inode_entry *parent,
 	struct dfuse_pool		*dfp = parent->ie_dfs->dfs_dfp;
 	struct dfuse_dfs		*dfs;
 	struct dfuse_dfs		*dfsi;
-	dfs_t				*ddfs;
 	int				rc;
 
 	/* This code is only supposed to support one level of directory descent
@@ -72,13 +71,15 @@ dfuse_cont_open(fuse_req_t req, struct dfuse_inode_entry *parent,
 
 	if (create) {
 		rc = dfs_cont_create(dfp->dfp_poh, dfs->dfs_cont,
-				     NULL, NULL, NULL);
+				     NULL, &dfs->dfs_coh, &dfs->dfs_ns);
 		if (rc) {
 			DFUSE_TRA_ERROR(dfs,
 					"dfs_cont_create() failed: (%d)",
 					rc);
 			D_GOTO(err_unlock, rc);
 		}
+		d_list_add(&dfs->dfs_list, &dfp->dfp_dfs_list);
+		D_GOTO(alloc_ie, 0);
 	} else {
 		d_list_for_each_entry(dfsi,
 				      &dfp->dfp_dfs_list,
@@ -143,15 +144,11 @@ dfuse_cont_open(fuse_req_t req, struct dfuse_inode_entry *parent,
 		D_GOTO(err_unlock, rc = daos_der2errno(rc));
 	}
 
-	rc = dfs_mount(dfp->dfp_poh, dfs->dfs_coh, O_RDWR, &ddfs);
+	rc = dfs_mount(dfp->dfp_poh, dfs->dfs_coh, O_RDWR, &dfs->dfs_ns);
 	if (rc) {
 		DFUSE_TRA_ERROR(ie, "dfs_mount() failed: (%s)", strerror(rc));
 		D_GOTO(close, rc);
 	}
-
-	dfs->dfs_ns = ddfs;
-
-	d_list_add(&dfs->dfs_list, &dfp->dfp_dfs_list);
 
 alloc_ie:
 	D_ALLOC_PTR(ie);

--- a/src/client/dfuse/dfuse_pool.c
+++ b/src/client/dfuse/dfuse_pool.c
@@ -169,7 +169,7 @@ dfuse_pool_lookup(fuse_req_t req, struct dfuse_inode_entry *parent,
 	if (rc != 0) {
 		DFUSE_TRA_ERROR(dfp, "Unable to convert owner to uid: (%d)",
 				rc);
-		D_GOTO(close, rc);
+		D_GOTO(close, rc = daos_der2errno(rc));
 	}
 
 	prop_entry = daos_prop_entry_get(prop, DAOS_PROP_PO_OWNER_GROUP);
@@ -180,7 +180,7 @@ dfuse_pool_lookup(fuse_req_t req, struct dfuse_inode_entry *parent,
 		DFUSE_TRA_ERROR(dfp,
 				"Unable to convert owner-group to gid: (%d)",
 				rc);
-		D_GOTO(close, rc);
+		D_GOTO(close, rc = daos_der2errno(rc));
 	}
 
 	/*
@@ -197,7 +197,7 @@ dfuse_pool_lookup(fuse_req_t req, struct dfuse_inode_entry *parent,
 				&ie->ie_stat.st_ino);
 	if (rc) {
 		DFUSE_TRA_ERROR(ie, "dfuse_lookup_inode() failed: (%d)", rc);
-		D_GOTO(close, rc = rc);
+		D_GOTO(close, rc);
 	}
 
 	dfs->dfs_root = ie->ie_stat.st_ino;


### PR DESCRIPTION
Always return a system error number from dfs_cont_create().
When calling dfs_cont_create() from dfuse pass in coh and
dfs handles to avoid a close/open cycle on the container.

Signed-off-by: Ashley Pittman <ashley.m.pittman@intel.com>