### PR TITLE
DAOS-4453 container: create_snap should not read epoch

### DIFF
--- a/src/container/srv_epoch.c
+++ b/src/container/srv_epoch.c
@@ -217,20 +217,14 @@ ds_cont_snap_create(struct rdb_tx *tx, struct ds_pool_hdl *pool_hdl,
 	daos_epoch_t			snap_eph;
 	int				rc;
 
-	D_DEBUG(DF_DSMS, DF_CONT": processing rpc %p: epoch="DF_U64"\n",
-		DP_CONT(pool_hdl->sph_pool->sp_uuid, in->cei_op.ci_uuid), rpc,
-		in->cei_epoch);
+	D_DEBUG(DF_DSMS, DF_CONT": processing rpc %p\n",
+		DP_CONT(pool_hdl->sph_pool->sp_uuid, in->cei_op.ci_uuid), rpc);
 
 	/* Verify handle has write access */
 	if (!ds_sec_cont_can_write_data(hdl->ch_sec_capas)) {
 		D_ERROR(DF_CONT": permission denied to create snapshot\n",
 			DP_CONT(cont->c_svc->cs_pool_uuid, cont->c_uuid));
 		rc = -DER_NO_PERM;
-		goto out;
-	}
-
-	if (in->cei_epoch >= DAOS_EPOCH_MAX) {
-		rc = -DER_OVERFLOW;
 		goto out;
 	}
 


### PR DESCRIPTION
The epoch parameter of daos_cont_create_snap is an output-only
parameter. It is currently set to the client HLC reading by
dc_cont_create_snap and read by dc_epoch_op and ds_cont_snap_create.
This patch removes the confusing setting and reading.

Signed-off-by: Li Wei <wei.g.li@intel.com>