### PR TITLE
DAOS-6103 documentation: Update doc/user/interface.md to correct link

### DIFF
--- a/doc/user/interface.md
+++ b/doc/user/interface.md
@@ -10,7 +10,7 @@ available under `src/tests`.
 
 `libdaos` is written in C and uses Doxygen comments that are added to C header
 files. The Doxygen documentation is available 
-[here](https://github.com/daos-stack/daos/blob/master/src/client/api/README.md).
+[here](https://daos-stack.github.io/html/).
 
 ## Python Bindings
 


### PR DESCRIPTION
Link to API documentation is wrong, Needs corrected

Skip-build: true
Skip-test: true


Signed-off-by: craig <craig.durfey@intel.com>