### PR TITLE
DAOS-5989 tools: Add acl option to cont get-prop cmd

### DIFF
--- a/src/utils/daos.c
+++ b/src/utils/daos.c
@@ -515,6 +515,7 @@ daos_parse_properties(char *props_string, daos_prop_t *props)
 /* values to identify options with no small value in getopt_long() */
 enum {
 	DAOS_PROPERTIES_OPTION = 1,
+	DAOS_INCLUDE_ACL_OPTION,
 };
 
 /* resource and command arguments (ie "container create" for example) can be
@@ -552,6 +553,7 @@ common_op_parse_hdlr(int argc, char *argv[], struct cmd_args_s *ap)
 		{"user",	required_argument,	NULL,	'u'},
 		{"group",	required_argument,	NULL,	'g'},
 		{"principal",	required_argument,	NULL,	'P'},
+		{"include-acl",	no_argument,		NULL,	DAOS_INCLUDE_ACL_OPTION},
 		{NULL,		0,			NULL,	0}
 	};
 	int			rc;
@@ -770,6 +772,9 @@ common_op_parse_hdlr(int argc, char *argv[], struct cmd_args_s *ap)
 			rc = daos_parse_properties(optarg, ap->props);
 			if (rc != 0)
 				D_GOTO(out_free, rc = RC_NO_HELP);
+			break;
+		case DAOS_INCLUDE_ACL_OPTION:
+			ap->include_acl = true;
 			break;
 		default:
 			fprintf(stderr, "unknown option : %d\n", rc);
@@ -1399,10 +1404,14 @@ help_hdlr(int argc, char *argv[], struct cmd_args_s *ap)
 			"	--group=ID         group who will own the container.\n"
 			"			   format: groupname@[domain]\n");
 			ALL_BUT_CONT_CREATE_OPTS_HELP();
+		} else if (strcmp(argv[3], "get-prop") == 0) {
+			fprintf(stream,
+			"container options (get-prop):\n"
+			"	--include-acl      include ACL in the list\n");
+			ALL_BUT_CONT_CREATE_OPTS_HELP();
 		} else if (strcmp(argv[3], "list-objects") == 0 ||
 			   strcmp(argv[3], "list-obj") == 0 ||
 			   strcmp(argv[3], "query") == 0 ||
-			   strcmp(argv[3], "get-prop") == 0 ||
 			   strcmp(argv[3], "stat") == 0 ||
 			   strcmp(argv[3], "list-attrs") == 0 ||
 			   strcmp(argv[3], "list-snaps") == 0) {

--- a/src/utils/daos_hdlr.c
+++ b/src/utils/daos_hdlr.c
@@ -1153,6 +1153,20 @@ cont_decode_props(daos_prop_t *props)
 		D_PRINT("owner-group:\t\t%s\n", entry->dpe_str);
 	}
 
+	/* Only print the ACL if it was included */
+	entry = daos_prop_entry_get(props, DAOS_PROP_CO_ACL);
+	if (entry != NULL && entry->dpe_val_ptr != NULL) {
+		D_PRINT("acl:\n");
+		rc = daos_acl_to_stream(stdout,
+					(struct daos_acl *)entry->dpe_val_ptr,
+					false);
+		if (rc != 0) {
+			fprintf(stderr,
+				"unable to print ACL property: %s (%d)\n",
+				d_errstr(rc), rc);
+		}
+	}
+
 	return rc;
 }
 
@@ -1174,7 +1188,7 @@ cont_get_prop_hdlr(struct cmd_args_s *ap)
 
 	entry_type = DAOS_PROP_CO_MIN + 1;
 	for (i = 0; i < prop_query->dpp_nr; entry_type++) {
-		if (entry_type == DAOS_PROP_CO_ACL)
+		if (!ap->include_acl && entry_type == DAOS_PROP_CO_ACL)
 			continue; /* skip ACL */
 		prop_query->dpp_entries[i].dpe_type = entry_type;
 		i++;

--- a/src/utils/daos_hdlr.h
+++ b/src/utils/daos_hdlr.h
@@ -103,6 +103,7 @@ struct cmd_args_s {
 	bool			verbose;	/* --verbose mode */
 	char			*entry;		/* --entry for ACL */
 	char			*principal;	/* --principal for ACL */
+	bool			include_acl;	/* --include-acl */
 };
 
 #define ARGS_VERIFY_PUUID(ap, label, rcexpr)			\


### PR DESCRIPTION
- Add the option '--include-acl' to the daos cont get-prop
  to allow the ACL to be fetched at the same time as other
  properties, if desired.

Signed-off-by: Kris Jacque <kristin.jacque@intel.com>