### PR TITLE
DAOS-6249 tests: enable rebuild 0-10

### DIFF
--- a/src/tests/ftest/daos_test/daos_core_test-rebuild.yaml
+++ b/src/tests/ftest/daos_test/daos_core_test-rebuild.yaml
@@ -57,12 +57,11 @@ daos_tests:
   num_replicas:
     num_replicas: 1
   Tests: !mux
-# Skipped for DAOS-5851
-#    test_r_0-10:
-#      daos_test: r
-#      test_name: rebuild tests 0-10
-#      args: -s3 -u subtests="0-10"
-#      test_timeout: 1500
+    test_r_0-10:
+      daos_test: r
+      test_name: rebuild tests 0-10
+      args: -s3 -u subtests="0-10"
+      test_timeout: 1500
     test_r_12-15:
       daos_test: r
       test_name: rebuild tests 12-15


### PR DESCRIPTION
Re-enable rebuild 0-10 after fixing related bugs via PR#3838.

Signed-off-by: Fan Yong <fan.yong@intel.com>