### PR TITLE
DAOS-6149 rebuild: use UV tree for container tree

### DIFF
--- a/src/common/btree_class.c
+++ b/src/common/btree_class.c
@@ -228,6 +228,21 @@ nv_key_cmp(struct btr_instance *tins, struct btr_record *rec, d_iov_t *key)
 			key->iov_len));
 }
 
+static void
+nv_key_encode(struct btr_instance *tins, d_iov_t *key,
+	      daos_anchor_t *anchor)
+{
+	if (key)
+		embedded_key_encode(key, anchor);
+}
+
+static void
+nv_key_decode(struct btr_instance *tins, d_iov_t *key,
+	      daos_anchor_t *anchor)
+{
+	embedded_key_decode(key, anchor);
+}
+
 static int
 nv_rec_alloc(struct btr_instance *tins, d_iov_t *key, d_iov_t *val,
 	       struct btr_record *rec)
@@ -370,6 +385,8 @@ btr_ops_t dbtree_nv_ops = {
 	.to_hkey_gen	= nv_hkey_gen,
 	.to_hkey_size	= nv_hkey_size,
 	.to_key_cmp	= nv_key_cmp,
+	.to_key_encode	= nv_key_encode,
+	.to_key_decode	= nv_key_decode,
 	.to_rec_alloc	= nv_rec_alloc,
 	.to_rec_free	= nv_rec_free,
 	.to_rec_fetch	= nv_rec_fetch,

--- a/src/include/daos/btree.h
+++ b/src/include/daos/btree.h
@@ -443,6 +443,45 @@ struct btr_instance {
 	btr_ops_t			*ti_ops;
 };
 
+/**
+ * Inline data structure for embedding the key bundle and key into an anchor
+ * for serialization.
+ */
+#define	EMBEDDED_KEY_MAX	100
+struct btr_embedded_key {
+	/** Inlined iov key references */
+	uint32_t	ek_size;
+	/** Inlined buffer the key references*/
+	unsigned char	ek_key[EMBEDDED_KEY_MAX];
+};
+
+D_CASSERT(sizeof(struct btr_embedded_key) == DAOS_ANCHOR_BUF_MAX);
+
+static inline void
+embedded_key_encode(d_iov_t *key, daos_anchor_t *anchor)
+{
+	struct btr_embedded_key *embedded =
+		(struct btr_embedded_key *)anchor->da_buf;
+
+	D_ASSERT(key->iov_len <= sizeof(embedded->ek_key));
+
+	memcpy(embedded->ek_key, key->iov_buf, key->iov_len);
+	/** Pointers will have to be set on decode. */
+	embedded->ek_size = key->iov_len;
+}
+
+static inline void
+embedded_key_decode(d_iov_t *key, daos_anchor_t *anchor)
+{
+	struct btr_embedded_key *embedded =
+		(struct btr_embedded_key *)anchor->da_buf;
+
+	/* Fix the pointer first */
+	key->iov_buf = &embedded->ek_key[0];
+	key->iov_len = embedded->ek_size;
+	key->iov_buf_len = embedded->ek_size;
+}
+
 /* Features are passed as 64-bit unsigned integer.   Only the bits below are
  * reserved.   A specific class can define its own bits to customize behavior.
  * For example, VOS can use bits to indicate the type of key comparison used

--- a/src/iosrv/init.c
+++ b/src/iosrv/init.c
@@ -132,7 +132,7 @@ register_dbtree_classes(void)
 		return rc;
 	}
 
-	rc = dbtree_class_register(DBTREE_CLASS_NV, 0 /* feats */,
+	rc = dbtree_class_register(DBTREE_CLASS_NV, BTR_FEAT_DIRECT_KEY,
 				   &dbtree_nv_ops);
 	if (rc != 0) {
 		D_ERROR("failed to register DBTREE_CLASS_NV: "DF_RC"\n",

--- a/src/object/srv_obj_migrate.c
+++ b/src/object/srv_obj_migrate.c
@@ -162,8 +162,8 @@ tree_cache_create_internal(daos_handle_t toh, unsigned int tree_class,
 	memset(&uma, 0, sizeof(uma));
 	uma.uma_id = UMEM_CLASS_VMEM;
 
-	rc = dbtree_create_inplace(tree_class, 0, 32, &uma, broot,
-				   &root.root_hdl);
+	rc = dbtree_create_inplace(tree_class, BTR_FEAT_DIRECT_KEY, 32,
+				   &uma, broot, &root.root_hdl);
 	if (rc) {
 		D_ERROR("failed to create rebuild tree: "DF_RC"\n", DP_RC(rc));
 		D_FREE(broot);
@@ -2434,7 +2434,7 @@ migrate_init_object_tree(struct migrate_pool_tls *tls)
 		/* migrate tree root init */
 		memset(&uma, 0, sizeof(uma));
 		uma.uma_id = UMEM_CLASS_VMEM;
-		rc = dbtree_create_inplace(DBTREE_CLASS_NV, 0, 4, &uma,
+		rc = dbtree_create_inplace(DBTREE_CLASS_UV, 0, 4, &uma,
 					   &tls->mpt_root,
 					   &tls->mpt_root_hdl);
 		if (rc != 0) {
@@ -2447,7 +2447,7 @@ migrate_init_object_tree(struct migrate_pool_tls *tls)
 		/* migrate tree root init */
 		memset(&uma, 0, sizeof(uma));
 		uma.uma_id = UMEM_CLASS_VMEM;
-		rc = dbtree_create_inplace(DBTREE_CLASS_NV, 0, 4, &uma,
+		rc = dbtree_create_inplace(DBTREE_CLASS_UV, 0, 4, &uma,
 					   &tls->mpt_migrated_root,
 					   &tls->mpt_migrated_root_hdl);
 		if (rc != 0) {

--- a/src/rebuild/scan.c
+++ b/src/rebuild/scan.c
@@ -666,7 +666,7 @@ rebuild_scanner(void *data)
 	/* Create object tree root */
 	memset(&uma, 0, sizeof(uma));
 	uma.uma_id = UMEM_CLASS_VMEM;
-	rc = dbtree_create(DBTREE_CLASS_NV, 0, 4, &uma, NULL,
+	rc = dbtree_create(DBTREE_CLASS_UV, 0, 4, &uma, NULL,
 			   &tls->rebuild_tree_hdl);
 	if (rc != 0) {
 		D_ERROR("failed to create rebuild tree: "DF_RC"\n", DP_RC(rc));

--- a/src/vos/vos_internal.h
+++ b/src/vos/vos_internal.h
@@ -559,19 +559,6 @@ struct vos_rec_bundle {
 	enum vos_tree_class	 rb_tclass;
 };
 
-/**
- * Inline data structure for embedding the key bundle and key into an anchor
- * for serialization.
- */
-#define	EMBEDDED_KEY_MAX	80
-struct vos_embedded_key {
-	/** Inlined iov key references */
-	d_iov_t		ek_kiov;
-	/** Inlined buffer the key references*/
-	unsigned char	ek_key[EMBEDDED_KEY_MAX];
-};
-D_CASSERT(sizeof(struct vos_embedded_key) == DAOS_ANCHOR_BUF_MAX);
-
 #define VOS_SIZE_ROUND		8
 
 /* size round up */

--- a/src/vos/vos_tree.c
+++ b/src/vos/vos_tree.c
@@ -315,28 +315,15 @@ static void
 ktr_key_encode(struct btr_instance *tins, d_iov_t *key,
 	       daos_anchor_t *anchor)
 {
-	if (key) {
-		struct vos_embedded_key *embedded =
-			(struct vos_embedded_key *)anchor->da_buf;
-		D_ASSERT(key->iov_len <= sizeof(embedded->ek_key));
-
-		memcpy(embedded->ek_key, key->iov_buf, key->iov_len);
-		/** Pointers will have to be set on decode. */
-		embedded->ek_kiov.iov_len = key->iov_len;
-		embedded->ek_kiov.iov_buf_len = sizeof(embedded->ek_key);
-	}
+	if (key)
+		embedded_key_encode(key, anchor);
 }
 
 static void
 ktr_key_decode(struct btr_instance *tins, d_iov_t *key,
 	       daos_anchor_t *anchor)
 {
-	struct vos_embedded_key *embedded =
-		(struct vos_embedded_key *) anchor->da_buf;
-
-	/* Fix the pointer first */
-	embedded->ek_kiov.iov_buf = &embedded->ek_key[0];
-	*key = embedded->ek_kiov;
+	embedded_key_decode(key, anchor);
 }
 
 /** create a new key-record, or install an externally allocated key-record */


### PR DESCRIPTION
Use DBTREE_CLASS_UV tree class for rebuild container
tree.

Signed-off-by: Di Wang <di.wang@intel.com>