### PR TITLE
DAOS-1364 tests: Multi-process vos_perf with SCM

### DIFF
--- a/src/bio/bio_xstream.c
+++ b/src/bio/bio_xstream.c
@@ -378,12 +378,6 @@ bio_nvme_init(const char *storage_path, const char *nvme_conf, int shm_id,
 	int		rc, fd;
 	uint64_t	size_mb = DAOS_DMA_CHUNK_MB;
 
-	rc = smd_init(storage_path);
-	if (rc != 0) {
-		D_ERROR("Initialize SMD store failed. "DF_RC"\n", DP_RC(rc));
-		return rc;
-	}
-
 	nvme_glb.bd_xstream_cnt = 0;
 	nvme_glb.bd_init_thread = NULL;
 	D_INIT_LIST_HEAD(&nvme_glb.bd_bdevs);
@@ -408,6 +402,12 @@ bio_nvme_init(const char *storage_path, const char *nvme_conf, int shm_id,
 		return 0;
 	}
 	close(fd);
+
+	rc = smd_init(storage_path);
+	if (rc != 0) {
+		D_ERROR("Initialize SMD store failed. "DF_RC"\n", DP_RC(rc));
+		return rc;
+	}
 
 	nvme_glb.bd_nvme_conf = spdk_conf_allocate();
 	if (nvme_glb.bd_nvme_conf == NULL) {

--- a/src/common/dts.c
+++ b/src/common/dts.c
@@ -250,12 +250,14 @@ pool_init(struct dts_context *tsc)
 	if (tsc->tsc_mpi_size <= 1)
 		goto out; /* don't need to share handle */
 
-	MPI_Bcast(&rc, 1, MPI_INT, 0, MPI_COMM_WORLD);
+	if (!tsc->tsc_pmem_file)
+		MPI_Bcast(&rc, 1, MPI_INT, 0, MPI_COMM_WORLD);
 	if (rc)
 		goto out; /* open failed */
 
-	handle_share(&tsc->tsc_poh, HANDLE_POOL, tsc->tsc_mpi_rank,
-		     tsc->tsc_poh, 0);
+	if (!tsc->tsc_pmem_file)
+		handle_share(&tsc->tsc_poh, HANDLE_POOL, tsc->tsc_mpi_rank,
+			     tsc->tsc_poh, 0);
  out:
 	return rc;
 }
@@ -319,8 +321,9 @@ cont_init(struct dts_context *tsc)
 	if (rc)
 		goto out; /* open failed */
 
-	handle_share(&tsc->tsc_coh, HANDLE_CO, tsc->tsc_mpi_rank,
-		     tsc->tsc_poh, 0);
+	if (!tsc->tsc_pmem_file)
+		handle_share(&tsc->tsc_coh, HANDLE_CO, tsc->tsc_mpi_rank,
+			     tsc->tsc_poh, 0);
  out:
 	return rc;
 }

--- a/src/tests/daos_perf.c
+++ b/src/tests/daos_perf.c
@@ -1339,7 +1339,7 @@ main(int argc, char **argv)
 			ts_zero_copy = true;
 			break;
 		case 'f':
