### PR TITLE
DAOS-6033 pool: Do not increase the f_seq for reint

### DIFF
--- a/src/include/daos/placement.h
+++ b/src/include/daos/placement.h
@@ -138,22 +138,19 @@ int pl_obj_find_rebuild(struct pl_map *map,
 			struct daos_obj_md *md,
 			struct daos_obj_shard_md *shard_md,
 			uint32_t rebuild_ver, uint32_t *tgt_rank,
-			uint32_t *shard_id, unsigned int array_size,
-			int myrank);
+			uint32_t *shard_id, unsigned int array_size);
 
 int pl_obj_find_reint(struct pl_map *map,
 			struct daos_obj_md *md,
 			struct daos_obj_shard_md *shard_md,
 			uint32_t rebuild_ver, uint32_t *tgt_rank,
-			uint32_t *shard_id, unsigned int array_size,
-			int myrank);
+			uint32_t *shard_id, unsigned int array_size);
 
 int pl_obj_find_addition(struct pl_map *map,
 			 struct daos_obj_md *md,
 			struct daos_obj_shard_md *shard_md,
 			uint32_t rebuild_ver, uint32_t *tgt_rank,
-			uint32_t *shard_id, unsigned int array_size,
-			int myrank);
+			uint32_t *shard_id, unsigned int array_size);
 
 typedef struct pl_obj_shard *(*pl_get_shard_t)(void *data, int idx);
 

--- a/src/placement/jump_map.c
+++ b/src/placement/jump_map.c
@@ -506,7 +506,7 @@ obj_remap_shards(struct pl_jump_map *jmap, struct daos_obj_md *md,
 	int                     rc;
 
 
-	remap_dump(remap_list, md, "before remap:");
+	remap_dump(remap_list, md, "remap:");
 
 	for_reint = (op_type == PL_REINT);
 	current = remap_list->next;
@@ -552,7 +552,6 @@ obj_remap_shards(struct pl_jump_map *jmap, struct daos_obj_md *md,
 		if (rc != 0)
 			return rc;
 	}
-	remap_dump(remap_list, md, "after remap:");
 	return 0;
 }
 
@@ -955,9 +954,6 @@ jump_map_obj_place(struct pl_map *map, struct daos_obj_md *md,
  *                              rebuilt (This is allocated by the caller)
  * \param[in]   array_size      The max size of the passed in arrays to store
  *                              info about the shards that need to be rebuilt.
- * \param[in]   myrank          The rank of the server. Only servers who are
- *                              the leader for a particular failed shard will
- *                              initiate a rebuild for it.
  *
  * \return                      The number of shards that need to be rebuilt on
  *                              another target, Or 0 if none need to be rebuilt.
@@ -966,8 +962,7 @@ static int
 jump_map_obj_find_rebuild(struct pl_map *map, struct daos_obj_md *md,
 			  struct daos_obj_shard_md *shard_md,
 			  uint32_t rebuild_ver, uint32_t *tgt_id,
-			  uint32_t *shard_idx, unsigned int array_size,
-			  int myrank)
+			  uint32_t *shard_idx, unsigned int array_size)
 {
 	struct pl_jump_map              *jmap;
 	struct pl_obj_layout            *layout;
@@ -1017,8 +1012,7 @@ jump_map_obj_find_rebuild(struct pl_map *map, struct daos_obj_md *md,
 	obj_layout_dump(oid, layout);
 
 	rc = remap_list_fill(map, md, shard_md, rebuild_ver, tgt_id, shard_idx,
-			     array_size, myrank, &idx, layout, &remap_list,
-			     false);
+			     array_size, &idx, layout, &remap_list, false);
 
 out:
 	remap_list_free_all(&remap_list);
@@ -1030,8 +1024,7 @@ static int
 jump_map_obj_find_reint(struct pl_map *map, struct daos_obj_md *md,
 			struct daos_obj_shard_md *shard_md,
 			uint32_t reint_ver, uint32_t *tgt_rank,
-			uint32_t *shard_id, unsigned int array_size,
-			int myrank)
+			uint32_t *shard_id, unsigned int array_size)
 {
 	struct pl_jump_map              *jmap;
 	struct pl_obj_layout            *layout;
@@ -1085,15 +1078,15 @@ jump_map_obj_find_reint(struct pl_map *map, struct daos_obj_md *md,
 
 	/* Get placement after reintegration. */
 	rc = get_object_layout(jmap, reint_layout, &jop, &remap_list, PL_REINT,
-				md);
+			       md);
 	if (rc)
 		goto out;
 
 	layout_find_diff(jmap, layout, reint_layout, &reint_list);
 
 	rc = remap_list_fill(map, md, shard_md, reint_ver, tgt_rank, shard_id,
-			     array_size, myrank, &idx, reint_layout,
-			     &reint_list, false);
+			     array_size, &idx, reint_layout, &reint_list,
+			     false);
 out:
 	remap_list_free_all(&reint_list);
 	remap_list_free_all(&remap_list);
