### PR TITLE
DAOS-6149 EC: set iod_size by reply size for EC object

### DIFF
--- a/src/object/cli_obj.c
+++ b/src/object/cli_obj.c
@@ -815,6 +815,7 @@ obj_rw_req_reassemb(struct dc_object *obj, daos_obj_rw_t *args,
 
 	if (epoch != NULL)
 		reasb_req->orr_epoch = *epoch;
+	reasb_req->orr_size_set = 0;
 	if (obj_auxi->req_reasbed && !reasb_req->orr_size_fetch) {
 		D_DEBUG(DB_TRACE, DF_OID" req reassembled (retry case).\n",
 			DP_OID(oid));

--- a/src/object/obj_internal.h
+++ b/src/object/obj_internal.h
@@ -176,7 +176,9 @@ struct obj_reasb_req {
 	/* only for single-value IO flag */
 					 orr_singv_only:1,
 	/* the flag of IOM re-allocable (used for EC IOM merge) */
-					 orr_iom_realloc:1;
+					 orr_iom_realloc:1,
+	/* iod_size is set by IO reply */
+					 orr_size_set:1;
 };
 
 static inline void

--- a/src/object/srv_obj_migrate.c
+++ b/src/object/srv_obj_migrate.c
@@ -1700,6 +1700,10 @@ migrate_enum_unpack_cb(struct dss_enum_unpack_io *io, void *data)
 							    &iod->iod_nr);
 				if (rc)
 					return rc;
+
+				/* No data needs to be migrate. */
+				if (iod->iod_nr == 0)
+					continue;
 				/* NB: data epoch can not be larger than
 				 * parity epoch, otherwise it will cause
 				 * issue in degraded fetch, since it will


### PR DESCRIPTION
Add orr_size_set to indicate if the iod_size has been
set by fetch shard reply, and only update size if
iod_size is not being set or iod_size is still 0.

Signed-off-by: Di Wang <di.wang@intel.com>