### PR TITLE
DAOS-6382 core: Call daos_handle_is_(valid|inval) correctly.

### DIFF
--- a/src/bio/smd/smd_device.c
+++ b/src/bio/smd/smd_device.c
@@ -40,8 +40,8 @@ smd_dev_assign(uuid_t dev_id, int tgt_id)
 	struct d_uuid		key_dev, bond_dev;
 	int			rc;
 
-	D_ASSERT(!daos_handle_is_inval(smd_store.ss_dev_hdl));
-	D_ASSERT(!daos_handle_is_inval(smd_store.ss_tgt_hdl));
+	D_ASSERT(daos_handle_is_valid(smd_store.ss_dev_hdl));
+	D_ASSERT(daos_handle_is_valid(smd_store.ss_tgt_hdl));
 
 	uuid_copy(key_dev.uuid, dev_id);
 	smd_lock(&smd_store);
@@ -139,7 +139,7 @@ smd_dev_set_state(uuid_t dev_id, enum smd_dev_state state)
 	int			rc;
 
 	D_ASSERT(state == SMD_DEV_NORMAL || state == SMD_DEV_FAULTY);
-	D_ASSERT(!daos_handle_is_inval(smd_store.ss_dev_hdl));
+	D_ASSERT(daos_handle_is_valid(smd_store.ss_dev_hdl));
 
 	uuid_copy(key_dev.uuid, dev_id);
 	smd_lock(&smd_store);
@@ -204,7 +204,7 @@ fetch_dev_info(uuid_t dev_id, struct smd_dev_info **dev_info)
 	d_iov_t			 key, val;
 	int			 rc;
 
-	D_ASSERT(!daos_handle_is_inval(smd_store.ss_dev_hdl));
+	D_ASSERT(daos_handle_is_valid(smd_store.ss_dev_hdl));
 
 	uuid_copy(key_dev.uuid, dev_id);
 
@@ -245,7 +245,7 @@ smd_dev_get_by_tgt(int tgt_id, struct smd_dev_info **dev_info)
 	d_iov_t		key, val;
 	int		rc;
 
-	D_ASSERT(!daos_handle_is_inval(smd_store.ss_tgt_hdl));
+	D_ASSERT(daos_handle_is_valid(smd_store.ss_tgt_hdl));
 	smd_lock(&smd_store);
 
 	d_iov_set(&key, &tgt_id, sizeof(tgt_id));
@@ -277,7 +277,7 @@ smd_dev_list(d_list_t *dev_list, int *devs)
 	int			 rc;
 
 	D_ASSERT(dev_list && d_list_empty(dev_list));
-	D_ASSERT(!daos_handle_is_inval(smd_store.ss_dev_hdl));
+	D_ASSERT(daos_handle_is_valid(smd_store.ss_dev_hdl));
 
 	smd_lock(&smd_store);
 
@@ -350,8 +350,8 @@ smd_dev_replace(uuid_t old_id, uuid_t new_id, d_list_t *pool_list)
 	int			 i, tgt_id, rc;
 
 	D_ASSERT(uuid_compare(old_id, new_id) != 0);
-	D_ASSERT(!daos_handle_is_inval(smd_store.ss_dev_hdl));
-	D_ASSERT(!daos_handle_is_inval(smd_store.ss_tgt_hdl));
+	D_ASSERT(daos_handle_is_valid(smd_store.ss_dev_hdl));
+	D_ASSERT(daos_handle_is_valid(smd_store.ss_tgt_hdl));
 
 	uuid_copy(key_dev.uuid, new_id);
 	smd_lock(&smd_store);

--- a/src/bio/smd/smd_pool.c
+++ b/src/bio/smd/smd_pool.c
@@ -53,7 +53,7 @@ smd_pool_assign(uuid_t pool_id, int tgt_id, uint64_t blob_id, uint64_t blob_sz)
 	d_iov_t			key, val;
 	int			tgt_idx, rc;
 
-	D_ASSERT(!daos_handle_is_inval(smd_store.ss_pool_hdl));
+	D_ASSERT(daos_handle_is_valid(smd_store.ss_pool_hdl));
 
 	uuid_copy(key_pool.uuid, pool_id);
 	smd_lock(&smd_store);
@@ -123,7 +123,7 @@ smd_pool_unassign(uuid_t pool_id, int tgt_id)
 	uint64_t		*blob_src, *blob_tgt;
 	int			 tgt_idx, rc, move_cnt;
 
-	D_ASSERT(!daos_handle_is_inval(smd_store.ss_pool_hdl));
+	D_ASSERT(daos_handle_is_valid(smd_store.ss_pool_hdl));
 
 	uuid_copy(key_pool.uuid, pool_id);
 	smd_lock(&smd_store);
@@ -220,7 +220,7 @@ smd_pool_get(uuid_t pool_id, struct smd_pool_info **pool_info)
 	d_iov_t			 key, val;
 	int			 rc;
 
-	D_ASSERT(!daos_handle_is_inval(smd_store.ss_pool_hdl));
+	D_ASSERT(daos_handle_is_valid(smd_store.ss_pool_hdl));
 
 	uuid_copy(key_pool.uuid, pool_id);
 	smd_lock(&smd_store);
@@ -254,7 +254,7 @@ smd_pool_get_blob(uuid_t pool_id, int tgt_id, uint64_t *blob_id)
 	d_iov_t			key, val;
 	int			tgt_idx, rc;
 
-	D_ASSERT(!daos_handle_is_inval(smd_store.ss_pool_hdl));
+	D_ASSERT(daos_handle_is_valid(smd_store.ss_pool_hdl));
 
 	uuid_copy(key_pool.uuid, pool_id);
 	smd_lock(&smd_store);
@@ -295,7 +295,7 @@ smd_pool_list(d_list_t *pool_list, int *pools)
 	int			 rc;
 
 	D_ASSERT(pool_list && d_list_empty(pool_list));
-	D_ASSERT(!daos_handle_is_inval(smd_store.ss_pool_hdl));
+	D_ASSERT(daos_handle_is_valid(smd_store.ss_pool_hdl));
 
 	smd_lock(&smd_store);
 
@@ -367,7 +367,7 @@ smd_replace_blobs(struct smd_pool_info *info, uint32_t tgt_cnt, int *tgts)
 	int			tgt_id, tgt_idx;
 	int			i, rc;
 
-	D_ASSERT(!daos_handle_is_inval(smd_store.ss_pool_hdl));
+	D_ASSERT(daos_handle_is_valid(smd_store.ss_pool_hdl));
 
 	uuid_copy(key_pool.uuid, info->spi_id);
 

