### PR TITLE
DAOS-6083 control: Improve Replicated MS client

### DIFF
--- a/ci/rpm/test_daos_node.sh
+++ b/ci/rpm/test_daos_node.sh
@@ -32,7 +32,7 @@ while [[ "$line" != *started\ on\ rank\ 0* ]]; do
   echo "Server stdout: $line"
 done
 echo "Server started!"
-daos_agent &
+daos_agent --debug &
 AGENT_PID=$!
 trap 'set -x; kill -INT $AGENT_PID $COPROC_PID' EXIT
 OFI_INTERFACE=eth0 daos_test -m

--- a/src/control/common/time_utils.go
+++ b/src/control/common/time_utils.go
@@ -24,6 +24,7 @@
 package common
 
 import (
+	"math/rand"
 	"time"
 )
 
@@ -32,6 +33,8 @@ const (
 	// widely supported by parsers (e.g. javascript, etc).
 	iso8601NoMicro = "2006-01-02T15:04:05Z0700"
 	iso8601        = "2006-01-02T15:04:05.000000Z0700"
+
+	defaultJitter = 500 * time.Millisecond
 )
 
 // FormatTime returns ISO8601 formatted representation of timestamp with
@@ -44,4 +47,40 @@ func FormatTime(t time.Time) string {
 // second resolution.
 func FormatTimeNoMicro(t time.Time) string {
 	return t.Format(iso8601NoMicro)
+}
+
+// ExpBackoffWithJitter is like ExpBackoff but allows for a custom
+// amount of jitter to be specified.
+func ExpBackoffWithJitter(base, jitter time.Duration, cur, limit uint64) time.Duration {
+	// Special case: If the current iteration is 0, just return
+	// a zero duration.
+	if cur == 0 {
+		return 0
+	}
+
+	min := func(a, b uint64) uint64 {
+		if a < b {
+			return a
+		}
+		return b
+	}
+
+	backoff := base
+	pow := min(cur, limit)
+	for pow > 2 {
+		backoff *= 2
+		pow--
+	}
+
+	backoff += jitter * time.Duration(rand.Int63n(int64(limit)))
+
+	return backoff
+
+}
+
+// ExpBackoff implements an exponential backoff algorithm, where the
+// parameters are used to multiplicatively slow down the rate of retries
+// of some operation, up to a maximum backoff limit.
+func ExpBackoff(base time.Duration, cur, limit uint64) time.Duration {
+	return ExpBackoffWithJitter(base, defaultJitter, cur, limit)
 }

--- a/src/control/lib/control/faults.go
+++ b/src/control/lib/control/faults.go
@@ -26,6 +26,8 @@ package control
 import (
 	"fmt"
 
+	"github.com/pkg/errors"
+
 	"github.com/daos-stack/daos/src/control/fault"
 	"github.com/daos-stack/daos/src/control/fault/code"
 )
@@ -47,6 +49,24 @@ var (
 		"specify a non-empty list of DAOS server addresses in configuration ('hostlist' parameter) and retry the client application",
 	)
 )
