### PR TITLE
DAOS-5925 logging: Correct usage of DF_UUID/DP_UUID.

### DIFF
--- a/src/container/srv_target.c
+++ b/src/container/srv_target.c
@@ -1579,8 +1579,8 @@ ds_cont_tgt_force_close(uuid_t cont_uuid)
 {
 	int rc;
 
-	D_DEBUG(DF_DSMS, DF_CONT": Force closing all handles for container "
-		DF_UUID"\n", DP_CONT(NULL, NULL), cont_uuid);
+	D_DEBUG(DF_DSMS, "Force closing all handles for container "
+		DF_UUID"\n", DP_UUID(cont_uuid));
 
 	rc = dss_thread_collective(cont_close_all, &cont_uuid, 0, DSS_ULT_IO);
 	if (rc != 0)

--- a/src/pool/srv_pool.c
+++ b/src/pool/srv_pool.c
@@ -3219,9 +3219,10 @@ rechoose:
 	rc = out->pto_op.po_rc;
 	if (rc != 0) {
 		D_ERROR(DF_UUID": Failed to set targets to %s state: "DF_RC"\n",
+			DP_UUID(pool_uuid),
 			state == PO_COMP_ST_DOWN ? "DOWN" :
 			state == PO_COMP_ST_UP ? "UP" : "UNKNOWN",
-			DP_UUID(pool_uuid), DP_RC(rc));
+			DP_RC(rc));
 		D_GOTO(out_rpc, rc);
 	}
 

--- a/src/pool/srv_util.c
+++ b/src/pool/srv_util.c
@@ -811,9 +811,10 @@ update_targets_ult(void *arg)
 		rc = dsc_pool_tgt_exclude(uta->uta_pool_id, NULL /* grp */,
 					  &svc, &tgt_list);
 	if (rc)
-		D_ERROR(DF_UUID": %s targets failed. %d\n",
+		D_ERROR(DF_UUID": %s targets failed. " DF_RC "\n",
+			DP_UUID(uta->uta_pool_id),
 			uta->uta_reint ? "Reint" : "Exclude",
-			DP_UUID(uta->uta_pool_id), rc);
+			DP_RC(rc));
 
 	free_update_targets_arg(uta);
 }
@@ -876,8 +877,8 @@ nvme_reaction(int *tgt_ids, int tgt_cnt, bool reint)
 			 * to transit BIO BS state to now.
 			 */
 			D_DEBUG(DB_MGMT, DF_UUID": Targets are all in %s\n",
-				reint ? "UP/UPIN" : "DOWN/DOWNOUT",
-				DP_UUID(pool_info->spi_id));
+				DP_UUID(pool_info->spi_id),
+				reint ? "UP/UPIN" : "DOWN/DOWNOUT");
 			break;
 		case 1:
 			/*
@@ -885,8 +886,8 @@ nvme_reaction(int *tgt_ids, int tgt_cnt, bool reint)
 			 * need to send exclude/reint RPC.
 			 */
 			D_DEBUG(DB_MGMT, DF_UUID": Trigger targets %s.\n",
-				reint ? "reint" : "exclude",
-				DP_UUID(pool_info->spi_id));
+				DP_UUID(pool_info->spi_id),
+				reint ? "reint" : "exclude");
 			rc = update_pool_targets(pool_info->spi_id, tgt_ids,
 						 tgt_cnt, reint, pl_rank);
 			if (rc == 0)

--- a/src/tests/suite/daos_degraded.c
+++ b/src/tests/suite/daos_degraded.c
@@ -84,7 +84,8 @@ insert_lookup_enum_with_ops(test_arg_t *arg, int op_kill)
 
 	ioreq_init(&req, arg->coh, oid, DAOS_IOD_ARRAY, arg);
 	if (!rank) {
-		print_message("Using pool: %s\n", DP_UUID(arg->pool.pool_uuid));
+		print_message("Using pool: " DF_UUID "\n",
+			      DP_UUID(arg->pool.pool_uuid));
 		print_message("Inserting %d keys ...\n", g_dkeys * size);
 	}
 

