### PR TITLE
DAOS-6318 rebuild: use target version as rebuild version

### DIFF
--- a/src/include/daos/debug.h
+++ b/src/include/daos/debug.h
@@ -82,7 +82,9 @@
 	/** security check */					\
 	ACTION(DB_SEC,	   sec,	    security,       0, arg)	\
 	/** checksum */						\
-	ACTION(DB_CSUM,	   csum,    checksum,	    0, arg)
+	ACTION(DB_CSUM,	   csum,    checksum,	    0, arg)	\
+	/** daos managment */					\
+	ACTION(DB_DSMS,	   dsms,    service,	    0, arg)
 
 DAOS_FOREACH_DB(D_LOG_DECLARE_DB, D_NOOP);
 DAOS_FOREACH_LOG_FAC(D_LOG_DECLARE_FAC, DAOS_FOREACH_DB);
@@ -94,7 +96,7 @@ DAOS_FOREACH_LOG_FAC(D_LOG_DECLARE_FAC, DAOS_FOREACH_DB);
 #define DB_NULL		0
 /** XXX Temporary things, should be replaced by debug bits above */
 #define DF_DSMC		DB_ANY
-#define DF_DSMS		DB_ANY
+#define DF_DSMS		DB_DSMS
 #define DF_MISC		DB_ANY
 
 /** initialize the debug system */

--- a/src/object/cli_ec.c
+++ b/src/object/cli_ec.c
@@ -2806,7 +2806,6 @@ obj_recx_ec_daos2shard(struct daos_oclass_attr *oca, int shard,
 
 	if (total == 0) {
 		D_FREE(*recxs_p);
-		*recxs_p = NULL;
 		*iod_nr = 0;
 		return 0;
 	}

--- a/src/pool/srv_internal.h
+++ b/src/pool/srv_internal.h
@@ -162,7 +162,7 @@ int ds_pool_tgt_connect(struct ds_pool *pool, struct pool_iv_conn *pic);
  */
 int ds_pool_map_tgts_update(struct pool_map *map,
 			    struct pool_target_id_list *tgts, int opc,
-			    bool evict_rank);
+			    bool evict_rank, uint32_t *tgt_map_ver);
 int ds_pool_check_failed_replicas(struct pool_map *map, d_rank_list_t *replicas,
 				  d_rank_list_t *failed, d_rank_list_t *alt);
 extern struct bio_reaction_ops nvme_reaction_ops;

--- a/src/pool/srv_pool.c
+++ b/src/pool/srv_pool.c
@@ -3763,9 +3763,9 @@ out:
 /* Callers are responsible for d_rank_list_free(*replicasp). */
 static int
 ds_pool_update_internal(uuid_t pool_uuid, struct pool_target_id_list *tgts,
-			unsigned int opc, uint32_t *map_version_p,
-			struct rsvc_hint *hint, bool *p_updated,
-			bool evict_rank)
+			unsigned int opc, struct rsvc_hint *hint,
+			bool *p_updated, bool evict_rank,
+			uint32_t *map_version_p, uint32_t *tgt_map_ver)
 {
 	struct pool_svc	       *svc;
 	struct rdb_tx		tx;
@@ -3795,8 +3795,7 @@ ds_pool_update_internal(uuid_t pool_uuid, struct pool_target_id_list *tgts,
 	 * before and after. If the version hasn't changed, we are done.
 	 */
 	map_version_before = pool_map_get_version(map);
-	rc = ds_pool_map_tgts_update(map, tgts, opc, evict_rank);
-
+	rc = ds_pool_map_tgts_update(map, tgts, opc, evict_rank, tgt_map_ver);
 	if (rc != 0)
 		D_GOTO(out_map, rc);
 
@@ -4121,21 +4120,21 @@ int
 ds_pool_tgt_exclude_out(uuid_t pool_uuid, struct pool_target_id_list *list)
 {
 	return ds_pool_update_internal(pool_uuid, list, POOL_EXCLUDE_OUT,
-				       NULL, NULL, NULL, false);
+				       NULL, NULL, false, NULL, NULL);
 }
 
 int
 ds_pool_tgt_exclude(uuid_t pool_uuid, struct pool_target_id_list *list)
 {
 	return ds_pool_update_internal(pool_uuid, list, POOL_EXCLUDE,
-				       NULL, NULL, NULL, false);
+				       NULL, NULL, false, NULL, NULL);
 }
 
 int
 ds_pool_tgt_add_in(uuid_t pool_uuid, struct pool_target_id_list *list)
 {
 	return ds_pool_update_internal(pool_uuid, list, POOL_ADD_IN,
-				       NULL, NULL, NULL, false);
+				       NULL, NULL, false, NULL, NULL);
 }
 
 /*
@@ -4153,6 +4152,7 @@ ds_pool_update(uuid_t pool_uuid, crt_opcode_t opc,
 	struct pool_target_id_list	target_list = { 0 };
 	struct ds_pool			*pool = NULL;
 	daos_prop_t			prop = { 0 };
+	uint32_t			tgt_map_ver = 0;
 	struct daos_prop_entry		*entry;
 	bool				updated;
 	int				rc;
@@ -4164,8 +4164,9 @@ ds_pool_update(uuid_t pool_uuid, crt_opcode_t opc,
 		D_GOTO(out, rc);
 
 	/* Update target by target id */
