### PR TITLE
DAOS-5906 test: daos_perf improvements

### DIFF
--- a/src/common/dts.c
+++ b/src/common/dts.c
@@ -56,6 +56,14 @@ enum {
 	DTS_INIT_CREDITS,	/* I/O credits have been initialized */
 };
 
+static void
+credit_return(struct dts_context *tsc, struct dts_io_credit *cred)
+{
+	tsc->tsc_credits[tsc->tsc_cred_avail] = cred;
+	tsc->tsc_cred_inuse--;
+	tsc->tsc_cred_avail++;
+}
+
 /**
  * examines if there is available credit freed by completed I/O, it will wait
  * until all credits are freed if @drain is true.
@@ -86,11 +94,8 @@ credit_poll(struct dts_context *tsc, bool drain)
 				fprintf(stderr, "failed op: %d\n", err);
 				return err;
 			}
-			tsc->tsc_credits[tsc->tsc_cred_avail] =
-			   container_of(evs[i], struct dts_io_credit, tc_ev);
-
-			tsc->tsc_cred_inuse--;
-			tsc->tsc_cred_avail++;
+			credit_return(tsc, container_of(evs[i],
+					 struct dts_io_credit, tc_ev));
 		}
 
 		if (tsc->tsc_cred_avail == 0)
@@ -131,6 +136,12 @@ int
 dts_credit_drain(struct dts_context *tsc)
 {
 	return credit_poll(tsc, true);
+}
+
+void
+dts_credit_return(struct dts_context *tsc, struct dts_io_credit *cred)
+{
+	credit_return(tsc, cred);
 }
 
 static int
@@ -229,6 +240,9 @@ pool_init(struct dts_context *tsc)
 
 	} else if (tsc->tsc_mpi_rank == 0) { /* DAOS mode and rank zero */
 		d_rank_list_t	*svc = &tsc->tsc_svc;
+
+		if (tsc->tsc_dmg_conf)
+			dmg_config_file = tsc->tsc_dmg_conf;
 
 		rc = dmg_pool_create(dmg_config_file, geteuid(), getegid(),
 				     NULL, NULL,

--- a/src/include/daos/dts.h
+++ b/src/include/daos/dts.h
@@ -52,4 +52,7 @@ struct dts_io_credit *dts_credit_take(struct dts_context *tsc);
  */
 int dts_credit_drain(struct dts_context *tsc);
 
+/** return an unused credit */
+void dts_credit_return(struct dts_context *tsc, struct dts_io_credit *cred);
+
 #endif /* __DTS_COMMON_H__ */

--- a/src/include/daos/tests_lib.h
+++ b/src/include/daos/tests_lib.h
@@ -136,6 +136,8 @@ struct dts_context {
 	/** INPUT: should be initialized by caller */
 	/** optional, pmem file name, only for VOS test */
 	char			*tsc_pmem_file;
+	/** DMG config file */
+	char			*tsc_dmg_conf;
 	/** optional, pool service ranks, only for DAOS test */
 	d_rank_list_t		 tsc_svc;
 	/** MPI rank of caller */


### PR DESCRIPTION
This patch includes a few changes:
- daos_perf has too many parameters, it is unrealistic to add
  a new opcode for a new test type. This patch add a generic
  opcode '-R', all tests are just parameter for this opcode.

  Example:
  Run UPDATE test with performance output, and run FETCH
  test with performance output as well, then verify data
  correctness without performance output, the parameter
  should be like:

  $ daos_perf ... -C 16 -A -R 'U;p F;p V'

  'U' means UPDATE, 'p' means outputing performance
  'F' means FETCH 'p' means outputing performance
  'V' means verify correctness of data

   Those orignal opcodes for update, fetch, rebuild...are removed
   by this patch

- daos_perf can run tests step by step by using -w
  In the previous example, if '-w' is added to daos_perf, then the
  test program will pause until user inputs 'y' to continue.
  This allow daos_perf to run in interactive mode for tests like
  degraded mode I/O.

Signed-off-by: Liang Zhen <liang.zhen@intel.com>