### PR TITLE
DAOS-4240 docker: move to /opt/daos

### DIFF
--- a/doc/admin/installation.md
+++ b/doc/admin/installation.md
@@ -97,20 +97,22 @@ building those tests.
 
 ### DAOS Source Code
 
-To check out the DAOS source code, run the following command:
+The DAOS repository is hosted on [GitHub](https://github.com/daos-stack/daos).
+
+To checkout the latest stable version, simply run:
 
 ```bash
-$ git clone https://github.com/daos-stack/daos.git
+git clone --recurse-submodules -b v1.0.1 https://github.com/daos-stack/daos.git
+```
+
+For the current development version, then run:
+
+```bash
+$ git clone --recurse-submodules https://github.com/daos-stack/daos.git
 ```
 
 This command clones the DAOS git repository (path referred as ${daospath}
-below). Then initialize the submodules with:
-
-```bash
-$ cd ${daospath}
-$ git submodule init
-$ git submodule update
-```
+below) and initilizes all the submodules automatically.
 
 ### Building DAOS & Dependencies
 
@@ -180,6 +182,8 @@ This creates a CentOS 7 image, fetches the latest DAOS version from GitHub,
 builds it, and installs it in the image.
 For Ubuntu and other Linux distributions, replace Dockerfile.centos.7 with
 Dockerfile.ubuntu.20.04 and the appropriate version of interest.
+`master` should be replaced by the relevant release tag (e.g. v1.0.1) to
+build a stable version.
 
 Once the image created, one can start a container that will eventually run
 the DAOS service:
@@ -187,9 +191,6 @@ the DAOS service:
 ```bash
 $ docker run -it -d --privileged --cap-add=ALL --name server -v /dev:/dev daos
 ```
-
-!!! note
-    Please make sure that the uio_pci_generic module is loaded.
 
 !!! note
     If you want to be more selective with the devices that are exported to the
@@ -227,7 +228,7 @@ Then execute the following command to build and install DAOS in the
 container:
 
 ```bash
-$ docker exec server scons --build-deps=yes install PREFIX=/usr/local
+$ docker exec server scons --build-deps=yes install PREFIX=/opt/daos
 ```
 
 ### Simple Docker Setup
@@ -243,6 +244,9 @@ The DAOS service can be started in the docker container as follows:
 $ docker exec server daos_server start \
         -o /home/daos/daos/utils/config/examples/daos_server_local.yml
 ```
+
+!!! note
+    Please make sure that the uio_pci_generic module is loaded on the host.
 
 Once started, the DAOS server waits for the administrator to format the system.
 This can be triggered in a different shell, using the following command:

--- a/doc/admin/installation.md
+++ b/doc/admin/installation.md
@@ -112,7 +112,7 @@ $ git clone --recurse-submodules https://github.com/daos-stack/daos.git
 ```
 
 This command clones the DAOS git repository (path referred as ${daospath}
-below) and initilizes all the submodules automatically.
+below) and initializes all the submodules automatically.
 
 ### Building DAOS & Dependencies
 

--- a/utils/docker/Dockerfile.centos.7
+++ b/utils/docker/Dockerfile.centos.7
@@ -94,12 +94,10 @@ RUN useradd -u $UID -ms /bin/bash $USER
 RUN echo "$USER:$PASSWD" | chpasswd
 
 # Create directory for DAOS backend storage
-RUN mkdir /mnt/daos
-RUN chown daos.daos /mnt/daos
-RUN mkdir /var/run/daos_server
-RUN chown daos.daos /var/run/daos_server
-RUN mkdir /var/run/daos_agent
-RUN chown daos.daos /var/run/daos_agent
+RUN mkdir -p /opt/daos && chown -R daos.daos /opt/daos
+RUN mkdir /mnt/daos && chown daos.daos /mnt/daos
+RUN mkdir /var/run/daos_server && chown daos.daos /var/run/daos_server
+RUN mkdir /var/run/daos_agent && chown daos.daos /var/run/daos_agent
 
 # Set maven repo mirror
 RUN mkdir -p /root/.m2
@@ -195,16 +193,15 @@ WORKDIR /home/$USER
 ARG NOBUILD
 
 # Fetch DAOS code
-RUN if [ "x$NOBUILD" = "x" ] ; then git clone https://github.com/daos-stack/daos.git; fi
+RUN if [ "x$NOBUILD" = "x" ] ; then \
+    git clone --recurse-submodules https://github.com/daos-stack/daos.git; fi
 WORKDIR /home/$USER/daos
 
 # Build DAOS & dependencies
 RUN if [ "x$NOBUILD" = "x" ] ; then \
-    git submodule init && git submodule update; fi
-RUN if [ "x$NOBUILD" = "x" ] ; then \
-    scons --build-deps=yes install PREFIX=/usr/local; fi
+    scons --build-deps=yes install PREFIX=/opt/daos; fi
 
 # Set environment variables
