### PR TITLE
DAOS-4398 bio: remove default NVMe config path

### DIFF
--- a/src/bio/bio_xstream.c
+++ b/src/bio/bio_xstream.c
@@ -394,9 +394,15 @@ bio_nvme_init(const char *storage_path, const char *nvme_conf, int shm_id,
 		goto free_mutex;
 	}
 
+	if (nvme_conf == NULL || strlen(nvme_conf) == 0) {
+		D_INFO("NVMe config isn't specified, skip NVMe setup.\n");
+		nvme_glb.bd_nvme_conf = NULL;
+		return 0;
+	}
+
 	fd = open(nvme_conf, O_RDONLY, 0600);
 	if (fd < 0) {
-		D_WARN("Open %s failed("DF_RC"), skip DAOS NVMe setup.\n",
+		D_WARN("Open %s failed, skip DAOS NVMe setup "DF_RC"\n",
 		       nvme_conf, DP_RC(daos_errno2der(errno)));
 		nvme_glb.bd_nvme_conf = NULL;
 		return 0;

--- a/src/iosrv/init.c
+++ b/src/iosrv/init.c
@@ -63,7 +63,7 @@ static char	       *daos_sysname = DAOS_DEFAULT_SYS_NAME;
 const char	       *dss_storage_path = "/mnt/daos";
 
 /** NVMe config file */
-const char	       *dss_nvme_conf = "/etc/daos_nvme.conf";
+const char	       *dss_nvme_conf;
 
 /** Socket Directory */
 const char	       *dss_socket_dir = "/var/run/daos_server";


### PR DESCRIPTION
Remove the default NVMe config path "/etc/daos_nvme.conf", this
default value is out of date now since control plane uses
"$storage_path/daos_nvme.conf" to start io server.

The wrong default value could cause io server start error when
NVMe isn't configured in server ymal but "/etc/daos_nvme.conf"
happen to be presented. (from prior daos_perf VOS mode runs).

Signed-off-by: Niu Yawei <yawei.niu@intel.com>