--- a/src/bio/smd/smd_store.c
+++ b/src/bio/smd/smd_store.c
@@ -214,17 +214,17 @@ close:
 static void
 smd_store_close(void)
 {
-	if (!daos_handle_is_inval(smd_store.ss_dev_hdl)) {
+	if (daos_handle_is_valid(smd_store.ss_dev_hdl)) {
 		dbtree_close(smd_store.ss_dev_hdl);
 		smd_store.ss_dev_hdl = DAOS_HDL_INVAL;
 	}
 
-	if (!daos_handle_is_inval(smd_store.ss_pool_hdl)) {
+	if (daos_handle_is_valid(smd_store.ss_pool_hdl)) {
 		dbtree_close(smd_store.ss_pool_hdl);
 		smd_store.ss_pool_hdl = DAOS_HDL_INVAL;
 	}
 
-	if (!daos_handle_is_inval(smd_store.ss_tgt_hdl)) {
+	if (daos_handle_is_valid(smd_store.ss_tgt_hdl)) {
 		dbtree_close(smd_store.ss_tgt_hdl);
 		smd_store.ss_tgt_hdl = DAOS_HDL_INVAL;
 	}

--- a/src/client/api/event.c
+++ b/src/client/api/event.c
@@ -409,7 +409,7 @@ daos_event_launch(struct daos_event *ev)
 		goto out;
 	}
 
-	if (!daos_handle_is_inval(evx->evx_eqh)) {
+	if (daos_handle_is_valid(evx->evx_eqh)) {
 		eqx = daos_eq_lookup(evx->evx_eqh);
 		if (eqx == NULL) {
 			D_ERROR("Can't find eq from handle %"PRIu64"\n",
@@ -471,7 +471,7 @@ daos_event_complete(struct daos_event *ev, int rc)
 	struct daos_event_private	*evx = daos_ev2evx(ev);
 	struct daos_eq_private		*eqx = NULL;
 
-	if (!daos_handle_is_inval(evx->evx_eqh)) {
+	if (daos_handle_is_valid(evx->evx_eqh)) {
 		eqx = daos_eq_lookup(evx->evx_eqh);
 		D_ASSERT(eqx != NULL);
 
@@ -578,7 +578,7 @@ daos_event_test(struct daos_event *ev, int64_t timeout, bool *flag)
 	epa.evx = evx;
 	epa.eqx = NULL;
 
-	if (!daos_handle_is_inval(evx->evx_eqh)) {
+	if (daos_handle_is_valid(evx->evx_eqh)) {
 		epa.eqx = daos_eq_lookup(evx->evx_eqh);
 		if (epa.eqx == NULL) {
 			D_ERROR("Can't find eq from handle %"PRIu64"\n",
@@ -1015,7 +1015,7 @@ daos_event_init(struct daos_event *ev, daos_handle_t eqh,
 		evx->evx_sched	= parent_evx->evx_sched;
 		evx->evx_parent	= parent_evx;
 		parent_evx->evx_nchild++;
-	} else if (!daos_handle_is_inval(eqh)) {
+	} else if (daos_handle_is_valid(eqh)) {
 		/* if there is event queue */
 		evx->evx_eqh = eqh;
 		eqx = daos_eq_lookup(eqh);
@@ -1053,7 +1053,7 @@ daos_event_fini(struct daos_event *ev)
 	struct daos_eq			*eq = NULL;
 	int				 rc = 0;
 
-	if (!daos_handle_is_inval(evx->evx_eqh)) {
+	if (daos_handle_is_valid(evx->evx_eqh)) {
 		eqx = daos_eq_lookup(evx->evx_eqh);
 		if (eqx == NULL)
 			return -DER_NONEXIST;
@@ -1175,7 +1175,7 @@ daos_event_abort(struct daos_event *ev)
 	struct daos_event_private	*evx = daos_ev2evx(ev);
 	struct daos_eq_private		*eqx = NULL;
 
-	if (!daos_handle_is_inval(evx->evx_eqh)) {
+	if (daos_handle_is_valid(evx->evx_eqh)) {
 		eqx = daos_eq_lookup(evx->evx_eqh);
 		if (eqx == NULL) {
 			D_ERROR("Invalid EQ handle %"PRIu64"\n",

--- a/src/client/dfuse/dfuse_inode.c
+++ b/src/client/dfuse/dfuse_inode.c
@@ -80,10 +80,10 @@ ie_close(struct dfuse_projection_info *fs_handle, struct dfuse_inode_entry *ie)
 		D_MUTEX_LOCK(&fs_handle->dpi_info->di_lock);
 
 		DFUSE_TRA_INFO(ie->ie_dfs, "Closing dfs_root %d %d",
-			       !daos_handle_is_inval(dfp->dfp_poh),
-			       !daos_handle_is_inval(dfs->dfs_coh));
+			       daos_handle_is_valid(dfp->dfp_poh),
+			       daos_handle_is_valid(dfs->dfs_coh));
 
-		if (!daos_handle_is_inval(dfs->dfs_coh)) {
+		if (daos_handle_is_valid(dfs->dfs_coh)) {
 			rc = dfs_umount(dfs->dfs_ns);
 			if (rc != 0)
 				DFUSE_TRA_ERROR(dfs,
@@ -103,7 +103,7 @@ ie_close(struct dfuse_projection_info *fs_handle, struct dfuse_inode_entry *ie)
 		D_FREE(dfs);
 
 		if (d_list_empty(&dfp->dfp_dfs_list)) {
-			if (!daos_handle_is_inval(dfp->dfp_poh)) {
+			if (daos_handle_is_valid(dfp->dfp_poh)) {
 				rc = daos_pool_disconnect(dfp->dfp_poh, NULL);
 				if (rc != -DER_SUCCESS) {
 					DFUSE_TRA_ERROR(dfp,

--- a/src/client/dfuse/dfuse_main.c
+++ b/src/client/dfuse/dfuse_main.c
@@ -540,7 +540,7 @@ out_dfs:
 		d_list_for_each_entry_safe(dfs, dfsn, &dfp->dfp_dfs_list,
 					   dfs_list) {
 			DFUSE_TRA_ERROR(dfs, "DFS left at the end");
-			if (!daos_handle_is_inval(dfs->dfs_coh)) {
+			if (daos_handle_is_valid(dfs->dfs_coh)) {
 				rc = dfs_umount(dfs->dfs_ns);
 				if (rc != 0)
 					DFUSE_TRA_ERROR(dfs,
@@ -559,7 +559,7 @@ out_dfs:
 			D_FREE(dfs);
 		}
 
-		if (!daos_handle_is_inval(dfp->dfp_poh)) {
+		if (daos_handle_is_valid(dfp->dfp_poh)) {
 			rc = daos_pool_disconnect(dfp->dfp_poh, NULL);
 			if (rc != -DER_SUCCESS) {
 				DFUSE_TRA_ERROR(dfp,

--- a/src/client/dfuse/ops/statfs.c
+++ b/src/client/dfuse/ops/statfs.c
@@ -31,7 +31,7 @@ dfuse_cb_statfs(fuse_req_t req, struct dfuse_inode_entry *inode)
 	daos_pool_info_t info = {.pi_bits = DPI_SPACE};
 	int rc;
 
-	if (!daos_handle_is_inval(inode->ie_dfs->dfs_dfp->dfp_poh)) {
+	if (daos_handle_is_valid(inode->ie_dfs->dfs_dfp->dfp_poh)) {
 		rc = daos_pool_query(inode->ie_dfs->dfs_dfp->dfp_poh, NULL,
 				     &info, NULL, NULL);
 		if (rc != -DER_SUCCESS)

--- a/src/common/btree_class.c
+++ b/src/common/btree_class.c
@@ -158,7 +158,7 @@ destroy_tree(daos_handle_t tree, d_iov_t *key)
 		umem_class_init(&attr.ba_uma, &umm);
 
 		rc_tmp = umem_tx_begin(&umm, NULL);
-		if (rc_tmp != 0 && !daos_handle_is_inval(hdl_tmp)) {
+		if (rc_tmp != 0 && daos_handle_is_valid(hdl_tmp)) {
 			dbtree_close(hdl_tmp);
 			return rc_tmp;
 		}
@@ -169,7 +169,7 @@ destroy_tree(daos_handle_t tree, d_iov_t *key)
 			rc_tmp = dbtree_delete(tree, BTR_PROBE_EQ, key, NULL);
 		}
 
-		if (!daos_handle_is_inval(hdl_tmp))
+		if (daos_handle_is_valid(hdl_tmp))
 			dbtree_close(hdl_tmp);
 
 		if (rc_tmp != 0)

--- a/src/common/dts.c
+++ b/src/common/dts.c
@@ -165,7 +165,7 @@ credits_init(struct dts_context *tsc)
 			return -1;
 		}
 
-		if (!daos_handle_is_inval(tsc->tsc_eqh)) {
+		if (daos_handle_is_valid(tsc->tsc_eqh)) {
 			rc = daos_event_init(&cred->tc_ev, tsc->tsc_eqh, NULL);
 			D_ASSERTF(!rc, "rc="DF_RC"\n", DP_RC(rc));
 			cred->tc_evp = &cred->tc_ev;
@@ -183,13 +183,13 @@ credits_fini(struct dts_context *tsc)
 	D_ASSERT(!tsc->tsc_cred_inuse);
 
 	for (i = 0; i < tsc->tsc_cred_nr; i++) {
-		if (!daos_handle_is_inval(tsc->tsc_eqh))
+		if (daos_handle_is_valid(tsc->tsc_eqh))
 			daos_event_fini(&tsc->tsc_cred_buf[i].tc_ev);
 
 		D_FREE(tsc->tsc_cred_buf[i].tc_vbuf);
 	}
 
-	if (!daos_handle_is_inval(tsc->tsc_eqh))
+	if (daos_handle_is_valid(tsc->tsc_eqh))
 		daos_eq_destroy(tsc->tsc_eqh, DAOS_EQ_DESTROY_FORCE);
 }
 
@@ -345,7 +345,7 @@ cont_fini(struct dts_context *tsc)
 bool
 dts_is_async(struct dts_context *tsc)
 {
-	return !daos_handle_is_inval(tsc->tsc_eqh);
+	return daos_handle_is_valid(tsc->tsc_eqh);
 }
 
 /* see comments in daos/dts.h */

--- a/src/common/tests/btree.c
+++ b/src/common/tests/btree.c
@@ -285,7 +285,7 @@ ik_btr_open_create(void **state)
 	create = tst_fn_val.input;
 	arg = tst_fn_val.optval;
 
-	if (!daos_handle_is_inval(ik_toh)) {
+	if (daos_handle_is_valid(ik_toh)) {
 		fail_msg("Tree has been opened\n");
 	}
 

--- a/src/common/tests/btree_direct.c
+++ b/src/common/tests/btree_direct.c
@@ -317,7 +317,7 @@ sk_btr_open_create(void **state)
 	create = tst_fn_val.input;
 	arg = tst_fn_val.optval;
 
-	if (!daos_handle_is_inval(sk_toh)) {
+	if (daos_handle_is_valid(sk_toh)) {
 		fail_msg("Tree has been opened\n");
 	}
 

--- a/src/container/srv_cli.c
+++ b/src/container/srv_cli.c
@@ -104,13 +104,13 @@ dsc_cont_open(daos_handle_t poh, uuid_t cont_uuid, uuid_t coh_uuid,
 	struct dc_pool	*pool = NULL;
 	int		rc = 0;
 
-	if (!daos_handle_is_inval(*coh)) {
+	if (daos_handle_is_valid(*coh)) {
 		cont = dc_hdl2cont(*coh);
 		if (cont != NULL)
 			D_GOTO(out, rc);
 	}
 
-	D_ASSERT(!daos_handle_is_inval(poh));
+	D_ASSERT(daos_handle_is_valid(poh));
 	pool = dc_hdl2pool(poh);
 	if (pool == NULL)
 		D_GOTO(out, rc = -DER_NO_HDL);

--- a/src/container/srv_target.c
+++ b/src/container/srv_target.c
@@ -605,7 +605,7 @@ cont_child_free_ref(struct daos_llink *llink)
 	struct ds_cont_child *cont = cont_child_obj(llink);
 
 	D_ASSERT(cont->sc_pool != NULL);
-	D_ASSERT(!daos_handle_is_inval(cont->sc_hdl));
+	D_ASSERT(daos_handle_is_valid(cont->sc_hdl));
 
 	D_DEBUG(DF_DSMS, DF_CONT": freeing\n",
 		DP_CONT(cont->sc_pool->spc_uuid, cont->sc_uuid));
@@ -1412,7 +1412,7 @@ err_cont:
 		cont_child_put(tls->dt_cont_cache, hdl->sch_cont);
 	}
 
-	if (!daos_handle_is_inval(poh)) {
+	if (daos_handle_is_valid(poh)) {
 		D_DEBUG(DF_DSMS, DF_CONT": destroying new vos container\n",
 			DP_CONT(pool_uuid, cont_uuid));
 		D_ASSERT(hdl->sch_cont != NULL);

--- a/src/dtx/dtx_common.c
+++ b/src/dtx/dtx_common.c
@@ -96,7 +96,7 @@ dtx_free_dbca(struct dtx_batched_commit_args *dbca)
 {
 	struct ds_cont_child	*cont = dbca->dbca_cont;
 
-	if (!daos_handle_is_inval(cont->sc_dtx_cos_hdl)) {
+	if (daos_handle_is_valid(cont->sc_dtx_cos_hdl)) {
 		dbtree_destroy(cont->sc_dtx_cos_hdl, NULL);
 		cont->sc_dtx_cos_hdl = DAOS_HDL_INVAL;
 	}

--- a/src/dtx/dtx_rpc.c
+++ b/src/dtx/dtx_rpc.c
@@ -648,7 +648,7 @@ out:
 
 	D_FREE(dti);
 
-	if (!daos_handle_is_inval(tree_hdl))
+	if (daos_handle_is_valid(tree_hdl))
 		dbtree_destroy(tree_hdl, NULL);
 
 	D_ASSERT(d_list_empty(&head));
@@ -708,7 +708,7 @@ out:
 
 	D_FREE(dti);
 
-	if (!daos_handle_is_inval(tree_hdl))
+	if (daos_handle_is_valid(tree_hdl))
 		dbtree_destroy(tree_hdl, NULL);
 
 	D_ASSERT(d_list_empty(&head));

--- a/src/object/cli_ec.c
+++ b/src/object/cli_ec.c
@@ -2157,7 +2157,7 @@ obj_ec_recov_task_fini(struct obj_reasb_req *reasb_req)
 
 	for (i = 0; i < fail_info->efi_recov_ntasks; i++) {
 		d_sgl_fini(&fail_info->efi_recov_tasks[i].ert_sgl, false);
-		if (!daos_handle_is_inval(fail_info->efi_recov_tasks[i].ert_th))
+		if (daos_handle_is_valid(fail_info->efi_recov_tasks[i].ert_th))
 			dc_tx_local_close(fail_info->efi_recov_tasks[i].ert_th);
 	}
 	D_FREE(fail_info->efi_recov_tasks);

--- a/src/object/cli_obj.c
+++ b/src/object/cli_obj.c
@@ -3584,7 +3584,7 @@ obj_comp_cb(tse_task_t *task, void *data)
 			}
 			break;
 		case DAOS_OBJ_RPC_UPDATE:
-			D_ASSERT(!daos_handle_is_valid(obj_auxi->th));
+			D_ASSERT(daos_handle_is_inval(obj_auxi->th));
 
 			obj_rw_csum_destroy(obj, obj_auxi);
 			break;
@@ -3608,7 +3608,7 @@ obj_comp_cb(tse_task_t *task, void *data)
 		case DAOS_OBJ_RPC_PUNCH:
 		case DAOS_OBJ_RPC_PUNCH_DKEYS:
 		case DAOS_OBJ_RPC_PUNCH_AKEYS:
-			D_ASSERT(!daos_handle_is_valid(obj_auxi->th));
+			D_ASSERT(daos_handle_is_inval(obj_auxi->th));
 			break;
 		case DAOS_OBJ_RPC_QUERY_KEY:
 		case DAOS_OBJ_RECX_RPC_ENUMERATE:

--- a/src/object/obj_tx.c
+++ b/src/object/obj_tx.c
@@ -292,7 +292,7 @@ dc_tx_alloc(daos_handle_t coh, daos_epoch_t epoch, uint64_t flags,
 		return -DER_NO_HDL;
 
 	ph = dc_cont_hdl2pool_hdl(coh);
-	D_ASSERT(!daos_handle_is_inval(ph));
+	D_ASSERT(daos_handle_is_valid(ph));
 
 	D_ALLOC_PTR(tx);
 	if (tx == NULL)

--- a/src/object/srv_obj.c
+++ b/src/object/srv_obj.c
@@ -111,7 +111,7 @@ obj_rw_complete(crt_rpc_t *rpc, unsigned int map_version,
 	struct obj_rw_in	*orwi = crt_req_get(rpc);
 	int			 rc;
 
-	if (!daos_handle_is_inval(ioh)) {
+	if (daos_handle_is_valid(ioh)) {
 		bool update = obj_rpc_is_update(rpc);
 
 		if (update) {
@@ -340,7 +340,7 @@ obj_bulk_transfer(crt_rpc_t *rpc, crt_bulk_op_t bulk_op, bool bulk_bind,
 			struct bio_sglist *bsgl;
 			bool deduped_skip = true;
 
-			D_ASSERT(!daos_handle_is_inval(ioh));
+			D_ASSERT(daos_handle_is_valid(ioh));
 			bsgl = vos_iod_sgl_at(ioh, i);
 			if (bsgls_dup) {	/* dedup verify case */
 				rc = vos_dedup_dup_bsgl(ioh, bsgl,
@@ -1056,7 +1056,7 @@ obj_dedup_verify(daos_handle_t ioh, struct bio_sglist *bsgls_dup, int sgl_nr)
 	struct bio_sglist	*bsgl, *bsgl_dup;
 	int			 i, j, rc;
 
-	D_ASSERT(!daos_handle_is_inval(ioh));
+	D_ASSERT(daos_handle_is_valid(ioh));
 	D_ASSERT(bsgls_dup != NULL);
 
 	for (i = 0; i < sgl_nr; i++) {

--- a/src/object/srv_obj_migrate.c
+++ b/src/object/srv_obj_migrate.c
@@ -183,7 +183,7 @@ tree_cache_create_internal(daos_handle_t toh, unsigned int tree_class,
 	*rootp = val_iov.iov_buf;
 	D_ASSERT(*rootp != NULL);
 out:
-	if (rc < 0 && !daos_handle_is_inval(root.root_hdl))
+	if (rc < 0 && daos_handle_is_valid(root.root_hdl))
 		dbtree_destroy(root.root_hdl, NULL);
 	return rc;
 }
@@ -310,9 +310,9 @@ migrate_pool_tls_destroy(struct migrate_pool_tls *tls)
 					     true /* force */);
 	if (tls->mpt_done_eventual)
 		ABT_eventual_free(&tls->mpt_done_eventual);
-	if (!daos_handle_is_inval(tls->mpt_root_hdl))
+	if (daos_handle_is_valid(tls->mpt_root_hdl))
 		obj_tree_destroy(tls->mpt_root_hdl);
-	if (!daos_handle_is_inval(tls->mpt_migrated_root_hdl))
+	if (daos_handle_is_valid(tls->mpt_migrated_root_hdl))
 		obj_tree_destroy(tls->mpt_migrated_root_hdl);
 	d_list_del(&tls->mpt_list);
 	D_FREE(tls);

--- a/src/pool/srv_cli.c
+++ b/src/pool/srv_cli.c
@@ -58,7 +58,7 @@ dsc_pool_open(uuid_t pool_uuid, uuid_t poh_uuid, unsigned int flags,
 	struct dc_pool	*pool;
 	int		rc = 0;
 
-	if (!daos_handle_is_inval(*ph)) {
+	if (daos_handle_is_valid(*ph)) {
 		pool = dc_hdl2pool(*ph);
 		if (pool != NULL)
 			D_GOTO(out, rc = 0);

--- a/src/rdb/rdb_raft.c
+++ b/src/rdb/rdb_raft.c
@@ -767,7 +767,7 @@ rdb_raft_cb_recv_installsnapshot(raft_server_t *raft, void *arg,
 	out = container_of(resp, struct rdb_installsnapshot_out, iso_msg);
 
 	/* Is there an existing SLC? */
-	if (!daos_handle_is_inval(*slc)) {
+	if (daos_handle_is_valid(*slc)) {
 		bool destroy = false;
 
 		/* As msg->term == currentTerm and currentTerm >= dlr_term... */
@@ -2288,7 +2288,7 @@ lc:
 err_lc:
 	vos_cont_close(db->d_lc);
 err_slc:
-	if (!daos_handle_is_inval(db->d_slc))
+	if (daos_handle_is_valid(db->d_slc))
 		vos_cont_close(db->d_slc);
 err:
 	return rc;
@@ -2298,7 +2298,7 @@ static void
 rdb_raft_unload_lc(struct rdb *db)
 {
 	rdb_raft_unload_snapshot(db);
-	if (!daos_handle_is_inval(db->d_slc))
+	if (daos_handle_is_valid(db->d_slc))
 		vos_cont_close(db->d_slc);
 	vos_cont_close(db->d_lc);
 }

--- a/src/rebuild/scan.c
+++ b/src/rebuild/scan.c
@@ -296,7 +296,7 @@ rebuild_object_insert(struct rebuild_tgt_pool_tracker *rpt,
 
 	tls = rebuild_pool_tls_lookup(rpt->rt_pool_uuid, rpt->rt_rebuild_ver);
 	D_ASSERT(tls != NULL);
-	D_ASSERT(!daos_handle_is_inval(tls->rebuild_tree_hdl));
+	D_ASSERT(daos_handle_is_valid(tls->rebuild_tree_hdl));
 
 	tls->rebuild_pool_obj_count++;
 	val.eph = epoch;

--- a/src/rebuild/srv.c
+++ b/src/rebuild/srv.c
@@ -120,7 +120,7 @@ rebuild_pool_tls_destroy(struct rebuild_pool_tls *tls)
 {
 	D_DEBUG(DB_REBUILD, "TLS destroy for "DF_UUID" ver %d\n",
 		DP_UUID(tls->rebuild_pool_uuid), tls->rebuild_pool_ver);
-	if (!daos_handle_is_inval(tls->rebuild_tree_hdl))
+	if (daos_handle_is_valid(tls->rebuild_tree_hdl))
 		obj_tree_destroy(tls->rebuild_tree_hdl);
 	d_list_del(&tls->rebuild_pool_list);
 	D_FREE(tls);
@@ -851,11 +851,11 @@ rpt_destroy(struct rebuild_tgt_pool_tracker *rpt)
 {
 	D_ASSERT(rpt->rt_refcount == 0);
 	D_ASSERT(d_list_empty(&rpt->rt_list));
-	if (!daos_handle_is_inval(rpt->rt_tobe_rb_root_hdl)) {
+	if (daos_handle_is_valid(rpt->rt_tobe_rb_root_hdl)) {
 		dbtree_destroy(rpt->rt_tobe_rb_root_hdl, NULL);
 		rpt->rt_tobe_rb_root_hdl = DAOS_HDL_INVAL;
 	}
-	if (!daos_handle_is_inval(rpt->rt_rebuilt_root_hdl)) {
+	if (daos_handle_is_valid(rpt->rt_rebuilt_root_hdl)) {
 		rebuilt_btr_destroy(rpt->rt_rebuilt_root_hdl);
 		rpt->rt_rebuilt_root_hdl = DAOS_HDL_INVAL;
 	}
@@ -1538,7 +1538,7 @@ rebuild_fini_one(void *arg)
 	if (pool_tls == NULL)
 		return 0;
 
-	if (!daos_handle_is_inval(pool_tls->rebuild_pool_hdl)) {
+	if (daos_handle_is_valid(pool_tls->rebuild_pool_hdl)) {
 		D_DEBUG(DB_REBUILD, "close container/pool "
 			DF_UUID"/"DF_UUID"\n",
 			DP_UUID(rpt->rt_coh_uuid), DP_UUID(rpt->rt_poh_uuid));

--- a/src/tests/suite/daos_pool.c
+++ b/src/tests/suite/daos_pool.c
@@ -939,7 +939,7 @@ list_containers_test(void **state)
 
 	/***** Test: retrieve number of containers in pool *****/
 	nconts = nconts_orig = 0xDEF0; /* Junk value (e.g., uninitialized) */
-	assert_false(daos_handle_is_inval(lcarg->tpool.poh));
+	assert_true(daos_handle_is_valid(lcarg->tpool.poh));
 	rc = daos_pool_list_cont(lcarg->tpool.poh, &nconts, NULL /* conts */,
 			NULL /* ev */);
 	print_message("daos_pool_list_cont returned rc=%d\n", rc);

--- a/src/tests/suite/daos_rebuild.c
+++ b/src/tests/suite/daos_rebuild.c
@@ -961,7 +961,7 @@ rebuild_io_cb(void *arg)
 	test_arg_t	*test_arg = arg;
 	daos_obj_id_t	*oids = test_arg->rebuild_cb_arg;
 
-	if (!daos_handle_is_inval(test_arg->coh))
+	if (daos_handle_is_valid(test_arg->coh))
 		rebuild_io(test_arg, oids, OBJ_NR);
 
 	return 0;
@@ -973,7 +973,7 @@ rebuild_io_post_cb(void *arg)
 	test_arg_t	*test_arg = arg;
 	daos_obj_id_t	*oids = test_arg->rebuild_post_cb_arg;
 
-	if (!daos_handle_is_inval(test_arg->coh))
+	if (daos_handle_is_valid(test_arg->coh))
 		rebuild_io_validate(test_arg, oids, OBJ_NR, true);
 
 	return 0;

--- a/src/tests/suite/daos_test_common.c
+++ b/src/tests/suite/daos_test_common.c
@@ -405,7 +405,7 @@ pool_destroy_safe(test_arg_t *arg, struct test_pool *extpool)
 		}
 	}
 
-	while (!daos_handle_is_inval(poh)) {
+	while (daos_handle_is_valid(poh)) {
 		struct daos_rebuild_status *rstat = &pinfo.pi_rebuild_st;
 
 		memset(&pinfo, 0, sizeof(pinfo));
@@ -502,7 +502,7 @@ test_teardown(void **state)
 	if (arg->multi_rank)
 		MPI_Barrier(MPI_COMM_WORLD);
 
-	if (!daos_handle_is_inval(arg->coh)) {
+	if (daos_handle_is_valid(arg->coh)) {
 		rc = test_teardown_cont_hdl(arg);
 		if (rc)
 			return rc;
@@ -527,7 +527,7 @@ test_teardown(void **state)
 	if (!uuid_is_null(arg->pool.pool_uuid) && !arg->pool.slave &&
 	    !arg->pool.destroyed) {
 		if (arg->myrank != 0) {
-			if (!daos_handle_is_inval(arg->pool.poh))
+			if (daos_handle_is_valid(arg->pool.poh))
 				rc = daos_pool_disconnect(arg->pool.poh, NULL);
 		}
 		if (arg->multi_rank)
@@ -545,7 +545,7 @@ test_teardown(void **state)
 		}
 	}
 
-	if (!daos_handle_is_inval(arg->eq)) {
+	if (daos_handle_is_valid(arg->eq)) {
 		rc = daos_eq_destroy(arg->eq, 0);
 		if (rc) {
 			print_message("failed to destroy eq: %d\n", rc);

--- a/src/vea/vea_alloc.c
+++ b/src/vea/vea_alloc.c
@@ -86,7 +86,7 @@ reserve_hint(struct vea_space_info *vsi, uint32_t blk_cnt,
 	d_iov_set(&key, &vfe.vfe_blk_off, sizeof(vfe.vfe_blk_off));
 	d_iov_set(&val, NULL, 0);
 
-	D_ASSERT(!daos_handle_is_inval(vsi->vsi_free_btr));
+	D_ASSERT(daos_handle_is_valid(vsi->vsi_free_btr));
 	rc = dbtree_fetch(vsi->vsi_free_btr, BTR_PROBE_EQ, DAOS_INTENT_DEFAULT,
 			  &key, NULL, &val);
 	if (rc)
@@ -361,7 +361,7 @@ persistent_alloc(struct vea_space_info *vsi, struct vea_free_extent *vfe)
 	D_ASSERT(vfe->vfe_blk_cnt > 0);
 
 	btr_hdl = vsi->vsi_md_free_btr;
-	D_ASSERT(!daos_handle_is_inval(btr_hdl));
+	D_ASSERT(daos_handle_is_valid(btr_hdl));
 
 	D_DEBUG(DB_IO, "Persistent alloc ["DF_U64", %u]\n",
 		vfe->vfe_blk_off, vfe->vfe_blk_cnt);

--- a/src/vea/vea_api.c
+++ b/src/vea/vea_api.c
@@ -171,9 +171,9 @@ vea_format(struct umem_instance *umem, struct umem_tx_stage_data *txd,
 		goto out;
 
 out:
-	if (!daos_handle_is_inval(free_btr))
+	if (daos_handle_is_valid(free_btr))
 		dbtree_close(free_btr);
-	if (!daos_handle_is_inval(vec_btr))
+	if (daos_handle_is_valid(vec_btr))
 		dbtree_close(vec_btr);
 
 	/* Commit/Abort transaction on success/error */
@@ -188,19 +188,19 @@ vea_unload(struct vea_space_info *vsi)
 	unload_space_info(vsi);
 
 	/* Destroy the in-memory free extent tree */
-	if (!daos_handle_is_inval(vsi->vsi_free_btr)) {
+	if (daos_handle_is_valid(vsi->vsi_free_btr)) {
 		dbtree_destroy(vsi->vsi_free_btr, NULL);
 		vsi->vsi_free_btr = DAOS_HDL_INVAL;
 	}
 
 	/* Destroy the in-memory extent vector tree */
-	if (!daos_handle_is_inval(vsi->vsi_vec_btr)) {
+	if (daos_handle_is_valid(vsi->vsi_vec_btr)) {
 		dbtree_destroy(vsi->vsi_vec_btr, NULL);
 		vsi->vsi_vec_btr = DAOS_HDL_INVAL;
 	}
 
 	/* Destroy the in-memory aggregation tree */
-	if (!daos_handle_is_inval(vsi->vsi_agg_btr)) {
+	if (daos_handle_is_valid(vsi->vsi_agg_btr)) {
 		dbtree_destroy(vsi->vsi_agg_btr, NULL);
 		vsi->vsi_agg_btr = DAOS_HDL_INVAL;
 	}

--- a/src/vea/vea_free.c
+++ b/src/vea/vea_free.c
@@ -166,7 +166,7 @@ merge_free_ext(struct vea_space_info *vsi, struct vea_free_extent *ext_in,
 	else
 		return -DER_INVAL;
 
-	D_ASSERT(!daos_handle_is_inval(btr_hdl));
+	D_ASSERT(daos_handle_is_valid(btr_hdl));
 	d_iov_set(&key, &ext_in->vfe_blk_off, sizeof(ext_in->vfe_blk_off));
 repeat:
 	d_iov_set(&key_out, NULL, 0);
@@ -295,7 +295,7 @@ compound_free(struct vea_space_info *vsi, struct vea_free_extent *vfe,
 	dummy.ve_ext = *vfe;
 
 	/* Add to in-memory free extent tree */
-	D_ASSERT(!daos_handle_is_inval(vsi->vsi_free_btr));
+	D_ASSERT(daos_handle_is_valid(vsi->vsi_free_btr));
 	d_iov_set(&key, &dummy.ve_ext.vfe_blk_off,
 		  sizeof(dummy.ve_ext.vfe_blk_off));
 	d_iov_set(&val, &dummy, sizeof(dummy));
@@ -346,7 +346,7 @@ persistent_free(struct vea_space_info *vsi, struct vea_free_extent *vfe)
 	dummy.vfe_age = VEA_EXT_AGE_MAX;
 
 	/* Add to persistent free extent tree */
-	D_ASSERT(!daos_handle_is_inval(btr_hdl));
+	D_ASSERT(daos_handle_is_valid(btr_hdl));
 	d_iov_set(&key, &dummy.vfe_blk_off, sizeof(dummy.vfe_blk_off));
 	d_iov_set(&val, &dummy, sizeof(dummy));
 
@@ -378,7 +378,7 @@ aggregated_free(struct vea_space_info *vsi, struct vea_free_extent *vfe)
 	dummy.ve_ext = *vfe;
 
 	/* Add to in-memory aggregate free extent tree */
-	D_ASSERT(!daos_handle_is_inval(btr_hdl));
+	D_ASSERT(daos_handle_is_valid(btr_hdl));
 	d_iov_set(&key, &dummy.ve_ext.vfe_blk_off,
 		  sizeof(dummy.ve_ext.vfe_blk_off));
 	d_iov_set(&val, &dummy, sizeof(dummy));
@@ -454,7 +454,7 @@ migrate_end_cb(void *data, bool noop)
 		 * deletion.
 		 */
 		d_iov_set(&key, &vfe.vfe_blk_off, sizeof(vfe.vfe_blk_off));
-		D_ASSERT(!daos_handle_is_inval(vsi->vsi_agg_btr));
+		D_ASSERT(daos_handle_is_valid(vsi->vsi_agg_btr));
 		rc = dbtree_delete(vsi->vsi_agg_btr, BTR_PROBE_EQ, &key, NULL);
 		if (rc) {
 			D_ERROR("Remove ["DF_U64", %u] from aggregated "

--- a/src/vea/vea_init.c
+++ b/src/vea/vea_init.c
@@ -131,12 +131,12 @@ error:
 void
 unload_space_info(struct vea_space_info *vsi)
 {
-	if (!daos_handle_is_inval(vsi->vsi_md_free_btr)) {
+	if (daos_handle_is_valid(vsi->vsi_md_free_btr)) {
 		dbtree_close(vsi->vsi_md_free_btr);
 		vsi->vsi_md_free_btr = DAOS_HDL_INVAL;
 	}
 
-	if (!daos_handle_is_inval(vsi->vsi_md_vec_btr)) {
+	if (daos_handle_is_valid(vsi->vsi_md_vec_btr)) {
 		dbtree_close(vsi->vsi_md_vec_btr);
 		vsi->vsi_md_vec_btr = DAOS_HDL_INVAL;
 	}

--- a/src/vea/vea_util.c
+++ b/src/vea/vea_util.c
@@ -141,7 +141,7 @@ vea_dump(struct vea_space_info *vsi, bool transient)
 	else
 		btr_hdl = vsi->vsi_md_free_btr;
 
-	D_ASSERT(!daos_handle_is_inval(btr_hdl));
+	D_ASSERT(daos_handle_is_valid(btr_hdl));
 	rc = dbtree_iter_prepare(btr_hdl, BTR_ITER_EMBEDDED, &ih);
 	if (rc)
 		return rc;
@@ -239,7 +239,7 @@ vea_verify_alloc(struct vea_space_info *vsi, bool transient, uint64_t off,
 	else
 		btr_hdl = vsi->vsi_md_free_btr;
 
-	D_ASSERT(!daos_handle_is_inval(btr_hdl));
+	D_ASSERT(daos_handle_is_valid(btr_hdl));
 	d_iov_set(&key, &vfe.vfe_blk_off, sizeof(vfe.vfe_blk_off));
 repeat:
 	d_iov_set(&key_out, NULL, 0);

--- a/src/vos/ilog.c
+++ b/src/vos/ilog.c
@@ -678,7 +678,7 @@ ilog_root_migrate(struct ilog_context *lctx, const struct ilog_id *id_in)
 	rc = ilog_ptr_set(lctx, root, &tmp);
 
 done:
-	if (!daos_handle_is_inval(toh))
+	if (daos_handle_is_valid(toh))
 		dbtree_close(toh);
 
 	return rc;
@@ -959,7 +959,7 @@ insert:
 	}
 
 done:
-	if (!daos_handle_is_inval(toh))
+	if (daos_handle_is_valid(toh))
 		dbtree_close(toh);
 
 	return rc;
@@ -1231,7 +1231,7 @@ reset:
 	lctx->ic_in_txn = false;
 	lctx->ic_ver_inc = false;
 
-	if (!daos_handle_is_inval(priv->ip_ih)) {
+	if (daos_handle_is_valid(priv->ip_ih)) {
 		dbtree_iter_finish(priv->ip_ih);
 		priv->ip_ih = DAOS_HDL_INVAL;
 	}
@@ -1444,7 +1444,7 @@ ilog_fetch_finish(struct ilog_entries *entries)
 	if (priv->ip_alloc_size)
 		D_FREE(entries->ie_entries);
 
-	if (!daos_handle_is_inval(priv->ip_ih))
+	if (daos_handle_is_valid(priv->ip_ih))
 		dbtree_iter_finish(priv->ip_ih);
 }
 
@@ -1689,7 +1689,7 @@ collapse:
 
 	empty = ilog_empty(root);
 done:
-	if (!daos_handle_is_inval(toh))
+	if (daos_handle_is_valid(toh))
 		dbtree_close(toh);
 
 	rc = ilog_tx_end(lctx, rc);

--- a/src/vos/tests/evt_ctl.c
+++ b/src/vos/tests/evt_ctl.c
@@ -147,7 +147,7 @@ ts_open_create(void **state)
 	create = tst_fn_val.input;
 	arg = tst_fn_val.optval;
 
-	if (!daos_handle_is_inval(ts_toh)) {
+	if (daos_handle_is_valid(ts_toh)) {
 		D_PRINT("Tree has been opened\n");
 		fail();
 	}

--- a/src/vos/vos_container.c
+++ b/src/vos/vos_container.c
@@ -191,9 +191,9 @@ cont_free_internal(struct vos_container *cont)
 
 	D_ASSERT(cont->vc_open_count == 0);
 
-	if (!daos_handle_is_inval(cont->vc_dtx_active_hdl))
+	if (daos_handle_is_valid(cont->vc_dtx_active_hdl))
 		dbtree_destroy(cont->vc_dtx_active_hdl, NULL);
-	if (!daos_handle_is_inval(cont->vc_dtx_committed_hdl))
+	if (daos_handle_is_valid(cont->vc_dtx_committed_hdl))
 		dbtree_destroy(cont->vc_dtx_committed_hdl, NULL);
 
 	if (cont->vc_dtx_array)
@@ -671,7 +671,7 @@ cont_iter_fini(struct vos_iterator *iter)
 
 	co_iter = vos_iter2co_iter(iter);
 
-	if (!daos_handle_is_inval(co_iter->cot_hdl)) {
+	if (daos_handle_is_valid(co_iter->cot_hdl)) {
 		rc = dbtree_iter_finish(co_iter->cot_hdl);
 		if (rc)
 			D_ERROR("co_iter_fini failed: "DF_RC"\n", DP_RC(rc));

--- a/src/vos/vos_dtx.c
+++ b/src/vos/vos_dtx.c
@@ -2613,9 +2613,9 @@ vos_dtx_cache_reset(daos_handle_t coh)
 	cont = vos_hdl2cont(coh);
 	D_ASSERT(cont != NULL);
 
-	if (!daos_handle_is_inval(cont->vc_dtx_active_hdl))
+	if (daos_handle_is_valid(cont->vc_dtx_active_hdl))
 		dbtree_destroy(cont->vc_dtx_active_hdl, NULL);
-	if (!daos_handle_is_inval(cont->vc_dtx_committed_hdl))
+	if (daos_handle_is_valid(cont->vc_dtx_committed_hdl))
 		dbtree_destroy(cont->vc_dtx_committed_hdl, NULL);
 
 	if (cont->vc_dtx_array)

--- a/src/vos/vos_dtx_iter.c
+++ b/src/vos/vos_dtx_iter.c
@@ -54,7 +54,7 @@ dtx_iter_fini(struct vos_iterator *iter)
 
 	D_ASSERT(iter->it_type == VOS_ITER_DTX);
 
-	if (!daos_handle_is_inval(oiter->oit_hdl)) {
+	if (daos_handle_is_valid(oiter->oit_hdl)) {
 		rc = dbtree_iter_finish(oiter->oit_hdl);
 		if (rc != 0)
 			D_ERROR("oid_iter_fini failed: rc = "DF_RC"\n",

--- a/src/vos/vos_gc.c
+++ b/src/vos/vos_gc.c
@@ -911,7 +911,7 @@ vos_gc_pool_run(daos_handle_t poh, int credits,
 	struct vos_pool	*pool = vos_hdl2pool(poh);
 	int		 rc, total = 0;
 
-	D_ASSERT(!daos_handle_is_inval(poh));
+	D_ASSERT(daos_handle_is_valid(poh));
 	if (!gc_have_pool(pool))
 		return 0; /* nothing to reclaim for this pool */
 
@@ -958,7 +958,7 @@ vos_gc_pool_run(daos_handle_t poh, int credits,
 inline bool
 vos_gc_pool_idle(daos_handle_t poh)
 {
-	D_ASSERT(!daos_handle_is_inval(poh));
+	D_ASSERT(daos_handle_is_valid(poh));
 	return !gc_have_pool(vos_hdl2pool(poh));
 }
 

--- a/src/vos/vos_io.c
+++ b/src/vos/vos_io.c
@@ -1183,7 +1183,7 @@ fetch_value:
 
 	ioc_trim_tail_holes(ioc);
 out:
-	if (!daos_handle_is_inval(toh))
+	if (daos_handle_is_valid(toh))
 		key_tree_release(toh, is_array);
 
 	return vos_dtx_hit_inprogress() ? -DER_INPROGRESS : rc;
@@ -1264,7 +1264,7 @@ fetch_akey:
 		goto out;
 
 out:
-	if (!daos_handle_is_inval(toh))
+	if (daos_handle_is_valid(toh))
 		key_tree_release(toh, false);
 
 	return vos_dtx_hit_inprogress() ? -DER_INPROGRESS : rc;
@@ -1594,7 +1594,7 @@ akey_update(struct vos_io_context *ioc, uint32_t pm_ver, daos_handle_t ak_toh,
 	}
 
 out:
-	if (!daos_handle_is_inval(toh))
+	if (daos_handle_is_valid(toh))
 		key_tree_release(toh, is_array);
 
 	return rc;
@@ -2300,7 +2300,7 @@ vos_dedup_dup_bsgl(daos_handle_t ioh, struct bio_sglist *bsgl,
 	struct vos_io_context	*ioc = vos_ioh2ioc(ioh);
 	int			 i, rc;
 
-	D_ASSERT(!daos_handle_is_inval(ioh));
+	D_ASSERT(daos_handle_is_valid(ioh));
 	D_ASSERT(bsgl != NULL);
 	D_ASSERT(bsgl_dup != NULL);
 
@@ -2348,7 +2348,7 @@ vos_dedup_free_bsgl(daos_handle_t ioh, struct bio_sglist *bsgl)
 	struct vos_io_context	*ioc = vos_ioh2ioc(ioh);
 	int			 i;
 
-	D_ASSERT(!daos_handle_is_inval(ioh));
+	D_ASSERT(daos_handle_is_valid(ioh));
 	for (i = 0; i < bsgl->bs_nr_out; i++) {
 		struct bio_iov	*biov = &bsgl->bs_iovs[i];
 		PMEMoid		 oid;

--- a/src/vos/vos_iterator.c
+++ b/src/vos/vos_iterator.c
@@ -198,7 +198,7 @@ vos_iter_prepare(vos_iter_type_t type, vos_iter_param_t *param,
 		return -DER_NOSYS;
 	}
 
-	if (!daos_handle_is_inval(param->ip_ih)) {
+	if (daos_handle_is_valid(param->ip_ih)) {
 		D_DEBUG(DB_TRACE, "Preparing nested iterator of type %s\n",
 			dict->id_name);
 		/** Nested operations are only used internally so there
@@ -800,7 +800,7 @@ vos_iterate_key(struct vos_object *obj, daos_handle_t toh, vos_iter_type_t type,
 	struct vos_iter_anchors	 anchors = {0};
 
 	D_ASSERT(type == VOS_ITER_DKEY || type == VOS_ITER_AKEY);
-	D_ASSERT(!daos_handle_is_inval(toh));
+	D_ASSERT(daos_handle_is_valid(toh));
 
 	param.ip_hdl = toh;
 	param.ip_epr = *epr;

--- a/src/vos/vos_obj.c
+++ b/src/vos/vos_obj.c
@@ -250,7 +250,7 @@ punch_dkey:
 	vos_ilog_fetch_finish(&dkey_info);
 	vos_ilog_fetch_finish(&akey_info);
 
-	if (!daos_handle_is_inval(toh))
+	if (daos_handle_is_valid(toh))
 		key_tree_release(toh, 0);
 
 	return rc;

--- a/src/vos/vos_obj_index.c
+++ b/src/vos/vos_obj_index.c
@@ -366,7 +366,7 @@ oi_iter_fini(struct vos_iterator *iter)
 
 	oiter = iter2oiter(iter);
 
-	if (!daos_handle_is_inval(oiter->oit_hdl)) {
+	if (daos_handle_is_valid(oiter->oit_hdl)) {
 		rc = dbtree_iter_finish(oiter->oit_hdl);
 		if (rc)
 			D_ERROR("oid_iter_fini failed:"DF_RC"\n", DP_RC(rc));

--- a/src/vos/vos_pool.c
+++ b/src/vos/vos_pool.c
@@ -133,7 +133,7 @@ pool_hop_free(struct d_ulink *hlink)
 	if (pool->vp_vea_info != NULL)
 		vea_unload(pool->vp_vea_info);
 
-	if (!daos_handle_is_inval(pool->vp_cont_th))
+	if (daos_handle_is_valid(pool->vp_cont_th))
 		dbtree_close(pool->vp_cont_th);
 
 	if (pool->vp_uma.uma_pool)

--- a/src/vos/vos_query.c
+++ b/src/vos/vos_query.c
@@ -271,7 +271,7 @@ open_and_query_key(struct open_query *query, daos_key_t *key,
 		tclass = VOS_BTR_AKEY;
 	}
 
-	if (!daos_handle_is_inval(*toh)) {
+	if (daos_handle_is_valid(*toh)) {
 		dbtree_close(*toh);
 		*toh = DAOS_HDL_INVAL;
 	}
@@ -524,9 +524,9 @@ vos_obj_query_key(daos_handle_t coh, daos_unit_oid_t oid, uint32_t flags,
 	}
 
 	vos_ilog_fetch_finish(&query.qt_info);
-	if (!daos_handle_is_inval(query.qt_akey_toh))
+	if (daos_handle_is_valid(query.qt_akey_toh))
 		dbtree_close(query.qt_akey_toh);
-	if (!daos_handle_is_inval(query.qt_dkey_toh))
+	if (daos_handle_is_valid(query.qt_dkey_toh))
 		dbtree_close(query.qt_dkey_toh);
 out:
 	if (obj != NULL)

--- a/src/vos/vos_tree.c
+++ b/src/vos/vos_tree.c
@@ -1208,7 +1208,7 @@ obj_tree_init(struct vos_object *obj)
 	struct vos_btr_attr *ta	= &vos_btr_attrs[0];
 	int		     rc;
 
-	if (!daos_handle_is_inval(obj->obj_toh))
+	if (daos_handle_is_valid(obj->obj_toh))
 		return 0;
 
 	D_ASSERT(obj->obj_df);
@@ -1249,7 +1249,7 @@ obj_tree_fini(struct vos_object *obj)
 	int	rc = 0;
 
 	/* NB: tree is created inplace, so don't need to destroy */
-	if (!daos_handle_is_inval(obj->obj_toh)) {
+	if (daos_handle_is_valid(obj->obj_toh)) {
 		D_ASSERT(obj->obj_df);
 		rc = dbtree_close(obj->obj_toh);
 		obj->obj_toh = DAOS_HDL_INVAL;


### PR DESCRIPTION
Do not use negation (!) to call these functions, however simply
call the correct function.

Signed-off-by: Ashley Pittman <ashley.m.pittman@intel.com>