### PR TITLE
CART-89 psm: Fix contig ep check for psm2

### DIFF
--- a/src/cart/crt_hg.c
+++ b/src/cart/crt_hg.c
@@ -385,6 +385,9 @@ crt_provider_is_block_mode(int provider)
 bool
 crt_provider_is_contig_ep(int provider)
 {
+	if (provider == CRT_NA_OFI_PSM2)
+		return false;
+
 	return crt_na_dict[provider].nad_port_bind;
 }
 


### PR DESCRIPTION
- PSM2 currently identifies as port-bound provider. Contig ep
helper function should return true for all port-bound providers except
for psm2.

Signed-off-by: Alexander A Oganezov <alexander.a.oganezov@intel.com>