### PR TITLE
DAOS-6077 swim: fault injection into SWIM

### DIFF
--- a/src/cart/crt_swim.c
+++ b/src/cart/crt_swim.c
@@ -26,10 +26,22 @@
 #define D_LOGFAC	DD_FAC(swim)
 #define CRT_USE_GURT_FAC
 
+#include <ctype.h>
 #include "crt_internal.h"
 #include "swim/swim_internal.h"
 
 #define CRT_OPC_SWIM_VERSION	0
+#define CRT_SWIM_FAIL_BASE	((CRT_OPC_SWIM_PROTO >> 16) | \
+				 (CRT_OPC_SWIM_VERSION << 4))
+#define CRT_SWIM_FAIL_DROP_RPC	(CRT_SWIM_FAIL_BASE | 0x1)
+
+/**
+ * use this macro to determine if a fault should be injected at
+ * a specific place
+ */
+#define CRT_SWIM_SHOULD_FAIL(fa, id)				\
+	(crt_swim_should_fail && (crt_swim_fail_id == id) &&	\
+	 D_SHOULD_FAIL(fa))
 
 #define crt_proc_swim_id_t	crt_proc_uint64_t
 
@@ -55,7 +67,40 @@ CRT_RPC_DEFINE(crt_rpc_swim,  CRT_ISEQ_RPC_SWIM, /* empty */)
 CRT_RPC_DECLARE(crt_rpc_swim_wack, CRT_ISEQ_RPC_SWIM, CRT_OSEQ_RPC_SWIM)
 CRT_RPC_DEFINE(crt_rpc_swim_wack,  CRT_ISEQ_RPC_SWIM, CRT_OSEQ_RPC_SWIM)
 
-uint32_t crt_swim_rpc_timeout;
+uint32_t	 crt_swim_rpc_timeout;
+static bool	 crt_swim_should_fail;
+static uint64_t	 crt_swim_fail_delay;
+static uint64_t	 crt_swim_fail_hlc;
+static swim_id_t crt_swim_fail_id;
+
+static struct d_fault_attr_t *d_fa_swim_drop_rpc;
+
+static void
+crt_swim_fault_init(const char *args)
+{
+	char	*s, *s_saved, *end, *save_ptr = NULL;
+
+	D_STRNDUP(s_saved, args, strlen(args));
+	s = s_saved;
+	if (s == NULL)
+		return;
+
+	while ((s = strtok_r(s, ",", &save_ptr)) != NULL) {
+		while (isspace(*s))
+			s++; /* skip space */
+		if (!strncasecmp(s, "delay=", 6)) {
+			crt_swim_fail_delay = strtoul(s + 6, &end, 0);
+			D_ERROR("*** CRT_SWIM_FAIL_DELAY=%lu\n",
+				crt_swim_fail_delay);
+		} else if (!strncasecmp(s, "rank=", 5)) {
+			crt_swim_fail_id = strtoul(s + 5, &end, 0);
+			D_ERROR("*** CRT_SWIM_FAIL_ID=%lu\n", crt_swim_fail_id);
+		}
+		s = NULL;
+	}
+
+	D_FREE(s_saved);
+}
 
 static inline uint32_t
 crt_swim_rpc_timeout_default(void)
@@ -129,6 +174,7 @@ static void crt_swim_srv_cb(crt_rpc_t *rpc_req)
 			  / NSEC_PER_MSEC;
 
 	/* Update all piggybacked members with remote delays */
