### PR TITLE
DAOS-5731 misc: Fix Coverity issues

### DIFF
--- a/src/container/cli.c
+++ b/src/container/cli.c
@@ -939,6 +939,7 @@ cont_query_bits(daos_prop_t *prop)
 			break;
 		case DAOS_PROP_CO_DEDUP_THRESHOLD:
 			bits |= DAOS_CO_QUERY_PROP_DEDUP_THRESHOLD;
+			break;
 		case DAOS_PROP_CO_REDUN_FAC:
 			bits |= DAOS_CO_QUERY_PROP_REDUN_FAC;
 			break;

--- a/src/vos/tests/vts_mvcc.c
+++ b/src/vos/tests/vts_mvcc.c
@@ -1423,6 +1423,7 @@ uncertainty_check_exec_one(struct io_test_args *arg, int i, int j, bool empty,
 		char		pp[L_COUNT + 1] = "coda";
 		daos_epoch_t	pe = ae - 1;
 
+		D_ASSERT(strlen(wp) <= sizeof(pp) - 1);
 		memcpy(pp, wp, strlen(wp));
 		print_message("  update(%s, "DF_U64") (expect 0): ", pp, pe);
 		rc = update_f(arg, NULL /* txh */, pp, pe);


### PR DESCRIPTION
This patch fixes a few issue found by Coverity:

  - cont_query_bits misses a break in the DAOS_PROP_CO_DEDUP_THRESHOLD
    case.
  - Assert the implicit size relation in vts_mvcc's
    uncertainty_check_exec_one, hopefully silent Coverity next time.

Signed-off-by: Li Wei <wei.g.li@intel.com>