### PR TITLE
DAOS-5852 test: Disable daoscoretest rebuild r26

### DIFF
--- a/src/tests/ftest/daos_test/daos_core_test-rebuild.yaml
+++ b/src/tests/ftest/daos_test/daos_core_test-rebuild.yaml
@@ -109,10 +109,11 @@ daos_tests:
       daos_test: r
       test_name: rebuild tests 25
       args: -s3 -u subtests="25"
-    test_r_26:
-      daos_test: r
-      test_name: rebuild tests 26
-      args: -s3 -u subtests="26"
+#Skipped for DAOS-5852
+#    test_r_26:
+#      daos_test: r
+#      test_name: rebuild tests 26
+#      args: -s3 -u subtests="26"
     test_r_27:
       daos_test: r
       test_name: rebuild tests 27


### PR DESCRIPTION
Disable daoscoretest rebuild r26 due to DAOS-5852