### PR TITLE
DAOS-6087 il: Handle large pool sizes by backing off.

### DIFF
--- a/src/client/dfuse/il/int_posix.c
+++ b/src/client/dfuse/il/int_posix.c
@@ -620,7 +620,7 @@ open_cont:
 		d_list_add(&pool->iop_pools, &ioil_iog.iog_pools_head);
 
 	rc = ioil_fetch_cont_handles(fd, cont);
-	if (rc == EPERM) {
+	if (rc == EPERM || rc == EOVERFLOW) {
 		bool rcb;
 
 		DFUSE_LOG_DEBUG("ioil_fetch_cont_handles() failed, backing off");

--- a/src/client/dfuse/ops/ioctl.c
+++ b/src/client/dfuse/ops/ioctl.c
@@ -28,6 +28,8 @@
 
 #include "dfuse_ioctl.h"
 
+#define MAX_IOCTL_SIZE ((1024*16)-1)
+
 static void
 handle_il_ioctl(struct dfuse_obj_hdl *oh, fuse_req_t req)
 {
@@ -67,18 +69,24 @@ handle_size_ioctl(struct dfuse_obj_hdl *oh, fuse_req_t req)
 		D_GOTO(err, rc = daos_der2errno(rc));
 
 	hs_reply.fsr_pool_size = iov.iov_buf_len;
+	if (hs_reply.fsr_pool_size > MAX_IOCTL_SIZE)
+		D_GOTO(err, rc = EOVERFLOW);
 
 	rc = daos_cont_local2global(oh->doh_ie->ie_dfs->dfs_coh, &iov);
 	if (rc)
 		D_GOTO(err, rc = daos_der2errno(rc));
 
 	hs_reply.fsr_cont_size = iov.iov_buf_len;
+	if (hs_reply.fsr_cont_size > MAX_IOCTL_SIZE)
+		D_GOTO(err, rc = EOVERFLOW);
 
 	rc = dfs_local2global(oh->doh_ie->ie_dfs->dfs_ns, &iov);
 	if (rc)
 		D_GOTO(err, rc);
 
 	hs_reply.fsr_dfs_size = iov.iov_buf_len;
+	if (hs_reply.fsr_dfs_size > MAX_IOCTL_SIZE)
+		D_GOTO(err, rc = EOVERFLOW);
 
 	DFUSE_REPLY_IOCTL(oh, req, hs_reply);
 	return;
@@ -160,6 +168,8 @@ handle_dsize_ioctl(struct dfuse_obj_hdl *oh, fuse_req_t req)
 		D_GOTO(err, rc = daos_der2errno(rc));
 
 	hsd_reply.fsr_dobj_size = iov.iov_buf_len;
+	if (hsd_reply.fsr_dobj_size > MAX_IOCTL_SIZE)
+		D_GOTO(err, rc = EOVERFLOW);
 
 	DFUSE_REPLY_IOCTL(oh, req, hsd_reply);
 	return;

--- a/src/client/dfuse/ops/ioctl.c
+++ b/src/client/dfuse/ops/ioctl.c
@@ -28,7 +28,7 @@
 
 #include "dfuse_ioctl.h"
 
-#define MAX_IOCTL_SIZE ((1024*16)-1)
+#define MAX_IOCTL_SIZE ((1024 * 16) - 1)
 
 static void
 handle_il_ioctl(struct dfuse_obj_hdl *oh, fuse_req_t req)


### PR DESCRIPTION
When a global pool handle is too large then back off to using
pool_connect etc rather than aborting.  This works, but does mean
on large systems additional steps are required to setup
interception, so an attempt at compression would be preferred here.

This re-instates the behaviour that we had until
4da39276479affaf05d79cd6010ac0142cacc016 where the IL would retry
on any error, the improvements there included only retrying on EPERM,
but this change allows it to retry on EOVERFLOW as well.

Signed-off-by: Ashley Pittman <ashley.m.pittman@intel.com>