### PR TITLE
DAOS-6176 bio: don't get traddr for unpluged device

### DIFF
--- a/src/bio/bio_device.c
+++ b/src/bio/bio_device.c
@@ -613,10 +613,11 @@ bio_dev_list(struct bio_xs_context *xs_ctxt, d_list_t *dev_list, int *dev_cnt)
 
 	/* Scan all devices present in bio_bdev list */
 	d_list_for_each_entry(d_bdev, bio_bdev_list(), bb_link) {
+		char *dev_name = d_bdev->bb_removed ? NULL : d_bdev->bb_name;
+
 		s_info = find_smd_dev(d_bdev->bb_uuid, &s_dev_list);
 
-		b_info = alloc_dev_info(d_bdev->bb_uuid, d_bdev->bb_name,
-					s_info);
+		b_info = alloc_dev_info(d_bdev->bb_uuid, dev_name, s_info);
 		if (b_info == NULL) {
 			D_ERROR("Failed to allocate device info\n");
 			rc = -DER_NOMEM;

--- a/src/mgmt/srv_query.c
+++ b/src/mgmt/srv_query.c
@@ -291,6 +291,16 @@ ds_mgmt_smd_list_devs(Mgmt__SmdDevResp *resp)
 			break;
 		}
 		mgmt__smd_dev_resp__device__init(resp->devices[i]);
+		/*
+		 * XXX: These fields are initialized as "empty string" by above
+		 * protobuf auto-generated function, to avoid error cleanup
+		 * code mistakenly free the "empty string", let's reset them as
+		 * NULL.
+		 */
+		resp->devices[i]->uuid = NULL;
+		resp->devices[i]->state = NULL;
+		resp->devices[i]->traddr = NULL;
+
 		D_ALLOC(resp->devices[i]->uuid, DAOS_UUID_STR_SIZE);
 		if (resp->devices[i]->uuid == NULL) {
 			rc = -DER_NOMEM;
@@ -414,6 +424,9 @@ ds_mgmt_smd_list_pools(Mgmt__SmdPoolResp *resp)
 			break;
 		}
 		mgmt__smd_pool_resp__pool__init(resp->pools[i]);
+		/* See "empty string" comments in ds_mgmt_smd_list_devs() */
+		resp->pools[i]->uuid = NULL;
+
 		D_ALLOC(resp->pools[i]->uuid, DAOS_UUID_STR_SIZE);
 		if (resp->pools[i]->uuid == NULL) {
 			rc = -DER_NOMEM;


### PR DESCRIPTION
- Don't try to get traddr for unplugged device.
- Fixed device/pool list drpc handler to avoid free "empty string"
  on error cleanup.

Signed-off-by: Niu Yawei <yawei.niu@intel.com>