### PR TITLE
DAOS-5647 test: skip for ticket daos vol unit tests

### DIFF
--- a/src/tests/ftest/io/daos_vol.py
+++ b/src/tests/ftest/io/daos_vol.py
@@ -44,7 +44,7 @@ class DaosVol(VolTestBase):
             self.cancelForTicket("DAOS-6076")
         if testname == "h5_partest_t_bigio":
             self.cancelForTicket("DAOS-5496")
-        if testname == "h5vl_test_parallel ":
+        if testname == "h5vl_test_parallel":
             self.cancelForTicket("DAOS-5647")
         super(DaosVol, self).setUp()
 

--- a/src/tests/ftest/io/daos_vol.py
+++ b/src/tests/ftest/io/daos_vol.py
@@ -36,10 +36,16 @@ class DaosVol(VolTestBase):
         # Cancel h5_test_testhdf5 with MPICH
         mpi_type = self.params.get("job_manager_mpi_type")
         testname = self.params.get("testname")
-        if mpi_type == "mpich" and testname == "h5_test_testhdf5":
+        if testname == "h5_partest_t_shapesame":
+            self.cancelForTicket("DAOS-5831")
+        if testname == "h5_test_testhdf5":
             self.cancelForTicket("DAOS-5469")
+        if testname == "h5_partest_testphdf5":
+            self.cancelForTicket("DAOS-6076")
         if testname == "h5_partest_t_bigio":
             self.cancelForTicket("DAOS-5496")
+        if testname == "h5vl_test_parallel ":
+            self.cancelForTicket("DAOS-5647")
         super(DaosVol, self).setUp()
 
     def test_daos_vol(self):
@@ -59,6 +65,6 @@ class DaosVol(VolTestBase):
               h5daos_test_map_parallel
               h5daos_test_oclass
 
-        :avocado: tags=all,hw,small,hdf5,vol,DAOS_5610
+        :avocado: tags=all,pr,hw,small,hdf5,vol,DAOS_5610
         """
         self.run_test()

--- a/src/tests/ftest/io/daos_vol.yaml
+++ b/src/tests/ftest/io/daos_vol.yaml
@@ -3,8 +3,8 @@ hosts:
         - server-A
     test_clients:
         - client-B
-timeout: 1800
-job_manager_timeout: 1700
+timeout: 800
+job_manager_timeout: 700
 server_config:
     name: daos_server
     servers:

--- a/src/tests/ftest/io/ior_small.yaml
+++ b/src/tests/ftest/io/ior_small.yaml
@@ -53,8 +53,7 @@ ior:
             - MPIIO
             - POSIX
             - HDF5
-# DAOS-5980: Disable HDF5-VOL until upstream is updated.
-#            - HDF5-VOL
+            - HDF5-VOL
           transfer_block_size:
             - [256B, 2M]
             - [1M, 32M]


### PR DESCRIPTION
This PR  enables the hdf5 vol daos unit test and
skip any tests that have open tickets.  This PR will also
enable ior -HDF5-VOL in ior_small

Signed-off-by: Maureen Jean <maureen.jean@intel.com>