### PR TITLE
DAOS-5486 pool: check spc_ref correctly during purge

### DIFF
--- a/src/pool/srv_target.c
+++ b/src/pool/srv_target.c
@@ -99,10 +99,12 @@ ds_pool_child_purge(struct pool_tls *tls)
 	struct ds_pool_child   *n;
 
 	d_list_for_each_entry_safe(child, n, &tls->dt_pool_list, spc_list) {
-		D_ASSERTF(child->spc_ref == 1, DF_UUID": %d\n",
+		D_ASSERTF(child->spc_ref <= 2, DF_UUID": %d\n",
 			  DP_UUID(child->spc_uuid), child->spc_ref);
 		d_list_del_init(&child->spc_list);
 		ds_cont_child_stop_all(child);
+		D_ASSERTF(child->spc_ref == 1, DF_UUID": %d\n",
+			  DP_UUID(child->spc_uuid), child->spc_ref);
 		ds_pool_child_put(child);
 	}
 }


### PR DESCRIPTION
ds_pool_child refernce count should decrease to 1
until all container child are stopped.

Signed-off-by: Di Wang <di.wang@intel.com>