--- a/src/tests/suite/daos_degraded.c
+++ b/src/tests/suite/daos_degraded.c
@@ -84,7 +84,7 @@ insert_lookup_enum_with_ops(test_arg_t *arg, int op_kill)
 
 	ioreq_init(&req, arg->coh, oid, DAOS_IOD_ARRAY, arg);
 	if (!rank) {
-		print_message("Using pool: " DF_UUID "\n",
+		print_message("Using pool: " DF_UUIDF "\n",
 			      DP_UUID(arg->pool.pool_uuid));
 		print_message("Inserting %d keys ...\n", g_dkeys * size);
 	}

--- a/src/tests/suite/daos_nvme_recovery.c
+++ b/src/tests/suite/daos_nvme_recovery.c
@@ -104,7 +104,7 @@ nvme_recov_1(void **state)
 	for (i = 0; i < ndisks; i++) {
 		if (devices[i].rank != rank)
 			continue;
-		print_message("Rank=%d UUID=" DF_UUID " state=%s host=%s tgts=",
+		print_message("Rank=%d UUID=" DF_UUIDF " state=%s host=%s tgts=",
 			      devices[i].rank, DP_UUID(devices[i].device_id),
 			      devices[i].state, devices[i].host);
 		for (j = 0; j < devices[i].n_tgtidx; j++)
@@ -247,7 +247,7 @@ nvme_test_verify_device_stats(void **state)
 	rc = dmg_storage_device_list(dmg_config_file, NULL, devices);
 	assert_int_equal(rc, 0);
 	for (i = 0; i < ndisks; i++)
-		print_message("Rank=%d UUID=" DF_UUID " state=%s host=%s\n",
+		print_message("Rank=%d UUID=" DF_UUIDF " state=%s host=%s\n",
 			      devices[i].rank, DP_UUID(devices[i].device_id),
 			devices[i].state, devices[i].host);
 
@@ -292,7 +292,7 @@ nvme_test_verify_device_stats(void **state)
 	/**
 	*Set single device for rank0 to faulty.
 	*/
-	print_message("NVMe with UUID=" DF_UUID " on host=%s\" set to Faulty\n",
+	print_message("NVMe with UUID=" DF_UUIDF " on host=%s\" set to Faulty\n",
 		      DP_UUID(devices[rank_pos].device_id),
 		devices[rank_pos].host);
 	rc = dmg_storage_set_nvme_fault(dmg_config_file,
@@ -391,7 +391,7 @@ nvme_test_get_blobstore_state(void **state)
 	rc = dmg_storage_device_list(dmg_config_file, NULL, devices);
 	assert_int_equal(rc, 0);
 	for (i = 0; i < ndisks; i++)
-		print_message("Rank=%d UUID=" DF_UUID " state=%s host=%s\n",
+		print_message("Rank=%d UUID=" DF_UUIDF " state=%s host=%s\n",
 			      devices[i].rank, DP_UUID(devices[i].device_id),
 			devices[i].state, devices[i].host);
 
@@ -436,7 +436,7 @@ nvme_test_get_blobstore_state(void **state)
 	 * Manually set first device returned to faulty via
 	 * 'dmg storage set nvme-faulty'.
 	 */
-	print_message("NVMe with UUID=" DF_UUID " on host=%s\" set to Faulty\n",
+	print_message("NVMe with UUID=" DF_UUIDF " on host=%s\" set to Faulty\n",
 		      DP_UUID(devices[0].device_id),
 		      devices[0].host);
 	rc = dmg_storage_set_nvme_fault(dmg_config_file, devices[0].host,

--- a/src/tests/suite/daos_nvme_recovery.c
+++ b/src/tests/suite/daos_nvme_recovery.c
@@ -104,7 +104,7 @@ nvme_recov_1(void **state)
 	for (i = 0; i < ndisks; i++) {
 		if (devices[i].rank != rank)
 			continue;
-		print_message("Rank=%d UUID=%s state=%s host=%s tgts=",
+		print_message("Rank=%d UUID=" DF_UUID " state=%s host=%s tgts=",
 			      devices[i].rank, DP_UUID(devices[i].device_id),
 			      devices[i].state, devices[i].host);
 		for (j = 0; j < devices[i].n_tgtidx; j++)
@@ -247,7 +247,7 @@ nvme_test_verify_device_stats(void **state)
 	rc = dmg_storage_device_list(dmg_config_file, NULL, devices);
 	assert_int_equal(rc, 0);
 	for (i = 0; i < ndisks; i++)
-		print_message("Rank=%d UUID=%s state=%s host=%s\n",
+		print_message("Rank=%d UUID=" DF_UUID " state=%s host=%s\n",
 			      devices[i].rank, DP_UUID(devices[i].device_id),
 			devices[i].state, devices[i].host);
 
@@ -292,7 +292,7 @@ nvme_test_verify_device_stats(void **state)
 	/**
 	*Set single device for rank0 to faulty.
 	*/
-	print_message("NVMe with UUID=%s on host=%s\" set to Faulty\n",
+	print_message("NVMe with UUID=" DF_UUID " on host=%s\" set to Faulty\n",
 		      DP_UUID(devices[rank_pos].device_id),
 		devices[rank_pos].host);
 	rc = dmg_storage_set_nvme_fault(dmg_config_file,
@@ -391,7 +391,7 @@ nvme_test_get_blobstore_state(void **state)
 	rc = dmg_storage_device_list(dmg_config_file, NULL, devices);
 	assert_int_equal(rc, 0);
 	for (i = 0; i < ndisks; i++)
-		print_message("Rank=%d UUID=%s state=%s host=%s\n",
+		print_message("Rank=%d UUID=" DF_UUID " state=%s host=%s\n",
 			      devices[i].rank, DP_UUID(devices[i].device_id),
 			devices[i].state, devices[i].host);
 
@@ -436,7 +436,7 @@ nvme_test_get_blobstore_state(void **state)
 	 * Manually set first device returned to faulty via
 	 * 'dmg storage set nvme-faulty'.
 	 */
-	print_message("NVMe with UUID=%s on host=%s\" set to Faulty\n",
+	print_message("NVMe with UUID=" DF_UUID " on host=%s\" set to Faulty\n",
 		      DP_UUID(devices[0].device_id),
 		      devices[0].host);
 	rc = dmg_storage_set_nvme_fault(dmg_config_file, devices[0].host,

--- a/src/tests/suite/daos_test_common.c
+++ b/src/tests/suite/daos_test_common.c
@@ -843,7 +843,7 @@ daos_dmg_pool_target(const char *sub_cmd, const uuid_t pool_uuid,
 	int		rc;
 
 	/* build and invoke dmg cmd */
-	dts_create_config(dmg_cmd, "dmg pool %s -i --pool=%s --rank=%d",
+	dts_create_config(dmg_cmd, "dmg pool %s -i --pool=" DF_UUIDF " --rank=%d",
 			  sub_cmd, DP_UUID(pool_uuid), rank);
 
 	if (tgt_idx != -1)

--- a/src/vos/vos_container.c
+++ b/src/vos/vos_container.c
@@ -99,7 +99,8 @@ cont_df_rec_alloc(struct btr_instance *tins, d_iov_t *key_iov,
 	args = (struct cont_df_args *)val_iov->iov_buf;
 	pool = args->ca_pool;
 
-	D_DEBUG(DB_DF, "Allocating container uuid=%s\n", DP_UUID(ukey->uuid));
+	D_DEBUG(DB_DF, "Allocating container uuid=" DF_UUID "\n",
+		DP_UUID(ukey->uuid));
 	offset = umem_zalloc(&tins->ti_umm, sizeof(struct vos_cont_df));
 	if (UMOFF_IS_NULL(offset))
 		return -DER_NOSPACE;


### PR DESCRIPTION
There were cases where DP_UUID wasn't used, resulting in invalid
data being written to the log file which was causing test errors
but on inspection there were also a number of places where
DF_UUID wasn't being used correctly either so fix those.

This fixes at least one logging error which was causing test failures
and could have caused a crash, and it resolves a number of places
where incorrect data would have been logged.

Signed-off-by: Ashley Pittman <ashley.m.pittman@intel.com>