### PR TITLE
DAOS-4433 md, api: remove svc rank list from libdaos APIs

### DIFF
--- a/doc/man/man8/daos.8
+++ b/doc/man/man8/daos.8
@@ -70,8 +70,6 @@ The \fBRESOURCE\fRs, respective \fBCOMMAND\fRs and \fBOPTION\fRs supported by \f
 .br
 	  \fB--sys=\fRSTR
 .br
-	  \fB--svc=\fRRANKS        pool service replicas like 1,2,3
-.br
 	  \fB--attr=\fRNAME        pool attribute name to get
 .br
 .TP
@@ -111,12 +109,12 @@ The \fBRESOURCE\fRs, respective \fBCOMMAND\fRs and \fBOPTION\fRs supported by \f
 	  \fBrollback\fR         roll back container to specified snapshot
 .TP
 .I container \fBOPTION\fRs (create by UUID):
-	  <\fIpool\fR options>   (\fB--pool\fR, \fB--sys-name\fR, \fB--svc\fR)
+	  <\fIpool\fR options>   (\fB--pool\fR, \fB--sys-name\fR)
 .br
 	  \fB--cont=\fRUUID      (optional) container UUID (or generated)
 .TP
 .I container \fBOPTION\fRs (create and link to namespace path):
-	  <\fIpool\fR/\fIcont\fR opts>   (\fB--pool\fR, \fB--sys-name\fR, \fB--svc\fR, \fB--cont\fR [optional])
+	  <\fIpool\fR/\fIcont\fR opts>   (\fB--pool\fR, \fB--sys-name\fR, \fB--cont\fR [optional])
 .br
 	  \fB--path=\fRPATHSTR     container namespace path to be created and provide a direct link to new DAOS container
 .br
@@ -170,9 +168,9 @@ The \fBRESOURCE\fRs, respective \fBCOMMAND\fRs and \fBOPTION\fRs supported by \f
 	  \fB--force\fR            destroy container regardless of state
 .TP
 .I container \fBOPTION\fRs (query, and all commands except create):
-	  <\fIpool\fR options>   with \fB--cont\fR use: (\fB--pool\fR, \fB--sys-name\fR, \fB--svc\fR)
+	  <\fIpool\fR options>   with \fB--cont\fR use: (\fB--pool\fR, \fB--sys-name\fR)
 .br
-	  <\fIpool\fR options>   with \fB--path\fR use: (\fB--sys-name\fR, \fB--svc\fR)
+	  <\fIpool\fR options>   with \fB--path\fR use: (\fB--sys-name\fR)
 .br
 	  \fB--cont=\fRUUID        (mandatory, unless using \fB--path\fR)
 .br
@@ -200,7 +198,7 @@ The \fBRESOURCE\fRs, respective \fBCOMMAND\fRs and \fBOPTION\fRs supported by \f
 	  \fBdump\fR             dump an object's contents
 .TP
 .I object \fR(\fIobj\fR) \fBOPTION\fRs:
-	  <\fIpool\fR options>   (\fB--pool\fR, \fB--sys-name\fR, \fB--svc\fR)
+	  <\fIpool\fR options>   (\fB--pool\fR, \fB--sys-name\fR)
 .br
 	  <\fIcont\fR options>   (\fB--cont\fR)
 .br

--- a/doc/user/container.md
+++ b/doc/user/container.md
@@ -16,7 +16,7 @@ provided to manage containers.
 
 To create a container:
 ```bash
-$ daos cont create --pool=a171434a-05a5-4671-8fe2-615aa0d05094 --svc=0
+$ daos cont create --pool=a171434a-05a5-4671-8fe2-615aa0d05094
 Successfully created container 008123fc-6b6c-4768-a88a-a2a5ef34a1a2
 ```
 
@@ -28,11 +28,11 @@ to the POSIX file or directory.
 
 ```bash
 $ daos cont create --pool=a171434a-05a5-4671-8fe2-615aa0d05094 \
-      --svc=0 --path=/tmp/mycontainer --type=POSIX --oclass=large \
+      --path=/tmp/mycontainer --type=POSIX --oclass=large \
       --chunk_size=4K
 Successfully created container 419b7562-5bb8-453f-bd52-917c8f5d80d1 type POSIX
 
-$ daos container query --svc=0 --path=/tmp/mycontainer
+$ daos container query --path=/tmp/mycontainer
 Pool UUID:      a171434a-05a5-4671-8fe2-615aa0d05094
 Container UUID: 419b7562-5bb8-453f-bd52-917c8f5d80d1
 Number of snapshots: 0
@@ -236,7 +236,7 @@ permission in the container's ACL.
 To create a container with a custom ACL:
 
 ```bash
-$ daos cont create --pool=<UUID> --svc=<rank> --acl-file=<path>
+$ daos cont create --pool=<UUID> --acl-file=<path>
 ```
 
 The ACL file format is detailed in the [ACL section](https://daos-stack.github.io/overview/security/#acl-file).
@@ -246,7 +246,7 @@ The ACL file format is detailed in the [ACL section](https://daos-stack.github.i
 To view a container's ACL:
 
 ```bash
-$ daos cont get-acl --pool=<UUID> --svc=<rank> --cont=<UUID>
+$ daos cont get-acl --pool=<UUID> --cont=<UUID>
 ```
 
 The output is in the same string format used in the ACL file during creation,
@@ -262,7 +262,7 @@ noted above for container creation.
 To replace a container's ACL with a new ACL:
 
 ```bash
-$ daos cont overwrite-acl --pool=<UUID> --svc=<rank> --cont=<UUID> \
+$ daos cont overwrite-acl --pool=<UUID> --cont=<UUID> \
       --acl-file=<path>
 ```
 
@@ -271,14 +271,14 @@ $ daos cont overwrite-acl --pool=<UUID> --svc=<rank> --cont=<UUID> \
 To add or update multiple entries in an existing container ACL:
 
 ```bash
-$ daos cont update-acl --pool=<UUID> --svc=<rank> --cont=<UUID> \
+$ daos cont update-acl --pool=<UUID> --cont=<UUID> \
       --acl-file=<path>
 ```
 
 To add or update a single entry in an existing container ACL:
 
 ```bash
-$ daos cont update-acl --pool=<UUID> --svc=<rank> --cont=<UUID> --entry <ACE>
+$ daos cont update-acl --pool=<UUID> --cont=<UUID> --entry <ACE>
 ```
 
 If there is no existing entry for the principal in the ACL, the new entry is
@@ -290,7 +290,7 @@ is replaced with the new one.
 To delete an entry for a given principal in an existing container ACL:
 
 ```bash
-$ daos cont delete-acl --pool=<UUID> --svc=<rank> --cont=<UUID> \
+$ daos cont delete-acl --pool=<UUID> --cont=<UUID> \
       --principal=<principal>
 ```
 
@@ -336,7 +336,7 @@ creating the container. However, a specific user and/or group may be specified
 at container creation time.
 
 ```bash
-$ daos cont create --pool=<UUID> --svc=<rank> --user=<owner-user> \
+$ daos cont create --pool=<UUID> --user=<owner-user> \
       --group=<owner-group>
 ```
 
@@ -348,14 +348,14 @@ The user and group names are case sensitive and must be formatted as
 To change the owner user:
 
 ```bash
-$ daos cont set-owner --pool=<UUID> --svc=<rank> --cont=<UUID> \
+$ daos cont set-owner --pool=<UUID> --cont=<UUID> \
       --user=<owner-user>
 ```
 
 To change the owner group:
 
 ```bash
-$ daos cont set-owner --pool=<UUID> --svc=<rank> --cont=<UUID> \
+$ daos cont set-owner --pool=<UUID> --cont=<UUID> \
       --group=<owner-group>
 ```
 

--- a/doc/user/mpi-io.md
+++ b/doc/user/mpi-io.md
@@ -78,7 +78,7 @@ To run an example:
 1. Create a DAOS pool on the DAOS server(s).
    This will return a pool uuid "puuid" and service rank list "svcl".
 2. Create a POSIX type container:
-   `daos cont create --pool=puuid --svc=svcl --type=POSIX`
+   `daos cont create --pool=puuid --type=POSIX`
    This will return a container uuid "cuuid".
 3. At the client side, the following environment variables need to be set:
    `export DAOS_POOL=puuid; export DAOS_SVCL=svcl; export DAOS_CONT=cuuid`.

--- a/doc/user/posix.md
+++ b/doc/user/posix.md
@@ -87,7 +87,6 @@ There are two mandatory command-line options, these are:
 
 | **Command-line Option**  | **Description**     |
 | ------------------------ | ------------------- |
-| --svc=<ranks\>           | service replicas    |
 | --mountpoint=<path\>     | path to mount dfuse |
 
 The mount point specified should be an empty directory on the local node that
@@ -143,7 +142,7 @@ To create a new container and link it into the namespace of an existing one,
 use the following command.
 
 ```bash
-$ daos container create --svc <svc> --type POSIX --pool <pool uuid> --path <path to entry point>
+$ daos container create --type POSIX --pool <pool uuid> --path <path to entry point>
 ```
 
 The pool uuid should already exist, and the path should specify a location
@@ -155,7 +154,7 @@ not supplied, it will be created.
 To destroy a container again, the following command should be used.
 
 ```bash
-$ daos container destroy --svc --path <path to entry point>
+$ daos container destroy --path <path to entry point>
 ```
 
 This will both remove the link between the containers and remove the container
@@ -168,7 +167,7 @@ Information about a container, for example, the presence of an entry point betwe
 containers, or the pool and container uuids of the container linked to can be
 read with the following command.
 ```bash
-$ daos container info --svc --path <path to entry point>
+$ daos container info --path <path to entry point>
 ```
 
 ### Enabling Caching

--- a/doc/user/spark.md
+++ b/doc/user/spark.md
@@ -81,7 +81,7 @@ method, `DaosUns.create()`. The "\[sub path\]" is optional. You can create the U
 path with below command.
 
 ```bash
-$ daos cont create --pool <pool UUID> --svc <svc list> -path <your path> --type=POSIX
+$ daos cont create --pool <pool UUID> -path <your path> --type=POSIX
 ```
 Or
 
@@ -111,7 +111,7 @@ replicas.
 
 ```bash
 $ dmg pool create --scm-size=<scm size> --nvme-size=<nvme size>
-$ daos cont create --pool <pool UUID> --svc <service replicas> --type POSIX
+$ daos cont create --pool <pool UUID> --type POSIX
 ```
 
 After that, configure `daos-site.xml` with the pool and container created.

--- a/src/cart/crt_hg.c
+++ b/src/cart/crt_hg.c
@@ -1021,10 +1021,14 @@ crt_hg_req_send_cb(const struct hg_cb_info *hg_cbinfo)
 				rpc_priv->crp_output_got = 1;
 				rc = rpc_priv->crp_reply_hdr.cch_rc;
 			} else {
-				RPC_ERROR(rpc_priv,
-					  "HG_Get_output failed, hg_ret: %d\n",
-					  hg_ret);
-				rc = -DER_HG;
+				if (hg_ret != HG_NOMEM) {
+					RPC_ERROR(rpc_priv,
+						  "HG_Get_output failed, "
+						  "hg_ret: %d\n", hg_ret);
+					rc = -DER_HG;
+				} else {
+					rc = -DER_NOMEM;
+				}
 			}
 		}
 	}

--- a/src/client/api/mgmt.c
+++ b/src/client/api/mgmt.c
@@ -75,7 +75,7 @@ daos_mgmt_set_params(const char *grp, d_rank_t rank, unsigned int key_id,
 
 int
 daos_pool_reint_tgt(const uuid_t uuid, const char *grp,
-		    const d_rank_list_t *svc, struct d_tgt_list *tgts,
+		    struct d_tgt_list *tgts,
 		    daos_event_t *ev)
 {
 	daos_pool_update_t	*args;
@@ -91,7 +91,6 @@ daos_pool_reint_tgt(const uuid_t uuid, const char *grp,
 
 	args = dc_task_get_args(task);
 	args->grp	= grp;
-	args->svc	= (d_rank_list_t *)svc;
 	args->tgts	= tgts;
 	uuid_copy((unsigned char *)args->uuid, uuid);
 
@@ -100,7 +99,7 @@ daos_pool_reint_tgt(const uuid_t uuid, const char *grp,
 
 int
 daos_pool_drain_tgt(const uuid_t uuid, const char *grp,
-		  const d_rank_list_t *svc, struct d_tgt_list *tgts,
+		  struct d_tgt_list *tgts,
 		  daos_event_t *ev)
 {
 	daos_pool_update_t	*args;
@@ -116,7 +115,6 @@ daos_pool_drain_tgt(const uuid_t uuid, const char *grp,
 
 	args = dc_task_get_args(task);
 	args->grp	= grp;
-	args->svc	= (d_rank_list_t *)svc;
 	args->tgts	= tgts;
 	uuid_copy((unsigned char *)args->uuid, uuid);
 
@@ -125,7 +123,7 @@ daos_pool_drain_tgt(const uuid_t uuid, const char *grp,
 
 int
 daos_pool_tgt_exclude_out(const uuid_t uuid, const char *grp,
-			  const d_rank_list_t *svc, struct d_tgt_list *tgts,
+			  struct d_tgt_list *tgts,
 			  daos_event_t *ev)
 {
 	daos_pool_update_t	*args;
@@ -141,7 +139,6 @@ daos_pool_tgt_exclude_out(const uuid_t uuid, const char *grp,
 
 	args = dc_task_get_args(task);
 	args->grp	= grp;
-	args->svc	= (d_rank_list_t *)svc;
 	args->tgts	= tgts;
 	uuid_copy((unsigned char *)args->uuid, uuid);
 
@@ -150,7 +147,7 @@ daos_pool_tgt_exclude_out(const uuid_t uuid, const char *grp,
 
 int
 daos_pool_tgt_exclude(const uuid_t uuid, const char *grp,
-		      const d_rank_list_t *svc, struct d_tgt_list *tgts,
+		      struct d_tgt_list *tgts,
 		      daos_event_t *ev)
 {
 	daos_pool_update_t	*args;
@@ -167,7 +164,6 @@ daos_pool_tgt_exclude(const uuid_t uuid, const char *grp,
 
 	args = dc_task_get_args(task);
 	args->grp	= grp;
-	args->svc	= (d_rank_list_t *)svc;
 	args->tgts	= tgts;
 	uuid_copy((unsigned char *)args->uuid, uuid);
 
@@ -183,7 +179,7 @@ daos_pool_extend(const uuid_t uuid, const char *grp, d_rank_list_t *tgts,
 
 int
 daos_pool_add_replicas(const uuid_t uuid, const char *group,
-		       d_rank_list_t *svc, d_rank_list_t *targets,
+		       d_rank_list_t *targets,
 		       d_rank_list_t *failed, daos_event_t *ev)
 {
 	daos_pool_replicas_t	*args;
@@ -201,7 +197,6 @@ daos_pool_add_replicas(const uuid_t uuid, const char *group,
 	args = dc_task_get_args(task);
 	uuid_copy((unsigned char *)args->uuid, uuid);
 	args->group	= group;
-	args->svc	= svc;
 	args->targets	= targets;
 	args->failed	= failed;
 
@@ -210,7 +205,7 @@ daos_pool_add_replicas(const uuid_t uuid, const char *group,
 
 int
 daos_pool_remove_replicas(const uuid_t uuid, const char *group,
-			  d_rank_list_t *svc, d_rank_list_t *targets,
+			  d_rank_list_t *targets,
 			  d_rank_list_t *failed, daos_event_t *ev)
 {
 	daos_pool_replicas_t	*args;
@@ -228,7 +223,6 @@ daos_pool_remove_replicas(const uuid_t uuid, const char *group,
 	args = dc_task_get_args(task);
 	uuid_copy((unsigned char *)args->uuid, uuid);
 	args->group	= group;
-	args->svc	= svc;
 	args->targets	= targets;
 	args->failed	= failed;
 

--- a/src/client/api/pool.c
+++ b/src/client/api/pool.c
@@ -30,7 +30,7 @@
 
 int
 daos_pool_connect(const uuid_t uuid, const char *grp,
-		  const d_rank_list_t *svc, unsigned int flags,
+		  unsigned int flags,
 		  daos_handle_t *poh, daos_pool_info_t *info, daos_event_t *ev)
 {
 	daos_pool_connect_t	*args;
@@ -47,7 +47,6 @@ daos_pool_connect(const uuid_t uuid, const char *grp,
 
 	args = dc_task_get_args(task);
 	args->grp		= grp;
-	args->svc		= svc;
 	args->flags		= flags;
 	args->poh		= poh;
 	args->info		= info;
@@ -277,8 +276,7 @@ daos_pool_stop_svc(daos_handle_t poh, daos_event_t *ev)
 }
 
 int
-daos_pool_evict(const uuid_t uuid, const char *grp, const d_rank_list_t *svc,
-		daos_event_t *ev)
+daos_pool_evict(const uuid_t uuid, const char *grp, daos_event_t *ev)
 {
 	daos_pool_evict_t       *args;
 	tse_task_t              *task;
@@ -294,7 +292,6 @@ daos_pool_evict(const uuid_t uuid, const char *grp, const d_rank_list_t *svc,
 
 	args = dc_task_get_args(task);
 	args->grp       = grp;
-	args->svc       = (d_rank_list_t *)svc;
 	uuid_copy((unsigned char *)args->uuid, uuid);
 
 	return dc_task_schedule(task, true);

--- a/src/client/dfs/dfuse_hl.c
+++ b/src/client/dfs/dfuse_hl.c
@@ -1137,7 +1137,7 @@ int main(int argc, char *argv[])
 	}
 
 	/** Connect to DAOS pool */
-	rc = daos_pool_connect(pool_uuid, dfuse_fs.group, NULL, DAOS_PC_RW,
+	rc = daos_pool_connect(pool_uuid, dfuse_fs.group, DAOS_PC_RW,
 			       &poh, &pool_info, NULL);
 	if (rc < 0) {
 		fprintf(stderr, "Failed to connect to pool (%d)\n", rc);

--- a/src/client/dfuse/dfuse.h
+++ b/src/client/dfuse/dfuse.h
@@ -45,7 +45,6 @@ struct dfuse_info {
 	char				*di_cont;
 	char				*di_group;
 	char				*di_mountpoint;
-	d_rank_list_t			*di_svcl;
 	bool				di_threaded;
 	bool				di_foreground;
 	bool				di_direct_io;

--- a/src/client/dfuse/dfuse_main.c
+++ b/src/client/dfuse/dfuse_main.c
@@ -241,7 +241,6 @@ show_help(char *name)
 	printf("usage: %s -m=PATHSTR -s=RANKS\n"
 		"\n"
 		"	-m --mountpoint=PATHSTR	Mount point to use\n"
-		"	-s --svc=RANKS		pool service replicas like 1,2,3\n"
 		"	   --pool=UUID		pool UUID\n"
 		"	   --container=UUID	container UUID\n"
 		"	   --sys-name=STR	DAOS system name context for servers\n"
@@ -255,7 +254,6 @@ int
 main(int argc, char **argv)
 {
 	struct dfuse_info	*dfuse_info = NULL;
-	char			*svcl = NULL;
 	struct dfuse_pool	*dfp = NULL;
 	struct dfuse_pool	*dfpn;
 	struct dfuse_dfs	*dfs = NULL;
@@ -274,7 +272,6 @@ main(int argc, char **argv)
 	struct option long_options[] = {
 		{"pool",		required_argument, 0, 'p'},
 		{"container",		required_argument, 0, 'c'},
-		{"svc",			required_argument, 0, 's'},
 		{"sys-name",		required_argument, 0, 'G'},
 		{"mountpoint",		required_argument, 0, 'm'},
 		{"singlethread",	no_argument,	   0, 'S'},
@@ -314,9 +311,6 @@ main(int argc, char **argv)
 			break;
 		case 'c':
 			dfuse_info->di_cont = optarg;
-			break;
-		case 's':
-			svcl = optarg;
 			break;
 		case 'G':
 			dfuse_info->di_group = optarg;
@@ -364,10 +358,6 @@ main(int argc, char **argv)
 		D_GOTO(out_debug, ret = -DER_NO_HDL);
 	}
 
-	/* svcl is optional. If unspecified libdaos will query
-	 * management service to get list of pool service replicas.
-	 */
-
 	if (dfuse_info->di_pool) {
 		if (uuid_parse(dfuse_info->di_pool, tmp_uuid) < 0) {
 			printf("Invalid pool uuid\n");
@@ -396,17 +386,9 @@ main(int argc, char **argv)
 
 	DFUSE_TRA_ROOT(dfuse_info, "dfuse_info");
 
-	if (svcl) {
-		dfuse_info->di_svcl = daos_rank_list_parse(svcl, ":");
-		if (dfuse_info->di_svcl == NULL) {
-			printf("Invalid pool service rank list\n");
-			D_GOTO(out_dfuse, ret = -DER_INVAL);
-		}
-	}
-
 	D_ALLOC_PTR(dfp);
 	if (!dfp)
-		D_GOTO(out_svcl, ret = -DER_NOMEM);
+		D_GOTO(out_dfuse, ret = -DER_NOMEM);
 
 	DFUSE_TRA_UP(dfp, dfuse_info, "dfp");
 	D_INIT_LIST_HEAD(&dfp->dfp_dfs_list);
@@ -462,7 +444,7 @@ main(int argc, char **argv)
 	if (uuid_is_null(dfp->dfp_pool) == 0) {
 		/** Connect to DAOS pool */
 		rc = daos_pool_connect(dfp->dfp_pool, dfuse_info->di_group,
-				       dfuse_info->di_svcl, DAOS_PC_RW,
+				       DAOS_PC_RW,
 				       &dfp->dfp_poh, &dfp->dfp_pool_info,
 				       NULL);
 		if (rc != -DER_SUCCESS) {
@@ -544,8 +526,6 @@ out_dfs:
 		DFUSE_TRA_DOWN(dfp);
 		D_FREE(dfp);
 	}
-out_svcl:
-	d_rank_list_free(dfuse_info->di_svcl);
 out_dfuse:
 	DFUSE_TRA_DOWN(dfuse_info);
 	D_MUTEX_DESTROY(&dfuse_info->di_lock);

--- a/src/client/dfuse/dfuse_main.c
+++ b/src/client/dfuse/dfuse_main.c
@@ -364,14 +364,9 @@ main(int argc, char **argv)
 		D_GOTO(out_debug, ret = -DER_NO_HDL);
 	}
 
-	/* Is this required, or can we assume some kind of default for
-	 * this.
+	/* svcl is optional. If unspecified libdaos will query
+	 * management service to get list of pool service replicas.
 	 */
-	if (!svcl) {
-		printf("Svcl is required\n");
-		show_help(argv[0]);
-		D_GOTO(out_debug, ret = -DER_NO_HDL);
-	}
 
 	if (dfuse_info->di_pool) {
 		if (uuid_parse(dfuse_info->di_pool, tmp_uuid) < 0) {
@@ -401,10 +396,12 @@ main(int argc, char **argv)
 
 	DFUSE_TRA_ROOT(dfuse_info, "dfuse_info");
 
-	dfuse_info->di_svcl = daos_rank_list_parse(svcl, ":");
-	if (dfuse_info->di_svcl == NULL) {
-		printf("Invalid pool service rank list\n");
-		D_GOTO(out_dfuse, ret = -DER_INVAL);
+	if (svcl) {
+		dfuse_info->di_svcl = daos_rank_list_parse(svcl, ":");
+		if (dfuse_info->di_svcl == NULL) {
+			printf("Invalid pool service rank list\n");
+			D_GOTO(out_dfuse, ret = -DER_INVAL);
+		}
 	}
 
 	D_ALLOC_PTR(dfp);

--- a/src/client/dfuse/dfuse_pool.c
+++ b/src/client/dfuse/dfuse_pool.c
@@ -119,7 +119,7 @@ dfuse_pool_lookup(fuse_req_t req, struct dfuse_inode_entry *parent,
 	DFUSE_TRA_UP(dfs, dfp, "dfs");
 
 	rc = daos_pool_connect(dfp->dfp_pool, dfuse_info->di_group,
-			       dfuse_info->di_svcl, DAOS_PC_RW,
+			       DAOS_PC_RW,
 			       &dfp->dfp_poh, &dfp->dfp_pool_info,
 			       NULL);
 	if (rc) {

--- a/src/client/dfuse/il/int_posix.c
+++ b/src/client/dfuse/il/int_posix.c
@@ -482,7 +482,7 @@ connect_daos_cont(int fd, struct dfuse_il_reply *il_reply)
 {
 	int			rc;
 
-	rc = daos_pool_connect(il_reply->fir_pool, NULL, NULL, DAOS_PC_RW,
+	rc = daos_pool_connect(il_reply->fir_pool, NULL, DAOS_PC_RW,
 			       &ioil_ioc.ioc_poh, NULL, NULL);
 	if (rc)
 		return rc;

--- a/src/client/dfuse/il/int_posix.c
+++ b/src/client/dfuse/il/int_posix.c
@@ -480,17 +480,12 @@ fetch_daos_handles(int fd, struct fd_entry *entry)
 static int
 connect_daos_cont(int fd, struct dfuse_il_reply *il_reply)
 {
-	d_rank_list_t		*svcl;
 	int			rc;
 
-	svcl = daos_rank_list_parse("0", ":");
-
-	rc = daos_pool_connect(il_reply->fir_pool, NULL, svcl, DAOS_PC_RW,
+	rc = daos_pool_connect(il_reply->fir_pool, NULL, NULL, DAOS_PC_RW,
 			       &ioil_ioc.ioc_poh, NULL, NULL);
-	if (rc) {
-		D_FREE(svcl);
+	if (rc)
 		return rc;
-	}
 
 	rc = daos_cont_open(ioil_ioc.ioc_poh, il_reply->fir_cont, DAOS_COO_RW,
 			    &ioil_ioc.ioc_coh, NULL, NULL);

--- a/src/client/dfuse/ops/lookup.c
+++ b/src/client/dfuse/ops/lookup.c
@@ -182,7 +182,7 @@ check_for_uns_ep(struct dfuse_projection_info *fs_handle,
 		/* Connect to DAOS pool */
 		rc = daos_pool_connect(dfp->dfp_pool,
 				       fs_handle->dpi_info->di_group,
-				       fs_handle->dpi_info->di_svcl, DAOS_PC_RW,
+				       DAOS_PC_RW,
 				       &dfp->dfp_poh, &dfp->dfp_pool_info,
 				       NULL);
 		if (rc != -DER_SUCCESS) {

--- a/src/client/java/README.md
+++ b/src/client/java/README.md
@@ -62,7 +62,7 @@ with DAOS command or Java DAOS UNS method, DaosUns.create(). "\[sub path\]" is o
 with below command.
 
 ```bash
