### PR TITLE
CART-89 logging: Add timeout and opcode logging

### DIFF
--- a/src/cart/crt_context.c
+++ b/src/cart/crt_context.c
@@ -806,12 +806,6 @@ crt_context_timeout_check(struct crt_context *crt_ctx)
 		crt_req_timeout_untrack(rpc_priv);
 
 		d_list_add_tail(&rpc_priv->crp_tmp_link, &timeout_list);
-		RPC_ERROR(rpc_priv,
-			  "ctx_id %d, (status: %#x) timed out, tgt rank %d, tag %d\n",
-			  crt_ctx->cc_idx,
-			  rpc_priv->crp_state,
-			  rpc_priv->crp_pub.cr_ep.ep_rank,
-			  rpc_priv->crp_pub.cr_ep.ep_tag);
 	};
 	D_MUTEX_UNLOCK(&crt_ctx->cc_mutex);
 
@@ -819,6 +813,15 @@ crt_context_timeout_check(struct crt_context *crt_ctx)
 	while ((rpc_priv = d_list_pop_entry(&timeout_list,
 					    struct crt_rpc_priv,
 					    crp_tmp_link))) {
+		RPC_ERROR(rpc_priv,
+			  "ctx_id %d, (status: %#x) timed out (%d seconds), "
+			  "target %d: %d\n",
+			  crt_ctx->cc_idx,
+			  rpc_priv->crp_state,
+			  rpc_priv->crp_timeout_sec,
+			  rpc_priv->crp_pub.cr_ep.ep_rank,
+			  rpc_priv->crp_pub.cr_ep.ep_tag);
+
 		/* check for and execute RPC timeout callbacks here */
 		crt_exec_timeout_cb(rpc_priv);
 		crt_req_timeout_hdlr(rpc_priv);

--- a/src/cart/crt_context.c
+++ b/src/cart/crt_context.c
@@ -815,7 +815,7 @@ crt_context_timeout_check(struct crt_context *crt_ctx)
 					    crp_tmp_link))) {
 		RPC_ERROR(rpc_priv,
 			  "ctx_id %d, (status: %#x) timed out (%d seconds), "
-			  "target %d: %d\n",
+			  "target (%d:%d)\n",
 			  crt_ctx->cc_idx,
 			  rpc_priv->crp_state,
 			  rpc_priv->crp_timeout_sec,

--- a/src/cart/crt_internal.h
+++ b/src/cart/crt_internal.h
@@ -57,16 +57,16 @@
 	} while (0)
 
 /* Log an error with a RPC descriptor */
-#define RPC_ERROR(rpc, fmt, ...)						\
-	do {									\
-		D_TRACE_ERROR((rpc),						\
-			"[opc=%#x (%s) rpcid=%#lx rank:tag=%d:%d] " fmt,	\
-			(rpc)->crp_pub.cr_opc,					\
-			crt_opc_to_str((rpc)->crp_pub.cr_opc),			\
-			(rpc)->crp_req_hdr.cch_rpcid,				\
-			(rpc)->crp_pub.cr_ep.ep_rank,				\
-			(rpc)->crp_pub.cr_ep.ep_tag,				\
-			## __VA_ARGS__);					\
+#define RPC_ERROR(rpc, fmt, ...)					\
+	do {								\
+		D_TRACE_ERROR((rpc),					\
+			"[opc=%#x (%s) rpcid=%#lx rank:tag=%d:%d] " fmt,\
+			(rpc)->crp_pub.cr_opc,				\
+			crt_opc_to_str((rpc)->crp_pub.cr_opc),		\
+			(rpc)->crp_req_hdr.cch_rpcid,			\
+			(rpc)->crp_pub.cr_ep.ep_rank,			\
+			(rpc)->crp_pub.cr_ep.ep_tag,			\
+			## __VA_ARGS__);				\
 	} while (0)
 
 extern uint32_t crt_swim_rpc_timeout;

--- a/src/cart/crt_internal.h
+++ b/src/cart/crt_internal.h
@@ -57,15 +57,16 @@
 	} while (0)
 
 /* Log an error with a RPC descriptor */
-#define RPC_ERROR(rpc, fmt, ...)					\
-	do {								\
-		D_TRACE_ERROR((rpc),					\
-			"[opc=%#x rpcid=%#lx rank:tag=%d:%d] " fmt,	\
-			(rpc)->crp_pub.cr_opc,				\
-			(rpc)->crp_req_hdr.cch_rpcid,			\
-			(rpc)->crp_pub.cr_ep.ep_rank,			\
-			(rpc)->crp_pub.cr_ep.ep_tag,			\
-			## __VA_ARGS__);				\
+#define RPC_ERROR(rpc, fmt, ...)						\
+	do {									\
+		D_TRACE_ERROR((rpc),						\
+			"[opc=%#x (%s) rpcid=%#lx rank:tag=%d:%d] " fmt,	\
+			(rpc)->crp_pub.cr_opc,					\
+			crt_opc_to_str((rpc)->crp_pub.cr_opc),			\
+			(rpc)->crp_req_hdr.cch_rpcid,				\
+			(rpc)->crp_pub.cr_ep.ep_rank,				\
+			(rpc)->crp_pub.cr_ep.ep_tag,				\
+			## __VA_ARGS__);					\
 	} while (0)
 
 extern uint32_t crt_swim_rpc_timeout;

--- a/src/cart/crt_rpc.c
+++ b/src/cart/crt_rpc.c
@@ -221,6 +221,8 @@ char
 	}
 }
 
+#undef X
+
 /* CRT RPC related APIs or internal functions */
 int
 crt_internal_rpc_register(void)

--- a/src/cart/crt_rpc.c
+++ b/src/cart/crt_rpc.c
@@ -214,10 +214,10 @@ char
 *crt_opc_to_str(crt_opcode_t opc)
 {
 	switch (opc) {
-		CRT_INTERNAL_RPCS_LIST
-		CRT_FI_RPCS_LIST
-		default:
-			return "External rpc";
+	CRT_INTERNAL_RPCS_LIST
+	CRT_FI_RPCS_LIST
+	default:
+		return "External rpc";
 	}
 }
 

--- a/src/cart/crt_rpc.c
+++ b/src/cart/crt_rpc.c
@@ -214,11 +214,14 @@ static struct crt_proto_rpc_format crt_fi_rpcs[] = {
 char
 *crt_opc_to_str(crt_opcode_t opc)
 {
+	if (crt_opc_is_swim(opc))
+		return "SWIM";
+
 	switch (opc) {
 	CRT_INTERNAL_RPCS_LIST
 	CRT_FI_RPCS_LIST
 	default:
-		return "External rpc";
+		return "DAOS";
 	}
 }
 

--- a/src/cart/crt_rpc.c
+++ b/src/cart/crt_rpc.c
@@ -208,6 +208,19 @@ static struct crt_proto_rpc_format crt_fi_rpcs[] = {
 
 #undef X
 
+#define X(a, b, c, d, e) case a: return #a;
+
+char
+*crt_opc_to_str(crt_opcode_t opc)
+{
+	switch (opc) {
+		CRT_INTERNAL_RPCS_LIST
+		CRT_FI_RPCS_LIST
+		default:
+			return "External rpc";
+	}
+}
+
 /* CRT RPC related APIs or internal functions */
 int
 crt_internal_rpc_register(void)

--- a/src/cart/crt_rpc.c
+++ b/src/cart/crt_rpc.c
@@ -210,6 +210,7 @@ static struct crt_proto_rpc_format crt_fi_rpcs[] = {
 
 #define X(a, b, c, d, e) case a: return #a;
 
+/* Helper function to convert internally registered RPC opc to str */
 char
 *crt_opc_to_str(crt_opcode_t opc)
 {

--- a/src/cart/crt_rpc.h
+++ b/src/cart/crt_rpc.h
@@ -662,4 +662,6 @@ int crt_iv_sync_corpc_pre_forward(crt_rpc_t *rpc, void *arg);
 int
 crt_proto_register_internal(struct crt_proto_format *crf);
 
+char *crt_opc_to_str(crt_opcode_t opc);
+
 #endif /* __CRT_RPC_H__ */

--- a/src/cart/crt_rpc.h
+++ b/src/cart/crt_rpc.h
@@ -629,7 +629,6 @@ crt_req_timedout(struct crt_rpc_priv *rpc_priv)
 static inline uint64_t
 crt_set_timeout(struct crt_rpc_priv *rpc_priv)
 {
-	uint32_t	timeout_sec;
 	uint64_t	sec_diff;
 
 	D_ASSERT(rpc_priv != NULL);

--- a/src/cart/crt_rpc.h
+++ b/src/cart/crt_rpc.h
@@ -634,15 +634,17 @@ crt_set_timeout(struct crt_rpc_priv *rpc_priv)
 
 	D_ASSERT(rpc_priv != NULL);
 
-	timeout_sec = rpc_priv->crp_timeout_sec > 0 ?
-		      rpc_priv->crp_timeout_sec : crt_gdata.cg_timeout;
+	if (rpc_priv->crp_timeout_sec == 0)
+		rpc_priv->crp_timeout_sec = crt_gdata.cg_timeout;
 
-	sec_diff = d_timeus_secdiff(timeout_sec);
+	sec_diff = d_timeus_secdiff(rpc_priv->crp_timeout_sec);
 	rpc_priv->crp_timeout_ts = sec_diff;
 
 	return sec_diff;
 }
 
+/* Convert opcode to string. Only returns string for internal RPCs */
+char *crt_opc_to_str(crt_opcode_t opc);
 
 /* crt_corpc.c */
 int crt_corpc_req_hdlr(struct crt_rpc_priv *rpc_priv);
@@ -661,7 +663,5 @@ int crt_iv_sync_corpc_pre_forward(crt_rpc_t *rpc, void *arg);
 /* crt_register.c */
 int
 crt_proto_register_internal(struct crt_proto_format *crf);
-
-char *crt_opc_to_str(crt_opcode_t opc);
 
 #endif /* __CRT_RPC_H__ */


### PR DESCRIPTION
- During timeout detection add timeout value to the error log
- crt_opc_to_str() added to print string version of internal opcodes
- RPC_ERROR modified to make use of crt_opc_to_str()

Signed-off-by: Alexander Oganezov <alexander.a.oganezov@intel.com>