### PR TITLE
DAOS-5719 compression: add qat asynchronous support

### DIFF
--- a/src/common/compression.c
+++ b/src/common/compression.c
@@ -41,15 +41,15 @@ daos_contprop2compresstype(int contprop_compress_val)
 	case DAOS_PROP_CO_COMPRESS_LZ4:
 		return COMPRESS_TYPE_LZ4;
 	case DAOS_PROP_CO_COMPRESS_DEFLATE:
-		return DAOS_PROP_CO_COMPRESS_DEFLATE;
+		return COMPRESS_TYPE_DEFLATE;
 	case DAOS_PROP_CO_COMPRESS_DEFLATE1:
-		return DAOS_PROP_CO_COMPRESS_DEFLATE1;
+		return COMPRESS_TYPE_DEFLATE1;
 	case DAOS_PROP_CO_COMPRESS_DEFLATE2:
-		return DAOS_PROP_CO_COMPRESS_DEFLATE2;
+		return COMPRESS_TYPE_DEFLATE2;
 	case DAOS_PROP_CO_COMPRESS_DEFLATE3:
-		return DAOS_PROP_CO_COMPRESS_DEFLATE3;
+		return COMPRESS_TYPE_DEFLATE3;
 	case DAOS_PROP_CO_COMPRESS_DEFLATE4:
-		return DAOS_PROP_CO_COMPRESS_DEFLATE4;
+		return COMPRESS_TYPE_DEFLATE4;
 	default:
 		return COMPRESS_TYPE_UNKNOWN;
 	}
@@ -196,6 +196,45 @@ daos_compressor_decompress(struct daos_compressor *obj,
 			src_buf, src_len,
 			dst_buf, dst_len,
 			produced);
+
+	return DC_STATUS_ERR;
+}
+
+
+int
+daos_compressor_compress_async(struct daos_compressor *obj,
+			       uint8_t *src_buf, size_t src_len,
+			       uint8_t *dst_buf, size_t dst_len,
+			       dc_callback_fn cb_fn, void *cb_data)
+{
+	if (obj->dc_algo->cf_compress_async)
+		return obj->dc_algo->cf_compress_async(
+				obj->dc_ctx,
+				src_buf, src_len,
+				dst_buf, dst_len,
+				cb_fn, cb_data);
+
+	return DC_STATUS_ERR;
+}
+
+int
+daos_compressor_decompress_async(struct daos_compressor *obj,
+				 uint8_t *src_buf, size_t src_len,
+				 uint8_t *dst_buf, size_t dst_len,
+				 dc_callback_fn cb_fn, void *cb_data)
+{
+	if (obj->dc_algo->cf_decompress_async)
+		return obj->dc_algo->cf_decompress_async(obj->dc_ctx,
+			src_buf, src_len, dst_buf, dst_len, cb_fn, cb_data);
+
+	return DC_STATUS_ERR;
+}
+
+int
+daos_compressor_poll_response(struct daos_compressor *obj)
+{
+	if (obj->dc_algo->cf_poll_response)
+		return obj->dc_algo->cf_poll_response(obj->dc_ctx);
 
 	return DC_STATUS_ERR;
 }

