### PR TITLE
DAOS-5807 tests: enable test_osa_online_reintegration

### DIFF
--- a/src/tests/ftest/osa/osa_online_reintegration.py
+++ b/src/tests/ftest/osa/osa_online_reintegration.py
@@ -26,7 +26,6 @@ import random
 import threading
 
 from itertools import product
-from apricot import skipForTicket
 from test_utils_pool import TestPool
 from write_host_file import write_host_file
 from daos_racer_utils import DaosRacerCommand
@@ -185,7 +184,6 @@ class OSAOnlineReintegration(OSAUtils):
             self.pool.display_pool_daos_space(display_string)
             pool[val].destroy()
 
-    @skipForTicket("DAOS-5807")
     def test_osa_online_reintegration(self):
         """Test ID: DAOS-5075.
 


### PR DESCRIPTION
Related issue should have been fixed via the patch PR#4135.

Signed-off-by: Fan Yong <fan.yong@intel.com>