### PR TITLE
DAOS-6183 control: Fix race in MgmtSvc.LeaderQuery test

### DIFF
--- a/src/control/server/mgmt_system_test.go
+++ b/src/control/server/mgmt_system_test.go
@@ -99,7 +99,7 @@ func TestServer_MgmtSvc_LeaderQuery(t *testing.T) {
 
 			// wait for the bootstrap to finish
 			for {
-				if db.IsLeader() {
+				if leader, _, _ := db.LeaderQuery(); leader != "" {
 					break
 				}
 			}


### PR DESCRIPTION
There was a very small window during which the raft state
could be leader while the leader address was unset, causing
intermittent failures in this test. Updating the test to
wait for the leader address to be set should eliminate the
race.