### PR TITLE
DAOS-5807 dtx: remove some debug message

### DIFF
--- a/src/vos/vos_dtx.c
+++ b/src/vos/vos_dtx.c
@@ -852,7 +852,7 @@ vos_dtx_commit_one(struct vos_container *cont, struct dtx_id *dti,
 	*dae_p = dae;
 
 out:
-	D_CDEBUG(rc != 0 && rc != -DER_NONEXIST, DLOG_ERR, DB_IO,
+	D_CDEBUG(rc != 0 && rc != -DER_NONEXIST, DLOG_ERR, DB_TRACE,
 		 "Commit the DTX "DF_DTI": rc = "DF_RC"\n",
 		 DP_DTI(dti), DP_RC(rc));
 	if (rc != 0) {


### PR DESCRIPTION
Change vos_dtx_commit_one debug from IO to TRACE for
debugging purpose.

Signed-off-by: Di Wang <di.wang@intel.com>