### PR TITLE
DAOS-6345 test: Use path when removing core files

### DIFF
--- a/src/tests/ftest/launch.py
+++ b/src/tests/ftest/launch.py
@@ -1457,7 +1457,7 @@ def process_the_cores(avocado_logs_dir, test_yaml, args):
         print(error)
         print("Removing core files to avoid archiving them")
         for corefile in cores:
-            os.remove(corefile)
+            os.remove(os.path.join(daos_cores_dir, corefile))
         return False
 
     def run_gdb(pattern):


### PR DESCRIPTION
In the clean up of the core file after a failed debuginfo installation,
the removal command was not using the path to the core file when trying
to  remove it resulting in an ENOENT.

Signed-off-by: Brian J. Murrell <brian.murrell@intel.com>