-$ daos cont create --pool <pool UUID> --svc <svc list> -path <your path> --type=POSIX
+$ daos cont create --pool <pool UUID> --path <your path> --type=POSIX
 ```
 Or
 

--- a/src/client/java/daos-java/src/main/native/io_daos_dfs_DaosFsClient.c
+++ b/src/client/java/daos-java/src/main/native/io_daos_dfs_DaosFsClient.c
@@ -211,48 +211,33 @@ Java_io_daos_dfs_DaosFsClient_daosOpenPool(JNIEnv *env,
 	const char *pool_str = (*env)->GetStringUTFChars(env, poolId, 0);
 	const char *server_group = (*env)->GetStringUTFChars(env, serverGroup,
 								0);
-	const char *svc_ranks = (*env)->GetStringUTFChars(env, ranks, 0);
 	uuid_t pool_uuid;
 	uuid_parse(pool_str, pool_uuid);
-	d_rank_list_t *svcl = daos_rank_list_parse(svc_ranks, ":");
 	jlong ret;
+	daos_handle_t poh;
+	int rc;
 
-	if (svcl == NULL) {
-		char *tmp = "Invalid pool service rank list (%s) when open " \
-				"pool (%s)";
-		char *msg = (char *)malloc(strlen(tmp) + strlen(svc_ranks) +
+	rc = daos_pool_connect(pool_uuid, server_group,
+			       flags,
+			       &poh /* returned pool handle */,
+			       NULL /* returned pool info */,
+			       NULL /* event */);
+
+	if (rc) {
+		char *tmp = "Failed to connect to pool (%s)";
+		char *msg = (char *)malloc(strlen(tmp) +
 				strlen(pool_str));
 
-		sprintf(msg, tmp, ranks, pool_str);
-		throw_exception(env, msg, CUSTOM_ERR2);
+		sprintf(msg, tmp, pool_str);
+		throw_exception_base(env, msg, rc, 1, 0);
 		ret = -1;
 	} else {
-		daos_handle_t poh;
-		int rc;
-		rc = daos_pool_connect(pool_uuid, server_group, svcl,
-			flags,
-			&poh /* returned pool handle */,
-			NULL /* returned pool info */,
-			NULL /* event */);
-
-		if (rc) {
-			char *tmp = "Failed to connect to pool (%s)";
-			char *msg = (char *)malloc(strlen(tmp) +
-					strlen(pool_str));
-
-			sprintf(msg, tmp, pool_str);
-			throw_exception_base(env, msg, rc, 1, 0);
-			ret = -1;
-		} else {
-			memcpy(&ret, &poh, sizeof(poh));
-		}
+		memcpy(&ret, &poh, sizeof(poh));
 	}
+
 	(*env)->ReleaseStringUTFChars(env, poolId, pool_str);
 	if (serverGroup != NULL) {
 		(*env)->ReleaseStringUTFChars(env, serverGroup, server_group);
-	}
-	if (ranks != NULL) {
-		(*env)->ReleaseStringUTFChars(env, ranks, svc_ranks);
 	}
 	return ret;
 }

--- a/src/client/pydaos/pydaos_core.py
+++ b/src/client/pydaos/pydaos_core.py
@@ -121,13 +121,12 @@ class Cont(object):
         if path != None:
             self.puuid = None
             self.cuuid = None
-            (ret, poh, coh) = pydaos_shim.cont_open_by_path(DAOS_MAGIC, path,
-                                                            svc, 0)
+            (ret, poh, coh) = pydaos_shim.cont_open_by_path(DAOS_MAGIC, path, 0)
         else:
             self.puuid = uuid.UUID(puuid)
             self.cuuid = uuid.UUID(cuuid)
             (ret, poh, coh) = pydaos_shim.cont_open(DAOS_MAGIC, str(puuid),
-                                                    str(cuuid), svc, 0)
+                                                    str(cuuid), 0)
         if ret != pydaos_shim.DER_SUCCESS:
             raise PyDError("failed to access container", ret)
         self.poh = poh

--- a/src/client/pydaos/pydaos_shim.c
+++ b/src/client/pydaos/pydaos_shim.c
@@ -145,7 +145,7 @@ cont_open(int ret, uuid_t puuid, uuid_t cuuid, int flags)
 	}
 
 	/** Connect to pool */
-	rc = daos_pool_connect(puuid, "daos_server", NULL, DAOS_PC_RW, &poh,
+	rc = daos_pool_connect(puuid, "daos_server", DAOS_PC_RW, &poh,
 			       NULL, NULL);
 	if (rc)
 		goto out;

--- a/src/client/pydaos/raw/daos_api.py
+++ b/src/client/pydaos/raw/daos_api.py
@@ -92,10 +92,14 @@ class DaosPool(object):
         c_info.pi_bits = ctypes.c_ulong(-1)
         func = self.context.get_function('connect-pool')
 
+        # phasing out the pool service rank list argument
+        # libdaos will query MS for up-to-date replica list
+        no_svcl = daos_cref.RankList(None, 0)
+
         # the callback function is optional, if not supplied then run the
         # create synchronously, if its there then run it in a thread
         if cb_func is None:
-            ret = func(self.uuid, self.group, ctypes.byref(self.svc), c_flags,
+            ret = func(self.uuid, self.group, ctypes.byref(no_svcl), c_flags,
                        ctypes.byref(self.handle), ctypes.byref(c_info), None)
 
             if ret != 0:
@@ -106,7 +110,7 @@ class DaosPool(object):
                 self.connected = 1
         else:
             event = daos_cref.DaosEvent()
-            params = [self.uuid, self.group, ctypes.byref(self.svc), c_flags,
+            params = [self.uuid, self.group, ctypes.byref(no_svcl), c_flags,
                       ctypes.byref(self.handle), ctypes.byref(c_info), event]
             thread = threading.Thread(target=daos_cref.AsyncWorker1,
                                       args=(func,
@@ -191,19 +195,20 @@ class DaosPool(object):
         c_tgts = ctypes.pointer(
             daos_cref.DTgtList(tl_ranks, ctypes.pointer(tl_tgts), tl_nr))
 
-        if self.svc is None:
-            c_svc = None
-        else:
-            c_svc = ctypes.pointer(self.svc)
         func = self.context.get_function('exclude-target')
+
+        # phasing out the pool service rank list argument
+        no_svcl = daos_cref.RankList(None, 0)
+
         if cb_func is None:
-            ret = func(self.uuid, self.group, c_svc, c_tgts, None)
+            ret = func(self.uuid, self.group, ctypes.byref(no_svcl), c_tgts,
+                       None)
             if ret != 0:
                 raise DaosApiError("Pool exclude returned non-zero. RC: {0}"
                                    .format(ret))
         else:
             event = daos_cref.DaosEvent()
-            params = [self.uuid, self.group, c_svc,
+            params = [self.uuid, self.group, ctypes.byref(no_svcl),
                       ctypes.byref(c_tgts), event]
             thread = threading.Thread(target=daos_cref.AsyncWorker1,
                                       args=(func,
@@ -221,14 +226,17 @@ class DaosPool(object):
         """Evict all connections to a pool."""
         func = self.context.get_function('evict-client')
 
+        # phasing out the pool service rank list argument
+        no_svcl = daos_cref.RankList(None, 0)
+
         if cb_func is None:
-            ret = func(self.uuid, self.group, ctypes.byref(self.svc), None)
+            ret = func(self.uuid, self.group, ctypes.byref(no_svcl), None)
             if ret != 0:
                 raise DaosApiError("Pool evict returned non-zero. "
                                    "RC: {0}".format(ret))
         else:
             event = daos_cref.DaosEvent()
-            params = [self.uuid, self.group, ctypes.byref(self.svc), event]
+            params = [self.uuid, self.group, ctypes.byref(no_svcl), event]
             thread = threading.Thread(target=daos_cref.AsyncWorker1,
                                       args=(func,
                                             params,
@@ -254,15 +262,18 @@ class DaosPool(object):
             daos_cref.DTgtList(tl_ranks, ctypes.pointer(tl_tgts), tl_nr))
         func = self.context.get_function("reint-target")
 
+        # phasing out the pool service rank list argument
+        no_svcl = daos_cref.RankList(None, 0)
+
         if cb_func is None:
-            ret = func(self.uuid, self.group, ctypes.byref(self.svc),
+            ret = func(self.uuid, self.group, ctypes.byref(no_svcl),
                        ctypes.byref(c_tgts), None)
             if ret != 0:
                 raise DaosApiError("Pool tgt_reint returned non-zero. RC: {0}"
                                    .format(ret))
         else:
             event = daos_cref.DaosEvent()
-            params = [self.uuid, self.group, ctypes.byref(self.svc),
+            params = [self.uuid, self.group, ctypes.byref(no_svcl),
                       ctypes.byref(c_tgts), event]
             thread = threading.Thread(target=daos_cref.AsyncWorker1,
                                       args=(func,
@@ -288,16 +299,19 @@ class DaosPool(object):
         c_tgts = ctypes.pointer(
             daos_cref.DTgtList(tl_ranks, ctypes.pointer(tl_tgts), tl_nr))
 
+        # phasing out the pool service rank list argument
+        no_svcl = daos_cref.RankList(None, 0)
+
         func = self.context.get_function('kill-target')
         if cb_func is None:
-            ret = func(self.uuid, self.group, ctypes.byref(self.svc),
+            ret = func(self.uuid, self.group, ctypes.byref(no_svcl),
                        ctypes.byref(c_tgts), None)
             if ret != 0:
                 raise DaosApiError(
                     "Pool exclude_out returned non-zero. RC: {0}".format(ret))
         else:
             event = daos_cref.DaosEvent()
-            params = [self.uuid, self.group, ctypes.byref(self.svc),
+            params = [self.uuid, self.group, ctypes.byref(no_svcl),
                       ctypes.byref(c_tgts), event]
             thread = threading.Thread(target=daos_cref.AsyncWorker1,
                                       args=(func,

--- a/src/client/pydaos/raw/daos_api.py
+++ b/src/client/pydaos/raw/daos_api.py
@@ -92,14 +92,10 @@ class DaosPool(object):
         c_info.pi_bits = ctypes.c_ulong(-1)
         func = self.context.get_function('connect-pool')
 
-        # phasing out the pool service rank list argument
-        # libdaos will query MS for up-to-date replica list
-        no_svcl = daos_cref.RankList(None, 0)
-
         # the callback function is optional, if not supplied then run the
         # create synchronously, if its there then run it in a thread
         if cb_func is None:
-            ret = func(self.uuid, self.group, ctypes.byref(no_svcl), c_flags,
+            ret = func(self.uuid, self.group, c_flags,
                        ctypes.byref(self.handle), ctypes.byref(c_info), None)
 
             if ret != 0:
@@ -110,7 +106,7 @@ class DaosPool(object):
                 self.connected = 1
         else:
             event = daos_cref.DaosEvent()
-            params = [self.uuid, self.group, ctypes.byref(no_svcl), c_flags,
+            params = [self.uuid, self.group, c_flags,
                       ctypes.byref(self.handle), ctypes.byref(c_info), event]
             thread = threading.Thread(target=daos_cref.AsyncWorker1,
                                       args=(func,
@@ -197,19 +193,14 @@ class DaosPool(object):
 
         func = self.context.get_function('exclude-target')
 
-        # phasing out the pool service rank list argument
-        no_svcl = daos_cref.RankList(None, 0)
-
         if cb_func is None:
-            ret = func(self.uuid, self.group, ctypes.byref(no_svcl), c_tgts,
-                       None)
+            ret = func(self.uuid, self.group, c_tgts, None)
             if ret != 0:
                 raise DaosApiError("Pool exclude returned non-zero. RC: {0}"
                                    .format(ret))
         else:
             event = daos_cref.DaosEvent()
-            params = [self.uuid, self.group, ctypes.byref(no_svcl),
-                      ctypes.byref(c_tgts), event]
+            params = [self.uuid, self.group, ctypes.byref(c_tgts), event]
             thread = threading.Thread(target=daos_cref.AsyncWorker1,
                                       args=(func,
                                             params,
@@ -226,17 +217,14 @@ class DaosPool(object):
         """Evict all connections to a pool."""
         func = self.context.get_function('evict-client')
 
-        # phasing out the pool service rank list argument
-        no_svcl = daos_cref.RankList(None, 0)
-
         if cb_func is None:
-            ret = func(self.uuid, self.group, ctypes.byref(no_svcl), None)
+            ret = func(self.uuid, self.group, None)
             if ret != 0:
                 raise DaosApiError("Pool evict returned non-zero. "
                                    "RC: {0}".format(ret))
         else:
             event = daos_cref.DaosEvent()
-            params = [self.uuid, self.group, ctypes.byref(no_svcl), event]
+            params = [self.uuid, self.group, event]
             thread = threading.Thread(target=daos_cref.AsyncWorker1,
                                       args=(func,
                                             params,
@@ -262,19 +250,14 @@ class DaosPool(object):
             daos_cref.DTgtList(tl_ranks, ctypes.pointer(tl_tgts), tl_nr))
         func = self.context.get_function("reint-target")
 
-        # phasing out the pool service rank list argument
-        no_svcl = daos_cref.RankList(None, 0)
-
         if cb_func is None:
-            ret = func(self.uuid, self.group, ctypes.byref(no_svcl),
-                       ctypes.byref(c_tgts), None)
+            ret = func(self.uuid, self.group, ctypes.byref(c_tgts), None)
             if ret != 0:
                 raise DaosApiError("Pool tgt_reint returned non-zero. RC: {0}"
                                    .format(ret))
         else:
             event = daos_cref.DaosEvent()
-            params = [self.uuid, self.group, ctypes.byref(no_svcl),
-                      ctypes.byref(c_tgts), event]
+            params = [self.uuid, self.group, ctypes.byref(c_tgts), event]
             thread = threading.Thread(target=daos_cref.AsyncWorker1,
                                       args=(func,
                                             params,
@@ -299,20 +282,15 @@ class DaosPool(object):
         c_tgts = ctypes.pointer(
             daos_cref.DTgtList(tl_ranks, ctypes.pointer(tl_tgts), tl_nr))
 
-        # phasing out the pool service rank list argument
-        no_svcl = daos_cref.RankList(None, 0)
-
         func = self.context.get_function('kill-target')
         if cb_func is None:
-            ret = func(self.uuid, self.group, ctypes.byref(no_svcl),
-                       ctypes.byref(c_tgts), None)
+            ret = func(self.uuid, self.group, ctypes.byref(c_tgts), None)
             if ret != 0:
                 raise DaosApiError(
                     "Pool exclude_out returned non-zero. RC: {0}".format(ret))
         else:
             event = daos_cref.DaosEvent()
-            params = [self.uuid, self.group, ctypes.byref(no_svcl),
-                      ctypes.byref(c_tgts), event]
+            params = [self.uuid, self.group, ctypes.byref(c_tgts), event]
             thread = threading.Thread(target=daos_cref.AsyncWorker1,
                                       args=(func,
                                             params,

--- a/src/common/dts.c
+++ b/src/common/dts.c
@@ -237,7 +237,7 @@ pool_init(struct dts_context *tsc)
 		if (rc)
 			goto bcast;
 
-		rc = daos_pool_connect(tsc->tsc_pool_uuid, NULL, NULL /* svc */,
+		rc = daos_pool_connect(tsc->tsc_pool_uuid, NULL,
 				       DAOS_PC_EX, &poh, NULL, NULL);
 		if (rc)
 			goto bcast;

--- a/src/common/dts.c
+++ b/src/common/dts.c
@@ -237,7 +237,7 @@ pool_init(struct dts_context *tsc)
 		if (rc)
 			goto bcast;
 
-		rc = daos_pool_connect(tsc->tsc_pool_uuid, NULL, svc,
+		rc = daos_pool_connect(tsc->tsc_pool_uuid, NULL, NULL /* svc */,
 				       DAOS_PC_EX, &poh, NULL, NULL);
 		if (rc)
 			goto bcast;

--- a/src/control/server/mgmt_drpc.go
+++ b/src/control/server/mgmt_drpc.go
@@ -87,12 +87,17 @@ func (mod *srvModule) handleGetPoolServiceRanks(reqb []byte) ([]byte, error) {
 
 	mod.log.Debugf("handling GetPoolSvcReq: %+v", req)
 
+	resp := new(srvpb.GetPoolSvcResp)
+
 	ps, err := mod.sysdb.FindPoolServiceByUUID(uuid)
 	if err != nil {
-		return nil, err
+		resp.Status = int32(drpc.DaosNonexistant)
+		mod.log.Debugf("GetPoolSvcResp: %+v", resp)
+		return proto.Marshal(resp)
+		// return nil, err
 	}
 
-	resp := new(srvpb.GetPoolSvcResp)
+	// resp := new(srvpb.GetPoolSvcResp)
 	resp.Svcreps = system.RanksToUint32(ps.Replicas)
 
 	mod.log.Debugf("GetPoolSvcResp: %+v", resp)

--- a/src/include/daos_mgmt.h
+++ b/src/include/daos_mgmt.h
@@ -65,7 +65,6 @@ daos_mgmt_svc_rip(const char *grp, d_rank_t rank, bool force,
  *
  * \param uuid	[IN]	UUID of the pool
  * \param grp	[IN]	process set name of the DAOS servers managing the pool
- * \param svc	[IN]	list of pool service ranks
  * \param tgts	[IN]	Target to be excluded from the pool.
  *			Now can-only exclude one target per API calling. If
  *			tl_tgts = -1, it means it will exclude all targets
@@ -82,7 +81,7 @@ daos_mgmt_svc_rip(const char *grp, d_rank_t rank, bool force,
  */
 int
 daos_pool_tgt_exclude(const uuid_t uuid, const char *grp,
-		      const d_rank_list_t *svc, struct d_tgt_list *tgts,
+		      struct d_tgt_list *tgts,
 		      daos_event_t *ev);
 
 /**
@@ -118,7 +117,6 @@ daos_pool_extend(const uuid_t uuid, const char *grp, d_rank_list_t *tgts,
  *
  * \param uuid	[IN]	UUID of the pool
  * \param grp	[IN]	process set name of the DAOS servers managing the pool
- * \param svc	[IN]	list of pool service ranks
  * \param tgts	[IN]	Target array to be reintegrated from the pool.  If
  *			tl_tgts = -1, it means it will reintegrate all targets
  *			on the rank.
@@ -134,7 +132,7 @@ daos_pool_extend(const uuid_t uuid, const char *grp, d_rank_list_t *tgts,
  */
 int
 daos_pool_reint_tgt(const uuid_t uuid, const char *grp,
-		    const d_rank_list_t *svc, struct d_tgt_list *tgts,
+		    struct d_tgt_list *tgts,
 		    daos_event_t *ev);
 
 /**
@@ -142,7 +140,6 @@ daos_pool_reint_tgt(const uuid_t uuid, const char *grp,
  *
  * \param uuid	[IN]	UUID of the pool
  * \param grp	[IN]	process set name of the DAOS servers managing the pool
- * \param svc	[IN]	list of pool service ranks
  * \param tgts	[IN]	Target array to be added from the pool.  If
  *			tl_tgts = -1, it means it will add all targets
  *			on the rank.
@@ -158,7 +155,7 @@ daos_pool_reint_tgt(const uuid_t uuid, const char *grp,
  */
 int
 daos_pool_drain_tgt(const uuid_t uuid, const char *grp,
-		    const d_rank_list_t *svc, struct d_tgt_list *tgts,
+		    struct d_tgt_list *tgts,
 		    daos_event_t *ev);
 
 
@@ -170,7 +167,6 @@ daos_pool_drain_tgt(const uuid_t uuid, const char *grp,
  *
  * \param uuid	[IN]	UUID of the pool
  * \param grp	[IN]	process set name of the DAOS servers managing the pool
- * \param svc	[IN]	list of pool service ranks
  * \param tgts	[IN]	Target array to be excluded from the pool.
  *			Now can-only exclude out one target per API calling. If
  *			tl_tgts = -1, it means it will exclude out all targets
@@ -187,7 +183,7 @@ daos_pool_drain_tgt(const uuid_t uuid, const char *grp,
  */
 int
 daos_pool_tgt_exclude_out(const uuid_t uuid, const char *grp,
-			  const d_rank_list_t *svc, struct d_tgt_list *tgts,
+			  struct d_tgt_list *tgts,
 			  daos_event_t *ev);
 
 /**
@@ -213,7 +209,6 @@ daos_pool_stop_svc(daos_handle_t poh, daos_event_t *ev);
  *
  * \param uuid	[IN]	UUID of the service to add replicas to.
  * \param group	[IN]	Name of DAOS server process set managing the service.
- * \param svc	[IN]	List of service ranks.
  * \param targets
  *		[IN]	Ranks of the replicas to be added.
  * \param failed
@@ -231,7 +226,7 @@ daos_pool_stop_svc(daos_handle_t poh, daos_event_t *ev);
  */
 int
 daos_pool_add_replicas(const uuid_t uuid, const char *group,
-		       d_rank_list_t *svc, d_rank_list_t *targets,
+		       d_rank_list_t *targets,
 		       d_rank_list_t *failed, daos_event_t *ev);
 
 /**
@@ -239,7 +234,6 @@ daos_pool_add_replicas(const uuid_t uuid, const char *group,
  *
  * \param uuid	[IN]	UUID of the service to remove replicas from.
  * \param group	[IN]	Name of DAOS server process set managing the service.
- * \param svc	[IN]	List of service ranks.
  * \param targets
  *		[IN]	Ranks of the replicas to be removed.
  * \param failed
@@ -257,7 +251,7 @@ daos_pool_add_replicas(const uuid_t uuid, const char *group,
  */
 int
 daos_pool_remove_replicas(const uuid_t uuid, const char *group,
-			  d_rank_list_t *svc, d_rank_list_t *targets,
+			  d_rank_list_t *targets,
 			  d_rank_list_t *failed, daos_event_t *ev);
 
 /**

--- a/src/include/daos_pool.h
+++ b/src/include/daos_pool.h
@@ -186,7 +186,7 @@ struct daos_pool_cont_info {
  *
  * \param[in]	uuid	UUID to identify a pool.
  * \param[in]	grp	Process set name of the DAOS servers managing the pool
- * \param[in]	svc	Pool service replica ranks, as reported by
+ * \param[in]	svc	Optional, pool service replica ranks, as reported by
  *			daos_pool_create().
  * \param[in]	flags	Connect mode represented by the DAOS_PC_ bits.
  * \param[out]	poh	Returned open handle.

--- a/src/include/daos_pool.h
+++ b/src/include/daos_pool.h
@@ -186,8 +186,6 @@ struct daos_pool_cont_info {
  *
  * \param[in]	uuid	UUID to identify a pool.
  * \param[in]	grp	Process set name of the DAOS servers managing the pool
- * \param[in]	svc	Optional, pool service replica ranks, as reported by
- *			daos_pool_create().
  * \param[in]	flags	Connect mode represented by the DAOS_PC_ bits.
  * \param[out]	poh	Returned open handle.
  * \param[in,out]
@@ -206,7 +204,7 @@ struct daos_pool_cont_info {
  */
 int
 daos_pool_connect(const uuid_t uuid, const char *grp,
-		  const d_rank_list_t *svc, unsigned int flags,
+		  unsigned int flags,
 		  daos_handle_t *poh, daos_pool_info_t *info, daos_event_t *ev);
 
 /**
@@ -231,7 +229,6 @@ daos_pool_disconnect(daos_handle_t poh, daos_event_t *ev);
  *
  * \param uuid	[IN]	UUID of the pool
  * \param grp	[IN]	process set name of the DAOS servers managing the pool
- * \param svc	[IN]	list of pool service ranks
  * \param ev	[IN]	Completion event, it is optional and can be NULL.
  *			Function will run in blocking mode if \a ev is NULL.
  *
@@ -242,8 +239,7 @@ daos_pool_disconnect(daos_handle_t poh, daos_event_t *ev);
  *			-DER_NONEXIST	Pool is nonexistent
  */
 int
-daos_pool_evict(const uuid_t uuid, const char *grp, const d_rank_list_t *svc,
-		daos_event_t *ev);
+daos_pool_evict(const uuid_t uuid, const char *grp, daos_event_t *ev);
 
 /*
  * Handle API

--- a/src/include/daos_srv/daos_server.h
+++ b/src/include/daos_srv/daos_server.h
@@ -685,9 +685,9 @@ int dsc_obj_list_obj(daos_handle_t oh, daos_epoch_range_t *epr,
 		     daos_anchor_t *anchor, daos_anchor_t *dkey_anchor,
 		     daos_anchor_t *akey_anchor, d_iov_t *csum);
 int dsc_pool_tgt_exclude(const uuid_t uuid, const char *grp,
-			 const d_rank_list_t *svc, struct d_tgt_list *tgts);
+			 struct d_tgt_list *tgts);
 int dsc_pool_tgt_reint(const uuid_t uuid, const char *grp,
-		       const d_rank_list_t *svc, struct d_tgt_list *tgts);
+		       struct d_tgt_list *tgts);
 
 int dsc_task_run(tse_task_t *task, tse_task_cb_t retry_cb, void *arg,
 		 int arg_size, bool sync);

--- a/src/include/daos_task.h
+++ b/src/include/daos_task.h
@@ -219,8 +219,6 @@ typedef struct {
 	const uuid_t		uuid;
 	/** Process set name of the DAOS servers managing the pool. */
 	const char		*grp;
-	/** list of pool service ranks. */
-	d_rank_list_t		*svc;
 } daos_pool_evict_t;
 
 /** pool connect args */
@@ -229,8 +227,6 @@ typedef struct {
 	const uuid_t		uuid;
 	/** Process set name of the DAOS servers managing the pool. */
 	const char		*grp;
-	/** Pool service replica ranks. */
-	const d_rank_list_t	*svc;
 	/** Connect mode represented by the DAOS_PC_ bits. */
 	unsigned int		flags;
 	/** Returned open handle. */
@@ -251,8 +247,6 @@ typedef struct {
 	const uuid_t		uuid;
 	/** Process set name of the DAOS servers managing the pool */
 	const char		*grp;
-	/** Pool service replica ranks. */
-	d_rank_list_t		*svc;
 	/** Target array */
 	struct d_tgt_list	*tgts;
 } daos_pool_update_t;
@@ -345,8 +339,6 @@ typedef struct {
 	const uuid_t		uuid;
 	/** Name of DAOS server process set managing the service. */
 	const char		*group;
-	/** List of service ranks. */
-	d_rank_list_t		*svc;
 	/** Ranks of the replicas to be added/removed. */
 	d_rank_list_t		*targets;
 	/** Optional, list of ranks which could not be added/removed. */

--- a/src/pool/cli.c
+++ b/src/pool/cli.c
@@ -501,7 +501,7 @@ dc_pool_connect(tse_task_t *task)
 		/** sy_info.crt_ctx_share_addr */
 		/** sy_info.crt_timeout */
 
-		rc = rsvc_client_init(&pool->dp_client, args->svc);
+		rc = rsvc_client_init(&pool->dp_client, NULL);
 		if (rc != 0)
 			D_GOTO(out_pool, rc);
 
@@ -1095,7 +1095,7 @@ dc_pool_update_internal(tse_task_t *task, daos_pool_update_t *args,
 				DP_UUID(args->uuid), rc);
 			D_GOTO(out_state, rc);
 		}
-		rc = rsvc_client_init(&state->client, args->svc);
+		rc = rsvc_client_init(&state->client, NULL);
 		if (rc != 0) {
 			D_ERROR(DF_UUID": failed to rsvc_client_init, rc %d.\n",
 				DP_UUID(args->uuid), rc);
@@ -1596,7 +1596,7 @@ dc_pool_evict(tse_task_t *task)
 		rc = dc_mgmt_sys_attach(args->grp, &state->sys);
 		if (rc != 0)
 			D_GOTO(out_state, rc);
-		rc = rsvc_client_init(&state->client, args->svc);
+		rc = rsvc_client_init(&state->client, NULL);
 		if (rc != 0)
 			D_GOTO(out_group, rc);
 
@@ -2369,7 +2369,7 @@ rsvc_client_state_cleanup(int stage, struct rsvc_client_state *state)
 
 static int
 rsvc_client_state_create(tse_task_t *task, const uuid_t svc_uuid,
-			 d_rank_list_t *targets, const char *group,
+			 const char *group,
 			 crt_rpc_t **rpcp, int opc, tse_task_cb_t callback)
 {
 	struct rsvc_client_state *state = dc_task_get_priv(task);
@@ -2386,7 +2386,7 @@ rsvc_client_state_create(tse_task_t *task, const uuid_t svc_uuid,
 			rsvc_client_state_cleanup(CCS_CU_MEM, state);
 			return rc;
 		}
-		rc = rsvc_client_init(&state->scs_client, targets);
+		rc = rsvc_client_init(&state->scs_client, NULL);
 		if (rc != 0) {
 			rsvc_client_state_cleanup(CCS_CU_GRP, state);
 			return rc;
@@ -2482,7 +2482,7 @@ dc_pool_membership_update(tse_task_t *task, int opc)
 		D_ERROR("Invalid targets specified\n");
 		D_GOTO(err, rc = -DER_INVAL);
 	}
-	rc = rsvc_client_state_create(task, args->uuid, args->svc, args->group,
+	rc = rsvc_client_state_create(task, args->uuid, args->group,
 				      &rpc, opc, pool_membership_update_cb);
 	if (rc != 0)
 		D_GOTO(err, rc);

--- a/src/pool/cli.c
+++ b/src/pool/cli.c
@@ -210,7 +210,7 @@ choose:
 			D_ERROR(DF_UUID ": dc_mgmt_get_pool_svc_ranks() "
 				"failed, " DF_RC "\n", DP_UUID(puuid),
 				DP_RC(rc));
-			return -DER_NOTREPLICA;
+			return rc;
 		}
 		if (cli_lock)
 			D_MUTEX_LOCK(cli_lock);
@@ -478,7 +478,6 @@ dc_pool_connect(tse_task_t *task)
 
 	if (pool == NULL) {
 		if (!daos_uuid_valid(args->uuid) ||
-		    !daos_rank_list_valid(args->svc) ||
 		    !flags_are_valid(args->flags) || args->poh == NULL)
 			D_GOTO(out_task, rc = -DER_INVAL);
 
@@ -519,8 +518,6 @@ dc_pool_connect(tse_task_t *task)
 	if (rc != 0) {
 		D_ERROR(DF_UUID": cannot find pool service: "DF_RC"\n",
 			DP_UUID(pool->dp_pool), DP_RC(rc));
-		if (rc == -DER_NOTREPLICA)
-			rc = -DER_NONEXIST;
 		goto out_pool;
 	}
 	rc = pool_req_create(daos_task2ctx(task), &ep, POOL_CONNECT, &rpc);
@@ -1586,8 +1583,7 @@ dc_pool_evict(tse_task_t *task)
 	state = dc_task_get_priv(task);
 
 	if (state == NULL) {
-		if (!daos_uuid_valid(args->uuid) ||
-		    !daos_rank_list_valid(args->svc))
+		if (!daos_uuid_valid(args->uuid))
 			D_GOTO(out_task, rc = -DER_INVAL);
 
 		D_DEBUG(DF_DSMC, DF_UUID": evicting\n", DP_UUID(args->uuid));
@@ -1613,8 +1609,6 @@ dc_pool_evict(tse_task_t *task)
 	if (rc != 0) {
 		D_ERROR(DF_UUID": cannot find pool service: "DF_RC"\n",
 			DP_UUID(args->uuid), DP_RC(rc));
-		if (rc == -DER_NOTREPLICA)
-			rc = -DER_NONEXIST;
 		goto out_client;
 	}
 	rc = pool_req_create(daos_task2ctx(task), &ep, POOL_EVICT, &rpc);

--- a/src/pool/srv_cli.c
+++ b/src/pool/srv_cli.c
@@ -103,7 +103,7 @@ out:
 
 int
 dsc_pool_tgt_exclude(const uuid_t uuid, const char *grp,
-		     const d_rank_list_t *svc, struct d_tgt_list *tgts)
+		     struct d_tgt_list *tgts)
 {
 	daos_pool_update_t	*args;
 	tse_task_t		*task;
@@ -117,7 +117,6 @@ dsc_pool_tgt_exclude(const uuid_t uuid, const char *grp,
 
 	args = dc_task_get_args(task);
 	args->grp	= grp;
-	args->svc	= (d_rank_list_t *)svc;
 	args->tgts	= tgts;
 	uuid_copy((unsigned char *)args->uuid, uuid);
 
@@ -126,7 +125,7 @@ dsc_pool_tgt_exclude(const uuid_t uuid, const char *grp,
 
 int
 dsc_pool_tgt_reint(const uuid_t uuid, const char *grp,
-		   const d_rank_list_t *svc, struct d_tgt_list *tgts)
+		   struct d_tgt_list *tgts)
 {
 	daos_pool_update_t	*args;
 	tse_task_t		*task;
@@ -140,7 +139,6 @@ dsc_pool_tgt_reint(const uuid_t uuid, const char *grp,
 
 	args = dc_task_get_args(task);
 	args->grp	= grp;
-	args->svc	= (d_rank_list_t *)svc;
 	args->tgts	= tgts;
 	uuid_copy((unsigned char *)args->uuid, uuid);
 

--- a/src/pool/srv_util.c
+++ b/src/pool/srv_util.c
@@ -777,11 +777,7 @@ update_targets_ult(void *arg)
 {
 	struct update_targets_arg	*uta = arg;
 	struct d_tgt_list		 tgt_list;
-	d_rank_list_t			 svc;
 	int				 rc;
-
-	svc.rl_ranks = &uta->uta_pl_rank;
-	svc.rl_nr = 1;
 
 	tgt_list.tl_nr = uta->uta_nr;
 	tgt_list.tl_ranks = uta->uta_ranks;
@@ -789,10 +785,10 @@ update_targets_ult(void *arg)
 
 	if (uta->uta_reint)
 		rc = dsc_pool_tgt_reint(uta->uta_pool_id, NULL /* grp */,
-					&svc, &tgt_list);
+					&tgt_list);
 	else
 		rc = dsc_pool_tgt_exclude(uta->uta_pool_id, NULL /* grp */,
-					  &svc, &tgt_list);
+					  &tgt_list);
 	if (rc)
 		D_ERROR(DF_UUID": %s targets failed. %d\n",
 			uta->uta_reint ? "Reint" : "Exclude",

--- a/src/tests/daos_perf.c
+++ b/src/tests/daos_perf.c
@@ -784,7 +784,7 @@ ts_exclude_server(d_rank_t rank)
 	targets.tl_nr = 1;
 	targets.tl_ranks = &rank;
 	targets.tl_tgts = &tgt;
-	rc = daos_pool_tgt_exclude(ts_ctx.tsc_pool_uuid, NULL, NULL /* svc */,
+	rc = daos_pool_tgt_exclude(ts_ctx.tsc_pool_uuid, NULL,
 				   &targets, NULL);
 
 	return rc;
@@ -801,7 +801,7 @@ ts_reint_server(d_rank_t rank)
 	targets.tl_nr = 1;
 	targets.tl_ranks = &rank;
 	targets.tl_tgts = &tgt;
-	rc = daos_pool_reint_tgt(ts_ctx.tsc_pool_uuid, NULL, NULL /* svc */,
+	rc = daos_pool_reint_tgt(ts_ctx.tsc_pool_uuid, NULL,
 				 &targets, NULL);
 	return rc;
 }

--- a/src/tests/daos_perf.c
+++ b/src/tests/daos_perf.c
@@ -784,7 +784,7 @@ ts_exclude_server(d_rank_t rank)
 	targets.tl_nr = 1;
 	targets.tl_ranks = &rank;
 	targets.tl_tgts = &tgt;
-	rc = daos_pool_tgt_exclude(ts_ctx.tsc_pool_uuid, NULL, &ts_ctx.tsc_svc,
+	rc = daos_pool_tgt_exclude(ts_ctx.tsc_pool_uuid, NULL, NULL /* svc */,
 				   &targets, NULL);
 
 	return rc;
@@ -801,7 +801,7 @@ ts_reint_server(d_rank_t rank)
 	targets.tl_nr = 1;
 	targets.tl_ranks = &rank;
 	targets.tl_tgts = &tgt;
-	rc = daos_pool_reint_tgt(ts_ctx.tsc_pool_uuid, NULL, &ts_ctx.tsc_svc,
+	rc = daos_pool_reint_tgt(ts_ctx.tsc_pool_uuid, NULL, NULL /* svc */,
 				 &targets, NULL);
 	return rc;
 }

--- a/src/tests/ftest/cart/util/cart_logtest.py
+++ b/src/tests/ftest/cart/util/cart_logtest.py
@@ -227,7 +227,8 @@ mismatch_alloc_ok = {'crt_self_uri_get': ('tmp_uri'),
                      'auth_cred_to_iov': ('packed'),
                      'd_sgl_init': ('sgl->sg_iovs'),
                      'daos_csummer_alloc_iods_csums': ('buf'),
-                     'daos_sgl_init': ('sgl->sg_iovs')}
+                     'daos_sgl_init': ('sgl->sg_iovs'),
+                     'get_pool_svc_ranks': ('req')}
 # pylint: enable=line-too-long
 
 mismatch_free_ok = {'crt_finalize': ('crt_gdata.cg_addr'),
@@ -478,7 +479,7 @@ class LogTest():
                         # that fail during shutdown.
                         if line.rpc_opcode == '0xfe000000':
                             show = False
-                    elif line.fac == 'external':
+                    if line.fac == 'external':
                         show = False
                     if show:
                         # Allow WARNING or ERROR messages, but anything higher

--- a/src/tests/ftest/container/list_containers.py
+++ b/src/tests/ftest/container/list_containers.py
@@ -44,18 +44,17 @@ class ListContainerTest(TestWithServers):
         super(ListContainerTest, self).__init__(*args, **kwargs)
         self.daos_cmd = None
 
-    def create_list(self, count, pool_uuid, sr, expected_uuids):
+    def create_list(self, count, pool_uuid, expected_uuids):
         """Create container and call daos pool list-cont to list and verify.
 
         Args:
             count (Integer): Number of containers to create.
             pool_uuid (String): Pool UUID to create containers in.
-            sr (String): Service replicas of the pool to create containers.
             expected_uuids (List of string): List that contains container UUID.
                 It should contain all the container UUIDs for the given pool.
         """
         # Create containers and store the container UUIDs into expected_uuids.
-        kwargs = {"pool": pool_uuid, "svc": sr}
+        kwargs = {"pool": pool_uuid}
         for _ in range(count):
             expected_uuids.append(
                 self.daos_cmd.get_output("container_create", **kwargs)[0])
@@ -82,13 +81,13 @@ class ListContainerTest(TestWithServers):
         self.daos_cmd = DaosCommand(self.bin)
 
         # 1. Create 1 container and list.
-        self.create_list(1, data1["uuid"], data1["svc"], expected_uuids1)
+        self.create_list(1, data1["uuid"], expected_uuids1)
 
         # 2. Create 1 more container and list; 2 total.
-        self.create_list(1, data1["uuid"], data1["svc"], expected_uuids1)
+        self.create_list(1, data1["uuid"], expected_uuids1)
 
         # 3. Create 98 more containers and list; 100 total.
-        self.create_list(98, data1["uuid"], data1["svc"], expected_uuids1)
+        self.create_list(98, data1["uuid"], expected_uuids1)
 
         # 4. Create 2 additional pools and create 10 containers in each pool.
         data2 = self.get_dmg_command().pool_create(scm_size="150MB")
@@ -96,7 +95,7 @@ class ListContainerTest(TestWithServers):
 
         # Create 10 containers in pool 2 and verify.
         expected_uuids2 = []
-        self.create_list(10, data2["uuid"], data2["svc"], expected_uuids2)
+        self.create_list(10, data2["uuid"], expected_uuids2)
         # Create 10 containers in pool 3 and verify.
         expected_uuids3 = []
-        self.create_list(10, data3["uuid"], data3["svc"], expected_uuids3)
+        self.create_list(10, data3["uuid"], expected_uuids3)

--- a/src/tests/ftest/container/query_attribute.py
+++ b/src/tests/ftest/container/query_attribute.py
@@ -60,8 +60,7 @@ class ContainerQueryAttributeTest(TestWithServers):
         self.add_pool()
         self.daos_cmd = DaosCommand(self.bin)
         self.expected_cont_uuid = self.daos_cmd.get_output(
-            "container_create", pool=self.pool.uuid,
-            svc=self.pool.svc_ranks[0])[0]
+            "container_create", pool=self.pool.uuid)[0]
 
     def test_container_query_attr(self):
         """JIRA ID: DAOS-4640
@@ -81,7 +80,6 @@ class ContainerQueryAttributeTest(TestWithServers):
         # compare against those used when creating the pool and the container.
         kwargs = {
             "pool": self.pool.uuid,
-            "svc": self.pool.svc_ranks[0],
             "cont": self.expected_cont_uuid
         }
         query_output = self.daos_cmd.get_output("container_query", **kwargs)[0]
@@ -131,8 +129,7 @@ class ContainerQueryAttributeTest(TestWithServers):
         for attr_value in attr_values:
             self.daos_cmd.container_set_attr(
                 pool=actual_pool_uuid, cont=actual_cont_uuid,
-                attr=attr_value[0], val=attr_value[1],
-                svc=self.pool.svc_ranks[0])
+                attr=attr_value[0], val=attr_value[1])
             kwargs["attr"] = attr_value[0]
             output = self.daos_cmd.container_get_attr(**kwargs)
             actual_val = output["value"]
@@ -159,7 +156,6 @@ class ContainerQueryAttributeTest(TestWithServers):
         expected_attrs.sort()
         kwargs = {
             "pool": actual_pool_uuid,
-            "svc": self.pool.svc_ranks[0],
             "cont": actual_cont_uuid
         }
         data = self.daos_cmd.container_list_attrs(**kwargs)
@@ -188,11 +184,10 @@ class ContainerQueryAttributeTest(TestWithServers):
         for expected_attr, val in zip(expected_attrs, vals):
             _ = self.daos_cmd.container_set_attr(
                 pool=self.pool.uuid, cont=self.expected_cont_uuid,
-                attr=expected_attr, val=val, svc=self.pool.svc_ranks[0])
+                attr=expected_attr, val=val)
         expected_attrs.sort()
         kwargs = {
             "pool": self.pool.uuid,
-            "svc": self.pool.svc_ranks[0],
             "cont": self.expected_cont_uuid
         }
         data = self.daos_cmd.container_list_attrs(**kwargs)

--- a/src/tests/ftest/container/snapshot_aggregation.py
+++ b/src/tests/ftest/container/snapshot_aggregation.py
@@ -123,7 +123,7 @@ class SnapshotAggregation(IorTestBase):
 
         # Delete the snapshot.
         daos.container_destroy_snap(
-            pool=self.pool.uuid, svc=self.pool.svc_ranks,
+            pool=self.pool.uuid,
             cont=self.container.uuid, epc=self.container.epoch)
 
         # Wait for aggregation to start and finish.

--- a/src/tests/ftest/control/daos_object_query.py
+++ b/src/tests/ftest/control/daos_object_query.py
@@ -96,7 +96,6 @@ class DaosObjectQuery(TestWithServers):
             oid_concat = "{}.{}".format(expected_oid_hi, expected_oid_lo)
             kwargs = {
                 "pool": self.pool.uuid,
-                "svc": convert_list(self.pool.svc_ranks),
                 "cont": self.container.uuid,
                 "oid": oid_concat
             }

--- a/src/tests/ftest/control/dmg_pool_evict.py
+++ b/src/tests/ftest/control/dmg_pool_evict.py
@@ -64,7 +64,7 @@ class DmgPoolEvictTest(TestWithServers):
         daos_cmd = self.get_daos_command()
         try:
             daos_cmd.pool_list_cont(
-                pool=self.pool[0].uuid, svc=self.pool[0].svc_ranks[0])
+                pool=self.pool[0].uuid)
             self.log.info(
                 "daos pool list-cont with first pool succeeded as expected")
         except CommandFailure:
@@ -75,7 +75,7 @@ class DmgPoolEvictTest(TestWithServers):
         # -1012.
         try:
             daos_cmd.pool_list_cont(
-                pool=self.pool[1].uuid, svc=self.pool[1].svc_ranks[0])
+                pool=self.pool[1].uuid)
             self.fail(
                 "daos pool list-cont with second pool succeeded after pool " +
                 "evict!")
@@ -89,11 +89,11 @@ class DmgPoolEvictTest(TestWithServers):
         # list, and destroy.
         self.container.append(self.get_container(self.pool[0]))
         data = daos_cmd.pool_list_cont(
-            pool=self.pool[0].uuid, svc=self.pool[0].svc_ranks[0])
+            pool=self.pool[0].uuid)
         self.assertEqual(len(data["uuids"]), len(self.container))
         self.container[0].destroy()
         data = daos_cmd.pool_list_cont(
-            pool=self.pool[0].uuid, svc=self.pool[0].svc_ranks[0])
+            pool=self.pool[0].uuid)
 
         # Create list of container UUIDs and compare. Convert command output to
         # upper case since we use upper case in object.

--- a/src/tests/ftest/io/io_aggregation.py
+++ b/src/tests/ftest/io/io_aggregation.py
@@ -110,7 +110,6 @@ class IoAggregation(IorTestBase):
         # obtain highest epoch before snapshot destroy via container query
         kwargs = {
             "pool": self.pool.uuid,
-            "svc": self.pool.svc_ranks[0],
             "cont": self.container.uuid
         }
         highest_epc_before_snap_destroy = self.highest_epoch(kwargs)

--- a/src/tests/ftest/io/parallel_io.py
+++ b/src/tests/ftest/io/parallel_io.py
@@ -259,7 +259,7 @@ class ParallelIo(FioBase, IorTestBase):
         for pool_job in pool_threads:
             pool_job.join()
 
-        # start dfuse using --svc option only.
+        # start dfuse.
         self.start_dfuse(self.hostlist_clients, None, None)
 
         # record free space using statvfs before any data is written.

--- a/src/tests/ftest/nvme/enospace.py
+++ b/src/tests/ftest/nvme/enospace.py
@@ -88,7 +88,7 @@ class NvmeEnospace(ServerFillUp):
         Delete all the containers.
         """
         #List all the container
-        kwargs = {"pool": self.pool.uuid, "svc": self.pool.svc_ranks}
+        kwargs = {"pool": self.pool.uuid}
         data = self.daos_cmd.pool_list_cont(**kwargs)
         containers = data["uuids"]
 

--- a/src/tests/ftest/nvme/nvme_fragmentation.py
+++ b/src/tests/ftest/nvme/nvme_fragmentation.py
@@ -132,8 +132,8 @@ class NvmeFragmentation(TestWithServers):
         # Destroy the container created by thread
         for key in container_info:
             cmd.sub_command_class.sub_command_class.pool.value = self.pool.uuid
-            cmd.sub_command_class.sub_command_class.svc.value = \
-                self.pool.svc_ranks
+            #cmd.sub_command_class.sub_command_class.svc.value = \
+            #    self.pool.svc_ranks
             cmd.sub_command_class.sub_command_class.cont.value = \
                 container_info[key]
 

--- a/src/tests/ftest/pool/bad_connect.py
+++ b/src/tests/ftest/pool/bad_connect.py
@@ -51,10 +51,6 @@ class BadConnectTest(TestWithServers):
         connectmode = modelist[0]
         expected_for_param.append(modelist[1])
 
-        svclist = self.params.get("ranklist", '/run/connecttests/svrlist/*/')
-        svc = svclist[0]
-        expected_for_param.append(svclist[1])
-
         setlist = self.params.get("setname",
                                   '/run/connecttests/connectsetnames/*/')
         connectset = setlist[0]
@@ -73,7 +69,7 @@ class BadConnectTest(TestWithServers):
                 break
 
         puuid = (ctypes.c_ubyte * 16)()
-        psvc = RankList()
+        #psvc = RankList()
         pgroup = ctypes.create_string_buffer(0)
         # initialize a python pool object then create the underlying
         # daos storage
@@ -84,11 +80,11 @@ class BadConnectTest(TestWithServers):
         ctypes.memmove(puuid, self.pool.pool.uuid, 16)
 
         # trash the the pool service rank list
-        psvc.rl_ranks = self.pool.pool.svc.rl_ranks
-        psvc.rl_nr = self.pool.pool.svc.rl_nr
-        if not svc == 'VALID':
-            rl_ranks = ctypes.POINTER(ctypes.c_uint)()
-            self.pool.pool.svc = RankList(rl_ranks, 1)
+        #psvc.rl_ranks = self.pool.pool.svc.rl_ranks
+        #psvc.rl_nr = self.pool.pool.svc.rl_nr
+        #if not svc == 'VALID':
+        #    rl_ranks = ctypes.POINTER(ctypes.c_uint)()
+        #    self.pool.pool.svc = RankList(rl_ranks, 1)
 
         # trash the pool group value
         pgroup = self.pool.pool.group
@@ -117,8 +113,8 @@ class BadConnectTest(TestWithServers):
         finally:
             if self.pool is not None and self.pool.pool.attached == 1:
                 # restore values in case we trashed them during test
-                self.pool.pool.svc.rl_ranks = psvc.rl_ranks
-                self.pool.pool.svc.rl_nr = psvc.rl_nr
+                #self.pool.pool.svc.rl_ranks = psvc.rl_ranks
+                #self.pool.pool.svc.rl_nr = psvc.rl_nr
                 self.pool.pool.group = pgroup
                 if self.pool.pool.uuid is None:
                     self.pool.pool.uuid = (ctypes.c_ubyte * 16)()

--- a/src/tests/ftest/pool/bad_connect.yaml
+++ b/src/tests/ftest/pool/bad_connect.yaml
@@ -29,15 +29,15 @@ connecttests:
           mode:
              - 512
              - FAIL
-   svrlist: !mux
-     goodlist:
-          ranklist:
-             - VALID
-             - PASS
-     badlist:
-          ranklist:
-             - NULLPTR
-             - FAIL
+#   svrlist: !mux
+#     goodlist:
+#          ranklist:
+#             - VALID
+#             - PASS
+#     badlist:
+#          ranklist:
+#             - NULLPTR
+#             - FAIL
    connectsetnames: !mux
      goodname:
           setname:

--- a/src/tests/ftest/pool/bad_evict.py
+++ b/src/tests/ftest/pool/bad_evict.py
@@ -60,9 +60,9 @@ class BadEvictTest(TestWithServers):
         # expected result of the test
         expected_for_param = []
 
-        svclist = self.params.get("ranklist", '/run/evicttests/svrlist/*/')
-        svc = svclist[0]
-        expected_for_param.append(svclist[1])
+        #svclist = self.params.get("ranklist", '/run/evicttests/svrlist/*/')
+        #svc = svclist[0]
+        #expected_for_param.append(svclist[1])
 
         setlist = self.params.get("setname",
                                   '/run/evicttests/connectsetnames/*/')
@@ -83,7 +83,7 @@ class BadEvictTest(TestWithServers):
 
         saveduuid = None
         savedgroup = None
-        savedsvc = None
+        #savedsvc = None
         pool = None
 
         try:
@@ -94,10 +94,10 @@ class BadEvictTest(TestWithServers):
                         createsize, createsetid, None)
 
             # trash the the pool service rank list
-            if not svc == 'VALID':
-                savedsvc = pool.svc
-                rl_ranks = ctypes.POINTER(ctypes.c_uint)()
-                pool.svc = RankList(rl_ranks, 1)
+            #if not svc == 'VALID':
+            #    savedsvc = pool.svc
+            #    rl_ranks = ctypes.POINTER(ctypes.c_uint)()
+            #    pool.svc = RankList(rl_ranks, 1)
 
             # trash the pool group value
             savedgroup = pool.group
@@ -136,6 +136,6 @@ class BadEvictTest(TestWithServers):
                 if saveduuid is not None:
                     for item in range(0, len(saveduuid)):
                         pool.uuid[item] = saveduuid[item]
-                if savedsvc is not None:
-                    pool.svc = savedsvc
+                #if savedsvc is not None:
+                #    pool.svc = savedsvc
                 pool.destroy(0)

--- a/src/tests/ftest/pool/bad_evict.yaml
+++ b/src/tests/ftest/pool/bad_evict.yaml
@@ -5,15 +5,15 @@ hosts:
     - server-A
 timeout: 650
 evicttests:
-   svrlist: !mux
-     goodlist:
-          ranklist:
-             - VALID
-             - PASS
-     badlist:
-          ranklist:
-             - NULL
-             - FAIL
+#   svrlist: !mux
+#     goodlist:
+#          ranklist:
+#             - VALID
+#             - PASS
+#     badlist:
+#          ranklist:
+#             - NULL
+#             - FAIL
    connectsetnames: !mux
      goodname:
           setname:

--- a/src/tests/ftest/pool/bad_exclude.py
+++ b/src/tests/ftest/pool/bad_exclude.py
@@ -59,9 +59,9 @@ class BadExcludeTest(TestWithServers):
             targets.append(tgtlist[0])
         expected_for_param.append(tgtlist[1])
 
-        svclist = self.params.get("ranklist", '/run/testparams/svrlist/*/')
-        svc = svclist[0]
-        expected_for_param.append(svclist[1])
+        #svclist = self.params.get("ranklist", '/run/testparams/svrlist/*/')
+        #svc = svclist[0]
+        #expected_for_param.append(svclist[1])
 
         setlist = self.params.get("setname",
                                   '/run/testparams/connectsetnames/*/')
@@ -80,17 +80,17 @@ class BadExcludeTest(TestWithServers):
                 expected_result = 'FAIL'
                 break
 
-        saved_svc = None
+        #saved_svc = None
         saved_grp = None
         saved_uuid = None
         self.prepare_pool()
 
         # trash the the pool service rank list
-        if not svc == 'VALID':
-            self.cancel("skipping this test until DAOS-1931 is fixed")
-            saved_svc = RankList(
-                self.pool.pool.svc.rl_ranks, self.pool.pool.svc.rl_nr)
-            self.pool.pool.svc = None
+        #if not svc == 'VALID':
+        #    self.cancel("skipping this test until DAOS-1931 is fixed")
+        #    saved_svc = RankList(
+        #        self.pool.pool.svc.rl_ranks, self.pool.pool.svc.rl_nr)
+        #    self.pool.pool.svc = None
 
         saved_grp = self.pool.pool.group
         if connectset == 'NULLPTR':
@@ -121,8 +121,8 @@ class BadExcludeTest(TestWithServers):
             if expected_result == 'PASS':
                 self.fail("Test was expected to pass but it failed.\n")
         finally:
-            if saved_svc is not None:
-                self.pool.pool.svc = saved_svc
+            #if saved_svc is not None:
+            #    self.pool.pool.svc = saved_svc
             if saved_grp is not None:
                 self.pool.pool.group = saved_grp
             if saved_uuid is not None:

--- a/src/tests/ftest/pool/bad_exclude.yaml
+++ b/src/tests/ftest/pool/bad_exclude.yaml
@@ -20,15 +20,15 @@ testparams:
          ranklist:
             - NULLPTR
             - FAIL
-   svrlist: !mux
-      goodlist:
-         ranklist:
-            - VALID
-            - PASS
-      badlist:
-         ranklist:
-            - NULLPTR
-            - FAIL
+#   svrlist: !mux
+#      goodlist:
+#         ranklist:
+#            - VALID
+#            - PASS
+#      badlist:
+#         ranklist:
+#            - NULLPTR
+#            - FAIL
    connectsetnames: !mux
       goodname:
          setname:

--- a/src/tests/ftest/pool/query_attribute.py
+++ b/src/tests/ftest/pool/query_attribute.py
@@ -64,7 +64,7 @@ class QueryAttributeTest(TestWithServers):
         daos_cmd = DaosCommand(self.bin)
         # Call daos pool query, obtain pool UUID and SCM size, and compare
         # against those used when creating the pool.
-        kwargs = {"pool": expected["uuid"], "svc": expected["svc"]}
+        kwargs = {"pool": expected["uuid"]}
         query_result = daos_cmd.get_output("pool_query", **kwargs)
         actual_uuid = query_result[0][0]
         actual_size = query_result[2][4]
@@ -83,12 +83,11 @@ class QueryAttributeTest(TestWithServers):
             sample_attrs.append(sample_attr)
             sample_vals.append(sample_val)
             daos_cmd.pool_set_attr(
-                pool=actual_uuid, attr=sample_attr, value=sample_val,
-                svc=expected["svc"])
+                pool=actual_uuid, attr=sample_attr, value=sample_val)
             expected_attrs.append(sample_attr)
             expected_attrs_dict[sample_attr] = sample_val
         # List the attribute names and compare against those set.
-        kwargs = {"pool": actual_uuid, "svc": expected["svc"]}
+        kwargs = {"pool": actual_uuid}
         actual_attrs = daos_cmd.get_output("pool_list_attrs", **kwargs)
         actual_attrs.sort()
         expected_attrs.sort()
@@ -98,7 +97,6 @@ class QueryAttributeTest(TestWithServers):
             kwargs = {
                 "pool": actual_uuid,
                 "attr": sample_attrs[i],
-                "svc": expected["svc"]
             }
             actual_val = daos_cmd.get_output("pool_get_attr", **kwargs)[0]
             self.assertEqual(sample_vals[i], actual_val)

--- a/src/tests/ftest/security/cont_create_acl.py
+++ b/src/tests/ftest/security/cont_create_acl.py
@@ -68,7 +68,6 @@ class CreateContainterACLTest(ContSecurityTestBase):
             self.fail("    An expected container could not be created")
 
         cont_acl = self.get_container_acl_list(self.pool_uuid,
-                                               self.pool_svc,
                                                self.container_uuid)
         if not self.compare_acl_lists(cont_acl, expected_acl):
             self.fail("    ACL permissions mismatch:\n\t \
@@ -99,7 +98,6 @@ class CreateContainterACLTest(ContSecurityTestBase):
             self.fail("    An expected container could not be created")
 
         cont_acl = self.get_container_acl_list(self.pool_uuid,
-                                               self.pool_svc,
                                                self.container_uuid,
                                                True)
         if not self.compare_acl_lists(cont_acl, expected_acl):

--- a/src/tests/ftest/security/cont_delete_acl.py
+++ b/src/tests/ftest/security/cont_delete_acl.py
@@ -44,7 +44,7 @@ class DeleteContainerACLTest(ContSecurityTestBase):
 
         # Get list of ACL entries
         cont_acl = self.get_container_acl_list(
-            self.pool.uuid, self.pool.svc_ranks[0], self.container.uuid)
+            self.pool.uuid, self.container.uuid)
 
         # Get principals
         self.principals_table = {}
@@ -71,7 +71,6 @@ class DeleteContainerACLTest(ContSecurityTestBase):
         for principal in invalid_principals:
             self.daos_cmd.container_delete_acl(
                 self.pool.uuid,
-                self.pool.svc_ranks[0],
                 self.container.uuid,
                 principal)
             test_errs.extend(self.error_handling(self.daos_cmd.result, "-1003"))
@@ -92,7 +91,6 @@ class DeleteContainerACLTest(ContSecurityTestBase):
         for principal in self.principals_table:
             self.daos_cmd.container_delete_acl(
                 self.pool.uuid,
-                self.pool.svc_ranks[0],
                 self.container.uuid,
                 principal)
             if self.principals_table[principal] in self.daos_cmd.result.stdout:
@@ -125,7 +123,6 @@ class DeleteContainerACLTest(ContSecurityTestBase):
         for principal in self.principals_table:
             self.daos_cmd.container_delete_acl(
                 self.pool.uuid,
-                self.pool.svc_ranks[0],
                 self.container.uuid,
                 principal)
             test_errs.extend(self.error_handling(self.daos_cmd.result, "-1001"))

--- a/src/tests/ftest/security/cont_get_acl.py
+++ b/src/tests/ftest/security/cont_get_acl.py
@@ -66,7 +66,6 @@ class GetContainerACLTest(ContSecurityTestBase):
                 self.daos_cmd.exit_status_exception = False
                 self.daos_cmd.container_get_acl(
                     self.pool.uuid,
-                    self.pool.svc_ranks[0],
                     self.container.uuid,
                     verbose=verbose,
                     outfile=path_to_file)
@@ -80,7 +79,6 @@ class GetContainerACLTest(ContSecurityTestBase):
                 self.daos_cmd.exit_status_exception = False
                 self.daos_cmd.container_get_acl(
                     self.pool.uuid,
-                    self.pool.svc_ranks[0],
                     self.container.uuid,
                     verbose=verbose,
                     outfile=path_to_file)
@@ -116,7 +114,6 @@ class GetContainerACLTest(ContSecurityTestBase):
         test_errs = []
         self.daos_cmd.container_get_acl(
             self.pool.uuid,
-            self.pool.svc_ranks[0],
             self.container.uuid,
             outfile="outfile.txt")
         test_errs.extend(self.error_handling(self.daos_cmd.result, "-1001"))

--- a/src/tests/ftest/security/cont_overwrite_acl.py
+++ b/src/tests/ftest/security/cont_overwrite_acl.py
@@ -48,7 +48,7 @@ class OverwriteContainerACLTest(ContSecurityTestBase):
 
         # List of ACL entries
         self.cont_acl = self.get_container_acl_list(
-            self.pool.uuid, self.pool.svc_ranks[0], self.container.uuid)
+            self.pool.uuid, self.container.uuid)
 
     def test_acl_overwrite_invalid_inputs(self):
         """
@@ -73,7 +73,6 @@ class OverwriteContainerACLTest(ContSecurityTestBase):
             # Run overwrite command
             self.daos_cmd.container_overwrite_acl(
                 self.pool.uuid,
-                self.pool.svc_ranks[0],
                 self.container.uuid,
                 acl_file)
             test_errs.extend(self.error_handling(
@@ -110,7 +109,6 @@ class OverwriteContainerACLTest(ContSecurityTestBase):
             # Run overwrite command
             self.daos_cmd.container_overwrite_acl(
                 self.pool.uuid,
-                self.pool.svc_ranks[0],
                 self.container.uuid,
                 path_to_file)
             test_errs.extend(self.error_handling(self.daos_cmd.result, "-1003"))
@@ -143,7 +141,6 @@ class OverwriteContainerACLTest(ContSecurityTestBase):
             create_acl_file(path_to_file, content)
             self.daos_cmd.container_overwrite_acl(
                 self.pool.uuid,
-                self.pool.svc_ranks[0],
                 self.container.uuid,
                 path_to_file)
 
@@ -179,14 +176,13 @@ class OverwriteContainerACLTest(ContSecurityTestBase):
             create_acl_file(path_to_file, content)
             self.daos_cmd.container_overwrite_acl(
                 self.pool.uuid,
-                self.pool.svc_ranks[0],
                 self.container.uuid,
                 path_to_file)
             test_errs.extend(self.error_handling(self.daos_cmd.result, "-1001"))
 
             # Check that the acl was unchanged.
             post_test_acls = self.get_container_acl_list(
-                self.pool.uuid, self.pool.svc_ranks[0], self.container.uuid)
+                self.pool.uuid, self.container.uuid)
             if not self.compare_acl_lists(self.cont_acl, post_test_acls):
                 self.fail("Previous ACL:\n{} Post command ACL:{}".format(
                     self.cont_acl, post_test_acls))

--- a/src/tests/ftest/security/cont_update_acl.py
+++ b/src/tests/ftest/security/cont_update_acl.py
@@ -46,7 +46,7 @@ class UpdateContainerACLTest(ContSecurityTestBase):
 
         # List of ACL entries
         self.cont_acl = self.get_container_acl_list(
-            self.pool.uuid, self.pool.svc_ranks[0], self.container.uuid)
+            self.pool.uuid, self.container.uuid)
 
     def test_acl_update_invalid_inputs(self):
         """
@@ -71,7 +71,6 @@ class UpdateContainerACLTest(ContSecurityTestBase):
             # Run update command
             self.daos_cmd.container_update_acl(
                 self.pool.uuid,
-                self.pool.svc_ranks[0],
                 self.container.uuid,
                 entry=entry)
             test_errs.extend(self.error_handling(self.daos_cmd.result, "-1003"))
@@ -84,7 +83,6 @@ class UpdateContainerACLTest(ContSecurityTestBase):
             # Run update command
             self.daos_cmd.container_update_acl(
                 self.pool.uuid,
-                self.pool.svc_ranks[0],
                 self.container.uuid,
                 acl_file=acl_file)
             test_errs.extend(self.error_handling(
@@ -119,7 +117,6 @@ class UpdateContainerACLTest(ContSecurityTestBase):
             # Run update command
             self.daos_cmd.container_update_acl(
                 self.pool.uuid,
-                self.pool.svc_ranks[0],
                 self.container.uuid,
                 path_to_file)
             test_errs.extend(self.error_handling(self.daos_cmd.result, "-1003"))
@@ -151,7 +148,6 @@ class UpdateContainerACLTest(ContSecurityTestBase):
         # Run update command
         self.daos_cmd.container_update_acl(
             self.pool.uuid,
-            self.pool.svc_ranks[0],
             self.container.uuid,
             acl_file=path_to_file)
 
@@ -165,7 +161,6 @@ class UpdateContainerACLTest(ContSecurityTestBase):
         # Run update command
         self.daos_cmd.container_update_acl(
             self.pool.uuid,
-            self.pool.svc_ranks[0],
             self.container.uuid,
             acl_file=path_to_file)
 
@@ -179,7 +174,6 @@ class UpdateContainerACLTest(ContSecurityTestBase):
         # Run update command
         self.daos_cmd.container_update_acl(
             self.pool.uuid,
-            self.pool.svc_ranks[0],
             self.container.uuid,
             acl_file=path_to_file)
 
@@ -215,7 +209,6 @@ class UpdateContainerACLTest(ContSecurityTestBase):
             create_acl_file(path_to_file, content)
             self.daos_cmd.container_update_acl(
                 self.pool.uuid,
-                self.pool.svc_ranks[0],
                 self.container.uuid,
                 path_to_file)
             test_errs.extend(self.error_handling(self.daos_cmd.result, "-1001"))

--- a/src/tests/ftest/server/daos_server_restart.py
+++ b/src/tests/ftest/server/daos_server_restart.py
@@ -104,10 +104,9 @@ class DaosServerTest(TestWithServers):
             dmg = self.get_dmg_command()
             result = dmg.pool_create(scm_size)
             uuid = result['uuid']
-            svc = result['svc']
             daos_cmd = DaosCommand(self.bin)
             for _ in range(container_per_pool):
-                result = daos_cmd.container_create(pool=uuid, svc=svc)
+                result = daos_cmd.container_create(pool=uuid)
                 self.log.info("container create status: %s", result)
 
     def test_daos_server_reformat(self):

--- a/src/tests/ftest/server/metadata.py
+++ b/src/tests/ftest/server/metadata.py
@@ -126,41 +126,6 @@ class ObjectMetadata(TestWithServers):
         self.d_log.debug("IOR {0} Threads Finished -----".format(operation))
         return "PASS"
 
-    def test_metadata_find_svc(self):
-        """JIRA ID: DAOS-3321.
-
-        Test Description:
-            Test to ask MS for list of PS replia ranks.
-
-        Use Cases:
-            ?
-
-        :avocado: tags=all,metadata,pr,large,metadatafindsvc,hw
-        """
-        # Connect to pool with svc argument being a valid rank,
-        # but one that is not a pool service replica. Rank 0 is convenient.
-        # libdaos should process a DER_NOTREPLICA reply, and then contact MS
-        # for the list of PS ranks
-
-        try:
-            # temporarily manipulate the pool's svc ranks
-            save_rank = self.pool.pool.svc.rl_ranks[0]
-            save_nranks = self.pool.pool.svc.rl_nr
-            self.pool.pool.svc.rl_ranks[0] = 0
-            self.pool.pool.svc.rl_nr = 1
-            self.pool.pool.connect(2)
-            self.pool.pool.disconnect()
-            self.log.info("connected to pool specifying incorrect svc rank 0")
-
-        except DaosApiError as exe:
-            print(exe, traceback.format_exc())
-            self.fail("pool connect failed when specifying svc rank 0")
-
-        finally:
-            # restore
-            self.pool.pool.svc.rl_ranks[0] = save_rank
-            self.pool.pool.svc.rl_nr = save_nranks
-
     def test_metadata_fillup(self):
         """JIRA ID: DAOS-1512.
 

--- a/src/tests/ftest/util/cont_security_test_base.py
+++ b/src/tests/ftest/util/cont_security_test_base.py
@@ -79,11 +79,11 @@ class ContSecurityTestBase(TestWithServers):
 
         Returns:
             pool_uuid (str): Pool UUID, randomly generated.
-            pool_svc (str): Pool service replica
+            pool_svc (str): Pool service replica rank list
         """
         self.prepare_pool()
         pool_uuid = self.pool.pool.get_uuid_str()
-        pool_svc = self.pool.svc_ranks[0]
+        pool_svc = self.pool.svc_ranks
 
         return pool_uuid, pool_svc
 
@@ -129,13 +129,12 @@ class ContSecurityTestBase(TestWithServers):
 
         return container_uuid
 
-    def get_container_acl_list(self, pool_uuid, pool_svc, container_uuid,
+    def get_container_acl_list(self, pool_uuid, container_uuid,
                                verbose=False, outfile=None):
         """Get daos container acl list by daos container get-acl.
 
         Args:
             pool_uuid (str): Pool uuid.
-            pool_svc (str): Pool service replicas.
             container_uuid (str): Container uuid.
             verbose (bool, optional): Verbose mode.
             outfile (str, optional): Write ACL to file
@@ -153,9 +152,8 @@ class ContSecurityTestBase(TestWithServers):
                 "    Invalid Container UUID '{}' provided.".format(
                     container_uuid))
 
-        result = self.daos_tool.container_get_acl(pool_uuid, pool_svc,
-                                                  container_uuid, verbose,
-                                                  outfile)
+        result = self.daos_tool.container_get_acl(pool_uuid, container_uuid,
+                                                  verbose, outfile)
 
         cont_permission_list = []
         for line in result.stdout.splitlines():
@@ -182,7 +180,7 @@ class ContSecurityTestBase(TestWithServers):
         """
         self.daos_tool.exit_status_exception = False
         result = self.daos_tool.container_overwrite_acl(
-            self.pool_uuid, self.pool_svc, self.container_uuid, acl_file)
+            self.pool_uuid, self.container_uuid, acl_file)
         return result
 
     def update_container_acl(self, entry):
@@ -196,15 +194,14 @@ class ContSecurityTestBase(TestWithServers):
         """
         self.daos_tool.exit_status_exception = False
         result = self.daos_tool.container_update_acl(
-            self.pool_uuid, self.pool_svc, self.container_uuid, entry=entry)
+            self.pool_uuid, self.container_uuid, entry=entry)
         return result
 
-    def test_container_destroy(self, pool_uuid, pool_svc, container_uuid):
+    def test_container_destroy(self, pool_uuid, container_uuid):
         """Test container destroy/delete.
 
         Args:
             pool_uuid (str): pool uuid.
-            pool_svc  (str): pool service replica.
             container_uuid (str): container uuid.
 
         Return:
@@ -212,16 +209,15 @@ class ContSecurityTestBase(TestWithServers):
         """
         self.daos_tool.exit_status_exception = False
         result = self.daos_tool.container_destroy(
-            pool_uuid, pool_svc, container_uuid, True)
+            pool_uuid, container_uuid, True)
         return result
 
     def set_container_attribute(
-            self, pool_uuid, pool_svc, container_uuid, attr, value):
+            self, pool_uuid, container_uuid, attr, value):
         """Write/Set container attribute.
 
         Args:
             pool_uuid (str): pool uuid.
-            pool_svc  (str): pool service replica.
             container_uuid (str): container uuid.
             attr (str): container attribute.
             value (str): container attribute value to be set.
@@ -231,16 +227,15 @@ class ContSecurityTestBase(TestWithServers):
         """
         self.daos_tool.exit_status_exception = False
         result = self.daos_tool.container_set_attr(
-            pool_uuid, container_uuid, attr, value, pool_svc)
+            pool_uuid, container_uuid, attr, value)
         return result
 
     def get_container_attribute(
-            self, pool_uuid, pool_svc, container_uuid, attr):
+            self, pool_uuid, container_uuid, attr):
         """Get container attribute.
 
         Args:
             pool_uuid (str): pool uuid.
-            pool_svc  (str): pool service replica.
             container_uuid (str): container uuid.
             attr (str): container attribute.
 
@@ -250,16 +245,15 @@ class ContSecurityTestBase(TestWithServers):
         """
         self.daos_tool.exit_status_exception = False
         self.daos_tool.container_get_attr(
-            pool_uuid, container_uuid, attr, pool_svc)
+            pool_uuid, container_uuid, attr)
         return self.daos_tool.result
 
     def list_container_attribute(
-            self, pool_uuid, pool_svc, container_uuid):
+            self, pool_uuid, container_uuid):
         """List container attribute.
 
         Args:
             pool_uuid (str): pool uuid.
-            pool_svc  (str): pool service replica.
             container_uuid (str): container uuid.
 
         Return:
@@ -267,17 +261,16 @@ class ContSecurityTestBase(TestWithServers):
         """
         self.daos_tool.exit_status_exception = False
         result = self.daos_tool.container_list_attrs(
-            pool_uuid, container_uuid, pool_svc)
+            pool_uuid, container_uuid)
         return result
 
 
     def set_container_property(
-            self, pool_uuid, pool_svc, container_uuid, prop, value):
+            self, pool_uuid, container_uuid, prop, value):
         """Write/Set container property.
 
         Args:
             pool_uuid (str): pool uuid.
-            pool_svc  (str): pool service replica.
             container_uuid (str): container uuid.
             prop (str): container property name.
             value (str): container property value to be set.
@@ -287,15 +280,14 @@ class ContSecurityTestBase(TestWithServers):
         """
         self.daos_tool.exit_status_exception = False
         result = self.daos_tool.container_set_prop(
-            pool_uuid, container_uuid, prop, value, pool_svc)
+            pool_uuid, container_uuid, prop, value)
         return result
 
-    def get_container_property(self, pool_uuid, pool_svc, container_uuid):
+    def get_container_property(self, pool_uuid, container_uuid):
         """Get container property.
 
         Args:
             pool_uuid (str): pool uuid.
-            pool_svc  (str): pool service replica.
             container_uuid (str): container uuid.
 
         Return:
@@ -303,16 +295,15 @@ class ContSecurityTestBase(TestWithServers):
         """
         self.daos_tool.exit_status_exception = False
         result = self.daos_tool.container_get_prop(
-            pool_uuid, container_uuid, pool_svc)
+            pool_uuid, container_uuid)
         return result
 
     def set_container_owner(
-            self, pool_uuid, pool_svc, container_uuid, user, group):
+            self, pool_uuid, container_uuid, user, group):
         """Set container owner.
 
         Args:
             pool_uuid (str): pool uuid.
-            pool_svc  (str): pool service replica.
             container_uuid (str): container uuid.
             user (str): container user-name to be set owner to.
             group (str): container group-name to be set owner to.
@@ -322,7 +313,7 @@ class ContSecurityTestBase(TestWithServers):
         """
         self.daos_tool.exit_status_exception = False
         result = self.daos_tool.container_set_owner(
-            pool_uuid, container_uuid, user, group, pool_svc)
+            pool_uuid, container_uuid, user, group)
         return result
 
     def compare_acl_lists(self, get_acl_list, expected_list):
@@ -450,7 +441,7 @@ class ContSecurityTestBase(TestWithServers):
                 contents are same. Defaults to True.
         """
         current_acl = self.get_container_acl_list(
-            self.pool.uuid, self.pool.svc_ranks[0], self.container.uuid)
+            self.pool.uuid, self.container.uuid)
         if self.compare_acl_lists(prev_acl, current_acl) != flag:
             self.fail("Previous ACL:\n{} \nPost command ACL:\n{}".format(
                 prev_acl, current_acl))

--- a/src/tests/ftest/util/daos_utils.py
+++ b/src/tests/ftest/util/daos_utils.py
@@ -70,14 +70,12 @@ class DaosCommand(DaosCommandBase):
             r"Highest Aggregated Epoch:\s+(\d+)",
     }
 
-    def pool_query(self, pool, sys_name=None, svc=None, sys=None):
+    def pool_query(self, pool, sys_name=None, sys=None):
         """Query a pool.
 
         Args:
             pool (str): pool UUID
             sys_name (str, optional): DAOS system name context for servers.
-                Defaults to None.
-            svc (str, optional): the pool service replicas, e.g. '1,2,3'.
                 Defaults to None.
             sys (str, optional): [description]. Defaults to None.
 
@@ -90,9 +88,9 @@ class DaosCommand(DaosCommandBase):
 
         """
         return self._get_result(
-            ("pool", "query"), pool=pool, sys_name=sys_name, svc=svc, sys=sys)
+            ("pool", "query"), pool=pool, sys_name=sys_name, sys=sys)
 
-    def container_create(self, pool, sys_name=None, svc=None, cont=None,
+    def container_create(self, pool, sys_name=None, cont=None,
                          path=None, cont_type=None, oclass=None,
                          chunk_size=None, properties=None, acl_file=None):
         # pylint: disable=too-many-arguments
@@ -101,8 +99,6 @@ class DaosCommand(DaosCommandBase):
         Args:
             pool (str): UUID of the pool in which to create the container
             sys_name (str, optional):  DAOS system name context for servers.
-                Defaults to None.
-            svc (str, optional): the pool service replicas, e.g. '1,2,3'.
                 Defaults to None.
             cont (str, optional): container UUID. Defaults to None.
             path (str, optional): container namespace path. Defaults to None.
@@ -125,16 +121,15 @@ class DaosCommand(DaosCommandBase):
 
         """
         return self._get_result(
-            ("container", "create"), pool=pool, sys_name=sys_name, svc=svc,
+            ("container", "create"), pool=pool, sys_name=sys_name,
             cont=cont, path=path, type=cont_type, oclass=oclass,
             chunk_size=chunk_size, properties=properties, acl_file=acl_file)
 
-    def container_destroy(self, pool, svc, cont, force=None, sys_name=None):
+    def container_destroy(self, pool, cont, force=None, sys_name=None):
         """Destroy a container.
 
         Args:
             pool (str): UUID of the pool in which to create the container
-            svc (str): the pool service replicas, e.g. '1,2,3'.
             cont (str): container UUID.
             force (bool, optional): Force the container destroy. Defaults to
                 None.
@@ -150,16 +145,15 @@ class DaosCommand(DaosCommandBase):
 
         """
         return self._get_result(
-            ("container", "destroy"), pool=pool, sys_name=sys_name, svc=svc,
+            ("container", "destroy"), pool=pool, sys_name=sys_name,
             cont=cont, force=force)
 
-    def container_get_acl(self, pool, svc, cont,
+    def container_get_acl(self, pool, cont,
                           verbose=False, outfile=None):
         """Get the ACL for a given container.
 
         Args:
             pool (str): Pool UUID
-            svc (str): Service replicas
             cont (str): Container for which to get the ACL.
             verbose (bool, optional): Verbose mode.
             outfile (str, optional): Write ACL to file.
@@ -173,15 +167,14 @@ class DaosCommand(DaosCommandBase):
 
         """
         return self._get_result(
-            ("container", "get-acl"), pool=pool, svc=svc, cont=cont,
+            ("container", "get-acl"), pool=pool, cont=cont,
             verbose=verbose, outfile=outfile)
 
-    def container_delete_acl(self, pool, svc, cont, principal):
+    def container_delete_acl(self, pool, cont, principal):
         """Delete an entry for a given principal in an existing container ACL.
 
         Args:
             pool (str): Pool UUID
-            svc (str): Service replicas
             cont (str): Container for which to get the ACL.
             principal (str): principal portion of the ACL.
 
@@ -194,15 +187,14 @@ class DaosCommand(DaosCommandBase):
 
         """
         return self._get_result(
-            ("container", "delete-acl"), pool=pool, svc=svc, cont=cont,
+            ("container", "delete-acl"), pool=pool, cont=cont,
             principal=principal)
 
-    def container_overwrite_acl(self, pool, svc, cont, acl_file):
+    def container_overwrite_acl(self, pool, cont, acl_file):
         """Overwrite the ACL for a given container.
 
         Args:
             pool (str): Pool UUID
-            svc (str): Service replicas
             cont (str): Container for which to get the ACL.
             acl_file (str): input file containing ACL
 
@@ -215,15 +207,14 @@ class DaosCommand(DaosCommandBase):
 
         """
         return self._get_result(
-            ("container", "overwrite-acl"), pool=pool, svc=svc, cont=cont,
+            ("container", "overwrite-acl"), pool=pool, cont=cont,
             acl_file=acl_file)
 
-    def container_update_acl(self, pool, svc, cont, entry=None, acl_file=None):
+    def container_update_acl(self, pool, cont, entry=None, acl_file=None):
         """Add or update the ACL entries for a given container.
 
         Args:
             pool (str): Pool UUID
-            svc (str): Service replicas
             cont (str): Container for which to get the ACL.
             entry (bool, optional): Add or modify a single ACL entry
             acl_file (str, optional): Input file containing ACL
@@ -237,16 +228,14 @@ class DaosCommand(DaosCommandBase):
 
         """
         return self._get_result(
-            ("container", "update-acl"), pool=pool, svc=svc, cont=cont,
+            ("container", "update-acl"), pool=pool, cont=cont,
             entry=entry, acl_file=acl_file)
 
-    def pool_list_cont(self, pool, svc, sys_name=None):
+    def pool_list_cont(self, pool, sys_name=None):
         """List containers in the given pool.
 
         Args:
             pool (str): Pool UUID
-            svc (str): Service replicas. If there are multiple, numbers must be
-                separated by comma like 1,2,3
             sys_name (str, optional): System name. Defaults to None.
 
         Returns:
@@ -257,7 +246,7 @@ class DaosCommand(DaosCommandBase):
 
         """
         self._get_result(
-            ("pool", "list-containers"), pool=pool, svc=svc, sys_name=sys_name)
+            ("pool", "list-containers"), pool=pool, sys_name=sys_name)
         # Sample output.
         # c8bfc7c9-cb19-4574-bae2-af4046d24b58
         # 182347e4-08ce-4069-b5e2-0dd04406dffd
@@ -266,14 +255,13 @@ class DaosCommand(DaosCommandBase):
             data["uuids"] = re.findall(r"([0-9a-f-]{36})", self.result.stdout)
         return data
 
-    def pool_set_attr(self, pool, attr, value, svc):
+    def pool_set_attr(self, pool, attr, value):
         """Set pool attribute.
 
         Args:
             pool (str): Pool UUID.
             attr (str): Attribute name.
             value (str): Attribute value
-            svc (str): Service replicas.
 
         Returns:
             CmdResult: Object that contains exit status, stdout, and other
@@ -284,15 +272,14 @@ class DaosCommand(DaosCommandBase):
 
         """
         return self._get_result(
-            ("pool", "set-attr"), pool=pool, svc=svc, attr=attr, value=value)
+            ("pool", "set-attr"), pool=pool, attr=attr, value=value)
 
-    def pool_get_attr(self, pool, attr, svc):
+    def pool_get_attr(self, pool, attr):
         """Set pool attribute.
 
         Args:
             pool (str): Pool UUID.
             attr (str): Pool UUID.
-            svc (str): Service replicas.
 
         Returns:
             CmdResult: Object that contains exit status, stdout, and other
@@ -303,14 +290,13 @@ class DaosCommand(DaosCommandBase):
 
         """
         return self._get_result(
-            ("pool", "get-attr"), pool=pool, svc=svc, attr=attr)
+            ("pool", "get-attr"), pool=pool, attr=attr)
 
-    def pool_list_attrs(self, pool, svc):
+    def pool_list_attrs(self, pool):
         """List pool attributes.
 
         Args:
             pool (str): Pool UUID.
-            svc (str): Service replicas.
 
         Returns:
             CmdResult: Object that contains exit status, stdout, and other
@@ -320,16 +306,14 @@ class DaosCommand(DaosCommandBase):
             CommandFailure: if the daos pool list-attrs command fails.
 
         """
-        return self._get_result(("pool", "list-attrs"), pool=pool, svc=svc)
+        return self._get_result(("pool", "list-attrs"), pool=pool)
 
-    def container_query(self, pool, cont, svc=None, sys_name=None):
+    def container_query(self, pool, cont, sys_name=None):
         """Query a container.
 
         Args:
             pool (str): Pool UUID.
             cont (str): Container UUID.
-            svc (str, optional): pool service replicas, e.g., '1,2,3'. Defaults
-                to None.
             sys_name (str, optional): DAOS system name context for servers.
                 Defaults to None.
 
@@ -342,10 +326,10 @@ class DaosCommand(DaosCommandBase):
 
         """
         return self._get_result(
-            ("container", "query"), pool=pool, svc=svc, cont=cont,
+            ("container", "query"), pool=pool, cont=cont,
             sys_name=sys_name)
 
-    def container_set_prop(self, pool, cont, prop, value, svc=None):
+    def container_set_prop(self, pool, cont, prop, value):
         """Call daos container set-prop.
 
         Args:
@@ -353,8 +337,6 @@ class DaosCommand(DaosCommandBase):
             cont (str): Container UUID.
             prop (str): Container property-name.
             value (str): Container property-name value to set.
-            svc (str, optional): Pool service replicas, e.g., '1,2,3'. Defaults
-                to None.
 
         Returns:
             CmdResult: Object that contains exit status, stdout, and other
@@ -367,16 +349,14 @@ class DaosCommand(DaosCommandBase):
         prop_value = ":".join([prop, value])
         return self._get_result(
             ("container", "set-prop"),
-            pool=pool, svc=svc, cont=cont, prop=prop_value)
+            pool=pool, cont=cont, prop=prop_value)
 
-    def container_get_prop(self, pool, cont, svc=None):
+    def container_get_prop(self, pool, cont):
         """Call daos container get-prop.
 
         Args:
             pool (str): Pool UUID.
             cont (str): Container UUID.
-            svc (str, optional): Pool service replicas, e.g., '1,2,3'. Defaults
-                to None.
 
         Returns:
             CmdResult: Object that contains exit status, stdout, and other
@@ -387,9 +367,9 @@ class DaosCommand(DaosCommandBase):
 
         """
         return self._get_result(
-            ("container", "get-prop"), pool=pool, svc=svc, cont=cont)
+            ("container", "get-prop"), pool=pool, cont=cont)
 
-    def container_set_owner(self, pool, cont, user, group, svc=None):
+    def container_set_owner(self, pool, cont, user, group):
         """Call daos container set-owner.
 
         Args:
@@ -397,8 +377,6 @@ class DaosCommand(DaosCommandBase):
             cont (str): Container UUID.
             user (str): New-user who will own the container.
             group (str): New-group who will own the container.
-            svc (str, optional): Pool service replicas, e.g., '1,2,3'. Defaults
-                to None.
 
         Returns:
             CmdResult: Object that contains exit status, stdout, and other
@@ -410,10 +388,10 @@ class DaosCommand(DaosCommandBase):
         """
         return self._get_result(
             ("container", "set-owner"),
-            pool=pool, svc=svc, cont=cont, user=user, group=group)
+            pool=pool, cont=cont, user=user, group=group)
 
     def container_set_attr(
-            self, pool, cont, attr, val, svc=None, sys_name=None):
+            self, pool, cont, attr, val, sys_name=None):
         """Call daos container set-attr.
 
         Args:
@@ -421,8 +399,6 @@ class DaosCommand(DaosCommandBase):
             cont (str): Container UUID.
             attr (str): Attribute name.
             val (str): Attribute value.
-            svc (str, optional): Pool service replicas, e.g., '1,2,3'. Defaults
-                to None.
             sys_name (str, optional): DAOS system name context for servers.
                 Defaults to None.
 
@@ -435,18 +411,16 @@ class DaosCommand(DaosCommandBase):
 
         """
         return self._get_result(
-            ("container", "set-attr"), pool=pool, svc=svc, cont=cont,
+            ("container", "set-attr"), pool=pool, cont=cont,
             sys_name=sys_name, attr=attr, value=val)
 
-    def container_get_attr(self, pool, cont, attr, svc=None, sys_name=None):
+    def container_get_attr(self, pool, cont, attr, sys_name=None):
         """Call daos container get-attr.
 
         Args:
             pool (str): Pool UUID.
             cont (str): Container UUID.
             attr (str): Attribute name.
-            svc (str, optional): Pool service replicas, e.g., '1,2,3'. Defaults
-                to None.
             sys_name (str, optional): DAOS system name context for servers.
                 Defaults to None.
 
@@ -459,7 +433,7 @@ class DaosCommand(DaosCommandBase):
 
         """
         self._get_result(
-            ("container", "get-attr"), pool=pool, svc=svc, cont=cont,
+            ("container", "get-attr"), pool=pool, cont=cont,
             sys_name=sys_name, attr=attr)
 
         # Sample output.
@@ -474,14 +448,12 @@ class DaosCommand(DaosCommandBase):
 
         return data
 
-    def container_list_attrs(self, pool, cont, svc=None, sys_name=None):
+    def container_list_attrs(self, pool, cont, sys_name=None):
         """Call daos container list-attrs.
 
         Args:
             pool (str): Pool UUID.
             cont (str): Container UUID.
-            svc (str, optional): Pool service replicas, e.g., '1,2,3'. Defaults
-                to None.
             sys_name (str, optional): DAOS system name context for servers.
                 Defaults to None.
 
@@ -493,7 +465,7 @@ class DaosCommand(DaosCommandBase):
 
         """
         self._get_result(
-            ("container", "list-attrs"), pool=pool, svc=svc, cont=cont,
+            ("container", "list-attrs"), pool=pool, cont=cont,
             sys_name=sys_name)
 
         # Sample output.
@@ -506,7 +478,7 @@ class DaosCommand(DaosCommandBase):
         return {"attrs": match}
 
     def container_create_snap(self, pool, cont, snap_name=None, epoch=None,
-                              svc=None, sys_name=None):
+                              sys_name=None):
         """Call daos container create-snap.
 
         Args:
@@ -514,8 +486,6 @@ class DaosCommand(DaosCommandBase):
             cont (str): Container UUID.
             snap_name (str, optional): Snapshot name. Defaults to None.
             epoch (str, optional): Epoch number. Defaults to None.
-            svc (str, optional): Pool service replicas, e.g., '1,2,3'. Defaults
-                to None.
             sys_name (str, optional): DAOS system name context for servers.
                 Defaults to None.
 
@@ -527,7 +497,7 @@ class DaosCommand(DaosCommandBase):
 
         """
         self._get_result(
-            ("container", "create-snap"), pool=pool, svc=svc, cont=cont,
+            ("container", "create-snap"), pool=pool, cont=cont,
             sys_name=sys_name, snap=snap_name, epc=epoch)
 
         # Sample create-snap output.
@@ -541,7 +511,7 @@ class DaosCommand(DaosCommandBase):
         return data
 
     def container_destroy_snap(self, pool, cont, snap_name=None, epc=None,
-                               svc=None, sys_name=None, epcrange=None):
+                               sys_name=None, epcrange=None):
         """Call daos container destroy-snap.
 
         Args:
@@ -550,8 +520,6 @@ class DaosCommand(DaosCommandBase):
             snap_name (str, optional): Snapshot name. Defaults to None.
             epc (str, optional): Epoch value of the snapshot to be destroyed.
                 Defaults to None.
-            svc (str, optional): Pool service replicas, e.g., '1,2,3'. Defaults
-                to None.
             sys_name (str, optional): DAOS system name context for servers.
                 Defaults to None.
             epcrange (str, optional): Epoch range in the format "<start>-<end>".
@@ -567,29 +535,28 @@ class DaosCommand(DaosCommandBase):
         """
         kwargs = {
             "pool": pool,
-            "svc": svc,
             "cont": cont,
             "sys_name": sys_name,
             "snap": snap_name,
             "epc": epc,
             "epcrange": epcrange
         }
+
         return self._get_result(("container", "destroy-snap"), **kwargs)
 
-    def container_list_snaps(self, pool, cont, svc=None):
+    def container_list_snaps(self, pool, cont):
         """List snapshot in a container.
 
         Args:
             pool (str): Pool UUID.
             cont (str): Container UUID.
-            svc (str): Service replicas. Defaults to None.
 
         Returns:
             dict: Dictionary that contains epoch values in key "epochs". Value
                 is a list of string.
         """
         self._get_result(
-            ("container", "list-snaps"), pool=pool, cont=cont, svc=svc)
+            ("container", "list-snaps"), pool=pool, cont=cont)
 
         # Sample container list-snaps output.
         # Container's snapshots :
@@ -600,13 +567,11 @@ class DaosCommand(DaosCommandBase):
             data["epochs"] = match
         return data
 
-    def object_query(self, pool, svc, cont, oid, sys_name=None):
+    def object_query(self, pool, cont, oid, sys_name=None):
         """Call daos object query and return its output with a dictionary.
 
         Args:
             pool (str): Pool UUID
-            svc (str): Service replicas. If there are multiple, numbers must be
-                separated by comma like 1,2,3
             cont (str): Container UUID
             oid (str): oid hi lo value in the format <hi>.<lo>
             sys_name (str, optional): System name. Defaults to None.
@@ -623,7 +588,7 @@ class DaosCommand(DaosCommandBase):
             CommandFailure: if the daos object query command fails.
         """
         self._get_result(
-            ("object", "query"), pool=pool, svc=svc, cont=cont,
+            ("object", "query"), pool=pool, cont=cont,
             oid=oid, sys_name=sys_name)
 
         # Sample daos object query output.

--- a/src/tests/ftest/util/daos_utils_base.py
+++ b/src/tests/ftest/util/daos_utils_base.py
@@ -89,7 +89,6 @@ class DaosCommandBase(CommandWithSubCommand):
                         "/run/daos/pool/{}/*".format(sub_command), sub_command)
                 self.pool = FormattedParameter("--pool={}")
                 self.sys_name = FormattedParameter("--sys-name={}")
-                self.svc = FormattedParameter("--svc={}")
                 self.sys = FormattedParameter("--sys={}")
 
         class ListContainersSubCommand(CommonPoolSubCommand):
@@ -220,7 +219,6 @@ class DaosCommandBase(CommandWithSubCommand):
                         sub_command)
                 self.pool = FormattedParameter("--pool={}")
                 self.sys_name = FormattedParameter("--sys-name={}")
-                self.svc = FormattedParameter("--svc={}")
                 self.cont = FormattedParameter("--cont={}")
                 self.path = FormattedParameter("--path={}")
 
@@ -497,7 +495,6 @@ class DaosCommandBase(CommandWithSubCommand):
                         sub_command)
                 self.pool = FormattedParameter("--pool={}")
                 self.sys_name = FormattedParameter("--sys-name={}")
-                self.svc = FormattedParameter("--svc={}")
                 self.cont = FormattedParameter("--cont={}")
                 self.oid = FormattedParameter("--oid={}")
 

--- a/src/tests/ftest/util/dfuse_utils.py
+++ b/src/tests/ftest/util/dfuse_utils.py
@@ -41,7 +41,7 @@ class DfuseCommand(ExecutableCommand):
         self.puuid = FormattedParameter("--pool {}")
         self.cuuid = FormattedParameter("--container {}")
         self.mount_dir = FormattedParameter("--mountpoint {}")
-        self.svcl = FormattedParameter("--svc {}", 0)
+        #self.svcl = FormattedParameter("--svc {}", 0)
         self.sys_name = FormattedParameter("--sys-name {}")
         self.singlethreaded = FormattedParameter("--singlethreaded", False)
         self.foreground = FormattedParameter("--foreground", False)
@@ -68,7 +68,7 @@ class DfuseCommand(ExecutableCommand):
             display (bool, optional): print updated params. Defaults to True.
         """
         self.puuid.update(pool.uuid, "puuid" if display else None)
-        self.set_dfuse_svcl_param(pool, display)
+        #self.set_dfuse_svcl_param(pool, display)
 
     def set_dfuse_svcl_param(self, pool, display=True):
         """Set the dfuse svcl param from the ranks of a DAOS pool object.

--- a/src/tests/ftest/util/macsio_util.py
+++ b/src/tests/ftest/util/macsio_util.py
@@ -467,6 +467,10 @@ class MacsioCommand(ExecutableCommand):
             "DAOS_SVCL": self.daos_svcl,
             "DAOS_CONT": self.daos_cont,
         }
+        #mapping = {
+        #    "DAOS_POOL": self.daos_pool,
+        #    "DAOS_CONT": self.daos_cont,
+        #}
         for key in mapping:
             if mapping[key]:
                 env[key] = mapping[key]

--- a/src/tests/ftest/util/mpio_test_base.py
+++ b/src/tests/ftest/util/mpio_test_base.py
@@ -71,8 +71,7 @@ class MpiioTests(TestWithServers):
         """
         cont_type = self.params.get("type", "/run/container/*")
         result = self.daos_cmd.container_create(
-            pool=self.pool.uuid, svc=self.pool.svc_ranks,
-            cont_type=cont_type)
+            pool=self.pool.uuid, cont_type=cont_type)
 
         # Extract the container UUID from the daos container create output
         cont_uuid = re.findall(

--- a/src/tests/ftest/util/mpio_utils.py
+++ b/src/tests/ftest/util/mpio_utils.py
@@ -99,7 +99,7 @@ class MpioUtils():
         # environment variables only to be set on client node
         env = EnvironmentVariables()
         env["DAOS_POOL"] = "{}".format(pool_uuid)
-        env["DAOS_SVCL"] = "{}".format(":".join([str(item) for item in svcl]))
+        env["DAOS_SVCL"] = "{}".format(",".join([str(item) for item in svcl]))
         env["DAOS_CONT"] = "{}".format(cont_uuid)
         env["DAOS_BYPASS_DUNS"] = "1"
         mpirun = os.path.join(self.mpichinstall, "bin", "mpirun")

--- a/src/tests/ftest/util/pool_security_test_base.py
+++ b/src/tests/ftest/util/pool_security_test_base.py
@@ -178,13 +178,11 @@ class PoolSecurityTestBase(TestWithServers):
         """
         if action.lower() == "write":
             result = self.set_container_attribute(self.pool_uuid,
-                                                  self.pool_svc,
                                                   self.container_uuid,
                                                   attribute,
                                                   value)
         elif action.lower() == "read":
             result = self.get_container_attribute(self.pool_uuid,
-                                                  self.pool_svc,
                                                   self.container_uuid,
                                                   attribute)
         else:
@@ -209,13 +207,11 @@ class PoolSecurityTestBase(TestWithServers):
         """
         if action.lower() == "write":
             result = self.set_container_property(self.pool_uuid,
-                                                 self.pool_svc,
                                                  self.container_uuid,
                                                  cont_property,
                                                  value)
         elif action.lower() == "read":
             result = self.get_container_property(self.pool_uuid,
-                                                 self.pool_svc,
                                                  self.container_uuid)
         else:
             self.fail(
@@ -237,7 +233,6 @@ class PoolSecurityTestBase(TestWithServers):
         """
         action = "set"
         result = self.set_container_owner(self.pool_uuid,
-                                          self.pool_svc,
                                           self.container_uuid,
                                           user,
                                           group)
@@ -259,7 +254,6 @@ class PoolSecurityTestBase(TestWithServers):
             result = self.update_container_acl(entry)
         elif action.lower() == "read":
             result = self.get_container_acl_list(self.pool_uuid,
-                                                 self.pool_svc,
                                                  self.container_uuid)
         else:
             self.fail(
@@ -307,7 +301,7 @@ class PoolSecurityTestBase(TestWithServers):
         """
         action = "cont_delete"
         result = self.test_container_destroy(
-            self.pool_uuid, self.pool_svc, self.container)
+            self.pool_uuid, self.container)
         self.log.info(
             "  In verify_cont_delete %s.\n =test_container_destroy() result:"
             "\n%s", action, result)
@@ -351,11 +345,10 @@ class PoolSecurityTestBase(TestWithServers):
                 "##setup_container_acl_and_permission, fail on "
                 "update_container_acl, expected Pass, but Failed.")
 
-    def verify_pool_readwrite(self, svc, uuid, action, expect='Pass'):
+    def verify_pool_readwrite(self, uuid, action, expect='Pass'):
         """Verify client is able to perform read or write on a pool.
 
         Args:
-            svc (int):  pool svc number.
             uuid (str): pool uuid number.
             action (str): read or write on pool.
             expect (str): expecting behavior pass or deny with RC -1001.
@@ -368,9 +361,9 @@ class PoolSecurityTestBase(TestWithServers):
         daos_cmd = DaosCommand(self.bin)
         daos_cmd.exit_status_exception = False
         if action.lower() == "write":
-            result = daos_cmd.container_create(pool=uuid, svc=svc)
+            result = daos_cmd.container_create(pool=uuid)
         elif action.lower() == "read":
-            result = daos_cmd.pool_query(pool=uuid, svc=svc)
+            result = daos_cmd.pool_query(pool=uuid)
         else:
             self.fail(
                 "##In verify_pool_readwrite, invalid action: {}".format(action))
@@ -435,8 +428,7 @@ class PoolSecurityTestBase(TestWithServers):
             secTestBase.add_del_user(self.hostlist_clients, "groupdel",
                                      groupname)
 
-    def verify_pool_acl_prim_sec_groups(self, pool_acl_list, acl_file, uuid,
-                                        svc):
+    def verify_pool_acl_prim_sec_groups(self, pool_acl_list, acl_file, uuid):
         """Verify daos pool acl access.
 
         Verify access with primary and secondary groups access permission.
@@ -445,7 +437,6 @@ class PoolSecurityTestBase(TestWithServers):
             pool_acl_list (list): pool acl entry list.
             acl_file (str): acl file to be used.
             uuid (str): daos pool uuid.
-            svc (int):  daos pool svc.
 
         Return:
             None.
@@ -504,13 +495,13 @@ class PoolSecurityTestBase(TestWithServers):
         # daos pool query --pool <uuid>
         self.log.info("  (8-6)Verify pool read by: daos pool query --pool")
         exp_read = sec_group_rw[0]
-        self.verify_pool_readwrite(svc, uuid, "read", expect=exp_read)
+        self.verify_pool_readwrite(uuid, "read", expect=exp_read)
 
         # Verify pool write operation
         # daos container create --pool <uuid>
         self.log.info("  (8-7)Verify pool write by: daos container create pool")
         exp_write = sec_group_rw[1]
-        self.verify_pool_readwrite(svc, uuid, "write", expect=exp_write)
+        self.verify_pool_readwrite(uuid, "write", expect=exp_write)
 
         for group in sec_group:
             secTestBase.add_del_user(self.hostlist_clients, "groupdel", group)
@@ -593,17 +584,17 @@ class PoolSecurityTestBase(TestWithServers):
         #    daos pool query --pool <uuid>
         self.log.info("  (7)Verify pool read by: daos pool query --pool")
         self.verify_pool_readwrite(
-            data["svc"], data["uuid"], "read", expect=read)
+            data["uuid"], "read", expect=read)
 
         # (8)Verify pool write operation
         #    daos container create --pool <uuid>
         self.log.info("  (8)Verify pool write by: daos container create --pool")
         self.verify_pool_readwrite(
-            data["svc"], data["uuid"], "write", expect=write)
+            data["uuid"], "write", expect=write)
         if secondary_grp_test:
             self.log.info("  (8-0)Verifying verify_pool_acl_prim_sec_groups")
             self.verify_pool_acl_prim_sec_groups(
-                pool_acl_list, acl_file, data["uuid"], data["svc"])
+                pool_acl_list, acl_file, data["uuid"])
 
         # (9)Cleanup user and destroy pool
         self.log.info("  (9)Cleanup users and groups")

--- a/src/tests/ftest/util/test_utils_container.py
+++ b/src/tests/ftest/util/test_utils_container.py
@@ -344,7 +344,6 @@ class TestContainer(TestDaosApiBase):
             kwargs = {
                 "pool": self.pool.uuid,
                 "sys_name": self.pool.name.value,
-                "svc": ",".join(str(rank) for rank in self.pool.svc_ranks),
                 "cont": uuid,
                 "path": self.path.value,
                 "cont_type": self.type.value,
@@ -353,6 +352,7 @@ class TestContainer(TestDaosApiBase):
                 "properties": self.properties.value,
                 "acl_file": acl_file,
             }
+
             self._log_method("daos.container_create", kwargs)
             uuid = self.daos.get_output("container_create", **kwargs)[0]
 
@@ -388,7 +388,6 @@ class TestContainer(TestDaosApiBase):
                 "cont" : self.uuid,
                 "snap_name" : snap_name,
                 "epoch" : epoch,
-                "svc" : ",".join(str(rank) for rank in self.pool.svc_ranks),
                 "sys_name": self.pool.name.value
             }
             self._log_method("daos.container_create_snap", kwargs)
@@ -426,7 +425,6 @@ class TestContainer(TestDaosApiBase):
                 "snap_name" : snap_name,
                 "epc" : epc,
                 "epcrange": epcrange,
-                "svc" : ",".join(str(rank) for rank in self.pool.svc_ranks),
                 "sys_name": self.pool.name.value,
             }
             self._log_method("daos.container_destroy_snap", kwargs)
@@ -522,8 +520,6 @@ class TestContainer(TestDaosApiBase):
                     # Destroy the container with the daos command
                     kwargs["pool"] = self.pool.uuid
                     kwargs["sys_name"] = self.pool.name.value
-                    kwargs["svc"] = ",".join(
-                        [str(item) for item in self.pool.svc_ranks])
                     kwargs["cont"] = self.uuid
                     self._log_method("daos.container_destroy", kwargs)
                     self.daos.container_destroy(**kwargs)

--- a/src/tests/ftest/util/test_utils_pool.py
+++ b/src/tests/ftest/util/test_utils_pool.py
@@ -132,12 +132,20 @@ class TestPool(TestDaosApiBase):
 
             # Convert the string of service replicas from the dmg command output
             # into an ctype array for the DaosPool object using the same
-            # technique used in DaosPool.create().
+            # technique used in DaosPool.create(). The long-term direction is
+            # to remove this parameter from DAOS tools and APIs. Leaving here
+            # for now for a gradual transition.
             service_replicas = [int(value) for value in data["svc"].split(",")]
             rank_t = ctypes.c_uint * len(service_replicas)
             rank = rank_t(*list([svc for svc in service_replicas]))
             rl_ranks = ctypes.POINTER(ctypes.c_uint)(rank)
             self.pool.svc = daos_cref.RankList(rl_ranks, len(service_replicas))
+
+            # TEMPORARY FOR TESTING
+            # svc is now optional, testing without it here. specify len 0 or
+            # specify no list at all
+            # self.pool.svc = daos_cref.RankList(rl_ranks, 0)
+            # self.pool.svc = daos_cref.RankList(None, 0)
 
             # Set UUID and attached to the DaosPool object
             self.pool.set_uuid_str(data["uuid"])
@@ -558,9 +566,13 @@ class TestPool(TestDaosApiBase):
 
         """
         self.log.info("Writing %s bytes to pool %s", size, self.uuid)
+        #env = {
+        #    "DAOS_POOL": self.uuid,
+        #    "DAOS_SVCL": "1",
+        #    "PYTHONPATH": os.getenv("PYTHONPATH", "")
+        #}
         env = {
             "DAOS_POOL": self.uuid,
-            "DAOS_SVCL": "1",
             "PYTHONPATH": os.getenv("PYTHONPATH", "")
         }
         if not load_mpi("openmpi"):

--- a/src/tests/ftest/util/vol_test_base.py
+++ b/src/tests/ftest/util/vol_test_base.py
@@ -64,7 +64,8 @@ class VolTestBase(DfuseTestBase):
 
         env = EnvironmentVariables()
         env["DAOS_POOL"] = "{}".format(self.pool.uuid)
-        env["DAOS_SVCL"] = "{}".format(self.pool.svc_ranks[0])
+        env["DAOS_SVCL"] = "{}".format(",".join([str(item) for item in
+                                                 self.pool.svc_ranks]))
         env["DAOS_CONT"] = "{}".format(self.container.uuid)
         env["HDF5_VOL_CONNECTOR"] = "daos"
         env["HDF5_PLUGIN_PATH"] = "{}".format(plugin_path)

--- a/src/tests/simple_array.c
+++ b/src/tests/simple_array.c
@@ -151,7 +151,7 @@ pool_create(void)
 			     10ULL << 30 /* target SCM size, 10G */,
 			     40ULL << 30 /* target NVMe size, 40G */,
 			     NULL /* pool props */,
-			     &svcl /* pool service nodes, used for connect */,
+			     &svcl /* pool service nodes */,
 			     pool_uuid /* the uuid of the pool created */);
 	ASSERT(rc == 0, "pool create failed with %d", rc);
 }
@@ -487,7 +487,7 @@ main(int argc, char **argv)
 		pool_create();
 
 		/** connect to the just created DAOS pool */
-		rc = daos_pool_connect(pool_uuid, DSS_PSETID, &svcl,
+		rc = daos_pool_connect(pool_uuid, DSS_PSETID, NULL /* svc */,
 				       DAOS_PC_EX /* exclusive access */,
 				       &poh /* returned pool handle */,
 				       NULL /* returned pool info */,

--- a/src/tests/simple_array.c
+++ b/src/tests/simple_array.c
@@ -487,7 +487,7 @@ main(int argc, char **argv)
 		pool_create();
 
 		/** connect to the just created DAOS pool */
-		rc = daos_pool_connect(pool_uuid, DSS_PSETID, NULL /* svc */,
+		rc = daos_pool_connect(pool_uuid, DSS_PSETID,
 				       DAOS_PC_EX /* exclusive access */,
 				       &poh /* returned pool handle */,
 				       NULL /* returned pool info */,

--- a/src/tests/simple_obj.c
+++ b/src/tests/simple_obj.c
@@ -694,7 +694,6 @@ int
 main(int argc, char **argv)
 {
 	uuid_t		pool_uuid, co_uuid;
-	d_rank_list_t	*svcl = NULL;
 	int		rc;
 
 	rc = MPI_Init(&argc, &argv);
@@ -706,8 +705,8 @@ main(int argc, char **argv)
 	rc = gethostname(node, sizeof(node));
 	ASSERT(rc == 0, "buffer for hostname too small");
 
-	if (argc != 3) {
-		fprintf(stderr, "args: pool svcl\n");
+	if (argc != 2) {
+		fprintf(stderr, "args: pool\n");
 		exit(1);
 	}
 
@@ -719,13 +718,9 @@ main(int argc, char **argv)
 	rc = uuid_parse(argv[1], pool_uuid);
 	ASSERT(rc == 0, "Failed to parse 'Pool uuid': %s", argv[1]);
 
-	svcl = daos_rank_list_parse(argv[2], ":");
-	if (svcl == NULL)
-		ASSERT(svcl != NULL, "Failed to allocate svcl");
-
 	/** Call connect on rank 0 only and broadcast handle to others */
 	if (rank == 0) {
-		rc = daos_pool_connect(pool_uuid, NULL, svcl, DAOS_PC_RW, &poh,
+		rc = daos_pool_connect(pool_uuid, NULL, NULL, DAOS_PC_RW, &poh,
 				       NULL, NULL);
 		ASSERT(rc == 0, "pool connect failed with %d", rc);
 	}
@@ -736,7 +731,7 @@ main(int argc, char **argv)
 	 * Create and open container on rank 0 and share the handle.
 	 *
 	 * Alternatively, one could create the container outside of this program
-	 * using the daos utility: daos cont create --pool=puuid --svc=svclist
+	 * using the daos utility: daos cont create --pool=puuid
 	 * and pass the uuid to the app.
 	 */
 	if (rank == 0) {

--- a/src/tests/simple_obj.c
+++ b/src/tests/simple_obj.c
@@ -720,7 +720,7 @@ main(int argc, char **argv)
 
 	/** Call connect on rank 0 only and broadcast handle to others */
 	if (rank == 0) {
-		rc = daos_pool_connect(pool_uuid, NULL, NULL, DAOS_PC_RW, &poh,
+		rc = daos_pool_connect(pool_uuid, NULL, DAOS_PC_RW, &poh,
 				       NULL, NULL);
 		ASSERT(rc == 0, "pool connect failed with %d", rc);
 	}

--- a/src/tests/suite/daos_capa.c
+++ b/src/tests/suite/daos_capa.c
@@ -71,7 +71,7 @@ query(void **state)
 
 	/** connect to the pool */
 	rc = daos_pool_connect(arg->pool.pool_uuid, arg->group,
-			       arg->pool.svc, DAOS_PC_RW, &poh,
+			       NULL /* arg->pool.svc */, DAOS_PC_RW, &poh,
 			       NULL /* info */,
 			       NULL /* ev */);
 	assert_int_equal(rc, 0);
@@ -108,7 +108,7 @@ create(void **state)
 
 	/** connect to the pool in read-only mode */
 	rc = daos_pool_connect(arg->pool.pool_uuid, arg->group,
-			       arg->pool.svc, DAOS_PC_RO, &poh,
+			       NULL /* arg->pool.svc */, DAOS_PC_RO, &poh,
 			       NULL /* info */,
 			       NULL /* ev */);
 	assert_int_equal(rc, 0);
@@ -125,7 +125,7 @@ create(void **state)
 
 	/** connect to the pool in read-write mode */
 	rc = daos_pool_connect(arg->pool.pool_uuid, arg->group,
-			       arg->pool.svc, DAOS_PC_RW, &poh,
+			       NULL /* arg->pool.svc */, DAOS_PC_RW, &poh,
 			       NULL /* info */,
 			       NULL /* ev */);
 	assert_int_equal(rc, 0);
@@ -158,7 +158,7 @@ destroy(void **state)
 
 	/** connect to the pool in read-write mode */
 	rc = daos_pool_connect(arg->pool.pool_uuid, arg->group,
-			       arg->pool.svc, DAOS_PC_RW, &poh,
+			       NULL /* arg->pool.svc */, DAOS_PC_RW, &poh,
 			       NULL /* info */,
 			       NULL /* ev */);
 	assert_int_equal(rc, 0);
@@ -182,7 +182,7 @@ destroy(void **state)
 
 	/** connect to the pool in read-only mode */
 	rc = daos_pool_connect(arg->pool.pool_uuid, arg->group,
-			       arg->pool.svc, DAOS_PC_RO, &poh,
+			       NULL /* arg->pool.svc */, DAOS_PC_RO, &poh,
 			       NULL /* info */,
 			       NULL /* ev */);
 	assert_int_equal(rc, 0);
@@ -198,7 +198,7 @@ destroy(void **state)
 
 	/** connect to the pool in read-write mode */
 	rc = daos_pool_connect(arg->pool.pool_uuid, arg->group,
-			       arg->pool.svc, DAOS_PC_RW, &poh,
+			       NULL /* arg->pool.svc */, DAOS_PC_RW, &poh,
 			       NULL /* info */,
 			       NULL /* ev */);
 	assert_int_equal(rc, 0);
@@ -228,7 +228,7 @@ open(void **state)
 
 	/** connect to the pool in read-write mode */
 	rc = daos_pool_connect(arg->pool.pool_uuid, arg->group,
-			       arg->pool.svc, DAOS_PC_RW, &poh,
+			       NULL /* arg->pool.svc */, DAOS_PC_RW, &poh,
 			       NULL /* info */,
 			       NULL /* ev */);
 	assert_int_equal(rc, 0);
@@ -247,7 +247,7 @@ open(void **state)
 
 	/** reconnect to the pool in read-only mode */
 	rc = daos_pool_connect(arg->pool.pool_uuid, arg->group,
-			       arg->pool.svc, DAOS_PC_RO, &poh,
+			       NULL /* arg->pool.svc */, DAOS_PC_RO, &poh,
 			       NULL /* info */,
 			       NULL /* ev */);
 	assert_int_equal(rc, 0);
@@ -300,7 +300,7 @@ io_invalid_poh(void **state)
 	if (arg->myrank == 0) {
 		/** connect to the pool in read-write mode */
 		rc = daos_pool_connect(arg->pool.pool_uuid, arg->group,
-				       arg->pool.svc, DAOS_PC_RW, &poh,
+				       NULL, DAOS_PC_RW, &poh,
 				       NULL /* info */,
 				       NULL /* ev */);
 		assert_int_equal(rc, 0);

--- a/src/tests/suite/daos_capa.c
+++ b/src/tests/suite/daos_capa.c
@@ -71,7 +71,7 @@ query(void **state)
 
 	/** connect to the pool */
 	rc = daos_pool_connect(arg->pool.pool_uuid, arg->group,
-			       NULL /* arg->pool.svc */, DAOS_PC_RW, &poh,
+			       DAOS_PC_RW, &poh,
 			       NULL /* info */,
 			       NULL /* ev */);
 	assert_int_equal(rc, 0);
@@ -108,7 +108,7 @@ create(void **state)
 
 	/** connect to the pool in read-only mode */
 	rc = daos_pool_connect(arg->pool.pool_uuid, arg->group,
-			       NULL /* arg->pool.svc */, DAOS_PC_RO, &poh,
+			       DAOS_PC_RO, &poh,
 			       NULL /* info */,
 			       NULL /* ev */);
 	assert_int_equal(rc, 0);
@@ -125,7 +125,7 @@ create(void **state)
 
 	/** connect to the pool in read-write mode */
 	rc = daos_pool_connect(arg->pool.pool_uuid, arg->group,
-			       NULL /* arg->pool.svc */, DAOS_PC_RW, &poh,
+			       DAOS_PC_RW, &poh,
 			       NULL /* info */,
 			       NULL /* ev */);
 	assert_int_equal(rc, 0);
@@ -158,7 +158,7 @@ destroy(void **state)
 
 	/** connect to the pool in read-write mode */
 	rc = daos_pool_connect(arg->pool.pool_uuid, arg->group,
-			       NULL /* arg->pool.svc */, DAOS_PC_RW, &poh,
+			       DAOS_PC_RW, &poh,
 			       NULL /* info */,
 			       NULL /* ev */);
 	assert_int_equal(rc, 0);
@@ -182,7 +182,7 @@ destroy(void **state)
 
 	/** connect to the pool in read-only mode */
 	rc = daos_pool_connect(arg->pool.pool_uuid, arg->group,
-			       NULL /* arg->pool.svc */, DAOS_PC_RO, &poh,
+			       DAOS_PC_RO, &poh,
 			       NULL /* info */,
 			       NULL /* ev */);
 	assert_int_equal(rc, 0);
@@ -198,7 +198,7 @@ destroy(void **state)
 
 	/** connect to the pool in read-write mode */
 	rc = daos_pool_connect(arg->pool.pool_uuid, arg->group,
-			       NULL /* arg->pool.svc */, DAOS_PC_RW, &poh,
+			       DAOS_PC_RW, &poh,
 			       NULL /* info */,
 			       NULL /* ev */);
 	assert_int_equal(rc, 0);
@@ -228,7 +228,7 @@ open(void **state)
 
 	/** connect to the pool in read-write mode */
 	rc = daos_pool_connect(arg->pool.pool_uuid, arg->group,
-			       NULL /* arg->pool.svc */, DAOS_PC_RW, &poh,
+			       DAOS_PC_RW, &poh,
 			       NULL /* info */,
 			       NULL /* ev */);
 	assert_int_equal(rc, 0);
@@ -247,7 +247,7 @@ open(void **state)
 
 	/** reconnect to the pool in read-only mode */
 	rc = daos_pool_connect(arg->pool.pool_uuid, arg->group,
-			       NULL /* arg->pool.svc */, DAOS_PC_RO, &poh,
+			       DAOS_PC_RO, &poh,
 			       NULL /* info */,
 			       NULL /* ev */);
 	assert_int_equal(rc, 0);
@@ -300,7 +300,7 @@ io_invalid_poh(void **state)
 	if (arg->myrank == 0) {
 		/** connect to the pool in read-write mode */
 		rc = daos_pool_connect(arg->pool.pool_uuid, arg->group,
-				       NULL, DAOS_PC_RW, &poh,
+				       DAOS_PC_RW, &poh,
 				       NULL /* info */,
 				       NULL /* ev */);
 		assert_int_equal(rc, 0);

--- a/src/tests/suite/daos_checksum.c
+++ b/src/tests/suite/daos_checksum.c
@@ -1785,7 +1785,7 @@ rebuild_test(void **state, int chunksize, int data_len_bytes, int iod_type)
 	print_message("Excluding rank %d\n", rank_to_exclude);
 	disabled_nr = disabled_targets(arg);
 	daos_exclude_server(arg->pool.pool_uuid, arg->group,
-			    arg->dmg_config, NULL /* arg->pool.alive_svc */,
+			    arg->dmg_config,
 			    layout1->ol_shards[0]->os_ranks[0]);
 	assert_true(disabled_nr < disabled_targets(arg));
 
@@ -1813,7 +1813,7 @@ rebuild_test(void **state, int chunksize, int data_len_bytes, int iod_type)
 	assert_success(rc);
 
 	daos_reint_server(arg->pool.pool_uuid, arg->group, arg->dmg_config,
-			  NULL /* arg->pool.alive_svc */, rank_to_exclude);
+			  rank_to_exclude);
 	assert_int_equal(disabled_nr, disabled_targets(arg));
 	/** wait for rebuild */
 	test_rebuild_wait(&arg, 1);

--- a/src/tests/suite/daos_checksum.c
+++ b/src/tests/suite/daos_checksum.c
@@ -1785,7 +1785,7 @@ rebuild_test(void **state, int chunksize, int data_len_bytes, int iod_type)
 	print_message("Excluding rank %d\n", rank_to_exclude);
 	disabled_nr = disabled_targets(arg);
 	daos_exclude_server(arg->pool.pool_uuid, arg->group,
-			    arg->dmg_config, arg->pool.alive_svc,
+			    arg->dmg_config, NULL /* arg->pool.alive_svc */,
 			    layout1->ol_shards[0]->os_ranks[0]);
 	assert_true(disabled_nr < disabled_targets(arg));
 
@@ -1813,7 +1813,7 @@ rebuild_test(void **state, int chunksize, int data_len_bytes, int iod_type)
 	assert_success(rc);
 
 	daos_reint_server(arg->pool.pool_uuid, arg->group, arg->dmg_config,
-			  arg->pool.alive_svc, rank_to_exclude);
+			  NULL /* arg->pool.alive_svc */, rank_to_exclude);
 	assert_int_equal(disabled_nr, disabled_targets(arg));
 	/** wait for rebuild */
 	test_rebuild_wait(&arg, 1);

--- a/src/tests/suite/daos_epoch_io.c
+++ b/src/tests/suite/daos_epoch_io.c
@@ -361,7 +361,7 @@ daos_test_cb_add(test_arg_t *arg, struct test_op_record *op,
 	print_message("add rank %u\n", op->ae_arg.ua_rank);
 	test_rebuild_wait(&arg, 1);
 	daos_reint_server(arg->pool.pool_uuid, arg->group, arg->dmg_config,
-			  arg->pool.svc, op->ae_arg.ua_rank);
+			  NULL /* arg->pool.svc */, op->ae_arg.ua_rank);
 	return 0;
 }
 
@@ -372,13 +372,13 @@ daos_test_cb_exclude(test_arg_t *arg, struct test_op_record *op,
 	if (op->ae_arg.ua_tgt == -1) {
 		print_message("exclude rank %u\n", op->ae_arg.ua_rank);
 		daos_exclude_server(arg->pool.pool_uuid, arg->group,
-				    arg->dmg_config, arg->pool.svc,
+				    arg->dmg_config, NULL /* arg->pool.svc */,
 				    op->ae_arg.ua_rank);
 	} else {
 		print_message("exclude rank %u target %d\n",
 			       op->ae_arg.ua_rank, op->ae_arg.ua_tgt);
 		daos_exclude_target(arg->pool.pool_uuid, arg->group,
-				    arg->dmg_config, arg->pool.svc,
+				    arg->dmg_config, NULL /* arg->pool.svc */,
 				    op->ae_arg.ua_rank, op->ae_arg.ua_tgt);
 	}
 	return 0;

--- a/src/tests/suite/daos_epoch_io.c
+++ b/src/tests/suite/daos_epoch_io.c
@@ -361,7 +361,7 @@ daos_test_cb_add(test_arg_t *arg, struct test_op_record *op,
 	print_message("add rank %u\n", op->ae_arg.ua_rank);
 	test_rebuild_wait(&arg, 1);
 	daos_reint_server(arg->pool.pool_uuid, arg->group, arg->dmg_config,
-			  NULL /* arg->pool.svc */, op->ae_arg.ua_rank);
+			  op->ae_arg.ua_rank);
 	return 0;
 }
 
@@ -372,13 +372,13 @@ daos_test_cb_exclude(test_arg_t *arg, struct test_op_record *op,
 	if (op->ae_arg.ua_tgt == -1) {
 		print_message("exclude rank %u\n", op->ae_arg.ua_rank);
 		daos_exclude_server(arg->pool.pool_uuid, arg->group,
-				    arg->dmg_config, NULL /* arg->pool.svc */,
+				    arg->dmg_config,
 				    op->ae_arg.ua_rank);
 	} else {
 		print_message("exclude rank %u target %d\n",
 			       op->ae_arg.ua_rank, op->ae_arg.ua_tgt);
 		daos_exclude_target(arg->pool.pool_uuid, arg->group,
-				    arg->dmg_config, NULL /* arg->pool.svc */,
+				    arg->dmg_config,
 				    op->ae_arg.ua_rank, op->ae_arg.ua_tgt);
 	}
 	return 0;

--- a/src/tests/suite/daos_epoch_recovery.c
+++ b/src/tests/suite/daos_epoch_recovery.c
@@ -145,7 +145,7 @@ epoch_recovery(test_arg_t *arg, enum epoch_recovery_op op)
 		if (arg->myrank == 0) {
 			print_message("evicting pool connections\n");
 			rc = daos_pool_evict(arg->pool.pool_uuid, arg->group,
-					     arg->pool.svc, NULL /* ev */);
+					     NULL /* svc */, NULL /* ev */);
 			assert_int_equal(rc, 0);
 		}
 		MPI_Barrier(MPI_COMM_WORLD);
@@ -164,7 +164,7 @@ epoch_recovery(test_arg_t *arg, enum epoch_recovery_op op)
 		print_message("reconnecting to pool\n");
 		if (arg->myrank == 0) {
 			rc = daos_pool_connect(arg->pool.pool_uuid, arg->group,
-					       arg->pool.svc, DAOS_PC_RW,
+					       NULL /* svc */, DAOS_PC_RW,
 					       &arg->pool.poh, NULL /* info */,
 					       NULL /* ev */);
 			assert_int_equal(rc, 0);

--- a/src/tests/suite/daos_epoch_recovery.c
+++ b/src/tests/suite/daos_epoch_recovery.c
@@ -145,7 +145,7 @@ epoch_recovery(test_arg_t *arg, enum epoch_recovery_op op)
 		if (arg->myrank == 0) {
 			print_message("evicting pool connections\n");
 			rc = daos_pool_evict(arg->pool.pool_uuid, arg->group,
-					     NULL /* svc */, NULL /* ev */);
+					     NULL /* ev */);
 			assert_int_equal(rc, 0);
 		}
 		MPI_Barrier(MPI_COMM_WORLD);
@@ -164,7 +164,7 @@ epoch_recovery(test_arg_t *arg, enum epoch_recovery_op op)
 		print_message("reconnecting to pool\n");
 		if (arg->myrank == 0) {
 			rc = daos_pool_connect(arg->pool.pool_uuid, arg->group,
-					       NULL /* svc */, DAOS_PC_RW,
+					       DAOS_PC_RW,
 					       &arg->pool.poh, NULL /* info */,
 					       NULL /* ev */);
 			assert_int_equal(rc, 0);

--- a/src/tests/suite/daos_md_replication.c
+++ b/src/tests/suite/daos_md_replication.c
@@ -66,7 +66,7 @@ mdr_stop_pool_svc(void **argv)
 	/* Connect to the pool. */
 	if (arg->myrank == 0) {
 		print_message("connecting to pool\n");
-		rc = daos_pool_connect(uuid, arg->group, arg->pool.svc,
+		rc = daos_pool_connect(uuid, arg->group, NULL /* svc */,
 				       DAOS_PC_RW, &poh, NULL /* info */,
 				       NULL /* ev */);
 	}
@@ -150,7 +150,7 @@ mdr_stop_cont_svc(void **argv)
 	}
 
 	print_message("connecting to pool\n");
-	rc = daos_pool_connect(pool_uuid, arg->group, arg->pool.svc,
+	rc = daos_pool_connect(pool_uuid, arg->group, NULL /* svc */,
 			       DAOS_PC_RW, &poh, NULL, NULL /* ev */);
 	assert_int_equal(rc, 0);
 	print_message("creating container\n");

--- a/src/tests/suite/daos_md_replication.c
+++ b/src/tests/suite/daos_md_replication.c
@@ -66,7 +66,7 @@ mdr_stop_pool_svc(void **argv)
 	/* Connect to the pool. */
 	if (arg->myrank == 0) {
 		print_message("connecting to pool\n");
-		rc = daos_pool_connect(uuid, arg->group, NULL /* svc */,
+		rc = daos_pool_connect(uuid, arg->group,
 				       DAOS_PC_RW, &poh, NULL /* info */,
 				       NULL /* ev */);
 	}
@@ -150,7 +150,7 @@ mdr_stop_cont_svc(void **argv)
 	}
 
 	print_message("connecting to pool\n");
-	rc = daos_pool_connect(pool_uuid, arg->group, NULL /* svc */,
+	rc = daos_pool_connect(pool_uuid, arg->group,
 			       DAOS_PC_RW, &poh, NULL, NULL /* ev */);
 	assert_int_equal(rc, 0);
 	print_message("creating container\n");

--- a/src/tests/suite/daos_obj.c
+++ b/src/tests/suite/daos_obj.c
@@ -3082,7 +3082,7 @@ tgt_idx_change_retry(void **state)
 		/** exclude target of the replica */
 		print_message("rank 0 excluding target rank %u ...\n", rank);
 		daos_exclude_server(arg->pool.pool_uuid, arg->group,
-				    arg->dmg_config, NULL /* svc */, rank);
+				    arg->dmg_config, rank);
 		assert_int_equal(rc, 0);
 
 		/** progress the async IO (not must) */
@@ -3139,8 +3139,7 @@ tgt_idx_change_retry(void **state)
 	if (arg->myrank == 0) {
 		print_message("rank 0 adding target rank %u ...\n", rank);
 		daos_reint_server(arg->pool.pool_uuid, arg->group,
-				  arg->dmg_config, NULL /* svc */,
-				  rank);
+				  arg->dmg_config, rank);
 	}
 	MPI_Barrier(MPI_COMM_WORLD);
 	ioreq_fini(&req);
@@ -3177,7 +3176,7 @@ fetch_replica_unavail(void **state)
 	if (arg->myrank == 0) {
 		/** exclude the target of this obj's replicas */
 		daos_exclude_server(arg->pool.pool_uuid, arg->group,
-				    arg->dmg_config, arg->pool.svc, rank);
+				    arg->dmg_config, rank);
 	}
 	MPI_Barrier(MPI_COMM_WORLD);
 
@@ -3195,8 +3194,7 @@ fetch_replica_unavail(void **state)
 
 		/* add back the excluded targets */
 		daos_reint_server(arg->pool.pool_uuid, arg->group,
-				  arg->dmg_config, NULL /* svc */,
-				  rank);
+				  arg->dmg_config, rank);
 
 		/* wait until reintegration is done */
 		test_rebuild_wait(&arg, 1);

--- a/src/tests/suite/daos_obj.c
+++ b/src/tests/suite/daos_obj.c
@@ -3082,7 +3082,7 @@ tgt_idx_change_retry(void **state)
 		/** exclude target of the replica */
 		print_message("rank 0 excluding target rank %u ...\n", rank);
 		daos_exclude_server(arg->pool.pool_uuid, arg->group,
-				    arg->dmg_config, arg->pool.svc, rank);
+				    arg->dmg_config, NULL /* svc */, rank);
 		assert_int_equal(rc, 0);
 
 		/** progress the async IO (not must) */
@@ -3139,7 +3139,7 @@ tgt_idx_change_retry(void **state)
 	if (arg->myrank == 0) {
 		print_message("rank 0 adding target rank %u ...\n", rank);
 		daos_reint_server(arg->pool.pool_uuid, arg->group,
-				  arg->dmg_config, arg->pool.svc,
+				  arg->dmg_config, NULL /* svc */,
 				  rank);
 	}
 	MPI_Barrier(MPI_COMM_WORLD);
@@ -3195,7 +3195,7 @@ fetch_replica_unavail(void **state)
 
 		/* add back the excluded targets */
 		daos_reint_server(arg->pool.pool_uuid, arg->group,
-				  arg->dmg_config, arg->pool.svc,
+				  arg->dmg_config, NULL /* svc */,
 				  rank);
 
 		/* wait until reintegration is done */

--- a/src/tests/suite/daos_oid_alloc.c
+++ b/src/tests/suite/daos_oid_alloc.c
@@ -45,7 +45,7 @@ reconnect(test_arg_t *arg) {
 	flags = (DAOS_COO_RW | DAOS_COO_FORCE);
 	if (arg->myrank == 0) {
 		rc = daos_pool_connect(arg->pool.pool_uuid, arg->group,
-				       NULL /* svc */, DAOS_PC_RW,
+				       DAOS_PC_RW,
 				       &arg->pool.poh, &arg->pool.pool_info,
 				       NULL /* ev */);
 		if (rc)

--- a/src/tests/suite/daos_oid_alloc.c
+++ b/src/tests/suite/daos_oid_alloc.c
@@ -45,7 +45,7 @@ reconnect(test_arg_t *arg) {
 	flags = (DAOS_COO_RW | DAOS_COO_FORCE);
 	if (arg->myrank == 0) {
 		rc = daos_pool_connect(arg->pool.pool_uuid, arg->group,
-				       arg->pool.svc, DAOS_PC_RW,
+				       NULL /* svc */, DAOS_PC_RW,
 				       &arg->pool.poh, &arg->pool.pool_info,
 				       NULL /* ev */);
 		if (rc)

--- a/src/tests/suite/daos_pool.c
+++ b/src/tests/suite/daos_pool.c
@@ -44,7 +44,7 @@ pool_connect_nonexist(void **state)
 
 	/* Contact pool service replicas as returned by pool create */
 	uuid_generate(uuid);
-	rc = daos_pool_connect(uuid, arg->group, NULL /* svc */, DAOS_PC_RW,
+	rc = daos_pool_connect(uuid, arg->group, DAOS_PC_RW,
 			       &poh, NULL /* info */, NULL /* ev */);
 	assert_int_equal(rc, -DER_NONEXIST);
 }
@@ -72,7 +72,7 @@ pool_connect(void **state)
 		print_message("rank 0 connecting to pool %ssynchronously ... ",
 			      arg->async ? "a" : "");
 		rc = daos_pool_connect(arg->pool.pool_uuid, arg->group,
-				       NULL /* svc */, DAOS_PC_RW, &poh, &info,
+				       DAOS_PC_RW, &poh, &info,
 				       arg->async ? &ev : NULL /* ev */);
 		assert_int_equal(rc, 0);
 		WAIT_ON_ASYNC(arg, ev);
@@ -128,12 +128,12 @@ pool_connect_exclusively(void **state)
 	print_message("SUBTEST 1: other connections already exist; shall get "
 		      "%d\n", -DER_BUSY);
 	print_message("establishing a non-exclusive connection\n");
-	rc = daos_pool_connect(arg->pool.pool_uuid, arg->group, NULL /* svc */,
+	rc = daos_pool_connect(arg->pool.pool_uuid, arg->group,
 			       DAOS_PC_RW, &poh, NULL /* info */,
 			       NULL /* ev */);
 	assert_int_equal(rc, 0);
 	print_message("trying to establish an exclusive connection\n");
-	rc = daos_pool_connect(arg->pool.pool_uuid, arg->group, NULL /* svc */,
+	rc = daos_pool_connect(arg->pool.pool_uuid, arg->group,
 			       DAOS_PC_EX, &poh_ex, NULL /* info */,
 			       NULL /* ev */);
 	assert_int_equal(rc, -DER_BUSY);
@@ -143,7 +143,7 @@ pool_connect_exclusively(void **state)
 
 	print_message("SUBTEST 2: no other connections; shall succeed\n");
 	print_message("establishing an exclusive connection\n");
-	rc = daos_pool_connect(arg->pool.pool_uuid, arg->group, NULL /* svc */,
+	rc = daos_pool_connect(arg->pool.pool_uuid, arg->group,
 			       DAOS_PC_EX, &poh_ex, NULL /* info */,
 			       NULL /* ev */);
 	assert_int_equal(rc, 0);
@@ -151,7 +151,7 @@ pool_connect_exclusively(void **state)
 	print_message("SUBTEST 3: shall prevent other connections (%d)\n",
 		      -DER_BUSY);
 	print_message("trying to establish a non-exclusive connection\n");
-	rc = daos_pool_connect(arg->pool.pool_uuid, arg->group, NULL /* svc */,
+	rc = daos_pool_connect(arg->pool.pool_uuid, arg->group,
 			       DAOS_PC_RW, &poh, NULL /* info */,
 			       NULL /* ev */);
 	assert_int_equal(rc, -DER_BUSY);
@@ -191,7 +191,7 @@ pool_exclude(void **state)
 	/** connect to pool */
 	print_message("rank 0 connecting to pool %ssynchronously... ",
 		      arg->async ? "a" : "");
-	rc = daos_pool_connect(arg->pool.pool_uuid, arg->group, NULL /* svc */,
+	rc = daos_pool_connect(arg->pool.pool_uuid, arg->group,
 			       DAOS_PC_RW, &poh, &info,
 			       arg->async ? &ev : NULL /* ev */);
 	assert_int_equal(rc, 0);
@@ -207,7 +207,7 @@ pool_exclude(void **state)
 	print_message("rank 0 excluding rank %u... ", rank);
 	for (idx = 0; idx < arg->pool.svc->rl_nr; idx++) {
 		daos_exclude_target(arg->pool.pool_uuid, arg->group,
-				    arg->dmg_config, NULL /* svc */,
+				    arg->dmg_config,
 				    arg->pool.svc->rl_ranks[idx], tgt);
 	}
 	WAIT_ON_ASYNC(arg, ev);
@@ -388,7 +388,7 @@ init_fini_conn(void **state)
 	assert_int_equal(rc, 0);
 
 	rc = daos_pool_connect(arg->pool.pool_uuid, arg->group,
-			       NULL /* svc */, DAOS_PC_RW,
+			       DAOS_PC_RW,
 			       &arg->pool.poh, &arg->pool.pool_info,
 			       NULL /* ev */);
 	if (rc)
@@ -604,7 +604,7 @@ pool_op_retry(void **state)
 
 	print_message("connecting to pool ... ");
 	rc = daos_pool_connect(arg->pool.pool_uuid, arg->group,
-			       NULL /* svc */, DAOS_PC_RW, &poh, &info,
+			       DAOS_PC_RW, &poh, &info,
 			       NULL /* ev */);
 	assert_int_equal(rc, 0);
 	assert_memory_equal(info.pi_uuid, arg->pool.pool_uuid,
@@ -703,7 +703,7 @@ setup_containers(void **state, daos_size_t nconts)
 	/* TODO: make test_setup_pool_connect() more generic, call here */
 	if (arg->myrank == 0) {
 		rc = daos_pool_connect(lcarg->tpool.pool_uuid, arg->group,
-				       NULL /* svc */, DAOS_PC_RW,
+				       DAOS_PC_RW,
 				       &lcarg->tpool.poh, NULL /* pool info */,
 				       NULL /* ev */);
 		if (rc != 0)

--- a/src/tests/suite/daos_pool.c
+++ b/src/tests/suite/daos_pool.c
@@ -42,8 +42,9 @@ pool_connect_nonexist(void **state)
 	if (arg->myrank != 0)
 		return;
 
+	/* Contact pool service replicas as returned by pool create */
 	uuid_generate(uuid);
-	rc = daos_pool_connect(uuid, arg->group, arg->pool.svc, DAOS_PC_RW,
+	rc = daos_pool_connect(uuid, arg->group, NULL /* svc */, DAOS_PC_RW,
 			       &poh, NULL /* info */, NULL /* ev */);
 	assert_int_equal(rc, -DER_NONEXIST);
 }
@@ -71,7 +72,7 @@ pool_connect(void **state)
 		print_message("rank 0 connecting to pool %ssynchronously ... ",
 			      arg->async ? "a" : "");
 		rc = daos_pool_connect(arg->pool.pool_uuid, arg->group,
-				       arg->pool.svc, DAOS_PC_RW, &poh, &info,
+				       NULL /* svc */, DAOS_PC_RW, &poh, &info,
 				       arg->async ? &ev : NULL /* ev */);
 		assert_int_equal(rc, 0);
 		WAIT_ON_ASYNC(arg, ev);
@@ -101,6 +102,8 @@ pool_connect(void **state)
 	rc = daos_pool_disconnect(poh, arg->async ? &ev : NULL /* ev */);
 	assert_int_equal(rc, 0);
 	WAIT_ON_ASYNC(arg, ev);
+	print_message("success\n");
+
 	if (arg->async) {
 		rc = daos_event_fini(&ev);
 		assert_int_equal(rc, 0);
@@ -125,12 +128,12 @@ pool_connect_exclusively(void **state)
 	print_message("SUBTEST 1: other connections already exist; shall get "
 		      "%d\n", -DER_BUSY);
 	print_message("establishing a non-exclusive connection\n");
-	rc = daos_pool_connect(arg->pool.pool_uuid, arg->group, arg->pool.svc,
+	rc = daos_pool_connect(arg->pool.pool_uuid, arg->group, NULL /* svc */,
 			       DAOS_PC_RW, &poh, NULL /* info */,
 			       NULL /* ev */);
 	assert_int_equal(rc, 0);
 	print_message("trying to establish an exclusive connection\n");
-	rc = daos_pool_connect(arg->pool.pool_uuid, arg->group, arg->pool.svc,
+	rc = daos_pool_connect(arg->pool.pool_uuid, arg->group, NULL /* svc */,
 			       DAOS_PC_EX, &poh_ex, NULL /* info */,
 			       NULL /* ev */);
 	assert_int_equal(rc, -DER_BUSY);
@@ -140,7 +143,7 @@ pool_connect_exclusively(void **state)
 
 	print_message("SUBTEST 2: no other connections; shall succeed\n");
 	print_message("establishing an exclusive connection\n");
-	rc = daos_pool_connect(arg->pool.pool_uuid, arg->group, arg->pool.svc,
+	rc = daos_pool_connect(arg->pool.pool_uuid, arg->group, NULL /* svc */,
 			       DAOS_PC_EX, &poh_ex, NULL /* info */,
 			       NULL /* ev */);
 	assert_int_equal(rc, 0);
@@ -148,7 +151,7 @@ pool_connect_exclusively(void **state)
 	print_message("SUBTEST 3: shall prevent other connections (%d)\n",
 		      -DER_BUSY);
 	print_message("trying to establish a non-exclusive connection\n");
-	rc = daos_pool_connect(arg->pool.pool_uuid, arg->group, arg->pool.svc,
+	rc = daos_pool_connect(arg->pool.pool_uuid, arg->group, NULL /* svc */,
 			       DAOS_PC_RW, &poh, NULL /* info */,
 			       NULL /* ev */);
 	assert_int_equal(rc, -DER_BUSY);
@@ -188,7 +191,7 @@ pool_exclude(void **state)
 	/** connect to pool */
 	print_message("rank 0 connecting to pool %ssynchronously... ",
 		      arg->async ? "a" : "");
-	rc = daos_pool_connect(arg->pool.pool_uuid, arg->group, arg->pool.svc,
+	rc = daos_pool_connect(arg->pool.pool_uuid, arg->group, NULL /* svc */,
 			       DAOS_PC_RW, &poh, &info,
 			       arg->async ? &ev : NULL /* ev */);
 	assert_int_equal(rc, 0);
@@ -204,7 +207,7 @@ pool_exclude(void **state)
 	print_message("rank 0 excluding rank %u... ", rank);
 	for (idx = 0; idx < arg->pool.svc->rl_nr; idx++) {
 		daos_exclude_target(arg->pool.pool_uuid, arg->group,
-				    arg->dmg_config, arg->pool.svc,
+				    arg->dmg_config, NULL /* svc */,
 				    arg->pool.svc->rl_ranks[idx], tgt);
 	}
 	WAIT_ON_ASYNC(arg, ev);
@@ -385,7 +388,7 @@ init_fini_conn(void **state)
 	assert_int_equal(rc, 0);
 
 	rc = daos_pool_connect(arg->pool.pool_uuid, arg->group,
-			       arg->pool.svc, DAOS_PC_RW,
+			       NULL /* svc */, DAOS_PC_RW,
 			       &arg->pool.poh, &arg->pool.pool_info,
 			       NULL /* ev */);
 	if (rc)
@@ -601,7 +604,7 @@ pool_op_retry(void **state)
 
 	print_message("connecting to pool ... ");
 	rc = daos_pool_connect(arg->pool.pool_uuid, arg->group,
-			       arg->pool.svc, DAOS_PC_RW, &poh, &info,
+			       NULL /* svc */, DAOS_PC_RW, &poh, &info,
 			       NULL /* ev */);
 	assert_int_equal(rc, 0);
 	assert_memory_equal(info.pi_uuid, arg->pool.pool_uuid,
@@ -700,7 +703,7 @@ setup_containers(void **state, daos_size_t nconts)
 	/* TODO: make test_setup_pool_connect() more generic, call here */
 	if (arg->myrank == 0) {
 		rc = daos_pool_connect(lcarg->tpool.pool_uuid, arg->group,
-				       lcarg->tpool.svc, DAOS_PC_RW,
+				       NULL /* svc */, DAOS_PC_RW,
 				       &lcarg->tpool.poh, NULL /* pool info */,
 				       NULL /* ev */);
 		if (rc != 0)

--- a/src/tests/suite/daos_rebuild.c
+++ b/src/tests/suite/daos_rebuild.c
@@ -922,7 +922,6 @@ rebuild_multiple_tgts(void **state)
 				daos_exclude_server(arg->pool.pool_uuid,
 						    arg->group,
 						    arg->dmg_config,
-						    NULL /* svc */,
 						    rank);
 				if (++fail_cnt >= 2)
 					break;
@@ -948,7 +947,7 @@ rebuild_multiple_tgts(void **state)
 	if (arg->myrank == 0) {
 		for (i = 0; i < 2; i++)
 			daos_reint_server(arg->pool.pool_uuid, arg->group,
-					  arg->dmg_config, arg->pool.svc,
+					  arg->dmg_config,
 					  exclude_ranks[i]);
 	}
 	MPI_Barrier(MPI_COMM_WORLD);

--- a/src/tests/suite/daos_rebuild.c
+++ b/src/tests/suite/daos_rebuild.c
@@ -922,7 +922,7 @@ rebuild_multiple_tgts(void **state)
 				daos_exclude_server(arg->pool.pool_uuid,
 						    arg->group,
 						    arg->dmg_config,
-						    arg->pool.svc,
+						    NULL /* svc */,
 						    rank);
 				if (++fail_cnt >= 2)
 					break;

--- a/src/tests/suite/daos_rebuild_common.c
+++ b/src/tests/suite/daos_rebuild_common.c
@@ -65,7 +65,7 @@ rebuild_exclude_tgt(test_arg_t **args, int arg_cnt, d_rank_t rank,
 	for (i = 0; i < arg_cnt; i++) {
 		daos_exclude_target(args[i]->pool.pool_uuid,
 				    args[i]->group, args[i]->dmg_config,
-				    args[i]->pool.svc,
+				    NULL /* svc */,
 				    rank, tgt_idx);
 	}
 }
@@ -81,7 +81,7 @@ rebuild_add_tgt(test_arg_t **args, int args_cnt, d_rank_t rank,
 			daos_reint_target(args[i]->pool.pool_uuid,
 					  args[i]->group,
 					  args[i]->dmg_config,
-					  args[i]->pool.svc,
+					  NULL /* svc */,
 					  rank, tgt_idx);
 		sleep(2);
 	}
@@ -98,7 +98,7 @@ rebuild_drain_tgt(test_arg_t **args, int args_cnt, d_rank_t rank,
 			daos_drain_target(args[i]->pool.pool_uuid,
 					args[i]->group,
 					args[i]->dmg_config,
-					args[i]->pool.svc,
+					NULL /* svc */,
 					rank, tgt_idx);
 		sleep(2);
 	}
@@ -242,7 +242,7 @@ rebuild_pool_connect_internal(void *data)
 	MPI_Barrier(MPI_COMM_WORLD);
 	if (arg->myrank == 0) {
 		rc = daos_pool_connect(arg->pool.pool_uuid, arg->group,
-				       arg->pool.svc, DAOS_PC_RW,
+				       NULL /* svc */, DAOS_PC_RW,
 				       &arg->pool.poh, &arg->pool.pool_info,
 				       NULL /* ev */);
 		if (rc)
@@ -362,7 +362,7 @@ rebuild_add_back_tgts(test_arg_t *arg, d_rank_t failed_rank, int *failed_tgts,
 
 		for (i = 0; i < nr; i++)
 			daos_reint_target(arg->pool.pool_uuid, arg->group,
-					  arg->dmg_config, arg->pool.svc,
+					  arg->dmg_config, NULL /* svc */,
 					  failed_rank,
 					  failed_tgts ? failed_tgts[i] : -1);
 	}

--- a/src/tests/suite/daos_rebuild_common.c
+++ b/src/tests/suite/daos_rebuild_common.c
@@ -65,7 +65,6 @@ rebuild_exclude_tgt(test_arg_t **args, int arg_cnt, d_rank_t rank,
 	for (i = 0; i < arg_cnt; i++) {
 		daos_exclude_target(args[i]->pool.pool_uuid,
 				    args[i]->group, args[i]->dmg_config,
-				    NULL /* svc */,
 				    rank, tgt_idx);
 	}
 }
@@ -81,7 +80,6 @@ rebuild_add_tgt(test_arg_t **args, int args_cnt, d_rank_t rank,
 			daos_reint_target(args[i]->pool.pool_uuid,
 					  args[i]->group,
 					  args[i]->dmg_config,
-					  NULL /* svc */,
 					  rank, tgt_idx);
 		sleep(2);
 	}
@@ -98,7 +96,6 @@ rebuild_drain_tgt(test_arg_t **args, int args_cnt, d_rank_t rank,
 			daos_drain_target(args[i]->pool.pool_uuid,
 					args[i]->group,
 					args[i]->dmg_config,
-					NULL /* svc */,
 					rank, tgt_idx);
 		sleep(2);
 	}
@@ -242,7 +239,7 @@ rebuild_pool_connect_internal(void *data)
 	MPI_Barrier(MPI_COMM_WORLD);
 	if (arg->myrank == 0) {
 		rc = daos_pool_connect(arg->pool.pool_uuid, arg->group,
-				       NULL /* svc */, DAOS_PC_RW,
+				       DAOS_PC_RW,
 				       &arg->pool.poh, &arg->pool.pool_info,
 				       NULL /* ev */);
 		if (rc)
@@ -362,7 +359,7 @@ rebuild_add_back_tgts(test_arg_t *arg, d_rank_t failed_rank, int *failed_tgts,
 
 		for (i = 0; i < nr; i++)
 			daos_reint_target(arg->pool.pool_uuid, arg->group,
-					  arg->dmg_config, NULL /* svc */,
+					  arg->dmg_config,
 					  failed_rank,
 					  failed_tgts ? failed_tgts[i] : -1);
 	}

--- a/src/tests/suite/daos_rebuild_simple.c
+++ b/src/tests/suite/daos_rebuild_simple.c
@@ -666,14 +666,14 @@ rebuild_sx_object(void **state)
 	get_killing_rank_by_oid(arg, oid, 1, 0, &rank, &rank_nr);
 	/** exclude the target of this obj's replicas */
 	daos_exclude_server(arg->pool.pool_uuid, arg->group,
-			    arg->dmg_config, arg->pool.svc, rank);
+			    arg->dmg_config, rank);
 
 	/* wait until rebuild done */
 	test_rebuild_wait(&arg, 1);
 
 	/* add back the excluded targets */
 	daos_reint_server(arg->pool.pool_uuid, arg->group,
-			  arg->dmg_config, arg->pool.svc, rank);
+			  arg->dmg_config, rank);
 
 	/* wait until reintegration is done */
 	test_rebuild_wait(&arg, 1);

--- a/src/tests/suite/daos_test.h
+++ b/src/tests/suite/daos_test.h
@@ -359,19 +359,19 @@ int test_get_leader(test_arg_t *arg, d_rank_t *rank);
 bool test_rebuild_query(test_arg_t **args, int args_cnt);
 void test_rebuild_wait(test_arg_t **args, int args_cnt);
 void daos_exclude_target(const uuid_t pool_uuid, const char *grp,
-			 const char *dmg_config, const d_rank_list_t *svc,
+			 const char *dmg_config,
 			 d_rank_t rank, int tgt);
 void daos_reint_target(const uuid_t pool_uuid, const char *grp,
-		       const char *dmg_config, const d_rank_list_t *svc,
+		       const char *dmg_config,
 		       d_rank_t rank, int tgt);
 void daos_drain_target(const uuid_t pool_uuid, const char *grp,
-		       const char *dmg_config, const d_rank_list_t *svc,
+		       const char *dmg_config,
 		       d_rank_t rank, int tgt);
 void daos_exclude_server(const uuid_t pool_uuid, const char *grp,
-			 const char *dmg_config, const d_rank_list_t *svc,
+			 const char *dmg_config,
 			 d_rank_t rank);
 void daos_reint_server(const uuid_t pool_uuid, const char *grp,
-		       const char *dmg_config, const d_rank_list_t *svc,
+		       const char *dmg_config,
 		       d_rank_t rank);
 
 void

--- a/src/tests/suite/daos_test_common.c
+++ b/src/tests/suite/daos_test_common.c
@@ -167,7 +167,7 @@ test_setup_pool_connect(void **state, struct test_pool *pool)
 
 		print_message("setup: connecting to pool\n");
 		rc = daos_pool_connect(arg->pool.pool_uuid, arg->group,
-				       arg->pool.svc,
+				       NULL /* arg->pool.svc */,
 				       arg->pool.pool_connect_flags,
 				       &arg->pool.poh, &arg->pool.pool_info,
 				       NULL /* ev */);
@@ -396,7 +396,7 @@ pool_destroy_safe(test_arg_t *arg, struct test_pool *extpool)
 
 	if (daos_handle_is_inval(poh)) {
 		rc = daos_pool_connect(pool->pool_uuid, arg->group,
-				       pool->svc, DAOS_PC_RW,
+				       NULL /* svc */, DAOS_PC_RW,
 				       &poh, &pool->pool_info,
 				       NULL /* ev */);
 		if (rc != 0) { /* destroy straight away */
@@ -637,7 +637,7 @@ test_pool_get_info(test_arg_t *arg, daos_pool_info_t *pinfo)
 
 	if (daos_handle_is_inval(arg->pool.poh)) {
 		rc = daos_pool_connect(arg->pool.pool_uuid, arg->group,
-				       arg->pool.svc, DAOS_PC_RW,
+				       NULL /* svc */, DAOS_PC_RW,
 				       &arg->pool.poh, pinfo,
 				       NULL /* ev */);
 		if (rc) {

--- a/src/tests/suite/daos_test_common.c
+++ b/src/tests/suite/daos_test_common.c
@@ -167,7 +167,6 @@ test_setup_pool_connect(void **state, struct test_pool *pool)
 
 		print_message("setup: connecting to pool\n");
 		rc = daos_pool_connect(arg->pool.pool_uuid, arg->group,
-				       NULL /* arg->pool.svc */,
 				       arg->pool.pool_connect_flags,
 				       &arg->pool.poh, &arg->pool.pool_info,
 				       NULL /* ev */);
@@ -396,7 +395,7 @@ pool_destroy_safe(test_arg_t *arg, struct test_pool *extpool)
 
 	if (daos_handle_is_inval(poh)) {
 		rc = daos_pool_connect(pool->pool_uuid, arg->group,
-				       NULL /* svc */, DAOS_PC_RW,
+				       DAOS_PC_RW,
 				       &poh, &pool->pool_info,
 				       NULL /* ev */);
 		if (rc != 0) { /* destroy straight away */
@@ -637,7 +636,7 @@ test_pool_get_info(test_arg_t *arg, daos_pool_info_t *pinfo)
 
 	if (daos_handle_is_inval(arg->pool.poh)) {
 		rc = daos_pool_connect(arg->pool.pool_uuid, arg->group,
-				       NULL /* svc */, DAOS_PC_RW,
+				       DAOS_PC_RW,
 				       &arg->pool.poh, pinfo,
 				       NULL /* ev */);
 		if (rc) {
@@ -837,7 +836,7 @@ run_daos_sub_tests(char *test_name, const struct CMUnitTest *tests,
 static void
 daos_dmg_pool_target(const char *sub_cmd, const uuid_t pool_uuid,
 		     const char *grp, const char *dmg_config,
-		     const d_rank_list_t *svc, d_rank_t rank, int tgt_idx)
+		     d_rank_t rank, int tgt_idx)
 {
 	char		dmg_cmd[DTS_CFG_MAX];
 	int		rc;
@@ -858,46 +857,42 @@ daos_dmg_pool_target(const char *sub_cmd, const uuid_t pool_uuid,
 
 void
 daos_exclude_target(const uuid_t pool_uuid, const char *grp,
-		    const char *dmg_config, const d_rank_list_t *svc,
+		    const char *dmg_config,
 		    d_rank_t rank, int tgt_idx)
 {
-	daos_dmg_pool_target("exclude", pool_uuid, grp, dmg_config, svc,
+	daos_dmg_pool_target("exclude", pool_uuid, grp, dmg_config,
 			     rank, tgt_idx);
 }
 
 void
 daos_reint_target(const uuid_t pool_uuid, const char *grp,
-		  const char *dmg_config, const d_rank_list_t *svc,
-		  d_rank_t rank, int tgt_idx)
+		  const char *dmg_config, d_rank_t rank, int tgt_idx)
 {
-	daos_dmg_pool_target("reintegrate", pool_uuid, grp, dmg_config, svc,
+	daos_dmg_pool_target("reintegrate", pool_uuid, grp, dmg_config,
 			     rank, tgt_idx);
 }
 
 void
 daos_drain_target(const uuid_t pool_uuid, const char *grp,
-		  const char *dmg_config, const d_rank_list_t *svc,
-		  d_rank_t rank, int tgt_idx)
+		  const char *dmg_config, d_rank_t rank, int tgt_idx)
 {
 
-	daos_dmg_pool_target("drain", pool_uuid, grp, dmg_config, svc,
+	daos_dmg_pool_target("drain", pool_uuid, grp, dmg_config,
 			     rank, tgt_idx);
 }
 
 void
 daos_exclude_server(const uuid_t pool_uuid, const char *grp,
-		    const char *dmg_config, const d_rank_list_t *svc,
-		    d_rank_t rank)
+		    const char *dmg_config, d_rank_t rank)
 {
-	daos_exclude_target(pool_uuid, grp, dmg_config, svc, rank, -1);
+	daos_exclude_target(pool_uuid, grp, dmg_config, rank, -1);
 }
 
 void
 daos_reint_server(const uuid_t pool_uuid, const char *grp,
-		  const char *dmg_config, const d_rank_list_t *svc,
-		  d_rank_t rank)
+		  const char *dmg_config, d_rank_t rank)
 {
-	daos_reint_target(pool_uuid, grp, dmg_config, svc, rank, -1);
+	daos_reint_target(pool_uuid, grp, dmg_config, rank, -1);
 }
 
 void

--- a/src/utils/daos.c
+++ b/src/utils/daos.c
@@ -810,7 +810,9 @@ common_op_parse_hdlr(int argc, char *argv[], struct cmd_args_s *ap)
 		D_GOTO(out_free, rc = RC_NO_HELP);
 	}
 
-	/* Verify pool svc provided */
+	/* Verify pool svc argument. If not provided pass NULL list to libdaos,
+	 * and client will query management service for rank list.
+	 */
 	ARGS_VERIFY_MDSRV(ap, out_free, rc = RC_PRINT_HELP);
 
 	D_FREE(cmdname);

--- a/src/utils/daos.c
+++ b/src/utils/daos.c
@@ -154,10 +154,6 @@ cmd_args_print(struct cmd_args_s *ap)
 	D_INFO("\tpool UUID: "DF_UUIDF"\n", DP_UUID(ap->p_uuid));
 	D_INFO("\tcont UUID: "DF_UUIDF"\n", DP_UUID(ap->c_uuid));
 
-	D_INFO("\tpool svc: parsed %u ranks from input %s\n",
-		ap->mdsrv ? ap->mdsrv->rl_nr : 0,
-		ap->mdsrv_str ? ap->mdsrv_str : "NULL");
-
 	D_INFO("\tattr: name=%s, value=%s\n",
 		ap->attrname_str ? ap->attrname_str : "NULL",
 		ap->value_str ? ap->value_str : "NULL");
@@ -531,7 +527,6 @@ common_op_parse_hdlr(int argc, char *argv[], struct cmd_args_s *ap)
 	struct option		options[] = {
 		{"sys-name",	required_argument,	NULL,	'G'},
 		{"pool",	required_argument,	NULL,	'p'},
-		{"svc",		required_argument,	NULL,	'm'},
 		{"cont",	required_argument,	NULL,	'c'},
 		{"attr",	required_argument,	NULL,	'a'},
 		{"value",	required_argument,	NULL,	'v'},
@@ -630,13 +625,6 @@ common_op_parse_hdlr(int argc, char *argv[], struct cmd_args_s *ap)
 				D_GOTO(out_free, rc = RC_NO_HELP);
 			}
 			break;
-		case 'm':
-			D_STRNDUP(ap->mdsrv_str, optarg, strlen(optarg));
-			if (ap->mdsrv_str == NULL)
-				D_GOTO(out_free, rc = RC_NO_HELP);
-			ap->mdsrv = daos_rank_list_parse(ap->mdsrv_str, ",");
-			break;
-
 		case 'a':
 			if (ap->attrname_str != NULL) {
 				fprintf(stderr,
@@ -810,20 +798,12 @@ common_op_parse_hdlr(int argc, char *argv[], struct cmd_args_s *ap)
 		D_GOTO(out_free, rc = RC_NO_HELP);
 	}
 
-	/* Verify pool svc argument. If not provided pass NULL list to libdaos,
-	 * and client will query management service for rank list.
-	 */
-	ARGS_VERIFY_MDSRV(ap, out_free, rc = RC_PRINT_HELP);
-
 	D_FREE(cmdname);
 	return 0;
 
 out_free:
-	d_rank_list_free(ap->mdsrv);
 	if (ap->sysname != NULL)
 		D_FREE(ap->sysname);
-	if (ap->mdsrv_str != NULL)
-		D_FREE(ap->mdsrv_str);
 	if (ap->attrname_str != NULL)
 		D_FREE(ap->attrname_str);
 	if (ap->value_str != NULL)
@@ -979,7 +959,7 @@ cont_op_hdlr(struct cmd_args_s *ap)
 		ARGS_VERIFY_PUUID(ap, out, rc = RC_PRINT_HELP);
 	}
 
-	rc = daos_pool_connect(ap->p_uuid, ap->sysname, ap->mdsrv,
+	rc = daos_pool_connect(ap->p_uuid, ap->sysname,
 			       DAOS_PC_RW, &ap->pool,
 			       NULL /* info */, NULL /* ev */);
 	if (rc != 0) {
@@ -1133,7 +1113,7 @@ obj_op_hdlr(struct cmd_args_s *ap)
 
 	/* TODO: support container lookup by path? */
 
-	rc = daos_pool_connect(ap->p_uuid, ap->sysname, ap->mdsrv,
+	rc = daos_pool_connect(ap->p_uuid, ap->sysname,
 			       DAOS_PC_RW, &ap->pool,
 			       NULL /* info */, NULL /* ev */);
 	if (rc != 0) {
@@ -1261,8 +1241,8 @@ do { \
 do { \
 	fprintf(stream, \
 	"container options (query, and all commands except create):\n" \
-	"	  <pool options>   with --cont use: (--pool, --sys-name, --svc)\n" \
-	"	  <pool options>   with --path use: (--sys-name, --svc)\n" \
+	"	  <pool options>   with --cont use: (--pool, --sys-name)\n" \
+	"	  <pool options>   with --path use: (--sys-name)\n" \
 	"	--cont=UUID        (mandatory, or use --path)\n" \
 	"	--path=PATHSTR     (mandatory, or use --cont)\n"); \
 } while (0)
@@ -1297,7 +1277,6 @@ help_hdlr(int argc, char *argv[], struct cmd_args_s *ap)
 		"	--pool=UUID        pool UUID\n"
 		"	--sys-name=STR     DAOS system name context for servers (\"%s\")\n"
 		"	--sys=STR\n"
-		"	--svc=RANKS        pool service replicas like 1,2,3\n"
 		"	--attr=NAME        pool attribute name to get, set, del\n"
 		"	--value=VALUESTR   pool attribute name to set\n",
 			default_sysname);
@@ -1309,10 +1288,10 @@ help_hdlr(int argc, char *argv[], struct cmd_args_s *ap)
 		} else if (strcmp(argv[3], "create") == 0) {
 			fprintf(stream,
 			"container options (create by UUID):\n"
-			"	  <pool options>   (--pool, --sys-name, --svc)\n"
+			"	  <pool options>   (--pool, --sys-name)\n"
 			"	--cont=UUID        (optional) container UUID (or generated)\n"
 			"container options (create and link to namespace path):\n"
-			"	  <pool/cont opts> (--pool, --sys-name, --svc, --cont [optional])\n"
+			"	  <pool/cont opts> (--pool, --sys-name, --cont [optional])\n"
 			"	--path=PATHSTR     container namespace path\n"
 			"container create common optional options:\n"
 			"	--type=CTYPESTR    container type (HDF5, POSIX)\n"
@@ -1420,7 +1399,7 @@ help_hdlr(int argc, char *argv[], struct cmd_args_s *ap)
 
 		fprintf(stream,
 		"object (obj) options:\n"
-		"	  <pool options>   (--pool, --sys-name, --svc)\n"
+		"	  <pool options>   (--pool, --sys-name)\n"
 		"	  <cont options>   (--cont)\n"
 		"	--oid=HI.LO        object ID\n");
 
@@ -1489,10 +1468,6 @@ main(int argc, char *argv[])
 	/* Call resource-specific handler function */
 	rc = hdlr(&dargs);
 
-	/* Clean up dargs.mdsrv allocated in common_op_parse_hdlr() */
-	d_rank_list_free(dargs.mdsrv);
-
-	D_FREE(dargs.mdsrv_str);
 	D_FREE(dargs.sysname);
 	D_FREE(dargs.path);
 

--- a/src/utils/daos_hdlr.c
+++ b/src/utils/daos_hdlr.c
@@ -164,7 +164,7 @@ pool_get_prop_hdlr(struct cmd_args_s *ap)
 	assert(ap->p_op == POOL_GET_PROP);
 
 	rc = daos_pool_connect(ap->p_uuid, ap->sysname,
-			       ap->mdsrv, DAOS_PC_RO, &ap->pool,
+			       DAOS_PC_RO, &ap->pool,
 			       NULL /* info */, NULL /* ev */);
 	if (rc != 0) {
 		fprintf(stderr, "failed to connect to pool "DF_UUIDF
@@ -219,7 +219,7 @@ pool_set_attr_hdlr(struct cmd_args_s *ap)
 	}
 
 	rc = daos_pool_connect(ap->p_uuid, ap->sysname,
-			       ap->mdsrv, DAOS_PC_RW, &ap->pool,
+			       DAOS_PC_RW, &ap->pool,
 			       NULL /* info */, NULL /* ev */);
 	if (rc != 0) {
 		fprintf(stderr, "failed to connect to pool "DF_UUIDF
@@ -269,7 +269,7 @@ pool_del_attr_hdlr(struct cmd_args_s *ap)
 	}
 
 	rc = daos_pool_connect(ap->p_uuid, ap->sysname,
-			       ap->mdsrv, DAOS_PC_RW, &ap->pool,
+			       DAOS_PC_RW, &ap->pool,
 			       NULL /* info */, NULL /* ev */);
 	if (rc != 0) {
 		fprintf(stderr, "failed to connect to pool "DF_UUIDF
@@ -318,7 +318,7 @@ pool_get_attr_hdlr(struct cmd_args_s *ap)
 	}
 
 	rc = daos_pool_connect(ap->p_uuid, ap->sysname,
-			       ap->mdsrv, DAOS_PC_RO, &ap->pool,
+			       DAOS_PC_RO, &ap->pool,
 			       NULL /* info */, NULL /* ev */);
 	if (rc != 0) {
 		fprintf(stderr, "failed to connect to pool "DF_UUIDF
@@ -394,7 +394,7 @@ pool_list_attrs_hdlr(struct cmd_args_s *ap)
 	assert(ap->p_op == POOL_LIST_ATTRS);
 
 	rc = daos_pool_connect(ap->p_uuid, ap->sysname,
-			       ap->mdsrv, DAOS_PC_RO, &ap->pool,
+			       DAOS_PC_RO, &ap->pool,
 			       NULL /* info */, NULL /* ev */);
 	if (rc != 0) {
 		fprintf(stderr, "failed to connect to pool "DF_UUIDF
@@ -474,7 +474,7 @@ pool_list_containers_hdlr(struct cmd_args_s *ap)
 	assert(ap->p_op == POOL_LIST_CONTAINERS);
 
 	rc = daos_pool_connect(ap->p_uuid, ap->sysname,
-			       ap->mdsrv, DAOS_PC_RO, &ap->pool,
+			       DAOS_PC_RO, &ap->pool,
 			       NULL /* info */, NULL /* ev */);
 	if (rc != 0) {
 		fprintf(stderr, "failed to connect to pool "DF_UUIDF
@@ -555,7 +555,7 @@ pool_query_hdlr(struct cmd_args_s *ap)
 	assert(ap->p_op == POOL_QUERY);
 
 	rc = daos_pool_connect(ap->p_uuid, ap->sysname,
-			       ap->mdsrv, DAOS_PC_RO, &ap->pool,
+			       DAOS_PC_RO, &ap->pool,
 			       NULL /* info */, NULL /* ev */);
 	if (rc != 0) {
 		fprintf(stderr, "failed to connect to pool "DF_UUIDF

--- a/src/utils/daos_hdlr.h
+++ b/src/utils/daos_hdlr.h
@@ -74,8 +74,6 @@ struct cmd_args_s {
 	daos_handle_t		pool;
 	uuid_t			c_uuid;		/* --cont */
 	daos_handle_t		cont;
-	char			*mdsrv_str;	/* --svc */
-	d_rank_list_t		*mdsrv;
 	int			force;		/* --force */
 	char			*attrname_str;	/* --attr attribute name */
 	char			*value_str;	/* --value attribute value */
@@ -111,20 +109,6 @@ struct cmd_args_s {
 			fprintf(stderr, "pool UUID required\n");\
 			D_GOTO(label, (rcexpr));		\
 		}						\
-	} while (0)
-
-/* --svc argument is optional. If provided by user, perform these checks */
-#define ARGS_VERIFY_MDSRV(ap, label, rcexpr)				\
-	do {								\
-		if (((ap)->mdsrv_str) && ((ap)->mdsrv == NULL)) {	\
-			fprintf(stderr, "failed to parse --svc=%s\n",	\
-					(ap)->mdsrv_str);		\
-			D_GOTO(label, (rcexpr));			\
-		}							\
-		if (((ap)->mdsrv) && ((ap)->mdsrv->rl_nr == 0)) {	\
-			fprintf(stderr, "--svc must not be empty\n");	\
-			D_GOTO(label, (rcexpr));			\
-		}							\
 	} while (0)
 
 #define ARGS_VERIFY_CUUID(ap, label, rcexpr)				\

--- a/src/utils/daos_hdlr.h
+++ b/src/utils/daos_hdlr.h
@@ -113,18 +113,15 @@ struct cmd_args_s {
 		}						\
 	} while (0)
 
+/* --svc argument is optional. If provided by user, perform these checks */
 #define ARGS_VERIFY_MDSRV(ap, label, rcexpr)				\
 	do {								\
-		if ((ap)->mdsrv_str == NULL) {				\
-			fprintf(stderr, "--svc must be specified\n");	\
-			D_GOTO(label, (rcexpr));			\
-		}							\
-		if ((ap)->mdsrv == NULL) {				\
+		if (((ap)->mdsrv_str) && ((ap)->mdsrv == NULL)) {	\
 			fprintf(stderr, "failed to parse --svc=%s\n",	\
 					(ap)->mdsrv_str);		\
 			D_GOTO(label, (rcexpr));			\
 		}							\
-		if ((ap)->mdsrv->rl_nr == 0) {				\
+		if (((ap)->mdsrv) && ((ap)->mdsrv->rl_nr == 0)) {	\
 			fprintf(stderr, "--svc must not be empty\n");	\
 			D_GOTO(label, (rcexpr));			\
 		}							\

--- a/utils/node_local_test.py
+++ b/utils/node_local_test.py
@@ -819,12 +819,12 @@ def run_daos_cmd(conf, cmd, valgrind=True, fi_file=None, fi_valgrind=False):
 
 def show_cont(conf, pool):
     """Create a container and return a container list"""
-    cmd = ['container', 'create', '--svc', '0', '--pool', pool]
+    cmd = ['container', 'create', '--pool', pool]
     rc = run_daos_cmd(conf, cmd)
     assert rc.returncode == 0
     print('rc is {}'.format(rc))
 
-    cmd = ['pool', 'list-containers', '--svc', '0', '--pool', pool]
+    cmd = ['pool', 'list-containers', '--pool', pool]
     rc = run_daos_cmd(conf, cmd)
     print('rc is {}'.format(rc))
     assert rc.returncode == 0
@@ -975,7 +975,7 @@ def create_and_read_via_il(dfuse, path):
 def run_container_query(conf, path):
     """Query a path to extract container information"""
 
-    cmd = ['container', 'query', '--svc', '0', '--path', path]
+    cmd = ['container', 'query', '--path', path]
 
     rc = run_daos_cmd(conf, cmd)
 
@@ -1003,8 +1003,6 @@ def run_duns_overlay_test(server, conf):
 
     rc = run_daos_cmd(conf, ['container',
                              'create',
-                             '--svc',
-                             '0',
                              '--pool',
                              pools[0],
                              '--type',
@@ -1094,7 +1092,7 @@ def run_dfuse(server, conf):
 
     uns_container = str(uuid.uuid4())
 
-    cmd = ['container', 'create', '--svc', '0',
+    cmd = ['container', 'create',
            '--pool', pools[0], '--cont', uns_container, '--path', uns_path,
            '--type', 'POSIX']
 
@@ -1126,7 +1124,7 @@ def run_dfuse(server, conf):
     uns_container = str(uuid.uuid4())
 
     # Make a link within the new container.
-    cmd = ['container', 'create', '--svc', '0',
+    cmd = ['container', 'create',
            '--pool', pools[0], '--cont', uns_container,
            '--path', uns_path, '--type', 'POSIX']
 
@@ -1258,12 +1256,12 @@ def run_in_fg(server, conf):
     t_dir = os.path.join(dfuse.dir, container)
     os.mkdir(t_dir)
     print('Running at {}'.format(t_dir))
-    print('daos container create --svc 0 --type POSIX' \
+    print('daos container create --type POSIX' \
           '--pool {} --path {}/uns-link'.format(
               pools[0], t_dir))
     print('cd {}/uns-link'.format(t_dir))
-    print('daos container destroy --svc 0 --path {}/uns-link'.format(t_dir))
-    print('daos pool list-containers --svc 0 --pool {}'.format(pools[0]))
+    print('daos container destroy --path {}/uns-link'.format(t_dir))
+    print('daos pool list-containers --pool {}'.format(pools[0]))
     try:
         dfuse.wait_for_exit()
     except KeyboardInterrupt:
@@ -1351,7 +1349,7 @@ def test_alloc_fail(server, conf):
 
     pool = pools[0]
 
-    cmd = ['pool', 'list-containers', '--svc', '0', '--pool', pool]
+    cmd = ['pool', 'list-containers', '--pool', pool]
 
     fid = 1
 
@@ -1452,7 +1450,7 @@ def main():
         server.start()
         pools = get_pool_list()
         for pool in pools:
-            cmd = ['pool', 'list-containers', '--svc', '0', '--pool', pool]
+            cmd = ['pool', 'list-containers', '--pool', pool]
             run_daos_cmd(conf, cmd, valgrind=False)
         if server.stop() != 0:
             fatal_errors.add_result(True)


### PR DESCRIPTION
With this large change the libdaos C API is updated to no longer
accept pool service replica rank lists libdaos instead will query
the management service to retrieve the pool service ranks for the
specified pool UUID. This is a follow-up patch to a previous
change that made the rank list optional.

Some notable areas of the code base modified in this change:

The daos user-level admin utility no longer accepts --svc=.
dfuse does not accept --svcl.
All calls to affected libdaos APIs e.g., daos_pool_connect(),
daos_pool_evict() have been modified to not pass a svc list.
(TODO) ior, mdtest, hdf5 tests will be modified to no longer be
run with dfs.svcl / DAOS_SVCL inputs. Several coordinated
PRs in the respective separate projects will be landed to align
with this libdaos API update.

(TODO) mechanisms to update the libdaos API version and
daos packaging versions are included in this change.

Signed-off-by: Kenneth Cain <kenneth.c.cain@intel.com>