### PR TITLE
DAOS-6347 tests: Upgrade DAOS EC rebuild tests

### DIFF
--- a/src/tests/suite/daos_rebuild_common.c
+++ b/src/tests/suite/daos_rebuild_common.c
@@ -30,14 +30,12 @@
 #define D_LOGFAC	DD_FAC(tests)
 
 #include "daos_iotest.h"
+#include "dfs_test.h"
 #include <daos/pool.h>
 #include <daos/mgmt.h>
 #include <daos/container.h>
 
 static test_arg_t *save_arg;
-
-#define REBUILD_SUBTEST_POOL_SIZE (1ULL << 30)
-#define REBUILD_SMALL_POOL_SIZE (1ULL << 29)
 
 enum REBUILD_TEST_OP_TYPE {
 	RB_OP_TYPE_FAIL,
@@ -728,6 +726,110 @@ verify_ec_full_partial(struct ioreq *req, int test_idx, daos_off_t off)
 	verify_ec(req, test_idx, buffer, off, DATA_SIZE);
 }
 
+void
+dfs_ec_rebuild_io(void **state, int *shards, int shards_nr)
+{
+	dfs_t		*dfs_mt;
+	daos_handle_t	co_hdl;
+	test_arg_t	*arg = *state;
+	d_sg_list_t	sgl;
+	d_iov_t		iov;
+	dfs_obj_t	*obj;
+	daos_size_t	buf_size = 32 * 1024 * 32;
+	daos_size_t	partial_size = 32 * 1024 * 2;
+	daos_size_t	chunk_size = 32 * 1024 * 4;
+	daos_size_t	fetch_size = 0;
+	uuid_t		co_uuid;
+	char		filename[32];
+	d_rank_t	ranks[4] = { -1 };
+	int		idx = 0;
+	daos_obj_id_t	oid;
+	char		*buf;
+	char		*vbuf;
+	int		i;
+	int		rc;
+
+	uuid_generate(co_uuid);
+	rc = dfs_cont_create(arg->pool.poh, co_uuid, NULL, &co_hdl,
+			     &dfs_mt);
+	assert_int_equal(rc, 0);
+	printf("Created DFS Container "DF_UUIDF"\n", DP_UUID(co_uuid));
+
+	D_ALLOC(buf, buf_size);
+	assert_true(buf != NULL);
+	D_ALLOC(vbuf, buf_size);
+	assert_true(vbuf != NULL);
+
+	d_iov_set(&iov, buf, buf_size);
+	sgl.sg_nr = 1;
+	sgl.sg_nr_out = 1;
+	sgl.sg_iovs = &iov;
+
+	dts_buf_render(buf, buf_size);
+	memcpy(vbuf, buf, buf_size);
+
+	/* Full stripe update */
+	sprintf(filename, "degrade_file");
+	rc = dfs_open(dfs_mt, NULL, filename, S_IFREG | S_IWUSR | S_IRUSR,
+		      O_RDWR | O_CREAT, DAOS_OC_EC_K4P2_L32K, chunk_size,
+		      NULL, &obj);
+	assert_int_equal(rc, 0);
+	rc = dfs_write(dfs_mt, obj, &sgl, 0, NULL);
+	assert_int_equal(rc, 0);
+
+	/* Partial update after that */
+	d_iov_set(&iov, buf, partial_size);
+	for (i = 0; i < 10; i++) {
+		dfs_write(dfs_mt, obj, &sgl, buf_size + i * 100 * 1024, NULL);
+		assert_int_equal(rc, 0);
+	}
+
+	dfs_obj2id(obj, &oid);
+	while (shards_nr-- > 0) {
+		ranks[idx] = get_rank_by_oid_shard(arg, oid, shards[idx]);
+		idx++;
+	}
+	rebuild_pools_ranks(&arg, 1, ranks, idx, false);
+
+	/* Verify full stripe */
+	d_iov_set(&iov, buf, buf_size);
+	fetch_size = 0;
+	rc = dfs_read(dfs_mt, obj, &sgl, 0, &fetch_size, NULL);
+	assert_int_equal(rc, 0);
+	assert_int_equal(fetch_size, buf_size);
+	assert_memory_equal(buf, vbuf, buf_size);
+
+	/* Verify partial stripe */
+	d_iov_set(&iov, buf, partial_size);
+	for (i = 0; i < 10; i++) {
+		memset(buf, 0, buf_size);
+		fetch_size = 0;
+		dfs_read(dfs_mt, obj, &sgl, buf_size + i * 100 * 1024,
+			 &fetch_size, NULL);
+		assert_int_equal(rc, 0);
+		assert_int_equal(fetch_size, partial_size);
+		assert_memory_equal(buf, vbuf, partial_size);
+	}
+
+	rc = dfs_release(obj);
+	assert_int_equal(rc, 0);
+
+	D_FREE(buf);
+	rc = dfs_umount(dfs_mt);
+	assert_int_equal(rc, 0);
+
+	rc = daos_cont_close(co_hdl, NULL);
+	assert_int_equal(rc, 0);
+
+	rc = daos_cont_destroy(arg->pool.poh, co_uuid, 1, NULL);
+	assert_int_equal(rc, 0);
+
+#if 0
+	while (idx > 0)
+		rebuild_add_back_tgts(arg, ranks[--idx], NULL, 1);
+#endif
+}
+
 /* Create a new pool for the sub_test */
 int
 rebuild_pool_create(test_arg_t **new_arg, test_arg_t *old_arg, int flag,
@@ -788,7 +890,8 @@ get_killing_rank_by_oid(test_arg_t *arg, daos_obj_id_t oid, int data_nr,
 	oca = daos_oclass_attr_find(oid);
 	if (oca->ca_resil == DAOS_RES_REPL) {
 		ranks[0] = get_rank_by_oid_shard(arg, oid, 0);
-		*ranks_num = 1;
+		if (ranks_num)
+			*ranks_num = 1;
 		return;
 	}
 
@@ -807,10 +910,11 @@ get_killing_rank_by_oid(test_arg_t *arg, daos_obj_id_t oid, int data_nr,
 			break;
 	}
 
-	*ranks_num = idx;
+	if (ranks_num)
+		*ranks_num = idx;
 }
 
-static void
+void
 save_group_state(void **state)
 {
 	if (state != NULL && *state != NULL) {

--- a/src/tests/suite/daos_rebuild_ec.c
+++ b/src/tests/suite/daos_rebuild_ec.c
@@ -44,11 +44,10 @@ rebuild_ec_internal(void **state, uint16_t oclass, int kill_data_nr,
 	struct ioreq		req;
 	d_rank_t		kill_ranks[4] = { -1 };
 	int			kill_ranks_num = 0;
-	d_rank_t		kill_data_rank;
 
-	if (oclass == OC_EC_2P1G1 && !test_runable(arg, 5))
+	if (oclass == OC_EC_2P1G1 && !test_runable(arg, 4))
 		return;
-	else if (oclass == OC_EC_4P2G1 && !test_runable(arg, 7))
+	if (oclass == OC_EC_4P2G1 && !test_runable(arg, 8))
 		return;
 
 	oid = dts_oid_gen(oclass, 0, arg->myrank);
@@ -71,15 +70,17 @@ rebuild_ec_internal(void **state, uint16_t oclass, int kill_data_nr,
 	rebuild_pools_ranks(&arg, 1, kill_ranks, kill_ranks_num, false);
 
 	ioreq_init(&req, arg->coh, oid, DAOS_IOD_ARRAY, arg);
-	if (kill_parity_nr > 0) {
-		int tmp;
 
-		/* To verify if the parity being rebuild correctly,
-		 * let's kill another data node to to rebuild data, then
-		 * verify if the rebuild data is correct.
-		 */
-		get_killing_rank_by_oid(arg, oid, 1, 0, &kill_data_rank, &tmp);
-		rebuild_pools_ranks(&arg, 1, &kill_data_rank, 1, false);
+	/*
+	 * let's kill another 2 data node to do degrade fetch, so to
+	 * verify degrade fetch is correct.
+	 */
+	if (oclass == OC_EC_2P1G1) {
+		get_killing_rank_by_oid(arg, oid, 2, 0, kill_ranks, NULL);
+		rebuild_pools_ranks(&arg, 1, &kill_ranks[1], 1, false);
+	} else { /* oclass OC_EC_4P2G1 */
+		get_killing_rank_by_oid(arg, oid, 4, 0, kill_ranks, NULL);
+		rebuild_pools_ranks(&arg, 1, &kill_ranks[2], 2, false);
 	}
 
 	if (write_type == PARTIAL_UPDATE)
@@ -99,6 +100,96 @@ rebuild_ec_internal(void **state, uint16_t oclass, int kill_data_nr,
 
 	reintegrate_pools_ranks(&arg, 1, kill_ranks, kill_ranks_num);
 #endif
+}
+
+#define CELL_SIZE	1048576
+
+static void
+rebuild_mixed_stripes(void **state)
+{
+	test_arg_t	*arg = *state;
+	daos_obj_id_t	oid;
+	struct ioreq	req;
+	char		*data;
+	char		*verify_data;
+	daos_recx_t	recxs[5];
+	d_rank_t	rank = 0;
+	int		size = 8 * 1048576 + 10000;
+
+	if (!test_runable(arg, 7))
+		return;
+
+	oid = dts_oid_gen(OC_EC_4P2G1, 0, arg->myrank);
+	ioreq_init(&req, arg->coh, oid, DAOS_IOD_ARRAY, arg);
+
+	recxs[0].rx_idx = 0;		/* full stripe */
+	recxs[0].rx_nr = 4 * CELL_SIZE;
+
+	recxs[1].rx_idx = 5 * CELL_SIZE; /* partial stripe */
+	recxs[1].rx_nr = 2000;
+
+	recxs[2].rx_idx = 8 * CELL_SIZE;	/* full stripe */
+	recxs[2].rx_nr = 4 * 1048576;
+
+	recxs[3].rx_idx = 12 * 1048576;	/* partial stripe */
+	recxs[3].rx_nr = 5000;
+
+	recxs[4].rx_idx = 16 * 1048576 - 3000;	/* partial stripe */
+	recxs[4].rx_nr = 3000;
+
+	data = (char *)malloc(size);
+	verify_data = (char *)malloc(size);
+	make_buffer(data, 'a', size);
+	make_buffer(verify_data, 'a', size);
+
+	req.iod_type = DAOS_IOD_ARRAY;
+	insert_recxs("d_key", "a_key", 1, DAOS_TX_NONE, recxs, 5,
+		     data, size, &req);
+
+	rank = get_rank_by_oid_shard(arg, oid, 0);
+	rebuild_pools_ranks(&arg, 1, &rank, 1, false);
+
+	memset(data, 0, size);
+	lookup_recxs("d_key", "a_key", 1, DAOS_TX_NONE, recxs, 5,
+		     data, size, &req);
+	assert_memory_equal(data, verify_data, size);
+
+	ioreq_fini(&req);
+
+	reintegrate_pools_ranks(&arg, 1, &rank, 1);
+}
+
+static int
+rebuild_ec_setup(void  **state, int number)
+{
+	test_arg_t	*arg;
+	int		rc;
+
+	save_group_state(state);
+	rc = test_setup(state, SETUP_CONT_CONNECT, true,
+			REBUILD_SMALL_POOL_SIZE, number, NULL);
+	if (rc)
+		return rc;
+
+	arg = *state;
+	if (dt_obj_class != DAOS_OC_UNKNOWN)
+		arg->obj_class = dt_obj_class;
+	else
+		arg->obj_class = DAOS_OC_R3S_SPEC_RANK;
+
+	return rc;
+}
+
+static int
+rebuild_ec_4nodes_setup(void **state)
+{
+	return rebuild_ec_setup(state, 4);
+}
+
+static int
+rebuild_ec_8nodes_setup(void **state)
+{
+	return rebuild_ec_setup(state, 8);
 }
 
 static void
@@ -179,99 +270,232 @@ rebuild2p_partial_fail_2parity(void **state)
 	rebuild_ec_internal(state, OC_EC_4P2G1, 0, 2, FULL_UPDATE);
 }
 
-#define CELL_SIZE	1048576
+static void
+rebuild_dfs_fail_data_s0(void **state)
+{
+	int shard = 0;
+
+	dfs_ec_rebuild_io(state, &shard, 1);
+}
 
 static void
-rebuild_mixed_stripes(void **state)
+rebuild_dfs_fail_data_s1(void **state)
 {
-	test_arg_t	*arg = *state;
-	daos_obj_id_t	oid;
-	struct ioreq	req;
-	char		*data;
-	char		*verify_data;
-	daos_recx_t	recxs[5];
-	d_rank_t	rank = 0;
-	int		size = 8 * 1048576 + 10000;
+	int shard = 1;
 
-	if (!test_runable(arg, 7))
-		return;
+	dfs_ec_rebuild_io(state, &shard, 1);
+}
 
-	oid = dts_oid_gen(OC_EC_4P2G1, 0, arg->myrank);
-	ioreq_init(&req, arg->coh, oid, DAOS_IOD_ARRAY, arg);
+static void
+rebuild_dfs_fail_data_s3(void **state)
+{
+	int shard = 3;
 
-	recxs[0].rx_idx = 0;		/* full stripe */
-	recxs[0].rx_nr = 4 * CELL_SIZE;
+	dfs_ec_rebuild_io(state, &shard, 1);
+}
 
-	recxs[1].rx_idx = 5 * CELL_SIZE; /* partial stripe */
-	recxs[1].rx_nr = 2000;
+static void
+rebuild_dfs_fail_2data_s0s1(void **state)
+{
+	int shards[2];
 
-	recxs[2].rx_idx = 8 * CELL_SIZE;	/* full stripe */
-	recxs[2].rx_nr = 4 * 1048576;
+	shards[0] = 0;
+	shards[1] = 1;
+	dfs_ec_rebuild_io(state, shards, 2);
+}
 
-	recxs[3].rx_idx = 12 * 1048576;	/* partial stripe */
-	recxs[3].rx_nr = 5000;
+static void
+rebuild_dfs_fail_2data_s0s2(void **state)
+{
+	int shards[2];
 
-	recxs[4].rx_idx = 16 * 1048576 - 3000;	/* partial stripe */
-	recxs[4].rx_nr = 3000;
+	shards[0] = 0;
+	shards[1] = 2;
+	dfs_ec_rebuild_io(state, shards, 2);
+}
 
-	data = (char *)malloc(size);
-	verify_data = (char *)malloc(size);
-	make_buffer(data, 'a', size);
-	make_buffer(verify_data, 'a', size);
+static void
+rebuild_dfs_fail_2data_s0s3(void **state)
+{
+	int shards[2];
 
-	req.iod_type = DAOS_IOD_ARRAY;
-	insert_recxs("d_key", "a_key", 1, DAOS_TX_NONE, recxs, 5,
-		     data, size, &req);
+	shards[0] = 0;
+	shards[1] = 3;
+	dfs_ec_rebuild_io(state, shards, 2);
+}
 
-	rank = get_rank_by_oid_shard(arg, oid, 0);
-	rebuild_pools_ranks(&arg, 1, &rank, 1, false);
+static void
+rebuild_dfs_fail_2data_s1s2(void **state)
+{
+	int shards[2];
 
-	memset(data, 0, size);
-	lookup_recxs("d_key", "a_key", 1, DAOS_TX_NONE, recxs, 5,
-		     data, size, &req);
-	assert_memory_equal(data, verify_data, size);
+	shards[0] = 1;
+	shards[1] = 2;
+	dfs_ec_rebuild_io(state, shards, 2);
+}
 
-	ioreq_fini(&req);
+static void
+rebuild_dfs_fail_2data_s1s3(void **state)
+{
+	int shards[2];
 
-	reintegrate_pools_ranks(&arg, 1, &rank, 1);
+	shards[0] = 1;
+	shards[1] = 3;
+	dfs_ec_rebuild_io(state, shards, 2);
+}
+
+static void
+rebuild_dfs_fail_2data_s2s3(void **state)
+{
+	int shards[2];
+
+	shards[0] = 2;
+	shards[1] = 3;
+	dfs_ec_rebuild_io(state, shards, 2);
+}
+
+static void
+rebuild_dfs_fail_data_parity_s0p1(void **state)
+{
+	int shards[2];
+
+	shards[0] = 0;
+	shards[1] = 5;
+	dfs_ec_rebuild_io(state, shards, 2);
+}
+
+static void
+rebuild_dfs_fail_data_parity_s3p1(void **state)
+{
+	int shards[2];
+
+	shards[0] = 3;
+	shards[1] = 5;
+	dfs_ec_rebuild_io(state, shards, 2);
+}
+
+static void
+rebuild_dfs_fail_data_parity_s2p1(void **state)
+{
+	int shards[2];
+
+	shards[0] = 2;
+	shards[1] = 5;
+	dfs_ec_rebuild_io(state, shards, 2);
+}
+
+static void
+rebuild_dfs_fail_data_parity_s0p0(void **state)
+{
+	int shards[2];
+
+	shards[0] = 0;
+	shards[1] = 4;
+	dfs_ec_rebuild_io(state, shards, 2);
+}
+
+static void
+rebuild_dfs_fail_data_parity_s2p0(void **state)
+{
+	int shards[2];
+
+	shards[0] = 2;
+	shards[1] = 4;
+	dfs_ec_rebuild_io(state, shards, 2);
+}
+
+static void
+rebuild_dfs_fail_data_parity_s3p0(void **state)
+{
+	int shards[2];
+
+	shards[0] = 3;
+	shards[1] = 4;
+	dfs_ec_rebuild_io(state, shards, 2);
 }
 
 /** create a new pool/container for each test */
 static const struct CMUnitTest rebuild_tests[] = {
 	{"REBUILD0: rebuild partial update with data tgt fail",
-	 rebuild_partial_fail_data, rebuild_small_sub_setup, test_teardown},
+	 rebuild_partial_fail_data, rebuild_ec_4nodes_setup, test_teardown},
 	{"REBUILD1: rebuild partial update with parity tgt fail",
-	 rebuild_partial_fail_parity, rebuild_small_sub_setup, test_teardown},
+	 rebuild_partial_fail_parity, rebuild_ec_4nodes_setup, test_teardown},
 	{"REBUILD2: rebuild full stripe update with data tgt fail",
-	 rebuild_full_fail_data, rebuild_small_sub_setup, test_teardown},
+	 rebuild_full_fail_data, rebuild_ec_4nodes_setup, test_teardown},
 	{"REBUILD3: rebuild full stripe update with parity tgt fail",
-	 rebuild_full_fail_parity, rebuild_small_sub_setup, test_teardown},
+	 rebuild_full_fail_parity, rebuild_ec_4nodes_setup, test_teardown},
 	{"REBUILD4: rebuild full then partial update with data tgt fail",
-	 rebuild_full_partial_fail_data, rebuild_small_sub_setup,
+	 rebuild_full_partial_fail_data, rebuild_ec_4nodes_setup,
 	 test_teardown},
 	{"REBUILD5: rebuild full then partial update with parity tgt fail",
-	 rebuild_full_partial_fail_parity, rebuild_small_sub_setup,
+	 rebuild_full_partial_fail_parity, rebuild_ec_4nodes_setup,
 	 test_teardown},
 	{"REBUILD6: rebuild partial then full update with data tgt fail",
-	 rebuild_partial_full_fail_data, rebuild_small_sub_setup,
+	 rebuild_partial_full_fail_data, rebuild_ec_4nodes_setup,
 	 test_teardown},
 	{"REBUILD7: rebuild partial then full update with parity tgt fail",
-	 rebuild_partial_full_fail_parity, rebuild_small_sub_setup,
+	 rebuild_partial_full_fail_parity, rebuild_ec_4nodes_setup,
 	 test_teardown},
 	{"REBUILD8: rebuild2p partial update with data tgt fail ",
-	 rebuild2p_partial_fail_data, rebuild_small_sub_setup, test_teardown},
+	 rebuild2p_partial_fail_data, rebuild_ec_8nodes_setup, test_teardown},
 	{"REBUILD9: rebuild2p partial update with 2 data tgt fail ",
-	 rebuild2p_partial_fail_2data, rebuild_small_sub_setup, test_teardown},
+	 rebuild2p_partial_fail_2data, rebuild_ec_8nodes_setup, test_teardown},
 	{"REBUILD10: rebuild2p partial update with data/parity tgts fail ",
-	 rebuild2p_partial_fail_data_parity, rebuild_small_sub_setup,
+	 rebuild2p_partial_fail_data_parity, rebuild_ec_8nodes_setup,
 	 test_teardown},
 	{"REBUILD11: rebuild2p partial update with parity tgt fail",
-	 rebuild2p_partial_fail_parity, rebuild_small_sub_setup, test_teardown},
+	 rebuild2p_partial_fail_parity, rebuild_ec_8nodes_setup, test_teardown},
 	{"REBUILD12: rebuild2p partial update with 2 parity tgt fail",
-	 rebuild2p_partial_fail_2parity, rebuild_small_sub_setup,
+	 rebuild2p_partial_fail_2parity, rebuild_ec_8nodes_setup,
 	 test_teardown},
 	{"REBUILD13: rebuild with mixed partial/full stripe",
-	 rebuild_mixed_stripes, rebuild_small_sub_setup, test_teardown},
+	 rebuild_mixed_stripes, rebuild_ec_8nodes_setup, test_teardown},
+	{"REBUILD14: rebuild dfs io with data(s0) tgt fail ",
+	 rebuild_dfs_fail_data_s0, rebuild_ec_8nodes_setup,
+	 test_teardown},
+	{"REBUILD15: rebuild dfs io with data(s1) tgt fail ",
+	 rebuild_dfs_fail_data_s1, rebuild_ec_8nodes_setup,
+	 test_teardown},
+	{"REBUILD16: rebuild dfs io with data(s1) tgt fail ",
+	 rebuild_dfs_fail_data_s3, rebuild_ec_8nodes_setup,
+	 test_teardown},
+	{"REBUILD17: rebuild dfs io with data(s0, s1) tgt fail ",
+	 rebuild_dfs_fail_2data_s0s1, rebuild_ec_8nodes_setup,
+	 test_teardown},
+	{"REBUILD18: rebuild dfs io with data(s0, s2) tgt fail ",
+	 rebuild_dfs_fail_2data_s0s2, rebuild_ec_8nodes_setup,
+	 test_teardown},
+	{"REBUILD19: rebuild dfs io with data(s0, s3) tgt fail ",
+	 rebuild_dfs_fail_2data_s0s3, rebuild_ec_8nodes_setup,
+	 test_teardown},
+	{"REBUILD20: rebuild dfs io with data(s1, s2) tgt fail ",
+	 rebuild_dfs_fail_2data_s1s2, rebuild_ec_8nodes_setup,
+	 test_teardown},
+	{"REBUILD21: rebuild dfs io with data(s1, s3) tgt fail ",
+	 rebuild_dfs_fail_2data_s1s3, rebuild_ec_8nodes_setup,
+	 test_teardown},
+	{"REBUILD22: rebuild dfs io with data(s2, s3) tgt fail ",
+	 rebuild_dfs_fail_2data_s2s3, rebuild_ec_8nodes_setup,
+	 test_teardown},
+	{"REBUILD23: rebuild dfs io with 1data 1parity(s0, p1)",
+	 rebuild_dfs_fail_data_parity_s0p1, rebuild_ec_8nodes_setup,
+	 test_teardown},
+	{"REBUILD24: rebuild dfs io with 1data 1parity(s3, p1)",
+	 rebuild_dfs_fail_data_parity_s3p1, rebuild_ec_8nodes_setup,
+	 test_teardown},
+	{"REBUILD25: rebuild dfs io with 1data 1parity(s2, p1)",
+	 rebuild_dfs_fail_data_parity_s2p1, rebuild_ec_8nodes_setup,
+	 test_teardown},
+	{"REBUILD26: rebuild dfs io with 1data 1parity(s0, p0)",
+	 rebuild_dfs_fail_data_parity_s0p0, rebuild_ec_8nodes_setup,
+	 test_teardown},
+	{"REBUILD27: rebuild dfs io with 1data 1parity(s3, p0)",
+	 rebuild_dfs_fail_data_parity_s3p0, rebuild_ec_8nodes_setup,
+	 test_teardown},
+	{"REBUILD28: rebuild dfs io with 1data 1parity(s2, p0)",
+	 rebuild_dfs_fail_data_parity_s2p0, rebuild_ec_8nodes_setup,
+	 test_teardown},
+
 };
 
 int

