### PR TITLE
DAOS-6021 container: EC aggregation IV

### DIFF
--- a/src/container/container_iv.c
+++ b/src/container/container_iv.c
@@ -470,18 +470,56 @@ cont_iv_capa_ent_update(struct ds_iv_entry *entry, struct ds_iv_key *key,
 	return rc;
 }
 
+/* Update the EC agg epoch all servers to the leader */
+static int
+cont_iv_ent_agg_eph_update(struct ds_iv_entry *entry, struct ds_iv_key *key,
+			   d_sg_list_t *src)
+{
+	struct cont_iv_key	*civ_key = key2priv(key);
+	struct cont_iv_entry	*civ_ent = src->sg_iovs[0].iov_buf;
+	d_rank_t		rank;
+	int			rc;
+
+	rc = crt_group_rank(NULL, &rank);
+	if (rc)
+		return rc;
+
+	if (rank != entry->ns->iv_master_rank)
+		return -DER_IVCB_FORWARD;
+
+	rc = ds_cont_leader_update_agg_eph(entry->ns->iv_pool_uuid,
+					   civ_key->cont_uuid,
+					   civ_ent->iv_agg_eph.rank,
+					   civ_ent->iv_agg_eph.eph);
+	return rc;
+}
+
+/* Each server refresh the VOS aggregation epoch gotten from the leader */
+static int
+cont_iv_ent_agg_eph_refresh(struct ds_iv_entry *entry, struct ds_iv_key *key,
+			    d_sg_list_t *src)
+{
+	struct cont_iv_entry	*civ_ent = src->sg_iovs[0].iov_buf;
+	struct cont_iv_key	*civ_key = key2priv(key);
+	int			rc;
+
+	rc = ds_cont_tgt_refresh_agg_eph(entry->ns->iv_pool_uuid,
+					 civ_key->cont_uuid,
+					 civ_ent->iv_agg_eph.eph);
+	return rc;
+}
+
 static int
 cont_iv_ent_update(struct ds_iv_entry *entry, struct ds_iv_key *key,
 		   d_sg_list_t *src, void **priv)
 {
 	daos_handle_t		root_hdl;
 	struct cont_iv_key	*civ_key = key2priv(key);
-	d_iov_t		key_iov;
-	d_iov_t		val_iov;
+	d_iov_t			key_iov;
+	d_iov_t			val_iov;
 	int			rc;
 
 	D_ASSERT(dss_get_module_info()->dmi_xs_id == 0);
-	/* If src == NULL, it is invalidate */
 	if (src != NULL) {
 		if (entry->iv_class->iv_class_id == IV_CONT_CAPA) {
 			rc = cont_iv_capa_ent_update(entry, key, src, priv);
@@ -497,12 +535,23 @@ cont_iv_ent_update(struct ds_iv_entry *entry, struct ds_iv_key *key,
 						civ_ent->iv_snap.snap_cnt);
 			if (rc)
 				return rc;
+		} else if (entry->iv_class->iv_class_id ==
+						IV_CONT_AGG_EPOCH_REPORT) {
+			rc = cont_iv_ent_agg_eph_update(entry, key, src);
+			if (rc)
+				return rc;
+		} else if (entry->iv_class->iv_class_id ==
+						IV_CONT_AGG_EPOCH_BOUNDRY) {
+			rc = cont_iv_ent_agg_eph_refresh(entry, key, src);
+			if (rc)
+				return rc;
 		}
 	}
 
 	memcpy(&root_hdl, entry->iv_value.sg_iovs[0].iov_buf, sizeof(root_hdl));
 	d_iov_set(&key_iov, civ_key, sizeof(*civ_key));
 	if (src == NULL) {
+		/* If src == NULL, it is invalidate */
 		if (entry->iv_class->iv_class_id == IV_CONT_CAPA &&
 		    !uuid_is_null(civ_key->cont_uuid)) {
 			rc = ds_cont_tgt_close(civ_key->cont_uuid);
@@ -542,7 +591,7 @@ cont_iv_ent_refresh(struct ds_iv_entry *entry, struct ds_iv_key *key,
 }
 
 static int
-cont_iv_capa_alloc_internal(d_sg_list_t *sgl)
+cont_iv_ent_alloc_internal(d_sg_list_t *sgl)
 {
 	struct cont_iv_entry	*entry;
 	int			rc;
@@ -570,7 +619,9 @@ cont_iv_value_alloc(struct ds_iv_entry *entry, d_sg_list_t *sgl)
 	case IV_CONT_SNAP:
 		return cont_iv_snap_alloc_internal(sgl);
 	case IV_CONT_CAPA:
-		return cont_iv_capa_alloc_internal(sgl);
+	case IV_CONT_AGG_EPOCH_REPORT:
+	case IV_CONT_AGG_EPOCH_BOUNDRY:
+		return cont_iv_ent_alloc_internal(sgl);
 	case IV_CONT_PROP:
 		return cont_iv_prop_alloc_internal(sgl);
 	default:
@@ -894,6 +945,46 @@ out_eventual:
 }
 
 int
+cont_iv_ec_agg_eph_update_internal(void *ns, uuid_t cont_uuid,
+				   daos_epoch_t eph, unsigned int shortcut,
+				   unsigned int sync_mode,
+				   uint32_t op)
+{
+	struct cont_iv_entry	iv_entry = { 0 };
+	int			rc;
+
+	/* Only happens on xstream 0 */
+	D_ASSERT(dss_get_module_info()->dmi_xs_id == 0);
+	iv_entry.iv_agg_eph.eph = eph;
+	uuid_copy(iv_entry.cont_uuid, cont_uuid);
+	rc = crt_group_rank(NULL, &iv_entry.iv_agg_eph.rank);
+	if (rc)
+		return rc;
+
+	rc = cont_iv_update(ns, op, cont_uuid, &iv_entry,
+			    sizeof(struct cont_iv_entry), shortcut,
+			    sync_mode, false /* retry */);
+	return rc;
+}
+
+int
+cont_iv_ec_agg_eph_update(void *ns, uuid_t cont_uuid, daos_epoch_t eph)
+{
+	return cont_iv_ec_agg_eph_update_internal(ns, cont_uuid, eph,
+						  CRT_IV_SHORTCUT_TO_ROOT,
+						  CRT_IV_SYNC_NONE,
+						  IV_CONT_AGG_EPOCH_REPORT);
+}
+
+int
+cont_iv_ec_agg_eph_refresh(void *ns, uuid_t cont_uuid, daos_epoch_t eph)
+{
+	return cont_iv_ec_agg_eph_update_internal(ns, cont_uuid, eph,
+						  0, CRT_IV_SYNC_LAZY,
+						  IV_CONT_AGG_EPOCH_BOUNDRY);
+}
+
+int
 cont_iv_capability_update(void *ns, uuid_t cont_hdl_uuid, uuid_t cont_uuid,
 			  uint64_t flags, uint64_t sec_capas)
 {
@@ -1200,36 +1291,46 @@ ds_cont_find_hdl(uuid_t po_uuid, uuid_t coh_uuid, struct ds_cont_hdl **coh_p)
 }
 
 int
-ds_cont_iv_init(void)
-{
-	int rc;
-
-	rc = ds_iv_class_register(IV_CONT_CAPA, &iv_cache_ops, &cont_iv_ops);
-	if (rc)
-		return rc;
-
-	rc = ds_iv_class_register(IV_CONT_SNAP, &iv_cache_ops, &cont_iv_ops);
-	if (rc) {
-		ds_iv_class_unregister(IV_CONT_SNAP);
-		return rc;
-	}
-
-	rc = ds_iv_class_register(IV_CONT_PROP, &iv_cache_ops, &cont_iv_ops);
-	if (rc) {
-		ds_iv_class_unregister(IV_CONT_CAPA);
-		ds_iv_class_unregister(IV_CONT_SNAP);
-		return rc;
-	}
-
-	return rc;
-}
-
-int
 ds_cont_iv_fini(void)
 {
 	ds_iv_class_unregister(IV_CONT_SNAP);
 	ds_iv_class_unregister(IV_CONT_CAPA);
 	ds_iv_class_unregister(IV_CONT_PROP);
-
+	ds_iv_class_unregister(IV_CONT_AGG_EPOCH_REPORT);
+	ds_iv_class_unregister(IV_CONT_AGG_EPOCH_BOUNDRY);
 	return 0;
 }
+
+int
+ds_cont_iv_init(void)
+{
+	int rc;
+
+	rc = ds_iv_class_register(IV_CONT_SNAP, &iv_cache_ops, &cont_iv_ops);
+	if (rc)
+		D_GOTO(out, rc);
+
+	rc = ds_iv_class_register(IV_CONT_CAPA, &iv_cache_ops, &cont_iv_ops);
+	if (rc)
+		D_GOTO(out, rc);
+
+	rc = ds_iv_class_register(IV_CONT_PROP, &iv_cache_ops, &cont_iv_ops);
+	if (rc)
+		D_GOTO(out, rc);
+
+	rc = ds_iv_class_register(IV_CONT_AGG_EPOCH_REPORT, &iv_cache_ops,
+				  &cont_iv_ops);
+	if (rc)
+		D_GOTO(out, rc);
+
+	rc = ds_iv_class_register(IV_CONT_AGG_EPOCH_BOUNDRY, &iv_cache_ops,
+				  &cont_iv_ops);
+	if (rc)
+		D_GOTO(out, rc);
+out:
+	if (rc)
+		ds_cont_iv_fini();
+
+	return rc;
+}
+

--- a/src/container/srv_internal.h
+++ b/src/container/srv_internal.h
@@ -67,6 +67,21 @@ dsm_tls_get()
  *
  * Identified by a number unique within the pool.
  */
+
+struct ec_eph {
+	d_rank_t	rank;
+	daos_epoch_t	eph;
+};
+
+/* container EC aggregation epoch control descriptor, which is only on leader */
+struct cont_ec_agg {
+	uuid_t			ea_cont_uuid;
+	daos_epoch_t		ea_current_eph;
+	int			ea_servers_num;
+	struct ec_eph		*ea_server_ephs;
+	d_list_t		ea_list;
+};
+
 struct cont_svc {
 	uuid_t			cs_pool_uuid;
 	uint64_t		cs_id;
@@ -76,6 +91,10 @@ struct cont_svc {
 	rdb_path_t		cs_conts;	/* container KVS */
 	rdb_path_t		cs_hdls;	/* container handle KVS */
 	struct ds_pool	       *cs_pool;
+
+	/* Manage the EC aggregation epoch */
+	struct sched_request	*cs_ec_leader_ephs_req;
+	d_list_t		cs_ec_agg_list; /* link cont_ec_agg */
 };
 
 /* Container descriptor */
@@ -126,12 +145,18 @@ struct cont_iv_prop {
 	struct daos_acl	cip_acl;
 };
 
+struct cont_iv_agg_eph {
+	daos_epoch_t	eph;
+	d_rank_t	rank;
+};
+
 struct cont_iv_entry {
 	uuid_t	cont_uuid;
 	union {
 		struct cont_iv_snapshot iv_snap;
 		struct cont_iv_capa	iv_capa;
 		struct cont_iv_prop	iv_prop;
+		struct cont_iv_agg_eph	iv_agg_eph;
 	};
 };
 
@@ -171,6 +196,8 @@ int ds_cont_acl_delete(struct rdb_tx *tx, struct ds_pool_hdl *pool_hdl,
 int ds_cont_get_prop(uuid_t pool_uuid, uuid_t cont_uuid,
 		     daos_prop_t **prop_out);
 
+int ds_cont_leader_update_agg_eph(uuid_t pool_uuid, uuid_t cont_uuid,
+				  d_rank_t rank, daos_epoch_t eph);
 /*
  * srv_epoch.c
  */
@@ -230,6 +257,8 @@ int ds_cont_tgt_snapshots_update(uuid_t pool_uuid, uuid_t cont_uuid,
 				 uint64_t *snapshots, int snap_count);
 int ds_cont_tgt_snapshots_refresh(uuid_t pool_uuid, uuid_t cont_uuid);
 int ds_cont_tgt_close(uuid_t cont_hdl_uuid);
+int ds_cont_tgt_refresh_agg_eph(uuid_t pool_uuid, uuid_t cont_uuid,
+				daos_epoch_t eph);
 /**
  * oid_iv.c
  */
@@ -255,4 +284,6 @@ int cont_iv_snapshots_update(void *ns, uuid_t cont_uuid,
 int cont_child_gather_oids(struct ds_cont_child *cont, uuid_t coh_uuid,
 			   daos_epoch_t epoch);
 
+int cont_iv_ec_agg_eph_update(void *ns, uuid_t cont_uuid, daos_epoch_t eph);
+int cont_iv_ec_agg_eph_refresh(void *ns, uuid_t cont_uuid, daos_epoch_t eph);
 #endif /* __CONTAINER_SRV_INTERNAL_H__ */

--- a/src/container/srv_target.c
+++ b/src/container/srv_target.c
@@ -1090,6 +1090,9 @@ out:
 	return rc;
 }
 
+static void
+cont_delete_ec_agg(uuid_t pool_uuid, uuid_t cont_uuid);
+
 int
 ds_cont_tgt_destroy(uuid_t pool_uuid, uuid_t cont_uuid)
 {
@@ -1099,6 +1102,7 @@ ds_cont_tgt_destroy(uuid_t pool_uuid, uuid_t cont_uuid)
 	uuid_copy(in.tdi_pool_uuid, pool_uuid);
 	uuid_copy(in.tdi_uuid, cont_uuid);
 
+	cont_delete_ec_agg(pool_uuid, cont_uuid);
 	rc = dss_thread_collective(cont_child_destroy_one, &in, 0, DSS_ULT_IO);
 	return rc;
 }
@@ -2118,4 +2122,233 @@ out:
 	out->co_rc = rc;
 	out->co_map_version = 0;
 	crt_reply_send(rpc);
+}
+
+/* Track each container EC aggregation Epoch under ds_pool */
+struct cont_ec_eph {
+	uuid_t		ce_cont_uuid;
+	d_list_t	ce_list;
+	daos_epoch_t	ce_eph;
+	uint32_t	ce_updated:1;
+};
+
+/* Argument to query ec aggregate epoch from each xstream */
+struct cont_ec_xs_eph {
+	uuid_t		cont_uuid;
+	daos_epoch_t	eph;
+};
+
+struct cont_ec_xs_query_arg {
+	uuid_t			pool_uuid;
+	int			tgt_id;
+	int			ephs_cnt;
+	struct cont_ec_xs_eph	*ephs;
+};
+
+static int
+cont_ec_xs_reduce_alloc(struct dss_stream_arg_type *xs, void *agg_arg)
+{
+	struct cont_ec_xs_query_arg *xs_arg;
+	struct ds_pool *pool = agg_arg;
+
+	D_ALLOC_PTR(xs_arg);
+	if (xs_arg == NULL)
+		return -DER_NOMEM;
+
+	uuid_copy(xs_arg->pool_uuid, pool->sp_uuid);
+	xs->st_arg = xs_arg;
+	return 0;
+}
+
+static void
+cont_ec_xs_reduce_free(struct dss_stream_arg_type *xs)
+{
+	struct cont_ec_xs_query_arg *xs_arg = xs->st_arg;
+
+	if (xs_arg->ephs)
+		D_FREE_PTR(xs_arg->ephs);
+	D_FREE_PTR(xs_arg);
+}
+
+static struct cont_ec_eph *
+lookup_cont_ec_eph(d_list_t *ec_list, uuid_t cont_uuid)
+{
+	struct cont_ec_eph	*found = NULL;
+
+	d_list_for_each_entry(found, ec_list, ce_list) {
+		if (uuid_compare(found->ce_cont_uuid, cont_uuid) == 0)
+			return found;
+	}
+
+	return NULL;
+}
+
+static struct cont_ec_eph *
+lookup_insert_cont_ec_eph(d_list_t *ec_list, uuid_t cont_uuid)
+{
+	struct cont_ec_eph	*found;
+
+	found = lookup_cont_ec_eph(ec_list, cont_uuid);
+	if (found != NULL)
+		return found;
+	D_ALLOC_PTR(found);
+	if (found == NULL)
+		return NULL;
+
+	d_list_add(&found->ce_list, ec_list);
+	uuid_copy(found->ce_cont_uuid, cont_uuid);
+	return found;
+}
+
+static void
+cont_ec_eph_reduce(void *agg_arg, void *xs_arg)
+{
+	struct cont_ec_xs_query_arg	*x_arg = xs_arg;
+	struct ds_pool			*pool = agg_arg;
+	int				i;
+
+	for (i = 0; i < x_arg->ephs_cnt; i++) {
+		struct cont_ec_eph *c_eph;
+
+		c_eph = lookup_insert_cont_ec_eph(&pool->sp_ec_ephs_list,
+						  x_arg->ephs[i].cont_uuid);
+		if (c_eph->ce_eph == 0 ||
+		    (x_arg->ephs[i].eph != 0 &&
+		     c_eph->ce_eph > x_arg->ephs[i].eph)) {
+			c_eph->ce_eph = x_arg->ephs[i].eph;
+			c_eph->ce_updated = 1;
+		}
+	}
+}
+
+static int
+cont_ec_eph_query_one(void *arg)
+{
+	struct dss_coll_stream_args	*reduce = arg;
+	struct dss_stream_arg_type	*streams = reduce->csa_streams;
+	struct dss_module_info		*info = dss_get_module_info();
+	int				 tid = info->dmi_tgt_id;
+	struct cont_ec_xs_query_arg	*x_arg = streams[tid].st_arg;
+	struct ds_pool_child		*dpc;
+	struct ds_cont_child		*dcc;
+	int				total = 0;
+	struct cont_ec_xs_eph		*ephs;
+	int				i = 0;
+	int				rc = 0;
+
+	dpc = ds_pool_child_lookup(x_arg->pool_uuid);
+	if (dpc == NULL)
+		return -DER_NONEXIST;
+
+	d_list_for_each_entry(dcc, &dpc->spc_cont_list, sc_link)
+		total++;
+
+	if (total == 0)
+		D_GOTO(out, rc = 0);
+
+	D_ALLOC_ARRAY(ephs, total);
+	if (ephs == NULL)
+		D_GOTO(out, rc = -DER_NOMEM);
+
+	d_list_for_each_entry(dcc, &dpc->spc_cont_list, sc_link) {
+		uuid_copy(ephs[i].cont_uuid, dcc->sc_uuid);
+		ephs[i].eph = dcc->sc_ec_agg_eph;
+		i++;
+	}
+
+	x_arg->tgt_id = tid;
+	x_arg->ephs_cnt = total;
+	x_arg->ephs = ephs;
+
+out:
+	ds_pool_child_put(dpc);
+	return rc;
+}
+
+static void
+cont_ec_eph_destroy(struct cont_ec_eph *ec_eph)
+{
+	d_list_del(&ec_eph->ce_list);
+	D_FREE_PTR(ec_eph);
+}
+
+static void
+cont_delete_ec_agg(uuid_t pool_uuid, uuid_t cont_uuid)
+{
+	struct ds_pool		*pool;
+	struct cont_ec_eph	*ec_eph;
+
+	pool = ds_pool_lookup(pool_uuid);
+	D_ASSERT(pool != NULL);
+
+	ec_eph = lookup_cont_ec_eph(&pool->sp_ec_ephs_list, cont_uuid);
+	if (ec_eph)
+		cont_ec_eph_destroy(ec_eph);
+	ds_pool_put(pool);
+}
+
+/**
+ * This ULT is actually per pool to collect all container EC aggregation
+ * epoch, then report to the container service leader.
+ */
+#define EC_TGT_AGG_INTV	 (10ULL * 1000)	/* seconds interval to check*/
+void
+ds_cont_tgt_ec_eph_query_ult(void *data)
+{
+	struct ds_pool		*pool = data;
+	struct cont_ec_eph	*ec_eph;
+	struct cont_ec_eph	*tmp;
+	int			rc;
+
+	D_DEBUG(DB_MD, DF_UUID" start tgt ec query eph ULT\n",
+		DP_UUID(pool->sp_uuid));
+	while (!dss_ult_exiting(pool->sp_ec_ephs_req)) {
+		struct dss_coll_ops	coll_ops = { 0 };
+		struct dss_coll_args	coll_args = { 0 };
+
+		/* collective operations */
+		coll_ops.co_func = cont_ec_eph_query_one;
+		coll_ops.co_reduce = cont_ec_eph_reduce;
+		coll_ops.co_reduce_arg_alloc = cont_ec_xs_reduce_alloc;
+		coll_ops.co_reduce_arg_free = cont_ec_xs_reduce_free;
+		coll_args.ca_aggregator = pool;
+		coll_args.ca_func_args	= &coll_args.ca_stream_args;
+
+		rc = dss_thread_collective_reduce(&coll_ops, &coll_args,
+						  0, DSS_ULT_IO);
+		if (rc) {
+			D_ERROR(DF_UUID": Can not collect min epoch: %d\n",
+				DP_UUID(pool->sp_uuid), rc);
+			D_GOTO(yield, rc);
+		}
+
+		d_list_for_each_entry(ec_eph, &pool->sp_ec_ephs_list, ce_list) {
+			if (ec_eph->ce_eph == 0 || ec_eph->ce_updated)
+				continue;
+
+			D_DEBUG(DB_MD, "eph "DF_U64" "DF_UUID"\n",
+				ec_eph->ce_eph, DP_UUID(ec_eph->ce_cont_uuid));
+			rc = cont_iv_ec_agg_eph_update(pool->sp_iv_ns,
+						       ec_eph->ce_cont_uuid,
+						       ec_eph->ce_eph);
+			if (rc == 0)
+				ec_eph->ce_updated = 0;
+			else
+				D_ERROR(DF_CONT": Update min epoch: %d\n",
+					DP_CONT(pool->sp_uuid,
+						ec_eph->ce_cont_uuid), rc);
+		}
+yield:
+		if (dss_ult_exiting(pool->sp_ec_ephs_req))
+			break;
+
+		sched_req_sleep(pool->sp_ec_ephs_req, EC_TGT_AGG_INTV);
+	}
+
+	D_DEBUG(DB_MD, DF_UUID" stop tgt ec aggregation\n",
+		DP_UUID(pool->sp_uuid));
+
+	d_list_for_each_entry_safe(ec_eph, tmp, &pool->sp_ec_ephs_list,
+				   ce_list)
+		cont_ec_eph_destroy(ec_eph);
 }

--- a/src/include/daos_srv/container.h
+++ b/src/include/daos_srv/container.h
@@ -112,6 +112,15 @@ struct ds_cont_child {
 	uint32_t		 sc_open;
 
 	uint64_t		 sc_dtx_committable_count;
+
+	/* The global minimum EC aggregation epoch, which will be upper
+	 * limit for VOS aggregation, i.e. EC object VOS aggregation can
+	 * not cross this limit. For simplification purpose, all objects
+	 * VOS aggregation will use this boundary. We will optimize it later.
+	 */
+	uint64_t		sc_ec_agg_eph_boundry;
+	/* The current EC aggregate epoch for this xstream */
+	uint64_t		sc_ec_agg_eph;
 	/* The objects with committable DTXs in DRAM. */
 	daos_handle_t		 sc_dtx_cos_hdl;
 	/* The DTX COS-btree. */
@@ -246,4 +255,6 @@ int dsc_cont_open(daos_handle_t poh, uuid_t cont_uuid, uuid_t cont_hdl_uuid,
 		  unsigned int flags, daos_handle_t *coh);
 int dsc_cont_close(daos_handle_t poh, daos_handle_t coh);
 
+
+void ds_cont_tgt_ec_eph_query_ult(void *data);
 #endif /* ___DAOS_SRV_CONTAINER_H_ */

--- a/src/include/daos_srv/iv.h
+++ b/src/include/daos_srv/iv.h
@@ -291,6 +291,14 @@ enum iv_key {
 	/* Container properties */
 	IV_CONT_PROP,
 	IV_POOL_HDL,
+	/* Each server report its own EC aggregation epoch to the container
+	 * service leader
+	 */
+	IV_CONT_AGG_EPOCH_REPORT,
+	/* leader sync the minimum epoch(VOS aggregate epoch boundary) to all
+	 * other servers
+	 */
+	IV_CONT_AGG_EPOCH_BOUNDRY,
 };
 
 int ds_iv_fetch(struct ds_iv_ns *ns, struct ds_iv_key *key, d_sg_list_t *value,

--- a/src/include/daos_srv/pool.h
+++ b/src/include/daos_srv/pool.h
@@ -56,6 +56,11 @@ struct ds_pool {
 	ABT_cond		sp_fetch_hdls_cond;
 	ABT_cond		sp_fetch_hdls_done_cond;
 	struct ds_iv_ns	       *sp_iv_ns;
+
+	/* structure related to EC aggregate epoch query */
+	d_list_t		sp_ec_ephs_list;
+	struct sched_request	*sp_ec_ephs_req;
+
 	uint32_t		sp_dtx_resync_version;
 	/* Special pool/container handle uuid, which are
 	 * created on the pool leader step up, and propagated

--- a/src/object/cli_shard.c
+++ b/src/object/cli_shard.c
@@ -962,10 +962,11 @@ dc_obj_shard_rw(struct dc_obj_shard *shard, enum obj_rpc_opc opc,
 					 0 : nr;
 	orw->orw_iod_array.oia_offs = args->offs;
 
-	D_DEBUG(DB_IO, "opc %d "DF_UOID" "DF_KEY" rank %d tag %d eph "
-		DF_U64", DTI = "DF_DTI" ver %u\n", opc, DP_UOID(shard->do_id),
-		DP_KEY(dkey), tgt_ep.ep_rank, tgt_ep.ep_tag,
-		auxi->epoch.oe_value, DP_DTI(&orw->orw_dti), orw->orw_map_ver);
+	D_DEBUG(DB_IO, "rpc %p opc %d "DF_UOID" "DF_KEY" rank %d tag %d eph "
+		DF_U64", DTI = "DF_DTI" ver %u\n", req, opc,
+		DP_UOID(shard->do_id), DP_KEY(dkey), tgt_ep.ep_rank,
+		tgt_ep.ep_tag, auxi->epoch.oe_value, DP_DTI(&orw->orw_dti),
+		orw->orw_map_ver);
 
 	if (args->bulks != NULL) {
 		orw->orw_sgls.ca_count = 0;

--- a/src/pool/srv_target.c
+++ b/src/pool/srv_target.c
@@ -348,6 +348,7 @@ pool_alloc_ref(void *key, unsigned int ksize, void *varg,
 	if (rc != ABT_SUCCESS)
 		D_GOTO(err_cond, rc = dss_abterr2der(rc));
 
+	D_INIT_LIST_HEAD(&pool->sp_ec_ephs_list);
 	uuid_copy(pool->sp_uuid, key);
 	pool->sp_map_version = arg->pca_map_version;
 	pool->sp_reclaim = DAOS_RECLAIM_LAZY; /* default reclaim strategy */
@@ -578,6 +579,54 @@ out:
 		D_FREE(iov.iov_buf);
 }
 
+static void
+tgt_ec_eph_query_ult(void *data)
+{
+	ds_cont_tgt_ec_eph_query_ult(data);
+}
+
+static int
+ds_pool_start_ec_eph_query_ult(struct ds_pool *pool)
+{
+	struct sched_req_attr	attr;
+	ABT_thread		ec_eph_query_ult = ABT_THREAD_NULL;
+	int			rc;
+
+	rc = dss_ult_create(tgt_ec_eph_query_ult, pool, DSS_ULT_POOL_SRV, 0,
+			    131072, &ec_eph_query_ult);
+	if (rc != 0) {
+		D_ERROR(DF_UUID": failed create ec eph equery ult: %d\n",
+			DP_UUID(pool->sp_uuid), rc);
+		return rc;
+	}
+
+	D_ASSERT(ec_eph_query_ult != ABT_THREAD_NULL);
+	sched_req_attr_init(&attr, SCHED_REQ_GC, &pool->sp_uuid);
+	pool->sp_ec_ephs_req = sched_req_get(&attr, ec_eph_query_ult);
+	if (pool->sp_ec_ephs_req == NULL) {
+		D_ERROR(DF_UUID"Failed to get req for ec eph query ULT\n",
+		       DP_UUID(pool->sp_uuid));
+		ABT_thread_join(ec_eph_query_ult);
+		return -DER_NOMEM;
+	}
+
+	return rc;
+}
+
+static void
+ds_pool_tgt_ec_eph_query_abort(struct ds_pool *pool)
+{
+	if (pool->sp_ec_ephs_req == NULL)
+		return;
+
+	D_DEBUG(DB_MD, DF_UUID"Stopping EC query ULT\n",
+		DP_UUID(pool->sp_uuid));
+
+	sched_req_wait(pool->sp_ec_ephs_req, true);
+	sched_req_put(pool->sp_ec_ephs_req);
+	pool->sp_ec_ephs_req = NULL;
+}
+
 /*
  * Start a pool. Must be called on the system xstream. Hold the ds_pool object
  * till ds_pool_stop. Only for mgmt and pool modules.
@@ -633,6 +682,13 @@ ds_pool_start(uuid_t uuid)
 	}
 
 	pool->sp_fetch_hdls = 1;
+	rc = ds_pool_start_ec_eph_query_ult(pool);
+	if (rc != 0) {
+		D_ERROR(DF_UUID": failed to start ec eph query ult: %d\n",
+			DP_UUID(uuid), rc);
+		ds_pool_put(pool);
+		D_GOTO(out_lock, rc);
+	}
 out_lock:
 	ABT_mutex_unlock(pool_cache_lock);
 	return rc;
@@ -669,7 +725,9 @@ ds_pool_stop(uuid_t uuid)
 		return;
 	pool->sp_stopping = 1;
 
+	ds_pool_tgt_ec_eph_query_abort(pool);
 	pool_fetch_hdls_ult_abort(pool);
+
 	ds_rebuild_abort(pool->sp_uuid, -1);
 	ds_migrate_abort(pool->sp_uuid, -1);
 	ds_pool_put(pool); /* held by ds_pool_start */


### PR DESCRIPTION
To coordinate EC aggregation and vos aggregation,
VOS aggregation can not aggregate the extent
which has not been processed by EC aggregation yet.

During EC aggregation, each server report
its current EC aggregation epoch to the leader,
and the leader will chose the minum epoch, then
broadcast (by IV sync) it to all servers, who
will use it as the VOS aggregation epoch bondary.

Signed-off-by: Di Wang <di.wang@intel.com>