### PR TITLE
DAOS-6333 dtx: disable DTX flush when close container

### DIFF
--- a/src/dtx/dtx_resync.c
+++ b/src/dtx/dtx_resync.c
@@ -109,7 +109,7 @@ next:
 	}
 
 	if (j > 0) {
-		rc = dtx_commit(cont, dte, j, false);
+		rc = dtx_commit(cont, dte, j, true);
 		if (rc < 0)
 			D_ERROR("Failed to commit the DTXs: rc = "DF_RC"\n",
 				DP_RC(rc));
@@ -148,9 +148,6 @@ dtx_is_leader(struct ds_pool *pool, struct dtx_resync_args *dra,
 	      struct dtx_resync_entry *dre)
 {
 	struct dtx_memberships	*mbs = dre->dre_dte.dte_mbs;
-
-	if (mbs->dm_dte_flags & DTE_LEADER)
-		return 1;
 
 	/* Old leader is still alive, then current server is not the leader. */
 	if (mbs->dm_flags & DMF_CONTAIN_LEADER &&
@@ -246,6 +243,12 @@ dtx_status_handle(struct dtx_resync_args *dra)
 	d_list_for_each_entry_safe(dre, next, &drh->drh_list, dre_link) {
 		struct dtx_memberships	*mbs = dre->dre_dte.dte_mbs;
 
+		if (cont->sc_closing)
+			goto out;
+
+		if (mbs->dm_dte_flags & DTE_LEADER)
+			goto commit;
+
 		rc = dtx_is_leader(pool, dra, dre);
 		if (rc <= 0) {
 			if (rc < 0)
@@ -295,6 +298,15 @@ dtx_status_handle(struct dtx_resync_args *dra)
 			}
 
 			goto commit;
+		}
+
+		if (rc == -DER_INPROGRESS) {
+			D_WARN("Other participants not sure about whether the "
+			       "DTX "DF_DTI" can be committed or not, retry.\n",
+			       DP_DTI(&dre->dre_xid));
+			d_list_del(&dre->dre_link);
+			d_list_add_tail(&dre->dre_link, &drh->drh_list);
+			continue;
 		}
 
 		if (rc != -DER_NONEXIST) {
@@ -375,7 +387,11 @@ commit:
 out:
 	D_FREE(tgt_array);
 
-	if (err >= 0)
+	while ((dre = d_list_pop_entry(&drh->drh_list, struct dtx_resync_entry,
+				       dre_link)) != NULL)
+		dtx_dre_release(drh, dre);
+
+	if (err >= 0 && !cont->sc_closing)
 		/* Drain old committable DTX to help subsequent rebuild. */
 		err = dtx_obj_sync(cont, NULL, dra->epoch);
 
@@ -400,16 +416,33 @@ dtx_iter_cb(uuid_t co_uuid, vos_iter_entry_t *ent, void *args)
 
 	D_ASSERT(!(ent->ie_dtx_flags & DTE_INVALID));
 
-	if (ent->ie_dtx_flags & DTE_LEADER && !dra->resync_all)
-		return 0;
-
 	/* Skip corrupted entry that will be handled via other special tool. */
 	if (ent->ie_dtx_flags & DTE_CORRUPTED)
 		return 0;
 
-	/* Only handle the DTX that happened before the DTX resync. */
-	if (ent->ie_dtx_ver >= dra->version)
-		return 0;
+	if (dra->resync_all) {
+		/* Open container case:
+		 * DTX leader: handle the DTX that happened before DTX resync.
+		 * non-leader: handle the DTX with old version.
+		 */
+		if (ent->ie_dtx_flags & DTE_LEADER) {
+			if (ent->ie_epoch < dra->epoch)
+				return 0;
+		} else {
+			if (ent->ie_dtx_ver >= dra->version)
+				return 0;
+		}
+	} else {
+		/* Pool map refresh case:
+		 * DTX leader: do nothing.
+		 * non-leader: handle the DTX with old version.
+		 */
+		if (ent->ie_dtx_flags & DTE_LEADER)
+			return 0;
+
+		if (ent->ie_dtx_ver >= dra->version)
+			return 0;
+	}
 
 	D_ASSERT(ent->ie_dtx_mbs_dsize > 0);
 	D_ASSERT(ent->ie_dtx_tgt_cnt > 0);
@@ -475,7 +508,7 @@ dtx_resync(daos_handle_t po_hdl, uuid_t po_uuid, uuid_t co_uuid, uint32_t ver,
 		resynced = true;
 	}
 	if (resynced || /* Someone just did the DTX resync*/
-	    cont->sc_stopping) {
+	    cont->sc_closing) {
 		ABT_mutex_unlock(cont->sc_mutex);
 		goto out;
 	}

--- a/src/dtx/dtx_srv.c
+++ b/src/dtx/dtx_srv.c
@@ -96,11 +96,13 @@ dtx_handler(crt_rpc_t *rpc)
 	case DTX_CHECK:
 		/* Currently, only support to check single DTX state. */
 		if (din->di_dtx_array.ca_count != 1)
-			rc = -DER_PROTO;
-		else
-			rc = vos_dtx_check(cont->sc_hdl,
-					   din->di_dtx_array.ca_arrays,
-					   NULL, NULL, NULL, false);
+			D_GOTO(out, rc = -DER_PROTO);
+
+		rc = vos_dtx_check(cont->sc_hdl, din->di_dtx_array.ca_arrays,
+				   NULL, NULL, NULL, false);
+		if (rc == -DER_NONEXIST && cont->sc_dtx_reindex)
+			rc = -DER_INPROGRESS;
+
 		break;
 	case DTX_REFRESH:
 		count = din->di_dtx_array.ca_count;
@@ -123,8 +125,9 @@ dtx_handler(crt_rpc_t *rpc)
 			*ptr = vos_dtx_check(cont->sc_hdl, dtis, NULL, &vers[i],
 					     &mbs[i], false);
 			/* The DTX status may be changes by DTX resync soon. */
-			if (*ptr == DTX_ST_PREPARED &&
-			    vers[i] < cont->sc_dtx_resync_ver)
+			if ((*ptr == DTX_ST_PREPARED &&
+			     cont->sc_dtx_resyncing) ||
+			    (*ptr == -DER_NONEXIST && cont->sc_dtx_reindex))
 				*ptr = -DER_INPROGRESS;
 			if (mbs[i] != NULL)
 				rc1++;

--- a/src/include/daos_srv/container.h
+++ b/src/include/daos_srv/container.h
@@ -80,6 +80,7 @@ struct ds_cont_child {
 				 sc_dtx_aggregating:1,
 				 sc_dtx_reindex:1,
 				 sc_dtx_reindex_abort:1,
+				 sc_closing:1,
 				 sc_vos_aggregating:1,
 				 sc_abort_vos_aggregating:1,
 				 sc_props_fetched:1,

--- a/src/include/daos_srv/dtx_srv.h
+++ b/src/include/daos_srv/dtx_srv.h
@@ -75,6 +75,8 @@ struct dtx_handle {
 	daos_unit_oid_t			 dth_leader_oid;
 
 	uint32_t			 dth_sync:1, /* commit synchronously. */
+					 /* DTXs in CoS list are committed. */
+					 dth_cos_done:1,
 					 dth_resent:1, /* For resent case. */
 					 /* Only one participator in the DTX. */
 					 dth_solo:1,

--- a/src/vos/tests/vts_dtx.c
+++ b/src/vos/tests/vts_dtx.c
@@ -71,6 +71,7 @@ vts_dtx_begin(const daos_unit_oid_t *oid, daos_handle_t coh, daos_epoch_t epoch,
 	dth->dth_leader_oid = *oid;
 
 	dth->dth_sync = 0;
+	dth->dth_cos_done = 0;
 	dth->dth_resent = 0;
 	dth->dth_touched_leader_oid = 0;
 	dth->dth_local_tx_started = 0;

--- a/src/vos/vos_io.c
+++ b/src/vos/vos_io.c
@@ -2062,7 +2062,8 @@ vos_update_end(daos_handle_t ioh, uint32_t pm_ver, daos_key_t *dkey, int err,
 	vos_dth_set(dth);
 
 	/* Commit the CoS DTXs via the IO PMDK transaction. */
-	if (dtx_is_valid_handle(dth) && dth->dth_dti_cos_count > 0) {
+	if (dtx_is_valid_handle(dth) && dth->dth_dti_cos_count > 0 &&
+	    !dth->dth_cos_done) {
 		D_ALLOC_ARRAY(daes, dth->dth_dti_cos_count);
 		if (daes == NULL)
 			D_GOTO(abort, err = -DER_NOMEM);
@@ -2106,20 +2107,6 @@ abort:
 			err = -DER_TX_RESTART;
 		}
 	}
-	err = vos_tx_end(ioc->ic_cont, dth, &ioc->ic_rsrvd_scm,
-			 &ioc->ic_blk_exts, tx_started, err);
-
-	if (err == 0) {
-		if (daes != NULL)
-			vos_dtx_post_handle(ioc->ic_cont, daes,
-					    dth->dth_dti_cos_count, false);
-		vos_dedup_process(vos_cont2pool(ioc->ic_cont),
-				  &ioc->ic_dedup_entries, false);
-	} else {
-		update_cancel(ioc);
-	}
-
-	D_FREE(daes);
 
 	if (err == 0)
 		vos_ts_set_upgrade(ioc->ic_ts_set);
@@ -2130,9 +2117,24 @@ abort:
 			vos_ts_set_wupdate(ioc->ic_ts_set, ioc->ic_epr.epr_hi);
 	}
 
+	err = vos_tx_end(ioc->ic_cont, dth, &ioc->ic_rsrvd_scm,
+			 &ioc->ic_blk_exts, tx_started, err);
+	if (err == 0) {
+		if (daes != NULL) {
+			vos_dtx_post_handle(ioc->ic_cont, daes,
+					    dth->dth_dti_cos_count, false);
+			dth->dth_cos_done = 1;
+		}
+		vos_dedup_process(vos_cont2pool(ioc->ic_cont),
+				  &ioc->ic_dedup_entries, false);
+	} else {
+		update_cancel(ioc);
+	}
+
 	VOS_TIME_END(time, VOS_UPDATE_END);
 	vos_space_unhold(vos_cont2pool(ioc->ic_cont), &ioc->ic_space_held[0]);
 
+	D_FREE(daes);
 	vos_ioc_destroy(ioc, err != 0);
 	vos_dth_set(NULL);
 


### PR DESCRIPTION
It is suspected that some bad things happened during DTX flush
as to the whole container close process is blocked. Disable it
and resync related DTX entries when reopen the container.

The patch also fixes some potential issue of DTX entry leak in
the DTX CoS cache after being committed, that will cause async
batched commit ULT or obj_sync related logic to handle the DTX
entry repeatedly for ever.

Signed-off-by: Fan Yong <fan.yong@intel.com>