### PR TITLE
DAOS-5999 tests: re-enable OID subtest 3

### DIFF
--- a/src/tests/suite/daos_oid_alloc.c
+++ b/src/tests/suite/daos_oid_alloc.c
@@ -226,9 +226,6 @@ oid_allocator_checker(void **state)
 	int		i;
 	int		rc, rc_reduce;
 
-	/* skipped until bug DAOS-5999 is fixed */
-	skip();
-
 	srand(time(NULL));
 	reconnect(arg);
 


### PR DESCRIPTION
Since DAOS-6187 has been fixed, let's re-enable OID
subtest 3.

Signed-off-by: Di Wang <di.wang@intel.com>