### PR TITLE
CART-927 hlc: Improve log messages on HLC failures

### DIFF
--- a/src/cart/crt_corpc.c
+++ b/src/cart/crt_corpc.c
@@ -777,6 +777,9 @@ crt_corpc_req_hdlr(struct crt_rpc_priv *rpc_priv)
 	opc_info = rpc_priv->crp_opc_info;
 	co_ops = opc_info->coi_co_ops;
 
+	if (rpc_priv->crp_fail_hlc)
+		D_GOTO(forward_done, rc = -DER_HLC_SYNC);
+
 	/* Invoke pre-forward callback first if it is registered */
 	if (co_ops && co_ops->co_pre_forward) {
 		rc = co_ops->co_pre_forward(&rpc_priv->crp_pub,

--- a/src/cart/crt_hg.c
+++ b/src/cart/crt_hg.c
@@ -828,6 +828,11 @@ crt_rpc_handler_common(hg_handle_t hg_hdl)
 		D_GOTO(decref, hg_ret = HG_SUCCESS);
 	}
 
+	if (rpc_priv->crp_fail_hlc) {
+		crt_hg_reply_error_send(rpc_priv, -DER_HLC_SYNC);
+		D_GOTO(decref, hg_ret = HG_SUCCESS);
+	}
+
 	if (!is_coll_req)
 		rc = crt_rpc_common_hdlr(rpc_priv);
 	else
@@ -1040,6 +1045,10 @@ crt_hg_req_send_cb(const struct hg_cb_info *hg_cbinfo)
 				}
 			}
 		}
+
+		/* HLC is checked during unpacking of the response */
+		if (rpc_priv->crp_fail_hlc)
+			rc = -DER_HLC_SYNC;
 	}
 
 	crt_cbinfo.cci_rpc = rpc_pub;

--- a/src/cart/crt_hg.c
+++ b/src/cart/crt_hg.c
@@ -783,6 +783,7 @@ crt_rpc_handler_common(hg_handle_t hg_hdl)
 	}
 
 	rpc_priv->crp_opc_info = opc_info;
+	rpc_priv->crp_fail_hlc = rpc_tmp.crp_fail_hlc;
 	rpc_pub->cr_opc = rpc_tmp.crp_pub.cr_opc;
 	rpc_pub->cr_ep.ep_rank = rpc_priv->crp_req_hdr.cch_dst_rank;
 	rpc_pub->cr_ep.ep_tag = rpc_priv->crp_req_hdr.cch_dst_tag;

