### PR TITLE
DAOS-5999 tests: Disabling tests failing in CI.

### DIFF
--- a/src/tests/ftest/datamover/copy_procs.py
+++ b/src/tests/ftest/datamover/copy_procs.py
@@ -23,6 +23,8 @@
 '''
 from data_mover_test_base import DataMoverTestBase
 from os.path import join, sep
+from avocado import skipForTicket
+
 
 class CopyProcsTest(DataMoverTestBase):
     # pylint: disable=too-many-ancestors
@@ -75,6 +77,7 @@ class CopyProcsTest(DataMoverTestBase):
         # Stop the servers and agents
         super(CopyProcsTest, self).tearDown()
 
+    @skipForTicket("DAOS-6194")
     def test_copy_procs(self):
         """
         Test Description:

--- a/src/tests/ftest/datamover/copy_procs.py
+++ b/src/tests/ftest/datamover/copy_procs.py
@@ -23,7 +23,7 @@
 '''
 from data_mover_test_base import DataMoverTestBase
 from os.path import join, sep
-from avocado import skipForTicket
+from apricot import skipForTicket
 
 
 class CopyProcsTest(DataMoverTestBase):

--- a/src/tests/suite/daos_oid_alloc.c
+++ b/src/tests/suite/daos_oid_alloc.c
@@ -226,6 +226,9 @@ oid_allocator_checker(void **state)
 	int		i;
 	int		rc, rc_reduce;
 
+	/* skipped until bug DAOS-5999 is fixed */
+	skip();
+
 	srand(time(NULL));
 	reconnect(arg);
 


### PR DESCRIPTION
Disabling the daos_test OID test due to DAOS-5999.
Disabling the datamover/copy_procs.py test due to DAOS-6194.

Signed-off-by: Phillip Henderson <phillip.henderson@intel.com>