### PR TITLE
DAOS-623 build: Add a BuildPriority parameter

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -402,7 +402,7 @@ String quick_build_deps(String distro) {
     } else {
         error("Unknown distro: ${distro} in quick_build_deps()")
     }
-    return sh(label:'Get Quickbuild dependencies',
+    return sh(label: 'Get Quickbuild dependencies',
               script: "rpmspec -q " +
                       "--srpm " +
                       rpmspec_args + ' ' +
@@ -430,6 +430,10 @@ pipeline {
         // preserve stashes so that jobs can be started at the test stage
         preserveStashes(buildCount: 5)
         ansiColor('xterm')
+    }
+
+    parameters {
+        string(name: 'BuildPriority', defaultValue: '', description: 'Priority of the build.  DO NOT USE WITHOUT PERMISSION.')
     }
 
     stages {


### PR DESCRIPTION
To make use of the Priority Sorter plugin.

This requires you to go to the Classic View page for your PR and click
Build with Parameters and then fill in a priority for your PR.  That
will cancel the existing run-in-progress and start a new run with the
specified priority.

This is a feature that should be used sparingly and only in the most
emergent cases of needing to prioritize a PR.  My suggestion would be
that it requires gatekeeper approval to use.  But use pollicy is some-
thing that can be decided later and tuned as time goes on.

Signed-off-by: Brian J. Murrell <brian.murrell@intel.com>