### PR TITLE
DAOS-6133 rebuild: store migrated objects into migrated tree

### DIFF
--- a/src/object/obj_internal.h
+++ b/src/object/obj_internal.h
@@ -208,6 +208,12 @@ struct migrate_pool_tls {
 	daos_handle_t		mpt_root_hdl;
 	struct btr_root		mpt_root;
 
+	/* Container/objects already migrated will be attached to the tree, to
+	 * avoid the object being migrated multiple times.
+	 */
+	daos_handle_t		mpt_migrated_root_hdl;
+	struct btr_root		mpt_migrated_root;
+
 	/* Hash table to store the container uuids which have already been
 	 * deleted (used by reintegration)
 	 */

--- a/src/object/srv_obj_migrate.c
+++ b/src/object/srv_obj_migrate.c
@@ -201,6 +201,45 @@ container_tree_create(daos_handle_t toh, uuid_t uuid,
 }
 
 int
+obj_tree_lookup(daos_handle_t toh, uuid_t co_uuid, daos_unit_oid_t oid,
+		d_iov_t *val_iov)
+{
+	struct tree_cache_root	*cont_root = NULL;
+	d_iov_t			key_iov;
+	d_iov_t			tmp_iov;
+	int			rc;
+
+	/* locate the container first */
+	d_iov_set(&key_iov, co_uuid, sizeof(uuid_t));
+	d_iov_set(&tmp_iov, NULL, 0);
+	rc = dbtree_lookup(toh, &key_iov, &tmp_iov);
+	if (rc < 0) {
+		if (rc != -DER_NONEXIST)
+			D_ERROR("lookup cont "DF_UUID" failed, "DF_RC"\n",
+				DP_UUID(co_uuid), DP_RC(rc));
+		else
+			D_DEBUG(DB_TRACE, "Container "DF_UUID" not exist\n",
+				DP_UUID(co_uuid));
+		return rc;
+	}
+
+	cont_root = tmp_iov.iov_buf;
+	/* Then try to insert the object under the container */
+	d_iov_set(&key_iov, &oid, sizeof(oid));
+	rc = dbtree_lookup(cont_root->root_hdl, &key_iov, val_iov);
+	if (rc < 0) {
+		if (rc != -DER_NONEXIST)
+			D_ERROR(DF_UUID"/"DF_UOID" "DF_RC"\n",
+				DP_UUID(co_uuid), DP_UOID(oid), DP_RC(rc));
+		else
+			D_DEBUG(DB_TRACE, DF_UUID"/"DF_UOID " not exist\n",
+				DP_UUID(co_uuid), DP_UOID(oid));
+	}
+
+	return rc;
+}
+
+int
 obj_tree_insert(daos_handle_t toh, uuid_t co_uuid, daos_unit_oid_t oid,
 		d_iov_t *val_iov)
 {
@@ -273,6 +312,8 @@ migrate_pool_tls_destroy(struct migrate_pool_tls *tls)
 		ABT_eventual_free(&tls->mpt_done_eventual);
 	if (!daos_handle_is_inval(tls->mpt_root_hdl))
 		obj_tree_destroy(tls->mpt_root_hdl);
+	if (!daos_handle_is_inval(tls->mpt_migrated_root_hdl))
+		obj_tree_destroy(tls->mpt_migrated_root_hdl);
 	d_list_del(&tls->mpt_list);
 	D_FREE(tls);
 }
@@ -922,7 +963,7 @@ migrate_fetch_update_bulk(struct migrate_one *mrone, daos_handle_t oh,
 	d_sg_list_t	 sgls[DSS_ENUM_UNPACK_MAX_IODS], *sgl;
 	daos_handle_t	 ioh;
 	struct daos_oclass_attr *oca;
-	int		 rc, i, ret, sgl_cnt = 0;
+	int		 rc, rc1, i, ret, sgl_cnt = 0;
 
 	if (obj_shard_is_ec_parity(mrone->mo_oid, &oca))
 		return migrate_fetch_update_parity(mrone, oh, ds_cont, oca);
@@ -992,7 +1033,9 @@ post:
 	}
 
 end:
-	vos_update_end(ioh, mrone->mo_version, &mrone->mo_dkey, rc, NULL);
+	rc1 = vos_update_end(ioh, mrone->mo_version, &mrone->mo_dkey, rc, NULL);
+	if (rc == 0)
+		rc = rc1;
 	return rc;
 }
 
@@ -1139,7 +1182,7 @@ free:
 	return rc;
 }
 
-void
+static void
 migrate_one_destroy(struct migrate_one *mrone)
 {
 	int i;
@@ -1976,6 +2019,12 @@ free:
 	migrate_pool_tls_put(tls);
 }
 
