### PR TITLE
DAOS-4093 travis: use 20.04 as baseline distrib

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,9 @@
+arch: amd64
+os: linux
 dist: focal
-sudo: required
 
 env:
- matrix:
+ jobs:
   - DOCKER_IMAGE=ubuntu.20.04
   - DOCKER_IMAGE=centos.7
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+dist: focal
 sudo: required
 
 env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,9 +8,6 @@ env:
 
 language: c
 
-language: java
-jdk: openjdk8
-
 services:
  - docker
 


### PR DESCRIPTION
Switch to Focal Fossa (20.04) as baseline distribution
instead of Xenial (16.04) for travis build.

Skip-build: true
Skip-test: true

Signed-off-by: Johann Lombardi <johann.lombardi@intel.com>