### PR TITLE
DAOS-6245 test: Increase server startup timeout

### DIFF
--- a/src/tests/ftest/util/server_utils.py
+++ b/src/tests/ftest/util/server_utils.py
@@ -44,7 +44,7 @@ class DaosServerCommand(YamlCommand):
     FORMAT_PATTERN = "(SCM format required)(?!;)"
     REFORMAT_PATTERN = "Metadata format required"
 
-    def __init__(self, path="", yaml_cfg=None, timeout=20):
+    def __init__(self, path="", yaml_cfg=None, timeout=30):
         """Create a daos_server command object.
 
         Args:
@@ -52,7 +52,7 @@ class DaosServerCommand(YamlCommand):
             yaml_cfg (YamlParameters, optional): yaml configuration parameters.
                 Defaults to None.
             timeout (int, optional): number of seconds to wait for patterns to
-                appear in the subprocess output. Defaults to 20 seconds.
+                appear in the subprocess output. Defaults to 30 seconds.
         """
         super(DaosServerCommand, self).__init__(
             "/run/daos_server/*", "daos_server", path, yaml_cfg, timeout)


### PR DESCRIPTION
The previous timeout of 20s was right on the edge of
startup timing variability, causing a number of spurious
intermittent failures.