+	D_SPIN_LOCK(&csm->csm_lock);
 	for (i = 0; i < rpc_swim_input->upds.ca_count; i++) {
 		struct swim_member_state *state;
 		swim_id_t id;
@@ -136,29 +182,30 @@ static void crt_swim_srv_cb(crt_rpc_t *rpc_req)
 		state = &rpc_swim_input->upds.ca_arrays[i].smu_state;
 		id = rpc_swim_input->upds.ca_arrays[i].smu_id;
 
-		D_SPIN_LOCK(&csm->csm_lock);
 		D_CIRCLEQ_FOREACH(cst, &csm->csm_head, cst_link) {
 			if (cst->cst_id == id) {
-				snd_delay = cst->cst_state.sms_delay;
-				snd_delay = snd_delay
-					  ? (snd_delay + state->sms_delay) / 2
-					  : state->sms_delay;
-				cst->cst_state.sms_delay = snd_delay;
+				uint32_t l = cst->cst_state.sms_delay;
+
+				if (id == from_id) {
+					l = l ? (l + rcv_delay) / 2 : rcv_delay;
+					snd_delay = l;
+				} else {
+					uint32_t r = state->sms_delay;
+
+					l = l ? (l + r) / 2 : r;
+				}
+				cst->cst_state.sms_delay = l;
+
+				if (crt_swim_fail_delay &&
+				    crt_swim_fail_id == id) {
+					crt_swim_fail_hlc = hlc
+							  - l * NSEC_PER_MSEC
+							  + crt_swim_fail_delay
+							  * NSEC_PER_SEC;
+					crt_swim_fail_delay = 0;
+				}
 				break;
 			}
-		}
-		D_SPIN_UNLOCK(&csm->csm_lock);
-	}
-
-	/* Update from_id member with remote delay */
-	D_SPIN_LOCK(&csm->csm_lock);
-	D_CIRCLEQ_FOREACH(cst, &csm->csm_head, cst_link) {
-		if (cst->cst_id == from_id) {
-			snd_delay = cst->cst_state.sms_delay;
-			snd_delay = snd_delay ? (snd_delay + rcv_delay) / 2
-					      : rcv_delay;
-			cst->cst_state.sms_delay = snd_delay;
-			break;
 		}
 	}
 	D_SPIN_UNLOCK(&csm->csm_lock);
@@ -168,9 +215,17 @@ static void crt_swim_srv_cb(crt_rpc_t *rpc_req)
 	else if (snd_delay > max_delay)
 		swim_net_glitch_update(ctx, from_id, snd_delay - max_delay);
 
-	rc = swim_parse_message(ctx, from_id,
-				rpc_swim_input->upds.ca_arrays,
-				rpc_swim_input->upds.ca_count);
+	if (CRT_SWIM_SHOULD_FAIL(d_fa_swim_drop_rpc, self_id)) {
+		rc = -d_fa_swim_drop_rpc->fa_err_code;
+		D_ERROR("*** DROP incoming opc %#x with %zu updates "
+			"%lu <= %lu error: "DF_RC"\n", rpc_req->cr_opc,
+			rpc_swim_input->upds.ca_count, self_id, from_id,
+			DP_RC(rc));
+	} else {
+		rc = swim_parse_message(ctx, from_id,
+					rpc_swim_input->upds.ca_arrays,
+					rpc_swim_input->upds.ca_count);
+	}
 	if (rc == -ESHUTDOWN) {
 		if (grp_priv->gp_size > 1)
 			D_ERROR("SWIM shutdown\n");
@@ -181,18 +236,19 @@ static void crt_swim_srv_cb(crt_rpc_t *rpc_req)
 	}
 
 out:
-	if (rpc_req->cr_opc & 0xFFFF) { /* RPC with acknowledge? */
-		D_TRACE_DEBUG(DB_TRACE, rpc_req,
-			"reply to opc %#x with %zu updates %lu <= %lu rc=%d\n",
-			rpc_req->cr_opc, rpc_swim_input->upds.ca_count,
-			self_id, from_id, rc);
+	if (rpc_priv->crp_opc_info->coi_no_reply)
+		return;
 
-		rpc_swim_output->rc = rc;
-		rc = crt_reply_send(rpc_req);
-		if (rc)
-			D_ERROR("send reply %d failed "DF_RC"\n",
-				rpc_swim_output->rc, DP_RC(rc));
-	}
+	D_TRACE_DEBUG(DB_TRACE, rpc_req,
+		      "reply to opc %#x with %zu updates %lu <= %lu rc=%d\n",
+		      rpc_req->cr_opc, rpc_swim_input->upds.ca_count,
+		      self_id, from_id, rc);
+
+	rpc_swim_output->rc = rc;
+	rc = crt_reply_send(rpc_req);
+	if (rc)
+		D_ERROR("send reply %d failed "DF_RC"\n",
+			rpc_swim_output->rc, DP_RC(rc));
 }
 
 static int crt_swim_get_member_state(struct swim_context *ctx, swim_id_t id,
@@ -202,35 +258,51 @@ static int crt_swim_set_member_state(struct swim_context *ctx, swim_id_t id,
 
 static void crt_swim_cli_cb(const struct crt_cb_info *cb_info)
 {
+	struct crt_rpc_priv	*rpc_priv = NULL;
 	struct swim_context	*ctx = cb_info->cci_arg;
 	crt_rpc_t		*rpc_req = cb_info->cci_rpc;
 	struct crt_rpc_swim_in	*rpc_swim_input = crt_req_get(rpc_req);
 	struct swim_member_state id_state;
+	swim_id_t		 self_id = swim_self_get(ctx);
 	swim_id_t		 id = rpc_req->cr_ep.ep_rank;
-	int			 rc;
+	int			 rc = 0;
 
 	D_TRACE_DEBUG(DB_TRACE, rpc_req,
 		      "complete opc %#x with %zu updates %lu => %lu "DF_RC"\n",
 		      rpc_req->cr_opc, rpc_swim_input->upds.ca_count,
 		      rpc_swim_input->src, id, DP_RC(cb_info->cci_rc));
 
+	rpc_priv = container_of(rpc_req, struct crt_rpc_priv, crp_pub);
+
+	if (rpc_priv->crp_opc_info->coi_no_reply)
+		D_GOTO(out, rc);
+
+	if (cb_info->cci_rc == -DER_UNREG) /* protocol not registered */
+		D_GOTO(out, rc);
+
 	/* check for RPC with acknowledge a return code of request */
-	if (cb_info->cci_rc && (rpc_req->cr_opc & 0xFFFF)) {
-		if (cb_info->cci_rc == -DER_UNREG) /* protocol not registered */
-			goto out;
+	if (cb_info->cci_rc) {
 		rc = crt_swim_get_member_state(ctx, id, &id_state);
 		if (!rc) {
 			D_TRACE_ERROR(rpc_req,
-				"member {%lu %c %lu} => {%lu D %lu}",
-				id, SWIM_STATUS_CHARS[id_state.sms_status],
-				id_state.sms_incarnation,
-				id, (id_state.sms_incarnation + 1));
+				      "member {%lu %c %lu} => {%lu D %lu}", id,
+				      SWIM_STATUS_CHARS[id_state.sms_status],
+				      id_state.sms_incarnation, id,
+				      (id_state.sms_incarnation + 1));
 			id_state.sms_incarnation++;
 			id_state.sms_status = SWIM_MEMBER_DEAD;
 			crt_swim_set_member_state(ctx, id, &id_state);
 		}
+		D_GOTO(out, rc);
 	}
+
 out:
+	if (crt_swim_fail_delay && crt_swim_fail_id == self_id) {
+		crt_swim_fail_hlc = crt_hlc_get()
+				  + crt_swim_fail_delay * NSEC_PER_SEC;
+		crt_swim_fail_delay = 0;
+	}
+
 	D_FREE(rpc_swim_input->upds.ca_arrays);
 }
 
@@ -244,9 +316,25 @@ static int crt_swim_send_message(struct swim_context *ctx, swim_id_t to,
 	crt_rpc_t		*rpc_req;
 	crt_endpoint_t		 ep;
 	crt_opcode_t		 opc;
+	swim_id_t		 self_id = swim_self_get(ctx);
 	int			 opc_idx = 0;
 	int			 ctx_idx = csm->csm_crt_ctx_idx;
 	int			 rc;
+
+	if (nupds > 0 && upds[0].smu_state.sms_status == SWIM_MEMBER_INACTIVE)
+		opc_idx = 1;
+
+	opc = CRT_PROTO_OPC(CRT_OPC_SWIM_PROTO, CRT_OPC_SWIM_VERSION, opc_idx);
+
+	if (CRT_SWIM_SHOULD_FAIL(d_fa_swim_drop_rpc, self_id)) {
+		rc = -d_fa_swim_drop_rpc->fa_err_code;
+		D_ERROR("*** DROP outgoing opc %#x with %zu updates "
+			"%lu => %lu error: "DF_RC"\n", opc, nupds,
+			self_id, to, DP_RC(rc));
+		if (!rc)
+			D_FREE(upds);
+		D_GOTO(out, rc);
+	}
 
 	crt_ctx = crt_context_lookup(ctx_idx);
 	if (crt_ctx == CRT_CONTEXT_NULL) {
@@ -258,10 +346,6 @@ static int crt_swim_send_message(struct swim_context *ctx, swim_id_t to,
 	ep.ep_rank = (d_rank_t)to;
 	ep.ep_tag  = ctx_idx;
 
-	if (nupds > 0 && upds[0].smu_state.sms_status == SWIM_MEMBER_INACTIVE)
-		opc_idx = 1;
-
-	opc = CRT_PROTO_OPC(CRT_OPC_SWIM_PROTO, CRT_OPC_SWIM_VERSION, opc_idx);
 	rc = crt_req_create(crt_ctx, &ep, opc, &rpc_req);
 	if (rc) {
 		D_ERROR("crt_req_create() failed "DF_RC"\n", DP_RC(rc));
@@ -280,13 +364,13 @@ static int crt_swim_send_message(struct swim_context *ctx, swim_id_t to,
 	}
 
 	rpc_swim_input = crt_req_get(rpc_req);
-	rpc_swim_input->src = swim_self_get(ctx);
+	rpc_swim_input->src = self_id;
 	rpc_swim_input->upds.ca_arrays = upds;
 	rpc_swim_input->upds.ca_count  = nupds;
 
 	D_TRACE_DEBUG(DB_TRACE, rpc_req,
 		"sending opc %#x with %zu updates %lu => %lu\n",
-		opc, nupds, swim_self_get(ctx), to);
+		opc, nupds, self_id, to);
 
 	rc = crt_req_send(rpc_req, crt_swim_cli_cb, ctx);
 	if (rc) {
@@ -463,6 +547,12 @@ static void crt_swim_progress_cb(crt_context_t crt_ctx, void *arg)
 	if (self_id == SWIM_ID_INVALID)
 		return;
 
+	if (crt_swim_fail_hlc && crt_hlc_get() >= crt_swim_fail_hlc) {
+		crt_swim_should_fail = true;
+		crt_swim_fail_hlc = 0;
+		D_ERROR("*** SWIM id=%lu should fail\n", crt_swim_fail_id);
+	}
+
 	rc = swim_progress(ctx, CRT_SWIM_PROGRESS_TIMEOUT);
 	if (rc == -ESHUTDOWN) {
 		if (grp_priv->gp_size > 1)
@@ -537,7 +627,8 @@ int crt_swim_init(int crt_ctx_idx)
 			rc = crt_swim_rank_add(grp_priv,
 					grp_membs->rl_ranks[i]);
 			if (rc && rc != -DER_ALREADY) {
-				D_ERROR("crt_swim_rank_add() failed=%d\n", rc);
+				D_ERROR("crt_swim_rank_add() failed "DF_RC"\n",
+					DP_RC(rc));
 				D_GOTO(cleanup, rc);
 			}
 		}
@@ -547,16 +638,40 @@ int crt_swim_init(int crt_ctx_idx)
 
 	rc = crt_proto_register(&crt_swim_proto_fmt);
 	if (rc) {
-		D_ERROR("crt_proto_register() failed=%d\n", rc);
+		D_ERROR("crt_proto_register() failed "DF_RC"\n", DP_RC(rc));
 		D_GOTO(cleanup, rc);
 	}
 
 	rc = crt_register_progress_cb(crt_swim_progress_cb, crt_ctx_idx, NULL);
 	if (rc) {
-		D_ERROR("crt_register_progress_cb() failed=%d\n", rc);
+		D_ERROR("crt_register_progress_cb() failed "DF_RC"\n",
+			DP_RC(rc));
 		D_GOTO(cleanup, rc);
 	}
 
+	if (!d_fault_inject_is_enabled())
+		D_GOTO(out, rc);
+
+	crt_swim_should_fail = false; /* disabled by default */
+	crt_swim_fail_hlc = 0;
+	crt_swim_fail_delay = 10;
+	crt_swim_fail_id = SWIM_ID_INVALID;
+
+	/* Search the attr in inject yml first */
+	d_fa_swim_drop_rpc = d_fault_attr_lookup(CRT_SWIM_FAIL_DROP_RPC);
+	if (d_fa_swim_drop_rpc != NULL) {
+		D_ERROR("*** fa_swim_drop_rpc: id=%u/0x%x, "
+			"interval=%u, max="DF_U64", x=%u, y=%u, args='%s'\n",
+			d_fa_swim_drop_rpc->fa_id,
+			d_fa_swim_drop_rpc->fa_id,
+			d_fa_swim_drop_rpc->fa_interval,
+			d_fa_swim_drop_rpc->fa_max_faults,
+			d_fa_swim_drop_rpc->fa_probability_x,
+			d_fa_swim_drop_rpc->fa_probability_y,
+			d_fa_swim_drop_rpc->fa_argument);
+		if (d_fa_swim_drop_rpc->fa_argument != NULL)
+			crt_swim_fault_init(d_fa_swim_drop_rpc->fa_argument);
+	}
 	D_GOTO(out, rc);
 
 cleanup:

--- a/src/cart/crt_swim.c
+++ b/src/cart/crt_swim.c
@@ -33,7 +33,7 @@
 #define CRT_OPC_SWIM_VERSION	0
 #define CRT_SWIM_FAIL_BASE	((CRT_OPC_SWIM_PROTO >> 16) | \
 				 (CRT_OPC_SWIM_VERSION << 4))
-#define CRT_SWIM_FAIL_DROP_RPC	(CRT_SWIM_FAIL_BASE | 0x1)
+#define CRT_SWIM_FAIL_DROP_RPC	(CRT_SWIM_FAIL_BASE | 0x1)	/* id: 65025 */
 
 /**
  * use this macro to determine if a fault should be injected at

--- a/src/cart/crt_swim.c
+++ b/src/cart/crt_swim.c
@@ -216,7 +216,7 @@ static void crt_swim_srv_cb(crt_rpc_t *rpc_req)
 		swim_net_glitch_update(ctx, from_id, snd_delay - max_delay);
 
 	if (CRT_SWIM_SHOULD_FAIL(d_fa_swim_drop_rpc, self_id)) {
-		rc = -d_fa_swim_drop_rpc->fa_err_code;
+		rc = d_fa_swim_drop_rpc->fa_err_code;
 		D_ERROR("*** DROP incoming opc %#x with %zu updates "
 			"%lu <= %lu error: "DF_RC"\n", rpc_req->cr_opc,
 			rpc_swim_input->upds.ca_count, self_id, from_id,
@@ -327,7 +327,7 @@ static int crt_swim_send_message(struct swim_context *ctx, swim_id_t to,
 	opc = CRT_PROTO_OPC(CRT_OPC_SWIM_PROTO, CRT_OPC_SWIM_VERSION, opc_idx);
 
 	if (CRT_SWIM_SHOULD_FAIL(d_fa_swim_drop_rpc, self_id)) {
-		rc = -d_fa_swim_drop_rpc->fa_err_code;
+		rc = d_fa_swim_drop_rpc->fa_err_code;
 		D_ERROR("*** DROP outgoing opc %#x with %zu updates "
 			"%lu => %lu error: "DF_RC"\n", opc, nupds,
 			self_id, to, DP_RC(rc));

--- a/src/cart/utils/fault-inject-cart.yaml
+++ b/src/cart/utils/fault-inject-cart.yaml
@@ -37,3 +37,22 @@ fault_config:
     interval:     1
     max_faults:   2
     err_code:     1011
+
+    # SWIM messages drop fault injection
+    # probability_x should be 1 always to drop SWIM messages
+    # Change probability_y to non-zero to introduce random failures.
+    # probability_y: 20  - will introduce 5% of message loss
+    # probability_y: 100 - will introduce 1% of message loss
+  - id:            65025
+    interval:      0
+    max_faults:    0
+    probability_x: 1
+    probability_y: 0
+    err_code:      0
+    # Comma separated list of SWIM messages drop fault injection arguments:
+    # rank=<num> - Set it to the rank number which should be evicted by
+    # simulation of network failures.
+    # delay=<num> - Set it to the number of seconds on which fault injection
+    # will be delayed. It can be useful to complete an initialization and
+    # creation of pool/container need for testing.
+    argument:     "rank=1,delay=10"

--- a/src/cart/utils/fault-inject-cart.yaml
+++ b/src/cart/utils/fault-inject-cart.yaml
@@ -23,7 +23,7 @@ fault_config:
     argument:     without-quoting-only-one-word-is-allowed
     interval:     1
     max_faults:   2
-    err_code:     1011
+    err_code:     -1011
 
     # Change probability_x and probability_y both to non-zero to turn on the
     # D_ALLOC injection in test_group.c
@@ -36,7 +36,7 @@ fault_config:
     argument:     "anything on this line is parsed as one single string"
     interval:     1
     max_faults:   2
-    err_code:     1011
+    err_code:     -1011
 
     # SWIM messages drop fault injection
     # probability_x should be 1 always to drop SWIM messages

--- a/src/gurt/fault_inject.c
+++ b/src/gurt/fault_inject.c
@@ -230,7 +230,7 @@ int
 d_fault_attr_err_code(uint32_t fault_id)
 {
 	struct d_fault_attr_t	*fault_attr;
-	uint32_t		 err_code;
+	int32_t			 err_code;
 
 	fault_attr = d_fault_attr_lookup(fault_id);
 	if (fault_attr == NULL) {
@@ -242,7 +242,7 @@ d_fault_attr_err_code(uint32_t fault_id)
 	err_code = fault_attr->fa_err_code;
 	D_SPIN_UNLOCK(&fault_attr->fa_lock);
 
-	return (int) err_code;
+	return err_code;
 }
 
 static int
@@ -323,8 +323,9 @@ one_fault_attr_parse(yaml_parser_t *parser)
 			attr.fa_max_faults = val;
 			D_DEBUG(DB_ALL, "max_faults: %lu\n", val);
 		} else if (!strcmp(key_str, err_code)) {
-			attr.fa_err_code = val;
-			D_DEBUG(DB_ALL, "err_code: %lu\n", val);
+			attr.fa_err_code = strtol(val_str, NULL, 0);
+			D_DEBUG(DB_ALL, "err_code: " DF_RC "\n",
+				DP_RC(attr.fa_err_code));
 		} else if (!strcmp(key_str, argument)) {
 			D_STRNDUP(attr.fa_argument, val_str,
 				  FI_CONFIG_ARG_STR_MAX_LEN);

--- a/src/include/gurt/fault_inject.h
+++ b/src/include/gurt/fault_inject.h
@@ -80,7 +80,7 @@ struct d_fault_attr_t {
 	/**
 	 * the error code to inject. Can be retrieved by d_fault_attr_err_code()
 	 */
-	uint32_t		fa_err_code;
+	int32_t			fa_err_code;
 	/**
 	 * state for nrand48. this allows each injection point has its own
 	 * independent random number sequence.


### PR DESCRIPTION
Add fault injection into SWIM to test the time of failure detection.
To enable this functionality you should set the following YAML file
in D_FI_CONFIG environment.
```
fault_config:
    # SWIM messages drop fault injection
    # probability_x should be 1 always to drop SWIM messages
    # Change probability_y to non-zero to introduce random failures.
    # probability_y: 20  - will introduce 5% of message loss
    # probability_y: 100 - will introduce 1% of message loss
  - id:            65025
    interval:      0
    max_faults:    0
    probability_x: 1
    probability_y: 0
    err_code:      0
    # Comma separated list of SWIM messages drop fault injection arguments:
    # rank=<num> - Set it to the rank number which should be evicted by
    # simulation of network failures.
    # delay=<num> - Set it to the number of seconds on which fault injection
    # will be delayed. It can be useful to complete an initialization and
    # creation of pool/container need for testing.
    argument:     "rank=1,delay=10"
```