### PR TITLE
DAOS-6081 doc: describe adjusting memlock ulimit

### DIFF
--- a/doc/admin/predeployment_check.md
+++ b/doc/admin/predeployment_check.md
@@ -206,3 +206,25 @@ $ sudo ln -s $SL_PREFIX/include \
     The RPM installation is preferred for production scenarios. Manual
     installation is most appropriate for development and predeployment
     proof-of-concept scenarios.
+
+## Memory Lock Limits
+
+Low ulimit for memlock can cause SPDK to fail and emit the following error:
+
+```bash
+daos_io_server:1 EAL: cannot set up DMA remapping, error 12 (Cannot allocate
+    memory)
+```
+
+The memlock limit only needs to be manually adjusted when `daos_server` is not
+running as a systemd service. Default ulimit settings vary between OSes.
+
+For RPM installations, the service will typically be launched by systemd and
+the limit is pre-set to unlimited in the `daos_server.service` unit file:
+https://github.com/daos-stack/daos/blob/master/utils/systemd/daos_server.service#L16.
+Note that values set in `/etc/security/limits.conf` are ignored by services
+launched by systemd.
+
+For non-RPM installations where `daos_server` is launched directly from the
+commandline, limits should be adjusted in `/etc/security/limits.conf` as per
+https://software.intel.com/content/www/us/en/develop/blogs/best-known-methods-for-setting-locked-memory-size.html.


### PR DESCRIPTION
SPDK can fail if memlock ulimit is low, needs manual adjustment for
non-RPM installs.

Signed-off-by: Tom Nabarro <tom.nabarro@intel.com>