@@ -1109,9 +1102,8 @@ out:
 static int
 jump_map_obj_find_addition(struct pl_map *map, struct daos_obj_md *md,
 			   struct daos_obj_shard_md *shard_md,
-			uint32_t reint_ver, uint32_t *tgt_rank,
-			uint32_t *shard_id, unsigned int array_size,
-			int myrank)
+			   uint32_t reint_ver, uint32_t *tgt_rank,
+			   uint32_t *shard_id, unsigned int array_size)
 {
 	struct pl_jump_map              *jmap;
 	struct pl_obj_layout            *layout;
@@ -1171,8 +1163,7 @@ jump_map_obj_find_addition(struct pl_map *map, struct daos_obj_md *md,
 	layout_find_diff(jmap, layout, add_layout, &add_list);
 
 	rc = remap_list_fill(map, md, shard_md, reint_ver, tgt_rank, shard_id,
-			     array_size, myrank, &idx, add_layout,
-			     &add_list, true);
+			     array_size, &idx, add_layout, &add_list, true);
 out:
 	remap_list_free_all(&add_list);
 	remap_list_free_all(&remap_list);
@@ -1194,5 +1185,4 @@ struct pl_map_ops       jump_map_ops = {
 	.o_obj_find_rebuild     = jump_map_obj_find_rebuild,
 	.o_obj_find_reint       = jump_map_obj_find_reint,
 	.o_obj_find_addition      = jump_map_obj_find_addition,
-
 };

--- a/src/placement/pl_map.c
+++ b/src/placement/pl_map.c
@@ -154,7 +154,6 @@ pl_obj_place(struct pl_map *map, struct daos_obj_md *md,
  * \param  tgt_rank [OUT]       spare target ranks
  * \param  shard_id [OUT]       shard ids to be rebuilt
  * \param  array_size [IN]      array size of tgt_rank & shard_id
- * \prarm  myrank [IN]          rank of current server in communication group
 
  * \return      > 0     the array size of tgt_rank & shard_id, so it means
  *                      getting the spare targets for the failure shards.
@@ -165,7 +164,7 @@ int
 pl_obj_find_rebuild(struct pl_map *map, struct daos_obj_md *md,
 		    struct daos_obj_shard_md *shard_md,
 		    uint32_t rebuild_ver, uint32_t *tgt_rank,
-		    uint32_t *shard_id, unsigned int array_size, int myrank)
+		    uint32_t *shard_id, unsigned int array_size)
 {
 	D_ASSERT(map->pl_ops != NULL);
 
@@ -173,15 +172,14 @@ pl_obj_find_rebuild(struct pl_map *map, struct daos_obj_md *md,
 		return -DER_NOSYS;
 
 	return map->pl_ops->o_obj_find_rebuild(map, md, shard_md, rebuild_ver,
-					       tgt_rank, shard_id, array_size,
-					       myrank);
+					       tgt_rank, shard_id, array_size);
 }
 
 int
 pl_obj_find_reint(struct pl_map *map, struct daos_obj_md *md,
 		    struct daos_obj_shard_md *shard_md,
 		    uint32_t reint_ver, uint32_t *tgt_rank,
-		    uint32_t *shard_id, unsigned int array_size, int myrank)
+		    uint32_t *shard_id, unsigned int array_size)
 {
 	D_ASSERT(map->pl_ops != NULL);
 
@@ -189,15 +187,14 @@ pl_obj_find_reint(struct pl_map *map, struct daos_obj_md *md,
 		return -DER_NOSYS;
 
 	return map->pl_ops->o_obj_find_reint(map, md, shard_md, reint_ver,
-					       tgt_rank, shard_id, array_size,
-					       myrank);
+					       tgt_rank, shard_id, array_size);
 }
 
 int
 pl_obj_find_addition(struct pl_map *map, struct daos_obj_md *md,
 		     struct daos_obj_shard_md *shard_md,
 		    uint32_t reint_ver, uint32_t *tgt_rank,
-		    uint32_t *shard_id, unsigned int array_size, int myrank)
+		    uint32_t *shard_id, unsigned int array_size)
 {
 	D_ASSERT(map->pl_ops != NULL);
 
@@ -205,8 +202,7 @@ pl_obj_find_addition(struct pl_map *map, struct daos_obj_md *md,
 		return -DER_NOSYS;
 
 	return map->pl_ops->o_obj_find_addition(map, md, shard_md, reint_ver,
-					       tgt_rank, shard_id, array_size,
-					       myrank);
+					       tgt_rank, shard_id, array_size);
 }
 
 void

