### PR TITLE
DAOS-6310 rebuild: skip uncommitted DTX for rebuild scan

### DIFF
--- a/src/dtx/dtx_common.c
+++ b/src/dtx/dtx_common.c
@@ -325,7 +325,7 @@ dtx_handle_init(struct dtx_id *dti, daos_handle_t coh, struct dtx_epoch *epoch,
 		daos_unit_oid_t *leader_oid, struct dtx_id *dti_cos,
 		int dti_cos_cnt, struct dtx_memberships *mbs, bool leader,
 		bool solo, bool sync, bool dist, bool migration,
-		struct dtx_handle *dth)
+		bool ignore_uncommitted, struct dtx_handle *dth)
 {
 	if (sub_modification_cnt > DTX_SUB_MOD_MAX) {
 		D_ERROR("Too many modifications in a single transaction:"
@@ -353,6 +353,7 @@ dtx_handle_init(struct dtx_id *dti, daos_handle_t coh, struct dtx_epoch *epoch,
 	dth->dth_local_retry = 0;
 	dth->dth_dist = dist ? 1 : 0;
 	dth->dth_for_migration = migration ? 1 : 0;
+	dth->dth_ignore_uncommitted = ignore_uncommitted ? 1 : 0;
 
 	dth->dth_dti_cos = dti_cos;
 	dth->dth_dti_cos_count = dti_cos_cnt;
@@ -545,7 +546,7 @@ out:
 /**
  * Prepare the leader DTX handle in DRAM.
  *
- * \param cont		[IN]	Pointer to the container.
+ * \param coh		[IN]	Container handle.
  * \param dti		[IN]	The DTX identifier.
  * \param epoch		[IN]	Epoch for the DTX.
  * \param sub_modification_cnt
@@ -563,7 +564,7 @@ out:
  * \return			Zero on success, negative value if error.
  */
 int
-dtx_leader_begin(struct ds_cont_child *cont, struct dtx_id *dti,
+dtx_leader_begin(daos_handle_t coh, struct dtx_id *dti,
 		 struct dtx_epoch *epoch, uint16_t sub_modification_cnt,
 		 uint32_t pm_ver, daos_unit_oid_t *leader_oid,
 		 struct dtx_id *dti_cos, int dti_cos_cnt,
@@ -587,12 +588,13 @@ dtx_leader_begin(struct ds_cont_child *cont, struct dtx_id *dti,
 		dlh->dlh_sub_cnt = tgt_cnt;
 	}
 
-	rc = dtx_handle_init(dti, cont->sc_hdl, epoch, sub_modification_cnt,
-			     pm_ver, leader_oid, dti_cos, dti_cos_cnt, mbs,
-			     true, (flags & DTX_SOLO) ? true : false,
+	rc = dtx_handle_init(dti, coh, epoch, sub_modification_cnt, pm_ver,
+			     leader_oid, dti_cos, dti_cos_cnt, mbs, true,
+			     (flags & DTX_SOLO) ? true : false,
 			     (flags & DTX_SYNC) ? true : false,
 			     (flags & DTX_DIST) ? true : false,
-			     (flags & DTX_FOR_MIGRATION) ? true : false, dth);
+			     (flags & DTX_FOR_MIGRATION) ? true : false,
+			     false, dth);
 
 	/* XXX: For non-solo DTX, the leader and non-leader will make each own
 	 *	local modification in parallel. If the non-leader goes so fast
@@ -871,7 +873,7 @@ out:
 /**
  * Prepare the DTX handle in DRAM.
  *
- * \param cont		[IN]	Pointer to the container.
+ * \param coh		[IN]	Container handle.
  * \param dti		[IN]	The DTX identifier.
  * \param epoch		[IN]	Epoch for the DTX.
  * \param sub_modification_cnt
@@ -887,7 +889,7 @@ out:
  * \return			Zero on success, negative value if error.
  */
 int
-dtx_begin(struct ds_cont_child *cont, struct dtx_id *dti,
+dtx_begin(daos_handle_t coh, struct dtx_id *dti,
 	  struct dtx_epoch *epoch, uint16_t sub_modification_cnt,
 	  uint32_t pm_ver, daos_unit_oid_t *leader_oid,
 	  struct dtx_id *dti_cos, int dti_cos_cnt, uint32_t flags,
@@ -895,11 +897,13 @@ dtx_begin(struct ds_cont_child *cont, struct dtx_id *dti,
 {
 	int	rc;
 
-	rc = dtx_handle_init(dti, cont->sc_hdl, epoch, sub_modification_cnt,
+	rc = dtx_handle_init(dti, coh, epoch, sub_modification_cnt,
 			     pm_ver, leader_oid, dti_cos, dti_cos_cnt, mbs,
 			     false, false, false,
 			     (flags & DTX_DIST) ? true : false,
-			     (flags & DTX_FOR_MIGRATION) ? true : false, dth);
+			     (flags & DTX_FOR_MIGRATION) ? true : false,
+			     (flags & DTX_IGNORE_UNCOMMITTED) ? true : false,
+			     dth);
 
 	D_DEBUG(DB_IO, "Start DTX "DF_DTI" sub modification %d, ver %u, "
 		"dti_cos_cnt %d, flags %x: "DF_RC"\n",

--- a/src/include/daos_srv/dtx_srv.h
+++ b/src/include/daos_srv/dtx_srv.h
@@ -93,7 +93,9 @@ struct dtx_handle {
 					 /* Distributed transaction. */
 					 dth_dist:1,
 					 /* For data migration. */
-					 dth_for_migration:1;
+					 dth_for_migration:1,
+					 /* Ignore other uncommitted DTXs. */
+					 dth_ignore_uncommitted:1;
 
 	/* The count the DTXs in the dth_dti_cos array. */
 	uint32_t			 dth_dti_cos_count;
@@ -193,12 +195,14 @@ enum dtx_flags {
 	DTX_DIST		= (1 << 2),
 	/** For data migration. */
 	DTX_FOR_MIGRATION	= (1 << 3),
+	/** Ignore other uncommitted DTXs. */
+	DTX_IGNORE_UNCOMMITTED	= (1 << 4),
 };
 
 int
 dtx_sub_init(struct dtx_handle *dth, daos_unit_oid_t *oid, uint64_t dkey_hash);
 int
-dtx_leader_begin(struct ds_cont_child *cont, struct dtx_id *dti,
+dtx_leader_begin(daos_handle_t coh, struct dtx_id *dti,
 		 struct dtx_epoch *epoch, uint16_t sub_modification_cnt,
 		 uint32_t pm_ver, daos_unit_oid_t *leader_oid,
 		 struct dtx_id *dti_cos, int dti_cos_cnt,
@@ -214,7 +218,7 @@ typedef int (*dtx_sub_func_t)(struct dtx_leader_handle *dlh, void *arg, int idx,
 			      dtx_sub_comp_cb_t comp_cb);
 
 int
-dtx_begin(struct ds_cont_child *cont, struct dtx_id *dti,
+dtx_begin(daos_handle_t coh, struct dtx_id *dti,
 	  struct dtx_epoch *epoch, uint16_t sub_modification_cnt,
 	  uint32_t pm_ver, daos_unit_oid_t *leader_oid,
 	  struct dtx_id *dti_cos, int dti_cos_cnt, uint32_t flags,

--- a/src/object/srv_obj.c
+++ b/src/object/srv_obj.c
@@ -1867,7 +1867,7 @@ ds_obj_tgt_update_handler(crt_rpc_t *rpc)
 	epoch.oe_first = orw->orw_epoch_first;
 	epoch.oe_flags = orf_to_dtx_epoch_flags(orw->orw_flags);
 
-	rc = dtx_begin(ioc.ioc_coc, &orw->orw_dti, &epoch, 1,
+	rc = dtx_begin(ioc.ioc_coc->sc_hdl, &orw->orw_dti, &epoch, 1,
 		       orw->orw_map_ver, &orw->orw_oid,
 		       orw->orw_dti_cos.ca_arrays,
 		       orw->orw_dti_cos.ca_count,
@@ -2033,7 +2033,7 @@ ds_obj_rw_handler(crt_rpc_t *rpc)
 			dtx_flags = DTX_FOR_MIGRATION;
 
 re_fetch:
-		rc = dtx_begin(ioc.ioc_coc, &orw->orw_dti, &epoch, 0,
+		rc = dtx_begin(ioc.ioc_coc->sc_hdl, &orw->orw_dti, &epoch, 0,
 			       orw->orw_map_ver, &orw->orw_oid,
 			       NULL, 0, dtx_flags, NULL, &dth);
 		if (rc != 0)
@@ -2155,8 +2155,8 @@ again:
 	 * the RPC to other replicas.
 	 */
 
-	rc = dtx_leader_begin(ioc.ioc_coc, &orw->orw_dti, &epoch, 1, version,
-			      &orw->orw_oid, dti_cos, dti_cos_cnt,
+	rc = dtx_leader_begin(ioc.ioc_coc->sc_hdl, &orw->orw_dti, &epoch, 1,
+			      version, &orw->orw_oid, dti_cos, dti_cos_cnt,
 			      tgts, tgt_cnt, dtx_flags, mbs, &dlh);
 	if (rc != 0) {
 		D_ERROR(DF_UOID": Failed to start DTX for update "DF_RC".\n",
@@ -2425,8 +2425,9 @@ obj_local_enum(struct obj_io_context *ioc, crt_rpc_t *rpc,
 		flags = DTX_FOR_MIGRATION;
 
 again:
-	rc = dtx_begin(ioc->ioc_coc, &oei->oei_dti, &epoch, 0, oei->oei_map_ver,
-		       &oei->oei_oid, NULL, 0, flags, NULL, &dth);
+	rc = dtx_begin(ioc->ioc_coc->sc_hdl, &oei->oei_dti, &epoch, 0,
+		       oei->oei_map_ver, &oei->oei_oid, NULL, 0, flags,
+		       NULL, &dth);
 	if (rc != 0)
 		goto failed;
 
@@ -2790,7 +2791,7 @@ ds_obj_tgt_punch_handler(crt_rpc_t *rpc)
 	epoch.oe_flags = orf_to_dtx_epoch_flags(opi->opi_flags);
 
 	/* Start the local transaction */
-	rc = dtx_begin(ioc.ioc_coc, &opi->opi_dti, &epoch, 1,
+	rc = dtx_begin(ioc.ioc_coc->sc_hdl, &opi->opi_dti, &epoch, 1,
 		       opi->opi_map_ver, &opi->opi_oid,
 		       opi->opi_dti_cos.ca_arrays,
 		       opi->opi_dti_cos.ca_count,
@@ -3016,8 +3017,8 @@ again:
 	 * the RPC to other replicas.
 	 */
 
-	rc = dtx_leader_begin(ioc.ioc_coc, &opi->opi_dti, &epoch, 1, version,
-			      &opi->opi_oid, dti_cos, dti_cos_cnt,
+	rc = dtx_leader_begin(ioc.ioc_coc->sc_hdl, &opi->opi_dti, &epoch, 1,
+			      version, &opi->opi_oid, dti_cos, dti_cos_cnt,
 			      tgts, tgt_cnt, dtx_flags, mbs, &dlh);
 	if (rc != 0) {
 		D_ERROR(DF_UOID": Failed to start DTX for punch "DF_RC".\n",
@@ -3120,7 +3121,7 @@ again:
 	epoch.oe_first = okqi->okqi_epoch_first;
 	epoch.oe_flags = orf_to_dtx_epoch_flags(okqi->okqi_flags);
 
-	rc = dtx_begin(ioc.ioc_coc, &okqi->okqi_dti, &epoch, 0,
+	rc = dtx_begin(ioc.ioc_coc->sc_hdl, &okqi->okqi_dti, &epoch, 0,
 		       okqi->okqi_map_ver, &okqi->okqi_oid, NULL, 0, 0, NULL,
 		       &dth);
 	if (rc != 0)
@@ -3784,7 +3785,7 @@ ds_obj_dtx_follower(crt_rpc_t *rpc, struct obj_io_context *ioc)
 	if (oci->oci_flags & ORF_DTX_SYNC)
 		dtx_flags |= DTX_SYNC;
 
-	rc = dtx_begin(ioc->ioc_coc, &dcsh->dcsh_xid, &dcsh->dcsh_epoch,
+	rc = dtx_begin(ioc->ioc_coc->sc_hdl, &dcsh->dcsh_xid, &dcsh->dcsh_epoch,
 		       dcde->dcde_write_cnt, oci->oci_map_ver,
 		       &dcsh->dcsh_leader_oid, NULL, 0, dtx_flags,
 		       dcsh->dcsh_mbs, &dth);
@@ -4023,7 +4024,7 @@ ds_obj_dtx_leader_ult(void *arg)
 	if (tgt_cnt <= 1 && dcde->dcde_write_cnt <= 1)
 		dtx_flags |= DTX_SOLO;
 
-	rc = dtx_leader_begin(dca->dca_ioc->ioc_coc, &dcsh->dcsh_xid,
+	rc = dtx_leader_begin(dca->dca_ioc->ioc_coc->sc_hdl, &dcsh->dcsh_xid,
 			      &dcsh->dcsh_epoch, dcde->dcde_write_cnt,
 			      oci->oci_map_ver, &dcsh->dcsh_leader_oid,
 			      NULL, 0, tgts, tgt_cnt - 1, dtx_flags,

--- a/src/vos/tests/vts_dtx.c
+++ b/src/vos/tests/vts_dtx.c
@@ -80,6 +80,7 @@ vts_dtx_begin(const daos_unit_oid_t *oid, daos_handle_t coh, daos_epoch_t epoch,
 	dth->dth_active = 0;
 	dth->dth_dist = 0;
 	dth->dth_for_migration = 0;
+	dth->dth_ignore_uncommitted = 0;
 
 	dth->dth_dti_cos_count = 0;
 	dth->dth_dti_cos = NULL;

--- a/src/vos/vos_dtx.c
+++ b/src/vos/vos_dtx.c
@@ -1318,8 +1318,17 @@ vos_dtx_check_availability(daos_handle_t coh, uint32_t entry,
 	 * related leader.
 	 */
 
-	if (intent == DAOS_INTENT_DEFAULT || intent == DAOS_INTENT_MIGRATION ||
-	    intent == DAOS_INTENT_IGNORE_NONCOMMITTED) {
+	if (intent == DAOS_INTENT_IGNORE_NONCOMMITTED) {
+		/* For transactional read, has to wait the non-committed
+		 * modification to guarantee the transaction semantics.
+		 */
+		if (dtx_is_valid_handle(dth))
+			return dtx_inprogress(dae, dth, false, 2);
+
+		return ALB_UNAVAILABLE;
+	}
+
+	if (intent == DAOS_INTENT_DEFAULT || intent == DAOS_INTENT_MIGRATION) {
 		if (!(DAE_FLAGS(dae) & DTE_LEADER) ||
 		    DAOS_FAIL_CHECK(DAOS_VOS_NON_LEADER))
 			/* Non-leader or rebuild case, return -DER_INPROGRESS,
@@ -1330,8 +1339,7 @@ vos_dtx_check_availability(daos_handle_t coh, uint32_t entry,
 		/* For transactional read, has to wait the non-committed
 		 * modification to guarantee the transaction semantics.
 		 */
-		if (dtx_is_valid_handle(dth) &&
-		    intent != DAOS_INTENT_IGNORE_NONCOMMITTED)
+		if (dtx_is_valid_handle(dth))
 			return dtx_inprogress(dae, dth, false, 2);
 
 		/* For stand-alone read on leader, ignore non-committed DTX. */

--- a/src/vos/vos_internal.h
+++ b/src/vos/vos_internal.h
@@ -1044,10 +1044,10 @@ vos_iter_intent(struct vos_iterator *iter)
 {
 	if (iter->it_for_purge)
 		return DAOS_INTENT_PURGE;
-	if (iter->it_for_migration)
-		return DAOS_INTENT_MIGRATION;
 	if (iter->it_ignore_uncommitted)
 		return DAOS_INTENT_IGNORE_NONCOMMITTED;
+	if (iter->it_for_migration)
+		return DAOS_INTENT_MIGRATION;
 	return DAOS_INTENT_DEFAULT;
 }
 

--- a/src/vos/vos_iterator.c
+++ b/src/vos/vos_iterator.c
@@ -651,7 +651,10 @@ vos_iterate_internal(vos_iter_param_t *param, vos_iter_type_t type,
 	}
 
 	iter = vos_hdl2iter(ih);
-	iter->it_ignore_uncommitted = ignore_inprogress ? 1 : 0;
+	if (ignore_inprogress || (dth != NULL && dth->dth_ignore_uncommitted))
+		iter->it_ignore_uncommitted = 1;
+	else
+		iter->it_ignore_uncommitted = 0;
 	read_time = dtx_is_valid_handle(dth) ? dth->dth_epoch : 0 /* unused */;
 probe:
 	if (!daos_anchor_is_zero(anchor))


### PR DESCRIPTION
After DTX resync, rebuild logic will scan locally to find out which
objects need to be rebuilt on new target. At that time, if hit some
uncommitted DTX, then such DTX leader will be on other DAOS target.
Under such case, we will not return -DER_INPROGRESS to the rebuild
logic, instead, skip related object that will be handled by related
rebuild scan on the DAOS target that the DTX leader resides on.

Signed-off-by: Fan Yong <fan.yong@intel.com>