### PR TITLE
DAOS-6315 vos: VOS_ITER_CB_ABORT flag for VOS iteration

### DIFF
--- a/src/container/srv_target.c
+++ b/src/container/srv_target.c
@@ -86,6 +86,10 @@ cont_aggregate_epr(struct ds_cont_child *cont, daos_epoch_range_t *epr)
 	rc = vos_aggregate(cont->sc_hdl, epr, ds_csum_recalc, dss_ult_yield,
 			   (void *)cont->sc_agg_req);
 
+	/* Suppress csum error and continue on other epoch ranges */
+	if (rc == -DER_CSUM)
+		rc = 0;
+
 	/* Wake up GC ULT */
 	sched_req_wakeup(cont->sc_pool->spc_gc_req);
 	return rc;

--- a/src/include/daos_srv/vos_types.h
+++ b/src/include/daos_srv/vos_types.h
@@ -439,9 +439,14 @@ typedef int (*vos_iter_cb_t)(daos_handle_t ih, vos_iter_entry_t *entry,
  * Actions performed in iteration callback
  */
 enum {
-	VOS_ITER_CB_YIELD	= (1UL << 0),	/* Yield */
-	VOS_ITER_CB_DELETE	= (1UL << 1),	/* Delete entry */
-	VOS_ITER_CB_SKIP	= (1UL << 2),	/* Skip entry */
+	/** Yield */
+	VOS_ITER_CB_YIELD	= (1UL << 0),
+	/** Delete entry */
+	VOS_ITER_CB_DELETE	= (1UL << 1),
+	/** Skip entry, don't iterate into next level for current entry */
+	VOS_ITER_CB_SKIP	= (1UL << 2),
+	/** Abort current level iteration */
+	VOS_ITER_CB_ABORT	= (1UL << 3),
 };
 
 /**

--- a/src/vos/vos_aggregate.c
+++ b/src/vos/vos_aggregate.c
@@ -145,7 +145,8 @@ struct vos_agg_param {
 	daos_unit_oid_t		ap_oid;		/* current object ID */
 	daos_key_t		ap_dkey;	/* current dkey */
 	daos_key_t		ap_akey;	/* current akey */
-	unsigned int		ap_discard:1;
+	unsigned int		ap_discard:1,
+				ap_csum_err:1;
 	struct umem_instance	*ap_umm;
 	bool			(*ap_yield_func)(void *arg);
 	void			*ap_yield_arg;
@@ -980,9 +981,7 @@ fill_one_segment(daos_handle_t ih, struct agg_merge_window *mw,
 		rc = csum_recalc(io, &bsgl, &sgl, ent_in, io->ic_csum_recalcs,
 				 seg_count, seg_size);
 		if (rc) {
-			if (rc == -DER_CSUM)
-				D_ERROR("CSUM verify error: "DF_RC"\n",
-					DP_RC(rc));
+			D_ERROR("CSUM verify error: "DF_RC"\n", DP_RC(rc));
 			goto out;
 		}
 	}
@@ -1772,6 +1771,15 @@ vos_aggregate_pre_cb(daos_handle_t ih, vos_iter_entry_t *entry,
 		break;
 	case VOS_ITER_RECX:
 		rc = vos_agg_ev(ih, entry, agg_param, acts);
+		if (rc == -DER_CSUM) {
+			/* Abort current evtree aggregation only */
+			D_DEBUG(DB_EPC, "Abort evtree aggregation "DF_RC"\n",
+				DP_RC(rc));
+
+			*acts |= VOS_ITER_CB_ABORT;
+			agg_param->ap_csum_err = true;
+			rc = 0;
+		}
 		break;
 	default:
 		D_ASSERTF(false, "Invalid iter type\n");
@@ -1975,6 +1983,10 @@ vos_aggregate(daos_handle_t coh, daos_epoch_range_t *epr,
 	if (rc != 0) {
 		close_merge_window(&agg_param.ap_window, rc);
 		goto exit;
+	} else if (agg_param.ap_csum_err) {
+		rc = -DER_CSUM;	/* Inform caller the csum error */
+		close_merge_window(&agg_param.ap_window, rc);
+		/* HAE needs be updated for csum error case */
 	}
 
 	/*

--- a/src/vos/vos_iterator.c
+++ b/src/vos/vos_iterator.c
@@ -754,7 +754,9 @@ next:
 			if (rc != 0)
 				break;
 
-			set_reprobe(type, acts, anchors, param->ip_flags);
+			if (!vos_dtx_hit_inprogress())
+				set_reprobe(type, acts, anchors,
+					    param->ip_flags);
 
 			if (acts & VOS_ITER_CB_ABORT)
 				break;


### PR DESCRIPTION
VOS_ITER_CB_ABORT flag is introduced, it'll be used by iteration
callbacks to inform the recursive VOS iterator to abort current
level iteration.

vos_aggregate() used to abort the whole container aggregation
once hitting a checksum error on an evtree, now it relies on the
VOS_ITER_CB_ABORT to abort current evtree aggregation only.

Small fixes in vos_iterate_internal().

Signed-off-by: Niu Yawei <yawei.niu@intel.com>