### PR TITLE
DAOS-6200 bio: race in sync blob open/close

### DIFF
--- a/src/tests/ftest/pool/create_test.py
+++ b/src/tests/ftest/pool/create_test.py
@@ -91,7 +91,6 @@ class PoolCreateTests(PoolTestBase):
         self.pool = self.get_pool_list(1, 0.9, 0.9)
         self.check_pool_creation(240)
 
-    @skipForTicket("DAOS-6200")
     def test_create_pool_quantity(self):
         """JIRA ID: DAOS-3599.
 


### PR DESCRIPTION
When SSD is shared by multiple xstreams, the sync blob open/close
completion could be executed on different xstream, so caller may
change/free the completion argument while completion is running.

This patch uses saved 'async' arg to avoid above race, re-enables
the test case was originally disabled for this defect.

Signed-off-by: Niu Yawei <yawei.niu@intel.com>