### PR TITLE
DAOS-6069 control: Filter out down ranks for pool svc requests

### DIFF
--- a/src/control/server/mgmt_pool.go
+++ b/src/control/server/mgmt_pool.go
@@ -71,7 +71,23 @@ func (svc *mgmtSvc) getPoolServiceRanks(uuidStr string) ([]uint32, error) {
 		return nil, drpc.DaosTryAgain
 	}
 
-	return system.RanksToUint32(ps.Replicas), nil
+	readyRanks := make([]system.Rank, 0, len(ps.Replicas))
+	for _, r := range ps.Replicas {
+		m, err := svc.sysdb.FindMemberByRank(r)
+		if err != nil {
+			return nil, err
+		}
+		if m.State()&system.AvailableMemberFilter == 0 {
+			continue
+		}
+		readyRanks = append(readyRanks, r)
+	}
+
+	if len(readyRanks) == 0 {
+		return nil, errors.Errorf("unable to find any available service ranks for pool %s", uuid)
+	}
+
+	return system.RanksToUint32(readyRanks), nil
 }
 
 // calculateCreateStorage determines the amount of SCM/NVMe storage to


### PR DESCRIPTION
When a rank has been stopped or is otherwise marked unavailable
to handle requests; filter it out of the set of ranks passed
down via dRPC.