--- a/src/cart/crt_hg_proc.c
+++ b/src/cart/crt_hg_proc.c
@@ -400,7 +400,7 @@ crt_hg_unpack_header(hg_handle_t handle, struct crt_rpc_priv *rpc_priv,
 	hg_class_t		*hg_class;
 	struct crt_context	*ctx;
 	struct crt_hg_context	*hg_ctx;
-	uint64_t		clock_drift;
+	uint64_t		clock_offset;
 	hg_proc_t		hg_proc = HG_PROC_NULL;
 
 	/* Get extra input buffer; if it's null, get regular input buffer */
@@ -440,13 +440,13 @@ crt_hg_unpack_header(hg_handle_t handle, struct crt_rpc_priv *rpc_priv,
 	/* Sync the HLC. Clients never decode requests. */
 	D_ASSERT(crt_is_service());
 	rc = crt_hlc_get_msg(rpc_priv->crp_req_hdr.cch_hlc, NULL /* hlc_out */,
-			     &clock_drift);
+			     &clock_offset);
 	if (rc != 0) {
 		REPORT_HLC_SYNC_ERR("failed to sync HLC for request: opc=%x ts="
-				    DF_U64" drift="DF_U64" from=%u\n",
+				    DF_U64" offset="DF_U64" from=%u\n",
 				    rpc_priv->crp_req_hdr.cch_opc,
 				    rpc_priv->crp_req_hdr.cch_hlc,
-				    clock_drift,
+				    clock_offset,
 				    rpc_priv->crp_req_hdr.cch_src_rank);
 		/* Fail all but SWIM requests. */
 		if (!crt_opc_is_swim(rpc_priv->crp_req_hdr.cch_opc))
@@ -674,20 +674,20 @@ crt_proc_out_common(crt_proc_t proc, crt_rpc_output_t *data)
 			struct crt_common_hdr *hdr = &rpc_priv->crp_reply_hdr;
 
 			if (crt_is_service()) {
-				uint64_t clock_drift;
+				uint64_t clock_offset;
 
 				rc = crt_hlc_get_msg(hdr->cch_hlc,
 						     NULL /* hlc_out */,
-						     &clock_drift);
+						     &clock_offset);
 				if (rc != 0) {
 					REPORT_HLC_SYNC_ERR("failed to sync "
 							    "HLC for reply: "
 							    "opc=%x ts="DF_U64
-							    " drift="DF_U64
+							    " offset="DF_U64
 							    " from=%u\n",
 							    hdr->cch_opc,
 							    hdr->cch_hlc,
-							    clock_drift,
+							    clock_offset,
 							    hdr->cch_dst_rank);
 					/* Fail all but SWIM replies. */
 					if (!crt_opc_is_swim(hdr->cch_opc))

--- a/src/cart/crt_hg_proc.c
+++ b/src/cart/crt_hg_proc.c
@@ -400,6 +400,7 @@ crt_hg_unpack_header(hg_handle_t handle, struct crt_rpc_priv *rpc_priv,
 	hg_class_t		*hg_class;
 	struct crt_context	*ctx;
 	struct crt_hg_context	*hg_ctx;
+	uint64_t		clock_drift;
 	hg_proc_t		hg_proc = HG_PROC_NULL;
 
 	/* Get extra input buffer; if it's null, get regular input buffer */
@@ -438,16 +439,18 @@ crt_hg_unpack_header(hg_handle_t handle, struct crt_rpc_priv *rpc_priv,
 
 	/* Sync the HLC. Clients never decode requests. */
 	D_ASSERT(crt_is_service());
-	rc = crt_hlc_get_msg(rpc_priv->crp_req_hdr.cch_hlc, NULL /* hlc_out */);
+	rc = crt_hlc_get_msg(rpc_priv->crp_req_hdr.cch_hlc, NULL /* hlc_out */,
+			     &clock_drift);
 	if (rc != 0) {
 		REPORT_HLC_SYNC_ERR("failed to sync HLC for request: opc=%x ts="
-				    DF_U64" from=%u\n",
+				    DF_U64" drift="DF_U64" from=%u\n",
 				    rpc_priv->crp_req_hdr.cch_opc,
 				    rpc_priv->crp_req_hdr.cch_hlc,
+				    clock_drift,
 				    rpc_priv->crp_req_hdr.cch_src_rank);
 		/* Fail all but SWIM requests. */
 		if (!crt_opc_is_swim(rpc_priv->crp_req_hdr.cch_opc))
-			D_GOTO(out, rc);
+			rpc_priv->crp_fail_hlc = 1;
 		rc = 0;
 	}
 
@@ -671,19 +674,25 @@ crt_proc_out_common(crt_proc_t proc, crt_rpc_output_t *data)
 			struct crt_common_hdr *hdr = &rpc_priv->crp_reply_hdr;
 
 			if (crt_is_service()) {
+				uint64_t clock_drift;
+
 				rc = crt_hlc_get_msg(hdr->cch_hlc,
-						     NULL /* hlc_out */);
+						     NULL /* hlc_out */,
+						     &clock_drift);
 				if (rc != 0) {
 					REPORT_HLC_SYNC_ERR("failed to sync "
 							    "HLC for reply: "
 							    "opc=%x ts="DF_U64
+							    " drift="DF_U64
 							    " from=%u\n",
 							    hdr->cch_opc,
 							    hdr->cch_hlc,
+							    clock_drift,
 							    hdr->cch_dst_rank);
 					/* Fail all but SWIM replies. */
 					if (!crt_opc_is_swim(hdr->cch_opc))
-						D_GOTO(out, rc);
+						rpc_priv->crp_fail_hlc = 1;
+
 					rc = 0;
 				}
 			} else {

--- a/src/cart/crt_hlc.c
+++ b/src/cart/crt_hlc.c
@@ -65,15 +65,19 @@ uint64_t crt_hlc_get(void)
 	return ret;
 }
 
-int crt_hlc_get_msg(uint64_t msg, uint64_t *hlc_out, uint64_t *drift)
+int crt_hlc_get_msg(uint64_t msg, uint64_t *hlc_out, uint64_t *offset)
 {
 	uint64_t pt = crt_hlc_localtime_get();
 	uint64_t hlc, ret, ml = msg & ~CRT_HLC_MASK;
+	uint64_t off;
 
-	if (ml > pt && ml - pt > crt_hlc_epsilon) {
-		*drift = ml - pt;
+	off = ml > pt ? ml - pt : 0;
+
+	if (offset != NULL)
+		*offset = off;
+
+	if (off > crt_hlc_epsilon)
 		return -DER_HLC_SYNC;
-	}
 
 	do {
 		hlc = crt_hlc;

--- a/src/cart/crt_hlc.c
+++ b/src/cart/crt_hlc.c
@@ -65,13 +65,15 @@ uint64_t crt_hlc_get(void)
 	return ret;
 }
 
-int crt_hlc_get_msg(uint64_t msg, uint64_t *hlc_out)
+int crt_hlc_get_msg(uint64_t msg, uint64_t *hlc_out, uint64_t *drift)
 {
 	uint64_t pt = crt_hlc_localtime_get();
 	uint64_t hlc, ret, ml = msg & ~CRT_HLC_MASK;
 
-	if (ml > pt && ml - pt > crt_hlc_epsilon)
+	if (ml > pt && ml - pt > crt_hlc_epsilon) {
+		*drift = ml - pt;
 		return -DER_HLC_SYNC;
+	}
 
 	do {
 		hlc = crt_hlc;

--- a/src/cart/crt_rpc.c
+++ b/src/cart/crt_rpc.c
@@ -1446,6 +1446,10 @@ crt_rpc_common_hdlr(struct crt_rpc_priv *rpc_priv)
 
 	self_rank = crt_gdata.cg_grp->gg_primary_grp->gp_self;
 
+	/* If RPC failed HLC epsilon delta check return an error */
+	if (rpc_priv->crp_fail_hlc)
+		D_GOTO(out, rc = -DER_HLC_SYNC);
+
 	if (self_rank == CRT_NO_RANK)
 		skip_check = true;
 

--- a/src/cart/crt_rpc.h
+++ b/src/cart/crt_rpc.h
@@ -189,7 +189,9 @@ struct crt_rpc_priv {
 				/* RPC is tracked by the context */
 				crp_ctx_tracked:1,
 				/* 1 if RPC is successfully put on the wire */
-				crp_on_wire:1;
+				crp_on_wire:1,
+				/* 1 if RPC fails HLC epsilon check */
+				crp_fail_hlc:1;
 	uint32_t		crp_refcount;
 	struct crt_opc_info	*crp_opc_info;
 	/* corpc info, only valid when (crp_coll == 1) */

--- a/src/include/cart/api.h
+++ b/src/include/cart/api.h
@@ -458,7 +458,7 @@ crt_hlc_get(void);
  *
  * \param[in] msg              remote HLC timestamp
  * \param[out] hlc_out         HLC timestamp
- * \param[out] clock_dirft     Optional returned clock drift. Only
+ * \param[out] clock_drift     Optional returned clock drift. Only
  *                             populated if -DER_HLC_SYNC is returned
  *
  * \return                     DER_SUCCESS on success or error

--- a/src/include/cart/api.h
+++ b/src/include/cart/api.h
@@ -458,6 +458,8 @@ crt_hlc_get(void);
  *
  * \param[in] msg              remote HLC timestamp
  * \param[out] hlc_out         HLC timestamp
+ * \param[out] clock_dirft     Optional returned clock drift. Only
+ *                             populated if -DER_HLC_SYNC is returned
  *
  * \return                     DER_SUCCESS on success or error
  *                             on failure
@@ -465,7 +467,7 @@ crt_hlc_get(void);
  *                             physical clock
  */
 int
-crt_hlc_get_msg(uint64_t msg, uint64_t *hlc_out);
+crt_hlc_get_msg(uint64_t msg, uint64_t *hlc_out, uint64_t *clock_drift);
 
 /**
  * Return the second timestamp of hlc.

--- a/src/include/cart/api.h
+++ b/src/include/cart/api.h
@@ -458,8 +458,7 @@ crt_hlc_get(void);
  *
  * \param[in] msg              remote HLC timestamp
  * \param[out] hlc_out         HLC timestamp
- * \param[out] clock_drift     Optional returned clock drift. Only
- *                             populated if -DER_HLC_SYNC is returned
+ * \param[out] offset          Returned observed clock offset.
  *
  * \return                     DER_SUCCESS on success or error
  *                             on failure
@@ -467,7 +466,7 @@ crt_hlc_get(void);
  *                             physical clock
  */
 int
-crt_hlc_get_msg(uint64_t msg, uint64_t *hlc_out, uint64_t *clock_drift);
+crt_hlc_get_msg(uint64_t msg, uint64_t *hlc_out, uint64_t *offset);
 
 /**
  * Return the second timestamp of hlc.

--- a/src/tests/ftest/cart/utest/utest_hlc.c
+++ b/src/tests/ftest/cart/utest/utest_hlc.c
@@ -70,7 +70,7 @@ test_hlc_get_msg(void **state)
 			time2 = time - 0x100;
 		else
 			time2 = time + (i % 3);
-		rc = crt_hlc_get_msg(time2, &time);
+		rc = crt_hlc_get_msg(time2, &time, NULL);
 		assert_true(rc == 0);
 		assert_true(time2 < time);
 		assert_true(last < time);


### PR DESCRIPTION
- Instead of returning errors directly to mercury during unpack we
now save error as part of rpc_priv field and fail gracefully
- Upon this failure application will now get -DER_HLC_SYNC error.
- crt_hlc_get_msg() expanded to include optional 'drift' output
parameter that will be set only for cases when -DER_HLC_SYNC is
generated

Signed-off-by: Alexander Oganezov <alexander.a.oganezov@intel.com>