### PR TITLE
DAOS-623 test: Use d_errstr rather than numeric code in output

### DIFF
--- a/src/object/cli_obj.c
+++ b/src/object/cli_obj.c
@@ -3111,8 +3111,9 @@ obj_shard_comp_cb(struct shard_auxi_args *shard_auxi,
 		    !obj_auxi->spec_group && !obj_auxi->to_leader) {
 			int new_tgt;
 
-			/* Check if there are other replicas avaible to fulfill the
-			 * request */
+			/* Check if there are other replicas available to
+			 * fulfill the request
+			 */
 			obj_auxi_add_failed_tgt(obj_auxi, shard_auxi->target);
 			new_tgt = obj_shard_find_replica(obj_auxi->obj,
 						 shard_auxi->target,

--- a/src/vos/tests/vts_mvcc.c
+++ b/src/vos/tests/vts_mvcc.c
@@ -1220,17 +1220,17 @@ conflicting_rw_exec_one(struct io_test_args *arg, int i, int j, bool empty,
 		print_message("  update(%s, "DF_X64") before %s(%s, "
 			      DF_X64"): ", pp, re - 1, r->o_name, rp, re);
 		rc = update_f(arg, NULL /* txh */, pp, re - 1);
-		print_message("%d\n", rc);
+		print_message("%s\n", d_errstr(rc));
 		if (rc != 0) {
 			nfailed++;
 			goto out;
 		}
 	}
 
-	print_message("  %s(%s, "DF_X64") (expect %d): ",
-		      r->o_name, rp, re, expected_rrc);
+	print_message("  %s(%s, "DF_X64") (expect %s): ",
+		      r->o_name, rp, re, d_errstr(expected_rrc));
 	rc = r->o_func(arg, rtx, rp, re);
-	print_message("%d\n", rc);
+	print_message("%s\n", d_errstr(rc));
 	if (rc != expected_rrc) {
 		nfailed++;
 		goto out;
@@ -1261,10 +1261,10 @@ conflicting_rw_exec_one(struct io_test_args *arg, int i, int j, bool empty,
 		else if (w->o_rtype == R_NE && e)
 			expected_wrc = -DER_NONEXIST;
 	}
-	print_message("  %s(%s, "DF_X64") (expect %d): ",
-		      w->o_name, wp, we, expected_wrc);
+	print_message("  %s(%s, "DF_X64") (expect %s): ",
+		      w->o_name, wp, we, d_errstr(expected_wrc));
 	rc = w->o_func(arg, wtx, wp, we);
-	print_message("%d\n", rc);
+	print_message("%s\n", d_errstr(rc));
 	if (rc != expected_wrc)
 		nfailed++;
 
@@ -1424,9 +1424,10 @@ uncertainty_check_exec_one(struct io_test_args *arg, int i, int j, bool empty,
 		daos_epoch_t	pe = ae - 1;
 
 		memcpy(pp, wp, strlen(wp));
-		print_message("  update(%s, "DF_U64") (expect 0): ", pp, pe);
+		print_message("  update(%s, "DF_U64") (expect DER_SUCCESS): ",
+			      pp, pe);
 		rc = update_f(arg, NULL /* txh */, pp, pe);
-		print_message("%d\n", rc);
+		print_message("%s\n", d_errstr(rc));
 		if (rc != 0) {
 			nfailed++;
 			goto out;
@@ -1445,9 +1446,10 @@ uncertainty_check_exec_one(struct io_test_args *arg, int i, int j, bool empty,
 	atx->th_epoch_bound = bound;
 
 	/* Perform w. */
-	print_message("  %s(%s, "DF_X64") (expect 0): ", w->o_name, wp, we);
+	print_message("  %s(%s, "DF_X64") (expect DER_SUCCESS): ", w->o_name,
+		      wp, we);
 	rc = w->o_func(arg, wtx, wp, we);
-	print_message("%d\n", rc);
+	print_message("%s\n", d_errstr(rc));
 	if (rc != 0) {
 		nfailed++;
 		goto out;
@@ -1468,13 +1470,14 @@ uncertainty_check_exec_one(struct io_test_args *arg, int i, int j, bool empty,
 		}
 	}
 	if (is_punch(w) && we > bound)
-		print_message("  %s(%s, "DF_X64") (expect %d or %d): ",
-			      a->o_name, ap, ae, expected_arc, -DER_TX_RESTART);
+		print_message("  %s(%s, "DF_X64
+			      ") (expect %s or DER_TX_RESTART): ", a->o_name,
+			      ap, ae, d_errstr(expected_arc));
 	else
-		print_message("  %s(%s, "DF_X64") (expect %d): ",
-			      a->o_name, ap, ae, expected_arc);
+		print_message("  %s(%s, "DF_X64") (expect %s): ",
+			      a->o_name, ap, ae, d_errstr(expected_arc));
 	rc = a->o_func(arg, atx, ap, ae);
-	print_message("%d\n", rc);
+	print_message("%s\n", d_errstr(rc));
 	if (rc != expected_arc) {
 		if (is_punch(w) && we > bound && rc == -DER_TX_RESTART)
 			goto out;


### PR DESCRIPTION
Modifies the mvcc test to use the d_errstr version of the error
code rather than the numeric code for easier reading

Also fix an unrelated spelling error

Signed-off-by: Jeff Olivier <jeffrey.v.olivier@intel.com>