### PR TITLE
DAOS-6238 dfuse: Ensure inode object is opened with O_RDRW.

### DIFF
--- a/src/client/dfuse/ops/create.c
+++ b/src/client/dfuse/ops/create.c
@@ -74,15 +74,15 @@ dfuse_cb_create(fuse_req_t req, struct dfuse_inode_entry *parent,
 			mode);
 
 	rc = dfs_open(parent->ie_dfs->dfs_ns, parent->ie_obj, name,
-		      mode, fi->flags, 0, 0, NULL, &ie->ie_obj);
+		      mode, fi->flags, 0, 0, NULL, &oh->doh_obj);
 	if (rc) {
 		DFUSE_TRA_DEBUG(parent, "dfs_open() failed %d", rc);
 		D_GOTO(err, rc);
 	}
 
 	/** duplicate the file handle for the fuse handle */
-	rc = dfs_dup(parent->ie_dfs->dfs_ns, ie->ie_obj, fi->flags,
-		     &oh->doh_obj);
+	rc = dfs_dup(parent->ie_dfs->dfs_ns, oh->doh_obj, O_RDWR,
+		     &ie->ie_obj);
 	if (rc) {
 		DFUSE_TRA_DEBUG(parent, "dfs_dup() failed %d", rc);
 		D_GOTO(release1, rc);
@@ -123,9 +123,9 @@ dfuse_cb_create(fuse_req_t req, struct dfuse_inode_entry *parent,
 
 	return;
 release2:
-	dfs_release(oh->doh_obj);
-release1:
 	dfs_release(ie->ie_obj);
+release1:
+	dfs_release(oh->doh_obj);
 err:
 	DFUSE_REPLY_ERR_RAW(fs_handle, req, rc);
 	D_FREE(oh);

--- a/src/client/dfuse/ops/symlink.c
+++ b/src/client/dfuse/ops/symlink.c
@@ -40,7 +40,8 @@ dfuse_cb_symlink(fuse_req_t req, const char *link,
 	DFUSE_TRA_UP(ie, parent, "inode");
 
 	rc = dfs_open(parent->ie_dfs->dfs_ns, parent->ie_obj, name,
-		      S_IFLNK, O_CREAT | O_RDWR | O_EXCL, 0, 0, link, &ie->ie_obj);
+		      S_IFLNK, O_CREAT | O_RDWR | O_EXCL,
+		      0, 0, link, &ie->ie_obj);
 	if (rc != 0)
 		D_GOTO(err, rc);
 

--- a/src/client/dfuse/ops/symlink.c
+++ b/src/client/dfuse/ops/symlink.c
@@ -40,7 +40,7 @@ dfuse_cb_symlink(fuse_req_t req, const char *link,
 	DFUSE_TRA_UP(ie, parent, "inode");
 
 	rc = dfs_open(parent->ie_dfs->dfs_ns, parent->ie_obj, name,
-		      S_IFLNK, O_CREAT, 0, 0, link, &ie->ie_obj);
+		      S_IFLNK, O_CREAT | O_RDWR | O_EXCL, 0, link, &ie->ie_obj);
 	if (rc != 0)
 		D_GOTO(err, rc);
 

--- a/src/client/dfuse/ops/symlink.c
+++ b/src/client/dfuse/ops/symlink.c
@@ -40,7 +40,7 @@ dfuse_cb_symlink(fuse_req_t req, const char *link,
 	DFUSE_TRA_UP(ie, parent, "inode");
 
 	rc = dfs_open(parent->ie_dfs->dfs_ns, parent->ie_obj, name,
-		      S_IFLNK, O_CREAT | O_RDWR | O_EXCL, 0, link, &ie->ie_obj);
+		      S_IFLNK, O_CREAT | O_RDWR | O_EXCL, 0, 0, link, &ie->ie_obj);
 	if (rc != 0)
 		D_GOTO(err, rc);
 

--- a/utils/node_local_test.py
+++ b/utils/node_local_test.py
@@ -909,6 +909,13 @@ def run_tests(dfuse):
     os.symlink(symlink_dest, symlink_name)
     assert symlink_dest == os.readlink(symlink_name)
 
+    # DAOS-6238
+    fname = os.path.join(path, 'test_file4')
+    ofd = os.open(fname, os.O_CREAT | os.O_RDONLY | os.O_EXCL)
+    assert_file_size_fd(ofd, 0)
+    os.close(ofd)
+    os.chmod(fname, stat.S_IRUSR)
+
 def stat_and_check(dfuse, pre_stat):
     """Check that dfuse started"""
     post_stat = os.stat(dfuse.dir)


### PR DESCRIPTION
This means that the inode always has write permissions, even if the
open file derived from it may not, and it fixes a bug where files
were created or opened in read-only mode.

Mkdir also needs updating however I have another fix for mkdir in review
so I will add that change there.

Signed-off-by: Ashley Pittman <ashley.m.pittman@intel.com>