### PR TITLE
DAOS-6010 build: Add daos-java rpm package

### DIFF
--- a/ci/rpm/scan_daos_node.sh
+++ b/ci/rpm/scan_daos_node.sh
@@ -3,7 +3,7 @@
 set -uex
 
 sudo yum -y install \
-  daos{,-{client,server,tests,debuginfo,devel}}-"${DAOS_PKG_VERSION}"
+  daos{,-{client,server,tests,debuginfo,devel,java}}-"${DAOS_PKG_VERSION}"
 
 lmd_src="maldet-current"
 lmd_tarball="maldetect-current.tar.gz"

--- a/ci/rpm/setup_dnf_mock.sh
+++ b/ci/rpm/setup_dnf_mock.sh
@@ -1,0 +1,64 @@
+#!/bin/bash
+# File: setup_dnf_mock.sh
+
+# This sets up a system, presumably Fedora for doing mock builds of RPMS.
+# After running this script the first time on a system, the user
+# may need to log off and log in again as they need to be a member of
+# the mock group.
+
+# This script needs to be run with the source command
+
+sudo dnf -y install createrepo curl git make mock python-srpm-macros \
+                    redhat-lsb-core rpmdevtools rpmlint
+
+grep use_nspawn /etc/mock/site-defaults.cfg || \
+  echo "config_opts['use_nspawn'] = False" |   \
+    sudo tee -a /etc/mock/site-defaults.cf
+
+sudo chmod g+w /etc/mock/*
+
+if id -nGz "${USER}" | grep -qzxF "mock"; then
+  echo "Already a member of mock group"
+else
+  sudo usermod -a -G mock $USER
+  echo "You must log out and back in to use mock"
+fi
+
+: "${STAGE_NAME:=Build RPM on CentOS 7}"
+#: "${STAGE_NAME:=Build RPM on Leap 15}"
+: "${SCONS_FAULTS_ARGS:=}"
+: "${DAOS_EMAIL:=nobody@example.com}"
+: "${DAOS_FULLNAME:=$USER}"
+: "${SCONS_FAULTS_ARGS:=BUILD_TYPE=dev}"
+export STAGE_NAME
+export SCONS_FAULTS_ARGS
+export DAOS_EMAIL
+export DAOS_FULLNAME
+export SCONS_FAULTS_ARGS
+
+el7_group="repository/daos-stack-external-el-7-x86_64-stable-group"
+el7_local="repository/daos-stack-el-7-x86_64-stable-local"
+el8_group="repository/daos-stack-external-el-8-x86_64-stable-group"
+el8_local="repository/daos-stack-el-8-x86_64-stable-local"
+leap15_group="repository/daos-stack-external-leap-15-x86_64-stable-group"
+leap15_local="repository/daos-stack-leap-15-x86_64-stable-local"
+tools_repo="repository/daos-stack-external-stable-local"
+repo_url="https://repo.dc.hpdd.intel.com/"
+: "${DAOS_STACK_EL_7_GROUP_REPO:=$el7_group}"
+: "${DAOS_STACK_EL_7_LOCAL_REPO:=$el7_local}"
+: "${DAOS_STACK_EL_8_GROUP_REPO:=$el8_group}"
+: "${DAOS_STACK_EL_8_LOCAL_REPO:=$el8_local}"
+: "${DAOS_STACK_LEAP_15_GROUP_REPO:=$leap15_group}"
+: "${DAOS_STACK_LEAP_15_LOCAL_REPO:=$leap15_local}"
+: "${DAOS_STACK_TOOLS_REPO:=$tools_repo}"
+: "${REPOSITORY_URL:=$repo_url}"
+
+export DAOS_STACK_EL_7_GROUP_REPO
+export DAOS_STACK_EL_7_LOCAL_REPO
+export DAOS_STACK_EL_8_GROUP_REPO
+export DAOS_STACK_EL_8_LOCAL_REPO
+export DAOS_STACK_LEAP_15_GROUP_REPO
+export DAOS_STACK_LEAP_15_LOCAL_REPO
+export DAOS_STACK_TOOLS_REPO
+export REPOSITORY_URL
+

--- a/ci/rpm/setup_dnf_mock_centos7.sh
+++ b/ci/rpm/setup_dnf_mock_centos7.sh
@@ -1,0 +1,65 @@
+#!/bin/bash
+# File: setup_dnf_mock.sh
+
+# This sets up a system, presumably Fedora for doing mock builds of RPMS.
+# After running this script the first time on a system, the user
+# may need to log off and log in again as they need to be a member of
+# the mock group.
+
+# This script needs to be run with the source command
+
+sudo dnf -y install createrepo curl git make mock python-srpm-macros \
+                    redhat-lsb-core rpmdevtools rpmlint
+
+grep use_nspawn /etc/mock/site-defaults.cfg || \
+  echo "config_opts['use_nspawn'] = False" |   \
+    sudo tee -a /etc/mock/site-defaults.cf
+
+sudo chmod g+w /etc/mock/*
+
+if id -nGz "${USER}" | grep -qzxF "mock"; then
+  echo "Already a member of mock group"
+else
+  sudo usermod -a -G mock $USER
+  echo "You must log out and back in to use mock"
+fi
+
+unset STAGE_NAME
+: "${STAGE_NAME:=Build RPM on CentOS 7}"
+#: "${STAGE_NAME:=Build RPM on Leap 15}"
+: "${SCONS_FAULTS_ARGS:=}"
+: "${DAOS_EMAIL:=nobody@example.com}"
+: "${DAOS_FULLNAME:=$USER}"
+: "${SCONS_FAULTS_ARGS:=BUILD_TYPE=dev}"
+export STAGE_NAME
+export SCONS_FAULTS_ARGS
+export DAOS_EMAIL
+export DAOS_FULLNAME
+export SCONS_FAULTS_ARGS
+
+el7_group="repository/daos-stack-external-el-7-x86_64-stable-group"
+el7_local="repository/daos-stack-el-7-x86_64-stable-local"
+el8_group="repository/daos-stack-external-el-8-x86_64-stable-group"
+el8_local="repository/daos-stack-el-8-x86_64-stable-local"
+leap15_group="repository/daos-stack-external-leap-15-x86_64-stable-group"
+leap15_local="repository/daos-stack-leap-15-x86_64-stable-local"
+tools_repo="repository/daos-stack-external-stable-local"
+repo_url="https://repo.dc.hpdd.intel.com/"
+: "${DAOS_STACK_EL_7_GROUP_REPO:=$el7_group}"
+: "${DAOS_STACK_EL_7_LOCAL_REPO:=$el7_local}"
+: "${DAOS_STACK_EL_8_GROUP_REPO:=$el8_group}"
+: "${DAOS_STACK_EL_8_LOCAL_REPO:=$el8_local}"
+: "${DAOS_STACK_LEAP_15_GROUP_REPO:=$leap15_group}"
+: "${DAOS_STACK_LEAP_15_LOCAL_REPO:=$leap15_local}"
+: "${DAOS_STACK_TOOLS_REPO:=$tools_repo}"
+: "${REPOSITORY_URL:=$repo_url}"
+
+export DAOS_STACK_EL_7_GROUP_REPO
+export DAOS_STACK_EL_7_LOCAL_REPO
+export DAOS_STACK_EL_8_GROUP_REPO
+export DAOS_STACK_EL_8_LOCAL_REPO
+export DAOS_STACK_LEAP_15_GROUP_REPO
+export DAOS_STACK_LEAP_15_LOCAL_REPO
+export DAOS_STACK_TOOLS_REPO
+export REPOSITORY_URL
+

--- a/ci/rpm/setup_dnf_mock_leap.sh
+++ b/ci/rpm/setup_dnf_mock_leap.sh
@@ -1,0 +1,65 @@
+#!/bin/bash
+# File: setup_dnf_mock.sh
+
+# This sets up a system, presumably Fedora for doing mock builds of RPMS.
+# After running this script the first time on a system, the user
+# may need to log off and log in again as they need to be a member of
+# the mock group.
+
+# This script needs to be run with the source command
+
+sudo dnf -y install createrepo curl git make mock python-srpm-macros \
+                    redhat-lsb-core rpmdevtools rpmlint
+
+grep use_nspawn /etc/mock/site-defaults.cfg || \
+  echo "config_opts['use_nspawn'] = False" |   \
+    sudo tee -a /etc/mock/site-defaults.cfg
+
+sudo chmod g+w /etc/mock/*
+
+if id -nGz "${USER}" | grep -qzxF "mock"; then
+  echo "Already a member of mock group"
+else
+  sudo usermod -a -G mock $USER
+  echo "You must log out and back in to use mock"
+fi
+
+unset STAGE_NAME
+#: "${STAGE_NAME:=Build RPM on CentOS 7}"
+: "${STAGE_NAME:=Build RPM on Leap 15}"
+: "${SCONS_FAULTS_ARGS:=}"
+: "${DAOS_EMAIL:=nobody@example.com}"
+: "${DAOS_FULLNAME:=$USER}"
+: "${SCONS_FAULTS_ARGS:=BUILD_TYPE=dev}"
+export STAGE_NAME
+export SCONS_FAULTS_ARGS
+export DAOS_EMAIL
+export DAOS_FULLNAME
+export SCONS_FAULTS_ARGS
+
+el7_group="repository/daos-stack-external-el-7-x86_64-stable-group"
+el7_local="repository/daos-stack-el-7-x86_64-stable-local"
+el8_group="repository/daos-stack-external-el-8-x86_64-stable-group"
+el8_local="repository/daos-stack-el-8-x86_64-stable-local"
+leap15_group="repository/daos-stack-external-leap-15-x86_64-stable-group"
+leap15_local="repository/daos-stack-leap-15-x86_64-stable-local"
+tools_repo="repository/daos-stack-external-stable-local"
+repo_url="https://repo.dc.hpdd.intel.com/"
+: "${DAOS_STACK_EL_7_GROUP_REPO:=$el7_group}"
+: "${DAOS_STACK_EL_7_LOCAL_REPO:=$el7_local}"
+: "${DAOS_STACK_EL_8_GROUP_REPO:=$el8_group}"
+: "${DAOS_STACK_EL_8_LOCAL_REPO:=$el8_local}"
+: "${DAOS_STACK_LEAP_15_GROUP_REPO:=$leap15_group}"
+: "${DAOS_STACK_LEAP_15_LOCAL_REPO:=$leap15_local}"
+: "${DAOS_STACK_TOOLS_REPO:=$tools_repo}"
+: "${REPOSITORY_URL:=$repo_url}"
+
+export DAOS_STACK_EL_7_GROUP_REPO
+export DAOS_STACK_EL_7_LOCAL_REPO
+export DAOS_STACK_EL_8_GROUP_REPO
+export DAOS_STACK_EL_8_LOCAL_REPO
+export DAOS_STACK_LEAP_15_GROUP_REPO
+export DAOS_STACK_LEAP_15_LOCAL_REPO
+export DAOS_STACK_TOOLS_REPO
+export REPOSITORY_URL
+

--- a/ci/rpm/test_daos_node.sh
+++ b/ci/rpm/test_daos_node.sh
@@ -4,7 +4,7 @@ set -uex
 sudo yum -y install --exclude ompi daos{,-client}-"${DAOS_PKG_VERSION}"
 sudo yum -y history rollback last-1
 sudo yum -y install --exclude ompi daos{,-{server,client}}-"${DAOS_PKG_VERSION}"
-sudo yum -y install --exclude ompi daos{,-tests}-"${DAOS_PKG_VERSION}"
+sudo yum -y install --exclude ompi daos{,-(tests,java}-"${DAOS_PKG_VERSION}"
 
 me=$(whoami)
 for dir in server agent; do

--- a/utils/rpms/packaging/rpm_chrootbuild
+++ b/utils/rpms/packaging/rpm_chrootbuild
@@ -44,4 +44,18 @@ else
     echo "Unable to update /etc/mock/$CHROOT_NAME.cfg."
     echo "You need to make sure it has the needed repos in it yourself."
 fi
-eval mock -r "$CHROOT_NAME" $MOCK_OPTIONS $RPM_BUILD_OPTIONS "$TARGET"
+
+echo mock -r "$CHROOT_NAME" $MOCK_OPTIONS --init
+eval mock -r "$CHROOT_NAME" $MOCK_OPTIONS --init
+
+echo mock -r "$CHROOT_NAME" $MOCK_OPTIONS --install bash
+eval mock -r "$CHROOT_NAME" $MOCK_OPTIONS --install bash
+#mock -r "$CHROOT_NAME" $MOCK_OPTIONS --install lz4-devel
+#mock -r "$CHROOT_NAME" $MOCK_OPTIONS --install mercury-devel
+#mock -r "$CHROOT_NAME" $MOCK_OPTIONS --debug-config
+#echo mock -r "$CHROOT_NAME" $MOCK_OPTIONS $RPM_BUILD_OPTIONS --installdeps "$TARGET"
+#eval mock -r "$CHROOT_NAME" $MOCK_OPTIONS $RPM_BUILD_OPTIONS --installdeps "$TARGET"
+echo mock -r "$CHROOT_NAME" $MOCK_OPTIONS $RPM_BUILD_OPTIONS --no-clean "$TARGET"
+eval mock -r "$CHROOT_NAME" $MOCK_OPTIONS $RPM_BUILD_OPTIONS --no-clean "$TARGET
+"
+#eval mock -r "$CHROOT_NAME" $MOCK_OPTIONS $RPM_BUILD_OPTIONS "$TARGET"


### PR DESCRIPTION
Add the daos-java RPM package.

Skip-build-centos7-gcc-debug:true
Skip-build-centos7-gcc-release:true
Skip-build-ubuntu-clang:true
Skip-build-leap15-icc:true
Skip-build-centos7-gcc:true
Skip-func-test:true
Skip-unit-test:true
Skip-checkpatch:true
Quick-Build:true

Signed-off-by: John E Malmberg <john.e.malmberg@intel.com>