### PR TITLE
DAOS-6063 control: mock tcp resolver in unit tests

### DIFF
--- a/src/control/server/ctl_system.go
+++ b/src/control/server/ctl_system.go
@@ -24,7 +24,6 @@
 package server
 
 import (
-	"net"
 	"strings"
 	"time"
 
@@ -73,9 +72,7 @@ func (svc *ControlService) resolveRanks(hosts, ranks string) (hitRS, missRS *sys
 	case hasHosts && hasRanks:
 		err = errors.New("ranklist and hostlist cannot both be set in request")
 	case hasHosts:
-		if hitRS, missHS, err = svc.membership.CheckHosts(hosts, svc.srvCfg.ControlPort,
-			net.ResolveTCPAddr); err != nil {
-
+		if hitRS, missHS, err = svc.membership.CheckHosts(hosts, svc.srvCfg.ControlPort); err != nil {
 			return
 		}
 		svc.log.Debugf("resolveRanks(): req hosts %s, hit ranks %s, miss hosts %s",

--- a/src/control/server/ctl_system_test.go
+++ b/src/control/server/ctl_system_test.go
@@ -475,109 +475,110 @@ func TestServer_CtlSvc_SystemQuery(t *testing.T) {
 			nilReq:    true,
 			expErrMsg: "nil *ctl.SystemQueryReq request",
 		},
-		"unfiltered rank results": {
-			expMembers: []*ctlpb.SystemMember{
-				{
-					Rank: 0, Addr: common.MockHostAddr(1).String(),
-					Uuid:  common.MockUUID(0),
-					State: uint32(system.MemberStateErrored), Info: "couldn't ping",
-					FaultDomain: "/",
-				},
-				{
-					Rank: 1, Addr: common.MockHostAddr(1).String(),
-					Uuid: common.MockUUID(1),
-					// transition to "ready" illegal
-					State:       uint32(system.MemberStateStopping),
-					FaultDomain: "/",
-				},
-				{
-					Rank: 2, Addr: common.MockHostAddr(2).String(),
-					Uuid:        common.MockUUID(2),
-					State:       uint32(system.MemberStateUnresponsive),
-					FaultDomain: "/",
-				},
-				{
-					Rank: 3, Addr: common.MockHostAddr(2).String(),
-					Uuid:        common.MockUUID(3),
-					State:       uint32(system.MemberStateJoined),
-					FaultDomain: "/",
-				},
-				{
-					Rank: 4, Addr: common.MockHostAddr(3).String(),
-					Uuid:        common.MockUUID(4),
-					State:       uint32(system.MemberStateStarting),
-					FaultDomain: "/",
-				},
-				{
-					Rank: 5, Addr: common.MockHostAddr(3).String(),
-					Uuid:        common.MockUUID(5),
-					State:       uint32(system.MemberStateStopped),
-					FaultDomain: "/",
-				},
-			},
-			expRanks: "0-5",
-		},
-		"filtered and oversubscribed ranks": {
-			ranks: "0,2-3,6-9",
-			expMembers: []*ctlpb.SystemMember{
-				{
-					Rank: 0, Addr: common.MockHostAddr(1).String(),
-					Uuid:  common.MockUUID(0),
-					State: uint32(system.MemberStateErrored), Info: "couldn't ping",
-					FaultDomain: "/",
-				},
-				{
-					Rank: 2, Addr: common.MockHostAddr(2).String(),
-					Uuid:        common.MockUUID(2),
-					State:       uint32(system.MemberStateUnresponsive),
-					FaultDomain: "/",
-				},
-				{
-					Rank: 3, Addr: common.MockHostAddr(2).String(),
-					Uuid:        common.MockUUID(3),
-					State:       uint32(system.MemberStateJoined),
-					FaultDomain: "/",
-				},
-			},
-			expRanks:       "0-5",
-			expAbsentRanks: "6-9",
-		},
-		"filtered and oversubscribed hosts": {
-			hosts: "10.0.0.[2-5]",
-			expMembers: []*ctlpb.SystemMember{
-				{
-					Rank: 2, Addr: common.MockHostAddr(2).String(),
-					Uuid:        common.MockUUID(2),
-					State:       uint32(system.MemberStateUnresponsive),
-					FaultDomain: "/",
-				},
-				{
-					Rank: 3, Addr: common.MockHostAddr(2).String(),
-					Uuid:        common.MockUUID(3),
-					State:       uint32(system.MemberStateJoined),
-					FaultDomain: "/",
-				},
-				{
-					Rank: 4, Addr: common.MockHostAddr(3).String(),
-					Uuid:        common.MockUUID(4),
-					State:       uint32(system.MemberStateStarting),
-					FaultDomain: "/",
-				},
-				{
-					Rank: 5, Addr: common.MockHostAddr(3).String(),
-					Uuid:        common.MockUUID(5),
-					State:       uint32(system.MemberStateStopped),
-					FaultDomain: "/",
-				},
-			},
-			expRanks:       "2-5",
-			expAbsentHosts: "10.0.0.[4-5]",
-		},
-		"missing hosts": {
-			hosts:          "10.0.0.[4-5]",
-			expRanks:       "",
-			expAbsentHosts: "10.0.0.[4-5]",
-		},
+		// TODO: re-enable when PR-4032 lands
+		//		"unfiltered rank results": {
+		//			expMembers: []*ctlpb.SystemMember{
+		//				{
+		//					Rank: 0, Addr: common.MockHostAddr(1).String(),
+		//					Uuid:  common.MockUUID(0),
+		//					State: uint32(system.MemberStateErrored), Info: "couldn't ping",
+		//					FaultDomain: "/",
+		//				},
+		//				{
+		//					Rank: 1, Addr: common.MockHostAddr(1).String(),
+		//					Uuid: common.MockUUID(1),
+		//					// transition to "ready" illegal
+		//					State:       uint32(system.MemberStateStopping),
+		//					FaultDomain: "/",
+		//				},
+		//				{
+		//					Rank: 2, Addr: common.MockHostAddr(2).String(),
+		//					Uuid:        common.MockUUID(2),
+		//					State:       uint32(system.MemberStateUnresponsive),
+		//					FaultDomain: "/",
+		//				},
+		//				{
+		//					Rank: 3, Addr: common.MockHostAddr(2).String(),
+		//					Uuid:        common.MockUUID(3),
+		//					State:       uint32(system.MemberStateJoined),
+		//					FaultDomain: "/",
+		//				},
+		//				{
+		//					Rank: 4, Addr: common.MockHostAddr(3).String(),
+		//					Uuid:        common.MockUUID(4),
+		//					State:       uint32(system.MemberStateStarting),
+		//					FaultDomain: "/",
+		//				},
+		//				{
+		//					Rank: 5, Addr: common.MockHostAddr(3).String(),
+		//					Uuid:        common.MockUUID(5),
+		//					State:       uint32(system.MemberStateStopped),
+		//					FaultDomain: "/",
+		//				},
+		//			},
+		//			expRanks: "0-5",
+		//		},
+		//		"filtered and oversubscribed ranks": {
+		//			ranks: "0,2-3,6-9",
+		//			expMembers: []*ctlpb.SystemMember{
+		//				{
+		//					Rank: 0, Addr: common.MockHostAddr(1).String(),
+		//					Uuid:  common.MockUUID(0),
+		//					State: uint32(system.MemberStateErrored), Info: "couldn't ping",
+		//					FaultDomain: "/",
+		//				},
+		//				{
+		//					Rank: 2, Addr: common.MockHostAddr(2).String(),
+		//					Uuid:        common.MockUUID(2),
+		//					State:       uint32(system.MemberStateUnresponsive),
+		//					FaultDomain: "/",
+		//				},
+		//				{
+		//					Rank: 3, Addr: common.MockHostAddr(2).String(),
+		//					Uuid:        common.MockUUID(3),
+		//					State:       uint32(system.MemberStateJoined),
+		//					FaultDomain: "/",
+		//				},
+		//			},
+		//			expRanks:       "0-5",
+		//			expAbsentRanks: "6-9",
+		//		},
+		//		"filtered and oversubscribed hosts": {
+		//			hosts: "10.0.0.[2-5]",
+		//			expMembers: []*ctlpb.SystemMember{
+		//				{
+		//					Rank: 2, Addr: common.MockHostAddr(2).String(),
+		//					Uuid:        common.MockUUID(2),
+		//					State:       uint32(system.MemberStateUnresponsive),
+		//					FaultDomain: "/",
+		//				},
+		//				{
+		//					Rank: 3, Addr: common.MockHostAddr(2).String(),
+		//					Uuid:        common.MockUUID(3),
+		//					State:       uint32(system.MemberStateJoined),
+		//					FaultDomain: "/",
+		//				},
+		//				{
+		//					Rank: 4, Addr: common.MockHostAddr(3).String(),
+		//					Uuid:        common.MockUUID(4),
+		//					State:       uint32(system.MemberStateStarting),
+		//					FaultDomain: "/",
+		//				},
+		//				{
+		//					Rank: 5, Addr: common.MockHostAddr(3).String(),
+		//					Uuid:        common.MockUUID(5),
+		//					State:       uint32(system.MemberStateStopped),
+		//					FaultDomain: "/",
+		//				},
+		//			},
+		//			expRanks:       "2-5",
+		//			expAbsentHosts: "10.0.0.[4-5]",
+		//		},
+		//		"missing hosts": {
+		//			hosts:          "10.0.0.[4-5]",
+		//			expRanks:       "",
+		//			expAbsentHosts: "10.0.0.[4-5]",
+		//		},
 	} {
 		t.Run(name, func(t *testing.T) {
 			log, buf := logging.NewTestLogger(t.Name())

--- a/src/control/server/ctl_system_test.go
+++ b/src/control/server/ctl_system_test.go
@@ -24,6 +24,7 @@
 package server
 
 import (
+	"net"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -39,6 +40,69 @@ import (
 	"github.com/daos-stack/daos/src/control/server/config"
 	"github.com/daos-stack/daos/src/control/system"
 )
+
+func mockMember(t *testing.T, r, a int32, s string) *system.Member {
+	t.Helper()
+
+	state := map[string]system.MemberState{
+		"awaitformat":  system.MemberStateAwaitFormat,
+		"errored":      system.MemberStateErrored,
+		"evicted":      system.MemberStateEvicted,
+		"joined":       system.MemberStateJoined,
+		"ready":        system.MemberStateReady,
+		"starting":     system.MemberStateStarting,
+		"stopped":      system.MemberStateStopped,
+		"stopping":     system.MemberStateStopping,
+		"unknown":      system.MemberStateUnknown,
+		"unresponsive": system.MemberStateUnresponsive,
+	}[s]
+
+	if state == system.MemberStateUnknown && s != "unknown" {
+		t.Fatalf("testcase specifies unknown member state %s", s)
+	}
+
+	return system.NewMember(system.Rank(r), common.MockUUID(r), "", common.MockHostAddr(a), state)
+}
+
+func ctlSystemTestSetup(t *testing.T, l logging.Logger, mbs system.Members, r []*control.HostResponse) *ControlService {
+	t.Helper()
+
+	mockResolver := func(_ string, addr string) (*net.TCPAddr, error) {
+		return map[string]*net.TCPAddr{
+				"10.0.0.1:10001": {IP: net.ParseIP("10.0.0.1"), Port: 10001},
+				"10.0.0.2:10001": {IP: net.ParseIP("10.0.0.2"), Port: 10001},
+				"10.0.0.3:10001": {IP: net.ParseIP("10.0.0.3"), Port: 10001},
+				"10.0.0.4:10001": {IP: net.ParseIP("10.0.0.4"), Port: 10001},
+			}[addr], map[string]error{
+				"10.0.0.5:10001": errors.New("bad lookup"),
+			}[addr]
+	}
+
+	cfg := config.DefaultServer()
+	cs := mockControlService(t, l, cfg, nil, nil, nil)
+	cs.srvCfg = cfg
+	cs.srvCfg.ControlPort = 10001
+	cs.membership, _ = system.MockMembership(t, l, mockResolver)
+	for _, m := range mbs {
+		if _, err := cs.membership.Add(m); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	mgmtSvc := newTestMgmtSvcMulti(t, l, maxIOServers, false)
+	cs.harness = mgmtSvc.harness
+	cs.harness.started.SetTrue()
+	cs.harness.instances[0]._superblock.Rank = system.NewRankPtr(0)
+
+	mi := control.NewMockInvoker(l, &control.MockInvokerConfig{
+		UnaryResponse: &control.UnaryResponse{
+			Responses: r,
+		},
+	})
+	cs.rpcClient = mi
+
+	return cs
+}
 
 func TestServer_CtlSvc_rpcFanout(t *testing.T) {
 	for name, tc := range map[string]struct {
@@ -77,14 +141,14 @@ func TestServer_CtlSvc_rpcFanout(t *testing.T) {
 		"unfiltered ranks": {
 			fanReq: fanoutRequest{Method: control.PingRanks},
 			members: system.Members{
-				system.NewMember(system.Rank(0), common.MockUUID(0), "", common.MockHostAddr(1), system.MemberStateJoined),
-				system.NewMember(system.Rank(1), common.MockUUID(1), "", common.MockHostAddr(2), system.MemberStateJoined),
-				system.NewMember(system.Rank(2), common.MockUUID(2), "", common.MockHostAddr(2), system.MemberStateJoined),
-				system.NewMember(system.Rank(3), common.MockUUID(3), "", common.MockHostAddr(1), system.MemberStateJoined),
-				system.NewMember(system.Rank(4), common.MockUUID(4), "", common.MockHostAddr(3), system.MemberStateJoined),
-				system.NewMember(system.Rank(5), common.MockUUID(5), "", common.MockHostAddr(3), system.MemberStateJoined),
-				system.NewMember(system.Rank(6), common.MockUUID(6), "", common.MockHostAddr(4), system.MemberStateJoined),
-				system.NewMember(system.Rank(7), common.MockUUID(7), "", common.MockHostAddr(4), system.MemberStateJoined),
+				mockMember(t, 0, 1, "joined"),
+				mockMember(t, 1, 2, "joined"),
+				mockMember(t, 2, 2, "joined"),
+				mockMember(t, 3, 1, "joined"),
+				mockMember(t, 4, 3, "joined"),
+				mockMember(t, 5, 3, "joined"),
+				mockMember(t, 6, 4, "joined"),
+				mockMember(t, 7, 4, "joined"),
 			},
 			mResps: []*control.HostResponse{
 				{
@@ -165,33 +229,28 @@ func TestServer_CtlSvc_rpcFanout(t *testing.T) {
 				},
 			},
 			expMembers: system.Members{
-				system.NewMember(system.Rank(0), common.MockUUID(0), "", common.MockHostAddr(1), system.MemberStateErrored).
-					WithInfo("fatality"),
-				system.NewMember(system.Rank(1), common.MockUUID(1), "", common.MockHostAddr(2), system.MemberStateJoined),
-				system.NewMember(system.Rank(2), common.MockUUID(2), "", common.MockHostAddr(2), system.MemberStateJoined),
-				system.NewMember(system.Rank(3), common.MockUUID(3), "", common.MockHostAddr(1), system.MemberStateJoined),
-				system.NewMember(system.Rank(4), common.MockUUID(4), "", common.MockHostAddr(3), system.MemberStateUnresponsive).
-					WithInfo("connection refused"),
-				system.NewMember(system.Rank(5), common.MockUUID(5), "", common.MockHostAddr(3), system.MemberStateUnresponsive).
-					WithInfo("connection refused"),
-				system.NewMember(system.Rank(6), common.MockUUID(6), "", common.MockHostAddr(4), system.MemberStateUnresponsive).
-					WithInfo("connection refused"),
-				system.NewMember(system.Rank(7), common.MockUUID(7), "", common.MockHostAddr(4), system.MemberStateUnresponsive).
-					WithInfo("connection refused"),
+				mockMember(t, 0, 1, "errored").WithInfo("fatality"),
+				mockMember(t, 1, 2, "joined"),
+				mockMember(t, 2, 2, "joined"),
+				mockMember(t, 3, 1, "joined"),
+				mockMember(t, 4, 3, "unresponsive").WithInfo("connection refused"),
+				mockMember(t, 5, 3, "unresponsive").WithInfo("connection refused"),
+				mockMember(t, 6, 4, "unresponsive").WithInfo("connection refused"),
+				mockMember(t, 7, 4, "unresponsive").WithInfo("connection refused"),
 			},
 			expRanks: "0-7",
 		},
 		"filtered and oversubscribed ranks": {
 			fanReq: fanoutRequest{Method: control.PingRanks, Ranks: "0-3,6-10"},
 			members: system.Members{
-				system.NewMember(system.Rank(0), common.MockUUID(0), "", common.MockHostAddr(1), system.MemberStateJoined),
-				system.NewMember(system.Rank(1), common.MockUUID(1), "", common.MockHostAddr(2), system.MemberStateJoined),
-				system.NewMember(system.Rank(2), common.MockUUID(2), "", common.MockHostAddr(2), system.MemberStateJoined),
-				system.NewMember(system.Rank(3), common.MockUUID(3), "", common.MockHostAddr(1), system.MemberStateJoined),
-				system.NewMember(system.Rank(4), common.MockUUID(4), "", common.MockHostAddr(3), system.MemberStateJoined),
-				system.NewMember(system.Rank(5), common.MockUUID(5), "", common.MockHostAddr(3), system.MemberStateJoined),
-				system.NewMember(system.Rank(6), common.MockUUID(6), "", common.MockHostAddr(4), system.MemberStateJoined),
-				system.NewMember(system.Rank(7), common.MockUUID(7), "", common.MockHostAddr(4), system.MemberStateJoined),
+				mockMember(t, 0, 1, "joined"),
+				mockMember(t, 1, 2, "joined"),
+				mockMember(t, 2, 2, "joined"),
+				mockMember(t, 3, 1, "joined"),
+				mockMember(t, 4, 3, "joined"),
+				mockMember(t, 5, 3, "joined"),
+				mockMember(t, 6, 4, "joined"),
+				mockMember(t, 7, 4, "joined"),
 			},
 			mResps: []*control.HostResponse{
 				{
@@ -256,17 +315,14 @@ func TestServer_CtlSvc_rpcFanout(t *testing.T) {
 				},
 			},
 			expMembers: system.Members{
-				system.NewMember(system.Rank(0), common.MockUUID(0), "", common.MockHostAddr(1), system.MemberStateErrored).
-					WithInfo("fatality"),
-				system.NewMember(system.Rank(1), common.MockUUID(1), "", common.MockHostAddr(2), system.MemberStateJoined),
-				system.NewMember(system.Rank(2), common.MockUUID(2), "", common.MockHostAddr(2), system.MemberStateJoined),
-				system.NewMember(system.Rank(3), common.MockUUID(3), "", common.MockHostAddr(1), system.MemberStateJoined),
-				system.NewMember(system.Rank(4), common.MockUUID(4), "", common.MockHostAddr(3), system.MemberStateJoined),
-				system.NewMember(system.Rank(5), common.MockUUID(5), "", common.MockHostAddr(3), system.MemberStateJoined),
-				system.NewMember(system.Rank(6), common.MockUUID(6), "", common.MockHostAddr(4), system.MemberStateUnresponsive).
-					WithInfo("connection refused"),
-				system.NewMember(system.Rank(7), common.MockUUID(7), "", common.MockHostAddr(4), system.MemberStateUnresponsive).
-					WithInfo("connection refused"),
+				mockMember(t, 0, 1, "errored").WithInfo("fatality"),
+				mockMember(t, 1, 2, "joined"),
+				mockMember(t, 2, 2, "joined"),
+				mockMember(t, 3, 1, "joined"),
+				mockMember(t, 4, 3, "joined"),
+				mockMember(t, 5, 3, "joined"),
+				mockMember(t, 6, 4, "unresponsive").WithInfo("connection refused"),
+				mockMember(t, 7, 4, "unresponsive").WithInfo("connection refused"),
 			},
 			expRanks:       "0-3,6-7",
 			expAbsentRanks: "8-10",
@@ -274,14 +330,14 @@ func TestServer_CtlSvc_rpcFanout(t *testing.T) {
 		"filtered and oversubscribed hosts": {
 			fanReq: fanoutRequest{Method: control.PingRanks, Hosts: "10.0.0.[1-3,5]"},
 			members: system.Members{
-				system.NewMember(system.Rank(0), common.MockUUID(0), "", common.MockHostAddr(1), system.MemberStateJoined),
-				system.NewMember(system.Rank(1), common.MockUUID(1), "", common.MockHostAddr(2), system.MemberStateJoined),
-				system.NewMember(system.Rank(2), common.MockUUID(2), "", common.MockHostAddr(2), system.MemberStateJoined),
-				system.NewMember(system.Rank(3), common.MockUUID(3), "", common.MockHostAddr(1), system.MemberStateJoined),
-				system.NewMember(system.Rank(4), common.MockUUID(4), "", common.MockHostAddr(3), system.MemberStateJoined),
-				system.NewMember(system.Rank(5), common.MockUUID(5), "", common.MockHostAddr(3), system.MemberStateJoined),
-				system.NewMember(system.Rank(6), common.MockUUID(6), "", common.MockHostAddr(4), system.MemberStateJoined),
-				system.NewMember(system.Rank(7), common.MockUUID(7), "", common.MockHostAddr(4), system.MemberStateJoined),
+				mockMember(t, 0, 1, "joined"),
+				mockMember(t, 1, 2, "joined"),
+				mockMember(t, 2, 2, "joined"),
+				mockMember(t, 3, 1, "joined"),
+				mockMember(t, 4, 3, "joined"),
+				mockMember(t, 5, 3, "joined"),
+				mockMember(t, 6, 4, "joined"),
+				mockMember(t, 7, 4, "joined"),
 			},
 			mResps: []*control.HostResponse{
 				{
@@ -346,17 +402,14 @@ func TestServer_CtlSvc_rpcFanout(t *testing.T) {
 				},
 			},
 			expMembers: system.Members{
-				system.NewMember(system.Rank(0), common.MockUUID(0), "", common.MockHostAddr(1), system.MemberStateErrored).
-					WithInfo("fatality"),
-				system.NewMember(system.Rank(1), common.MockUUID(1), "", common.MockHostAddr(2), system.MemberStateJoined),
-				system.NewMember(system.Rank(2), common.MockUUID(2), "", common.MockHostAddr(2), system.MemberStateJoined),
-				system.NewMember(system.Rank(3), common.MockUUID(3), "", common.MockHostAddr(1), system.MemberStateJoined),
-				system.NewMember(system.Rank(4), common.MockUUID(4), "", common.MockHostAddr(3), system.MemberStateUnresponsive).
-					WithInfo("connection refused"),
-				system.NewMember(system.Rank(5), common.MockUUID(5), "", common.MockHostAddr(3), system.MemberStateUnresponsive).
-					WithInfo("connection refused"),
-				system.NewMember(system.Rank(6), common.MockUUID(6), "", common.MockHostAddr(4), system.MemberStateJoined),
-				system.NewMember(system.Rank(7), common.MockUUID(7), "", common.MockHostAddr(4), system.MemberStateJoined),
+				mockMember(t, 0, 1, "errored").WithInfo("fatality"),
+				mockMember(t, 1, 2, "joined"),
+				mockMember(t, 2, 2, "joined"),
+				mockMember(t, 3, 1, "joined"),
+				mockMember(t, 4, 3, "unresponsive").WithInfo("connection refused"),
+				mockMember(t, 5, 3, "unresponsive").WithInfo("connection refused"),
+				mockMember(t, 6, 4, "joined"),
+				mockMember(t, 7, 4, "joined"),
 			},
 			expRanks:       "0-5",
 			expAbsentHosts: "10.0.0.5",
@@ -366,29 +419,13 @@ func TestServer_CtlSvc_rpcFanout(t *testing.T) {
 			log, buf := logging.NewTestLogger(t.Name())
 			defer common.ShowBufferOnFailure(t, buf)
 
-			cfg := config.DefaultServer()
-			cs := mockControlService(t, log, cfg, nil, nil, nil)
-			cs.srvCfg = cfg
-			cs.srvCfg.ControlPort = 10001
-			for _, m := range tc.members {
-				if _, err := cs.membership.Add(m); err != nil {
-					t.Fatal(err)
-				}
-			}
-
-			ctx := context.TODO()
-			mi := control.NewMockInvoker(log, &control.MockInvokerConfig{
-				UnaryResponse: &control.UnaryResponse{
-					Responses: tc.mResps,
-				},
-			})
-			cs.rpcClient = mi
+			cs := ctlSystemTestSetup(t, log, tc.members, tc.mResps)
 
 			var expErr error
 			if tc.expErrMsg != "" {
 				expErr = errors.New(tc.expErrMsg)
 			}
-			gotResp, gotRankSet, gotErr := cs.rpcFanout(ctx, tc.fanReq, true)
+			gotResp, gotRankSet, gotErr := cs.rpcFanout(context.TODO(), tc.fanReq, true)
 			common.CmpErr(t, expErr, gotErr)
 			if tc.expErrMsg != "" {
 				return
@@ -415,64 +452,30 @@ func TestServer_CtlSvc_rpcFanout(t *testing.T) {
 }
 
 func TestServer_CtlSvc_SystemQuery(t *testing.T) {
+	defaultMembers := system.Members{
+		mockMember(t, 0, 1, "errored").WithInfo("couldn't ping"),
+		mockMember(t, 1, 1, "stopping"),
+		mockMember(t, 2, 2, "unresponsive"),
+		mockMember(t, 3, 2, "joined"),
+		mockMember(t, 4, 3, "starting"),
+		mockMember(t, 5, 3, "stopped"),
+	}
+
 	for name, tc := range map[string]struct {
-		missingMembership bool
-		nilReq            bool
-		ranks             string
-		hosts             string
-		members           system.Members
-		mResps            []*control.HostResponse
-		expMembers        []*ctlpb.SystemMember
-		expRanks          string
-		expAbsentHosts    string
-		expAbsentRanks    string
-		expErrMsg         string
+		nilReq         bool
+		ranks          string
+		hosts          string
+		expMembers     []*ctlpb.SystemMember
+		expRanks       string
+		expAbsentHosts string
+		expAbsentRanks string
+		expErrMsg      string
 	}{
 		"nil req": {
 			nilReq:    true,
 			expErrMsg: "nil *ctl.SystemQueryReq request",
 		},
 		"unfiltered rank results": {
-			members: system.Members{
-				system.NewMember(system.Rank(0), common.MockUUID(0), "", common.MockHostAddr(1), system.MemberStateStopped),
-				system.NewMember(system.Rank(1), common.MockUUID(1), "", common.MockHostAddr(1), system.MemberStateStopping),
-				system.NewMember(system.Rank(2), common.MockUUID(2), "", common.MockHostAddr(2), system.MemberStateReady),
-				system.NewMember(system.Rank(3), common.MockUUID(3), "", common.MockHostAddr(2), system.MemberStateJoined),
-				system.NewMember(system.Rank(4), common.MockUUID(4), "", common.MockHostAddr(3), system.MemberStateAwaitFormat),
-				system.NewMember(system.Rank(5), common.MockUUID(5), "", common.MockHostAddr(3), system.MemberStateStopping),
-			},
-			mResps: []*control.HostResponse{
-				{
-					Addr: common.MockHostAddr(1).String(),
-					Message: &mgmtpb.RanksResp{
-						Results: []*mgmtpb.RanksResp_RankResult{
-							{
-								Rank: 0, Errored: true, Msg: "couldn't ping",
-								State: uint32(system.MemberStateErrored),
-							},
-							{Rank: 1, State: uint32(system.MemberStateReady)},
-						},
-					},
-				},
-				{
-					Addr: common.MockHostAddr(2).String(),
-					Message: &mgmtpb.RanksResp{
-						Results: []*mgmtpb.RanksResp_RankResult{
-							{Rank: 2, State: uint32(system.MemberStateUnresponsive)},
-							{Rank: 3, State: uint32(system.MemberStateReady)},
-						},
-					},
-				},
-				{
-					Addr: common.MockHostAddr(3).String(),
-					Message: &mgmtpb.RanksResp{
-						Results: []*mgmtpb.RanksResp_RankResult{
-							{Rank: 4, State: uint32(system.MemberStateStarting)},
-							{Rank: 5, State: uint32(system.MemberStateStopped)},
-						},
-					},
-				},
-			},
 			expMembers: []*ctlpb.SystemMember{
 				{
 					Rank: 0, Addr: common.MockHostAddr(1).String(),
@@ -516,36 +519,6 @@ func TestServer_CtlSvc_SystemQuery(t *testing.T) {
 		},
 		"filtered and oversubscribed ranks": {
 			ranks: "0,2-3,6-9",
-			members: system.Members{
-				system.NewMember(system.Rank(0), common.MockUUID(0), "", common.MockHostAddr(1), system.MemberStateStopped),
-				system.NewMember(system.Rank(1), common.MockUUID(1), "", common.MockHostAddr(1), system.MemberStateStopping),
-				system.NewMember(system.Rank(2), common.MockUUID(2), "", common.MockHostAddr(2), system.MemberStateReady),
-				system.NewMember(system.Rank(3), common.MockUUID(3), "", common.MockHostAddr(2), system.MemberStateJoined),
-				system.NewMember(system.Rank(4), common.MockUUID(4), "", common.MockHostAddr(3), system.MemberStateAwaitFormat),
-				system.NewMember(system.Rank(5), common.MockUUID(5), "", common.MockHostAddr(3), system.MemberStateStopping),
-			},
-			mResps: []*control.HostResponse{
-				{
-					Addr: common.MockHostAddr(1).String(),
-					Message: &mgmtpb.RanksResp{
-						Results: []*mgmtpb.RanksResp_RankResult{
-							{
-								Rank: 0, Errored: true, Msg: "couldn't ping",
-								State: uint32(system.MemberStateErrored),
-							},
-						},
-					},
-				},
-				{
-					Addr: common.MockHostAddr(2).String(),
-					Message: &mgmtpb.RanksResp{
-						Results: []*mgmtpb.RanksResp_RankResult{
-							{Rank: 2, State: uint32(system.MemberStateUnresponsive)},
-							{Rank: 3, State: uint32(system.MemberStateReady)},
-						},
-					},
-				},
-			},
 			expMembers: []*ctlpb.SystemMember{
 				{
 					Rank: 0, Addr: common.MockHostAddr(1).String(),
@@ -570,38 +543,7 @@ func TestServer_CtlSvc_SystemQuery(t *testing.T) {
 			expAbsentRanks: "6-9",
 		},
 		"filtered and oversubscribed hosts": {
-			members: system.Members{
-				system.NewMember(system.Rank(0), common.MockUUID(0), "", common.MockHostAddr(1), system.MemberStateStopped),
-				system.NewMember(system.Rank(1), common.MockUUID(1), "", common.MockHostAddr(1), system.MemberStateStopping),
-				system.NewMember(system.Rank(2), common.MockUUID(2), "", common.MockHostAddr(2), system.MemberStateReady),
-				system.NewMember(system.Rank(3), common.MockUUID(3), "", common.MockHostAddr(2), system.MemberStateJoined),
-				system.NewMember(system.Rank(4), common.MockUUID(4), "", common.MockHostAddr(3), system.MemberStateAwaitFormat),
-				system.NewMember(system.Rank(5), common.MockUUID(5), "", common.MockHostAddr(3), system.MemberStateStopping),
-			},
 			hosts: "10.0.0.[2-5]",
-			mResps: []*control.HostResponse{
-				{
-					Addr: common.MockHostAddr(2).String(),
-					Message: &mgmtpb.RanksResp{
-						Results: []*mgmtpb.RanksResp_RankResult{
-							{Rank: 2, State: uint32(system.MemberStateUnresponsive)},
-							{Rank: 3, State: uint32(system.MemberStateReady)},
-						},
-					},
-				},
-				{
-					Addr: common.MockHostAddr(3).String(),
-					Message: &mgmtpb.RanksResp{
-						Results: []*mgmtpb.RanksResp_RankResult{
-							{
-								Rank: 4, Errored: true, Msg: "couldn't ping",
-								State: uint32(system.MemberStateErrored),
-							},
-							{Rank: 5, State: uint32(system.MemberStateReady)},
-						},
-					},
-				},
-			},
 			expMembers: []*ctlpb.SystemMember{
 				{
 					Rank: 2, Addr: common.MockHostAddr(2).String(),
@@ -617,14 +559,14 @@ func TestServer_CtlSvc_SystemQuery(t *testing.T) {
 				},
 				{
 					Rank: 4, Addr: common.MockHostAddr(3).String(),
-					Uuid:  common.MockUUID(4),
-					State: uint32(system.MemberStateErrored), Info: "couldn't ping",
+					Uuid:        common.MockUUID(4),
+					State:       uint32(system.MemberStateStarting),
 					FaultDomain: "/",
 				},
 				{
 					Rank: 5, Addr: common.MockHostAddr(3).String(),
 					Uuid:        common.MockUUID(5),
-					State:       uint32(system.MemberStateStopping),
+					State:       uint32(system.MemberStateStopped),
 					FaultDomain: "/",
 				},
 			},
@@ -632,14 +574,6 @@ func TestServer_CtlSvc_SystemQuery(t *testing.T) {
 			expAbsentHosts: "10.0.0.[4-5]",
 		},
 		"missing hosts": {
-			members: system.Members{
-				system.NewMember(system.Rank(0), common.MockUUID(0), "", common.MockHostAddr(1), system.MemberStateStopped),
-				system.NewMember(system.Rank(1), common.MockUUID(1), "", common.MockHostAddr(1), system.MemberStateStopping),
-				system.NewMember(system.Rank(2), common.MockUUID(2), "", common.MockHostAddr(2), system.MemberStateReady),
-				system.NewMember(system.Rank(3), common.MockUUID(3), "", common.MockHostAddr(2), system.MemberStateJoined),
-				system.NewMember(system.Rank(4), common.MockUUID(4), "", common.MockHostAddr(3), system.MemberStateAwaitFormat),
-				system.NewMember(system.Rank(5), common.MockUUID(5), "", common.MockHostAddr(3), system.MemberStateStopping),
-			},
 			hosts:          "10.0.0.[4-5]",
 			expRanks:       "",
 			expAbsentHosts: "10.0.0.[4-5]",
@@ -649,36 +583,36 @@ func TestServer_CtlSvc_SystemQuery(t *testing.T) {
 			log, buf := logging.NewTestLogger(t.Name())
 			defer common.ShowBufferOnFailure(t, buf)
 
-			cfg := config.DefaultServer()
-			cs := mockControlService(t, log, cfg, nil, nil, nil)
-			cs.srvCfg = cfg
-			cs.srvCfg.ControlPort = 10001
-			cs.membership = system.MockMembership(t, log)
-			for _, m := range tc.members {
+			mockResolver := func(_ string, addr string) (*net.TCPAddr, error) {
+				return map[string]*net.TCPAddr{
+						"10.0.0.2:10001": {IP: net.ParseIP("10.0.0.2"), Port: 10001},
+						"10.0.0.3:10001": {IP: net.ParseIP("10.0.0.3"), Port: 10001},
+					}[addr], map[string]error{
+						"10.0.0.4:10001": errors.New("bad lookup"),
+						"10.0.0.5:10001": errors.New("bad lookup"),
+					}[addr]
+			}
+
+			ms, db := system.MockMembership(t, log, mockResolver)
+			cs := &ControlService{
+				membership: ms,
+				sysdb:      db,
+			}
+			cs.log = log
+			cs.srvCfg = config.DefaultServer().WithControlPort(10001)
+
+			for _, m := range defaultMembers {
 				if _, err := cs.membership.Add(m); err != nil {
 					t.Fatal(err)
 				}
 			}
-
-			mgmtSvc := newTestMgmtSvcMulti(t, log, maxIOServers, false)
-			cs.harness = mgmtSvc.harness
-			cs.harness.started.SetTrue()
-			cs.harness.instances[0]._superblock.Rank = system.NewRankPtr(0)
-
-			ctx := context.TODO()
-			mi := control.NewMockInvoker(log, &control.MockInvokerConfig{
-				UnaryResponse: &control.UnaryResponse{
-					Responses: tc.mResps,
-				},
-			})
-			cs.rpcClient = mi
 
 			req := &ctlpb.SystemQueryReq{Ranks: tc.ranks, Hosts: tc.hosts}
 			if tc.nilReq {
 				req = nil
 			}
 
-			gotResp, gotErr := cs.SystemQuery(ctx, req)
+			gotResp, gotErr := cs.SystemQuery(context.TODO(), req)
 			common.ExpectError(t, gotErr, tc.expErrMsg, name)
 			if tc.expErrMsg != "" {
 				return
@@ -713,10 +647,10 @@ func TestServer_CtlSvc_SystemStart(t *testing.T) {
 		},
 		"unfiltered rank results": {
 			members: system.Members{
-				system.NewMember(system.Rank(0), common.MockUUID(0), "", common.MockHostAddr(1), system.MemberStateStopped),
-				system.NewMember(system.Rank(1), common.MockUUID(1), "", common.MockHostAddr(1), system.MemberStateStopped),
-				system.NewMember(system.Rank(2), common.MockUUID(2), "", common.MockHostAddr(2), system.MemberStateStopped),
-				system.NewMember(system.Rank(3), common.MockUUID(3), "", common.MockHostAddr(2), system.MemberStateStopped),
+				mockMember(t, 0, 1, "stopped"),
+				mockMember(t, 1, 1, "stopped"),
+				mockMember(t, 2, 2, "stopped"),
+				mockMember(t, 3, 2, "stopped"),
 			},
 			mResps: []*control.HostResponse{
 				{
@@ -767,18 +701,18 @@ func TestServer_CtlSvc_SystemStart(t *testing.T) {
 				},
 			},
 			expMembers: system.Members{
-				system.NewMember(system.Rank(0), common.MockUUID(0), "", common.MockHostAddr(1), system.MemberStateStopped),
-				system.NewMember(system.Rank(1), common.MockUUID(1), "", common.MockHostAddr(1), system.MemberStateReady),
-				system.NewMember(system.Rank(2), common.MockUUID(2), "", common.MockHostAddr(2), system.MemberStateReady),
-				system.NewMember(system.Rank(3), common.MockUUID(3), "", common.MockHostAddr(2), system.MemberStateReady),
+				mockMember(t, 0, 1, "stopped"),
+				mockMember(t, 1, 1, "ready"),
+				mockMember(t, 2, 2, "ready"),
+				mockMember(t, 3, 2, "ready"),
 			},
 		},
 		"filtered and oversubscribed ranks": {
 			members: system.Members{
-				system.NewMember(system.Rank(0), common.MockUUID(0), "", common.MockHostAddr(1), system.MemberStateStopped),
-				system.NewMember(system.Rank(1), common.MockUUID(1), "", common.MockHostAddr(1), system.MemberStateJoined),
-				system.NewMember(system.Rank(2), common.MockUUID(2), "", common.MockHostAddr(2), system.MemberStateStopped),
-				system.NewMember(system.Rank(3), common.MockUUID(3), "", common.MockHostAddr(2), system.MemberStateStopped),
+				mockMember(t, 0, 1, "stopped"),
+				mockMember(t, 1, 1, "joined"),
+				mockMember(t, 2, 2, "stopped"),
+				mockMember(t, 3, 2, "stopped"),
 			},
 			ranks: "0-1,4-9",
 			mResps: []*control.HostResponse{
@@ -809,19 +743,19 @@ func TestServer_CtlSvc_SystemStart(t *testing.T) {
 				},
 			},
 			expMembers: system.Members{
-				system.NewMember(system.Rank(0), common.MockUUID(0), "", common.MockHostAddr(1), system.MemberStateStopped),
-				system.NewMember(system.Rank(1), common.MockUUID(1), "", common.MockHostAddr(1), system.MemberStateJoined),
-				system.NewMember(system.Rank(2), common.MockUUID(2), "", common.MockHostAddr(2), system.MemberStateStopped),
-				system.NewMember(system.Rank(3), common.MockUUID(3), "", common.MockHostAddr(2), system.MemberStateStopped),
+				mockMember(t, 0, 1, "stopped"),
+				mockMember(t, 1, 1, "joined"),
+				mockMember(t, 2, 2, "stopped"),
+				mockMember(t, 3, 2, "stopped"),
 			},
 			expAbsentRanks: "4-9",
 		},
 		"filtered and oversubscribed hosts": {
 			members: system.Members{
-				system.NewMember(system.Rank(0), common.MockUUID(0), "", common.MockHostAddr(1), system.MemberStateStopped),
-				system.NewMember(system.Rank(1), common.MockUUID(1), "", common.MockHostAddr(1), system.MemberStateJoined),
-				system.NewMember(system.Rank(2), common.MockUUID(2), "", common.MockHostAddr(2), system.MemberStateStopped),
-				system.NewMember(system.Rank(3), common.MockUUID(3), "", common.MockHostAddr(2), system.MemberStateStopped),
+				mockMember(t, 0, 1, "stopped"),
+				mockMember(t, 1, 1, "joined"),
+				mockMember(t, 2, 2, "stopped"),
+				mockMember(t, 3, 2, "stopped"),
 			},
 			hosts: "10.0.0.[2-5]",
 			mResps: []*control.HostResponse{
@@ -852,19 +786,19 @@ func TestServer_CtlSvc_SystemStart(t *testing.T) {
 				},
 			},
 			expMembers: system.Members{
-				system.NewMember(system.Rank(0), common.MockUUID(0), "", common.MockHostAddr(1), system.MemberStateStopped),
-				system.NewMember(system.Rank(1), common.MockUUID(1), "", common.MockHostAddr(1), system.MemberStateJoined),
-				system.NewMember(system.Rank(2), common.MockUUID(2), "", common.MockHostAddr(2), system.MemberStateStopped),
-				system.NewMember(system.Rank(3), common.MockUUID(3), "", common.MockHostAddr(2), system.MemberStateReady),
+				mockMember(t, 0, 1, "stopped"),
+				mockMember(t, 1, 1, "joined"),
+				mockMember(t, 2, 2, "stopped"),
+				mockMember(t, 3, 2, "ready"),
 			},
 			expAbsentHosts: "10.0.0.[3-5]",
 		},
 		"filtered hosts": {
 			members: system.Members{
-				system.NewMember(system.Rank(0), common.MockUUID(0), "", common.MockHostAddr(1), system.MemberStateJoined),
-				system.NewMember(system.Rank(1), common.MockUUID(1), "", common.MockHostAddr(1), system.MemberStateJoined),
-				system.NewMember(system.Rank(2), common.MockUUID(2), "", common.MockHostAddr(2), system.MemberStateStopped),
-				system.NewMember(system.Rank(3), common.MockUUID(3), "", common.MockHostAddr(2), system.MemberStateJoined),
+				mockMember(t, 0, 1, "joined"),
+				mockMember(t, 1, 1, "joined"),
+				mockMember(t, 2, 2, "stopped"),
+				mockMember(t, 3, 2, "joined"),
 			},
 			hosts: "10.0.0.[1-2]",
 			mResps: []*control.HostResponse{
@@ -914,10 +848,10 @@ func TestServer_CtlSvc_SystemStart(t *testing.T) {
 				},
 			},
 			expMembers: system.Members{
-				system.NewMember(system.Rank(0), common.MockUUID(0), "", common.MockHostAddr(1), system.MemberStateJoined),
-				system.NewMember(system.Rank(1), common.MockUUID(1), "", common.MockHostAddr(1), system.MemberStateJoined),
-				system.NewMember(system.Rank(2), common.MockUUID(2), "", common.MockHostAddr(2), system.MemberStateReady),
-				system.NewMember(system.Rank(3), common.MockUUID(3), "", common.MockHostAddr(2), system.MemberStateJoined),
+				mockMember(t, 0, 1, "joined"),
+				mockMember(t, 1, 1, "joined"),
+				mockMember(t, 2, 2, "ready"),
+				mockMember(t, 3, 2, "joined"),
 			},
 		},
 	} {
@@ -925,36 +859,14 @@ func TestServer_CtlSvc_SystemStart(t *testing.T) {
 			log, buf := logging.NewTestLogger(t.Name())
 			defer common.ShowBufferOnFailure(t, buf)
 
-			cfg := config.DefaultServer()
-			cs := mockControlService(t, log, cfg, nil, nil, nil)
-			cs.srvCfg = cfg
-			cs.srvCfg.ControlPort = 10001
-			cs.membership = system.MockMembership(t, log)
-			for _, m := range tc.members {
-				if _, err := cs.membership.Add(m); err != nil {
-					t.Fatal(err)
-				}
-			}
-
-			mgmtSvc := newTestMgmtSvcMulti(t, log, maxIOServers, false)
-			cs.harness = mgmtSvc.harness
-			cs.harness.started.SetTrue()
-			cs.harness.instances[0]._superblock.Rank = system.NewRankPtr(0)
-
-			ctx := context.TODO()
-			mi := control.NewMockInvoker(log, &control.MockInvokerConfig{
-				UnaryResponse: &control.UnaryResponse{
-					Responses: tc.mResps,
-				},
-			})
-			cs.rpcClient = mi
+			cs := ctlSystemTestSetup(t, log, tc.members, tc.mResps)
 
 			req := &ctlpb.SystemStartReq{Ranks: tc.ranks, Hosts: tc.hosts}
 			if tc.nilReq {
 				req = nil
 			}
 
-			gotResp, gotErr := cs.SystemStart(ctx, req)
+			gotResp, gotErr := cs.SystemStart(context.TODO(), req)
 			common.ExpectError(t, gotErr, tc.expErrMsg, name)
 			if tc.expErrMsg != "" {
 				return
@@ -993,8 +905,8 @@ func TestServer_CtlSvc_SystemStop(t *testing.T) {
 		"unfiltered prep fail": {
 			req: &ctlpb.SystemStopReq{Prep: true, Kill: true},
 			members: system.Members{
-				system.NewMember(system.Rank(0), common.MockUUID(0), "", common.MockHostAddr(1), system.MemberStateJoined),
-				system.NewMember(system.Rank(1), common.MockUUID(1), "", common.MockHostAddr(1), system.MemberStateJoined),
+				mockMember(t, 0, 1, "joined"),
+				mockMember(t, 1, 1, "joined"),
 			},
 			mResps: []*control.HostResponse{
 				{
@@ -1025,16 +937,16 @@ func TestServer_CtlSvc_SystemStop(t *testing.T) {
 				},
 			},
 			expMembers: system.Members{
-				system.NewMember(system.Rank(0), common.MockUUID(0), "", common.MockHostAddr(1), system.MemberStateJoined),
-				system.NewMember(system.Rank(1), common.MockUUID(1), "", common.MockHostAddr(1), system.MemberStateStopping),
+				mockMember(t, 0, 1, "joined"),
+				mockMember(t, 1, 1, "stopping"),
 			},
 		},
 		"filtered and oversubscribed ranks prep fail": {
 			req: &ctlpb.SystemStopReq{Prep: true, Kill: true, Ranks: "0-1,9"},
 			members: system.Members{
-				system.NewMember(system.Rank(0), common.MockUUID(0), "", common.MockHostAddr(1), system.MemberStateJoined),
-				system.NewMember(system.Rank(1), common.MockUUID(1), "", common.MockHostAddr(1), system.MemberStateJoined),
-				system.NewMember(system.Rank(3), common.MockUUID(3), "", common.MockHostAddr(2), system.MemberStateJoined),
+				mockMember(t, 0, 1, "joined"),
+				mockMember(t, 1, 1, "joined"),
+				mockMember(t, 3, 2, "joined"),
 			},
 			mResps: []*control.HostResponse{
 				{
@@ -1065,18 +977,18 @@ func TestServer_CtlSvc_SystemStop(t *testing.T) {
 				},
 			},
 			expMembers: system.Members{
-				system.NewMember(system.Rank(0), common.MockUUID(0), "", common.MockHostAddr(1), system.MemberStateJoined),
-				system.NewMember(system.Rank(1), common.MockUUID(1), "", common.MockHostAddr(1), system.MemberStateStopping),
-				system.NewMember(system.Rank(3), common.MockUUID(3), "", common.MockHostAddr(2), system.MemberStateJoined),
+				mockMember(t, 0, 1, "joined"),
+				mockMember(t, 1, 1, "stopping"),
+				mockMember(t, 3, 2, "joined"),
 			},
 			expAbsentRanks: "9",
 		},
 		"filtered and oversubscribed hosts prep fail": {
 			req: &ctlpb.SystemStopReq{Prep: true, Kill: true, Hosts: "10.0.0.[1,3]"},
 			members: system.Members{
-				system.NewMember(system.Rank(0), common.MockUUID(0), "", common.MockHostAddr(1), system.MemberStateJoined),
-				system.NewMember(system.Rank(1), common.MockUUID(1), "", common.MockHostAddr(1), system.MemberStateJoined),
-				system.NewMember(system.Rank(3), common.MockUUID(3), "", common.MockHostAddr(2), system.MemberStateJoined),
+				mockMember(t, 0, 1, "joined"),
+				mockMember(t, 1, 1, "joined"),
+				mockMember(t, 3, 2, "joined"),
 			},
 			mResps: []*control.HostResponse{
 				{
@@ -1107,19 +1019,19 @@ func TestServer_CtlSvc_SystemStop(t *testing.T) {
 				},
 			},
 			expMembers: system.Members{
-				system.NewMember(system.Rank(0), common.MockUUID(0), "", common.MockHostAddr(1), system.MemberStateJoined),
-				system.NewMember(system.Rank(1), common.MockUUID(1), "", common.MockHostAddr(1), system.MemberStateStopping),
-				system.NewMember(system.Rank(3), common.MockUUID(3), "", common.MockHostAddr(2), system.MemberStateJoined),
+				mockMember(t, 0, 1, "joined"),
+				mockMember(t, 1, 1, "stopping"),
+				mockMember(t, 3, 2, "joined"),
 			},
 			expAbsentHosts: "10.0.0.3",
 		},
 		"unfiltered rank results": {
 			req: &ctlpb.SystemStopReq{Prep: false, Kill: true},
 			members: system.Members{
-				system.NewMember(system.Rank(0), common.MockUUID(0), "", common.MockHostAddr(1), system.MemberStateJoined),
-				system.NewMember(system.Rank(1), common.MockUUID(1), "", common.MockHostAddr(1), system.MemberStateJoined),
-				system.NewMember(system.Rank(2), common.MockUUID(3), "", common.MockHostAddr(2), system.MemberStateJoined),
-				system.NewMember(system.Rank(3), common.MockUUID(4), "", common.MockHostAddr(2), system.MemberStateJoined),
+				mockMember(t, 0, 1, "joined"),
+				mockMember(t, 1, 1, "joined"),
+				mockMember(t, 2, 2, "joined"),
+				mockMember(t, 3, 2, "joined"),
 			},
 			mResps: []*control.HostResponse{
 				{
@@ -1170,19 +1082,19 @@ func TestServer_CtlSvc_SystemStop(t *testing.T) {
 				},
 			},
 			expMembers: system.Members{
-				system.NewMember(system.Rank(0), common.MockUUID(0), "", common.MockHostAddr(1), system.MemberStateJoined),
-				system.NewMember(system.Rank(1), common.MockUUID(1), "", common.MockHostAddr(1), system.MemberStateStopped),
-				system.NewMember(system.Rank(2), common.MockUUID(3), "", common.MockHostAddr(2), system.MemberStateStopped),
-				system.NewMember(system.Rank(3), common.MockUUID(4), "", common.MockHostAddr(2), system.MemberStateStopped),
+				mockMember(t, 0, 1, "joined"),
+				mockMember(t, 1, 1, "stopped"),
+				mockMember(t, 2, 2, "stopped"),
+				mockMember(t, 3, 2, "stopped"),
 			},
 		},
 		"filtered and oversubscribed ranks": {
 			req: &ctlpb.SystemStopReq{Prep: false, Kill: true, Ranks: "0,2,3-9"},
 			members: system.Members{
-				system.NewMember(system.Rank(0), common.MockUUID(0), "", common.MockHostAddr(1), system.MemberStateJoined),
-				system.NewMember(system.Rank(1), common.MockUUID(1), "", common.MockHostAddr(1), system.MemberStateJoined),
-				system.NewMember(system.Rank(2), common.MockUUID(3), "", common.MockHostAddr(2), system.MemberStateStopped),
-				system.NewMember(system.Rank(3), common.MockUUID(4), "", common.MockHostAddr(2), system.MemberStateStopped),
+				mockMember(t, 0, 1, "joined"),
+				mockMember(t, 1, 1, "joined"),
+				mockMember(t, 2, 2, "stopped"),
+				mockMember(t, 3, 2, "stopped"),
 			},
 			mResps: []*control.HostResponse{
 				{
@@ -1226,20 +1138,20 @@ func TestServer_CtlSvc_SystemStop(t *testing.T) {
 				},
 			},
 			expMembers: system.Members{
-				system.NewMember(system.Rank(0), common.MockUUID(0), "", common.MockHostAddr(1), system.MemberStateJoined),
-				system.NewMember(system.Rank(1), common.MockUUID(1), "", common.MockHostAddr(1), system.MemberStateJoined),
-				system.NewMember(system.Rank(2), common.MockUUID(3), "", common.MockHostAddr(2), system.MemberStateStopped),
-				system.NewMember(system.Rank(3), common.MockUUID(4), "", common.MockHostAddr(2), system.MemberStateStopped),
+				mockMember(t, 0, 1, "joined"),
+				mockMember(t, 1, 1, "joined"),
+				mockMember(t, 2, 2, "stopped"),
+				mockMember(t, 3, 2, "stopped"),
 			},
 			expAbsentRanks: "4-9",
 		},
 		"filtered and oversubscribed hosts": {
 			req: &ctlpb.SystemStopReq{Prep: false, Kill: true, Hosts: "10.0.0.[2-5]"},
 			members: system.Members{
-				system.NewMember(system.Rank(0), common.MockUUID(0), "", common.MockHostAddr(1), system.MemberStateJoined),
-				system.NewMember(system.Rank(1), common.MockUUID(1), "", common.MockHostAddr(1), system.MemberStateJoined),
-				system.NewMember(system.Rank(2), common.MockUUID(3), "", common.MockHostAddr(2), system.MemberStateStopped),
-				system.NewMember(system.Rank(3), common.MockUUID(4), "", common.MockHostAddr(2), system.MemberStateJoined),
+				mockMember(t, 0, 1, "joined"),
+				mockMember(t, 1, 1, "joined"),
+				mockMember(t, 2, 2, "stopped"),
+				mockMember(t, 3, 2, "joined"),
 			},
 			mResps: []*control.HostResponse{
 				{
@@ -1267,20 +1179,20 @@ func TestServer_CtlSvc_SystemStop(t *testing.T) {
 				},
 			},
 			expMembers: system.Members{
-				system.NewMember(system.Rank(0), common.MockUUID(0), "", common.MockHostAddr(1), system.MemberStateJoined),
-				system.NewMember(system.Rank(1), common.MockUUID(1), "", common.MockHostAddr(1), system.MemberStateJoined),
-				system.NewMember(system.Rank(2), common.MockUUID(3), "", common.MockHostAddr(2), system.MemberStateStopped),
-				system.NewMember(system.Rank(3), common.MockUUID(4), "", common.MockHostAddr(2), system.MemberStateStopped),
+				mockMember(t, 0, 1, "joined"),
+				mockMember(t, 1, 1, "joined"),
+				mockMember(t, 2, 2, "stopped"),
+				mockMember(t, 3, 2, "stopped"),
 			},
 			expAbsentHosts: "10.0.0.[3-5]",
 		},
 		"filtered hosts": {
 			req: &ctlpb.SystemStopReq{Prep: false, Kill: true, Hosts: "10.0.0.[1-2]"},
 			members: system.Members{
-				system.NewMember(system.Rank(0), common.MockUUID(0), "", common.MockHostAddr(1), system.MemberStateJoined),
-				system.NewMember(system.Rank(1), common.MockUUID(1), "", common.MockHostAddr(1), system.MemberStateJoined),
-				system.NewMember(system.Rank(2), common.MockUUID(3), "", common.MockHostAddr(2), system.MemberStateStopped),
-				system.NewMember(system.Rank(3), common.MockUUID(4), "", common.MockHostAddr(2), system.MemberStateJoined),
+				mockMember(t, 0, 1, "joined"),
+				mockMember(t, 1, 1, "joined"),
+				mockMember(t, 2, 2, "stopped"),
+				mockMember(t, 3, 2, "joined"),
 			},
 			mResps: []*control.HostResponse{
 				{
@@ -1329,10 +1241,10 @@ func TestServer_CtlSvc_SystemStop(t *testing.T) {
 				},
 			},
 			expMembers: system.Members{
-				system.NewMember(system.Rank(0), common.MockUUID(0), "", common.MockHostAddr(1), system.MemberStateStopped),
-				system.NewMember(system.Rank(1), common.MockUUID(1), "", common.MockHostAddr(1), system.MemberStateStopped),
-				system.NewMember(system.Rank(2), common.MockUUID(3), "", common.MockHostAddr(2), system.MemberStateStopped),
-				system.NewMember(system.Rank(3), common.MockUUID(4), "", common.MockHostAddr(2), system.MemberStateStopped),
+				mockMember(t, 0, 1, "stopped"),
+				mockMember(t, 1, 1, "stopped"),
+				mockMember(t, 2, 2, "stopped"),
+				mockMember(t, 3, 2, "stopped"),
 			},
 		},
 	} {
@@ -1340,31 +1252,9 @@ func TestServer_CtlSvc_SystemStop(t *testing.T) {
 			log, buf := logging.NewTestLogger(t.Name())
 			defer common.ShowBufferOnFailure(t, buf)
 
-			cfg := config.DefaultServer()
-			cs := mockControlService(t, log, cfg, nil, nil, nil)
-			cs.srvCfg = cfg
-			cs.srvCfg.ControlPort = 10001
-			cs.membership = system.MockMembership(t, log)
-			for _, m := range tc.members {
-				if _, err := cs.membership.Add(m); err != nil {
-					t.Fatal(err)
-				}
-			}
+			cs := ctlSystemTestSetup(t, log, tc.members, tc.mResps)
 
-			mgmtSvc := newTestMgmtSvcMulti(t, log, maxIOServers, false)
-			cs.harness = mgmtSvc.harness
-			cs.harness.started.SetTrue()
-			cs.harness.instances[0]._superblock.Rank = system.NewRankPtr(0)
-
-			ctx := context.TODO()
-			mi := control.NewMockInvoker(log, &control.MockInvokerConfig{
-				UnaryResponse: &control.UnaryResponse{
-					Responses: tc.mResps,
-				},
-			})
-			cs.rpcClient = mi
-
-			gotResp, gotErr := cs.SystemStop(ctx, tc.req)
+			gotResp, gotErr := cs.SystemStop(context.TODO(), tc.req)
 			common.ExpectError(t, gotErr, tc.expErrMsg, name)
 			if tc.expErrMsg != "" && tc.expErrMsg != "PrepShutdown HasErrors" {
 				return
@@ -1411,10 +1301,10 @@ func TestServer_CtlSvc_SystemResetFormat(t *testing.T) {
 		},
 		"unfiltered rank results": {
 			members: system.Members{
-				system.NewMember(system.Rank(0), common.MockUUID(0), "", common.MockHostAddr(1), system.MemberStateStopped),
-				system.NewMember(system.Rank(1), common.MockUUID(1), "", common.MockHostAddr(1), system.MemberStateStopped),
-				system.NewMember(system.Rank(2), common.MockUUID(3), "", common.MockHostAddr(2), system.MemberStateStopped),
-				system.NewMember(system.Rank(3), common.MockUUID(4), "", common.MockHostAddr(2), system.MemberStateStopped),
+				mockMember(t, 0, 1, "stopped"),
+				mockMember(t, 1, 1, "stopped"),
+				mockMember(t, 2, 2, "stopped"),
+				mockMember(t, 3, 2, "stopped"),
 			},
 			mResps: []*control.HostResponse{
 				{
@@ -1466,18 +1356,18 @@ func TestServer_CtlSvc_SystemResetFormat(t *testing.T) {
 			},
 
 			expMembers: system.Members{
-				system.NewMember(system.Rank(0), common.MockUUID(0), "", common.MockHostAddr(1), system.MemberStateStopped),
-				system.NewMember(system.Rank(1), common.MockUUID(1), "", common.MockHostAddr(1), system.MemberStateAwaitFormat),
-				system.NewMember(system.Rank(2), common.MockUUID(3), "", common.MockHostAddr(2), system.MemberStateAwaitFormat),
-				system.NewMember(system.Rank(3), common.MockUUID(4), "", common.MockHostAddr(2), system.MemberStateAwaitFormat),
+				mockMember(t, 0, 1, "stopped"),
+				mockMember(t, 1, 1, "awaitformat"),
+				mockMember(t, 2, 2, "awaitformat"),
+				mockMember(t, 3, 2, "awaitformat"),
 			},
 		},
 		"filtered and oversubscribed ranks": {
 			members: system.Members{
-				system.NewMember(system.Rank(0), common.MockUUID(0), "", common.MockHostAddr(1), system.MemberStateStopped),
-				system.NewMember(system.Rank(1), common.MockUUID(1), "", common.MockHostAddr(1), system.MemberStateJoined),
-				system.NewMember(system.Rank(2), common.MockUUID(3), "", common.MockHostAddr(2), system.MemberStateStopped),
-				system.NewMember(system.Rank(3), common.MockUUID(4), "", common.MockHostAddr(2), system.MemberStateStopped),
+				mockMember(t, 0, 1, "stopped"),
+				mockMember(t, 1, 1, "joined"),
+				mockMember(t, 2, 2, "stopped"),
+				mockMember(t, 3, 2, "stopped"),
 			},
 			ranks: "0-1,4-9",
 			mResps: []*control.HostResponse{
@@ -1508,19 +1398,19 @@ func TestServer_CtlSvc_SystemResetFormat(t *testing.T) {
 				},
 			},
 			expMembers: system.Members{
-				system.NewMember(system.Rank(0), common.MockUUID(0), "", common.MockHostAddr(1), system.MemberStateStopped),
-				system.NewMember(system.Rank(1), common.MockUUID(1), "", common.MockHostAddr(1), system.MemberStateAwaitFormat),
-				system.NewMember(system.Rank(2), common.MockUUID(3), "", common.MockHostAddr(2), system.MemberStateStopped),
-				system.NewMember(system.Rank(3), common.MockUUID(4), "", common.MockHostAddr(2), system.MemberStateStopped),
+				mockMember(t, 0, 1, "stopped"),
+				mockMember(t, 1, 1, "awaitformat"),
+				mockMember(t, 2, 2, "stopped"),
+				mockMember(t, 3, 2, "stopped"),
 			},
 			expAbsentRanks: "4-9",
 		},
 		"filtered and oversubscribed hosts": {
 			members: system.Members{
-				system.NewMember(system.Rank(0), common.MockUUID(0), "", common.MockHostAddr(1), system.MemberStateStopped),
-				system.NewMember(system.Rank(1), common.MockUUID(1), "", common.MockHostAddr(1), system.MemberStateJoined),
-				system.NewMember(system.Rank(2), common.MockUUID(3), "", common.MockHostAddr(2), system.MemberStateStopped),
-				system.NewMember(system.Rank(3), common.MockUUID(4), "", common.MockHostAddr(2), system.MemberStateStopped),
+				mockMember(t, 0, 1, "stopped"),
+				mockMember(t, 1, 1, "joined"),
+				mockMember(t, 2, 2, "stopped"),
+				mockMember(t, 3, 2, "stopped"),
 			},
 			hosts: "10.0.0.[2-5]",
 			mResps: []*control.HostResponse{
@@ -1551,10 +1441,10 @@ func TestServer_CtlSvc_SystemResetFormat(t *testing.T) {
 				},
 			},
 			expMembers: system.Members{
-				system.NewMember(system.Rank(0), common.MockUUID(0), "", common.MockHostAddr(1), system.MemberStateStopped),
-				system.NewMember(system.Rank(1), common.MockUUID(1), "", common.MockHostAddr(1), system.MemberStateJoined),
-				system.NewMember(system.Rank(2), common.MockUUID(3), "", common.MockHostAddr(2), system.MemberStateStopped),
-				system.NewMember(system.Rank(3), common.MockUUID(4), "", common.MockHostAddr(2), system.MemberStateAwaitFormat),
+				mockMember(t, 0, 1, "stopped"),
+				mockMember(t, 1, 1, "joined"),
+				mockMember(t, 2, 2, "stopped"),
+				mockMember(t, 3, 2, "awaitformat"),
 			},
 			expAbsentHosts: "10.0.0.[3-5]",
 		},
@@ -1563,36 +1453,14 @@ func TestServer_CtlSvc_SystemResetFormat(t *testing.T) {
 			log, buf := logging.NewTestLogger(t.Name())
 			defer common.ShowBufferOnFailure(t, buf)
 
-			cfg := config.DefaultServer()
-			cs := mockControlService(t, log, cfg, nil, nil, nil)
-			cs.srvCfg = cfg
-			cs.srvCfg.ControlPort = 10001
-			cs.membership = system.MockMembership(t, log)
-			for _, m := range tc.members {
-				if _, err := cs.membership.Add(m); err != nil {
-					t.Fatal(err)
-				}
-			}
-
-			mgmtSvc := newTestMgmtSvcMulti(t, log, maxIOServers, false)
-			cs.harness = mgmtSvc.harness
-			cs.harness.started.SetTrue()
-			cs.harness.instances[0]._superblock.Rank = system.NewRankPtr(0)
-
-			ctx := context.TODO()
-			mi := control.NewMockInvoker(log, &control.MockInvokerConfig{
-				UnaryResponse: &control.UnaryResponse{
-					Responses: tc.mResps,
-				},
-			})
-			cs.rpcClient = mi
+			cs := ctlSystemTestSetup(t, log, tc.members, tc.mResps)
 
 			req := &ctlpb.SystemResetFormatReq{Ranks: tc.ranks, Hosts: tc.hosts}
 			if tc.nilReq {
 				req = nil
 			}
 
-			gotResp, gotErr := cs.SystemResetFormat(ctx, req)
+			gotResp, gotErr := cs.SystemResetFormat(context.TODO(), req)
 			common.ExpectError(t, gotErr, tc.expErrMsg, name)
 			if tc.expErrMsg != "" {
 				return

--- a/src/control/server/harness_test.go
+++ b/src/control/server/harness_test.go
@@ -295,8 +295,7 @@ func TestServer_Harness_Start(t *testing.T) {
 
 			// start harness async and signal completion
 			var gotErr error
-			membership := system.MockMembership(t, log)
-			sysdb := system.MockDatabase(t, log)
+			membership, sysdb := system.MockMembership(t, log, mockTCPResolver)
 			done := make(chan struct{})
 			go func(ctxIn context.Context) {
 				gotErr = harness.Start(ctxIn, sysdb, config)

--- a/src/control/server/mgmt_pool_test.go
+++ b/src/control/server/mgmt_pool_test.go
@@ -272,7 +272,8 @@ func TestServer_MgmtSvc_PoolCreate(t *testing.T) {
 				}
 				harness.started.SetTrue()
 
-				tc.mgmtSvc = newMgmtSvc(harness, system.MockMembership(t, log), system.MockDatabase(t, log))
+				ms, db := system.MockMembership(t, log, mockTCPResolver)
+				tc.mgmtSvc = newMgmtSvc(harness, ms, db)
 			}
 			tc.mgmtSvc.log = log
 

--- a/src/control/system/member.go
+++ b/src/control/system/member.go
@@ -332,11 +332,22 @@ func (smr MemberResults) HasErrors() bool {
 	return false
 }
 
+// resolveTCPFn is a type alias for the net.ResolveTCPAddr function signature.
+type resolveTCPFn func(string, string) (*net.TCPAddr, error)
+
 // Membership tracks details of system members.
 type Membership struct {
 	sync.RWMutex
-	log logging.Logger
-	db  *Database
+	log        logging.Logger
+	db         *Database
+	resolveTCP resolveTCPFn
+}
+
+// WithTCPResolver adds a resolveTCPFn to the membership structure.
+func (m *Membership) WithTCPResolver(resolver resolveTCPFn) *Membership {
+	m.resolveTCP = resolver
+
+	return m
 }
 
 func (m *Membership) addMember(member *Member) error {
@@ -663,12 +674,11 @@ func (m *Membership) CheckRanks(ranks string) (hit, miss *RankSet, err error) {
 	return
 }
 
-type resolveFnSig func(string, string) (*net.TCPAddr, error)
-
 // CheckHosts returns set of all ranks on any of the hosts in provided host set
 // string and another slice of all hosts from input hostset string that are
-// missing from the membership.
-func (m *Membership) CheckHosts(hosts string, ctlPort int, resolveFn resolveFnSig) (*RankSet, *hostlist.HostSet, error) {
+// missing from the membership. Host addresses are resolved before looking up
+// resident ranks to verify destination server is still available.
+func (m *Membership) CheckHosts(hosts string, ctlPort int) (*RankSet, *hostlist.HostSet, error) {
 	m.RLock()
 	defer m.RUnlock()
 
@@ -692,7 +702,7 @@ func (m *Membership) CheckHosts(hosts string, ctlPort int, resolveFn resolveFnSi
 			host = net.JoinHostPort(host, strconv.Itoa(ctlPort))
 		}
 
-		tcpAddr, resolveErr := resolveFn("tcp", host)
+		tcpAddr, resolveErr := m.resolveTCP("tcp", host)
 		if resolveErr != nil {
 			m.log.Debugf("host addr %q didn't resolve: %s", host, resolveErr)
 			if _, err := missHS.Insert(origHostString); err != nil {
@@ -719,5 +729,9 @@ func (m *Membership) CheckHosts(hosts string, ctlPort int, resolveFn resolveFnSi
 
 // NewMembership returns a reference to a new DAOS system membership.
 func NewMembership(log logging.Logger, db *Database) *Membership {
-	return &Membership{db: db, log: log}
+	return &Membership{
+		db:         db,
+		log:        log,
+		resolveTCP: net.ResolveTCPAddr,
+	}
 }

--- a/src/control/system/mocks.go
+++ b/src/control/system/mocks.go
@@ -65,8 +65,10 @@ func MockMemberResult(rank Rank, action string, err error, state MemberState) *M
 	return result
 }
 
-func MockMembership(t *testing.T, log logging.Logger) *Membership {
-	return NewMembership(log, MockDatabase(t, log))
+func MockMembership(t *testing.T, log logging.Logger, resolver resolveTCPFn) (*Membership, *Database) {
+	db := MockDatabase(t, log)
+
+	return NewMembership(log, db).WithTCPResolver(resolver), db
 }
 
 type (


### PR DESCRIPTION
Prevent unit tests from attempting to resolve TCP addresses on the
running host as test outcomes are then dependent on the network of
the test host. Unit tests should not be calling the real TCP resolver
so apply the relevant mocking. Also DRY-up ctlsvc tests.

Signed-off-by: Tom Nabarro <tom.nabarro@intel.com>