### PR TITLE
DAOS-6225 control: Parse server access_points as hostlist

### DIFF
--- a/src/control/cmd/daos_agent/main.go
+++ b/src/control/cmd/daos_agent/main.go
@@ -241,7 +241,7 @@ func parseOpts(args []string, opts *cliOptions, invoker control.Invoker, log *lo
 		}
 
 		var err error
-		if cfg.AccessPoints, err = control.ParseHostList(cfg.AccessPoints, cfg.ControlPort); err != nil {
+		if cfg.AccessPoints, err = common.ParseHostList(cfg.AccessPoints, cfg.ControlPort); err != nil {
 			return errors.Wrap(err, "Failed to parse config access_points")
 		}
 

--- a/src/control/common/net_utils.go
+++ b/src/control/common/net_utils.go
@@ -29,8 +29,10 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/daos-stack/daos/src/control/build"
 	"github.com/pkg/errors"
+
+	"github.com/daos-stack/daos/src/control/build"
+	"github.com/daos-stack/daos/src/control/lib/hostlist"
 )
 
 // HasPort checks if addr specifies a port. This only works with IPv4
@@ -107,4 +109,38 @@ func LocalhostCtrlAddr() *net.TCPAddr {
 		IP:   net.IPv4(127, 0, 0, 1),
 		Port: build.DefaultControlPort,
 	}
+}
+
+// ParseHostList validates and deduplicates the given list of host
+// strings. Any hosts missing a port will have one added according
+// to the defaultPort parameter.
+func ParseHostList(in []string, defaultPort int) (out []string, err error) {
+	if len(in) == 0 {
+		return
+	}
+
+	var set *hostlist.HostSet
+	set, err = hostlist.CreateSet(strings.Join(in, ","))
+	if err != nil {
+		return nil, err
+	}
+	out = strings.Split(set.DerangedString(), ",")
+
+	for i, host := range out {
+		hostPort := strings.Split(host, ":")
+		switch len(hostPort) {
+		case 1:
+			out[i] = fmt.Sprintf("%s:%d", host, defaultPort)
+		case 2:
+			_, err = strconv.Atoi(hostPort[1])
+		default:
+			err = errors.New("host should conform to hostname[:port]")
+		}
+
+		if err != nil {
+			return nil, errors.Wrapf(err, "invalid host %q", host)
+		}
+	}
+
+	return
 }

--- a/src/control/common/net_utils_test.go
+++ b/src/control/common/net_utils_test.go
@@ -24,10 +24,12 @@
 package common
 
 import (
+	"fmt"
 	"net"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/pkg/errors"
 )
 
 func TestUtils_HasPort(t *testing.T) {
@@ -149,4 +151,73 @@ func TestCommon_IsLocalAddr(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestCommon_ParseHostList(t *testing.T) {
+	testPort := 12345
+
+	mockHostList := func(hosts ...string) []string {
+		return hosts
+	}
+
+	for name, tc := range map[string]struct {
+		in     []string
+		expOut []string
+		expErr error
+	}{
+		"nil in, nil out": {},
+		"empty in, nil out": {
+			in: []string{},
+		},
+		"host with too many :": {
+			in:     mockHostList("foo::10"),
+			expErr: errors.New("invalid host"),
+		},
+		"host with non-numeric port": {
+			in:     mockHostList("foo:bar"),
+			expErr: errors.New("invalid host"),
+		},
+		"host with just a port": {
+			in:     mockHostList(":42"),
+			expErr: errors.New("invalid host"),
+		},
+		"should append missing port": {
+			in:     mockHostList("foo"),
+			expOut: mockHostList(fmt.Sprintf("foo:%d", testPort)),
+		},
+		"should append missing port (multiple)": {
+			in: mockHostList("foo", "bar:4242", "baz"),
+			expOut: mockHostList(
+				"bar:4242",
+				fmt.Sprintf("baz:%d", testPort),
+				fmt.Sprintf("foo:%d", testPort),
+			),
+		},
+		"should append missing port (ranges)": {
+			in: mockHostList("foo-[1-4]", "bar[2-4]", "baz[8-9]:4242"),
+			expOut: mockHostList(
+				fmt.Sprintf("bar2:%d", testPort),
+				fmt.Sprintf("bar3:%d", testPort),
+				fmt.Sprintf("bar4:%d", testPort),
+				"baz8:4242",
+				"baz9:4242",
+				fmt.Sprintf("foo-1:%d", testPort),
+				fmt.Sprintf("foo-2:%d", testPort),
+				fmt.Sprintf("foo-3:%d", testPort),
+				fmt.Sprintf("foo-4:%d", testPort),
+			),
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			gotOut, gotErr := ParseHostList(tc.in, testPort)
+			CmpErr(t, tc.expErr, gotErr)
+			if tc.expErr != nil {
+				return
+			}
+			if diff := cmp.Diff(tc.expOut, gotOut); diff != "" {
+				t.Fatalf("unexpected output (-want, +got):\n%s\n", diff)
+			}
+		})
+	}
+
 }

--- a/src/control/lib/control/hostlist.go
+++ b/src/control/lib/control/hostlist.go
@@ -23,45 +23,7 @@
 
 package control
 
-import (
-	"fmt"
-	"strconv"
-	"strings"
-
-	"github.com/pkg/errors"
-
-	"github.com/daos-stack/daos/src/control/lib/hostlist"
-)
-
-// ParseHostList validates and deduplicates the given list of host
-// strings. Any hosts missing a port will have one added according
-// to the defaultPort parameter.
-func ParseHostList(in []string, defaultPort int) (out []string, err error) {
-	var set *hostlist.HostSet
-	set, err = hostlist.CreateSet(strings.Join(in, ","))
-	if err != nil {
-		return nil, err
-	}
-	out = strings.Split(set.DerangedString(), ",")
-
-	for i, host := range out {
-		hostPort := strings.Split(host, ":")
-		switch len(hostPort) {
-		case 1:
-			out[i] = fmt.Sprintf("%s:%d", host, defaultPort)
-		case 2:
-			_, err = strconv.Atoi(hostPort[1])
-		default:
-			err = errors.New("host should conform to hostname[:port]")
-		}
-
-		if err != nil {
-			return nil, errors.Wrapf(err, "invalid host %q", host)
-		}
-	}
-
-	return
-}
+import "github.com/daos-stack/daos/src/control/common"
 
 // getRequestHosts returns a list of control plane addresses for
 // the request. The logic for determining the list is as follows:
@@ -93,7 +55,7 @@ func getRequestHosts(cfg *Config, req targetChooser) (hosts []string, err error)
 		return nil, FaultConfigBadControlPort
 	}
 