+struct migrate_obj_val {
+	daos_epoch_t	epoch;
+	uint32_t	shard;
+	uint32_t	tgt_idx;
+};
+
 static int
 migrate_one_object(daos_unit_oid_t oid, daos_epoch_t eph, unsigned int shard,
 		   unsigned int tgt_idx, void *data)
@@ -2011,20 +2060,34 @@ migrate_one_object(daos_unit_oid_t oid, daos_epoch_t eph, unsigned int shard,
 	rc = dss_ult_create(migrate_obj_ult, obj_arg, DSS_ULT_REBUILD,
 			    oid.id_pub.lo % dss_tgt_nr, MIGRATE_STACK_SIZE,
 			    NULL);
-	if (rc == 0)
-		cont_arg->pool_tls->mpt_obj_generated_ult++;
+	if (rc == 0) {
+		struct migrate_pool_tls *tls = cont_arg->pool_tls;
+		daos_handle_t		toh = tls->mpt_migrated_root_hdl;
+		struct migrate_obj_val	val;
+		d_iov_t			val_iov;
+		int			ret;
+
+		tls->mpt_obj_generated_ult++;
+
+		D_ASSERT(daos_handle_is_valid(toh));
+		val.epoch = eph;
+		val.shard = shard;
+		val.tgt_idx = tgt_idx;
+
+		d_iov_set(&val_iov, &val, sizeof(struct migrate_obj_val));
+		ret = obj_tree_insert(toh, cont_arg->cont_uuid, oid, &val_iov);
+		D_DEBUG(DB_REBUILD, "Insert "DF_UUID"/"DF_UOID": "DF_RC"\n",
+			DP_UUID(cont_arg->cont_uuid), DP_UOID(oid), DP_RC(ret));
+	}
+
+	return rc;
+
 free:
 	if (rc)
 		D_FREE(obj_arg);
 
 	return rc;
 }
-
-struct migrate_obj_val {
-	daos_epoch_t	epoch;
-	uint32_t	shard;
-	uint32_t	tgt_idx;
-};
 
 #define DEFAULT_YIELD_FREQ	128
 
@@ -2294,47 +2357,87 @@ migrate_ult(void *arg)
 	migrate_pool_tls_put(pool_tls);
 }
 
+/**
+ * Init migrate objects tree, so the migrating objects are added to
+ * to-be-migrated tree(mpt_root/mpt_root_hdl) first, then moved to
+ * migrated tree once it is being migrated. (mpt_migrated_root/
+ * mpt_migrated_root_hdl). The incoming objects will check both
+ * tree to see if the objects being migrated already.
+ */
 static int
