### PR TITLE
DAOS-623 build: Use BUILD_TYPE=dev for travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ before_install:
 
 script:
  - docker build -f utils/docker/Dockerfile.$DOCKER_IMAGE -t daos/$DOCKER_IMAGE --build-arg NOBUILD=1 --build-arg UID=$UID .
- - docker run -v $PWD:/home/daos/daos:z daos/$DOCKER_IMAGE /bin/bash -c "scons --build-deps=yes install"
+ - docker run -v $PWD:/home/daos/daos:z daos/$DOCKER_IMAGE /bin/bash -c "scons --build-deps=yes install BUILD_TYPE=dev"
  - if [ $TRAVIS_TEST_RESULT == "0" ]; then
         docker run -v $PWD:/home/daos/daos:z daos/$DOCKER_IMAGE /bin/bash -c "cd src/client/java && mvn clean install -DskipITs -Ddaos.install.path=/home/daos/daos/install";
    else


### PR DESCRIPTION
The java .xom file wants it in dev.   We should automate this but
this should fix the immediate issue.

Signed-off-by: Jeff Olivier <jeffrey.v.olivier@intel.com>