-ENV LD_LIBRARY_PATH=/usr/local/lib:/usr/local/lib64:$LD_LIBRARY_PATH
-ENV PATH=/usr/local/bin:$PATH
+ENV LD_LIBRARY_PATH=/opt/daos/lib:/opt/daos/lib64:$LD_LIBRARY_PATH
+ENV PATH=/opt/daos/bin:$PATH
 ENV FI_SOCKETS_MAX_CONN_RETRY=1

--- a/utils/docker/Dockerfile.leap.15
+++ b/utils/docker/Dockerfile.leap.15
@@ -120,6 +120,8 @@ RUN echo -e "<settings>\n\
 </settings>" > /home/$USER/.m2/settings.xml
 
 # Create directory for DAOS backend storage
+RUN mkdir -p /opt/daos
+RUN chown -R daos.daos /opt/daos || { cat /etc/passwd; cat /etc/group; cat /etc/shadow; chown -R daos /opt/daos; chgrp -R daos /opt/daos; ls -ld /opt/daos; }
 RUN mkdir /mnt/daos
 RUN chown daos.daos /mnt/daos || { cat /etc/passwd; cat /etc/group; cat /etc/shadow; chown daos /mnt/daos; chgrp daos /mnt/daos; ls -ld /mnt/daos; }
 RUN mkdir /var/run/daos_server
@@ -175,16 +177,15 @@ WORKDIR /home/$USER
 ARG NOBUILD
 
 # Fetch DAOS code
-RUN if [ "x$NOBUILD" = "x" ] ; then git clone https://github.com/daos-stack/daos.git; fi
+RUN if [ "x$NOBUILD" = "x" ] ; then \
+    git clone --recurse-submodules https://github.com/daos-stack/daos.git; fi
 WORKDIR /home/$USER/daos
 
 # Build DAOS & dependencies
 RUN if [ "x$NOBUILD" = "x" ] ; then \
-    git submodule init && git submodule update; fi
-RUN if [ "x$NOBUILD" = "x" ] ; then \
-    scons --build-deps=yes install PREFIX=/usr/local; fi
+    scons --build-deps=yes install PREFIX=/opt/daos; fi
 
 # Set environment variables
-ENV LD_LIBRARY_PATH=/usr/local/lib:/usr/local/lib64:$LD_LIBRARY_PATH
-ENV PATH=/usr/local/bin:$PATH
+ENV LD_LIBRARY_PATH=/opt/daos/lib:/opt/daos/lib64:$LD_LIBRARY_PATH
+ENV PATH=/opt/daos/bin:$PATH
 ENV FI_SOCKETS_MAX_CONN_RETRY=1

--- a/utils/docker/Dockerfile.ubuntu.20.04
+++ b/utils/docker/Dockerfile.ubuntu.20.04
@@ -54,12 +54,10 @@ RUN useradd -u $UID -ms /bin/bash $USER
 RUN echo "$USER:$PASSWD" | chpasswd
 
 # Create directory for DAOS backend storage
-RUN mkdir /mnt/daos
-RUN chown daos.daos /mnt/daos
-RUN mkdir /var/run/daos_server
-RUN chown daos.daos /var/run/daos_server
-RUN mkdir /var/run/daos_agent
-RUN chown daos.daos /var/run/daos_agent
+RUN mkdir -p /opt/daos && chown -R daos.daos /opt/daos
+RUN mkdir /mnt/daos && chown daos.daos /mnt/daos
+RUN mkdir /var/run/daos_server && chown daos.daos /var/run/daos_server
+RUN mkdir /var/run/daos_agent && chown daos.daos /var/run/daos_agent
 
 # Set maven repo mirror
 RUN mkdir -p /root/.m2
@@ -83,16 +81,14 @@ ARG NOBUILD
 
 # Fetch DAOS code
 RUN if [ "x$NOBUILD" = "x" ] ; then \
-  git clone https://github.com/daos-stack/daos.git; fi
+  git clone --recurse-submodules https://github.com/daos-stack/daos.git; fi
 WORKDIR /home/$USER/daos
 
 # Build DAOS & dependencies
 RUN if [ "x$NOBUILD" = "x" ] ; then \
-  git submodule init && git submodule update; fi
-RUN if [ "x$NOBUILD" = "x" ] ; then \
-  scons --build-deps=yes install PREFIX=/usr/local; fi
+  scons --build-deps=yes install PREFIX=/opt/daos; fi
 
 # Set environment variables
-ENV LD_LIBRARY_PATH=/usr/local/lib:/usr/local/lib64:$LD_LIBRARY_PATH
-ENV PATH=/usr/local/bin:$PATH
+ENV LD_LIBRARY_PATH=/opt/daos/lib:/opt/daos/lib64:$LD_LIBRARY_PATH
+ENV PATH=/opt/daos/bin:$PATH
 ENV FI_SOCKETS_MAX_CONN_RETRY=1


### PR DESCRIPTION
Change prefix from /usr/local to /opt/daos to fix
build issue with rpath not being set.
Update documentation to skip submodule init/update.

Signed-off-by: Johann Lombardi <johann.lombardi@intel.com>