--- a/src/common/compression_isal.c
+++ b/src/common/compression_isal.c
@@ -154,18 +154,14 @@ deflate_compress(void *daos_dc_ctx, uint8_t *src, size_t src_len,
 	int ret = 0;
 	struct deflate_ctx *ctx = daos_dc_ctx;
 
-	ctx->stream.total_in = 0;
-	ctx->stream.total_out = 0;
-	ctx->stream.avail_in = src_len;
+	isal_deflate_reset(&ctx->stream);
+
 	ctx->stream.next_in = src;
-	ctx->stream.avail_out = dst_len;
+	ctx->stream.avail_in = src_len;
 	ctx->stream.next_out = dst;
+	ctx->stream.avail_out = dst_len;
 
 	ret = isal_deflate_stateless(&ctx->stream);
-
-	/* Check if input buffer are all consumed */
-	if (ctx->stream.avail_in)
-		return DC_STATUS_ERR;
 
 	if (ret == COMP_OK) {
 		*produced = ctx->stream.total_out;
@@ -185,18 +181,14 @@ deflate_decompress(void *daos_dc_ctx, uint8_t *src, size_t src_len,
 	int ret = 0;
 	struct deflate_ctx *ctx = daos_dc_ctx;
 
-	ctx->stream.total_in = 0;
-	ctx->stream.total_out = 0;
+	isal_inflate_reset(&ctx->state);
+
 	ctx->state.next_in = src;
 	ctx->state.avail_in = src_len;
 	ctx->state.next_out = dst;
 	ctx->state.avail_out = dst_len;
 
 	ret = isal_inflate(&ctx->state);
-
-	/* Check if input buffer are all consumed */
-	if (ctx->state.avail_in)
-		return DC_STATUS_ERR;
 
 	if (ret == ISAL_DECOMP_OK) {
 		*produced = ctx->state.total_out;

--- a/src/common/compression_qat.c
+++ b/src/common/compression_qat.c
@@ -110,6 +110,44 @@ deflate_decompress(void *daos_dc_ctx, uint8_t *src, size_t src_len,
 		dst, dst_len, produced, DIR_DECOMPRESS);
 }
 
+static int
+deflate_compress_async(void *daos_dc_ctx, uint8_t *src, size_t src_len,
+		       uint8_t *dst, size_t dst_len,
+		       dc_callback_fn cb_fn, void *cb_data)
+{
+	struct deflate_ctx *ctx = daos_dc_ctx;
+
+	return qat_dc_compress_async(
+		&ctx->dc_inst_hdl,
+		&ctx->session_hdl,
+		src, src_len, 
+		dst, dst_len, DIR_COMPRESS,
+		cb_fn, cb_data);
+}
+
+static int
+deflate_decompress_async(void *daos_dc_ctx, uint8_t *src, size_t src_len,
+			 uint8_t *dst, size_t dst_len,
+			 dc_callback_fn cb_fn, void *cb_data)
+{
+	struct deflate_ctx *ctx = daos_dc_ctx;
+
+	return qat_dc_compress_async(
+		&ctx->dc_inst_hdl,
+		&ctx->session_hdl,
+		src, src_len,
+		dst, dst_len, DIR_DECOMPRESS,
+		cb_fn, cb_data);
+}
+
+static int
+deflate_poll_response(void *daos_dc_ctx)
+{
+	struct deflate_ctx *ctx = daos_dc_ctx;
+
+	return qat_dc_poll_response(&ctx->dc_inst_hdl);
+}
+
 static void
 deflate_destroy(void *daos_dc_ctx)
 {
@@ -134,6 +172,9 @@ struct compress_ft qat_deflate_algo = {
 	.cf_init = deflate_init,
 	.cf_compress = deflate_compress,
 	.cf_decompress = deflate_decompress,
+	.cf_compress_async = deflate_compress_async,
+	.cf_decompress_async = deflate_decompress_async,
+	.cf_poll_response = deflate_poll_response,
 	.cf_destroy = deflate_destroy,
 	.cf_available = is_available,
 	.cf_level = 1,
@@ -145,6 +186,9 @@ struct compress_ft qat_deflate1_algo = {
 	.cf_init = deflate_init,
 	.cf_compress = deflate_compress,
 	.cf_decompress = deflate_decompress,
+	.cf_compress_async = deflate_compress_async,
+	.cf_decompress_async = deflate_decompress_async,
+	.cf_poll_response = deflate_poll_response,
 	.cf_destroy = deflate_destroy,
 	.cf_available = is_available,
 	.cf_level = 1,
@@ -156,6 +200,9 @@ struct compress_ft qat_deflate2_algo = {
 	.cf_init = deflate_init,
 	.cf_compress = deflate_compress,
 	.cf_decompress = deflate_decompress,
+	.cf_compress_async = deflate_compress_async,
+	.cf_decompress_async = deflate_decompress_async,
+	.cf_poll_response = deflate_poll_response,
 	.cf_destroy = deflate_destroy,
 	.cf_available = is_available,
 	.cf_level = 2,
@@ -167,6 +214,9 @@ struct compress_ft qat_deflate3_algo = {
 	.cf_init = deflate_init,
 	.cf_compress = deflate_compress,
 	.cf_decompress = deflate_decompress,
+	.cf_compress_async = deflate_compress_async,
+	.cf_decompress_async = deflate_decompress_async,
+	.cf_poll_response = deflate_poll_response,
 	.cf_destroy = deflate_destroy,
 	.cf_available = is_available,
 	.cf_level = 3,
@@ -178,6 +228,9 @@ struct compress_ft qat_deflate4_algo = {
 	.cf_init = deflate_init,
 	.cf_compress = deflate_compress,
 	.cf_decompress = deflate_decompress,
+	.cf_compress_async = deflate_compress_async,
+	.cf_decompress_async = deflate_decompress_async,
+	.cf_poll_response = deflate_poll_response,
 	.cf_destroy = deflate_destroy,
 	.cf_available = is_available,
 	.cf_level = 4,

--- a/src/common/compression_qat.c
+++ b/src/common/compression_qat.c
@@ -120,7 +120,7 @@ deflate_compress_async(void *daos_dc_ctx, uint8_t *src, size_t src_len,
 	return qat_dc_compress_async(
 		&ctx->dc_inst_hdl,
 		&ctx->session_hdl,
-		src, src_len, 
+		src, src_len,
 		dst, dst_len, DIR_COMPRESS,
 		cb_fn, cb_data);
 }

--- a/src/common/qat.c
+++ b/src/common/qat.c
@@ -38,12 +38,25 @@
 #define MAX_INSTANCES 32
 
 /* Max buffer size is used for intermediate buffer allocation, */
-/* it is NOT hardware limitation */
+/* it is NOT hardware limitation, which is used only when the */
+/* caller doesn't specify a value */
 #define MAX_BUF_SIZE 65536
+
+struct callback_data {
+	CpaDcRqResults *dcResults;
+	CpaBufferList *pBufferListSrc;
+	CpaBufferList *pBufferListDst;
+	uint8_t *dst;
+	size_t dstLen;
+	dc_callback_fn user_cb_fn;
+	void *user_cb_data;
+};
+
+static int inst_num = 0;
 
 /** Memory */
 static inline CpaStatus
-Mem_Alloc_Contig(void **ppMemAddr,
+mem_alloc_contig(void **ppMemAddr,
 		 Cpa32U sizeBytes,
 		 Cpa32U alignment)
 {
@@ -55,7 +68,7 @@ Mem_Alloc_Contig(void **ppMemAddr,
 }
 
 static inline void
-Mem_Free_Contig(void **ppMemAddr)
+mem_free_contig(void **ppMemAddr)
 {
 	if (*ppMemAddr != NULL) {
 		qaeMemFreeNUMA(ppMemAddr);
@@ -63,33 +76,15 @@ Mem_Free_Contig(void **ppMemAddr)
 	}
 }
 
-static inline CpaStatus
-OS_SLEEP(Cpa32U ms)
-{
-	int ret = 0;
-	struct timespec resTime, remTime;
-
-	resTime.tv_sec = ms / 1000;
-	resTime.tv_nsec = (ms % 1000) * 1000000;
-	do {
-		ret = nanosleep(&resTime, &remTime);
-		resTime = remTime;
-	} while ((ret != 0) && (errno == EINTR));
-
-	if (ret != 0)
-		return CPA_STATUS_FAIL;
-	else
-		return CPA_STATUS_SUCCESS;
-}
-
 static inline CpaPhysicalAddr
-virtToPhys(void *virtAddr)
+virt_to_phys(void *virtAddr)
 {
 	return (CpaPhysicalAddr)qaeVirtToPhysNUMA(virtAddr);
 }
 
+/** Get Compression Instance */
 static void
-getDcInstance(CpaInstanceHandle *pDcInstHandle)
+get_dc_instance(CpaInstanceHandle *pDcInstHandle)
 {
 	CpaInstanceHandle dcInstHandles[MAX_INSTANCES];
 	Cpa16U numInstances = 0;
@@ -103,16 +98,72 @@ getDcInstance(CpaInstanceHandle *pDcInstHandle)
 
 	if ((status == CPA_STATUS_SUCCESS) && (numInstances > 0)) {
 		status = cpaDcGetInstances(numInstances, dcInstHandles);
+		inst_num = (inst_num + 1) % numInstances;
 		if (status == CPA_STATUS_SUCCESS)
-			*pDcInstHandle = dcInstHandles[0];
+			*pDcInstHandle = dcInstHandles[inst_num];
 	}
 }
 
+/** Define user callback function for post processing */
 static void
-dcCallback(void *pCallbackTag, CpaStatus status)
+user_callback(void *user_cb_data, int produced, int status)
 {
-	if (pCallbackTag != NULL)
-		*(Cpa32U *)pCallbackTag = 1;
+	int *cb_data = (int *)user_cb_data;
+	if (status == DC_STATUS_OK)
+		*cb_data = produced;
+	else
+		*cb_data = status;
+}
+
+/** Define callback function triggered by QAT driver */
+static void
+dc_callback(void *pCallbackTag, CpaStatus status)
+{
+	int dc_status = DC_STATUS_OK;
+	int produced = 0;
+	dc_callback_fn user_cb_fn;
+	void *user_cb_data;
+	if (pCallbackTag != NULL) {
+		struct callback_data* cb_data =
+				(struct callback_data*)pCallbackTag;
+		user_cb_fn = cb_data->user_cb_fn;
+		user_cb_data = cb_data->user_cb_data;
+		produced = cb_data->dcResults->produced;
+		if (status == CPA_DC_OK &&
+		    produced > 0 &&
+		    produced <= cb_data->dstLen) {
+			/* Copy output from pinned-mem to virtual-mem */
+			memcpy(cb_data->dst,
+			       cb_data->pBufferListDst->pBuffers->pData,
+			       produced);
+		} else {
+			produced = 0;
+			if (status == CPA_DC_OVERFLOW)
+				dc_status = DC_STATUS_OVERFLOW;
+			else
+				dc_status = DC_STATUS_ERR;
+		}
+
+		/** Free memory */
+		mem_free_contig(
+			(void *)&cb_data->pBufferListSrc->pPrivateMetaData);
+		mem_free_contig(
+			(void *)&cb_data->pBufferListSrc->pPrivateMetaData);
+		mem_free_contig(
+			(void *)&cb_data->pBufferListSrc->pBuffers->pData);
+		mem_free_contig(
+			(void *)&cb_data->pBufferListDst->pPrivateMetaData);
+		mem_free_contig(
+			(void *)&cb_data->pBufferListDst->pBuffers->pData);
+		D_FREE(cb_data->pBufferListSrc);
+		D_FREE(cb_data->pBufferListDst);
+		D_FREE(cb_data->dcResults);
+		D_FREE(cb_data);
+
+		/** Now trigger user-defined callback function */
+		if (user_cb_fn)
+			(user_cb_fn)(user_cb_data, produced, dc_status);
+	}
 }
 
 /** Common Functions */
@@ -127,8 +178,13 @@ qat_dc_is_available()
 
 	cpaDcGetNumInstances(&numInstances);
 	icp_sal_userStop();
-
 	return (numInstances > 0);
+}
+
+int
+qat_dc_poll_response(CpaInstanceHandle *dcInstHandle)
+{
+	return icp_sal_DcPollInstance(*dcInstHandle, 0);
 }
 
 /** Compression Functions */
@@ -164,7 +220,7 @@ qat_dc_init(CpaInstanceHandle *dcInstHandle,
 		return DC_STATUS_ERR;
 	}
 
-	getDcInstance(dcInstHandle);
+	get_dc_instance(dcInstHandle);
 	if (*dcInstHandle == NULL) {
 		D_ERROR("QAT: No DC instance\n");
 		qaeMemDestroy();
@@ -180,7 +236,7 @@ qat_dc_init(CpaInstanceHandle *dcInstHandle,
 			numInterBuffLists);
 
 	if (status == CPA_STATUS_SUCCESS && *numInterBuffLists != 0)
-		status = Mem_Alloc_Contig(
+		status = mem_alloc_contig(
 			(void *)&interBufs,
 			*numInterBuffLists * sizeof(CpaBufferList *),
 			1);
@@ -191,17 +247,17 @@ qat_dc_init(CpaInstanceHandle *dcInstHandle,
 
 	for (i = 0; i < *numInterBuffLists; i++) {
 		if (status == CPA_STATUS_SUCCESS)
-			status = Mem_Alloc_Contig(
+			status = mem_alloc_contig(
 				(void *)&interBufs[i],
 				sizeof(CpaBufferList), 1);
 
 		if (status == CPA_STATUS_SUCCESS)
-			status = Mem_Alloc_Contig(
+			status = mem_alloc_contig(
 			(void *)(&interBufs[i]->pPrivateMetaData),
 			buffMetaSize, 1);
 
 		if (status == CPA_STATUS_SUCCESS)
-			status = Mem_Alloc_Contig(
+			status = mem_alloc_contig(
 				(void *)&interBufs[i]->pBuffers,
 				sizeof(CpaFlatBuffer), 1);
 
@@ -209,7 +265,7 @@ qat_dc_init(CpaInstanceHandle *dcInstHandle,
 			/* Implementation requires an intermediate */
 			/* buffer approximately twice the size of */
 			/* the output buffer */
-			status = Mem_Alloc_Contig(
+			status = mem_alloc_contig(
 				(void *)&interBufs[i]->pBuffers->pData,
 				2 * maxBufferSize, 1);
 			interBufs[i]->numBuffers = 1;
@@ -219,7 +275,8 @@ qat_dc_init(CpaInstanceHandle *dcInstHandle,
 	}
 
 	if (status == CPA_STATUS_SUCCESS)
-		status = cpaDcSetAddressTranslation(*dcInstHandle, virtToPhys);
+		status = cpaDcSetAddressTranslation(*dcInstHandle,
+						    virt_to_phys);
 
 	if (status == CPA_STATUS_SUCCESS)
 		status = cpaDcStartInstance(
@@ -239,7 +296,7 @@ qat_dc_init(CpaInstanceHandle *dcInstHandle,
 	}
 
 	if (status == CPA_STATUS_SUCCESS)
-		status = Mem_Alloc_Contig((void *)sessionHdl, sess_size, 1);
+		status = mem_alloc_contig((void *)sessionHdl, sess_size, 1);
 
 	/* Initialize the Stateless session */
 	if (status == CPA_STATUS_SUCCESS) {
@@ -248,7 +305,7 @@ qat_dc_init(CpaInstanceHandle *dcInstHandle,
 			*sessionHdl,
 			&sd,
 			NULL,
-			dcCallback);
+			dc_callback);
 	}
 
 	*bufferInterArrayPtr = interBufs;
@@ -262,14 +319,16 @@ qat_dc_init(CpaInstanceHandle *dcInstHandle,
 }
 
 int
-qat_dc_compress(CpaInstanceHandle *dcInstHandle,
+qat_dc_compress_async(
+		CpaInstanceHandle *dcInstHandle,
 		CpaDcSessionHandle *sessionHdl,
 		uint8_t *src,
 		size_t srcLen,
 		uint8_t *dst,
 		size_t dstLen,
-		size_t *produced,
-		enum QAT_COMPRESS_DIR dir)
+		enum QAT_COMPRESS_DIR dir,
+		dc_callback_fn user_cb_fn,
+		void *user_cb_data)
 {
 	CpaStatus status = CPA_STATUS_SUCCESS;
 	Cpa8U *pBufferMetaSrc = NULL;
@@ -280,13 +339,22 @@ qat_dc_compress(CpaInstanceHandle *dcInstHandle,
 	CpaFlatBuffer *pFlatBuffer = NULL;
 	Cpa8U *pSrcBuffer = NULL;
 	Cpa8U *pDstBuffer = NULL;
-	CpaDcRqResults dcResults;
+	CpaDcRqResults *dcResults;
 	CpaDcOpData opData = {};
 	Cpa32U numBuffers = 1;
-	Cpa32U complete = 0;
+	struct callback_data *cb_data;
+
+	D_ALLOC(cb_data, sizeof(struct callback_data));
+	D_ALLOC(dcResults, sizeof(CpaDcRqResults));
+
+	cb_data->dcResults = dcResults;
+	cb_data->dst = dst;
+	cb_data->dstLen = dstLen;
+	cb_data->user_cb_fn = user_cb_fn;
+	cb_data->user_cb_data = user_cb_data;
+
 	Cpa32U bufferListMemSize =
 		sizeof(CpaBufferList) + (numBuffers * sizeof(CpaFlatBuffer));
-	int rc = DC_STATUS_ERR;
 
 	opData.compressAndVerify = CPA_TRUE;
 
@@ -297,7 +365,7 @@ qat_dc_compress(CpaInstanceHandle *dcInstHandle,
 
 	/* Allocate source buffer */
 	if (status == CPA_STATUS_SUCCESS)
-		status = Mem_Alloc_Contig(
+		status = mem_alloc_contig(
 				(void *)&pBufferMetaSrc, bufferMetaSize, 1);
 
 
@@ -306,11 +374,11 @@ qat_dc_compress(CpaInstanceHandle *dcInstHandle,
 		status = pBufferListSrc ? CPA_STATUS_SUCCESS : CPA_STATUS_FAIL;
 	}
 	if (status == CPA_STATUS_SUCCESS)
-		status = Mem_Alloc_Contig((void *)&pSrcBuffer, srcLen, 1);
+		status = mem_alloc_contig((void *)&pSrcBuffer, srcLen, 1);
 
 	/* Allocate destination buffer the same size as source buffer */
 	if (status == CPA_STATUS_SUCCESS)
-		status = Mem_Alloc_Contig(
+		status = mem_alloc_contig(
 				(void *)&pBufferMetaDst, bufferMetaSize, 1);
 
 	if (status == CPA_STATUS_SUCCESS) {
@@ -318,7 +386,10 @@ qat_dc_compress(CpaInstanceHandle *dcInstHandle,
 		status = pBufferListDst ? CPA_STATUS_SUCCESS : CPA_STATUS_FAIL;
 	}
 	if (status == CPA_STATUS_SUCCESS)
-		status = Mem_Alloc_Contig((void *)&pDstBuffer, dstLen, 1);
+		status = mem_alloc_contig((void *)&pDstBuffer, dstLen, 1);
+
+	cb_data->pBufferListSrc = pBufferListSrc;
+	cb_data->pBufferListDst = pBufferListDst;
 
 	if (status == CPA_STATUS_SUCCESS) {
 		/* Copy source into buffer */
@@ -345,7 +416,7 @@ qat_dc_compress(CpaInstanceHandle *dcInstHandle,
 		pFlatBuffer->pData = pDstBuffer;
 
 		do {
-			/** keep trying to send the request until success */
+			/** Keep trying to send the request until success */
 			if (dir == DIR_COMPRESS)
 				status = cpaDcCompressData2(
 					*dcInstHandle,
@@ -353,8 +424,8 @@ qat_dc_compress(CpaInstanceHandle *dcInstHandle,
 					pBufferListSrc,
 					pBufferListDst,
 					&opData,
-					&dcResults,
-					(void *)&complete);
+					dcResults,
+					(void *)cb_data);
 			else
 				status = cpaDcDecompressData2(
 					*dcInstHandle,
@@ -362,38 +433,47 @@ qat_dc_compress(CpaInstanceHandle *dcInstHandle,
 					pBufferListSrc,
 					pBufferListDst,
 					&opData,
-					&dcResults,
-					(void *)&complete);
+					dcResults,
+					(void *)cb_data);
+			icp_sal_DcPollInstance(*dcInstHandle, 0);
 		} while (status == CPA_STATUS_RETRY);
-
-		if (status == CPA_STATUS_SUCCESS) {
-			/** wait until the completion of the operation */
-			do {
-				icp_sal_DcPollInstance(*dcInstHandle, 0);
-
-				/** Sleep and poll */
-				OS_SLEEP(10);
-			} while (!complete);
-
-			if (dcResults.status == CPA_DC_OK &&
-			    dcResults.produced <= dstLen) {
-				/** Copy the output to dst buffer */
-				memcpy(dst, pDstBuffer, dcResults.produced);
-				*produced = dcResults.produced;
-				rc = DC_STATUS_OK;
-			} else if (dcResults.status == CPA_DC_OVERFLOW)
-				rc = DC_STATUS_OVERFLOW;
-		}
 	}
 
-	Mem_Free_Contig((void *)&pBufferMetaSrc);
-	Mem_Free_Contig((void *)&pSrcBuffer);
-	Mem_Free_Contig((void *)&pBufferMetaDst);
-	Mem_Free_Contig((void *)&pDstBuffer);
-	D_FREE(pBufferListSrc);
-	D_FREE(pBufferListDst);
+	if (status == CPA_STATUS_SUCCESS)
+		return DC_STATUS_OK;
+	return DC_STATUS_ERR;
+}
 
-	return rc;
+int
+qat_dc_compress(CpaInstanceHandle *dcInstHandle,
+		CpaDcSessionHandle *sessionHdl,
+		uint8_t *src,
+		size_t srcLen,
+		uint8_t *dst,
+		size_t dstLen,
+		size_t *produced,
+		enum QAT_COMPRESS_DIR dir)
+{
+	int user_cb_data = 0;
+	CpaStatus status = CPA_STATUS_SUCCESS;
+
+	status = qat_dc_compress_async(dcInstHandle, sessionHdl,
+				       src, srcLen, dst, dstLen, dir,
+				       user_callback, (void*)&user_cb_data);
+
+	if (CPA_STATUS_SUCCESS == status) {
+		/** wait until the completion of the operation */
+		do {
+			icp_sal_DcPollInstance(*dcInstHandle, 0);
+		} while (user_cb_data == 0);
+	}
+
+	if (user_cb_data > 0) {
+		*produced = user_cb_data;
+		return DC_STATUS_OK;
+	}
+
+	return user_cb_data;
 }
 
 int
@@ -409,20 +489,20 @@ qat_dc_destroy(CpaInstanceHandle *dcInstHandle,
 	cpaDcStopInstance(*dcInstHandle);
 
 	/* Free session Context */
-	Mem_Free_Contig((void *)sessionHdl);
+	mem_free_contig((void *)sessionHdl);
 
 	/* Free intermediate buffers */
 	if (interBufs != NULL) {
 		for (i = 0; i < numInterBuffLists; i++) {
-			Mem_Free_Contig((void *)
+			mem_free_contig((void *)
 					&interBufs[i]->pBuffers->pData);
-			Mem_Free_Contig((void *)
+			mem_free_contig((void *)
 					&interBufs[i]->pBuffers);
-			Mem_Free_Contig((void *)
+			mem_free_contig((void *)
 					&interBufs[i]->pPrivateMetaData);
-			Mem_Free_Contig((void *)&interBufs[i]);
+			mem_free_contig((void *)&interBufs[i]);
 		}
-		Mem_Free_Contig((void *)&interBufs);
+		mem_free_contig((void *)&interBufs);
 	}
 
 	icp_sal_userStop();

--- a/src/common/tests/SConscript
+++ b/src/common/tests/SConscript
@@ -8,12 +8,6 @@ def define_checksum_timing(build, env, prereqs):
     build.test(env, 'checksum_timing', 'checksum_timing.c',
                LIBS=checksum_timing_libs)
 
-def define_compress_timing(build, env, prereqs):
-    """Define the Compress Timing build"""
-    compress_timing_libs = ['daos_common', 'gurt']
-    build.test(env, 'compress_timing', 'compress_timing.c',
-               LIBS=compress_timing_libs)
-
 def scons():
     """Execute build"""
     Import('tenv', 'prereqs')
@@ -48,7 +42,6 @@ def scons():
     daos_build.test(tenv, 'prop_tests', 'prop_tests.c',
                     LIBS=['daos_common', 'gurt', 'cmocka'])
     define_checksum_timing(daos_build, tenv, prereqs)
-    define_compress_timing(daos_build, tenv, prereqs)
 
     tenv.Install('$PREFIX/bin/', [common_test])
 

--- a/src/common/tests/SConscript
+++ b/src/common/tests/SConscript
@@ -8,6 +8,11 @@ def define_checksum_timing(build, env, prereqs):
     build.test(env, 'checksum_timing', 'checksum_timing.c',
                LIBS=checksum_timing_libs)
 
+def define_compress_timing(build, env, prereqs):
+    """Define the Compress Timing build"""
+    compress_timing_libs = ['daos_common', 'gurt']
+    build.test(env, 'compress_timing', 'compress_timing.c',
+               LIBS=compress_timing_libs)
 
 def scons():
     """Execute build"""
@@ -43,6 +48,7 @@ def scons():
     daos_build.test(tenv, 'prop_tests', 'prop_tests.c',
                     LIBS=['daos_common', 'gurt', 'cmocka'])
     define_checksum_timing(daos_build, tenv, prereqs)
+    define_compress_timing(daos_build, tenv, prereqs)
 
     tenv.Install('$PREFIX/bin/', [common_test])
 

--- a/src/include/daos/compression.h
+++ b/src/include/daos/compression.h
@@ -76,17 +76,36 @@ struct daos_compressor {
 	void *dc_ctx;
 };
 
+typedef void (*dc_callback_fn)(void *cb_data, int produced, int status);
+
 struct compress_ft {
-	int		(*cf_init)(void **daos_dc_ctx,
-				   uint16_t level, uint32_t max_buf_size);
-	int		(*cf_compress)(void *daos_dc_ctx,
-				       uint8_t *src, size_t src_len,
-				       uint8_t *dst, size_t dst_len,
-				       size_t *produced);
-	int		(*cf_decompress)(void *daos_mhash_ctx,
-					 uint8_t *src, size_t src_len,
-					 uint8_t *dst, size_t dst_len,
-					 size_t *produced);
+	int		(*cf_init)(
+				void **daos_dc_ctx,
+				uint16_t level,
+				uint32_t max_buf_size);
+	int		(*cf_compress)(
+				void *daos_dc_ctx,
+				uint8_t *src, size_t src_len,
+				uint8_t *dst, size_t dst_len,
+				size_t *produced);
+	int		(*cf_decompress)(
+				void *daos_mhash_ctx,
+				uint8_t *src, size_t src_len,
+				uint8_t *dst, size_t dst_len,
+				size_t *produced);
+	int		(*cf_compress_async)(
+				void *daos_dc_ctx, 
+				uint8_t *src, size_t src_len,
+				uint8_t *dst, size_t dst_len,
+				dc_callback_fn cb_fn,
+				void *cb_data);
+	int		(*cf_decompress_async)(
+				void *daos_dc_ctx, 
+				uint8_t *src, size_t src_len,
+				uint8_t *dst, size_t dst_len,
+				dc_callback_fn cb_fn,
+				void *cb_data);
+	int		(*cf_poll_response)(void *daos_dc_ctx);
 	void		(*cf_destroy)(void *daos_dc_ctx);
 	int		(*cf_available)();
 	uint16_t	cf_level;
@@ -107,9 +126,10 @@ daos_compress_type2algo(enum DAOS_COMPRESS_TYPE type, bool qat_preferred);
  *		in qat, if the size is set to 0, 64KB is used by default.
  */
 int
-daos_compressor_init(struct daos_compressor **obj,
-		     struct compress_ft *ft,
-		     uint32_t max_buf_size);
+daos_compressor_init(
+		struct daos_compressor **obj,
+		struct compress_ft *ft,
+		uint32_t max_buf_size);
 
 /**
  * Initialize compressor with the specified compress type.
@@ -122,10 +142,11 @@ daos_compressor_init(struct daos_compressor **obj,
  *		in qat, if the size is set to 0, 64KB is used by default.
  */
 int
-daos_compressor_init_with_type(struct daos_compressor **obj,
-			       enum DAOS_COMPRESS_TYPE type,
-			       bool qat_preferred,
-			       uint32_t max_buf_size);
+daos_compressor_init_with_type(
+		struct daos_compressor **obj,
+		enum DAOS_COMPRESS_TYPE type,
+		bool qat_preferred,
+		uint32_t max_buf_size);
 
 /**
  * Compression function.
@@ -139,10 +160,30 @@ daos_compressor_init_with_type(struct daos_compressor **obj,
  * \param[out]	produced	length of compress result.
  */
 int
-daos_compressor_compress(struct daos_compressor *obj,
-			 uint8_t *src_buf, size_t src_len,
-			 uint8_t *dst_buf, size_t dst_len,
-			 size_t *produced);
+daos_compressor_compress(
+		struct daos_compressor *obj,
+		uint8_t *src_buf, size_t src_len,
+		uint8_t *dst_buf, size_t dst_len,
+		size_t *produced);
+
+/**
+ * Compression asynchronous function.
+ *
+ * \param[in]	obj		compressor.
+ * \param[in]	src_buf		pointer to the buffer to be compressed.
+ * \param[in]	src_len		length of the buffer to be compressed.
+ * \param[in]	dst_buf		pointer to the pre-allocated output buffer
+ *				for the compression result.
+ * \param[in]	dst_len		length of the output buffer.
+ * \param[out]	cb_fn		callback function when async call complete.
+ * \param[out]	cb_data		transparent data sent back to callback func.
+ */
+int
+daos_compressor_compress_async(
+		struct daos_compressor *obj,
+		uint8_t *src_buf, size_t src_len,
+		uint8_t *dst_buf, size_t dst_len,
+		dc_callback_fn cb_fn, void *cb_data);
 
 /**
  * DeCompression function.
@@ -156,10 +197,38 @@ daos_compressor_compress(struct daos_compressor *obj,
  * \param[out]	produced	length of decompress result.
  */
 int
-daos_compressor_decompress(struct daos_compressor *obj,
-			   uint8_t *src_buf, size_t src_len,
-			   uint8_t *dst_buf, size_t dst_len,
-			   size_t *produced);
+daos_compressor_decompress(
+		struct daos_compressor *obj,
+		uint8_t *src_buf, size_t src_len,
+		uint8_t *dst_buf, size_t dst_len,
+		size_t *produced);
+
+/**
+ * DeCompression asynchronous function.
+ *
+ * \param[in]	obj		compressor.
+ * \param[in]	src_buf		pointer to the buffer to be de-compressed.
+ * \param[in]	src_len		length of the buffer to be de-compressed.
+ * \param[in]	dst_buf		pointer to the pre-allocated output buffer
+ *				for the decompression result.
+ * \param[in]	dst_len		length of the output buffer.
+ * \param[out]	cb_fn		callback function when async call complete.
+ * \param[out]	cb_data		transparent data sent back to callback func.
+ */
+int
+daos_compressor_decompress_async(
+		struct daos_compressor *obj,
+		uint8_t *src_buf, size_t src_len,
+		uint8_t *dst_buf, size_t dst_len,
+		dc_callback_fn cb_fn, void *cb_data);
+
+/**
+ * Poll response on asynchronous mode.
+ *
+ * \param[in]	obj		compressor.
+ */
+int
+daos_compressor_poll_response(struct daos_compressor *obj);
 
 /**
  * Destroy and release the compressor.

--- a/src/include/daos/compression.h
+++ b/src/include/daos/compression.h
@@ -94,13 +94,13 @@ struct compress_ft {
 				uint8_t *dst, size_t dst_len,
 				size_t *produced);
 	int		(*cf_compress_async)(
-				void *daos_dc_ctx, 
+				void *daos_dc_ctx,
 				uint8_t *src, size_t src_len,
 				uint8_t *dst, size_t dst_len,
 				dc_callback_fn cb_fn,
 				void *cb_data);
 	int		(*cf_decompress_async)(
-				void *daos_dc_ctx, 
+				void *daos_dc_ctx,
 				uint8_t *src, size_t src_len,
 				uint8_t *dst, size_t dst_len,
 				dc_callback_fn cb_fn,

--- a/src/include/daos/qat.h
+++ b/src/include/daos/qat.h
@@ -58,6 +58,20 @@ qat_dc_compress(CpaInstanceHandle *dcInstHandle,
 		size_t *produced,
 		enum QAT_COMPRESS_DIR dir);
 
+int qat_dc_compress_async(
+		CpaInstanceHandle *dcInstHandle,
+		CpaDcSessionHandle *sessionHdl,
+		uint8_t *src,
+		size_t srcLen,
+		uint8_t *dst,
+		size_t dstLen,
+		enum QAT_COMPRESS_DIR dir,
+		dc_callback_fn user_cb_fn,
+		void *user_cb_data);
+
+int
+qat_dc_poll_response(CpaInstanceHandle *dcInstHandle);
+
 int
 qat_dc_destroy(CpaInstanceHandle *dcInstHandle,
 	       CpaDcSessionHandle *sessionHdl,


### PR DESCRIPTION
* Support function "daos_compressor_(de)compress_async",
  user doesn't need to wait for completion, the post-processing
  work can be done in the registered callback function.

* The synchronous QAT function "qat_dc_compress" relies on
  "qat_dc_compress_async" now, the sync function polls response
  in the current context.

* The compress_timing test will be added in the next PR to support
  test cases for asynchronous functions.

Signed-off-by: Weigang Li <weigang.li@intel.com>