### PR TITLE
DAOS-623 build: Fix compiler warning

### DIFF
--- a/src/cart/crt_rpc.c
+++ b/src/cart/crt_rpc.c
@@ -423,7 +423,7 @@ int
 crt_req_set_endpoint(crt_rpc_t *req, crt_endpoint_t *tgt_ep)
 {
 	struct crt_rpc_priv	*rpc_priv;
-	struct crt_grp_priv	*grp_priv;
+	struct crt_grp_priv	*grp_priv = NULL;
 	int			 rc = 0;
 
 	if (req == NULL || tgt_ep == NULL) {


### PR DESCRIPTION
It's a false positive but setting the value to NULL gets rid of it

Signed-off-by: Jeff Olivier <jeffrey.v.olivier@intel.com>