-	hosts, err = ParseHostList(hosts, cfg.ControlPort)
+	hosts, err = common.ParseHostList(hosts, cfg.ControlPort)
 	if err != nil {
 		return nil, err
 	}

--- a/src/control/lib/control/hostlist_test.go
+++ b/src/control/lib/control/hostlist_test.go
@@ -54,67 +54,6 @@ func mockHostList(hosts ...string) []string {
 	return hosts
 }
 
-func TestControl_ParseHostList(t *testing.T) {
-	defaultCfg := DefaultConfig()
-
-	for name, tc := range map[string]struct {
-		in     []string
-		expOut []string
-		expErr error
-	}{
-		"host with too many :": {
-			in:     mockHostList("foo::10"),
-			expErr: errors.New("invalid host"),
-		},
-		"host with non-numeric port": {
-			in:     mockHostList("foo:bar"),
-			expErr: errors.New("invalid host"),
-		},
-		"host with just a port": {
-			in:     mockHostList(":42"),
-			expErr: errors.New("invalid host"),
-		},
-		"should append missing port": {
-			in:     mockHostList("foo"),
-			expOut: mockHostList(fmt.Sprintf("foo:%d", defaultCfg.ControlPort)),
-		},
-		"should append missing port (multiple)": {
-			in: mockHostList("foo", "bar:4242", "baz"),
-			expOut: mockHostList(
-				"bar:4242",
-				fmt.Sprintf("baz:%d", defaultCfg.ControlPort),
-				fmt.Sprintf("foo:%d", defaultCfg.ControlPort),
-			),
-		},
-		"should append missing port (ranges)": {
-			in: mockHostList("foo-[1-4]", "bar[2-4]", "baz[8-9]:4242"),
-			expOut: mockHostList(
-				fmt.Sprintf("bar2:%d", defaultCfg.ControlPort),
-				fmt.Sprintf("bar3:%d", defaultCfg.ControlPort),
-				fmt.Sprintf("bar4:%d", defaultCfg.ControlPort),
-				"baz8:4242",
-				"baz9:4242",
-				fmt.Sprintf("foo-1:%d", defaultCfg.ControlPort),
-				fmt.Sprintf("foo-2:%d", defaultCfg.ControlPort),
-				fmt.Sprintf("foo-3:%d", defaultCfg.ControlPort),
-				fmt.Sprintf("foo-4:%d", defaultCfg.ControlPort),
-			),
-		},
-	} {
-		t.Run(name, func(t *testing.T) {
-			gotOut, gotErr := ParseHostList(tc.in, defaultCfg.ControlPort)
-			common.CmpErr(t, tc.expErr, gotErr)
-			if tc.expErr != nil {
-				return
-			}
-			if diff := cmp.Diff(tc.expOut, gotOut); diff != "" {
-				t.Fatalf("unexpected output (-want, +got):\n%s\n", diff)
-			}
-		})
-	}
-
-}
-
 func TestControl_getRequestHosts(t *testing.T) {
 	defaultCfg := DefaultConfig()
 	defaultCfg.HostList = mockHostList("a", "b", "c")

--- a/src/control/server/config/server_test.go
+++ b/src/control/server/config/server_test.go
@@ -327,6 +327,12 @@ func TestServer_ConfigValidation(t *testing.T) {
 			},
 			nil,
 		},
+		"multiple access points (dupes)": {
+			func(c *Server) *Server {
+				return c.WithAccessPoints("1.2.3.4:1234", "5.6.7.8:5678", "1.2.3.4:1234")
+			},
+			FaultConfigEvenAccessPoints,
+		},
 		"no access points": {
 			func(c *Server) *Server {
 				return c.WithAccessPoints()


### PR DESCRIPTION
Dedupe and normalize before further validation in order
to ensure that the access_points list contains a set of
distinct and valid entries.