+
+func IsConnectionError(err error) bool {
+	f, ok := errors.Cause(err).(*fault.Fault)
+	if !ok {
+		return false
+	}
+
+	for _, connCode := range []code.Code{
+		code.ClientConnectionBadHost, code.ClientConnectionClosed,
+		code.ClientConnectionNoRoute, code.ClientConnectionRefused,
+	} {
+		if f.Code == connCode {
+			return true
+		}
+	}
+
+	return false
+}
 
 func FaultConnectionBadHost(srvAddr string) *fault.Fault {
 	return clientFault(

--- a/src/control/lib/control/hostlist.go
+++ b/src/control/lib/control/hostlist.go
@@ -26,43 +26,26 @@ package control
 import "github.com/daos-stack/daos/src/control/common"
 
 // getRequestHosts returns a list of control plane addresses for
-// the request. The logic for determining the list is as follows:
-//
-// 1.  If the request has an explicit hostlist set, use it regardless
-//     of request type. This allows for flexibility and config overrides,
-//     but generally should be used for non-AP requests to specific hosts.
-// 2.  If there is no hostlist set on the request, check the request type
-//     and use the following decision tree:
-// 2a. If the request is destined for an Access Point (DAOS MS Replica),
-//     pick the first host in the configuration's hostlist. By convention
-//     this host will be an AP and the request should succeed. If for some
-//     reason the request fails, a future mechanism will attempt to find
-//     a working AP replica to service the request.
-// 2b. If the request is not destined for an AP, then the request is sent
-//     to the entire hostlist set in the configuration.
-//
-// Will always return at least 1 host, or an error.
+// the request. If the request does not supply its own hostlist,
+// create one from the configuration's hostlist.
 func getRequestHosts(cfg *Config, req targetChooser) (hosts []string, err error) {
-	hosts = req.getHostList()
-	if len(hosts) == 0 {
-		if len(cfg.HostList) == 0 {
-			return nil, FaultConfigEmptyHostList
-		}
-		hosts = cfg.HostList
+	if len(req.getHostList()) == 0 && len(cfg.HostList) == 0 {
+		return nil, FaultConfigEmptyHostList
 	}
-
 	if cfg.ControlPort == 0 {
 		return nil, FaultConfigBadControlPort
 	}
 
-	hosts, err = common.ParseHostList(hosts, cfg.ControlPort)
+	hosts, err = common.ParseHostList(req.getHostList(), cfg.ControlPort)
 	if err != nil {
 		return nil, err
 	}
 
-	if req.isMSRequest() {
-		// pick first host as AP, by convention
-		hosts = hosts[:1]
+	if len(hosts) == 0 {
+		hosts, err = common.ParseHostList(cfg.HostList, cfg.ControlPort)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	return hosts, nil

--- a/src/control/lib/control/hostlist_test.go
+++ b/src/control/lib/control/hostlist_test.go
@@ -24,7 +24,6 @@
 package control
 
 import (
-	"fmt"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -56,10 +55,6 @@ func mockHostList(hosts ...string) []string {
 
 func TestControl_getRequestHosts(t *testing.T) {
 	defaultCfg := DefaultConfig()
-	defaultCfg.HostList = mockHostList("a", "b", "c")
-	for i, host := range defaultCfg.HostList {
-		defaultCfg.HostList[i] = fmt.Sprintf("%s:%d", host, defaultCfg.ControlPort)
-	}
 
 	for name, tc := range map[string]struct {
 		cfg    *Config
@@ -98,21 +93,6 @@ func TestControl_getRequestHosts(t *testing.T) {
 			cfg:    defaultCfg,
 			req:    &testTgtChooser{},
 			expOut: mockHostList(defaultCfg.HostList...),
-		},
-		"default config; MS request; empty req list": {
-			cfg: defaultCfg,
-			req: &testTgtChooser{
-				toMS: true,
-			},
-			expOut: mockHostList(defaultCfg.HostList[0]),
-		},
-		"default config; MS request; use req list": {
-			cfg: defaultCfg,
-			req: &testTgtChooser{
-				hostList: defaultCfg.HostList[1:],
-				toMS:     true,
-			},
-			expOut: mockHostList(defaultCfg.HostList[1]),
 		},
 	} {
 		t.Run(name, func(t *testing.T) {

--- a/src/control/lib/control/interceptors.go
+++ b/src/control/lib/control/interceptors.go
@@ -40,7 +40,8 @@ func connErrToFault(st *status.Status, target string) error {
 	switch {
 	case strings.Contains(st.Message(), "connection refused"):
 		return FaultConnectionRefused(target)
-	case strings.Contains(st.Message(), "connection closed"):
+	case strings.Contains(st.Message(), "connection closed"),
+		strings.Contains(st.Message(), "transport is closing"):
 		return FaultConnectionClosed(target)
 	case strings.Contains(st.Message(), "no route to host"):
 		return FaultConnectionNoRoute(target)

--- a/src/control/lib/control/mocks.go
+++ b/src/control/lib/control/mocks.go
@@ -89,7 +89,7 @@ func (mi *MockInvoker) Debugf(fmtStr string, args ...interface{}) {
 }
 
 func (mi *MockInvoker) InvokeUnaryRPC(ctx context.Context, uReq UnaryRequest) (*UnaryResponse, error) {
-	return invokeUnaryRPC(ctx, mi.log, mi, uReq)
+	return invokeUnaryRPC(ctx, mi.log, mi, uReq, nil)
 }
 
 func (mi *MockInvoker) InvokeUnaryRPCAsync(ctx context.Context, uReq UnaryRequest) (HostResponseChan, error) {

--- a/src/control/lib/control/network.go
+++ b/src/control/lib/control/network.go
@@ -39,6 +39,7 @@ import (
 	ctlpb "github.com/daos-stack/daos/src/control/common/proto/ctl"
 	mgmtpb "github.com/daos-stack/daos/src/control/common/proto/mgmt"
 	"github.com/daos-stack/daos/src/control/lib/hostlist"
+	"github.com/daos-stack/daos/src/control/system"
 )
 
 // HostFabricInterface describes a host fabric interface.
@@ -214,6 +215,7 @@ type (
 	GetAttachInfoReq struct {
 		unaryRequest
 		msRequest
+		retryableRequest
 		System   string
 		AllRanks bool
 	}
@@ -262,6 +264,10 @@ func GetAttachInfo(ctx context.Context, rpcClient UnaryInvoker, req *GetAttachIn
 			AllRanks: req.AllRanks,
 		})
 	})
+	req.retryTestFn = func(err error, _ uint) bool {
+		// If the MS hasn't added any members yet, retry the request.
+		return system.IsEmptyGroupMap(err)
+	}
 
 	ur, err := rpcClient.InvokeUnaryRPC(ctx, req)
 	if err != nil {

--- a/src/control/lib/control/network_test.go
+++ b/src/control/lib/control/network_test.go
@@ -34,6 +34,7 @@ import (
 	ctlpb "github.com/daos-stack/daos/src/control/common/proto/ctl"
 	mgmtpb "github.com/daos-stack/daos/src/control/common/proto/mgmt"
 	"github.com/daos-stack/daos/src/control/logging"
+	"github.com/daos-stack/daos/src/control/system"
 )
 
 type mockFabricScan struct {
@@ -313,6 +314,32 @@ func TestControl_GetAttachInfo(t *testing.T) {
 				UnaryResponse: MockMSResponse("host1", errors.New("remote failed"), nil),
 			},
 			expErr: errors.New("remote failed"),
+		},
+		"retry after EmptyGroupMap": {
+			req: &GetAttachInfoReq{},
+			mic: &MockInvokerConfig{
+				UnaryResponseSet: []*UnaryResponse{
+					MockMSResponse("host1", system.ErrEmptyGroupMap, nil),
+					MockMSResponse("host1", nil, &mgmtpb.GetAttachInfoResp{
+						Psrs: []*mgmtpb.GetAttachInfoResp_Psr{
+							{
+								Rank: 42,
+								Uri:  "foo://bar",
+							},
+						},
+						Provider: "cow",
+					}),
+				},
+			},
+			expResp: &GetAttachInfoResp{
+				ServiceRanks: []*PrimaryServiceRank{
+					{
+						Rank: 42,
+						Uri:  "foo://bar",
+					},
+				},
+				Provider: "cow",
+			},
 		},
 		"success": {
 			mic: &MockInvokerConfig{

--- a/src/control/lib/control/pool.go
+++ b/src/control/lib/control/pool.go
@@ -43,8 +43,11 @@ import (
 )
 
 const (
-	defaultPoolSvcReps       = 1
-	defaultPoolCreateTimeout = 10 * time.Minute // be generous for large pools
+	// PoolCreateTimeout defines the amount of time a pool create
+	// request can take before being timed out.
+	PoolCreateTimeout = 10 * time.Minute // be generous for large pools
+
+	defaultPoolSvcReps = 1
 )
 
 type (
@@ -168,7 +171,7 @@ func PoolCreate(ctx context.Context, rpcClient UnaryInvoker, req *PoolCreateReq)
 	}
 	// TODO: Set this timeout based on the SCM size, when we have a
 	// better understanding of the relationship.
-	req.SetTimeout(defaultPoolCreateTimeout)
+	req.SetTimeout(PoolCreateTimeout)
 	req.setRPC(func(ctx context.Context, conn *grpc.ClientConn) (proto.Message, error) {
 		return mgmtpb.NewMgmtSvcClient(conn).PoolCreate(ctx, pbReq)
 	})

--- a/src/control/lib/control/request.go
+++ b/src/control/lib/control/request.go
@@ -59,11 +59,13 @@ type (
 		// used to limit the number of retries and/or execute some custom retry
 		// logic on each iteration.
 		onRetry(context.Context, uint) error
-		// retryAfter returns a channel to be waited on in order to pause
-		// a goroutine's execution for some duration. For safety, the
-		// channel should be waited on in a select with a context in order to
-		// avoid blocking a goroutine forever.
-		retryAfter(time.Duration) <-chan time.Time
+		// retryAfter returns a duration to specify how long the caller should
+		// wait before trying the request again. It accepts a default duration
+		// which is returned if the request does not specify its own retry interval.
+		retryAfter(time.Duration) time.Duration
+		// getRetryTimeout returns a duration to specify how long each retry attempt
+		// may take. This should be shorter than any overall per-request Deadline.
+		getRetryTimeout() time.Duration
 	}
 
 	// deadliner defines an interface to be implemented by
@@ -143,9 +145,15 @@ func (r *request) onRetry(_ context.Context, _ uint) error {
 }
 
 // retryAfter implements the retrier interface and always returns
-// a time channel defined by the supplied duration.
-func (r *request) retryAfter(interval time.Duration) <-chan time.Time {
-	return time.After(interval)
+// the supplied retry interval.
+func (r *request) retryAfter(interval time.Duration) time.Duration {
+	return interval
+}
+
+// getRetryTimeout implements the retrier interface and always returns
+// zero.
+func (r *request) getRetryTimeout() time.Duration {
+	return 0
 }
 
 // msRequest is an embeddable struct to implement the targetChooser
@@ -161,6 +169,8 @@ func (r *msRequest) isMSRequest() bool {
 
 // retryableRequest is the default implementation of the retryer interface.
 type retryableRequest struct {
+	// retryTimeout sets an optional timeout for each retry.
+	retryTimeout time.Duration
 	// retryInterval is an optional interval to override the default.
 	retryInterval time.Duration
 	// retryMaxTries is an optional max number of retry attempts.
@@ -173,11 +183,15 @@ type retryableRequest struct {
 	retryFn func(context.Context, uint) error
 }
 
-func (r *retryableRequest) retryAfter(defInterval time.Duration) <-chan time.Time {
+func (r *retryableRequest) getRetryTimeout() time.Duration {
+	return r.retryTimeout
+}
+
+func (r *retryableRequest) retryAfter(defInterval time.Duration) time.Duration {
 	if r.retryInterval > 0 {
-		return time.After(r.retryInterval)
+		return r.retryInterval
 	}
-	return time.After(defInterval)
+	return defInterval
 }
 
 func (r *retryableRequest) canRetry(err error, cur uint) bool {

--- a/src/control/lib/control/response.go
+++ b/src/control/lib/control/response.go
@@ -32,6 +32,7 @@ import (
 	"github.com/golang/protobuf/proto"
 	"github.com/pkg/errors"
 
+	"github.com/daos-stack/daos/src/control/build"
 	"github.com/daos-stack/daos/src/control/common/proto/convert"
 	ctlpb "github.com/daos-stack/daos/src/control/common/proto/ctl"
 	"github.com/daos-stack/daos/src/control/lib/hostlist"
@@ -213,7 +214,10 @@ func (ur *UnaryResponse) getMSResponse() (proto.Message, error) {
 func convertMSResponse(ur *UnaryResponse, out interface{}) error {
 	msResp, err := ur.getMSResponse()
 	if err != nil {
-		return errors.Wrap(err, "failed to get MS response")
+		if IsConnectionError(err) {
+			return errors.Errorf("unable to contact the %s", build.ManagementServiceName)
+		}
+		return err
 	}
 
 	return convert.Types(msResp, out)

--- a/src/control/lib/control/rpc.go
+++ b/src/control/lib/control/rpc.go
@@ -25,12 +25,18 @@ package control
 
 import (
 	"context"
+	"math/rand"
 	"sync"
 	"time"
 
 	"github.com/golang/protobuf/proto"
+	"github.com/pkg/errors"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 
+	"github.com/daos-stack/daos/src/control/common"
+	"github.com/daos-stack/daos/src/control/lib/hostlist"
 	"github.com/daos-stack/daos/src/control/security"
 	"github.com/daos-stack/daos/src/control/system"
 )
@@ -40,7 +46,13 @@ const (
 	// it almost certainly needs to be fixed.
 	defaultRequestTimeout = 5 * time.Minute
 
-	defaultMSRetry = 250 * time.Millisecond
+	baseMSBackoff      = 250 * time.Millisecond
+	maxMSBackoffFactor = 7 // 8s
+	maxMSCandidates    = 5
+)
+
+var (
+	msCandidateRandSource = rand.NewSource(time.Now().UnixNano())
 )
 
 type (
@@ -189,7 +201,7 @@ func setDeadlineIfUnset(parent context.Context, req UnaryRequest) (context.Conte
 }
 
 // InvokeUnaryRPCAsync performs an asynchronous invocation of the given RPC
-// across all hosts in the provided host list. The returned HostResponseChan
+// across all hosts in the request's host list. The returned HostResponseChan
 // provides access to a stream of HostResponse items as they are received, and
 // is closed when no more responses are expected.
 func (c *Client) InvokeUnaryRPCAsync(parent context.Context, req UnaryRequest) (HostResponseChan, error) {
@@ -241,7 +253,7 @@ func (c *Client) InvokeUnaryRPCAsync(parent context.Context, req UnaryRequest) (
 // invokeUnaryRPC is the actual implementation which is called by the
 // real Client as well as the MockInvoker. This allows us to ensure that
 // the retry logic here gets adequate test coverage.
-func invokeUnaryRPC(parent context.Context, log debugLogger, c UnaryInvoker, req UnaryRequest) (*UnaryResponse, error) {
+func invokeUnaryRPC(parentCtx context.Context, log debugLogger, c UnaryInvoker, req UnaryRequest, defaultHosts []string) (*UnaryResponse, error) {
 	gatherResponses := func(ctx context.Context, respChan chan *HostResponse, ur *UnaryResponse) error {
 		for {
 			select {
@@ -257,27 +269,86 @@ func invokeUnaryRPC(parent context.Context, log debugLogger, c UnaryInvoker, req
 	}
 
 	// Set a deadline for the request across all retries.
-	ctx, cancel := setDeadlineIfUnset(parent, req)
+	reqCtx, cancel := setDeadlineIfUnset(parentCtx, req)
 	defer cancel()
 
-	var tries uint = 0
-	for {
-		tries++
-		respChan, err := c.InvokeUnaryRPCAsync(ctx, req)
+	// For non-MS requests, just keep things simple. Fan-out, fan-in,
+	// no retries possible.
+	if !req.isMSRequest() {
+		respChan, err := c.InvokeUnaryRPCAsync(reqCtx, req)
 		if err != nil {
 			return nil, err
 		}
 
-		ur := &UnaryResponse{
-			fromMS: req.isMSRequest(),
+		ur := new(UnaryResponse)
+		if err := gatherResponses(reqCtx, respChan, ur); err != nil {
+			return nil, err
 		}
-		if err := gatherResponses(ctx, respChan, ur); err != nil {
+		return ur, nil
+	}
+
+	if len(req.getHostList()) == 0 {
+		// For a MS request with no specific hostlist, choose a random subset
+		// of the default hostlist, with the idea that at least one of them
+		// will be up and running enough to return ErrNotReplica in order to
+		// learn the actual list of MS replicas. We may also get lucky and
+		// send the request to a server that can handle the request directly.
+		rnd := rand.New(msCandidateRandSource)
+		msCandidates := hostlist.MustCreateSet("")
+		for i := 0; i < len(defaultHosts) && msCandidates.Count() < maxMSCandidates; i++ {
+			if _, err := msCandidates.Insert(defaultHosts[rnd.Intn(len(defaultHosts))]); err != nil {
+				return nil, errors.Wrap(err, "failed to build MS candidates set")
+			}
+		}
+		req.SetHostList(msCandidates.Slice())
+		if len(req.getHostList()) == 0 {
+			return nil, errors.New("unable to select MS candidates")
+		}
+	}
+
+	isHardFailure := func(err error, reqCtx context.Context) bool {
+		if err == nil {
+			return false
+		}
+
+		// If the error is something other than a context error,
+		// then it's considered a hard failure and not retryable.
+		code := status.Code(errors.Cause(err))
+		if code != codes.Canceled && code != codes.DeadlineExceeded {
+			return true
+		}
+
+		// If the context error is from the overall request context,
+		// then it's a hard failure. Otherwise, it's a soft failure
+		// and can be retried.
+		return errors.Cause(err) == reqCtx.Err()
+	}
+
+	// MS requests are a little more complicated. The general idea here is that
+	// we want to discover the current MS leader for requests that must be
+	// handled by the leader; otherwise we want to find at least one MS replica
+	// to service the request. In this case we may get multiple responses, and
+	// we just return the first successful response as we assume that every
+	// replica is returning the same answer.
+	var try uint = 0
+	for {
+		tryCtx := reqCtx
+		if tryTimeout := req.getRetryTimeout(); tryTimeout > 0 {
+			var tryCancel context.CancelFunc
+			tryCtx, tryCancel = context.WithTimeout(reqCtx, tryTimeout)
+			defer tryCancel()
+		}
+		respChan, err := c.InvokeUnaryRPCAsync(tryCtx, req)
+		if isHardFailure(err, reqCtx) {
 			return nil, err
 		}
 
-		if !ur.fromMS {
-			return ur, nil
+		ur := &UnaryResponse{fromMS: true}
+		err = gatherResponses(tryCtx, respChan, ur)
+		if isHardFailure(err, reqCtx) {
+			return nil, err
 		}
+
 		_, err = ur.getMSResponse()
 		switch e := err.(type) {
 		case *system.ErrNotLeader:
@@ -287,7 +358,9 @@ func invokeUnaryRPC(parent context.Context, log debugLogger, c UnaryInvoker, req
 			// empty (as can happen during an election), just send
 			// the retry to all of the replicas.
 			if e.LeaderHint == "" {
-				req.SetHostList(e.Replicas)
+				if len(e.Replicas) > 0 {
+					req.SetHostList(e.Replicas)
+				}
 				break
 			}
 			req.SetHostList([]string{e.LeaderHint})
@@ -296,33 +369,31 @@ func invokeUnaryRPC(parent context.Context, log debugLogger, c UnaryInvoker, req
 			// the error should give us the list of replicas to try.
 			// One of them should be the current leader and will
 			// service the request.
-			req.SetHostList(e.Replicas)
+			if len(e.Replicas) > 0 {
+				req.SetHostList(e.Replicas)
+			}
 		default:
-			// If the request defines its own retry criteria, run
+			// If the request defines its own retry logic for the error, run
 			// that logic and break out early.
-			if req.canRetry(err, tries) {
-				if err := req.onRetry(ctx, tries); err != nil {
+			if req.canRetry(err, try) {
+				if err := req.onRetry(tryCtx, try); err != nil {
 					return ur, nil
 				}
 				break
 			}
 
-			// If the request succeeded, or there was only one host to try,
-			// return now. Otherwise, remove the failed host from the list
-			// and try again.
-			if err == nil || len(req.getHostList()) < 2 {
-				return ur, nil
-			}
-			log.Debugf("removing %s from request hosts due to %s", req.getHostList()[0], e)
-			req.SetHostList(req.getHostList()[1:])
+			// Otherwise, we're finished trying.
+			return ur, nil
 		}
 
-		log.Debugf("MS request error: %v; retrying after %s", err, defaultMSRetry)
+		backoff := common.ExpBackoff(req.retryAfter(baseMSBackoff), uint64(try), maxMSBackoffFactor)
+		log.Debugf("MS request error: %v; retrying after %s", err, backoff)
 		select {
-		case <-ctx.Done():
-			return nil, ctx.Err()
-		case <-req.retryAfter(defaultMSRetry):
+		case <-reqCtx.Done():
+			return nil, reqCtx.Err()
+		case <-time.After(backoff):
 		}
+		try++
 	}
 }
 
@@ -331,5 +402,5 @@ func invokeUnaryRPC(parent context.Context, log debugLogger, c UnaryInvoker, req
 // items which represent the success or failure of the RPC invocation for each host
 // in the request.
 func (c *Client) InvokeUnaryRPC(ctx context.Context, req UnaryRequest) (*UnaryResponse, error) {
-	return invokeUnaryRPC(ctx, c.log, c, req)
+	return invokeUnaryRPC(ctx, c.log, c, req, c.config.HostList)
 }

--- a/src/control/lib/control/rpc_test.go
+++ b/src/control/lib/control/rpc_test.go
@@ -25,6 +25,8 @@ package control
 
 import (
 	"context"
+	"fmt"
+	"math/rand"
 	"os"
 	"runtime"
 	"sort"
@@ -216,14 +218,45 @@ func TestControl_InvokeUnaryRPCAsync(t *testing.T) {
 }
 
 func TestControl_InvokeUnaryRPC(t *testing.T) {
+	// make the rand deterministic for testing
+	msCandidateRandSource = rand.NewSource(1)
+
 	clientCfg := DefaultConfig()
 	clientCfg.TransportConfig.AllowInsecure = true
+	clientCfg.HostList = nil
+	for i := 0; i < maxMSCandidates*2; i++ {
+		clientCfg.HostList = append(clientCfg.HostList, fmt.Sprintf("host%02d:%d", i, clientCfg.ControlPort))
+	}
 
-	fnGen := func(inner func(*int) (proto.Message, error)) func(_ context.Context, _ *grpc.ClientConn) (proto.Message, error) {
-		callCount := 0
-		return func(_ context.Context, _ *grpc.ClientConn) (proto.Message, error) {
-			return inner(&callCount)
+	leaderHost := "host08:10001"
+	replicaHosts := []string{"host01:10001", "host05:10001", "host07:10001", "host08:10001", "host09:10001"}
+	repMap := make(map[string]struct{})
+	for _, rep := range replicaHosts {
+		repMap[rep] = struct{}{}
+	}
+	nonLeaderReplicas := make([]string, 0, len(replicaHosts)-1)
+	for _, rep := range replicaHosts {
+		if rep != leaderHost {
+			nonLeaderReplicas = append(nonLeaderReplicas, rep)
 		}
+	}
+
+	var nonReplicaHosts []string
+	for _, host := range clientCfg.HostList {
+		if _, isRep := repMap[host]; !isRep {
+			nonReplicaHosts = append(nonReplicaHosts, host)
+		}
+	}
+
+	errNotLeader := &system.ErrNotLeader{
+		LeaderHint: leaderHost,
+		Replicas:   replicaHosts,
+	}
+	errNotLeaderNoLeader := &system.ErrNotLeader{
+		Replicas: replicaHosts,
+	}
+	errNotReplica := &system.ErrNotReplica{
+		Replicas: replicaHosts,
 	}
 
 	for name, tc := range map[string]struct {
@@ -276,23 +309,25 @@ func TestControl_InvokeUnaryRPC(t *testing.T) {
 				},
 			},
 		},
-		"multiple hosts in MS request, first fails": {
+		"multiple hosts in request, one fails": {
 			req: &testRequest{
 				retryableRequest: retryableRequest{
 					retryTestFn: func(_ error, _ uint) bool { return false },
 				},
 				HostList: []string{"127.0.0.1:1", "127.0.0.1:2"},
-				toMS:     true,
-				rpcFn: fnGen(func(callCount *int) (proto.Message, error) {
-					*callCount++
-					if *callCount == 1 {
+				rpcFn: func(_ context.Context, cc *grpc.ClientConn) (proto.Message, error) {
+					if cc.Target() == "127.0.0.1:1" {
 						return nil, errors.New("whoops")
 					}
 					return defaultMessage, nil
-				}),
+				},
 			},
 			expResp: &UnaryResponse{
 				Responses: []*HostResponse{
+					{
+						Addr:  "127.0.0.1:1",
+						Error: errors.New("whoops"),
+					},
 					{
 						Addr:    "127.0.0.1:2",
 						Message: defaultMessage,
@@ -300,61 +335,68 @@ func TestControl_InvokeUnaryRPC(t *testing.T) {
 				},
 			},
 		},
-		"request to non-leader replica": {
+		"request to non-leader replicas discovers leader": {
 			req: &testRequest{
-				toMS: true,
-				rpcFn: fnGen(func(callCount *int) (proto.Message, error) {
-					*callCount++
-					if *callCount == 1 {
-						return nil, &system.ErrNotLeader{LeaderHint: "foo:1"}
+				HostList: nonLeaderReplicas,
+				toMS:     true,
+				rpcFn: func(_ context.Context, cc *grpc.ClientConn) (proto.Message, error) {
+					if cc.Target() == errNotLeader.LeaderHint {
+						return defaultMessage, nil
 					}
-					return defaultMessage, nil
-				}),
+					return nil, errNotLeader
+				},
 			},
 			expResp: &UnaryResponse{
 				Responses: []*HostResponse{
 					{
-						Addr:    "foo:1",
+						Addr:    "host08:10001",
 						Message: defaultMessage,
 					},
 				},
 			},
 		},
-		"request to non-leader replica; no current leader": {
+		"request to non-leader replicas with no current leader times out": {
 			req: &testRequest{
-				toMS: true,
-				rpcFn: fnGen(func(callCount *int) (proto.Message, error) {
-					*callCount++
-					if *callCount == 1 {
-						return nil, &system.ErrNotLeader{Replicas: []string{"foo:1"}}
-					}
-					return defaultMessage, nil
-				}),
-			},
-			expResp: &UnaryResponse{
-				Responses: []*HostResponse{
-					{
-						Addr:    "foo:1",
-						Message: defaultMessage,
-					},
+				HostList: nonLeaderReplicas,
+				Deadline: time.Now().Add(10 * time.Millisecond),
+				toMS:     true,
+				rpcFn: func(_ context.Context, cc *grpc.ClientConn) (proto.Message, error) {
+					return nil, errNotLeaderNoLeader
 				},
 			},
+			expErr: context.DeadlineExceeded,
 		},
-		"request to non-replica": {
+		"request to non-replicas eventually discovers at least one replica": {
 			req: &testRequest{
-				toMS: true,
-				rpcFn: fnGen(func(callCount *int) (proto.Message, error) {
-					*callCount++
-					if *callCount == 1 {
-						return nil, &system.ErrNotReplica{Replicas: []string{"foo:1"}}
+				HostList: nonReplicaHosts,
+				toMS:     true,
+				rpcFn: func(_ context.Context, cc *grpc.ClientConn) (proto.Message, error) {
+					if _, isRep := repMap[cc.Target()]; isRep {
+						return defaultMessage, nil
 					}
-					return defaultMessage, nil
-				}),
+					return nil, errNotReplica
+				},
 			},
 			expResp: &UnaryResponse{
 				Responses: []*HostResponse{
 					{
-						Addr:    "foo:1",
+						Addr:    "host01:10001",
+						Message: defaultMessage,
+					},
+					{
+						Addr:    "host05:10001",
+						Message: defaultMessage,
+					},
+					{
+						Addr:    "host07:10001",
+						Message: defaultMessage,
+					},
+					{
+						Addr:    "host08:10001",
+						Message: defaultMessage,
+					},
+					{
+						Addr:    "host09:10001",
 						Message: defaultMessage,
 					},
 				},
@@ -399,6 +441,7 @@ func TestControl_InvokeUnaryRPC(t *testing.T) {
 			if tc.withCancel == nil {
 				cmpOpts := []cmp.Option{
 					cmpopts.IgnoreUnexported(UnaryResponse{}),
+					cmp.Comparer(func(x, y error) bool { return common.CmpErrBool(x, y) }),
 					cmp.Transformer("Sort", func(in []*HostResponse) []*HostResponse {
 						out := append([]*HostResponse(nil), in...)
 						sort.Slice(out, func(i, j int) bool { return out[i].Addr < out[j].Addr })

--- a/src/control/lib/control/system.go
+++ b/src/control/lib/control/system.go
@@ -28,6 +28,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net"
+	"time"
 
 	"github.com/dustin/go-humanize/english"
 	"github.com/golang/protobuf/proto"
@@ -41,6 +42,17 @@ import (
 	"github.com/daos-stack/daos/src/control/events"
 	"github.com/daos-stack/daos/src/control/lib/hostlist"
 	"github.com/daos-stack/daos/src/control/system"
+)
+
+const (
+	// SystemJoinTimeout defines the overall amount of time a system join attempt
+	// can take. It should be an extremely generous value, in order to
+	// accommodate (re)joins during leadership upheaval and other scenarios
+	// that are expected to eventually resolve.
+	SystemJoinTimeout = 1 * time.Hour // effectively "forever", just keep retrying
+	// SystemJoinRetryTimeout defines the amount of time a retry attempt can take. It
+	// should be set low in order to ensure that individual join attempts retry quickly.
+	SystemJoinRetryTimeout = 10 * time.Second
 )
 
 type sysRequest struct {
@@ -88,6 +100,7 @@ func (resp *sysResponse) DisplayAbsentHostsRanks() string {
 type SystemJoinReq struct {
 	unaryRequest
 	msRequest
+	retryableRequest
 	ControlAddr *net.TCPAddr
 	UUID        string
 	Rank        system.Rank
@@ -129,8 +142,16 @@ func SystemJoin(ctx context.Context, rpcClient UnaryInvoker, req *SystemJoinReq)
 	req.setRPC(func(ctx context.Context, conn *grpc.ClientConn) (proto.Message, error) {
 		return mgmtpb.NewMgmtSvcClient(conn).Join(ctx, pbReq)
 	})
+	req.SetTimeout(SystemJoinTimeout)
+	req.retryTimeout = SystemJoinRetryTimeout
+	req.retryTestFn = func(err error, _ uint) bool {
+		switch {
+		case IsConnectionError(err), system.IsUnavailable(err):
+			return true
+		}
+		return false
+	}
 	rpcClient.Debugf("DAOS system join request: %+v", pbReq)
-	rpcClient.Debugf("DAOS system join req hosts: %+v", req.HostList)
 
 	ur, err := rpcClient.InvokeUnaryRPC(ctx, req)
 	if err != nil {
@@ -138,7 +159,13 @@ func SystemJoin(ctx context.Context, rpcClient UnaryInvoker, req *SystemJoinReq)
 	}
 
 	resp := new(SystemJoinResp)
-	return resp, convertMSResponse(ur, resp)
+	if err := convertMSResponse(ur, resp); err != nil {
+		rpcClient.Debugf("DAOS system join failed: %s", err)
+		return nil, err
+	}
+
+	rpcClient.Debugf("DAOS system join response: %+v", resp)
+	return resp, nil
 }
 
 // SystemNotifyReq contains the inputs for the system notify request.

--- a/src/control/lib/hostlist/hostlist.go
+++ b/src/control/lib/hostlist/hostlist.go
@@ -298,7 +298,7 @@ func (hl *HostList) RangedString() string {
 
 		if open {
 			if next != nil && hr.within(next) {
-				bld.WriteString(",")
+				bld.WriteString(innerRangeSeparator)
 				continue
 			} else {
 				open = false
@@ -334,6 +334,12 @@ func (hl *HostList) DerangedString() string {
 	}
 
 	return bld.String()
+}
+
+// Slice returns a string slice containing the hostnames of every
+// host in the HostList.
+func (hl *HostList) Slice() []string {
+	return strings.Split(hl.DerangedString(), ",")
 }
 
 // Push adds a string representation of hostnames to this HostList.

--- a/src/control/lib/hostlist/hostlist_test.go
+++ b/src/control/lib/hostlist/hostlist_test.go
@@ -27,6 +27,8 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
+
 	"github.com/daos-stack/daos/src/control/lib/hostlist"
 )
 
@@ -473,6 +475,31 @@ func TestHostList_Etc(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestHostList_Slice(t *testing.T) {
+	for name, tc := range map[string]struct {
+		startList *string
+		expOut    []string
+	}{
+		"empty list": {
+			startList: makeStringRef(""),
+			expOut:    []string{""},
+		},
+		"normal": {
+			startList: makeStringRef("foo-1,foo-2,foo-[8-10]"),
+			expOut:    []string{"foo-1", "foo-2", "foo-8", "foo-9", "foo-10"},
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			hl := hostlist.MustCreate(*tc.startList)
+
+			if diff := cmp.Diff(tc.expOut, hl.Slice()); diff != "" {
+				t.Fatalf("unexpected Slice() (-want, +got):\n%s\n", diff)
+			}
+		})
+	}
+
 }
 
 func TestHostList_Nth(t *testing.T) {

--- a/src/control/lib/hostlist/hostset.go
+++ b/src/control/lib/hostlist/hostset.go
@@ -89,6 +89,13 @@ func (hs *HostSet) DerangedString() string {
 	return hs.list.DerangedString()
 }
 
+// Slice returns a string slice containing the hostnames of
+// every host in the HostSet.
+func (hs *HostSet) Slice() []string {
+	hs.initList()
+	return hs.list.Slice()
+}
+
 // Insert adds a host or list of hosts to the HostSet.
 // Returns the number of non-duplicate hosts successfully added.
 func (hs *HostSet) Insert(stringHosts string) (int, error) {

--- a/src/control/server/ctl_system.go
+++ b/src/control/server/ctl_system.go
@@ -186,7 +186,7 @@ func (svc *ControlService) SystemQuery(ctx context.Context, req *ctlpb.SystemQue
 		return nil, errors.Errorf("nil %T request", req)
 	}
 
-	if err := svc.sysdb.CheckLeader(); err != nil {
+	if err := svc.sysdb.CheckReplica(); err != nil {
 		return nil, err
 	}
 

--- a/src/control/server/harness.go
+++ b/src/control/server/harness.go
@@ -149,24 +149,6 @@ func (h *IOServerHarness) CallDrpc(ctx context.Context, method drpc.Method, body
 	return
 }
 
-// getMSLeaderInstance returns a managed IO Server instance to be used as a
-// management target and fails if selected instance is not MS Leader.
-func (h *IOServerHarness) getMSLeaderInstance() (*IOServerInstance, error) {
-	if !h.isStarted() {
-		return nil, FaultHarnessNotStarted
-	}
-
-	h.RLock()
-	defer h.RUnlock()
-
-	if len(h.instances) == 0 {
-		return nil, errors.New("harness has no managed instances")
-	}
-
-	// hack for now
-	return h.instances[0], nil
-}
-
 // Start starts harness by setting up and starting dRPC before initiating
 // configured instances' processing loops.
 //

--- a/src/control/server/instance_superblock_test.go
+++ b/src/control/server/instance_superblock_test.go
@@ -71,10 +71,7 @@ func TestServer_Instance_createSuperblock(t *testing.T) {
 	}
 
 	h.started.SetTrue()
-	mi, err := h.getMSLeaderInstance()
-	if err != nil {
-		t.Fatal(err)
-	}
+	mi := h.instances[0]
 	if mi._superblock == nil {
 		t.Fatal("instance superblock is nil after createSuperblock()")
 	}

--- a/src/control/server/mgmt_pool.go
+++ b/src/control/server/mgmt_pool.go
@@ -122,8 +122,6 @@ func (svc *mgmtSvc) PoolCreate(ctx context.Context, req *mgmtpb.PoolCreateReq) (
 	if err := svc.checkLeaderRequest(req); err != nil {
 		return nil, err
 	}
-	resp = new(mgmtpb.PoolCreateResp)
-
 	svc.log.Debugf("MgmtSvc.PoolCreate dispatch, req:%+v\n", req)
 
 	if err := svc.calculateCreateStorage(req); err != nil {
@@ -135,6 +133,7 @@ func (svc *mgmtSvc) PoolCreate(ctx context.Context, req *mgmtpb.PoolCreateReq) (
 		return nil, errors.Wrapf(err, "failed to parse pool UUID %q", req.GetUuid())
 	}
 
+	resp = new(mgmtpb.PoolCreateResp)
 	ps, err := svc.sysdb.FindPoolServiceByUUID(uuid)
 	if ps != nil {
 		svc.log.Debugf("found pool %s state=%s", ps.PoolUUID, ps.State)
@@ -545,7 +544,7 @@ func resolvePoolPropVal(req *mgmtpb.PoolSetPropReq) (*mgmtpb.PoolSetPropReq, err
 }
 
 // PoolSetProp forwards a request to the I/O server to set a pool property.
-func (svc *mgmtSvc) PoolSetProp(ctx context.Context, req *mgmtpb.PoolSetPropReq) (resp *mgmtpb.PoolSetPropResp, err error) {
+func (svc *mgmtSvc) PoolSetProp(ctx context.Context, req *mgmtpb.PoolSetPropReq) (*mgmtpb.PoolSetPropResp, error) {
 	if err := svc.checkLeaderRequest(req); err != nil {
 		return nil, err
 	}
@@ -609,7 +608,7 @@ func (svc *mgmtSvc) PoolSetProp(ctx context.Context, req *mgmtpb.PoolSetPropReq)
 		return nil, err
 	}
 
-	resp = &mgmtpb.PoolSetPropResp{}
+	resp := new(mgmtpb.PoolSetPropResp)
 	if err = proto.Unmarshal(dresp.Body, resp); err != nil {
 		return nil, errors.Wrap(err, "unmarshal PoolSetProp response")
 	}
@@ -665,7 +664,7 @@ func (svc *mgmtSvc) PoolGetACL(ctx context.Context, req *mgmtpb.GetACLReq) (*mgm
 
 // PoolOverwriteACL forwards a request to the IO server to overwrite a pool's Access Control List
 func (svc *mgmtSvc) PoolOverwriteACL(ctx context.Context, req *mgmtpb.ModifyACLReq) (*mgmtpb.ACLResp, error) {
-	if err := svc.checkReplicaRequest(req); err != nil {
+	if err := svc.checkLeaderRequest(req); err != nil {
 		return nil, err
 	}
 	svc.log.Debugf("MgmtSvc.PoolOverwriteACL dispatch, req:%+v\n", req)
@@ -688,7 +687,7 @@ func (svc *mgmtSvc) PoolOverwriteACL(ctx context.Context, req *mgmtpb.ModifyACLR
 // PoolUpdateACL forwards a request to the IO server to add or update entries in
 // a pool's Access Control List
 func (svc *mgmtSvc) PoolUpdateACL(ctx context.Context, req *mgmtpb.ModifyACLReq) (*mgmtpb.ACLResp, error) {
-	if err := svc.checkReplicaRequest(req); err != nil {
+	if err := svc.checkLeaderRequest(req); err != nil {
 		return nil, err
 	}
 	svc.log.Debugf("MgmtSvc.PoolUpdateACL dispatch, req:%+v\n", req)
@@ -711,7 +710,7 @@ func (svc *mgmtSvc) PoolUpdateACL(ctx context.Context, req *mgmtpb.ModifyACLReq)
 // PoolDeleteACL forwards a request to the IO server to delete an entry from a
 // pool's Access Control List.
 func (svc *mgmtSvc) PoolDeleteACL(ctx context.Context, req *mgmtpb.DeleteACLReq) (*mgmtpb.ACLResp, error) {
-	if err := svc.checkReplicaRequest(req); err != nil {
+	if err := svc.checkLeaderRequest(req); err != nil {
 		return nil, err
 	}
 	svc.log.Debugf("MgmtSvc.PoolDeleteACL dispatch, req:%+v\n", req)
@@ -731,8 +730,7 @@ func (svc *mgmtSvc) PoolDeleteACL(ctx context.Context, req *mgmtpb.DeleteACLReq)
 	return resp, nil
 }
 
-// ListPools forwards a gRPC request to the DAOS IO server to fetch a list of
-// all pools in the system.
+// ListPools returns a set of all pools in the system.
 func (svc *mgmtSvc) ListPools(ctx context.Context, req *mgmtpb.ListPoolsReq) (*mgmtpb.ListPoolsResp, error) {
 	if err := svc.checkReplicaRequest(req); err != nil {
 		return nil, err

--- a/src/control/server/mgmt_pool_test.go
+++ b/src/control/server/mgmt_pool_test.go
@@ -279,14 +279,12 @@ func TestServer_MgmtSvc_PoolCreate(t *testing.T) {
 			}
 			tc.mgmtSvc.log = log
 
-			if _, err := tc.mgmtSvc.harness.getMSLeaderInstance(); err == nil {
-				if tc.setupMockDrpc == nil {
-					tc.setupMockDrpc = func(svc *mgmtSvc, err error) {
-						setupMockDrpcClient(tc.mgmtSvc, tc.expResp, tc.expErr)
-					}
+			if tc.setupMockDrpc == nil {
+				tc.setupMockDrpc = func(svc *mgmtSvc, err error) {
+					setupMockDrpcClient(tc.mgmtSvc, tc.expResp, tc.expErr)
 				}
-				tc.setupMockDrpc(tc.mgmtSvc, tc.expErr)
 			}
+			tc.setupMockDrpc(tc.mgmtSvc, tc.expErr)
 
 			pcCtx, pcCancel := context.WithTimeout(context.Background(), defaultRetryAfter+10*time.Millisecond)
 			defer pcCancel()
@@ -418,14 +416,12 @@ func TestServer_MgmtSvc_PoolDestroy(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			if _, err := tc.mgmtSvc.harness.getMSLeaderInstance(); err == nil {
-				if tc.setupMockDrpc == nil {
-					tc.setupMockDrpc = func(svc *mgmtSvc, err error) {
-						setupMockDrpcClient(tc.mgmtSvc, tc.expResp, tc.expErr)
-					}
+			if tc.setupMockDrpc == nil {
+				tc.setupMockDrpc = func(svc *mgmtSvc, err error) {
+					setupMockDrpcClient(tc.mgmtSvc, tc.expResp, tc.expErr)
 				}
-				tc.setupMockDrpc(tc.mgmtSvc, tc.expErr)
 			}
+			tc.setupMockDrpc(tc.mgmtSvc, tc.expErr)
 
 			gotResp, gotErr := tc.mgmtSvc.PoolDestroy(context.TODO(), tc.req)
 			common.CmpErr(t, tc.expErr, gotErr)
@@ -508,14 +504,12 @@ func TestServer_MgmtSvc_PoolDrain(t *testing.T) {
 			tc.mgmtSvc.log = log
 			addTestPoolService(t, tc.mgmtSvc.sysdb, testPoolService)
 
-			if _, err := tc.mgmtSvc.harness.getMSLeaderInstance(); err == nil {
-				if tc.setupMockDrpc == nil {
-					tc.setupMockDrpc = func(svc *mgmtSvc, err error) {
-						setupMockDrpcClient(tc.mgmtSvc, tc.expResp, tc.expErr)
-					}
+			if tc.setupMockDrpc == nil {
+				tc.setupMockDrpc = func(svc *mgmtSvc, err error) {
+					setupMockDrpcClient(tc.mgmtSvc, tc.expResp, tc.expErr)
 				}
-				tc.setupMockDrpc(tc.mgmtSvc, tc.expErr)
 			}
+			tc.setupMockDrpc(tc.mgmtSvc, tc.expErr)
 
 			gotResp, gotErr := tc.mgmtSvc.PoolDrain(context.TODO(), tc.req)
 			common.CmpErr(t, tc.expErr, gotErr)
@@ -594,14 +588,12 @@ func TestServer_MgmtSvc_PoolEvict(t *testing.T) {
 			tc.mgmtSvc.log = log
 			addTestPoolService(t, tc.mgmtSvc.sysdb, testPoolService)
 
-			if _, err := tc.mgmtSvc.harness.getMSLeaderInstance(); err == nil {
-				if tc.setupMockDrpc == nil {
-					tc.setupMockDrpc = func(svc *mgmtSvc, err error) {
-						setupMockDrpcClient(tc.mgmtSvc, tc.expResp, tc.expErr)
-					}
+			if tc.setupMockDrpc == nil {
+				tc.setupMockDrpc = func(svc *mgmtSvc, err error) {
+					setupMockDrpcClient(tc.mgmtSvc, tc.expResp, tc.expErr)
 				}
-				tc.setupMockDrpc(tc.mgmtSvc, tc.expErr)
 			}
+			tc.setupMockDrpc(tc.mgmtSvc, tc.expErr)
 
 			gotResp, gotErr := tc.mgmtSvc.PoolEvict(context.TODO(), tc.req)
 			common.CmpErr(t, tc.expErr, gotErr)
@@ -1097,14 +1089,12 @@ func TestServer_MgmtSvc_PoolQuery(t *testing.T) {
 			tc.mgmtSvc.log = log
 			addTestPools(t, tc.mgmtSvc.sysdb, mockUUID)
 
-			if _, err := tc.mgmtSvc.harness.getMSLeaderInstance(); err == nil {
-				if tc.setupMockDrpc == nil {
-					tc.setupMockDrpc = func(svc *mgmtSvc, err error) {
-						setupMockDrpcClient(tc.mgmtSvc, tc.expResp, tc.expErr)
-					}
+			if tc.setupMockDrpc == nil {
+				tc.setupMockDrpc = func(svc *mgmtSvc, err error) {
+					setupMockDrpcClient(tc.mgmtSvc, tc.expResp, tc.expErr)
 				}
-				tc.setupMockDrpc(tc.mgmtSvc, tc.expErr)
 			}
+			tc.setupMockDrpc(tc.mgmtSvc, tc.expErr)
 
 			gotResp, gotErr := tc.mgmtSvc.PoolQuery(context.TODO(), tc.req)
 			common.CmpErr(t, tc.expErr, gotErr)
@@ -1266,7 +1256,7 @@ func TestServer_MgmtSvc_PoolSetProp_Label(t *testing.T) {
 
 func TestServer_MgmtSvc_PoolSetProp(t *testing.T) {
 	lastCall := func(svc *mgmtSvc) *drpc.Call {
-		mi, _ := svc.harness.getMSLeaderInstance()
+		mi := svc.harness.instances[0]
 		if mi == nil || mi._drpcClient == nil {
 			return nil
 		}

--- a/src/control/server/mgmt_svc.go
+++ b/src/control/server/mgmt_svc.go
@@ -120,10 +120,10 @@ func (svc *mgmtSvc) GetAttachInfo(ctx context.Context, req *mgmtpb.GetAttachInfo
 		return nil, err
 	}
 	svc.log.Debugf("MgmtSvc.GetAttachInfo dispatch, req:%+v\n", *req)
-
 	if svc.clientNetworkCfg == nil {
 		return nil, errors.New("clientNetworkCfg is missing")
 	}
+	svc.log.Debugf("MgmtSvc.GetAttachInfo dispatch, req:%+v\n", *req)
 
 	var groupMap *system.GroupMap
 	var err error

--- a/src/control/server/mgmt_svc_test.go
+++ b/src/control/server/mgmt_svc_test.go
@@ -27,12 +27,10 @@ import (
 	"context"
 	"testing"
 
-	"github.com/golang/protobuf/proto"
 	"github.com/google/go-cmp/cmp"
 
 	"github.com/daos-stack/daos/src/control/common"
 	mgmtpb "github.com/daos-stack/daos/src/control/common/proto/mgmt"
-	"github.com/daos-stack/daos/src/control/drpc"
 	"github.com/daos-stack/daos/src/control/lib/netdetect"
 	"github.com/daos-stack/daos/src/control/logging"
 	"github.com/daos-stack/daos/src/control/server/config"
@@ -40,6 +38,9 @@ import (
 )
 
 func TestServer_MgmtSvc_GetAttachInfo(t *testing.T) {
+	msReplica := system.MockMember(t, 0, system.MemberStateJoined)
+	nonReplica := system.MockMember(t, 1, system.MemberStateJoined)
+
 	for name, tc := range map[string]struct {
 		mgmtSvc          *mgmtSvc
 		clientNetworkCfg *config.ClientNetworkCfg
@@ -47,14 +48,45 @@ func TestServer_MgmtSvc_GetAttachInfo(t *testing.T) {
 		expResp          *mgmtpb.GetAttachInfoResp
 	}{
 		"Server uses verbs + Infiniband": {
-			clientNetworkCfg: &config.ClientNetworkCfg{Provider: "ofi+verbs", CrtCtxShareAddr: 1, CrtTimeout: 10, NetDevClass: netdetect.Infiniband},
-			req:              &mgmtpb.GetAttachInfoReq{},
-			expResp:          &mgmtpb.GetAttachInfoResp{Provider: "ofi+verbs", CrtCtxShareAddr: 1, CrtTimeout: 10, NetDevClass: netdetect.Infiniband},
+			clientNetworkCfg: &config.ClientNetworkCfg{
+				Provider:        "ofi+verbs",
+				CrtCtxShareAddr: 1,
+				CrtTimeout:      10, NetDevClass: netdetect.Infiniband,
+			},
+			req: &mgmtpb.GetAttachInfoReq{},
+			expResp: &mgmtpb.GetAttachInfoResp{
+				Provider:        "ofi+verbs",
+				CrtCtxShareAddr: 1,
+				CrtTimeout:      10,
+				NetDevClass:     netdetect.Infiniband,
+				Psrs: []*mgmtpb.GetAttachInfoResp_Psr{
+					{
+						Rank: msReplica.Rank.Uint32(),
+						Uri:  msReplica.FabricURI,
+					},
+				},
+			},
 		},
 		"Server uses sockets + Ethernet": {
-			clientNetworkCfg: &config.ClientNetworkCfg{Provider: "ofi+sockets", CrtCtxShareAddr: 0, CrtTimeout: 5, NetDevClass: netdetect.Ether},
-			req:              &mgmtpb.GetAttachInfoReq{},
-			expResp:          &mgmtpb.GetAttachInfoResp{Provider: "ofi+sockets", CrtCtxShareAddr: 0, CrtTimeout: 5, NetDevClass: netdetect.Ether},
+			clientNetworkCfg: &config.ClientNetworkCfg{
+				Provider:        "ofi+sockets",
+				CrtCtxShareAddr: 0,
+				CrtTimeout:      5,
+				NetDevClass:     netdetect.Ether,
+			},
+			req: &mgmtpb.GetAttachInfoReq{},
+			expResp: &mgmtpb.GetAttachInfoResp{
+				Provider:        "ofi+sockets",
+				CrtCtxShareAddr: 0,
+				CrtTimeout:      5,
+				NetDevClass:     netdetect.Ether,
+				Psrs: []*mgmtpb.GetAttachInfoResp_Psr{
+					{
+						Rank: msReplica.Rank.Uint32(),
+						Uri:  msReplica.FabricURI,
+					},
+				},
+			},
 		},
 	} {
 		t.Run(name, func(t *testing.T) {
@@ -69,11 +101,15 @@ func TestServer_MgmtSvc_GetAttachInfo(t *testing.T) {
 			srv.setDrpcClient(newMockDrpcClient(nil))
 			harness.started.SetTrue()
 
-			cfg := new(mockDrpcClientConfig)
-			rb, _ := proto.Marshal(&mgmtpb.GetAttachInfoResp{})
-			cfg.setSendMsgResponse(drpc.Status_SUCCESS, rb, nil)
-			srv.setDrpcClient(newMockDrpcClient(cfg))
-			tc.mgmtSvc = newMgmtSvc(harness, nil, system.MockDatabase(t, log), nil)
+			db := system.MockDatabaseWithAddr(t, log, msReplica.Addr)
+			m := system.NewMembership(log, db)
+			tc.mgmtSvc = newMgmtSvc(harness, m, db, nil)
+			if _, err := tc.mgmtSvc.membership.Add(msReplica); err != nil {
+				t.Fatal(err)
+			}
+			if _, err := tc.mgmtSvc.membership.Add(nonReplica); err != nil {
+				t.Fatal(err)
+			}
 			tc.mgmtSvc.clientNetworkCfg = tc.clientNetworkCfg
 			gotResp, gotErr := tc.mgmtSvc.GetAttachInfo(context.TODO(), tc.req)
 			if gotErr != nil {

--- a/src/control/server/mgmt_system.go
+++ b/src/control/server/mgmt_system.go
@@ -180,6 +180,7 @@ func (svc *mgmtSvc) StopRanks(ctx context.Context, req *mgmtpb.RanksReq) (*mgmtp
 	if req == nil {
 		return nil, errors.New("nil request")
 	}
+
 	if len(req.GetRanks()) == 0 {
 		return nil, errors.New("no ranks specified in request")
 	}

--- a/src/control/server/test_utils.go
+++ b/src/control/server/test_utils.go
@@ -160,8 +160,7 @@ func newMockDrpcClient(cfg *mockDrpcClientConfig) *mockDrpcClient {
 // setupMockDrpcClientBytes sets up the dRPC client for the mgmtSvc to return
 // a set of bytes as a response.
 func setupMockDrpcClientBytes(svc *mgmtSvc, respBytes []byte, err error) {
-	mi, _ := svc.harness.getMSLeaderInstance()
-
+	mi := svc.harness.instances[0]
 	cfg := &mockDrpcClientConfig{}
 	cfg.setSendMsgResponse(drpc.Status_SUCCESS, respBytes, err)
 	mi.setDrpcClient(newMockDrpcClient(cfg))

--- a/src/control/system/database.go
+++ b/src/control/system/database.go
@@ -51,6 +51,7 @@ type (
 	raftService interface {
 		Apply([]byte, time.Duration) raft.ApplyFuture
 		AddVoter(raft.ServerID, raft.ServerAddress, uint64, time.Duration) raft.IndexFuture
+		RemoveServer(raft.ServerID, uint64, time.Duration) raft.IndexFuture
 		BootstrapCluster(raft.Configuration) raft.Future
 		Leader() raft.ServerAddress
 		LeaderCh() <-chan bool
@@ -459,6 +460,11 @@ func (db *Database) GroupMap() (*GroupMap, error) {
 	for _, srv := range db.data.Members.Ranks {
 		gm.RankURIs[srv.Rank] = srv.FabricURI
 	}
+
+	if len(gm.RankURIs) == 0 {
+		return nil, ErrEmptyGroupMap
+	}
+
 	return gm, nil
 }
 
@@ -477,6 +483,11 @@ func (db *Database) ReplicaRanks() (*GroupMap, error) {
 		}
 		gm.RankURIs[srv.Rank] = srv.FabricURI
 	}
+
+	if len(gm.RankURIs) == 0 {
+		return nil, ErrEmptyGroupMap
+	}
+
 	return gm, nil
 }
 
@@ -599,6 +610,45 @@ func (db *Database) RemoveMember(m *Member) error {
 	return db.submitMemberUpdate(raftOpRemoveMember, &memberUpdate{Member: m})
 }
 
+func (db *Database) manageVoter(vc *Member, op raftOp) error {
+	// Ignore self as a voter candidate.
+	if common.CmpTCPAddr(db.getReplica(), vc.Addr) {
+		return nil
+	}
+
+	// Ignore non-replica candidates.
+	if !db.isReplica(vc.Addr) {
+		return nil
+	}
+
+	rsi := raft.ServerID(vc.Addr.String())
+	rsa := raft.ServerAddress(vc.Addr.String())
+
+	switch op {
+	case raftOpAddMember:
+	case raftOpUpdateMember, raftOpRemoveMember:
+		// If we're updating an existing member, we need to kick it out of the
+		// raft cluster and then re-add it so that it doesn't hijack the campaign.
+		db.log.Debugf("removing %s as a current raft voter", vc)
+		if err := db.raft.withReadLock(func(svc raftService) error {
+			return svc.RemoveServer(rsi, 0, 0).Error()
+		}); err != nil {
+			return errors.Wrapf(err, "failed to remove %q as a raft replica", vc.Addr)
+		}
+	default:
+		return errors.Errorf("unhandled manageVoter op: %s", op)
+	}
+
+	db.log.Debugf("adding %s as a new raft voter", vc)
+	if err := db.raft.withReadLock(func(svc raftService) error {
+		return svc.AddVoter(rsi, rsa, 0, 0).Error()
+	}); err != nil {
+		return errors.Wrapf(err, "failed to add %q as raft replica", vc.Addr)
+	}
+
+	return nil
+}
+
 // AddMember adds a member to the system.
 func (db *Database) AddMember(newMember *Member) error {
 	if err := db.CheckLeader(); err != nil {
@@ -612,24 +662,13 @@ func (db *Database) AddMember(newMember *Member) error {
 		return &ErrMemberExists{Rank: cur.Rank}
 	}
 
+	if err := db.manageVoter(newMember, raftOpAddMember); err != nil {
+		return err
+	}
+
 	if newMember.Rank.Equals(NilRank) {
 		newMember.Rank = db.data.NextRank
 		mu.NextRank = true
-	}
-
-	// If the new member is hosted by a MS replica other than this one,
-	// add it as a voter.
-	if !common.CmpTCPAddr(db.getReplica(), newMember.Addr) {
-		if db.isReplica(newMember.Addr) {
-			repAddr := newMember.Addr
-			rsi := raft.ServerID(repAddr.String())
-			rsa := raft.ServerAddress(repAddr.String())
-			if err := db.raft.withReadLock(func(svc raftService) error {
-				return svc.AddVoter(rsi, rsa, 0, 0).Error()
-			}); err != nil {
-				return errors.Wrapf(err, "failed to add %q as raft replica", repAddr)
-			}
-		}
 	}
 
 	if err := db.submitMemberUpdate(raftOpAddMember, mu); err != nil {

--- a/src/control/system/errors.go
+++ b/src/control/system/errors.go
@@ -45,6 +45,12 @@ func IsUnavailable(err error) bool {
 	return strings.Contains(errors.Cause(err).Error(), ErrRaftUnavail.Error())
 }
 
+// IsEmptyGroupMap returns a boolean indicating whether or not the
+// supplied error corresponds to an empty system group map.
+func IsEmptyGroupMap(err error) bool {
+	return strings.Contains(errors.Cause(err).Error(), ErrEmptyGroupMap.Error())
+}
+
 // ErrNotReplica indicates that a request was made to a control plane
 // instance that is not a designated Management Service replica.
 type ErrNotReplica struct {

--- a/src/control/system/mocks.go
+++ b/src/control/system/mocks.go
@@ -67,8 +67,13 @@ func MockMemberResult(rank Rank, action string, err error, state MemberState) *M
 
 func MockMembership(t *testing.T, log logging.Logger, resolver resolveTCPFn) (*Membership, *Database) {
 	db := MockDatabase(t, log)
+	m := NewMembership(log, db)
 
-	return NewMembership(log, db).WithTCPResolver(resolver), db
+	if resolver != nil {
+		return m.WithTCPResolver(resolver), db
+	}
+
+	return m, db
 }
 
 type (
@@ -99,6 +104,10 @@ func (mrs *mockRaftService) Apply(cmd []byte, timeout time.Duration) raft.ApplyF
 }
 
 func (mr *mockRaftService) AddVoter(_ raft.ServerID, _ raft.ServerAddress, _ uint64, _ time.Duration) raft.IndexFuture {
+	return &mockRaftFuture{}
+}
+
+func (mr *mockRaftService) RemoveServer(_ raft.ServerID, _ uint64, _ time.Duration) raft.IndexFuture {
 	return &mockRaftFuture{}
 }
 


### PR DESCRIPTION
Adds a number of improvements and adjustments based on
testing with 8-16 ioservers.

  * Use exponential backoffs with jitter on retries in order
    to minimize "thundering herd" issues
  * Simplify the error handling and retry logic in control/rpc.go
    and more clearly distinguish between MS/non-MS requests.
  * Leverage the retryableRequest functionality to improve
    control.SystemJoin() performance when dealing with
    adverse conditions (MS leadership changed, not available yet, etc)

Also fixes a bug with NextRank observed when a second batch of ranks
joins after a MS leadership change.