### PR TITLE
DAOS-6149 vos: Add print for when non-direct key compare fails.

### DIFF
--- a/src/common/btree.c
+++ b/src/common/btree.c
@@ -1438,7 +1438,8 @@ btr_probe(struct btr_context *tcx, dbtree_probe_opc_t probe_opc,
 			rc = PROBE_RC_ERR;
 			goto out;
 		}
-		D_ASSERTF(cmp == BTR_CMP_EQ, "Hash collision is unsupported\n");
+		D_ASSERTF(cmp == BTR_CMP_EQ,
+			  "Hash collision is unsupported cmp=%d\n", cmp);
 	}
 
 	alb.nd_off = nd_off;


### PR DESCRIPTION
This can only happen if there is a hash collision.  I have yet
to find a case where a collision isn't caused by some other
corruption rather than a real collision so adding this to capture
it if it does happen.

Signed-off-by: Jeff Olivier <jeffrey.v.olivier@intel.com>