### PR TITLE
DAOS-6114 control: Require fabric_iface_port in server config

### DIFF
--- a/src/control/cmd/daos_server/start_test.go
+++ b/src/control/cmd/daos_server/start_test.go
@@ -63,7 +63,8 @@ func genMinimalConfig() *config.Server {
 				WithScmClass("ram").
 				WithScmRamdiskSize(1).
 				WithScmMountPoint("/mnt/daos").
-				WithFabricInterface("foo0"),
+				WithFabricInterface("foo0").
+				WithFabricInterfacePort(42),
 		)
 	cfg.Path = path.Join(os.Args[0], cfg.Path)
 	return cfg
@@ -78,7 +79,8 @@ func genDefaultExpected() *config.Server {
 				WithScmClass("ram").
 				WithScmRamdiskSize(1).
 				WithScmMountPoint("/mnt/daos").
-				WithFabricInterface("foo0"),
+				WithFabricInterface("foo0").
+				WithFabricInterfacePort(42),
 		)
 }
 

--- a/src/control/server/config/server_test.go
+++ b/src/control/server/config/server_test.go
@@ -449,6 +449,7 @@ func TestServer_ConfigDuplicateValues(t *testing.T) {
 		return ioserver.NewConfig().
 			WithLogFile("a").
 			WithFabricInterface("a").
+			WithFabricInterfacePort(42).
 			WithScmClass("ram").
 			WithScmRamdiskSize(1).
 			WithScmMountPoint("a")
@@ -457,6 +458,7 @@ func TestServer_ConfigDuplicateValues(t *testing.T) {
 		return ioserver.NewConfig().
 			WithLogFile("b").
 			WithFabricInterface("b").
+			WithFabricInterfacePort(42).
 			WithScmClass("ram").
 			WithScmRamdiskSize(1).
 			WithScmMountPoint("b")
@@ -529,6 +531,7 @@ func TestServer_ConfigNetworkDeviceClass(t *testing.T) {
 			WithLogFile("a").
 			WithScmClass("ram").
 			WithScmRamdiskSize(1).
+			WithFabricInterfacePort(42).
 			WithScmMountPoint("a")
 	}
 	configB := func() *ioserver.Config {
@@ -536,6 +539,7 @@ func TestServer_ConfigNetworkDeviceClass(t *testing.T) {
 			WithLogFile("b").
 			WithScmClass("ram").
 			WithScmRamdiskSize(1).
+			WithFabricInterfacePort(43).
 			WithScmMountPoint("b")
 	}
 

--- a/src/control/server/ioserver/config.go
+++ b/src/control/server/ioserver/config.go
@@ -94,10 +94,13 @@ func (fc *FabricConfig) GetNumaNode() (uint, error) {
 // Validate ensures that the configuration meets minimum standards.
 func (fc *FabricConfig) Validate() error {
 	if fc.Provider == "" {
-		return errors.New("missing provider")
+		return errors.New("provider not set")
 	}
 	if fc.Interface == "" {
-		return errors.New("missing interface")
+		return errors.New("fabric_iface not set")
+	}
+	if fc.InterfacePort == 0 {
+		return errors.New("fabric_iface_port not set")
 	}
 	return nil
 }


### PR DESCRIPTION
Since CART-924 has landed, this parameter is now required in
order to prevent issues with randomly-generated fabric URIs.