### PR TITLE
DAOS-6335 vos: Limit MVCC checks

### DIFF
--- a/src/include/daos/dtx.h
+++ b/src/include/daos/dtx.h
@@ -177,7 +177,7 @@ daos_dti_copy(struct dtx_id *des, const struct dtx_id *src)
 }
 
 static inline bool
-daos_is_zero_dti(struct dtx_id *dti)
+daos_is_zero_dti(const struct dtx_id *dti)
 {
 	return dti->dti_hlc == 0;
 }

--- a/src/include/daos_srv/dtx_srv.h
+++ b/src/include/daos_srv/dtx_srv.h
@@ -288,7 +288,7 @@ dtx_entry_put(struct dtx_entry *dte)
 }
 
 static inline bool
-dtx_is_valid_handle(struct dtx_handle *dth)
+dtx_is_valid_handle(const struct dtx_handle *dth)
 {
 	return dth != NULL && !daos_is_zero_dti(&dth->dth_xid);
 }

--- a/src/vos/tests/vts_io.c
+++ b/src/vos/tests/vts_io.c
@@ -2310,6 +2310,7 @@ io_query_key(void **state)
 	/* Only execute the transactional tests when rollback is available */
 
 	vts_dtx_begin(&oid, arg->ctx.tc_co_hdl, epoch++, 0, &dth);