-			if (strlen(optarg) > PATH_MAX - 5) {
+			if (strnlen(optarg, PATH_MAX) < (PATH_MAX - 5)) {
 				fprintf(stderr, "filename size must be < %d\n",
 					PATH_MAX - 5);
 				return -1;

--- a/src/tests/daos_perf.c
+++ b/src/tests/daos_perf.c
@@ -1477,12 +1477,12 @@ main(int argc, char **argv)
 		}
 		ts_ctx.tsc_cred_nr = -1; /* VOS can only support sync mode */
 		if (strlen(ts_pmem_file) == 0) {
-			int len = snprintf(NULL, 0, "/mnt/daos/vos_perf%d.pmem",
-					   ts_ctx.tsc_mpi_rank) + 1;
-			snprintf(ts_pmem_file, len, "/mnt/daos/vos_perf%d.pmem",
+			snprintf(ts_pmem_file, sizeof(ts_pmem_file),
+				 "/mnt/daos/vos_perf%d.pmem",
 				 ts_ctx.tsc_mpi_rank);
 		} else {
 			char id[4];
+
 			snprintf(id, sizeof(id), "%d", ts_ctx.tsc_mpi_rank);
 			strncat(ts_pmem_file, id,
 				(sizeof(ts_pmem_file) - strlen(ts_pmem_file)));

--- a/src/tests/daos_perf.c
+++ b/src/tests/daos_perf.c
@@ -1339,7 +1339,7 @@ main(int argc, char **argv)
 			ts_zero_copy = true;
 			break;
 		case 'f':
-			if (strnlen(optarg, PATH_MAX) < (PATH_MAX - 5)) {
+			if (strnlen(optarg, PATH_MAX) >= (PATH_MAX - 5)) {
 				fprintf(stderr, "filename size must be < %d\n",
 					PATH_MAX - 5);
 				return -1;
@@ -1483,10 +1483,9 @@ main(int argc, char **argv)
 				 ts_ctx.tsc_mpi_rank);
 		} else {
 			char id[4];
-			int  len = snprintf(NULL, 0, "%d",
-					    ts_ctx.tsc_mpi_rank);
-			snprintf(id, len, "%d", ts_ctx.tsc_mpi_rank);
-			strcat(ts_pmem_file, id);
+			snprintf(id, sizeof(id), "%d", ts_ctx.tsc_mpi_rank);
+			strncat(ts_pmem_file, id,
+				(sizeof(ts_pmem_file) - strlen(ts_pmem_file)));
 		}
 		ts_ctx.tsc_pmem_file = ts_pmem_file;
 		if (ts_in_ult) {

--- a/src/tests/daos_perf.c
+++ b/src/tests/daos_perf.c
@@ -1339,7 +1339,12 @@ main(int argc, char **argv)
 			ts_zero_copy = true;
 			break;
 		case 'f':
-			strncpy(ts_pmem_file, optarg, PATH_MAX - 1);
+			if (strlen(optarg) > PATH_MAX - 5) {
+				fprintf(stderr, "filename size must be < %d\n",
+						PATH_MAX - 5);
+				return -1;
+			}
+			strncpy(ts_pmem_file, optarg, PATH_MAX - 5);
 			break;
 		case 'U':
 			perf_tests_prep[UPDATE_TEST] = ts_io_prep;
@@ -1464,10 +1469,25 @@ main(int argc, char **argv)
 	}
 
 	if (ts_mode == TS_MODE_VOS) {
+		if (ts_ctx.tsc_mpi_size > 1 &&
+		    (access("/etc/daos_nvme.conf", F_OK) != -1)) {
+			fprintf(stderr,
+				"no support: multi-proc vos_perf with NVMe\n");
+			return -1;
+		}
 		ts_ctx.tsc_cred_nr = -1; /* VOS can only support sync mode */
-		if (strlen(ts_pmem_file) == 0)
-			strcpy(ts_pmem_file, "/mnt/daos/vos_perf.pmem");
-
+		if (strlen(ts_pmem_file) == 0) {
+			int len = snprintf(NULL, 0, "/mnt/daos/vos_perf%d.pmem",
+					   ts_ctx.tsc_mpi_rank) + 1;
+			snprintf(ts_pmem_file, len, "/mnt/daos/vos_perf%d.pmem",
+				ts_ctx.tsc_mpi_rank);
+		} else {
+			char id[4];
+			int  len = snprintf(NULL, 0, "%d",
+					    ts_ctx.tsc_mpi_rank);
+			snprintf(id, len, "%d", ts_ctx.tsc_mpi_rank);
+			strcat(ts_pmem_file, id);
+		}
 		ts_ctx.tsc_pmem_file = ts_pmem_file;
 		if (ts_in_ult) {
 			rc = ts_abt_init();

--- a/src/tests/daos_perf.c
+++ b/src/tests/daos_perf.c
@@ -1341,7 +1341,7 @@ main(int argc, char **argv)
 		case 'f':
 			if (strlen(optarg) > PATH_MAX - 5) {
 				fprintf(stderr, "filename size must be < %d\n",
-						PATH_MAX - 5);
+					PATH_MAX - 5);
 				return -1;
 			}
 			strncpy(ts_pmem_file, optarg, PATH_MAX - 5);

--- a/src/tests/daos_perf.c
+++ b/src/tests/daos_perf.c
@@ -1480,7 +1480,7 @@ main(int argc, char **argv)
 			int len = snprintf(NULL, 0, "/mnt/daos/vos_perf%d.pmem",
 					   ts_ctx.tsc_mpi_rank) + 1;
 			snprintf(ts_pmem_file, len, "/mnt/daos/vos_perf%d.pmem",
-				ts_ctx.tsc_mpi_rank);
+				 ts_ctx.tsc_mpi_rank);
 		} else {
 			char id[4];
 			int  len = snprintf(NULL, 0, "%d",

--- a/src/tests/daos_perf.c
+++ b/src/tests/daos_perf.c
@@ -1481,7 +1481,8 @@ main(int argc, char **argv)
 				 "/mnt/daos/vos_perf%d.pmem",
 				 ts_ctx.tsc_mpi_rank);
 		} else {
-			char id[4];
+			char id[16];
+
 
 			snprintf(id, sizeof(id), "%d", ts_ctx.tsc_mpi_rank);
 			strncat(ts_pmem_file, id,


### PR DESCRIPTION
Fixes to daos_perf to ensure it works with multiprocess mode.
This is for SCM-only mode and added for simulating multiple targets.

Create SMD only when nvme is used.

Signed-off-by: Vishwanath Venkatesan <vishwanath.venkatesan@intel.com>