-migrate_tree_get_hdl(struct migrate_pool_tls *tls, daos_handle_t *hdl)
+migrate_init_object_tree(struct migrate_pool_tls *tls)
 {
-	struct umem_attr uma = { 0 };
+	struct umem_attr uma;
 	int rc;
 
-	if (!daos_handle_is_inval(tls->mpt_root_hdl)) {
-		*hdl = tls->mpt_root_hdl;
-		return 0;
+	if (daos_handle_is_inval(tls->mpt_root_hdl)) {
+		/* migrate tree root init */
+		memset(&uma, 0, sizeof(uma));
+		uma.uma_id = UMEM_CLASS_VMEM;
+		rc = dbtree_create_inplace(DBTREE_CLASS_NV, 0, 4, &uma,
+					   &tls->mpt_root,
+					   &tls->mpt_root_hdl);
+		if (rc != 0) {
+			D_ERROR("failed to create tree: "DF_RC"\n", DP_RC(rc));
+			return rc;
+		}
 	}
 
-	/* migrate tree root init */
-	memset(&uma, 0, sizeof(uma));
-	uma.uma_id = UMEM_CLASS_VMEM;
-	rc = dbtree_create_inplace(DBTREE_CLASS_NV, 0, 4, &uma,
-				   &tls->mpt_root,
-				   &tls->mpt_root_hdl);
-	if (rc != 0) {
-		D_ERROR("failed to create tree: "DF_RC"\n", DP_RC(rc));
-		return rc;
+	if (daos_handle_is_inval(tls->mpt_migrated_root_hdl)) {
+		/* migrate tree root init */
+		memset(&uma, 0, sizeof(uma));
+		uma.uma_id = UMEM_CLASS_VMEM;
+		rc = dbtree_create_inplace(DBTREE_CLASS_NV, 0, 4, &uma,
+					   &tls->mpt_migrated_root,
+					   &tls->mpt_migrated_root_hdl);
+		if (rc != 0) {
+			D_ERROR("failed to create tree: "DF_RC"\n", DP_RC(rc));
+			return rc;
+		}
 	}
 
-	*hdl = tls->mpt_root_hdl;
 	return 0;
 }
 
-int
-migrate_obj_insert(daos_handle_t toh, uuid_t co_uuid, daos_unit_oid_t oid,
-		   daos_epoch_t epoch, unsigned int shard, unsigned int tgt_idx)
+/**
+ * Only insert objects if the objects does not exist in both
+ * tobe-migrated tree and migrated tree.
+ */
+static int
+migrate_try_obj_insert(struct migrate_pool_tls *tls, uuid_t co_uuid,
+		       daos_unit_oid_t oid, daos_epoch_t epoch,
+		       unsigned int shard, unsigned int tgt_idx)
 {
 	struct migrate_obj_val	val;
+	daos_handle_t		toh = tls->mpt_root_hdl;
+	daos_handle_t		migrated_toh = tls->mpt_migrated_root_hdl;
 	d_iov_t			val_iov;
 	int			rc;
+
+	D_ASSERT(daos_handle_is_valid(toh));
+	D_ASSERT(daos_handle_is_valid(migrated_toh));
 
 	val.epoch = epoch;
 	val.shard = shard;
 	val.tgt_idx = tgt_idx;
+	D_DEBUG(DB_REBUILD, "Insert migrate "DF_UUID"/"DF_UOID" "DF_U64
+		"/%d/%d\n", DP_UUID(co_uuid), DP_UOID(oid), epoch, shard,
+		tgt_idx);
 
-	D_DEBUG(DB_REBUILD, "Insert migrate "DF_UOID" "DF_U64"/%d/%d\n",
-		DP_UOID(oid), epoch, shard, tgt_idx);
 	d_iov_set(&val_iov, &val, sizeof(struct migrate_obj_val));
+	rc = obj_tree_lookup(toh, co_uuid, oid, &val_iov);
+	if (rc != -DER_NONEXIST) {
+		D_DEBUG(DB_REBUILD, DF_UUID"/"DF_UOID" not need insert: "
+			DF_RC"\n", DP_UUID(co_uuid), DP_UOID(oid), DP_RC(rc));
+		return rc;
+	}
+
+	rc = obj_tree_lookup(migrated_toh, co_uuid, oid, &val_iov);
+	if (rc != -DER_NONEXIST) {
+		D_DEBUG(DB_REBUILD, DF_UUID"/"DF_UOID" not need insert: "
+			DF_RC"\n", DP_UUID(co_uuid), DP_UOID(oid), DP_RC(rc));
+		return rc;
+	}
 
 	rc = obj_tree_insert(toh, co_uuid, oid, &val_iov);
 
@@ -2356,7 +2459,6 @@ ds_obj_migrate_handler(crt_rpc_t *rpc)
 	unsigned int		ephs_count;
 	uint32_t		*shards;
 	unsigned int		shards_count;
-	daos_handle_t		btr_hdl;
 	uuid_t			po_uuid;
 	uuid_t			po_hdl_uuid;
 	uuid_t			co_uuid;
@@ -2412,15 +2514,15 @@ ds_obj_migrate_handler(crt_rpc_t *rpc)
 		D_GOTO(out, rc = -DER_NOMEM);
 
 	/* NB: only create this tree on xstream 0 */
-	rc = migrate_tree_get_hdl(pool_tls, &btr_hdl);
+	rc = migrate_init_object_tree(pool_tls);
 	if (rc)
 		D_GOTO(out, rc);
 
 	/* Insert these oids/conts into the local tree */
 	for (i = 0; i < oids_count; i++) {
 		/* firstly insert/check rebuilt tree */
-		rc = migrate_obj_insert(btr_hdl, co_uuid, oids[i], ephs[i],
-					shards[i], migrate_in->om_tgt_idx);
+		rc = migrate_try_obj_insert(pool_tls, co_uuid, oids[i], ephs[i],
+					    shards[i], migrate_in->om_tgt_idx);
 		if (rc == -DER_EXIST) {
 			D_DEBUG(DB_TRACE, DF_UOID"/"DF_UUID"exists.\n",
 				DP_UOID(oids[i]), DP_UUID(co_uuid));


### PR DESCRIPTION
Since duplicating write with the same epoch might cause some
trouble for VOS, so let's remember all migrated objects in a
separated migrated tree to avoid the objects being migrated
multiple times.

We used to have this in the old rebuild code, but got removed
when separating the migration with rebuild.

Signed-off-by: Di Wang <di.wang@intel.com>