### PR TITLE
DAOS-2666 task: the task struct should not use const for uuids

### DIFF
--- a/src/include/daos_task.h
+++ b/src/include/daos_task.h
@@ -192,7 +192,7 @@ typedef struct {
 /** pool destroy args */
 typedef struct {
 	/** UUID of the pool to destroy. */
-	const uuid_t		uuid;
+	uuid_t			uuid;
 	/** Process set name of the DAOS servers managing the pool */
 	const char		*grp;
 	/** Force destruction even if there are active connections */
@@ -202,7 +202,7 @@ typedef struct {
 /** pool extend args */
 typedef struct {
 	/** UUID of the pool to extend. */
-	const uuid_t		uuid;
+	uuid_t			uuid;
 	/** Process set name of the DAOS servers managing the pool. */
 	const char		*grp;
 	/**  Optional, only extend the pool to included targets. */
@@ -214,7 +214,7 @@ typedef struct {
 /** pool evict args */
 typedef struct {
 	/** UUID of the pool. */
-	const uuid_t		uuid;
+	uuid_t			uuid;
 	/** Process set name of the DAOS servers managing the pool. */
 	const char		*grp;
 	/** list of pool service ranks. */
@@ -224,7 +224,7 @@ typedef struct {
 /** pool connect args */
 typedef struct {
 	/** UUID of the pool. */
-	const uuid_t		uuid;
+	uuid_t			uuid;
 	/** Process set name of the DAOS servers managing the pool. */
 	const char		*grp;
 	/** Pool service replica ranks. */
@@ -246,7 +246,7 @@ typedef struct {
 /** pool target update (add/exclude) args */
 typedef struct {
 	/** UUID of the pool. */
-	const uuid_t		uuid;
+	uuid_t			uuid;
 	/** Process set name of the DAOS servers managing the pool */
 	const char		*grp;
 	/** Pool service replica ranks. */
@@ -340,7 +340,7 @@ typedef struct {
 /** pool add/remove replicas args */
 typedef struct {
 	/** UUID of the pool. */
-	const uuid_t		uuid;
+	uuid_t			uuid;
 	/** Name of DAOS server process set managing the service. */
 	const char		*group;
 	/** List of service ranks. */
@@ -379,7 +379,7 @@ typedef struct {
 	/** Pool open handle. */
 	daos_handle_t		poh;
 	/** Container UUID. */
-	const uuid_t		uuid;
+	uuid_t			uuid;
 	/** Optional container properties. */
 	daos_prop_t		*prop;
 } daos_cont_create_t;
@@ -389,7 +389,7 @@ typedef struct {
 	/** Pool open handle. */
 	daos_handle_t		poh;
 	/** Container UUID. */
-	const uuid_t		uuid;
+	uuid_t			uuid;
 	/** Open mode, represented by the DAOS_COO_ bits.*/
 	unsigned int		flags;
 	/** Returned container open handle. */
@@ -409,7 +409,7 @@ typedef struct {
 	/** Pool open handle. */
 	daos_handle_t		poh;
 	/** Container UUID. */
-	const uuid_t		uuid;
+	uuid_t			uuid;
 	/** Force destroy even if there is outstanding open handles. */
 	int			force;
 } daos_cont_destroy_t;


### PR DESCRIPTION
Users using the task API should be able to set the uuid in the struct
for operations that take them as input parameters (pool/container
create, destroy, etc.). This is different than an API call where
the uuid is passed vs being set in a struct which will cause warnings
in the user code.

Signed-off-by: Mohamad Chaarawi <mohamad.chaarawi@intel.com>