+	dth->dth_dist = 1;
 
 	rc = vos_obj_query_key(arg->ctx.tc_co_hdl, oid, DAOS_GET_DKEY |
 			       DAOS_GET_MAX, 0 /* Ignored epoch */, &dkey_read,
@@ -2321,12 +2322,14 @@ io_query_key(void **state)
 
 	/* Now punch the object at earlier epoch */
 	vts_dtx_begin(&oid, arg->ctx.tc_co_hdl, epoch - 3, 0, &dth);
+	dth->dth_dist = 1;
 	rc = vos_obj_punch(arg->ctx.tc_co_hdl, oid, 0 /* ignored epoch */, 0, 0,
 			   NULL, 0, NULL, dth);
 	assert_int_equal(rc, -DER_TX_RESTART);
 	vts_dtx_end(dth);
 
 	vts_dtx_begin(&oid, arg->ctx.tc_co_hdl, epoch + 1, 0, &dth);
+	dth->dth_dist = 1;
 	/* Now punch the object */
 	rc = vos_obj_punch(arg->ctx.tc_co_hdl, oid, epoch++, 0, 0, NULL, 0,
 			   NULL, dth);

--- a/src/vos/tests/vts_mvcc.c
+++ b/src/vos/tests/vts_mvcc.c
@@ -236,6 +236,7 @@ start_tx(daos_handle_t coh, daos_unit_oid_t oid, daos_epoch_t epoch,
 	if (dth == NULL) {
 		vts_dtx_begin_ex(&oid, coh, epoch, txh->th_epoch_bound, 0,
 				 txh->th_nr_mods, &dth);
+		dth->dth_dist = 1;
 		txh->th_dth = dth;
 	}
 

--- a/src/vos/tests/vts_ts.c
+++ b/src/vos/tests/vts_ts.c
@@ -740,10 +740,7 @@ ts_test_init(void **state)
 	struct vos_ts_table	*ts_table;
 	struct ts_test_arg	*ts_arg;
 	int			 rc;
-	struct dtx_id		 xid = {0};
-
-	uuid_clear(xid.dti_uuid);
-	xid.dti_hlc = 1;
+	struct dtx_handle	 dth = {0};
 
 	D_ALLOC_PTR(ts_arg);
 	if (ts_arg == NULL)
@@ -758,7 +755,9 @@ ts_test_init(void **state)
 	for (i = 0; i < VOS_TS_TYPE_COUNT; i++)
 		ts_arg->ta_counts[i] = ts_table->tt_type_info[i].ti_count;
 
-	rc = vos_ts_set_allocate(&ts_arg->ta_ts_set, 0, 0, 1, &xid);
+	daos_dti_gen_unique(&dth.dth_xid);
+	dth.dth_dist = 1;
+	rc = vos_ts_set_allocate(&ts_arg->ta_ts_set, 0, 0, 1, &dth);
 	if (rc != 0) {
 		D_FREE(ts_arg);
 		return rc;

--- a/src/vos/vos_io.c
+++ b/src/vos/vos_io.c
@@ -536,8 +536,7 @@ vos_ioc_create(daos_handle_t coh, daos_unit_oid_t oid, bool read_only,
 	}
 
 	rc = vos_ts_set_allocate(&ioc->ic_ts_set, vos_flags, cflags, iod_nr,
-				 dtx_is_valid_handle(dth) ?
-				 &dth->dth_xid : NULL);
+				 dth);
 	if (rc != 0)
 		goto error;
 

--- a/src/vos/vos_iterator.c
+++ b/src/vos/vos_iterator.c
@@ -232,9 +232,7 @@ vos_iter_prepare(vos_iter_type_t type, vos_iter_param_t *param,
 		D_ASSERT(!dtx_is_valid_handle(dth));
 		break;
 	}
-	rc = vos_ts_set_allocate(&ts_set, 0, rlevel, 1 /* max akeys */,
-				 dtx_is_valid_handle(dth) ?
-				 &dth->dth_xid : NULL);
+	rc = vos_ts_set_allocate(&ts_set, 0, rlevel, 1 /* max akeys */, dth);
 	if (rc != 0)
 		goto out;
 

--- a/src/vos/vos_obj.c
+++ b/src/vos/vos_obj.c
@@ -349,9 +349,7 @@ vos_obj_punch(daos_handle_t coh, daos_unit_oid_t oid, daos_epoch_t epoch,
 
 	}
 
-	rc = vos_ts_set_allocate(&ts_set, flags, cflags, akey_nr,
-				 dtx_is_valid_handle(dth) ?
-				 &dth->dth_xid : NULL);
+	rc = vos_ts_set_allocate(&ts_set, flags, cflags, akey_nr, dth);
 	if (rc != 0)
 		goto reset;
 

--- a/src/vos/vos_query.c
+++ b/src/vos/vos_query.c
@@ -403,8 +403,7 @@ vos_obj_query_key(daos_handle_t coh, daos_unit_oid_t oid, uint32_t flags,
 	}
 
 	vos_dth_set(dth);
-	rc = vos_ts_set_allocate(&query.qt_ts_set, 0, cflags, nr_akeys,
-				 dth ? &dth->dth_xid : NULL);
+	rc = vos_ts_set_allocate(&query.qt_ts_set, 0, cflags, nr_akeys, dth);
 	if (rc != 0) {
 		D_ERROR("Failed to allocate timestamp set: "DF_RC"\n",
 			DP_RC(rc));

--- a/src/vos/vos_ts.c
+++ b/src/vos/vos_ts.c
@@ -279,18 +279,24 @@ vos_ts_evict_lru(struct vos_ts_table *ts_table, struct vos_ts_entry **entryp,
 int
 vos_ts_set_allocate(struct vos_ts_set **ts_set, uint64_t flags,
 		    uint16_t cflags, uint32_t akey_nr,
-		    const struct dtx_id *tx_id)
+		    const struct dtx_handle *dth)
 {
-	uint32_t	size;
-	uint64_t	array_size;
-	uint64_t	cond_mask = VOS_COND_FETCH_MASK | VOS_COND_UPDATE_MASK |
-		VOS_OF_COND_PER_AKEY;
+	const struct dtx_id	*tx_id = NULL;
+	uint32_t		 size;
+	uint64_t		 array_size;
+	uint64_t		 cond_mask = VOS_COND_FETCH_MASK |
+					     VOS_COND_UPDATE_MASK |
+					     VOS_OF_COND_PER_AKEY;
 
 	vos_kh_clear();
 
 	*ts_set = NULL;
-	if (tx_id == NULL && (flags & cond_mask) == 0)
-		return 0;
+	if (!dtx_is_valid_handle(dth)) {
+		if ((flags & cond_mask) == 0)
+			return 0;
+	} else if (dth->dth_dist || (flags & cond_mask)) {
+		tx_id = &dth->dth_xid;
+	}
 
 	size = VOS_TS_TYPE_AKEY + akey_nr;
 	array_size = size * sizeof((*ts_set)->ts_entries[0]);

--- a/src/vos/vos_ts.h
+++ b/src/vos/vos_ts.h
@@ -628,14 +628,14 @@ vos_ts_table_free(struct vos_ts_table **ts_table);
  * \param[in]		flags	Operations flags
  * \param[in]		cflags	Check/update flags
  * \param[in]		akey_nr	Number of akeys in operation
- * \param[in]		tx_id	Optional transaction id
+ * \param[in]		dth	Optional transaction handle
  *
  * \return	0 on success, error otherwise.
  */
 int
 vos_ts_set_allocate(struct vos_ts_set **ts_set, uint64_t flags,
 		    uint16_t cflags, uint32_t akey_nr,
-		    const struct dtx_id *tx_id);
+		    const struct dtx_handle *dth);
 
 /** Upgrade any negative entries in the set now that the associated
  *  update/punch has committed


### PR DESCRIPTION
This limits MVCC checks to distributed transactions and
conditional operations.

Signed-off-by: Jeff Olivier <jeffrey.v.olivier@intel.com>