### PR TITLE
DAOS-623 build: Remove -mavx2 flag for now

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -21,8 +21,7 @@ DESIRED_FLAGS = ['-Wno-gnu-designator',
                  '-Wno-gnu-zero-variadic-macro-arguments',
                  '-Wno-tautological-constant-out-of-range-compare',
                  '-Wno-unused-command-line-argument',
-                 '-Wframe-larger-than=4096',
-                 ' -mavx2']
+                 '-Wframe-larger-than=4096']
 
 # Compiler flags to prevent optimizing out security checks
 DESIRED_FLAGS.extend(['-fno-strict-overflow', '-fno-delete-null-pointer-checks',


### PR DESCRIPTION
The code doesn't compile as is and the presence of the flag
with the extra space causes the compiler to fail on
some platforms.   Better to remove and work on fixing the
avx2 code offline.

Signed-off-by: Jeff Olivier <jeffrey.v.olivier@intel.com>