### PR TITLE
DAOS-4882 obj: check container rf when obj open

### DIFF
--- a/src/client/pydaos/raw/daos_cref.py
+++ b/src/client/pydaos/raw/daos_cref.py
@@ -135,6 +135,7 @@ class ContInfo(ctypes.Structure):
                 ("es_ghce", ctypes.c_uint64),
                 ("es_glre", ctypes.c_uint64),
                 ("es_ghpce", ctypes.c_uint64),
+                ("ci_redun_fac", ctypes.c_uint32),
                 ("ci_nsnapshots", ctypes.c_uint32),
                 ("ci_snapshots", ctypes.POINTER(ctypes.c_uint64)),
                 ("ci_min_slipped_epoch", ctypes.c_uint64)]

--- a/src/common/cont_props.c
+++ b/src/common/cont_props.c
@@ -51,6 +51,9 @@ daos_props_2cont_props(daos_prop_t *props, struct cont_props *cont_prop)
 	cont_prop->dcp_encrypt_type	= daos_cont_prop2encrypt(props);
 	cont_prop->dcp_encrypt_enabled	=
 		daos_cont_encrypt_prop_is_enabled(cont_prop->dcp_encrypt_type);
+
+	/** redundancy */
+	cont_prop->dcp_redun_fac	= daos_cont_prop2redunfac(props);
 }
 
 uint16_t
@@ -174,4 +177,54 @@ daos_cont_prop2encrypt(daos_prop_t *props)
 		daos_prop_entry_get(props, DAOS_PROP_CO_ENCRYPT);
 
 	return prop == NULL ? false : prop->dpe_val != DAOS_PROP_CO_ENCRYPT_OFF;
+}
+
+/** Get the redundancy factor from a containers properites. */
+uint32_t
+daos_cont_prop2redunfac(daos_prop_t *props)
+{
+	struct daos_prop_entry *prop =
+		daos_prop_entry_get(props, DAOS_PROP_CO_REDUN_FAC);
+
+	return prop == NULL ? DAOS_PROP_CO_REDUN_RF1 : (uint32_t)prop->dpe_val;
+}
+
+/** Get the redundancy level from a containers properites. */
+uint32_t
+daos_cont_prop2redunlvl(daos_prop_t *props)
+{
+	struct daos_prop_entry *prop =
+		daos_prop_entry_get(props, DAOS_PROP_CO_REDUN_LVL);
+
+	return prop == NULL ? DAOS_PROP_CO_REDUN_NODE : (uint32_t)prop->dpe_val;
+}
+
+/** Convert the redun_fac to number of allowed failures */
+int
+daos_cont_rf2allowedfailures(int rf)
+{
+	int	rc;
+
+	switch (rf) {
+	case DAOS_PROP_CO_REDUN_RF0:
+		rc = 0;
+		break;
+	case DAOS_PROP_CO_REDUN_RF1:
+		rc = 1;
+		break;
+	case DAOS_PROP_CO_REDUN_RF2:
+		rc = 2;
+		break;
+	case DAOS_PROP_CO_REDUN_RF3:
+		rc = 3;
+		break;
+	case DAOS_PROP_CO_REDUN_RF4:
+		rc = 4;
+		break;
+	default:
+		rc = -DER_INVAL;
+		break;
+	}
+
+	return rc;
 }

