### PR TITLE
DAOS-623 api: Add back deprecated API

### DIFF
--- a/src/common/misc.c
+++ b/src/common/misc.c
@@ -34,12 +34,14 @@ int
 daos_sgl_init(d_sg_list_t *sgl, unsigned int nr)
 {
 	D_ASSERTF(0, "This function is deprecated.  Use d_sgl_init\n");
+	return 0;
 }
 
 int
 daos_sgl_fini(d_sg_list_t *sgl, bool free_iovs)
 {
 	D_ASSERTF(0, "This function is deprecated.  Use d_sgl_fini\n");
+	return 0;
 }
 
 static int

--- a/src/common/misc.c
+++ b/src/common/misc.c
@@ -30,6 +30,18 @@
 #include <daos/checksum.h>
 #include <daos/dtx.h>
 
+int
+daos_sgl_init(d_sg_list_t *sgl, unsigned int nr)
+{
+	D_ASSERTF(0, "This function is deprecated.  Use d_sgl_init\n");
+}
+
+int
+daos_sgl_fini(d_sg_list_t *sgl, bool free_iovs)
+{
+	D_ASSERTF(0, "This function is deprecated.  Use d_sgl_fini\n");
+}
+
 static int
 daos_sgls_copy_internal(d_sg_list_t *dst_sgl, uint32_t dst_nr,
 			d_sg_list_t *src_sgl, uint32_t src_nr,


### PR DESCRIPTION
We just need the entry point as both mpich and ior just check
existence of this API but don't use them.  We can remove them
once those components are updated

Signed-off-by: Jeff Olivier <jeffrey.v.olivier@intel.com>