--- a/src/tests/suite/daos_rebuild_simple.c
+++ b/src/tests/suite/daos_rebuild_simple.c
@@ -42,8 +42,6 @@
 #define OBJ_REPLICAS	3
 #define DEFAULT_FAIL_TGT 0
 #define REBUILD_POOL_SIZE	(4ULL << 30)
-#define REBUILD_SUBTEST_POOL_SIZE (1ULL << 30)
-#define REBUILD_SMALL_POOL_SIZE (1ULL << 28)
 
 #define DATA_SIZE	(1048576 * 2 + 512)
 static void

--- a/src/tests/suite/daos_test.h
+++ b/src/tests/suite/daos_test.h
@@ -233,6 +233,9 @@ enum {
 #define SMALL_POOL_SIZE		(1ULL << 30)	/* 1GB */
 #define DEFAULT_POOL_SIZE	(4ULL << 30)	/* 4GB */
 
+#define REBUILD_SUBTEST_POOL_SIZE (1ULL << 30)
+#define REBUILD_SMALL_POOL_SIZE (1ULL << 28)
+
 #define WAIT_ON_ASYNC_ERR(arg, ev, err)			\
 	do {						\
 		int _rc;				\
@@ -405,6 +408,8 @@ run_daos_sub_tests_only(char *test_name, const struct CMUnitTest *tests,
 void rebuild_io(test_arg_t *arg, daos_obj_id_t *oids, int oids_nr);
 void rebuild_io_validate(test_arg_t *arg, daos_obj_id_t *oids, int oids_nr,
 			 bool discard);
+void dfs_ec_rebuild_io(void **state, int *shards, int shards_nr);
+
 void rebuild_single_pool_target(test_arg_t *arg, d_rank_t failed_rank,
 				int failed_tgt, bool kill);
 void rebuild_single_pool_rank(test_arg_t *arg, d_rank_t failed_rank, bool kill);
@@ -446,6 +451,7 @@ int wait_and_verify_blobstore_state(uuid_t bs_uuid, char *expected_state,
 				    const char *group);
 int wait_and_verify_pool_tgt_state(daos_handle_t poh, int tgtidx, int rank,
 				   char *expected_state);
+void save_group_state(void **state);
 
 enum op_type {
 	PARTIAL_UPDATE	=	1,


### PR DESCRIPTION
1. Upgrade DAOS EC rebuild tests to include DFS tests.

2. Kill more nodes after rebuild ec to verify parity rebuild.

Signed-off-by: Di Wang <di.wang@intel.com>