### PR TITLE
DAOS-5512 test: Enable datamover subset test

### DIFF
--- a/src/tests/ftest/datamover/copy_basics.py
+++ b/src/tests/ftest/datamover/copy_basics.py
@@ -23,7 +23,6 @@
 '''
 from data_mover_test_base import DataMoverTestBase
 from os.path import join, sep
-from apricot import skipForTicket
 
 
 class CopyBasicsTest(DataMoverTestBase):
@@ -235,7 +234,6 @@ class CopyBasicsTest(DataMoverTestBase):
         self.run_datamover(test_desc="copy_auto_create_dest (different pool)")
         self.read_verify_location("DAOS_UUID", "/", pool2, new_uuid)
 
-    @skipForTicket("DAOS-5512")
     def test_copy_subsets(self):
         """
         Test Description:

--- a/src/tests/ftest/datamover/copy_basics.py
+++ b/src/tests/ftest/datamover/copy_basics.py
@@ -237,7 +237,7 @@ class CopyBasicsTest(DataMoverTestBase):
     def test_copy_subsets(self):
         """
         Test Description:
-            DAOS-5512: Verify ability to copy container subsets
+            DAOS-5512: Verify ability to copy container subsets.
         Use Cases:
             Create pool1.
             Create POSIX cont1 in pool1.

--- a/src/tests/ftest/datamover/copy_basics.yaml
+++ b/src/tests/ftest/datamover/copy_basics.yaml
@@ -3,7 +3,7 @@ hosts:
         - server-A
     test_clients:
         - server-A
-timeout: 600
+timeout: 360
 server_config:
     name: daos_server
 pool:

--- a/src/tests/ftest/datamover/copy_negative.py
+++ b/src/tests/ftest/datamover/copy_negative.py
@@ -115,12 +115,6 @@ class CopyNegativeTest(DataMoverTestBase):
             expected_rc=1,
             expected_output=self.MFU_ERR_DAOS_INVAL_ARG)
 
-        self.set_src_location("DAOS_UUID", "/", pool1.uuid, container1)
-        self.run_datamover(
-            test_desc="copy_bad_params (source pool but no source svcl)",
-            expected_rc=1,
-            expected_output=self.MFU_ERR_DAOS_INVAL_ARG)
-
         # Bad parameter: required arguments.
         # These tests use the same valid source parameters,
         # but varying invalid destination parameters.
@@ -129,44 +123,6 @@ class CopyNegativeTest(DataMoverTestBase):
         self.set_dst_location("DAOS_UUID", "/", None, container1)
         self.run_datamover(
             test_desc="copy_bad_params (dest cont but no dest pool)",
-            expected_rc=1,
-            expected_output=self.MFU_ERR_DAOS_INVAL_ARG)
-
-        self.set_dst_location("DAOS_UUID", "/", pool1.uuid, container1)
-        self.run_datamover(
-            test_desc="copy_bad_params (dest pool but no dest svcl)",
-            expected_rc=1,
-            expected_output=self.MFU_ERR_DAOS_INVAL_ARG)
-
-        # Bad parameter: required arguments.
-        # These tests use missing prefix/UNS parameters.
-        self.set_dst_location("POSIX", self.posix_test_file)
-        self.set_src_location("DAOS_UNS", self.daos_test_file,
-                              None, container1)
-        self.run_datamover(
-            test_desc="copy_bad_params (source prefix but no svcl)",
-            expected_rc=1,
-            expected_output=self.MFU_ERR_DAOS_INVAL_ARG)
-
-        self.set_dst_location("POSIX", self.posix_test_paths[0])
-        self.set_src_location("DAOS_UNS", "/", None, container1)
-        self.run_datamover(
-            test_desc="copy_bad_params (source UNS but no svcl)",
-            expected_rc=1,
-            expected_output=self.MFU_ERR_DAOS_INVAL_ARG)
-
-        self.set_src_location("POSIX", self.posix_test_file)
-        self.set_dst_location("DAOS_UNS", self.daos_test_file,
-                              None, container1)
-        self.run_datamover(
-            test_desc="copy_bad_params (dest prefix but no svcl)",
-            expected_rc=1,
-            expected_output=self.MFU_ERR_DAOS_INVAL_ARG)
-
-        self.set_src_location("POSIX", self.posix_test_paths[0])
-        self.set_dst_location("DAOS_UNS", "/", None, container1)
-        self.run_datamover(
-            test_desc="copy_bad_params (dest UNS but no svcl)",
             expected_rc=1,
             expected_output=self.MFU_ERR_DAOS_INVAL_ARG)
 

--- a/src/tests/ftest/util/data_mover_test_base.py
+++ b/src/tests/ftest/util/data_mover_test_base.py
@@ -221,11 +221,6 @@ class DataMoverTestBase(IorTestBase):
             return join(prefix, daos_dir)
         return join("/", daos_dir)
 
-    @staticmethod
-    def svcl_from_pool(pool):
-        """Get the string svc for a pool."""
-        return ":".join(map(str, pool.svc_ranks))
-
     def set_src_location(self, *args, **kwargs):
         """Shorthand for set_location("src", ...)."""
         self.set_location("src", *args, **kwargs)
@@ -258,20 +253,16 @@ class DataMoverTestBase(IorTestBase):
         if src_or_dst == "src":
             dm_path = self.dm_cmd.src_path
             dm_pool = self.dm_cmd.daos_src_pool
-            dm_svcl = self.dm_cmd.daos_src_svcl
             dm_cont = self.dm_cmd.daos_src_cont
             display_path = "src_path" if display else None
             display_pool = "daos_src_pool" if display else None
-            display_svcl = "daos_src_svcl" if display else None
             display_cont = "daos_src_cont" if display else None
         elif src_or_dst == "dst":
             dm_path = self.dm_cmd.dest_path
             dm_pool = self.dm_cmd.daos_dst_pool
-            dm_svcl = self.dm_cmd.daos_dst_svcl
             dm_cont = self.dm_cmd.daos_dst_cont
             display_path = "dest_path" if display else None
             display_pool = "daos_dst_pool" if display else None
-            display_svcl = "daos_dst_svcl" if display else None
             display_cont = "daos_dst_cont" if display else None
 
         # Only a single prefix supported at this time.
@@ -283,7 +274,6 @@ class DataMoverTestBase(IorTestBase):
         # Reset params
         dm_path.update(None)
         dm_pool.update(None)
-        dm_svcl.update(None)
         dm_cont.update(None)
         dm_prefix.update(None)
 
@@ -293,10 +283,8 @@ class DataMoverTestBase(IorTestBase):
         # Allow pool to be either the pool or the uuid
         if hasattr(pool, "uuid"):
             pool_uuid = pool.uuid
-            pool_svcl = self.svcl_from_pool(pool)
         else:
             pool_uuid = pool
-            pool_svcl = None
 
         if param_type == "POSIX":
             dm_path.update(path, display_path)
@@ -304,8 +292,6 @@ class DataMoverTestBase(IorTestBase):
             dm_path.update(path, display_path)
             if pool_uuid:
                 dm_pool.update(pool_uuid, display_pool)
-            if pool_svcl:
-                dm_svcl.update(pool_svcl, display_svcl)
             if cont_uuid:
                 dm_cont.update(cont_uuid, display_cont)
         elif param_type == "DAOS_UNS":
@@ -315,8 +301,6 @@ class DataMoverTestBase(IorTestBase):
                 else:
                     dm_prefix.update(cont.path, display_prefix)
                     dm_path.update(str(cont.path) + path, display_path)
-            if pool_svcl:
-                dm_svcl.update(pool_svcl, display_svcl)
 
     def set_ior_location(self, param_type, path, pool=None, cont=None,
                          path_suffix=None, display=True):

--- a/src/tests/ftest/util/data_mover_utils.py
+++ b/src/tests/ftest/util/data_mover_utils.py
@@ -48,10 +48,6 @@ class DataMoverCommand(ExecutableCommand):
         self.daos_src_cont = FormattedParameter("--daos-src-cont {}")
         # DAOS destination container
         self.daos_dst_cont = FormattedParameter("--daos-dst-cont {}")
-        # Source service level
-        self.daos_src_svcl = FormattedParameter("--daos-src-svcl {}")
-        # Destination service level
-        self.daos_dst_svcl = FormattedParameter("--daos-dst-svcl {}")
         # DAOS prefix for unified namespace path
         self.daos_prefix = FormattedParameter("--daos-prefix {}")
         # read source list from file
@@ -103,22 +99,10 @@ class DataMoverCommand(ExecutableCommand):
         if src_pool:
             self.daos_src_pool.update(src_pool.uuid,
                                       "daos_src_pool" if display else None)
-            # setting src service level
-            src_svcl = ":".join(
-                [str(item) for item in [
-                    int(src_pool.pool.svc.rl_ranks[index])
-                    for index in range(src_pool.pool.svc.rl_nr)]])
-            self.daos_src_svcl.update(src_svcl, "src_svcl" if display else None)
 
         if dst_pool:
             self.daos_dst_pool.update(dst_pool.uuid,
                                       "daos_dst_pool" if display else None)
-            # setting destination service level
-            dst_svcl = ":".join(
-                [str(item) for item in [
-                    int(dst_pool.pool.svc.rl_ranks[index])
-                    for index in range(dst_pool.pool.svc.rl_nr)]])
-            self.daos_dst_svcl.update(dst_svcl, "dst_svcl" if display else None)
 
         if src_cont:
             self.daos_src_cont.update(src_cont.uuid,


### PR DESCRIPTION
Test-tag: pr,-hw datamover,-hw
Test-tag-hw-small: pr,hw,small datamover,hw,small
Test-tag-hw-large: pr,hw,large datamover,hw,large

Enabled copy_subsets, now that mpifileutils has
been updated.

Removed svcl from the dcp utility.
Removed svcl negative testing.

Signed-off-by: Dalton Bohning <daltonx.bohning@intel.com>