### PR TITLE
DAOS-6200 tests: Skipping variants 3 & 5 from pool/create_test.py

### DIFF
--- a/src/tests/ftest/pool/create_test.py
+++ b/src/tests/ftest/pool/create_test.py
@@ -25,6 +25,7 @@ import time
 
 from pool_test_base import PoolTestBase
 from server_utils import ServerFailed
+from apricot import skipForTicket
 
 
 class PoolCreateTests(PoolTestBase):
@@ -90,6 +91,7 @@ class PoolCreateTests(PoolTestBase):
         self.pool = self.get_pool_list(1, 0.9, 0.9)
         self.check_pool_creation(240)
 
+    @skipForTicket("DAOS-6200")
     def test_create_pool_quantity(self):
         """JIRA ID: DAOS-3599.
 
@@ -189,6 +191,7 @@ class PoolCreateTests(PoolTestBase):
             "should succeed."
         )
 
+    @skipForTicket("DAOS-6174")
     def test_create_no_space_loop(self):
         """JIRA ID: DAOS-3728.
 


### PR DESCRIPTION
There are two intermittent pool/create_test.py issues:
- creating a pool across 5 of 6 ranks after an expected failed attempt
to create the same pool using all 6 ranks as a pool already exists on
the first rank (DAOS-6174)
- destroying pools after creating 100 and rebooting the
daos_io_servers (DAOS-6200)

These two test variants are being skipped until they have been
resolved.

Signed-off-by: Phillip Henderson <phillip.henderson@intel.com>