### PR TITLE
DAOS-6106 examples: Restore simple_obj building step

### DIFF
--- a/src/tests/SConscript
+++ b/src/tests/SConscript
@@ -25,6 +25,7 @@ def scons():
     prereqs.require(denv, 'argobots', 'hwloc', 'protobufc')
 
     daos_build.program(denv, 'simple_array', 'simple_array.c', LIBS=libs)
+    daos_build.program(denv, 'simple_obj', 'simple_obj.c', LIBS=libs)
     libs += ['vos', 'bio', 'pthread', 'abt', 'dts']
 
     daos_perf = daos_build.program(denv, 'daos_perf',


### PR DESCRIPTION
On DAOS-4584 simple_obj building step was removed by accident.

Signed-off-by: Jonathan Martinez Montes <jonathan.martinez.montes@intel.com>