--- a/src/placement/pl_map.h
+++ b/src/placement/pl_map.h
@@ -59,21 +59,21 @@ struct pl_map_ops {
 				  uint32_t rebuild_ver,
 				  uint32_t *tgt_rank,
 				  uint32_t *shard_id,
-				  unsigned int array_size, int myrank);
+				  unsigned int array_size);
 	int (*o_obj_find_reint)(struct pl_map *map,
 				  struct daos_obj_md *md,
 				  struct daos_obj_shard_md *shard_md,
 				  uint32_t reint_ver,
 				  uint32_t *tgt_rank,
 				  uint32_t *shard_id,
-				  unsigned int array_size, int myrank);
+				  unsigned int array_size);
 	int (*o_obj_find_addition)(struct pl_map *map,
 				   struct daos_obj_md *md,
 				  struct daos_obj_shard_md *shard_md,
 				  uint32_t reint_ver,
 				  uint32_t *tgt_rank,
 				  uint32_t *shard_id,
-				  unsigned int array_size, int myrank);
+				  unsigned int array_size);
 
 };
 
@@ -124,7 +124,7 @@ int
 remap_list_fill(struct pl_map *map, struct daos_obj_md *md,
 		struct daos_obj_shard_md *shard_md, uint32_t rebuild_ver,
 		uint32_t *tgt_id, uint32_t *shard_idx,
-		unsigned int array_size, int myrank, int *idx,
+		unsigned int array_size, int *idx,
 		struct pl_obj_layout *layout, d_list_t *remap_list,
 		bool fill_addition);
 

--- a/src/placement/pl_map_common.c
+++ b/src/placement/pl_map_common.c
@@ -40,7 +40,8 @@ remap_add_one(d_list_t *remap_list, struct failed_shard *f_new)
 
 	d_list_t                *tmp;
 
