### PR TITLE
DAOS-6204 pool: Fix pool_alloc_ref error reporting

### DIFF
--- a/src/pool/srv_target.c
+++ b/src/pool/srv_target.c
@@ -318,6 +318,7 @@ pool_alloc_ref(void *key, unsigned int ksize, void *varg,
 	struct dss_module_info	       *info = dss_get_module_info();
 	unsigned int			iv_ns_id;
 	int				rc;
+	int				rc_tmp;
 
 	if (arg == NULL) {
 		/* The caller doesn't want to create a ds_pool object. */
@@ -385,12 +386,12 @@ pool_alloc_ref(void *key, unsigned int ksize, void *varg,
 err_iv_ns:
 	ds_iv_ns_destroy(pool->sp_iv_ns);
 err_group:
-	crt_group_secondary_destroy(pool->sp_group);
+	rc_tmp = crt_group_secondary_destroy(pool->sp_group);
+	if (rc_tmp != 0)
+		D_ERROR(DF_UUID": failed to destroy pool group: "DF_RC"\n",
+			DP_UUID(pool->sp_uuid), DP_RC(rc_tmp));
 err_done_cond:
-	rc = ABT_cond_free(&pool->sp_fetch_hdls_done_cond);
-	if (rc != 0)
-		D_ERROR(DF_UUID": failed to destroy pool group: %d\n",
-			DP_UUID(pool->sp_uuid), rc);
+	ABT_cond_free(&pool->sp_fetch_hdls_done_cond);
 err_cond:
 	ABT_cond_free(&pool->sp_fetch_hdls_cond);
 err_mutex:


### PR DESCRIPTION
When pool_alloc_ref encounters certain errors, the ABT_cond_free call
under err_done_cond throws away the error and report its own return
value, which is likely 0, instead. This has led to segfaults in
daos_lru_ref_hold, which sees the 0 return value, believes the entry has
been allocated successfully, and dereferences the NULL entry pointer. It
is a regression introduced by #3672. This patch guesses that #3672
intends to check the return value of the crt_group_secondary_destroy
call instead, and employ a temporary variable to store its return value.

Signed-off-by: Li Wei <wei.g.li@intel.com>