### PR TITLE
DAOS-623 build: Limit travis branch builds to master only

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,11 @@ arch: amd64
 os: linux
 dist: focal
 
+branches:
+  only:
+    - master
+    - /^jvolivie\/.*/
+
 env:
  jobs:
   - DOCKER_IMAGE=ubuntu.20.04


### PR DESCRIPTION
PR's will still be tested but not the underlying branch

Skip-build: true
Skip-test: true

Signed-off-by: Jeff Olivier <jeffrey.v.olivier@intel.com>