--- a/src/container/srv_container.c
+++ b/src/container/srv_container.c
@@ -48,26 +48,6 @@ cont_prop_read(struct rdb_tx *tx, struct cont *cont, uint64_t bits,
 
 /** Container Property knowledge */
 
-/** Get the redundancy factor from a containers properites. */
-uint32_t
-daos_cont_prop2redunfac(daos_prop_t *props)
-{
-	struct daos_prop_entry *prop =
-		daos_prop_entry_get(props, DAOS_PROP_CO_REDUN_FAC);
-
-	return prop == NULL ? DAOS_PROP_CO_REDUN_RF1 : (uint32_t)prop->dpe_val;
-}
-
-/** Get the redundancy level from a containers properites. */
-uint32_t
-daos_cont_prop2redunlvl(daos_prop_t *props)
-{
-	struct daos_prop_entry *prop =
-		daos_prop_entry_get(props, DAOS_PROP_CO_REDUN_LVL);
-
-	return prop == NULL ? DAOS_PROP_CO_REDUN_NODE : (uint32_t)prop->dpe_val;
-}
-
 /**
  * This function verifies that the container meets it's redundancy requirements
  * based on the current pool map. The redundancy requirement is measured
@@ -85,11 +65,11 @@ daos_cont_prop2redunlvl(daos_prop_t *props)
 static int
 cont_verify_redun_req(struct pool_map *pmap, daos_prop_t *props)
 {
-	uint32_t num_failed;
-	uint32_t num_allowed_failures;
-	int rc = 0;
-	int redun_fac = daos_cont_prop2redunfac(props);
-	int redun_lvl = daos_cont_prop2redunlvl(props);
+	int		num_failed;
+	int		num_allowed_failures;
+	int		redun_fac = daos_cont_prop2redunfac(props);
+	int		redun_lvl = daos_cont_prop2redunlvl(props);
+	int		rc = 0;
 
 	switch (redun_lvl) {
 	case DAOS_PROP_CO_REDUN_RACK:
@@ -112,25 +92,9 @@ cont_verify_redun_req(struct pool_map *pmap, daos_prop_t *props)
 	 * before pool_open fails and an error is reported.
 	 */
 	num_failed = rc;
-	switch (redun_fac) {
-	case DAOS_PROP_CO_REDUN_RF0:
-		num_allowed_failures = 0;
-		break;
-	case DAOS_PROP_CO_REDUN_RF1:
-		num_allowed_failures = 1;
-		break;
-	case DAOS_PROP_CO_REDUN_RF2:
-		num_allowed_failures = 2;
-		break;
-	case DAOS_PROP_CO_REDUN_RF3:
-		num_allowed_failures = 3;
-		break;
-	case DAOS_PROP_CO_REDUN_RF4:
-		num_allowed_failures = 4;
-		break;
-	default:
-		return -DER_INVAL;
-	}
+	num_allowed_failures = daos_cont_rf2allowedfailures(redun_fac);
+	if (num_allowed_failures < 0)
+		return num_allowed_failures;
 
 	if (num_allowed_failures >= num_failed)
 		return 0;

--- a/src/container/srv_layout.c
+++ b/src/container/srv_layout.c
@@ -81,7 +81,7 @@ struct daos_prop_entry cont_prop_entries_default[CONT_PROP_NUM] = {
 		.dpe_val	= DAOS_PROP_CO_CSUM_SV_OFF,
 	}, {
 		.dpe_type	= DAOS_PROP_CO_REDUN_FAC,
-		.dpe_val	= DAOS_PROP_CO_REDUN_RF1,
+		.dpe_val	= DAOS_PROP_CO_REDUN_RF0,
 	}, {
 		.dpe_type	= DAOS_PROP_CO_REDUN_LVL,
 		.dpe_val	= DAOS_PROP_CO_REDUN_RACK,

--- a/src/include/daos/cont_props.h
+++ b/src/include/daos/cont_props.h
@@ -36,6 +36,7 @@ struct cont_props {
 	uint32_t	 dcp_compress_type;
 	uint16_t	 dcp_csum_type;
 	uint16_t	 dcp_encrypt_type;
+	uint32_t	 dcp_redun_fac;
 	uint32_t	 dcp_csum_enabled:1,
 			 dcp_srv_verify:1,
 			 dcp_dedup_enabled:1,
@@ -90,10 +91,23 @@ daos_cont_prop2compress(daos_prop_t *props);
 /**
  * Encryption properties
  */
-
 bool
 daos_cont_encrypt_prop_is_enabled(uint16_t val);
 
 uint16_t
 daos_cont_prop2encrypt(daos_prop_t *props);
+
+
+/**
+ * Redundancy properties
+ */
+uint32_t
+daos_cont_prop2redunfac(daos_prop_t *props);
+
+uint32_t
+daos_cont_prop2redunlvl(daos_prop_t *props);
+
+int
+daos_cont_rf2allowedfailures(int rf);
+
 #endif /** __DAOS_CONT_PROPS_H__ */

--- a/src/include/daos/container.h
+++ b/src/include/daos/container.h
@@ -44,6 +44,7 @@ int dc_cont_hdl2uuid(daos_handle_t coh, uuid_t *hdl_uuid, uuid_t *con_uuid);
 daos_handle_t dc_cont_hdl2pool_hdl(daos_handle_t coh);
 struct daos_csummer *dc_cont_hdl2csummer(daos_handle_t coh);
 struct cont_props dc_cont_hdl2props(daos_handle_t coh);
+int dc_cont_hdl2redunfac(daos_handle_t coh);
 
 int dc_cont_local2global(daos_handle_t coh, d_iov_t *glob);
 int dc_cont_global2local(daos_handle_t poh, d_iov_t glob,

--- a/src/include/daos_cont.h
+++ b/src/include/daos_cont.h
@@ -62,6 +62,8 @@ typedef struct {
 	uuid_t			ci_uuid;
 	/** Epoch of latest persistent snapshot */
 	daos_epoch_t		ci_lsnapshot;
+	/** Redundancy factor */
+	uint32_t		ci_redun_fac;
 	/** Number of snapshots */
 	uint32_t		ci_nsnapshots;
 	/** Epochs of returns snapshots */

--- a/src/object/cli_obj.c
+++ b/src/object/cli_obj.c
@@ -458,30 +458,26 @@ obj_auxi_free_failed_tgt_list(struct obj_auxi_args *obj_auxi)
 }
 
 struct daos_oclass_attr *
-obj_get_oca(struct dc_object *obj, bool force_check)
+obj_get_oca(struct dc_object *obj)
 {
-	if (obj->cob_oca == NULL && force_check) {
+	if (obj->cob_oca == NULL)
 		obj->cob_oca = daos_oclass_attr_find(obj->cob_md.omd_id);
-		D_ASSERT(obj->cob_oca != NULL);
-	}
+
 	return obj->cob_oca;
 }
 
 bool
 obj_is_ec(struct dc_object *obj)
 {
-	struct daos_oclass_attr	*oca;
-
-	oca = obj_get_oca(obj, false);
-	return (oca != NULL && DAOS_OC_IS_EC(oca));
+	return DAOS_OC_IS_EC(obj_get_oca(obj));
 }
 
 int
 obj_get_replicas(struct dc_object *obj)
 {
-	struct daos_oclass_attr *oc_attr = obj_get_oca(obj, true);
+	struct daos_oclass_attr *oc_attr = obj_get_oca(obj);
 	D_ASSERT(oc_attr != NULL);
-	if (oc_attr->ca_resil == DAOS_RES_EC)
+	if (DAOS_OC_IS_EC(oc_attr))
 		return obj_ec_tgt_nr(oc_attr);
 
 	D_ASSERT(oc_attr->ca_resil == DAOS_RES_REPL);
@@ -824,9 +820,10 @@ obj_rw_req_reassemb(struct dc_object *obj, daos_obj_rw_t *args,
 	obj_auxi->iod_nr = args->nr;
 
 	/** XXX possible re-order/merge for both replica and EC */
+	oca = obj_get_oca(obj);
 	if (args->extra_flags & DIOF_CHECK_EXISTENCE ||
 	    args->extra_flags & DIOF_TO_SPEC_SHARD ||
-	    !daos_oclass_is_ec(oid, &oca))
+	    !DAOS_OC_IS_EC(oca))
 		return 0;
 
 	if (!obj_auxi->req_reasbed) {
@@ -1237,12 +1234,58 @@ dc_obj_list_class(tse_task_t *task)
 	return 0;
 }
 
+static int
+dc_obj_redun_check(struct dc_object *obj, daos_handle_t coh)
+{
+	struct daos_oclass_attr	*oca;
+	int			 obj_tf;	/* obj #tolerate failures */
+	int			 cont_rf;	/* cont redun_fac */
+	int			 cont_tf;	/* cont #tolerate failures */
+	int			 rc;
+
+	oca = obj_get_oca(obj);
+	if (oca == NULL) {
+		D_ERROR(DF_OID" obj_get_oca failed.\n",
+			DP_OID(obj->cob_md.omd_id));
+		return -DER_INVAL;
+	}
+
+	cont_rf = dc_cont_hdl2redunfac(coh);
+	if (cont_rf < 0) {
+		D_ERROR(DF_OID" dc_cont_hdl2redunfac failed, "DF_RC".\n",
+			DP_OID(obj->cob_md.omd_id), DP_RC(cont_rf));
+		return cont_rf;
+	}
+
+	if (DAOS_OC_IS_EC(oca)) {
+		obj_tf = obj_ec_parity_tgt_nr(oca);
+	} else {
+		D_ASSERT(oca->ca_resil == DAOS_RES_REPL);
+		obj_tf = (oca->u.rp.r_num == DAOS_OBJ_REPL_MAX) ?
+			 obj->cob_grp_size : oca->u.rp.r_num;
+		D_ASSERT(obj_tf >= 1);
+		obj_tf -= 1;
+	}
+
+	cont_tf = daos_cont_rf2allowedfailures(cont_rf);
+	D_ASSERT(cont_tf >= 0);
+	if (obj_tf < cont_tf) {
+		rc = -DER_INVAL;
+		D_ERROR(DF_OID" obj:cont tolerate faiures %d:%d, "DF_RC"\n",
+			DP_OID(obj->cob_md.omd_id), obj_tf, cont_tf,
+			DP_RC(rc));
+		return rc;
+	}
+
+	return 0;
+}
+
 int
 dc_obj_open(tse_task_t *task)
 {
 	daos_obj_open_t		*args;
 	struct dc_object	*obj;
-	int			rc;
+	int			 rc;
 
 	args = dc_task_get_args(task);
 	D_ASSERTF(args != NULL, "Task Argument OPC does not match DC OPC\n");
@@ -1256,30 +1299,43 @@ dc_obj_open(tse_task_t *task)
 
 	rc = D_SPIN_INIT(&obj->cob_spin, PTHREAD_PROCESS_PRIVATE);
 	if (rc != 0)
-		D_GOTO(out, rc);
+		D_GOTO(fail, rc);
 
 	rc = D_RWLOCK_INIT(&obj->cob_lock, NULL);
 	if (rc != 0)
-		D_GOTO(out, rc);
+		D_GOTO(fail_spin_created, rc);
 
 	/* it is a local operation for now, does not require event */
 	rc = dc_obj_fetch_md(args->oid, &obj->cob_md);
 	if (rc != 0)
-		D_GOTO(out, rc);
+		D_GOTO(fail_rwlock_created, rc);
 
 	rc = obj_layout_create(obj, false);
 	if (rc != 0)
-		D_GOTO(out, rc);
+		D_GOTO(fail_rwlock_created, rc);
+
+	rc = dc_obj_redun_check(obj, args->coh);
+	if (rc != 0)
+		D_GOTO(fail_layout_created, rc);
 
 	rc = obj_ptr2pm_ver(obj, &obj->cob_md.omd_ver);
 	if (rc)
-		D_GOTO(out, rc);
+		D_GOTO(fail_layout_created, rc);
 
 	obj_hdl_link(obj);
 	*args->oh = obj_ptr2hdl(obj);
-
-out:
 	obj_decref(obj);
+	tse_task_complete(task, rc);
+	return rc;
+
+fail_layout_created:
+	obj_layout_free(obj);
+fail_rwlock_created:
+	D_RWLOCK_DESTROY(&obj->cob_lock);
+fail_spin_created:
+	D_SPIN_DESTROY(&obj->cob_spin);
+fail:
+	D_FREE(obj);
 	tse_task_complete(task, rc);
 	return rc;
 }
@@ -1386,7 +1442,7 @@ dc_obj_layout_get(daos_handle_t oh, struct daos_obj_layout **p_layout)
 	if (obj == NULL)
 		return -DER_NO_HDL;
 
-	oc_attr = daos_oclass_attr_find(obj->cob_md.omd_id);
+	oc_attr = obj_get_oca(obj);
 	D_ASSERT(oc_attr != NULL);
 	grp_size = daos_oclass_grp_size(oc_attr);
 	grp_nr = daos_oclass_grp_nr(oc_attr, &obj->cob_md);
@@ -2205,7 +2261,7 @@ obj_req_get_tgts(struct dc_object *obj, int *shard, daos_key_t *dkey,
 		if (obj_auxi->is_ec_obj) {
 			struct daos_oclass_attr	*oca;
 
-			oca = daos_oclass_attr_find(obj->cob_md.omd_id);
+			oca = obj_get_oca(obj);
 			D_ASSERT(oca != NULL);
 			if (shard_idx % obj_ec_tgt_nr(oca) <
 			    obj_ec_data_tgt_nr(oca)) {
@@ -2825,7 +2881,7 @@ obj_ec_recxs_convert(d_list_t *merge_list, daos_recx_t *recx,
 	int			cell_nr;
 	int			stripe_nr;
 
-	oca = daos_oclass_attr_find(shard_auxi->obj->cob_md.omd_id);
+	oca = obj_get_oca(shard_auxi->obj);
 	D_ASSERT(oca != NULL);
 	/* Normally the enumeration is sent to the parity node */
 	/* convert the parity off to daos off */
@@ -3206,7 +3262,7 @@ obj_list_recxs_cb(tse_task_t *task, struct obj_auxi_args *obj_auxi,
 		return 0;
 	}
 
-	D_ASSERT(daos_oclass_is_ec(obj_auxi->obj->cob_md.omd_id, NULL));
+	D_ASSERT(obj_is_ec(obj_auxi->obj));
 	d_list_for_each_entry_safe(recx, tmp, &arg->merge_list,
 				   recx_list) {
 		D_ASSERTF(idx <= *obj_args->nr, "more recx %d max_num %d\n",
@@ -3223,11 +3279,10 @@ obj_list_recxs_cb(tse_task_t *task, struct obj_auxi_args *obj_auxi,
 static void
 anchor_check_eof(struct dc_object *obj, daos_anchor_t *anchor)
 {
-	struct daos_oclass_attr	*oca;
+	struct daos_oclass_attr	*oca = obj_get_oca(obj);
 	int i;
 
-	if (!anchor->da_sub_anchors ||
-	    !daos_oclass_is_ec(obj->cob_md.omd_id, &oca))
+	if (!anchor->da_sub_anchors || !DAOS_OC_IS_EC(oca))
 		return;
 
 	for (i = 0; i < obj_ec_data_tgt_nr(oca); i++) {
@@ -4338,7 +4393,7 @@ shard_list_prep(struct shard_auxi_args *shard_auxi, struct dc_object *obj,
 	obj_args = dc_task_get_args(obj_auxi->obj_task);
 	shard_arg = container_of(shard_auxi, struct shard_list_args, la_auxi);
 	shard_arg->la_api_args = obj_args;
-	oca = daos_oclass_attr_find(obj->cob_md.omd_id);
+	oca = obj_get_oca(obj);
 	D_ASSERT(oca != NULL);
 	if (obj_auxi->is_ec_obj &&
 	    shard_auxi->shard < obj_ec_data_tgt_nr(oca)) {
@@ -4347,7 +4402,7 @@ shard_list_prep(struct shard_auxi_args *shard_auxi, struct dc_object *obj,
 		int			shard_nr;
 		int			rc;
 
-		D_ASSERT(oca->ca_resil == DAOS_RES_EC);
+		D_ASSERT(DAOS_OC_IS_EC(oca));
 		shard_nr = obj_ec_data_tgt_nr(oca);
 
 		/* check and allocate the sub_anchors */
@@ -4427,7 +4482,7 @@ obj_ec_list_get_shard(struct obj_auxi_args *obj_auxi, unsigned int map_ver,
 	int			idx;
 	int			i;
 
-	oca = daos_oclass_attr_find(obj->cob_md.omd_id);
+	oca = obj_get_oca(obj);
 	D_ASSERT(oca != NULL);
 	obj_ec_get_parity_shards(obj, grp_idx, obj_ec_parity_tgt_nr(oca),
 				 obj_ec_data_tgt_nr(oca), parities);
@@ -4606,7 +4661,7 @@ obj_list_common(tse_task_t *task, int opc, daos_obj_list_t *args)
 		D_GOTO(out_task, rc);
 	}
 
-	if (daos_oclass_is_ec(obj->cob_md.omd_id, NULL))
+	if (obj_is_ec(obj))
 		obj_auxi->is_ec_obj = 1;
 
 	shard = obj_list_get_shard(obj_auxi, map_ver, args);
@@ -4773,7 +4828,7 @@ dc_obj_punch(tse_task_t *task, struct dtx_epoch *epoch, uint32_t map_ver,
 
 	if (DAOS_FAIL_CHECK(DAOS_DTX_COMMIT_SYNC))
 		obj_auxi->flags |= ORF_DTX_SYNC;
-	if (daos_oclass_is_ec(obj->cob_md.omd_id, NULL))
+	if (obj_is_ec(obj))
 		obj_auxi->flags |= ORF_EC;
 
 	D_DEBUG(DB_IO, "punch "DF_OID" dkey %llu\n",
@@ -5094,7 +5149,7 @@ dc_obj_query_key(tse_task_t *api_task)
 						DP_RC(rc));
 					D_GOTO(out_task, rc);
 				}
-				oca = obj_get_oca(obj, true);
+				oca = obj_get_oca(obj);
 				D_ASSERT(oca != NULL);
 				D_ASSERT(shard_first == 0 &&
 					 (i % replicas == 0));
@@ -5263,7 +5318,7 @@ dc_obj_verify(daos_handle_t oh, daos_epoch_t *epochs, unsigned int nr)
 	if (obj == NULL)
 		return -DER_NO_HDL;
 
-	oc_attr = daos_oclass_attr_find(obj->cob_md.omd_id);
+	oc_attr = obj_get_oca(obj);
 	D_ASSERT(oc_attr != NULL);
 
 	/* XXX: Currently, only support to verify replicated object.

--- a/src/object/cli_shard.c
+++ b/src/object/cli_shard.c
@@ -1746,7 +1746,7 @@ obj_shard_query_recx_post(struct obj_query_key_cb_args *cb_args, uint32_t shard,
 	struct daos_oclass_attr	*oca;
 	uint64_t		 stripe_rec_nr, cell_rec_nr, rx_idx;
 
-	oca = obj_get_oca(cb_args->obj, false);
+	oca = obj_get_oca(cb_args->obj);
 	if (oca == NULL || !DAOS_OC_IS_EC(oca)) {
 		*result_recx = *reply_recx;
 		return;

--- a/src/object/obj_class.c
+++ b/src/object/obj_class.c
@@ -562,7 +562,7 @@ obj_ec_codec_fini(void)
 		return;
 
 	for (oc = &daos_obj_classes[0]; oc->oc_id != OC_UNKNOWN; oc++) {
-		if (oc->oc_attr.ca_resil == DAOS_RES_EC)
+		if (DAOS_OC_IS_EC(&oc->oc_attr))
 			ocnr++;
 	}
 	D_ASSERTF(oc_ec_codec_nr == ocnr,
@@ -598,7 +598,7 @@ obj_ec_codec_init()
 
 	ocnr = 0;
 	for (oc = &daos_obj_classes[0]; oc->oc_id != OC_UNKNOWN; oc++) {
-		if (oc->oc_attr.ca_resil == DAOS_RES_EC)
+		if (DAOS_OC_IS_EC(&oc->oc_attr))
 			ocnr++;
 	}
 	if (ocnr == 0)
@@ -611,7 +611,7 @@ obj_ec_codec_init()
 
 	i = 0;
 	for (oc = &daos_obj_classes[0]; oc->oc_id != OC_UNKNOWN; oc++) {
-		if (oc->oc_attr.ca_resil != DAOS_RES_EC)
+		if (!DAOS_OC_IS_EC(&oc->oc_attr))
 			continue;
 
 		oc_ec_codecs[i].ec_oc_id = oc->oc_id;

--- a/src/object/obj_internal.h
+++ b/src/object/obj_internal.h
@@ -469,7 +469,7 @@ void obj_reasb_req_fini(struct obj_reasb_req *reasb_req, uint32_t iod_nr);
 int obj_bulk_prep(d_sg_list_t *sgls, unsigned int nr, bool bulk_bind,
 		  crt_bulk_perm_t bulk_perm, tse_task_t *task,
 		  crt_bulk_t **p_bulks);
-struct daos_oclass_attr *obj_get_oca(struct dc_object *obj, bool force_check);
+struct daos_oclass_attr *obj_get_oca(struct dc_object *obj);
 bool obj_is_ec(struct dc_object *obj);
 int obj_get_replicas(struct dc_object *obj);
 int obj_shard_open(struct dc_object *obj, unsigned int shard,

--- a/src/object/obj_tx.c
+++ b/src/object/obj_tx.c
@@ -1060,7 +1060,8 @@ dc_tx_classify_update(struct dc_tx *tx, struct daos_cpd_sub_req *dcsr,
 	struct daos_oclass_attr		*oca = NULL;
 	int				 rc = 0;
 
-	if (daos_oclass_is_ec(obj->cob_md.omd_id, &oca)) {
+	oca = obj_get_oca(obj);
+	if (DAOS_OC_IS_EC(oca)) {
 		struct obj_reasb_req	*reasb_req;
 
 		D_ALLOC_PTR(reasb_req);
@@ -1158,7 +1159,7 @@ dc_tx_classify_common(struct dc_tx *tx, struct daos_cpd_sub_req *dcsr,
 		leader_dtr = d_list_entry(dtr_list->next, struct dc_tx_rdg,
 					  dtr_link);
 
-	oca = daos_oclass_attr_find(obj->cob_md.omd_id);
+	oca = obj_get_oca(obj);
 	size = sizeof(*dtr) + sizeof(uint32_t) * obj->cob_grp_size;
 	D_ALLOC(dtr, size);
 	if (dtr == NULL)
@@ -1187,7 +1188,7 @@ dc_tx_classify_common(struct dc_tx *tx, struct daos_cpd_sub_req *dcsr,
 
 		rc = obj_shard_open(obj, idx, tx->tx_pm_ver, &shard);
 		if (rc == -DER_NONEXIST) {
-			if (oca->ca_resil == DAOS_RES_EC && !all) {
+			if (DAOS_OC_IS_EC(oca) && !all) {
 				if (idx >= start + obj->cob_grp_size -
 							oca->u.ec.e_p)
 					skipped_parity++;
@@ -1341,7 +1342,7 @@ dc_tx_classify_common(struct dc_tx *tx, struct daos_cpd_sub_req *dcsr,
 	if (read)
 		dtr->dtr_group.drg_flags = DGF_RDONLY;
 
-	if (oca->ca_resil == DAOS_RES_EC && !all) {
+	if (DAOS_OC_IS_EC(oca) && !all) {
 		dtr->dtr_group.drg_redundancy = oca->u.ec.e_p + 1;
 		D_ASSERT(dtr->dtr_group.drg_redundancy <= obj->cob_grp_size);
 	} else {
@@ -1617,7 +1618,7 @@ dc_tx_commit_prepare(struct dc_tx *tx, tse_task_t *task)
 		leader_oid.id_pub = obj->cob_md.omd_id;
 		leader_oid.id_shard = i;
 		leader_dtrg_idx = obj_get_shard(obj, i)->po_target;
-		if (!daos_oclass_is_ec(obj->cob_md.omd_id, NULL))
+		if (!obj_is_ec(obj))
 			mbs->dm_flags |= DMF_SRDG_REP;
 
 		/* If there is only one redundancy group to be modified,

--- a/src/tests/suite/daos_rebuild_common.c
+++ b/src/tests/suite/daos_rebuild_common.c
@@ -266,8 +266,9 @@ rebuild_pool_connect_internal(void *data)
 	/** open container */
 	MPI_Barrier(MPI_COMM_WORLD);
 	if (arg->myrank == 0) {
-		rc = daos_cont_open(arg->pool.poh, arg->co_uuid, DAOS_COO_RW,
-		&arg->coh, &arg->co_info, NULL);
+		rc = daos_cont_open(arg->pool.poh, arg->co_uuid,
+				    DAOS_COO_RW | DAOS_COO_FORCE,
+				    &arg->coh, &arg->co_info, NULL);
 		if (rc)
 			print_message("daos_cont_open failed, rc: %d\n", rc);
 

--- a/src/utils/daos_hdlr.c
+++ b/src/utils/daos_hdlr.c
@@ -1488,6 +1488,8 @@ cont_query_hdlr(struct cmd_args_s *ap)
 	printf("Latest Persistent Snapshot: %i\n",
 		(int)cont_info.ci_lsnapshot);
 	printf("Highest Aggregated Epoch: "DF_U64"\n", cont_info.ci_hae);
+	printf("Container redundancy factor: %d\n", cont_info.ci_redun_fac);
+
 	/* TODO: list snapshot epoch numbers, including ~80 column wrap. */
 
 	if (ap->oid.hi || ap->oid.lo) {


### PR DESCRIPTION
Only allow to obj open when #replicas > container_rf (for EC, it is
p >= container_rf).
Set the default container rf as zero, to allow to create/open
non-replica obj (such as OC_SX).
Refine/reduce daos_oclass_attr_find/daos_oclass_is_ec() callings by
cache+reuse obj oca.

Signed-off-by: Xuezhao Liu <xuezhao.liu@intel.com>