-	D_DEBUG(DB_PL, "fnew: %u", f_new->fs_shard_idx);
+	D_DEBUG(DB_PL, "fnew: %u/%d/%u/%u", f_new->fs_shard_idx,
+		f_new->fs_tgt_id, f_new->fs_fseq, f_new->fs_status);
 
 	/* All failed shards are sorted by fseq in ascending order */
 	d_list_for_each_prev(tmp, remap_list) {
@@ -196,13 +197,12 @@ int
 remap_list_fill(struct pl_map *map, struct daos_obj_md *md,
 		struct daos_obj_shard_md *shard_md, uint32_t r_ver,
 		uint32_t *tgt_id, uint32_t *shard_idx,
-		unsigned int array_size, int myrank, int *idx,
+		unsigned int array_size, int *idx,
 		struct pl_obj_layout *layout, d_list_t *remap_list,
 		bool fill_addition)
 {
 	struct failed_shard     *f_shard;
 	struct pl_obj_shard     *l_shard;
-	int                     rc = 0;
 
 	d_list_for_each_entry(f_shard, remap_list, fs_list) {
 		l_shard = &layout->ol_shards[f_shard->fs_shard_idx];
@@ -210,9 +210,15 @@ remap_list_fill(struct pl_map *map, struct daos_obj_md *md,
 		if (f_shard->fs_fseq > r_ver)
 			break;
 
+		/**
+		 * NB: due to colrelocation, the data on healthy
+		 * shard might need move to, so let's include
+		 * UPIN status here as well.
+		 */
 		if (f_shard->fs_status == PO_COMP_ST_DOWN ||
 		    f_shard->fs_status == PO_COMP_ST_UP ||
 		    f_shard->fs_status == PO_COMP_ST_DRAIN ||
+		    f_shard->fs_status == PO_COMP_ST_UPIN ||
 		    fill_addition == true) {
 			/*
 			 * Target id is used for rw, but rank is used
@@ -225,16 +231,16 @@ remap_list_fill(struct pl_map *map, struct daos_obj_md *md,
 				shard_idx[*idx] = l_shard->po_shard;
 				(*idx)++;
 			}
-		} else if (f_shard->fs_tgt_id != -1) {
-			rc = -DER_ALREADY;
-			D_ERROR(""DF_OID" rebuild is done for "
-				"fseq:%d(status:%d)? rbd_ver:%d rc %d\n",
-				DP_OID(md->omd_id), f_shard->fs_fseq,
-				f_shard->fs_status, r_ver, rc);
+		} else {
+			D_DEBUG(DB_REBUILD, ""DF_OID" skip id %u idx %u"
+				"fseq:%d(status:%d)? rbd_ver:%d\n",
+				DP_OID(md->omd_id), f_shard->fs_tgt_id,
+				f_shard->fs_shard_idx, f_shard->fs_fseq,
+				f_shard->fs_status, r_ver);
 		}
 	}
 
-	return rc;
+	return 0;
 }
 
 void
@@ -273,8 +279,13 @@ determine_valid_spares(struct pool_target *spare_tgt, struct daos_obj_md *md,
 		 * one, then it can't be a valid spare, let's skip it
 		 * and try next spare on the ring.
 		 */
-		if (spare_tgt->ta_comp.co_fseq < f_shard->fs_fseq)
+		if (spare_tgt->ta_comp.co_fseq < f_shard->fs_fseq) {
+			D_DEBUG(DB_PL, "spare tgt %u co fs_seq %u"
+				" shard f_seq %u\n", spare_tgt->ta_comp.co_id,
+				spare_tgt->ta_comp.co_fseq,
+				f_shard->fs_fseq);
 			return; /* try next spare */
+		}
 		/*
 		 * If both failed target and spare target are down, then
 		 * add the spare target to the fail list for remap, and
@@ -305,6 +316,9 @@ determine_valid_spares(struct pool_target *spare_tgt, struct daos_obj_md *md,
 			if (f_shard->fs_fseq < f_tmp->fs_fseq)
 				(*current) = &f_shard->fs_list;
 		}
+		D_DEBUG(DB_PL, "spare_tgt %u status %u f_seq %u try next.\n",
+			spare_tgt->ta_comp.co_id, spare_tgt->ta_comp.co_status,
+			spare_tgt->ta_comp.co_fseq);
 		return; /* try next spare */
 	}
 next_fail:

--- a/src/placement/ring_map.c
+++ b/src/placement/ring_map.c
@@ -1151,8 +1151,7 @@ int
 ring_obj_find_rebuild(struct pl_map *map, struct daos_obj_md *md,
 		      struct daos_obj_shard_md *shard_md,
 		      uint32_t rebuild_ver, uint32_t *tgt_id,
-		      uint32_t *shard_idx, unsigned int array_size,
-		      int myrank)
+		      uint32_t *shard_idx, unsigned int array_size)
 {
 	struct ring_obj_placement  rop;
 	struct pl_ring_map	  *rimap = pl_map2rimap(map);
@@ -1203,7 +1202,7 @@ ring_obj_find_rebuild(struct pl_map *map, struct daos_obj_md *md,
 		goto out;
 
 	remap_list_fill(map, md, shard_md, rebuild_ver, tgt_id, shard_idx,
-			array_size, myrank, &idx, layout, &remap_list, false);
+			array_size, &idx, layout, &remap_list, false);
 out:
 	remap_list_free_all(&remap_list);
 	if (shards_count > SHARDS_ON_STACK_COUNT)
@@ -1216,8 +1215,7 @@ int
 ring_obj_find_reint(struct pl_map *map, struct daos_obj_md *md,
 			struct daos_obj_shard_md *shard_md,
 			uint32_t reint_ver, uint32_t *tgt_rank,
-			uint32_t *shard_id, unsigned int array_size,
-			int myrank)
+			uint32_t *shard_id, unsigned int array_size)
 {
 	uint32_t                   reint_shard_cnt = SHARDS_ON_STACK_COUNT / 2;
 	struct ring_obj_placement  rop;
@@ -1312,7 +1310,7 @@ ring_obj_find_reint(struct pl_map *map, struct daos_obj_md *md,
 	}
 
 	remap_list_fill(map, md, shard_md, reint_ver, tgt_rank, shard_id,
-			array_size, myrank, &idx, layout, &reint_list, false);
+			array_size, &idx, layout, &reint_list, false);
 out:
 	remap_list_free_all(&remap_list);
 	remap_list_free_all(&reint_list);

--- a/src/placement/tests/jump_map_place_obj.c
+++ b/src/placement/tests/jump_map_place_obj.c
@@ -145,7 +145,7 @@ rebuild_object_class(daos_oclass_id_t cid)
 			num_new_spares = pl_obj_find_rebuild(pl_map,
 					&md_arr[test_num], NULL, po_ver,
 					spare_tgt_ranks, shard_ids,
-					SPARE_MAX_NUM, -1);
+					SPARE_MAX_NUM);
 
 			spares_left = NUM_TARGETS - layout->ol_nr + fail_tgt;
 			plt_obj_rebuild_layout_check(layout,
@@ -279,7 +279,7 @@ reint_object_class(daos_oclass_id_t cid)
 
 			num_reint = pl_obj_find_reint(pl_map, &md_arr[test_num],
 					NULL, po_ver,  spare_tgt_ranks,
-					shard_ids, SPARE_MAX_NUM, -1);
+					shard_ids, SPARE_MAX_NUM);
 
 			plt_obj_reint_layout_check(temp_layout,
 					layout[fail_tgt][test_num],
@@ -395,7 +395,7 @@ drain_object_class(daos_oclass_id_t cid)
 			num_new_spares = pl_obj_find_rebuild(pl_map,
 					&md_arr[test_num], NULL, po_ver,
 					spare_tgt_ranks, shard_ids,
-					SPARE_MAX_NUM, -1);
+					SPARE_MAX_NUM);
 
 			plt_obj_layout_check(layout, COMPONENT_NR,
 					layout->ol_nr);
@@ -515,7 +515,7 @@ add_object_class(daos_oclass_id_t cid)
 						      NULL, po_ver,
 						      spare_tgt_ranks,
 						      shard_ids,
-						      SPARE_MAX_NUM, -1);
+						      SPARE_MAX_NUM);
 		D_ASSERT(num_new_spares >= 0);
 
 		plt_obj_add_layout_check(layout, org_layout[test_num],

--- a/src/placement/tests/place_obj_common.c
+++ b/src/placement/tests/place_obj_common.c
@@ -450,7 +450,7 @@ plt_spare_tgts_get(uuid_t pl_uuid, daos_obj_id_t oid, uint32_t *failed_tgts,
 	md.omd_ver = *po_ver;
 	*spare_cnt = pl_obj_find_rebuild(pl_map, &md, NULL, *po_ver,
 					 spare_tgt_ranks, shard_ids,
-					 spare_max_nr, -1);
+					 spare_max_nr);
 	D_PRINT("spare_cnt %d for version %d -\n", *spare_cnt, *po_ver);
 	for (i = 0; i < *spare_cnt; i++)
 		D_PRINT("shard %d, spare target rank %d\n",
@@ -567,9 +567,8 @@ plt_reint_tgts_get(uuid_t pl_uuid, daos_obj_id_t oid, uint32_t *failed_tgts,
 	D_ASSERT(pl_map != NULL);
 	dc_obj_fetch_md(oid, &md);
 	md.omd_ver = *po_ver;
-	rc = pl_obj_find_reint(pl_map, &md, NULL, *po_ver,
-					 spare_tgt_ranks, shard_ids,
-					 spare_max_nr, -1);
+	rc = pl_obj_find_reint(pl_map, &md, NULL, *po_ver, spare_tgt_ranks,
+			       shard_ids, spare_max_nr);
 
 	D_ASSERT(rc >= 0);
 	*spare_cnt = rc;

--- a/src/pool/srv_util.c
+++ b/src/pool/srv_util.c
@@ -321,7 +321,7 @@ update_one_tgt(struct pool_map *map, struct pool_target *target,
 				target->ta_comp.co_rank,
 				target->ta_comp.co_index, map);
 			target->ta_comp.co_status = PO_COMP_ST_UP;
-			target->ta_comp.co_fseq = ++(*version);
+			++(*version);
 
 			D_PRINT("Target (rank %u idx %u) start reintegration\n",
 				target->ta_comp.co_rank,

--- a/src/rebuild/scan.c
+++ b/src/rebuild/scan.c
@@ -374,22 +374,22 @@ rebuild_obj_scan_cb(daos_handle_t ch, vos_iter_entry_t *ent,
 		rebuild_nr = pl_obj_find_rebuild(map, &md, NULL,
 						 rpt->rt_rebuild_ver,
 						 tgts, shards,
-						 rpt->rt_tgts_num, myrank);
+						 rpt->rt_tgts_num);
 	} else if (rpt->rt_rebuild_op == RB_OP_DRAIN) {
 		rebuild_nr = pl_obj_find_rebuild(map, &md, NULL,
 						 rpt->rt_rebuild_ver,
 						 tgts, shards,
-						 rpt->rt_tgts_num, -1);
+						 rpt->rt_tgts_num);
 	} else if (rpt->rt_rebuild_op == RB_OP_REINT) {
 		rebuild_nr = pl_obj_find_reint(map, &md, NULL,
 					       rpt->rt_rebuild_ver,
 					       tgts, shards,
-					       rpt->rt_tgts_num, myrank);
+					       rpt->rt_tgts_num);
 	} else if (rpt->rt_rebuild_op == RB_OP_EXTEND) {
 		rebuild_nr = pl_obj_find_addition(map, &md, NULL,
 						  rpt->rt_rebuild_ver,
 						  tgts, shards,
-						  rpt->rt_tgts_num, myrank);
+						  rpt->rt_tgts_num);
 	} else {
 		D_ASSERT(rpt->rt_rebuild_op == RB_OP_FAIL ||
 			 rpt->rt_rebuild_op == RB_OP_DRAIN ||

--- a/src/vos/evtree.c
+++ b/src/vos/evtree.c
@@ -1990,6 +1990,10 @@ evt_insert(daos_handle_t toh, const struct evt_entry_in *entry,
 		return -DER_INVAL;
 	}
 
+	D_ASSERT(evt_rect_width(&entry->ei_rect) != 0);
+	D_ASSERT(entry->ei_inob != 0 || bio_addr_is_hole(&entry->ei_addr));
+	D_ASSERT(bio_addr_is_hole(&entry->ei_addr) ||
+		 entry->ei_addr.ba_off != 0);
 	if (evt_rect_width(&entry->ei_rect) > MAX_RECT_WIDTH) {
 		if (bio_addr_is_hole(&entry->ei_addr)) {
 			/** csum_bufp is specific to aggregation case and we


### PR DESCRIPTION
Do not update f_seq for reintegration, otherwise the
object layout might be calculated incorrectly, because
the remap shards needs to strictly follow the f_seq order.

Adding a few assertion (from Jeff) in evt_insert() to avoid
inserting invalid extent into the evtree.

Signed-off-by: Di Wang <di.wang@intel.com>
Signed-off-by: Jeff Olivier <jeffrey.v.olivier@intel.com>