### PR TITLE
CART-89 fix: Remove sleep from tc_wait_for_ranks

### DIFF
--- a/src/tests/ftest/cart/tests_common.h
+++ b/src/tests/ftest/cart/tests_common.h
@@ -204,13 +204,6 @@ tc_wait_for_ranks(crt_context_t ctx, crt_group_t *grp, d_rank_list_t *rank_list,
 
 	D_ASSERTF(opts.is_initialized == true, "tc_test_init not called.\n");
 
-	/* This is needed until hg cancel is fully working.
-	 * RPCs in wait_for_ranks are expected to fail
-	 * and needs to be canceled correctly.
-	 * It should be removed when hg cancel is fixed - HG PR #284
-	 */
-	sleep(2);
-
 	rc = d_gettime(&t1);
 	D_ASSERTF(rc == 0, "d_gettime() failed; rc=%d\n", rc);
 


### PR DESCRIPTION
- Remove sleep(2) from tc_wait_for_ranks, which was originally added
as a workaround to 'stabilize' endpoints. This stabilization was
required before when early RPC pings were causing server to become
unresponsive later on.

Signed-off-by: Alexander Oganezov <alexander.a.oganezov@intel.com>