### PR TITLE
DAOS-6261 ci: Improve checkpatch to only inspect modified files.

### DIFF
--- a/ci/patch_src_in_place
+++ b/ci/patch_src_in_place
@@ -1,7 +1,9 @@
 #!/bin/sh
 
+set -x
+
 # shellcheck disable=SC2046,SC2035
-codespell -w --ignore-words-list dedup,nd,uint,ths,ba,creat,te,cas,mapp,pres,crashers,dout,tre,reord,mimick,cloneable,keypair,bject,tread,cancelled,controllerd --builtin clear,rare,informal,names,en-GB_to_en-US --skip *.png,*.PNG,*.pyc,src/rdb/raft/*,src/control/vendor/*,RSA.golden,utils/rpms/* $(git diff --name-only origin/"$CHANGE_TARGET" .)
+codespell -w --ignore-words-list dedup,nd,uint,ths,ba,creat,te,cas,mapp,pres,crashers,dout,tre,reord,mimick,cloneable,keypair,bject,tread,cancelled,controllerd --builtin clear,rare,informal,names,en-GB_to_en-US --skip *.png,*.PNG,*.pyc,src/rdb/raft/*,src/control/vendor/*,RSA.golden,utils/rpms/* $(git diff --name-only origin/"$CHANGE_TARGET"...)
 
 # The return code of codespell is the number of words it could not correct
 # because of multiple options.  We could report on these but they're rare
@@ -22,7 +24,7 @@ fi
 
 if [ -x $CP ]
 then
-    for FILE in $(git diff --name-only origin/"$CHANGE_TARGET" . | grep "^src" | grep -v -e src/control/vendor -e .go\$ -e pb-c -e debug_setup.h)
+    for FILE in $(git diff --name-only origin/"$CHANGE_TARGET"... | grep "^src" | grep -v -e src/control/vendor -e .go\$ -e pb-c -e debug_setup.h)
     do
 	ignore="$def_ignore"
 	if grep -lq CRT_RPC_DECLARE "$FILE"; then

--- a/ci/patch_src_in_place
+++ b/ci/patch_src_in_place
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 # shellcheck disable=SC2046,SC2035
-codespell -w --ignore-words-list dedup,nd,uint,ths,ba,creat,te,cas,mapp,pres,crashers,dout,tre,reord,mimick,cloneable,keypair,bject,tread,cancelled,controllerd --builtin clear,rare,informal,names,en-GB_to_en-US --skip *.png,*.PNG,*.pyc,src/rdb/raft/*,src/control/vendor/*,RSA.golden,utils/rpms/* $(git ls-tree --full-tree --name-only HEAD)
+codespell -w --ignore-words-list dedup,nd,uint,ths,ba,creat,te,cas,mapp,pres,crashers,dout,tre,reord,mimick,cloneable,keypair,bject,tread,cancelled,controllerd --builtin clear,rare,informal,names,en-GB_to_en-US --skip *.png,*.PNG,*.pyc,src/rdb/raft/*,src/control/vendor/*,RSA.golden,utils/rpms/* $(git diff --name-only origin/"$CHANGE_TARGET" .)
 
 # The return code of codespell is the number of words it could not correct
 # because of multiple options.  We could report on these but they're rare
@@ -22,7 +22,7 @@ fi
 
 if [ -x $CP ]
 then
-    for FILE in $(git ls-tree --full-tree --name-only HEAD -r src | grep -v -e src/control/vendor -e .go\$ -e pb-c -e debug_setup.h)
+    for FILE in $(git diff --name-only origin/"$CHANGE_TARGET" . | grep "^src" | grep -v -e src/control/vendor -e .go\$ -e pb-c -e debug_setup.h)
     do
 	ignore="$def_ignore"
 	if grep -lq CRT_RPC_DECLARE "$FILE"; then

--- a/src/gurt/fault_inject.c
+++ b/src/gurt/fault_inject.c
@@ -28,7 +28,7 @@
 /** max length of argument string in the yaml config file */
 #define FI_CONFIG_ARG_STR_MAX_LEN 4096
 
-/* (1 << D_FA_TABLE_BITS) is the number of buckets of fa hash table */
+/* (1 << D_FA_TABLE_BITS) is the nuber of buckets of fa hash table */
 #define D_FA_TABLE_BITS		(13)
 
 #include <gurt/common.h>

--- a/src/gurt/fault_inject.c
+++ b/src/gurt/fault_inject.c
@@ -28,7 +28,7 @@
 /** max length of argument string in the yaml config file */
 #define FI_CONFIG_ARG_STR_MAX_LEN 4096
 
-/* (1 << D_FA_TABLE_BITS) is the nuber of buckets of fa hash table */
+/* (1 << D_FA_TABLE_BITS) is the number of buckets of fa hash table */
 #define D_FA_TABLE_BITS		(13)
 
 #include <gurt/common.h>

--- a/src/include/daos/debug.h
+++ b/src/include/daos/debug.h
@@ -83,7 +83,7 @@
 	ACTION(DB_SEC,	   sec,	    security,       0, arg)	\
 	/** checksum */						\
 	ACTION(DB_CSUM,	   csum,    checksum,	    0, arg)	\
-	/** daos managment */					\
+	/** daos management */					\
 	ACTION(DB_DSMS,	   dsms,    service,	    0, arg)
 
 DAOS_FOREACH_DB(D_LOG_DECLARE_DB, D_NOOP);


### PR DESCRIPTION
Rather than test the entire tree, only check files that are
touched by the PR.

Fix spelling mistake.

Signed-off-by: Ashley Pittman <ashley.m.pittman@intel.com>