### PR TITLE
DAOS-6187 mgmt: client iterate sy_psrs[] for get svcranks rpc

### DIFF
--- a/src/mgmt/cli_mgmt.c
+++ b/src/mgmt/cli_mgmt.c
@@ -854,6 +854,7 @@ dc_mgmt_get_pool_svc_ranks(struct dc_mgmt_sys *sys, const uuid_t puuid,
 	crt_opcode_t				opc;
 	int					i;
 	int					idx;
+	crt_context_t				ctx;
 	bool					success = false;
 	int					rc = 0;
 
@@ -864,19 +865,20 @@ dc_mgmt_get_pool_svc_ranks(struct dc_mgmt_sys *sys, const uuid_t puuid,
 	 */
 	D_ASSERT(sys->sy_npsrs > 0);
 	idx = rand() % sys->sy_npsrs;
+	ctx = daos_get_crt_ctx();
+	opc = DAOS_RPC_OPCODE(MGMT_POOL_GET_SVCRANKS, DAOS_MGMT_MODULE,
+			      DAOS_MGMT_VERSION);
+	srv_ep.ep_grp = sys->sy_group;
+	srv_ep.ep_tag = daos_rpc_tag(DAOS_REQ_MGMT, 0);
 	for (i = 0 ; i < sys->sy_npsrs; i++) {
-		srv_ep.ep_grp = sys->sy_group;
 		srv_ep.ep_rank = sys->sy_psrs[idx].rank;
-		srv_ep.ep_tag = daos_rpc_tag(DAOS_REQ_MGMT, 0);
-
 		rpc = NULL;
-		opc = DAOS_RPC_OPCODE(MGMT_POOL_GET_SVCRANKS, DAOS_MGMT_MODULE,
-				      DAOS_MGMT_VERSION);
-		rc = crt_req_create(daos_get_crt_ctx(), &srv_ep, opc, &rpc);
+		rc = crt_req_create(ctx, &srv_ep, opc, &rpc);
 		if (rc != 0) {
-			D_ERROR(DF_UUID ": crt_req_create() failed, "DF_RC "\n",
-				DP_UUID(puuid), DP_RC(rc));
-			return rc;
+			D_ERROR(DF_UUID ": crt_req_create() failed, "
+				DF_RC "\n", DP_UUID(puuid), DP_RC(rc));
+			idx = (idx + 1) % sys->sy_npsrs;
+			continue;
 		}
 
 		rpc_in = NULL;
@@ -890,9 +892,9 @@ dc_mgmt_get_pool_svc_ranks(struct dc_mgmt_sys *sys, const uuid_t puuid,
 		rc = daos_rpc_send_wait(rpc);
 		if (rc != 0) {
 			D_DEBUG(DB_MGMT, DF_UUID ": daos_rpc_send_wait() failed"
-				", "DF_RC "\n", DP_UUID(puuid), DP_RC(rc));
+				", " DF_RC "\n", DP_UUID(puuid), DP_RC(rc));
 			crt_req_decref(rpc);
-			idx = (idx +1) % sys->sy_npsrs;
+			idx = (idx + 1) % sys->sy_npsrs;
 			continue;
 		}
 		success = true;
@@ -901,7 +903,7 @@ dc_mgmt_get_pool_svc_ranks(struct dc_mgmt_sys *sys, const uuid_t puuid,
 
 	if (!success) {
 		D_ERROR(DF_UUID ": failed to get PS replicas list from %d "
-			"servers, " DF_RC"\n", DP_UUID(puuid), sys->sy_npsrs,
+			"servers, " DF_RC "\n", DP_UUID(puuid), sys->sy_npsrs,
 			DP_RC(rc));
 		return rc;
 	}
@@ -911,7 +913,7 @@ dc_mgmt_get_pool_svc_ranks(struct dc_mgmt_sys *sys, const uuid_t puuid,
 	rc = rpc_out->gsr_rc;
 	if (rc != 0) {
 		D_ERROR(DF_UUID ": MGMT_POOL_GET_SVCRANKS rpc failed to all %d "
-			"ranks, "DF_RC "\n", DP_UUID(puuid), sys->sy_npsrs,
+			"ranks, " DF_RC "\n", DP_UUID(puuid), sys->sy_npsrs,
 			DP_RC(rc));
 		goto decref;
 	}
@@ -920,13 +922,14 @@ dc_mgmt_get_pool_svc_ranks(struct dc_mgmt_sys *sys, const uuid_t puuid,
 		DP_UUID(puuid), srv_ep.ep_rank);
 	rc = d_rank_list_dup(svcranksp, rpc_out->gsr_ranks);
 	if (rc != 0)
-		D_ERROR(DF_UUID ": d_rank_list_dup() failed, "DF_RC "\n",
+		D_ERROR(DF_UUID ": d_rank_list_dup() failed, " DF_RC "\n",
 			DP_UUID(puuid), DP_RC(rc));
 
 decref:
 	crt_req_decref(rpc);
 	return rc;
 }
+
 /**
  * Initialize management interface
  */

--- a/src/tests/ftest/daos_test/daos_core_test-rebuild.yaml
+++ b/src/tests/ftest/daos_test/daos_core_test-rebuild.yaml
@@ -93,20 +93,18 @@ daos_tests:
       daos_test: r
       test_name: rebuild tests 21
       args: -s3 -u subtests="21"
-# Skipped for DAOS-6187
-#    test_r_22:
-#      daos_test: r
-#      test_name: rebuild tests 22
-#      args: -s3 -u subtests="22"
+    test_r_22:
+      daos_test: r
+      test_name: rebuild tests 22
+      args: -s3 -u subtests="22"
     test_r_23:
       daos_test: r
       test_name: rebuild tests 23
       args: -s3 -u subtests="23"
-# Skipped for DAOS-6187
-#    test_r_24:
-#      daos_test: r
-#      test_name: rebuild tests 24
-#      args: -s3 -u subtests="24"
+    test_r_24:
+      daos_test: r
+      test_name: rebuild tests 24
+      args: -s3 -u subtests="24"
     test_r_25:
       daos_test: r
       test_name: rebuild tests 25


### PR DESCRIPTION
Client function dc_mgmt_get_pool_svc_ranks() selects sy_psrs[0] from
struct dc_mgmt_sys returned by get_attach_info() to identify the
"management service" ioserver to send MGMT_POOL_GET_SVCRANKS rpc.
This is done when a client needs to discover the list of pool
service replica ranks.

Recent changes have populated sy_psrs[] with multiple servers,
e.g., referring to two ioservers deployed on a single MS replica
host. Some tests e.g., rebuild will stop some ranks and it has
been shown that in some cases the rank associated with sy_psrs[0]
in the test client is the one affected. This causes the client
to time out or get a DER_UNREACH error when trying to fetch
the pool service ranks.

This change iterates through sy_psrs[] attempting to fetch
the pool service ranks.

Signed-off-by: Kenneth Cain <kenneth.c.cain@intel.com>