### PR TITLE
DAOS-6174: re-enable pool create_test

### DIFF
--- a/src/tests/ftest/pool/create_test.py
+++ b/src/tests/ftest/pool/create_test.py
@@ -191,7 +191,6 @@ class PoolCreateTests(PoolTestBase):
             "should succeed."
         )
 
-    @skipForTicket("DAOS-6174")
     def test_create_no_space_loop(self):
         """JIRA ID: DAOS-3728.
 


### PR DESCRIPTION
PR-3997 landed the main fix for pool create failing with DER_TIMEDOUT
followed by DER_EXIST. There might be some intricate race/timing
questions to study at the ioserver target level. However, given the
nature of the fix in PR-3997 (pool create retries occurring only
after RPC reply with error), it makes sense to re-enable this test
at this time.

Signed-off-by: Kenneth Cain <kenneth.c.cain@intel.com>