### PR TITLE
DAOS-5996 obj: refine EC server IO to support different leader

### DIFF
--- a/src/object/cli_shard.c
+++ b/src/object/cli_shard.c
@@ -921,6 +921,8 @@ dc_obj_shard_rw(struct dc_obj_shard *shard, enum obj_rpc_opc opc,
 	daos_dti_copy(&orw->orw_dti, &args->dti);
 	orw->orw_flags = auxi->flags | flags;
 	orw->orw_tgt_idx = auxi->ec_tgt_idx;
+	if (args->reasb_req && args->reasb_req->orr_oca)
+		orw->orw_tgt_max = obj_ec_tgt_nr(args->reasb_req->orr_oca) - 1;
 	if (obj_op_is_ec_fetch(auxi->obj_auxi) &&
 	    (auxi->shard != (auxi->start_shard + auxi->ec_tgt_idx)))
 		orw->orw_flags |= ORF_EC_DEGRADED;

--- a/src/object/obj_ec.h
+++ b/src/object/obj_ec.h
@@ -666,7 +666,7 @@ int obj_ec_get_degrade(struct obj_reasb_req *reasb_req, uint16_t fail_tgt_idx,
 struct obj_rw_in;
 int obj_ec_rw_req_split(daos_unit_oid_t oid, struct obj_iod_array *iod_array,
 			uint32_t iod_nr, uint32_t start_shard,
-			void *tgt_map, uint32_t map_size,
+			uint32_t max_shard, void *tgt_map, uint32_t map_size,
 			uint32_t tgt_nr, struct daos_shard_tgt *tgts,
 			struct obj_ec_split_req **split_req);
 void obj_ec_split_req_fini(struct obj_ec_split_req *req);

--- a/src/object/obj_rpc.h
+++ b/src/object/obj_rpc.h
@@ -184,7 +184,9 @@ enum obj_rpc_flags {
 	((d_sg_list_t)		(orw_sgls)		CRT_ARRAY) \
 	((crt_bulk_t)		(orw_bulks)		CRT_ARRAY) \
 	((struct daos_shard_tgt)(orw_shard_tgts)	CRT_ARRAY) \
-	((uint32_t)		(orw_tgt_idx)		CRT_VAR)
+	/* orw_tgt_idx and orw_tgt_max only for EC obj */	   \
+	((uint32_t)		(orw_tgt_idx)		CRT_VAR)   \
+	((uint32_t)		(orw_tgt_max)		CRT_VAR)
 
 #define DAOS_OSEQ_OBJ_RW	/* output fields */		 \
 	((int32_t)		(orw_ret)		CRT_VAR) \

--- a/src/object/srv_ec.c
+++ b/src/object/srv_ec.c
@@ -62,7 +62,7 @@ obj_ec_is_valid_tgt(struct daos_cpd_ec_tgts *tgt_map, uint32_t map_size,
  */
 int
 obj_ec_rw_req_split(daos_unit_oid_t oid, struct obj_iod_array *iod_array,
-		    uint32_t iod_nr, uint32_t start_shard,
+		    uint32_t iod_nr, uint32_t start_shard, uint32_t max_shard,
 		    void *tgt_map, uint32_t map_size,
 		    uint32_t tgt_nr, struct daos_shard_tgt *tgts,
 		    struct obj_ec_split_req **split_req)
@@ -78,7 +78,7 @@ obj_ec_rw_req_split(daos_unit_oid_t oid, struct obj_iod_array *iod_array,
 	struct dcs_iod_csums	*iod_csums = iod_array->oia_iod_csums;
 	struct dcs_iod_csums	*split_iod_csum = NULL;
 	struct dcs_iod_csums	*split_iod_csums;
-	uint32_t		 i, tgt_max_idx;
+	uint32_t		 i, tgt_max_idx, self_tgt_idx;
 	daos_size_t		 req_size, iods_size;
 	daos_size_t		 csums_size = 0, singv_ci_size = 0;
 	uint8_t			 tgt_bit_map[OBJ_TGT_BITMAP_LEN] = {0};
@@ -97,10 +97,11 @@ obj_ec_rw_req_split(daos_unit_oid_t oid, struct obj_iod_array *iod_array,
 	D_ASSERT((oiods[0].oiod_flags & OBJ_SIOD_SINGV) ||
 		 oiods[0].oiod_nr >= 2);
 
+	self_tgt_idx = oid.id_shard - start_shard;
 	if (tgt_map != NULL)
 		tgt_max_idx = 0;
 	else
-		tgt_max_idx = oid.id_shard - start_shard;
+		tgt_max_idx = max_shard;
 
 	req_size = roundup(sizeof(struct obj_ec_split_req), 8);
 	iods_size = roundup(sizeof(daos_iod_t) * iod_nr, 8);
@@ -134,7 +135,7 @@ obj_ec_rw_req_split(daos_unit_oid_t oid, struct obj_iod_array *iod_array,
 				tgt_max_idx = tgt_idx;
 		} else {
 			tgt_idx = tgts[i].st_shard - start_shard;
-			D_ASSERT(tgt_idx < tgt_max_idx);
+			D_ASSERT(tgt_idx <= tgt_max_idx);
 		}
 
 		setbit(tgt_bit_map, tgt_idx);
@@ -144,7 +145,7 @@ obj_ec_rw_req_split(daos_unit_oid_t oid, struct obj_iod_array *iod_array,
 	if (tgt_map != NULL) {
 		D_ASSERT(count == map_size);
 	} else {
-		setbit(tgt_bit_map, tgt_max_idx);
+		setbit(tgt_bit_map, self_tgt_idx);
 		count++;
 	}
 

--- a/src/object/srv_obj.c
+++ b/src/object/srv_obj.c
@@ -1959,7 +1959,8 @@ again:
 	if (orw->orw_iod_array.oia_oiods != NULL && split_req == NULL) {
 		rc = obj_ec_rw_req_split(orw->orw_oid, &orw->orw_iod_array,
 					 orw->orw_nr, orw->orw_start_shard,
-					 NULL, 0, orw->orw_shard_tgts.ca_count,
+					 orw->orw_tgt_max, NULL, 0,
+					 orw->orw_shard_tgts.ca_count,
 					 orw->orw_shard_tgts.ca_arrays,
 					 &split_req);
 		if (rc != 0) {
@@ -3645,7 +3646,7 @@ ds_obj_dtx_leader_prep_handle(struct daos_cpd_sub_head *dcsh,
 			continue;
 
 		rc = obj_ec_rw_req_split(dcsr->dcsr_oid, &dcu->dcu_iod_array,
-					 dcsr->dcsr_nr, dcu->dcu_start_shard,
+					 dcsr->dcsr_nr, dcu->dcu_start_shard, 0,
 					 dcu->dcu_ec_tgts, dcsr->dcsr_ec_tgt_nr,
 					 tgt_cnt, tgts, &dcu->dcu_ec_split_req);
 		if (rc != 0) {


### PR DESCRIPTION
Original code assume the last shard as the leader, since PR3901 landed
that assumption is not always true. This patch refine related code.

Signed-off-by: Xuezhao Liu <xuezhao.liu@intel.com>