-	rc = ds_pool_update_internal(pool_uuid, &target_list, opc, map_version,
-				     hint, &updated, evict_rank);
+	rc = ds_pool_update_internal(pool_uuid, &target_list, opc, hint,
+				     &updated, evict_rank, map_version,
+				     &tgt_map_ver);
 	if (rc)
 		D_GOTO(out, rc);
 
@@ -4209,10 +4210,15 @@ ds_pool_update(uuid_t pool_uuid, crt_opcode_t opc,
 		D_GOTO(out, rc);
 	}
 
-	rc = ds_rebuild_schedule(pool_uuid, *map_version, &target_list, op);
-	if (rc != 0) {
-		D_ERROR("rebuild fails rc: "DF_RC"\n", DP_RC(rc));
-		D_GOTO(out, rc);
+	D_DEBUG(DF_DSMS, "map ver %u/%u\n", map_version ? *map_version : -1,
+		tgt_map_ver);
+	if (tgt_map_ver != 0) {
+		rc = ds_rebuild_schedule(pool_uuid, tgt_map_ver, &target_list,
+					 op);
+		if (rc != 0) {
+			D_ERROR("rebuild fails rc: "DF_RC"\n", DP_RC(rc));
+			D_GOTO(out, rc);
+		}
 	}
 
 out:

--- a/src/rebuild/srv.c
+++ b/src/rebuild/srv.c
@@ -1413,11 +1413,16 @@ ds_rebuild_schedule(const uuid_t uuid, uint32_t map_ver,
 				  uuid, map_ver, rebuild_op, tgts);
 	d_list_add_tail(&task->dst_list, &rebuild_gst.rg_queue_list);
 
+	D_DEBUG(DB_REBUILD, "rebuild queue "DF_UUID" ver=%u, op=%s",
+		DP_UUID(uuid), map_ver, RB_OP_STR(rebuild_op));
+
 	if (!rebuild_gst.rg_rebuild_running) {
 		rc = ABT_cond_create(&rebuild_gst.rg_stop_cond);
 		if (rc != ABT_SUCCESS)
 			D_GOTO(free, rc = dss_abterr2der(rc));
 
+		D_DEBUG(DB_REBUILD, "rebuild ult "DF_UUID" ver=%u, op=%s",
+			DP_UUID(uuid), map_ver, RB_OP_STR(rebuild_op));
 		rebuild_gst.rg_rebuild_running = 1;
 		rc = dss_ult_create(rebuild_ults, NULL, DSS_ULT_REBUILD,
 				    DSS_TGT_SELF, 0, NULL);
@@ -1699,8 +1704,9 @@ rebuild_tgt_status_check_ult(void *arg)
 		 * the rebuild.
 		 */
 		if (!rpt->rt_global_done) {
-			iv.riv_master_rank =
-				rpt->rt_pool->sp_iv_ns->iv_master_rank;
+			struct ds_iv_ns *ns = rpt->rt_pool->sp_iv_ns;
+
+			iv.riv_master_rank = ns->iv_master_rank;
 			iv.riv_rank = rpt->rt_rank;
 			iv.riv_ver = rpt->rt_rebuild_ver;
 			iv.riv_leader_term = rpt->rt_leader_term;
@@ -1711,9 +1717,9 @@ rebuild_tgt_status_check_ult(void *arg)
 			if (DAOS_FAIL_CHECK(DAOS_REBUILD_TGT_IV_UPDATE_FAIL))
 				rc = -DER_INVAL;
 			else
-				rc = rebuild_iv_update(rpt->rt_pool->sp_iv_ns,
-						   &iv, CRT_IV_SHORTCUT_TO_ROOT,
-						   CRT_IV_SYNC_NONE, false);
+				rc = rebuild_iv_update(ns, &iv,
+						       CRT_IV_SHORTCUT_TO_ROOT,
+						       CRT_IV_SYNC_NONE, false);
 			if (rc == 0) {
 				if (rpt->rt_re_report) {
 					rpt->rt_reported_toberb_objs =
@@ -1727,8 +1733,7 @@ rebuild_tgt_status_check_ult(void *arg)
 				rpt->rt_reported_rec_cnt = status.rec_count;
 				rpt->rt_reported_size = status.size;
 			} else {
-				D_WARN("rebuild tgt iv update failed: %d\n",
-					rc);
+				D_WARN("rebuild iv update failed: %d\n", rc);
 				/* Already finish rebuilt, but it can not
 				 * its rebuild status on the leader, i.e.
 				 * it can not find the IV see crt_iv_hdlr_xx().
@@ -1736,6 +1741,26 @@ rebuild_tgt_status_check_ult(void *arg)
 				 */
 				if (rc == -DER_NONEXIST && !status.rebuilding)
 					rpt->rt_global_done = 1;
+
+				if (rc == -DER_NOTLEADER) {
+					/* If the leader is changed, let's
+					 * check if it needs to abort the
+					 * current rebuild and wait the new
+					 * leader to re-start the rebuild.
+					 */
+					if (iv.riv_master_rank !=
+					    ns->iv_master_rank) {
+						D_DEBUG(DB_REBUILD, "master %u"
+							"-> %u ignore %d\n",
+							iv.riv_master_rank,
+							ns->iv_master_rank, rc);
+					} else {
+						D_DEBUG(DB_REBUILD, "abort"
+							" rebuild "DF_UUID"\n",
+						    DP_UUID(rpt->rt_pool_uuid));
+						rpt->rt_abort = 1;
+					}
+				}
 			}
 		}
 

--- a/src/tests/ftest/daos_test/daos_core_test-rebuild.yaml
+++ b/src/tests/ftest/daos_test/daos_core_test-rebuild.yaml
@@ -27,7 +27,7 @@ server_config:
       scm_mount: /mnt/daos0
       log_mask: DEBUG,MEM=ERR
       env_vars:
-        - DD_MASK=mgmt,io,md,epc,rebuild
+        - DD_MASK=mgmt,io,md,epc,dsms,rebuild
     1:
       pinned_numa_node: 1
       nr_xs_helpers: 1
@@ -42,7 +42,7 @@ server_config:
       scm_mount: /mnt/daos1
       log_mask: DEBUG,MEM=ERR
       env_vars:
-        - DD_MASK=mgmt,io,md,epc,rebuild
+        - DD_MASK=mgmt,io,md,epc,dsms,rebuild
   transport_config:
     allow_insecure: True
 agent_config:
@@ -76,11 +76,10 @@ daos_tests:
       daos_test: r
       test_name: rebuild tests 17
       args: -s3 -u subtests="17"
-# Skipped for DAOS-6247
-#    test_r_18:
-#      daos_test: r
-#      test_name: rebuild tests 18
-#      args: -s3 -u subtests="18"
+    test_r_18:
+      daos_test: r
+      test_name: rebuild tests 18
+      args: -s3 -u subtests="18"
     test_r_19:
       daos_test: r
       test_name: rebuild tests 19
@@ -109,11 +108,10 @@ daos_tests:
       daos_test: r
       test_name: rebuild tests 25
       args: -s3 -u subtests="25"
-#Skipped for DAOS-5852
-#    test_r_26:
-#      daos_test: r
-#      test_name: rebuild tests 26
-#      args: -s3 -u subtests="26"
+    test_r_26:
+      daos_test: r
+      test_name: rebuild tests 26
+      args: -s3 -u subtests="26"
     test_r_27:
       daos_test: r
       test_name: rebuild tests 27


### PR DESCRIPTION
1. Use target version as the rebuild version, instead of
pool map version, which might be updated when the node
status changes as well, because only the target status
changes needs to retrigger rebuild/reintegration.

2. let's abort the local target rebuild status ULT if it
return ENOTLEADER, otherwise it will become the orphan
ULT, which will block the pool destory.

Signed-off-by: Di Wang <di.wang@intel.com>