### PR TITLE
DAOS-5579 doc: remove "libioil is currently planned for DAOS v1.2"

### DIFF
--- a/doc/user/posix.md
+++ b/doc/user/posix.md
@@ -212,7 +212,7 @@ library works in conjunction with DFuse and allows the interception of POSIX I/O
 calls and issue the I/O operations directly from the application context through
 `libdaos` without any application changes.  This provides kernel-bypass for I/O data,
 leading to improved performance.
-To use this, set the `LD_PRELOAD` to point to the shared library in the DAOS install
+To use this, set `LD_PRELOAD` to point to the shared library in the DAOS install
 directory:
 
 ```
@@ -220,4 +220,3 @@ LD_PRELOAD=/path/to/daos/install/lib/libioil.so
 LD_PRELOAD=/usr/lib64/libioil.so # when installed from RPMs
 ```
 
-Support for `libioil` is currently planned for DAOS v1.2.


### PR DESCRIPTION
Remove the statement that libioil is only supported in 1.2.
It is already supported with DAOS 1.0 and 1.1.

Signed-off-by: Michael Hennecke <mhennecke@lenovo.com>