### PR TITLE
DAOS-4240 leap: add chown hack to docker file

### DIFF
--- a/utils/docker/Dockerfile.leap.15
+++ b/utils/docker/Dockerfile.leap.15
@@ -123,9 +123,9 @@ RUN echo -e "<settings>\n\
 RUN mkdir /mnt/daos
 RUN chown daos.daos /mnt/daos || { cat /etc/passwd; cat /etc/group; cat /etc/shadow; chown daos /mnt/daos; chgrp daos /mnt/daos; ls -ld /mnt/daos; }
 RUN mkdir /var/run/daos_server
-RUN chown daos.daos /var/run/daos_server
+RUN chown daos.daos /var/run/daos_server || { cat /etc/passwd; cat /etc/group; cat /etc/shadow; chown daos /var/run/daos_server; chgrp daos /var/run/daos_server; ls -ld /var/run/daos_server; }
 RUN mkdir /var/run/daos_agent
-RUN chown daos.daos /var/run/daos_agent
+RUN chown daos.daos /var/run/daos_agent || { cat /etc/passwd; cat /etc/group; cat /etc/shadow; chown daos /var/run/daos_agent; chgrp daos /var/run/daos_agent; ls -ld /var/run/daos_agent; }
 
 # Dependencies
 # Packages for NVML exist in CentOS, but are


### PR DESCRIPTION
Use chown workaround to change ownership of /var/run/daos_server
and /var/run/daos_agent.

Skip-test: true

Signed-off-by: Johann Lombardi <johann.lombardi@intel.com>